### PR TITLE
qbittorrent: update to 4.2.2

### DIFF
--- a/mingw-w64-qbittorrent/PKGBUILD
+++ b/mingw-w64-qbittorrent/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=qbittorrent
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-pkgver=4.2.1
+pkgver=4.2.2
 pkgrel=1
 pkgdesc="An advanced BitTorrent client programmed in C++, based on Qt toolkit and libtorrent-rasterbar (mingw-w64)"
 arch=('any')
@@ -15,12 +15,13 @@ depends=("${MINGW_PACKAGE_PREFIX}-boost"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 optdepends=("${MINGW_PACKAGE_PREFIX}-python3: needed for torrent search tab")
 makedepends=("${MINGW_PACKAGE_PREFIX}-pkg-config")
-source=(${_realname}-${pkgver}.tar.gz::https://github.com/qbittorrent/qBittorrent/archive/release-${pkgver}.tar.gz)
-sha256sums=('723e68807ff0faffda68ed95b515d31abd23a667d949bddf0021ad81f7400a1f')
-validpgpkeys=('D8F3DA77AAC6741053599C136E4A2D025B7CC9A2')
+source=("https://downloads.sourceforge.net/sourceforge/qbittorrent/${_realname}-${pkgver}.tar.xz"{,.asc})
+sha256sums=('fa457cc6fef02fe15958f94863181e64b8dcd9762184f8a53ad4c75f89d42223'
+            'SKIP')
+validpgpkeys=('D8F3DA77AAC6741053599C136E4A2D025B7CC9A2') # sledgehammer_999 <hammered999@gmail.com>
 
 prepare() {
-  cd "${srcdir}/${_realname}-release-${pkgver}"
+  cd "${srcdir}/${_realname}-${pkgver}"
 
   # prepare env for mingw
   sed -i 's/unix:!macx:/unix|win32-g++:/g' "src/src.pro"
@@ -29,7 +30,7 @@ prepare() {
 
 build() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
-  cp -rf ${_realname}-release-${pkgver} build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
+  cp -rf ${_realname}-${pkgver} build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
 
   ./configure \
     --prefix=${MINGW_PREFIX} \


### PR DESCRIPTION
replace source from .tar.gz to .tar.xz