### PR TITLE
openFPGALoader: add ed7e934

### DIFF
--- a/mingw-w64-openFPGALoader/PKGBUILD
+++ b/mingw-w64-openFPGALoader/PKGBUILD
@@ -1,0 +1,48 @@
+# Maintainer: umarcor <unai.martinezcorral@ehu.eus>
+
+_realname=openFPGALoader
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.1.r381.ed7e934
+pkgrel=1
+pkgdesc="openFPGALoader: universal utility for programming FPGA (mingw-w64)"
+arch=('any')
+url="https://github.com/trabucayre/openFPGALoader"
+license=('AGPLv3.0')
+depends=("${MINGW_PACKAGE_PREFIX}-libftdi")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "git")
+
+_commit="ed7e934"
+source=("openFPGALoader::git://github.com/trabucayre/openFPGALoader.git#commit=${_commit}")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "openFPGALoader"
+  printf "0.1.r%s.%s" "$(git rev-list --count "${_commit}")" "$(git rev-parse --short "${_commit}")"
+}
+
+build() {
+  cd "${srcdir}/${_realname}"
+  mkdir build
+  cd build
+  MSYS2_ARG_CONV_EXCL=- cmake \
+    -G "MinGW Makefiles" \
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+    ../
+  cmake --build .
+}
+
+check() {
+  "${srcdir}/${_realname}"/build/openFPGALoader.exe --help
+}
+
+package() {
+  cd "${srcdir}/${_realname}"/build
+  make DESTDIR="${pkgdir}" install
+
+  _licenses="${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
+  mkdir -p "${_licenses}"
+  install -m 644 "${srcdir}"/../../LICENSE "${_licenses}"
+}

--- a/mingw-w64-openFPGALoader/PKGBUILD
+++ b/mingw-w64-openFPGALoader/PKGBUILD
@@ -12,6 +12,7 @@ license=('AGPLv3.0')
 depends=("${MINGW_PACKAGE_PREFIX}-libftdi")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-make"
              "git")
 
 _commit="ed7e934"
@@ -40,7 +41,7 @@ check() {
 
 package() {
   cd "${srcdir}/${_realname}"/build
-  make DESTDIR="${pkgdir}" install
+  mingw32-make DESTDIR="${pkgdir}" install
 
   _licenses="${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
   mkdir -p "${_licenses}"


### PR DESCRIPTION
This PR adds `openFPGALoader`: https://github.com/trabucayre/openFPGALoader, a universal utility for programming FPGA.

I asked the maintainer to release a new tag (https://github.com/trabucayre/openFPGALoader/pull/65#issuecomment-735372538). Hence, we might wait until that's done, for removing `git` from makedepends, and using a tarball instead.