### PR TITLE
python-pillow: update to 6.1.0

### DIFF
--- a/mingw-w64-python-pillow/PKGBUILD
+++ b/mingw-w64-python-pillow/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=Pillow
 pkgbase=mingw-w64-python-pillow
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-pillow" "${MINGW_PACKAGE_PREFIX}-python3-pillow")
-pkgver=6.0.0
+pkgver=6.1.0
 pkgrel=1
 arch=('any')
 license=('custom')
@@ -25,10 +25,10 @@ source=(${_realname}-${pkgver}.tar.gz::https://github.com/python-pillow/Pillow/a
         001-freeze-support.patch
         002-shared-openjpeg.patch
         dlopen-fix.patch)
-sha256sums=('f0babf5d7072ea9923a3950cd7ea41b0008429b16584de7d95cc5550a2806cda'
+sha256sums=('9a3a613e7780362605b10765274389b3e9a6fe3201dd2bceeb422d45c5c9ba18'
             '6865da61534a45645fff71e139226bbce00c636a5f82ef824d13ad5a22efaac5'
             '581387337db4c6c0a7dae05d6462da92f47e822bd6b482a7a4e7c8637ca7e9f2'
-            '46d7a5c146ec4cc7d0f359f0875570132ce70fec4836281976da586478a09258')
+            '2154e61a7f88d4f22430fc20097431df827960777320e14f53c8e86e8f4f048b')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {

--- a/mingw-w64-python-pillow/dlopen-fix.patch
+++ b/mingw-w64-python-pillow/dlopen-fix.patch
@@ -1,6 +1,6 @@
---- Pillow-5.0.0/src/_imagingft.c.orig	2018-01-01 10:03:06.000000000 -0500
-+++ Pillow-5.0.0/src/_imagingft.c	2018-02-18 03:38:28.511730800 -0500
-@@ -28,7 +28,7 @@
+--- Pillow-6.1.0.orig/src/_imagingft.c	2019-07-04 23:53:09.565089500 -0400
++++ Pillow-6.1.0/src/_imagingft.c	2019-07-04 23:59:00.793782000 -0400
+@@ -31,7 +31,7 @@
  #define KEEP_PY_UNICODE
  #include "py3.h"
  
@@ -9,7 +9,7 @@
  #include <dlfcn.h>
  #endif
  
-@@ -142,20 +142,23 @@ setraqm(void)
+@@ -154,20 +154,23 @@
      p_raqm.raqm = NULL;
  
      /* Microsoft needs a totally different system */
@@ -32,6 +32,6 @@
  
 -#if !defined(_MSC_VER)
 +#if !defined(_MSC_VER) && !defined(__MINGW32__)
+     p_raqm.version_atleast = (t_raqm_version_atleast)dlsym(p_raqm.raqm, "raqm_version_atleast");
      p_raqm.create = (t_raqm_create)dlsym(p_raqm.raqm, "raqm_create");
      p_raqm.set_text = (t_raqm_set_text)dlsym(p_raqm.raqm, "raqm_set_text");
-     p_raqm.set_text_utf8 = (t_raqm_set_text_utf8)dlsym(p_raqm.raqm, "raqm_set_text_utf8");


### PR DESCRIPTION
This updates python-pillow to 6.1.0.