### PR TITLE
mingw-w64-make(4.2.1): bug fix to unlock GNU make's dll load feature (autotools build)

### DIFF
--- a/mingw-w64-make/PKGBUILD
+++ b/mingw-w64-make/PKGBUILD
@@ -1,12 +1,18 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 _realname=make
+# NOTE: The name of the target executable (_prog_name) MUST remain unchanged
+#       when installed, otherwise GNU make's dll load feature in connection
+#       with the target executable breaks.  The reason is that the executable
+#       name is part of the import library (libgnumake-1.dll.a) used to link
+#       customized dll's.
+#       General information at https://www.gnu.org/software/make/manual/html_node/Loading-Objects.html#Loading-Objects.
 _autotools=yes
-_libgnumake_api_version=1
+_prog_name=mingw32-make
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=4.2.1
-pkgrel=3
+pkgrel=4
 pkgdesc="GNU make utility to maintain groups of programs (mingw-w64)"
 arch=('any')
 url="https://www.gnu.org/software/make"
@@ -17,47 +23,103 @@ makedepends=('wget')
 source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.bz2"
         'make-getopt.patch'
         'make-linebuf-mingw.patch'
-        'make-4.2.1-Makefile.am-gcc-only-link-libgnumake-1.dll.a.patch')
+        'make-4.2.1-Makefile.am-gcc-only-link-libgnumake-1.dll.a.patch'
+        'make-check-load-feature.mak'
+        'mk_temp.c')
 sha256sums=('d6e262bf3601b42d2b1e4ef8310029e1dcf20083c5446b4b7aa67081fdffc589'
             '15a86d5143c9ec6337bdd69fecb7c33c36e4fd925528dc1498b0bc4fbd31b0bb'
             'cbb8c0a1bdd6e8174febce01946bd42da26dfcb73a7338c0a1df89ac6b8e157b'
-            'd46b0a8cacc95e2e88c6a71c7246fd84f5fb0dea3d6c5774baaaebbfb2603ee7')
+            '85f8c3c555079026f3debab350c9ee27a717cdd08eca3f8bf9ac58e78544d21d'
+            'f4b92323f5df81fd83f6bd0beddf85b1acff0fe4a8648fb57b8e72f12e9123a5'
+            '61d4f57c311cf2e27ccf4d1da847216730f304cf17c5c386721182ffe2d4b1aa')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
+
   patch -p1 -i ${srcdir}/make-getopt.patch
   patch -p1 -i ${srcdir}/make-linebuf-mingw.patch
   patch -p1 -i ${srcdir}/make-4.2.1-Makefile.am-gcc-only-link-libgnumake-1.dll.a.patch
