### PR TITLE
libwebp: define WEBP_EXTERN as __declspec(dllexport) in CPPFLAGS

### DIFF
--- a/mingw-w64-libwebp/PKGBUILD
+++ b/mingw-w64-libwebp/PKGBUILD
@@ -23,6 +23,7 @@ validpgpkeys=('6B0E6B70976DE303EDF2F601F9C3D6BDB8232B5D')
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
   ./autogen.sh
+  export CPPFLAGS="-DWEBP_EXTERN=__declspec\(dllexport\)"
 }
 
 build() {


### PR DESCRIPTION
Otherwise, the dlls export everything.