### PR TITLE
glib-networking: update to 2.60.1

### DIFF
--- a/mingw-w64-glib-networking/PKGBUILD
+++ b/mingw-w64-glib-networking/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=glib-networking
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.58.0
-pkgrel=3
+pkgver=2.60.1
+pkgrel=1
 pkgdesc="Network-related GIO modules for glib (mingw-w64)"
 arch=(any)
 url="https://gitlab.gnome.org/GNOME/glib-networking"
@@ -20,7 +20,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-gsettings-desktop-schemas")
 options=('staticlibs' 'strip')
 source=("https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz")
-sha256sums=('bdfa0255e031b8ee003cc283002536b77ee76450105f1dc6ab066b9bf4330068')
+sha256sums=('d71c6b2faa5ac29100314f08a1be020a2afd0291f025614c0af0d17b14435d92')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"


### PR DESCRIPTION
This updates glib-networking to 2.60.1.