### PR TITLE
python3-cmd2: update to 0.9.16

### DIFF
--- a/mingw-w64-python3-cmd2/PKGBUILD
+++ b/mingw-w64-python3-cmd2/PKGBUILD
@@ -5,7 +5,7 @@
 _realname=cmd2
 pkgbase=mingw-w64-python-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
-pkgver=0.9.15
+pkgver=0.9.16
 pkgrel=1
 pkgdesc="Extra features for standard library's cmd module (mingw-w64)"
 arch=('any')
@@ -25,7 +25,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python3-pytest-runner"
 # 'vi')
 options=('staticlibs' 'strip' '!debug')
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/python-cmd2/cmd2/archive/${pkgver}.tar.gz")
-sha512sums=('1cf297a0413f92a6a007e997bf5e5513dab4349dfa1c7776f126ffce652a32a7991d2a30d87ba866d4b55b684516d88ef9326d1362b7e3555b5abac71b589bc5')
+sha512sums=('903b69388984cbbf3f2bf746c238259dc61b31a1bc8dce0d5caa9dc70bb3366457a226d248558601d4d9d43b9aae0abf0fc171f100ab2358b58a74813de63025')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {


### PR DESCRIPTION
This updates python3-cmd2 to 0.9.16.