### PR TITLE
Add libpq client package

### DIFF
--- a/mingw-w64-libpq/PKGBUILD
+++ b/mingw-w64-libpq/PKGBUILD
@@ -1,0 +1,69 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+
+_realname=libpq
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=12.2
+pkgrel=1
+pkgdesc="Postgres C API library (mingw-w64)"
+arch=('any')
+url="https://www.postgresql.org/"
+license=('custom:PostgreSQL')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+depends=("${MINGW_PACKAGE_PREFIX}-openssl"
+         "${MINGW_PACKAGE_PREFIX}-zlib"
+         "winpty")
+conflicts=("${MINGW_PACKAGE_PREFIX}-postgresql-client")
+provides=("${MINGW_PACKAGE_PREFIX}-postgresql-client")
+options=('staticlibs' 'strip')
+source=("https://ftp.postgresql.org/pub/source/v${pkgver}/postgresql-${pkgver}.tar.bz2")
+sha256sums=('ad1dcc4c4fc500786b745635a9e1eba950195ce20b8913f50345bb7d5369b5de')
+
+build() {
+  [[ -d "${srcdir}/build-${CARCH}" ]] && rm -rf "${srcdir}/build-${CARCH}"
+  mkdir -p "${srcdir}/build-${CARCH}" && cd "${srcdir}/build-${CARCH}"
+  ../postgresql-${pkgver}/configure \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --prefix=${MINGW_PREFIX} \
+    --with-openssl \
+    --with-ldap \
+    --disable-thread-safety \
+    --enable-integer-datetimes \
+    --disable-nls \
+    --disable-rpath \
+    --without-libxml \
+    --without-libxslt \
+    --without-python \
+    --without-perl \
+    --without-tcl
+
+  # Make DLL definition file visible during each arch build
+  ln -s "${srcdir}/postgresql-${pkgver}/src/interfaces/libpq/libpqdll.def" src/interfaces/libpq/
+  ln -s "${srcdir}/postgresql-${pkgver}/src/interfaces/ecpg/ecpglib/libecpgdll.def" src/interfaces/ecpg/ecpglib/
+  ln -s "${srcdir}/postgresql-${pkgver}/src/interfaces/ecpg/pgtypeslib/libpgtypesdll.def" src/interfaces/ecpg/pgtypeslib/
+  ln -s "${srcdir}/postgresql-${pkgver}/src/interfaces/ecpg/compatlib/libecpg_compatdll.def" src/interfaces/ecpg/compatlib/    
+
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${CARCH}"
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/"{bin,include,lib}
+
+  make DESTDIR="${pkgdir}" -C "src/interfaces" install
+  make DESTDIR="${pkgdir}" -C "src/common" install
+  make DESTDIR="${pkgdir}" -C "src/port" install
+  make DESTDIR="${pkgdir}" -C "src/include" install
+
+  # Move dll's to bin directory
+  mv "${pkgdir}${MINGW_PREFIX}/lib/"*.dll "${pkgdir}${MINGW_PREFIX}/bin/"
+
+  # these headers are needed by the not-so-public headers of the interfaces
+  mkdir -p "${pkgdir}${MINGW_PREFIX}"/include/{libpq,postgresql/internal/libpq}
+  install -m644 ${srcdir}/postgresql-${pkgver}/src/include/c.h "${pkgdir}${MINGW_PREFIX}/include/postgresql/internal/"
+  install -m644 ${srcdir}/postgresql-${pkgver}/src/include/port.h "${pkgdir}${MINGW_PREFIX}/include/postgresql/internal/"
+  install -m644 ${srcdir}/postgresql-${pkgver}/src/include/postgres_fe.h "${pkgdir}${MINGW_PREFIX}/include/postgresql/internal/"
+  install -m644 ${srcdir}/postgresql-${pkgver}/src/include/libpq/pqcomm.h "${pkgdir}${MINGW_PREFIX}/include/postgresql/internal/libpq/"
+}

--- a/mingw-w64-postgresql/PKGBUILD
+++ b/mingw-w64-postgresql/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=postgresql
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=12.1
+pkgver=12.2
 pkgrel=1
 pkgdesc="Libraries for use with PostgreSQL (mingw-w64)"
 arch=('any')
@@ -21,6 +21,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          #"${MINGW_PACKAGE_PREFIX}-wineditline"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "winpty")
+conflicts=("${MINGW_PACKAGE_PREFIX}-postgresql-client")
+provides=("${MINGW_PACKAGE_PREFIX}-postgresql-client")
 options=('staticlibs' 'strip')
 source=("https://ftp.postgresql.org/pub/source/v${pkgver}/postgresql-${pkgver}.tar.bz2"
         postgresql-12.0-mingw-link.patch
@@ -28,7 +30,7 @@ source=("https://ftp.postgresql.org/pub/source/v${pkgver}/postgresql-${pkgver}.t
         postgresql-9.5.1-pl-python.patch
         postgresql-9.4.1-pl-tcl.patch
         postgresql-9.4.1-mingw-enable-readline.patch)
-sha256sums=('a09bf3abbaf6763980d0f8acbb943b7629a8b20073de18d867aecdb7988483ed'
+sha256sums=('ad1dcc4c4fc500786b745635a9e1eba950195ce20b8913f50345bb7d5369b5de'
             '607217b422349770d25af20f88e4a7925e68bb934232dff368c2ee59f24249a4'
             '57c1e9b75c042af591b05b9dda60e6327b5c364bb5adc2675da8a48b47e11b81'
             '1afbe207b0fe8c4178cc3f8cb4e3923c7c000207d22ec4f3875d6358b312a1d5'


### PR DESCRIPTION
A lighter alternative for the [mingw-w64-postgres](https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-postgresql) for packages that only need the client library, and not the full database server system. In particular GDAL, see: https://github.com/msys2/MINGW-packages/pull/3196

Similar package exists in [libpq.rb](https://github.com/homebrew/homebrew-core/blob/master/Formula/libpq.rb) in homebrew or [libpq-dev](https://packages.debian.org/sid/libpq-dev) in Debian.

In order to make sure packages can depend on either `postgresql` and `libpq`, we provide a virtual package `postgresql-client` similar to the [arch package](https://www.archlinux.org/packages/extra/x86_64/postgresql-libs/). So other packages should use:

```sh
makedepends=("${MINGW_PACKAGE_PREFIX}-libpq")
depends=("${MINGW_PACKAGE_PREFIX}-postgresql-client")
```

That way the package can be installed if `postgresql` is already installed.