### PR TITLE
mumps: dependencies fix

### DIFF
--- a/mingw-w64-mumps/PKGBUILD
+++ b/mingw-w64-mumps/PKGBUILD
@@ -5,13 +5,21 @@ _realname=mumps
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.3.3
-pkgrel=1
+pkgrel=2
 arch=('any')
 pkgdesc="Sparse direct SLAE solver (mingw-w64)"
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-gcc-fortran" "${MINGW_PACKAGE_PREFIX}-msmpi" "${MINGW_PACKAGE_PREFIX}-openblas" "${MINGW_PACKAGE_PREFIX}-metis" "${MINGW_PACKAGE_PREFIX}-parmetis" "${MINGW_PACKAGE_PREFIX}-scotch" "${MINGW_PACKAGE_PREFIX}-scalapack")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran"
+         "${MINGW_PACKAGE_PREFIX}-openblas"
+         "${MINGW_PACKAGE_PREFIX}-metis"
+         "${MINGW_PACKAGE_PREFIX}-parmetis"
+         "${MINGW_PACKAGE_PREFIX}-scotch"
+         "${MINGW_PACKAGE_PREFIX}-scalapack"
+         "${MINGW_PACKAGE_PREFIX}-msmpi")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-gcc-fortran")
 options=('strip' 'staticlibs')
-license=('LGPL')
+license=('CeCILL-C')
 url="http://mumps.enseeiht.fr/"
 source=("http://mumps.enseeiht.fr/MUMPS_${pkgver}.tar.gz"
         "0001-makefile.inc.patch")


### PR DESCRIPTION
Redistributed dependencies to fix installation issue on a pristine MSYS2.
License fix.