### PR TITLE
Add PKGBUILDs for Corrade and Magnum

### DIFF
--- a/mingw-w64-corrade/PKGBUILD
+++ b/mingw-w64-corrade/PKGBUILD
@@ -1,0 +1,47 @@
+# Author: williamjcm <w.jcm59@gmail.com>
+# Contributor: mosra <mosra@centrum.cz>
+# Based on the Corrade Arch Linux PKGBUILD maintained by xyproto and the MSYS2/MinGW PKGBUILD templates
+
+_realname=corrade
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=2019.01
+pkgrel=1
+pkgdesc='C++11/C++14 multiplatform utility library'
+arch=('any')
+url='https://magnum.graphics/corrade/'
+license=('MIT')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake" "${MINGW_PACKAGE_PREFIX}-ninja" 'git')
+# The .tar.gz / .zip download contains symlinks (.travis.yml), making tar and
+# unzip on Windows grumpy because dangling symlinks are created. Could be fixed
+# by manually extracting everything except symlinks, but that's hard to
+# maintain. Downloading a Git tag works.
+source=("${_realname}-${pkgver}"::"git+https://github.com/mosra/corrade.git#tag=v$pkgver")
+sha1sums=('SKIP')
+
+build() {
+    mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+
+    declare -a extra_config
+    if check_option "debug" "n"; then
+        extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+    else
+        extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+    fi
+
+    MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+        ${MINGW_PREFIX}/bin/cmake \
+            -G'Ninja' \
+            -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+            "${extra_config[@]}" \
+            ../${_realname}-${pkgver}
+    ninja
+}
+
+package() {
+    cd "${srcdir}"/build-${CARCH}
+    DESTDIR="${pkgdir}" ninja install
+
+    install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" \
+        "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}

--- a/mingw-w64-magnum-integration/PKGBUILD
+++ b/mingw-w64-magnum-integration/PKGBUILD
@@ -1,0 +1,52 @@
+# Author: williamjcm <w.jcm59@gmail.com>
+# Contributor: mosra <mosra@centrum.cz>
+# Based on the AUR PKGBUILD from https://github.com/mosra/magnum-integration and the MSYS2/MinGW PKGBUILD templates
+
+_realname=magnum-integration
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=2019.01
+pkgrel=1
+pkgdesc='Integration libraries for the Magnum C++11/C++14 graphics engine'
+arch=('any')
+url='https://magnum.graphics/'
+license=('MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-magnum>=$pkgver"
+         "${MINGW_PACKAGE_PREFIX}-bullet"
+         "${MINGW_PACKAGE_PREFIX}-glm")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake" "${MINGW_PACKAGE_PREFIX}-ninja" 'git')
+# The .tar.gz / .zip download contains symlinks (.travis.yml), making tar and
+# unzip on Windows grumpy because dangling symlinks are created. Could be fixed
+# by manually extracting everything except symlinks, but that's hard to
+# maintain. Downloading a Git tag works.
+source=("${_realname}-${pkgver}"::"git+https://github.com/mosra/magnum-integration.git#tag=v$pkgver")
+sha1sums=('SKIP')
+
+build() {
+    mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+
+    declare -a extra_config
+    if check_option "debug" "n"; then
+        extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+    else
+        extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+    fi
+
+    MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+        ${MINGW_PREFIX}/bin/cmake \
+            -G'Ninja' \
+            -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+            -DWITH_BULLET=ON \
+            -DWITH_GLM=ON \
+            "${extra_config[@]}" \
+            ../${_realname}-${pkgver}
+    ninja
+}
+
+package() {
+    cd "${srcdir}"/build-${CARCH}
+    DESTDIR="${pkgdir}" ninja install
+
+    install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" \
+        "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}

