### PR TITLE
pdcurses: Fix `_bool` is not declared error in C++.

### DIFF
--- a/mingw-w64-pdcurses/003-fix-_bool-was-not-declared.patch
+++ b/mingw-w64-pdcurses/003-fix-_bool-was-not-declared.patch
@@ -1,0 +1,53 @@
+--- pdcurses-4.1.0.orig/curses.h	2019-05-09 07:27:41.000000000 +0800
++++ pdcurses-4.1.0/curses.h	2019-06-13 21:48:34.230201400 +0800
+@@ -56,6 +56,10 @@
+ # include <wchar.h>
+ #endif
+ 
++#if defined(__cplusplus) && __cplusplus >= 199711L
++# define PDC_PP98       1
++#endif
++
+ #if defined(__STDC_VERSION__) && __STDC_VERSION >= 199901L && \
+     !defined(__bool_true_false_are_defined)
+ # include <stdbool.h>
+@@ -64,7 +68,9 @@
+ #ifdef __cplusplus
+ extern "C"
+ {
+-# define bool _bool
++# ifndef PDC_PP98
++#  define bool _bool
++# endif
+ #endif
+ 
+ /*----------------------------------------------------------------------
+@@ -83,13 +89,15 @@
+ 
+ #else
+ 
+-typedef unsigned char bool;
+-
+ # define FALSE 0
+ # define TRUE 1
+ 
+ #endif
+ 
++#if !defined(PDC_PP98) && !defined(__bool_true_false_are_defined)
++typedef unsigned char bool;
++#endif
++
+ #undef ERR
+ #define ERR (-1)
+ 
+@@ -1840,7 +1848,9 @@
+ #define PDC_KEY_MODIFIER_REPEAT  16
+ 
+ #ifdef __cplusplus
+-# undef bool
++# ifndef PDC_PP98
++#  undef bool
++# endif
+ }
+ #endif
+ 

--- a/mingw-w64-pdcurses/PKGBUILD
+++ b/mingw-w64-pdcurses/PKGBUILD
@@ -8,7 +8,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-curses")
 replaces=("${MINGW_PACKAGE_PREFIX}-ncurses" "${MINGW_PACKAGE_PREFIX}-termcap")
 conflicts=("${MINGW_PACKAGE_PREFIX}-ncurses" "${MINGW_PACKAGE_PREFIX}-termcap")
 pkgver=4.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Curses library on the Win32 API (mingw-w64)"
 arch=('any')
 url="https://www.projectpluto.com/win32a.htm"
@@ -18,15 +18,18 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 options=('staticlibs' 'strip')
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/Bill-Gray/PDCurses/archive/v${pkgver}.tar.gz"
         001-mingw-pdcurses-4.1.0-build.patch
-        002-fix-exports.patch)
+        002-fix-exports.patch
+        003-fix-_bool-was-not-declared.patch)
 sha256sums=('3421e2e84bdc8220dc6740b70aa9b0e30542064189efc8609e00de78ced75656'
             '913b5aff09d0ab1a2197f66a98657927d85a0dc3577c2b5e69179148fb2b0242'
-            '246f93facdd2703f8b9d0bcd57e89688fd861d34a30facc60a48892b330b08bc')
+            '246f93facdd2703f8b9d0bcd57e89688fd861d34a30facc60a48892b330b08bc'
+            '6f6875068a13988988b8b04300636db4c4f9f543632597232cb2b64a2fd1218b')
 
 prepare() {
   cd PDCurses-${pkgver}
   patch -p1 -i ${srcdir}/001-mingw-pdcurses-4.1.0-build.patch
   patch -p1 -i ${srcdir}/002-fix-exports.patch
+  patch -p1 -i ${srcdir}/003-fix-_bool-was-not-declared.patch
 }
 
 build() {


### PR DESCRIPTION
Prior to this patch, C++ programs that include pdcurses headers hit this error:

  C:/MinGW/MSYS2/mingw64/include/pdcurses/curses.h:67:15: error: _bool was not declared in this scope; did you mean bool?
     67 | # define bool _bool
        |               ^~~~~

, which has been fixed by <https://sourceforge.net/p/pdcurses/code/ci/8e41f712184156fa4e0966c0c9b3b3fe0dc990be/>.

Signed-off-by: Liu Hao <lh_mouse@126.com>