### PR TITLE
gdk-pixbuf2: update to 2.38.1

### DIFF
--- a/mingw-w64-gdk-pixbuf2/PKGBUILD
+++ b/mingw-w64-gdk-pixbuf2/PKGBUILD
@@ -5,8 +5,8 @@
 _realname=gdk-pixbuf2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.38.0
-pkgrel=2
+pkgver=2.38.1
+pkgrel=1
 pkgdesc="An image loading library (mingw-w64)"
 arch=('any')
 url="https://www.gtk.org/"
@@ -29,7 +29,7 @@ source=("https://download.gnome.org/sources/gdk-pixbuf/${pkgver%.*}/gdk-pixbuf-$
         0004-build-all-loaders-plus-gdi.patch
         fix-missing-meson-dep.patch)
 noextract=("gdk-pixbuf-${pkgver}.tar.xz")
-sha256sums=('dd50973c7757bcde15de6bcd3a6d462a445efd552604ae6435a0532fbbadae47'
+sha256sums=('f19ff836ba991031610dcc53774e8ca436160f7d981867c8c3a37acfe493ab3a'
             '21bd9b2ba1447267c84f1b445cbcf50c62299254856c1c227cc7ba4babc9f27e'
             '1863341d4b4f9c52c92438b275aed1acb5c2cd3018c5e75a61a6cd9415d2f621'
             '3d3350dbb437a675e1bdfbc45ad7701634516cd95508411dfb33005b28c01044')


### PR DESCRIPTION
This updates gdk-pixbuf2 to 2.38.1.