### PR TITLE
python: Move idle, pydoc and 2to3 to python3

### DIFF
--- a/mingw-w64-python2/PKGBUILD
+++ b/mingw-w64-python2/PKGBUILD
@@ -6,7 +6,7 @@ _realname=python2
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.7.16
-pkgrel=6
+pkgrel=7
 _pybasever=${pkgver%.*}
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
@@ -394,6 +394,11 @@ package() {
   for fscripts in 2to3 idle pydoc; do
     sed -e "s|${PREFIX_WIN}/bin/|/usr/bin/env |g" -i "${pkgdir}${MINGW_PREFIX}"/bin/$fscripts
   done
+
+  # These are provided by Python 3 now
+  mv "${pkgdir}${MINGW_PREFIX}"/bin/idle "${pkgdir}${MINGW_PREFIX}"/bin/idle2
+  mv "${pkgdir}${MINGW_PREFIX}"/bin/pydoc "${pkgdir}${MINGW_PREFIX}"/bin/pydoc2
+  mv "${pkgdir}${MINGW_PREFIX}"/bin/2to3 "${pkgdir}${MINGW_PREFIX}"/bin/2to3-"${_pybasever}"
 
   sed -i "s|#!${pkgdir}${MINGW_PREFIX}/bin/python${_pybasever}.exe|#!/usr/bin/env python${_pybasever}.exe|" "${pkgdir}${MINGW_PREFIX}"/bin/python${_pybasever}-config
   sed -i "s|#!${pkgdir}${MINGW_PREFIX}/bin/python${_pybasever}.exe|#!/usr/bin/env python${_pybasever}.exe|" "${pkgdir}${MINGW_PREFIX}"/bin/python2-config

--- a/mingw-w64-python3/PKGBUILD
+++ b/mingw-w64-python3/PKGBUILD
@@ -17,11 +17,12 @@ _realname=python3
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 provides=("${MINGW_PACKAGE_PREFIX}-python3-virtualenv")
-conflicts=("${MINGW_PACKAGE_PREFIX}-python3-virtualenv")
+conflicts=("${MINGW_PACKAGE_PREFIX}-python3-virtualenv"
+           "${MINGW_PACKAGE_PREFIX}-python2<2.7.16-7")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-virtualenv")
 _pybasever=3.7
 pkgver=${_pybasever}.4
-pkgrel=6
+pkgrel=7
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 license=('PSF')
@@ -460,8 +461,13 @@ package() {
   sed -i "s#${srcdir}/Python-${pkgver}:##" "${pkgdir}${MINGW_PREFIX}"/lib/python${_pybasever}/config-${VERABI}/Makefile
 
   for fscripts in 2to3-${_pybasever} idle3 idle${_pybasever} pydoc3 pydoc${_pybasever} pyvenv pyvenv-${_pybasever}; do
-    sed -e "s|${PREFIX_WIN}/bin/python${_pybasever}.exe|/usr/bin/env python${_pybasever}.exe|g" -i "${pkgdir}${MINGW_PREFIX}"/bin/${fscripts}
+    sed -i "s|$(cygpath -w ${MINGW_PREFIX} | sed 's|\\|\\\\|g')/bin/python${_pybasever}.exe|/usr/bin/env python${_pybasever}.exe|g" "${pkgdir}${MINGW_PREFIX}"/bin/${fscripts}
   done
+
+  # Default names are aliases for Python3 now
+  cp "${pkgdir}${MINGW_PREFIX}"/bin/idle3 "${pkgdir}${MINGW_PREFIX}"/bin/idle
+  cp "${pkgdir}${MINGW_PREFIX}"/bin/pydoc3 "${pkgdir}${MINGW_PREFIX}"/bin/pydoc
+  cp "${pkgdir}${MINGW_PREFIX}"/bin/2to3-3.7 "${pkgdir}${MINGW_PREFIX}"/bin/2to3
 
   sed -i "s|#!${pkgdir}${MINGW_PREFIX}/bin/python${VERABI}.exe|#!/usr/bin/env python${_pybasever}.exe|" "${pkgdir}${MINGW_PREFIX}"/lib/python${_pybasever}/config-${VERABI}/python-config.py
 


### PR DESCRIPTION
Python 2 now has idle2, pydoc2 and 2to3-2.7

This also fixes the shebang line of the python3 scripts.
They contain backslashes which we need to escape for sed.