### PR TITLE
Fix compile of gnupg on windows

### DIFF
--- a/mingw-w64-gnupg/PKGBUILD
+++ b/mingw-w64-gnupg/PKGBUILD
@@ -1,5 +1,8 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
+# uncomment patch fix_seat_check_on_windows.patch to compile on windows
+# requires unix2dos (installed using pacman -S dos2unix)
+
 _realname=gnupg
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.4.18
@@ -19,14 +22,17 @@ makedepends=("texinfo" "${MINGW_PACKAGE_PREFIX}-gcc")
 license=('GPL')
 url="http://www.gnupg.org/"
 source=(ftp://ftp.gnupg.org/gcrypt/gnupg/gnupg-$pkgver.tar.bz2{,.sig}
-        gnupg-1.4.15-libiconv-dll.patch)
+        gnupg-1.4.15-libiconv-dll.patch
+        fix_seat_check_on_windows.patch)
 sha1sums=('41462d1a97f91abc16a0031b5deadc3095ce88ae'
           'SKIP'
-          '2ea46a1c24a30016e21b9f16e324798ec2b54d98')
+          '2ea46a1c24a30016e21b9f16e324798ec2b54d98'
+          'a8eb0dec2ca2d23d9fcb4efba9b09ef6724cf053')
 
 prepare() {
   cd "${srcdir}"/gnupg-${pkgver}
   patch -p1 -i ${srcdir}/gnupg-1.4.15-libiconv-dll.patch
+#  patch -p1 -i ../fix_seat_check_on_windows.patch
   
   #./autogen.sh
   # libtoolize --copy --force

--- a/mingw-w64-gnupg/fix_seat_check_on_windows.patch
+++ b/mingw-w64-gnupg/fix_seat_check_on_windows.patch
@@ -1,0 +1,14 @@
+diff --git a/checks/seat.test.orig b/checks/seat.test
+index 72ab27f..6dbb542 100755
+--- a/checks/seat.test.orig
++++ b/checks/seat.test
+@@ -6,6 +6,8 @@ for i in $plain_files ; do
+     echo "$usrpass1" | $GPG --passphrase-fd 0 --always-trust -seat \
+                         -r two -o x --yes $i
+     $GPG -o y --yes x
+-    cmp $i y || error "$i: mismatch"
++    cp $i z
++    unix2dos z
++    cmp z y || error "$i: mismatch"
+ done
+ 


### PR DESCRIPTION
To compile gnupg on windows one of the checks needs to be altered. This patch alters seat.test to use dos line endings.
