### PR TITLE
Add yices2 SMT solver package.

### DIFF
--- a/mingw-w64-yices/PKGBUILD
+++ b/mingw-w64-yices/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: William D. Jones <thor0505@comcast.net>
 
-_realname=yices2
+_realname=yices
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.6.1

--- a/mingw-w64-yices2/PKGBUILD
+++ b/mingw-w64-yices2/PKGBUILD
@@ -1,0 +1,64 @@
+# Maintainer: William D. Jones <thor0505@comcast.net>
+
+_realname=yices2
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=2.6.1
+pkgrel=1
+pkgdesc="Yices is a fast SMT solver with C and Python bindings."
+arch=('any')
+url="https://yices.csl.sri.com"
+license=('GPLv3')
+depends=("${MINGW_PACKAGE_PREFIX}-gmp")
+makedepends=("dos2unix"
+             "gperf")
+options=() # 'debug')
+source=("${_realname}-${pkgver}.tar.gz"::"https://yices.csl.sri.com/releases/${pkgver}/yices-${pkgver}-src.tar.gz")
+sha256sums=('c37340616483f584ee403a06ab01fc9151a834e07a4d937a155b1e6a73b3b93e')
+
+apply_patch_with_msg() {
+  for _fname in "$@"
+  do
+    msg2 "Applying ${_fname}"
+    patch -Nbp1 -i "${srcdir}"/${_fname}
+  done
+}
+
+prepare() {
+  msg "Nothing to prepare"
+}
+
+build() {
+  local build
+  local mode
+
+  # Autodetection of build architecture isn't great within the build system.
+  # Using config.guess directly works.
+  build=`"${srcdir}"/yices-${pkgver}/config.guess`
+
+  if check_option "debug" "y"; then
+    mode="debug"
+  else
+    mode="release"
+  fi
+
+  [[ -d "${srcdir}"/yices-${pkgver}/build/${build}-${mode} ]] && rm -rf "${srcdir}"/yices-${pkgver}/build/${build}-${mode}
+  cd "${srcdir}"/yices-${pkgver}
+
+  ./configure --prefix=${MINGW_PREFIX} \
+    --build=${build}
+
+  MODE=${mode} make
+}
+
+check() {
+  cd "${srcdir}"/yices-${pkgver}
+  # make check # wd/parser-bug-reduced fails as of 2.6.1
+}
+
+package() {
+  cd "${srcdir}"/yices-${pkgver}
+  make install DESTDIR="${pkgdir}"
+
+  install -Dm644 "${srcdir}"/yices-${pkgver}/LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+}

--- a/mingw-w64-yices2/PKGBUILD
+++ b/mingw-w64-yices2/PKGBUILD
@@ -42,6 +42,8 @@ build() {
     mode="release"
   fi
 
+  CFLAGS+=" -fcommon"  # work around gcc 10 being stricter here
+
   [[ -d "${srcdir}"/yices-${pkgver}/build/${build}-${mode} ]] && rm -rf "${srcdir}"/yices-${pkgver}/build/${build}-${mode}
   cd "${srcdir}"/yices-${pkgver}
 


### PR DESCRIPTION
`yices2` is an SMT solver like z3, but is (_much_) faster on some problems. I've tested `yices2` locally for months, although in the most recent version one of the regression tests fails, so I [disabled](https://github.com/msys2/MINGW-packages/compare/master...cr1901:yices2?expand=1#diff-7f5afad67b37bbeb62ae102e27581256R56) `make check`.