### PR TITLE
Update Mesa3D to 19.2.0

### DIFF
--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=19.1.6
+pkgver=19.1.7
 pkgrel=1
 pkgdesc="Open-source implementation of the OpenGL specification (mingw-w64)"
 arch=('any')
@@ -19,7 +19,7 @@ source=(https://mesa.freedesktop.org/archive/${_realname}-${pkgver}.tar.xz{,.sig
         001-extra-libs.patch
         msys2-mingw_w64-fixes.patch
         osmesa.pc)
-sha256sums=('2a369b7b48545c6486e7e44913ad022daca097c8bd937bf30dcf3f17a94d3496'
+sha256sums=('e287920fdb38712a9fed448dc90b3ca95048c7face5db52e58361f8b6e0f3cd5'
             'SKIP'
             'bc9bb5013ac80ded47ad164ae1ef58cc9a39784eb4bf61e8c7d654bb273b05a9'
             'd18124d610ba2f8a7205c8ff73e29a788af8619358ee1230b19f12c2d333335f'

--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=19.1.5
+pkgver=19.1.6
 pkgrel=1
 pkgdesc="Open-source implementation of the OpenGL specification (mingw-w64)"
 arch=('any')
@@ -19,7 +19,7 @@ source=(https://mesa.freedesktop.org/archive/${_realname}-${pkgver}.tar.xz{,.sig
         001-extra-libs.patch
         msys2-mingw_w64-fixes.patch
         osmesa.pc)
-sha256sums=('7b54e14e35c7251b171b4cf9d84cbc1d760eafe00132117db193454999cd6eb4'
+sha256sums=('2a369b7b48545c6486e7e44913ad022daca097c8bd937bf30dcf3f17a94d3496'
             'SKIP'
             'bc9bb5013ac80ded47ad164ae1ef58cc9a39784eb4bf61e8c7d654bb273b05a9'
             'd18124d610ba2f8a7205c8ff73e29a788af8619358ee1230b19f12c2d333335f'

--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=19.1.7
+pkgver=19.2.0
 pkgrel=1
 pkgdesc="Open-source implementation of the OpenGL specification (mingw-w64)"
 arch=('any')
@@ -19,10 +19,10 @@ source=(https://mesa.freedesktop.org/archive/${_realname}-${pkgver}.tar.xz{,.sig
         001-extra-libs.patch
         msys2-mingw_w64-fixes.patch
         osmesa.pc)
-sha256sums=('e287920fdb38712a9fed448dc90b3ca95048c7face5db52e58361f8b6e0f3cd5'
+sha256sums=('b060caa2a00f856431160ff7377d0e8f58f2aa48c16ee5a9e265ebdccb10852a'
             'SKIP'
             'bc9bb5013ac80ded47ad164ae1ef58cc9a39784eb4bf61e8c7d654bb273b05a9'
-            'd18124d610ba2f8a7205c8ff73e29a788af8619358ee1230b19f12c2d333335f'
+            'e9ea6806cfc022e34e7ff52f28ea52eb24c7c22e966bc17a2a6da3214807e8fe'
             'fdf26548336cc7e5700560c6636a87ffa63daa3048fa94cf4a4a0b50890c9327')
 validpgpkeys=('8703B6700E7EE06D7A39B8D6EDAE37B02CEB490D') # Emil Velikov <emil.l.velikov@gmail.com>
 validpgpkeys+=('946D09B5E4C9845E63075FF1D961C596A7203456') # Andres Gomez <tanty@igalia.com>

--- a/mingw-w64-mesa/msys2-mingw_w64-fixes.patch
+++ b/mingw-w64-mesa/msys2-mingw_w64-fixes.patch
@@ -12,14 +12,6 @@ index 61bbeb2399f..a1756a2220b 100755
      host_machine = os.environ.get('PROCESSOR_ARCHITEW6432', os.environ.get('PROCESSOR_ARCHITECTURE', host_platform.machine()))
      host_machine = {
          'x86': 'x86',
-@@ -671,6 +674,7 @@ def generate(env):
- 
-     env.Tool('yacc')
-     if host_platform.system() == 'Windows':
-+        libs += ['shell32', 'version', 'uuid', 'ole32']
-         if check_prog(env, 'win_bison'):
-             env["YACC"] = 'win_bison'
- 
 diff --git a/scons/llvm.py b/scons/llvm.py
 index a84ad51d97a..a389dd5157c 100644
 --- a/scons/llvm.py
@@ -32,11 +24,8 @@ index a84ad51d97a..a389dd5157c 100644
  import sys
  import distutils.version
  
-@@ -215,8 +216,15 @@ def generate(env):
-             'advapi32',
-             'ole32',
+@@ -217,6 +218,12 @@ def generate(env):
              'uuid',
-+            'version',
          ])
  
 +        # Mingw-w64 zlib is required when building with LLVM support in MSYS2 environment
@@ -70,27 +59,3 @@ index a89d02c5db0..ed68798bf15 100644
      envavx2.Append(CCFLAGS = ['/arch:AVX2'])
  else:
      envavx2.Append(CCFLAGS = ['-mavx2', '-mfma', '-mbmi2', '-mf16c'])
-diff --git a/src/gallium/targets/graw-gdi/SConscript b/src/gallium/targets/graw-gdi/SConscript
-index e59127cc25e..0a52bb5a7fc 100644
---- a/src/gallium/targets/graw-gdi/SConscript
-+++ b/src/gallium/targets/graw-gdi/SConscript
-@@ -14,6 +14,7 @@ env.Prepend(LIBS = [
-     gallium,
-     'gdi32',
-     'user32',
-+    'ole32',
-     'ws2_32',
- ])
- 
-diff --git a/src/gallium/targets/libgl-gdi/SConscript b/src/gallium/targets/libgl-gdi/SConscript
-index 94feca24ef3..4b0b5621b29 100644
---- a/src/gallium/targets/libgl-gdi/SConscript
-+++ b/src/gallium/targets/libgl-gdi/SConscript
-@@ -15,6 +15,7 @@ env.Append(LIBS = [
-     'gdi32',
-     'user32',
-     'kernel32',
-+    'ole32',
-     'ws2_32',
-     'advapi32',
- ])


### PR DESCRIPTION
Now that Mingw posix flag has been fixed in mesa3d/mesa@88eb2a1f
things can be simplified:
- we no longer need to extra link shell32, uuid, version and ole32;
- we only need to alias mingw platform and link zlib to LLVM.
