### PR TITLE
python-icu: update to 2.3

### DIFF
--- a/mingw-w64-python-icu/001-icu-config.patch
+++ b/mingw-w64-python-icu/001-icu-config.patch
@@ -1,11 +1,11 @@
---- PyICU-1.9.7/setup.py.orig	2017-06-06 19:56:33.173238900 +0300
-+++ PyICU-1.9.7/setup.py	2017-06-06 20:04:19.423906900 +0300
-@@ -23,7 +23,7 @@
-                 raise RuntimeError((retcode, popenargs[0], output))
-             return output
+--- PyICU-2.3.orig/setup.py	2019-04-12 21:52:55.795377100 -0400
++++ PyICU-2.3/setup.py	2019-04-14 22:13:41.983753300 -0400
+@@ -62,7 +62,7 @@
+     ICU_VERSION = os.environ['ICU_VERSION']
+ except:
      try:
 -        ICU_VERSION = check_output(('icu-config', '--version')).strip()
 +        ICU_VERSION = check_output(('sh', 'icu-config', '--version')).strip()
-         if sys.version_info >= (3,):
-             ICU_VERSION = str(ICU_VERSION, 'ascii')
      except:
+         try:
+             ICU_VERSION = check_output(('pkg-config', '--modversion', 'icu-i18n')).strip()

--- a/mingw-w64-python-icu/002-fix-mingw-build.patch
+++ b/mingw-w64-python-icu/002-fix-mingw-build.patch
@@ -1,0 +1,74 @@
+--- PyICU-2.3.orig/setup.py	2019-04-12 21:52:55.795377100 -0400
++++ PyICU-2.3/setup.py	2019-04-14 22:08:46.314364100 -0400
+@@ -82,7 +82,7 @@
+     'darwin': True,
+     'linux': True,
+     'freebsd': False, # not tested
+-    'win32': False,   # no icu-config
++    'win32': True,
+     'sunos5': False,  # not tested
+     'cygwin': False,  # not tested
+ }
+@@ -91,7 +91,7 @@
+     'darwin': False,  # no pkg-config ?
+     'linux': True,
+     'freebsd': False, # not tested
+-    'win32': False,   # no pkg-config ?
++    'win32': True,
+     'sunos5': False,  # not tested
+     'cygwin': False,  # not tested
+ }
+@@ -100,7 +100,7 @@
+     'darwin': [],
+     'linux': [],
+     'freebsd': ['/usr/local/include'],
+-    'win32': ['c:/icu/include'],
++    'win32': [],
+     'sunos5': [],
+     'cygwin': [],
+ }
+@@ -109,7 +109,7 @@
+     'darwin': ['-DPYICU_VER="%s"' %(VERSION)],
+     'linux': ['-DPYICU_VER="%s"' %(VERSION)],
+     'freebsd': ['-DPYICU_VER="%s"' %(VERSION)],
+-    'win32': ['/DPYICU_VER=\\"%s\\"' %(VERSION)],
++    'win32': ['-DPYICU_VER="%s"' %(VERSION)],
+     'sunos5': ['-DPYICU_VER="%s"' %(VERSION)],
+     'cygwin': ['-DPYICU_VER="%s"' %(VERSION)],
+ }
+@@ -118,7 +118,7 @@
+     'darwin': [],
+     'linux': [],
+     'freebsd': ['-std=c++11'],
+-    'win32': ['/Zc:wchar_t', '/EHsc'],
++    'win32': [],
+     'sunos5': ['-std=c++11'],
+     'cygwin': ['-D_GNU_SOURCE=1', '-std=c++11'],
+ }
+@@ -128,7 +128,7 @@
+     'darwin': ['-O0', '-g', '-DDEBUG'],
+     'linux': ['-O0', '-g', '-DDEBUG'],
+     'freebsd': ['-O0', '-g', '-DDEBUG'],
+-    'win32': ['/Od', '/DDEBUG'],
++    'win32': ['-O0', '-g', '-DDEBUG'],
+     'sunos5': ['-DDEBUG'],
+     'cygwin': ['-Og', '-g', '-DDEBUG'],
+ }
+@@ -137,7 +137,7 @@
+     'darwin': [],
+     'linux': [],
+     'freebsd': ['-L/usr/local/lib'],
+-    'win32': ['/LIBPATH:c:/icu/lib'],
++    'win32': [],
+     'sunos5': [],
+     'cygwin': [],
+ }
+@@ -146,7 +146,7 @@
+     'darwin': [],
+     'linux': [],
+     'freebsd': ['icui18n', 'icuuc', 'icudata'],
+-    'win32': ['icuin', 'icuuc', 'icudt'],
++    'win32': [],
+     'sunos5': ['icui18n', 'icuuc', 'icudata'],
+     'cygwin': ['icui18n', 'icuuc', 'icudata'],
+ }

--- a/mingw-w64-python-icu/PKGBUILD
+++ b/mingw-w64-python-icu/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=PyICU
 pkgbase=mingw-w64-python-icu
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-icu" "${MINGW_PACKAGE_PREFIX}-python3-icu")
-pkgver=2.2
+pkgver=2.3
 pkgrel=1
 pkgdesc="Python extension wrapping the ICU C++ API (mingw-w64)"
 arch=('any')
@@ -16,14 +16,17 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
                         "${MINGW_PACKAGE_PREFIX}-icu")
 options=('staticlibs' 'strip' '!debug')
 source=("https://pypi.io/packages/source/P/${_realname}/${_realname}-${pkgver}.tar.gz"
-        001-icu-config.patch)
-sha256sums=('ea6ae8bb6845e2e145cf03cd80cf258487b80fca3669ae8a7bf0c5105df10973'
-            '9bca6c1cde20c5d4a7b383aead2df2cc51cbabaf2c5631c9a9de86ec37f5e64f')
+        001-icu-config.patch
+        002-fix-mingw-build.patch)
+sha256sums=('419d389b014ee48f31014920f300c842df0770a283ab1fb4de82a6af334cac4d'
+            'b12166984b7e7118c2d22934ff4370dea57635a161b7db4184e790472ec5b337'
+            '95c6738d18639a2551ea42283d4a7a0d4ab675e6e9c9baa17718909c3c54aa2e')
 
 prepare() {
   cd "${srcdir}"
   pushd ${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/001-icu-config.patch
+  patch -p1 -i ${srcdir}/002-fix-mingw-build.patch
   popd
 
   cp -r ${_realname}-${pkgver} build-${CARCH}


### PR DESCRIPTION
This updates python-icu to 2.3. This now requires icu version 64 to build.