### PR TITLE
libiptcdata: Add package, for RawTherapee.

### DIFF
--- a/mingw-w64-libiptcdata/0001-libiptcdata-automake-remove-iptc-docs.patch
+++ b/mingw-w64-libiptcdata/0001-libiptcdata-automake-remove-iptc-docs.patch
@@ -1,0 +1,31 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -2,7 +2,7 @@
+ MAYBE_PYTHONLIB = python
+ endif
+ 
+-SUBDIRS = m4 libiptcdata po iptc docs win $(MAYBE_PYTHONLIB)
++SUBDIRS = m4 libiptcdata po win $(MAYBE_PYTHONLIB)
+ 
+ EXTRA_DIST = @PACKAGE@.spec
+ 
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -71,7 +71,7 @@
+ 	distdir dist dist-all distcheck
+ ETAGS = etags
+ CTAGS = ctags
+-DIST_SUBDIRS = m4 libiptcdata po iptc docs win python
++DIST_SUBDIRS = m4 libiptcdata po win python
+ DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
+ distdir = $(PACKAGE)-$(VERSION)
+ top_distdir = $(distdir)
+@@ -254,7 +254,7 @@
+ top_builddir = @top_builddir@
+ top_srcdir = @top_srcdir@
+ @PYTHONLIB_TRUE@MAYBE_PYTHONLIB = python
+-SUBDIRS = m4 libiptcdata po iptc docs win $(MAYBE_PYTHONLIB)
++SUBDIRS = m4 libiptcdata po win $(MAYBE_PYTHONLIB)
+ EXTRA_DIST = @PACKAGE@.spec
+ ACLOCAL_AMFLAGS = -I m4
+ DISTCHECK_CONFIGURE_FLAGS = --enable-gtk-doc

--- a/mingw-w64-libiptcdata/PKGBUILD
+++ b/mingw-w64-libiptcdata/PKGBUILD
@@ -1,0 +1,46 @@
+# Maintainer: Biswapriyo Nath <nathbappai@gmail.com>
+
+_realname=libiptcdata
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.0.4
+pkgrel=1
+pkgdesc="Library for manipulating the IPTC metadata (mingw-w64)"
+arch=('any')
+url="http://libiptcdata.sourceforge.net/"
+license=('GPL')
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+source=("https://downloads.sourceforge.net/sourceforge/libiptcdata/${_realname}-${pkgver}.tar.gz"
+        "0001-libiptcdata-automake-remove-iptc-docs.patch")
+sha512sums=('8656b2febaec133d1a8783252047672bebd58ae9ceab5477c4acfa35bcc381dfda08b655a957b962878af28c69deff77d920e780c84b4debdff2f980b3de94e8'
+            'c1375955a53343c8a00a6cb169b56d1e3582900a2fd823b64787c45b6a5764bdd3e21825128f7c75b32171f73499521aacf8aed1f3dbec5ec6b67f1dd6f2c382')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  # Source: https://rawpedia.rawtherapee.com/Windows#Download_and_build_libiptcdata
+  patch -Np1 -i "${srcdir}/0001-libiptcdata-automake-remove-iptc-docs.patch"
+}
+
+build() {
+  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
+
+  ../${_realname}-${pkgver}/configure \
+      --prefix=${MINGW_PREFIX} \
+      --build=${MINGW_CHOST} \
+      --host=${MINGW_CHOST}
+
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR="${pkgdir}" install
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/README" "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}/README"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}
+
+# vim:set ts=2 sw=2 et:


### PR DESCRIPTION
Found that to compile RawTherapee one has to first compile libiptcdata [here][1]. What if we can provide libiptcdata as a package? /cc @Beep6581 @Desmis

[1]: https://rawpedia.rawtherapee.com/Windows#Download_and_build_libiptcdata
