### PR TITLE
pango: backport font fallback list fix

### DIFF
--- a/mingw-w64-pango/002-font-fallback.patch
+++ b/mingw-w64-pango/002-font-fallback.patch
@@ -1,0 +1,43 @@
+From 842e5675224adfc49ddadfeb084bf61166dc7101 Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Sun, 21 Jul 2019 16:06:55 +0200
+Subject: [PATCH] pangowin32: add back the old font fallback list for each
+ registered font
+
+In f523c25c12c I changed the font fallback list from hardcoded to reading it from
+the registry to cover all potentially default Windows UI fonts. Turns out that this
+doesn't cover all of Unicode and breaks things like Marathi.
+
+This adds back the language specific font fallbacks to each font read from the registry
+to restore the old Unicode coverage.
+
+Fixes #375
+---
+ pango/pangowin32-fontmap.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/pango/pangowin32-fontmap.c b/pango/pangowin32-fontmap.c
+index 130b76e9..976a36cb 100644
+--- a/pango/pangowin32-fontmap.c
++++ b/pango/pangowin32-fontmap.c
+@@ -574,6 +574,17 @@ read_windows_fallbacks (GHashTable *ht_aliases)
+           entry_len = wcslen (entry);
+         }
+       g_free (value_data);
++
++      /* For some reason the default fallback list doesn't cover all of Unicode
++       * and Windows has additional fonts for certain languages.
++       * Some of them are listed in
++       * SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontMapperFamilyFallback
++       * but I couldn't find any docs for it. Feel free to improve this */
++      g_string_append (line_buffer,
++                       ",gisha,leelawadee,arial unicode ms,browallia new,"
++                       "mingliu,simhei,gulimche,ms gothic,sylfaen,kartika,"
++                       "latha,mangal,raavi");
++
+       g_string_append (line_buffer, "\"");
+ 
+       handle_alias_line (line_buffer, &errstring, ht_aliases);
+-- 
+2.21.0
+

--- a/mingw-w64-pango/PKGBUILD
+++ b/mingw-w64-pango/PKGBUILD
@@ -4,8 +4,9 @@
 _realname=pango
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+# Don't update to 1.44.0! https://gitlab.gnome.org/GNOME/pango/issues/385
 pkgver=1.43.0
-pkgrel=2
+pkgrel=3
 pkgdesc="A library for layout and rendering of text (mingw-w64)"
 arch=('any')
 url="http://www.pango.org"
@@ -27,10 +28,12 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 options=('staticlibs' 'strip' 'emptydirs')
 source=("https://download.gnome.org/sources/pango/${pkgver:0:4}/${_realname}-${pkgver}.tar.xz"
         static-skip-help2man.patch
-        0001-pango.pc-Make-gobject-2.0-a-non-private-requirement.patch)
+        0001-pango.pc-Make-gobject-2.0-a-non-private-requirement.patch
+        002-font-fallback.patch)
 sha256sums=('d2c0c253a5328a0eccb00cdd66ce2c8713fabd2c9836000b6e22a8b06ba3ddd2'
             '0d4bfd80f82969ae555b7bda6905ac413c325457360164fcd404e23278b51e1a'
-            '4e605934977b9e4ac1aae58bee47b152397ffd4e97138c184b2508c1cd3b7bab')
+            '4e605934977b9e4ac1aae58bee47b152397ffd4e97138c184b2508c1cd3b7bab'
+            '41e72fc17f0e15d74c03eb61fa44750fedcecfc2373bbdee7b28ec9c65a2406d')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -40,6 +43,9 @@ prepare() {
 
   # https://github.com/Alexpux/MINGW-packages/issues/4830
   patch -p1 -i ${srcdir}/0001-pango.pc-Make-gobject-2.0-a-non-private-requirement.patch
+
+  # https://gitlab.gnome.org/GNOME/pango/merge_requests/97
+  patch -p1 -i ${srcdir}/002-font-fallback.patch
 }
 
 build() {


### PR DESCRIPTION
This restores the support of optional font fallbacks.