### PR TITLE
Disable parallel installation of XmlAda

### DIFF
--- a/FAIL_LIST.md
+++ b/FAIL_LIST.md
@@ -36,5 +36,3 @@ List of packages that currently fail to build
 - plplot
 
 - pitivi-git
-
-- xmlada-gpl

--- a/mingw-w64-xmlada-gpl/PKGBUILD
+++ b/mingw-w64-xmlada-gpl/PKGBUILD
@@ -9,7 +9,7 @@ _realname=xmlada-gpl
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=2017
-pkgrel=1
+pkgrel=2
 pkgdesc="A full XML suite for Ada (mingw-w64)"
 arch=('any')
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname%-*}")
@@ -44,7 +44,7 @@ package() {
   mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/gnat/xmlada
 
   cd ${srcdir}/${_realname}
-  make prefix=${pkgdir}${MINGW_PREFIX} INSTALL=cp install
+  make -j1 prefix=${pkgdir}${MINGW_PREFIX} INSTALL=cp install
 
   rm -rf ${pkgdir}${MINGW_PREFIX}/share/examples
   rm -rf ${pkgdir}${MINGW_PREFIX}/share/doc


### PR DESCRIPTION
because it breaks gprinstall run.