### PR TITLE
[v8] 32 bit builds do not support compressed pointers

### DIFF
--- a/mingw-w64-v8/PKGBUILD
+++ b/mingw-w64-v8/PKGBUILD
@@ -4,7 +4,7 @@ _realname=v8
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=8.5.210.20
-pkgrel=2
+pkgrel=3
 pkgdesc="Fast and modern Javascript engine (mingw-w64)"
 arch=('any')
 url="https://v8.dev"
@@ -83,10 +83,10 @@ prepare() {
   rm -rf "${srcdir}"/v8-${pkgver}/third_party/markupsafe
   ln -sf "${srcdir}"/markupsafe "${srcdir}"/v8-${pkgver}/third_party
 
-  _cflags="-DV8_COMPRESS_POINTERS"
+  _cflags=""
   case ${CARCH} in
     x86_64)
-      _cflags="$_cflags -DV8_31BIT_SMIS_ON_64BIT_ARCH"
+      _cflags="$_cflags -DV8_COMPRESS_POINTERS -DV8_31BIT_SMIS_ON_64BIT_ARCH"
     ;;
   esac
 


### PR DESCRIPTION
Removing -DV8_COMPRESS_POINTERS from pkg-config file cflags when
building 32 bit package.

Sorry I missed this one 😒, found out because my CI build failed:

[https://ci.appveyor.com/project/Kwizatz/aeongui-altq2](https://ci.appveyor.com/project/Kwizatz/aeongui-altq2)
