### PR TITLE
leptonica: update to 1.78.0

### DIFF
--- a/mingw-w64-leptonica/PKGBUILD
+++ b/mingw-w64-leptonica/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=leptonica
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.77.0
+pkgver=1.78.0
 pkgrel=1
 pkgdesc="Leptonica library (mingw-w64)"
 arch=('any')
@@ -19,7 +19,7 @@ depends=(${MINGW_PACKAGE_PREFIX}-gcc-libs
          ${MINGW_PACKAGE_PREFIX}-zlib)
 options=('!libtool' 'strip')
 source=(https://github.com/DanBloomberg/leptonica/releases/download/${pkgver}/${_realname}-${pkgver}.tar.gz)
-sha256sums=('161d0b368091986b6c60990edf257460bdc7da8dd18d48d4179e297bcdca5eb7')
+sha256sums=('e2ed2e81e7a22ddf45d2c05f0bc8b9ae7450545d995bfe28517ba408d14a5a88')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -27,8 +27,7 @@ prepare() {
 
 build() {
   [[ -d "${srcdir}/build-${CARCH}" ]] && rm -rf "${srcdir}/build-${CARCH}"
-  mkdir "${srcdir}/build-${CARCH}"
-  cd "${srcdir}/build-${CARCH}"
+  mkdir -p "${srcdir}/build-${CARCH}" && cd "${srcdir}/build-${CARCH}"
   CFLAGS+=" -DMINIMUM_SEVERITY=L_SEVERITY_WARNING"
   ../${_realname}-${pkgver}/configure \
     --disable-dependency-tracking \
@@ -48,4 +47,7 @@ build() {
 package() {
   cd "${srcdir}/build-${CARCH}"
   make DESTDIR="${pkgdir}" install
+
+  # Fix .pc file
+  sed -s "s|$(cygpath -m ${MINGW_PREFIX})|${MINGW_PREFIX}|g" -i "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/lept.pc
 }


### PR DESCRIPTION
This updates leptonica to 1.78.0. The pkg-config file is also fixed.