### PR TITLE
ducible: new package, replaces ducible-git

### DIFF
--- a/mingw-w64-ducible/PKGBUILD
+++ b/mingw-w64-ducible/PKGBUILD
@@ -1,23 +1,20 @@
 # Maintainer: Oscar Fuentes <ofv@wanadoo.es>
 
 _realname=ducible
-pkgbase=mingw-w64-${_realname}-git
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
-pkgver=r208.956976c
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.2.1
 pkgrel=1
 pkgdesc="A tool to make Windows builds reproducible."
 arch=('any')
+conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
+replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 url="https://github.com/jasonwhite/ducible"
 license=("MIT")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "git" "python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "git" "${MINGW_PACKAGE_PREFIX}-python3")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
-source=("${_realname}"::"git+https://github.com/jasonwhite/ducible.git")
+source=("${_realname}"::"git+https://github.com/jasonwhite/ducible.git#tag=v${pkgver}")
 sha256sums=('SKIP')
-
-pkgver() {
-  cd "${_realname}"
-  printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
-}
 
 build() {
   cd "$srcdir/${_realname}"


### PR DESCRIPTION
Builds from release tags. Please create binary package. Thanks.