### PR TITLE
pyopengl 3.1.3rc1

### DIFF
--- a/mingw-w64-python-pyopengl/PKGBUILD
+++ b/mingw-w64-python-pyopengl/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=PyOpenGL
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=3.1.1a1
-pkgrel=3
+pkgver=3.1.3rc1
+pkgrel=1
 pkgdesc="PyOpenGL is the most common cross platform Python binding to OpenGL and related APIs (mingw-w64)"
 arch=('any')
 url='http://pyopengl.sourceforge.net'
@@ -18,37 +18,20 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
 options=('staticlibs' 'strip' '!debug')
 _dtoken='df/fe/b9da75e85bcf802ed5ef92a5c5e4022bf06faa1d41b9630b9bb49f827483'
 _acceltoken='84/74/b48e413c97cbe51d778cba58a431bb8348d826a1576ab48b3c5340628bd8'
-source=("https://files.pythonhosted.org/packages/${_dtoken}/${_realname}-${pkgver}.tar.gz"
-        "https://files.pythonhosted.org/packages/${_acceltoken}/${_realname}-accelerate-${pkgver}.tar.gz"
-        "formathandler.pxd"
-        "wrapper.pxd")
-sha512sums=('8f4f57b153ee014dc238fe83180cc92f8e789a274fc6b0cbef6f5dec9dbc44cb1ae1f6b142a6c2b4c8c000709338d64f5968939eeb6a2384f87fb63ae99b40d8'
-            '6881e3b435da5a33ff31c0991f403166236b44a5bd21ca60418d131dafc1159d6b1c73e60b935d1761d4fc848b824422abbe0e850fe860fa694b64536dddc35c'
-            'c7d846aaf9b3af526ae8870d9821846ddbfb132b4db05a974f0198dea9bf76684f4473bb6ba88e0c6dd3732865b1963489a506dca91d0613b53af598e4fdb684'
-            'cc8c06550fb365929ca0fae237298ad64c2d4c14fda8963ab0601bd55c9b43c15787bd77784419d8590335fee4be73b916a19436a752f33ceedc7d6ab3e48c9e')
+source=("https://files.pythonhosted.org/packages/95/32/f655c15deada40134cb2e56037ec13968fe5b1fedafe71d5026aa1d64f41/${_realname}-${pkgver}.tar.gz"
+        "https://files.pythonhosted.org/packages/81/61/252f8d3f0736964b55e565b550cf9f2912f7363269ce9a26402a0ff06cf1/${_realname}-accelerate-${pkgver}.tar.gz")
+sha512sums=('f9f446cdf06bcb10420c90e668ef77c7207ebc3c9401da2a8923ca2cb3941493ad3acfd49038bd923eadad7854e01b594843bfe9f2bb1af40f06c42987792687'
+            '2b458da701178ab6a21467cf4291aaf7517f281162ad60cf4691d6cead39f0af3183de0e70a3fedff1f62eadd776860f5b91d8fbcfcaefc2f30b1e51fabc2b20')
 
 prepare() {
-  #force regeneration of the .c files since the ones distributed
-  #with the source are too old and don't compile with python3.7:
-  accel_dir="${srcdir}/${_realname}-accelerate-${pkgver}"
-  rm -f ${accel_dir}/src/*.c
-  #now add the missing sources files:
-  #https://github.com/mcfletch/pyopengl/issues/12
-  #we have to create a module structure, so cython will find them:
-  mkdir ${accel_dir}/OpenGL_accelerate
-  cp formathandler.pxd wrapper.pxd "${accel_dir}/OpenGL_accelerate/"
-  cp ${accel_dir}/__init__.py "${accel_dir}/OpenGL_accelerate/"
-
   cd "${srcdir}"
   for builddir in python{2,3}-build-${CARCH}; do
     rm -rf ${builddir} | true
     cp -r "${_realname}-${pkgver}" "${builddir}"
     cp -r "${_realname}-accelerate-${pkgver}" "${builddir}-accelerate"
+    echo "TODO" > "${builddir}/readme.rst"
+    echo "TODO" > "${builddir}-accelerate/readme.rst"
   done
-  #'async' is a keyword now in python 3.7,
-  #just remove those extensions which aren't used on win32 anyway:
-  rm -fr python3-build-${CARCH}/OpenGL/GL/SGIX/async*
-  rm -fr python3-build-${CARCH}/OpenGL/raw/GL/SGIX/async*
 }
 
 build() {


### PR DESCRIPTION
- removes all the workarounds we had added for python 3.8 since those have now been merged
- adds a workaround for the missing `readme.rst` file containing the long description (which is not shown anywhere)