### PR TITLE
libplist: Don't include DllMain in static lib

### DIFF
--- a/mingw-w64-libplist/002-dll-export.patch
+++ b/mingw-w64-libplist/002-dll-export.patch
@@ -1,0 +1,22 @@
+diff --git a/src/plist.c b/src/plist.c
+index f62e6be..d563fe5 100644
+--- a/src/plist.c
++++ b/src/plist.c
+@@ -29,7 +29,7 @@
+ #include <stdio.h>
+ #include <math.h>
+ 
+-#ifdef WIN32
++#ifdef DLL_EXPORT
+ #include <windows.h>
+ #else
+ #include <pthread.h>
+@@ -56,7 +56,7 @@ static void internal_plist_deinit(void)
+     plist_xml_deinit();
+ }
+ 
+-#ifdef WIN32
++#ifdef DLL_EXPORT
+ 
+ typedef volatile struct {
+     LONG lock;

--- a/mingw-w64-libplist/PKGBUILD
+++ b/mingw-w64-libplist/PKGBUILD
@@ -1,26 +1,30 @@
 # Maintainer: Ray Donnelly <mingw.android@gmail.com>
+# Contributor: Luke Street <luke.street@encounterpc.com>
 
 _realname=libplist
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc='A library to handle Apple Property List format in binary or XML (mingw-w64)'
 arch=('any')
 url='http://www.libimobiledevice.org/'
 license=('GPL2+')
 source=("http://www.libimobiledevice.org/downloads/${_realname}-${pkgver}.tar.bz2"
-        001-cython-module.patch)
+        001-cython-module.patch
+        002-dll-export.patch)
 depends=("${MINGW_PACKAGE_PREFIX}-libxml2"
          "${MINGW_PACKAGE_PREFIX}-cython")
 options=('staticlibs')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python3")
 sha256sums=('3a7e9694c2d9a85174ba1fa92417cfabaea7f6d19631e544948dc7e17e82f602'
-            '42e7c4d3fa91b5b5d206faf51e95690f74b751b1896056bb32a616e17563ee93')
+            '42e7c4d3fa91b5b5d206faf51e95690f74b751b1896056bb32a616e17563ee93'
+            'e16bf7029135ec97a54f0690ea9de579f7c6f78b26998868307f7aedd1534675')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/001-cython-module.patch
+  patch -p1 -i ${srcdir}/002-dll-export.patch
 
   autoreconf -fiv
 }
@@ -43,8 +47,7 @@ build() {
 
 check() {
   cd "${srcdir}"/build-${CARCH}
-  # || true because of FAIL: bigarraycmp .. File does not exists
-  make check || true
+  make check
 }
 
 package() {


### PR DESCRIPTION
This fixes an issue I was getting trying to include this static library. 

(I also noticed that openssl's libcrypto.a includes a DllMain, is this intentional?)