### PR TITLE
gnome-calculator: Update version to 3.33.2

### DIFF
--- a/mingw-w64-gnome-calculator/001-gc3-Remove-Posix.nl_langinfo-usage.patch
+++ b/mingw-w64-gnome-calculator/001-gc3-Remove-Posix.nl_langinfo-usage.patch
@@ -1,0 +1,125 @@
+From d34fb77c64fb182f91dca389e8b19b1a6ea6d612 Mon Sep 17 00:00:00 2001
+From: Tim Stahlhut <stahta01@gmail.com>
+Date: Wed, 12 Jun 2019 17:31:22 -0400
+Subject: [PATCH] Remove Posix.nl_langinfo usage
+
+---
+ lib/math-equation.vala               |  4 +---
+ lib/serializer.vala                  | 23 +++--------------------
+ search-provider/search-provider.vala |  8 ++------
+ src/gcalccmd.vala                    |  8 ++------
+ src/gnome-calculator.vala            |  8 ++------
+ 5 files changed, 10 insertions(+), 41 deletions(-)
+
+diff --git a/lib/math-equation.vala b/lib/math-equation.vala
+index d2c3e620..72f0428e 100644
+--- a/lib/math-equation.vala
++++ b/lib/math-equation.vala
+@@ -495,9 +495,7 @@ public class MathEquation : Gtk.SourceBuffer
+             get_bounds (out start, out end);
+ 
+         var text = get_text (start, end, false);
+-        var tsep_string = Posix.nl_langinfo (Posix.NLItem.THOUSEP);
+-        if (tsep_string == null || tsep_string == "")
+-            tsep_string = " ";
++        var tsep_string = " ";
+         text = text.replace (tsep_string, "");
+         Gtk.Clipboard.get (Gdk.Atom.NONE).set_text (text, -1);
+     }
+diff --git a/lib/serializer.vala b/lib/serializer.vala
+index 21bfee4b..dab63d00 100644
+--- a/lib/serializer.vala
++++ b/lib/serializer.vala
+@@ -37,26 +37,9 @@ public class Serializer : Object
+ 
+     public Serializer (DisplayFormat format, int number_base, int trailing_digits)
+     {
+-        var radix_string = Posix.nl_langinfo (Posix.NLItem.RADIXCHAR);
+-        if (radix_string != null && radix_string != "") {
+-            var radix_utf8 = radix_string.locale_to_utf8 (-1, null, null);
+-            if (radix_utf8 != null)
+-                radix = radix_utf8.get_char (0);
+-            else
+-                radix = '.';
+-        }
+-        else
+-            radix = '.';
+-        var tsep_string = Posix.nl_langinfo (Posix.NLItem.THOUSEP);
+-        if (tsep_string != null && tsep_string != "") {
+-            var tsep_utf8 = tsep_string.locale_to_utf8 (-1, null, null);
+-            if (tsep_utf8 != null)
+-                tsep = tsep_utf8.get_char (0);
+-            else
+-                tsep = ' ';
+-        }
+-        else
+-            tsep = ' ';
++        radix = '.';
++
++        tsep = ' ';
+         tsep_count = 3;
+ 
+         this.number_base = number_base;
+diff --git a/search-provider/search-provider.vala b/search-provider/search-provider.vala
+index 7aa5f44f..3b94027b 100644
+--- a/search-provider/search-provider.vala
++++ b/search-provider/search-provider.vala
+@@ -87,13 +87,9 @@ public class SearchProvider : Object
+ 
+         cancel();
+ 
+-        var tsep_string = Posix.nl_langinfo (Posix.NLItem.THOUSEP);
+-        if (tsep_string == null || tsep_string == "")
+-        tsep_string = " ";
++        var tsep_string = " ";
+ 
+-        var decimal = Posix.nl_langinfo (Posix.NLItem.RADIXCHAR);
+-        if (decimal == null)
+-        decimal = "";
++        var decimal = "";
+ 
+         // "normalize" input to a format known to double.try_parse
+         var normalized_equation = equation.replace (tsep_string, "").replace (decimal, ".");
+diff --git a/src/gcalccmd.vala b/src/gcalccmd.vala
+index 3bf6c45e..a07058f0 100644
+--- a/src/gcalccmd.vala
++++ b/src/gcalccmd.vala
+@@ -15,13 +15,9 @@ private static Serializer result_serializer;
+ 
+ static void solve (string equation)
+ {
+-    var tsep_string = Posix.nl_langinfo (Posix.NLItem.THOUSEP);
+-    if (tsep_string == null || tsep_string == "")
+-        tsep_string = " ";
++    var tsep_string = " ";
+ 
+-    var decimal = Posix.nl_langinfo (Posix.NLItem.RADIXCHAR);
+-    if (decimal == null)
+-        decimal = "";
++    var decimal = "";
+ 
+     string? error_token = null;
+     var e = new Equation (equation.replace (tsep_string, "").replace (decimal, "."));
+diff --git a/src/gnome-calculator.vala b/src/gnome-calculator.vala
+index 60b072d8..b846fab1 100644
+--- a/src/gnome-calculator.vala
++++ b/src/gnome-calculator.vala
+@@ -204,13 +204,9 @@ public class Calculator : Gtk.Application
+         if (options.contains ("solve"))
+         {
+             var solve_equation = (string) options.lookup_value ("solve", VariantType.STRING);
+-            var tsep_string = Posix.nl_langinfo (Posix.NLItem.THOUSEP);
+-            if (tsep_string == null || tsep_string == "")
+-                tsep_string = " ";
++            var tsep_string = " ";
+ 
+-            var decimal = Posix.nl_langinfo (Posix.NLItem.RADIXCHAR);
+-            if (decimal == null)
+-                decimal = "";
++            var decimal = "";
+ 
+             settings = new Settings ("org.gnome.calculator");
+             var angle_units = (AngleUnit) settings.get_enum ("angle-units");
+-- 
+2.22.0.windows.1
+

--- a/mingw-w64-gnome-calculator/PKGBUILD
+++ b/mingw-w64-gnome-calculator/PKGBUILD
@@ -1,38 +1,44 @@
-# Maintainer: Andrea Zagli <andrea.zagli.free@gmail.com>
+####
+# Based partly on https://www.archlinux.org/packages/extra/x86_64/gnome-calculator/
+####
+# Past Maintainer: Andrea Zagli <andrea.zagli.free@gmail.com>
+# Contributor: Tim Stahlhut <stahta01@gmail.com>
 
 _realname=gnome-calculator
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.16.2
+pkgver=3.33.2
 pkgrel=1
 arch=('any')
 pkgdesc="GNOME desktop calculator (mingw-w64)"
 options=(strip staticlibs)
 depends=("${MINGW_PACKAGE_PREFIX}-glib2"
          "${MINGW_PACKAGE_PREFIX}-gtk3"
-         "${MINGW_PACKAGE_PREFIX}-gtksourceview3"
+         "${MINGW_PACKAGE_PREFIX}-gtksourceview4"
          "${MINGW_PACKAGE_PREFIX}-gsettings-desktop-schemas"
-         "${MINGW_PACKAGE_PREFIX}-libxml2"
+         "${MINGW_PACKAGE_PREFIX}-libsoup"
          "${MINGW_PACKAGE_PREFIX}-mpfr")
 makedepends=("${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-vala"
-             "${MINGW_PACKAGE_PREFIX}-gobject-introspection")
-license=("GPL 2")
-url="https://www.gnome.org"
+             "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-appstream-glib"
+             "${MINGW_PACKAGE_PREFIX}-libgee" # Not sure if it is only needed during make
+             "${MINGW_PACKAGE_PREFIX}-gmp"
+             "${MINGW_PACKAGE_PREFIX}-yelp-tools" # Used in package step
+             "${MINGW_PACKAGE_PREFIX}-meson"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
+license=("GPL 3")
+url="https://wiki.gnome.org/Apps/Calculator"
 install=${_realname}-${CARCH}.install
 source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz
-        001-win.patch)
-sha256sums=('f4c6ca7e0eda0dbb7d5cfb85ee9fe3351b1d8bd1bf05ce890939374b95e230a0'
-            '7555c43e7b4aa3c6041f0c1641e96186adc02092cb0b5b83fb45f6276e271248')
-
+        001-gc3-Remove-Posix.nl_langinfo-usage.patch)
+sha256sums=('b26d69c24dd79858fb09179d0a503a1c189ba839d20e2daf8a79362b6e1edf35'
+            '59661ad7ba0e9f9bfc8bade20f64df6e74640bab1068992524dc05500bc5586d')
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
 
-  echo "" > src/windows.c
-
-  patch -b -V simple -p1 -i ${srcdir}/001-win.patch
-
-  autoreconf -f -i
+  patch -p1 -i ${srcdir}/001-gc3-Remove-Posix.nl_langinfo-usage.patch
 }
 
 build() {
@@ -40,19 +46,19 @@ build() {
   mkdir -p build-${MINGW_CHOST}
   cd build-${MINGW_CHOST}
 
-  ../${_realname}-${pkgver}/configure \
-    --host=${MINGW_CHOST} \
-    --target=${MINGW_CHOST} \
-    --build=${MINGW_CHOST} \
-    --prefix=${MINGW_PREFIX} \
-    --libexecdir=${MINGW_PREFIX}/lib
+  ${MINGW_PREFIX}/bin/meson \
+    --buildtype plain \
+    ../${_realname}-${pkgver}
 
-  make
+  # Both mpc and mpfr needs the gmp library or linker error happens.
+  sed 's|"-lmpc" "-lmpfr"|"-lmpc" "-lmpfr" "-lgmp"|g' -i build.ninja
+
+  ninja
 }
 
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
-  make DESTDIR=${pkgdir} install
+  DESTDIR="${pkgdir}${MINGW_PREFIX}" ninja install
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }


### PR DESCRIPTION
The decimal point and thousand seperator no longer looks for system set values.