### PR TITLE
yasm: use python3 for the build

### DIFF
--- a/mingw-w64-yasm/PKGBUILD
+++ b/mingw-w64-yasm/PKGBUILD
@@ -4,14 +4,16 @@ _realname=yasm
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.3.0
-pkgrel=3
+pkgrel=4
 pkgdesc="A rewrite of NASM to allow for multiple syntax supported (NASM, TASM, GAS, etc.) (mingw-w64)"
 arch=('any')
 license=('BSD' 'GPL2' 'LGPL2.1' 'PerlArtistic')
 url="https://www.tortall.net/projects/yasm/"
 depends=("${MINGW_PACKAGE_PREFIX}-gettext")
 options=('strip' '!libtool' 'staticlibs')
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config" "python2")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-python3")
 source=(https://www.tortall.net/projects/yasm/releases/${_realname}-${pkgver}.tar.gz)
 sha256sums=('3dce6601b495f5b3d45b59f7d2492a340ee7e84b5beca17e48f862502bd5603f')
 


### PR DESCRIPTION
It builds fine with mingw python3, so let's use it.