### PR TITLE
libpng-1.6.37 - add tests   and include  png2pnm pnm2png programs fro…

### DIFF
--- a/mingw-w64-libpng/PKGBUILD
+++ b/mingw-w64-libpng/PKGBUILD
@@ -42,8 +42,12 @@ build() {
   msg2 "Build contributed programs"
   mkdir -p ".libs/contrib/pngminus" && cd ".libs/contrib/pngminus"
   cp -r "${srcdir}/${_realname}-${pkgver}/contrib/pngminus"/* .
-  sed -e "s|#EXEEXT = .exe|EXEEXT = .exe|g" -i Makefile
-  make PNGINC="-I${srcdir}/${_realname}-${pkgver}" CC="${MINGW_PREFIX}/bin/gcc" CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" png2pnm.exe pnm2png.exe
+  sed -e "s|#EXEEXT = .exe|EXEEXT = .exe|g" \
+    -e "s|libpng.a|libpng16.a|g" \
+    -e "s|-lpng|-lpng16|g" \
+    -i Makefile
+  make PNGINC="-I${srcdir}/${_realname}-${pkgver} -I${srcdir}/build-${MINGW_CHOST}" CC="${MINGW_PREFIX}/bin/gcc" CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" \
+    png2pnm.exe pnm2png.exe
 }
 
 check() {
@@ -59,7 +63,8 @@ package () {
   install -D -m644 "${srcdir}/libpng-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 
   msg2 "Install contributed programs"
-  cd "${srcdir}/build-${MINGW_CHOST}/.libs/contrib/pngminus"
+  cd ".libs/contrib/pngminus"
+
   install -m0755 png2pnm.exe pnm2png.exe "$pkgdir${MINGW_PREFIX}/bin/"
 }
 

--- a/mingw-w64-libpng/PKGBUILD
+++ b/mingw-w64-libpng/PKGBUILD
@@ -42,12 +42,20 @@ build() {
   msg2 "Build contributed programs"
   mkdir -p ".libs/contrib/pngminus" && cd ".libs/contrib/pngminus"
   cp -r "${srcdir}/${_realname}-${pkgver}/contrib/pngminus"/* .
-  sed -e "s|#EXEEXT = .exe|EXEEXT = .exe|g" \
-    -e "s|libpng.a|libpng16.a|g" \
-    -e "s|-lpng|-lpng16|g" \
-    -i Makefile
-  make PNGINC="-I${srcdir}/${_realname}-${pkgver} -I${srcdir}/build-${MINGW_CHOST}" CC="${MINGW_PREFIX}/bin/gcc" CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" \
-    png2pnm.exe pnm2png.exe
+# libpng.a and libpng.dll.a are basically symlinks to libpng16.a 
+# and libpng16.dll.a that are created at "make install" but we are
+# building the contributed programs before the "make install" so
+# we have to link to libpng16.dll.a or libpng16.a if building 
+# statically. When building the static programs, we might also
+# want to build with the static version of zlib.
+  make PNGINC="-I${srcdir}/${_realname}-${pkgver} -I${srcdir}/build-${MINGW_CHOST}" \
+    CC="${MINGW_PREFIX}/bin/gcc" \
+    PNGLIB_SHARED="-L../.. -lpng16" \
+    PNGLIB_STATIC="../../libpng16.a" \
+    ZLIB_STATIC="${MINGW_PREFIX}/lib/libz.a" \
+    CFLAGS="$CFLAGS" \
+    LDFLAGS="-L../.. $LDFLAGS" \
+    png2pnm pnm2png png2pnm-static pnm2png-static
 }
 
 check() {
@@ -65,6 +73,8 @@ package () {
   msg2 "Install contributed programs"
   cd ".libs/contrib/pngminus"
 
-  install -m0755 png2pnm.exe pnm2png.exe "$pkgdir${MINGW_PREFIX}/bin/"
+# deploy both the shared lib and static programs in case a developer wants to
+# redistribute those.  I was also building statically for some internal testing.
+  install -m0755 png2pnm.exe pnm2png.exe png2pnm-static.exe pnm2png-static.exe "$pkgdir${MINGW_PREFIX}/bin/"
 }
 

--- a/mingw-w64-libpng/PKGBUILD
+++ b/mingw-w64-libpng/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.6.37
 _apngver=1.6.36
-pkgrel=1
+pkgrel=2
 arch=('any')
 pkgdesc="A collection of routines used to create PNG format graphics (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
@@ -39,6 +39,17 @@ build() {
     --enable-shared --enable-static \
     as_ln_s="cp -pR"
   make
+  msg2 "Build contributed programs"
+  mkdir -p ".libs/contrib/pngminus" && cd ".libs/contrib/pngminus"
+  cp -r "${srcdir}/${_realname}-${pkgver}/contrib/pngminus"/* .
+  sed -e "s|#EXEEXT = .exe|EXEEXT = .exe|g" -i Makefile
+  make CC="${MINGW_PREFIX}/bin/gcc" CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" png2pnm.exe pnm2png.exe
+}
+
+check() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+
+  make check
 }
 
 package () {
@@ -46,4 +57,9 @@ package () {
   make install DESTDIR="${pkgdir}"
 
   install -D -m644 "${srcdir}/libpng-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+
+  msg2 "Install contributed programs"
+  cd "${srcdir}/build-${MINGW_CHOST}/.libs/contrib/pngminus"
+  install -m0755 png2pnm.exe pnm2png.exe "$pkgdir${MINGW_PREFIX}/bin/"
 }
+

--- a/mingw-w64-libpng/PKGBUILD
+++ b/mingw-w64-libpng/PKGBUILD
@@ -43,7 +43,7 @@ build() {
   mkdir -p ".libs/contrib/pngminus" && cd ".libs/contrib/pngminus"
   cp -r "${srcdir}/${_realname}-${pkgver}/contrib/pngminus"/* .
   sed -e "s|#EXEEXT = .exe|EXEEXT = .exe|g" -i Makefile
-  make CC="${MINGW_PREFIX}/bin/gcc" CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" png2pnm.exe pnm2png.exe
+  make PNGINC="-I${srcdir}/${_realname}-${pkgver}" CC="${MINGW_PREFIX}/bin/gcc" CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" png2pnm.exe pnm2png.exe
 }
 
 check() {


### PR DESCRIPTION
…m the /contrib/pngminus dir..

This is for cconsistency with Archlinux and in case those 2 programs are used by other stuff.