+
+  # 1 - The import library libgnumake-1.dll.a contains the name of the program to be
+  #     installed.  This requires autotools to be informed about the installed program
+  #     name in case it is different from the standard name 'make' hardcoded in the GNU
+  #     Make package.
+  # 2 - automake requires hardcoded program names in any Makefile.am, i.e. in the
+  #     variable bin_PROGRAMS and the induced variables derived from the program
+  #     name.  We use sed to change the program name from 'make' to the customized
+  #     name in Makefile.am, if different from 'make'.
+  # 3 - After packaging we run a test if the dll load feature for the installed
+  #     program works.  See function 'package()'.
+  if test ${_prog_name} != make; then
+    msg2 "Changing the program name from 'make' to '${_prog_name}' in Makefile.am."
+    test -f Makefile.am.orig || mv Makefile.am Makefile.am.orig
+    local _prog_name_am=${_prog_name//[^a-zA-Z0-9@]/_}
+    sed -e "/bin_PROGRAMS/ { s:\bmake\b:${_prog_name}:g };
+            s:\bmake_\(SOURCES\|LDADD\|LDFLAGS\)\b:${_prog_name_am}_\1:g ;
+            s:\bEXTRA_make_\([A-Z]\+\):EXTRA_${_prog_name_am}_\1:g ;" \
+          Makefile.am.orig > Makefile.am
+    # log the changes made to Makefile.am by sed
+    diff -u Makefile.am.orig Makefile.am > Makefile.am.diff || true
+    cat Makefile.am.diff
+  fi
+
   test "${_autotools}" = "yes" && autoreconf -vfi
 }
 
 build() {
   if [[ "${_autotools}" = "yes" ]]; then
-    [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}
-    mkdir -p build-${MINGW_CHOST} && cd build-${MINGW_CHOST}
+    mkdir -vp build-${MINGW_CHOST}
+    cd build-${MINGW_CHOST}
     ../${_realname}-${pkgver}/configure \
+      -C \
       --prefix=${MINGW_PREFIX} \
       --host=${MINGW_CHOST} \
       --without-libintl-prefix \
       --without-libiconv-prefix \
+      CPPFLAGS=-DMAKE_LOAD \
+      CFLAGS=-mthreads \
       ac_cv_dos_paths=yes
+    # Create _prog_name and associated import library libgnumake-1.dll.a.
     make -j1
   else
+    [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}
+    mkdir -p build-${MINGW_CHOST} && cd build-${MINGW_CHOST}
+    # Create gnumake.exe and associated import library libgnumake-1.dll.a.
     cmd /c 'build_w32.bat --without-guile gcc'
   fi
 }
 
 package() {
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/{bin,lib,include}
-  if [[ "${_autotools}" = "yes" ]]; then
-    cd ${srcdir}/build-${MINGW_CHOST}
-    cp -f make.exe ${pkgdir}${MINGW_PREFIX}/bin/mingw32-make.exe
-    cp -f libgnumake-${_libgnumake_api_version}.dll.a ${pkgdir}${MINGW_PREFIX}/lib/
-    cp -f ${srcdir}/${_realname}-${pkgver}/gnumake.h ${pkgdir}${MINGW_PREFIX}/include/
+  local _exe_name
+  local _exe_dir
+  if test ${_autotools} = yes; then
+    # Built with autotools.
+    _exe_dir=${srcdir}/build-${MINGW_CHOST}
+    _exe_name=${_prog_name}.exe
   else
-    cd ${srcdir}/${_realname}-${pkgver}
-    cp -f gnumake.exe ${pkgdir}${MINGW_PREFIX}/bin/mingw32-make.exe
-    cp -f libgnumake-${_libgnumake_api_version}.dll.a ${pkgdir}${MINGW_PREFIX}/lib/
-    cp -f gnumake.h ${pkgdir}${MINGW_PREFIX}/include/
+    # Built by running build_w32.bat.
+    # NOTE: If the name of the installed executable is NOT 'gnumake.exe', the dll
+    #       load feature should not work and the test below is expected to fail.
+    _exe_dir=${srcdir}/${_realname}-${pkgver}/GccRel
+    _exe_name=gnumake.exe
+  fi
+  mkdir -pv ${pkgdir}${MINGW_PREFIX}/{bin,lib,include}
+  cp -fv ${_exe_dir}/${_exe_name}                     ${pkgdir}${MINGW_PREFIX}/bin/
+  cp -fv ${_exe_dir}/libgnumake-1.dll.a               ${pkgdir}${MINGW_PREFIX}/lib/
+  cp -fv ${srcdir}/${_realname}-${pkgver}/gnumake.h   ${pkgdir}${MINGW_PREFIX}/include/
+
+  # Run check on packaged program and import library:
+  msg "Checking if GNU Make's dll loading feature we compiled into ${_prog_name}.exe works ..."
+  rm -fv ${srcdir}/*.dll
+  if ${pkgdir}${MINGW_PREFIX}/bin/${_prog_name}.exe \
+      -C ${srcdir} \
+      -f make-check-load-feature.mak \
+      --debug=v \
+      LIBS="${pkgdir}${MINGW_PREFIX}/lib/libgnumake-1.dll.a"
+  then
+    msg2 "PASSED"
+  else
+    error "FAILED"
+    exit 1
   fi
 }

--- a/mingw-w64-make/make-4.2.1-Makefile.am-gcc-only-link-libgnumake-1.dll.a.patch
+++ b/mingw-w64-make/make-4.2.1-Makefile.am-gcc-only-link-libgnumake-1.dll.a.patch
@@ -1,11 +1,13 @@
-diff --git a/Makefile.am b/Makefile.am
-index c88c465..ea28e54 100644
---- a/Makefile.am
-+++ b/Makefile.am
-@@ -26,6 +26,7 @@ if WINDOWSENV
+diff --git "a/Makefile.am" "b/Makefile.am"
+index c88c465..9c1bb4d 100644
+--- "a/Makefile.am"
++++ "b/Makefile.am"
+@@ -25,7 +25,8 @@ MAKE_HOST =	@MAKE_HOST@
+ if WINDOWSENV
    MAYBE_W32 =	w32
    W32INC =	-I $(top_srcdir)/w32/include
-   W32LIB =	-Lw32 -lw32
+-  W32LIB =	-Lw32 -lw32
++  W32LIB =	$(top_builddir)/w32/libw32.a
 +  make_LDFLAGS = -Wl,--out-implib=libgnumake-1.dll.a
    ossrc =
  else

--- a/mingw-w64-make/make-check-load-feature.mak
+++ b/mingw-w64-make/make-check-load-feature.mak
@@ -1,0 +1,25 @@
+# Check whether GNU Make's dll load feature
+# - is unlocked and compiled into $(MAKE)
+# - works when using the compiled import library libgnumake-1.dll.a
+
+# Check if our make prog is compiled with activated load feature.
+ifeq ($(filter load,$(.FEATURES)),)
+  $(error FAILED ...GNU Make feature to load a dll not active in executable '$(MAKE)')
+else
+  $(warning PASSED ... GNU Make feature to load a dll active in executable '$(MAKE)'.)
+endif
+
+# If loading the dll fails, make will try to build the
+# target 'mk_temp.dll' and restart from scratch again.
+-load mk_temp.dll
+
+# Run and check the new make function 'mk-temp'.
+.PHONY: all
+TXT_ERROR=FAILED Temporary file not created
+TXT_PASSED=PASSED Temporary file created.
+all:
+	$(if $(mk-temp tmpfile.),$(warning $(TXT_PASSED)),$(error $(TXT_ERROR)))
+
+%.dll: %.c
+	$(warning Compiling $@.)
+	gcc -shared -fPIC -o $@ $< $(if $(LIBS),$(LIBS),-lgnumake-1)

--- a/mingw-w64-make/mk_temp.c
+++ b/mingw-w64-make/mk_temp.c
@@ -1,0 +1,55 @@
+
+/* Sample from example in GNU Make Manual
+ * (https://www.gnu.org/software/make/manual/html_node/Loaded-Object-Example.html#Loaded-Object-Example)
+ * with minor edits for error reporting.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include <gnumake.h>
+
+int plugin_is_GPL_compatible;
+
+char *
+gen_tmpfile ( const char *nm, unsigned int argc, char **argv )
+{
+  int fd;
+
+  /* Compute the size of the filename and allocate space for it.  */
+  int len = strlen ( argv[0] ) + 6 + 1;
+  char *buf = gmk_alloc ( len );
+
+  strcpy ( buf, argv[0] );
+  strcat ( buf, "XXXXXX" );
+
+  fd = mkstemp ( buf );
+  if ( fd >= 0 ) {
+    /* Don't leak the file descriptor.  */
+    close ( fd );
+  } else {
+    /* Failure.  */
+    fprintf ( stderr, "%s:%d: error: mkstemp(%s) failed: %s\n"
+              , __FILE__, __LINE__, buf, strerror ( errno ) );
+    gmk_free ( buf );
+    buf = NULL;
+  }
+
+  return buf;
+}
+
+int
+mk_temp_gmk_setup (const gmk_floc *floc)
+{
+  const char* funcnm = "mk-temp";
+
+  fprintf(stderr, "%s:%d(%s): Registering function with make name '%s', implemented in '%s'.\n",
+          floc->filenm, floc->lineno, __FILE__, funcnm, "mk_temp.dll");
+
+  /* Register the function with make name "mk-temp".  */
+  gmk_add_function ( funcnm, gen_tmpfile, 1, 1, 1 );
+  return 1;
+}


### PR DESCRIPTION
Addition to #5574:

1.  BugFix: Unlock GNU Make's dll load feature in the executable.
2.  BugFix: User-defined dll's for the dll load feature are linked against     the created import library libgnumake-1.dll.a which itself refers   to its associated executable.  The executable name is hardcoded in the     import library.  In order not to break the dll load feature, this implies     for the autotools build branch that in the installation process the     executable must not be renamed and autotools has to create the main     executable with our preferred name  (here: mingw32-make.exe).  Thus     the autotools package is to be informed about the new executable name     if different from 'make'.
3.  Update the build branch using build_w32.bat of the GNU Make package.     The standard executable is 'gnumake' which currently cannot be changed     without breaking the dll load feature.

Documentation on GNU make's dll load feature: [here](https://www.gnu.org/software/make/manual/html_node/Loading-Objects.html#Loading-Objects).

Apologies for the lengthy comments containing the essentials about the commit. Please feel free to edit and shorten as you might consider it apporpriate.