### PR TITLE
python-pyparsing: update to 2.4.0

### DIFF
--- a/mingw-w64-python-pyparsing/PKGBUILD
+++ b/mingw-w64-python-pyparsing/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=pyparsing
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=2.3.1
+pkgver=2.4.0
 pkgrel=1
 pkgdesc='General parsing module for Python (mingw-w64)'
 arch=('any')
@@ -14,7 +14,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python3"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
 source=("https://github.com/pyparsing/pyparsing/archive/pyparsing_$pkgver.tar.gz")
-sha512sums=('8c0e2c7a7dc7ec12f3e7c260bde25a33f325af89d9bc2329b7882ebd8a3f506fb06a36fdaba0fd8ed48040d5b7fc5288c41b01f2df84459a9980a035cb213dd0')
+sha512sums=('2888b60c2518b19979e00b01ea499c45cd0a98affe0551f80ea7985acd649d62b4e231e142d3efd65cdcd9e3a0182680bfe1c4d98e310fa2ac476f37ac4ff344')
 
 prepare() {
   cd "$srcdir"/


### PR DESCRIPTION
This updates python-pyparsing to 2.4.0.