### PR TITLE
gtk2: Add patch to fix rendering glitches

### DIFF
--- a/mingw-w64-gtk2/0013-gtk-revert-recreatecairosurface-commit.patch
+++ b/mingw-w64-gtk2/0013-gtk-revert-recreatecairosurface-commit.patch
@@ -1,0 +1,89 @@
+--- gtk-2.24.23.orig/gdk/win32/gdkdrawable-win32.c	2014-03-18 02:19:03.000000000 +0100
++++ gtk-2.24.23/gdk/win32/gdkdrawable-win32.c	2014-05-29 15:57:21.843450500 +0200
+@@ -144,7 +144,6 @@
+ static void gdk_drawable_impl_win32_finalize   (GObject *object);
+ 
+ static const cairo_user_data_key_t gdk_win32_cairo_key;
+-static const cairo_user_data_key_t gdk_win32_cairo_hdc_key;
+ 
+ G_DEFINE_TYPE (GdkDrawableImplWin32,  _gdk_drawable_impl_win32, GDK_TYPE_DRAWABLE)
+ 
+@@ -1910,33 +1909,13 @@
+     }
+ }
+ 
+-static void
+-gdk_win32_cairo_surface_release_hdc (void *data)
+-{
+-  _gdk_win32_drawable_release_dc (GDK_DRAWABLE (data));
+-}
+-
+ cairo_surface_t *
+ _gdk_windowing_create_cairo_surface (GdkDrawable *drawable,
+ 				     gint width,
+ 				     gint height)
+ {
+-  cairo_surface_t *surface;
+-  HDC hdc;
+-
+-  hdc = _gdk_win32_drawable_acquire_dc (drawable);
+-  if (!hdc)
+-    return NULL;
+-
+-  surface = cairo_win32_surface_create (hdc);
+-
+-  /* Whenever the cairo surface is destroyed, we need to release the
+-   * HDC that was acquired */
+-  cairo_surface_set_user_data (surface, &gdk_win32_cairo_hdc_key,
+-			       drawable,
+-			       gdk_win32_cairo_surface_release_hdc);
+-
+-  return surface;
++  /* width and height are determined from the DC */
++  return gdk_win32_ref_cairo_surface (drawable);
+ }
+ 
+ static void
+@@ -1944,6 +1923,7 @@
+ {
+   GdkDrawableImplWin32 *impl = data;
+ 
++  _gdk_win32_drawable_release_dc (GDK_DRAWABLE (impl));
+   impl->cairo_surface = NULL;
+ }
+ 
+@@ -1958,14 +1938,14 @@
+ 
+   if (!impl->cairo_surface)
+     {
+-      /* width and height are determined from the DC */
+-      impl->cairo_surface = _gdk_windowing_create_cairo_surface (drawable, 0, 0);
++       HDC hdc = _gdk_win32_drawable_acquire_dc (drawable);
++       if (!hdc)
++      return NULL;
++
++      impl->cairo_surface = cairo_win32_surface_create (hdc);
+ 
+-      /* Whenever the cairo surface is destroyed, we need to clear the
+-       * pointer that we had stored here */
+       cairo_surface_set_user_data (impl->cairo_surface, &gdk_win32_cairo_key,
+-				   drawable,
+-				   gdk_win32_cairo_surface_destroy);
++                  drawable, gdk_win32_cairo_surface_destroy);
+     }
+   else
+     cairo_surface_reference (impl->cairo_surface);
+@@ -2044,11 +2024,9 @@
+   if (impl->cairo_surface)
+     {
+       cairo_surface_finish (impl->cairo_surface);
+-      cairo_surface_set_user_data (impl->cairo_surface, &gdk_win32_cairo_hdc_key, NULL, NULL);
+       cairo_surface_set_user_data (impl->cairo_surface, &gdk_win32_cairo_key, NULL, NULL);
+     }
+ 
+-  /* impl->hdc_count doesn't have to be 0 here; as there may still be surfaces
+-   * created with gdk_windowing_create_cairo_surface() out there, which are not
+-   * managed internally by the drawable */
++  g_assert (impl->hdc_count == 0);
++
+ }

--- a/mingw-w64-gtk2/PKGBUILD
+++ b/mingw-w64-gtk2/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gtk2
 
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.24.23
-pkgrel=1
+pkgrel=2
 pkgdesc="GTK+ is a multi-platform toolkit (v2) (mingw-w64)"
 arch=('any')
 url="http://www.gtk.org"
@@ -35,7 +35,8 @@ source=("http://ftp.gnome.org/pub/gnome/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}
     0009-give-cc-to-gir-scanner.mingw.patch
     0010-put-gtk-dll-into-path.mingw.patch
     0011-gir-for-gdkwin32.mingw.patch
-    0012-embed-manifest.all.patch)
+    0012-embed-manifest.all.patch
+    0013-gtk-revert-recreatecairosurface-commit.patch)
 
 md5sums=('0be39fbed4ca125645175cd6e22f2548'
          '5105b21ea13dbfbef8975138b4355e7a'
@@ -47,7 +48,8 @@ md5sums=('0be39fbed4ca125645175cd6e22f2548'
          'e8bd83e4eb9877d009ad57458cf5a6b0'
          '9e0296da2986be7697cf343563b85d1f'
          '91d12fc6da9026deb0f94f38ab22a3ec'
-         '864a719c5fea860ced90cacab5545b1d')
+         '864a719c5fea860ced90cacab5545b1d'
+         '1dbf362025860675ace96bdfaa96f283')
 
 prepare() {
   cd gtk+-$pkgver
@@ -60,6 +62,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0010-put-gtk-dll-into-path.mingw.patch
   patch -p1 -i ${srcdir}/0011-gir-for-gdkwin32.mingw.patch
   patch -p1 -i ${srcdir}/0012-embed-manifest.all.patch
+  patch -p1 -i ${srcdir}/0013-gtk-revert-recreatecairosurface-commit.patch
   
   autoreconf -fi
 }


### PR DESCRIPTION
This reverts https://git.gnome.org/browse/gtk+/commit/?h=gtk-2-24&id=4ecbef0791d420c014ecca911cd2a1cc18122e9a
