### PR TITLE
python-lxml: update to 4.3.3

### DIFF
--- a/mingw-w64-python-lxml/PKGBUILD
+++ b/mingw-w64-python-lxml/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" 
          "${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-python-${_realname}-docs")
-pkgver=4.3.1
+pkgver=4.3.3
 pkgrel=1
 arch=('any')
 license=('BSD' 'custom')
@@ -26,7 +26,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cython"
 source=("https://pypi.io/packages/source/l/lxml/${_realname}-${pkgver}.tar.gz"
         "mingw-python-fix.patch"
         "use-distutils-get_platform.patch")
-sha256sums=('da5e7e941d6e71c9c9a717c93725cda0708c2474f532e3680ac5e39ec57d224d'
+sha256sums=('4a03dd682f8e35a10234904e0b9508d705ff98cf962c5851ed052e9340df3d90'
             'd5811e7c0be65d7e9ce59ad925466ac7dc95bdca05439be0becf2cca7bb9602a'
             'd50fefc47295d8c6eecf1ca42d03af43dc79d3debb52caf8edbed3b56df2f672')
 


### PR DESCRIPTION
This updates python-lxml to 4.3.3.