### PR TITLE
iverilog: add v12.0.rc

### DIFF
--- a/mingw-w64-iverilog/PKGBUILD
+++ b/mingw-w64-iverilog/PKGBUILD
@@ -27,13 +27,13 @@ build() {
   make
 }
 
-#check() {
-#  cd "${srcdir}/${_realname}-${_ver}/"
-#  make check
+check() {
+  cd "${srcdir}/${_realname}-${_ver}/"
+  make check
 #  git clone git://github.com/steveicarus/ivtest.git
 #  cd ivtest
 #  ./regress
-#}
+}
 
 package() {
   cd "${srcdir}/${_realname}-${_ver}/"

--- a/mingw-w64-iverilog/PKGBUILD
+++ b/mingw-w64-iverilog/PKGBUILD
@@ -20,16 +20,16 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 # NOTE: MSYS2 support was improved/fixed in 'master' (2020/12/04).
 # When 12.0 is tagged/released, this should be changed to use a tarball instead.
 _commit="96df23c"
-source=("iverilog::git://github.com/steveicarus/iverilog.git#commit=${_commit}")
+source=("${_realname}::git://github.com/steveicarus/iverilog.git#commit=${_commit}")
 sha256sums=('SKIP')
 
 pkgver() {
-  cd "${srcdir}"/iverilog
+  cd "${srcdir}/${_realname}"
   printf "12.0.r%s.%s" "$(git rev-list --count "${_commit}")" "$(git rev-parse --short "${_commit}")"
 }
 
 build() {
-  cd "${srcdir}"/iverilog
+  cd "${srcdir}/${_realname}"
   sh autoconf.sh
   ./configure \
     --prefix="${MINGW_PREFIX}" \
@@ -38,7 +38,7 @@ build() {
 }
 
 check() {
-  cd "${srcdir}"/iverilog
+  cd "${srcdir}/${_realname}"
   mingw32-make check
 #  git clone git://github.com/steveicarus/ivtest.git
 #  cd ivtest
@@ -46,7 +46,7 @@ check() {
 }
 
 package() {
-  cd "${srcdir}"/iverilog
+  cd "${srcdir}/${_realname}"
   mingw32-make DESTDIR="${pkgdir}" install
   mkdir -p "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"
   mv "${pkgdir}${MINGW_PREFIX}"/*.pdf "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"

--- a/mingw-w64-iverilog/PKGBUILD
+++ b/mingw-w64-iverilog/PKGBUILD
@@ -1,0 +1,41 @@
+# Maintainer: umarcor <unai.martinezcorral@ehu.eus>
+
+_realname=iverilog
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=11.0
+pkgrel=1
+pkgdesc="Icarus Verilog, is a Verilog simulation and synthesis tool (mingw-w64)"
+arch=('any')
+url="http://iverilog.icarus.com/"
+license=('LGPLv2.1')
+depends=()
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-ghostscript"
+             "git")
+
+_ver="11_0"
+source=("iverilog::https://codeload.github.com/steveicarus/iverilog/tar.gz/v${_ver}")
+sha256sums=('6327fb900e66b46803d928b7ca439409a0dc32731d82143b20387be0833f1c95')
+
+build() {
+  cd "${srcdir}/${_realname}-${_ver}/"
+  sh autoconf.sh
+  ./configure \
+    --prefix="${MINGW_PREFIX}" \
+    --host="$CARCH"-w64-mingw32
+  make
+}
+
+#check() {
+#  cd "${srcdir}/${_realname}-${_ver}/"
+#  make check
+#  git clone git://github.com/steveicarus/ivtest.git
+#  cd ivtest
+#  ./regress
+#}
+
+package() {
+  cd "${srcdir}/${_realname}-${_ver}/"
+  make DESTDIR="${pkgdir}" install
+}

--- a/mingw-w64-iverilog/PKGBUILD
+++ b/mingw-w64-iverilog/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=iverilog
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=11.0
+pkgver=12.0
 pkgrel=1
 pkgdesc="Icarus Verilog, is a Verilog simulation and synthesis tool (mingw-w64)"
 arch=('any')
@@ -13,14 +13,22 @@ depends=("${MINGW_PACKAGE_PREFIX}-readline"
          "${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-ghostscript"
-             "${MINGW_PACKAGE_PREFIX}-make")
+             "${MINGW_PACKAGE_PREFIX}-make"
+             'git')
 
-_ver="11_0"
-source=("iverilog::https://codeload.github.com/steveicarus/iverilog/tar.gz/v${_ver}")
-sha256sums=('6327fb900e66b46803d928b7ca439409a0dc32731d82143b20387be0833f1c95')
+# NOTE: MSYS2 support was improved/fixed in 'master' (2020/12/04).
+# When 12.0 is tagged/released, this should be changed to use a tarball instead.
+_commit="96df23c"
+source=("iverilog::git://github.com/steveicarus/iverilog.git#commit=${_commit}")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "${srcdir}"/iverilog
+  printf "12.0.r%s.%s" "$(git rev-list --count "${_commit}")" "$(git rev-parse --short "${_commit}")"
+}
 
 build() {
-  cd "${srcdir}/${_realname}-${_ver}/"
+  cd "${srcdir}"/iverilog
   sh autoconf.sh
   ./configure \
     --prefix="${MINGW_PREFIX}" \
@@ -29,7 +37,7 @@ build() {
 }
 
 check() {
-  cd "${srcdir}/${_realname}-${_ver}/"
+  cd "${srcdir}"/iverilog
   mingw32-make check
 #  git clone git://github.com/steveicarus/ivtest.git
 #  cd ivtest
@@ -37,7 +45,7 @@ check() {
 }
 
 package() {
-  cd "${srcdir}/${_realname}-${_ver}/"
+  cd "${srcdir}"/iverilog
   mingw32-make DESTDIR="${pkgdir}" install
   mkdir -p "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"
   mv "${pkgdir}${MINGW_PREFIX}"/*.pdf "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"

--- a/mingw-w64-iverilog/PKGBUILD
+++ b/mingw-w64-iverilog/PKGBUILD
@@ -38,4 +38,6 @@ build() {
 package() {
   cd "${srcdir}/${_realname}-${_ver}/"
   make DESTDIR="${pkgdir}" install
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"
+  mv "${pkgdir}${MINGW_PREFIX}"/*.pdf "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"
 }

--- a/mingw-w64-iverilog/PKGBUILD
+++ b/mingw-w64-iverilog/PKGBUILD
@@ -9,7 +9,8 @@ pkgdesc="Icarus Verilog, is a Verilog simulation and synthesis tool (mingw-w64)"
 arch=('any')
 url="http://iverilog.icarus.com/"
 license=('LGPLv2.1')
-depends=()
+depends=("${MINGW_PACKAGE_PREFIX}-readline"
+         "${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-ghostscript")
 

--- a/mingw-w64-iverilog/PKGBUILD
+++ b/mingw-w64-iverilog/PKGBUILD
@@ -8,7 +8,7 @@ pkgrel=1
 pkgdesc="Icarus Verilog, is a Verilog simulation and synthesis tool (mingw-w64)"
 arch=('any')
 url="http://iverilog.icarus.com/"
-license=('LGPLv2.1')
+license=('GPLv2+')
 depends=("${MINGW_PACKAGE_PREFIX}-readline"
          "${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"

--- a/mingw-w64-iverilog/PKGBUILD
+++ b/mingw-w64-iverilog/PKGBUILD
@@ -40,4 +40,8 @@ package() {
   make DESTDIR="${pkgdir}" install
   mkdir -p "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"
   mv "${pkgdir}${MINGW_PREFIX}"/*.pdf "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"
+
+  _licenses="${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
+  mkdir -p "${_licenses}"
+  install -m 644 COPYING "${_licenses}"
 }

--- a/mingw-w64-iverilog/PKGBUILD
+++ b/mingw-w64-iverilog/PKGBUILD
@@ -10,6 +10,7 @@ arch=('any')
 url="http://iverilog.icarus.com/"
 license=('GPLv2+')
 depends=("${MINGW_PACKAGE_PREFIX}-readline"
+         "${MINGW_PACKAGE_PREFIX}-gcc"
          "${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-ghostscript"

--- a/mingw-w64-iverilog/PKGBUILD
+++ b/mingw-w64-iverilog/PKGBUILD
@@ -12,7 +12,8 @@ license=('GPLv2+')
 depends=("${MINGW_PACKAGE_PREFIX}-readline"
          "${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-ghostscript")
+             "${MINGW_PACKAGE_PREFIX}-ghostscript"
+             "${MINGW_PACKAGE_PREFIX}-make")
 
 _ver="11_0"
 source=("iverilog::https://codeload.github.com/steveicarus/iverilog/tar.gz/v${_ver}")
@@ -24,12 +25,12 @@ build() {
   ./configure \
     --prefix="${MINGW_PREFIX}" \
     --host="$CARCH"-w64-mingw32
-  make
+  mingw32-make
 }
 
 check() {
   cd "${srcdir}/${_realname}-${_ver}/"
-  make check
+  mingw32-make check
 #  git clone git://github.com/steveicarus/ivtest.git
 #  cd ivtest
 #  ./regress
@@ -37,7 +38,7 @@ check() {
 
 package() {
   cd "${srcdir}/${_realname}-${_ver}/"
-  make DESTDIR="${pkgdir}" install
+  mingw32-make DESTDIR="${pkgdir}" install
   mkdir -p "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"
   mv "${pkgdir}${MINGW_PREFIX}"/*.pdf "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"
 

--- a/mingw-w64-iverilog/PKGBUILD
+++ b/mingw-w64-iverilog/PKGBUILD
@@ -11,8 +11,7 @@ url="http://iverilog.icarus.com/"
 license=('LGPLv2.1')
 depends=()
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-ghostscript"
-             "git")
+             "${MINGW_PACKAGE_PREFIX}-ghostscript")
 
 _ver="11_0"
 source=("iverilog::https://codeload.github.com/steveicarus/iverilog/tar.gz/v${_ver}")


### PR DESCRIPTION
This PR adds package `iverilog`: [steveicarus/iverilog](https://github.com/steveicarus/iverilog) ([iverilog.icarus.com](http://iverilog.icarus.com)). It's "*a Verilog simulation and synthesis tool*".