### PR TITLE
vulkan-validation-layers: Build layer support files

### DIFF
--- a/mingw-w64-vulkan-validation-layers/PKGBUILD
+++ b/mingw-w64-vulkan-validation-layers/PKGBUILD
@@ -5,7 +5,7 @@ _realname=Vulkan-ValidationLayers
 pkgbase=mingw-w64-vulkan-validation-layers
 pkgname=("${MINGW_PACKAGE_PREFIX}-vulkan-validation-layers")
 pkgver=1.2.148
-pkgrel=1
+pkgrel=2
 pkgdesc='Vulkan Validation Layers (mingw-w64)'
 arch=('any')
 url="https://www.khronos.org/vulkan/"
@@ -55,7 +55,8 @@ build() {
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DGLSLANG_INSTALL_DIR=${MINGW_PREFIX} \
     -DSPIRV_HEADERS_INSTALL_DIR=${MINGW_PREFIX} \
-    -DBUILD_LAYER_SUPPORT_FILES=OFF \
+    -DBUILD_LAYER_SUPPORT_FILES=ON \
+    -DCMAKE_INSTALL_INCLUDEDIR=include/vulkan \
     -DBUILD_TESTS=OFF \
     ../${_realname}-${pkgver}
 
@@ -66,5 +67,6 @@ package() {
   cd ${srcdir}/build-${CARCH}
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --build ./ --target install
 
+  install -Dm644 ${srcdir}/${_realname}-${pkgver}/docs/* -t ${pkgdir}${MINGW_PREFIX}/share/doc/vulkan-validation-layers/
   install -Dm644 ${srcdir}/${_realname}-${pkgver}/LICENSE.TXT ${pkgdir}${MINGW_PREFIX}/share/licenses/vulkan-validation-layers/LICENSE
 }


### PR DESCRIPTION
From #6799,

Changes are based on https://github.com/archlinux/svntogit-packages/blob/packages/vulkan-validation-layers/trunk/PKGBUILD

As a test I was able to compile [vkdevicechooser](https://github.com/aejsmith/vkdevicechooser) with both mingw64 and mingw32:

```
LDFLAGS=-static meson build-win64
meson compile -C build-win64
```

and

```
LDFLAGS='-static -Wl,--kill-at' meson build-win32
meson compile -C build-win32
```
