### PR TITLE
meson: Update to 0.50.1; don't enable colors in the legacy cmd, fixes #5044

### DIFF
--- a/mingw-w64-meson/PKGBUILD
+++ b/mingw-w64-meson/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=meson
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.50.0
+pkgver=0.50.1
 pkgrel=1
 pkgdesc="High-productivity build system (mingw-w64)"
 arch=('any')
@@ -18,8 +18,8 @@ source=("https://github.com/mesonbuild/${_realname}/releases/download/${pkgver}/
         '0002-Default-to-sys.prefix-as-the-default-prefix.patch'
         '0003-Strip-the-prefix-from-all-paths-when-installing-with.patch'
         'install-man.patch')
-sha256sums=('2a1bc42dda58206fb922cda5e1ca95cc03ad126321d26acc47d3493ec4e7021f'
-            'edec6de6f5fa60f0737fdb25a3ac276a0187a6f961544289e5472bcb4194e954'
+sha256sums=('f68f56d60c80a77df8fc08fa1016bc5831605d4717b622c96212573271e14ecc'
+            '5805aed0a117536eb16dd8eef978c6be57c2471b655ede63e25517c28b4f4cf0'
             '4ef1e6fb0e9bd927b4646e416631b8a0a9aece763d259dbba58168bcba93f673'
             '2093c617cf3146a4cea601e7c73400d8ec5fd52ac5cf642c4f5af2d6493b1cb1'
             '0682a36cb75e545a78b81293303835a16171f25baf949905dc08029436efff84')

--- a/mingw-w64-meson/color-term.patch
+++ b/mingw-w64-meson/color-term.patch
@@ -1,11 +1,11 @@
---- meson-0.47.0/mesonbuild/mlog.py.orig	2018-07-03 13:53:50.151713800 +0200
-+++ meson-0.47.0/mesonbuild/mlog.py	2018-07-03 14:15:33.385701800 +0200
-@@ -34,7 +34,7 @@
-     return kernel.SetConsoleMode(stdout, mode.value | 0x4) or os.environ.get('ANSICON')
- 
- if platform.system().lower() == 'windows':
--    colorize_console = os.isatty(sys.stdout.fileno()) and _windows_ansi()
-+    colorize_console = os.isatty(sys.stdout.fileno())
- else:
-     colorize_console = os.isatty(sys.stdout.fileno()) and os.environ.get('TERM') != 'dumb'
- log_dir = None
+--- meson-0.50.1/mesonbuild/mlog.py.orig	2019-03-06 21:48:10.000000000 +0100
++++ meson-0.50.1/mesonbuild/mlog.py	2019-04-17 17:46:10.229092600 +0200
+@@ -31,7 +31,7 @@
+     stdout = kernel.GetStdHandle(-11)
+     mode = DWORD()
+     if not kernel.GetConsoleMode(stdout, byref(mode)):
+-        return False
++        return os.isatty(sys.stdout.fileno())
+     # ENABLE_VIRTUAL_TERMINAL_PROCESSING == 0x4
+     # If the call to enable VT processing fails (returns 0), we fallback to
+     # original behavior


### PR DESCRIPTION
Only force colors in case we don't have a console attached so we know
we are not running in any of the CMDs.

Fixes #5044