### PR TITLE
python2-pyqt4: don't install Python3 uic port

### DIFF
--- a/mingw-w64-python2-pyqt4/PKGBUILD
+++ b/mingw-w64-python2-pyqt4/PKGBUILD
@@ -49,4 +49,5 @@ package() {
   cd "${srcdir}"/PyQt-win-gpl-$pkgver
   make install
   install -D -m644 LICENSE-MERGED "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  rm -rf "${pkgdir}${MINGW_PREFIX}"/lib/python2.7/site-packages/PyQt4/uic/port_v3
 }


### PR DESCRIPTION
It only gives us trouble because 'freezing' an application will choke on
those files. Also, it doesn't make sense to install them since this is a
Python2 package.
