### PR TITLE
[RFC] add GitHub Actions workflow(s)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,43 @@
+name: 'build'
+
+on:
+  push:
+  schedule:
+    - cron: '0 0/4 * * *'
+
+jobs:
+
+  build:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - uses: msys2/setup-msys2@v1
+      with:
+        msystem: MSYS
+        update: true
+        cache: true
+        install: base-devel git python python-pip mingw-w64-x86_64-toolchain mingw-w64-i686-toolchain
+
+    - name: Process build queue
+      run: |
+        mkdir artifacts
+        python -m pip install pytest pytest-timeout
+        python -m pytest -v -s -ra buildqueue.py --timeout=18000
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: artifacts/*
+
+    - name: Upload packages to stagging
+      run: echo "PLACEHOLDER"
+      #uses: eine/tip@master
+      #with:
+      #  token: ${{ secrets.GITHUB_TOKEN }}
+      #  tag: 'stagging'
+      #  rm: false
+      #  files: *.pkg.zst

--- a/buildqueue.py
+++ b/buildqueue.py
@@ -1,0 +1,37 @@
+from urllib.request import urlopen
+from json import loads
+from pathlib import Path
+from subprocess import check_call
+from sys import stdout
+
+PKGEXT='.pkg.tar.zst'
+SRCEXT='.src.tar.gz'
+
+ROOT = Path(__file__).resolve().parent
+
+def test_file(pkg):
+    print('\n::group::Package %s...' % pkg)
+    stdout.flush()
+
+    def run_cmd(args):
+        check_call(['bash'] + args, cwd=str(ROOT/pkg))
+
+    try:
+        run_cmd(['makepkg-mingw', '--noconfirm', '--noprogressbar', '--skippgpcheck', '--nocheck', '--syncdeps', '--rmdeps', '--cleanbuild'])
+        run_cmd(['makepkg', '--noconfirm', '--noprogressbar', '--skippgpcheck', '--allsource', '--config', '/etc/makepkg_mingw64.conf'])
+        run_cmd(['mv', '*%s' % PKGEXT, '*%s' % SRCEXT, '../artifacts/'])
+        print('::endgroup::')
+        stdout.flush()
+        return 0
+    except:
+        print('::endgroup::')
+        stdout.flush()
+        return 1
+
+def pytest_generate_tests(metafunc):
+    pkgs = [
+        pkg['repo_path']
+        for pkg in loads(urlopen("https://packages.msys2.org/api/buildqueue").read())
+        if pkg['repo_url'] == 'https://github.com/msys2/MINGW-packages'
+    ]
+    metafunc.parametrize("pkg", pkgs)


### PR DESCRIPTION
This PR is currently a placeholder to discuss using GitHub Actions workflows in this and/or other repositories of the org. After reading [Off-load package building and uploading](https://github.com/msys2/msys2.github.io/blob/source/docs/wiki/Devtopics.md#off-load-package-building-and-uploading) I'd like to note the following points:

- Execution time limit for each job in GitHub Actions is 6h (unlike AppVeyor or Travis, where it is 50-90 min).
- GitHub Actions allows to execute up to 20 workflows/jobs at the same time.
- GitHub Actions are not limited to "plain CI testing", but can have tight integration with GitHub's API (both for triggering workflows and for interacting with it from within the workflows). Default Actions are written in JavaScript/TypeScript, but any language which can be packaged in a Docker container is suitable for jobs run on Linux.
- It is possible to cross-trigger workflows, within the same repo or between repos.

---

The first proposal in this PR is 'build'. It is an scheduled (CRON) job that is executed every 6 hours. The idea is to retrieve lists of pending tasks from [packages.msys2.org/new](https://packages.msys2.org/new) or [packages.msys2.org/queue](https://packages.msys2.org/queue) or [packages.msys2.org/outofdate](https://packages.msys2.org/outofdate). After each task is successfully completed, resulting packages can be pushed to an stagging area. I assume that 'Stagging' would be a new section in packages.msys2.org. Regarding where to store the packages/artifacts/assets for stagging, an alternative to using some external service is to use a GitHub pre-release. It can be done with [eine/tip](https://github.com/eine/tip).

Hopefully, such an approach would allow maintainers to focus on downloading and testing pre-built packages, instead of them building the packages manually.

Regarding packages that take longer than 6h, or other which cannot be built for any other reason, I think that the workflow can have exceptions. Those packages will be kept in the New Queue, Outdated or Update Queue. Alternatively, GitHub Action's caching features can be used to build a sequence of jobs.

Hence, although this proposal is not a complete solution yet, I believe it can help reduce most of the manual work.

---

The second proposal is to have a 'PR' workflow. As the name suggests, this is to test specific PRs and it is similar current Azure or AppVeyor services. In fact, I believe that GitHub Actions workflows are executed on Azure under-the-hood. Updating 'Stagging' packages from PR workflows is an optional feature. If the previous workflow is added, I believe that PRs should not push packages to stagging. However, it is also possible to only add this workflow.

---

Overall, I'd like to ask whether scripts exist already which can be used in place of the `echo "PLACEHOLDER"` commands in this PR.

---

[eine/setup-msys2](https://github.com/eine/setup-msys2) is used to set up MSYS2 in the workflows. See [msys2/msys2-installer#5](https://github.com/msys2/msys2-installer/issues/5#issuecomment-635495897).

/cc @Alexpux @elieux @lazka @Diablo-D3