### PR TITLE
libavro: add threadsafe option

### DIFF
--- a/mingw-w64-libavro/002-libavro-1.10.0-add-threadsafe-option.patch
+++ b/mingw-w64-libavro/002-libavro-1.10.0-add-threadsafe-option.patch
@@ -1,0 +1,57 @@
+From f561633d59490fe57901302f7aa50fe178a273f3 Mon Sep 17 00:00:00 2001
+From: Diego Sogari <dsogari@nelogica.com.br>
+Date: Thu, 29 Oct 2020 10:56:08 -0300
+Subject: [PATCH] Add support for THREADSAFE option in MinGW build
+
+---
+ lang/c/CMakeLists.txt | 4 ++--
+ lang/c/src/errors.c   | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/lang/c/CMakeLists.txt b/lang/c/CMakeLists.txt
+index f3a013c4..0c359fae 100644
+--- a/lang/c/CMakeLists.txt
++++ b/lang/c/CMakeLists.txt
+@@ -121,7 +121,7 @@ endif(WIN32 AND NOT MINGW)
+ 
+ # Thread support (only for *nix with pthreads)
+ set(THREADS_LIBRARIES)
+-if(UNIX AND THREADSAFE AND CMAKE_COMPILER_IS_GNUCC)
++if((UNIX OR MINGW) AND THREADSAFE AND CMAKE_COMPILER_IS_GNUCC)
+     set(CMAKE_THREAD_PREFER_PTHREAD)
+     find_package(Threads)
+ 
+@@ -131,7 +131,7 @@ if(UNIX AND THREADSAFE AND CMAKE_COMPILER_IS_GNUCC)
+ 
+     add_definitions(-DTHREADSAFE -D_REENTRANT)
+     set(THREADS_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
+-endif(UNIX AND THREADSAFE AND CMAKE_COMPILER_IS_GNUCC)
++endif((UNIX OR MINGW) AND THREADSAFE AND CMAKE_COMPILER_IS_GNUCC)
+ 
+ include_directories(${AvroC_SOURCE_DIR}/src)
+ 
+diff --git a/lang/c/src/errors.c b/lang/c/src/errors.c
+index 8abd8c83..a320810f 100644
+--- a/lang/c/src/errors.c
++++ b/lang/c/src/errors.c
+@@ -42,7 +42,7 @@ struct avro_error_data_t {
+ 
+ 
+ #if defined THREADSAFE 
+-#if ( defined __unix__ || defined __unix )
++#if ( defined __unix__ || defined __unix || defined __MINGW32__ )
+ #include <pthread.h>
+ static pthread_key_t error_data_key;
+ static pthread_once_t error_data_key_once = PTHREAD_ONCE_INIT;
+@@ -63,7 +63,7 @@ static struct avro_error_data_t *
+ avro_get_error_data(void)
+ {
+ #if defined THREADSAFE  
+-#if defined __unix__ || defined __unix
++#if defined __unix__ || defined __unix || defined __MINGW32__
+ 
+     pthread_once(&error_data_key_once, make_error_data_key);
+ 
+-- 
+2.26.2.windows.1
+

--- a/mingw-w64-libavro/PKGBUILD
+++ b/mingw-w64-libavro/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libavro
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.10.0
-pkgrel=1
+pkgrel=2
 pkgdesc="The Apache Avro data serialization system (mingw-w64)"
 arch=('any')
 url="https://github.com/apache/avro"
@@ -20,13 +20,16 @@ depends=("${MINGW_PACKAGE_PREFIX}-boost"
          "${MINGW_PACKAGE_PREFIX}-xz"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/apache/avro/archive/release-${pkgver}.tar.gz"
-        "001-libavro-1.10.0-fix-mingw-build.patch")
+        "001-libavro-1.10.0-fix-mingw-build.patch"
+        "002-libavro-1.10.0-add-threadsafe-option.patch")
 sha256sums=('50ceefe582193ef8a92a8891bac1520df778f5c260f2ba68f4c9ae41417e3777'
-            '0914fa866147664df53daf8217c13fe34de477ddf5081d7aba7eca8575155606')
+            '0914fa866147664df53daf8217c13fe34de477ddf5081d7aba7eca8575155606'
+            '346e37dc9adb52739e672483ee895299da6e00121ae0061beb2df3063234d62b')
 
 prepare() {
   cd "${srcdir}/avro-release-${pkgver}"
   patch -Np1 -i "${srcdir}/001-libavro-1.10.0-fix-mingw-build.patch"
+  patch -Np1 -i "${srcdir}/002-libavro-1.10.0-add-threadsafe-option.patch"
 }
 
 build() {
@@ -40,6 +43,8 @@ build() {
     ${MINGW_PREFIX}/bin/cmake.exe \
       -G"MSYS Makefiles" \
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      -DCMAKE_BUILD_TYPE="Release" \
+      -DTHREADSAFE=ON \
       "../avro-release-${pkgver}/lang/${lang}"
 
     make


### PR DESCRIPTION
There's no need to rebuild dependent packages.