### PR TITLE
python-package series for python-markups

### DIFF
--- a/mingw-w64-python-markdown-math/PKGBUILD
+++ b/mingw-w64-python-markdown-math/PKGBUILD
@@ -1,0 +1,115 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_realname=markdown-math
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=0.6
+pkgrel=1
+pkgdesc="Math extension for Python-Markdown (mingw-w64)"
+arch=('any')
+url='https://github.com/mitya57/python-markdown-math'
+license=('BSD')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+options=('staticlibs' 'strip' '!debug')
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python2-markdown" "${MINGW_PACKAGE_PREFIX}-python3-markdown")
+source=("https://files.pythonhosted.org/packages/source/python-${_realname:0:1}/python-${_realname}/python-${_realname}-${pkgver}.tar.gz"{,.asc}
+        "fix-markdown-3.x.patch)
+sha256sums=('c68d8cb9695cb7b435484403dc18941d1bad0ff148e4166d9417046a0d5d3022'
+            'SKIP'
+            '06ba6b40175a410534d14fe5482d773c1d49d684c0ac74c4795f187c10890c5f')
+validpgpkeys=('F24299FF1BBC9018B906A4CB6026936D2F1C8AE0') # Dmitry Shachnev <mitya57@debian.org>
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
+prepare() {
+  cd "${srcdir}"
+  pushd "python-${_realname}-${pkgver}"
+    apply_patch_with_msg fix-markdown-3.x.patch
+  popd 
+  for builddir in python{2,3}-build-${CARCH}; do
+    rm -rf ${builddir} | true
+    cp -r "python-${_realname}-${pkgver}" "${builddir}"
+  done
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
+}
+
+# Note that build() is sometimes skipped because it's done in 
+# the packages setup.py install for simplicity if you can do so.
+# but sometimes, you want to do a check before install which would
+# also trigger the build.
+build() {
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
+}
+
+check() {
+  for pver in {2,3}; do
+    msg "Python ${pver} test for ${CARCH}"
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py test
+  done
+}
+
+package_python3-markdown-math() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3"
+           "${MINGW_PACKAGE_PREFIX}-python3-markdown")
+
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+}
+
+package_python2-markdown-math() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2"
+           "${MINGW_PACKAGE_PREFIX}-python2-markdown")
+
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
+}
+
+package_mingw-w64-i686-python2-markdown-math() {
+  package_python2-markdown-math
+}
+
+package_mingw-w64-i686-python3-markdown-math() {
+  package_python3-markdown-math
+}
+
+package_mingw-w64-x86_64-python2-markdown-math() {
+  package_python2-markdown-math
+}
+
+package_mingw-w64-x86_64-python3-markdown-math() {
+  package_python3-markdown-math
+}

--- a/mingw-w64-python-markdown/PKGBUILD
+++ b/mingw-w64-python-markdown/PKGBUILD
@@ -4,23 +4,33 @@ _realname=markdown
 _pyname=Markdown
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=3.0.1
-pkgrel=2
+pkgver=3.1
+pkgrel=1
 pkgdesc="Python implementation of John Gruber's Markdown (mingw-w64)"
 url='https://pypi.python.org/pypi/Markdown'
 license=('BSD')
 arch=('any')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python2-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python2-yaml"
+              "${MINGW_PACKAGE_PREFIX}-python3-yaml")
 source=("https://pypi.io/packages/source/${_pyname:0:1}/${_pyname}/${_pyname}-${pkgver}.tar.gz")
