### PR TITLE
ruby - 2.6.3 - added provides.

### DIFF
--- a/mingw-w64-ruby/PKGBUILD
+++ b/mingw-w64-ruby/PKGBUILD
@@ -7,7 +7,7 @@ _realname=ruby
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.6.3
-pkgrel=1
+pkgrel=2
 pkgdesc="An object-oriented language for quick and easy programming (mingw-w64)"
 arch=('any')
 url="https://www.ruby-lang.org/en"
@@ -29,6 +29,55 @@ source=("https://cache.ruby-lang.org/pub/ruby/${pkgver%.*}/${_realname}-${pkgver
         0003-fix-check-types.patch
         0004-rbinstall-destdir.patch
         0005-rbinstall-rake-bash.patch)
+## Populated by the updpkgprovs script
+provides=(
+    "${MINGW_PACKAGE_PREFIX}-ruby-did_you_mean=1.3.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-minitest=5.11.3"
+    "${MINGW_PACKAGE_PREFIX}-ruby-net-telnet=0.2.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-power_assert=1.1.3"
+    "${MINGW_PACKAGE_PREFIX}-ruby-rake=12.3.2"
+    "${MINGW_PACKAGE_PREFIX}-ruby-test-unit=3.2.9"
+    "${MINGW_PACKAGE_PREFIX}-ruby-xmlrpc=0.3.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-bigdecimal=1.4.1"
+    "${MINGW_PACKAGE_PREFIX}-ruby-bundler=1.17.2"
+    "${MINGW_PACKAGE_PREFIX}-ruby-cmath=1.0.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-csv=3.0.9"
+    "${MINGW_PACKAGE_PREFIX}-ruby-date=2.0.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-dbm=1.0.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-e2mmap=0.1.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-etc=1.0.1"
+    "${MINGW_PACKAGE_PREFIX}-ruby-fcntl=1.0.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-fiddle=1.0.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-fileutils=1.1.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-forwardable=1.2.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-gdbm=2.0.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-io-console=0.4.7"
+    "${MINGW_PACKAGE_PREFIX}-ruby-ipaddr=1.2.2"
+    "${MINGW_PACKAGE_PREFIX}-ruby-irb=1.0.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-json=2.1.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-logger=1.3.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-matrix=0.1.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-mutex_m=0.1.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-openssl=2.1.2"
+    "${MINGW_PACKAGE_PREFIX}-ruby-ostruct=0.1.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-prime=0.1.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-psych=3.1.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-rdoc=6.1.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-rexml=3.1.9"
+    "${MINGW_PACKAGE_PREFIX}-ruby-rss=0.2.7"
+    "${MINGW_PACKAGE_PREFIX}-ruby-scanf=1.0.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-sdbm=1.0.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-shell=0.7"
+    "${MINGW_PACKAGE_PREFIX}-ruby-stringio=0.0.2"
+    "${MINGW_PACKAGE_PREFIX}-ruby-strscan=1.0.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-sync=0.5.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-thwait=0.1.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-tracer=0.1.0"
+    "${MINGW_PACKAGE_PREFIX}-ruby-webrick=1.4.2"
+    "${MINGW_PACKAGE_PREFIX}-ruby-zlib=1.0.0"
+)
+## End of pkgupdprovs modifications
+
 sha256sums=('dd638bf42059182c1d04af0d5577131d4ce70b79105231c4cc0a60de77b14f2e'
             '329994d3bf7e692e18c1faffbedfbd076e5d00257b2100387a773b59b81ccd4e'
             'cbb083aece8e284fb1ae625e689f044a608aa9750bba9f7d399e895547eee39b'

--- a/mingw-w64-ruby/updpkgprovs
+++ b/mingw-w64-ruby/updpkgprovs
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -o errexit
+set -o errtrace
+set -o pipefail
+set -o nounset
+
+readonly progpath="$(realpath "$0")"
+readonly progname="$(basename "$progpath")"
+readonly progdir="$(dirname "$progpath")"
+if [ -d "pkg/mingw-w64-i686-ruby" ]; then
+    readonly _d="pkg/mingw-w64-i686-ruby/mingw32/"
+else
+    readonly _d="pkg/mingw-w64-x86_64-ruby/mingw64/"
+fi
+
+ruby_default() {
+  for f in ${_d}/lib/ruby/gems/*/specifications/default/*; do
+    if [ -f "$f" ]; then
+      echo $(basename ${f%.*}) | sed -r 's/(.*)-/\1=/'
+    fi
+  done
+}
+
+ruby_bundled() {
+  for f in ${_d}/lib/ruby/gems/*/cache//*; do
+    if [ -f "$f" ]; then
+      echo $(basename ${f%.*}) | sed -r 's/(.*)-/\1=/'
+    fi
+  done
+}
+
+usage() {
+    echo "   Usage: $progname"
+    echo
+    echo "   ruby and gawk (mingw-w64) needs to be installed"
+    echo
+    [[ "${1:-}" =~ ^[0-9]{1,3}$ ]] && exit $1
+}
+
+command -v gawk &>/dev/null || usage 1
+
+declare -r tmpfile="$(mktemp)"
+ruby_bundled \
+| while IFS='' read -r line; do
+    echo "$line"
+done | sort -f > "$tmpfile"
+
+ruby_default \
+| while IFS='' read -r line; do
+    echo "$line"
+done | sort -f >> "$tmpfile"
+
+mv "PKGBUILD" "PKGBUILD~"
+
+gawk '
+/^provides=/ { s = 1 }
+s && /)/ {
+    s = 0
+    print "provides=("
+    while ( (getline line < "'"$tmpfile"'") > 0 ) {
+        print "    \"${MINGW_PACKAGE_PREFIX}-ruby-" line "\""
+    }
+    print ")"
+    next
+}
+s { next }
+! s { print }
+' "PKGBUILD~" > "PKGBUILD"
+
+rm "$tmpfile"
+
+# vim: set ts=4 sw=4 et ai:


### PR DESCRIPTION
Added provides for the default gems and the bundled gems that are included as well as a script for updating them.  The idea is that as more gems get added, we could track dependencies or gems that are already included.  This is similar to what is being done with perl.  If ruby drops a gem from the bundle or default, we want to know in case a dependency is broken.  Some distributions actually package bundled gems separately.