### PR TITLE
zeromq: update to libzmq 4.3.2 and cppzmq 4.5.0

### DIFF
--- a/mingw-w64-zeromq/001-mingw-__except-fixes.patch
+++ b/mingw-w64-zeromq/001-mingw-__except-fixes.patch
@@ -1,0 +1,177 @@
+diff --git a/src/thread.cpp b/src/thread.cpp
+index b14d70757..3675899be 100644
+--- a/src/thread.cpp
++++ b/src/thread.cpp
+@@ -32,6 +32,10 @@
+ #include "thread.hpp"
+ #include "err.hpp"
+ 
++#ifdef ZMQ_HAVE_WINDOWS
++#include <winnt.h>
++#endif
++
+ bool zmq::thread_t::get_started () const
+ {
+     return _started;
+@@ -113,10 +117,22 @@ struct thread_info_t
+ #pragma pack(pop)
+ }
+ 
++typedef struct _MY_EXCEPTION_REGISTRATION_RECORD
++{
++    struct _MY_EXCEPTION_REGISTRATION_RECORD *Next;
++    void *Handler;
++} MY_EXCEPTION_REGISTRATION_RECORD;
++
++static EXCEPTION_DISPOSITION NTAPI continue_execution (EXCEPTION_RECORD *rec,
++	void *frame, CONTEXT *ctx, void *disp)
++{
++	return ExceptionContinueExecution;
++}
++
+ void zmq::thread_t::
+   applyThreadName () // to be called in secondary thread context
+ {
+-    if (!_name[0])
++    if (!_name[0] || !IsDebuggerPresent())
+         return;
+ 
+     thread_info_t thread_info;
+@@ -125,17 +141,19 @@ void zmq::thread_t::
+     thread_info._thread_id = -1;
+     thread_info._flags = 0;
+ 
+-#pragma warning(push)
+-#pragma warning(disable : 6320 6322)
+-    __try {
+-        DWORD MS_VC_EXCEPTION = 0x406D1388;
++    NT_TIB *tib = ((NT_TIB*)NtCurrentTeb());
++
++    MY_EXCEPTION_REGISTRATION_RECORD rec;
++    rec.Next = (MY_EXCEPTION_REGISTRATION_RECORD *)tib->ExceptionList;
++    rec.Handler = continue_execution;
++
++    // push our handler, raise, and finally pop our handler
++    tib->ExceptionList = (_EXCEPTION_REGISTRATION_RECORD *)&rec;
++    DWORD MS_VC_EXCEPTION = 0x406D1388;
+         RaiseException (MS_VC_EXCEPTION, 0,
+-                        sizeof (thread_info) / sizeof (ULONG_PTR),
+-                        (ULONG_PTR *) &thread_info);
+-    }
+-    __except (EXCEPTION_CONTINUE_EXECUTION) {
+-    }
+-#pragma warning(pop)
++            sizeof (thread_info) / sizeof (ULONG_PTR),
++            (ULONG_PTR *) &thread_info);
++    tib->ExceptionList = (_EXCEPTION_REGISTRATION_RECORD *)(((MY_EXCEPTION_REGISTRATION_RECORD *)tib->ExceptionList)->Next);
+ }
+ 
+ #elif defined ZMQ_HAVE_VXWORKS
+
+diff --git a/src/thread.cpp b/src/thread.cpp
+index 3675899be..2cad2adaa 100644
+--- a/src/thread.cpp
++++ b/src/thread.cpp
+@@ -124,15 +124,17 @@ typedef struct _MY_EXCEPTION_REGISTRATION_RECORD
+ } MY_EXCEPTION_REGISTRATION_RECORD;
+ 
+ static EXCEPTION_DISPOSITION NTAPI continue_execution (EXCEPTION_RECORD *rec,
+-	void *frame, CONTEXT *ctx, void *disp)
++                                                       void *frame,
++                                                       CONTEXT *ctx,
++                                                       void *disp)
+ {
+-	return ExceptionContinueExecution;
++    return ExceptionContinueExecution;
+ }
+ 
+ void zmq::thread_t::
+   applyThreadName () // to be called in secondary thread context
+ {
+-    if (!_name[0] || !IsDebuggerPresent())
++    if (!_name[0] || !IsDebuggerPresent ())
+         return;
+ 
+     thread_info_t thread_info;
+@@ -141,19 +143,21 @@ void zmq::thread_t::
+     thread_info._thread_id = -1;
+     thread_info._flags = 0;
+ 
+-    NT_TIB *tib = ((NT_TIB*)NtCurrentTeb());
++    NT_TIB *tib = ((NT_TIB *) NtCurrentTeb ());
+ 
+     MY_EXCEPTION_REGISTRATION_RECORD rec;
+-    rec.Next = (MY_EXCEPTION_REGISTRATION_RECORD *)tib->ExceptionList;
++    rec.Next = (MY_EXCEPTION_REGISTRATION_RECORD *) tib->ExceptionList;
+     rec.Handler = continue_execution;
+ 
+     // push our handler, raise, and finally pop our handler
+-    tib->ExceptionList = (_EXCEPTION_REGISTRATION_RECORD *)&rec;
++    tib->ExceptionList = (_EXCEPTION_REGISTRATION_RECORD *) &rec;
+     DWORD MS_VC_EXCEPTION = 0x406D1388;
+-        RaiseException (MS_VC_EXCEPTION, 0,
+-            sizeof (thread_info) / sizeof (ULONG_PTR),
+-            (ULONG_PTR *) &thread_info);
+-    tib->ExceptionList = (_EXCEPTION_REGISTRATION_RECORD *)(((MY_EXCEPTION_REGISTRATION_RECORD *)tib->ExceptionList)->Next);
++    RaiseException (MS_VC_EXCEPTION, 0,
++                    sizeof (thread_info) / sizeof (ULONG_PTR),
++                    (ULONG_PTR *) &thread_info);
++    tib->ExceptionList =
++      (_EXCEPTION_REGISTRATION_RECORD
++         *) (((MY_EXCEPTION_REGISTRATION_RECORD *) tib->ExceptionList)->Next);
+ }
+ 
+ #elif defined ZMQ_HAVE_VXWORKS
+
+diff --git a/src/thread.cpp b/src/thread.cpp
+index 2cad2ada..4cc5944e 100644
+--- a/src/thread.cpp
++++ b/src/thread.cpp
+@@ -120,7 +120,7 @@ struct thread_info_t
+ typedef struct _MY_EXCEPTION_REGISTRATION_RECORD
+ {
+     struct _MY_EXCEPTION_REGISTRATION_RECORD *Next;
+-    void *Handler;
++    EXCEPTION_DISPOSITION (*Handler) (EXCEPTION_RECORD*, void*, CONTEXT*, void*);
+ } MY_EXCEPTION_REGISTRATION_RECORD;
+ 
+ static EXCEPTION_DISPOSITION NTAPI continue_execution (EXCEPTION_RECORD *rec,
+
+diff --git a/src/thread.cpp b/src/thread.cpp
+index 4cc5944e..b81d458a 100644
+--- a/src/thread.cpp
++++ b/src/thread.cpp
+@@ -120,7 +120,7 @@ struct thread_info_t
+ typedef struct _MY_EXCEPTION_REGISTRATION_RECORD
+ {
+     struct _MY_EXCEPTION_REGISTRATION_RECORD *Next;
+-    EXCEPTION_DISPOSITION (*Handler) (EXCEPTION_RECORD*, void*, CONTEXT*, void*);
++    EXCEPTION_DISPOSITION NTAPI (*Handler) (EXCEPTION_RECORD*, void*, CONTEXT*, void*);
+ } MY_EXCEPTION_REGISTRATION_RECORD;
+ 
+ static EXCEPTION_DISPOSITION NTAPI continue_execution (EXCEPTION_RECORD *rec,
+
+diff --git a/src/thread.cpp b/src/thread.cpp
+index b81d458a..6f07e9ce 100644
+--- a/src/thread.cpp
++++ b/src/thread.cpp
+@@ -117,11 +117,14 @@ struct thread_info_t
+ #pragma pack(pop)
+ }
+ 
+-typedef struct _MY_EXCEPTION_REGISTRATION_RECORD
++struct MY_EXCEPTION_REGISTRATION_RECORD
+ {
+-    struct _MY_EXCEPTION_REGISTRATION_RECORD *Next;
+-    EXCEPTION_DISPOSITION NTAPI (*Handler) (EXCEPTION_RECORD*, void*, CONTEXT*, void*);
+-} MY_EXCEPTION_REGISTRATION_RECORD;
++    typedef EXCEPTION_DISPOSITION (NTAPI *HandlerFunctionType) (
++      EXCEPTION_RECORD *, void *, CONTEXT *, void *);
++
++    MY_EXCEPTION_REGISTRATION_RECORD *Next;
++    HandlerFunctionType Handler;
++};
+ 
+ static EXCEPTION_DISPOSITION NTAPI continue_execution (EXCEPTION_RECORD *rec,
+                                                        void *frame,
+

--- a/mingw-w64-zeromq/PKGBUILD
+++ b/mingw-w64-zeromq/PKGBUILD
@@ -3,8 +3,9 @@
 _realname=zeromq
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.3.1
-pkgrel=3
+pkgver=4.3.2
+_cppzmqver=4.5.0
+pkgrel=1
 pkgdesc="Fast messaging system built on sockets, C and C++ bindings. aka 0MQ, ZMQ (mingw-w64)"
 arch=('any')
 url="https://www.zeromq.org/"
@@ -13,13 +14,17 @@ depends=("${MINGW_PACKAGE_PREFIX}-libsodium")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 options=('staticlibs' 'strip')
 source=("https://github.com/zeromq/libzmq/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz"
-        "https://raw.githubusercontent.com/zeromq/cppzmq/81c2938faad8b62167642e43b2d646591650c3f6/zmq.hpp")
-sha256sums=('bcbabe1e2c7d0eec4ed612e10b94b112dd5f06fcefa994a0c79a45d835cd21eb'
-            '71adbb0e86c7730cce0bc5ae0195dd0891b78a601d44dff1913f9c0864c35872')
+        "zmq-${_cppzmqver}.hpp::https://raw.githubusercontent.com/zeromq/cppzmq/v${_cppzmqver}/zmq.hpp"
+        "zmq_addon-${_cppzmqver}.hpp::https://raw.githubusercontent.com/zeromq/cppzmq/v${_cppzmqver}/zmq_addon.hpp"
+        "001-mingw-__except-fixes.patch")
+sha256sums=('ebd7b5c830d6428956b67a0454a7f8cbed1de74b3b01e5c33c5378e22740f763'
+            '132c0e40e5a2f97e6946d2a3d0428e05c916c6d2c5702a59188f9788e09d2321'
+            'cb0e966111b73689c9fb908bef46ddaf327cba299c41f24d67f1a0151e11242d'
+            '054314f319d9b7d085975e01ddb7bcf39377ceef38b9796cd40d40cde6ce78ca')
 
 prepare() {
   cd ${_realname}-${pkgver}
-  #patch -p1 -i ${srcdir}/001-guard-msvc-code.patch
+  patch -Np1 -i "${srcdir}/001-mingw-__except-fixes.patch"
 }
 
 build() {
@@ -45,7 +50,8 @@ package() {
 
   cd "${srcdir}/build-${CARCH}"
   make DESTDIR="${pkgdir}" install
-  install -Dm644 "${srcdir}/zmq.hpp" "${pkgdir}${MINGW_PREFIX}/include/zmq.hpp"
+  install -Dm644 "${srcdir}/zmq-${_cppzmqver}.hpp" "${pkgdir}${MINGW_PREFIX}/include/zmq.hpp"
+  install -Dm644 "${srcdir}/zmq_addon-${_cppzmqver}.hpp" "${pkgdir}${MINGW_PREFIX}/include/zmq_addon.hpp"
   
   # Fix .pc file
   local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})


### PR DESCRIPTION
As stated in the title the package was updated. That patches were taken from zeromq's repo and wont be needed in next release.

-------
Some additional notes:
There are actually 3 ZeroMQ projects:
libzmq (the zeromq C library)
cppzmq (the cpp binding, basically just 2 header files)
pyzmq (the python binding)
MSYS2 provides those in 2 packages:
zeromq = libzmq + cppzmq
python-pyzmq = pyzmq

I think there are some minor problems with this:
- the names of our packages neither match each other nor the names of the original project perfectly
- the zeromq package consists of two original projects, that get updated independently from each other, so we need keep track of both
- the zeromq package does not mention the cppzmq version number anywhere, only that of libzmq

Do you think any of those should get addressed somehow?