### PR TITLE
Add back python2-pip

### DIFF
--- a/mingw-w64-python2-pip/PKGBUILD
+++ b/mingw-w64-python2-pip/PKGBUILD
@@ -1,0 +1,40 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+
+_realname=pip
+pkgbase=mingw-w64-python2-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}")
+pkgver=19.3.1
+pkgrel=5
+pkgdesc="An easy_install replacement for installing pypi python packages (mingw-w64)"
+arch=('any')
+license=('MIT')
+url="https://pip.pypa.io/"
+depends=("${MINGW_PACKAGE_PREFIX}-python2"
+         "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+install=${_realname}2-${CARCH}.install
+source=(${_realname}-${pkgver}.tar.gz::https://github.com/pypa/pip/archive/${pkgver}.tar.gz)
+sha256sums=('f12b7a6be2dbbfeefae5f14992c89175ef72ce0fe96452b4f66be855a12841ff')
+
+build() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  ${MINGW_PREFIX}/bin/python2 setup.py build
+}
+
+package() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX#\/} --root="${pkgdir}" --optimize=1 --skip-build -v
+
+  rm -f ${pkgdir}${MINGW_PREFIX}/bin/pip{.exe,.exe.manifest,-script.py}
+
+  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+  # fix python command in files
+  for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
+    sed -e "s|/usr/bin/env |${MINGW_PREFIX}|g" \
+        -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${_f}
+  done
+
+  install -D -m644 LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
+}

--- a/mingw-w64-python2-pip/pip2-i686.install
+++ b/mingw-w64-python2-pip/pip2-i686.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw32
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in pip2 pip2.7; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i ${_prefix}/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-python2-pip/pip2-x86_64.install
+++ b/mingw-w64-python2-pip/pip2-x86_64.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw64
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in pip2 pip2.7; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i ${_prefix}/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}


### PR DESCRIPTION
This adds back a Python 2 version of pip but with all dependencies vendored.
In combination with setuptools this allows users to install Python 2 packages
from pypi.

See #4993