### PR TITLE
gtk3: Port to meson

### DIFF
--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gtk3
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.24.9
-pkgrel=1
+pkgrel=2
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
 url="https://www.gtk.org/"
@@ -13,9 +13,10 @@ install=gtk3-${CARCH}.install
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-gtk-doc"
-             "${MINGW_PACKAGE_PREFIX}-gobject-introspection")
-makedepends+=("autoconf" "automake" "libtool")
-# autotools are required because several Makefile.am are modified
+             "${MINGW_PACKAGE_PREFIX}-meson"
+             "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
+             "${MINGW_PACKAGE_PREFIX}-sassc"
+             "${MINGW_PACKAGE_PREFIX}-libxslt")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme"
          "${MINGW_PACKAGE_PREFIX}-atk"
@@ -37,43 +38,32 @@ prepare() {
 
   # https://bugzilla.gnome.org/show_bug.cgi?id=778791
   patch -p1 -i "${srcdir}"/0001-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch
-
-  NOCONFIGURE=1 ./autogen.sh
 }
 
 build() {
-  #export GI_SCANNER_DEBUG="save-temps"
-  export MSYS2_ARG_CONV_EXCL="-//OASIS//DTD"
-  rm -rf ${srcdir}/build-${MINGW_CHOST}
-  cp -rf ${srcdir}/gtk+-${pkgver} ${srcdir}/build-${MINGW_CHOST}
-  cd ${srcdir}/build-${MINGW_CHOST}
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
 
-  PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:/usr/share/pkgconfig" \
-  ./configure \
-    --prefix=${MINGW_PREFIX} \
-    --build=${MINGW_CHOST} \
-    --host=${MINGW_CHOST} \
-    --enable-win32-backend \
-    --enable-shared \
-    --enable-introspection \
-    --enable-broadway-backend \
-    --disable-cups \
-    --with-included-immodules \
-    --enable-silent-rules \
-    --without-libiconv-prefix \
-    --without-libintl-prefix
+  meson \
+    --buildtype=plain \
+    -Dbroadway_backend=true \
+    -Dman=true \
+    "../gtk+-${pkgver}"
 
-  make #V=1
+  ninja
 }
 
 package() {
-  #export MSYS2_ARG_CONV_EXCL="-//OASIS"
-  cd "${srcdir}/build-${MINGW_CHOST}"
-  make -j1 DESTDIR="${pkgdir}" install
-  find "${pkgdir}${MINGW_PREFIX}" -name '*.def' -o -name '*.exp' -o -name '*.manifest' | xargs -rtl1 rm
+  cd "${srcdir}/build-${CARCH}"
+
+  DESTDIR="${pkgdir}${MINGW_PREFIX}" ninja install
 
   mv ${pkgdir}${MINGW_PREFIX}/bin/gtk-update-icon-cache{,-3.0}.exe
   mv ${pkgdir}${MINGW_PREFIX}/share/man/man1/gtk-update-icon-cache{,-3.0}.1
+
+  for pcfile in  "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/*.pc; do
+    sed -s "s|$(cygpath -m ${MINGW_PREFIX})|${MINGW_PREFIX}|g" -i "${pcfile}"
+  done
 
   install -Dm644 "${srcdir}/gtk+-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }


### PR DESCRIPTION
gtk-doc skipped for now since there is some argument passing issue
in meson or gtk-doc where gcc gets wrong args with '-DFOO="string"'.