### PR TITLE
dlib: update to 19.19 snapshot

### DIFF
--- a/mingw-w64-dlib/PKGBUILD
+++ b/mingw-w64-dlib/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=dlib
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=19.18
+pkgver=19.19
 pkgrel=2
 pkgdesc="A toolkit for making real world machine learning and data analysis applications in C++ (mingw-w64)"
 arch=('any')
@@ -21,13 +21,14 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-python3"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
 options=('strip')
-source=(${_realname}-${pkgver}.tar.gz::"https://github.com/davisking/${_realname}/archive/v${pkgver}.tar.gz"
+source=(${_realname}-${pkgver}.tar.gz::"https://github.com/davisking/${_realname}/tarball/b817bc1ea9ade43c8ca0094ae71ccfe652dcfc32"
         "001-python-binding.patch")
-sha256sums=('e9a8540ad0ff84eda92dea7127cd7d078457caf7ced64400c25c9a0b8c96e242'
+sha256sums=('5975b80bc0c0f8afaf60933a81ed247bb8cbce53a977f50c2330c0b7931c382b'
             'd40f90a70da30689343071a7194ddcff73e225a6fff49ef6389b3dd861ac586f')
 
 
 prepare() {
+  mv "$srcdir/davisking-dlib-b817bc1" "$srcdir/${_realname}-${pkgver}"
   cd "$srcdir/${_realname}-${pkgver}"
 
   patch -Np1 -i "${srcdir}/001-python-binding.patch"


### PR DESCRIPTION
Currently the dlib package is based on dlib release 19.19 (but build script is not updated on git). Dlib release 19.19 does not work with most current version of OpenCV, what makes it quite unusable. This is fixed in current snapshots of dlib, but a new release is probably weeks or even months away. Since our package is unusable I think this is urgent. I ask you to accept this PR, that uses current snapshot to make the package usable again.