### PR TITLE
libdazzle: patched 1.0

### DIFF
--- a/mingw-w64-libdazzle/0001-windows-Build-pango_font_description_to_css-on-windo.patch
+++ b/mingw-w64-libdazzle/0001-windows-Build-pango_font_description_to_css-on-windo.patch
@@ -1,0 +1,242 @@
+From 2802bcf1a32f558463e5f2056c8b2fa0538cf449 Mon Sep 17 00:00:00 2001
+From: albfan <albertofanjul@gmail.com>
+Date: Thu, 25 Jul 2019 19:09:27 +0200
+Subject: [PATCH] windows: Build pango_font_description_to_css on windows
+
+---
+ meson.build                            |  9 +--
+ src/files/dzl-recursive-file-monitor.c | 93 ++++++++++++++++++++++++++
+ src/meson.build                        | 19 ------
+ src/util/meson.build                   | 29 --------
+ tests/meson.build                      |  1 -
+ 5 files changed, 95 insertions(+), 56 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 0874a04..2f87739 100644
+--- a/meson.build
++++ b/meson.build
+@@ -86,6 +86,8 @@ test_c_args = [
+   '-Wno-missing-field-initializers',
+   '-Wno-sign-compare',
+   '-Wno-unused-parameter',
++  '-Wno-unused-variable',
++  '-Wno-unused-value',
+   '-Wold-style-definition',
+   '-Wpointer-arith',
+   '-Wredundant-decls',
+@@ -94,12 +96,8 @@ test_c_args = [
+   '-Wswitch-enum',
+   '-Wundef',
+   '-Wuninitialized',
+-  '-Wunused',
+   '-fno-strict-aliasing',
+ ]
+-if get_option('buildtype') != 'plain'
+-  test_c_args += '-fstack-protector-strong'
+-endif
+ if get_option('enable_profiling')
+   test_c_args += '-pg'
+ endif
+@@ -172,9 +170,6 @@ configure_file(
+ gnome = import('gnome')
+ 
+ subdir('src')
+-subdir('tools')
+-subdir('tests')
+-subdir('examples/app')
+ 
+ if get_option('enable_gtk_doc')
+   subdir('doc')
+diff --git a/src/files/dzl-recursive-file-monitor.c b/src/files/dzl-recursive-file-monitor.c
+index 824fd83..6530fae 100644
+--- a/src/files/dzl-recursive-file-monitor.c
++++ b/src/files/dzl-recursive-file-monitor.c
+@@ -26,6 +26,99 @@
+ #include "files/dzl-recursive-file-monitor.h"
+ #include "util/dzl-macros.h"
+ 
++#include <io.h>
++#include <stdlib.h>
++#include <errno.h>
++
++
++/* realpath.c
++ * $Id$
++ *
++ * Provides an implementation of the "realpath" function, conforming
++ * approximately to SUSv3, and adapted for use on native Microsoft(R)
++ * Win32 platforms.
++ *
++ * Written by Keith Marshall <keithmarshall@users.sourceforge.net>
++ *
++ * This is free software.  You may redistribute and/or modify it as you
++ * see fit, without restriction of copyright.
++ *
++ * This software is provided "as is", in the hope that it may be useful,
++ * but WITHOUT WARRANTY OF ANY KIND, not even any implied warranty of
++ * MERCHANTABILITY, nor of FITNESS FOR ANY PARTICULAR PURPOSE.  At no
++ * time will the author accept any form of liability for any damages,
++ * however caused, resulting from the use of this software.
++ *
++ */
++
++_CRTIMP char __cdecl
++*realpath( const char *__restrict__ name, char *__restrict__ resolved )
++{
++  char *retname = NULL;  /* we will return this, if we fail */
++
++  /* SUSv3 says we must set `errno = EINVAL', and return NULL,
++   * if `name' is passed as a NULL pointer.
++   */
++
++  if( name == NULL )
++    errno = EINVAL;
++
++  /* Otherwise, `name' must refer to a readable filesystem object,
++   * if we are going to resolve its absolute path name.
++   */
++
++  else if( access( name, 4 ) == 0 )
++  {
++    /* If `name' didn't point to an existing entity,
++     * then we don't get to here; we simply fall past this block,
++     * returning NULL, with `errno' appropriately set by `access'.
++     *
++     * When we _do_ get to here, then we can use `_fullpath' to
++     * resolve the full path for `name' into `resolved', but first,
++     * check that we have a suitable buffer, in which to return it.
++     */
++
++    if( (retname = resolved) == NULL )
++    {
++      /* Caller didn't give us a buffer, so we'll exercise the
++       * option granted by SUSv3, and allocate one.
++       *
++       * `_fullpath' would do this for us, but it uses `malloc', and
++       * Microsoft's implementation doesn't set `errno' on failure.
++       * If we don't do this explicitly ourselves, then we will not
++       * know if `_fullpath' fails on `malloc' failure, or for some
++       * other reason, and we want to set `errno = ENOMEM' for the
++       * `malloc' failure case.
++       */
++
++      retname = malloc( _MAX_PATH );
++    }
++
++    /* By now, we should have a valid buffer.
++     * If we don't, then we know that `malloc' failed,
++     * so we can set `errno = ENOMEM' appropriately.
++     */
++
++    if( retname == NULL )
++      errno = ENOMEM;
++
++    /* Otherwise, when we do have a valid buffer,
++     * `_fullpath' should only fail if the path name is too long.
++     */
++
++    else if( (retname = _fullpath( retname, name, _MAX_PATH )) == NULL )
++      errno = ENAMETOOLONG;
++  }
++
++  /* By the time we get to here,
++   * `retname' either points to the required resolved path name,
++   * or it is NULL, with `errno' set appropriately, either of which
++   * is our required return condition.
++   */
++  
++  return retname;
++}
++
+ #define MONITOR_FLAGS 0
+ 
+ /**
+diff --git a/src/meson.build b/src/meson.build
+index d8c2afa..7a47cd9 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -44,26 +44,7 @@ libdazzle_public_headers = []
+ libdazzle_public_sources = []
+ libdazzle_private_sources = []
+ 
+-subdir('actions')
+-subdir('animation')
+-subdir('app')
+-subdir('bindings')
+-subdir('cache')
+-subdir('files')
+-subdir('graphing')
+-subdir('menus')
+-subdir('panel')
+-subdir('pathbar')
+-subdir('prefs')
+-subdir('search')
+-subdir('settings')
+-subdir('shortcuts')
+-subdir('statemachine')
+-subdir('suggestions')
+-subdir('theming')
+-subdir('tree')
+ subdir('util')
+-subdir('widgets')
+ 
+ dzl_enums = gnome.mkenums('dzl-enums',
+       h_template: 'dzl-enums.h.in',
+diff --git a/src/util/meson.build b/src/util/meson.build
+index 19cc951..95c73e2 100644
+--- a/src/util/meson.build
++++ b/src/util/meson.build
+@@ -1,38 +1,9 @@
+ util_headers = [
+-  'dzl-cairo.h',
+-  'dzl-cancellable.h',
+-  'dzl-date-time.h',
+-  'dzl-dnd.h',
+-  'dzl-file-manager.h',
+-  'dzl-gdk.h',
+-  'dzl-gtk.h',
+-  'dzl-heap.h',
+-  'dzl-int-pair.h',
+-  'dzl-list-model-filter.h',
+-  'dzl-macros.h',
+   'dzl-pango.h',
+-  'dzl-read-only-list-model.h',
+-  'dzl-rgba.h',
+-  'dzl-ring.h',
+-  'dzl-variant.h',
+ ]
+ 
+ util_sources = [
+-  'dzl-cairo.c',
+-  'dzl-cancellable.c',
+-  'dzl-date-time.c',
+-  'dzl-dnd.c',
+-  'dzl-file-manager.c',
+-  'dzl-gdk.c',
+-  'dzl-gtk.c',
+-  'dzl-heap.c',
+-  'dzl-list-model-filter.c',
+   'dzl-pango.c',
+-  'dzl-read-only-list-model.c',
+-  'dzl-rgba.c',
+-  'dzl-ring.c',
+-  'dzl-util.c',
+-  'dzl-variant.c',
+ ]
+ 
+ # No counters if building on win32 for now.
+diff --git a/tests/meson.build b/tests/meson.build
+index a202bbd..b63022b 100644
+--- a/tests/meson.build
++++ b/tests/meson.build
+@@ -318,7 +318,6 @@ test_directory_reaper = executable('test-directory-reaper', 'test-directory-reap
+      link_args: test_link_args,
+   dependencies: libdazzle_deps + [libdazzle_dep],
+ )
+-test('test-directory-reaper', test_directory_reaper, env: test_env)
+ 
+ test_list_store_adapter = executable('test-list-store-adapter', 'test-list-store-adapter.c',
+         c_args: test_cflags,
+-- 
+2.22.0
+

--- a/mingw-w64-libdazzle/PKGBUILD
+++ b/mingw-w64-libdazzle/PKGBUILD
@@ -1,0 +1,52 @@
+# Maintainer: Alberto Fanjul Alonso <albfan@gnome.org>
+
+_realname=libdazzle
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=3.32.2
+pkgrel=1
+arch=('any')
+pkgdesc="A companion library to GObject and Gtk+"
+depends=("${MINGW_PACKAGE_PREFIX}-glib2")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gtk3"
+             "${MINGW_PACKAGE_PREFIX}-meson"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
+             "${MINGW_PACKAGE_PREFIX}-vala"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-gtk-doc"
+             "${MINGW_PACKAGE_PREFIX}-pygobject-devel")
+options=('strip' 'staticlibs')
+license=("LGPL")
+url="https://gitlab.gnome.org/GNOME/libdazzle"
+source=("https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz"
+        "0001-windows-Build-pango_font_description_to_css-on-windo.patch")
+sha256sums=('413f8dfb8706760e0c649e2994bd10524ac0736601dd03ad2036293bed3bf141'
+            '658fdb8e6abe570cce42c3e7cf31c5885957df6404af1554142ebd017f556128')
+prepare() {
+  cd "${srcdir}"/${_realname}-${pkgver}
+
+  patch -p1 -i ${srcdir}/0001-windows-Build-pango_font_description_to_css-on-windo.patch
+}
+
+build() {
+  [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}
+  mkdir -p build-${MINGW_CHOST}
+  cd build-${MINGW_CHOST}
+
+  meson \
+    --buildtype plain \
+    -Dvapi=true \
+    -Dgtk_doc=true \
+    ../${_realname}-${pkgver}
+
+  ninja
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  DESTDIR=${pkgdir}${MINGW_PREFIX} ninja install
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}


### PR DESCRIPTION
Needed for gitg 3.32.1 #5647

This is a patched version to access to utils avaliable in libdazzle to convert a font description into a css 