### PR TITLE
snappy: update to 1.1.8

### DIFF
--- a/mingw-w64-snappy/PKGBUILD
+++ b/mingw-w64-snappy/PKGBUILD
@@ -4,11 +4,11 @@
 _realname=snappy
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.1.7
-pkgrel=2
-pkgdesc="A fast C++ compressor/decompressor library (mingw-w64)"
+pkgver=1.1.8
+pkgrel=1
+pkgdesc="A fast compressor/decompressor library (mingw-w64)"
 arch=('any')
-license=('New BSD License')
+license=('BSD')
 url="https://github.com/google/snappy"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
@@ -17,13 +17,12 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
 checkdepends=("${MINGW_PACKAGE_PREFIX}-zlib"
               "${MINGW_PACKAGE_PREFIX}-lzo2")
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/google/snappy/archive/${pkgver}.tar.gz")
-sha256sums=('3dfa02e873ff51a11ee02b9ca391807f0c8ea0529a4924afa645fbf97163f9d4')
+sha256sums=('16b677f07832a612b0836178db7f374e414f94657c138e6993cbfc5dcc58651f')
 
 build() {
   # Shared Build
   [[ -d "${srcdir}"/build-${MINGW_CHOST}-shared ]] && rm -rf "${srcdir}"/build-${MINGW_CHOST}-shared
-  mkdir -p ${srcdir}/build-${MINGW_CHOST}-shared
-  cd ${srcdir}/build-${MINGW_CHOST}-shared
+  mkdir -p ${srcdir}/build-${MINGW_CHOST}-shared && cd ${srcdir}/build-${MINGW_CHOST}-shared
   
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake \
@@ -38,8 +37,7 @@ build() {
   
   # Static Build
   [[ -d "${srcdir}"/build-${MINGW_CHOST}-static ]] && rm -rf "${srcdir}"/build-${MINGW_CHOST}-static
-  mkdir -p ${srcdir}/build-${MINGW_CHOST}-static
-  cd ${srcdir}/build-${MINGW_CHOST}-static
+  mkdir -p ${srcdir}/build-${MINGW_CHOST}-static && cd ${srcdir}/build-${MINGW_CHOST}-static
   
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake \


### PR DESCRIPTION
This updates snappy to 1.1.8.