### PR TITLE
double-conversion: update to 3.1.2

### DIFF
--- a/mingw-w64-double-conversion/PKGBUILD
+++ b/mingw-w64-double-conversion/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=double-conversion
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=3.1.1
+pkgver=3.1.2
 pkgrel=1
 pkgdesc="Binary-decimal and decimal-binary routines for IEEE doubles (mingw-w64)"
 arch=('any')
@@ -13,7 +13,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake")
 options=('strip' 'staticlibs')
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/google/double-conversion/archive/v${pkgver}.tar.gz")
-sha256sums=('c49a6b3fa9c917f827b156c8e0799ece88ae50440487a99fc2f284cfd357a5b9')
+sha256sums=('2a9795dd9e56fbc616f8d51833fbd706a10c965ec588d1a5557af8b129cdb5b0')
 
 build() {
   # shared


### PR DESCRIPTION
This updates double-conversion to 3.1.2.