### PR TITLE
brotli: drop python2-brotli

### DIFF
--- a/mingw-w64-brotli/PKGBUILD
+++ b/mingw-w64-brotli/PKGBUILD
@@ -3,35 +3,32 @@
 _realname=brotli
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
-         "${MINGW_PACKAGE_PREFIX}-python2-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-brotli-testdata")
 pkgver=1.0.7
-pkgrel=1
+pkgrel=2
 pkgdesc="Brotli compression library (mingw-w64)"
 arch=('any')
 url='https://github.com/google/brotli'
-makedepends=("${MINGW_PACKAGE_PREFIX}-cmake" "${MINGW_PACKAGE_PREFIX}-python3" "${MINGW_PACKAGE_PREFIX}-python2")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake" "${MINGW_PACKAGE_PREFIX}-python3")
 license=('MIT')
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/google/brotli/archive/v${pkgver}.tar.gz")
 sha256sums=('4c61bfb0faca87219ea587326c467b95acb25555b53d1a421ffa3c8a9296ee2c')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
-  for builddir in python{2,3}-build-${CARCH}; do  
-    rm -rf ${builddir} | true
-    cp -r "${srcdir}/${_realname}-${pkgver}" "${srcdir}/${builddir}"
-  done
+  rm -rf python3-build-${CARCH} | true
+  cp -r "${srcdir}/${_realname}-${pkgver}" "${srcdir}/python3-build-${CARCH}"
 }
 
 build() {
   cd "${srcdir}"/${_realname}-${pkgver}
-  for pver in {2,3}; do  
-    msg "Python ${pver} build for ${CARCH}"  
-    cd "${srcdir}/python${pver}-build-${CARCH}"
-    MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-      ${MINGW_PREFIX}/bin/python${pver} setup.py build
-  done  
+
+  msg "Python 3 build for ${CARCH}"
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    ${MINGW_PREFIX}/bin/python3 setup.py build
+
   cd "${srcdir}"/${_realname}-${pkgver}
   [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
   mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
@@ -77,17 +74,6 @@ package_python3-brotli() {
 
 }
 
-package_python2-brotli() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python2" "${MINGW_PACKAGE_PREFIX}-libwinpthread-git")
-
-  cd "${srcdir}/python2-build-${CARCH}"
-  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
-    --root="${pkgdir}" --optimize=1 --skip-build
-
-  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/COPYING"
-}
-
 package_brotli-testdata() {
   depends=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 
@@ -105,10 +91,6 @@ package_mingw-w64-i686-brotli-testdata() {
   package_brotli-testdata
 }
 
-package_mingw-w64-i686-python2-brotli() {
-  package_python2-brotli
-}
-
 package_mingw-w64-i686-python3-brotli() {
   package_python3-brotli
 }
@@ -119,10 +101,6 @@ package_mingw-w64-x86_64-brotli() {
 
 package_mingw-w64-x86_64-brotli-testdata() {
   package_brotli-testdata
-}
-
-package_mingw-w64-x86_64-python2-brotli() {
-  package_python2-brotli
 }
 
 package_mingw-w64-x86_64-python3-brotli() {


### PR DESCRIPTION
Nothing depends on it and there is python3-brotli for Python 3.

@JPeterMugaas any objections?