### PR TITLE
emacs: use jansson (native JSON support)

### DIFF
--- a/mingw-w64-emacs/PKGBUILD
+++ b/mingw-w64-emacs/PKGBUILD
@@ -5,7 +5,7 @@ _realname=emacs
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=27.1
-pkgrel=1
+pkgrel=2
 pkgdesc="The extensible, customizable, self-documenting, real-time display editor (mingw-w64)"
 url="https://www.gnu.org/software/${_realname}/"
 license=('GPL3')
@@ -14,6 +14,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-universal-ctags-git"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-xpm-nox"
          "${MINGW_PACKAGE_PREFIX}-harfbuzz"
+         "${MINGW_PACKAGE_PREFIX}-jansson"
          "${MINGW_PACKAGE_PREFIX}-gnutls"
          "${MINGW_PACKAGE_PREFIX}-libwinpthread")
 optdepends=("${MINGW_PACKAGE_PREFIX}-giflib"


### PR DESCRIPTION
Improves JSON parsing speed, noticeable with some packages such as LSP.