### PR TITLE
p11-kit: avoid using strerror_s

### DIFF
--- a/mingw-w64-p11-kit/0010-no-strerror_s.patch
+++ b/mingw-w64-p11-kit/0010-no-strerror_s.patch
@@ -1,0 +1,16 @@
+--- p11-kit-0.20.1/common/compat.c	2014-07-22 16:37:06.456094868 +0200
++++ p11-kit-0.20.1/common/compat.c	2014-07-22 16:42:16.440081230 +0200
+@@ -833,7 +833,12 @@
+             size_t buflen)
+ {
+ #ifdef OS_WIN32
+-	return strerror_s (buf, buflen, errnum);
++        /* non-recursive implementation of strerror_r */
++        char *retbuf;
++        retbuf = strerror(errnum);
++        strncpy(buf, retbuf, buflen);
++        buf[buflen - 1] = '\0';
++        return 0;
+ #else
+ 	#error no strerror_r implementation
+ #endif

--- a/mingw-w64-p11-kit/PKGBUILD
+++ b/mingw-w64-p11-kit/PKGBUILD
@@ -1,4 +1,5 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Saul Ibarra Corretge <saghul@gmail.com>
 
 _realname=p11-kit
 
@@ -14,19 +15,22 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 source=($url/releases/$_realname-$pkgver.tar.gz{,.sig}
     p11-kit-0.20.1-getuid.patch
     0000-no-proxy.mingw.patch
-    0001-fix-gtkdoc.all.patch)
+    0001-fix-gtkdoc.all.patch
+    0010-no-strerror_s.patch)
 md5sums=('88c651137f76a167336639371eafd8cc'
          'SKIP'
          '163f463a5ab7611790ecdeb42c39be6f'
          '411a2c8c553d961a9a1ae7507b952d22'
-         'b573ff16048f807a7310a6e893e1b2ce')
+         'b573ff16048f807a7310a6e893e1b2ce'
+         '1c0b88272082431ef6c6319615b6588f')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/p11-kit-0.20.1-getuid.patch
   patch -p1 -i ${srcdir}/0000-no-proxy.mingw.patch
   patch -p1 -i ${srcdir}/0001-fix-gtkdoc.all.patch
-  
+  patch -p1 -i ${srcdir}/0010-no-strerror_s.patch
+
   autoreconf -fi
 }
 
@@ -37,8 +41,8 @@ build() {
       --prefix=${MINGW_PREFIX} \
       --build=${MINGW_CHOST} \
       --host=${MINGW_CHOST} \
-    --target=${MINGW_CHOST} \
-       --disable-trust-module
+      --target=${MINGW_CHOST} \
+      --disable-trust-module
     make
   #make -C trust asn || make -j1 -C trust asn
   #make || make -j1


### PR DESCRIPTION
It's not available on Windows XP.
