### PR TITLE
Update opencascade to version 7.5.0

### DIFF
--- a/mingw-w64-opencascade/0001-fix-compile-openvr.patch
+++ b/mingw-w64-opencascade/0001-fix-compile-openvr.patch
@@ -1,0 +1,12 @@
+diff -ur occt-V7_5_0.orig/src/Aspect/Aspect_OpenVRSession.cxx occt-V7_5_0/src/Aspect/Aspect_OpenVRSession.cxx
+--- occt-V7_5_0.orig/src/Aspect/Aspect_OpenVRSession.cxx	2020-11-26 11:27:09.822443300 +0100
++++ occt-V7_5_0/src/Aspect/Aspect_OpenVRSession.cxx	2020-11-26 11:30:38.912514000 +0100
+@@ -168,7 +168,7 @@
+   vr::IVRSystem*          System; //!< OpenVR session object
+ 
+   //! Empty constructor.
+-  Aspect_OpenVRSession::VRContext() : System (NULL)
++  VRContext() : System (NULL)
+   {
+     memset (TrackedPoses, 0, sizeof(TrackedPoses));
+   }

--- a/mingw-w64-opencascade/PKGBUILD
+++ b/mingw-w64-opencascade/PKGBUILD
@@ -19,7 +19,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-tk"
          "${MINGW_PACKAGE_PREFIX}-openvr")
 makedepends=("${MINGW_PACKAGE_PREFIX}-qt5"
              "${MINGW_PACKAGE_PREFIX}-ninja"
-             "${MINGW_PACKAGE_PREFIX}-cmake")
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-doxygen")
 license=('custom')
 url='https://www.opencascade.org'
 source=("opencascade-${pkgver}.tgz::https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=refs/tags/${_pkgver2};sf=tgz"
@@ -95,6 +96,7 @@ build() {
     ${MINGW_PREFIX}/bin/cmake \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -G"MSYS Makefiles" \
+    -DCMAKE_BUILD_TYPE="Release" \
     -DINSTALL_DIR_LAYOUT="Unix" \
     -DBUILD_LIBRARY_TYPE="Static" \
     "${common_config[@]}" \
@@ -119,6 +121,7 @@ build() {
     ${MINGW_PREFIX}/bin/cmake \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -G"MSYS Makefiles" \
+    -DCMAKE_BUILD_TYPE="Release" \
     -DINSTALL_DIR_LAYOUT="Unix" \
     -DBUILD_LIBRARY_TYPE="Shared" \
     "${common_config[@]}" \

--- a/mingw-w64-opencascade/PKGBUILD
+++ b/mingw-w64-opencascade/PKGBUILD
@@ -29,7 +29,7 @@ md5sums=('c3085cc8da488a645e90da8be7aff1b6'
          'SKIP')
 		 
 prepare() {
-  cd "${srcdir}"/occt-${pkgver2}
+  cd "${srcdir}"/occt-${_pkgver2}
   patch -p1 -i "${srcdir}"/0001-fix-compile-openvr.patch
 }
 
@@ -148,5 +148,5 @@ package() {
   cd "${srcdir}/build-${MINGW_CHOST}-shared"
   DESTDIR=${pkgdir} cmake --build . --target install
   
-  install -Dm644 ${srcdir}/occt-${pkgver2}/LICENSE_LGPL_21.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+  install -Dm644 ${srcdir}/occt-${_pkgver2}/LICENSE_LGPL_21.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
 }

--- a/mingw-w64-opencascade/PKGBUILD
+++ b/mingw-w64-opencascade/PKGBUILD
@@ -3,25 +3,90 @@
 _realname=opencascade
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=7.4.0p1
-pkgrel=2
+pkgver=7.5.0
+_pkgver2=V7_5_0
+pkgrel=1
 pkgdesc='Open CASCADE Technology, 3D modeling & numerical simulation (mingw-w64)'
 arch=('any')
 depends=("${MINGW_PACKAGE_PREFIX}-tk"
          "${MINGW_PACKAGE_PREFIX}-tcl"
-         "${MINGW_PACKAGE_PREFIX}-freetype")
-makedepends=("${MINGW_PACKAGE_PREFIX}-ninja"
+         "${MINGW_PACKAGE_PREFIX}-freetype"
+         "${MINGW_PACKAGE_PREFIX}-intel-tbb"
+         "${MINGW_PACKAGE_PREFIX}-freeimage"
+         "${MINGW_PACKAGE_PREFIX}-vtk"
+         "${MINGW_PACKAGE_PREFIX}-ffmpeg"
+         "${MINGW_PACKAGE_PREFIX}-rapidjson"
+         "${MINGW_PACKAGE_PREFIX}-openvr")
+makedepends=("${MINGW_PACKAGE_PREFIX}-qt5"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cmake")
-optdepends=("${MINGW_PACKAGE_PREFIX}-intel-tbb"
-            "${MINGW_PACKAGE_PREFIX}-freeimage"
-            "${MINGW_PACKAGE_PREFIX}-gl2ps"
-            "${MINGW_PACKAGE_PREFIX}-VTK")
 license=('custom')
 url='https://www.opencascade.org'
-source=(http://files.salome-platform.org/Salome/other/${_realname}-${pkgver}.tar.gz)
-md5sums=('7b875206d595c150ab547f1d4b721920')
+source=("opencascade-${pkgver}.tgz::https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=refs/tags/${_pkgver2};sf=tgz"
+        "0001-fix-compile-openvr.patch")
+md5sums=('c3085cc8da488a645e90da8be7aff1b6'
+         'SKIP')
+		 
+prepare() {
+  cd "${srcdir}"/occt-${pkgver2}
+  patch -p1 -i "${srcdir}"/0001-fix-compile-openvr.patch
+}
 
 build() {
+  local common_config
+  common_config=(
+    -DUSE_D3D=1
+    -D3RDPARTY_DIR="${MINGW_PREFIX}"
+    -D3RDPARTY_TK_DIR="${MINGW_PREFIX}"
+    -D3RDPARTY_TCL_DIR="${MINGW_PREFIX}"
+    -D3RDPARTY_FREETYPE_DIR="${MINGW_PREFIX}"
+    -D3RDPARTY_FREEIMAGE_DIR="${MINGW_PREFIX}"
+    -D3RDPARTY_FFMPEG_DIR="${MINGW_PREFIX}"
+    -D3RDPARTY_RAPIDJSON_DIR="${MINGW_PREFIX}"
+    -D3RDPARTY_OPENVR_DIR="${MINGW_PREFIX}"
+    -D3RDPARTY_TK_DLL_DIR="${MINGW_PREFIX}/bin/"
+    -D3RDPARTY_TK_DLL="${MINGW_PREFIX}/bin/tk86.dll"
+    -D3RDPARTY_TK_LIBRARY_DIR="${MINGW_PREFIX}/lib/"
+    -D3RDPARTY_TCL_DLL_DIR="${MINGW_PREFIX}/bin/"
+    -D3RDPARTY_TCL_DLL="${MINGW_PREFIX}/bin/tcl86.dll"
+    -D3RDPARTY_TCL_LIBRARY_DIR="${MINGW_PREFIX}/lib/"
+    -D3RDPARTY_FREETYPE_DLL_DIR="${MINGW_PREFIX}/bin/"
+    -D3RDPARTY_FREETYPE_DLL="${MINGW_PREFIX}/bin/libfreetype-6.dll"
+    -D3RDPARTY_FREETYPE_LIBRARY_DIR="${MINGW_PREFIX}/lib/"
+    -DUSE_FFMPEG=1
+    -D3RDPARTY_FFMPEG_DLL_DIR_avformat="${MINGW_PREFIX}/bin/"
+    -D3RDPARTY_FFMPEG_DLL_avformat="${MINGW_PREFIX}/bin/avformat-58.dll"
+    -D3RDPARTY_FFMPEG_LIBRARY_DIR_avformat="${MINGW_PREFIX}/lib/"
+    -D3RDPARTY_FFMPEG_DLL_DIR_avutil="${MINGW_PREFIX}/bin/"
+    -D3RDPARTY_FFMPEG_DLL_avutil="${MINGW_PREFIX}/bin/avutil-56.dll"
+    -D3RDPARTY_FFMPEG_LIBRARY_DIR_avutil="${MINGW_PREFIX}/lib/"
+    -D3RDPARTY_FFMPEG_DLL_DIR_avcodec="${MINGW_PREFIX}/bin/"
+    -D3RDPARTY_FFMPEG_DLL_avcodec="${MINGW_PREFIX}/bin/avcodec-58.dll"
+    -D3RDPARTY_FFMPEG_LIBRARY_DIR_avcodec="${MINGW_PREFIX}/lib/"
+    -D3RDPARTY_FFMPEG_DLL_DIR_swscale="${MINGW_PREFIX}/bin/"
+    -D3RDPARTY_FFMPEG_DLL_swscale="${MINGW_PREFIX}/bin/swscale-5.dll"
+    -D3RDPARTY_FFMPEG_LIBRARY_DIR_swscale="${MINGW_PREFIX}/lib"
+    -DUSE_FREEIMAGE=1
+    -D3RDPARTY_FREEIMAGE_DLL_DIR_freeimage="${MINGW_PREFIX}/bin/"
+    -D3RDPARTY_FREEIMAGE_DLL_freeimage="${MINGW_PREFIX}/bin/libfreeimage-3.dll"
+    -D3RDPARTY_FREEIMAGE_LIBRARY_DIR_freeimage="${MINGW_PREFIX}/lib/"
+    -DUSE_OPENVR=1
+    -D3RDPARTY_OPENVR_DLL_DIR_openvr_api="${MINGW_PREFIX}/bin/"
+    -D3RDPARTY_OPENVR_DLL_openvr_api="${MINGW_PREFIX}/bin/libopenvr_api.dll"
+    -D3RDPARTY_OPENVR_LIBRARY_DIR_openvr_api="${MINGW_PREFIX}/lib/"
+    -DUSE_RAPIDJSON=1
+    -DUSE_TBB=1
+    -D3RDPARTY_TBB_DLL_DIR="${MINGW_PREFIX}/bin/"
+    -D3RDPARTY_TBB_DLL="${MINGW_PREFIX}/bin/tbb.dll"
+    -D3RDPARTY_TBB_LIBRARY_DIR="${MINGW_PREFIX}/lib/"
+    -D3RDPARTY_TBB_LIBRARY="${MINGW_PREFIX}/lib/libtbb.dll.a"
+    -D3RDPARTY_TBBMALLOC_DLL_DIR="${MINGW_PREFIX}/bin/"
+    -D3RDPARTY_TBBMALLOC_DLL="${MINGW_PREFIX}/bin/tbbmalloc.dll"
+    -D3RDPARTY_TBBMALLOC_LIBRARY_DIR="${MINGW_PREFIX}/lib/"
+    -D3RDPARTY_TBBMALLOC_LIBRARY="${MINGW_PREFIX}/lib/libtbbmalloc.dll.a"
+    -DUSE_VTK=1	
+  )
+
   #Static Build
   [[ -d "${srcdir}/build-${MINGW_CHOST}-static" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}-static"
   mkdir -p "${srcdir}/build-${MINGW_CHOST}-static" && cd "${srcdir}/build-${MINGW_CHOST}-static"
@@ -29,13 +94,22 @@ build() {
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DBUILD_LIBRARY_TYPE=STATIC \
-    -DINSTALL_DIR_LAYOUT=Unix \
-    ../${_realname}-${pkgver}
-
-  ninja
+    -G"MSYS Makefiles" \
+    -DINSTALL_DIR_LAYOUT="Unix" \
+    -DBUILD_LIBRARY_TYPE="Static" \
+    "${common_config[@]}" \
+    -D3RDPARTY_TK_LIBRARY="${MINGW_PREFIX}/lib/libtk86.a" \
+    -D3RDPARTY_TCL_LIBRARY="${MINGW_PREFIX}/lib/libtcl86.a" \
+    -D3RDPARTY_FREETYPE_LIBRARY="${MINGW_PREFIX}/lib/libfreetype.a" \
+    -D3RDPARTY_FFMPEG_LIBRARY_avformat="${MINGW_PREFIX}/lib/libavformat.a" \
+    -D3RDPARTY_FFMPEG_LIBRARY_avutil="${MINGW_PREFIX}/lib/libavutil.a" \
+    -D3RDPARTY_FFMPEG_LIBRARY_avcodec="${MINGW_PREFIX}/lib/libavcodec.a" \
+    -D3RDPARTY_FFMPEG_LIBRARY_swscale="${MINGW_PREFIX}/lib/libswscale.a" \
+    -D3RDPARTY_FREEIMAGE_LIBRARY="${MINGW_PREFIX}/lib/libfreeimage.a" \
+    -D3RDPARTY_OPENVR_LIBRARY_openvr_api="${MINGW_PREFIX}/lib/libopenvr_api.a" \
+    ../occt-${_pkgver2}	
+	
+    ${MINGW_PREFIX}/bin/cmake --build .
 
   #Shared Build
   [[ -d "${srcdir}/build-${MINGW_CHOST}-shared" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}-shared"
@@ -44,13 +118,22 @@ build() {
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DBUILD_LIBRARY_TYPE=SHARED \
-    -DINSTALL_DIR_LAYOUT=Unix \
-    ../${_realname}-${pkgver}
-
-  ninja
+    -G"MSYS Makefiles" \
+    -DINSTALL_DIR_LAYOUT="Unix" \
+    -DBUILD_LIBRARY_TYPE="Shared" \
+    "${common_config[@]}" \
+    -D3RDPARTY_TK_LIBRARY="${MINGW_PREFIX}/lib/libtk86.dll.a" \
+    -D3RDPARTY_TCL_LIBRARY="${MINGW_PREFIX}/lib/libtcl86.dll.a" \
+    -D3RDPARTY_FREETYPE_LIBRARY="${MINGW_PREFIX}/lib/libfreetype.dll.a" \
+    -D3RDPARTY_FFMPEG_LIBRARY_avformat="${MINGW_PREFIX}/lib/libavformat.dll.a" \
+    -D3RDPARTY_FFMPEG_LIBRARY_avutil="${MINGW_PREFIX}/lib/libavutil.dll.a" \
+    -D3RDPARTY_FFMPEG_LIBRARY_avcodec="${MINGW_PREFIX}/lib/libavcodec.dll.a" \
+    -D3RDPARTY_FFMPEG_LIBRARY_swscale="${MINGW_PREFIX}/lib/libswscale.dll.a" \
+    -D3RDPARTY_FREEIMAGE_LIBRARY="${MINGW_PREFIX}/lib/libfreeimage.dll.a" \
+    -D3RDPARTY_OPENVR_LIBRARY_openvr_api="${MINGW_PREFIX}/lib/libopenvr_api.dll.a" \
+    ../occt-${_pkgver2}
+	
+    ${MINGW_PREFIX}/bin/cmake --build .
 }
 
 package() {
@@ -61,7 +144,6 @@ package() {
   #Shared Install
   cd "${srcdir}/build-${MINGW_CHOST}-shared"
   DESTDIR=${pkgdir} cmake --build . --target install
-  install -Dm644 ${srcdir}/${_realname}-${pkgver}/LICENSE_LGPL_21.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+  
+  install -Dm644 ${srcdir}/occt-${pkgver2}/LICENSE_LGPL_21.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
 }
-
-# vim: ts=2 sw=2 et:

--- a/mingw-w64-opencascade/PKGBUILD
+++ b/mingw-w64-opencascade/PKGBUILD
@@ -76,7 +76,7 @@ build() {
     -D3RDPARTY_OPENVR_DLL_openvr_api="${MINGW_PREFIX}/bin/libopenvr_api.dll"
     -D3RDPARTY_OPENVR_LIBRARY_DIR_openvr_api="${MINGW_PREFIX}/lib/"
     -DUSE_RAPIDJSON=1
-    -DUSE_TBB=1
+    -DUSE_TBB=0
     -D3RDPARTY_TBB_DLL_DIR="${MINGW_PREFIX}/bin/"
     -D3RDPARTY_TBB_DLL="${MINGW_PREFIX}/bin/tbb.dll"
     -D3RDPARTY_TBB_LIBRARY_DIR="${MINGW_PREFIX}/lib/"


### PR DESCRIPTION
This PR update opencascade to version 7.5.0 and enable more opencascade dependencies to be used:
- ffmpeg
- freeimage
- rapidjson
- vtk
- openvr
- d3d
- tbb

gl2ps dependency was removed because opencascade does not use it anymore.

A lot of 3RDPARTY_* variable are defined to ensure the cmake build find the right lib in both static and shared build.

A patch has been made to fix a compilation error when using openvr.

Fix #7343 I guess.

What is the politics about the makefiles generator here ? Sometimes it uses MSYS Generator, sometimes ninja. So I do not know what should be used by default when creating packages.