### PR TITLE
meson: Fix has_function() returning false positives with GCC 10

### DIFF
--- a/mingw-w64-meson/0001-Fix-builtin-check-in-has_function-with-GCC-10-on-Win.patch
+++ b/mingw-w64-meson/0001-Fix-builtin-check-in-has_function-with-GCC-10-on-Win.patch
@@ -1,0 +1,32 @@
+diff --git a/mesonbuild/compilers/mixins/clike.py b/mesonbuild/compilers/mixins/clike.py
+index 322364b95..10bce20e4 100644
+--- a/mesonbuild/compilers/mixins/clike.py
++++ b/mesonbuild/compilers/mixins/clike.py
+@@ -729,21 +729,17 @@ class CLikeCompiler:
+         fargs['no_includes'] = '#include' not in prefix
+         t = '''{prefix}
+         int main(void) {{
++
++        #if !{no_includes:d} && !defined({func})
++            #error "No definition for __builtin_{func} found in the prefix"
++        #endif
++
+         #ifdef __has_builtin
+             #if !__has_builtin(__builtin_{func})
+                 #error "__builtin_{func} not found"
+             #endif
+         #elif ! defined({func})
+-            /* Check for __builtin_{func} only if no includes were added to the
+-             * prefix above, which means no definition of {func} can be found.
+-             * We would always check for this, but we get false positives on
+-             * MSYS2 if we do. Their toolchain is broken, but we can at least
+-             * give them a workaround. */
+-            #if {no_includes:d}
+-                __builtin_{func};
+-            #else
+-                #error "No definition for __builtin_{func} found in the prefix"
+-            #endif
++            __builtin_{func};
+         #endif
+         return 0;
+         }}'''

--- a/mingw-w64-meson/PKGBUILD
+++ b/mingw-w64-meson/PKGBUILD
@@ -4,7 +4,7 @@ _realname=meson
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.54.1
-pkgrel=1
+pkgrel=2
 pkgdesc="High-productivity build system (mingw-w64)"
 arch=('any')
 url="https://mesonbuild.com/"
@@ -15,11 +15,13 @@ depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-ninja")
 source=("https://github.com/mesonbuild/${_realname}/releases/download/${pkgver}/${_realname}-${pkgver}.tar.gz"
         'color-term.patch'
+        '0001-Fix-builtin-check-in-has_function-with-GCC-10-on-Win.patch'
         '0002-Default-to-sys.prefix-as-the-default-prefix.patch'
         '0003-Strip-the-prefix-from-all-paths-when-installing-with.patch'
         'install-man.patch')
 sha256sums=('2f76fb4572762be13ee479292610091b4509af5788bcceb391fe222bcd0296dc'
             '5805aed0a117536eb16dd8eef978c6be57c2471b655ede63e25517c28b4f4cf0'
+            'a02c48983bdea3b2427100454a671fb7c7c8a60ae4e68ba623d0a1e1ee896204'
             '363182db7e7059526353278966aa4704e8a26cbaf7c3b7dc5d6e4f01692a40e6'
             '2093c617cf3146a4cea601e7c73400d8ec5fd52ac5cf642c4f5af2d6493b1cb1'
             '0682a36cb75e545a78b81293303835a16171f25baf949905dc08029436efff84')
@@ -28,6 +30,8 @@ prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
   patch -Np1 -i "${srcdir}"/color-term.patch
+  # https://github.com/mesonbuild/meson/pull/7116
+  patch -Np1 -i "${srcdir}"/0001-Fix-builtin-check-in-has_function-with-GCC-10-on-Win.patch
   patch -Np1 -i "${srcdir}"/0002-Default-to-sys.prefix-as-the-default-prefix.patch
   patch -Np1 -i "${srcdir}"/0003-Strip-the-prefix-from-all-paths-when-installing-with.patch
   patch -Np1 -i "${srcdir}"/install-man.patch


### PR DESCRIPTION
GCC 10 now provides __has_builtin() which leads to meson to skipping
a required mingw workaround.

See https://github.com/mesonbuild/meson/pull/7116 for a version of
this for meson master.

This fixes for example the glib build.