### PR TITLE
gtk3: Backport some fixes

### DIFF
--- a/mingw-w64-gtk3/0002-win32-Don-t-multiply-the-scroll-event-deltas-by-the-.patch
+++ b/mingw-w64-gtk3/0002-win32-Don-t-multiply-the-scroll-event-deltas-by-the-.patch
@@ -1,0 +1,50 @@
+From edc25ce56e43852fe2a223d43d7bb38d0f6f6eb6 Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Wed, 21 Nov 2018 20:34:29 +0100
+Subject: [PATCH 2/4] win32: Don't multiply the scroll event deltas by the
+ Windows scroll lines setting. See #1408
+
+GTK widgets expect the scroll deltas to be 1 or -1 and calculate a scroll value from that.
+Multiplying the delta by the Windows scroll line setting (which defaults to 3) results
+in a much larger delta and vastly different behaviour for running a GTK app on Windows
+vs on Linux. For example text view and tree view scroll by 9 lines per scroll wheel tick
+per default this way while on Linux it is around 3.
+
+Remove the multiplication for now.
+---
+ gdk/win32/gdkevents-win32.c | 14 --------------
+ 1 file changed, 14 deletions(-)
+
+diff --git a/gdk/win32/gdkevents-win32.c b/gdk/win32/gdkevents-win32.c
+index a410d5acce..34b9fbda9f 100644
+--- a/gdk/win32/gdkevents-win32.c
++++ b/gdk/win32/gdkevents-win32.c
+@@ -3075,25 +3075,11 @@ gdk_event_translate (MSG  *msg,
+ 
+       if (msg->message == WM_MOUSEWHEEL)
+         {
+-          UINT lines_multiplier = 3;
+           event->scroll.delta_y = (gdouble) GET_WHEEL_DELTA_WPARAM (msg->wParam) / (gdouble) WHEEL_DELTA;
+-          /* -1 means that we should scroll in screens, not lines.
+-           * Right now GDK doesn't support that.
+-           */
+-          if (SystemParametersInfo (SPI_GETWHEELSCROLLLINES, 0, &lines_multiplier, 0) &&
+-              lines_multiplier != (UINT) -1)
+-            event->scroll.delta_y *= (gdouble) lines_multiplier;
+         }
+       else if (msg->message == WM_MOUSEHWHEEL)
+         {
+-          UINT chars_multiplier = 3;
+           event->scroll.delta_x = (gdouble) GET_WHEEL_DELTA_WPARAM (msg->wParam) / (gdouble) WHEEL_DELTA;
+-          /* There doesn't seem to be any indication that
+-           * h-scroll has an equivalent of the "screen" mode,
+-           * indicated by multiplier being (UINT) -1.
+-           */
+-          if (SystemParametersInfo (SPI_GETWHEELSCROLLCHARS, 0, &chars_multiplier, 0))
+-            event->scroll.delta_x *= (gdouble) chars_multiplier;
+         }
+       /* Positive delta scrolls up, not down,
+          see API documentation for WM_MOUSEWHEEL message.
+-- 
+2.19.2
+

--- a/mingw-w64-gtk3/0003-GDK-W32-set-default-settings-for-fontconfig.patch
+++ b/mingw-w64-gtk3/0003-GDK-W32-set-default-settings-for-fontconfig.patch
@@ -1,0 +1,62 @@
+From 398c4b91e1ed20fe3ce2f3f5099cab95e202107d Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Sat, 1 Dec 2018 10:38:10 +0100
+Subject: [PATCH 3/4] GDK W32: set default settings for fontconfig
+
+Enables hinting, antialiasing and set the subpixel orientation according to the
+active clear type setting. This ensures that font rendering with the fontconfig backend
+looks similar to the win32 backend, at least with the default system font.
+---
+ gdk/win32/gdkproperty-win32.c | 36 +++++++++++++++++++++++++++++++++++
+ 1 file changed, 36 insertions(+)
+
+diff --git a/gdk/win32/gdkproperty-win32.c b/gdk/win32/gdkproperty-win32.c
+index 06e8bb79fb..b0d432e9d2 100644
+--- a/gdk/win32/gdkproperty-win32.c
++++ b/gdk/win32/gdkproperty-win32.c
+@@ -333,6 +333,42 @@ _gdk_win32_screen_get_setting (GdkScreen   *screen,
+       g_value_set_boolean (value, TRUE);
+       return TRUE;
+     }
++  else if (strcmp ("gtk-xft-hinting", name) == 0)
++    {
++      GDK_NOTE(MISC, g_print ("gdk_screen_get_setting(\"%s\") : 1\n", name));
++      g_value_set_int (value, 1);
++      return TRUE;
++    }
++  else if (strcmp ("gtk-xft-antialias", name) == 0)
++    {
++      GDK_NOTE(MISC, g_print ("gdk_screen_get_setting(\"%s\") : 1\n", name));
++      g_value_set_int (value, 1);
++      return TRUE;
++    }
++  else if (strcmp ("gtk-xft-hintstyle", name) == 0)
++    {
++      g_value_set_static_string (value, "hintfull");
++      GDK_NOTE(MISC, g_print ("gdk_screen_get_setting(\"%s\") : %s\n", name, g_value_get_string (value)));
++      return TRUE;
++    }
++  else if (strcmp ("gtk-xft-rgba", name) == 0)
++    {
++      unsigned int orientation = 0;
++      if (SystemParametersInfoW (SPI_GETFONTSMOOTHINGORIENTATION, 0, &orientation, 0))
++        {
++          if (orientation == FE_FONTSMOOTHINGORIENTATIONRGB)
++            g_value_set_static_string (value, "rgb");
++          else if (orientation == FE_FONTSMOOTHINGORIENTATIONBGR)
++            g_value_set_static_string (value, "bgr");
++          else
++            g_value_set_static_string (value, "none");
++        }
++      else
++        g_value_set_static_string (value, "none");
++
++      GDK_NOTE(MISC, g_print ("gdk_screen_get_setting(\"%s\") : %s\n", name, g_value_get_string (value)));
++      return TRUE;
++    }
+   else if (strcmp ("gtk-font-name", name) == 0)
+     {
+       NONCLIENTMETRICS ncm;
+-- 
+2.19.2
+

--- a/mingw-w64-gtk3/0004-GDK-W32-Always-set-gtk-font-name-to-the-active-UI-fo.patch
+++ b/mingw-w64-gtk3/0004-GDK-W32-Always-set-gtk-font-name-to-the-active-UI-fo.patch
@@ -1,0 +1,144 @@
+From 717ad2fb15c656c44016aef9559291af685e5959 Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Thu, 29 Nov 2018 23:19:38 +0100
+Subject: [PATCH 4/4] GDK W32: Always set gtk-font-name to the active UI font.
+ Fixes #1484
+
+This makes apps use "Segoe UI 9" by default instead of whatever matches "Sans 10".
+It also cleans up the code and uses some new pango API while at it.
+
+This was previously disabled in 9e686d1fb5cb20 because it led to a poor glyph coverage
+on certain versions of Windows which don't default to "Segoe UI 9" (Chinese, Korean, ..)
+because the font fallback list was missing in pango.
+
+This is about to get fixed in https://gitlab.gnome.org/GNOME/pango/merge_requests/34
+so enable it again when we detect a new enough pango version.
+---
+ gdk/win32/gdkproperty-win32.c | 94 +++++++++++++++++------------------
+ 1 file changed, 45 insertions(+), 49 deletions(-)
+
+diff --git a/gdk/win32/gdkproperty-win32.c b/gdk/win32/gdkproperty-win32.c
+index b0d432e9d2..fa1d20fef4 100644
+--- a/gdk/win32/gdkproperty-win32.c
++++ b/gdk/win32/gdkproperty-win32.c
+@@ -27,6 +27,7 @@
+ #include <string.h>
+ #include <stdlib.h>
+ #include <glib/gprintf.h>
++#include <pango/pangowin32.h>
+ 
+ #include "gdkscreen.h"
+ #include "gdkproperty.h"
+@@ -239,6 +240,32 @@ _gdk_win32_window_delete_property (GdkWindow *window,
+     }
+ }
+ 
++static gchar*
++_get_system_font_name (HDC hdc)
++{
++  NONCLIENTMETRICSW ncm;
++  PangoFontDescription *font_desc;
++  gchar *result, *font_desc_string;
++  int logpixelsy;
++  gint font_size;
++
++  ncm.cbSize = sizeof(NONCLIENTMETRICSW);
++  if (!SystemParametersInfoW (SPI_GETNONCLIENTMETRICS, ncm.cbSize, &ncm, 0))
++    return NULL;
++
++  logpixelsy = GetDeviceCaps (hdc, LOGPIXELSY);
++  font_desc = pango_win32_font_description_from_logfontw (&ncm.lfMessageFont);
++  font_desc_string = pango_font_description_to_string (font_desc);
++  pango_font_description_free (font_desc);
++
++  /* https://docs.microsoft.com/en-us/windows/desktop/api/wingdi/ns-wingdi-taglogfonta */
++  font_size = -MulDiv (ncm.lfMessageFont.lfHeight, 72, logpixelsy);
++  result = g_strdup_printf ("%s %d", font_desc_string, font_size);
++  g_free (font_desc_string);
++
++  return result;
++}
++
+ /*
+   For reference, from gdk/x11/gdksettings.c:
+ 
+@@ -371,58 +398,27 @@ _gdk_win32_screen_get_setting (GdkScreen   *screen,
+     }
+   else if (strcmp ("gtk-font-name", name) == 0)
+     {
+-      NONCLIENTMETRICS ncm;
+-      CPINFOEX cpinfoex_default, cpinfoex_curr_thread;
+-      OSVERSIONINFO info;
+-      BOOL result_default, result_curr_thread;
+-
+-      info.dwOSVersionInfoSize = sizeof (OSVERSIONINFO);
+-
+-      /* TODO: Fallback to using Pango on Windows 8 and later,
+-       * as this method of handling gtk-font-name does not work
+-       * well there, where garbled text will be displayed for texts
+-       * that are not supported by the default menu font.  Look for
+-       * whether there is a better solution for this on Windows 8 and
+-       * later
+-       */
+-      if (!GetVersionEx (&info) ||
+-          info.dwMajorVersion > 6 ||
+-          (info.dwMajorVersion == 6 && info.dwMinorVersion >= 2))
+-        return FALSE;
+-
+-      /* check whether the system default ANSI codepage matches the
+-       * ANSI code page of the running thread.  If so, continue, otherwise
+-       * fall back to using Pango to handle gtk-font-name
+-       */
+-      result_default = GetCPInfoEx (CP_ACP, 0, &cpinfoex_default);
+-      result_curr_thread = GetCPInfoEx (CP_THREAD_ACP, 0, &cpinfoex_curr_thread);
+-
+-      if (!result_default ||
+-          !result_curr_thread ||
+-          cpinfoex_default.CodePage != cpinfoex_curr_thread.CodePage)
+-        return FALSE;
+-
+-      ncm.cbSize = sizeof(NONCLIENTMETRICS);
+-      if (SystemParametersInfo (SPI_GETNONCLIENTMETRICS, ncm.cbSize, &ncm, FALSE))
++      gchar *font_name = _get_system_font_name (_gdk_display_hdc);
++
++      if (font_name)
+         {
+-          /* Pango finally uses GetDeviceCaps to scale, we use simple
+-	   * approximation here.
+-	   */
+-          int nHeight = (0 > ncm.lfMenuFont.lfHeight ? - 3 * ncm.lfMenuFont.lfHeight / 4 : 10);
+-          if (OUT_STRING_PRECIS == ncm.lfMenuFont.lfOutPrecision)
+-            GDK_NOTE(MISC, g_print("gdk_screen_get_setting(%s) : ignoring bitmap font '%s'\n",
+-                                   name, ncm.lfMenuFont.lfFaceName));
+-          else if (ncm.lfMenuFont.lfFaceName && strlen(ncm.lfMenuFont.lfFaceName) > 0 &&
+-                   /* Avoid issues like those described in bug #135098 */
+-                   g_utf8_validate (ncm.lfMenuFont.lfFaceName, -1, NULL))
++          /* The pango font fallback list got fixed during 1.43, before that
++           * using anything but "Segoe UI" would lead to a poor glyph coverage */
++          if (pango_version_check (1, 43, 0) != NULL &&
++              g_ascii_strncasecmp (font_name, "Segoe UI", strlen ("Segoe UI")) != 0)
+             {
+-              char *s = g_strdup_printf ("%s %d", ncm.lfMenuFont.lfFaceName, nHeight);
+-              GDK_NOTE(MISC, g_print("gdk_screen_get_setting(%s) : %s\n", name, s));
+-              g_value_set_string (value, s);
+-
+-              g_free(s);
+-              return TRUE;
++              g_free (font_name);
++              return FALSE;
+             }
++
++          GDK_NOTE(MISC, g_print("gdk_screen_get_setting(\"%s\") : %s\n", name, font_name));
++          g_value_take_string (value, font_name);
++          return TRUE;
++        }
++      else
++        {
++          g_warning ("gdk_screen_get_setting: Detecting the system font failed");
++          return FALSE;
+         }
+     }
+ 
+-- 
+2.19.2
+

