### PR TITLE
universal-ctags-git: Update to r7242

### DIFF
--- a/mingw-w64-universal-ctags-git/PKGBUILD
+++ b/mingw-w64-universal-ctags-git/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=ctags
 pkgbase=mingw-w64-universal-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-universal-${_realname}-git"
-pkgver=r6369.5728abe4
+pkgver=r7242.db4357d0
 pkgrel=1
 pkgdesc="A maintained Ctags implementation (mingw-w64)"
 arch=('any')
@@ -42,11 +42,10 @@ build() {
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \
     --disable-etags \
-    --disable-external-sort \
-    --enable-iconv
+    --disable-external-sort
 
   make
-  make -C docs html man RST2HTML=rst2html3
+  make -C docs html man
 }
 
 package() {


### PR DESCRIPTION
* --enable-iconv is now the default. No need to set it explicitly.
* rst2html3 was renamed to rst2html a few months ago.