### PR TITLE
lasem: update to 0.4.4

### DIFF
--- a/mingw-w64-lasem/002-no-undefined.patch
+++ b/mingw-w64-lasem/002-no-undefined.patch
@@ -1,0 +1,11 @@
+--- lasem-LASEM_0_4_4.orig/src/Makefile.am	2019-06-03 20:54:54.789589000 -0400
++++ lasem-LASEM_0_4_4/src/Makefile.am	2019-06-03 20:56:54.075516900 -0400
+@@ -268,7 +268,7 @@
+ liblasem_@LASEM_API_VERSION@_la_HEADERS = $(LASEM_DOM_HDRS)
+ liblasem_@LASEM_API_VERSION@_la_HEADERS += lsmdomenumtypes.h
+ 
+-liblasem_@LASEM_API_VERSION@_la_LDFLAGS = -version-info $(LASEM_LIBTOOL_VERSION)
++liblasem_@LASEM_API_VERSION@_la_LDFLAGS = -version-info $(LASEM_LIBTOOL_VERSION) -no-undefined
+ 
+ lsmdomenumtypes.h: lsmdomenumtypes.h.template $(LASEM_DOM_HDRS) $(GLIB_MKENUMS)
+ 	$(AM_V_GEN) (cd $(srcdir) && $(GLIB_MKENUMS) --template lsmdomenumtypes.h.template $(LASEM_DOM_HDRS)) > $@

--- a/mingw-w64-lasem/PKGBUILD
+++ b/mingw-w64-lasem/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=lasem
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.4.3
-pkgrel=2
+pkgver=0.4.4
+pkgrel=1
 pkgdesc="Lasem aims to be a C/Gobject based SVG/Mathml renderer (mingw-w64)"
 arch=('any')
 url="https://github.com/GNOME/lasem"
@@ -22,19 +22,22 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gobject-introspection"
              "intltool"
             )
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/GNOME/lasem/archive/LASEM_${pkgver//./_}.tar.gz"
-        001-fix-doc-install.patch)
-sha256sums=('20506a874a718c141ee2870aebee6a1017bb951f4a52f7b8f13f4e497621e310'
-            '9c9321e4f2c841d3b348204519b5e508492521f4c2c512ecfb8a083a06dca1e3')
+        001-fix-doc-install.patch
+        002-no-undefined.patch)
+sha256sums=('d23779ab5626872f96fba9400d6062027aecadc60b76cf18ff4320e0d63118cf'
+            '9c9321e4f2c841d3b348204519b5e508492521f4c2c512ecfb8a083a06dca1e3'
+            '7f98e6d191c53ffe80235258c5114c78e3e7af889c5c07c79ed4134e2be7e3b8')
 
 prepare() {
   cd "${_realname}-LASEM_${pkgver//./_}"
   patch -p1 -i ${srcdir}/001-fix-doc-install.patch
+  patch -p1 -i ${srcdir}/002-no-undefined.patch
   NOCONFIGURE=1 ./autogen.sh
 }
 
 build() {
-  [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}
-  mkdir -p build-${MINGW_CHOST} && cd build-${MINGW_CHOST}
+  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
+  mkdir -p ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
 
   ../${_realname}-LASEM_${pkgver//./_}/configure \
     --prefix=${MINGW_PREFIX} \


### PR DESCRIPTION
This updates `lasem` to `0.4.4` and adds a missing shared library.