### PR TITLE
sox: add -Wno-format to CFLAGS

### DIFF
--- a/mingw-w64-sox/PKGBUILD
+++ b/mingw-w64-sox/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 # https://sourceforge.net/p/sox/code/ci/07de8a77a862e6800b95a8d3a61c6b4e41362755/
 pkgver=14.4.2.r3203.07de8a77
-pkgrel=2
+pkgrel=3
 pkgdesc="SoX is the Swiss Army Knife of sound processing utilities (mingw-w64)"
 arch=('any')
 url="https://sourceforge.net/projects/sox/"
@@ -63,13 +63,15 @@ prepare() {
 
 build() {
   mkdir -p "$srcdir/build-${MINGW_CHOST}" && cd "$srcdir/build-${MINGW_CHOST}"
+  # Silence format warnings originating from usage of PRIu64 and PRIuPTR within lsx_warn, lsx_debug and lsx_fail
+  export CFLAGS="$CFLAGS -Wno-format"
   ../${_realname}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
     --with-distro='MSYS2 MINGW-packages'
 
-  make CFLAGS="$CFLAGS -D__USE_MINGW_ANSI_STDIO=1"
+  make
 }
 
 package() {


### PR DESCRIPTION
This is an update to commit 9a95842.
Silence format warnings originating from usage of `PRIu64`
and `PRIuPTR` within `lsx_warn`, `lsx_debug` and `lsx_fail`, e.g.:
```console
  warning: unknown conversion type character 'l' in format [-Wformat=]
  warning: too many arguments for format [-Wformat-extra-args]
```
