### PR TITLE
VapourSynth: update to R47.1

### DIFF
--- a/mingw-w64-vapoursynth/PKGBUILD
+++ b/mingw-w64-vapoursynth/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=vapoursynth
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=45.1
+pkgver=47.1
 pkgrel=1
 pkgdesc="A video processing framework with simplicity in mind (mingw-w64)"
 arch=('any')
@@ -18,8 +18,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-python3"
          "${MINGW_PACKAGE_PREFIX}-tesseract-ocr"
          "${MINGW_PACKAGE_PREFIX}-zimg")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-nasm")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 options=(!strip staticlibs)
 source=("vapoursynth-${pkgver}.tar.gz::https://github.com/vapoursynth/vapoursynth/archive/R${pkgver}.tar.gz")
 sha256sums=('4f43e5bb8c4817fdebe572d82febe4abac892918c54e1cb71aa6f6eb3677a877')


### PR DESCRIPTION
Remove nasm from makedepends

See https://github.com/vapoursynth/vapoursynth/issues/460#issuecomment-516011740