### PR TITLE
new package: geos 3.4.2

### DIFF
--- a/mingw-w64-geos/PKGBUILD
+++ b/mingw-w64-geos/PKGBUILD
@@ -1,0 +1,34 @@
+# Maintainer: Alexey Kasatkin <alexeikasatkin@gmail.com>
+# Maintainer in ArchLinux: Jaroslav Lichtblau <dragonlord@aur.archlinux.org>
+# Contributor: dibblethewrecker dibblethewrecker.at.jiwe.dot.org
+# Contributor: William Rea <sillywilly@gmail.com>
+# Contributor: Alexander Rødseth <rodseth@gmail.com>
+
+_realname=geos
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=3.4.2
+pkgrel=2
+pkgdesc="C++ port of the Java Topology Suite (mingw-w64)"
+arch=('any')
+url="http://trac.osgeo.org/geos/"
+license=('LGPL')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+options=('strip' '!emptydirs')
+source=(http://download.osgeo.org/geos/geos-$pkgver.tar.bz2)
+sha256sums=('15e8bfdf7e29087a957b56ac543ea9a80321481cef4d4f63a7b268953ad26c53')
+
+build() {
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  ../${_realname}-${pkgver}/configure \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --build=${MINGW_CHOST} \
+    --prefix=${MINGW_PREFIX}
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR=${pkgdir} install
+}


### PR DESCRIPTION
This is a package widely used in GIS and other geometry-processing applications.
I have just copied PKGBUILD from archlinux.org and replaced paths with mingw-w64-specific.
(also added `options=('strip' 'staticlibs'` - is this OK?)
