### PR TITLE
openjpeg2 - 2.3.0 - Fixes for a build issue on my computer with Java

### DIFF
--- a/mingw-w64-openjpeg2/0007-disable-jpip-client.patch
+++ b/mingw-w64-openjpeg2/0007-disable-jpip-client.patch
@@ -1,0 +1,25 @@
+--- openjpeg-2.3.0/CMakeLists.txt.orig	2018-08-23 01:11:20.224502000 -0400
++++ openjpeg-2.3.0/CMakeLists.txt	2018-08-23 01:13:11.209812900 -0400
+@@ -265,6 +265,7 @@ option(BUILD_JPWL "Build the JPWL librar
+ option(BUILD_JPIP "Build the JPIP library and executables." OFF)
+ if(BUILD_JPIP)
+   option(BUILD_JPIP_SERVER "Build the JPIP server." OFF)
++  option(BUILD_JPIP_CLIENT "Build the JPIP client (Java)." OFF)
+ endif()
+ option(BUILD_VIEWER "Build the OPJViewer executable (C++)" OFF)
+ option(BUILD_JAVA "Build the openjpeg jar (Java)" OFF)
+--- openjpeg-2.3.0/src/bin/jpip/CMakeLists.txt.orig	2018-08-23 01:13:49.781712900 -0400
++++ openjpeg-2.3.0/src/bin/jpip/CMakeLists.txt	2018-08-23 01:15:11.096739600 -0400
+@@ -56,6 +56,7 @@ add_executable(${exe} ${exe}.c)
+     )
+ endforeach()
+ 
++if(BUILD_JPIP_CLIENT)
+ # Build the two java clients:
+ find_package(Java 1.5 COMPONENTS Development) # javac, jar
+ 
+@@ -159,3 +160,4 @@ if(Java_Development_FOUND AND Java_JAVAC
+ else()
+   message(WARNING "No java compiler found. Wont be able to build java viewer")
+ endif()
++endif()

--- a/mingw-w64-openjpeg2/PKGBUILD
+++ b/mingw-w64-openjpeg2/PKGBUILD
@@ -4,7 +4,7 @@ _realname=openjpeg
 pkgbase=mingw-w64-${_realname}2
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}2"
 pkgver=2.3.0
-pkgrel=2
+pkgrel=3
 pkgdesc="An open source JPEG 2000 codec (mingw-w64)"
 arch=('any')
 url="http://www.openjpeg.org"
@@ -23,13 +23,15 @@ source=(${_realname}-${pkgver}.tar.gz::https://github.com/uclouvain/openjpeg/arc
         0002-cmake-files-destination.patch
         0003-versioned-dlls.mingw.patch
         0005-sock-jpip.all.patch
-        0006-openjpeg-2.1.0-stdcall-for-all-win.patch)
+        0006-openjpeg-2.1.0-stdcall-for-all-win.patch
+        0007-disable-jpip-client.patch)
 sha256sums=('3dc787c1bb6023ba846c2a0d9b1f6e179f1cd255172bde9eb75b01f1e6c7d71a'
             '3f3bde353ca3432f157258164c5e3c345af82ca3a9d5a68f815c3030b01cbc32'
             '1af48e3b746c27ecbfbff22a13a30956b755bf560975b9128414f83f9db723ec'
             'b45bc20a761b0d8dfd039ee9443a12d95ddd89ce05683fe0510fb8061f608b78'
             'b7b22dca26d5fd98ca5bc6ce775bbbabebc0e10fcf07fd0afb54d580699b8312'
-            'e8c375faa317c819174b50aa43b6be61c108872661b014738c4a0cfa95aac919')
+            'e8c375faa317c819174b50aa43b6be61c108872661b014738c4a0cfa95aac919'
+            '50fdf8e2d565bce1f21cb06c1b4507da00ed3cfd752561d9df887a23959f5a1b')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -38,6 +40,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0003-versioned-dlls.mingw.patch
   patch -p1 -i ${srcdir}/0005-sock-jpip.all.patch
   #patch -p1 -i ${srcdir}/0006-openjpeg-2.1.0-stdcall-for-all-win.patch
+  patch -p1 -i ${srcdir}/0007-disable-jpip-client.patch
 }
 
 build() {


### PR DESCRIPTION
I identified an issue on my computer with the build and Java.  It turns out that the JPIP includes two clients that are written in Java that will be installed if you have Java installed.  Unofrtunately, the Java version 9.x does not work with the JDK 1.5 source-code.  In any case, MINGW-W64 does support Java and any setups (well, just say all bets are OFF).