### PR TITLE
mingw-w64-cmake - Update to latest version

### DIFF
--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=cmake
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.12.4
+pkgver=3.13.2
 pkgrel=1
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
@@ -31,7 +31,7 @@ source=("https://www.cmake.org/files/v${pkgver%.*}/${_realname}-${pkgver}.tar.gz
         "0006-pkg-config-Add-dont-define-prefix-when-PKG_CONFIG_WI.patch"
         "0007-Do-not-generate-import-libs-for-exes.patch"
         "0008-Output-line-numbers-in-callstacks.patch")
-sha256sums=('5255584bfd043eb717562cff8942d472f1c0e4679c4941d84baadaa9b28e3194'
+sha256sums=('c925e7d2c5ba511a69f43543ed7b4182a7d446c274c7480d0e42cd933076ae25'
             'e747f6a2de187d1ad469872432a2afd15252dafe4babf5b2c713372c864ef8ba'
             '77763df03e8a9ca66c3f9368fe7e1fc36bb041455733258d73aeb40246a61354'
             '4402730b932e94630beecbc596fe33868338b162f200e8c0464ac71acf4b0fbe'
@@ -65,8 +65,9 @@ prepare() {
   cd ${_realname}-${pkgver}
   apply_patch_with_msg \
     0001-Windows-Add-missing-stringapiset.h-include.patch \
-    0003-Disable-response-files-for-MSYS-Generator.patch \
-    0004-Implement-Qt5-static-plugin-support.patch \
+    0003-Disable-response-files-for-MSYS-Generator.patch 
+#    0004-Implement-Qt5-static-plugin-support.patch \
+  apply_patch_with_msg \
     0005-Do-not-install-Qt-bundle-in-cmake-gui.patch \
     0006-pkg-config-Add-dont-define-prefix-when-PKG_CONFIG_WI.patch \
     0007-Do-not-generate-import-libs-for-exes.patch \


### PR DESCRIPTION
I also disabled "0004-Implement-Qt5-static-plugin-support.patch" because that failed to merge.  I was able to use mingw-w64-PKGBUILD-common/build-kf5 with this but there was another failure with kcrash having to do with failing to find "QT:WinExtras".