### PR TITLE
opencv: Update to 2.4.10

### DIFF
--- a/mingw-w64-opencv/PKGBUILD
+++ b/mingw-w64-opencv/PKGBUILD
@@ -2,8 +2,8 @@
 
 _realname=opencv
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.4.9
-pkgrel=4
+pkgver=2.4.10
+pkgrel=1
 pkgdesc="Open Source Computer Vision Library (mingw-w64)"
 arch=('any')
 url="http://opencv.org/"
@@ -22,45 +22,54 @@ depends=(#"${MINGW_PACKAGE_PREFIX}-gst-plugins-base0.10"
         )
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
             #"${MINGW_PACKAGE_PREFIX}-qt5"
-            "${MINGW_PACKAGE_PREFIX}-python2-numpy"
-            "${MINGW_PACKAGE_PREFIX}-python2-sphinx"
             "${MINGW_PACKAGE_PREFIX}-eigen3"
+            "${MINGW_PACKAGE_PREFIX}-python2-numpy"
+            "${MINGW_PACKAGE_PREFIX}-vtk"
             )
 optdepends=("${MINGW_PACKAGE_PREFIX}-eigen3"
-            #'libcl: For coding with OpenCL'
-            "${MINGW_PACKAGE_PREFIX}-python2-numpy: Python 2.x interface")
+            "${MINGW_PACKAGE_PREFIX}-python2-numpy: Python 2.x interface"
+            "${MINGW_PACKAGE_PREFIX}-vtk: opencv_viz module")
 source=(#"http://downloads.sourceforge.net/opencvlibrary/${_realname}-$pkgver.zip"
         https://github.com/Itseez/opencv/archive/$pkgver.tar.gz
-        'mingw-w64-cmake.patch')
-md5sums=('cc0a8307403ff471f554197401ec0eb9'
-         '7b819e76a4849bdf70be07a1478281aa')
+        'mingw-w64-cmake.patch'
+        'free-tls-keys-on-dll-unload.patch'
+        'solve_deg3-underflow.patch')
+md5sums=('3346a59310d788d3845f4fd6043a108a'
+         '3b4bc1c4b03c5c8eb1a69aaf7a37a12c'
+         '91fcecdc23a870cafad6f51c2a45e647'
+         'ae03a59cf1202d5eafa94c2aac419ae6')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
   patch -Np1 -i "$srcdir/mingw-w64-cmake.patch"
