### PR TITLE
New package: petsc

### DIFF
--- a/mingw-w64-petsc/0001-mpi-detection-override.patch
+++ b/mingw-w64-petsc/0001-mpi-detection-override.patch
@@ -1,0 +1,21 @@
+diff -urN petsc-3.13.5.orig/config/BuildSystem/config/packages/MPI.py petsc-3.13.5/config/BuildSystem/config/packages/MPI.py
+--- petsc-3.13.5.orig/config/BuildSystem/config/packages/MPI.py	2020-07-02 06:50:43.000000000 +0500
++++ petsc-3.13.5/config/BuildSystem/config/packages/MPI.py	2020-10-03 19:01:00.180021500 +0500
+@@ -14,7 +14,7 @@
+     config.package.Package.__init__(self, framework)
+     self.minversion         = '2'
+     self.versionname        = 'MPI_VERSION'
+-    self.functions          = ['MPI_Init', 'MPI_Comm_create']
++    self.functions          = []
+     self.includes           = ['mpi.h']
+     liblist_mpich         = [['fmpich2.lib','fmpich2g.lib','fmpich2s.lib','mpi.lib'],
+                              ['fmpich2.lib','fmpich2g.lib','mpi.lib'],['fmpich2.lib','mpich2.lib'],
+@@ -289,6 +289,8 @@
+     # flag broken one-sided tests
+     if not 'HAVE_MSMPI' in self.defines and not (hasattr(self, 'mpich_numversion') and int(self.mpich_numversion) <= 30004300):
+       self.addDefine('HAVE_MPI_ONE_SIDED', 1)
++    for f in '''MPI_Comm_spawn MPI_Type_get_envelope MPI_Type_get_extent MPI_Type_dup MPI_Init_thread MPI_Finalized MPI_Exscan'''.split():
++      self.addDefine('HAVE_' + f.upper(),1)
+     self.compilers.CPPFLAGS = oldFlags
+     self.compilers.LIBS = oldLibs
+     self.logWrite(self.framework.restoreLog())

--- a/mingw-w64-petsc/PKGBUILD
+++ b/mingw-w64-petsc/PKGBUILD
@@ -3,10 +3,13 @@
 _realname=petsc
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-${_realname}-build")
+# The `petsc-build` package contains the distilled PETSc build tree
+# required at compile time by some packages (such as SLEPc).
+# Regular users should use the `petsc` package.
 pkgver=3.14.1
 pkgrel=1
 arch=('any')
-pkgdesc="Sparse iterative (non)linear solver package (mingw-w64)"
+pkgdesc='Sparse iterative (non)linear solver package (mingw-w64)'
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran"	
          "${MINGW_PACKAGE_PREFIX}-openblas"
@@ -14,14 +17,14 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-metis"
          "${MINGW_PACKAGE_PREFIX}-scotch"
          "${MINGW_PACKAGE_PREFIX}-msmpi")
