### PR TITLE
sip4, pyqt4: new packages (Python 2 only)

### DIFF
--- a/mingw-w64-python2-pyqt4/0001-fix-configure.patch
+++ b/mingw-w64-python2-pyqt4/0001-fix-configure.patch
@@ -1,0 +1,11 @@
+--- configure.py.orig	2014-07-15 16:41:19.233000000 +0200
++++ configure.py	2014-07-15 16:41:40.357000000 +0200
+@@ -2131,7 +2131,7 @@
+ 
+     # Create the output file, first making sure it doesn't exist.
+     remove_file(out_file)
+-    run_command(exe_file)
++    run_command("sh -c " + exe_file)
+ 
+     if not os.access(out_file, os.F_OK):
+         sipconfig.error("%s failed to create %s. Make sure your Qt installation is correct." % (exe_file, out_file))

--- a/mingw-w64-python2-pyqt4/PKGBUILD
+++ b/mingw-w64-python2-pyqt4/PKGBUILD
@@ -1,0 +1,52 @@
+# Maintainer: Saul Ibarra Corretge <saghul@gmail.com>
+
+_realname=python2-pyqt4
+
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=4.11.1
+pkgrel=1
+pkgdesc="Qt4 bindings for Python (mingw-w64)"
+arch=('any')
+license=('GPL')
+url="http://www.riverbankcomputing.co.uk/software/pyqt"
+depends=("${MINGW_PACKAGE_PREFIX}-python2"
+         "${MINGW_PACKAGE_PREFIX}-python2-sip4"
+         "${MINGW_PACKAGE_PREFIX}-qt4")
+source=("http://downloads.sourceforge.net/project/pyqt/PyQt4/PyQt-$pkgver/PyQt-win-gpl-$pkgver.zip"
+        0001-fix-configure.patch)
+md5sums=('b97e2e0bb2c1c9d785b4dd76924be63c'
+         'bd1f4d8baecc7016aa21912e03323625')
+
+prepare() {
+  cd "${srcdir}"/PyQt-win-gpl-$pkgver
+
+  # Apply patches
+  patch -p0 -i "${srcdir}"/0001-fix-configure.patch
+}
+
+build() {
+  cd "${srcdir}"/PyQt-win-gpl-$pkgver
+
+  ${MINGW_PREFIX}/bin/python2 configure.py \
+    --bindir "${pkgdir}${MINGW_PREFIX}"/bin \
+    --destdir "${pkgdir}${MINGW_PREFIX}"/lib/python2.7/site-packages \
+    --sipdir "${pkgdir}${MINGW_PREFIX}"/sip \
+    --confirm-license \
+    --no-designer-plugin \
+    --no-sip-files \
+    --concatenate \
+    -p win32-g++
+
+  # Fix Makefiles
+  sed -i 's/@if not exist \(.*\) mkdir /mkdir -p /' Makefile */Makefile
+  sed -i 's@copy /y@cp -r@' Makefile */Makefile
+
+  # Build
+  make
+}
+
+package() {
+  cd "${srcdir}"/PyQt-win-gpl-$pkgver
+  make install
+  install -D -m644 LICENSE-MERGED "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}

--- a/mingw-w64-python2-sip4/PKGBUILD
+++ b/mingw-w64-python2-sip4/PKGBUILD
@@ -1,0 +1,45 @@
+# Maintainer: Saul Ibarra Corretge <saghul@gmail.com>
+
+_realname=python2-sip4
+
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=4.16.2
+pkgrel=1
+pkgdesc="Tool to create Python bindings for C and C++ libraries"
+arch=('any')
+license=('GPL')
+url="http://www.riverbankcomputing.co.uk/software/sip"
+depends=("${MINGW_PACKAGE_PREFIX}-python2"
+         "${MINGW_PACKAGE_PREFIX}-qt4")
+
+source=("http://downloads.sourceforge.net/project/pyqt/sip/sip-$pkgver/sip-$pkgver.zip")
+md5sums=('8e651c3216d247444967189e5553e750')
+
+prepare() {
+  cd "${srcdir}"/sip-$pkgver
+}
+
+build() {
+  cd "${srcdir}"/sip-$pkgver
+  mkdir -p "${pkgdir}"
+
+  ${MINGW_PREFIX}/bin/python2 configure.py \
+    --bindir "${pkgdir}${MINGW_PREFIX}"/bin \
+    --destdir "${pkgdir}${MINGW_PREFIX}"/lib/python2.7/site-packages \
+    --incdir "${pkgdir}${MINGW_PREFIX}"/include/python2.7 \
+    --sipdir "${pkgdir}${MINGW_PREFIX}"/sip \
+    -p win32-g++
+
+  # Fix makefiles
+  sed -i 's/@if not exist \(.*\) mkdir /mkdir -p /' Makefile */Makefile
+  sed -i 's@copy /y@cp -r@' Makefile */Makefile
+
+  # Build
+  make
+}
+
+package() {
+  cd "${srcdir}"/sip-$pkgver
+  make install
+  install -D -m644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
These packages a bit tricky to build, having them in the repo would be nice :-)

I could only test them on a 32bit system, though I don't expect any trouble in 64, since they are python extensions, for the most part.

I hope the PKGBUILD files are OK, I "borrowed some inspiration" from other packages.

PS: Thanks guys, MSYS2 is awesome!
PPS: AFAIK Python3 is only supported on PyQt5 and SIP5.
