### PR TITLE
binutils: fix crash creating empty implib.

### DIFF
--- a/mingw-w64-binutils/1001-Change-the-default-characteristics-of-DLLs-built-by-.patch
+++ b/mingw-w64-binutils/1001-Change-the-default-characteristics-of-DLLs-built-by-.patch
@@ -1,7 +1,7 @@
 From 3021170f1728200d1f08c2a57af625f7a1003097 Mon Sep 17 00:00:00 2001
 From: Jeremy Drake <sourceware-bugzilla@jdrake.com>
 Date: Thu, 27 Aug 2020 12:58:27 +0100
-Subject: [PATCH 1/3] Change the default characteristics of DLLs built by the
+Subject: [PATCH 1/4] Change the default characteristics of DLLs built by the
  linker to more secure settings.
 
 	PR 19011

--- a/mingw-w64-binutils/1002-mingw-plugin-test-regressions-due-to-commit-514b4e19.patch
+++ b/mingw-w64-binutils/1002-mingw-plugin-test-regressions-due-to-commit-514b4e19.patch
@@ -1,7 +1,7 @@
 From 369140ab89948265c722a9b7a7e92b7de4a88d02 Mon Sep 17 00:00:00 2001
 From: Alan Modra <amodra@gmail.com>
 Date: Fri, 28 Aug 2020 10:51:28 +0930
-Subject: [PATCH 2/3] mingw plugin test regressions due to commit 514b4e191d5f
+Subject: [PATCH 2/4] mingw plugin test regressions due to commit 514b4e191d5f
 
 Fixes new failures due to image base change.
 

--- a/mingw-w64-binutils/1003-Fixes-for-testsuite-failures-introduced-by-the-chang.patch
+++ b/mingw-w64-binutils/1003-Fixes-for-testsuite-failures-introduced-by-the-chang.patch
@@ -1,7 +1,7 @@
 From f62e26a9b35e76eec4e11753eaf9dcb61b9ddda3 Mon Sep 17 00:00:00 2001
 From: Nick Clifton <nickc@redhat.com>
 Date: Fri, 28 Aug 2020 09:43:13 +0100
-Subject: [PATCH 3/3] Fixes for testsuite failures introduced by the changes
+Subject: [PATCH 3/4] Fixes for testsuite failures introduced by the changes
  made for PR 19011.
 
 	PR19011

--- a/mingw-w64-binutils/1004-Pass-disable-reloc-section-on-PE-targets-for-PR-2566.patch
+++ b/mingw-w64-binutils/1004-Pass-disable-reloc-section-on-PE-targets-for-PR-2566.patch
@@ -1,0 +1,60 @@
+From 97208d22d1f9bc1fc9fa6b8b64fbbbeacdedb73c Mon Sep 17 00:00:00 2001
+From: "H.J. Lu" <hjl.tools@gmail.com>
+Date: Tue, 8 Sep 2020 10:01:45 -0700
+Subject: [PATCH 4/4] Pass --disable-reloc-section on PE targets for PR 25662
+ test
+
+Pass --disable-reloc-section on PE targets for PR 25662 test since
+
+commit 514b4e191d5f46de8e142fe216e677a35fa9c4bb
+
+Author: Jeremy Drake <sourceware-bugzilla@jdrake.com>
+Date:   Thu Aug 27 12:58:27 2020 +0100
+
+    Change the default characteristics of DLLs built by the linker to more secure settings.
+
+defaulted to --enable-reloc-section.
+
+	PR ld/26587
+	* testsuite/binutils-all/objcopy.exp: Pass --disable-reloc-section
+	to ld on PE targets for PR 25662 test.
+---
+ binutils/ChangeLog                          |  6 ++++++
+ binutils/testsuite/binutils-all/objcopy.exp | 10 +++++++++-
+ 2 files changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/binutils/ChangeLog b/binutils/ChangeLog
+index 2b9ac6e792..678a19f572 100644
+--- a/binutils/ChangeLog
++++ b/binutils/ChangeLog
+@@ -1,3 +1,9 @@
++2020-09-08  H.J. Lu  <hongjiu.lu@intel.com>
++
++	PR ld/26587
++	* testsuite/binutils-all/objcopy.exp: Pass --disable-reloc-section
++	to ld on PE targets for PR 25662 test.
++
+ 2020-07-24  Nick Clifton  <nickc@redhat.com>
+ 
+ 	2.35 Release:
+diff --git a/binutils/testsuite/binutils-all/objcopy.exp b/binutils/testsuite/binutils-all/objcopy.exp
+index dd74860f9e..90ababf905 100644
+--- a/binutils/testsuite/binutils-all/objcopy.exp
++++ b/binutils/testsuite/binutils-all/objcopy.exp
+@@ -1354,4 +1354,12 @@ if { [istarget pdp11-*-*] } {
+     set src "pr25662.s"
+ }
+ 
+-objcopy_test "pr25662" $src executable "" "-T$srcdir/$subdir/pr25662.ld"
++set ldflags "-T$srcdir/$subdir/pr25662.ld"
++if { [istarget *-*-cygwin] || [istarget *-*-mingw*] } {
++   append ldflags " --disable-reloc-section"
++}
++
++#xcoff doesn't support arbitrary sections
++if { ![is_xcoff_format] } {
++    objcopy_test "pr25662" $src executable "" $ldflags
++}
+-- 
+2.28.0.windows.1
+

