### PR TITLE
python3: fix HAVE_INET_PTON configure check on Windows. Fixes #5184

### DIFF
--- a/mingw-w64-python3/2010-configure-have-inet-pton.patch
+++ b/mingw-w64-python3/2010-configure-have-inet-pton.patch
@@ -1,0 +1,17 @@
+--- Python-3.7.2/configure.ac.orig	2019-04-13 17:14:32.296998700 +0200
++++ Python-3.7.2/configure.ac	2019-04-13 17:27:16.307347800 +0200
+@@ -4107,10 +4107,14 @@
+ 
+ AC_MSG_CHECKING(for inet_pton)
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
++#ifdef _WIN32
++#include <ws2tcpip.h>
++#else
+ #include <sys/types.h>
+ #include <sys/socket.h>
+ #include <netinet/in.h>
+ #include <arpa/inet.h>
++#endif
+ ]], [[void* p = inet_pton]])],
+   [AC_DEFINE(HAVE_INET_PTON, 1, Define if you have the 'inet_pton' function.)
+    AC_MSG_RESULT(yes)],

--- a/mingw-w64-python3/PKGBUILD
+++ b/mingw-w64-python3/PKGBUILD
@@ -18,7 +18,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _pybasever=3.7
 pkgver=${_pybasever}.2
-pkgrel=2
+pkgrel=3
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 license=('PSF')
@@ -125,6 +125,7 @@ source=("https://www.python.org/ftp/python/${pkgver%rc?}/Python-${pkgver}.tar.xz
         1860-fix-isselectable.patch
         2000-warnings-fixes.patch
         1900-ctypes-dont-depend-on-internal-libffi.patch
+        2010-configure-have-inet-pton.patch
         smoketests.py)
 
 # Helper macros to help make tasks easier #
@@ -282,6 +283,9 @@ prepare() {
 
   # https://github.com/python/cpython/pull/9258
   apply_patch_with_msg 1900-ctypes-dont-depend-on-internal-libffi.patch
+
+  # https://github.com/msys2/MINGW-packages/issues/5184
+  apply_patch_with_msg 2010-configure-have-inet-pton.patch
 
   autoreconf -vfi
 
@@ -511,4 +515,5 @@ sha256sums=('d83fe8ce51b1bb48bbcf0550fd265b9a75cdfdfa93f916f9e700aef8444bf1bb'
             'bd9b934e8c1f92573115efaef6b6b04966e3222ba769511e006366d1217d34d6'
             'e91f897e43063e0c4e52d971f5de4b5e193d9eb6a35fc3acfca1dc057a2fcd65'
             'e3b0171303b3e28a7347a81b1110dfe42df92a87d160caf624510304d5390728'
-            'a547d3de6a619f5f8e8e44f87c8f726271f1cfc2449e91c63022cfd82dff430e')
+            '150dc7a5c59ef82b0bf258a2cd4233f2975fb89818849de39c185ce368a124ab'
+            '821402ddaef92140c70041b007bcf15e1cd5fe0fdb9f4f612da868382cc24585')

--- a/mingw-w64-python3/smoketests.py
+++ b/mingw-w64-python3/smoketests.py
@@ -51,6 +51,14 @@ class Tests(unittest.TestCase):
         import ssl
         import ctypes
 
+    def test_socket_inet_ntop(self):
+        import socket
+        self.assertTrue(hasattr(socket, "inet_ntop"))
+
+    def test_socket_inet_pton(self):
+        import socket
+        self.assertTrue(hasattr(socket, "inet_pton"))
+
     def test_multiprocessing_queue(self):
         from multiprocessing import Queue
         Queue(0)


### PR DESCRIPTION
HAVE_INET_PTON is hardcoded to 1 in the official Windows build. Since we use autotools
we need to make the check work on Windows.

This makes socket.inet_ntop() and socket.inet_pton() available like with the official build.

Fixes #5184