### PR TITLE
dlib: add python-dlib packages

### DIFF
--- a/mingw-w64-dlib/001-python-binding.patch
+++ b/mingw-w64-dlib/001-python-binding.patch
@@ -1,0 +1,41 @@
+--- a/dlib/external/pybind11/tools/FindPythonLibsNew.cmake
++++ b/dlib/external/pybind11/tools/FindPythonLibsNew.cmake
+@@ -138,7 +138,7 @@
+ string(REGEX REPLACE "\\\\" "/" PYTHON_INCLUDE_DIR ${PYTHON_INCLUDE_DIR})
+ string(REGEX REPLACE "\\\\" "/" PYTHON_SITE_PACKAGES ${PYTHON_SITE_PACKAGES})
+ 
+-if(CMAKE_HOST_WIN32)
++if(CMAKE_HOST_WIN32 AND NOT (MSYS OR MINGW))
+     set(PYTHON_LIBRARY
+         "${PYTHON_PREFIX}/libs/Python${PYTHON_LIBRARY_SUFFIX}.lib")
+
+--- a/setup.py
++++ b/setup.py
+@@ -34,6 +34,7 @@
+ import sys
+ import shutil
+ import platform
++import sysconfig
+ import subprocess
+ import multiprocessing
+ from distutils import log
+@@ -145,7 +146,7 @@
+         cfg = 'Debug' if self.debug else 'Release'
+         build_args = ['--config', cfg]
+ 
+-        if platform.system() == "Windows":
++        if platform.system() == "Windows" and sysconfig.get_platform() != 'mingw':
+             cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), extdir)]
+             if sys.maxsize > 2**32:
+                 cmake_args += ['-A', 'x64']
+@@ -188,8 +189,8 @@
+         # We are limited either by RAM or CPU cores.  So pick the limiting amount
+         # and return that.
+         return max(min(num_cores, mem_cores), 1)
+-    except ValueError:
++    except:
+-        return 2 # just assume 2 if we can't get the os to tell us the right answer.
++        return 3 # just assume 3 if we can't get the os to tell us the right answer.
+ 
+ 
+ from setuptools.command.test import test as TestCommand

--- a/mingw-w64-dlib/PKGBUILD
+++ b/mingw-w64-dlib/PKGBUILD
@@ -1,10 +1,10 @@
 # Maintainer: Peter Budai <peterbudai@hotmail.com>
 
 _realname=dlib
-pkgbase=mingw-w64-${_realname}
-pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgbase=("mingw-w64-${_realname}" "mingw-w64-python-${_realname}")
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=19.17
-pkgrel=1
+pkgrel=2
 pkgdesc="A toolkit for making real world machine learning and data analysis applications in C++ (mingw-w64)"
 arch=('any')
 url='http://dlib.net/'
@@ -16,17 +16,31 @@ depends=("${MINGW_PACKAGE_PREFIX}-lapack"
   "${MINGW_PACKAGE_PREFIX}-openblas"
   "${MINGW_PACKAGE_PREFIX}-lapack"
   "${MINGW_PACKAGE_PREFIX}-fftw"
-  "${MINGW_PACKAGE_PREFIX}-sqlite3"
-  )
-
-makedepends=("${MINGW_PACKAGE_PREFIX}-cmake")
+  "${MINGW_PACKAGE_PREFIX}-sqlite3")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
 options=('strip')
