### PR TITLE
Yelp Tools version for mingw

### DIFF
--- a/mingw-w64-python3-mallard-ducktype/PKGBUILD
+++ b/mingw-w64-python3-mallard-ducktype/PKGBUILD
@@ -1,0 +1,87 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_realname=mallard-ducktype
+pkgbase=mingw-w64-python-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
+pkgver=1.0.1
+pkgrel=1
+pkgdesc="Parser for the lightweight Ducktype syntax for Mallard (mingw-w64)"
+arch=('any')
+url='http://projectmallard.org/'
+license=('MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-python3")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools")
+options=('staticlibs' 'strip' '!debug')
+source=("${_realname}-$pkgver.tar.gz"::"https://github.com/projectmallard/mallard-ducktype/archive/$pkgver.tar.gz")
+sha256sums=('1c7ca0d1a34d20bc03509760b46f5e0729562825c4a7f39eba9f4b497cd858c5')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
+prepare() {
+  cd "${srcdir}"
+  for builddir in python{2,3}-build-${CARCH}; do
+    rm -rf ${builddir} | true
+    cp -r "${_realname}-${pkgver}" "${builddir}"
+  done
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
+}
+
+# Note that build() is sometimes skipped because it's done in 
+# the packages setup.py install for simplicity if you can do so.
+# but sometimes, you want to do a check before install which would
+# also trigger the build.
+build() {
+    msg "Python 3 build for ${CARCH}"  
+    cd "${srcdir}/python3-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python3 setup.py build
+}
+
+check() {
+    msg "Python 3 test for ${CARCH}"
+    cd "${srcdir}/python3-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python3 setup.py test
+}
+
+package() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+  #This package install is needed for .fixups with .EXE's 
+  #in the bit directory.  The install files "python-exe-installs"
+  #and should be renamed to your _realname .
+  install=${_realname}3-${CARCH}.install
+
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+#  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+
+# This entire section should be removed if the package does NOT install
+# anything in the /mingw*/bin directory.
+### begin section ###
+  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+  # fix python command in files
+  for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*; do
+    sed -e "s|/usr/bin/env |${MINGW_PREFIX}|g" \
+        -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${_f}
+  done
+#### end section ####
+}

