### PR TITLE
dav1d: Add dav1d 0.5.2 PKGBUILD

### DIFF
--- a/mingw-w64-dav1d/PKGBUILD
+++ b/mingw-w64-dav1d/PKGBUILD
@@ -1,0 +1,71 @@
+# Maintainer: Christopher Degawa <ccom@randomderp.com>
+
+_realname=dav1d
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=0.5.2
+pkgrel=1
+pkgdesc="AV1 cross-platform decoder focused on speed and correctness (mingw-w64)"
+arch=('any')
+url='https://code.videolan.org/videolan/dav1d'
+license=('BSD')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-nasm"
+             "${MINGW_PACKAGE_PREFIX}-meson"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+options=('staticlibs' 'strip' 'emptydirs')
+source=("https://downloads.videolan.org/pub/videolan/dav1d/${pkgver}/dav1d-${pkgver}.tar.xz"{,.asc})
+sha256sums=('f94cf88c4a3ac2fd3cb30d688e8ef5943854d73db2dd12985a78892e76560f0a'
+            'SKIP')
+validpgpkeys=('65F7C6B4206BD057A7EB73787180713BE58D1ADC') # VideoLAN Release Signing Key
+
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+    for _patch in "$@"; do
+        msg2 "Applying $_patch"
+        patch -Nbp1 -i "${srcdir}/$_patch"
+    done
+}
+
+del_file_exists() {
+    for _fname in "$@"; do
+        if [ -f $_fname ]; then
+            rm -rf $_fname
+        fi
+    done
+}
+# =========================================== #
+
+prepare() {
+    :
+}
+
+build() {
+    cd "${srcdir}"
+    [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}
+    mkdir -p build-${MINGW_CHOST}
+    cd build-${MINGW_CHOST}
+
+    meson \
+        --default-library both \
+        --buildtype plain \
+        -Denable_tests=false \
+        ../${_realname}-${pkgver}
+
+    ninja
+}
+
+package() {
+    DESTDIR=${pkgdir}${MINGW_PREFIX} ninja -C "${srcdir}/build-${MINGW_CHOST}" install
+
+    for pcfile in  "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/*.pc; do
+        sed -i "s|$(cygpath -m ${MINGW_PREFIX})|${MINGW_PREFIX}|g" "${pcfile}"
+    done
+
+    # License
+    install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+    install -Dm644 "${srcdir}/${_realname}-${pkgver}/doc/PATENTS" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/PATENTS"
+}


### PR DESCRIPTION
Based on archlinux's PKBGUILD and also using the meson parts from one from @lazka

The dav1d.exe is linked to libdav1d.dll and works

Do I need a prepare function? I've set it to no-op for now