### PR TITLE
lcms2: Force new build for re-release

### DIFF
--- a/mingw-w64-lcms2/PKGBUILD
+++ b/mingw-w64-lcms2/PKGBUILD
@@ -4,7 +4,7 @@ _realname=lcms2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.10
-pkgrel=1
+pkgrel=2
 pkgdesc="Small-footprint color management engine, version 2 (mingw-w64)"
 arch=('any')
 url="http://www.littlecms.com"
@@ -12,8 +12,8 @@ license=("MIT")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-libtiff")
 options=('staticlibs' 'strip')
-source=("https://downloads.sourceforge.net/sourceforge/lcms/lcms2-${pkgver}.tar.gz")
-sha256sums=('e11bc4e538587ec1530f9fef25f77261b94d5886c5ea81d8bb171a802df970ad')
+source=("https://downloads.sourceforge.net/sourceforge/lcms/lcms2-${pkgver}_no_docs.tar.gz")
+sha256sums=('72e16d64dc1d2634727606888366845913c938fbdee77d8ae2c9901b61d319cb')
 
 prepare() {
   cd ${_realname}-$pkgver


### PR DESCRIPTION
Fixes a regression, re-released as same version, see https://github.com/mm2/Little-CMS/issues/219

Also use a newly provided smaller tarball w/o PDF docs