### PR TITLE
iverilog/deps: add bzip2, remove gcc-libs

### DIFF
--- a/mingw-w64-iverilog/PKGBUILD
+++ b/mingw-w64-iverilog/PKGBUILD
@@ -4,14 +4,14 @@ _realname=iverilog
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=12.0.r8793.96df23c5
-pkgrel=1
+pkgrel=2
 pkgdesc="Icarus Verilog, is a Verilog simulation and synthesis tool (mingw-w64)"
 arch=('any')
 url="http://iverilog.icarus.com/"
 license=('GPLv2+')
-depends=("${MINGW_PACKAGE_PREFIX}-readline"
+depends=("${MINGW_PACKAGE_PREFIX}-bzip2"
          "${MINGW_PACKAGE_PREFIX}-gcc"
-         "${MINGW_PACKAGE_PREFIX}-gcc-libs")
+         "${MINGW_PACKAGE_PREFIX}-readline")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-ghostscript"
              'git')


### PR DESCRIPTION
I got the test environment contaminated and I was mislead. This fixes iverilog's runtime deps.