### PR TITLE
rocksdb: Update to 6.5.3 and tweak build settings

### DIFF
--- a/mingw-w64-rocksdb/PKGBUILD
+++ b/mingw-w64-rocksdb/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=rocksdb
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=6.5.2
+pkgver=6.5.3
 pkgrel=1
 pkgdesc="A library that provides an embeddable, persistent key-value store for fast storage (mingw-w64)"
 arch=('any')
@@ -20,7 +20,7 @@ options=('staticlibs' 'strip')
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/facebook/${_realname}/archive/v${pkgver}.tar.gz"
         "0002-suppress-unused-warnings.patch"
         "0004-fix-generating-and-install-import-lib.patch")
-sha256sums=('a923e36aa1cdd1429ae93a0b26baf477c714060ce7dd1c52e873754e1468d7ff'
+sha256sums=('6dc023a11d61d00c8391bd44f26ba7db06c44be228c10b552edc84e02d7fbde2'
             '739b2101c35ce9d495bb5997c6fc056d41723f3f19dadae48c38782e5e4ad83d'
             '6dffb7e67dd2235162e6d9fac2b3baacb6547358a0a40d7babd85a797238f344')
 
@@ -53,6 +53,8 @@ build() {
     -DWITH_BZ2=ON \
     -DWITH_LZ4=ON \
     -DWITH_SNAPPY=ON \
+    -DUSE_RTTI=ON \
+    -DPORTABLE=ON \
     -DROCKSDB_INSTALL_ON_WINDOWS=ON \
     ../${_realname}-${pkgver}
 


### PR DESCRIPTION
This compiles rocksdb with RTTI support and in portable mode.

Portable mode is needed because otherwise the resulting binary might be unusable on older processors.

See https://bugs.archlinux.org/task/65093