### PR TITLE
wineditline: Fix missing "extern c" in header

### DIFF
--- a/mingw-w64-wineditline/005-fix-missing-extern-c.patch
+++ b/mingw-w64-wineditline/005-fix-missing-extern-c.patch
@@ -1,0 +1,13 @@
+--- src/editline/readline.h	2019-07-03 09:09:00.000000000 +0200
++++ src/editline/readline.h	2019-11-30 16:56:47.213858800 +0100
+@@ -46,6 +46,10 @@
+ */
+ #define DEFAULT_HISTORY_SIZE    200  /* default number of history entries */
+ 
++#ifdef __cplusplus
++extern "C" {
++#endif
++
+ typedef char **rl_completion_func_t(const char *, int, int);
+ typedef char *rl_compentry_func_t(const char *, int);
+ typedef void rl_compentryfree_func_t(void *);

--- a/mingw-w64-wineditline/PKGBUILD
+++ b/mingw-w64-wineditline/PKGBUILD
@@ -4,7 +4,7 @@ _realname=wineditline
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.205
-pkgrel=2
+pkgrel=3
 pkgdesc="port of the NetBSD Editline library (mingw-w64)"
 arch=('any')
 license=('BSD')
@@ -15,12 +15,14 @@ source=("https://sourceforge.net/projects/mingweditline/files/${_realname}-${pkg
         '001-fix-installing.patch'
         '002-fix-exports.patch'
         '003-dont-link-with-def.patch'
-        '004-add-pkgconfig.patch')
+        '004-add-pkgconfig.patch'
+        '005-fix-missing-extern-c.patch')
 sha256sums=('dc8b25cbd503dd41241b8de0146af20182b552ac31cf0fc7e103b83aec25e448'
             '821d0a36115832a76497dc6d7ea4b6e45e4ce73621030a59865f851309f8db34'
             '38e779fbdebf2f29038b598920e733a4a51638834013c3cc73fb85a7d50cffd2'
             '19077726758de7780cd68f3f47d8353516fd864ede1903d55280a1fb3dbe408d'
-            '0350d2d027ae665fb39bbdf847da3c9e0bbd5f55ee0f90b377b1891e933dd28c')
+            '0350d2d027ae665fb39bbdf847da3c9e0bbd5f55ee0f90b377b1891e933dd28c'
+            '9668acad9e37a4fd21ba4242e183ce6515d749f9f58d89ffece5ffeb4ab7274e')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
@@ -32,6 +34,7 @@ prepare() {
   patch -Np1 -i ${srcdir}/002-fix-exports.patch
   patch -Np1 -i ${srcdir}/003-dont-link-with-def.patch
   patch -Np1 -i ${srcdir}/004-add-pkgconfig.patch
+  patch -Np1 -i ${srcdir}/005-fix-missing-extern-c.patch
 
   rm -rf bin32 bin64 lib32 lib64
 }


### PR DESCRIPTION
Fixes #6008 

As I don't know how to integrate SVN sources, I instead supply the patch provided by @olafmandel in the mentioned issue.