### PR TITLE
GDB: Fix support for 64-bit targets on 32-bit

### DIFF
--- a/mingw-w64-gdb/PKGBUILD
+++ b/mingw-w64-gdb/PKGBUILD
@@ -7,7 +7,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 # Until https://gcc.gnu.org/bugzilla/show_bug.cgi?id=62279 is
 # fixed, we will stick with 7.6.2 which hasn't got this bug..
 pkgver=8.3.1
-pkgrel=3
+pkgrel=4
 pkgdesc="GNU Debugger (mingw-w64)"
 arch=('any')
 url="https://www.gnu.org/software/gdb/"
@@ -82,10 +82,7 @@ build() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
   mkdir ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
   
-  declare -a _extra_conf
-  if [ "${CARCH}" = "x86_64" ]; then
-    _extra_conf+=(--enable-64-bit-bfd)
-  else
+  if [ "${CARCH}" != "x86_64" ]; then
     LDFLAGS+=" -Wl,--large-address-aware"
   fi
 
@@ -106,7 +103,7 @@ build() {
     --target=${MINGW_CHOST} \
     --prefix=${MINGW_PREFIX} \
     --enable-targets="i686-w64-mingw32,x86_64-w64-mingw32" \
-    "${_extra_conf[@]}" \
+    --enable-64-bit-bfd \
     --disable-werror \
     --disable-win32-registry \
     --disable-rpath \


### PR DESCRIPTION
If GDB is built with --enable-targets=all it should be able to connect
remotely and open core dumps from all target types.

But this change broke it for 32-bit build.

This partially reverts be921a6c47be60e25514032ba53835a98e4d5046.