--- a/mingw-w64-magnum-plugins/PKGBUILD
+++ b/mingw-w64-magnum-plugins/PKGBUILD
@@ -1,0 +1,73 @@
+# Author: williamjcm <w.jcm59@gmail.com>
+# Contributor: mosra <mosra@centrum.cz>
+# Based on the magnum-plugins Arch Linux PKGBUILD maintained by xyproto and the MSYS2/MinGW PKGBUILD templates
+
+_realname=magnum-plugins
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=2019.01
+pkgrel=1
+pkgdesc='Plugins for the Magnum C++11/C++14 graphics engine'
+arch=('any')
+url='https://magnum.graphics/'
+license=('MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-magnum>=$pkgver"
+         "${MINGW_PACKAGE_PREFIX}-assimp"
+         "${MINGW_PACKAGE_PREFIX}-devil"
+         "${MINGW_PACKAGE_PREFIX}-freetype"
+         "${MINGW_PACKAGE_PREFIX}-harfbuzz"
+         "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
+         "${MINGW_PACKAGE_PREFIX}-libpng")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake" "${MINGW_PACKAGE_PREFIX}-ninja" 'git')
+# The .tar.gz / .zip download contains symlinks (.travis.yml), making tar and
+# unzip on Windows grumpy because dangling symlinks are created. Could be fixed
+# by manually extracting everything except symlinks, but that's hard to
+# maintain. Downloading a Git tag works.
+source=("${_realname}-${pkgver}"::"git+https://github.com/mosra/magnum-plugins.git#tag=v$pkgver")
+sha1sums=('SKIP')
+
+build() {
+    mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+
+    declare -a extra_config
+    if check_option "debug" "n"; then
+        extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+    else
+        extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+    fi
+
+    MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+        ${MINGW_PREFIX}/bin/cmake \
+            -G'Ninja' \
+            -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+            -DWITH_ASSIMPIMPORTER=ON \
+            -DWITH_DDSIMPORTER=ON \
+            -DWITH_DEVILIMAGEIMPORTER=ON \
+            -DWITH_DRFLACAUDIOIMPORTER=ON \
+            -DWITH_DRWAVAUDIOIMPORTER=ON \
+            -DWITH_FREETYPEFONT=ON \
+            -DWITH_HARFBUZZFONT=ON \
+            -DWITH_JPEGIMAGECONVERTER=ON \
+            -DWITH_JPEGIMPORTER=ON \
+            -DWITH_MINIEXRIMAGECONVERTER=ON \
+            -DWITH_PNGIMAGECONVERTER=ON \
+            -DWITH_PNGIMPORTER=ON \
+            -DWITH_OPENGEXIMPORTER=ON \
+            -DWITH_STANFORDIMPORTER=ON \
+            -DWITH_STBIMAGECONVERTER=ON \
+            -DWITH_STBIMAGEIMPORTER=ON \
+            -DWITH_STBTRUETYPEFONT=ON \
+            -DWITH_STBVORBISAUDIOIMPORTER=ON \
+            -DWITH_TINYGLTFIMPORTER=ON \
+            "${extra_config[@]}" \
+            ../${_realname}-${pkgver}
+    ninja
+}
+
+package() {
+    cd "${srcdir}"/build-${CARCH}
+    DESTDIR="${pkgdir}" ninja install
+
+    install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" \
+        "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}

