### PR TITLE
ruby-ronn - 0.7.3 and packages itit requires (please see notes)

### DIFF
--- a/mingw-w64-ruby-hpricot/PKGBUILD
+++ b/mingw-w64-ruby-hpricot/PKGBUILD
@@ -1,0 +1,46 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+# Note: hpricot was discontinued aboust 6 years ago and it hasn't had a release in 9 years.
+# I am only providing this so that we can use the original version of ruby-ronn gem.
+#
+# The most ideal solution to this situation is to update to ruby-ng but that seems
+# to depend upon an old version of mustache (0.7.x) - see: https://github.com/apjanke/ronn-ng/blob/master/ronn-ng.gemspec
+
+_realname=hpricot
+pkgbase="mingw-w64-ruby-${_realname}"
+pkgname="${MINGW_PACKAGE_PREFIX}-ruby-${_realname}"
+pkgver=0.8.6
+pkgrel=1
+pkgdesc="Manual page formatter that generates man pages from markdown (mingw-w64)"
+arch=('any')
+url='https://github.com/hpricot/hpricot'
+license=('MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-ruby")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+options=(!emptydirs)
+source=(https://rubygems.org/downloads/${_realname}-$pkgver.gem)
+noextract=(${_realname}-$pkgver.gem)
+sha1sums=('87ce2c17960a5e1d7ceaa16d0591ca6a28379ce0')
+
+check() {
+  local _gemdir="$(ruby -e 'puts Gem.default_dir')"
+  _gemdir="$(cygpath -u ${_gemdir})"
+
+  ${MINGW_PREFIX}/bin/gem check --verbose \
+    "${_realname}-${pkgver}.gem"
+}
+
+package() {
+  local _gemdir="$(${MINGW_PREFIX}/bin/ruby -e 'puts Gem.default_dir')"
+  _gemdir="$(cygpath -u ${_gemdir})"
+
+  ${MINGW_PREFIX}/bin/gem install --ignore-dependencies --no-user-install --no-document --verbose \
+    -i "${pkgdir}/${_gemdir}" -n "${pkgdir}${MINGW_PREFIX}/bin" \
+    "${_realname}-${pkgver}.gem"
+
+  install -D -m644 "$pkgdir/$_gemdir/gems/${_realname}-$pkgver/COPYING" \
+    "$pkgdir${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+
+  rm "${pkgdir}/${_gemdir}/cache/${_realname}-${pkgver}.gem"
+  rm -rf "${pkgdir}${MINGW_PREFIX}/${_gemdir}/gems/${_realname}-${pkgver}/man"
+}

--- a/mingw-w64-ruby-mustache/PKGBUILD
+++ b/mingw-w64-ruby-mustache/PKGBUILD
@@ -1,0 +1,56 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_realname=mustache
+pkgbase="mingw-w64-ruby-${_realname}"
+pkgname="${MINGW_PACKAGE_PREFIX}-ruby-${_realname}"
+pkgver=1.1.0
+pkgrel=1
+pkgdesc="Mustache is a framework-agnostic way to render logic-free views. (mingw-w64)"
+arch=('any')
+url='https://github.com/mustache/mustache'
+license=('MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-ruby")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+source=(https://rubygems.org/downloads/${_realname}-${pkgver}.gem)
+noextract=(${_realname}-$pkgver.gem)
+sha256sums=('7365441281b93b9a3e7299c432af1b971435155168ef12631a72bbdaf9ed2899')
+
+check() {
+  local _gemdir="$(ruby -e 'puts Gem.default_dir')"
+  _gemdir="$(cygpath -u ${_gemdir})"
+
+  ${MINGW_PREFIX}/bin/gem check --verbose \
+    "${_realname}-${pkgver}.gem"
+}
+
+package() {
+  local _gemdir="$(${MINGW_PREFIX}/bin/ruby -e 'puts Gem.default_dir')"
+  _gemdir="$(cygpath -u ${_gemdir})"
+
+  ${MINGW_PREFIX}/bin/gem install --ignore-dependencies --no-user-install --verbose \
+    -i "${pkgdir}/${_gemdir}" -n "${pkgdir}${MINGW_PREFIX}/bin" \
+    "${_realname}-${pkgver}.gem"
+
+  local _ruby_exe=$(cygpath -m ${MINGW_PREFIX}/bin/ruby.exe)
+
+  #for this conversion, we want the fully qualified ruby .exe path
+  #so that we can be sure that we are calling the correct one.
+  sed -e "s|${_ruby_exe}|${MINGW_PREFIX}/bin/ruby|g" \
+      -i ${pkgdir}${MINGW_PREFIX}/bin/mustache
+
+  #for Win32 .bat files, we want to drop the path references as the path
+  #refs are not needed since it's involved from the same dir.  If we did
+  #need fully-qualified pathes, they would have to be fully-qualified and
+  # in DOS format.
+  local _inst_dir=$(cygpath -m ${pkgdir}/${MINGW_PREFIX}/bin/)
+  local _w_ruby_exe=$(cygpath -w ${MINGW_PREFIX}/bin/ruby.exe | sed 's/\\/\\\\/g')
+  sed  -e "s|${_w_ruby_exe}|ruby.exe|g" \
+       -e "s|${_inst_dir}||g" \
+       -i ${pkgdir}${MINGW_PREFIX}/bin/mustache.bat
+
+  install -Dm644 "${pkgdir}/${_gemdir}/gems/${_realname}-${pkgver}/man/mustache.1" \
+    "${pkgdir}${MINGW_PREFIX}/share/man/man1/mustache.1"
+
+  rm "${pkgdir}/${_gemdir}/cache/${_realname}-${pkgver}.gem"
+  rm -rf "${pkgdir}${MINGW_PREFIX}/${_gemdir}/gems/${_realname}-${pkgver}/man"
+}

--- a/mingw-w64-ruby-rdiscount/PKGBUILD
+++ b/mingw-w64-ruby-rdiscount/PKGBUILD
@@ -1,0 +1,56 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_realname=rdiscount
+pkgbase="mingw-w64-ruby-${_realname}"
+pkgname="${MINGW_PACKAGE_PREFIX}-ruby-${_realname}"
+pkgver=2.2.0.1
+pkgrel=1
+pkgdesc="Fast Implementation of Gruber's Markdown in C (mingw-w64)"
+arch=('any')
+url='https://github.com/davidfstr/rdiscount'
+license=('MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-ruby")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+source=(https://rubygems.org/downloads/${_realname}-${pkgver}.gem)
+noextract=(${_realname}-$pkgver.gem)
+sha256sums=('a34f55937c84f390f979808c7002fd24ab1e8b0172c916b0563d5f03e6983bab')
+
+check() {
+  local _gemdir="$(ruby -e 'puts Gem.default_dir')"
+  _gemdir="$(cygpath -u ${_gemdir})"
+
+  ${MINGW_PREFIX}/bin/gem check --verbose \
+    "${_realname}-${pkgver}.gem"
+}
+
+package() {
+  local _gemdir="$(${MINGW_PREFIX}/bin/ruby -e 'puts Gem.default_dir')"
+  _gemdir="$(cygpath -u ${_gemdir})"
+
+  ${MINGW_PREFIX}/bin/gem install --ignore-dependencies --no-user-install --verbose \
+    -i "${pkgdir}/${_gemdir}" -n "${pkgdir}${MINGW_PREFIX}/bin" \
+    "${_realname}-${pkgver}.gem"
+
+  local _ruby_exe=$(cygpath -m ${MINGW_PREFIX}/bin/ruby.exe)
+
+  #for this conversion, we want the fully qualified ruby .exe path
+  #so that we can be sure that we are calling the correct one.
+  sed -e "s|${_ruby_exe}|${MINGW_PREFIX}/bin/ruby|g" \
+      -i ${pkgdir}${MINGW_PREFIX}/bin/rdiscount
+
+  #for Win32 .bat files, we want to drop the path references as the path
+  #refs are not needed since it's involved from the same dir.  If we did
+  #need fully-qualified pathes, they would have to be fully-qualified and
+  # in DOS format.
+  local _inst_dir=$(cygpath -m ${pkgdir}/${MINGW_PREFIX}/bin/)
+  local _w_ruby_exe=$(cygpath -w ${MINGW_PREFIX}/bin/ruby.exe | sed 's/\\/\\\\/g')
+  sed  -e "s|${_w_ruby_exe}|ruby.exe|g" \
+       -e "s|${_inst_dir}||g" \
+       -i ${pkgdir}${MINGW_PREFIX}/bin/rdiscount.bat
+
+  install -Dm644 "${pkgdir}/${_gemdir}/gems/${_realname}-${pkgver}/man/rdiscount.1" \
+    "${pkgdir}${MINGW_PREFIX}/share/man/man1/rdiscount.1"
+
+  rm "${pkgdir}/${_gemdir}/cache/${_realname}-${pkgver}.gem"
+  rm -rf "${pkgdir}${MINGW_PREFIX}/${_gemdir}/gems/${_realname}-${pkgver}/man"
+}

--- a/mingw-w64-ruby-ronn/PKGBUILD
+++ b/mingw-w64-ruby-ronn/PKGBUILD
@@ -1,0 +1,65 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+# Note: hpricot was discontinued aboust 6 years ago and it hasn't had a release in 9 years.
+# Likewise, ruby-ronn in it's original version has not had a release in about 9 years.
+#
+# The most ideal solution to this situation is to update to ruby-ng but that seems
+# to depend upon an old version of mustache (0.7.x) - see: https://github.com/apjanke/ronn-ng/blob/master/ronn-ng.gemspec
+
+_realname=ronn
+pkgbase="mingw-w64-ruby-${_realname}"
+pkgname="${MINGW_PACKAGE_PREFIX}-ruby-${_realname}"
+pkgver=0.7.3
+pkgrel=1
+pkgdesc="ronn is a framework-agnostic way to render logic-free views. (mingw-w64)"
+arch=('any')
+url='http://rtomayko.github.io/ronn/'
+license=('MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-ruby" 
+         "${MINGW_PACKAGE_PREFIX}-ruby-hpricot"
+         "${MINGW_PACKAGE_PREFIX}-ruby-mustache"
+         "${MINGW_PACKAGE_PREFIX}-ruby-rdiscount")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+source=(https://rubygems.org/downloads/${_realname}-${pkgver}.gem)
+noextract=(${_realname}-$pkgver.gem)
+sha256sums=('82df6fd4a3aa91734866710d2811a6387e50a7513fc528ce6c7d95ee7ad7f41e')
+
+check() {
+  local _gemdir="$(ruby -e 'puts Gem.default_dir')"
+  _gemdir="$(cygpath -u ${_gemdir})"
+
+  ${MINGW_PREFIX}/bin/gem check --verbose \
+    "${_realname}-${pkgver}.gem"
+}
+
+package() {
+  local _gemdir="$(${MINGW_PREFIX}/bin/ruby -e 'puts Gem.default_dir')"
+  _gemdir="$(cygpath -u ${_gemdir})"
+
+  ${MINGW_PREFIX}/bin/gem install --ignore-dependencies --no-user-install --verbose \
+    -i "${pkgdir}/${_gemdir}" -n "${pkgdir}${MINGW_PREFIX}/bin" \
+    "${_realname}-${pkgver}.gem"
+
+  local _ruby_exe=$(cygpath -m ${MINGW_PREFIX}/bin/ruby.exe)
+
+  #for this conversion, we want the fully qualified ruby .exe path
+  #so that we can be sure that we are calling the correct one.
+  sed -e "s|${_ruby_exe}|${MINGW_PREFIX}/bin/ruby|g" \
+      -i ${pkgdir}${MINGW_PREFIX}/bin/ronn
+
+  #for Win32 .bat files, we want to drop the path references as the path
+  #refs are not needed since it's involved from the same dir.  If we did
+  #need fully-qualified pathes, they would have to be fully-qualified and
+  # in DOS format.
+  local _inst_dir=$(cygpath -m ${pkgdir}/${MINGW_PREFIX}/bin/)
+  local _w_ruby_exe=$(cygpath -w ${MINGW_PREFIX}/bin/ruby.exe | sed 's/\\/\\\\/g')
+  sed  -e "s|${_w_ruby_exe}|ruby.exe|g" \
+       -e "s|${_inst_dir}||g" \
+       -i ${pkgdir}${MINGW_PREFIX}/bin/ronn.bat
+
+  install -Dm644 "${pkgdir}/${_gemdir}/gems/${_realname}-${pkgver}/man/ronn.1" \
+    "${pkgdir}${MINGW_PREFIX}/share/man/man1/ronn.1"
+
+  rm "${pkgdir}/${_gemdir}/cache/${_realname}-${pkgver}.gem"
+  rm -rf "${pkgdir}${MINGW_PREFIX}/${_gemdir}/gems/${_realname}-${pkgver}/man"
+}


### PR DESCRIPTION
ruby-hpricot - 0.8.6- - final release version of hpricot - required by ruby-ronn
ruby-mustache - 1.1.0 - - New package required by ruby-ronn
ruby-rdiscount - 2.2.0.1 - new package required by ruby-ronn