### PR TITLE
libwebp: define WEBP_EXTERN as __declspec(dllexport)

### DIFF
--- a/mingw-w64-libwebp/0001-dllexport.patch
+++ b/mingw-w64-libwebp/0001-dllexport.patch
@@ -1,0 +1,32 @@
+diff --git a/configure.ac b/configure.ac
+index 501d933..557d492 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -9,6 +9,7 @@ dnl === automake >= 1.12 requires this for 'unusual archivers' support.
+ dnl === it must occur before LT_INIT (AC_PROG_LIBTOOL).
+ m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
+ 
++AC_LIBTOOL_WIN32_DLL
+ AC_PROG_LIBTOOL
+ AC_PROG_SED
+ AM_PROG_CC_C_O
+diff --git a/src/webp/types.h b/src/webp/types.h
+index 0ce2622..5ec9c2d 100644
+--- a/src/webp/types.h
++++ b/src/webp/types.h
+@@ -39,11 +39,15 @@ typedef long long int int64_t;
+ #ifndef WEBP_EXTERN
+ // This explicitly marks library functions and allows for changing the
+ // signature for e.g., Windows DLL builds.
++# if defined(_WIN32)
++#  define WEBP_EXTERN __declspec(dllexport)
++# else
+ # if defined(__GNUC__) && __GNUC__ >= 4
+ #  define WEBP_EXTERN extern __attribute__ ((visibility ("default")))
+ # else
+ #  define WEBP_EXTERN extern
+ # endif  /* __GNUC__ >= 4 */
++# endif  /* _WIN32 */
+ #endif  /* WEBP_EXTERN */
+ 
+ // Macro to check ABI compatibility (same major revision number)

--- a/mingw-w64-libwebp/PKGBUILD
+++ b/mingw-w64-libwebp/PKGBUILD
@@ -16,12 +16,15 @@ depends=("${MINGW_PACKAGE_PREFIX}-giflib"
          "${MINGW_PACKAGE_PREFIX}-libtiff")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-SDL")
-source=(${_realname}-${pkgver}.tar.gz::https://github.com/webmproject/libwebp/archive/v${pkgver}.tar.gz)
-sha256sums=('082d114bcb18a0e2aafc3148d43367c39304f86bf18ba0b2e766447e111a4a91')
+source=(${_realname}-${pkgver}.tar.gz::https://github.com/webmproject/libwebp/archive/v${pkgver}.tar.gz
+        0001-dllexport.patch)
+sha256sums=('082d114bcb18a0e2aafc3148d43367c39304f86bf18ba0b2e766447e111a4a91'
+            '21ad66437da8c272cd38bf15e7be7fba5431a6a0a4a7a694c574226135ef750e')
 validpgpkeys=('6B0E6B70976DE303EDF2F601F9C3D6BDB8232B5D')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
+  patch -p1 -i "${srcdir}/0001-dllexport.patch"
   ./autogen.sh
 }
 


### PR DESCRIPTION
Otherwise, the dlls export everything.