### PR TITLE
New package: bootloadhid

### DIFF
--- a/mingw-w64-bootloadhid/PKGBUILD
+++ b/mingw-w64-bootloadhid/PKGBUILD
@@ -1,0 +1,39 @@
+# Maintainer: fauxpark <fauxpark@gmail.com>
+
+_realname=bootloadhid
+_realver=2012-12-08
+pkgbase=mingw-w64-${_realname}
+pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
+pkgver=${_realver//-/}
+pkgrel=1
+pkgdesc='HID-based USB bootloader for AVR microcontrollers (mingw-w64)'
+arch=('any')
+license=('GPL')
+url='https://www.obdev.at/products/vusb/bootloadhid.html'
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+source=(https://www.obdev.at/downloads/vusb/bootloadHID.${_realver}.tar.gz)
+sha256sums=('154e7e38629a3a2eec2df666edfa1ee2f2e9a57018f17d9f0f8f064cc20d8754')
+
+prepare() {
+  cd ${srcdir}/${_realname}.${_realver}/commandline
+
+  # Remove precompiled binary
+  rm BootloadHID.exe
+
+  # Strip "ddk/" prefix from hidpi.h and hidusage.h includes
+  sed -i "s/ddk\///g" hidsdi.h usb-windows.c
+  # Remove "-lusb" from Makefile.windows
+  sed -i "s/-lusb//g" Makefile.windows
+}
+
+build() {
+  cd ${srcdir}/${_realname}.${_realver}/commandline
+
+  make -f Makefile.windows
+}
+
+package() {
+  cd ${srcdir}/${_realname}.${_realver}/commandline
+
+  install -Dm755 bootloadHID ${pkgdir}${MINGW_PREFIX}/bin/bootloadHID
+}


### PR DESCRIPTION
https://www.obdev.at/products/vusb/bootloadhid.html

BootloadHID is a USB bootloader and accompanying flashing tool for Atmel AVR microcontrollers. It leverages the HID protocol to communicate, so there are no drivers or libraries necessary.