### PR TITLE
spdlog: Rebuild

### DIFF
--- a/mingw-w64-spdlog/001-spdlog-1.4.2-include-cassert.patch
+++ b/mingw-w64-spdlog/001-spdlog-1.4.2-include-cassert.patch
@@ -1,0 +1,25 @@
+diff --git a/include/spdlog/details/pattern_formatter-inl.h b/include/spdlog/details/pattern_formatter-inl.h
+index 1b95eb6d..ac6e7f71 100644
+--- a/include/spdlog/details/pattern_formatter-inl.h
++++ b/include/spdlog/details/pattern_formatter-inl.h
+@@ -18,6 +18,7 @@
+ #include <ctime>
+ #include <cctype>
+ #include <cstring>
++#include <cassert>
+ #include <memory>
+ #include <mutex>
+ #include <string>
+diff --git a/include/spdlog/details/thread_pool-inl.h b/include/spdlog/details/thread_pool-inl.h
+index 77d0b1fb..c7731496 100644
+--- a/include/spdlog/details/thread_pool-inl.h
++++ b/include/spdlog/details/thread_pool-inl.h
+@@ -9,6 +9,8 @@
+ 
+ #include "spdlog/common.h"
+ 
++#include <cassert>
++
+ namespace spdlog {
+ namespace details {
+ 

--- a/mingw-w64-spdlog/PKGBUILD
+++ b/mingw-w64-spdlog/PKGBUILD
@@ -4,7 +4,7 @@ _realname=spdlog
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.4.2
-pkgrel=1
+pkgrel=2
 pkgdesc='Very fast, header-only/compiled, C++ logging library'
 arch=('any')
 url='https://github.com/gabime/spdlog'
@@ -13,8 +13,15 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake")
 depends=("${MINGW_PACKAGE_PREFIX}-fmt")
 options=('staticlibs' '!strip' '!buildflags')
-source=("${_realname}-${pkgver}.tar.gz::https://github.com/gabime/spdlog/archive/v${pkgver}.tar.gz")
-sha256sums=('821c85b120ad15d87ca2bc44185fa9091409777c756029125a02f81354072157')
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/gabime/spdlog/archive/v${pkgver}.tar.gz"
+        "001-spdlog-1.4.2-include-cassert.patch")
+sha256sums=('821c85b120ad15d87ca2bc44185fa9091409777c756029125a02f81354072157'
+            '88f49454903d23b22ea05bc54d5316757d63019459873fffafc4be56969f1b71')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -p1 -i "${srcdir}"/001-spdlog-1.4.2-include-cassert.patch
+}
 
 build() {
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"


### PR DESCRIPTION
This required for binary compatibility since dependency `fmt` package updated.
The patch `001-spdlog-1.4.2-include-cassert.patch` required to fix https://github.com/gabime/spdlog/issues/1340.