### PR TITLE
sqlite3: update to 3.28.0

### DIFF
--- a/mingw-w64-sqlite3/PKGBUILD
+++ b/mingw-w64-sqlite3/PKGBUILD
@@ -5,9 +5,9 @@
 _realname=sqlite3
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-_amalgamationver=3270200
-pkgver=3.27.2
-pkgrel=2
+_amalgamationver=3280000
+pkgver=3.28.0
+pkgrel=1
 pkgdesc="A C library that implements an SQL database engine (mingw-w64)"
 arch=('any')
 license=(PublicDomain)
@@ -18,7 +18,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 source=("https://www.sqlite.org/2019/sqlite-autoconf-${_amalgamationver}.tar.gz"
         LICENSE)
-sha256sums=('50c39e85ea28b5ecfdb3f9e860afe9ba606381e21836b2849efca6a0bfe6ef6e'
+sha256sums=('d61b5286f062adfce5125eaf544d495300656908e61fca143517afcc0a89b7c3'
             '0b76663a90e034f3d7f2af5bfada4cedec5ebc275361899eccc5c18e6f01ff1f')
 options=('!strip' 'staticlibs' '!buildflags')
 


### PR DESCRIPTION
This updates sqlite3 to 3.28.0.