### PR TITLE
libsoup: update to 2.66.2

### DIFF
--- a/mingw-w64-libsoup/PKGBUILD
+++ b/mingw-w64-libsoup/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libsoup
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.66.1
+pkgver=2.66.2
 pkgrel=1
 pkgdesc="HTTP client/server library (mingw-w64)"
 arch=(any)
@@ -25,7 +25,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 options=('staticlibs' 'strip')
 source=("https://download.gnome.org/sources/${_realname}/${pkgver:0:4}/${_realname}-${pkgver}.tar.xz"
         "libsoup-2.66.1-fix-gnome.patch")
-sha256sums=('4a2cb6c1174540af13661636035992c2b179dfcb39f4d3fa7bee3c7e355c43ff'
+sha256sums=('bd2ea602eba642509672812f3c99b77cbec2f3de02ba1cc8cb7206bf7de0ae2a'
             'df00b6cb694abcdef034285ab0435fa033beb4501e7de616076ad31f996e787a')
 
 prepare() {


### PR DESCRIPTION
This updates libsoup to 2.66.2.