### PR TITLE
arm-none-eabi-newlib: remove workaround from gcc

### DIFF
--- a/mingw-w64-arm-none-eabi-newlib/PKGBUILD
+++ b/mingw-w64-arm-none-eabi-newlib/PKGBUILD
@@ -48,9 +48,6 @@ _build_gcc() {
     cp -a ${MINGW_PREFIX}/${_target} ${srcdir}/gcc-${_gccver}/gcc-install-${MINGW_CHOST}
 
     local _GCC_LDFLAGS="${LDFLAGS} -Wl,--disable-dynamicbase"
-    if [ "${CARCH}" = 'x86_64' ]; then
-        _GCC_LDFLAGS+=",--image-base=0x400000"
-    fi
     ../configure \
         --build=${MINGW_CHOST} \
         --host=${MINGW_CHOST} \


### PR DESCRIPTION
Lower imagebase is no longer needed after #7052.

Not bumping pkgrel because the built gcc is not packaged.