### PR TITLE
mingw-w64-giflib - t5.1.8 - rwork to keep binaries separate.

### DIFF
--- a/mingw-w64-giflib/001-mingw-build.patch
+++ b/mingw-w64-giflib/001-mingw-build.patch
@@ -1,6 +1,15 @@
---- giflib-5.1.6/Makefile.orig	2019-02-18 09:51:14.067307400 +0300
-+++ giflib-5.1.6/Makefile	2019-02-18 09:55:49.687992300 +0300
-@@ -60,21 +60,19 @@
+--- giflib-5.1.8/Makefile.orig	2019-03-17 12:33:02.000000000 -0400
++++ giflib-5.1.8/Makefile	2019-03-21 17:04:26.168590200 -0400
+@@ -6,7 +6,7 @@
+ # of code space in the shared library.
+ 
+ #
+-CC    = gcc
++CC    ?= gcc
+ OFLAGS = -O0 -g
+ #OFLAGS  = -O2 -fwhole-program
+ CFLAGS  = -std=gnu99 -fPIC -Wall -Wno-format-truncation $(OFLAGS)
+@@ -60,21 +60,19 @@ UTILS = $(INSTALLABLE) \
  
  LDLIBS=libgif.a -lm
  
@@ -11,12 +20,12 @@
  $(UTILS):: libgif.a
  
 -libgif.so: $(OBJECTS) $(HEADERS)
--	$(CC) $(CFLAGS) -shared $(OFLAGS) -o libgif.so $(OBJECTS)
+-	$(CC) $(CFLAGS) -shared $(OFLAGS) -Wl,-soname -Wl,libgif.so.$(LIBMAJOR) -o libgif.so $(OBJECTS)
 +libgif-$(LIBMAJOR).dll: $(OBJECTS) $(HEADERS)
 +	$(CC) $(CFLAGS) -shared $(OFLAGS) -Wl,--out-implib,libgif.dll.a -o libgif-$(LIBMAJOR).dll $(OBJECTS)
  
  libgif.a: $(OBJECTS) $(HEADERS)
- 	ar rcs libgif.a $(OBJECTS)
+ 	$(AR) rcs libgif.a $(OBJECTS)
  
  clean:
 -	rm -f $(UTILS) $(TARGET) libgetarg.a libgif.a libgif.so
