### PR TITLE
glib2: Fix critical in g_utf8_to_utf16()

### DIFF
--- a/mingw-w64-glib2/0001-gwinhttpvfs-Handle-g_get_prgname-returning-NULL.patch
+++ b/mingw-w64-glib2/0001-gwinhttpvfs-Handle-g_get_prgname-returning-NULL.patch
@@ -1,0 +1,35 @@
+From bf2a10211b3d3896943bac2010197b0728a32fac Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Sun, 6 Oct 2019 20:05:44 +0200
+Subject: [PATCH] gwinhttpvfs: Handle g_get_prgname() returning NULL
+
+When prgname wasn't set NULL would be passed to g_utf8_to_utf16()
+resulting in "g_utf8_to_utf16: assertion 'str != NULL' failed"
+---
+ gio/win32/gwinhttpvfs.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/gio/win32/gwinhttpvfs.c b/gio/win32/gwinhttpvfs.c
+index 91d7fed9d..3dfac259e 100644
+--- a/gio/win32/gwinhttpvfs.c
++++ b/gio/win32/gwinhttpvfs.c
+@@ -121,12 +121,13 @@ static void
+ g_winhttp_vfs_init (GWinHttpVfs *vfs)
+ {
+   wchar_t *wagent;
++  const gchar *prgname = g_get_prgname ();
+ 
+   vfs->wrapped_vfs = g_vfs_get_local ();
+ 
+-  wagent = g_utf8_to_utf16 (g_get_prgname (), -1, NULL, NULL, NULL);
+-
+-  if (!wagent)
++  if (prgname)
++    wagent = g_utf8_to_utf16 (prgname, -1, NULL, NULL, NULL);
++  else
+     wagent = g_utf8_to_utf16 ("GWinHttpVfs", -1, NULL, NULL, NULL);
+ 
+   vfs->session = (G_WINHTTP_VFS_GET_CLASS (vfs)->funcs->pWinHttpOpen)
+-- 
+2.23.0
+

--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -7,7 +7,7 @@ _realname=glib2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.62.1
-pkgrel=1
+pkgrel=2
 url="https://www.gtk.org/"
 arch=('any')
 pkgdesc="Common C routines used by GTK+ 2.4 and other libs (mingw-w64)"
@@ -27,11 +27,13 @@ source=("https://download.gnome.org/sources/glib/${pkgver%.*}/glib-${pkgver}.tar
         0001-Update-g_fopen-g_open-and-g_creat-to-open-with-FILE_.patch
         0001-win32-Make-the-static-build-work-with-MinGW-when-pos.patch
         0001-disable-some-tests-when-static.patch
+        0001-gwinhttpvfs-Handle-g_get_prgname-returning-NULL.patch
         pyscript2exe.py)
 sha256sums=('3dd9024e1d0872a6da7ac509937ccf997161b11d7d35be337c7e829cbae0f9df'
             '51d02360a1ee978fd45e77b84bca9cfbcf080d91986b5c0efe0732779c6a54ec'
             '1e3ac7cfd4644f3849704e54fcfbb12d15440a33cd5c2d014d4a479c6aaab185'
             '0f44135a139e3951c4b5fa7d4628d75226e0666d891faf524777e1d1ec3b440b'
+            'f344e25520e7a64aec520a3518b87b8c719c50648018d5eae9d033bbff53d1ce'
             '00e03a8b9d45e620c6fabbf96f5ccb41d1e49cc9b35ccb846d423f235ad5bec6')
 
 prepare() {
@@ -40,6 +42,8 @@ prepare() {
   patch -Np1 -i "${srcdir}"/0001-Update-g_fopen-g_open-and-g_creat-to-open-with-FILE_.patch
   patch -Np1 -i "${srcdir}"/0001-win32-Make-the-static-build-work-with-MinGW-when-pos.patch
   patch -Np1 -i "${srcdir}"/0001-disable-some-tests-when-static.patch
+  # https://gitlab.gnome.org/GNOME/glib/merge_requests/1152
+  patch -Np1 -i "${srcdir}"/0001-gwinhttpvfs-Handle-g_get_prgname-returning-NULL.patch
 }
 
 build() {


### PR DESCRIPTION
See !5769

Reported upstream: https://gitlab.gnome.org/GNOME/glib/merge_requests/1152