### PR TITLE
google snappy: new package

### DIFF
--- a/mingw-w64-snappy/PKGBUILD
+++ b/mingw-w64-snappy/PKGBUILD
@@ -3,7 +3,7 @@
 pkgname="$MINGW_PACKAGE_PREFIX-snappy"
 pkgver=1.1.1
 pkgrel=1
-pkgdesc="A C++/Qt ZIP library (mingw-w64)"
+pkgdesc="A fast C++ compressor/decompressor library (mingw-w64)"
 arch=('any')
 license=('New BSD License')
 url="snappy.googlecode.com"


### PR DESCRIPTION
I chose the 1.1.1 release as arch does, because i was unable to get makepkg to successfully download 1.1.2 from their temporary gdrive download link. 
