### PR TITLE
Mesa3D: Update to 19.2.5 and implement LLVM Meson wrap generator

### DIFF
--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -3,13 +3,14 @@
 _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=19.2.4
+pkgver=19.2.5
 pkgrel=1
 pkgdesc="Open-source implementation of the OpenGL specification (mingw-w64)"
 arch=('any')
 makedepends=("${MINGW_PACKAGE_PREFIX}-llvm"
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-zlib"
+             "${MINGW_PACKAGE_PREFIX}-python3"
              "scons"
              "python2-mako")
 optdepends=("${MINGW_PACKAGE_PREFIX}-opengl-man-pages: for the OpenGL API man pages")
@@ -18,11 +19,13 @@ license=('MIT')
 options=('staticlibs' 'strip')
 source=(https://mesa.freedesktop.org/archive/${_realname}-${pkgver}.tar.xz{,.sig}
         001-extra-libs.patch
-        osmesa.pc)
-sha256sums=('09000a0f7dbbd82e193b81a8f1bf0c118eab7ca975c0329181968596e548e30f'
+        osmesa.pc
+        llvmwrapgen.sh)
+sha256sums=('3d010a366b28d10bdd71e32091d8684baf1522e6466c5c5703667091b2108c8b'
             'SKIP'
             'bc9bb5013ac80ded47ad164ae1ef58cc9a39784eb4bf61e8c7d654bb273b05a9'
-            'fdf26548336cc7e5700560c6636a87ffa63daa3048fa94cf4a4a0b50890c9327')
+            'fdf26548336cc7e5700560c6636a87ffa63daa3048fa94cf4a4a0b50890c9327'
+            'c9df8e4258b9723c4438556a2683f9891033bb1d26f35e0b4d789da5f728c138')
 validpgpkeys=('8703B6700E7EE06D7A39B8D6EDAE37B02CEB490D') # Emil Velikov <emil.l.velikov@gmail.com>
 validpgpkeys+=('946D09B5E4C9845E63075FF1D961C596A7203456') # Andres Gomez <tanty@igalia.com>
 validpgpkeys+=('E3E8F480C52ADD73B278EE78E1ECBE07D7D70895') # Juan Antonio Suárez Romero (Igalia, S.L.) <jasuarez@igalia.com>"
@@ -68,6 +71,11 @@ prepare() {
 # values and we probably don't need to call it anyway.
 
 #  patch -p1 -i ${srcdir}/001-extra-libs.patch
+
+# Run and optionally test LLVM Meson wrap generator
+
+  ${srcdir}/llvmwrapgen.sh
+# /bin/cat ${srcdir}/${_realname}-${pkgver}/subprojects/llvm/meson.build
 }
 
 buildcmd(){

--- a/mingw-w64-mesa/llvmwrapgen.sh
+++ b/mingw-w64-mesa/llvmwrapgen.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Get LLVM libraries
+llvmlibs=$(${MINGW_PREFIX}/bin/llvm-config --libnames engine coroutines)
+
+# Get LLVM RTTI status
+rtti=false
+if [ $(${MINGW_PREFIX}/bin/llvm-config --has-rtti) = YES ]; then
+  rtti=true
+fi
+
+# Convert llvm-config output into a Python list
+llvmlibs="${llvmlibs//.a/}"
+llvmlibs=\'"${llvmlibs// /\', \'}"\'
+
+# Get MSYS2 Mingw-w64 runtime location
+msysloc=$(${MINGW_PREFIX}/bin/python3 -c "import sys; print(sys.executable)")
+msysloc=${msysloc//\"/}
+msysloc=${msysloc//\\/\/}
+msysloc=${msysloc:0:-16}
+
+# Generate a Meson wrap file for LLVM
+mkdir -p ./subprojects/llvm
+FILE="./subprojects/llvm/meson.build"
+/bin/cat <<EOM >${FILE}
+project('llvm', ['cpp'])
+
+cpp = meson.get_compiler('cpp')
+
+_deps = []
+_search = '${msysloc}/lib'
+foreach d : [${llvmlibs}]
+  _deps += cpp.find_library(d, dirs : _search)
+endforeach
+
+dep_llvm = declare_dependency(
+  include_directories : include_directories('${msysloc}/include'),
+  dependencies : _deps,
+  version : '$(${MINGW_PREFIX}/bin/llvm-config --version)',
+)
+
+has_rtti = ${rtti}
+irbuilder_h = files('${msysloc}/include/llvm/IR/IRBuilder.h')
+EOM


### PR DESCRIPTION
In addition to updating to 19.2.5 this PR includes LLVM Meson wrap generator from #5977 with improvement to properly get LLVM RTTI status instead of hard-coding it. I chose to include it as it isn't bound to any Mesa3D version. I thought it's a good idea to get it done early so that switch to Meson later becomes less of a hassle.