### PR TITLE
tup: New package.

### DIFF
--- a/mingw-w64-tup/PKGBUILD
+++ b/mingw-w64-tup/PKGBUILD
@@ -1,0 +1,22 @@
+_realname=tup
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=v0.7.2_14_gf8864f9
+pkgrel=1
+pkgdesc='A fast, file-based build system'
+arch=('any')
+url='http://gittup.org/tup/index.html'
+license=(GPL2)
+makedepends=('unzip')
+provides=(tup)
+conflicts=(tup)
+source=("http://gittup.org/tup/win32/${_realname}-${pkgver//_/-}.zip")
+md5sums=('7fe4ec3d5efc73066e99fc42a6d62c59')
+
+package() {
+  cd "${srcdir}"
+  install -d "$pkgdir/$MINGW_PREFIX"/bin "$pkgdir/$MINGW_PREFIX"/share/man/man1 "$pkgdir/$MINGW_PREFIX"/share/doc/tup
+  install -m755 -t "$pkgdir/$MINGW_PREFIX"/bin tup
+  install -m755 -t "$pkgdir/$MINGW_PREFIX"/bin tup-dllinject.dll
+  install -m644 -t "$pkgdir/$MINGW_PREFIX"/share/man/man1 tup.1
+  install -m644 -t "$pkgdir/$MINGW_PREFIX"/share/doc/tup manual.html
+}


### PR DESCRIPTION
I opted to download the prebuilt binary here because the build scripts tup ships with only support cross-compiling from Linux. A native windows build is probably possible.

Note that tup doesn't support 64-bit compilers on windows at present. I haven't been able to work out how to get the pkgbuild to only emit an i686 package.