--- a/mingw-w64-binutils/2000-Temporarily-revert-default-dll-characteristics.patch
+++ b/mingw-w64-binutils/2000-Temporarily-revert-default-dll-characteristics.patch
@@ -1,7 +1,7 @@
-From 322caba57ff2728aa8f194683af3109a122c0130 Mon Sep 17 00:00:00 2001
+From 3542e64573975b82f74f68215c7603e94879ac6d Mon Sep 17 00:00:00 2001
 From: Jeremy Drake <github@jdrake.com>
 Date: Mon, 31 Aug 2020 10:26:19 -0700
-Subject: [PATCH 4/4] Temporarily revert default dll characteristics.
+Subject: [PATCH 1/3] Temporarily revert default dll characteristics.
 
 Until more testing is done, this patch reverts the
 DEFAULT_DLL_CHARACTERISTICS to 0, but keeps the new --disable- options

--- a/mingw-w64-binutils/2001-ld-option-to-move-default-bases-under-4GB.patch
+++ b/mingw-w64-binutils/2001-ld-option-to-move-default-bases-under-4GB.patch
@@ -1,3 +1,15 @@
+From 7061c779dd2cc672d9a8c8b17c8ceb95232e455c Mon Sep 17 00:00:00 2001
+From: Jeremy Drake <github@jdrake.com>
+Date: Thu, 10 Sep 2020 10:28:28 -0700
+Subject: [PATCH 2/3] ld option to move default bases under 4GB.
+
+Some (buggy) programs have 'latent pointer truncation' issues, and
+setting the ImageBase below 4GB indicates to Windows that it's not safe
+to relocate these using ASLR in such a way as to trigger them.
+---
+ ld/emultempl/pep.em | 50 ++++++++++++++++++++++++++++++++++++++++++---
+ 1 file changed, 47 insertions(+), 3 deletions(-)
+
 diff --git a/ld/emultempl/pep.em b/ld/emultempl/pep.em
 index ea792fe25a..de6d7aafbb 100644
 --- a/ld/emultempl/pep.em
@@ -126,3 +138,6 @@ index ea792fe25a..de6d7aafbb 100644
        init[MSIMAGEBASEOFF].value = init[IMAGEBASEOFF].value;
      }
  
+-- 
+2.28.0.windows.1
+

