### PR TITLE
intel-tbb: added debug build

### DIFF
--- a/mingw-w64-intel-tbb/PKGBUILD
+++ b/mingw-w64-intel-tbb/PKGBUILD
@@ -6,8 +6,8 @@ pkgname="${_mingw_suff}-${_realname}"
 pkgver=4.2_20140122
 pkgrel=1
 pkgdesc='High level abstract threading library (mingw-w64)'
-depends=("${_mingw_suff}-gcc-libs" "${_mingw_suff}-dlfcn")
-makedepends=("${_mingw_suff}-gcc")
+depends=("${_mingw_suff}-gcc-libs")
+makedepends=("${_mingw_suff}-gcc" "${_mingw_suff}-make")
 options=('strip' 'staticlibs')
 arch=('any')
 url='http://www.threadingbuildingblocks.org/'
@@ -21,27 +21,27 @@ prepare () {
   cd tbb${pkgver/\./}oss
   
   # do not build debug libraries
-  sed -i "/debug/d" Makefile
+  #sed -i "/debug/d" Makefile
   
   # not not use win32 api
   #patch -p1 -i "$srcdir"/tbb-disable_windows_api.patch
   #echo "CPLUS_FLAGS += -DUSE_WIN32_API=0" >> build/windows.gcc.inc
   
   # platform configuration
-  sed -i "s|export SHELL = cmd|export SHELL = sh -c|g" build/windows.inc
-  sed -i "s|CMD=cmd /C|CMD=sh -c|g" build/windows.inc
-  sed -i "s|CWD=\$(shell cmd /C echo %CD%)|CWD=\$(shell pwd)|g" build/windows.inc
-  sed -i "s|RM=cmd /C del /Q /F|RM?=rm -f|g" build/windows.inc
-  sed -i "s|RD=cmd /C rmdir|RD?=rmdir|g" build/windows.inc
-  sed -i "s|MD=cmd /c mkdir|MD?=mkdir -p|g" build/windows.inc
-  sed -i "s|SLASH=\\\\\\\\|SLASH=/|g" build/windows.inc
-  sed -i "s|NUL = nul|NUL= /dev/null|g" build/windows.inc
-  sed -i "s|.DLL = tbb|.DLL = libtbb|g" build/windows.inc
-  sed -i "s|.LIB = tbb|.LIB = libtbb|g" build/windows.inc
-  sed -i "/MAKE_VERSIONS/d" build/windows.inc
-  echo "MAKE_VERSIONS=sh \$(tbb_root)/build/version_info_linux.sh \$(CPLUS) \$(CPLUS_FLAGS) \$(INCLUDES) >version_string.ver" >> build/windows.inc
-  sed -i "/MAKE_TBBVARS/d" build/windows.inc
-  echo "MAKE_TBBVARS=sh \$(tbb_root)/build/generate_tbbvars.sh" >> build/windows.inc
+  #sed -i "s|export SHELL = cmd|export SHELL = sh -c|g" build/windows.inc
+  #sed -i "s|CMD=cmd /C|CMD=sh -c|g" build/windows.inc
+  #sed -i "s|CWD=\$(shell cmd /C echo %CD%)|CWD=\$(shell pwd)|g" build/windows.inc
+  #sed -i "s|RM=cmd /C del /Q /F|RM?=rm -f|g" build/windows.inc
+  #sed -i "s|RD=cmd /C rmdir|RD?=rmdir|g" build/windows.inc
+  #sed -i "s|MD=cmd /c mkdir|MD?=mkdir -p|g" build/windows.inc
+  #sed -i "s|SLASH=\\\\\\\\|SLASH=/|g" build/windows.inc
+  #sed -i "s|NUL = nul|NUL= /dev/null|g" build/windows.inc
+  #sed -i "s|.DLL = tbb|.DLL = libtbb|g" build/windows.inc
+  #sed -i "s|.LIB = tbb|.LIB = libtbb|g" build/windows.inc
+  #sed -i "/MAKE_VERSIONS/d" build/windows.inc
+  #echo "MAKE_VERSIONS=sh \$(tbb_root)/build/version_info_linux.sh \$(CPLUS) \$(CPLUS_FLAGS) \$(INCLUDES) >version_string.ver" >> build/windows.inc
+  #sed -i "/MAKE_TBBVARS/d" build/windows.inc
+  #echo "MAKE_TBBVARS=sh \$(tbb_root)/build/generate_tbbvars.sh" >> build/windows.inc
 
 }
 
@@ -50,12 +50,13 @@ build() {
 
     sed -i "s|CPLUS = g++|CPLUS = ${_arch}-g++|g" build/windows.gcc.inc
     sed -i "s|CONLY = gcc|CONLY = ${_arch}-gcc|g" build/windows.gcc.inc
-    sed -i "s|OUTPUT_KEY = -o #|OUTPUT_KEY = -Wl,--out-implib,\$(BUILDING_LIBRARY).a -o #|g" build/windows.gcc.inc
-    sed -i "s|\$(call detect_js,/minversion gcc 4.4)|ok|g" build/windows.gcc.inc
+    sed -i "s|OUTPUT_KEY = -o #|OUTPUT_KEY = -Wl,--out-implib,lib\$(BUILDING_LIBRARY).a -o #|g" build/windows.gcc.inc
+    #sed -i "s|\$(call detect_js,/minversion gcc 4.4)|ok|g" build/windows.gcc.inc
+    echo "CPLUS_FLAGS += -mrtm" >> build/windows.gcc.inc # makes test cases pass
 
     # use mingw's pthreads
-    sed -i "s|USE_WINTHREAD|USE_PTHREAD|g" build/windows.gcc.inc src/tbbmalloc/TypeDefinitions.h
-    sed -i "s|LIBDL =|LIBDL = -ldl|g" build/windows.gcc.inc
+    #sed -i "s|USE_WINTHREAD|USE_PTHREAD|g" build/windows.gcc.inc src/tbbmalloc/TypeDefinitions.h
+    #sed -i "s|LIBDL =|LIBDL = -ldl|g" build/windows.gcc.inc
   
     if test "${MINGW_CHOST}" = "x86_64-w64-mingw32"
     then
@@ -64,7 +65,7 @@ build() {
       parch=ia32
     fi
     unset LDFLAGS
-    make arch=$parch tbb_os=windows runtime=mingw compiler=gcc
+    mingw32-make arch=$parch tbb_os=windows runtime=mingw compiler=gcc cpp0x=1
 }
 
 package() {
@@ -80,7 +81,9 @@ package() {
   install -d "${pkgdir}${MINGW_PREFIX}"/include
   cp -a include/tbb "${pkgdir}${MINGW_PREFIX}"/include
   install -d "${pkgdir}${MINGW_PREFIX}"/bin
+  install -m755 build/windows_${parch}_gcc_mingw_debug//*.dll "${pkgdir}${MINGW_PREFIX}"/bin
   install -m755 build/windows_${parch}_gcc_mingw_release//*.dll "${pkgdir}${MINGW_PREFIX}"/bin
   install -d "${pkgdir}${MINGW_PREFIX}"/lib
+  install -m755 build/windows_${parch}_gcc_mingw_debug/*.a "${pkgdir}${MINGW_PREFIX}"/lib
   install -m755 build/windows_${parch}_gcc_mingw_release/*.a "${pkgdir}${MINGW_PREFIX}"/lib
 }


### PR DESCRIPTION
I don't think we really want to skip debug build.
Also, consider building with `mingw32-make` if we solely work in native environment.
And how can we support C++11 build mode with a PKGBUILD? Some other packages like
`boost` also support C++11 mode.
Thanks.
