### PR TITLE
New package: md4c

### DIFF
--- a/mingw-w64-md4c/001-md4c-0.3.4-md2html-add-exe-suffix.patch
+++ b/mingw-w64-md4c/001-md4c-0.3.4-md2html-add-exe-suffix.patch
@@ -1,0 +1,9 @@
+diff -ruN a/md2html/CMakeLists.txt b/md2html/CMakeLists.txt
+--- a/md2html/CMakeLists.txt	2019-06-19 15:04:48.000000000 +0000
++++ b/md2html/CMakeLists.txt	2019-07-11 07:28:37.465695100 +0000
+@@ -4,4 +4,4 @@
+ add_executable(md2html cmdline.c cmdline.h entity.c entity.h md2html.c render_html.c render_html.h)
+ target_link_libraries(md2html md4c)
+ 
+-install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/md2html DESTINATION ${CMAKE_INSTALL_BINDIR})
++install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/md2html.exe DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/mingw-w64-md4c/PKGBUILD
+++ b/mingw-w64-md4c/PKGBUILD
@@ -12,6 +12,7 @@ license=("MIT")
 depends=()
 makedepends=("bsdtar"
              "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-gcc")
 source=("${url}/archive/release-${pkgver}.tar.gz")
 sha256sums=("cf3f6b75d4b1304551a68272d3b403e4cd0952d976a280e8b7db68090354486f")
@@ -38,17 +39,19 @@ build() {
 
     MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     "${MINGW_PREFIX}/bin/cmake" \
-        -G "MSYS Makefiles" \
+        -G "Ninja" \
         -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
         -DBUILD_SHARED_LIBS=ON \
         "${extra_config[@]}" \
         "../${extractdir}"
-    make
+
+    ninja
 }
 
 package() {
     cd "${srcdir}/${builddir_static}"
-    ${MINGW_PREFIX}/bin/cmake -DCMAKE_INSTALL_PREFIX:PATH=${pkgdir}${MINGW_PREFIX} -P cmake_install.cmake
+
+    DESTDIR="${pkgdir}" ninja install
 
     # license
     install -Dm644 "${srcdir}/${extractdir}/LICENSE.md" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.md"

--- a/mingw-w64-md4c/PKGBUILD
+++ b/mingw-w64-md4c/PKGBUILD
@@ -4,7 +4,7 @@ _realname=md4c
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgbase="mingw-w64-${_realname}"
 pkgver=0.3.4
-pkgrel=1
+pkgrel=2
 pkgdesc="C Markdown parser implementation compliant to CommonMark specification"
 arch=("any")
 url="https://github.com/mity/md4c"
@@ -40,6 +40,7 @@ build() {
     "${MINGW_PREFIX}/bin/cmake" \
         -G "MSYS Makefiles" \
         -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+        -DBUILD_SHARED_LIBS=ON \
         "${extra_config[@]}" \
         "../${extractdir}"
     make

--- a/mingw-w64-md4c/PKGBUILD
+++ b/mingw-w64-md4c/PKGBUILD
@@ -1,0 +1,54 @@
+# Maintainer: Jordan Irwin <antumdeluge@gmail.com>
+
+_realname=md4c
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgbase="mingw-w64-${_realname}"
+pkgver=0.3.4
+pkgrel=1
+pkgdesc="C Markdown parser implementation compliant to CommonMark specification"
+arch=("any")
+url="https://github.com/mity/md4c"
+license=("MIT")
+depends=()
+makedepends=("bsdtar"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-gcc")
+source=("${url}/archive/release-${pkgver}.tar.gz")
+sha256sums=("cf3f6b75d4b1304551a68272d3b403e4cd0952d976a280e8b7db68090354486f")
+extractdir="${_realname}-release-${pkgver}"
+builddir_static="build-${CARCH}-static"
+
+prepare() {
+    cd "${srcdir}/${extractdir}"
+    patch -p1 -i "${startdir}/001-md4c-0.3.4-md2html-add-exe-suffix.patch"
+}
+
+build() {
+    # TODO: add shared build
+    # static build
+    [[ -d "${srcdir}/${builddir_static}" ]] && rm -rf "${srcdir}/${builddir_static}"
+    mkdir -p "${srcdir}/${builddir_static}" && cd "${srcdir}/${builddir_static}"
+
+    declare -a extra_config
+    if check_option "debug" "n"; then
+        extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+    else
+        extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+    fi
+
+    MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    "${MINGW_PREFIX}/bin/cmake" \
+        -G "MSYS Makefiles" \
+        -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+        "${extra_config[@]}" \
+        "../${extractdir}"
+    make
+}
+
+package() {
+    cd "${srcdir}/${builddir_static}"
+    ${MINGW_PREFIX}/bin/cmake -DCMAKE_INSTALL_PREFIX:PATH=${pkgdir}${MINGW_PREFIX} -P cmake_install.cmake
+
+    # license
+    install -Dm644 "${srcdir}/${extractdir}/LICENSE.md" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.md"
+}


### PR DESCRIPTION
C Markdown parser implementation compliant to CommonMark specification.

Homepage: https://github.com/mity/md4c