### PR TITLE
msmpi: force / as file name separator in command line paths

### DIFF
--- a/mingw-w64-msmpi/PKGBUILD
+++ b/mingw-w64-msmpi/PKGBUILD
@@ -4,7 +4,7 @@ _realname=msmpi
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=10.1.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Microsoft MPI SDK (mingw-w64)"
 arch=('any')
 url="https://docs.microsoft.com/en-us/message-passing-interface/microsoft-mpi"
@@ -22,16 +22,15 @@ source=(
   'msmpi.def.x86_64'
   'msmpi.def.i686'
 )
-sha256sums=(
-  'b77161211b70dbdd866e3df710c4a0e54d74b1421dade0a2f5c716fb5f2b82d9'
-  'baee3f18f38650e7182956baa0d3d8f8e5c26d8603ccee4871a4dbd160c13660'
-  'f3384eeb848164e518edfd2b2b9ff1d0f33e267efd5811d5a7c5f79ef7a0a81e'
-  '38e7be31ad555570f6122058317c08504472b8cfd0a198cdad827519b941ba2c'
-  '031f910c6ce9a0f7bf66365dd4271fa36530f32c5d22755b10ef2d89dc605e1f'
-  '4ff6e817fe7517f04f0ca04a038e4c136264384d36f520b79995604e3986fce4'
-  'fd18184993872fc4eaea825e85f974dca4b020598d838c424c6c112c2328cf2a'
-  '7b8ed9d3e257e439678cc648164164d6817f7fde68530055b392f67d97bf8ec8'
-)
+sha256sums=('8284306d3d86a29904ce55b6a91a982470b0648821da0a563a34977a542e30e4'
+            'baee3f18f38650e7182956baa0d3d8f8e5c26d8603ccee4871a4dbd160c13660'
+            'f3384eeb848164e518edfd2b2b9ff1d0f33e267efd5811d5a7c5f79ef7a0a81e'
+            '38e7be31ad555570f6122058317c08504472b8cfd0a198cdad827519b941ba2c'
+            '031f910c6ce9a0f7bf66365dd4271fa36530f32c5d22755b10ef2d89dc605e1f'
+            '4ff6e817fe7517f04f0ca04a038e4c136264384d36f520b79995604e3986fce4'
+            'fd18184993872fc4eaea825e85f974dca4b020598d838c424c6c112c2328cf2a'
+            '7b8ed9d3e257e439678cc648164164d6817f7fde68530055b392f67d97bf8ec8')
+
 
 build() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}

--- a/mingw-w64-msmpi/mpi.c
+++ b/mingw-w64-msmpi/mpi.c
@@ -19,13 +19,15 @@ int main(int argc, char** argv) {
 	int s = strlen(argv[0]);
 	while(argv[0][s] != '\\' && argv[0][s] != '/') --s; --s;
 	while(argv[0][s] != '\\' && argv[0][s] != '/') --s;
-	char slash = argv[0][s];
 	argv[0][s] = '\0';
+        // Force forward slash as a file name separator
+        s = strlen(argv[0]);
+        while(s >= 0) if(argv[0][s--] == '\\') argv[0][s+1] = '/';
 #define SZ 32767	
 	char* lpath = malloc(SZ*sizeof(char));
-	snprintf(lpath, SZ, "-L%s%clib", argv[0], slash);
+	snprintf(lpath, SZ, "-L%s/lib", argv[0]);
 	char* ipath = malloc(SZ*sizeof(char));
-	snprintf(ipath, SZ, "-I%s%cinclude", argv[0], slash);
+	snprintf(ipath, SZ, "-I%s/include", argv[0]);
 	char* comp = malloc(SZ*sizeof(char));
 	char** args = malloc(SZ*sizeof(char*));
 	int show = (argc == 2 && strcmp(argv[1], "-show") == 0);
@@ -47,6 +49,6 @@ int main(int argc, char** argv) {
 		fflush(stdout);
 		return 0;
 	} else {
-		return _spawnvp(_P_WAIT, args[0], args);
+		return _spawnvp(_P_WAIT, args[0], (const char* const*)args);
 	}
 };


### PR DESCRIPTION
Commit is intended to fix issue manifested in #6216 