### PR TITLE
python-astroid - 22.2.5 - add pytest-runner to makedepends.  A build …

### DIFF
--- a/mingw-w64-python-pytest-runner/PKGBUILD
+++ b/mingw-w64-python-pytest-runner/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=pytest-runner
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=4.4
+pkgver=5.1
 pkgrel=1
 pkgdesc="Invoke py.test as distutils command with dependency resolution (mingw-w64)"
 arch=('any')
@@ -17,13 +17,14 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools-scm"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools-scm")
-#checkdepends=("${MINGW_PACKAGE_PREFIX}-python3-pytest-flake8"
-#              "${MINGW_PACKAGE_PREFIX}-python2-pytest-flake8")
+#checkdepends=("${MINGW_PACKAGE_PREFIX}-python3-pytest-black"
+#              "${MINGW_PACKAGE_PREFIX}-python3-pytest-flake8"
+#              "${MINGW_PACKAGE_PREFIX}-python2-pytest-flake8"
 #              "${MINGW_PACKAGE_PREFIX}-python3-pytest-virtualenv"
 #              "${MINGW_PACKAGE_PREFIX}-python2-pytest-virtualenv")
 options=('staticlibs' 'strip' '!debug')
 source=("${_realname}-$pkgver.tar.gz::https://github.com/pytest-dev/${_realname}/archive/$pkgver.tar.gz")
-sha256sums=('5b27b8f8c77a27a1f143ef9214c42b4e4bfe844636c7caf708346af91f71de1a')
+sha256sums=('86912015c23ff1a68a2c59fcead6efd1c90c1bbe7035121fcb1d9ef54d2eae64')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -65,20 +66,20 @@ build() {
   done  
 }
 
-#enable only when we have "${MINGW_PACKAGE_PREFIX}-python3-pytest-virtualenv"
-#check() {
-#  for pver in {2,3}; do
-#    msg "Python ${pver} test for ${CARCH}"
-#    cd "${srcdir}/python${pver}-build-${CARCH}"
-#    ${MINGW_PREFIX}/bin/python${pver} setup.py egg_info
-## we need the flake8 package for this
-#    if [ "${pver}" = "2" ]; then
-#      PYTHONPATH="$PWD" ${MINGW_PREFIX}/bin/pytest2
-#    else
-#      PYTHONPATH="$PWD" ${MINGW_PREFIX}/bin/pytest
-#    fi
-#  done
-#}
+enable only when we have "${MINGW_PACKAGE_PREFIX}-python3-pytest-virtualenv"
+check() {
+  for pver in {2,3}; do
+    msg "Python ${pver} test for ${CARCH}"
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py egg_info
+# we need the flake8 package for this
+    if [ "${pver}" = "2" ]; then
+      PYTHONPATH="$PWD" ${MINGW_PREFIX}/bin/pytest2
+    else
+      PYTHONPATH="$PWD" ${MINGW_PREFIX}/bin/pytest
+    fi
+  done
+}
 
 package_python3-pytest-runner() {
   depends=("${MINGW_PACKAGE_PREFIX}-python3"

--- a/mingw-w64-python3-astroid/PKGBUILD
+++ b/mingw-w64-python3-astroid/PKGBUILD
@@ -17,7 +17,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python3-dateutil"
               "${MINGW_PACKAGE_PREFIX}-python3-pytest"
               "${MINGW_PACKAGE_PREFIX}-python3-numpy"
-              "${MINGW_PACKAGE_PREFIX}-python3-nose")
+              "${MINGW_PACKAGE_PREFIX}-python3-nose"
+              "${MINGW_PACKAGE_PREFIX}-python3-pytest-runner")
 source=(https://github.com/PyCQA/astroid/archive/astroid-${pkgver}.tar.gz)
 sha512sums=('16cc46987a1bed40040b9e1833d0c74dd4c1da91f385fe947d42776197970abaec91a8473069aad4480c877e444802f43a644a63cbaeebfb3824aaf7bc2d5c89')
 


### PR DESCRIPTION
…failure could result if it isn't present

python-pytest-runner 5.1  - Update to latest version while I'm at it