### PR TITLE
ghdl: add 'ghdl-llvm' (for mingw32) and/or 'ghdl-gcc' (for mingw32|mingw64)

### DIFF
--- a/mingw-w64-ghdl-llvm/PKGBUILD
+++ b/mingw-w64-ghdl-llvm/PKGBUILD
@@ -3,13 +3,13 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=dev
 pkgrel=1
-pkgdesc="GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL (LLVM backend) (mingw-w64)"
-arch=('x86_64')
+pkgdesc="GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL (LLVM backend)"
+arch=('any')
 license=('GPL2+')
 url="http://github.com/ghdl"
 provides=('ghdl')
 conflicts=('ghdl-mcode')
-depends=('zlib-devel' 'mingw-w64-x86_64-clang')
+depends=('zlib-devel' "${MINGW_PACKAGE_PREFIX}-clang")
 makedepends=("${MINGW_PACKAGE_PREFIX}-clang" "${MINGW_PACKAGE_PREFIX}-gcc-ada")
 source=("ghdl::git://github.com/ghdl/ghdl.git#commit=e2d751d6")
 sha512sums=('SKIP')

--- a/mingw-w64-ghdl-llvm/PKGBUILD
+++ b/mingw-w64-ghdl-llvm/PKGBUILD
@@ -28,8 +28,8 @@ pkgver() {
 build() {
   mkdir "${srcdir}/builddir"
   cd "${srcdir}/builddir"
-  CC=clang ../ghdl/configure --prefix=${MINGW_PREFIX} --with-llvm-config="llvm-config --link-static" LDFLAGS="-static" --enable-libghdl --enable-synth
-  CC=clang make GNATMAKE="gnatmake -j$(nproc)"
+  ../ghdl/configure --prefix=${MINGW_PREFIX} --with-llvm-config="llvm-config --link-static" LDFLAGS="-static" --enable-libghdl --enable-synth
+  make GNATMAKE="gnatmake -j$(nproc)"
 }
 
 # FIXME: Cannot run tests because expected failures make 'check()' exit with error: A failure occurred in check()

--- a/mingw-w64-ghdl-llvm/PKGBUILD
+++ b/mingw-w64-ghdl-llvm/PKGBUILD
@@ -28,8 +28,8 @@ pkgver() {
 build() {
   mkdir "${srcdir}/builddir"
   cd "${srcdir}/builddir"
-  ../ghdl/configure --prefix=${MINGW_PREFIX} --with-llvm-config="llvm-config --link-static" LDFLAGS="-static" --enable-libghdl --enable-synth
-  make GNATMAKE="gnatmake -j$(nproc)"
+  CC=clang ../ghdl/configure --prefix=${MINGW_PREFIX} --with-llvm-config="llvm-config --link-static" LDFLAGS="-static" --enable-libghdl --enable-synth
+  CC=clang make GNATMAKE="gnatmake -j$(nproc)"
 }
 
 # FIXME: Cannot run tests because expected failures make 'check()' exit with error: A failure occurred in check()

--- a/mingw-w64-ghdl-llvm/PKGBUILD
+++ b/mingw-w64-ghdl-llvm/PKGBUILD
@@ -1,0 +1,41 @@
+_realname=ghdl-llvm
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=dev
+pkgrel=1
+pkgdesc="GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL (LLVM backend) (mingw-w64)"
+arch=('x86_64')
+license=('GPL2+')
+url="http://github.com/ghdl"
+provides=('ghdl')
+conflicts=('ghdl-mcode')
+depends=('zlib-devel' 'mingw-w64-x86_64-clang')
+makedepends=("${MINGW_PACKAGE_PREFIX}-clang" "${MINGW_PACKAGE_PREFIX}-gcc-ada")
+source=("ghdl::git://github.com/ghdl/ghdl.git#commit=e2d751d6")
+sha512sums=('SKIP')
+
+pkgver() {
+  cd "${srcdir}/ghdl"
+  # Date of the last git commit
+  _verdate=`git log -1 --date=short --pretty=format:%cd`
+  if `git describe --exact-match > /dev/null 2>&1` ; then
+    echo "`git describe --tags`.$_verdate" | sed 's/-//g'
+  else
+    git describe --tags --abbrev=10 | sed "s/\([!-]*\)-\(.*\)/\1.$_verdate.\2/g" | sed 's/-//g'
+  fi;
+}
+
+build() {
+  mkdir "${srcdir}/builddir"
+  cd "${srcdir}/builddir"
+  ../ghdl/configure --prefix=${MINGW_PREFIX} --with-llvm-config="llvm-config --link-static" LDFLAGS="-static" --enable-libghdl --enable-synth
+  make GNATMAKE="gnatmake -j$(nproc)"
+}
+
+# FIXME: Cannot run tests because expected failures make 'check()' exit with error: A failure occurred in check()
+
+package() {
+  cd "${srcdir}/builddir"
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/lib"
+  make DESTDIR="${pkgdir}" install
+}

--- a/mingw-w64-ghdl-mcode/PKGBUILD
+++ b/mingw-w64-ghdl-mcode/PKGBUILD
@@ -1,0 +1,41 @@
+_realname=ghdl-mcode
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=dev
+pkgrel=1
+pkgdesc="GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL (mcode backend) (mingw-w64)"
+arch=('i686')
+license=('GPL2+')
+url="http://github.com/ghdl"
+provides=('ghdl')
+conflicts=('ghdl-llvm')
+depends=('zlib-devel')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-gcc-ada")
+source=("ghdl::git://github.com/ghdl/ghdl.git#commit=e2d751d6")
+sha512sums=('SKIP')
+
+pkgver() {
+  cd "${srcdir}/ghdl"
+  # Date of the last git commit
+  _verdate=`git log -1 --date=short --pretty=format:%cd`
+  if `git describe --exact-match > /dev/null 2>&1` ; then
+    echo "`git describe --tags`.$_verdate" | sed 's/-//g'
+  else
+    git describe --tags --abbrev=10 | sed "s/\([!-]*\)-\(.*\)/\1.$_verdate.\2/g" | sed 's/-//g'
+  fi;
+}
+
+build() {
+  mkdir "${srcdir}/builddir"
+  cd "${srcdir}/builddir"
+  ../ghdl/configure --prefix=${MINGW_PREFIX} LDFLAGS=-static --enable-libghdl --enable-synth
+  make GNATMAKE="gnatmake -j$(nproc)"
+}
+
+# FIXME: Cannot run tests because expected failures make 'check()' exit with error: A failure occurred in check()
+
+package() {
+  cd "${srcdir}/builddir"
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/lib"
+  make DESTDIR="${pkgdir}" install
+}


### PR DESCRIPTION
GHDL was added in #6688 :tada: :tada: :tada:

However, the current package is an split package that builds GHDL with mcode for MINGW32 and with LLVM for MINGW64. This PR is for tracking other builds: LLVM on MINGW32 and GCC on either MINGW32 or MING64.

---

[GHDL](https://github.com/ghdl/ghdl) supports three different backends: mcode (built-in, for x86 32/64 bit only), LLVM and GCC.

|   | mingw32 | mingw64 |
|---|---|---|
| mcode | ok | build successful<br>`Segmentation fault` at runtime<br> (mcode is not supported on win64 yet) |
| LLVM | build error<br>see below | ok |
| GCC | not contributed yet | not contributed yet |

Hence, I have tested these locally with:

```
cd mingw-w64-ghdl-mcode
MINGW_INSTALLS=mingw32 makepkg-mingw -sCLfc
pacman -U mingw-w64-i686-ghdl-mcode-v0.36-1-any.pkg.tar.xz

cd mingw-w64-ghdl-llvm
MINGW_INSTALLS=mingw64 makepkg-mingw -sCLfc
pacman -U mingw-w64-x86_64-ghdl-llvm-v0.36-1-any.pkg.tar.xz
```

LLVM for mingw32 produces the following error during build:

``` bash
gcc.exe: internal compiler error: Aborted signal terminated program gnat1
Please submit a full bug report,
with preprocessed source if appropriate.
See <https://sourceforge.net/projects/msys2> for instructions.
gnatmake: "run-bind.adb" compilation error
make: *** [../ghdl/src/grt/Makefile.inc:126: grt/run-bind.o] Error 4
make: *** Waiting for unfinished jobs....
````