### PR TITLE
glib-networking: update to 2.60.2

### DIFF
--- a/mingw-w64-glib-networking/PKGBUILD
+++ b/mingw-w64-glib-networking/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=glib-networking
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.60.1
+pkgver=2.60.2
 pkgrel=1
 pkgdesc="Network-related GIO modules for glib (mingw-w64)"
 arch=(any)
@@ -20,7 +20,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-gsettings-desktop-schemas")
 options=('staticlibs' 'strip')
 source=("https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz")
-sha256sums=('d71c6b2faa5ac29100314f08a1be020a2afd0291f025614c0af0d17b14435d92')
+sha256sums=('c022f3d10f55a5b7c31676fb001b4cb6401db8ab9f6e8418c69de00d0f268732')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -28,8 +28,7 @@ prepare() {
 
 build() {
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
-  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
-  cd build-${MINGW_CHOST}
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
 
   ${MINGW_PREFIX}/bin/meson \
     --buildtype plain \


### PR DESCRIPTION
This updates glib-networking to 2.60.2.