### PR TITLE
nspr and nss: update to 4.22 and 3.46

### DIFF
--- a/mingw-w64-nspr/PKGBUILD
+++ b/mingw-w64-nspr/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=nspr
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.21
+pkgver=4.22
 pkgrel=1
 pkgdesc="Netscape Portable Runtime (mingw-w64)"
 arch=('any')
@@ -21,10 +21,10 @@ source=(https://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v${pkgver}/src/${_
         nspr-4.10.2_staticbuild.patch
         nspr-4.10.2_x64.patch
         manifest)
-sha256sums=('15ea32c7b100217b6e3193bc03e77f485d9bf7504051443ba9ce86d1c17c6b5a'
+sha256sums=('c9e4b6cc24856ec93202fe13704b38b38ba219f0f2aeac93090ce2b6c696d430'
             '1894bc68a0badd6e6f68f66abc4c6cd8e222791dd194f6b631ce536011ab6707'
             '725f8d6da56e44dba7669c498ed66af1b2145640115fd9bae9663c9364d9fde9'
-            'e3358ed82a289b76b23ceb95308a517145e8c915c0056af58ad1193db870269a'
+            '3108ea02a33dbe8d612b70c44b60826d8beea1bbfa907668dc798f8061fb4ad4'
             '4f47fbfce21a5634094d6a0c7fdd29f2bbdcb352074b8c498ba23a9f4f859b29'
             'bdb7138b12b7fbc32e906347e0dc963342316032ac3db8586683e54e40126e26'
             '599ab9edb21568c02c4e6e96b366e51c042a9e789b72b9e7d9b7acc283757ab4'

--- a/mingw-w64-nspr/nspr-4.10.2_autotools.patch
+++ b/mingw-w64-nspr/nspr-4.10.2_autotools.patch
@@ -98,7 +98,7 @@
      DLL_SUFFIX=dll
      MKSHLIB='$(LD) -DLL $(DSO_LDOPTS) -OUT:$@'
  
-@@ -7801,6 +7801,7 @@
+@@ -7409,6 +7409,7 @@
      $as_echo "#define TCPV40HDRS 1" >>confdefs.h
  
      LIB_SUFFIX=lib
@@ -156,7 +156,7 @@
      DLL_SUFFIX=dll
      MKSHLIB=
      DSO_LDOPTS=
-@@ -2509,6 +2513,7 @@
+@@ -2211,6 +2211,7 @@
      AC_DEFINE(BSD_SELECT)
      AC_DEFINE(TCPV40HDRS)
      LIB_SUFFIX=lib

--- a/mingw-w64-nss/PKGBUILD
+++ b/mingw-w64-nss/PKGBUILD
@@ -4,8 +4,8 @@
 _realname=nss
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.45
-_nsprver=4.21
+pkgver=3.46
+_nsprver=4.22
 pkgrel=1
 pkgdesc="Mozilla Network Security Services (mingw-w64)"
 arch=('any')
@@ -27,7 +27,7 @@ source=(https://ftp.mozilla.org/pub/security/nss/releases/NSS_${pkgver//./_}_RTM
         blank-key3.db
         blank-secmod.db
         nss-3.20.1-headers.patch)
-sha256sums=('112f05223d1fde902c170966bfc6f011b24a838be16969b110ecf2bb7bc24e8b'
+sha256sums=('6b699649d285602ba258a4b0957cb841eafc94eff5735a9da8da0adbb9a10cef'
             '1894bc68a0badd6e6f68f66abc4c6cd8e222791dd194f6b631ce536011ab6707'
             'b9f1428ca2305bf30b109507ff335fa00bce5a7ce0434b50acd26ad7c47dd5bd'
             'e44ac5095b4d88f24ec7b2e6a9f1581560bd3ad41a3d198596d67ef22f67adb9'
@@ -55,7 +55,6 @@ prepare() {
 }
 
 build() {
-  cd ${srcdir}/${_realname}-${pkgver}
   [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
   mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
   cp -rf ${srcdir}/${_realname}-${pkgver}/* "${srcdir}"/build-${CARCH}


### PR DESCRIPTION
This updates nspr and nss to 4.22 and 3.46, respectively.