### PR TITLE
New package: tnef

### DIFF
--- a/mingw-w64-tnef/PKGBUILD
+++ b/mingw-w64-tnef/PKGBUILD
@@ -1,0 +1,41 @@
+# Maintainer: Joan Karadimov <joan.karadimov@gmail.com>
+# Contributor: Luca P <meti at lplab.net>
+# Contributor: Sergej Pupykin <pupykin.s+arch@gmail.com>
+# Contributor: Jeffrey 'jf' Lim <jfs.world@gmail.com>
+
+_realname=tnef
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.4.18
+pkgrel=1
+arch=('any')
+pkgdesc="Program which operates like tar to unpack the files inside an ms-tnef MIME attachment"
+url="https://github.com/verdammelt/tnef"
+license=('GPL')
+depends=()
+makedepends=('autoconf' 'automake-wrapper' 'make')
+source=("$_realname-$pkgver.tar.gz::https://github.com/verdammelt/tnef/archive/$pkgver.tar.gz"
+        "index-functions.patch")
+sha256sums=('fa56dd08649f51b173017911cae277dc4b2c98211721c2a60708bf1d28839922'
+            '5d4e51329ef93f9a756522818407202092baa89a36e83f7c3b9f279685f44169')
+
+prepare() {
+  cd "${srcdir}/$_realname-$pkgver"
+  patch -p1 < "${startdir}"/index-functions.patch
+  [ -x configure ] || autoreconf
+}
+
+build() {
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  ../${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST}
+  make
+}
+
+package() {
+  cd "$srcdir"/$_realname-$pkgver
+  make DESTDIR="$pkgdir" install
+}

--- a/mingw-w64-tnef/index-functions.patch
+++ b/mingw-w64-tnef/index-functions.patch
@@ -1,0 +1,11 @@
+--- 000/src/path.c	2019-11-14 16:19:01.394256300 +0200
++++ 001/src/path.c	2019-11-14 16:18:55.296378500 +0200
+@@ -35,6 +35,8 @@
+ #include "path.h"
+ #include "debug.h"
+ 
++#define rindex strrchr
++#define index strchr
+ /* concatenates fname1 with fname2 to make a pathname, adds '/' as needed */
+ /* strips trailing '/' */
+ 


### PR DESCRIPTION
Mostly based on https://aur.archlinux.org/packages/tnef/, although there's nothing too fancy.

There is a patch file for the current version (1.4.18). But the next version will feature a mingw fix (https://github.com/verdammelt/tnef/pull/43) and will compile without any patches.