### PR TITLE
python-gmpy2: Fix import on 64 bit Windows

### DIFF
--- a/mingw-w64-python-gmpy2/PKGBUILD
+++ b/mingw-w64-python-gmpy2/PKGBUILD
@@ -7,7 +7,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=2.1.0b4
-pkgrel=1
+pkgrel=2
 pkgdesc="Provides C-coded Python modules for fast multiple-precision arithmetic (mingw-w64)"
 arch=('any')
 url='https://github.com/aleaxit/gmpy'
@@ -16,9 +16,11 @@ depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-mpc")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('staticlibs' 'strip' '!debug')
-source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/aleaxit/gmpy/archive/${_realname}-${pkgver}.tar.gz")
+source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/aleaxit/gmpy/archive/${_realname}-${pkgver}.tar.gz"
+        "remove-wrong-msys2-checks.patch")
 noextract=("${_realname}-${pkgver}.tar.gz")
-sha256sums=('83589062bc2b221080d6e32aa197b845be16dcda8aa0f92781854636f17b0a5b')
+sha256sums=('83589062bc2b221080d6e32aa197b845be16dcda8aa0f92781854636f17b0a5b'
+            '96355ecdb49a266146c9fc370a434af472519039ed5fa41c22b1b7ce70f4910c')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -48,6 +50,9 @@ prepare() {
   pushd "gmpy-${_realname}-${pkgver}"
   cp src/gmpy2.h gmpy2/gmpy2.h
   cp src/gmpy2.pxd gmpy2/gmpy2.pxd
+
+  # https://github.com/aleaxit/gmpy/issues/268
+  apply_patch_with_msg remove-wrong-msys2-checks.patch
   popd
 
   rm -rf python-build-${CARCH} | true

--- a/mingw-w64-python-gmpy2/remove-wrong-msys2-checks.patch
+++ b/mingw-w64-python-gmpy2/remove-wrong-msys2-checks.patch
@@ -1,0 +1,22 @@
+--- gmpy-gmpy2-2.1.0b4/src/gmpy2.c.orig	2020-02-04 05:36:50.000000000 +0100
++++ gmpy-gmpy2-2.1.0b4/src/gmpy2.c	2020-04-07 21:48:24.187539100 +0200
+@@ -932,7 +932,7 @@
+ 
+     /* Validate the sizes of the various typedef'ed integer types. */
+ 
+-#if defined _WIN64 && (MPIR || MSYS2)
++#if defined _WIN64 && MPIR
+     if (sizeof(mp_bitcnt_t) != sizeof(PY_LONG_LONG)) {
+         /* LCOV_EXCL_START */
+         SYSTEM_ERROR("Size of PY_LONG_LONG and mp_bitcnt_t not compatible (_WIN64 && MPIR)");
+--- gmpy-gmpy2-2.1.0b4/src/gmpy2_convert_utils.h.orig	2020-02-04 05:36:50.000000000 +0100
++++ gmpy-gmpy2-2.1.0b4/src/gmpy2_convert_utils.h	2020-04-07 21:48:30.754303500 +0200
+@@ -53,7 +53,7 @@
+  * builds has been changed to unsigned long long int.
+  */
+ 
+-#if defined _WIN64 && (MPIR || MSYS2)
++#if defined _WIN64 && MPIR
+ # define mp_bitcnt_t_From_Integer c_ulonglong_From_Integer
+ # define GMPy_Integer_AsMpBitCntAndError GMPy_Integer_AsUnsignedLongLongAndError
+ #else


### PR DESCRIPTION
Fixes #6058