### PR TITLE
mono: update to 5.10.1.47 and update bootstrap

### DIFF
--- a/mingw-w64-mono/PKGBUILD
+++ b/mingw-w64-mono/PKGBUILD
@@ -4,8 +4,8 @@ _realname=mono
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 
-_gitcommit=bf27e2544662ab34e1d50f1d43ea96ee2502c685
-pkgver=5.10.1.16
+_gitcommit=8eb8f7d5e74787049316fef1f4d09f2e9e2d6968
+pkgver=5.10.1.47
 pkgrel=1
 pkgdesc='Free implementation of the .NET platform including runtime and compiler (mingw-w64)'
 url='http://www.mono-project.com/'

--- a/mingw-w64-mono/bootstrap/PKGBUILD
+++ b/mingw-w64-mono/bootstrap/PKGBUILD
@@ -4,9 +4,9 @@ _realname=mono
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 
-_gitcommit=e66d9abbb271c3d08589c09afce4afc80de2d3b6
-pkgver=5.4.1.7
-pkgrel=2
+_gitcommit=8eb8f7d5e74787049316fef1f4d09f2e9e2d6968
+pkgver=5.10.1.47
+pkgrel=1
 pkgdesc='Free implementation of the .NET platform including runtime and compiler (mingw-w64)'
 url='http://www.mono-project.com/'
 arch=('any')
@@ -121,7 +121,7 @@ build() {
   
   make get-monolite-latest
   mkdir -p ./mono/mini/lib/mono/4.5/
-  cp -R ./mcs/class/lib/monolite-win32/1050400003/* ./mono/mini/lib/mono/4.5/
+  cp -R ./mcs/class/lib/monolite-win32/1051000004/* ./mono/mini/lib/mono/4.5/
 
   make
   make -C mcs/jay
@@ -134,7 +134,7 @@ package() {
   
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
   # Fix paths in bin directory
-  for f in ${pkgdir}${MINGW_PREFIX}/bin/{al,al2,caspol,cccheck,ccrewrite,cert2spc,certmgr,cert-sync,chktrust,crlupdate,csc,csharp,csi,disco,dmcs,dtd2rng,dtd2xsd,gacutil,gacutil2,genxs,httpcfg,ikdasm,ilasm,installvst,lc,macpack,makecert,mconfig,mcs,mdassembler,mdbrebase,mdoc,mdoc-assemble,mdoc-export-html,mdoc-export-msxdoc,mdoc-update,mdoc-validate,mdvalidater,mkbundle,mod,mono-api-html,mono-api-info,mono-cil-strip,mono-configuration-crypto,monodocer,monodocs2html,monodocs2slashdoc,mono-find-provides,mono-find-requires,monolinker,monop,monop2,mono-package-runtime,mono-service,mono-service2,mono-shlib-cop,mono-symbolicate,mono-test-install,mono-xmltool,mozroots,nunit-console,nunit-console2,nunit-console4,pdb2mdb,permview,peverify,prj2make,resgen,resgen2,secutil,setreg,sgen,signcode,sn,soapsuds,sqlmetal,sqlsharp,svcutil,wsdl,wsdl2,xbuild,xsd}; do
+  for f in ${pkgdir}${MINGW_PREFIX}/bin/{al,al2,caspol,cccheck,ccrewrite,cert2spc,certmgr,cert-sync,chktrust,crlupdate,csc,csharp,csi,disco,dmcs,dtd2rng,dtd2xsd,gacutil,gacutil2,genxs,httpcfg,ikdasm,ilasm,installvst,lc,macpack,makecert,mconfig,mcs,mdassembler,mdbrebase,mdoc,mdoc-assemble,mdoc-export-html,mdoc-export-msxdoc,mdoc-update,mdoc-validate,mdvalidater,mkbundle,mod,mono-api-html,mono-api-info,mono-cil-strip,mono-configuration-crypto,monodocer,monodocs2html,monodocs2slashdoc,mono-find-provides,mono-find-requires,monolinker,monop,monop2,mono-package-runtime,mono-service,mono-service2,mono-shlib-cop,mono-symbolicate,mono-test-install,mono-xmltool,mozroots,nunit-console,nunit-console2,nunit-console4,pdb2mdb,permview,peverify,resgen,resgen2,secutil,setreg,sgen,signcode,sn,soapsuds,sqlmetal,sqlsharp,svcutil,wsdl,wsdl2,xbuild,xsd}; do
     sed -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${f}
   done
 }


### PR DESCRIPTION
This updates mono to 5.10.1.47 and updates the bootstrap PKGBUILD
accordingly. Unfortunately, sometimes the build will fail due to failures with the git
sources.