### PR TITLE
python-ldap3: Add pyasn1 to depends

### DIFF
--- a/mingw-w64-python-ldap3/PKGBUILD
+++ b/mingw-w64-python-ldap3/PKGBUILD
@@ -7,12 +7,13 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=2.7
-pkgrel=1
+pkgrel=2
 pkgdesc="a strictly RFC 4510 conforming LDAP V3 pure Python client (mingw-w64)"
 arch=('any')
 url='https://github.com/cannatag/ldap3'
 license=('LICENSE')
-depends=("${MINGW_PACKAGE_PREFIX}-python")
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-pyasn1")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('staticlibs' 'strip' '!debug')
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/cannatag/ldap3/archive/v${pkgver}.tar.gz")


### PR DESCRIPTION
Without this dependency, I get the error:

```python
import ldap3
Traceback (most recent call last):
...
    from pyasn1.type.univ import OctetString, Integer, Sequence, Choice, SequenceOf, Boolean, Null, Enumerated, SetOf
ModuleNotFoundError: No module named 'pyasn1'
```