### PR TITLE
mingw-w64-curl: Update PKGBUILD in order to build with libssh2.

### DIFF
--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -113,6 +113,7 @@ build() {
     --with-brotli \
     --with-ldap-lib=wldap32 \
     --with-libmetalink=${MINGW_PREFIX} \
+    --with-libssh2 \
     "${_variant_config[@]}" \
     "${extra_config[@]}"
 # there's a bug with zsh completion generation script and Windows.


### PR DESCRIPTION
cURL, starting with version 7.58, changed build settings around SSH support so that MinGW builds of cURL made since have scp and scftp protocols support disabled.

This commit re-enabled SSH support for MinGW builds.

Signed-off-by: François-Xavier MAURICARD <fxmauricard@gmail.com>