### PR TITLE
gtk3: re-enable gtk debug features

### DIFF
--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gtk3
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.24.10
-pkgrel=1
+pkgrel=2
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
 url="https://www.gtk.org/"
@@ -44,6 +44,7 @@ build() {
   [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
   mkdir "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
 
+  CFLAGS+=" -DG_ENABLE_DEBUG -DG_DISABLE_CAST_CHECKS"
   meson \
     --buildtype=plain \
     -Dbroadway_backend=true \


### PR DESCRIPTION
gtk ties the debug options to the build type, but since we use "plain" so that
the the makepkg CFLAGS get used we lose that.

Instead pass the CFLAGS manually.

See https://gitlab.gnome.org/GNOME/gtk/issues/2020