### PR TITLE
fftw: enable support for SMP

### DIFF
--- a/mingw-w64-fftw/PKGBUILD
+++ b/mingw-w64-fftw/PKGBUILD
@@ -4,7 +4,7 @@ _realname=fftw
 
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.3.4
-pkgrel=2
+pkgrel=3
 pkgdesc="A library for computing the discrete Fourier transform (DFT) (mingw-w64)"
 arch=('any')
 url="http://www.fftw.org"
@@ -26,7 +26,8 @@ build() {
     --enable-avx \
     --enable-static \
     --enable-shared \
-    --enable-threads=win32 \
+    --enable-threads \
+    --with-combined-threads \
     --with-our-malloc \
     --with-g77-wrappers \
     --with-windows-f77-mangling
@@ -41,7 +42,8 @@ build() {
     --enable-long-double \
     --enable-static \
     --enable-shared \
-    --enable-threads=win32 \
+    --enable-threads \
+    --with-combined-threads \
     --with-our-malloc \
     --with-g77-wrappers \
     --with-windows-f77-mangling
@@ -58,7 +60,8 @@ build() {
     --enable-avx \
     --enable-static \
     --enable-shared \
-    --enable-threads=win32 \
+    --enable-threads \
+    --with-combined-threads \
     --with-our-malloc \
     --with-g77-wrappers \
     --with-windows-f77-mangling


### PR DESCRIPTION
This enables multi-threaded FFTW build.
