### PR TITLE
glib: Add pacman hooks for gio-querymodules and glib-compile-schemas

### DIFF
--- a/mingw-w64-glib2/0002-disable_glib_compile_schemas_warning.patch
+++ b/mingw-w64-glib2/0002-disable_glib_compile_schemas_warning.patch
@@ -1,0 +1,36 @@
+From: Iain Lane <iain.lane@canonical.com>
+Date: Mon, 10 Sep 2012 16:25:18 +0100
+Subject: Disable confusing (to users) warning about deprecated schema paths
+
+Disable a warning when compiling schemas which are installed
+into 'deprecated' locations. Users see this very often due to
+glib-compile-schemas being called from libglib2.0-0's trigger and it is
+not very useful for them.
+
+Forwarded: not-needed
+---
+ gio/glib-compile-schemas.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/gio/glib-compile-schemas.c b/gio/glib-compile-schemas.c
+index 7888120..4c4d22e 100644
+--- a/gio/glib-compile-schemas.c
++++ b/gio/glib-compile-schemas.c
+@@ -1232,6 +1232,9 @@ parse_state_start_schema (ParseState  *state,
+       return;
+     }
+ 
++  // Disable this warning: it confuses users and there is unlikely to be much
++  // progress towards fixing
++  /*
+   if (path && (g_str_has_prefix (path, "/apps/") ||
+                g_str_has_prefix (path, "/desktop/") ||
+                g_str_has_prefix (path, "/system/")))
+@@ -1244,6 +1247,7 @@ parse_state_start_schema (ParseState  *state,
+       g_printerr ("%s\n", message);
+       g_free (message);
+     }
++    */
+ 
+   state->schema_state = schema_state_new (path, gettext_domain,
+                                           extends, extends_name, list_of);

