### PR TITLE
wxSVG: patch to add 'pango' & 'libexif' to 'Requires.private' in pkg-config file

### DIFF
--- a/mingw-w64-wxSVG/001-wxsvg-1.5.19-pkg-config.patch
+++ b/mingw-w64-wxSVG/001-wxsvg-1.5.19-pkg-config.patch
@@ -1,0 +1,13 @@
+--- wxsvg-1.5.19/libwxsvg.pc.in.orig	2019-08-01 17:53:44.236248500 +0000
++++ wxsvg-1.5.19/libwxsvg.pc.in	2019-08-01 17:57:21.174242500 +0000
+@@ -4,8 +4,9 @@
+ includedir=@includedir@
+ 
+ Name: libwxsvg
+-Description: C++ library to create, manipulate and render SVG files 
++Description: C++ library to create, manipulate and render SVG files
+ Requires:
++Requires.private: pango, libexif
+ Version: @VERSION@
+ Libs: -L${libdir} -lwxsvg
+ Cflags: -I${includedir}

--- a/mingw-w64-wxSVG/PKGBUILD
+++ b/mingw-w64-wxSVG/PKGBUILD
@@ -4,7 +4,7 @@ _realname=wxsvg
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgbase="mingw-w64-${_realname}"
 pkgver=1.5.19
-pkgrel=2
+pkgrel=3
 pkgdesc="A C++ library to create, manipulate and render SVG files (mingw-w64)"
 arch=("any")
 url="http://wxsvg.sourceforge.net/"
@@ -18,14 +18,17 @@ depends=("${MINGW_PACKAGE_PREFIX}-wxWidgets"
 makedepends=("bsdtar"
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
-source=("https://downloads.sourceforge.net/project/wxsvg/wxsvg/${pkgver}/wxsvg-${pkgver}.tar.bz2")
-sha256sums=('3f78783fb1ea8242cc3f5f4d9b5ca8c79ea90f0837849f5a908478e13a560f9e')
+source=("https://downloads.sourceforge.net/project/wxsvg/wxsvg/${pkgver}/wxsvg-${pkgver}.tar.bz2"
+        "001-wxsvg-1.5.19-pkg-config.patch")
+sha256sums=('3f78783fb1ea8242cc3f5f4d9b5ca8c79ea90f0837849f5a908478e13a560f9e'
+            '1138bfac5305a1dc805f43821796f733b275fde9cd8a9855308a962761be3baa')
 extractdir="${_realname}-${pkgver}"
 builddir="build-${CARCH}"
 
-#prepare() {
-# cd "${srcdir}/${extractdir}"
-#}
+prepare() {
+ cd "${srcdir}/${extractdir}"
+ patch -p1 -i "${startdir}/001-wxsvg-1.5.19-pkg-config.patch"
+}
 
 build() {
   [[ -d "${srcdir}/${builddir}" ]] && rm -rf "${srcdir}/${builddir}"


### PR DESCRIPTION
Adds the line `Requires.private: pango, libexif` to `libwxsvg.pc.in` file for correct static linking using `pkg-config`.

**Note:** I also sent a patch/PR upstream.