### PR TITLE
gcc-git: Add patch for libgomp

### DIFF
--- a/mingw-w64-gcc-git/0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
+++ b/mingw-w64-gcc-git/0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
@@ -1,0 +1,53 @@
+From 05b0bb43124b041da360ba9adcbaab8430be6d18 Mon Sep 17 00:00:00 2001
+From: Liu Hao <lh_mouse@126.com>
+Date: Wed, 6 May 2020 21:49:18 +0800
+Subject: [PATCH] libgomp: Don't hard-code MS printf attributes
+
+---
+ libgomp/libgomp.h | 13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/libgomp/libgomp.h b/libgomp/libgomp.h
+index c98c1452bd4..0cc8443f6c2 100644
+--- a/libgomp/libgomp.h
++++ b/libgomp/libgomp.h
+@@ -69,6 +69,13 @@
+ # endif
+ #endif
+ 
++#include <stdio.h>
++#ifdef __MINGW_PRINTF_FORMAT
++#define PRINTF_FORMAT __MINGW_PRINTF_FORMAT
++#else
++#define PRINTF_FORMAT printf
++#endif
++
+ #ifdef HAVE_ATTRIBUTE_VISIBILITY
+ # pragma GCC visibility push(hidden)
+ #endif
+@@ -110,7 +117,7 @@ extern void gomp_aligned_free (void *);
+ 
+ extern void gomp_vdebug (int, const char *, va_list);
+ extern void gomp_debug (int, const char *, ...)
+-	__attribute__ ((format (printf, 2, 3)));
++	__attribute__ ((format (PRINTF_FORMAT, 2, 3)));
+ #define gomp_vdebug(KIND, FMT, VALIST) \
+   do { \
+     if (__builtin_expect (gomp_debug_var, 0)) \
+@@ -123,11 +130,11 @@ extern void gomp_debug (int, const char *, ...)
+   } while (0)
+ extern void gomp_verror (const char *, va_list);
+ extern void gomp_error (const char *, ...)
+-	__attribute__ ((format (printf, 1, 2)));
++	__attribute__ ((format (PRINTF_FORMAT, 1, 2)));
+ extern void gomp_vfatal (const char *, va_list)
+ 	__attribute__ ((noreturn));
+ extern void gomp_fatal (const char *, ...)
+-	__attribute__ ((noreturn, format (printf, 1, 2)));
++	__attribute__ ((noreturn, format (PRINTF_FORMAT, 1, 2)));
+ 
+ struct gomp_task;
+ struct gomp_taskgroup;
+-- 
+2.26.2
+

--- a/mingw-w64-gcc-git/PKGBUILD
+++ b/mingw-w64-gcc-git/PKGBUILD
@@ -62,7 +62,8 @@ source=(${_sourcedir}::"git://gcc.gnu.org/git/gcc.git#branch=${_branch}"
         "0016-gcc-7-branch-disable-weak-refs-in-libstdc++.patch"
         "0017-gcc-7-branch-Enable-std-experimental-filesystem.patch"
         "0018-gcc-7-branch-Enable-a-native-GCC-to-color-diagnostic-messages-sen.patch"
-        "0019-gcc-8-branch-Backport-patches-for-std-filesystem-from-master.patch")
+        "0019-gcc-8-branch-Backport-patches-for-std-filesystem-from-master.patch"
+        "0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch")
 sha256sums=('SKIP'
             '83e9c6f76f728ae3e2f2eabb588b0d6cea7a3eda03cd5e77aed9d613143b7348'
             '6033acda690786397059536787a6577e1a9f2b39f8a66276821917066094f43c'
@@ -78,7 +79,8 @@ sha256sums=('SKIP'
             'c1e271c166de0062092cb61d50977c0e61d75b0ae6fb086cb8bb4da2b3fd18d7'
             'b1c3c20bf501cebbcb02b4a50f117a4f90eb4fb79eac7aa99c85e2c54c106790'
             '33392651e17b81609718873ff32606deee5f3fc5176c197bb96eedc3dada8912'
-            'bf83cbc79de4c86f02664c8a624e26b12f570e3c31116fc7c46ecf655696f9a6')
+            'bf83cbc79de4c86f02664c8a624e26b12f570e3c31116fc7c46ecf655696f9a6'
+            '2331365b6d42250d83eba36a1ef1a02e56b81a7c2595df6a43cb1a6abbcb99f0')
 
 _threads="posix"
 _git_base_commit=
@@ -118,6 +120,7 @@ prepare() {
   if [ "${_branch}" == "releases/gcc-8" ]; then
     ${GIT_AM} ${srcdir}/0019-gcc-8-branch-Backport-patches-for-std-filesystem-from-master.patch
   fi
+  ${GIT_AM} ${srcdir}/0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
 
   # do not expect $prefix/mingw symlink - this should be superceded by
   # 0004-Windows-Don-t-ignore-native-system-header-dir.patch .. but isn't!


### PR DESCRIPTION
Note there are a lot of other printf attributes that might need fixing.
But as they don't cause builds to fail, I decide to leave them alone.

Reference: https://gcc.gnu.org/pipermail/gcc-help/2020-May/138869.html
Signed-off-by: Liu Hao <lh_mouse@126.com>