### PR TITLE
Lib3mf: Add to version 1.8.1

### DIFF
--- a/mingw-w64-lib3mf/PKGBUILD
+++ b/mingw-w64-lib3mf/PKGBUILD
@@ -11,10 +11,18 @@ arch=('any')
 url='https://github.com/3MFConsortium/lib3mf'
 license=('BSD 2-Clause')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-pkg-config")
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+  "${MINGW_PACKAGE_PREFIX}-pkg-config")
 options=(!staticlibs strip)
-source=("${_realname}-${pkgver}.tar.gz"::"${url}/archive/v${pkgver}.tar.gz")
-sha256sums=('207dd142c9ca86a4fb1a4b2baadbdf579f35e03f9b8bf5c02dae027da5ae9d17')
+source=("${_realname}-${pkgver}.tar.gz"::"${url}/archive/v${pkgver}.tar.gz"
+  install_component.patch)
+sha256sums=('207dd142c9ca86a4fb1a4b2baadbdf579f35e03f9b8bf5c02dae027da5ae9d17'
+            '6a241fa8fd4f378661fdd11e06797524ce84db2854c630cbfa279add716c6c64')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+	patch -Np1 -i "${srcdir}"/install_component.patch
+}
 
 build() {
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
@@ -35,24 +43,10 @@ eval "package_${MINGW_PACKAGE_PREFIX}-${_realname}-devel() {
 
 package_lib3mf() {
   cd "${srcdir}/build-${MINGW_CHOST}"
-  make DESTDIR="${pkgdir}" install_arch
-#  ${MINGW_PREFIX}/bin/cmake.exe -DCMAKE_INSTALL_PREFIX="${pkgdir}"${MINGW_PREFIX} -DCOMPONENT=arch -P cmake_install.cmake
-#  make DESTDIR="${pkgdir}" install 
-#  install -Dm644 "${srcdir}/${_realname}-${pkgver}/Include/Model/COM/NMR_DLLInterfaces.h" "${pkgdir}${MINGW_PREFIX}/Include/NMR_DLLInterfaces.h"
+  make DESTDIR="${pkgdir}" install_bin
 }
 
 package_lib3mf-devel() {
   cd "${srcdir}/build-${MINGW_CHOST}"
-#  ${MINGW_PREFIX}/bin/cmake.exe -DCMAKE_INSTALL_PREFIX="${pkgdir}"${MINGW_PREFIX} -DCOMPONENT=inc -P cmake_install.cmake
-  make DESTDIR="${pkgdir}" install_inc install_lib
-#  ${MINGW_PREFIX}/bin/cmake.exe -DCMAKE_INSTALL_PREFIX="${pkgdir}"${MINGW_PREFIX} -DCOMPONENT=pkgconfig -P cmake_install.cmake
-#  ${MINGW_PREFIX}/bin/cmake.exe -DCMAKE_INSTALL_PREFIX="${pkgdir}"${MINGW_PREFIX} -DCOMPONENT=lib -P cmake_install.cmake
-#  make DESTDIR="${pkgdir}" install
-#  install -Dm644 "${srcdir}/${_realname}-${pkgver}/Include/Model/COM/NMR_DLLInterfaces.h" "${pkgdir}${MINGW_PREFIX}/Include/NMR_DLLInterfaces.h"
-#  install -Dm644 "${srcdir}/${_realname}-${pkgver}/Include/Model/COM/NMR_DLLInterfaces.h" "${pkgdir}${MINGW_PREFIX}/Include/NMR_DLLInterfaces.h"
+  make DESTDIR="${pkgdir}" install_devel
 }
-
-declare -f package_lib3mf 
-declare -f package_lib3mf-devel
-declare -f package_mingw-w64-x86_64-lib3mf
-declare -f package_mingw-w64-x86_64-lib3mf-devel

--- a/mingw-w64-lib3mf/PKGBUILD
+++ b/mingw-w64-lib3mf/PKGBUILD
@@ -1,0 +1,58 @@
+# Maintainer:
+
+_realname=lib3mf
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
+  "${MINGW_PACKAGE_PREFIX}-${_realname}-devel")
+pkgver=1.8.1
+pkgrel=1
+pkgdesc='Lib3MF is the reference implementation of the 3D Manufacturing Format file standard http://3mf.io'
+arch=('any')
+url='https://github.com/3MFConsortium/lib3mf'
+license=('BSD 2-Clause')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config")
+options=(!staticlibs strip)
+source=("${_realname}-${pkgver}.tar.gz"::"${url}/archive/v${pkgver}.tar.gz")
+sha256sums=('207dd142c9ca86a4fb1a4b2baadbdf579f35e03f9b8bf5c02dae027da5ae9d17')
+
+build() {
+  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
+  
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G "MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DLIB3MF_TESTS=OFF \
+    ../${_realname}-${pkgver}
+}
+
+eval "package_${MINGW_PACKAGE_PREFIX}-${_realname}() { package_${_realname}; }"
+eval "package_${MINGW_PACKAGE_PREFIX}-${_realname}-devel() {
+  depends=(\"\${MINGW_PACKAGE_PREFIX}-lib3mf\")
+  package_${_realname}-devel; }"
+
+package_lib3mf() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR="${pkgdir}" install_arch
+#  ${MINGW_PREFIX}/bin/cmake.exe -DCMAKE_INSTALL_PREFIX="${pkgdir}"${MINGW_PREFIX} -DCOMPONENT=arch -P cmake_install.cmake
+#  make DESTDIR="${pkgdir}" install 
+#  install -Dm644 "${srcdir}/${_realname}-${pkgver}/Include/Model/COM/NMR_DLLInterfaces.h" "${pkgdir}${MINGW_PREFIX}/Include/NMR_DLLInterfaces.h"
+}
+
+package_lib3mf-devel() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+#  ${MINGW_PREFIX}/bin/cmake.exe -DCMAKE_INSTALL_PREFIX="${pkgdir}"${MINGW_PREFIX} -DCOMPONENT=inc -P cmake_install.cmake
+  make DESTDIR="${pkgdir}" install_inc install_lib
+#  ${MINGW_PREFIX}/bin/cmake.exe -DCMAKE_INSTALL_PREFIX="${pkgdir}"${MINGW_PREFIX} -DCOMPONENT=pkgconfig -P cmake_install.cmake
+#  ${MINGW_PREFIX}/bin/cmake.exe -DCMAKE_INSTALL_PREFIX="${pkgdir}"${MINGW_PREFIX} -DCOMPONENT=lib -P cmake_install.cmake
+#  make DESTDIR="${pkgdir}" install
+#  install -Dm644 "${srcdir}/${_realname}-${pkgver}/Include/Model/COM/NMR_DLLInterfaces.h" "${pkgdir}${MINGW_PREFIX}/Include/NMR_DLLInterfaces.h"
+#  install -Dm644 "${srcdir}/${_realname}-${pkgver}/Include/Model/COM/NMR_DLLInterfaces.h" "${pkgdir}${MINGW_PREFIX}/Include/NMR_DLLInterfaces.h"
+}
+
+declare -f package_lib3mf 
+declare -f package_lib3mf-devel
+declare -f package_mingw-w64-x86_64-lib3mf
+declare -f package_mingw-w64-x86_64-lib3mf-devel

