### PR TITLE
gdk-pixbuf2: update to 2.38.2

### DIFF
--- a/mingw-w64-gdk-pixbuf2/PKGBUILD
+++ b/mingw-w64-gdk-pixbuf2/PKGBUILD
@@ -5,12 +5,12 @@
 _realname=gdk-pixbuf2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.38.1
+pkgver=2.38.2
 pkgrel=1
 pkgdesc="An image loading library (mingw-w64)"
 arch=('any')
-url="https://www.gtk.org/"
-license=(LGPL2)
+url="https://wiki.gnome.org/Projects/GdkPixbuf"
+license=(LGPL2.1)
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
@@ -29,7 +29,7 @@ source=("https://download.gnome.org/sources/gdk-pixbuf/${pkgver%.*}/gdk-pixbuf-$
         0004-build-all-loaders-plus-gdi.patch
         fix-missing-meson-dep.patch)
 noextract=("gdk-pixbuf-${pkgver}.tar.xz")
-sha256sums=('f19ff836ba991031610dcc53774e8ca436160f7d981867c8c3a37acfe493ab3a'
+sha256sums=('73fa651ec0d89d73dd3070b129ce2203a66171dfc0bd2caa3570a9c93d2d0781'
             '21bd9b2ba1447267c84f1b445cbcf50c62299254856c1c227cc7ba4babc9f27e'
             '1863341d4b4f9c52c92438b275aed1acb5c2cd3018c5e75a61a6cd9415d2f621'
             '3d3350dbb437a675e1bdfbc45ad7701634516cd95508411dfb33005b28c01044')
@@ -51,8 +51,7 @@ prepare() {
 
 build() {
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
-  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
 
   meson \
     --buildtype=plain \


### PR DESCRIPTION
This updates gdk-pixbuf2 to 2.38.2.