### PR TITLE
xpra: update to 2.5.1

### DIFF
--- a/mingw-w64-python-xpra/PKGBUILD
+++ b/mingw-w64-python-xpra/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-common"
          "${MINGW_PACKAGE_PREFIX}-python2-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=2.5
+pkgver=2.5.1
 pkgrel=1
 pkgdesc="Remote access client / server software"
 arch=('any')
@@ -38,7 +38,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pygobject-devel"
              "${MINGW_PACKAGE_PREFIX}-python3-cairo")
 source=("https://xpra.org/src/xpra-${pkgver}.tar.xz")
-sha512sums=('408f149b74f0a2f16a6c545a165b6e819e8a79392ae16c0d2db2a6c3e908dc82e7d9cbc125c191ca804fcc19b72b8c91a0b7534243af3421ecac4c76bcbda855')
+sha512sums=('05ea7ca1c81225db19f285ee95df8fe53240b9ddec67eb005ffae833a80f45d4ecd7a4d444dfb3cff144bc60441017d378db69b7a589d58a9a63f4e6d201bad1')
 
 prepare() {
   cd "${srcdir}"
@@ -68,6 +68,7 @@ package_python3-xpra() {
             "${MINGW_PACKAGE_PREFIX}-python3-comtypes"
             "${MINGW_PACKAGE_PREFIX}-python3-setproctitle")
   optdepends+=("${MINGW_PACKAGE_PREFIX}-python3-paramiko: SSH client and server support"
+              "${MINGW_PACKAGE_PREFIX}-python3-dnspython: SSHFP support with paramiko"
               "${MINGW_PACKAGE_PREFIX}-python3-netifaces: mDNS and network integration"
               "${MINGW_PACKAGE_PREFIX}-python3-pyu2f: U2F authentication"
               "${MINGW_PACKAGE_PREFIX}-python3-ldap: LDAP authentication via python-ldap"
@@ -100,6 +101,7 @@ package_python2-xpra() {
             "${MINGW_PACKAGE_PREFIX}-python2-setproctitle"
             "${MINGW_PACKAGE_PREFIX}-python2-zeroconf")
   optdepends+=("${MINGW_PACKAGE_PREFIX}-python2-paramiko: SSH client and server support"
+              "${MINGW_PACKAGE_PREFIX}-python2-dnspython: SSHFP support with paramiko"
               "${MINGW_PACKAGE_PREFIX}-python2-netifaces: mDNS and network integration"
               "${MINGW_PACKAGE_PREFIX}-python2-pyu2f: U2F authentication"
               "${MINGW_PACKAGE_PREFIX}-python2-ldap: LDAP authentication via python-ldap"


### PR DESCRIPTION
also adds an optional dependency on dnspython to get SSHFP support.