### PR TITLE
libsigc++: update to 2.10.2

### DIFF
--- a/mingw-w64-libsigc++/PKGBUILD
+++ b/mingw-w64-libsigc++/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libsigc++
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.10.1
+pkgver=2.10.2
 pkgrel=1
 pkgdesc="Libsigc++ implements a full callback system for use in widget libraries - V2 (mingw-w64)"
 arch=('any')
@@ -13,7 +13,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 options=('staticlibs' 'strip')
 source=("https://download.gnome.org/sources/libsigc++/${pkgver%.*}/libsigc++-${pkgver}.tar.xz")
-sha256sums=('c9a25f26178c6cbb147f9904d8c533b5a5c5111a41ac2eb781eb734eea446003')
+sha256sums=('b1ca0253379596f9c19f070c83d362b12dfd39c0a3ea1dd813e8e21c1a097a98')
 
 build() {
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"


### PR DESCRIPTION
This updates libsigc++ to 2.10.2.