### PR TITLE
V8 'stable' branch

### DIFF
--- a/mingw-w64-v8-315/PKGBUILD
+++ b/mingw-w64-v8-315/PKGBUILD
@@ -26,8 +26,9 @@ prepare() {
 
 build() {
   local BUILDTYPE=Release
+  local BUILDDIR="${srcdir}/build-${CARCH}"
   export PYTHON=/usr/bin/python2
-  mkdir -p "${srcdir}/build-${CARCH}"
+  mkdir -p "${BUILDDIR}"
 
   case ${CARCH} in
     i686)
@@ -45,22 +46,23 @@ build() {
       -Duse_system_icu=1 \
       -Dconsole=readline \
       -Dv8_target_arch=${_arch} \
-      --generator-output=dist \
+      --generator-output=${BUILDDIR} \
       -f make
 
-  LINK=g++ make -C dist BUILDTYPE=${BUILDTYPE} mksnapshot V=1
-  LINK=g++ make -C dist BUILDTYPE=${BUILDTYPE} V=1
+  LINK=g++ make -C ${BUILDDIR} BUILDTYPE=${BUILDTYPE} mksnapshot V=1
+  LINK=g++ make -C ${BUILDDIR} BUILDTYPE=${BUILDTYPE} V=1
 }
 
 package() {
   cd "v8-git-mirror-${pkgver}"
   local BUILDTYPE=Release
+  local BUILDDIR="${srcdir}/build-${CARCH}"
 
   install -d "$pkgdir"/${MINGW_PREFIX}/bin
-  install -Dm755 dist/out/${BUILDTYPE}/d8 "$pkgdir"/${MINGW_PREFIX}/bin/d8
+  install -Dm755 ${BUILDDIR}/out/${BUILDTYPE}/d8 "$pkgdir"/${MINGW_PREFIX}/bin/d8
 
   install -d "$pkgdir"/${MINGW_PREFIX}/lib
-  install -Dm755 dist/out/${BUILDTYPE}/obj.target/tools/gyp/*.a "$pkgdir"/${MINGW_PREFIX}/lib/
+  install -Dm755 ${BUILDDIR}/out/${BUILDTYPE}/obj.target/tools/gyp/*.a "$pkgdir"/${MINGW_PREFIX}/lib/
 
   install -d "$pkgdir"/${MINGW_PREFIX}/include
   install -Dm644 include/*.h "$pkgdir"/${MINGW_PREFIX}/include

--- a/mingw-w64-v8-315/PKGBUILD
+++ b/mingw-w64-v8-315/PKGBUILD
@@ -1,4 +1,4 @@
-# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Maintainer: Jeroen Ooms <jeroenooms@gmail.com>
 
 _realname=v8
 pkgbase=mingw-w64-${_realname}-315
@@ -14,11 +14,11 @@ depends=("${MINGW_PACKAGE_PREFIX}-readline"
          "${MINGW_PACKAGE_PREFIX}-icu")
 options=('!emptydirs' '!strip')
 conflicts=("${MINGW_PACKAGE_PREFIX}-v8")
-source=("https://github.com/v8/v8-git-mirror/archive/${pkgver}.tar.gz")
-md5sums=('d9a7f06067105ce701cfcd3e39d16f1a')
+source=("https://github.com/v8/v8/archive/${pkgver}.tar.gz")
+md5sums=('1406770373cc26e5af26e5e04c2756f2')
 
 prepare() {
-  cd v8-git-mirror-${pkgver}
+  cd ${_realname}-${pkgver}
   sed -i s/winmm.lib/winmm/g tools/gyp/v8.gyp
   sed -i s/ws2_32.lib/ws2_32/g tools/gyp/v8.gyp
   sed -i '/#include "cctest.h"/a #include "win32-headers.h"' test/cctest/test-platform-win32.cc
@@ -38,7 +38,7 @@ build() {
       _arch=x64
     ;;
   esac
-  cd "${srcdir}"/v8-git-mirror-${pkgver}
+  cd "${srcdir}/${_realname}-${pkgver}"
   
   GYP_GENERATORS=make \
     $PYTHON build/gyp_v8 \
@@ -54,7 +54,7 @@ build() {
 }
 
 package() {
-  cd "v8-git-mirror-${pkgver}"
+  cd "${_realname}-${pkgver}"
   local BUILDTYPE=Release
   local BUILDDIR="${srcdir}/build-${CARCH}"
 

--- a/mingw-w64-v8-315/PKGBUILD
+++ b/mingw-w64-v8-315/PKGBUILD
@@ -1,0 +1,70 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+
+_realname=v8
+pkgbase=mingw-w64-${_realname}-315
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-315"
+pkgver=3.15.11.18
+pkgrel=1
+pkgdesc="Fast and modern Javascript engine (mingw-w64)"
+arch=('any')
+url="http://code.google.com/p/v8"
+license=("BSD")
+makedepends=("gyp-svn")
+depends=("${MINGW_PACKAGE_PREFIX}-readline"
+         "${MINGW_PACKAGE_PREFIX}-icu")
+options=('!emptydirs' '!strip')
+conflicts=("${MINGW_PACKAGE_PREFIX}-v8")
+source=("https://github.com/v8/v8-git-mirror/archive/${pkgver}.tar.gz")
+md5sums=('d9a7f06067105ce701cfcd3e39d16f1a')
+
+prepare() {
+  cd v8-git-mirror-${pkgver}
+  sed -i s/winmm.lib/winmm/g tools/gyp/v8.gyp
+  sed -i s/ws2_32.lib/ws2_32/g tools/gyp/v8.gyp
+  sed -i '/#include "cctest.h"/a #include "win32-headers.h"' test/cctest/test-platform-win32.cc
+}
+
+build() {
+  local BUILDTYPE=Release
+  export PYTHON=/usr/bin/python2
+  mkdir -p "${srcdir}/build-${CARCH}"
+
+  case ${CARCH} in
+    i686)
+      _arch=ia32
+    ;;
+    x86_64)
+      _arch=x64
+    ;;
+  esac
+  cd "${srcdir}"/v8-git-mirror-${pkgver}
+  
+  GYP_GENERATORS=make \
+    $PYTHON build/gyp_v8 \
+      -Dv8_enable_i18n_support=true \
+      -Duse_system_icu=1 \
+      -Dconsole=readline \
+      -Dv8_target_arch=${_arch} \
+      --generator-output=out \
+      -f make
+
+  LINK=g++ make -C out BUILDTYPE=${BUILDTYPE} mksnapshot V=1
+  LINK=g++ make -C out BUILDTYPE=${BUILDTYPE} V=1
+}
+
+package() {
+  cd "v8-git-mirror-${pkgver}"
+  local BUILDTYPE=Release
+
+  install -d "$pkgdir"/${MINGW_PREFIX}/bin
+  install -Dm755 out/out/${BUILDTYPE}/d8 "$pkgdir"/${MINGW_PREFIX}/bin/d8
+
+  install -d "$pkgdir"/${MINGW_PREFIX}/lib
+  install -Dm755 out/out/${BUILDTYPE}/obj.target/tools/gyp/*.a "$pkgdir"/${MINGW_PREFIX}/lib/
+
+  install -d "$pkgdir"/${MINGW_PREFIX}/include
+  install -Dm644 include/*.h "$pkgdir"/${MINGW_PREFIX}/include
+
+  install -d "$pkgdir"/${MINGW_PREFIX}/share/licenses/v8
+  install -m644 LICENSE* "$pkgdir"/${MINGW_PREFIX}/share/licenses/v8
+}

--- a/mingw-w64-v8-315/PKGBUILD
+++ b/mingw-w64-v8-315/PKGBUILD
@@ -45,11 +45,11 @@ build() {
       -Duse_system_icu=1 \
       -Dconsole=readline \
       -Dv8_target_arch=${_arch} \
-      --generator-output=out \
+      --generator-output=dist \
       -f make
 
-  LINK=g++ make -C out BUILDTYPE=${BUILDTYPE} mksnapshot V=1
-  LINK=g++ make -C out BUILDTYPE=${BUILDTYPE} V=1
+  LINK=g++ make -C dist BUILDTYPE=${BUILDTYPE} mksnapshot V=1
+  LINK=g++ make -C dist BUILDTYPE=${BUILDTYPE} V=1
 }
 
 package() {
@@ -57,10 +57,10 @@ package() {
   local BUILDTYPE=Release
 
   install -d "$pkgdir"/${MINGW_PREFIX}/bin
-  install -Dm755 out/out/${BUILDTYPE}/d8 "$pkgdir"/${MINGW_PREFIX}/bin/d8
+  install -Dm755 dist/out/${BUILDTYPE}/d8 "$pkgdir"/${MINGW_PREFIX}/bin/d8
 
   install -d "$pkgdir"/${MINGW_PREFIX}/lib
-  install -Dm755 out/out/${BUILDTYPE}/obj.target/tools/gyp/*.a "$pkgdir"/${MINGW_PREFIX}/lib/
+  install -Dm755 dist/out/${BUILDTYPE}/obj.target/tools/gyp/*.a "$pkgdir"/${MINGW_PREFIX}/lib/
 
   install -d "$pkgdir"/${MINGW_PREFIX}/include
   install -Dm644 include/*.h "$pkgdir"/${MINGW_PREFIX}/include


### PR DESCRIPTION
Much software that depends on V8 today actually depends on version 3.14 ~ 3.15. This is also the 'stable' version in homebrew and most Linux distributions:
- Debian: https://packages.debian.org/sid/libv8-dev
- Fedora: https://apps.fedoraproject.org/packages/v8-devel
- Arch https://aur.archlinux.org/packages/v8-3.15/
- Homebrew: https://github.com/Homebrew/homebrew-versions/blob/master/v8-315.rb

The 3.15 branch is fully compatible with 3.14, but not with more recent versions.
