### PR TITLE
mingw-w64-mesa: Get static linking right. Drop all runtime dependencies.

### DIFF
--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -4,28 +4,25 @@ _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=20.0.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Open-source implementation of the OpenGL specification (mingw-w64)"
 arch=('any')
 makedepends=("${MINGW_PACKAGE_PREFIX}-llvm"
              "${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-zlib"
              "${MINGW_PACKAGE_PREFIX}-python-mako"
              "${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
-# Workaround bug https://gitlab.freedesktop.org/mesa/mesa/issues/2012 by adding dependencies
-depends=("${MINGW_PACKAGE_PREFIX}-zlib"
-         "${MINGW_PACKAGE_PREFIX}-gcc-libs")
-optdepends=("${MINGW_PACKAGE_PREFIX}-opengl-man-pages: for the OpenGL API man pages"
-            "${MINGW_PACKAGE_PREFIX}-llvm: for shared linking LLVM")
+optdepends=("${MINGW_PACKAGE_PREFIX}-opengl-man-pages: for the OpenGL API man pages")
 url="https://www.mesa3d.org/"
 license=('MIT')
 options=('staticlibs' 'strip')
 source=(https://mesa.freedesktop.org/archive/${_realname}-${pkgver}.tar.xz{,.sig}
-        llvmwrapgen.sh)
+        llvmwrapgen.sh
+        zlibwrapgen.sh)
 sha256sums=('6153ba3f8cb0524bbfc08e4db76b408126b2d1be8f789dffe28d1a0461eedde4'
             'SKIP'
-            'e0340aad84db73fea994f2ce6a91bd19e54c17b6137e0dfb1bc8fabca8e72ed8')
+            '6e783a1576ba84949031da291471426a5b5d8ec8eca97e871447d0741ad4405d'
+            'acb6172102df0c7fb84255fe4ea07fa8550fd66a0d78fddc76fe1bfe67b0a461')
 validpgpkeys=('8703B6700E7EE06D7A39B8D6EDAE37B02CEB490D') # Emil Velikov <emil.l.velikov@gmail.com>
 validpgpkeys+=('946D09B5E4C9845E63075FF1D961C596A7203456') # Andres Gomez <tanty@igalia.com>
 validpgpkeys+=('E3E8F480C52ADD73B278EE78E1ECBE07D7D70895') # Juan Antonio Suárez Romero (Igalia, S.L.) <jasuarez@igalia.com>"
@@ -68,19 +65,22 @@ prepare() {
 
   cd ${srcdir}/${_realname}-${pkgver}
 
-# Run and optionally test LLVM Meson wrap generator
+# Generate Meson wraps for LLVM and zlib
 
   ${srcdir}/llvmwrapgen.sh
+  ${srcdir}/zlibwrapgen.sh
 # /bin/cat ${srcdir}/${_realname}-${pkgver}/subprojects/llvm/meson.build
 }
 
 buildcmd(){
+# Workaround https://gitlab.freedesktop.org/mesa/mesa/issues/2012 by using Meson force fallback wrap mode
   ${MINGW_PREFIX}/bin/meson ./build/windows-${_mach} \
   --prefix=${MINGW_PREFIX} \
   --includedir=include/mesa \
-  --default-library=both \
+  --default-library=static \
   --buildtype=release \
   --backend=ninja \
+  --wrap-mode=forcefallback \
   -Dshared-glapi=true \
   -Dgles1=true \
   -Dgles2=true \
@@ -92,9 +92,11 @@ buildcmd(){
 
 build() {
   cd ${srcdir}/${_realname}-${pkgver}
+# Remove wrapdb based zlib fetch
+  rm ./subprojects/zlib.wrap
   CFLAGS="-march=core2 -pipe" \
   CXXFLAGS="-march=core2 -pipe" \
-  LDFLAGS="-s" \
+  LDFLAGS="-static -s" \
   PROCESSOR_ARCHITECTURE="${CARCH}" \
   buildcmd
 }

--- a/mingw-w64-mesa/llvmwrapgen.sh
+++ b/mingw-w64-mesa/llvmwrapgen.sh
@@ -25,10 +25,6 @@ _search = '$(cygpath -m ${MINGW_PREFIX})/lib'
 foreach d : [${llvmlibs}]
   _deps += cpp.find_library(d, dirs : _search)
 endforeach
-_search2 = '$(cygpath -m ${MINGW_PREFIX})/bin'
-foreach d2 : ['libLLVM', 'libLTO', 'libRemarks']
-  _deps += cpp.find_library(d2, dirs : _search2)
-endforeach
 
 dep_llvm = declare_dependency(
   include_directories : include_directories('$(cygpath -m ${MINGW_PREFIX})/include'),

--- a/mingw-w64-mesa/zlibwrapgen.sh
+++ b/mingw-w64-mesa/zlibwrapgen.sh
@@ -1,0 +1,21 @@
+# Generate a Meson wrap file for zlib
+mkdir -p ./subprojects/zlib
+FILE="./subprojects/zlib/meson.build"
+/bin/cat <<EOM >${FILE}
+project('zlib', ['cpp'])
+
+cpp = meson.get_compiler('cpp')
+
+_deps = []
+_search = '$(cygpath -m ${MINGW_PREFIX})/lib'
+foreach d : ['libz', 'libz.dll']
+  _deps += cpp.find_library(d, dirs : _search)
+endforeach
+
+zlib_dep = declare_dependency(
+  include_directories : include_directories('$(cygpath -m ${MINGW_PREFIX})/include'),
+  dependencies : _deps,
+  version : '$(pacman -Q ${MINGW_PACKAGE_PREFIX}-zlib | cut -d" " -f 2 | cut -d"-" -f 1)',
+)
+
+EOM


### PR DESCRIPTION
This makes Meson behave exactly like Scons did before replacement.
Drop shared build. I didn't see much value in it anyway, especially with
both linking negating all storage saving and the fact that there are no
packages in mingw-packages and msys2-packages repositories depending on
mingw-w64-mesa at this point. mingw-w64-mesa has been fine with static
linking since its debut anyway.