### PR TITLE
glib2: Update to 2.60.1

### DIFF
--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -6,7 +6,7 @@
 _realname=glib2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.58.3
+pkgver=2.60.1
 pkgrel=1
 url="https://www.gtk.org/"
 arch=('any')
@@ -30,7 +30,7 @@ source=("https://download.gnome.org/sources/glib/${pkgver%.*}/glib-${pkgver}.tar
         0001-Revert-tests-W32-ugly-fix-for-sscanf-format.patch
         pyscript2exe.py
         )
-sha256sums=('8f43c31767e88a25da72b52a40f3301fefc49a665b56dc10ee7cc9565cbe7481'
+sha256sums=('89f884f5d5c6126140ec868cef184c42ce72902c13cd08f36e660371779b5560'
             'ff0d3df5d57cf621cac79f5bea8bd175e6c18b3fbf7cdd02df38c1eab9f40ac3'
             '838abaeab8ca4978770222ef5f88c4b464545dd591b2d532c698caa875b46931'
             '0f44135a139e3951c4b5fa7d4628d75226e0666d891faf524777e1d1ec3b440b'
@@ -67,8 +67,10 @@ build() {
     -Ddefault_library=shared \
     -Dman=true \
     -Dforce_posix_threads=true \
-    -Dgtk_doc=true \
     "../glib-${pkgver}"
+    # https://github.com/msys2/MINGW-packages/issues/5146
+    # -Dgtk_doc=true \
+
   ninja
 }
 


### PR DESCRIPTION
gtk-doc disabled for now because it fails to link if an older glib
is installed.
Caused by https://github.com/msys2/MINGW-packages/issues/5146