### PR TITLE
arm-none-eabi-gcc: use default LDFLAGS for plugin.

### DIFF
--- a/mingw-w64-arm-none-eabi-gcc/PKGBUILD
+++ b/mingw-w64-arm-none-eabi-gcc/PKGBUILD
@@ -8,7 +8,7 @@ _target=arm-none-eabi
 pkgbase=mingw-w64-${_target}-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_target}-${_realname}")
 pkgver=8.4.0
-pkgrel=1
+pkgrel=2
 pkgdesc='GNU Tools for ARM Embedded Processors - GCC (mingw-w64)'
 arch=('any')
 license=('GPL')
@@ -75,6 +75,7 @@ _build_gcc() {
         --enable-gnu-indirect_function \
         --with-multilib-list=rmprofile \
         --with-host-libstdcxx="-static-libgcc -Wl,-Bstatic,-lstdc++,-Bdynamic -lm" \
+        --enable-linker-plugin-flags='LDFLAGS=-static-libstdc++\ -static-libgcc\ '"${LDFLAGS// /\\ }"'\ -Wl,--stack,12582912' \
         LDFLAGS="${_GCC_LDFLAGS}"
 
     make INHIBIT_LIBC_CFLAGS='-DUSE_TM_CLONE_REGISTRY=0'


### PR DESCRIPTION
https://gitter.im/msys2/msys2?at=5f5533a849a1df0a12d16fe2