### PR TITLE
Update GnuCOBOL to 3.1.1

### DIFF
--- a/mingw-w64-gnucobol/PKGBUILD
+++ b/mingw-w64-gnucobol/PKGBUILD
@@ -6,8 +6,8 @@ _realname=gnucobol
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=3.1
-pkgver_real=3.1
-pkgrel=1
+pkgver_real=3.1.1
+pkgrel=2
 pkgdesc="GnuCOBOL, a free and modern COBOL compiler (mingw-w64)"
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-svn" "${MINGW_PACKAGE_PREFIX}-gnu-cobol-svn")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-svn" "${MINGW_PACKAGE_PREFIX}-gnu-cobol-svn")
@@ -37,12 +37,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-pkg-config")
 
 # local definitions
 #source=("https://alpha.gnu.org/gnu/${_realname}/${_realname}-${pkgver_real}.tar.xz"{,.sig}
-source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.xz"{,.sig}
+#source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver_real}.tar.xz"{,.sig}
+source=("https://ftpmirror.gnu.org/${_realname}/${_realname}-${pkgver_real}.tar.xz"{,.sig}
         "cobenv.sh" "cobenv.cmd"
 #FIXME deactivated for now as cobc.exe is not found during make test
 #       "https://www.itl.nist.gov/div897/ctg/suites/newcob.val.Z"
         )
-sha256sums=('28890804ADA74DEE1433B5C46F6774CE9740EDD2BA047443C3E634217FA0C21A'
+sha256sums=('C1B1D7DEAD3B141ED2F30102934E94B48D01845C79FCCF19110F34016970F423'
             SKIP
             'EEDFC170CFD6606527DD701C3CF6BBA2029C33CE694F697F8B7EE527B4ED7F1C'
             '225F7F6E17FC125AF6348028FDB86278C990BEAB07D230A158D9B9373CD58506'


### PR DESCRIPTION
additionally switched to GNU ftp mirror as the integrity of the package can be checked via signature

Note: using json-c would be possible `--with-json=json-c` if this would be preferable because of the number of uses. The test results are identical using that option...
