### PR TITLE
Update luarocks to version 3.4.0

### DIFF
--- a/mingw-w64-lua-luarocks/PKGBUILD
+++ b/mingw-w64-lua-luarocks/PKGBUILD
@@ -14,7 +14,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "unzip")
 options=('staticlibs' 'strip')
 source=("https://luarocks.org/releases/${_realname}-${pkgver}.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('62ce5826f0eeeb760d884ea8330cd1552b5d432138b8bade0fa72f35badd02d0')
 
 prepare() {
   plain 'No Step'
@@ -24,7 +24,7 @@ build() {
   cd "${srcdir}/${_realname}-${pkgver}"
   ./configure --prefix=${MINGW_PREFIX} --lua-version=5.3 --with-lua-interpreter=lua.exe
   make ./build/luarocks ./build/luarocks-admin ./build/config-5.3.lua
-  make LUA_VERSION=5.1 LUA_INTERPRETER=lua5.1.exe LUA_INCDIR=/usr/include/lua5.1 ./build/config-5.1.lua
+  make LUA_VERSION=5.1 LUA_INTERPRETER=lua5.1.exe LUA_INCDIR=${MINGW_PREFIX}/include/lua5.1 ./build/config-5.1.lua
 }
 
 package() {

--- a/mingw-w64-lua-luarocks/PKGBUILD
+++ b/mingw-w64-lua-luarocks/PKGBUILD
@@ -2,42 +2,33 @@
 
 _realname=luarocks
 pkgbase=mingw-w64-lua-${_realname}
-pkgname=("${MINGW_PACKAGE_PREFIX}-lua51-${_realname}")
-pkgver=2.4.4
-pkgrel=2
+pkgname=("${MINGW_PACKAGE_PREFIX}-lua-${_realname}")
+pkgver=3.4.0
+pkgrel=1
 pkgdesc="the package manager for Lua modules (mingw-w64)"
 arch=('any')
 url="https://luarocks.org"
 license=("MIT")
-install=luarocks-${CARCH}.install
-depends=("${MINGW_PACKAGE_PREFIX}-lua51")
+depends=("${MINGW_PACKAGE_PREFIX}-lua")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "unzip")
 options=('staticlibs' 'strip')
-source=("https://luarocks.org/releases/${_realname}-${pkgver}.tar.gz"
-        "mingw32-msys2.patch")
-sha256sums=('3938df33de33752ff2c526e604410af3dceb4b7ff06a770bc4a240de80a1f934'
-            '620d094f4f2fcf72a6c09699d84baa3f9a1a745f1cdf14e89d93375f5ad0998c')
+source=("https://luarocks.org/releases/${_realname}-${pkgver}.tar.gz")
+sha256sums=('SKIP')
 
 prepare() {
-  cd "${srcdir}/${_realname}-${pkgver}"
-  patch -p1 -i ${srcdir}/mingw32-msys2.patch
+  plain 'No Step'
 }
 
 build() {
-  #mkdir -p "build-${MINGW_CHOST}"
   cd "${srcdir}/${_realname}-${pkgver}"
-
-  ../${_realname}-${pkgver}/configure \
-    --prefix=${MINGW_PREFIX} \
-    --with-lua-include=${MINGW_PREFIX}/include/lua5.1 \
-    --lua-version=5.1 \
-    --lua-suffix=5.1.exe
-
-  make build
+  ./configure --prefix=${MINGW_PREFIX} --lua-version=5.3 --with-lua-interpreter=lua.exe
+  make ./build/luarocks ./build/luarocks-admin ./build/config-5.3.lua
+  make LUA_VERSION=5.1 LUA_INTERPRETER=lua5.1.exe LUA_INCDIR=/usr/include/lua5.1 ./build/config-5.1.lua
 }
 
 package() {
   cd "${srcdir}/${_realname}-${pkgver}"
   make DESTDIR="${pkgdir}" install
+  make DESTDIR="$pkgdir" LUA_VERSION=5.1 install-config
 }

--- a/mingw-w64-lua-luarocks/PKGBUILD
+++ b/mingw-w64-lua-luarocks/PKGBUILD
@@ -1,4 +1,5 @@
 # Maintainer: Ricky Wu <rickleaf.wu@gmail.com>
+# Contributor: ImperatorS79 <fevrier.simon@gmail.com>
 
 _realname=luarocks
 pkgbase=mingw-w64-lua-${_realname}


### PR DESCRIPTION
Should fix #7402 and #3434.

Arch-linux also add the following:
```
install -Dm644 luarocks.bash "$pkgdir/usr/share/bash-completion/completions/luarocks"
install -Dm644 luarocks.fish "$pkgdir/usr/share/fish/vendor_completions.d/luarocks.fish"
install -Dm644 luarocks.zsh "$pkgdir/usr/share/zsh/site-functions/_luarocks"
install -Dm644 luarocks-admin.bash "$pkgdir/usr/share/bash-completion/completions/luarocks-admin"
install -Dm644 luarocks-admin.fish "$pkgdir/usr/share/fish/vendor_completions.d/luarocks-admin.fish"
install -Dm644 luarocks-admin.zsh "$pkgdir/usr/share/zsh/site-functions/_luarocks-admin"
```
I have no idea what they are used for. Should I add them too ?