### PR TITLE
libsass: Update to 3.6.3

### DIFF
--- a/mingw-w64-libsass/PKGBUILD
+++ b/mingw-w64-libsass/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libsass
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.6.2
+pkgver=3.6.3
 pkgrel=1
 pkgdesc="C implementation of Sass CSS preprocessor (library) (mingw-w64)"
 arch=('any')
@@ -11,7 +11,7 @@ url="http://libsass.org/"
 license=("MIT")
 options=('strip' 'staticlibs')
 source=("$_realname-$pkgver.tar.gz::https://github.com/sass/$_realname/archive/$pkgver.tar.gz")
-sha256sums=('0ecd2405f869901d70e7b1960259aac3f21a33c59a820a0a579a16f8f8dc43b9')
+sha256sums=('dadb470bb9141e91b437119d367654427180ed2b3d04b8000eab5b0ca47cd5bb')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"


### PR DESCRIPTION
3.6.2 was broken and breaks the gtk build, 3.6.3 works again