### PR TITLE
new package: freexl 1.0.0g

### DIFF
--- a/mingw-w64-libfreexl/PKGBUILD
+++ b/mingw-w64-libfreexl/PKGBUILD
@@ -1,0 +1,34 @@
+# Maintainer: Alexey Kasatkin <alexeikasatkin@gmail.com>
+# ArchLinux maintainer: Jaroslav Lichtblau <dragonlord@aur.archlinux.org>
+# Contributor: Brian Galey <bkgaley at gmail dot com>
+# Contributor: Bruno Gola <brunogola at gmail dot com>
+
+_realname=libfreexl
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.0.0g
+pkgrel=2
+pkgdesc="Library to extract valid data from within an Excel (.xls) spreadsheet"
+arch=('any')
+url="https://www.gaia-gis.it/fossil/freexl"
+license=('MPL' 'GPL' 'LGPL')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+options=(strip)
+source=("http://www.gaia-gis.it/gaia-sins/freexl-$pkgver.tar.gz")
+sha256sums=('cf2b110f5fc7089fa61c7421f59caa4125b13087b4686ed82dba7abedf2ec266')
+
+build() {
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+
+  ../freexl-${pkgver}/configure \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --build=${MINGW_CHOST} \
+    --prefix=${MINGW_PREFIX}
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR=${pkgdir} install
+}


### PR DESCRIPTION
Another package from ArchLinux: reading xls files.
This is a last missing dependency to libspatialite (that is needed for GDAL)
