### PR TITLE
pqp: Add package

### DIFF
--- a/mingw-w64-pqp/PKGBUILD
+++ b/mingw-w64-pqp/PKGBUILD
@@ -1,0 +1,49 @@
+# Maintainer: Markus Rickert <rickert@fortiss.org>
+
+_realname=pqp
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+_commit=713de5b70dd1849b915f6412330078a9814e01ab
+pkgver=1.3
+pkgrel=1
+pkgdesc="A library for performing proximity queries on a pair of geometric models composed of triangles (mingw-w64)"
+arch=('any')
+url="https://github.com/GammaUNC/PQP"
+license=('custom')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+options=('strip' 'staticlibs')
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/GammaUNC/PQP/archive/${_commit}.tar.gz")
+sha256sums=('ae33a4506d70b68176d4e56d60bcc5760f46cc4e71d5856c02fd82db5026457f')
+
+build() {
+  cd "${srcdir}"/PQP-${_commit}
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake \
+    -GNinja \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    "${extra_config[@]}" \
+    ../PQP-${_commit}
+
+  ${MINGW_PREFIX}/bin/cmake --build .
+}
+
+package() {
+  cd "${srcdir}"/build-${CARCH}
+
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --build . --target install
+
+  install -Dm644 "${srcdir}/PQP-${_commit}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
Adds a new package for PQP, a library for performing proximity queries on 3D meshes.

The last release does not have a tag, so I used the corresponding commit ID.