### PR TITLE
gcc-git: Add Ada and object c build guards

### DIFF
--- a/mingw-w64-gcc-git/0017-gcc-7-branch-Enable-std-experimental-filesystem.patch
+++ b/mingw-w64-gcc-git/0017-gcc-7-branch-Enable-std-experimental-filesystem.patch
@@ -4,10 +4,10 @@ Date: Wed, 10 May 2017 20:29:02 +0800
 Subject: [PATCH] Enable std::experimental::filesystem.
 
 ---
- libstdc++-v3/src/filesystem/dir.cc     | 24 +++++----
- libstdc++-v3/src/filesystem/fs-posix.h | 49 ++++++++++++++++++
- libstdc++-v3/src/filesystem/fs-win32.h | 64 ++++++++++++++++++++++++
- libstdc++-v3/src/filesystem/ops.cc     | 91 ++++++++++++++++++++--------------
+ libstdc++-v3/src/filesystem/dir.cc     | 24 +++----
+ libstdc++-v3/src/filesystem/fs-posix.h | 49 ++++++++++++++
+ libstdc++-v3/src/filesystem/fs-win32.h | 64 ++++++++++++++++++
+ libstdc++-v3/src/filesystem/ops.cc     | 91 ++++++++++++++++----------
  libstdc++-v3/src/filesystem/path.cc    |  2 +-
  5 files changed, 182 insertions(+), 48 deletions(-)
  create mode 100644 libstdc++-v3/src/filesystem/fs-posix.h
@@ -224,7 +224,7 @@ index 00000000000..23053343fc0
 +
 +#endif // _GLIBCXX_EXPERIMENTAL_FS_WIN32_H
 diff --git a/libstdc++-v3/src/filesystem/ops.cc b/libstdc++-v3/src/filesystem/ops.cc
-index 8de3511346e..dfccb8f9b50 100644
+index 397a8d7ffe7..0621184f3c3 100644
 --- a/libstdc++-v3/src/filesystem/ops.cc
 +++ b/libstdc++-v3/src/filesystem/ops.cc
 @@ -56,11 +56,10 @@
@@ -367,11 +367,11 @@ index 8de3511346e..dfccb8f9b50 100644
 +    if (::os_mkdir(p.c_str(), mode))
 +#else
 +    if (::os_mkdir(p.c_str()))
