### PR TITLE
libvips: Fix build with gobject-introspect enabled

### DIFF
--- a/mingw-w64-libvips/0001-Fix-dependency-to-introspect-program-on-Windows-MING.patch
+++ b/mingw-w64-libvips/0001-Fix-dependency-to-introspect-program-on-Windows-MING.patch
@@ -1,0 +1,34 @@
+From 861f11994729596d0105acd2281f6069f893c2b1 Mon Sep 17 00:00:00 2001
+From: Lars Kanis <lars@greiz-reinsdorf.de>
+Date: Sun, 27 Oct 2019 17:46:38 +0100
+Subject: [PATCH] Fix dependency to introspect program on Windows MINGW
+
+---
+ libvips/Makefile.am | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libvips/Makefile.am b/libvips/Makefile.am
+index eab4793..73e68b7 100644
+--- a/libvips/Makefile.am
++++ b/libvips/Makefile.am
+@@ -87,7 +87,7 @@ AM_LDFLAGS = \
+ LDADD = @INTROSPECTION_LIBS@ @VIPS_CFLAGS@ libvips.la @VIPS_LIBS@ 
+ 
+ noinst_PROGRAMS = \
+-	introspect
++	introspect$(EXEEXT)
+ introspect_SOURCES = \
+ 	introspect.c
+ 
+@@ -96,7 +96,7 @@ introspect_SOURCES = \
+ introspection_sources = @vips_introspection_sources@
+ 
+ # we make the vips8 API
+-Vips-8.0.gir: introspect
++Vips-8.0.gir: introspect$(EXEEXT)
+ Vips_8_0_gir_INCLUDES = GObject-2.0
+ Vips_8_0_gir_CFLAGS = $(INCLUDES) -I${top_srcdir}/libvips/include
+ Vips_8_0_gir_LIBS = libvips.la
+-- 
+2.12.2.windows.2
+

--- a/mingw-w64-libvips/PKGBUILD
+++ b/mingw-w64-libvips/PKGBUILD
@@ -10,6 +10,7 @@ arch=('any')
 url="https://libvips.github.io/libvips/"
 license=("LGPL-2.1")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=("${MINGW_PACKAGE_PREFIX}-cairo"
          "${MINGW_PACKAGE_PREFIX}-cfitsio"
@@ -33,8 +34,18 @@ depends=("${MINGW_PACKAGE_PREFIX}-cairo"
          "${MINGW_PACKAGE_PREFIX}-pango"
          "${MINGW_PACKAGE_PREFIX}-poppler")
 options=('staticlibs' 'strip')
-source=("https://github.com/libvips/libvips/releases/download/v${pkgver}/vips-${pkgver}.tar.gz")
-sha256sums=('c5e4dd5a5c6a777c129037d19ca606769b3f1d405fcc9c8eeda906a61491f790')
+source=("https://github.com/libvips/libvips/releases/download/v${pkgver}/vips-${pkgver}.tar.gz"
+        "0001-Fix-dependency-to-introspect-program-on-Windows-MING.patch")
+sha256sums=('c5e4dd5a5c6a777c129037d19ca606769b3f1d405fcc9c8eeda906a61491f790'
+            'b58454a9c50145187cf69f018351ffe93a8a49809a44435f175cc7e109507cd1')
+
+
+prepare() {
+  cd "${srcdir}"/vips-${pkgver}
+  patch -p1 -i ${srcdir}/0001-Fix-dependency-to-introspect-program-on-Windows-MING.patch
+
+  autoreconf -if
+}
 
 build() {
   [[ -d "${srcdir}/build-${CARCH}" ]] && rm -rf "${srcdir}/build-${CARCH}"


### PR DESCRIPTION
This could previously fail in make parallel builds due to a wrong
file dependency like so:
```
x86_64-w64-mingw32-gcc -march=x86-64 -mtune=generic -O2 -pipe
-D__USE_MINGW_ANSI_STDIO=1 -pipe  ../../vips-8.8.3/libvips/introspect.c
-o introspect
../../vips-8.8.3/libvips/introspect.c:42:10: fatal error: vips/intl.h:
No such file or directory
   42 | #include <vips/intl.h>
         |          ^~~~~~~~~~~~~
	 compilation terminated.
	 make[3]: *** [<builtin>: introspect] Error 1
```

Fixes #5885
