### PR TITLE
dlib: fix compatibility with opencv and drop python 2

### DIFF
--- a/mingw-w64-dlib/002-fix-opencv-in-19.19.patch
+++ b/mingw-w64-dlib/002-fix-opencv-in-19.19.patch
@@ -1,0 +1,157 @@
+diff --git a/dlib/opencv/cv_image.h b/dlib/opencv/cv_image.h
+index 5f224d003..f6f4bbe95 100644
+--- a/dlib/opencv/cv_image.h
++++ b/dlib/opencv/cv_image.h
+@@ -34,7 +34,11 @@ namespace dlib
+                          << "\n\t img.channels(): " << img.channels() 
+                          << "\n\t img.pixel_traits<pixel_type>::num: " << pixel_traits<pixel_type>::num 
+                          );
++#if CV_VERSION_MAJOR > 3
++            IplImage temp = cvIplImage(img);
++#else
+             IplImage temp = img;
++#endif
+             init(&temp);
+         }
+ 
+diff --git a/dlib/opencv/cv_image.h b/dlib/opencv/cv_image.h
+index f6f4bbe95..05af05511 100644
+--- a/dlib/opencv/cv_image.h
++++ b/dlib/opencv/cv_image.h
+@@ -34,7 +34,12 @@ namespace dlib
+                          << "\n\t img.channels(): " << img.channels() 
+                          << "\n\t img.pixel_traits<pixel_type>::num: " << pixel_traits<pixel_type>::num 
+                          );
+-#if CV_VERSION_MAJOR > 3
++// Note, do NOT use CV_VERSION_MAJOR because in OpenCV 2 CV_VERSION_MAJOR actually held
++// CV_VERSION_MINOR and instead they used CV_VERSION_EPOCH.  So for example, in OpenCV
++// 2.4.9.1 CV_VERSION_MAJOR==4 and CV_VERSION_EPOCH==2.  However, CV_MAJOR_VERSION has always
++// (seemingly) held the actual major version number, so we use that to test for the OpenCV major
++// version.
++#if CV_MAJOR_VERSION > 3
+             IplImage temp = cvIplImage(img);
+ #else
+             IplImage temp = img;
+diff --git a/dlib/opencv/cv_image.h b/dlib/opencv/cv_image.h
+index 05af05511..31b96751c 100644
+--- a/dlib/opencv/cv_image.h
++++ b/dlib/opencv/cv_image.h
+@@ -23,7 +23,7 @@ namespace dlib
+         typedef pixel_type type;
+         typedef default_memory_manager mem_manager_type;
+ 
+-        cv_image (const cv::Mat img) 
++        cv_image (const cv::Mat &img) 
+         {
+             DLIB_CASSERT(img.depth() == cv::DataType<typename pixel_traits<pixel_type>::basic_pixel_type>::depth &&
+                          img.channels() == pixel_traits<pixel_type>::num, 
+@@ -119,34 +119,6 @@ namespace dlib
+         long nc() const { return _nc; }
+         long width_step() const { return _widthStep; }
+ 
+-        cv_image& operator=( const cv_image& item)
+-        {
+-            _data = item._data;
+-            _widthStep = item._widthStep;
+-            _nr = item._nr;
+-            _nc = item._nc;
+-            return *this;
+-        }
+-
+-        cv_image& operator=( const IplImage* img)
+-        {
+-            init(img);
+-            return *this;
+-        }
+-
+-        cv_image& operator=( const IplImage img)
+-        {
+-            init(&img);
+-            return *this;
+-        }
+-
+-        cv_image& operator=( const cv::Mat img)
+-        {
+-            IplImage temp = img;
+-            init(&temp);
+-            return *this;
+-        }
+-
+     private:
+ 
+         void init (const IplImage* img) 
+diff --git a/dlib/opencv/cv_image_abstract.h b/dlib/opencv/cv_image_abstract.h
+index 6fbc56b43..d019d148d 100644
+--- a/dlib/opencv/cv_image_abstract.h
++++ b/dlib/opencv/cv_image_abstract.h
+@@ -181,70 +181,6 @@ namespace dlib
+                   of this image
+         !*/
+ 
+-        cv_image& operator= ( 
+-            const cv_image& item
+-        );
+-        /*!
+-            ensures
+-                - #*this is an identical copy of item
+-                - returns #*this
+-        !*/
+-
+-        cv_image& operator=( 
+-            const IplImage* img
+-        );
+-        /*!
+-            requires
+-                - img->dataOrder == 0
+-                  (i.e. Only interleaved color channels are supported with cv_image)
+-                - (img->depth&0xFF)/8*img->nChannels == sizeof(pixel_type)
+-                  (i.e. The size of the pixel_type needs to match the size of the pixels 
+-                  inside the OpenCV image)
+-            ensures
+-                - #nr() == img->height
+-                  #nc() == img->width
+-                - using the operator[] on this object you will be able to access the pixels
+-                  inside this OpenCV image.
+-                - returns #*this
+-        !*/
+-
+-        cv_image& operator=( 
+-            const IplImage img
+-        );
+-        /*!
+-            requires
+-                - img->dataOrder == 0
+-                  (i.e. Only interleaved color channels are supported with cv_image)
+-                - (img->depth&0xFF)/8*img->nChannels == sizeof(pixel_type)
+-                  (i.e. The size of the pixel_type needs to match the size of the pixels 
+-                  inside the OpenCV image)
+-            ensures
+-                - #nr() == img->height
+-                  #nc() == img->width
+-                - using the operator[] on this object you will be able to access the pixels
+-                  inside this OpenCV image.
+-                - returns #*this
+-        !*/
+-
+-        cv_image& operator=( 
+-            const cv::Mat img
+-        );
+-        /*!
+-            requires
+-                - img.depth() == cv::DataType<pixel_traits<pixel_type>::basic_pixel_type>::depth
+-                  (i.e. The pixel_type template argument needs to match the type of pixel 
+-                  used inside the OpenCV image)
+-                - img.channels() == pixel_traits<pixel_type>::num
+-                  (i.e. the number of channels in the pixel_type needs to match the number of 
+-                  channels in the OpenCV image)
+-            ensures
+-                - #nr() == img.rows
+-                - #nc() == img.cols
+-                - using the operator[] on this object you will be able to access the pixels
+-                  inside this OpenCV image.
+-                - returns #*this
+-        !*/
+-
+         long width_step (
+         ) const;
+         /*!

--- a/mingw-w64-dlib/PKGBUILD
+++ b/mingw-w64-dlib/PKGBUILD
@@ -2,8 +2,8 @@
 
 _realname=dlib
 pkgbase="mingw-w64-${_realname}"
-pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=19.18
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=19.19
 pkgrel=2
 pkgdesc="A toolkit for making real world machine learning and data analysis applications in C++ (mingw-w64)"
 arch=('any')
@@ -18,22 +18,25 @@ depends=("${MINGW_PACKAGE_PREFIX}-lapack"
   "${MINGW_PACKAGE_PREFIX}-fftw"
   "${MINGW_PACKAGE_PREFIX}-sqlite3")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-python3"
-             "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
+             "${MINGW_PACKAGE_PREFIX}-python"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('strip')
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/davisking/${_realname}/archive/v${pkgver}.tar.gz"
-        "001-python-binding.patch")
-sha256sums=('e9a8540ad0ff84eda92dea7127cd7d078457caf7ced64400c25c9a0b8c96e242'
-            'd40f90a70da30689343071a7194ddcff73e225a6fff49ef6389b3dd861ac586f')
+        "001-python-binding.patch"
+        "002-fix-opencv-in-19.19.patch")
+sha256sums=('7af455bb422d3ae5ef369c51ee64e98fa68c39435b0fa23be2e5d593a3d45b87'
+            'd40f90a70da30689343071a7194ddcff73e225a6fff49ef6389b3dd861ac586f'
+            '81fe5b0daa2581de9ff151eaecdc85bf03efbd687ef97723d7227f5771658f47')
 
 
 prepare() {
   cd "$srcdir/${_realname}-${pkgver}"
 
   patch -Np1 -i "${srcdir}/001-python-binding.patch"
+  patch -Np1 -i "${srcdir}/002-fix-opencv-in-19.19.patch"
 
   cd "${srcdir}"
-  cp -r "${_realname}-${pkgver}" "python3-build-${CARCH}"
+  cp -r "${_realname}-${pkgver}" "python-build-${CARCH}"
 
   # Set version for setuptools_scm
   export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
@@ -62,8 +65,8 @@ build() {
   cmake --build . --config Release
 
   msg "Python 3 build for ${CARCH}"
-  cd "${srcdir}/python3-build-${CARCH}"
-  ${MINGW_PREFIX}/bin/python3 setup.py build -G "MSYS Makefiles" \
+  cd "${srcdir}/python-build-${CARCH}"
+  ${MINGW_PREFIX}/bin/python setup.py build -G "MSYS Makefiles" \
     --set CMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     --set USE_AVX_INSTRUCTIONS=ON \
     --set DLIB_ISO_CPP_ONLY=OFF \
@@ -82,7 +85,7 @@ build() {
 #}
 
 package_dlib() {
-  optdepends=("${MINGW_PACKAGE_PREFIX}-python3-dlib")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-python-dlib")
   cd "${srcdir}"/build-${CARCH}
   make install DESTDIR="${pkgdir}"
 
@@ -96,12 +99,12 @@ package_dlib() {
 
 package_python-dlib() {
   depends=("${MINGW_PACKAGE_PREFIX}-dlib"
-           "${MINGW_PACKAGE_PREFIX}-python3")
-  optdepends=("${MINGW_PACKAGE_PREFIX}-python3-numpy: Python 3.x interface")
+           "${MINGW_PACKAGE_PREFIX}-python")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-python-numpy: Python 3.x interface")
 
-  cd "${srcdir}/python3-build-${CARCH}"
+  cd "${srcdir}/python-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-    ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" --optimize=1 --skip-build
+    ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" --optimize=1 --skip-build
 }
 
 package_mingw-w64-i686-dlib() {
@@ -112,10 +115,10 @@ package_mingw-w64-x86_64-dlib() {
   package_dlib
 }
 
-package_mingw-w64-i686-python3-dlib() {
+package_mingw-w64-i686-python-dlib() {
   package_python-dlib
 }
 
-package_mingw-w64-x86_64-python3-dlib() {
+package_mingw-w64-x86_64-python-dlib() {
   package_python-dlib
 }


### PR DESCRIPTION
@Alexpux
This is a follow up to #6105. You did not give any reason why you turned down my PR, but I did what you asked me to do: Now dlib release 19.19 is used again and patches (taken from dlib github) are used to fix OpenCV compatibility. That patch can get removed once dlib 19.20 gets released.
I also included changes so the python-dlib package is build instead of python3-dlib.