### PR TITLE
jq: drop unnecessary python2 dep

### DIFF
--- a/mingw-w64-jq/PKGBUILD
+++ b/mingw-w64-jq/PKGBUILD
@@ -4,16 +4,16 @@ _realname=jq
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.6
-pkgrel=1
+pkgrel=2
 pkgdesc="Command-line JSON processor (mingw-w64)"
 arch=('any')
 url='https://stedolan.github.io/jq/'
 license=('MIT')
-makedepends=("autoconf" "automake" "bison" "flex" "python2")
+makedepends=("autoconf" "automake" "bison" "flex")
 depends=("${MINGW_PACKAGE_PREFIX}-oniguruma")
 source=("https://github.com/stedolan/${_realname}/releases/download/${_realname}-${pkgver}/${_realname}-${pkgver}.tar.gz"
         no-undefined.patch)
-sha256sums=('9625784cf2e4fd9842f1d407681ce4878b5b0dcddbcd31c6135114a30c71e6a8'
+sha256sums=('5de8c8e29aaa3fb9cc6b47bb27299f271354ebb72514e3accadc7d38b5bbaa72'
             'ed3f9824901a49d146b74c2a0a212595522dfa0fa5da32200c8384a779bbfa78')
 noextract=(${_realname}-${pkgver}.tar.gz)
 
@@ -37,7 +37,8 @@ build() {
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \
     --enable-static \
-    --enable-shared
+    --enable-shared \
+    --disable-docs
 
   make
 }


### PR DESCRIPTION
It's only used for the docs, but that needs ruby as well and we didn't build it.

Also update the checksum, the tarball was updated after the release:
   https://github.com/stedolan/jq/issues/1773