### PR TITLE
reduce mingw-w64-clang package size via dynamic linking #6072

### DIFF
--- a/mingw-w64-clang/0010-mbig-obj-for-all.patch
+++ b/mingw-w64-clang/0010-mbig-obj-for-all.patch
@@ -1,6 +1,9 @@
 --- llvm-6.0.0.src/cmake/modules/HandleLLVMOptions.cmake.orig	2018-06-06 14:33:51.928460200 +0300
 +++ llvm-6.0.0.src/cmake/modules/HandleLLVMOptions.cmake	2018-06-06 14:33:59.840471400 +0300
 @@ -312,9 +312,7 @@
+-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--stack,16777216")
++  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--stack,16777216,--allow-multiple-definition")
+
    # Pass -mbig-obj to mingw gas on Win64. COFF has a 2**16 section limit, and
    # on Win64, every COMDAT function creates at least 3 sections: .text, .pdata,
    # and .xdata.

--- a/mingw-w64-clang/0105-build-libclang-cpp-fix.patch
+++ b/mingw-w64-clang/0105-build-libclang-cpp-fix.patch
@@ -1,0 +1,10 @@
+--- a/tools/CMakeLists.txt	2019-12-31 00:31:56.129822600 +0100
++++ b/tools/CMakeLists.txt	2019-12-31 00:32:53.903739000 +0100
+@@ -14,7 +14,7 @@
+ 
+ add_clang_subdirectory(clang-rename)
+ add_clang_subdirectory(clang-refactor)
+-if(UNIX)
++if(UNIX OR MINGW)
+   add_clang_subdirectory(clang-shlib)
+ endif()

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -5,6 +5,7 @@
 # Contributor: wirx6 <wirx654@gmail.com>
 # Contributor: Yuui Tanabe <yuuitanabe@163.com>
 # Contributor: Oscar Fuentes <ofv@wanadoo.es>
+# Contributor: Adrian Pop <adrian.pop@liu.se>
 
 
 # We can switch to clang when it fully works with mingw-w64
@@ -31,7 +32,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-llvm"
          "${MINGW_PACKAGE_PREFIX}-polly")
 pkgver=9.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 url="https://llvm.org/"
@@ -79,6 +80,7 @@ source=(${_url}/$pkgver/llvm-${pkgver}.src.tar.xz{,.sig}
         "0102-fix-libclang-name-for-mingw.patch"
         "0103-Set-the-x86-arch-name-to-i686-for-mingw-w64.patch"
         "0104-link-pthread-with-mingw.patch"
+        "0105-build-libclang-cpp-fix.patch"
         "0201-mingw-w64-__udivdi3-mangle-hack.patch"
         "0401-disable-visibility-annotations.patch"
         "0405-fix-conflict-win32-posix-threads.patch"
@@ -134,7 +136,7 @@ sha256sums=('d6a0565cf21f22e9b4353b2eb92622e8365000a9e90a16b09b56f8157eabfe84'
             '2c2431997e664c5b42b359f4134a4773578753e5e25c505ba30de42d357f3057'
             '1887ea21fcd591a50dd10559774e872ce1183177e672b028133d9b669e3cac32'
             '33400d16d5f6671a8fd60345c3ae44b9777a7d600061957889d14305eb2ad709'
-            '1c9efccd40a0e7834c3aa9d819aa25cfdd2cec389d1bd3e8a89bc9ff670a0129'
+            '8c216c885a1cd84a63c842ac4ce7c857b1bb4952a46bbd9905adaadacb1a758a'
             '18e719f49af8704c66d7d5e0c0c94ab04a7206fe2a3d711eb652e0afb35ff52c'
             'c486e1d45f6fb2a24823d776d2b47d6930530d423df73cc635f863265210c294'
             '656007a5eb587ac51e8d953fd28522c53cc56d297f2fa87ba818a0fe2ebd2b76'
@@ -143,6 +145,7 @@ sha256sums=('d6a0565cf21f22e9b4353b2eb92622e8365000a9e90a16b09b56f8157eabfe84'
             '01b029f2a21bd998ce374a90d41d214c891dfbb611dfbd9ca147517cd2c228ea'
             'ab49b90d69a609f441fa58e835873f2b1a8a060c9ca6358fee7d99c1973da692'
             '53646dd01af2862473e9719c5223366486268891ccbff86413943a432a8342e9'
+            'a60f7328d84628a56a9f626e4dc26ffd0c35292c79eeba62ac3d4f25aef2fe5c'
             '5d6b066d63ea927b87e32b8e70a38f763373622ae4f6a5062db7a5e087b41faf'
             '219eca2ad015ababb05d81ed97b4b40cf13ea189ee93cf57aa814cca7cf40001'
             '2f8f3c819837e4a16a364ed6e2a0a879cd10f924169ed7d89c27c1ed64edfe95'
@@ -211,7 +214,8 @@ prepare() {
       "0101-Allow-build-static-clang-library-for-mingw.patch" \
       "0102-fix-libclang-name-for-mingw.patch" \
       "0103-Set-the-x86-arch-name-to-i686-for-mingw-w64.patch" \
-      "0104-link-pthread-with-mingw.patch"
+      "0104-link-pthread-with-mingw.patch" \
+      "0105-build-libclang-cpp-fix.patch"
 
   cd "${srcdir}/compiler-rt-${pkgver}.src"
   apply_patch_with_msg \
@@ -312,11 +316,11 @@ build() {
     -DLIBUNWIND_ENABLE_SHARED=OFF \
     -DLLVM_BUILD_STATIC=OFF \
     -DLLVM_BUILD_LLVM_DYLIB=ON \
+    -DLLVM_LINK_LLVM_DYLIB=ON \
     -DLLVM_ENABLE_ASSERTIONS=OFF \
     -DLLVM_ENABLE_FFI=ON \
     -DLLVM_ENABLE_THREADS=ON \
     -DLLVM_ENABLE_SPHINX=ON \
-    -DLLVM_LINK_LLVM_DYLIB=OFF \
     -DLLVM_POLLY_LINK_INTO_TOOLS=OFF \
     -DLLDB_RELOCATABLE_PYTHON=ON \
     -DLLDB_USE_SYSTEM_SIX=ON \


### PR DESCRIPTION
- enable build of libclang-cpp
- allow multiple definitions while linking as it seems to be multiple definitions in
  libLLVM.dll.a and all other libLVM*.a; to handle this properly one would need to
  change the way the libs are built
- tested clang/clang++ by building a large project