### PR TITLE
gdb: apply upstream patch for rebasing aslr exes.

### DIFF
--- a/mingw-w64-gdb/PKGBUILD
+++ b/mingw-w64-gdb/PKGBUILD
@@ -5,7 +5,7 @@ _realname=gdb
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=9.2
-pkgrel=1
+pkgrel=2
 pkgdesc="GNU Debugger (mingw-w64)"
 arch=('any')
 url="https://www.gnu.org/software/gdb/"
@@ -29,7 +29,8 @@ source=(https://ftp.gnu.org/gnu/gdb/${_realname}-${pkgver}.tar.xz{,.sig}
         'python-configure-path-fixes.patch'
         'gdb-fix-tui-with-pdcurses.patch'
         'gdb-9.1-lib-order.patch'
-        'gdb-home-is-userprofile.patch')
+        'gdb-home-is-userprofile.patch'
+        'gdb-windows-aslr.patch')
 validpgpkeys=('F40ADB902B24264AA42E50BF92EDB04BFF325CF3')
 sha256sums=('360cd7ae79b776988e89d8f9a01c985d0b1fa21c767a4295e5f88cb49175c555'
             'SKIP'
@@ -39,7 +40,8 @@ sha256sums=('360cd7ae79b776988e89d8f9a01c985d0b1fa21c767a4295e5f88cb49175c555'
             '6378e1a96e3bedc2a160f0f6780cb973ce6139017f2786e7ab97f8bcd9824d27'
             'f70cc0a0633d01adf777eb57a82f8c9880f6511d55e44c1dc415ddebc7467e0b'
             'dcfbfb2e3fc90a51e11202529e34c1b3dcc17e352067ffdfc58b63c1deab9523'
-            'a63ba094dcd9bf0c0f98c6dce5825590b2cf7014834fd3bec5f88fe25d90228a')
+            'a63ba094dcd9bf0c0f98c6dce5825590b2cf7014834fd3bec5f88fe25d90228a'
+            '7c40bd442dcd4eb32310b1b6979a96fd41253f4b3128ad0fac2f8ebff132666b')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
@@ -57,6 +59,9 @@ prepare() {
   patch -p1 -i ${srcdir}/gdb-fix-tui-with-pdcurses.patch
   patch -p1 -i ${srcdir}/gdb-9.1-lib-order.patch
   patch -p1 -i ${srcdir}/gdb-home-is-userprofile.patch
+
+  # https://sourceware.org/bugzilla/show_bug.cgi?id=26037
+  patch -p1 -i ${srcdir}/gdb-windows-aslr.patch
 
   # hack! - libiberty configure tests for header files using "$CPP $CPPFLAGS"
   sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" libiberty/configure

--- a/mingw-w64-gdb/gdb-windows-aslr.patch
+++ b/mingw-w64-gdb/gdb-windows-aslr.patch
@@ -1,0 +1,121 @@
+From 1edea4df38b2c007fe68f387edfdcf6f2fea4e7e Mon Sep 17 00:00:00 2001
+From: Hannes Domani <ssbssa@yahoo.de>
+Date: Wed, 12 Feb 2020 17:53:32 +0100
+Subject: [PATCH] Rebase executable to match relocated base address
+
+Windows executables linked with -dynamicbase get a new base address
+when loaded, which makes debugging impossible if the executable isn't
+also rebased in gdb.
+
+The new base address is read from the Process Environment Block.
+
+gdb/ChangeLog:
+
+2020-03-03  Hannes Domani  <ssbssa@yahoo.de>
+
+	* windows-tdep.c (windows_solib_create_inferior_hook): New function.
+	(windows_init_abi): Set and use windows_so_ops.
+---
+ gdb/ChangeLog      |  5 +++++
+ gdb/windows-tdep.c | 55 +++++++++++++++++++++++++++++++++++++++++++++-
+ 2 files changed, 59 insertions(+), 1 deletion(-)
+
+diff --git a/gdb/ChangeLog b/gdb/ChangeLog
+index 9dec4a4427..ca700fbab5 100644
+--- a/gdb/ChangeLog
++++ b/gdb/ChangeLog
+@@ -30,6 +30,11 @@
+ 	PR symtab/26003
+ 	* symfile.c (symbol_file_add_separate): Preserve OBJF_MAINLINE.
+ 
++2020-03-03  Hannes Domani  <ssbssa@yahoo.de>
++
++	* windows-tdep.c (windows_solib_create_inferior_hook): New function.
++	(windows_init_abi): Set and use windows_so_ops.
++
+ 2020-03-03  Sergio Durigan Junior  <sergiodj@redhat.com>
+ 
+ 	PR gdb/25650
+diff --git a/gdb/windows-tdep.c b/gdb/windows-tdep.c
+index ca9b81df29..a07c00b2f1 100644
+--- a/gdb/windows-tdep.c
++++ b/gdb/windows-tdep.c
+@@ -34,6 +34,9 @@
+ #include "solib.h"
+ #include "solib-target.h"
+ #include "gdbcore.h"
++#include "coff/internal.h"
++#include "libcoff.h"
++#include "solist.h"
+ 
+ struct cmd_list_element *info_w32_cmdlist;
+ 
+@@ -461,6 +464,53 @@ init_w32_command_list (void)
+     }
+ }
+ 
++/* Implement the "solib_create_inferior_hook" target_so_ops method.  */
++
++static void
++windows_solib_create_inferior_hook (int from_tty)
++{
++  CORE_ADDR exec_base = 0;
++
++  /* Find base address of main executable in
++     TIB->process_environment_block->image_base_address.  */
++  struct gdbarch *gdbarch = target_gdbarch ();
++  enum bfd_endian byte_order = gdbarch_byte_order (gdbarch);
++  int ptr_bytes;
++  int peb_offset;  /* Offset of process_environment_block in TIB.  */
++  int base_offset; /* Offset of image_base_address in PEB.  */
++  if (gdbarch_ptr_bit (gdbarch) == 32)
++    {
++      ptr_bytes = 4;
++      peb_offset = 48;
++      base_offset = 8;
++    }
++  else
++    {
++      ptr_bytes = 8;
++      peb_offset = 96;
++      base_offset = 16;
++    }
++  CORE_ADDR tlb;
++  gdb_byte buf[8];
++  if (target_get_tib_address (inferior_ptid, &tlb)
++      && !target_read_memory (tlb + peb_offset, buf, ptr_bytes))
++    {
++      CORE_ADDR peb = extract_unsigned_integer (buf, ptr_bytes, byte_order);
++      if (!target_read_memory (peb + base_offset, buf, ptr_bytes))
++	exec_base = extract_unsigned_integer (buf, ptr_bytes, byte_order);
++    }
++
++  /* Rebase executable if the base address changed because of ASLR.  */
++  if (symfile_objfile != nullptr && exec_base != 0)
++    {
++      CORE_ADDR vmaddr = pe_data (exec_bfd)->pe_opthdr.ImageBase;
++      if (vmaddr != exec_base)
++	objfile_rebase (symfile_objfile, exec_base - vmaddr);
++    }
++}
++
++static struct target_so_ops windows_so_ops;
++
+ /* To be called from the various GDB_OSABI_CYGWIN handlers for the
+    various Windows architectures and machine types.  */
+ 
+@@ -477,7 +527,10 @@ windows_init_abi (struct gdbarch_info info, struct gdbarch *gdbarch)
+   set_gdbarch_iterate_over_objfiles_in_search_order
+     (gdbarch, windows_iterate_over_objfiles_in_search_order);
+ 
+-  set_solib_ops (gdbarch, &solib_target_so_ops);
++  windows_so_ops = solib_target_so_ops;
++  windows_so_ops.solib_create_inferior_hook
++    = windows_solib_create_inferior_hook;
++  set_solib_ops (gdbarch, &windows_so_ops);
+ }
+ 
+ /* Implementation of `tlb' variable.  */
+-- 
+2.28.0.windows.1
+


### PR DESCRIPTION
Fixes #6941

Patch had to be adjusted to apply on 9.2.  It looks like more goodies for windows were added upstream than just this.