### PR TITLE
Add GCC 4.9.1 to header search paths

### DIFF
--- a/mingw-w64-clang/clang-3.4-add-recent-gcc-versions.patch
+++ b/mingw-w64-clang/clang-3.4-add-recent-gcc-versions.patch
@@ -13,6 +13,7 @@
 +    AddMinGW64CXXPaths(HSOpts.ResourceDir, "4.8.2");
 +    AddMinGW64CXXPaths(HSOpts.ResourceDir, "4.8.3");
 +    AddMinGW64CXXPaths(HSOpts.ResourceDir, "4.9.0");
++    AddMinGW64CXXPaths(HSOpts.ResourceDir, "4.9.1");
      // mingw.org C++ include paths
      AddMinGWCPlusPlusIncludePaths("/mingw/lib/gcc", "mingw32", "4.5.2"); //MSYS
  #if defined(_WIN32)


### PR DESCRIPTION
Probably useful to add 4.9.2 as well (current stable branch version), and some others that are possible as well
