### PR TITLE
ci: add name to 'main' GHA workflow, update shields/badges

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+name: main
+
+on:
+  push:
+  pull_request:
 
 jobs:
   build:
@@ -12,22 +16,20 @@ jobs:
           - msystem: MINGW32
             msystem_lower: mingw32
             arch: i686
+    defaults:
+      run:
+        shell: msys2 {0}
+
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
-      - name: setup-msys2
-        uses: msys2/setup-msys2@v1
+      - uses: msys2/setup-msys2@v1
         with:
           msystem: ${{ matrix.msystem }}
           install: git base-devel mingw-w64-${{ matrix.arch }}-toolchain
           update: true
 
       - name: CI-Build
-        env:
-          MINGW_INSTALLS: ${{ matrix.msystem_lower }}
-        shell: msys2 {0}
-        run: |
-          ./ci-build.sh
+        run: MINGW_INSTALLS=${{ matrix.msystem_lower }} ./ci-build.sh

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
+<p align="center">
+  <a title="msys2.github.io" href="https://msys2.github.io"><img src="https://img.shields.io/website.svg?label=msys2.github.io&longCache=true&style=flat-square&url=http%3A%2F%2Fmsys2.github.io%2Findex.html&logo=github"></a><!--
+  -->
+  <a title="Join the chat at https://gitter.im/msys2/msys2" href="https://gitter.im/msys2/msys2"><img src="https://img.shields.io/badge/chat-on%20gitter-4db797.svg?longCache=true&style=flat-square&logo=gitter&logoColor=e8ecef"></a><!--
+  -->
+  <a title="GitHub Actions" href="https://github.com/msys2/MINGW-packages/actions?query=workflow%3Amain"><img alt="'main' workflow Status" src="https://img.shields.io/github/workflow/status/msys2/MINGW-packages/main?longCache=true&style=flat-square&label=build&logo=github"></a><!--
+  -->
+  <a title="AppVeyor" href="https://ci.appveyor.com/project/Alexpux/mingw-packages"><img src="https://img.shields.io/appveyor/ci/Alexpux/mingw-packages/master.svg?logo=appveyor&logoColor=e8ecef&style=flat-square"></a><!--
+  -->
+  <a title="Azure DevOps" href="https://dev.azure.com/msys2/mingw/_build/latest?definitionId=4&branchName=master"><img src="https://img.shields.io/azure-devops/build/msys2/5ee43462-f2c2-45d5-8c1c-31fdb1fd15b4/4/master?style=flat-square&logo=azure-pipelines"></a><!--
+  -->
+</p>
+
 # MINGW-packages
-
-
-[![Gitter chat][1]][2]&nbsp;&nbsp;
-[![AppVeyor status][3]][4]&nbsp;&nbsp;
-[![Azure status][5]][6]&nbsp;&nbsp;
-
-[1]: https://badges.gitter.im/msys2/msys2.png
-[2]: https://gitter.im/msys2/msys2
-[3]: https://ci.appveyor.com/api/projects/status/github/Alexpux/mingw-packages?branch=master&svg=true
-[4]: https://ci.appveyor.com/project/Alexpux/mingw-packages
-[5]: https://dev.azure.com/msys2/mingw/_apis/build/status/msys2.MINGW-packages?branchName=master&svg=true
-[6]: https://dev.azure.com/msys2/mingw/_build/latest?definitionId=4&branchName=master
-
 
 This repository contains package scripts for MinGW-w64 targets to build under MSYS2.
 


### PR DESCRIPTION
Coming from https://github.com/msys2/MSYS2-packages/commit/dc1a2957f4018d9a95f8a8b80219b92f103758fb#r40206293:

- Name `main` is added to workflow `main.yml`.
- The workflow is slightly simplified.
- A shield is added to the README, which references the name of the workflow.
- Other shields are updated to use the same source and style.
- Shields are shown centered above the title of the README.