### PR TITLE
added gmic to mingw64

### DIFF
--- a/mingw-w64-gmic/0001-gmic-2.6.4-windows-build.patch
+++ b/mingw-w64-gmic/0001-gmic-2.6.4-windows-build.patch
@@ -1,0 +1,83 @@
+From 38c7c653cfddbc6c4fb9f9fb1744ab3e1ecbc9f4 Mon Sep 17 00:00:00 2001
+From: phweyland <philippe.weyland@libertysurf.fr>
+Date: Wed, 12 Jun 2019 11:38:44 -0300
+Subject: [PATCH] patch makefile for msys2
+
+---
+ Makefile | 26 +++++++++++++++++++++-----
+ 1 file changed, 21 insertions(+), 5 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 547cd70..e118b54 100644
+--- a/Makefile
++++ b/Makefile
+@@ -186,9 +186,9 @@ ifndef NO_STDLIB
+ MANDATORY_CFLAGS += -stdlib=libc++
+ endif
+ endif
+-ifeq ($(OS),Windows)
+-MANDATORY_LIBS += -Wl,--stack,16777216
+-endif
++#ifeq ($(OS),Windows)
++#MANDATORY_LIBS += -Wl,--stack,16777216
++#endif
+ 
+ # Enable optimizations.
+ OPT_CFLAGS = -Ofast
+@@ -288,8 +288,8 @@ CURL_LIBS = $(shell pkg-config --libs libcurl || echo -lcurl)
+ 
+ # Enable native support of webcams and video streaming, using the OpenCV library.
+ # (https://opencv.org/)
+-OPENCV_CFLAGS = -Dcimg_use_opencv $(shell pkg-config opencv --cflags || echo -I/usr/include/opencv) -I/usr/include/opencv
+-OPENCV_LIBS = $(shell pkg-config opencv --libs || echo -lopencv_core -lopencv_highgui)
++OPENCV_CFLAGS = -Dcimg_use_opencv $(shell pkg-config opencv4 --cflags)
++OPENCV_LIBS = $(shell pkg-config opencv4 --libs || echo -lopencv_core -lopencv_highgui)
+ 
+ # Enable support of most classical image file formats, using the GraphicsMagick++ library.
+ # (http://www.graphicsmagick.org/Magick++/)
+@@ -403,12 +403,21 @@ lib:
+ 
+ _lib: libgmic.o use_libgmic.cpp
+ 	ar rcs libgmic.a libgmic.o
++ifeq ($(OS),Windows)
++	$(CXX) -shared -o libgmic$(SO) \
++	-Wl,--out-implib=libgmic$(SO).a \
++	-Wl,--export-all-symbols \
++	-Wl,--enable-auto-import \
++	-Wl,--whole-archive libgmic.o \
++	-Wl,--no-whole-archive $(LIBS)
++else
+ ifeq ($(OS),Darwin)
+ 	$(CXX) -shared -o libgmic.so libgmic.o $(LIBS)
+ else
+ 	$(CXX) -shared -Wl,-soname,libgmic.so.$(VERSION1) -o libgmic.so libgmic.o $(LIBS)
+ 	$(CXX) -o use_libgmic use_libgmic.cpp -L. -lgmic $(LIBS)
+ endif
++endif
+ 
+ libgmic.o: gmic.cpp gmic.h gmic_stdlib.h CImg.h
+ 	$(CXX) -o libgmic.o -c gmic.cpp $(PIC) $(CFLAGS)
+@@ -708,6 +717,12 @@ install:
+ 	@if [ -f ../gmic-qt/gmic_gimp_qt ]; then cp -f ../gmic-qt/gmic_gimp_qt $(DESTDIR)$(PLUGINDIR)/; fi
+ 	@if [ -f ../gmic-qt/gmic_krita_qt ]; then cp -f ../gmic-qt/gmic_krita_qt $(DESTDIR)$(USR)/$(BIN)/; fi
+ 
++ifeq ($(OS),Windows)
++	mkdir -p $(DESTDIR)$(USR)/share
++	mkdir -p $(DESTDIR)$(USR)/$(LIB)
++	cp -f libgmic$(SO) $(DESTDIR)$(USR)/$(LIB)
++	cp -f libgmic$(SO).a $(DESTDIR)$(USR)/$(LIB)
++else
+ ifneq ($(OS),Darwin)
+ 	mkdir -p $(DESTDIR)$(USR)/share
+ 	mkdir -p $(DESTDIR)$(USR)/$(LIB)
+@@ -720,6 +735,7 @@ ifneq ($(OS),Darwin)
+           ln -fs libcgmic.so.$(VERSION) $(DESTDIR)$(USR)/$(LIB)/libcgmic.so.$(VERSION1) ; \
+           ln -fs libcgmic.so.$(VERSION1) $(DESTDIR)$(USR)/$(LIB)/libcgmic.so; \
+         fi
++endif
+ endif
+ 	mkdir -p $(DESTDIR)$(USR)/share/man/
+ 	mkdir -p $(DESTDIR)$(USR)/share/man/man1/
+-- 
+2.21.0
+

--- a/mingw-w64-gmic/PKGBUILD
+++ b/mingw-w64-gmic/PKGBUILD
@@ -1,0 +1,43 @@
+# Maintainer: Philippe Weyland <philippe.weyland@libertysurf.fr>
+
+_realname=gmic
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=2.6.4
+pkgrel=1
+pkgdesc="A Full-Featured Open-Source Framework for Image Processing (mingw-w64)"
+arch=(any)
+url="https://gmic.eu"
+license=("CeCILL")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-gobject-introspection")
+depends=("${MINGW_PACKAGE_PREFIX}-fftw"
+		"${MINGW_PACKAGE_PREFIX}-libpng"
+		"${MINGW_PACKAGE_PREFIX}-libjpeg"
+		"${MINGW_PACKAGE_PREFIX}-libtiff"
+		"${MINGW_PACKAGE_PREFIX}-curl"
+    "${MINGW_PACKAGE_PREFIX}-openexr"
+		"${MINGW_PACKAGE_PREFIX}-opencv"
+		)
+source=("${_realname}-${pkgver}.tar.gz::https://gmic.eu/files/source/${_realname}_${pkgver}.tar.gz"
+		"0001-gmic-2.6.4-windows-build.patch")
+md5sums=('D796C8DCDB4C724DBB29A5CDE0A7566A'
+		 '66FDBB04898D544B91E3BDF757D19276')
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}/src"
+  export PKG_CONFIG_PATH=/usr/lib/pkgconfig
+  patch -p1 -i "${srcdir}/0001-gmic-2.6.4-windows-build.patch"
+}
+
+build() {
+  cd "${srcdir}/${_realname}-${pkgver}/src"
+  make cli lib
+}
+
+package() {
+  cd "${srcdir}/${_realname}-${pkgver}/src"
+  make -j1 DESTDIR="${pkgdir}" install
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}


### PR DESCRIPTION
To add the G'MIC application to mingw64.
Works on my machine.
I've let some dependencies commented because I haven't found the way to check them: gomp, gdi32, IlmImf & Half.

