### PR TITLE
catch: Update to 2.12.1

### DIFF
--- a/mingw-w64-catch/PKGBUILD
+++ b/mingw-w64-catch/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=catch
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.11.3
+pkgver=2.12.1
 pkgrel=1
 pkgdesc="Multi-paradigm automated test framework for C++ and Objective-C (mingw-w64)"
 arch=('any')
@@ -13,13 +13,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-python")
 license=('custom')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/catchorg/Catch2/archive/v${pkgver}.tar.gz)
-sha256sums=('9a6967138062688f04374698fce4ce65908f907d8c0fe5dfe8dc33126bd46543')
+sha256sums=('e5635c082282ea518a8dd7ee89796c8026af8ea9068cd7402fb1615deacd91c3')
 
 build() {
   rm -rf "${srcdir}/build-${MINGW_CHOST}"
   mkdir -p "${srcdir}/build-${MINGW_CHOST}"
   cd "${srcdir}/build-${MINGW_CHOST}"
-  
+
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe \
     -G"MSYS Makefiles" \
@@ -32,7 +32,7 @@ build() {
 
 check() {
   cd "${srcdir}/build-${MINGW_CHOST}"
-  ./SelfTest.exe
+  projects/SelfTest.exe
 }
 
 package() {


### PR DESCRIPTION
I can't say why the location of SelfText.exe changed, but it builds only with this change.