### PR TITLE
python3-cmd2: update to 0.9.12

### DIFF
--- a/mingw-w64-python3-cmd2/PKGBUILD
+++ b/mingw-w64-python3-cmd2/PKGBUILD
@@ -5,7 +5,7 @@
 _realname=cmd2
 pkgbase=mingw-w64-python-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
-pkgver=0.9.10
+pkgver=0.9.12
 pkgrel=1
 pkgdesc="Extra features for standard library's cmd module (mingw-w64)"
 arch=('any')
@@ -17,14 +17,15 @@ depends=("${MINGW_PACKAGE_PREFIX}-python3-attrs"
              "${MINGW_PACKAGE_PREFIX}-python3-pyreadline"
              "${MINGW_PACKAGE_PREFIX}-python3-colorama" 
              "${MINGW_PACKAGE_PREFIX}-python3-wcwidth")
-makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools") 
+makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools-scm") 
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python3-pytest-runner"
               "${MINGW_PACKAGE_PREFIX}-python3-pytest-xdist"
               "${MINGW_PACKAGE_PREFIX}-python3-mock" )
 # 'vi')
 options=('staticlibs' 'strip' '!debug')
 source=("${_realname}-$pkgver.tar.gz::https://github.com/python-cmd2/cmd2/archive/$pkgver.tar.gz")
-sha512sums=('0fdc9558a4f9788d42c8154a033acb0f9fa6e3b4877c86d05e8365e5706706e7ca232a24f07e4e815b423a993f37344d9611a8d372dc1ce8c9fa5284bf25bab2')
+sha512sums=('aa6dc14c3e958d644b1d4afbbe16b88d781a2a016b5691a82648a22ef61b7b31512621814c0a1298a8f2cd74cb1fe0243b97fea7c8e4aeffe7e752e2fd56d4b8')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {


### PR DESCRIPTION
This updates python3-cmd2 to 0.9.12. python3-setuptools-scm is added to makedepends to fix build.