### PR TITLE
Fix mingw-w64-bmake package.

### DIFF
--- a/mingw-w64-bmake/0004-add-windows-draft-configs.patch
+++ b/mingw-w64-bmake/0004-add-windows-draft-configs.patch
@@ -9,14 +9,20 @@ index a6bf9a2..fa50e79 100644
 +sys/MSYS.mk
  sys/NetBSD.mk
 diff --git a/mk/sys/MINGW32.mk b/mk/sys/MINGW32.mk
-index 10da919..5ba0424 100644
+index 10da919..5e9f2b5 100644
 --- a/mk/sys/MINGW32.mk
 +++ b/mk/sys/MINGW32.mk
 @@ -1,2 +1,2 @@
 -#	$Id: Linux.mk,v 1.9 2017/05/05 18:02:16 sjg Exp $
 +#	$Id: MINGW32.mk,v 1.9 2017/05/05 18:02:16 sjg Exp $
  #	$NetBSD: sys.mk,v 1.19.2.1 1994/07/26 19:58:31 cgd Exp $
-@@ -16,3 +16,7 @@ NEED_SOLINKS=yes
+@@ -14,5 +14,13 @@ NEED_SOLINKS=yes
+ 
++LD_X=
++LD_x=
++SHLIB_LD = ${CC}
++
+ .SUFFIXES: .out .a .ln .o .c ${CXX_SUFFIXES} .F .f .r .y .l .s .S .cl .p .h .sh .m4
  
 -.LIBS:		.a
 +.LIBS:		.a .dll
@@ -25,21 +31,27 @@ index 10da919..5ba0424 100644
 +HOST_LIBEXT =	.dll
 +DSHLIBEXT =	.dll
  
-@@ -21,2 +25,5 @@ ARFLAGS=	rl
+@@ -21,2 +29,5 @@ ARFLAGS=	rl
  RANLIB=		ranlib
 +LD_shared= -Bshareable
 +LD_so= dll.${SHLIB_FULLVERSION}
 +LD_solink= dll
  
 diff --git a/mk/sys/MINGW64.mk b/mk/sys/MINGW64.mk
-index 10da919..f7a1fe7 100644
+index 10da919..29f6ef2 100644
 --- a/mk/sys/MINGW64.mk
 +++ b/mk/sys/MINGW64.mk
 @@ -1,2 +1,2 @@
 -#	$Id: Linux.mk,v 1.9 2017/05/05 18:02:16 sjg Exp $
 +#	$Id: MINGW64.mk,v 1.9 2017/05/05 18:02:16 sjg Exp $
  #	$NetBSD: sys.mk,v 1.19.2.1 1994/07/26 19:58:31 cgd Exp $
-@@ -16,3 +16,7 @@ NEED_SOLINKS=yes
+@@ -14,5 +14,13 @@ NEED_SOLINKS=yes
+ 
++LD_X=
++LD_x=
++SHLIB_LD = ${CC}
++
+ .SUFFIXES: .out .a .ln .o .c ${CXX_SUFFIXES} .F .f .r .y .l .s .S .cl .p .h .sh .m4
  
 -.LIBS:		.a
 +.LIBS:		.a .dll
@@ -48,21 +60,27 @@ index 10da919..f7a1fe7 100644
 +HOST_LIBEXT =	.dll
 +DSHLIBEXT =	.dll
  
-@@ -21,2 +25,5 @@ ARFLAGS=	rl
+@@ -21,2 +29,5 @@ ARFLAGS=	rl
  RANLIB=		ranlib
 +LD_shared= -Bshareable
 +LD_so= dll.${SHLIB_FULLVERSION}
 +LD_solink= dll
  
 diff --git a/mk/sys/MSYS.mk b/mk/sys/MSYS.mk
-index 10da919..2454fd1 100644
+index 10da919..d91ca9d 100644
 --- a/mk/sys/MSYS.mk
 +++ b/mk/sys/MSYS.mk
 @@ -1,2 +1,2 @@
 -#	$Id: Linux.mk,v 1.9 2017/05/05 18:02:16 sjg Exp $
 +#	$Id: MSYS.mk,v 1.9 2017/05/05 18:02:16 sjg Exp $
  #	$NetBSD: sys.mk,v 1.19.2.1 1994/07/26 19:58:31 cgd Exp $
-@@ -16,3 +16,7 @@ NEED_SOLINKS=yes
+@@ -14,5 +14,13 @@ NEED_SOLINKS=yes
+ 
++LD_X=
++LD_x=
++SHLIB_LD = ${CC}
++
+ .SUFFIXES: .out .a .ln .o .c ${CXX_SUFFIXES} .F .f .r .y .l .s .S .cl .p .h .sh .m4
  
 -.LIBS:		.a
 +.LIBS:		.a .dll
@@ -71,7 +89,7 @@ index 10da919..2454fd1 100644
 +HOST_LIBEXT =	.dll
 +DSHLIBEXT =	.dll
  
-@@ -21,2 +25,5 @@ ARFLAGS=	rl
+@@ -21,2 +29,5 @@ ARFLAGS=	rl
  RANLIB=		ranlib
 +LD_shared= -Bshareable
 +LD_so= dll.${SHLIB_FULLVERSION}

--- a/mingw-w64-bmake/PKGBUILD
+++ b/mingw-w64-bmake/PKGBUILD
@@ -8,7 +8,7 @@ _realname=bmake
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=20181221
-pkgrel=2
+pkgrel=3
 pkgdesc='Portable version of the NetBSD make build tool'
 arch=('any')
 url='http://www.crufty.net/help/sjg/bmake.html'
@@ -72,6 +72,6 @@ package() {
 
   # install profile script
   mkdir -p "${pkgdir}${MINGW_PREFIX}"/etc/profile.d
-  echo "export SYSROOTWINDOWSPATH=$(cygpath -w /)" > "${pkgdir}${MINGW_PREFIX}"/etc/profile.d/bmake.sh
+  echo "export SYSROOTWINDOWSPATH=$(cygpath -w /); export MAKESYSPATH=${MINGW_PREFIX}/share/mk" > "${pkgdir}${MINGW_PREFIX}"/etc/profile.d/bmake.sh
   cp "${pkgdir}${MINGW_PREFIX}"/etc/profile.d/bmake.{sh,zsh}
 }


### PR DESCRIPTION
pkgrel=3: Fix Windows draft configs in mk/sys directory. Now all link operations should go through ${CC} compiler.

Related to https://github.com/msys2/MINGW-packages/issues/5859