### PR TITLE
Add back python2-setuptools

### DIFF
--- a/mingw-w64-python-setuptools/PKGBUILD
+++ b/mingw-w64-python-setuptools/PKGBUILD
@@ -3,10 +3,9 @@
 
 _realname=setuptools
 pkgbase=mingw-w64-python-${_realname}
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-python3-setuptools")
 pkgver=42.0.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Easily download, build, install, upgrade, and uninstall Python packages (mingw-w64)"
 arch=('any')
 license=('PSF')
@@ -17,6 +16,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-python3>=3.3"
          "${MINGW_PACKAGE_PREFIX}-python3-ordered-set"
          "${MINGW_PACKAGE_PREFIX}-python3-appdirs"
          "${MINGW_PACKAGE_PREFIX}-python3-six")
+conflicts=("${MINGW_PACKAGE_PREFIX}-python2-setuptools<42.0.2")
 optdepends=("${MINGW_PACKAGE_PREFIX}-python3-certifi: Mozilla's CA Bundle support"
             "${MINGW_PACKAGE_PREFIX}-python3-wincertstore: Windows' cert store support")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python3-certifi"

--- a/mingw-w64-python2-setuptools/0001-mingw-python-fix.patch
+++ b/mingw-w64-python2-setuptools/0001-mingw-python-fix.patch
@@ -1,0 +1,13 @@
+--- setuptools-5.4.1/setuptools/command/easy_install.py.orig	2014-02-11 21:11:57.898800000 +0400
++++ setuptools-5.4.1/setuptools/command/easy_install.py	2014-02-11 21:41:20.905000000 +0400
+@@ -1256,8 +1256,8 @@
+     )
+ 
+     DEFAULT_SCHEME = dict(
+-        install_dir='$base/Lib/site-packages',
+-        script_dir='$base/Scripts',
++        install_dir='$base/lib/python$py_version_short/site-packages',
++        script_dir='$base/bin',
+     )
+ 
+     def _expand(self, *attrs):

--- a/mingw-w64-python2-setuptools/0002-Allow-usr-bin-env-in-script.patch
+++ b/mingw-w64-python2-setuptools/0002-Allow-usr-bin-env-in-script.patch
@@ -1,0 +1,104 @@
+--- setuptools-5.4.1/launcher.c.orig   2014-06-29 02:40:09.000000000 +0100
++++ setuptools-5.4.1/launcher.c        2014-10-19 13:37:21.272787900 +0100
+@@ -104,9 +104,19 @@
+ }
+ 
+ 
+-char *find_exe(char *exename, char *script) {
++int file_exists(char* path)
++{
++    DWORD attrib = GetFileAttributes(path);
++
++    if ((attrib == INVALID_FILE_ATTRIBUTES) || (attrib & FILE_ATTRIBUTE_DIRECTORY)) return 0;
++    return 1;
++}
++
++char *find_exe(char *exename, char *script, int search_in_path) {
+     char drive[_MAX_DRIVE], dir[_MAX_DIR], fname[_MAX_FNAME], ext[_MAX_EXT];
+     char path[_MAX_PATH], c, *result;
++    char *path_env, *path_env_start;
++    int maximum, needs_exe = 0;
+ 
+     /* convert slashes to backslashes for uniform search below */
+     result = exename;
+@@ -116,6 +126,34 @@
+     if (drive[0] || dir[0]=='\\') {
+         return loadable_exe(exename);   /* absolute path, use directly */
+     }
++
++    if (search_in_path) {
++        if (strstr(exename, ".exe") == NULL) needs_exe = 1;
++        char *path_env = getenv("PATH");
++        while (path_env != NULL) {
++            path_env_start = path_env;
++            path_env = strchr(path_env, ';');
++            maximum = _MAX_PATH - 2 - strlen(exename) - (needs_exe * strlen(".exe"));
++            if (path_env == NULL) {
++                strncpy(path, path_env_start, maximum);
++            }
++            else {
++                maximum = path_env - path_env_start < maximum ? path_env - path_env_start : maximum;
++                memcpy(path, path_env_start, maximum);
++                ++path_env;
++            }
++            path[maximum] = '\0';
++            strcat(path, "\\");
++            strcat(path, exename);
++            if (needs_exe) strcat(path, ".exe");
++            /* printf("Checking %s\n", path); */
++            if (file_exists(path)) {
++                /* printf("Found\n"); */
++                return loadable_exe(path);
++            }
++        }
++    }
++
+     /* Use the script's parent directory, which should be the Python home
+        (This should only be used for bdist_wininst-installed scripts, because
+         easy_install-ed scripts use the absolute path to python[w].exe
+@@ -206,7 +244,7 @@
+     // set-up control handler callback funciotn
+     SetConsoleCtrlHandler((PHANDLER_ROUTINE) control_handler, TRUE);
+     if (!CreateProcessA(NULL, commandline, NULL, NULL, TRUE, 0, NULL, NULL, &s_info, &p_info)) {
+-        fprintf(stderr, "failed to create process.\n");
++        fprintf(stderr, "failed to create process (%s).\n", commandline);
+         return 0;
+     }   
+     child_pid = p_info.dwProcessId;
+@@ -256,6 +294,9 @@
+     char *ptr, *end;    /* working pointers for string manipulation */
+     char *cmdline;
+     int i, parsedargc;              /* loop counter */
++    char *env, *first_space;
++    int skip = 2;
++    int search_in_path = 0;
+ 
+     /* compute script name from our .exe name*/
+     GetModuleFileNameA(NULL, script, sizeof(script));
+@@ -284,12 +325,24 @@
+         strcpy(python, "#!python.exe");
+     }
+ 
+-    parsedargs = parse_argv(python+2, &parsedargc);
++    /* Check if "env" appears before the first space and skip
++       ahead to the next space. */
++    env = strstr(python+skip, "env");
++    first_space = strchr(python+skip, ' ');
++    if (env != NULL && (first_space == NULL || env < first_space)) {
++        search_in_path = 1;
++        env += 3;
++        while (*env && *env != ' ')
++          ++env;
++        skip = env - python;
++    }
++
++    parsedargs = parse_argv(python+skip, &parsedargc);
+ 
+     /* Using spawnv() can fail strangely if you e.g. find the Cygwin
+        Python, so we'll make sure Windows can find and load it */
+ 
+-    ptr = find_exe(parsedargs[0], script);
++    ptr = find_exe(parsedargs[0], script, search_in_path);
+     if (!ptr) {
+         return fail("Cannot find Python executable %s\n", parsedargs[0]);
+     }

--- a/mingw-w64-python2-setuptools/0003-MinGW-w64-Look-in-same-dir-as-script-for-exe.patch
+++ b/mingw-w64-python2-setuptools/0003-MinGW-w64-Look-in-same-dir-as-script-for-exe.patch
@@ -1,0 +1,21 @@
+--- setuptools-5.4.1/launcher.c.orig   2014-06-29 02:40:09.000000000 +0100
++++ setuptools-5.4.1/launcher.c        2014-10-19 13:37:21.272787900 +0100
+@@ -154,14 +154,16 @@
+         }
+     }
+ 
+-    /* Use the script's parent directory, which should be the Python home
+-       (This should only be used for bdist_wininst-installed scripts, because
++    /* Use the script's directory (parent directory if not mingw-w64), which should be the
++	   Python home (This should only be used for bdist_wininst-installed scripts, because
+         easy_install-ed scripts use the absolute path to python[w].exe
+     */
+     _splitpath(script, drive, dir, fname, ext);
+     result = dir + strlen(dir) -1;
++#if !defined(__MINGW64_VERSION_MAJOR)
+     if (*result == '\\') result--;
+     while (*result != '\\' && result>=dir) *result-- = 0;
++#endif
+     _makepath(path, drive, dir, exename, NULL);
+     return loadable_exe(path);
+ }

