### PR TITLE
xpra 3.0.3

### DIFF
--- a/mingw-w64-python-xpra/PKGBUILD
+++ b/mingw-w64-python-xpra/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-common"
          "${MINGW_PACKAGE_PREFIX}-python2-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=3.0.2
+pkgver=3.0.3
 pkgrel=1
 pkgdesc="Remote access client / server software"
 arch=('any')
@@ -38,7 +38,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pygobject-devel"
              "${MINGW_PACKAGE_PREFIX}-python3-cairo")
 source=("https://xpra.org/src/xpra-${pkgver}.tar.xz")
-sha512sums=('115f606ff5886d99a906f318cb1a7a4a86e80ebf23e4336e67938267d92ef624de577cc8fc06c6ce541b7c44a0cef58d930b5928f32e24dfc67c72127c7b623c')
+sha512sums=('0d13a2685b22e0c90450c0dddeef0663255c6d9e15e347e960c9ac7857cd2081b15d1fdc29b816b5cfdf1f000375be34510fe25be23af3f3b63a8a25d1b31003')
 
 prepare() {
   cd "${srcdir}"


### PR DESCRIPTION
simple version bump.

Link to the release notes: [xpra 3.0.3](https://lists.devloop.org.uk/pipermail/shifter-users/2019-December/002451.html)