### PR TITLE
gcc: specify LDFLAGS_FOR_TARGET and --with-boot-ldflags

### DIFF
--- a/mingw-w64-gcc/0150-gcc-10.2.0-libgcc-ldflags.patch
+++ b/mingw-w64-gcc/0150-gcc-10.2.0-libgcc-ldflags.patch
@@ -1,0 +1,19 @@
+--- a/libgcc/Makefile.in	2020-08-29 23:18:54.246729700 -0700
++++ b/libgcc/Makefile.in	2020-08-29 23:23:26.754578500 -0700
+@@ -84,6 +84,7 @@
+ 
+ CC = @CC@
+ CFLAGS = @CFLAGS@
++LDFLAGS = @LDFLAGS@
+ RANLIB = @RANLIB@
+ LN_S = @LN_S@
+ 
+@@ -991,7 +992,7 @@
+ 	# @multilib_dir@ is not really necessary, but sometimes it has
+ 	# more uses than just a directory name.
+ 	$(mkinstalldirs) $(MULTIDIR)
+-	$(subst @multilib_flags@,$(CFLAGS) -B./,$(subst \
++	$(subst @multilib_flags@,$(CFLAGS) -B./ $(LDFLAGS),$(subst \
+ 		@multilib_dir@,$(MULTIDIR),$(subst \
+ 		@shlib_objs@,$(objects) libgcc.a,$(subst \
+ 		@shlib_base_name@,libgcc_s,$(subst \

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -243,6 +243,7 @@ build() {
   if [ "$_enable_ada" == "yes" ]; then
     mv ${srcdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/adalib/*.dll ${srcdir}${MINGW_PREFIX}/bin/
   fi
+  peflags -d0 ${srcdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/*1*.exe
 }
 
 package_mingw-w64-gcc-libs() {

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -21,7 +21,7 @@ pkgver=10.2.0
 #_majorver=${pkgver:0:1}
 #_sourcedir=${_realname}-${_majorver}-${_snapshot}
 _sourcedir=${_realname}-${pkgver}
-pkgrel=1
+pkgrel=2
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 url="https://gcc.gnu.org"
@@ -63,7 +63,8 @@ source=("https://ftp.gnu.org/gnu/gcc/${_realname}-${pkgver%%+*}/${_realname}-${p
         0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
         0021-gcc-config-i386-mingw32.h-Ensure-lmsvcrt-precede-lke.patch
         0130-libstdc++-in-out.patch
-        0140-gcc-8.2.0-diagnostic-color.patch)
+        0140-gcc-8.2.0-diagnostic-color.patch
+        0150-gcc-10.2.0-libgcc-ldflags.patch)
 sha256sums=('b8dd4368bb9c7f0b98188317ee0254dd8cc99d1e3a18d0ff146c855fe16c1d8c'
             'SKIP'
             'bce81824fc89e5e62cca350de4c17a27e27a18a1a1ad5ca3492aec1fc5af3234'
@@ -83,7 +84,8 @@ sha256sums=('b8dd4368bb9c7f0b98188317ee0254dd8cc99d1e3a18d0ff146c855fe16c1d8c'
             '276ecc392c777d4b17d771a987e80dca50ff25d8f65671d5de139be73997064b'
             'c7359f4c7015bc1fb02bc13449fa9826669273bd1f0663ba898decb67e8487fc'
             '055289699c4222ef0b8125abdc8c9ceeff0712876c86e6d552a056fbacc14284'
-            '5240a9e731b45c17a164066c7eb193c1fbee9fd8d9a2a5afa2edbcde9510da47')
+            '5240a9e731b45c17a164066c7eb193c1fbee9fd8d9a2a5afa2edbcde9510da47'
+            '7f0b4e45d933e18c9d8bd2afcd83e4f52e97e2e25dd41bfa0cba755c70e591c7')
 validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.org
               86CFFCA918CF3AF47147588051E8B148A9999C34  # evangelos@foutrelis.com
               13975A70E63C361C73AE69EF6EEB81F8981C74C7  # richard.guenther@gmail.com
@@ -138,6 +140,9 @@ prepare() {
   # Вячеслав Петрищев <vyachemail@gmail.com>
   apply_patch_with_msg \
     0140-gcc-8.2.0-diagnostic-color.patch
+
+  apply_patch_with_msg \
+    0150-gcc-10.2.0-libgcc-ldflags.patch
 
   # do not expect ${prefix}/mingw symlink - this should be superceded by
   # 0005-Windows-Don-t-ignore-native-system-header-dir.patch .. but isn't!
@@ -219,6 +224,8 @@ build() {
     --with-pkgversion="Rev${pkgrel}, Built by MSYS2 project" \
     --with-bugurl="https://github.com/msys2/MINGW-packages/issues" \
     --with-gnu-as --with-gnu-ld \
+    --with-boot-ldflags="${LDFLAGS} -static-libstdc++ -static-libgcc" \
+    LDFLAGS_FOR_TARGET="${LDFLAGS}" \
     ${_conf}
 
   # While we're debugging -fopenmp problems at least.


### PR DESCRIPTION
Allows these flags to affect binaries produced post-stage1.

After much fiddling and time spent compiling, this gets the flags applied to **most** binaries.  With what's live right now, the large address aware flag on i686 is a good indicator, as someone previously added the flag to the PKGBUILD, but it never actually took effect later than stage1.

```
$ find . -name \*.exe -o -name \*.dll | peflags -vT - | grep -v bigaddr
./mingw-w64-i686-gcc-ada-10.2.0-2-any/mingw32/bin/libgnarl-10.dll: coff(0x2306[+executable_image,+line_nums_stripped,+32bit_machine,+sepdbg,+dll]) pe(0x0000)
./mingw-w64-i686-gcc-ada-10.2.0-2-any/mingw32/bin/libgnat-10.dll: coff(0x2306[+executable_image,+line_nums_stripped,+32bit_machine,+sepdbg,+dll]) pe(0x0000)
./mingw-w64-i686-gcc-libs-10.2.0-2-any/mingw32/bin/libgcc_s_dw2-1.dll: coff(0x2306[+executable_image,+line_nums_stripped,+32bit_machine,+sepdbg,+dll]) pe(0x0000)
```

I have not yet found a way to get LDFLAGS applied to libgcc*.dll, and I have no idea about ada.