### PR TITLE
oce: support unicode filenames

### DIFF
--- a/mingw-w64-oce/PKGBUILD
+++ b/mingw-w64-oce/PKGBUILD
@@ -21,7 +21,9 @@ sha256sums=('c553d6a7bf52f790abc3b6bb7a1e91a65947e92a426bb1a88a11960c31f0966c'
 
 prepare() {
   cd "${srcdir}/oce-OCE-${pkgver}"
-  patch -p3 -i "${srcdir}"/unicode.patch
+  if [ "$MINGW_CHOST" == "x86_64-w64-mingw32" ]; then
+    patch -p3 -i "${srcdir}"/unicode.patch
+  fi
 }
 
 build() {

--- a/mingw-w64-oce/PKGBUILD
+++ b/mingw-w64-oce/PKGBUILD
@@ -4,7 +4,7 @@ _realname=oce
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=0.18.3
-pkgrel=1
+pkgrel=2
 pkgdesc="Open CASCADE Community Edition: patches/improvements/experiments contributed by users over the official Open CASCADE library."
 url="https://github.com/tpaviot/oce"
 arch=('any')
@@ -13,12 +13,16 @@ conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake")
 depends=("${MINGW_PACKAGE_PREFIX}-freetype")
 #depends=('intel-tbb' 'gl2ps' 'freeimage' 'tk')
-source=(https://github.com/tpaviot/${_realname}/archive/OCE-${pkgver}.tar.gz)
+source=(https://github.com/tpaviot/${_realname}/archive/OCE-${pkgver}.tar.gz unicode.patch)
 # 99_oce.sh 99_oce.conf)
 install=oce-${CARCH}.install
-sha256sums=('c553d6a7bf52f790abc3b6bb7a1e91a65947e92a426bb1a88a11960c31f0966c')
-         #'606e400a97d9947459e4de2eca65f04c'
-         #'167a9f5c94a16d7855c3ac99e34a4506')
+sha256sums=('c553d6a7bf52f790abc3b6bb7a1e91a65947e92a426bb1a88a11960c31f0966c'
+            'bff7743d03258a532578c642a8140a0583fcff3bd05cc0a81a8bef00f2629c83')
+
+prepare() {
+  cd "${srcdir}/oce-OCE-${pkgver}"
+  patch -p3 -i "${srcdir}"/unicode.patch
+}
 
 build() {
   [[ -d "build-${MINGW_CHOST}" ]] && rm -rf "build-${MINGW_CHOST}"

--- a/mingw-w64-oce/unicode.patch
+++ b/mingw-w64-oce/unicode.patch
@@ -1,0 +1,58 @@
+diff --git a/src/oce-OCE-0.18.3/src/OSD/OSD_OpenFile.cxx b/src-old/oce-OCE-0.18.3/src/OSD/OSD_OpenFile.cxx
+index 32e5ccd..95fde0e 100644
+--- a/src/oce-OCE-0.18.3/src/OSD/OSD_OpenFile.cxx
++++ b/src-old/oce-OCE-0.18.3/src/OSD/OSD_OpenFile.cxx
+@@ -23,7 +23,7 @@ FILE* OSD_OpenFile(const char* theName,
+                    const char* theMode)
+ {
+   FILE* aFile = 0;
+-#if defined(_WIN32) && !defined(__MINGW32__) && !defined(__MINGW64__)
++#if defined(_WIN32)
+   // file name is treated as UTF-8 string and converted to UTF-16 one
+   const TCollection_ExtendedString aFileNameW (theName, Standard_True);
+   const TCollection_ExtendedString aFileModeW (theMode, Standard_True);
+@@ -43,7 +43,7 @@ FILE* OSD_OpenFile(const TCollection_ExtendedString& theName,
+                    const char* theMode)
+ {
+   FILE* aFile = 0;
+-#if defined(_WIN32) && !defined(__MINGW32__) && !defined(__MINGW64__)
++#if defined(_WIN32)
+   const TCollection_ExtendedString aFileModeW (theMode, Standard_True);
+   aFile = ::_wfopen ((const wchar_t* )theName.ToExtString(),
+                      (const wchar_t* )aFileModeW.ToExtString());
+@@ -63,7 +63,7 @@ void OSD_OpenFileBuf(std::filebuf& theBuff,
+                      const char* theName,
+                      const std::ios_base::openmode theMode)
+ {
+-#if defined(_WIN32) && !defined(__MINGW32__) && !defined(__MINGW64__)
++#if defined(_WIN32)
+   // file name is treated as UTF-8 string and converted to UTF-16 one
+   const TCollection_ExtendedString aFileNameW (theName, Standard_True);
+   theBuff.open ((const wchar_t* )aFileNameW.ToExtString(), theMode);
+@@ -80,7 +80,7 @@ void OSD_OpenFileBuf(std::filebuf& theBuff,
+                      const TCollection_ExtendedString& theName,
+                      const std::ios_base::openmode theMode)
+ {
+-#if defined(_WIN32) && !defined(__MINGW32__) && !defined(__MINGW64__)
++#if defined(_WIN32)
+   theBuff.open ((const wchar_t* )theName.ToExtString(), theMode);
+ #else
+   // conversion in UTF-8 for linux
+@@ -97,7 +97,7 @@ void OSD_OpenStream(std::ofstream& theStream,
+                     const char* theName,
+                     const std::ios_base::openmode theMode)
+ {
+-#if defined(_WIN32) && !defined(__MINGW32__) && !defined(__MINGW64__)
++#if defined(_WIN32)
+   // file name is treated as UTF-8 string and converted to UTF-16 one
+   const TCollection_ExtendedString aFileNameW (theName, Standard_True);
+   theStream.open ((const wchar_t* )aFileNameW.ToExtString(), theMode);
+@@ -114,7 +114,7 @@ void OSD_OpenStream(std::ofstream& theStream,
+                     const TCollection_ExtendedString& theName,
+                     const std::ios_base::openmode theMode)
+ {
+-#if defined(_WIN32) && !defined(__MINGW32__) && !defined(__MINGW64__)
++#if defined(_WIN32)
+   theStream.open ((const wchar_t* )theName.ToExtString(), theMode);
+ #else
+   // conversion in UTF-8 for linux


### PR DESCRIPTION
For some reason, opencascade developers thought that MINGW doesn't
support the windows-specific unicode extensions to fopen and friends
and thus use the non-unicode ones, making dealing with non-ASCII
filenames impossible.

This patch enables unicode fopen on MINGW.