### PR TITLE
fix pyscript2exe.py so that it provides the propper shabbang just lik…

### DIFF
--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -7,7 +7,7 @@ _realname=glib2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.60.3
-pkgrel=1
+pkgrel=3
 url="https://www.gtk.org/"
 arch=('any')
 pkgdesc="Common C routines used by GTK+ 2.4 and other libs (mingw-w64)"
@@ -36,7 +36,7 @@ sha256sums=('04ab0d560d45790d055f50db2d69974eab8b693a77390075462c56e652b760b9'
             '0f44135a139e3951c4b5fa7d4628d75226e0666d891faf524777e1d1ec3b440b'
             '601b4da43aeccfa522ea46fcb9c33ec9530b8c4b965b8964abd3f4972b769cdd'
             'c7da07a48604ecbba4d88cf1a5dc1f5d9384886af3ecfdcb9ad6e7bf6ddd29bb'
-            'f68b24932b3365c4098c04eeaeaf87275ceec29694b3f0597c431bbcf4f913a3')
+            '00e03a8b9d45e620c6fabbf96f5ccb41d1e49cc9b35ccb846d423f235ad5bec6')
 
 prepare() {
   cd "${srcdir}/glib-${pkgver}"
@@ -84,13 +84,16 @@ package() {
 
   install -Dm644 "${srcdir}/glib-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 
+  local _PRE_WIN="$(cygpath -m ${MINGW_PREFIX})"
   for name in glib-mkenums glib-genmarshal gdbus-codegen gtester-report; do
     ${MINGW_PREFIX}/bin/python3 \
       "${srcdir}/pyscript2exe.py" "${pkgdir}${MINGW_PREFIX}/bin/${name}"
+    sed -e "s|${_PRE_WIN}|${MINGW_PREFIX}|g" \
+     -i ${pkgdir}${MINGW_PREFIX}/bin/${name}-script.py
   done
 
   for pcfile in  "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/*.pc; do
-    sed -s "s|$(cygpath -m ${MINGW_PREFIX})|${MINGW_PREFIX}|g" -i "${pcfile}"
+    sed -s "s|${_PRE_WIN}|${MINGW_PREFIX}|g" -i "${pcfile}"
     # https://github.com/Alexpux/MINGW-packages/issues/4364
     # https://gitlab.gnome.org/GNOME/glib/issues/1516
     sed -s "s| -lgiowin32||g" -i "${pcfile}"
@@ -98,5 +101,5 @@ package() {
     sed -s "s| -lcharset||g" -i "${pcfile}"
   done
 
-  sed -s "s|$(cygpath -m ${MINGW_PREFIX})|${MINGW_PREFIX}|g" -i "${pkgdir}${MINGW_PREFIX}/bin/glib-gettextize"
+  sed -s "s|${_PRE_WIN}|${MINGW_PREFIX}|g" -i "${pkgdir}${MINGW_PREFIX}/bin/glib-gettextize"
 }

--- a/mingw-w64-glib2/glib2-i686.install
+++ b/mingw-w64-glib2/glib2-i686.install
@@ -1,5 +1,13 @@
 post_install() {
   mingw32/bin/glib-compile-schemas.exe mingw32/share/glib-2.0/schemas
+  cd mingw32
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in gdbus-codegen glib-genmarshal glib-mkenums gtester-report; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i ${_prefix}/bin/${_it}-script.py
+  done
 }
 
 post_upgrade() {

--- a/mingw-w64-glib2/pyscript2exe.py
+++ b/mingw-w64-glib2/pyscript2exe.py
@@ -12,7 +12,7 @@ path = sys.argv[1]
 with open(path, "rb") as f:
     data = f.read()
 with open(path, "wb") as f:
-    shebang = "#!/usr/bin/env " + os.path.basename(sys.executable)
+    shebang = "#!" + os.path.join(sys.prefix, 'bin',os.path.basename(sys.executable))
     f.write(re.sub(b"^#![^\n\r]*", shebang.encode(), data))
 root, ext = os.path.splitext(path)
 with open(root + ".exe", "wb") as f:

--- a/mingw-w64-gobject-introspection/PKGBUILD
+++ b/mingw-w64-gobject-introspection/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-runtime")
 pkgver=1.60.1
-pkgrel=2
+pkgrel=3
 arch=('any')
 url="https://live.gnome.org/GObjectIntrospection"
 license=("LGPL")
@@ -38,7 +38,7 @@ sha256sums=('d844d1499ecd36f3ec8a3573616186d36626ec0c9a7981939e99aa02e9c824b3'
             '7a256fe30eb5db3e2216ae7862b4f20c6691e7a01de4c480091f03d1e4e9f4ba'
             '19ca830262339c4ac9f21bfb8d669ee8e126a949a4237d55656e00c5ae81c451'
             '3f38bdd0dd43d9cf626cbca7c2abd22a7ed0213e6756252c6d467d470d9c5948'
-            'f68b24932b3365c4098c04eeaeaf87275ceec29694b3f0597c431bbcf4f913a3')
+            '00e03a8b9d45e620c6fabbf96f5ccb41d1e49cc9b35ccb846d423f235ad5bec6')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
@@ -72,18 +72,22 @@ package_gobject-introspection() {
            "${MINGW_PACKAGE_PREFIX}-python3"
            "${MINGW_PACKAGE_PREFIX}-python3-mako")
   options=('!emptydirs')
+  install=${_realname}-${CARCH}.install
 
   cd "${srcdir}/build-${MINGW_CHOST}"
 
   DESTDIR="${pkgdir}${MINGW_PREFIX}" ninja install
 
+  local _PRE_WIN="$(cygpath -m ${MINGW_PREFIX})"
   for name in g-ir-scanner g-ir-doc-tool g-ir-annotation-tool; do
     ${MINGW_PREFIX}/bin/python3 \
       "${srcdir}/pyscript2exe.py" "${pkgdir}${MINGW_PREFIX}/bin/${name}"
+    sed -e "s|${_PRE_WIN}|${MINGW_PREFIX}|g" \
+      -i ${pkgdir}${MINGW_PREFIX}/bin/${name}-script.py
   done
 
   for pcfile in  "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/*.pc; do
-    sed -s "s|$(cygpath -m ${MINGW_PREFIX})|${MINGW_PREFIX}|g" -i "${pcfile}"
+    sed -s "s|${_PRE_WIN}|${MINGW_PREFIX}|g" -i "${pcfile}"
   done
 
   rm "${pkgdir}${MINGW_PREFIX}/bin/libgirepository"*.dll

--- a/mingw-w64-gobject-introspection/gobject-introspection-i686.install
+++ b/mingw-w64-gobject-introspection/gobject-introspection-i686.install
@@ -1,10 +1,9 @@
 post_install() {
-  mingw64/bin/glib-compile-schemas.exe mingw64/share/glib-2.0/schemas
-  cd mingw64
+  cd mingw32
   local _prefix=$(pwd -W)
   cd -
   local _it
-  for _it in gdbus-codegen glib-genmarshal glib-mkenums gtester-report; do
+  for _it in g-ir-scanner g-ir-doc-tool g-ir-annotation-tool; do
     sed -e "s|/mingw32|${_prefix}|g" \
         -i ${_prefix}/bin/${_it}-script.py
   done

--- a/mingw-w64-gobject-introspection/gobject-introspection-x86_64.install
+++ b/mingw-w64-gobject-introspection/gobject-introspection-x86_64.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw64
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in g-ir-scanner g-ir-doc-tool g-ir-annotation-tool; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i ${_prefix}/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-gobject-introspection/pyscript2exe.py
+++ b/mingw-w64-gobject-introspection/pyscript2exe.py
@@ -12,7 +12,7 @@ path = sys.argv[1]
 with open(path, "rb") as f:
     data = f.read()
 with open(path, "wb") as f:
-    shebang = "#!/usr/bin/env " + os.path.basename(sys.executable)
+    shebang = "#!" + os.path.join(sys.prefix, 'bin',os.path.basename(sys.executable))
     f.write(re.sub(b"^#![^\n\r]*", shebang.encode(), data))
 root, ext = os.path.splitext(path)
 with open(root + ".exe", "wb") as f:

--- a/mingw-w64-gtk-doc/PKGBUILD
+++ b/mingw-w64-gtk-doc/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gtk-doc
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.30
-pkgrel=1
+pkgrel=2
 pkgdesc="Documentation tool for public library API (mingw-w64)"
 arch=('any')
 url="https://www.gtk.org/gtk-doc/"
@@ -25,7 +25,7 @@ url="https://www.gtk.org/gtk-doc/"
 source=(https://download.gnome.org/sources/${_realname}/${pkgver}/${_realname}-${pkgver}.tar.xz
         pyscript2exe.py)
 sha256sums=('a4f6448eb838ccd30d76a33b1fd095f81aea361f03b12c7b23df181d21b7069e'
-            'f68b24932b3365c4098c04eeaeaf87275ceec29694b3f0597c431bbcf4f913a3')
+            '00e03a8b9d45e620c6fabbf96f5ccb41d1e49cc9b35ccb846d423f235ad5bec6')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -58,12 +58,16 @@ build() {
 }
 
 package() {
+  install=${_realname}-${CARCH}.install
   cd "${srcdir}/build-${MINGW_CHOST}"
 
   make DESTDIR="$pkgdir" install
 
+  local _PRE_WIN="$(cygpath -m ${MINGW_PREFIX})"
   for name in check fixxref mkdb mkhtml mkman mkpdf rebase scan scangobj depscan mkhtml2; do
     ${MINGW_PREFIX}/bin/python3 \
       "${srcdir}/pyscript2exe.py" "${pkgdir}${MINGW_PREFIX}/bin/gtkdoc-${name}"
+    sed -e "s|${_PRE_WIN}|${MINGW_PREFIX}|g" \
+      -i "${pkgdir}${MINGW_PREFIX}/bin/gtkdoc-${name}-script.py"
   done
 }

--- a/mingw-w64-gtk-doc/gtk-doc-i686.install
+++ b/mingw-w64-gtk-doc/gtk-doc-i686.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw32
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in check fixxref mkdb mkhtml mkman mkpdf rebase scan scangobj depscan mkhtml2; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i ${_prefix}/bin/gtkdoc-${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-gtk-doc/gtk-doc-x86_64.install
+++ b/mingw-w64-gtk-doc/gtk-doc-x86_64.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw64
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in check fixxref mkdb mkhtml mkman mkpdf rebase scan scangobj depscan mkhtml2; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i ${_prefix}/bin/gtkdoc-${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-gtk-doc/pyscript2exe.py
+++ b/mingw-w64-gtk-doc/pyscript2exe.py
@@ -12,7 +12,7 @@ path = sys.argv[1]
 with open(path, "rb") as f:
     data = f.read()
 with open(path, "wb") as f:
-    shebang = "#!/usr/bin/env " + os.path.basename(sys.executable)
+    shebang = "#!" + os.path.join(sys.prefix, 'bin',os.path.basename(sys.executable))
     f.write(re.sub(b"^#![^\n\r]*", shebang.encode(), data))
 root, ext = os.path.splitext(path)
 with open(root + ".exe", "wb") as f:

--- a/mingw-w64-itstool/PKGBUILD
+++ b/mingw-w64-itstool/PKGBUILD
@@ -4,7 +4,7 @@ _realname=itstool
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.0.6
-pkgrel=1
+pkgrel=2
 arch=('any')
 pkgdesc="XML to PO and back again (mingw-w64)"
 url="http://itstool.org/"
@@ -17,7 +17,7 @@ source=(http://files.itstool.org/itstool/${_realname}-${pkgver}.tar.bz2
         'pyscript2exe.py')
 sha256sums=('6233cc22726a9a5a83664bf67d1af79549a298c23185d926c3677afa917b92a9'
             'f292bcd116da4ea36ee9c42e206dbd9151d147da1ef5a078e743fc9ed0a4ab47'
-            'f68b24932b3365c4098c04eeaeaf87275ceec29694b3f0597c431bbcf4f913a3')
+            '00e03a8b9d45e620c6fabbf96f5ccb41d1e49cc9b35ccb846d423f235ad5bec6')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -48,9 +48,13 @@ check() {
 }
 
 package() {
+  install=${_realname}-${CARCH}.install
   cd "${srcdir}/build-${CHOST}"
 
   make DESTDIR="${pkgdir}" install
 
   ${MINGW_PREFIX}/bin/python2 "${srcdir}/pyscript2exe.py" "${pkgdir}${MINGW_PREFIX}/bin/itstool"
+  local _PRE_WIN="$(cygpath -m ${MINGW_PREFIX})"
+  sed -e "s|${_PRE_WIN}|${MINGW_PREFIX}|g" \
+    -i ${pkgdir}${MINGW_PREFIX}/bin/itstool-script.py
 }

--- a/mingw-w64-itstool/itstool-i686.install
+++ b/mingw-w64-itstool/itstool-i686.install
@@ -1,10 +1,9 @@
 post_install() {
-  mingw64/bin/glib-compile-schemas.exe mingw64/share/glib-2.0/schemas
-  cd mingw64
+  cd mingw32
   local _prefix=$(pwd -W)
   cd -
   local _it
-  for _it in gdbus-codegen glib-genmarshal glib-mkenums gtester-report; do
+  for _it in itstool; do
     sed -e "s|/mingw32|${_prefix}|g" \
         -i ${_prefix}/bin/${_it}-script.py
   done

--- a/mingw-w64-itstool/itstool-x86_64.install
+++ b/mingw-w64-itstool/itstool-x86_64.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw64
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in itstool; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i ${_prefix}/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-itstool/pyscript2exe.py
+++ b/mingw-w64-itstool/pyscript2exe.py
@@ -12,7 +12,7 @@ path = sys.argv[1]
 with open(path, "rb") as f:
     data = f.read()
 with open(path, "wb") as f:
-    shebang = "#!/usr/bin/env " + os.path.basename(sys.executable)
+    shebang = "#!" + os.path.join(sys.prefix, 'bin',os.path.basename(sys.executable))
     f.write(re.sub(b"^#![^\n\r]*", shebang.encode(), data))
 root, ext = os.path.splitext(path)
 with open(root + ".exe", "wb") as f:


### PR DESCRIPTION
…e setuptools and then change the sshabbang for the user's particular system

mingw-w64-glib2
mingw-w64-gobject-introspection
mingw-w64-gtk-doc
mingw-w64-itstool

Note that the shabbang should be a file name and not "/usr/bin/env python2.exe" or something like that.  The env command is for accessing something in the environment.  I think this could be effecting some Gnome-build scripts.