### PR TITLE
python: build with --enable-loadable-sqlite-extensions

### DIFF
--- a/mingw-w64-python/PKGBUILD
+++ b/mingw-w64-python/PKGBUILD
@@ -18,7 +18,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 _pybasever=3.8
 pkgver=${_pybasever}.3
-pkgrel=1
+pkgrel=2
 provides=("${MINGW_PACKAGE_PREFIX}-python3=${pkgver}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3"
            "${MINGW_PACKAGE_PREFIX}-python2<2.7.16-7")
@@ -397,6 +397,7 @@ build() {
     --with-system-ffi \
     --with-system-libmpdec \
     --without-ensurepip \
+    --enable-loadable-sqlite-extensions \
     "${_extra_config[@]}" \
     OPT=""
 
@@ -569,4 +570,4 @@ sha256sums=('dfab5ec723c218082fe3d5d7ae17ecbdebffa9a1aea4d64aa3a2ecdd2e795864'
             'f6ecf2edc9468210111d77e396853af49cb8a43d9bc0d20212f88cf2bc33685d'
             '6efc39323d14239f2a55576a8b3f32cb79eeefdd5881ba813493c14be2939f3c'
             '24151631c3e70306ae92ffb8fea38992a752cd0a76771a5e53445f56c2be1f00'
-            '6b535c53435ebed57e6f519429bd4ff845d1651e5a080e6f0517307cb45c5da7')
+            'e5312ed2b5b93cdb842d3e341f2f1171fc6ade11659533fe9b2289a5bd4a5519')

--- a/mingw-w64-python/smoketests.py
+++ b/mingw-w64-python/smoketests.py
@@ -101,6 +101,11 @@ class Tests(unittest.TestCase):
         # This should be able to execute without exceptions
         sysconfig.get_config_vars()
 
+    def test_sqlite_enable_load_extension(self):
+        # Make sure --enable-loadable-sqlite-extensions is used
+        import sqlite3
+        self.assertTrue(sqlite3.Connection.enable_load_extension)
+
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)


### PR DESCRIPTION
our sqlite has this feature enabled, and the official CPython is
also built this ways.

See https://docs.python.org/3.9/library/sqlite3.html#f1

Fixes #6592