### PR TITLE
qt5: Fix CMake config file regression

### DIFF
--- a/mingw-w64-qt5/0039-qt-5.4.0-Make-it-possible-to-use-static-builds-of-Qt-with-CMa.patch
+++ b/mingw-w64-qt5/0039-qt-5.4.0-Make-it-possible-to-use-static-builds-of-Qt-with-CMa.patch
@@ -27,16 +27,16 @@ diff -Naur qt-everywhere-src-5.12.4-orig/qtbase/mkspecs/features/data/cmake/Qt5B
 +        endif()
 +    endmacro()
 +
-+    !!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
-+        macro_process_prl_file(\"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_PRL_FILE_LOCATION_DEBUG}\" DEBUG)
-+    !!ELSE
-+        macro_process_prl_file(\"$${CMAKE_LIB_DIR}$${CMAKE_PRL_FILE_LOCATION_DEBUG}\" DEBUG)
-+    !!ENDIF
-+    !!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
-+        macro_process_prl_file(\"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_PRL_FILE_LOCATION_RELEASE}\" RELEASE)
-+    !!ELSE
-+        macro_process_prl_file(\"$${CMAKE_LIB_DIR}$${CMAKE_PRL_FILE_LOCATION_RELEASE}\" RELEASE)
-+    !!ENDIF
++!!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
++    macro_process_prl_file(\"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_PRL_FILE_LOCATION_DEBUG}\" DEBUG)
++!!ELSE
++    macro_process_prl_file(\"$${CMAKE_LIB_DIR}$${CMAKE_PRL_FILE_LOCATION_DEBUG}\" DEBUG)
++!!ENDIF
++!!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
++    macro_process_prl_file(\"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_PRL_FILE_LOCATION_RELEASE}\" RELEASE)
++!!ELSE
++    macro_process_prl_file(\"$${CMAKE_LIB_DIR}$${CMAKE_PRL_FILE_LOCATION_RELEASE}\" RELEASE)
++!!ENDIF
 +
 +    # Excerpt from: end
  !!ELSE

--- a/mingw-w64-qt5/0042-qt-5.4.0-static-cmake-also-link-plugins-and-plugin-deps.patch
+++ b/mingw-w64-qt5/0042-qt-5.4.0-static-cmake-also-link-plugins-and-plugin-deps.patch
@@ -44,9 +44,9 @@ diff -Naur qt-everywhere-src-5.12.4-orig/qtbase/mkspecs/features/data/cmake/Qt5B
 +        macro_process_prl_file(${prl_file_location} ${Configuration})
 +    endmacro()
 +
-     !!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
-         macro_process_prl_file(\"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_PRL_FILE_LOCATION_DEBUG}\" DEBUG)
-     !!ELSE
+ !!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+     macro_process_prl_file(\"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_PRL_FILE_LOCATION_DEBUG}\" DEBUG)
+ !!ELSE
 @@ -294,6 +319,57 @@
          )
      endif()

--- a/mingw-w64-qt5/PKGBUILD
+++ b/mingw-w64-qt5/PKGBUILD
@@ -109,7 +109,7 @@ _ver_base=5.13.1
 # use 5.6.1-1 hot fix : only the archive name was changed from *-5.6.1.tar.xz to *-5.6.1-1.tar.xz
 _hotfix=
 pkgver=${_ver_base//-/}
-pkgrel=1
+pkgrel=2
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='https://www.qt.io/'
@@ -783,10 +783,10 @@ sha256sums=('adf00266dc38352a166a9739f1a24a1e36f1be9c04bf72e16e142a256436974e'
             '8beeb610df3aff14bae43c56e5781cda3d49f1ad23c6e3fc2aa2405ce002de46'
             '6595c9a5dbbdcea44f1c085c25a186b15ca4a732b28d1894a11141ddd472250d'
             'ff97cc90d9eb9c4b9dcdc4adb613a83433a12df9f3034ae8b7a815d0a9b1d242'
-            'f6f843fec71a6206d365a78dac3a6674d63fa3816198039c351e8b0ab659f341'
+            '5273b3a1ffd36ffafe09cc069862e4fdb3f00f43e885e3e8889b7f6d829bcd34'
             '549df8ae7572476e6729a4ee9d9dde99900e8bb9d25019aab5b999a8d9d7482c'
             '9f9e950f94959a3d831450a38b2791178dfff9e111de6de806c33d6a27f5d53e'
-            'e6216f8c7b11a9dc8b5a0cf9461c4078b7e02c93363a169ebd456ce144800684'
+            'c5f8718dbcc0de10b8d1e454baaecbf97759ed1356541d6eb140c3c7f59ed0ea'
             '90e18bfda930188f8c6b06526262617ba3e56be3aa282da121acb7173fc5b17d'
             '2816d297d783c00744d6cf94758da1cb59dfd1061deceb82744e607b8292e324'
             '42724bd154ed98c612d19a7daee2b5028270ef6dbfe7f35d5f97c8d0605f9fe6'


### PR DESCRIPTION
```
CMake Error at D:/msys64/mingw64/lib/cmake/Qt5UiTools/Qt5UiToolsConfig.cmake:283:
  Parse error.  Expected a command name, got unquoted argument with text
  "!!IF".
```