### PR TITLE
docbook-xml 5.0.1 - Update to latest version of docbook-schemas

### DIFF
--- a/mingw-w64-docbook-xml/PKGBUILD
+++ b/mingw-w64-docbook-xml/PKGBUILD
@@ -1,394 +1,381 @@
-# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: dorphell <dorphell@archlinux.org>
+# Contributor: Judd Vinet <jvinet@zeroflux.org>
 
+_vers_4x=(4.{2..5})
+_vers_5x=(5.0 5.0.1)
 _realname=docbook-xml
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=5.0
+pkgver=${_vers_5x[-1]}
 pkgrel=1
 pkgdesc="A widely used XML scheme for writing documentation and help"
-arch=('any')
 url="https://www.oasis-open.org/docbook/"
-license=('MIT')
+arch=(any)
+license=(MIT)
 depends=("${MINGW_PACKAGE_PREFIX}-libxml2")
 install=docbook-xml-${CARCH}.install
-source=('http://docbook.org/xml/5.0/docbook-5.0.zip'
-        'http://www.docbook.org/xml/4.5/docbook-xml-4.5.zip'
-        'http://www.docbook.org/xml/4.4/docbook-xml-4.4.zip'
-        'http://www.docbook.org/xml/4.3/docbook-xml-4.3.zip'
-        'http://www.docbook.org/xml/4.2/docbook-xml-4.2.zip'
-        'http://www.docbook.org/xml/4.1.2/docbkx412.zip'
-        'LICENSE'
-        '4.1.2-add-catalog.all.patch'
-        '4.2-Add-system.all.patch'
-        '4.3-Add-system-and-htmltbl.all.patch')
-noextract=('docbook-5.0.zip', 'docbook-xml-4.5.zip' 'docbook-xml-4.4.zip' 'docbook-xml-4.3.zip' 'docbook-xml-4.2.zip' 'docbkx412.zip')
-sha256sums=('3dcd65e1f5d9c0c891b3be204fa2bb418ce485d32310e1ca052e81d36623208e'
-            '4e4e037a2b83c98c6c94818390d4bdd3f6e10f6ec62dd79188594e26190dc7b4'
-            '02f159eb88c4254d95e831c51c144b1863b216d909b5ff45743a1ce6f5273090'
-            '23068a94ea6fd484b004c5a73ec36a66aa47ea8f0d6b62cc1695931f5c143464'
-            'acc4601e4f97a196076b7e64b368d9248b07c7abf26b34a02cca40eeebe60fa2'
-            '30f0644064e0ea71751438251940b1431f46acada814a062870f486c772e7772'
-            'adf79c0ee42b5b0d9b0d10def6aca4f7c97a0ce7333b3012af2c929e1ed72b77'
-            '100b85e6b1f4b676765ad718d6f75e4f85b921376282f368e1131774ba29e491'
-            '323de7ae4c74f6eaba3d41c4b6a312b140b40d39ad93ae8dd3fa9e88bcfd079b'
-            '93d3267fa285d7f16aec93392b032d8b8043f3d3779708a3859671e11a3ffed3')
+source=(https://docbook.org/xml/4.1.2/docbkx412.zip
+        LICENSE)
+noextract=(docbkx412.zip)
+
+for _ver in ${_vers_4x[@]}; do
+  source+=("https://docbook.org/xml/$_ver/docbook-xml-$_ver.zip")
+  noextract+=("docbook-xml-$_ver.zip")
+done
+for _ver in ${_vers_5x[@]}; do
+  source+=("https://docbook.org/xml/$_ver/docbook-$_ver.zip")
+  noextract+=("docbook-$_ver.zip")
+done
+ 
+sha512sums=('f700591a671694ca0ac51f5b5b7e825df5c0b3604b20baa6afd3aaafa7ce99470ca1c261781b105b42bfa5485c23217cf3db821b3fcf2ebdae9df07bb8ae4063'
+            'd852ab8e1442af4a91ffc32b9bb37377d98171dbc379cfd9787a2e06fc5c9b8ed04c5cd156ff5b7799973250011389456a3a3584ed4ae99362420c15235fcbb5'
+            '0c836346130d1e8f4e26e00959f6b4fd2c3c11269ba5cbf11cdc904724e189606f431c99cd5ab188877daa0eb44c58d0bc30556df3b51df480396818d61c4e0a'
+            'f5090fb74884bae3d4fac8a3c5060bffff5d6a74272de183c181a7642e4b91f4ed32ad028537d198010782c3d98575ce679672f76a9749ed124432195886a7cb'
+            '7df5af4df24e4618b09814e4e20c147c722962531f03a40c28cd60f1db16b4c330420adf96adb7d66ed6eda84046ee91b467fd6f6fbfac2201537e2080735d76'
+            '1ee282fe86c9282610ee72c0e1d1acfc03f1afb9dc67166f438f2703109046479edb6329313ecb2949db27993077e077d111501c10b8769ebb20719eb6213d27'
+            'a245796881762cf001f0d32b7c87315cba0454750d6b4178e4546357e320e2ab602d84c08a7e44329f406a8d32340605671c351e87c0b9097582ebf6d10fede4'
+            'df85ab724d3205086dfbab40419e268d5bf183b028ed8c58d30068bdc82c1e10fc05bf167d5efcdbeb6b6c9c8dbf96ca4f979fcc6da2e2fea99cbf1bd8aaad30')
 
 package() {
-  # export MSYS2_ARG_CONV_EXCL="-//OASIS"
-  for ver in 4.2 4.3 4.4 4.5; do
-    rm -rf docbook-xml-${ver} || true
-    mkdir docbook-xml-${ver}
-    pushd docbook-xml-${ver}
-      /usr/bin/bsdtar xf "${srcdir}/docbook-xml-${ver}.zip"
-      case $ver in
-        4.2)
-        patch -p1 -i ${srcdir}/4.2-Add-system.all.patch
-      ;;
-        4.3)
-        patch -p1 -i ${srcdir}/4.3-Add-system-and-htmltbl.all.patch
-      ;;
-      4.4)
-      ;;
-      4.5)
-      ;;
-      esac
-      rm -rf "${pkgdir}${MINGW_PREFIX}/share/xml/docbook/xml-dtd-${ver}" || true
-      mkdir -p "${pkgdir}${MINGW_PREFIX}/share/xml/docbook/xml-dtd-${ver}"
-      cp -dRf docbook.cat *.dtd ent/ *.mod \
-      "${pkgdir}${MINGW_PREFIX}/share/xml/docbook/xml-dtd-${ver}/"
-    popd
+  local ver xml
+
+  mkdir -p "$pkgdir${MINGW_PREFIX}/etc/xml"
+  ${MINGW_PREFIX}/bin/xmlcatalog --noout --create "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+
+  mkdir -p docbook-xml-4.1.2
+  bsdtar -C docbook-xml-4.1.2 -xf docbkx412.zip
+  for ver in ${_vers_4x[@]}; do
+    mkdir -p docbook-xml-$ver
+    bsdtar -C docbook-xml-$ver -xf docbook-xml-$ver.zip
   done
 
