### PR TITLE
Link LLVM dynamically

### DIFF
--- a/mingw-w64-clang/0001-Add-options-to-link-LLVM-with-compiler-rt-and-libunw.patch
+++ b/mingw-w64-clang/0001-Add-options-to-link-LLVM-with-compiler-rt-and-libunw.patch
@@ -1,0 +1,138 @@
+From 5dca7a33d7fbfdd4425650f060876b91885c124c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Mateusz=20Miku=C5=82a?= <mati865@gmail.com>
+Date: Thu, 23 Jul 2020 18:03:58 +0200
+Subject: [PATCH] Add options to link LLVM with compiler-rt and libunwind
+
+---
+ CMakeLists.txt                          |  2 ++
+ cmake/config-ix.cmake                   |  2 ++
+ cmake/modules/HandleLLVMOptions.cmake   |  2 ++
+ cmake/modules/HandleLLVMRTlib.cmake     | 34 +++++++++++++++++++++++++
+ cmake/modules/HandleLLVMUnwindlib.cmake | 33 ++++++++++++++++++++++++
+ 5 files changed, 73 insertions(+)
+ create mode 100644 cmake/modules/HandleLLVMRTlib.cmake
+ create mode 100644 cmake/modules/HandleLLVMUnwindlib.cmake
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0e85afa8..ae21329f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -398,6 +398,8 @@ option(LLVM_STATIC_LINK_CXX_STDLIB "Statically link the standard library." OFF)
+ option(LLVM_ENABLE_LLD "Use lld as C and C++ linker." OFF)
+ option(LLVM_ENABLE_PEDANTIC "Compile with pedantic enabled." ON)
+ option(LLVM_ENABLE_WERROR "Fail and stop if a warning is triggered." OFF)
++option(LLVM_ENABLE_COMPILER_RT "Use compiler-rt if available." OFF)
++option(LLVM_ENABLE_LIBUNWIND "Use libunwind if available." OFF)
+ 
+ option(LLVM_ENABLE_DUMP "Enable dump functions even when assertions are disabled" OFF)
+ 
+diff --git a/cmake/config-ix.cmake b/cmake/config-ix.cmake
+index f758366b..e71585e6 100644
+--- a/cmake/config-ix.cmake
++++ b/cmake/config-ix.cmake
+@@ -11,7 +11,9 @@ include(CheckStructHasMember)
+ include(CheckCCompilerFlag)
+ 
+ include(CheckCompilerVersion)
++include(HandleLLVMRTlib)
+ include(HandleLLVMStdlib)
++include(HandleLLVMUnwindlib)
+ 
+ if( UNIX AND NOT (BEOS OR HAIKU) )
+   # Used by check_symbol_exists:
+diff --git a/cmake/modules/HandleLLVMOptions.cmake b/cmake/modules/HandleLLVMOptions.cmake
+index be5cc358..2f3ce5be 100644
+--- a/cmake/modules/HandleLLVMOptions.cmake
++++ b/cmake/modules/HandleLLVMOptions.cmake
+@@ -7,7 +7,9 @@
+ string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)
+ 
+ include(CheckCompilerVersion)
++include(HandleLLVMRTlib)
+ include(HandleLLVMStdlib)
++include(HandleLLVMUnwindlib)
+ include(CheckCCompilerFlag)
+ include(CheckCXXCompilerFlag)
+ include(CheckSymbolExists)
+diff --git a/cmake/modules/HandleLLVMRTlib.cmake b/cmake/modules/HandleLLVMRTlib.cmake
+new file mode 100644
+index 00000000..d9e1c212
+--- /dev/null
++++ b/cmake/modules/HandleLLVMRTlib.cmake
+@@ -0,0 +1,34 @@
++# This CMake module is responsible for setting the compiler library to compiler-rt
++# if the user has requested it.
++
++include(DetermineGCCCompatible)
++
++if(NOT DEFINED LLVM_RTLIB_HANDLED)
++  set(LLVM_RTLIB_HANDLED ON)
++
++  function(append value)
++    foreach(variable ${ARGN})
++      set(${variable} "${${variable}} ${value}" PARENT_SCOPE)
++    endforeach(variable)
++  endfunction()
++
++  include(CheckCXXCompilerFlag)
++  include(CheckLinkerFlag)
++  set(LLVM_COMPILER_RT_USED 0)
++  if(LLVM_ENABLE_COMPILER_RT)
++    if(LLVM_COMPILER_IS_GCC_COMPATIBLE)
++      check_cxx_compiler_flag("-rtlib=compiler-rt" CXX_COMPILER_SUPPORTS_RTLIB)
++      check_linker_flag("-rtlib=compiler-rt" CXX_LINKER_SUPPORTS_RTLIB)
++      if(CXX_COMPILER_SUPPORTS_RTLIB AND CXX_LINKER_SUPPORTS_RTLIB)
++        append("-rtlib=compiler-rt"
++          CMAKE_CXX_FLAGS CMAKE_EXE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS
++          CMAKE_MODULE_LINKER_FLAGS)
++        set(LLVM_LIBCXX_USED 1)
++      else()
++        message(WARNING "Can't specify compiler-rt with '-rtlib='")
++      endif()
++    else()
++      message(WARNING "Not sure how to specify compiler-rt for this compiler")
++    endif()
++  endif()
++endif()
+diff --git a/cmake/modules/HandleLLVMUnwindlib.cmake b/cmake/modules/HandleLLVMUnwindlib.cmake
+new file mode 100644
+index 00000000..b72d3e6e
+--- /dev/null
++++ b/cmake/modules/HandleLLVMUnwindlib.cmake
+@@ -0,0 +1,33 @@
++# This CMake module is responsible for setting the unwind library to libunwind
++# if the user has requested it.
++
++include(DetermineGCCCompatible)
++
++if(NOT DEFINED LLVM_UNWINDLIB_HANDLED)
++  set(LLVM_UNWINDLIB_HANDLED ON)
++
++  function(append value)
++    foreach(variable ${ARGN})
++      set(${variable} "${${variable}} ${value}" PARENT_SCOPE)
++    endforeach(variable)
++  endfunction()
++
++  include(CheckCXXCompilerFlag)
++  include(CheckLinkerFlag)
++  set(LLVM_LIBUNWIND_USED 0)
++  if(LLVM_ENABLE_LIBUNWIND)
++    if(LLVM_COMPILER_IS_GCC_COMPATIBLE)
++      check_cxx_compiler_flag("-unwindlib=libunwind" CXX_COMPILER_SUPPORTS_UNWINDLIB)
++      check_linker_flag("-unwindlib=libunwind" CXX_LINKER_SUPPORTS_UNWINDLIB)
++      if(CXX_COMPILER_SUPPORTS_UNWINDLIB AND CXX_LINKER_SUPPORTS_UNWINDLIB)
++        append("-unwindlib=libunwind"
++          CMAKE_EXE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS)
++        set(LLVM_LIBCXX_USED 1)
++      else()
++        message(WARNING "Can't specify libunwind with '-unwindlib='")
++      endif()
++    else()
++      message(WARNING "Not sure how to specify libunwind for this compiler")
++    endif()
++  endif()
++endif()
+-- 
+2.27.0.windows.1
+

