### PR TITLE
geany-plugins: Update to 1.36; Remove Python 2 dep

### DIFF
--- a/mingw-w64-geany-plugins/PKGBUILD
+++ b/mingw-w64-geany-plugins/PKGBUILD
@@ -7,7 +7,7 @@
 _realname=geany-plugins
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.35.0
+pkgver=1.36.0
 pkgrel=1
 pkgdesc='Plugins for Geany (mingw-w64)'
 arch=('any')
@@ -21,8 +21,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-geany>=${pkgver}"
 #         "${MINGW_PACKAGE_PREFIX}-vte"
          "${MINGW_PACKAGE_PREFIX}-lua51"
          "${MINGW_PACKAGE_PREFIX}-gtk3"
-         "${MINGW_PACKAGE_PREFIX}-hicolor-icon-theme"
-         "${MINGW_PACKAGE_PREFIX}-python2")
+         "${MINGW_PACKAGE_PREFIX}-libgit2"
+         "${MINGW_PACKAGE_PREFIX}-hicolor-icon-theme")
 makedepends=('intltool'
              "${MINGW_PACKAGE_PREFIX}-vala"
              "${MINGW_PACKAGE_PREFIX}-gdb"
@@ -33,7 +33,7 @@ install="${_realname}-${CARCH}.install"
 source=(#"https://plugins.geany.org/${_realname}/${_realname}-${pkgver}.tar.bz2"
         ${_realname}-${pkgver}.tar.gz::https://github.com/geany/geany-plugins/archive/${pkgver}.tar.gz
         001-no-undefined.patch)
-sha256sums=('8a46ed8ed79443ec891e0ac2da039ece666de1601178afe030dd50bcd6515fce'
+sha256sums=('39409e948502a7d6d88a290f201b7c6c678ce8ecaff7c73589ee0f6dcc059568'
             '8f1f6ddcdb180e44cafe2ed0b30a120ec5c89ff7ac8b7833d8da7fdb328a370a')
 noextract=(${_realname}-${pkgver}.tar.gz)
 
@@ -56,6 +56,7 @@ build() {
     --build=${MINGW_CHOST} \
     --prefix=${MINGW_PREFIX} \
     --libexecdir=${MINGW_PREFIX}/lib \
+    --disable-geanypy \
     --disable-static
 
   make


### PR DESCRIPTION
Also remove python2 dep and disable the Python plugin.
It's not ported to gtk3/python3 yet, so it wasn't used anyway.
Make that explicit by disabling it.