### PR TITLE
python: copy all python launchers into the venv

### DIFF
--- a/mingw-w64-python/2052-venv-creation-fixes.patch
+++ b/mingw-w64-python/2052-venv-creation-fixes.patch
@@ -31,13 +31,16 @@ diff -Naur Python-3.8.0-orig/Lib/venv/__init__.py Python-3.8.0/Lib/venv/__init__
                  # For symlinking, we need a complete copy of the root directory
                  # If symlinks fail, you'll get unnecessary copies of files, but
                  # we assume that if you've opted into symlinks on Windows then
-@@ -267,7 +267,10 @@
+@@ -266,7 +267,13 @@
                  if os.path.lexists(src):
                      copier(src, os.path.join(binpath, suffix))
  
 -            if sysconfig.is_python_build(True):
 +            if _POSIX_BUILD:
++                # copy from python/pythonw so the venvlauncher magic in symlink_or_copy triggers
 +                copier(os.path.join(dirname, 'python.exe'), os.path.join(binpath, 'python3.exe'))
++                copier(os.path.join(dirname, 'python.exe'), os.path.join(binpath, 'python%d.%d.exe' % sys.version_info[:2]))
++                copier(os.path.join(dirname, 'pythonw.exe'), os.path.join(binpath, 'python3w.exe'))
 +
 +            if sysconfig.is_python_build(True) and not _POSIX_BUILD:
                  # copy init.tcl

--- a/mingw-w64-python/PKGBUILD
+++ b/mingw-w64-python/PKGBUILD
@@ -18,7 +18,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 _pybasever=3.8
 pkgver=${_pybasever}.6
-pkgrel=5
+pkgrel=6
 provides=("${MINGW_PACKAGE_PREFIX}-python3=${pkgver}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3"
            "${MINGW_PACKAGE_PREFIX}-python2<2.7.16-7")
@@ -537,7 +537,7 @@ sha256sums=('a9e0b79d27aa056eb9cce8d63a427b5f9bab1465dee3f942dcfdb25a82f4ab8a'
             '0ded9e2792b95902d898aba91020103875f2987a9566b353f3e6988b08848f4a'
             'd3a0669c83e4df5d33606b4c3443d2c6c71b76cb4f6421d6d54ee630023be6c2'
             'a7fbf65a86889f95138360ca4dbd4e51de2e214384ee39740d9c6c381ff997d9'
-            '3aa8eec5334635b6a0e5910ca43531f58d25a0836d9e8beeacaae8558b335f2b'
+            'ac0400fd7c9ceada1356fe4b7eae3892f35652f09f488b31fd011e0642d373a3'
             '6f1a48380445406709ba5c6b4b9c6f0301ea645324feb429f3719dc29b8f28ff'
             'b2f4083ada35c18876edf38220d84ca757cf710bc5c2d80ee8b5083dc6c2609f'
             '487c92837717975ad6c63fe2a1f8e8c5c9e0554e96000102d83c82f4a77fd9bd'


### PR DESCRIPTION
Turns out Python uses the basename of the calling executable to
decide which launcher in the venv it uses to call pip with.
This means we have to copy all launchers we ship.

Use the non versioned launchers as src so the rewrite logic in venv
copies the venvlauncher variants.

Fixes #7227