-source=(${_realname}-${pkgver}.tar.gz::"https://github.com/davisking/${_realname}/archive/v${pkgver}.tar.gz")
-sha256sums=('9d2a158b2adad6acba2346f90d929558a691151aa076a0b409ee685534118692')
+source=(${_realname}-${pkgver}.tar.gz::"https://github.com/davisking/${_realname}/archive/v${pkgver}.tar.gz"
+        "001-python-binding.patch")
+sha256sums=('9d2a158b2adad6acba2346f90d929558a691151aa076a0b409ee685534118692'
+            'd40f90a70da30689343071a7194ddcff73e225a6fff49ef6389b3dd861ac586f')
 
 
 prepare() {
   cd "$srcdir"/${_realname}-${pkgver}
+  patch -Np1 -i "${srcdir}/001-python-binding.patch"
+
+  cd "${srcdir}"
+  for builddir in python{2,3}-build-${CARCH}; do
+    rm -rf ${builddir} | true
+    cp -r "${_realname}-${pkgver}" "${builddir}"
+  done
+
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
 }
 
 build() {
@@ -38,7 +52,7 @@ build() {
     ${MINGW_PREFIX}/bin/cmake \
       -G'MSYS Makefiles' \
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-      -USE_AVX_INSTRUCTIONS=ON \
+      -DUSE_AVX_INSTRUCTIONS=ON \
       -DDLIB_ISO_CPP_ONLY=OFF \
       -DDLIB_IN_PROJECT_BUILD=OFF \
       -DDLIB_USE_CUDA=OFF \
@@ -49,8 +63,23 @@ build() {
       -DDLIB_USE_FFTW=ON \
       -DBUILD_SHARED_LIBS=ON \
       ../${_realname}-${pkgver}
-
   cmake --build . --config Release
+
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build -G "MSYS Makefiles" \
+      --set CMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      --set USE_AVX_INSTRUCTIONS=ON \
+      --set DLIB_ISO_CPP_ONLY=OFF \
+      --set DLIB_IN_PROJECT_BUILD=ON \
+      --set DLIB_USE_CUDA=OFF \
+      --set DLIB_JPEG_SUPPORT=ON \
+      --set DLIB_PNG_SUPPORT=ON \
+      --set DLIB_GIF_SUPPORT=ON \
+      --set DLIB_LINK_WITH_SQLITE3=ON \
+      --set DLIB_USE_FFTW=ON
+  done  
 }
 
 #check() {
@@ -58,16 +87,50 @@ build() {
   #make check
 #}
 
-package() {
+package_dlib() {
+  optdepends=("${MINGW_PACKAGE_PREFIX}-python2-dlib"
+              "${MINGW_PACKAGE_PREFIX}-python3-dlib")
   cd "${srcdir}"/build-${CARCH}
   make install DESTDIR="${pkgdir}"
 
   # Remove hard coded library path from cmake files
   local PREFIX_DEPS=$(cygpath -am ${MINGW_PREFIX})
-
   pushd "${pkgdir}${MINGW_PREFIX}/lib/cmake/dlib" > /dev/null
-  sed -s "s|${PREFIX_DEPS}|${MINGW_PREFIX}|g" -i ./dlibConfig.cmake
-  sed -s "s|${PREFIX_DEPS}|${MINGW_PREFIX}|g" -i ./dlib.cmake
+  sed -s "s|${PREFIX_DEPS}/include||g" -i ./dlibConfig.cmake
+  sed -s -e "s|${PREFIX_DEPS}/lib/||g" -e "s|${PREFIX_DEPS}/include||g" -i ./dlib.cmake
   popd > /dev/null
+}
 
+package_python-dlib() {
+  depends=("${MINGW_PACKAGE_PREFIX}-dlib"
+           "${MINGW_PACKAGE_PREFIX}-python${1}")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-python${1}-numpy: Python ${1}.x interface")
+
+  cd "${srcdir}/python${1}-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    ${MINGW_PREFIX}/bin/python${1} setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" --optimize=1 --skip-build
+}
+
+package_mingw-w64-i686-dlib() {
+  package_dlib
+}
+
+package_mingw-w64-x86_64-dlib() {
+  package_dlib
+}
+
+package_mingw-w64-i686-python2-dlib() {
+  package_python-dlib 2
+}
+
+package_mingw-w64-i686-python3-dlib() {
+  package_python-dlib 3
+}
+
+package_mingw-w64-x86_64-python2-dlib() {
+  package_python-dlib 2
+}
+
+package_mingw-w64-x86_64-python3-dlib() {
+  package_python-dlib 3
 }


### PR DESCRIPTION
Hi,
currently there is no python binding in mingw-w64-dlib package.

I think there are 3 different ways to add the missing binding:
1. include them in all inside the existing mingw-w64-dlib packages (e.g. OpenCV does this)
2. create a separate package script to create the individual python binding packages (e.g. zeromq does this)
3. extend the the existing package script to generate individual packages

In this PR I choose the third option, the package script will now create 6 packages:
mingw-w64-i686-dlib
mingw-w64-i686-python2-dlib
mingw-w64-i686-python3-dlib
mingw-w64-x86_64-dlib
mingw-w64-x86_64-python2-dlib
mingw-w64-x86_64-python3-dlib

@peterbud @Alexpux please review and make any changes you want. :)