### PR TITLE
Added xmlada-gpl and gprbuild-gpl

### DIFF
--- a/mingw-w64-gprbuild-gpl/PKGBUILD
+++ b/mingw-w64-gprbuild-gpl/PKGBUILD
@@ -1,0 +1,49 @@
+# Maintainer: Jürgen Pfeifer <juergen@familiepfeifer.de>
+#
+# The 2014 version doesn't comile, need to investigate
+#
+_basename=gprbuild
+_realname=gprbuild-gpl
+pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
+pkgrel=1
+pkgver=2013
+pkgdesc="Software tool designed to help automate the construction of multi-language systems"
+arch=('any')
+provides=("${MINGW_PACKAGE_PREFIX}-${_basename}")
+license=('GPL3')
+groups=("${MINGW_PACKAGE_PREFIX}")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc-ada"
+	     "${MINGW_PACKAGE_PREFIX}-xmlada")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-ada"
+	 "${MINGW_PACKAGE_PREFIX}-xmlada")
+url="http://www.adacore.com/gnatpro/toolsuite/gprbuild/"
+source=("http://downloads.dragonlace.net/src/${_realname}-${pkgver}-src.tgz")
+sha512sums=('f97cfb8b1dba3a10a9de1ef4d71117f8')
+
+prepare()
+{
+  cd ${srcdir}/${_basename}-${pkgver}-src
+}
+
+build() {
+  cd ${srcdir}/${_basename}-${pkgver}-src
+  if [ -f Makefile ]; then
+    make distclean
+  fi
+  ./configure \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --prefix=${MINGW_PREFIX}
+    
+    make
+}
+
+package() {
+  cd ${srcdir}/${_basename}-${pkgver}-src
+  make prefix="${pkgdir}${MINGW_PREFIX}" INSTALL=cp install
+
+  # Copy License Files
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/share/licenses/$_realname  
+  cp -pf COPYING* \
+    ${pkgdir}${MINGW_PREFIX}/share/licenses/$_realname/
+}

--- a/mingw-w64-xmlada-gpl/PKGBUILD
+++ b/mingw-w64-xmlada-gpl/PKGBUILD
@@ -1,0 +1,50 @@
+# Maintainer: Jürgen Pfeifer <juergen@familiepfeifer.de>
+
+# Pathnames in this project can get quite long, so at least on Windows
+# I recommend to use a short BUILDDIR setting to avoid problems
+#
+_basename=xmlada
+_realname=${_basename}-gpl
+pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
+pkgrel=1
+pkgver=2014
+pkgdesc="A full XML suite for Ada"
+arch=('any')
+provides=("${MINGW_PACKAGE_PREFIX}-${_basename}")
+url="http://libre.adacore.com/libre/tools/xmlada/"
+license=('GPL3')
+depends=("gcc-ada")
+source=(http://downloads.dragonlace.net/src/${_realname}-${pkgver}-src.tar.gz)
+md5sums=('1aaa49885ec280a3242823f659460dff')
+options=('strip')
+groups=("${MINGW_PACKAGE_PREFIX}")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc-ada")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-ada")
+
+build() {
+  cd $srcdir/$_basename-$pkgver-src
+  ./configure \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --prefix=${MINGW_PREFIX} \
+    --enable-shared
+  make  
+}
+
+package() {
+  mkdir -p $pkgdir$MINGW_PREFIX/include/xmlada
+  mkdir -p $pkgdir$MINGW_PREFIX/lib/xmlada/static
+  mkdir -p $pkgdir$MINGW_PREFIX/lib/xmlada/relocatable
+  mkdir -p $pkgdir$MINGW_PREFIX/lib/gnat/xmlada
+
+  cd ${srcdir}/$_basename-$pkgver-src
+  make prefix=$pkgdir$MINGW_PREFIX INSTALL=cp install
+
+  rm -rf ${pkgdir}${MINGW_PREFIX}/share/examples
+  rm -rf ${pkgdir}${MINGW_PREFIX}/share/doc
+
+  # Copy License Files
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/share/licenses/$_realname  
+  cp -pf ${srcdir}/${_basename}-$pkgver-src/COPYING* \
+    ${pkgdir}${MINGW_PREFIX}/share/licenses/$_realname
+}


### PR DESCRIPTION
Two basic add-ons to the gcc-ada toolsuite
Please note that xmlada-gpl build process on Windows may experience problems if the build directory has too long pathname.
