### PR TITLE
gdk-pixbuf2: remove internal staticpixbufloader-gdiplus from the .pc …

### DIFF
--- a/mingw-w64-gdk-pixbuf2/PKGBUILD
+++ b/mingw-w64-gdk-pixbuf2/PKGBUILD
@@ -6,7 +6,7 @@ _realname=gdk-pixbuf2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.38.0
-pkgrel=1
+pkgrel=2
 pkgdesc="An image loading library (mingw-w64)"
 arch=('any')
 url="https://www.gtk.org/"
@@ -75,6 +75,8 @@ package() {
 
   sed -s "s|$(cygpath -m ${MINGW_PREFIX})|${MINGW_PREFIX}|g" -i "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/gdk-pixbuf-2.0.pc
   sed -s "s|$(cygpath -m ${MINGW_PREFIX})|${MINGW_PREFIX}|g" -i "${pkgdir}${MINGW_PREFIX}"/share/thumbnailers/gdk-pixbuf-thumbnailer.thumbnailer
+  # https://github.com/Alexpux/MINGW-packages/issues/4726
+  sed -s "s| -lstaticpixbufloader-gdiplus||g" -i "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/gdk-pixbuf-2.0.pc
 
   install -Dm644 "${srcdir}/gdk-pixbuf-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }


### PR DESCRIPTION
…file. Fixes #4726 