### PR TITLE
openssl: Update to 1.1.1f - fix for breaking change in 1.1.1e

### DIFF
--- a/mingw-w64-openssl/PKGBUILD
+++ b/mingw-w64-openssl/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=openssl
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_ver=1.1.1e
+_ver=1.1.1f
 # use a pacman compatible version scheme
 pkgver=${_ver/[a-z]/.${_ver//[0-9.]/}}
 pkgrel=2
@@ -17,7 +17,7 @@ url="https://www.openssl.org"
 noextract=(${_realname}-${_ver}.tar.gz)
 source=(https://www.openssl.org/source/${_realname}-${_ver}.tar.gz{,.asc}
         'openssl-1.1.1-relocation.patch')
-sha256sums=('694f61ac11cb51c9bf73f54e771ff6022b0327a43bbdfa1b2f19de1662a6dcbe'
+sha256sums=('186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35'
             'SKIP'
             '798d1b4dec28429d6cf2081c5b5b23b4344590a9b812e8089842389dbd175b77')
 
@@ -55,7 +55,7 @@ prepare() {
 
 build() {
   rm -rf ${srcdir}/build-${CARCH}
- 
+
   # No support for out-of-source builds
   mkdir -p ${srcdir}/build-${CARCH}
 #  cp -a ${srcdir}/${_realname}-${_ver}/* ${srcdir}/build-${CARCH}


### PR DESCRIPTION
1.1.1f is a 'bug fix only release', and reverts a breaking change introduced in 1.1.1e involving error handling.

See:
https://mta.openssl.org/pipermail/openssl-announce/2020-March/000168.html