### PR TITLE
imagemagick: Update to 7.0.10-3

### DIFF
--- a/mingw-w64-imagemagick/PKGBUILD
+++ b/mingw-w64-imagemagick/PKGBUILD
@@ -3,9 +3,9 @@
 _realname=imagemagick
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-_basever=7.0.9
-_rc=-17
-pkgver=${_basever}${_rc//-/.}
+_basever=7.0.10
+_rc=-3
+pkgver=${_basever}${_rc//-/.} # pkgver doesn't have "," "/", "-" and space.
 pkgrel=1
 pkgdesc="An image viewing/manipulation program (mingw-w64)"
 arch=('any')
@@ -58,12 +58,11 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-ghostscript: for Ghostscript support"
             #"${MINGW_PACKAGE_PREFIX}-libwebp: for WEBP support"
             )
 options=('staticlibs' 'strip' '!debug' 'libtool')
-source=(#https://www.imagemagick.org/download/ImageMagick-${pkgver%.*}-${pkgver##*.}.tar.xz{,.asc}
-        https://www.imagemagick.org/download/ImageMagick-${_basever}${_rc}.tar.xz{,.asc}
+source=(https://imagemagick.org/download/ImageMagick-${_basever}${_rc}.tar.xz{,.asc}
         ImageMagick-7.0.1.3-mingw.patch
         001-7.0.4.1-relocate.patch
         002-7.0.4.1-build-fixes.patch)
-sha256sums=('e926b494fd0c7faa51f5fc1da40cda87f62f5fa4e77c9bcc0f15c3bfa1e42ed3'
+sha256sums=('bcf11e2339544fb9a324ca31ecae895ba641e28241f26382c8917370174458d9'
             'SKIP'
             '313e781918c66a2acfdbd99fab3de2fd680c34efdaaab18318d7543d4c79bb3e'
             '28c54cd97706e14e631f5dd4d67b79c1680be6eacaf94c15b0f5acd8159b64b0'


### PR DESCRIPTION
## Overview

Merging this PR resolves the following issues:

- Failed to build

## Notes

ImageMagick source code package is here:
https://imagemagick.org/download/