### PR TITLE
dbus: update to 1.12.14

### DIFF
--- a/mingw-w64-dbus/PKGBUILD
+++ b/mingw-w64-dbus/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=dbus
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.12.12
+pkgver=1.12.14
 pkgrel=1
 arch=('any')
 pkgdesc="Freedesktop.org message bus system (mingw-w64)"
@@ -14,10 +14,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-python2"
              "xmlto")
 options=('strip' 'staticlibs')
-license=("BSD")
+license=('GPL' 'custom')
 url="https://www.freedesktop.org/wiki/Software/dbus"
 source=("https://dbus.freedesktop.org/releases/dbus/${_realname}-${pkgver}.tar.gz"{,.asc})
-sha256sums=('9546f226011a1e5d9d77245fe5549ef25af4694053189d624d0d6ac127ecf5f8'
+sha256sums=('44f9c290ae8f6cadeb2c329316c03716f171ce10daddd85c0bffd0f7df514c8d'
             'SKIP')
 
 prepare() {
@@ -27,8 +27,8 @@ prepare() {
 }
 
 build() {
-  mkdir -p build-${MINGW_CHOST}
-  cd build-${MINGW_CHOST}
+  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
 
   ../${_realname}-${pkgver}/configure \
     --host=${MINGW_CHOST} \
@@ -44,7 +44,7 @@ build() {
 }
 
 check() {
-  cd build-${MINGW_CHOST}
+  cd "${srcdir}/build-${MINGW_CHOST}"
   make check || true
 }
 


### PR DESCRIPTION
This updates dbus to 1.12.14.

The license array is corrected as well from BSD to GPL and custom.