### PR TITLE
opencv: Build ffmpeg plugin, fix memory leak in viz module

### DIFF
--- a/mingw-w64-opencv/PKGBUILD
+++ b/mingw-w64-opencv/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=opencv
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.4.10
-pkgrel=1
+pkgrel=2
 pkgdesc="Open Source Computer Vision Library (mingw-w64)"
 arch=('any')
 url="http://opencv.org/"
@@ -12,7 +12,6 @@ depends=(#"${MINGW_PACKAGE_PREFIX}-gst-plugins-base0.10"
         "${MINGW_PACKAGE_PREFIX}-libpng"
         "${MINGW_PACKAGE_PREFIX}-libtiff"
         "${MINGW_PACKAGE_PREFIX}-jasper"
-        "${MINGW_PACKAGE_PREFIX}-ffmpeg"
         "${MINGW_PACKAGE_PREFIX}-openexr"
         "${MINGW_PACKAGE_PREFIX}-intel-tbb"
         "${MINGW_PACKAGE_PREFIX}-zlib"
@@ -23,21 +22,25 @@ depends=(#"${MINGW_PACKAGE_PREFIX}-gst-plugins-base0.10"
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
             #"${MINGW_PACKAGE_PREFIX}-qt5"
             "${MINGW_PACKAGE_PREFIX}-eigen3"
+            "${MINGW_PACKAGE_PREFIX}-ffmpeg"
             "${MINGW_PACKAGE_PREFIX}-python2-numpy"
             "${MINGW_PACKAGE_PREFIX}-vtk"
             )
 optdepends=("${MINGW_PACKAGE_PREFIX}-eigen3"
+            "${MINGW_PACKAGE_PREFIX}-ffmpeg: support to read and write video files"
             "${MINGW_PACKAGE_PREFIX}-python2-numpy: Python 2.x interface"
             "${MINGW_PACKAGE_PREFIX}-vtk: opencv_viz module")
 source=(#"http://downloads.sourceforge.net/opencvlibrary/${_realname}-$pkgver.zip"
         https://github.com/Itseez/opencv/archive/$pkgver.tar.gz
         'mingw-w64-cmake.patch'
         'free-tls-keys-on-dll-unload.patch'
-        'solve_deg3-underflow.patch')
+        'solve_deg3-underflow.patch'
+        'upstream-40efd17.patch')
 md5sums=('3346a59310d788d3845f4fd6043a108a'
-         '3b4bc1c4b03c5c8eb1a69aaf7a37a12c'
+         '94672506dd30d8113904cd0514047da7'
          '91fcecdc23a870cafad6f51c2a45e647'
-         'ae03a59cf1202d5eafa94c2aac419ae6')
+         'ae03a59cf1202d5eafa94c2aac419ae6'
+         '4099f3949fc7215d34e5ef09d6bbe36c')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -45,6 +48,7 @@ prepare() {
   patch -Np1 -i "$srcdir/mingw-w64-cmake.patch"
   patch -Np1 -i "$srcdir/free-tls-keys-on-dll-unload.patch"
   patch -Np1 -i "$srcdir/solve_deg3-underflow.patch"
+  patch -Np1 -i "$srcdir/upstream-40efd17.patch"
 }
 
 build() {
@@ -54,14 +58,25 @@ build() {
       '-DENABLE_SSE2=OFF'
       '-DENABLE_SSE3=OFF')
     CXXFLAGS+=" -DEIGEN_DONT_VECTORIZE"
+    _ffmpeg_plugin='opencv_ffmpeg.dll'
   }
 
   # all x64 CPUs support SSE2 but not SSE3
