### PR TITLE
pycairo: Update to 1.19.0

### DIFF
--- a/mingw-w64-pycairo/PKGBUILD
+++ b/mingw-w64-pycairo/PKGBUILD
@@ -2,80 +2,39 @@
 
 _realname=pycairo
 pkgbase=mingw-w64-${_realname}
-pkgname=("${MINGW_PACKAGE_PREFIX}-python2-cairo" "${MINGW_PACKAGE_PREFIX}-python-cairo")
-pkgver=1.18.2
-pkgrel=2
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-cairo")
+pkgver=1.19.0
+pkgrel=1
 pkgdesc="Python bindings for the cairo graphics library (mingw-w64)"
 url="https://pycairo.readthedocs.io"
 arch=('any')
 license=('LGPL' 'MPL')
-depends=("${MINGW_PACKAGE_PREFIX}-cairo")
-makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
-             "${MINGW_PACKAGE_PREFIX}-python")
-checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest"
-              "${MINGW_PACKAGE_PREFIX}-python2-pytest")
+depends=("${MINGW_PACKAGE_PREFIX}-cairo"
+         "${MINGW_PACKAGE_PREFIX}-python")
+provides=("${MINGW_PACKAGE_PREFIX}-python3-cairo")
+conflicts=("${MINGW_PACKAGE_PREFIX}-python3-cairo")
+replaces=("${MINGW_PACKAGE_PREFIX}-python3-cairo")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
 source=(https://github.com/pygobject/${_realname}/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz)
-sha256sums=('dcb853fd020729516e8828ad364084e752327d4cff8505d20b13504b32b16531')
-
-prepare() {
-  cd "${srcdir}"
-  rm -rf python2-build python3-build
-  cp -r ${_realname}-${pkgver} python2-build
-  cp -r ${_realname}-${pkgver} python-build
-}
+sha256sums=('4f5ba9374a46c98729dd3727d993f5e17ed0286fd6738ed464fe4efa0612d19c')
 
 build() {
-  cd "${srcdir}"
-  for builddir in python{,2}-build; do
-    pushd ${builddir}
-    ${MINGW_PREFIX}/bin/${builddir%-build} setup.py build
-    popd
-  done
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  ${MINGW_PREFIX}/bin/python setup.py build
 }
 
 check() {
-  cd "${srcdir}"
-  for builddir in python{,2}-build; do
-    pushd ${builddir}
-    ${MINGW_PREFIX}/bin/${builddir%-build} setup.py test
-    popd
-  done
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  ${MINGW_PREFIX}/bin/python setup.py test
 }
 
-package_python2-cairo() {
-  depends+=("${MINGW_PACKAGE_PREFIX}-python2")
-  cd "${srcdir}/python2-build"
-  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-    ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" -O1
+package() {
+  cd "${srcdir}/${_realname}-${pkgver}"
 
-  install -Dm644 COPYING* -t "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-cairo"
-}
-
-package_python-cairo() {
-  depends+=("${MINGW_PACKAGE_PREFIX}-python")
-  provides=("${MINGW_PACKAGE_PREFIX}-python3-cairo")
-  conflicts=("${MINGW_PACKAGE_PREFIX}-python3-cairo")
-  replaces=("${MINGW_PACKAGE_PREFIX}-python3-cairo")
-
-  cd "${srcdir}/python-build"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
     ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" -O1
 
   install -Dm644 COPYING* -t "${pkgdir}${MINGW_PREFIX}/share/licenses/python-cairo"
-}
-
-package_mingw-w64-i686-python2-cairo() {
-  package_python2-cairo
-}
-
-package_mingw-w64-i686-python-cairo() {
-  package_python-cairo
-}
-
-package_mingw-w64-x86_64-python2-cairo() {
-  package_python2-cairo
-}
-
-package_mingw-w64-x86_64-python-cairo() {
-  package_python-cairo
 }

--- a/mingw-w64-python2-pycairo/PKGBUILD
+++ b/mingw-w64-python2-pycairo/PKGBUILD
@@ -1,0 +1,30 @@
+# Maintainer: Christoph Reiter <reiter.christoph@gmail.com>
+
+_realname=pycairo
+pkgbase=mingw-w64-python2-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-cairo")
+pkgver=1.18.2
+pkgrel=3
+pkgdesc="Python bindings for the cairo graphics library (mingw-w64)"
+url="https://pycairo.readthedocs.io"
+arch=('any')
+license=('LGPL' 'MPL')
+depends=("${MINGW_PACKAGE_PREFIX}-cairo"
+         "${MINGW_PACKAGE_PREFIX}-python2")
+source=(https://github.com/pygobject/${_realname}/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz)
+sha256sums=('dcb853fd020729516e8828ad364084e752327d4cff8505d20b13504b32b16531')
+
+build() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  ${MINGW_PREFIX}/bin/python2 setup.py build
+}
+
+package() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" -O1
+
+  install -Dm644 COPYING* -t "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-cairo"
+}


### PR DESCRIPTION
Also split the package because Python 2 support was dropped with 1.19