### PR TITLE
Fix internal compiler error in dwarfout.c during compilation with GCC 8

### DIFF
--- a/mingw-w64-gcc/0150-Fix-internal-compiler-error-in-dwarf2out.patch
+++ b/mingw-w64-gcc/0150-Fix-internal-compiler-error-in-dwarf2out.patch
@@ -1,0 +1,86 @@
+From: "H.J. Lu" <hjl dot tools at gmail dot com>
+To: gcc-patches at gcc dot gnu dot org
+Date: Wed, 8 Aug 2018 06:32:08 -0700
+Subject: [PATCH] Relax SUPPORTS_STACK_ALIGNMENT with !crtl->stack_realign_tried
+
+Assert for SUPPORTS_STACK_ALIGNMENT was added for dynamic stack
+alignment.  At the time, arg_pointer_rtx would only be eliminated
+by either hard_frame_pointer_rtx or stack_pointer_rtx only when
+dynamic stack alignment is supported.  With
+
+commit cd557ff63f388ad27c376d0a225e74d3594a6f9d
+Author: hjl <hjl@138bc75d-0d04-0410-961f-82ee72b054a4>
+Date:   Thu Aug 10 15:29:05 2017 +0000
+
+    i386: Don't use frame pointer without stack access
+
+    When there is no stack access, there is no need to use frame pointer
+    even if -fno-omit-frame-pointer is used and caller's frame pointer is
+    unchanged.
+
+this can happen when there is no dynamic stack alignment.  This patch
+relaxes SUPPORTS_STACK_ALIGNMENT with !crtl->stack_realign_tried to
+allow arg_pointer_rtx to be eliminated by either hard_frame_pointer_rtx
+or stack_pointer_rtx when there is no dynamic stack alignment at all.
+
+gcc/
+
+	PR debug/86593
+	* dwarf2out.c (based_loc_descr): Replace SUPPORTS_STACK_ALIGNMENT
+	with (SUPPORTS_STACK_ALIGNMENT || !crtl->stack_realign_tried).
+	(compute_frame_pointer_to_fb_displacement): Likewise.
+
+gcc/testsuite/
+
+	PR debug/86593
+	* g++.dg/pr86593.C: New test.
+---
+ gcc/dwarf2out.c                |  6 ++++--
+ gcc/testsuite/g++.dg/pr86593.C | 11 +++++++++++
+ 2 files changed, 15 insertions(+), 2 deletions(-)
+ create mode 100644 gcc/testsuite/g++.dg/pr86593.C
+
+diff --git a/gcc/dwarf2out.c b/gcc/dwarf2out.c
+index b67481dd2db..6ecdc4562d0 100644
+--- a/gcc/dwarf2out.c
++++ b/gcc/dwarf2out.c
+@@ -14304,7 +14304,8 @@ based_loc_descr (rtx reg, poly_int64 offset,
+       if (elim != reg)
+ 	{
+ 	  elim = strip_offset_and_add (elim, &offset);
+-	  gcc_assert ((SUPPORTS_STACK_ALIGNMENT
++	  gcc_assert (((SUPPORTS_STACK_ALIGNMENT
++			|| !crtl->stack_realign_tried)
+ 		       && (elim == hard_frame_pointer_rtx
+ 			   || elim == stack_pointer_rtx))
+ 	              || elim == (frame_pointer_needed
+@@ -20492,7 +20493,8 @@ compute_frame_pointer_to_fb_displacement (poly_int64 offset)
+      this, assume that while we cannot provide a proper value for
+      frame_pointer_fb_offset, we won't need one either.  */
+   frame_pointer_fb_offset_valid
+-    = ((SUPPORTS_STACK_ALIGNMENT
++    = (((SUPPORTS_STACK_ALIGNMENT
++	 || !crtl->stack_realign_tried)
+ 	&& (elim == hard_frame_pointer_rtx
+ 	    || elim == stack_pointer_rtx))
+        || elim == (frame_pointer_needed
+diff --git a/gcc/testsuite/g++.dg/pr86593.C b/gcc/testsuite/g++.dg/pr86593.C
+new file mode 100644
+index 00000000000..f4de0c1166a
+--- /dev/null
++++ b/gcc/testsuite/g++.dg/pr86593.C
+@@ -0,0 +1,11 @@
++// { dg-options "-O -g -fno-omit-frame-pointer" }
++
++struct Foo
++{
++    int bar(int a, int b, int c, int i1, int i2, int i3, int d);
++};
++
++int Foo::bar(int a, int b, int c, int i1, int i2, int i3, int d)
++{
++  return 0;
++}
+-- 
+2.17.1
+

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -17,7 +17,7 @@ pkgver=8.3.0
 #_majorver=${pkgver:0:1}
 #_sourcedir=${_realname}-${_majorver}-${_snapshot}
 _sourcedir=${_realname}-${pkgver}
-pkgrel=2
+pkgrel=3
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 url="https://gcc.gnu.org"
@@ -56,7 +56,8 @@ source=("https://ftp.gnu.org/gnu/gcc/${_realname}-${pkgver%%+*}/${_realname}-${p
         0019-gcc-8-branch-Backport-patches-for-std-filesystem-from-master.patch
         0130-libstdc++-in-out.patch
         0140-gcc-8.2.0-diagnostic-color.patch
-        pr88568.patch)
+        pr88568.patch
+        0150-Fix-internal-compiler-error-in-dwarf2out.patch)
 sha256sums=('64baadfe6cc0f4947a84cb12d7f0dfaf45bb58b7e92461639596c21e02d97d2c'
             'SKIP'
             'dea2bbad4967280910559c6a11b865aeec19cab34647fb5894cb498b24b14462'
@@ -74,7 +75,8 @@ sha256sums=('64baadfe6cc0f4947a84cb12d7f0dfaf45bb58b7e92461639596c21e02d97d2c'
             'bf83cbc79de4c86f02664c8a624e26b12f570e3c31116fc7c46ecf655696f9a6'
             'ba2f77db605577d08e4079f08a7a9556c975b5416be8610c5be31e915637feb7'
             'e467f0ac68b349de826c79b00a45c5ad9e7c5a55d06b9b9fa7afd94c597f6376'
-            '4bbcb71f7e9e25af641e7abcb12ea4cd7a5ade3a82739414c65259afcbf21256')
+            '4bbcb71f7e9e25af641e7abcb12ea4cd7a5ade3a82739414c65259afcbf21256'
+            'c8965b9e3940b4f077f0137b8da56ecef081c93c42fd57ff4427477ab717f351')
 
 _threads="posix"
 
@@ -131,6 +133,10 @@ prepare() {
   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88568
   apply_patch_with_msg \
     pr88568.patch
+
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86593
+  apply_patch_with_msg \
+    0150-Fix-internal-compiler-error-in-dwarf2out.patch
 
   # do not expect ${prefix}/mingw symlink - this should be superceded by
   # 0005-Windows-Don-t-ignore-native-system-header-dir.patch .. but isn't!


### PR DESCRIPTION
Fix GCC 8 stopping with internal compiler error when -fno-omit-frame-pointer is used.

Backported patch from here:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86593
https://gcc.gnu.org/ml/gcc-patches/2018-08/msg00559.html