### PR TITLE
solid3: Add package

### DIFF
--- a/mingw-w64-solid3/PKGBUILD
+++ b/mingw-w64-solid3/PKGBUILD
@@ -1,0 +1,66 @@
+# Maintainer: Markus Rickert <rickert@fortiss.org>
+
+_realname=solid3
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+_commit=c53f6bb1eaaafb1cfb305ef71b1c3a2edb4844e6
+pkgver=3.5.8
+pkgrel=1
+pkgdesc="A software library for performing intersection tests and proximity queries (mingw-w64)"
+arch=('any')
+url="https://github.com/dtecta/solid3"
+license=('GPL' 'QPL')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-qhull"
+             "patch")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+options=('strip' 'staticlibs')
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/dtecta/solid3/archive/${_commit}.tar.gz"
+        "disable-examples.patch"
+        "use-external-qhull.patch")
+sha256sums=('fccb1fb30d8836d1c9216d3b36042b0a9651697fd743a4c4e9251dfea59ac964'
+            '2c663db880d38c862c0b33eae9a44be3918547cff35196d0077365b5aa376a2b'
+            '6dce2fea19456640a81a935b0405ae9b2d5d1167816578b86dd8299abbb47241')
+
+prepare() {
+  cd "${srcdir}"/${_realname}-${_commit}
+
+  patch -Np1 -i "${srcdir}"/disable-examples.patch
+  patch -Np1 -i "${srcdir}"/use-external-qhull.patch
+}
+
+build() {
+  cd "${srcdir}"/${_realname}-${_commit}
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake \
+    -GNinja \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    "${extra_config[@]}" \
+    -DDYNAMIC_SOLID=ON \
+    -DUSE_DOUBLES=ON \
+    ../${_realname}-${_commit}
+
+  ${MINGW_PREFIX}/bin/cmake --build .
+}
+
+package() {
+  cd "${srcdir}"/build-${CARCH}
+
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --build . --target install
+
+  install -Dm644 "${srcdir}/${_realname}-${_commit}/LICENSE_GPL.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE_GPL.txt"
+  install -Dm644 "${srcdir}/${_realname}-${_commit}/LICENSE_QPL.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE_QPL.txt"
+  install -Dm644 "${srcdir}/${_realname}-${_commit}/README.md" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/README.md"
+}

--- a/mingw-w64-solid3/disable-examples.patch
+++ b/mingw-w64-solid3/disable-examples.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0303a8f..be43838 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -97,7 +97,7 @@ if(UNIX)
+ endif(UNIX)
+ 
+ add_subdirectory(src)
+-add_subdirectory(examples)
++#add_subdirectory(examples)
+ #add_subdirectory(doc)
+ 
+ include(CMakePackageConfigHelpers)

--- a/mingw-w64-solid3/use-external-qhull.patch
+++ b/mingw-w64-solid3/use-external-qhull.patch
@@ -1,0 +1,43 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index d1a0c1d..9cefff9 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-add_subdirectory(qhull)
++find_package(Qhull REQUIRED)
+ 
+ if(DYNAMIC_SOLID)
+   set(LIBRARY_TYPE "SHARED")
+@@ -80,10 +80,10 @@ add_library(solid3 ${LIBRARY_TYPE}
+   DT_RespTable.h
+   DT_Scene.cpp
+   DT_Scene.h
+-  $<TARGET_OBJECTS:qhull>
+ )
+ 
+ target_include_directories(solid3 INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>)
++target_link_libraries(solid3 Qhull::qhullstatic)
+ set_target_properties(solid3 PROPERTIES VERSION ${VERSION})
+ 
+ install(
+diff --git a/src/convex/DT_Polyhedron.cpp b/src/convex/DT_Polyhedron.cpp
+index 8bf8e8e..f1f9d6b 100644
+--- a/src/convex/DT_Polyhedron.cpp
++++ b/src/convex/DT_Polyhedron.cpp
+@@ -26,7 +26,7 @@
+ #ifdef QHULL
+ 
+ extern "C" {
+-#include <qhull/qhull_a.h>
++#include <libqhull/qhull_a.h>
+ }
+ 
+ #include <vector>
+@@ -65,6 +65,7 @@ T_IndexBuf *adjacency_graph(DT_Count count, const MT_Point3 *verts, const char *
+ 	{
+ 		exit(exitcode);
+ 	}
++    qh NOerrexit = False;
+     qh_initflags(options);
+     qh_init_B(array[0], array.size(), 3, False);
+     qh_qhull();


### PR DESCRIPTION
Adds a new package for SOLID, a library for collision detection and distance computation of 3D meshes.

The last release does not have a tag, so I used the corresponding commit ID.

One patch enables the use of the QHull package over the included copy of an older Qhull version. The other one disables the examples, as these show compiler errors when enabling double-precision floating-point format for better accuracy. Corresponding patches are already submitted upstream but not merged yet.