### PR TITLE
yaml-cpp: remove the python2 dependency

### DIFF
--- a/mingw-w64-yaml-cpp/PKGBUILD
+++ b/mingw-w64-yaml-cpp/PKGBUILD
@@ -4,7 +4,7 @@ _realname=yaml-cpp
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.6.3
-pkgrel=2
+pkgrel=3
 pkgdesc="A YAML parser and emitter in C++ matching the YAML 1.2 spec (mingw-w64)"
 arch=('any')
 url="https://github.com/jbeder/yaml-cpp"
@@ -12,8 +12,7 @@ license=("MIT")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-boost"
-             "${MINGW_PACKAGE_PREFIX}-pkg-config"
-             "${MINGW_PACKAGE_PREFIX}-python2")
+             "${MINGW_PACKAGE_PREFIX}-pkg-config")
 options=('staticlibs' 'strip')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/jbeder/yaml-cpp/archive/${_realname}-${pkgver}.tar.gz
         mingw-install-pkgconfig.patch)


### PR DESCRIPTION
It's not used during the build.