### PR TITLE
gtk3: add patch from GIMP project (ported for gtk3)

### DIFF
--- a/mingw-w64-gtk3/0006_fix_mouse_events.patch
+++ b/mingw-w64-gtk3/0006_fix_mouse_events.patch
@@ -1,0 +1,49 @@
+From 8972d6e0b2c6d6afa5a1128641127fe66d0f159b Mon Sep 17 00:00:00 2001
+From: Patrick Storz <eduard.braun2@gmx.de>
+Date: Thu, 9 Jul 2020 18:13:02 +0200
+Subject: [PATCH] Add patch from GIMP project
+
+This prevents transparent top-level windows from intercepting mouse
+events as often the case with screen capturing software, see
+https://bugzilla.gnome.org/show_bug.cgi?id=780979
+---
+ gdk/win32/gdkdevice-win32.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/gdk/win32/gdkdevice-win32.c b/gdk/win32/gdkdevice-win32.c
+index 190372de2d..3d89290b25 100644
+--- a/gdk/win32/gdkdevice-win32.c
++++ b/gdk/win32/gdkdevice-win32.c
+@@ -214,6 +214,10 @@ _gdk_device_win32_window_at_position (GdkDevice       *device,
+        * WindowFromPoint() can find our windows, we follow similar logic
+        * here, and ignore invisible and disabled windows.
+        */
++       UINT cwp_flags = CWP_SKIPDISABLED  |
++                        CWP_SKIPINVISIBLE |
++                        CWP_SKIPTRANSPARENT;
++
+       hwnd = GetDesktopWindow ();
+       do {
+         window = gdk_win32_handle_table_lookup (hwnd);
+@@ -224,8 +228,7 @@ _gdk_device_win32_window_at_position (GdkDevice       *device,
+           break;
+ 
+         screen_to_client (hwnd, screen_pt, &client_pt);
+-        hwndc = ChildWindowFromPointEx (hwnd, client_pt, CWP_SKIPDISABLED  |
+-                                                         CWP_SKIPINVISIBLE);
++        hwndc = ChildWindowFromPointEx (hwnd, client_pt, cwp_flags);
+ 
+ 	/* Verify that we're really inside the client area of the window */
+ 	if (hwndc != hwnd)
+@@ -236,6 +239,8 @@ _gdk_device_win32_window_at_position (GdkDevice       *device,
+ 	      hwndc = hwnd;
+ 	  }
+ 
++        /* Only ignore top-level transparent windows */
++        cwp_flags &= ~CWP_SKIPTRANSPARENT;
+       } while (hwndc != hwnd && (hwnd = hwndc, 1));
+ 
+     }
+-- 
+2.25.1.windows.1
+

--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gtk3
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.24.20
-pkgrel=2
+pkgrel=3
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
 url="https://www.gtk.org/"
@@ -32,6 +32,7 @@ source=("https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}.tar
         "0003-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch"
         "0004-Disable-low-level-keyboard-hook.patch"
         "0005-fix-build.patch"
+        "0006_fix_mouse_events.patch"
         "gtk-query-immodules-3.0.hook.in"
         "gtk-update-icon-cache.hook.in"
         "gtk-update-icon-cache.script.in")
@@ -40,6 +41,7 @@ sha256sums=('2dac69f716e8d04ba7a95091589e2baaec95dcace932cb15839163db479b1df3'
             'b84a7f38f0af80680bee143d431f2a7bae53899efb337de0f67a1b4d9b59fa02'
             'e553083298495f9581ae1454b1046a22b83e81862311b30de984057eec859708'
             '233a1238913034a538b6ab495d06f2f2045fc72b749e337d99b932f7eaddec42'
+            'ae048aa0674124217e26e7a3041e2aa34cea89b1e36534c97448d841687a035d'
             'adbe57eb726d882bba7a031ab8fb1788e7cd03cbf713823fd0f99d3cb380b97c'
             '56a566739c4f153f3c924b2bfe5ec7aaca469e15c023810cd7c5f57036d1a258'
             'b6306c6e117e879a60febc8e398a5a181325255a2e2c785c77222664b683f9dd')
@@ -56,6 +58,8 @@ prepare() {
   patch -p1 -i "${srcdir}"/0004-Disable-low-level-keyboard-hook.patch
 
   patch -p1 -i "${srcdir}"/0005-fix-build.patch
+
+  patch -p1 -i "${srcdir}"/0006_fix_mouse_events.patch
 }
 
 build() {


### PR DESCRIPTION
This prevents transparent top-level windows from intercepting mouse
events as often the case with screen capturing software, see
https://bugzilla.gnome.org/show_bug.cgi?id=780979

Applies the same patch that was added for gtk2 in
  023eb8614b8f320563ecb625da334cd1392d430d