### PR TITLE
ecpprog: add d654a4d

### DIFF
--- a/mingw-w64-ecpprog/PKGBUILD
+++ b/mingw-w64-ecpprog/PKGBUILD
@@ -1,0 +1,41 @@
+# Maintainer: umarcor <unai.martinezcorral@ehu.eus>
+
+_realname=ecpprog
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.0.r29.d654a4d
+pkgrel=1
+pkgdesc="ecpprog: basic driver for FTDI based JTAG probes, to program ECP5 FPGAs (mingw-w64)"
+arch=('any')
+url="https://github.com/gregdavill/ecpprog"
+license=('ISC')
+depends=("${MINGW_PACKAGE_PREFIX}-libftdi")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "git")
+
+_commit="d654a4d"
+source=("ecpprog::git://github.com/gregdavill/ecpprog#commit=${_commit}")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "${_realname}/${_realname}"
+  printf "0.0.r%s.%s" "$(git rev-list --count "${_commit}")" "$(git rev-parse --short "${_commit}")"
+}
+
+build() {
+  cd "${srcdir}/${_realname}/${_realname}"
+  make
+}
+
+check() {
+  "${srcdir}/${_realname}/${_realname}/${_realname}".exe --help
+}
+
+package() {
+  mkdir -p "${pkgdir}${MINGW_PREFIX}"/bin/
+  cp "${srcdir}/${_realname}/${_realname}/${_realname}".exe "${pkgdir}${MINGW_PREFIX}"/bin/
+
+  _licenses="${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
+  mkdir -p "${_licenses}"
+  install -m 644 "${srcdir}/${_realname}"/COPYING "${_licenses}"
+}


### PR DESCRIPTION
Replacement for #7349 with a different source fork (a user's, instead of some org's).