### PR TITLE
parmetis: namespace the mtest binary to avoid conflict with tfel

### DIFF
--- a/mingw-w64-parmetis/PKGBUILD
+++ b/mingw-w64-parmetis/PKGBUILD
@@ -4,7 +4,7 @@ _realname=parmetis
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=4.0.3
-pkgrel=1
+pkgrel=2
 pkgdesc="Parallel Graph Partitioning and Fill-reducing Matrix Ordering (mingw-w64)"
 arch=('any')
 url='http://glaros.dtc.umn.edu/gkhome/views/parmetis'
@@ -77,4 +77,5 @@ package() {
   done
   
   mv ${pkgdir}${MINGW_PREFIX}/bin/ptest{,_parmetis}.exe
+  mv ${pkgdir}${MINGW_PREFIX}/bin/mtest{,_parmetis}.exe
 }


### PR DESCRIPTION
I don't know what the parmetis version does since it's broken.
So let's namespace for now.

Fixes #7220