### PR TITLE
New package: CLBlast

### DIFF
--- a/mingw-w64-clblast/PKGBUILD
+++ b/mingw-w64-clblast/PKGBUILD
@@ -1,0 +1,66 @@
+# Maintainer: Peter Budai <peterbudai at hotmail.com>
+
+_realname=clblast
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.5.0
+pkgrel=1
+pkgdesc="Tuned OpenCL BLAS (mingw-w64)"
+arch=('any')
+url='https://github.com/CNugteren/CLBlast'
+license=('Apache 2.0')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+            "${MINGW_PACKAGE_PREFIX}-opencl-headers"
+            "${MINGW_PACKAGE_PREFIX}-opencl-icd")
+
+options=('strip' 'staticlibs')
+source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/CNugteren/${_realname}/archive/${pkgver}.tar.gz")
+sha256sums=('b3198d84d175fd18b0674c0c36f5fb8b7c61a00662afb8596eb5b0b9ab98630c')
+
+prepare() {
+  cd "${srcdir}"
+}
+
+build() {
+  cd "${srcdir}"/${_realname}-${pkgver}
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake \
+      -G'MSYS Makefiles' \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      "${extra_config[@]}" \
+      ../${_realname}-${pkgver}
+
+  make
+}
+
+
+check() {
+  cd "${srcdir}"/build-${CARCH}
+  #make check
+}
+
+package() {
+  cd "${srcdir}"/build-${CARCH}
+  make install DESTDIR="${pkgdir}"
+
+  install -Dm644 ${srcdir}/${_realname}-${pkgver}/LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+
+  # move the dll to bin
+  mv "${pkgdir}${MINGW_PREFIX}/lib/libclblast.dll" "${pkgdir}${MINGW_PREFIX}/bin"
+
+  local WINPREFIX=$(cygpath -wm ${MINGW_PREFIX})
+  # Fix paths
+  sed -i "s|${WINPREFIX}|${MINGW_PREFIX}|g" \
+    ${pkgdir}${MINGW_PREFIX}/lib/cmake/CLBlast/CLBlastConfig.cmake \
+    ${pkgdir}${MINGW_PREFIX}/lib/cmake/CLBlast/CLBlastConfig-release.cmake
+}

--- a/mingw-w64-opencl-icd-git/01-OpenCL-icd-mingw.patch
+++ b/mingw-w64-opencl-icd-git/01-OpenCL-icd-mingw.patch
@@ -49,67 +49,67 @@
 +#endif
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1,41 +1,93 @@
+@@ -1,71 +1,93 @@
 -cmake_minimum_required (VERSION 2.6)
--
++cmake_minimum_required (VERSION 3.1)
+ 
 -project (OPENCL_ICD_LOADER)
--
--set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
++project(OPENCL_ICD_LOADER VERSION 2.1)
+ 
+-# The option below allows building the ICD Loader library as a shared library
+-# (ON, default) or a static library (OFF).
+-#
+-# Khronos OpenCL Working Group strongly recommends building and using the ICD
+-# loader as a shared library due to the following benefits:
+-#
+-# 1. The shared library can be updated independent of the application. This
+-#    allows releasing new fixes and features in the ICD loader without updating
+-#    the application.
+-#
+-#    In rare cases when there are backward-incompatible changes to the ICD
+-#    loader (due to platform requirements, for instance), using a shared
+-#    library allows updating the library to make the transition seamless to
+-#    installed applications.
+-#
+-# 2. On platforms that require the ICD mechanism there are multiple vendors
+-#    shipping their OpenCL implementations. The vendor installers collaborate
+-#    to make sure that the installed ICD shared library version is suitable for
+-#    working with all vendor implementations installed on the system.
+-#
+-#    If applications statically link to ICD Loader then that version of the ICD
+-#    loader may not work with one or more installed vendor implementations.
+-#
+-# Using the OpenCL ICD loader as a static library is NOT recommended for
+-# end-user installations in general. However in some controlled environments it
+-# may be useful to simplify the build and distribution of the application. E.g.
+-# in test farms, or in cases where the end-user system configs are known in
+-# advance. Use it with discretion.
+-option (BUILD_SHARED_LIBS "Build shared libs" ON)
++option(BUILD_SHARED_LIBS "Build shared libs" ON)
++option(OPENCL_TESTS "Enable building tests" ON)
+ 
+ set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 -set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
--
--set (OPENCL_ICD_LOADER_SOURCES icd.c icd_dispatch.c)
--
++set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+ 
+ set (OPENCL_ICD_LOADER_SOURCES icd.c icd_dispatch.c)
+ 
 -if (WIN32)
 -    list (APPEND OPENCL_ICD_LOADER_SOURCES icd_windows.c icd_windows_hkr.c OpenCL.def OpenCL.rc)
 -    include_directories ($ENV{DXSDK_DIR}/Include)
 -else ()
