### PR TITLE
Add another libtool patch for picking up compiler-rt builtins from clang

### DIFF
--- a/mingw-w64-libtool/0013-Allow-statically-linking-compiler-support-libraries-.patch
+++ b/mingw-w64-libtool/0013-Allow-statically-linking-compiler-support-libraries-.patch
@@ -1,0 +1,38 @@
+From b9f77cae8cfbe850e58cac686fcb4d246b5bfc51 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Storsj=C3=B6?= <martin@martin.st>
+Date: Mon, 19 Aug 2019 13:34:51 +0300
+Subject: [PATCH] Allow statically linking compiler support libraries when
+ linking a library
+
+For cases with deplibs_check_method="file_magic ..." (as it is for mingw),
+there were previously no way that a static library could be accepted
+here.
+---
+ build-aux/ltmain.in | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/build-aux/ltmain.in b/build-aux/ltmain.in
+index e2fb2633..db4d775c 100644
+--- a/build-aux/ltmain.in
++++ b/build-aux/ltmain.in
+@@ -5870,8 +5870,15 @@ func_mode_link ()
+ 	  fi
+ 	  case $linkmode in
+ 	  lib)
+-	    # Linking convenience modules into shared libraries is allowed,
+-	    # but linking other static libraries is non-portable.
++	    # Linking convenience modules and compiler provided static libraries
++	    # into shared libraries is allowed, but linking other static
++	    # libraries is non-portable.
++	    case $deplib in
++	      */libgcc*.$libext | */libclang_rt*.$libext)
++		deplibs="$deplib $deplibs"
++		continue
++	      ;;
++	    esac
+ 	    case " $dlpreconveniencelibs " in
+ 	    *" $deplib "*) ;;
+ 	    *)
+-- 
+2.17.1
+

--- a/mingw-w64-libtool/PKGBUILD
+++ b/mingw-w64-libtool/PKGBUILD
@@ -5,7 +5,7 @@ _realname=libtool
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.4.6
-pkgrel=14
+pkgrel=15
 pkgdesc="A system independent dlopen wrapper for GNU libtool (mingw-w64)"
 arch=('any')
 url="https://www.gnu.org/software/libtool"
@@ -21,7 +21,8 @@ source=("https://ftp.gnu.org/pub/gnu/libtool/${_realname}-${pkgver}.tar.xz"{,.si
         0007-fix-cr-for-awk-in-configure.all.patch
         0008-tests.patch
         0011-Pick-up-clang_rt-static-archives-compiler-internal-l.patch
-        0012-Prefer-response-files-over-linker-scripts-for-mingw-.patch)
+        0012-Prefer-response-files-over-linker-scripts-for-mingw-.patch
+        0013-Allow-statically-linking-compiler-support-libraries-.patch)
 sha256sums=('7c87a8c2c8c0fc9cd5019e402bed4292462d00a718a7cd5f11218153bf28b26f'
             'SKIP'
             'fe8b80efd34f9385220ebc90aaec945e44de8c343c75719d6ac0d4e472a6eed5'
@@ -31,7 +32,8 @@ sha256sums=('7c87a8c2c8c0fc9cd5019e402bed4292462d00a718a7cd5f11218153bf28b26f'
             'd96beecfc5d15f94ce46bbe0e89d6e6fdb973a25ad6be98c30504b58453792c1'
             'f00b44b49f83b20d4fbde89253666d0eb769172cfd711110f1be6a175294cb27'
             'c727b2b017163cfdeca60820d3cff2dac8968c5630745602b150f92b159af313'
-            'c95a65e890b1ae6362807abc66809e72cf81aeea5f9f556e38f9752f974bf435')
+            'c95a65e890b1ae6362807abc66809e72cf81aeea5f9f556e38f9752f974bf435'
+            '8069e887aeeab7491f15e00547fa66d9b9e86407f5a23f37a6d8c7d165de752e')
 
 validpgpkeys=('CFE2BE707B538E8B26757D84151308092983D606') #Gary Vaughan (Free Software Developer) <gary@vaughan.pe>
 
@@ -45,6 +47,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0008-tests.patch
   patch -p1 -i ${srcdir}/0011-Pick-up-clang_rt-static-archives-compiler-internal-l.patch
   patch -p1 -i ${srcdir}/0012-Prefer-response-files-over-linker-scripts-for-mingw-.patch
+  patch -p1 -i ${srcdir}/0013-Allow-statically-linking-compiler-support-libraries-.patch
 }
 
 build() {


### PR DESCRIPTION
The previous patch for the same issue (in
fed7da94ad6ab2ca781ff71ea36564c0f2402f04) works fine for VLC, which
manually overrides "lt_cv_deplibs_check_method=pass_all" in their
configure.ac to get rid of this check in libtool in general.

To fix linking other projects without such existing workarounds
in their configure scripts, we need to patch libtool to allow
statically linking the compiler-rt builtins.

This patch is under discussion upstream at
https://debbugs.gnu.org/cgi/bugreport.cgi?bug=27866#65 (but doesn't
seem to be making any progress at the moment).