### PR TITLE
mingw-w64-openjpeg2 - 2.3.1 - - Update to latest version

### DIFF
--- a/mingw-w64-openjpeg2/0002-cmake-files-destination.patch
+++ b/mingw-w64-openjpeg2/0002-cmake-files-destination.patch
@@ -9,14 +9,3 @@
  endif()
  
  if (APPLE)
---- openjpeg-2.3.0/cmake/OpenJPEGConfig.cmake.in.orig	2018-08-21 10:42:11.707314700 +0300
-+++ openjpeg-2.3.0/cmake/OpenJPEGConfig.cmake.in	2018-08-21 10:42:18.490702700 +0300
-@@ -26,7 +26,7 @@
- if(EXISTS ${SELF_DIR}/OpenJPEGTargets.cmake)
-   # This is an install tree
-   include(${SELF_DIR}/OpenJPEGTargets.cmake)
--  get_filename_component(OPENJPEG_INCLUDE_ROOT "${SELF_DIR}/../../@OPENJPEG_INSTALL_INCLUDE_DIR@" ABSOLUTE)
-+  get_filename_component(OPENJPEG_INCLUDE_ROOT "${SELF_DIR}/../../../@OPENJPEG_INSTALL_INCLUDE_DIR@" ABSOLUTE)
-   set(OPENJPEG_INCLUDE_DIRS ${OPENJPEG_INCLUDE_ROOT})
- 
- else()

--- a/mingw-w64-openjpeg2/0003-versioned-dlls.mingw.patch
+++ b/mingw-w64-openjpeg2/0003-versioned-dlls.mingw.patch
@@ -1,56 +1,65 @@
---- openjpeg-2.1.2/src/lib/openjp2/CMakeLists.txt.orig	2016-10-01 08:31:32.273920100 -0400
-+++ openjpeg-2.1.2/src/lib/openjp2/CMakeLists.txt	2016-10-01 08:36:28.474703900 -0400
-@@ -85,7 +85,7 @@
- if(UNIX)
+--- openjpeg-2.3.1/src/lib/openjp2/CMakeLists.txt.orig	2019-04-04 02:55:04.959853700 -0400
++++ openjpeg-2.3.1/src/lib/openjp2/CMakeLists.txt	2019-04-04 03:02:55.237882800 -0400
+@@ -107,6 +107,9 @@ if(UNIX)
    target_link_libraries(${OPENJPEG_LIBRARY_NAME} m)
  endif()
--set_target_properties(${OPENJPEG_LIBRARY_NAME} PROPERTIES ${OPENJPEG_LIBRARY_PROPERTIES})
-+set_target_properties(${OPENJPEG_LIBRARY_NAME} PROPERTIES ${OPENJPEG_LIBRARY_PROPERTIES} OUTPUT_NAME openjp2 RUNTIME_OUTPUT_NAME openjp2-${OPENJPEG_SOVERSION} ARCHIVE_OUTPUT_NAME openjp2)
- if(${CMAKE_VERSION} VERSION_GREATER "2.8.11")
-   target_compile_options(${OPENJPEG_LIBRARY_NAME} PRIVATE ${OPENJPEG_LIBRARY_COMPILE_OPTIONS})
+ set_target_properties(${OPENJPEG_LIBRARY_NAME} PROPERTIES ${OPENJPEG_LIBRARY_PROPERTIES})
++if(MINGW)
++  set_target_properties(${OPENJPEG_LIBRARY_NAME} PROPERTIES OUTPUT_NAME openjp2 RUNTIME_OUTPUT_NAME openjp2-${OPENJPEG_SOVERSION} ARCHIVE_OUTPUT_NAME openjp2)
++endif(MINGW)
+ if(NOT ${CMAKE_VERSION} VERSION_LESS "2.8.12")
+   target_compile_options(${OPENJPEG_LIBRARY_NAME} PRIVATE ${OPENJP2_COMPILE_OPTIONS})
  endif()
---- openjpeg-2.1.2/src/lib/openjp3d/CMakeLists.txt.orig	2016-10-01 08:59:49.819661900 -0400
-+++ openjpeg-2.1.2/src/lib/openjp3d/CMakeLists.txt	2016-10-01 09:33:11.456919300 -0400
-@@ -26,7 +26,7 @@
- if(UNIX)
+--- openjpeg-2.3.1/src/lib/openjp3d/CMakeLists.txt.orig	2019-04-04 02:55:04.961847200 -0400
++++ openjpeg-2.3.1/src/lib/openjp3d/CMakeLists.txt	2019-04-04 03:07:09.045105000 -0400
+@@ -27,6 +27,9 @@ if(UNIX)
    target_link_libraries(${OPENJP3D_LIBRARY_NAME} m)
  endif()
