### PR TITLE
glib: Update to 2.64.0

### DIFF
--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -6,7 +6,7 @@
 _realname=glib2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.62.4
+pkgver=2.64.0
 pkgrel=1
 url="https://www.gtk.org/"
 arch=('any')
@@ -28,7 +28,7 @@ source=("https://download.gnome.org/sources/glib/${pkgver%.*}/glib-${pkgver}.tar
         0001-win32-Make-the-static-build-work-with-MinGW-when-pos.patch
         0001-disable-some-tests-when-static.patch
         pyscript2exe.py)
-sha256sums=('4c84030d77fa9712135dfa8036ad663925655ae95b1d19399b6200e869925bbc'
+sha256sums=('e5e514e47d169cdb4111c3ea4af0300e1b1a5f428a474d2d7ddadf38dd061280'
             '51d02360a1ee978fd45e77b84bca9cfbcf080d91986b5c0efe0732779c6a54ec'
             '1e3ac7cfd4644f3849704e54fcfbb12d15440a33cd5c2d014d4a479c6aaab185'
             '0f44135a139e3951c4b5fa7d4628d75226e0666d891faf524777e1d1ec3b440b'
@@ -63,7 +63,7 @@ build() {
     -Ddefault_library=shared \
     -Dman=true \
     -Dforce_posix_threads=true \
-    -Dgtk_doc=true \
+    -Dgtk_doc=false \
     "../glib-${pkgver}"
 
   ninja
@@ -88,11 +88,6 @@ package() {
 
   for pcfile in  "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/*.pc; do
     sed -s "s|${_PRE_WIN}|${MINGW_PREFIX}|g" -i "${pcfile}"
-    # https://github.com/Alexpux/MINGW-packages/issues/4364
-    # https://gitlab.gnome.org/GNOME/glib/issues/1516
-    sed -s "s| -lgiowin32||g" -i "${pcfile}"
-    sed -s "s| -lgnulib||g" -i "${pcfile}"
-    sed -s "s| -lcharset||g" -i "${pcfile}"
   done
 
   sed -s "s|${_PRE_WIN}|${MINGW_PREFIX}|g" -i "${pkgdir}${MINGW_PREFIX}/bin/glib-gettextize"


### PR DESCRIPTION
* gtk-doc build is broken, so disabled.
* pkg-config workaround no longer needed with newer meson