### PR TITLE
spatialite-tools: add readline in depends

### DIFF
--- a/mingw-w64-spatialite-tools/PKGBUILD
+++ b/mingw-w64-spatialite-tools/PKGBUILD
@@ -6,13 +6,16 @@ _realname=spatialite-tools
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.3.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Set of CLI tools for spatialite (mingw-w64)'
 arch=('any')
 url='https://www.gaia-gis.it/fossil/spatialite-tools/index'
-license=('MPL')
+license=('GPL3+')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
-depends=("${MINGW_PACKAGE_PREFIX}-libspatialite" "${MINGW_PACKAGE_PREFIX}-readosm" "${MINGW_PACKAGE_PREFIX}-libiconv")
+depends=("${MINGW_PACKAGE_PREFIX}-libiconv"
+         "${MINGW_PACKAGE_PREFIX}-libspatialite"
+         "${MINGW_PACKAGE_PREFIX}-readline"
+         "${MINGW_PACKAGE_PREFIX}-readosm")
 options=('!libtool')
 source=("https://www.gaia-gis.it/gaia-sins/${_realname}-sources/${_realname}-${pkgver}.tar.gz")
 sha256sums=('f739859bc04f38735591be2f75009b98a2359033675ae310dffc3114a17ccf89')


### PR DESCRIPTION
Added readline in spatialite-tools depends.
Binary package rebuild is required to address the readline:7->readline:8 upgrade.

Minor: fixed the license.

Ref: osmcode/libosmium#285.