### PR TITLE
Add mingw-w64-onigmo package

### DIFF
--- a/mingw-w64-onigmo/PKGBUILD
+++ b/mingw-w64-onigmo/PKGBUILD
@@ -1,0 +1,43 @@
+# Maintainer: Hiroshi Hatake <cosmo0920.wp@gmail.com>
+
+_realname=Onigmo
+_fullname=onigmo
+pkgbase=mingw-w64-${_fullname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_fullname}"
+pkgver=6.2.0
+pkgrel=1
+pkgdesc="A regular expressions library forked from Oniguruma. (mingw-w64)"
+arch=('any')
+license=('BSD')
+url="https://github.com/k-takata/Onigmo"
+options=('staticlibs')
+source=("https://github.com/k-takata/${_realname}/releases/download/${_realname}-${pkgver}/${_fullname}-${pkgver}.tar.gz")
+sha256sums=('c648496b5339953b925ebf44b8de356feda8d3428fa07dc1db95bfe2570feb76')
+prepare() {
+  cd ${srcdir}/${_realname}-${pkgver}
+
+  touch NEWS
+  touch ChangeLog
+  autoreconf -fi
+}
+
+build() {
+  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+
+  ../${_realname}-${pkgver}/configure \
+      --prefix=${MINGW_PREFIX} \
+      --build=${MINGW_CHOST} \
+      --host=${MINGW_CHOST} \
+      --target=${MINGW_CHOST} \
+      --enable-shared \
+      --enable-static
+
+  make
+}
+
+package() {
+  cd ${srcdir}/build-${MINGW_CHOST}
+  make install DESTDIR="${pkgdir}"
+}


### PR DESCRIPTION
Onigmo is a regular expressions library forked from Oniguruma. 
This package is different from Oniguruma.