### PR TITLE
gtkwave: update to 3.3.106

### DIFF
--- a/mingw-w64-gtkwave/PKGBUILD
+++ b/mingw-w64-gtkwave/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gtkwave
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.3.105
+pkgver=3.3.106
 pkgrel=1
 pkgdesc='GTKWaveGTKWave is a fully featured GTK+ based wave viewer for Unix, Win32, and Mac OSX'
 arch=('any')
@@ -20,7 +20,7 @@ makedepends=('perlxml'
              "${MINGW_PACKAGE_PREFIX}-gcc")
 install=gtkwave-${CARCH}.install
 source=("https://gtkwave.sourceforge.io/${_realname}-${pkgver}.tar.gz")
-sha256sums=('cf9757055ee3a1c5550cad66da1996e33145f8e13752e1c6ed2299ffb431612f')
+sha256sums=('c8da2000b64b44645439ed46b549441ffa87dc74a5085bf3f7f2aa4a9b91d1df')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"


### PR DESCRIPTION
A minor update, which fixes some issues with GHW formats (gtkwave/gtkwave#31, ghdl/ghdl#1478).