--- a/mingw-w64-clang/0014-Disable-linking-llvm-exegesis-to-dylib.patch
+++ b/mingw-w64-clang/0014-Disable-linking-llvm-exegesis-to-dylib.patch
@@ -1,0 +1,27 @@
+From 1ad5e3cd6b8147d6919a2dbee9b905f86ba50c97 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20G=C3=B3rny?= <mgorny@gentoo.org>
+Date: Tue, 16 Jun 2020 12:31:36 +0200
+Subject: [PATCH] [llvm] Disable linking llvm-exegesis to dylib
+
+Force linking llvm-exegesis to static LLVM libraries instead of dylib
+to prevent duplicate symbols due to linking both.  Ideally, we'd want
+to link to the dylib only here but the target sub-libraries use hidden
+symbols from LLVM target libraries and therefore linking the dylib
+fails.
+
+Differential Revision: https://reviews.llvm.org/D81922
+---
+ tools/llvm-exegesis/CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/tools/llvm-exegesis/CMakeLists.txt b/tools/llvm-exegesis/CMakeLists.txt
+index a59e1b74024e..0575f2a06bb7 100644
+--- a/tools/llvm-exegesis/CMakeLists.txt
++++ b/tools/llvm-exegesis/CMakeLists.txt
+@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
+   )
+
+ add_llvm_tool(llvm-exegesis
++  DISABLE_LLVM_LINK_LLVM_DYLIB
+   llvm-exegesis.cpp
+   )

--- a/mingw-w64-clang/0015-Avoid-linking-llvm-cfi-verify-to-duplicate-libs.patch
+++ b/mingw-w64-clang/0015-Avoid-linking-llvm-cfi-verify-to-duplicate-libs.patch
@@ -1,0 +1,47 @@
+From 352558e69b3691cfdc8e1adc2a1fbb737bc67cbb Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20G=C3=B3rny?= <mgorny@gentoo.org>
+Date: Tue, 16 Jun 2020 12:16:52 +0200
+Subject: [PATCH] [llvm] Avoid linking llvm-cfi-verify to duplicate libs
+
+Fix the CMake rules for LLVMCFIVerify library not to pull duplicate
+LLVM .a libraries when linking to the dylib.  This prevents problems
+due to duplicate symbols and apparently fixes mingw32.
+
+This is an alternative approach to D44650 that just forces .a libraries
+instead.  However, there doesn't seem to be any reason to do that.
+
+Differential Revision: https://reviews.llvm.org/D81921
+---
+ tools/llvm-cfi-verify/lib/CMakeLists.txt | 20 +++++++++++--------
+ 1 file changed, 12 insertions(+), 8 deletions(-)
+
+diff --git a/tools/llvm-cfi-verify/lib/CMakeLists.txt b/tools/llvm-cfi-verify/lib/CMakeLists.txt
+index 82ca42e624a4..41d55ed93216 100644
+--- a/tools/llvm-cfi-verify/lib/CMakeLists.txt
++++ b/tools/llvm-cfi-verify/lib/CMakeLists.txt
+@@ -7,13 +7,17 @@ add_library(LLVMCFIVerify
+   )
+
+ llvm_update_compile_flags(LLVMCFIVerify)
+-llvm_map_components_to_libnames(libs
+-  DebugInfoDWARF
+-  MC
+-  MCParser
+-  Object
+-  Support
+-  Symbolize
+-  )
++if (LLVM_LINK_LLVM_DYLIB)
++  set(libs LLVM)
++else()
++  llvm_map_components_to_libnames(libs
++    DebugInfoDWARF
++    MC
++    MCParser
++    Object
++    Support
++    Symbolize
++    )
++endif()
+ target_link_libraries(LLVMCFIVerify ${libs})
+ set_target_properties(LLVMCFIVerify PROPERTIES FOLDER "Libraries")

--- a/mingw-w64-clang/0016-Add-ffi-to-system-libraries-list-if-enabled.patch
+++ b/mingw-w64-clang/0016-Add-ffi-to-system-libraries-list-if-enabled.patch
@@ -1,0 +1,64 @@
+From cdc1f28fee31e704835d286c9650c79e87b75d6a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Mateusz=20Miku=C5=82a?= <mati865@gmail.com>
+Date: Sun, 26 Jul 2020 13:24:05 +0200
+Subject: [PATCH] Add ffi to system libraries list if enabled
+
+---
+ cmake/config-ix.cmake                          | 11 +++++++++--
+ lib/ExecutionEngine/Interpreter/CMakeLists.txt |  4 ----
+ lib/Support/CMakeLists.txt                     |  4 ++++
+ 3 files changed, 13 insertions(+), 6 deletions(-)
+
+diff --git a/cmake/config-ix.cmake b/cmake/config-ix.cmake
+index e71585e..1cab540 100644
+--- a/cmake/config-ix.cmake
++++ b/cmake/config-ix.cmake
+@@ -321,9 +321,16 @@ if( LLVM_ENABLE_FFI )
+     message(FATAL_ERROR "libffi includes are not found.")
+   endif()
+ 
+-  find_library(FFI_LIBRARY_PATH ffi PATHS ${FFI_LIBRARY_DIR})
++  # If ffi is available in standard locations we prefer to use -lffi in llvm-config
++  # otherwise use absolute path
++  find_library(FFI_LIBRARY_PATH ffi)
+   if( NOT FFI_LIBRARY_PATH )
+-    message(FATAL_ERROR "libffi is not found.")
++    find_library(FFI_LIBRARY_PATH ffi PATHS ${FFI_LIBRARY_DIR})
++    if( NOT FFI_LIBRARY_PATH )
++      message(FATAL_ERROR "libffi is not found.")
++    endif()
++  else()
++    set(FFI_LIBRARY_PATH ffi CACHE INTERNAL "")
+   endif()
+ 
+   list(APPEND CMAKE_REQUIRED_LIBRARIES ${FFI_LIBRARY_PATH})
+diff --git a/lib/ExecutionEngine/Interpreter/CMakeLists.txt b/lib/ExecutionEngine/Interpreter/CMakeLists.txt
+index b8adea5..44363ef 100644
+--- a/lib/ExecutionEngine/Interpreter/CMakeLists.txt
++++ b/lib/ExecutionEngine/Interpreter/CMakeLists.txt
+@@ -14,7 +14,3 @@ add_llvm_component_library(LLVMInterpreter
+   DEPENDS
+   intrinsics_gen
+   )
+-
+-if( LLVM_ENABLE_FFI )
+-  target_link_libraries( LLVMInterpreter PRIVATE ${FFI_LIBRARY_PATH} )
+-endif()
+diff --git a/lib/Support/CMakeLists.txt b/lib/Support/CMakeLists.txt
+index ef12af6..14892bb 100644
+--- a/lib/Support/CMakeLists.txt
++++ b/lib/Support/CMakeLists.txt
+@@ -1,6 +1,10 @@
+ set(system_libs)
+ if ( LLVM_ENABLE_ZLIB AND HAVE_LIBZ )
+   set(system_libs ${system_libs} ${ZLIB_LIBRARIES})
++if( LLVM_ENABLE_FFI )
++  set(system_libs ${system_libs} ${FFI_LIBRARY_PATH})
++endif()
++
+ endif()
+ if( MSVC OR MINGW )
+   # libuuid required for FOLDERID_Profile usage in lib/Support/Windows/Path.inc.
+-- 
+2.27.0.windows.1
+

