### PR TITLE
bindtextdomain relocation: fix dirname=NULL crash

### DIFF
--- a/mingw-w64-gettext/00-relocatex-libintl-0.18.3.1.patch
+++ b/mingw-w64-gettext/00-relocatex-libintl-0.18.3.1.patch
@@ -142,7 +142,7 @@ index 2e7ada4..bd0cddd 100644
 -  dirname = saved_dirname;
 -#endif
 -  return (char *) dirname;
-+  if (!access (dirname, R_OK)) {
++  if (!dirname || !access (dirname, R_OK)) {
 +	  set_binding_values (domainname, &dirname, NULL);
 +#ifdef __EMX__
 +	  dirname = saved_dirname;

--- a/mingw-w64-gettext/PKGBUILD
+++ b/mingw-w64-gettext/PKGBUILD
@@ -5,7 +5,7 @@ _realname=gettext
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.19.8.1
-pkgrel=5
+pkgrel=6
 arch=('any')
 pkgdesc="GNU internationalization library (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-expat"
@@ -33,7 +33,7 @@ source=("https://ftp.gnu.org/pub/gnu/${_realname}/${_realname}-${pkgver}.tar.gz"
         122-Use-LF-as-newline-in-envsubst.patch)
 sha256sums=('ff942af0e438ced4a8b0ea4b0b6e0d6d657157c5e2364de57baa279c1c125c43'
             'SKIP'
-            '1741536dd342ae8ceaea15518d4f3b561ac1db981b6f6738e21c72035994c93a'
+            '030987c317279c27eea503ef257c7c3cf4ff947de8ea71d84fdf5eea802ee587'
             '8f51c320c104c94e1ab3c8630905185214ca0c7ecf5423f20001c8694ead454c'
             'bebc791443a739f91ace5bca1dba3d45d50dff92706fae7629d150e197d2f411'
             '51604823755d1ae669544bb9730c5a09b78b0f1b1978577c8604fbd6cafc073e'


### PR DESCRIPTION
According to bindtextdomain man passing NULL is allowed
and must be interpreted as current value request.
This behaviour is implemented in non-patched bindtextdomain version.

The relocatable bindtextdomain implementation crashed in strrchr()
call when dirname==NULL was passed: it tried to relocate
NULL dirname (and strdup(NULL) returns NULL).

This patch disables relocation attempt if dirname=NULL.

The user-visible problem that lead to the crash is NOT tightly-related.
I was using VERY experimental mingw64 location on win7: gedit.exe from
"D:\m\noshortname with spaces and non ascii абвг ææ\msys2\mingw64\bin\"
where "D:\m\noshortname with spaces and non ascii абвг ææ\msys2"
is a junction to the actual msys2 root D:\apps\msys2 and
"noshortname with spaces and non ascii абвг ææ" has no short 8.3-name.

Understanding that this is NOT very useful scenario,
I think that bindtextdomain should handle NULL value according to man
since it may lead to another problems in "normal" usages
if some app would call it with NULL (as allowed in the docs).

I didn't investigate why gtk passes NULL as a dirname in this setup,
but after this libintl fix - gedit.exe starts fine.
(even more - it started from link with non-BMP characters in its name)