### PR TITLE
Add vips image processing library

### DIFF
--- a/mingw-w64-libvips/PKGBUILD
+++ b/mingw-w64-libvips/PKGBUILD
@@ -1,0 +1,60 @@
+# Maintainer: Lars Kanis <lars@greiz-reinsdorf.de>
+
+_realname=libvips
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=8.8.3
+pkgrel=1
+pkgdesc="A fast image processing library with low memory needs (mingw-w64)"
+arch=('any')
+url="https://libvips.github.io/libvips/"
+license=("LGPL-2.1")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config")
+depends=("${MINGW_PACKAGE_PREFIX}-cairo"
+         "${MINGW_PACKAGE_PREFIX}-cfitsio"
+         "${MINGW_PACKAGE_PREFIX}-fftw"
+         "${MINGW_PACKAGE_PREFIX}-giflib"
+         "${MINGW_PACKAGE_PREFIX}-glib2"
+         "${MINGW_PACKAGE_PREFIX}-gobject-introspection-runtime"
+         "${MINGW_PACKAGE_PREFIX}-imagemagick"
+         "${MINGW_PACKAGE_PREFIX}-lcms2"
+         "${MINGW_PACKAGE_PREFIX}-libexif"
+         "${MINGW_PACKAGE_PREFIX}-libgsf"
+         "${MINGW_PACKAGE_PREFIX}-libimagequant"
+         "${MINGW_PACKAGE_PREFIX}-libpng"
+         "${MINGW_PACKAGE_PREFIX}-librsvg"
+         "${MINGW_PACKAGE_PREFIX}-libtiff"
+         "${MINGW_PACKAGE_PREFIX}-libwebp"
+#         "${MINGW_PACKAGE_PREFIX}-matio"   Temporary disabled by --without-matio due to https://github.com/msys2/MINGW-packages/issues/5758
+         "${MINGW_PACKAGE_PREFIX}-opencl-icd-git"
+         "${MINGW_PACKAGE_PREFIX}-openexr"
+#         "${MINGW_PACKAGE_PREFIX}-orc"    Temporary disabled by --without-orc due to https://github.com/libvips/libvips/issues/1426
+         "${MINGW_PACKAGE_PREFIX}-pango"
+         "${MINGW_PACKAGE_PREFIX}-poppler")
+options=('staticlibs' 'strip')
+source=("https://github.com/libvips/libvips/releases/download/v${pkgver}/vips-${pkgver}.tar.gz")
+sha256sums=('c5e4dd5a5c6a777c129037d19ca606769b3f1d405fcc9c8eeda906a61491f790')
+
+build() {
+  [[ -d "${srcdir}/build-${CARCH}" ]] && rm -rf "${srcdir}/build-${CARCH}"
+  mkdir -p "${srcdir}/build-${CARCH}"
+  cd "${srcdir}/build-${CARCH}"
+  ../vips-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --enable-shared \
+    --disable-static \
+    --without-matio \
+    --without-openslide \
+    --without-orc
+
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${CARCH}"
+  make DESTDIR="${pkgdir}" install
+}


### PR DESCRIPTION
The following optional dependencies currently fail:

* ~~imagequant due to a missing pkgconfig file. If #5883 and #5888 are applied, libvips builds with it.~~
* matio is disabled due to https://github.com/msys2/MINGW-packages/issues/5758
* orc is disabled due to https://github.com/libvips/libvips/issues/1426
* openslide is not (yet) in MINGW-packages and therefore disabled

These dependencies are noncritical for libvips, so that I think the library can be merged without them enabled.

I tested the command line tools that come with libvips and I tested the package with [ruby-vips](https://github.com/libvips/ruby-vips) and [RubyInstaller](https://rubyinstaller.org).

The compiled tar file is named "vips" only, not "libvips". However I found it more clear to name the package "libvips", since the name "libvips" typically refers to the vips C library which this package is about. Also the [github project](https://github.com/libvips/libvips/) is called "libvips".