--    list (APPEND OPENCL_ICD_LOADER_SOURCES icd_linux.c icd_exports.map)
--endif ()
--
++if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+     list (APPEND OPENCL_ICD_LOADER_SOURCES icd_linux.c icd_exports.map)
++else ()
++    list (APPEND OPENCL_ICD_LOADER_SOURCES icd_windows.c icd_windows_hkr.c OpenCL.rc)
++    include_directories ($ENV{DXSDK_DIR}/Include)
+ endif ()
+ 
 -# Change this to point to a directory containing OpenCL header directory "CL"
 -# OR copy OpenCL headers to ./inc/CL/
 -if (NOT DEFINED OPENCL_INCLUDE_DIRS)
 -    set (OPENCL_INCLUDE_DIRS ./inc)
 -endif ()
--
--include_directories (${OPENCL_INCLUDE_DIRS})
--
--add_library (OpenCL SHARED ${OPENCL_ICD_LOADER_SOURCES})
--set_target_properties (OpenCL PROPERTIES VERSION "1.2" SOVERSION "1")
--
--if (WIN32)
--    target_link_libraries (OpenCL cfgmgr32.lib)
--else()
--    if (APPLE)
--        set_target_properties (OpenCL PROPERTIES LINK_FLAGS "-pthread")
--    else ()
--        set_target_properties (OpenCL PROPERTIES LINK_FLAGS "-pthread -Wl,--version-script -Wl,${CMAKE_CURRENT_SOURCE_DIR}/icd_exports.map")
--    endif ()
--endif ()
--
--target_link_libraries (OpenCL ${CMAKE_DL_LIBS})
--
--enable_testing()
--add_subdirectory (test)
-+cmake_minimum_required (VERSION 3.1)
-+
-+project(OpenCL VERSION 2.1)
-+
-+option(BUILD_SHARED_LIBS "Build shared libs" ON)
-+option(OPENCL_TESTS "Enable building tests" ON)
-+
-+set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-+set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-+
-+set (OPENCL_ICD_LOADER_SOURCES icd.c icd_dispatch.c)
-+
-+if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
-+    list (APPEND OPENCL_ICD_LOADER_SOURCES icd_linux.c icd_exports.map)
-+else ()
-+    list (APPEND OPENCL_ICD_LOADER_SOURCES icd_windows.c icd_windows_hkr.c OpenCL.rc)
-+    include_directories ($ENV{DXSDK_DIR}/Include)
-+endif ()
-+
 +if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/inc")
 +    file(RENAME "${CMAKE_CURRENT_LIST_DIR}/inc" "${CMAKE_CURRENT_LIST_DIR}/include")
 +endif()
@@ -125,10 +125,12 @@
 +        set (OPENCL_INCLUDE_DIRS ./include)
 +    endif ()
 +endif()
-+
-+include_directories (${OPENCL_INCLUDE_DIRS})
-+
-+
+ 
+ include_directories (${OPENCL_INCLUDE_DIRS})
+ 
+-add_library (OpenCL SHARED ${OPENCL_ICD_LOADER_SOURCES})
+-set_target_properties (OpenCL PROPERTIES VERSION "1.2" SOVERSION "1")
+ 
 +add_library (OpenCL ${OPENCL_ICD_LOADER_SOURCES})
 +set_target_properties (OpenCL PROPERTIES VERSION "2.1" SOVERSION "1")
 +
