### PR TITLE
Doxygen - 1.8.14 - use ahttps source that does not cause an error,  r…

### DIFF
--- a/mingw-w64-doxygen/PKGBUILD
+++ b/mingw-w64-doxygen/PKGBUILD
@@ -4,37 +4,42 @@ _realname=doxygen
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.8.14
-pkgrel=2
+pkgrel=3
 pkgdesc="A documentation system for C++, C, Java, IDL and PHP (mingw-w64)"
 arch=('any')
 url="http://www.doxygen.org/"
 options=('strip' 'staticlibs')
 license=('GPL')
-depends=(#"${MINGW_PACKAGE_PREFIX}-clang"
+depends=("${MINGW_PACKAGE_PREFIX}-clang"
          "${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libiconv"
          "${MINGW_PACKAGE_PREFIX}-sqlite3"
          "${MINGW_PACKAGE_PREFIX}-xapian-core")
-makedepends=(#"${MINGW_PACKAGE_PREFIX}-clang-tools-extra"
+makedepends=("${MINGW_PACKAGE_PREFIX}-clang-tools-extra"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
-             #"${MINGW_PACKAGE_PREFIX}-polly"
+             "${MINGW_PACKAGE_PREFIX}-polly"
              "${MINGW_PACKAGE_PREFIX}-python2"
-             #"${MINGW_PACKAGE_PREFIX}-qt5"
+             "${MINGW_PACKAGE_PREFIX}-qt5"
              'flex'
              'bison')
 optdepends=("${MINGW_PACKAGE_PREFIX}-qt5")
-source=("https://ftp.stack.nl/pub/users/dimitri/${_realname}-${pkgver}.src.tar.gz"
+source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/doxygen/doxygen/archive/Release_${pkgver//./_}.tar.gz"
         'cmake-mingw.patch'
         'fix-casts.patch')
-sha256sums=('d1757e02755ef6f56fd45f1f4398598b920381948d6fcfa58f5ca6aa56f59d4d'
+noextract=("${_realname}-${pkgver}.tar.gz")
+sha256sums=('18bc3790b4d5f4d57cb8ee0a77dd63a52518f3f70d7fdff868a7ce7961a6edc3'
             'c760a8d583c1d27ef7dbdc7e43ec6bc9d4af8ead6fdb95d539b4857f2c41dbf6'
             '0cbf92d80e757287bfe1bb86168751de8a467e31e8ed26baf7c2b75450ce1f4c')
 
 prepare() {
-  cd "${srcdir}/${_realname}-${pkgver}"
-
+# We have to work around bsdtar's problem with symlinks
+  cd "${srcdir}"
+  tar zxf doxygen-1.8.14.tar.gz >> /dev/nul | true
+  
+  cd "${srcdir}/${_realname}-Release_${pkgver//./_}"
+  cp addon/doxmlparser/src/doxmlintf.h addon/doxmlparser/include/doxmlintf.
   patch -p1 -i "${srcdir}/cmake-mingw.patch"
   patch -p1 -i "${srcdir}/fix-casts.patch"
 }
@@ -53,17 +58,17 @@ build() {
     -Dbuild_wizard=ON \
     -Dbuild_search=ON \
     -Duse_sqlite3=ON \
-    -Duse_libclang=OFF \
+    -Duse_libclang=ON \
     -Dbuild_parse=ON \
-    ../${_realname}-${pkgver}
+    "../${_realname}-Release_${pkgver//./_}"
 
   # fix some generated makefiles: replace LLVM-NOTFOUND by the path to LLVM.dll
-  llvm_path_mixed=$(cygpath -m `which LLVM.dll`)
-  llvm_path_unix=$(echo ${llvm_path_mixed} | sed 's|C:|/C|')
-  sed -e "s|\(bin/.*\.exe: \)LLVM-NOTFOUND|\1${llvm_path_mixed}|" \
-      -e "s|\(.*libclangBasic.a \)LLVM-NOTFOUND|\1${llvm_path_unix}|" \
-      -i ./addon/doxyparse/CMakeFiles/doxyparse.dir/build.make \
-         ./src/CMakeFiles/doxygen.dir/build.make
+#  llvm_path_mixed=$(cygpath -m `which LLVM.dll`)
+#  llvm_path_unix=$(echo ${llvm_path_mixed} | sed 's|C:|/C|')
+#  sed -e "s|\(bin/.*\.exe: \)LLVM-NOTFOUND|\1${llvm_path_mixed}|" \
+#      -e "s|\(.*libclangBasic.a \)LLVM-NOTFOUND|\1${llvm_path_unix}|" \
+#      -i ./addon/doxyparse/CMakeFiles/doxyparse.dir/build.make \
+#         ./src/CMakeFiles/doxygen.dir/build.make
 
   make
 }


### PR DESCRIPTION
…eenable LLVM support and uncomment qt5 in makedepends.  It turns out that the LLVM workaround was not needed.