### PR TITLE
source-highlight-3.1.8-  - various improvements

### DIFF
--- a/mingw-w64-source-highlight/3.1.4-no-undefined.patch
+++ b/mingw-w64-source-highlight/3.1.4-no-undefined.patch
@@ -1,0 +1,11 @@
+--- origsrc/source-highlight-3.1.4/lib/srchilite/Makefile.am	2010-06-14 09:41:58.000000000 -0500
++++ src/source-highlight-3.1.4/lib/srchilite/Makefile.am	2010-09-07 00:33:53.901330300 -0500
+@@ -98,7 +98,7 @@ libsource_highlight_la_SOURCES = \
+ libsource_highlight_la_LIBADD = $(top_builddir)/gl/libgnu.la \
+ 	@LTLIBOBJS@ $(BOOST_REGEX_LIB)
+ 
+-libsource_highlight_la_LDFLAGS = $(AM_LDFLAGS) -version-info $(LIBRARY_VERSION)
++libsource_highlight_la_LDFLAGS = $(AM_LDFLAGS) -version-info $(LIBRARY_VERSION) -no-undefined
+ 
+ library_includedir=$(includedir)/$(LIBRARY_NAMESPACE)
+ library_include_HEADERS = $(h_sources)

--- a/mingw-w64-source-highlight/PKGBUILD
+++ b/mingw-w64-source-highlight/PKGBUILD
@@ -4,18 +4,51 @@ _realname=source-highlight
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=3.1.8
-pkgrel=1
+pkgrel=2
 pkgdesc="Convert source code to syntax highlighted document (mingw-w64)"
 arch=('any')
 url="https://www.gnu.org/software/src-highlite/"
 license=('GPL')
 depends=("bash" "${MINGW_PACKAGE_PREFIX}-boost")
-#makedepends=("ctags" "${MINGW_PACKAGE_PREFIX}-boost")
-source=("https://ftp.gnu.org/gnu/src-highlite/${_realname}-${pkgver}.tar.gz")
-sha256sums=('01336a7ea1d1ccc374201f7b81ffa94d0aecb33afc7d6903ebf9fbf33a55ada3')
+makedepends=("${MINGW_PACKAGE_PREFIX}-ctags" 
+             "${MINGW_PACKAGE_PREFIX}-doxygen"
+             "${MINGW_PACKAGE_PREFIX}-graphviz")
+source=("https://ftp.gnu.org/gnu/src-highlite/${_realname}-${pkgver}.tar.gz"
+        "3.1.4-no-undefined.patch"
+        "fix-zsh-highlighting-hangups.patch")
+sha256sums=('01336a7ea1d1ccc374201f7b81ffa94d0aecb33afc7d6903ebf9fbf33a55ada3'
+            '971063177b338e9a037b755c9ade11f8a2d6ec44be576da24e0a73d33fe63fc7'
+            '11248760543ffd9801a2ce40e7fbf7c511c56f82b4c0338b1b79518d37685327')
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+apply_patch_p2_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp2 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
 
 prepare() {
   cd "$srcdir"/${_realname}-${pkgver}
+  apply_patch_p2_with_msg 3.1.4-no-undefined.patch
+  apply_patch_with_msg fix-zsh-highlighting-hangups.patch
   autoreconf -fiv
 }
 
@@ -29,12 +62,18 @@ build() {
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \
     --with-boost-libdir=${MINGW_PREFIX}/lib \
-    --with-bash-completion=no
+    --with-bash-completion=no \
+    --with-doxygen=on
+# Fix source documentation so your packaging dirs don't appear
+  sed "s|STRIP_FROM_PATH =*|STRIP_FROM_PATH = $(cygpath -m ${srcdir})|g" \
+     -i lib/srchilite/srchilite.doxyfile
   make
 }
 
 package() {
   cd "${srcdir}"/build-${CARCH}
   make install DESTDIR="${pkgdir}"
-
+  #Fix documentation to give a sensible path for source.
+#  local _src="$(cygpath -m ${srcdir}/src)"
+  
 }

--- a/mingw-w64-source-highlight/fix-zsh-highlighting-hangups.patch
+++ b/mingw-w64-source-highlight/fix-zsh-highlighting-hangups.patch
@@ -1,0 +1,13 @@
+diff --git a/src/zsh.lang b/src/zsh.lang
+index 69542a7..a0bac36 100644
+--- a/src/zsh.lang
++++ b/src/zsh.lang
+@@ -35,7 +35,7 @@ keyword = "alias|always|autoload|bg|bindkey|break|builtin",
+           "unlimit|unset|unsetopt|until|vared|wait|whence",
+           "where|which|while|zcompile|zformat|zftp|zle",
+           "zmodload|zparseopts|zprof|zpty|zregexparse",
+-          "zsocket|zstyle|ztcp|"
++          "zsocket|zstyle|ztcp"
+ 
+ variable = '\$\{([^[:blank:]]+)\}'
+ variable = '\$\(([^[:blank:]]+)\)'


### PR DESCRIPTION
0 add3.1.4-no-undefined.patch 0 from Cygwin  to make .DLL's
 fix-zsh-highlighting-hangups.patch - from Archlinux to fix a problem they found
fbuild Documentation with Doxygen
fix depends so that building requires ${MINGW_PACKAGE_PREFIX}-ctags and ${MINGW_PACKAGE_PREFIX}-doxygen for documentation.  This is onlyr equired for builds.