### PR TITLE
geocode-glib-3.26.1

### DIFF
--- a/mingw-w64-geocode-glib/PKGBUILD
+++ b/mingw-w64-geocode-glib/PKGBUILD
@@ -3,12 +3,12 @@
 _realname=geocode-glib
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.26.0
+pkgver=3.26.1
 pkgrel=1
 arch=('any')
-pkgdesc="geocoding and reverse geocoding GLib library using Yahoo! Place Finder (mingw-w64)"
-license=("LGPL 2")
-url="https://www.gnome.org/"
+pkgdesc="Helper library for geocoding services (mingw-w64)"
+license=("LGPL")
+url="https://gitlab.gnome.org/GNOME/geocode-glib"
 install=${_realname}-${CARCH}.install
 depends=("${MINGW_PACKAGE_PREFIX}-glib2"
          "${MINGW_PACKAGE_PREFIX}-json-glib"
@@ -22,18 +22,20 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 options=('strip' '!debug' 'staticlibs')
 source=(https://download.gnome.org/sources/${_realname}/${pkgver:0:4}/${_realname}-${pkgver}.tar.xz
         001-locale.patch)
-sha256sums=('ea4086b127050250c158beff28dbcdf81a797b3938bb79bbaaecc75e746fbeee'
+sha256sums=('5baa6ab76a76c9fc567e4c32c3af2cd1d1784934c255bc5a62c512e6af6bde1c'
             '7379362319bab800b464ae4cf1d33e05f51bf500d8b0f65be63c05036f040c34')
 
 prepare() {
-  cd ${_realname}-${pkgver}
-  patch -p1 -i ${srcdir}/001-locale.patch
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -Np1 -i ${srcdir}/001-locale.patch
+
+  # From Arch
+  sed -i 's/gnome/Adwaita/' icons/meson.build
 }
 
 build() {
-  [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}
-  mkdir -p build-${MINGW_CHOST}
-  cd build-${MINGW_CHOST}
+  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
 
   meson \
     --buildtype=plain \
@@ -46,6 +48,8 @@ build() {
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   DESTDIR="${pkgdir}${MINGW_PREFIX}" ninja install
+
+  sed -s "s|$(cygpath -m ${MINGW_PREFIX})|${MINGW_PREFIX}|g" -i "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/${_realname}-1.0.pc"
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING.LIB" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.LIB"
 }


### PR DESCRIPTION
This updates geocode-glib to 3.26.1.