### PR TITLE
Update MyPaint packages (mypaint/libmypaint)[-git] to use Python 3

### DIFF
--- a/mingw-w64-libmypaint-git/PKGBUILD
+++ b/mingw-w64-libmypaint-git/PKGBUILD
@@ -1,4 +1,4 @@
-# Maintainer: Andrew Chadwick <a.t.chadwick@gmail.com>
+# Maintainer: The MyPaint Team <mypaintopensource@gmail.com>
 
 _realname=libmypaint
 pkgbase=mingw-w64-${_realname}-git

--- a/mingw-w64-mypaint-git/PKGBUILD
+++ b/mingw-w64-mypaint-git/PKGBUILD
@@ -1,4 +1,4 @@
-# Maintainer: Andrew Chadwick <a.t.chadwick@gmail.com>
+# Maintainer: The MyPaint Team <mypaintopensource@gmail.com>
 
 _realname=mypaint
 pkgbase=mingw-w64-${_realname}-git
@@ -16,11 +16,11 @@ pkgdesc="Simple drawing & painting program that works well with Wacom-style grap
 depends=(
     "${MINGW_PACKAGE_PREFIX}-libmypaint-git"
     "${MINGW_PACKAGE_PREFIX}-gtk3"
-    "${MINGW_PACKAGE_PREFIX}-python2-numpy"
+    "${MINGW_PACKAGE_PREFIX}-python3-numpy"
     "${MINGW_PACKAGE_PREFIX}-json-c"
     "${MINGW_PACKAGE_PREFIX}-lcms2"
-    "${MINGW_PACKAGE_PREFIX}-python2-cairo"
-    "${MINGW_PACKAGE_PREFIX}-python2-gobject"
+    "${MINGW_PACKAGE_PREFIX}-python3-cairo"
+    "${MINGW_PACKAGE_PREFIX}-python3-gobject"
     "${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme"
     "${MINGW_PACKAGE_PREFIX}-librsvg"
     "${MINGW_PACKAGE_PREFIX}-gcc-libs"
@@ -32,8 +32,8 @@ makedepends=(
     "${MINGW_PACKAGE_PREFIX}-swig"
     "${MINGW_PACKAGE_PREFIX}-pkg-config"
     "${MINGW_PACKAGE_PREFIX}-pygobject-devel"
-    "${MINGW_PACKAGE_PREFIX}-python2"
-    "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
+    "${MINGW_PACKAGE_PREFIX}-python3"
+    "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
     "swig"
 )
 options=('!strip' 'debug' 'staticlibs')
@@ -45,7 +45,7 @@ sha256sums=('SKIP')
 
 pkgver() {
     cd "${srcdir}"/${_realname}
-    eval `python2 lib/meta.py`
+    eval `python3 lib/meta.py`
     echo "$MYPAINT_VERSION_CEREMONIAL" \
       | sed 's,-\(alpha\),\1.'`date +d%Y%m%d`',' \
       | sed 's,-\(beta\|rc\),\1,' \
@@ -59,8 +59,9 @@ prepare() {
 
 build() {
     cd "${srcdir}/${_realname}"
-    ${MINGW_PREFIX}/bin/python2 setup.py clean --all
-    ${MINGW_PREFIX}/bin/python2 setup.py build
+    ${MINGW_PREFIX}/bin/python3 setup.py clean --all
+    REL_BRUSH_PATH=".${MINGW_PREFIX}/share/mypaint-data/2.0/brushes"
+    ${MINGW_PREFIX}/bin/python3 setup.py build_config --brushdir-path="${REL_BRUSH_PATH}" build
 }
 
 package() {
@@ -69,7 +70,7 @@ package() {
     echo "root: ${pkgdir}"
 
     MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=;--install-purelib=;--install-data=" \
-    ${MINGW_PREFIX}/bin/python2 setup.py install \
+    ${MINGW_PREFIX}/bin/python3 setup.py install \
 	--prefix=${MINGW_PREFIX} --root="${pkgdir}" \
 	--optimize=1 \
 	--skip-build


### PR DESCRIPTION
Switch dependencies from Py2 to Py3 for *-git and libmypaint packages.
Add brush directory fix for the *-mypaint-git build.
Update maintainer contact info.

The Mypaint release package still relies on Py2, but the new release (which does not) should be out in late January.

~~MyPaint builds and runs fine w. Py3 on windows for the most part (the exception is png export, but it should be fixed within a day or two).~~
Edit: Actually, the png export does work, only the tests fail (...)

**Edit:** Alright, let's not update the info in the release packages for now.