### PR TITLE
appstream-glib: update list of dependencies

### DIFF
--- a/mingw-w64-appstream-glib/PKGBUILD
+++ b/mingw-w64-appstream-glib/PKGBUILD
@@ -4,7 +4,7 @@ _realname=appstream-glib
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.7.17
-pkgrel=1
+pkgrel=2
 arch=('any')
 pkgdesc="Objects and methods for reading and writing AppStream metadata (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-gdk-pixbuf2"
@@ -14,10 +14,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gdk-pixbuf2"
          "${MINGW_PACKAGE_PREFIX}-json-glib"
          "${MINGW_PACKAGE_PREFIX}-libyaml"
          "${MINGW_PACKAGE_PREFIX}-libsoup"
-         "${MINGW_PACKAGE_PREFIX}-gtksourceview3"
-         "${MINGW_PACKAGE_PREFIX}-iso-codes"
-         "${MINGW_PACKAGE_PREFIX}-libpeas"
-         "${MINGW_PACKAGE_PREFIX}-libsoup")
+         "${MINGW_PACKAGE_PREFIX}-libarchive")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
              "${MINGW_PACKAGE_PREFIX}-meson"


### PR DESCRIPTION
Note that libsoup is required, but was listed two times.

git grep in appstream-glib sources gives no results for gtksourceview,
iso-codes and peas.

libarchive was missing.