### PR TITLE
python-cffi: fix source download and rebuild

### DIFF
--- a/mingw-w64-python-cffi/PKGBUILD
+++ b/mingw-w64-python-cffi/PKGBUILD
@@ -4,7 +4,8 @@ _realname=cffi
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=1.12.1
-pkgrel=1
+pkgrel=2
+_revision=ac7cb142e8f5
 pkgdesc="Foreign Function Interface for Python calling C code (mingw-w64)"
 url='https://cffi.readthedocs.io/'
 license=('MIT')
@@ -15,14 +16,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python3-pycparser")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python2-pytest-runner"
               "${MINGW_PACKAGE_PREFIX}-python3-pytest-runner")
-_revision=486d919c0b87288ec93c7696f75e2105ed4a91fd
-source=("${_realname}-${pkgver}.tar.gz::https://bitbucket.org/cffi/cffi/get/${_revision}.tar.gz")
-sha256sums=('4e679ec73037b0cfa3b23f6ee4fbb278595b8ecfa6adc101e7b55e51e2a28812')
+source=("${_realname}-${pkgver}.tar.bz2::https://bitbucket.org/cffi/cffi/get/v${pkgver}.tar.bz2")
+sha256sums=('155026e0989fd2ee32257cd9598e0cd9e729f1ee6151ddcabe69f047c8576ed4')
 
 prepare() {
   cd ${srcdir}
-  cp -r cffi-cffi-${_revision::12} python2-build-${CARCH}
-  cp -r cffi-cffi-${_revision::12} python3-build-${CARCH}
+  cp -r cffi-cffi-${_revision} python2-build-${CARCH}
+  cp -r cffi-cffi-${_revision} python3-build-${CARCH}
 }
 
 build() {


### PR DESCRIPTION
While scanning new commits, I noticed `sha256sum` wasn't updated for this package, see e.g. #3785. The source that was downloaded depended entirely on `_revision`, which had never been changed in PKGBUILD, so an incorrectly labelled 1.10.0 is all that was ever pushed to repo.

The revision code is still needed due to the tarball's path structure. Changing the downloaded source to a tagged version prevents future updates from building unless `_revision` is updated along with `pkgver`.