### PR TITLE
appstream-glib: remove gtk2 dependency

### DIFF
--- a/mingw-w64-appstream-glib/PKGBUILD
+++ b/mingw-w64-appstream-glib/PKGBUILD
@@ -4,12 +4,11 @@ _realname=appstream-glib
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.7.17
-pkgrel=2
+pkgrel=3
 arch=('any')
 pkgdesc="Objects and methods for reading and writing AppStream metadata (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-gdk-pixbuf2"
          "${MINGW_PACKAGE_PREFIX}-glib2"
-         "${MINGW_PACKAGE_PREFIX}-gtk2"
          "${MINGW_PACKAGE_PREFIX}-gtk3"
          "${MINGW_PACKAGE_PREFIX}-json-glib"
          "${MINGW_PACKAGE_PREFIX}-libyaml"


### PR DESCRIPTION
Not needed normally, there is already the gtk3 dependency.

The Arch Linux package does not have the gtk2 dep either, only the gtk3
dep:
https://www.archlinux.org/packages/extra/x86_64/appstream-glib/