### PR TITLE
pngquant-2.1- 2.12.5

### DIFF
--- a/mingw-w64-pngquant/PKGBUILD
+++ b/mingw-w64-pngquant/PKGBUILD
@@ -1,0 +1,56 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_realname=pngquant
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=2.12.5
+pkgrel=1
+pkgdesc="Command-line utility to quantize PNGs down to 8-bit paletted PNGs (mingw-w64)"
+arch=('any')
+url='https://pngquant.org/'
+license=("BSD")
+depends=("${MINGW_PACKAGE_PREFIX}-libpng"
+         "${MINGW_PACKAGE_PREFIX}-lcms2"
+         "${MINGW_PACKAGE_PREFIX}-libimagequant")
+source=("https://github.com/kornelski/${_realname}/archive/$pkgver/${_realname}-$pkgver.tar.gz")
+sha256sums=('9d2c5197b21c42931623fb3e6064b91c133bfb52c84428ee1bf9b84712c9b83c')
+
+prepare() {
+  cd $srcdir/${_realname}-${pkgver}
+#  patch -p1 -i ${srcdir}/0001-min-build-fix.patch
+}
+
+build() {
+  cd "$srcdir"/${_realname}-${pkgver}
+  rm -rf "${srcdir}"/build-${CARCH} || true
+  cp -r "${srcdir}/${_realname}-${pkgver}" "${srcdir}/build-${CARCH}"
+  cd "${srcdir}"/build-${CARCH}
+  msg2 "PWD $(pwd)"
+  if [ "${CARCH}" = "i686" ]; then
+    SSE="--disable-sse"
+  else
+    SSE="--enable-sse"
+  fi
+  ./configure --prefix=${MINGW_PREFIX} \
+    CC="${MINGW_PREFIX}/bin/gcc" \
+    --with-libimagequant=${MINGW_PREFIX}/lib/ \
+    ${SSE}
+  make --jobs=1
+}
+
+package() {
+  cd "${srcdir}"/build-${CARCH}
+
+  install -dm 0755 ${pkgdir}${MINGW_PREFIX}/bin
+  install -dm 0755 ${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}
+  install -dm 0755 ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}
+  install -m 0644 -p pngquant.exe \
+     ${pkgdir}${MINGW_PREFIX}/bin/pngquant.exe
+   install -m 0644 -p CHANGELOG \
+      ${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}/CHANGELOG
+   install -m 0644 -p README.md \
+      ${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}/README.md
+   install -m 0644 -p COPYRIGHT \
+       ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYRIGHT
+}
+


### PR DESCRIPTION
New package -  Command-line utility to quantize PNGs down to 8-bit paletted PNGs