### PR TITLE
gdb: Fix link order on Windows

### DIFF
--- a/mingw-w64-gdb/PKGBUILD
+++ b/mingw-w64-gdb/PKGBUILD
@@ -7,7 +7,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 # Until https://gcc.gnu.org/bugzilla/show_bug.cgi?id=62279 is
 # fixed, we will stick with 7.6.2 which hasn't got this bug..
 pkgver=8.3
-pkgrel=4
+pkgrel=5
 pkgdesc="GNU Debugger (mingw-w64)"
 arch=('any')
 url="https://www.gnu.org/software/gdb/"
@@ -33,7 +33,8 @@ source=(https://ftp.gnu.org/gnu/gdb/${_realname}-${pkgver}.tar.xz{,.sig}
         'gdb-7.12-dynamic-libs.patch'
         'gdb-py3-fixes.patch'
         'python-configure-path-fixes.patch'
-        'gdb-fix-tui-with-pdcurses.patch')
+        'gdb-fix-tui-with-pdcurses.patch'
+        'gdb-8.3-lib-order.patch')
 validpgpkeys=('F40ADB902B24264AA42E50BF92EDB04BFF325CF3')
 sha256sums=('802f7ee309dcc547d65a68d61ebd6526762d26c3051f52caebe2189ac1ffd72e'
             'SKIP'
@@ -45,7 +46,8 @@ sha256sums=('802f7ee309dcc547d65a68d61ebd6526762d26c3051f52caebe2189ac1ffd72e'
             '4398bd83a798baa15c0f91878391a0882239a682cf523ef6551766cba7b03699'
             'bfe8985e806200e5a1007c4565bd60de0a297369d17d4a0178512f2df29b34fc'
             'bdf6c2b51d6c8c84b7b20abb9d1702f110c0c0e06e3d68eb6aba817664354450'
-            '4d6b2b8ab03cea1c47e882ed17ddc3c528e22c92e3538ab261d9bb629626d50b')
+            '4d6b2b8ab03cea1c47e882ed17ddc3c528e22c92e3538ab261d9bb629626d50b'
+            'd92e2135e6f1bed51128f702a0630a961c0eaf241bb35fdafd0fe0d67cd0fb48')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
@@ -67,6 +69,7 @@ prepare() {
   patch -p1 -i ${srcdir}/python-configure-path-fixes.patch
 
   patch -p1 -i ${srcdir}/gdb-fix-tui-with-pdcurses.patch
+  patch -p1 -i ${srcdir}/gdb-8.3-lib-order.patch
 
   # hack! - libiberty configure tests for header files using "$CPP $CPPFLAGS"
   sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" libiberty/configure
@@ -85,7 +88,7 @@ build() {
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \
     --prefix=${MINGW_PREFIX} \
-    --enable-targets="i686-w64-mingw32,x86_64-w64-mingw32" \
+    --enable-targets=all \
     --enable-64-bit-bfd \
     --disable-werror \
     --disable-win32-registry \

--- a/mingw-w64-gdb/gdb-8.3-lib-order.patch
+++ b/mingw-w64-gdb/gdb-8.3-lib-order.patch
@@ -1,0 +1,29 @@
+From 699d1bec385c16261eb9fe3de0f71a8cafc73082 Mon Sep 17 00:00:00 2001
+From: Orgad Shaneh <orgads@gmail.com>
+Date: Sun, 2 Jun 2019 11:43:52 +0300
+Subject: [PATCH] Fix link order on Windows
+
+libgnu uses ntop, which comes from ws2_32 library, so ws2_32 needs
+to be linked after libgnu.
+---
+ gdb/Makefile.in | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/gdb/Makefile.in b/gdb/Makefile.in
+index 5614cc3386..037f9ae356 100644
+--- a/gdb/Makefile.in
++++ b/gdb/Makefile.in
+@@ -595,8 +595,8 @@ CLIBS = $(SIM) $(READLINE) $(OPCODES) $(BFD) $(ZLIB) $(INTL) $(LIBIBERTY) $(LIBD
+ 	$(XM_CLIBS) $(GDBTKLIBS) \
+ 	@LIBS@ @GUILE_LIBS@ @PYTHON_LIBS@ \
+ 	$(LIBEXPAT) $(LIBLZMA) $(LIBBABELTRACE) $(LIBIPT) \
+-	$(LIBIBERTY) $(WIN32LIBS) $(LIBGNU) $(LIBICONV) $(LIBMPFR) \
+-	$(SRCHIGH_LIBS)
++	$(LIBIBERTY) $(LIBGNU) $(LIBICONV) $(LIBMPFR) \
++	$(SRCHIGH_LIBS) $(WIN32LIBS)
+ CDEPS = $(NAT_CDEPS) $(SIM) $(BFD) $(READLINE_DEPS) \
+ 	$(OPCODES) $(INTL_DEPS) $(LIBIBERTY) $(CONFIG_DEPS) $(LIBGNU)
+ 
+-- 
+2.22.0.rc0.windows.1
+


### PR DESCRIPTION
Required when building with GCC 9.1, which defaults to version 0x0601.