### PR TITLE
libmatroska: update to 1.5.0

### DIFF
--- a/mingw-w64-libmatroska/PKGBUILD
+++ b/mingw-w64-libmatroska/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=libmatroska
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.4.9
-pkgrel=2
+pkgver=1.5.0
+pkgrel=1
 pkgdesc="Matroska library (mingw-w64)"
 arch=('any')
 license=('LGPL')
@@ -18,7 +18,7 @@ source=("https://dl.matroska.org/downloads/${_realname}/${_realname}-${pkgver}.t
         001-mingw-use-posix-layout.patch
         002-mingw-versioned-dll.patch
         003-export-missing-symbols.patch)
-sha256sums=('38a61dd5d87c070928b5deb3922b63b2b83c09e2e4a10f9393eecb6afa9795c8'
+sha256sums=('f0efdc1827fa8012a16d764a45ed84d544d92a2027113245f522f5e1f713ad1e'
             'bc71b9c2facf085cd6d59cf926450bc8ef1b925aaa0ca9b84cf241c66753e088'
             'fd66a3336cf7f7b914acf5dd0ba51f5e030ca45f082706093238026e97960ee6'
             '22428d36b52206c8178da408669872371b2ceba7b3109c88de27b59ea61cdb79')


### PR DESCRIPTION
This updates libmatroska to 1.5.0. The new version requires libebml version 1.3.7.