### PR TITLE
mingw-w64-adobe-source-code-prof-fonts - 3.32.0 - add dependencies on…

### DIFF
--- a/mingw-w64-adobe-source-code-pro-fonts/PKGBUILD
+++ b/mingw-w64-adobe-source-code-pro-fonts/PKGBUILD
@@ -1,0 +1,29 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_realname=adobe-source-code-pro-fonts
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=2.030ro+1.050it
+_relver=2.030R-ro/1.050R-it
+pkgrel=1
+pkgdesc="Monospaced font family for user interface and coding environments (mingw-w64)"
+url="https://adobe-fonts.github.io/source-code-pro/"
+arch=(any)
+license=(custom)
+_tarname=source-code-pro-${_relver//\//-}
+install=font-${CARCH}.install
+source=("$_tarname.tar.gz::https://github.com/adobe-fonts/source-code-pro/archive/$_relver.tar.gz"
+        https://github.com/adobe-fonts/source-code-pro/releases/download/variable-fonts/SourceCodeVariable-Roman.otf
+        https://github.com/adobe-fonts/source-code-pro/releases/download/variable-fonts/SourceCodeVariable-Italic.otf)
+sha256sums=('a4e4dd59b8e0a436b934f0f612c2e91b5932910c6d1c3b7d1a5a9f389c86302b'
+            'af8fdd265f6208816fde44062a27b79ce2a594ded44ea96055a1655b6869992d'
+            'b2ca3a3c1fe0701ad74aa7c66c37972d07b1237197a816a1a5646c7e42a11353')
+
+package() {
+  cd $_tarname
+  install -d "$pkgdir${MINGW_PREFIX}/share/fonts/${_realname%-fonts}"
+  install -t "$pkgdir${MINGW_PREFIX}/share/fonts/${_realname%-fonts}" -m644 OTF/*.otf ../*.otf
+  install -Dm644 LICENSE.txt "$pkgdir${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}
+
+# vim:set ts=2 sw=2 et:

--- a/mingw-w64-adobe-source-code-pro-fonts/font-i686.install
+++ b/mingw-w64-adobe-source-code-pro-fonts/font-i686.install
@@ -1,0 +1,11 @@
+post_install() {
+  post_upgrade $1
+}
+
+post_upgrade() {
+  echo -n "Rebuilding fontconfig cache..."
+  # a full forced directory scan is required here
+  /mingw32/bin/fc-cache -rs
+  echo " done."
+}
+

--- a/mingw-w64-adobe-source-code-pro-fonts/font-x86_64.install
+++ b/mingw-w64-adobe-source-code-pro-fonts/font-x86_64.install
@@ -1,0 +1,11 @@
+post_install() {
+  post_upgrade $1
+}
+
+post_upgrade() {
+  echo -n "Rebuilding fontconfig cache..."
+  # a full forced directory scan is required here
+  /mingw64/bin/fc-cache -rs
+  echo " done."
+}
+

--- a/mingw-w64-cantarell-fonts/PKGBUILD
+++ b/mingw-w64-cantarell-fonts/PKGBUILD
@@ -1,0 +1,42 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_realname=cantarell-fonts
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.111
+pkgrel=1
+arch=('any')
+pkgdesc="Humanist sans serif font (mingw-w64)"
+makedepends=("${MINGW_PACKAGE_PREFIX}-meson"
+             "${MINGW_PACKAGE_PREFIX}-appstream-glib")
+license=(custom:SIL)
+url="https://www.gnome.org"
+install=font-${CARCH}.install
+source=("https://download.gnome.org/sources/${_realname}/0.111/${_realname}-$pkgver.tar.xz")
+sha256sums=('858b2bc196ee851c8e5a76376097bc75f23bc01b29591c30ed3a550e23b41716')
+
+prepare() {
+  cd "${srcdir}"/${_realname}-$pkgver
+}
+
+build() {
+  [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}
+  mkdir -p build-${MINGW_CHOST} && cd build-${MINGW_CHOST}
+  cp -r "../${_realname}-$pkgver/prebuilt" \
+    ${srcdir}/build-${MINGW_CHOST}
+  ${MINGW_PREFIX}/bin/meson \
+    --buildtype=plain \
+    -Duseprebuilt=true \
+    -Dbuildappstream=true \
+    -Dfontsdir=${MINGW_PREFIX}/share/fonts/cantarell \
+    "../${_realname}-$pkgver"
+
+  ninja
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  DESTDIR="${pkgdir}${MINGW_PREFIX}" ninja install
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}

--- a/mingw-w64-cantarell-fonts/font-i686.install
+++ b/mingw-w64-cantarell-fonts/font-i686.install
@@ -1,0 +1,11 @@
+post_install() {
+  post_upgrade $1
+}
+
+post_upgrade() {
+  echo -n "Rebuilding fontconfig cache..."
+  # a full forced directory scan is required here
+  /mingw32/bin/fc-cache -rs
+  echo " done."
+}
+

--- a/mingw-w64-cantarell-fonts/font-x86_64.install
+++ b/mingw-w64-cantarell-fonts/font-x86_64.install
@@ -1,0 +1,11 @@
+post_install() {
+  post_upgrade $1
+}
+
+post_upgrade() {
+  echo -n "Rebuilding fontconfig cache..."
+  # a full forced directory scan is required here
+  /mingw64/bin/fc-cache -rs
+  echo " done."
+}
+

--- a/mingw-w64-gsettings-desktop-schemas/PKGBUILD
+++ b/mingw-w64-gsettings-desktop-schemas/PKGBUILD
@@ -4,11 +4,13 @@ _realname=gsettings-desktop-schemas
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.32.0
-pkgrel=1
+pkgrel=2
 arch=('any')
 url="https://wiki.gnome.org/"
 pkgdesc="Shared GSettings schemas for the desktop (mingw-w64)"
-depends=("${MINGW_PACKAGE_PREFIX}-glib2")
+depends=("${MINGW_PACKAGE_PREFIX}-glib2"
+         "${MINGW_PACKAGE_PREFIX}-adobe-source-code-pro-fonts"
+         "${MINGW_PACKAGE_PREFIX}-cantarell-fonts")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gobject-introspection"
              "${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-ninja")


### PR DESCRIPTION
… some fonts used by Gnome

adobe-source-code-pro-fonts - -2.030ro+1.050it - new package
cantarell-fonts - 0.111 - new package