### PR TITLE
python-gssapi 1.6.2

### DIFF
--- a/mingw-w64-python-gssapi/PKGBUILD
+++ b/mingw-w64-python-gssapi/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=python-gssapi
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=1.6.1
+pkgver=1.6.2
 pkgrel=1
 pkgdesc="A python interface to RFC 2743/2744 (plus common extensions). (mingw-w64)"
 arch=('any')
@@ -16,8 +16,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-python3"
          "${MINGW_PACKAGE_PREFIX}-cython")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools")
 options=('staticlibs' 'strip' '!debug')
-source=("${_realname}-$pkgver.tar.gz::https://github.com/pythongssapi/python-gssapi/releases/download/v1.6.1/${_realname}-$pkgver.tar.gz")
-sha512sums=('061e6bc408a9dcb336596911a2a0f7eec69deeff7ebba3f217e898339273f59d7aa6bffb82a6dac39d041772134302da0f373931b7b6d3d67bf3d55fac93d9c1')
+source=("${_realname}-$pkgver.tar.gz::https://github.com/pythongssapi/python-gssapi/releases/download/v1.6.2/${_realname}-$pkgver.tar.gz")
+sha512sums=('8d5efc743cb7de03e20de65c12fa6e124bf14a90d9df773a2f95dd13e821b3862b52f3585e082b93abe840a171282dcd65a45331117441bea2d49d69da605820')
 export MSYS=winsymlinks:lnk
 
 prepare() {

--- a/mingw-w64-python-gssapi/PKGBUILD
+++ b/mingw-w64-python-gssapi/PKGBUILD
@@ -16,7 +16,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-python3"
          "${MINGW_PACKAGE_PREFIX}-cython")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools")
 options=('staticlibs' 'strip' '!debug')
-source=("${_realname}-$pkgver.tar.gz::https://github.com/pythongssapi/python-gssapi/releases/download/v1.6.2/${_realname}-$pkgver.tar.gz")
+source=("${_realname}-$pkgver.tar.gz::https://github.com/pythongssapi/${_realname}/releases/download/v$pkgver/${_realname}-$pkgver.tar.gz")
 sha512sums=('8d5efc743cb7de03e20de65c12fa6e124bf14a90d9df773a2f95dd13e821b3862b52f3585e082b93abe840a171282dcd65a45331117441bea2d49d69da605820')
 export MSYS=winsymlinks:lnk
 


### PR DESCRIPTION
Release notes:
https://github.com/pythongssapi/python-gssapi/releases/tag/v1.6.2