### PR TITLE
xpra 3.0.2

### DIFF
--- a/mingw-w64-python-xpra/PKGBUILD
+++ b/mingw-w64-python-xpra/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-common"
          "${MINGW_PACKAGE_PREFIX}-python2-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=3.0.1
+pkgver=3.0.2
 pkgrel=1
 pkgdesc="Remote access client / server software"
 arch=('any')
@@ -38,7 +38,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pygobject-devel"
              "${MINGW_PACKAGE_PREFIX}-python3-cairo")
 source=("https://xpra.org/src/xpra-${pkgver}.tar.xz")
-sha512sums=('2fd04afe416c9b26c5404f0114c8abbe8367a6cb3e745ffaecedcbb864b1ada4575f7289807a152f6d01834e1f1fc4d6ac780335537f69ec393ef3d16928f4e2')
+sha512sums=('115f606ff5886d99a906f318cb1a7a4a86e80ebf23e4336e67938267d92ef624de577cc8fc06c6ce541b7c44a0cef58d930b5928f32e24dfc67c72127c7b623c')
 
 prepare() {
   cd "${srcdir}"
@@ -140,6 +140,8 @@ package_xpra-common() {
   #python version agnostic launch scripts in /bin:
   for script in xpra xpra_launcher; do
     install -Dm755 scripts/${script} "${pkgdir}${MINGW_PREFIX}/bin/${script}"
+    #patch path to the python interpreter:
+    sed -i -e "s+/usr/bin/python+$MINGW_PREFIX/bin/python+g" "${pkgdir}${MINGW_PREFIX}/bin/${script}"
   done
 
   #html5 client:


### PR DESCRIPTION
- version bump 
- fixes the launch scripts so it will correctly fallback to using the python2 build if that is the only version installed