### PR TITLE
fix qt5-static for CMake 3.17

### DIFF
--- a/mingw-w64-qt5-static/0044-qt-5.13-static-cmake-fix-default-libs.patch
+++ b/mingw-w64-qt5-static/0044-qt-5.13-static-cmake-fix-default-libs.patch
@@ -1,12 +1,11 @@
---- b/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in.before
-+++ a/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
-@@ -86,6 +86,10 @@ function(_qt5_$${CMAKE_MODULE_NAME}_process_prl_file prl_file_location Configura
-                     find_package(Threads REQUIRED)
-                     list(APPEND _lib_deps Threads::Threads)
-                 else()
-+                    if(_lib MATCHES "advapi32|amstrmid|comdlg32|crypt32|dmoguids|dnsapi|dwmapi|dxguid|gdi32|imm32|IPHLPAPI|kernel32|ksuser|mpr|netapi32|ole32|oleaut32|shell32|strmiids|user32|userenv|uuid|uxtheme|version|winmm|winspool|ws2_32")
-+                        list(APPEND _lib_deps ${_flag})
-+                        continue()
-+                    endif()
-                     set(current_search_paths \"${_search_paths}\")
-                     if(_framework_flag)
+--- qtbase-everywhere-src-5.14.0/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in.orig       2019-12-07 06:27:07.000000000 +0000
++++ qtbase-everywhere-src-5.14.0/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in    2020-01-23 19:45:11.239484100 +0000
+@@ -71,7 +71,7 @@
+
+         string(REGEX REPLACE \"QMAKE_PRL_LIBS_FOR_CMAKE[ \\t]*=[ \\t]*([^\\n]*)\" \"\\\\1\" _static_depends \"${_prl_strings}\")
+         string(REGEX REPLACE \"[ \\t]+\" \";\" _standard_libraries \"${CMAKE_CXX_STANDARD_LIBRARIES}\")
+-        set(_search_paths)
++        set(_search_paths ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
+         set(_fw_search_paths)
+         set(_framework_flag)
+         string(REPLACE \"\\$\\$[QT_INSTALL_LIBS]\" \"${_qt5_install_libs}\" _static_depends \"${_static_depends}\")

--- a/mingw-w64-qt5-static/PKGBUILD
+++ b/mingw-w64-qt5-static/PKGBUILD
@@ -112,7 +112,7 @@ _ver_base=5.14.1
 # use 5.6.1-1 hot fix : only the archive name was changed from *-5.6.1.tar.xz to *-5.6.1-1.tar.xz
 _hotfix=
 pkgver=${_ver_base//-/}
-pkgrel=3
+pkgrel=4
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='https://www.qt.io/'
@@ -805,7 +805,7 @@ sha256sums=('6f17f488f512b39c2feb57d83a5e0a13dcef32999bea2e2a8f832f54a29badb8'
             '8beeb610df3aff14bae43c56e5781cda3d49f1ad23c6e3fc2aa2405ce002de46'
             '6595c9a5dbbdcea44f1c085c25a186b15ca4a732b28d1894a11141ddd472250d'
             '14b88305c02f8471d5b01a2c9d2385fbeee78f5084a6d0da53246623243ebffd'
-            '04ff6646cf5785f97e03d5b6cd599044d9879533b2dd3ca65aa928d748924abb'
+            '6e9fa42f26625fd7c8d4ce180b5ec9a0b640501eb976da50a49d6a376019cc0e'
             '2816d297d783c00744d6cf94758da1cb59dfd1061deceb82744e607b8292e324'
             '42724bd154ed98c612d19a7daee2b5028270ef6dbfe7f35d5f97c8d0605f9fe6'
             '3dc4d7c4fed8fedd726211edbfe13f4d78247d3ab2f789f3ce2a8e43e59a7c5b'

--- a/mingw-w64-qt5/0044-qt-5.13-static-cmake-fix-default-libs.patch
+++ b/mingw-w64-qt5/0044-qt-5.13-static-cmake-fix-default-libs.patch
@@ -1,12 +1,11 @@
---- b/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in.before
-+++ a/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
-@@ -86,6 +86,10 @@ function(_qt5_$${CMAKE_MODULE_NAME}_process_prl_file prl_file_location Configura
-                     find_package(Threads REQUIRED)
-                     list(APPEND _lib_deps Threads::Threads)
-                 else()
-+                    if(_lib MATCHES "advapi32|amstrmid|comdlg32|crypt32|dmoguids|dnsapi|dwmapi|dxguid|gdi32|imm32|IPHLPAPI|kernel32|ksuser|mpr|netapi32|ole32|oleaut32|shell32|strmiids|user32|userenv|uuid|uxtheme|version|winmm|winspool|ws2_32")
-+                        list(APPEND _lib_deps ${_flag})
-+                        continue()
-+                    endif()
-                     set(current_search_paths \"${_search_paths}\")
-                     if(_framework_flag)
+--- qtbase-everywhere-src-5.14.0/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in.orig       2019-12-07 06:27:07.000000000 +0000
++++ qtbase-everywhere-src-5.14.0/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in    2020-01-23 19:45:11.239484100 +0000
+@@ -71,7 +71,7 @@
+
+         string(REGEX REPLACE \"QMAKE_PRL_LIBS_FOR_CMAKE[ \\t]*=[ \\t]*([^\\n]*)\" \"\\\\1\" _static_depends \"${_prl_strings}\")
+         string(REGEX REPLACE \"[ \\t]+\" \";\" _standard_libraries \"${CMAKE_CXX_STANDARD_LIBRARIES}\")
+-        set(_search_paths)
++        set(_search_paths ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
+         set(_fw_search_paths)
+         set(_framework_flag)
+         string(REPLACE \"\\$\\$[QT_INSTALL_LIBS]\" \"${_qt5_install_libs}\" _static_depends \"${_static_depends}\")

--- a/mingw-w64-qt5/PKGBUILD
+++ b/mingw-w64-qt5/PKGBUILD
@@ -112,7 +112,7 @@ _ver_base=5.14.1
 # use 5.6.1-1 hot fix : only the archive name was changed from *-5.6.1.tar.xz to *-5.6.1-1.tar.xz
 _hotfix=
 pkgver=${_ver_base//-/}
-pkgrel=3
+pkgrel=4
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='https://www.qt.io/'
@@ -805,7 +805,7 @@ sha256sums=('6f17f488f512b39c2feb57d83a5e0a13dcef32999bea2e2a8f832f54a29badb8'
             '8beeb610df3aff14bae43c56e5781cda3d49f1ad23c6e3fc2aa2405ce002de46'
             '6595c9a5dbbdcea44f1c085c25a186b15ca4a732b28d1894a11141ddd472250d'
             '14b88305c02f8471d5b01a2c9d2385fbeee78f5084a6d0da53246623243ebffd'
-            '04ff6646cf5785f97e03d5b6cd599044d9879533b2dd3ca65aa928d748924abb'
+            '6e9fa42f26625fd7c8d4ce180b5ec9a0b640501eb976da50a49d6a376019cc0e'
             '2816d297d783c00744d6cf94758da1cb59dfd1061deceb82744e607b8292e324'
             '42724bd154ed98c612d19a7daee2b5028270ef6dbfe7f35d5f97c8d0605f9fe6'
             '3dc4d7c4fed8fedd726211edbfe13f4d78247d3ab2f789f3ce2a8e43e59a7c5b'


### PR DESCRIPTION
CMake 3.17 stops finding dll files for additional libraries trying to be found by Qt
replace expanding the list with the workaround that will be in 5.14.2 anyway