### PR TITLE
Fix libbacktrace on mingw64

### DIFF
--- a/mingw-w64-gcc/0160-libbacktrace-seh.patch
+++ b/mingw-w64-gcc/0160-libbacktrace-seh.patch
@@ -1,0 +1,23 @@
+libgcc/Changelog:
+        * unwind-seh.c (_Unwind_Backtrace): Set the ra and cfa pointers
+        before calling the callback.
+---
+ libgcc/unwind-seh.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/libgcc/unwind-seh.c b/libgcc/unwind-seh.c
+index 1a70180cfaa..275d782903a 100644
+--- a/libgcc/unwind-seh.c
++++ b/libgcc/unwind-seh.c
+@@ -466,6 +466,11 @@ _Unwind_Backtrace(_Unwind_Trace_Fn trace,
+ 			    &gcc_context.disp->HandlerData,
+ 			    &gcc_context.disp->EstablisherFrame, NULL);
+ 
++      /* Set values that the callback can inspect via _Unwind_GetIP
++       * and _Unwind_GetCFA. */
++      gcc_context.ra = ms_context.Rip;
++      gcc_context.cfa = ms_context.Rsp;
++
+       /* Call trace function.  */
+       if (trace (&gcc_context, trace_argument) != _URC_NO_REASON)
+ 	return _URC_FATAL_PHASE1_ERROR;

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -3,6 +3,7 @@
 # Contributor: Ray Donnelly <mingw.android@gmail.com>
 # Contributor: Renato Silva <br.renatosilva@gmail.com>
 # Contributor: wirx6 <wirx654@gmail.com>
+# Contributor: Kirill Müller <krlmlr@mailbox.org>
 
 _enable_ada=yes
 _enable_objc=yes
@@ -21,7 +22,7 @@ pkgver=10.2.0
 #_majorver=${pkgver:0:1}
 #_sourcedir=${_realname}-${_majorver}-${_snapshot}
 _sourcedir=${_realname}-${pkgver}
-pkgrel=4
+pkgrel=5
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 url="https://gcc.gnu.org"
@@ -64,7 +65,8 @@ source=("https://ftp.gnu.org/gnu/gcc/${_realname}-${pkgver%%+*}/${_realname}-${p
         0021-gcc-config-i386-mingw32.h-Ensure-lmsvcrt-precede-lke.patch
         0130-libstdc++-in-out.patch
         0140-gcc-8.2.0-diagnostic-color.patch
-        0150-gcc-10.2.0-libgcc-ldflags.patch)
+        0150-gcc-10.2.0-libgcc-ldflags.patch
+        0160-libbacktrace-seh.patch)
 sha256sums=('b8dd4368bb9c7f0b98188317ee0254dd8cc99d1e3a18d0ff146c855fe16c1d8c'
             'SKIP'
             'bce81824fc89e5e62cca350de4c17a27e27a18a1a1ad5ca3492aec1fc5af3234'
@@ -85,7 +87,8 @@ sha256sums=('b8dd4368bb9c7f0b98188317ee0254dd8cc99d1e3a18d0ff146c855fe16c1d8c'
             'c7359f4c7015bc1fb02bc13449fa9826669273bd1f0663ba898decb67e8487fc'
             '055289699c4222ef0b8125abdc8c9ceeff0712876c86e6d552a056fbacc14284'
             '5240a9e731b45c17a164066c7eb193c1fbee9fd8d9a2a5afa2edbcde9510da47'
-            '7f0b4e45d933e18c9d8bd2afcd83e4f52e97e2e25dd41bfa0cba755c70e591c7')
+            '7f0b4e45d933e18c9d8bd2afcd83e4f52e97e2e25dd41bfa0cba755c70e591c7'
+            '88c1d65e763e631ad49f9a077ed631f4acac9ef4732e2818ccddaefc883b1811')
 validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.org
               86CFFCA918CF3AF47147588051E8B148A9999C34  # evangelos@foutrelis.com
               13975A70E63C361C73AE69EF6EEB81F8981C74C7  # richard.guenther@gmail.com
@@ -143,6 +146,11 @@ prepare() {
 
   apply_patch_with_msg \
     0150-gcc-10.2.0-libgcc-ldflags.patch
+
+  # ensure libbacktrace works with SEH
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96948
+  apply_patch_with_msg \
+    0160-libbacktrace-seh.patch
 
   # do not expect ${prefix}/mingw symlink - this should be superceded by
   # 0005-Windows-Don-t-ignore-native-system-header-dir.patch .. but isn't!


### PR DESCRIPTION
Downstream: https://github.com/ianlancetaylor/libbacktrace/issues/43

Upstream: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96948, https://gcc.gnu.org/pipermail/gcc-patches/2020-September/553418.html