### PR TITLE
Add blackmagic-decklink-sdk (version 10.9.5)

### DIFF
--- a/mingw-w64-blackmagic-decklink-sdk/LICENSE
+++ b/mingw-w64-blackmagic-decklink-sdk/LICENSE
@@ -1,0 +1,129 @@
+
+End User License Agreement for the Software Development Kit
+
+IMPORTANT
+
+YOU SHOULD CAREFULLY READ THE FOLLOWING TERMS AND CONDITIONS BEFORE DOWNLOADING, INSTALLING AND USING THE SOFTWARE DEVELOPMENT KIT ('SDK') PROVIDED BY BLACKMAGIC DESIGN PTY. LTD. (the Licensor).
+
+These are the terms and conditions on which the Licensor licenses to you (the Licensee) to use the software product known as the Blackmagic Software Development Kit or SDK and the accompanying documentation (the Software). By clicking on the "AGREE" button, you are agreeing to the following terms and conditions (the Agreement). If you DO NOT AGREE to the following terms, you must not download, install or use this Software.
+
+1. Grant of Licence
+
+1.1 The Licensor grants to the Licensee a non-exclusive, non-transferable, royalty-free license to use the Software for the term of this Agreement.
+
+1.2 The Licensee is entitled to download, install and use the Software on any personal computer or networked machine only, for the sole purpose of:
+
+    1. determining whether to create or modify an application using the Software; and
+    2. creating software that will be compatible with the Licensor's products, or making the Licensee's existing software compatible with the Licensor's products,
+
+(collectively, the Permitted Use).
+
+1.3 The Licensee agrees to use the Software only for the Permitted Use and in compliance with all applicable laws, including all applicable intellectual property laws.
+
+1.4 The Licensee must not lease, rent, distribute or sub-license the Software, or use the Software in a time-sharing arrangement, or in any other manner that is not the Permitted Use.
+
+1.5 The Licensee may make one copy only of the Software if it is essential for back-up and archival purposes, in accordance with its use of the Software. Any such copy must reproduce and contain all of the copyright and other proprietary notices appearing in the Software.
+
+1.6 The Licensor reserves the right at any time to alter the price, features, specifications, capabilities, functions, licensing terms, release dates, general availability or other characteristics of the Software.
+
+1.7 The Software contains sample source code in the form of example applications and code fragments (collectively the Sample Source Code). The Licensee may only use the Sample Source Code internally for the Permitted Use.
+
+2. Warranty and Disclaimer
+
+2.1 The Software has not been written to meet individual requirements of the Licensee and is supplied without warranty of any kind. A failure of any part or the whole of the Software to be suitable for the Licensee's requirements will not give rise to any right or claim against the Licensor or its suppliers.
+
+2.2 THE LICENSOR AND ITS SUPPLIERS MAKE NO WARRANTY OR REPRESENTATION TO THE LICENSEE AS TO THE PERFORMANCE OR OPERATION OF THE SOFTWARE, AND TO THE FULLEST EXTENT PERMITTED BY LAW DISCLAIMS ALL EXPRESS, IMPLIED AND STATUTORY WARRANTIES, INCLUDING (BUT NOT LIMITED TO) MERCHANTABILITY, FITNESS FOR PURPOSE, SECURITY, RELIABILITY, NON-INFRINGEMENT AND PERFORMANCE OF THE SOFTWARE.
+
+2.3 The Licensee acknowledges and agrees that it downloads, installs and uses the Software at its own discretion and risk, and that it will be solely responsible for any damage to its computer system or any loss of data that results from such downloading, installing or use of the Software.
+
+2.4 To the fullest extent permitted by law, any condition or warranty which would otherwise be implied in this Agreement is hereby excluded. Where legislation implies in this Agreement any condition or warranty, and that legislation avoids or prohibits provisions in a contract from excluding or modifying the application of or exercise of or liability under such a condition or warranty, that condition or warranty will be deemed to be included in this Agreement. However, the liability of the Licensor or its suppliers for any breach of such a condition or warranty will be limited, at the option of the Licensor, to one or more of the following:
+
+    1. in the case of the supply of goods:
+        1. the replacement of the goods;
+        2. the supply of equivalent goods;
+        3. the repair of the goods;
+        4. the payment of the cost of replacing the goods or of acquiring equivalent goods; or
+        5. the payment of the cost of having the goods repaired; and
+    2. in the case of the provision of services:
+        1. the supplying of the services again; or
+        2. the payment of the cost of having the services supplied again.
+
+2.5 The Licensee acknowledges that the Software in general is not error-free and agrees that the existence of such errors will not constitute a breach of this Agreement.
+
+2.6 The Licensor and its suppliers do not warrant that the Software will be free from all known viruses and the Licensee is solely responsible for virus scanning the Software.
+
+2.7 The Licensor and its suppliers do not warrant that the Software will enable the Licensee to render its products compatible with the Licensor or its suppliers' products.
+
+3. Liability
+
+3.1 IN NO EVENT WILL THE LICENSOR OR ITS SUPPLIERS BE LIABLE TO THE LICENSEE OR ANY OTHER PERSON FOR ANY LOST PROFITS, LOST SAVINGS, LOST DATA, OR OTHER SPECIAL, DIRECT, INDIRECT, PUNITIVE, CONSEQUENTIAL, OR INCIDENTAL DAMAGES ARISING OUT OF OR RELATING TO THIS AGREEMENT OR ANY PRODUCT OR SERVICE FURNISHED OR TO BE FURNISHED UNDER THIS AGREEMENT OR THE USE THEREOF, EVEN IF THE LICENSOR OR ITS SUPPLIERS HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH LOSS OR DAMAGE.
+
+3.2 The aggregate liability of the Licensor and its suppliers upon any claims howsoever arising out of or relating to this Agreement or any products or services furnished or to be furnished by the Licensor or its suppliers under this Agreement will in any event be absolutely limited to US$100
+
+3.3 Unless this Agreement expressly provides otherwise:
+
+    1. to the maximum extent permitted by law, all express and implied conditions, warranties or liabilities (including liability as to negligence) regarding the condition, accuracy, suitability, quality or title to the Software are negated and excluded; and
+    2. the Licensor and its suppliers give no condition, warranty, undertaking or representation in relation to the condition, accuracy, suitability, quality of or title to the Software (including any data contained in or supplied in relation to it or reports generated or produced by or with the aid of any of them).
+
+3.4 The Licensee acknowledges that the Licensor has entered into this Agreement in reliance upon the Warranty and Disclaimer and Liability clauses set forth in this Agreement, and that the same form an essential basis of the bargain between the parties. The parties agree that the limitation of liability specified in this Agreement will survive and apply even if the Warranty and Disclaimer or Liability clause, or any limitation of remedies is found to have failed its essential purpose.
+
+4. Intellectual Property Rights
+
+4.1 For the purposes of this Agreement, the term Intellectual Property Rights means all copyright, patents, designs, trademarks or service marks, brand names, product names, trade secrets, know-how, rights to confidentiality and other intellectual and industrial property rights (including Marks as defined in clause 6), whether or not registered or capable of registration, in all parts of the world.
+
+4.2 The Licensee acknowledges that it obtains no Intellectual Property Rights whatsoever in the Software. As between the parties all Intellectual Property Rights vest in the Licensor or its suppliers.
+
+4.3 The Licensee must not, except to the extent permitted by any law that cannot be excluded by the parties, copy, modify, disassemble, decompile, or reverse engineer the Software nor directly or indirectly permit any third party to do any of the foregoing.
+
+4.4 The only permitted copying of the Software is for the back-up purposes referred to in clause 1.5. The Licensee acknowledges and agrees that ownership of, and title to, the Software and all subsequent copies thereof regardless of form or media are held by the Licensor and its suppliers.
+
+5. Infringement of Intellectual Property Rights
+
+If the Licensee becomes aware of any infringements or suspected infringements by any third party of any Intellectual Property Rights in the Software, the Licensee must immediately notify the Licensor, and must at the request and expense of the Licensor, take such action as the Licensor may reasonably deem appropriate to protect its Intellectual Property Rights.
+
+6. Marks
+
+6.1 The Licensee will not adopt or use, nor authorise others to adopt or use, any trademark, service mark or trade name which includes, or is likely to mislead, deceive or cause confusion, or is substantially identical with, or deceptively similar to, any Mark. This clause will survive the expiration or earlier termination of this Agreement.
+
+6.2 For the avoidance of doubt, the Licensee is permitted to use the following designations only during the term of this Agreement:
+
+    1. 'XXX compatible with Blackmagic Design YYY'; and
+    2. 'XXX for Blackmagic Design YYY',
+
+where 'XXX' refers to the Licensee's product name, and YYY refers to the Blackmagic product, "DeckLink," "Multibridge," "Intensity," "HDLink," "Videohub," or "UltraScope," with which such XXX product is compatible (provided that the Licensee's product is compatible with such Blackmagic product). If the Licensor determines in its sole discretion that any of the Licensee's products are not compatible with the applicable Blackmagic product, then the Licensor shall so notify the Licensee, and the Licensee shall discontinue any use of the Marks on such incompatible Licensee product(s).
+
+6.3 For the purposes of this Agreement, the term Marks means any trademark, service mark or trade name of Blackmagic or its affiliates, as the case may be, including but not limited to "DeckLink", "Multibridge", "Intensity", "HDLink", "Videohub" or "UltraScope", whether or not they are registered or capable of being registered.
+
+7. Term and Termination
+
+7.1 This Agreement is effective until terminated.
+
+7.2 The Licensor may immediately terminate this Agreement at any time with or without notice:
+
+    1. at the Licensor's sole discretion; or
+    2. if the Licensee breaches a term of this Agreement.
+
+7.3 Upon termination of this Agreement, the Licensee must immediately cease to use the Software and if capable of return, return the Software (and all copies thereof) to the Licensor. Where such Software is incapable of return, the Licensee must permanently delete or destroy the Software and provide a declaration to the Licensor that the Licensee has complied with this clause 7.3. This requirement is without prejudice to any other rights and remedies that the Licensor may have in respect of the breach.
+
+7.4 Despite any other provision of this Agreement this clause 7.4 and clauses 2, 3, 4, 5, 6, 7.3 and 8 survive the expiration or termination of this Agreement.
+
+8. General
+
+8.1 This written Agreement constitutes the entire agreement between the parties relating to the subject matter of this Agreement and supersedes all prior communications and agreements between the parties as to its subject matter. Each party agrees that unless expressly stated in this Agreement, that party has not relied on any representation, warranty or undertaking of any kind in relation to the subject matter of this Agreement.
+
+8.2 If any provision of this Agreement or any part of a provision is unenforceable or void for any reason, then:
+
+    1. that provision of the Agreement will be enforced to the maximum extent permissible so as to effect the economic intent of the parties, and the remainder of this Agreement will continue in full force and effect; and
+    2. in any other case, such provision must be severed from this Agreement, in which case a valid, legal and enforceable provision of similar intent and economic impact will be substituted, and the remaining provisions will continue in full force and effect as if the severed provision had not been included.
+
+8.3 The Licensee must not, without prior written consent of the Licensor assign, charge, sub-license, or otherwise transfer any of its rights or obligations under this Agreement in whole or in part.
+
+8.4 Any delay or forbearance by either party in enforcing any provisions of this Agreement or any of its rights hereunder will not be construed as a waiver of such provision or right to subsequently enforce the same.
+
+8.5 Clause headings have been included in this Agreement for convenience only and must not be considered part of, or be used in interpreting, this Agreement.
+
+8.6 This Agreement is governed by and must be construed in accordance with the laws in force in the State of California. The parties submit to the exclusive jurisdiction of the courts of that State and the United States of America in respect of all matters arising out of or relating to this Agreement, its performance or subject matter.
+
+8.7 The Licensee agrees to abide by all applicable laws of the State of California and all applicable jurisdictions, including the federal laws of the United States. The Licensor reserves the right to enforce its Intellectual Property Rights before the competent courts of any jurisdiction where an act of infringement has occurred.
+
+8.8 The Licensee acknowledges and agrees that it will not export or re-export the Software or any products utilizing the Software in violation of any applicable laws or regulations of the United States of America.

