### PR TITLE
wxWidgets3.1: Fix passing of C/CXXFLAGS

### DIFF
--- a/mingw-w64-wxWidgets3.1/PKGBUILD
+++ b/mingw-w64-wxWidgets3.1/PKGBUILD
@@ -19,7 +19,7 @@ _wx_buildver=
 pkgbase=mingw-w64-${_basename}${_wx_basever}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}${_wx_basever}"
 pkgver=${_wx_basever}.3
-pkgrel=1
+pkgrel=2
 pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX (mingw-w64)"
 arch=('any')
 url="https://wxwidgets.org/"
@@ -98,13 +98,21 @@ build() {
   #   --disable-mediactrl
   ####
 
+case ${MINGW_CHOST} in
+  i686*)
+    _march=i686
+  ;;
+  x86_64*)
+    _march=x86-64
+  ;;
+esac
+
 # Remove the -O and -g options to avoid configuration warnings
 # from the normal settings found in /etc/makepkg_mingw??.conf
   unset CFLAGS
   unset CXXFLAGS
-  CFLAGS="-march=${CARCH} -mtune=generic -pipe"
-  CXXFLAGS="-march=${CARCH} -mtune=generic -pipe"
-  #echo "CXXFLAGS := ${CXXFLAGS}"
+  CFLAGS="-march=${_march} -mtune=generic -pipe"
+  CXXFLAGS="-march=${_march} -mtune=generic -pipe"
 
   local -a _debug_options=()
 
@@ -117,11 +125,14 @@ build() {
     _debug_options+=("--enable-debug=yes")
   fi
 
+  #echo "CXXFLAGS := ${CXXFLAGS}"
   #echo "_debug_options := ${_debug_options[@]}"
 
   [[ -d "${srcdir}"/build-${CARCH}-shared ]] && rm -rf "${srcdir}"/build-${CARCH}-shared
   mkdir -p "${srcdir}"/build-${CARCH}-shared && cd "${srcdir}"/build-${CARCH}-shared
 
+  CFLAGS="$CFLAGS" \
+  CXXFLAGS="$CXXFLAGS" \
   ../${_basename}-${pkgver}${_wx_buildver}/configure \
     --prefix=${MINGW_PREFIX} \
     --host=${MINGW_CHOST} \
@@ -131,7 +142,7 @@ build() {
     --enable-shared \
     --enable-std_string \
     --enable-iff \
-    --enable-permissive \
+    --disable-permissive \
     --enable-unicode \
     --enable-graphics_ctx \
     --enable-accessibility \
@@ -151,6 +162,8 @@ build() {
   [[ -d "${srcdir}"/build-${CARCH}-static ]] && rm -rf "${srcdir}"/build-${CARCH}-static
   mkdir -p "${srcdir}"/build-${CARCH}-static && cd "${srcdir}"/build-${CARCH}-static
 
+  CFLAGS="$CFLAGS" \
+  CXXFLAGS="$CXXFLAGS" \
   ../${_basename}-${pkgver}${_wx_buildver}/configure \
     --prefix=${MINGW_PREFIX} \
     --host=${MINGW_CHOST} \
@@ -160,7 +173,7 @@ build() {
     --disable-shared \
     --enable-std_string \
     --enable-iff \
-    --enable-permissive \
+    --disable-permissive \
     --enable-unicode \
     --enable-graphics_ctx \
     --enable-accessibility \
@@ -169,9 +182,11 @@ build() {
     --with-msw \
     --with-cxx=14 \
     --with-opengl \
-    --with-libpng=sys \
-    --with-libjpeg=sys \
-    --with-libtiff=sys \
+    --with-libpng=builtin \
+    --with-libjpeg=builtin \
+    --with-libtiff=builtin \
+    --with-zlib=builtin \
+    --with-expat=builtin \
     --with-regex=builtin
 
   make #VERBOSE=1 -j1


### PR DESCRIPTION
When static build use builtin support libraries.
Also, change to disable-permissive

Tim S.