### PR TITLE
Ffmpeg: build both shared and static libs

### DIFF
--- a/mingw-w64-ffmpeg/PKGBUILD
+++ b/mingw-w64-ffmpeg/PKGBUILD
@@ -198,6 +198,9 @@ package() {
   
   cd "${srcdir}/build-${MINGW_CHOST}-shared"
   make DESTDIR="${pkgdir}" install
+  
+  rm -f ${pkgdir}/${MINGW_PREFIX}/lib/*.def
+  rm -f ${pkgdir}/${MINGW_PREFIX}/bin/*.lib
 
   #find ${pkgdir}${MINGW_PREFIX}/bin -type f -name "*.exe" -exec objcopy --subsystem console {} \;
 

--- a/mingw-w64-ffmpeg/PKGBUILD
+++ b/mingw-w64-ffmpeg/PKGBUILD
@@ -60,12 +60,12 @@ prepare() {
 }
 
 build() {
-  [[ -d "${srcdir}/build-${MINGW_CHOST}-static" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}-static"
-  mkdir -p "${srcdir}/build-${MINGW_CHOST}-static" && cd "${srcdir}/build-${MINGW_CHOST}-static"
-
   # Fix using SRT headers
   CFLAGS+=" -DWIN32"
   CXXFLAGS+=" -DWIN32"
+  
+  [[ -d "${srcdir}/build-${MINGW_CHOST}-static" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}-static"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}-static" && cd "${srcdir}/build-${MINGW_CHOST}-static"
 
   CC=${MINGW_PREFIX}/bin/gcc \
   CXX=${MINGW_PREFIX}/bin/g++ \
@@ -125,10 +125,6 @@ build() {
   
   [[ -d "${srcdir}/build-${MINGW_CHOST}-shared" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}-shared"
   mkdir -p "${srcdir}/build-${MINGW_CHOST}-shared" && cd "${srcdir}/build-${MINGW_CHOST}-shared"
-
-  # Fix using SRT headers
-  CFLAGS+=" -DWIN32"
-  CXXFLAGS+=" -DWIN32"
 
   CC=${MINGW_PREFIX}/bin/gcc \
   CXX=${MINGW_PREFIX}/bin/g++ \

--- a/mingw-w64-ffmpeg/PKGBUILD
+++ b/mingw-w64-ffmpeg/PKGBUILD
@@ -6,7 +6,7 @@ _realname=ffmpeg
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.3.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Complete and free Internet live audio and video broadcasting solution (mingw-w64)"
 arch=('any')
 url="https://ffmpeg.org/"
@@ -47,18 +47,19 @@ depends=("${MINGW_PACKAGE_PREFIX}-aom"
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-nasm")
-source=(https://ffmpeg.org/releases/${_realname}-${pkgver}.tar.xz{,.asc})
-validpgpkeys=('FCF986EA15E6E293A5644F10B4322F04D67658D8')
+source=(https://ffmpeg.org/releases/${_realname}-${pkgver}.tar.xz
+        srt.patch)
 sha256sums=('ad009240d46e307b4e03a213a0f49c11b650e445b1f8be0dda2a9212b34d2ffb'
             'SKIP')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
+  patch -p1 -i "${srcdir}"/srt.patch
 }
 
 build() {
-  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
-  mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
+  [[ -d "${srcdir}/build-${MINGW_CHOST}-static" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}-static"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}-static" && cd "${srcdir}/build-${MINGW_CHOST}-static"
 
   # Fix using SRT headers
   CFLAGS+=" -DWIN32"
@@ -71,7 +72,6 @@ build() {
     --target-os=mingw32 \
     --arch=${CARCH%%-*} \
     --disable-debug \
-    --disable-static \
     --enable-dxva2 \
     --enable-d3d11va \
     --enable-fontconfig \
@@ -108,8 +108,70 @@ build() {
     --enable-pic \
     --enable-postproc \
     --enable-runtime-cpudetect \
-    --enable-shared \
     --enable-static \
+    --enable-swresample \
+    --enable-version3 \
+    --enable-vulkan \
+    --enable-zlib \
+    --disable-doc ||
+    #--enable-pthreads
+    {
+      find . -name "config.log" -exec cat {} +
+      exit 1
+    }
+  make
+  
+  [[ -d "${srcdir}/build-${MINGW_CHOST}-shared" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}-shared"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}-shared" && cd "${srcdir}/build-${MINGW_CHOST}-shared"
+
+  # Fix using SRT headers
+  CFLAGS+=" -DWIN32"
+  CXXFLAGS+=" -DWIN32"
+
+  CC=${MINGW_PREFIX}/bin/gcc \
+  CXX=${MINGW_PREFIX}/bin/g++ \
+  ../${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --target-os=mingw32 \
+    --arch=${CARCH%%-*} \
+    --disable-debug \
+    --enable-dxva2 \
+    --enable-d3d11va \
+    --enable-fontconfig \
+    --enable-gnutls \
+    --enable-gpl \
+    --enable-libaom \
+    --enable-libass \
+    --enable-libbluray \
+    --enable-libcaca \
+    --enable-libcelt \
+    --enable-libdav1d \
+    --enable-libfreetype \
+    --enable-libgsm \
+    --enable-libmfx \
+    --enable-libmodplug \
+    --enable-libmp3lame \
+    --enable-libopencore_amrnb \
+    --enable-libopencore_amrwb \
+    --enable-libopenjpeg \
+    --enable-libopus \
+    --enable-librtmp \
+    --enable-libspeex \
+    --enable-libsrt \
+    --enable-libtheora \
+    --enable-libvorbis \
+    --enable-libx264 \
+    --enable-libx265 \
+    --enable-libxvid \
+    --enable-libvpx \
+    --enable-libwebp \
+    --enable-libxml2 \
+    --enable-openal \
+    --enable-libwavpack \
+    --enable-pic \
+    --enable-postproc \
+    --enable-runtime-cpudetect \
+    --enable-shared\
     --enable-swresample \
     --enable-version3 \
     --enable-vulkan \
@@ -131,13 +193,13 @@ check() {
 }
 
 package() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}-static"
   make DESTDIR="${pkgdir}" install
-  mv "${pkgdir}${MINGW_PREFIX}"/bin/*.lib "${pkgdir}${MINGW_PREFIX}"/lib/
+  
+  cd "${srcdir}/build-${MINGW_CHOST}-shared"
+  make DESTDIR="${pkgdir}" install
 
   #find ${pkgdir}${MINGW_PREFIX}/bin -type f -name "*.exe" -exec objcopy --subsystem console {} \;
-  rm -f ${pkgdir}${MINGW_PREFIX}/lib/*.def
-  rm -f ${pkgdir}${MINGW_PREFIX}/lib/*.lib
 
   local PREFIX_DEPS=$(cygpath -am ${MINGW_PREFIX})
   find ${pkgdir}${MINGW_PREFIX}/lib/pkgconfig -name *.pc -exec sed -i -e"s|${PREFIX_DEPS}|${MINGW_PREFIX}|g" {} \;

--- a/mingw-w64-ffmpeg/PKGBUILD
+++ b/mingw-w64-ffmpeg/PKGBUILD
@@ -6,7 +6,7 @@ _realname=ffmpeg
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.3.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Complete and free Internet live audio and video broadcasting solution (mingw-w64)"
 arch=('any')
 url="https://ffmpeg.org/"
@@ -63,7 +63,53 @@ build() {
   # Fix using SRT headers
   CFLAGS+=" -DWIN32"
   CXXFLAGS+=" -DWIN32"
-  
+
+  local common_config
+  common_config=(
+    --disable-debug
+    --enable-dxva2
+    --enable-d3d11va
+    --enable-fontconfig
+    --enable-gnutls
+    --enable-gpl
+    --enable-libaom
+    --enable-libass
+    --enable-libbluray
+    --enable-libcaca
+    --enable-libcelt
+    --enable-libdav1d
+    --enable-libfreetype
+    --enable-libgsm
+    --enable-libmfx
+    --enable-libmodplug
+    --enable-libmp3lame
+    --enable-libopencore_amrnb
+    --enable-libopencore_amrwb
+    --enable-libopenjpeg
+    --enable-libopus
+    --enable-librtmp
+    --enable-libspeex
+    --enable-libsrt
+    --enable-libtheora
+    --enable-libvorbis
+    --enable-libx264
+    --enable-libx265
+    --enable-libxvid
+    --enable-libvpx
+    --enable-libwebp
+    --enable-libxml2
+    --enable-openal
+    --enable-libwavpack
+    --enable-pic
+    --enable-postproc
+    --enable-runtime-cpudetect
+    --enable-swresample
+    --enable-version3
+    --enable-vulkan
+    --enable-zlib
+    --disable-doc
+  )
+
   [[ -d "${srcdir}/build-${MINGW_CHOST}-static" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}-static"
   mkdir -p "${srcdir}/build-${MINGW_CHOST}-static" && cd "${srcdir}/build-${MINGW_CHOST}-static"
 
@@ -73,50 +119,8 @@ build() {
     --prefix=${MINGW_PREFIX} \
     --target-os=mingw32 \
     --arch=${CARCH%%-*} \
-    --disable-debug \
-    --enable-dxva2 \
-    --enable-d3d11va \
-    --enable-fontconfig \
-    --enable-gnutls \
-    --enable-gpl \
-    --enable-libaom \
-    --enable-libass \
-    --enable-libbluray \
-    --enable-libcaca \
-    --enable-libcelt \
-    --enable-libdav1d \
-    --enable-libfreetype \
-    --enable-libgsm \
-    --enable-libmfx \
-    --enable-libmodplug \
-    --enable-libmp3lame \
-    --enable-libopencore_amrnb \
-    --enable-libopencore_amrwb \
-    --enable-libopenjpeg \
-    --enable-libopus \
-    --enable-librtmp \
-    --enable-libspeex \
-    --enable-libsrt \
-    --enable-libtheora \
-    --enable-libvorbis \
-    --enable-libx264 \
-    --enable-libx265 \
-    --enable-libxvid \
-    --enable-libvpx \
-    --enable-libwebp \
-    --enable-libxml2 \
-    --enable-openal \
-    --enable-libwavpack \
-    --enable-pic \
-    --enable-postproc \
-    --enable-runtime-cpudetect \
-    --enable-static \
-    --enable-swresample \
-    --enable-version3 \
-    --enable-vulkan \
-    --enable-zlib \
-    --disable-doc ||
-    #--enable-pthreads
+    "${common_config[@]}" \
+    --enable-static ||
     {
       find . -name "config.log" -exec cat {} +
       exit 1
@@ -132,50 +136,8 @@ build() {
     --prefix=${MINGW_PREFIX} \
     --target-os=mingw32 \
     --arch=${CARCH%%-*} \
-    --disable-debug \
-    --enable-dxva2 \
-    --enable-d3d11va \
-    --enable-fontconfig \
-    --enable-gnutls \
-    --enable-gpl \
-    --enable-libaom \
-    --enable-libass \
-    --enable-libbluray \
-    --enable-libcaca \
-    --enable-libcelt \
-    --enable-libdav1d \
-    --enable-libfreetype \
-    --enable-libgsm \
-    --enable-libmfx \
-    --enable-libmodplug \
-    --enable-libmp3lame \
-    --enable-libopencore_amrnb \
-    --enable-libopencore_amrwb \
-    --enable-libopenjpeg \
-    --enable-libopus \
-    --enable-librtmp \
-    --enable-libspeex \
-    --enable-libsrt \
-    --enable-libtheora \
-    --enable-libvorbis \
-    --enable-libx264 \
-    --enable-libx265 \
-    --enable-libxvid \
-    --enable-libvpx \
-    --enable-libwebp \
-    --enable-libxml2 \
-    --enable-openal \
-    --enable-libwavpack \
-    --enable-pic \
-    --enable-postproc \
-    --enable-runtime-cpudetect \
-    --enable-shared\
-    --enable-swresample \
-    --enable-version3 \
-    --enable-vulkan \
-    --enable-zlib \
-    --disable-doc ||
-    #--enable-pthreads
+    "${common_config[@]}" \
+    --enable-shared ||
     {
       find . -name "config.log" -exec cat {} +
       exit 1

--- a/mingw-w64-ffmpeg/srt.patch
+++ b/mingw-w64-ffmpeg/srt.patch
@@ -1,0 +1,27 @@
+--- a/libavformat/libsrt.c
++++ b/libavformat/libsrt.c
+@@ -313,8 +313,12 @@ static int libsrt_set_options_pre(URLContext *h, int fd)
+         (s->pbkeylen >= 0 && libsrt_setsockopt(h, fd, SRTO_PBKEYLEN, "SRTO_PBKEYLEN", &s->pbkeylen, sizeof(s->pbkeylen)) < 0) ||
+         (s->passphrase && libsrt_setsockopt(h, fd, SRTO_PASSPHRASE, "SRTO_PASSPHRASE", s->passphrase, strlen(s->passphrase)) < 0) ||
+ #if SRT_VERSION_VALUE >= 0x010302
++#if SRT_VERSION_VALUE >= 0x010401
++        (s->enforced_encryption >= 0 && libsrt_setsockopt(h, fd, SRTO_ENFORCEDENCRYPTION, "SRTO_ENFORCEDENCRYPTION", &s->enforced_encryption, sizeof(s->enforced_encryption)) < 0) ||
++#else
+         /* SRTO_STRICTENC == SRTO_ENFORCEDENCRYPTION (53), but for compatibility, we used SRTO_STRICTENC */
+         (s->enforced_encryption >= 0 && libsrt_setsockopt(h, fd, SRTO_STRICTENC, "SRTO_STRICTENC", &s->enforced_encryption, sizeof(s->enforced_encryption)) < 0) ||
++#endif
+         (s->kmrefreshrate >= 0 && libsrt_setsockopt(h, fd, SRTO_KMREFRESHRATE, "SRTO_KMREFRESHRATE", &s->kmrefreshrate, sizeof(s->kmrefreshrate)) < 0) ||
+         (s->kmpreannounce >= 0 && libsrt_setsockopt(h, fd, SRTO_KMPREANNOUNCE, "SRTO_KMPREANNOUNCE", &s->kmpreannounce, sizeof(s->kmpreannounce)) < 0) ||
+ #endif
+@@ -333,7 +337,11 @@ static int libsrt_set_options_pre(URLContext *h, int fd)
+         (s->lossmaxttl >= 0 && libsrt_setsockopt(h, fd, SRTO_LOSSMAXTTL, "SRTO_LOSSMAXTTL", &s->lossmaxttl, sizeof(s->lossmaxttl)) < 0) ||
+         (s->minversion >= 0 && libsrt_setsockopt(h, fd, SRTO_MINVERSION, "SRTO_MINVERSION", &s->minversion, sizeof(s->minversion)) < 0) ||
+         (s->streamid && libsrt_setsockopt(h, fd, SRTO_STREAMID, "SRTO_STREAMID", s->streamid, strlen(s->streamid)) < 0) ||
++#if SRT_VERSION_VALUE >= 0x010401
++        (s->smoother && libsrt_setsockopt(h, fd, SRTO_CONGESTION, "SRTO_CONGESTION", s->smoother, strlen(s->smoother)) < 0) ||
++#else
+         (s->smoother && libsrt_setsockopt(h, fd, SRTO_SMOOTHER, "SRTO_SMOOTHER", s->smoother, strlen(s->smoother)) < 0) ||
++#endif
+         (s->messageapi >= 0 && libsrt_setsockopt(h, fd, SRTO_MESSAGEAPI, "SRTO_MESSAGEAPI", &s->messageapi, sizeof(s->messageapi)) < 0) ||
+         (s->payload_size >= 0 && libsrt_setsockopt(h, fd, SRTO_PAYLOADSIZE, "SRTO_PAYLOADSIZE", &s->payload_size, sizeof(s->payload_size)) < 0) ||
+         ((h->flags & AVIO_FLAG_WRITE) && libsrt_setsockopt(h, fd, SRTO_SENDER, "SRTO_SENDER", &yes, sizeof(yes)) < 0)) {


### PR DESCRIPTION
The patch directly comes from here: http://git.videolan.org/?p=ffmpeg.git;a=commitdiff;h=7c59e1b0f285cd7c7b35fcd71f49c5fd52cf9315. It seems srt was updated and removed some deprecated constant.

I removed the pgp key check because it did not work on my end but I can add it again if someone explains me how it works ^^.

EDIT: without the patch it did not compile locally