### PR TITLE
p11-kit: fix "trust list" crashing

### DIFF
--- a/mingw-w64-p11-kit/0013-fix-reallocarray-decl.patch
+++ b/mingw-w64-p11-kit/0013-fix-reallocarray-decl.patch
@@ -1,0 +1,11 @@
+--- p11-kit-0.23.21/common/compat.h.orig	2020-10-25 22:40:35.843040200 +0100
++++ p11-kit-0.23.21/common/compat.h	2020-10-25 22:41:06.882100100 +0100
+@@ -294,7 +294,7 @@
+ 
+ #endif /* HAVE_STRDUP */
+ 
+-#if defined HAVE_DECL_REALLOCARRAY && !HAVE_DECL_REALLOCARRAY
++#if !defined(HAVE_DECL_REALLOCARRAY) || !HAVE_DECL_REALLOCARRAY
+ 
+ void *     reallocarray     (void *ptr,
+                              size_t nmemb,

--- a/mingw-w64-p11-kit/PKGBUILD
+++ b/mingw-w64-p11-kit/PKGBUILD
@@ -6,7 +6,7 @@ _realname=p11-kit
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.23.21
-pkgrel=3
+pkgrel=4
 pkgdesc="Library to work with PKCS#11 modules"
 arch=('any')
 url="https://p11-glue.freedesktop.org/p11-kit.html"
@@ -28,7 +28,8 @@ source=(https://github.com/p11-glue/p11-kit/releases/download/${pkgver}/${_realn
         0009-add-debugging-to-path.patch
         0010-fix-transport-test.patch
         0011-p11-kit-spawn-external.patch
-        0012-no-version-script.patch)
+        0012-no-version-script.patch
+        0013-fix-reallocarray-decl.patch)
 validpgpkeys=('C0F67099B808FB063E2C81117BFB1108D92765AF'
               '462225C3B46F34879FC8496CD605848ED7E69871')
 sha256sums=('f1baa493f05ca0d867f06bcb54cbb5cdb28c756db07207b6e18de18a87b10627'
@@ -42,7 +43,8 @@ sha256sums=('f1baa493f05ca0d867f06bcb54cbb5cdb28c756db07207b6e18de18a87b10627'
             '8c796ade0ef6356c796d2e87b967c7a9d888783c08e740e35d5686f6deb7f009'
             '6c4b94bb8aee1981c07215d2c8449614f1a604a705f05806f6f1e8299b729698'
             'd5e804ba795aefe0a3938bc527b0e6c8ff8c1d5dfa1c0c1728c20a249504af6b'
-            '15a2729f39e260f7fe8d55a91a399f2512854da626a69bc215470f902fc178cd')
+            '15a2729f39e260f7fe8d55a91a399f2512854da626a69bc215470f902fc178cd'
+            '83ecf11aaf9a1c6f617790048e80febd7320edae6ba203958349264170956911')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
@@ -57,6 +59,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0010-fix-transport-test.patch
   patch -p1 -i ${srcdir}/0011-p11-kit-spawn-external.patch
   patch -p1 -i ${srcdir}/0012-no-version-script.patch
+  patch -p1 -i ${srcdir}/0013-fix-reallocarray-decl.patch
 
   autoreconf -vfi
   gtkdocize


### PR DESCRIPTION
The code in compat.h assumes that HAVE_DECL_REALLOCARRAY is defined
and 0, but with autotools it's just not defined, leading to reallocarray
not being declared.

One reason why this started crashing now might be our new linker hardening flags
leading to larger pointer values.

Hopefully fixes #7166