### PR TITLE
mingw-w64-x264: fix patch for changes upstream

### DIFF
--- a/mingw-w64-x264-git/0001-beautify-pc.all.patch
+++ b/mingw-w64-x264-git/0001-beautify-pc.all.patch
@@ -1,14 +1,14 @@
---- x264-snapshot-20140208-2245-stable/configure.orig	2014-02-09 16:10:32.011010400 +0000
-+++ x264-snapshot-20140208-2245-stable/configure	2014-02-09 16:11:59.730649400 +0000
-@@ -1249,9 +1249,9 @@
+--- x264/configure.orig	2020-01-16 21:08:21.000000000 +0100
++++ x264/configure	2020-01-16 21:09:16.000000000 +0100
+@@ -1571,9 +1571,9 @@ includedir=$includedir
  Name: x264
  Description: H.264 (MPEG4 AVC) encoder library
- Version: $(grep POINTVER < x264_config.h | sed -e 's/.* "//; s/".*//')
+ Version: $(grep POINTVER < x264_config.h | sed -e 's/.* "//; s/".*//; s/ .*//')
 -Libs: -L$libdir -lx264 $([ "$shared" = "yes" ] || echo $libpthread $libm $libdl)
 +Libs: -L\${libdir} -lx264 $([ "$shared" = "yes" ] || echo $libpthread $libm $libdl)
  Libs.private: $([ "$shared" = "yes" ] && echo $libpthread $libm $libdl)
--Cflags: -I$includedir
-+Cflags: -I\${includedir}
+-Cflags: -I$includedir $([ "$shared" = "yes" ] && echo "-DX264_API_IMPORTS")
++Cflags: -I\${includedir} $([ "$shared" = "yes" ] && echo "-DX264_API_IMPORTS")
  EOF
  
  filters="crop select_every"

--- a/mingw-w64-x264-git/PKGBUILD
+++ b/mingw-w64-x264-git/PKGBUILD
@@ -6,7 +6,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=r2970.5493be84
+pkgver=r2991.1771b556
 pkgrel=1
 pkgdesc="Library for encoding H264/AVC video streams (mingw-w64)"
 arch=('any')
@@ -24,7 +24,7 @@ source=("${_realname}"::"git+https://code.videolan.org/videolan/${_realname}.git
         0001-beautify-pc.all.patch
         0002-install-avisynth_c.h.mingw.patch)
 sha256sums=('SKIP'
-            '0eba3b41ef0c01f33280ce61bdd47cb966d765c0cb02db239fc6c89d601a2596'
+            '8e92f4d6c1924664e7c9f5b797070a35f8eabbfce431f996167fe426fc833dda'
             '51d7efd8eb504d42767c04cfe8abb9c7ccbe84d76e7150c5c46535507763d1b8')
 
 pkgver() {


### PR DESCRIPTION
I noticed that the build started failing because the patch no longer applies.