### PR TITLE
Update aom and libheif

### DIFF
--- a/mingw-w64-aom/PKGBUILD
+++ b/mingw-w64-aom/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=aom
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.0.0
+pkgver=2.0.0
 pkgrel=1
 pkgdesc='AV1 codec library(mingw-w64)'
 arch=('any')
@@ -15,9 +15,18 @@ makedepends=("perl" "git"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-yasm"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-python3")
-source=("git+https://aomedia.googlesource.com/aom#tag=v${pkgver}")
-sha256sums=('SKIP')
+source=("git+https://aomedia.googlesource.com/aom#tag=v${pkgver}"
+        "fix-lib-dest.patch")
+sha256sums=('SKIP'
+            '3a202005676f91b2b5ee5d7c10792f1930b204f36a96d7d5b893ef81d375b19d')
+
+prepare() {
+  cd "${srcdir}/${_realname}"
+
+  patch -Np1 -i "${srcdir}"/fix-lib-dest.patch
+}
 
 build() {
   [[ -d ${srcdir}/build-${CARCH} ]] && rm -rf ${srcdir}/build-${CARCH}
@@ -25,18 +34,21 @@ build() {
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake \
-    -G"MSYS Makefiles" \
+    -G Ninja \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DBUILD_SHARED_LIBS=1 \
     -DENABLE_TESTS=OFF \
     ../${_realname}
 
-  make
+  ${MINGW_PREFIX}/bin/cmake --build .
 }
 
 package() {
   cd ${srcdir}/build-${CARCH}
-  make DESTDIR="${pkgdir}" install
+
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --build . --target install
+
   install -Dm644 ${srcdir}/${_realname}/LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
   install -Dm644 ${srcdir}/${_realname}/PATENTS ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/PATENTS
 }

--- a/mingw-w64-aom/fix-lib-dest.patch
+++ b/mingw-w64-aom/fix-lib-dest.patch
@@ -1,0 +1,14 @@
+diff --git a/build/cmake/aom_install.cmake b/build/cmake/aom_install.cmake
+index cd40fe4245..71d625fb27 100644
+--- a/build/cmake/aom_install.cmake
++++ b/build/cmake/aom_install.cmake
+@@ -86,7 +86,8 @@ macro(setup_aom_install_targets)
+       FILES "${AOM_PKG_CONFIG_FILE}"
+       DESTINATION "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+     install(TARGETS ${AOM_INSTALL_LIBS} DESTINATION
+-                    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
++                    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
++                    RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}")
+ 
+     if(ENABLE_EXAMPLES)
+       install(TARGETS ${AOM_INSTALL_BINS} DESTINATION

--- a/mingw-w64-libheif/PKGBUILD
+++ b/mingw-w64-libheif/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=libheif
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.6.2
-pkgrel=2
+pkgver=1.7.0
+pkgrel=1
 pkgdesc="HEIF image decoder/encoder library and tools (mingw-w64)"
 arch=('any')
 url="https://github.com/strukturag/libheif"
@@ -15,12 +15,13 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libde265"
          "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
          "${MINGW_PACKAGE_PREFIX}-libpng"
+         "${MINGW_PACKAGE_PREFIX}-aom"
          "${MINGW_PACKAGE_PREFIX}-libwinpthread-git"
          "${MINGW_PACKAGE_PREFIX}-x265")
 options=('strip')
 source=("https://github.com/strukturag/libheif/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz"
         001-fix-pkgconfig-provide-includedir.patch)
-sha256sums=('bb229e855621deb374f61bee95c4642f60c2a2496bded35df3d3c42cc6d8eefc'
+sha256sums=('842a9ab4b8d6f0faf5a6dc5e8507321199ec44c0b1d8eb199f2de9b49e2db092'
             'b782444a8f2c3f23c3b57e6e0a25ebe1313656aeeb72fad2335b1c6ee4b90a0b')
 
 prepare() {


### PR DESCRIPTION
aom now provides shared libs and libheif links against them.

I also switch cmake to ninja, seems to work fine.