### PR TITLE
cmake tweak FindSWIG command such that users can set a search path fo…

### DIFF
--- a/mingw-w64-cmake/0009-FindSWIG-allow-to-provide-search-prefix-on-Windows.patch
+++ b/mingw-w64-cmake/0009-FindSWIG-allow-to-provide-search-prefix-on-Windows.patch
@@ -1,0 +1,28 @@
+From d9ddd961094e59ede6658f1776f88f259dc4e45d Mon Sep 17 00:00:00 2001
+From: Geert Janssens <geert@kobaltwit.be>
+Date: Tue, 30 Apr 2019 11:09:44 +0200
+Subject: [PATCH] FindSWIG - allow to provide search prefix on Windows
+
+The default search paths won't find SWIG on windows, so we need a way to
+tell cmake where to look. The NO_CMAKE_FIND_ROOT_PATH prevents us
+from doing so.
+---
+ Modules/FindSWIG.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Modules/FindSWIG.cmake b/Modules/FindSWIG.cmake
+index fc0ed009da..78592c4ea3 100644
+--- a/Modules/FindSWIG.cmake
++++ b/Modules/FindSWIG.cmake
+@@ -42,7 +42,7 @@ if(SWIG_EXECUTABLE)
+     endif()
+   else()
+     string(REGEX REPLACE "[\n\r]+" ";" SWIG_swiglib_output ${SWIG_swiglib_output})
+-    find_path(SWIG_DIR swig.swg PATHS ${SWIG_swiglib_output} NO_CMAKE_FIND_ROOT_PATH)
++    find_path(SWIG_DIR swig.swg PATHS ${SWIG_swiglib_output})
+     if(SWIG_DIR)
+       set(SWIG_USE_FILE ${CMAKE_CURRENT_LIST_DIR}/UseSWIG.cmake)
+       execute_process(COMMAND ${SWIG_EXECUTABLE} -version
+-- 
+2.20.1
+

--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -30,7 +30,8 @@ source=("https://www.cmake.org/files/v${pkgver%.*}/${_realname}-${pkgver}.tar.gz
         "0005-Do-not-install-Qt-bundle-in-cmake-gui.patch"
         "0006-pkg-config-Add-dont-define-prefix-when-PKG_CONFIG_WI.patch"
         "0007-Do-not-generate-import-libs-for-exes.patch"
-        "0008-Output-line-numbers-in-callstacks.patch")
+        "0008-Output-line-numbers-in-callstacks.patch"
+        "0009-FindSWIG-allow-to-provide-search-prefix-on-Windows.patch")
 sha256sums=('a3cbf562b99270c0ff192f692139e98c605f292bfdbc04d70da0309a5358e71e'
             '1b68fe64e1b389134db44dc34368713f6e28d3463ab1e7fc3d93857c0459beb7'
             '77763df03e8a9ca66c3f9368fe7e1fc36bb041455733258d73aeb40246a61354'
@@ -38,7 +39,8 @@ sha256sums=('a3cbf562b99270c0ff192f692139e98c605f292bfdbc04d70da0309a5358e71e'
             '7eb60d12b610c70413412521dcc860d1948c169e721f3525d9be99b3913dc37e'
             'b3905abed55c012108b0254c69cb4027a739f15772500b0a99c400d9dfdf50a7'
             'd0aaa6fbf3e740341aaac2b43033f6c20f56a94ea0b2c509233f693cabe2a912'
-            '94642670c922c9acfade79bc567c6b28f2d2f89e27aa391b562e8c90baa49ce1')
+            '94642670c922c9acfade79bc567c6b28f2d2f89e27aa391b562e8c90baa49ce1'
+	    'bfa59f2dcbda584e243066c6d9e7d478b27bf5e98cff404e7b3c1a9c76445b8b')
 
 
 # Helper macros to help make tasks easier #
@@ -70,7 +72,8 @@ prepare() {
     0005-Do-not-install-Qt-bundle-in-cmake-gui.patch \
     0006-pkg-config-Add-dont-define-prefix-when-PKG_CONFIG_WI.patch \
     0007-Do-not-generate-import-libs-for-exes.patch \
-    0008-Output-line-numbers-in-callstacks.patch
+    0008-Output-line-numbers-in-callstacks.patch \
+    0009-FindSWIG-allow-to-provide-search-prefix-on-Windows.patch
 }
 
 build() {


### PR DESCRIPTION
…r swig

As mingw is not typically installed in a path that's hard-coded into cmake, the original find
command would not find swig. By allowing the user to set search paths (that is, by removing
the NO_CMAKE_FIND_ROOT_PATH flag), a user can tell cmake where to look for swig.