### PR TITLE
Add new package: stxxl

### DIFF
--- a/mingw-w64-stxxl-git/PKGBUILD
+++ b/mingw-w64-stxxl-git/PKGBUILD
@@ -1,0 +1,42 @@
+# Maintainer: Alexey Kasatkin <alexeikasatkin@gmail.com>
+
+_realname=stxxl
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
+pkgver=1.4.0.349.g20bfe2b
+pkgrel=1
+pkgdesc="Standard Template Library for Extra Large Data Sets (mingw-w64)"
+arch=('any')
+url="http://stxxl.sourceforge.net/"
+license=('custom:Boost')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-cmake" 'git')
+options=('strip' 'staticlibs')
+source=("${_realname}"::"git+https://github.com/stxxl/stxxl.git")
+md5sums=('SKIP')
+
+pkgver() {
+  cd "$_realname"
+  git describe --tags | sed 's|-|.|g'
+}
+
+build() {
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  ${MINGW_PREFIX}/bin/cmake \
+    -G"MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${pkgdir}${MINGW_PREFIX} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DUSE_GNU_PARALLEL=ON \
+    -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON \
+    ../${_realname}
+  make
+}
+
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make install
+ 
+  mkdir -p "${srcdir}/${pkgdir}${MINGW_PREFIX}/usr/share/licenses/$pkgname"
+  install -Dm644 ../${_realname}/LICENSE_1_0.txt \
+    "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE_1_0.txt"
+}


### PR DESCRIPTION
Here is a package for stxxl library (STL containers and tools for big datasets).
(needed this to compile OSRM on MinGW more conveniently than custom-made batch files, used in OSRM OpenStreetMap routing project for example)

This is my first PKGBUILD and I am not sure it is ready for inclusiion. Could someone have a look?
