### PR TITLE
sox: update to 14.4.2.r3203.07de8a77

### DIFF
--- a/mingw-w64-sox/PKGBUILD
+++ b/mingw-w64-sox/PKGBUILD
@@ -4,8 +4,8 @@ _realname=sox
 _base_ver=14.4.2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-# https://sourceforge.net/p/sox/code/ci/784021f41f97a65471d961d39474c85ba00318de/
-pkgver=14.4.2.r3197.784021f4
+# https://sourceforge.net/p/sox/code/ci/07de8a77a862e6800b95a8d3a61c6b4e41362755/
+pkgver=14.4.2.r3203.07de8a77
 pkgrel=1
 pkgdesc="SoX is the Swiss Army Knife of sound processing utilities (mingw-w64)"
 arch=('any')
@@ -28,6 +28,7 @@ makedepends=(autoconf-archive git
              ${MINGW_PACKAGE_PREFIX}-opusfile
              ${MINGW_PACKAGE_PREFIX}-pkg-config
              ${MINGW_PACKAGE_PREFIX}-twolame
+             ${MINGW_PACKAGE_PREFIX}-vo-amrwbenc
              ${MINGW_PACKAGE_PREFIX}-wavpack)
 depends=(${MINGW_PACKAGE_PREFIX}-gcc-libs
              ${MINGW_PACKAGE_PREFIX}-flac
@@ -39,23 +40,25 @@ depends=(${MINGW_PACKAGE_PREFIX}-gcc-libs
              ${MINGW_PACKAGE_PREFIX}-libmad
              ${MINGW_PACKAGE_PREFIX}-libpng
              ${MINGW_PACKAGE_PREFIX}-libsndfile
+             ${MINGW_PACKAGE_PREFIX}-libtool
              ${MINGW_PACKAGE_PREFIX}-libvorbis
              ${MINGW_PACKAGE_PREFIX}-opencore-amr
              ${MINGW_PACKAGE_PREFIX}-opusfile
              ${MINGW_PACKAGE_PREFIX}-twolame
+             ${MINGW_PACKAGE_PREFIX}-vo-amrwbenc
              ${MINGW_PACKAGE_PREFIX}-wavpack)
 options=('staticlibs' 'strip')
-source=("${_realname}"::"git+https://git.code.sf.net/p/sox/code#commit=784021f41f97a65471d961d39474c85ba00318de")
+source=("${_realname}"::"git+https://git.code.sf.net/p/sox/code#commit=07de8a77a862e6800b95a8d3a61c6b4e41362755")
 sha256sums=('SKIP')
+
+pkgver() {
+  cd "${srcdir}/${_realname}"
+  printf "%s.r%s.%s" "${_base_ver}" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
 
 prepare() {
   cd "${srcdir}/${_realname}"
   autoreconf -i
-}
-
-pkgver() {
-  cd "${srcdir}/${_realname}"
-  printf "%s.r%s.%s" "${_base_ver}" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)" 
 }
 
 build() {


### PR DESCRIPTION
Update SoX to current commit of git master.

- Add dependency **`vo-amrwbenc`**. A check for vo-amrwbenc has been recently
  added to configure of sox, see commit:
  https://sourceforge.net/p/sox/code/ci/9abe8822/
- Add **`mingw-w64-libtool`** to `depends`, which is used by sox since:
  https://sourceforge.net/p/sox/code/ci/0d44e15d/
- Move `pkgver()` earlier in the **`PKGBUILD`** file, before `prepare()`
