### PR TITLE
SDL: Disable broken assembly code.

### DIFF
--- a/mingw-w64-SDL/PKGBUILD
+++ b/mingw-w64-SDL/PKGBUILD
@@ -4,7 +4,7 @@ _realname=SDL
 
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.2.15
-pkgrel=3
+pkgrel=4
 pkgdesc="A library for portable low-level access to a video framebuffer, audio output, mouse, and keyboard (mingw-w64)"
 arch=('any')
 url="http://libsdl.org"
@@ -21,7 +21,8 @@ build() {
   "${srcdir}"/SDL-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
-    --host=${MINGW_CHOST}
+    --host=${MINGW_CHOST} \
+    --disable-assembly
   make
 }
 


### PR DESCRIPTION
MMX asm codes are broken.
This commit fixes the problem that ffplay for i686 didn't work.
