### PR TITLE
mingw-w64-mesa: Clean-up dependencies and add a new GPG key

### DIFF
--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -9,10 +9,7 @@ pkgdesc="Open-source implementation of the OpenGL specification (mingw-w64)"
 arch=('any')
 makedepends=("${MINGW_PACKAGE_PREFIX}-clang"
              "scons"
-             "python2-mako"
-             "patch"
-             "flex"
-             "bison")
+             "python2-mako")
 url="https://www.mesa3d.org/"
 license=('MIT')
 options=('staticlibs' 'strip')

--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -9,7 +9,10 @@ pkgdesc="Open-source implementation of the OpenGL specification (mingw-w64)"
 arch=('any')
 makedepends=("${MINGW_PACKAGE_PREFIX}-clang"
              "scons"
-             "python2-mako")
+             "python2-mako"
+             "patch"
+             "flex"
+             "bison")
 url="https://www.mesa3d.org/"
 license=('MIT')
 options=('staticlibs' 'strip')
@@ -22,10 +25,11 @@ sha256sums=('32314da4365d37f80d84f599bd9625b00161c273c39600ba63b45002d500bb07'
             'bc9bb5013ac80ded47ad164ae1ef58cc9a39784eb4bf61e8c7d654bb273b05a9'
             '65991de6edd2614a4bedb23a9419966473b3c705c3d3dad3176924ad2e4b86a5'
             'fdf26548336cc7e5700560c6636a87ffa63daa3048fa94cf4a4a0b50890c9327')
-validpgpkeys=('8703B6700E7EE06D7A39B8D6EDAE37B02CEB490D')
+validpgpkeys=('8703B6700E7EE06D7A39B8D6EDAE37B02CEB490D') # Emil Velikov <emil.l.velikov@gmail.com>
 validpgpkeys+=('946D09B5E4C9845E63075FF1D961C596A7203456') # Andres Gomez <tanty@igalia.com>
 validpgpkeys+=('E3E8F480C52ADD73B278EE78E1ECBE07D7D70895') # Juan Antonio Suárez Romero (Igalia, S.L.) <jasuarez@igalia.com>"
-validpgpkeys+=('A5CC9FEC93F2F837CB044912336909B6B25FADFA')
+validpgpkeys+=('A5CC9FEC93F2F837CB044912336909B6B25FADFA') # Juan A. Suarez Romero <jasuarez@igalia.com>
+validpgpkeys+=('71C4B75620BC75708B4BDB254C95FAAB3EB073EC') # Dylan Baker <dylan@pnwbakers.com>
 
 case ${MINGW_CHOST} in
   i686*)

--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -7,9 +7,7 @@ pkgver=18.3.4
 pkgrel=1
 pkgdesc="Open-source implementation of the OpenGL specification (mingw-w64)"
 arch=('any')
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-clang"
-             "${MINGW_PACKAGE_PREFIX}-zlib"
+makedepends=("${MINGW_PACKAGE_PREFIX}-clang"
              "scons"
              "python2-mako")
 url="https://www.mesa3d.org/"


### PR DESCRIPTION
Tests I made indicate that '${MINGW_PACKAGE_PREFIX}-clang' on its own encapsulates '${MINGW_PACKAGE_PREFIX}-gcc' and '${MINGW_PACKAGE_PREFIX}-zlib'.

Flex and bison are required. patch is used inside PKGBUILD so it has to be added too.