### PR TITLE
build clang OpenMP

### DIFF
--- a/mingw-w64-clang/0010-mbig-obj-for-all.patch
+++ b/mingw-w64-clang/0010-mbig-obj-for-all.patch
@@ -1,6 +1,9 @@
 --- llvm-6.0.0.src/cmake/modules/HandleLLVMOptions.cmake.orig	2018-06-06 14:33:51.928460200 +0300
 +++ llvm-6.0.0.src/cmake/modules/HandleLLVMOptions.cmake	2018-06-06 14:33:59.840471400 +0300
 @@ -312,9 +312,7 @@
+-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--stack,16777216")
++  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--stack,16777216,--allow-multiple-definition")
+
    # Pass -mbig-obj to mingw gas on Win64. COFF has a 2**16 section limit, and
    # on Win64, every COMDAT function creates at least 3 sections: .text, .pdata,
    # and .xdata.

--- a/mingw-w64-clang/0105-build-libclang-cpp-fix.patch
+++ b/mingw-w64-clang/0105-build-libclang-cpp-fix.patch
@@ -1,0 +1,10 @@
+--- a/tools/CMakeLists.txt	2019-12-31 00:31:56.129822600 +0100
++++ b/tools/CMakeLists.txt	2019-12-31 00:32:53.903739000 +0100
+@@ -14,7 +14,7 @@
+ 
+ add_clang_subdirectory(clang-rename)
+ add_clang_subdirectory(clang-refactor)
+-if(UNIX)
++if(UNIX OR MINGW)
+   add_clang_subdirectory(clang-shlib)
+ endif()

--- a/mingw-w64-clang/0901-openmp-kpm-lock.patch
+++ b/mingw-w64-clang/0901-openmp-kpm-lock.patch
@@ -1,0 +1,14 @@
+diff --git a/runtime/src/kmp_lock.cpp b/runtime/src/kmp_lock.cpp
+index 78d63c678..0907fedcf 100644
+--- a/runtime/src/kmp_lock.cpp
++++ b/runtime/src/kmp_lock.cpp
+@@ -1703,7 +1703,8 @@ static void __kmp_set_queuing_lock_flags(kmp_queuing_lock_t *lck,
+ 
+ #if (KMP_COMPILER_ICC && __INTEL_COMPILER >= 1300) ||                          \
+     (KMP_COMPILER_MSVC && _MSC_VER >= 1700) ||                                 \
+-    (KMP_COMPILER_CLANG && KMP_MSVC_COMPAT)
++    (KMP_COMPILER_CLANG && (KMP_MSVC_COMPAT || __MINGW32__)) ||                \
++    (KMP_COMPILER_GCC && __MINGW32__)
+ 
+ #include <immintrin.h>
+ #define SOFT_ABORT_MASK (_XABORT_RETRY | _XABORT_CONFLICT | _XABORT_EXPLICIT)

--- a/mingw-w64-clang/0902-libomp-weak-mingw.patch
+++ b/mingw-w64-clang/0902-libomp-weak-mingw.patch
@@ -1,0 +1,13 @@
+diff --git "a/runtime/src/kmp_os.h" "b/runtime/src/kmp_os.h"
+index c4c7bcf6c..580326bfc 100644
+--- "a/runtime/src/kmp_os.h"
++++ "b/runtime/src/kmp_os.h"
+@@ -337,7 +337,7 @@ extern "C" {
+ #define KMP_ALIAS(alias_of) __attribute__((alias(alias_of)))
+ #endif
+ 
+-#if KMP_HAVE_WEAK_ATTRIBUTE
++#if KMP_HAVE_WEAK_ATTRIBUTE && !defined(__MINGW32__)
+ #define KMP_WEAK_ATTRIBUTE __attribute__((weak))
+ #else
+ #define KMP_WEAK_ATTRIBUTE /* Nothing */

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -30,9 +30,10 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-lld"
          "${MINGW_PACKAGE_PREFIX}-lldb"
          "${MINGW_PACKAGE_PREFIX}-llvm"
+         "${MINGW_PACKAGE_PREFIX}-openmp"
          "${MINGW_PACKAGE_PREFIX}-polly")
 pkgver=9.0.0
-pkgrel=2
+pkgrel=3
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 url="https://llvm.org/"
@@ -51,9 +52,11 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake>=3.4.3"
              $([[ "$_generator" == "Ninja" ]] && echo \
                "${MINGW_PACKAGE_PREFIX}-ninja")
              )
