### PR TITLE
* ngraph-gtk: new upstream release (version 6.08.04).

### DIFF
--- a/mingw-w64-ngraph-gtk/PKGBUILD
+++ b/mingw-w64-ngraph-gtk/PKGBUILD
@@ -3,14 +3,14 @@
 _realname=ngraph-gtk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=6.08.03
+pkgver=6.08.04
 pkgrel=1
 arch=('any')
 pkgdesc="create scientific 2-dimensional graphs (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme"
          "${MINGW_PACKAGE_PREFIX}-gsettings-desktop-schemas"
          "${MINGW_PACKAGE_PREFIX}-gtk3"
-         "${MINGW_PACKAGE_PREFIX}-gtksourceview3"
+         "${MINGW_PACKAGE_PREFIX}-gtksourceview4"
          "${MINGW_PACKAGE_PREFIX}-readline"
          "${MINGW_PACKAGE_PREFIX}-gsl"
          "${MINGW_PACKAGE_PREFIX}-ruby")
@@ -22,7 +22,7 @@ options=('strip' 'staticlibs')
 license=("GPL")
 url="https://htrb.github.io/ngraph-gtk/"
 source=("https://github.com/htrb/ngraph-gtk/releases/download/v${pkgver}/ngraph-gtk-${pkgver}.tar.gz")
-sha256sums=("8ac62546cc6e41fb096eaee25d343842db7f42411f6052ed7fffce62d37b86b5")
+sha256sums=("632ba3bdaa874e9133da7535398626fb575d5df056f4cf6d5b42e70230c47702")
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}


### PR DESCRIPTION
new upstream version of ngraph-gtk is released.