### PR TITLE
hexyl: add hexyl

### DIFF
--- a/mingw-w64-hexyl/PKGBUILD
+++ b/mingw-w64-hexyl/PKGBUILD
@@ -1,0 +1,29 @@
+# Maintainer: yumetodo <yume-wikijp@live.jp>
+
+_realname=hexyl
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.3.1
+pkgrel=1
+pkgdesc="A command-line hex viewer"
+arch=('any')
+url="https://github.com/sharkdp/hexyl"
+license=('APACHE' 'MIT')
+depends=()
+makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
+source=(
+  "git+https://github.com/sharkdp/hexyl.git#tag=v${pkgver}"
+)
+sha256sums=(
+  'SKIP'
+)
+
+build() {
+  cd "${srcdir}/${_realname}"
+  cargo build --release
+}
+
+package() {
+  cd "${srcdir}/${_realname}"
+  install -Dm755 "target/release/${_realname}" "${pkgdir}${MINGW_PREFIX}/bin/${_realname}"
+}


### PR DESCRIPTION
`hexyl` is a simple hex viewer for the terminal. It uses a colored output to distinguish different categories of bytes (NULL bytes, printable ASCII characters, ASCII whitespace characters, other ASCII characters and non-ASCII).

https://github.com/sharkdp/hexyl