### PR TITLE
Python updates

### DIFF
--- a/mingw-w64-python-hypothesis/PKGBUILD
+++ b/mingw-w64-python-hypothesis/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=hypothesis
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=4.32.2
+pkgver=4.36.2
 pkgrel=1
 pkgdesc="Advanced Quickcheck style testing library for Python (mingw-w64)"
 arch=('any')
@@ -42,7 +42,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
 #              "${MINGW_PACKAGE_PREFIX}-python2-pandas")
 options=('staticlibs' 'strip' '!debug')
 source=("${_realname}-$pkgver.tar.gz"::"https://github.com/HypothesisWorks/hypothesis/archive/hypothesis-python-$pkgver.tar.gz")
-sha512sums=('ed8cc36ee2329d6ee078a5bbae49b28be52c58d715d5fe755d8816f62c17292b766c585b2d02767b2aae563c279c6cb64e3af7a29f81be0f86c47454c0b923a3')
+sha512sums=('301076674a0751d052f3df6a03f6d6ac8c9288e1f6a6dcce998153cd93129228749e5d89679dc02fb25d581ccc2678b49489ea416754c551993355cf1ec76b0f')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {

--- a/mingw-w64-python-importlib-metadata/PKGBUILD
+++ b/mingw-w64-python-importlib-metadata/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=importlib-metadata
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=0.19
+pkgver=0.23
 pkgrel=1
 pkgdesc="Read metadata from Python packages (mingw-w64)"
 arch=('any')
@@ -25,7 +25,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python2-importlib_resources"
               "${MINGW_PACKAGE_PREFIX}-python3-pytest-runner"
               "${MINGW_PACKAGE_PREFIX}-python3-wheel")
 source=("${_realname}-$pkgver.tar.gz"::"https://files.pythonhosted.org/packages/source/${_realname::1}/${_realname//-/_}/${_realname//-/_}-${pkgver}.tar.gz")
-sha512sums=('2d0126e7430804b2295ec159778082806957cb86b5c7408c38064cc7c7e62229d382778284a5a231925ab336a7cc6da8e705f6bd7ae6da66f11acd1229bda17b')
+sha512sums=('56594dfd67733842d83547770a09e12b4e4e3c000b7c9743206e13e4629906bb7271065e03c387f5114bac7f673fc17594d2ef90af23cd34b7ededecaf3fd47a')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {

--- a/mingw-w64-python-jedi/PKGBUILD
+++ b/mingw-w64-python-jedi/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=jedi
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=0.14.0
+pkgver=0.15.1
 pkgrel=1
 pkgdesc="Awesome autocompletion for python (mingw-w64)"
 arch=('any')
@@ -20,7 +20,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python3-pytest"
               "${MINGW_PACKAGE_PREFIX}-python2-pytest")
 options=('staticlibs' 'strip' '!debug')
 source=("https://pypi.python.org/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('49ccb782651bb6f7009810d17a3316f8867dde31654c750506970742e18b553d')
+sha256sums=('ba859c74fa3c966a22f2aeebe1b74ee27e2a462f56d3f5f7ca4a59af61bfe42e')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {

--- a/mingw-w64-python-pyzmq/PKGBUILD
+++ b/mingw-w64-python-pyzmq/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=pyzmq
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=18.0.2
+pkgver=18.1.0
 pkgrel=1
 pkgdesc="Python bindings for zeromq, written in Cython (mingw-w64)"
 arch=('any')
@@ -18,7 +18,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-zeromq")
 
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/zeromq/${_realname}/archive/v${pkgver}.tar.gz"
         "001-mingw-python.patch")
-sha256sums=('46b3cf243866632148e8040ad3f82498691acc24f8df7ae23b91e99d9f7ea9d4'
+sha256sums=('32f7618b8104021bc96cbd60be4330bdf37b929e8061dbce362c9f3478a08e21'
             '3106e8f70443154aa978b3fe1928774624f1ec21574dd7df9aa4699199afd43a')
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"

--- a/mingw-w64-python-statsmodels/PKGBUILD
+++ b/mingw-w64-python-statsmodels/PKGBUILD
@@ -4,7 +4,7 @@ _realname=statsmodels
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-$_realname"
          "${MINGW_PACKAGE_PREFIX}-python3-$_realname")
-pkgver=0.10.0
+pkgver=0.10.1
 pkgrel=1
 pkgdesc="Statistical computations and models for use with SciPy (mingw-w64)"
 arch=('any')
@@ -25,7 +25,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2-scipy"
              "${MINGW_PACKAGE_PREFIX}-gcc")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/${_realname}/${_realname}/archive/v${pkgver}.tar.gz"
         001-dont-include-extra-files.patch)
