### PR TITLE
Clang: Fix lld with g++

### DIFF
--- a/mingw-w64-clang/0015-cmake-symlinks.patch
+++ b/mingw-w64-clang/0015-cmake-symlinks.patch
@@ -1,0 +1,48 @@
+From 31cf4b1ff245e0456a1f9b47fd818ed560afb259 Mon Sep 17 00:00:00 2001
+From: Orgad Shaneh <orgads@gmail.com>
+Date: Wed, 5 Jun 2019 08:55:57 +0300
+Subject: [PATCH] CMake: Use symlinks also on MSYS
+
+---
+ cmake/modules/AddLLVM.cmake            | 4 ++--
+ cmake/modules/LLVMInstallSymlink.cmake | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/cmake/modules/AddLLVM.cmake b/cmake/modules/AddLLVM.cmake
+index 1a417447278..febf2c0e9b6 100644
+--- a/cmake/modules/AddLLVM.cmake
++++ b/cmake/modules/AddLLVM.cmake
+@@ -1505,7 +1505,7 @@ function(add_llvm_tool_symlink link_name target)
+   if(NOT ARG_OUTPUT_DIR)
+     # If you're not overriding the OUTPUT_DIR, we can make the link relative in
+     # the same directory.
+-    if(CMAKE_HOST_UNIX)
++    if(CMAKE_HOST_UNIX OR MSYS)
+       set(dest_binary "$<TARGET_FILE_NAME:${target}>")
+     endif()
+     if(CMAKE_CONFIGURATION_TYPES)
+@@ -1531,7 +1531,7 @@ function(add_llvm_tool_symlink link_name target)
+     endif()
+   endif()
+ 
+-  if(CMAKE_HOST_UNIX)
++  if(CMAKE_HOST_UNIX OR MSYS)
+     set(LLVM_LINK_OR_COPY create_symlink)
+   else()
+     set(LLVM_LINK_OR_COPY copy)
+diff --git a/cmake/modules/LLVMInstallSymlink.cmake b/cmake/modules/LLVMInstallSymlink.cmake
+index 1a04de931ff..7c5d50ca53e 100644
+--- a/cmake/modules/LLVMInstallSymlink.cmake
++++ b/cmake/modules/LLVMInstallSymlink.cmake
+@@ -3,7 +3,7 @@
+ # See PR8397.
+ 
+ function(install_symlink name target outdir)
+-  if(CMAKE_HOST_UNIX)
++  if(CMAKE_HOST_UNIX OR MSYS)
+     set(LINK_OR_COPY create_symlink)
+     set(DESTDIR $ENV{DESTDIR})
+   else()
+-- 
+2.21.0.windows.1
+

--- a/mingw-w64-clang/0301-lld-mingw-flags.patch
+++ b/mingw-w64-clang/0301-lld-mingw-flags.patch
@@ -1,0 +1,28 @@
+Index: MinGW/Options.td
+===================================================================
+--- MinGW/Options.td
++++ MinGW/Options.td
+@@ -54,6 +54,11 @@
+ def require_defined: S<"require-defined">,
+     HelpText<"Force symbol to be added to symbol table as an undefined one">;
+ def require_defined_eq: J<"require-defined=">, Alias<require_defined>;
++// Strictly taken, the -u option allows for the symbol to remain undefined,
++// which this currently doesn't.
++def undefined: S<"u">, Alias<require_defined>;
++def undefined_long: S<"undefined">, Alias<require_defined>;
++def undefined_eq: J<"undefined=">, Alias<require_defined>;
+ 
+ // LLD specific options
+ def _HASH_HASH_HASH : Flag<["-"], "###">,
+Index: test/MinGW/driver.test
+===================================================================
+--- test/MinGW/driver.test
++++ test/MinGW/driver.test
+@@ -155,6 +155,7 @@
+ MAP: -lldmap:bar.map
+ 
+ RUN: ld.lld -### foo.o -m i386pe -require-defined _foo --require-defined _bar -require-defined=_baz --require-defined=_foo2 | FileCheck -check-prefix=REQUIRE-DEFINED %s
++RUN: ld.lld -### foo.o -m i386pe -u _foo --undefined _bar -undefined=_baz --undefined=_foo2 | FileCheck -check-prefix=REQUIRE-DEFINED %s
+ REQUIRE-DEFINED: -include:_foo -include:_bar -include:_baz -include:_foo2
+ 
+ RUN: ld.lld -### -m i386pep foo.o -Llibpath | FileCheck -check-prefix LIBPATH %s

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -29,7 +29,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-llvm"
          "${MINGW_PACKAGE_PREFIX}-polly")
 pkgver=8.0.0
