### PR TITLE
libevent: Port to Python 3

### DIFF
--- a/mingw-w64-libevent/PKGBUILD
+++ b/mingw-w64-libevent/PKGBUILD
@@ -5,15 +5,14 @@ _realname=libevent
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.1.11
-pkgrel=1
+pkgrel=2
 pkgdesc="An event notification library (mingw-w64)"
 arch=('any')
 url="https://libevent.org"
 license=('BSD')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-openssl"
-             "${MINGW_PACKAGE_PREFIX}-python2")
-optdepends=("${MINGW_PACKAGE_PREFIX}-python2")
+             "${MINGW_PACKAGE_PREFIX}-openssl")
+optdepends=("${MINGW_PACKAGE_PREFIX}-python3")
 source=(https://github.com/${_realname}/${_realname}/releases/download/release-${pkgver}-stable/${_realname}-${pkgver}-stable.tar.gz
         'event2-02-win32.patch')
 sha256sums=('a65bac6202ea8c5609fd5c7e480e6d25de467ea1917c08290c521752f147283d'


### PR DESCRIPTION
Python isn't used during the build, only for the installed event_rpcgen.py
script, which supports both Python 2 and 3 for some time now.
And since our switch to python beaing python3 we were usign Python 3 anyway.