-sha256sums=('d02e0f9b04c500cde6637c11ad7c72671f359b87b9fe924b2383649d8841db7c')
+sha256sums=('fc4a6f69a656b8d858d7503bda633f4dd63c2d70cf80abdc6eafa64c4ae8c250')
 
 prepare() {
   cd "${srcdir}"
+
+  # bug in 2.4, some DOS line endings slipped in
+  find "${_realname}-${pkgver}" -name '*py' -exec sed -i 's|\r||g' {} +
+
+  # ImportError: No module named pkg_resources
+  sed -i 's/^from pkg_resources.*$/import packaging.version/' "${_realname}-${pkgver}/markdown/__init__.py"
+
   for builddir in python{2,3}-build-${CARCH}; do
     rm -rf ${builddir} | true
     cp -r "${_realname}-${pkgver}" "${builddir}"
   done
+  find "$srcdir/python2-build-${CARCH}" -name '*py' -exec sed -i 's|#!/usr/bin/env python$|&2|' {} +
 }
 
 build() {
@@ -30,6 +40,15 @@ build() {
     ${MINGW_PREFIX}/bin/python${pver} setup.py build
   done 
 }
+
+check() {
+  for pver in {2,3}; do
+    msg "Python ${pver} test for ${CARCH}"
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} -m unittest discover tests
+  done
+}
+
 
 package_python3-markdown() {
   depends=("${MINGW_PACKAGE_PREFIX}-python3")
@@ -89,3 +108,30 @@ package_mingw-w64-x86_64-python3-markdown() {
   install=python3-${_realname}-${CARCH}.install
   package_python3-markdown
 }
+
+check_python3-markdown() {
+  [[ $(${MINGW_PREFIX}/bin/python3 -c "import markdown; print(markdown.version)") == "$pkgver" ]]
+  [[ $(${MINGW_PREFIX}/bin/python3 -c "import markdown; print(markdown.markdown('*test*'))") == "<p><em>test</em></p>" ]]
+}
+
+check_python2-markdown() {
+  [[ $(${MINGW_PREFIX}/bin/python2 -c "import markdown; print(markdown.version)") == "$pkgver" ]]
+  [[ $(${MINGW_PREFIX}/bin/python2 -c "import markdown; print(markdown.markdown('*test*'))") == "<p><em>test</em></p>" ]]
+}
+
+check_mingw-w64-i686-python2-markdown() {
+  check_python2-markdown
+}
+
+check_pmingw-w64-x86_64-python2-markdown() {
+  check_python2-markdown
+}
+
+check_mingw-w64-i686-python3-markdown() {
+  check_python3-markdown
+}
+
+check_pmingw-w64-x86_64-python3-markdown() {
+  check_python3-markdown
+}
+

--- a/mingw-w64-python-markups/PKGBUILD
+++ b/mingw-w64-python-markups/PKGBUILD
@@ -1,0 +1,123 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_pyname=Markups
+_realname=markups
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=3.0.0
+pkgrel=1
+pkgdesc="Wrapper around various text markups (mingw-w64)"
+arch=('any')
+url='https://launchpad.net/python-markups'
+license=('BSD')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python2-docutils"
+             "${MINGW_PACKAGE_PREFIX}-python2-markdown-math"
+             "${MINGW_PACKAGE_PREFIX}-python2-pygments"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python3-docutils"
+             "${MINGW_PACKAGE_PREFIX}-python3-markdown-math"
+             "${MINGW_PACKAGE_PREFIX}-python3-pygments"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
+options=('staticlibs' 'strip' '!debug')
+source=($pyname-$pkgver.tar.gz::http://github.com/retext-project/pymarkups/archive/$pkgver.tar.gz)
+source=("https://files.pythonhosted.org/packages/source/${_pyname:0:1}/${_pyname}/${_pyname}-${pkgver}.tar.gz"{,.asc})
+sha256sums=('1ea19458dfca6a4562044e701aa8698089a0c659fc535689ed260f89a04f8d39'
+            'SKIP')
+validpgpkeys=('F24299FF1BBC9018B906A4CB6026936D2F1C8AE0') # Dmitry Shachnev <mitya57@debian.org>
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
+prepare() {
+  cd "${srcdir}"
+  for builddir in python{2,3}-build-${CARCH}; do
+    rm -rf ${builddir} | true
+    cp -r "${_realname}-${pkgver}" "${builddir}"
+  done
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
+}
+
+# Note that build() is sometimes skipped because it's done in 
+# the packages setup.py install for simplicity if you can do so.
+# but sometimes, you want to do a check before install which would
+# also trigger the build.
+build() {
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
+}
+
+check() {
+  for pver in {2,3}; do
+    msg "Python ${pver} test for ${CARCH}"
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py test
+  done
+}
+
+package_python3-markups() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3"
+           "${MINGW_PACKAGE_PREFIX}-python3-markdown-math"
+           "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-python3-docutils: for reStructuredText language support"
+              "${MINGW_PACKAGE_PREFIX}-python3-pygments: for highlighting output style")
+
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+}
+
+package_python2-markups() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2"
+           "${MINGW_PACKAGE_PREFIX}-python2-markdown-math"
+           "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-python2-docutils: for reStructuredText language support"
+              "${MINGW_PACKAGE_PREFIX}-python2-pygments: for highlighting output style")
+
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
+}
+
+package_mingw-w64-i686-python2-markups() {
+  package_python2-markups
+}
+
+package_mingw-w64-i686-python3-markups() {
+  package_python3-markups
+}
+
+package_mingw-w64-x86_64-python2-markups() {
+  package_python2-markups
+}
+
+package_mingw-w64-x86_64-python3-markups() {
+  package_python3-markups
+}


### PR DESCRIPTION
python-markdown: - 3,1 - update to latest version
python-markdown-math - 0.6 - Math extension for Python-Markdown
python-markups - 3.0.0 - new package - Wrapper around various text markups