### PR TITLE
GTK+3 : upgrade to gtk-3.14.4.

### DIFF
--- a/mingw-w64-gtk3/0055-skip-testsuite.all.patch
+++ b/mingw-w64-gtk3/0055-skip-testsuite.all.patch
@@ -1,16 +1,16 @@
---- Makefile.am.orig	2014-10-24 20:50:20.326352400 +0200
-+++ Makefile.am	2014-10-24 20:50:40.434722400 +0200
+--- Makefile.am.orig	2014-10-24 21:22:13.559889300 +0200
++++ Makefile.am	2014-10-24 21:22:37.105175200 +0200
 @@ -1,7 +1,7 @@
  ## Makefile.am for GTK+
  include $(top_srcdir)/Makefile.decl
  
 -SRC_SUBDIRS = util gdk gtk libgail-util modules demos tests testsuite examples
-+SRC_SUBDIRS = util gdk gtk libgail-util modules demos
++SRC_SUBDIRS = util gdk gtk libgail-util modules
  SUBDIRS = po po-properties $(SRC_SUBDIRS) docs m4macros build
  
  ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
---- Makefile.in.orig	2014-10-24 20:50:53.418442700 +0200
-+++ Makefile.in	2014-10-24 20:51:08.948890500 +0200
+--- Makefile.in.orig	2014-10-24 21:22:20.402924300 +0200
++++ Makefile.in	2014-10-24 21:22:52.339700600 +0200
 @@ -540,7 +540,7 @@ XVFB_START = \
  	|| { echo "Gtk+Tests:ERROR: Failed to start Xvfb environment for X11 target tests."; exit 1; } \
  	&& DISPLAY=:$$XID && export DISPLAY

--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=gtk3
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.14.0
+pkgver=3.14.4
 pkgrel=1
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
@@ -31,13 +31,15 @@ source=("http://ftp.gnome.org/pub/gnome/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}
         0035-enable-rgba-w32-windows.all.patch
         0037-W32-better-dwm-loading-and-support-dwm-detection.all.patch
         0054-no-transparency-for-children.all.patch
+        0055-skip-testsuite.all.patch
         Make-reftest-plugins-W32-compatible.patch)
-md5sums=('2e4e64a29e0373f36fbc98e1531da2db'
+md5sums=('103a3521cf792f2ee12d0d1349d79288'
          '9e0296da2986be7697cf343563b85d1f'
          '21789d52c1debcab59f8b6a99232de68'
          '397bf8001d3da75e06b5794e378ae25f'
          'ad383a497a9134355e0a549f844c3a33'
          '31d098e6856ddc8dde7259ae572f8bf1'
+         'b52eab2ba0da33ae55050b0a68cc996f'
          '864d4b2cd6f72115cc78a393ccd96b47')
 
 prepare() {
@@ -47,6 +49,7 @@ prepare() {
   patch -Np1 -i "${srcdir}"/0035-enable-rgba-w32-windows.all.patch
   patch -Np1 -i "${srcdir}"/0037-W32-better-dwm-loading-and-support-dwm-detection.all.patch
   patch -Np1 -i "${srcdir}"/0054-no-transparency-for-children.all.patch
+  patch -N < "${srcdir}"/0055-skip-testsuite.all.patch
   #patch -Np1 -i "${srcdir}"/Make-reftest-plugins-W32-compatible.patch
 
   autoreconf -i


### PR DESCRIPTION
Update to 3.14.4 and remove "demos tests testsuite examples" during compilation to speed up time and because testsuite don't like Windows.
