### PR TITLE
adwaita-icon-theme: update to 3.32.0

### DIFF
--- a/mingw-w64-adwaita-icon-theme/PKGBUILD
+++ b/mingw-w64-adwaita-icon-theme/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=adwaita-icon-theme
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.30.1
+pkgver=3.32.0
 pkgrel=1
 pkgdesc="GNOME icon theme (mingw-w64)"
 arch=('any')
@@ -17,7 +17,7 @@ install=theme-${CARCH}.install
 source=(
   "https://download.gnome.org/sources/${_realname}/${pkgver:0:4}/${_realname}-${pkgver}.tar.xz"
 )
-sha256sums=('6d752a2b1bc668483956d4485c39cad1642d9358e133ff689526e43674a4e1ce')
+sha256sums=('698db6e407bb987baec736c6a30216dfc0317e3ca2403c7adf3a5aa46c193286')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}


### PR DESCRIPTION
This updates adwaita-icon-theme to 3.32.0.