### PR TITLE
Update Rust to 1.41.1

### DIFF
--- a/mingw-w64-rust/0001-add-missing-libs.patch
+++ b/mingw-w64-rust/0001-add-missing-libs.patch
@@ -2,11 +2,13 @@ diff --git a/src/librustc_llvm/build.rs b/src/librustc_llvm/build.rs
 index caa2740408..52738a47f7 100644
 --- a/src/librustc_llvm/build.rs
 +++ b/src/librustc_llvm/build.rs
-@@ -269,6 +269,7 @@
+@@ -269,6 +269,9 @@
      // LLVM requires symbols from this library, but apparently they're not printed
      // during llvm-config?
      if target.contains("windows-gnu") {
 +        println!("cargo:rustc-link-lib=static-nobundle=ffi");
++        println!("cargo:rustc-link-lib=static-nobundle=z3");
++        println!("cargo:rustc-link-lib=stdc++");
          println!("cargo:rustc-link-lib=static-nobundle=gcc_s");
          println!("cargo:rustc-link-lib=static-nobundle=pthread");
      }

--- a/mingw-w64-rust/0004-unbundle-gcc.patch
+++ b/mingw-w64-rust/0004-unbundle-gcc.patch
@@ -47,14 +47,6 @@
          let mut cmd = rust_installer(builder);
 --- rustc-1.29.2-src/src/bootstrap/lib.rs.orig	2018-10-29 07:40:35.561580700 +0300
 +++ rustc-1.29.2-src/src/bootstrap/lib.rs	2018-10-29 07:45:54.426140700 +0300
-@@ -114,7 +114,6 @@
- //! also check out the `src/bootstrap/README.md` file for more information.
- 
- #![deny(rust_2018_idioms)]
--#![deny(warnings)]
- #![feature(core_intrinsics)]
- #![feature(drain_filter)]
- 
 @@ -1202,6 +1201,7 @@
          }
      }

--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -3,10 +3,10 @@
 # Contributor: Mateusz Mikuła <mati865@gmail.com
 
 _realname=rust
-_bootstrapping=no
+_bootstrapping=yes
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.37.0
+pkgver=1.41.1
 pkgrel=1
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
@@ -36,13 +36,13 @@ source=("https://static.rust-lang.org/dist/${_realname}c-${pkgver}-src.tar.gz"{,
         "0003-link-with-system-curl.patch"
         "0004-unbundle-gcc.patch"
         "0005-win32-config.patch")
-sha256sums=('120e7020d065499cc6b28759ff04153bfdc2ac9b5adeb252331a4eb87cbe38c3'
+sha256sums=('38c93d016e6d3e083aa15e8f65511d3b4983072c0218a529f5ee94dd1de84573'
             'SKIP'
             '500f9bd7452c8d35115ad823d8fcb9bda8b86878c2a0f57f9e6a72fc4ba9a8f5'
-            '4b6953fc6ab12d2ac45f65c429bf6be69d80bbf65727f293e2ced69ac9acc666'
+            'c1b3a4d234ba10d2baf9cc1a15e830f1b722b10d80f37b316f47501f5274c9c5'
             'e54e1da8428c484f41005bf4f9f7a8643253306e115b23e4dc17b24a6647ecab'
             'b16f65dfdc79e7a722b3e2589e90a1431a971038dd5dfa1394ec0427e3c0a2b4'
-            'b51bed9c6c6c558272f2de9fdf50d002211e92859df0598721d61b50188ea8d0'
+            '1a3d00f3bcf5c21beaa20ee729c45b7b3d76cd2a2c6b70562020f11c1e9dcc6d'
             '061f1cf5374c926bc130a4afbde005dcd09fdbaee079469ad045fd23a7a88a2c')
 validpgpkeys=('108F66205EAEB0AAA8DD5E1C85AB96E6FA1BE5FE') # Rust Language (Tag and Release Signing Key) <rust-key@rust-lang.org>
 noextract=(${_realname}c-${pkgver}-src.tar.gz)


### PR DESCRIPTION
WARNING: It won't build if build path is too long.