--- a/mingw-w64-lib3mf/install_component.patch
+++ b/mingw-w64-lib3mf/install_component.patch
@@ -1,0 +1,52 @@
+--- a/CMakeLists.txt.origin
++++ b/CMakeLists.txt
+@@ -135,17 +135,41 @@ if (UNIX OR MINGW)
+ 	SET_TARGET_PROPERTIES(${PROJECT_NAME} PROPERTIES VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}.${BUILD_NUMBER}")
+ 	SET_TARGET_PROPERTIES(${PROJECT_NAME} PROPERTIES SOVERSION "${PROJECT_VERSION_MAJOR}")
+ endif()
+-install(TARGETS ${PROJECT_NAME}
+-	ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+-	LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+-	RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+-install(DIRECTORY Include/Model DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+-install(DIRECTORY Include/Common DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Include/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
++include(GNUInstallDirs)
++install(TARGETS ${PROJECT_NAME} 
++	COMPONENT bin ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++	COMPONENT lib LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++	COMPONENT run RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
++install(FILES "Include/Model/COM/NMR_DLLInterfaces.h"
++  COMPONENT inc DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++install(FILES "Include/Model/Classes/NMR_ModelTypes.h"
++  COMPONENT inc DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/Model/Classes)
++install(FILES "Include/Model/COM/NMR_COMFactory.h"
++  "Include/Model/COM/NMR_COMInterfaces.h"
++  COMPONENT inc DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/Model/COM)
++install(FILES "Include/Common/Platform/NMR_COM_Native.h"
++  "Include/Common/Platform/NMR_SAL.h"
++  "Include/Common/Platform/NMR_WinTypes.h"
++  "Include/Common/Platform/NMR_COM_Emulation.h"
++  COMPONENT inc DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/Common/Platform)
++install(FILES "Include/Common/3MF_ProgressTypes.h"
++  COMPONENT inc DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/Common)
++install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Include/
++  COMPONENT inc DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++
++add_custom_target(install_bin
++  DEPENDS ${PROJECT_NAME}
++  COMMAND "${CMAKE_COMMAND}" -DCMAKE_INSTALL_COMPONENT=bin -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")
++add_custom_target(install_devel
++  DEPENDS ${PROJECT_NAME}
++  COMMAND "${CMAKE_COMMAND}" -DCMAKE_INSTALL_COMPONENT=lib -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
++  COMMAND "${CMAKE_COMMAND}" -DCMAKE_INSTALL_COMPONENT=inc -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
++  COMMAND "${CMAKE_COMMAND}" -DCMAKE_INSTALL_COMPONENT=pkgconfig -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")
+ 
+ #########################################################
+ configure_file(lib3MF.pc.in lib3MF.pc @ONLY)
+-install(FILES ${CMAKE_BINARY_DIR}/lib3MF.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
++install(FILES ${CMAKE_BINARY_DIR}/lib3MF.pc
++  COMPONENT pkgconfig DESTINATION ${CMAKE_INSTALL_LIBDIR}/lib)
+ 
+ #########################################################
+ option(LIB3MF_TESTS "Switch whether the tests of Lib3MF should be build" ON)


### PR DESCRIPTION
Lib3MF is the reference implementation of the 3D Manufacturing Format file standard http://3mf.io (https://github.com/3MFConsortium/lib3mf)
Required for example openscad. Split packages on bin/dll and devel. Patch CMakeLists for this.