-depends=("${MINGW_PACKAGE_PREFIX}-gcc")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc"
+         "${MINGW_PACKAGE_PREFIX}-uasm")
 options=('!debug' 'strip')
 source=(${_url}/$pkgver/llvm-${pkgver}.src.tar.xz{,.sig}
+        ${_url}/$pkgver/openmp-${pkgver}.src.tar.xz{,.sig}
         ${_url}/$pkgver/cfe-${pkgver}.src.tar.xz{,.sig}
         ${_url}/$pkgver/compiler-rt-${pkgver}.src.tar.xz{,.sig}
         ${_url}/$pkgver/test-suite-${pkgver}.src.tar.xz{,.sig}
@@ -96,7 +99,9 @@ source=(${_url}/$pkgver/llvm-${pkgver}.src.tar.xz{,.sig}
         "0510-fix-CMake-when-LLDB_DISABLE_PYTHON-if-ON-and-ep.patch"
         "0601-fix-static-assert-macro.patch"
         "0701-disable-visibility-annotations.patch"
-        "0801-Don-t-build-LLVMPolly-on-WIN32.patch")
+        "0801-Don-t-build-LLVMPolly-on-WIN32.patch"
+        "0901-openmp-kpm-lock.patch"
+        "0902-libomp-weak-mingw.patch")
 # Some patch notes :)
 #0001-0099 -> llvm
 #0101-0199 -> clang
