### PR TITLE
Add mingw-w64-libserialport-git package

### DIFF
--- a/mingw-w64-libserialport-git/PKGBUILD
+++ b/mingw-w64-libserialport-git/PKGBUILD
@@ -1,0 +1,50 @@
+_realname=libserialport
+pkgbase="mingw-w64-${_realname}-git"
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
+pkgver=r318.a84ffb5
+pkgrel=1
+pkgdesc='A minimal, cross-platform shared library for for writing software that uses serial ports (git version)'
+arch=('any')
+url="http://sigrok.org/wiki/Libserialport"
+license=('LGPL3')
+makedepends=(
+  autoconf automake libtool make pkg-config git
+  "${MINGW_PACKAGE_PREFIX}-gcc"
+)
+conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+source=(${_realname}::"git://sigrok.org/${_realname}")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "${srcdir}/${_realname}"
+  printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+prepare() {
+  cd "${srcdir}/${_realname}"
+  ./autogen.sh
+}
+
+build() {
+  [[ -d "build-${MINGW_CHOST}" ]] && rm -rf "build-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
+  cd "build-${MINGW_CHOST}"
+
+  "../${_realname}/configure" \
+    --prefix="$MINGW_PREFIX" \
+    --build="$MINGW_CHOST" \
+    --host="$MINGW_CHOST" \
+    --target="$MINGW_CHOST" \
+    --enable-shared \
+    --enable-static
+
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR="${pkgdir}" install
+  install -Dm644 "${srcdir}"/${_realname}/COPYING "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}2/COPYING
+}
+


### PR DESCRIPTION
libserialport is a minimal, cross-platform shared library for for writing software that uses serial ports.

/cc @uwehermann