### PR TITLE
cmake: update to 3.19.1, depends on pkgconf

### DIFF
--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=cmake
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.19.0
+pkgver=3.19.1
 pkgrel=1
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
@@ -14,12 +14,12 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-bzip2"
              "${MINGW_PACKAGE_PREFIX}-emacs"
              "${MINGW_PACKAGE_PREFIX}-ncurses"
-             "${MINGW_PACKAGE_PREFIX}-python3-sphinx"
+             "${MINGW_PACKAGE_PREFIX}-python-sphinx"
              "${MINGW_PACKAGE_PREFIX}-qt5"
              "${MINGW_PACKAGE_PREFIX}-xz"
              "${MINGW_PACKAGE_PREFIX}-zstd")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
-         "${MINGW_PACKAGE_PREFIX}-pkg-config"
+         "${MINGW_PACKAGE_PREFIX}-pkgconf"
          "${MINGW_PACKAGE_PREFIX}-curl"
          "${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-jsoncpp"
@@ -37,7 +37,7 @@ source=("https://github.com/Kitware/CMake/releases/download/v${pkgver}/${_realna
         "0006-pkg-config-Add-dont-define-prefix-when-PKG_CONFIG_WI.patch"
         "0007-Do-not-generate-import-libs-for-exes.patch"
         "0008-Output-line-numbers-in-callstacks.patch")
-sha256sums=('fdda688155aa7e72b7c63ef6f559fca4b6c07382ea6dca0beb5f45aececaf493'
+sha256sums=('1d266ea3a76ef650cdcf16c782a317cb4a7aa461617ee941e389cb48738a3aba'
             '1b68fe64e1b389134db44dc34368713f6e28d3463ab1e7fc3d93857c0459beb7'
             '77763df03e8a9ca66c3f9368fe7e1fc36bb041455733258d73aeb40246a61354'
             '7eb60d12b610c70413412521dcc860d1948c169e721f3525d9be99b3913dc37e'
@@ -85,7 +85,6 @@ build() {
     "${srcdir}"/${_realname}-${pkgver}/configure  \
     --prefix=${MINGW_PREFIX}                      \
     --system-libs                                 \
-    --no-system-expat                             \
     --qt-gui                                      \
     --qt-qmake=${MINGW_PREFIX}/bin/qmake.exe      \
     --parallel=${NUMBER_OF_PROCESSORS}            \


### PR DESCRIPTION
Since pkgconf replaces pkg-config, let cmake depends on pkgconf

bzip2, xz, zlib, zstd are pulled in by libarchive, so I think it is not necessary to list them in dependencies