### PR TITLE
mingw-w64-mesa: Link LLVM statically in response to #6353

### DIFF
--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -4,7 +4,7 @@ _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=20.0.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Open-source implementation of the OpenGL specification (mingw-w64)"
 arch=('any')
 makedepends=("${MINGW_PACKAGE_PREFIX}-llvm"
@@ -12,10 +12,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-llvm"
              "${MINGW_PACKAGE_PREFIX}-python-mako"
              "${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
-# Workaround bug https://gitlab.freedesktop.org/mesa/mesa/issues/2012 by adding dependencies
 depends=("${MINGW_PACKAGE_PREFIX}-zlib")
-optdepends=("${MINGW_PACKAGE_PREFIX}-opengl-man-pages: for the OpenGL API man pages"
-            "${MINGW_PACKAGE_PREFIX}-llvm: for shared linking LLVM")
+optdepends=("${MINGW_PACKAGE_PREFIX}-opengl-man-pages: for the OpenGL API man pages")
 url="https://www.mesa3d.org/"
 license=('MIT')
 options=('staticlibs' 'strip')
@@ -23,7 +21,7 @@ source=(https://mesa.freedesktop.org/archive/${_realname}-${pkgver}.tar.xz{,.sig
         llvmwrapgen.sh)
 sha256sums=('c4ed491517a94118a7a611810eeb92645d42ffd82280dcd51be8cc2ba1aabba5'
             'SKIP'
-            'e0340aad84db73fea994f2ce6a91bd19e54c17b6137e0dfb1bc8fabca8e72ed8')
+            '3ad048a4c395adf6d24f2e9325d6a125822b323d494149e00d5cc435d16075e4')
 validpgpkeys=('8703B6700E7EE06D7A39B8D6EDAE37B02CEB490D') # Emil Velikov <emil.l.velikov@gmail.com>
 validpgpkeys+=('946D09B5E4C9845E63075FF1D961C596A7203456') # Andres Gomez <tanty@igalia.com>
 validpgpkeys+=('E3E8F480C52ADD73B278EE78E1ECBE07D7D70895') # Juan Antonio Suárez Romero (Igalia, S.L.) <jasuarez@igalia.com>"
@@ -66,19 +64,26 @@ prepare() {
 
   cd ${srcdir}/${_realname}-${pkgver}
 
-# Run and optionally test LLVM Meson wrap generator
+# Run and optionally test LLVM Meson wrap generator.
+# Change nollvmconfig value to 1 if you know llvm-config is broken.
 
-  ${srcdir}/llvmwrapgen.sh
+  nollvmconfig=0 ${srcdir}/llvmwrapgen.sh
 # /bin/cat ${srcdir}/${_realname}-${pkgver}/subprojects/llvm/meson.build
 }
 
