### PR TITLE
Added new package: Libnotify

### DIFF
--- a/mingw-w64-libnotify/PKGBUILD
+++ b/mingw-w64-libnotify/PKGBUILD
@@ -1,0 +1,45 @@
+# $Id$
+# Maintainer: Jan de Groot <jgc@archlinux.org>
+# Maintainer: Zach Bacon <11doctorwhocanada@gmail.com>
+
+_realname=libnotify
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=0.7.6
+pkgrel=1
+pkgdesc="Desktop notification library"
+arch=('any')
+url="http://library.gnome.org/devel/notification-spec/"
+license=('LGPL')
+depends=("${MINGW_PACKAGE_PREFIX}-gdk-pixbuf2")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gtk3" "${MINGW_PACKAGE_PREFIX}-gobject-introspection")
+source=("http://ftp.gnome.org/pub/GNOME/sources/${pkgname}/0.7/${_realname}-${pkgver}.tar.xz"
+		"introspection.patch"
+		"test-fix.patch")
+sha256sums=("0ef61ca400d30e28217979bfa0e73a7406b19c32dd76150654ec5b2bdf47d837"
+			"7c5795ac0a74a2d5efdc13ae05d610acc8176fce7114ed6b9322be4f0ca710e9"
+			"185e7885512106172627525a4ec1fc18c2f95844f733e49cece325874a55f8e6")
+
+prepare() {
+  cd $srcdir/${_realname}-${pkgver}
+  patch -p1 -i ${srcdir}/introspection.patch
+  patch -p1 -i ${srcdir}/test-fix.patch
+}
+
+build() {
+  cd "$srcdir"/${_realname}-${pkgver}
+  [ -d "${srcdir}"/build-${CARCH} ] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+  ../${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --enable-static \
+    --enable-shared \
+    --enable-introspection=yes
+  make
+}
+
+package() {
+  cd "${srcdir}"/build-${CARCH}
+  make install DESTDIR="${pkgdir}"
+}

--- a/mingw-w64-libnotify/introspection.patch
+++ b/mingw-w64-libnotify/introspection.patch
@@ -1,0 +1,20 @@
+--- libnotify-0.7.6/libnotify/Makefile.am	Fri Jan 27 02:52:36 2012
++++ libnotify-0.7.6/libnotify/Makefile.am	Mon Oct 20 11:08:31 2014
+@@ -44,7 +44,8 @@
+
+ libnotify_la_LDFLAGS = \
+ 	-version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE) \
+-	-export-symbols-regex "^notify_.*"
++	-export-symbols-regex "^notify_.*" \
++	-no-undefined
+
+ notify-marshal.h: notify-marshal.list
+ 	$(AM_V_GEN) $(GLIB_GENMARSHAL) --prefix=$(MARSHAL_PREFIX) $(srcdir)/notify-marshal.list \
+@@ -86,6 +87,7 @@
+
+ -include $(INTROSPECTION_MAKEFILE)
+ INTROSPECTION_GIRS = Notify-0.7.gir
++INTROSPECTION_SCANNER_ENV = CC="$(CC)"
+ INTROSPECTION_SCANNER_ARGS = --add-include-path=$(top_srcdir) --add-include-path=$(top_builddir) --warn-all -I$(top_srcdir) -I$(top_builddir)
+ INTROSPECTION_COMPILER_ARGS = --includedir=$(top_srcdir)
+

--- a/mingw-w64-libnotify/test-fix.patch
+++ b/mingw-w64-libnotify/test-fix.patch
@@ -1,0 +1,10 @@
+--- libnotify-0.7.6-new/tests/test-image.c	Sat Aug 31 13:10:05 2013
++++ libnotify-0.7.6/tests/test-image.c	Mon Oct 20 06:52:59 2014
+@@ -27,7 +27,6 @@
+ #include <assert.h>
+ #include <string.h>
+ #include <errno.h>
+-#include <sys/mman.h>
+ #include <sys/stat.h>
+ #include <unistd.h>
+ #include <fcntl.h>


### PR DESCRIPTION
Just added a new package for libnotify, allows build with introspection and added flags to generate a shared/static build of the library.
