### PR TITLE
libimagequant: Fix include file location

### DIFF
--- a/mingw-w64-libimagequant/PKGBUILD
+++ b/mingw-w64-libimagequant/PKGBUILD
@@ -40,7 +40,7 @@ package() {
   cd "${srcdir}"/build-${CARCH}
    mkdir -p ${pkgdir}${MINGW_PREFIX}/bin
    mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/pkgconfig
-   mkdir -p ${pkgdir}${MINGW_PREFIX}/include/libimagequant
+   mkdir -p ${pkgdir}${MINGW_PREFIX}/include
    mkdir -p ${pkgdir}${MINGW_PREFIX}/share/doc/libimagequant
    mkdir -p ${pkgdir}${MINGW_PREFIX}/share/licenses/libimagequant
    install -m 0644 -p imagequant.dll \
@@ -49,11 +49,8 @@ package() {
      ${pkgdir}${MINGW_PREFIX}/lib/libimagequant.a
    install -m 0644 -p imagequant_dll.a \
      ${pkgdir}${MINGW_PREFIX}/lib/libimagequant.dll.a
-   for _file in *.h
-   do
-     install -m 0644 -p ${_file} \
-        ${pkgdir}${MINGW_PREFIX}/include/libimagequant/${_file}
-   done
+   install -m 0644 -p libimagequant.h \
+      ${pkgdir}${MINGW_PREFIX}/include/libimagequant.h
    install -m 0644 -p imagequant.pc \
        ${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/imagequant.pc
    install -m 0644 -p CHANGELOG \


### PR DESCRIPTION
and remove private header files from package

This now matches the dev package on debian: https://packages.debian.org/sid/amd64/libimagequant-dev/filelist