### PR TITLE
x264: add missing ffms2 dep

### DIFF
--- a/mingw-w64-x264-git/PKGBUILD
+++ b/mingw-w64-x264-git/PKGBUILD
@@ -6,7 +6,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=r2935.545de2ff
+pkgver=r2970.5493be84
 pkgrel=1
 pkgdesc="Library for encoding H264/AVC video streams (mingw-w64)"
 arch=('any')
@@ -17,9 +17,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-nasm"
              "git")
 depends=("${MINGW_PACKAGE_PREFIX}-libwinpthread"
-         "${MINGW_PACKAGE_PREFIX}-l-smash")
+         "${MINGW_PACKAGE_PREFIX}-l-smash"
+         "${MINGW_PACKAGE_PREFIX}-ffms2")
 options=('strip' 'staticlibs')
-source=("${_realname}"::"git+https://git.videolan.org/git/${_realname}.git"
+source=("${_realname}"::"git+https://code.videolan.org/videolan/${_realname}.git"
         0001-beautify-pc.all.patch
         0002-install-avisynth_c.h.mingw.patch)
 sha256sums=('SKIP'


### PR DESCRIPTION
```
$ ntldd x264.exe
        KERNEL32.dll => C:\WINDOWS\SYSTEM32\KERNEL32.dll (0x01060000)
        msvcrt.dll => C:\WINDOWS\SYSTEM32\msvcrt.dll (0x01200000)
        SHELL32.dll => C:\WINDOWS\SYSTEM32\SHELL32.dll (0x01200000)
        USER32.dll => C:\WINDOWS\SYSTEM32\USER32.dll (0x01760000)
        avcodec-58.dll => C:\msys64\mingw32\bin\avcodec-58.dll (0x01f00000)
        avformat-58.dll => C:\msys64\mingw32\bin\avformat-58.dll (0x01200000)
        avutil-56.dll => C:\msys64\mingw32\bin\avutil-56.dll (0x01060000)
        libffms2-4.dll => not found
        liblsmash-2.dll => C:\msys64\mingw32\bin\liblsmash-2.dll (0x01060000)
        swscale-5.dll => C:\msys64\mingw32\bin\swscale-5.dll (0x01060000)
```