### PR TITLE
libplacebo: add spirv-tools dep; increment pkgrel

### DIFF
--- a/mingw-w64-libplacebo/PKGBUILD
+++ b/mingw-w64-libplacebo/PKGBUILD
@@ -4,11 +4,12 @@ _realname=libplacebo
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.21.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Reusable library for GPU-accelerated video/image rendering primitives (mingw-w64)"
 arch=('any')
 url="https://github.com/haasn/libplacebo/"
-depends=("${MINGW_PACKAGE_PREFIX}-vulkan")
+depends=("${MINGW_PACKAGE_PREFIX}-vulkan"
+         "${MINGW_PACKAGE_PREFIX}-spirv-tools")
 makedepends=("${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-glslang"


### PR DESCRIPTION
```
> cygcheck /mingw64/bin/libplacebo-21.dll
C:\msys64\mingw64\bin\libplacebo-21.dll
  C:\msys64\mingw64\bin\libSPIRV-Tools.dll
...
> pacman -Qo /mingw64/bin/libSPIRV-Tools.dll
/mingw64/bin/libSPIRV-Tools.dll is owned by mingw-w64-x86_64-spirv-tools 2019.4-1
```