### PR TITLE
New package drmingw (release-based)

### DIFF
--- a/mingw-w64-drmingw/PKGBUILD
+++ b/mingw-w64-drmingw/PKGBUILD
@@ -1,0 +1,41 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
+
+_realname=drmingw
+pkgname=(${MINGW_PACKAGE_PREFIX}-${_realname})
+pkgver=0.6.4
+pkgrel=1
+pkgdesc="Just-in-Time (JIT) debugger (mingw-w64)"
+arch=('any')
+license=('GPL' 'LGPL')
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake" "${MINGW_PACKAGE_PREFIX}-gcc")
+url=('https://github.com/jrfonseca/drmingw')
+source=(${_realname}-${pkgver}.tar.gz::"https://github.com/jrfonseca/drmingw/archive/${pkgver}.tar.gz")
+options=(!strip staticlibs)
+md5sums=('SKIP')
+
+prepare() {
+  cd "${srcdir}"
+  mv "${_realname}-${pkgver}" "${_realname}"
+}
+
+build() {
+  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
+  mkdir -p ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
+
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G"MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX:PATH=${pkgdir}${MINGW_PREFIX} \
+    ../${_realname}
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make -j1 install
+  rm -rf "${pkgdir}${MINGW_PREFIX}"/doc
+  rm -rf "${pkgdir}${MINGW_PREFIX}"/sample
+
+  install -Dm644 "${srcdir}/${_realname}/COPYING.LIB" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
Latest release 0.6.4 is several months newer than current build of drmingw-git and seems to have fixed the 64-bit issue.
