### PR TITLE
Corrade: add a patch to fix CorradeMain build on i686.

### DIFF
--- a/mingw-w64-corrade/001-corrade-2019.10-fix-corrademain-on-i686.patch
+++ b/mingw-w64-corrade/001-corrade-2019.10-fix-corrademain-on-i686.patch
@@ -1,0 +1,15 @@
+diff --git a/src/Corrade/CorradeMain.cpp b/src/Corrade/CorradeMain.cpp
+index cc47a607..e117a6e5 100644
+--- a/src/Corrade/CorradeMain.cpp
++++ b/src/Corrade/CorradeMain.cpp
+@@ -28,6 +28,10 @@
+ #ifdef CORRADE_TARGET_WINDOWS
+ #include <cstdint>
+
++/* 32-bit MinGW doesn't have implicit __argc / __wargv for some reason:
++   https://github.com/mirror/mingw-w64/blob/f8e2c9ac594259fd2a46746943f84bd8766d7054/mingw-w64-headers/crt/stdlib.h#L178-L189 */
++#include <cstdlib>
++
+ /* Use Array, but in a way that doesn't require the whole Utility library
+    to be linked */
+ #define CORRADE_NO_DEBUG

--- a/mingw-w64-corrade/PKGBUILD
+++ b/mingw-w64-corrade/PKGBUILD
@@ -6,7 +6,7 @@ _realname=corrade
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2019.10
-pkgrel=1
+pkgrel=2
 pkgdesc='C++11/C++14 multiplatform utility library'
 arch=('any')
 url='https://magnum.graphics/corrade/'
@@ -16,8 +16,16 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake" "${MINGW_PACKAGE_PREFIX}-ninja" 'gi
 # unzip on Windows grumpy because dangling symlinks are created. Could be fixed
 # by manually extracting everything except symlinks, but that's hard to
 # maintain. Downloading a Git tag works.
-source=("${_realname}-${pkgver}"::"git+https://github.com/mosra/corrade.git#tag=v$pkgver")
-sha256sums=('SKIP')
+source=("${_realname}-${pkgver}"::"git+https://github.com/mosra/corrade.git#tag=v$pkgver"
+        "001-corrade-2019.10-fix-corrademain-on-i686.patch")
+sha256sums=('SKIP'
+            '9b1434577f13c711e9bb703744e8042940725150481cce555bcf456ffb684675')
+
+prepare() {
+    cd "${srcdir}"/${_realname}-${pkgver}
+
+    patch -p1 -i "${srcdir}"/001-corrade-2019.10-fix-corrademain-on-i686.patch
+}
 
 build() {
     mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}


### PR DESCRIPTION
Since #5898 was merged too early, here's the patch and updated Corrade PKGBUILD to fix building of CorradeMain on i686.