### PR TITLE
flatbuffers: Add missing -DCMAKE_BUILD_TYPE=Release

### DIFF
--- a/mingw-w64-flatbuffers/PKGBUILD
+++ b/mingw-w64-flatbuffers/PKGBUILD
@@ -4,7 +4,7 @@ _realname=flatbuffers
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.11.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Memory Efficient Serialization Library (mingw-w64)'
 arch=('any')
 url='https://google.github.io/flatbuffers/'
@@ -33,6 +33,7 @@ build() {
   ${MINGW_PREFIX}/bin/cmake \
     -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+    -DCMAKE_BUILD_TYPE=Release \
     -DFLATBUFFERS_BUILD_SHAREDLIB=ON \
     ../${_realname}-${pkgver}
 


### PR DESCRIPTION
If CMAKE_BUILD_TYPE is missing, lib/cmake/flatbuffers/*-noconfig.cmake
are installed. They aren't used from other projects when other
projects use -DCMAKE_BUILD_TYPE=Release. Generally,
-DCMAKE_BUILD_TYPE=Release is used for package build. We already use
it in many packages:

    $ grep CMAKE_BUILD_TYPE=Release */PKGBUILD | wc -l
    164

If -DCMAKE_BUILD_TYPE=Release is specified,
lib/cmake/flatbuffers/*-release.cmake are installed. They are used from
other projects when other projects use -DCMAKE_BUILD_TYPE=Release.