### PR TITLE
gmp: remove workaround --default-image-base-low

### DIFF
--- a/mingw-w64-gmp/PKGBUILD
+++ b/mingw-w64-gmp/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gmp
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=6.2.0
-pkgrel=2
+pkgrel=3
 pkgdesc="A free library for arbitrary precision arithmetic (mingw-w64)"
 arch=('any')
 url="https://gmplib.org/"
@@ -35,11 +35,6 @@ build() {
     --disable-shared
   make
 
-  if [ "${CARCH}" = 'x86_64' ]; then
-    # Without this, breaks existing gcc
-    # XXX remove this once gcc is rebuilt
-    LDFLAGS+=" -Wl,--default-image-base-low"
-  fi
   # Build shared version
   mkdir -p "${srcdir}/shared-${MINGW_CHOST}" && cd "${srcdir}/shared-${MINGW_CHOST}"
   ../${_realname}-${pkgver}/configure --build=${MINGW_CHOST} \


### PR DESCRIPTION
This was only required until gcc was rebuilt with the fixed import library from #7052.