### PR TITLE
arm-none-eabi-gcc: rebuild (without imagebase)

### DIFF
--- a/mingw-w64-arm-none-eabi-gcc/PKGBUILD
+++ b/mingw-w64-arm-none-eabi-gcc/PKGBUILD
@@ -8,7 +8,7 @@ _target=arm-none-eabi
 pkgbase=mingw-w64-${_target}-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_target}-${_realname}")
 pkgver=8.4.0
-pkgrel=2
+pkgrel=3
 pkgdesc='GNU Tools for ARM Embedded Processors - GCC (mingw-w64)'
 arch=('any')
 license=('GPL')
@@ -38,9 +38,6 @@ prepare() {
 
 _build_gcc() {
     local _GCC_LDFLAGS="${LDFLAGS} -Wl,--disable-dynamicbase"
-    if [ "${CARCH}" = 'x86_64' ]; then
-        _GCC_LDFLAGS+=",--image-base=0x400000"
-    fi
     ../configure \
         --build=${MINGW_CHOST} \
         --host=${MINGW_CHOST} \


### PR DESCRIPTION
When built with the fixed import library from #7052, the imagebase workaround is no longer needed.