### PR TITLE
gobject-introspection: fix g_ir_scanner var in .pc file

### DIFF
--- a/mingw-w64-gobject-introspection/PKGBUILD
+++ b/mingw-w64-gobject-introspection/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-runtime")
 pkgver=1.64.1
-pkgrel=2
+pkgrel=3
 arch=('any')
 url="https://live.gnome.org/GObjectIntrospection"
 license=("LGPL")
@@ -84,6 +84,8 @@ package_gobject-introspection() {
   for pcfile in  "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/*.pc; do
     sed -s "s|${_PRE_WIN}/lib/libffi|\${prefix}/lib/libffi|g" -i "${pcfile}"
     sed -s "s|${_PRE_WIN}|${MINGW_PREFIX}|g" -i "${pcfile}"
+    # we create an .exe launcher for g-ir-scanner, so adjust here too
+    sed -s "s|/g-ir-scanner|/g-ir-scanner.exe|g" -i "${pcfile}"
   done
 
   rm "${pkgdir}${MINGW_PREFIX}/bin/libgirepository"*.dll


### PR DESCRIPTION
We create an .exe launcher for it so the variable in the .pc file
no longer matched.

This is a problem because meson 0.55.0 has started to use the variable
to look up g-ir-scanner and fails.

Fixes #6677