### PR TITLE
bzip2: Switch the tarball source to a working URL. Fixes #4251

### DIFF
--- a/mingw-w64-bzip2/PKGBUILD
+++ b/mingw-w64-bzip2/PKGBUILD
@@ -13,7 +13,7 @@ license=("custom")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 options=('strip' 'staticlibs')
-source=("http://www.bzip.org/${pkgver}/bzip2-${pkgver}.tar.gz"
+source=("https://sources.archlinux.org/other/packages/bzip2/bzip2-${pkgver}.tar.gz"
         "bzip2-1.0.5-slash.patch"
         "bzip2-1.0.4-bzip2recover.patch"
         "bzgrep-debian-1.0.5-6.all.patch"


### PR DESCRIPTION
The original website is gone.
Use the one Arch uses for now..