### PR TITLE
luajit: Update to 2.1.0-beta3

### DIFF
--- a/mingw-w64-luajit/PKGBUILD
+++ b/mingw-w64-luajit/PKGBUILD
@@ -3,9 +3,9 @@
 _realname=luajit
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.0.5
+pkgver=2.1.0_beta3
 pkgrel=1
-_sourcedir=${_realname}-${pkgver}
+_sourcedir=${_realname}-${pkgver//_/-}
 pkgdesc="Just-in-time compiler and drop-in replacement for Lua 5.1 (mingw-w64)"
 arch=('any')
 url="https://luajit.org/"
@@ -19,10 +19,10 @@ replaces=("${MINGW_PACKAGE_PREFIX}-lua51"
           "${MINGW_PACKAGE_PREFIX}-luajit-git")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 options=('strip' 'staticlibs')
-source=("https://luajit.org/download/LuaJIT-${pkgver}.tar.gz"
+source=("https://luajit.org/download/LuaJIT-${pkgver//_/-}.tar.gz"
         001-make-import-library.patch
         002-fix-pkg-config-file.patch)
-sha256sums=('874b1f8297c697821f561f9b73b57ffd419ed8f4278c82e05b48806d30c1e979'
+sha256sums=('1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3'
             '53ae9e09c524b9dfb3c9e918204b84c23ec45f352fa64a39cbb26c27699ecd89'
             '4df486e82b0bbeead01dcf6001e90c51477a3a8ac18611d60d7067f2c7013428')
 
@@ -37,10 +37,10 @@ build() {
   cd "${srcdir}/${_sourcedir}"
 
   msg "Build static version"
-  make amalg BUILDMODE=static
+  make amalg BUILDMODE=static XCFLAGS=-DLUAJIT_ENABLE_GC64
 
   msg "Build dynamic version"
-  make
+  make XCFLAGS=-DLUAJIT_ENABLE_GC64
 }
 
 package() {


### PR DESCRIPTION
I want to use "JIT compiler support for x64 in GC64 mode" feature implemented in 2.1.0-beta3:

https://luajit.org/ :

> LuaJIT 2.1.0-beta3 has been released
>
> ...
>
> This is the third beta release for the new v2.1 branch. Apart from various fixes, the major new features are JIT compiler support for x64 in GC64 mode, ARM64 and MIPS64.

I know that this is a beta release not a stable release.
But It seems that there is no plan to release a new stable version: https://github.com/LuaJIT/LuaJIT/issues/563

Can we use beta release in our repository?