### PR TITLE
WIP: clang: Reduce install size by using hard links

### DIFF
--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -31,7 +31,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-llvm"
          "${MINGW_PACKAGE_PREFIX}-polly")
 pkgver=9.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 url="https://llvm.org/"
@@ -344,6 +344,20 @@ build() {
 #  make check-polly || true
 #}
 
+do_link() {
+  TARGET=$1
+  LINK=$2
+
+  if [ -f $TARGET ] && [ -f $LINK ]; then
+    # Check if the content of files are exactly the same.
+    if diff $TARGET $LINK > /dev/null; then
+      # Convert to a hard link.
+      echo "Linking $LINK to $TARGET"
+      ln -f $TARGET $LINK
+    fi
+  fi
+}
+
 package_clang() {
   pkgdesc="C language family frontend for LLVM (mingw-w64)"
   url="https://clang.llvm.org/"
@@ -357,6 +371,11 @@ package_clang() {
   # Install static libraries
   install -Dm644 ../build-${CARCH}/lib/libclang.a ${pkgdir}${MINGW_PREFIX}/lib/libclang.a
   install -Dm644 ../build-${CARCH}/lib/libclang.a ${pkgdir}${MINGW_PREFIX}/lib/libclang_static.a
+
+  # Convert to hard links
+  do_link ${pkgdir}${MINGW_PREFIX}/bin/clang.exe ${pkgdir}${MINGW_PREFIX}/bin/clang++.exe
+  do_link ${pkgdir}${MINGW_PREFIX}/bin/clang.exe ${pkgdir}${MINGW_PREFIX}/bin/clang-cl.exe
+  do_link ${pkgdir}${MINGW_PREFIX}/bin/clang.exe ${pkgdir}${MINGW_PREFIX}/bin/clang-cpp.exe
 }
 
 package_clang-analyzer() {
@@ -430,6 +449,12 @@ package_lld() {
 
   cd "${srcdir}/llvm-${pkgver}.src"
   ${_make_cmd} -C ../build-${CARCH}/tools/lld -j1 DESTDIR="${pkgdir}" install
+
+  # Convert to hard links
+  do_link ${pkgdir}${MINGW_PREFIX}/bin/lld.exe ${pkgdir}${MINGW_PREFIX}/bin/ld.lld.exe
+  do_link ${pkgdir}${MINGW_PREFIX}/bin/lld.exe ${pkgdir}${MINGW_PREFIX}/bin/ld64.lld.exe
+  do_link ${pkgdir}${MINGW_PREFIX}/bin/lld.exe ${pkgdir}${MINGW_PREFIX}/bin/lld-link.exe
+  do_link ${pkgdir}${MINGW_PREFIX}/bin/lld.exe ${pkgdir}${MINGW_PREFIX}/bin/wasm-ld.exe
 }
 
 package_lldb() {
@@ -476,6 +501,14 @@ package_llvm() {
   # fox cmake files.
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
   sed -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${pkgdir}/${MINGW_PREFIX}/lib/cmake/llvm/LLVMExports.cmake
+
+  # Convert to hard links
+  do_link ${pkgdir}${MINGW_PREFIX}/bin/llvm-ar.exe ${pkgdir}${MINGW_PREFIX}/bin/llvm-dlltool.exe
+  do_link ${pkgdir}${MINGW_PREFIX}/bin/llvm-ar.exe ${pkgdir}${MINGW_PREFIX}/bin/llvm-lib.exe
+  do_link ${pkgdir}${MINGW_PREFIX}/bin/llvm-ar.exe ${pkgdir}${MINGW_PREFIX}/bin/llvm-ranlib.exe
+  do_link ${pkgdir}${MINGW_PREFIX}/bin/llvm-readelf.exe ${pkgdir}${MINGW_PREFIX}/bin/llvm-readobj.exe
+  do_link ${pkgdir}${MINGW_PREFIX}/bin/llvm-addr2line.exe ${pkgdir}${MINGW_PREFIX}/bin/llvm-symbolizer.exe
+  do_link ${pkgdir}${MINGW_PREFIX}/bin/llvm-objcopy.exe ${pkgdir}${MINGW_PREFIX}/bin/llvm-strip.exe
 }
 
 package_polly() {


### PR DESCRIPTION
Clang has some files which have different names with exactly the same
contents. (E.g. clang.exe, clang++.exe, clang-cl.exe and clang-cpp.exe)
This is a waste of disk size. Use hard links to reduce the install size.

(This reduces the install size about 1.4 GB in my environment.)