-  #extract v4.1.2
-  rm -rf docbook-xml-4.1.2 || true
-  mkdir docbook-xml-4.1.2
-  pushd docbook-xml-4.1.2
-    /usr/bin/bsdtar xf "${srcdir}/docbkx412.zip"
-    patch -p1 -i ${srcdir}/4.1.2-add-catalog.all.patch
-    mkdir -p "${pkgdir}${MINGW_PREFIX}/share/xml/docbook/xml-dtd-4.1.2"
-    cp -dRf docbook.cat *.dtd ent/ *.mod \
-    "${pkgdir}${MINGW_PREFIX}/share/xml/docbook/xml-dtd-4.1.2/"
-  popd
+  for ver in ${_vers_5x[@]}; do
+    mkdir -p docbook-xml-$ver
+    bsdtar -C docbook-xml-$ver -xf docbook-$ver.zip
+  done
 
-  #extract v5.0
-  rm -rf docbook-xml-5.0 || true
-  mkdir docbook-xml-5.0
-  pushd docbook-xml-5.0
-    /usr/bin/bsdtar xf "${srcdir}/docbook-5.0.zip"
-    mkdir -p "${pkgdir}${MINGW_PREFIX}/share/xml/docbook/xml-dtd-5.0"
-    #cp -dRf docbook-5.0/catalog.xml docbook-5.0/xsd/*.xsd docbook-5.0/sch/docbook.sch docbook-5.0/dtd/docbook.dtd  \   
-    cp -dRf \
-      docbook-5.0/catalog.xml \
-      docbook-5.0/xsd/ \
-      docbook-5.0/sch/ \
-      docbook-5.0/dtd/ \
-      docbook-5.0/rng/ \
-    "${pkgdir}${MINGW_PREFIX}/share/xml/docbook/xml-dtd-5.0/"
-  popd
+  for ver in 4.1.2 ${_vers_4x[@]}; do
+    pushd docbook-xml-$ver
+    mkdir -p "$pkgdir${MINGW_PREFIX}/share/xml/docbook/xml-dtd-$ver"
+    cp -dr docbook.cat *.dtd ent/ *.mod \
+        "$pkgdir${MINGW_PREFIX}/share/xml/docbook/xml-dtd-$ver"
+    popd
 
