### PR TITLE
Provide GNAT runtime import libraries to allow to link against shared ru...

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -12,7 +12,7 @@ pkgname=(
         "${MINGW_PACKAGE_PREFIX}-${_realname}-objc"
         )
 pkgver=4.9.1
-pkgrel=3
+pkgrel=4
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 url="http://gcc.gnu.org"
@@ -44,6 +44,7 @@ source=("ftp://gcc.gnu.org/pub/gcc/releases/${_realname}-${pkgver}/${_realname}-
         'enable-shared-gnat.mingw.patch'
         'no-fpic-in-sanitizer.all.patch'
         'port-sanitizer-to-mingw.all.patch'
+        'enable-shared-gnat-implib.mingw.patch'
         )
 md5sums=('fddf71348546af523353bd43d34919c1'
          '41635a40493dc79416db6627b2826b21'
@@ -65,7 +66,9 @@ md5sums=('fddf71348546af523353bd43d34919c1'
          '5201bee23601ddfacde436461559f561'
          'a56fb2cf67ae619f22e0d21f378ff704'
          '0f3fb8c9aab4bbb02a9923adc22c6109'
-         '52592c1d7c6031ff601ecfdf3942b940')
+         '52592c1d7c6031ff601ecfdf3942b940'
+	 '62cc23251ae746b5f39c2c7aef121e8f')
+
 _threads="posix"
 
 prepare() {
@@ -138,6 +141,8 @@ prepare() {
   patch -p1 -i ${srcdir}/230-build-more-gnattools.mingw.patch
   
   patch -p1 -i ${srcdir}/240-prettify-linking-no-undefined.mingw.patch
+
+  patch -p1 -i ${srcdir}/enable-shared-gnat-implib.mingw.patch
 
   # patch -p1 -i ${srcdir}/enable-libitm.mingw.patch
   # patch -p1 -i ${srcdir}/enable-libsanitizer.mingw.patch
@@ -364,8 +369,8 @@ package_mingw-w64-gcc-ada() {
   # cp bin/gnatxref.exe ${pkgdir}${MINGW_PREFIX}/bin/
   
   cp bin/{libgnarl*,libgnat*}.dll ${pkgdir}${MINGW_PREFIX}/bin/
-  
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver}
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver}/adalib
+
   cp -r lib/gcc/${MINGW_CHOST}/${pkgver}/adainclude ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver}/
   cp -r lib/gcc/${MINGW_CHOST}/${pkgver}/adalib ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver}/
   cp lib/gcc/${MINGW_CHOST}/${pkgver}/gnat1.exe ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver}/

--- a/mingw-w64-gcc/enable-shared-gnat-implib.mingw.patch
+++ b/mingw-w64-gcc/enable-shared-gnat-implib.mingw.patch
@@ -1,0 +1,21 @@
+diff -ruN gcc-4.9.1.orig/gcc/ada/gcc-interface/Makefile.in gcc-4.9.1/gcc/ada/gcc-interface/Makefile.in
+--- gcc-4.9.1.orig/gcc/ada/gcc-interface/Makefile.in	2014-05-17 12:13:12.000000000 +0200
++++ gcc-4.9.1/gcc/ada/gcc-interface/Makefile.in	2014-08-16 05:32:07.771651300 +0200
+@@ -2886,13 +2886,16 @@
+ 		$(PICFLAG_FOR_TARGET) \
+ 		-o libgnat$(hyphen)$(LIBRARY_VERSION)$(soext) \
+ 		$(GNATRTL_NONTASKING_OBJS) $(LIBGNAT_OBJS) \
+-		$(SO_OPTS)libgnat$(hyphen)$(LIBRARY_VERSION)$(soext) $(MISCLIB)
++		$(SO_OPTS)libgnat$(hyphen)$(LIBRARY_VERSION)$(soext) \
++		-Wl,-out-implib,libgnat$(hyphen)$(LIBRARY_VERSION).dll.a \
++		$(MISCLIB)
+ 	cd $(RTSDIR); `echo "$(GCC_FOR_TARGET)" \
+                 | sed -e 's,\./xgcc,../../xgcc,' -e 's,-B\./,-B../../,'` -shared -shared-libgcc \
+ 		$(PICFLAG_FOR_TARGET) \
+ 		-o libgnarl$(hyphen)$(LIBRARY_VERSION)$(soext) \
+ 		$(GNATRTL_TASKING_OBJS) \
+ 		$(SO_OPTS)libgnarl$(hyphen)$(LIBRARY_VERSION)$(soext) \
++		-Wl,-out-implib,libgnarl$(hyphen)$(LIBRARY_VERSION).dll.a \
+ 		$(THREADSLIB) -Wl,libgnat$(hyphen)$(LIBRARY_VERSION)$(soext)
+ 
+ gnatlib-shared-darwin:


### PR DESCRIPTION
The buildscript rightfully moves libgnat-4.9.dll and libgnarl-4.9.dll from the runtime adalib directory to bin in order to allow dynamically linked Ada programs to find the runtime DLLs. Removing these DLLs from the adalib directory nevertheless prevents Ada programs from being linked against the shared runtime out-of-the-box (using gnatmake option "-bargs -shared"). This patch forces the build of the import libraries for these DLLs which are left in the adalib directory, so Ada programs can now be linked against the dynamic runtime again.
