### PR TITLE
Update mingw-w64-gtk4 package to 3.96.0

### DIFF
--- a/mingw-w64-gtk4/0001-imcontextime-Add-missing-semicolon.patch
+++ b/mingw-w64-gtk4/0001-imcontextime-Add-missing-semicolon.patch
@@ -1,0 +1,26 @@
+From ca2bffc06024d12b65995900f2b61de09051bd8e Mon Sep 17 00:00:00 2001
+From: Benjamin Otte <otte@redhat.com>
+Date: Tue, 21 May 2019 07:18:50 +0200
+Subject: [PATCH] imcontextime: Add missing semicolon
+
+I wonder how thoroughly this was tested... ;)
+---
+ gtk/gtkimcontextime.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gtk/gtkimcontextime.c b/gtk/gtkimcontextime.c
+index ab972c90e6..1814e7b30b 100644
+--- a/gtk/gtkimcontextime.c
++++ b/gtk/gtkimcontextime.c
+@@ -879,7 +879,7 @@ gtk_im_context_ime_set_preedit_font (GtkIMContext *context)
+ 
+   widget = gtk_root_get_for_surface (context_ime->client_surface);
+   if (!widget)
+-    return
++    return;
+ 
+   hwnd = gdk_win32_surface_get_impl_hwnd (context_ime->client_surface);
+   himc = ImmGetContext (hwnd);
+-- 
+2.23.0.windows.1
+

--- a/mingw-w64-gtk4/PKGBUILD
+++ b/mingw-w64-gtk4/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gtk4
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.94.0
+pkgver=3.96.0
 pkgrel=1
 pkgdesc="GObject-based multi-platform GUI toolkit (v4) (mingw-w64)"
 arch=('any')
@@ -25,14 +25,16 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libepoxy"
          "${MINGW_PACKAGE_PREFIX}-pango"
          "${MINGW_PACKAGE_PREFIX}-gst-plugins-bad"
-         "${MINGW_PACKAGE_PREFIX}-gtk3" # for the conflicting files
          "${MINGW_PACKAGE_PREFIX}-shared-mime-info")
-options=('strip' '!debug')
-source=("https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}.tar.xz")
-sha256sums=('a947caa5296610b0f1d7a03b58df34765c227c577c78e683e75eea3251a67035')
+options=('!strip' '!debug')
+source=("https://gitlab.gnome.org/GNOME/gtk/-/archive/${pkgver}/gtk-${pkgver}.tar.gz"
+        "0001-imcontextime-Add-missing-semicolon.patch")
+sha512sums=('d16d36725a82fe06bdd6b7346348fae0e709351f46337a5e8c0cffce3ea69fa79d449def4dfe53167d2363e959ee6b33d122415e3f443135f5ed79d037071a7f'
+            'eafa6ebe1153ff56b8e870461e2173adbebf572cc9fbb8c1b7926c9064c8741549d87b92ebae98158ff4170970aed1edddbad5d14c0c5bee92a520f3e5ee7ce2')
 
 prepare() {
-  cd "${srcdir}/gtk+-${pkgver}"
+  cd "${srcdir}/gtk-${pkgver}"
+  patch -p1 -i "${srcdir}"/0001-imcontextime-Add-missing-semicolon.patch
 }
 
 build() {
@@ -40,12 +42,14 @@ build() {
   mkdir "${srcdir}/build-${MINGW_CHOST}"
   cd "${srcdir}/build-${MINGW_CHOST}"
 
+  CFLAGS+=" -DG_ENABLE_DEBUG -DG_DISABLE_CAST_CHECKS"
   meson \
+    --buildtype=plain \
     -Dbuild-examples=false \
     -Dbuild-tests=false \
     -Dman-pages=true \
     -Dvulkan=no \
-    ../gtk+-${pkgver}
+    ../gtk-${pkgver}
 
   ninja
 }
@@ -59,10 +63,5 @@ package() {
     sed -s "s|$(cygpath -m ${MINGW_PREFIX})|${MINGW_PREFIX}|g" -i "${pcfile}"
   done
 
-  # In conflict with gtk3
-  rm "${pkgdir}${MINGW_PREFIX}"/share/gettext/its/gtkbuilder{.its,.loc}
-  rm "${pkgdir}${MINGW_PREFIX}"/share/glib-2.0/schemas/org.gtk.Demo.gschema.xml
-  rm "${pkgdir}${MINGW_PREFIX}"/share/glib-2.0/schemas/org.gtk.Settings.{ColorChooser,Debug,EmojiChooser,FileChooser}.gschema.xml
-
-  install -Dm644 "${srcdir}/gtk+-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+  install -Dm644 "${srcdir}/gtk-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }


### PR DESCRIPTION
Update to 3.96.0. The conflicts with files in gtk3 package are now gone (https://gitlab.gnome.org/GNOME/gtk/commit/5c31c721af45a3cf884575c41c5e14899b3a0c08). Also, the PKGBUILD changed a bit to follow the renaming from GTK+ to GTK.

Other changes:
- Changed to `--buildtype=plain` as done for the gtk3 package
- Disabled the `strip` build option