### PR TITLE
asio: Update to 1.16.1

### DIFF
--- a/mingw-w64-asio/PKGBUILD
+++ b/mingw-w64-asio/PKGBUILD
@@ -3,19 +3,19 @@
 _realname=asio
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.14.0
+pkgver=1.16.1
 pkgrel=1
 pkgdesc='Cross-platform C++ library for ASynchronous network I/O (mingw-w64)'
 url='https://think-async.com/Asio/'
 arch=('any')
 license=('custom:boost')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-boost"
+             #"${MINGW_PACKAGE_PREFIX}-boost"
              "${MINGW_PACKAGE_PREFIX}-openssl")
 _realver=${pkgver//./-}
 _realpath=${_realname}-${_realname}-${_realver}
 source=("${_realpath}.tar.gz::https://github.com/chriskohlhoff/${_realname}/archive/${_realname}-${_realver}.tar.gz")
-sha256sums=('bdb01a649c24d73ca4a836662e7af442d935313ed6deef6b07f17f3bc5f78d7a')
+sha256sums=('e40bbd531530f08318b7c7d7e84e457176d8eae6f5ad2e3714dc27b9131ecd35')
 
 prepare() {
   cd ${srcdir}/${_realpath}/${_realname}/
@@ -30,7 +30,7 @@ build() {
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
-    --with-boost=yes \
+    --with-boost=no \
     --with-openssl=yes
 
   make


### PR DESCRIPTION
Compiling with `boost` disabled because it is default behavior.
For integration with `boost` we have asio library in `boost` package.