### PR TITLE
fontconfig: add gperf as build dependency

### DIFF
--- a/mingw-w64-fontconfig/PKGBUILD
+++ b/mingw-w64-fontconfig/PKGBUILD
@@ -12,7 +12,8 @@ url="https://wiki.freedesktop.org/www/Software/fontconfig/"
 license=("custom")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
-             "${MINGW_PACKAGE_PREFIX}-python3-lxml")
+             "${MINGW_PACKAGE_PREFIX}-python3-lxml"
+             "${MINGW_PACKAGE_PREFIX}-gperf")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-expat>=2.1.0"
          "${MINGW_PACKAGE_PREFIX}-freetype>=2.3.11"


### PR DESCRIPTION
Build fails if [gperf](https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-gperf) is not installed.