-sha256sums=('3aae6454480f485821a8e5761a0456030bc7e41f01648b177d141899f06588e6'
+sha256sums=('269ec50719c47f946cf3872b8abfcb36e15d5614e3bb81c4c39e74cce673d5b8'
             'd6ca9de4dbf5a8a578b582ddab7b0931ed037470b04b5a3c0ed8056ace94e257')
 
 prepare() {

--- a/mingw-w64-python-urllib3/PKGBUILD
+++ b/mingw-w64-python-urllib3/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=urllib3
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=1.25.3
+pkgver=1.25.5
 pkgrel=1
 pkgdesc="HTTP library with thread-safe connection pooling and file post support (mingw-w64)"
 url='https://github.com/shazow/urllib3'
@@ -31,7 +31,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python2-nose"
               "${MINGW_PACKAGE_PREFIX}-python2-psutil"
               "${MINGW_PACKAGE_PREFIX}-python3-psutil")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/shazow/urllib3/archive/${pkgver}.tar.gz")
-sha256sums=('fd0376d5a0d8ac633693dcbefc8f4b7acecae81e5aee7c824682cd11b3edb635')
+sha256sums=('293b19109464d9ff67cf1d241acf01c194ec092d55a117f8bd41024274c8522f')
 
 prepare() {
   cd ${srcdir}

--- a/mingw-w64-python2-pandas/PKGBUILD
+++ b/mingw-w64-python2-pandas/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=pandas
 pkgbase=mingw-w64-python-${_realname}
-pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgname="${MINGW_PACKAGE_PREFIX}-python2-${_realname}"
 pkgver=0.24.2
 pkgrel=1
 pkgdesc="Cross-section and time series data analysis toolkit (mingw-w64)"
@@ -10,13 +10,9 @@ arch=('any')
 url="https://pandas.pydata.org/"
 license=('BSD')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python2-numpy"
-             "${MINGW_PACKAGE_PREFIX}-python3-numpy"
              "${MINGW_PACKAGE_PREFIX}-python2-pytz"
-             "${MINGW_PACKAGE_PREFIX}-python3-pytz"
              "${MINGW_PACKAGE_PREFIX}-python2-dateutil"
-             "${MINGW_PACKAGE_PREFIX}-python3-dateutil"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
-             "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
              "${MINGW_PACKAGE_PREFIX}-gcc")
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/pandas-dev/${_realname}/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('4f919f409c433577a501e023943e582c57355d50a724c589e78bc1d551a535a2')
@@ -24,7 +20,6 @@ sha256sums=('4f919f409c433577a501e023943e582c57355d50a724c589e78bc1d551a535a2')
 
 prepare() {
   cp -a ${_realname}-${pkgver} ${_realname}-py2-${pkgver}
-  cp -a ${_realname}-${pkgver} ${_realname}-py3-${pkgver}
 
   cd ${_realname}-py2-${pkgver}
   sed -e "s|#![ ]*/usr/bin/python$|#!/usr/bin/python2|" \
@@ -41,17 +36,9 @@ build() {
 
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python2 setup.py build
-
-  # build for python3
-  cd ${srcdir}/${_realname}-py3-${pkgver}
-  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  ${MINGW_PREFIX}/bin/python3 setup.py build_ext --inplace
-
-  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  ${MINGW_PREFIX}/bin/python3 setup.py build
 }
 
-package_python2-pandas() {
+package() {
   depends=("${MINGW_PACKAGE_PREFIX}-python2-numpy"
            "${MINGW_PACKAGE_PREFIX}-python2-pytz"
            "${MINGW_PACKAGE_PREFIX}-python2-dateutil"
@@ -68,39 +55,4 @@ package_python2-pandas() {
 
   install -Dm644 LICENSE \
     "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
-}
-
-package_python3-pandas() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python3-numpy"
-           "${MINGW_PACKAGE_PREFIX}-python3-pytz"
-           "${MINGW_PACKAGE_PREFIX}-python3-dateutil"
-           "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
-  optdepends=("${MINGW_PACKAGE_PREFIX}-python3-scipy: needed for miscellaneous statistical functions"
-              "${MINGW_PACKAGE_PREFIX}-python3-matplotlib: needed for plotting"
-              "${MINGW_PACKAGE_PREFIX}-python3-numexpr: needed for accelerating certain numerical operations (recommended)"
-              "${MINGW_PACKAGE_PREFIX}-python3-openpyxl: needed for reading/writing Excel file")
-
-  cd ${_realname}-py3-${pkgver}
-  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  ${MINGW_PREFIX}/bin/python3 setup.py install --skip-build \
-    --prefix=${MINGW_PREFIX} --root=${pkgdir} --optimize=1
-
-  install -Dm644 LICENSE \
-    "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
-}
-
-package_mingw-w64-i686-python2-pandas() {
-  package_python2-pandas
-}
-
-package_mingw-w64-i686-python3-pandas() {
-  package_python3-pandas
-}
-
-package_mingw-w64-x86_64-python2-pandas() {
-  package_python2-pandas
-}
-
-package_mingw-w64-x86_64-python3-pandas() {
-  package_python3-pandas
 }

--- a/mingw-w64-python3-imbalanced-learn/PKGBUILD
+++ b/mingw-w64-python3-imbalanced-learn/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=imbalanced-learn
 pkgbase=mingw-w64-python3-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=0.4.3
+pkgver=0.5.0
 pkgrel=1
 pkgdesc="A Python Package to Tackle the Curse of Imbalanced Datasets in Machine Learning (mingw-w64)"
 arch=('any')
@@ -16,7 +16,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python3"
              "${MINGW_PACKAGE_PREFIX}-cython"
              )
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/scikit-learn-contrib//${_realname}/archive/${pkgver}.tar.gz")
-sha256sums=('81f590b0db7d4a5abd9eadb570b91fa05b31518805cf332dc63ee1286c0451ef')
+sha256sums=('3bad0144b0ecc078d29026ce785f3160d00eba1ffdcb51ffcff56e840f8c68fb')
 
 prepare() {
   cd "${srcdir}"

--- a/mingw-w64-python3-more-itertools/PKGBUILD
+++ b/mingw-w64-python3-more-itertools/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=more-itertools
 pkgbase=mingw-w64-python3-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=7.0.0
-pkgrel=2
+pkgver=7.2.0
+pkgrel=1
 pkgdesc="More routines for operating on iterables, beyond itertools (mingw-w64)"
 arch=('any')
 url="https://github.com/erikrose/more-itertools"
@@ -12,8 +12,8 @@ license=('MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-python3")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools")
 options=('staticlibs' 'strip' '!debug')
-source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/erikrose/more-itertools/archive/${pkgver}.tar.gz")
-sha256sums=('3a4be24ce0cc357e227e216cf16309bac255fa984b1e26e47f88d12cb857334d')
+source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/erikrose/more-itertools/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832')
 
 prepare() {
   cd "${srcdir}"

--- a/mingw-w64-python3-numpy/0010-mingw-inline-stuff.patch
+++ b/mingw-w64-python3-numpy/0010-mingw-inline-stuff.patch
@@ -20,3 +20,14 @@
  #include <stdlib.h>
  #define inline __forceinline
  #endif
+--- a/numpy/random/src/philox/philox.h    2019-09-19 21:22:05.822734300 +0200
++++ b/numpy/random/src/philox/philox.h    2019-09-06 01:59:07.000000000 +0200
+@@ -33,7 +33,7 @@
+   return (uint64_t)product;
+ }
+ #else
+-#ifdef _WIN32
++#if defined(_WIN32) && !defined(__MINGW32__)
+ #include <intrin.h>
+ #if defined(_WIN64) && defined(_M_AMD64)
+ #pragma intrinsic(_umul128)

--- a/mingw-w64-python3-numpy/0010-mingw-inline-stuff.patch
+++ b/mingw-w64-python3-numpy/0010-mingw-inline-stuff.patch
@@ -1,0 +1,22 @@
+--- a/numpy/random/src/mt19937/mt19937.h	2019-09-19 14:43:38.757883000 +0200
++++ b/numpy/random/src/mt19937/mt19937.h	2019-09-19 14:43:08.257910100 +0200
+@@ -2,7 +2,7 @@
+ #include <math.h>
+ #include <stdint.h>
+ 
+-#ifdef _WIN32
++#if defined(_WIN32) && !defined (__MINGW32__)
+ #define inline __forceinline
+ #endif
+ 
+--- a/numpy/random/src/pcg64/pcg64.h	2019-09-19 14:43:38.757883000 +0200
++++ b/numpy/random/src/pcg64/pcg64.h	2019-09-19 14:43:08.257910100 +0200
+@@ -52,7 +52,7 @@
+ 
+ #include <inttypes.h>
+ 
+-#ifdef _WIN32
++#if defined(_WIN32) && !defined (__MINGW32__)
+ #include <stdlib.h>
+ #define inline __forceinline
+ #endif

--- a/mingw-w64-python3-numpy/PKGBUILD
+++ b/mingw-w64-python3-numpy/PKGBUILD
@@ -5,8 +5,8 @@
 _realname=numpy
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=1.16.4
-pkgrel=2
+pkgver=1.17.2
+pkgrel=1
 pkgdesc="Scientific tools for Python (mingw-w64)"
 arch=('any')
 license=('BSD')
@@ -28,8 +28,9 @@ source=(https://github.com/numpy/numpy/releases/download/v${pkgver}/${_realname}
         0006-disable-visualcompaq-for-mingw.patch
         0007-disable-64bit-experimental-warning.patch
         0008-mingw-gcc-doesnt-support-visibility.patch
-        0009-disable-old-mingw-stuff.patch)
-sha256sums=('a3bccb70ad94091a5b9e2469fabd41ac877c140a6828c2022e35560a2ec0346c'
+        0009-disable-old-mingw-stuff.patch
+        0010-mingw-inline-stuff.patch)
+sha256sums=('81a4f748dcfa80a7071ad8f3d9f8edb9f8bc1f0a9bdd19bfd44fd42c02bd286c'
             '173e9020eb88a9b281180024ad0f137f86f893e2099693693e42a5bf5944381a'
             '140c23c214cae880833380e8479e4ce45c8439b22b1432d73ff0cc2cd58da886'
             '3b640625b56b158465d6628f75fadce90af8825259d04af1b1af09fef53a720c'
@@ -38,7 +39,8 @@ sha256sums=('a3bccb70ad94091a5b9e2469fabd41ac877c140a6828c2022e35560a2ec0346c'
             'e8f2c52131e79a4e36c98f499efa85bc56254e577fae11ebce0093422114a306'
             'c1114a027fc797bb6c5c6f7b3044fa853b9e9263555088b4b2b12bdb77baefd5'
             '9204922151a7459ed0ecb5d7379fc16bdee6b8c74c925c575667b0ac6ff6441a'
-            'a089bb11db5110903dba987c2ffb0ab9468414c5828bdc18809b1baeebe61b92')
+            'a089bb11db5110903dba987c2ffb0ab9468414c5828bdc18809b1baeebe61b92'
+            '68d228b3bf6afd0905772c33928d3887fd00bae7f8ab7876cefe032f8b91e8a4')
 
 prepare() {
   cd ${_realname}-${pkgver}
@@ -53,6 +55,7 @@ prepare() {
   patch -Np1 -i ${srcdir}/0007-disable-64bit-experimental-warning.patch
   patch -Np1 -i ${srcdir}/0008-mingw-gcc-doesnt-support-visibility.patch
   patch -Np1 -i ${srcdir}/0009-disable-old-mingw-stuff.patch
+  patch -Np1 -i ${srcdir}/0010-mingw-inline-stuff.patch
   cd ..
 
   cp -a ${_realname}-${pkgver} ${_realname}-py3-${CARCH}
@@ -61,6 +64,8 @@ prepare() {
 build() {
   export ATLAS=None
   export LDFLAGS="$LDFLAGS -shared"
+  # See: https://sourceforge.net/p/mingw-w64/mailman/message/36287627/
+  export CFLAGS="$CFLAGS -fno-asynchronous-unwind-tables"
 
   cd ${_realname}-py3-${CARCH}
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
@@ -73,6 +78,7 @@ package() {
 
   export ATLAS=None
   export LDFLAGS="$LDFLAGS -shared"
+  export CFLAGS="$CFLAGS -fno-asynchronous-unwind-tables"
 
   cd ${_realname}-py3-${CARCH}
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \

--- a/mingw-w64-python3-numpy/PKGBUILD
+++ b/mingw-w64-python3-numpy/PKGBUILD
@@ -40,7 +40,7 @@ sha256sums=('81a4f748dcfa80a7071ad8f3d9f8edb9f8bc1f0a9bdd19bfd44fd42c02bd286c'
             'c1114a027fc797bb6c5c6f7b3044fa853b9e9263555088b4b2b12bdb77baefd5'
             '9204922151a7459ed0ecb5d7379fc16bdee6b8c74c925c575667b0ac6ff6441a'
             'a089bb11db5110903dba987c2ffb0ab9468414c5828bdc18809b1baeebe61b92'
-            '68d228b3bf6afd0905772c33928d3887fd00bae7f8ab7876cefe032f8b91e8a4')
+            'c95b2702467055f2f0ff68fe6ba339999d4843ad1c0b8401be16a775e1ffc170')
 
 prepare() {
   cd ${_realname}-${pkgver}

--- a/mingw-w64-python3-pandas/PKGBUILD
+++ b/mingw-w64-python3-pandas/PKGBUILD
@@ -1,0 +1,52 @@
+# Contributor: Runar Tenfjord < runar dot tenfjord at gmail dot com >
+
+_realname=pandas
+pkgbase=mingw-w64-python-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
+pkgver=0.25.1
+pkgrel=1
+pkgdesc="Cross-section and time series data analysis toolkit (mingw-w64)"
+arch=('any')
+url="https://pandas.pydata.org/"
+license=('BSD')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python3-numpy"
+             "${MINGW_PACKAGE_PREFIX}-python3-pytz"
+             "${MINGW_PACKAGE_PREFIX}-python3-dateutil"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-gcc")
+source=(${_realname}-${pkgver}.tar.gz::"https://github.com/pandas-dev/${_realname}/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('cb2e197b7b0687becb026b84d3c242482f20cbb29a9981e43604eb67576da9f6')
+
+
+prepare() {
+  cp -a ${_realname}-${pkgver} ${_realname}-py3-${pkgver}
+}
+
+build() {
+  # build for python3
+  cd ${srcdir}/${_realname}-py3-${pkgver}
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py build_ext --inplace
+
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py build
+}
+
+package() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3-numpy"
+           "${MINGW_PACKAGE_PREFIX}-python3-pytz"
+           "${MINGW_PACKAGE_PREFIX}-python3-dateutil"
+           "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-python3-scipy: needed for miscellaneous statistical functions"
+              "${MINGW_PACKAGE_PREFIX}-python3-matplotlib: needed for plotting"
+              "${MINGW_PACKAGE_PREFIX}-python3-numexpr: needed for accelerating certain numerical operations (recommended)"
+              "${MINGW_PACKAGE_PREFIX}-python3-openpyxl: needed for reading/writing Excel file")
+
+  cd ${_realname}-py3-${pkgver}
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --skip-build \
+    --prefix=${MINGW_PREFIX} --root=${pkgdir} --optimize=1
+
+  install -Dm644 LICENSE \
+    "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+}


### PR DESCRIPTION
* python3-numpy: Update to 1.17.2
* python-pandas: separate python2 and python3 packages, update python3-pandas to 0.25.1
* python-urllib3: Update to 1.25.5 
* python-pyzmq: Update to 18.1.0
* python3-imbalanced-learn: Update to 0.5.0
* python-statsmodels: Update to 0.10.1
* python-hypothesis: Update to 4.36.2
* python-importlib-metadata: Update to 0.23
* python-jedi: Update to 0.15.1 