### PR TITLE
new package: readosm 1.0.0b

### DIFF
--- a/mingw-w64-readosm/PKGBUILD
+++ b/mingw-w64-readosm/PKGBUILD
@@ -1,0 +1,34 @@
+# Maintainer: Alexey Kasatkin <alexeikasatkin@gmail.com>
+# ArchLinux maintainer: Brian Galey <bkgaley@gmail.com>
+
+_realname=readosm
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.0.0b
+pkgrel=1
+pkgdesc="Library to extract valid data from within an Open Street Map input file (mingw-w64)"
+arch=('any')
+url="https://www.gaia-gis.it/fossil/readosm/index"
+license=('MPL')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+depends=("${MINGW_PACKAGE_PREFIX}-expat" "${MINGW_PACKAGE_PREFIX}-zlib")
+options=('strip' '!libtool')
+source=("http://www.gaia-gis.it/gaia-sins/${_realname}-sources/${_realname}-$pkgver.tar.gz")
+sha256sums=('ed7e0d17fbfc7574b097e2358a143788eba23e0477e7108237f4b0aac3d85710')
+
+build() {
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+
+  ../${_realname}-${pkgver}/configure \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --build=${MINGW_CHOST} \
+    --prefix=${MINGW_PREFIX}
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR=${pkgdir} install
+}
+


### PR DESCRIPTION
This is one more package for spatialite/gdal translated from ArchLinux
( http://www.gaia-gis.it/gaia-sins/mingw64_how_to.html )
Both static and shared libs (hope the other packages will now which one to use)