@@ -137,12 +139,22 @@
 +endif ()
 +
 +find_package(Threads REQUIRED)
-+if (WIN32)
-+    target_link_libraries (OpenCL cfgmgr32.lib)
-+else()
+ if (WIN32)
+     target_link_libraries (OpenCL cfgmgr32.lib)
+ else()
+-    if (APPLE)
+-        set_target_properties (OpenCL PROPERTIES LINK_FLAGS "-pthread")
+-    else ()
+-        set_target_properties (OpenCL PROPERTIES LINK_FLAGS "-pthread -Wl,--version-script -Wl,${PROJECT_SOURCE_DIR}/icd_exports.map")
+-    endif ()
+-endif ()
+-
+-target_link_libraries (OpenCL ${CMAKE_DL_LIBS})
 +    target_link_libraries(OpenCL PRIVATE Threads::Threads ${CMAKE_DL_LIBS})
 +endif()
-+
+ 
+-enable_testing()
+-add_subdirectory (test)
 +#Installation
 +set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
 +set(config_install_dir "lib/cmake/${PROJECT_NAME}")
@@ -190,20 +202,6 @@
 +include(CMakeFindDependencyMacro)
 +find_dependency(Threads)
 +include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
---- a/icd_dispatch.c
-+++ b/icd_dispatch.c
-@@ -1442,8 +1442,9 @@ clGetExtensionFunctionAddressForPlatform(cl_platform_id platform,
- 
-     // fall back to vendor extension detection
- 
--    // FIXME Now that we have a platform id here, we need to validate that it isn't NULL, so shouldn't we have an errcode_ret
--    // KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(platform, CL_INVALID_PLATFORM);   
-+    // Now that we have a platform id here, we need to validate that it isn't NULL.
-+    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(platform, CL_INVALID_PLATFORM);   
-+
-     return platform->dispatch->clGetExtensionFunctionAddressForPlatform(
-         platform,
-         function_name);
 --- a/test/loader_test/test_create_calls.c
 +++ b/test/loader_test/test_create_calls.c
 @@ -174,12 +174,17 @@ int test_clGetPlatformIDs(const struct clGetPlatformIDs_st* data)

--- a/mingw-w64-opencl-icd-git/01-OpenCL-icd-mingw.patch
+++ b/mingw-w64-opencl-icd-git/01-OpenCL-icd-mingw.patch
@@ -1,0 +1,241 @@
+--- a/icd_windows_hkr.h	2019-01-21 23:29:54.652497400 +0100
++++ b/icd_windows_hkr.h	2019-01-21 23:28:42.455736800 +0100
+@@ -36,5 +36,46 @@
+  */
+ 
+ #include <stdbool.h>
++#include <guiddef.h>
+ 
+ bool khrIcdOsVendorsEnumerateHKR(void);
++
++typedef unsigned long int DEVPROPTYPE, *PDEVPROPTYPE;
++
++typedef GUID  DEVPROPGUID, *PDEVPROPGUID;
++typedef unsigned long int DEVPROPID,   *PDEVPROPID;
++
++typedef struct _DEVPROPKEY {
++    DEVPROPGUID fmtid;
++    DEVPROPID   pid;
++} DEVPROPKEY, *PDEVPROPKEY;
++
++#define CM_GETIDLIST_FILTER_PRESENT             (0x00000100)
++#define CM_GETIDLIST_FILTER_CLASS               (0x00000200)
++
++#define DEFINE_DEVPROPKEY(name, l, w1, w2, b1, b2, b3, b4, b5, b6, b7, b8, pid) extern const DEVPROPKEY DECLSPEC_SELECTANY name = { { l, w1, w2, { b1, b2,  b3,  b4,  b5,  b6,  b7,  b8 } }, pid }
++
++DEFINE_DEVPROPKEY(DEVPKEY_Device_ClassGuid,              0xa45c254e, 0xdf1c, 0x4efd, 0x80, 0x20, 0x67, 0xd1, 0x46, 0xa8, 0x50, 0xe0, 10);    // DEVPROP_TYPE_GUID
++#if !defined(__MINGW64__)
++#include <windows.h>
++
++#if defined (CMAPI)
++#undef CMAPI
++#endif
++
++#define CMAPI __stdcall 
++
++typedef _Return_type_success_(return == 0) DWORD        RETURN_TYPE;
++typedef RETURN_TYPE CONFIGRET;
++typedef DWORD DEVNODE, DEVINST;
++
++CMAPI CONFIGRET CM_Get_DevNode_PropertyW(
++  DEVINST          dnDevInst,
++  const DEVPROPKEY *PropertyKey,
++  DEVPROPTYPE      *PropertyType,
++  PBYTE            PropertyBuffer,
++  PULONG           PropertyBufferSize,
++  ULONG            ulFlags
++);
++
++#endif
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,41 +1,93 @@
+-cmake_minimum_required (VERSION 2.6)
+-
+-project (OPENCL_ICD_LOADER)
+-
+-set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+-set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+-
+-set (OPENCL_ICD_LOADER_SOURCES icd.c icd_dispatch.c)
+-
+-if (WIN32)
+-    list (APPEND OPENCL_ICD_LOADER_SOURCES icd_windows.c icd_windows_hkr.c OpenCL.def OpenCL.rc)
+-    include_directories ($ENV{DXSDK_DIR}/Include)
+-else ()
+-    list (APPEND OPENCL_ICD_LOADER_SOURCES icd_linux.c icd_exports.map)
+-endif ()
+-
+-# Change this to point to a directory containing OpenCL header directory "CL"
+-# OR copy OpenCL headers to ./inc/CL/
+-if (NOT DEFINED OPENCL_INCLUDE_DIRS)
+-    set (OPENCL_INCLUDE_DIRS ./inc)
+-endif ()
+-
+-include_directories (${OPENCL_INCLUDE_DIRS})
+-
+-add_library (OpenCL SHARED ${OPENCL_ICD_LOADER_SOURCES})
+-set_target_properties (OpenCL PROPERTIES VERSION "1.2" SOVERSION "1")
+-
+-if (WIN32)
+-    target_link_libraries (OpenCL cfgmgr32.lib)
+-else()
+-    if (APPLE)
+-        set_target_properties (OpenCL PROPERTIES LINK_FLAGS "-pthread")
+-    else ()
+-        set_target_properties (OpenCL PROPERTIES LINK_FLAGS "-pthread -Wl,--version-script -Wl,${CMAKE_CURRENT_SOURCE_DIR}/icd_exports.map")
+-    endif ()
+-endif ()
+-
+-target_link_libraries (OpenCL ${CMAKE_DL_LIBS})
+-
+-enable_testing()
+-add_subdirectory (test)
++cmake_minimum_required (VERSION 3.1)
++
++project(OpenCL VERSION 2.1)
++
++option(BUILD_SHARED_LIBS "Build shared libs" ON)
++option(OPENCL_TESTS "Enable building tests" ON)
++
++set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
++set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
++
++set (OPENCL_ICD_LOADER_SOURCES icd.c icd_dispatch.c)
++
++if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
++    list (APPEND OPENCL_ICD_LOADER_SOURCES icd_linux.c icd_exports.map)
++else ()
++    list (APPEND OPENCL_ICD_LOADER_SOURCES icd_windows.c icd_windows_hkr.c OpenCL.rc)
++    include_directories ($ENV{DXSDK_DIR}/Include)
++endif ()
++
++if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/inc")
++    file(RENAME "${CMAKE_CURRENT_LIST_DIR}/inc" "${CMAKE_CURRENT_LIST_DIR}/include")
++endif()
++
++if(APPLE) #for some reason on apple opencl is expected under OpenCL. And oddly enough, still need the include/CL version for ICD to build
++    set(opencl_include_dir "${CMAKE_CURRENT_BINARY_DIR}/include")
++    if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/include/CL")
++        file(COPY "${CMAKE_CURRENT_LIST_DIR}/include/CL/" DESTINATION "${opencl_include_dir}/OpenCL")
++    endif()
++    include_directories("${opencl_include_dir}")
++else()
++    if (NOT DEFINED OPENCL_INCLUDE_DIRS)
++        set (OPENCL_INCLUDE_DIRS ./include)
++    endif ()
++endif()
++
++include_directories (${OPENCL_INCLUDE_DIRS})
++
++
++add_library (OpenCL ${OPENCL_ICD_LOADER_SOURCES})
++set_target_properties (OpenCL PROPERTIES VERSION "2.1" SOVERSION "1")
++
++if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
++    set_target_properties (OpenCL PROPERTIES LINK_FLAGS "-Wl,--version-script -Wl,${CMAKE_SOURCE_DIR}/icd_exports.map")
++endif ()
++
++find_package(Threads REQUIRED)
++if (WIN32)
++    target_link_libraries (OpenCL cfgmgr32.lib)
++else()
++    target_link_libraries(OpenCL PRIVATE Threads::Threads ${CMAKE_DL_LIBS})
++endif()
++
++#Installation
++set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
++set(config_install_dir "lib/cmake/${PROJECT_NAME}")
++set(include_install_dir "include")
++
++set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
++set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
++set(targets_export_name "${PROJECT_NAME}Targets")
++set(namespace "${PROJECT_NAME}::")
++
++include(CMakePackageConfigHelpers)
++write_basic_package_version_file(
++    "${version_config}" COMPATIBILITY SameMajorVersion
++)
++
++configure_file("Config.cmake.in" "${project_config}" @ONLY)
++
++install(
++    TARGETS OpenCL
++    EXPORT "${targets_export_name}"
++    LIBRARY DESTINATION "lib"
++    ARCHIVE DESTINATION "lib"
++    RUNTIME DESTINATION "bin"
++    INCLUDES DESTINATION "${include_install_dir}"
++)
++
++install(
++    FILES "${project_config}" "${version_config}"
++    DESTINATION "${config_install_dir}"
++)
++
++install(
++    EXPORT "${targets_export_name}"
++    NAMESPACE "${namespace}"
++    DESTINATION "${config_install_dir}"
++)
++
++if(OPENCL_TESTS)
++    enable_testing()
++    add_subdirectory(test)
++endif ()
+--- /dev/null
++++ b/Config.cmake.in
+@@ -0,0 +1,3 @@
++include(CMakeFindDependencyMacro)
++find_dependency(Threads)
++include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
+--- a/icd_dispatch.c
++++ b/icd_dispatch.c
+@@ -1442,8 +1442,9 @@ clGetExtensionFunctionAddressForPlatform(cl_platform_id platform,
+ 
+     // fall back to vendor extension detection
+ 
+-    // FIXME Now that we have a platform id here, we need to validate that it isn't NULL, so shouldn't we have an errcode_ret
+-    // KHR_ICD_VALIDATE_HANDLE_RETURN_HANDLE(platform, CL_INVALID_PLATFORM);   
++    // Now that we have a platform id here, we need to validate that it isn't NULL.
++    KHR_ICD_VALIDATE_HANDLE_RETURN_ERROR(platform, CL_INVALID_PLATFORM);   
++
+     return platform->dispatch->clGetExtensionFunctionAddressForPlatform(
+         platform,
+         function_name);
+--- a/test/loader_test/test_create_calls.c
++++ b/test/loader_test/test_create_calls.c
+@@ -174,12 +174,17 @@ int test_clGetPlatformIDs(const struct clGetPlatformIDs_st* data)
+                 &param_val_ret_size );  
+ 
+         if (ret_val == CL_SUCCESS ){
+-            if(!strcmp(platform_name, "ICD_LOADER_TEST_OPENCL_STUB")) {
++            if (!strcmp(platform_name, "ICD_LOADER_TEST_OPENCL_STUB")) {
+                 platform = all_platforms[i];                
+             }
+         }
+     }
+ 
++    if (!platform) {
++        // The stub OpenCL not found.
++        return -2;
++    }
++
+ #if ENABLE_MISMATCHING_PRINTS
+     test_icd_app_log("Value returned: %d\n", ret_val);
+ #endif
+--- a/test/loader_test/test_program_objects.c
++++ b/test/loader_test/test_program_objects.c
+@@ -165,6 +165,11 @@ int test_clGetExtensionFunctionAddressForPlatform(const struct clGetExtensionFun
+                      platform,  
+                      data->func_name);
+ 
++    if (!platform) {
++        test_icd_app_log("No stub platform\n");
++        return -2;
++    }
++
+     return_value=clGetExtensionFunctionAddressForPlatform(platform,
+                                                         data->func_name);
+ 

--- a/mingw-w64-opencl-icd-git/PKGBUILD
+++ b/mingw-w64-opencl-icd-git/PKGBUILD
@@ -5,19 +5,26 @@ pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=15.261c128
+pkgver=19.c262c83
 pkgrel=1
 pkgdesc="OpenCL ICD Loader (mingw-w64)"
 arch=('any')
 url='https://github.com/KhronosGroup/OpenCL-ICD-Loader'
 license=('BSD')
 depends=("${MINGW_PACKAGE_PREFIX}-opencl-headers")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-cmake")
+makedepends=(git
+            "${MINGW_PACKAGE_PREFIX}-gcc"
+            "${MINGW_PACKAGE_PREFIX}-cmake")
 source=("${_realname}"::"git+https://github.com/KhronosGroup/OpenCL-ICD-Loader.git#branch=master"
         01-OpenCL-icd-mingw.patch)
 sha256sums=('SKIP'
-            'c67f682e0dbadf2480f147fc2cef4b4e6289c0e742983cac1f92c13ab6234071')
+            'abecccacbebba1cf05864adc412bfe13e5c42eb4f9d6563892e1e02d9a53164d')
+
+pkgver() {
+  cd "${srcdir}"/${_realname}
+  printf "%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
 
 prepare() {
   cd ${srcdir}/${_realname}

--- a/mingw-w64-opencl-icd-git/PKGBUILD
+++ b/mingw-w64-opencl-icd-git/PKGBUILD
@@ -1,0 +1,57 @@
+# Maintainer: Peter Budai <peterbudai at hotmail.com>
+
+_realname=opencl-icd
+pkgbase=mingw-w64-${_realname}-git
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=15.261c128
+pkgrel=1
+pkgdesc="OpenCL ICD Loader (mingw-w64)"
+arch=('any')
+url='https://github.com/KhronosGroup/OpenCL-ICD-Loader'
+license=('BSD')
+depends=("${MINGW_PACKAGE_PREFIX}-opencl-headers")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-cmake")
+source=("${_realname}"::"git+https://github.com/KhronosGroup/OpenCL-ICD-Loader.git#branch=master"
+        01-OpenCL-icd-mingw.patch)
+sha256sums=('SKIP'
+            'c67f682e0dbadf2480f147fc2cef4b4e6289c0e742983cac1f92c13ab6234071')
+
+prepare() {
+  cd ${srcdir}/${_realname}
+  patch -p1 -i "${srcdir}"/01-OpenCL-icd-mingw.patch
+}
+
+build() {
+  cd "${srcdir}"/${_realname}
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake \
+      -G'MSYS Makefiles' \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      "${extra_config[@]}" \
+      -DBUILD_{SHARED,STATIC}_LIBS=ON \
+      -DOPENCL_INCLUDE_DIRS=${MINGW_PREFIX}/include/CL \
+      -DOPENCL_TESTS=OFF \
+      ../${_realname}
+
+  make
+}
+
+package() {
+  cd "${srcdir}"/build-${CARCH}
+  make DESTDIR=${pkgdir} install
+
+  install -Dm644 ${srcdir}/${_realname}/LICENSE.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+}

--- a/mingw-w64-opencl-icd-git/PKGBUILD
+++ b/mingw-w64-opencl-icd-git/PKGBUILD
@@ -4,7 +4,6 @@ _realname=opencl-icd
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=19.c262c83
 pkgrel=1
 pkgdesc="OpenCL ICD Loader (mingw-w64)"


### PR DESCRIPTION
Two packages:
* **OpenCL-ICD**: this is an OpenCL ICD Loader, it compiles and installs an OpenCL shared and static library, subsequent OpenCL based libraries can link to the static version (this is also useful for Appveyor CI, which does not have OpenCL ICD at all).
* **CLBlast** package itself