### PR TITLE
mingw-w64-mesa: Update to 20.2.2

### DIFF
--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=20.2.1
+pkgver=20.2.2
 pkgrel=1
 pkgdesc="Open-source implementation of the OpenGL specification (mingw-w64)"
 arch=('any')
@@ -12,7 +12,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-llvm"
              "${MINGW_PACKAGE_PREFIX}-python-mako"
              "${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
-depends=("${MINGW_PACKAGE_PREFIX}-zlib")
+depends=("${MINGW_PACKAGE_PREFIX}-llvm"
+         "${MINGW_PACKAGE_PREFIX}-zlib")
 optdepends=("${MINGW_PACKAGE_PREFIX}-opengl-man-pages: for the OpenGL API man pages"
             "${MINGW_PACKAGE_PREFIX}-zstd: use ZSTD instead of zlib for certain compression tasks")
 url="https://www.mesa3d.org/"
@@ -20,7 +21,7 @@ license=('MIT')
 options=('staticlibs' 'strip')
 source=(https://mesa.freedesktop.org/archive/${_realname}-${pkgver}.tar.xz{,.sig}
         llvmwrapgen.sh)
-sha256sums=('d1a46d9a3f291bc0e0374600bdcb59844fa3eafaa50398e472a36fc65fd0244a'
+sha256sums=('1f93eb1090cf71490cd0e204e04f8427a82b6ed534b7f49ca50cea7dcc89b861'
             'SKIP'
             '44e7684f962442aa9733abcdd5bccff15f8d163b40149d113a68de2e8146fc55')
 validpgpkeys=('8703B6700E7EE06D7A39B8D6EDAE37B02CEB490D') # Emil Velikov <emil.l.velikov@gmail.com>
@@ -79,10 +80,11 @@ build() {
   --includedir=include/mesa
   --buildtype=release
   --backend=ninja
-  -Dshared-glapi=true
-  -Dgles1=true
-  -Dgles2=true
-  -Dllvm=true
+  -Dshared-glapi=enabled
+  -Dgles1=enabled
+  -Dgles2=enabled
+  -Dllvm=enabled
+  -Dshared-llvm=enabled
   -Dosmesa=gallium
   -Dbuild-tests=true"
 

--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -23,7 +23,7 @@ source=(https://mesa.freedesktop.org/archive/${_realname}-${pkgver}.tar.xz{,.sig
         llvmwrapgen.sh)
 sha256sums=('1f93eb1090cf71490cd0e204e04f8427a82b6ed534b7f49ca50cea7dcc89b861'
             'SKIP'
-            '44e7684f962442aa9733abcdd5bccff15f8d163b40149d113a68de2e8146fc55')
+            '69f21522f20c10f5699dfe3e128aa88d4fedde816f6e8df1506d7470c44bf3da')
 validpgpkeys=('8703B6700E7EE06D7A39B8D6EDAE37B02CEB490D') # Emil Velikov <emil.l.velikov@gmail.com>
 validpgpkeys+=('946D09B5E4C9845E63075FF1D961C596A7203456') # Andres Gomez <tanty@igalia.com>
 validpgpkeys+=('E3E8F480C52ADD73B278EE78E1ECBE07D7D70895') # Juan Antonio Suárez Romero (Igalia, S.L.) <jasuarez@igalia.com>"
@@ -69,7 +69,7 @@ prepare() {
 
 # Generate binary wrap for LLVM if llvm-config tool is busted
   if ! [ "$(${MINGW_PREFIX}/bin/llvm-config --has-rtti 2>&1)" = YES ] && ! [ "$(${MINGW_PREFIX}/bin/llvm-config --has-rtti 2>&1)" = NO ]; then
-    nollvmconfig=1 ${srcdir}/llvmwrapgen.sh
+    nollvmconfig=1 llvm_static=false ${srcdir}/llvmwrapgen.sh
   fi
 }
 

--- a/mingw-w64-mesa/llvmwrapgen.sh
+++ b/mingw-w64-mesa/llvmwrapgen.sh
@@ -1,9 +1,15 @@
 #!/bin/sh
 # Get LLVM libraries
-if [ ${nollvmconfig} = 1 ]; then
+if [ ${nollvmconfig} = 1 ] && [ ${llvm_static} = true ]; then
   llvmlibs='libLLVMCoroutines.a libLLVMipo.a libLLVMInstrumentation.a libLLVMVectorize.a libLLVMLinker.a libLLVMIRReader.a libLLVMAsmParser.a libLLVMFrontendOpenMP.a libLLVMX86Disassembler.a libLLVMX86AsmParser.a libLLVMX86CodeGen.a libLLVMCFGuard.a libLLVMGlobalISel.a libLLVMSelectionDAG.a libLLVMAsmPrinter.a libLLVMDebugInfoDWARF.a libLLVMCodeGen.a libLLVMScalarOpts.a libLLVMInstCombine.a libLLVMAggressiveInstCombine.a libLLVMTransformUtils.a libLLVMBitWriter.a libLLVMX86Desc.a libLLVMMCDisassembler.a libLLVMX86Info.a libLLVMMCJIT.a libLLVMExecutionEngine.a libLLVMTarget.a libLLVMAnalysis.a libLLVMProfileData.a libLLVMRuntimeDyld.a libLLVMObject.a libLLVMTextAPI.a libLLVMMCParser.a libLLVMBitReader.a libLLVMMC.a libLLVMDebugInfoCodeView.a libLLVMDebugInfoMSF.a libLLVMCore.a libLLVMRemarks.a libLLVMBitstreamReader.a libLLVMBinaryFormat.a libLLVMSupport.a libLLVMDemangle.a'
-else
+fi
+
+if ! [ ${nollvmconfig} = 1 ] && [ ${llvm_static} = true ]; then
   llvmlibs=$(${MINGW_PREFIX}/bin/llvm-config --link-static --libnames engine coroutines 2>&1)
+fi
+
+if [ ${llvm_static} = false ]; then
+  llvmlibs=libLLVM
 fi
 
 # Get LLVM RTTI status
@@ -16,6 +22,14 @@ fi
 llvmlibs="${llvmlibs//.a/}"
 llvmlibs=\'"${llvmlibs// /\', \'}"\'
 
+# Get libraries directory
+if [ ${llvm_static} = false ]; then
+  wraplibdir=bin
+fi
+if [ ${llvm_static} = true ]; then
+  wraplibdir=lib
+fi
+
 # Generate a Meson wrap file for LLVM
 mkdir -p ./subprojects/llvm
 FILE="./subprojects/llvm/meson.build"
@@ -25,9 +39,9 @@ project('llvm', ['cpp'])
 cpp = meson.get_compiler('cpp')
 
 _deps = []
-_search = '$(cygpath -m ${MINGW_PREFIX})/lib'
+_search = '$(cygpath -m ${MINGW_PREFIX})/${wraplibdir}'
 foreach d : [${llvmlibs}]
-  _deps += cpp.find_library(d, dirs : _search, static : true)
+  _deps += cpp.find_library(d, dirs : _search, static : ${llvm_static})
 endforeach
 
 dep_llvm = declare_dependency(


### PR DESCRIPTION
Improvements
- Correct deprecation warnings with llvm, shared-glapi, gles1 and gles2 build options during build configuration
- Link LLVM dynamically.

Build fails on CI for now, but it should work as soon as LLVM 11.0.0-4 appears on repo.