### PR TITLE
New package: fritzing

### DIFF
--- a/mingw-w64-fritzing/0001-Fix-libgit2-version-check-to-allow-building-with-ver.patch
+++ b/mingw-w64-fritzing/0001-Fix-libgit2-version-check-to-allow-building-with-ver.patch
@@ -1,0 +1,26 @@
+From 0a2df4e229c9e0564f452943688c81c9a93f9a4a Mon Sep 17 00:00:00 2001
+From: PsikoBlock <rramsch@googlemail.com>
+Date: Fri, 10 Apr 2020 21:41:52 +0200
+Subject: [PATCH 1/3] Fix libgit2 version check to allow building with versions
+ >= 1.0
+
+---
+ src/version/partschecker.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/version/partschecker.cpp b/src/version/partschecker.cpp
+index 65daf76e..36300fe0 100644
+--- a/src/version/partschecker.cpp
++++ b/src/version/partschecker.cpp
+@@ -115,7 +115,7 @@ bool PartsChecker::newPartsAvailable(const QString &repoPath, const QString & sh
+ 	/**
+ 	 * Connect to the remote.
+ 	 */
+-#if LIBGIT2_VER_MINOR > 24
++#if LIBGIT2_VER_MAJOR > 0 || (LIBGIT2_VER_MAJOR == 0 && LIBGIT2_VER_MINOR > 24)
+ 	error = git_remote_connect(remote, GIT_DIRECTION_FETCH, &callbacks, NULL, NULL);
+ #elif LIBGIT2_VER_MINOR == 24
+ 	error = git_remote_connect(remote, GIT_DIRECTION_FETCH, &callbacks, NULL);
+-- 
+2.29.2.windows.2
+

--- a/mingw-w64-fritzing/0002-Fix-casts-from-pointer-to-long-to-size_t-instead.patch
+++ b/mingw-w64-fritzing/0002-Fix-casts-from-pointer-to-long-to-size_t-instead.patch
@@ -1,0 +1,134 @@
+From 593e5084ab2fedcbc43917d1049a807c19be8841 Mon Sep 17 00:00:00 2001
+From: Jeremy Drake <github@jdrake.com>
+Date: Wed, 2 Dec 2020 11:54:32 -0800
+Subject: [PATCH 2/3] Fix casts from pointer to long to size_t instead.
+
+These caused an error on mingw64.
+---
+ src/autoroute/cmrouter/cmrouter.cpp | 14 +++++++-------
+ src/connectors/connectoritem.cpp    |  4 ++--
+ src/items/clipablewire.cpp          |  2 +-
+ src/items/itembase.cpp              |  2 +-
+ src/items/paletteitem.cpp           |  2 +-
+ src/sketch/sketchwidget.cpp         |  4 ++--
+ 6 files changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/src/autoroute/cmrouter/cmrouter.cpp b/src/autoroute/cmrouter/cmrouter.cpp
+index ce5bee4a..6f261191 100644
+--- a/src/autoroute/cmrouter/cmrouter.cpp
++++ b/src/autoroute/cmrouter/cmrouter.cpp
+@@ -154,21 +154,21 @@ static inline void infoTile(const QString & message, Tile * tile)
+ 	}
+ 
+ 	DebugDialog::debug(QString("tile:%1 lb:%2 bl:%3 tr:%4 rt%5")
+-	                   .arg((long) tile, 0, 16)
+-	                   .arg((long) tile->ti_lb, 0, 16)
+-	                   .arg((long) tile->ti_bl, 0, 16)
+-	                   .arg((long) tile->ti_tr, 0, 16)
+-	                   .arg((long) tile->ti_rt, 0, 16));
++	                   .arg((size_t) tile, 0, 16)
++	                   .arg((size_t) tile->ti_lb, 0, 16)
++	                   .arg((size_t) tile->ti_bl, 0, 16)
++	                   .arg((size_t) tile->ti_tr, 0, 16)
++	                   .arg((size_t) tile->ti_rt, 0, 16));
+ 
+ 	DebugDialog::debug(QString("%1 tile:%2 l:%3 t:%4 w:%5 h:%6 type:%7 body:%8")
+ 	                   .arg(message)
+-	                   .arg((long) tile, 0, 16)
++	                   .arg((size_t) tile, 0, 16)
+ 	                   .arg(LEFT(tile))
+ 	                   .arg(YMIN(tile))
+ 	                   .arg(WIDTH(tile))
+ 	                   .arg(HEIGHT(tile))
+ 	                   .arg(TiGetType(tile))
+-	                   .arg((long) TiGetBody(tile), 0, 16)
++	                   .arg((size_t) TiGetBody(tile), 0, 16)
+ 	                  );
+ }
+ 
+diff --git a/src/connectors/connectoritem.cpp b/src/connectors/connectoritem.cpp
+index 4aaa5a83..5a60ca8c 100644
+--- a/src/connectors/connectoritem.cpp
++++ b/src/connectors/connectoritem.cpp
+@@ -480,7 +480,7 @@ ConnectorItem * ConnectorItem::removeConnection(ItemBase * itemBase) {
+ 			}
+ 			restoreColor(visited);
+ 			DebugDialog::debug(QString("remove from:%1 to:%2 count%3")
+-			                   .arg((long) this, 0, 16)
++			                   .arg((size_t) this, 0, 16)
+ 			                   .arg(itemBase->modelPartShared()->title())
+ 			                   .arg(m_connectedTo.count()) );
+ 			return removed;
+@@ -1931,7 +1931,7 @@ void ConnectorItem::debugInfo(const QString & msg)
+ 	            .arg(this->attachedToViewLayerPlacement())
+ 	            .arg(this->attachedTo()->wireFlags())
+ 	            .arg(this->m_hybrid)
+-	            .arg((long) this->bus(), 0, 16)
++	            .arg((size_t) this->bus(), 0, 16)
+ 	            .arg(this->m_radius)
+ 	            .arg(this->m_strokeWidth)
+ 	            .arg(p.x())
+diff --git a/src/items/clipablewire.cpp b/src/items/clipablewire.cpp
+index 2e4c080d..b7eb266a 100644
+--- a/src/items/clipablewire.cpp
++++ b/src/items/clipablewire.cpp
+@@ -297,7 +297,7 @@ bool ClipableWire::filterMousePressConnectorEvent(ConnectorItem * connectorItem,
+ 
+ void ClipableWire::mousePressEvent(QGraphicsSceneMouseEvent *event)
+ {
+-	if ((long) event == (long) m_justFilteredEvent) {
++	if ((size_t) event == (size_t) m_justFilteredEvent) {
+ 		event->ignore();
+ 		return;
+ 	}
+diff --git a/src/items/itembase.cpp b/src/items/itembase.cpp
+index b2b2519d..01434a86 100644
+--- a/src/items/itembase.cpp
++++ b/src/items/itembase.cpp
+@@ -1958,7 +1958,7 @@ void ItemBase::debugInfo2(const QString & msg) const
+ 	                   .arg(this->viewLayerID())
+ 	                   .arg(this->viewLayerPlacement())
+ 	                   .arg(this->wireFlags())
+-	                   .arg((long) dynamic_cast<const QGraphicsItem *const>(this), 0, 16)
++	                   .arg((size_t) dynamic_cast<const QGraphicsItem *const>(this), 0, 16)
+ 	                   .arg(m_viewID)
+ 	                   .arg(this->zValue())
+ 	                   .arg(this->pos().x())
+diff --git a/src/items/paletteitem.cpp b/src/items/paletteitem.cpp
+index 6a3e2718..63f29107 100644
+--- a/src/items/paletteitem.cpp
++++ b/src/items/paletteitem.cpp
+@@ -200,7 +200,7 @@ void PaletteItem::makeOneKin(qint64 & id, ViewLayer::ViewLayerID viewLayerID, Vi
+ 	if (lkpi->ok()) {
+ 		DebugDialog::debug(QString("adding layer kin %1 %2 %3 %4")
+ 		                   .arg(id).arg(m_viewID).arg(viewLayerID)
+-		                   .arg((long) lkpi, 0, 16)
++		                   .arg((size_t) lkpi, 0, 16)
+ 		                  );
+ 		addLayerKin(lkpi);
+ 		id++;
+diff --git a/src/sketch/sketchwidget.cpp b/src/sketch/sketchwidget.cpp
+index 126f8e4a..dc0cb91e 100644
+--- a/src/sketch/sketchwidget.cpp
++++ b/src/sketch/sketchwidget.cpp
+@@ -993,7 +993,7 @@ ItemBase * SketchWidget::findItem(long id) {
+ 
+ void SketchWidget::deleteItem(long id, bool deleteModelPart, bool doEmit, bool later) {
+ 	ItemBase * pitem = findItem(id);
+-	DebugDialog::debug(QString("delete item (1) %1 %2 %3 %4").arg(id).arg(doEmit).arg(m_viewID).arg((long) pitem, 0, 16) );
++	DebugDialog::debug(QString("delete item (1) %1 %2 %3 %4").arg(id).arg(doEmit).arg(m_viewID).arg((size_t) pitem, 0, 16) );
+ 	if (pitem != NULL) {
+ 		deleteItem(pitem, deleteModelPart, doEmit, later);
+ 	}
+@@ -1007,7 +1007,7 @@ void SketchWidget::deleteItem(long id, bool deleteModelPart, bool doEmit, bool l
+ void SketchWidget::deleteItem(ItemBase * itemBase, bool deleteModelPart, bool doEmit, bool later)
+ {
+ 	long id = itemBase->id();
+-	DebugDialog::debug(QString("delete item (2) %1 %2 %3 %4").arg(id).arg(itemBase->title()).arg(m_viewID).arg((long) itemBase, 0, 16) );
++	DebugDialog::debug(QString("delete item (2) %1 %2 %3 %4").arg(id).arg(itemBase->title()).arg(m_viewID).arg((size_t) itemBase, 0, 16) );
+ 
+ 	// this is a hack to try to workaround a Qt 4.7 crash in QGraphicsSceneFindItemBspTreeVisitor::visit
+ 	// when using a custom boundingRect, after deleting an item, it still appears on the visit list.
+-- 
+2.29.2.windows.2
+

--- a/mingw-w64-fritzing/0003-qmake-fixes-for-mingw.patch
+++ b/mingw-w64-fritzing/0003-qmake-fixes-for-mingw.patch
@@ -1,16 +1,16 @@
-From 9e84df39164fbdfee6cee5aafae5e0ff5dec1fc4 Mon Sep 17 00:00:00 2001
+From 0277828e3b0ad06470209695baa97f4bf3fa12dd Mon Sep 17 00:00:00 2001
 From: Jeremy Drake <github@jdrake.com>
 Date: Wed, 2 Dec 2020 12:00:03 -0800
-Subject: [PATCH 3/3] qmake fixes for mingw.
+Subject: [PATCH 3/4] qmake fixes for mingw.
 
 Mostly want it to act like unix.
 ---
- phoenix.pro           | 41 ++++++++++++++++++++++++-----------------
+ phoenix.pro           | 43 +++++++++++++++++++++++++------------------
  pri/libgit2detect.pri |  4 ++--
- 2 files changed, 26 insertions(+), 19 deletions(-)
+ 2 files changed, 27 insertions(+), 20 deletions(-)
 
 diff --git a/phoenix.pro b/phoenix.pro
-index 8a7e828b..b52c862b 100644
+index 8a7e828b..919fef23 100644
 --- a/phoenix.pro
 +++ b/phoenix.pro
 @@ -24,7 +24,7 @@ lessThan(QT_MAJOR_VERSION, 5) {
@@ -27,7 +27,7 @@ index 8a7e828b..b52c862b 100644
      DEFINES += _WINDOWS
      RELEASE_SCRIPT = $$(RELEASE_SCRIPT)    # environment variable set from release script
 +    mingw:isEmpty(QMAKE_TARGET.arch) {
-+        QMAKE_TARGET.arch = $$system(uname -m)
++        QMAKE_TARGET.arch = $$(MSYSTEM_CARCH)
 +    }
  
      message("target arch: $${QMAKE_TARGET.arch}")
@@ -70,12 +70,13 @@ index 8a7e828b..b52c862b 100644
 -unix {
 +unix|mingw {
      !macx { # unix is defined on mac
-         HARDWARE_PLATFORM = $$system(uname -m)
+-        HARDWARE_PLATFORM = $$system(uname -m)
 -        contains(HARDWARE_PLATFORM, x86_64) {
 -            DEFINES += LINUX_64
 -        } else {
 -            DEFINES += LINUX_32
 +        !mingw {
++            HARDWARE_PLATFORM = $$system(uname -m)
 +            contains(HARDWARE_PLATFORM, x86_64) {
 +                DEFINES += LINUX_64
 +            } else {

--- a/mingw-w64-fritzing/0003-qmake-fixes-for-mingw.patch
+++ b/mingw-w64-fritzing/0003-qmake-fixes-for-mingw.patch
@@ -1,0 +1,111 @@
+From 9e84df39164fbdfee6cee5aafae5e0ff5dec1fc4 Mon Sep 17 00:00:00 2001
+From: Jeremy Drake <github@jdrake.com>
+Date: Wed, 2 Dec 2020 12:00:03 -0800
+Subject: [PATCH 3/3] qmake fixes for mingw.
+
+Mostly want it to act like unix.
+---
+ phoenix.pro           | 41 ++++++++++++++++++++++++-----------------
+ pri/libgit2detect.pri |  4 ++--
+ 2 files changed, 26 insertions(+), 19 deletions(-)
+
+diff --git a/phoenix.pro b/phoenix.pro
+index 8a7e828b..b52c862b 100644
+--- a/phoenix.pro
++++ b/phoenix.pro
+@@ -24,7 +24,7 @@ lessThan(QT_MAJOR_VERSION, 5) {
+ 
+ CONFIG += debug_and_release
+ 
+-unix:!macx {
++if(unix:!macx)|mingw {
+     CONFIG += link_pkgconfig
+ }
+ 
+@@ -38,6 +38,9 @@ win32 {
+     DEFINES += _CRT_SECURE_NO_DEPRECATE
+     DEFINES += _WINDOWS
+     RELEASE_SCRIPT = $$(RELEASE_SCRIPT)    # environment variable set from release script
++    mingw:isEmpty(QMAKE_TARGET.arch) {
++        QMAKE_TARGET.arch = $$system(uname -m)
++    }
+ 
+     message("target arch: $${QMAKE_TARGET.arch}")
+     contains(QMAKE_TARGET.arch, x86_64) {
+@@ -49,17 +52,19 @@ win32 {
+         DEBDIR = ../debug32
+     }
+ 
+-    Release:DESTDIR = $${RELDIR}
+-    Release:OBJECTS_DIR = $${RELDIR}
+-    Release:MOC_DIR = $${RELDIR}
+-    Release:RCC_DIR = $${RELDIR}
+-    Release:UI_DIR = $${RELDIR}
+-
+-    Debug:DESTDIR = $${DEBDIR}
+-    Debug:OBJECTS_DIR = $${DEBDIR}
+-    Debug:MOC_DIR = $${DEBDIR}
+-    Debug:RCC_DIR = $${DEBDIR}
+-    Debug:UI_DIR = $${DEBDIR}
++    !mingw {
++        Release:DESTDIR = $${RELDIR}
++        Release:OBJECTS_DIR = $${RELDIR}
++        Release:MOC_DIR = $${RELDIR}
++        Release:RCC_DIR = $${RELDIR}
++        Release:UI_DIR = $${RELDIR}
++
++        Debug:DESTDIR = $${DEBDIR}
++        Debug:OBJECTS_DIR = $${DEBDIR}
++        Debug:MOC_DIR = $${DEBDIR}
++        Debug:RCC_DIR = $${DEBDIR}
++        Debug:UI_DIR = $${DEBDIR}
++    }
+ }
+ macx {
+     RELDIR = ../release64
+@@ -87,13 +92,15 @@ macx {
+     LIBS += /System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
+     LIBS += -liconv
+ }
+-unix {
++unix|mingw {
+     !macx { # unix is defined on mac
+         HARDWARE_PLATFORM = $$system(uname -m)
+-        contains(HARDWARE_PLATFORM, x86_64) {
+-            DEFINES += LINUX_64
+-        } else {
+-            DEFINES += LINUX_32
++        !mingw {
++            contains(HARDWARE_PLATFORM, x86_64) {
++                DEFINES += LINUX_64
++            } else {
++                DEFINES += LINUX_32
++            }
+         }
+         !contains(DEFINES, QUAZIP_INSTALLED) {
+             LIBS += -lz
+diff --git a/pri/libgit2detect.pri b/pri/libgit2detect.pri
+index f5de3c77..7ed878ae 100644
+--- a/pri/libgit2detect.pri
++++ b/pri/libgit2detect.pri
+@@ -34,7 +34,7 @@ if ($$LIBGIT_STATIC) {
+     INCLUDEPATH += $$LIBGIT2INCLUDE
+ }
+ 
+-win32 {
++win32:!mingw {
+     contains(QMAKE_TARGET.arch, x86_64) {
+         LIBGIT2LIB = "$$_PRO_FILE_PWD_/../libgit2/build64/Release"
+     } else {
+@@ -51,7 +51,7 @@ win32 {
+     message($$PKGCONFIG)
+ }
+ 
+-unix {
++unix|mingw {
+     if ($$LIBGIT_STATIC) {
+         LIBGIT2LIB = $$_PRO_FILE_PWD_/../libgit2/build
+         exists($$LIBGIT2LIB/libgit2.a) {
+-- 
+2.29.2.windows.2
+

--- a/mingw-w64-fritzing/0004-Look-in-.-share-fritzing-from-bin-dir-on-mingw.patch
+++ b/mingw-w64-fritzing/0004-Look-in-.-share-fritzing-from-bin-dir-on-mingw.patch
@@ -1,0 +1,36 @@
+From 2903c1051f296ccde4a44f0beda076f8dbd4defa Mon Sep 17 00:00:00 2001
+From: Jeremy Drake <github@jdrake.com>
+Date: Wed, 2 Dec 2020 23:07:02 -0800
+Subject: [PATCH 4/4] Look in ../share/fritzing from bin dir on mingw.
+
+This seems to be the best option for finding the prefix.
+---
+ src/utils/folderutils.cpp | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/utils/folderutils.cpp b/src/utils/folderutils.cpp
+index c6761b3b..3ab40857 100644
+--- a/src/utils/folderutils.cpp
++++ b/src/utils/folderutils.cpp
+@@ -212,7 +212,7 @@ const QString FolderUtils::libraryPath()
+ 
+ const QString FolderUtils::applicationDirPath() {
+ 	if (m_appPath.isEmpty()) {
+-#ifdef Q_OS_WIN
++#if defined(Q_OS_WIN) && !defined(__MINGW32__)
+ 		m_appPath = QCoreApplication::applicationDirPath();
+ #else
+ 		// look in standard Fritzing location (applicationDirPath and parent folders) then in standard linux locations
+@@ -220,6 +220,9 @@ const QString FolderUtils::applicationDirPath() {
+ 		candidates.append(QCoreApplication::applicationDirPath());
+ 		QDir dir(QCoreApplication::applicationDirPath());
+ 		if (dir.cdUp()) {
++#ifdef __MINGW32__
++			candidates.append(QDir::cleanPath(dir.absolutePath() + "/share/fritzing"));
++#endif
+ 			candidates.append(dir.absolutePath());
+ 			if (dir.cdUp()) {
+ 				candidates.append(dir.absolutePath());
+-- 
+2.29.2.windows.2
+

--- a/mingw-w64-fritzing/PKGBUILD
+++ b/mingw-w64-fritzing/PKGBUILD
@@ -19,20 +19,24 @@ source=("${_realname}"::"git+https://github.com/fritzing/fritzing-app.git#tag=CD
         0001-Fix-libgit2-version-check-to-allow-building-with-ver.patch
         0002-Fix-casts-from-pointer-to-long-to-size_t-instead.patch
         0003-qmake-fixes-for-mingw.patch
+        0004-Look-in-.-share-fritzing-from-bin-dir-on-mingw.patch
         system-libgit2.patch)
 sha256sums=('SKIP'
             'SKIP'
             '98042c42cc10847f76285e0a84d258d9818571e695dd87dd6d52ef3ac387c7a7'
             '7a91295b4ab91edb4efba9d08a9f2a0cb2761da1b04e39eaca165eee53ac9e6b'
             '2d9f550ce25ddb78ac683d23c55b5b794a06eef3b022f686bad89651793c8423'
+            'fa2c0eecea654ca2f5412acec31bd0c871ddcf271886886c78e2dd07ee70bf80'
             'b9fcdd41207a5d8fd67d44c5d4b3348e25464815431a91b61111b1fd91f1495f')
 
 prepare() {
   cd "${srcdir}"/${_realname}
 
+  # upstream commit 472951243d70eeb40a53b1f7e16e6eab0588d079
   git apply "${srcdir}"/0001-Fix-libgit2-version-check-to-allow-building-with-ver.patch
   git apply "${srcdir}"/0002-Fix-casts-from-pointer-to-long-to-size_t-instead.patch
   git apply "${srcdir}"/0003-qmake-fixes-for-mingw.patch
+  git apply "${srcdir}"/0004-Look-in-.-share-fritzing-from-bin-dir-on-mingw.patch
   patch -Np1 -i "${srcdir}"/system-libgit2.patch
 }
 

--- a/mingw-w64-fritzing/PKGBUILD
+++ b/mingw-w64-fritzing/PKGBUILD
@@ -66,11 +66,14 @@ package() {
   install -Dm644 ${srcdir}/${_realname}/LICENSE.* ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/
 
   rm -rf "${pkgdir}${MINGW_PREFIX}/share/fritzing/parts"
-  cp -Rf "${srcdir}"/${_realname}-parts "${pkgdir}${MINGW_PREFIX}/share/fritzing/parts"
+  git clone --single-branch -b makepkg --no-local --dissociate "${srcdir}"/${_realname}-parts "${pkgdir}${MINGW_PREFIX}/share/fritzing/parts"
   cd "${pkgdir}${MINGW_PREFIX}/share/fritzing/parts"
-  git remote set-url origin https://github.com/fritzing/fritzing-parts.git
   git branch -M master
-  git repack -a -d
-  rm -f .git/objects/info/alternates
+  git remote set-branches origin master
+  git update-ref --no-deref refs/remotes/origin/master refs/remotes/origin/makepkg
+  git branch --set-upstream-to origin/master
+  git update-ref -d refs/remotes/origin/makepkg
+  git remote set-head origin master
+  git remote set-url origin https://github.com/fritzing/fritzing-parts.git
   "${pkgdir}${MINGW_PREFIX}/bin/Fritzing" -db "${pkgdir}${MINGW_PREFIX}/share/fritzing/parts/parts.db" -pp "${pkgdir}${MINGW_PREFIX}/share/fritzing/parts" -f "${pkgdir}${MINGW_PREFIX}/share/fritzing"
 }

--- a/mingw-w64-fritzing/PKGBUILD
+++ b/mingw-w64-fritzing/PKGBUILD
@@ -25,7 +25,7 @@ sha256sums=('SKIP'
             'SKIP'
             '98042c42cc10847f76285e0a84d258d9818571e695dd87dd6d52ef3ac387c7a7'
             '7a91295b4ab91edb4efba9d08a9f2a0cb2761da1b04e39eaca165eee53ac9e6b'
-            '2d9f550ce25ddb78ac683d23c55b5b794a06eef3b022f686bad89651793c8423'
+            'f095db7f3f1bc03304f98697cf7b1eba30e67e8a70734362d1d8cba689da6384'
             'fa2c0eecea654ca2f5412acec31bd0c871ddcf271886886c78e2dd07ee70bf80'
             'b9fcdd41207a5d8fd67d44c5d4b3348e25464815431a91b61111b1fd91f1495f')
 

--- a/mingw-w64-fritzing/PKGBUILD
+++ b/mingw-w64-fritzing/PKGBUILD
@@ -14,8 +14,11 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-boost"
 depends=("${MINGW_PACKAGE_PREFIX}-qt5"
          "${MINGW_PACKAGE_PREFIX}-libgit2"
          "${MINGW_PACKAGE_PREFIX}-zlib")
+# Fritzing updates its parts repo online from the master branch, so the latest
+# master commit should be fine here
+_partscommit='e79a69765026f3fda8aab1b3e7a4952c28047a62'
 source=("${_realname}"::"git+https://github.com/fritzing/fritzing-app.git#tag=CD-498"
-        "${_realname}-parts"::"git+https://github.com/fritzing/fritzing-parts.git#branch=master"
+        "${_realname}-parts"::"git+https://github.com/fritzing/fritzing-parts.git#commit=$_partscommit"
         0001-Fix-libgit2-version-check-to-allow-building-with-ver.patch
         0002-Fix-casts-from-pointer-to-long-to-size_t-instead.patch
         0003-qmake-fixes-for-mingw.patch

--- a/mingw-w64-fritzing/PKGBUILD
+++ b/mingw-w64-fritzing/PKGBUILD
@@ -15,11 +15,13 @@ depends=("${MINGW_PACKAGE_PREFIX}-qt5"
          "${MINGW_PACKAGE_PREFIX}-libgit2"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 source=("${_realname}"::"git+https://github.com/fritzing/fritzing-app.git#tag=CD-498"
+        "${_realname}-parts"::"git+https://github.com/fritzing/fritzing-parts.git#branch=master"
         0001-Fix-libgit2-version-check-to-allow-building-with-ver.patch
         0002-Fix-casts-from-pointer-to-long-to-size_t-instead.patch
         0003-qmake-fixes-for-mingw.patch
         system-libgit2.patch)
 sha256sums=('SKIP'
+            'SKIP'
             '98042c42cc10847f76285e0a84d258d9818571e695dd87dd6d52ef3ac387c7a7'
             '7a91295b4ab91edb4efba9d08a9f2a0cb2761da1b04e39eaca165eee53ac9e6b'
             '2d9f550ce25ddb78ac683d23c55b5b794a06eef3b022f686bad89651793c8423'
@@ -55,4 +57,13 @@ package() {
 
   mkdir -p "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/"
   install -Dm644 ${srcdir}/${_realname}/LICENSE.* ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/
+
+  rm -rf "${pkgdir}${MINGW_PREFIX}/share/fritzing/parts"
+  cp -Rf "${srcdir}"/${_realname}-parts "${pkgdir}${MINGW_PREFIX}/share/fritzing/parts"
+  cd "${pkgdir}${MINGW_PREFIX}/share/fritzing/parts"
+  git remote set-url origin https://github.com/fritzing/fritzing-parts.git
+  git branch -M master
+  git repack -a -d
+  rm -f .git/objects/info/alternates
+  "${pkgdir}${MINGW_PREFIX}/bin/Fritzing" -db "${pkgdir}${MINGW_PREFIX}/share/fritzing/parts/parts.db" -pp "${pkgdir}${MINGW_PREFIX}/share/fritzing/parts" -f "${pkgdir}${MINGW_PREFIX}/share/fritzing"
 }

--- a/mingw-w64-fritzing/PKGBUILD
+++ b/mingw-w64-fritzing/PKGBUILD
@@ -1,0 +1,55 @@
+# Maintainer: Jeremy Drake <github@jdrake.com>
+
+_realname=fritzing
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.9.4
+pkgrel=1
+pkgdesc="Electronic Design Automation software with a low entry barrier, suited for the needs of makers and hobbyists (mingw-w64)"
+arch=('any')
+url="https://github.com/fritzing/fritzing-app"
+license=('GPL' 'CCPL:cc-by-sa-3.0')
+makedepends=("${MINGW_PACKAGE_PREFIX}-boost"
+             'git')
+depends=("${MINGW_PACKAGE_PREFIX}-qt5"
+         "${MINGW_PACKAGE_PREFIX}-libgit2"
+         "${MINGW_PACKAGE_PREFIX}-zlib")
+source=("${_realname}"::"git+https://github.com/fritzing/fritzing-app.git#tag=CD-498"
+        0001-Fix-libgit2-version-check-to-allow-building-with-ver.patch
+        0002-Fix-casts-from-pointer-to-long-to-size_t-instead.patch
+        0003-qmake-fixes-for-mingw.patch)
+sha256sums=('SKIP'
+            '98042c42cc10847f76285e0a84d258d9818571e695dd87dd6d52ef3ac387c7a7'
+            '7a91295b4ab91edb4efba9d08a9f2a0cb2761da1b04e39eaca165eee53ac9e6b'
+            '2d9f550ce25ddb78ac683d23c55b5b794a06eef3b022f686bad89651793c8423')
+
+prepare() {
+  cd "${srcdir}"/${_realname}
+
+  git apply "${srcdir}"/0001-Fix-libgit2-version-check-to-allow-building-with-ver.patch
+  git apply "${srcdir}"/0002-Fix-casts-from-pointer-to-long-to-size_t-instead.patch
+  git apply "${srcdir}"/0003-qmake-fixes-for-mingw.patch
+}
+
+build() {
+  cd "${srcdir}"/${_realname}
+  lrelease phoenix.pro
+  local qmake_config
+  if check_option "debug" "y"; then
+    qmake_config=debug
+  else
+    qmake_config=release
+  fi
+  MSYS2_ARG_CONV_EXCL="PREFIX=" \
+  qmake CONFIG+=${qmake_config} DEFINES+=QUAZIP_LIB PREFIX=${MINGW_PREFIX}
+  make
+}
+
+package() {
+  cd "${srcdir}"/${_realname}
+
+  make INSTALL_ROOT="${pkgdir}" install -j1
+
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/"
+  install -Dm644 ${srcdir}/${_realname}/LICENSE.* ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/
+}

--- a/mingw-w64-fritzing/PKGBUILD
+++ b/mingw-w64-fritzing/PKGBUILD
@@ -17,11 +17,13 @@ depends=("${MINGW_PACKAGE_PREFIX}-qt5"
 source=("${_realname}"::"git+https://github.com/fritzing/fritzing-app.git#tag=CD-498"
         0001-Fix-libgit2-version-check-to-allow-building-with-ver.patch
         0002-Fix-casts-from-pointer-to-long-to-size_t-instead.patch
-        0003-qmake-fixes-for-mingw.patch)
+        0003-qmake-fixes-for-mingw.patch
+        system-libgit2.patch)
 sha256sums=('SKIP'
             '98042c42cc10847f76285e0a84d258d9818571e695dd87dd6d52ef3ac387c7a7'
             '7a91295b4ab91edb4efba9d08a9f2a0cb2761da1b04e39eaca165eee53ac9e6b'
-            '2d9f550ce25ddb78ac683d23c55b5b794a06eef3b022f686bad89651793c8423')
+            '2d9f550ce25ddb78ac683d23c55b5b794a06eef3b022f686bad89651793c8423'
+            'b9fcdd41207a5d8fd67d44c5d4b3348e25464815431a91b61111b1fd91f1495f')
 
 prepare() {
   cd "${srcdir}"/${_realname}
@@ -29,6 +31,7 @@ prepare() {
   git apply "${srcdir}"/0001-Fix-libgit2-version-check-to-allow-building-with-ver.patch
   git apply "${srcdir}"/0002-Fix-casts-from-pointer-to-long-to-size_t-instead.patch
   git apply "${srcdir}"/0003-qmake-fixes-for-mingw.patch
+  patch -Np1 -i "${srcdir}"/system-libgit2.patch
 }
 
 build() {

--- a/mingw-w64-fritzing/system-libgit2.patch
+++ b/mingw-w64-fritzing/system-libgit2.patch
@@ -1,0 +1,11 @@
+--- fritzing-app/phoenix.pro.orig	2020-12-02 13:11:47.719516300 -0800
++++ fritzing-app/phoenix.pro	2020-12-02 13:11:59.404107500 -0800
+@@ -173,7 +173,7 @@
+ RESOURCES += phoenixresources.qrc
+ 
+ # Disable this if you have (and want) libgit2 dynamically
+-LIBGIT_STATIC = true
++LIBGIT_STATIC = false
+ include(pri/libgit2detect.pri)
+ 
+ include(pri/boostdetect.pri)


### PR DESCRIPTION
My first attempt at packaging something.

> The Fritzing application is an Electronic Design Automation software with a low entry barrier, suited for the needs of makers and hobbyists. It offers a unique real-life "breadboard" view, and a parts library with many commonly used high-level components. Fritzing makes it very easy to communicate about circuits, as well as to turn them into PCB layouts ready for production. It is particularly popular among Arduino and Raspberry Pi users, and is widely used in education and creative tinkering.

https://fritzing.org
https://github.com/fritzing/fritzing-app

Major ~~outstanding~~[solved](https://github.com/msys2/MINGW-packages/pull/7376#issuecomment-738217175) issue is that Fritzing cannot find its files out of the box.  This can be worked around by launching `Fritzing -f /mingw{32,64}/share/fritzing`.  It passes path defines to the compiler, but I found that in order for `qmake` to allow `make install` to work properly I had to use `MSYS2_ARG_CONV_EXCL="PREFIX="`.  That results in that define using a path starting with /mingw64.  Not that the alternative would have been better, since that was an absolute path on the GHA builder...  Also, the code that uses that is ifdef'd out on `QT_OS_WIN`.  Is there some common solution for mingw programs to know their prefix, so they can find their installed files?

A couple of points of oddness about this package:
* Fritzing is no longer officially supported on 32-bit.  However, it does still build and seems to run fine.
* Fritzing keeps its parts database in a git repository, and uses libgit2 to keep it up to date.  This resulted in a bit of a song-and-dance with `git` to turn the `fritzing-parts` checkout from makepkg into a self-contained git repo with the proper origin url and branch name.