### PR TITLE
Tesseract version should be 3.03 only

### DIFF
--- a/mingw-w64-tesseract-ocr/PKGBUILD
+++ b/mingw-w64-tesseract-ocr/PKGBUILD
@@ -3,7 +3,7 @@
 
 _realname=tesseract-ocr
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.04
+pkgver=3.03.298e31465a44
 pkgrel=1
 pkgdesc="Tesseract OCR (mingw-w64)"
 arch=('any')


### PR DESCRIPTION
3.04 has not been released, hence please keep the version as 3.03.

Minor version can indicate the  Revision: 298e31465a44

https://code.google.com/p/tesseract-ocr/source/detail?r=298e31465a445e54defedd076217ff24b1af3fc2

Thank you.
