### PR TITLE
asciidoc: Install asciidoc.bat

### DIFF
--- a/mingw-w64-asciidoc/PKGBUILD
+++ b/mingw-w64-asciidoc/PKGBUILD
@@ -1,4 +1,5 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Konstantin Podsvirov <konstantin@podsvirov.pro>
 
 _realname=asciidoc
 pkgbase=mingw-w64-${_realname}
@@ -6,7 +7,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 conflicts=("${MINGW_PACKAGE_PREFIX}-asciidoc-py3-git")
 provides=("${MINGW_PACKAGE_PREFIX}-asciidoc-py3-git")
 pkgver=9.0.3
-pkgrel=1
+pkgrel=2
 pkgdesc="AsciiDoc is a text document format for writing notes, documentation, articles, books, ebooks, slideshows, web pages, man pages and blogs (mingw-w64)"
 arch=('any')
 url="https://github.com/asciidoc/asciidoc-py3"
@@ -17,9 +18,11 @@ depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-docbook-xsl")
 options=('staticlibs' 'strip')
 source=(https://github.com/asciidoc/asciidoc-py3/releases/download/${pkgver}/asciidoc-${pkgver}.tar.gz
-        0001-W32-confdir.mingw.patch)
+        0001-W32-confdir.mingw.patch
+        asciidoc.bat)
 sha256sums=('d99c8be8e8a9232742253c2d87c547b2efd4bbd3f0c1e23ef14898ad0fff77c4'
-            'e44d1f3a98ef7e06102323843054d7443d833f421bfba55382b961fa9e4691b2')
+            'e44d1f3a98ef7e06102323843054d7443d833f421bfba55382b961fa9e4691b2'
+            '526ef4f839b01f493539b27fa4cb538c130767b3b37e51037a8c0326938953d8')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -43,6 +46,8 @@ build() {
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   make DESTDIR="${pkgdir}" install
+
+  install -Dm644 "${srcdir}/asciidoc.bat" "${pkgdir}${MINGW_PREFIX}/bin/asciidoc.bat"
 
   install -Dm644 COPYRIGHT  ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYRIGHT
 }

--- a/mingw-w64-asciidoc/asciidoc.bat
+++ b/mingw-w64-asciidoc/asciidoc.bat
@@ -1,0 +1,2 @@
+@ECHO OFF
+@"%~dp0python3.exe" "%~dpn0" %*


### PR DESCRIPTION
It's allow to call `asciidoc` command from `cmd` or `subprocess.Popen(...)` via `python` like in [asciidoc reader](https://github.com/getpelican/pelican-plugins/blob/master/asciidoc_reader/asciidoc_reader.py#L20).