### PR TITLE
Fix lldb's embedded PYTHONHOME

### DIFF
--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -33,7 +33,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-openmp"
          "${MINGW_PACKAGE_PREFIX}-polly")
 pkgver=11.0.0
-pkgrel=4
+pkgrel=5
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 url="https://llvm.org/"
@@ -289,6 +289,7 @@ build() {
     -DLLVM_POLLY_LINK_INTO_TOOLS=OFF \
     -DPython3_FIND_REGISTRY=NEVER \
     -DPython3_ROOT_DIR=${MINGW_PREFIX} \
+    -DLLDB_EMBED_PYTHON_HOME=OFF \
     "${extra_config[@]}" \
     ../llvm-${pkgver}.src
 


### PR DESCRIPTION
Fixes issue #7256 

lldb includes a hardcoded PYTHONHOME set to where python was during building. As can be seen in [lldb output here](https://github.com/msys2/MINGW-packages/issues/7256#issue-738833113) it was D:/a/_temp/msys/msys64/mingw32/bin.

This change makes the embedded path relative to liblldb.lldb - i.e. not absolute to the D:\ drive from build machine. Another option could be to use the build option to disable embedding the  #PYTHONHOME which is standard on non-windows targets.

As a side note: I think lldb's build scripts doesn't set this correctly. In the sys.path in the mentioned lldb output the /msys64/mingw32/bin/lib/python3.8 should rather be /msys64/mingw32/lib/python3.8. Maybe this matches the official python installer where python lib is in folder in same directory as python.exe.

I have not made commits in here before. Hope this one is ok :)