### PR TITLE
glibmm: update to 2.60.0

### DIFF
--- a/mingw-w64-glibmm/PKGBUILD
+++ b/mingw-w64-glibmm/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=glibmm
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.58.0
+pkgver=2.60.0
 pkgrel=1
 pkgdesc="Glib-- (glibmm) is a C++ interface for glib (mingw-w64)"
 arch=('any')
@@ -13,7 +13,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=("${MINGW_PACKAGE_PREFIX}-libsigc++" "${MINGW_PACKAGE_PREFIX}-glib2")
 options=('staticlibs' 'strip')
 source=("https://download.gnome.org/sources/glibmm/${pkgver%.*}/glibmm-${pkgver}.tar.xz")
-sha256sums=('d34189237b99e88228e6f557f7d6e62f767fe356f395a244f5ad0e486254b645')
+sha256sums=('a3a1b1c9805479a16c0018acd84b3bfff23a122aee9e3c5013bb81231aeef2bc')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}


### PR DESCRIPTION
This updates glibmm to 2.60.0, which now requires a glib2 version of at least 2.60.0.