### PR TITLE
gnutls: Remove dependency on libgcrypt

### DIFF
--- a/mingw-w64-gnutls/PKGBUILD
+++ b/mingw-w64-gnutls/PKGBUILD
@@ -12,7 +12,6 @@ url="http://www.gnutls.org/"
 options=('!zipman')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
     "${MINGW_PACKAGE_PREFIX}-libtasn1"
-    "${MINGW_PACKAGE_PREFIX}-libgcrypt"
     "${MINGW_PACKAGE_PREFIX}-gmp"
     "${MINGW_PACKAGE_PREFIX}-zlib"
     "${MINGW_PACKAGE_PREFIX}-nettle"


### PR DESCRIPTION
GnuTLS 3.X no longer uses it
