### PR TITLE
have the mingw64 pkg-config installed with cmake

### DIFF
--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -11,9 +11,9 @@ arch=('any')
 url="https://www.cmake.org/"
 license=("MIT")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-qt5")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-pkg-config"
          "${MINGW_PACKAGE_PREFIX}-curl"
          "${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-jsoncpp"


### PR DESCRIPTION
when running under mingw64.exe/mingw32.exe the pathes from the environment are
transformed into Windows pathes. As a result PKG_CONFIG_PATH because a Windows
path. When passed to the non-mingw pkg-config the path becomes invalid and is
not used properly.

To solve this the mingw pkg-config must be installed. It works with Windows
pathes as expected.

As a background to this issue, this was originally reported to cmake:
https://gitlab.kitware.com/cmake/cmake/issues/18980