### PR TITLE
make: Update to 4.3

### DIFF
--- a/mingw-w64-make/PKGBUILD
+++ b/mingw-w64-make/PKGBUILD
@@ -7,12 +7,12 @@ _realname=make
 #       name is part of the import library (libgnumake-1.dll.a) used to link
 #       customized dll's.
 #       General information at https://www.gnu.org/software/make/manual/html_node/Loading-Objects.html#Loading-Objects.
-_autotools=yes
+_autotools=no
 _prog_name=mingw32-make
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=4.2.1
-pkgrel=4
+pkgver=4.3
+pkgrel=1
 pkgdesc="GNU make utility to maintain groups of programs (mingw-w64)"
 arch=('any')
 url="https://www.gnu.org/software/make"
@@ -20,54 +20,75 @@ license=('GPL3')
 groups=("${MINGW_PACKAGE_PREFIX}-toolchain")
 depends=("${MINGW_PACKAGE_PREFIX}-gettext")
 makedepends=('wget')
-source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.bz2"
+source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.gz"
         'make-getopt.patch'
         'make-linebuf-mingw.patch'
+        'make-4.3_undef-HAVE_STRUCT_DIRENT_D_TYPE.patch'
         'make-4.2.1-Makefile.am-gcc-only-link-libgnumake-1.dll.a.patch'
         'make-check-load-feature.mak'
         'mk_temp.c')