--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -29,6 +29,7 @@ source=("https://download.gnome.org/sources/glib/${pkgver%.*}/glib-${pkgver}.tar
         0001-disable-some-tests-when-static.patch
         glib-compile-schemas.hook.in
         gio-querymodules.hook.in
+        0002-disable_glib_compile_schemas_warning.patch
         pyscript2exe.py)
 sha256sums=('9a2f21ed8f13b9303399de13a0252b7cbcede593d26971378ec6cb90e87f2277'
             '51d02360a1ee978fd45e77b84bca9cfbcf080d91986b5c0efe0732779c6a54ec'
@@ -36,6 +37,7 @@ sha256sums=('9a2f21ed8f13b9303399de13a0252b7cbcede593d26971378ec6cb90e87f2277'
             '0f44135a139e3951c4b5fa7d4628d75226e0666d891faf524777e1d1ec3b440b'
             '0c3d54636407e0e13429b73959cace626253cd772e1d4870de0fb92b0b99545a'
             'f18d27d98709dba8c5f9756672baaf0158fb4353c9edbdc2e80021f88ff34ced'
+            '396c25cfd740ffbb72209133c7b9453173167577265a4bb14502678de8d5a8f9'
             '00e03a8b9d45e620c6fabbf96f5ccb41d1e49cc9b35ccb846d423f235ad5bec6')
 
 prepare() {
@@ -44,6 +46,7 @@ prepare() {
   patch -Np1 -i "${srcdir}"/0001-Update-g_fopen-g_open-and-g_creat-to-open-with-FILE_.patch
   patch -Np1 -i "${srcdir}"/0001-win32-Make-the-static-build-work-with-MinGW-when-pos.patch
   patch -Np1 -i "${srcdir}"/0001-disable-some-tests-when-static.patch
+  patch -Np1 -i "${srcdir}"/0002-disable_glib_compile_schemas_warning.patch
 }
 
 build() {

--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -7,7 +7,7 @@ _realname=glib2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.64.2
-pkgrel=1
+pkgrel=2
 url="https://www.gtk.org/"
 arch=('any')
 pkgdesc="Common C routines used by GTK+ 2.4 and other libs (mingw-w64)"
@@ -27,11 +27,15 @@ source=("https://download.gnome.org/sources/glib/${pkgver%.*}/glib-${pkgver}.tar
         0001-Update-g_fopen-g_open-and-g_creat-to-open-with-FILE_.patch
         0001-win32-Make-the-static-build-work-with-MinGW-when-pos.patch
         0001-disable-some-tests-when-static.patch
+        glib-compile-schemas.hook.in
+        gio-querymodules.hook.in
         pyscript2exe.py)
 sha256sums=('9a2f21ed8f13b9303399de13a0252b7cbcede593d26971378ec6cb90e87f2277'
             '51d02360a1ee978fd45e77b84bca9cfbcf080d91986b5c0efe0732779c6a54ec'
             '1e3ac7cfd4644f3849704e54fcfbb12d15440a33cd5c2d014d4a479c6aaab185'
             '0f44135a139e3951c4b5fa7d4628d75226e0666d891faf524777e1d1ec3b440b'
+            '0c3d54636407e0e13429b73959cace626253cd772e1d4870de0fb92b0b99545a'
+            'f18d27d98709dba8c5f9756672baaf0158fb4353c9edbdc2e80021f88ff34ced'
             '00e03a8b9d45e620c6fabbf96f5ccb41d1e49cc9b35ccb846d423f235ad5bec6')
 
 prepare() {
@@ -75,6 +79,14 @@ package() {
 
   cd "${srcdir}/build-${CARCH}-shared"
   DESTDIR="${pkgdir}${MINGW_PREFIX}" ninja install
+
+  for hook in glib-compile-schemas gio-querymodules; do
+    local hook_path="${srcdir}/${MINGW_PACKAGE_PREFIX}-${hook}.hook";
+    cp "${srcdir}/${hook}.hook.in" "${hook_path}"
+    sed -s "s|@MINGW_HOOK_TARGET_PREFIX@|${MINGW_PREFIX:1}|g" -i "${hook_path}"
+    sed -s "s|@MINGW_PREFIX@|${MINGW_PREFIX}|g" -i "${hook_path}"
+    install -Dt "$pkgdir/usr/share/libalpm/hooks" -m644 "${hook_path}"
+  done
 
   install -Dm644 "${srcdir}/glib-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 

--- a/mingw-w64-glib2/gio-querymodules.hook.in
+++ b/mingw-w64-glib2/gio-querymodules.hook.in
@@ -1,0 +1,11 @@
+[Trigger]
+Type = Path
+Operation = Install
+Operation = Upgrade
+Operation = Remove
+Target = @MINGW_HOOK_TARGET_PREFIX@/lib/gio/modules/*.dll
+
+[Action]
+Description = Updating GIO module cache...
+When = PostTransaction
+Exec = @MINGW_PREFIX@/bin/gio-querymodules.exe @MINGW_PREFIX@/lib/gio/modules

--- a/mingw-w64-glib2/glib-compile-schemas.hook.in
+++ b/mingw-w64-glib2/glib-compile-schemas.hook.in
@@ -1,0 +1,12 @@
+[Trigger]
+Type = Path
+Operation = Install
+Operation = Upgrade
+Operation = Remove
+Target = @MINGW_HOOK_TARGET_PREFIX@/share/glib-2.0/schemas/*.gschema.xml
+Target = @MINGW_HOOK_TARGET_PREFIX@/share/glib-2.0/schemas/*.gschema.override
+
+[Action]
+Description = Compiling GSettings XML schema files...
+When = PostTransaction
+Exec = @MINGW_PREFIX@/bin/glib-compile-schemas.exe @MINGW_PREFIX@/share/glib-2.0/schemas

--- a/mingw-w64-glib2/glib2-i686.install
+++ b/mingw-w64-glib2/glib2-i686.install
@@ -1,5 +1,4 @@
 post_install() {
-  mingw32/bin/glib-compile-schemas.exe mingw32/share/glib-2.0/schemas
   cd mingw32
   local _prefix=$(pwd -W)
   cd -

--- a/mingw-w64-glib2/glib2-x86_64.install
+++ b/mingw-w64-glib2/glib2-x86_64.install
@@ -1,5 +1,4 @@
 post_install() {
-  mingw64/bin/glib-compile-schemas.exe mingw64/share/glib-2.0/schemas
   cd mingw64
   local _prefix=$(pwd -W)
   cd -


### PR DESCRIPTION
This means we can remove all glib-compile-schemas install scripts in other
packages.

Also silences some annoying deprecation warnings like other distros while at it.