--- a/mingw-w64-binutils/2002-Don-t-crash-if-asked-to-create-an-empty-implib.patch
+++ b/mingw-w64-binutils/2002-Don-t-crash-if-asked-to-create-an-empty-implib.patch
@@ -1,0 +1,48 @@
+From bcf96e82c0d340556a4ed863f76788510f002555 Mon Sep 17 00:00:00 2001
+From: Jeremy Drake <github@jdrake.com>
+Date: Thu, 10 Sep 2020 10:31:34 -0700
+Subject: [PATCH 3/3] Don't crash if asked to create an empty implib.
+
+With --enable-reloc-section (now default), ld segfaults if asked to
+create an import lib for an executable with 0 exports.  With
+--disable-reloc-section (the old default), it would just silently not
+create one.  This patch restores the latter behavior for the
+--enable-reloc-section case.
+
+PR 26588
+---
+ ld/emultempl/pe.em  | 3 ++-
+ ld/emultempl/pep.em | 3 ++-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/ld/emultempl/pe.em b/ld/emultempl/pe.em
+index b3990cf677..32cd175ebb 100644
+--- a/ld/emultempl/pe.em
++++ b/ld/emultempl/pe.em
+@@ -2012,7 +2012,8 @@ gld_${EMULATION_NAME}_finish (void)
+     )
+     {
+       pe_dll_fill_sections (link_info.output_bfd, &link_info);
+-      if (command_line.out_implib_filename)
++      if (command_line.out_implib_filename
++          && pe_def_file->num_exports != 0)
+ 	pe_dll_generate_implib (pe_def_file, command_line.out_implib_filename,
+ 				&link_info);
+     }
+diff --git a/ld/emultempl/pep.em b/ld/emultempl/pep.em
+index de6d7aafbb..0b43ec515d 100644
+--- a/ld/emultempl/pep.em
++++ b/ld/emultempl/pep.em
+@@ -1865,7 +1865,8 @@ gld_${EMULATION_NAME}_finish (void)
+ 	  && pep_def_file->num_exports != 0))
+     {
+       pep_dll_fill_sections (link_info.output_bfd, &link_info);
+-      if (command_line.out_implib_filename)
++      if (command_line.out_implib_filename
++          && pep_def_file->num_exports != 0)
+ 	pep_dll_generate_implib (pep_def_file,
+ 				 command_line.out_implib_filename, &link_info);
+     }
+-- 
+2.28.0.windows.1
+

--- a/mingw-w64-binutils/PKGBUILD
+++ b/mingw-w64-binutils/PKGBUILD
@@ -6,7 +6,7 @@ _realname=binutils
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.35
-pkgrel=5
+pkgrel=6
 pkgdesc="A set of programs to assemble and manipulate binary and object files (mingw-w64)"
 arch=('any')
 url="https://www.gnu.org/software/binutils/"
