### PR TITLE
mingw63-xmlada: fix build of shared libraries

### DIFF
--- a/mingw-w64-xmlada/PKGBUILD
+++ b/mingw-w64-xmlada/PKGBUILD
@@ -10,7 +10,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 _gh_release=21.0.0
 pkgver=20${_gh_release}
-pkgrel=1
+pkgrel=2
 
 pkgdesc="A full XML suite for Ada (mingw-w64)"
 arch=('any')
@@ -25,12 +25,20 @@ sha256sums=('923024931f0c57451aa52cb9a3333874646102cb75957f27e3689670f90edc1e')
 options=('strip')
 
 build() {
+
+  if [ "${CARCH}" = "x86_64" ]; then
+    local _target='x86_64-windows'
+  else
+    local _target='x86-windows'
+  fi
+
   cd ${srcdir}/xmlada-${_gh_release}/
   ./configure \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
     --prefix=${MINGW_PREFIX} \
-    --enable-shared
+    --enable-shared \
+    --target=${_target}
 
   make
 }


### PR DESCRIPTION
Configure is not able to detect the ability to build shared libraries without the target set.