### PR TITLE
putty: Fixed license installation location

### DIFF
--- a/mingw-w64-putty/PKGBUILD
+++ b/mingw-w64-putty/PKGBUILD
@@ -46,7 +46,7 @@ build() {
 
 package() {
   cd "${srcdir}"/${_realname}/windows
-  install -D -m644 ../LICENCE "${pkgdir}"/${MINGW_PREFIX}/usr/share/licenses/${_realname}/LICENSE
+  install -D -m644 ../LICENCE "${pkgdir}"/${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
   for f in putty.exe puttygen.exe pageant.exe plink.exe pscp.exe psftp.exe
   do
     install -D -m755 $f "${pkgdir}"/${MINGW_PREFIX}/bin/$f


### PR DESCRIPTION
The license file was installed into a wrong location. I fixed it.
