### PR TITLE
metis: PkgConfig support

### DIFF
--- a/mingw-w64-metis/PKGBUILD
+++ b/mingw-w64-metis/PKGBUILD
@@ -4,7 +4,7 @@ _realname=metis
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=5.1.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Serial Graph Partitioning and Fill-reducing Matrix Ordering (mingw-w64)"
 arch=('any')
 url='http://glaros.dtc.umn.edu/gkhome/views/metis'
@@ -57,5 +57,17 @@ package() {
   for _shared in OFF ON; do
     cd "${srcdir}"/build-shared-${_shared}-${CARCH}
     make install DESTDIR="${pkgdir}"
+    mkdir -p "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig"
+    echo "
+      prefix=${MINGW_PREFIX}
+      libdir=\${prefix}/lib
+      includedir=\${prefix}/include
+      Name: ${_realname}
+      URL: ${url}
+      Version: ${pkgver}
+      Description: ${pkgdesc}
+      Cflags: -I\${includedir}
+      Libs: -L\${libdir} -l${_realname}
+    " | sed '/^\s*$/d;s/^\s*//' > "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/${_realname}.pc"
   done
 }


### PR DESCRIPTION
This adds PkgConfig support to help the dependant packages such as parmetis.