### PR TITLE
mingw-w64-gprbuild: remove run dependencies

### DIFF
--- a/mingw-w64-gprbuild/PKGBUILD
+++ b/mingw-w64-gprbuild/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 _gh_release=21.0.0
 pkgver=20${_gh_release}
-pkgrel=1
+pkgrel=2
 
 pkgdesc="Software tool designed to help automate the construction of multi-language systems (mingw-w64)"
 arch=('any')
@@ -16,8 +16,6 @@ url="https://github.com/AdaCore/gprbuild/"
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc-ada"
              "${MINGW_PACKAGE_PREFIX}-xmlada"
              "${MINGW_PACKAGE_PREFIX}-gprbuild-bootstrap-git")
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-ada"
-         "${MINGW_PACKAGE_PREFIX}-xmlada")
 conflicts=("${MINGW_PACKAGE_PREFIX}-gprbuild-bootstrap")
 source=("gprbuild-${_gh_release}.tar.gz::https://github.com/AdaCore/gprbuild/archive/v${_gh_release}.tar.gz"
         "gprconfig_kb-${_gh_release}.tar.gz::https://github.com/AdaCore/gprconfig_kb/archive/v${_gh_release}.tar.gz")


### PR DESCRIPTION
xmlada is statically linked and gprbuild doesn't need the compiler to run.