-  mkdir -p "${pkgdir}${MINGW_PREFIX}/etc/xml"
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --create "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+    xml=
+    case $ver in
+      4.1.2) xml=' XML' ;;&
+      *)
+        ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
+          "-//OASIS//DTD DocBook XML V$ver//EN" \
+          "http://www.oasis-open.org/docbook/xml/$ver/docbookx.dtd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+        ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
+          "-//OASIS//DTD DocBook$xml CALS Table Model V$ver//EN" \
+          "http://www.oasis-open.org/docbook/xml/$ver/calstblx.dtd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+        ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
+          "-//OASIS//DTD XML Exchange Table Model 19990315//EN" \
+          "http://www.oasis-open.org/docbook/xml/$ver/soextblx.dtd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+        ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
+          "-//OASIS//ELEMENTS DocBook$xml Information Pool V$ver//EN" \
+          "http://www.oasis-open.org/docbook/xml/$ver/dbpoolx.mod" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+        ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
+          "-//OASIS//ELEMENTS DocBook$xml Document Hierarchy V$ver//EN" \
+          "http://www.oasis-open.org/docbook/xml/$ver/dbhierx.mod" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+        ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
+          "-//OASIS//ENTITIES DocBook$xml Additional General Entities V$ver//EN" \
+          "http://www.oasis-open.org/docbook/xml/$ver/dbgenent.mod" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+        ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
+          "-//OASIS//ENTITIES DocBook$xml Notations V$ver//EN" \
+          "http://www.oasis-open.org/docbook/xml/$ver/dbnotnx.mod" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+        ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
+          "-//OASIS//ENTITIES DocBook$xml Character Entities V$ver//EN" \
+          "http://www.oasis-open.org/docbook/xml/$ver/dbcentx.mod" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+        ;;&
+      4.[45])
+        ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
+          "-//OASIS//ELEMENTS DocBook XML HTML Tables V$ver//EN" \
+          "http://www.oasis-open.org/docbook/xml/$ver/htmltblx.mod" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+        ;;&
+      *)
+        ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://www.oasis-open.org/docbook/xml/$ver" \
+          "${MINGW_PREFIX}/share/xml/docbook/xml-dtd-$ver" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+        ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://www.oasis-open.org/docbook/xml/$ver" \
+          "${MINGW_PREFIX}/share/xml/docbook/xml-dtd-$ver" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+        ;;&
+    esac
+  done
 
