### PR TITLE
boost: remove cmake config

### DIFF
--- a/mingw-w64-boost/PKGBUILD
+++ b/mingw-w64-boost/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.70.0
 _boostver=${pkgver//./_}
-pkgrel=1
+pkgrel=2
 pkgdesc="Free peer-reviewed portable C++ source libraries (mingw-w64)"
 arch=('any')
 url="https://www.boost.org/"
@@ -154,6 +154,7 @@ build() {
     --prefix=${MINGW_PREFIX} \
     --layout=tagged \
     --without-mpi \
+    --no-cmake-config \
     -sHAVE_ICU=1 \
     -sICU_PATH=${MINGW_PREFIX} \
     -sICU_LINK="-L${MINGW_PREFIX}/lib -licuuc -licuin -licudt" \
@@ -200,6 +201,7 @@ package() {
       --prefix=${pkgdir}${MINGW_PREFIX} \
       --layout=tagged \
       --without-mpi \
+      --no-cmake-config \
       -sHAVE_ICU=1 \
       -sICU_PATH=${MINGW_PREFIX} \
       -sICU_LINK="-L${MINGW_PREFIX}/lib -licuuc -licuin -licudt" \


### PR DESCRIPTION
This removes the boost cmake config, which causes packages depending on boost to fail during building (cannot detect boost libraries using cmake config).