### PR TITLE
Updated 'mingw-w64-arm-none-eabi-gdb' PKGBUILD

### DIFF
--- a/mingw-w64-arm-none-eabi-gdb/PKGBUILD
+++ b/mingw-w64-arm-none-eabi-gdb/PKGBUILD
@@ -53,18 +53,18 @@ prepare() {
 
 
     # https://sourceware.org/bugzilla/show_bug.cgi?id=15412
-    patch -p1 -i ${srcdir}/gdb-perfomance.patch
+    patch -p1 -i ../gdb-perfomance.patch
 
-    patch -p1 -i ${srcdir}/gdb-fix-using-gnu-print.patch
+    patch -p1 -i ../gdb-fix-using-gnu-print.patch
 
     # https://sourceware.org/bugzilla/show_bug.cgi?id=21078
-    patch -p1 -i ${srcdir}/gdb-7.12-dynamic-libs.patch
+    patch -p1 -i ../gdb-7.12-dynamic-libs.patch
 
-    patch -p1 -i ${srcdir}/python-configure-path-fixes.patch
+    patch -p1 -i ../python-configure-path-fixes.patch
 
-    patch -p1 -i ${srcdir}/gdb-fix-tui-with-pdcurses.patch
-    patch -p1 -i ${srcdir}/gdb-9.1-lib-order.patch
-    patch -p1 -i ${srcdir}/gdb-home-is-userprofile.patch
+    patch -p1 -i ../gdb-fix-tui-with-pdcurses.patch
+    patch -p1 -i ../gdb-9.1-lib-order.patch
+    patch -p1 -i ../gdb-home-is-userprofile.patch
 
     # hack! - libiberty configure tests for header files using "$CPP $CPPFLAGS"
     sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" libiberty/configure

--- a/mingw-w64-arm-none-eabi-gdb/PKGBUILD
+++ b/mingw-w64-arm-none-eabi-gdb/PKGBUILD
@@ -72,8 +72,7 @@ prepare() {
 }
 
 build() {
-    [[ -d ${srcdir}/${_realname}-${pkgver}/${_realname}-build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/${_realname}-${pkgver}/${_realname}-build-${MINGW_CHOST}
-    mkdir ${srcdir}/${_realname}-${pkgver}/${_realname}-build-${MINGW_CHOST} && cd ${srcdir}/${_realname}-${pkgver}/${_realname}-build-${MINGW_CHOST}
+    cd ${srcdir}/${_realname}-${pkgver}/${_realname}-build-${MINGW_CHOST}
     
     if [ "${CARCH}" != "x86_64" ]; then
       LDFLAGS+=" -Wl,--large-address-aware"

--- a/mingw-w64-arm-none-eabi-gdb/PKGBUILD
+++ b/mingw-w64-arm-none-eabi-gdb/PKGBUILD
@@ -51,6 +51,7 @@ validpgpkeys=('F40ADB902B24264AA42E50BF92EDB04BFF325CF3') # Joel Brobecker
 prepare() {
     cd ${srcdir}/${_realname}-${pkgver}
 
+    mkdir ${_realname}-build-${MINGW_CHOST}
 
     # https://sourceware.org/bugzilla/show_bug.cgi?id=15412
     patch -p1 -i ../gdb-perfomance.patch

--- a/mingw-w64-arm-none-eabi-gdb/PKGBUILD
+++ b/mingw-w64-arm-none-eabi-gdb/PKGBUILD
@@ -85,7 +85,6 @@ build() {
 
     ../configure \
         --build=${MINGW_CHOST} \
-        --host=${MINGW_CHOST} \
         --prefix=${MINGW_PREFIX} \
         --target=${_target} \
         --disable-nls \

--- a/mingw-w64-arm-none-eabi-gdb/PKGBUILD
+++ b/mingw-w64-arm-none-eabi-gdb/PKGBUILD
@@ -8,30 +8,84 @@ _target=arm-none-eabi
 pkgbase=mingw-w64-${_target}-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_target}-${_realname}")
 pkgver=9.2
-pkgrel=1
+pkgrel=2
 pkgdesc='GNU Tools for ARM Embedded Processors - GDB (mingw-w64)'
 arch=('any')
 license=('GPL')
 url='https://www.gnu.org/software/gdb/'
 groups=("${MINGW_PACKAGE_PREFIX}-${_target}-toolchain")
-source=(https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.xz{,.sig})
+source=(
+    https://ftp.gnu.org/gnu/gdb/${_realname}-${pkgver}.tar.xz{,.sig}
+    'gdb-perfomance.patch'
+    'gdb-fix-using-gnu-print.patch'
+    'gdb-7.12-dynamic-libs.patch'
+    'python-configure-path-fixes.patch'
+    'gdb-fix-tui-with-pdcurses.patch'
+    'gdb-9.1-lib-order.patch'
+    'gdb-home-is-userprofile.patch'
+)
 sha256sums=(
     '360cd7ae79b776988e89d8f9a01c985d0b1fa21c767a4295e5f88cb49175c555'
     'SKIP'
+    'a0a2d974e80b656646c87cc669fda798182a35b001aab933567c41b880530aa0'
+    '29fce74348a2862dd3856da58cd3c6c40a910cbdb95e5003d571c33a04532b78'
+    '9de9c30bbb8cd2c6f60414b5a34cdf1fae27238293fb6007c628a8b821f88e0b'
+    '6378e1a96e3bedc2a160f0f6780cb973ce6139017f2786e7ab97f8bcd9824d27'
+    'f70cc0a0633d01adf777eb57a82f8c9880f6511d55e44c1dc415ddebc7467e0b'
+    'dcfbfb2e3fc90a51e11202529e34c1b3dcc17e352067ffdfc58b63c1deab9523'
+    'a63ba094dcd9bf0c0f98c6dce5825590b2cf7014834fd3bec5f88fe25d90228a'
 )
+depends=("${MINGW_PACKAGE_PREFIX}-expat"
+         "${MINGW_PACKAGE_PREFIX}-libiconv"
+         "${MINGW_PACKAGE_PREFIX}-ncurses"
+         "${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-readline"
+         "${MINGW_PACKAGE_PREFIX}-xxhash"
+         "${MINGW_PACKAGE_PREFIX}-zlib")
+checkdepends=('dejagnu' 'bc')
+makedepends=("${MINGW_PACKAGE_PREFIX}-iconv"
+             "${MINGW_PACKAGE_PREFIX}-xz")
+options=('staticlibs' '!distcc' '!ccache')
 validpgpkeys=('F40ADB902B24264AA42E50BF92EDB04BFF325CF3') # Joel Brobecker
 
 prepare() {
     cd ${srcdir}/${_realname}-${pkgver}
 
-    mkdir ${_realname}-build
+
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=15412
+    patch -p1 -i ${srcdir}/gdb-perfomance.patch
+
+    patch -p1 -i ${srcdir}/gdb-fix-using-gnu-print.patch
+
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=21078
+    patch -p1 -i ${srcdir}/gdb-7.12-dynamic-libs.patch
+
+    patch -p1 -i ${srcdir}/python-configure-path-fixes.patch
+
+    patch -p1 -i ${srcdir}/gdb-fix-tui-with-pdcurses.patch
+    patch -p1 -i ${srcdir}/gdb-9.1-lib-order.patch
+    patch -p1 -i ${srcdir}/gdb-home-is-userprofile.patch
+
+    # hack! - libiberty configure tests for header files using "$CPP $CPPFLAGS"
+    sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" libiberty/configure
 }
 
 build() {
-    cd ${srcdir}/${_realname}-${pkgver}/${_realname}-build
+    [[ -d ${srcdir}/${_realname}-${pkgver}/${_realname}-build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/${_realname}-${pkgver}/${_realname}-build-${MINGW_CHOST}
+    mkdir ${srcdir}/${_realname}-${pkgver}/${_realname}-build-${MINGW_CHOST} && cd ${srcdir}/${_realname}-${pkgver}/${_realname}-build-${MINGW_CHOST}
+    
+    if [ "${CARCH}" != "x86_64" ]; then
+      LDFLAGS+=" -Wl,--large-address-aware"
+    fi
+
+    CPPFLAGS+=" -I${MINGW_PREFIX}/include/ncurses"
+    CFLAGS+=" -I${MINGW_PREFIX}/include/ncurses"
+    CXXFLAGS+=" -I${MINGW_PREFIX}/include/ncurses"
+    LDFLAGS+=" -fstack-protector"
 
     ../configure \
         --build=${MINGW_CHOST} \
+        --host=${MINGW_CHOST} \
         --prefix=${MINGW_PREFIX} \
         --target=${_target} \
         --disable-nls \
@@ -41,17 +95,31 @@ build() {
         --disable-libssp \
         --disable-install-libbfd \
         --disable-install-libiberty \
-        --with-system-readline
+        --with-system-readline \
+        --enable-languages=c,c++ \
+        --disable-werror \
+        --disable-win32-registry \
+        --disable-rpath \
+        --with-curses \
+        --with-system-gdbinit=${MINGW_PREFIX}/etc/gdbinit \
+        --with-python=${MINGW_PREFIX}/bin/python \
+        --with-expat \
+        --with-libiconv-prefix=${MINGW_PREFIX} \
+        --with-zlib \
+        --with-lzma \
+        --enable-tui \
+        --enable-source-highlight=no
+
     make
 }
 
 package() {
-    cd ${srcdir}/${_realname}-${pkgver}/${_realname}-build
+    cd ${srcdir}/${_realname}-${pkgver}/${_realname}-build-${MINGW_CHOST}
 
     make DESTDIR="$pkgdir" install-gdb
 
     cd ${pkgdir}${MINGW_PREFIX}
 
     # Remove files that conflict with native gdb
-    rm -rf include share/gdb share/info
+    rm -rf include share/gdb share/info lib
 }

--- a/mingw-w64-arm-none-eabi-gdb/gdb-7.12-dynamic-libs.patch
+++ b/mingw-w64-arm-none-eabi-gdb/gdb-7.12-dynamic-libs.patch
@@ -1,0 +1,36 @@
+From 55058413c83f650adfcd3d92a0005fae46f51505 Mon Sep 17 00:00:00 2001
+From: Orgad Shaneh <orgads@gmail.com>
+Date: Tue, 7 Mar 2017 19:13:41 +0200
+Subject: [PATCH] configure: Disable static linking with standard libs
+
+Linking statically causes spurious crashes on exception handling
+with mingw32.
+---
+ configure | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/configure b/configure
+index 276f33fee3..e5e83482c3 100755
+--- a/configure
++++ b/configure
+@@ -5878,7 +5878,7 @@ else
+  # trust that they are doing what they want.
+  if test "$with_static_standard_libraries" = yes -a "$stage1_libs" = "" \
+      -a "$have_static_libs" = yes; then
+-   stage1_ldflags="-static-libstdc++ -static-libgcc"
++   stage1_ldflags=""
+  fi
+ fi
+ 
+@@ -5914,7 +5914,7 @@ else
+  # statically.  But if the user explicitly specified the libraries to
+  # use, trust that they are doing what they want.
+  if test "$poststage1_libs" = ""; then
+-   poststage1_ldflags="-static-libstdc++ -static-libgcc"
++   poststage1_ldflags=""
+  fi
+ fi
+ 
+-- 
+2.25.0.windows.1
+

--- a/mingw-w64-arm-none-eabi-gdb/gdb-9.1-lib-order.patch
+++ b/mingw-w64-arm-none-eabi-gdb/gdb-9.1-lib-order.patch
@@ -1,0 +1,29 @@
+From 4a5db02d1ae86a498c9f38e2ff26f1a799e21c64 Mon Sep 17 00:00:00 2001
+From: Orgad Shaneh <orgads@gmail.com>
+Date: Sun, 2 Jun 2019 11:43:52 +0300
+Subject: [PATCH] Fix link order on Windows
+
+libgnu uses ntop, which comes from ws2_32 library, so ws2_32 needs
+to be linked after libgnu.
+---
+ gdb/Makefile.in | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/gdb/Makefile.in b/gdb/Makefile.in
+index c3e074b21f..dee3c89c8e 100644
+--- a/gdb/Makefile.in
++++ b/gdb/Makefile.in
+@@ -611,8 +611,8 @@ CLIBS = $(SIM) $(READLINE) $(OPCODES) $(BFD) $(LIBCTF) $(ZLIB) \
+ 	$(XM_CLIBS) $(GDBTKLIBS) \
+ 	@LIBS@ @GUILE_LIBS@ @PYTHON_LIBS@ \
+ 	$(LIBEXPAT) $(LIBLZMA) $(LIBBABELTRACE) $(LIBIPT) \
+-	$(LIBIBERTY) $(WIN32LIBS) $(LIBGNU) $(LIBICONV) $(LIBMPFR) \
+-	$(SRCHIGH_LIBS) $(LIBXXHASH) $(PTHREAD_LIBS)
++	$(LIBIBERTY) $(LIBGNU) $(LIBICONV) $(LIBMPFR) \
++	$(SRCHIGH_LIBS) $(LIBXXHASH) $(PTHREAD_LIBS) $(WIN32LIBS)
+ CDEPS = $(NAT_CDEPS) $(SIM) $(BFD) $(READLINE_DEPS) $(LIBCTF) \
+ 	$(OPCODES) $(INTL_DEPS) $(LIBIBERTY) $(CONFIG_DEPS) $(LIBGNU)
+ 
+-- 
+2.25.0.windows.1
+

--- a/mingw-w64-arm-none-eabi-gdb/gdb-fix-tui-with-pdcurses.patch
+++ b/mingw-w64-arm-none-eabi-gdb/gdb-fix-tui-with-pdcurses.patch
@@ -1,0 +1,40 @@
+From 2d2c2efa3f47f00f3c392cf7dd3431d25194c543 Mon Sep 17 00:00:00 2001
+From: Orgad Shaneh <orgads@gmail.com>
+Date: Thu, 13 Feb 2020 09:25:02 +0200
+Subject: [PATCH] Fix TUI with pdcurses
+
+---
+ gdb/tui/tui-win.c | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/gdb/tui/tui-win.c b/gdb/tui/tui-win.c
+index d6ceacc041..2c793a6d02 100644
+--- a/gdb/tui/tui-win.c
++++ b/gdb/tui/tui-win.c
+@@ -123,15 +123,15 @@ struct tui_translate
+    The list of values must be terminated by a NULL.
+    After the NULL value, an entry defines the default.  */
+ struct tui_translate tui_border_mode_translate[] = {
+-  { "normal",		A_NORMAL },
+-  { "standout",		A_STANDOUT },
+-  { "reverse",		A_REVERSE },
+-  { "half",		A_DIM },
+-  { "half-standout",	A_DIM | A_STANDOUT },
+-  { "bold",		A_BOLD },
+-  { "bold-standout",	A_BOLD | A_STANDOUT },
++  { "normal",		static_cast<int>(A_NORMAL) },
++  { "standout",		static_cast<int>(A_STANDOUT) },
++  { "reverse",		static_cast<int>(A_REVERSE) },
++  { "half",		static_cast<int>(A_DIM) },
++  { "half-standout",	static_cast<int>(A_DIM | A_STANDOUT) },
++  { "bold",		static_cast<int>(A_BOLD) },
++  { "bold-standout",	static_cast<int>(A_BOLD | A_STANDOUT) },
+   { 0, 0 },
+-  { "normal",		A_NORMAL }
++  { "normal",		static_cast<int>(A_NORMAL) }
+ };
+ 
+ /* Translation tables for border-kind, one for each border
+-- 
+2.25.0.windows.1
+

--- a/mingw-w64-arm-none-eabi-gdb/gdb-fix-using-gnu-print.patch
+++ b/mingw-w64-arm-none-eabi-gdb/gdb-fix-using-gnu-print.patch
@@ -1,0 +1,98 @@
+From 23c68472557842b9c2706ba25d28711db3241081 Mon Sep 17 00:00:00 2001
+From: Orgad Shaneh <orgads@gmail.com>
+Date: Thu, 13 Feb 2020 09:25:02 +0200
+Subject: [PATCH] Fix using gnu print
+
+---
+ bfd/bfd-in.h                | 2 +-
+ bfd/bfd-in2.h               | 2 +-
+ gdb/gdbsupport/format.h     | 6 +++++-
+ gnulib/import/inttypes.in.h | 8 ++++----
+ 4 files changed, 11 insertions(+), 7 deletions(-)
+
+diff --git a/bfd/bfd-in.h b/bfd/bfd-in.h
+index d81cbb791f..6c14fc5da5 100644
+--- a/bfd/bfd-in.h
++++ b/bfd/bfd-in.h
+@@ -158,7 +158,7 @@ typedef BFD_HOST_U_64_BIT symvalue;
+ 
+ #if BFD_HOST_64BIT_LONG
+ #define BFD_VMA_FMT "l"
+-#elif defined (__MSVCRT__)
++#elif defined(__MSVCRT__) && !defined( __USE_MINGW_ANSI_STDIO)
+ #define BFD_VMA_FMT "I64"
+ #else
+ #define BFD_VMA_FMT "ll"
+diff --git a/bfd/bfd-in2.h b/bfd/bfd-in2.h
+index 6f3e41da37..54e9c7a56d 100644
+--- a/bfd/bfd-in2.h
++++ b/bfd/bfd-in2.h
+@@ -165,7 +165,7 @@ typedef BFD_HOST_U_64_BIT symvalue;
+ 
+ #if BFD_HOST_64BIT_LONG
+ #define BFD_VMA_FMT "l"
+-#elif defined (__MSVCRT__)
++#elif defined (__MSVCRT__) && !defined(__USE_MINGW_ANSI_STDIO)
+ #define BFD_VMA_FMT "I64"
+ #else
+ #define BFD_VMA_FMT "ll"
+diff --git a/gdb/gdbsupport/format.h b/gdb/gdbsupport/format.h
+index 80f012a41a..17a5560283 100644
+--- a/gdb/gdbsupport/format.h
++++ b/gdb/gdbsupport/format.h
+@@ -23,7 +23,11 @@
+ #include "gdbsupport/gdb_string_view.h"
+ 
+ #if defined(__MINGW32__) && !defined(PRINTF_HAS_LONG_LONG)
+-# define USE_PRINTF_I64 1
++# if !defined(__USE_MINGW_ANSI_STDIO)
++#  define USE_PRINTF_I64 1
++# else
++#  define USE_PRINTF_I64 0
++# endif
+ # define PRINTF_HAS_LONG_LONG
+ #else
+ # define USE_PRINTF_I64 0
+diff --git a/gnulib/import/inttypes.in.h b/gnulib/import/inttypes.in.h
+index ed09db6e86..ae06fdedc8 100644
+--- a/gnulib/import/inttypes.in.h
++++ b/gnulib/import/inttypes.in.h
+@@ -187,7 +187,7 @@
+ #ifdef INT64_MAX
+ # if (@APPLE_UNIVERSAL_BUILD@ ? defined _LP64 : @INT64_MAX_EQ_LONG_MAX@)
+ #  define _PRI64_PREFIX "l"
+-# elif defined _MSC_VER || defined __MINGW32__
++# elif (defined _MSC_VER || defined __MINGW32__) && !defined(__USE_MINGW_ANSI_STDIO)
+ #  define _PRI64_PREFIX "I64"
+ # elif @HAVE_LONG_LONG_INT@ && LONG_MAX >> 30 == 1
+ #  define _PRI64_PREFIX _LONG_LONG_FORMAT_PREFIX
+@@ -204,7 +204,7 @@
+ #ifdef UINT64_MAX
+ # if (@APPLE_UNIVERSAL_BUILD@ ? defined _LP64 : @UINT64_MAX_EQ_ULONG_MAX@)
+ #  define _PRIu64_PREFIX "l"
+-# elif defined _MSC_VER || defined __MINGW32__
++# elif (defined _MSC_VER || defined __MINGW32__) && !defined(__USE_MINGW_ANSI_STDIO)
+ #  define _PRIu64_PREFIX "I64"
+ # elif @HAVE_UNSIGNED_LONG_LONG_INT@ && ULONG_MAX >> 31 == 1
+ #  define _PRIu64_PREFIX _LONG_LONG_FORMAT_PREFIX
+@@ -680,7 +680,7 @@
+ #ifdef INT64_MAX
+ # if (@APPLE_UNIVERSAL_BUILD@ ? defined _LP64 : @INT64_MAX_EQ_LONG_MAX@)
+ #  define _SCN64_PREFIX "l"
+-# elif defined _MSC_VER || defined __MINGW32__
++# elif (defined _MSC_VER || defined __MINGW32__) && !defined(__USE_MINGW_ANSI_STDIO)
+ #  define _SCN64_PREFIX "I64"
+ # elif @HAVE_LONG_LONG_INT@ && LONG_MAX >> 30 == 1
+ #  define _SCN64_PREFIX _LONG_LONG_FORMAT_PREFIX
+@@ -697,7 +697,7 @@
+ #ifdef UINT64_MAX
+ # if (@APPLE_UNIVERSAL_BUILD@ ? defined _LP64 : @UINT64_MAX_EQ_ULONG_MAX@)
+ #  define _SCNu64_PREFIX "l"
+-# elif defined _MSC_VER || defined __MINGW32__
++# elif (defined _MSC_VER || defined __MINGW32__) && !defined(__USE_MINGW_ANSI_STDIO)
+ #  define _SCNu64_PREFIX "I64"
+ # elif @HAVE_UNSIGNED_LONG_LONG_INT@ && ULONG_MAX >> 31 == 1
+ #  define _SCNu64_PREFIX _LONG_LONG_FORMAT_PREFIX
+-- 
+2.25.0.windows.1
+

--- a/mingw-w64-arm-none-eabi-gdb/gdb-home-is-userprofile.patch
+++ b/mingw-w64-arm-none-eabi-gdb/gdb-home-is-userprofile.patch
@@ -1,0 +1,111 @@
+From e7cfeb6cd5d53a8708455680c13fd4c5f61bc78e Mon Sep 17 00:00:00 2001
+From: Buster <rcopley@gmail.com>
+Date: Sat, 26 Oct 2019 12:15:37 +0100
+Subject: [PATCH] W32: Always check $USERPROFILE if $HOME is not set
+
+---
+ gdb/auto-load.c            |  4 ++++
+ gdb/gdbsupport/pathstuff.c |  4 ++++
+ gdb/main.c                 |  4 ++++
+ gdb/windows-nat.c          |  4 ++++
+ gnulib/import/glob.c       | 24 +++---------------------
+ 5 files changed, 19 insertions(+), 21 deletions(-)
+
+diff --git a/gdb/auto-load.c b/gdb/auto-load.c
+index 5a9f47f078..8575ea1ecf 100644
+--- a/gdb/auto-load.c
++++ b/gdb/auto-load.c
+@@ -499,6 +499,10 @@ file_is_auto_load_safe (const char *filename, const char *debug_fmt, ...)
+   if (!advice_printed)
+     {
+       const char *homedir = getenv ("HOME");
++#ifdef _WIN32
++      if (homedir == NULL)
++        homedir = getenv ("USERPROFILE");
++#endif
+ 
+       if (homedir == NULL)
+ 	homedir = "$HOME";
+diff --git a/gdb/gdbsupport/pathstuff.c b/gdb/gdbsupport/pathstuff.c
+index f9882a2635..a90587103c 100644
+--- a/gdb/gdbsupport/pathstuff.c
++++ b/gdb/gdbsupport/pathstuff.c
+@@ -231,6 +231,10 @@ get_standard_cache_dir ()
+ #endif
+ 
+   const char *home = getenv ("HOME");
++#ifdef _WIN32
++  if (home == NULL)
++    home = getenv ("USERPROFILE");
++#endif
+   if (home != NULL)
+     {
+       /* Make sure the path is absolute and tilde-expanded.  */
+diff --git a/gdb/main.c b/gdb/main.c
+index 66a9e6a6d2..2a7228f20c 100644
+--- a/gdb/main.c
++++ b/gdb/main.c
+@@ -300,6 +300,10 @@ get_init_files (std::vector<std::string> *system_gdbinit,
+ 	}
+ 
+       const char *homedir = getenv ("HOME");
++#ifdef _WIN32
++      if (homedir == NULL)
++        homedir = getenv ("USERPROFILE");
++#endif
+ 
+       /* If the .gdbinit file in the current directory is the same as
+ 	 the $HOME/.gdbinit file, it should not be sourced.  homebuf
+diff --git a/gdb/windows-nat.c b/gdb/windows-nat.c
+index 31a5cabfb3..e60298ff60 100644
+--- a/gdb/windows-nat.c
++++ b/gdb/windows-nat.c
+@@ -3201,6 +3201,10 @@ _initialize_check_for_gdb_ini (void)
+     return;
+ 
+   homedir = getenv ("HOME");
++#ifdef _WIN32
++  if (homedir == NULL)
++    homedir = getenv ("USERPROFILE");
++#endif
+   if (homedir)
+     {
+       char *p;
+diff --git a/gnulib/import/glob.c b/gnulib/import/glob.c
+index 416d210b63..77888277db 100644
+--- a/gnulib/import/glob.c
++++ b/gnulib/import/glob.c
+@@ -663,27 +663,9 @@ glob (const char *pattern, int flags, int (*errfunc) (const char *, int),
+           if (home_dir == NULL || home_dir[0] == '\0')
+             home_dir = "SYS:";
+ # else
+-#  ifdef WINDOWS32
+-          /* Windows NT defines HOMEDRIVE and HOMEPATH.  But give preference
+-             to HOME, because the user can change HOME.  */
+-          if (home_dir == NULL || home_dir[0] == '\0')
+-            {
+-              const char *home_drive = getenv ("HOMEDRIVE");
+-              const char *home_path = getenv ("HOMEPATH");
+-
+-              if (home_drive != NULL && home_path != NULL)
+-                {
+-                  size_t home_drive_len = strlen (home_drive);
+-                  size_t home_path_len = strlen (home_path);
+-                  char *mem = alloca (home_drive_len + home_path_len + 1);
+-
+-                  memcpy (mem, home_drive, home_drive_len);
+-                  memcpy (mem + home_drive_len, home_path, home_path_len + 1);
+-                  home_dir = mem;
+-                }
+-              else
+-                home_dir = "c:/users/default"; /* poor default */
+-            }
++#  ifdef _WIN32
++          if (home_dir== NULL || home_dir[0] == '\0')
++            home_dir = getenv ("USERPROFILE");
+ #  else
+           if (home_dir == NULL || home_dir[0] == '\0')
+             {
+-- 
+2.25.0.windows.1
+

--- a/mingw-w64-arm-none-eabi-gdb/gdb-perfomance.patch
+++ b/mingw-w64-arm-none-eabi-gdb/gdb-perfomance.patch
@@ -1,0 +1,25 @@
+From 6bae5cab05d22b5eb933e198b0034112fed2f65d Mon Sep 17 00:00:00 2001
+From: Orgad Shaneh <orgads@gmail.com>
+Date: Thu, 13 Feb 2020 09:33:39 +0200
+Subject: [PATCH] As DJE said, the workaround looks like below
+
+---
+ gdb/typeprint.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gdb/typeprint.c b/gdb/typeprint.c
+index effc511e5b..32918ff0cd 100644
+--- a/gdb/typeprint.c
++++ b/gdb/typeprint.c
+@@ -54,7 +54,7 @@ const struct type_print_options type_print_raw_options =
+ 
+ static struct type_print_options default_ptype_flags =
+ {
+-  0,				/* raw */
++  1,				/* raw */
+   1,				/* print_methods */
+   1,				/* print_typedefs */
+   0,				/* print_offsets */
+-- 
+2.25.0.windows.1
+

--- a/mingw-w64-arm-none-eabi-gdb/python-configure-path-fixes.patch
+++ b/mingw-w64-arm-none-eabi-gdb/python-configure-path-fixes.patch
@@ -1,0 +1,25 @@
+From 42c791d0d2e21b80aff0dbdb4402c6d633a5002a Mon Sep 17 00:00:00 2001
+From: Orgad Shaneh <orgads@gmail.com>
+Date: Thu, 13 Feb 2020 09:25:04 +0200
+Subject: [PATCH] Python: Configure path fixes
+
+---
+ gdb/configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gdb/configure b/gdb/configure
+index b572d414ca..2c8df2616e 100755
+--- a/gdb/configure
++++ b/gdb/configure
+@@ -10488,7 +10488,7 @@ fi
+         as_fn_error $? "failure running python-config --ldflags" "$LINENO" 5
+       fi
+     fi
+-    python_prefix=`${python_prog} ${srcdir}/python/python-config.py --exec-prefix`
++    python_prefix=`cygpath -u "$(${python_prog} ${srcdir}/python/python-config.py --exec-prefix)"`
+     if test $? != 0; then
+       have_python_config=failed
+       if test "${with_python}" != auto; then
+-- 
+2.25.0.windows.1
+


### PR DESCRIPTION
PKGBUILD changed to a mash-up between 'mingw-w64-gdb' and
Arch Linux 'arm-none-eabi-gdb'

Fix Python dependency issues, and build dependencies