### PR TITLE
gdb-git: Upgrade to track `gdb-8.3-branch`.

### DIFF
--- a/mingw-w64-gdb-git/PKGBUILD
+++ b/mingw-w64-gdb-git/PKGBUILD
@@ -3,7 +3,7 @@
 # Contributor: Liu Hao <lh_mouse@126.com>
 
 _realname=gdb
-_branch=gdb-8.2-branch
+_branch=gdb-8.3-branch
 _gcc_ver=$(gcc -v 2>&1 | grep "^gcc version" | head -n1 | cut -c 13- | sed -r "s/\\s.*$//")
 pkgbase=mingw-w64-${_realname}-git
 pkgver=r94720.772f5e2f80


### PR DESCRIPTION
Signed-off-by: Liu Hao <lh_mouse@126.com>