### PR TITLE
tepl: remove vala from makedepends

### DIFF
--- a/mingw-w64-tepl/PKGBUILD
+++ b/mingw-w64-tepl/PKGBUILD
@@ -4,7 +4,7 @@ _realname=tepl
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}4"
 pkgver=4.4.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Library that eases the development of GtkSourceView-based text editors and IDEs (mingw-w64)"
 arch=('any')
 url="https://wiki.gnome.org/Projects/Tepl"
@@ -13,7 +13,6 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-gtk-doc"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
-             "${MINGW_PACKAGE_PREFIX}-vala"
              "autoconf-archive")
 depends=("${MINGW_PACKAGE_PREFIX}-amtk"
          "${MINGW_PACKAGE_PREFIX}-gtksourceview4"


### PR DESCRIPTION
A *.vapi file is not generated by the Tepl library. Only the GIR
(GObject Introspection) is generated, which Vala can also use.