### PR TITLE
gr: use qhull

### DIFF
--- a/mingw-w64-gr/PKGBUILD
+++ b/mingw-w64-gr/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gr
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.53.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A graphics library for visualisation applications (mingw-w64)"
 arch=("any")
 url="https://gr-framework.org/"
@@ -17,16 +17,19 @@ depends=("${MINGW_PACKAGE_PREFIX}-bzip2"
          "${MINGW_PACKAGE_PREFIX}-libjpeg"
          "${MINGW_PACKAGE_PREFIX}-libpng"
          "${MINGW_PACKAGE_PREFIX}-libtiff"
-         "${MINGW_PACKAGE_PREFIX}-qhull-git"
+         "${MINGW_PACKAGE_PREFIX}-qhull"
          "${MINGW_PACKAGE_PREFIX}-qt5"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 makedepends=("git"
+             "tar"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-gcc")
 options=("staticlibs" "strip" "!buildflags")
-source=("${_realname}-${pkgver}.tar.gz::https://github.com/sciapp/gr/archive/v${pkgver}.tar.gz")
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/sciapp/gr/archive/v${pkgver}.tar.gz"
+        "https://github.com/sciapp/gr/pull/129.patch")
 noextract=("${_realname}-${pkgver}.tar.gz")
-sha256sums=("A348602C3E2D928B5C293A19ED91E126BF56E23720D4F0E12AA92767DA767276")
+sha256sums=("A348602C3E2D928B5C293A19ED91E126BF56E23720D4F0E12AA92767DA767276"
+            "115ea2beeec6f689b21219e9f2f8824e608506a16567eda7e78f1f1bf4095e81")
 
 prepare() {
   # We can't use bsdtar to extract the archive because the archive includes
@@ -34,6 +37,8 @@ prepare() {
   cd "${srcdir}/"
   rm -rf "${_realname}-${pkgver}"
   tar -xf "${_realname}-${pkgver}.tar.gz"
+  cd "${_realname}-${pkgver}"
+  patch -p1 -i "${srcdir}/129.patch"
 }
 
 build() {


### PR DESCRIPTION
We removed -git suffix from qhull-git by fd033db7ff110e747138223a65cc483f571445e8.