### PR TITLE
gettext: fix tools relocation support

### DIFF
--- a/mingw-w64-gettext/200-tools-gnulib-define-installdir.patch
+++ b/mingw-w64-gettext/200-tools-gnulib-define-installdir.patch
@@ -1,0 +1,12 @@
+for relocate()
+--- gettext-0.19.8.1/gettext-tools/gnulib-lib/Makefile.am.orig	2019-05-11 22:20:53.069987300 +0200
++++ gettext-0.19.8.1/gettext-tools/gnulib-lib/Makefile.am	2019-05-11 22:21:54.510209600 +0200
+@@ -48,6 +48,8 @@
+ # Parametrization of the 'relocatable' module.
+ AM_CPPFLAGS += -DDEPENDS_ON_LIBICONV=1 -DDEPENDS_ON_LIBINTL=1
+ 
++AM_CPPFLAGS += -DINSTALLDIR=\"$(bindir)\"
++
+ # Parametrization of the 'libxml' module:
+ # When building a shared library, don't export the variables
+ # xmlMalloc, xmlMallocAtomic, xmlRealloc, xmlFree, xmlMemStrdup.

--- a/mingw-w64-gettext/PKGBUILD
+++ b/mingw-w64-gettext/PKGBUILD
@@ -5,7 +5,7 @@ _realname=gettext
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.19.8.1
-pkgrel=7
+pkgrel=8
 arch=('any')
 pkgdesc="GNU internationalization library (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-expat"
@@ -30,7 +30,8 @@ source=("https://ftp.gnu.org/pub/gnu/${_realname}/${_realname}-${pkgver}.tar.gz"
         08-vs-compatible.patch
         09-asm-underscore-mingw.patch
         121-keep-posix-path.patch
-        122-Use-LF-as-newline-in-envsubst.patch)
+        122-Use-LF-as-newline-in-envsubst.patch
+        200-tools-gnulib-define-installdir.patch)
 sha256sums=('ff942af0e438ced4a8b0ea4b0b6e0d6d657157c5e2364de57baa279c1c125c43'
             'SKIP'
             '030987c317279c27eea503ef257c7c3cf4ff947de8ea71d84fdf5eea802ee587'
@@ -42,7 +43,8 @@ sha256sums=('ff942af0e438ced4a8b0ea4b0b6e0d6d657157c5e2364de57baa279c1c125c43'
             '522715ac22936943a85b4b78274302a6058f4f5371439cf491193ed53d8fc729'
             '2ffc73f1b8d66d88ff5ce640be211e5a927daba13788cb2319b97fc885444eac'
             '051bf975687a92da8a5acc09a367632396570c2609c5ecc1eba06c60c7135ad6'
-            '2abfa598e1586abe14e982b867c8981790d8114e1ee575cb08b7ed49d4a46c74')
+            '2abfa598e1586abe14e982b867c8981790d8114e1ee575cb08b7ed49d4a46c74'
+            '71eb3554cbf37a8c866722e39c6102c3ae3a215b82e153000f61f2e80d3bfd1b')
 validpgpkeys=('462225C3B46F34879FC8496CD605848ED7E69871') #Daiki Ueno
 
 prepare() {
@@ -72,6 +74,7 @@ prepare() {
   patch -p1 -i ${srcdir}/120-Fix-Woe32-link-errors-when-compiling-with-O0.patch
   #patch -p1 -i ${srcdir}/121-keep-posix-path.patch
   patch -p1 -i ${srcdir}/122-Use-LF-as-newline-in-envsubst.patch
+  patch -p1 -i ${srcdir}/200-tools-gnulib-define-installdir.patch
 
   libtoolize --automake --copy --force
   WANT_AUTOMAKE=latest ./autogen.sh --skip-gnulib
@@ -80,7 +83,7 @@ prepare() {
 build() {
   export lt_cv_deplibs_check_method='pass_all'
 
-  export MSYS2_ARG_CONV_EXCL="-DLOCALEDIR=;-DLIBDIR=;-DLOCALE_ALIAS_PATH=;-DINSTALLDIR="
+  export MSYS2_ARG_CONV_EXCL="-DLOCALEDIR=;-DLIBDIR=;-DLOCALE_ALIAS_PATH="
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
   mkdir -p ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
 
@@ -105,6 +108,9 @@ build() {
     --with-included-glib \
     --with-libncurses-prefix=${MINGW_PREFIX} \
     --disable-silent-rules
+
+  # to make relocate() in gnulib-lib work
+  sed -s "s|${MINGW_PREFIX}|$(cygpath -m ${MINGW_PREFIX})|g" -i gettext-tools/config.h
 
   make V=1
 }


### PR DESCRIPTION
relocate() in gnulib-lib needs INSTALLDIR and INSTALLPREFIX to be
Windows paths so it can relocate the input.

Fix by removing INSTALLPREFIX from MSYS2_ARG_CONV_EXCL so it gets
converted when passed to the compiler and pass it to gnulib-lib,
and convert INSTALLPREFIX in gettext-tools/config.h manually.

Fixes #4392 (for real, hopefully)