### PR TITLE
docbook package restructuring

### DIFF
--- a/mingw-w64-docbook-xml/PKGBUILD
+++ b/mingw-w64-docbook-xml/PKGBUILD
@@ -2,12 +2,12 @@
 # Contributor: Judd Vinet <jvinet@zeroflux.org>
 
 _vers_4x=(4.{2..5})
-_vers_5x=(5.0 5.0.1)
 _realname=docbook-xml
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=${_vers_5x[-1]}
+pkgver=${_vers_4x[-1]}
 pkgrel=1
+epoch=1
 pkgdesc="A widely used XML scheme for writing documentation and help"
 url="https://www.oasis-open.org/docbook/"
 arch=(any)
@@ -17,24 +17,22 @@ install=docbook-xml-${CARCH}.install
 source=(https://docbook.org/xml/4.1.2/docbkx412.zip
         LICENSE)
 noextract=(docbkx412.zip)
+for _ver in ${_vers_5x[@]}; do
+  source+=("https://docbook.org/xml/$_ver/docbook-$_ver.zip")
+  noextract+=("docbook-$_ver.zip")
+done
+noextract=(docbkx412.zip)
 
 for _ver in ${_vers_4x[@]}; do
   source+=("https://docbook.org/xml/$_ver/docbook-xml-$_ver.zip")
   noextract+=("docbook-xml-$_ver.zip")
 done
