### PR TITLE
python3: Fix compilation of ctypes module if dlfcn.h is present.

### DIFF
--- a/mingw-w64-python3/PKGBUILD
+++ b/mingw-w64-python3/PKGBUILD
@@ -352,6 +352,19 @@ build() {
   # Workaround for conftest error on 64-bit builds
   export ac_cv_working_tzset=no
 
+  # Workaround for when dlfcn exists on Windows, which causes
+  # some conftests to succeed when they shouldn't (we don't use dlfcn).
+  export ac_cv_header_dlfcn_h=no
+  export ac_cv_lib_dl_dlopen=no
+  export ac_cv_have_decl_RTLD_GLOBAL=no
+  export ac_cv_have_decl_RTLD_LAZY=no
+  export ac_cv_have_decl_RTLD_LOCAL=no
+  export ac_cv_have_decl_RTLD_NOW=no
+  export ac_cv_have_decl_RTLD_DEEPBIND=no
+  export ac_cv_have_decl_RTLD_MEMBER=no
+  export ac_cv_have_decl_RTLD_NODELETE=no
+  export ac_cv_have_decl_RTLD_NOLOAD=no
+
   [[ -d "${srcdir}/build-${CARCH}" ]] && rm -rf "${srcdir}/build-${CARCH}"
   mkdir -p "${srcdir}/build-${CARCH}" && cd "${srcdir}/build-${CARCH}"
 


### PR DESCRIPTION
I needed to compile a debug-enabled Python 3 for a few client projects. On my machine this ended up failing to compile ctypes properly and thus the `check` phase of the build would fail.

The failure was explained in the build output:
```
building '_ctypes' extension
C:\msys64\mingw64\bin/x86_64-w64-mingw32-gcc.exe -Wno-unused-result -Wsign-compare -DNDEBUG -march=x86-64 -mtune=generic -O2 -pipe -fwrapv -D__USE_MINGW_ANSI_STDIO=1 -D_WIN32_WINNT=0x0601 -DNDEBUG -march=x86-64 -mtune=generic -O2 -pipe -fwrapv -D__USE_MINGW_ANSI_STDIO=1 -D_WIN32_WINNT=0x0601 -DNDEBUG -std=c99 -Wextra -Wno-unused-result -Wno-unused-parameter -Wno-missing-field-initializers -Wno-cast-function-type -Werror=implicit-function-declaration -DPy_BUILD_CORE_MODULE -IC:/msys64/mingw64/lib/libffi-3.2.1/include -I. -IC:\msys64\mingw64/include -IObjects -IPython -I../Python-3.7.3/Include -I../Python-3.7.3/PC -IC:/msys64/mingw64/include/pdcurses -IC:/msys64/home/William/src/MINGW-packages/mingw-w64-python3/src/Python-3.7.3/Include -IC:/msys64/home/William/src/MINGW-packages/mingw-w64-python3/src/build-x86_64 -c C:/msys64/home/William/src/MINGW-packages/mingw-w64-python3/src/Python-3.7.3/Modules/_ctypes/_ctypes.c -o build/temp.mingw-3.7/msys64/home/William/src/MINGW-packages/mingw-w64-python3/src/Python-3.7.3/Modules/_ctypes/_ctypes.o
C:/msys64/home/William/src/MINGW-packages/mingw-w64-python3/src/Python-3.7.3/Modules/_ctypes/_ctypes.c: In function 'PyInit__ctypes':
C:/msys64/home/William/src/MINGW-packages/mingw-w64-python3/src/Python-3.7.3/Modules/_ctypes/_ctypes.c:5615:57: error: 'RTLD_LOCAL' undeclared (first use in this function); did you mean 'PID_LOCALE'?
     PyModule_AddObject(m, "RTLD_LOCAL", PyLong_FromLong(RTLD_LOCAL));
                                                         ^~~~~~~~~~
                                                         PID_LOCALE
C:/msys64/home/William/src/MINGW-packages/mingw-w64-python3/src/Python-3.7.3/Modules/_ctypes/_ctypes.c:5615:57: note: each undeclared identifier is reported only once for each function it appears in
C:/msys64/home/William/src/MINGW-packages/mingw-w64-python3/src/Python-3.7.3/Modules/_ctypes/_ctypes.c:5616:58: error: 'RTLD_GLOBAL' undeclared (first use in this function); did you mean 'RemHGLOBAL'?
     PyModule_AddObject(m, "RTLD_GLOBAL", PyLong_FromLong(RTLD_GLOBAL));
                                                          ^~~~~~~~~~~
                                                          RemHGLOBAL
```

As it turns out, Windows builds of Python are not expected to use `dlfcn.h`. But if `dlfcn.h` _is_ present, as it is on my machine, the call to `AC_CHECK_DECLS` that tests `dlfcn.h` will succeed anyway, which ultimately cascades into this error, because `_ctypes.c` does not pick up `dlfcn.h` in the Windows build.

I could fix this by adding a `#include "ctypes_dlfcn.h"` line under Windows-specific headers if the relevant `autoconf` tests succeed. But since presumably we don't want to use `RTLD_{GLOBAL, LOCAL}` at all in the `mingw64` Python, I decided to manually override the relevant `autoconf` vars in `PKGBUILD` to force the tests to fail even if `dlfcn.h` is present. This shouldn't affect a CI build.

I now have a Python 3 that successfully builds on my machine after this patch.
