### PR TITLE
Add new package: libosmpbf

### DIFF
--- a/mingw-w64-libosmpbf-git/PKGBUILD
+++ b/mingw-w64-libosmpbf-git/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: Alexey Kasatkin <alexeikasatkin@gmail.com>
+
+_realname=libosmpbf
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
+pkgver=1.3.3.10.g3730430
+pkgrel=1
+pkgdesc="A library to support OpenStreetMap's protocolbuffer binary .pbf format (mingw-w64)"
+arch=('any')
+url="https://github.com/scrosby/OSM-binary"
+license=('LGPL3')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-cmake" "git")
+depends=("${MINGW_PACKAGE_PREFIX}-protobuf")
+options=('staticlibs' 'strip')
+source=("${_realname}::git+https://github.com/scrosby/OSM-binary.git")
+md5sums=('SKIP')
+
+pkgver() {
+  cd "$_realname"
+  git describe --tags | sed -e 's|-|.|g' -e 's|v||g'
+}
+
+build() {
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G"MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${pkgdir}${MINGW_PREFIX} \
+    -DCMAKE_BUILD_TYPE=Release \
+    ../${_realname}
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make install
+}


### PR DESCRIPTION
This small library is needed to compile some OpenStreetMap-related projects like OSRM
(it depends on protobuf compiler). Is it possible to include it or this is too specific library?
