### PR TITLE
python3: append prefix to PATH instead of prepending it. Fixes #5146

### DIFF
--- a/mingw-w64-python3/0565-mingw-add-ModuleFileName-dir-to-PATH.patch
+++ b/mingw-w64-python3/0565-mingw-add-ModuleFileName-dir-to-PATH.patch
@@ -1,31 +1,35 @@
-diff -Naur Python-3.7.0-orig/Modules/getpath.c Python-3.7.0/Modules/getpath.c
---- Python-3.7.0-orig/Modules/getpath.c	2018-07-12 10:21:50.372404600 +0300
-+++ Python-3.7.0/Modules/getpath.c	2018-07-12 10:21:50.700005100 +0300
-@@ -1005,6 +1005,31 @@
+--- Python-3.7.3/Modules/getpath.c.orig	2019-03-25 21:21:05.000000000 +0100
++++ Python-3.7.3/Modules/getpath.c	2019-04-16 21:51:06.279967700 +0200
+@@ -959,6 +1091,36 @@
      memset(exec_prefix, 0, sizeof(exec_prefix));
      calculate_exec_prefix(core_config, calculate, exec_prefix);
  
 +#ifdef MS_WINDOWS
 +    if (calculate->path_env) {
-+        wchar_t *module_path, *new_path;
++        wchar_t *module_path, *norm_path;
 +        // Add path of executable/dll to system path. This
 +        // is so that the correct tcl??.dll and tk??.dll get used.
 +        module_path = config->dll_path[0] ? config->dll_path : config->program_full_path;
-+        new_path = (wchar_t *)alloca(sizeof(wchar_t)*(wcslen(L"PATH=") + wcslen(module_path) + 1 + wcslen(calculate->path_env) + 1));
-+        if (new_path) {
-+            wchar_t *slashes, *end;
-+            wcscpy(new_path, L"PATH=");
-+            wcscat(new_path, module_path);
-+            slashes = wcschr(new_path, L'/');
++        norm_path = (wchar_t *)alloca(sizeof(wchar_t) * (wcslen(module_path) + 1));
++        if (norm_path) {
++            wchar_t *slashes, *end, *new_path;
++            wcscpy(norm_path, module_path);
++            slashes = wcschr(norm_path, L'/');
 +            while (slashes) {
 +                *slashes = L'\\';
-+                slashes = wcschr(slashes+1, L'/');
++                slashes = wcschr(slashes + 1, L'/');
 +            }
-+            end = wcsrchr(new_path, L'\\') ? wcsrchr(new_path, L'\\') : new_path + wcslen(new_path);
-+            end[0] = L';';
++            end = wcsrchr(norm_path, L'\\') ? wcsrchr(norm_path, L'\\') : norm_path + wcslen(norm_path);
 +            end[1] = L'\0';
-+            wcscat(new_path, calculate->path_env);
-+            _wputenv(new_path);
++
++            new_path = (wchar_t *)alloca(sizeof(wchar_t) * (wcslen(L"PATH=") + wcslen(calculate->path_env) + 1 + wcslen(norm_path) + 1));
++            if (new_path) {
++                wcscpy(new_path, L"PATH=");
++                wcscat(new_path, calculate->path_env);
++                wcscat(new_path, L";");
++                wcscat(new_path, norm_path);
++                _wputenv(new_path);
++            }
 +        }
 +    }
 +#endif

--- a/mingw-w64-python3/PKGBUILD
+++ b/mingw-w64-python3/PKGBUILD
@@ -18,7 +18,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _pybasever=3.7
 pkgver=${_pybasever}.3
-pkgrel=1
+pkgrel=2
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 license=('PSF')
@@ -471,7 +471,7 @@ sha256sums=('da60b54064d4cfcd9c26576f6df2690e62085123826cff2e667e72a91952d318'
             'a88ed0a61dcb0a860286ab1d6bf489b272a670625687924943713a58c6068a94'
             '80dabe16710799fb070dfeed071161dfd439f156e2cf79e0c5ab7d51279d342f'
             '3f743eb2e067dc0d315dee875c4525791388a2d7636f9a74cd9721002fc13b83'
-            'e7be78409c070ea2fa76a8f568d6121deaa3fc4545fc0565745c044a67376616'
+            '76340fbb1d12383cfe6abcfa7d5e4f993f98c2b03b5216c8af62219afa7405a1'
             'c64baa4c0457186269f02c74f5f58f4c56fd435384c45f778e86deac9b9f435f'
             '65454f7d338af3a41f574f87b2d5a91ec3a96d474fb61d2d5fc9f9938a7a83fb'
             '5a5e9bbe642e2c86b3feee87b14ca3c4716178266a08deaa02a79b71fd36f00f'


### PR DESCRIPTION
This is also a problem with meson which tries to execute things in the build
directory using the build directory DLLs by prepending those to PATH.
Since meson uses a Python helper the PATH gets updated to include the
system prefix first which makes things link against the installed libraries
instead and fail because symbols are missing.

One of the reasons why this was added in the first place is that Python loads
C extensions in lib-dynload which then can't find the libraries in prefix
(e.g. "import tkinter") if it isn't in PATH.

By moving the prefix at the end of PATH we make both cases work.

Starting with Python 3.8 C extensions will no longer use PATH for loading
DLL dependencies, see https://github.com/python/cpython/pull/12302
so we will have to look into this again then.