@@ -107,7 +112,10 @@ source=(${_url}/$pkgver/llvm-${pkgver}.src.tar.xz{,.sig}
 #0601-0699 -> libunwind
 #0701-0799 -> libc++abi
 #0801-0899 -> polly
+#0901-0999 -> openmp
 sha256sums=('d6a0565cf21f22e9b4353b2eb92622e8365000a9e90a16b09b56f8157eabfe84'
+            'SKIP'
+            '9979eb1133066376cc0be29d1682bc0b0e7fb541075b391061679111ae4d3b5b'
             'SKIP'
             '7ba81eef7c22ca5da688fdf9d88c20934d2d6b40bfe150ffd338900890aa4610'
             'SKIP'
@@ -161,7 +169,9 @@ sha256sums=('d6a0565cf21f22e9b4353b2eb92622e8365000a9e90a16b09b56f8157eabfe84'
             '963387da0ff24e167c91d193def2f5a7581dca41166f73b8914fcf8fd636101f'
             'b9727a84f6e412ef9ace5f1b4030ccbc8789a6f1ef74cc09f95dfa9118515b8a'
             'eaa7ad87e3f0fc9ff697c8865cce5c501fcb3a71a9a29c9497e444013163976f'
-            'bc394e597f8939b6f6630bd88c990f951738aaadacded2f3be71c658e9608fe7')
+            'bc394e597f8939b6f6630bd88c990f951738aaadacded2f3be71c658e9608fe7'
+            'db8dc554f7780609ee4eb4bc9e3817d4a9409b622f6471c8db06c92705805ead'
+            'f7958638e73273ea6a8df4a4e8726a0904d049fdaea7e84c33db5dec1af08fa8')
 validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Google.
               '474E22316ABF4785A88C6E8EA2C794A986419D8A') # Tom Stellard
 noextract=(cfe-${pkgver}.src.tar.xz
@@ -252,12 +262,19 @@ prepare() {
   apply_patch_with_msg \
       "0801-Don-t-build-LLVMPolly-on-WIN32.patch"
 
+  cd "${srcdir}/openmp-${pkgver}.src"
+  apply_patch_with_msg \
+      "0901-openmp-kpm-lock.patch" \
+      "0902-libomp-weak-mingw.patch"
+    
+
+
   # At the present, clang must reside inside the LLVM source code tree to build
   # See https://bugs.llvm.org/show_bug.cgi?id=4840
 
   cd "${srcdir}"/llvm-${pkgver}.src
   rm -rf tools/clang tools/clang/tools/extra tools/lld tools/lldb tools/polly projects/compiler-rt projects/libcxx \
-         projects/libcxxabi projects/libunwind projects/test-suite | true
+         projects/libcxxabi projects/libunwind projects/openmp projects/test-suite | true
   mv "${srcdir}/cfe-${pkgver}.src"               tools/clang
   mv "${srcdir}/clang-tools-extra-${pkgver}.src" tools/clang/tools/extra
   mv "${srcdir}/lld-${pkgver}.src"               tools/lld
@@ -267,6 +284,7 @@ prepare() {
   mv "${srcdir}/libcxxabi-${pkgver}.src"         projects/libcxxabi
   mv "${srcdir}/libcxx-${pkgver}.src"            projects/libcxx
   mv "${srcdir}/libunwind-${pkgver}.src"         projects/libunwind
+  mv "${srcdir}/openmp-${pkgver}.src"            projects/openmp
   #mv "${srcdir}/testsuite-${pkgver}.src"         projects/test-suite
 }
 
@@ -298,10 +316,19 @@ build() {
     export CC='clang'
     export CXX='clang++'
   fi
+  
+  export ASM_COMPILER="${MINGW_PREFIX}/bin/uasm.exe"
+  if [ "${CARCH}" == "x86_64" ]; then
+    export ASM_COMPILER_FLAGS=-win64
+  fi
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe \
     -G"$_generator" \
+    -DCMAKE_VERBOSE_MAKEFILE=ON \
+    -DCMAKE_ASM_MASM_COMPILER="${ASM_COMPILER}" \
+    -DLIBOMP_ASMFLAGS="${ASM_COMPILER_FLAGS}" \
+    -DLIBOMP_FORTRAN_MODULES=ON \
     -DCMAKE_SYSTEM_IGNORE_PATH=/usr/lib \
     -DFFI_INCLUDE_DIR="${FFI_INCLUDE_DIR}" \
     -DCMAKE_C_FLAGS="${CFLAGS}" \
@@ -329,7 +356,11 @@ build() {
     "${extra_config[@]}" \
     ../llvm-${pkgver}.src
 
-  ${_make_cmd}
+  # sed away the bad windows style command line parameters (they are translated by msys from /bad to c:\msys\bad
+  sed -i.orig 's/\/c  \/Fo/-c -Fo/' projects/openmp/runtime/src/CMakeFiles/omp.dir/build.make
+  sed -i.orig 's/\/safeseh \/coff/-safeseh -coff/' projects/openmp/runtime/src/CMakeFiles/omp.dir/build.make
+
+  ${_make_cmd} VERBOSE=1
 
   # Disable automatic installation of components that go into subpackages
   # -i.orig to check what has been removed in-case it starts dropping more than it should
@@ -337,7 +368,8 @@ build() {
   sed -i.orig '/\(clang\|lld\|lldb\|polly\)\/cmake_install.cmake/d' tools/cmake_install.cmake
   sed -i.orig '/\(extra\|scan-build\|scan-view\)\/cmake_install.cmake/d' tools/clang/tools/cmake_install.cmake
 # sed -i.orig '/\(compiler-rt\|libcxxabi\|libcxx\)\/cmake_install.cmake/d' projects/cmake_install.cmake
-  sed -i.orig '/\(compiler-rt\|libcxxabi\|libcxx\|libunwind\)\/cmake_install.cmake/d' projects/cmake_install.cmake
+  sed -i.orig '/\(compiler-rt\|libcxxabi\|libcxx\|openmp\|libunwind\)\/cmake_install.cmake/d' projects/cmake_install.cmake
+  # fix the bad command line parameters, use unix style
 }
 
 #check() {
@@ -408,6 +440,14 @@ package_libcxx() {
 
   cd "${srcdir}/llvm-${pkgver}.src"
   ${_make_cmd} -C ../build-${CARCH}/projects/libcxx -j1 DESTDIR="${pkgdir}" install
+}
+
+package_openmp() {
+  pkgdesc="OpenMP library (mingw-w64)"
+  url="https://openmp.llvm.org/"
+
+  cd "${srcdir}/llvm-${pkgver}.src"
+  ${_make_cmd} -C ../build-${CARCH}/projects/openmp DESTDIR="${pkgdir}" install
 }
 
 package_libcxxabi() {
@@ -522,6 +562,10 @@ package_mingw-w64-i686-libc++(){
   package_libcxx
 }
 
+package_mingw-w64-i686-openmp(){
+  package_openmp
+}
+
 package_mingw-w64-i686-lld(){
   package_lld
 }
@@ -565,6 +609,11 @@ package_mingw-w64-x86_64-libc++abi(){
 package_mingw-w64-x86_64-libc++(){
   package_libcxx
 }
+
+package_mingw-w64-x86_64-openmp(){
+  package_openmp
+}
+
 
 package_mingw-w64-x86_64-lld(){
   package_lld

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -5,6 +5,7 @@
 # Contributor: wirx6 <wirx654@gmail.com>
 # Contributor: Yuui Tanabe <yuuitanabe@163.com>
 # Contributor: Oscar Fuentes <ofv@wanadoo.es>
+# Contributor: Adrian Pop <adrian.pop@liu.se>
 
 
 # We can switch to clang when it fully works with mingw-w64
@@ -31,7 +32,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-llvm"
          "${MINGW_PACKAGE_PREFIX}-polly")
 pkgver=9.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 url="https://llvm.org/"
@@ -79,6 +80,7 @@ source=(${_url}/$pkgver/llvm-${pkgver}.src.tar.xz{,.sig}
         "0102-fix-libclang-name-for-mingw.patch"
         "0103-Set-the-x86-arch-name-to-i686-for-mingw-w64.patch"
         "0104-link-pthread-with-mingw.patch"
+        "0105-build-libclang-cpp-fix.patch"
         "0201-mingw-w64-__udivdi3-mangle-hack.patch"
         "0401-disable-visibility-annotations.patch"
         "0405-fix-conflict-win32-posix-threads.patch"
@@ -134,7 +136,7 @@ sha256sums=('d6a0565cf21f22e9b4353b2eb92622e8365000a9e90a16b09b56f8157eabfe84'
             '2c2431997e664c5b42b359f4134a4773578753e5e25c505ba30de42d357f3057'
             '1887ea21fcd591a50dd10559774e872ce1183177e672b028133d9b669e3cac32'
             '33400d16d5f6671a8fd60345c3ae44b9777a7d600061957889d14305eb2ad709'
-            '1c9efccd40a0e7834c3aa9d819aa25cfdd2cec389d1bd3e8a89bc9ff670a0129'
+            '8c216c885a1cd84a63c842ac4ce7c857b1bb4952a46bbd9905adaadacb1a758a'
             '18e719f49af8704c66d7d5e0c0c94ab04a7206fe2a3d711eb652e0afb35ff52c'
             'c486e1d45f6fb2a24823d776d2b47d6930530d423df73cc635f863265210c294'
             '656007a5eb587ac51e8d953fd28522c53cc56d297f2fa87ba818a0fe2ebd2b76'
@@ -143,6 +145,7 @@ sha256sums=('d6a0565cf21f22e9b4353b2eb92622e8365000a9e90a16b09b56f8157eabfe84'
             '01b029f2a21bd998ce374a90d41d214c891dfbb611dfbd9ca147517cd2c228ea'
             'ab49b90d69a609f441fa58e835873f2b1a8a060c9ca6358fee7d99c1973da692'
             '53646dd01af2862473e9719c5223366486268891ccbff86413943a432a8342e9'
+            'a60f7328d84628a56a9f626e4dc26ffd0c35292c79eeba62ac3d4f25aef2fe5c'
             '5d6b066d63ea927b87e32b8e70a38f763373622ae4f6a5062db7a5e087b41faf'
             '219eca2ad015ababb05d81ed97b4b40cf13ea189ee93cf57aa814cca7cf40001'
             '2f8f3c819837e4a16a364ed6e2a0a879cd10f924169ed7d89c27c1ed64edfe95'
@@ -211,7 +214,8 @@ prepare() {
       "0101-Allow-build-static-clang-library-for-mingw.patch" \
       "0102-fix-libclang-name-for-mingw.patch" \
       "0103-Set-the-x86-arch-name-to-i686-for-mingw-w64.patch" \
-      "0104-link-pthread-with-mingw.patch"
+      "0104-link-pthread-with-mingw.patch" \
+      "0105-build-libclang-cpp-fix.patch"
 
   cd "${srcdir}/compiler-rt-${pkgver}.src"
   apply_patch_with_msg \
@@ -312,11 +316,11 @@ build() {
     -DLIBUNWIND_ENABLE_SHARED=OFF \
     -DLLVM_BUILD_STATIC=OFF \
     -DLLVM_BUILD_LLVM_DYLIB=ON \
+    -DLLVM_LINK_LLVM_DYLIB=ON \
     -DLLVM_ENABLE_ASSERTIONS=OFF \
     -DLLVM_ENABLE_FFI=ON \
     -DLLVM_ENABLE_THREADS=ON \
     -DLLVM_ENABLE_SPHINX=ON \
-    -DLLVM_LINK_LLVM_DYLIB=OFF \
     -DLLVM_POLLY_LINK_INTO_TOOLS=OFF \
     -DLLDB_RELOCATABLE_PYTHON=ON \
     -DLLDB_USE_SYSTEM_SIX=ON \


### PR DESCRIPTION
build clang-openmp library (#6102) 
- use uasm instead of masm to build the libomp .asm file 
- add uasm as dependency to the clang package (needed by openmp) 
- include the header having xbegin on mingw as well 
- don't use weak attribute on mingw 
- sed away the windows like /flag to -flag on the call to uasm 
