### PR TITLE
python-can: update to 3.2.0

### DIFF
--- a/mingw-w64-python-can/PKGBUILD
+++ b/mingw-w64-python-can/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=can
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=3.1.1
+pkgver=3.2.0
 pkgrel=1
 pkgdesc="Provides controller area network (CAN) support for Python developers (mingw-w64)"
 arch=('any')
@@ -28,11 +28,9 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python2-mock"
               "${MINGW_PACKAGE_PREFIX}-python3-future"
               "${MINGW_PACKAGE_PREFIX}-python3-six")
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/hardbyte/python-can/archive/${pkgver}.tar.gz)
-sha256sums=('c25b9e6be656877720af81c91014cf6ad078de70b76fa443c7b7eee9624452f6')
+sha256sums=('8c7744438769f88d76de972b5637ea4dd6045929637d25fa5fba5f55e882f2d9')
 
 prepare() {
-  cd "${srcdir}/python-${_realname}-${pkgver}"
-
   cd "${srcdir}"
   for pver in {2,3}; do 
     rm -rf python${pver}-build-${CARCH} | true


### PR DESCRIPTION
This updates python-can to 3.2.0.