### PR TITLE
updated mono to 5.20.1.19 package.

### DIFF
--- a/mingw-w64-mono/PKGBUILD
+++ b/mingw-w64-mono/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=mono
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_gitcommit=d75c142a4646af45f680cd90cafe05843d1d5945
-pkgver=6.0.0.176
+_gitcommit=886c49017470112af1a73034d8951d6ca00b641e
+pkgver=5.20.1.19
 pkgrel=1
 pkgdesc='Free implementation of the .NET platform including runtime and compiler (mingw-w64)'
 url='http://www.mono-project.com/'
@@ -126,12 +126,12 @@ package() {
   cd "${srcdir}"/build-${CARCH}
   make DESTDIR="${pkgdir}" install
   make -C mcs/jay DESTDIR="${pkgdir}" prefix=${MINGW_PREFIX} install
-  
+
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
   # Fix paths in bin directory
   for f in ${pkgdir}${MINGW_PREFIX}/bin/{al,al2,caspol,cccheck,ccrewrite,cert2spc,certmgr,cert-sync,chktrust,crlupdate,csc,csc-dim,csharp,csi,disco,dmcs,dtd2rng,dtd2xsd,gacutil,gacutil2,genxs,httpcfg,ikdasm,ilasm,illinkanalyzer,installvst,lc,macpack,makecert,mconfig,mcs,mdassembler,mdbrebase,mdoc,mdoc-assemble,mdoc-export-html,mdoc-export-msxdoc,mdoc-update,mdoc-validate,mdvalidater,mkbundle,mod,mono-api-html,mono-api-info,mono-cil-strip,mono-configuration-crypto,monodocer,monodocs2html,monodocs2slashdoc,mono-find-provides,mono-find-requires,monolinker,monop,monop2,mono-package-runtime,mono-service,mono-service2,mono-shlib-cop,mono-symbolicate,mono-test-install,mono-xmltool,mozroots,pdb2mdb,permview,peverify,resgen,resgen2,secutil,setreg,sgen,signcode,sn,soapsuds,sqlmetal,sqlsharp,svcutil,vbc,wsdl,wsdl2,xbuild,xsd}; do
     sed -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${f}
   done
-  
+
   mv  ${pkgdir}${MINGW_PREFIX}/bin/mono{,.exe}
 }


### PR DESCRIPTION
This put's the mono package on par with arch, tested compile on both x86_64 and i686, packages built locally.