### PR TITLE
gdb: Add multiarch package

### DIFF
--- a/mingw-w64-gdb/PKGBUILD
+++ b/mingw-w64-gdb/PKGBUILD
@@ -3,9 +3,10 @@
 
 _realname=gdb
 pkgbase=mingw-w64-${_realname}
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-multiarch")
 pkgver=9.2
-pkgrel=3
+pkgrel=4
 pkgdesc="GNU Debugger (mingw-w64)"
 arch=('any')
 url="https://www.gnu.org/software/gdb/"
@@ -70,10 +71,11 @@ prepare() {
   sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" libiberty/configure
 }
 
-build() {
-  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
-  mkdir ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
-  
+do_build() {
+  builddir=${srcdir}/build-${MINGW_CHOST}$1
+  [[ -d ${builddir} ]] && rm -rf ${builddir}
+  mkdir ${builddir} && cd ${builddir}
+
   if [ "${CARCH}" != "x86_64" ]; then
     LDFLAGS+=" -Wl,--large-address-aware"
   fi
@@ -82,7 +84,7 @@ build() {
     CFLAGS+=" -O0"
     CXXFLAGS+=" -O0"
   fi
-  
+
 
   CPPFLAGS+=" -I${MINGW_PREFIX}/include/ncurses"
   CFLAGS+=" -I${MINGW_PREFIX}/include/ncurses"
@@ -94,7 +96,7 @@ build() {
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \
     --prefix=${MINGW_PREFIX} \
-    --enable-targets="i686-w64-mingw32,x86_64-w64-mingw32" \
+    $2 \
     --enable-64-bit-bfd \
     --disable-werror \
     --disable-win32-registry \
@@ -113,7 +115,12 @@ build() {
   make
 }
 
-package() {
+build() {
+  do_build
+  do_build -multiarch --enable-targets=all
+}
+
+package_gdb() {
   cd ${srcdir}/build-${MINGW_CHOST}
   make DESTDIR=${pkgdir} install
 
@@ -122,4 +129,30 @@ package() {
 
   rm -f ${pkgdir}${MINGW_PREFIX}/include/*.h
   rm -f ${pkgdir}${MINGW_PREFIX}/lib/*.a
+}
+
+package_gdb-multiarch() {
+  pkgdesc="GNU Debugger (supports all targets)"
+  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+
+  destdir=${pkgdir}${MINGW_PREFIX}/bin
+  mkdir -p $destdir
+  strip -o ${destdir}/gdb-multiarch.exe ${srcdir}/build-${MINGW_CHOST}-multiarch/gdb/gdb.exe
+  strip -o ${destdir}/gdbserver-multiarch.exe ${srcdir}/build-${MINGW_CHOST}-multiarch/gdb/gdbserver/gdbserver.exe
+}
+
+package_mingw-w64-i686-gdb() {
+  package_gdb
+}
+
+package_mingw-w64-i686-gdb-multiarch() {
+  package_gdb-multiarch
+}
+
+package_mingw-w64-x86_64-gdb() {
+  package_gdb
+}
+
+package_mingw-w64-x86_64-gdb-multiarch() {
+  package_gdb-multiarch
 }


### PR DESCRIPTION
This doubles the build time, but is useful for embedded developers.