### PR TITLE
wxSVG: Add pkg-config as build dependency

### DIFF
--- a/mingw-w64-wxSVG/PKGBUILD
+++ b/mingw-w64-wxSVG/PKGBUILD
@@ -4,7 +4,7 @@ _realname=wxsvg
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgbase="mingw-w64-${_realname}"
 pkgver=1.5.19
-pkgrel=1
+pkgrel=2
 pkgdesc="A C++ library to create, manipulate and render SVG files (mingw-w64)"
 arch=("any")
 url="http://wxsvg.sourceforge.net/"
@@ -16,7 +16,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-wxWidgets"
          "${MINGW_PACKAGE_PREFIX}-libexif"
          "${MINGW_PACKAGE_PREFIX}-ffmpeg")
 makedepends=("bsdtar"
-             "${MINGW_PACKAGE_PREFIX}-gcc")
+             "${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config")
 source=("https://downloads.sourceforge.net/project/wxsvg/wxsvg/${pkgver}/wxsvg-${pkgver}.tar.bz2")
 sha256sums=('3f78783fb1ea8242cc3f5f4d9b5ca8c79ea90f0837849f5a908478e13a560f9e')
 extractdir="${_realname}-${pkgver}"


### PR DESCRIPTION
Simply adds `${MINGW_PACKAGE_PREFIX}-pkg-config` as build dependency.