--set_target_properties(${OPENJP3D_LIBRARY_NAME} PROPERTIES ${OPENJPEG_LIBRARY_PROPERTIES})
-+set_target_properties(${OPENJP3D_LIBRARY_NAME} PROPERTIES ${OPENJPEG_LIBRARY_PROPERTIES} OUTPUT_NAME openjp3d RUNTIME_OUTPUT_NAME openjp3d-${OPENJPEG_SOVERSION} ARCHIVE_OUTPUT_NAME openjp3d)
- if(${CMAKE_VERSION} VERSION_GREATER "2.8.11")
+ set_target_properties(${OPENJP3D_LIBRARY_NAME} PROPERTIES ${OPENJPEG_LIBRARY_PROPERTIES})
++if(MINGW)
++  set_target_properties(${OPENJP3D_LIBRARY_NAME} PROPERTIES OUTPUT_NAME openjp3d RUNTIME_OUTPUT_NAME openjp3d-${OPENJPEG_SOVERSION} ARCHIVE_OUTPUT_NAME openjp3d)
++endif(MINGW)
+ if(NOT ${CMAKE_VERSION} VERSION_LESS "2.8.12")
    target_compile_options(${OPENJP3D_LIBRARY_NAME} PRIVATE ${OPENJPEG_LIBRARY_COMPILE_OPTIONS})
  endif()
---- openjpeg-2.1.2/src/lib/openjpip/CMakeLists.txt.orig	2016-10-01 08:31:32.305170000 -0400
-+++ openjpeg-2.1.2/src/lib/openjpip/CMakeLists.txt	2016-10-01 08:40:01.492903300 -0400
-@@ -60,8 +60,7 @@
-   endif()
- endif()
+--- openjpeg-2.3.1/src/lib/openjpip/CMakeLists.txt.orig	2019-04-04 02:55:04.963841200 -0400
++++ openjpeg-2.3.1/src/lib/openjpip/CMakeLists.txt	2019-04-04 03:17:37.009413600 -0400
+@@ -62,6 +62,11 @@ endif()
  add_library(openjpip ${OPENJPIP_SRCS} ${LOCAL_SRCS})
--set_target_properties(openjpip
--  PROPERTIES ${OPENJPEG_LIBRARY_PROPERTIES})
-+set_target_properties(openjpip PROPERTIES ${OPENJPEG_LIBRARY_PROPERTIES} OUTPUT_NAME openjpip RUNTIME_OUTPUT_NAME openjpip-${OPENJPEG_SOVERSION} ARCHIVE_OUTPUT_NAME openjpip)
- if(${CMAKE_VERSION} VERSION_GREATER "2.8.11")
+ set_target_properties(openjpip
+   PROPERTIES ${OPENJPEG_LIBRARY_PROPERTIES})
++if(MINGW)
++  set_target_properties(openjpip 
++    PROPERTIES OUTPUT_NAME openjpip RUNTIME_OUTPUT_NAME openjpip-${OPENJPEG_SOVERSION} 
++    ARCHIVE_OUTPUT_NAME openjpip)
++endif()
+ if(NOT ${CMAKE_VERSION} VERSION_LESS "2.8.12")
    target_compile_options(openjpip PRIVATE ${OPENJPEG_LIBRARY_COMPILE_OPTIONS})
  endif()
---- openjpeg-2.1.2/src/lib/openjpwl/CMakeLists.txt.orig	2016-10-01 08:59:49.830163000 -0400
-+++ openjpeg-2.1.2/src/lib/openjpwl/CMakeLists.txt	2016-10-01 09:38:06.899451900 -0400
-@@ -50,7 +50,7 @@
-   target_link_libraries(openjpwl m)
+--- openjpeg-2.3.1/src/lib/openjpwl/CMakeLists.txt.orig	2019-04-04 02:55:04.966861700 -0400
++++ openjpeg-2.3.1/src/lib/openjpwl/CMakeLists.txt	2019-04-04 03:21:28.997116400 -0400
+@@ -51,6 +51,10 @@ if(UNIX)
  endif()
  set_target_properties(openjpwl
--  PROPERTIES ${OPENJPEG_LIBRARY_PROPERTIES})
-+  PROPERTIES ${OPENJPEG_LIBRARY_PROPERTIES} OUTPUT_NAME openjpwl RUNTIME_OUTPUT_NAME openjpwl-${OPENJPEG_SOVERSION} ARCHIVE_OUTPUT_NAME openjpwl)
- if(${CMAKE_VERSION} VERSION_GREATER "2.8.11")
+   PROPERTIES ${OPENJPEG_LIBRARY_PROPERTIES})
++if(MINGW)
++  set_target_properties(openjpwl 
++  PROPERTIES OUTPUT_NAME openjpwl RUNTIME_OUTPUT_NAME openjpwl-${OPENJPEG_SOVERSION} ARCHIVE_OUTPUT_NAME openjpwl)
++endif(MINGW)
+ if(NOT ${CMAKE_VERSION} VERSION_LESS "2.8.12")
    target_compile_options(openjpwl PRIVATE ${OPENJPEG_LIBRARY_COMPILE_OPTIONS})
  endif()
