### PR TITLE
cmake: Don't generate .orig artefacts from patches

### DIFF
--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -5,7 +5,7 @@ _realname=cmake
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.15.6
-pkgrel=1
+pkgrel=2
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
 url="https://www.cmake.org/"
@@ -53,7 +53,7 @@ apply_patch_with_msg() {
   for _patch in "$@"
   do
     msg2 "Applying $_patch"
-    patch -Nbp1 -i "${srcdir}/$_patch"
+    patch -Np1 -i "${srcdir}/$_patch"
   done
 }
 


### PR DESCRIPTION
All files in the Modules tree end up packaged in the final build,
including these patch-generated backups.

A *failed* patch will still generate .rej and .orig artefacts, so this
should not introduce any workflow issues for any package developers.