### PR TITLE
julia: Use libopenblas.dll instead of liblapack.dll; Open the test function; Install lib{c,llvm}calltest.dll to the bin directory.

### DIFF
--- a/mingw-w64-julia/0010-fix-install-dir.patch
+++ b/mingw-w64-julia/0010-fix-install-dir.patch
@@ -1,5 +1,5 @@
---- julia-1.1.1/Makefile	2019-08-06 13:11:41.716887700 +0800
-+++ build-x86_64-w64-mingw32/Makefile	2019-08-06 13:53:49.367698400 +0800
+--- julia-1.1.1/Makefile	2019-08-07 06:30:31.338129300 +0800
++++ build-x86_64-w64-mingw32/Makefile	2019-08-08 22:45:09.645033500 +0800
 @@ -330,7 +330,7 @@
  
  
@@ -9,7 +9,7 @@
  		mkdir -p $(DESTDIR)$$subdir; \
  	done
  
-@@ -339,13 +339,14 @@
+@@ -339,13 +339,16 @@
  	$(INSTALL_M) $(build_bindir)/julia-debug $(DESTDIR)$(bindir)/
  endif
  ifeq ($(OS),WINNT)
@@ -21,7 +21,9 @@
  	-$(INSTALL_M) $(build_libdir)/libjulia-debug.dll.a $(DESTDIR)$(libdir)/
  endif
 -	-$(INSTALL_M) $(build_bindir)/libopenlibm.dll.a $(DESTDIR)$(libdir)/
-+	-$(INSTALL_M) $(filter-out $(foreach suffix,$(JL_TARGETS),$(build_bindir)/lib$(suffix).dll),$(wildcard $(build_bindir)/*.dll)) $(DESTDIR)$(bindir)/julia-$(JULIA_VERSION)/
++	-$(INSTALL_M) $(build_bindir)/libccalltest.dll $(DESTDIR)$(bindir)/
++	-$(INSTALL_M) $(build_bindir)/libllvmcalltest.dll $(DESTDIR)$(bindir)/
++	-$(INSTALL_M) $(filter-out $(foreach suffix,$(JL_TARGETS) ccalltest llvmcalltest,$(build_bindir)/lib$(suffix).dll),$(wildcard $(build_bindir)/*.dll)) $(DESTDIR)$(bindir)/julia-$(JULIA_VERSION)/
 +	-$(INSTALL_M) $(build_bindir)/libopenlibm.dll.a $(DESTDIR)$(private_libdir)/
  else
  

--- a/mingw-w64-julia/PKGBUILD
+++ b/mingw-w64-julia/PKGBUILD
@@ -35,7 +35,7 @@ sha256sums=('0155a33448cb2334ae7487a35a2416a4205da4541b90fc9f97208da11e273c9e'
             'bd05dbdfd81173d6fbecd2d35b65699d76e97ea887fab140bb7642eff31dedf6'
             '71fb4b167b9dcf5d227e8ce7e05d35301f2f6ce2b353c4215e8282d5d3a8dc33'
             'f82628d0a12c1503ce3a032c6194392f257f49c03724d6788a6d7f5789e33982'
-            'b450607ff753a75c625d2042780bb1295874880704bfc8e7ebc6b2dc759c7262'
+            '0ac90c5d4d56dc65827bc5ca7189bd983f2cfb33a70ed46d48243f5db4af76df'
             '3263ef60feb20fd3605b8abd159d06e76c43c03e8aba893864182aac813cddba')
 
 # Helper macros to help make tasks easier #
@@ -83,6 +83,8 @@ USE_SYSTEM_SUITESPARSE = 1
 USE_LLVM_SHLIB = 0
 # USE_SYSTEM_PCRE = 1
 USE_SYSTEM_BLAS = 1
+LIBBLAS=-lopenblas
+LIBBLASNAME=libopenblas
 # USE_SYSTEM_GMP = 1
 USE_SYSTEM_MBEDTLS = 1
 USE_SYSTEM_LIBSSH2 = 1
@@ -107,10 +109,10 @@ EOF
 check() {
   cd "${srcdir}/build-${MINGW_CHOST}"
 
-  # cd test
-  # ../usr/bin/julia --check-bounds=yes --startup-file=no ./runtests.jl all --skip Sockets --skip Distributed
-  # find ../stdlib \( -name \*.cov -o -name \*.mem \) -delete
-  # rm -r depot/compiled
+  cd test
+  ../usr/bin/julia --check-bounds=yes --startup-file=no ./runtests.jl all --skip Sockets --skip Distributed
+  find ../stdlib \( -name \*.cov -o -name \*.mem \) -delete
+  rm -r depot/compiled
 }
 
 package() {


### PR DESCRIPTION
Use libopenblas.dll instead of liblapack.dll; 
Open the test function; 
Install lib{c,llvm}calltest.dll to the bin directory.