### PR TITLE
sox: add -D__USE_MINGW_ANSI_STDIO=1 to CFLAGS

### DIFF
--- a/mingw-w64-sox/PKGBUILD
+++ b/mingw-w64-sox/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 # https://sourceforge.net/p/sox/code/ci/07de8a77a862e6800b95a8d3a61c6b4e41362755/
 pkgver=14.4.2.r3203.07de8a77
-pkgrel=1
+pkgrel=2
 pkgdesc="SoX is the Swiss Army Knife of sound processing utilities (mingw-w64)"
 arch=('any')
 url="https://sourceforge.net/projects/sox/"
@@ -69,7 +69,7 @@ build() {
     --host=${MINGW_CHOST} \
     --with-distro='MSYS2 MINGW-packages'
 
-  make
+  make CFLAGS="$CFLAGS -D__USE_MINGW_ANSI_STDIO=1"
 }
 
 package() {


### PR DESCRIPTION
This fixes several warnings concerning `PRIu64` and `PRIuPTR`, e.g.:
```console
  warning: unknown conversion type character 'l' in format [-Wformat=]
  warning: too many arguments for format [-Wformat-extra-args]
```