### PR TITLE
New package: bin2header

### DIFF
--- a/mingw-w64-bin2header/PKGBUILD
+++ b/mingw-w64-bin2header/PKGBUILD
@@ -1,0 +1,35 @@
+# Maintainer: Jordan Irwin <antumdeluge@gmail.com>
+
+_realname=bin2header
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.2.0
+pkgrel=1
+pkgdesc='Binary file to C/C++ header converter.'
+arch=('any')
+url="https://github.com/AntumDeluge/${_realname}"
+license=('MIT')
+source=("${url}/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.xz")
+sha256sums=('f7bfd28e43bc00f6f505e74bfda582e992a673b09a38a891447cb508427f6d9b')
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-cmake")
+_dirbuild="build-${CARCH}"
+
+build() {
+    [[ -d "${srcdir}/${_dirbuild}" ]] && rm -rf "${srcdir}/${_dirbuild}"
+    mkdir -p "${srcdir}/${_dirbuild}" && cd "${srcdir}/${_dirbuild}"
+
+    MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    "${MINGW_PREFIX}/bin/cmake" \
+        -G "MSYS Makefiles" \
+        -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+        -DCMAKE_BUILD_TYPE=Release \
+        "${srcdir}/${_realname}-${pkgver}"
+
+    make
+}
+
+package() {
+    cd "${srcdir}/${_dirbuild}"
+    make install DESTDIR="${pkgdir}"
+}


### PR DESCRIPTION
**Binary to Header**

*bin2header* is a command line tool. It takes any file as an argument and converts its binary data into a source header file for use in C/C++ applications. The data is stored as a character array.

Current version: 0.2.0

Upstream: https://github.com/AntumDeluge/bin2header