### PR TITLE
Fix SHA1 checksum for 0013-mozilla-transparent-windows.all.patch

### DIFF
--- a/mingw-w64-cairo/PKGBUILD
+++ b/mingw-w64-cairo/PKGBUILD
@@ -34,7 +34,7 @@ source=("http://cairographics.org/releases/cairo-${pkgver}.tar.xz"
 sha1sums=('53cf589b983412ea7f78feee2e1ba9cea6e3ebae'
           'eed29a424e5e0bc9bd8d651b6237e541273c3f93'
           '58c548d2791ba20dd7f6e328ff596f746df3aa10'
-          '51bf688f1fb5e706fa5d71cb26d256e1a009cb7c'
+          'b4b8c6f4931814e7e77ddeb98fecaf70cb807e04'
           'fa601d6d2b2c75b0b1608ab3fa9c2e5b6cc31c9e'
           '9c0e533614782a41af2c3806a43ab7fe9d6a5431'
           'b74c9998d960a64fbf606ebe0284187add0da55a')


### PR DESCRIPTION
Patch file 0013-mozilla-transparent-windows.all.patch had the wrong SHA1 checksum and build was failing for this reason.
