### PR TITLE
unbound: update to 1.9.1

### DIFF
--- a/mingw-w64-unbound/PKGBUILD
+++ b/mingw-w64-unbound/PKGBUILD
@@ -3,13 +3,14 @@
 _realname=unbound
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.9.0
+pkgver=1.9.1
 pkgrel=1
 pkgdesc="Validating, recursive, and caching DNS resolver (mingw-w64)"
 arch=('any')
 url='https://unbound.net/'
 license=('custom:BSD')
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-libtool")
 depends=("${MINGW_PACKAGE_PREFIX}-openssl"
          "${MINGW_PACKAGE_PREFIX}-expat"
          #"${MINGW_PACKAGE_PREFIX}-libevent"
@@ -17,7 +18,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-openssl"
 options=(strip staticlibs)
 source=("https://unbound.net/downloads/${_realname}-${pkgver}.tar.gz"
         'manifest')
-sha256sums=('415af94b8392bc6b2c52e44ac8f17935cc6ddf2cc81edfb47c5be4ad205ab917'
+sha256sums=('c3c0bf9b86ccba4ca64f93dd4fe7351308ab54293f297a67de5a8914c1dc59c5'
             '838098b25a8044176b3139b4003594570c62a8d64f5470fbbd769f3bf44e0855')
 
 prepare() {


### PR DESCRIPTION
This updates unbound to 1.9.1.

Libtool is added to makedepends to allow build to succeed.