### PR TITLE
glslang: Fix redefinition of snprintf_s

### DIFF
--- a/mingw-w64-glslang/002-remove-deprecated-mingw-secure-api.patch
+++ b/mingw-w64-glslang/002-remove-deprecated-mingw-secure-api.patch
@@ -1,0 +1,11 @@
+--- a/glslang/Include/Common.h
++++ b/glslang/Include/Common.h
+@@ -50,7 +50,7 @@
+ }
+ #endif
+ 
+-#if (defined(_MSC_VER) && _MSC_VER < 1900 /*vs2015*/) || defined MINGW_HAS_SECURE_API
++#if (defined(_MSC_VER) && _MSC_VER < 1900 /*vs2015*/)
+     #include <basetsd.h>
+     #ifndef snprintf
+     #define snprintf sprintf_s

--- a/mingw-w64-glslang/PKGBUILD
+++ b/mingw-w64-glslang/PKGBUILD
@@ -5,7 +5,7 @@ _realname=glslang
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=8.13.3743
-pkgrel=1
+pkgrel=2
 pkgdesc='An OpenGL and OpenGL ES shader front end and validator (mingw-w64)'
 arch=('any')
 url='https://github.com/KhronosGroup/glslang'
@@ -13,13 +13,16 @@ license=('BSD')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake")
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/KhronosGroup/glslang/archive/${pkgver}.tar.gz
-        001-install-missing-dll.patch)
+        001-install-missing-dll.patch
+        002-remove-deprecated-mingw-secure-api.patch)
 sha256sums=('639ebec56f1a7402f2fa094469a5ddea1eceecfaf2e9efe361376a0f73a7ee2f'
-            'bffb1088ce17f24f3d43f31919251667cf2812cf933830a99622549423ea1e45')
+            'bffb1088ce17f24f3d43f31919251667cf2812cf933830a99622549423ea1e45'
+            '8b9f56e57a892aa3e1617b7a268a6bb2a309a11c874ef11d9ad59aadf94ca932')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/001-install-missing-dll.patch
+  patch -p1 -i ${srcdir}/002-remove-deprecated-mingw-secure-api.patch
 }
 
 build() {
@@ -33,12 +36,11 @@ build() {
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
-  CFLAGS+=" -Wno-switch"
-  CXXFLAGS+=" -Wno-switch"
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake \
     -G'MSYS Makefiles' \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DCMAKE_INSTALL_LIBDIR=lib \
     "${extra_config[@]}" \
     -DBUILD_SHARED_LIBS=OFF \
     ../${_realname}-${pkgver}


### PR DESCRIPTION
Changes:
  * Add patch file to remove MINGW_HAS_SECURE_API define.
  * Remove -Wno-switch compiler flag.
  * Add CMAKE_INSTALL_LIBDIR option.