### PR TITLE
librsvg: update to version 2.46.4

### DIFF
--- a/mingw-w64-librsvg/PKGBUILD
+++ b/mingw-w64-librsvg/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=librsvg
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.46.3
+pkgver=2.46.4
 pkgrel=1
 pkgdesc="SVG rendering library (mingw-w64)"
 arch=('any')
@@ -23,7 +23,7 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-gtk3: for rsvg-view-3")
 options=('staticlibs' 'strip')
 source=("https://download.gnome.org/sources/librsvg/${pkgver%.*}/${_realname}-${pkgver}.tar.xz"
         "0005-hack-unixy-paths.patch")
-sha256sums=('768e46467d874161a277bd696551f4f364b3c8d51eeedeb9b4fe1277a2496ae8'
+sha256sums=('b45b9ee3b64c58baaf800bcdff5fcd04d79930dba4c56e46e0d3b0aead40cc29'
             'b23b094c0cb65fcbbbb952350448de6f3430b30f273e05acdbf7a56d634212dc')
 
 prepare() {


### PR DESCRIPTION
Primarily to fix https://gitlab.gnome.org/GNOME/librsvg/issues/525