### PR TITLE
PostgreSQL: Split server and client packages

### DIFF
--- a/mingw-w64-postgresql/PKGBUILD
+++ b/mingw-w64-postgresql/PKGBUILD
@@ -1,28 +1,26 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Maintainer: Lars Kanis <lars@greiz-reinsdorf.de>
 
 _realname=postgresql
 pkgbase=mingw-w64-${_realname}
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-client")
 pkgver=12.0
 pkgrel=1
-pkgdesc="Libraries for use with PostgreSQL (mingw-w64)"
 arch=('any')
 url="https://www.postgresql.org/"
 license=('custom:PostgreSQL')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-gcc-libs"
+             "${MINGW_PACKAGE_PREFIX}-gettext"
              "${MINGW_PACKAGE_PREFIX}-libxml2"
-             "${MINGW_PACKAGE_PREFIX}-python2")
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
-         "${MINGW_PACKAGE_PREFIX}-gettext"
-         "${MINGW_PACKAGE_PREFIX}-libxml2"
-         "${MINGW_PACKAGE_PREFIX}-libxslt"
-         "${MINGW_PACKAGE_PREFIX}-openssl"
-         "${MINGW_PACKAGE_PREFIX}-python2"
-         "${MINGW_PACKAGE_PREFIX}-tcl"
-         #"${MINGW_PACKAGE_PREFIX}-readline"
-         #"${MINGW_PACKAGE_PREFIX}-wineditline"
-         "${MINGW_PACKAGE_PREFIX}-zlib"
-         "winpty")
+             "${MINGW_PACKAGE_PREFIX}-libxslt"
+             "${MINGW_PACKAGE_PREFIX}-openssl"
+             "${MINGW_PACKAGE_PREFIX}-python2"
+             #"${MINGW_PACKAGE_PREFIX}-readline"
+             "${MINGW_PACKAGE_PREFIX}-tcl"
+             #"${MINGW_PACKAGE_PREFIX}-wineditline"
+             "${MINGW_PACKAGE_PREFIX}-zlib")
 options=('staticlibs' 'strip')
 source=("https://ftp.postgresql.org/pub/source/v${pkgver}/postgresql-${pkgver}.tar.bz2"
         postgresql-12.0-mingw-link.patch
@@ -81,50 +79,183 @@ build() {
   #  make -C ${dir}
   #done
   make
+
+  rm -rf ${srcdir}${MINGW_PREFIX}
+
+  make -j1 DESTDIR=${srcdir} install
+
+  # DLLs are duplicated in in bin and lib, but needed in bin only
+  rm -rf ${srcdir}${MINGW_PREFIX}/lib/*.dll
 }
 
-package() {
-  cd "${srcdir}/build-${CARCH}"
-  mkdir -p "${pkgdir}${MINGW_PREFIX}/"{bin,include,lib}
+package_postgresql() {
+  pkgdesc="PostgreSQL server and client (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-libxslt"
+           "${MINGW_PACKAGE_PREFIX}-postgresql-client"
+           "${MINGW_PACKAGE_PREFIX}-python2"
+           "${MINGW_PACKAGE_PREFIX}-tcl"
+           "${MINGW_PACKAGE_PREFIX}-zlib")
 
-  make DESTDIR="${pkgdir}" install
-  # install libs
+  cd ${srcdir}${MINGW_PREFIX}
 
-  #for dir in src/interfaces src/bin/pg_config src/bin/psql src/bin/pg_dump; do
-  #  make -C ${dir} DESTDIR="${pkgdir}" install
-  #done
+  files="
+    bin/initdb.exe
+    bin/pg_archivecleanup.exe
+    bin/pgbench.exe
+    bin/pg_checksums.exe
+    bin/pg_config
+    bin/pg_controldata.exe
+    bin/pg_ctl.exe
+    bin/pg_resetwal.exe
+    bin/pg_rewind.exe
+    bin/pg_test_fsync.exe
+    bin/pg_test_timing.exe
+    bin/pg_upgrade.exe
+    bin/pg_waldump.exe
+    bin/postgres.exe
+    bin/postmaster.exe
 
-  # Move dll's to bin directory
-  mv "${pkgdir}${MINGW_PREFIX}/lib/"*.dll "${pkgdir}${MINGW_PREFIX}/bin/"
+    include/postgresql/server
+    lib/libpgcommon*
+    lib/libpgport*
+    lib/libpostgres.*
+    lib/postgresql/pgxs/*
 
-  # Rename the .a files to .dll.a as they're actually import libraries and not static libraries
-  #for implib in "${pkgdir}${MINGW_PREFIX}/lib/"*.a; do
-  #  mv $implib ${implib/.a/.dll.a}
-  #done
+    lib/postgresql/*.dll
 
-  # these headers are needed by the not-so-public headers of the interfaces
-  mkdir -p "${pkgdir}${MINGW_PREFIX}"/include/{libpq,postgresql/internal/libpq}
-  install -m644 ${srcdir}/postgresql-${pkgver}/src/include/c.h "${pkgdir}${MINGW_PREFIX}/include/postgresql/internal/"
-  install -m644 ${srcdir}/postgresql-${pkgver}/src/include/port.h "${pkgdir}${MINGW_PREFIX}/include/postgresql/internal/"
-  install -m644 ${srcdir}/postgresql-${pkgver}/src/include/postgres_fe.h "${pkgdir}${MINGW_PREFIX}/include/postgresql/internal/"
-  install -m644 ${srcdir}/postgresql-${pkgver}/src/include/libpq/pqcomm.h "${pkgdir}${MINGW_PREFIX}/include/postgresql/internal/libpq/"
+    share/locale/*/LC_MESSAGES/initdb-*.mo
+    share/locale/*/LC_MESSAGES/pg_archivecleanup-*.mo
+    share/locale/*/LC_MESSAGES/pg_checksums-*.mo
+    share/locale/*/LC_MESSAGES/pg_config-*.mo
+    share/locale/*/LC_MESSAGES/pg_controldata-*.mo
+    share/locale/*/LC_MESSAGES/pg_ctl-*.mo
+    share/locale/*/LC_MESSAGES/pg_resetwal-*.mo
+    share/locale/*/LC_MESSAGES/pg_rewind-*.mo
+    share/locale/*/LC_MESSAGES/pg_test_fsync-*.mo
+    share/locale/*/LC_MESSAGES/pg_test_timing-*.mo
+    share/locale/*/LC_MESSAGES/pg_upgrade-*.mo
+    share/locale/*/LC_MESSAGES/pg_waldump-*.mo
+    share/locale/*/LC_MESSAGES/plpgsql-*.mo
+    share/locale/*/LC_MESSAGES/plpython-*.mo
+    share/locale/*/LC_MESSAGES/pltcl-*.mo
+    share/locale/*/LC_MESSAGES/postgres-*.mo
 
-  # these headers are needed by the public headers of the interfaces
-  #  install -m644 pg_config.h "${pkgdir}${MINGW_PREFIX}/include/"
-  #  install -m644 pg_config_os.h "${pkgdir}${MINGW_PREFIX}/include/"
-  #  install -m644 pg_config_ext.h "${pkgdir}${MINGW_PREFIX}/include/"
-  #  cd "${srcdir}/postgresql-$pkgver/src/include"
-  #  install -m644 postgres_ext.h "${pkgdir}${MINGW_PREFIX}/include/"
-  #  install -m644 libpq/libpq-fs.h "${pkgdir}${MINGW_PREFIX}/include/libpq/"
-  #  install -m644 pg_config_manual.h "${pkgdir}${MINGW_PREFIX}/include/"
+    share/postgresql/errcodes.txt
+    share/postgresql/extension/*
+    share/postgresql/timezone/*
+    share/postgresql/timezonesets/*
+    share/postgresql/tsearch_data
+    share/postgresql/*.sql
+    share/postgresql/*.conf.sample
+    share/postgresql/postgres.bki
+    share/postgresql/postgres.description
+    share/postgresql/postgres.shdescription
+    share/postgresql/sql_features.txt
+  "
+  for fil in $files; do
+    dir=${fil%/*}
+    mkdir -p "${pkgdir}/${MINGW_PREFIX}/${dir}"
+    mv ${fil} "${pkgdir}/${MINGW_PREFIX}/${dir}/"
+  done
+}
+
+package_postgresql-client() {
+  pkgdesc="Front-end programs and libraries for use with PostgreSQL (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-gettext"
+           "${MINGW_PACKAGE_PREFIX}-gcc-libs"
+           "${MINGW_PACKAGE_PREFIX}-libxml2"
+           "${MINGW_PACKAGE_PREFIX}-openssl"
+           "winpty")
+
+  cd ${srcdir}${MINGW_PREFIX}
+
+  files="
+    bin/clusterdb.exe
+    bin/createdb.exe
+    bin/createuser.exe
+    bin/dropdb.exe
+    bin/dropuser.exe
+    bin/ecpg.exe
+    bin/pg_basebackup.exe
+    bin/pg_dump.exe
+    bin/pg_dumpall.exe
+    bin/pg_isready.exe
+    bin/pg_receivewal.exe
+    bin/pg_recvlogical.exe
+    bin/pg_restore.exe
+    bin/psql.exe
+    bin/reindexdb.exe
+    bin/vacuumdb.exe
+
+    bin/libpq.dll
+    bin/libpgtypes.dll
+    bin/libecpg_compat.dll
+    bin/libecpg.dll
+
+    include/ecpg*.h
+    include/libpq-events.h
+    include/libpq-fe.h
+    include/libpq/libpq-fs.h
+    include/pg_config*.h
+    include/postgres_ext.h
+    include/postgresql/internal/*
+    include/postgresql/informix/esql
+    include/pgtypes*.h
+    include/sql3types.h
+    include/sqlca.h
+    include/sqlda-compat.h
+    include/sqlda-native.h
+    include/sqlda.h
+
+    lib/libecpg.*
+    lib/libecpg_compat.*
+    lib/libpgfeutils.*
+    lib/libpgtypes.*
+    lib/libpq.*
+    lib/pkgconfig
+
+    share/locale/*/LC_MESSAGES/ecpg-*.mo
+    share/locale/*/LC_MESSAGES/ecpglib6-*.mo
+    share/locale/*/LC_MESSAGES/libpq5-*.mo
+    share/locale/*/LC_MESSAGES/pg_basebackup-*.mo
+    share/locale/*/LC_MESSAGES/pg_dump-*.mo
+    share/locale/*/LC_MESSAGES/pgscripts-*.mo
+    share/locale/*/LC_MESSAGES/psql-*.mo
+
+    share/postgresql/psqlrc.sample
+  "
+  for fil in $files; do
+    dir=${fil%/*}
+    mkdir -p "${pkgdir}/${MINGW_PREFIX}/${dir}"
+    mv ${fil} "${pkgdir}/${MINGW_PREFIX}/${dir}/"
+  done
 
   # Use winpty-git script to invoke utilities. Please don't move this into a patch as
   # hopefully one day we won't need this hack.
-  for f in clusterdb createdb createuser dropdb dropuser initdb pg_basebackup pg_dump pg_dumpall pg_receivewal pg_restore psql reindexdb vacuumdb; do
+  for f in clusterdb createdb createuser dropdb dropuser pg_basebackup pg_dump pg_dumpall pg_receivewal pg_restore psql reindexdb vacuumdb; do
     mv "${pkgdir}"${MINGW_PREFIX}/bin/${f}.exe "${pkgdir}"${MINGW_PREFIX}/bin/${f}_exe
     _exename="${f}"
     echo "#!/usr/bin/env bash" > "${pkgdir}${MINGW_PREFIX}/bin/${_exename}"
     echo '/usr/bin/winpty "$( dirname ${BASH_SOURCE[0]} )/'${_exename}'.exe" "$@"' >> "${pkgdir}${MINGW_PREFIX}/bin/${_exename}"
     mv "${pkgdir}"${MINGW_PREFIX}/bin/${f}_exe "${pkgdir}"${MINGW_PREFIX}/bin/${f}.exe
   done
+}
+
+# NOTE: In order to avoid lost files from packaging, check that the install directory is empty after makepkg by running:
+#       find src/mingw64/ -type f
+
+package_mingw-w64-i686-postgresql() {
+  package_postgresql
+}
+
+package_mingw-w64-i686-postgresql-client() {
+  package_postgresql-client
+}
+
+package_mingw-w64-x86_64-postgresql() {
+  package_postgresql
+}
+
+package_mingw-w64-x86_64-postgresql-client() {
+  package_postgresql-client
 }

--- a/mingw-w64-postgresql/PKGBUILD
+++ b/mingw-w64-postgresql/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=postgresql
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=11.5
+pkgver=12.0
 pkgrel=1
 pkgdesc="Libraries for use with PostgreSQL (mingw-w64)"
 arch=('any')
@@ -25,13 +25,13 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "winpty")
 options=('staticlibs' 'strip')
 source=("https://ftp.postgresql.org/pub/source/v${pkgver}/postgresql-${pkgver}.tar.bz2"
-        postgresql-9.4.1-mingw-link.patch
+        postgresql-12.0-mingw-link.patch
         postgresql-9.5.1-pl-perl.patch
         postgresql-9.5.1-pl-python.patch
         postgresql-9.4.1-pl-tcl.patch
         postgresql-9.4.1-mingw-enable-readline.patch)
-sha256sums=('7fdf23060bfc715144cbf2696cf05b0fa284ad3eb21f0c378591c6bca99ad180'
-            'c740a8f308abc85f460ca170969feb1ec41e99072f0e06ef44a63173b26fd7b5'
+sha256sums=('cda2397215f758b793f741c86be05468257b0e6bcb1a6113882ab5d0df0855c6'
+            '607217b422349770d25af20f88e4a7925e68bb934232dff368c2ee59f24249a4'
             '57c1e9b75c042af591b05b9dda60e6327b5c364bb5adc2675da8a48b47e11b81'
             '1afbe207b0fe8c4178cc3f8cb4e3923c7c000207d22ec4f3875d6358b312a1d5'
             'ab9c42374b4e8a01b598810b19b583d9ee7bf5c43c39c019f66b62aacac38926'
@@ -39,7 +39,7 @@ sha256sums=('7fdf23060bfc715144cbf2696cf05b0fa284ad3eb21f0c378591c6bca99ad180'
 
 prepare() {
   cd ${srcdir}/postgresql-${pkgver}
-  patch -p1 -i ${srcdir}/postgresql-9.4.1-mingw-link.patch
+  patch -p1 -i ${srcdir}/postgresql-12.0-mingw-link.patch
   patch -p1 -i ${srcdir}/postgresql-9.5.1-pl-perl.patch
   patch -p1 -i ${srcdir}/postgresql-9.5.1-pl-python.patch
   patch -p1 -i ${srcdir}/postgresql-9.4.1-pl-tcl.patch

--- a/mingw-w64-postgresql/postgresql-12.0-mingw-link.patch
+++ b/mingw-w64-postgresql/postgresql-12.0-mingw-link.patch
@@ -1,5 +1,5 @@
---- postgresql-9.4.1/src/Makefile.shlib.orig	2015-02-10 19:14:10.984800000 +0300
-+++ postgresql-9.4.1/src/Makefile.shlib	2015-02-10 19:14:16.554000000 +0300
+--- postgresql-12.0/src/Makefile.shlib.orig	2015-02-10 19:14:10.984800000 +0300
++++ postgresql-12.0/src/Makefile.shlib	2015-02-10 19:14:16.554000000 +0300
 @@ -86,7 +86,7 @@
  # Naming convention for dynamically loadable modules
  shlib		= $(NAME)$(DLSUFFIX)
@@ -9,14 +9,14 @@
  
  ifndef soname
  # additional flags for backend modules
---- postgresql-9.4.1/src/backend/Makefile.orig	2015-02-10 21:01:34.928800000 +0300
-+++ postgresql-9.4.1/src/backend/Makefile	2015-02-10 21:03:43.819000000 +0300
-@@ -79,11 +79,11 @@
+--- postgresql-12.0/src/backend/Makefile.orig	2015-02-10 21:01:34.928800000 +0300
++++ postgresql-12.0/src/backend/Makefile	2015-02-10 21:03:43.819000000 +0300
+@@ -82,11 +82,11 @@
  LIBS += -lsecur32
  
  postgres: $(OBJS) $(WIN32RES)
--	$(CC) $(CFLAGS) $(LDFLAGS) $(LDFLAGS_EX) -Wl,--stack=$(WIN32_STACK_RLIMIT) -Wl,--export-all-symbols -Wl,--out-implib=libpostgres.a $(call expand_subsys,$(OBJS)) $(WIN32RES) $(LIBS) -o $@$(X)
-+	$(CC) $(CFLAGS) $(LDFLAGS) $(LDFLAGS_EX) -Wl,--stack=$(WIN32_STACK_RLIMIT) -Wl,--export-all-symbols -Wl,--out-implib=libpostgres.dll.a $(call expand_subsys,$(OBJS)) $(WIN32RES) $(LIBS) -o $@$(X)
+-	$(CC) $(CFLAGS) $(call expand_subsys,$(OBJS)) $(WIN32RES) $(LDFLAGS) $(LDFLAGS_EX) -Wl,--stack=$(WIN32_STACK_RLIMIT) -Wl,--export-all-symbols -Wl,--out-implib=libpostgres.a $(LIBS) -o $@$(X)
++	$(CC) $(CFLAGS) $(call expand_subsys,$(OBJS)) $(WIN32RES) $(LDFLAGS) $(LDFLAGS_EX) -Wl,--stack=$(WIN32_STACK_RLIMIT) -Wl,--export-all-symbols -Wl,--out-implib=libpostgres.dll.a $(LIBS) -o $@$(X)
  
  # libpostgres.a is actually built in the preceding rule, but we need this to
  # ensure it's newer than postgres; see notes in src/backend/parser/Makefile
@@ -25,7 +25,7 @@
  	touch $@
  
  endif # win32
-@@ -207,7 +207,7 @@
+@@ -200,7 +200,7 @@
  endif
  ifeq ($(PORTNAME), win32)
  ifeq ($(MAKE_DLL), true)
@@ -43,7 +43,7 @@
  endif
  endif
  	$(MAKE) -C catalog uninstall-data
-@@ -288,7 +288,7 @@
+@@ -287,7 +287,7 @@
  	rm -f postgres.dll libpostgres.a
  endif
  ifeq ($(PORTNAME), win32)


### PR DESCRIPTION
The current postgresql package is rather large and has large dependencies like tcl and python2. This makes it inconvenient to be used for many client only purposes. I therefore propose two split packages as common on Linux distros. This greatly reduces the amount of files and dependencies to be installed when no server libraries are needed.

The new package is called "postgresql-client". Package "postgresql" installs "postgresql-client" implicit, so that the package is fully backward compatible. I used the [debian package repo](https://salsa.debian.org/postgresql/postgresql/tree/12/debian) to separate which files belongs to which package (although debian splits it into a dozen packages).

Background is that I'm maintaining both [RubyInstaller](https://rubyinstaller.org/) and [ruby-pg](https://github.com/ged/ruby-pg) (the ruby client library for postgres) and I would like to install ruby-pg gem on top of the postgresql-client package.

For some reason gcc links to libxml2.dll, when linker is called with -lxml2 , although --as-needed is specified. Unfortunatelly there seems to be no easy way to disable -lxml2 for client libraries only, so that the package "postgresql-client" depends on libxml2, although it has no use there other than fulfilling this dll dependency at runtime.

I successfully tested the postgresql-client package with ruby-pg.
