### PR TITLE
python3-sphinx: make pkgbase match the dirname

### DIFF
--- a/mingw-w64-python3-sphinx/PKGBUILD
+++ b/mingw-w64-python3-sphinx/PKGBUILD
@@ -3,10 +3,10 @@
 
 _pyname=Sphinx
 _realname=sphinx
-pkgbase=mingw-w64-python-${_realname}
+pkgbase=mingw-w64-python3-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=2.0.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Python documentation generator (mingw-w64)"
 arch=('any')
 license=('BSD')


### PR DESCRIPTION
The web interface depends on it