-pkgrel=4
+pkgrel=5
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 url="https://llvm.org/"
@@ -74,6 +74,7 @@ source=(https://releases.llvm.org/${pkgver}/llvm-${pkgver}.src.tar.xz{,.sig}
         "0012-fix-testplugin-linking.patch"
         "0013-set-cxx-version.patch"
         "0014-winpthreads-workaround.patch"
+        "0015-cmake-symlinks.patch"
         "0101-Allow-build-static-clang-library-for-mingw.patch"
         "0102-fix-libclang-name-for-mingw.patch"
         "0103-Set-the-x86-arch-name-to-i686-for-mingw-w64.patch"
@@ -138,6 +139,7 @@ sha256sums=('8872be1b12c61450cacc82b3d153eab02be2546ef34fa3580ed14137bb26224c'
             'c486e1d45f6fb2a24823d776d2b47d6930530d423df73cc635f863265210c294'
             '656007a5eb587ac51e8d953fd28522c53cc56d297f2fa87ba818a0fe2ebd2b76'
             'cf726c9048de1a0e812192295803eed751235cd85347a8c967c29e3740565670'
+            'e4cf98b909589b750cf805435f618b9caae1fe307ef2e8ef71395351a39ef072'
             'b2e5fd29bf666998d495a321690c97fe239bb998abcf0739418ac0ea725fecd6'
             '01b029f2a21bd998ce374a90d41d214c891dfbb611dfbd9ca147517cd2c228ea'
             'ab49b90d69a609f441fa58e835873f2b1a8a060c9ca6358fee7d99c1973da692'
@@ -188,6 +190,7 @@ prepare() {
   patch -p1 -i "${srcdir}/0012-fix-testplugin-linking.patch"
   patch -p1 -i "${srcdir}/0013-set-cxx-version.patch"
   patch -p1 -i "${srcdir}/0014-winpthreads-workaround.patch"
+  patch -p1 -i "${srcdir}/0015-cmake-symlinks.patch"
 
   # https://bugs.llvm.org/show_bug.cgi?id=25493
   patch -p1 -i "${srcdir}/0006-add-coff-exported-flag.patch"

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -29,7 +29,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-llvm"
          "${MINGW_PACKAGE_PREFIX}-polly")
 pkgver=8.0.0
-pkgrel=3
+pkgrel=4
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 url="https://llvm.org/"
@@ -80,6 +80,7 @@ source=(https://releases.llvm.org/${pkgver}/llvm-${pkgver}.src.tar.xz{,.sig}
         "0104-link-pthread-with-mingw.patch"
         "0106-MinGW-use-flto-visibility-public-std-CC1-arg-to-get-.patch"
         "0201-mingw-w64-__udivdi3-mangle-hack.patch"
+        "0301-lld-mingw-flags.patch"
         "0401-mingw-w64-hack-and-slash-fixes-for-libc.patch"
         "0405-fix-conflict-win32-posix-threads.patch"
         "0406-fix-static_asserts-and-unique_ptr-for-libcxx.patch"
@@ -143,6 +144,7 @@ sha256sums=('8872be1b12c61450cacc82b3d153eab02be2546ef34fa3580ed14137bb26224c'
             '53646dd01af2862473e9719c5223366486268891ccbff86413943a432a8342e9'
             '3d6045cf35d5523c68baf87bd490007d4ac8fe3eabcbc23d8c66e80ff1c234e7'
             'bafaf7d06bec3ed7fba58e8a926e7b472b5e16442b6ee9dd8c7ee6c0cce9792a'
+            '13ccda3de2ce417724bb364d7cf38fe80094a6d9ea8d926216751ec3b5a7e705'
             'da44cca549bc7fb9e04f0f038a1ed68ba99cdfec834fc241ab13880bd0aa3b0f'
             '2f8f3c819837e4a16a364ed6e2a0a879cd10f924169ed7d89c27c1ed64edfe95'
             'a219798d0199e0b34c90fcdacada7e0f6d179fa4349a26bce8f714173046ecc7'
@@ -202,7 +204,8 @@ prepare() {
   cd "${srcdir}/compiler-rt-${pkgver}.src"
   patch -p1 -i "${srcdir}/0201-mingw-w64-__udivdi3-mangle-hack.patch"
 
-  #cd "${srcdir}/lld-${pkgver}.src"
+  cd "${srcdir}/lld-${pkgver}.src"
+  patch -p0 -i "${srcdir}/0301-lld-mingw-flags.patch"
 
   cd "${srcdir}/libcxx-${pkgver}.src"
   patch -p1 -i "${srcdir}/0401-mingw-w64-hack-and-slash-fixes-for-libc.patch"


### PR DESCRIPTION
and use symlinks instead of copies for all llvm tools.