### PR TITLE
arrow: Update to 0.15.1

### DIFF
--- a/mingw-w64-arrow/PKGBUILD
+++ b/mingw-w64-arrow/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=arrow
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.15.0
+pkgver=0.15.1
 pkgrel=1
 pkgdesc="Apache Arrow is a cross-language development platform for in-memory data (mingw-w64)"
 arch=("any")
@@ -33,7 +33,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-meson")
 options=("staticlibs" "strip" "!buildflags")
 source=(https://github.com/apache/arrow/archive/apache-arrow-${pkgver}.tar.gz)
-sha256sums=('be92f0169747c99282da71e951a8fbe72fef2058ee95a207ad484b5307b5003c')
+sha256sums=('ab1c0d371a10b615eccfcead71bb79832245d788f4834cc6b278c03c3872d593')
 
 cmake_build_type=release
 meson_build_type=debugoptimized


### PR DESCRIPTION
#5933 was failed by gRPC/Protobuf related crash.

gRPC update by ef22c59a13346fa69f8255b7b02be189803897f0 fixed the failure in #5933.