### PR TITLE
tesseract-ocr: add missing dependencies

### DIFF
--- a/mingw-w64-tesseract-ocr/PKGBUILD
+++ b/mingw-w64-tesseract-ocr/PKGBUILD
@@ -5,16 +5,18 @@ _realname=tesseract-ocr
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.1.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Tesseract OCR (mingw-w64)"
 arch=('any')
 url="https://github.com/tesseract-ocr/tesseract"
 license=("Apache License 2.0")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=(${MINGW_PACKAGE_PREFIX}-cairo
+         ${MINGW_PACKAGE_PREFIX}-curl
          ${MINGW_PACKAGE_PREFIX}-gcc-libs
          ${MINGW_PACKAGE_PREFIX}-icu
          ${MINGW_PACKAGE_PREFIX}-leptonica
+         ${MINGW_PACKAGE_PREFIX}-libarchive
          ${MINGW_PACKAGE_PREFIX}-pango
          ${MINGW_PACKAGE_PREFIX}-zlib)
 options=('!libtool' 'strip')


### PR DESCRIPTION
Add `curl` and `libarchive` as dependencies.
Without these, `tesseract.exe` produces a misleading error:
```
... error while loading shared libraries: libtiff-5.dll ...
```
Fixes #6382

Note: Before making this pull request, I've recreated the package on a clean MinGW64, then installed it on another clean one (no dev tools), and all went well.