### PR TITLE
unicorn: drop unnecessary msys python2 dependency

### DIFF
--- a/mingw-w64-unicorn/PKGBUILD
+++ b/mingw-w64-unicorn/PKGBUILD
@@ -6,14 +6,13 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-unicorn"
          "${MINGW_PACKAGE_PREFIX}-python2-unicorn"
          "${MINGW_PACKAGE_PREFIX}-python3-unicorn")
 pkgver=1.0.1
-pkgrel=3
+pkgrel=4
 pkgdesc="A lightweight multi-platform, multi-architecture CPU emulator framework based on QEMU (mingw-w64)"
 url='http://www.unicorn-engine.org/index.html'
 arch=('any')
 license=('GPL2')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
-makedepends=(python2
-             "${MINGW_PACKAGE_PREFIX}-python2"
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python3"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
@@ -37,7 +36,7 @@ build() {
   cd "${_realname}-${pkgver}"
   make clean
 
-  UNICORN_QEMU_FLAGS="--python=/usr/bin/python2" \
+  UNICORN_QEMU_FLAGS="--python=${MINGW_PREFIX}/bin/python2" \
   make PREFIX="${MINGW_PREFIX}"
 
   (cd bindings


### PR DESCRIPTION
It builds fine with the mingw one.