### PR TITLE
Fix kicad PKGBUILD.

### DIFF
--- a/mingw-w64-kicad-git/003-unix-files-layout.patch
+++ b/mingw-w64-kicad-git/003-unix-files-layout.patch
@@ -1,15 +1,17 @@
---- kicad/CMakeLists.txt.orig	2014-10-02 09:27:42.914800000 +0400
-+++ kicad/CMakeLists.txt	2014-10-02 09:31:37.975600000 +0400
-@@ -312,7 +312,7 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3dda778..953bfec 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -309,7 +309,7 @@ set( KICAD_BIN bin
  set( KICAD_FP_LIB_INSTALL_PATH "${CMAKE_INSTALL_PREFIX}"
       CACHE PATH "Default path where footprint libraries are installed." )
  
--if( UNIX )
-+if( UNIX OR MINGW )
+-if( UNIX AND NOT APPLE )
++if( NOT APPLE )
      # Everything without leading / is relative to CMAKE_INSTALL_PREFIX.
      set( KICAD_PLUGINS lib/kicad/plugins
          CACHE PATH "Location of KiCad plugins." )
-@@ -323,17 +323,6 @@
+@@ -320,17 +320,6 @@ if( UNIX AND NOT APPLE )
      set( KICAD_FP_LIB_INSTALL_PATH "${KICAD_FP_LIB_INSTALL_PATH}/share/kicad/modules" )
  endif()
  

--- a/mingw-w64-kicad-git/PKGBUILD
+++ b/mingw-w64-kicad-git/PKGBUILD
@@ -2,34 +2,32 @@
 
 _realname=kicad
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
-pkgver=r6681.7c747c1
+pkgver=r6787.f86eb75
 pkgrel=1
 pkgdesc="Software for the creation of electronic schematic diagrams and printed circuit board artworkrs (mingw-w64)"
 arch=('any')
-url="https://github.com/imageworks/OpenShadingLanguage/"
+url="http://www.kicad-pcb.org"
 license=("custom")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 depends=("${MINGW_PACKAGE_PREFIX}-boost"
-        "${MINGW_PACKAGE_PREFIX}-cairo" 
+        "${MINGW_PACKAGE_PREFIX}-cairo"
         "${MINGW_PACKAGE_PREFIX}-glew"
         "${MINGW_PACKAGE_PREFIX}-openssl"
-        "${MINGW_PACKAGE_PREFIX}-swig"
         "${MINGW_PACKAGE_PREFIX}-wxPython"
         "${MINGW_PACKAGE_PREFIX}-wxWidgets")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-swig"
              "doxygen")
 source=("${_realname}"::"git+https://github.com/KiCad/kicad-source-mirror.git"
-        001-use-system-openssl.patch
-        002-fix-python-module-install.patch
-        003-unix-files-layout.patch)
+        003-unix-files-layout.patch
+       )
 md5sums=('SKIP'
-         '679b2e817d70182b631b631d54e1fef9'
-         '7e84409ccbafcc1137471655132f945e'
-         '17becd7e91e77fde1cb73999c8f8b151')
+         'c5a8fc60a66225755bfcfd92d56cd5a2'
+        )
 
 pkgver() {
   cd "$srcdir/$_realname"
@@ -38,31 +36,27 @@ pkgver() {
 
 prepare() {
   cd ${srcdir}/$_realname
-  patch -p1 -i ${srcdir}/001-use-system-openssl.patch
-  patch -p1 -i ${srcdir}/002-fix-python-module-install.patch
+
   patch -p1 -i ${srcdir}/003-unix-files-layout.patch
-  
-  # Use modules from cmake
-  rm -f CMakeModules/FindwxWidgets.cmake
-  rm -f CMakeModules/FindPythonLibs.cmake
 }
 
 build() {
   [[ -d build-${MINGW_CHOST} ]] && rm -r build-${MINGW_CHOST}
   mkdir build-${MINGW_CHOST} && cd build-${MINGW_CHOST}
-  export OPENSSL_ROOT_DIR=${MINGW_PREFIX}
-  export PYTHON_ROOT_DIR=${MINGW_PREFIX}
   ${MINGW_PREFIX}/bin/cmake.exe \
     -G"MSYS Makefiles" \
+    -DCMAKE_PREFIX_PATH=${MINGW_PREFIX} \
     -DCMAKE_INSTALL_PREFIX=${pkgdir}${MINGW_PREFIX} \
+    -DOPENSSL_ROOT_DIR=${MINGW_PREFIX} \
     -DKICAD_SKIP_BOOST=ON \
     -DKICAD_SCRIPTING=ON \
     -DKICAD_SCRIPTING_MODULES=ON \
     -DKICAD_SCRIPTING_WXPYTHON=ON \
     -DPYTHON_EXECUTABLE=${MINGW_PREFIX}/bin/python2.exe \
+    -DCMAKE_INSTALL_PREFIX=${pkgdir}/${MINGW_PREFIX} \
     ../$_realname
     #-DVERBOSE=1
-    
+
   make
 }
 


### PR DESCRIPTION
I fixed the KiCad PKGBUILD and modified the file layout patch.  Both mingw32 and mingw64 packages build correctly.  I think I even got the GitHub pull request done right.  Let me know if there is anything else I need to do.  I still have to package the help files and the library files.  I may package them separately to keep the size of the pack file reasonably sane.

Best Regards,

Wayne
