### PR TITLE
tcl, tk: update to 8.6.10

### DIFF
--- a/mingw-w64-tcl/004-use-system-zlib.mingw.patch
+++ b/mingw-w64-tcl/004-use-system-zlib.mingw.patch
@@ -23,9 +23,9 @@ diff -Naur tcl8.6.5-orig/win/Makefile.in tcl8.6.5/win/Makefile.in
 --- tcl8.6.5-orig/win/Makefile.in	2016-03-01 04:59:35.000000000 +0300
 +++ tcl8.6.5/win/Makefile.in	2016-03-03 08:47:47.129571100 +0300
 @@ -146,9 +146,8 @@
- REG_LIB_FILE		= @LIBPREFIX@tclreg$(REGVER)${LIBSUFFIX}
- TEST_DLL_FILE		= tcltest$(VER)${DLLSUFFIX}
- TEST_LIB_FILE		= @LIBPREFIX@tcltest$(VER)${LIBSUFFIX}
+			  package ifneeded registry 1.3.4 [list load [file normalize ${REG_DLL_FILE}] registry]
+ TEST_LOAD_FACILITIES	= package ifneeded Tcltest ${VERSION}@TCL_PATCH_LEVEL@ [list load [file normalize ${TEST_DLL_FILE}] Tcltest];\
+			  $(TEST_LOAD_PRMS)
 -ZLIB_DLL_FILE		= zlib1.dll
  
 -SHARED_LIBRARIES 	= $(TCL_DLL_FILE) @ZLIB_DLL_FILE@
@@ -42,15 +42,6 @@ diff -Naur tcl8.6.5-orig/win/Makefile.in tcl8.6.5/win/Makefile.in
  
  RMDIR		= rm -rf
  MKDIR		= mkdir -p
-@@ -446,7 +445,7 @@
- 	@MAKE_STUB_LIB@ ${STUB_OBJS}
- 	@POST_MAKE_LIB@
- 
--${TCL_DLL_FILE}: ${TCL_OBJS} tcl.$(RES) @ZLIB_DLL_FILE@
-+${TCL_DLL_FILE}: ${TCL_OBJS} tcl.$(RES)
- 	@$(RM) ${TCL_DLL_FILE} $(TCL_LIB_FILE)
- 	@MAKE_DLL@ ${TCL_OBJS} tcl.$(RES) $(SHLIB_LD_LIBS)
- 	@VC_MANIFEST_EMBED_DLL@
 @@ -466,14 +465,6 @@
  	@$(RM) ${TEST_DLL_FILE} ${TEST_LIB_FILE}
  	@MAKE_DLL@ ${TCLTEST_OBJS} $(TCL_STUB_LIB_FILE) $(SHLIB_LD_LIBS)

--- a/mingw-w64-tcl/006-proper-implib-name.mingw.patch
+++ b/mingw-w64-tcl/006-proper-implib-name.mingw.patch
@@ -18,7 +18,7 @@ diff -Naur tcl8.6.5-orig/win/configure.in tcl8.6.5/win/configure.in
 diff -Naur tcl8.6.5-orig/win/Makefile.in tcl8.6.5/win/Makefile.in
 --- tcl8.6.5-orig/win/Makefile.in	2016-03-03 08:47:47.868497200 +0300
 +++ tcl8.6.5/win/Makefile.in	2016-03-03 08:47:48.739410100 +0300
-@@ -141,11 +141,11 @@
+@@ -141,12 +141,12 @@
  TCL_DLL_FILE		= @TCL_DLL_FILE@
  TCL_LIB_FILE		= @TCL_LIB_FILE@
  DDE_DLL_FILE		= tcldde$(DDEVER)${DLLSUFFIX}
@@ -28,11 +28,12 @@ diff -Naur tcl8.6.5-orig/win/Makefile.in tcl8.6.5/win/Makefile.in
 -REG_LIB_FILE		= @LIBPREFIX@tclreg$(REGVER)${LIBSUFFIX}
 +REG_LIB_FILE		= @LIBPREFIX@tclreg$(REGVER)${DLLSUFFIX}${LIBSUFFIX}
  TEST_DLL_FILE		= tcltest$(VER)${DLLSUFFIX}
+ TEST_EXE_FILE		= tcltest${EXESUFFIX}
 -TEST_LIB_FILE		= @LIBPREFIX@tcltest$(VER)${LIBSUFFIX}
 +TEST_LIB_FILE		= @LIBPREFIX@tcltest$(VER)${DLLSUFFIX}${LIBSUFFIX}