-+#endif // _GLIBCXX_FILESYSTEM_IS_WINDOWS
++#endif // _GLIBCXX_FILESYSTEM_IS_WINDOW
        {
  	const int err = errno;
- 	if (err != EEXIST || !is_directory(p))
-@@ -772,7 +781,7 @@ fs::create_directory(const path& p, const path& attributes,
+ 	if (err != EEXIST || !is_directory(p, ec))
+@@ -770,7 +779,7 @@ fs::create_directory(const path& p, const path& attributes,
  {
  #ifdef _GLIBCXX_HAVE_SYS_STAT_H
    stat_type st;
@@ -380,7 +380,7 @@ index 8de3511346e..dfccb8f9b50 100644
      {
        ec.assign(errno, std::generic_category());
        return false;
-@@ -821,7 +830,7 @@ void
+@@ -819,7 +828,7 @@ void
  fs::create_hard_link(const path& to, const path& new_hard_link,
  		     error_code& ec) noexcept
  {
@@ -389,7 +389,7 @@ index 8de3511346e..dfccb8f9b50 100644
    if (::link(to.c_str(), new_hard_link.c_str()))
      ec.assign(errno, std::generic_category());
    else
-@@ -845,7 +854,7 @@ void
+@@ -843,7 +852,7 @@ void
  fs::create_symlink(const path& to, const path& new_symlink,
  		   error_code& ec) noexcept
  {
@@ -398,7 +398,7 @@ index 8de3511346e..dfccb8f9b50 100644
    if (::symlink(to.c_str(), new_symlink.c_str()))
      ec.assign(errno, std::generic_category());
    else
-@@ -871,8 +880,8 @@ fs::current_path(error_code& ec)
+@@ -869,8 +878,8 @@ fs::current_path(error_code& ec)
  {
    path p;
  #ifdef _GLIBCXX_HAVE_UNISTD_H
@@ -409,7 +409,7 @@ index 8de3511346e..dfccb8f9b50 100644
      {
        p.assign(cwd.get());
        ec.clear();
-@@ -930,7 +939,7 @@ void
+@@ -928,7 +937,7 @@ void
  fs::current_path(const path& p, error_code& ec) noexcept
  {
  #ifdef _GLIBCXX_HAVE_UNISTD_H
@@ -418,7 +418,7 @@ index 8de3511346e..dfccb8f9b50 100644
      ec.assign(errno, std::generic_category());
    else
      ec.clear();
-@@ -957,14 +966,14 @@ fs::equivalent(const path& p1, const path& p2, error_code& ec) noexcept
+@@ -955,14 +964,14 @@ fs::equivalent(const path& p1, const path& p2, error_code& ec) noexcept
    int err = 0;
    file_status s1, s2;
    stat_type st1, st2;
@@ -435,7 +435,7 @@ index 8de3511346e..dfccb8f9b50 100644
      s2 = make_file_status(st2);
    else if (is_not_found_errno(errno))
      s2.type(file_type::not_found);
-@@ -1014,7 +1023,7 @@ namespace
+@@ -1012,7 +1021,7 @@ namespace
      {
  #ifdef _GLIBCXX_HAVE_SYS_STAT_H
        stat_type st;
@@ -444,7 +444,7 @@ index 8de3511346e..dfccb8f9b50 100644
  	{
  	  ec.assign(errno, std::generic_category());
  	  return deflt;
-@@ -1064,8 +1073,14 @@ fs::hard_link_count(const path& p)
+@@ -1062,8 +1071,14 @@ fs::hard_link_count(const path& p)
  std::uintmax_t
  fs::hard_link_count(const path& p, error_code& ec) noexcept
  {
@@ -459,7 +459,7 @@ index 8de3511346e..dfccb8f9b50 100644
  }
  
  bool
-@@ -1140,11 +1155,11 @@ fs::last_write_time(const path& p __attribute__((__unused__)),
+@@ -1138,11 +1153,11 @@ fs::last_write_time(const path& p __attribute__((__unused__)),
    else
      ec.clear();
  #elif _GLIBCXX_HAVE_UTIME_H
@@ -473,7 +473,7 @@ index 8de3511346e..dfccb8f9b50 100644
      ec.assign(errno, std::generic_category());
    else
      ec.clear();
-@@ -1197,7 +1212,7 @@ fs::permissions(const path& p, perms prms, error_code& ec) noexcept
+@@ -1195,7 +1210,7 @@ fs::permissions(const path& p, perms prms, error_code& ec) noexcept
  #else
    if (nofollow && is_symlink(st))
      ec = std::make_error_code(std::errc::operation_not_supported);
@@ -482,7 +482,7 @@ index 8de3511346e..dfccb8f9b50 100644
      err = errno;
  #endif
  
-@@ -1220,7 +1235,7 @@ fs::read_symlink(const path& p)
+@@ -1218,7 +1233,7 @@ fs::read_symlink(const path& p)
  fs::path fs::read_symlink(const path& p, error_code& ec)
  {
    path result;
@@ -491,7 +491,7 @@ index 8de3511346e..dfccb8f9b50 100644
    stat_type st;
    if (::lstat(p.c_str(), &st))
      {
-@@ -1274,7 +1289,7 @@ fs::remove(const path& p)
+@@ -1272,7 +1287,7 @@ fs::remove(const path& p)
  bool
  fs::remove(const path& p, error_code& ec) noexcept
  {
@@ -500,7 +500,7 @@ index 8de3511346e..dfccb8f9b50 100644
      {
        ec.clear();
        return true;
-@@ -1336,7 +1351,7 @@ fs::rename(const path& from, const path& to)
+@@ -1334,7 +1349,7 @@ fs::rename(const path& from, const path& to)
  void
  fs::rename(const path& from, const path& to, error_code& ec) noexcept
  {
@@ -509,7 +509,7 @@ index 8de3511346e..dfccb8f9b50 100644
      ec.assign(errno, std::generic_category());
    else
      ec.clear();
-@@ -1357,7 +1372,7 @@ fs::resize_file(const path& p, uintmax_t size, error_code& ec) noexcept
+@@ -1355,7 +1370,7 @@ fs::resize_file(const path& p, uintmax_t size, error_code& ec) noexcept
  #ifdef _GLIBCXX_HAVE_UNISTD_H
    if (size > static_cast<uintmax_t>(std::numeric_limits<off_t>::max()))
      ec.assign(EINVAL, std::generic_category());
@@ -518,7 +518,7 @@ index 8de3511346e..dfccb8f9b50 100644
      ec.assign(errno, std::generic_category());
    else
      ec.clear();
-@@ -1410,7 +1425,7 @@ fs::status(const fs::path& p, error_code& ec) noexcept
+@@ -1409,7 +1424,7 @@ fs::status(const fs::path& p, error_code& ec) noexcept
  {
    file_status status;
    stat_type st;
@@ -527,7 +527,7 @@ index 8de3511346e..dfccb8f9b50 100644
      {
        int err = errno;
        ec.assign(err, std::generic_category());
-@@ -1428,11 +1443,13 @@ fs::status(const fs::path& p, error_code& ec) noexcept
+@@ -1427,11 +1442,13 @@ fs::status(const fs::path& p, error_code& ec) noexcept
      }
    return status;
  }
@@ -541,7 +541,7 @@ index 8de3511346e..dfccb8f9b50 100644
    stat_type st;
    if (::lstat(p.c_str(), &st))
      {
-@@ -1446,9 +1463,11 @@ fs::symlink_status(const fs::path& p, std::error_code& ec) noexcept
+@@ -1445,9 +1462,11 @@ fs::symlink_status(const fs::path& p, std::error_code& ec) noexcept
        status = make_file_status(st);
        ec.clear();
      }
@@ -568,5 +568,3 @@ index c66d52bf4b0..c0ecb1e37d3 100644
    if (_M_type != _Type::_Multi)
      s = &_M_pathname;
 -- 
-2.15.0
-

--- a/mingw-w64-gcc-git/PKGBUILD
+++ b/mingw-w64-gcc-git/PKGBUILD
@@ -5,6 +5,8 @@
 # Contributor: Liu Hao <lh_mouse@126.com>
 # Contributor: Tim Stahlhut <stahta01@gmail.com>
 
+_enable_ada=no
+_enable_objc=no
 _realname=gcc
 _sourcedir=${_realname}-git
 pkgbase=mingw-w64-${_realname}-git
@@ -12,9 +14,10 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-libs-git"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-libgfortran-git"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-fortran-git"
-         "${MINGW_PACKAGE_PREFIX}-${_realname}-ada-git"
-         "${MINGW_PACKAGE_PREFIX}-${_realname}-objc-git")
-pkgver=9.1.1.d20190515.c10.gbdc6c4d09ec
+         $([[ "$_enable_ada" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-ada")
+         $([[ "$_enable_objc" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-objc")
+        )
+pkgver=9.1.1.d20190611.c10.ga33ff7d5fd0
 pkgrel=1
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
@@ -22,7 +25,7 @@ url="https://gcc.gnu.org"
 license=('GPL' 'LGPL' 'FDL' 'custom')
 groups=("${MINGW_PACKAGE_PREFIX}-toolchain")
 makedepends=("${MINGW_PACKAGE_PREFIX}-${_realname}"
-             "${MINGW_PACKAGE_PREFIX}-${_realname}-ada"
+             $([[ "$_enable_ada" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-ada")
              "${MINGW_PACKAGE_PREFIX}-binutils"
              "${MINGW_PACKAGE_PREFIX}-crt"
              "${MINGW_PACKAGE_PREFIX}-headers"
@@ -142,6 +145,14 @@ build() {
     ;;
   esac
 
+  local _languages="c,lto,c++,fortran"
+  if [ "$_enable_ada" == "yes" ]; then
+    _languages+=",ada"
+  fi
+  if [ "$_enable_objc" == "yes" ]; then
+    _languages+=",objc,obj-c++"
+  fi
+
   ../${_sourcedir}/configure \
     --prefix=${MINGW_PREFIX} \
     --with-local-prefix=${MINGW_PREFIX}/local \
@@ -153,7 +164,7 @@ build() {
     --enable-bootstrap \
     --with-arch=${_arch} \
     --with-tune=generic \
-    --enable-languages=c,lto,c++,objc,obj-c++,fortran,ada \
+    --enable-languages=${_languages} \
     --enable-shared --enable-static \
     --enable-libatomic \
     --enable-threads=${_threads} \
@@ -198,7 +209,9 @@ build() {
   rm -rf ${srcdir}${MINGW_PREFIX}
 
   make -j1 DESTDIR=${srcdir} install
-  mv ${srcdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/adalib/*.dll ${srcdir}${MINGW_PREFIX}/bin/
+  if [ "$_enable_ada" == "yes" ]; then
+    mv ${srcdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/adalib/*.dll ${srcdir}${MINGW_PREFIX}/bin/
+  fi
 }
 
 package_mingw-w64-gcc-libs-git() {

--- a/mingw-w64-gcc-git/PKGBUILD
+++ b/mingw-w64-gcc-git/PKGBUILD
@@ -5,6 +5,7 @@
 # Contributor: Liu Hao <lh_mouse@126.com>
 # Contributor: Tim Stahlhut <stahta01@gmail.com>
 
+_enable_fortran=no
 _enable_ada=no
 _enable_objc=no
 _realname=gcc
@@ -12,12 +13,12 @@ _sourcedir=${_realname}-git
 pkgbase=mingw-w64-${_realname}-git
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-libs-git"
-         "${MINGW_PACKAGE_PREFIX}-${_realname}-libgfortran-git"
-         "${MINGW_PACKAGE_PREFIX}-${_realname}-fortran-git"
+         $([[ "$_enable_fortran" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-libgfortran-git")
+         $([[ "$_enable_fortran" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-fortran-git")
          $([[ "$_enable_ada" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-ada")
          $([[ "$_enable_objc" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-objc")
         )
-pkgver=9.1.1.d20190611.c10.ga33ff7d5fd0
+pkgver=9.1.1.d20190612.c10.geaf19faa8ed
 pkgrel=1
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
@@ -75,7 +76,7 @@ sha256sums=('SKIP'
             '60a58ed41389691a68ef4b7d47a0328df4d28d26e6c680a6b06b31191481ca65'
             '2321c7dce29a600477e481d16d847f05dc8c6d6461ee1eba7814c5bf62c2ef95'
             'c1e271c166de0062092cb61d50977c0e61d75b0ae6fb086cb8bb4da2b3fd18d7'
-            'b1c3c20bf501cebbcb02b4a50f117a4f90eb4fb79eac7aa99c85e2c54c106790'
+            'c0b376bfe24b7ac0703ae9bb5a859c01faf7897495dce8d68e205c49d2296195'
             '33392651e17b81609718873ff32606deee5f3fc5176c197bb96eedc3dada8912'
             'bf83cbc79de4c86f02664c8a624e26b12f570e3c31116fc7c46ecf655696f9a6')
 
@@ -145,7 +146,15 @@ build() {
     ;;
   esac
 
-  local _languages="c,lto,c++,fortran"
+  if [ "${_branch}" == "gcc-9-branch" ]; then
+    # gcc-7-branch errors during configure with plugin option
+    _conf+=" --enable-plugin"
+  fi
+
+  local _languages="c,lto,c++"
+  if [ "$_enable_fortran" == "yes" ]; then
+    _languages+=",fortran"
+  fi
   if [ "$_enable_ada" == "yes" ]; then
     _languages+=",ada"
   fi
@@ -190,7 +199,6 @@ build() {
     --with-pkgversion="Rev${pkgrel}, Built by MSYS2 project" \
     --with-bugurl="https://sourceforge.net/projects/msys2" \
     --with-gnu-as --with-gnu-ld \
-    --enable-plugin  \
     ${_conf}
     #--enable-libitm
     #--enable-objc-gc


### PR DESCRIPTION
Copied the _enable_ada=no and _enable_objc=no changes to gcc-git.

Tim S.