### PR TITLE
gnucobol: update to 3.1 rc1

### DIFF
--- a/mingw-w64-gnucobol/PKGBUILD
+++ b/mingw-w64-gnucobol/PKGBUILD
@@ -5,9 +5,9 @@
 _realname=gnucobol
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-pkgver=3.0rc1
-pkgver_real=3.0-rc1
-pkgrel=2
+pkgver=3.1rc1
+pkgver_real=3.1-rc1
+pkgrel=1
 pkgdesc="GnuCOBOL, a free and modern COBOL compiler (mingw-w64)"
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-svn" "${MINGW_PACKAGE_PREFIX}-gnu-cobol-svn")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-svn" "${MINGW_PACKAGE_PREFIX}-gnu-cobol-svn")
@@ -29,15 +29,16 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc"
 source=("https://alpha.gnu.org/gnu/${_realname}/${_realname}-${pkgver_real}.tar.xz"{,.sig}
         "001-mingw-gnucobol-2.2-fixformatwarnings.patch"
         "cobenv.sh" "cobenv.cmd")
-sha256sums=('BF76441EE7F8DC9AEB78291231F32273EAFC4EC827F26840846A257A04BBC594'
+sha256sums=('C2E41C2BA520681A67C570D7246D25C31F7F55C8A145AAEC3F6273A500A93A76'
             SKIP
             '3FBFDAF61EB6EC125258DE62B404C97BF6DCCF39BD3B9152510F794B5383CA33'
-            'E55ED37EA93DFB7911B4CAD7F9F45422D831092668991120EA0CD0BCF79605AC'
-            '37F0848BCC386179D24986D17102F318AAF534D25682A09969B349916B56726B')
+            'EEDFC170CFD6606527DD701C3CF6BBA2029C33CE694F697F8B7EE527B4ED7F1C'
+            '225F7F6E17FC125AF6348028FDB86278C990BEAB07D230A158D9B9373CD58506')
 
 prepare() {
   cd "${_realname}-${pkgver_real}"
-  patch -Np1 -i ${srcdir}/001-mingw-gnucobol-2.2-fixformatwarnings.patch
+  # disabled patch for now, doesn't seem useful any moe
+  # patch -Np1 -i ${srcdir}/001-mingw-gnucobol-2.2-fixformatwarnings.patch
 }
 
 build() {
@@ -58,6 +59,7 @@ build() {
     --disable-static
     #  --> as using the static libcob would be the builtin default,
     #      all generated COBOL modules would be GPLed (and big)...
+    #      ... and only work when all linked together
 
   #make -j1
   make "--jobs=$(($(nproc)+1))"


### PR DESCRIPTION
additional:
* fixed sha256sums that were broken because of the http->https change in c213366c9e787c9698a7f405a579cb7043b41f2b
* disabled applying the formatwarning patch, seems to be not necessary any more