### PR TITLE
libid3tag: fix build

### DIFF
--- a/mingw-w64-libid3tag/006-libid3tag-0.15.1b-gperf-size_t.patch
+++ b/mingw-w64-libid3tag/006-libid3tag-0.15.1b-gperf-size_t.patch
@@ -1,0 +1,25 @@
+Index: libid3tag-0.15.1b/frametype.h
+===================================================================
+--- libid3tag-0.15.1b.orig/frametype.h
++++ libid3tag-0.15.1b/frametype.h
+@@ -37,6 +37,6 @@ extern struct id3_frametype const id3_fr
+ extern struct id3_frametype const id3_frametype_obsolete;
+ 
+ struct id3_frametype const *id3_frametype_lookup(register char const *,
+-						 register unsigned int);
++						 register size_t);
+ 
+ # endif
+Index: libid3tag-0.15.1b/compat.h
+===================================================================
+--- libid3tag-0.15.1b.orig/compat.h
++++ libid3tag-0.15.1b/compat.h
+@@ -34,7 +34,7 @@ struct id3_compat {
+ };
+ 
+ struct id3_compat const *id3_compat_lookup(register char const *,
+-					   register unsigned int);
++					   register size_t);
+ 
+ int id3_compat_fixup(struct id3_tag *);
+ 

--- a/mingw-w64-libid3tag/PKGBUILD
+++ b/mingw-w64-libid3tag/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libid3tag
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.15.1b
-pkgrel=1
+pkgrel=2
 pkgdesc="Library for id3 tagging (mingw-w64)"
 arch=('any')
 url="https://www.underbit.com/products/mad/"
@@ -19,6 +19,7 @@ source=(#"ftp://ftp.mars.org/pub/mpeg/${_realname}-${pkgver}.tar.gz"
         '10_utf16.patch'
         '11_unknown_encoding.patch'
         'CVE-2008-2109.patch'
+        '006-libid3tag-0.15.1b-gperf-size_t.patch'
         'id3tag.pc'
         )
 sha256sums=('63da4f6e7997278f8a3fef4c6a372d342f705051d1eeb6a46a86b03610e26151'
@@ -27,7 +28,8 @@ sha256sums=('63da4f6e7997278f8a3fef4c6a372d342f705051d1eeb6a46a86b03610e26151'
             '8aa2ef25a6560d5f82e8f1b06c080bf7bb507d63098915b9aa6614684f44af0f'
             'f58b782bef23fe393b992b74ef2fe4c5f7715b971faf9e048e65f8eb020b0c1a'
             '43ea3e0b324fb25802dae6410564c947ce1982243c781ef54b023f060c3b0ac4'
-            '224815cbbaaf8008061fca9a65524629eec4dbd4dc7f4db35645e0c89b30f37d')
+            'e85136f6f907c5e5f8f04ce5d125316ffbfc215f84cd06eea4196b651184fe89'
+            '12c59fd85e1e327c96e33457e71d41018e6200cd0d567c0fc7556328f88a8f23')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -36,10 +38,14 @@ prepare() {
   patch -p1 -i ${srcdir}/10_utf16.patch
   patch -p1 -i ${srcdir}/11_unknown_encoding.patch
   patch -Np0 -i ${srcdir}/CVE-2008-2109.patch
+  patch -p1 -i ${srcdir}/006-libid3tag-0.15.1b-gperf-size_t.patch
 
   touch NEWS AUTHORS ChangeLog
   rm aclocal.m4
   rm Makefile.in
+  # Force these files to be regenerated from the .gperf sources.
+  rm compat.c frametype.c
+
   autoreconf -fi
 }
 

--- a/mingw-w64-libid3tag/id3tag.pc
+++ b/mingw-w64-libid3tag/id3tag.pc
@@ -5,6 +5,6 @@ includedir=${prefix}/include
 
 Name: ID3TAG
 Description: libid3tag - ID3 tag manipulation library
-Version: 0.15.0b
+Version: 0.15.1b
 Libs: -L${libdir} -lid3tag -lz
 Cflags:


### PR DESCRIPTION
- add **`006-libid3tag-0.15.1b-gperf-size_t.patch`**
  Fixes the following error:
```console
frametype.gperf:322:1: error: conflicting types for 'id3_frametype_lookup'
In file included from frametype.gperf:32:
../libid3tag-0.15.1b/frametype.h:39:29: note: previous declaration of 'id3_frametype_lookup' was here
   39 | struct id3_frametype const *id3_frametype_lookup(register char const *,
      |                             ^~~~~~~~~~~~~~~~~~~~
make[2]: *** [Makefile:571: frametype.lo] Error 1
```
- remove `compat.c` and `frametype.c` from the source dir, so that they are
  regenerated from the `.gperf` sources during build. The files `compat.c`
  and `frametype.c` in the tarball have been produced using gperf 3.0.1,
  whereas in the meantime gperf is at version 3.1
- Fix version in **`id3tag.pc`**
