### PR TITLE
twolame: fix missing export of twolame_encode_buffer_float32_interleaved

### DIFF
--- a/mingw-w64-twolame/0002-Add-missing-TL_API.patch
+++ b/mingw-w64-twolame/0002-Add-missing-TL_API.patch
@@ -1,0 +1,21 @@
+From: Sebastian Ramacher <sramacher@debian.org>
+Date: Tue, 15 Oct 2019 20:22:34 +0200
+Subject: Add missing TL_API
+
+---
+ libtwolame/twolame.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libtwolame/twolame.h b/libtwolame/twolame.h
+index 4348fde..a88e8ac 100644
+--- a/libtwolame/twolame.h
++++ b/libtwolame/twolame.h
+@@ -263,7 +263,7 @@ TL_API int twolame_encode_buffer_float32(twolame_options * glopts,
+  *  \return                The number of bytes put in output buffer
+  *                         or a negative value on error
+  */
+-int twolame_encode_buffer_float32_interleaved(twolame_options * glopts,
++TL_API int twolame_encode_buffer_float32_interleaved(twolame_options * glopts,
+         const float pcm[],
+         int num_samples,
+         unsigned char *mp2buffer, int mp2buffer_size);

--- a/mingw-w64-twolame/PKGBUILD
+++ b/mingw-w64-twolame/PKGBUILD
@@ -4,7 +4,7 @@ _realname=twolame
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.4.0
-pkgrel=1
+pkgrel=2
 pkgdesc="An optimized MPEG Audio Layer 2 (MP2) encoder (mingw-w64)"
 arch=('any')
 license=('LGPL')
@@ -15,15 +15,18 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 depends=("${MINGW_PACKAGE_PREFIX}-libsndfile")
 source=("https://downloads.sourceforge.net/${_realname}/${_realname}-${pkgver}.tar.gz"
         0001-mingw32-does-not-need-handholding.all.patch
-        0005-silent.mingw.patch)
+        0005-silent.mingw.patch
+        0002-Add-missing-TL_API.patch)
 sha256sums=('cc35424f6019a88c6f52570b63e1baf50f62963a3eac52a03a800bb070d7c87d'
             '89bab27e8fb97eb1ca59e353705f2a22cf4e9c570c22f599b9090d0fd344b035'
-            '01b00dfa83ad4af3dad944ddbe1f5b1da03fb9ea2b699d95c9da109391eec911')
+            '01b00dfa83ad4af3dad944ddbe1f5b1da03fb9ea2b699d95c9da109391eec911'
+            'ad0bf19387e842ce6070a7a812a80237b16591441f6b822909722d3870a01c88')
 
 prepare() {
   cd ${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/0001-mingw32-does-not-need-handholding.all.patch
   patch -p1 -i ${srcdir}/0005-silent.mingw.patch
+  patch -p1 -i ${srcdir}/0002-Add-missing-TL_API.patch
 
   WANT_AUTOMAKE=latest autoreconf -fi
 }


### PR DESCRIPTION
patch taken from debian

upstream issue: https://github.com/njh/twolame/pull/94