### PR TITLE
 * ngraph-gtk: new upstream release (version 6.08.05).

### DIFF
--- a/mingw-w64-ngraph-gtk/PKGBUILD
+++ b/mingw-w64-ngraph-gtk/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=ngraph-gtk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=6.08.04
+pkgver=6.08.05
 pkgrel=1
 arch=('any')
 pkgdesc="create scientific 2-dimensional graphs (mingw-w64)"
@@ -22,7 +22,7 @@ options=('strip' 'staticlibs')
 license=("GPL")
 url="https://htrb.github.io/ngraph-gtk/"
 source=("https://github.com/htrb/ngraph-gtk/releases/download/v${pkgver}/ngraph-gtk-${pkgver}.tar.gz")
-sha256sums=("632ba3bdaa874e9133da7535398626fb575d5df056f4cf6d5b42e70230c47702")
+sha256sums=("f151f816b2d3382054408bac1bc378be9f5c7f60a6fdfe9b3f4fe840745c3f27")
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}


### PR DESCRIPTION
new upstream release (version 6.08.05).