-makedepends=("python"
+makedepends=('python'
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-gcc-fortran")
 options=('strip' 'staticlibs')
 license=('2-clause BSD')
 url="https://www.mcs.anl.gov/petsc/"
 source=("http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/${_realname}-lite-${pkgver}.tar.gz"
-        "0001-mpi-detection-override.patch")
+        '0001-mpi-detection-override.patch')
 noextract=("${_realname}-lite-${pkgver}.tar.gz")
 sha256sums=('0b4681165a9af96594c794b97ac6993452ec902726679f6b50bb450f89d230ed'
             'a28912b086807df7381abaec28353023a148f17a594abb6a1478f3b7b434373b')
@@ -35,12 +38,13 @@ prepare() {
   done
 }
 
-builds="dso dto dmo zso zto zmo sso sto smo cso cto cmo"
+builds='dso dto dmo zso zto zmo sso sto smo cso cto cmo'
 
 _petsc() {
   opts="--with-single-library=0 --disable-shared --with-windows-graphics=0 --with-x=0 --with-openblas=1 --with-openblas-dir=$MINGW_PREFIX"
   ld=gfortran
   pc=openblas
+  xflags=-msse # SSE support is required for proper FP trapping
   iflags=
   ldflags=
   desc=
@@ -83,21 +87,20 @@ _petsc() {
       desc="$desc complex"
     ;;
   esac
-  cf=-msse # SSE support is required for FP trapping
   case $1 in
     *o)
       opts="$opts --with-debugging=0"
-      cflags="$CFLAGS $cf"
-      cxxflags="$CXXFLAGS $cf"
-      fflags="$CFLAGS $cf"
+      cflags="$CFLAGS $xflags"
+      cxxflags="$CXXFLAGS $xflags"
+      fflags="$CFLAGS $xflags"
       options=('strip' 'staticlibs')
     ;;
     *g)
       opts="$opts --with-debugging=1"
       debug="-g -Og"
-      cflags="$CFLAGS $debug $cf"
-      cxxflags="$CXXFLAGS $debug $cf"
-      fflags="$CFLAGS $debug $cf"
+      cflags="$CFLAGS $debug $xflags"
+      cxxflags="$CXXFLAGS $debug $xflags"
+      fflags="$CFLAGS $debug $xflags"
       options=('!strip' 'staticlibs')
     ;;
   esac
@@ -185,7 +188,7 @@ _package_build() {
       ${_realname}-${pkgver}/${build}/lib/petsc/conf/petscvariables
   done
   echo "
-    petsc_ver=${pkgver}
+    petsc_pkgver=${pkgver}
     petsc_builds=\"${builds}\"
   " | sed '/^\s*$/d;s/^\s*//' > ${_realname}-${pkgver}/petsc
 }

--- a/mingw-w64-petsc/PKGBUILD
+++ b/mingw-w64-petsc/PKGBUILD
@@ -175,6 +175,14 @@ _package_build() {
   find . -regextype posix-extended \( -regex '.*\.(o|dll|log|DIR)$' -or -regex '.*/__pycache__' \) -exec rm -rf {} +
   for build in ${builds}; do
     find . -regextype posix-extended -regex ".*$build/(bin|obj|tests)" -exec rm -rf {} +
+    si=${MINGW_PREFIX}/src/${_realname}-${pkgver}/include
+    sb=${MINGW_PREFIX}/src/${_realname}-${pkgver}/${build}/include
+    pi=${MINGW_PREFIX}/include/petsc
+    pb=${MINGW_PREFIX}/include/petsc/${build}
+    sed -r -i \
+      -e "s%(PETSC_(C|F)C_INCLUDES)[[:space:]]+.*$%\\1 = -I${sb} -I${si}%" \
+      -e "s%(PETSC_(C|F)C_INCLUDES_INSTALL)[[:space:]]+.*$%\\1 = -I${pb} -I${pi}%" \
+      ${_realname}-${pkgver}/${build}/lib/petsc/conf/petscvariables
   done
   echo "
     petsc_ver=${pkgver}

--- a/mingw-w64-petsc/PKGBUILD
+++ b/mingw-w64-petsc/PKGBUILD
@@ -1,0 +1,165 @@
+# Contributor: Oleg A. Khlybov <fougas@mail.ru>
+
+_realname=petsc
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=3.14.1
+pkgrel=1
+arch=('any')
+pkgdesc="Sparse iterative (non)linear solver package (mingw-w64)"
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran"	
+         "${MINGW_PACKAGE_PREFIX}-openblas"
+         "${MINGW_PACKAGE_PREFIX}-parmetis"
+         "${MINGW_PACKAGE_PREFIX}-metis"
+         "${MINGW_PACKAGE_PREFIX}-scotch"
+         "${MINGW_PACKAGE_PREFIX}-msmpi")
+makedepends=("python"
+             "${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-gcc-fortran")
+options=('strip' 'staticlibs')
+license=('2-clause BSD')
+url="https://www.mcs.anl.gov/petsc/"
+source=("http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/${_realname}-lite-${pkgver}.tar.gz"
+        "0001-mpi-detection-override.patch")
+noextract=("${_realname}-lite-${pkgver}.tar.gz")
+sha256sums=('0b4681165a9af96594c794b97ac6993452ec902726679f6b50bb450f89d230ed'
+            'a28912b086807df7381abaec28353023a148f17a594abb6a1478f3b7b434373b')
+
+prepare() {
+  mkdir -p $srcdir/build-${MINGW_CHOST} && cd $srcdir/build-${MINGW_CHOST}
+  tar xzf $srcdir/${_realname}-lite-${pkgver}.tar.gz
+  cd ${_realname}-${pkgver}
+  for p in ${source[*]:1}; do
+    patch -p1 -i "$srcdir/$p"
+  done
+}
+
+builds="dso dto dmo zso zto zmo sso sto smo cso cto cmo"
+
+_petsc() {
+  opts="--with-single-library=0 --disable-shared --with-windows-graphics=0 --with-x=0 --with-openblas=1 --with-openblas-dir=$MINGW_PREFIX"
+  ld=gfortran
+  pc=openblas
+  iflags=
+  ldflags=
+  desc=
+  case $1 in
+    ?m?)
+      opts="$opts --with-mpi=1 --with-mpi-compilers=1 --with-pthread=0 --with-openmp=0 --with-metis=1 --with-parmetis=1 --with-scotch=1 --with-ptscotch=1"
+      pc="$pc parmetis ptscotch msmpi"
+      ldflags="$ldflags -lptscotchparmetis"
+      ld=mpifort
+      desc="MPI parallel"
+    ;;
+    ?t?)
+      opts="$opts --with-mpi=0 --with-pthread=0 --with-openmp=1"
+      iflags="$iflags -I\${includedir}/mpiuni"
+      ldflags="-fopenmp $ldflags"
+      desc="OpenMP parallel"
+    ;;
+    ?s?)
+      opts="$opts --with-mpi=0 --with-pthread=0 --with-openmp=0"
+      iflags="$iflags -I\${includedir}/mpiuni"
+      desc="Sequential"
+    ;;
+  esac
+  case $1 in
+    z*|d*)
+      opts="$opts --with-precision=double"
+      desc="$desc double precision"
+    ;;
+    c*|s*)
+      opts="$opts --with-precision=single"
+      desc="$desc single precision"
+    ;;
+  esac
+  case $1 in
+    d*|s*)
+      opts="$opts --with-scalar-type=real"
+    ;;
+    z*|c*)
+      opts="$opts --with-scalar-type=complex"
+      desc="$desc complex"
+    ;;
+  esac
+  # SSE support is required for FP trapping
+  case $1 in
+    *o)
+      opts="$opts --with-debugging=0"
+      cflags="$CFLAGS -msse"
+      cxxflags="$CXXFLAGS -msse"
+      fflags="$CFLAGS -msse"
+      options=('strip' 'staticlibs')
+    ;;
+    *g)
+      opts="$opts --with-debugging=1"
+      debug="-g -Og"
+      cflags="$CFLAGS $debug -msse"
+      cxxflags="$CXXFLAGS $debug -msse"
+      fflags="$CFLAGS $debug -msse"
+      options=('!strip' 'staticlibs')
+    ;;
+  esac
+}
+
+build() {
+  cd  "${srcdir}/build-${MINGW_CHOST}/${_realname}-${pkgver}"
+  for build in ${builds}; do
+    _petsc ${build}
+    export PETSC_DIR=`pwd`
+    /usr/bin/python configure --PETSC_ARCH=${build} ${opts} CFLAGS="$cflags" FFLAGS="$fflags" CXXFLAGS="$cxxflags" CPPFLAGS="$CPPFLAGS" LDFLAGS="$LDFLAGS" MAKEFLAGS="$MAKEFLAGS"
+    make PETSC_ARCH=${build} all
+  	(
+  		cd ${build}/lib
+  		lib=libpetsc-${build}
+  		rm -rf ${lib}.a
+  	  case ${build} in
+    		*o) strip -S *.a ;;
+  	  esac
+  		ar crsT ${lib}.a libpetscts.a libpetscsnes.a libpetscksp.a libpetscdm.a libpetscmat.a libpetscvec.a libpetscsys.a
+  		${ld} -shared -Wl,--enable-auto-import -Wl,--export-all-symbols -o ${lib}.dll -Wl,--out-implib,${lib}.dll.a -Wl,--whole-archive ${lib}.a -Wl,--no-whole-archive ${ldflags} $(pkg-config ${pc} --libs)
+  	)
+  done
+}
+
+package() {
+  cd ${srcdir}/build-${MINGW_CHOST}/${_realname}-${pkgver}
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/{bin,lib/pkgconfig,lib/${_realname},include/${_realname}}
+  (
+    cd include
+    cp *.h ${pkgdir}${MINGW_PREFIX}/include/${_realname}
+    cd ${_realname}
+    cp -R finclude mpiuni ${pkgdir}${MINGW_PREFIX}/include/${_realname}
+    cd ${pkgdir}${MINGW_PREFIX}/include/${_realname}
+    find . \( ! -name '*.h' -a -type f \) -delete
+  )
+  for build in ${builds}; do
+    _petsc ${build}
+  	(
+  		cd ${build}/lib
+  		mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/${_realname}/${build}
+  		cp *.a ${pkgdir}${MINGW_PREFIX}/lib/${_realname}/${build}
+  		cp *.dll ${pkgdir}${MINGW_PREFIX}/bin
+  	)
+  	(
+  		cd ${build}/include
+  		mkdir -p ${pkgdir}${MINGW_PREFIX}/include/${_realname}/${build}
+  		cp *.{h,mod} ${pkgdir}${MINGW_PREFIX}/include/${_realname}/${build}
+  	)
+    lib=${_realname}-${build}
+    echo "
+      prefix=${MINGW_PREFIX}
+      libdir=\${prefix}/lib/${_realname}
+      includedir=\${prefix}/include/${_realname}
+      Name: ${_realname}
+      URL: ${url}
+      Version: ${pkgver}
+      Description: ${desc} PETSc build
+      Requires.private: ${pc}
+      Cflags: -I\${includedir}/${build} -I\${includedir} ${iflags}
+      Libs.private: -L\${libdir}/${build} -l${lib} ${ldflags} -lgfortran -lquadmath
+      Libs: -L\${libdir}/${build} -l${lib}
+    " | sed '/^\s*$/d;s/^\s*//' > ${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/${lib}.pc
+  done
+}

