### PR TITLE
GDB 8.3 Disable Source Highlight

### DIFF
--- a/mingw-w64-gdb/PKGBUILD
+++ b/mingw-w64-gdb/PKGBUILD
@@ -17,7 +17,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-libiconv"
          "${MINGW_PACKAGE_PREFIX}-python3"
          "${MINGW_PACKAGE_PREFIX}-readline"
-         "${MINGW_PACKAGE_PREFIX}-source-highlight"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 checkdepends=('dejagnu' 'bc')
 makedepends=("${MINGW_PACKAGE_PREFIX}-iconv"
@@ -91,7 +90,8 @@ build() {
     --with-libiconv-prefix=${MINGW_PREFIX} \
     --with-zlib \
     --with-lzma \
-    --enable-tui
+    --enable-tui \
+    --enable-source-highlight=no
 
   make
 }

--- a/mingw-w64-gdb/PKGBUILD
+++ b/mingw-w64-gdb/PKGBUILD
@@ -7,7 +7,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 # Until https://gcc.gnu.org/bugzilla/show_bug.cgi?id=62279 is
 # fixed, we will stick with 7.6.2 which hasn't got this bug..
 pkgver=8.3
-pkgrel=2
+pkgrel=3
 pkgdesc="GNU Debugger (mingw-w64)"
 arch=('any')
 url="https://www.gnu.org/software/gdb/"


### PR DESCRIPTION
This will remove the new default dependency of boost and source-highlight on GDB 8.3 release, by providing the configure switch `--enable-source-highlight=no` and removing source-highlight from the package dependencies.

Has been tested locally, GDB doesn't crash if boost dlls are missing.

(This time the PR should be correct)