### PR TITLE
fix patch file - remove -std=c++11 -pedantic for windows

### DIFF
--- a/mingw-w64-gmic/0001-gmic-windows-build.patch
+++ b/mingw-w64-gmic/0001-gmic-windows-build.patch
@@ -15,7 +15,7 @@ index 547cd70..e118b54 100644
 @@ -113,10 +113,15 @@
  OS = Unix
  endif
- 
+
 -ifneq (, $(findstring MINGW, $(OS)))
 +ifneq (, $(findstring MINGW64, $(OS)))
  OS = Windows
@@ -26,7 +26,7 @@ index 547cd70..e118b54 100644
 +OS = Windows
 +USR = /mingw32
 +endif
- 
+
  ifeq ($(OS),Darwin)
  ifeq (,$(wildcard /opt/local))
 @@ -186,9 +186,6 @@ ifndef NO_STDLIB
@@ -36,26 +36,26 @@ index 547cd70..e118b54 100644
 -ifeq ($(OS),Windows)
 -MANDATORY_LIBS += -Wl,--stack,16777216
 -endif
- 
+
  # Enable optimizations.
  OPT_CFLAGS = -Ofast
 @@ -288,8 +288,8 @@ CURL_LIBS = $(shell pkg-config --libs libcurl || echo -lcurl)
- 
+
  # Enable native support of webcams and video streaming, using the OpenCV library.
  # (https://opencv.org/)
 -OPENCV_CFLAGS = -Dcimg_use_opencv $(shell pkg-config opencv --cflags || echo -I/usr/include/opencv) -I/usr/include/opencv
 -OPENCV_LIBS = $(shell pkg-config opencv --libs || echo -lopencv_core -lopencv_highgui)
 +OPENCV_CFLAGS = -Dcimg_use_opencv $(shell pkg-config opencv4 --cflags)
 +OPENCV_LIBS = $(shell pkg-config opencv4 --libs || echo -lopencv_core -lopencv_highgui)
- 
+
  # Enable support of most classical image file formats, using the GraphicsMagick++ library.
  # (http://www.graphicsmagick.org/Magick++/)
 @@ -403,12 +403,21 @@ lib:
- 
+
  _lib: libgmic.o use_libgmic.cpp
  	ar rcs libgmic.a libgmic.o
 +ifeq ($(OS),Windows)
-+	$(CXX) -shared -std=c++11 -pedantic -o libgmic$(SO) \
++	$(CXX) -shared -o libgmic$(SO) \
 +	-Wl,--out-implib=libgmic$(SO).a \
 +	-Wl,--export-all-symbols \
 +	-Wl,--enable-auto-import \
@@ -69,13 +69,13 @@ index 547cd70..e118b54 100644
  	$(CXX) -o use_libgmic use_libgmic.cpp -std=c++11 -pedantic -L. -lgmic $(LIBS)
  endif
 +endif
- 
+
  libgmic.o: gmic.cpp gmic.h gmic_stdlib.h CImg.h
  	$(CXX) -o libgmic.o -c gmic.cpp $(PIC) $(CFLAGS)
 @@ -708,6 +717,12 @@ install:
  	@if [ -f ../gmic-qt/gmic_gimp_qt ]; then cp -f ../gmic-qt/gmic_gimp_qt $(DESTDIR)$(PLUGINDIR)/; fi
  	@if [ -f ../gmic-qt/gmic_krita_qt ]; then cp -f ../gmic-qt/gmic_krita_qt $(DESTDIR)$(USR)/$(BIN)/; fi
- 
+
 +ifeq ($(OS),Windows)
 +	mkdir -p $(DESTDIR)$(USR)/share
 +	mkdir -p $(DESTDIR)$(USR)/$(LIB)
@@ -93,14 +93,14 @@ index 547cd70..e118b54 100644
  endif
  	mkdir -p $(DESTDIR)$(USR)/share/man/
  	mkdir -p $(DESTDIR)$(USR)/share/man/man1/
--- 
+--
 2.21.0
 
 --- gmic-2.6.6/CMakeLists.txt.orig	2019-06-21 15:19:00.697414100 +0300
 +++ gmic-2.6.6/CMakeLists.txt	2019-06-21 15:19:11.752429600 +0300
 @@ -174,7 +174,7 @@
  endif()
- 
+
  if(ENABLE_OPENCV)
 -  pkg_check_modules(OPENCV opencv)
 +  pkg_check_modules(OPENCV opencv4)

--- a/mingw-w64-gmic/PKGBUILD
+++ b/mingw-w64-gmic/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gmic
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.8.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A Full-Featured Open-Source Framework for Image Processing (mingw-w64)"
 arch=(any)
 url="https://gmic.eu"
@@ -21,13 +21,13 @@ depends=("${MINGW_PACKAGE_PREFIX}-fftw"
          "${MINGW_PACKAGE_PREFIX}-openexr"
          "${MINGW_PACKAGE_PREFIX}-opencv")
 source=("${_realname}-${pkgver}.tar.gz::https://gmic.eu/files/source/${_realname}_${pkgver}.tar.gz"
-        "0001-gmic-2.6.4-windows-build.patch")
+        "0001-gmic-windows-build.patch")
 sha256sums=('d1ca5c726f7570af3a6f0bca27eeb66ef1e6a1b6a17bdaeaf0d59be40b9cd075'
-            '4b6d303af305e7d6f8c38995ce3e37d30d9dced4f4ab4b7d3f00bc90273ffa26')
+            '6a662bf159b9903b13e3eaa23d75ebf1db3b8569b4e9be319d8b3711e3928ec5')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
-  patch -p1 -i "${srcdir}/0001-gmic-2.6.4-windows-build.patch"
+  patch -p1 -i "${srcdir}/0001-gmic-windows-build.patch"
 }
 
 build() {
@@ -59,16 +59,11 @@ build() {
 
   make
 
-  #cd "${srcdir}/${_realname}-${pkgver}/src"
-  #make USR=${MINGW_PREFIX} cli lib
 }
 
 package() {
   cd build-${MINGW_CHOST}
   make DESTDIR="${pkgdir}" install
-
-  #cd "${srcdir}/${_realname}-${pkgver}/src"
-  #make -j1  USR=${MINGW_PREFIX} DESTDIR="${pkgdir}" install
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }


### PR DESCRIPTION
EDIT: gmic package update. The previous version failed with darktable.

I've tried commit --amend but this was bringing some of your previous changes sig ...
I've created a new commit. I hope that's ok.

