### PR TITLE
icesprog: get tarball instead of using git

### DIFF
--- a/mingw-w64-icesprog/PKGBUILD
+++ b/mingw-w64-icesprog/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=icesprog
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.0.r67.8e33c6a
+pkgver=1.0
 pkgrel=1
 pkgdesc="iCESugar FPGA Board programming tool (mingw-w64)"
 arch=('any')
@@ -15,26 +15,20 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "git")
 
-_commit="8e33c6a"
-source=("icesugar::git://github.com/wuxx/icesugar.git#commit=${_commit}")
-sha256sums=('SKIP')
-
-pkgver() {
-  cd "icesugar"
-
-  printf "1.0.r%s.%s" "$(git rev-list --count "${_commit}")" "$(git rev-parse --short "${_commit}")"
-}
+_ver="1.5"
+source=("icesugar::https://codeload.github.com//wuxx/icesugar/tar.gz/v${_ver}")
+sha256sums=('2a77e9e6b332713cc78751dcc2968ac2bcabf539dd52055ae2b097e8e62c479f')
 
 build() {
-  cd "${srcdir}/icesugar/tools/src"
+  cd "${srcdir}/icesugar-${_ver}"/tools/src
   make
 }
 
 check() {
-  "${srcdir}"/icesugar/tools/src/icesprog.exe -h
+  "${srcdir}/icesugar-${_ver}"/tools/src/icesprog.exe -h
 }
 
 package() {
   mkdir -p "${pkgdir}${MINGW_PREFIX}"/bin/
-  cp "${srcdir}"/icesugar/tools/src/icesprog.exe "${pkgdir}${MINGW_PREFIX}"/bin/
+  cp "${srcdir}/icesugar-${_ver}"/tools/src/icesprog.exe "${pkgdir}${MINGW_PREFIX}"/bin/
 }

--- a/mingw-w64-icesprog/PKGBUILD
+++ b/mingw-w64-icesprog/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=icesprog
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.0
+pkgver=1.0.0
 pkgrel=1
 pkgdesc="iCESugar FPGA Board programming tool (mingw-w64)"
 arch=('any')


### PR DESCRIPTION
Upon request, the maintainer of icesprog released a new git tag: https://github.com/wuxx/icesugar/issues/19. In this PR, the recipe is changed for retrieving a tarball, instead of using git.

/cc @Biswa96 