### PR TITLE
fix version of hard-coded libffi DLL

### DIFF
--- a/mingw-w64-python-cx_Freeze/PKGBUILD
+++ b/mingw-w64-python-cx_Freeze/PKGBUILD
@@ -9,7 +9,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=6.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Python package for freezing scripts into executables (mingw-w64)"
 arch=('any')
 license=('PSF')
@@ -29,6 +29,8 @@ prepare() {
 build() {
   echo "Building for Python"
   cd python-cx_Freeze-${CARCH}
+  #change version of hard-coded DLL:
+  sed -i -e 's/libffi-7.dll/libffi-6.dll/g' ./cx_Freeze/hooks.py
   ${MINGW_PREFIX}/bin/python setup.py build
 }
 


### PR DESCRIPTION
cx_Freeze version 6.1 has hard-coded `libffi-7.dll` in the source:
https://github.com/anthony-tuininga/cx_Freeze/pull/556/commits/648ce78f4bf00bf7e57e6a6558cabe7a419948eb

The problem is that MSYS2 ships `libffi-6.dll` instead.
This pkgrel bump fixes things using sed.

Note: this will break again when libffi is updated to `libffi-7.dll`. Not sure how to deal with this more properly.