### PR TITLE
glib: Update to 2.66.3

### DIFF
--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -6,8 +6,8 @@
 _realname=glib2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.66.2
-pkgrel=2
+pkgver=2.66.3
+pkgrel=1
 url="https://www.gtk.org/"
 arch=('any')
 pkgdesc="Common C routines used by GTK+ 3 and other libs (mingw-w64)"
@@ -31,7 +31,7 @@ source=("https://download.gnome.org/sources/glib/${pkgver%.*}/glib-${pkgver}.tar
         gio-querymodules.hook.in
         0002-disable_glib_compile_schemas_warning.patch
         pyscript2exe.py)
-sha256sums=('ec390bed4e8dd0f89e918f385e8d4cfd7470b1ef7c1ce93ec5c4fc6e3c6a17c4'
+sha256sums=('79f31365a99cb1cc9db028625635d1438890702acde9e2802eae0acebcf7b5b1'
             '51d02360a1ee978fd45e77b84bca9cfbcf080d91986b5c0efe0732779c6a54ec'
             '1e3ac7cfd4644f3849704e54fcfbb12d15440a33cd5c2d014d4a479c6aaab185'
             '0f44135a139e3951c4b5fa7d4628d75226e0666d891faf524777e1d1ec3b440b'
@@ -54,10 +54,17 @@ build() {
   [[ -d "${srcdir}"/build-${CARCH}-static ]] && rm -rf "${srcdir}"/build-${CARCH}-static
   mkdir "${srcdir}"/build-${CARCH}-static && cd "${srcdir}"/build-${CARCH}-static
 
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("--buildtype=release")
+  else
+    extra_config+=("--buildtype=debug")
+  fi
+
   MSYS2_ARG_CONV_EXCL="--prefix=" \
   meson \
     --prefix="${MINGW_PREFIX}" \
-    --buildtype=plain \
+    "${extra_config[@]}" \
     --default-library=static \
     -Dforce_posix_threads=true \
     "../glib-${pkgver}"
@@ -70,7 +77,7 @@ build() {
   MSYS2_ARG_CONV_EXCL="--prefix=" \
   meson \
     --prefix="${MINGW_PREFIX}" \
-    --buildtype=plain \
+    "${extra_config[@]}" \
     -Ddefault_library=shared \
     -Dman=true \
     -Dforce_posix_threads=true \


### PR DESCRIPTION
Also stop using buildtype=plain, as upstream sets various things based
on buildtype and we want to leave that up to upstream.