### PR TITLE
python-uncidoe - 3 and 2 - Make unicodedata2 into both a 2 and 3 pack…

### DIFF
--- a/mingw-w64-python-fonttools/PKGBUILD
+++ b/mingw-w64-python-fonttools/PKGBUILD
@@ -10,11 +10,26 @@ arch=('any')
 url='https://github.com/fonttools/fonttools'
 license=('MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
-             "${MINGW_PACKAGE_PREFIX}-python3"
-             "${MINGW_PACKAGE_PREFIX}-python3-numpy"
+             "${MINGW_PACKAGE_PREFIX}-python2-brotli"
+             "${MINGW_PACKAGE_PREFIX}-python2-enum34"
+             "${MINGW_PACKAGE_PREFIX}-python3-matplotlib"
              "${MINGW_PACKAGE_PREFIX}-python2-numpy"
+             "${MINGW_PACKAGE_PREFIX}-python2-pyfilesystem2"
+             "${MINGW_PACKAGE_PREFIX}-python2-pyzopfli"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python2-sympy"
+             "${MINGW_PACKAGE_PREFIX}-python2-unicodedata2>=12.0.0"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python3-brotli"
+             "${MINGW_PACKAGE_PREFIX}-python3-matplotlib"
+             "${MINGW_PACKAGE_PREFIX}-python3-numpy"
+             "${MINGW_PACKAGE_PREFIX}-python3-pyfilesystem2"
+             "${MINGW_PACKAGE_PREFIX}-python3-pyzopfli"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
-             "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+             "${MINGW_PACKAGE_PREFIX}-python2-sympy"
+             "${MINGW_PACKAGE_PREFIX}-python3-unicodedata2>=12.0.0")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python2-pytest-runner"
+              "${MINGW_PACKAGE_PREFIX}-python3-pytest-runner")
 options=('staticlibs' 'strip' '!debug')
 source=("https://github.com/fonttools/fonttools/releases/download/${pkgver}/fonttools-${pkgver}.zip")
 sha256sums=('c00b393b8fb8644acc7a0c7b71d2e70eadc21db494baaa05b32b08148c661670')
@@ -37,17 +52,22 @@ build() {
 }
 
 #Enable tests when the dependencies are solved
-#check() {
-#  for pver in {2,3}; do
-#    msg "Python ${pver} test for ${CARCH}"
-#    cd "${srcdir}/python${pver}-build-${CARCH}"
-#    ${MINGW_PREFIX}/bin/python${pver} setup.py test
-#  done
-#}
+check() {
+  for pver in {2,3}; do
+    msg "Python ${pver} test for ${CARCH}"
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py pytest || warning "Tests failed"
+  done
+}
 
 package_python3-fonttools() {
   depends=("${MINGW_PACKAGE_PREFIX}-python3"
            "${MINGW_PACKAGE_PREFIX}-python3-numpy")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-python3-brotli: WOFF 1.0 and WOFF 2.0 webfonts"
+              "${MINGW_PACKAGE_PREFIX}-python3-pyfilesystem2: for fontTools.ufoLib: to read/write UFO fonts"
+              "${MINGW_PACKAGE_PREFIX}-python3-pyzopfli: WOFF 1.0 and WOFF 2.0 webfonts"
+              "${MINGW_PACKAGE_PREFIX}-python3-sympy: for fontTools.misc.symfont, module for symbolic font statistics analysis"
+              "${MINGW_PACKAGE_PREFIX}-python3-unicodedata2: for Unicode 12.0")
   install=${_realname}3-${CARCH}.install
 
   cd "${srcdir}/python3-build-${CARCH}"
