### PR TITLE
pixman: ensure use of correct ninja executable

### DIFF
--- a/mingw-w64-pixman/PKGBUILD
+++ b/mingw-w64-pixman/PKGBUILD
@@ -47,19 +47,19 @@ build() {
     -Dgtk=disabled \
     ../${_realname}-${pkgver}
 
-  ninja
+  ${MINGW_PREFIX}/bin/ninja
 }
 
 check() {
   cd "${srcdir}/build-${MINGW_CHOST}"
 
-  ninja test
+  ${MINGW_PREFIX}/bin/ninja test
 }
 
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
 
-  DESTDIR="${pkgdir}${MINGW_PREFIX}" ninja install
+  DESTDIR="${pkgdir}${MINGW_PREFIX}" ${MINGW_PREFIX}/bin/ninja install
 
   for pcfile in  "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/*.pc; do
     sed -s "s|$(cygpath -m ${MINGW_PREFIX})|${MINGW_PREFIX}|g" -i "${pcfile}"


### PR DESCRIPTION
Executes `${MINGW_PREFIX}/bin/ninja` instead of `ninja`.

*(not sure if I should add myself as contributor in `PKGBUILD` for such a small change)*