### PR TITLE
mecab: adjust dicdir in mecabrc

### DIFF
--- a/mingw-w64-mecab/PKGBUILD
+++ b/mingw-w64-mecab/PKGBUILD
@@ -4,7 +4,7 @@ _realname=mecab
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.996
-pkgrel=1
+pkgrel=2
 pkgdesc="Yet another Japanese morphological analyzer (mingw-w64)"
 arch=('any')
 url="https://taku910.github.io/mecab/"
@@ -14,6 +14,7 @@ source=("http://ftp.debian.org/debian/pool/main/m/mecab/mecab_0.996.orig.tar.gz"
         "mecab-0.996.diff"
         "mecab-0.996-iconv.patch"
         "mecab-0.996-naist-jdic.patch")
+install=${_realname}-${CARCH}.install
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 depends=("${MINGW_PACKAGE_PREFIX}-libiconv")
 sha256sums=("e073325783135b72e666145c781bb48fada583d5224fb2490fb6c1403ba69c59"

--- a/mingw-w64-mecab/mecab-i686.install
+++ b/mingw-w64-mecab/mecab-i686.install
@@ -1,0 +1,13 @@
+post_install() {
+  local MINGW_PREFIX="/mingw32"
+  local MINGW_PREFIX_WIN="$(cygpath -am "${MINGW_PREFIX}")"
+  sed \
+    -e "s|${MINGW_PREFIX}|${MINGW_PREFIX_WIN}|g" \
+    -e "s|/|\\\\|g" \
+    -i \
+    "${MINGW_PREFIX}/bin/mecabrc"
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-mecab/mecab-x86_64.install
+++ b/mingw-w64-mecab/mecab-x86_64.install
@@ -1,0 +1,13 @@
+post_install() {
+  local MINGW_PREFIX="/mingw64"
+  local MINGW_PREFIX_WIN="$(cygpath -am "${MINGW_PREFIX}")"
+  sed \
+    -e "s|${MINGW_PREFIX}|${MINGW_PREFIX_WIN}|g" \
+    -e "s|/|\\\\|g" \
+    -i \
+    "${MINGW_PREFIX}/bin/mecabrc"
+}
+
+post_upgrade() {
+  post_install
+}


### PR DESCRIPTION
We need to use absolute path in Windows instead of absolute path in
MSYS2.