### PR TITLE
CI: disable update-srcinfo on forks

### DIFF
--- a/.github/workflows/generate-srcinfo.yml
+++ b/.github/workflows/generate-srcinfo.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   update-srcinfo:
     runs-on: windows-latest
+    if: ${{ github.repository == 'msys2/MINGW-packages' || github.event_name == 'workflow_dispatch' }}
     defaults:
       run:
         shell: msys2 {0}


### PR DESCRIPTION
This workflow is meant to generate a file that msys2-web consumes, and just generates meaningless errors on forks.  Forks can still trigger the workflow via workflow_dispatch, for developing/testing the workflow.