### PR TITLE
libarchive: update to version 3.4.3

### DIFF
--- a/mingw-w64-libarchive/PKGBUILD
+++ b/mingw-w64-libarchive/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=libarchive
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.4.2
-pkgrel=3
+pkgver=3.4.3
+pkgrel=1
 pkgdesc="Multi-format archive and compression library (mingw-w64)"
 arch=('any')
 url="https://www.libarchive.org/"
@@ -22,9 +22,9 @@ depends=(${MINGW_PACKAGE_PREFIX}-gcc-libs
          ${MINGW_PACKAGE_PREFIX}-zlib
          ${MINGW_PACKAGE_PREFIX}-zstd)
 options=('!libtool' 'strip')
-source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/libarchive/libarchive/archive/v${pkgver}.tar.gz"
+source=("${_realname}-${pkgver}.tar.gz"::"https://libarchive.org/downloads/${_realname}-${pkgver}.tar.gz"
         "0001-libarchive-3.3.3-bcrypt-fix.patch")
-sha256sums=('ce926cea1195b53ee0868020c00f8c98ecf15497856b79c85430749634827f80'
+sha256sums=('ee1e749213c108cb60d53147f18c31a73d6717d7e3d2481c157e1b34c881ea39'
             '2c318a025029998a9389eb99ab80f733c0fcf3b4888421879f2f6b4530d7f522')
 
 prepare() {
@@ -44,6 +44,11 @@ build() {
     --without-xml2 \
     --without-lzo2
   make
+}
+
+check() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make check
 }
 
 package() {


### PR DESCRIPTION
This was released a couple days ago.
This PR also adds a check to run the standard test ssuite  with make check 

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>