### PR TITLE
libhandy: enable glade support

### DIFF
--- a/mingw-w64-libhandy/PKGBUILD
+++ b/mingw-w64-libhandy/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libhandy
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.0.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A library full of GTK+ widgets for mobile phones (mingw-w64)"
 url="https://gitlab.gnome.org/GNOME/libhandy"
 license=("LGPL2.1+")
@@ -29,15 +29,13 @@ build() {
   [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
   mkdir "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
 
-  # glade support temporarily disabled becuase of
-  # https://gitlab.gnome.org/GNOME/libhandy/-/issues/335
   MSYS2_ARG_CONV_EXCL="--prefix=" \
   ${MINGW_PREFIX}/bin/meson \
     --prefix="${MINGW_PREFIX}" \
     --buildtype=plain \
     -Dexamples=false \
     -Dgtk_doc=false \
-    -Dglade_catalog=disabled \
+    -Dglade_catalog=enabled \
     ../"libhandy-${pkgver}"
 
   ${MINGW_PREFIX}/bin/ninja


### PR DESCRIPTION
build fixed in glade 3.38.1