### PR TITLE
Add new package: luabind

### DIFF
--- a/mingw-w64-luabind-git/PKGBUILD
+++ b/mingw-w64-luabind-git/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: Alexey Kasatkin <alexeikasatkin@gmail.com>
+
+_realname=luabind
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
+pkgver=0.9.1.142.g2b904b3
+pkgrel=1
+pkgdesc="A library that helps you create bindings between C++ and Lua (mingw-w64)"
+arch=('any')
+url="http://www.rasterbar.com/products/luabind.html"
+license=("MIT")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-cmake" "git")
+depends=("${MINGW_PACKAGE_PREFIX}-boost" "${MINGW_PACKAGE_PREFIX}-lua")
+options=('strip' 'staticlibs')
+source=("${_realname}"::"git+https://github.com/DennisOSRM/luabind.git")
+md5sums=(SKIP)
+
+pkgver() {
+  cd "$_realname"
+  git describe --tags | sed -e 's|-|.|g' -e 's|v||g'
+}
+
+build() {
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  ${MINGW_PREFIX}/bin/cmake \
+    -G"MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${pkgdir}${MINGW_PREFIX} \
+    -DCMAKE_BUILD_TYPE=Release \
+    ../${_realname}
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make install
+}


### PR DESCRIPTION
I tried to make a package for Luabind library (C++ bindings to Lua). It was needed for OSRM project.

I am not an expert in packaging, so this could need a review.

Possible problem: I have used the updated Github repository for Luabind project, not the "official" 2010-freezed version.
