### PR TITLE
mingw-w64-mesa: Don't binary wrap and autodetect runtime dependency at the same time when linking LLVM

### DIFF
--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -4,7 +4,7 @@ _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=20.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Open-source implementation of the OpenGL specification (mingw-w64)"
 arch=('any')
 makedepends=("${MINGW_PACKAGE_PREFIX}-llvm"
@@ -67,7 +67,7 @@ prepare() {
 # Run and optionally test LLVM Meson wrap generator.
 # Change nollvmconfig value to 1 if you know llvm-config is broken.
 
-  nollvmconfig=0 ${srcdir}/llvmwrapgen.sh
+# nollvmconfig=0 ${srcdir}/llvmwrapgen.sh
 # /bin/cat ${srcdir}/${_realname}-${pkgver}/subprojects/llvm/meson.build
 }
 


### PR DESCRIPTION
Use runtime dependency autodetection as it's working properly now.

Dependencies wrappping precedence can change even between point releases
in Meson, as seen in 0.54.1 when Meson was using binary wraps and now in
0.54.2 it used runtime dependency autodetection and the way build is
configured hasn't changed since then.

Because both runtime dependency autodetection and binary wrap methods link
the gigantic mingw-w64-llvm statically and didn't add it as dependency,
we don't need to rebuild mesa.