+  patch -Np1 -i "$srcdir/free-tls-keys-on-dll-unload.patch"
+  patch -Np1 -i "$srcdir/solve_deg3-underflow.patch"
 }
 
 build() {
   # SSE only available from Pentium 3 onwards (i686 is way older)
-  [[ "$CARCH" = 'i686' ]] && \
+  [[ "$CARCH" = 'i686' ]] && {
     _cmakeopts=('-D ENABLE_SSE=OFF'
       '-DENABLE_SSE2=OFF'
       '-DENABLE_SSE3=OFF')
+    CXXFLAGS+=" -DEIGEN_DONT_VECTORIZE"
+  }
 
   # all x64 CPUs support SSE2 but not SSE3
   [[ "$CARCH" = 'x86_64' ]] && _cmakeopts+=('-DENABLE_SSE3=OFF')
 
-  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
-  mkdir -p ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
+  [[ -d ${srcdir}/build-${CARCH} ]] && rm -rf ${srcdir}/build-${CARCH}
+  mkdir -p ${srcdir}/build-${CARCH} && cd ${srcdir}/build-${CARCH}
   ${MINGW_PREFIX}/bin/cmake.exe \
     -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${pkgdir}${MINGW_PREFIX} \
-    -DWITH_OPENCL=OFF \
+    -DWITH_OPENCL=ON \
     -DWITH_OPENGL=ON \
     -DWITH_TBB=ON \
     -DWITH_XINE=OFF \
     -DBUILD_WITH_DEBUG_INFO=OFF \
+    -DBUILD_DOCS=OFF \
     -DBUILD_TESTS=OFF \
     -DBUILD_PERF_TESTS=OFF \
     -DBUILD_EXAMPLES=ON \
@@ -68,9 +77,11 @@ build() {
     -DINSTALL_PYTHON_EXAMPLES=ON \
     -DWITH_GTK=OFF \
     -DWITH_QT=OFF \
+    -DWITH_VTK=ON \
     -DWITH_GSTREAMER=OFF \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_SKIP_RPATH=ON \
+    -DENABLE_PRECOMPILED_HEADERS=OFF \
     ${_cmakeopts[@]} \
     ../${_realname}-${pkgver}
 
@@ -78,7 +89,7 @@ build() {
 }
 
 package() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${CARCH}"
   make -j1 install
 
   pushd ${pkgdir}${MINGW_PREFIX} > /dev/null

--- a/mingw-w64-opencv/free-tls-keys-on-dll-unload.patch
+++ b/mingw-w64-opencv/free-tls-keys-on-dll-unload.patch
@@ -1,0 +1,63 @@
+diff -Naur a/modules/core/src/alloc.cpp b/modules/core/src/alloc.cpp
+--- a/modules/core/src/alloc.cpp	2014-10-01 14:33:36.000000000 +0700
++++ b/modules/core/src/alloc.cpp	2014-10-02 23:40:21.133326500 +0700
+@@ -56,7 +56,7 @@
+ #if CV_USE_SYSTEM_MALLOC
+ 
+ #if defined WIN32 || defined _WIN32
+-void deleteThreadAllocData() {}
++void deleteThreadAllocData(unsigned long) {}
+ #endif
+ 
+ void* fastMalloc( size_t size )
+diff -Naur a/modules/core/src/precomp.hpp b/modules/core/src/precomp.hpp
+--- a/modules/core/src/precomp.hpp	2014-10-01 14:33:36.000000000 +0700
++++ b/modules/core/src/precomp.hpp	2014-10-02 23:40:21.133326500 +0700
+@@ -83,8 +83,8 @@
+ 
+ 
+ #if defined WIN32 || defined _WIN32
+-void deleteThreadAllocData();
+-void deleteThreadRNGData();
++void deleteThreadAllocData(unsigned long);
++void deleteThreadRNGData(unsigned long);
+ #endif
+ 
+ template<typename T1, typename T2=T1, typename T3=T1> struct OpAdd
+diff -Naur a/modules/core/src/rand.cpp b/modules/core/src/rand.cpp
+--- a/modules/core/src/rand.cpp	2014-10-01 14:33:36.000000000 +0700
++++ b/modules/core/src/rand.cpp	2014-10-02 23:40:21.133326500 +0700
+@@ -752,10 +752,15 @@
+ #endif
+ static DWORD tlsRNGKey = TLS_OUT_OF_INDEXES;
+ 
+- void deleteThreadRNGData()
+- {
+-     if( tlsRNGKey != TLS_OUT_OF_INDEXES )
+-         delete (RNG*)TlsGetValue( tlsRNGKey );
++void deleteThreadRNGData(unsigned long reason)
++{
++    if( tlsRNGKey != TLS_OUT_OF_INDEXES )
++        delete (RNG*)TlsGetValue( tlsRNGKey );
++    if( reason == DLL_PROCESS_DETACH && tlsRNGKey != TLS_OUT_OF_INDEXES )
++    {
++        TlsFree(tlsRNGKey);
++        tlsRNGKey = TLS_OUT_OF_INDEXES;
++    }
+ }
+ 
+ RNG& theRNG()
+diff -Naur a/modules/core/src/system.cpp b/modules/core/src/system.cpp
+--- a/modules/core/src/system.cpp	2014-10-01 14:33:36.000000000 +0700
++++ b/modules/core/src/system.cpp	2014-10-02 23:40:21.133326500 +0700
+@@ -1079,8 +1079,8 @@
+ {
+     if (fdwReason == DLL_THREAD_DETACH || fdwReason == DLL_PROCESS_DETACH)
+     {
+-        cv::deleteThreadAllocData();
+-        cv::deleteThreadRNGData();
++        cv::deleteThreadAllocData(fdwReason);
++        cv::deleteThreadRNGData(fdwReason);
+         cv::deleteThreadData();
+     }
+     return TRUE;

--- a/mingw-w64-opencv/mingw-w64-cmake.patch
+++ b/mingw-w64-opencv/mingw-w64-cmake.patch
@@ -1,7 +1,7 @@
-diff -Naur opencv-2.4.9-orig/cmake/OpenCVDetectPython.cmake opencv-2.4.9/cmake/OpenCVDetectPython.cmake
---- opencv-2.4.9-orig/cmake/OpenCVDetectPython.cmake	2014-04-11 14:15:26.000000000 +0400
-+++ opencv-2.4.9/cmake/OpenCVDetectPython.cmake	2014-05-29 00:42:28.419600000 +0400
-@@ -50,7 +50,7 @@
+diff -Naur a/cmake/OpenCVDetectPython.cmake b/cmake/OpenCVDetectPython.cmake
+--- a/cmake/OpenCVDetectPython.cmake	2014-10-01 14:33:36.000000000 +0700
++++ b/cmake/OpenCVDetectPython.cmake	2014-10-02 23:18:25.505210700 +0700
+@@ -52,7 +52,7 @@
    endif()
  
    if(NOT ANDROID AND NOT IOS)
@@ -10,10 +10,10 @@ diff -Naur opencv-2.4.9-orig/cmake/OpenCVDetectPython.cmake opencv-2.4.9/cmake/O
        execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import *; print get_python_lib()"
                        RESULT_VARIABLE PYTHON_CVPY_PROCESS
                        OUTPUT_VARIABLE PYTHON_STD_PACKAGES_PATH
-diff -Naur opencv-2.4.9-orig/cmake/OpenCVFindLibsVideo.cmake opencv-2.4.9/cmake/OpenCVFindLibsVideo.cmake
---- opencv-2.4.9-orig/cmake/OpenCVFindLibsVideo.cmake	2014-04-11 14:15:26.000000000 +0400
-+++ opencv-2.4.9/cmake/OpenCVFindLibsVideo.cmake	2014-05-29 00:05:53.249600000 +0400
-@@ -151,7 +151,7 @@
+diff -Naur a/cmake/OpenCVFindLibsVideo.cmake b/cmake/OpenCVFindLibsVideo.cmake
+--- a/cmake/OpenCVFindLibsVideo.cmake	2014-10-01 14:33:36.000000000 +0700
++++ b/cmake/OpenCVFindLibsVideo.cmake	2014-10-02 23:18:25.505210700 +0700
+@@ -184,7 +184,7 @@
  # --- FFMPEG ---
  ocv_clear_vars(HAVE_FFMPEG HAVE_FFMPEG_CODEC HAVE_FFMPEG_FORMAT HAVE_FFMPEG_UTIL HAVE_FFMPEG_SWSCALE HAVE_GENTOO_FFMPEG HAVE_FFMPEG_FFMPEG)
  if(WITH_FFMPEG)
@@ -22,9 +22,9 @@ diff -Naur opencv-2.4.9-orig/cmake/OpenCVFindLibsVideo.cmake opencv-2.4.9/cmake/
      include("${OpenCV_SOURCE_DIR}/3rdparty/ffmpeg/ffmpeg_version.cmake")
    elseif(UNIX)
      CHECK_MODULE(libavcodec HAVE_FFMPEG_CODEC)
-diff -Naur opencv-2.4.9-orig/cmake/OpenCVFindOpenEXR.cmake opencv-2.4.9/cmake/OpenCVFindOpenEXR.cmake
---- opencv-2.4.9-orig/cmake/OpenCVFindOpenEXR.cmake	2014-04-11 14:15:26.000000000 +0400
-+++ opencv-2.4.9/cmake/OpenCVFindOpenEXR.cmake	2014-05-29 00:06:29.535200000 +0400
+diff -Naur a/cmake/OpenCVFindOpenEXR.cmake b/cmake/OpenCVFindOpenEXR.cmake
+--- a/cmake/OpenCVFindOpenEXR.cmake	2014-10-01 14:33:36.000000000 +0700
++++ b/cmake/OpenCVFindOpenEXR.cmake	2014-10-02 23:18:25.505210700 +0700
 @@ -13,7 +13,7 @@
  SET(OPENEXR_LIBSEARCH_SUFFIXES "")
  file(TO_CMAKE_PATH "$ENV{ProgramFiles}" ProgramFiles_ENV_PATH)
@@ -34,9 +34,9 @@ diff -Naur opencv-2.4.9-orig/cmake/OpenCVFindOpenEXR.cmake opencv-2.4.9/cmake/Op
      SET(OPENEXR_ROOT "C:/Deploy" CACHE STRING "Path to the OpenEXR \"Deploy\" folder")
      if(CMAKE_CL_64)
          SET(OPENEXR_LIBSEARCH_SUFFIXES x64/Release x64 x64/Debug)
-diff -Naur opencv-2.4.9-orig/cmake/OpenCVGenConfig.cmake opencv-2.4.9/cmake/OpenCVGenConfig.cmake
---- opencv-2.4.9-orig/cmake/OpenCVGenConfig.cmake	2014-04-11 14:15:26.000000000 +0400
-+++ opencv-2.4.9/cmake/OpenCVGenConfig.cmake	2014-05-29 00:49:56.707600000 +0400
+diff -Naur a/cmake/OpenCVGenConfig.cmake b/cmake/OpenCVGenConfig.cmake
+--- a/cmake/OpenCVGenConfig.cmake	2014-10-01 14:33:36.000000000 +0700
++++ b/cmake/OpenCVGenConfig.cmake	2014-10-02 23:18:25.505210700 +0700
 @@ -101,7 +101,7 @@
  configure_file("${OpenCV_SOURCE_DIR}/cmake/templates/OpenCVConfig.cmake.in" "${CMAKE_BINARY_DIR}/unix-install/OpenCVConfig.cmake" @ONLY)
  configure_file("${OpenCV_SOURCE_DIR}/cmake/templates/OpenCVConfig-version.cmake.in" "${CMAKE_BINARY_DIR}/unix-install/OpenCVConfig-version.cmake" @ONLY)
@@ -55,9 +55,9 @@ diff -Naur opencv-2.4.9-orig/cmake/OpenCVGenConfig.cmake opencv-2.4.9/cmake/Open
    set(OpenCV_INCLUDE_DIRS_CONFIGCMAKE "\"\${OpenCV_CONFIG_PATH}/include\" \"\${OpenCV_CONFIG_PATH}/include/opencv\"")
    set(OpenCV2_INCLUDE_DIRS_CONFIGCMAKE "\"\"")
  
-diff -Naur opencv-2.4.9-orig/cmake/OpenCVGenPkgconfig.cmake opencv-2.4.9/cmake/OpenCVGenPkgconfig.cmake
---- opencv-2.4.9-orig/cmake/OpenCVGenPkgconfig.cmake	2014-04-11 14:15:26.000000000 +0400
-+++ opencv-2.4.9/cmake/OpenCVGenPkgconfig.cmake	2014-05-29 00:03:43.677400000 +0400
+diff -Naur a/cmake/OpenCVGenPkgconfig.cmake b/cmake/OpenCVGenPkgconfig.cmake
+--- a/cmake/OpenCVGenPkgconfig.cmake	2014-10-01 14:33:36.000000000 +0700
++++ b/cmake/OpenCVGenPkgconfig.cmake	2014-10-02 23:18:25.505210700 +0700
 @@ -10,7 +10,7 @@
  # -------------------------------------------------------------------------------------------
  set(prefix      "${CMAKE_INSTALL_PREFIX}")
@@ -99,10 +99,10 @@ diff -Naur opencv-2.4.9-orig/cmake/OpenCVGenPkgconfig.cmake opencv-2.4.9/cmake/O
 +if(UNIX OR MINGW AND NOT ANDROID)
    install(FILES ${CMAKE_BINARY_DIR}/unix-install/${OPENCV_PC_FILE_NAME} DESTINATION ${OPENCV_LIB_INSTALL_PATH}/pkgconfig COMPONENT dev)
  endif()
-diff -Naur opencv-2.4.9-orig/cmake/OpenCVModule.cmake opencv-2.4.9/cmake/OpenCVModule.cmake
---- opencv-2.4.9-orig/cmake/OpenCVModule.cmake	2014-04-11 14:15:26.000000000 +0400
-+++ opencv-2.4.9/cmake/OpenCVModule.cmake	2014-05-28 23:53:46.340200000 +0400
-@@ -563,7 +563,9 @@
+diff -Naur a/cmake/OpenCVModule.cmake b/cmake/OpenCVModule.cmake
+--- a/cmake/OpenCVModule.cmake	2014-10-01 14:33:36.000000000 +0700
++++ b/cmake/OpenCVModule.cmake	2014-10-02 23:18:25.505210700 +0700
+@@ -585,7 +585,9 @@
    endif()
  
    set_target_properties(${the_module} PROPERTIES
@@ -113,9 +113,21 @@ diff -Naur opencv-2.4.9-orig/cmake/OpenCVModule.cmake opencv-2.4.9/cmake/OpenCVM
      DEBUG_POSTFIX "${OPENCV_DEBUG_POSTFIX}"
      ARCHIVE_OUTPUT_DIRECTORY ${LIBRARY_OUTPUT_PATH}
      LIBRARY_OUTPUT_DIRECTORY ${LIBRARY_OUTPUT_PATH}
-diff -Naur opencv-2.4.9-orig/CMakeLists.txt opencv-2.4.9/CMakeLists.txt
---- opencv-2.4.9-orig/CMakeLists.txt	2014-04-11 14:15:26.000000000 +0400
-+++ opencv-2.4.9/CMakeLists.txt	2014-05-29 00:38:47.940400000 +0400
+diff -Naur a/cmake/templates/OpenCVConfig.cmake.in b/cmake/templates/OpenCVConfig.cmake.in
+--- a/cmake/templates/OpenCVConfig.cmake.in	2014-10-01 14:33:36.000000000 +0700
++++ b/cmake/templates/OpenCVConfig.cmake.in	2014-10-02 23:20:38.776244800 +0700
+@@ -75,7 +75,7 @@
+ # Extract the directory where *this* file has been installed (determined at cmake run-time)
+ get_filename_component(OpenCV_CONFIG_PATH "${CMAKE_CURRENT_LIST_FILE}" PATH CACHE)
+ 
+-if(NOT WIN32 OR ANDROID)
++if(NOT WIN32 OR MINGW OR ANDROID)
+   if(ANDROID)
+     set(OpenCV_INSTALL_PATH "${OpenCV_CONFIG_PATH}/../../..")
+   else()
+diff -Naur a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	2014-10-01 14:33:36.000000000 +0700
++++ b/CMakeLists.txt	2014-10-02 23:18:25.505210700 +0700
 @@ -104,20 +104,6 @@
    endif()
  endif()
@@ -137,7 +149,7 @@ diff -Naur opencv-2.4.9-orig/CMakeLists.txt opencv-2.4.9/CMakeLists.txt
  # ----------------------------------------------------------------------------
  # OpenCV cmake options
  # ----------------------------------------------------------------------------
-@@ -183,12 +169,12 @@
+@@ -184,12 +170,12 @@
  OCV_OPTION(BUILD_ANDROID_PACKAGE    "Build platform-specific package for Google Play" OFF IF ANDROID )
  
  # 3rd party libs
@@ -156,7 +168,7 @@ diff -Naur opencv-2.4.9-orig/CMakeLists.txt opencv-2.4.9/CMakeLists.txt
  OCV_OPTION(BUILD_TBB                "Download and build TBB from source" ANDROID )
  
  # OpenCV installation options
-@@ -255,7 +241,7 @@
+@@ -261,7 +247,7 @@
    endif()
  endif()
  
@@ -165,7 +177,7 @@ diff -Naur opencv-2.4.9-orig/CMakeLists.txt opencv-2.4.9/CMakeLists.txt
    set(OPENCV_DOC_INSTALL_PATH doc)
  elseif(INSTALL_TO_MANGLED_PATHS)
    set(OPENCV_DOC_INSTALL_PATH share/OpenCV-${OPENCV_VERSION}/doc)
-@@ -263,7 +249,7 @@
+@@ -269,7 +255,7 @@
    set(OPENCV_DOC_INSTALL_PATH share/OpenCV/doc)
  endif()
  
@@ -174,7 +186,7 @@ diff -Naur opencv-2.4.9-orig/CMakeLists.txt opencv-2.4.9/CMakeLists.txt
    if(DEFINED OpenCV_RUNTIME AND DEFINED OpenCV_ARCH)
      set(OpenCV_INSTALL_BINARIES_PREFIX "${OpenCV_ARCH}/${OpenCV_RUNTIME}/")
    else()
-@@ -303,7 +289,7 @@
+@@ -309,7 +295,7 @@
  else()
    set(LIBRARY_OUTPUT_PATH         "${OpenCV_BINARY_DIR}/lib")
    set(3P_LIBRARY_OUTPUT_PATH      "${OpenCV_BINARY_DIR}/3rdparty/lib${LIB_SUFFIX}")
@@ -183,7 +195,7 @@ diff -Naur opencv-2.4.9-orig/CMakeLists.txt opencv-2.4.9/CMakeLists.txt
      if(OpenCV_STATIC)
        set(OPENCV_LIB_INSTALL_PATH   "${OpenCV_INSTALL_BINARIES_PREFIX}staticlib${LIB_SUFFIX}")
      else()
-@@ -624,7 +610,7 @@
+@@ -635,7 +621,7 @@
  endif()
  
  # for UNIX it does not make sense as LICENSE and readme will be part of the package automatically
@@ -192,10 +204,10 @@ diff -Naur opencv-2.4.9-orig/CMakeLists.txt opencv-2.4.9/CMakeLists.txt
    install(FILES ${OPENCV_LICENSE_FILE}
          PERMISSIONS OWNER_READ GROUP_READ WORLD_READ
          DESTINATION ${CMAKE_INSTALL_PREFIX} COMPONENT libs)
-diff -Naur opencv-2.4.9-orig/modules/highgui/CMakeLists.txt opencv-2.4.9/modules/highgui/CMakeLists.txt
---- opencv-2.4.9-orig/modules/highgui/CMakeLists.txt	2014-04-11 14:15:26.000000000 +0400
-+++ opencv-2.4.9/modules/highgui/CMakeLists.txt	2014-05-28 23:55:30.818800000 +0400
-@@ -287,7 +287,7 @@
+diff -Naur a/modules/highgui/CMakeLists.txt b/modules/highgui/CMakeLists.txt
+--- a/modules/highgui/CMakeLists.txt	2014-10-01 14:33:36.000000000 +0700
++++ b/modules/highgui/CMakeLists.txt	2014-10-02 23:18:25.505210700 +0700
+@@ -296,7 +296,7 @@
  
  if(WIN32 AND WITH_FFMPEG)
    #copy ffmpeg dll to the output folder

--- a/mingw-w64-opencv/solve_deg3-underflow.patch
+++ b/mingw-w64-opencv/solve_deg3-underflow.patch
@@ -1,0 +1,13 @@
+diff --git a/modules/calib3d/src/polynom_solver.cpp b/modules/calib3d/src/polynom_solver.cpp
+index 1813340..051ed03 100644
+--- a/modules/calib3d/src/polynom_solver.cpp
++++ b/modules/calib3d/src/polynom_solver.cpp
+@@ -60,7 +60,7 @@ int solve_deg3(double a, double b, double c, double d,
+   double D = Q3 + R * R;
+   double b_a_3 = (1. / 3.) * b_a;
+ 
+-  if (Q == 0) {
++  if (Q3 == 0) {
+     if(R == 0) {
+       x0 = x1 = x2 = - b_a_3;
+       return 3;


### PR DESCRIPTION
Also
- fixed OpenCV_INSTALL_PATH in cmake use-script. This fix is included into the updated mingw-w64-cmake.patch;
- enabled OCL module. OpenCL headers ship with OpenCV sources and needed only at build time. At runtime opencl.dll is loaded dynamically (if available). Hence enabling this module does not restricts usage of the library;
- enabled VIZ module. This requires the fixed VTK use-scrpts from PR #239 .
