### PR TITLE
pkg-config: stop conflicting with pkgconf

### DIFF
--- a/mingw-w64-pkg-config/PKGBUILD
+++ b/mingw-w64-pkg-config/PKGBUILD
@@ -4,14 +4,12 @@ _realname=pkg-config
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.29.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A system for managing library compile/link flags (mingw-w64)"
 arch=('any')
 url="https://www.freedesktop.org/wiki/Software/pkg-config/"
 license=('GPL')
 depends=("${MINGW_PACKAGE_PREFIX}-libwinpthread")
-conflicts=("${MINGW_PACKAGE_PREFIX}-pkgconf")
-replaces=("${MINGW_PACKAGE_PREFIX}-pkgconf")
 groups=("${MINGW_PACKAGE_PREFIX}-toolchain")
 source=(https://pkgconfig.freedesktop.org/releases/${_realname}-${pkgver}.tar.gz
         0001-fix-double-slash-in-test.patch


### PR DESCRIPTION
This was used to replace it 6 years ago, but makes it hard to test
pkgconf again.

I want to test it again to see if it's viable now.