### PR TITLE
osm-gps-map: clean up dependencies

### DIFF
--- a/mingw-w64-osm-gps-map/PKGBUILD
+++ b/mingw-w64-osm-gps-map/PKGBUILD
@@ -4,24 +4,20 @@ _realname=osm-gps-map
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.1.0
-pkgrel=2
+pkgrel=3
 pkgdesc="A Gtk+ Widget for Displaying OpenStreetMap tiles. (mingw-w64)"
 arch=('any')
 url="https://nzjrs.github.io/osm-gps-map/"
 license=("GPLv2+")
 depends=(
-    "${MINGW_PACKAGE_PREFIX}-libxml2"
     "${MINGW_PACKAGE_PREFIX}-libsoup"
-    "${MINGW_PACKAGE_PREFIX}-python2"
     "${MINGW_PACKAGE_PREFIX}-gtk3"
-    "${MINGW_PACKAGE_PREFIX}-python2-gobject2"
-    "${MINGW_PACKAGE_PREFIX}-python2-cairo"
-    "${MINGW_PACKAGE_PREFIX}-python2-pygtk"
     "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
 )
 makedepends=(
     "${MINGW_PACKAGE_PREFIX}-gcc"
     "${MINGW_PACKAGE_PREFIX}-libtool"
+    "${MINGW_PACKAGE_PREFIX}-gnome-common"
 )
 
 source=( https://github.com/nzjrs/osm-gps-map/releases/download/${pkgver}/${_realname}-${pkgver}.tar.gz) 


### PR DESCRIPTION
It's pulling in python2/gtk2 but they are not used anymore.