### PR TITLE
Update innoextract to 1.9.

### DIFF
--- a/mingw-w64-innoextract/0001-fix-segfault-windows.patch
+++ b/mingw-w64-innoextract/0001-fix-segfault-windows.patch
@@ -1,9 +1,0 @@
-diff --git a/src/util/windows.cpp b/src/util/windows.cpp
-index 9a978d7..1bebe9c 100644
---- a/src/util/windows.cpp
-+++ b/src/util/windows.cpp
-@@ -523,3 +523,3 @@ int main() {
- 	// Tell boost::filesystem to interpret our path strings as UTF-8
--	boost::filesystem::path::imbue(std::locale(std::locale(), &util::codecvt));
-+	boost::filesystem::path::imbue(std::locale(std::locale(), new std::codecvt_utf8_utf16<wchar_t>()));
- 	

--- a/mingw-w64-innoextract/PKGBUILD
+++ b/mingw-w64-innoextract/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=innoextract
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.8
-pkgrel=2
+pkgver=1.9
+pkgrel=1
 pkgdesc="A tool to extract installers created by Inno Setup (mingw-w64)"
 arch=('any')
 url="https://constexpr.org/innoextract/"
@@ -19,16 +19,10 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 options=('staticlibs' '!strip')
 source=("https://constexpr.org/innoextract/files/${_realname}-${pkgver}.tar.gz"
-        0001-fix-segfault-windows.patch
-)
-sha256sums=('5e78f6295119eeda08a54dcac75306a1a4a40d0cb812ff3cd405e9862c285269'
-            'BFBDF47059B1EFDD74F7847679B0ED9B61E00E8A6236BA518C050B43C4D09D2A'
 )
 
-prepare() {
-  cd "${srcdir}/${_realname}-${pkgver}"
-  patch -p1 -l -i "${srcdir}"/0001-fix-segfault-windows.patch # see https://github.com/dscharrer/innoextract/pull/114 for details
-}
+sha256sums=('6344A69FC1ED847D4ED3E272E0DA5998948C6B828CB7AF39C6321ABA6CF88126'
+)
 
 build() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}


### PR DESCRIPTION
Update innoextract to 1.9. Get rid of patch. It merged to upstream in https://github.com/dscharrer/innoextract/commit/1381ebdab633d827faced1b994693deda05de98d