### PR TITLE
ci(gha): remove redundant keys

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,18 +9,15 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        include:
-          - msystem: MINGW64
-            msystem_lower: mingw64
-            arch: x86_64
-          - msystem: MINGW32
-            msystem_lower: mingw32
-            arch: i686
+        include: [
+          { msystem: MINGW64, arch: x86_64 },
+          { msystem: MINGW32, arch: i686   }
+        ]
     defaults:
       run:
         shell: msys2 {0}
-
     steps:
+
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -32,4 +29,4 @@ jobs:
           update: true
 
       - name: CI-Build
-        run: MINGW_INSTALLS=${{ matrix.msystem_lower }} ./ci-build.sh
+        run: MINGW_INSTALLS=${{ matrix.msystem }} ./ci-build.sh


### PR DESCRIPTION
@lazka, I think that 2020-07-19 includes msys2/MSYS2-packages#2041, so the workflow can be slightly simplified.