### PR TITLE
Fix Ada shared libraries

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -113,7 +113,6 @@ prepare() {
     0008-Prettify-linking-no-undefined.patch \
     0009-gcc-make-xmmintrin-header-cplusplus-compatible-depre.patch \
     0010-Fix-using-large-PCH.patch \
-    0011-Enable-shared-gnat-implib.patch \
     0012-Handle-spaces-in-path-for-default-manifest.patch \
     0014-gcc-9-branch-clone_function_name_1-Retain-any-stdcall-suffix.patch
 
@@ -220,7 +219,7 @@ build() {
 
   make -j1 DESTDIR=${srcdir} install
   if [ "$_enable_ada" == "yes" ]; then
-    mv ${srcdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/adalib/*.dll ${srcdir}${MINGW_PREFIX}/bin/
+    cp ${srcdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/adalib/*.dll ${srcdir}${MINGW_PREFIX}/bin/
   fi
 }
 


### PR DESCRIPTION
Instead of building *.dll.a files with 0011-Enable-shared-gnat-implib.patch, build normally and copy the *.dll files from adalib/ to bin/.

Originally reported in https://github.com/AdaCore/gtkada/issues/27.  Please see discussion there for details.  The existing 0011-\*.patch appears to be both not necessary and broken at the present time.  May want to totally delete the 0011-*.patch.  Also, if accepted it should be applied to the gcc-git package as well.

Fixes #6181