--- a/mingw-w64-clang/1001-Prevent-linking-to-duplicate-.a-libs-and-dylib.patch
+++ b/mingw-w64-clang/1001-Prevent-linking-to-duplicate-.a-libs-and-dylib.patch
@@ -1,0 +1,790 @@
+From 0aae4a6a4810e4d6f2c20b9b9868d2691681da05 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20G=C3=B3rny?= <mgorny@gentoo.org>
+Date: Tue, 16 Jun 2020 20:43:55 +0200
+Subject: [PATCH] Prevent linking to duplicate .a libs and dylib
+
+Fix various tool libraries not to link to clang's .a libraries and dylib
+simultaneously.  This may cause breakage, in particular through
+duplicate command-line option declarations.
+
+Differential Revision: https://reviews.llvm.org/D81967
+---
+ clang-apply-replacements/CMakeLists.txt            |  4 +++-
+ clang-change-namespace/CMakeLists.txt              |  4 +++-
+ clang-doc/CMakeLists.txt                           |  4 +++-
+ clang-include-fixer/CMakeLists.txt                 |  6 +++++-
+ .../find-all-symbols/CMakeLists.txt                |  4 +++-
+ clang-move/CMakeLists.txt                          |  4 +++-
+ clang-query/CMakeLists.txt                         |  4 +++-
+ clang-reorder-fields/CMakeLists.txt                |  4 +++-
+ clang-tidy/CMakeLists.txt                          |  7 +++++--
+ clang-tidy/abseil/CMakeLists.txt                   |  8 ++++++--
+ clang-tidy/android/CMakeLists.txt                  |  8 ++++++--
+ clang-tidy/boost/CMakeLists.txt                    |  8 ++++++--
+ clang-tidy/bugprone/CMakeLists.txt                 | 10 +++++++---
+ clang-tidy/cert/CMakeLists.txt                     | 12 ++++++++----
+ clang-tidy/cppcoreguidelines/CMakeLists.txt        | 14 +++++++++-----
+ clang-tidy/darwin/CMakeLists.txt                   |  8 ++++++--
+ clang-tidy/fuchsia/CMakeLists.txt                  | 10 +++++++---
+ clang-tidy/google/CMakeLists.txt                   | 10 +++++++---
+ clang-tidy/hicpp/CMakeLists.txt                    | 14 +++++++++-----
+ clang-tidy/linuxkernel/CMakeLists.txt              |  8 ++++++--
+ clang-tidy/llvm/CMakeLists.txt                     | 10 +++++++---
+ clang-tidy/misc/CMakeLists.txt                     |  8 ++++++--
+ clang-tidy/modernize/CMakeLists.txt                | 10 +++++++---
+ clang-tidy/mpi/CMakeLists.txt                      |  8 ++++++--
+ clang-tidy/objc/CMakeLists.txt                     |  8 ++++++--
+ clang-tidy/openmp/CMakeLists.txt                   |  8 ++++++--
+ clang-tidy/performance/CMakeLists.txt              |  8 ++++++--
+ clang-tidy/plugin/CMakeLists.txt                   |  8 ++++++--
+ clang-tidy/portability/CMakeLists.txt              |  8 ++++++--
+ clang-tidy/readability/CMakeLists.txt              |  8 ++++++--
+ clang-tidy/utils/CMakeLists.txt                    |  6 +++++-
+ clang-tidy/zircon/CMakeLists.txt                   |  8 ++++++--
+ clangd/CMakeLists.txt                              | 12 ++++++++----
+ clangd/unittests/CMakeLists.txt                    |  1 -
+ 34 files changed, 189 insertions(+), 73 deletions(-)
+
+diff --git a/clang-apply-replacements/CMakeLists.txt b/clang-apply-replacements/CMakeLists.txt
+index 5bfdcb4..27383b4 100644
+--- a/clang-apply-replacements/CMakeLists.txt
++++ b/clang-apply-replacements/CMakeLists.txt
+@@ -4,8 +4,10 @@ set(LLVM_LINK_COMPONENTS
+ 
+ add_clang_library(clangApplyReplacements
+   lib/Tooling/ApplyReplacements.cpp
++)
+ 
+-  LINK_LIBS
++clang_target_link_libraries(clangApplyReplacements
++  PRIVATE
+   clangAST
+   clangBasic
+   clangRewrite
+diff --git a/clang-change-namespace/CMakeLists.txt b/clang-change-namespace/CMakeLists.txt
+index 1783064..dccfd7c 100644
+--- a/clang-change-namespace/CMakeLists.txt
++++ b/clang-change-namespace/CMakeLists.txt
+@@ -4,8 +4,10 @@ set(LLVM_LINK_COMPONENTS
+ 
+ add_clang_library(clangChangeNamespace
+   ChangeNamespace.cpp
++)
+ 
+-  LINK_LIBS
++clang_target_link_libraries(clangChangeNamespace
++  PRIVATE
+   clangAST
+   clangASTMatchers
+   clangBasic
+diff --git a/clang-doc/CMakeLists.txt b/clang-doc/CMakeLists.txt
+index c301ad5..6f303a6 100644
+--- a/clang-doc/CMakeLists.txt
++++ b/clang-doc/CMakeLists.txt
+@@ -14,8 +14,10 @@ add_clang_library(clangDoc
+   Representation.cpp
+   Serialize.cpp
+   YAMLGenerator.cpp
++)
+ 
+-  LINK_LIBS
++clang_target_link_libraries(clangDoc
++  PRIVATE
+   clangAnalysis
+   clangAST
+   clangASTMatchers
+diff --git a/clang-include-fixer/CMakeLists.txt b/clang-include-fixer/CMakeLists.txt
+index f27f740..d8685cb 100644
+--- a/clang-include-fixer/CMakeLists.txt
++++ b/clang-include-fixer/CMakeLists.txt
+@@ -11,6 +11,11 @@ add_clang_library(clangIncludeFixer
+   YamlSymbolIndex.cpp
+ 
+   LINK_LIBS
++  findAllSymbols
++  )
++
++clang_target_link_libraries(clangIncludeFixer
++  PRIVATE
+   clangAST
+   clangBasic
+   clangFormat
+@@ -21,7 +26,6 @@ add_clang_library(clangIncludeFixer
+   clangSerialization
+   clangTooling
+   clangToolingCore
+-  findAllSymbols
+   )
+ 
+ add_subdirectory(plugin)
+diff --git a/clang-include-fixer/find-all-symbols/CMakeLists.txt b/clang-include-fixer/find-all-symbols/CMakeLists.txt
+index c5fe19b..06a2324 100644
+--- a/clang-include-fixer/find-all-symbols/CMakeLists.txt
++++ b/clang-include-fixer/find-all-symbols/CMakeLists.txt
+@@ -11,8 +11,10 @@ add_clang_library(findAllSymbols
+   PragmaCommentHandler.cpp
+   STLPostfixHeaderMap.cpp
+   SymbolInfo.cpp
++  )
+ 
+-  LINK_LIBS
++clang_target_link_libraries(findAllSymbols
++  PRIVATE
+   clangAST
+   clangASTMatchers
+   clangBasic
+diff --git a/clang-move/CMakeLists.txt b/clang-move/CMakeLists.txt
+index c63127e..9ea4099 100644
+--- a/clang-move/CMakeLists.txt
++++ b/clang-move/CMakeLists.txt
+@@ -5,8 +5,10 @@ set(LLVM_LINK_COMPONENTS
+ add_clang_library(clangMove
+   Move.cpp
+   HelperDeclRefGraph.cpp
++  )
+ 
+-  LINK_LIBS
++clang_target_link_libraries(clangMove
++  PRIVATE
+   clangAnalysis
+   clangAST
+   clangASTMatchers
+diff --git a/clang-query/CMakeLists.txt b/clang-query/CMakeLists.txt
+index d1d68d5..bc76bae 100644
+--- a/clang-query/CMakeLists.txt
++++ b/clang-query/CMakeLists.txt
+@@ -6,8 +6,10 @@ set(LLVM_LINK_COMPONENTS
+ add_clang_library(clangQuery
+   Query.cpp
+   QueryParser.cpp
++  )
+ 
+-  LINK_LIBS
++clang_target_link_libraries(clangQuery
++  PRIVATE
+   clangAST
+   clangASTMatchers
+   clangBasic
+diff --git a/clang-reorder-fields/CMakeLists.txt b/clang-reorder-fields/CMakeLists.txt
+index 9c75d78..e555fd5 100644
+--- a/clang-reorder-fields/CMakeLists.txt
++++ b/clang-reorder-fields/CMakeLists.txt
+@@ -2,8 +2,10 @@ set(LLVM_LINK_COMPONENTS support)
+ 
+ add_clang_library(clangReorderFields
+   ReorderFieldsAction.cpp
++)
+ 
+-  LINK_LIBS
++clang_target_link_libraries(clangReorderFields
++  PRIVATE
+   clangAST
+   clangASTMatchers
+   clangBasic
+diff --git a/clang-tidy/CMakeLists.txt b/clang-tidy/CMakeLists.txt
+index 6dadb27..329df19 100644
+--- a/clang-tidy/CMakeLists.txt
++++ b/clang-tidy/CMakeLists.txt
+@@ -14,8 +14,10 @@ add_clang_library(clangTidy
+ 
+   DEPENDS
+   ClangSACheckers
++  )
+ 
+-  LINK_LIBS
++clang_target_link_libraries(clangTidy
++  PRIVATE
+   clangAnalysis
+   clangAST
+   clangASTMatchers
+@@ -31,7 +33,8 @@ add_clang_library(clangTidy
+   )
+ 
+ if(CLANG_ENABLE_STATIC_ANALYZER)
+-  target_link_libraries(clangTidy PRIVATE
++  clang_target_link_libraries(clangTidy
++    PRIVATE
+     clangStaticAnalyzerCore
+     clangStaticAnalyzerFrontend
+   )
+diff --git a/clang-tidy/abseil/CMakeLists.txt b/clang-tidy/abseil/CMakeLists.txt
+index 3f88da6..0f040e5 100644
+--- a/clang-tidy/abseil/CMakeLists.txt
++++ b/clang-tidy/abseil/CMakeLists.txt
+@@ -22,11 +22,15 @@ add_clang_library(clangTidyAbseilModule
+   UpgradeDurationConversionsCheck.cpp
+ 
+   LINK_LIBS
++  clangTidy
++  clangTidyUtils
++  )
++
++clang_target_link_libraries(clangTidyAbseilModule
++  PRIVATE
+   clangAST
+   clangASTMatchers
+   clangBasic
+   clangLex
+-  clangTidy
+-  clangTidyUtils
+   clangTooling
+   )
+diff --git a/clang-tidy/android/CMakeLists.txt b/clang-tidy/android/CMakeLists.txt
+index 9d04003..d29adc6 100644
+--- a/clang-tidy/android/CMakeLists.txt
++++ b/clang-tidy/android/CMakeLists.txt
+@@ -20,10 +20,14 @@ add_clang_library(clangTidyAndroidModule
+   ComparisonInTempFailureRetryCheck.cpp
+ 
+   LINK_LIBS
++  clangTidy
++  clangTidyUtils
++  )
++
++clang_target_link_libraries(clangTidyAndroidModule
++  PRIVATE
+   clangAST
+   clangASTMatchers
+   clangBasic
+   clangLex
+-  clangTidy
+-  clangTidyUtils
+   )
+diff --git a/clang-tidy/boost/CMakeLists.txt b/clang-tidy/boost/CMakeLists.txt
+index 059f6e9..481a709 100644
+--- a/clang-tidy/boost/CMakeLists.txt
++++ b/clang-tidy/boost/CMakeLists.txt
+@@ -5,10 +5,14 @@ add_clang_library(clangTidyBoostModule
+   UseToStringCheck.cpp
+ 
+   LINK_LIBS
++  clangTidy
++  clangTidyUtils
++  )
++
++clang_target_link_libraries(clangTidyBoostModule
++  PRIVATE
+   clangAST
+   clangASTMatchers
+   clangBasic
+   clangLex
+-  clangTidy
+-  clangTidyUtils
+   )
+diff --git a/clang-tidy/bugprone/CMakeLists.txt b/clang-tidy/bugprone/CMakeLists.txt
+index 2cb28f4..d664f5e 100644
+--- a/clang-tidy/bugprone/CMakeLists.txt
++++ b/clang-tidy/bugprone/CMakeLists.txt
+@@ -52,13 +52,17 @@ add_clang_library(clangTidyBugproneModule
+   VirtualNearMissCheck.cpp
+ 
+   LINK_LIBS
++  clangTidy
++  clangTidyCppCoreGuidelinesModule
++  clangTidyUtils
++  )
++
++clang_target_link_libraries(clangTidyBugproneModule
++  PRIVATE
+   clangAnalysis
+   clangAST
+   clangASTMatchers
+   clangBasic
+   clangLex
+-  clangTidy
+-  clangTidyCppCoreGuidelinesModule
+-  clangTidyUtils
+   clangTooling
+   )
+diff --git a/clang-tidy/cert/CMakeLists.txt b/clang-tidy/cert/CMakeLists.txt
+index 66ea2a1..75a1334 100644
+--- a/clang-tidy/cert/CMakeLists.txt
++++ b/clang-tidy/cert/CMakeLists.txt
+@@ -17,10 +17,6 @@ add_clang_library(clangTidyCERTModule
+   VariadicFunctionDefCheck.cpp
+ 
+   LINK_LIBS
+-  clangAST
+-  clangASTMatchers
+-  clangBasic
+-  clangLex
+   clangTidy
+   clangTidyBugproneModule
+   clangTidyGoogleModule
+@@ -29,3 +25,11 @@ add_clang_library(clangTidyCERTModule
+   clangTidyReadabilityModule
+   clangTidyUtils
+   )
++
++clang_target_link_libraries(clangTidyCERTModule
++  PRIVATE
++  clangAST
++  clangASTMatchers
++  clangBasic
++  clangLex
++  )
+diff --git a/clang-tidy/cppcoreguidelines/CMakeLists.txt b/clang-tidy/cppcoreguidelines/CMakeLists.txt
+index 13c15bc..e48bc1c 100644
+--- a/clang-tidy/cppcoreguidelines/CMakeLists.txt
++++ b/clang-tidy/cppcoreguidelines/CMakeLists.txt
+@@ -23,15 +23,19 @@ add_clang_library(clangTidyCppCoreGuidelinesModule
+   SpecialMemberFunctionsCheck.cpp
+ 
+   LINK_LIBS
+-  clangAST
+-  clangASTMatchers
+-  clangBasic
+-  clangLex
+-  clangSerialization
+   clangTidy
+   clangTidyMiscModule
+   clangTidyModernizeModule
+   clangTidyReadabilityModule
+   clangTidyUtils
++  )
++
++clang_target_link_libraries(clangTidyCppCoreGuidelinesModule
++  PRIVATE
++  clangAST
++  clangASTMatchers
++  clangBasic
++  clangLex
++  clangSerialization
+   clangTooling
+   )
+diff --git a/clang-tidy/darwin/CMakeLists.txt b/clang-tidy/darwin/CMakeLists.txt
+index c650efb..feec79c 100644
+--- a/clang-tidy/darwin/CMakeLists.txt
++++ b/clang-tidy/darwin/CMakeLists.txt
+@@ -6,11 +6,15 @@ add_clang_library(clangTidyDarwinModule
+   DispatchOnceNonstaticCheck.cpp
+ 
+   LINK_LIBS
++  clangTidy
++  clangTidyUtils
++  )
++
++clang_target_link_libraries(clangTidyDarwinModule
++  PRIVATE
+   clangAnalysis
+   clangAST
+   clangASTMatchers
+   clangBasic
+   clangLex
+-  clangTidy
+-  clangTidyUtils
+   )
+diff --git a/clang-tidy/fuchsia/CMakeLists.txt b/clang-tidy/fuchsia/CMakeLists.txt
+index 30b319e..0148b20 100644
+--- a/clang-tidy/fuchsia/CMakeLists.txt
++++ b/clang-tidy/fuchsia/CMakeLists.txt
+@@ -12,11 +12,15 @@ add_clang_library(clangTidyFuchsiaModule
+   VirtualInheritanceCheck.cpp
+ 
+   LINK_LIBS
++  clangTidy
++  clangTidyGoogleModule
++  clangTidyUtils
++  )
++
++clang_target_link_libraries(clangTidyFuchsiaModule
++  PRIVATE
+   clangAST
+   clangASTMatchers
+   clangBasic
+   clangLex
+-  clangTidy
+-  clangTidyGoogleModule
+-  clangTidyUtils
+   )
+diff --git a/clang-tidy/google/CMakeLists.txt b/clang-tidy/google/CMakeLists.txt
+index 0836893..302561b 100644
+--- a/clang-tidy/google/CMakeLists.txt
++++ b/clang-tidy/google/CMakeLists.txt
+@@ -21,11 +21,15 @@ add_clang_library(clangTidyGoogleModule
+   UsingNamespaceDirectiveCheck.cpp
+ 
+   LINK_LIBS
++  clangTidy
++  clangTidyReadabilityModule
++  clangTidyUtils
++  )
++
++clang_target_link_libraries(clangTidyGoogleModule
++  PRIVATE
+   clangAST
+   clangASTMatchers
+   clangBasic
+   clangLex
+-  clangTidy
+-  clangTidyReadabilityModule
+-  clangTidyUtils
+   )
+diff --git a/clang-tidy/hicpp/CMakeLists.txt b/clang-tidy/hicpp/CMakeLists.txt
+index 4cf2676..b4c9eb7 100644
+--- a/clang-tidy/hicpp/CMakeLists.txt
++++ b/clang-tidy/hicpp/CMakeLists.txt
+@@ -8,11 +8,6 @@ add_clang_library(clangTidyHICPPModule
+   SignedBitwiseCheck.cpp
+ 
+   LINK_LIBS
+-  clangAST
+-  clangASTMatchers
+-  clangBasic
+-  clangLex
+-  clangSerialization
+   clangTidy
+   clangTidyBugproneModule
+   clangTidyCppCoreGuidelinesModule
+@@ -23,3 +18,12 @@ add_clang_library(clangTidyHICPPModule
+   clangTidyReadabilityModule
+   clangTidyUtils
+   )
++
++clang_target_link_libraries(clangTidyHICPPModule
++  PRIVATE
++  clangAST
++  clangASTMatchers
++  clangBasic
++  clangLex
++  clangSerialization
++  )
+diff --git a/clang-tidy/linuxkernel/CMakeLists.txt b/clang-tidy/linuxkernel/CMakeLists.txt
+index f0e766d..bfcc2ba 100644
+--- a/clang-tidy/linuxkernel/CMakeLists.txt
++++ b/clang-tidy/linuxkernel/CMakeLists.txt
+@@ -5,10 +5,14 @@ add_clang_library(clangTidyLinuxKernelModule
+   MustCheckErrsCheck.cpp
+ 
+   LINK_LIBS
++  clangTidy
++  clangTidyUtils
++  )
++
++clang_target_link_libraries(clangTidyLinuxKernelModule
++  PRIVATE
+   clangAST
+   clangASTMatchers
+   clangBasic
+   clangLex
+-  clangTidy
+-  clangTidyUtils
+   )
+diff --git a/clang-tidy/llvm/CMakeLists.txt b/clang-tidy/llvm/CMakeLists.txt
+index c035596..bff128c 100644
+--- a/clang-tidy/llvm/CMakeLists.txt
++++ b/clang-tidy/llvm/CMakeLists.txt
+@@ -9,12 +9,16 @@ add_clang_library(clangTidyLLVMModule
+   TwineLocalCheck.cpp
+ 
+   LINK_LIBS
++  clangTidy
++  clangTidyReadabilityModule
++  clangTidyUtils
++  )
++
++clang_target_link_libraries(clangTidyLLVMModule
++  PRIVATE
+   clangAST
+   clangASTMatchers
+   clangBasic
+   clangLex
+-  clangTidy
+-  clangTidyReadabilityModule
+-  clangTidyUtils
+   clangTooling
+   )
+diff --git a/clang-tidy/misc/CMakeLists.txt b/clang-tidy/misc/CMakeLists.txt
+index 3fc1521..37bc2aa 100644
+--- a/clang-tidy/misc/CMakeLists.txt
++++ b/clang-tidy/misc/CMakeLists.txt
+@@ -17,13 +17,17 @@ add_clang_library(clangTidyMiscModule
+   UnusedUsingDeclsCheck.cpp
+ 
+   LINK_LIBS
++  clangTidy
++  clangTidyUtils
++  )
++
++clang_target_link_libraries(clangTidyMiscModule
++  PRIVATE
+   clangAnalysis
+   clangAST
+   clangASTMatchers
+   clangBasic
+   clangLex
+   clangSerialization
+-  clangTidy
+-  clangTidyUtils
+   clangTooling
+   )
+diff --git a/clang-tidy/modernize/CMakeLists.txt b/clang-tidy/modernize/CMakeLists.txt
+index 36193f0..162f445 100644
+--- a/clang-tidy/modernize/CMakeLists.txt
++++ b/clang-tidy/modernize/CMakeLists.txt
+@@ -36,12 +36,16 @@ add_clang_library(clangTidyModernizeModule
+   UseUsingCheck.cpp
+ 
+   LINK_LIBS
++  clangTidy
++  clangTidyReadabilityModule
++  clangTidyUtils
++  )
++
++clang_target_link_libraries(clangTidyModernizeModule
++  PRIVATE
+   clangAST
+   clangASTMatchers
+   clangBasic
+   clangLex
+-  clangTidy
+-  clangTidyReadabilityModule
+-  clangTidyUtils
+   clangTooling
+   )
+diff --git a/clang-tidy/mpi/CMakeLists.txt b/clang-tidy/mpi/CMakeLists.txt
+index 5be7b36..b36767a 100644
+--- a/clang-tidy/mpi/CMakeLists.txt
++++ b/clang-tidy/mpi/CMakeLists.txt
+@@ -6,13 +6,17 @@ add_clang_library(clangTidyMPIModule
+   TypeMismatchCheck.cpp
+ 
+   LINK_LIBS
++  clangTidy
++  clangTidyUtils
++  )
++
++clang_target_link_libraries(clangTidyMPIModule
++  PRIVATE
+   clangAnalysis
+   clangAST
+   clangASTMatchers
+   clangBasic
+   clangLex
+-  clangTidy
+-  clangTidyUtils
+   clangTooling
+   clangStaticAnalyzerCheckers
+   )
+diff --git a/clang-tidy/objc/CMakeLists.txt b/clang-tidy/objc/CMakeLists.txt
+index 68dda65..3624d2f 100644
+--- a/clang-tidy/objc/CMakeLists.txt
++++ b/clang-tidy/objc/CMakeLists.txt
+@@ -9,10 +9,14 @@ add_clang_library(clangTidyObjCModule
+   SuperSelfCheck.cpp
+ 
+   LINK_LIBS
++  clangTidy
++  clangTidyUtils
++  )
++
++clang_target_link_libraries(clangTidyObjCModule
++  PRIVATE
+   clangAST
+   clangASTMatchers
+   clangBasic
+   clangLex
+-  clangTidy
+-  clangTidyUtils
+   )
+diff --git a/clang-tidy/openmp/CMakeLists.txt b/clang-tidy/openmp/CMakeLists.txt
+index af95704..d182b29 100644
+--- a/clang-tidy/openmp/CMakeLists.txt
++++ b/clang-tidy/openmp/CMakeLists.txt
+@@ -8,9 +8,13 @@ add_clang_library(clangTidyOpenMPModule
+   UseDefaultNoneCheck.cpp
+ 
+   LINK_LIBS
++  clangTidy
++  clangTidyUtils
++  )
++
++clang_target_link_libraries(clangTidyOpenMPModule
++  PRIVATE
+   clangAST
+   clangASTMatchers
+   clangBasic
+-  clangTidy
+-  clangTidyUtils
+   )
+diff --git a/clang-tidy/performance/CMakeLists.txt b/clang-tidy/performance/CMakeLists.txt
+index d1f9897..c9a7e26 100644
+--- a/clang-tidy/performance/CMakeLists.txt
++++ b/clang-tidy/performance/CMakeLists.txt
+@@ -18,11 +18,15 @@ add_clang_library(clangTidyPerformanceModule
+   UnnecessaryValueParamCheck.cpp
+ 
+   LINK_LIBS
++  clangTidy
++  clangTidyUtils
++  )
++
++clang_target_link_libraries(clangTidyPerformanceModule
++  PRIVATE
+   clangAST
+   clangASTMatchers
+   clangAnalysis
+   clangBasic
+   clangLex
+-  clangTidy
+-  clangTidyUtils
+   )
+diff --git a/clang-tidy/plugin/CMakeLists.txt b/clang-tidy/plugin/CMakeLists.txt
+index 4adc3f2..0bfe122 100644
+--- a/clang-tidy/plugin/CMakeLists.txt
++++ b/clang-tidy/plugin/CMakeLists.txt
+@@ -2,12 +2,16 @@ add_clang_library(clangTidyPlugin
+   ClangTidyPlugin.cpp
+ 
+   LINK_LIBS
++  clangTidy
++  ${ALL_CLANG_TIDY_CHECKS}
++  )
++
++clang_target_link_libraries(clangTidyPlugin
++  PRIVATE
+   clangAST
+   clangASTMatchers
+   clangBasic
+   clangFrontend
+   clangSema
+-  clangTidy
+   clangTooling
+-  ${ALL_CLANG_TIDY_CHECKS}
+   )
+diff --git a/clang-tidy/portability/CMakeLists.txt b/clang-tidy/portability/CMakeLists.txt
+index 0420a18..bbe9ccb 100644
+--- a/clang-tidy/portability/CMakeLists.txt
++++ b/clang-tidy/portability/CMakeLists.txt
+@@ -5,11 +5,15 @@ add_clang_library(clangTidyPortabilityModule
+   SIMDIntrinsicsCheck.cpp
+ 
+   LINK_LIBS
++  clangTidy
++  clangTidyUtils
++  )
++
++clang_target_link_libraries(clangTidyPortabilityModule
++  PRIVATE
+   clangAST
+   clangASTMatchers
+   clangBasic
+   clangLex
+-  clangTidy
+-  clangTidyUtils
+   clangTooling
+   )
+diff --git a/clang-tidy/readability/CMakeLists.txt b/clang-tidy/readability/CMakeLists.txt
+index 97144af..5af900d 100644
+--- a/clang-tidy/readability/CMakeLists.txt
++++ b/clang-tidy/readability/CMakeLists.txt
+@@ -41,11 +41,15 @@ add_clang_library(clangTidyReadabilityModule
+   UppercaseLiteralSuffixCheck.cpp
+ 
+   LINK_LIBS
++  clangTidy
++  clangTidyUtils
++  )
++
++clang_target_link_libraries(clangTidyReadabilityModule
++  PRIVATE
+   clangAST
+   clangASTMatchers
+   clangBasic
+   clangLex
+-  clangTidy
+-  clangTidyUtils
+   clangTooling
+   )
+diff --git a/clang-tidy/utils/CMakeLists.txt b/clang-tidy/utils/CMakeLists.txt
+index fc383a3..5c837ca 100644
+--- a/clang-tidy/utils/CMakeLists.txt
++++ b/clang-tidy/utils/CMakeLists.txt
+@@ -18,11 +18,15 @@ add_clang_library(clangTidyUtils
+   UsingInserter.cpp
+ 
+   LINK_LIBS
++  clangTidy
++  )
++
++clang_target_link_libraries(clangTidyUtils
++  PRIVATE
+   clangAST
+   clangASTMatchers
+   clangBasic
+   clangLex
+   clangSema
+-  clangTidy
+   clangTransformer
+   )
+diff --git a/clang-tidy/zircon/CMakeLists.txt b/clang-tidy/zircon/CMakeLists.txt
+index 7aa7cd3..71db5e9 100644
+--- a/clang-tidy/zircon/CMakeLists.txt
++++ b/clang-tidy/zircon/CMakeLists.txt
+@@ -5,10 +5,14 @@ add_clang_library(clangTidyZirconModule
+   ZirconTidyModule.cpp
+ 
+   LINK_LIBS
++  clangTidy
++  clangTidyUtils
++  )
++
++clang_target_link_libraries(clangTidyZirconModule
++  PRIVATE
+   clangAST
+   clangASTMatchers
+   clangBasic
+   clangLex
+-  clangTidy
+-  clangTidyUtils
+   )
+diff --git a/clangd/CMakeLists.txt b/clangd/CMakeLists.txt
+index e3eccb5..c797c4e 100644
+--- a/clangd/CMakeLists.txt
++++ b/clangd/CMakeLists.txt
+@@ -110,6 +110,14 @@ add_clang_library(clangDaemon
+   refactor/Tweak.cpp
+ 
+   LINK_LIBS
++  clangTidy
++  ${LLVM_PTHREAD_LIB}
++  ${CLANGD_ATOMIC_LIB}
++  ${ALL_CLANG_TIDY_CHECKS}
++  )
++
++clang_target_link_libraries(clangDaemon
++  PRIVATE
+   clangAST
+   clangASTMatchers
+   clangBasic
+@@ -120,15 +128,11 @@ add_clang_library(clangDaemon
+   clangLex
+   clangSema
+   clangSerialization
+-  clangTidy
+   clangTooling
+   clangToolingCore
+   clangToolingInclusions
+   clangToolingRefactoring
+   clangToolingSyntax
+-  ${LLVM_PTHREAD_LIB}
+-  ${CLANGD_ATOMIC_LIB}
+-  ${ALL_CLANG_TIDY_CHECKS}
+   )
+ 
+ add_subdirectory(refactor/tweaks)
+diff --git a/clangd/unittests/CMakeLists.txt b/clangd/unittests/CMakeLists.txt
+index 62113c6..6c2b56c 100644
+--- a/clangd/unittests/CMakeLists.txt
++++ b/clangd/unittests/CMakeLists.txt
+@@ -103,7 +103,6 @@ target_link_libraries(ClangdTests
+   PRIVATE
+   clangDaemon
+   clangTidy
+-  LLVMSupport
+   LLVMTestingSupport
+   )
+ 
+-- 
+2.27.0.windows.1
+

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -82,6 +82,7 @@ source=(${_url}/llvm-${pkgver}.src.tar.xz{,.sig}
         "0013-Add-Z3-to-system-libraries-list-if-enabled.patch"
         "0014-Disable-linking-llvm-exegesis-to-dylib.patch"
         "0015-Avoid-linking-llvm-cfi-verify-to-duplicate-libs.patch"
+        "0016-Add-ffi-to-system-libraries-list-if-enabled.patch"
         "0101-Allow-build-static-clang-library-for-mingw.patch"
         "0102-fix-libclang-name-for-mingw.patch"
         "0104-link-pthread-with-mingw.patch"
@@ -146,6 +147,7 @@ sha256sums=('c5d8e30b57cbded7128d78e5e8dad811bff97a8d471896812f57fa99ee82cdf3'
             'a2f0e8090a9450abe51e43ba9e9c8ff4b2a4024ba394deea4b8aff547e30fc33'
             '0cf11cd86c8c57b110c590489b849f0445753ff542a984bfc86bbf3ac1d3c022'
             'bbddabd4175128328a7358c1161f7900a9fa69937ef6e21cdec3ff05ff7fb9b8'
+            '92e771359fbbeaa301b5c8921340a35309c6cb75f149b259f6b7533d1b2e6253'
             'b2e5fd29bf666998d495a321690c97fe239bb998abcf0739418ac0ea725fecd6'
             '01b029f2a21bd998ce374a90d41d214c891dfbb611dfbd9ca147517cd2c228ea'
             '53646dd01af2862473e9719c5223366486268891ccbff86413943a432a8342e9'

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -8,8 +8,8 @@
 # Contributor: Adrian Pop <adrian.pop@liu.se>
 
 
-# We can switch to clang when it fully works with mingw-w64
-_compiler=gcc
+# We use Clang with libc++ because libstdc++ suffers from winpthreads bugs
+_compiler=clang
 _generator="MSYS Makefiles"
 #_generator="Ninja"
 if [ "${_generator}" = "Ninja" ]; then
@@ -31,15 +31,16 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-llvm"
          "${MINGW_PACKAGE_PREFIX}-openmp"
          "${MINGW_PACKAGE_PREFIX}-polly")
-pkgver=10.0.0
-pkgrel=3
+pkgver=10.0.1
+pkgrel=1
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 url="https://llvm.org/"
 license=("custom:University of Illinois/NCSA Open Source License")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake>=3.4.3"
-             "${MINGW_PACKAGE_PREFIX}-z3"
-             "${MINGW_PACKAGE_PREFIX}-libffi"
+             "${MINGW_PACKAGE_PREFIX}-compiler-rt"
+             "${MINGW_PACKAGE_PREFIX}-libc++"
+             "${MINGW_PACKAGE_PREFIX}-lld"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-python-sphinx"
              "${MINGW_PACKAGE_PREFIX}-python"
@@ -68,6 +69,7 @@ source=(${_url}/llvm-${pkgver}.src.tar.xz{,.sig}
         ${_url}/lldb-${pkgver}.src.tar.xz{,.sig}
         ${_url}/libunwind-${pkgver}.src.tar.xz{,.sig}
         ${_url}/polly-${pkgver}.src.tar.xz{,.sig}
+        "0001-Add-options-to-link-LLVM-with-compiler-rt-and-libunw.patch"
         "0002-Fix-GetHostTriple-for-mingw-w64-in-msys.patch"
         "0004-llvm-config-look-for-unversioned-shared-lib-on-win32.patch"
         "0005-add-pthread-as-system-lib-for-mingw.patch"
@@ -78,6 +80,8 @@ source=(${_url}/llvm-${pkgver}.src.tar.xz{,.sig}
         "0010-mbig-obj-for-all.patch"
         "0012-fix-testplugin-linking.patch"
         "0013-Add-Z3-to-system-libraries-list-if-enabled.patch"
+        "0014-Disable-linking-llvm-exegesis-to-dylib.patch"
+        "0015-Avoid-linking-llvm-cfi-verify-to-duplicate-libs.patch"
         "0101-Allow-build-static-clang-library-for-mingw.patch"
         "0102-fix-libclang-name-for-mingw.patch"
         "0104-link-pthread-with-mingw.patch"
@@ -91,7 +95,8 @@ source=(${_url}/llvm-${pkgver}.src.tar.xz{,.sig}
         "0801-Don-t-build-LLVMPolly-on-WIN32.patch"
         "0901-openmp-kpm-lock.patch"
         "0902-libomp-weak-mingw.patch"
-        "0903-Fix-implib-for-MinGW.patch")
+        "0903-Fix-implib-for-MinGW.patch"
+        "1001-Prevent-linking-to-duplicate-.a-libs-and-dylib.patch")
 # Some patch notes :)
 #0001-0099 -> llvm
 #0101-0199 -> clang
@@ -103,30 +108,32 @@ source=(${_url}/llvm-${pkgver}.src.tar.xz{,.sig}
 #0701-0799 -> libc++abi
 #0801-0899 -> polly
 #0901-0999 -> openmp
-sha256sums=('df83a44b3a9a71029049ec101fb0077ecbbdf5fe41e395215025779099a98fdf'
+#1001-1099
+sha256sums=('c5d8e30b57cbded7128d78e5e8dad811bff97a8d471896812f57fa99ee82cdf3'
             'SKIP'
-            '3b9ff29a45d0509a1e9667a0feb43538ef402ea8cfc7df3758a01f20df08adfa'
+            'd19f728c8e04fb1e94566c8d76aef50ec926cd2f95ef3bf1e0a5de4909b28b44'
             'SKIP'
-            '885b062b00e903df72631c5f98b9579ed1ed2790f74e5646b4234fa084eacb21'
+            'f99afc382b88e622c689b6d96cadfa6241ef55dca90e87fc170352e12ddb2b24'
             'SKIP'
-            '6a7da64d3a0a7320577b68b9ca4933bdcab676e898b759850e827333c3282c75'
+            'd90dc8e121ca0271f0fd3d639d135bfaa4b6ed41e67bd6eb77808f72629658fa'
             'SKIP'
-            '2bcf0f76263572bf45bf7c552e3eae886ec2f315bbc529f3a68603bfc1d13b33'
+            '3418a2d6fd32f4fa2901e740c4a90b512675a941639cdbb9becfbbdc8981f5f1'
             'SKIP'
-            '270f8a3f176f1981b0f6ab8aa556720988872ec2b48ed3b605d0ced8d09156c7'
+            'def674535f22f83131353b3c382ccebfef4ba6a35c488bdb76f10b68b25be86c'
             'SKIP'
-            'e71bac75a88c9dde455ad3f2a2b449bf745eafd41d2d8432253b2964e0ca14e1'
+            'a97ef810b2e9fb70e8f7e317b74e646ed4944f488b02ac5ddd9c99e385381a7b'
             'SKIP'
-            'acdf8cf6574b40e6b1dabc93e76debb84a9feb6f22970126b04d4ba18b92911c'
+            'd093782bcfcd0c3f496b67a5c2c997ab4b85816b62a7dd5b27026634ccf5c11a'
             'SKIP'
-            'b9a0d7c576eeef05bc06d6e954938a01c5396cee1d1e985891e0b1cf16e3d708'
+            '591449e0aa623a6318d5ce2371860401653c48bb540982ccdd933992cb88df7a'
             'SKIP'
-            'dd1ffcb42ed033f5167089ec4c6ebe84fbca1db4a9eaebf5c614af09d89eb135'
+            '07abe87c25876aa306e73127330f5f37d270b6b082d50cc679e31b4fc02a3714'
             'SKIP'
-            '09dc5ecc4714809ecf62908ae8fe8635ab476880455287036a2730966833c626'
+            '741903ec1ebff2253ff19d803629d88dc7612598758b6e48bea2da168de95e27'
             'SKIP'
-            '35fba6ed628896fe529be4c10407f1b1c8a7264d40c76bced212180e701b4d97'
+            'd2fb0bb86b21db1f52402ba231da7c119c35c21dfb843c9496fe901f2d6aa25a'
             'SKIP'
+            '11aa5f17c8f29e4f2b3e3fa129965179956b332f193eb81f789dc974d3ca6ed1'
             '9b6d3ecb0ef4a38d34aefaefff8c6257ff22d366d84630020d7f079dc8065d97'
             '1f318c0370357fdf9c54ae6d31bad761b0caa58ac099998937b636309ecb6590'
             '7f0c64cd87b61e894be632f180ae5291e1aa9f1d9d382608f659067eeeda7146'
@@ -137,6 +144,8 @@ sha256sums=('df83a44b3a9a71029049ec101fb0077ecbbdf5fe41e395215025779099a98fdf'
             '1c9efccd40a0e7834c3aa9d819aa25cfdd2cec389d1bd3e8a89bc9ff670a0129'
             'c486e1d45f6fb2a24823d776d2b47d6930530d423df73cc635f863265210c294'
             'a2f0e8090a9450abe51e43ba9e9c8ff4b2a4024ba394deea4b8aff547e30fc33'
+            '0cf11cd86c8c57b110c590489b849f0445753ff542a984bfc86bbf3ac1d3c022'
+            'bbddabd4175128328a7358c1161f7900a9fa69937ef6e21cdec3ff05ff7fb9b8'
             'b2e5fd29bf666998d495a321690c97fe239bb998abcf0739418ac0ea725fecd6'
             '01b029f2a21bd998ce374a90d41d214c891dfbb611dfbd9ca147517cd2c228ea'
             '53646dd01af2862473e9719c5223366486268891ccbff86413943a432a8342e9'
@@ -150,7 +159,8 @@ sha256sums=('df83a44b3a9a71029049ec101fb0077ecbbdf5fe41e395215025779099a98fdf'
             'bc394e597f8939b6f6630bd88c990f951738aaadacded2f3be71c658e9608fe7'
             'db8dc554f7780609ee4eb4bc9e3817d4a9409b622f6471c8db06c92705805ead'
             'f7958638e73273ea6a8df4a4e8726a0904d049fdaea7e84c33db5dec1af08fa8'
-            'a633c38149772f90cc34f83b144185746b5a47f7d3d10a97cb060c31d140ab7e')
+            'a633c38149772f90cc34f83b144185746b5a47f7d3d10a97cb060c31d140ab7e'
+            'd770cfd931ae07019a888cc1b33a76aaae8347c069679a106a0d7ccca56f86b8')
 validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Google.
               '474E22316ABF4785A88C6E8EA2C794A986419D8A') # Tom Stellard
 noextract=(clang-${pkgver}.src.tar.xz
@@ -181,6 +191,7 @@ prepare() {
 
   cd "${srcdir}/llvm-${pkgver}.src"
   apply_patch_with_msg \
+      "0001-Add-options-to-link-LLVM-with-compiler-rt-and-libunw.patch" \
       "0002-Fix-GetHostTriple-for-mingw-w64-in-msys.patch" \
       "0004-llvm-config-look-for-unversioned-shared-lib-on-win32.patch" \
       "0005-add-pthread-as-system-lib-for-mingw.patch" \
@@ -188,7 +199,9 @@ prepare() {
       "0009-empty-target-prefix-only-msvc.patch" \
       "0010-mbig-obj-for-all.patch" \
       "0012-fix-testplugin-linking.patch" \
-      "0013-Add-Z3-to-system-libraries-list-if-enabled.patch"
+      "0013-Add-Z3-to-system-libraries-list-if-enabled.patch" \
+      "0014-Disable-linking-llvm-exegesis-to-dylib.patch" \
+      "0015-Avoid-linking-llvm-cfi-verify-to-duplicate-libs.patch"
 
   # https://bugs.llvm.org/show_bug.cgi?id=25493
   apply_patch_with_msg \
@@ -229,6 +242,10 @@ prepare() {
       "0901-openmp-kpm-lock.patch" \
       "0902-libomp-weak-mingw.patch" \
       "0903-Fix-implib-for-MinGW.patch"
+
+  cd "${srcdir}/clang-tools-extra-${pkgver}.src"
+  apply_patch_with_msg \
+      "1001-Prevent-linking-to-duplicate-.a-libs-and-dylib.patch"
 
   # At the present, clang must reside inside the LLVM source code tree to build
   # See https://bugs.llvm.org/show_bug.cgi?id=4840
@@ -272,8 +289,6 @@ build() {
   # https://github.com/martine/ninja/issues/932
 
   if [ "${_compiler}" == "clang" ]; then
-    #export CC='clang -stdlib=libc++'
-    #export CXX='clang++ -stdlib=libc++'
     export CC='clang'
     export CXX='clang++'
   fi
@@ -302,11 +317,15 @@ build() {
     -DLLVM_BUILD_STATIC=OFF \
     -DLLVM_ENABLE_ASSERTIONS=OFF \
     -DLLVM_ENABLE_FFI=ON \
+    -DLLVM_ENABLE_LLD=ON \
+    -DLLVM_ENABLE_LIBCXX=ON \
+    -DLLVM_ENABLE_COMPILER_RT=ON \
+    -DLLVM_ENABLE_LIBUNWIND=ON \
     -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;compiler-rt;lld;lldb;openmp;polly" \
     -DLLVM_ENABLE_SPHINX=ON \
     -DLLVM_ENABLE_THREADS=ON \
     -DLLVM_INCLUDE_EXAMPLES=OFF \
-    -DLLVM_LINK_LLVM_DYLIB=OFF \
+    -DLLVM_LINK_LLVM_DYLIB=ON \
     -DLLVM_POLLY_LINK_INTO_TOOLS=OFF \
     -DPYTHON_EXECUTABLE=${MINGW_PREFIX}/bin/python.exe \
     "${extra_config[@]}" \
@@ -398,8 +417,7 @@ package_clang() {
   pkgdesc="C language family frontend for LLVM (mingw-w64)"
   url="https://clang.llvm.org/"
   depends=("${MINGW_PACKAGE_PREFIX}-llvm=${pkgver}-${pkgrel}"
-           "${MINGW_PACKAGE_PREFIX}-gcc"
-           "${MINGW_PACKAGE_PREFIX}-z3")
+           "${MINGW_PACKAGE_PREFIX}-gcc")
 
   cd "${srcdir}/clang"
   ${_make_cmd} -C ../build-${CARCH}/tools/clang DESTDIR="${pkgdir}" install
@@ -434,6 +452,7 @@ package_clang-analyzer() {
 package_clang-tools-extra() {
   pkgdesc="Extra tools built using Clang's tooling APIs (mingw-w64)"
   url="https://clang.llvm.org/"
+    depends=("${MINGW_PACKAGE_PREFIX}-clang=${pkgver}-${pkgrel}")
 
   cd "${srcdir}/clang-tools-extra"
   ${_make_cmd} -C ../build-${CARCH}/tools/clang/tools/extra DESTDIR="${pkgdir}" install
@@ -442,7 +461,6 @@ package_clang-tools-extra() {
 package_compiler-rt() {
   pkgdesc="Runtime libraries for Clang and LLVM (mingw-w64)"
   url="https://compiler-rt.llvm.org/"
-  depends=("${MINGW_PACKAGE_PREFIX}-llvm=${pkgver}-${pkgrel}")
 
   cd "${srcdir}"/compiler-rt
   ${_make_cmd} -C ../build-${CARCH}/projects/compiler-rt DESTDIR="${pkgdir}" install
@@ -491,6 +509,7 @@ package_libunwind() {
 package_lld() {
   pkgdesc="Linker tools for LLVM (mingw-w64)"
   url="https://lld.llvm.org/"
+  depends=("${MINGW_PACKAGE_PREFIX}-llvm")
 
   cd "${srcdir}/lld"
   ${_make_cmd} -C ../build-${CARCH}/tools/lld DESTDIR="${pkgdir}" install
@@ -499,7 +518,8 @@ package_lld() {
 package_lldb() {
   pkgdesc="Next generation, high-performance debugger (mingw-w64)"
   url="https://lldb.llvm.org/"
-  depends=("${MINGW_PACKAGE_PREFIX}-libxml2"
+  depends=("${MINGW_PACKAGE_PREFIX}-clang"
+           "${MINGW_PACKAGE_PREFIX}-libxml2"
            "${MINGW_PACKAGE_PREFIX}-llvm"
            "${MINGW_PACKAGE_PREFIX}-lua"
            "${MINGW_PACKAGE_PREFIX}-python"
@@ -521,8 +541,8 @@ package_lldb() {
 package_llvm() {
   pkgdesc="Low Level Virtual Machine (mingw-w64)"
   depends=("${MINGW_PACKAGE_PREFIX}-libffi"
-           "${MINGW_PACKAGE_PREFIX}-z3"
-           "${MINGW_PACKAGE_PREFIX}-gcc-libs") # "compiler-rt"
+           "${MINGW_PACKAGE_PREFIX}-libc++"
+           "${MINGW_PACKAGE_PREFIX}-z3")
 
   cd "${srcdir}"/llvm-${pkgver}.src
 


### PR DESCRIPTION
Fixes https://github.com/msys2/MINGW-packages/issues/4006

There is a problem however:
```
$ llvm-config --link-shared --cxxflags
-ID:\msys64\mingw64/include -std=c++14 -stdlib=libc++  -fno-exceptions -fno-rtti -D_FILE_OFFSET_BITS=64 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
```
GCC doesn't understand `-stdlib=libc++` and will throw an error. So to link LLVM (and all related tools) dynamically at the very least we have to make GCC ignore `-stdlib`.