### PR TITLE
libcroco: update to 0.6.13

### DIFF
--- a/mingw-w64-libcroco/PKGBUILD
+++ b/mingw-w64-libcroco/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libcroco
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.6.12
+pkgver=0.6.13
 pkgrel=1
 pkgdesc="A CSS parsing library (mingw-w64)"
 arch=('any')
@@ -13,7 +13,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=("${MINGW_PACKAGE_PREFIX}-glib2" "${MINGW_PACKAGE_PREFIX}-libxml2")
 options=('staticlibs' 'strip')
 source=("https://download.gnome.org/sources/libcroco/${pkgver%.*}/${_realname}-${pkgver}.tar.xz")
-sha256sums=('ddc4b5546c9fb4280a5017e2707fbd4839034ed1aba5b7d4372212f34f84f860')
+sha256sums=('767ec234ae7aa684695b3a735548224888132e063f92db585759b422570621d4')
 
 build() {
   mkdir -p "${srcdir}/build-${MINGW_CHOST}"


### PR DESCRIPTION
This updates libcroco to 0.6.13.