@@ -27,8 +27,10 @@ source=(https://ftp.gnu.org/gnu/binutils/${_realname}-${pkgver}.tar.xz{,.sig}
         1001-Change-the-default-characteristics-of-DLLs-built-by-.patch
         1002-mingw-plugin-test-regressions-due-to-commit-514b4e19.patch
         1003-Fixes-for-testsuite-failures-introduced-by-the-chang.patch
+        1004-Pass-disable-reloc-section-on-PE-targets-for-PR-2566.patch
         2000-Temporarily-revert-default-dll-characteristics.patch
-        2001-option-x64-default-bases-low.patch)
+        2001-ld-option-to-move-default-bases-under-4GB.patch
+        2002-Don-t-crash-if-asked-to-create-an-empty-implib.patch)
 sha256sums=('1b11659fb49e20e18db460d44485f09442c8c56d5df165de9461eb09c8302f85'
             'SKIP'
             '93296b909e1a4f9d8a4bbe2437aafa17ca565ef6642a9812b0360c05be228c9d'
@@ -37,11 +39,13 @@ sha256sums=('1b11659fb49e20e18db460d44485f09442c8c56d5df165de9461eb09c8302f85'
             '34ba6c001ff7f95ae1da0619c73130112b76d0d2a31bb8a00602eb22f1f84cb8'
             '76658ef1bb8c5fc3fe6c26e2b5dd9ee0f1d12661988c0c65562b0a3e2d32ae1f'
             '86ae90d997e986a54aaebb5251f3a71800b0c5c3f5b57b9094a42995e9f5c478'
-            '4bc1d1481f060f99330e897652f499dd61afda8f8d1c8769e8e54adcd3c8eb7e'
-            '4af3eed435759426fa30b621821edfb2a27a67d182db2f5e22bc86c3dd61d62d'
-            '9170e8efb3db82acb98561e472e441c9e5e829997a40836bd9b2f2cc19557b05'
-            '5009fd749d4a8e710e26da988157d69f797eefb202ed7d246999c9e4bd9e8755'
-            '02cd51648b34c634857082c1988f81c15048202920cf4ca6776a45af5284aab9')
+            '922c53a7f09790c74ec1aea6f96ade8bb32ecab22c2beccb24a45e15b960273b'
+            '111a7385b93e9f1bf97503fe354ebe50f9be4b6d25cbb8678dde45df5e29ee8a'
+            '57a61ac664027bed5da848a16af2ea3ad63e820d7db2d24588c33168d93276bb'
+            'dc3724a9f42db77b38cb5db78aeaf3f92dbe8ea630db80e73135e9358d1e55c9'
+            'a9b0e140a34032a67a051d693460b10c03f1a1361c210e687a214d0505deb494'
+            'b790b09db892a1acde82bfe570ca52b50ed2ca98e6a99254cc8a8528eb87f8b2'
+            'f37671f4d571d4b5477979798887d245c2e163a6e247591a01761b136c673eaa')
 validpgpkeys=('EAF1C276A747E9ED86210CBAC3126D3B4AE55E93'
               '3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F')
 
@@ -57,11 +61,14 @@ prepare() {
   patch -p1 -i "${srcdir}"/1001-Change-the-default-characteristics-of-DLLs-built-by-.patch
   patch -p1 -i "${srcdir}"/1002-mingw-plugin-test-regressions-due-to-commit-514b4e19.patch
   patch -p1 -i "${srcdir}"/1003-Fixes-for-testsuite-failures-introduced-by-the-chang.patch
+  patch -p1 -i "${srcdir}"/1004-Pass-disable-reloc-section-on-PE-targets-for-PR-2566.patch
 
   # Temporarily revert defaults change while testing.
   patch -p1 -i "${srcdir}"/2000-Temporarily-revert-default-dll-characteristics.patch
   # Add an option to change default bases back below 4GB to ease transition
-  patch -p1 -i "${srcdir}"/2001-option-x64-default-bases-low.patch
+  patch -p1 -i "${srcdir}"/2001-ld-option-to-move-default-bases-under-4GB.patch
+  # https://sourceware.org/bugzilla/show_bug.cgi?id=26588
+  patch -p1 -i "${srcdir}"/2002-Don-t-crash-if-asked-to-create-an-empty-implib.patch
 }
 
 build() {


### PR DESCRIPTION
Fixes #6107 (most of the comments at least, the original report didn't give much to go on).

Also, added another upstream test patch, and turned my last patch into a
git-format one.

>> Just wondering. As we are importing many patches from upstream, how about using a git commit as source tarball for binutils?
>
> Are you talking about an upstream git commit, with whatever other changes might be pending for 2.36, or a branch on a fork with the desired patches cherry-picked on top of 2.35?

To maintain these patch series, I've got 2 branches going atm.  https://github.com/jeremyd2019/binutils-gdb/tree/backport-binutils-2_35 has upstream commits cherry-picked onto binutils 2.35 release tag.  https://github.com/jeremyd2019/binutils-gdb/tree/backport-binutils-2_35-revert-defaults is based on that branch but has additional patches not upstreamed (kind of unfortunately named based on the first of those patches).