### PR TITLE
Fixing pkg-config for gsettings-desktop-schemas

### DIFF
--- a/mingw-w64-gsettings-desktop-schemas/PKGBUILD
+++ b/mingw-w64-gsettings-desktop-schemas/PKGBUILD
@@ -43,13 +43,5 @@ package() {
 
   DESTDIR="${pkgdir}${MINGW_PREFIX}" ninja install
 
-  for pcfile in  "${pkgdir}${MINGW_PREFIX}"/share/pkgconfig/*.pc; do
-    sed -s "s|$(cygpath -m ${MINGW_PREFIX})|${MINGW_PREFIX}|g" -i "${pcfile}"
-  done
-
-  for schema in "${pkgdir}${MINGW_PREFIX}"/share/glib-2.0/schemas/*.xml; do
-    sed -s "s|$(cygpath -m ${MINGW_PREFIX})|${MINGW_PREFIX}|g" -i "${schema}"
-  done
-
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }


### PR DESCRIPTION
Seems we are doing some unneeded replacements for pkg-config. Maybe those are things related to autotools, not needed anymore for meson.