### PR TITLE
mingw-w64-mesa: Build both static and shared

### DIFF
--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -4,7 +4,7 @@ _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=19.3.3
-pkgrel=1
+pkgrel=2
 pkgdesc="Open-source implementation of the OpenGL specification (mingw-w64)"
 arch=('any')
 makedepends=("${MINGW_PACKAGE_PREFIX}-llvm"
@@ -16,7 +16,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-llvm"
 # Workaround bug https://gitlab.freedesktop.org/mesa/mesa/issues/2012 by adding dependencies
 depends=("${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-gcc-libs")
-optdepends=("${MINGW_PACKAGE_PREFIX}-opengl-man-pages: for the OpenGL API man pages")
+optdepends=("${MINGW_PACKAGE_PREFIX}-opengl-man-pages: for the OpenGL API man pages"
+            "${MINGW_PACKAGE_PREFIX}-llvm: for shared linking LLVM")
 url="https://www.mesa3d.org/"
 license=('MIT')
 options=('staticlibs' 'strip')
@@ -24,7 +25,7 @@ source=(https://mesa.freedesktop.org/archive/${_realname}-${pkgver}.tar.xz{,.sig
         llvmwrapgen.sh)
 sha256sums=('81ce4810bb25d61300f8104856461f4d49cf7cb794aa70cb572312e370c39f09'
             'SKIP'
-            '82a8835800fbe5fba31b89aa32232b69fe97088b12b7fc0e47d8ae6102525b70')
+            'e0340aad84db73fea994f2ce6a91bd19e54c17b6137e0dfb1bc8fabca8e72ed8')
 validpgpkeys=('8703B6700E7EE06D7A39B8D6EDAE37B02CEB490D') # Emil Velikov <emil.l.velikov@gmail.com>
 validpgpkeys+=('946D09B5E4C9845E63075FF1D961C596A7203456') # Andres Gomez <tanty@igalia.com>
 validpgpkeys+=('E3E8F480C52ADD73B278EE78E1ECBE07D7D70895') # Juan Antonio Suárez Romero (Igalia, S.L.) <jasuarez@igalia.com>"
@@ -77,7 +78,7 @@ buildcmd(){
   ${MINGW_PREFIX}/bin/meson ./build/windows-${_mach} \
   --prefix=${MINGW_PREFIX} \
   --includedir=include/mesa \
-  --default-library=static \
+  --default-library=both \
   --buildtype=release \
   --backend=ninja \
   -Dshared-glapi=true \
@@ -93,7 +94,7 @@ build() {
   cd ${srcdir}/${_realname}-${pkgver}
   CFLAGS="-march=core2 -pipe" \
   CXXFLAGS="-march=core2 -pipe" \
-  LDFLAGS="-static -s" \
+  LDFLAGS="-s" \
   PROCESSOR_ARCHITECTURE="${CARCH}" \
   buildcmd
 }

--- a/mingw-w64-mesa/llvmwrapgen.sh
+++ b/mingw-w64-mesa/llvmwrapgen.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Get LLVM libraries
-llvmlibs=$(${MINGW_PREFIX}/bin/llvm-config --libnames engine coroutines)
+llvmlibs=$(${MINGW_PREFIX}/bin/llvm-config --link-static --libnames engine coroutines)
 
 # Get LLVM RTTI status
 rtti=false
@@ -24,6 +24,10 @@ _deps = []
 _search = '$(cygpath -m ${MINGW_PREFIX})/lib'
 foreach d : [${llvmlibs}]
   _deps += cpp.find_library(d, dirs : _search)
+endforeach
+_search2 = '$(cygpath -m ${MINGW_PREFIX})/bin'
+foreach d2 : ['libLLVM', 'libLTO', 'libRemarks']
+  _deps += cpp.find_library(d2, dirs : _search2)
 endforeach
 
 dep_llvm = declare_dependency(


### PR DESCRIPTION
This should fix potential missing `libLLVM.dll` related errors with 19.3.2-1 and 19.3.3-1 when mingw-w64-llvm is not installed. Regression caused by #6098. That pull request naturally changed the output of `llvm-config --libnames` to be identical to `llvm-config --link-shared --libnames`.  To adapt to this behavior change, static libraries have to be explicitly requested with `llvm-config --link-static --libnames`. when needed This maintains compatibility with minngw-w64-llvm from before #6098 when `llvm-config --libnames` output matched `llvm-config --link-static --libnames`.

This pull request also adjusts Meson subproject wrap generator for LLVM (`llvmwrapgen.sh`) to lookup both static and shared libraries and flips Meson `--default-library` to `both` as requested a long time ago. It was way too complicated to do back then and I learned more about Meson since then.