### PR TITLE
Add mingw-w64-imgui-git package

### DIFF
--- a/mingw-w64-imgui-git/PKGBUILD
+++ b/mingw-w64-imgui-git/PKGBUILD
@@ -1,0 +1,48 @@
+# Maintainer: Konstantin Podsvirov <konstantin@podsvirov.pro>
+
+_realname=imgui
+pkgbase=mingw-w64-${_realname}-git
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=v1.68.r62.0e580770
+pkgrel=1
+pkgdesc="Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies (mingw-w64)"
+arch=('any')
+license=('MIT')
+url="https://github.com/ocornut/imgui"
+makedepends=("make"
+             "${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-glfw"
+             "${MINGW_PACKAGE_PREFIX}-vulkan"
+             "${MINGW_PACKAGE_PREFIX}-freetype")
+optdepends=("${MINGW_PACKAGE_PREFIX}-glfw"
+            "${MINGW_PACKAGE_PREFIX}-vulkan"
+            "${MINGW_PACKAGE_PREFIX}-freetype")
+options=(!strip staticlibs !buildflags)
+# Until the https://github.com/ocornut/imgui/pull/1713 is merged
+source=(${_realname}::git+https://github.com/podsvirov/imgui.git#branch=cmake)
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "${srcdir}/${_realname}"
+  printf "%s" "$(git describe --tags | sed 's/\([^-]*-\)g/r\1/;s/-/./g')"
+}
+
+build() {
+  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
+  mkdir -p ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G"MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DImGui_EXAMPLES=OFF \
+    ../${_realname}/examples
+  make
+}
+
+package() {
+  cd ${srcdir}/build-${MINGW_CHOST}
+  make DESTDIR=${pkgdir} install
+}


### PR DESCRIPTION
This package depend on unmerged ocornut/imgui#1713, but topic is [important](https://github.com/ocornut/imgui/wiki#issues-some-important-topics) for @ocornut (Dear ImGui author).

Not all functionality is available now, but it can be added in the following revisions.

For example, I have difficulty linking to SDL2, because its package is build by autotools, but I need CMake package.