### PR TITLE
libnotify: update to 0.7.8

### DIFF
--- a/mingw-w64-libnotify/PKGBUILD
+++ b/mingw-w64-libnotify/PKGBUILD
@@ -5,7 +5,7 @@
 _realname=libnotify
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.7.7
+pkgver=0.7.8
 pkgrel=1
 pkgdesc="Desktop notification library (mingw-w64)"
 arch=('any')
@@ -22,7 +22,7 @@ source=("https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realnam
         "introspection.patch"
         "test-fix.patch"
         "glib-mkenums.patch")
-sha256sums=('9cb4ce315b2655860c524d46b56010874214ec27e854086c1a1d0260137efc04'
+sha256sums=('69209e0b663776a00c7b6c0e560302a8dbf66b2551d55616304f240bba66e18c'
             '7c5795ac0a74a2d5efdc13ae05d610acc8176fce7114ed6b9322be4f0ca710e9'
             '185e7885512106172627525a4ec1fc18c2f95844f733e49cece325874a55f8e6'
             'fde6d3cd8c6000d21df1363eece53119827526b70e66e939eec3df1ba69cc141')


### PR DESCRIPTION
This updates libnotify to 0.7.8.