### PR TITLE
cmak3 3.15.1 - update to latest version

### DIFF
--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -4,14 +4,20 @@
 _realname=cmake
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.15.0
+pkgver=3.15.1
 pkgrel=1
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
 url="https://www.cmake.org/"
 license=("MIT")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-qt5")
+             "${MINGW_PACKAGE_PREFIX}-bzip2"
+             "${MINGW_PACKAGE_PREFIX}-emacs"
+             "${MINGW_PACKAGE_PREFIX}-ncurses"
+             "${MINGW_PACKAGE_PREFIX}-python3-sphinx"
+             "${MINGW_PACKAGE_PREFIX}-qt5"
+             "${MINGW_PACKAGE_PREFIX}-xz"
+             "${MINGW_PACKAGE_PREFIX}-zstd")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-pkg-config"
          "${MINGW_PACKAGE_PREFIX}-curl"
@@ -21,7 +27,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libuv"
          "${MINGW_PACKAGE_PREFIX}-rhash"
          "${MINGW_PACKAGE_PREFIX}-zlib")
-optdepends=("${MINGW_PACKAGE_PREFIX}-qt5: CMake Qt GUI")
+optdepends=("${MINGW_PACKAGE_PREFIX}-qt5: CMake Qt GUI"
+            "${MINGW_PACKAGE_PREFIX}-emacs: for cmake emacs mode")
 options=('staticlibs') # '!strip' 'debug'
 source=("https://www.cmake.org/files/v${pkgver%.*}/${_realname}-${pkgver}.tar.gz"
         "0001-Windows-Add-missing-stringapiset.h-include.patch"
@@ -31,7 +38,7 @@ source=("https://www.cmake.org/files/v${pkgver%.*}/${_realname}-${pkgver}.tar.gz
         "0006-pkg-config-Add-dont-define-prefix-when-PKG_CONFIG_WI.patch"
         "0007-Do-not-generate-import-libs-for-exes.patch"
         "0008-Output-line-numbers-in-callstacks.patch")
-sha256sums=('0678d74a45832cacaea053d85a5685f3ed8352475e6ddf9fcb742ffca00199b5'
+sha256sums=('18dec548d8f8b04d53c60f9cedcebaa6762f8425339d1e2c889c383d3ccdd7f7'
             '1b68fe64e1b389134db44dc34368713f6e28d3463ab1e7fc3d93857c0459beb7'
             '77763df03e8a9ca66c3f9368fe7e1fc36bb041455733258d73aeb40246a61354'
             '297ad7f9ebbc13cd9439a45f6952094b5ac913de0c4eaa046441f0fa044f19fd'
@@ -77,21 +84,31 @@ build() {
   mkdir -p "${srcdir}/build-${MINGW_CHOST}"
   cd "${srcdir}/build-${MINGW_CHOST}"
 
-  MSYSTEM=MINGW \
+  MSYSTEM=MINGW FC=${MINGW_PREFIX}/bin/gfortran.exe \
     "${srcdir}"/${_realname}-${pkgver}/configure  \
     --prefix=${MINGW_PREFIX}                      \
     --system-libs                                 \
     --no-system-expat                             \
     --qt-gui                                      \
+    --qt-qmake=${MINGW_PREFIX}/bin/qmake.exe      \
     --parallel=${NUMBER_OF_PROCESSORS}            \
     --mandir=share                                \
-    --docdir=share/doc/cmake
-
+    --docdir=share/doc/cmake                      \
+    --sphinx-man --sphinx-html
   plain "Start building..."
   make
 }
 
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
-  ./bin/cmake.exe -DCMAKE_INSTALL_PREFIX:PATH=${pkgdir}${MINGW_PREFIX} -P cmake_install.cmake
+  ./bin/cmake.exe \
+     -DCMAKE_INSTALL_PREFIX:PATH=${pkgdir}${MINGW_PREFIX} \
+     -DCMAKE_INSTALL_LOCAL_ONLY:BOOL=OFF -P cmake_install.cmake
+  install -d "${pkgdir}${MINGW_PREFIX}"/share/emacs/site-lisp/
+  ${MINGW_PREFIX}/bin/emacs -batch -f batch-byte-compile \
+    "${pkgdir}${MINGW_PREFIX}"/share/cmake-${pkgver%.*}/editors/emacs/cmake-mode.el
+  ln -s ${pkgdir}${MINGW_PREFIX}/share/cmake-${pkgver%.*}/editors/emacs/cmake-mode.el \
+    "${pkgdir}${MINGW_PREFIX}"/share/emacs/site-lisp/
+  ln -s ${pkgdir}${MINGW_PREFIX}/share/cmake-${pkgver%.*}/editors/emacs/cmake-mode.elc \
+    "${pkgdir}${MINGW_PREFIX}"/share/emacs/site-lisp/
 }


### PR DESCRIPTION
clarrifed dependencies including zstd, ncurses, xz, bzlib2
add support for mingw-w64-emacs including opt-depends