-buildcmd(){
+build() {
+  cd ${srcdir}/${_realname}-${pkgver}
+  PROCESSOR_ARCHITECTURE="${CARCH}" \
   ${MINGW_PREFIX}/bin/meson ./build/windows-${_mach} \
   --prefix=${MINGW_PREFIX} \
   --includedir=include/mesa \
   --default-library=both \
   --buildtype=release \
   --backend=ninja \
+  -Dc_args='-march=core2 -pipe' \
+  -Dcpp_args='-march=core2 -pipe' \
+  -Dc_link_args='-s' \
+  -Dcpp_link_args='-s' \
   -Dshared-glapi=true \
   -Dgles1=true \
   -Dgles2=true \
@@ -88,18 +93,11 @@ buildcmd(){
   ${MINGW_PREFIX}/bin/ninja -C ./build/windows-${_mach}
 }
 
-build() {
-  cd ${srcdir}/${_realname}-${pkgver}
-  CFLAGS="-march=core2 -pipe" \
-  CXXFLAGS="-march=core2 -pipe" \
-  LDFLAGS="-s" \
-  PROCESSOR_ARCHITECTURE="${CARCH}" \
-  buildcmd
-}
-
 package() {
   cd ${srcdir}/${_realname}-${pkgver}/build/windows-${_mach}
   DESTDIR=${pkgdir}${MINGW_PREFIX} ${MINGW_PREFIX}/bin/meson install
+
+# Install graw library
   cp -f ${srcdir}/${_realname}-${pkgver}/build/windows-${_mach}/src/gallium/targets/graw-gdi/graw.dll ${pkgdir}${MINGW_PREFIX}/bin/
   cp -f ${srcdir}/${_realname}-${pkgver}/build/windows-${_mach}/src/gallium/targets/graw-null/graw_null.dll ${pkgdir}${MINGW_PREFIX}/bin/
   cp -f ${srcdir}/${_realname}-${pkgver}/build/windows-${_mach}/src/gallium/targets/graw-gdi/graw.dll.a ${pkgdir}${MINGW_PREFIX}/lib/

--- a/mingw-w64-mesa/llvmwrapgen.sh
+++ b/mingw-w64-mesa/llvmwrapgen.sh
@@ -1,14 +1,18 @@
 #!/bin/sh
 # Get LLVM libraries
-llvmlibs=$(${MINGW_PREFIX}/bin/llvm-config --link-static --libnames engine coroutines)
+if [ ${nollvmconfig} = 1 ]; then
+  llvmlibs='libLLVMCoroutines.a libLLVMipo.a libLLVMInstrumentation.a libLLVMVectorize.a libLLVMLinker.a libLLVMIRReader.a libLLVMAsmParser.a libLLVMX86Disassembler.a libLLVMX86AsmParser.a libLLVMX86CodeGen.a libLLVMCFGuard.a libLLVMGlobalISel.a libLLVMSelectionDAG.a libLLVMAsmPrinter.a libLLVMDebugInfoDWARF.a libLLVMCodeGen.a libLLVMScalarOpts.a libLLVMInstCombine.a libLLVMAggressiveInstCombine.a libLLVMTransformUtils.a libLLVMBitWriter.a libLLVMX86Desc.a libLLVMMCDisassembler.a libLLVMX86Utils.a libLLVMX86Info.a libLLVMMCJIT.a libLLVMExecutionEngine.a libLLVMTarget.a libLLVMAnalysis.a libLLVMProfileData.a libLLVMRuntimeDyld.a libLLVMObject.a libLLVMTextAPI.a libLLVMMCParser.a libLLVMBitReader.a libLLVMMC.a libLLVMDebugInfoCodeView.a libLLVMDebugInfoMSF.a libLLVMCore.a libLLVMRemarks.a libLLVMBitstreamReader.a libLLVMBinaryFormat.a libLLVMSupport.a libLLVMDemangle.a'
+else
+  llvmlibs=$(${MINGW_PREFIX}/bin/llvm-config --link-static --libnames engine coroutines 2>&1)
+fi
 
 # Get LLVM RTTI status
 rtti=false
-if [ $(${MINGW_PREFIX}/bin/llvm-config --has-rtti) = YES ]; then
+if [ $(${MINGW_PREFIX}/bin/llvm-config --has-rtti 2>&1) = YES ]; then
   rtti=true
 fi
 
-# Convert llvm-config output into a Python list
+# Convert llvm-config libraries list into a Python list
 llvmlibs="${llvmlibs//.a/}"
 llvmlibs=\'"${llvmlibs// /\', \'}"\'
 
@@ -23,17 +27,13 @@ cpp = meson.get_compiler('cpp')
 _deps = []
 _search = '$(cygpath -m ${MINGW_PREFIX})/lib'
 foreach d : [${llvmlibs}]
-  _deps += cpp.find_library(d, dirs : _search)
-endforeach
-_search2 = '$(cygpath -m ${MINGW_PREFIX})/bin'
-foreach d2 : ['libLLVM', 'libLTO', 'libRemarks']
-  _deps += cpp.find_library(d2, dirs : _search2)
+  _deps += cpp.find_library(d, dirs : _search, static : true)
 endforeach
 
 dep_llvm = declare_dependency(
   include_directories : include_directories('$(cygpath -m ${MINGW_PREFIX})/include'),
   dependencies : _deps,
-  version : '$(${MINGW_PREFIX}/bin/llvm-config --version)',
+  version : '$(/usr/bin/pacman -Q ${MINGW_PACKAGE_PREFIX}-llvm | cut -d" " -f 2 | cut -d"-" -f 1)',
 )
 
 has_rtti = ${rtti}


### PR DESCRIPTION
disabling LLVM shared linking.

Other changes:
- use Meson builtin options to pass compiler and linker flags for
symbols stripping and SSSE3 optimization respectively;
- made it possible to build mingw-w64-mesa when llvm config is known to be
broken.