### PR TITLE
tklib: disables test code on dateentry.tcl

### DIFF
--- a/mingw-w64-tklib/001-no-dateentry-test-code.patch
+++ b/mingw-w64-tklib/001-no-dateentry-test-code.patch
@@ -1,0 +1,57 @@
+diff -r -u tklib-tklib_0_6-ori/modules/widget/dateentry.tcl tklib-tklib_0_6/modules/widget/dateentry.tcl
+--- tklib-tklib_0_6-ori/modules/widget/dateentry.tcl	2014-11-11 16:48:25.994498100 +0100
++++ tklib-tklib_0_6/modules/widget/dateentry.tcl	2014-11-11 16:50:48.619383900 +0100
+@@ -314,29 +314,29 @@
+ # TEST CODE ##
+ ##############
+ 
+-if { [info script] eq $argv0 } {
+-    set auto_path [linsert $auto_path 0 [file dirname [info script]]]
+-    package require widget::dateentry
+-    destroy {*}[winfo children .]
+-    proc getDate { args } {
+-	puts [info level 0]
+-	puts "DATE $::DATE"
+-	update idle
+-    }
++# if { [info script] eq $argv0 } {
++#     set auto_path [linsert $auto_path 0 [file dirname [info script]]]
++#     package require widget::dateentry
++#     destroy {*}[winfo children .]
++#     proc getDate { args } {
++# 	puts [info level 0]
++# 	puts "DATE $::DATE"
++# 	update idle
++#     }
+ 
+-    # Samples
+-    # package require widget::dateentry
+-    set ::DATE ""
+-    set start [widget::dateentry .s -textvariable ::DATE \
+-		   -dateformat "%d.%m.%Y %H:%M" \
+-		   -command [list getDate .s]]
+-    set end [widget::dateentry .e \
+-		 -command [list getDate .e] \
+-		 -highlightcolor dimgrey \
+-		 -font {Courier 10} \
+-		 -firstday sunday]
+-    grid [label .sl -text "Start:"] $start  -padx 4 -pady 4
+-    grid [label .el -text "End:"  ] $end    -padx 4 -pady 4
++#     # Samples
++#     # package require widget::dateentry
++#     set ::DATE ""
++#     set start [widget::dateentry .s -textvariable ::DATE \
++# 		   -dateformat "%d.%m.%Y %H:%M" \
++# 		   -command [list getDate .s]]
++#     set end [widget::dateentry .e \
++# 		 -command [list getDate .e] \
++# 		 -highlightcolor dimgrey \
++# 		 -font {Courier 10} \
++# 		 -firstday sunday]
++#     grid [label .sl -text "Start:"] $start  -padx 4 -pady 4
++#     grid [label .el -text "End:"  ] $end    -padx 4 -pady 4
+ 
+-    puts [$end get]
+-}
++#     puts [$end get]
++# }

--- a/mingw-w64-tklib/PKGBUILD
+++ b/mingw-w64-tklib/PKGBUILD
@@ -3,14 +3,21 @@
 _realname=tklib
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=0.6
-pkgrel=1
+pkgrel=2
 pkgdesc='A companion to Tcllib, for Tk related packages.'
 arch=('any')
 url='http://core.tcl.tk/tklib/home'
 license=('BSD')
 depends=("${MINGW_PACKAGE_PREFIX}-tk" "${MINGW_PACKAGE_PREFIX}-tcllib")
-source=("https://github.com/tcltk/tklib/archive/tklib_${pkgver/./_}.tar.gz")
-md5sums=('233c195515505d43a72680269cbcbaed')
+source=("https://github.com/tcltk/tklib/archive/tklib_${pkgver/./_}.tar.gz"
+	'001-no-dateentry-test-code.patch')
+md5sums=('233c195515505d43a72680269cbcbaed'
+         'dd548d2d73f784ee2eac5d3f1baadb6d')
+
+prepare() {
+    cd ${srcdir}/tklib-tklib_${pkgver/./_}
+    patch -Np1 -i "${srcdir}/001-no-dateentry-test-code.patch"
+}
 
 build() {
     cd ${srcdir}/tklib-tklib_${pkgver/./_}


### PR DESCRIPTION
This would cause an eval error when calling from an application that
embeds Tcl/Tk.
