### PR TITLE
gspell: update list of dependencies and package description

### DIFF
--- a/mingw-w64-gspell/PKGBUILD
+++ b/mingw-w64-gspell/PKGBUILD
@@ -4,16 +4,13 @@ _realname=gspell
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.8.3
-pkgrel=1
+pkgrel=2
 arch=('any')
-pkgdesc="Spell-checking library for GTK+ (mingw-w64)"
+pkgdesc="Spell-checking library for GTK applications (mingw-w64)"
 options=(strip staticlibs)
-depends=("${MINGW_PACKAGE_PREFIX}-gsettings-desktop-schemas"
-         "${MINGW_PACKAGE_PREFIX}-gtk3"
-         "${MINGW_PACKAGE_PREFIX}-gtksourceview3"
+depends=("${MINGW_PACKAGE_PREFIX}-gtk3"
          "${MINGW_PACKAGE_PREFIX}-iso-codes"
-         "${MINGW_PACKAGE_PREFIX}-enchant"
-         "${MINGW_PACKAGE_PREFIX}-libxml2")
+         "${MINGW_PACKAGE_PREFIX}-enchant")
 makedepends=("${MINGW_PACKAGE_PREFIX}-vala"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection")
 license=("LGPL 2.1")


### PR DESCRIPTION
Note that I’m the upstream maintainer of gspell.

gspell doesn’t use GSettings, and it no longer depends on GtkSourceView
and the libxml2 (these deps were removed in gspell 0.2.2).