### PR TITLE
* ngraph-gtk: new upstream release (version 6.08.07).

### DIFF
--- a/mingw-w64-ngraph-gtk/PKGBUILD
+++ b/mingw-w64-ngraph-gtk/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=ngraph-gtk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=6.08.06
+pkgver=6.08.07
 pkgrel=1
 arch=('any')
 pkgdesc="create scientific 2-dimensional graphs (mingw-w64)"
@@ -22,7 +22,7 @@ options=('strip' 'staticlibs')
 license=("GPL")
 url="https://htrb.github.io/ngraph-gtk/"
 source=("https://github.com/htrb/ngraph-gtk/releases/download/v${pkgver}/ngraph-gtk-${pkgver}.tar.gz")
-sha256sums=("fa7d68774fc6d01421344211d456d75541f0a82e82768bfe073160cbcba44fbf")
+sha256sums=("8403d83a42eb25a0ad8d4afdc07b00e3b71a53818875cf132563648a5c41b8ba")
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}


### PR DESCRIPTION
* ngraph-gtk: new upstream release (version 6.08.07).