### PR TITLE
gtk3: update to 3.24.8

### DIFF
--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gtk3
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.24.7
+pkgver=3.24.8
 pkgrel=1
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
@@ -29,7 +29,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 options=('strip' '!debug' 'staticlibs')
 source=("https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}.tar.xz"
         "0001-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch")
-sha256sums=('52121144a2df4babed75eb5f34de130a46420101fde3ae216d3142df8a481520'
+sha256sums=('666962de9b9768fe9ca785b0e2f42c8b9db3868a12fa9b356b167238d70ac799'
             'f6f8019e21b2932ee2cfb3b261d57b79f6492d4f0a61f9fbf5b8edd193758d9a')
 
 prepare() {
@@ -59,7 +59,9 @@ build() {
     --enable-broadway-backend \
     --disable-cups \
     --with-included-immodules \
-    --enable-silent-rules
+    --enable-silent-rules \
+    --without-libiconv-prefix \
+    --without-libintl-prefix
 
   make #V=1
 }


### PR DESCRIPTION
This updates gtk3 to 3.24.8. This also fixes linking with libintl and libiconv libraries.