### PR TITLE
python3: fix wrong path separator in module paths with MSYSTEM set

### DIFF
--- a/mingw-w64-python3/3000-importlib-bootstrap-path-sep.patch
+++ b/mingw-w64-python3/3000-importlib-bootstrap-path-sep.patch
@@ -1,0 +1,14 @@
+--- Python-3.8.0/Lib/importlib/_bootstrap_external.py.orig	2019-12-21 14:31:23.806479400 +0100
++++ Python-3.8.0/Lib/importlib/_bootstrap_external.py	2019-12-21 14:34:37.093867400 +0100
+@@ -1603,6 +1603,11 @@
+                 continue
+     else:
+         raise ImportError('importlib requires posix or nt')
++
++    if 'MSYSTEM' in os_module.environ:
++        path_separators = path_separators[::-1]
++        path_sep = path_separators[0]
++
+     setattr(self_module, '_os', os_module)
+     setattr(self_module, 'path_sep', path_sep)
+     setattr(self_module, 'path_separators', ''.join(path_separators))

--- a/mingw-w64-python3/PKGBUILD
+++ b/mingw-w64-python3/PKGBUILD
@@ -19,7 +19,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 conflicts=("${MINGW_PACKAGE_PREFIX}-python2<2.7.16-7")
 _pybasever=3.8
 pkgver=${_pybasever}.0
-pkgrel=2
+pkgrel=3
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 license=('PSF')
@@ -130,6 +130,7 @@ source=("https://www.python.org/ftp/python/${pkgver%rc?}/Python-${pkgver}.tar.xz
         2060-pass-gen-profile-ldflags.patch
         2070-distutils-add-windmc-to-cygwinccompiler.patch
         2080-pkg-config-windows-must-link-ext-with-python-lib.patch
+        3000-importlib-bootstrap-path-sep.patch
         5000-warnings-fixes.patch
         smoketests.py)
 
@@ -298,7 +299,10 @@ prepare() {
   
   apply_patch_with_msg 2070-distutils-add-windmc-to-cygwinccompiler.patch
   apply_patch_with_msg 2080-pkg-config-windows-must-link-ext-with-python-lib.patch
-  
+
+  # https://github.com/msys2/MINGW-packages/issues/6035
+  apply_patch_with_msg 3000-importlib-bootstrap-path-sep.patch
+
   apply_patch_with_msg 5000-warnings-fixes.patch
 
   autoreconf -vfi
@@ -390,6 +394,9 @@ build() {
     --without-ensurepip \
     "${_extra_config[@]}" \
     OPT=""
+
+  # We patch importlib which is embedded in C headers, so regenerate them
+  make regen-importlib
 
   make
 }
@@ -554,5 +561,6 @@ sha256sums=('b356244e13fb5491da890b35b13b2118c3122977c2cd825e3eb6e7d462030d84'
             '6f1a48380445406709ba5c6b4b9c6f0301ea645324feb429f3719dc29b8f28ff'
             'b2f4083ada35c18876edf38220d84ca757cf710bc5c2d80ee8b5083dc6c2609f'
             '487c92837717975ad6c63fe2a1f8e8c5c9e0554e96000102d83c82f4a77fd9bd'
+            'f6ecf2edc9468210111d77e396853af49cb8a43d9bc0d20212f88cf2bc33685d'
             '24151631c3e70306ae92ffb8fea38992a752cd0a76771a5e53445f56c2be1f00'
-            '821402ddaef92140c70041b007bcf15e1cd5fe0fdb9f4f612da868382cc24585')
+            '8b9f0ff6624d9e8e86112f711bd1d261e9ebca2e2a2e3c5d9d0b0f0c0a292421')

--- a/mingw-w64-python3/smoketests.py
+++ b/mingw-w64-python3/smoketests.py
@@ -39,6 +39,16 @@ class Tests(unittest.TestCase):
     def test_sep(self):
         self.assertEqual(os.sep, SEP)
 
+    def test_module_file_path(self):
+        import asyncio
+        import zlib
+        self.assertEqual(zlib.__file__, os.path.normpath(zlib.__file__))
+        self.assertEqual(asyncio.__file__, os.path.normpath(asyncio.__file__))
+
+    def test_importlib_frozen_path_sep(self):
+        import importlib._bootstrap_external
+        self.assertEqual(importlib._bootstrap_external.path_sep, SEP)
+
     def test_os_commonpath(self):
         self.assertEqual(
             os.path.commonpath(


### PR DESCRIPTION
The importlib bootstrap code hardcodes the path separators to use
as well (os.path doesn't exist yet). Check for MSYSTEM there and
adjust the separators.

This makes things like `module.__path__` use the same separator in all
places again and for example fixes pytest with MSYSTEM set.

Fixes #6035