### PR TITLE
protobuf and protobuf-c: update to 3.9.0 and 1.3.2

### DIFF
--- a/mingw-w64-protobuf-c/PKGBUILD
+++ b/mingw-w64-protobuf-c/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=protobuf-c
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.3.1
+pkgver=1.3.2
 pkgrel=1
 pkgdesc="Protocol Buffers implementation in C (mingw-w64)"
 arch=('any')
@@ -13,7 +13,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-protobuf")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 options=('staticlibs' 'strip')
 source=("$url/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('51472d3a191d6d7b425e32b612e477c06f73fe23e07f6a6a839b11808e9d2267')
+sha256sums=('53f251f14c597bdb087aecf0b63630f434d73f5a10fc1ac545073597535b9e74')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"

--- a/mingw-w64-protobuf/PKGBUILD
+++ b/mingw-w64-protobuf/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=protobuf
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.8.0
+pkgver=3.9.0
 _gtest_ver=1.8.1
 pkgrel=1
 pkgdesc="Protocol Buffers - Google's data interchange format (mingw-w64)"
@@ -19,7 +19,7 @@ source=(${_realname}-${pkgver}.tar.gz::https://github.com/google/protobuf/archiv
         0001-protobuf-3.1.0-gcc6.2.0-tests.patch
         0002-windres-invocation.patch)
 noextract=("${_realname}-${pkgver}.tar.gz")
-sha256sums=('03d2e5ef101aee4c2f6ddcf145d2a04926b9c19e7086944df3842b1b8502b783'
+sha256sums=('2ee9dcec820352671eb83e081295ba43f7a4157181dad549024d7070d079cf65'
             '9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c'
             '15c2248597356040be0111d5bfc7317d59a49552d5cd05b0fa70c76980b7ca66'
             '7c5434ca428784058d6a3bb4a14ff8ff2c4ee843c51800751bbee599d5a63288')


### PR DESCRIPTION
This updates protobuf to 3.9.0 and protobuf-c to 1.3.2.