### PR TITLE
pygobject: Split into a Python 2 and Python 3 package

### DIFF
--- a/mingw-w64-pygobject/PKGBUILD
+++ b/mingw-w64-pygobject/PKGBUILD
@@ -2,108 +2,44 @@
 
 _realname=pygobject
 pkgbase=mingw-w64-${_realname}
-pkgname=("${MINGW_PACKAGE_PREFIX}-python2-gobject"
-         "${MINGW_PACKAGE_PREFIX}-python-gobject"
-         "${MINGW_PACKAGE_PREFIX}-pygobject-devel")
-pkgver=3.34.0
-pkgrel=3
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-gobject")
+pkgver=3.36.0
+pkgrel=1
 pkgdesc="Python Bindings for GLib/GObject/GIO/GTK+ (mingw-w64)"
 arch=(any)
 url="https://pygobject.readthedocs.io"
 license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
-             "${MINGW_PACKAGE_PREFIX}-python"
-             "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
+depends=("${MINGW_PACKAGE_PREFIX}-glib2"
+         "${MINGW_PACKAGE_PREFIX}-python-cairo"
+         "${MINGW_PACKAGE_PREFIX}-libffi"
+         "${MINGW_PACKAGE_PREFIX}-gobject-introspection-runtime")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"
-             "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
-             "${MINGW_PACKAGE_PREFIX}-python-cairo"
-             "${MINGW_PACKAGE_PREFIX}-python2-cairo")
+             "${MINGW_PACKAGE_PREFIX}-gobject-introspection")
+provides=("${MINGW_PACKAGE_PREFIX}-pygobject-devel"
+          "${MINGW_PACKAGE_PREFIX}-python3-gobject=${pkgver}")
+conflicts=("${MINGW_PACKAGE_PREFIX}-pygobject-devel"
+           "${MINGW_PACKAGE_PREFIX}-python3-gobject")
+replaces=("${MINGW_PACKAGE_PREFIX}-pygobject-devel"
+          "${MINGW_PACKAGE_PREFIX}-python3-gobject")
 source=(https://download.gnome.org/sources/pygobject/${pkgver%.*}/${_realname}-${pkgver}.tar.xz)
-sha256sums=('87e2c9aa785f352ef111dcc5f63df9b85cf6e05e52ff04f803ffbebdacf5271a')
+sha256sums=('8683d2dfb5baa9e501a9a64eeba5c2c1117eadb781ab1cd7a9d255834af6daef')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 }
 
 build() {
-  cd "${srcdir}"
+  cd "${srcdir}/${_realname}-${pkgver}"
 
-  rm -rf python{2,}-build devel || true
-  mkdir devel
-
-  for builddir in python{2,}-build; do
-    cp -r ${_realname}-${pkgver} ${builddir}
-    pushd ${builddir}
-    ${MINGW_PREFIX}/bin/${builddir%-build} setup.py build
-    popd
-  done
+  ${MINGW_PREFIX}/bin/python3 setup.py build
 }
 
-package_python2-gobject() {
-  pkgdesc="Python 2 bindings for GLib/GObject/GIO/GTK+ (mingw-w64)"
-  depends=("${MINGW_PACKAGE_PREFIX}-glib2"
-           "${MINGW_PACKAGE_PREFIX}-python2-cairo"
-           "${MINGW_PACKAGE_PREFIX}-libffi"
-           "${MINGW_PACKAGE_PREFIX}-gobject-introspection-runtime"
-           "${MINGW_PACKAGE_PREFIX}-pygobject-devel=${pkgver}")
+package() {
+  cd "${srcdir}/${_realname}-${pkgver}"
 
-  cd python2-build
-  # --no-compile because older packages didn't install .pyc and adding them
-  # would lead to upgrade conflicts
-  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-    ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" --no-compile
-  mv "${pkgdir}${MINGW_PREFIX}"/{include,lib/pkgconfig} "${srcdir}/devel"
-}
-
-package_python-gobject() {
-  pkgdesc="Python bindings for GLib/GObject/GIO/GTK+ (mingw-w64)"
-  depends=("${MINGW_PACKAGE_PREFIX}-glib2"
-           "${MINGW_PACKAGE_PREFIX}-python-cairo"
-           "${MINGW_PACKAGE_PREFIX}-libffi"
-           "${MINGW_PACKAGE_PREFIX}-gobject-introspection-runtime"
-           "${MINGW_PACKAGE_PREFIX}-pygobject-devel=${pkgver}")
-
-  provides=("${MINGW_PACKAGE_PREFIX}-python3-gobject=${pkgver}")
-  conflicts=("${MINGW_PACKAGE_PREFIX}-python3-gobject")
-  replaces=("${MINGW_PACKAGE_PREFIX}-python3-gobject")
-
-  cd python-build
   # --no-compile because older packages didn't install .pyc and adding them
   # would lead to upgrade conflicts
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
     ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" --no-compile
-  rm -r "${pkgdir}${MINGW_PREFIX}"/{include,lib/pkgconfig}
-}
-
-package_pygobject-devel() {
-  pkgdesc="Development files for the pygobject bindings"
-
-  cd "devel"
-  mkdir -p "${pkgdir}${MINGW_PREFIX}"/{include,lib}
-  mv include "${pkgdir}${MINGW_PREFIX}/"
-  mv pkgconfig "${pkgdir}${MINGW_PREFIX}/lib/"
-}
-
-package_mingw-w64-i686-pygobject-devel() {
-  package_pygobject-devel
-}
-
-package_mingw-w64-x86_64-pygobject-devel() {
-  package_pygobject-devel
-}
-
-package_mingw-w64-i686-python2-gobject() {
-  package_python2-gobject
-}
-
-package_mingw-w64-i686-python-gobject() {
-  package_python-gobject
-}
-
-package_mingw-w64-x86_64-python2-gobject() {
-  package_python2-gobject
-}
-
-package_mingw-w64-x86_64-python-gobject() {
-  package_python-gobject
 }

--- a/mingw-w64-python2-pygobject/PKGBUILD
+++ b/mingw-w64-python2-pygobject/PKGBUILD
@@ -1,0 +1,40 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+
+_realname=pygobject
+pkgbase=mingw-w64-python2-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-gobject")
+pkgver=3.34.0
+pkgrel=4
+pkgdesc="Python 2 bindings for GLib/GObject/GIO/GTK+ (mingw-w64)"
+arch=(any)
+url="https://pygobject.readthedocs.io"
+license=('LGPL')
+depends=("${MINGW_PACKAGE_PREFIX}-glib2"
+         "${MINGW_PACKAGE_PREFIX}-python2-cairo"
+         "${MINGW_PACKAGE_PREFIX}-libffi"
+         "${MINGW_PACKAGE_PREFIX}-gobject-introspection-runtime")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-gobject-introspection")
+source=(https://download.gnome.org/sources/pygobject/${pkgver%.*}/${_realname}-${pkgver}.tar.xz)
+sha256sums=('87e2c9aa785f352ef111dcc5f63df9b85cf6e05e52ff04f803ffbebdacf5271a')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+}
+
+build() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  ${MINGW_PREFIX}/bin/python2 setup.py build
+}
+
+package() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  # --no-compile because older packages didn't install .pyc and adding them
+  # would lead to upgrade conflicts
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" --no-compile
+  rm -Rf "${pkgdir}${MINGW_PREFIX}"/{include,lib/pkgconfig}
+}


### PR DESCRIPTION
The devel files move into the Python 3 version, which means using the
C API from Python 2 is no longer supported, kinda, but it will probably work anyway because 3.36 headers still work with Python 2.

Also update the Python 3 version to 3.36.0