### PR TITLE
boost: Speeding up the build

### DIFF
--- a/mingw-w64-boost/PKGBUILD
+++ b/mingw-w64-boost/PKGBUILD
@@ -90,11 +90,11 @@ build() {
     -sZLIB_BINARY=z \
     -sZLIB_INCLUDE=${MINGW_PREFIX}/include \
     -sZLIB_LIBPATH=${MINGW_PREFIX}/zlib \
-    pch=off \
     -d2 \
     address-model=${_model} \
     --layout=tagged \
-    --without-mpi
+    --without-mpi \
+    -j$(($(nproc)+1))
 }
 
 package() {


### PR DESCRIPTION
b2 considers pch=on/off as distinct build configurations. Removing "pch=off" fixes rebuilding boost in package().
