### PR TITLE
qca: always link to release library

### DIFF
--- a/mingw-w64-qca-qt5/PKGBUILD
+++ b/mingw-w64-qca-qt5/PKGBUILD
@@ -28,14 +28,16 @@ source=("https://download.kde.org/stable/${_realname}/${pkgver}/${_realname}-${p
         "find_nss_cmake.patch"
         "qt5-custom-dirs.patch"
         "qca-mingw-pkg-config.patch"
-        "qca-mingw-custom-certificates.patch")
+        "qca-mingw-custom-certificates.patch"
+        "qca-mingw-link-to-release.patch")
 sha256sums=('d716d2d8e3ed8d95bbdb061f03081d7d032206f746a30a4d29d72196f50e7b02'
             'SKIP'
             'a5eeb6e2c3e884b54dc3837509d1cbde4611623a2888775ddb7e3868b1623e7c'
             '42a6f06f75213836d90b9b720afa29c1a9404ec0aedd332662abc694d3965fbd'
             '1734f88bb79bac16427b89d351c2775992743a791c28d4c04770c7055819880e'
             '3d682bcee66b48d50c9a037a4c0b088fb39059852f3a38950e64d55f2221539f'
-            '2d601d3d7992c92f2cca450cf3906ab598a413733afa0eb5c15b85cf22aa27be')
+            '2d601d3d7992c92f2cca450cf3906ab598a413733afa0eb5c15b85cf22aa27be'
+            '037b615f8b6f609112383b69e6050e7c939b12b0c7c0fa210a58e075c0d1c589')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -44,6 +46,7 @@ prepare() {
   patch -p1 -i ${srcdir}/qt5-custom-dirs.patch
   patch -p1 -i ${srcdir}/qca-mingw-pkg-config.patch
   patch -p1 -i ${srcdir}/qca-mingw-custom-certificates.patch
+  patch -p1 -i ${srcdir}/qca-mingw-link-to-release.patch
 }
 
 build() {

--- a/mingw-w64-qca-qt5/qca-mingw-link-to-release.patch
+++ b/mingw-w64-qca-qt5/qca-mingw-link-to-release.patch
@@ -1,0 +1,13 @@
+--- a/crypto.prf.cmake
++++ b/crypto.prf.cmake
+@@ -17,10 +17,6 @@
+ 	INCLUDEPATH += $$QCA_INCDIR/QtCrypto
+ 	LIBS += -L$$QCA_LIBDIR
+ 	LINKAGE = -l@QCA_LIB_NAME@
+-	CONFIG(debug, debug|release) {
+-		windows:LINKAGE = -l@QCA_LIB_NAME@d
+-		mac:LINKAGE = -l@QCA_LIB_NAME@_debug
+-	}
+ }
+ 
+ LIBS += $$LINKAGE


### PR DESCRIPTION
We only compile in release mode and worse: the Qt library itself is only
available in release mode. So we don't want to link to a (non-existing)
debug-library.