### PR TITLE
libogg: update to 1.3.4

### DIFF
--- a/mingw-w64-libogg/PKGBUILD
+++ b/mingw-w64-libogg/PKGBUILD
@@ -3,36 +3,76 @@
 _realname=libogg
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.3.3
+pkgver=1.3.4
 pkgrel=1
 pkgdesc="Ogg bitstream and framing library (mingw-w64)"
 arch=('any')
 url="https://xiph.org/"
 license=('BSD')
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-gcc")
 options=('staticlibs' 'strip')
-source=(https://downloads.xiph.org/releases/ogg/${_realname}-${pkgver}.tar.gz)
-sha256sums=('c2e8a485110b97550f453226ec644ebac6cb29d1caef2902c007edab4308d985')
+source=("https://downloads.xiph.org/releases/ogg/${_realname}-${pkgver}.tar.gz"
+        "libogg-1.3.4-versioned-dll-cmake.patch")
+sha256sums=('fe5670640bd49e828d64d2879c31cb4dde9758681bb664f9bdbf159a01b0c76e'
+            'dd62d87b3890fc274f60dd8209979d0494e25a33a7128c917e7b14ba2d24aba7')
 
 prepare() {
-  cd ${srcdir}/libogg-${pkgver}
+  cd ${srcdir}/${_realname}-${pkgver}
+  patch -Np1 -i "${srcdir}/libogg-1.3.4-versioned-dll-cmake.patch"
 }
 
 build() {
-  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
-  mkdir -p ${srcdir}/build-${MINGW_CHOST}
-  cd ${srcdir}/build-${MINGW_CHOST}
-  ../libogg-${pkgver}/configure \
-    --enable-shared \
-    --enable-static \
-    --prefix=${MINGW_PREFIX} \
-    --build=${MINGW_CHOST} \
-    --host=${MINGW_CHOST} \
-    --target=${MINGW_CHOST}
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  # Static
+  [[ -d "${srcdir}/build-${MINGW_CHOST}-static" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}-static"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}-static" && cd "${srcdir}/build-${MINGW_CHOST}-static"
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake \
+      -G'MSYS Makefiles' \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      "${extra_config[@]}" \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DBUILD_TESTING=OFF \
+      ../${_realname}-${pkgver}
+
+  make
+
+  # Shared
+  [[ -d "${srcdir}/build-${MINGW_CHOST}-shared" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}-shared"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}-shared" && cd "${srcdir}/build-${MINGW_CHOST}-shared"
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake \
+      -G'MSYS Makefiles' \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      "${extra_config[@]}" \
+      -DBUILD_SHARED_LIBS=ON \
+      -DBUILD_TESTING=OFF \
+      ../${_realname}-${pkgver}
+
   make
 }
 
 package() {
-  cd ${srcdir}/build-${MINGW_CHOST}
+  # Static
+  cd "${srcdir}/build-${MINGW_CHOST}-static"
   make DESTDIR="${pkgdir}" install
+
+  # Shared
+  cd "${srcdir}/build-${MINGW_CHOST}-shared"
+  make DESTDIR="${pkgdir}" install
+
+  # m4
+  install -Dm644 ${srcdir}/${_realname}-${pkgver}/ogg.m4 ${pkgdir}${MINGW_PREFIX}/share/aclocal/ogg.m4
+
+  # License
+  install -Dm644 ${srcdir}/${_realname}-${pkgver}/COPYING ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING
 }

--- a/mingw-w64-libogg/libogg-1.3.4-versioned-dll-cmake.patch
+++ b/mingw-w64-libogg/libogg-1.3.4-versioned-dll-cmake.patch
@@ -1,0 +1,15 @@
+diff -Naur libogg-1.3.4.orig/CMakeLists.txt libogg-1.3.4/CMakeLists.txt
+--- libogg-1.3.4.orig/CMakeLists.txt	2019-09-02 15:05:06.093041600 -0400
++++ libogg-1.3.4/CMakeLists.txt	2019-09-02 15:08:44.811923200 -0400
+@@ -103,6 +103,11 @@
+     VERSION ${LIB_VERSION}
+     PUBLIC_HEADER "${OGG_HEADERS}"
+ )
++if(WIN32)
++    set_target_properties(ogg
++        PROPERTIES
++        RUNTIME_OUTPUT_NAME ogg-${LIB_SOVERSION})
++endif()
+ 
+ if(BUILD_FRAMEWORK)
+     set_target_properties(ogg PROPERTIES


### PR DESCRIPTION
This updates libogg to 1.3.4. Build is switched to cmake.