### PR TITLE
gegl: Update to 0.4.14, enable ffmpeg plugin

### DIFF
--- a/mingw-w64-gegl/001-gegl-0.4.14-win32-build.patch
+++ b/mingw-w64-gegl/001-gegl-0.4.14-win32-build.patch
@@ -1,0 +1,13 @@
+--- gegl-0.4.14/gegl/gegl-config.c.orig
++++ gegl-0.4.14/gegl/gegl-config.c
+@@ -34,6 +34,10 @@
+ #include <unistd.h>
+ #endif
+ 
++#ifdef G_OS_WIN32
++#include <windows.h>
++#endif
++
+ G_DEFINE_TYPE (GeglConfig, gegl_config, G_TYPE_OBJECT)
+ 
+ static GObjectClass * parent_class = NULL;

--- a/mingw-w64-gegl/002-gegl-0.4.14-libavutil.patch
+++ b/mingw-w64-gegl/002-gegl-0.4.14-libavutil.patch
@@ -1,0 +1,22 @@
+--- gegl-0.4.14/configure.ac.orig
++++ gegl-0.4.14/configure.ac
+@@ -66,6 +66,7 @@
+ m4_define([vapigen_required_version], [0.20.0])
+ m4_define([libavformat_required_version], [55.48.100])
+ m4_define([libavcodec_required_version], [55.69.100])
++m4_define([libavutil_required_version], [52.92.100])
+ m4_define([libswscale_required_version], [2.6.100])
+ 
+ AC_INIT(gegl, gegl_major_version.gegl_minor_version.gegl_micro_version)
+@@ -1072,9 +1073,9 @@
+ AC_ARG_WITH(libavformat,  [  --without-libavformat   build without libavformat support])
+ 
+ if test "x$with_libavformat" != xno; then
+-  PKG_CHECK_MODULES(AVFORMAT, libavformat >= libavformat_required_version libavcodec >= libavcodec_required_version libswscale >= libswscale_required_version,
++  PKG_CHECK_MODULES(AVFORMAT, libavformat >= libavformat_required_version libavcodec >= libavcodec_required_version libavutil >= libavutil_required_version libswscale >= libswscale_required_version,
+     have_libavformat="yes",
+-    have_libavformat="no  (sufficiently new libavformat / libavcodec or libswcale not found)")
++    have_libavformat="no  (sufficiently new libavformat / libavcodec / libavutil or libswcale not found)")
+   # verify the presence of the avformat.h header
+   if test "x$have_libavformat" = "xyes"; then
+     gegl_save_CPPFLAGS=$CPPFLAGS

--- a/mingw-w64-gegl/PKGBUILD
+++ b/mingw-w64-gegl/PKGBUILD
@@ -7,7 +7,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
-pkgver=0.4.12
+pkgver=0.4.14
 pkgrel=1
 pkgdesc="Generic Graphics Library (mingw-w64)"
 arch=('any')
@@ -15,7 +15,6 @@ url="http://gegl.org/"
 license=("GPL-3.0+" "LGPL-3.0+")
 makedepends=("asciidoc"
              "intltool"
-             #"${MINGW_PACKAGE_PREFIX}-ffmpeg"
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
              "${MINGW_PACKAGE_PREFIX}-lua"
@@ -45,18 +44,21 @@ depends=("${MINGW_PACKAGE_PREFIX}-babl"
          "${MINGW_PACKAGE_PREFIX}-pango"
          "${MINGW_PACKAGE_PREFIX}-SDL"
          "${MINGW_PACKAGE_PREFIX}-suitesparse")
-#optdepends=("${MINGW_PACKAGE_PREFIX}-openexr: for using the openexr plugin"
-#            "${MINGW_PACKAGE_PREFIX}-ffmpeg: for using the ffmpeg plugin"
-#            "${MINGW_PACKAGE_PREFIX}-librsvg: for using the svg plugin"
-#            "${MINGW_PACKAGE_PREFIX}-jasper: for using the jasper plugin")
+optdepends=("${MINGW_PACKAGE_PREFIX}-ffmpeg: for using the ffmpeg plugin")
 #options=('!strip' 'debug')
 source=(#"${_realname}"::"git+https://git.gnome.org/browse/gegl"
-        https://ftp.gtk.org/pub/gegl/${pkgver%.*}/${_realname}-${pkgver}.tar.bz2)
-sha256sums=('e967293eabe89257e1d511bf68435fbfd44e6e0f9ef51b86cc50781f09eb5852')
+        https://ftp.gtk.org/pub/gegl/${pkgver%.*}/${_realname}-${pkgver}.tar.bz2
+        001-gegl-0.4.14-win32-build.patch
+        002-gegl-0.4.14-libavutil.patch)
+sha256sums=('4c01d58599d8ddb3714effd2675ea1863272cf2d7d9ed3d32aee80c89f859901'
+            'd166929e7c5c5f279742453314f24faf9fe5ae6d56c2e9f68de8c1c94d14da75'
+            'b1948b5916fdf9d324dc1ac2c96758d9e68f69660950ce4e5cf8575f77eb8fcf')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
-  #autoreconf --force --install --verbose
+  patch -p1 -i ${srcdir}/001-gegl-0.4.14-win32-build.patch
+  patch -p1 -i ${srcdir}/002-gegl-0.4.14-libavutil.patch
+  autoreconf --force --install --verbose
 }
 
 build() {
@@ -83,7 +85,7 @@ build() {
     --with-openexr \
     --with-librsvg \
     --with-jasper \
-    --without-libavformat \
+    --with-libavformat \
     --disable-docs \
     --with-vala \
     --enable-introspection \


### PR DESCRIPTION
This new version is required by the latest GIMP 2.10.10. The patches are from upstream, and will not be needed for subsequent releases. I made ffmpeg an optional dependency because it is a large install for just one plugin; also this is what Arch does.