### PR TITLE
Remove unneeded headers in libdazzle

### DIFF
--- a/mingw-w64-libdazzle/0001-windows-Build-pango_font_description_to_css-on-windo.patch
+++ b/mingw-w64-libdazzle/0001-windows-Build-pango_font_description_to_css-on-windo.patch
@@ -1,18 +1,19 @@
-From 2802bcf1a32f558463e5f2056c8b2fa0538cf449 Mon Sep 17 00:00:00 2001
+From 4c5ec295ebdc63e183793d1727346bf71dbb96d5 Mon Sep 17 00:00:00 2001
 From: albfan <albertofanjul@gmail.com>
 Date: Thu, 25 Jul 2019 19:09:27 +0200
 Subject: [PATCH] windows: Build pango_font_description_to_css on windows
 
 ---
- meson.build                            |  9 +--
- src/files/dzl-recursive-file-monitor.c | 93 ++++++++++++++++++++++++++
- src/meson.build                        | 19 ------
- src/util/meson.build                   | 29 --------
- tests/meson.build                      |  1 -
- 5 files changed, 95 insertions(+), 56 deletions(-)
+ meson.build                            |   9 +-
+ src/dazzle.h                           | 138 -------------------------
+ src/files/dzl-recursive-file-monitor.c |  93 +++++++++++++++++
+ src/meson.build                        |  19 ----
+ src/util/meson.build                   |  29 ------
+ tests/meson.build                      |   1 -
+ 6 files changed, 95 insertions(+), 194 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index 0874a04..2f87739 100644
+index 2bf987a..643e9cc 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -86,6 +86,8 @@ test_c_args = [
@@ -47,6 +48,156 @@ index 0874a04..2f87739 100644
  
  if get_option('enable_gtk_doc')
    subdir('doc')
+diff --git a/src/dazzle.h b/src/dazzle.h
+index b206337..e48d90c 100644
+--- a/src/dazzle.h
++++ b/src/dazzle.h
+@@ -34,145 +34,7 @@ G_BEGIN_DECLS
+ #define DAZZLE_INSIDE
+ #include "dzl-version.h"
+ #include "dzl-enums.h"
+-#include "actions/dzl-action-group.h"
+-#include "actions/dzl-child-property-action.h"
+-#include "actions/dzl-properties-group.h"
+-#include "actions/dzl-settings-flag-action.h"
+-#include "actions/dzl-widget-action-group.h"
+-#include "animation/dzl-animation.h"
+-#include "animation/dzl-box-theatric.h"
+-#include "animation/dzl-frame-source.h"
+-#include "app/dzl-application.h"
+-#include "app/dzl-application-window.h"
+-#include "bindings/dzl-binding-group.h"
+-#include "bindings/dzl-signal-group.h"
+-#include "cache/dzl-task-cache.h"
+-#include "files/dzl-directory-model.h"
+-#include "files/dzl-directory-reaper.h"
+-#include "files/dzl-file-transfer.h"
+-#include "files/dzl-recursive-file-monitor.h"
+-#include "graphing/dzl-cpu-graph.h"
+-#include "graphing/dzl-cpu-model.h"
+-#include "graphing/dzl-graph-column.h"
+-#include "graphing/dzl-graph-line-renderer.h"
+-#include "graphing/dzl-graph-model.h"
+-#include "graphing/dzl-graph-renderer.h"
+-#include "graphing/dzl-graph-view.h"
+-#include "menus/dzl-joined-menu.h"
+-#include "menus/dzl-menu-button.h"
+-#include "menus/dzl-menu-manager.h"
+-#include "panel/dzl-dock-bin-edge.h"
+-#include "panel/dzl-dock-bin.h"
+-#include "panel/dzl-dock-item.h"
+-#include "panel/dzl-dock-manager.h"
+-#include "panel/dzl-dock-overlay-edge.h"
+-#include "panel/dzl-dock-overlay.h"
+-#include "panel/dzl-dock-paned.h"
+-#include "panel/dzl-dock-revealer.h"
+-#include "panel/dzl-dock-stack.h"
+-#include "panel/dzl-dock-transient-grab.h"
+-#include "panel/dzl-dock-types.h"
+-#include "panel/dzl-dock-widget.h"
+-#include "panel/dzl-dock-window.h"
+-#include "panel/dzl-dock.h"
+-#include "panel/dzl-tab-strip.h"
+-#include "panel/dzl-tab.h"
+-#include "pathbar/dzl-path.h"
+-#include "pathbar/dzl-path-bar.h"
+-#include "pathbar/dzl-path-element.h"
+-#include "prefs/dzl-preferences-bin.h"
+-#include "prefs/dzl-preferences-entry.h"
+-#include "prefs/dzl-preferences-file-chooser-button.h"
+-#include "prefs/dzl-preferences-flow-box.h"
+-#include "prefs/dzl-preferences-font-button.h"
+-#include "prefs/dzl-preferences-group.h"
+-#include "prefs/dzl-preferences-page.h"
+-#include "prefs/dzl-preferences-spin-button.h"
+-#include "prefs/dzl-preferences-switch.h"
+-#include "prefs/dzl-preferences-view.h"
+-#include "prefs/dzl-preferences.h"
+-#include "search/dzl-fuzzy-index.h"
+-#include "search/dzl-fuzzy-index-builder.h"
+-#include "search/dzl-fuzzy-index-cursor.h"
+-#include "search/dzl-fuzzy-index-match.h"
+-#include "search/dzl-fuzzy-mutable-index.h"
+-#include "search/dzl-levenshtein.h"
+-#include "search/dzl-pattern-spec.h"
+-#include "search/dzl-trie.h"
+-#include "settings/dzl-settings-sandwich.h"
+-#include "shortcuts/dzl-shortcut-accel-dialog.h"
+-#include "shortcuts/dzl-shortcut-chord.h"
+-#include "shortcuts/dzl-shortcut-context.h"
+-#include "shortcuts/dzl-shortcut-controller.h"
+-#include "shortcuts/dzl-shortcut-label.h"
+-#include "shortcuts/dzl-shortcut-manager.h"
+-#include "shortcuts/dzl-shortcut-model.h"
+-#include "shortcuts/dzl-shortcut-phase.h"
+-#include "shortcuts/dzl-shortcut-simple-label.h"
+-#include "shortcuts/dzl-shortcut-theme-editor.h"
+-#include "shortcuts/dzl-shortcut-theme.h"
+-#include "shortcuts/dzl-shortcut-tooltip.h"
+-#include "shortcuts/dzl-shortcuts-group.h"
+-#include "shortcuts/dzl-shortcuts-section.h"
+-#include "shortcuts/dzl-shortcuts-shortcut.h"
+-#include "shortcuts/dzl-shortcuts-window.h"
+-#include "statemachine/dzl-state-machine-buildable.h"
+-#include "statemachine/dzl-state-machine.h"
+-#include "suggestions/dzl-suggestion-button.h"
+-#include "suggestions/dzl-suggestion-entry-buffer.h"
+-#include "suggestions/dzl-suggestion-entry.h"
+-#include "suggestions/dzl-suggestion-popover.h"
+-#include "suggestions/dzl-suggestion-row.h"
+-#include "suggestions/dzl-suggestion.h"
+-#include "theming/dzl-css-provider.h"
+-#include "theming/dzl-theme-manager.h"
+-#include "tree/dzl-list-store-adapter.h"
+-#include "tree/dzl-tree.h"
+-#include "tree/dzl-tree-builder.h"
+-#include "tree/dzl-tree-node.h"
+-#include "tree/dzl-tree-types.h"
+-#include "util/dzl-cairo.h"
+-#include "util/dzl-cancellable.h"
+-#include "util/dzl-counter.h"
+-#include "util/dzl-date-time.h"
+-#include "util/dzl-dnd.h"
+-#include "util/dzl-file-manager.h"
+-#include "util/dzl-gdk.h"
+-#include "util/dzl-gtk.h"
+-#include "util/dzl-heap.h"
+-#include "util/dzl-int-pair.h"
+-#include "util/dzl-list-model-filter.h"
+-#include "util/dzl-macros.h"
+ #include "util/dzl-pango.h"
+-#include "util/dzl-read-only-list-model.h"
+-#include "util/dzl-rgba.h"
+-#include "util/dzl-ring.h"
+-#include "util/dzl-variant.h"
+-#include "widgets/dzl-bin.h"
+-#include "widgets/dzl-bolding-label.h"
+-#include "widgets/dzl-box.h"
+-#include "widgets/dzl-centering-bin.h"
+-#include "widgets/dzl-column-layout.h"
+-#include "widgets/dzl-counters-window.h"
+-#include "widgets/dzl-elastic-bin.h"
+-#include "widgets/dzl-empty-state.h"
+-#include "widgets/dzl-entry-box.h"
+-#include "widgets/dzl-file-chooser-entry.h"
+-#include "widgets/dzl-list-box.h"
+-#include "widgets/dzl-multi-paned.h"
+-#include "widgets/dzl-pill-box.h"
+-#include "widgets/dzl-priority-box.h"
+-#include "widgets/dzl-progress-button.h"
+-#include "widgets/dzl-progress-menu-button.h"
+-#include "widgets/dzl-progress-icon.h"
+-#include "widgets/dzl-radio-box.h"
+-#include "widgets/dzl-scrolled-window.h"
+-#include "widgets/dzl-search-bar.h"
+-#include "widgets/dzl-simple-label.h"
+-#include "widgets/dzl-simple-popover.h"
+-#include "widgets/dzl-slider.h"
+-#include "widgets/dzl-stack-list.h"
+-#include "widgets/dzl-three-grid.h"
+ #undef DAZZLE_INSIDE
+ 
+ G_END_DECLS
 diff --git a/src/files/dzl-recursive-file-monitor.c b/src/files/dzl-recursive-file-monitor.c
 index 824fd83..6530fae 100644
 --- a/src/files/dzl-recursive-file-monitor.c

--- a/mingw-w64-libdazzle/PKGBUILD
+++ b/mingw-w64-libdazzle/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libdazzle
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.32.2
+pkgver=3.33.4
 pkgrel=1
 arch=('any')
 pkgdesc="A companion library to GObject and Gtk+"
@@ -22,8 +22,8 @@ license=("LGPL")
 url="https://gitlab.gnome.org/GNOME/libdazzle"
 source=("https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz"
         "0001-windows-Build-pango_font_description_to_css-on-windo.patch")
-sha256sums=('413f8dfb8706760e0c649e2994bd10524ac0736601dd03ad2036293bed3bf141'
-            '658fdb8e6abe570cce42c3e7cf31c5885957df6404af1554142ebd017f556128')
+sha256sums=('d3a4d0fa2c40c1e3b1d913f0e1f8f9cda05cc007671a19f5c0c1d17742da70e6'
+            'b5df286670f4d1b87a9c14a22562d93135b6686471a20270f50adc1ed1ece8fe')
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
 


### PR DESCRIPTION
Some removed headers are getting in the way, until https://gitlab.gnome.org/GNOME/libdazzle/merge_requests/37 is merged.

This upgrade to version 3.33.4 too