### PR TITLE
gcc-git: Sync with the new GCC Git repo

### DIFF
--- a/mingw-w64-gcc-git/PKGBUILD
+++ b/mingw-w64-gcc-git/PKGBUILD
@@ -42,8 +42,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-${_realname}"
 optdepends=()
 options=('staticlibs' '!emptydirs' '!strip' 'debug')
 
-#_branch=gcc-7-branch
-_branch=gcc-9-branch
+#_branch=releases/gcc-7
+_branch=releases/gcc-9
 _realpkgver="$(git archive --remote=git://gcc.gnu.org/git/gcc.git refs/heads/${_branch}:gcc/ BASE-VER | tar -xO)"
 
 # git+https://gcc.gnu.org/git/gcc.git#branch=${_branch}
@@ -105,17 +105,17 @@ prepare() {
   ${GIT_AM} ${srcdir}/0008-Prettify-linking-no-undefined.patch
   ${GIT_AM} ${srcdir}/0010-Fix-using-large-PCH.patch
   ${GIT_AM} ${srcdir}/0011-Enable-shared-gnat-implib.patch
-  if [ "${_branch}" != "gcc-9-branch" ]; then
+  if [ "${_branch}" != "releases/gcc-9" ]; then
     ${GIT_AM} ${srcdir}/0014-clone_function_name_1-Retain-any-stdcall-suffix.patch
   else
     ${GIT_AM} ${srcdir}/0014-gcc-9-branch-clone_function_name_1-Retain-any-stdcall-suffix.patch
   fi
-  if [ "${_branch}" == "gcc-7-branch" ]; then
+  if [ "${_branch}" == "releases/gcc-7" ]; then
     ${GIT_AM} ${srcdir}/0016-gcc-7-branch-disable-weak-refs-in-libstdc++.patch
     ${GIT_AM} ${srcdir}/0017-gcc-7-branch-Enable-std-experimental-filesystem.patch
     ${GIT_AM} ${srcdir}/0018-gcc-7-branch-Enable-a-native-GCC-to-color-diagnostic-messages-sen.patch
   fi
-  if [ "${_branch}" == "gcc-8-branch" ]; then
+  if [ "${_branch}" == "releases/gcc-8" ]; then
     ${GIT_AM} ${srcdir}/0019-gcc-8-branch-Backport-patches-for-std-filesystem-from-master.patch
   fi
 


### PR DESCRIPTION
The GCC developers decided to migrate to Git, which means the old Git
mirror is now the official repo. The scheme of naming of branches has
changed in this process.

Signed-off-by: Liu Hao <lh_mouse@126.com>