### PR TITLE
glfw: Build and install glfw3.pc

### DIFF
--- a/mingw-w64-glfw/0001-enabled-pkg-config-file-generation-on-mingw.patch
+++ b/mingw-w64-glfw/0001-enabled-pkg-config-file-generation-on-mingw.patch
@@ -1,0 +1,69 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 60f2302..d10f10d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -154,6 +154,9 @@ endif()
+ # Use Win32 for window creation
+ #--------------------------------------------------------------------
+ if (_GLFW_WIN32)
++
++    set(GLFW_PKG_LIBS "${GLFW_PKG_LIBS} -lgdi32 -lwinmm")
++
+     # The DLL links against winmm; the static library loads it
+     # That way, both code paths receive testing
+     if (BUILD_SHARED_LIBS)
+@@ -180,8 +183,12 @@ endif()
+ # Use WGL for context creation
+ #--------------------------------------------------------------------
+ if (_GLFW_WGL)
++
++    set(GLFW_PKG_LIBS "${GLFW_PKG_LIBS} -lopengl32")
++
+     list(APPEND glfw_INCLUDE_DIRS ${OPENGL_INCLUDE_DIR})
+     list(APPEND glfw_LIBRARIES ${OPENGL_gl_LIBRARY})
++
+ endif()
+
+ #--------------------------------------------------------------------
+@@ -308,9 +315,7 @@ if (_GLFW_EGL)
+     list(APPEND glfw_INCLUDE_DIRS ${EGL_INCLUDE_DIR})
+     list(APPEND glfw_LIBRARIES ${EGL_LIBRARY})
+
+-    if (UNIX)
+-        set(GLFW_PKG_DEPS "${GLFW_PKG_DEPS} egl")
+-    endif()
++    set(GLFW_PKG_DEPS "${GLFW_PKG_DEPS} egl")
+
+     if (_GLFW_USE_OPENGL)
+         list(APPEND glfw_LIBRARIES ${OPENGL_gl_LIBRARY})
+@@ -397,10 +402,8 @@ configure_file(${GLFW_SOURCE_DIR}/src/glfwConfig.cmake.in
+ configure_file(${GLFW_SOURCE_DIR}/src/glfwConfigVersion.cmake.in
+                ${GLFW_BINARY_DIR}/src/glfwConfigVersion.cmake @ONLY)
+
+-if (UNIX)
+-    configure_file(${GLFW_SOURCE_DIR}/src/glfw3.pc.in
+-                   ${GLFW_BINARY_DIR}/src/glfw3.pc @ONLY)
+-endif()
++configure_file(${GLFW_SOURCE_DIR}/src/glfw3.pc.in
++                ${GLFW_BINARY_DIR}/src/glfw3.pc @ONLY)
+
+ #--------------------------------------------------------------------
+ # Add subdirectories
+@@ -431,11 +434,9 @@ if (GLFW_INSTALL)
+                   ${GLFW_BINARY_DIR}/src/glfwConfigVersion.cmake
+             DESTINATION lib${LIB_SUFFIX}/cmake/glfw)
+
+-    if (UNIX)
+-        install(EXPORT glfwTargets DESTINATION lib${LIB_SUFFIX}/cmake/glfw)
+-        install(FILES ${GLFW_BINARY_DIR}/src/glfw3.pc
+-                DESTINATION lib${LIB_SUFFIX}/pkgconfig)
+-    endif()
++    install(EXPORT glfwTargets DESTINATION lib${LIB_SUFFIX}/cmake/glfw)
++    install(FILES ${GLFW_BINARY_DIR}/src/glfw3.pc
++            DESTINATION lib${LIB_SUFFIX}/pkgconfig)
+
+     # Only generate this target if no higher-level project already has
+     if (NOT TARGET uninstall)
+--
+2.0.3
+

--- a/mingw-w64-glfw/PKGBUILD
+++ b/mingw-w64-glfw/PKGBUILD
@@ -4,7 +4,7 @@ _realname=glfw
 
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.0.4
-pkgrel=1
+pkgrel=2
 pkgdesc="A free, open source, portable framework for OpenGL application development. (mingw-w64)"
 arch=('any')
 url="http://www.glfw.org/"
@@ -14,8 +14,15 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-cmake")
 optdepends=()
 conflicts=()
 options=('staticlibs' 'strip')
-source=(http://downloads.sourceforge.net/project/glfw/glfw/$pkgver/${_realname}-$pkgver.tar.gz)
-sha1sums=('9b04309418ccbc74b2115d11198b7912669814ee')
+source=(http://downloads.sourceforge.net/project/glfw/glfw/$pkgver/${_realname}-$pkgver.tar.gz
+        0001-enabled-pkg-config-file-generation-on-mingw.patch)
+sha1sums=('9b04309418ccbc74b2115d11198b7912669814ee'
+          '1018e847e3bd3874662788c883bebb453d490267')
+
+prepare() {
+  cd "${srcdir}/glfw-${pkgver}"
+  patch -p1 -i "${srcdir}/0001-enabled-pkg-config-file-generation-on-mingw.patch"
+}
 
 build() {
   # Build static libs
@@ -57,4 +64,10 @@ package() {
   #copy license file
   mkdir -p "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
   cp "${srcdir}/${_realname}-${pkgver}/COPYING.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
+
+  pushd ${pkgdir}${MINGW_PREFIX} > /dev/null
+  export PREFIX_WIN=`pwd -W`
+  popd > /dev/null
+  sed -s "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" \
+    -i ${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/glfw3.pc
 }


### PR DESCRIPTION
I'm trying to build a GLFW program with MSYS2, but it uses pkg-config. This adds a patch from GLFW-git to enable pkg-config on MinGW (in 3.0.4 it's only enabled for *nix.)
