### PR TITLE
petsc: version bump

### DIFF
--- a/mingw-w64-petsc/PKGBUILD
+++ b/mingw-w64-petsc/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-${_real
 # The `petsc-build` package contains the distilled PETSc build tree
 # required at compile time by some packages (such as SLEPc).
 # Regular users should use the `petsc` package.
-pkgver=3.14.1
+pkgver=3.14.2
 pkgrel=1
 arch=('any')
 pkgdesc='Sparse iterative (non)linear solver package (mingw-w64)'
@@ -15,7 +15,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-openblas"
          "${MINGW_PACKAGE_PREFIX}-parmetis"
          "${MINGW_PACKAGE_PREFIX}-metis"
-         "${MINGW_PACKAGE_PREFIX}-scotch"
          "${MINGW_PACKAGE_PREFIX}-msmpi")
 makedepends=('python'
              "${MINGW_PACKAGE_PREFIX}-gcc"
@@ -26,7 +25,7 @@ url="https://www.mcs.anl.gov/petsc/"
 source=("http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/${_realname}-lite-${pkgver}.tar.gz"
         '0001-mpi-detection-override.patch')
 noextract=("${_realname}-lite-${pkgver}.tar.gz")
-sha256sums=('0b4681165a9af96594c794b97ac6993452ec902726679f6b50bb450f89d230ed'
+sha256sums=('87a04fd05cac20a2ec47094b7d18b96e0651257d8c768ced2ef7db270ecfb9cb'
             'a28912b086807df7381abaec28353023a148f17a594abb6a1478f3b7b434373b')
 
 prepare() {
@@ -50,9 +49,8 @@ _petsc() {
   desc=
   case $1 in
     ?m?)
-      opts="$opts --with-mpi=1 --with-mpi-compilers=1 --with-pthread=0 --with-openmp=0 --with-metis=1 --with-parmetis=1 --with-scotch=1 --with-ptscotch=1"
-      pc="$pc parmetis ptscotch msmpi"
-      ldflags="$ldflags -lptscotchparmetis"
+      opts="$opts --with-mpi=1 --with-mpi-compilers=1 --with-pthread=0 --with-openmp=0 --with-metis=1 --with-parmetis=1"
+      pc="$pc parmetis msmpi"
       ld=mpifort
       desc="MPI parallel"
     ;;
@@ -60,7 +58,7 @@ _petsc() {
       opts="$opts --with-mpi=0 --with-pthread=0 --with-openmp=1"
       iflags="$iflags -I\${includedir}/mpiuni"
       ldflags="-fopenmp $ldflags"
-      desc="OpenMP parallel"
+      desc="OpenMP multithreaded"
     ;;
     ?s?)
       opts="$opts --with-mpi=0 --with-pthread=0 --with-openmp=0"

--- a/mingw-w64-petsc/PKGBUILD
+++ b/mingw-w64-petsc/PKGBUILD
@@ -15,6 +15,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-openblas"
          "${MINGW_PACKAGE_PREFIX}-parmetis"
          "${MINGW_PACKAGE_PREFIX}-metis"
+         "${MINGW_PACKAGE_PREFIX}-hwloc"
          "${MINGW_PACKAGE_PREFIX}-msmpi")
 makedepends=('python'
              "${MINGW_PACKAGE_PREFIX}-gcc"
@@ -40,9 +41,9 @@ prepare() {
 builds='dso dto dmo zso zto zmo sso sto smo cso cto cmo'
 
 _petsc() {
-  opts="--with-single-library=0 --disable-shared --with-windows-graphics=0 --with-x=0 --with-openblas=1 --with-openblas-dir=$MINGW_PREFIX"
+  opts="--with-single-library=0 --disable-shared --with-windows-graphics=0 --with-x=0 --with-openblas=1 --with-hwloc=1 --with-openblas-dir=$MINGW_PREFIX"
   ld=gfortran
-  pc=openblas
+  pc="openblas hwloc"
   xflags=-msse # SSE support is required for proper FP trapping
   iflags=
   ldflags=


### PR DESCRIPTION
Added support for hwloc. In addition PT-Scotch gets disabled as it seems to conflict with ParMetis so these two partitioners are mutually exclusive.