--- a/mingw-w64-python3-mallard-ducktype/mallard-ducktype3-i686.install
+++ b/mingw-w64-python3-mallard-ducktype/mallard-ducktype3-i686.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw32
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in ducktype; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i ${_prefix}/bin/${_it}
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-python3-mallard-ducktype/mallard-ducktype3-x86_64.install
+++ b/mingw-w64-python3-mallard-ducktype/mallard-ducktype3-x86_64.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw64
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in ducktype; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i ${_prefix}/bin/${_it}
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-yelp-tools/PKGBUILD
+++ b/mingw-w64-yelp-tools/PKGBUILD
@@ -1,0 +1,57 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_realname=yelp-tools
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=3.32.1
+pkgrel=1
+pkgdesc="Tools for creating Yelp documentation (mingw-w64)"
+arch=('any')
+license=('GPL')
+url="https://www.gnome.org"
+depends=("intltool"
+         "${MINGW_PACKAGE_PREFIX}-libxml2"
+         "${MINGW_PACKAGE_PREFIX}-libxslt" 
+         "${MINGW_PACKAGE_PREFIX}-itstool"
+         "${MINGW_PACKAGE_PREFIX}-python3-mallard-ducktype"
+         "${MINGW_PACKAGE_PREFIX}-yelp-xsl")
+options=('strip' '!libtool' 'staticlibs')
+source=(https://download.gnome.org/sources/${_realname}/${pkgver:0:4}/${_realname}-$pkgver.tar.xz
+        yelp-no-symlinks.patch)
+sha256sums=('99a7c312a5fcb427870dc198af02801eb0f8ea63317e20110fc0303eb44636e3'
+            'f5cdcdc450d2689196e37855f1fa3bcd2b4459563b1bf147c8b01e7e8b735979')
+
+prepare() {
+  cd ${srcdir}/${_realname}-${pkgver}
+  patch -p1 -i ${srcdir}/yelp-no-symlinks.patch
+  autoreconf -ivf
+}
+
+build() {
+  export PYTHON=${MINGW_PREFIX}/bin/python3
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+  ${srcdir}/${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${CHOST} \
+    --host=${CHOST} \
+    --sysconfdir=${MINGW_PREFIX}/etc \
+    --localstatedir=${MINGW_PREFIX}/var
+
+  make
+}
+
+package() {
+  cd ${srcdir}/build-${CARCH}
+  make DESTDIR="${pkgdir}" install
+  local WIN_PREFIX="$(cygpath -m /)"
+  for ff in yelp-build yelp-check yelp-new; do
+    sed -e "s| xsltproc| ${MINGW_PREFIX}/bin/xsltproc|g" \
+     -e "s|${WIN_PREFIX}|${MINGW_PREFIX}|g" \
+     -i ${pkgdir}/${MINGW_PREFIX}/bin/$ff
+  done
+  for ff in mal-ncx mal-opf; do
+    sed -e "s|${WIN_PREFIX}|${MINGW_PREFIX}|g" \
+     -i ${pkgdir}${MINGW_PREFIX}/share/yelp-tools/xslt/$ff.xsl
+  done
+}

--- a/mingw-w64-yelp-tools/yelp-no-symlinks.patch
+++ b/mingw-w64-yelp-tools/yelp-no-symlinks.patch
@@ -1,0 +1,14 @@
+--- yelp-tools-3.12.1/tools/yelp.m4.orig	2014-02-02 23:28:10.000000000 +0400
++++ yelp-tools-3.12.1/tools/yelp.m4	2014-07-22 18:58:17.925000000 +0400
+@@ -177,11 +177,6 @@
+ 	    if test -f "$$d$$lc/$$f"; then \
+ 	      echo "$(INSTALL_DATA) $$d$$lc/$$f $$helpdir$$f"; \
+ 	      $(INSTALL_DATA) "$$d$$lc/$$f" "$$helpdir$$f" || exit 1; \
+-	    elif test "x$$lc" != "xC"; then \
+-	      if test "x$(YELP_LC_MEDIA_LINKS)" != "x"; then \
+-	        echo "$(LN_S) -f $(HELP_DIR)/C/$(HELP_ID)/$$f $$helpdir$$f"; \
+-	        $(LN_S) -f "$(HELP_DIR)/C/$(HELP_ID)/$$f" "$$helpdir$$f" || exit 1; \
+-	      fi; \
+ 	    fi; \
+ 	  done; \
+ 	done

--- a/mingw-w64-yelp-xsl/PKGBUILD
+++ b/mingw-w64-yelp-xsl/PKGBUILD
@@ -1,0 +1,52 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_realname=yelp-xsl
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=3.32.1
+pkgrel=1
+pkgdesc="Stylesheets for Yelp (mingw-w64)"
+arch=('any')
+license=('GPL')
+url="https://www.gnome.org"
+options=('strip' '!libtool' 'staticlibs')
+makedepends=("intltool"
+             "${MINGW_PACKAGE_PREFIX}-itstool"
+             "${MINGW_PACKAGE_PREFIX}-libxml2" 
+             "${MINGW_PACKAGE_PREFIX}-libxslt"
+             "${MINGW_PACKAGE_PREFIX}-python3-mallard-ducktype")
+source=(https://download.gnome.org/sources/${_realname}/${pkgver:0:4}/${_realname}-${pkgver}.tar.xz)
+sha256sums=('cac31bc150545d6aa0de15dce04560cbf591008d17a783a1d1d9cdd47b147f04')
+
+prepare() {
+  cd ${srcdir}/${_realname}-${pkgver}
+  autoreconf -ivf
+}
+
+build() {
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+  PYTHON=${MINGW_PREFIX}/bin/python3 \
+  ../${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --sysconfdir=${MINGW_PREFIX}/etc \
+    --localstatedir=${MINGW_PREFIX}/var \
+    --enable-doc 
+
+  make
+}
+
+check() {
+  cd ${srcdir}/build-${CARCH}
+  make -k check
+}
+
+package() {
+  cd ${srcdir}/build-${CARCH}
+  make DESTDIR="${pkgdir}" install
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/lib
+  mv ${pkgdir}${MINGW_PREFIX}/share/pkgconfig ${pkgdir}${MINGW_PREFIX}/lib/
+}


### PR DESCRIPTION
python3-mallard-ducktype - 1.0.1 - New package - required to build yelp-xsl and for yelp-tools
yelp-xsl - 3.32.1 - New package - Style-sheets for yelp
yelp-tools - 3.32.1 - New package - Tools for creating Yelp Documentation