### PR TITLE
dfu-util: libwinpthread is a dep

### DIFF
--- a/mingw-w64-dfu-util/PKGBUILD
+++ b/mingw-w64-dfu-util/PKGBUILD
@@ -4,23 +4,22 @@ _realname=dfu-util
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=0.10
-pkgrel=1
+pkgrel=2
 pkgdesc='Device firmware upgrade utilities (mingw-w64)'
 arch=('any')
 license=('GPL2')
 url='http://dfu-util.sourceforge.net/'
-depends=("${MINGW_PACKAGE_PREFIX}-libusb")
+depends=("${MINGW_PACKAGE_PREFIX}-libusb"
+         "${MINGW_PACKAGE_PREFIX}-libwinpthread-git")
 source=("https://downloads.sourceforge.net/project/dfu-util/dfu-util-${pkgver}.tar.gz")
 sha256sums=('a03dc58dfc79c056819c0544b2a5970537566460102b3d82cfb038c60e619b42')
 
 build() {
     cd ${srcdir}/${_realname}-${pkgver}
-
     ./configure --prefix=${MINGW_PREFIX}
 }
 
 package() {
     cd ${srcdir}/${_realname}-${pkgver}
-
     make DESTDIR="$pkgdir" install
 }


### PR DESCRIPTION
Executing `dfu-util --help` fails if `*-libwinpthread-git` is not installed. See https://github.com/umarcor/MINGW-packages/runs/1509020890?check_suite_focus=true#step:4:73.

/cc @fauxpark