### PR TITLE
icesprog: add 1.0

### DIFF
--- a/mingw-w64-icesprog/PKGBUILD
+++ b/mingw-w64-icesprog/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=icesprog
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=8e33c6a
+pkgver=1.0
 pkgrel=1
 pkgdesc="iCESugar FPGA Board programming tool (mingw-w64)"
 arch=('any')
@@ -14,7 +14,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-hidapi"
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
 
-source=("icesugar::git://github.com/wuxx/icesugar.git#commit=${pkgver}")
+source=("icesugar::git://github.com/wuxx/icesugar.git#commit=8e33c6a")
 sha256sums=('SKIP')
 
 build() {

--- a/mingw-w64-icesprog/PKGBUILD
+++ b/mingw-w64-icesprog/PKGBUILD
@@ -1,0 +1,31 @@
+# Maintainer: umarcor <unai.martinezcorral@ehu.eus>
+
+_realname=icesprog
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=9a28317
+pkgrel=1
+pkgdesc="iCESugar FPGA Board programming tool (mingw-w64)"
+arch=('any')
+url="https://github.com/wuxx/icesugar/tree/master/tools/"
+license=('GPLv2+')
+depends=("${MINGW_PACKAGE_PREFIX}-hidapi"
+         "${MINGW_PACKAGE_PREFIX}-libusb")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+
+source=("icesugar::git://github.com/wuxx/icesugar.git#commit=${pkgver}")
+sha256sums=('SKIP')
+
+build() {
+  cd "${srcdir}/icesugar/tools/src"
+  make HIDAPI=hidapi
+}
+
+check() {
+  "${srcdir}"/icesugar/tools/src/icesprog.exe -h
+}
+
+package() {
+  mkdir "${pkgdir}"/bin/
+  cp "${srcdir}"/icesugar/tools/src/icesprog.exe "${pkgdir}"/bin/
+}

--- a/mingw-w64-icesprog/PKGBUILD
+++ b/mingw-w64-icesprog/PKGBUILD
@@ -11,7 +11,8 @@ url="https://github.com/wuxx/icesugar/tree/master/tools/"
 license=('GPLv2+')
 depends=("${MINGW_PACKAGE_PREFIX}-hidapi"
          "${MINGW_PACKAGE_PREFIX}-libusb")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config")
 
 source=("icesugar::git://github.com/wuxx/icesugar.git#commit=${pkgver}")
 sha256sums=('SKIP')

--- a/mingw-w64-icesprog/PKGBUILD
+++ b/mingw-w64-icesprog/PKGBUILD
@@ -27,6 +27,6 @@ check() {
 }
 
 package() {
-  mkdir "${pkgdir}"/bin/
-  cp "${srcdir}"/icesugar/tools/src/icesprog.exe "${pkgdir}"/bin/
+  mkdir -p "${pkgdir}${MINGW_PREFIX}"/bin/
+  cp "${srcdir}"/icesugar/tools/src/icesprog.exe "${pkgdir}${MINGW_PREFIX}"/bin/
 }

--- a/mingw-w64-icesprog/PKGBUILD
+++ b/mingw-w64-icesprog/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=icesprog
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=9a28317
+pkgver=8e33c6a
 pkgrel=1
 pkgdesc="iCESugar FPGA Board programming tool (mingw-w64)"
 arch=('any')
@@ -19,7 +19,7 @@ sha256sums=('SKIP')
 
 build() {
   cd "${srcdir}/icesugar/tools/src"
-  make HIDAPI=hidapi
+  make
 }
 
 check() {


### PR DESCRIPTION
This PR adds package `icesprog`, a bitstream programmer for the [iCESugar FPGA Board](https://github.com/wuxx/icesugar/blob/master/README_en.md#icesugar-1).