### PR TITLE
vala: patch for glib-2.0.vapigen that allows proper compilation of Time.local()

### DIFF
--- a/mingw-w64-vala/002-use_time_s_functions_on_windows.mingw.patch
+++ b/mingw-w64-vala/002-use_time_s_functions_on_windows.mingw.patch
@@ -1,0 +1,28 @@
+--- vala-0.46.4/vapi/glib-2.0.vapi.orig	2019-12-05 21:22:56.738635900 +0100
++++ vala-0.46.4/vapi/glib-2.0.vapi	2019-12-05 21:23:59.901794000 +0100
+@@ -2950,19 +2950,19 @@
+ 		[CCode (cname = "tm_isdst")]
+ 		public int isdst;
+ 
+-		[CCode (cname = "gmtime_r", feature_test_macro = "_XOPEN_SOURCE")]
+-		static void gmtime_r (ref time_t time, out Time result);
+-		[CCode (cname = "localtime_r", feature_test_macro = "_XOPEN_SOURCE")]
+-		static void localtime_r (ref time_t time, out Time result);
++		[CCode (cname = "gmtime_s", feature_test_macro = "_XOPEN_SOURCE")]
++		static void gmtime_s (out Time result, ref time_t time);
++		[CCode (cname = "localtime_s", feature_test_macro = "_XOPEN_SOURCE")]
++		static void localtime_s (out Time result, ref time_t time);
+ 
+ 		public static Time gm (time_t time) {
+ 			Time result;
+-			gmtime_r (ref time, out result);
++			gmtime_s (out result, ref time);
+ 			return result;
+ 		}
+ 		public static Time local (time_t time) {
+ 			Time result;
+-			localtime_r (ref time, out result);
++			localtime_s (out result, ref time);
+ 			return result;
+ 		}
+ 

--- a/mingw-w64-vala/PKGBUILD
+++ b/mingw-w64-vala/PKGBUILD
@@ -17,13 +17,17 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 depends=("${MINGW_PACKAGE_PREFIX}-glib2"
          "${MINGW_PACKAGE_PREFIX}-graphviz")
 source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz
-        001-change-pkg-config-invocations.mingw.patch)
+        001-change-pkg-config-invocations.mingw.patch
+	002-use_time_s_functions_on_windows.mingw.patch)
 sha256sums=('4bb9b60fc0230b0db2c8a0e2a80ec29f1c10b43dc78355abba78adedbc2e03a1'
-            'c588a3a69097aae30ada1d543001d5029865b1dd1f46132d9e60d12e1833b325')
+            'c588a3a69097aae30ada1d543001d5029865b1dd1f46132d9e60d12e1833b325'
+	    '1309ae50867b81ea5d170487b36443a41c8dfee202213198c980a133300d6f9a'
+)
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/001-change-pkg-config-invocations.mingw.patch
+  patch -p1 -i ${srcdir}/002-use_time_s_functions_on_windows.mingw.patch
   autoreconf -ivf
 }
 
@@ -48,3 +52,4 @@ package() {
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }
+

--- a/mingw-w64-vala/PKGBUILD
+++ b/mingw-w64-vala/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=vala
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.46.4
+pkgver=0.46.5
 pkgrel=1
 pkgdesc="Compiler for the GObject type system (mingw-w64)"
 arch=('any')
@@ -19,7 +19,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-glib2"
 source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz
         001-change-pkg-config-invocations.mingw.patch
 	002-use_time_s_functions_on_windows.mingw.patch)
-sha256sums=('4bb9b60fc0230b0db2c8a0e2a80ec29f1c10b43dc78355abba78adedbc2e03a1'
+sha256sums=('1a7847d2599d902c805a58b95b72b69e64c0223c2f6220163998a7ab4b42db1d'
             'c588a3a69097aae30ada1d543001d5029865b1dd1f46132d9e60d12e1833b325'
 	    '1309ae50867b81ea5d170487b36443a41c8dfee202213198c980a133300d6f9a'
 )


### PR DESCRIPTION
Without this patch a simple program like this would not compile in a MINGW environment:
`void main () {
    
    time_t original_time = time_t();
    print( Time.local(original_time)
		.to_string() );
}
`
