### PR TITLE
godot-python deps

### DIFF
--- a/mingw-w64-python-autopxd2/PKGBUILD
+++ b/mingw-w64-python-autopxd2/PKGBUILD
@@ -1,0 +1,35 @@
+# Maintainer: Sarah Ottinger <schalaalexiazeal@gmail.com>
+
+_realname=autopxd2
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=1.1.0
+pkgrel=1
+pkgdesc='Automatically generate Cython pxd files from C headers (mingw-w64)'
+arch=('any')
+url="https://github.com/psf/black"
+license=('MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!emptydirs')
+source=("https://files.pythonhosted.org/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('faa4b7eeb6b1d7217c46d3660640d4a72fb5c86d4559017c1f58a55d34332b2a')
+
+prepare() {  
+  cd "$srcdir"
+  rm -rf python-build-${CARCH} | true
+  cp -r "${_realname}-$pkgver" "python-build-${CARCH}"
+}
+
+build() {
+  msg "Python build for ${CARCH}"  
+  cd "${srcdir}/python-build-${CARCH}"
+  ${MINGW_PREFIX}/bin/python setup.py build
+}
+
+package() {
+  cd "${srcdir}/python-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+}

--- a/mingw-w64-python-zstandard/PKGBUILD
+++ b/mingw-w64-python-zstandard/PKGBUILD
@@ -1,0 +1,45 @@
+# Maintainer: Sarah Ottinger <schalaalexiazeal@gmail.com>
+
+_realname=zstandard
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=0.14.1
+pkgrel=1
+pkgdesc='Python bindings to the Zstandard (zstd) compression library (mingw-w64)'
+arch=('any')
+url="https://github.com/indygreg/python-zstandard"
+license=('BSD')
+depends=("${MINGW_PACKAGE_PREFIX}-python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-hypothesis")
+optdepends=("${MINGW_PACKAGE_PREFIX}-python-cffi")
+options=('!emptydirs')
+source=("https://github.com/indygreg/python-zstandard/archive/$pkgver.tar.gz")
+sha256sums=('15d3b92e1b5aad5af7b93830825291821831baa6a2a0bf1b389b6171d4f8114f')
+
+prepare() {  
+  cd "$srcdir"
+  rm -rf python-build-${CARCH} | true
+  cp -r "python-${_realname}-$pkgver" "python-build-${CARCH}"
+}
+
+build() {
+  msg "Python build for ${CARCH}"  
+  cd "${srcdir}/python-build-${CARCH}"
+  sed -i 's,if compiler.compiler_type == "unix",if compiler.compiler_type == "mingw32",g' make_cffi.py
+  ${MINGW_PREFIX}/bin/python setup.py build_ext
+}
+
+check() {
+  cd "${srcdir}/python-build-${CARCH}"
+  ${MINGW_PREFIX}/bin/python setup.py build_ext --inplace | warning "Tests failed"
+  ${MINGW_PREFIX}/bin/python setup.py test | warning "Tests failed"
+}
+
+package() {
+  cd "${srcdir}/python-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}

--- a/mingw-w64-python-zstandard/PKGBUILD
+++ b/mingw-w64-python-zstandard/PKGBUILD
@@ -27,12 +27,12 @@ build() {
   msg "Python build for ${CARCH}"  
   cd "${srcdir}/python-build-${CARCH}"
   sed -i 's,if compiler.compiler_type == "unix",if compiler.compiler_type == "mingw32",g' make_cffi.py
-  ${MINGW_PREFIX}/bin/python setup.py build_ext
+  ${MINGW_PREFIX}/bin/python setup.py build
 }
 
 check() {
   cd "${srcdir}/python-build-${CARCH}"
-  ${MINGW_PREFIX}/bin/python setup.py build_ext --inplace | warning "Tests failed"
+  ${MINGW_PREFIX}/bin/python setup.py build --inplace | warning "Tests failed"
   ${MINGW_PREFIX}/bin/python setup.py test | warning "Tests failed"
 }
 


### PR DESCRIPTION
Tried to package the third party godot-python bindings, but it is messy. The dependencies consist of python-autopxd2 and python-zstandard, so I figured someone could use those if needed.