### PR TITLE
[do not merge] Fix shiboken2 and pyside2 build issues

### DIFF
--- a/mingw-w64-pyside2-qt5/001-pyside.patch
+++ b/mingw-w64-pyside2-qt5/001-pyside.patch
@@ -1,18 +1,7 @@
-diff -Naur a/sources/pyside2/CMakeLists.txt b/sources/pyside2/CMakeLists.txt
---- a/sources/pyside2/CMakeLists.txt	2018-06-19 16:00:53.944984400 +0300
-+++b/sources/pyside2/CMakeLists.txt	2018-06-19 16:18:12.926410700 +0300
-@@ -232,7 +232,7 @@
- use_protected_as_public_hack()
- 
- # Build with Address sanitizer enabled if requested. This may break things, so use at your own risk.
--if (SANITIZE_ADDRESS AND NOT MSVC)
-+if (SANITIZE_ADDRESS AND NOT WIN32)
-     setup_sanitize_address()
- endif()
- 
---- a/sources/pyside2/cmake/Macros/PySideModules.cmake.orig	2015-06-26 11:55:02.330400000 +0300
-+++ b/sources/pyside2/cmake/Macros/PySideModules.cmake	2015-06-26 12:29:31.912800000 +0300
-@@ -123,9 +123,9 @@
+diff -Naur pyside-setup-opensource-src-5.15.0-orig/sources/pyside2/cmake/Macros/PySideModules.cmake pyside-setup-opensource-src-5.15.0/sources/pyside2/cmake/Macros/PySideModules.cmake
+--- pyside-setup-opensource-src-5.15.0-orig/sources/pyside2/cmake/Macros/PySideModules.cmake	2020-05-26 10:58:24.000000000 -0700
++++ pyside-setup-opensource-src-5.15.0/sources/pyside2/cmake/Macros/PySideModules.cmake	2020-07-30 04:42:55.046927600 -0700
+@@ -126,9 +126,9 @@
                          BYPRODUCTS ${${module_SOURCES}}
                          COMMAND Shiboken2::shiboken2 ${GENERATOR_EXTRA_FLAGS}
                          "${pyside2_BINARY_DIR}/${module_NAME}_global.h"
@@ -24,11 +13,66 @@ diff -Naur a/sources/pyside2/CMakeLists.txt b/sources/pyside2/CMakeLists.txt
                          --output-directory=${CMAKE_CURRENT_BINARY_DIR}
                          --license-file=${CMAKE_CURRENT_SOURCE_DIR}/../licensecomment.txt
                          ${typesystem_path}
