### PR TITLE
ghdl: add split package

### DIFF
--- a/mingw-w64-ghdl/PKGBUILD
+++ b/mingw-w64-ghdl/PKGBUILD
@@ -56,7 +56,7 @@ check() {
 
 _package_ghdl-mcode() {
   pkgdesc="$pkgdesc (mcode backend) (mingw-w64)"
-  depends=('zlib-devel')
+  depends=("${MINGW_PACKAGE_PREFIX}-zlib")
 
   cd "${srcdir}"/build-${CARCH}
   mkdir -p "${pkgdir}${MINGW_PREFIX}/lib"
@@ -69,7 +69,7 @@ _package_ghdl-mcode() {
 _package_ghdl-llvm() {
   pkgdesc="$pkgdesc (LLVM backend) (mingw-w64)"
   depends=(
-    'zlib-devel'
+    "${MINGW_PACKAGE_PREFIX}-zlib"
     "${MINGW_PACKAGE_PREFIX}-clang"
     "${MINGW_PACKAGE_PREFIX}-llvm"
   )

--- a/mingw-w64-ghdl/PKGBUILD
+++ b/mingw-w64-ghdl/PKGBUILD
@@ -1,16 +1,24 @@
 _realname=ghdl
-pkgbase=mingw-w64-${_realname}
-pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=dev
+pkgbase="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=c5b094bb
 pkgrel=1
 pkgdesc='GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL (mingw-w64)'
 arch=('any')
 license=('GPL2+')
 url='https://github.com/ghdl'
 #checkdepends=("${MINGW_PACKAGE_PREFIX}-python")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 makedepends=("${MINGW_PACKAGE_PREFIX}-clang" "${MINGW_PACKAGE_PREFIX}-gcc-ada")
-source=("ghdl::git://github.com/ghdl/ghdl.git#commit=e2d751d6")
+source=("ghdl::git://github.com/ghdl/ghdl.git#commit=${pkgver}")
 sha512sums=('SKIP')
+
+pkgname=(__placeholder__)
+if [ "${CARCH}" = "x86_64" ]; then
+  pkgname=("${pkgbase}-llvm")
+fi
+if [ "${CARCH}" = "i686" ]; then
+  pkgname=("${pkgbase}-mcode")
+fi
 
 build() {
   [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
@@ -40,16 +48,11 @@ build() {
   make GNATMAKE="gnatmake -j$(nproc)"
 }
 
-# FIXME: Cannot run tests because expected failures make 'check()' exit with error: A failure occurred in check()
-#check() {
-#  cd $pkgbase-$pkgver/testsuite
-#
-#  echo 'Running tests for ghdl-mcode...'
-#  GHDL="$srcdir"/ghdl-mcode/ghdl_mcode ./testsuite.sh
-#
-#  echo 'Running tests for ghdl-llvm...'
-#  GHDL="$srcdir"/ghdl-llvm/ghdl1-llvm ./testsuite.sh
-#}
+check() {
+  cd "${srcdir}/build-${CARCH}"
+  make install.vpi.local
+  make test
+}
 
 _package_ghdl-mcode() {
   pkgdesc="$pkgdesc (mcode backend) (mingw-w64)"
@@ -80,5 +83,5 @@ _package_ghdl-llvm() {
   install -Dm644 ${srcdir}/${_realname}/doc/licenses.rst ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/licenses.rst
 }
 
-package_mingw-w64-i686-ghdl() { _package_ghdl-mcode; }
-package_mingw-w64-x86_64-ghdl() { _package_ghdl-llvm; }
+package_mingw-w64-i686-ghdl-mcode() { _package_ghdl-mcode; }
+package_mingw-w64-x86_64-ghdl-llvm() { _package_ghdl-llvm; }

--- a/mingw-w64-ghdl/PKGBUILD
+++ b/mingw-w64-ghdl/PKGBUILD
@@ -1,24 +1,23 @@
 _realname=ghdl
-pkgbase="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=c5b094bb
+pkgbase="mingw-w64-${_realname}"
+pkgname='__placeholder__'
+pkgver=0.37.0.r1063.gc5b094bb
 pkgrel=1
 pkgdesc='GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL (mingw-w64)'
 arch=('any')
 license=('GPL2+')
 url='https://github.com/ghdl'
-#checkdepends=("${MINGW_PACKAGE_PREFIX}-python")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 makedepends=("${MINGW_PACKAGE_PREFIX}-clang" "${MINGW_PACKAGE_PREFIX}-gcc-ada")
-source=("ghdl::git://github.com/ghdl/ghdl.git#commit=${pkgver}")
+_commit='c5b094bb'
+source=("ghdl::git://github.com/ghdl/ghdl.git#commit=${_commit}")
 sha512sums=('SKIP')
 
-pkgname=(__placeholder__)
-if [ "${CARCH}" = "x86_64" ]; then
-  pkgname=("${pkgbase}-llvm")
-fi
-if [ "${CARCH}" = "i686" ]; then
-  pkgname=("${pkgbase}-mcode")
-fi
+pkgver() {
+  cd "ghdl"
+  git describe --long | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//g'
+}
 
 build() {
   [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
@@ -54,10 +53,7 @@ check() {
   make test
 }
 
-_package_ghdl-mcode() {
-  pkgdesc="$pkgdesc (mcode backend) (mingw-w64)"
-  depends=("${MINGW_PACKAGE_PREFIX}-zlib")
-
+_package() {
   cd "${srcdir}"/build-${CARCH}
   mkdir -p "${pkgdir}${MINGW_PREFIX}/lib"
   make DESTDIR="${pkgdir}" install
@@ -66,22 +62,28 @@ _package_ghdl-mcode() {
   install -Dm644 ${srcdir}/${_realname}/doc/licenses.rst ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/licenses.rst
 }
 
-_package_ghdl-llvm() {
-  pkgdesc="$pkgdesc (LLVM backend) (mingw-w64)"
-  depends=(
-    "${MINGW_PACKAGE_PREFIX}-zlib"
-    "${MINGW_PACKAGE_PREFIX}-clang"
-    "${MINGW_PACKAGE_PREFIX}-llvm"
-  )
-  options=(!emptydirs)
+if [ "${CARCH}" = "x86_64" ]; then
+  pkgname=("${pkgbase}-llvm")
 
-  cd "${srcdir}"/build-${CARCH}
-  mkdir -p "${pkgdir}${MINGW_PREFIX}/lib"
-  make DESTDIR="${pkgdir}" install
+  package() {
+    pkgdesc="$pkgdesc (LLVM backend) (mingw-w64)"
+    depends=(
+      "${MINGW_PACKAGE_PREFIX}-zlib"
+      "${MINGW_PACKAGE_PREFIX}-clang"
+      "${MINGW_PACKAGE_PREFIX}-llvm"
+    )
+    options=(!emptydirs)
 
-  # License
-  install -Dm644 ${srcdir}/${_realname}/doc/licenses.rst ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/licenses.rst
-}
+    _package
+  }
+fi
+if [ "${CARCH}" = "i686" ]; then
+  pkgname=("${pkgbase}-mcode")
 
-package_mingw-w64-i686-ghdl-mcode() { _package_ghdl-mcode; }
-package_mingw-w64-x86_64-ghdl-llvm() { _package_ghdl-llvm; }
+  package() {
+    pkgdesc="$pkgdesc (mcode backend) (mingw-w64)"
+    depends=("${MINGW_PACKAGE_PREFIX}-zlib")
+
+    _package
+  }
+fi

--- a/mingw-w64-ghdl/PKGBUILD
+++ b/mingw-w64-ghdl/PKGBUILD
@@ -1,0 +1,84 @@
+_realname=ghdl
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=dev
+pkgrel=1
+pkgdesc='GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL (mingw-w64)'
+arch=('any')
+license=('GPL2+')
+url='https://github.com/ghdl'
+#checkdepends=("${MINGW_PACKAGE_PREFIX}-python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-clang" "${MINGW_PACKAGE_PREFIX}-gcc-ada")
+source=("ghdl::git://github.com/ghdl/ghdl.git#commit=e2d751d6")
+sha512sums=('SKIP')
+
+build() {
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+
+  if [ "$CARCH" = "i686" ]; then
+    echo 'Configuring ghdl-mcode...'
+    ../${_realname}/configure \
+        --prefix=${MINGW_PREFIX} \
+        --enable-checks \
+        --enable-libghdl \
+        --enable-synth \
+        LDFLAGS="-static"
+  fi
+
+  if [ "$CARCH" = "x86_64" ]; then
+    echo 'Configuring ghdl-llvm...'
+    ../${_realname}/configure \
+        --prefix=${MINGW_PREFIX} \
+        --enable-checks \
+        --enable-libghdl \
+        --enable-synth \
+        --with-llvm-config="llvm-config --link-static" \
+        LDFLAGS="-static"
+  fi
+
+  make GNATMAKE="gnatmake -j$(nproc)"
+}
+
+# FIXME: Cannot run tests because expected failures make 'check()' exit with error: A failure occurred in check()
+#check() {
+#  cd $pkgbase-$pkgver/testsuite
+#
+#  echo 'Running tests for ghdl-mcode...'
+#  GHDL="$srcdir"/ghdl-mcode/ghdl_mcode ./testsuite.sh
+#
+#  echo 'Running tests for ghdl-llvm...'
+#  GHDL="$srcdir"/ghdl-llvm/ghdl1-llvm ./testsuite.sh
+#}
+
+_package_ghdl-mcode() {
+  pkgdesc="$pkgdesc (mcode backend) (mingw-w64)"
+  depends=('zlib-devel')
+
+  cd "${srcdir}"/build-${CARCH}
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/lib"
+  make DESTDIR="${pkgdir}" install
+
+  # License
+  install -Dm644 ${srcdir}/${_realname}/doc/licenses.rst ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/licenses.rst
+}
+
+_package_ghdl-llvm() {
+  pkgdesc="$pkgdesc (LLVM backend) (mingw-w64)"
+  depends=(
+    'zlib-devel'
+    "${MINGW_PACKAGE_PREFIX}-clang"
+    "${MINGW_PACKAGE_PREFIX}-llvm"
+  )
+  options=(!emptydirs)
+
+  cd "${srcdir}"/build-${CARCH}
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/lib"
+  make DESTDIR="${pkgdir}" install
+
+  # License
+  install -Dm644 ${srcdir}/${_realname}/doc/licenses.rst ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/licenses.rst
+}
+
+package_mingw-w64-i686-ghdl() { _package_ghdl-mcode; }
+package_mingw-w64-x86_64-ghdl() { _package_ghdl-llvm; }


### PR DESCRIPTION
Co-authored-by: Tim Stahlhut <stahta01@gmail.com>

This PR contributes an split package for GHDL: mcode on MINGW32, and LLVM on MINGW64. See #5757.

Close #6686