### PR TITLE
curl: update to 7.74.0

### DIFF
--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -13,13 +13,14 @@ fi
 _realname=curl
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}${_namesuff}"
-pkgver=7.73.0
+pkgver=7.74.0
 pkgrel=1
 pkgdesc="Command line tool and library for transferring data with URLs. (mingw-w64)"
 arch=('any')
 url="https://curl.haxx.se/"
 license=("MIT")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pkgconf")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-c-ares"
          "${MINGW_PACKAGE_PREFIX}-brotli"
@@ -28,6 +29,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libpsl"
          "${MINGW_PACKAGE_PREFIX}-libssh2"
          "${MINGW_PACKAGE_PREFIX}-zlib"
+         "${MINGW_PACKAGE_PREFIX}-zstd"
          $([[ "$_variant" == "-openssl" ]] && echo \
             "${MINGW_PACKAGE_PREFIX}-ca-certificates" \
             "${MINGW_PACKAGE_PREFIX}-openssl" \
@@ -46,7 +48,7 @@ source=("${url}/download/${_realname}-${pkgver}.tar.bz2"{,.asc}
         "0001-Make-cURL-relocatable.patch"
         "0002-nghttp2-static.patch"
         "0003-libpsl-static-libs.patch")
-sha256sums=('cf34fe0b07b800f1c01a499a6e8b2af548f6d0e044dca4a29d88a4bee146d131'
+sha256sums=('0f4d63e6681636539dc88fa8e929f934cd3a840c46e0bf28c73be11e521b77a5'
             'SKIP'
             'b00b4f0fb904941b5278807ebe581dfe89b237a6a2ff6a89e39c1ba368c8b96a'
             '79eec8a337e375d5102fef884030ceacd163a79e5c495e9a974a6b9a11b60c61'
@@ -114,6 +116,7 @@ build() {
     --with-ldap-lib=wldap32 \
     --with-libmetalink=${MINGW_PREFIX} \
     --with-libssh2 \
+    --with-zstd \
     "${_variant_config[@]}" \
     "${extra_config[@]}"
 # there's a bug with zsh completion generation script and Windows.


### PR DESCRIPTION
I disable the signature checks temporarily because of CI errors
It can be restored later if wanted