### PR TITLE
python3: Improve patching _sysconfigdata.py

### DIFF
--- a/mingw-w64-python3/0000-make-_sysconfigdata.py-relocatable.patch
+++ b/mingw-w64-python3/0000-make-_sysconfigdata.py-relocatable.patch
@@ -1,31 +1,40 @@
-diff -Naur Python-3.7.0-orig/Lib/sysconfig.py Python-3.7.0/Lib/sysconfig.py
---- Python-3.7.0-orig/Lib/sysconfig.py	2018-06-27 06:07:35.000000000 +0300
-+++ Python-3.7.0/Lib/sysconfig.py	2018-07-12 10:20:37.489076500 +0300
-@@ -251,6 +251,7 @@
-     # if the expansion uses the name without a prefix.
-     renamed_variables = ('CFLAGS', 'LDFLAGS', 'CPPFLAGS')
+--- Python-3.7.2\Lib\sysconfig_old.py Fri Mar 15 19:42:37 2019
++++ Python-3.7.2\Lib\sysconfig.py Fri Mar 15 19:42:10 2019
+@@ -2,6 +2,7 @@
  
-+    done['prefix']='${SYS_PREFIX}'
-     while len(variables) > 0:
-         for name in tuple(variables):
-             value = notdone[name]
-@@ -404,6 +405,19 @@
+ import os
+ import sys
++import textwrap
+ from os.path import pardir, realpath
+ 
+ __all__ = [
+@@ -398,11 +399,29 @@
+     os.makedirs(pybuilddir, exist_ok=True)
+     destfile = os.path.join(pybuilddir, name + '.py')
+ 
++    replacement = """
++        keys_to_replace = [
++            'BINDIR', 'BINLIBDEST', 'CONFINCLUDEDIR',
++            'CONFINCLUDEPY', 'DESTDIRS', 'DESTLIB', 'DESTSHARED',
++            'INCLDIRSTOMAKE', 'INCLUDEDIR', 'INCLUDEPY',
++            'LIBDEST', 'LIBDIR', 'LIBPC', 'LIBPL', 'MACHDESTLIB',
++            'MANDIR', 'SCRIPTDIR', 'datarootdir', 'exec_prefix',
++        ]
++
++        prefix = build_time_vars['BINDIR'][:-4]
++
++        for key in keys_to_replace:
++            value = build_time_vars[key]
++            build_time_vars[key] = value.replace(prefix, sys.prefix)
++    """
++
+     with open(destfile, 'w', encoding='utf8') as f:
++        f.write('import sys\n')
+         f.write('# system configuration generated and used by'
+                 ' the sysconfig module\n')
          f.write('build_time_vars = ')
          pprint.pprint(vars, stream=f)
++        f.write('\n%s' % textwrap.dedent(replacement))
  
-+    # Now reload the file and replace:
-+    replacements = {": '${SYS_PREFIX}'" : ": sys.prefix",
-+                    ": '${SYS_PREFIX}"  : ": sys.prefix + '",
-+                     "${SYS_PREFIX}'" : "' + sys.prefix",
-+                     "${SYS_PREFIX}"  : "' + sys.prefix + '"}
-+
-+    contents = open(destfile).read()
-+    for rep in replacements.keys():
-+        contents = contents.replace(rep, replacements[rep])
-+    with open(destfile, 'w', encoding='utf8') as f:
-+        f.write('import sys\n')
-+        f.write(contents)
-+
      # Create file used for sys.path fixup -- see Modules/getpath.c
      with open('pybuilddir.txt', 'w', encoding='ascii') as f:
-         f.write(pybuilddir)

--- a/mingw-w64-python3/PKGBUILD
+++ b/mingw-w64-python3/PKGBUILD
@@ -18,7 +18,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _pybasever=3.7
 pkgver=${_pybasever}.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 license=('PSF')
@@ -422,26 +422,10 @@ package() {
     "${pkgdir}${MINGW_PREFIX}"/lib/python${_pybasever}/lib-dynload/_sysconfigdata*.py \
     "${pkgdir}${MINGW_PREFIX}"/lib/python${_pybasever}/smtpd.py
 
-  # Doing sysconfig relocatable as patch 0000 do it only partially
-  sed -e "s/sys.prefix + //g" \
-      -e "s/'\/bin'/sys.prefix + '\/bin'/g" \
-      -e "s/'\/include\//sys.prefix + '\/include\//g" \
-      -e "s/'\/include /sys.prefix + '\/include /g" \
-      -e "s/'\/include'/sys.prefix + '\/include'/g" \
-      -e "s/ \/include\// ' + sys.prefix + '\/include\//g" \
-      -e "s/ \/include / ' + sys.prefix + '\/include /g" \
-      -e "s/'\/lib\//sys.prefix + '\/lib\//g" \
-      -e "s/'\/lib /sys.prefix + '\/lib /g" \
-      -e "s/'\/lib'/sys.prefix + '\/lib'/g" \
-      -e "s/ \/lib\// ' + sys.prefix + '\/lib\//g" \
-      -e "s/ \/lib / ' + sys.prefix + '\/lib /g" \
-      -e "s/'\/share\//sys.prefix + '\/share\//g" \
-      -e "s/'\/share'/sys.prefix + '\/share'/g" \
-      -i "${pkgdir}${MINGW_PREFIX}"/lib/python${_pybasever}/lib-dynload/_sysconfigdata*.py
 }
 
 sha256sums=('d83fe8ce51b1bb48bbcf0550fd265b9a75cdfdfa93f916f9e700aef8444bf1bb'
-            'fa58527f17b1c3defeb9345ef0606d937b2c6ea2746033bfe980879eefe2c50e'
+            'a2e92cf57985b93bb6203b26c84140610378bd1eb57e8ab8f00e0c0f9afb7b75'
             '8b2c7d6b3d0efec48f44c1e46be25fcfb4ba6711ca49b93cf9fa40fb4f0966b6'
             'b2111d31e812b33e5cec85f6505bd730975dd242f8eb138307f71ffe0d7fdf6b'
             '7983bc803f4b845c09589b039d4dd099570e68716c339c940d785ef4785ee1a8'
@@ -527,4 +511,4 @@ sha256sums=('d83fe8ce51b1bb48bbcf0550fd265b9a75cdfdfa93f916f9e700aef8444bf1bb'
             'bd9b934e8c1f92573115efaef6b6b04966e3222ba769511e006366d1217d34d6'
             'e91f897e43063e0c4e52d971f5de4b5e193d9eb6a35fc3acfca1dc057a2fcd65'
             'e3b0171303b3e28a7347a81b1110dfe42df92a87d160caf624510304d5390728'
-            'ea41f389324bf56277ef27a02f3510d22e5c88becbdb465468bdad9c15e0d229')
+            'a547d3de6a619f5f8e8e44f87c8f726271f1cfc2449e91c63022cfd82dff430e')

--- a/mingw-w64-python3/smoketests.py
+++ b/mingw-w64-python3/smoketests.py
@@ -72,6 +72,11 @@ class Tests(unittest.TestCase):
             for res in pool.map(lambda *x: None, range(10000)):
                 pass
 
+    def test_sysconfig(self):
+        import sysconfig
+        # This should be able to execute without exceptions
+        sysconfig.get_config_vars()
+
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)


### PR DESCRIPTION
Add code at the end of `_sysconfigdata.py` that modifys `build_time_vars` at
module load time with python syntax.

Remove all the sed replaces from PKGBUILD because its hard to review and prone to breakage

Finally a test is added to detect syntax errors next time early on

Fixes https://github.com/msys2/MINGW-packages/issues/5048