### PR TITLE
meson: fix static linking with system libs

### DIFF
--- a/mingw-w64-meson/0001-hacky-fix-for-splitting-paths-in-get_compiler_dirs.patch
+++ b/mingw-w64-meson/0001-hacky-fix-for-splitting-paths-in-get_compiler_dirs.patch
@@ -1,0 +1,26 @@
+From 4e946a5bcfc6393519ff055cd39b58503b045e2e Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Sun, 12 May 2019 19:45:00 +0200
+Subject: [PATCH] hacky fix for splitting paths in get_compiler_dirs()
+
+reported upstream: https://github.com/mesonbuild/meson/issues/5386
+---
+ mesonbuild/compilers/c.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/mesonbuild/compilers/c.py b/mesonbuild/compilers/c.py
+index ff6ca519..7d8b7fa4 100644
+--- a/mesonbuild/compilers/c.py
++++ b/mesonbuild/compilers/c.py
+@@ -199,7 +199,7 @@ class CCompiler(Compiler):
+         return stdo
+ 
+     @staticmethod
+-    def _split_fetch_real_dirs(pathstr, sep=':'):
++    def _split_fetch_real_dirs(pathstr, sep=';'):
+         paths = []
+         for p in pathstr.split(sep):
+             # GCC returns paths like this:
+-- 
+2.21.0
+

--- a/mingw-w64-meson/PKGBUILD
+++ b/mingw-w64-meson/PKGBUILD
@@ -4,7 +4,7 @@ _realname=meson
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.50.1
-pkgrel=1
+pkgrel=2
 pkgdesc="High-productivity build system (mingw-w64)"
 arch=('any')
 url="http://mesonbuild.com/"
@@ -17,12 +17,14 @@ source=("https://github.com/mesonbuild/${_realname}/releases/download/${pkgver}/
         'color-term.patch'
         '0002-Default-to-sys.prefix-as-the-default-prefix.patch'
         '0003-Strip-the-prefix-from-all-paths-when-installing-with.patch'
-        'install-man.patch')
+        'install-man.patch'
+        '0001-hacky-fix-for-splitting-paths-in-get_compiler_dirs.patch')
 sha256sums=('f68f56d60c80a77df8fc08fa1016bc5831605d4717b622c96212573271e14ecc'
             '5805aed0a117536eb16dd8eef978c6be57c2471b655ede63e25517c28b4f4cf0'
             '4ef1e6fb0e9bd927b4646e416631b8a0a9aece763d259dbba58168bcba93f673'
             '2093c617cf3146a4cea601e7c73400d8ec5fd52ac5cf642c4f5af2d6493b1cb1'
-            '0682a36cb75e545a78b81293303835a16171f25baf949905dc08029436efff84')
+            '0682a36cb75e545a78b81293303835a16171f25baf949905dc08029436efff84'
+            '6c19a8e03df1fc24e12799c456675abd3bf8a0be3e80c0f7b49db0c32e5ae318')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -31,6 +33,8 @@ prepare() {
   patch -Np1 -i "${srcdir}"/0002-Default-to-sys.prefix-as-the-default-prefix.patch
   patch -Np1 -i "${srcdir}"/0003-Strip-the-prefix-from-all-paths-when-installing-with.patch
   patch -Np1 -i "${srcdir}"/install-man.patch
+  # https://github.com/mesonbuild/meson/issues/5386
+  patch -Np1 -i "${srcdir}"/0001-hacky-fix-for-splitting-paths-in-get_compiler_dirs.patch
 }
 
 build() {


### PR DESCRIPTION
meson was using : to split a path list.
See https://github.com/mesonbuild/meson/issues/5386