### PR TITLE
binutils: default to <4GB image base for now

### DIFF
--- a/mingw-w64-binutils/2003-Temporarily-revert-default-high-base.patch
+++ b/mingw-w64-binutils/2003-Temporarily-revert-default-high-base.patch
@@ -1,0 +1,11 @@
+--- binutils-2.35/ld/emultempl/pep.em.orig	2020-09-26 15:59:07.076581000 +0200
++++ binutils-2.35/ld/emultempl/pep.em	2020-09-26 16:03:30.120283000 +0200
+@@ -159,7 +159,7 @@
+ static lang_assignment_statement_type *image_base_statement = 0;
+ static unsigned short pe_dll_characteristics = DEFAULT_DLL_CHARACTERISTICS;
+ static bfd_boolean insert_timestamp = TRUE;
+-static bfd_boolean high_default_bases = TRUE;
++static bfd_boolean high_default_bases = FALSE;
+ static const char *emit_build_id;
+ 
+ #ifdef DLL_SUPPORT

--- a/mingw-w64-binutils/PKGBUILD
+++ b/mingw-w64-binutils/PKGBUILD
@@ -6,7 +6,7 @@ _realname=binutils
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.35
-pkgrel=7
+pkgrel=8
 pkgdesc="A set of programs to assemble and manipulate binary and object files (mingw-w64)"
 arch=('any')
 url="https://www.gnu.org/software/binutils/"
@@ -31,7 +31,8 @@ source=(https://ftp.gnu.org/gnu/binutils/${_realname}-${pkgver}.tar.xz{,.sig}
         1005-Fix-a-segfault-when-creating-an-import-library-with-.patch
         2000-Temporarily-revert-default-dll-characteristics.patch
         2001-ld-option-to-move-default-bases-under-4GB.patch
-        2002-Allow-creating-an-empty-import-library-for-a-dll.patch)
+        2002-Allow-creating-an-empty-import-library-for-a-dll.patch
+        2003-Temporarily-revert-default-high-base.patch)
 sha256sums=('1b11659fb49e20e18db460d44485f09442c8c56d5df165de9461eb09c8302f85'
             'SKIP'
             '93296b909e1a4f9d8a4bbe2437aafa17ca565ef6642a9812b0360c05be228c9d'
@@ -47,7 +48,8 @@ sha256sums=('1b11659fb49e20e18db460d44485f09442c8c56d5df165de9461eb09c8302f85'
             '19229691da6a8e74be1d81caedd322f9d125dcd99bbb93937df3d22739d0ed2a'
             'ca835968772bd144d71a6408b4e13d55ae3b10b30138fd2ca5b57409e4557810'
             'b790b09db892a1acde82bfe570ca52b50ed2ca98e6a99254cc8a8528eb87f8b2'
-            '23efc95826a4a60bccb4ee304129066c2f955149093c1320f6854500e41c36e0')
+            '23efc95826a4a60bccb4ee304129066c2f955149093c1320f6854500e41c36e0'
+            'e11b55ef6a0f4b5d4d6dd65df723e90dce359cc27c79787f3a51b7b7fbc7dfcf')
 validpgpkeys=('EAF1C276A747E9ED86210CBAC3126D3B4AE55E93'
               '3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F')
 
@@ -72,6 +74,9 @@ prepare() {
   patch -p1 -i "${srcdir}"/2001-ld-option-to-move-default-bases-under-4GB.patch
   # https://sourceware.org/bugzilla/show_bug.cgi?id=26588
   patch -p1 -i "${srcdir}"/2002-Allow-creating-an-empty-import-library-for-a-dll.patch
+  # https://github.com/msys2/MINGW-packages/issues/7027
+  # https://github.com/msys2/MINGW-packages/issues/7023
+  patch -p1 -i "${srcdir}"/2003-Temporarily-revert-default-high-base.patch
 }
 
 build() {


### PR DESCRIPTION
It can still be enabled via --default-image-base-high

Fixes #7027 #7023