@@ -26,7 +35,7 @@
  	rm -fr doc/*.1 *.html doc/staging
  
  check: all
-@@ -86,15 +84,14 @@
+@@ -86,15 +84,14 @@ install: all install-bin install-include
  install-bin: $(INSTALLABLE)
  	$(INSTALL) -d "$(DESTDIR)$(BINDIR)"
  	$(INSTALL) $^ "$(DESTDIR)$(BINDIR)"
@@ -42,14 +51,14 @@
 -	ln -sf libgif.so.$(LIBVER) "$(DESTDIR)$(LIBDIR)/libgif.so.$(LIBMAJOR)"
 -	ln -sf libgif.so.$(LIBMAJOR) "$(DESTDIR)$(LIBDIR)/libgif.so"
  install-man:
- 	$(INSTALL) -d "$(DESTDIR)$(MANDIR)"
- 	$(INSTALL) -m 644 doc/*.1 "$(DESTDIR)$(MANDIR)"
-@@ -105,7 +102,7 @@
+ 	$(INSTALL) -d "$(DESTDIR)$(MANDIR)/man1"
+ 	$(INSTALL) -m 644 doc/*.1 "$(DESTDIR)$(MANDIR)/man1"
+@@ -105,7 +102,7 @@ uninstall-include:
  	rm -f "$(DESTDIR)$(INCDIR)/gif_lib.h"
  uninstall-lib:
  	cd "$(DESTDIR)$(LIBDIR)" && \
 -		rm -f libgif.a libgif.so libgif.so.$(LIBMAJOR) libgif.so.$(LIBVER)
 +		rm -f libgif.a libgif.dll.a libgif-$(LIBMAJOR).dll
  uninstall-man:
- 	cd "$(DESTDIR)$(MANDIR)" && rm -f $(shell cd doc >/dev/null && echo *.1)
+ 	cd "$(DESTDIR)$(MANDIR)/man1" && rm -f $(shell cd doc >/dev/null && echo *.1)
  

--- a/mingw-w64-giflib/001-mingw-build.patch
+++ b/mingw-w64-giflib/001-mingw-build.patch
@@ -1,15 +1,6 @@
---- giflib-5.1.8/Makefile.orig	2019-03-17 12:33:02.000000000 -0400
-+++ giflib-5.1.8/Makefile	2019-03-21 17:04:26.168590200 -0400
-@@ -6,7 +6,7 @@
- # of code space in the shared library.
- 
- #
--CC    = gcc
-+CC    ?= gcc
- OFLAGS = -O0 -g
- #OFLAGS  = -O2 -fwhole-program
- CFLAGS  = -std=gnu99 -fPIC -Wall -Wno-format-truncation $(OFLAGS)
-@@ -60,21 +60,19 @@ UTILS = $(INSTALLABLE) \
+--- giflib-5.1.6/Makefile.orig	2019-02-18 09:51:14.067307400 +0300
++++ giflib-5.1.6/Makefile	2019-02-18 09:55:49.687992300 +0300
+@@ -60,21 +60,19 @@
  
  LDLIBS=libgif.a -lm
  
@@ -35,7 +26,7 @@
  	rm -fr doc/*.1 *.html doc/staging
  
  check: all
-@@ -86,15 +84,14 @@ install: all install-bin install-include
+@@ -86,15 +84,14 @@
  install-bin: $(INSTALLABLE)
  	$(INSTALL) -d "$(DESTDIR)$(BINDIR)"
  	$(INSTALL) $^ "$(DESTDIR)$(BINDIR)"
@@ -51,14 +42,14 @@
 -	ln -sf libgif.so.$(LIBVER) "$(DESTDIR)$(LIBDIR)/libgif.so.$(LIBMAJOR)"
 -	ln -sf libgif.so.$(LIBMAJOR) "$(DESTDIR)$(LIBDIR)/libgif.so"
  install-man:
- 	$(INSTALL) -d "$(DESTDIR)$(MANDIR)/man1"
- 	$(INSTALL) -m 644 doc/*.1 "$(DESTDIR)$(MANDIR)/man1"
-@@ -105,7 +102,7 @@ uninstall-include:
+ 	$(INSTALL) -d "$(DESTDIR)$(MANDIR)"
+ 	$(INSTALL) -m 644 doc/*.1 "$(DESTDIR)$(MANDIR)"
+@@ -105,7 +102,7 @@
  	rm -f "$(DESTDIR)$(INCDIR)/gif_lib.h"
  uninstall-lib:
  	cd "$(DESTDIR)$(LIBDIR)" && \
 -		rm -f libgif.a libgif.so libgif.so.$(LIBMAJOR) libgif.so.$(LIBVER)
 +		rm -f libgif.a libgif.dll.a libgif-$(LIBMAJOR).dll
  uninstall-man:
- 	cd "$(DESTDIR)$(MANDIR)/man1" && rm -f $(shell cd doc >/dev/null && echo *.1)
+ 	cd "$(DESTDIR)$(MANDIR)" && rm -f $(shell cd doc >/dev/null && echo *.1)
  

--- a/mingw-w64-giflib/PKGBUILD
+++ b/mingw-w64-giflib/PKGBUILD
@@ -4,7 +4,7 @@ _realname=giflib
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.1.8
-pkgrel=2
+pkgrel=1
 pkgdesc="A library for reading and writing gif images (mingw-w64)"
 arch=('any')
 url="https://sourceforge.net/projects/giflib"
@@ -15,34 +15,23 @@ options=('staticlibs' 'strip')
 source=("https://downloads.sourceforge.net/sourceforge/giflib/${_realname}-${pkgver}.tar.gz"
         "001-mingw-build.patch")
 sha256sums=('d105a905df34a7822172d13657cdae3d4b0c8e8c7067ccf05e39a40044f8ca53'
-            'a2f7a25a75041def0b775367a7497658a89e5c7c55fec716fdd965aa97fb97b5')
+            '89f11195afbf5ac4f47b3cb6c6e06386ebab727cb360af46ca07151508a2683a')
 noextract=(${_realname}-${pkgver}.tar.gz)
-
-# Helper macros to help make tasks easier #
-apply_patch_with_msg() {
-  for _patch in "$@"
-  do
-    msg2 "Applying $_patch"
-    patch -Nbp1 -i "${srcdir}/$_patch"
-  done
-}
 
 prepare() {
   [[ -d ${srcdir}/${_realname}-${pkgver} ]] && rm -rf ${srcdir}/${_realname}-${pkgver}
   tar -xzf ${srcdir}/${_realname}-${pkgver}.tar.gz -C ${srcdir} || true
 
   cd "${srcdir}/${_realname}-${pkgver}"
-  apply_patch_with_msg "001-mingw-build.patch"
+  patch -Np1 -i "${srcdir}/001-mingw-build.patch"
 }
 
 build() {
-  rm -rf "${srcdir}/build-${CARCH}"
-  cp -r "${srcdir}/${_realname}-${pkgver}" "${srcdir}/build-${CARCH}"
-  cd "${srcdir}/build-${CARCH}"
-  CC=${MINGW_PREFIX}/bin/gcc make
+  cd "${srcdir}/${_realname}-${pkgver}"
+  make
 }
 
 package() {
-  cd "${srcdir}/build-${CARCH}"
+  cd "${srcdir}/${_realname}-${pkgver}"
   make DESTDIR="${pkgdir}" PREFIX="${MINGW_PREFIX}" install
 }

--- a/mingw-w64-giflib/PKGBUILD
+++ b/mingw-w64-giflib/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=giflib
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=5.1.6
-pkgrel=1
+pkgver=5.1.8
+pkgrel=2
 pkgdesc="A library for reading and writing gif images (mingw-w64)"
 arch=('any')
 url="https://sourceforge.net/projects/giflib"
@@ -14,24 +14,35 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 options=('staticlibs' 'strip')
 source=("https://downloads.sourceforge.net/sourceforge/giflib/${_realname}-${pkgver}.tar.gz"
         "001-mingw-build.patch")
-sha256sums=('53968f6d39bb4b99f57cc29887a09a3ca500e33b69fb259edaf4f6a622c8b578'
-            '6fd53154f0bd964f4fbe3c5ddd5b573cea503c0b2b760a05a892edd1adabb261')
+sha256sums=('d105a905df34a7822172d13657cdae3d4b0c8e8c7067ccf05e39a40044f8ca53'
+            'a2f7a25a75041def0b775367a7497658a89e5c7c55fec716fdd965aa97fb97b5')
 noextract=(${_realname}-${pkgver}.tar.gz)
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
 
 prepare() {
   [[ -d ${srcdir}/${_realname}-${pkgver} ]] && rm -rf ${srcdir}/${_realname}-${pkgver}
   tar -xzf ${srcdir}/${_realname}-${pkgver}.tar.gz -C ${srcdir} || true
 
   cd "${srcdir}/${_realname}-${pkgver}"
-  patch -Np1 -i "${srcdir}/001-mingw-build.patch"
+  apply_patch_with_msg "001-mingw-build.patch"
 }
 
 build() {
-  cd "${srcdir}/${_realname}-${pkgver}"
-  make
+  rm -rf "${srcdir}/build-${CARCH}"
+  cp -r "${srcdir}/${_realname}-${pkgver}" "${srcdir}/build-${CARCH}"
+  cd "${srcdir}/build-${CARCH}"
+  CC=${MINGW_PREFIX}/bin/gcc make
 }
 
 package() {
-  cd "${srcdir}/${_realname}-${pkgver}"
+  cd "${srcdir}/build-${CARCH}"
   make DESTDIR="${pkgdir}" PREFIX="${MINGW_PREFIX}" install
 }

--- a/mingw-w64-libgdiplus/PKGBUILD
+++ b/mingw-w64-libgdiplus/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libgdiplus
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=5.6
+pkgver=5.6.1
 pkgrel=1
 pkgdesc="An Open Source Implementation of the GDI+ API (mingw-w64)"
 arch=('any')
@@ -23,7 +23,7 @@ source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/mono/${_realname}/a
         "0002-libgdiplus-5.4-fix-conflicting-types-error.patch"
         "0003-libgdiplus-5.4-fix-font-windows-error.patch"
         "0004-libgdiplus-5.4-disable-tests.patch")
-sha256sums=('6a75e4a476695cd6a1475fd6b989423ecf73978fd757673669771d8a6e13f756'
+sha256sums=('deff863023950b1d1de7e47e44fc31c8ba39cfc06334737261965f697b2ad312'
             '07ab03de3c86f18a9871794f6dd41de8852b42994e7845c220ba9ad8713f0e12'
             '0fc780dd34c01623a6910d6920d17549347b80351ed1baae05ad64f65c475dd4'
             '2835964746038b10f08f3530c450d7380c0b545b1a5c4884b8f513d7e6c0f809'

--- a/mingw-w64-mono/PKGBUILD
+++ b/mingw-w64-mono/PKGBUILD
@@ -4,8 +4,8 @@ _realname=mono
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 
-_gitcommit=8eb8f7d5e74787049316fef1f4d09f2e9e2d6968
-pkgver=5.10.1.47
+_gitcommit=9cb3348c311bd8a2dbb4a2fc3fb7ba026ac9bac5
+pkgver=5.18.1.0
 pkgrel=1
 pkgdesc='Free implementation of the .NET platform including runtime and compiler (mingw-w64)'
 url='http://www.mono-project.com/'


### PR DESCRIPTION
libgdiplus - 5.6.1 -  - update to latest release
mono -  5.18.1.0  - update to latest release