@@ -67,7 +87,14 @@ package_python3-fonttools() {
 
 package_python2-fonttools() {
   depends=("${MINGW_PACKAGE_PREFIX}-python2"
-           "${MINGW_PACKAGE_PREFIX}-python2-numpy")
+           "${MINGW_PACKAGE_PREFIX}-python2-numpy"           
+           )
+  optdepends=("${MINGW_PACKAGE_PREFIX}-python3-brotli: WOFF 1.0 and WOFF 2.0 webfonts"
+              "${MINGW_PACKAGE_PREFIX}-python2-pyfilesystem2: to read/write UFO fonts"
+              "${MINGW_PACKAGE_PREFIX}-python2-enum34: to read/write UFO fonts"
+              "${MINGW_PACKAGE_PREFIX}-python2-pyzopfli: WOFF 1.0 and WOFF 2.0 webfonts"
+              "${MINGW_PACKAGE_PREFIX}-python2-sympy: for fontTools.misc.symfont, module for symbolic font statistics analysis"
+              "${MINGW_PACKAGE_PREFIX}-python2-unicodedata2: for Unicode 12.0")
   install=${_realname}2-${CARCH}.install
 
   cd "${srcdir}/python2-build-${CARCH}"

--- a/mingw-w64-python-pyfilesystem2/PKGBUILD
+++ b/mingw-w64-python-pyfilesystem2/PKGBUILD
@@ -1,0 +1,131 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_realname=pyfilesystem2
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=2.4.5
+pkgrel=1
+pkgdesc="Python's filesystem abstraction layer (mingw-w64)"
+arch=('any')
+url='https://github.com/PyFilesystem/pyfilesystem2'
+license=('MIT')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python3-appdirs"
+             "${MINGW_PACKAGE_PREFIX}-python2-enum34"
+             "${MINGW_PACKAGE_PREFIX}-python2-backports.os"
+             "${MINGW_PACKAGE_PREFIX}-python3-pytz"
+             "${MINGW_PACKAGE_PREFIX}-python2-scandir"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python2-six"
+             "${MINGW_PACKAGE_PREFIX}-python2-typing"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python3-appdirs"
+             "${MINGW_PACKAGE_PREFIX}-python3-pytz"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python3-six")
+# We would require "${MINGW_PACKAGE_PREFIX}-python2-pyftpdlib" amd "${MINGW_PACKAGE_PREFIX}-python3-pyftpdlib"
+#checkdepends=("${MINGW_PACKAGE_PREFIX}-python2-appdirs" 
+#              "${MINGW_PACKAGE_PREFIX}-python2-mock"
+#              "${MINGW_PACKAGE_PREFIX}-python2-pytz"
+#              "${MINGW_PACKAGE_PREFIX}-python2-pyftpdlib"
+#              "${MINGW_PACKAGE_PREFIX}-python3-appdirs" 
+#              "${MINGW_PACKAGE_PREFIX}-python3-mock"
+#              "${MINGW_PACKAGE_PREFIX}-python3-pytz"
+#              "${MINGW_PACKAGE_PREFIX}-python3-pyftpdlib")
+options=('staticlibs' 'strip' '!debug')
+source=("${_realname}-$pkgver.tar.gz"::"https://github.com/PyFilesystem/pyfilesystem2/archive/v2.4.5.tar.gz")
+sha256sums=('1f9a068f822052d30d4cd0cbcbfee1ca26d8305298328054eae756917d39fac8')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
+prepare() {
+  cd "${srcdir}"
+  for builddir in python{2,3}-build-${CARCH}; do
+    rm -rf ${builddir} | true
+    cp -r "${_realname}-${pkgver}" "${builddir}"
+  done
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
+}
+
+build() {
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
+}
+
+# We would require "${MINGW_PACKAGE_PREFIX}-python2-pyftpdlib" amd "${MINGW_PACKAGE_PREFIX}-python3-pyftpdlib"
+#check() {
+#  for pver in {2,3}; do
+#    msg "Python ${pver} test for ${CARCH}"
+#    cd "${srcdir}/python${pver}-build-${CARCH}"
+#    ${MINGW_PREFIX}/bin/python${pver} setup.py test
+#  done
+#}
+
+package_python3-pyfilesystem2() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3"
+           "${MINGW_PACKAGE_PREFIX}-python3-appdirs"
+           "${MINGW_PACKAGE_PREFIX}-python3-pytz"
+           "${MINGW_PACKAGE_PREFIX}-python3-six")
+
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+}
+
+package_python2-pyfilesystem2() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2"
+           "${MINGW_PACKAGE_PREFIX}-python2-appdirs"
+           "${MINGW_PACKAGE_PREFIX}-python2-backports.os"
+           "${MINGW_PACKAGE_PREFIX}-python2-pytz"
+           "${MINGW_PACKAGE_PREFIX}-python2-enum34"
+           "${MINGW_PACKAGE_PREFIX}-python2-scandir"
+           "${MINGW_PACKAGE_PREFIX}-python2-six"
+           "${MINGW_PACKAGE_PREFIX}-python2-typing")
+
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
+}
+
+package_mingw-w64-i686-python2-pyfilesystem2() {
+  package_python2-pyfilesystem2
+}
+
+package_mingw-w64-i686-python3-pyfilesystem2() {
+  package_python3-pyfilesystem2
+}
+
+package_mingw-w64-x86_64-python2-pyfilesystem2() {
+  package_python2-pyfilesystem2
+}
+
+package_mingw-w64-x86_64-python3-pyfilesystem2() {
+  package_python3-pyfilesystem2
+}

