### PR TITLE
Add docs to KiCad package.

### DIFF
--- a/mingw-w64-kicad-git/PKGBUILD
+++ b/mingw-w64-kicad-git/PKGBUILD
@@ -2,12 +2,12 @@
 
 _realname=kicad
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
-pkgver=r6787.f86eb75
+pkgver=r6803.0561940
 pkgrel=1
-pkgdesc="Software for the creation of electronic schematic diagrams and printed circuit board artworkrs (mingw-w64)"
+pkgdesc="Software for the creation of electronic schematic diagrams and printed circuit board artwork"
 arch=('any')
 url="http://www.kicad-pcb.org"
-license=("custom")
+license=("GPL2+")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 depends=("${MINGW_PACKAGE_PREFIX}-boost"
@@ -23,10 +23,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-swig"
              "doxygen")
 source=("${_realname}"::"git+https://github.com/KiCad/kicad-source-mirror.git"
-        003-unix-files-layout.patch
+        "${_realname}-docs"::"bzr+https://code.launchpad.net/~kicad-developers/kicad/doc"
        )
 md5sums=('SKIP'
-         'c5a8fc60a66225755bfcfd92d56cd5a2'
+         'SKIP'
         )
 
 pkgver() {
@@ -34,13 +34,8 @@ pkgver() {
   printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
 }
 
-prepare() {
-  cd ${srcdir}/$_realname
-
-  patch -p1 -i ${srcdir}/003-unix-files-layout.patch
-}
-
 build() {
+  # Configure and build KiCad.
   [[ -d build-${MINGW_CHOST} ]] && rm -r build-${MINGW_CHOST}
   mkdir build-${MINGW_CHOST} && cd build-${MINGW_CHOST}
   ${MINGW_PREFIX}/bin/cmake.exe \
@@ -53,15 +48,30 @@ build() {
     -DKICAD_SCRIPTING_MODULES=ON \
     -DKICAD_SCRIPTING_WXPYTHON=ON \
     -DPYTHON_EXECUTABLE=${MINGW_PREFIX}/bin/python2.exe \
-    -DCMAKE_INSTALL_PREFIX=${pkgdir}/${MINGW_PREFIX} \
     ../$_realname
     #-DVERBOSE=1
 
   make
+
+  cd ../
+
+  # Configure the documentation installation build.
+  [[ -d build-${MINGW_CHOST}-docs ]] && rm -r build-${MINGW_CHOST}-docs
+  mkdir build-${MINGW_CHOST}-docs && cd build-${MINGW_CHOST}-docs
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G "MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${pkgdir}${MINGW_PREFIX} \
+    ../${_realname}-docs
 }
 
 package() {
+  # Install KiCad.
   cd build-${MINGW_CHOST}
+  make install
 
+  cd ../
+
+  # Install KiCad documentation.
+  cd build-${MINGW_CHOST}-docs
   make install
 }


### PR DESCRIPTION
This pull request add the documentation package, removes the mingw install path patch which was fixed in the project source, and remove a redundant install prefix from the CMake configuration.  All that is left is to add the component and 3D model libraries to the package and that will make KiCad a complete install.