- 
- SHARED_LIBRARIES 	= $(TCL_DLL_FILE)
- STATIC_LIBRARIES	= $(TCL_LIB_FILE)
+ TEST_LOAD_PRMS		= package ifneeded dde 1.4.2 [list load [file normalize ${DDE_DLL_FILE}] dde];\
+ 			  package ifneeded registry 1.3.4 [list load [file normalize ${REG_DLL_FILE}] registry]
+ TEST_LOAD_FACILITIES	= package ifneeded Tcltest ${VERSION}@TCL_PATCH_LEVEL@ [list load [file normalize ${TEST_DLL_FILE}] Tcltest];\
 diff -Naur tcl8.6.5-orig/win/tcl.m4 tcl8.6.5/win/tcl.m4
 --- tcl8.6.5-orig/win/tcl.m4	2016-03-01 04:59:35.000000000 +0300
 +++ tcl8.6.5/win/tcl.m4	2016-03-03 08:47:48.763407700 +0300

--- a/mingw-w64-tcl/PKGBUILD
+++ b/mingw-w64-tcl/PKGBUILD
@@ -4,8 +4,8 @@
 _realname=tcl
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=8.6.9
-pkgrel=2
+pkgver=8.6.10
+pkgrel=1
 pkgdesc="The Tcl scripting language (mingw-w64)"
 arch=('any')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-zlib")
@@ -24,12 +24,12 @@ source=("https://downloads.sourceforge.net/sourceforge/tcl/tcl${pkgver}-src.tar.
         008-tcl-8.5.14-hidden.patch
         009-fix-using-gnu-print.patch)
 
-sha256sums=('ad0cd2de2c87b9ba8086b43957a0de3eb2eb565c7159d5f53ccbba3feb915f4e'
+sha256sums=('5196dbf6638e3df8d5c87b5815c8c2b758496eb6f0e41446596c9a4e638d87ed'
             'cfcf9b3816f8bb063b514ac7f63a5ba73108f27e16fdf8e8312dc5f0683083f6'
             '70bf0d8e84985f4e8ee63447ad37d5e50376eaf35ace51112761cacbbd596c4c'
-            '01bf81675bb189314be5e024f58d20aafb3d2a35c1d2c4353045bbebd1e7a926'
+            '2d7581ad118c01afcebd762051eb74fe31511e8b40505554068f126bcd8d5d9f'
             '2b0f41f6704aa964dbfafa0a65dd5ce0ab97e82ff5cbbe2a95a2e8d644cc5550'
-            '5c0162fbb018c03b3e4b907bd0098ab5282314bc212e3929a0416126637e1350'
+            '9ffbba1a185fc3425d1398361472df3ca2a488ed9101970dc3325d512f0d6e19'
             'f1833c3164229b017417d2ab2ce4cb066252fc1ad256de2313f0239481c7cc37'
             '3ec2702efb1be6873d6ffd2ffb357637588f835f8817ae65cf0373020fcc7359'
             'e49a314ff0262e487f15fa1cb6253e22e25e8b18dad0b057d600e833efa947a7')
@@ -93,8 +93,8 @@ package() {
   local _libver=${pkgver%.*}
   _libver=${_libver//./}
 
-  local _odbc_ver=1.1.0
-  local _itcl_ver=4.1.2
+  local _odbc_ver=1.1.1
+  local _itcl_ver=4.2.0
   sed \
     -e "s|^\(TCL_BUILD_LIB_SPEC\)='.*|\1='-Wl,${MINGW_PREFIX}/lib/libtcl${_libver}.dll.a'|" \
     -e "s|^\(TCL_SRC_DIR\)='.*'|\1='${MINGW_PREFIX}/include/tcl${pkgver%.*}/tcl-private'|" \

--- a/mingw-w64-tk/PKGBUILD
+++ b/mingw-w64-tk/PKGBUILD
@@ -4,8 +4,8 @@
 _realname=tk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-_basever=8.6.9
-_patch=.1
+_basever=8.6.10
+_patch=
 pkgver=${_basever}${_patch}
 pkgrel=1
 pkgdesc="A windowing toolkit for use with tcl (mingw-w64)"
@@ -21,7 +21,7 @@ source=("https://downloads.sourceforge.net/sourceforge/tcl/${_realname}${pkgver}
         004-install-man.mingw.patch
         006-prevent-tclStubsPtr-segfault.patch
         008-dont-link-shared-with--static-libgcc.patch)
-sha256sums=('8fcbcd958a8fd727e279f4cac00971eee2ce271dc741650b1fc33375fb74ebb4'
+sha256sums=('63df418a859d0a463347f95ded5cd88a3dd3aaa1ceecaeee362194bc30f3e386'
             '441f2f5bdf1ee2bf6697569365207d554130bd5a2bac01e10a6e1a37738d8006'
             '5347487af0e736dbb51425b22ed308840faf75b44c070623baa55f78dac3d053'
             '8516749dd73c084ece7b9df6d1ba5708e652e8ba39cad59120c7f909f61747f0'


### PR DESCRIPTION
While packaging this warning is show:

==> WARNING: Package contains reference to $srcdir