-  # V4.1.2
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//DTD DocBook XML V4.1.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+  for ver in ${_vers_5x[@]}; do
+    pushd docbook-xml-$ver
+#    mkdir -p "$pkgdir${MINGW_PREFIX}/share/xml/docbook/xml-dtd-$ver"
+     mkdir -p $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/dtd/$ver \
+       $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver/ \
+       $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/sch/$ver/ \
+       $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/xsd/$ver/ \
+       $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/$ver/ \
+       $pkgdir${MINGW_PREFIX}/share/doc/docbook5-schemas \
+       $pkgdir${MINGW_PREFIX}/share/xml/docbook/stylesheet/docbook-$ver/ \
+       $pkgdir${MINGW_PREFIX}/bin
+     cp -r docbook-$ver/docs/* $pkgdir${MINGW_PREFIX}/share/doc/docbook5-schemas
+     cp docbook-$ver/catalog.xml $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/catalog-docbook-$ver.xml
+     cp -r docbook-$ver/dtd/* $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/dtd/$ver
+     cp -r docbook-$ver/rng/* $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver
+     cp -r docbook-$ver/sch/* $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/sch/$ver/
+     cp -r docbook-$ver/xsd/* $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/xsd/$ver/
+     cp -r docbook-$ver/tools/db4-upgrade.xsl $pkgdir${MINGW_PREFIX}/share/xml/docbook/stylesheet/docbook-$ver/
+     cp -r docbook-$ver/tools/db4-entities.pl $pkgdir${MINGW_PREFIX}/bin
+     cp -r docbook-$ver/docbook.nvdl $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/$ver/docbook.nvdl
+        ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
+          "-//OASIS//DTD DocBook XML V$ver//EN" \
+          "http://www.oasis-open.org/docbook/xml/$ver/docbookx.dtd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//DTD DocBook XML CALS Table Model V4.1.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.1.2/calstblx.dtd" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+## dtd dir
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://www.oasis-open.org/docbook/xml/$ver/dtd/docbook.dtd" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/dtd/$ver/docbook.dtd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://www.oasis-open.org/docbook/xml/$ver/dtd/docbook.dtd" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/dtd/$ver/docbook.dtd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//DTD DocBook XML CALS Table Model V4.1.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.1.2/calstblx.dtd" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://docbook.org/xml/$ver/dtd/docbook.dtd" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/dtd/$ver/docbook.dtd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://docbook.org/xml/$ver/dtd/docbook.dtd" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/dtd/$ver/docbook.dtd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//DTD XML Exchange Table Model 19990315//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.1.2/soextblx.dtd" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+#rng dir
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://www.oasis-open.org/docbook/xml/$ver/rng/docbook.rng" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver/docbook.rng" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://www.oasis-open.org/docbook/xml/$ver/rng/docbook.rng" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver/docbook.rng" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ELEMENTS DocBook XML Information Pool V4.1.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.1.2/dbpoolx.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://docbook.org/xml/$ver/rng/docbook.rng" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver/docbook.rng" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://docbook.org/xml/$ver/rng/docbook.rng" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver/docbook.rng" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ELEMENTS DocBook XML Document Hierarchy V4.1.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.1.2/dbhierx.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://www.oasis-open.org/docbook/xml/$ver/rng/docbookxi.rng" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver/docbookxi.rng" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://www.oasis-open.org/docbook/xml/$ver/rng/docbookxi.rng" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver/docbookxi.rng" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ENTITIES DocBook XML Additional General Entities V4.1.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.1.2/dbgenent.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://docbook.org/xml/$ver/rng/docbookxi.rng" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver/docbookxi.rng" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://docbook.org/xml/$ver/rng/docbookxi.rng" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver/docbookxi.rng" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ENTITIES DocBook XML Notations V4.1.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.1.2/dbnotnx.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://www.oasis-open.org/docbook/xml/$ver/rng/docbook.rnc" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver/docbook.rnc" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://www.oasis-open.org/docbook/xml/$ver/rng/docbook.rnc" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver/docbook.rnc" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ENTITIES DocBook XML Character Entities V4.1.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.1.2/dbcentx.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://docbook.org/xml/$ver/rng/docbook.rnc" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver/docbook.rnc" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://docbook.org/xml/$ver/rng/docbook.rnc" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver/docbook.rnc" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-    "http://www.oasis-open.org/docbook/xml/4.1.2" \
-    "../../share/xml/docbook/xml-dtd-4.1.2" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://www.oasis-open.org/docbook/xml/$ver/rng/docbookxi.rnc" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver/docbookxi.rnc" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://www.oasis-open.org/docbook/xml/$ver/rng/docbookxi.rnc" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver/docbookxi.rnc" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-    "http://www.oasis-open.org/docbook/xml/4.1.2" \
-    "../../share/xml/docbook/xml-dtd-4.1.2" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://docbook.org/xml/$ver/rng/docbookxi.rnc" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver/docbookxi.rnc" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://docbook.org/xml/$ver/rng/docbookxi.rnc" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver/docbookxi.rnc" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
 
-  # V4.2
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//DTD DocBook XML V4.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+# xsd dir
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://www.oasis-open.org/docbook/xml/$ver/xsd/docbook.xsd" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/xsd/$ver/docbook.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://www.oasis-open.org/docbook/xml/$ver/xsd/docbook.xsd" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/xsd/$ver/docbook.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//DTD DocBook CALS Table Model V4.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.2/calstblx.dtd" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://docbook.org/xml/$ver/xsd/docbook.xsd" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/xsd/$ver/docbook.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://docbook.org/xml/$ver/xsd/docbook.xsd" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/xsd/$ver/docbook.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//DTD XML Exchange Table Model 19990315//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.2/soextblx.dtd" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://www.oasis-open.org/docbook/xml/$ver/xsd/docbookxi.xsd" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/xsd/$ver/docbookxi.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://www.oasis-open.org/docbook/xml/$ver/xsd/docbookxi.xsd" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/xsd/$ver/docbookxi.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ELEMENTS DocBook Information Pool V4.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.2/dbpoolx.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://docbook.org/xml/$ver/xsd/docbookxi.xsd" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/xsd/$ver/docbookxi.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://docbook.org/xml/$ver/xsd/docbookxi.xsd" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/xsd/$ver/docbookxi.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ELEMENTS DocBook Document Hierarchy V4.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.2/dbhierx.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://www.oasis-open.org/docbook/xml/$ver/xsd/xi.xsd" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/xsd/$ver/xi.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://www.oasis-open.org/docbook/xml/$ver/xsd/xi.xsd" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/xsd$/$ver/xi.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ENTITIES DocBook Additional General Entities V4.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.2/dbgenent.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://docbook.org/xml/$ver/xsd/xi.xsd" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/xsd/$ver/xi.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://docbook.org/xml/$ver/xsd/xi.xsd" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/$ver/xsd/xi.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ENTITIES DocBook Notations V4.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.2/dbnotnx.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://www.oasis-open.org/docbook/xml/$ver/xsd/xlink.xsd" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/xsd/$ver/xlink.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://www.oasis-open.org/docbook/xml/$ver/xsd/xlink.xsd" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/xsd/$ver/xlink.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ENTITIES DocBook Character Entities V4.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.2/dbcentx.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://docbook.org/xml/$ver/xsd/xlink.xsd" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/xsd/$ver/xlink.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://docbook.org/xml/$ver/xsd/xlink.xsd" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/xsd/$ver/xlink.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-    "http://www.oasis-open.org/docbook/xml/4.2" \
-    "../../share/xml/docbook/xml-dtd-4.2" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://www.oasis-open.org/docbook/xml/$ver/xsd/xml.xsd" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/xsd/$ver/xml.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://www.oasis-open.org/docbook/xml/$ver/xsd/xml.xsd" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/xsd/$ver/xml.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-    "http://www.oasis-open.org/docbook/xml/4.2" \
-    "../../share/xml/docbook/xml-dtd-4.2" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://docbook.org/xml/$ver/xsd/xml.xsd" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/xsd/$ver/xml.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://docbook.org/xml/$ver/xsd/xml.xsd" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/xsd/$ver/xml.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
 
-  # V4.3
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//DTD DocBook XML V4.3//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+##sch dir
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://www.oasis-open.org/docbook/xml/$ver/sch/docbook.sch" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/sch/$ver/docbook.sch" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://www.oasis-open.org/docbook/xml/sch/$ver/docbook.sch" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/sch/$ver/docbook.sch" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//DTD DocBook CALS Table Model V4.3//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.3/calstblx.dtd" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://docbook.org/xml/$ver/sch/docbook.sch" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/sch/$ver/docbook.sch" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://docbook.org/xml/$ver/sch/docbook.sch" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/sch/$ver/docbook.sch" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//DTD XML Exchange Table Model 19990315//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.3/soextblx.dtd" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+# 5.0 dir
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://www.oasis-open.org/docbook/xml/$ver/docbook.nvdl" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/$ver/docbook.nvdl" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://www.oasis-open.org/docbook/xml/$ver/docbook.nvdl" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/$ver/docbook.nvdl" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ELEMENTS DocBook Information Pool V4.3//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.3/dbpoolx.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://docbook.org/xml/$ver/docbook.nvdl" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/$ver/docbook.nvdl" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://docbook.org/xml/$ver/docbook.nvdl" \
+          "${MINGW_PREFIX}/share/xml/docbook/schema/$ver/docbook.nvdl" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
+   popd
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ELEMENTS DocBook Document Hierarchy V4.3//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.3/dbhierx.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+  done
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ENTITIES DocBook Additional General Entities V4.3//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.3/dbgenent.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+#//DOCBOOK 5.0 and 5.0.1 entries
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ENTITIES DocBook Notations V4.3//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.3/dbnotnx.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+  local PREFIX_WIN="$(cygpath -m ${MINGW_PREFIX})"
+  sed -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" \
+      -i "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ENTITIES DocBook Character Entities V4.3//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.3/dbcentx.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+  install -Dt "$pkgdir${MINGW_PREFIX}/share/licenses/$pkgname" -m644 LICENSE
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-    "http://www.oasis-open.org/docbook/xml/4.3" \
-    "../../share/xml/docbook/xml-dtd-4.3" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-    "http://www.oasis-open.org/docbook/xml/4.3" \
-    "../../share/xml/docbook/xml-dtd-4.3" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  # V4.4
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//DTD DocBook XML V4.4//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//DTD DocBook CALS Table Model V4.4//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.4/calstblx.dtd" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ELEMENTS DocBook XML HTML Tables V4.4//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.4/htmltblx.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//DTD XML Exchange Table Model 19990315//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.4/soextblx.dtd" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ELEMENTS DocBook Information Pool V4.4//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.4/dbpoolx.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ELEMENTS DocBook Document Hierarchy V4.4//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.4/dbhierx.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ENTITIES DocBook Additional General Entities V4.4//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.4/dbgenent.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ENTITIES DocBook Notations V4.4//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.4/dbnotnx.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ENTITIES DocBook Character Entities V4.4//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.4/dbcentx.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-    "http://www.oasis-open.org/docbook/xml/4.4" \
-    "../../share/xml/docbook/xml-dtd-4.4" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-    "http://www.oasis-open.org/docbook/xml/4.4" \
-    "../../share/xml/docbook/xml-dtd-4.4" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  # V4.5
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//DTD DocBook XML V4.5//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//DTD DocBook XML CALS Table Model V4.5//EN" \
-    "../../share/xml/docbook/xml-dtd-4.5/calstblx.dtd" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//DTD XML Exchange Table Model 19990315//EN" \
-    "../../share/xml/docbook/xml-dtd-4.5/soextblx.dtd" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ELEMENTS DocBook XML Information Pool V4.5//EN" \
-    "../../share/xml/docbook/xml-dtd-4.5/dbpoolx.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ELEMENTS DocBook XML Document Hierarchy V4.5//EN" \
-    "../../share/xml/docbook/xml-dtd-4.5/dbhierx.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ELEMENTS DocBook XML HTML Tables V4.5//EN" \
-    "../../share/xml/docbook/xml-dtd-4.5/htmltblx.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ENTITIES DocBook XML Notations V4.5//EN" \
-    "../../share/xml/docbook/xml-dtd-4.5/dbnotnx.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ENTITIES DocBook XML Character Entities V4.5//EN" \
-    "../../share/xml/docbook/xml-dtd-4.5/dbcentx.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ENTITIES DocBook XML Additional General Entities V4.5//EN" \
-    "../../share/xml/docbook/xml-dtd-4.5/dbgenent.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-    "http://www.oasis-open.org/docbook/xml/4.5" \
-    "../../share/xml/docbook/xml-dtd-4.5" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-    "http://www.oasis-open.org/docbook/xml/4.5" \
-    "../../share/xml/docbook/xml-dtd-4.5" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  # 5.0
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//DTD DocBook XML 5.0//EN" \
-    "http://docbook.org/xml/5.0/dtd/docbook.dtd" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-    "-//OASIS//ENTITIES DocBook XML Character Entities V4.5//EN" \
-    "../../share/xml/docbook/xml-dtd-4.5/dbcentx.mod" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-    "http://www.oasis-open.org/docbook/xml/5.0" \
-    "../../share/xml/docbook/xml-dtd-5.0" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-    "http://docbook.org/xml/5.0" \
-    "../../share/xml/docbook/xml-dtd-5.0" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-    "http://www.oasis-open.org/docbook/xml/5.0" \
-    "../../share/xml/docbook/xml-dtd-5.0" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-    "http://docbook.org/xml/5.0/" \
-    "../../share/xml/docbook/xml-dtd-5.0" \
-    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  # license
-  install -D -m644 "${srcdir}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  # Fix permissions
+  find "$pkgdir" -type f -exec chmod -c a-x {} +
+  chmod -Rc u=rwX,go=rX "$pkgdir"
 }
+

--- a/mingw-w64-docbook-xml/docbook-xml-i686.install
+++ b/mingw-w64-docbook-xml/docbook-xml-i686.install
@@ -1,37 +1,35 @@
 MINGW_INSTALL=mingw32
 MINGW_XML_CATALOG=${MINGW_INSTALL}/etc/xml
 # export MSYS2_ARG_CONV_EXCL="-//OASIS"
+_vers_4x=(4.{2..5})
 
 post_install() {
+  local PREFIX_WIN="$(cygpath -m /${MINGW_INSTALL})"
+  sed -e "s|/${MINGW_INSTALL}|${PREFIX_WIN}|g" \
+      -i "${MINGW_INSTALL}/etc/xml/docbook-xml"
   if [ -e ${MINGW_XML_CATALOG}/catalog.preserve ]; then
     mv ${MINGW_XML_CATALOG}/catalog.preserve ${MINGW_XML_CATALOG}/catalog
   elif [ ! -e mingw32/etc/xml/catalog ]; then
     ${MINGW_INSTALL}/bin/xmlcatalog --noout --create ${MINGW_XML_CATALOG}/catalog
   fi
   ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegatePublic" \
-    '-//OASIS//ENTITIES DocBook XML' \
+    "-//OASIS//ENTITIES DocBook XML" \
     "./docbook-xml" \
     ${MINGW_XML_CATALOG}/catalog
+
   ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegatePublic" \
-    '-//OASIS//DTD DocBook XML' \
+    "-//OASIS//DTD DocBook XML" \
     "./docbook-xml" \
     ${MINGW_XML_CATALOG}/catalog
+
   ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateSystem" \
     "http://www.oasis-open.org/docbook/" \
     "./docbook-xml" \
     ${MINGW_XML_CATALOG}/catalog
-  ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateSystem" \
-    "http://docbook.org/" \
-    "./docbook-xml" \
-    ${MINGW_XML_CATALOG}/catalog      
   ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateURI" \
     "http://www.oasis-open.org/docbook/" \
     "./docbook-xml" \
     ${MINGW_XML_CATALOG}/catalog
-  ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateURI" \
-    "http://docbook.org/" \
-    "./docbook-xml" \
-    ${MINGW_XML_CATALOG}/catalog       
 }
 
 # arg 1:  the new package version

--- a/mingw-w64-docbook-xml/docbook-xml-x86_64.install
+++ b/mingw-w64-docbook-xml/docbook-xml-x86_64.install
@@ -1,8 +1,12 @@
 MINGW_INSTALL=mingw64
 MINGW_XML_CATALOG=${MINGW_INSTALL}/etc/xml
 # export MSYS2_ARG_CONV_EXCL="-//OASIS"
+_vers_4x=(4.{2..5})
 
 post_install() {
+  local PREFIX_WIN="$(cygpath -m /${MINGW_INSTALL})"
+  sed -e "s|/${MINGW_INSTALL}|${PREFIX_WIN}|g" \
+      -i "${MINGW_INSTALL}/etc/xml/docbook-xml"
   if [ -e ${MINGW_XML_CATALOG}/catalog.preserve ]; then
     mv ${MINGW_XML_CATALOG}/catalog.preserve ${MINGW_XML_CATALOG}/catalog
   elif [ ! -e mingw64/etc/xml/catalog ]; then


### PR DESCRIPTION
Rework some cataloging to provide a fully-qualified path.

Note that docbook-xml  is really still at 4.5 but we had included docbook5-schemas with it.