### PR TITLE
graphviz: add missing dependency on gts. Fixes #5203

### DIFF
--- a/mingw-w64-graphviz/PKGBUILD
+++ b/mingw-w64-graphviz/PKGBUILD
@@ -4,7 +4,7 @@ _realname=graphviz
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.40.1
-pkgrel=7
+pkgrel=8
 pkgdesc="Graph Visualization Software (mingw-w64)"
 arch=('any')
 url='http://www.graphviz.org/'
@@ -23,6 +23,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-cairo"
          "${MINGW_PACKAGE_PREFIX}-libpng"
          "${MINGW_PACKAGE_PREFIX}-libsystre"
          "${MINGW_PACKAGE_PREFIX}-libwebp"
+         "${MINGW_PACKAGE_PREFIX}-gts"
          "${MINGW_PACKAGE_PREFIX}-pango"
          "${MINGW_PACKAGE_PREFIX}-poppler"
          "${MINGW_PACKAGE_PREFIX}-zlib"


### PR DESCRIPTION
Without this package executing `dot -c` results in

Warning: Could not load "C:\msys32\mingw32\bin\libgvplugin_neato_layout-6.dll" - The specified module could not be found.

Warning: Could not load "C:\msys32\mingw32\bin\libgvplugin_neato_layout-6.dll" - The specified module could not be found.