### PR TITLE
mecab: fix failed to load mecab dicrc issue

### DIFF
--- a/mingw-w64-mecab/PKGBUILD
+++ b/mingw-w64-mecab/PKGBUILD
@@ -4,7 +4,7 @@ _realname=mecab
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.996
-pkgrel=1
+pkgrel=2
 pkgdesc="Yet another Japanese morphological analyzer (mingw-w64)"
 arch=('any')
 url="https://taku910.github.io/mecab/"
@@ -47,6 +47,8 @@ package() {
   cd ${srcdir}/build-${CARCH}
   make DESTDIR="${pkgdir}" install
 
+  # Prepend actual install prefix to detect dicrc correctly
+  sed -i'' -e "s,${MINGW_PREFIX},c:/msys64${MINGW_PREFIX}," "${pkgdir}${MINGW_PREFIX}/etc/mecabrc"
   mv "${pkgdir}${MINGW_PREFIX}/etc/mecabrc" "${pkgdir}${MINGW_PREFIX}/bin/mecabrc"
   for license in AUTHORS BSD COPYING GPL LGPL; do
     install -Dm644 ${srcdir}/${_realname}-${pkgver}/${license} "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/${license}"


### PR DESCRIPTION
This commit fixes the following error:

  ../../mecab-0.996/src/param.cpp(69) [ifs] no such file or directory:
  /mingw64/lib/mecab/dic/naist-jdic\dicrc