### PR TITLE
update included cppzmq to 4.5.0 (zmq still is 4.3.1)

### DIFF
--- a/mingw-w64-zeromq/PKGBUILD
+++ b/mingw-w64-zeromq/PKGBUILD
@@ -4,7 +4,7 @@ _realname=zeromq
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.3.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Fast messaging system built on sockets, C and C++ bindings. aka 0MQ, ZMQ (mingw-w64)"
 arch=('any')
 url="http://www.zeromq.org"
@@ -13,9 +13,9 @@ depends=("${MINGW_PACKAGE_PREFIX}-libsodium")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 options=('staticlibs' 'strip' '!buildflags')
 source=("https://github.com/zeromq/libzmq/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz"
-        "https://raw.githubusercontent.com/zeromq/cppzmq/1fdf3d1dfe1491209b0d7c71e38b2f1e3f801ac9/zmq.hpp")
+        "https://raw.githubusercontent.com/zeromq/cppzmq/81c2938faad8b62167642e43b2d646591650c3f6/zmq.hpp")
 sha256sums=('bcbabe1e2c7d0eec4ed612e10b94b112dd5f06fcefa994a0c79a45d835cd21eb'
-            '88d5978e7c7220e71aa7aa255081e7e01502d18d89f2eb9d42b96a43bb642293')
+            '71adbb0e86c7730cce0bc5ae0195dd0891b78a601d44dff1913f9c0864c35872')
 
 build() {
   [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}


### PR DESCRIPTION
mingw-w64-zeromq does include cppzmq but in a very old version. I updated this.
Note that zeromq 4.3.2 was released - but it would need to get patched to be compatible with mingw. So while we wait for this to happen, we can at least get a current version of the cpp wrapper included.