### PR TITLE
pywin32: Update PKGBUILD

### DIFF
--- a/mingw-w64-python-pywin32/PKGBUILD
+++ b/mingw-w64-python-pywin32/PKGBUILD
@@ -14,7 +14,7 @@ pkgname=(${MINGW_PACKAGE_PREFIX}-python2-${_realname} ${MINGW_PACKAGE_PREFIX}-py
 source=("https://prdownloads.sourceforge.net/${_realname}/${_realname}-${pkgver}.zip"
         001-compile-and-setup-fixes.patch)
 sha256sums=('30c3dbcd45d0c126ad9102d4bbcdeb6b9846869d0b1721faa4f8c9b563ccdb49'
-            '6968c607e1768fd2a78aa5aa8bf7238606638aec81e8844f840eabcf2a6da092')
+            'bcad6631e0fc31ebe4e9383f407a2e1e0caefba4035c4701cf1810e8b20fce3c')
 
 prepare() {
     cd "${srcdir}/${_realname}-${pkgver}"
@@ -28,7 +28,7 @@ build() {
         cd "${srcdir}/build-${_python}-${CARCH}-${_realname}-${pkgver}"
         LIB="${MINGW_PREFIX}/lib:${MINGW_PREFIX}/${CARCH}-w64-mingw32/lib" \
         INCLUDE="${MINGW_PREFIX}/include:${MINGW_PREFIX}/${CARCH}-w64-mingw32/include" \
-        ${MINGW_PREFIX}/bin/${_python} setup.py build --compiler=mingw32
+        ${MINGW_PREFIX}/bin/${_python} setup.py build --skip-verstamp
     done
 }
 


### PR DESCRIPTION
Update setup.py:
- Only for Python3
- If Python were built with py.exe, we don't have to parse '--skip-verstamp'
- Put $(SDKDIR) in your PATH (this is only for these 4 libs, currently unavailable in MinGW-w64):

Copy just these libs from WINSDK 7.1 to $(SDKDIR)/lib/x64:
	ADSIid.Lib
	Bits.Lib
	NtQuery.Lib
	propsys.lib

Copy just this header from WINSDK 7.1 to $(SDKDIR)/include:
	bits2_5.h : comment out '#include "bits3_0.h"'