### PR TITLE
mingw-w64-mesa: Remove unnecessary dependency checks

### DIFF
--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -4,18 +4,16 @@ _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=20.0.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Open-source implementation of the OpenGL specification (mingw-w64)"
 arch=('any')
 makedepends=("${MINGW_PACKAGE_PREFIX}-llvm"
              "${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-zlib"
              "${MINGW_PACKAGE_PREFIX}-python-mako"
              "${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
 # Workaround bug https://gitlab.freedesktop.org/mesa/mesa/issues/2012 by adding dependencies
-depends=("${MINGW_PACKAGE_PREFIX}-zlib"
-         "${MINGW_PACKAGE_PREFIX}-gcc-libs")
+depends=("${MINGW_PACKAGE_PREFIX}-zlib")
 optdepends=("${MINGW_PACKAGE_PREFIX}-opengl-man-pages: for the OpenGL API man pages"
             "${MINGW_PACKAGE_PREFIX}-llvm: for shared linking LLVM")
 url="https://www.mesa3d.org/"


### PR DESCRIPTION
${MINGW_PACKAGE_PREFIX}-gcc requires ${MINGW_PACKAGE_PREFIX}-zlib;
${MINGW_PACKAGE_PREFIX}-zlib requires ${MINGW_PACKAGE_PREFIX}-bzip2
which in turn requires ${MINGW_PACKAGE_PREFIX}-gcc-libs.