### PR TITLE
gdb: Restore default targets

### DIFF
--- a/mingw-w64-gdb/PKGBUILD
+++ b/mingw-w64-gdb/PKGBUILD
@@ -7,7 +7,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 # Until https://gcc.gnu.org/bugzilla/show_bug.cgi?id=62279 is
 # fixed, we will stick with 7.6.2 which hasn't got this bug..
 pkgver=8.3
-pkgrel=6
+pkgrel=7
 pkgdesc="GNU Debugger (mingw-w64)"
 arch=('any')
 url="https://www.gnu.org/software/gdb/"
@@ -91,7 +91,7 @@ build() {
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \
     --prefix=${MINGW_PREFIX} \
-    --enable-targets=all \
+    --enable-targets="i686-w64-mingw32,x86_64-w64-mingw32" \
     --enable-64-bit-bfd \
     --disable-werror \
     --disable-win32-registry \


### PR DESCRIPTION
Sneaked in by mistake in 1b05bf47f31384f13a218dc4290cd4274e22889e.