### PR TITLE
qt-creator: update to 4.9.0

### DIFF
--- a/mingw-w64-qt-creator/PKGBUILD
+++ b/mingw-w64-qt-creator/PKGBUILD
@@ -5,7 +5,7 @@ _realname=qt-creator
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 __pre=
-_base_ver=4.8.2
+_base_ver=4.9.0
 pkgver=${_base_ver}${_pre}
 pkgrel=1
 pkgdesc='Cross-platform IDE (mingw-w64)'
@@ -42,7 +42,7 @@ source=(#https://download.qt.io/development_releases/qtcreator/${_base_ver%.*}/$
         qt-creator-4.3.0-qbs-CONFIG-add-qbs_enable_project_file_updates.patch
         qt-creator-4.6.2-fix-clang-detect.patch)
 noextract=(${_pkgfqn}.tar.gz)
-sha256sums=('7353ece17b18d6584abc60430a077beb60db6f609fa5568c084ab7a460c0ed75'
+sha256sums=('e6401acf36a304739308d3958cf9abb1f43ef991d4b84f3642fb3875ef0e221a'
             'b4eba129997fef75b811d0ba3ef573db23ba13e43f9dbdb0c27164ee551ba08d'
             '96c14f54577bf6cadf5c12018745666a9e99cd8d6a876c29a28b13599a8cb368'
             '24f93d9d888027915ce3eb387d2d52123fd625ae1b3cd31adb6500952bc6e192'
@@ -84,8 +84,7 @@ prepare() {
 
 build() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
-  mkdir ${srcdir}/build-${MINGW_CHOST}
-  cd ${srcdir}/build-${MINGW_CHOST}
+  mkdir -p ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
   export LLVM_INSTALL_DIR=${MINGW_PREFIX}
   export QTC_FORCE_CLANG_LIBTOOLING=1
   export QBS_INSTALL_DIR=${MINGW_PREFIX}


### PR DESCRIPTION
This updates qt-creator to 4.9.0, which requires qbs 1.13.0.