### PR TITLE
python3: build with PGO+LTO

### DIFF
--- a/mingw-w64-python3/2060-pass-gen-profile-ldflags.patch
+++ b/mingw-w64-python3/2060-pass-gen-profile-ldflags.patch
@@ -1,0 +1,11 @@
+--- Python-3.7.4/Makefile.pre.in.orig	2019-07-22 09:15:44.386184900 +0200
++++ Python-3.7.4/Makefile.pre.in	2019-07-22 08:57:45.643259600 +0200
+@@ -713,7 +713,7 @@
+ $(DLLLIBRARY) libpython$(LDVERSION).dll.a: $(LIBRARY_OBJS) python_nt.o
+ 	if test -n "$(DLLLIBRARY)"; then \
+ 		$(LDSHARED) -Wl,--out-implib=$@ -o $(DLLLIBRARY) $^ \
+-			$(LIBS) $(MODLIBS) $(SYSLIBS) $(LDLAST) python_nt.o; \
++			$(LIBS) $(LDFLAGS_NODIST) $(MODLIBS) $(SYSLIBS) $(LDLAST) python_nt.o; \
+ 	else true; \
+ 	fi
+ 

--- a/mingw-w64-python3/PKGBUILD
+++ b/mingw-w64-python3/PKGBUILD
@@ -18,7 +18,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _pybasever=3.7
 pkgver=${_pybasever}.4
-pkgrel=2
+pkgrel=3
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 license=('PSF')
@@ -132,6 +132,7 @@ source=("https://www.python.org/ftp/python/${pkgver%rc?}/Python-${pkgver}.tar.xz
         2050-undo-venv-redirector.patch
         2051-set-venv-activate-path-unix.patch
         2052-venv-remove-msys-from-env-and-add-exe-prefix.patch
+        2060-pass-gen-profile-ldflags.patch
         smoketests.py)
 
 # Helper macros to help make tasks easier #
@@ -303,6 +304,8 @@ prepare() {
   apply_patch_with_msg 2051-set-venv-activate-path-unix.patch
   apply_patch_with_msg 2052-venv-remove-msys-from-env-and-add-exe-prefix.patch
 
+  apply_patch_with_msg 2060-pass-gen-profile-ldflags.patch
+
   autoreconf -vfi
 
   # Temporary workaround for FS#22322
@@ -350,6 +353,8 @@ build() {
   if check_option "debug" "n"; then
     CFLAGS+=" -DNDEBUG "
     CXXFLAGS+=" -DNDEBUG "
+    _extra_config+=("--enable-optimizations")
+    _extra_config+=("--with-lto")
   else
     plain " -DDEBUG -DPy_DEBUG -D_DEBUG does not work unfortunately .."
     #    CFLAGS+=" -DDEBUG -DPy_DEBUG -D_DEBUG "
@@ -391,7 +396,21 @@ build() {
     "${_extra_config[@]}" \
     OPT=""
 
-  make
+  # Tests to run for the PGO build (see --enable-optimizations)
+  # Backported from 3.8, so we can drop it with 3.8:
+  # https://github.com/python/cpython/pull/14910
+  local PROFILE_TASK='-m test.regrtest --pgo \
+    test_array test_base64 test_binascii test_binop test_bisect test_bytes \
+    test_cmath test_codecs test_collections test_complex test_dataclasses \
+    test_datetime test_decimal test_difflib test_embed test_float \
+    test_fstring test_functools test_generators test_hashlib test_heapq \
+    test_int test_itertools test_json test_long test_math test_memoryview \
+    test_operator test_ordered_dict test_pickle test_pprint test_re test_set \
+    test_statistics test_struct test_tabnanny test_time test_unicode \
+    test_xml_etree test_xml_etree_c'
+
+  make \
+    PROFILE_TASK="${PROFILE_TASK}"
 }
 
 package() {
@@ -552,4 +571,5 @@ sha256sums=('fb799134b868199930b75f26678f18932214042639cd52b16da7fd134cd9b13f'
             '1497d664aa746cd6b0995d5518c7e0de2f80a08d125b472c81aabc99a484d445'
             '6ee9095eb78c88c205e225c0e8a0b169f5498c62d6531a2d3199450d0fe895e5'
             '09c9f8e14c1f54a1242f4db21af4a014d414fd72b3a92241842965f550f75472'
+            '180fd0a8f4d24ed7e50eb7916548f7fe398811a76063b043efdf7ab18602c55b'
             '821402ddaef92140c70041b007bcf15e1cd5fe0fdb9f4f612da868382cc24585')


### PR DESCRIPTION
It gives a nice ~15-20% speedup with the pyperformance benchmarks.
Build time increases from ~10 minutes to ~20 minutes (pgo only would be ~15 minutes)