### PR TITLE
python: better compatibility with unpatched setuptools. Fixes #5155

### DIFF
--- a/mingw-w64-python-setuptools/PKGBUILD
+++ b/mingw-w64-python-setuptools/PKGBUILD
@@ -51,6 +51,8 @@ prepare() {
   patch -p1 -i ${srcdir}/0001-mingw-python-fix.patch
   patch -p1 -i ${srcdir}/0002-Allow-usr-bin-env-in-script.patch
   patch -p1 -i ${srcdir}/0003-MinGW-w64-Look-in-same-dir-as-script-for-exe.patch
+  # TODO: This one is fixed now in python2/3 itself, so this can be dropped
+  # in the future: https://github.com/msys2/MINGW-packages/issues/5155
   patch -p1 -i ${srcdir}/0004-dont-execute-msvc.patch
   patch -p1 -i ${srcdir}/0005-execv-warning-patch
 

--- a/mingw-w64-python2/2030-fix-msvc9-import.patch
+++ b/mingw-w64-python2/2030-fix-msvc9-import.patch
@@ -1,0 +1,23 @@
+setuptools imports it and VERSION is 6 with a mingw Python. Move the version
+check to the actual compiler instance creation, which is also the only place
+where it's used.
+--- Python-3.7.3/Lib/distutils/msvc9compiler.py.orig	2019-03-25 21:21:05.000000000 +0100
++++ Python-3.7.3/Lib/distutils/msvc9compiler.py	2019-04-21 15:56:16.997090000 +0200
+@@ -292,8 +292,6 @@
+ 
+ # More globals
+ VERSION = get_build_version()
+-if VERSION < 8.0:
+-    raise DistutilsPlatformError("VC %0.1f is not supported by this module" % VERSION)
+ # MACROS = MacroExpander(VERSION)
+ 
+ class MSVCCompiler(CCompiler) :
+@@ -328,6 +326,8 @@
+ 
+     def __init__(self, verbose=0, dry_run=0, force=0):
+         CCompiler.__init__ (self, verbose, dry_run, force)
++        if VERSION < 8.0:
++            raise DistutilsPlatformError("VC %0.1f is not supported by this module" % VERSION)
+         self.__version = VERSION
+         self.__root = r"Software\Microsoft\VisualStudio"
+         # self.__macros = MACROS

--- a/mingw-w64-python2/PKGBUILD
+++ b/mingw-w64-python2/PKGBUILD
@@ -6,7 +6,7 @@ _realname=python2
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.7.16
-pkgrel=1
+pkgrel=2
 _pybasever=${pkgver%.*}
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
@@ -111,7 +111,8 @@ source=("https://www.python.org/ftp/python/${pkgver%rc?}/Python-${pkgver}.tar.xz
         1900-ctypes-dont-depend-on-internal-libffi.patch
         2000-distutils-add-windmc-to-cygwinccompiler.patch
         2700-cygpty-isatty-disable-readline.patch
-        2701-disable-broken-gdbm-module.patch)
+        2701-disable-broken-gdbm-module.patch
+        2030-fix-msvc9-import.patch)
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -263,6 +264,9 @@ prepare() {
   # like with the official CPython build.
   apply_patch_with_msg \
     2701-disable-broken-gdbm-module.patch
+
+  # https://github.com/msys2/MINGW-packages/issues/5155
+  apply_patch_with_msg 2030-fix-msvc9-import.patch
 
   autoreconf -vfi
 
@@ -494,4 +498,5 @@ sha256sums=('f222ef602647eecb6853681156d32de4450a2c39f4de93bd5b20235f2e660ed7'
             'e3b0171303b3e28a7347a81b1110dfe42df92a87d160caf624510304d5390728'
             'aa623bd762f33f2724b40a55bd2d2c4100b47b81586ae2f5d6b430ab4646f02c'
             '2874642706ef2360960c254a318da6be72a83e3f4c9e0cd8d411a66c0864d911'
-            'da2353b0d62d3511e44f27696cea0d4b7540b77cedffa5840fe202ae57e09890')
+            'da2353b0d62d3511e44f27696cea0d4b7540b77cedffa5840fe202ae57e09890'
+            '6c4b0c469f3c04e5586553b7e4e8e30e8e36163f30d4139605b7c0eddf994347')

