### PR TITLE
wxWidgets update to 3.0.5 and use builtin libraries in Static library build

### DIFF
--- a/mingw-w64-wxWidgets/PKGBUILD
+++ b/mingw-w64-wxWidgets/PKGBUILD
@@ -9,8 +9,8 @@ _wx_basever=3.0
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 provides=("${MINGW_PACKAGE_PREFIX}-wxmsw${_wx_basever}")
 pkgbase=mingw-w64-${_realname}
-pkgver=${_wx_basever}.4
-pkgrel=6
+pkgver=${_wx_basever}.5
+pkgrel=1
 pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX (mingw-w64)"
 arch=('any')
 license=("custom:wxWindows")
@@ -31,7 +31,7 @@ source=(https://github.com/wxWidgets/wxWidgets/releases/download/v${pkgver}/wxWi
         "001-wxWidgets-3.0.2-relocate-prefix-in-bin-wx-config.patch"
         "002-wxWidgets-3.0.2-relax-abi-compatibility-gcc.patch"
         "003-wxWidgets-3.0.2-fix-access-sample.patch")
-sha256sums=('96157f988d261b7368e5340afa1a0cad943768f35929c22841f62c25b17bf7f0'
+sha256sums=('8aacd56b462f42fb6e33b4d8f5d40be5abc3d3b41348ea968aa515cc8285d813'
             '7c3b8f6ba275a448a5e82d64c4914acd5aefb8bbb952389688f3e7167a787c56'
             '3138f7b84bf988892f62167afc6fa640ac154b629b243d86413f7c811e508713'
             'b8684dca94b288a023a8a3d55ad56bce87570576ead71670a237d909ff1c3625')

--- a/mingw-w64-wxWidgets/PKGBUILD
+++ b/mingw-w64-wxWidgets/PKGBUILD
@@ -10,7 +10,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 provides=("${MINGW_PACKAGE_PREFIX}-wxmsw${_wx_basever}")
 pkgbase=mingw-w64-${_realname}
 pkgver=${_wx_basever}.4
-pkgrel=5
+pkgrel=6
 pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX (mingw-w64)"
 arch=('any')
 license=("custom:wxWindows")
@@ -107,11 +107,11 @@ build() {
     --disable-precomp-headers \
     --with-msw \
     --with-opengl \
-    --with-libpng=sys \
-    --with-libjpeg=sys \
-    --with-libtiff=sys \
-    --with-zlib=sys \
-    --with-expat=sys \
+    --with-libpng=builtin \
+    --with-libjpeg=builtin \
+    --with-libtiff=builtin \
+    --with-zlib=builtin \
+    --with-expat=builtin \
     --with-regex=builtin
 
   make #VERBOSE=1


### PR DESCRIPTION
See [wxSVG: Cannot Link Statically](https://github.com/msys2/MINGW-packages/issues/5601) for reason for using builtin library. This does not fix that issue; but, should help with that issue.

Tim S.
