### PR TITLE
WIP: glib2: Update to 2.60.0

### DIFF
--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -6,7 +6,7 @@
 _realname=glib2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.58.3
+pkgver=2.60.0
 pkgrel=1
 url="https://www.gtk.org/"
 arch=('any')
@@ -30,7 +30,7 @@ source=("https://download.gnome.org/sources/glib/${pkgver%.*}/glib-${pkgver}.tar
         0001-Revert-tests-W32-ugly-fix-for-sscanf-format.patch
         pyscript2exe.py
         )
-sha256sums=('8f43c31767e88a25da72b52a40f3301fefc49a665b56dc10ee7cc9565cbe7481'
+sha256sums=('20865d8b96840d89d9340fc485b4b1131c1bb24d16a258a22d642c3bb1b44353'
             'ff0d3df5d57cf621cac79f5bea8bd175e6c18b3fbf7cdd02df38c1eab9f40ac3'
             '838abaeab8ca4978770222ef5f88c4b464545dd591b2d532c698caa875b46931'
             '0f44135a139e3951c4b5fa7d4628d75226e0666d891faf524777e1d1ec3b440b'
@@ -67,7 +67,6 @@ build() {
     -Ddefault_library=shared \
     -Dman=true \
     -Dforce_posix_threads=true \
-    -Dgtk_doc=true \
     "../glib-${pkgver}"
   ninja
 }


### PR DESCRIPTION
gtk-doc disabled for now since "ninja gio-doc" fails for some reason