### PR TITLE
gtk3: Update to 3.24.17

### DIFF
--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gtk3
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.24.16
+pkgver=3.24.17
 pkgrel=1
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
@@ -32,7 +32,7 @@ source=("https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}.tar
         "0002-Revert-Quartz-Set-the-popup-menu-type-hint-before-re.patch"
         "0003-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch"
         "0004-Disable-low-level-keyboard-hook.patch")
-sha256sums=('0d5e1e1494101b8c0c63c0526180780559eee469f021ca0d714018b20fa3d8e8'
+sha256sums=('f210255b221cb0f0db3e7b21399983b715c9dda6eb1e5c2f7fdf38f4f1b6bac0'
             '5cdebb11098d241da955d4662904215275fa7a54d52877cc38c4ff4a3087fafd'
             'b84a7f38f0af80680bee143d431f2a7bae53899efb337de0f67a1b4d9b59fa02'
             'e553083298495f9581ae1454b1046a22b83e81862311b30de984057eec859708')
@@ -47,6 +47,8 @@ prepare() {
   patch -p1 -i "${srcdir}"/0003-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch
 
   patch -p1 -i "${srcdir}"/0004-Disable-low-level-keyboard-hook.patch
+
+  #sed -s "s|version: '3.24.17',|version: '${pkgver}',|" -i "${srcdir}/gtk+-${pkgver}/meson.build"
 }
 
 build() {


### PR DESCRIPTION
Problem is wrong version reported by pkg-config.

This is a quick fix; the more proper fix is to go back to configure/make build.

Tim S.

`$ pkg-config --modversion gtk+-3.0
3.24.14

stahta01@Laptop2-tim MINGW64 ~
$ pacman -Qs gtk3
local/mingw-w64-x86_64-gtk3 3.24.16-1
    GObject-based multi-platform GUI toolkit (v3) (mingw-w64)
`