### PR TITLE
gimp: fix dependency on pygobject

### DIFF
--- a/mingw-w64-gimp/PKGBUILD
+++ b/mingw-w64-gimp/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 _basever=2.10.18
 _prever=
 pkgver=${_basever}${_prever//-/}
-pkgrel=2
+pkgrel=3
 pkgdesc="GNU Image Manipulation Program (mingw-w64)"
 arch=('any')
 url="https://www.gimp.org/"
@@ -34,10 +34,12 @@ depends=("${MINGW_PACKAGE_PREFIX}-babl"
          "${MINGW_PACKAGE_PREFIX}-openjpeg2"
          "${MINGW_PACKAGE_PREFIX}-poppler"
          "${MINGW_PACKAGE_PREFIX}-python2-pygtk"
-         "${MINGW_PACKAGE_PREFIX}-python2-gobject"
+         "${MINGW_PACKAGE_PREFIX}-python2-gobject2"
          "${MINGW_PACKAGE_PREFIX}-xpm-nox"
         )
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pygobject2-devel"
+             "${MINGW_PACKAGE_PREFIX}-gtk-doc"
              "intltool")
 options=('strip' 'makeflags')
 install=gimp-${CARCH}.install


### PR DESCRIPTION
It uses the old static bindings, not pygobject3