### PR TITLE
Fix missing ngspice pkg-config file.

### DIFF
--- a/mingw-w64-ngspice/PKGBUILD
+++ b/mingw-w64-ngspice/PKGBUILD
@@ -11,12 +11,12 @@ _realname=ngspice
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=32
-pkgrel=1
+pkgrel=2
 pkgdesc="Mixed-level/Mixed-signal circuit simulator based on Spice3f5, Cider1b1, and Xspice (mingw-w64)"
 url='https://ngspice.sourceforge.io/'
 license=('BSD')
 arch=('any')
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 conflicts=(${MINGW_PACKAGE_PREFIX}-${_realname}-git)
 replaces=(${MINGW_PACKAGE_PREFIX}-${_realname}-git)
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
@@ -60,6 +60,10 @@ package() {
   cd "${srcdir}/build-static-${CARCH}"
   make install DESTDIR="${pkgdir}"
   install -D -m644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+
+  # pkg-conf file has to be copied manually.  Generated pkg-config file is the same for
+  # static and shared builds.
+  install -D -m644 "${srcdir}/build-shared-${CARCH}/ngspice.pc" "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/ngspice.pc"
 
   # library files have to be copied manually
   cd "${srcdir}/build-shared-${CARCH}"


### PR DESCRIPTION
I discovered that the pkg-config file for the ngspice package was missing so I updated the PKGBUILD file accordingly.  Please let me know if there is anything else I need to do to get the merged.  Thanks in advance for the help.