### PR TITLE
python3-sphinx: Add missing dependency

### DIFF
--- a/mingw-w64-python3-sphinx/PKGBUILD
+++ b/mingw-w64-python3-sphinx/PKGBUILD
@@ -6,7 +6,7 @@ _realname=sphinx
 pkgbase=mingw-w64-python3-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=2.1.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Python documentation generator (mingw-w64)"
 arch=('any')
 license=('BSD')
@@ -14,6 +14,7 @@ url="http://www.sphinx-doc.org/"
 
 depends=(
     "${MINGW_PACKAGE_PREFIX}-python3-babel"
+    "${MINGW_PACKAGE_PREFIX}-python3-colorama"
     "${MINGW_PACKAGE_PREFIX}-python3-docutils"
     "${MINGW_PACKAGE_PREFIX}-python3-imagesize"
     "${MINGW_PACKAGE_PREFIX}-python3-jinja"


### PR DESCRIPTION
colorama was missing.