### PR TITLE
Rename gprbuild-gpl, xmlada-gpl into gprbuild, xmlada

### DIFF
--- a/mingw-w64-gprbuild-bootstrap-git/PKGBUILD
+++ b/mingw-w64-gprbuild-bootstrap-git/PKGBUILD
@@ -8,6 +8,12 @@ pkgbase=mingw-w64-${_realname}-git
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}-git
 pkgver=r3576.43e55df6
 pkgrel=1
+
+_gprbuild_commit="43e55df6c26e2bd48ab6c2f4214f497c4ddbc943"
+_gprbuild_extract_dir="AdaCore-gprbuild-43e55df"
+_xmlada_commit="c16f24ebf752b7d75dfdd0eaa7dd501a08a31256"
+_xmlada_extract_dir="AdaCore-xmlada-c16f24e"
+
 pkgdesc="Static GPRbuild to bootstrap XML/Ada and GPRbuild itself (mingw-w64)"
 arch=('any')
 url='https://github.com/AdaCore/gprbuild/'
@@ -19,18 +25,18 @@ provides=("${MINGW_PACKAGE_PREFIX}-gprbuild-bootstrap")
 conflicts=("${MINGW_PACKAGE_PREFIX}-gprbuild"
            "${MINGW_PACKAGE_PREFIX}-gprbuild-gpl"
            "${MINGW_PACKAGE_PREFIX}-gprbuild-bootstrap")
