### PR TITLE
New package: libusb-win32 1.2.6.0

### DIFF
--- a/mingw-w64-libusb-win32/01-mingw32-ddk-headers.patch
+++ b/mingw-w64-libusb-win32/01-mingw32-ddk-headers.patch
@@ -1,0 +1,22 @@
+--- a/src/install.c
++++ b/src/install.c
+@@ -35,7 +35,7 @@
+ #if  defined(_WIN64)
+ #include <cfgmgr32.h>
+ #else
+-#include <ddk/cfgmgr32.h>
++#include <cfgmgr32.h>
+ #endif
+ #else
+ #include <cfgmgr32.h>
+--- a/src/registry.c
++++ b/src/registry.c
+@@ -28,7 +28,7 @@
+ #if  defined(_WIN64)
+ #include <cfgmgr32.h>
+ #else
+-#include <ddk/cfgmgr32.h>
++#include <cfgmgr32.h>
+ #endif
+ #else
+ #include <cfgmgr32.h>

--- a/mingw-w64-libusb-win32/PKGBUILD
+++ b/mingw-w64-libusb-win32/PKGBUILD
@@ -1,0 +1,39 @@
+# Maintainer: fauxpark <fauxpark@gmail.com>
+
+_realname=libusb-win32
+pkgbase=mingw-w64-${_realname}
+pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
+pkgver=1.2.6.0
+pkgrel=1
+pkgdesc='Port of libusb-0.1 under Windows (mingw-w64)'
+arch=('any')
+license=('GPL3')
+url='https://sourceforge.net/projects/libusb-win32/'
+source=(
+    "https://downloads.sourceforge.net/project/libusb-win32/libusb-win32-releases/${pkgver}/libusb-win32-src-${pkgver}.zip"
+    01-mingw32-ddk-headers.patch
+)
+sha256sums=(
+    'f3faf094c9b3415ede42eeb5032feda2e71945f13f0ca3da58ca10dcb439bfee'
+    '71c3f422719cf229e7aaf9e06369ef5a0065b799f2184a4bbd8826bc5fad1687'
+)
+
+prepare() {
+    cd ${srcdir}/${_realname}-src-${pkgver}
+
+    patch -p1 -i ../01-mingw32-ddk-headers.patch
+}
+
+build() {
+    cd ${srcdir}/${_realname}-src-${pkgver}
+
+    make dll
+}
+
+package() {
+    cd ${srcdir}/${_realname}-src-${pkgver}
+
+    install -Dm755 libusb0.dll "${pkgdir}${MINGW_PREFIX}/bin/libusb0.dll"
+    install -Dm644 libusb.a "${pkgdir}${MINGW_PREFIX}/lib/libusb0.dll.a"
+    install -Dm644 src/lusb0_usb.h "${pkgdir}${MINGW_PREFIX}/include/lusb0_usb.h"
+}


### PR DESCRIPTION
This package is needed in order to build dfu-programmer without using libusb 1.0 - although it is possible, doing so would make it incompatible with the official release, as the MSYS2 dfu-programmer would be expecting the device to be using the WinUSB driver, while the release expects libusb0 (libusb-win32).