### PR TITLE
graphviz: fix the build

### DIFF
--- a/mingw-w64-graphviz/PKGBUILD
+++ b/mingw-w64-graphviz/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.40.1
 _commit='67cd2e5121379a38e0801cc05cce503' # stable_release_2.40.1
-pkgrel=12
+pkgrel=13
 pkgdesc="Graph Visualization Software (mingw-w64)"
 arch=('any')
 url='https://www.graphviz.org/'
@@ -32,7 +32,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-cairo"
 makedepends=(#"${MINGW_PACKAGE_PREFIX}-ocaml"
              #"${MINGW_PACKAGE_PREFIX}-lua"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
-             "${MINGW_PACKAGE_PREFIX}-python2"
+             #"${MINGW_PACKAGE_PREFIX}-python"
              #"${MINGW_PACKAGE_PREFIX}-ruby"
              #"${MINGW_PACKAGE_PREFIX}-tcl"
              "${MINGW_PACKAGE_PREFIX}-zlib"

--- a/mingw-w64-graphviz/PKGBUILD
+++ b/mingw-w64-graphviz/PKGBUILD
@@ -4,7 +4,8 @@ _realname=graphviz
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.40.1
-pkgrel=11
+_commit='67cd2e5121379a38e0801cc05cce503' # stable_release_2.40.1
+pkgrel=12
 pkgdesc="Graph Visualization Software (mingw-w64)"
 arch=('any')
 url='https://www.graphviz.org/'
@@ -38,7 +39,7 @@ makedepends=(#"${MINGW_PACKAGE_PREFIX}-ocaml"
              "git")
 options=(libtool)
 install=${_realname}-${CARCH}.install
-source=(${_realname}-${pkgver}::git+https://gitlab.com/graphviz/graphviz.git#tag=stable_release_${pkgver}
+source=(${_realname}-${pkgver}::git+https://gitlab.com/graphviz/graphviz.git#commit=${_commit}
         #https://graphviz.gitlab.io/pub/graphviz/stable/SOURCES/graphviz.tar.gz
         #"https://www.graphviz.org/pub/${_realname}/stable/SOURCES/${_realname}-${pkgver}.tar.gz"
         001-msvc-pragma.patch.patch
@@ -83,6 +84,7 @@ build() {
   local gd_incdir=$(pkg-config --variable=includedir gdlib)
   CFLAGS+=" -Wno-sign-conversion -Wno-sign-compare -Wno-conversion"
   CXXFLAGS+=" -Wno-sign-conversion -Wno-sign-compare -Wno-conversion"
+  CFLAGS+=" -fcommon"  # GCC10 is stricter, change to the previous default
   [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
   mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
   ../${_realname}-${pkgver}/configure \


### PR DESCRIPTION
It's an ancient version, but this is easier than updating.

Use a commit hash because the git tag was removed upstream.
Build with -fcommon which was the default before gcc 10.