### PR TITLE
glibmm: update to version 2.64.2

### DIFF
--- a/mingw-w64-glibmm/PKGBUILD
+++ b/mingw-w64-glibmm/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=glibmm
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.64.1
+pkgver=2.64.2
 pkgrel=1
 pkgdesc="Glib-- (glibmm) is a C++ interface for glib (mingw-w64)"
 arch=('any')
@@ -13,7 +13,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=("${MINGW_PACKAGE_PREFIX}-libsigc++" "${MINGW_PACKAGE_PREFIX}-glib2")
 options=('staticlibs' 'strip')
 source=("https://download.gnome.org/sources/glibmm/${pkgver%.*}/glibmm-${pkgver}.tar.xz")
-sha256sums=('aae0616c777a44a4ecf2ab74372cafbcbe14da3233fa389787d52cd4fd48c9f5')
+sha256sums=('a75282e58d556d9b2bb44262b6f5fb76c824ac46a25a06f527108bec86b8d4ec')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}


### PR DESCRIPTION
Fixes a second regression in the 2.64 branch that broke compilation of downstream projects, see https://gitlab.gnome.org/GNOME/glibmm/issues/71.