### PR TITLE
go: remove unneeded workaround [DO NOT MERGE]

### DIFF
--- a/mingw-w64-go/PKGBUILD
+++ b/mingw-w64-go/PKGBUILD
@@ -40,13 +40,7 @@ build() {
   export GO_CFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
   export CFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
   export GO_BUILD_VERBOSE=1
-  # I have no idea why we need this to be run from a completely seperate
-  # MSDOS shell, but it does. Without this, the build exits with no info
-  # about what went wrong.
-  # ./make.bat
-  echo "cd $(cygpath -w $PWD)"                    > /tmp/bootstrap_go.bat
-  echo "start /wait \"\" cmd.exe /c .\\make.bat" >> /tmp/bootstrap_go.bat
-  /tmp/bootstrap_go.bat
+  ./make.bat
 }
 
 package() {
@@ -106,21 +100,3 @@ package() {
   cp "${pkgdir}${MINGW_PREFIX}"/etc/profile.d/go.{sh,zsh}
 }
 
-# Please leave this debugging stuff here until someone gets to the bottom of the problem why ./make.bat fails.
-
-# pushd ~/msys2/MINGW-packages/mingw-w64-go/src/go-1.7.4/src
-# (export GOROOT_BOOTSTRAP=C:/msys64/mingw64/lib/go export CC_FOR_TARGET=gcc ; export GOROOT=/home/ray/msys2/MINGW-packages/mingw-w64-go/src/go-1.7.4 ; export GOBIN=C:/msys64/home/ray/msys2/MINGW-packages/mingw-w64-go/src/go-1.7.4/bin ; export GOARCH=amd64 ; export GOOS=windows ; export GOHOSTARCH=amd64 ; export GOHOSTOS=windows ; export GOTOOLDIR=/home/ray/msys2/MINGW-packages/mingw-w64-go/src/go-1.7.4/pkg/tool/windows_amd64 ; PATH=/home/ray/msys2/MINGW-packages/mingw-w64-go/src/go-1.7.4/bin:/mingw64/bin:$PATH .\\cmd\\dist\\dist bootstrap -a -v=5)
-
-# From MSDOS:
-# pushd C:\Users\ray\msys2\MINGW-packages\mingw-w64-go\src\go-1.7.4\src
-# set GOROOT_BOOTSTRAP=C:/msys64/mingw64/lib/go
-# set CC_FOR_TARGET=gcc
-# set GOROOT=C:/msys64/home/ray/msys2/MINGW-packages/mingw-w64-go/src/go-1.7.4
-# set GOBIN=C:/msys64/home/ray/msys2/MINGW-packages/mingw-w64-go/src/go-1.7.4/bin
-# set GOARCH=amd64
-# set GOOS=windows
-# set GOHOSTARCH=amd64
-# set GOHOSTOS=windows
-# set GOTOOLDIR=C:/msys64/home/ray/msys2/MINGW-packages/mingw-w64-go/src/go-1.7.4/pkg/tool/windows_amd64
-# set "PATH=C:/msys64/home/ray/msys2/MINGW-packages/mingw-w64-go/src/go-1.7.4/bin;C:/msys64/mingw64/bin;%PATH%"
-# .\cmd\dist\dist bootstrap -a -v=5


### PR DESCRIPTION
I seem to be able to build go just fine without this workaround that opens a new windows terminal window for building go. This interferes with automated builds, etc. Let's remove it.

@mingwandroid Can you please check if it works for you?