-  [[ "$CARCH" = 'x86_64' ]] && _cmakeopts+=('-DENABLE_SSE3=OFF')
+  [[ "$CARCH" = 'x86_64' ]] && {
+    _cmakeopts+=('-DENABLE_SSE3=OFF')
+    _ffmpeg_plugin='opencv_ffmpeg_64.dll'
+  }
+
+  pushd ${srcdir}/${_realname}-${pkgver}/3rdparty/ffmpeg > /dev/null
+  rm -f ./*.dll
+  gcc -Wall -shared -o ${_ffmpeg_plugin} ${CXXFLAGS} -x c++ \
+    -I../include -I../../modules/highgui/src ffopencv.c \
+    -lavformat -lavcodec -lavdevice -lswscale -lavutil -lws2_32
+  popd > /dev/null
 
   [[ -d ${srcdir}/build-${CARCH} ]] && rm -rf ${srcdir}/build-${CARCH}
   mkdir -p ${srcdir}/build-${CARCH} && cd ${srcdir}/build-${CARCH}
-  ${MINGW_PREFIX}/bin/cmake.exe \
+  ${MINGW_PREFIX}/bin/cmake.exe -Wno-dev \
     -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${pkgdir}${MINGW_PREFIX} \
     -DWITH_OPENCL=ON \
@@ -78,6 +93,7 @@ build() {
     -DWITH_GTK=OFF \
     -DWITH_QT=OFF \
     -DWITH_VTK=ON \
+    -DWITH_FFMPEG=ON \
     -DWITH_GSTREAMER=OFF \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_SKIP_RPATH=ON \

--- a/mingw-w64-opencv/mingw-w64-cmake.patch
+++ b/mingw-w64-opencv/mingw-w64-cmake.patch
@@ -10,18 +10,6 @@ diff -Naur a/cmake/OpenCVDetectPython.cmake b/cmake/OpenCVDetectPython.cmake
        execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import *; print get_python_lib()"
                        RESULT_VARIABLE PYTHON_CVPY_PROCESS
                        OUTPUT_VARIABLE PYTHON_STD_PACKAGES_PATH
-diff -Naur a/cmake/OpenCVFindLibsVideo.cmake b/cmake/OpenCVFindLibsVideo.cmake
---- a/cmake/OpenCVFindLibsVideo.cmake	2014-10-01 14:33:36.000000000 +0700
-+++ b/cmake/OpenCVFindLibsVideo.cmake	2014-10-02 23:18:25.505210700 +0700
-@@ -184,7 +184,7 @@
- # --- FFMPEG ---
- ocv_clear_vars(HAVE_FFMPEG HAVE_FFMPEG_CODEC HAVE_FFMPEG_FORMAT HAVE_FFMPEG_UTIL HAVE_FFMPEG_SWSCALE HAVE_GENTOO_FFMPEG HAVE_FFMPEG_FFMPEG)
- if(WITH_FFMPEG)
--  if(WIN32 AND NOT ARM)
-+  if(WIN32 AND NOT ARM AND NOT MINGW)
-     include("${OpenCV_SOURCE_DIR}/3rdparty/ffmpeg/ffmpeg_version.cmake")
-   elseif(UNIX)
-     CHECK_MODULE(libavcodec HAVE_FFMPEG_CODEC)
 diff -Naur a/cmake/OpenCVFindOpenEXR.cmake b/cmake/OpenCVFindOpenEXR.cmake
 --- a/cmake/OpenCVFindOpenEXR.cmake	2014-10-01 14:33:36.000000000 +0700
 +++ b/cmake/OpenCVFindOpenEXR.cmake	2014-10-02 23:18:25.505210700 +0700
@@ -204,15 +192,15 @@ diff -Naur a/CMakeLists.txt b/CMakeLists.txt
    install(FILES ${OPENCV_LICENSE_FILE}
          PERMISSIONS OWNER_READ GROUP_READ WORLD_READ
          DESTINATION ${CMAKE_INSTALL_PREFIX} COMPONENT libs)
-diff -Naur a/modules/highgui/CMakeLists.txt b/modules/highgui/CMakeLists.txt
---- a/modules/highgui/CMakeLists.txt	2014-10-01 14:33:36.000000000 +0700
-+++ b/modules/highgui/CMakeLists.txt	2014-10-02 23:18:25.505210700 +0700
-@@ -296,7 +296,7 @@
- 
- if(WIN32 AND WITH_FFMPEG)
-   #copy ffmpeg dll to the output folder
--  if(MSVC64 OR MINGW64)
-+  if(MSVC64)
-     set(FFMPEG_SUFFIX _64)
-   endif()
- 
+diff -Naur opencv.a/cmake/OpenCVDetectCXXCompiler.cmake opencv.b/cmake/OpenCVDetectCXXCompiler.cmake
+--- opencv.a/cmake/OpenCVDetectCXXCompiler.cmake	2014-10-01 14:33:36.000000000 +0700
++++ opencv.b/cmake/OpenCVDetectCXXCompiler.cmake	2014-10-28 03:46:24.726004000 +0600
+@@ -145,7 +145,7 @@
+   execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpmachine
+                   OUTPUT_VARIABLE OPENCV_GCC_TARGET_MACHINE
+                   OUTPUT_STRIP_TRAILING_WHITESPACE)
+-  if(CMAKE_OPENCV_GCC_TARGET_MACHINE MATCHES "64")
++  if(CMAKE_OPENCV_GCC_TARGET_MACHINE MATCHES "amd64|x86_64|AMD64")
+     set(MINGW64 1)
+     set(OpenCV_ARCH x64)
+   else()

--- a/mingw-w64-opencv/upstream-40efd17.patch
+++ b/mingw-w64-opencv/upstream-40efd17.patch
@@ -1,0 +1,25 @@
+From 0f2b7fbc451a34c9eba34616e726985b7a0d14b1 Mon Sep 17 00:00:00 2001
+From: Anatoly Baksheev <no@email>
+Date: Sat, 18 Oct 2014 18:12:36 +0400
+Subject: [PATCH] viz: fixed memory leak, issue 3961
+
+---
+ modules/viz/src/vtk/vtkImageMatSource.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/modules/viz/src/vtk/vtkImageMatSource.cpp b/modules/viz/src/vtk/vtkImageMatSource.cpp
+index 58a5642..6586175 100644
+--- a/modules/viz/src/vtk/vtkImageMatSource.cpp
++++ b/modules/viz/src/vtk/vtkImageMatSource.cpp
+@@ -52,7 +52,7 @@ namespace cv { namespace viz
+ cv::viz::vtkImageMatSource::vtkImageMatSource()
+ {
+     this->SetNumberOfInputPorts(0);
+-    this->ImageData = vtkImageData::New();
++    this->ImageData = vtkSmartPointer<vtkImageData>::New();
+ }
+ 
+ int cv::viz::vtkImageMatSource::RequestInformation(vtkInformation *, vtkInformationVector**, vtkInformationVector *outputVector)
+-- 
+1.8.3.msysgit.0
+


### PR DESCRIPTION
PR to fix some problems with opencv ffmpeg plugin:
- the prebuilt plugin binaries that ship with source distribution are used;
- mingw32 package installs x64 ffmpeg plugin binary;
- x64 ffmpeg plugin doesn't load due to wrong dll suffix.

Added small patch from upstream to fix huge memory leak.
