### PR TITLE
Gdb 8.3 disable source highlight

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,108 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Ray Donnelly <mingw.android@gmail.com>
+
+_realname=gdb
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+# Until https://gcc.gnu.org/bugzilla/show_bug.cgi?id=62279 is
+# fixed, we will stick with 7.6.2 which hasn't got this bug..
+pkgver=8.3
+pkgrel=2
+pkgdesc="GNU Debugger (mingw-w64)"
+arch=('any')
+url="https://www.gnu.org/software/gdb/"
+license=('GPL')
+groups=("${MINGW_PACKAGE_PREFIX}-toolchain")
+depends=("${MINGW_PACKAGE_PREFIX}-expat"
+         "${MINGW_PACKAGE_PREFIX}-libiconv"
+         "${MINGW_PACKAGE_PREFIX}-python3"
+         "${MINGW_PACKAGE_PREFIX}-readline"
+         "${MINGW_PACKAGE_PREFIX}-source-highlight"
+         "${MINGW_PACKAGE_PREFIX}-zlib")
+checkdepends=('dejagnu' 'bc')
+makedepends=("${MINGW_PACKAGE_PREFIX}-iconv"
+             "${MINGW_PACKAGE_PREFIX}-ncurses"
+             "${MINGW_PACKAGE_PREFIX}-xz")
+options=('staticlibs' '!distcc' '!ccache')
+source=(https://ftp.gnu.org/gnu/gdb/${_realname}-${pkgver}.tar.xz{,.sig}
+        'gdb-fix-display-tabs-on-mingw.patch'
+        #'gdb-mingw-gcc-4.7.patch'
+        'gdb-7.8.1-mingw-gcc-4.7.patch'
+        'gdb-7.6.2-mingw-gcc-4.7.patch'
+        'gdb-perfomance.patch'
+        'gdb-fix-using-gnu-print.patch'
+        'gdb-7.12-dynamic-libs.patch'
+        'gdb-py3-fixes.patch'
+        'python-configure-path-fixes.patch')
+validpgpkeys=('F40ADB902B24264AA42E50BF92EDB04BFF325CF3')
+sha256sums=('802f7ee309dcc547d65a68d61ebd6526762d26c3051f52caebe2189ac1ffd72e'
+            'SKIP'
+            'a3e64bf3acc8e92016d493aa1e2fbb5b55c67bfce4359b3578d7a6b5e5d5692a'
+            '225608a1e486ee98641611804b07209915367c6767a735ae928175ad45b93060'
+            '82ea717b628c8970055a9cbb8edaed8fbebc2cac27467337426dfc4b4c514a6b'
+            '6be0f95483e02d5447c93ab5e2c9554d254c6888b1fa3f3a4c011cd6a0a403ad'
+            '264eba33ef71c4762514a634dcf94fdb778914dbba6ce99e63804fe063225d97'
+            '4398bd83a798baa15c0f91878391a0882239a682cf523ef6551766cba7b03699'
+            'bfe8985e806200e5a1007c4565bd60de0a297369d17d4a0178512f2df29b34fc'
+            'bdf6c2b51d6c8c84b7b20abb9d1702f110c0c0e06e3d68eb6aba817664354450')
+
+prepare() {
+  cd ${srcdir}/${_realname}-${pkgver}
+
+  # https://sourceware.org/ml/gdb-patches/2013-11/msg00224.html
+  #patch -p1 -i ${srcdir}/gdb-fix-display-tabs-on-mingw.patch
+  # https://sourceware.org/bugzilla/show_bug.cgi?id=15559
+  # patch -p1 -i ${srcdir}/gdb-mingw-gcc-4.7.patch
+  # patch -p1 -i ${srcdir}/gdb-${pkgver}-mingw-gcc-4.7.patch
+  # https://sourceware.org/bugzilla/show_bug.cgi?id=15412
+  patch -p1 -i ${srcdir}/gdb-perfomance.patch
+
+  patch -p1 -i ${srcdir}/gdb-fix-using-gnu-print.patch
+
+  # https://sourceware.org/bugzilla/show_bug.cgi?id=21078
+  patch -p1 -i ${srcdir}/gdb-7.12-dynamic-libs.patch
+
+  patch -p1 -i ${srcdir}/gdb-py3-fixes.patch
+  patch -p1 -i ${srcdir}/python-configure-path-fixes.patch
+
+  # hack! - libiberty configure tests for header files using "$CPP $CPPFLAGS"
+  sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" libiberty/configure
+}
+
+build() {
+  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
+  mkdir ${srcdir}/build-${MINGW_CHOST}
+  cd ${srcdir}/build-${MINGW_CHOST}
+
+  ../${_realname}-${pkgver}/configure \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --prefix=${MINGW_PREFIX} \
+    --enable-targets="i686-w64-mingw32,x86_64-w64-mingw32" \
+    --enable-64-bit-bfd \
+    --disable-werror \
+    --disable-win32-registry \
+    --disable-rpath \
+    --with-system-gdbinit=${MINGW_PREFIX}/etc/gdbinit \
+    --with-system-readline \
+    --with-python=${MINGW_PREFIX}/bin/python3 \
+    --with-expat \
+    --with-libiconv-prefix=${MINGW_PREFIX} \
+    --with-zlib \
+    --with-lzma \
+    --enable-tui
+
+  make
+}
+
+package() {
+  cd ${srcdir}/build-${MINGW_CHOST}
+  make DESTDIR=${pkgdir} install
+
+  # Remove unwanted files
+  rm -rf ${pkgdir}${MINGW_PREFIX}/share/{man,info}
+
+  rm -f ${pkgdir}${MINGW_PREFIX}/include/*.h
+  rm -f ${pkgdir}${MINGW_PREFIX}/lib/*.a
+}

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -17,7 +17,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-libiconv"
          "${MINGW_PACKAGE_PREFIX}-python3"
          "${MINGW_PACKAGE_PREFIX}-readline"
-         "${MINGW_PACKAGE_PREFIX}-source-highlight"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 checkdepends=('dejagnu' 'bc')
 makedepends=("${MINGW_PACKAGE_PREFIX}-iconv"
@@ -91,7 +90,8 @@ build() {
     --with-libiconv-prefix=${MINGW_PREFIX} \
     --with-zlib \
     --with-lzma \
-    --enable-tui
+    --enable-tui \
+	--enable-source-highlight=no
 
   make
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -91,7 +91,7 @@ build() {
     --with-zlib \
     --with-lzma \
     --enable-tui \
-	--enable-source-highlight=no
+    --enable-source-highlight=no
 
   make
 }

--- a/gdb-7.12-dynamic-libs.patch
+++ b/gdb-7.12-dynamic-libs.patch
@@ -1,0 +1,36 @@
+From 04a27a15b268e07c76578c074c3822477ceabc50 Mon Sep 17 00:00:00 2001
+From: Orgad Shaneh <orgads@gmail.com>
+Date: Tue, 7 Mar 2017 19:13:41 +0200
+Subject: [PATCH] configure: Disable static linking with standard libs
+
+Linking statically causes spurious crashes on exception handling
+with mingw32.
+---
+ configure | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/configure b/configure
+index a5f4fc5aa7..f5a9766c39 100755
+--- a/configure
++++ b/configure
+@@ -5902,7 +5902,7 @@ else
+  # if supported.  But if the user explicitly specified the libraries to use,
+  # trust that they are doing what they want.
+  if test "$stage1_libs" = "" -a "$have_static_libs" = yes; then
+-   stage1_ldflags="-static-libstdc++ -static-libgcc"
++   stage1_ldflags=""
+  fi
+ fi
+ 
+@@ -5938,7 +5938,7 @@ else
+  # statically.  But if the user explicitly specified the libraries to
+  # use, trust that they are doing what they want.
+  if test "$poststage1_libs" = ""; then
+-   poststage1_ldflags="-static-libstdc++ -static-libgcc"
++   poststage1_ldflags=""
+  fi
+ fi
+ 
+-- 
+2.12.0.windows.1
+

--- a/gdb-7.6.2-mingw-gcc-4.7.patch
+++ b/gdb-7.6.2-mingw-gcc-4.7.patch
@@ -1,0 +1,144 @@
+@@ -, +, @@ 
+ gdb/eval.c      |  7 +++++++
+ gdb/i386-tdep.c | 39 ++++++++++++++++++++++++++++++++++++++-
+ gdb/infcall.c   | 23 +++++++++++++++++++++++
+ 3 files changed, 68 insertions(+), 1 deletion(-)
+--- a/gdb/eval.c	
++++ a/gdb/eval.c	
+@@ -49,6 +49,10 @@ 
+ /* This is defined in valops.c */
+ extern int overload_resolution;
+ 
++/* this variable is to notify i386_push_dummy_call that an 
++  function is static member function, it is a hack */
++extern int i386_windows_static_memfun; 
++
+ /* Prototypes for local functions.  */
+ 
+ static struct value *evaluate_subexp_for_sizeof (struct expression *, int *);
+@@ -1668,7 +1672,10 @@ evaluate_subexp_standard (struct type *expect_type,
+ 	      argvec[1] = argvec[0];
+ 	      nargs--;
+ 	      argvec++;
++	      i386_windows_static_memfun = 1;
+ 	    }
++          else
++            i386_windows_static_memfun = 0;
+ 	}
+       else if (op == STRUCTOP_MEMBER || op == STRUCTOP_MPTR)
+ 	{
+--- a/gdb/i386-tdep.c	
++++ a/gdb/i386-tdep.c	
+@@ -2396,6 +2396,15 @@ i386_push_dummy_code (struct gdbarch *gdbarch, CORE_ADDR sp, CORE_ADDR funaddr,
+   /* Keep the stack aligned.  */
+   return sp - 16;
+ }
++/* This is the hack to handle the non-static member function to thiscall 
++   calling convention mode, this variable is updated in eval.c of the 
++   static member function check */
++int i386_windows_static_memfun = 0; 
++
++/* This is the hack to determine which version of gcc is used to generate
++   the function, if it is greater than 4.6, this use thiscall for member
++   function. */
++int i386_windows_build_gt_gcc46 = 0;
+ 
+ static CORE_ADDR
+ i386_push_dummy_call (struct gdbarch *gdbarch, struct value *function,
+@@ -2408,6 +2417,28 @@ i386_push_dummy_call (struct gdbarch *gdbarch, struct value *function,
+   int i;
+   int write_pass;
+   int args_space = 0;
++  struct type *func_type = value_type (function);
++  int i386_windows_thiscall = 0;
++
++  if (func_type)
++    {
++      func_type = check_typedef (func_type);
++      
++      if (TYPE_CODE (func_type) == TYPE_CODE_PTR)
++        func_type = check_typedef (TYPE_TARGET_TYPE (func_type));
++      
++      if( (TYPE_CODE (func_type) == TYPE_CODE_METHOD)
++         && i386_windows_build_gt_gcc46 == 1
++         && (nargs > 0) 
++         && i386_windows_static_memfun == 0 )
++        {
++         /* a.f(5,6);
++            args[0] = this pointer;
++            args[1] = 5;
++            args[2] = 6; */
++         i386_windows_thiscall = 1;
++        }
++    }
+ 
+   /* Determine the total space required for arguments and struct
+      return address in a first pass (allowing for 16-byte-aligned
+@@ -2430,7 +2461,7 @@ i386_push_dummy_call (struct gdbarch *gdbarch, struct value *function,
+ 	    args_space += 4;
+ 	}
+ 
+-      for (i = 0; i < nargs; i++)
++      for (i = i386_windows_thiscall; i < nargs; i++)
+ 	{
+ 	  int len = TYPE_LENGTH (value_enclosing_type (args[i]));
+ 
+@@ -2482,6 +2513,12 @@ i386_push_dummy_call (struct gdbarch *gdbarch, struct value *function,
+   /* ...and fake a frame pointer.  */
+   regcache_cooked_write (regcache, I386_EBP_REGNUM, buf);
+ 
++  if (i386_windows_thiscall)
++    {
++      /* args[0] refer to the last argument which is the this pointer */
++      regcache_cooked_write (regcache, I386_ECX_REGNUM, value_contents_all(args[0]));
++    }
++
+   /* MarkK wrote: This "+ 8" is all over the place:
+      (i386_frame_this_id, i386_sigtramp_frame_this_id,
+      i386_dummy_id).  It's there, since all frame unwinders for
+--- a/gdb/infcall.c	
++++ a/gdb/infcall.c	
+@@ -36,6 +36,12 @@ 
+ #include "ada-lang.h"
+ #include "gdbthread.h"
+ #include "exceptions.h"
++#include "utils.h"
++
++/* this value is defined in i386-tdep.c, and we set this value here
++   if the dummy call function is build from gcc 4.7 and later, we 
++   should set this value to 1, other wise, set it to 0 */
++extern int i386_windows_build_gt_gcc46;
+ 
+ /* If we can't find a function's name from its address,
+    we print this instead.  */
+@@ -480,6 +486,8 @@ call_function_by_hand (struct value *function, int nargs, struct value **args)
+   ptid_t call_thread_ptid;
+   struct gdb_exception e;
+   char name_buf[RAW_FUNCTION_ADDRESS_SIZE];
++  struct symtab *sym;
++  int gcc_minor;
+ 
+   if (TYPE_CODE (ftype) == TYPE_CODE_PTR)
+     ftype = check_typedef (TYPE_TARGET_TYPE (ftype));
+@@ -745,6 +753,21 @@ call_function_by_hand (struct value *function, int nargs, struct value **args)
+     }
+   else
+     args_cleanup = make_cleanup (null_cleanup, NULL);
++    
++  /* before we push the dummy call, we need to use the real_pc to determine 
++     what gcc producer is used to generate this function, so it will notify
++     this information to i386-tdep.c */
++     sym = find_pc_symtab(real_pc);
++     if (sym != NULL && sym->producer != NULL)
++     {
++        gcc_minor = producer_is_gcc_ge_4(sym->producer);
++        if (gcc_minor>6)
++            i386_windows_build_gt_gcc46 = 1;
++        else
++            i386_windows_build_gt_gcc46 = 0;
++     }
++     else
++        i386_windows_build_gt_gcc46 = 0;
+ 
+   /* Create the dummy stack frame.  Pass in the call dummy address as,
+      presumably, the ABI code knows where, in the call dummy, the

--- a/gdb-7.8.1-mingw-gcc-4.7.patch
+++ b/gdb-7.8.1-mingw-gcc-4.7.patch
@@ -1,0 +1,144 @@
+@@ -, +, @@ 
+ gdb/eval.c      |  7 +++++++
+ gdb/i386-tdep.c | 39 ++++++++++++++++++++++++++++++++++++++-
+ gdb/infcall.c   | 23 +++++++++++++++++++++++
+ 3 files changed, 68 insertions(+), 1 deletion(-)
+--- a/gdb/eval.c	
++++ a/gdb/eval.c	
+@@ -49,6 +49,10 @@ 
+ /* This is defined in valops.c */
+ extern int overload_resolution;
+ 
++/* this variable is to notify i386_push_dummy_call that an 
++  function is static member function, it is a hack */
++extern int i386_windows_static_memfun; 
++
+ /* Prototypes for local functions.  */
+ 
+ static struct value *evaluate_subexp_for_sizeof (struct expression *, int *);
+@@ -1668,7 +1672,10 @@ evaluate_subexp_standard (struct type *expect_type,
+ 	      argvec[1] = argvec[0];
+ 	      nargs--;
+ 	      argvec++;
++	      i386_windows_static_memfun = 1;
+ 	    }
++          else
++            i386_windows_static_memfun = 0;
+ 	}
+       else if (op == STRUCTOP_MEMBER || op == STRUCTOP_MPTR)
+ 	{
+--- a/gdb/i386-tdep.c	
++++ a/gdb/i386-tdep.c	
+@@ -2396,6 +2396,15 @@ i386_push_dummy_code (struct gdbarch *gdbarch, CORE_ADDR sp, CORE_ADDR funaddr,
+   /* Keep the stack aligned.  */
+   return sp - 16;
+ }
++/* This is the hack to handle the non-static member function to thiscall 
++   calling convention mode, this variable is updated in eval.c of the 
++   static member function check */
++int i386_windows_static_memfun = 0; 
++
++/* This is the hack to determine which version of gcc is used to generate
++   the function, if it is greater than 4.6, this use thiscall for member
++   function. */
++int i386_windows_build_gt_gcc46 = 0;
+ 
+ static CORE_ADDR
+ i386_push_dummy_call (struct gdbarch *gdbarch, struct value *function,
+@@ -2408,6 +2417,28 @@ i386_push_dummy_call (struct gdbarch *gdbarch, struct value *function,
+   int i;
+   int write_pass;
+   int args_space = 0;
++  struct type *func_type = value_type (function);
++  int i386_windows_thiscall = 0;
++
++  if (func_type)
++    {
++      func_type = check_typedef (func_type);
++      
++      if (TYPE_CODE (func_type) == TYPE_CODE_PTR)
++        func_type = check_typedef (TYPE_TARGET_TYPE (func_type));
++      
++      if( (TYPE_CODE (func_type) == TYPE_CODE_METHOD)
++         && i386_windows_build_gt_gcc46 == 1
++         && (nargs > 0) 
++         && i386_windows_static_memfun == 0 )
++        {
++         /* a.f(5,6);
++            args[0] = this pointer;
++            args[1] = 5;
++            args[2] = 6; */
++         i386_windows_thiscall = 1;
++        }
++    }
+ 
+   /* Determine the total space required for arguments and struct
+      return address in a first pass (allowing for 16-byte-aligned
+@@ -2430,7 +2461,7 @@ i386_push_dummy_call (struct gdbarch *gdbarch, struct value *function,
+ 	    args_space += 4;
+ 	}
+ 
+-      for (i = 0; i < nargs; i++)
++      for (i = i386_windows_thiscall; i < nargs; i++)
+ 	{
+ 	  int len = TYPE_LENGTH (value_enclosing_type (args[i]));
+ 
+@@ -2482,6 +2513,12 @@ i386_push_dummy_call (struct gdbarch *gdbarch, struct value *function,
+   /* ...and fake a frame pointer.  */
+   regcache_cooked_write (regcache, I386_EBP_REGNUM, buf);
+ 
++  if (i386_windows_thiscall)
++    {
++      /* args[0] refer to the last argument which is the this pointer */
++      regcache_cooked_write (regcache, I386_ECX_REGNUM, value_contents_all(args[0]));
++    }
++
+   /* MarkK wrote: This "+ 8" is all over the place:
+      (i386_frame_this_id, i386_sigtramp_frame_this_id,
+      i386_dummy_id).  It's there, since all frame unwinders for
+--- a/gdb/infcall.c	
++++ a/gdb/infcall.c	
+@@ -38,6 +38,12 @@
+ #include "gdbthread.h"
+ #include "exceptions.h"
+ #include "event-top.h"
++#include "utils.h"
++
++/* this value is defined in i386-tdep.c, and we set this value here
++   if the dummy call function is build from gcc 4.7 and later, we 
++   should set this value to 1, other wise, set it to 0 */
++extern int i386_windows_build_gt_gcc46;
+ 
+ /* If we can't find a function's name from its address,
+    we print this instead.  */
+@@ -498,6 +504,8 @@
+   ptid_t call_thread_ptid;
+   struct gdb_exception e;
+   char name_buf[RAW_FUNCTION_ADDRESS_SIZE];
++  struct symtab *sym;
++  int gcc_minor;
+ 
+   if (TYPE_CODE (ftype) == TYPE_CODE_PTR)
+     ftype = check_typedef (TYPE_TARGET_TYPE (ftype));
+@@ -763,6 +771,21 @@
+     }
+   else
+     args_cleanup = make_cleanup (null_cleanup, NULL);
++    
++  /* before we push the dummy call, we need to use the real_pc to determine 
++     what gcc producer is used to generate this function, so it will notify
++     this information to i386-tdep.c */
++     sym = find_pc_symtab(real_pc);
++     if (sym != NULL && sym->producer != NULL)
++     {
++        gcc_minor = producer_is_gcc_ge_4(sym->producer);
++        if (gcc_minor>6)
++            i386_windows_build_gt_gcc46 = 1;
++        else
++            i386_windows_build_gt_gcc46 = 0;
++     }
++     else
++        i386_windows_build_gt_gcc46 = 0;
+ 
+   /* Create the dummy stack frame.  Pass in the call dummy address as,
+      presumably, the ABI code knows where, in the call dummy, the

--- a/gdb-7.9-mingw-gcc-4.7.patch
+++ b/gdb-7.9-mingw-gcc-4.7.patch
@@ -1,0 +1,143 @@
+ gdb/eval.c      |  7 +++++++
+ gdb/i386-tdep.c | 39 ++++++++++++++++++++++++++++++++++++++-
+ gdb/infcall.c   | 23 +++++++++++++++++++++++
+ 3 files changed, 68 insertions(+), 1 deletion(-)
+--- a/gdb/eval.c	
++++ a/gdb/eval.c	
+@@ -49,6 +49,10 @@ 
+ /* This is defined in valops.c */
+ extern int overload_resolution;
+ 
++/* this variable is to notify i386_push_dummy_call that an 
++  function is static member function, it is a hack */
++extern int i386_windows_static_memfun; 
++
+ /* Prototypes for local functions.  */
+ 
+ static struct value *evaluate_subexp_for_sizeof (struct expression *, int *);
+@@ -1668,7 +1672,10 @@ evaluate_subexp_standard (struct type *expect_type,
+ 	      argvec[1] = argvec[0];
+ 	      nargs--;
+ 	      argvec++;
++	      i386_windows_static_memfun = 1;
+ 	    }
++          else
++            i386_windows_static_memfun = 0;
+ 	}
+       else if (op == STRUCTOP_MEMBER || op == STRUCTOP_MPTR)
+ 	{
+--- a/gdb/i386-tdep.c	
++++ a/gdb/i386-tdep.c	
+@@ -2396,6 +2396,15 @@ i386_push_dummy_code (struct gdbarch *gdbarch, CORE_ADDR sp, CORE_ADDR funaddr,
+   /* Keep the stack aligned.  */
+   return sp - 16;
+ }
++/* This is the hack to handle the non-static member function to thiscall 
++   calling convention mode, this variable is updated in eval.c of the 
++   static member function check */
++int i386_windows_static_memfun = 0; 
++
++/* This is the hack to determine which version of gcc is used to generate
++   the function, if it is greater than 4.6, this use thiscall for member
++   function. */
++int i386_windows_build_gt_gcc46 = 0;
+ 
+ static CORE_ADDR
+ i386_push_dummy_call (struct gdbarch *gdbarch, struct value *function,
+@@ -2408,6 +2417,28 @@ i386_push_dummy_call (struct gdbarch *gdbarch, struct value *function,
+   int i;
+   int write_pass;
+   int args_space = 0;
++  struct type *func_type = value_type (function);
++  int i386_windows_thiscall = 0;
++
++  if (func_type)
++    {
++      func_type = check_typedef (func_type);
++      
++      if (TYPE_CODE (func_type) == TYPE_CODE_PTR)
++        func_type = check_typedef (TYPE_TARGET_TYPE (func_type));
++      
++      if( (TYPE_CODE (func_type) == TYPE_CODE_METHOD)
++         && i386_windows_build_gt_gcc46 == 1
++         && (nargs > 0) 
++         && i386_windows_static_memfun == 0 )
++        {
++         /* a.f(5,6);
++            args[0] = this pointer;
++            args[1] = 5;
++            args[2] = 6; */
++         i386_windows_thiscall = 1;
++        }
++    }
+ 
+   /* Determine the total space required for arguments and struct
+      return address in a first pass (allowing for 16-byte-aligned
+@@ -2430,7 +2461,7 @@ i386_push_dummy_call (struct gdbarch *gdbarch, struct value *function,
+ 	    args_space += 4;
+ 	}
+ 
+-      for (i = 0; i < nargs; i++)
++      for (i = i386_windows_thiscall; i < nargs; i++)
+ 	{
+ 	  int len = TYPE_LENGTH (value_enclosing_type (args[i]));
+ 
+@@ -2482,6 +2513,12 @@ i386_push_dummy_call (struct gdbarch *gdbarch, struct value *function,
+   /* ...and fake a frame pointer.  */
+   regcache_cooked_write (regcache, I386_EBP_REGNUM, buf);
+ 
++  if (i386_windows_thiscall)
++    {
++      /* args[0] refer to the last argument which is the this pointer */
++      regcache_cooked_write (regcache, I386_ECX_REGNUM, value_contents_all(args[0]));
++    }
++
+   /* MarkK wrote: This "+ 8" is all over the place:
+      (i386_frame_this_id, i386_sigtramp_frame_this_id,
+      i386_dummy_id).  It's there, since all frame unwinders for
+--- a/gdb/infcall.c	
++++ a/gdb/infcall.c	
+@@ -36,6 +36,12 @@ 
+ #include "gdbthread.h"
+ #include "exceptions.h"
+ #include "event-top.h"
++#include "utils.h"
++
++/* this value is defined in i386-tdep.c, and we set this value here
++   if the dummy call function is build from gcc 4.7 and later, we 
++   should set this value to 1, other wise, set it to 0 */
++extern int i386_windows_build_gt_gcc46;
+ 
+ /* If we can't find a function's name from its address,
+    we print this instead.  */
+@@ -480,6 +486,8 @@ call_function_by_hand (struct value *function, int nargs, struct value **args)
+   ptid_t call_thread_ptid;
+   struct gdb_exception e;
+   char name_buf[RAW_FUNCTION_ADDRESS_SIZE];
++  struct symtab *sym;
++  int gcc_minor;
+ 
+   if (TYPE_CODE (ftype) == TYPE_CODE_PTR)
+     ftype = check_typedef (TYPE_TARGET_TYPE (ftype));
+@@ -745,6 +753,21 @@ call_function_by_hand (struct value *function, int nargs, struct value **args)
+     }
+   else
+     args_cleanup = make_cleanup (null_cleanup, NULL);
++    
++  /* before we push the dummy call, we need to use the real_pc to determine 
++     what gcc producer is used to generate this function, so it will notify
++     this information to i386-tdep.c */
++     sym = find_pc_symtab(real_pc);
++     if (sym != NULL && sym->producer != NULL)
++     {
++        gcc_minor = producer_is_gcc_ge_4(sym->producer);
++        if (gcc_minor>6)
++            i386_windows_build_gt_gcc46 = 1;
++        else
++            i386_windows_build_gt_gcc46 = 0;
++     }
++     else
++        i386_windows_build_gt_gcc46 = 0;
+ 
+   /* Create the dummy stack frame.  Pass in the call dummy address as,
+      presumably, the ABI code knows where, in the call dummy, the

--- a/gdb-fix-display-tabs-on-mingw.patch
+++ b/gdb-fix-display-tabs-on-mingw.patch
@@ -1,0 +1,143 @@
+iff --git a/gdb/valprint.c b/gdb/valprint.c
+index 0ecea0c..7e864f6 100644
+--- a/gdb/valprint.c
++++ b/gdb/valprint.c
+@@ -1929,73 +1929,79 @@ print_wchar (gdb_wint_t w, const gdb_byte *orig,
+   int need_escape = *need_escapep;
+ 
+   *need_escapep = 0;
+-  if (gdb_iswprint (w) && (!need_escape || (!gdb_iswdigit (w)
+-					    && w != LCST ('8')
+-					    && w != LCST ('9'))))
+-    {
+-      gdb_wchar_t wchar = w;
+ 
+-      if (w == gdb_btowc (quoter) || w == LCST ('\\'))
+-	obstack_grow_wstr (output, LCST ("\\"));
+-      obstack_grow (output, &wchar, sizeof (gdb_wchar_t));
+-    }
+-  else
++  /* iswprint implementation returns 1 on mingw hosts.
++     In order to avoid different printout on this host,
++     we explicitly use wchar_printable function.  */
++  switch (w)
+     {
+-      switch (w)
++      case LCST ('\a'):
++	obstack_grow_wstr (output, LCST ("\\a"));
++	break;
++      case LCST ('\b'):
++	obstack_grow_wstr (output, LCST ("\\b"));
++	break;
++      case LCST ('\f'):
++	obstack_grow_wstr (output, LCST ("\\f"));
++	break;
++      case LCST ('\n'):
++	obstack_grow_wstr (output, LCST ("\\n"));
++	break;
++      case LCST ('\r'):
++	obstack_grow_wstr (output, LCST ("\\r"));
++	break;
++      case LCST ('\t'):
++	obstack_grow_wstr (output, LCST ("\\t"));
++	break;
++      case LCST ('\v'):
++	obstack_grow_wstr (output, LCST ("\\v"));
++	break;
++      default:
+ 	{
+-	case LCST ('\a'):
+-	  obstack_grow_wstr (output, LCST ("\\a"));
+-	  break;
+-	case LCST ('\b'):
+-	  obstack_grow_wstr (output, LCST ("\\b"));
+-	  break;
+-	case LCST ('\f'):
+-	  obstack_grow_wstr (output, LCST ("\\f"));
+-	  break;
+-	case LCST ('\n'):
+-	  obstack_grow_wstr (output, LCST ("\\n"));
+-	  break;
+-	case LCST ('\r'):
+-	  obstack_grow_wstr (output, LCST ("\\r"));
+-	  break;
+-	case LCST ('\t'):
+-	  obstack_grow_wstr (output, LCST ("\\t"));
+-	  break;
+-	case LCST ('\v'):
+-	  obstack_grow_wstr (output, LCST ("\\v"));
+-	  break;
+-	default:
+-	  {
+-	    int i;
++	  if (wchar_printable (w)
++	      && (!sevenbit_strings || (w >= 0 && w < 0x7f))
++	      && (!need_escape || (!gdb_iswdigit (w)
++				   && w != LCST ('8')
++				   && w != LCST ('9'))))
++	    {
++	      gdb_wchar_t wchar = w;
+ 
+-	    for (i = 0; i + width <= orig_len; i += width)
+-	      {
+-		char octal[30];
+-		ULONGEST value;
++	      if (w == gdb_btowc (quoter) || w == LCST ('\\'))
++		obstack_grow_wstr (output, LCST ("\\"));
++	      obstack_grow (output, &wchar, sizeof (gdb_wchar_t));
++	    }
++	  else
++	    {
++	      int i;
++
++	      for (i = 0; i + width <= orig_len; i += width)
++		{
++		  char octal[30];
++		  ULONGEST value;
+ 
+-		value = extract_unsigned_integer (&orig[i], width,
++		  value = extract_unsigned_integer (&orig[i], width,
+ 						  byte_order);
+-		/* If the value fits in 3 octal digits, print it that
+-		   way.  Otherwise, print it as a hex escape.  */
+-		if (value <= 0777)
+-		  xsnprintf (octal, sizeof (octal), "\\%.3o",
+-			     (int) (value & 0777));
+-		else
+-		  xsnprintf (octal, sizeof (octal), "\\x%lx", (long) value);
+-		append_string_as_wide (octal, output);
+-	      }
+-	    /* If we somehow have extra bytes, print them now.  */
+-	    while (i < orig_len)
+-	      {
+-		char octal[5];
++		  /* If the value fits in 3 octal digits, print it that
++		     way.  Otherwise, print it as a hex escape.  */
++		  if (value <= 0777)
++		    xsnprintf (octal, sizeof (octal), "\\%.3o",
++			       (int) (value & 0777));
++		  else
++		    xsnprintf (octal, sizeof (octal), "\\x%lx", (long)value);
++		  append_string_as_wide (octal, output);
++		}
++	      /* If we somehow have extra bytes, print them now.  */
++	      while (i < orig_len)
++		{
++		  char octal[5];
+ 
+-		xsnprintf (octal, sizeof (octal), "\\%.3o", orig[i] & 0xff);
+-		append_string_as_wide (octal, output);
+-		++i;
+-	      }
++		  xsnprintf (octal, sizeof (octal), "\\%.3o", orig[i] & 0xff);
++		  append_string_as_wide (octal, output);
++		  ++i;
++		}
+ 
+-	    *need_escapep = 1;
+-	  }
++	      *need_escapep = 1;
++	    }
+ 	  break;
+ 	}
+     }

--- a/gdb-fix-using-gnu-print.patch
+++ b/gdb-fix-using-gnu-print.patch
@@ -1,0 +1,79 @@
+diff -Naur gdb-7.7-orig/bfd/bfd-in.h gdb-7.7/bfd/bfd-in.h
+--- gdb-7.7-orig/bfd/bfd-in.h	2014-02-06 06:21:29.000000000 +0400
++++ gdb-7.7/bfd/bfd-in.h	2014-03-14 10:39:32.085200000 +0400
+@@ -137,7 +137,7 @@
+ 
+ #if BFD_HOST_64BIT_LONG
+ #define BFD_VMA_FMT "l"
+-#elif defined (__MSVCRT__)
++#elif defined(__MSVCRT__) && !defined( __USE_MINGW_ANSI_STDIO)
+ #define BFD_VMA_FMT "I64"
+ #else
+ #define BFD_VMA_FMT "ll"
+diff -Naur gdb-7.7-orig/bfd/bfd-in2.h gdb-7.7/bfd/bfd-in2.h
+--- gdb-7.7-orig/bfd/bfd-in2.h	2014-02-06 06:21:29.000000000 +0400
++++ gdb-7.7/bfd/bfd-in2.h	2014-03-14 10:39:32.085200000 +0400
+@@ -144,7 +144,7 @@
+ 
+ #if BFD_HOST_64BIT_LONG
+ #define BFD_VMA_FMT "l"
+-#elif defined (__MSVCRT__)
++#elif defined (__MSVCRT__) && !defined(__USE_MINGW_ANSI_STDIO)
+ #define BFD_VMA_FMT "I64"
+ #else
+ #define BFD_VMA_FMT "ll"
+diff -Naur gdb-7.7-orig/gdb/common/format.h gdb-7.7/gdb/common/format.h
+--- gdb-7.7-orig/gdb/common/format.h	2014-01-08 13:23:36.000000000 +0400
++++ gdb-7.7/gdb/common/format.h	2014-03-14 10:39:32.412800000 +0400
+@@ -18,7 +18,11 @@
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+ 
+ #if defined(__MINGW32__) && !defined(PRINTF_HAS_LONG_LONG)
+-# define USE_PRINTF_I64 1
++# if !defined(__USE_MINGW_ANSI_STDIO)
++#  define USE_PRINTF_I64 1
++# else
++#  define USE_PRINTF_I64 0
++# endif
+ # define PRINTF_HAS_LONG_LONG
+ #else
+ # define USE_PRINTF_I64 0
+diff -Naur gdb-7.7-orig/gdb/gnulib/import/inttypes.in.h gdb-7.7/gdb/gnulib/import/inttypes.in.h
+--- gdb-7.7-orig/gdb/gnulib/import/inttypes.in.h	2013-12-08 08:11:51.000000000 +0400
++++ gdb-7.7/gdb/gnulib/import/inttypes.in.h	2014-03-14 10:43:47.309400000 +0400
+@@ -183,7 +183,7 @@
+ #ifdef INT64_MAX
+ # if (@APPLE_UNIVERSAL_BUILD@ ? defined _LP64 : @INT64_MAX_EQ_LONG_MAX@)
+ #  define _PRI64_PREFIX "l"
+-# elif defined _MSC_VER || defined __MINGW32__
++# elif (defined _MSC_VER || defined __MINGW32__) && !defined(__USE_MINGW_ANSI_STDIO)
+ #  define _PRI64_PREFIX "I64"
+ # elif @HAVE_LONG_LONG_INT@ && LONG_MAX >> 30 == 1
+ #  define _PRI64_PREFIX _LONG_LONG_FORMAT_PREFIX
+@@ -200,7 +200,7 @@
+ #ifdef UINT64_MAX
+ # if (@APPLE_UNIVERSAL_BUILD@ ? defined _LP64 : @UINT64_MAX_EQ_ULONG_MAX@)
+ #  define _PRIu64_PREFIX "l"
+-# elif defined _MSC_VER || defined __MINGW32__
++# elif (defined _MSC_VER || defined __MINGW32__) && !defined(__USE_MINGW_ANSI_STDIO)
+ #  define _PRIu64_PREFIX "I64"
+ # elif @HAVE_UNSIGNED_LONG_LONG_INT@ && ULONG_MAX >> 31 == 1
+ #  define _PRIu64_PREFIX _LONG_LONG_FORMAT_PREFIX
+@@ -676,7 +676,7 @@
+ #ifdef INT64_MAX
+ # if (@APPLE_UNIVERSAL_BUILD@ ? defined _LP64 : @INT64_MAX_EQ_LONG_MAX@)
+ #  define _SCN64_PREFIX "l"
+-# elif defined _MSC_VER || defined __MINGW32__
++# elif (defined _MSC_VER || defined __MINGW32__) && !defined(__USE_MINGW_ANSI_STDIO)
+ #  define _SCN64_PREFIX "I64"
+ # elif @HAVE_LONG_LONG_INT@ && LONG_MAX >> 30 == 1
+ #  define _SCN64_PREFIX _LONG_LONG_FORMAT_PREFIX
+@@ -693,7 +693,7 @@
+ #ifdef UINT64_MAX
+ # if (@APPLE_UNIVERSAL_BUILD@ ? defined _LP64 : @UINT64_MAX_EQ_ULONG_MAX@)
+ #  define _SCNu64_PREFIX "l"
+-# elif defined _MSC_VER || defined __MINGW32__
++# elif (defined _MSC_VER || defined __MINGW32__) && !defined(__USE_MINGW_ANSI_STDIO)
+ #  define _SCNu64_PREFIX "I64"
+ # elif @HAVE_UNSIGNED_LONG_LONG_INT@ && ULONG_MAX >> 31 == 1
+ #  define _SCNu64_PREFIX _LONG_LONG_FORMAT_PREFIX

--- a/gdb-mingw-gcc-4.7.patch
+++ b/gdb-mingw-gcc-4.7.patch
@@ -1,0 +1,144 @@
+@@ -, +, @@ 
+ gdb/eval.c      |  7 +++++++
+ gdb/i386-tdep.c | 39 ++++++++++++++++++++++++++++++++++++++-
+ gdb/infcall.c   | 23 +++++++++++++++++++++++
+ 3 files changed, 68 insertions(+), 1 deletion(-)
+--- a/gdb/eval.c	
++++ a/gdb/eval.c	
+@@ -49,6 +49,10 @@ 
+ /* This is defined in valops.c */
+ extern int overload_resolution;
+ 
++/* this variable is to notify i386_push_dummy_call that an 
++  function is static member function, it is a hack */
++extern int i386_windows_static_memfun; 
++
+ /* Prototypes for local functions.  */
+ 
+ static struct value *evaluate_subexp_for_sizeof (struct expression *, int *);
+@@ -1668,7 +1672,10 @@ evaluate_subexp_standard (struct type *expect_type,
+ 	      argvec[1] = argvec[0];
+ 	      nargs--;
+ 	      argvec++;
++	      i386_windows_static_memfun = 1;
+ 	    }
++          else
++            i386_windows_static_memfun = 0;
+ 	}
+       else if (op == STRUCTOP_MEMBER || op == STRUCTOP_MPTR)
+ 	{
+--- a/gdb/i386-tdep.c	
++++ a/gdb/i386-tdep.c	
+@@ -2396,6 +2396,15 @@ i386_push_dummy_code (struct gdbarch *gdbarch, CORE_ADDR sp, CORE_ADDR funaddr,
+   /* Keep the stack aligned.  */
+   return sp - 16;
+ }
++/* This is the hack to handle the non-static member function to thiscall 
++   calling convention mode, this variable is updated in eval.c of the 
++   static member function check */
++int i386_windows_static_memfun = 0; 
++
++/* This is the hack to determine which version of gcc is used to generate
++   the function, if it is greater than 4.6, this use thiscall for member
++   function. */
++int i386_windows_build_gt_gcc46 = 0;
+ 
+ static CORE_ADDR
+ i386_push_dummy_call (struct gdbarch *gdbarch, struct value *function,
+@@ -2408,6 +2417,28 @@ i386_push_dummy_call (struct gdbarch *gdbarch, struct value *function,
+   int i;
+   int write_pass;
+   int args_space = 0;
++  struct type *func_type = value_type (function);
++  int i386_windows_thiscall = 0;
++
++  if (func_type)
++    {
++      func_type = check_typedef (func_type);
++      
++      if (TYPE_CODE (func_type) == TYPE_CODE_PTR)
++        func_type = check_typedef (TYPE_TARGET_TYPE (func_type));
++      
++      if( (TYPE_CODE (func_type) == TYPE_CODE_METHOD)
++         && i386_windows_build_gt_gcc46 == 1
++         && (nargs > 0) 
++         && i386_windows_static_memfun == 0 )
++        {
++         /* a.f(5,6);
++            args[0] = this pointer;
++            args[1] = 5;
++            args[2] = 6; */
++         i386_windows_thiscall = 1;
++        }
++    }
+ 
+   /* Determine the total space required for arguments and struct
+      return address in a first pass (allowing for 16-byte-aligned
+@@ -2430,7 +2461,7 @@ i386_push_dummy_call (struct gdbarch *gdbarch, struct value *function,
+ 	    args_space += 4;
+ 	}
+ 
+-      for (i = 0; i < nargs; i++)
++      for (i = i386_windows_thiscall; i < nargs; i++)
+ 	{
+ 	  int len = TYPE_LENGTH (value_enclosing_type (args[i]));
+ 
+@@ -2482,6 +2513,12 @@ i386_push_dummy_call (struct gdbarch *gdbarch, struct value *function,
+   /* ...and fake a frame pointer.  */
+   regcache_cooked_write (regcache, I386_EBP_REGNUM, buf);
+ 
++  if (i386_windows_thiscall)
++    {
++      /* args[0] refer to the last argument which is the this pointer */
++      regcache_cooked_write (regcache, I386_ECX_REGNUM, value_contents_all(args[0]));
++    }
++
+   /* MarkK wrote: This "+ 8" is all over the place:
+      (i386_frame_this_id, i386_sigtramp_frame_this_id,
+      i386_dummy_id).  It's there, since all frame unwinders for
+--- a/gdb/infcall.c	
++++ a/gdb/infcall.c	
+@@ -36,6 +36,12 @@ 
+ #include "gdbthread.h"
+ #include "exceptions.h"
+ #include "event-top.h"
++#include "utils.h"
++
++/* this value is defined in i386-tdep.c, and we set this value here
++   if the dummy call function is build from gcc 4.7 and later, we 
++   should set this value to 1, other wise, set it to 0 */
++extern int i386_windows_build_gt_gcc46;
+ 
+ /* If we can't find a function's name from its address,
+    we print this instead.  */
+@@ -480,6 +486,8 @@ call_function_by_hand (struct value *function, int nargs, struct value **args)
+   ptid_t call_thread_ptid;
+   struct gdb_exception e;
+   char name_buf[RAW_FUNCTION_ADDRESS_SIZE];
++  struct symtab *sym;
++  int gcc_minor;
+ 
+   if (TYPE_CODE (ftype) == TYPE_CODE_PTR)
+     ftype = check_typedef (TYPE_TARGET_TYPE (ftype));
+@@ -745,6 +753,21 @@ call_function_by_hand (struct value *function, int nargs, struct value **args)
+     }
+   else
+     args_cleanup = make_cleanup (null_cleanup, NULL);
++    
++  /* before we push the dummy call, we need to use the real_pc to determine 
++     what gcc producer is used to generate this function, so it will notify
++     this information to i386-tdep.c */
++     sym = find_pc_symtab(real_pc);
++     if (sym != NULL && sym->producer != NULL)
++     {
++        gcc_minor = producer_is_gcc_ge_4(sym->producer);
++        if (gcc_minor>6)
++            i386_windows_build_gt_gcc46 = 1;
++        else
++            i386_windows_build_gt_gcc46 = 0;
++     }
++     else
++        i386_windows_build_gt_gcc46 = 0;
+ 
+   /* Create the dummy stack frame.  Pass in the call dummy address as,
+      presumably, the ABI code knows where, in the call dummy, the

--- a/gdb-perfomance.patch
+++ b/gdb-perfomance.patch
@@ -1,0 +1,17 @@
+ As DJE said, the workaround looks like below:
+ gdb/typeprint.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gdb/typeprint.c b/gdb/typeprint.c
+index 4e70593..6e62922 100644
+--- a/gdb/typeprint.c
++++ b/gdb/typeprint.c
+@@ -62,7 +62,7 @@ const struct type_print_options type_print_raw_options =
+ 
+ static struct type_print_options default_ptype_flags =
+ {
+-  0,				/* raw */
++  1,				/* raw */
+   1,				/* print_methods */
+   1,				/* print_typedefs */
+   NULL,				/* local_typedefs */

--- a/gdb-py3-fixes.patch
+++ b/gdb-py3-fixes.patch
@@ -1,0 +1,27 @@
+--- gdb-8.0.1/gdb/python/python.c.orig	2018-01-29 17:17:16.030537500 +0100
++++ gdb-8.0.1/gdb/python/python.c	2018-01-29 17:17:25.135058300 +0100
+@@ -351,6 +351,9 @@
+ 
+   /* Because we have a string for a filename, and are using Python to
+      open the file, we need to expand any tilde in the path first.  */
++
++#ifndef IS_PY3K
++
+   gdb::unique_xmalloc_ptr<char> full_path (tilde_expand (filename));
+   gdbpy_ref<> python_file (PyFile_FromString (full_path.get (), (char *) "r"));
+   if (python_file == NULL)
+@@ -361,6 +364,14 @@
+ 
+   PyRun_SimpleFile (PyFile_AsFile (python_file.get ()), filename);
+ 
++#else
++
++  /* Python 3 no loner exposes FILE structs, so we are out of luck */
++  gdb::unique_xmalloc_ptr<char> full_path (tilde_expand (filename));
++  PyRun_SimpleFile (fopen (full_path.get(), "r"), filename);
++
++#endif
++
+ #endif /* _WIN32 */
+ }
+ 

--- a/python-configure-path-fixes.patch
+++ b/python-configure-path-fixes.patch
@@ -1,0 +1,11 @@
+--- gdb-8.0.1/gdb/configure.orig	2018-02-04 15:54:00.599198000 +0100
++++ gdb-8.0.1/gdb/configure	2018-02-04 15:53:04.392983200 +0100
+@@ -9872,7 +9872,7 @@
+         as_fn_error "failure running python-config --ldflags" "$LINENO" 5
+       fi
+     fi
+-    python_prefix=`${python_prog} ${srcdir}/python/python-config.py --exec-prefix`
++    python_prefix=`cygpath -u "$(${python_prog} ${srcdir}/python/python-config.py --exec-prefix)"`
+     if test $? != 0; then
+       have_python_config=failed
+       if test "${with_python}" != auto; then


### PR DESCRIPTION
This will remove the new default dependency of boost and source-highlight on GDB 8.3 release, by providing the configure switch `--enable-source-highlight=no` and removing source-highlight from the package dependencies.

Has been tested locally, GDB doesn't crash if boost dlls are missing.