### PR TITLE
dfu-programmer: Fix libusb-win32 dependency

### DIFF
--- a/mingw-w64-dfu-programmer/PKGBUILD
+++ b/mingw-w64-dfu-programmer/PKGBUILD
@@ -4,12 +4,12 @@ _realname=dfu-programmer
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=0.7.2
-pkgrel=1
+pkgrel=2
 pkgdesc='Device firmware update based USB programmer for Atmel chips (mingw-w64)'
 arch=('any')
 license=('GPL')
 url='https://github.com/dfu-programmer/dfu-programmer'
-makedepends=("${MINGW_PACKAGE_PREFIX}-libusb-win32")
+depends=("${MINGW_PACKAGE_PREFIX}-libusb-win32")
 source=(
     "https://downloads.sourceforge.net/project/dfu-programmer/dfu-programmer/${pkgver}/dfu-programmer-${pkgver}.tar.gz"
     01-use-libusb-win32.patch


### PR DESCRIPTION
Turned libusb-win32 into a normal dependency - otherwise running dfu-programmer (without the libusb0 driver installed into System32 through eg. Zadig) crashes either with "error while loading shared libraries: libusb0.dll", or prints nothing at all. However, the device will still not be seen unless it has the libusb0 driver assigned, but this behaviour is expected and is the same as the official release.