### PR TITLE
appstream-glib-0.7.15 - 2 f- fix bad path references in files.

### DIFF
--- a/mingw-w64-appstream-glib/PKGBUILD
+++ b/mingw-w64-appstream-glib/PKGBUILD
@@ -9,6 +9,7 @@ arch=('any')
 pkgdesc="Objects and methods for reading and writing AppStream metadata (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-gdk-pixbuf2"
          "${MINGW_PACKAGE_PREFIX}-glib2"
+         "${MINGW_PACKAGE_PREFIX}-gtk2"
          "${MINGW_PACKAGE_PREFIX}-gtk3"
          "${MINGW_PACKAGE_PREFIX}-json-glib"
          "${MINGW_PACKAGE_PREFIX}-libyaml"

--- a/mingw-w64-appstream-glib/PKGBUILD
+++ b/mingw-w64-appstream-glib/PKGBUILD
@@ -4,7 +4,7 @@ _realname=appstream-glib
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.7.15
-pkgrel=1
+pkgrel=2
 arch=('any')
 pkgdesc="Objects and methods for reading and writing AppStream metadata (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-gdk-pixbuf2"
@@ -59,6 +59,11 @@ build() {
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   DESTDIR="${pkgdir}${MINGW_PREFIX}" ninja install
+  local _PRE_WIN="$(cygpath -m /)"
+  sed -e "s|${_PRE_WIN}|${MINGW_PREFIX}|g" \
+    -i ${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/appstream-glib.pc \
+    -i ${pkgdir}${MINGW_PREFIX}/share/installed-tests/appstream-glib/appdata-validate.test \
+    -i ${pkgdir}${MINGW_PREFIX}/share/installed-tests/appstream-glib/destdir-check.test
 
   install -Dm644 "${srcdir}/${_realname}-${_realname//-/_}_${pkgver//./_}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }


### PR DESCRIPTION
Found when rebuilding annd with the command

"find pkg -type f -exec grep -nH "$(cygpath -m /)" {} \;"