--- a/mingw-w64-python2-setuptools/0004-dont-execute-msvc.patch
+++ b/mingw-w64-python2-setuptools/0004-dont-execute-msvc.patch
@@ -1,0 +1,12 @@
+--- setuptools-27.3.0/setuptools/monkey.py.orig	2016-09-23 11:38:23.517707200 +0300
++++ setuptools-27.3.0/setuptools/monkey.py	2016-09-23 11:39:40.362333800 +0300
+@@ -90,7 +90,8 @@
+             setuptools.extension.Extension
+         )
+ 
+-    patch_for_msvc_specialized_compiler()
++    if not 'GCC' in sys.version:
++        patch_for_msvc_specialized_compiler()
+ 
+ 
+ def _patch_distribution_metadata_write_pkg_file():

--- a/mingw-w64-python2-setuptools/0005-execv-warning.patch
+++ b/mingw-w64-python2-setuptools/0005-execv-warning.patch
@@ -1,0 +1,14 @@
+--- setuptools-40.2.0/launcher.c.orig	2018-08-27 00:31:49.470981800 -0400
++++ setuptools-40.2.0/launcher.c	2018-08-27 00:35:03.568692800 -0400
+@@ -369,7 +372,11 @@ int run(int argc, char **argv, int is_gu
+ 
+     if (is_gui) {
+         /* Use exec, we don't need to wait for the GUI to finish */
++#ifdef __MINGW32__
++        _execv(ptr, (const char * const *)(newargs));
++#else
+         execv(ptr, (const char * const *)(newargs));
++#endif
+         return fail("Could not exec %s", ptr);   /* shouldn't get here! */
+     }
+ 

--- a/mingw-w64-python2-setuptools/PKGBUILD
+++ b/mingw-w64-python2-setuptools/PKGBUILD
@@ -1,0 +1,77 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Ray Donnelly <mingw.android@gmail.com>
+
+_realname=setuptools
+pkgbase=mingw-w64-python2-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}")
+pkgver=42.0.2
+pkgrel=1
+pkgdesc="Easily download, build, install, upgrade, and uninstall Python packages (mingw-w64)"
+arch=('any')
+license=('PSF')
+url="https://pypi.python.org/pypi/setuptools"
+depends=("${MINGW_PACKAGE_PREFIX}-python2")
+install=${_realname}2-${CARCH}.install
+source=(${_realname}-${pkgver}.tar.gz::https://github.com/pypa/setuptools/archive/v${pkgver}.tar.gz
+        '0001-mingw-python-fix.patch'
+        '0002-Allow-usr-bin-env-in-script.patch'
+        '0003-MinGW-w64-Look-in-same-dir-as-script-for-exe.patch'
+        '0004-dont-execute-msvc.patch'
+        '0005-execv-warning.patch')
+sha256sums=('24d07d1053431afb40ba9c82cc00f08259a1e4240098358c5da9c13dc49b640d'
+            'd3bc778723e63bbd6e43ab3536a015c547c8c20a95c6679a952284a7a4822996'
+            '7bb5617c69566f5fbf1a3ee29a08179e1b41bdeabbc2998bf67615e9aa000424'
+            '0e556505cb70ff3a5df856e352d5e2b3cf1582c25d02fc00a2d935a28576b28c'
+            '2a854e21e99d6724999e2abeff08451923e9940b4092eb2b638702da17abdb73'
+            'f8db482721900dbbfd19f52b9042954c85b9e3a61a5e4b68a82aeafec8cba34a')
+
+prepare() {
+  cd "${srcdir}/setuptools-${pkgver}"
+
+  export SETUPTOOLS_INSTALL_WINDOWS_SPECIFIC_FILES=1
+
+  patch -p1 -i ${srcdir}/0001-mingw-python-fix.patch
+  patch -p1 -i ${srcdir}/0002-Allow-usr-bin-env-in-script.patch
+  patch -p1 -i ${srcdir}/0003-MinGW-w64-Look-in-same-dir-as-script-for-exe.patch
+  patch -p1 -i ${srcdir}/0004-dont-execute-msvc.patch
+  patch -p1 -i ${srcdir}/0005-execv-warning.patch
+
+  cd "${srcdir}"
+
+  # Compile our own MSYS2-layout and /usr/bin/env capable {cli,gui}{-32,-64}.exe to replace the precompiled binaries.
+  # .. when arm is ready, add it to this.
+  PATH=/mingw32/bin:$PATH gcc -DGUI=0           -O -s -o setuptools-${pkgver}/setuptools/cli-32.exe setuptools-${pkgver}/launcher.c
+  PATH=/mingw32/bin:$PATH gcc -DGUI=1 -mwindows -O -s -o setuptools-${pkgver}/setuptools/gui-32.exe setuptools-${pkgver}/launcher.c
+  PATH=/mingw64/bin:$PATH gcc -DGUI=0           -O -s -o setuptools-${pkgver}/setuptools/cli-64.exe setuptools-${pkgver}/launcher.c
+  PATH=/mingw64/bin:$PATH gcc -DGUI=1 -mwindows -O -s -o setuptools-${pkgver}/setuptools/gui-64.exe setuptools-${pkgver}/launcher.c
+
+  # Remove post-release tag since we are using stable tags
+  sed -e '/tag_build = .post/d' \
+      -e '/tag_date = 1/d' \
+      -i setuptools-${pkgver}/setup.cfg
+
+  cp -r setuptools-${pkgver} setuptools-python-${CARCH}
+
+  cd "${srcdir}"/setuptools-python-${CARCH}
+  sed -i -e "s|^#\!.*/usr/bin/env python|#!/usr/bin/env python2|" setuptools/command/easy_install.py
+}
+
+build() {
+  cd "${srcdir}"/setuptools-python-${CARCH}
+
+  ${MINGW_PREFIX}/bin/python2 bootstrap.py
+  ${MINGW_PREFIX}/bin/python2 setup.py build
+}
+
+package() {
+  local _mingw_prefix=$(cygpath -wm ${MINGW_PREFIX})
+
+  cd "${srcdir}/setuptools-python-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX#\/} --root="${pkgdir}" --optimize=1 --skip-build
+
+  rm ${pkgdir}${MINGW_PREFIX}/bin/easy_install-script.py
+  rm ${pkgdir}${MINGW_PREFIX}/bin/easy_install.exe*
+
+  sed -e "s|${_mingw_prefix}/bin/|${MINGW_PREFIX}/bin/|g" -i ${pkgdir}${MINGW_PREFIX}/bin/easy_install-2.7-script.py
+}

--- a/mingw-w64-python2-setuptools/setuptools2-i686.install
+++ b/mingw-w64-python2-setuptools/setuptools2-i686.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw32
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in easy_install-2.7; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i ${_prefix}/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-python2-setuptools/setuptools2-x86_64.install
+++ b/mingw-w64-python2-setuptools/setuptools2-x86_64.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw64
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in easy_install-2.7; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i ${_prefix}/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}


### PR DESCRIPTION
This adds back a python 2 version of setuptools but with all dependencies vendored
(the upstream default..). To allow users to install Python 2 packages we no longer
have in the repo etc which should help them transitioning.

This also adds conflicts between py2/3 setuptools because of the esy_install rename.

See #4993