### PR TITLE
python3: Update to 3.8.1

### DIFF
--- a/mingw-w64-python/0180-MINGW-init-system-calls.patch
+++ b/mingw-w64-python/0180-MINGW-init-system-calls.patch
@@ -16,9 +16,8 @@ diff -Naur Python-3.8.0-orig/configure.ac Python-3.8.0/configure.ac
  # Record the configure-time value of MACOSX_DEPLOYMENT_TARGET,
  # it may influence the way we can build extensions, so distutils
  # needs to check it
-diff -Naur Python-3.8.0-orig/Modules/posixmodule.c Python-3.8.0/Modules/posixmodule.c
---- Python-3.8.0-orig/Modules/posixmodule.c	2019-10-14 16:34:47.000000000 +0300
-+++ Python-3.8.0/Modules/posixmodule.c	2019-10-22 10:00:53.603730800 +0300
+--- Python-3.8.1/Modules/posixmodule.c.orig	2019-12-18 18:21:23.000000000 +0100
++++ Python-3.8.1/Modules/posixmodule.c	2019-12-23 10:35:51.095967700 +0100
 @@ -193,6 +193,27 @@
  #define HAVE_CWAIT      1
  #define HAVE_FSYNC      1
@@ -65,10 +64,10 @@ diff -Naur Python-3.8.0-orig/Modules/posixmodule.c Python-3.8.0/Modules/posixmod
  
  #ifndef MAXPATHLEN
  #if defined(PATH_MAX) && PATH_MAX > 1024
-@@ -1373,9 +1394,9 @@
+@@ -1372,9 +1393,9 @@
+ ** man environ(7).
  */
  #include <crt_externs.h>
- static char **environ;
 -#elif !defined(_MSC_VER) && (!defined(__WATCOMC__) || defined(__QNX__) || defined(__VXWORKS__))
 +#elif !defined(MS_WINDOWS) && (!defined(__WATCOMC__) || defined(__QNX__) || defined(__VXWORKS__))
  extern char **environ;

--- a/mingw-w64-python/3001-pathlib-path-sep.patch
+++ b/mingw-w64-python/3001-pathlib-path-sep.patch
@@ -1,0 +1,11 @@
+--- Python-3.8.1/Lib/pathlib.py.orig	2019-12-18 18:21:23.000000000 +0100
++++ Python-3.8.1/Lib/pathlib.py	2019-12-23 11:17:46.731915100 +0100
+@@ -122,6 +122,8 @@
+ 
+     sep = '\\'
+     altsep = '/'
++    if 'MSYSTEM' in os.environ:
++        sep, altsep = altsep, sep
+     has_drv = True
+     pathmod = ntpath
+ 

--- a/mingw-w64-python/PKGBUILD
+++ b/mingw-w64-python/PKGBUILD
@@ -18,8 +18,8 @@ pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 conflicts=("${MINGW_PACKAGE_PREFIX}-python2<2.7.16-7")
 _pybasever=3.8
-pkgver=${_pybasever}.0
-pkgrel=3
+pkgver=${_pybasever}.1
+pkgrel=1
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 license=('PSF')
@@ -469,7 +469,7 @@ package() {
 
 }
 
-sha256sums=('b356244e13fb5491da890b35b13b2118c3122977c2cd825e3eb6e7d462030d84'
+sha256sums=('75894117f6db7051c1b34f37410168844bbb357c139a8a10a352e9bf8be594e8'
             '0ee1acf745d38d41fd098487b9595705fd8f6666d7b154d54ddba32d14f1253b'
             '0d27f52bc514dbf2b730f62fa6c18c797a2f4cbad8698d95b15e2774d68e483d'
             'd2d73d9fb9db48fecb3a6856e4606f444eaac7637fd4f65e192701e53ac422eb'
@@ -479,7 +479,7 @@ sha256sums=('b356244e13fb5491da890b35b13b2118c3122977c2cd825e3eb6e7d462030d84'
             '8e90c38ac27316781f8853fcbce300526d92732edf4cd08d1dc2a0438fd2d694'
             '36f6e8b4320ee79b6ff7e84aefec3aec57293bcbacf08ea7847f3147d459b4a9'
             '0a6a1ee72f3aa050f1ff0b8ff88845189309163ef1a5f70808f1ab351348cdae'
-            '704cf5712013cb2c0299f9122a3e40817e8f2b9e4ae33b949aad02299251aa3d'
+            '56bdf305a3786ae50871045373e89f2e20df3055e1033197f122ee2c6c8b0966'
             '910c84eb01cfe2207ee7fd8549247d9498be8b58c4dbbb6eaa2118037e77730e'
             'da5057e58a4866e20c3c604153febb2b57a089d327a954ee5b51830af8204e17'
             '265a3c99923b76210e0401bc0cafa88b99328343aec43d64aa94cb84fcdda6d8'

--- a/mingw-w64-python/PKGBUILD
+++ b/mingw-w64-python/PKGBUILD
@@ -19,7 +19,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 conflicts=("${MINGW_PACKAGE_PREFIX}-python2<2.7.16-7")
 _pybasever=3.8
 pkgver=${_pybasever}.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 license=('PSF')
@@ -131,6 +131,7 @@ source=("https://www.python.org/ftp/python/${pkgver%rc?}/Python-${pkgver}.tar.xz
         2070-distutils-add-windmc-to-cygwinccompiler.patch
         2080-pkg-config-windows-must-link-ext-with-python-lib.patch
         3000-importlib-bootstrap-path-sep.patch
+        3001-pathlib-path-sep.patch
         5000-warnings-fixes.patch
         smoketests.py)
 
@@ -302,6 +303,7 @@ prepare() {
 
   # https://github.com/msys2/MINGW-packages/issues/6035
   apply_patch_with_msg 3000-importlib-bootstrap-path-sep.patch
+  apply_patch_with_msg 3001-pathlib-path-sep.patch
 
   apply_patch_with_msg 5000-warnings-fixes.patch
 
@@ -562,5 +564,6 @@ sha256sums=('75894117f6db7051c1b34f37410168844bbb357c139a8a10a352e9bf8be594e8'
             'b2f4083ada35c18876edf38220d84ca757cf710bc5c2d80ee8b5083dc6c2609f'
             '487c92837717975ad6c63fe2a1f8e8c5c9e0554e96000102d83c82f4a77fd9bd'
             'f6ecf2edc9468210111d77e396853af49cb8a43d9bc0d20212f88cf2bc33685d'
+            '6efc39323d14239f2a55576a8b3f32cb79eeefdd5881ba813493c14be2939f3c'
             '24151631c3e70306ae92ffb8fea38992a752cd0a76771a5e53445f56c2be1f00'
-            '8b9f0ff6624d9e8e86112f711bd1d261e9ebca2e2a2e3c5d9d0b0f0c0a292421')
+            '6b535c53435ebed57e6f519429bd4ff845d1651e5a080e6f0517307cb45c5da7')

--- a/mingw-w64-python/smoketests.py
+++ b/mingw-w64-python/smoketests.py
@@ -56,6 +56,12 @@ class Tests(unittest.TestCase):
                  os.path.join("C:", os.sep, "foo")]),
                  os.path.join("C:", os.sep, "foo"))
 
+    def test_pathlib(self):
+        import pathlib
+
+        p = pathlib.Path("foo") / pathlib.Path("foo")
+        self.assertEqual(str(p), os.path.normpath(p))
+
     def test_modules_import(self):
         import sqlite3
         import ssl


### PR DESCRIPTION
The second commit fixes a pathsep issue with pathlib (which I noticed because pytest has started using pathlib)