### PR TITLE
groonga: update to Groonga 9.1.0

### DIFF
--- a/mingw-w64-groonga/PKGBUILD
+++ b/mingw-w64-groonga/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=groonga
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=9.0.9
+pkgver=9.1.0
 pkgrel=1
 pkgdesc="An opensource fulltext search engine (mingw-w64)"
 arch=('any')
@@ -23,7 +23,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-arrow"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-zstd")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
-sha256sums=('09767f0295b3321d8b41802c5a190ac3b0118f4b9106422754b448f4d801ae2b')
+sha256sums=('7342ffee8f64a8d95d323b53b30d0d07aede1296f8ac86d120dfac4695bdb486')
 
 build() {
   [[ -d ${srcdir}/build-${CARCH} ]] && rm -rf ${srcdir}/build-${CARCH}


### PR DESCRIPTION
I update Groonga's version in PKGBUILD.
Because upstream was update.