-source=(gprbuild::"git+https://github.com/AdaCore/gprbuild.git#commit=43e55df6c26e2bd48ab6c2f4214f497c4ddbc943"
-        xmlada::"git+https://github.com/AdaCore/xmlada.git#commit=c16f24ebf752b7d75dfdd0eaa7dd501a08a31256")
-sha256sums=('SKIP'
-            'SKIP')
+source=("gprbuild.tar.gz::https://api.github.com/repos/AdaCore/gprbuild/tarball/${_gprbuild_commit}"
+        "xmlada.tar.gz::https://api.github.com/repos/AdaCore/xmlada/tarball/${_xmlada_commit}")
+sha256sums=('d4491ae831ce3ab89ea930cc58280372325476046054cf64691bda867a52b028'
+            '12139d8c3d511b516f9dcf68ee76a70f2dc52031d379e9e4942aa84346974751')
 
 pkgver() {
-  cd "${srcdir}/gprbuild"
+  cd "${srcdir}/${_gprbuild_extract_dir}"
   printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
 }
 
 prepare() {
-  cd "${srcdir}/gprbuild"
+  cd "${srcdir}/${_gprbuild_extract_dir}"
 
   # GPRbuild hard-codes references to ${MINGW_PREFIX}/libexec, but MINGW packages
   # must use ${MINGW_PREFIX}/lib instead.
@@ -41,14 +47,14 @@ prepare() {
 }
 
 build() {
-  cd "${srcdir}/gprbuild"
+  cd "${srcdir}/${_gprbuild_extract_dir}"
 
   export GNATMAKEFLAGS="-j$(nproc)"
   export DESTDIR="${srcdir}/bootstrap"
   ./bootstrap.sh \
     --prefix=${MINGW_PREFIX} \
     --libexecdir=/lib \
-    --with-xmlada="${srcdir}/xmlada"
+    --with-xmlada="${srcdir}/${_xmlada_extract_dir}"
 }
 
 package() {

--- a/mingw-w64-gprbuild-bootstrap-git/PKGBUILD
+++ b/mingw-w64-gprbuild-bootstrap-git/PKGBUILD
@@ -19,8 +19,8 @@ provides=("${MINGW_PACKAGE_PREFIX}-gprbuild-bootstrap")
 conflicts=("${MINGW_PACKAGE_PREFIX}-gprbuild"
            "${MINGW_PACKAGE_PREFIX}-gprbuild-gpl"
            "${MINGW_PACKAGE_PREFIX}-gprbuild-bootstrap")
-source=('git+https://github.com/AdaCore/gprbuild.git'
-        'git+https://github.com/AdaCore/xmlada.git')
+source=(gprbuild::"git+https://github.com/AdaCore/gprbuild.git#commit=43e55df6c26e2bd48ab6c2f4214f497c4ddbc943"
+        xmlada::"git+https://github.com/AdaCore/xmlada.git#commit=c16f24ebf752b7d75dfdd0eaa7dd501a08a31256")
 sha256sums=('SKIP'
             'SKIP')
 

--- a/mingw-w64-gprbuild/PKGBUILD
+++ b/mingw-w64-gprbuild/PKGBUILD
@@ -1,14 +1,14 @@
 # Maintainer: Jürgen Pfeifer <juergen@familiepfeifer.de>
 # Contributor: Tim S <stahta01@gmail.com>
 
-_realname=gprbuild-gpl
+_realname=gprbuild
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=2020.0.43e55df
 pkgrel=1
 pkgdesc="Software tool designed to help automate the construction of multi-language systems (mingw-w64)"
 arch=('any')
-provides=("${MINGW_PACKAGE_PREFIX}-${_realname%-*}")
+replaces=("${MINGW_PACKAGE_PREFIX}-gprbuild-gpl")
 license=('GPL3')
 url="https://www.adacore.com/gnatpro/toolsuite/gprbuild/"
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc-ada"
@@ -21,21 +21,21 @@ source=("${_realname}"::"git+https://github.com/AdaCore/gprbuild.git#commit=43e5
 sha256sums=('SKIP')
 
 prepare() {
-  cd ${srcdir}/gprbuild-gpl
+  cd ${srcdir}/gprbuild
 
   #./bootstrap.sh
 }
 
 build() {
-  cd ${srcdir}/gprbuild-gpl
+  cd ${srcdir}/gprbuild
 
   make SOURCE_DIR="$PWD" prefix=${MINGW_PREFIX} setup
 
-    make
+  make
 }
 
 package() {
-  cd ${srcdir}/gprbuild-gpl
+  cd ${srcdir}/gprbuild
   make prefix="${pkgdir}${MINGW_PREFIX}" INSTALL=cp install
 
   # Copy License Files

--- a/mingw-w64-gprbuild/PKGBUILD
+++ b/mingw-w64-gprbuild/PKGBUILD
@@ -6,6 +6,10 @@ pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=2020.0.43e55df
 pkgrel=1
+
+_gprbuild_commit="43e55df6c26e2bd48ab6c2f4214f497c4ddbc943"
+_gprbuild_extract_dir="AdaCore-gprbuild-43e55df"
+
 pkgdesc="Software tool designed to help automate the construction of multi-language systems (mingw-w64)"
 arch=('any')
 replaces=("${MINGW_PACKAGE_PREFIX}-gprbuild-gpl")
@@ -17,17 +21,17 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc-ada"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-ada"
          "${MINGW_PACKAGE_PREFIX}-xmlada")
 conflicts=("${MINGW_PACKAGE_PREFIX}-gprbuild-bootstrap")
-source=("${_realname}"::"git+https://github.com/AdaCore/gprbuild.git#commit=43e55df6c26e2bd48ab6c2f4214f497c4ddbc943")
-sha256sums=('SKIP')
+source=("gprbuild.tar.gz::https://api.github.com/repos/AdaCore/gprbuild/tarball/${_gprbuild_commit}")
+sha256sums=('d4491ae831ce3ab89ea930cc58280372325476046054cf64691bda867a52b028')
 
 prepare() {
-  cd ${srcdir}/gprbuild
+  cd "${srcdir}/${_gprbuild_extract_dir}"
 
   #./bootstrap.sh
 }
 
 build() {
-  cd ${srcdir}/gprbuild
+  cd "${srcdir}/${_gprbuild_extract_dir}"
 
   make SOURCE_DIR="$PWD" prefix=${MINGW_PREFIX} setup
 
@@ -35,7 +39,7 @@ build() {
 }
 
 package() {
-  cd ${srcdir}/gprbuild
+  cd "${srcdir}/${_gprbuild_extract_dir}"
   make prefix="${pkgdir}${MINGW_PREFIX}" INSTALL=cp install
 
   # Copy License Files

--- a/mingw-w64-xmlada/PKGBUILD
+++ b/mingw-w64-xmlada/PKGBUILD
@@ -10,6 +10,10 @@ pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=2020
 pkgrel=1
+
+_xmlada_commit="c16f24ebf752b7d75dfdd0eaa7dd501a08a31256"
+_xmlada_extract_dir="AdaCore-xmlada-c16f24e"
+
 pkgdesc="A full XML suite for Ada (mingw-w64)"
 arch=('any')
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-gpl")
@@ -18,16 +22,12 @@ license=('GPL3')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc-ada"
              "${MINGW_PACKAGE_PREFIX}-gprbuild-bootstrap-git")
 depends=()
-source=("${_realname}"::"git+https://github.com/AdaCore/xmlada.git#commit=c16f24ebf752b7d75dfdd0eaa7dd501a08a31256")
-sha256sums=('SKIP')
+source=("xmlada.tar.gz::https://api.github.com/repos/AdaCore/xmlada/tarball/${_xmlada_commit}")
+sha256sums=('12139d8c3d511b516f9dcf68ee76a70f2dc52031d379e9e4942aa84346974751')
 options=('strip')
 
-prepare() {
-  cd ${srcdir}/${_realname}
-}
-
 build() {
-  cd ${srcdir}/${_realname}
+  cd ${srcdir}/${_xmlada_extract_dir}
   ./configure \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
@@ -43,7 +43,7 @@ package() {
   mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/xmlada/relocatable
   mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/gnat/xmlada
 
-  cd ${srcdir}/${_realname}
+  cd ${srcdir}/${_xmlada_extract_dir}
   make -j1 prefix=${pkgdir}${MINGW_PREFIX} INSTALL=cp install
 
   rm -rf ${pkgdir}${MINGW_PREFIX}/share/examples
@@ -51,6 +51,6 @@ package() {
 
   # Copy License Files
   mkdir -p ${pkgdir}${MINGW_PREFIX}/share/licenses/$_realname
-  cp -pf ${srcdir}/${_realname}/COPYING* \
+  cp -pf ${srcdir}/${_xmlada_extract_dir}/COPYING* \
     ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}
 }

--- a/mingw-w64-xmlada/PKGBUILD
+++ b/mingw-w64-xmlada/PKGBUILD
@@ -5,14 +5,14 @@
 # I recommend to use a short BUILDDIR setting to avoid problems
 #
 
-_realname=xmlada-gpl
+_realname=xmlada
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=2017
 pkgrel=2
 pkgdesc="A full XML suite for Ada (mingw-w64)"
 arch=('any')
-provides=("${MINGW_PACKAGE_PREFIX}-${_realname%-*}")
+replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-gpl")
 url="https://libre.adacore.com/libre/tools/xmlada/"
 license=('GPL3')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc-ada"

--- a/mingw-w64-xmlada/PKGBUILD
+++ b/mingw-w64-xmlada/PKGBUILD
@@ -8,8 +8,8 @@
 _realname=xmlada
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-pkgver=2017
-pkgrel=2
+pkgver=2020
+pkgrel=1
 pkgdesc="A full XML suite for Ada (mingw-w64)"
 arch=('any')
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-gpl")
@@ -18,7 +18,7 @@ license=('GPL3')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc-ada"
              "${MINGW_PACKAGE_PREFIX}-gprbuild-bootstrap-git")
 depends=()
-source=("${_realname}"::"git+https://github.com/AdaCore/xmlada.git#branch=gpl-${pkgver}")
+source=("${_realname}"::"git+https://github.com/AdaCore/xmlada.git#commit=c16f24ebf752b7d75dfdd0eaa7dd501a08a31256")
 sha256sums=('SKIP')
 options=('strip')
 


### PR DESCRIPTION
As discussed in #6754, the `-gpl` suffix comes from the time when these packages were built from the sources of the `GNAT GPL` release. But the `GNAT GPL` release doesn't exist anymore, and the packages are now built from the GitHub repos.

This PR also updates `xmlada`, this is required for compatibility with GCC GNAT 10.

CC @juergenpf and @reznikmm 