### PR TITLE
Filter -D__USE_MINGW_ANSI_STDIO=1 from CPPFLAGS.

### DIFF
--- a/mingw-w64-winpthreads-git/PKGBUILD
+++ b/mingw-w64-winpthreads-git/PKGBUILD
@@ -6,7 +6,7 @@ _realname=winpthreads
 pkgbase=mingw-w64-${_realname}-git
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git" "${MINGW_PACKAGE_PREFIX}-libwinpthread-git")
 pkgver=8.0.0.6001.98dad1fe
-pkgrel=2
+pkgrel=3
 _commit='98dad1fefed2a07ade0b37ca6c610ad66739631a'
 pkgdesc="MinGW-w64 winpthreads library"
 url="https://mingw-w64.sourceforge.io/"
@@ -49,6 +49,8 @@ build() {
   mkdir -p "${srcdir}"/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
 
   declare -a extra_config
+  # https://github.com/msys2/MINGW-packages/issues/7043
+  extra_config+=("CPPFLAGS=${CPPFLAGS//-D__USE_MINGW_ANSI_STDIO=1/}")
   if check_option "debug" "y"; then
     extra_config+=("CFLAGS=-O0 -g -DWINPTHREAD_DBG")
     extra_config+=("CXXFLAGS=-O0 -g -DWINPTHREAD_DBG")


### PR DESCRIPTION
Fixes #7043.

Draft until my gcc build gets far enough along to verify libstdc++ build.