### PR TITLE
ca-certificates: Port build to Python 3

### DIFF
--- a/mingw-w64-ca-certificates/PKGBUILD
+++ b/mingw-w64-ca-certificates/PKGBUILD
@@ -4,13 +4,13 @@ _realname=ca-certificates
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=20180409
-pkgrel=1
+pkgrel=2
 pkgdesc='Common CA certificates (mingw-w64)'
 arch=('any')
 url='https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/'
 license=('MPL' 'GPL')
 install="ca-certificates-${CARCH}.install"
-source=("http://ftp.debian.org/debian/pool/main/c/${_realname}/${_realname}_${pkgver}.tar.xz"
+source=("http://archive.ubuntu.com/ubuntu/pool/main/c/${_realname}/${_realname}_${pkgver}.tar.xz"
         'certdata2pem.py'
         'trust-fixes'
         'update-ca-trust'
@@ -24,7 +24,7 @@ sha256sums=('7af6f5bfc619fd29cbf0258c1d95107c38ce840ad6274e343e1e0d971fc72b51'
             '4e96bd7424062d365b75247dfc4b3b6510f09ca5161c0f7c3ce76b10edf633aa'
             'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
             '65fc13d01550be7f89046a62605d6203eb68dba7edf5dbb04a2068b4f7cd2e65'
-            'a73c6430e734178b9aa4d303709470383bc2b1cfbeb0d44fe34615df812f479d')
+            'b052972dd118a3e25f785b6caa141599f0db6fc1d943e9ebcd6ca0e1f0421f60')
 
 prepare() {
   sed "s|/usr/bin/python|${MINGW_PREFIX}/bin/python2|g" -i certdata2pem.py

--- a/mingw-w64-ca-certificates/PKGBUILD
+++ b/mingw-w64-ca-certificates/PKGBUILD
@@ -4,7 +4,7 @@ _realname=ca-certificates
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=20180409
-pkgrel=2
+pkgrel=3
 pkgdesc='Common CA certificates (mingw-w64)'
 arch=('any')
 url='https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/'
@@ -12,22 +12,25 @@ license=('MPL' 'GPL')
 install="ca-certificates-${CARCH}.install"
 source=("http://archive.ubuntu.com/ubuntu/pool/main/c/${_realname}/${_realname}_${pkgver}.tar.xz"
         'certdata2pem.py'
+        'certdata2pem.patch'
         'trust-fixes'
         'update-ca-trust'
         'update-ca-trust.8')
 depends=("${MINGW_PACKAGE_PREFIX}-p11-kit")
 makedepends=("${MINGW_PACKAGE_PREFIX}-openssl"
              "${MINGW_PACKAGE_PREFIX}-p11-kit"
-             "${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python3"
              'asciidoc' 'libxslt' 'sed' 'grep')
 sha256sums=('7af6f5bfc619fd29cbf0258c1d95107c38ce840ad6274e343e1e0d971fc72b51'
-            '4e96bd7424062d365b75247dfc4b3b6510f09ca5161c0f7c3ce76b10edf633aa'
+            '0be02cecc27a6e55e1cad1783033b147f502b26f9fb1bb5a53e7a43bbcb68fa0'
+            'e42619b231f371dcd0e6bcae078f7082d0c0d6af86c6f11d962de361ce493178'
             'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
             '65fc13d01550be7f89046a62605d6203eb68dba7edf5dbb04a2068b4f7cd2e65'
             'b052972dd118a3e25f785b6caa141599f0db6fc1d943e9ebcd6ca0e1f0421f60')
 
 prepare() {
-  sed "s|/usr/bin/python|${MINGW_PREFIX}/bin/python2|g" -i certdata2pem.py
+  sed "s|/usr/bin/python|${MINGW_PREFIX}/bin/python3|g" -i certdata2pem.py
+  patch -p0 -i ${srcdir}/certdata2pem.patch
   cp certdata2pem.py ${srcdir}/${_realname}/mozilla/certdata2pem.py
   cd ${srcdir}/${_realname}
   cp ${srcdir}/update-ca-trust sbin/
@@ -38,7 +41,7 @@ build() {
   cd ${srcdir}/${_realname}/mozilla
   mkdir -p legacy-{default,disable}
 
-  PYTHONIOENCODING=utf-8 ${MINGW_PREFIX}/bin/python2 ./certdata2pem.py
+  PYTHONIOENCODING=utf-8 ${MINGW_PREFIX}/bin/python3 ./certdata2pem.py
 
   (
    cat <<EOF

--- a/mingw-w64-ca-certificates/certdata2pem.patch
+++ b/mingw-w64-ca-certificates/certdata2pem.patch
@@ -1,0 +1,19 @@
+--- certdata2pem.py.orig	2019-10-24 09:39:21.722533400 +0200
++++ certdata2pem.py	2019-10-24 09:37:39.184178700 +0200
+@@ -110,6 +110,7 @@
+     label = obj['CKA_LABEL'][1:-1]
+     label = label.replace('/', '_')\
+         .replace(' ', '_')\
++        .replace(':', '_')\
+         .replace('(', '=')\
+         .replace(')', '=')\
+         .replace(',', '_')
+@@ -126,7 +127,7 @@
+         continue
+     label = labelbytes.decode('utf-8')
+     serial = printable_serial(obj)
+-    return label + ":" + serial
++    return label + "_" + serial
+ 
+ def write_cert_ext_to_file(f, oid, value, public_key):
+     f.write("[p11-kit-object-v1]\n")

--- a/mingw-w64-ca-certificates/certdata2pem.py
+++ b/mingw-w64-ca-certificates/certdata2pem.py
@@ -26,17 +26,17 @@ import os.path
 import re
 import sys
 import textwrap
-import urllib
+import urllib.request, urllib.parse, urllib.error
 import subprocess
 
 objects = []
 
 def printable_serial(obj):
-  return ".".join(map(lambda x:str(ord(x)), obj['CKA_SERIAL_NUMBER']))
+  return ".".join([str(x) for x in obj['CKA_SERIAL_NUMBER']])
 
 # Dirty file parser.
 in_data, in_multiline, in_obj = False, False, False
-field, type, value, obj = None, None, None, dict()
+field, ftype, value, binval, obj = None, None, None, bytearray(), dict()
 for line in open('certdata.txt', 'r'):
     # Ignore the file header.
     if not in_data:
@@ -56,33 +56,36 @@ for line in open('certdata.txt', 'r'):
         continue
     if in_multiline:
         if not line.startswith('END'):
-            if type == 'MULTILINE_OCTAL':
+            if ftype == 'MULTILINE_OCTAL':
                 line = line.strip()
                 for i in re.finditer(r'\\([0-3][0-7][0-7])', line):
-                    value += chr(int(i.group(1), 8))
+                    integ = int(i.group(1), 8)
+                    binval.extend((integ).to_bytes(1, sys.byteorder))
+                obj[field] = binval
             else:
                 value += line
+                obj[field] = value
             continue
-        obj[field] = value
         in_multiline = False
         continue
     if line.startswith('CKA_CLASS'):
         in_obj = True
     line_parts = line.strip().split(' ', 2)
     if len(line_parts) > 2:
-        field, type = line_parts[0:2]
+        field, ftype = line_parts[0:2]
         value = ' '.join(line_parts[2:])
     elif len(line_parts) == 2:
-        field, type = line_parts
+        field, ftype = line_parts
         value = None
     else:
         raise NotImplementedError('line_parts < 2 not supported.\n' + line)
-    if type == 'MULTILINE_OCTAL':
+    if ftype == 'MULTILINE_OCTAL':
         in_multiline = True
         value = ""
+        binval = bytearray()
         continue
     obj[field] = value
-if len(obj.items()) > 0:
+if len(list(obj.items())) > 0:
     objects.append(obj)
 
 # Build up trust database.
@@ -92,7 +95,7 @@ for obj in objects:
         continue
     key = obj['CKA_LABEL'] + printable_serial(obj)
     trustmap[key] = obj
-    print " added trust", key
+    print(" added trust", key)
 
 # Build up cert database.
 certmap = dict()
@@ -101,19 +104,29 @@ for obj in objects:
         continue
     key = obj['CKA_LABEL'] + printable_serial(obj)
     certmap[key] = obj
-    print " added cert", key
+    print(" added cert", key)
 
 def obj_to_filename(obj):
     label = obj['CKA_LABEL'][1:-1]
     label = label.replace('/', '_')\
         .replace(' ', '_')\
-        .replace(':', '_')\
         .replace('(', '=')\
         .replace(')', '=')\
         .replace(',', '_')
-    label = re.sub(r'\\x[0-9a-fA-F]{2}', lambda m:chr(int(m.group(0)[2:], 16)), label)
+    labelbytes = bytearray()
+    i = 0
+    imax = len(label)
+    while i < imax:
+        if i < imax-3 and label[i] == '\\' and label[i+1] == 'x':
+            labelbytes.extend(bytes.fromhex(label[i+2:i+4]))
+            i += 4
+            continue
+        labelbytes.extend(str.encode(label[i]))
+        i = i+1
+        continue
+    label = labelbytes.decode('utf-8')
     serial = printable_serial(obj)
-    return label + "_" + serial
+    return label + ":" + serial
 
 def write_cert_ext_to_file(f, oid, value, public_key):
     f.write("[p11-kit-object-v1]\n")
@@ -167,31 +180,31 @@ openssl_trust = {
 for tobj in objects:
     if tobj['CKA_CLASS'] == 'CKO_NSS_TRUST':
         key = tobj['CKA_LABEL'] + printable_serial(tobj)
-        print "producing trust for " + key
+        print("producing trust for " + key)
         trustbits = []
         distrustbits = []
         openssl_trustflags = []
         openssl_distrustflags = []
         legacy_trustbits = []
         legacy_openssl_trustflags = []
-        for t in trust_types.keys():
-            if tobj.has_key(t) and tobj[t] == 'CKT_NSS_TRUSTED_DELEGATOR':
+        for t in list(trust_types.keys()):
+            if t in tobj and tobj[t] == 'CKT_NSS_TRUSTED_DELEGATOR':
                 trustbits.append(t)
                 if t in openssl_trust:
                     openssl_trustflags.append(openssl_trust[t])
-            if tobj.has_key(t) and tobj[t] == 'CKT_NSS_NOT_TRUSTED':
+            if t in tobj and tobj[t] == 'CKT_NSS_NOT_TRUSTED':
                 distrustbits.append(t)
                 if t in openssl_trust:
                     openssl_distrustflags.append(openssl_trust[t])
 
-        for t in legacy_trust_types.keys():
-            if tobj.has_key(t) and tobj[t] == 'CKT_NSS_TRUSTED_DELEGATOR':
+        for t in list(legacy_trust_types.keys()):
+            if t in tobj and tobj[t] == 'CKT_NSS_TRUSTED_DELEGATOR':
                 real_t = legacy_to_real_trust_types[t]
                 legacy_trustbits.append(real_t)
                 if real_t in openssl_trust:
                     legacy_openssl_trustflags.append(openssl_trust[real_t])
-            if tobj.has_key(t) and tobj[t] == 'CKT_NSS_NOT_TRUSTED':
-                raise NotImplementedError, 'legacy distrust not supported.\n' + line
+            if t in tobj and tobj[t] == 'CKT_NSS_NOT_TRUSTED':
+                raise NotImplementedError('legacy distrust not supported.\n' + line)
 
         fname = obj_to_filename(tobj)
         try:
@@ -207,10 +220,10 @@ for tobj in objects:
         #dumpf.close();
 
         is_legacy = 0
-        if tobj.has_key('LEGACY_CKA_TRUST_SERVER_AUTH') or tobj.has_key('LEGACY_CKA_TRUST_EMAIL_PROTECTION') or tobj.has_key('LEGACY_CKA_TRUST_CODE_SIGNING'):
+        if 'LEGACY_CKA_TRUST_SERVER_AUTH' in tobj or 'LEGACY_CKA_TRUST_EMAIL_PROTECTION' in tobj or 'LEGACY_CKA_TRUST_CODE_SIGNING' in tobj:
             is_legacy = 1
             if obj == None:
-                raise NotImplementedError, 'found legacy trust without certificate.\n' + line
+                raise NotImplementedError('found legacy trust without certificate.\n' + line)
 
             legacy_fname = "legacy-default/" + fname + ".crt"
             f = open(legacy_fname, 'w')
@@ -219,11 +232,13 @@ for tobj in objects:
             if legacy_openssl_trustflags:
                 f.write("# openssl-trust=" + " ".join(legacy_openssl_trustflags) + "\n")
             f.write("-----BEGIN CERTIFICATE-----\n")
-            f.write("\n".join(textwrap.wrap(base64.b64encode(obj['CKA_VALUE']), 64)))
+            temp_encoded_b64 = base64.b64encode(obj['CKA_VALUE'])
+            temp_wrapped = textwrap.wrap(temp_encoded_b64.decode(), 64)
+            f.write("\n".join(temp_wrapped))
             f.write("\n-----END CERTIFICATE-----\n")
             f.close()
 
-            if tobj.has_key('CKA_TRUST_SERVER_AUTH') or tobj.has_key('CKA_TRUST_EMAIL_PROTECTION') or tobj.has_key('CKA_TRUST_CODE_SIGNING'):
+            if 'CKA_TRUST_SERVER_AUTH' in tobj or 'CKA_TRUST_EMAIL_PROTECTION' in tobj or 'CKA_TRUST_CODE_SIGNING' in tobj:
                 legacy_fname = "legacy-disable/" + fname + ".crt"
                 f = open(legacy_fname, 'w')
                 f.write("# alias=%s\n"%tobj['CKA_LABEL'])
@@ -245,7 +260,9 @@ for tobj in objects:
             cert_fname = "cert-" + fname
             fc = open(cert_fname, 'w')
             fc.write("-----BEGIN CERTIFICATE-----\n")
-            fc.write("\n".join(textwrap.wrap(base64.b64encode(obj['CKA_VALUE']), 64)))
+            temp_encoded_b64 = base64.b64encode(obj['CKA_VALUE'])
+            temp_wrapped = textwrap.wrap(temp_encoded_b64.decode(), 64)
+            fc.write("\n".join(temp_wrapped))
             fc.write("\n-----END CERTIFICATE-----\n")
             fc.close();
             pk_fname = "pubkey-" + fname
@@ -263,7 +280,7 @@ for tobj in objects:
             fcout.close()
             sed_command = ["sed", "--in-place", "s/^/#/", comment_fname]
             subprocess.call(sed_command)
-            with open (comment_fname, "r") as myfile:
+            with open (comment_fname, "r", errors = 'replace') as myfile:
                 cert_comment=myfile.read()
 
         fname += ".tmp-p11-kit"
@@ -275,19 +292,19 @@ for tobj in objects:
             has_email_trust = False
             has_code_trust = False
 
-            if tobj.has_key('CKA_TRUST_SERVER_AUTH'):
+            if 'CKA_TRUST_SERVER_AUTH' in tobj:
                 if tobj['CKA_TRUST_SERVER_AUTH'] == 'CKT_NSS_NOT_TRUSTED':
                     is_distrusted = True
                 elif tobj['CKA_TRUST_SERVER_AUTH'] == 'CKT_NSS_TRUSTED_DELEGATOR':
                     has_server_trust = True
 
-            if tobj.has_key('CKA_TRUST_EMAIL_PROTECTION'):
+            if 'CKA_TRUST_EMAIL_PROTECTION' in tobj:
                 if tobj['CKA_TRUST_EMAIL_PROTECTION'] == 'CKT_NSS_NOT_TRUSTED':
                     is_distrusted = True
                 elif tobj['CKA_TRUST_EMAIL_PROTECTION'] == 'CKT_NSS_TRUSTED_DELEGATOR':
                     has_email_trust = True
 
-            if tobj.has_key('CKA_TRUST_CODE_SIGNING'):
+            if 'CKA_TRUST_CODE_SIGNING' in tobj:
                 if tobj['CKA_TRUST_CODE_SIGNING'] == 'CKT_NSS_NOT_TRUSTED':
                     is_distrusted = True
                 elif tobj['CKA_TRUST_CODE_SIGNING'] == 'CKT_NSS_TRUSTED_DELEGATOR':
@@ -353,7 +370,9 @@ for tobj in objects:
             f.write("modifiable: false\n");
 
             f.write("-----BEGIN CERTIFICATE-----\n")
-            f.write("\n".join(textwrap.wrap(base64.b64encode(obj['CKA_VALUE']), 64)))
+            temp_encoded_b64 = base64.b64encode(obj['CKA_VALUE'])
+            temp_wrapped = textwrap.wrap(temp_encoded_b64.decode(), 64)
+            f.write("\n".join(temp_wrapped))
             f.write("\n-----END CERTIFICATE-----\n")
             f.write(cert_comment)
             f.write("\n")
@@ -367,13 +386,13 @@ for tobj in objects:
             f.write("certificate-type: x-509\n")
             f.write("modifiable: false\n");
             f.write("issuer: \"");
-            f.write(urllib.quote(tobj['CKA_ISSUER']));
+            f.write(urllib.parse.quote(tobj['CKA_ISSUER']));
             f.write("\"\n")
             f.write("serial-number: \"");
-            f.write(urllib.quote(tobj['CKA_SERIAL_NUMBER']));
+            f.write(urllib.parse.quote(tobj['CKA_SERIAL_NUMBER']));
             f.write("\"\n")
             if (tobj['CKA_TRUST_SERVER_AUTH'] == 'CKT_NSS_NOT_TRUSTED') or (tobj['CKA_TRUST_EMAIL_PROTECTION'] == 'CKT_NSS_NOT_TRUSTED') or (tobj['CKA_TRUST_CODE_SIGNING'] == 'CKT_NSS_NOT_TRUSTED'):
               f.write("x-distrusted: true\n")
             f.write("\n\n")
         f.close()
-        print " -> written as '%s', trust = %s, openssl-trust = %s, distrust = %s, openssl-distrust = %s" % (fname, trustbits, openssl_trustflags, distrustbits, openssl_distrustflags)
+        print(" -> written as '%s', trust = %s, openssl-trust = %s, distrust = %s, openssl-distrust = %s" % (fname, trustbits, openssl_trustflags, distrustbits, openssl_distrustflags))


### PR DESCRIPTION
Take certdata2pem.py from the ca-certificates-mozilla package in Arch
and apply our changes in an extra patch to make future updates easier.

I've compared the package results with Python 2 and Python 3 and they
are identical.