### PR TITLE
Add pngcrush

### DIFF
--- a/mingw-w64-pngcrush/PKGBUILD
+++ b/mingw-w64-pngcrush/PKGBUILD
@@ -1,3 +1,4 @@
+# Maintainer: Nicolas Frattaroli <ovdev@fratti.ch>
 
 _realname=pngcrush
 _mingw_suff="mingw-w64-${CARCH}"


### PR DESCRIPTION
pngcrush can be considered the predecessor of optipng. It also losslessly recompresses PNG images, but as far as I'm aware is not as good as optipng at it. However, older scripts or other software may still use it, and pngcrush still appears to be somewhat actively developed.
