### PR TITLE
New packages libheif and libde265

### DIFF
--- a/mingw-w64-libde265/001-fix-VPATH.patch
+++ b/mingw-w64-libde265/001-fix-VPATH.patch
@@ -1,0 +1,20 @@
+diff -Naur libde265-1.0.3.orig/sherlock265/Makefile.am libde265-1.0.3/sherlock265/Makefile.am
+--- libde265-1.0.3.orig/sherlock265/Makefile.am	2016-06-23 03:31:00.000000000 -0500
++++ libde265-1.0.3/sherlock265/Makefile.am	2018-07-16 05:31:16.578125000 -0500
+@@ -37,13 +37,13 @@
+ endif
+ 
+ moc_VideoWidget.cpp: VideoWidget.hh
+-	$(QTMOC) $(DEFINES) $(INCPATH) VideoWidget.hh -o moc_VideoWidget.cpp
++	$(QTMOC) $(DEFINES) $(INCPATH) $(srcdir)/VideoWidget.hh -o moc_VideoWidget.cpp
+ 
+ moc_VideoPlayer.cpp: VideoPlayer.hh
+-	$(QTMOC) $(DEFINES) $(INCPATH) VideoPlayer.hh -o moc_VideoPlayer.cpp
++	$(QTMOC) $(DEFINES) $(INCPATH) $(srcdir)/VideoPlayer.hh -o moc_VideoPlayer.cpp
+ 
+ moc_VideoDecoder.cpp: VideoDecoder.hh
+-	$(QTMOC) $(DEFINES) $(INCPATH) VideoDecoder.hh -o moc_VideoDecoder.cpp
++	$(QTMOC) $(DEFINES) $(INCPATH) $(srcdir)/VideoDecoder.hh -o moc_VideoDecoder.cpp
+ 
+ EXTRA_DIST = \
+   README

--- a/mingw-w64-libde265/002-use-new-FFMPEG-enum-names.patch
+++ b/mingw-w64-libde265/002-use-new-FFMPEG-enum-names.patch
@@ -1,0 +1,22 @@
+From e5b8e2e703d608777afadc54955bd396e4211da0 Mon Sep 17 00:00:00 2001
+From: Dirk Farin <farin@struktur.de>
+Date: Thu, 19 Apr 2018 13:15:18 +0200
+Subject: [PATCH] use new FFMPEG enum names
+
+---
+ sherlock265/VideoDecoder.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sherlock265/VideoDecoder.cc b/sherlock265/VideoDecoder.cc
+index 119f6152..b829e1c7 100644
+--- a/sherlock265/VideoDecoder.cc
++++ b/sherlock265/VideoDecoder.cc
+@@ -237,7 +237,7 @@ void VideoDecoder::convert_frame_swscale(const de265_image* img, QImage & qimg)
+     }
+     width = img->get_width();
+     height = img->get_height();
+-    sws = sws_getContext(width, height, PIX_FMT_YUV420P, width, height, PIX_FMT_BGRA, SWS_FAST_BILINEAR, NULL, NULL, NULL);
++    sws = sws_getContext(width, height, AV_PIX_FMT_YUV420P, width, height, AV_PIX_FMT_BGRA, SWS_FAST_BILINEAR, NULL, NULL, NULL);
+   }
+ 
+   int stride[3];

--- a/mingw-w64-libde265/PKGBUILD
+++ b/mingw-w64-libde265/PKGBUILD
@@ -1,0 +1,52 @@
+# Contributor: Edward E. <develinthedetail@gmail.com>
+
+_realname=libde265
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.0.3
+pkgrel=1
+pkgdesc="Open h.265 video codec library (mingw-w64)"
+arch=('any')
+url="https://github.com/strukturag/libde265"
+license=(LGPL3' GPL3')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+optdepends=("${MINGW_PACKAGE_PREFIX}-ffmpeg: sherlock265"
+            "${MINGW_PACKAGE_PREFIX}-qt5: sherlock265"
+            "${MINGW_PACKAGE_PREFIX}-SDL: dec265")
+options=('strip')
+source=("https://github.com/strukturag/libde265/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz"
+        "001-fix-VPATH.patch"
+        "002-use-new-FFMPEG-enum-names.patch") # https://github.com/strukturag/libde265/commit/e5b8e2e7.patch
+sha256sums=('e4206185a7c67d3b797d6537df8dcaa6e5fd5a5f93bd14e65a755c33cd645f7a'
+            'b4cdce2b362fde574512c2fad2e479f27969c0fe4df241322d9915d189dcb763'
+            'ba043c3ab34d93818d368f703926b8e4d4b822168d2236d2685458a40f70645b')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  patch -p1 -i ${srcdir}/001-fix-VPATH.patch
+  patch -p1 -i ${srcdir}/002-use-new-FFMPEG-enum-names.patch
+
+  ./autogen.sh
+}
+
+build() {
+  [[ -d "${srcdir}"/build-${MINGW_CHOST} ]] && rm -rf "${srcdir}"/build-${MINGW_CHOST}
+  mkdir -p "${srcdir}"/build-${MINGW_CHOST} && cd "${srcdir}"/build-${MINGW_CHOST}
+
+  ../${_realname}-${pkgver}/configure \
+    CPPFLAGS='-I$(top_srcdir)/libde265 -I$(top_srcdir) -I$(top_srcdir)/sherlock265' \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST}
+
+  make
+}
+
+package() {
+  cd "${srcdir}"/build-${MINGW_CHOST}
+  make DESTDIR="${pkgdir}" install
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}

--- a/mingw-w64-libheif/PKGBUILD
+++ b/mingw-w64-libheif/PKGBUILD
@@ -1,0 +1,41 @@
+# Contributor: Edward E. <develinthedetail@gmail.com>
+
+_realname=libheif
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.4.0
+pkgrel=1
+pkgdesc="HEIF image decoder/encoder library and tools (mingw-w64)"
+arch=('any')
+url="https://github.com/strukturag/libheif"
+license=('LGPL3' 'MIT')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-libde265"
+         "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
+         "${MINGW_PACKAGE_PREFIX}-libpng"
+         "${MINGW_PACKAGE_PREFIX}-libwinpthread-git"
+         "${MINGW_PACKAGE_PREFIX}-x265")
+options=('strip')
+source=("https://github.com/strukturag/libheif/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('977a9831f1d61b5005566945c7e16e31de35a57a8dd6eb715ae0f40a3595cb60')
+
+build() {
+  [[ -d "${srcdir}"/build-${MINGW_CHOST} ]] && rm -rf "${srcdir}"/build-${MINGW_CHOST}
+  mkdir -p "${srcdir}"/build-${MINGW_CHOST} && cd "${srcdir}"/build-${MINGW_CHOST}
+
+  ../${_realname}-${pkgver}/configure \
+    --disable-gdk-pixbuf \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST}
+
+  make
+}
+
+package() {
+  cd "${srcdir}"/build-${MINGW_CHOST}
+  make DESTDIR="${pkgdir}" install
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}


### PR DESCRIPTION
[Libheif](https://github.com/strukturag/libheif), which requires [libde265](https://github.com/strukturag/libde265), is a codec library for Apple's .heic image files. Packages in mingw-w64 that can use it include GIMP, ImageMagick, and Krita.

@jernejs and @lillolollo may like to know about this being available.