--- a/mingw-w64-python2-unicodedata2/PKGBUILD
+++ b/mingw-w64-python2-unicodedata2/PKGBUILD
@@ -1,22 +1,21 @@
 # Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
 _realname=unicodedata2
-pkgbase=mingw-w64-python-${_realname}
+pkgbase=mingw-w64-python2-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-python2-${_realname}"
-pkgver=11.0.0
+pkgver=12.0.0
 pkgrel=1
 pkgdesc='unicodedata backport/updates (mingw-w64)'
 arch=('any')
 url="https://github.com/mikekap/${_realname}"
 license=('Apache')
 depends=("${MINGW_PACKAGE_PREFIX}-python2")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cython2" "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
 source=("${_realname}-$pkgver.tar.gz"::"https://github.com/mikekap/unicodedata2/archive/$pkgver.tar.gz")
-sha256sums=('b69709806e97b2aed0f63dbcec4b6046c464a1263df5e600915639bf6ccf979a')
+sha256sums=('cf32b4fd0d25e31e4caa40c99cc048c41c56a49ede07f55afd90519dea4a837e')
 
 prepare() {
-  for builddir in python2-build-${CARCH}; do
-    rm -rf $builddir | true
-    cp -r "${_realname}-${pkgver}" "${builddir}"
-  done  
+  rm -rf python2-build-${CARCH} | true
+  cp -r "${_realname}-${pkgver}" "python2-build-${CARCH}"
 }
 
 build() {
@@ -25,9 +24,15 @@ build() {
      ${MINGW_PREFIX}/bin/python2 setup.py build
 }
 
+check() {
+   cd "$srcdir/python2-build-${CARCH}"
+   ${MINGW_PREFIX}/bin/python2 setup.py test
+}
+
 package() {
    cd "$srcdir/python2-build-${CARCH}"
    MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
      ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
        --root="$pkgdir" --optimize=1
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
 }

--- a/mingw-w64-python3-unicodedata2/PKGBUILD
+++ b/mingw-w64-python3-unicodedata2/PKGBUILD
@@ -1,0 +1,43 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+# Note!!!
+# This is a temporary solution because Python 3.7 does not
+# include the unicode 12 data that fonttools depends upon.
+# We should drop this PKGBUILD once Python 3.8 is built.
+_realname=unicodedata2
+pkgbase=mingw-w64-python3-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
+pkgver=12.0.0
+pkgrel=1
+pkgdesc='unicodedata backport/updates (mingw-w64)'
+arch=('any')
+url="https://github.com/mikekap/${_realname}"
+license=('Apache')
+depends=("${MINGW_PACKAGE_PREFIX}-python3<3.8")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cython" "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
+source=("${_realname}-$pkgver.tar.gz"::"https://github.com/mikekap/unicodedata2/archive/$pkgver.tar.gz")
+sha256sums=('cf32b4fd0d25e31e4caa40c99cc048c41c56a49ede07f55afd90519dea4a837e')
+
+prepare() {
+  for builddir in python3-build-${CARCH}; do
+    rm -rf $builddir | true
+    cp -r "${_realname}-${pkgver}" "${builddir}"
+  done
+}
+
+build() {
+   cd "$srcdir/python3-build-${CARCH}"
+   ${MINGW_PREFIX}/bin/python3 setup.py build
+}
+
+check() {
+   cd "$srcdir/python3-build-${CARCH}"
+   ${MINGW_PREFIX}/bin/python3 setup.py test
+}
+
+package() {
+   cd "$srcdir/python3-build-${CARCH}"
+   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+     ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+       --root="$pkgdir" --optimize=1
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+}


### PR DESCRIPTION
…age for 12 version using separate PKGBUILD's.  This is because it's a backport from Python 3.8.

python-pyfilesystem2 - 2.4.5 - new package required by fonttols
python-w64-fonttols - 3.42.0 - update to latest version, clarify dependencies