---- openjpeg-2.1.2/src/lib/openmj2/CMakeLists.txt.orig	2016-10-01 08:59:49.839164400 -0400
-+++ openjpeg-2.1.2/src/lib/openmj2/CMakeLists.txt	2016-10-01 09:44:10.251707400 -0400
-@@ -45,7 +45,7 @@
- if(UNIX)
+--- openjpeg-2.3.1/src/lib/openmj2/CMakeLists.txt.orig	2019-04-04 02:55:04.968854100 -0400
++++ openjpeg-2.3.1/src/lib/openmj2/CMakeLists.txt	2019-04-04 03:28:00.801821500 -0400
+@@ -46,6 +46,11 @@ if(UNIX)
    target_link_libraries(${OPENMJ2_LIBRARY_NAME} m)
  endif()
--set_target_properties(${OPENMJ2_LIBRARY_NAME} PROPERTIES ${OPENJPEG_LIBRARY_PROPERTIES})
-+set_target_properties(${OPENMJ2_LIBRARY_NAME} PROPERTIES ${OPENJPEG_LIBRARY_PROPERTIES} OUTPUT_NAME openmj2 RUNTIME_OUTPUT_NAME openmj2-${OPENJPEG_SOVERSION} ARCHIVE_OUTPUT_NAME openmj2)
- if(${CMAKE_VERSION} VERSION_GREATER "2.8.11")
+ set_target_properties(${OPENMJ2_LIBRARY_NAME} PROPERTIES ${OPENJPEG_LIBRARY_PROPERTIES})
++if(MINGW)
++  set_target_properties(${OPENMJ2_LIBRARY_NAME} PROPERTIES OUTPUT_NAME openmj2 
++     RUNTIME_OUTPUT_NAME openmj2-${OPENJPEG_SOVERSION} 
++     ARCHIVE_OUTPUT_NAME openmj2)
++endif(MINGW)
+ if(NOT ${CMAKE_VERSION} VERSION_LESS "2.8.12")
    target_compile_options(${OPENMJ2_LIBRARY_NAME} PRIVATE ${OPENJPEG_LIBRARY_COMPILE_OPTIONS})
  endif()

