### PR TITLE
cppcheck: update to 1.89

### DIFF
--- a/mingw-w64-cppcheck/0010-change-language-files-path.patch
+++ b/mingw-w64-cppcheck/0010-change-language-files-path.patch
@@ -1,11 +1,11 @@
---- a/gui/translationhandler.cpp	2016-03-11 04:45:55.738362700 +0900
-+++ b/gui/translationhandler.cpp	2016-03-11 04:45:50.961447900 +0900
-@@ -111,7 +111,7 @@ bool TranslationHandler::SetLanguage(con
-     QSettings settings;
-     QString datadir = settings.value("DATADIR").toString();
-     if (datadir.isEmpty())
--        datadir = appPath;
-+        datadir = appPath + "/../share/cppcheck/cfg/lang/";
+--- a/gui/translationhandler.cpp	2019-09-01 15:01:12.000000000 +0200
++++ b/gui/translationhandler.cpp	2019-09-20 23:24:54.233058500 +0200
+@@ -114,7 +114,7 @@
+         QSettings settings;
+         QString datadir = settings.value("DATADIR").toString();
+         if (datadir.isEmpty())
+-            datadir = appPath;
++            datadir = appPath + "/../share/cppcheck/lang/";
  
-     QString translationFile;
-     if (QFile::exists(datadir + "/lang/" + mTranslations[index].mFilename + ".qm"))
+         QString translationFile;
+         if (QFile::exists(datadir + "/lang/" + mTranslations[index].mFilename + ".qm"))

--- a/mingw-w64-cppcheck/PKGBUILD
+++ b/mingw-w64-cppcheck/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=cppcheck
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.88
+pkgver=1.89
 pkgrel=1
 pkgdesc="static analysis of C/C++ code (mingw-w64)"
 arch=('any')
@@ -18,8 +18,8 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-qt5: cppcheck-gui"
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/danmar/cppcheck/archive/${pkgver}.tar.gz"
         '0010-change-language-files-path.patch'
         '0020-change-cfg-path.patch')
-sha256sums=('4aace0420d6aaa900b84b3329c5173c2294e251d2e24d8cba6e38254333dde3f'
-            'a15a73396a2fa346d29df52c3143b46618454d0bc0f12f0ad891d5a4a856cb56'
+sha256sums=('37452d378825c7bd78116b4d7073df795fa732207d371ad5348287f811755783'
+            '574b040179c29a3eac19e7abd121f5d9c13c72a5dfdb66f4d903357da1e3944d'
             '3d54eb5abb99f88846e0d2a1e21793904efbe7179464631ca05985d03642d134')
 
 prepare() {
@@ -36,14 +36,14 @@ build() {
     PREFIX=${MINGW_PREFIX} \
     CXX=${MINGW_PREFIX}/bin/g++ \
     LD=${MINGW_PREFIX}/bin/ld \
-    SRCDIR=build \
-    CFGDIR=${MINGW_PREFIX}/share/cppcheck/cfg \
+    MATCHCOMPILER=yes \
+    FILESDIR=${MINGW_PREFIX}/share/cppcheck \
     HAVE_RULES=yes \
     LDFLAGS=-lshlwapi RDYNAMIC=
 
   make man \
     DB2MAN=${MINGW_PREFIX}/share/xml/docbook/xsl-stylesheets-1.79.2/manpages/docbook.xsl \
-    CFGDIR=${MINGW_PREFIX}/share/cppcheck/cfg
+    FILESDIR=${MINGW_PREFIX}/share/cppcheck
 
   cd gui
   lrelease gui.pro
@@ -52,8 +52,8 @@ build() {
     CXX=${MINGW_PREFIX}/bin/g++ \
     LD=${MINGW_PREFIX}/bin/ld \
     PREFIX=${MINGW_PREFIX} \
-    SRCDIR=build \
-    CFGDIR=${MINGW_PREFIX}/share/cppcheck/cfg \
+    MATCHCOMPILER=yes \
+    FILESDIR=${MINGW_PREFIX}/share/cppcheck \
     HAVE_RULES=yes \
     HAVE_QCHART=yes
 }
@@ -61,11 +61,11 @@ build() {
 check() {
   cd "${srcdir}"/build-${CARCH}
    LANG='en_US.UTF-8' make test \
-     SRCDIR=build \
+     MATCHCOMPILER=yes \
      CXX=${MINGW_PREFIX}/bin/g++ \
      LD=${MINGW_PREFIX}/bin/ld \
      PREFIX="${MINGW_PREFIX}" \
-     CFGDIR=${MINGW_PREFIX}/share/cppcheck/cfg \
+     FILESDIR=${MINGW_PREFIX}/share/cppcheck \
      HAVE_RULES=yes \
      HAVE_QCHART=yes \
      LDFLAGS=-lshlwapi RDYNAMIC=
@@ -79,8 +79,8 @@ package() {
     CXX=${MINGW_PREFIX}/bin/g++ \
     LD=${MINGW_PREFIX}/bin/ld \
     PREFIX="${MINGW_PREFIX}" \
-    SRCDIR=build \
-    CFGDIR=${MINGW_PREFIX}/share/cppcheck/cfg \
+    MATCHCOMPILER=yes \
+    FILESDIR=${MINGW_PREFIX}/share/cppcheck \
     HAVE_QCHART=yes \
     HAVE_RULES=yes
 
@@ -90,9 +90,10 @@ package() {
 
   # GUI
   install -m755 build/gui/cppcheck-gui.exe "${pkgdir}${MINGW_PREFIX}/bin"
-  install -d "${pkgdir}${MINGW_PREFIX}/share/cppcheck/cfg/lang"
+  install -d "${pkgdir}${MINGW_PREFIX}/share/cppcheck/cfg"
+  install -d "${pkgdir}${MINGW_PREFIX}/share/cppcheck/lang"
   install -D cfg/* -t "${pkgdir}${MINGW_PREFIX}/share/cppcheck/cfg"
-  install -D gui/*.qm -t "${pkgdir}${MINGW_PREFIX}/share/cppcheck/cfg/lang"
+  install -D gui/*.qm -t "${pkgdir}${MINGW_PREFIX}/share/cppcheck/lang"
 }
 
 # vim: set ft=sh ts=2 sw=2 et :


### PR DESCRIPTION
- Update 0010-change-language-files-path.patch to 1.89
- Use `FILESDIR` instead of `CFGDIR`, see:
  https://github.com/danmar/cppcheck/commit/a17f2a6
- Install .qm files in subfolder 'lang' and not 'cfg/lang' any more.
- Use `MATCHCOMPILER=yes` instead of `SRCDIR=build`, see:
  https://github.com/danmar/cppcheck/commit/1b4485a
  Fixes warning `Makefile:10:`
  `Usage of SRCDIR to activate match compiler is deprecated.`
  `Use MATCHCOMPILER=yes instead.`