--- a/mingw-w64-petsc/PKGBUILD
+++ b/mingw-w64-petsc/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=petsc
 pkgbase=mingw-w64-${_realname}
-pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-${_realname}-build")
 pkgver=3.14.1
 pkgrel=1
 arch=('any')
@@ -83,21 +83,21 @@ _petsc() {
       desc="$desc complex"
     ;;
   esac
-  # SSE support is required for FP trapping
+  cf=-msse # SSE support is required for FP trapping
   case $1 in
     *o)
       opts="$opts --with-debugging=0"
-      cflags="$CFLAGS -msse"
-      cxxflags="$CXXFLAGS -msse"
-      fflags="$CFLAGS -msse"
+      cflags="$CFLAGS $cf"
+      cxxflags="$CXXFLAGS $cf"
+      fflags="$CFLAGS $cf"
       options=('strip' 'staticlibs')
     ;;
     *g)
       opts="$opts --with-debugging=1"
       debug="-g -Og"
-      cflags="$CFLAGS $debug -msse"
-      cxxflags="$CXXFLAGS $debug -msse"
-      fflags="$CFLAGS $debug -msse"
+      cflags="$CFLAGS $debug $cf"
+      cxxflags="$CXXFLAGS $debug $cf"
+      fflags="$CFLAGS $debug $cf"
       options=('!strip' 'staticlibs')
     ;;
   esac
