### PR TITLE
gdal package: xerces-c package is needed

### DIFF
--- a/mingw-w64-gdal/PKGBUILD
+++ b/mingw-w64-gdal/PKGBUILD
@@ -19,7 +19,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-geos" "${MINGW_PACKAGE_PREFIX}-curl" "${MINGW_
          "${MINGW_PACKAGE_PREFIX}-cfitsio" "${MINGW_PACKAGE_PREFIX}-xz" "${MINGW_PACKAGE_PREFIX}-jasper"
          "${MINGW_PACKAGE_PREFIX}-libxml2" "${MINGW_PACKAGE_PREFIX}-proj" "${MINGW_PACKAGE_PREFIX}-sqlite3"
          "${MINGW_PACKAGE_PREFIX}-libspatialite" "${MINGW_PACKAGE_PREFIX}-hdf5" "${MINGW_PACKAGE_PREFIX}-poppler"
-         "${MINGW_PACKAGE_PREFIX}-postgresql" "${MINGW_PACKAGE_PREFIX}-libmariadbclient")
+         "${MINGW_PACKAGE_PREFIX}-postgresql" "${MINGW_PACKAGE_PREFIX}-xerces-c")
 options=(strip)
 
 source=(http://download.osgeo.org/${_realname}/${pkgver}/${_realname}-${pkgver}.tar.gz)


### PR DESCRIPTION
Current binary version of package foundxerces-c library when building, so it refuses to work without that package installed. It is better to explicitly add the dependency. (DLL **errors** when xerces not installed)

Mysql client is not currently detected by gdal, so libmariadbclient is not needed for now.
