### PR TITLE
Add pngnq

### DIFF
--- a/mingw-w64-pngnq/PKGBUILD
+++ b/mingw-w64-pngnq/PKGBUILD
@@ -1,0 +1,40 @@
+_realname=pngnq
+_mingw_suff=mingw-w64-${CARCH}
+pkgname="${_mingw_suff}-${_realname}"
+pkgver=1.1
+pkgrel=2
+pkgdesc="Pngnq is a tool for quantizing PNG images in RGBA format"
+url="http://pngnq.sourceforge.net/"
+license=("BSD")
+arch=("any")
+makedepends=("${_mingw_suff}-gcc")
+depends=("${_mingw_suff}-gcc-libs" "${_mingw_suff}-libpng" "${_mingw_suff}-zlib")
+options=('strip' 'staticlibs')
+source=("http://downloads.sourceforge.net/${_realname}/${_realname}-${pkgver}.tar.gz"
+        no-syslog.patch)
+md5sums=("fdbb94d504931b50c54202b62f98aa44"
+         "a42c37e648385985cc2d17ae10b8b22a")
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -p0 -i "${srcdir}/no-syslog.patch"
+}
+
+build() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  
+  sed "35i#include <zlib.h>" -i src/rwpng.c
+  
+  # The LIBS line fixes some build script weirdness where it only passes the zlib
+  # link command to gcc in the right order, but not the libpng one.
+  LIBS="`libpng-config --ldflags` -lz" ./configure \
+    --prefix=${MINGW_PREFIX} \
+    --mandir="${pkgdir}${MINGW_PREFIX}/share/man" 
+  make
+
+}
+
+package() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  make prefix="${pkgdir}${MINGW_PREFIX}" mandir="${pkgdir}${MINGW_PREFIX}/share/man" install
+}

--- a/mingw-w64-pngnq/no-syslog.patch
+++ b/mingw-w64-pngnq/no-syslog.patch
@@ -1,0 +1,36 @@
+--- src/errors.h.orig	  2014-04-25 10:24:16.396471000 +0200
++++ src/errors.h    2014-04-25 10:51:47.402099600 +0200
+@@ -1,18 +1,26 @@
+ /* error.h
+  * Error handling for pngnq 
+  */
+-#include "syslog.h"
++
++#ifndef _WIN32
++    #include "syslog.h"
++#endif
+ 
+ /* Error codes */
+ #define PNGNQ_ERR_NONE 0
+ #define PNGNQ_ERR_ 0
+ 
+-#define PNGNQ_LOG_ERR(...)(syslog(LOG_ERR,\
+-    "pngnq - Error in %s near line %d:",__FILE__,__LINE__));\
+-    syslog(LOG_ERR, __VA_ARGS__); 
+-    
+-#define PNGNQ_LOG_WARNING(...)(syslog(LOG_WARNING,"pngnq - warning: "));\
+-    syslog(LOG_WARNING, __VA_ARGS__);
++#ifdef _WIN32
++    #define PNGNQ_LOG_ERR(...)
++    #define PNGNQ_LOG_WARNING(...)
++#else
++    #define PNGNQ_LOG_ERR(...)(syslog(LOG_ERR,\
++        "pngnq - Error in %s near line %d:",__FILE__,__LINE__));\
++        syslog(LOG_ERR, __VA_ARGS__); 
++        
++    #define PNGNQ_LOG_WARNING(...)(syslog(LOG_WARNING,"pngnq - warning: "));\
++        syslog(LOG_WARNING, __VA_ARGS__);
++#endif
+ 
+ #define PNGNQ_ERROR(...) (fprintf(stderr,\
+     "pngnq - Error in %s near line %d :\n",__FILE__,__LINE__));\


### PR DESCRIPTION
Adds the pngnq utility, which is useful for quantizing RGBA images without throwing away the Alpha channel. (pngnq was at the time one of the only tools that handled quantizing Alpha correctly for PNG8, and to this day, still is one of the only tools that does it correctly.)

The weird sed line in the PKGBUILD comes directly from the AUR PKGBUILD, which does the same thing. It fixes a compile time error that stems from weird include order, apparently. Should this be moved to its own patch?
