### PR TITLE
ghex: update to 3.18.4

### DIFF
--- a/mingw-w64-ghex/001-nohelp.patch
+++ b/mingw-w64-ghex/001-nohelp.patch
@@ -1,11 +1,9 @@
---- ./Makefile.am.orig	2015-02-03 21:31:06.938593300 +0100
-+++ ./Makefile.am	2015-02-03 21:31:09.376081200 +0100
-@@ -2,7 +2,7 @@
+--- ghex-3.18.4.orig/meson.build	2019-07-13 12:32:37.053697800 -0400
++++ ghex-3.18.4/meson.build	2019-07-13 12:33:20.793687700 -0400
+@@ -95,6 +95,5 @@
+ subdir('data')
+ subdir('icons')
+ subdir('po')
+-subdir('help')
  
- ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
- 
--SUBDIRS = data po help src icons
-+SUBDIRS = data po src icons
- 
- EXTRA_DIST =			\
- 	COPYING-DOCS		\
+ meson.add_install_script('meson_post_install.py')

--- a/mingw-w64-ghex/002-fread.patch
+++ b/mingw-w64-ghex/002-fread.patch
@@ -1,5 +1,5 @@
---- ./src/hex-document.c.orig	2014-04-14 22:42:15.000000000 +0200
-+++ ./src/hex-document.c	2015-02-15 10:48:42.205722500 +0100
+--- ghex-3.18.4.orig/src/hex-document.c	2019-07-13 12:32:37.104694200 -0400
++++ ghex-3.18.4/src/hex-document.c	2019-07-13 12:36:29.883514700 -0400
 @@ -652,7 +652,7 @@
  	if(!get_document_attributes(doc))
  		return FALSE;

--- a/mingw-w64-ghex/PKGBUILD
+++ b/mingw-w64-ghex/PKGBUILD
@@ -3,52 +3,48 @@
 _realname=ghex
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.18.3
+pkgver=3.18.4
 pkgrel=1
+pkgdesc="A simple binary editor for the Gnome desktop (mingw-w64)"
+url="https://wiki.gnome.org/Apps/Ghex"
 arch=('any')
-pkgdesc="GNOME Hex editor for files (mingw-w64)"
+license=("GPL2")
 options=(strip staticlibs)
-depends=("${MINGW_PACKAGE_PREFIX}-gtk3"
-         "${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme")
+depends=("${MINGW_PACKAGE_PREFIX}-gtk3")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
-license=("GPL 2")
-url="https://www.gnome.org"
 install=ghex-${CARCH}.install
 source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz
         001-nohelp.patch
         002-fread.patch)
-sha256sums=('c67450f86f9c09c20768f1af36c11a66faf460ea00fbba628a9089a6804808d3'
-            'cd87d0040cd37a942ff8a1e3013bc96083920dc959dac0a96b543b8b706585ff'
-            '8e403c1e7c3f83adc768bfe45bb1ea42ae90fc4dfb7fe9bf4544820541a3241d')
+sha256sums=('c2d9c191ff5bce836618779865bee4059db81a3a0dff38bda3cc7a9e729637c0'
+            '30a351ef0c0b0bc319edec222de5222879b8eecfb58237e5b25c3c1dccf02788'
+            '670d0ac95803ea84e53d2d3ee27bd272599c4cab92501426644bfde9fef3d2ae')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
-
-  patch -p0 -i ${srcdir}/001-nohelp.patch
-  patch -p0 -i ${srcdir}/002-fread.patch
-
-  autoreconf -ifv
+  patch -Np1 -i ${srcdir}/001-nohelp.patch
+  patch -Np1 -i ${srcdir}/002-fread.patch
 }
 
 build() {
-  [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}
-  mkdir -p build-${MINGW_CHOST}
-  cd build-${MINGW_CHOST}
+  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
+  mkdir -p ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
 
-  ../${_realname}-${pkgver}/configure \
-    --host=${MINGW_CHOST} \
-    --target=${MINGW_CHOST} \
-    --build=${MINGW_CHOST} \
-    --prefix=${MINGW_PREFIX} \
-    --libexecdir=${MINGW_PREFIX}/lib
+  meson \
+    --buildtype=plain \
+    -Ddefault_library=both \
+    "../${_realname}-${pkgver}"
 
-  make
+  ninja
 }
 
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
-  make DESTDIR=${pkgdir} install
+  DESTDIR=${pkgdir}${MINGW_PREFIX} ninja install
+
+  sed -s "s|$(cygpath -m ${MINGW_PREFIX})|${MINGW_PREFIX}|g" -i "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/gtkhex-3.pc"
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-ghex/ghex-i686.install
+++ b/mingw-w64-ghex/ghex-i686.install
@@ -1,6 +1,5 @@
 post_install() {
   mingw32/bin/gtk-update-icon-cache-3.0 -f -t /mingw32/share/icons/hicolor
-  mingw32/bin/gtk-update-icon-cache-3.0 -f -t /mingw32/share/icons/HighContrast
   mingw32/bin/glib-compile-schemas /mingw32/share/glib-2.0/schemas
 }
 

--- a/mingw-w64-ghex/ghex-x86_64.install
+++ b/mingw-w64-ghex/ghex-x86_64.install
@@ -1,6 +1,5 @@
 post_install() {
   mingw64/bin/gtk-update-icon-cache-3.0 -f -t /mingw64/share/icons/hicolor
-  mingw64/bin/gtk-update-icon-cache-3.0 -f -t /mingw64/share/icons/HighContrast
   mingw64/bin/glib-compile-schemas /mingw64/share/glib-2.0/schemas
 }
 


### PR DESCRIPTION
This updates ghex to 3.18.4, ports it to meson and removes adwaita-icon-theme from depends because gtk3 already depends on it.