### PR TITLE
python: rebuild without high-entropy-va

### DIFF
--- a/mingw-w64-python/PKGBUILD
+++ b/mingw-w64-python/PKGBUILD
@@ -18,7 +18,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 _pybasever=3.8
 pkgver=${_pybasever}.5
-pkgrel=1
+pkgrel=2
 provides=("${MINGW_PACKAGE_PREFIX}-python3=${pkgver}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3"
            "${MINGW_PACKAGE_PREFIX}-python2<2.7.16-7")
@@ -349,6 +349,9 @@ build() {
   CFLAGS+=" -fwrapv -D__USE_MINGW_ANSI_STDIO=1 -D_WIN32_WINNT=0x0601"
   CXXFLAGS+=" -fwrapv -D__USE_MINGW_ANSI_STDIO=1 -D_WIN32_WINNT=0x0601"
   CPPFLAGS+=" -I${PREFIX_WIN}/include/ncurses "
+  if [[ "$CARCH" = 'x86_64' ]]; then
+    LDFLAGS+=" -Wl,--disable-high-entropy-va"
+  fi
 
   declare -a _extra_config
   if check_option "strip" "y"; then


### PR DESCRIPTION
It crashes the build otherwise
