### PR TITLE
lld: Backport TLS and whole-archive fixes

### DIFF
--- a/mingw-w64-clang/0305-lld-exception-handling.patch
+++ b/mingw-w64-clang/0305-lld-exception-handling.patch
@@ -71,16 +71,42 @@ Index: lld/trunk/COFF/Writer.cpp
 ===================================================================
 --- lld/trunk/COFF/Writer.cpp
 +++ lld/trunk/COFF/Writer.cpp
-@@ -733,7 +733,13 @@
+@@ -688,6 +688,28 @@
+     IATSize += C->getSize();
+ }
+ 
++// Return whether a SectionChunk's suffix (the dollar and any trailing
++// suffix) should be removed and sorted into the main suffixless
++// PartialSection.
++static bool shouldStripSectionSuffix(SectionChunk *SC, StringRef Name) {
++  // On MinGW, comdat groups are formed by putting the comdat group name
++  // after the '$' in the section name. For .eh_frame$<symbol>, that must
++  // still be sorted before the .eh_frame trailer from crtend.o, thus just
++  // strip the section name trailer. For other sections, such as
++  // .tls$$<symbol> (where non-comdat .tls symbols are otherwise stored in
++  // ".tls$"), they must be strictly sorted after .tls. And for the
++  // hypothetical case of comdat .CRT$XCU, we definitely need to keep the
++  // suffix for sorting. Thus, to play it safe, only strip the suffix for
++  // the standard sections.
++  if (!Config->MinGW)
++    return false;
++  if (!SC || !SC->isCOMDAT())
++    return false;
++  return Name.startswith(".text$") || Name.startswith(".data$") ||
++         Name.startswith(".rdata$") || Name.startswith(".pdata$") ||
++         Name.startswith(".xdata$") || Name.startswith(".eh_frame$");
++}
++
+ // Create output section objects and add them to OutputSections.
+ void Writer::createSections() {
+   // First, create the builtin sections.
+@@ -733,7 +755,10 @@
          SC->printDiscardedMessage();
        continue;
      }
 -    Map[{C->getSectionName(), C->getOutputCharacteristics()}].push_back(C);
 +    StringRef Name = C->getSectionName();
-+    // On MinGW, comdat groups are formed by putting the comdat group name
-+    // after the '$' in the section name. Such a section name suffix shouldn't
-+    // imply separate alphabetical sorting of those section chunks though.
-+    if (Config->MinGW && SC && SC->isCOMDAT())
++    if (shouldStripSectionSuffix(SC, Name))
 +      Name = Name.split('$').first;
 +    Map[{Name, C->getOutputCharacteristics()}].push_back(C);
    }

--- a/mingw-w64-clang/0307-lld-fix-whole-archive.patch
+++ b/mingw-w64-clang/0307-lld-fix-whole-archive.patch
@@ -1,0 +1,15 @@
+Index: lld/trunk/COFF/Driver.cpp
+===================================================================
+--- lld/trunk/COFF/Driver.cpp
++++ lld/trunk/COFF/Driver.cpp
+@@ -167,7 +167,9 @@
+       std::unique_ptr<Archive> File =
+           CHECK(Archive::create(MBRef), Filename + ": failed to parse archive");
+ 
+-      for (MemoryBufferRef M : getArchiveMembers(File.get()))
++      Archive *archive = File.get();
++      make<std::unique_ptr<Archive>>(std::move(File)); // take ownership
++      for (MemoryBufferRef M : getArchiveMembers(archive))
+         addArchiveBuffer(M, "<whole-archive>", Filename);
+       return;
+     }

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -29,7 +29,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-llvm"
          "${MINGW_PACKAGE_PREFIX}-polly")
 pkgver=8.0.1
-pkgrel=1
+pkgrel=2
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 url="https://llvm.org/"
@@ -85,6 +85,7 @@ source=(https://github.com/llvm/llvm-project/releases/download/llvmorg-$pkgver/l
         "0304-lld-version-flags.patch"
         "0305-lld-exception-handling.patch"
         "0306-lld-fix-static-lib.patch"
+        "0307-lld-fix-whole-archive.patch"
         "0401-disable-visibility-annotations.patch"
         "0405-fix-conflict-win32-posix-threads.patch"
         "0406-fix-static_asserts-and-unique_ptr-for-libcxx.patch"
@@ -152,8 +153,9 @@ sha256sums=('44787a6d02f7140f145e2250d56c9f849334e11f9ae379827510ed72f12b75e7'
             '994aba4761990d5addb2581e5a985fd8278ff1c05a77cac963ce0396126bbd07'
             '63ffa972420d32befdb0812dc8f7da06433a3c16cc93f2daedad6d72d0714e69'
             'cd8417499aa2d49e21847eec24e0fe33ec77376639f0fc011e1077e21456525c'
-            'b99dd4f250706a75c076797f2b2e0a9848187869df822ab78633c3acc805f799'
+            'ef4d241a113f55ae0ac912deeb3d275a437d225c1eefeeff6936a2258c668b9a'
             '526264f75e9ad32391cbb0c2ac8c946f282378e99a931c375981aeae110b56ed'
+            '119263d21c7a75f8ae8f70e4a401e42ccf31d688b9bc5ad4711fcc79a212198e'
             '219eca2ad015ababb05d81ed97b4b40cf13ea189ee93cf57aa814cca7cf40001'
             '2f8f3c819837e4a16a364ed6e2a0a879cd10f924169ed7d89c27c1ed64edfe95'
             'a219798d0199e0b34c90fcdacada7e0f6d179fa4349a26bce8f714173046ecc7'
@@ -220,6 +222,7 @@ prepare() {
   patch -p2 -i "${srcdir}/0304-lld-version-flags.patch"
   patch -p2 -i "${srcdir}/0305-lld-exception-handling.patch"
   patch -p2 -i "${srcdir}/0306-lld-fix-static-lib.patch"
+  patch -p2 -i "${srcdir}/0307-lld-fix-whole-archive.patch"
 
   cd "${srcdir}/libcxx-${pkgver}.src"
   patch -p1 -i "${srcdir}/0401-disable-visibility-annotations.patch"


### PR DESCRIPTION
Upstream patch: https://reviews.llvm.org/D65018