### PR TITLE
Update libtorrent-rasterbar to v2.0.1

### DIFF
--- a/mingw-w64-libtorrent-rasterbar/PKGBUILD
+++ b/mingw-w64-libtorrent-rasterbar/PKGBUILD
@@ -5,7 +5,7 @@
 _realname=libtorrent-rasterbar
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.2.10
+pkgver=2.0.1
 pkgrel=1
 pkgdesc="libtorrent is a feature complete C++ bittorrent implementation focusing on efficiency and scalability (mingw-w64)"
 arch=('any')
@@ -17,8 +17,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
 options=(staticlibs strip)
-source=("https://github.com/arvidn/libtorrent/releases/download/libtorrent-${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('d0dd30bdc3926587c4241f4068d8e39628a6c1f9f6cf53195f0e9bc90017befb')
+source=("https://github.com/arvidn/libtorrent/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('7b39599bf602bf2f208f8f05bf2327576356a3c192175b3a4603262ede42ffd7')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"


### PR DESCRIPTION
@Alexpux, do you think, since libtorrent v2.0 introduces API breakage (https://libtorrent.org/upgrade_to_2.0-ref.html), that we should rather make v2.0 available from another msys package, since v1.2 is still maintained ? (https://github.com/arvidn/libtorrent/releases/tag/v1.2.11)

Cheers !