### PR TITLE
libvirt: Port to Python 3

### DIFF
--- a/mingw-w64-libvirt/PKGBUILD
+++ b/mingw-w64-libvirt/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libvirt
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.6.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Windows libvirt virtualization library (mingw-w64)"
 arch=('any')
 url="https://libvirt.org"
@@ -15,9 +15,10 @@ depends=("${MINGW_PACKAGE_PREFIX}-curl"
          "${MINGW_PACKAGE_PREFIX}-libgcrypt"
          "${MINGW_PACKAGE_PREFIX}-libgpg-error"
          "${MINGW_PACKAGE_PREFIX}-libxml2"
-         "${MINGW_PACKAGE_PREFIX}-portablexdr"
-         "${MINGW_PACKAGE_PREFIX}-python2")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
+         "${MINGW_PACKAGE_PREFIX}-portablexdr")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-python3")
 options=('strip' 'staticlibs')
 source=(https://libvirt.org/sources/${_realname}-${pkgver}.tar.xz
         001-fix-not-supported-authenticate-method.patch)
@@ -34,6 +35,10 @@ build() {
   mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
 
   CPPFLAGS+=" -D_WIN32_WINNT=0x0501"
+  # https://github.com/msys2/MINGW-packages-dev/pull/6
+  LDFLAGS+=" -fstack-protector"
+
+  PYTHON="${MINGW_PREFIX}/bin/python3" \
   ../${_realname}-${pkgver}/configure \
     --enable-shared \
     --enable-static \


### PR DESCRIPTION
It only needs Python for the build, so move it to makedepends

Also adds -fstack-protector to fix the build, see
https://github.com/msys2/MINGW-packages-dev/pull/6