### PR TITLE
Fix the install path for CMake’s man pages

### DIFF
--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -5,7 +5,7 @@ _realname=cmake
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.19.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
 url="https://www.cmake.org/"
@@ -88,7 +88,7 @@ build() {
     --qt-gui                                      \
     --qt-qmake=${MINGW_PREFIX}/bin/qmake.exe      \
     --parallel=${NUMBER_OF_PROCESSORS}            \
-    --mandir=share                                \
+    --mandir=share/man                            \
     --docdir=share/doc/cmake                      \
     --sphinx-man --sphinx-html
   plain "Start building..."


### PR DESCRIPTION
I assume that this was an oversight, as `cmake` is the only package I have that seems to have installed anything directly in `/mingw64/share/man{1,7}` instead of `/mingw64/share/man/man*`.