### PR TITLE
python2-pyqt4: rebuild

### DIFF
--- a/mingw-w64-python2-pyqt4/PKGBUILD
+++ b/mingw-w64-python2-pyqt4/PKGBUILD
@@ -4,7 +4,7 @@ _realname=python2-pyqt4
 
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=4.11.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Qt4 bindings for Python (mingw-w64)"
 arch=('any')
 license=('GPL')


### PR DESCRIPTION
So it gets the new changes. Also, looks like the packages for pyqt4 and sip4 are gone from the repos, why is that?
