### PR TITLE
indent: Fix build and depends

### DIFF
--- a/mingw-w64-indent/PKGBUILD
+++ b/mingw-w64-indent/PKGBUILD
@@ -1,32 +1,60 @@
 # $Id$
 # Maintainer (MSYS2): Ray Donnelly <mingw.android@gmail.com>
+# Contributer: Tim Stahlhut <stahta01@gmail.com>
 
 _realname=indent
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.2.12
-pkgrel=1
+pkgrel=2
 pkgdesc="C language source code formatting program (mingw-w64)"
 arch=('any')
 url="https://www.gnu.org/software/indent/"
 license=('GPL3')
-makedepends=('texinfo-tex')
+depends=("${MINGW_PACKAGE_PREFIX}-gettext")
+makedepends=('tar' 'texinfo-tex')
 source=(https://ftp.gnu.org/gnu/indent/${_realname}-${pkgver}.tar.gz{,.sig}
         indent-2.2.11-segfault.patch
         indent-2.2.11-disable-documentation.patch
-        indent-2.2.11-win32-wildexp-automake-support.patch)
+        indent-2.2.11-win32-wildexp-automake-support.patch
+        indent-2.2.12-disable-texinfo2man.patch)
 sha256sums=('e77d68c0211515459b8812118d606812e300097cfac0b4e9fb3472664263bb8b'
             'SKIP'
             '63c66b49831a90c5191cd3295d17a4e1888d8fa2a0b02589448de3b78d4e0293'
             '624ae1c52b01e52dfd4417bb160ef606342f25548fbd90c58ef4962367179750'
-            'd0ecfbc7cbf694b4222545bbd19d1b81f320ee9f5a2d5bfc86f27fe365f63145')
+            'd0ecfbc7cbf694b4222545bbd19d1b81f320ee9f5a2d5bfc86f27fe365f63145'
+            'b8489a9dd7e4983f63ba6960bc3b1d8f51dd6ae08c29c6e8a9878491d0bf5e11')
 validpgpkeys=('782130B4C9944247977B82FD6EA4D2311A2D268D')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# ======================================= #
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
-  patch -Np1 -i ${srcdir}/indent-2.2.11-segfault.patch
-  patch -Np1 -i ${srcdir}/indent-2.2.11-disable-documentation.patch
-  patch -Np1 -i ${srcdir}/indent-2.2.11-win32-wildexp-automake-support.patch
+
+  del_file_exists src/wildexp.h
+
+  apply_patch_with_msg \
+    indent-2.2.11-segfault.patch \
+    indent-2.2.11-disable-documentation.patch \
+    indent-2.2.11-win32-wildexp-automake-support.patch \
+    indent-2.2.12-disable-texinfo2man.patch
 
   autoreconf -vfi
 }

--- a/mingw-w64-indent/indent-2.2.12-disable-texinfo2man.patch
+++ b/mingw-w64-indent/indent-2.2.12-disable-texinfo2man.patch
@@ -1,0 +1,10 @@
+--- a/man/Makefile.am
++++ b/man/Makefile.am
+@@ -12,5 +12,5 @@
+ 	$(CC_FOR_BUILD) -o $@ ${srcdir}/texinfo2man.c
+ 
+ @PACKAGE@.1: ${srcdir}/@PACKAGE@.1.in  ${srcdir}/../doc/@PACKAGE@.texi texinfo2man  Makefile.am
+-	./texinfo2man ${srcdir}/@PACKAGE@.1.in ${srcdir}/../doc/@PACKAGE@.texi > $@
++	@echo Skipping
+ 
+--


### PR DESCRIPTION
Add depends=("${MINGW_PACKAGE_PREFIX}-gettext") and
added indent-2.2.12-disable-texinfo2man.patch.
Also, added apply_patch_with_msg and del_file_exists.