### PR TITLE
libssh2: update to 1.8.2

### DIFF
--- a/mingw-w64-libssh2/PKGBUILD
+++ b/mingw-w64-libssh2/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libssh2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.8.1
+pkgver=1.8.2
 pkgrel=1
 pkgdesc="A library implementing the SSH2 protocol as defined by Internet Drafts (mingw-w64)"
 arch=('any')
@@ -13,7 +13,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=("${MINGW_PACKAGE_PREFIX}-openssl" "${MINGW_PACKAGE_PREFIX}-zlib")
 options=('staticlibs' 'strip')
 source=("${url}/download/${_realname}-${pkgver}.tar.gz")
-sha256sums=('40b517f35b1bb869d0075b15125c7a015557f53a5a3a6a8bffb89b69fd70f159')
+sha256sums=('088307d9f6b6c4b8c13f34602e8ff65d21c2dc4d55284dfe15d502c4ee190d67')
 
 build() {
   [[ -d "${srcdir}/build-${CARCH}" ]] && rm -rf "${srcdir}/build-${CARCH}"


### PR DESCRIPTION
This updates libssh2 to 1.8.2.