### PR TITLE
itk: update to 5.1.0 and fix build with gdcm

### DIFF
--- a/mingw-w64-itk/PKGBUILD
+++ b/mingw-w64-itk/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=itk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=5.0.1
+pkgver=5.1.0
 pkgrel=1
 pkgdesc='An open-source C++ toolkit for medical image processing (mingw-w64)'
 arch=('any')
@@ -25,7 +25,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 optdepends=("${MINGW_PACKAGE_PREFIX}-opencv: ITK-OpenCV bridge"
             "${MINGW_PACKAGE_PREFIX}-vtk: ITK-VTK bridge")
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/InsightSoftwareConsortium/ITK/archive/v${pkgver}.tar.gz")
-sha256sums=('c6b3c33ecc73104c906e0e1a1bfaa41a09af24bf53a4ec5e5c265d7e82bdf69f')
+sha256sums=('7cd0849f8f6769de8c5e90dd4de019a2c4b447d907b5d2193a95a3ec6267e76d')
 
 build() {
   CFLAGS+=" ${CPPFLAGS}"
@@ -44,8 +44,6 @@ build() {
   [[ -d "${srcdir}/build-${CARCH}" ]] && rm -rf "${srcdir}/build-${CARCH}"
   mkdir -p "${srcdir}/build-${CARCH}" && cd "${srcdir}/build-${CARCH}"
 
-  GDCM_INCLUDE_DIRS=${MINGW_PREFIX}/include/gdcm-2.8 \
-  GDCM_LIBRARY_DIRS=${MINGW_PREFIX}/lib \
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   "${MINGW_PREFIX}/bin/cmake.exe" \
     -G"MSYS Makefiles" \
@@ -62,7 +60,6 @@ build() {
     -DITK_USE_SYSTEM_FFTW=ON \
     -DUSE_FFTWD=ON \
     -DUSE_FFTWF=ON \
-    -DITK_USE_SYSTEM_GDCM=OFF \
     -DITK_USE_SYSTEM_HDF5=ON \
     -DITK_USE_SYSTEM_JPEG=ON \
     -DITK_USE_SYSTEM_PNG=ON \
@@ -81,7 +78,7 @@ build() {
 
 package() {
   cd "${srcdir}/build-${CARCH}"
-  make DESTDIR=${pkgdir} -j1 install
+  make DESTDIR=${pkgdir} install
 
   local PREFIX_DEPS=$(cygpath -am ${MINGW_PREFIX})
 


### PR DESCRIPTION
1. update itk to 5.1.0
2. set `ITK_USE_SYSTEM_GDCM=ON`

see also https://github.com/msys2/MINGW-packages/issues/6449