### PR TITLE
CI: add a job using pkgconf

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,9 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          { msystem: MINGW64, arch: x86_64 },
-          { msystem: MINGW32, arch: i686   }
+          { msystem: MINGW64, arch: x86_64, pkgconf: pkg-config },
+          { msystem: MINGW64, arch: x86_64, pkgconf: pkgconf },
+          { msystem: MINGW32, arch: i686, pkgconf: pkg-config }
         ]
     steps:
 
@@ -34,6 +35,7 @@ jobs:
       - name: CI-Build
         shell: msys2 {0}
         run: |
+          pacman -S --noconfirm --needed mingw-w64-${{ matrix.arch }}-${{ matrix.pkgconf }}
           cd /C/_
           MINGW_INSTALLS=${{ matrix.msystem }} ./ci-build.sh
 


### PR DESCRIPTION
The goal is to build various things also with pkgconf for a month or so, to find out if it is compatible enough with pkg-config, so we can switch.