### PR TITLE
boost: support 'debug' option

### DIFF
--- a/mingw-w64-boost/PKGBUILD
+++ b/mingw-w64-boost/PKGBUILD
@@ -72,9 +72,15 @@ build() {
     ;;
   esac
 
+  if check_option "debug" "y"; then
+      local variant=debug
+  else
+      local variant=release
+  fi
+
   ./b2 \
     toolset=gcc \
-    variant=release \
+    variant=$variant \
     threading=multi \
     threadapi=win32 \
     link=shared,static \
@@ -112,9 +118,15 @@ package() {
     ;;
   esac
 
+  if check_option "debug" "y"; then
+      local variant=debug
+  else
+      local variant=release
+  fi
+
   ./b2 \
       toolset=gcc \
-      variant=release \
+      variant=$variant \
       threading=multi \
       threadapi=win32 \
       link=shared,static \


### PR DESCRIPTION
Creates libraries with  `-d.dll/-d.a` suffix.
