### PR TITLE
gedit: fix the DLL loading warning at the start 

### DIFF
--- a/mingw-w64-gedit/0001-workaround-no-delayed-loading.patch
+++ b/mingw-w64-gedit/0001-workaround-no-delayed-loading.patch
@@ -1,0 +1,35 @@
+--- gedit-3.38.0/gedit/gedit.c.orig	2020-11-28 22:35:27.317196900 +0100
++++ gedit-3.38.0/gedit/gedit.c	2020-11-28 22:38:42.563357000 +0100
+@@ -124,11 +124,6 @@
+ #if defined OS_OSX
+ 	type = GEDIT_TYPE_APP_OSX;
+ #elif defined G_OS_WIN32
+-	if (!gedit_w32_load_private_dll ())
+-	{
+-		return 1;
+-	}
+-
+ 	type = GEDIT_TYPE_APP_WIN32;
+ #else
+ 	type = GEDIT_TYPE_APP;
+@@ -170,10 +165,6 @@
+ 	tepl_finalize ();
+ 	gedit_dirs_shutdown ();
+ 
+-#ifdef G_OS_WIN32
+-	gedit_w32_unload_private_dll ();
+-#endif
+-
+ 	return status;
+ }
+ 
+--- gedit-3.38.0/gedit/meson.build.orig	2020-09-11 15:06:08.423460500 +0200
++++ gedit-3.38.0/gedit/meson.build	2020-11-28 22:36:49.283350700 +0100
+@@ -180,7 +180,6 @@
+   c_args: libgedit_c_args,
+   link_args: libgedit_link_args,
+   install: true,
+-  install_dir: get_option('libdir') / 'gedit',
+ )
+ 
+ # GObject Introspection

--- a/mingw-w64-gedit/PKGBUILD
+++ b/mingw-w64-gedit/PKGBUILD
@@ -32,11 +32,18 @@ options=('strip' 'staticlibs')
 license=("GPL")
 url="https://www.gnome.org"
 install=${_realname}-${CARCH}.install
-source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz)
-sha256sums=('46cf06806de58f6e5e95e34fd98ad0b2c0c50b3dae6d23ca57d16d5cc41856f8')
+source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz
+        "0001-workaround-no-delayed-loading.patch")
+sha256sums=('46cf06806de58f6e5e95e34fd98ad0b2c0c50b3dae6d23ca57d16d5cc41856f8'
+            '96f71347451a4443e29135853abea2260e3d4cc32b1691569f2669f18720dd52')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
+
+  # gedit requires delayed loading which isn't supported by meson
+  # yet, so move the lib to /bin.
+  # https://github.com/mesonbuild/meson/issues/5093
+  patch -Np1 -i "${srcdir}"/0001-workaround-no-delayed-loading.patch
 }
 
 build() {
@@ -55,8 +62,6 @@ build() {
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   DESTDIR="${pkgdir}" ninja install
-
-  mv "${pkgdir}${MINGW_PREFIX}"/lib/gedit/*.dll "${pkgdir}${MINGW_PREFIX}"/bin
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-gedit/PKGBUILD
+++ b/mingw-w64-gedit/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=gedit
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.38.0
-pkgrel=2
+pkgver=3.38.1
+pkgrel=1
 arch=('any')
 pkgdesc="A text editor for GNOME (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme"
@@ -34,7 +34,7 @@ url="https://www.gnome.org"
 install=${_realname}-${CARCH}.install
 source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz
         "0001-workaround-no-delayed-loading.patch")
-sha256sums=('46cf06806de58f6e5e95e34fd98ad0b2c0c50b3dae6d23ca57d16d5cc41856f8'
+sha256sums=('0053853d2cd59cad8a1662f5b4fdcfab47b4c0940063bacd6790a9948642844d'
             '96f71347451a4443e29135853abea2260e3d4cc32b1691569f2669f18720dd52')
 
 prepare() {


### PR DESCRIPTION
It's supposed to use delayed DLL loading, but that's not supported
by meson, so patch things to link normally.

Fixes #7322