### PR TITLE
Various Python updates

### DIFF
--- a/mingw-w64-python-importlib-metadata/PKGBUILD
+++ b/mingw-w64-python-importlib-metadata/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=importlib-metadata
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=1.3.0
+pkgver=1.5.0
 pkgrel=1
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}=${pkgver}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
@@ -13,15 +13,14 @@ arch=('any')
 url='https://importlib-metadata.readthedocs.io/'
 license=('Apache')
 depends=("${MINGW_PACKAGE_PREFIX}-python"
-         "${MINGW_PACKAGE_PREFIX}-python-contextlib2"
-         "${MINGW_PACKAGE_PREFIX}-python-pathlib2"
          "${MINGW_PACKAGE_PREFIX}-python-zipp")
-makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pip"
               "${MINGW_PACKAGE_PREFIX}-python-pytest-runner"
               "${MINGW_PACKAGE_PREFIX}-python-wheel")
 source=("${_realname}-${pkgver}.tar.gz"::"https://files.pythonhosted.org/packages/source/${_realname::1}/${_realname//-/_}/${_realname//-/_}-${pkgver}.tar.gz")
-sha512sums=('45d09cbbbceee80a4769f2d374a3c4b511fda56a100ad1a6fc7cedf9a0cd251600c960430c608c7bcd60bdd9a0117f83025ed7b05f9f6a53edc791d128e8b0d7')
+sha512sums=('074bc38df2a1b20dac62d88e209b2730cc56f8a8bb7f7b99bf766028f602700733448e7cb4d22ea099be38cfc9484ff6a235a46c6c114c3d70883393eeef3aa0')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {

--- a/mingw-w64-python-packaging/PKGBUILD
+++ b/mingw-w64-python-packaging/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=19.2
+pkgver=20.1
 pkgrel=1
 pkgdesc="Core utilities for Python packages (mingw-w64)"
 arch=('any')
@@ -21,7 +21,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest-runner"
               "${MINGW_PACKAGE_PREFIX}-python-pretend"
               "${MINGW_PACKAGE_PREFIX}-python-coverage")
 source=(https://pypi.io/packages/source/p/packaging/${_realname}-${pkgver}.tar.gz)
-sha256sums=('28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47')
+sha256sums=('e665345f9eef0c621aa0bf2f8d78cf6d21904eef16a93f020240b704a57f1334')
 
 prepare() {  
   cd "${srcdir}"

--- a/mingw-w64-python-pip/PKGBUILD
+++ b/mingw-w64-python-pip/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=19.3.1
+pkgver=20.0.2
 pkgrel=1
 pkgdesc="An easy_install replacement for installing pypi python packages (mingw-w64)"
 arch=('any')
@@ -34,7 +34,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools"
 install=${_realname}3-${CARCH}.install
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/pypa/pip/archive/${pkgver}.tar.gz)
 noextract=(${_realname}-${pkgver}.tar.gz)
-sha256sums=('f12b7a6be2dbbfeefae5f14992c89175ef72ce0fe96452b4f66be855a12841ff')
+sha256sums=('00bdc118df4552f654a5ccf0bd3ff1a7d101ee7d7ac899fe9a752363b3f2f070')
 
 shopt -s extglob
 
@@ -47,7 +47,7 @@ prepare() {
   # specify that third-party stuff should not be bundled.  This is from Archlinux
   rm -rf ${_realname}-${pkgver}/src/pip/_vendor/!(__init__.py)
   sed -i -e 's/DEBUNDLED = False/DEBUNDLED = True/' \
-         -e '/cachecontrol/a\    vendored("pep517")' \
+         -e '/cachecontrol/a\    vendored("appdirs")' \
         ${_realname}-${pkgver}/src/pip/_vendor/__init__.py
 
   rm -rf python-build-${CARCH}| true

--- a/mingw-w64-python-setuptools/PKGBUILD
+++ b/mingw-w64-python-setuptools/PKGBUILD
@@ -8,7 +8,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
            "${MINGW_PACKAGE_PREFIX}-python2-setuptools<42.0.2")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=43.0.0
+pkgver=45.1.0
 pkgrel=1
 pkgdesc="Easily download, build, install, upgrade, and uninstall Python packages (mingw-w64)"
 arch=('any')
@@ -36,7 +36,7 @@ source=(${_realname}-${pkgver}.tar.gz::https://github.com/pypa/setuptools/archiv
 #checkdepends=("${_checkdeps[@]/#/${MINGW_PACKAGE_PREFIX}-python3-}"
 #              "${MINGW_PACKAGE_PREFIX}-python3-paver"
 #              'git')
-sha256sums=('7776f8f25a2f01a1c82ab1754af2fbdc583f3e1a2ecff3ca5027c6951d465de2'
+sha256sums=('e545c3d8390a7a664c0243910341c06fc3239b6b3be69a64e7f4ad2fdac1cb24'
             'd3bc778723e63bbd6e43ab3536a015c547c8c20a95c6679a952284a7a4822996'
             '7bb5617c69566f5fbf1a3ee29a08179e1b41bdeabbc2998bf67615e9aa000424'
             '0e556505cb70ff3a5df856e352d5e2b3cf1582c25d02fc00a2d935a28576b28c'

--- a/mingw-w64-python-six/PKGBUILD
+++ b/mingw-w64-python-six/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=1.13.0
+pkgver=1.14.0
 pkgrel=1
 pkgdesc="Python 2 and 3 compatibility utilities (mingw-w64)"
 arch=('any')
@@ -14,7 +14,7 @@ url="https://pypi.python.org/pypi/six/"
 license=('MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-python")
 source=(https://pypi.io/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz)
-sha256sums=('30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66')
+sha256sums=('236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a')
 
 prepare() {
   cd "${srcdir}"

--- a/mingw-w64-python-urllib3/PKGBUILD
+++ b/mingw-w64-python-urllib3/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=1.25.7
+pkgver=1.25.8
 pkgrel=1
 pkgdesc="HTTP library with thread-safe connection pooling and file post support (mingw-w64)"
 url='https://github.com/urllib3/urllib3'
@@ -26,7 +26,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python-nose"
               "${MINGW_PACKAGE_PREFIX}-python-coverage"
               "${MINGW_PACKAGE_PREFIX}-python-psutil")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/urllib3/urllib3/archive/${pkgver}.tar.gz")
-sha256sums=('7d68d64c7374fd232b98a94b54915d964046d4a8eaac0a4f0404f7b3e84c04f0')
+sha256sums=('15fefe1fce1d5a0795a1ab3e635d9261d5e05e9b4c34153a310eb6087d4517ff')
 
 prepare() {
   cd ${srcdir}


### PR DESCRIPTION
* python-packaging: Update to 20.1
* python-urllib3: Update to 1.25.8 
* python-six: Update to 1.14.0
* python-importlib-metadata: Update to 1.5.0
* python-setuptools: Update to 45.1.0
* python-pip: Update to 20.0.2