### PR TITLE
Clang/lld: Fix g++ arguments parsing

### DIFF
--- a/mingw-w64-clang/0301-lld-mingw-flags.patch
+++ b/mingw-w64-clang/0301-lld-mingw-flags.patch
@@ -1,0 +1,28 @@
+Index: MinGW/Options.td
+===================================================================
+--- MinGW/Options.td
++++ MinGW/Options.td
+@@ -54,6 +54,11 @@
+ def require_defined: S<"require-defined">,
+     HelpText<"Force symbol to be added to symbol table as an undefined one">;
+ def require_defined_eq: J<"require-defined=">, Alias<require_defined>;
++// Strictly taken, the -u option allows for the symbol to remain undefined,
++// which this currently doesn't.
++def undefined: S<"u">, Alias<require_defined>;
++def undefined_long: S<"undefined">, Alias<require_defined>;
++def undefined_eq: J<"undefined=">, Alias<require_defined>;
+ 
+ // LLD specific options
+ def _HASH_HASH_HASH : Flag<["-"], "###">,
+Index: test/MinGW/driver.test
+===================================================================
+--- test/MinGW/driver.test
++++ test/MinGW/driver.test
+@@ -155,6 +155,7 @@
+ MAP: -lldmap:bar.map
+ 
+ RUN: ld.lld -### foo.o -m i386pe -require-defined _foo --require-defined _bar -require-defined=_baz --require-defined=_foo2 | FileCheck -check-prefix=REQUIRE-DEFINED %s
++RUN: ld.lld -### foo.o -m i386pe -u _foo --undefined _bar -undefined=_baz --undefined=_foo2 | FileCheck -check-prefix=REQUIRE-DEFINED %s
+ REQUIRE-DEFINED: -include:_foo -include:_bar -include:_baz -include:_foo2
+ 
+ RUN: ld.lld -### -m i386pep foo.o -Llibpath | FileCheck -check-prefix LIBPATH %s

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -29,7 +29,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-llvm"
          "${MINGW_PACKAGE_PREFIX}-polly")
 pkgver=8.0.0
-pkgrel=3
+pkgrel=4
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 url="https://llvm.org/"
@@ -80,6 +80,7 @@ source=(https://releases.llvm.org/${pkgver}/llvm-${pkgver}.src.tar.xz{,.sig}
         "0104-link-pthread-with-mingw.patch"
         "0106-MinGW-use-flto-visibility-public-std-CC1-arg-to-get-.patch"
         "0201-mingw-w64-__udivdi3-mangle-hack.patch"
+        "0301-lld-mingw-flags.patch"
         "0401-mingw-w64-hack-and-slash-fixes-for-libc.patch"
         "0405-fix-conflict-win32-posix-threads.patch"
         "0406-fix-static_asserts-and-unique_ptr-for-libcxx.patch"
@@ -143,6 +144,7 @@ sha256sums=('8872be1b12c61450cacc82b3d153eab02be2546ef34fa3580ed14137bb26224c'
             '53646dd01af2862473e9719c5223366486268891ccbff86413943a432a8342e9'
             '3d6045cf35d5523c68baf87bd490007d4ac8fe3eabcbc23d8c66e80ff1c234e7'
             'bafaf7d06bec3ed7fba58e8a926e7b472b5e16442b6ee9dd8c7ee6c0cce9792a'
+            '13ccda3de2ce417724bb364d7cf38fe80094a6d9ea8d926216751ec3b5a7e705'
             'da44cca549bc7fb9e04f0f038a1ed68ba99cdfec834fc241ab13880bd0aa3b0f'
             '2f8f3c819837e4a16a364ed6e2a0a879cd10f924169ed7d89c27c1ed64edfe95'
             'a219798d0199e0b34c90fcdacada7e0f6d179fa4349a26bce8f714173046ecc7'
@@ -202,7 +204,8 @@ prepare() {
   cd "${srcdir}/compiler-rt-${pkgver}.src"
   patch -p1 -i "${srcdir}/0201-mingw-w64-__udivdi3-mangle-hack.patch"
 
-  #cd "${srcdir}/lld-${pkgver}.src"
+  cd "${srcdir}/lld-${pkgver}.src"
+  patch -p0 -i "${srcdir}/0301-lld-mingw-flags.patch"
 
   cd "${srcdir}/libcxx-${pkgver}.src"
   patch -p1 -i "${srcdir}/0401-mingw-w64-hack-and-slash-fixes-for-libc.patch"


### PR DESCRIPTION
Upstream patch: https://reviews.llvm.org/D62876