### PR TITLE
OpenAI deps tier 3

### DIFF
--- a/mingw-w64-python-aiohttp/.gitignore
+++ b/mingw-w64-python-aiohttp/.gitignore
@@ -1,0 +1,2 @@
+aiohttp/
+http-parser/

--- a/mingw-w64-python-aiohttp/PKGBUILD
+++ b/mingw-w64-python-aiohttp/PKGBUILD
@@ -1,0 +1,58 @@
+# Maintainer: Sarah Ottinger <schalaalexiazeal@gmail.com>
+
+_realname=aiohttp
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=3.6.2
+_gitcommit=6a5ab96bd9cb404b4abfd5160fe8f34a29d941e5
+pkgrel=1
+pkgdesc='HTTP client/server for asyncio (mingw-w64)'
+arch=('any')
+url="https://aiohttp.readthedocs.io/"
+license=('Apache')
+depends=("${MINGW_PACKAGE_PREFIX}-python-async-timeout" "${MINGW_PACKAGE_PREFIX}-python-attrs" "${MINGW_PACKAGE_PREFIX}-python-chardet" "${MINGW_PACKAGE_PREFIX}-python-yarl")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools" "${MINGW_PACKAGE_PREFIX}-cython" "git")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-freezegun" "${MINGW_PACKAGE_PREFIX}-python-pytest-runner" "${MINGW_PACKAGE_PREFIX}-python-pytest-cov" "${MINGW_PACKAGE_PREFIX}-python-pytest-forked" "${MINGW_PACKAGE_PREFIX}-python-pytest-mock" "${MINGW_PACKAGE_PREFIX}-python-pytest-timeout" "${MINGW_PACKAGE_PREFIX}-python-pytest-xdist")
+source=(${_realname}::"git+https://github.com/aio-libs/aiohttp#commit=${_gitcommit}"
+        "git+https://github.com/nodejs/http-parser")
+sha512sums=('SKIP'
+            'SKIP')
+
+pkgver() {
+  cd ${_realname}
+  git describe --tags | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+prepare() {  
+  cd "$srcdir"
+  rm -rf python-build-${CARCH} | true
+  cp -r "${_realname}" "python-build-${CARCH}"
+  cd "${srcdir}/python-build-${CARCH}"
+  git submodule init
+  git config submodule."vendor/http-parser".url "${srcdir}/http-parser"
+  git submodule update --recursive
+  sed 's|.install-cython ||' -i Makefile
+}
+
+build() {
+  msg "Python build for ${CARCH}"
+  cd "${srcdir}/python-build-${CARCH}"
+  make cythonize
+  ${MINGW_PREFIX}/bin/python setup.py build
+}
+
+check() {
+  cd "${srcdir}/python-build-${CARCH}"
+  ${MINGW_PREFIX}/bin/python setup.py test || warning "Tests failed"
+}
+
+package() {
+  cd "${srcdir}/python-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+  install -Dm644 LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE.txt"
+}

--- a/mingw-w64-python-aiohttp/PKGBUILD
+++ b/mingw-w64-python-aiohttp/PKGBUILD
@@ -3,9 +3,6 @@
 _realname=aiohttp
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=3.6.2
 _gitcommit=6a5ab96bd9cb404b4abfd5160fe8f34a29d941e5
 pkgrel=1

--- a/mingw-w64-python-google-auth/PKGBUILD
+++ b/mingw-w64-python-google-auth/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=1.22.0
+pkgver=1.22.1
 pkgrel=1
 pkgdesc='Google Authentication Library (mingw-w64)'
 arch=('any')
@@ -17,7 +17,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python-mock" "${MINGW_PACKAGE_PREFIX}-pyt
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!emptydirs')
 source=("${_realname}-$pkgver.tar.gz::https://github.com/GoogleCloudPlatform/google-auth-library-python/archive/v$pkgver.tar.gz")
-sha256sums=('554559ef390e0685cf9bf6d97d9d95f4f6afa4763e5aff44d376b1cb219dc769')
+sha256sums=('bf6ca783aecefe25d7713c07b63f0146373f4b29674f61a633755d86d1660e15')
 
 prepare() {  
   cd "$srcdir"

--- a/mingw-w64-python-google-auth/PKGBUILD
+++ b/mingw-w64-python-google-auth/PKGBUILD
@@ -3,9 +3,6 @@
 _realname=google-auth
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=1.22.1
 pkgrel=1
 pkgdesc='Google Authentication Library (mingw-w64)'

--- a/mingw-w64-python-google-auth/PKGBUILD
+++ b/mingw-w64-python-google-auth/PKGBUILD
@@ -1,0 +1,45 @@
+# Maintainer: Sarah Ottinger <schalaalexiazeal@gmail.com>
+
+_realname=google-auth
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=1.22.0
+pkgrel=1
+pkgdesc='Google Authentication Library (mingw-w64)'
+arch=('any')
+url="https://github.com/GoogleCloudPlatform/google-auth-library-python"
+license=('Apache')
+depends=("${MINGW_PACKAGE_PREFIX}-ca-certificates" "${MINGW_PACKAGE_PREFIX}-python-cachetools" "${MINGW_PACKAGE_PREFIX}-python-pyasn1-modules" "${MINGW_PACKAGE_PREFIX}-python-rsa")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-mock" "${MINGW_PACKAGE_PREFIX}-python-requests" "${MINGW_PACKAGE_PREFIX}-python-flask" "${MINGW_PACKAGE_PREFIX}-python-oauth2client" "${MINGW_PACKAGE_PREFIX}-python-pytest-localserver" "${MINGW_PACKAGE_PREFIX}-python-cryptography" "${MINGW_PACKAGE_PREFIX}-python-freezegun" "${MINGW_PACKAGE_PREFIX}-python-responses" "${MINGW_PACKAGE_PREFIX}-python-pyopenssl")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!emptydirs')
+source=("${_realname}-$pkgver.tar.gz::https://github.com/GoogleCloudPlatform/google-auth-library-python/archive/v$pkgver.tar.gz")
+sha256sums=('554559ef390e0685cf9bf6d97d9d95f4f6afa4763e5aff44d376b1cb219dc769')
+
+prepare() {  
+  cd "$srcdir"
+  rm -rf python-build-${CARCH} | true
+  cp -r "${_realname}-library-python-${pkgver}" "python-build-${CARCH}"
+}
+
+build() {
+  msg "Python build for ${CARCH}"  
+  cd "${srcdir}/python-build-${CARCH}"
+  ${MINGW_PREFIX}/bin/python setup.py build
+}
+
+check() {
+  cd "${srcdir}/python-build-${CARCH}"
+  ${MINGW_PREFIX}/bin/python -m pytest tests || warning "Tests failed"
+}
+
+package() {
+  cd "${srcdir}/python-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}

--- a/mingw-w64-python-resampy/PKGBUILD
+++ b/mingw-w64-python-resampy/PKGBUILD
@@ -3,9 +3,6 @@
 _realname=resampy
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=0.2.2
 pkgrel=1
 pkgdesc='Efficient sample rate conversion in python (mingw-w64)'

--- a/mingw-w64-python-resampy/PKGBUILD
+++ b/mingw-w64-python-resampy/PKGBUILD
@@ -1,0 +1,38 @@
+# Maintainer: Sarah Ottinger <schalaalexiazeal@gmail.com>
+
+_realname=resampy
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=0.2.2
+pkgrel=1
+pkgdesc='Efficient sample rate conversion in python (mingw-w64)'
+arch=('any')
+url="https://github.com/bmcfee/resampy"
+license=('ISC')
+depends=("${MINGW_PACKAGE_PREFIX}-python-numba" "${MINGW_PACKAGE_PREFIX}-python-scipy" "${MINGW_PACKAGE_PREFIX}-python-six")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools" "${MINGW_PACKAGE_PREFIX}-cython")
+source=("${_realname}-$pkgver.tar.gz::https://github.com/bmcfee/resampy/archive/$pkgver.tar.gz")
+sha256sums=('1d2b49db943acbf821b96b4e260e2dbf43cbb9ee34a4513f0e4a2c1c9abcdf6e')
+
+prepare() {  
+  cd "$srcdir"
+  rm -rf python-build-${CARCH} | true
+  cp -r "${_realname}-${pkgver}" "python-build-${CARCH}"
+}
+
+build() {
+  msg "Python build for ${CARCH}"  
+  cd "${srcdir}/python-build-${CARCH}"
+  ${MINGW_PREFIX}/bin/python setup.py build
+}
+
+package() {
+  cd "${srcdir}/python-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}


### PR DESCRIPTION
The following new packages added are dependent on the formerly committed tier 2 packages for OpenAI. There are more on the way than what is listed here, because I have to go back to previous tiers and add new dependencies.

- python-aiohttp
- python-google-auth
- python-resampy