### PR TITLE
python-pluggy: fix missing dep on python-importlib-metadata

### DIFF
--- a/mingw-w64-python-pluggy/PKGBUILD
+++ b/mingw-w64-python-pluggy/PKGBUILD
@@ -4,7 +4,7 @@ _realname=pluggy
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=0.12.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Plugin and hook calling mechanisms for python (mingw-w64)'
 url='https://github.com/pytest-dev/pluggy'
 license=('MIT')
@@ -13,8 +13,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python3"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
-             "${MINGW_PACKAGE_PREFIX}-python2-setuptools-scm" 
-             "${MINGW_PACKAGE_PREFIX}-python3-setuptools-scm")
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools-scm"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools-scm"
+             "${MINGW_PACKAGE_PREFIX}-python2-importlib-metadata"
+             "${MINGW_PACKAGE_PREFIX}-python3-importlib-metadata")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python2-pytest-runner" 
               "${MINGW_PACKAGE_PREFIX}-python3-pytest-runner")
 source=("${_realname}-$pkgver.tar.gz"::"https://github.com/pytest-dev/pluggy/archive/$pkgver.tar.gz")
@@ -47,7 +49,8 @@ check() {
 }
 
 package_python3-pluggy() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+  depends=("${MINGW_PACKAGE_PREFIX}-python3"
+           "${MINGW_PACKAGE_PREFIX}-python3-importlib-metadata")
 
   cd ${srcdir}/python3-build-${CARCH}
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
@@ -57,7 +60,8 @@ package_python3-pluggy() {
 }
 
 package_python2-pluggy() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+  depends=("${MINGW_PACKAGE_PREFIX}-python2"
+           "${MINGW_PACKAGE_PREFIX}-python2-importlib-metadata")
 
   cd ${srcdir}/python2-build-${CARCH}
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \


### PR DESCRIPTION
This broke pytest for example