### PR TITLE
mingw-w64-pdcurses - 44.1.0 fix a build failure caused by i32-bit bin…

### DIFF
--- a/mingw-w64-pdcurses/PKGBUILD
+++ b/mingw-w64-pdcurses/PKGBUILD
@@ -32,8 +32,12 @@ prepare() {
 build() {
   cd "${srcdir}/PDCurses-${pkgver}"
 
-  cp -rf wingui wingui-shared
-  pushd wingui-shared
+# NOte that you should use something like -${CARCH}
+# to prevent building i686 compiled binaries from
+# being compiled with x86_64 compiled binaries and
+# vice-versa.  That causes build failures - no surpise.
+  cp -rf wingui wingui-shared-${CARCH}
+  pushd wingui-shared-${CARCH}
     make -f Makefile.mng \
       CC=${MINGW_PREFIX}/bin/gcc \
       LINK=${MINGW_PREFIX}/bin/gcc \
@@ -44,8 +48,8 @@ build() {
       DLL=Y
   popd
 
-  cp -rf wingui wingui-static
-  pushd wingui-static
+  cp -rf wingui wingui-static-${CARCH}
+  pushd wingui-static-${CARCH}
     make -f Makefile.mng \
       CC=${MINGW_PREFIX}/bin/gcc \
       LINK=${MINGW_PREFIX}/bin/gcc \
@@ -63,15 +67,15 @@ package() {
   mkdir -p ${pkgdir}${MINGW_PREFIX}/{bin,include,lib}
   mkdir ${pkgdir}${MINGW_PREFIX}/include/pdcurses
  
-  install wingui-shared/*.exe ${pkgdir}${MINGW_PREFIX}/bin/
-  install wingui-shared/libpdcurses.dll ${pkgdir}${MINGW_PREFIX}/bin/
-  install wingui-shared/libpdcurses.dll.a ${pkgdir}${MINGW_PREFIX}/lib/libpdcurses.dll.a
-  install wingui-shared/libpdcurses.dll.a ${pkgdir}${MINGW_PREFIX}/lib/libcurses.dll.a
-  install wingui-shared/libpdcurses.dll.a ${pkgdir}${MINGW_PREFIX}/lib/libpanel.dll.a
+  install wingui-shared-${CARCH}/*.exe ${pkgdir}${MINGW_PREFIX}/bin/
+  install wingui-shared-${CARCH}/libpdcurses.dll ${pkgdir}${MINGW_PREFIX}/bin/
+  install wingui-shared-${CARCH}/libpdcurses.dll.a ${pkgdir}${MINGW_PREFIX}/lib/libpdcurses.dll.a
+  install wingui-shared-${CARCH}/libpdcurses.dll.a ${pkgdir}${MINGW_PREFIX}/lib/libcurses.dll.a
+  install wingui-shared-${CARCH}/libpdcurses.dll.a ${pkgdir}${MINGW_PREFIX}/lib/libpanel.dll.a
 
-  install wingui-static/libpdcurses.a ${pkgdir}${MINGW_PREFIX}/lib/libpdcurses.a
-  install wingui-static/libpdcurses.a ${pkgdir}${MINGW_PREFIX}/lib/libcurses.a
-  install wingui-static/libpdcurses.a ${pkgdir}${MINGW_PREFIX}/lib/libpanel.a
+  install wingui-static-${CARCH}/libpdcurses.a ${pkgdir}${MINGW_PREFIX}/lib/libpdcurses.a
+  install wingui-static-${CARCH}/libpdcurses.a ${pkgdir}${MINGW_PREFIX}/lib/libcurses.a
+  install wingui-static-${CARCH}/libpdcurses.a ${pkgdir}${MINGW_PREFIX}/lib/libpanel.a
 
   echo '#include "pdcurses/curses.h"' > pdcurses.h
   install -m 0644 curses.h panel.h term.h acs_defs.h ${pkgdir}${MINGW_PREFIX}/include/pdcurses/


### PR DESCRIPTION
…aries being compiled in the same place as x864_64 binaries.

We are essentially compiling 2 separate sets of binary files and these two isets have to always be separated.

Otherwise, you may get:
/home/jpmugaas/exp/mingw-w64-pdcurses/src/PDCurses-4.1.0/wingui-shared /home/jpmugaas/exp/mingw-w64-pdcurses/src/PDCurses-4.1.0
/mingw32/bin/gcc -c -O4 -Wall -pedantic -I.. -DPDC_WIDE -DPDC_FORCE_UTF8 -DPDC_DLL_BUILD ../pdcurses/terminfo.c
/mingw32/bin/gcc -Wl,--out-implib,libpdcurses.dll.a -shared -o libpdcurses.dll terminfo.o -lgdi32 -lcomdlg32
terminfo.o:terminfo.c:(.text+0xb): undefined reference to `LINES'
terminfo.o:terminfo.c:(.text+0x17): undefined reference to `COLS'
terminfo.o:terminfo.c:(.text+0x2d): undefined reference to `PDC_gotoyx'
terminfo.o:terminfo.c:(.text+0x32): undefined reference to `SP'
collect2.exe: error: ld returned 1 exit status
make: *** [Makefile.mng:141: libpdcurses.dll] Error 1

if the build dirs are cleaned beforehand.  But we might NOT want to clean because we may need to examine the files aftwards.