### PR TITLE
mpv: fix build failed

### DIFF
--- a/mingw-w64-mpv/PKGBUILD
+++ b/mingw-w64-mpv/PKGBUILD
@@ -72,7 +72,6 @@ build() {
     --enable-libbluray \
     --enable-lua \
     --enable-rubberband \
-    --enable-shaderc \
     --enable-uchardet \
     --enable-vapoursynth \
     --enable-vulkan \

--- a/mingw-w64-mpv/PKGBUILD
+++ b/mingw-w64-mpv/PKGBUILD
@@ -23,6 +23,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-ffmpeg"
          "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
          "${MINGW_PACKAGE_PREFIX}-libplacebo"
          "${MINGW_PACKAGE_PREFIX}-lua51"
+         "${MINGW_PACKAGE_PREFIX}-pkg-config"
          "${MINGW_PACKAGE_PREFIX}-rubberband"
          "${MINGW_PACKAGE_PREFIX}-uchardet"
          "${MINGW_PACKAGE_PREFIX}-vapoursynth"
@@ -31,7 +32,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-ffmpeg"
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-python3-docutils"
              "perl"
-             "pkg-config"
              "python")
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/mpv-player/${_realname}/archive/v${pkgver}.tar.gz)
 sha256sums=('33a1bcb7e74ff17f070e754c15c52228cf44f2cefbfd8f34886ae81df214ca35')
@@ -51,7 +51,7 @@ build() {
 
   DEST_OS=win32 \
   TARGET=${MINGW_CHOST} \
-  PKG_CONFIG=/usr/bin/pkg-config \
+  PKG_CONFIG=${MINGW_PREFIX}/bin/pkg-config \
   CC=gcc PERL=/usr/bin/perl \
   AR=${MINGW_PREFIX}/bin/ar \
   WINDRES=${MINGW_PREFIX}/bin/windres \


### PR DESCRIPTION
I don't know why, but when we use `pkg-config` of `MSYS2`, building of the package fails.