### PR TITLE
python-wrapt: update to 1.11.2

### DIFF
--- a/mingw-w64-python-wrapt/PKGBUILD
+++ b/mingw-w64-python-wrapt/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=wrapt
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=1.11.1
+pkgver=1.11.2
 pkgrel=1
 pkgdesc="A Python module for decorators, wrappers and monkey patching (mingw-w64)"
 arch=('any')
@@ -15,7 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
 options=('staticlibs' 'strip' '!debug')
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/GrahamDumpleton/wrapt/archive/${pkgver}.tar.gz")
-sha256sums=('8a6fb40e8f8b6a66b4ba81a4044c68e6a7b1782f21cfabc06fb765332b4c3e51')
+sha256sums=('a91e2f31d71c2fcaaa1dc116ce37901aad18a554cdcc69db1dca0743d790ba72')
 
 prepare() {  
   cd "${srcdir}"


### PR DESCRIPTION
This updates python-wrapt to 1.11.2.