### PR TITLE
opencv: Update dependencies

### DIFF
--- a/mingw-w64-opencv/PKGBUILD
+++ b/mingw-w64-opencv/PKGBUILD
@@ -4,7 +4,7 @@ _realname=opencv
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Open Source Computer Vision Library (mingw-w64)"
 arch=('any')
 url="https://opencv.org/"
@@ -26,7 +26,7 @@ depends=(#"${MINGW_PACKAGE_PREFIX}-gst-plugins-base
          )
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              #"${MINGW_PACKAGE_PREFIX}-qt5"
-             "${MINGW_PACKAGE_PREFIX}-eigen3"
+             "${MINGW_PACKAGE_PREFIX}-ceres-solver"
              "${MINGW_PACKAGE_PREFIX}-ffmpeg"
              "${MINGW_PACKAGE_PREFIX}-ogre3d"
              "${MINGW_PACKAGE_PREFIX}-python2-numpy"
@@ -41,7 +41,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              #"${MINGW_PACKAGE_PREFIX}-vtk"
              "${MINGW_PACKAGE_PREFIX}-cereal"
             )
-optdepends=("${MINGW_PACKAGE_PREFIX}-eigen3"
+optdepends=("${MINGW_PACKAGE_PREFIX}-ceres-solver: SFM module"
             "${MINGW_PACKAGE_PREFIX}-ffmpeg: support to read and write video files"
             "${MINGW_PACKAGE_PREFIX}-python2-numpy: Python 2.x interface"
             "${MINGW_PACKAGE_PREFIX}-python3-numpy: Python 3.x interface"


### PR DESCRIPTION
As mentioned in #5361, opencv's python modules require ceres-solver at runtime. Since ceres-solver in turn requires eigen3, I replaced it in optdepends. I did not build test this, so putting it in makedepends as well is an assumption on my part.