### PR TITLE
WIP: gcc: Reduce install size by using hard links

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -21,7 +21,7 @@ pkgver=9.2.0
 #_majorver=${pkgver:0:1}
 #_sourcedir=${_realname}-${_majorver}-${_snapshot}
 _sourcedir=${_realname}-${pkgver}
-pkgrel=2
+pkgrel=3
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 url="https://gcc.gnu.org"
@@ -258,6 +258,20 @@ ENDFILE
   cp bin/{libatomic*,libgcc*,libgomp*,libquadmath*,libssp*,libstdc*}.dll ${pkgdir}${MINGW_PREFIX}/bin/
 }
 
+do_link() {
+  TARGET=$1
+  LINK=$2
+
+  if [ -f $TARGET ] && [ -f $LINK ]; then
+    # Check if the content of files are exactly the same.
+    if diff $TARGET $LINK > /dev/null; then
+      # Convert to a hard link.
+      echo "Linking $LINK to $TARGET"
+      ln -f $TARGET $LINK
+    fi
+  fi
+}
+
 package_mingw-w64-gcc() {
   pkgdesc="GNU Compiler Collection (C,C++,OpenMP) for MinGW-w64"
   depends=("${MINGW_PACKAGE_PREFIX}-binutils"
@@ -293,6 +307,17 @@ package_mingw-w64-gcc() {
   cp bin/${MINGW_CHOST}-gcc-ar.exe                      ${pkgdir}${MINGW_PREFIX}/bin/
   cp bin/${MINGW_CHOST}-gcc-nm.exe                      ${pkgdir}${MINGW_PREFIX}/bin/
   cp bin/${MINGW_CHOST}-gcc-ranlib.exe                  ${pkgdir}${MINGW_PREFIX}/bin/
+
+  # Convert to hard links
+  do_link ${pkgdir}${MINGW_PREFIX}/bin/gcc.exe          ${pkgdir}${MINGW_PREFIX}/bin/cc.exe
+  do_link ${pkgdir}${MINGW_PREFIX}/bin/gcc.exe          ${pkgdir}${MINGW_PREFIX}/bin/${MINGW_CHOST}-gcc-${pkgver%%+*}.exe
+  do_link ${pkgdir}${MINGW_PREFIX}/bin/gcc.exe          ${pkgdir}${MINGW_PREFIX}/bin/${MINGW_CHOST}-gcc.exe
+  do_link ${pkgdir}${MINGW_PREFIX}/bin/g++.exe          ${pkgdir}${MINGW_PREFIX}/bin/c++.exe
+  do_link ${pkgdir}${MINGW_PREFIX}/bin/g++.exe          ${pkgdir}${MINGW_PREFIX}/bin/${MINGW_CHOST}-c++.exe
+  do_link ${pkgdir}${MINGW_PREFIX}/bin/g++.exe          ${pkgdir}${MINGW_PREFIX}/bin/${MINGW_CHOST}-g++.exe
+  do_link ${pkgdir}${MINGW_PREFIX}/bin/gcc-ar.exe       ${pkgdir}${MINGW_PREFIX}/bin/${MINGW_CHOST}-gcc-ar.exe
+  do_link ${pkgdir}${MINGW_PREFIX}/bin/gcc-nm.exe       ${pkgdir}${MINGW_PREFIX}/bin/${MINGW_CHOST}-gcc-nm.exe
+  do_link ${pkgdir}${MINGW_PREFIX}/bin/gcc-ranlib.exe   ${pkgdir}${MINGW_PREFIX}/bin/${MINGW_CHOST}-gcc-ranlib.exe
 
   #cp bin/{libgcc*,libgomp*,libquadmath*,libssp*,libstdc*}.dll ${pkgdir}${MINGW_PREFIX}/bin/
   mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/include
@@ -381,6 +406,9 @@ package_mingw-w64-gcc-fortran() {
   cd ${srcdir}${MINGW_PREFIX}
   cp bin/gfortran.exe ${pkgdir}${MINGW_PREFIX}/bin/
   cp bin/${MINGW_CHOST}-gfortran.exe ${pkgdir}${MINGW_PREFIX}/bin/
+
+  # Convert to hard links
+  do_link ${pkgdir}${MINGW_PREFIX}/bin/gfortran.exe     ${pkgdir}${MINGW_PREFIX}/bin/${MINGW_CHOST}-gfortran.exe
 
   #cp bin/libgfortran*.dll ${pkgdir}${MINGW_PREFIX}/bin/
 

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -288,7 +288,7 @@ package_mingw-w64-gcc() {
   cp bin/g++.exe                                        ${pkgdir}${MINGW_PREFIX}/bin/
   cp bin/${MINGW_CHOST}-c++.exe                         ${pkgdir}${MINGW_PREFIX}/bin/
   cp bin/${MINGW_CHOST}-g++.exe                         ${pkgdir}${MINGW_PREFIX}/bin/
-  cp bin/${MINGW_CHOST}-gcc-${pkgver%%+*}.exe               ${pkgdir}${MINGW_PREFIX}/bin/
+  cp bin/${MINGW_CHOST}-gcc-${pkgver%%+*}.exe           ${pkgdir}${MINGW_PREFIX}/bin/
   cp bin/${MINGW_CHOST}-gcc.exe                         ${pkgdir}${MINGW_PREFIX}/bin/
   cp bin/${MINGW_CHOST}-gcc-ar.exe                      ${pkgdir}${MINGW_PREFIX}/bin/
   cp bin/${MINGW_CHOST}-gcc-nm.exe                      ${pkgdir}${MINGW_PREFIX}/bin/
@@ -311,7 +311,7 @@ package_mingw-w64-gcc() {
 
   cp lib/libatomic*                                      ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
   cp lib/libgcc*                                         ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
-  cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/libgcc*            ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
+  cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/libgcc*        ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
 
   cp lib/libgomp*                                        ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
   # cp lib/libitm*                                         ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
@@ -343,7 +343,7 @@ package_mingw-w64-gcc() {
 
   #cp share/locale/* ${pkgdir}${MINGW_PREFIX}/share/locale/
   mkdir -p ${pkgdir}${MINGW_PREFIX}/share/gcc-${pkgver%%+*}/python
-  cp -r share/gcc-${pkgver%%+*}/python/libstdcxx             ${pkgdir}${MINGW_PREFIX}/share/gcc-${pkgver%%+*}/python/
+  cp -r share/gcc-${pkgver%%+*}/python/libstdcxx         ${pkgdir}${MINGW_PREFIX}/share/gcc-${pkgver%%+*}/python/
   mkdir -p ${pkgdir}${MINGW_PREFIX}/share/man/man1
   cp share/man/man1/cpp.1*                               ${pkgdir}${MINGW_PREFIX}/share/man/man1/
   cp share/man/man1/gcc.1*                               ${pkgdir}${MINGW_PREFIX}/share/man/man1/
@@ -355,7 +355,7 @@ package_mingw-w64-gcc() {
 
   # install plugins for binutils
   mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/bfd-plugins
-  cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/*plugin*.dll       ${pkgdir}${MINGW_PREFIX}/lib/bfd-plugins/
+  cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/*plugin*.dll   ${pkgdir}${MINGW_PREFIX}/lib/bfd-plugins/
 
   # install "custom" system gdbinit
   install -D -m644 ${srcdir}/gdbinit ${pkgdir}${MINGW_PREFIX}/etc/gdbinit
@@ -407,9 +407,9 @@ package_mingw-w64-gcc-ada() {
   cp bin/{libgnarl*,libgnat*}.dll                       ${pkgdir}${MINGW_PREFIX}/bin/
 
   mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}
-  cp -r lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/adainclude     ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
-  cp -r lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/adalib         ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
-  cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/gnat1.exe         ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
+  cp -r lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/adainclude ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
+  cp -r lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/adalib     ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
+  cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/gnat1.exe     ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
 
   mkdir -p ${pkgdir}${MINGW_PREFIX}/share/info
   cp share/info/gnat-style.info*                        ${pkgdir}${MINGW_PREFIX}/share/info/


### PR DESCRIPTION
Use hard links to reduce the install size.
See also #5970.

Also adjust alignment.