--- a/mingw-w64-magnum/001-magnum-2019.01-fix-flextvk-on-i686.patch
+++ b/mingw-w64-magnum/001-magnum-2019.01-fix-flextvk-on-i686.patch
@@ -1,0 +1,26 @@
+diff --git a/src/MagnumExternal/Vulkan/flextVk.cpp b/src/MagnumExternal/Vulkan/flextVk.cpp
+index 0ac06a8b5..1ec0b9127 100644
+--- a/src/MagnumExternal/Vulkan/flextVk.cpp
++++ b/src/MagnumExternal/Vulkan/flextVk.cpp
+@@ -33,7 +33,7 @@ FlextVkInstance flextVkInstance{};
+ FlextVkDevice flextVkDevice{};
+
+ void flextVkInit() {
+-    flextvkEnumerateInstanceVersion = reinterpret_cast<VkResult(*)(uint32_t*)>(vkGetInstanceProcAddr(nullptr, "vkEnumerateInstanceVersion"));
++    flextvkEnumerateInstanceVersion = reinterpret_cast<VkResult(VKAPI_PTR*)(uint32_t*)>(vkGetInstanceProcAddr(nullptr, "vkEnumerateInstanceVersion"));
+ }
+
+ void flextVkInitInstance(VkInstance instance, FlextVkInstance* data) {
+diff --git a/src/MagnumExternal/Vulkan/flextVk.cpp.template b/src/MagnumExternal/Vulkan/flextVk.cpp.template
+index 837e6d08d..788774106 100644
+--- a/src/MagnumExternal/Vulkan/flextVk.cpp.template
++++ b/src/MagnumExternal/Vulkan/flextVk.cpp.template
+@@ -48,7 +48,7 @@ void flextVkInit() {
+     @for f in funcs:
+     @if f.name in ['EnumerateInstanceVersion']:
+     flextvk@f.name = reinterpret_cast<@f.returntype\
+-(*)(@f.param_type_list_string())>(vkGetInstanceProcAddr(nullptr, "vk@f.name"));
++(VKAPI_PTR*)(@f.param_type_list_string())>(vkGetInstanceProcAddr(nullptr, "vk@f.name"));
+     @end
+     @end
+     @end

--- a/mingw-w64-magnum/PKGBUILD
+++ b/mingw-w64-magnum/PKGBUILD
@@ -1,0 +1,81 @@
+# Author: williamjcm <w.jcm59@gmail.com>
+# Contributor: mosra <mosra@centrum.cz>
+# Based on the Magnum Arch Linux PKGBUILD maintained by xyproto and the MSYS2/MinGW PKGBUILD templates
+
+_realname=magnum
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=2019.01
+pkgrel=1
+pkgdesc='C++11/C++14 graphics middleware for games and data visualization'
+arch=('any')
+url='https://magnum.graphics/'
+license=('MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-corrade>=$pkgver"
+         "${MINGW_PACKAGE_PREFIX}-openal"
+         "${MINGW_PACKAGE_PREFIX}-SDL2"
+         "${MINGW_PACKAGE_PREFIX}-vulkan-loader")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake" "${MINGW_PACKAGE_PREFIX}-ninja" 'git')
+optdepends=("${MINGW_PACKAGE_PREFIX}-magnum-plugins: import and export features"
+            "${MINGW_PACKAGE_PREFIX}-magnum-integration: integrations with third-party math and physics libraries")
+# The .tar.gz / .zip download contains symlinks (.travis.yml), making tar and
+# unzip on Windows grumpy because dangling symlinks are created. Could be fixed
+# by manually extracting everything except symlinks, but that's hard to
+# maintain. Downloading a Git tag works.
+source=("${_realname}-${pkgver}"::"git+https://github.com/mosra/magnum.git#tag=v$pkgver"
+        "001-magnum-2019.01-fix-flextvk-on-i686.patch")
+sha1sums=('SKIP'
+          "e59a8860c30a58ae172f5b0d5d3c0b711d6b4c1a")
+
+prepare() {
+    cd "${srcdir}"/${_realname}-${pkgver}
+
+    patch -p1 -i "${srcdir}"/001-magnum-2019.01-fix-flextvk-on-i686.patch
+}
+          
+build() {
+    mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+
+    declare -a extra_config
+    if check_option "debug" "n"; then
+        extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+    else
+        extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+    fi
+
+    MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+        ${MINGW_PREFIX}/bin/cmake \
+            -G'Ninja' \
+            -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+            -DWITH_AL_INFO=ON \
+            -DWITH_ANYAUDIOIMPORTER=ON \
+            -DWITH_ANYIMAGECONVERTER=ON \
+            -DWITH_ANYIMAGEIMPORTER=ON \
+            -DWITH_ANYSCENEIMPORTER=ON \
+            -DWITH_AUDIO=ON \
+            -DWITH_DISTANCEFIELDCONVERTER=ON \
+            -DWITH_WGLCONTEXT=ON \
+            -DWITH_IMAGECONVERTER=ON \
+            -DWITH_MAGNUMFONT=ON \
+            -DWITH_MAGNUMFONTCONVERTER=ON \
+            -DWITH_OBJIMPORTER=ON \
+            -DWITH_FONTCONVERTER=ON \
+            -DWITH_GL_INFO=ON \
+            -DWITH_SDL2APPLICATION=ON \
+            -DWITH_TGAIMAGECONVERTER=ON \
+            -DWITH_TGAIMPORTER=ON \
+            -DWITH_VK=ON \
+            -DWITH_WAVAUDIOIMPORTER=ON \
+            -DWITH_WINDOWLESSWGLAPPLICATION=ON \
+            "${extra_config[@]}" \
+            ../${_realname}-${pkgver}
+    ninja
+}
+
+package() {
+    cd "${srcdir}"/build-${CARCH}
+    DESTDIR="${pkgdir}" ninja install
+
+    install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" \
+        "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}


### PR DESCRIPTION
[Magnum](https://magnum.graphics/) is a lightweight and modular C++ graphics middleware.

It depends on [Corrade](https://magnum.graphics/corrade/), a C++ utility library.

Also provided are plugins for Magnum, providing support for many audio, image, and scene formats.

I created the `PKGBUILD` files based on the official Arch Linux `PKGBUILD`s, and I built and tested them on both `MINGW32` and `MINGW64` shells.

@mosra, the creator of Corrade and Magnum, allowed me to submit the files to the MSYS2/MinGW repo in his stead.