### PR TITLE
jemalloc: build without prefix as is default on other systems

### DIFF
--- a/mingw-w64-jemalloc/PKGBUILD
+++ b/mingw-w64-jemalloc/PKGBUILD
@@ -4,7 +4,7 @@ _realname=jemalloc
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=5.2.1
-pkgrel=1
+pkgrel=2
 pkgdesc="General-purpose scalable concurrent malloc implementation (mingw64)"
 arch=('any')
 url="http://jemalloc.net/"
@@ -44,6 +44,7 @@ build() {
     --host=${MINGW_CHOST} \
     --enable-autogen \
     --with-xslroot=${_XMLROOT} \
+    --with-jemalloc-prefix= \
     ${_btype}
 
   make


### PR DESCRIPTION
This allows the library to be statically linked to replace `malloc` and other functions like is possible on other systems.

I don't know why this was made default, does anyone know a good reason? I tested it and it works.

https://github.com/jemalloc/jemalloc/commit/7cdea3973cab8640d1f44c7638ed5e30ed18be24

This is where it was changed, no reason given. I've also checked the changelog and issue tracker and found nothing.