### PR TITLE
mingw-w64-gcc: Update validpgpkeys

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -84,7 +84,10 @@ sha256sums=('b8dd4368bb9c7f0b98188317ee0254dd8cc99d1e3a18d0ff146c855fe16c1d8c'
             'c7359f4c7015bc1fb02bc13449fa9826669273bd1f0663ba898decb67e8487fc'
             '055289699c4222ef0b8125abdc8c9ceeff0712876c86e6d552a056fbacc14284'
             '5240a9e731b45c17a164066c7eb193c1fbee9fd8d9a2a5afa2edbcde9510da47')
-validpgpkeys=('33C235A34C46AA3FFB293709A328C3A2C3C45C06')
+validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.org
+              86CFFCA918CF3AF47147588051E8B148A9999C34  # evangelos@foutrelis.com
+              13975A70E63C361C73AE69EF6EEB81F8981C74C7  # richard.guenther@gmail.com
+              33C235A34C46AA3FFB293709A328C3A2C3C45C06) # Jakub Jelinek <jakub@redhat.com>
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {


### PR DESCRIPTION
Existing package failed due to being signed with a different key.

List shamelessly lifted from https://github.com/archlinux/svntogit-packages/blob/6e8b5dac2553664eaac8e8f23555a85a99fb3045/trunk/PKGBUILD#L29-L32