### PR TITLE
gnuplot: Enable d2d11 and prntvpt functions.

### DIFF
--- a/mingw-w64-gnuplot/01-gnuplot.patch
+++ b/mingw-w64-gnuplot/01-gnuplot.patch
@@ -138,14 +138,14 @@ diff --unified '--color=auto' -r gnuplot-5.4.0.orig/src/command.c gnuplot-5.4.0/
 diff --unified '--color=auto' -r gnuplot-5.4.0.orig/src/Makefile.am gnuplot-5.4.0/src/Makefile.am
 --- gnuplot-5.4.0.orig/src/Makefile.am	2020-03-31 22:58:16.000000000 +0530
 +++ gnuplot-5.4.0/src/Makefile.am	2020-09-06 20:06:11.275225300 +0530
-@@ -93,6 +93,25 @@
+@@ -93,6 +93,27 @@
  # Hercules and original pc graphics driver code
  # corgraph.asm header.mac hrcgraph.asm pcgraph.asm lineproc.mac
  
 +# MINGW specific build section
 +if BUILD_MINGW
 +
-+AM_CPPFLAGS += -DHAVE_GDIPLUS -DHAVE_DWRITE -DHAVE_D2D -DWIN32
++AM_CPPFLAGS += -DHAVE_GDIPLUS -DHAVE_DWRITE -DHAVE_D2D -DHAVE_D2D11 -DHAVE_PRNTVPT -DWIN32
 +AM_CPPFLAGS += -O2 -pipe -DUNICODE -D_UNICODE -Wno-unused-function
 +AM_CPPFLAGS += -D_Windows -DHAVE_CONFIG_H
 +AM_CPPFLAGS += -D__USE_MINGW_ANSI_STDIO=1
@@ -158,7 +158,9 @@ diff --unified '--color=auto' -r gnuplot-5.4.0.orig/src/Makefile.am gnuplot-5.4.
 +gpexecute.c
 +
 +gnuplot_CPPFLAGS = $(AM_CPPFLAGS) -DPIPES -DWGP_CONSOLE
-+gnuplot_LDADD += -lkernel32 -lgdi32 -lwinspool -lcomdlg32 -lcomctl32 -ladvapi32 -lshell32 -lmsimg32 -lgdiplus -lshlwapi -ld2d1 -ldwrite -lole32 -lgobject-2.0
++gnuplot_LDADD += -lkernel32 -lgdi32 -lwinspool -lcomdlg32 -lcomctl32 \
++ -ladvapi32 -lshell32 -lmsimg32 -lgdiplus -lshlwapi -ld2d1 -ld3d11 -ldwrite \
++ -lprntvpt -lwindowscodecs -lole32 -lgobject-2.0
 +gnuplot_LDFLAGS = $(AM_LDFLAGS) -mconsole
 +
  if BUILD_WXWIDGETS

--- a/mingw-w64-gnuplot/PKGBUILD
+++ b/mingw-w64-gnuplot/PKGBUILD
@@ -7,7 +7,7 @@ _realname=gnuplot
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=5.4.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Plotting package which outputs to X11, PostScript, PNG, GIF, and others (mingw-w64)"
 arch=('any')
 url='http://www.gnuplot.info/'
@@ -26,7 +26,7 @@ options=('strip' 'staticlibs')
 source=("https://downloads.sourceforge.net/sourceforge/${_realname}/${_realname}-${pkgver}.tar.gz"
         "01-gnuplot.patch" )
 sha256sums=('eb4082f03a399fd1e9e2b380cf7a4f785e77023d8dcc7e17570c1b5570a49c47'
-            '9f32dd569400d986f4597a89ecb83021cebb4ce8a15256cab7a0d71581b05fa4')
+            'b07b4220743b47c88d67f41a542562329205d8a2cfa60b9e225ca5b71b4fab5d')
 
 
 prepare() {


### PR DESCRIPTION
This requires latest mingw-w64 headers and crt as of today.