### PR TITLE
Add gtk-update-icon-cache package

### DIFF
--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -2,9 +2,9 @@
 
 _realname=gtk3
 pkgbase=mingw-w64-${_realname}
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-gtk-update-icon-cache")
 pkgver=3.24.23
-pkgrel=2
+pkgrel=3
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
 url="https://www.gtk.org/"
@@ -74,14 +74,37 @@ build() {
   ninja
 }
 
-package() {
+package_gtk3() {
+  depends+=("${MINGW_PACKAGE_PREFIX}-gtk-update-icon-cache")
+
   cd "${srcdir}/build-${CARCH}"
 
   DESTDIR="${pkgdir}" ninja install
 
   # the hook needs this directory to exist, even if empty
   mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/gtk-3.0/3.0.0/immodules
-  for hook in gtk-query-immodules-3.0 gtk-update-icon-cache; do
+  for hook in gtk-query-immodules-3.0; do
+    local hook_path="${srcdir}/${MINGW_PACKAGE_PREFIX}-${hook}.hook";
+    cp "${srcdir}/${hook}.hook.in" "${hook_path}"
+    sed -s "s|@MINGW_HOOK_TARGET_PREFIX@|${MINGW_PREFIX:1}|g" -i "${hook_path}"
+    sed -s "s|@MINGW_PREFIX@|${MINGW_PREFIX}|g" -i "${hook_path}"
+    sed -s "s|@MINGW_PACKAGE_PREFIX@|${MINGW_PACKAGE_PREFIX}|g" -i "${hook_path}"
+    install -Dt "$pkgdir/usr/share/libalpm/hooks" -m644 "${hook_path}"
+  done
+
+  mv ${pkgdir}${MINGW_PREFIX}/bin/gtk-update-icon-cache "$srcdir"
+  mv ${pkgdir}${MINGW_PREFIX}/share/man/man1/gtk-update-icon-cache.1 "$srcdir"
+
+  install -Dm644 "${srcdir}/gtk+-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}
+
+package_gtk-update-icon-cache() {
+  pkgdesc="GTK+ icon cache updater (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-gdk-pixbuf2"
+           "${MINGW_PACKAGE_PREFIX}-librsvg"
+           "${MINGW_PACKAGE_PREFIX}-hicolor-icon-theme")
+
+  for hook in gtk-update-icon-cache; do
     local hook_path="${srcdir}/${MINGW_PACKAGE_PREFIX}-${hook}.hook";
     cp "${srcdir}/${hook}.hook.in" "${hook_path}"
     sed -s "s|@MINGW_HOOK_TARGET_PREFIX@|${MINGW_PREFIX:1}|g" -i "${hook_path}"
@@ -97,8 +120,12 @@ package() {
     install -Dt "$pkgdir/usr/share/libalpm/scripts" -m644 "${script_path}"
   done
 
+  install -Dt "${pkgdir}${MINGW_PREFIX}/bin" gtk-update-icon-cache
+  install -Dt "${pkgdir}${MINGW_PREFIX}/share/man/man1" gtk-update-icon-cache.1
   mv ${pkgdir}${MINGW_PREFIX}/bin/gtk-update-icon-cache{,-3.0}.exe
   mv ${pkgdir}${MINGW_PREFIX}/share/man/man1/gtk-update-icon-cache{,-3.0}.1
-
-  install -Dm644 "${srcdir}/gtk+-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }
+
+for _name in "${pkgname[@]}"; do
+  eval "package_${_name}() { package_${_name#${MINGW_PACKAGE_PREFIX}-}; }";
+done


### PR DESCRIPTION
This just contains the gtk-update-icon-cache binary which doesn't
depend on gtk itself and the pacman hooks for updating the cache.

This allows other packages to depend on it for getting the hooks without
having to depend on gtk3.

This mirrors what Arch Linux does.