-for _ver in ${_vers_5x[@]}; do
-  source+=("https://docbook.org/xml/$_ver/docbook-$_ver.zip")
-  noextract+=("docbook-$_ver.zip")
-done
- 
 sha512sums=('f700591a671694ca0ac51f5b5b7e825df5c0b3604b20baa6afd3aaafa7ce99470ca1c261781b105b42bfa5485c23217cf3db821b3fcf2ebdae9df07bb8ae4063'
             'd852ab8e1442af4a91ffc32b9bb37377d98171dbc379cfd9787a2e06fc5c9b8ed04c5cd156ff5b7799973250011389456a3a3584ed4ae99362420c15235fcbb5'
             '0c836346130d1e8f4e26e00959f6b4fd2c3c11269ba5cbf11cdc904724e189606f431c99cd5ab188877daa0eb44c58d0bc30556df3b51df480396818d61c4e0a'
             'f5090fb74884bae3d4fac8a3c5060bffff5d6a74272de183c181a7642e4b91f4ed32ad028537d198010782c3d98575ce679672f76a9749ed124432195886a7cb'
             '7df5af4df24e4618b09814e4e20c147c722962531f03a40c28cd60f1db16b4c330420adf96adb7d66ed6eda84046ee91b467fd6f6fbfac2201537e2080735d76'
-            '1ee282fe86c9282610ee72c0e1d1acfc03f1afb9dc67166f438f2703109046479edb6329313ecb2949db27993077e077d111501c10b8769ebb20719eb6213d27'
-            'a245796881762cf001f0d32b7c87315cba0454750d6b4178e4546357e320e2ab602d84c08a7e44329f406a8d32340605671c351e87c0b9097582ebf6d10fede4'
-            'df85ab724d3205086dfbab40419e268d5bf183b028ed8c58d30068bdc82c1e10fc05bf167d5efcdbeb6b6c9c8dbf96ca4f979fcc6da2e2fea99cbf1bd8aaad30')
+            '1ee282fe86c9282610ee72c0e1d1acfc03f1afb9dc67166f438f2703109046479edb6329313ecb2949db27993077e077d111501c10b8769ebb20719eb6213d27')
 
 package() {
   local ver xml
@@ -123,265 +121,7 @@ package() {
     esac
   done
 
-  for ver in ${_vers_5x[@]}; do
-    pushd docbook-xml-$ver
-      # mkdir -p "$pkgdir${MINGW_PREFIX}/share/xml/docbook/xml-dtd-$ver"
-      mkdir -p $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/dtd/$ver \
-               $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver/ \
-               $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/sch/$ver/ \
-               $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/xsd/$ver/ \
-               $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/$ver/ \
-               $pkgdir${MINGW_PREFIX}/share/doc/docbook5-schemas \
-               $pkgdir${MINGW_PREFIX}/share/xml/docbook/stylesheet/docbook-$ver/ \
-               $pkgdir${MINGW_PREFIX}/bin
-
-      cp -r docbook-$ver/docs/* $pkgdir${MINGW_PREFIX}/share/doc/docbook5-schemas
-      cp docbook-$ver/catalog.xml $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/catalog-docbook-$ver.xml
-      cp -r docbook-$ver/dtd/* $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/dtd/$ver
-      cp -r docbook-$ver/rng/* $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver
-      cp -r docbook-$ver/sch/* $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/sch/$ver/
-      cp -r docbook-$ver/xsd/* $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/xsd/$ver/
-      cp -r docbook-$ver/tools/db4-upgrade.xsl $pkgdir${MINGW_PREFIX}/share/xml/docbook/stylesheet/docbook-$ver/
-      cp -r docbook-$ver/tools/db4-entities.pl $pkgdir${MINGW_PREFIX}/bin
-      cp -r docbook-$ver/docbook.nvdl $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/$ver/docbook.nvdl
-
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
-          "-//OASIS//DTD DocBook XML V$ver//EN" \
-          "http://www.oasis-open.org/docbook/xml/$ver/docbookx.dtd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-      ## dtd dir
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-          "http://www.oasis-open.org/docbook/xml/$ver/dtd/docbook.dtd" \
-          "../../share/xml/docbook/schema/dtd/$ver/docbook.dtd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-          "http://www.oasis-open.org/docbook/xml/$ver/dtd/docbook.dtd" \
-          "../../share/xml/docbook/schema/dtd/$ver/docbook.dtd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-          "http://docbook.org/xml/$ver/dtd/docbook.dtd" \
-          "../../share/xml/docbook/schema/dtd/$ver/docbook.dtd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-          "http://docbook.org/xml/$ver/dtd/docbook.dtd" \
-          "../../share/xml/docbook/schema/dtd/$ver/docbook.dtd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-      #rng dir
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-          "http://www.oasis-open.org/docbook/xml/$ver/rng/docbook.rng" \
-          "../../share/xml/docbook/schema/rng/$ver/docbook.rng" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-          "http://www.oasis-open.org/docbook/xml/$ver/rng/docbook.rng" \
-          "../../share/xml/docbook/schema/rng/$ver/docbook.rng" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-          "http://docbook.org/xml/$ver/rng/docbook.rng" \
-          "../../share/xml/docbook/schema/rng/$ver/docbook.rng" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-          "http://docbook.org/xml/$ver/rng/docbook.rng" \
-          "../../share/xml/docbook/schema/rng/$ver/docbook.rng" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-          "http://www.oasis-open.org/docbook/xml/$ver/rng/docbookxi.rng" \
-          "../../share/xml/docbook/schema/rng/$ver/docbookxi.rng" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-          "http://www.oasis-open.org/docbook/xml/$ver/rng/docbookxi.rng" \
-          "../../share/xml/docbook/schema/rng/$ver/docbookxi.rng" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-          "http://docbook.org/xml/$ver/rng/docbookxi.rng" \
-          "../../share/xml/docbook/schema/rng/$ver/docbookxi.rng" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-          "http://docbook.org/xml/$ver/rng/docbookxi.rng" \
-          "../../share/xml/docbook/schema/rng/$ver/docbookxi.rng" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-          "http://www.oasis-open.org/docbook/xml/$ver/rng/docbook.rnc" \
-          "../../share/xml/docbook/schema/rng/$ver/docbook.rnc" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-          "http://www.oasis-open.org/docbook/xml/$ver/rng/docbook.rnc" \
-          "../../share/xml/docbook/schema/rng/$ver/docbook.rnc" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-          "http://docbook.org/xml/$ver/rng/docbook.rnc" \
-          "../../share/xml/docbook/schema/rng/$ver/docbook.rnc" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-          "http://docbook.org/xml/$ver/rng/docbook.rnc" \
-          "../../share/xml/docbook/schema/rng/$ver/docbook.rnc" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-          "http://www.oasis-open.org/docbook/xml/$ver/rng/docbookxi.rnc" \
-          "../../share/xml/docbook/schema/rng/$ver/docbookxi.rnc" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-          "http://www.oasis-open.org/docbook/xml/$ver/rng/docbookxi.rnc" \
-          "../../share/xml/docbook/schema/rng/$ver/docbookxi.rnc" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-          "http://docbook.org/xml/$ver/rng/docbookxi.rnc" \
-          "../../share/xml/docbook/schema/rng/$ver/docbookxi.rnc" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-          "http://docbook.org/xml/$ver/rng/docbookxi.rnc" \
-          "../../share/xml/docbook/schema/rng/$ver/docbookxi.rnc" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-      # xsd dir
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-          "http://www.oasis-open.org/docbook/xml/$ver/xsd/docbook.xsd" \
-          "../../share/xml/docbook/schema/xsd/$ver/docbook.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-          "http://www.oasis-open.org/docbook/xml/$ver/xsd/docbook.xsd" \
-          "../../share/xml/docbook/schema/xsd/$ver/docbook.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-          "http://docbook.org/xml/$ver/xsd/docbook.xsd" \
-          "../../share/xml/docbook/schema/xsd/$ver/docbook.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-          "http://docbook.org/xml/$ver/xsd/docbook.xsd" \
-          "../../share/xml/docbook/schema/xsd/$ver/docbook.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-          "http://www.oasis-open.org/docbook/xml/$ver/xsd/docbookxi.xsd" \
-          "../../share/xml/docbook/schema/xsd/$ver/docbookxi.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-          "http://www.oasis-open.org/docbook/xml/$ver/xsd/docbookxi.xsd" \
-          "../../share/xml/docbook/schema/xsd/$ver/docbookxi.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-          "http://docbook.org/xml/$ver/xsd/docbookxi.xsd" \
-          "../../share/xml/docbook/schema/xsd/$ver/docbookxi.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-          "http://docbook.org/xml/$ver/xsd/docbookxi.xsd" \
-          "../../share/xml/docbook/schema/xsd/$ver/docbookxi.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-          "http://www.oasis-open.org/docbook/xml/$ver/xsd/xi.xsd" \
-          "../../share/xml/docbook/schema/xsd/$ver/xi.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-          "http://www.oasis-open.org/docbook/xml/$ver/xsd/xi.xsd" \
-          "../../share/xml/docbook/schema/xsd$/$ver/xi.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-          "http://docbook.org/xml/$ver/xsd/xi.xsd" \
-          "../../share/xml/docbook/schema/xsd/$ver/xi.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-          "http://docbook.org/xml/$ver/xsd/xi.xsd" \
-          "../../share/xml/docbook/schema/$ver/xsd/xi.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-          "http://www.oasis-open.org/docbook/xml/$ver/xsd/xlink.xsd" \
-          "../../share/xml/docbook/schema/xsd/$ver/xlink.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-          "http://www.oasis-open.org/docbook/xml/$ver/xsd/xlink.xsd" \
-          "../../share/xml/docbook/schema/xsd/$ver/xlink.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-          "http://docbook.org/xml/$ver/xsd/xlink.xsd" \
-          "../../share/xml/docbook/schema/xsd/$ver/xlink.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-          "http://docbook.org/xml/$ver/xsd/xlink.xsd" \
-          "../../share/xml/docbook/schema/xsd/$ver/xlink.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-          "http://www.oasis-open.org/docbook/xml/$ver/xsd/xml.xsd" \
-          "../../share/xml/docbook/schema/xsd/$ver/xml.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-          "http://www.oasis-open.org/docbook/xml/$ver/xsd/xml.xsd" \
-          "../../share/xml/docbook/schema/xsd/$ver/xml.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-          "http://docbook.org/xml/$ver/xsd/xml.xsd" \
-          "../../share/xml/docbook/schema/xsd/$ver/xml.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-          "http://docbook.org/xml/$ver/xsd/xml.xsd" \
-          "../../share/xml/docbook/schema/xsd/$ver/xml.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-      ##sch dir
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-          "http://www.oasis-open.org/docbook/xml/$ver/sch/docbook.sch" \
-          "../../share/xml/docbook/schema/sch/$ver/docbook.sch" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-          "http://www.oasis-open.org/docbook/xml/sch/$ver/docbook.sch" \
-          "../../share/xml/docbook/schema/sch/$ver/docbook.sch" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-          "http://docbook.org/xml/$ver/sch/docbook.sch" \
-          "../../share/xml/docbook/schema/sch/$ver/docbook.sch" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-          "http://docbook.org/xml/$ver/sch/docbook.sch" \
-          "../../share/xml/docbook/schema/sch/$ver/docbook.sch" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-      # 5.0 dir
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-          "http://www.oasis-open.org/docbook/xml/$ver/docbook.nvdl" \
-          "../../share/xml/docbook/schema/$ver/docbook.nvdl" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-          "http://www.oasis-open.org/docbook/xml/$ver/docbook.nvdl" \
-          "../../share/xml/docbook/schema/$ver/docbook.nvdl" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
-          "http://docbook.org/xml/$ver/docbook.nvdl" \
-          "../../share/xml/docbook/schema/$ver/docbook.nvdl" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
-          "http://docbook.org/xml/$ver/docbook.nvdl" \
-          "../../share/xml/docbook/schema/$ver/docbook.nvdl" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-   popd
-
-  done
-
-#//DOCBOOK 5.0 and 5.0.1 entries
-
-  local PREFIX_WIN="$(cygpath -m ${MINGW_PREFIX})"
-  sed -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" \
-      -i "$pkgdir${MINGW_PREFIX}/etc/xml/docbook-xml"
-
-  install -Dt "$pkgdir${MINGW_PREFIX}/share/licenses/$pkgname" -m644 LICENSE
+  install -Dt "$pkgdir${MINGW_PREFIX}/share/licenses/${_realname}" -m644 LICENSE
 
   # Fix permissions
   find "$pkgdir" -type f -exec chmod -c a-x {} +

--- a/mingw-w64-docbook-xml/docbook-xml-i686.install
+++ b/mingw-w64-docbook-xml/docbook-xml-i686.install
@@ -34,6 +34,7 @@ post_install() {
 pre_upgrade() {
   if [ $(vercmp $2 4.5) -lt 0 ]; then
     ${MINGW_INSTALL}/bin/xmlcatalog --del "${MINGW_XML_CATALOG}/docbook" ${MINGW_XML_CATALOG}/catalog > ${MINGW_XML_CATALOG}/catalog.preserve
+    echo ":: docbook5 is now in docbook5-xml"
   fi
 }
 

--- a/mingw-w64-docbook-xml/docbook-xml-x86_64.install
+++ b/mingw-w64-docbook-xml/docbook-xml-x86_64.install
@@ -32,6 +32,7 @@ post_install() {
 pre_upgrade() {
   if [ $(vercmp $2 4.5) -lt 0 ]; then
     ${MINGW_INSTALL}/bin/xmlcatalog --del "${MINGW_XML_CATALOG}/docbook" ${MINGW_XML_CATALOG}/catalog > ${MINGW_XML_CATALOG}/catalog.preserve
+    echo ":: docbook5 is now in docbook5-xml"
   fi
 }
 

--- a/mingw-w64-docbook5-xml/PKGBUILD
+++ b/mingw-w64-docbook5-xml/PKGBUILD
@@ -59,7 +59,7 @@ package() {
   for ver in ${_vers_50x[@]}; do
     pushd docbook-xml-$ver
       _cat=docbook-$ver.xml
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --create "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --create "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
       # mkdir -p "$pkgdir${MINGW_PREFIX}/share/xml/docbook/xml-dtd-$ver"
       mkdir -p $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/dtd/$ver \
                $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver/ \
@@ -80,230 +80,230 @@ package() {
       cp -r docbook-$ver/tools/db4-entities.pl $pkgdir${MINGW_PREFIX}/bin
       cp -r docbook-$ver/docbook.nvdl $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/$ver/docbook.nvdl
 
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --create --noout "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+      ${MINGW_PREFIX}/bin/xmlcatalog  --create --noout "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "public" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "public" \
           "-//OASIS//DTD DocBook XML V$ver//EN" \
           "http://www.oasis-open.org/docbook/xml/$ver/docbookx.dtd" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
       ## dtd dir
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteSystem" \
           "http://www.oasis-open.org/docbook/xml/$ver/dtd/docbook.dtd" \
           "../../share/xml/docbook/schema/dtd/$ver/docbook.dtd" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteURI" \
           "http://www.oasis-open.org/docbook/xml/$ver/dtd/docbook.dtd" \
           "../../share/xml/docbook/schema/dtd/$ver/docbook.dtd" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteSystem" \
           "http://docbook.org/xml/$ver/dtd/docbook.dtd" \
           "../../share/xml/docbook/schema/dtd/$ver/docbook.dtd" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteURI" \
           "http://docbook.org/xml/$ver/dtd/docbook.dtd" \
           "../../share/xml/docbook/schema/dtd/$ver/docbook.dtd" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
       #rng dir
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteSystem" \
           "http://www.oasis-open.org/docbook/xml/$ver/rng/docbook.rng" \
           "../../share/xml/docbook/schema/rng/$ver/docbook.rng" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteURI" \
           "http://www.oasis-open.org/docbook/xml/$ver/rng/docbook.rng" \
           "../../share/xml/docbook/schema/rng/$ver/docbook.rng" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteSystem" \
           "http://docbook.org/xml/$ver/rng/docbook.rng" \
           "../../share/xml/docbook/schema/rng/$ver/docbook.rng" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteURI" \
           "http://docbook.org/xml/$ver/rng/docbook.rng" \
           "../../share/xml/docbook/schema/rng/$ver/docbook.rng" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteSystem" \
           "http://www.oasis-open.org/docbook/xml/$ver/rng/docbookxi.rng" \
           "../../share/xml/docbook/schema/rng/$ver/docbookxi.rng" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteURI" \
           "http://www.oasis-open.org/docbook/xml/$ver/rng/docbookxi.rng" \
           "../../share/xml/docbook/schema/rng/$ver/docbookxi.rng" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteSystem" \
           "http://docbook.org/xml/$ver/rng/docbookxi.rng" \
           "../../share/xml/docbook/schema/rng/$ver/docbookxi.rng" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteURI" \
           "http://docbook.org/xml/$ver/rng/docbookxi.rng" \
           "../../share/xml/docbook/schema/rng/$ver/docbookxi.rng" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteSystem" \
           "http://www.oasis-open.org/docbook/xml/$ver/rng/docbook.rnc" \
           "../../share/xml/docbook/schema/rng/$ver/docbook.rnc" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteURI" \
           "http://www.oasis-open.org/docbook/xml/$ver/rng/docbook.rnc" \
           "../../share/xml/docbook/schema/rng/$ver/docbook.rnc" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteSystem" \
           "http://docbook.org/xml/$ver/rng/docbook.rnc" \
           "../../share/xml/docbook/schema/rng/$ver/docbook.rnc" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteURI" \
           "http://docbook.org/xml/$ver/rng/docbook.rnc" \
           "../../share/xml/docbook/schema/rng/$ver/docbook.rnc" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteSystem" \
           "http://www.oasis-open.org/docbook/xml/$ver/rng/docbookxi.rnc" \
           "../../share/xml/docbook/schema/rng/$ver/docbookxi.rnc" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteURI" \
           "http://www.oasis-open.org/docbook/xml/$ver/rng/docbookxi.rnc" \
           "../../share/xml/docbook/schema/rng/$ver/docbookxi.rnc" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteSystem" \
           "http://docbook.org/xml/$ver/rng/docbookxi.rnc" \
           "../../share/xml/docbook/schema/rng/$ver/docbookxi.rnc" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteURI" \
           "http://docbook.org/xml/$ver/rng/docbookxi.rnc" \
           "../../share/xml/docbook/schema/rng/$ver/docbookxi.rnc" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
       # xsd dir
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteSystem" \
           "http://www.oasis-open.org/docbook/xml/$ver/xsd/docbook.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/docbook.xsd" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteURI" \
           "http://www.oasis-open.org/docbook/xml/$ver/xsd/docbook.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/docbook.xsd" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteSystem" \
           "http://docbook.org/xml/$ver/xsd/docbook.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/docbook.xsd" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteURI" \
           "http://docbook.org/xml/$ver/xsd/docbook.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/docbook.xsd" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteSystem" \
           "http://www.oasis-open.org/docbook/xml/$ver/xsd/docbookxi.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/docbookxi.xsd" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteURI" \
           "http://www.oasis-open.org/docbook/xml/$ver/xsd/docbookxi.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/docbookxi.xsd" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteSystem" \
           "http://docbook.org/xml/$ver/xsd/docbookxi.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/docbookxi.xsd" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteURI" \
           "http://docbook.org/xml/$ver/xsd/docbookxi.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/docbookxi.xsd" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteSystem" \
           "http://www.oasis-open.org/docbook/xml/$ver/xsd/xi.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/xi.xsd" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteURI" \
           "http://www.oasis-open.org/docbook/xml/$ver/xsd/xi.xsd" \
           "../../share/xml/docbook/schema/xsd$/$ver/xi.xsd" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteSystem" \
           "http://docbook.org/xml/$ver/xsd/xi.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/xi.xsd" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteURI" \
           "http://docbook.org/xml/$ver/xsd/xi.xsd" \
           "../../share/xml/docbook/schema/$ver/xsd/xi.xsd" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteSystem" \
           "http://www.oasis-open.org/docbook/xml/$ver/xsd/xlink.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/xlink.xsd" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteURI" \
           "http://www.oasis-open.org/docbook/xml/$ver/xsd/xlink.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/xlink.xsd" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteSystem" \
           "http://docbook.org/xml/$ver/xsd/xlink.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/xlink.xsd" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteURI" \
           "http://docbook.org/xml/$ver/xsd/xlink.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/xlink.xsd" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteSystem" \
           "http://www.oasis-open.org/docbook/xml/$ver/xsd/xml.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/xml.xsd" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteURI" \
           "http://www.oasis-open.org/docbook/xml/$ver/xsd/xml.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/xml.xsd" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteSystem" \
           "http://docbook.org/xml/$ver/xsd/xml.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/xml.xsd" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteURI" \
           "http://docbook.org/xml/$ver/xsd/xml.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/xml.xsd" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
       ##sch dir
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteSystem" \
           "http://www.oasis-open.org/docbook/xml/$ver/sch/docbook.sch" \
           "../../share/xml/docbook/schema/sch/$ver/docbook.sch" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteURI" \
           "http://www.oasis-open.org/docbook/xml/sch/$ver/docbook.sch" \
           "../../share/xml/docbook/schema/sch/$ver/docbook.sch" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteSystem" \
           "http://docbook.org/xml/$ver/sch/docbook.sch" \
           "../../share/xml/docbook/schema/sch/$ver/docbook.sch" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteURI" \
           "http://docbook.org/xml/$ver/sch/docbook.sch" \
           "../../share/xml/docbook/schema/sch/$ver/docbook.sch" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
       # 5.0 dir
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteSystem" \
           "http://www.oasis-open.org/docbook/xml/$ver/docbook.nvdl" \
           "../../share/xml/docbook/schema/$ver/docbook.nvdl" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteURI" \
           "http://www.oasis-open.org/docbook/xml/$ver/docbook.nvdl" \
           "../../share/xml/docbook/schema/$ver/docbook.nvdl" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteSystem" \
           "http://docbook.org/xml/$ver/docbook.nvdl" \
           "../../share/xml/docbook/schema/$ver/docbook.nvdl" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "rewriteURI" \
           "http://docbook.org/xml/$ver/docbook.nvdl" \
           "../../share/xml/docbook/schema/$ver/docbook.nvdl" \
           "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
@@ -318,7 +318,7 @@ package() {
   for ver in ${_vers_51x[@]}; do
     pushd docbook-xml-$ver
     _cat=docbook-$ver.xml
-    ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --create "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+    ${MINGW_PREFIX}/bin/xmlcatalog  --noout --create "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
     # RNG
       mkdir -p $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver/ \
                $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/sch/$ver/ \
@@ -335,52 +335,52 @@ package() {
       cp -r tools/db4-entities.pl $pkgdir${MINGW_PREFIX}/bin
       cp -r schemas/docbook.nvdl $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/$ver/docbook.nvdl
 
-    ${MINGW_PREFIX}/bin/xmlcatalog -v  --create --noout "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+    ${MINGW_PREFIX}/bin/xmlcatalog  --create --noout "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
     msg2 "RNG ${ver}"
-    ${MINGW_PREFIX}/bin/xmlcatalog -v --noout --add "uri" \
+    ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
       "http://www.oasis-open.org/docbook/xml/${ver}/rng/docbook.rng" \
       "../../share/xml/docbook/schema/rng/${ver}/docbook.rng" \
       "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-    ${MINGW_PREFIX}/bin/xmlcatalog -v --noout --add "uri" \
+    ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
       "http://docbook.org/xml/${ver}/rng/docbook.rng" \
       "../../share/xml/docbook/schema/rng/${ver}/docbook.rng" \
       "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
     # RNG+XInclude
    msg2 "RNG+XInclude ${ver}"
-    ${MINGW_PREFIX}/bin/xmlcatalog -v --noout --add "uri" \
+    ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
       "http://www.oasis-open.org/docbook/xml/${ver}/rng/docbookxi.rng" \
       "../../share/xml/docbook/schema/rng/${ver}/docbookxi.rng" \
       "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-    ${MINGW_PREFIX}/bin/xmlcatalog -v --noout --add "uri" \
+    ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
       "http://docbook.org/xml/${ver}/rng/docbookxi.rng" \
       "../../share/xml/docbook/schema/rng/${ver}/docbookxi.rng" \
       "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
     # RNC
     msg2 "RNC ${ver}"
-    ${MINGW_PREFIX}/bin/xmlcatalog -v --noout --add "uri" \
+    ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
       "http://www.oasis-open.org/docbook/xml/${ver}/rnc/docbook.rnc" \
       "../../share/xml/docbook/schema/rng/${ver}/docbook.rnc" \
       "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-    ${MINGW_PREFIX}/bin/xmlcatalog -v --noout --add "uri" \
+    ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
       "http://docbook.org/xml/${ver}/rng/docbook.rnc" \
       "../../share/xml/docbook/schema/rng/${ver}/docbook.rnc" \
       "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
     # RNC+XInclude
-    ${MINGW_PREFIX}/bin/xmlcatalog -v --noout --add "uri" \
+    ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
       "http://www.oasis-open.org/docbook/xml/${ver}/rnc/docbookxi.rnc" \
       "../../share/xml/docbook/schema/rng/${ver}/docbookxi.rnc" \
       "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-    ${MINGW_PREFIX}/bin/xmlcatalog -v --noout --add "uri" \
+    ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
       "http://docbook.org/xml/${ver}/rng/docbookxi.rnc" \
       "../../share/xml/docbook/schema/rng/${ver}/docbookxi.rnc" \
       "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
     # Schematron
-    ${MINGW_PREFIX}/bin/xmlcatalog -v --noout --add "uri" \
+    ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
       "http://www.oasis-open.org/docbook/xml/${ver}/sch/docbook.sch" \
       "../../share/xml/docbook/schema/sch/${ver}/docbook.sch" \
       "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
-    ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "uri" \
+    ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "uri" \
       "http://docbook.org/xml/${ver}/sch/docbook.sch" \
       "../../share/xml/docbook/schema/sch/${ver}/docbook.sch" \
       "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
@@ -389,39 +389,39 @@ package() {
     # Build XML catalog files for each Schema
     for s in schemas/rng schemas/sch; do
       _schema_catalog=${s}/catalog.xml
-      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --create ${_schema_catalog}
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --create ${_schema_catalog}
       case $s in
         sch)
-          ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "uri" \
+          ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "uri" \
             "http://docbook.org/xml/${ver}/${s}/docbook.${s}" \
             "docbook.${s}" ${_schema_catalog}
-          ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "uri" \
+          ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "uri" \
             "http://www.oasis-open.org/docbook/xml/${ver}/${s}/docbook.${s}" \
             "docbook.${s}" ${_schema_catalog}
           ;;
         rng)
-          ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "uri" \
+          ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "uri" \
             "http://docbook.org/xml/${ver}/${s}/docbook.${s}" \
             "docbook.${s}" ${_schema_catalog}
-          ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "uri" \
+          ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "uri" \
             "http://www.oasis-open.org/docbook/xml/${ver}/${s}/docbook.${s}" \
             "docbook.${s}" ${_schema_catalog}
-          ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "uri" \
+          ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "uri" \
             "http://docbook.org/xml/${ver}/${s}/docbookxi.${s}" \
             "docbookxi.${s}" ${_schema_catalog}
-          ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "uri" \
+          ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "uri" \
             "http://www.oasis-open.org/docbook/xml/${ver}/${s}/docbookxi.${s}" \
             "docbookxi.${s}" ${_schema_catalog}
-          ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "uri" \
+          ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "uri" \
             "http://docbook.org/xml/${ver}/${s}/docbook.rnc" \
             "docbook.rnc" ${_schema_catalog}
-          ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "uri" \
+          ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "uri" \
             "http://www.oasis-open.org/docbook/xml/${ver}/${s}/docbook.rnc" \
             "docbook.rnc" ${_schema_catalog}
-          ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "uri" \
+          ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "uri" \
             "http://docbook.org/xml/${ver}/${s}/docbookxi.rnc" \
             "docbookxi.rnc" ${_schema_catalog}
-          ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "uri" \
+          ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "uri" \
             "http://www.oasis-open.org/docbook/xml/${ver}/${s}/docbookxi.rnc" \
             "docbookxi.rnc" ${_schema_catalog}
           ;;

--- a/mingw-w64-docbook5-xml/PKGBUILD
+++ b/mingw-w64-docbook5-xml/PKGBUILD
@@ -1,0 +1,464 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_realname=docbook5-xml
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+_vers_50x=(5.0 5.0.1)
+_vers_51x=(5.1)
+_vers_5x=$_vers_50x
+_vers_5x+=$_vers_51x
+pkgver=${_vers_51x[-1]}
+pkgrel=1
+pkgdesc="a complete rewrite of the well-known DocBook 4 XML schema (DTD, Relax NG, W3C schema) for Docbook 5.X (mingw-w64)"
+arch=('any')
+depends=("${MINGW_PACKAGE_PREFIX}-libxml2")
+makedepends=('unzip')
+optdepends=('perl: for docbook v4 upgrade tools')
+url="https://docbook.org/schemas/5x"
+license=('MIT')
+for _ver in ${_vers_50x[@]}; do
+  source+=("https://docbook.org/xml/$_ver/docbook-$_ver.zip")
+  noextract+=("docbook-$_ver.zip")
+done
+for _ver in ${_vers_51x[@]}; do
+  source+=("https://docbook.org/xml/5.1/docbook-v${_ver}-os.zip")
+  noextract+=("docbook-v${_ver}-os.zip")
+done
+sha512sums=('a245796881762cf001f0d32b7c87315cba0454750d6b4178e4546357e320e2ab602d84c08a7e44329f406a8d32340605671c351e87c0b9097582ebf6d10fede4'
+            'df85ab724d3205086dfbab40419e268d5bf183b028ed8c58d30068bdc82c1e10fc05bf167d5efcdbeb6b6c9c8dbf96ca4f979fcc6da2e2fea99cbf1bd8aaad30'
+            'b55f8eda4dcff9d4ebd31876bc33c244ef3884afc167da1425531266963ba64000fbe619ec7c049ae65c0aab864a5a7228caef08b53f546e2686296d97190873')
+install=docbook5-xml-${CARCH}.install
+_datadir=${MINGW_PREFIX}/share
+_catalog50=docbook-5.0.xml
+_catalog51=docbook-5.1.xml  
+
+build() {
+
+  # docbook-5.0x
+  for ver in ${_vers_50x[@]}; do
+    mkdir -p docbook-xml-$ver
+    bsdtar -C docbook-xml-$ver -xf docbook-$ver.zip
+  done
+
+  for ver in ${_vers_51x[@]}; do
+    mkdir -p docbook-xml-$ver
+    bsdtar -C docbook-xml-$ver -xf docbook-v$ver-os.zip
+  done
+}
+
+package() {
+  local ver xml
+
+  _docbook5dir="${pkgdir}${_datadir}/xml/docbook-xml"
+
+  mkdir -p "$pkgdir${MINGW_PREFIX}/etc/xml"
+  ${MINGW_PREFIX}/bin/xmlcatalog --noout --create "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+	
+  for ver in ${_vers_50x[@]}; do
+    pushd docbook-xml-$ver
+      # mkdir -p "$pkgdir${MINGW_PREFIX}/share/xml/docbook/xml-dtd-$ver"
+      mkdir -p $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/dtd/$ver \
+               $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver/ \
+               $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/sch/$ver/ \
+               $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/xsd/$ver/ \
+               $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/$ver/ \
+               $pkgdir${MINGW_PREFIX}/share/doc/docbook5-schemas \
+               $pkgdir${MINGW_PREFIX}/share/xml/docbook/stylesheet/docbook-$ver/ \
+               $pkgdir${MINGW_PREFIX}/bin
+
+      cp -r docbook-$ver/docs/* $pkgdir${MINGW_PREFIX}/share/doc/docbook5-schemas
+      cp docbook-$ver/catalog.xml $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/catalog-docbook-$ver.xml
+      cp -r docbook-$ver/dtd/* $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/dtd/$ver
+      cp -r docbook-$ver/rng/* $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver
+      cp -r docbook-$ver/sch/* $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/sch/$ver/
+      cp -r docbook-$ver/xsd/* $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/xsd/$ver/
+      cp -r docbook-$ver/tools/db4-upgrade.xsl $pkgdir${MINGW_PREFIX}/share/xml/docbook/stylesheet/docbook-$ver/
+      cp -r docbook-$ver/tools/db4-entities.pl $pkgdir${MINGW_PREFIX}/bin
+      cp -r docbook-$ver/docbook.nvdl $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/$ver/docbook.nvdl
+
+      ${MINGW_PREFIX}/bin/xmlcatalog --create --noout "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
+          "-//OASIS//DTD DocBook XML V$ver//EN" \
+          "http://www.oasis-open.org/docbook/xml/$ver/docbookx.dtd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+
+      ## dtd dir
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://www.oasis-open.org/docbook/xml/$ver/dtd/docbook.dtd" \
+          "../../share/xml/docbook/schema/dtd/$ver/docbook.dtd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://www.oasis-open.org/docbook/xml/$ver/dtd/docbook.dtd" \
+          "../../share/xml/docbook/schema/dtd/$ver/docbook.dtd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://docbook.org/xml/$ver/dtd/docbook.dtd" \
+          "../../share/xml/docbook/schema/dtd/$ver/docbook.dtd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://docbook.org/xml/$ver/dtd/docbook.dtd" \
+          "../../share/xml/docbook/schema/dtd/$ver/docbook.dtd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+
+      #rng dir
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://www.oasis-open.org/docbook/xml/$ver/rng/docbook.rng" \
+          "../../share/xml/docbook/schema/rng/$ver/docbook.rng" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://www.oasis-open.org/docbook/xml/$ver/rng/docbook.rng" \
+          "../../share/xml/docbook/schema/rng/$ver/docbook.rng" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://docbook.org/xml/$ver/rng/docbook.rng" \
+          "../../share/xml/docbook/schema/rng/$ver/docbook.rng" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://docbook.org/xml/$ver/rng/docbook.rng" \
+          "../../share/xml/docbook/schema/rng/$ver/docbook.rng" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://www.oasis-open.org/docbook/xml/$ver/rng/docbookxi.rng" \
+          "../../share/xml/docbook/schema/rng/$ver/docbookxi.rng" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://www.oasis-open.org/docbook/xml/$ver/rng/docbookxi.rng" \
+          "../../share/xml/docbook/schema/rng/$ver/docbookxi.rng" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://docbook.org/xml/$ver/rng/docbookxi.rng" \
+          "../../share/xml/docbook/schema/rng/$ver/docbookxi.rng" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://docbook.org/xml/$ver/rng/docbookxi.rng" \
+          "../../share/xml/docbook/schema/rng/$ver/docbookxi.rng" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://www.oasis-open.org/docbook/xml/$ver/rng/docbook.rnc" \
+          "../../share/xml/docbook/schema/rng/$ver/docbook.rnc" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://www.oasis-open.org/docbook/xml/$ver/rng/docbook.rnc" \
+          "../../share/xml/docbook/schema/rng/$ver/docbook.rnc" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://docbook.org/xml/$ver/rng/docbook.rnc" \
+          "../../share/xml/docbook/schema/rng/$ver/docbook.rnc" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://docbook.org/xml/$ver/rng/docbook.rnc" \
+          "../../share/xml/docbook/schema/rng/$ver/docbook.rnc" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://www.oasis-open.org/docbook/xml/$ver/rng/docbookxi.rnc" \
+          "../../share/xml/docbook/schema/rng/$ver/docbookxi.rnc" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://www.oasis-open.org/docbook/xml/$ver/rng/docbookxi.rnc" \
+          "../../share/xml/docbook/schema/rng/$ver/docbookxi.rnc" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://docbook.org/xml/$ver/rng/docbookxi.rnc" \
+          "../../share/xml/docbook/schema/rng/$ver/docbookxi.rnc" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://docbook.org/xml/$ver/rng/docbookxi.rnc" \
+          "../../share/xml/docbook/schema/rng/$ver/docbookxi.rnc" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+
+      # xsd dir
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://www.oasis-open.org/docbook/xml/$ver/xsd/docbook.xsd" \
+          "../../share/xml/docbook/schema/xsd/$ver/docbook.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://www.oasis-open.org/docbook/xml/$ver/xsd/docbook.xsd" \
+          "../../share/xml/docbook/schema/xsd/$ver/docbook.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://docbook.org/xml/$ver/xsd/docbook.xsd" \
+          "../../share/xml/docbook/schema/xsd/$ver/docbook.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://docbook.org/xml/$ver/xsd/docbook.xsd" \
+          "../../share/xml/docbook/schema/xsd/$ver/docbook.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://www.oasis-open.org/docbook/xml/$ver/xsd/docbookxi.xsd" \
+          "../../share/xml/docbook/schema/xsd/$ver/docbookxi.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://www.oasis-open.org/docbook/xml/$ver/xsd/docbookxi.xsd" \
+          "../../share/xml/docbook/schema/xsd/$ver/docbookxi.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://docbook.org/xml/$ver/xsd/docbookxi.xsd" \
+          "../../share/xml/docbook/schema/xsd/$ver/docbookxi.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://docbook.org/xml/$ver/xsd/docbookxi.xsd" \
+          "../../share/xml/docbook/schema/xsd/$ver/docbookxi.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://www.oasis-open.org/docbook/xml/$ver/xsd/xi.xsd" \
+          "../../share/xml/docbook/schema/xsd/$ver/xi.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://www.oasis-open.org/docbook/xml/$ver/xsd/xi.xsd" \
+          "../../share/xml/docbook/schema/xsd$/$ver/xi.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://docbook.org/xml/$ver/xsd/xi.xsd" \
+          "../../share/xml/docbook/schema/xsd/$ver/xi.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://docbook.org/xml/$ver/xsd/xi.xsd" \
+          "../../share/xml/docbook/schema/$ver/xsd/xi.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://www.oasis-open.org/docbook/xml/$ver/xsd/xlink.xsd" \
+          "../../share/xml/docbook/schema/xsd/$ver/xlink.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://www.oasis-open.org/docbook/xml/$ver/xsd/xlink.xsd" \
+          "../../share/xml/docbook/schema/xsd/$ver/xlink.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://docbook.org/xml/$ver/xsd/xlink.xsd" \
+          "../../share/xml/docbook/schema/xsd/$ver/xlink.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://docbook.org/xml/$ver/xsd/xlink.xsd" \
+          "../../share/xml/docbook/schema/xsd/$ver/xlink.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://www.oasis-open.org/docbook/xml/$ver/xsd/xml.xsd" \
+          "../../share/xml/docbook/schema/xsd/$ver/xml.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://www.oasis-open.org/docbook/xml/$ver/xsd/xml.xsd" \
+          "../../share/xml/docbook/schema/xsd/$ver/xml.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://docbook.org/xml/$ver/xsd/xml.xsd" \
+          "../../share/xml/docbook/schema/xsd/$ver/xml.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://docbook.org/xml/$ver/xsd/xml.xsd" \
+          "../../share/xml/docbook/schema/xsd/$ver/xml.xsd" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+
+      ##sch dir
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://www.oasis-open.org/docbook/xml/$ver/sch/docbook.sch" \
+          "../../share/xml/docbook/schema/sch/$ver/docbook.sch" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://www.oasis-open.org/docbook/xml/sch/$ver/docbook.sch" \
+          "../../share/xml/docbook/schema/sch/$ver/docbook.sch" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://docbook.org/xml/$ver/sch/docbook.sch" \
+          "../../share/xml/docbook/schema/sch/$ver/docbook.sch" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://docbook.org/xml/$ver/sch/docbook.sch" \
+          "../../share/xml/docbook/schema/sch/$ver/docbook.sch" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+
+      # 5.0 dir
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://www.oasis-open.org/docbook/xml/$ver/docbook.nvdl" \
+          "../../share/xml/docbook/schema/$ver/docbook.nvdl" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://www.oasis-open.org/docbook/xml/$ver/docbook.nvdl" \
+          "../../share/xml/docbook/schema/$ver/docbook.nvdl" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+          "http://docbook.org/xml/$ver/docbook.nvdl" \
+          "../../share/xml/docbook/schema/$ver/docbook.nvdl" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "http://docbook.org/xml/$ver/docbook.nvdl" \
+          "../../share/xml/docbook/schema/$ver/docbook.nvdl" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+
+   popd
+
+  done
+
+#//DOCBOOK 5.1
+  mkdir -p "$pkgdir${MINGW_PREFIX}/etc/xml"
+  ${MINGW_PREFIX}/bin/xmlcatalog --noout --create "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog51}"
+
+  for ver in ${_vers_51x[@]}; do
+    pushd docbook-xml-$ver
+    # RNG
+      mkdir -p $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver/ \
+               $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/sch/$ver/ \
+               $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/$ver/ \
+               $pkgdir${MINGW_PREFIX}/share/doc/docbook5.1-schemas \
+               $pkgdir${MINGW_PREFIX}/share/xml/docbook/stylesheet/docbook-$ver/ \
+               $pkgdir${MINGW_PREFIX}/bin
+
+      cp -r docbook-v5.1-os.* $pkgdir${MINGW_PREFIX}/share/doc/docbook5.1-schemas
+      cp  schemas/catalog.xml $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/catalog-docbook-$ver.xml
+      cp -r schemas/rng/* $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver
+      cp -r schemas/sch/* $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/sch/$ver/
+      cp -r tools/db4-upgrade.xsl $pkgdir${MINGW_PREFIX}/share/xml/docbook/stylesheet/docbook-$ver/
+      cp -r tools/db4-entities.pl $pkgdir${MINGW_PREFIX}/bin
+      cp -r schemas/docbook.nvdl $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/$ver/docbook.nvdl
+
+    ${MINGW_PREFIX}/bin/xmlcatalog --create --noout "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog51}"
+
+    msg2 "RNG ${ver}"
+    ${MINGW_PREFIX}/bin/xmlcatalog -v --noout --add "uri" \
+      "http://www.oasis-open.org/docbook/xml/${ver}/rng/docbook.rng" \
+      "../../share/xml/docbook/schema/rng/${ver}/docbook.rng" \
+      "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog51}"
+    ${MINGW_PREFIX}/bin/xmlcatalog -v --noout --add "uri" \
+      "http://docbook.org/xml/${ver}/rng/docbook.rng" \
+      "../../share/xml/docbook/schema/rng/${ver}/docbook.rng" \
+      "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog51}"
+    # RNG+XInclude
+   msg2 "RNG+XInclude ${ver}"
+    ${MINGW_PREFIX}/bin/xmlcatalog -v --noout --add "uri" \
+      "http://www.oasis-open.org/docbook/xml/${ver}/rng/docbookxi.rng" \
+      "../../share/xml/docbook/schema/rng/${ver}/docbookxi.rng" \
+      "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog51}"
+    ${MINGW_PREFIX}/bin/xmlcatalog -v --noout --add "uri" \
+      "http://docbook.org/xml/${ver}/rng/docbookxi.rng" \
+      "../../share/xml/docbook/schema/rng/${ver}/docbookxi.rng" \
+      "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog51}"
+    # RNC
+    msg2 "RNC ${ver}"
+    ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+      "http://www.oasis-open.org/docbook/xml/${ver}/rnc/docbook.rnc" \
+      "../../share/xml/docbook/schema/rng/${ver}/docbook.rnc" \
+      "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog51}"
+    ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+      "http://docbook.org/xml/${ver}/rng/docbook.rnc" \
+      "../../share/xml/docbook/schema/rng/${ver}/docbook.rnc" \
+      "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog51}"
+    # RNC+XInclude
+    ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+      "http://www.oasis-open.org/docbook/xml/${ver}/rnc/docbookxi.rnc" \
+      "../../share/xml/docbook/schema/rng/${ver}/docbookxi.rnc" \
+      "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog51}"
+    ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+      "http://docbook.org/xml/${ver}/rng/docbookxi.rnc" \
+      "../../share/xml/docbook/schema/rng/${ver}/docbookxi.rnc" \
+      "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog51}"
+    # Schematron
+    ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+      "http://www.oasis-open.org/docbook/xml/${ver}/sch/docbook.sch" \
+      "../../share/xml/docbook/schema/sch/${ver}/docbook.sch" \
+      "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog51}"
+    ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+      "http://docbook.org/xml/${ver}/sch/docbook.sch" \
+      "../../share/xml/docbook/schema/sch/${ver}/docbook.sch" \
+      "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog51}"
+
+    # ---------------------
+    # Build XML catalog files for each Schema
+    for s in schemas/rng schemas/sch; do
+      _schema_catalog=${s}/catalog.xml
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --create ${_schema_catalog}
+      case $s in
+        sch)
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+            "http://docbook.org/xml/${ver}/${s}/docbook.${s}" \
+            "docbook.${s}" ${_schema_catalog}
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+            "http://www.oasis-open.org/docbook/xml/${ver}/${s}/docbook.${s}" \
+            "docbook.${s}" ${_schema_catalog}
+          ;;
+        rng)
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+            "http://docbook.org/xml/${ver}/${s}/docbook.${s}" \
+            "docbook.${s}" ${_schema_catalog}
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+            "http://www.oasis-open.org/docbook/xml/${ver}/${s}/docbook.${s}" \
+            "docbook.${s}" ${_schema_catalog}
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+            "http://docbook.org/xml/${ver}/${s}/docbookxi.${s}" \
+            "docbookxi.${s}" ${_schema_catalog}
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+            "http://www.oasis-open.org/docbook/xml/${ver}/${s}/docbookxi.${s}" \
+            "docbookxi.${s}" ${_schema_catalog}
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+            "http://docbook.org/xml/${ver}/${s}/docbook.rnc" \
+            "docbook.rnc" ${_schema_catalog}
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+            "http://www.oasis-open.org/docbook/xml/${ver}/${s}/docbook.rnc" \
+            "docbook.rnc" ${_schema_catalog}
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+            "http://docbook.org/xml/${ver}/${s}/docbookxi.rnc" \
+            "docbookxi.rnc" ${_schema_catalog}
+          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+            "http://www.oasis-open.org/docbook/xml/${ver}/${s}/docbookxi.rnc" \
+            "docbookxi.rnc" ${_schema_catalog}
+          ;;
+      esac
+    done
+    popd
+  done
+
+#//DOCBOOK 5.0, 5.0.1, and 5.1 entries
+
+  local PREFIX_WIN="$(cygpath -m ${MINGW_PREFIX})"
+  sed -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" \
+      -i "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}" \
+      -i "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog51}" 
+
+#Install bit
+  msg2 "Install bit"
+  _docbook5dir="${pkgdir}${_datadir}/xml/docbook"
+ # docbook-5.0
+
+  for ver in ${_vers_50x[@]}; do
+    pushd "$srcdir/docbook-xml-${ver}/docbook-${ver}"
+      for type in dtd rng sch xsd; do
+        mkdir -p ${_docbook5dir}/schema/${type}/${ver}
+        install -m644 ${type}/* ${_docbook5dir}/schema/${type}/${ver}
+      done
+    popd
+  done
+
+  # docbook-5.1
+
+  for ver in ${_vers_51x[@]}; do
+    pushd "$srcdir/docbook-xml-${ver}/schemas"
+      for type in rng sch; do
+        mkdir -p ${_docbook5dir}/schema/${type}/${ver}
+        install -m644 ${type}/* ${_docbook5dir}/schema/${type}/${ver}
+      done
+    popd
+  done
+
+  mkdir -p "$pkgdir/${MINGW_PREFIX}/bin"
+  install -m755 "$srcdir/docbook-xml-${ver}/tools/db4-entities.pl" "$pkgdir${MINGW_PREFIX}/bin"
+  mkdir -p "${_docbook5dir}/stylesheet/docbook5"
+  install -m644 "$srcdir/docbook-xml-${ver}/tools/db4-upgrade.xsl" "${_docbook5dir}/stylesheet/docbook5/"
+}

--- a/mingw-w64-docbook5-xml/PKGBUILD
+++ b/mingw-w64-docbook5-xml/PKGBUILD
@@ -28,7 +28,7 @@ sha512sums=('a245796881762cf001f0d32b7c87315cba0454750d6b4178e4546357e320e2ab602
             'df85ab724d3205086dfbab40419e268d5bf183b028ed8c58d30068bdc82c1e10fc05bf167d5efcdbeb6b6c9c8dbf96ca4f979fcc6da2e2fea99cbf1bd8aaad30'
             'b55f8eda4dcff9d4ebd31876bc33c244ef3884afc167da1425531266963ba64000fbe619ec7c049ae65c0aab864a5a7228caef08b53f546e2686296d97190873')
 install=docbook5-xml-${CARCH}.install
-_datadir=${MINGW_PREFIX}/share
+_datadir=$(cygpath -m ${MINGW_PREFIX}/share)
 _catalog50=docbook-5.0.xml
 _catalog51=docbook-5.1.xml  
 
@@ -48,14 +48,18 @@ build() {
 
 package() {
   local ver xml
+  local _cat
+  local PREFIX_WIN="$(cygpath -m ${MINGW_PREFIX})"
 
   _docbook5dir="${pkgdir}${_datadir}/xml/docbook-xml"
 
   mkdir -p "$pkgdir${MINGW_PREFIX}/etc/xml"
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --create "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+ 
 	
   for ver in ${_vers_50x[@]}; do
     pushd docbook-xml-$ver
+      _cat=docbook-$ver.xml
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --create "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
       # mkdir -p "$pkgdir${MINGW_PREFIX}/share/xml/docbook/xml-dtd-$ver"
       mkdir -p $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/dtd/$ver \
                $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver/ \
@@ -76,233 +80,233 @@ package() {
       cp -r docbook-$ver/tools/db4-entities.pl $pkgdir${MINGW_PREFIX}/bin
       cp -r docbook-$ver/docbook.nvdl $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/$ver/docbook.nvdl
 
-      ${MINGW_PREFIX}/bin/xmlcatalog --create --noout "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --create --noout "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "public" \
           "-//OASIS//DTD DocBook XML V$ver//EN" \
           "http://www.oasis-open.org/docbook/xml/$ver/docbookx.dtd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
       ## dtd dir
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
           "http://www.oasis-open.org/docbook/xml/$ver/dtd/docbook.dtd" \
           "../../share/xml/docbook/schema/dtd/$ver/docbook.dtd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
           "http://www.oasis-open.org/docbook/xml/$ver/dtd/docbook.dtd" \
           "../../share/xml/docbook/schema/dtd/$ver/docbook.dtd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
           "http://docbook.org/xml/$ver/dtd/docbook.dtd" \
           "../../share/xml/docbook/schema/dtd/$ver/docbook.dtd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
           "http://docbook.org/xml/$ver/dtd/docbook.dtd" \
           "../../share/xml/docbook/schema/dtd/$ver/docbook.dtd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
       #rng dir
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
           "http://www.oasis-open.org/docbook/xml/$ver/rng/docbook.rng" \
           "../../share/xml/docbook/schema/rng/$ver/docbook.rng" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
           "http://www.oasis-open.org/docbook/xml/$ver/rng/docbook.rng" \
           "../../share/xml/docbook/schema/rng/$ver/docbook.rng" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
           "http://docbook.org/xml/$ver/rng/docbook.rng" \
           "../../share/xml/docbook/schema/rng/$ver/docbook.rng" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
           "http://docbook.org/xml/$ver/rng/docbook.rng" \
           "../../share/xml/docbook/schema/rng/$ver/docbook.rng" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
           "http://www.oasis-open.org/docbook/xml/$ver/rng/docbookxi.rng" \
           "../../share/xml/docbook/schema/rng/$ver/docbookxi.rng" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
           "http://www.oasis-open.org/docbook/xml/$ver/rng/docbookxi.rng" \
           "../../share/xml/docbook/schema/rng/$ver/docbookxi.rng" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
           "http://docbook.org/xml/$ver/rng/docbookxi.rng" \
           "../../share/xml/docbook/schema/rng/$ver/docbookxi.rng" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
           "http://docbook.org/xml/$ver/rng/docbookxi.rng" \
           "../../share/xml/docbook/schema/rng/$ver/docbookxi.rng" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
           "http://www.oasis-open.org/docbook/xml/$ver/rng/docbook.rnc" \
           "../../share/xml/docbook/schema/rng/$ver/docbook.rnc" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
           "http://www.oasis-open.org/docbook/xml/$ver/rng/docbook.rnc" \
           "../../share/xml/docbook/schema/rng/$ver/docbook.rnc" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
           "http://docbook.org/xml/$ver/rng/docbook.rnc" \
           "../../share/xml/docbook/schema/rng/$ver/docbook.rnc" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
           "http://docbook.org/xml/$ver/rng/docbook.rnc" \
           "../../share/xml/docbook/schema/rng/$ver/docbook.rnc" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
           "http://www.oasis-open.org/docbook/xml/$ver/rng/docbookxi.rnc" \
           "../../share/xml/docbook/schema/rng/$ver/docbookxi.rnc" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
           "http://www.oasis-open.org/docbook/xml/$ver/rng/docbookxi.rnc" \
           "../../share/xml/docbook/schema/rng/$ver/docbookxi.rnc" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
           "http://docbook.org/xml/$ver/rng/docbookxi.rnc" \
           "../../share/xml/docbook/schema/rng/$ver/docbookxi.rnc" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
           "http://docbook.org/xml/$ver/rng/docbookxi.rnc" \
           "../../share/xml/docbook/schema/rng/$ver/docbookxi.rnc" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
       # xsd dir
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
           "http://www.oasis-open.org/docbook/xml/$ver/xsd/docbook.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/docbook.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
           "http://www.oasis-open.org/docbook/xml/$ver/xsd/docbook.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/docbook.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
           "http://docbook.org/xml/$ver/xsd/docbook.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/docbook.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
           "http://docbook.org/xml/$ver/xsd/docbook.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/docbook.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
           "http://www.oasis-open.org/docbook/xml/$ver/xsd/docbookxi.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/docbookxi.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
           "http://www.oasis-open.org/docbook/xml/$ver/xsd/docbookxi.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/docbookxi.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
           "http://docbook.org/xml/$ver/xsd/docbookxi.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/docbookxi.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
           "http://docbook.org/xml/$ver/xsd/docbookxi.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/docbookxi.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
           "http://www.oasis-open.org/docbook/xml/$ver/xsd/xi.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/xi.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
           "http://www.oasis-open.org/docbook/xml/$ver/xsd/xi.xsd" \
           "../../share/xml/docbook/schema/xsd$/$ver/xi.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
           "http://docbook.org/xml/$ver/xsd/xi.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/xi.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
           "http://docbook.org/xml/$ver/xsd/xi.xsd" \
           "../../share/xml/docbook/schema/$ver/xsd/xi.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
           "http://www.oasis-open.org/docbook/xml/$ver/xsd/xlink.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/xlink.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
           "http://www.oasis-open.org/docbook/xml/$ver/xsd/xlink.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/xlink.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
           "http://docbook.org/xml/$ver/xsd/xlink.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/xlink.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
           "http://docbook.org/xml/$ver/xsd/xlink.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/xlink.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
           "http://www.oasis-open.org/docbook/xml/$ver/xsd/xml.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/xml.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
           "http://www.oasis-open.org/docbook/xml/$ver/xsd/xml.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/xml.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
           "http://docbook.org/xml/$ver/xsd/xml.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/xml.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
           "http://docbook.org/xml/$ver/xsd/xml.xsd" \
           "../../share/xml/docbook/schema/xsd/$ver/xml.xsd" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
       ##sch dir
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
           "http://www.oasis-open.org/docbook/xml/$ver/sch/docbook.sch" \
           "../../share/xml/docbook/schema/sch/$ver/docbook.sch" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
           "http://www.oasis-open.org/docbook/xml/sch/$ver/docbook.sch" \
           "../../share/xml/docbook/schema/sch/$ver/docbook.sch" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
           "http://docbook.org/xml/$ver/sch/docbook.sch" \
           "../../share/xml/docbook/schema/sch/$ver/docbook.sch" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
           "http://docbook.org/xml/$ver/sch/docbook.sch" \
           "../../share/xml/docbook/schema/sch/$ver/docbook.sch" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
       # 5.0 dir
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
           "http://www.oasis-open.org/docbook/xml/$ver/docbook.nvdl" \
           "../../share/xml/docbook/schema/$ver/docbook.nvdl" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
           "http://www.oasis-open.org/docbook/xml/$ver/docbook.nvdl" \
           "../../share/xml/docbook/schema/$ver/docbook.nvdl" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteSystem" \
           "http://docbook.org/xml/$ver/docbook.nvdl" \
           "../../share/xml/docbook/schema/$ver/docbook.nvdl" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "rewriteURI" \
           "http://docbook.org/xml/$ver/docbook.nvdl" \
           "../../share/xml/docbook/schema/$ver/docbook.nvdl" \
-          "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}"
+          "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
    popd
 
@@ -310,10 +314,11 @@ package() {
 
 #//DOCBOOK 5.1
   mkdir -p "$pkgdir${MINGW_PREFIX}/etc/xml"
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --create "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog51}"
 
   for ver in ${_vers_51x[@]}; do
     pushd docbook-xml-$ver
+    _cat=docbook-$ver.xml
+    ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --create "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
     # RNG
       mkdir -p $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/rng/$ver/ \
                $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/sch/$ver/ \
@@ -330,111 +335,108 @@ package() {
       cp -r tools/db4-entities.pl $pkgdir${MINGW_PREFIX}/bin
       cp -r schemas/docbook.nvdl $pkgdir${MINGW_PREFIX}/share/xml/docbook/schema/$ver/docbook.nvdl
 
-    ${MINGW_PREFIX}/bin/xmlcatalog --create --noout "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog51}"
+    ${MINGW_PREFIX}/bin/xmlcatalog -v  --create --noout "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
     msg2 "RNG ${ver}"
     ${MINGW_PREFIX}/bin/xmlcatalog -v --noout --add "uri" \
       "http://www.oasis-open.org/docbook/xml/${ver}/rng/docbook.rng" \
       "../../share/xml/docbook/schema/rng/${ver}/docbook.rng" \
-      "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog51}"
+      "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
     ${MINGW_PREFIX}/bin/xmlcatalog -v --noout --add "uri" \
       "http://docbook.org/xml/${ver}/rng/docbook.rng" \
       "../../share/xml/docbook/schema/rng/${ver}/docbook.rng" \
-      "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog51}"
+      "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
     # RNG+XInclude
    msg2 "RNG+XInclude ${ver}"
     ${MINGW_PREFIX}/bin/xmlcatalog -v --noout --add "uri" \
       "http://www.oasis-open.org/docbook/xml/${ver}/rng/docbookxi.rng" \
       "../../share/xml/docbook/schema/rng/${ver}/docbookxi.rng" \
-      "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog51}"
+      "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
     ${MINGW_PREFIX}/bin/xmlcatalog -v --noout --add "uri" \
       "http://docbook.org/xml/${ver}/rng/docbookxi.rng" \
       "../../share/xml/docbook/schema/rng/${ver}/docbookxi.rng" \
-      "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog51}"
+      "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
     # RNC
     msg2 "RNC ${ver}"
-    ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+    ${MINGW_PREFIX}/bin/xmlcatalog -v --noout --add "uri" \
       "http://www.oasis-open.org/docbook/xml/${ver}/rnc/docbook.rnc" \
       "../../share/xml/docbook/schema/rng/${ver}/docbook.rnc" \
-      "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog51}"
-    ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+      "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+    ${MINGW_PREFIX}/bin/xmlcatalog -v --noout --add "uri" \
       "http://docbook.org/xml/${ver}/rng/docbook.rnc" \
       "../../share/xml/docbook/schema/rng/${ver}/docbook.rnc" \
-      "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog51}"
+      "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
     # RNC+XInclude
-    ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+    ${MINGW_PREFIX}/bin/xmlcatalog -v --noout --add "uri" \
       "http://www.oasis-open.org/docbook/xml/${ver}/rnc/docbookxi.rnc" \
       "../../share/xml/docbook/schema/rng/${ver}/docbookxi.rnc" \
-      "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog51}"
-    ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+      "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+    ${MINGW_PREFIX}/bin/xmlcatalog -v --noout --add "uri" \
       "http://docbook.org/xml/${ver}/rng/docbookxi.rnc" \
       "../../share/xml/docbook/schema/rng/${ver}/docbookxi.rnc" \
-      "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog51}"
+      "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
     # Schematron
-    ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+    ${MINGW_PREFIX}/bin/xmlcatalog -v --noout --add "uri" \
       "http://www.oasis-open.org/docbook/xml/${ver}/sch/docbook.sch" \
       "../../share/xml/docbook/schema/sch/${ver}/docbook.sch" \
-      "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog51}"
-    ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+      "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+    ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "uri" \
       "http://docbook.org/xml/${ver}/sch/docbook.sch" \
       "../../share/xml/docbook/schema/sch/${ver}/docbook.sch" \
-      "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog51}"
+      "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
 
     # ---------------------
     # Build XML catalog files for each Schema
     for s in schemas/rng schemas/sch; do
       _schema_catalog=${s}/catalog.xml
-      ${MINGW_PREFIX}/bin/xmlcatalog --noout --create ${_schema_catalog}
+      ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --create ${_schema_catalog}
       case $s in
         sch)
-          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+          ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "uri" \
             "http://docbook.org/xml/${ver}/${s}/docbook.${s}" \
             "docbook.${s}" ${_schema_catalog}
-          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+          ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "uri" \
             "http://www.oasis-open.org/docbook/xml/${ver}/${s}/docbook.${s}" \
             "docbook.${s}" ${_schema_catalog}
           ;;
         rng)
-          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+          ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "uri" \
             "http://docbook.org/xml/${ver}/${s}/docbook.${s}" \
             "docbook.${s}" ${_schema_catalog}
-          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+          ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "uri" \
             "http://www.oasis-open.org/docbook/xml/${ver}/${s}/docbook.${s}" \
             "docbook.${s}" ${_schema_catalog}
-          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+          ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "uri" \
             "http://docbook.org/xml/${ver}/${s}/docbookxi.${s}" \
             "docbookxi.${s}" ${_schema_catalog}
-          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+          ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "uri" \
             "http://www.oasis-open.org/docbook/xml/${ver}/${s}/docbookxi.${s}" \
             "docbookxi.${s}" ${_schema_catalog}
-          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+          ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "uri" \
             "http://docbook.org/xml/${ver}/${s}/docbook.rnc" \
             "docbook.rnc" ${_schema_catalog}
-          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+          ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "uri" \
             "http://www.oasis-open.org/docbook/xml/${ver}/${s}/docbook.rnc" \
             "docbook.rnc" ${_schema_catalog}
-          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+          ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "uri" \
             "http://docbook.org/xml/${ver}/${s}/docbookxi.rnc" \
             "docbookxi.rnc" ${_schema_catalog}
-          ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "uri" \
+          ${MINGW_PREFIX}/bin/xmlcatalog -v  --noout --add "uri" \
             "http://www.oasis-open.org/docbook/xml/${ver}/${s}/docbookxi.rnc" \
             "docbookxi.rnc" ${_schema_catalog}
           ;;
       esac
     done
     popd
+    sed -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" \
+      -i "$pkgdir${MINGW_PREFIX}/etc/xml/${_cat}"
+
   done
 
-#//DOCBOOK 5.0, 5.0.1, and 5.1 entries
-
-  local PREFIX_WIN="$(cygpath -m ${MINGW_PREFIX})"
-  sed -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" \
-      -i "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog50}" \
-      -i "$pkgdir${MINGW_PREFIX}/etc/xml/${_catalog51}" 
 
 #Install bit
   msg2 "Install bit"
-  _docbook5dir="${pkgdir}${_datadir}/xml/docbook"
+  _docbook5dir="${pkgdir}${MINGW_PREFIX}/etc/xml/docbook"
  # docbook-5.0
 
   for ver in ${_vers_50x[@]}; do

--- a/mingw-w64-docbook5-xml/docbook5-xml-i686.install
+++ b/mingw-w64-docbook5-xml/docbook5-xml-i686.install
@@ -1,4 +1,5 @@
 MINGW_INSTALL=/mingw32
+_subcatalogdir=$(cygpath -m ${MINGW_INSTALL}/etc/xml/)
 _rootcatalog=$(cygpath -m ${MINGW_INSTALL}/etc/xml/catalog)
 # export MSYS2_ARG_CONV_EXCL="-//OASIS"
 
@@ -6,34 +7,13 @@ post_install() {
   if [ -e ${MINGW_XML_CATALOG}/catalog.preserve ]; then
     mv ${MINGW_XML_CATALOG}/catalog.preserve ${MINGW_XML_CATALOG}/catalog
   elif [ ! -e ${MINGW_INSTALL}/etc/xml/catalog ]; then
-    ${MINGW_INSTALL}/bin/xmlcatalog --noout --create ${MINGW_XML_CATALOG}/catalog
+    ${MINGW_PREFIX}/bin/xmlcatalog --noout --create ${MINGW_XML_CATALOG}/catalog
   fi
 
   for v in 5.{0,0.1,1}; do
-      ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegatePublic" \
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "delegatePublic" \
         "-//OASIS//DTD DocBook XML ${v}//EN" \
-        "file://${_datadir}/xml/docbook/schema/dtd/${v}/catalog.xml" \
-        ${_rootcatalog}
-      false
-      ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateSystem" \
-        "http://docbook.org/xml/${v}/dtd/" \
-        "file://${_datadir}/xml/docbook/schema/dtd/${v}/catalog.xml" \
-        ${_rootcatalog}
-      ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateURI" \
-        "http://docbook.org/xml/${v}/dtd/" \
-        "file://${_datadir}/xml/docbook/schema/dtd/${v}/catalog.xml" \
-        ${_rootcatalog}
-      ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateURI" \
-        "http://docbook.org/xml/${v}/rng/"  \
-        "file://${_datadir}/xml/docbook/schema/rng/${v}/catalog.xml" \
-        ${_rootcatalog}
-      ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateURI" \
-        "http://docbook.org/xml/${v}/sch/"  \
-        "file://${_datadir}/xml/docbook/schema/sch/${v}/catalog.xml" \
-        ${_rootcatalog}
-      ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateURI" \
-        "http://docbook.org/xml/${v}/xsd/"  \
-        "file://${_datadir}/xml/docbook/schema/xsd/${v}/catalog.xml" \
+        "${_subcatalogdir}/docbook-${v}.xml" \
         ${_rootcatalog}
   done
 }
@@ -42,7 +22,8 @@ post_install() {
 # arg 2:  the old package version
 pre_upgrade() {
   if [ $(vercmp $2 4.5) -lt 0 ]; then
-    ${MINGW_INSTALL}/bin/xmlcatalog --del "${MINGW_XML_CATALOG}/docbook-5.0.xml" ${MINGW_XML_CATALOG}/catalog > ${MINGW_XML_CATALOG}/catalog.preserve
+    ${MINGW_PREFIX}/bin/xmlcatalog --del "${MINGW_XML_CATALOG}/docbook-5.0.xml" \
+    ${MINGW_XML_CATALOG}/catalog > ${MINGW_XML_CATALOG}/catalog.preserve
   fi
 }
 
@@ -55,17 +36,8 @@ post_upgrade() {
 
 post_remove() {
   for v in 5.{0,0.1,1}; do
-    ${MINGW_INSTALL}/bin/xmlcatalog --noout --del \
-       "file://${_datadir}/xml/docbook/schema/dtd/${v}/catalog.xml" \
-       ${_rootcatalog}
-    ${MINGW_INSTALL}/bin/xmlcatalog --noout --del \
-       "file://${_datadir}/xml/docbook/schema/rng/${v}/catalog.xml" \
-       ${_rootcatalog}
-    ${MINGW_INSTALL}/bin/xmlcatalog --noout --del \
-       "file://${_datadir}/xml/docbook/schema/sch/${v}/catalog.xml" \
-       ${_rootcatalog}
-    ${MINGW_INSTALL}/bin/xmlcatalog --noout --del \
-       "file://${_datadir}/xml/docbook/schema/xsd/${v}/catalog.xml" \
+    ${MINGW_PREFIX}/bin/xmlcatalog --noout --del \
+       "file://${_subcatalogdir}/docbook-${v}.xml" \
        ${_rootcatalog}
   done
 }

--- a/mingw-w64-docbook5-xml/docbook5-xml-i686.install
+++ b/mingw-w64-docbook5-xml/docbook5-xml-i686.install
@@ -1,0 +1,71 @@
+MINGW_INSTALL=/mingw32
+_rootcatalog=$(cygpath -m ${MINGW_INSTALL}/etc/xml/catalog)
+# export MSYS2_ARG_CONV_EXCL="-//OASIS"
+
+post_install() {
+  if [ -e ${MINGW_XML_CATALOG}/catalog.preserve ]; then
+    mv ${MINGW_XML_CATALOG}/catalog.preserve ${MINGW_XML_CATALOG}/catalog
+  elif [ ! -e ${MINGW_INSTALL}/etc/xml/catalog ]; then
+    ${MINGW_INSTALL}/bin/xmlcatalog --noout --create ${MINGW_XML_CATALOG}/catalog
+  fi
+
+  for v in 5.{0,0.1,1}; do
+      ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegatePublic" \
+        "-//OASIS//DTD DocBook XML ${v}//EN" \
+        "file://${_datadir}/xml/docbook/schema/dtd/${v}/catalog.xml" \
+        ${_rootcatalog}
+      false
+      ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateSystem" \
+        "http://docbook.org/xml/${v}/dtd/" \
+        "file://${_datadir}/xml/docbook/schema/dtd/${v}/catalog.xml" \
+        ${_rootcatalog}
+      ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateURI" \
+        "http://docbook.org/xml/${v}/dtd/" \
+        "file://${_datadir}/xml/docbook/schema/dtd/${v}/catalog.xml" \
+        ${_rootcatalog}
+      ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateURI" \
+        "http://docbook.org/xml/${v}/rng/"  \
+        "file://${_datadir}/xml/docbook/schema/rng/${v}/catalog.xml" \
+        ${_rootcatalog}
+      ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateURI" \
+        "http://docbook.org/xml/${v}/sch/"  \
+        "file://${_datadir}/xml/docbook/schema/sch/${v}/catalog.xml" \
+        ${_rootcatalog}
+      ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateURI" \
+        "http://docbook.org/xml/${v}/xsd/"  \
+        "file://${_datadir}/xml/docbook/schema/xsd/${v}/catalog.xml" \
+        ${_rootcatalog}
+  done
+}
+
+# arg 1:  the new package version
+# arg 2:  the old package version
+pre_upgrade() {
+  if [ $(vercmp $2 4.5) -lt 0 ]; then
+    ${MINGW_INSTALL}/bin/xmlcatalog --del "${MINGW_XML_CATALOG}/docbook-5.0.xml" ${MINGW_XML_CATALOG}/catalog > ${MINGW_XML_CATALOG}/catalog.preserve
+  fi
+}
+
+post_upgrade() {
+  if [ $(vercmp $2 4.5) -ge 0 ]; then
+    post_remove
+  fi
+  post_install
+}
+
+post_remove() {
+  for v in 5.{0,0.1,1}; do
+    ${MINGW_INSTALL}/bin/xmlcatalog --noout --del \
+       "file://${_datadir}/xml/docbook/schema/dtd/${v}/catalog.xml" \
+       ${_rootcatalog}
+    ${MINGW_INSTALL}/bin/xmlcatalog --noout --del \
+       "file://${_datadir}/xml/docbook/schema/rng/${v}/catalog.xml" \
+       ${_rootcatalog}
+    ${MINGW_INSTALL}/bin/xmlcatalog --noout --del \
+       "file://${_datadir}/xml/docbook/schema/sch/${v}/catalog.xml" \
+       ${_rootcatalog}
+    ${MINGW_INSTALL}/bin/xmlcatalog --noout --del \
+       "file://${_datadir}/xml/docbook/schema/xsd/${v}/catalog.xml" \
+       ${_rootcatalog}
+  done
+}

--- a/mingw-w64-docbook5-xml/docbook5-xml-i686.install
+++ b/mingw-w64-docbook5-xml/docbook5-xml-i686.install
@@ -1,5 +1,4 @@
 MINGW_INSTALL=/mingw32
-_subcatalogdir=$(cygpath -m ${MINGW_INSTALL}/etc/xml/)
 _rootcatalog=$(cygpath -m ${MINGW_INSTALL}/etc/xml/catalog)
 # export MSYS2_ARG_CONV_EXCL="-//OASIS"
 
@@ -13,7 +12,7 @@ post_install() {
   for v in 5.{0,0.1,1}; do
       ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "delegatePublic" \
         "-//OASIS//DTD DocBook XML ${v}//EN" \
-        "${_subcatalogdir}/docbook-${v}.xml" \
+        "./docbook-${v}.xml" \
         ${_rootcatalog}
   done
 }
@@ -37,7 +36,7 @@ post_upgrade() {
 post_remove() {
   for v in 5.{0,0.1,1}; do
     ${MINGW_PREFIX}/bin/xmlcatalog --noout --del \
-       "file://${_subcatalogdir}/docbook-${v}.xml" \
+       "./docbook-${v}.xml" \
        ${_rootcatalog}
   done
 }

--- a/mingw-w64-docbook5-xml/docbook5-xml-x86_64.install
+++ b/mingw-w64-docbook5-xml/docbook5-xml-x86_64.install
@@ -1,0 +1,71 @@
+MINGW_INSTALL=/mingw64
+_rootcatalog=$(cygpath -m ${MINGW_INSTALL}/etc/xml/catalog)
+# export MSYS2_ARG_CONV_EXCL="-//OASIS"
+
+post_install() {
+  if [ -e ${MINGW_XML_CATALOG}/catalog.preserve ]; then
+    mv ${MINGW_XML_CATALOG}/catalog.preserve ${MINGW_XML_CATALOG}/catalog
+  elif [ ! -e ${MINGW_INSTALL}/etc/xml/catalog ]; then
+    ${MINGW_INSTALL}/bin/xmlcatalog --noout --create ${MINGW_XML_CATALOG}/catalog
+  fi
+
+  for v in 5.{0,0.1,1}; do
+      ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegatePublic" \
+        "-//OASIS//DTD DocBook XML ${v}//EN" \
+        "file://${_datadir}/xml/docbook/schema/dtd/${v}/catalog.xml" \
+        ${_rootcatalog}
+      false
+      ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateSystem" \
+        "http://docbook.org/xml/${v}/dtd/" \
+        "file://${_datadir}/xml/docbook/schema/dtd/${v}/catalog.xml" \
+        ${_rootcatalog}
+      ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateURI" \
+        "http://docbook.org/xml/${v}/dtd/" \
+        "file://${_datadir}/xml/docbook/schema/dtd/${v}/catalog.xml" \
+        ${_rootcatalog}
+      ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateURI" \
+        "http://docbook.org/xml/${v}/rng/"  \
+        "file://${_datadir}/xml/docbook/schema/rng/${v}/catalog.xml" \
+        ${_rootcatalog}
+      ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateURI" \
+        "http://docbook.org/xml/${v}/sch/"  \
+        "file://${_datadir}/xml/docbook/schema/sch/${v}/catalog.xml" \
+        ${_rootcatalog}
+      ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateURI" \
+        "http://docbook.org/xml/${v}/xsd/"  \
+        "file://${_datadir}/xml/docbook/schema/xsd/${v}/catalog.xml" \
+        ${_rootcatalog}
+  done
+}
+
+# arg 1:  the new package version
+# arg 2:  the old package version
+pre_upgrade() {
+  if [ $(vercmp $2 4.5) -lt 0 ]; then
+    ${MINGW_INSTALL}/bin/xmlcatalog --del "${MINGW_XML_CATALOG}/docbook-5.0.xml" ${MINGW_XML_CATALOG}/catalog > ${MINGW_XML_CATALOG}/catalog.preserve
+  fi
+}
+
+post_upgrade() {
+  if [ $(vercmp $2 4.5) -ge 0 ]; then
+    post_remove
+  fi
+  post_install
+}
+
+post_remove() {
+  for v in 5.{0,0.1,1}; do
+    ${MINGW_INSTALL}/bin/xmlcatalog --noout --del \
+       "file://${_datadir}/xml/docbook/schema/dtd/${v}/catalog.xml" \
+       ${_rootcatalog}
+    ${MINGW_INSTALL}/bin/xmlcatalog --noout --del \
+       "file://${_datadir}/xml/docbook/schema/rng/${v}/catalog.xml" \
+       ${_rootcatalog}
+    ${MINGW_INSTALL}/bin/xmlcatalog --noout --del \
+       "file://${_datadir}/xml/docbook/schema/sch/${v}/catalog.xml" \
+       ${_rootcatalog}
+    ${MINGW_INSTALL}/bin/xmlcatalog --noout --del \
+       "file://${_datadir}/xml/docbook/schema/xsd/${v}/catalog.xml" \
+       ${_rootcatalog}
+  done
+}

--- a/mingw-w64-docbook5-xml/docbook5-xml-x86_64.install
+++ b/mingw-w64-docbook5-xml/docbook5-xml-x86_64.install
@@ -1,4 +1,5 @@
 MINGW_INSTALL=/mingw64
+_subcatalogdir=$(cygpath -m ${MINGW_INSTALL}/etc/xml/)
 _rootcatalog=$(cygpath -m ${MINGW_INSTALL}/etc/xml/catalog)
 # export MSYS2_ARG_CONV_EXCL="-//OASIS"
 
@@ -6,34 +7,13 @@ post_install() {
   if [ -e ${MINGW_XML_CATALOG}/catalog.preserve ]; then
     mv ${MINGW_XML_CATALOG}/catalog.preserve ${MINGW_XML_CATALOG}/catalog
   elif [ ! -e ${MINGW_INSTALL}/etc/xml/catalog ]; then
-    ${MINGW_INSTALL}/bin/xmlcatalog --noout --create ${MINGW_XML_CATALOG}/catalog
+    ${MINGW_PREFIX}/bin/xmlcatalog  --noout --create ${MINGW_XML_CATALOG}/catalog
   fi
 
   for v in 5.{0,0.1,1}; do
-      ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegatePublic" \
+      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "delegatePublic" \
         "-//OASIS//DTD DocBook XML ${v}//EN" \
-        "file://${_datadir}/xml/docbook/schema/dtd/${v}/catalog.xml" \
-        ${_rootcatalog}
-      false
-      ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateSystem" \
-        "http://docbook.org/xml/${v}/dtd/" \
-        "file://${_datadir}/xml/docbook/schema/dtd/${v}/catalog.xml" \
-        ${_rootcatalog}
-      ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateURI" \
-        "http://docbook.org/xml/${v}/dtd/" \
-        "file://${_datadir}/xml/docbook/schema/dtd/${v}/catalog.xml" \
-        ${_rootcatalog}
-      ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateURI" \
-        "http://docbook.org/xml/${v}/rng/"  \
-        "file://${_datadir}/xml/docbook/schema/rng/${v}/catalog.xml" \
-        ${_rootcatalog}
-      ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateURI" \
-        "http://docbook.org/xml/${v}/sch/"  \
-        "file://${_datadir}/xml/docbook/schema/sch/${v}/catalog.xml" \
-        ${_rootcatalog}
-      ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateURI" \
-        "http://docbook.org/xml/${v}/xsd/"  \
-        "file://${_datadir}/xml/docbook/schema/xsd/${v}/catalog.xml" \
+        "${_subcatalogdir}/docbook-${v}.xml" \
         ${_rootcatalog}
   done
 }
@@ -42,7 +22,8 @@ post_install() {
 # arg 2:  the old package version
 pre_upgrade() {
   if [ $(vercmp $2 4.5) -lt 0 ]; then
-    ${MINGW_INSTALL}/bin/xmlcatalog --del "${MINGW_XML_CATALOG}/docbook-5.0.xml" ${MINGW_XML_CATALOG}/catalog > ${MINGW_XML_CATALOG}/catalog.preserve
+    ${MINGW_PREFIX}/bin/xmlcatalog  --del "${MINGW_XML_CATALOG}/docbook-5.0.xml" \
+    ${MINGW_XML_CATALOG}/catalog > ${MINGW_XML_CATALOG}/catalog.preserve
   fi
 }
 
@@ -55,17 +36,8 @@ post_upgrade() {
 
 post_remove() {
   for v in 5.{0,0.1,1}; do
-    ${MINGW_INSTALL}/bin/xmlcatalog --noout --del \
-       "file://${_datadir}/xml/docbook/schema/dtd/${v}/catalog.xml" \
-       ${_rootcatalog}
-    ${MINGW_INSTALL}/bin/xmlcatalog --noout --del \
-       "file://${_datadir}/xml/docbook/schema/rng/${v}/catalog.xml" \
-       ${_rootcatalog}
-    ${MINGW_INSTALL}/bin/xmlcatalog --noout --del \
-       "file://${_datadir}/xml/docbook/schema/sch/${v}/catalog.xml" \
-       ${_rootcatalog}
-    ${MINGW_INSTALL}/bin/xmlcatalog --noout --del \
-       "file://${_datadir}/xml/docbook/schema/xsd/${v}/catalog.xml" \
+    ${MINGW_PREFIX}/bin/xmlcatalog  --noout --del \
+       "file://${_subcatalogdir}/docbook-${v}.xml" \
        ${_rootcatalog}
   done
 }

--- a/mingw-w64-docbook5-xml/docbook5-xml-x86_64.install
+++ b/mingw-w64-docbook5-xml/docbook5-xml-x86_64.install
@@ -11,9 +11,9 @@ post_install() {
   fi
 
   for v in 5.{0,0.1,1}; do
-      ${MINGW_PREFIX}/bin/xmlcatalog  --noout --add "delegatePublic" \
+      ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "delegatePublic" \
         "-//OASIS//DTD DocBook XML ${v}//EN" \
-        "${_subcatalogdir}/docbook-${v}.xml" \
+        "./docbook-${v}.xml" \
         ${_rootcatalog}
   done
 }
@@ -22,7 +22,7 @@ post_install() {
 # arg 2:  the old package version
 pre_upgrade() {
   if [ $(vercmp $2 4.5) -lt 0 ]; then
-    ${MINGW_PREFIX}/bin/xmlcatalog  --del "${MINGW_XML_CATALOG}/docbook-5.0.xml" \
+    ${MINGW_PREFIX}/bin/xmlcatalog --del "${MINGW_XML_CATALOG}/docbook-5.0.xml" \
     ${MINGW_XML_CATALOG}/catalog > ${MINGW_XML_CATALOG}/catalog.preserve
   fi
 }
@@ -36,8 +36,8 @@ post_upgrade() {
 
 post_remove() {
   for v in 5.{0,0.1,1}; do
-    ${MINGW_PREFIX}/bin/xmlcatalog  --noout --del \
-       "file://${_subcatalogdir}/docbook-${v}.xml" \
+    ${MINGW_PREFIX}/bin/xmlcatalog --noout --del \
+       "./docbook-${v}.xml" \
        ${_rootcatalog}
   done
 }

--- a/mingw-w64-opengl-man-pages/LICENSE
+++ b/mingw-w64-opengl-man-pages/LICENSE
@@ -1,0 +1,116 @@
+SGI Free Software B License:
+
+SGI FREE SOFTWARE LICENSE B (Version 2.0, Sept. 18, 2008)
+Copyright (C) [dates of first publication] Silicon Graphics, Inc. All Rights Reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to
+whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice including the dates of first publication and either this
+permission notice or a reference to http://oss.sgi.com/projects/FreeB/ shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL SILICON GRAPHICS, INC. BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+
+Except as contained in this notice, the name of Silicon Graphics, Inc. shall not be used in
+advertising or otherwise to promote the sale, use or other dealings in this Software
+without prior written authorization from Silicon Graphics, Inc.
+
+================================
+Open Publication License, v 1.0:
+
+Open Publication License
+v1.0, 8 June 1999
+
+
+I. REQUIREMENTS ON BOTH UNMODIFIED AND MODIFIED VERSIONS
+
+The Open Publication works may be reproduced and distributed in whole or in part, in any medium physical or electronic, provided that the terms of this license are adhered to, and that this license or an incorporation of it by reference (with any options elected by the author(s) and/or publisher) is displayed in the reproduction.
+
+Proper form for an incorporation by reference is as follows:
+
+    Copyright (c) <year> by <author's name or designee>. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, vX.Y or later (the latest version is presently available at http://www.opencontent.org/openpub/).
+
+The reference must be immediately followed with any options elected by the author(s) and/or publisher of the document (see section VI).
+
+Commercial redistribution of Open Publication-licensed material is permitted.
+
+Any publication in standard (paper) book form shall require the citation of the original publisher and author. The publisher and author's names shall appear on all outer surfaces of the book. On all outer surfaces of the book the original publisher's name shall be as large as the title of the work and cited as possessive with respect to the title.
+
+
+II. COPYRIGHT
+
+The copyright to each Open Publication is owned by its author(s) or designee.
+
+
+III. SCOPE OF LICENSE
+
+The following license terms apply to all Open Publication works, unless otherwise explicitly stated in the document.
+
+Mere aggregation of Open Publication works or a portion of an Open Publication work with other works or programs on the same media shall not cause this license to apply to those other works. The aggregate work shall contain a notice specifying the inclusion of the Open Publication material and appropriate copyright notice.
+
+SEVERABILITY. If any part of this license is found to be unenforceable in any jurisdiction, the remaining portions of the license remain in force.
+
+NO WARRANTY. Open Publication works are licensed and provided "as is" without warranty of any kind, express or implied, including, but not limited to, the implied warranties of merchantability and fitness for a particular purpose or a warranty of non-infringement.
+
+
+IV. REQUIREMENTS ON MODIFIED WORKS
+
+All modified versions of documents covered by this license, including translations, anthologies, compilations and partial documents, must meet the following requirements:
+
+   1. The modified version must be labeled as such.
+   2. The person making the modifications must be identified and the modifications dated.
+   3. Acknowledgement of the original author and publisher if applicable must be retained according to normal academic citation practices.
+   4. The location of the original unmodified document must be identified.
+   5. The original author's (or authors') name(s) may not be used to assert or imply endorsement of the resulting document without the original author's (or authors') permission. 
+
+
+V. GOOD-PRACTICE RECOMMENDATIONS
+
+In addition to the requirements of this license, it is requested from and strongly recommended of redistributors that:
+
+   1. If you are distributing Open Publication works on hardcopy or CD-ROM, you provide email notification to the authors of your intent to redistribute at least thirty days before your manuscript or media freeze, to give the authors time to provide updated documents. This notification should describe modifications, if any, made to the document.
+   2. All substantive modifications (including deletions) be either clearly marked up in the document or else described in an attachment to the document.
+   3. Finally, while it is not mandatory under this license, it is considered good form to offer a free copy of any hardcopy and CD-ROM expression of an Open Publication-licensed work to its author(s). 
+
+
+VI. LICENSE OPTIONS
+
+The author(s) and/or publisher of an Open Publication-licensed document may elect certain options by appending language to the reference to or copy of the license. These options are considered part of the license instance and must be included with the license (or its incorporation by reference) in derived works.
+
+A. To prohibit distribution of substantively modified versions without the explicit permission of the author(s). "Substantive modification" is defined as a change to the semantic content of the document, and excludes mere changes in format or typographical corrections.
+
+To accomplish this, add the phrase `Distribution of substantively modified versions of this document is prohibited without the explicit permission of the copyright holder.' to the license reference or copy.
+
+B. To prohibit any publication of this work or derivative works in whole or in part in standard (paper) book form for commercial purposes unless prior permission is obtained from the copyright holder.
+
+To accomplish this, add the phrase 'Distribution of the work or derivative of the work in any standard (paper) book form is prohibited unless prior permission is obtained from the copyright holder.' to the license reference or copy.
+================================
+
+W3C Software Notice and License:
+
+W3C® SOFTWARE NOTICE AND LICENSE
+Copyright © 1994-2002 World Wide Web Consortium, (Massachusetts Institute of Technology, Institut National de Recherche en Informatique et en Automatique, Keio University). All Rights Reserved. http://www.w3.org/Consortium/Legal/
+
+This W3C work (including software, documents, or other related items) is being provided by the copyright holders under the following license. By obtaining, using and/or copying this work, you (the licensee) agree that you have read, understood, and will comply with the following terms and conditions:
+
+Permission to use, copy, modify, and distribute this software and its documentation, with or without modification,  for any purpose and without fee or royalty is hereby granted, provided that you include the following on ALL copies of the software and documentation or portions thereof, including modifications, that you make:
+
+   1. The full text of this NOTICE in a location viewable to users of the redistributed or derivative work.
+   2. Any pre-existing intellectual property disclaimers, notices, or terms and conditions. If none exist, a short notice of the following form (hypertext is preferred, text is permitted) should be used within the body of any redistributed or derivative code: "Copyright © [$date-of-software] World Wide Web Consortium, (Massachusetts Institute of Technology, Institut National de Recherche en Informatique et en Automatique, Keio University). All Rights Reserved. http://www.w3.org/Consortium/Legal/"
+   3. Notice of any changes or modifications to the W3C files, including the date changes were made. (We recommend you provide URIs to the location from which the code is derived.)
+
+THIS SOFTWARE AND DOCUMENTATION IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE OR DOCUMENTATION WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENTATION.
+
+The name and trademarks of copyright holders may NOT be used in advertising or publicity pertaining to the software without specific, written prior permission. Title to copyright in this software and any associated documentation will at all times remain with copyright holders.

--- a/mingw-w64-opengl-man-pages/PKGBUILD
+++ b/mingw-w64-opengl-man-pages/PKGBUILD
@@ -1,0 +1,45 @@
+# Maintainer: AndyRTR <andyrtr@archlinux.org>
+
+_realname=opengl-man-pages
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=20191106
+_commit=8acb9c72a30d36a6f7e89b9b2de0635c50773cdb
+pkgrel=1
+pkgdesc="OpenGL Man Pages - OpenGL 4.x (mingw-w64)"
+arch=('any')
+url="https://github.com/KhronosGroup/OpenGL-Refpages"
+license=('custom')
+makedepends=("${MINGW_PACKAGE_PREFIX}-docbook5-xml"
+    "${MINGW_PACKAGE_PREFIX}-docbook-xsl"
+    "${MINGW_PACKAGE_PREFIX}-libxslt"
+    "${MINGW_PACKAGE_PREFIX}-docbook-mathml"
+    "${MINGW_PACKAGE_PREFIX}-w3c-mathml2"
+    "${MINGW_PACKAGE_PREFIX}-python3" 'git')
+source=(${_realname}::git+https://github.com/KhronosGroup/OpenGL-Refpages#commit=$_commit
+        'LICENSE')
+sha256sums=('SKIP'
+            'a7b2f6669d7ead91dcaf5a03620cdf9d37c54d83fd1899b4ef84683c7e6d4024')
+
+pkgver() {
+  date +%Y%m%d
+}
+
+build() {
+  for manpages in gl4; do
+    cd "${srcdir}/${_realname}/${manpages}"
+      for file in *.xml; do
+        ${MINGW_PREFIX}/bin/xsltproc --xinclude --noout --nonet ${MINGW_PREFIX}/share/xml/docbook/xsl-stylesheets-*/manpages/docbook.xsl ${file}
+      done
+  done
+}
+
+package() {
+  install -d "${pkgdir}${MINGW_PREFIX}/share/man/man3"
+  for manpages in gl4; do
+    cd "${srcdir}/${_realname}/${manpages}"
+    install -m644 *.3G "${pkgdir}${MINGW_PREFIX}/share/man/man3/"
+  done
+  # license
+  install -D -m644 "${srcdir}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}

--- a/mingw-w64-w3c-mathml2/LICENSE
+++ b/mingw-w64-w3c-mathml2/LICENSE
@@ -1,0 +1,12 @@
+     Copyright 1998-2000 World Wide Web Consortium
+        (Massachusetts Institute of Technology, Institut National de
+         Recherche en Informatique et en Automatique, Keio University).
+         All Rights Reserved.
+
+     Permission to use, copy, modify and distribute the XHTML 1.1 DTD and
+     its accompanying documentation for any purpose and without fee is
+     hereby granted in perpetuity, provided that the above copyright notice
+     and this paragraph appear in all copies.  The copyright holders make
+     no representation about the suitability of the DTD for any purpose.
+
+     It is provided "as is" without expressed or implied warranty.

--- a/mingw-w64-w3c-mathml2/PKGBUILD
+++ b/mingw-w64-w3c-mathml2/PKGBUILD
@@ -1,10 +1,10 @@
-# Contributor: Sylvain HENRY <hsyl20@gmail.com>
+# Contributor: J. Peter Mugaas <jpmugaas@suddenlink.net>
 
 _realname=w3c-mathml2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.0
-pkgrel=5
+pkgrel=1
 pkgdesc="MathML XML scheme (mingw-w64)"
 arch=('any')
 url="https://www.w3.org/TR/MathML2/"

--- a/mingw-w64-w3c-mathml2/PKGBUILD
+++ b/mingw-w64-w3c-mathml2/PKGBUILD
@@ -1,0 +1,70 @@
+# Contributor: Sylvain HENRY <hsyl20@gmail.com>
+
+_realname=w3c-mathml2
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=2.0
+pkgrel=5
+pkgdesc="MathML XML scheme (mingw-w64)"
+arch=('any')
+url="https://www.w3.org/TR/MathML2/"
+license=('BSD')
+depends=("${MINGW_PACKAGE_PREFIX}-libxml2")
+install=w3c-mathml2-${CARCH}.install
+source=(https://www.w3.org/TR/2001/REC-MathML2-20010221/dtd/mathml2.dtd
+        https://www.w3.org/TR/2001/REC-MathML2-20010221/dtd/mathml2-qname-1.mod
+        https://www.w3.org/TR/2001/REC-MathML2-20010221/dtd/isoamsa.ent
+        https://www.w3.org/TR/2001/REC-MathML2-20010221/dtd/isoamsb.ent
+        https://www.w3.org/TR/2001/REC-MathML2-20010221/dtd/isoamsc.ent
+        https://www.w3.org/TR/2001/REC-MathML2-20010221/dtd/isoamsn.ent
+        https://www.w3.org/TR/2001/REC-MathML2-20010221/dtd/isoamso.ent
+        https://www.w3.org/TR/2001/REC-MathML2-20010221/dtd/isoamsr.ent
+        https://www.w3.org/TR/2001/REC-MathML2-20010221/dtd/isogrk3.ent
+        https://www.w3.org/TR/2001/REC-MathML2-20010221/dtd/isomfrk.ent
+        https://www.w3.org/TR/2001/REC-MathML2-20010221/dtd/isomopf.ent
+        https://www.w3.org/TR/2001/REC-MathML2-20010221/dtd/isomscr.ent
+        https://www.w3.org/TR/2001/REC-MathML2-20010221/dtd/isotech.ent
+        https://www.w3.org/TR/2001/REC-MathML2-20010221/dtd/isobox.ent
+        https://www.w3.org/TR/2001/REC-MathML2-20010221/dtd/isocyr1.ent
+        https://www.w3.org/TR/2001/REC-MathML2-20010221/dtd/isocyr2.ent
+        https://www.w3.org/TR/2001/REC-MathML2-20010221/dtd/isodia.ent
+        https://www.w3.org/TR/2001/REC-MathML2-20010221/dtd/isolat1.ent
+        https://www.w3.org/TR/2001/REC-MathML2-20010221/dtd/isolat2.ent
+        https://www.w3.org/TR/2001/REC-MathML2-20010221/dtd/isonum.ent
+        https://www.w3.org/TR/2001/REC-MathML2-20010221/dtd/isopub.ent
+        https://www.w3.org/TR/2001/REC-MathML2-20010221/dtd/mmlextra.ent
+        https://www.w3.org/TR/2001/REC-MathML2-20010221/dtd/mmlalias.ent
+        LICENSE)
+sha512sums=('3a91e7df45d5d1b802c0a95d7e61ed06c46dca5c2e49151a17d8ffebaf03c044ca77303a0bac0c0622aeb024ea37a55dd9fabafa21a7edb5d702fa2f480ae041'
+            '16d06d874988f1c53d9fb5ef7f1532d5fb883f81e20a2d4a1935e43b6343d21929974b53b4f8065beae1a4d971bc9c4a04ec47b082824b4ab82c454b10fcfafe'
+            'fb3bd7f8ee918b2cffab77e8b8b3067fdb72e32258aef1fe79caa26e8057f836512fa2974f7c5697c1d921e16b7188addb23ed50c8f2bc2f727318996b245720'
+            'e1ebcd82a2e5ae54895585870f4e8b0a5b5a3d27a64dbcd55006eba5e549ab3ba272d656d92d7f4a4ec34bb812f780267fe324ffe1763bbdb50a085492191d6b'
+            'a4e590adfb28e38df448e544e0b15f3760d127d31a853be6c0235a1a7868eaad49d83a3899884f4bfe448b03bae2b873f990142da23a2b27421ddb3d60c17970'
+            '32e5a6565f29175c0c46ea7096c8e62a84d1ed19cf4f138787597c2b47afa5c17977060425106378af9b9151c75798fc1207b491d089f04f5515c883df1c2de8'
+            '6e8a5393b2e8b818af22694c272c90832a011bdcc566ea03d5d54354f4de5353cd7b41dcd79cb0c8fdad8338e94fbf634a10a7e0e11e2ff620d22101dd7ff792'
+            'a313dd60e34e61faca2b0bf1ed763c9facde9a92cbe282e2ba80c5341ad18352b8ee1821615e72ef1ef15d17990114d6bdef3898b4619999336163a7fcc73d41'
+            '38c39e62dce37796e6b7d4d076723e1a78265d10cbea8ae0bb5641d00cae101c617d47b5f4bb75b15065f2bb9283d9de9fe19c203217d34bb5f2beea38aefa50'
+            '9380ac0b18c09c86e56ccf524ec37e0ee6c8ec361655d540e7ed8ff08e9eccfe83cc3bc1e0bc40bc74f91d700c1a28720f5c0d471c46fc1c0cf007f49f9f318e'
+            '4e07b48f8a951cad7c20e2d8a4d3ae110b6b9f784b04a9fc8476362a363ced1937cfde5098e423051e030e9aca1093db27632aed292c379e5b03b2c06a70c157'
+            '0e2f02a9c5a8d97a08d2216099c7032cee78af5dde21c6afc4567db855a4c8b29328477cf4849a03728864adbc2075e2065ad398fefabe7ec3c45a894302da08'
+            '22406d6fa54862348c257e0672099586ccfd37a5a5be954f415f5f9bad4d5f73d84571ee6cddf347beaeaee7ede91288332c925ecde3e3c85b3138cce7f8dec4'
+            'ea2bf4fae2f818a77e16fd13f45f9e6346e4dde6123a58be3353a3b2d677f6dbc2e60de94e47af20b639f21240b37130861809758632eb5c098f54110eb69586'
+            '78ba9aaa41cf3ea665f441cffc6a2a21f64e986dc68bb0b94f3168b3e4a6687f1a5bfeab59abe3c87c157f73ed6c310f48237dae102952ec626bb69ac1a8f849'
+            '90344ae40a3c918e7ca07a6a9afcd53d3861cc76b4897970cbd07ffbb0d703a5569dd94d67c45ebee7f38dd7c820f9428a5e1d2e8da8704f2f637c72b8d5bff4'
+            '4a9312909303c053777189a67efd3bc071ed19df8e728aebf09a9a368ea50f9377ea0228fea6b6291df6c7fac91233cbc57907f1ed77119f218f7c694fcb2080'
+            '1e64cab457e2828fce2ed38d9952d592f7be6a1406b0db210e2e953b36f8d368275a09115333a10a2bce66f75715aba8f16a40f144b096fa15ee961a72f032e5'
+            '34f1dd8e57307b70c4c71994817b895aa6c18028f5797b917076099b23c3802ca663890478adb464bc60d7c536e43908139aca7fc1613039f2cb7876c5148e33'
+            '4b8c516ca4f983cc3da4895a7643a7d813426b2356c7545fe5903b3310dd2f5a04507c29271b208db4b29528720a9948f27253117bd6c5a19d06c575bffed833'
+            'ba3522584b5ef1633ac6f1ba569a195b4e466a05ee90242a0ec3bb4ecc729d2a5667d534c6ae8ad6986017de148a3ff552f0d8fe06ed3fa366fd70753e13a085'
+            'b55f5ce85a1e8ea281f6b462c8000bf92bf1942ba3671553753c2a410bd67218594ba971bc6f30bee1a3544c59432aa979d9fc156bb08b823ee9a41624f4ee63'
+            '9e9c3ff17461061caebcf73edf09cd7481325652f8374138a6a6b965244bec5c0e9576ad386b371573b7344c035045e5b1c3af38eed5521899cf2b6890a33e23'
+            '9b76407aafd493752f47c9b9b474e6bfcc5f87eb96a438338138828d8de275ca30d4c2443d73332a68730924876efc853682f27d47072423999290e01add2660')
+
+package() {
+  cd "${srcdir}"
+  install -d -m 755 "${pkgdir}${MINGW_PREFIX}/share/xml/w3c/mathml2"
+  install -m644 mathml2.dtd "${pkgdir}${MINGW_PREFIX}/share/xml/w3c/mathml2/"
+  install -m644 *.mod "${pkgdir}${MINGW_PREFIX}/share/xml/w3c/mathml2/"
+  install -m644 *.ent "${pkgdir}${MINGW_PREFIX}/share/xml/w3c/mathml2/"
+  install -D -m644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}

--- a/mingw-w64-w3c-mathml2/w3c-mathml2-i686.install
+++ b/mingw-w64-w3c-mathml2/w3c-mathml2-i686.install
@@ -1,0 +1,18 @@
+MINGW_INSTALL=/mingw32
+_rootcatalog=$(cygpath -m ${MINGW_INSTALL}/etc/xml/catalog)
+
+post_install() {
+  if [ ! -e etc/xml/catalog ]; then
+    ${MINGW_INSTALL}/bin/xmlcatalog --noout --create ${MINGW_INSTALL}/etc/xml/catalog
+  fi
+
+  ${MINGW_INSTALL}/bin/xmlcatalog  --noout --add public "-//W3C//DTD MathML 2.0//EN" "${_rootcatalog}/share/xml/w3c/mathml2/mathml2.dtd" ${MINGW_INSTALL}/eetc/xml/catalog
+  ${MINGW_INSTALL}/bin/xmlcatalog  --noout --add public "-//W3C//DTD MathML//EN" "${_rootcatalog}/share/xml/w3c/mathml2/mathml2.dtd" ${MINGW_INSTALL}/eetc/xml/catalog
+  ${MINGW_INSTALL}/bin/xmlcatalog  --noout --add system "http://www.w3.org/TR/MathML2/dtd/mathml2.dtd" "${_rootcatalog}/share/xml/w3c/mathml2/mathml2.dtd" ${MINGW_INSTALL}/eetc/xml/catalog
+}
+
+post_remove() {
+  ${MINGW_INSTALL}/bin/xmlcatalog  --noout --del "-//W3C//DTD MathML 2.0//EN" ${MINGW_INSTALL}/etc/xml/catalog
+  ${MINGW_INSTALL}/bin/xmlcatalog  --noout --del "-//W3C//DTD MathML//EN" ${MINGW_INSTALL}/etc/xml/catalog
+  ${MINGW_INSTALL}/bin/xmlcatalog  --noout --del "http://www.w3.org/TR/MathML2/dtd/mathml2.dtd" ${MINGW_INSTALL}/etc/xml/catalog
+}

--- a/mingw-w64-w3c-mathml2/w3c-mathml2-i686.install
+++ b/mingw-w64-w3c-mathml2/w3c-mathml2-i686.install
@@ -6,13 +6,21 @@ post_install() {
     ${MINGW_INSTALL}/bin/xmlcatalog --noout --create ${MINGW_INSTALL}/etc/xml/catalog
   fi
 
-  ${MINGW_INSTALL}/bin/xmlcatalog  --noout --add public "-//W3C//DTD MathML 2.0//EN" "${_rootcatalog}/share/xml/w3c/mathml2/mathml2.dtd" ${MINGW_INSTALL}/eetc/xml/catalog
-  ${MINGW_INSTALL}/bin/xmlcatalog  --noout --add public "-//W3C//DTD MathML//EN" "${_rootcatalog}/share/xml/w3c/mathml2/mathml2.dtd" ${MINGW_INSTALL}/eetc/xml/catalog
-  ${MINGW_INSTALL}/bin/xmlcatalog  --noout --add system "http://www.w3.org/TR/MathML2/dtd/mathml2.dtd" "${_rootcatalog}/share/xml/w3c/mathml2/mathml2.dtd" ${MINGW_INSTALL}/eetc/xml/catalog
+  ${MINGW_INSTALL}/bin/xmlcatalog --noout --add public "-//W3C//DTD MathML 2.0//EN" "../../share/xml/w3c/mathml2/mathml2.dtd" ${MINGW_INSTALL}/etc/xml/catalog
+  ${MINGW_INSTALL}/bin/xmlcatalog --noout --add public "-//W3C//DTD MathML//EN" "../../share/xml/w3c/mathml2/mathml2.dtd" ${MINGW_INSTALL}/etc/xml/catalog
+  ${MINGW_INSTALL}/bin/xmlcatalog --noout --add system "http://www.w3.org/TR/MathML2/dtd/mathml2.dtd" "../../share/xml/w3c/mathml2/mathml2.dtd" ${MINGW_INSTALL}/etc/xml/catalog
 }
 
 post_remove() {
-  ${MINGW_INSTALL}/bin/xmlcatalog  --noout --del "-//W3C//DTD MathML 2.0//EN" ${MINGW_INSTALL}/etc/xml/catalog
-  ${MINGW_INSTALL}/bin/xmlcatalog  --noout --del "-//W3C//DTD MathML//EN" ${MINGW_INSTALL}/etc/xml/catalog
-  ${MINGW_INSTALL}/bin/xmlcatalog  --noout --del "http://www.w3.org/TR/MathML2/dtd/mathml2.dtd" ${MINGW_INSTALL}/etc/xml/catalog
+  ${MINGW_INSTALL}/bin/xmlcatalog --noout --del "-//W3C//DTD MathML 2.0//EN" ${MINGW_INSTALL}/etc/xml/catalog
+  ${MINGW_INSTALL}/bin/xmlcatalog --noout --del "-//W3C//DTD MathML//EN" ${MINGW_INSTALL}/etc/xml/catalog
+  ${MINGW_INSTALL}/bin/xmlcatalog --noout --del "http://www.w3.org/TR/MathML2/dtd/mathml2.dtd" ${MINGW_INSTALL}/etc/xml/catalog
+}
+
+
+post_upgrade() {
+  if [ $(vercmp $2 4.5) -ge 0 ]; then
+    post_remove
+  fi
+  post_install
 }

--- a/mingw-w64-w3c-mathml2/w3c-mathml2-x86_64.install
+++ b/mingw-w64-w3c-mathml2/w3c-mathml2-x86_64.install
@@ -1,0 +1,18 @@
+MINGW_INSTALL=/mingw64
+_rootcatalog=$(cygpath -m ${MINGW_INSTALL}/etc/xml/catalog)
+
+post_install() {
+  if [ ! -e etc/xml/catalog ]; then
+    ${MINGW_INSTALL}/bin/xmlcatalog --noout --create ${MINGW_INSTALL}/etc/xml/catalog
+  fi
+
+  ${MINGW_INSTALL}/bin/xmlcatalog  --noout --add public "-//W3C//DTD MathML 2.0//EN" "${_rootcatalog}/share/xml/w3c/mathml2/mathml2.dtd" ${MINGW_INSTALL}/etc/xml/catalog
+  ${MINGW_INSTALL}/bin/xmlcatalog  --noout --add public "-//W3C//DTD MathML//EN" "${_rootcatalog}/share/xml/w3c/mathml2/mathml2.dtd" ${MINGW_INSTALL}/etc/xml/catalog
+  ${MINGW_INSTALL}/bin/xmlcatalog  --noout --add system "http://www.w3.org/TR/MathML2/dtd/mathml2.dtd" "${_rootcatalog}/share/xml/w3c/mathml2/mathml2.dtd" ${MINGW_INSTALL}/etc/xml/catalog
+}
+
+post_remove() {
+  ${MINGW_INSTALL}/bin/xmlcatalog  --noout --del "-//W3C//DTD MathML 2.0//EN" ${MINGW_INSTALL}/etc/xml/catalog
+  ${MINGW_INSTALL}/bin/xmlcatalog  --noout --del "-//W3C//DTD MathML//EN" ${MINGW_INSTALL}/etc/xml/catalog
+  ${MINGW_INSTALL}/bin/xmlcatalog  --noout --del "http://www.w3.org/TR/MathML2/dtd/mathml2.dtd" ${MINGW_INSTALL}/etc/xml/catalog
+}

--- a/mingw-w64-w3c-mathml2/w3c-mathml2-x86_64.install
+++ b/mingw-w64-w3c-mathml2/w3c-mathml2-x86_64.install
@@ -6,13 +6,22 @@ post_install() {
     ${MINGW_INSTALL}/bin/xmlcatalog --noout --create ${MINGW_INSTALL}/etc/xml/catalog
   fi
 
-  ${MINGW_INSTALL}/bin/xmlcatalog  --noout --add public "-//W3C//DTD MathML 2.0//EN" "${_rootcatalog}/share/xml/w3c/mathml2/mathml2.dtd" ${MINGW_INSTALL}/etc/xml/catalog
-  ${MINGW_INSTALL}/bin/xmlcatalog  --noout --add public "-//W3C//DTD MathML//EN" "${_rootcatalog}/share/xml/w3c/mathml2/mathml2.dtd" ${MINGW_INSTALL}/etc/xml/catalog
-  ${MINGW_INSTALL}/bin/xmlcatalog  --noout --add system "http://www.w3.org/TR/MathML2/dtd/mathml2.dtd" "${_rootcatalog}/share/xml/w3c/mathml2/mathml2.dtd" ${MINGW_INSTALL}/etc/xml/catalog
+  ${MINGW_INSTALL}/bin/xmlcatalog --noout --add public "-//W3C//DTD MathML 2.0//EN" "../../share/xml/w3c/mathml2/mathml2.dtd" ${MINGW_INSTALL}/etc/xml/catalog
+  ${MINGW_INSTALL}/bin/xmlcatalog --noout --add public "-//W3C//DTD MathML//EN" "../../share/xml/w3c/mathml2/mathml2.dtd" ${MINGW_INSTALL}/etc/xml/catalog
+  ${MINGW_INSTALL}/bin/xmlcatalog --noout --add system "http://www.w3.org/TR/MathML2/dtd/mathml2.dtd" "../../share/xml/w3c/mathml2/mathml2.dtd" ${MINGW_INSTALL}/etc/xml/catalog
 }
 
 post_remove() {
-  ${MINGW_INSTALL}/bin/xmlcatalog  --noout --del "-//W3C//DTD MathML 2.0//EN" ${MINGW_INSTALL}/etc/xml/catalog
-  ${MINGW_INSTALL}/bin/xmlcatalog  --noout --del "-//W3C//DTD MathML//EN" ${MINGW_INSTALL}/etc/xml/catalog
-  ${MINGW_INSTALL}/bin/xmlcatalog  --noout --del "http://www.w3.org/TR/MathML2/dtd/mathml2.dtd" ${MINGW_INSTALL}/etc/xml/catalog
+  ${MINGW_INSTALL}/bin/xmlcatalog --noout --del "-//W3C//DTD MathML 2.0//EN" ${MINGW_INSTALL}/etc/xml/catalog
+  ${MINGW_INSTALL}/bin/xmlcatalog --noout --del "-//W3C//DTD MathML//EN" ${MINGW_INSTALL}/etc/xml/catalog
+  ${MINGW_INSTALL}/bin/xmlcatalog --noout --del "http://www.w3.org/TR/MathML2/dtd/mathml2.dtd" ${MINGW_INSTALL}/etc/xml/catalog
 }
+
+
+post_upgrade() {
+  if [ $(vercmp $2 4.5) -ge 0 ]; then
+    post_remove
+  fi
+  post_install
+}
+


### PR DESCRIPTION
docbook-xml - remove 5.x series (that's a total rewrite)
docbook5-xml - new package that includes docbook 5.0, 5.0.1, and 5.1
w3c-mathml2 - new package MathML XML scheme
opengl-man-pages - new package - opengl documentaiton (uses docbook5-xml, docbook 4.x) and we

Since opengl-man-pages builds, I'm assume that this works as it does use some of the old packaging stuff and I ddidn't see an error when testing xmlcat with the -v parameter.