### PR TITLE
Build 'bpy' module

### DIFF
--- a/mingw-w64-blender/PKGBUILD
+++ b/mingw-w64-blender/PKGBUILD
@@ -18,7 +18,7 @@ _minorchar=
 } || {
   pkgver=${_basever}.${_minorchar}
 }
-pkgrel=1
+pkgrel=2
 pkgdesc="A fully integrated 3D graphics creation suite (mingw-w64)"
 arch=('any')
 license=('GPL')
@@ -173,6 +173,7 @@ build() {
     -DPYTHON_LIBRARY=python${_pyver}m \
     -DPYTHON_INCLUDE_DIRS=${MINGW_PREFIX}/include/python${_pyver}m \
     -DWITH_PYTHON_INSTALL=OFF \
+    -DWITH_PYTHON_MODULE=ON \
     -DWITH_PYTHON_INSTALL_NUMPY=OFF \
     -DPYTHON_NUMPY_PATH=${MINGW_PREFIX}/lib/python${_pyver}/site-packages \
     -DCYCLES_OSL=${MINGW_PREFIX} \


### PR DESCRIPTION
Enabled building the bpy.pyd Python module, which should be useful for debugging Blender addons externally, as Blender's script debugging via internal Python console is rather lacking. While this builds, I'm not sure if Blender itself is built with it. Should this be a separate package?