---- a/sources/pyside2/tests/pysidetest/CMakeLists.txt.orig	2015-06-26 12:32:49.376400000 +0300
-+++ b/sources/pyside2/tests/pysidetest/CMakeLists.txt	2015-06-26 12:33:01.903200000 +0300
-@@ -72,9 +72,9 @@
- add_custom_command(OUTPUT ${testbinding_SRC}
- COMMAND ${SHIBOKEN_BINARY} ${GENERATOR_EXTRA_FLAGS}
+@@ -143,6 +143,9 @@
+     include_directories(${module_NAME} ${${module_INCLUDE_DIRS}} ${pyside2_SOURCE_DIR})
+     add_library(${module_NAME} MODULE ${${module_SOURCES}}
+                                       ${${module_STATIC_SOURCES}})
++    if(MINGW)
++        set(SHIBOKEN_PYTHON_EXTENSION_SUFFIX "")
++    endif()
+     set_target_properties(${module_NAME} PROPERTIES
+                           PREFIX ""
+                           OUTPUT_NAME "${module_NAME}${SHIBOKEN_PYTHON_EXTENSION_SUFFIX}"
+@@ -203,12 +206,14 @@
+         list(APPEND generate_pyi_options "--quiet")
+     endif()
+ 
++    if(NOT MINGW)
+     # Add target to generate pyi file, which depends on the module target.
+     add_custom_target("${module_NAME}_pyi" ALL
+                       COMMAND ${CMAKE_COMMAND} -E env ${ld_prefix}
+                       "${SHIBOKEN_PYTHON_INTERPRETER}"
+                       "${CMAKE_CURRENT_SOURCE_DIR}/../support/generate_pyi.py" ${generate_pyi_options})
+     add_dependencies("${module_NAME}_pyi" ${module_NAME})
++    endif()
+ 
+     # install
+     install(TARGETS ${module_NAME} LIBRARY DESTINATION "${PYTHON_SITE_PACKAGES}/PySide2")
+diff -Naur pyside-setup-opensource-src-5.15.0-orig/sources/pyside2/CMakeLists.txt pyside-setup-opensource-src-5.15.0/sources/pyside2/CMakeLists.txt
+--- pyside-setup-opensource-src-5.15.0-orig/sources/pyside2/CMakeLists.txt	2020-05-26 10:58:24.000000000 -0700
++++ pyside-setup-opensource-src-5.15.0/sources/pyside2/CMakeLists.txt	2020-07-30 04:42:52.592848300 -0700
+@@ -243,7 +243,7 @@
+ use_protected_as_public_hack()
+ 
+ # Build with Address sanitizer enabled if requested. This may break things, so use at your own risk.
+-if (SANITIZE_ADDRESS AND NOT MSVC)
++if (SANITIZE_ADDRESS AND NOT WIN32)
+     setup_sanitize_address()
+ endif()
+ 
+diff -Naur pyside-setup-opensource-src-5.15.0-orig/sources/pyside2/PySide2/QtNetwork/typesystem_network.xml pyside-setup-opensource-src-5.15.0/sources/pyside2/PySide2/QtNetwork/typesystem_network.xml
+--- pyside-setup-opensource-src-5.15.0-orig/sources/pyside2/PySide2/QtNetwork/typesystem_network.xml	2020-05-26 10:58:24.000000000 -0700
++++ pyside-setup-opensource-src-5.15.0/sources/pyside2/PySide2/QtNetwork/typesystem_network.xml	2020-07-30 04:42:56.905572400 -0700
+@@ -271,6 +271,13 @@
+         <enum-type name="Capability" flags="Capabilities" since="4.7"/>
+     </object-type>
+     <object-type name="QNetworkSession" since="4.7">
++        <modify-function signature="interface()const">
++        <inject-code class="target" position="beginning">
++            #undef interface
++            %RETURN_TYPE %0 = %CPPSELF->%FUNCTION_NAME();
++            %PYARG_0 = %CONVERTTOPYTHON[%RETURN_TYPE](%0);
++        </inject-code>
++        </modify-function>
+         <enum-type name="SessionError" since="4.7"/>
+         <enum-type name="State" since="4.7"/>
+         <enum-type name="UsagePolicy" flags="UsagePolicies"/>
+diff -Naur pyside-setup-opensource-src-5.15.0-orig/sources/pyside2/tests/pysidetest/CMakeLists.txt pyside-setup-opensource-src-5.15.0/sources/pyside2/tests/pysidetest/CMakeLists.txt
+--- pyside-setup-opensource-src-5.15.0-orig/sources/pyside2/tests/pysidetest/CMakeLists.txt	2020-05-26 10:58:24.000000000 -0700
++++ pyside-setup-opensource-src-5.15.0/sources/pyside2/tests/pysidetest/CMakeLists.txt	2020-07-30 04:43:00.343248600 -0700
+@@ -82,9 +82,9 @@
+         BYPRODUCTS ${testbinding_SRC}
+         COMMAND Shiboken2::shiboken2 ${GENERATOR_EXTRA_FLAGS}
          ${CMAKE_CURRENT_SOURCE_DIR}/pysidetest_global.h
 -        --include-paths=${testbinding_include_dirs}
 +        --include-paths="${testbinding_include_dirs}"

--- a/mingw-w64-pyside2-qt5/PKGBUILD
+++ b/mingw-w64-pyside2-qt5/PKGBUILD
@@ -11,7 +11,7 @@ arch=('any')
 url="https://doc-snapshots.qt.io/qtforpython/"
 license=("LGPL")
 depends=("${MINGW_PACKAGE_PREFIX}-python"
-         "${MINGW_PACKAGE_PREFIX}-shiboken2-qt5=${pkgver}"
+         "${MINGW_PACKAGE_PREFIX}-shiboken2-qt5"
          "${MINGW_PACKAGE_PREFIX}-qt5")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake"

--- a/mingw-w64-pyside2-qt5/PKGBUILD
+++ b/mingw-w64-pyside2-qt5/PKGBUILD
@@ -1,10 +1,11 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Andrew Smeltzov <andrew.smeltzov@gmail.com>
 
 _realname=pyside2
 pkgbase=mingw-w64-${_realname}-qt5
 pkgname=(${MINGW_PACKAGE_PREFIX}-${_realname}-qt5)
 pkgdesc="Provides LGPL Qt5 bindings for Python and related tools for binding generation (mingw-w64)"
-pkgver=5.14.2
+pkgver=5.15.0
 pkgrel=1
 arch=('any')
 url="https://doc-snapshots.qt.io/qtforpython/"
@@ -19,8 +20,8 @@ options=('staticlibs' 'strip')
 install=${_realname}-${CARCH}.install
 source=(https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-${pkgver}-src/pyside-setup-opensource-src-${pkgver}.tar.xz
         001-pyside.patch)
-sha256sums=('7c7af33792de57255dbdc165c808e1f03a2520295c5922d9897aca8ad1be92b3'
-            '9bb699a4c11e038fd156744ee7e772e437dafbd266509d0fa238b4794a42d94d')
+sha256sums=('f1cdee53de3b76e22c1117a014a91ed95ac16e4760776f4f12dc38cd5a7b6b68'
+            '52eb1cc427b852984858d965401c07fe2d4fbe1ca3849882187334aa02e15136')
 
 prepare() {
   cd "${srcdir}"/pyside-setup-opensource-src-${pkgver}
@@ -36,6 +37,7 @@ build() {
     -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_TESTS=OFF \
     ${_conf} \
     -DPYTHON_EXECUTABLE=${MINGW_PREFIX}/bin/python.exe \
     ../pyside-setup-opensource-src-${pkgver}/sources/pyside2

--- a/mingw-w64-shiboken2-qt5/003-llvm-paths.patch
+++ b/mingw-w64-shiboken2-qt5/003-llvm-paths.patch
@@ -1,0 +1,108 @@
+diff -Naur pyside-setup-opensource-src-5.15.0/sources/shiboken2/ApiExtractor/abstractmetabuilder.cpp pyside-setup-opensource-src-5.15.0-patched/sources/shiboken2/ApiExtractor/abstractmetabuilder.cpp
+--- pyside-setup-opensource-src-5.15.0/sources/shiboken2/ApiExtractor/abstractmetabuilder.cpp	2020-05-26 10:58:24.000000000 -0700
++++ pyside-setup-opensource-src-5.15.0-patched/sources/shiboken2/ApiExtractor/abstractmetabuilder.cpp	2020-07-29 10:37:03.275443600 -0700
+@@ -411,6 +411,14 @@
+ {
+     clang::Builder builder;
+     builder.setSystemIncludes(TypeDatabase::instance()->systemIncludes());
++#ifdef Q_CC_MINGW
++    auto includePaths = clang::emulatedSystemIncludePaths();
++    std::transform(includePaths.begin(), includePaths.end(), includePaths.begin(),
++              [](QByteArray filename) { // to forward slashes
++      return QFile::encodeName(QDir::cleanPath(QFile::decodeName(filename)));
++    });
++    builder.setSystemIncludePaths(includePaths);
++#endif
+     if (level == LanguageLevel::Default)
+         level = clang::emulatedCompilerLanguageLevel();
+     arguments.prepend(QByteArrayLiteral("-std=")
+diff -Naur pyside-setup-opensource-src-5.15.0/sources/shiboken2/ApiExtractor/clangparser/clangbuilder.cpp pyside-setup-opensource-src-5.15.0-patched/sources/shiboken2/ApiExtractor/clangparser/clangbuilder.cpp
+--- pyside-setup-opensource-src-5.15.0/sources/shiboken2/ApiExtractor/clangparser/clangbuilder.cpp	2020-05-26 10:58:24.000000000 -0700
++++ pyside-setup-opensource-src-5.15.0-patched/sources/shiboken2/ApiExtractor/clangparser/clangbuilder.cpp	2020-07-29 10:59:22.454320100 -0700
+@@ -794,7 +794,8 @@
+     // Has been observed to be 0 for invalid locations
+     bool result = false;
+     if (const char *cFileName = clang_getCString(cxFileName)) {
+-        result = d->visitHeader(cFileName);
++        QString absoluteFileName = QDir::cleanPath(QString::fromUtf8(cFileName));
++        result = d->visitHeader(absoluteFileName.toUtf8().constData());
+         clang_disposeString(cxFileName);
+     }
+     return result;
+@@ -810,6 +811,11 @@
+     }
+ }
+ 
++void Builder::setSystemIncludePaths(const QByteArrayList &systemIncludePaths)
++{
++    d->m_systemIncludePaths.append(systemIncludePaths);
++}
++
+ FileModelItem Builder::dom() const
+ {
+     Q_ASSERT(!d->m_scopeStack.isEmpty());
+diff -Naur pyside-setup-opensource-src-5.15.0/sources/shiboken2/ApiExtractor/clangparser/clangbuilder.h pyside-setup-opensource-src-5.15.0-patched/sources/shiboken2/ApiExtractor/clangparser/clangbuilder.h
+--- pyside-setup-opensource-src-5.15.0/sources/shiboken2/ApiExtractor/clangparser/clangbuilder.h	2020-05-26 10:58:24.000000000 -0700
++++ pyside-setup-opensource-src-5.15.0-patched/sources/shiboken2/ApiExtractor/clangparser/clangbuilder.h	2020-07-29 07:42:28.465778700 -0700
+@@ -45,6 +45,7 @@
+     ~Builder();
+ 
+     void setSystemIncludes(const QByteArrayList &systemIncludes);
++    void setSystemIncludePaths(const QByteArrayList &systemIncludePaths);
+ 
+     bool visitLocation(const CXSourceLocation &location) const override;
+ 
+diff -Naur pyside-setup-opensource-src-5.15.0/sources/shiboken2/ApiExtractor/clangparser/compilersupport.cpp pyside-setup-opensource-src-5.15.0-patched/sources/shiboken2/ApiExtractor/clangparser/compilersupport.cpp
+--- pyside-setup-opensource-src-5.15.0/sources/shiboken2/ApiExtractor/clangparser/compilersupport.cpp	2020-05-26 10:58:24.000000000 -0700
++++ pyside-setup-opensource-src-5.15.0-patched/sources/shiboken2/ApiExtractor/clangparser/compilersupport.cpp	2020-07-29 07:44:21.186726500 -0700
+@@ -401,4 +401,15 @@
+     return LanguageLevel::Default;
+ }
+ 
++QByteArrayList emulatedSystemIncludePaths()
++{
++    HeaderPaths headerPaths = gppInternalIncludePaths(compilerFromCMake(QStringLiteral("clang++")));
++    QByteArrayList result;
++    std::transform(headerPaths.cbegin(), headerPaths.cend(),
++                   std::back_inserter(result), [](const HeaderPath& path) {
++        return path.path;
++    });
++    return result;
++}
++
+ } // namespace clang
+diff -Naur pyside-setup-opensource-src-5.15.0/sources/shiboken2/ApiExtractor/clangparser/compilersupport.h pyside-setup-opensource-src-5.15.0-patched/sources/shiboken2/ApiExtractor/clangparser/compilersupport.h
+--- pyside-setup-opensource-src-5.15.0/sources/shiboken2/ApiExtractor/clangparser/compilersupport.h	2020-05-26 10:58:24.000000000 -0700
++++ pyside-setup-opensource-src-5.15.0-patched/sources/shiboken2/ApiExtractor/clangparser/compilersupport.h	2020-07-29 07:29:43.909862800 -0700
+@@ -46,6 +46,7 @@
+ QVersionNumber libClangVersion();
+ 
+ QByteArrayList emulatedCompilerOptions();
++QByteArrayList emulatedSystemIncludePaths();
+ LanguageLevel emulatedCompilerLanguageLevel();
+ 
+ const char *languageLevelOption(LanguageLevel l);
+diff -Naur pyside-setup-opensource-src-5.15.0/sources/shiboken2/ApiExtractor/reporthandler.cpp pyside-setup-opensource-src-5.15.0-patched/sources/shiboken2/ApiExtractor/reporthandler.cpp
+--- pyside-setup-opensource-src-5.15.0/sources/shiboken2/ApiExtractor/reporthandler.cpp	2020-05-26 10:58:24.000000000 -0700
++++ pyside-setup-opensource-src-5.15.0-patched/sources/shiboken2/ApiExtractor/reporthandler.cpp	2020-07-28 08:42:08.462697500 -0700
+@@ -35,7 +35,7 @@
+ #include <cstdarg>
+ #include <cstdio>
+ 
+-#if defined(_WINDOWS) || defined(NOCOLOR)
++#if defined(Q_OS_WIN) || defined(NOCOLOR)
+     #define COLOR_END ""
+     #define COLOR_WHITE ""
+     #define COLOR_YELLOW ""
+diff -Naur pyside-setup-opensource-src-5.15.0/sources/shiboken2/generator/main.cpp pyside-setup-opensource-src-5.15.0-patched/sources/shiboken2/generator/main.cpp
+--- pyside-setup-opensource-src-5.15.0/sources/shiboken2/generator/main.cpp	2020-05-26 10:58:24.000000000 -0700
++++ pyside-setup-opensource-src-5.15.0-patched/sources/shiboken2/generator/main.cpp	2020-07-29 08:47:14.789277700 -0700
+@@ -42,7 +42,7 @@
+ #include "headergenerator.h"
+ #include "qtdocgenerator.h"
+ 
+-#ifdef _WINDOWS
++#ifdef Q_OS_WIN
+ static const QChar pathSplitter = QLatin1Char(';');
+ #else
+ static const QChar pathSplitter = QLatin1Char(':');

--- a/mingw-w64-shiboken2-qt5/004-shibokenmodule-name.patch
+++ b/mingw-w64-shiboken2-qt5/004-shibokenmodule-name.patch
@@ -1,0 +1,16 @@
+diff -Naur pyside-setup-opensource-src-5.15.0-orig/sources/shiboken2/shibokenmodule/CMakeLists.txt pyside-setup-opensource-src-5.15.0/sources/shiboken2/shibokenmodule/CMakeLists.txt
+--- pyside-setup-opensource-src-5.15.0-orig/sources/shiboken2/shibokenmodule/CMakeLists.txt	2020-05-26 10:58:24.000000000 -0700
++++ pyside-setup-opensource-src-5.15.0/sources/shiboken2/shibokenmodule/CMakeLists.txt	2020-07-30 01:40:20.584830100 -0700
+@@ -23,7 +23,11 @@
+ target_include_directories(shibokenmodule PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+                                                   ${CMAKE_SOURCE_DIR})
+ set_property(TARGET shibokenmodule PROPERTY PREFIX "")
+-set_property(TARGET shibokenmodule PROPERTY OUTPUT_NAME "shiboken2${PYTHON_EXTENSION_SUFFIX}")
++if(MINGW)
++	set_property(TARGET shibokenmodule PROPERTY OUTPUT_NAME "shiboken2")
++else()
++	set_property(TARGET shibokenmodule PROPERTY OUTPUT_NAME "shiboken2${PYTHON_EXTENSION_SUFFIX}")
++endif()
+ 
+ if(WIN32)
+     set_property(TARGET shibokenmodule PROPERTY SUFFIX ".pyd")

--- a/mingw-w64-shiboken2-qt5/PKGBUILD
+++ b/mingw-w64-shiboken2-qt5/PKGBUILD
@@ -1,10 +1,11 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Andrew Smeltzov <andrew.smeltzov@gmail.com>
 
 _realname=shiboken2
 pkgbase=mingw-w64-${_realname}-qt5
 pkgname=(${MINGW_PACKAGE_PREFIX}-${_realname}-qt5)
 pkgdesc="CPython bindings generator for C++ libraries (mingw-w64)"
-pkgver=5.14.2
+pkgver=5.15.0
 pkgrel=1
 arch=('any')
 url="https://doc-snapshots.qt.io/qtforpython/"
@@ -20,15 +21,21 @@ options=('staticlibs' 'strip')
 install=${_realname}-${CARCH}.install
 source=(https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-${pkgver}-src/pyside-setup-opensource-src-${pkgver}.tar.xz
         001-shiboken.patch
-        002-cmake-relative-paths.patch)
-sha256sums=('7c7af33792de57255dbdc165c808e1f03a2520295c5922d9897aca8ad1be92b3'
+        002-cmake-relative-paths.patch
+        003-llvm-paths.patch
+        004-shibokenmodule-name.patch)
+sha256sums=('f1cdee53de3b76e22c1117a014a91ed95ac16e4760776f4f12dc38cd5a7b6b68'
             '1dd8273f99c2d1a9e82f7c0c3c03afcc73ce9bc75e68b8bd1863cf41674da25d'
-            'e8fce91fee692a3ef906c841575e53e141a58c0c97c63fd1d94bed5a823190f9')
+            'e8fce91fee692a3ef906c841575e53e141a58c0c97c63fd1d94bed5a823190f9'
+            '0f3b8d58b270da50392a65d42e4e1e5092d69c846f0d2e2eb82f661558ee78ab'
+            'bcf980041803028f9006e08e247327848145696f315b6319fe8de60501a27190')
 
 prepare() {
   cd ${srcdir}/pyside-setup-opensource-src-${pkgver}
   patch -p1 -i ${srcdir}/001-shiboken.patch
   patch -p1 -i ${srcdir}/002-cmake-relative-paths.patch
+  patch -p1 -i ${srcdir}/003-llvm-paths.patch
+  patch -p1 -i ${srcdir}/004-shibokenmodule-name.patch
 }
 
 build() {


### PR DESCRIPTION
There is at least one license issue though. PySide2 is built with Qt Data Visualization module which is not available under LGPL. https://doc.qt.io/qt-5/qtmodules.html#qt-add-ons
The question is should I exclude it from build or mark the Pyside2 package with more restrictive "GPL".