### PR TITLE
nlohmann_json: Rename to nlohmann-json and update to 3.7.3

### DIFF
--- a/mingw-w64-nlohmann-json/PKGBUILD
+++ b/mingw-w64-nlohmann-json/PKGBUILD
@@ -1,10 +1,10 @@
 # Maintainer: Konstantin Podsvirov <konstantin@podsvirov.pro>
 
 _realname=json
-_pkgname=nlohmann_json
+_pkgname=nlohmann-json
 pkgbase=mingw-w64-${_pkgname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_pkgname}"
-pkgver=3.7.2
+pkgver=3.7.3
 pkgrel=1
 pkgdesc="JSON for Modern C++ (mingw-w64)"
 arch=('any')
@@ -12,9 +12,12 @@ url="https://github.com/nlohmann/json"
 license=('MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake")
+conflicts=("${MINGW_PACKAGE_PREFIX}-nlohmann_json")
+provides=("${MINGW_PACKAGE_PREFIX}-nlohmann_json")
+replaces=("${MINGW_PACKAGE_PREFIX}-nlohmann_json")
 options=('staticlibs' '!strip' '!buildflags')
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/nlohmann/json/archive/v${pkgver}.tar.gz")
-sha256sums=('914c4af3f14bb98ff084172685fba5d32e8ce4390ec8ba5da45c63daa305df4d')
+sha256sums=('249548f4867417d66ae46b338dfe0a2805f3323e81c9e9b83c89f3adbfde6f31')
 
 build() {
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"


### PR DESCRIPTION
Rename to `nlohmann-json` to be consistence with Arch [package](https://aur.archlinux.org/packages/nlohmann-json/).
Update to 3.7.3 to fix latest bugs.