### PR TITLE
Openai dep updates

### DIFF
--- a/mingw-w64-python-cachetools/PKGBUILD
+++ b/mingw-w64-python-cachetools/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=cachetools
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=4.1.1
+pkgver=4.2.0
 pkgrel=1
 pkgdesc='Extensible memoizing collections and decorators (mingw-w64)'
 arch=('any')
@@ -13,7 +13,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-python")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest-runner")
 source=("${_realname}-$pkgver.tar.gz::https://github.com/tkem/cachetools/archive/v$pkgver.tar.gz")
-sha512sums=('c5d8a304defd0d9cd767b4e00f70c8df31067003afec43459db239d9c59c582fe6454c2956f5092e15b464bf53adf33a1214c1d03bd2dca610b112b9a63b7a06')
+sha256sums=('697b5040b30c5dbd403410bd9a15c66672f84761acea4d333853f334c6193291')
 
 prepare() {  
   cd "$srcdir"

--- a/mingw-w64-python-google-auth/PKGBUILD
+++ b/mingw-w64-python-google-auth/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=google-auth
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=1.23.0
+pkgver=1.24.0
 pkgrel=1
 pkgdesc='Google Authentication Library (mingw-w64)'
 arch=('any')
@@ -14,7 +14,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python-mock" "${MINGW_PACKAGE_PREFIX}-pyt
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!emptydirs')
 source=("${_realname}-$pkgver.tar.gz::https://github.com/GoogleCloudPlatform/google-auth-library-python/archive/v$pkgver.tar.gz")
-sha256sums=('f7b3aa2549ab0a5aa13741f325e900127ef76700aa97b11f3dac2759bd6cb9e8')
+sha256sums=('f37b9cdbe1ce503ff4472a45f9b3fbbe6724f64664573397ac7011b2b3fffbb5')
 
 prepare() {  
   cd "$srcdir"

--- a/mingw-w64-python-google-cloud-storage/PKGBUILD
+++ b/mingw-w64-python-google-cloud-storage/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=google-cloud-storage
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=1.33.0
+pkgver=1.34.0
 pkgrel=1
 pkgdesc='Google Cloud Storage API client library (mingw-w64)'
 arch=('any')
@@ -13,7 +13,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-python-google-cloud-core" "${MINGW_PACKAGE_PRE
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!emptydirs')
 source=("${_realname}-$pkgver.tar.gz::https://github.com/googleapis/python-storage/archive/v$pkgver.tar.gz")
-sha256sums=('b464acc68994d941a0307a8ed29b124490411a2ee68f84404396f9d52668b548')
+sha256sums=('d81b0e062ab5924bdcd3e67a324e06432979cc2827de055050b5bd34e52abdf2')
 
 prepare() {  
   cd "$srcdir"

--- a/mingw-w64-python-gsutil/PKGBUILD
+++ b/mingw-w64-python-gsutil/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gsutil
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=4.56
+pkgver=4.57
 pkgrel=1
 pkgdesc='A command line tool for interacting with cloud storage services. (mingw-w64)'
 arch=('any')
@@ -14,7 +14,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-monotonic>=1.4")
 options=('!emptydirs')
 source=("https://github.com/GoogleCloudPlatform/gsutil/archive/v$pkgver.tar.gz")
-sha256sums=('27cba55885f33fe62fb75710954c2a58edbc20f0ddc379ef300bb9d80fee1682')
+sha256sums=('9b8913c2fb498d80ab754774016fb4d5e9c5ac422ce8a01bcc41d463c752ce1c')
 
 prepare() {  
   cd "$srcdir"

--- a/mingw-w64-python-tifffile/PKGBUILD
+++ b/mingw-w64-python-tifffile/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=tifffile
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=2020.12.4
+pkgver=2020.12.8
 pkgrel=1
 pkgdesc='Read and write image data from and to TIFF files (mingw-w64)'
 arch=('any')
@@ -15,7 +15,7 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-python-imagecodecs: required only for encod
             "${MINGW_PACKAGE_PREFIX}-python-matplotlib: required only for plotting"
             "${MINGW_PACKAGE_PREFIX}-python-lxml: required only for validating and printing XML")
 source=("https://files.pythonhosted.org/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('5a388f8f3ca3f69a62f7c1cda72837fa5e9070e89992e7702408a786d526b3ff')
+sha256sums=('6c65c3997a21cad40349921e557a383fd5f0ebd728f5e91fa6c8f8f9e45c4bbd')
 
 prepare() {
   cd "$srcdir"


### PR DESCRIPTION
Updated:

- python-cachetools 4.2
- python-google-auth 1.24
- python-google-cloud-storage 1.34
- python-gsutil 4.57
- python-tifffile 2020.12.8