-sha256sums=('d6e262bf3601b42d2b1e4ef8310029e1dcf20083c5446b4b7aa67081fdffc589'
+sha256sums=('e05fdde47c5f7ca45cb697e973894ff4f5d79e13b750ed57d7b66d8defc78e19'
             '15a86d5143c9ec6337bdd69fecb7c33c36e4fd925528dc1498b0bc4fbd31b0bb'
             'cbb8c0a1bdd6e8174febce01946bd42da26dfcb73a7338c0a1df89ac6b8e157b'
+            '5d71fccedb80e4713ed5a0cf73ca79d66f29894eeb6ad4b02037edecf81c2444'
             '85f8c3c555079026f3debab350c9ee27a717cdd08eca3f8bf9ac58e78544d21d'
-            'f4b92323f5df81fd83f6bd0beddf85b1acff0fe4a8648fb57b8e72f12e9123a5'
+            '3d6ece384425ff1c3f691efeb7c97e89bb11825bb6648995552dfcb52afe661d'
             '61d4f57c311cf2e27ccf4d1da847216730f304cf17c5c386721182ffe2d4b1aa')
+
+
+# helper function
+get_exe_dir() {
+  if test ${_autotools} = yes; then
+     echo "${srcdir}/build-${MINGW_CHOST}"
+  else
+    echo "${srcdir}/${_realname}-${pkgver}/GccRel"
+  fi
+}
+
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
 
-  patch -p1 -i ${srcdir}/make-getopt.patch
-  patch -p1 -i ${srcdir}/make-linebuf-mingw.patch
-  patch -p1 -i ${srcdir}/make-4.2.1-Makefile.am-gcc-only-link-libgnumake-1.dll.a.patch
+  pushd src
+    patch -p1 -i ${srcdir}/make-getopt.patch
+    patch -p1 -i ${srcdir}/make-linebuf-mingw.patch
+    patch -p2 -i ${srcdir}/make-4.3_undef-HAVE_STRUCT_DIRENT_D_TYPE.patch
+  popd
 
-  # 1 - The import library libgnumake-1.dll.a contains the name of the program to be
-  #     installed.  This requires autotools to be informed about the installed program
-  #     name in case it is different from the standard name 'make' hardcoded in the GNU
-  #     Make package.
-  # 2 - automake requires hardcoded program names in any Makefile.am, i.e. in the
-  #     variable bin_PROGRAMS and the induced variables derived from the program
-  #     name.  We use sed to change the program name from 'make' to the customized
-  #     name in Makefile.am, if different from 'make'.
-  # 3 - After packaging we run a test if the dll load feature for the installed
-  #     program works.  See function 'package()'.
-  if test ${_prog_name} != make; then
-    msg2 "Changing the program name from 'make' to '${_prog_name}' in Makefile.am."
+  if test "${_autotools}" = "yes"; then
+    patch -p1 -i ${srcdir}/make-4.2.1-Makefile.am-gcc-only-link-libgnumake-1.dll.a.patch
+    # 1 - The import library libgnumake-1.dll.a contains the name of the program to be
+    #     installed.  This requires autotools to be informed about the installed program
+    #     name in case it is different from the standard name 'make' hardcoded in the GNU
+    #     Make package.
+    # 2 - automake requires hardcoded program names in any Makefile.am, i.e. in the
+    #     variable bin_PROGRAMS and the induced variables derived from the program
+    #     name.  We use sed to change the program name from 'make' to the customized
+    #     name in Makefile.am, if different from 'make'.
+    # 3 - After packaging we run a test if the dll load feature for the installed
+    #     program works.  See function 'package()'.
+    if test ${_prog_name} != make; then
+      msg2 "Changing the program name from 'make' to '${_prog_name}' in Makefile.am."
     test -f Makefile.am.orig || mv Makefile.am Makefile.am.orig
     local _prog_name_am=${_prog_name//[^a-zA-Z0-9@]/_}
-    sed -e "/bin_PROGRAMS/ { s:\bmake\b:${_prog_name}:g };
-            s:\bmake_\(SOURCES\|LDADD\|LDFLAGS\)\b:${_prog_name_am}_\1:g ;
-            s:\bEXTRA_make_\([A-Z]\+\):EXTRA_${_prog_name_am}_\1:g ;" \
-          Makefile.am.orig > Makefile.am
+      sed -e "/bin_PROGRAMS/ { s:\bmake\b:${_prog_name}:g };
+              s:\bmake_\(SOURCES\|LDADD\|LDFLAGS\)\b:${_prog_name_am}_\1:g ;
+              s:\bEXTRA_make_\([A-Z]\+\):EXTRA_${_prog_name_am}_\1:g ;" \
+            Makefile.am.orig > Makefile.am
     # log the changes made to Makefile.am by sed
-    diff -u Makefile.am.orig Makefile.am > Makefile.am.diff || true
-    cat Makefile.am.diff
+      diff -u Makefile.am.orig Makefile.am > Makefile.am.diff || true
+      cat Makefile.am.diff
+    fi
+    autoreconf -vfi
+  else
+    sed "/^set MAKE=gnumake/ s/gnumake/${_prog_name}/" build_w32.bat > build_w32-PKGBUILD.bat
+    # make sure that the batch file has CRLF as EOL for reliable processing by cmd
+    unix2dos build_w32-PKGBUILD.bat
   fi
-
-  test "${_autotools}" = "yes" && autoreconf -vfi
 }
 
 build() {
-  if [[ "${_autotools}" = "yes" ]]; then
+  if test "${_autotools}" = "yes"; then
     mkdir -vp build-${MINGW_CHOST}
     cd build-${MINGW_CHOST}
     ../${_realname}-${pkgver}/configure \
@@ -79,47 +100,35 @@ build() {
       CPPFLAGS=-DMAKE_LOAD \
       CFLAGS=-mthreads \
       ac_cv_dos_paths=yes
-    # Create _prog_name and associated import library libgnumake-1.dll.a.
     make -j1
   else
-    [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}
-    mkdir -p build-${MINGW_CHOST} && cd build-${MINGW_CHOST}
-    # Create gnumake.exe and associated import library libgnumake-1.dll.a.
-    cmd /c 'build_w32.bat --without-guile gcc'
+    cd ${srcdir}/${_realname}-${pkgver}
+    ./build_w32-PKGBUILD.bat --without-guile gcc
   fi
 }
 
-package() {
-  local _exe_name
-  local _exe_dir
-  if test ${_autotools} = yes; then
-    # Built with autotools.
-    _exe_dir=${srcdir}/build-${MINGW_CHOST}
-    _exe_name=${_prog_name}.exe
-  else
-    # Built by running build_w32.bat.
-    # NOTE: If the name of the installed executable is NOT 'gnumake.exe', the dll
-    #       load feature should not work and the test below is expected to fail.
-    _exe_dir=${srcdir}/${_realname}-${pkgver}/GccRel
-    _exe_name=gnumake.exe
-  fi
-  mkdir -pv ${pkgdir}${MINGW_PREFIX}/{bin,lib,include}
-  cp -fv ${_exe_dir}/${_exe_name}                     ${pkgdir}${MINGW_PREFIX}/bin/
-  cp -fv ${_exe_dir}/libgnumake-1.dll.a               ${pkgdir}${MINGW_PREFIX}/lib/
-  cp -fv ${srcdir}/${_realname}-${pkgver}/gnumake.h   ${pkgdir}${MINGW_PREFIX}/include/
-
-  # Run check on packaged program and import library:
+check() {
+  _exe_dir=$(get_exe_dir)
   msg "Checking if GNU Make's dll loading feature we compiled into ${_prog_name}.exe works ..."
-  rm -fv ${srcdir}/*.dll
-  if ${pkgdir}${MINGW_PREFIX}/bin/${_prog_name}.exe \
-      -C ${srcdir} \
-      -f make-check-load-feature.mak \
+  cd "${srcdir}"
+  rm -fv ./*.dll
+  if "${_exe_dir}"/${_prog_name}.exe -f ./make-check-load-feature.mak \
       --debug=v \
-      LIBS="${pkgdir}${MINGW_PREFIX}/lib/libgnumake-1.dll.a"
+      CFLAGS="-I${srcdir}/${_realname}-${pkgver}/src" \
+      LIBS="${_exe_dir}/libgnumake-1.dll.a"
   then
     msg2 "PASSED"
   else
     error "FAILED"
     exit 1
   fi
+}
+
+package() {
+  _exe_dir=$(get_exe_dir)
+  mkdir -pv "${pkgdir}${MINGW_PREFIX}"/{bin,lib,include}
+  cd "${srcdir}/${_realname}-${pkgver}"
+  cp -fv "${_exe_dir}/${_prog_name}.exe"                    "${pkgdir}${MINGW_PREFIX}/bin/"
+  cp -fv "${_exe_dir}/libgnumake-1.dll.a"                   "${pkgdir}${MINGW_PREFIX}/lib/"
+  cp -fv "${srcdir}/${_realname}-${pkgver}/src/gnumake.h"   "${pkgdir}${MINGW_PREFIX}/include/"
 }

--- a/mingw-w64-make/make-4.3_undef-HAVE_STRUCT_DIRENT_D_TYPE.patch
+++ b/mingw-w64-make/make-4.3_undef-HAVE_STRUCT_DIRENT_D_TYPE.patch
@@ -1,0 +1,13 @@
+diff --git a/src/config.h.W32 b/src/config.h.W32
+index be2a33e..f43c2ad 100644
+--- a/src/config.h.W32
++++ b/src/config.h.W32
+@@ -294,7 +294,7 @@ this program.  If not, see <http://www.gnu.org/licenses/>.  */
+ /* Define to 1 if `d_type' is a member of `struct dirent'. */
+ /* SV 57152: MinGW64 version of dirent doesn't support d_type. */
+ #ifndef __MINGW64__
+-# define HAVE_STRUCT_DIRENT_D_TYPE 1
++/* # define HAVE_STRUCT_DIRENT_D_TYPE 1 */
+ #endif
+ 
+ /* Define to 1 if you have the `isatty' function. */

--- a/mingw-w64-make/make-check-load-feature.mak
+++ b/mingw-w64-make/make-check-load-feature.mak
@@ -15,11 +15,15 @@ endif
 
 # Run and check the new make function 'mk-temp'.
 .PHONY: all
-TXT_ERROR=FAILED Temporary file not created
-TXT_PASSED=PASSED Temporary file created.
+  TXT_ERROR  = FAILED  Temporary file not created
+  TXT_PASSED = PASSED  Temporary file created.
 all:
 	$(if $(mk-temp tmpfile.),$(warning $(TXT_PASSED)),$(error $(TXT_ERROR)))
 
+ifeq ($(LIBS),)
+  LIBS       = -lgnumake-1
+endif
+
 %.dll: %.c
 	$(warning Compiling $@.)
-	gcc -shared -fPIC -o $@ $< $(if $(LIBS),$(LIBS),-lgnumake-1)
+	gcc -shared -fPIC $(CFLAGS) -o $@ $< $(LIBS)


### PR DESCRIPTION
* mingw-w64-make/PKGBUILD:
  - config: set arch to 'i686' 'x86_64', since batch build is supposed
    for pure Windows builds.
  - prepare: build with batch file build_w32.bat (instead of autotools,
     - since autotools approach is not fully supported for Windows builds).
     - overwrite default executable name 'gnumake' with 'mingw32-make'.
     - cd to src dir of package to apply package patches, since the dir
        structure was changed with make version 4.3.
  - check: move check section in package to separate function check.
  - use overall helper function defining the executable dir.

* mingw-w64-make/make-check-load-feature.mak:
  - add CFLAGS the user can pass to the makefile on the command line
  - simplify setting of default value of LIBS