### PR TITLE
Update both cmake and libssh.

### DIFF
--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=cmake
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.13.3
+pkgver=3.13.4
 pkgrel=1
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
@@ -31,7 +31,7 @@ source=("https://www.cmake.org/files/v${pkgver%.*}/${_realname}-${pkgver}.tar.gz
         "0006-pkg-config-Add-dont-define-prefix-when-PKG_CONFIG_WI.patch"
         "0007-Do-not-generate-import-libs-for-exes.patch"
         "0008-Output-line-numbers-in-callstacks.patch")
-sha256sums=('665f905036b1f731a2a16f83fb298b1fb9d0f98c382625d023097151ad016b25'
+sha256sums=('fdd928fee35f472920071d1c7f1a6a2b72c9b25e04f7a37b409349aef3f20e9b'
             '1b68fe64e1b389134db44dc34368713f6e28d3463ab1e7fc3d93857c0459beb7'
             '77763df03e8a9ca66c3f9368fe7e1fc36bb041455733258d73aeb40246a61354'
             'bf676abff7e944ce726f8b16ccb7085cb96f5e12f94b657b455bd749145ba968'

--- a/mingw-w64-libssh/PKGBUILD
+++ b/mingw-w64-libssh/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libssh
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.8.6
+pkgver=0.8.7
 pkgrel=1
 pkgdesc="Library for accessing ssh client services through C libraries (mingw-w64)"
 arch=('any')
@@ -12,7 +12,8 @@ license=("LGPL")
 install=libssh-${CARCH}.install
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
-             "${MINGW_PACKAGE_PREFIX}-cmake")
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-cmocka")
 depends=("${MINGW_PACKAGE_PREFIX}-openssl"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 options=('staticlibs' 'strip')
@@ -21,7 +22,7 @@ source=("https://www.libssh.org/files/${pkgver%.*}/${_realname}-${pkgver}.tar.xz
         "https://www.libssh.org/files/${pkgver%.*}/${_realname}-${pkgver}.tar.xz.asc"
         "mingw-as-unix.patch"
         "mingw-DATADIR-conflict.patch")
-sha256sums=('1046b95632a07fc00b1ea70ee683072d0c8a23f544f4535440b727812002fd01'
+sha256sums=('43304ca22f0ba0b654e14b574a39816bc70212fdea5858a6637cc26cade3d592'
             'SKIP'
             '8db580bf64d37f3d6b9a13558696eae8586edd3195eb2e930b7e326b98a9aef9'
             'a56298da4ff75d7c2a7f4c4068a814c67f34773ea23601b2c236b669de320af6')
@@ -41,10 +42,17 @@ build() {
     -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DCMAKE_BUILD_TYPE=Release \
+    -DWITH_GSSAPI=OFF \
+    -DUNIT_TESTING=ON \
     -DWITH_STATIC_LIB=ON \
     ../${_realname}-${pkgver}
 
   make all
+}
+
+check() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make test
 }
 
 package() {


### PR DESCRIPTION
Update cmake to 1.13.4 - This fixes an issue with Doxygen build module.
Update libssh to 0.8.7 - update to altest version and run some tests.