### PR TITLE
faudio: udpate to 20.08

### DIFF
--- a/mingw-w64-faudio/PKGBUILD
+++ b/mingw-w64-faudio/PKGBUILD
@@ -3,18 +3,20 @@
 _realname=FAudio
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=20.06
+pkgver=20.08
 pkgrel=1
 pkgdesc="FAudio - Accuracy-focused XAudio reimplementation for open platforms (mingw-w64)"
 arch=('any')
 url="https://github.com/FNA-XNA/FAudio"
 license=('custom')
-makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-ffmpeg"
-             "${MINGW_PACKAGE_PREFIX}-SDL2")
+depends=("${MINGW_PACKAGE_PREFIX}-SDL2"
+         "${MINGW_PACKAGE_PREFIX}-glib2"
+         "${MINGW_PACKAGE_PREFIX}-gstreamer"
+         "${MINGW_PACKAGE_PREFIX}-gst-plugins-base")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake")
 options=('strip' 'staticlibs')
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/FNA-XNA/FAudio/archive/${pkgver}.tar.gz")
-sha256sums=('d6e89e1d5d2a95e2c2759318c6dba6ecd922c452668996e6e7e40294c3875725')
+sha256sums=('5c3409fa0e532591f0ab4de1ae57d07cc345efa5cbe83ec25e9f5ba180f920f4')
 
 build() {
   [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
@@ -30,7 +32,7 @@ build() {
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake \
       -G'MSYS Makefiles' \
-      -DFFMPEG=ON \
+      -DGSTREAMER=ON \
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
       "${extra_config[@]}" \
       ../${_realname}-${pkgver}


### PR DESCRIPTION
* Replace dependency ffmpeg to gstreamer
* Add glib2, gstreamer, gst-plugins-base as dependencies
* Use -DGSTREAMER instead of -DFFMPEG option for cmake