### PR TITLE
nghttp2: update to 1.38.0

### DIFF
--- a/mingw-w64-nghttp2/PKGBUILD
+++ b/mingw-w64-nghttp2/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=nghttp2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.37.0
+pkgver=1.38.0
 pkgrel=1
 pkgdesc="Framing layer of HTTP/2 is implemented as a reusable C library (mingw-w64)"
 arch=('any')
@@ -18,17 +18,15 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-cunit")
 license=('MIT')
 source=("https://github.com/nghttp2/nghttp2/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.xz")
-sha256sums=('aa090b164b17f4b91fe32310a1c0edf3e97e02cd9d1524eef42d60dd1e8d47b7')
+sha256sums=('ef75c761858241c6b4372fa6397aa0481a984b84b7b07c4ec7dc2d7b9eee87f8')
 
 prepare() {
   cd $srcdir/${_realname}-${pkgver}
 }
 
 build() {
-  cd "$srcdir"/${_realname}-${pkgver}
   [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
-  mkdir -p "${srcdir}"/build-${CARCH}
-  cd "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
   # Note, cmake system does not yet work well with this.
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \


### PR DESCRIPTION
This updates nghttp2 to 1.38.0.