### PR TITLE
gexiv2: Update to 0.10.10; drop py2; Re-enable introspection. Fixes #4956

### DIFF
--- a/mingw-w64-gexiv2/PKGBUILD
+++ b/mingw-w64-gexiv2/PKGBUILD
@@ -3,18 +3,16 @@
 _realname=gexiv2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.10.9
+pkgver=0.10.10
 pkgrel=1
 arch=('any')
 pkgdesc="GObject-based wrapper around the Exiv2 library (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-glib2"
-         "${MINGW_PACKAGE_PREFIX}-exiv2"
-         "${MINGW_PACKAGE_PREFIX}-python2")
+         "${MINGW_PACKAGE_PREFIX}-exiv2")
 makedepends=("${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-ninja"
-			 "${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-vala"
-             "${MINGW_PACKAGE_PREFIX}-python2-gobject"
              "${MINGW_PACKAGE_PREFIX}-python3-gobject"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
              "${MINGW_PACKAGE_PREFIX}-gtk-doc")
@@ -22,7 +20,7 @@ options=('strip' 'staticlibs')
 license=("LGPL 2.1")
 url="https://www.gnome.org/"
 source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz)
-sha256sums=('8806234aa6fd1c345d46bf07a14e82771415071ca5ff63615b1ea62bd2fec0ed')
+sha256sums=('7d9ad7147ab51ab691edf043c44a0a44de4088c48a12d9c23c26939710e66ce1')
 
 prepare() {
   cd ${_realname}-${pkgver}
@@ -35,7 +33,7 @@ build() {
 
   ${MINGW_PREFIX}/bin/meson \
     --buildtype plain \
-    -Ddisable-introspection=true \
+    -Dpython2-girdir=no \
     ../${_realname}-${pkgver}
 
   ninja


### PR DESCRIPTION
Also drops unnecessary python2 deps while at it.

#4956