--- a/mingw-w64-openjpeg2/0004-mingw-disable-java.patch
+++ b/mingw-w64-openjpeg2/0004-mingw-disable-java.patch
@@ -1,0 +1,17 @@
+--- openjpeg-2.3.1/src/bin/jpip/CMakeLists.txt.orig	2019-04-04 03:43:35.698890000 -0400
++++ openjpeg-2.3.1/src/bin/jpip/CMakeLists.txt	2019-04-04 03:47:36.921116900 -0400
+@@ -68,6 +68,7 @@ if(NOT DEFINED JAVA_TARGET_VERSION)
+ endif()
+ 
+ # Only build the java viewer if dev is found:
++if(NOT MINGW)
+ if(Java_Development_FOUND AND Java_JAVAC_EXECUTABLE)
+   set(jflags $ENV{JFLAGS})
+   # search for package org.apache.xerces.parsers
+@@ -159,3 +160,6 @@ if(Java_Development_FOUND AND Java_JAVAC
+ else()
+   message(WARNING "No java compiler found. Wont be able to build java viewer")
+ endif()
++else()
++    message(WARNING "MINGW does NOT support JAVA. Will NOT build java viewer")
++endif(NOT MINGW)

--- a/mingw-w64-openjpeg2/0005-sock-jpip.all.patch
+++ b/mingw-w64-openjpeg2/0005-sock-jpip.all.patch
@@ -1,21 +1,11 @@
---- openjpeg-2.1.0/src/lib/openjpip/sock_manager.c.orig	2014-04-29 07:15:01.000000000 +0000
-+++ openjpeg-2.1.0/src/lib/openjpip/sock_manager.c	2014-07-29 15:35:10.066130700 +0000
-@@ -28,13 +28,17 @@
-  * POSSIBILITY OF SUCH DAMAGE.
+--- openjpeg-2.3.1/src/lib/openjpip/sock_manager.c.orig	2019-04-04 03:29:40.223754700 -0400
++++ openjpeg-2.3.1/src/lib/openjpip/sock_manager.c	2019-04-04 03:35:01.793021400 -0400
+@@ -29,6 +29,8 @@
   */
  
--#ifdef _WIN32
-+#ifdef _MSC_VER
- #include <windows.h>
- typedef SSIZE_T ssize_t;
- #else
- #include <sys/types.h>
-+#ifdef _WIN32
+ #ifdef _WIN32
++#include <winsock2.h>
 +#include <ws2tcpip.h>
-+#else
- #include <sys/socket.h>
- #include <arpa/inet.h>
-+#endif
- #include <unistd.h>
- #endif
- 
+ #include <windows.h>
+ #ifdef _MSC_VER
+ typedef SSIZE_T ssize_t;

--- a/mingw-w64-openjpeg2/PKGBUILD
+++ b/mingw-w64-openjpeg2/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=openjpeg
 pkgbase=mingw-w64-${_realname}2
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}2"
-pkgver=2.3.0
-pkgrel=2
+pkgver=2.3.1
+pkgrel=1
 pkgdesc="An open source JPEG 2000 codec (mingw-w64)"
 arch=('any')
 url="http://www.openjpeg.org"
@@ -22,21 +22,43 @@ source=(${_realname}-${pkgver}.tar.gz::https://github.com/uclouvain/openjpeg/arc
         0001-fix-install-for-dlls.all.patch
         0002-cmake-files-destination.patch
         0003-versioned-dlls.mingw.patch
+        0004-mingw-disable-java.patch
         0005-sock-jpip.all.patch
         0006-openjpeg-2.1.0-stdcall-for-all-win.patch)
-sha256sums=('3dc787c1bb6023ba846c2a0d9b1f6e179f1cd255172bde9eb75b01f1e6c7d71a'
+sha256sums=('63f5a4713ecafc86de51bfad89cc07bb788e9bba24ebbf0c4ca637621aadb6a9'
             '3f3bde353ca3432f157258164c5e3c345af82ca3a9d5a68f815c3030b01cbc32'
-            '1af48e3b746c27ecbfbff22a13a30956b755bf560975b9128414f83f9db723ec'
-            'b45bc20a761b0d8dfd039ee9443a12d95ddd89ce05683fe0510fb8061f608b78'
-            'b7b22dca26d5fd98ca5bc6ce775bbbabebc0e10fcf07fd0afb54d580699b8312'
+            '31b2cc6824b07b705ba1c05b38904c8c4fc6ba39acefebda3e6ec85dbef9a174'
+            '0f95f52b6fd662acb84b481a998ec4170369fe94247e0fa227fcda1f6ba18f1b'
+            'adade9b29e4292b642d547644e26fab6e193bbfe31d25f07d89a8c35e4d0993d'
+            '9df169f03e6e69cba0d7d33592f9eba373a02cd9554b456d3eb9ff3d9135391b'
             'e8c375faa317c819174b50aa43b6be61c108872661b014738c4a0cfa95aac919')
 
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
-  patch -p1 -i ${srcdir}/0001-fix-install-for-dlls.all.patch
-  patch -p1 -i ${srcdir}/0002-cmake-files-destination.patch
-  patch -p1 -i ${srcdir}/0003-versioned-dlls.mingw.patch
-  patch -p1 -i ${srcdir}/0005-sock-jpip.all.patch
+  apply_patch_with_msg \
+   0001-fix-install-for-dlls.all.patch \
+   0002-cmake-files-destination.patch \
+   0003-versioned-dlls.mingw.patch \
+   0004-mingw-disable-java.patch \
+   0005-sock-jpip.all.patch
   #patch -p1 -i ${srcdir}/0006-openjpeg-2.1.0-stdcall-for-all-win.patch
 }
 
@@ -60,6 +82,7 @@ build() {
     -DBUILD_JP3D=ON \
     -DBUILD_JAVA=OFF \
     ../${_realname}-${pkgver}
+
   make
 
   msg "Build shared version"


### PR DESCRIPTION
Update  patches for new version and add a patch to disable the Java  opj_viewer .jar since we don't support Java.