### PR TITLE
gcc: Install libbacktrace

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -22,7 +22,7 @@ pkgver=10.2.0
 #_majorver=${pkgver:0:1}
 #_sourcedir=${_realname}-${_majorver}-${_snapshot}
 _sourcedir=${_realname}-${pkgver}
-pkgrel=5
+pkgrel=6
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 url="https://gcc.gnu.org"
@@ -255,6 +255,14 @@ build() {
   if [ "$_enable_ada" == "yes" ]; then
     mv ${srcdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/adalib/*.dll ${srcdir}${MINGW_PREFIX}/bin/
   fi
+
+  # libbacktrace is not installed by default
+  strip -d -o ${srcdir}${MINGW_PREFIX}/lib/libbacktrace.a libbacktrace/.libs/libbacktrace.a
+  mkdir -p ${srcdir}${MINGW_PREFIX}/include/backtrace
+  cp libbacktrace/backtrace-supported.h \
+    libbacktrace/gstdint.h \
+    ../${_sourcedir}/libbacktrace/backtrace.h \
+    ${srcdir}${MINGW_PREFIX}/include/backtrace/
 }
 
 package_mingw-w64-gcc-libs() {


### PR DESCRIPTION
Found several requests[1][2][3].

It is built anyway with gcc, but not installed.

[1] https://sourceforge.net/p/mingw-w64/mailman/mingw-w64-public/thread/oga0ug%24kno%241%40blaine.gmane.org/#msg35861445
[2] https://github.com/boostorg/stacktrace/issues/14
[3] https://sourceforge.net/p/mingw/bugs/2356/