### PR TITLE
libgit2: update to 0.21.0 with thread safe support

### DIFF
--- a/mingw-w64-libgit2/PKGBUILD
+++ b/mingw-w64-libgit2/PKGBUILD
@@ -7,8 +7,8 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 #just comment out both pre defines to build stable release
 
 _commit=ce5e661
-_pre=rc2
-__pre=-${_pre}
+#_pre=rc2
+#__pre=-${_pre}
 
 _pkgver=0.21.0
 
@@ -18,7 +18,7 @@ pkgdesc='A linkable library for Git (mingw-w64)'
 arch=('any')
 url='http://www.libgit2.github.com/'
 license=('GPL2' 'custom')
-source=("v${_pkgver}${__pre}.tar.gz::https://github.com/libgit2/libgit2/archive/")
+source=("https://github.com/libgit2/libgit2/archive/v${_pkgver}${__pre}.tar.gz")
 md5sums=('SKIP')
 options=('strip')
 depends=("${MINGW_PACKAGE_PREFIX}-http-parser")
@@ -43,6 +43,7 @@ build() {
   
   ${MINGW_PREFIX}/bin/cmake.exe \
     -G"MSYS Makefiles" \
+    -DTHREADSAFE:BOOL=1 \
     -DCMAKE_INSTALL_PREFIX:PATH=${pkgdir}${MINGW_PREFIX} \
     ${srcdir}/${_realname}-${_pkgver}${__pre}
 


### PR DESCRIPTION
It seems to fail due to the http library. Might be that I need to update the http one...

In file included from C:/msys64/home/NICE/MINGW-packages/mingw-w64-libgit2/src/libgit2-0.21.0/deps/regex/regex.c:82:0:
C:/msys64/home/NICE/MINGW-packages/mingw-w64-libgit2/src/libgit2-0.21.0/deps/regex/regcomp.c: In function 'parse_dup_op':
C:/msys64/home/NICE/MINGW-packages/mingw-w64-libgit2/src/libgit2-0.21.0/deps/regex/regcomp.c:2553:39: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
     postorder (elem, mark_opt_subexp, (void _) (long) elem->token.opr.idx);
                                       ^
C:/msys64/home/NICE/MINGW-packages/mingw-w64-libgit2/src/libgit2-0.21.0/deps/regex/regcomp.c: In function 'mark_opt_subexp':
C:/msys64/home/NICE/MINGW-packages/mingw-w64-libgit2/src/libgit2-0.21.0/deps/regex/regcomp.c:3782:19: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
   int idx = (int) (long) extra;
                   ^
Linking C shared library libgit2.dll
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/4.9.1/../../../../lib\libhttp_parser.a(http_parser.o):(.text+0x58e): undefined reference to `__assert_func'
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/4.9.1/../../../../lib\libhttp_parser.a(http_parser.o):(.text+0x795): undefined reference to`__assert_func'
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/4.9.1/../../../../lib\libhttp_parser.a(http_parser.o):(.text+0x10fb): undefined reference to `__assert_func'
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/4.9.1/../../../../lib\libhttp_parser.a(http_parser.o):(.text+0x16c5): undefined reference to`__assert_func'
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/4.9.1/../../../../lib\libhttp_parser.a(http_parser.o):(.text+0x1876): undefined reference to `__assert_func'
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/4.9.1/../../../../lib\libhttp_parser.a(http_parser.o):(.text+0x1b10): more undefined references to`__assert_func' follow
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/4.9.1/../../../../x86_64-w64-mingw32/bin/ld.exe: C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/4.9.1/../../../../lib\libhttp_parser.a(http_parser.o): bad reloc address 0x0 in section `.rdata'
collect2.exe: error: ld returned 1 exit status
CMakeFiles/git2.dir/build.make:3164: recipe for target 'libgit2.dll' failed
make[2]: *_\* [libgit2.dll] Error 1
CMakeFiles/Makefile2:60: recipe for target 'CMakeFiles/git2.dir/all' failed
make[1]: **\* [CMakeFiles/git2.dir/all] Error 2
Makefile:127: recipe for target 'all' failed
make: **\* [all] Error 2
==> ERROR: A failure occurred in build().
    Aborting...
