### PR TITLE
shiboken2-qt5: Resolve build failure 

### DIFF
--- a/mingw-w64-shiboken2-qt5/004-shiboken-apiextractor-header.patch
+++ b/mingw-w64-shiboken2-qt5/004-shiboken-apiextractor-header.patch
@@ -1,0 +1,20 @@
+--- a/sources/shiboken2/ApiExtractor/abstractmetabuilder.h	2018-06-12 06:53:26.000000000 +0900
++++ b/sources/shiboken2/ApiExtractor/abstractmetabuilder.h	2020-04-20 19:56:36.187412300 +0900
+@@ -31,6 +31,7 @@
+ 
+ #include "abstractmetalang_typedefs.h"
+ #include "dependency.h"
++#include <QtCore/QByteArrayList>
+ 
+ QT_FORWARD_DECLARE_CLASS(QIODevice)
+--- a/sources/shiboken2/ApiExtractor/clangparser/clangutils.h	2018-06-12 06:53:26.000000000 +0900
++++ b/sources/shiboken2/ApiExtractor/clangparser/clangutils.h	2020-04-20 20:24:08.085642500 +0900
+@@ -32,6 +32,7 @@
+ #include <clang-c/Index.h>
+ #include <QtCore/QPair>
+ #include <QtCore/QString>
++#include <QtCore/QStringList>
+ #include <QtCore/QVector>
+ 
+ QT_FORWARD_DECLARE_CLASS(QDebug)
+

--- a/mingw-w64-shiboken2-qt5/PKGBUILD
+++ b/mingw-w64-shiboken2-qt5/PKGBUILD
@@ -4,18 +4,20 @@ _realname=shiboken2
 pkgbase=mingw-w64-${_realname}-qt5
 pkgname=(${MINGW_PACKAGE_PREFIX}-${_realname}-qt5 ${MINGW_PACKAGE_PREFIX}-python{2,3}-${_realname}-qt5)
 pkgver=5.11.0
-pkgrel=1
+pkgrel=2
 arch=('any')
 url="https://doc-snapshots.qt.io/qtforpython/"
 license=("LGPL")
 source=(https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-${pkgver}-src/pyside-setup-everywhere-src-${pkgver}.tar.xz
         001-shiboken.patch
         002-cmake-relative-paths.patch
-        003-mingw-adjust-flags.patch)
+        003-mingw-adjust-flags.patch
+        004-shiboken-apiextractor-header.patch)
 sha256sums=('fbc412c4544bca308291a08a5173a949ca530d801f00b8337902a5067e490922'
             '7fbf1140d6c63b6c1a6f621b800654236dd5e8b0ff0bbd42c5e5940a51f0052d'
             'da64af18fbc52e34eed454287de01cecebf069354d2a206f172dad329065fdd6'
-            '3acdc6da5bc063256dce0ca31ed4dee2f35beb734792675a4c2bafdb2e365019')
+            '3acdc6da5bc063256dce0ca31ed4dee2f35beb734792675a4c2bafdb2e365019'
+            'cc5ae757975ce3908407789ae394d22b69fd0a00e48f70224a7584aba81d3bdb')
 makedepends=("${MINGW_PACKAGE_PREFIX}-clang"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-gcc"
@@ -31,6 +33,7 @@ prepare() {
   patch -p1 -i ${srcdir}/001-shiboken.patch
   patch -p1 -i ${srcdir}/002-cmake-relative-paths.patch
   patch -p1 -i ${srcdir}/003-mingw-adjust-flags.patch
+  patch -p1 -i ${srcdir}/004-shiboken-apiextractor-header.patch
 }
 
 build() {


### PR DESCRIPTION
## Overview

Resolve build failure of `mingw-w64-shiboken2-qt5` by merging this PR.
Fixed a reference error that occurred in ApiExtractor of shibouken2.

## Note

Ref #4507