### PR TITLE
glib2: update to 2.60.2

### DIFF
--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -6,7 +6,7 @@
 _realname=glib2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.60.1
+pkgver=2.60.2
 pkgrel=1
 url="https://www.gtk.org/"
 arch=('any')
@@ -28,15 +28,14 @@ source=("https://download.gnome.org/sources/glib/${pkgver%.*}/glib-${pkgver}.tar
         0001-win32-Make-the-static-build-work-with-MinGW-when-pos.patch
         0001-disable-some-tests-when-static.patch
         0001-Revert-tests-W32-ugly-fix-for-sscanf-format.patch
-        pyscript2exe.py
-        )
-sha256sums=('89f884f5d5c6126140ec868cef184c42ce72902c13cd08f36e660371779b5560'
+        pyscript2exe.py)
+sha256sums=('2ef15475060addfda0443a7e8a52b28a10d5e981e82c083034061daf9a8f80d9'
             'ff0d3df5d57cf621cac79f5bea8bd175e6c18b3fbf7cdd02df38c1eab9f40ac3'
             '838abaeab8ca4978770222ef5f88c4b464545dd591b2d532c698caa875b46931'
             '0f44135a139e3951c4b5fa7d4628d75226e0666d891faf524777e1d1ec3b440b'
             '601b4da43aeccfa522ea46fcb9c33ec9530b8c4b965b8964abd3f4972b769cdd'
-            'f68b24932b3365c4098c04eeaeaf87275ceec29694b3f0597c431bbcf4f913a3'
-            )
+            'f68b24932b3365c4098c04eeaeaf87275ceec29694b3f0597c431bbcf4f913a3')
+
 prepare() {
   cd "${srcdir}/glib-${pkgver}"
 
@@ -67,9 +66,8 @@ build() {
     -Ddefault_library=shared \
     -Dman=true \
     -Dforce_posix_threads=true \
+    -Dgtk_doc=true \
     "../glib-${pkgver}"
-    # https://github.com/msys2/MINGW-packages/issues/5146
-    # -Dgtk_doc=true \
 
   ninja
 }


### PR DESCRIPTION
This updates glib2 to 2.60.2.

gtk-doc support is brought back.