### PR TITLE
python-mako: update to 1.0.13

### DIFF
--- a/mingw-w64-python-mako/PKGBUILD
+++ b/mingw-w64-python-mako/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=mako
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=1.0.12
+pkgver=1.0.13
 pkgrel=1
 pkgdesc="A super-fast templating language that borrows the best ideas from the existing templating languages (mingw-w64)"
 arch=('any')
@@ -20,7 +20,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python2-nose"
               "${MINGW_PACKAGE_PREFIX}-python3-nose")
 options=('staticlibs')
 source=("https://pypi.org/packages/source/M/Mako/Mako-${pkgver}.tar.gz")
-sha256sums=('0cfa65de3a835e87eeca6ac856b3013aade55f49e32515f65d999f91a2324162')
+sha256sums=('95ee720cc3453063788515d55bd7ce4a2a77b7b209e4ac70ec5c86091eb02541')
 
 prepare() {
   cd ${srcdir}


### PR DESCRIPTION
This updates python-mako to 1.0.13.