### PR TITLE
groonga: update to 9.0.6

### DIFF
--- a/mingw-w64-groonga/PKGBUILD
+++ b/mingw-w64-groonga/PKGBUILD
@@ -3,15 +3,14 @@
 _realname=groonga
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=9.0.4
+pkgver=9.0.6
 pkgrel=1
 pkgdesc="An opensource fulltext search engine (mingw-w64)"
 arch=('any')
 url="http://groonga.org/"
 license=('LGPL2')
 options=('strip' 'staticlibs')
-source=("http://packages.groonga.org/source/${_realname}/${_realname}-${pkgver}.tar.gz"
-        001-fix-build.patch)
+source=("http://packages.groonga.org/source/${_realname}/${_realname}-${pkgver}.tar.gz")
 depends=("${MINGW_PACKAGE_PREFIX}-arrow"
          #"${MINGW_PACKAGE_PREFIX}-libevent"
          "${MINGW_PACKAGE_PREFIX}-lz4"
@@ -24,14 +23,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-arrow"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-zstd")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
-sha256sums=('4fd8a0aca37f6c675c52cde58fb15a460ac90bf111825559077e8081e6fe9e01'
-            '1b080f699bd5d2b47ee145ca9d2f631703eb0f275d7ddd62c513d60639362cf3')
-
-prepare() {
-  cd ${_realname}-${pkgver}
-  patch -p1 -i ${srcdir}/001-fix-build.patch
-  autoreconf -fv
-}
+sha256sums=('874e14b409ced9559152cfdcce872503bd0501e1411174ed1ff0a486cf463734')
 
 build() {
   [[ -d ${srcdir}/build-${CARCH} ]] && rm -rf ${srcdir}/build-${CARCH}


### PR DESCRIPTION
001-fix-build.patch is also removed because this build issue was fixed
in upstream.