### PR TITLE
openblas: bind import lib to libopenblas.dll

### DIFF
--- a/mingw-w64-OpenBLAS-git/PKGBUILD
+++ b/mingw-w64-OpenBLAS-git/PKGBUILD
@@ -5,7 +5,7 @@ _realname=OpenBLAS
 _mingw_suff=mingw-w64-${CARCH}
 pkgname="${_mingw_suff}-${_realname}-git"
 pkgrel=1
-pkgver=r828.4d42368
+pkgver=r830.66198fa
 pkgdesc="OpenBLAS is an optimized BLAS library (mingw-w64)"
 provides=("${_mingw_suff}-${_realname}")
 arch=('any')
@@ -35,7 +35,7 @@ package() {
   cd ${srcdir}/build-${CARCH}
   if [ -f libopenblas.dll ]; then
     if [ -f exports/libopenblas.def ]; then
-      dlltool -d exports/libopenblas.def -l libopenblas.dll.a
+      dlltool -D libopenblas.dll -d exports/libopenblas.def -l libopenblas.dll.a
     else
       echo "Cannot build export library" >&2
       exit 1


### PR DESCRIPTION
We have to let the import lib know which is its main DLL.
The HEAD ref of openblas is also updated.
