### PR TITLE
mingw-w64-cfitsio: Enable large file support for cfitsio

### DIFF
--- a/mingw-w64-cfitsio/PKGBUILD
+++ b/mingw-w64-cfitsio/PKGBUILD
@@ -40,8 +40,6 @@ build() {
     -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DBUILD_SHARED_LIBS=OFF \
-    -D_LARGEFILE_SOURCE=ON \
-    -D_FILE_OFFSET_BITS=64 \
     ../${_realname}
 
   make
@@ -56,8 +54,6 @@ build() {
     -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DBUILD_SHARED_LIBS=ON \
-    -D_LARGEFILE_SOURCE=ON \
-    -D_FILE_OFFSET_BITS=64 \
     ../${_realname}
 
   make

--- a/mingw-w64-cfitsio/PKGBUILD
+++ b/mingw-w64-cfitsio/PKGBUILD
@@ -39,6 +39,8 @@ build() {
     -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DBUILD_SHARED_LIBS=OFF \
+    -D_LARGEFILE_SOURCE \
+    -D_FILE_OFFSET_BITS=64 \
     ../${_realname}
 
   make
@@ -52,6 +54,8 @@ build() {
     -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DBUILD_SHARED_LIBS=ON \
+    -D_LARGEFILE_SOURCE \
+    -D_FILE_OFFSET_BITS=64 \
     ../${_realname}
 
   make

--- a/mingw-w64-cfitsio/PKGBUILD
+++ b/mingw-w64-cfitsio/PKGBUILD
@@ -4,7 +4,7 @@ _realname=cfitsio
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.450
-pkgrel=1
+pkgrel=2
 pkgdesc="A library of C and Fortran subroutines for reading and writing data files in FITS (Flexible Image Transport System) data format (mingw-w64)"
 arch=('any')
 url="https://heasarc.gsfc.nasa.gov/fitsio/"
@@ -39,7 +39,7 @@ build() {
     -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DBUILD_SHARED_LIBS=OFF \
-    -D_LARGEFILE_SOURCE \
+    -D_LARGEFILE_SOURCE=ON \
     -D_FILE_OFFSET_BITS=64 \
     ../${_realname}
 
@@ -54,7 +54,7 @@ build() {
     -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DBUILD_SHARED_LIBS=ON \
-    -D_LARGEFILE_SOURCE \
+    -D_LARGEFILE_SOURCE=ON \
     -D_FILE_OFFSET_BITS=64 \
     ../${_realname}
 

--- a/mingw-w64-cfitsio/PKGBUILD
+++ b/mingw-w64-cfitsio/PKGBUILD
@@ -35,7 +35,8 @@ build() {
   mkdir ${srcdir}/static-${MINGW_CHOST} && cd "${srcdir}/static-${MINGW_CHOST}"
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX" \
-  ${MINGW_PREFIX}/bin/cmake.exe \
+  CFLAGS+=" -D_LARGEFILE_SOURCE=ON -D_FILE_OFFSET_BITS=64" \
+    ${MINGW_PREFIX}/bin/cmake.exe \
     -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DBUILD_SHARED_LIBS=OFF \
@@ -50,7 +51,8 @@ build() {
   mkdir ${srcdir}/shared-${MINGW_CHOST} && cd "${srcdir}/shared-${MINGW_CHOST}"
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX" \
-  ${MINGW_PREFIX}/bin/cmake.exe \
+  CFLAGS+=" -D_LARGEFILE_SOURCE=ON -D_FILE_OFFSET_BITS=64" \
+    ${MINGW_PREFIX}/bin/cmake.exe \
     -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DBUILD_SHARED_LIBS=ON \


### PR DESCRIPTION
It would be great to compile cfitsio with

-D_LARGEFILE_SOURCE \
-D_FILE_OFFSET_BITS=64 \

if not, there is a limitation of FITS size.