--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gtk3
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.24.1
-pkgrel=1
+pkgrel=2
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
 url="https://www.gtk.org/"
@@ -28,15 +28,24 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-shared-mime-info")
 options=('strip' '!debug' 'staticlibs')
 source=("https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}.tar.xz"
-        "0001-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch")
+        "0001-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch"
+        "0002-win32-Don-t-multiply-the-scroll-event-deltas-by-the-.patch"
+        "0003-GDK-W32-set-default-settings-for-fontconfig.patch"
+        "0004-GDK-W32-Always-set-gtk-font-name-to-the-active-UI-fo.patch")
 sha256sums=('68387be307b99aadcdc653561d7a2a7f0113b93561fb18ded7075ec9ced5b02f'
-            'f6f8019e21b2932ee2cfb3b261d57b79f6492d4f0a61f9fbf5b8edd193758d9a')
+            'f6f8019e21b2932ee2cfb3b261d57b79f6492d4f0a61f9fbf5b8edd193758d9a'
+            'a8693c23cb2dc4e261ead23c7613557e6d16c5f6dd7f2b965f348a3ce087f5cb'
+            '10654e00a19f45e83bd1531336e190346061099f36c802351689a45cc5ffeacb'
+            '4caf249fcdb2e77d968cfcf1a8b1ddee31408fc4ff0b8a20d51de83060f12aa4')
 
 prepare() {
   cd "${srcdir}/gtk+-${pkgver}"
 
   # https://bugzilla.gnome.org/show_bug.cgi?id=778791
   patch -p1 -i "${srcdir}"/0001-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch
+  patch -p1 -i "${srcdir}"/0002-win32-Don-t-multiply-the-scroll-event-deltas-by-the-.patch
+  patch -p1 -i "${srcdir}"/0003-GDK-W32-set-default-settings-for-fontconfig.patch
+  patch -p1 -i "${srcdir}"/0004-GDK-W32-Always-set-gtk-font-name-to-the-active-UI-fo.patch
 
   NOCONFIGURE=1 ./autogen.sh
 }

