### PR TITLE
Add new package mingw-w64-ttfautohint

### DIFF
--- a/mingw-w64-ttfautohint/PKGBUILD
+++ b/mingw-w64-ttfautohint/PKGBUILD
@@ -1,0 +1,44 @@
+# Contributor: Jim Killingsworth <jkillingsworth@gmail.com>
+
+_realname=ttfautohint
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.8.3
+pkgrel=1
+pkgdesc="Automated hinting tools for TrueType fonts (mingw-w64)"
+arch=('any')
+url="https://www.freetype.org/ttfautohint/"
+license=(GPL2+ custom:FreeType)
+depends=("${MINGW_PACKAGE_PREFIX}-freetype"
+         "${MINGW_PACKAGE_PREFIX}-harfbuzz"
+         "${MINGW_PACKAGE_PREFIX}-qt5")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
+options=('strip' '!libtool' 'staticlibs')
+source=(https://downloads.sourceforge.net/sourceforge/freetype/${_realname}-${pkgver}.tar.gz)
+sha256sums=('87bb4932571ad57536a7cc20b31fd15bc68cb5429977eb43d903fa61617cf87e')
+
+build() {
+  [[ -d "${srcdir}/build-${CARCH}" ]] && rm -rf "${srcdir}/build-${CARCH}"
+  mv "${srcdir}/${_realname}-${pkgver}" "${srcdir}/build-${CARCH}"
+  cd "${srcdir}/build-${CARCH}"
+
+  ./configure \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --prefix=${MINGW_PREFIX} \
+    --enable-static \
+    --enable-shared
+
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${CARCH}"
+  make DESTDIR="${pkgdir}" install
+
+  # Licenses
+  install -Dm644 "${srcdir}/build-${CARCH}/COPYING"   "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+  install -Dm644 "${srcdir}/build-${CARCH}/GPLv2.TXT" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/GPLv2.TXT"
+  install -Dm644 "${srcdir}/build-${CARCH}/FTL.TXT"   "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/FTL.TXT"
+}


### PR DESCRIPTION
This package is for **ttfautohint**, which is a set of automated hinting tools for TrueType fonts. It allows the user to manipulate the font hinting instructions embedded in TTF files. It is associated with the FreeType project. More information can be found here:

https://www.freetype.org/ttfautohint/

This package installs the following:

* The library and header files
* A command line tool called `ttfautohint.exe`
* A GUI tool called `ttfautohintGUI.exe`

It has the following dependencies:

* FreeType
* HarfBuzz
* Qt

I want to point out that the Qt dependency is quite large, with about a 1 GB download size and a 7 GB installation footprint. The Qt dependency is for the GUI tool only. If the user only wants to use the command line tool or the library, they will still need to have the Qt prerequisite installed in order to use this package. Is this acceptable? Am I taking the right approach here? What is the best practice for handling Qt dependencies within the MSYS2 ecosystem?

As an alternative approach, it is possible to eliminate the Qt dependency by passing the `--without-qt` option to the configure script in the build step. This would exclude the GUI tool from the package. Is it better to exclude the GUI tool or not? The project website includes a download link for a precompiled stand-alone version of the GUI tool, so the user would still be able to access the GUI tool separately outside of the MSYS2 environment if they choose to use it. For comparison, the stand-alone tool is only a 5 MB download.

I have considered other alternatives as well, such as creating a statically linked version of the GUI executable or splitting the package into two parts, one with and one without the GUI tool and Qt dependency. However, these options might not be as simple to create or maintain. And there might be other ways of dealing with Qt dependencies that I have not thought of.

For my purposes, I only need the command line tool, so part of me wants to use the `--without-qt` option to exclude the GUI tool and Qt dependency. However, I will not complain if there is a preference for this to be a more complete package. Since this is my first contribution to the MSYS2 project, I welcome any feedback from others in the community.
