### PR TITLE
mingw-w64-make(4.2.1): create libgnumake.dll.a when building with autoconf

### DIFF
--- a/mingw-w64-make/PKGBUILD
+++ b/mingw-w64-make/PKGBUILD
@@ -2,10 +2,11 @@
 
 _realname=make
 _autotools=yes
+_libgnumake_api_version=1
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=4.2.1
-pkgrel=2
+pkgrel=3
 pkgdesc="GNU make utility to maintain groups of programs (mingw-w64)"
 arch=('any')
 url="https://www.gnu.org/software/make"
@@ -15,16 +16,19 @@ depends=("${MINGW_PACKAGE_PREFIX}-gettext")
 makedepends=('wget')
 source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.bz2"
         'make-getopt.patch'
-        'make-linebuf-mingw.patch')
+        'make-linebuf-mingw.patch'
+        'make-4.2.1-Makefile.am-gcc-only-link-libgnumake-1.dll.a.patch')
 sha256sums=('d6e262bf3601b42d2b1e4ef8310029e1dcf20083c5446b4b7aa67081fdffc589'
             '15a86d5143c9ec6337bdd69fecb7c33c36e4fd925528dc1498b0bc4fbd31b0bb'
-            'cbb8c0a1bdd6e8174febce01946bd42da26dfcb73a7338c0a1df89ac6b8e157b')
-
+            'cbb8c0a1bdd6e8174febce01946bd42da26dfcb73a7338c0a1df89ac6b8e157b'
+            'd46b0a8cacc95e2e88c6a71c7246fd84f5fb0dea3d6c5774baaaebbfb2603ee7')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/make-getopt.patch
   patch -p1 -i ${srcdir}/make-linebuf-mingw.patch
+  patch -p1 -i ${srcdir}/make-4.2.1-Makefile.am-gcc-only-link-libgnumake-1.dll.a.patch
+  test "${_autotools}" = "yes" && autoreconf -vfi
 }
 
 build() {
@@ -48,11 +52,12 @@ package() {
   if [[ "${_autotools}" = "yes" ]]; then
     cd ${srcdir}/build-${MINGW_CHOST}
     cp -f make.exe ${pkgdir}${MINGW_PREFIX}/bin/mingw32-make.exe
+    cp -f libgnumake-${_libgnumake_api_version}.dll.a ${pkgdir}${MINGW_PREFIX}/lib/
     cp -f ${srcdir}/${_realname}-${pkgver}/gnumake.h ${pkgdir}${MINGW_PREFIX}/include/
   else
     cd ${srcdir}/${_realname}-${pkgver}
     cp -f gnumake.exe ${pkgdir}${MINGW_PREFIX}/bin/mingw32-make.exe
-    cp -f libgnumake-1.dll.a ${pkgdir}${MINGW_PREFIX}/lib/
+    cp -f libgnumake-${_libgnumake_api_version}.dll.a ${pkgdir}${MINGW_PREFIX}/lib/
     cp -f gnumake.h ${pkgdir}${MINGW_PREFIX}/include/
   fi
 }

--- a/mingw-w64-make/make-4.2.1-Makefile.am-gcc-only-link-libgnumake-1.dll.a.patch
+++ b/mingw-w64-make/make-4.2.1-Makefile.am-gcc-only-link-libgnumake-1.dll.a.patch
@@ -1,0 +1,12 @@
+diff --git a/Makefile.am b/Makefile.am
+index c88c465..ea28e54 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -26,6 +26,7 @@ if WINDOWSENV
+   MAYBE_W32 =	w32
+   W32INC =	-I $(top_srcdir)/w32/include
+   W32LIB =	-Lw32 -lw32
++  make_LDFLAGS = -Wl,--out-implib=libgnumake-1.dll.a
+   ossrc =
+ else
+   ossrc =	posixos.c


### PR DESCRIPTION
This is my first commit here - I hope that it complies with your requirements and that a new `make` package version could be shipped soon.

* Fixes msys2/MSYS2-packages#978.
* Running `autoreconf -vfi` added.
* The `LDFLAGS` added to `Makefile.am` to have gcc generate `libgnumake.dll.a` are gcc-compliant only, but this should be sufficient for the compilation purposes here.  The flags are copied from `build_w32.bat` of the `make` package `PKGBUILD` calls for a non-`autoconf` build.
* The adjustments might be rolled over to the other `make` packages.  Happy to do that.