### PR TITLE
llvm: install libLLVM.dll.a

### DIFF
--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -29,7 +29,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-llvm"
          "${MINGW_PACKAGE_PREFIX}-polly")
 pkgver=8.0.0
-pkgrel=2
+pkgrel=3
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 url="https://llvm.org/"
@@ -441,7 +441,7 @@ package_llvm() {
   ${_make_cmd} -C ../build-${CARCH} DESTDIR="${pkgdir}" install
 
   # TODO: why CMake haven't included it?
-  #cp ../build-${CARCH}/lib/libLLVM.dll.a "${pkgdir}/${MINGW_PREFIX}/lib/"
+  cp ../build-${CARCH}/lib/libLLVM.dll.a "${pkgdir}/${MINGW_PREFIX}/lib/"
 
   install -Dm644 LICENSE.TXT "${pkgdir}${MINGW_PREFIX}/share/licenses/llvm/LICENSE"
 


### PR DESCRIPTION
Until now libLLVM.dll was built and installed, but not its import
library, which installation was disabled for uknnown reasons.

Fixes #5192.