### PR TITLE
wxWidgets3.1: When static build use builtin support libraries.

### DIFF
--- a/mingw-w64-wxWidgets3.1/PKGBUILD
+++ b/mingw-w64-wxWidgets3.1/PKGBUILD
@@ -19,7 +19,7 @@ _wx_buildver=
 pkgbase=mingw-w64-${_basename}${_wx_basever}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}${_wx_basever}"
 pkgver=${_wx_basever}.3
-pkgrel=1
+pkgrel=2
 pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX (mingw-w64)"
 arch=('any')
 url="https://wxwidgets.org/"
@@ -98,14 +98,6 @@ build() {
   #   --disable-mediactrl
   ####
 
-# Remove the -O and -g options to avoid configuration warnings
-# from the normal settings found in /etc/makepkg_mingw??.conf
-  unset CFLAGS
-  unset CXXFLAGS
-  CFLAGS="-march=${CARCH} -mtune=generic -pipe"
-  CXXFLAGS="-march=${CARCH} -mtune=generic -pipe"
-  #echo "CXXFLAGS := ${CXXFLAGS}"
-
   local -a _debug_options=()
 
   if check_option "debug" "y"; then
@@ -131,7 +123,7 @@ build() {
     --enable-shared \
     --enable-std_string \
     --enable-iff \
-    --enable-permissive \
+    --disable-permissive \
     --enable-unicode \
     --enable-graphics_ctx \
     --enable-accessibility \
@@ -160,7 +152,7 @@ build() {
     --disable-shared \
     --enable-std_string \
     --enable-iff \
-    --enable-permissive \
+    --disable-permissive \
     --enable-unicode \
     --enable-graphics_ctx \
     --enable-accessibility \
@@ -169,9 +161,11 @@ build() {
     --with-msw \
     --with-cxx=14 \
     --with-opengl \
-    --with-libpng=sys \
-    --with-libjpeg=sys \
-    --with-libtiff=sys \
+    --with-libpng=builtin \
+    --with-libjpeg=builtin \
+    --with-libtiff=builtin \
+    --with-zlib=builtin \
+    --with-expat=builtin \
     --with-regex=builtin
 
   make #VERBOSE=1 -j1


### PR DESCRIPTION
Also, change to disable-permissive in configure.
And, remove the local C/CXXFLAGS; this did not work well enough for
production package.