### PR TITLE
mingw-w64-qemu: qemu requires SDL2_image

### DIFF
--- a/mingw-w64-qemu/PKGBUILD
+++ b/mingw-w64-qemu/PKGBUILD
@@ -28,6 +28,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-capstone"
          "${MINGW_PACKAGE_PREFIX}-pixman"
          "${MINGW_PACKAGE_PREFIX}-snappy"
          "${MINGW_PACKAGE_PREFIX}-SDL2"
+         "${MINGW_PACKAGE_PREFIX}-SDL2_image"
          "${MINGW_PACKAGE_PREFIX}-usbredir")
 source=(https://download.qemu.org/${_realname}-${pkgver}.tar.xz
         001-iovec-sasl-conflict.patch)


### PR DESCRIPTION
Fixes issue with SDL2_image.dll not being found at startup.