### PR TITLE
Add clang patch to fix fabs lowering

### DIFF
--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -26,6 +26,7 @@ source=(http://llvm.org/releases/$pkgver/llvm-$pkgver.src.tar.xz{,.sig}
         #http://llvm.org/releases/$pkgver/libcxx-$pkgver.src.tar.xz{,.sig}
         http://llvm.org/releases/$pkgver/clang-tools-extra-$pkgver.src.tar.xz{,.sig}
         #http://llvm.org/releases/$pkgver/lldb-$pkgver.src.tar.xz{,.sig}
+        clang-fabs.patch
         clang-win64-seh.patch
         clang-mingw-driver.patch
         llvm-3.5.0-force-link-pass.o.patch
@@ -41,6 +42,7 @@ sha256sums=('28e199f368ef0a4666708f31c7991ad3bcc3a578342b0306526dd35f07595c03'
             'SKIP'
             '2981beb378afb5aa5c50ed017720a42a33e77e902c7086ad2d412ef4fa931f69'
             'SKIP'
+            'DA18E02154892362B09957D8FCE8231ACA303A7366B078C61F1566C840D8BF14'
             '6e1168e5c9cba875ef7e87ccfd3060c3a0db6b5e2c3f1fa9fdb4d0eaea465025'
             '2f49bba3acb0e45b0c3374537f2f9036891013c751930437c80472d8d8d8e2a7'
             '5702053503d49448598eda1b8dc8c263f0df9ad7486833273e3987b5dec25a19'
@@ -63,6 +65,7 @@ prepare() {
   patch -p0 -i "$srcdir/llvm-3.5.0-fix-cmake-llvm-exports.patch"
 
   cd "$srcdir/cfe-$pkgver.src"
+  patch -p1 -i ${srcdir}/clang-fabs.patch
   patch -p1 -i ${srcdir}/clang-win64-seh.patch
   patch -p1 -i ${srcdir}/clang-mingw-driver.patch
   patch -p1 -i ${srcdir}/clang-3.6-allow-dll-attributes0.patch

--- a/mingw-w64-clang/clang-fabs.patch
+++ b/mingw-w64-clang/clang-fabs.patch
@@ -1,0 +1,32 @@
+Original author: Reid Kleckner <rnk@google.com>
+Backported to clang 3.5 by: Antal Szabó <szabo.antal.92@gmail.com>
+
+This patch fixes the lowering of __builtin_fabs, __builtin_fabsf and __builtin_fabsl. Based on clang r221206.
+
+Original log message:
+
+Lower __builtin_fabs* to @llvm.fabs.*
+
+mingw64's headers implement fabs by calling __builtin_fabs, so using the
+library call results in an infinite loop. If the backend legalizes
+@llvm.fabs as a call to fabs later, things should work out, as the crt
+provides a definition.
+
+diff --git a/lib/CodeGen/CGBuiltin.cpp b/lib/CodeGen/CGBuiltin.cpp
+index 4f68b34..230a770 100644
+--- a/lib/CodeGen/CGBuiltin.cpp
++++ b/lib/CodeGen/CGBuiltin.cpp
+@@ -255,6 +255,13 @@ RValue CodeGenFunction::EmitBuiltinExpr(const FunctionDecl *FD,
+ 
+     return RValue::get(Result);
+   }
++  case Builtin::BI__builtin_fabs:
++  case Builtin::BI__builtin_fabsf:
++  case Builtin::BI__builtin_fabsl: {
++    Value *Arg1 = EmitScalarExpr(E->getArg(0));
++    Value *Result = EmitFAbs(*this, Arg1, E->getArg(0)->getType());
++    return RValue::get(Result);
++  }
+ 
+   case Builtin::BI__builtin_conj:
+   case Builtin::BI__builtin_conjf:


### PR DESCRIPTION
This should fix https://github.com/Alexpux/MINGW-packages/issues/328. I didn't actually test it though, as I don't have everything set up to compile clang, can someone please give feedback on this?
