### PR TITLE
OpenAI deps: moving from dirty branch

### DIFF
--- a/mingw-w64-python-black/PKGBUILD
+++ b/mingw-w64-python-black/PKGBUILD
@@ -1,0 +1,37 @@
+# Maintainer: Sarah Ottinger <schalaalexiazeal@gmail.com>
+
+_realname=black
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=20.8b1
+pkgrel=1
+pkgdesc='Uncompromising Python code formatter (mingw-w64)'
+arch=('any')
+url="https://github.com/psf/black"
+license=('MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-python-appdirs" "${MINGW_PACKAGE_PREFIX}-python-click" "${MINGW_PACKAGE_PREFIX}-python-mypy_extensions" "${MINGW_PACKAGE_PREFIX}-python-pathspec" "${MINGW_PACKAGE_PREFIX}-python-regex" "${MINGW_PACKAGE_PREFIX}-python-toml" "${MINGW_PACKAGE_PREFIX}-python-typed_ast" "${MINGW_PACKAGE_PREFIX}-python-typing_extensions")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-aiohttp-cors")
+options=('!emptydirs')
+source=("https://files.pythonhosted.org/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea')
+
+prepare() {  
+  cd "$srcdir"
+  rm -rf python-build-${CARCH} | true
+  cp -r "${_realname}-$pkgver" "python-build-${CARCH}"
+}
+
+build() {
+  msg "Python build for ${CARCH}"  
+  cd "${srcdir}/python-build-${CARCH}"
+  ${MINGW_PREFIX}/bin/python setup.py build
+}
+
+package() {
+  cd "${srcdir}/python-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}

--- a/mingw-w64-python-black/PKGBUILD
+++ b/mingw-w64-python-black/PKGBUILD
@@ -10,7 +10,8 @@ arch=('any')
 url="https://github.com/psf/black"
 license=('MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-python-appdirs" "${MINGW_PACKAGE_PREFIX}-python-click" "${MINGW_PACKAGE_PREFIX}-python-mypy_extensions" "${MINGW_PACKAGE_PREFIX}-python-pathspec" "${MINGW_PACKAGE_PREFIX}-python-regex" "${MINGW_PACKAGE_PREFIX}-python-toml" "${MINGW_PACKAGE_PREFIX}-python-typed_ast" "${MINGW_PACKAGE_PREFIX}-python-typing_extensions")
-makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-aiohttp-cors")
 options=('!emptydirs')
 source=("https://files.pythonhosted.org/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz")

--- a/mingw-w64-python-google-cloud-core/PKGBUILD
+++ b/mingw-w64-python-google-cloud-core/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=google-cloud-core
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=1.4.3
+pkgver=1.4.4
 pkgrel=1
 pkgdesc='Google Cloud API client core library (mingw-w64)'
 arch=('any')
@@ -13,7 +13,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-python-google-auth" "${MINGW_PACKAGE_PREFIX}-p
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!emptydirs')
 source=("https://files.pythonhosted.org/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('21afb70c1b0bce8eeb8abb5dca63c5fd37fc8aea18f4b6d60e803bd3d27e6b80')
+sha256sums=('5bf32a3476412bbbf37660d73c46a7217a0db7913d4f4db6490b56d7a93f1d86')
 
 prepare() {  
   cd "$srcdir"

--- a/mingw-w64-python-pytest-asyncio/PKGBUILD
+++ b/mingw-w64-python-pytest-asyncio/PKGBUILD
@@ -1,0 +1,44 @@
+# Maintainer: Sarah Ottinger <schalaalexiazeal@gmail.com>
+
+_realname=pytest-asyncio
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=0.14.0
+pkgrel=1
+pkgdesc='Pytest support for asyncio (mingw-w64)'
+arch=('any')
+url="https://github.com/pytest-dev/pytest-asyncio/"
+license=('Apache')
+depends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-async_generator" "${MINGW_PACKAGE_PREFIX}-python-coverage" "${MINGW_PACKAGE_PREFIX}-python-hypothesis")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
+source=("https://github.com/pytest-dev/pytest-asyncio/archive/v$pkgver.tar.gz")
+sha256sums=('95c1ace9c204deaca484dcb4bf3beed4afda38cf7f1721f4ce74567bb23a30f1')
+
+prepare() {  
+  cd "$srcdir"
+  rm -rf python-build-${CARCH} | true
+  cp -r "${_realname}-${pkgver}" "python-build-${CARCH}"
+}
+
+build() {
+  msg "Python build for ${CARCH}"  
+  cd "${srcdir}/python-build-${CARCH}"
+  # Don't treat DeprecationWarnings as errors
+  sed -i '/filterwarnings = error/d' setup.cfg
+  ${MINGW_PREFIX}/bin/python setup.py build
+}
+
+check() {
+  cd "${srcdir}/python-build-${CARCH}"
+  ${MINGW_PREFIX}/bin/python setup.py install --root="$PWD/tmp_install" --optimize=1 || warning "Tests failed"
+  PYTHONPATH="$PWD/tmp_install/usr/lib/python3.8/site-packages:$PYTHONPATH:$PWD/tests" py.test || warning "Tests failed"
+}
+
+package() {
+  cd "${srcdir}/python-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}

--- a/mingw-w64-python-tqdm/PKGBUILD
+++ b/mingw-w64-python-tqdm/PKGBUILD
@@ -3,17 +3,19 @@
 _realname=tqdm
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=4.52.0
+pkgver=4.54.0
 pkgrel=1
 pkgdesc='Fast, Extensible Progress Meter (mingw-w64)'
 arch=('any')
 url="https://github.com/tqdm/tqdm"
 license=('MIT' 'MPL')
 depends=("${MINGW_PACKAGE_PREFIX}-python")
-checkdepends=("${MINGW_PACKAGE_PREFIX}-python-nose" "${MINGW_PACKAGE_PREFIX}-python-coverage" "${MINGW_PACKAGE_PREFIX}-python-flake8")
-makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
+#checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest-asyncio" "${MINGW_PACKAGE_PREFIX}-python-pandas" "${MINGW_PACKAGE_PREFIX}-python-numpy")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools-scm")
 source=("${_realname}-$pkgver.tar.gz::https://github.com/tqdm/tqdm/archive/v$pkgver.tar.gz")
-sha256sums=('ae56e568e9651a083719b6678ab3544be7104ce7a136c4027048fd6971b8087f')
+sha256sums=('226031403d7bec48accf420be05f8a3e469875032bcfb5989d9a59ddda9f95f7')
+
+export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
 
 prepare() {  
   cd "$srcdir"
@@ -27,11 +29,11 @@ build() {
   ${MINGW_PREFIX}/bin/python setup.py build
 }
 
-check() {
-  cd "${srcdir}/python-build-${CARCH}"
-  ${MINGW_PREFIX}/bin/python setup.py egg_info
-  PYTHONPATH="$PWD" ${MINGW_PREFIX}/bin/nosetests --ignore-files="tests_perf\.py" || warning "Tests failed"
-}
+# check() {
+#   cd "${srcdir}/python-build-${CARCH}"
+#   ${MINGW_PREFIX}/bin/python setup.py egg_info || warning "Tests failed"
+#   ${MINGW_PREFIX}/bin/python -m pytest || warning "Tests failed"
+# }
 
 package() {
   cd "${srcdir}/python-build-${CARCH}"

--- a/mingw-w64-python-trimesh/PKGBUILD
+++ b/mingw-w64-python-trimesh/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=trimesh
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=3.8.14
+pkgver=3.8.15
 pkgrel=1
 pkgdesc='Trimesh is a pure Python (2.7-3.4+) library for loading and using triangular meshes with an emphasis on watertight surfaces. (mingw-w64)'
 arch=('any')
@@ -15,7 +15,7 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-python-networkx: graph operations"
 "${MINGW_PACKAGE_PREFIX}-python-scipy: convex hulls"
 "${MINGW_PACKAGE_PREFIX}-python-pyglet: preview windows")
 source=("https://files.pythonhosted.org/packages/source/${_realname::1}/$_realname/$_realname-$pkgver.tar.gz")
-sha256sums=('dba3d9fa1d9488053fc7504c141fbb2258cf5f37377a3824b20bd0a93f7240a0')
+sha256sums=('3ab9c15e53916fd68d0c0ca9b46d95693d3238f164ffcf528a974c6e15cd353e')
 
 prepare() {  
   cd "$srcdir"


### PR DESCRIPTION
New:

- python-black: dependency for "lip2wav" AI, not sure why this fails build bot. It builds for me
- python-pytest-asyncio: for python-tqdm check

Updated:

- python-google-cloud-core 1.4.4
- python-tqdm 4.54
- python-trimesh 3.8.15