### PR TITLE
libgpg-error: update to 1.36

### DIFF
--- a/mingw-w64-libgpg-error/PKGBUILD
+++ b/mingw-w64-libgpg-error/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libgpg-error
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.35
+pkgver=1.36
 pkgrel=1
 pkgdesc="Support library for libgcrypt (mingw-w64)"
 arch=('any')
@@ -24,7 +24,7 @@ validpgpkeys=('D8692123C4065DEA5E0F3AB5249B39D24F25E3B6'
               '46CC730865BB5C78EBABADCF04376F3EE0856959'
               '031EC2536E580D8EA286A9F22071B08A33BD3F06'
               'D238EA65D64C67ED4C3073F28A861B1C7EFD60D9')
-sha256sums=('cbd5ee62a8a8c88d48c158fff4fc9ead4132aacd1b4a56eb791f9f997d07e067'
+sha256sums=('babd98437208c163175c29453f8681094bcaf92968a15cafb1a276076b33c97c'
             'SKIP'
             '252349e58d418adfec5621af1e09753db52b1bf39983aa3bc398d636afb9b495'
             '364da17febff3f6eeffee5a5f1e3ed1b644adeb5ca48a972c5c4675c10238a91'


### PR DESCRIPTION
This updates libgpg-error to 1.36.