### PR TITLE
cego : update to version 2.45.20

### DIFF
--- a/mingw-w64-cego/PKGBUILD
+++ b/mingw-w64-cego/PKGBUILD
@@ -2,7 +2,7 @@
 _realname=cego
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.45.19
+pkgver=2.45.20
 pkgrel=1
 pkgdesc="Cego database system (mingw-w64)"
 arch=('any')
@@ -15,7 +15,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-readline"
 
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 
-sha256sums=('e127118a023d9bc3fd5e48ef2dc146b03600b0f94bf56aa3310c21df0c002ecf')
+sha256sums=('61d48a792f32df42d92f57f2d6583b28d0f9d4caffb9266cfa0b12120c3cc777')
 
 prepare() {
   cd $srcdir/${_realname}-${pkgver}


### PR DESCRIPTION
This is a sync patch to build cego with lfcbase-1.14.4 ( header was modified with 1.14.4 )