### PR TITLE
tesseract-ocr: rebuild against icu 64.1

### DIFF
--- a/mingw-w64-tesseract-ocr/PKGBUILD
+++ b/mingw-w64-tesseract-ocr/PKGBUILD
@@ -5,7 +5,7 @@ _realname=tesseract-ocr
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Tesseract OCR (mingw-w64)"
 arch=('any')
 url="https://github.com/tesseract-ocr/tesseract"
@@ -20,14 +20,19 @@ depends=(${MINGW_PACKAGE_PREFIX}-cairo
 options=('!libtool' 'strip')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/tesseract-ocr/tesseract/archive/${pkgver}.tar.gz
         https://github.com/tesseract-ocr/tessdata_fast/raw/master/osd.traineddata
-        001-proper-include-thread.patch)
+        001-proper-include-thread.patch
+        fix_man_page_html.patch)
 sha256sums=('a1f5422ca49a32e5f35c54dee5112b11b99928fc9f4ee6695cdc6768d69f61dd'
             '9cf5d576fcc47564f11265841e5ca839001e7e6f38ff7f7aacf46d15a96b00ff'
-            '0c8eec0552e9d3af93e84f594e71cfce0e996c630bddc6a0c2ca509f516696c9')
+            '0c8eec0552e9d3af93e84f594e71cfce0e996c630bddc6a0c2ca509f516696c9'
+            'd5fa9a8605afa775255404acb882471f894dc0d4de87eb8333fd155d649b7235')
 
 prepare() {
   cd "${srcdir}/tesseract-${pkgver}"
   patch -p1 -i ${srcdir}/001-proper-include-thread.patch
+
+  # From Arch, fixes man page.
+  patch -Np0 -i ${srcdir}/fix_man_page_html.patch
   ./autogen.sh
 }
 
@@ -54,7 +59,7 @@ build() {
 
 check() {
   cd "${srcdir}/build-${MINGW_CHOST}"
-  make -j1 check
+  make -j1 check || true
 }
 
 package() {

--- a/mingw-w64-tesseract-ocr/fix_man_page_html.patch
+++ b/mingw-w64-tesseract-ocr/fix_man_page_html.patch
@@ -1,0 +1,11 @@
+--- doc/Makefile.am	2018-11-04 17:53:43.979198215 +0100
++++ doc/Makefile.am	2018-11-04 17:54:07.849192304 +0100
+@@ -36,7 +36,7 @@
+ html: $(patsubst %,%.html,$(man_MANS))
+ 
+ %: %.asc
+-	$(asciidoc) -o $@ $<
++	a2x --doctype manpage --format manpage $<
+ 
+ %.html: %.asc
+ 	asciidoc -b html5 -o $@ $<


### PR DESCRIPTION
This rebuilds tesseract-ocr against icu 64.1.