### PR TITLE
CI: store packages as GHA artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,3 +31,15 @@ jobs:
 
       - name: CI-Build
         run: MINGW_INSTALLS=${{ matrix.msystem }} ./ci-build.sh
+
+      - name: "Upload binaries"
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.msystem }}-packages
+          path: artifacts/*.pkg.tar.*
+
+      - name: "Upload sources"
+        uses: actions/upload-artifact@v2
+        with:
+          name: sources
+          path: artifacts/*.src.tar.*

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -9,7 +9,7 @@ set -e
 # Configure
 cd "$(dirname "$0")"
 source 'ci-library.sh'
-deploy_enabled && mkdir artifacts
+mkdir artifacts
 git_config user.email 'ci@msys2.org'
 git_config user.name  'MSYS2 Continuous Integration'
 git remote add upstream 'https://github.com/MSYS2/MINGW-packages'
@@ -34,8 +34,8 @@ for package in "${packages[@]}"; do
     execute 'Building binary' makepkg-mingw --noconfirm --noprogressbar --nocheck --syncdeps --rmdeps --cleanbuild
     execute 'Building source' makepkg --noconfirm --noprogressbar --allsource --config '/etc/makepkg_mingw64.conf'
     execute 'Installing' yes:pacman --noprogressbar --upgrade *"${PKGEXT}"
-    deploy_enabled && mv "${package}"/*"${PKGEXT}" artifacts
-    deploy_enabled && mv "${package}"/*"${SRCEXT}" artifacts
+    mv "${package}"/*"${PKGEXT}" artifacts
+    mv "${package}"/*"${SRCEXT}" artifacts
     unset package
 done
 


### PR DESCRIPTION
This makes the artifacts from available for download from GHA. This is very useful, for example when you want to download the binaries from a PR and run them locally.
