### PR TITLE
gtk3: disable low level keyboard hook

### DIFF
--- a/mingw-w64-gtk3/0004-Disable-low-level-keyboard-hook.patch
+++ b/mingw-w64-gtk3/0004-Disable-low-level-keyboard-hook.patch
@@ -1,0 +1,38 @@
+From 0d860b1994961585b42ea2f25ab5bc8a0fb7331d Mon Sep 17 00:00:00 2001
+From: Patrick Storz <eduard.braun2@gmx.de>
+Date: Sat, 29 Feb 2020 17:53:19 +0100
+Subject: [PATCH] Only install low level keyboard hook if GTK_CSD=1
+
+Added in eece8a7dd2405f76829031f3d6dd5e39fb5dc542 in order to
+intercept keyboard combos to provide AeroSnap-like functionality for
+CSD windows.
+
+Unfortunately it causes many issues, e.g.
+- https://gitlab.gnome.org/GNOME/gtk/issues/2015
+- https://gitlab.gnome.org/GNOME/gtk/issues/1082
+- https://gitlab.gnome.org/GNOME/gtk/issues/1033
+
+As the hook is completely useless for non-CSD windows, only install
+it if CSD is explicitly requested (environment variable GTK_CSD=1).
+---
+ gdk/win32/gdkevents-win32.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/gdk/win32/gdkevents-win32.c b/gdk/win32/gdkevents-win32.c
+index 7aef277c27..8b64d7dd22 100644
+--- a/gdk/win32/gdkevents-win32.c
++++ b/gdk/win32/gdkevents-win32.c
+@@ -530,7 +530,9 @@ _gdk_events_init (GdkDisplay *display)
+   g_source_set_can_recurse (source, TRUE);
+   g_source_attach (source, NULL);
+ 
+-  set_up_low_level_keyboard_hook ();
++  if (g_strcmp0 (g_getenv ("GTK_CSD"), "1") == 0) {
++    set_up_low_level_keyboard_hook ();
++  }
+ }
+ 
+ gboolean
+-- 
+2.25.1.windows.1
+

--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gtk3
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.24.14
-pkgrel=1
+pkgrel=2
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
 url="https://www.gtk.org/"
@@ -30,10 +30,12 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 options=('strip' '!debug' 'staticlibs')
 source=("https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}.tar.xz"
         "0002-Revert-Quartz-Set-the-popup-menu-type-hint-before-re.patch"
-        "0003-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch")
+        "0003-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch"
+        "0004-Disable-low-level-keyboard-hook.patch")
 sha256sums=('1c4d69f93ab884fd80c6b95115bfbc12d51ecd029178b6dad3672fdc5ff91e88'
             '5cdebb11098d241da955d4662904215275fa7a54d52877cc38c4ff4a3087fafd'
-            'b84a7f38f0af80680bee143d431f2a7bae53899efb337de0f67a1b4d9b59fa02')
+            'b84a7f38f0af80680bee143d431f2a7bae53899efb337de0f67a1b4d9b59fa02'
+            'e553083298495f9581ae1454b1046a22b83e81862311b30de984057eec859708')
 
 prepare() {
   cd "${srcdir}/gtk+-${pkgver}"
@@ -43,6 +45,8 @@ prepare() {
 
   # https://gitlab.gnome.org/GNOME/gtk/issues/760
   patch -p1 -i "${srcdir}"/0003-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch
+
+  patch -p1 -i "${srcdir}"/0004-Disable-low-level-keyboard-hook.patch
 }
 
 build() {


### PR DESCRIPTION
The hook is used to intercept keyboard combos so gtk is able to trigger the AeroSnap-like functionality it implements as a replacement for real AeroSnap when client-side decorations (CSD) are used on a window.

However the keyboard hook causes significant performance issues, especially on startup of gtk3 apps (those are system-wide and *not* limited to the gtk3 app itself). Input performance can be continuously degraded for any console application that is attached to the gtk3 app, e.g. debuggers.

Loss of the keyboard combos in CSD windows seems to be acceptable considering the severe functional limitations the hook itself causes.

This is especially true as we [do not use CSD by default](https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-gtk3/0003-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch) so we do not even depend on the (incomplete) AeroSnap-emulation GTK provides in most cases. Instead we're using native AeroSnap as provided by the OS directly, with keyboard combos working as expected.

Related issues:
- https://gitlab.gnome.org/GNOME/gtk/issues/2015
- https://gitlab.gnome.org/GNOME/gtk/issues/1082
- https://gitlab.gnome.org/GNOME/gtk/issues/1033