### PR TITLE
python-sqlalchemy: update to 1.3.2

### DIFF
--- a/mingw-w64-python-sqlalchemy/PKGBUILD
+++ b/mingw-w64-python-sqlalchemy/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=sqlalchemy
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=1.2.18
+pkgver=1.3.2
 pkgrel=1
 pkgdesc="Python SQL toolkit and Object Relational Mapper (mingw-w64)"
 arch=('any')
@@ -22,7 +22,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python3-pytest-runner"
 options=('staticlibs' 'strip' '!debug')
 source=("https://pypi.io/packages/source/S/SQLAlchemy/SQLAlchemy-$pkgver.tar.gz"{,.asc})
 validpgpkeys=('83AF7ACE251C13E6BB7DEFBD330239C1C4DAFEE1')
-sha512sums=('a3074e0f7b9a307937f02ad030811413f3c92b7edcc4f1c6eda7c94c1178708f8c920840385a9b33c7952e224fe46dc73223aee00123e863abf6d1d446aebdb2'
+sha512sums=('fbbcff21e722a26a914d701cce430fcc5dac503fffb65e385e86754f39b585b5a4c6b4914533bc4adfe48269130e9b5c1c8c539aa60481c721c2ce7cfedca1bf'
             'SKIP')
 
 # Helper macros to help make tasks easier #


### PR DESCRIPTION
This updates python-sqlalchemy to 1.3.2.