### PR TITLE
Revert "python3: Replace python3-virtualenv package"

### DIFF
--- a/mingw-w64-python3/PKGBUILD
+++ b/mingw-w64-python3/PKGBUILD
@@ -16,13 +16,10 @@
 _realname=python3
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-provides=("${MINGW_PACKAGE_PREFIX}-python3-virtualenv")
-conflicts=("${MINGW_PACKAGE_PREFIX}-python3-virtualenv"
-           "${MINGW_PACKAGE_PREFIX}-python2<2.7.16-7")
-replaces=("${MINGW_PACKAGE_PREFIX}-python3-virtualenv")
+conflicts=("${MINGW_PACKAGE_PREFIX}-python2<2.7.16-7")
 _pybasever=3.7
 pkgver=${_pybasever}.4
-pkgrel=7
+pkgrel=8
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 license=('PSF')


### PR DESCRIPTION
This reverts commit a934b5a5d1d50e71d4f27e3036c0711e16b397e8.

python3 doesn't provide a virtualenv command