@@ -123,7 +123,10 @@ build() {
   done
 }
 
-package() {
+eval "package_${MINGW_PACKAGE_PREFIX}-${_realname}() { _package; }"
+eval "package_${MINGW_PACKAGE_PREFIX}-${_realname}-build() { _package_build; }"
+
+_package() {
   cd ${srcdir}/build-${MINGW_CHOST}/${_realname}-${pkgver}
   mkdir -p ${pkgdir}${MINGW_PREFIX}/{bin,lib/pkgconfig,lib/${_realname},include/${_realname}}
   (
@@ -162,4 +165,19 @@ package() {
       Libs: -L\${libdir}/${build} -l${lib}
     " | sed '/^\s*$/d;s/^\s*//' > ${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/${lib}.pc
   done
+}
+
+_package_build() {
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/src
+  cd ${srcdir}/build-${MINGW_CHOST}
+  cp -R ${_realname}-${pkgver} ${pkgdir}${MINGW_PREFIX}/src
+  cd ${pkgdir}${MINGW_PREFIX}/src
+  find . -regextype posix-extended \( -regex '.*\.(a|o|dll|log|DIR)$' -or -regex '.*/__pycache__' \) -exec rm -rf {} +
+  for build in ${builds}; do
+    find . -regextype posix-extended -regex ".*$build/(bin|obj|tests)" -exec rm -rf {} +
+  done
+  echo "
+    petsc_ver=${pkgver}
+    petsc_builds=\"${builds}\"
+  " | sed '/^\s*$/d;s/^\s*//' > ${_realname}-${pkgver}/petsc
 }

--- a/mingw-w64-petsc/PKGBUILD
+++ b/mingw-w64-petsc/PKGBUILD
@@ -172,7 +172,7 @@ _package_build() {
   cd ${srcdir}/build-${MINGW_CHOST}
   cp -R ${_realname}-${pkgver} ${pkgdir}${MINGW_PREFIX}/src
   cd ${pkgdir}${MINGW_PREFIX}/src
-  find . -regextype posix-extended \( -regex '.*\.(a|o|dll|log|DIR)$' -or -regex '.*/__pycache__' \) -exec rm -rf {} +
+  find . -regextype posix-extended \( -regex '.*\.(o|dll|log|DIR)$' -or -regex '.*/__pycache__' \) -exec rm -rf {} +
   for build in ${builds}; do
     find . -regextype posix-extended -regex ".*$build/(bin|obj|tests)" -exec rm -rf {} +
   done


### PR DESCRIPTION
This recipe builds {SDCZ} x {sequential, OpenMP and MPI} static and DLL PETSc builds (12 variants in total) with PkgConfig support.