### PR TITLE
groonga: update to Groonga 9.1.1

### DIFF
--- a/mingw-w64-groonga/PKGBUILD
+++ b/mingw-w64-groonga/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=groonga
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=9.1.0
+pkgver=9.1.1
 pkgrel=1
 pkgdesc="An opensource fulltext search engine (mingw-w64)"
 arch=('any')
@@ -23,7 +23,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-arrow"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-zstd")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
-sha256sums=('7342ffee8f64a8d95d323b53b30d0d07aede1296f8ac86d120dfac4695bdb486')
+sha256sums=('02652b3ec04b1fca6b36a8e4669e5174e7f1417e1801f40c53b273757d5d259a')
 
 build() {
   [[ -d ${srcdir}/build-${CARCH} ]] && rm -rf ${srcdir}/build-${CARCH}


### PR DESCRIPTION
I update Groonga's version in PKGBUILD.
Because upstream was an update.