### PR TITLE
Update PKGBUILD for Glade

### DIFF
--- a/mingw-w64-libhandy/PKGBUILD
+++ b/mingw-w64-libhandy/PKGBUILD
@@ -4,13 +4,16 @@ _realname=libhandy
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.90.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A library full of GTK+ widgets for mobile phones (mingw-w64)"
 url="https://gitlab.gnome.org/GNOME/libhandy"
 license=("LGPL2.1+")
 arch=('any')
-depends=("${MINGW_PACKAGE_PREFIX}-gtk3")
-makedepends=("${MINGW_PACKAGE_PREFIX}-meson"
+depends=("${MINGW_PACKAGE_PREFIX}-glib2"
+         "${MINGW_PACKAGE_PREFIX}-gtk3")
+makedepends=("${MINGW_PACKAGE_PREFIX}-glade"
+             "${MINGW_PACKAGE_PREFIX}-meson"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-vala"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection")

--- a/mingw-w64-libhandy/PKGBUILD
+++ b/mingw-w64-libhandy/PKGBUILD
@@ -30,7 +30,7 @@ build() {
     --buildtype=plain \
     -Dexamples=false \
     -Dgtk_doc=false \
-    -Dglade_catalog=disabled \
+    -Dglade_catalog=enabled \
     ../"libhandy-${pkgver}"
 
   ${MINGW_PREFIX}/bin/ninja


### PR DESCRIPTION
Create the "mingw-w64-libhandy" package with the flag "-Dglade_catalog=enabled" to display the libhandy widgets in Glade.