### PR TITLE
vlc: Use binary-version to not conflict with a system installed vlc

### DIFF
--- a/mingw-w64-vlc/PKGBUILD
+++ b/mingw-w64-vlc/PKGBUILD
@@ -11,15 +11,17 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 pkgver=3.0.8
-pkgrel=3
+pkgrel=4
 pkgdesc="A multi-platform MPEG, VCD/DVD, and DivX player (mingw-w64)"
 arch=('any')
 url="https://www.videolan.org/vlc/"
+install=vlc-${CARCH}.install
 license=('LGPL2.1' 'GPL2')
 depends=("${MINGW_PACKAGE_PREFIX}-a52dec"
          "${MINGW_PACKAGE_PREFIX}-aom"
          "${MINGW_PACKAGE_PREFIX}-aribb24"
          "${MINGW_PACKAGE_PREFIX}-chromaprint"
+         "${MINGW_PACKAGE_PREFIX}-dav1d"
          "${MINGW_PACKAGE_PREFIX}-faad2"
          "${MINGW_PACKAGE_PREFIX}-freetype"
          "${MINGW_PACKAGE_PREFIX}-ffmpeg"
@@ -93,6 +95,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-a52dec"
          )
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-glew"
+             "${MINGW_PACKAGE_PREFIX}-cyrus-sasl"
              #"${MINGW_PACKAGE_PREFIX}-ncurses"
              "autoconf"
              "automake"
@@ -234,6 +238,7 @@ build() {
       --build=${MINGW_CHOST} \
       --host=${MINGW_CHOST} \
       --target=${MINGW_CHOST} \
+      --with-binary-version="msys2" \
       --enable-winstore-app \
       --disable-vlc \
       --enable-lua \
@@ -287,7 +292,9 @@ build() {
       --build=${MINGW_CHOST} \
       --host=${MINGW_CHOST} \
       --target=${MINGW_CHOST} \
+      --with-binary-version="msys2" \
       --enable-qt \
+      --enable-dav1d \
       --disable-ncurses \
       --disable-dbus \
       --disable-telx \

--- a/mingw-w64-vlc/vlc-i686.install
+++ b/mingw-w64-vlc/vlc-i686.install
@@ -1,0 +1,9 @@
+post_install() {
+  if [ -f "mingw32/lib/vlc/vlc-cache-gen.exe" ]; then
+    ./mingw32/lib/vlc/vlc-cache-gen.exe ./mingw32/lib/vlc/plugins
+  fi
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-vlc/vlc-x86_64.install
+++ b/mingw-w64-vlc/vlc-x86_64.install
@@ -1,0 +1,9 @@
+post_install() {
+  if [ -f "mingw64/lib/vlc/vlc-cache-gen.exe" ]; then
+    ./mingw64/lib/vlc/vlc-cache-gen.exe ./mingw64/lib/vlc/plugins
+  fi
+}
+
+post_upgrade() {
+  post_install
+}


### PR DESCRIPTION
Currently, when using the vlc installed by pacman, there's a chance
that vlc will pick the user's installed vlc's plugin instead of the
one installed by pacman

I'm not sure if all of the following are necessary

---

add glew to makedepends to fix missing `GL/glew.h`

Add dav1d as an av1 decoder

Add cyrus-sasl to fix missing `sasl/sasl.h`

Add post-install/upgrade vlc-cache-gen

Without running vlc-cache-gen, vlc complains about:
    `main libvlc error: stale plugins cache: modified`
