### PR TITLE
python-importlib-metadata: fix missing configparser dep

### DIFF
--- a/mingw-w64-python-importlib-metadata/PKGBUILD
+++ b/mingw-w64-python-importlib-metadata/PKGBUILD
@@ -4,7 +4,7 @@ _realname=importlib-metadata
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=0.17
-pkgrel=1
+pkgrel=2
 pkgdesc="Read metadata from Python packages (mingw-w64)"
 arch=('any')
 url='https://importlib-metadata.readthedocs.io/'
@@ -97,7 +97,8 @@ package_python2-importlib-metadata() {
   depends=("${MINGW_PACKAGE_PREFIX}-python2"
            "${MINGW_PACKAGE_PREFIX}-python2-contextlib2" 
            "${MINGW_PACKAGE_PREFIX}-python2-pathlib2"
-           "${MINGW_PACKAGE_PREFIX}-python2-zipp")
+           "${MINGW_PACKAGE_PREFIX}-python2-zipp"
+           "${MINGW_PACKAGE_PREFIX}-python2-configparser")
 
  cd "${srcdir}/python2-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \


### PR DESCRIPTION
```python
$ python2 -c "import importlib_metadata"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:/msys64/mingw64/lib/python2.7/site-packages/importlib_metadata/__init__.py", line 14, in <module>
    from ._compat import (
  File "C:/msys64/mingw64/lib/python2.7/site-packages/importlib_metadata/_compat.py", line 19, in <module>
    from backports.configparser import ConfigParser
ImportError: No module named configparser
```