### PR TITLE
libsass and sassc: update to 3.6.1

### DIFF
--- a/mingw-w64-libsass/PKGBUILD
+++ b/mingw-w64-libsass/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libsass
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.6.0
+pkgver=3.6.1
 pkgrel=1
 pkgdesc="C implementation of Sass CSS preprocessor (library) (mingw-w64)"
 arch=('any')
@@ -11,11 +11,10 @@ url="http://libsass.org/"
 license=("MIT")
 options=('strip' 'staticlibs')
 source=("$_realname-$pkgver.tar.gz::https://github.com/sass/$_realname/archive/$pkgver.tar.gz")
-sha256sums=('b4b962a30bcd99adf0162a8eac7e1be94612b1c19912237f53d9a2c11d375169')
+sha256sums=('18d6e866ba2430cccae2551f384aca253a84592c692ce7146550f1d4f273b7d7')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
-
   autoreconf -vfi
 }
 

--- a/mingw-w64-sassc/PKGBUILD
+++ b/mingw-w64-sassc/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=sassc
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.6.0
+pkgver=3.6.1
 pkgrel=1
 pkgdesc="C implementation of Sass CSS preprocessor (mingw-w64)"
 arch=('any')
@@ -11,11 +11,10 @@ url="http://libsass.org/"
 license=("MIT")
 depends=("${MINGW_PACKAGE_PREFIX}-libsass")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/sass/${_realname}/archive/${pkgver}.tar.gz")
-sha256sums=('dac8d83339c3c8fc6b9599e2ff1e0a0ae833ab0e65d4370b9c69bde18f8ec676')
+sha256sums=('8cee391c49a102b4464f86fc40c4ceac3a2ada52a89c4c933d8348e3e4542a60')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
-
   autoreconf -vfi
 }
 


### PR DESCRIPTION
This updates libsass and sassc to 3.6.1.