### PR TITLE
gdb: Fix array subscript when upper bound is unknown

### DIFF
--- a/mingw-w64-gdb/PKGBUILD
+++ b/mingw-w64-gdb/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-multiarch")
 pkgver=10.1
-pkgrel=1
+pkgrel=2
 pkgdesc="GNU Debugger (mingw-w64)"
 arch=('any')
 url="https://www.gnu.org/software/gdb/"
@@ -30,6 +30,7 @@ source=(https://ftp.gnu.org/gnu/gdb/${_realname}-${pkgver}.tar.xz{,.sig}
         'python-configure-path-fixes.patch'
         'gdb-fix-tui-with-pdcurses.patch'
         'gdb-lib-order.patch'
+        'gdb-fix-array.patch'
         'gdb-home-is-userprofile.patch')
 validpgpkeys=('F40ADB902B24264AA42E50BF92EDB04BFF325CF3')
 sha256sums=('f82f1eceeec14a3afa2de8d9b0d3c91d5a3820e23e0a01bbb70ef9f0276b62c0'
@@ -40,6 +41,7 @@ sha256sums=('f82f1eceeec14a3afa2de8d9b0d3c91d5a3820e23e0a01bbb70ef9f0276b62c0'
             '6378e1a96e3bedc2a160f0f6780cb973ce6139017f2786e7ab97f8bcd9824d27'
             '6d9b91ca2823207c77b587d6e16a56ca3db1a08bda3d7d09292a25ffe03fafe0'
             'ac38fca803d1626c858a0ebc046f9670547c36543eace767c73bc7b59313ea51'
+            '6db37fd357c3ec16ccd1dd7c22e3f3975f2b998be0497cc46db98850d2875957'
             '4c8f889202a1fa3ef684c96063ce7c0e949274a11998c7f95b45bb7032f15b4a')
 
 prepare() {
@@ -57,6 +59,7 @@ prepare() {
 
   patch -p1 -i ${srcdir}/gdb-fix-tui-with-pdcurses.patch
   patch -p1 -i ${srcdir}/gdb-lib-order.patch
+  patch -p1 -i ${srcdir}/gdb-fix-array.patch
   patch -p1 -i ${srcdir}/gdb-home-is-userprofile.patch
 
   # hack! - libiberty configure tests for header files using "$CPP $CPPFLAGS"

--- a/mingw-w64-gdb/gdb-fix-array.patch
+++ b/mingw-w64-gdb/gdb-fix-array.patch
@@ -1,0 +1,891 @@
+From 3d92ef6a5340bff8e706e916fbf34273bd4f9bea Mon Sep 17 00:00:00 2001
+From: Simon Marchi <simon.marchi@efficios.com>
+Date: Wed, 9 Dec 2020 13:51:45 -0500
+Subject: [PATCH] gdb: fix value_subscript when array upper bound is not known
+
+Since commit 7c6f27129631 ("gdb: make get_discrete_bounds check for
+non-constant range bounds"), subscripting  flexible array member fails:
+
+    struct no_size
+    {
+      int n;
+      int items[];
+    };
+
+    (gdb) p *ns
+    $1 = {n = 3, items = 0x5555555592a4}
+    (gdb) p ns->items[0]
+    Cannot access memory at address 0xfffe555b733a0164
+    (gdb) p *((int *) 0x5555555592a4)
+    $2 = 101  <--- we would expect that
+    (gdb) p &ns->items[0]
+    $3 = (int *) 0xfffe5559ee829a24  <--- wrong address
+
+Since the flexible array member (items) has an unspecified size, the array type
+created for it in the DWARF doesn't have dimensions (this is with gcc 9.3.0,
+Ubuntu 20.04):
+
+    0x000000a4:   DW_TAG_array_type
+                    DW_AT_type [DW_FORM_ref4]       (0x00000038 "int")
+                    DW_AT_sibling [DW_FORM_ref4]    (0x000000b3)
+
+    0x000000ad:     DW_TAG_subrange_type
+                      DW_AT_type [DW_FORM_ref4]     (0x00000031 "long unsigned int")
+
+This causes GDB to create a range type (TYPE_CODE_RANGE) with a defined
+constant low bound (dynamic_prop with kind PROP_CONST) and an undefined
+high bound (dynamic_prop with kind PROP_UNDEFINED).
+
+value_subscript gets both bounds of that range using
+get_discrete_bounds.  Before commit 7c6f27129631, get_discrete_bounds
+didn't check the kind of the dynamic_props and would just blindly read
+them as if they were PROP_CONST.  It would return 0 for the high bound,
+because we zero-initialize the range_bounds structure.  And it didn't
+really matter in this case, because the returned high bound wasn't used
+in the end.
+
+Commit 7c6f27129631 changed get_discrete_bounds to return a failure if
+either the low or high bound is not a constant, to make sure we don't
+read a dynamic prop that isn't a PROP_CONST as a PROP_CONST.  This
+change made get_discrete_bounds start to return a failure for that
+range, and as a result would not set *lowp and *highp.  And since
+value_subscript doesn't check get_discrete_bounds' return value, it just
+carries on an uses an uninitialized value for the low bound.  If
+value_subscript did check the return value of get_discrete_bounds, we
+would get an error message instead of a bogus value.  But it would still
+be a bug, as we wouldn't be able to print the flexible array member's
+elements.
+
+Looking at value_subscript, we see that the low bound is always needed,
+but the high bound is only needed if !c_style.  So, change
+value_subscript to use get_discrete_low_bound and
+get_discrete_high_bound separately.  This fixes the case described
+above, where the low bound is known but the high bound isn't (and is not
+needed).  This restores the original behavior without accessing a
+dynamic_prop in a wrong way.
+
+A test is added.  In addition to the case described above, a case with
+an array member of size 0 is added, which is a GNU C extension that
+existed before flexible array members were introduced.  That case
+currently fails when compiled with gcc <= 8.  gcc <= 8 produces DWARF
+similar to the one shown above, while gcc 9 adds a DW_AT_count of 0 in
+there, which makes the high bound known.  A case where an array member
+of size 0 is the only member of the struct is also added, as that was
+how PR 28675 was originally reported, and it's an interesting corner
+case that I think could trigger other funny bugs.
+
+Question about the implementation: in value_subscript, I made it such
+that if the low or high bound is unknown, we fall back to zero.  That
+effectively makes it the same as it was before 7c6f27129631.  But should
+we instead error() out?
+
+Change-Id: I832056f80e6c56f621f398b4780d55a3a1e299d7
+(cherry picked from commits f5fca0ec15660667b202e4c2873af4df480956ea,
+f47d1c255d21d7425b8a45c7a20979e9cb553ed8, bd1768de2174b4f22ccd7ea1c076e031c5835cce,
+138084b24811c191a85c919116d839a8bd89d57c and 969da52cb04effd49b937f5f1754e0f4b84809b7)
+---
+ gdb/ada-lang.c                                |  31 ++-
+ gdb/ada-valprint.c                            |   2 +-
+ gdb/c-lang.c                                  |   4 +-
+ gdb/eval.c                                    |   4 +-
+ gdb/gdbtypes.c                                | 228 ++++++++++++------
+ gdb/gdbtypes.h                                |  20 +-
+ gdb/m2-typeprint.c                            |   4 +-
+ gdb/m2-valprint.c                             |   6 +-
+ gdb/p-valprint.c                              |   3 +-
+ .../gdb.base/flexible-array-member.c          |  70 ++++++
+ .../gdb.base/flexible-array-member.exp        |  66 +++++
+ gdb/valarith.c                                |  24 +-
+ gdb/valops.c                                  |   4 +-
+ 13 files changed, 353 insertions(+), 113 deletions(-)
+ create mode 100644 gdb/testsuite/gdb.base/flexible-array-member.c
+ create mode 100644 gdb/testsuite/gdb.base/flexible-array-member.exp
+
+diff --git a/gdb/ada-lang.c b/gdb/ada-lang.c
+index f13866ed58f..e1d6c73c099 100644
+--- a/gdb/ada-lang.c
++++ b/gdb/ada-lang.c
+@@ -2097,7 +2097,7 @@ constrained_packed_array_type (struct type *type, long *elt_bits)
+ 
+   if ((check_typedef (index_type)->code () == TYPE_CODE_RANGE
+        && is_dynamic_type (check_typedef (index_type)))
+-      || get_discrete_bounds (index_type, &low_bound, &high_bound) < 0)
++      || !get_discrete_bounds (index_type, &low_bound, &high_bound))
+     low_bound = high_bound = 0;
+   if (high_bound < low_bound)
+     *elt_bits = TYPE_LENGTH (new_type) = 0;
+@@ -2243,7 +2243,7 @@ value_subscript_packed (struct value *arr, int arity, struct value **ind)
+           LONGEST lowerbound, upperbound;
+           LONGEST idx;
+ 
+-          if (get_discrete_bounds (range_type, &lowerbound, &upperbound) < 0)
++          if (!get_discrete_bounds (range_type, &lowerbound, &upperbound))
+             {
+               lim_warning (_("don't know bounds of array"));
+               lowerbound = upperbound = 0;
+@@ -2759,11 +2759,13 @@ ada_value_slice_from_ptr (struct value *array_ptr, struct type *type,
+ 			       type0->dyn_prop (DYN_PROP_BYTE_STRIDE),
+ 			       TYPE_FIELD_BITSIZE (type0, 0));
+   int base_low =  ada_discrete_type_low_bound (type0->index_type ());
+-  LONGEST base_low_pos, low_pos;
++  gdb::optional<LONGEST> base_low_pos, low_pos;
+   CORE_ADDR base;
+ 
+-  if (!discrete_position (base_index_type, low, &low_pos)
+-      || !discrete_position (base_index_type, base_low, &base_low_pos))
++  low_pos = discrete_position (base_index_type, low);
++  base_low_pos = discrete_position (base_index_type, base_low);
++
++  if (!low_pos.has_value () || !base_low_pos.has_value ())
+     {
+       warning (_("unable to get positions in slice, use bounds instead"));
+       low_pos = low;
+@@ -2771,7 +2773,7 @@ ada_value_slice_from_ptr (struct value *array_ptr, struct type *type,
+     }
+ 
+   base = value_as_address (array_ptr)
+-    + ((low_pos - base_low_pos)
++    + ((*low_pos - *base_low_pos)
+        * TYPE_LENGTH (TYPE_TARGET_TYPE (type0)));
+   return value_at_lazy (slice_type, base);
+ }
+@@ -2788,10 +2790,13 @@ ada_value_slice (struct value *array, int low, int high)
+ 			      (NULL, TYPE_TARGET_TYPE (type), index_type,
+ 			       type->dyn_prop (DYN_PROP_BYTE_STRIDE),
+ 			       TYPE_FIELD_BITSIZE (type, 0));
+-  LONGEST low_pos, high_pos;
++  gdb::optional<LONGEST> low_pos, high_pos;
++
+ 
+-  if (!discrete_position (base_index_type, low, &low_pos)
+-      || !discrete_position (base_index_type, high, &high_pos))
++  low_pos = discrete_position (base_index_type, low);
++  high_pos = discrete_position (base_index_type, high);
++
++  if (!low_pos.has_value () || !high_pos.has_value ())
+     {
+       warning (_("unable to get positions in slice, use bounds instead"));
+       low_pos = low;
+@@ -2799,7 +2804,7 @@ ada_value_slice (struct value *array, int low, int high)
+     }
+ 
+   return value_cast (slice_type,
+-		     value_slice (array, low, high_pos - low_pos + 1));
++		     value_slice (array, low, *high_pos - *low_pos + 1));
+ }
+ 
+ /* If type is a record type in the form of a standard GNAT array
+@@ -8861,15 +8866,15 @@ pos_atr (struct value *arg)
+ {
+   struct value *val = coerce_ref (arg);
+   struct type *type = value_type (val);
+-  LONGEST result;
+ 
+   if (!discrete_type_p (type))
+     error (_("'POS only defined on discrete types"));
+ 
+-  if (!discrete_position (type, value_as_long (val), &result))
++  gdb::optional<LONGEST> result = discrete_position (type, value_as_long (val));
++  if (!result.has_value ())
+     error (_("enumeration value is invalid: can't find 'POS"));
+ 
+-  return result;
++  return *result;
+ }
+ 
+ static struct value *
+diff --git a/gdb/ada-valprint.c b/gdb/ada-valprint.c
+index 6a5b7d3f37a..c2cb9920dd1 100644
+--- a/gdb/ada-valprint.c
++++ b/gdb/ada-valprint.c
+@@ -136,7 +136,7 @@ val_print_packed_array_elements (struct type *type, const gdb_byte *valaddr,
+   {
+     LONGEST high;
+ 
+-    if (get_discrete_bounds (index_type, &low, &high) < 0)
++    if (!get_discrete_bounds (index_type, &low, &high))
+       len = 1;
+     else if (low > high)
+       {
+diff --git a/gdb/c-lang.c b/gdb/c-lang.c
+index f29f2cef610..feb5ecacc15 100644
+--- a/gdb/c-lang.c
++++ b/gdb/c-lang.c
+@@ -698,8 +698,8 @@ evaluate_subexp_c (struct type *expect_type, struct expression *exp,
+ 		LONGEST low_bound, high_bound;
+ 		int element_size = TYPE_LENGTH (type);
+ 
+-		if (get_discrete_bounds (expect_type->index_type (),
+-					 &low_bound, &high_bound) < 0)
++		if (!get_discrete_bounds (expect_type->index_type (),
++					  &low_bound, &high_bound))
+ 		  {
+ 		    low_bound = 0;
+ 		    high_bound = (TYPE_LENGTH (expect_type) / element_size) - 1;
+diff --git a/gdb/eval.c b/gdb/eval.c
+index 51b51865f43..c0eb0822b91 100644
+--- a/gdb/eval.c
++++ b/gdb/eval.c
+@@ -1464,7 +1464,7 @@ evaluate_subexp_standard (struct type *expect_type,
+ 	  int element_size = TYPE_LENGTH (check_typedef (element_type));
+ 	  LONGEST low_bound, high_bound, index;
+ 
+-	  if (get_discrete_bounds (range_type, &low_bound, &high_bound) < 0)
++	  if (!get_discrete_bounds (range_type, &low_bound, &high_bound))
+ 	    {
+ 	      low_bound = 0;
+ 	      high_bound = (TYPE_LENGTH (type) / element_size) - 1;
+@@ -1517,7 +1517,7 @@ evaluate_subexp_standard (struct type *expect_type,
+ 		 || check_type->code () == TYPE_CODE_TYPEDEF)
+ 	    check_type = TYPE_TARGET_TYPE (check_type);
+ 
+-	  if (get_discrete_bounds (element_type, &low_bound, &high_bound) < 0)
++	  if (!get_discrete_bounds (element_type, &low_bound, &high_bound))
+ 	    error (_("(power)set type with unknown size"));
+ 	  memset (valaddr, '\0', TYPE_LENGTH (type));
+ 	  for (tem = 0; tem < nargs; tem++)
+diff --git a/gdb/gdbtypes.c b/gdb/gdbtypes.c
+index a40ae5f30eb..6c1cd08532e 100644
+--- a/gdb/gdbtypes.c
++++ b/gdb/gdbtypes.c
+@@ -1024,92 +1024,172 @@ has_static_range (const struct range_bounds *bounds)
+ 	  && bounds->stride.kind () == PROP_CONST);
+ }
+ 
++/* See gdbtypes.h.  */
+ 
+-/* Set *LOWP and *HIGHP to the lower and upper bounds of discrete type
+-   TYPE.
+-
+-   Return 1 if type is a range type with two defined, constant bounds.
+-   Else, return 0 if it is discrete (and bounds will fit in LONGEST).
+-   Else, return -1.  */
+-
+-int
+-get_discrete_bounds (struct type *type, LONGEST *lowp, LONGEST *highp)
++gdb::optional<LONGEST>
++get_discrete_low_bound (struct type *type)
+ {
+   type = check_typedef (type);
+   switch (type->code ())
+     {
+     case TYPE_CODE_RANGE:
+-      /* This function currently only works for ranges with two defined,
+-         constant bounds.  */
+-      if (type->bounds ()->low.kind () != PROP_CONST
+-	  || type->bounds ()->high.kind () != PROP_CONST)
+-	return -1;
++      {
++	/* This function only works for ranges with a constant low bound.  */
++	if (type->bounds ()->low.kind () != PROP_CONST)
++	  return {};
+ 
+-      *lowp = type->bounds ()->low.const_val ();
+-      *highp = type->bounds ()->high.const_val ();
++	LONGEST low = type->bounds ()->low.const_val ();
++
++	if (TYPE_TARGET_TYPE (type)->code () == TYPE_CODE_ENUM)
++	  {
++	    gdb::optional<LONGEST> low_pos
++	      = discrete_position (TYPE_TARGET_TYPE (type), low);
++
++	    if (low_pos.has_value ())
++	      low = *low_pos;
++	  }
++
++	return low;
++      }
+ 
+-      if (TYPE_TARGET_TYPE (type)->code () == TYPE_CODE_ENUM)
+-	{
+-	  if (!discrete_position (TYPE_TARGET_TYPE (type), *lowp, lowp)
+-	      || ! discrete_position (TYPE_TARGET_TYPE (type), *highp, highp))
+-	    return 0;
+-	}
+-      return 1;
+     case TYPE_CODE_ENUM:
+-      if (type->num_fields () > 0)
+-	{
+-	  /* The enums may not be sorted by value, so search all
+-	     entries.  */
+-	  int i;
++      {
++	if (type->num_fields () > 0)
++	  {
++	    /* The enums may not be sorted by value, so search all
++	       entries.  */
++	    LONGEST low = TYPE_FIELD_ENUMVAL (type, 0);
+ 
+-	  *lowp = *highp = TYPE_FIELD_ENUMVAL (type, 0);
+-	  for (i = 0; i < type->num_fields (); i++)
+-	    {
+-	      if (TYPE_FIELD_ENUMVAL (type, i) < *lowp)
+-		*lowp = TYPE_FIELD_ENUMVAL (type, i);
+-	      if (TYPE_FIELD_ENUMVAL (type, i) > *highp)
+-		*highp = TYPE_FIELD_ENUMVAL (type, i);
+-	    }
++	    for (int i = 0; i < type->num_fields (); i++)
++	      {
++		if (TYPE_FIELD_ENUMVAL (type, i) < low)
++		  low = TYPE_FIELD_ENUMVAL (type, i);
++	      }
+ 
+-	  /* Set unsigned indicator if warranted.  */
+-	  if (*lowp >= 0)
+-	    {
++	    /* Set unsigned indicator if warranted.  */
++	    if (low >= 0)
+ 	      TYPE_UNSIGNED (type) = 1;
+-	    }
+-	}
+-      else
+-	{
+-	  *lowp = 0;
+-	  *highp = -1;
+-	}
+-      return 0;
++
++	    return low;
++	  }
++	else
++	  return 0;
++      }
++
+     case TYPE_CODE_BOOL:
+-      *lowp = 0;
+-      *highp = 1;
+       return 0;
++
+     case TYPE_CODE_INT:
+       if (TYPE_LENGTH (type) > sizeof (LONGEST))	/* Too big */
+-	return -1;
++	return {};
++
++      if (!TYPE_UNSIGNED (type))
++	return -(1 << (TYPE_LENGTH (type) * TARGET_CHAR_BIT - 1));
++
++      /* fall through */
++    case TYPE_CODE_CHAR:
++      return 0;
++
++    default:
++      return {};
++    }
++}
++
++/* See gdbtypes.h.  */
++
++gdb::optional<LONGEST>
++get_discrete_high_bound (struct type *type)
++{
++  type = check_typedef (type);
++  switch (type->code ())
++    {
++    case TYPE_CODE_RANGE:
++      {
++	/* This function only works for ranges with a constant high bound.  */
++	if (type->bounds ()->high.kind () != PROP_CONST)
++	  return {};
++
++	LONGEST high = type->bounds ()->high.const_val ();
++
++	if (TYPE_TARGET_TYPE (type)->code () == TYPE_CODE_ENUM)
++	  {
++	    gdb::optional<LONGEST> high_pos
++	      = discrete_position (TYPE_TARGET_TYPE (type), high);
++
++	    if (high_pos.has_value ())
++	      high = *high_pos;
++	  }
++
++	return high;
++      }
++
++    case TYPE_CODE_ENUM:
++      {
++	if (type->num_fields () > 0)
++	  {
++	    /* The enums may not be sorted by value, so search all
++	       entries.  */
++	    LONGEST high = TYPE_FIELD_ENUMVAL (type, 0);
++
++	    for (int i = 0; i < type->num_fields (); i++)
++	      {
++		if (TYPE_FIELD_ENUMVAL (type, i) > high)
++		  high = TYPE_FIELD_ENUMVAL (type, i);
++	      }
++
++	    return high;
++	  }
++	else
++	  return -1;
++      }
++
++    case TYPE_CODE_BOOL:
++      return 1;
++
++    case TYPE_CODE_INT:
++      if (TYPE_LENGTH (type) > sizeof (LONGEST))	/* Too big */
++	return {};
++
+       if (!TYPE_UNSIGNED (type))
+ 	{
+-	  *lowp = -(1 << (TYPE_LENGTH (type) * TARGET_CHAR_BIT - 1));
+-	  *highp = -*lowp - 1;
+-	  return 0;
++	  LONGEST low = -(1 << (TYPE_LENGTH (type) * TARGET_CHAR_BIT - 1));
++	  return -low - 1;
+ 	}
++
+       /* fall through */
+     case TYPE_CODE_CHAR:
+-      *lowp = 0;
+-      /* This round-about calculation is to avoid shifting by
+-         TYPE_LENGTH (type) * TARGET_CHAR_BIT, which will not work
+-         if TYPE_LENGTH (type) == sizeof (LONGEST).  */
+-      *highp = 1 << (TYPE_LENGTH (type) * TARGET_CHAR_BIT - 1);
+-      *highp = (*highp - 1) | *highp;
+-      return 0;
++      {
++	/* This round-about calculation is to avoid shifting by
++	   TYPE_LENGTH (type) * TARGET_CHAR_BIT, which will not work
++	   if TYPE_LENGTH (type) == sizeof (LONGEST).  */
++	LONGEST high = 1 << (TYPE_LENGTH (type) * TARGET_CHAR_BIT - 1);
++	return (high - 1) | high;
++      }
++
+     default:
+-      return -1;
++      return {};
+     }
+ }
+ 
++/* See gdbtypes.h.  */
++
++bool
++get_discrete_bounds (struct type *type, LONGEST *lowp, LONGEST *highp)
++{
++  gdb::optional<LONGEST> low = get_discrete_low_bound (type);
++  if (!low.has_value ())
++    return false;
++
++  gdb::optional<LONGEST> high = get_discrete_high_bound (type);
++  if (!high.has_value ())
++    return false;
++
++  *lowp = *low;
++  *highp = *high;
++
++  return true;
++}
++
+ /* Assuming TYPE is a simple, non-empty array type, compute its upper
+    and lower bound.  Save the low bound into LOW_BOUND if not NULL.
+    Save the high bound into HIGH_BOUND if not NULL.
+@@ -1123,13 +1203,11 @@ get_array_bounds (struct type *type, LONGEST *low_bound, LONGEST *high_bound)
+   struct type *index = type->index_type ();
+   LONGEST low = 0;
+   LONGEST high = 0;
+-  int res;
+ 
+   if (index == NULL)
+     return 0;
+ 
+-  res = get_discrete_bounds (index, &low, &high);
+-  if (res == -1)
++  if (!get_discrete_bounds (index, &low, &high))
+     return 0;
+ 
+   if (low_bound)
+@@ -1155,8 +1233,8 @@ get_array_bounds (struct type *type, LONGEST *low_bound, LONGEST *high_bound)
+    in which case the value of POS is unmodified.
+ */
+ 
+-int
+-discrete_position (struct type *type, LONGEST val, LONGEST *pos)
++gdb::optional<LONGEST>
++discrete_position (struct type *type, LONGEST val)
+ {
+   if (type->code () == TYPE_CODE_RANGE)
+     type = TYPE_TARGET_TYPE (type);
+@@ -1168,19 +1246,13 @@ discrete_position (struct type *type, LONGEST val, LONGEST *pos)
+       for (i = 0; i < type->num_fields (); i += 1)
+         {
+           if (val == TYPE_FIELD_ENUMVAL (type, i))
+-	    {
+-	      *pos = i;
+-	      return 1;
+-	    }
++	    return i;
+         }
+       /* Invalid enumeration value.  */
+-      return 0;
++      return {};
+     }
+   else
+-    {
+-      *pos = val;
+-      return 1;
+-    }
++    return val;
+ }
+ 
+ /* If the array TYPE has static bounds calculate and update its
+@@ -1211,8 +1283,9 @@ update_static_array_size (struct type *type)
+       if (stride == 0)
+ 	stride = range_type->bit_stride ();
+ 
+-      if (get_discrete_bounds (range_type, &low_bound, &high_bound) < 0)
++      if (!get_discrete_bounds (range_type, &low_bound, &high_bound))
+ 	low_bound = high_bound = 0;
++
+       element_type = check_typedef (TYPE_TARGET_TYPE (type));
+       /* Be careful when setting the array length.  Ada arrays can be
+ 	 empty arrays with the high_bound being smaller than the low_bound.
+@@ -1394,8 +1467,9 @@ create_set_type (struct type *result_type, struct type *domain_type)
+     {
+       LONGEST low_bound, high_bound, bit_length;
+ 
+-      if (get_discrete_bounds (domain_type, &low_bound, &high_bound) < 0)
++      if (!get_discrete_bounds (domain_type, &low_bound, &high_bound))
+ 	low_bound = high_bound = 0;
++
+       bit_length = high_bound - low_bound + 1;
+       TYPE_LENGTH (result_type)
+ 	= (bit_length + TARGET_CHAR_BIT - 1) / TARGET_CHAR_BIT;
+diff --git a/gdb/gdbtypes.h b/gdb/gdbtypes.h
+index 9c2059d40c0..119e0509e87 100644
+--- a/gdb/gdbtypes.h
++++ b/gdb/gdbtypes.h
+@@ -46,6 +46,7 @@
+ 
+ #include "hashtab.h"
+ #include "gdbsupport/array-view.h"
++#include "gdbsupport/gdb_optional.h"
+ #include "gdbsupport/offset-type.h"
+ #include "gdbsupport/enum-flags.h"
+ #include "gdbsupport/underlying.h"
+@@ -2261,12 +2262,27 @@ extern struct type *lookup_template_type (const char *, struct type *,
+ 
+ extern int get_vptr_fieldno (struct type *, struct type **);
+ 
+-extern int get_discrete_bounds (struct type *, LONGEST *, LONGEST *);
++/* Set *LOWP and *HIGHP to the lower and upper bounds of discrete type
++   TYPE.
++
++   Return true if the two bounds are available, false otherwise.  */
++
++extern bool get_discrete_bounds (struct type *type, LONGEST *lowp,
++				 LONGEST *highp);
++
++/* If TYPE's low bound is a known constant, return it, else return nullopt.  */
++
++extern gdb::optional<LONGEST> get_discrete_low_bound (struct type *type);
++
++/* If TYPE's high bound is a known constant, return it, else return nullopt.  */
++
++extern gdb::optional<LONGEST> get_discrete_high_bound (struct type *type);
+ 
+ extern int get_array_bounds (struct type *type, LONGEST *low_bound,
+ 			     LONGEST *high_bound);
+ 
+-extern int discrete_position (struct type *type, LONGEST val, LONGEST *pos);
++extern gdb::optional<LONGEST> discrete_position (struct type *type,
++						 LONGEST val);
+ 
+ extern int class_types_same_p (const struct type *, const struct type *);
+ 
+diff --git a/gdb/m2-typeprint.c b/gdb/m2-typeprint.c
+index 521d9260322..184d2e366d9 100644
+--- a/gdb/m2-typeprint.c
++++ b/gdb/m2-typeprint.c
+@@ -372,7 +372,7 @@ m2_is_long_set (struct type *type)
+                             This should be integrated into gdbtypes.c
+                             inside get_discrete_bounds.  */
+ 
+-static int
++static bool
+ m2_get_discrete_bounds (struct type *type, LONGEST *lowp, LONGEST *highp)
+ {
+   type = check_typedef (type);
+@@ -419,7 +419,7 @@ m2_is_long_set_of_type (struct type *type, struct type **of_type)
+       l1 = type->field (i).type ()->bounds ()->low.const_val ();
+       h1 = type->field (len - 1).type ()->bounds ()->high.const_val ();
+       *of_type = target;
+-      if (m2_get_discrete_bounds (target, &l2, &h2) >= 0)
++      if (m2_get_discrete_bounds (target, &l2, &h2))
+ 	return (l1 == l2 && h1 == h2);
+       error (_("long_set failed to find discrete bounds for its subtype"));
+       return 0;
+diff --git a/gdb/m2-valprint.c b/gdb/m2-valprint.c
+index b0a3ce3ec3e..a798a902717 100644
+--- a/gdb/m2-valprint.c
++++ b/gdb/m2-valprint.c
+@@ -97,7 +97,7 @@ m2_print_long_set (struct type *type, const gdb_byte *valaddr,
+ 
+   target = TYPE_TARGET_TYPE (range);
+ 
+-  if (get_discrete_bounds (range, &field_low, &field_high) >= 0)
++  if (get_discrete_bounds (range, &field_low, &field_high))
+     {
+       for (i = low_bound; i <= high_bound; i++)
+ 	{
+@@ -137,7 +137,7 @@ m2_print_long_set (struct type *type, const gdb_byte *valaddr,
+ 	      if (field == len)
+ 		break;
+ 	      range = type->field (field).type ()->index_type ();
+-	      if (get_discrete_bounds (range, &field_low, &field_high) < 0)
++	      if (!get_discrete_bounds (range, &field_low, &field_high))
+ 		break;
+ 	      target = TYPE_TARGET_TYPE (range);
+ 	    }
+@@ -398,7 +398,7 @@ m2_value_print_inner (struct value *val, struct ui_file *stream, int recurse,
+ 
+ 	  fputs_filtered ("{", stream);
+ 
+-	  i = get_discrete_bounds (range, &low_bound, &high_bound);
++	  i = get_discrete_bounds (range, &low_bound, &high_bound) ? 0 : -1;
+ 	maybe_bad_bstring:
+ 	  if (i < 0)
+ 	    {
+diff --git a/gdb/p-valprint.c b/gdb/p-valprint.c
+index c98f3c5bf73..d3d9ca1c6d5 100644
+--- a/gdb/p-valprint.c
++++ b/gdb/p-valprint.c
+@@ -343,7 +343,8 @@ pascal_value_print_inner (struct value *val, struct ui_file *stream,
+ 
+ 	  fputs_filtered ("[", stream);
+ 
+-	  int bound_info = get_discrete_bounds (range, &low_bound, &high_bound);
++	  int bound_info = (get_discrete_bounds (range, &low_bound, &high_bound)
++			    ? 0 : -1);
+ 	  if (low_bound == 0 && high_bound == -1 && TYPE_LENGTH (type) > 0)
+ 	    {
+ 	      /* If we know the size of the set type, we can figure out the
+diff --git a/gdb/testsuite/gdb.base/flexible-array-member.c b/gdb/testsuite/gdb.base/flexible-array-member.c
+new file mode 100644
+index 00000000000..1d8bb06b514
+--- /dev/null
++++ b/gdb/testsuite/gdb.base/flexible-array-member.c
+@@ -0,0 +1,70 @@
++/* This testcase is part of GDB, the GNU debugger.
++
++   Copyright 2020 Free Software Foundation, Inc.
++
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3 of the License, or
++   (at your option) any later version.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
++
++#include <stdlib.h>
++
++struct no_size
++{
++  int n;
++  int items[];
++};
++
++struct zero_size
++{
++  int n;
++  int items[0];
++};
++
++struct zero_size_only
++{
++  int items[0];
++};
++
++struct no_size *ns;
++struct zero_size *zs;
++struct zero_size_only *zso;
++
++static void
++break_here (void)
++{
++}
++
++int
++main (void)
++{
++  ns = (struct no_size *) malloc (sizeof (*ns) + 3 * sizeof (int));
++  zs = (struct zero_size *) malloc (sizeof (*zs) + 3 * sizeof (int));
++  zso = (struct zero_size_only *) malloc (sizeof (*zso) + 3 * sizeof (int));
++
++  ns->n = 3;
++  ns->items[0] = 101;
++  ns->items[1] = 102;
++  ns->items[2] = 103;
++
++  zs->n = 3;
++  zs->items[0] = 201;
++  zs->items[1] = 202;
++  zs->items[2] = 203;
++
++  zso->items[0] = 301;
++  zso->items[1] = 302;
++  zso->items[2] = 303;
++
++  break_here ();
++
++  return 0;
++}
+diff --git a/gdb/testsuite/gdb.base/flexible-array-member.exp b/gdb/testsuite/gdb.base/flexible-array-member.exp
+new file mode 100644
+index 00000000000..973a248c5b6
+--- /dev/null
++++ b/gdb/testsuite/gdb.base/flexible-array-member.exp
+@@ -0,0 +1,66 @@
++# Copyright 2020 Free Software Foundation, Inc.
++
++# This program is free software; you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation; either version 3 of the License, or
++# (at your option) any later version.
++#
++# This program is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++#
++# You should have received a copy of the GNU General Public License
++# along with this program.  If not, see <http://www.gnu.org/licenses/>.
++
++# Test printing and subscripting flexible array members.
++
++standard_testfile
++
++if { [prepare_for_testing "failed to prepare" \
++	${testfile} ${srcfile}] } {
++    return
++}
++
++if { ![runto break_here] } {
++    untested "could not run to break_here"
++    return
++}
++
++# The various cases are:
++#
++#  - ns: flexible array member with no size
++#  - zs: flexible array member with size 0 (GNU C extension that predates the
++#    standardization of the feature, but widely supported)
++#  - zso: zero-size only, a corner case where the array is the sole member of
++#    the structure
++
++# Print the whole structure.
++
++gdb_test "print *ns" " = {n = 3, items = $hex}"
++gdb_test "print *zs" " = {n = 3, items = $hex}"
++gdb_test "print *zso" " = {items = $hex}"
++
++# Print all items.
++
++gdb_test "print ns->items\[0\]" " = 101"
++gdb_test "print ns->items\[1\]" " = 102"
++gdb_test "print ns->items\[2\]" " = 103"
++
++gdb_test "print zs->items\[0\]" " = 201"
++gdb_test "print zs->items\[1\]" " = 202"
++gdb_test "print zs->items\[2\]" " = 203"
++
++gdb_test "print zso->items\[0\]" " = 301"
++gdb_test "print zso->items\[1\]" " = 302"
++gdb_test "print zso->items\[2\]" " = 303"
++
++# Check taking the address of array elements (how PR 28675 was originally
++# reported).
++
++gdb_test "print ns->items == &ns->items\[0\]" " = 1"
++gdb_test "print ns->items + 1 == &ns->items\[1\]" " = 1"
++gdb_test "print zs->items == &zs->items\[0\]" " = 1"
++gdb_test "print zs->items + 1 == &zs->items\[1\]" " = 1"
++gdb_test "print zso->items == &zso->items\[0\]" " = 1"
++gdb_test "print zso->items + 1 == &zso->items\[1\]" " = 1"
+diff --git a/gdb/valarith.c b/gdb/valarith.c
+index 0221bc6e939..dfd3ac19436 100644
+--- a/gdb/valarith.c
++++ b/gdb/valarith.c
+@@ -150,25 +150,33 @@ value_subscript (struct value *array, LONGEST index)
+       || tarray->code () == TYPE_CODE_STRING)
+     {
+       struct type *range_type = tarray->index_type ();
+-      LONGEST lowerbound, upperbound;
++      gdb::optional<LONGEST> lowerbound = get_discrete_low_bound (range_type);
++      if (!lowerbound.has_value ())
++	lowerbound = 0;
+ 
+-      get_discrete_bounds (range_type, &lowerbound, &upperbound);
+       if (VALUE_LVAL (array) != lval_memory)
+-	return value_subscripted_rvalue (array, index, lowerbound);
++	return value_subscripted_rvalue (array, index, *lowerbound);
+ 
+       if (c_style == 0)
+ 	{
+-	  if (index >= lowerbound && index <= upperbound)
+-	    return value_subscripted_rvalue (array, index, lowerbound);
++	  gdb::optional<LONGEST> upperbound
++	    = get_discrete_high_bound (range_type);
++
++	  if (!upperbound.has_value ())
++	    upperbound = 0;
++
++	  if (index >= *lowerbound && index <= *upperbound)
++	    return value_subscripted_rvalue (array, index, *lowerbound);
++
+ 	  /* Emit warning unless we have an array of unknown size.
+ 	     An array of unknown size has lowerbound 0 and upperbound -1.  */
+-	  if (upperbound > -1)
++	  if (*upperbound > -1)
+ 	    warning (_("array or string index out of range"));
+ 	  /* fall doing C stuff */
+ 	  c_style = 1;
+ 	}
+ 
+-      index -= lowerbound;
++      index -= *lowerbound;
+       array = value_coerce_array (array);
+     }
+ 
+@@ -1873,7 +1881,7 @@ value_bit_index (struct type *type, const gdb_byte *valaddr, int index)
+   unsigned rel_index;
+   struct type *range = type->index_type ();
+ 
+-  if (get_discrete_bounds (range, &low_bound, &high_bound) < 0)
++  if (!get_discrete_bounds (range, &low_bound, &high_bound))
+     return -2;
+   if (index < low_bound || index > high_bound)
+     return -1;
+diff --git a/gdb/valops.c b/gdb/valops.c
+index 0eb2b096211..c53a96406fb 100644
+--- a/gdb/valops.c
++++ b/gdb/valops.c
+@@ -394,7 +394,7 @@ value_cast (struct type *type, struct value *arg2)
+ 	  int val_length = TYPE_LENGTH (type2);
+ 	  LONGEST low_bound, high_bound, new_length;
+ 
+-	  if (get_discrete_bounds (range_type, &low_bound, &high_bound) < 0)
++	  if (!get_discrete_bounds (range_type, &low_bound, &high_bound))
+ 	    low_bound = 0, high_bound = 0;
+ 	  new_length = val_length / element_length;
+ 	  if (val_length % element_length != 0)
+@@ -3773,7 +3773,7 @@ value_slice (struct value *array, int lowbound, int length)
+     error (_("array not associated"));
+ 
+   range_type = array_type->index_type ();
+-  if (get_discrete_bounds (range_type, &lowerbound, &upperbound) < 0)
++  if (!get_discrete_bounds (range_type, &lowerbound, &upperbound))
+     error (_("slice from bad array or bitstring"));
+ 
+   if (lowbound < lowerbound || length < 0
+-- 
+2.29.2.windows.1
+


### PR DESCRIPTION
Backport fix from gdb-10-branch.