### PR TITLE
gdcm: fix build with poppler 0.87

### DIFF
--- a/mingw-w64-gdcm/0006-fix-build-with-poppler.patch
+++ b/mingw-w64-gdcm/0006-fix-build-with-poppler.patch
@@ -1,0 +1,122 @@
+From be7d49cf3d13eafffdba801ba30e1c98202843a8 Mon Sep 17 00:00:00 2001
+From: Mathieu Malaterre <mathieu.malaterre@gmail.com>
+Date: Mon, 27 Apr 2020 14:07:15 +0000
+Subject: [PATCH] Update gdcminfo for new poppler. Fixes #500
+
+- Add LIBPOPPLER_UNICODEMAP_HAS_CONSTMAPUNICODE
+- Add LIBPOPPLER_GLOBALPARAMS_HAS_RESET
+
+Thanks to Darcy (hot123tea123-users.sourceforge.net) for inspiration. Turns out the original patch is from Even Rouault :
+
+* https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=cafa6007bf77dd0cd210ed9aeecd9e47053a9223
+---
+ Applications/Cxx/CMakeLists.txt | 13 +++++++++++++
+ Applications/Cxx/gdcminfo.cxx   | 12 ++++++++++++
+ Applications/Cxx/gdcmpdf.cxx    | 12 ++++++++++++
+ 3 files changed, 37 insertions(+)
+
+diff --git a/Applications/Cxx/CMakeLists.txt b/Applications/Cxx/CMakeLists.txt
+index af799930b..820745295 100644
+--- a/Applications/Cxx/CMakeLists.txt
++++ b/Applications/Cxx/CMakeLists.txt
+@@ -72,6 +72,13 @@ if(GDCM_USE_SYSTEM_POPPLER)
+   if(LIBPOPPLER_GLOBALPARAMS_CSTOR_HAS_PARAM)
+     list(APPEND libpoppler_flags -DLIBPOPPLER_GLOBALPARAMS_CSTOR_HAS_PARAM)
+   endif()
++  CHECK_CXX_SOURCE_COMPILES(
++    "\#include <poppler/GlobalParams.h>\nint main() { globalParams.reset( new GlobalParams()); return 0;}"
++    LIBPOPPLER_GLOBALPARAMS_HAS_RESET)
++  set(libpoppler_flags)
++  if(LIBPOPPLER_GLOBALPARAMS_HAS_RESET)
++    list(APPEND libpoppler_flags -DLIBPOPPLER_GLOBALPARAMS_HAS_RESET)
++  endif()
+   CHECK_CXX_SOURCE_COMPILES(
+     "\#include <poppler/PDFDoc.h>\nint main() { PDFDoc d((GooString*)NULL,(GooString*)NULL,(GooString*)NULL); d.getPDFVersion(); return 0;}"
+     LIBPOPPLER_PDFDOC_HAS_PDFVERSION)
+@@ -102,6 +109,12 @@ if(GDCM_USE_SYSTEM_POPPLER)
+   if(LIBPOPPLER_GOOSTRING_HAS_GETCSTRING)
+     list(APPEND libpoppler_flags -DLIBPOPPLER_GOOSTRING_HAS_GETCSTRING)
+   endif()
++  CHECK_CXX_SOURCE_COMPILES(
++          "\#include <poppler/UnicodeMap.h>\nint main() {  Unicode u; char buf[8]; const UnicodeMap *uMap; uMap->mapUnicode(u, buf, sizeof(buf)); return 0; }"
++    LIBPOPPLER_UNICODEMAP_HAS_CONSTMAPUNICODE)
++  if(LIBPOPPLER_UNICODEMAP_HAS_CONSTMAPUNICODE)
++    list(APPEND libpoppler_flags -DLIBPOPPLER_UNICODEMAP_HAS_CONSTMAPUNICODE)
++  endif()
+   if(libpoppler_flags)
+     string(REPLACE ";" " " libpoppler_flags_string "${libpoppler_flags}")
+     set_source_files_properties(
+diff --git a/Applications/Cxx/gdcminfo.cxx b/Applications/Cxx/gdcminfo.cxx
+index bef80248e..a134e9487 100644
+--- a/Applications/Cxx/gdcminfo.cxx
++++ b/Applications/Cxx/gdcminfo.cxx
+@@ -258,7 +258,11 @@ static std::string getInfoDate(Dict *infoDict, const char *key)
+   return out;
+ }
+ 
++#ifdef LIBPOPPLER_UNICODEMAP_HAS_CONSTMAPUNICODE
++static std::string getInfoString(Dict *infoDict, const char *key, const UnicodeMap *uMap)
++#else
+ static std::string getInfoString(Dict *infoDict, const char *key, UnicodeMap *uMap)
++#endif
+ {
+   Object obj;
+ #ifdef LIBPOPPLER_GOOSTRING_HAS_CONSTGETCHAR
+@@ -509,11 +513,19 @@ static int ProcessOneFile( std::string const & filename, gdcm::Defs const & defs
+     std::string creationdate;
+     std::string moddate;
+ 
++#ifdef LIBPOPPLER_UNICODEMAP_HAS_CONSTMAPUNICODE
++    const UnicodeMap *uMap;
++#else
+     UnicodeMap *uMap;
++#endif
+ #ifdef LIBPOPPLER_GLOBALPARAMS_CSTOR_HAS_PARAM
+     globalParams = new GlobalParams(0);
++#else
++#ifdef LIBPOPPLER_GLOBALPARAMS_HAS_RESET
++    globalParams.reset(new GlobalParams());
+ #else
+     globalParams = new GlobalParams();
++#endif
+ #endif
+     uMap = globalParams->getTextEncoding();
+ 
+diff --git a/Applications/Cxx/gdcmpdf.cxx b/Applications/Cxx/gdcmpdf.cxx
+index 4d97d81e0..59ca77a28 100644
+--- a/Applications/Cxx/gdcmpdf.cxx
++++ b/Applications/Cxx/gdcmpdf.cxx
+@@ -106,7 +106,11 @@ static std::string getInfoDate(Dict *infoDict, const char *key)
+   return out;
+ }
+ 
++#ifdef LIBPOPPLER_UNICODEMAP_HAS_CONSTMAPUNICODE
++static std::string getInfoString(Dict *infoDict, const char *key, const UnicodeMap *uMap, bool & unicode)
++#else
+ static std::string getInfoString(Dict *infoDict, const char *key, UnicodeMap *uMap, bool & unicode)
++#endif
+ {
+   Object obj;
+ #ifdef LIBPOPPLER_GOOSTRING_HAS_CONSTGETCHAR
+@@ -333,13 +337,21 @@ int main (int argc, char *argv[])
+   GooString *fileName;
+   PDFDoc *doc;
+   Object info;
++#ifdef LIBPOPPLER_UNICODEMAP_HAS_CONSTMAPUNICODE
++  const UnicodeMap *uMap;
++#else
+   UnicodeMap *uMap;
++#endif
+   ownerPW = NULL;
+   userPW = NULL;
+ #ifdef LIBPOPPLER_GLOBALPARAMS_CSTOR_HAS_PARAM
+   globalParams = new GlobalParams(0);
++#else
++#ifdef LIBPOPPLER_GLOBALPARAMS_HAS_RESET
++  globalParams.reset(new GlobalParams());
+ #else
+   globalParams = new GlobalParams();
++#endif
+ #endif
+   uMap = globalParams->getTextEncoding();
+ 

--- a/mingw-w64-gdcm/PKGBUILD
+++ b/mingw-w64-gdcm/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gdcm
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.0.5
-pkgrel=4
+pkgrel=5
 pkgdesc="The Grassroots DICOM library (mingw-w64)"
 arch=('any')
 url="https://gdcm.sourceforge.io/wiki/index.php"
@@ -21,23 +21,27 @@ depends=("${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-docbook-xsl"
              "${MINGW_PACKAGE_PREFIX}-cmake")
 options=('staticlibs' 'strip')
 source=(#"https://downloads.sourceforge.net/project/gdcm/gdcm%202.x/GDCM%20${pkgver}/gdcm-${pkgver}.tar.bz2"
         gdcm-${pkgver}.tar.gz::https://github.com/malaterre/GDCM/archive/v${pkgver}.tar.gz
         0002-cmake-config-destination.patch
         0004-fix-find-openssl.patch
-        0005-fix-cross-initializing.patch)
+        0005-fix-cross-initializing.patch
+        0006-fix-build-with-poppler.patch::https://github.com/malaterre/GDCM/commit/be7d49cf3d13eafffdba801ba30e1c98202843a8.patch)
 sha256sums=('5cc175d9b845db91143f972e505680e766ab814a147b16abbb34acd88dacdb5a'
             '70b1f693e381f4d8e725db7a71df79f2803809cc7b0ac90ea41b1f3c6238c945'
             '77645101ea8425c601fb0717630b334c8a4ced3ea7f3625c11d338c56529e5fb'
-            '018b083e74091776afaef9894fcb1c7554b36828f162bc4c9b2ea2a6b154b159')
+            '018b083e74091776afaef9894fcb1c7554b36828f162bc4c9b2ea2a6b154b159'
+            '9f6d6d3167fe40ccda4d03edc5d6f9a36ea121a25994b3620b2d91a2bf188d88')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   patch -p1 -i ${srcdir}/0002-cmake-config-destination.patch
   patch -p1 -i ${srcdir}/0004-fix-find-openssl.patch
   patch -p1 -i ${srcdir}/0005-fix-cross-initializing.patch
+  patch -p1 -i ${srcdir}/0006-fix-build-with-poppler.patch
 }
 
 build() {
@@ -75,7 +79,7 @@ build() {
     -DGDCM_DOCUMENTATION=OFF \
     -DGDCM_USE_VTK=OFF \
     -DGDCM_USE_PARAVIEW=OFF \
-    -DGDCM_BUILD_APPLICATIONS=OFF \
+    -DGDCM_BUILD_APPLICATIONS=ON \
     ../${_realname}-${pkgver}
   make
 
@@ -113,7 +117,7 @@ build() {
     -DGDCM_DOCUMENTATION=OFF \
     -DGDCM_USE_VTK=OFF \
     -DGDCM_USE_PARAVIEW=OFF \
-    -DGDCM_BUILD_APPLICATIONS=OFF \
+    -DGDCM_BUILD_APPLICATIONS=ON \
     ../${_realname}-${pkgver}
   make
 }

--- a/mingw-w64-gdcm/PKGBUILD
+++ b/mingw-w64-gdcm/PKGBUILD
@@ -29,7 +29,7 @@ source=(#"https://downloads.sourceforge.net/project/gdcm/gdcm%202.x/GDCM%20${pkg
         0002-cmake-config-destination.patch
         0004-fix-find-openssl.patch
         0005-fix-cross-initializing.patch
-        0006-fix-build-with-poppler.patch::https://github.com/malaterre/GDCM/commit/be7d49cf3d13eafffdba801ba30e1c98202843a8.patch)
+        0006-fix-build-with-poppler.patch)
 sha256sums=('5cc175d9b845db91143f972e505680e766ab814a147b16abbb34acd88dacdb5a'
             '70b1f693e381f4d8e725db7a71df79f2803809cc7b0ac90ea41b1f3c6238c945'
             '77645101ea8425c601fb0717630b334c8a4ced3ea7f3625c11d338c56529e5fb'


### PR DESCRIPTION
1. apply this https://github.com/malaterre/GDCM/commit/be7d49cf3d13eafffdba801ba30e1c98202843a8 to build with `poppler 0.87`
2. add `docbook-xsl` to `makedepends` for building manpages
3. set `GDCM_BUILD_APPLICATIONS=ON` to build gdcm applications