### PR TITLE
tkimg: new package

### DIFF
--- a/mingw-w64-tkimg/001-compile-tif_jbig.patch
+++ b/mingw-w64-tkimg/001-compile-tif_jbig.patch
@@ -1,0 +1,12 @@
+diff -ru tkimg1.4.ori/libtiff/Makefile.in tkimg1.4/libtiff/Makefile.in
+--- tkimg1.4.ori/libtiff/Makefile.in	Thu Nov 21 23:03:10 2013
++++ tkimg1.4/libtiff/Makefile.in	Fri Oct 24 03:30:07 2014
+@@ -247,7 +247,7 @@
+ 
+ $(PKG_LIB_FILE): $(PKG_OBJECTS)
+ 	-rm -f $(PKG_LIB_FILE)
+-	${MAKE_LIB}
++	${MAKE_LIB} -ljbig
+ 	$(RANLIB) $(PKG_LIB_FILE)
+ 
+ $(PKG_STUB_LIB_FILE): $(PKG_STUB_OBJECTS)

--- a/mingw-w64-tkimg/002-dtplite_tcl.patch
+++ b/mingw-w64-tkimg/002-dtplite_tcl.patch
@@ -1,0 +1,12 @@
+diff -ru tkimg1.4.orig/Makefile.in tkimg1.4/Makefile.in
+--- tkimg1.4.ori/Makefile.in	Thu Nov 21 23:03:12 2013
++++ tkimg1.4/Makefile.in	Fri Oct 24 04:16:26 2014
+@@ -118,7 +118,7 @@
+ 	mkdir -p $(MAN_INSTALL_DIR)/mann
+ 	for i in $(srcdir)/doc/*.man ; \
+ 	do	\
+-		dtplite -ext n -o $(MAN_INSTALL_DIR)/mann nroff $$i ; \
++		dtplite.tcl -ext n -o $(MAN_INSTALL_DIR)/mann nroff $$i ; \
+ 	done
+ 
+ collate: all

--- a/mingw-w64-tkimg/PKGBUILD
+++ b/mingw-w64-tkimg/PKGBUILD
@@ -1,0 +1,47 @@
+# Based on the Arch package
+
+_pkgname=tkimg
+pkgname=${MINGW_PACKAGE_PREFIX}-$_pkgname
+_pkgver=1.4
+pkgver=${_pkgver}.2
+pkgrel=1
+pkgdesc="Adds support to Tk for many other Image formats: BMP, XBM, XPM, GIF, PNG, JPEG, TIFF and postscript."
+url="http://tkimg.sourceforge.net"
+arch=('any')
+license=('BSD')
+depends=("${MINGW_PACKAGE_PREFIX}-zlib" "${MINGW_PACKAGE_PREFIX}-libjpeg"
+	 "${MINGW_PACKAGE_PREFIX}-libpng" "${MINGW_PACKAGE_PREFIX}-libtiff"
+	 "${MINGW_PACKAGE_PREFIX}-tk")
+# Uses dtplite for generating the man pages:
+makedepends=("${MINGW_PACKAGE_PREFIX}-tcllib")
+source=("http://downloads.sourceforge.net/tkimg/$_pkgname$pkgver.tar.gz"
+	001-compile-tif_jbig.patch
+	002-dtplite_tcl.patch)
+md5sums=('c42b46692a55c402c97e8f2a896bc2d4'
+	 '9582ee32e4e7c9c0002dcc8127c5f7fd'
+	 'c8aa6d8c1b182826d794a214fea18e6e')
+
+prepare() {
+  cd "${srcdir}/${_pkgname}${_pkgver}"
+  patch -Np1 -i "${srcdir}/001-compile-tif_jbig.patch"
+  patch -Np1 -i "${srcdir}/002-dtplite_tcl.patch"
+}
+
+build() {
+  if check_option "debug" "y"; then
+    extra_config+=( --enable-symbols )
+  fi
+
+  mkdir -p "${srcdir}/build-${CARCH}"
+  cd "${srcdir}/build-${CARCH}"
+
+  ../${_pkgname}${_pkgver}/configure --prefix=${MINGW_PREFIX} \
+     "${extra_config[@]}"
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${CARCH}"
+  make INSTALL_ROOT="$pkgdir" install
+  rm -f ${pkgdir}/${MINGW_PREFIX}/lib/*.sh
+}


### PR DESCRIPTION
The i686 build comes from upstream with the -static-libgcc workaround.
