### PR TITLE
openimageio: updated to 2.1.18.1

### DIFF
--- a/mingw-w64-openimageio/PKGBUILD
+++ b/mingw-w64-openimageio/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=openimageio
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.1.16.0
+pkgver=2.1.18.1
 pkgrel=1
 pkgdesc="A library for reading and writing images, including classes, utilities, and applications (mingw-w64)"
 arch=('any')
@@ -53,7 +53,7 @@ source=(${_realname}-${pkgver}.tar.gz::https://github.com/OpenImageIO/oiio/archi
         0013-dont-export-enums.patch
         0014-fix-ptex-string-format.patch
         0015-python-module-ext.patch)
-sha256sums=('f44e3b3cffe9a8f47395da1ae59e972ecb26adf65f17581e6a489fdcce0cb116'
+sha256sums=('e2cf54f5b28e18fc88e76e1703f2e39bf144c88378334527e4a1246974659a85'
             'SKIP'
             '73c46166c1d19922b6b54f4e1e18128c33dadbc72a36b683049ec297ce1056b3'
             '9e4e21333676268a91c0f4e7676aeab7658e5f748e7e5cfe43a92f0fd7931229'


### PR DESCRIPTION
Fixes issue where OpenImageIO would look for LibRaw 0.19 (fixed in OIIO 2.1.17)