### PR TITLE
Add a cninja package

### DIFF
--- a/mingw-w64-cninja/PKGBUILD
+++ b/mingw-w64-cninja/PKGBUILD
@@ -1,0 +1,45 @@
+# Maintainer: Jean-Michaël Celerier <jeanmichael.celerier at gmail dot com>
+_realname=cninja
+pkgbase=mingw-w64-${_realname}
+pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
+pkgver=3.5.3
+pkgrel=1
+pkgdesc="cninja, an opinionated cmake config manager"
+arch=('any')
+url="https://github.com/jcelerier/cninja"
+license=('AGPLv3')
+depends=(
+    "${MINGW_PACKAGE_PREFIX}-cmake" 
+    "${MINGW_PACKAGE_PREFIX}-clang" 
+    "${MINGW_PACKAGE_PREFIX}-lld" 
+    "${MINGW_PACKAGE_PREFIX}-ninja"
+    "${MINGW_PACKAGE_PREFIX}-libc++"
+)
+makedepends=(
+    "${MINGW_PACKAGE_PREFIX}-boost"
+)
+provides=("$pkgname=$pkgver")
+source=("https://github.com/jcelerier/cninja/releases/download/v${pkgver}/cninja-v${pkgver}-src.tar.gz")
+sha512sums=("915495dcd0abfda9adc7c7b69bb195929a9e26e5052314f9d14596924dac5c62487b488a5926fc59b5e2bf44ea033acbb2c49adb88f5e5ed180f2b6398936f8d")
+
+build() {
+  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST} 
+  mkdir -p build-${MINGW_CHOST} && cd build-${MINGW_CHOST}
+ 
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake \
+    -GNinja \
+    -Wno-dev \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+     "$srcdir"
+
+  cmake --build .
+}
+
+package() {
+  cd "$srcdir/build-${MINGW_CHOST}"
+  DESTDIR="${pkgdir}" cmake --build . --target install/strip
+
+  install -D -m644 "$srcdir/LICENSE.md" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}


### PR DESCRIPTION
cninja is a software to make use of cmake easier and set sane cross-platform defaults to it. 