### PR TITLE
some prerequisits for python-redbaron - a requirement of openmdao .

### DIFF
--- a/mingw-w64-python-baron/PKGBUILD
+++ b/mingw-w64-python-baron/PKGBUILD
@@ -1,0 +1,87 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_realname=baron
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=0.9
+pkgrel=1
+pkgdesc="Full Syntax Tree for python to make writing refactoring code a realist task (mingw-w64)"
+arch=('any')
+url='https://github.com/PyCQA/baron'
+license=('LGPL')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python2-rply"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python2-rply"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python2-pytest-runner"
+              "${MINGW_PACKAGE_PREFIX}-python3-pytest-runner")
+options=('staticlibs' 'strip' '!debug')
+source=("${_realname}-$pkgver.tar.gz"::"https://github.com/PyCQA/baron/archive/$pkgver.tar.gz")
+sha512sums=('ed31bad1442b8d868ab9872f057db31ad8730654a7e8d49119c75d5631c881b074baf5754b0b0b5023dad62eda1f40461e4445321695248cfa3530b608d48c8e')
+
+
+prepare() {
+  cd "${srcdir}"
+  for builddir in python{2,3}-build-${CARCH}; do
+    rm -rf ${builddir} | true
+    cp -r "${_realname}-${pkgver}" "${builddir}"
+  done
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
+}
+
+# Note that build() is sometimes skipped because it's done in 
+# the packages setup.py install for simplicity if you can do so.
+# but sometimes, you want to do a check before install which would
+# also trigger the build.
+build() {
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
+}
+
+check() {
+  for pver in {2,3}; do
+    msg "Python ${pver} test for ${CARCH}"
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py pytest
+  done
+}
+
+package_python3-baron() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+}
+
+package_python2-baron() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+}
+
+package_mingw-w64-i686-python2-baron() {
+  package_python2-baron
+}
+
+package_mingw-w64-i686-python3-baron() {
+  package_python3-baron
+}
+
+package_mingw-w64-x86_64-python2-baron() {
+  package_python2-baron
+}
+
+package_mingw-w64-x86_64-python3-baron() {
+  package_python3-baron
+}

--- a/mingw-w64-python-rply/PKGBUILD
+++ b/mingw-w64-python-rply/PKGBUILD
@@ -1,0 +1,113 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_realname=rply
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=0.7.7
+pkgrel=1
+pkgdesc="A pure Python Lex/Yacc that works with RPython (mingw-w64)"
+arch=('any')
+url='https://www.rply.org/'
+license=('BSD')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python2-appdirs"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python3-appdirs"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python2-pytest"
+              "${MINGW_PACKAGE_PREFIX}-python3-pytest")
+options=('staticlibs' 'strip' '!debug')
+source=("$pkgbase-$pkgver.tar.gz"::"https://github.com/alex/rply/archive/v$pkgver.tar.gz")
+sha512sums=('c01166b7df067a6a55d1b43caa7b5a349045e838899daf82e2ba70a2c2525fd68e95f11e5319a1fe36936e696352a37bdc13f132f739cd52759a9a9c91e317ba')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
+prepare() {
+  cd "${srcdir}"
+  for builddir in python{2,3}-build-${CARCH}; do
+    rm -rf ${builddir} | true
+    cp -r "${_realname}-${pkgver}" "${builddir}"
+  done
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
+}
+
+# Note that build() is sometimes skipped because it's done in 
+# the packages setup.py install for simplicity if you can do so.
+# but sometimes, you want to do a check before install which would
+# also trigger the build.
+build() {
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
+}
+
+check() {
+    msg "Python 2 test for ${CARCH}"
+    cd "${srcdir}/python2-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/py.test2
+
+    msg "Python 3 test for ${CARCH}"
+    cd "${srcdir}/python3-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/py.test
+}
+
+package_python3-rply() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python3-appdirs")
+
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+}
+
+package_python2-rply() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2"
+           "${MINGW_PACKAGE_PREFIX}-python2-appdirs")
+
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
+}
+
+package_mingw-w64-i686-python2-rply() {
+  package_python2-rply
+}
+
+package_mingw-w64-i686-python3-rply() {
+  package_python3-rply
+}
+
+package_mingw-w64-x86_64-python2-rply() {
+  package_python2-rply
+}
+
+package_mingw-w64-x86_64-python3-rply() {
+  package_python3-rply
+}


### PR DESCRIPTION
python-rply - - 0.7.7 - Update to  latest version
python-baron - 0.9 - New package required for redbaron (prerequisit topenmdao

Not ethat I can NOT yet provide redbarron because it requires pypandoc filters and a setuptools extension that requires pandoc.  Pandoc itself was written with the ghc compiler.