### PR TITLE
python2-networkx - 2.2 - always use MINGW version of python, drop tes…

### DIFF
--- a/mingw-w64-python2-networkx/PKGBUILD
+++ b/mingw-w64-python2-networkx/PKGBUILD
@@ -4,22 +4,19 @@ _realname=networkx
 pkgbase=mingw-w64-python2-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}")
 pkgver=2.2
-pkgrel=1
+pkgrel=2
 pkgdesc="High-productivity software for complex networks (mingw-w64)"
 arch=('any')
 license=('BSD')
 url="https://github.com/networkx/networkx"
 depends=(
   "${MINGW_PACKAGE_PREFIX}-python2"
-  "${MINGW_PACKAGE_PREFIX}-python2-decorator"
-)
+  "${MINGW_PACKAGE_PREFIX}-python2-decorator")
 optdepends=(
   "${MINGW_PACKAGE_PREFIX}-python2-numpy"
   "${MINGW_PACKAGE_PREFIX}-python2-scipy"
   "${MINGW_PACKAGE_PREFIX}-python2-pyparsing"
-  "${MINGW_PACKAGE_PREFIX}-python2-yaml"
-)
-
+  "${MINGW_PACKAGE_PREFIX}-python2-yaml")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python2-setuptools")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python2-nose")
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/networkx/networkx/archive/${_realname}-${pkgver}.tar.gz")
@@ -27,22 +24,21 @@ sha256sums=('74efce06507cdc2e506c6b7d485a18617adc3a7f355e2dc48ca71c83929bc679')
 
 build() {
   cd ${srcdir}/${_realname}-${_realname}-${pkgver}
-  python2 setup.py build
+  ${MINGW_PREFIX}/bin/python2 setup.py build
 }
 
-check() {
-  cd ${srcdir}/${_realname}-${_realname}-${pkgver}
-  python2 setup.py nosetests
-}
+# Python 2.7x will be discontinued next year so it might be pointless.
+#check() {
+#  cd ${srcdir}/${_realname}-${_realname}-${pkgver}
+#  ${MINGW_PREFIX}/bin/nosetests2
+#}
 
 package() {
   cd ${srcdir}/${_realname}-${_realname}-${pkgver}
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  ${MINGW_PREFIX}/bin/python2 setup.py install --root=${pkgdir} --prefix=${MINGW_PREFIX} --optimize=1
+  ${MINGW_PREFIX}/bin/python2 setup.py install --root=${pkgdir} --prefix=${MINGW_PREFIX} --optimize=1 --skip-build
   install -D -m644 LICENSE.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE
-  
+
   # Conflict files for both packages.
   rm -rf ${pkgdir}${MINGW_PREFIX}/share/doc
 }
-
-# vim:set ts=2 sw=2 et:

--- a/mingw-w64-python3-networkx/PKGBUILD
+++ b/mingw-w64-python3-networkx/PKGBUILD
@@ -4,7 +4,7 @@ _realname=networkx
 pkgbase=mingw-w64-python3-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=2.3
-pkgrel=1
+pkgrel=2
 pkgdesc="High-productivity software for complex networks (mingw-w64)"
 arch=('any')
 license=('BSD')
@@ -27,18 +27,18 @@ sha256sums=('36c96a5bef38c96df9c0840931a6785a747bba1437cc19b753d97564ffd74713')
 
 build() {
   cd ${srcdir}/${_realname}-${_realname}-${pkgver}
-  python3 setup.py build
+  ${MINGW_PREFIX}/bin/python3 setup.py build
 }
 
 check() {
   cd ${srcdir}/${_realname}-${_realname}-${pkgver}
-  python3 setup.py nosetests
+  ${MINGW_PREFIX}/bin/nosetests3
 }
 
 package() {
   cd ${srcdir}/${_realname}-${_realname}-${pkgver}
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  ${MINGW_PREFIX}/bin/python3 setup.py install --root=${pkgdir} --prefix=${MINGW_PREFIX} --optimize=1
+  ${MINGW_PREFIX}/bin/python3 setup.py install --root=${pkgdir} --prefix=${MINGW_PREFIX} --optimize=1 --skip-build
   install -D -m644 LICENSE.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE
 }
 


### PR DESCRIPTION
…ting since Python2 is being dropped next year.

python3-networkx - 2.3 - always use MINGW version of python, run mingw-w64-python3-nose for testing