### PR TITLE
python-pip: Make pip.exe the Python 3 version

### DIFF
--- a/mingw-w64-python-pip/PKGBUILD
+++ b/mingw-w64-python-pip/PKGBUILD
@@ -4,7 +4,7 @@ _realname=pip
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=19.1.1
-pkgrel=1
+pkgrel=2
 pkgdesc="An easy_install replacement for installing pypi python packages (mingw-w64)"
 arch=('any')
 license=('MIT')
@@ -49,10 +49,14 @@ build() {
 
 package_python2-pip() {
   depends=("${_deps[@]/#/${MINGW_PACKAGE_PREFIX}-python2-}" "${MINGW_PACKAGE_PREFIX}-python2-ipaddress")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}<19.1.1-2")
 
   cd "${srcdir}/python2-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
     ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX#\/} --root="${pkgdir}" --optimize=1 --skip-build
+
+  # Remove conflicted files
+  rm -f ${pkgdir}${MINGW_PREFIX}/bin/pip{.exe,.exe.manifest,-script.py}
 
   install -D -m644 LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
 
@@ -67,15 +71,13 @@ package_python2-pip() {
 
 package_python3-pip() {
   depends=("${_deps[@]/#/${MINGW_PACKAGE_PREFIX}-python3-}")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}<19.1.1-2")
 
   local _mingw_prefix=$(cygpath -wm ${MINGW_PREFIX})
 
   cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
     ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX#\/} --root="${pkgdir}" --optimize=1 --skip-build -v
-
-  # Remove conflicted files
-  rm -f ${pkgdir}${MINGW_PREFIX}/bin/pip{.exe,.exe.manifest,-script.py}
 
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
   # fix python command in files

--- a/mingw-w64-python-pip/pip2-i686.install
+++ b/mingw-w64-python-pip/pip2-i686.install
@@ -3,7 +3,7 @@ post_install() {
   local _prefix=$(pwd -W)
   cd -
   local _it
-  for _it in pip pip2 pip2.7; do
+  for _it in pip2 pip2.7; do
     sed -e "s|/mingw32|${_prefix}|g" \
         -i ${_prefix}/bin/${_it}-script.py
   done

--- a/mingw-w64-python-pip/pip2-x86_64.install
+++ b/mingw-w64-python-pip/pip2-x86_64.install
@@ -3,7 +3,7 @@ post_install() {
   local _prefix=$(pwd -W)
   cd -
   local _it
-  for _it in pip pip2 pip2.7; do
+  for _it in pip2 pip2.7; do
     sed -e "s|/mingw64|${_prefix}|g" \
         -i ${_prefix}/bin/${_it}-script.py
   done

--- a/mingw-w64-python-pip/pip3-i686.install
+++ b/mingw-w64-python-pip/pip3-i686.install
@@ -3,7 +3,7 @@ post_install() {
   local _prefix=$(pwd -W)
   cd -
   local _it
-  for _it in pip3 pip3.7; do
+  for _it in pip pip3 pip3.7; do
     sed -e "s|/mingw32|${_prefix}|g" \
         -i ${_prefix}/bin/${_it}-script.py
   done

--- a/mingw-w64-python-pip/pip3-x86_64.install
+++ b/mingw-w64-python-pip/pip3-x86_64.install
@@ -3,7 +3,7 @@ post_install() {
   local _prefix=$(pwd -W)
   cd -
   local _it
-  for _it in pip3 pip3.7; do
+  for _it in pip pip3 pip3.7; do
     sed -e "s|/mingw64|${_prefix}|g" \
         -i ${_prefix}/bin/${_it}-script.py
   done


### PR DESCRIPTION
This moves pip.exe from python2-pip to python3-pip and makes it the Python 3 version.

See #4950