### PR TITLE
gtk2: add a patch to fix svg file detection

### DIFF
--- a/mingw-w64-gtk2/0022-icontheme-win32-detect-SVG-files-by-extension.patch
+++ b/mingw-w64-gtk2/0022-icontheme-win32-detect-SVG-files-by-extension.patch
@@ -1,0 +1,32 @@
+From e49ed73cd1faa10c88fdf5f91f8e23a86603a909 Mon Sep 17 00:00:00 2001
+From: Edward E <develinthedetail@gmail.com>
+Date: Thu, 28 Jun 2018 08:41:21 -0500
+Subject: icontheme (win32): detect SVG files by extension if registered incorrectly
+
+It seems XP shipped without a registered Content Type for .svg,
+and some newer systems have 'text/xml' instead of 'image/svg+xml'.
+
+see https://gitlab.gnome.org/GNOME/gimp/issues/1563
+---
+ gtk/gtkicontheme.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/gtk/gtkicontheme.c b/gtk/gtkicontheme.c
+index ea4046022e..16bae20627 100644
+--- a/gtk/gtkicontheme.c
++++ b/gtk/gtkicontheme.c
+@@ -2927,6 +2927,11 @@ icon_info_ensure_scale_and_pixbuf (GtkIconInfo  *icon_info,
+ 
+               if (mime_type && strcmp (mime_type, "image/svg+xml") == 0)
+                 is_svg = TRUE;
++#ifdef G_OS_WIN32
++              else
++                if (strcmp (content_type, ".svg") == 0)
++                  is_svg = TRUE;
++#endif
+             }
+ 
+           g_object_unref (file_info);
+-- 
+2.22.0
+

--- a/mingw-w64-gtk2/PKGBUILD
+++ b/mingw-w64-gtk2/PKGBUILD
@@ -5,7 +5,7 @@ _realname=gtk2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.24.32
-pkgrel=3
+pkgrel=4
 pkgdesc="GTK+ is a multi-platform toolkit (v2) (mingw-w64)"
 arch=('any')
 url="https://www.gtk.org/"
@@ -42,7 +42,8 @@ source=("https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}.tar
         0013_fix_mouse_events.patch
         0019_use_g_stat_and_gstatbuf.patch
         0020-GDK-W32-Always-process-all-available-messages.patch
-        0021-GDK-W32-Ignore-autorepeated-key-presses-on-modifier-.patch)
+        0021-GDK-W32-Ignore-autorepeated-key-presses-on-modifier-.patch
+        0022-icontheme-win32-detect-SVG-files-by-extension.patch)
 
 sha256sums=('b6c8a93ddda5eabe3bfee1eb39636c9a03d2a56c7b62828b359bf197943c582e'
             'b77a427df55a14182c10ad7e683b4d662df2846fcd38df2aa8918159d6be3ae2'
@@ -57,7 +58,8 @@ sha256sums=('b6c8a93ddda5eabe3bfee1eb39636c9a03d2a56c7b62828b359bf197943c582e'
             'f6d731acecf6e35e4ec9739a6d949d2d045c9396c4564283ee6ec935ec690e24'
             '2903708fda7b9f306a6a7b7b41518ce7a9ac7b9e622d4a1eed9ce30b945d5971'
             'f984baf140fa325fab1bbd213d17f9cdcd5138b5ab9d76bd17c2434c4e4b2ac5'
-            '8955a689e9107c175a79766d4dd485941b3974b181e51f40ed2ae6028fd1b170')
+            '8955a689e9107c175a79766d4dd485941b3974b181e51f40ed2ae6028fd1b170'
+            'b0f18b85d2fd47057c266887848be1f1c0b6171a1ee6d52a33df7af6e0abb8b0')
 
 prepare() {
   cd gtk+-${pkgver}
@@ -74,6 +76,7 @@ prepare() {
 
   patch -p1 -i ${srcdir}/0020-GDK-W32-Always-process-all-available-messages.patch
   patch -p1 -i ${srcdir}/0021-GDK-W32-Ignore-autorepeated-key-presses-on-modifier-.patch
+  patch -p1 -i ${srcdir}/0022-icontheme-win32-detect-SVG-files-by-extension.patch
 
   autoreconf -fi
   rm "${srcdir}/gtk+-${pkgver}/gtk/gtk.def"


### PR DESCRIPTION
As requested in #4046.

@Alexpux, shouldn't makedepends have `"${MINGW_PACKAGE_PREFIX}-gtk-doc"` instead of `"gtk-doc"`? You switched it long ago in 601f8e45d48f9d767afb2eac2e821b6b7d3f5280, but I'm not sure why, so I'll leave it to you.