### PR TITLE
libass: update to 0.12.0

### DIFF
--- a/mingw-w64-libass/PKGBUILD
+++ b/mingw-w64-libass/PKGBUILD
@@ -3,13 +3,15 @@
 _realname=libass
 
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.11.2
+pkgver=0.12.0
 pkgrel=1
 pkgdesc="A portable library for SSA/ASS subtitles rendering (mingw-w64)"
 arch=('any')
-url="http://code.google.com/p/libass/"
-license=("BSD")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
+url='https://github.com/libass/libass'
+license=('ISC')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-yasm"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=("${MINGW_PACKAGE_PREFIX}-fribidi"
         "${MINGW_PACKAGE_PREFIX}-fontconfig"
         "${MINGW_PACKAGE_PREFIX}-freetype"
@@ -17,7 +19,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-fribidi"
         "${MINGW_PACKAGE_PREFIX}-enca")
 options=('strip' 'staticlibs')
 source=(https://github.com/libass/${_realname}/archive/${pkgver}.tar.gz)
-md5sums=('715cc10e02a193a229046591fac94161')
+md5sums=('80917075df8dda2779e83e092c81ed16')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -35,7 +37,8 @@ build() {
     --enable-shared \
     --enable-harfbuzz \
     --enable-fontconfig \
-    --enable-enca
+    --enable-enca \
+    --enable-asm
   make
 }
 


### PR DESCRIPTION
0.12.0 fixes several bugs, including one that causes a crash. This also updates the homepage, the licence and adds YASM as a dependency for --enable-asm.
