### PR TITLE
emacs: Fix for the `emacs-24` branch

### DIFF
--- a/mingw-w64-emacs-git/PKGBUILD
+++ b/mingw-w64-emacs-git/PKGBUILD
@@ -2,7 +2,7 @@
 
 _name='emacs'
 pkgname="${MINGW_PACKAGE_PREFIX}-${_name}-git"
-pkgver=r133086.ba9fc93
+pkgver=r133128.051bf7a
 pkgrel=1
 pkgdesc=\
 "The extensible, customizable, self-documenting, real-time display editor."
@@ -71,10 +71,12 @@ build() {
     with_wide_int='yes'
   fi
 
+  # NOTE:
+  # Do not add `-funroll-loops' to `CFLAGS'!
   PKG_CONFIG_PATH="${MINGW_PREFIX}/lib/pkgconfig"                              \
   "${srcdir}/${_name}/configure"                                               \
     CPPFLAGS="-DNDEBUG -isystem ${MINGW_PREFIX}/include"                       \
-      CFLAGS="-pipe -O3 -fomit-frame-pointer -funroll-loops"                   \
+      CFLAGS="-pipe -O3 -fomit-frame-pointer"                                  \
      LDFLAGS="-s -Wl,-s"                                                       \
     --prefix="${MINGW_PREFIX}"                                                 \
     --build="${MINGW_CHOST}"                                                   \

--- a/mingw-w64-emacs/Makefile.in.diff
+++ b/mingw-w64-emacs/Makefile.in.diff
@@ -1,0 +1,11 @@
+--- admin/unidata/Makefile.in.orig	2014-11-08 01:37:29.445161700 +0100
++++ admin/unidata/Makefile.in	2014-11-08 01:33:48.642212600 +0100
+@@ -33,7 +33,7 @@
+ 
+ .PHONY: all compile install
+ 
+-all: ${top_srcdir}/src/macuvs.h ${DSTDIR}/charprop.el
++all: ${DSTDIR}/charprop.el
+ 
+ ${top_srcdir}/src/macuvs.h: ${srcdir}/uvs.el ${srcdir}/IVD_Sequences.txt
+ 	${EMACS} -batch -l "${srcdir}/uvs.el" \

--- a/mingw-w64-emacs/PKGBUILD
+++ b/mingw-w64-emacs/PKGBUILD
@@ -42,11 +42,13 @@ source=(
   "${_name}"::"git://git.savannah.gnu.org/${_name}.git#tag=${_name}-${pkgver}"
   'image.c.diff'
   'lread.c.diff'
+  'Makefile.in.diff'
 )
 sha256sums=(
   'SKIP'
   '4571d45ec26fd556e73a70bb0ab0a2a8fa1efc5e3b3c5b472ab68bb7dc9bf52c'
   'b9db1b7d939301d0fedf52db6ac055f7265ee5bc0c3c757e394700ca39577b7f'
+  '1a49a2d4711d0204db80a88c120510168b2eb7649888de65634da252f03b7f16'
 )
 
 pkgver() {
@@ -60,6 +62,7 @@ prepare() {
   cd "${_name}"
   patch --binary --forward -p0 < "${srcdir}/image.c.diff"
   patch --binary --forward -p0 < "${srcdir}/lread.c.diff"
+  patch --binary --forward -p0 < "${srcdir}/Makefile.in.diff"
   ./autogen.sh
 }
 
@@ -73,10 +76,12 @@ build() {
     with_wide_int='yes'
   fi
 
+  # NOTE:
+  # Do not add `-funroll-loops' to `CFLAGS'!
   PKG_CONFIG_PATH="${MINGW_PREFIX}/lib/pkgconfig"                              \
   "${srcdir}/${_name}/configure"                                               \
     CPPFLAGS="-DNDEBUG -isystem ${MINGW_PREFIX}/include"                       \
-      CFLAGS="-pipe -O3 -fomit-frame-pointer -funroll-loops"                   \
+      CFLAGS="-pipe -O3 -fomit-frame-pointer"                                  \
      LDFLAGS="-s -Wl,-s"                                                       \
     --prefix="${MINGW_PREFIX}"                                                 \
     --build="${MINGW_CHOST}"                                                   \


### PR DESCRIPTION
`mingw-w64-emacs` is now ready for production builds. Please, note that `mingw-w64-emacs-git` can sometimes fail to build (like today, for example) due to the development process.
