### PR TITLE
libcdio-paranoia: update to 10.2+2.0.0

### DIFF
--- a/mingw-w64-libcdio-paranoia/PKGBUILD
+++ b/mingw-w64-libcdio-paranoia/PKGBUILD
@@ -5,16 +5,16 @@
 _realname=libcdio-paranoia
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.2+0.94+2
-pkgrel=2
+pkgver=10.2+2.0.0
+pkgrel=1
 pkgdesc="CD paranoia libraries from libcdio (mingw-w64)"
 arch=('any')
 license=('GPL' 'LGPL')
 url="https://www.gnu.org/software/libcdio/"
 depends=("${MINGW_PACKAGE_PREFIX}-libcdio")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
-source=(https://ftp.gnu.org/gnu/libcdio/${_realname}-${pkgver}.tar.gz{,.sig})
-sha256sums=('d60f82ece97eeb92407a9ee03f3499c8983206672c28ae5e4e22179063c81941'
+source=(https://ftp.gnu.org/gnu/libcdio/${_realname}-${pkgver}.tar.bz2{,.sig})
+sha256sums=('4565c18caf401083c53733e6d2847b6671ba824cff1c7792b9039693d34713c1'
             'SKIP')
 
 build() {


### PR DESCRIPTION
This updates libcdio-paranoia to 10.2+2.0.0.