### PR TITLE
Fix Boost::locale compilation to use ICU backend

### DIFF
--- a/mingw-w64-boost/PKGBUILD
+++ b/mingw-w64-boost/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.73.0
 _boostver=${pkgver//./_}
-pkgrel=3
+pkgrel=4
 pkgdesc="Free peer-reviewed portable C++ source libraries (mingw-w64)"
 arch=('any')
 url="https://www.boost.org/"
@@ -114,7 +114,7 @@ prepare() {
   msg2 "boost-1.73.0-context-gas_mingw_symbols.patch"
   patch -p1 -i ${srcdir}/boost-1.73.0-context-gas_mingw_symbols.patch  
   
-  # Fix Boost::locale compilation to ise ICU backend
+  # Fix Boost::locale compilation to use ICU backend
   msg2 "boost-1.73.0-fix-locale-icu.patch"
   patch -p1 -i ${srcdir}/boost-1.73.0-fix-locale-icu.patch
 }

--- a/mingw-w64-boost/PKGBUILD
+++ b/mingw-w64-boost/PKGBUILD
@@ -32,6 +32,7 @@ source=(#https://downloads.sourceforge.net/sourceforge/boost/boost_${_boostver}.
         boost-1.69-old-style-names-layout.patch
         boost-1.70.0-fix-python-install.patch
         boost-1.73.0-context-gas_mingw_symbols.patch
+        boost-1.73.0-fix-locale-icu.patch 
         using-mingw-w64-python.patch
         msys2-mingw-folders-bootstrap.patch)
 sha256sums=('4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402'
@@ -48,6 +49,7 @@ sha256sums=('4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402'
             'c2508e60bed41471b396875e0289b4b1d4e021f3d01f4294615c72fcd8567439'
             '21d039cf867a41253f752c5f04f0cdb2ec86f17ad88459918b326fa48e9c1e05'
             'bb84f3c7fc4b856c2bc2dc5c385152905c51ba8bffffa9371370c41168d55fcc'
+            '5ef2b1011dc960b7f55d4da89bcd75418eb696dce677b9fd0c78632f4109e7d3'
             '0dd6346d369850aad13bf8d9bc2f0abc16d4b0586e34d61fab11f65d3d7fa9d4'
             '5117629ee577de0da800b6923675683ba69422cdbe958e70c9081fdc6886402e')
 
@@ -110,7 +112,11 @@ prepare() {
 
   # Correct GAS naming for MinGW
   msg2 "boost-1.73.0-context-gas_mingw_symbols.patch"
-  patch -p1 -i ${srcdir}/boost-1.73.0-context-gas_mingw_symbols.patch
+  patch -p1 -i ${srcdir}/boost-1.73.0-context-gas_mingw_symbols.patch  
+  
+  # Fix Boost::locale compilation to ise ICU backend
+  msg2 "boost-1.73.0-fix-locale-icu.patch"
+  patch -p1 -i ${srcdir}/boost-1.73.0-fix-locale-icu.patch
 }
 
 build() {
@@ -161,6 +167,7 @@ build() {
     --no-cmake-config \
     -sHAVE_ICU=1 \
     -sICU_PATH=${MINGW_PREFIX} \
+    -sICU_LINK="-L${MINGW_PREFIX}/lib -licuuc -licuin -licudt" \
     -sICU_ICUUC_NAME=icuuc \
     -sICU_ICUDT_NAME=icudt \
     -sICU_ICUIN_NAME=icuin \
@@ -211,6 +218,7 @@ package() {
       --without-mpi \
       --no-cmake-config \
       -sHAVE_ICU=1 \
+      -sICU_LINK="-L${MINGW_PREFIX}/lib -licuuc -licuin -licudt" \
       -sICU_PATH=${MINGW_PREFIX} \
       -sICU_ICUUC_NAME=icuuc \
       -sICU_ICUDT_NAME=icudt \

--- a/mingw-w64-boost/boost-1.73.0-fix-locale-icu.patch
+++ b/mingw-w64-boost/boost-1.73.0-fix-locale-icu.patch
@@ -1,0 +1,14 @@
+--- boost_1_73_0/libs/regex/build/Jamfile.v2.orig	2020-04-22 16:35:55.000000000 +0300
++++ boost_1_73_0/libs/regex/build/Jamfile.v2	2020-05-24 16:51:35.262191700 +0300
+@@ -33,11 +33,6 @@
+ #
+ if ! $(disable-icu)
+ {
+-   if [ modules.peek : ICU_LINK ]
+-   {    
+-       errors.user-error : "The ICU_LINK option is no longer supported by the Boost.Regex build - please refer to the documentation for equivalent options" ;
+-   }
+-
+    if [ modules.peek : ICU_PATH ]
+    {    
+        ICU_PATH =  [ modules.peek : ICU_PATH ] ;


### PR DESCRIPTION

Fixes #6183. 

Looks like boost::locale and boost::regex ICU configurations are in conflict. So, fix to compile  boost::regex with ICU ([99ffbce](https://github.com/msys2/MINGW-packages/commit/99ffbce6bffe1eed97a9429368ad286a8e717ad9)) broke boost::locale usage of ICU. 

Build variables ICU_ICUUC_NAME, ICU_ICUDT_NAME and ICU_ICUIN_NAME are honored by boost::regex but ignored by boost::locale (see libs/regex/build/Jamfile.v2 and libs/locale/build/Jamfile.v2). ICU_LINK is used by boost::locale but setting it leads to error in boost::regex. 

Though more general fix would be to modify boost::locale Jamfile, working with boost build is a daunting task (at last for me). So I have used minimal approach -- disabled error on defined	 ICU_LINK in boost::regex (and checked that this variable is really unused by the library) and re-added ICU_LINK variable for boost::locale.