### PR TITLE
gtk3: disable forcing CSD again and skip sass rebuild due to broken libsass

### DIFF
--- a/mingw-w64-gtk3/0001-disable-sass-rebuild.patch
+++ b/mingw-w64-gtk3/0001-disable-sass-rebuild.patch
@@ -1,0 +1,13 @@
+diff --git a/gtk/meson.build b/gtk/meson.build
+index 5a0b1547d8..b008eba4fd 100644
+--- a/gtk/meson.build
++++ b/gtk/meson.build
+@@ -682,7 +682,7 @@ gtk_gresources_xml = configure_file(output: 'gtk.gresources.xml',
+ # Re-build the theme files if sassc is available
+ theme_deps = []
+ sassc = find_program('sassc', required: false)
+-if sassc.found()
++if sassc.found() and false
+   sassc_opts = [ '-a', '-M', '-t', 'compact' ]
+ 
+   subdir('theme/Adwaita')

--- a/mingw-w64-gtk3/0003-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch
+++ b/mingw-w64-gtk3/0003-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch
@@ -1,0 +1,35 @@
+From 975e5ce8ac04632606917e321cddad4bcce31553 Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Thu, 28 Sep 2017 12:02:03 +0200
+Subject: [PATCH] gtkwindow: Don't force enable CSD under Windows
+
+CSD look a bit out of place under Windows, especially
+when the application doesn't use the headerbar and the CSD
+doesn't add any value.
+
+Instead let the application decide, like under X11.
+It can still be force enabled through GTK_CSD=1
+---
+ gtk/gtkwindow.c | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/gtk/gtkwindow.c b/gtk/gtkwindow.c
+index 6c5f136043..d178390536 100644
+--- a/gtk/gtkwindow.c
++++ b/gtk/gtkwindow.c
+@@ -6119,12 +6119,6 @@ gtk_window_should_use_csd (GtkWindow *window)
+     }
+ #endif
+ 
+-#ifdef GDK_WINDOWING_WIN32
+-  if (g_strcmp0 (csd_env, "0") != 0 &&
+-      GDK_IS_WIN32_DISPLAY (gtk_widget_get_display (GTK_WIDGET (window))))
+-    return TRUE;
+-#endif
+-
+   return (g_strcmp0 (csd_env, "1") == 0);
+ }
+ 
+-- 
+2.24.0
+

--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gtk3
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.24.12
-pkgrel=1
+pkgrel=2
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
 url="https://www.gtk.org/"
@@ -29,15 +29,25 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-shared-mime-info")
 options=('strip' '!debug' 'staticlibs')
 source=("https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}.tar.xz"
-        "0002-Revert-Quartz-Set-the-popup-menu-type-hint-before-re.patch")
+        "0001-disable-sass-rebuild.patch"
+        "0002-Revert-Quartz-Set-the-popup-menu-type-hint-before-re.patch"
+        "0003-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch")
 sha256sums=('1384eba5614fed160044ae0d32369e3df7b4f517b03f4b1f24d383e528f4be83'
-            '5cdebb11098d241da955d4662904215275fa7a54d52877cc38c4ff4a3087fafd')
+            '4c4b597c4a1fb2d4ba7f90741c317be9eeb2053a09a80c2e1095b34b1d86ef06'
+            '5cdebb11098d241da955d4662904215275fa7a54d52877cc38c4ff4a3087fafd'
+            'b84a7f38f0af80680bee143d431f2a7bae53899efb337de0f67a1b4d9b59fa02')
 
 prepare() {
   cd "${srcdir}/gtk+-${pkgver}"
 
+  # https://gitlab.gnome.org/GNOME/gtk/issues/2237
+  patch -p1 -i "${srcdir}"/0001-disable-sass-rebuild.patch
+
   # https://gitlab.gnome.org/GNOME/gtk/issues/2019
   patch -p1 -i "${srcdir}"/0002-Revert-Quartz-Set-the-popup-menu-type-hint-before-re.patch
+
+  # https://gitlab.gnome.org/GNOME/gtk/issues/760
+  patch -p1 -i "${srcdir}"/0003-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch
 }
 
 build() {


### PR DESCRIPTION
This re-applies the CSD patch dropped due to a misunderstanding in the last commit.

Because gtk isn't buildable with libsass 3.6.3 due to libsass bugs disable the CSS
regeneration for now and use the one from the tarball.