### PR TITLE
gtk3: fix broken menu borders

### DIFF
--- a/mingw-w64-gtk3/0002-Revert-Quartz-Set-the-popup-menu-type-hint-before-re.patch
+++ b/mingw-w64-gtk3/0002-Revert-Quartz-Set-the-popup-menu-type-hint-before-re.patch
@@ -1,0 +1,37 @@
+From b298190f63af35003e59145f8ce570a9e8bfbb13 Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Fri, 12 Jul 2019 18:56:15 +0200
+Subject: [PATCH] Revert ""]Quartz] Set the popup menu type hint before
+ realizing the popup.""
+
+This reverts commit 13e64aa1032ad6c41f8061a0b64e54ef7e970344.
+---
+ gtk/gtkmenu.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/gtk/gtkmenu.c b/gtk/gtkmenu.c
+index 32ed9b3f45..f12deb52ff 100644
+--- a/gtk/gtkmenu.c
++++ b/gtk/gtkmenu.c
+@@ -5268,15 +5268,15 @@ gtk_menu_position (GtkMenu  *menu,
+                                          !!(anchor_hints & GDK_ANCHOR_RESIZE_X),
+                                          !!(anchor_hints & GDK_ANCHOR_RESIZE_Y));
+ 
+-  if (!gtk_widget_get_visible (priv->toplevel))
+-    gtk_window_set_type_hint (GTK_WINDOW (priv->toplevel), priv->menu_type_hint);
+-
+   /* Realize so we have the proper width and height to figure out
+    * the right place to popup the menu.
+    */
+   gtk_widget_realize (priv->toplevel);
+   gtk_window_move_resize (GTK_WINDOW (priv->toplevel));
+ 
++  if (!gtk_widget_get_visible (priv->toplevel))
++    gtk_window_set_type_hint (GTK_WINDOW (priv->toplevel), priv->menu_type_hint);
++
+   if (text_direction == GTK_TEXT_DIR_NONE)
+     text_direction = gtk_widget_get_direction (GTK_WIDGET (menu));
+ 
+-- 
+2.22.0
+

--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gtk3
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.24.10
-pkgrel=2
+pkgrel=3
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
 url="https://www.gtk.org/"
@@ -29,15 +29,20 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-shared-mime-info")
 options=('strip' '!debug' 'staticlibs')
 source=("https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}.tar.xz"
-        "0001-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch")
+        "0001-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch"
+        "0002-Revert-Quartz-Set-the-popup-menu-type-hint-before-re.patch")
 sha256sums=('35a8f107e2b90fda217f014c0c15cb20a6a66678f6fd7e36556d469372c01b03'
-            'f6f8019e21b2932ee2cfb3b261d57b79f6492d4f0a61f9fbf5b8edd193758d9a')
+            'f6f8019e21b2932ee2cfb3b261d57b79f6492d4f0a61f9fbf5b8edd193758d9a'
+            '5cdebb11098d241da955d4662904215275fa7a54d52877cc38c4ff4a3087fafd')
 
 prepare() {
   cd "${srcdir}/gtk+-${pkgver}"
 
   # https://bugzilla.gnome.org/show_bug.cgi?id=778791
   patch -p1 -i "${srcdir}"/0001-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch
+
+  # https://gitlab.gnome.org/GNOME/gtk/issues/2019
+  patch -p1 -i "${srcdir}"/0002-Revert-Quartz-Set-the-popup-menu-type-hint-before-re.patch
 }
 
 build() {


### PR DESCRIPTION
revert the upstream commit causing it for starters

See https://gitlab.gnome.org/GNOME/gtk/issues/2019

@Ede123 