--- a/mingw-w64-python3/2030-fix-msvc9-import.patch
+++ b/mingw-w64-python3/2030-fix-msvc9-import.patch
@@ -1,0 +1,23 @@
+setuptools imports it and VERSION is 6 with a mingw Python. Move the version
+check to the actual compiler instance creation, which is also the only place
+where it's used.
+--- Python-3.7.3/Lib/distutils/msvc9compiler.py.orig	2019-03-25 21:21:05.000000000 +0100
++++ Python-3.7.3/Lib/distutils/msvc9compiler.py	2019-04-21 15:56:16.997090000 +0200
+@@ -292,8 +292,6 @@
+ 
+ # More globals
+ VERSION = get_build_version()
+-if VERSION < 8.0:
+-    raise DistutilsPlatformError("VC %0.1f is not supported by this module" % VERSION)
+ # MACROS = MacroExpander(VERSION)
+ 
+ class MSVCCompiler(CCompiler) :
+@@ -328,6 +326,8 @@
+ 
+     def __init__(self, verbose=0, dry_run=0, force=0):
+         CCompiler.__init__ (self, verbose, dry_run, force)
++        if VERSION < 8.0:
++            raise DistutilsPlatformError("VC %0.1f is not supported by this module" % VERSION)
+         self.__version = VERSION
+         self.__root = r"Software\Microsoft\VisualStudio"
+         # self.__macros = MACROS

--- a/mingw-w64-python3/PKGBUILD
+++ b/mingw-w64-python3/PKGBUILD
@@ -18,7 +18,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _pybasever=3.7
 pkgver=${_pybasever}.3
-pkgrel=2
+pkgrel=3
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 license=('PSF')
@@ -126,6 +126,7 @@ source=("https://www.python.org/ftp/python/${pkgver%rc?}/Python-${pkgver}.tar.xz
         1900-ctypes-dont-depend-on-internal-libffi.patch
         2010-configure-have-inet-pton.patch
         2020-use-_wcsnicmp-instead-wcsncasecmp.patch
+        2030-fix-msvc9-import.patch
         smoketests.py)
 
 # Helper macros to help make tasks easier #
@@ -286,6 +287,9 @@ prepare() {
 
   # https://github.com/msys2/MINGW-packages/issues/5184
   apply_patch_with_msg 2010-configure-have-inet-pton.patch
+
+  # https://github.com/msys2/MINGW-packages/issues/5155
+  apply_patch_with_msg 2030-fix-msvc9-import.patch
 
   autoreconf -vfi
 
@@ -516,4 +520,5 @@ sha256sums=('da60b54064d4cfcd9c26576f6df2690e62085123826cff2e667e72a91952d318'
             'e3b0171303b3e28a7347a81b1110dfe42df92a87d160caf624510304d5390728'
             '150dc7a5c59ef82b0bf258a2cd4233f2975fb89818849de39c185ce368a124ab'
             '2d6605515648ef3ffe53e417719d4d51a7a2a79566e26e920733422dfd3751cb'
+            '6c4b0c469f3c04e5586553b7e4e8e30e8e36163f30d4139605b7c0eddf994347'
             '821402ddaef92140c70041b007bcf15e1cd5fe0fdb9f4f612da868382cc24585')


### PR DESCRIPTION
We currently patch setuptools itself to not import distutils.msvc9compiler,
which fails because it fails to detect the msvc version and falls back to an unsupported
version 6 and raises.

This doesn't help much in case setuptools is installed through pip which doesn't contain
the fix.

This fixes msvc9compiler.py instead to not fail on import but at the compiler instance creation,
i.e. the point where the version is actually used. The setuptools fix remains for now to make
updates easier.

Fixes #5155