### PR TITLE
libical: upgrade to 1.0.1

### DIFF
--- a/mingw-w64-libical/001-win.patch
+++ b/mingw-w64-libical/001-win.patch
@@ -13,13 +13,3 @@
  #if !defined(HAVE_BYTESWAP_H) && !defined(HAVE_SYS_ENDIAN_H) && !defined(HAVE_ENDIAN_H)
  #define bswap_16(x) (((x) << 8) & 0xff00) | (((x) >> 8 ) & 0xff)
  #define bswap_32(x) (((x) << 24) & 0xff000000)  \
---- libical-1.0.0-orig/src/libical/Makefile.am	2014-06-28 23:45:24.000000000 +0200
-+++ libical-1.0.0/src/libical/Makefile.am	2014-08-13 17:22:46.036793000 +0200
-@@ -105,7 +105,6 @@
- 	pvl.h			\
- 	sspm.c			\
- 	sspm.h			\
--	libicals_w32_vsnprintf_replacement.c \
- 	icallangbind.h		\
- 	icallangbind.c 		\
- 	caldate.c 		\

--- a/mingw-w64-libical/PKGBUILD
+++ b/mingw-w64-libical/PKGBUILD
@@ -2,49 +2,46 @@
 
 _realname=libical
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.0.0
-pkgrel=2
+pkgver=1.0.1
+pkgrel=1
 arch=('any')
 pkgdesc="An Open Source implementation of the iCalendar protocols and protocol data units (mingw-w64)"
 license=("LGPL 2.1")
 url="https://github.com/libical/libical"
 depends=()
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
-            "make"
-            "libtool"
-            "automake-wrapper"
-            "autoconf"
-            "patch")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake")
 options=('strip' '!debug' 'staticlibs')
 source=(https://github.com/${_realname}/${_realname}/archive/v$pkgver.tar.gz
         001-win.patch)
-sha256sums=('0072e83834092315772e6719b85fc8b11530b1ff53f4d108315fb38cddbce8c2'
-            '42f818a7d1304252b49c331a13ba58f681c834b00799fd3771c5eb9bfb95427b')
+sha256sums=('7d5f613454ec6c7d1bcfb441c919215be53292aa15cd1cb14249d1413d6c610c'
+            'f080396da2203af16ed770141595fed86934df51c2ce40edfeccea23eaf25e00')
 
 prepare() {
   cd ${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/001-win.patch
-  
-  autoreconf -fi
 }
 
 build() {
   mkdir -p build-${MINGW_CHOST}
   cd build-${MINGW_CHOST}
 
-  ../${_realname}-${pkgver}/configure \
-    --host=${MINGW_CHOST} \
-    --target=${MINGW_CHOST} \
-    --build=${MINGW_CHOST} \
-    --prefix=${MINGW_PREFIX} \
-    --libexecdir=${MINGW_PREFIX}/lib \
-    --enable-shared \
-    --disable-static \
-    --with-devel
+  ${MINGW_PREFIX}/bin/cmake \
+    -DCMAKE_INSTALL_PREFIX=${pkgdir}${MINGW_PREFIX} \
+    -DCMAKE_SKIP_RPATH=ON \
+    -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
+    -DCMAKE_C_FLAGS="${CFLAGS}" \
+    -G "MSYS Makefiles" \
+    ../${_realname}-${pkgver}
   make
 }
 
 package() {
   cd "$srcdir/build-${MINGW_CHOST}"
-  make DESTDIR=$pkgdir install
+  make install
+
+  pushd ${pkgdir}${MINGW_PREFIX} > /dev/null
+  local PREFIX_WIN=`pwd -W`
+  popd > /dev/null
+  sed -s "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" \
+    -i ${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/libical.pc
 }


### PR DESCRIPTION
They have abandoned autotools for cmake.

I don't know why but when i run the first time makepkg-mingw i got an error from bsdtar; rerunning makepkg-mingw it works...
