### PR TITLE
Correct catalog directory

### DIFF
--- a/mingw-w64-docbook-xsl/PKGBUILD
+++ b/mingw-w64-docbook-xsl/PKGBUILD
@@ -63,7 +63,7 @@ package() {
 
   local pkgroot ns dir
   for ns in -nons ''; do
-    pkgroot="$pkgdir${MINGW_PREFIX}/share/xml/docbook/xsl-stylesheets$ns-$pkgver$ns"
+    pkgroot="$pkgdir${MINGW_PREFIX}/share/xml/docbook/xsl-stylesheets$ns-$pkgver"
     dir=${_realname}$ns-$pkgver
     install -Dt ${pkgroot} -m644 $dir/catalog.xml
     install -Dt "$pkgroot" -m644 $dir/VERSION{,.xsl}
@@ -79,15 +79,17 @@ package() {
     )
   done
 
+  # sf.net nons version
   ${MINGW_PREFIX}/bin/xmlcatalog --noout --add delegateURI \
       "http://docbook.sourceforge.net/release/xsl/" \
-      "../../share/xml/docbook/xsl-stylesheets-$pkgver/catalog.xml" \
+      "../../share/xml/docbook/xsl-stylesheets-nons-$pkgver/catalog.xml" \
       "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xsl"
   ${MINGW_PREFIX}/bin/xmlcatalog --noout --add delegateSystem \
       "http://docbook.sourceforge.net/release/xsl/" \
-      "../../share/xml/docbook/xsl-stylesheets-$pkgver/catalog.xml" \
+      "../../share/xml/docbook/xsl-stylesheets-nons-$pkgver/catalog.xml" \
       "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xsl"
 
+  # sf.net ns version
   ${MINGW_PREFIX}/bin/xmlcatalog --noout --add delegateURI \
       "http://docbook.sourceforge.net/release/xsl-ns/" \
       "../../share/xml/docbook/xsl-stylesheets-$pkgver/catalog.xml" \
@@ -97,16 +99,7 @@ package() {
       "../../share/xml/docbook/xsl-stylesheets-$pkgver/catalog.xml" \
       "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xsl"
 
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add delegateURI \
-      "http://cdn.docbook.org/release/xsl/" \
-      "../../share/xml/docbook/xsl-stylesheets-$pkgver/catalog.xml" \
-      "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xsl"
-  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add delegateSystem \
-      "http://cdn.docbook.org/release/xsl/" \
-      "../../share/xml/docbook/xsl-stylesheets-$pkgver/catalog.xml" \
-      "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xsl"
-
-  # nons
+  # cdn nons version
   ${MINGW_PREFIX}/bin/xmlcatalog --noout --add delegateURI \
       "http://cdn.docbook.org/release/xsl-nons/" \
       "../../share/xml/docbook/xsl-stylesheets-nons-$pkgver/catalog.xml" \
@@ -116,13 +109,14 @@ package() {
       "../../share/xml/docbook/xsl-stylesheets-nons-$pkgver/catalog.xml" \
       "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xsl"
 
+  # cdn ns version
   ${MINGW_PREFIX}/bin/xmlcatalog --noout --add delegateURI \
-      "http://docbook.sourceforge.net/release/xsl-nons/" \
-      "../../share/xml/docbook/xsl-stylesheets-nons-$pkgver/catalog.xml" \
+      "http://cdn.docbook.org/release/xsl/" \
+      "../../share/xml/docbook/xsl-stylesheets-$pkgver/catalog.xml" \
       "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xsl"
   ${MINGW_PREFIX}/bin/xmlcatalog --noout --add delegateSystem \
-      "http://docbook.sourceforge.net/release/xsl-nons/" \
-      "../../share/xml/docbook/xsl-stylesheets-nons-$pkgver/catalog.xml" \
+      "http://cdn.docbook.org/release/xsl/" \
+      "../../share/xml/docbook/xsl-stylesheets-$pkgver/catalog.xml" \
       "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xsl"
 
   install -Dt "$pkgdir${MINGW_PREFIX}/share/licenses/$pkgname" -m644 $dir/COPYING

--- a/mingw-w64-docbook-xsl/docbook-xsl-x86_64.install
+++ b/mingw-w64-docbook-xsl/docbook-xsl-x86_64.install
@@ -43,15 +43,6 @@ post_install() {
     "http://cdn.docbook.org/release/xsl-nons/" \
     "./docbook-xsl" \
     ${MINGW_XML_CATALOG}/catalog
-
-  ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateSystem" \
-    "http://docbook.sourceforge.net/release/xsl-nons/" \
-    "./docbook-xsl" \
-    ${MINGW_XML_CATALOG}/catalog
-  ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateURI" \
-    "http://docbook.sourceforge.net/release/xsl-nons/" \
-    "./docbook-xsl" \
-    ${MINGW_XML_CATALOG}/catalog
 }
 
 post_upgrade() {


### PR DESCRIPTION
I was faced with errors when built PostgreSQL documentation in msys2 environment using last docbook packages. I installed the following packages (besides obvious libxml & libxslt that are used in PostgreSQL to build documentation).
mingw64/mingw-w64-x86_64-docbook-xsl 1.79.2-4
mingw64/mingw-w64-x86_64-docbook-xml 1~4.5-1

I had errors during the build:
/mingw64/bin/xsltproc --path . --stringparam pg.version '11.5'  stylesheet-man.xsl postgres.sgml
Note: namesp. add : added namespace before processing              PostgreSQL 11.5 Documentation
Element div in namespace '' encountered in td, but no template matches.

and no result files were genearted.

Investigating docbook installation in my msys2 env I found that needed styles for successfuyl build (docbook < 5) are installed in the wrong directories.

The current installation directory is /mingw64/share/xml/docbook/xsl-stylesheets-nons-1.79.2-nons.
The last "-nons" suffix seems wrong. Why is it needed?

Also, it seems that references from /etc/xml/docbook-xsl are pointed on wrong catalog content (with ns, or without ns). I checked style contents from cdn.docbook.org & docbook.sourceforge.net and found misalignes between release/xsl & release/xsl-ns on these sites and references in /etc/xml/docbook-xsl from this package. References on NS and NoNS versions are mixed up.

I try to correct these errors in the following patch and made pull request for discution these misalignes.  Hope it helps to improve docbook and msys2. With correction proposed in this patch, the PostgreSQL documentation build is finished successfully.

I tried to fix these errors in the patch and made a pull request to review and discuss these misalignes. Hope this helps improve docbook and msys2. With the fixes proposed in the patch, the PostgreSQL documentation builds successfully.