--- a/mingw-w64-gtk3/gtk3-i686.install
+++ b/mingw-w64-gtk3/gtk3-i686.install
@@ -4,16 +4,6 @@ post_install() {
   mingw32/bin/gtk-update-icon-cache-3.0 -q -t -f mingw32/share/icons/hicolor
   mingw32/bin/gtk-update-icon-cache-3.0 -q -t -f mingw32/share/icons/Adwaita
   mingw32/bin/glib-compile-schemas.exe mingw32/share/glib-2.0/schemas
-
-  settingsfile=mingw32/etc/gtk-3.0/settings.ini
-  if test ! -f $settingsfile
-  then
-    echo [Settings]>>$settingsfile
-    echo gtk-xft-antialias=1>>$settingsfile
-    echo gtk-xft-hinting=1>>$settingsfile
-    echo gtk-xft-hintstyle=hintfull>>$settingsfile
-    echo gtk-xft-rgba=rgb>>$settingsfile
-  fi
 }
 
 post_upgrade() {

--- a/mingw-w64-gtk3/gtk3-x86_64.install
+++ b/mingw-w64-gtk3/gtk3-x86_64.install
@@ -4,16 +4,6 @@ post_install() {
   mingw64/bin/gtk-update-icon-cache-3.0 -q -t -f mingw64/share/icons/hicolor
   mingw64/bin/gtk-update-icon-cache-3.0 -q -t -f mingw64/share/icons/Adwaita
   mingw64/bin/glib-compile-schemas.exe mingw64/share/glib-2.0/schemas
-
-  settingsfile=mingw64/etc/gtk-3.0/settings.ini
-  if test ! -f $settingsfile
-  then
-    echo [Settings]>>$settingsfile
-    echo gtk-xft-antialias=1>>$settingsfile
-    echo gtk-xft-hinting=1>>$settingsfile
-    echo gtk-xft-hintstyle=hintfull>>$settingsfile
-    echo gtk-xft-rgba=rgb>>$settingsfile
-  fi
 }
 
 post_upgrade() {


### PR DESCRIPTION
* Fix the default scrolling sensitivity
* Make gtk use the default font on Windows 8/10
* Adds defaults for gtk fontconfig so we can drop the settings.ini

All commited upstream.