### PR TITLE
python-jedi: update to 0.14.0

### DIFF
--- a/mingw-w64-python-jedi/PKGBUILD
+++ b/mingw-w64-python-jedi/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=jedi
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=0.13.3
+pkgver=0.14.0
 pkgrel=1
 pkgdesc="Awesome autocompletion for python (mingw-w64)"
 arch=('any')
@@ -11,15 +11,16 @@ url='https://github.com/davidhalter/jedi'
 license=('MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python3"
-              "${MINGW_PACKAGE_PREFIX}-python3-parso" 
-              "${MINGW_PACKAGE_PREFIX}-python2-parso"
+             "${MINGW_PACKAGE_PREFIX}-python3-parso" 
+             "${MINGW_PACKAGE_PREFIX}-python2-parso"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
-             "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
+             "git")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python3-pytest"
               "${MINGW_PACKAGE_PREFIX}-python2-pytest")
 options=('staticlibs' 'strip' '!debug')
-source=("${_realname}-$pkgver.tar.gz"::"https://github.com/davidhalter/jedi/archive/v$pkgver.tar.gz")
-sha256sums=('e82c4933b4c9717276fa6528b91d7c667463ac2773ccecd076e6b068c70a6e0e')
+source=("https://pypi.python.org/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('49ccb782651bb6f7009810d17a3316f8867dde31654c750506970742e18b553d')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {


### PR DESCRIPTION
This updates python-jedi to 0.14.0. Source is changed because of upstream using 3rd party typeshed submodule via git.