### PR TITLE
python-psycopg2: update to 2.8.2

### DIFF
--- a/mingw-w64-python-psycopg2/PKGBUILD
+++ b/mingw-w64-python-psycopg2/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=psycopg2
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=2.7.7
+pkgver=2.8.2
 pkgrel=1
 pkgdesc="A PostgreSQL database adapter for the Python programming language. (mingw-w64)"
 arch=('any')
@@ -16,9 +16,9 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
              "${MINGW_PACKAGE_PREFIX}-postgresql>=8.4.1")
 options=('staticlibs' 'strip' '!debug')
-source=(http://initd.org/psycopg/tarballs/PSYCOPG-2-7/psycopg2-$pkgver.tar.gz{,.asc}
+source=(http://initd.org/psycopg/tarballs/PSYCOPG-2-8/psycopg2-$pkgver.tar.gz{,.asc}
 mingw-fix.patch)
-sha256sums=('f4526d078aedd5187d0508aa5f9a01eae6a48a470ed678406da94b4cd6524b7e'
+sha256sums=('5cacf21b6f813c239f100ef78a4132056f93a5940219ec25d2ef833cbeb05588'
             'SKIP'
             'bd100f943db9893d8676bdde81fb3ebd0ac4a7bcf44b8d6c77bce0c75e25374a')
 


### PR DESCRIPTION
This updates python-psycopg2 to 2.8.2.