--- a/mingw-w64-blackmagic-decklink-sdk/PKGBUILD
+++ b/mingw-w64-blackmagic-decklink-sdk/PKGBUILD
@@ -1,0 +1,118 @@
+_realname=blackmagic-decklink-sdk
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=10.9.5
+pkgrel=1
+pkgdesc='Blackmagic DeckLink SDK (mingw-w64)'
+arch=('any')
+url='https://www.blackmagicdesign.com/support/family/capture-and-playback/'
+license=('custom')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config" "curl")
+source=('LICENSE')
+sha256sums=('25fafed93b109e5bf1d107f5e9a629c30f7bf3568f1c40c5d4554140c903947b')
+
+_srcfile="Blackmagic_DeckLink_SDK_${pkgver}.zip"
+_downloadid='627a3b1bcfdb4996a2bcc0d70af9ee3b'
+_referid='c4985c77ccb24b48b4be5ae7e309e92d'
+_srcurl="https://www.blackmagicdesign.com/api/register/us/download/${_downloadid}"
+_expected_sha256sum='1aa0fd45714ee955badbe986254cd6c7537f25e6ff596cbc1b9499bf5dcaf32b'
+
+_useragent="User-Agent: Mozilla/5.0 (X11; Windows x86_64) \
+                        AppleWebKit/537.36 (KHTML, like Gecko) \
+                        Chrome/60.0.3112.90 \
+                        Safari/537.36"
+_reqjson="{ \
+    \"platform\": \"Windows\", \
+    \"country\": \"us\", \
+    \"firstname\": \"Mingw\", \
+    \"lastname\": \"w64\", \
+    \"email\": \"someone@windows.org\", \
+    \"phone\": \"202-555-0194\", \
+    \"state\": \"New York\", \
+    \"city\": \"MSYS2\", \
+    \"hasAgreedToTerms\": true, \
+    \"product\": \"Desktop Video ${pkgver} SDK\" \
+}"
+_useragent="$(printf '%s' "$_useragent" | sed 's/[[:space:]]\+/ /g')"
+_reqjson="$(  printf '%s' "$_reqjson"   | sed 's/[[:space:]]\+/ /g')"
+
+_exit_makepkg() {
+    printf '%s\n' "error: failed to ${1} ${_srcfile}"
+    exit 1
+}
+
+prepare() {
+    # check if decklink sdk zip file was already downloaded
+    if ! [ -f "../${_srcfile}" ] 
+    then
+        # download decklink sdk zip file from website
+        msg2 "Downloading ${_srcfile} from website..."
+        curl \
+            -o "../${_srcfile}" \
+            -H 'Host: sw.blackmagicdesign.com' \
+            -H 'Upgrade-Insecure-Requests: 1' \
+            -H "$_useragent" \
+            -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8' \
+            -H 'Accept-Language: en-US,en;q=0.8' \
+            --compressed \
+            "$(curl \
+                -s \
+                -H 'Host: www.blackmagicdesign.com' \
+                -H 'Accept: application/json, text/plain, */*' \
+                -H 'Origin: https://www.blackmagicdesign.com' \
+                -H "$_useragent" \
+                -H 'Content-Type: application/json;charset=UTF-8' \
+                -H "Referer: https://www.blackmagicdesign.com/support/download/${_referid}/Windows" \
+                -H 'Accept-Language: en-US,en;q=0.8' \
+                -H 'Cookie: _ga=GA1.3.853760154.1498322710; _gid=GA1.3.1693019090.1500064482' \
+                --data-binary "$_reqjson" \
+                --compressed \
+                "$_srcurl" \
+            )" || _exit_makepkg 'download'
+    else
+        msg2 "Found ${_srcfile}"
+    fi
+    
+    # check integrity of the decklink sdk zip file (file validation)
+    msg2 "Validating ${_srcfile} with sha256sum..."
+    local _real_sha256sum="$(openssl dgst -sha256 "../${_srcfile}" || _exit_makepkg 'calculate SHA256 of')"
+    _real_sha256sum="${_real_sha256sum##* }"
+    printf '%s' "       ${_srcfile} ... "
+    if [ "$_expected_sha256sum" = "$_real_sha256sum" ] 
+    then
+        printf '%s\n' 'Passed'
+    else
+        printf '%s\n' 'FAILED'
+        exit 1
+    fi
+    
+    # create symbolic link of decklink sdk zip file in $srcdir
+    ln -sf "../${_srcfile}" "${srcdir}/${_srcfile}" || _exit_makepkg 'create symbolic link of'
+    
+    # extract decklink sdk zip file
+    msg2 "Extracting ${_srcfile} with bsdtar..."
+    bsdtar -xf "${_srcfile}" || _exit_makepkg 'extract'
+	
+}
+
+package() {
+    # directories creation
+    mkdir -p "${pkgdir}/${MINGW_PREFIX}/include"
+    mkdir -p "${pkgdir}/${MINGW_PREFIX}/share/doc/${_realname}"
+    
+    # convert idl file to header file
+    cd "${srcdir}/Blackmagic DeckLink SDK ${pkgver}/Win/include"
+    ${MINGW_PREFIX}/bin/widl -h "DeckLinkAPI.idl" -o "${pkgdir}/${MINGW_PREFIX}/include/DeckLinkAPI.h"
+   
+    
+    # includes
+    cd "${srcdir}/Blackmagic DeckLink SDK ${pkgver}/Win/include"
+    install -D -m644 *.h "${pkgdir}/${MINGW_PREFIX}/include" 
+    
+    # documentation
+    cd "${srcdir}/Blackmagic DeckLink SDK ${pkgver}"
+    install -D -m644 *.pdf "${pkgdir}/${MINGW_PREFIX}/share/doc/${_realname}"
+    
+    # license
+    install -D -m644 "${srcdir}/LICENSE" "${pkgdir}/${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
This adds the blackmagic-decklink-sdk package.

Although the blackmagic-decklink-sdk package is proprietary, the package is needed by FFmpeg to use Blackmagic Decklink functions. This will certainly not make it into the package repository.