### PR TITLE
WIP: python3: fix syntaxerror in sysconfig for some builds

### DIFF
--- a/mingw-w64-python3/0000-make-_sysconfigdata.py-relocatable.patch
+++ b/mingw-w64-python3/0000-make-_sysconfigdata.py-relocatable.patch
@@ -1,6 +1,5 @@
-diff -Naur Python-3.7.0-orig/Lib/sysconfig.py Python-3.7.0/Lib/sysconfig.py
---- Python-3.7.0-orig/Lib/sysconfig.py	2018-06-27 06:07:35.000000000 +0300
-+++ Python-3.7.0/Lib/sysconfig.py	2018-07-12 10:20:37.489076500 +0300
+--- Python-3.7.2/Lib/sysconfig.py.orig	2018-12-23 22:37:36.000000000 +0100
++++ Python-3.7.2/Lib/sysconfig.py	2019-03-15 15:58:58.818000800 +0100
 @@ -251,6 +251,7 @@
      # if the expansion uses the name without a prefix.
      renamed_variables = ('CFLAGS', 'LDFLAGS', 'CPPFLAGS')
@@ -9,10 +8,13 @@ diff -Naur Python-3.7.0-orig/Lib/sysconfig.py Python-3.7.0/Lib/sysconfig.py
      while len(variables) > 0:
          for name in tuple(variables):
              value = notdone[name]
-@@ -404,6 +405,19 @@
+@@ -402,7 +403,20 @@
+         f.write('# system configuration generated and used by'
+                 ' the sysconfig module\n')
          f.write('build_time_vars = ')
-         pprint.pprint(vars, stream=f)
- 
+-        pprint.pprint(vars, stream=f)
++        pprint.pprint(vars, stream=f, width=999999)
++
 +    # Now reload the file and replace:
 +    replacements = {": '${SYS_PREFIX}'" : ": sys.prefix",
 +                    ": '${SYS_PREFIX}"  : ": sys.prefix + '",
@@ -25,7 +27,6 @@ diff -Naur Python-3.7.0-orig/Lib/sysconfig.py Python-3.7.0/Lib/sysconfig.py
 +    with open(destfile, 'w', encoding='utf8') as f:
 +        f.write('import sys\n')
 +        f.write(contents)
-+
+ 
      # Create file used for sys.path fixup -- see Modules/getpath.c
      with open('pybuilddir.txt', 'w', encoding='ascii') as f:
-         f.write(pybuilddir)

--- a/mingw-w64-python3/PKGBUILD
+++ b/mingw-w64-python3/PKGBUILD
@@ -18,7 +18,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _pybasever=3.7
 pkgver=${_pybasever}.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 license=('PSF')
@@ -441,7 +441,7 @@ package() {
 }
 
 sha256sums=('d83fe8ce51b1bb48bbcf0550fd265b9a75cdfdfa93f916f9e700aef8444bf1bb'
-            'fa58527f17b1c3defeb9345ef0606d937b2c6ea2746033bfe980879eefe2c50e'
+            '742870a2cfc9e6f2a34467377ef5898751d4910f2b647e9d0364eee35cb0410b'
             '8b2c7d6b3d0efec48f44c1e46be25fcfb4ba6711ca49b93cf9fa40fb4f0966b6'
             'b2111d31e812b33e5cec85f6505bd730975dd242f8eb138307f71ffe0d7fdf6b'
             '7983bc803f4b845c09589b039d4dd099570e68716c339c940d785ef4785ee1a8'


### PR DESCRIPTION
The build scripts does basic sed replacement to make things relocatable
and fails when strings are wrapped (depending on the path lengths).

Disable wrapping when writing out the file to prevent that.

Ideally we would not use sed and write out the correct values in the first place,
but that's for another time.

Fixes #5048