### PR TITLE
msmpi: FORTRAN90's .mod files, test suite

### DIFF
--- a/mingw-w64-msmpi/PKGBUILD
+++ b/mingw-w64-msmpi/PKGBUILD
@@ -4,13 +4,14 @@ _realname=msmpi
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=10.1.1
-pkgrel=3
+pkgrel=4
 pkgdesc="Microsoft MPI SDK (mingw-w64)"
 arch=('any')
 url="https://docs.microsoft.com/en-us/message-passing-interface/microsoft-mpi"
 license=('MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-binutils")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-gcc-fortran")
+optdepends=("${MINGW_PACKAGE_PREFIX}-tcl: build & run test suite")
 options=('strip')
 source=(
   'mpi.c'
@@ -21,6 +22,13 @@ source=(
   'mpifptr.h.i686'
   'msmpi.def.x86_64'
   'msmpi.def.i686'
+  'hello_mpi.c'
+  'hello_mpi.cpp'
+  'hello_mpi.F'
+  'hello_mpi.f90'
+  'all.tcl'
+  'tclbuildtest.tcl'
+  'msmpi.test'
 )
 sha256sums=('8284306d3d86a29904ce55b6a91a982470b0648821da0a563a34977a542e30e4'
             'baee3f18f38650e7182956baa0d3d8f8e5c26d8603ccee4871a4dbd160c13660'
@@ -29,7 +37,14 @@ sha256sums=('8284306d3d86a29904ce55b6a91a982470b0648821da0a563a34977a542e30e4'
             '031f910c6ce9a0f7bf66365dd4271fa36530f32c5d22755b10ef2d89dc605e1f'
             '4ff6e817fe7517f04f0ca04a038e4c136264384d36f520b79995604e3986fce4'
             'fd18184993872fc4eaea825e85f974dca4b020598d838c424c6c112c2328cf2a'
-            '7b8ed9d3e257e439678cc648164164d6817f7fde68530055b392f67d97bf8ec8')
+            '7b8ed9d3e257e439678cc648164164d6817f7fde68530055b392f67d97bf8ec8'
+            'ea8203492942fa900c4946741ad88af8957c4d058e06eb618ffae0e5e967b71b'
+            '9483053c0f3ce15d850f69565f2b4e53630cee75073c27432cd08ecc596a57d9'
+            'c9f63c1ca20f8ebfe26ad455342f34c27bc1a1a83778240388e9f18b26c2e889'
+            '8cb47bb77451dbe2703f7f28eef422e55e7a33a28977bf13bbd11d305aeef61e'
+            'ec5072630e1c0309fe383669e9187790cd135a393c67bc4bc35cf60b0ba396ff'
+            '15c7af25b91406d5fe5f26cfe00963b6cfde1c3dd466eb25f1b6fae299934966'
+            '773d406e05340b3b96326ddd04f43fea3df3ca30912412824a976a18a86fc007')
 
 
 build() {
@@ -50,11 +65,16 @@ build() {
   gcc ${cflags} -o bin/mpifort.exe -DFC "${mpic}"
   cp bin/mpifort.exe bin/mpif77.exe
   cp bin/mpifort.exe bin/mpif90.exe
+  # FORTRAN90 MPI modules
+  bin/mpifort -c -Jinclude ${srcdir}/mpi.f90
+  rm mpi.o
 }
 
 package() {
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" "${pkgdir}${MINGW_PREFIX}/share/test/msmpi"
+  cd ${srcdir}
+  cp {all,tclbuildtest}.tcl hello_mpi.{c,cpp,F,f90} msmpi.test "${pkgdir}${MINGW_PREFIX}/share/test/msmpi"
   cd "${srcdir}/build-${CARCH}"
-  mkdir -p "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig"
   cp -r * "${pkgdir}${MINGW_PREFIX}"
   echo "
     prefix=${MINGW_PREFIX}
@@ -67,4 +87,5 @@ package() {
     Cflags: -I\${includedir}
     Libs: -L\${libdir} -l${_realname}
   " | sed '/^\s*$/d;s/^\s*//' > "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/${_realname}.pc"
+
 }

--- a/mingw-w64-msmpi/all.tcl
+++ b/mingw-w64-msmpi/all.tcl
@@ -1,0 +1,7 @@
+# Template {all.tcl} file which is to be put into each test module's directory.
+# Either [source] the bundled {tclbuildtest.tcl} to force load the specific code or
+# alter the $auto_path list to add location of {pkgIndex.tcl,tclbuildtest.tcl}.
+# The same scheme is to be applied to all .test files.
+source [file join [file dirname [file normalize [info script]]] tclbuildtest.tcl]
+package require tclbuildtest
+::tclbuildtest::suite {*}$::argv

--- a/mingw-w64-msmpi/hello_mpi.F
+++ b/mingw-w64-msmpi/hello_mpi.F
@@ -1,0 +1,180 @@
+      program main
+
+c*********************************************************************72
+c
+cc MAIN is the main program for HELLO_MPI.
+c
+c  Discussion:
+c
+c    HELLO is a simple MPI test program.
+c
+c    Each process prints out a "Hello, world!" message.
+c
+c    The master process also prints out a short message.
+c
+c  Licensing:
+c
+c    This code is distributed under the GNU LGPL license. 
+c
+c  Modified:
+c
+c    30 October 2008
+c
+c  Author:
+c
+c    John Burkardt
+c
+c  Reference:
+c
+c    William Gropp, Ewing Lusk, Anthony Skjellum,
+c    Using MPI: Portable Parallel Programming with the
+c    Message-Passing Interface,
+c    Second Edition,
+c    MIT Press, 1999,
+c    ISBN: 0262571323,
+c    LC: QA76.642.G76.
+c
+
+c
+c  Define MPI symbols:
+c
+      include 'mpif.h'
+c
+c implicit none
+c
+      integer error
+      integer id
+      integer p
+      double precision wtime
+c
+c  Initialize MPI.
+c
+      call MPI_Init ( error )
+c
+c  Get the number of processes.
+c
+      call MPI_Comm_size ( MPI_COMM_WORLD, p, error )
+c
+c  Get the individual process ID.
+c
+      call MPI_Comm_rank ( MPI_COMM_WORLD, id, error )
+c
+c  Print a message.
+c
+      if ( id .eq. 0 ) then
+        call timestamp ( )
+        write ( *, '(a)' ) ' '
+        write ( *, '(a)' ) 'HELLO_MPI - Master process:'
+        write ( *, '(a)' ) '  FORTRAN77/MPI version'
+        write ( *, '(a)' ) '  A simple MPI program.'
+        write ( *, '(a)' ) ' '
+        write ( *, '(a,i3)' ) '  The number of processes is ', p
+        write ( *, '(a)' ) ' '
+      end if
+
+      if ( id .eq. 0 ) then
+        wtime = MPI_Wtime ( )
+      end if
+
+      write ( *, '(a,i3,a)' ) '  Process ', id, 
+     &  ' says "Hello, world!"'
+
+      if ( id .eq. 0 ) then
+        wtime = MPI_Wtime ( ) - wtime
+        write ( *, '(a)' ) ' '
+        write ( *, '(a,g14.6,a)' ) 
+     &  'Elapsed wall clock time = ', wtime, ' seconds.'
+
+      end if
+c
+c  Terminate MPI.
+c
+      call MPI_Finalize ( error )
+c
+c  Terminate.
+c
+      if ( id .eq. 0 ) then
+        write ( *, '(a)' ) ' '
+        write ( *, '(a)' ) 'HELLO_MPI:'
+        write ( *, '(a)' ) '  Normal end of execution.'
+        write ( *, '(a)' ) ' '
+        call timestamp ( )
+      end if
+
+      stop
+      end
+      subroutine timestamp ( )
+
+c*********************************************************************72
+c
+cc TIMESTAMP prints out the current YMDHMS date as a timestamp.
+c
+c  Licensing:
+c
+c    This code is distributed under the GNU LGPL license.
+c
+c  Modified:
+c
+c    12 January 2007
+c
+c  Author:
+c
+c    John Burkardt
+c
+c  Parameters:
+c
+c    None
+c
+      implicit none
+
+      character * ( 8 ) ampm
+      integer d
+      character * ( 8 ) date
+      integer h
+      integer m
+      integer mm
+      character * ( 9 ) month(12)
+      integer n
+      integer s
+      character * ( 10 ) time
+      integer y
+
+      save month
+
+      data month /
+     &  'January  ', 'February ', 'March    ', 'April    ', 
+     &  'May      ', 'June     ', 'July     ', 'August   ', 
+     &  'September', 'October  ', 'November ', 'December ' /
+
+      call date_and_time ( date, time )
+
+      read ( date, '(i4,i2,i2)' ) y, m, d
+      read ( time, '(i2,i2,i2,1x,i3)' ) h, n, s, mm
+
+      if ( h .lt. 12 ) then
+        ampm = 'AM'
+      else if ( h .eq. 12 ) then
+        if ( n .eq. 0 .and. s .eq. 0 ) then
+          ampm = 'Noon'
+        else
+          ampm = 'PM'
+        end if
+      else
+        h = h - 12
+        if ( h .lt. 12 ) then
+          ampm = 'PM'
+        else if ( h .eq. 12 ) then
+          if ( n .eq. 0 .and. s .eq. 0 ) then
+            ampm = 'Midnight'
+          else
+            ampm = 'AM'
+          end if
+        end if
+      end if
+
+      write ( *, 
+     &  '(i2,1x,a,1x,i4,2x,i2,a1,i2.2,a1,i2.2,a1,i3.3,1x,a)' ) 
+     &  d, month(m), y, h, ':', n, ':', s, '.', mm, ampm
+
+      return
+      end

--- a/mingw-w64-msmpi/hello_mpi.c
+++ b/mingw-w64-msmpi/hello_mpi.c
@@ -1,0 +1,162 @@
+# include <stdlib.h>
+# include <stdio.h>
+# include <time.h>
+
+# include "mpi.h"
+
+int main ( int argc, char *argv[] );
+void timestamp ( );
+
+/******************************************************************************/
+
+int main ( int argc, char *argv[] )
+
+/******************************************************************************/
+/*
+  Purpose:
+
+    MAIN is the main program for HELLO_MPI.
+
+  Discussion:
+
+    This is a simple MPI test program.
+
+    Each process prints out a "Hello, world!" message.
+
+    The master process also prints out a short message.
+
+  Licensing:
+
+    This code is distributed under the GNU LGPL license. 
+
+  Modified:
+
+    30 October 2008
+
+  Author:
+
+    John Burkardt
+
+  Reference:
+
+    William Gropp, Ewing Lusk, Anthony Skjellum,
+    Using MPI: Portable Parallel Programming with the
+    Message-Passing Interface,
+    Second Edition,
+    MIT Press, 1999,
+    ISBN: 0262571323,
+    LC: QA76.642.G76.
+*/
+{
+  int id;
+  int ierr;
+  int p;
+  double wtime;
+/*
+  Initialize MPI.
+*/
+  ierr = MPI_Init ( &argc, &argv );
+
+  if ( ierr != 0 )
+  {
+    printf ( "\n" );
+    printf ( "HELLO_MPI - Fatal error!\n" );
+    printf ( "  MPI_Init returned nonzero IERR.\n" );
+    exit ( 1 );
+  }
+/*
+  Get the number of processes.
+*/
+  ierr = MPI_Comm_size ( MPI_COMM_WORLD, &p );
+/*
+  Get the individual process ID.
+*/
+  ierr = MPI_Comm_rank ( MPI_COMM_WORLD, &id );
+/*
+  Process 0 prints an introductory message.
+*/
+  if ( id == 0 ) 
+  {
+    wtime = MPI_Wtime ( );
+
+    printf ( "\n" );
+    printf ( "P%d:  HELLO_MPI - Master process:\n", id );
+    printf ( "P%d:    C/MPI version\n", id );
+    printf ( "P%d:    An MPI example program.\n", id );
+    printf ( "P%d:    The number of processes is %d.\n", id, p );
+    printf ( "\n" );
+  }
+/*
+  Every process prints a hello.
+*/
+  printf ( "P%d:    'Hello, world!'\n", id );
+
+  if ( id == 0 )
+  {
+    wtime = MPI_Wtime ( ) - wtime;
+    printf ( "P%d:    Elapsed wall clock time = %f seconds.\n", id, wtime );
+  }
+/*
+  Terminate MPI.
+*/
+  ierr = MPI_Finalize ( );
+/*
+  Terminate
+*/
+  if ( id == 0 )
+  {
+    printf ( "\n" );
+    printf ( "P%d:  HELLO_MPI - Master process:\n", id );
+    printf ( "P%d:    Normal end of execution: 'Goodbye, world!'\n", id );
+    printf ( "\n" );
+    timestamp ( );
+  }
+  return 0;
+}
+/******************************************************************************/
+
+void timestamp ( )
+
+/******************************************************************************/
+/*
+  Purpose:
+
+    TIMESTAMP prints the current YMDHMS date as a time stamp.
+
+  Example:
+
+    31 May 2001 09:45:54 AM
+
+  Licensing:
+
+    This code is distributed under the GNU LGPL license. 
+
+  Modified:
+
+    24 September 2003
+
+  Author:
+
+    John Burkardt
+
+  Parameters:
+
+    None
+*/
+{
+# define TIME_SIZE 40
+
+  static char time_buffer[TIME_SIZE];
+  const struct tm *tm;
+  time_t now;
+
+  now = time ( NULL );
+  tm = localtime ( &now );
+
+  strftime ( time_buffer, TIME_SIZE, "%d %B %Y %I:%M:%S %p", tm );
+
+  printf ( "%s\n", time_buffer );
+
+  return;
+# undef TIME_SIZE
+}

--- a/mingw-w64-msmpi/hello_mpi.cpp
+++ b/mingw-w64-msmpi/hello_mpi.cpp
@@ -1,0 +1,170 @@
+# include <cstdlib>
+# include <ctime>
+# include <iomanip>
+# include <iostream>
+# include <mpi.h>
+
+using namespace std;
+
+int main ( int argc, char *argv[] );
+void timestamp ( );
+
+//****************************************************************************80
+
+int main ( int argc, char *argv[] )
+
+//****************************************************************************80
+//
+//  Purpose:
+//
+//    MAIN is the main program for HELLO_MPI.
+//
+//  Discussion:
+//
+//    This is a simple MPI test program.
+//    Each process prints out a "Hello, world!" message.
+//    The master process also prints out a short message.
+//
+//    Modified to use the C MPI bindings, 14 June 2016.
+//
+//  Licensing:
+//
+//    This code is distributed under the GNU LGPL license. 
+//
+//  Modified:
+//
+//    14 June 2016
+//
+//  Author:
+//
+//    John Burkardt
+//
+//  Reference:
+//
+//    William Gropp, Ewing Lusk, Anthony Skjellum,
+//    Using MPI: Portable Parallel Programming with the
+//    Message-Passing Interface,
+//    Second Edition,
+//    MIT Press, 1999,
+//    ISBN: 0262571323,
+//    LC: QA76.642.G76.
+//
+{
+  int id;
+  int ierr;
+  int p;
+  double wtime;
+//
+//  Initialize MPI.
+//
+  ierr = MPI_Init ( &argc, &argv );
+
+  if ( ierr != 0 )
+  {
+    cout << "\n";
+    cout << "HELLO_MPI - Fatal error!\n";
+    cout << "  MPI_Init returned nonzero ierr.\n";
+    exit ( 1 );
+  }
+//
+//  Get the number of processes.
+//
+  ierr = MPI_Comm_size ( MPI_COMM_WORLD, &p );
+//
+//  Get the individual process ID.
+//
+  ierr = MPI_Comm_rank ( MPI_COMM_WORLD, &id );
+//
+//  Process 0 prints an introductory message.
+//
+  if ( id == 0 ) 
+  {
+    timestamp ( );
+    cout << "\n";
+    cout << "P" << id << ":  HELLO_MPI - Master process:\n";
+    cout << "P" << id << ":    C++/MPI version\n";
+    cout << "P" << id << ":    An MPI example program.\n";
+    cout << "\n";
+    cout << "P" << id << ":    The number of processes is " << p << "\n";
+    cout << "\n";
+  }
+//
+//  Every process prints a hello.
+//
+  if ( id == 0 ) 
+  {
+    wtime = MPI_Wtime ( );
+  }
+  cout << "P" << id << ":    'Hello, world!'\n";
+//
+//  Process 0 says goodbye.
+//
+  if ( id == 0 )
+  {
+    wtime = MPI_Wtime ( ) - wtime;
+    cout << "P" << id << ":    Elapsed wall clock time = " << wtime << " seconds.\n";
+  }
+//
+//  Terminate MPI.
+//
+  MPI_Finalize ( );
+//
+//  Terminate.
+//
+  if ( id == 0 )
+  {
+    cout << "\n";
+    cout << "P" << id << ":  HELLO_MPI:\n";
+    cout << "P" << id << ":    Normal end of execution.\n";
+    cout << "\n";
+    timestamp ( );
+  }
+  return 0;
+}
+//****************************************************************************80
+
+void timestamp ( )
+
+//****************************************************************************80
+//
+//  Purpose:
+//
+//    TIMESTAMP prints the current YMDHMS date as a time stamp.
+//
+//  Example:
+//
+//    31 May 2001 09:45:54 AM
+//
+//  Licensing:
+//
+//    This code is distributed under the GNU LGPL license. 
+//
+//  Modified:
+//
+//    08 July 2009
+//
+//  Author:
+//
+//    John Burkardt
+//
+//  Parameters:
+//
+//    None
+//
+{
+# define TIME_SIZE 40
+
+  static char time_buffer[TIME_SIZE];
+  const struct std::tm *tm_ptr;
+  std::time_t now;
+
+  now = std::time ( NULL );
+  tm_ptr = std::localtime ( &now );
+
+  std::strftime ( time_buffer, TIME_SIZE, "%d %B %Y %I:%M:%S %p", tm_ptr );
+
+  std::cout << time_buffer << "\n";
+
+  return;
+# undef TIME_SIZE
+}

--- a/mingw-w64-msmpi/hello_mpi.f90
+++ b/mingw-w64-msmpi/hello_mpi.f90
@@ -1,0 +1,181 @@
+program main
+
+!*****************************************************************************80
+!
+!! MAIN is the main program for HELLO_MPI.
+!
+!  Discussion:
+!
+!    HELLO is a simple MPI test program.
+!
+!    Each process prints out a "Hello, world!" message.
+!
+!    The master process also prints out a short message.
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license.
+!
+!  Modified:
+!
+!    30 October 2008
+!
+!  Author:
+!
+!    John Burkardt
+!
+!  Reference:
+!
+!    William Gropp, Ewing Lusk, Anthony Skjellum,
+!    Using MPI: Portable Parallel Programming with the
+!    Message-Passing Interface,
+!    Second Edition,
+!    MIT Press, 1999,
+!    ISBN: 0262571323,
+!    LC: QA76.642.G76.
+!
+  use mpi
+
+  integer ( kind = 4 ) error
+  integer ( kind = 4 ) id
+  integer ( kind = 4 ) p
+  real ( kind = 8 ) wtime
+!
+!  Initialize MPI.
+!
+  call MPI_Init ( error )
+!
+!  Get the number of processes.
+!
+  call MPI_Comm_size ( MPI_COMM_WORLD, p, error )
+!
+!  Get the individual process ID.
+!
+  call MPI_Comm_rank ( MPI_COMM_WORLD, id, error )
+!
+!  Print a message.
+!
+  if ( id == 0 ) then
+
+    wtime = MPI_Wtime ( )
+
+    call timestamp ( )
+    write ( *, '(a)' ) ''
+    write ( *, '(a,i1,2x,a)' ) 'P', id, 'HELLO_MPI - Master process:'
+    write ( *, '(a,i1,2x,a)' ) 'P', id, '  FORTRAN90/MPI version'
+    write ( *, '(a,i1,2x,a)' ) 'P', id, '  An MPI test program.'
+    write ( *, '(a,i1,2x,a,i8)' ) 'P', id, '  The number of MPI processes is ', p
+
+  end if
+!
+!  Every MPI process will print this message.
+!
+  write ( *, '(a,i1,2x,a)' ) 'P', id, '"Hello, world!"'
+
+  if ( id == 0 ) then
+
+    write ( *, '(a)' ) ''
+    write ( *, '(a,i1,2x,a)' ) 'P', id, 'HELLO_MPI - Master process:'
+    write ( *, '(a,i1,2x,a)' ) 'P', id, '  Normal end of execution: "Goodbye, world!".'
+
+    wtime = MPI_Wtime ( ) - wtime
+    write ( *, '(a)' ) ''
+    write ( *, '(a,i1,2x,a,g14.6,a)' ) &
+      'P', id, '  Elapsed wall clock time = ', wtime, ' seconds.'
+
+  end if
+!
+!  Shut down MPI.
+!
+  call MPI_Finalize ( error )
+!
+!  Terminate.
+!
+  if ( id == 0 ) then
+    write ( *, '(a)' ) ''
+    write ( *, '(a,i1,2x,a)' ) 'P', id, 'HELLO_MPI - Master process:'
+    write ( *, '(a,i1,2x,a)' ) 'P', id, '  Normal end of execution.'
+    write ( *, '(a)' ) ''
+    call timestamp ( )
+  end if
+
+  stop
+end
+subroutine timestamp ( )
+
+!*****************************************************************************80
+!
+!! TIMESTAMP prints the current YMDHMS date as a time stamp.
+!
+!  Example:
+!
+!    31 May 2001   9:45:54.872 AM
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license.
+!
+!  Modified:
+!
+!    06 August 2005
+!
+!  Author:
+!
+!    John Burkardt
+!
+!  Parameters:
+!
+!    None
+!
+  implicit none
+
+  character ( len = 8 ) ampm
+  integer ( kind = 4 ) d
+  integer ( kind = 4 ) h
+  integer ( kind = 4 ) m
+  integer ( kind = 4 ) mm
+  character ( len = 9 ), parameter, dimension(12) :: month = (/ &
+    'January  ', 'February ', 'March    ', 'April    ', &
+    'May      ', 'June     ', 'July     ', 'August   ', &
+    'September', 'October  ', 'November ', 'December ' /)
+  integer ( kind = 4 ) n
+  integer ( kind = 4 ) s
+  integer ( kind = 4 ) values(8)
+  integer ( kind = 4 ) y
+
+  call date_and_time ( values = values )
+
+  y = values(1)
+  m = values(2)
+  d = values(3)
+  h = values(5)
+  n = values(6)
+  s = values(7)
+  mm = values(8)
+
+  if ( h < 12 ) then
+    ampm = 'AM'
+  else if ( h == 12 ) then
+    if ( n == 0 .and. s == 0 ) then
+      ampm = 'Noon'
+    else
+      ampm = 'PM'
+    end if
+  else
+    h = h - 12
+    if ( h < 12 ) then
+      ampm = 'PM'
+    else if ( h == 12 ) then
+      if ( n == 0 .and. s == 0 ) then
+        ampm = 'Midnight'
+      else
+        ampm = 'AM'
+      end if
+    end if
+  end if
+
+  write ( *, '(i2,1x,a,1x,i4,2x,i2,a1,i2.2,a1,i2.2,a1,i3.3,1x,a)' ) &
+    d, trim ( month(m) ), y, h, ':', n, ':', s, '.', mm, trim ( ampm )
+
+  return
+end

--- a/mingw-w64-msmpi/msmpi.sh
+++ b/mingw-w64-msmpi/msmpi.sh
@@ -57,4 +57,4 @@ rootdir=`pwd`
 )
 
 # Export file signatures to be embed into PKGBUILD in order to ensure build integrity
-ruby export.rb mpi.c mpi.h mpif.h mpi.f90 mpifptr.h.{x86_64,i686} msmpi.def.{x86_64,i686}
+# ruby export.rb mpi.c mpi.h mpif.h mpi.f90 mpifptr.h.{x86_64,i686} msmpi.def.{x86_64,i686}

--- a/mingw-w64-msmpi/msmpi.test
+++ b/mingw-w64-msmpi/msmpi.test
@@ -1,0 +1,20 @@
+source [file join [file dirname [file normalize [info script]]] tclbuildtest.tcl]
+
+package require tclbuildtest
+
+::tclbuildtest::sandbox {
+    foreach b {{} static} {
+        test -description {MPI C basic test} [list mpi c $b] {
+            run [build hello_mpi.c]
+        }
+        test -description {MPI C++ basic test} [list mpi cxx $b] {
+            run [build hello_mpi.cpp]
+        }
+        test -description {MPI FORTRAN77 basic test with INCLUDE directive} [list mpi fortran $b] {
+            run [build hello_mpi.F]
+        }
+        test -description {MPI FORTRAN90 basic test with USE module directive} [list mpi fortran $b] {
+            run [build hello_mpi.f90]
+        }
+    }
+}

--- a/mingw-w64-msmpi/tclbuildtest.tcl
+++ b/mingw-w64-msmpi/tclbuildtest.tcl
@@ -1,0 +1,751 @@
+#
+# TclTest extenstion to test source code compilation & running
+#
+# https://github.com/okhlybov/tclbuildtest
+#
+
+package provide tclbuildtest 0.1.0
+
+package require Tcl 8.6
+package require tcltest 2.5.1
+
+namespace eval ::tcltest {}; # Make pkg_mkIndex happy
+
+# https://github.com/tcl2020/named-parameters
+
+namespace eval ::np {
+	#
+	# proc_args_to_dict - given a proc name and declared
+	#   proc arguments (variable names with optional
+	#   default values and a -- and possible some more
+	#   stuff, create and return a dict containing that
+	#   info in a way that's convenient and quicker
+	#   for us at runtime:
+	#   * we store a list of positional parameters
+	#   * we store a list of named parameters
+	#   * we store a list of var-value defaults
+	#   * we get a tricked-out error message in errmsg
+	#
+	::proc proc_args_to_dict {name procArgs} {
+		set seenDashes 0
+		dict set d defaults [list]
+		dict set d positional [list]
+		dict set d named [list]
+		set errmsg "wrong # args: should be \"$name "
+
+		foreach arg $procArgs {
+			if {$arg eq "--"} {
+				set seenDashes 1
+				append errmsg "?--? "
+				continue
+			}
+
+			set var [lindex $arg 0]
+			dict lappend d [expr {$seenDashes ? "positional" : "named"}] $var
+
+			if {[llength $arg] == 2} {
+				dict lappend d defaults $var [lindex $arg 1]
+				if {$seenDashes} {
+					append errmsg "?$var? "
+				} else {
+					append errmsg "?-$var val? "
+				}
+			} elseif {$var eq "args"} {
+				dict lappend d defaults $var [list]
+				append errmsg "?arg ...? "
+			} else {
+				if {$seenDashes} {
+					append errmsg "$var "
+				} else {
+					append errmsg "-$var val "
+				}
+			}
+		}
+		dict set d errmsg "[string range $errmsg 0 end-1]\""
+		return $d
+	}
+
+	#
+	# np_handler - look at an argument dict created by proc_args_to_dict
+	#   and look at the real arguments to a function (args), and sort
+	#   out the named and positional parameters to behave in the
+	#   expected way.
+	#
+	::proc np_handler {argd realArgs} {
+		set named [dict get $argd named]
+		set positional [dict get $argd positional]
+
+		# process named parameters
+		while {[llength $realArgs] > 0} {
+			set arg [lindex $realArgs 0]
+
+			# if arg is --, flip to positional
+			if {$arg eq "--"} {
+				set realArgs [lrange $realArgs 1 end]
+				break
+			}
+
+			# if "var" doesn't start with a dash, flip to positional
+			if {[string index $arg 0] ne "-"} {
+				#puts "possible var '$arg' doesn't start with a dash, flip to positional"
+				break
+			}
+
+			# if "var" isn't known to us as a named parameter, flip to positional
+			set var [string range $arg 1 end]
+			if {[lsearch $named $var] < 0} {
+				#puts "'var' '$arg' not recognized, flip to positional"
+				break
+			}
+
+			# if there isn't at least one more element in the arg list,
+			# we are missing a value for one of our named parameters
+			if {[llength $realArgs] == 0} {
+				#puts "realArgs is empty but i expect something for $var"
+				error [dict get $argd errmsg] "" [list TCL WRONGARGS]
+			}
+
+			# we're good, set the named parameter into the variable sets
+			#puts [list set vsets($var) [lindex $realArgs 1]]
+
+			# but don't allow the same variable to be set twice
+			if {[info exists vsets($var)]} {
+				error [dict get $argd errmsg] "" [list TCL WRONGARGS]
+			}
+
+			set vsets($var) [lindex $realArgs 1]
+			set realArgs [lrange $realArgs 2 end]
+		}
+
+		# fill in defaults for all the vars with defaults that
+		# didn't get set to a value
+		foreach "var value" [dict get $argd defaults] {
+			if {![info exists vsets($var)]} {
+				set vsets($var) $value
+			}
+		}
+
+		foreach var $positional {
+			if {$var eq "args"} {
+				set vsets($var) $realArgs
+				set realArgs [list]
+				break
+			}
+
+			if {[llength $realArgs] > 0} {
+				set vsets($var) [lindex $realArgs 0]
+				set realArgs [lrange $realArgs 1 end]
+			}
+
+			# no arguments left.  if this var doesn't
+			# have a default value, it's a wrong args error
+			if {![info exists vsets($var)]} {
+				error [dict get $argd errmsg] "" [list TCL WRONGARGS]
+			}
+		}
+
+		# make sure all the named parameters have been set, either
+		# by defaults or explicitly, any not set is an error
+		foreach var $named {
+			if {![info exists vsets($var)]} {
+				#puts "required named parameter '-$var' is not set"
+				error [dict get $argd errmsg] "" [list TCL WRONGARGS]
+			}
+		}
+
+		# are there too many arguments?
+		if {[llength $realArgs] > 0} {
+			#puts "leftover arguments (too many) '$realArgs'"
+			error [dict get $argd errmsg] "" [list TCL WRONGARGS]
+		}
+
+		# now iterate through the var-value pairs and set them into
+		# the caller's frame
+		foreach "var value" [array get vsets] {
+			#puts "set '$var' '$value'"
+			upvar $var myvar
+			set myvar $value
+		}
+		return
+	}
+
+	#
+	# np::proc - same as proc except if -- is in the argv
+	#   then it will generate a proc that has extra code
+	#   at the beginning to wrangle the named parameters
+	#
+	proc proc {name argv body} {
+		# handle the case where there are no named parameters
+		if {[lsearch $argv --] < 0} {
+			uplevel [list ::proc $name $argv $body]
+			return
+		}
+
+		if {[lsearch $argv --] == 0} {
+			return -code error "-- cannot be the first argument for named parameters. Use positional parameters."
+		}
+
+		set d [proc_args_to_dict $name $argv]
+		set newbody "::proc $name args {\n"
+		append newbody "    ::np::np_handler [list $d] \$args\n"
+		append newbody $body
+		append newbody "\n}"
+		#puts $newbody
+		uplevel $newbody
+	}
+}
+
+namespace eval ::tclbuildtest {
+	
+	variable system-count 0
+	variable build-count 0
+
+	# Standard predefined constraints
+	foreach ct {
+		c cxx fortran
+		single double
+		real complex
+		openmp thread hybrid mpi
+		static
+		debug
+	} {::tcltest::testConstraint $ct 1}
+
+	# Return a value of the environment variable or {} if no such variable is set
+	proc env {var} {
+		try {return [set ::env($var)]} on error {} {return {}}
+	}
+
+	# MpiExec detection
+	proc mpiexec {} {
+		variable mpiexec
+		try {set mpiexec} on error {} {
+			set mpiexec {}
+			foreach x [collect [env MPIEXEC] mpiexec mpirun] {
+				if {![catch {exec {*}$x}]} {
+					set mpiexec $x
+					break
+				}
+			}
+		}
+		if {$mpiexec == {}} {error {failed to detect MpiExec or equivalent}}
+		return $mpiexec
+	}
+
+	# PkgConfig detection
+	proc pkg-config {} {
+		variable pc
+		try {set pc} on error {} {
+			set pc {}
+			foreach x [collect [env PKG_CONFIG] pkg-config pkgconf] {
+				if {![catch {exec {*}$x --version}]} {
+					set pc $x
+					break
+				}
+			}
+		}
+		if {$pc == {}} {error {failed to detect PkgConfig or equivalent}}
+		return $pc
+	}
+
+	# C compiler detection
+	proc cc {} {
+		variable cc
+		try {set cc} on error {} {
+			set cc {}
+			foreach x [collect [env CC] gcc] {
+				if {![catch {exec {*}$x --version}]} {
+					set cc $x
+					break
+				}
+			}
+		}
+		if {$cc == {}} {error {failed to detect C compiler}}
+		return $cc
+	}
+
+	# C++ compiler detection
+	proc cxx {} {
+		variable cxx
+		try {set cxx} on error {} {
+			set cxx {}
+			foreach x [collect [env CXX] g++] {
+				if {![catch {exec {*}$x --version}]} {
+					set cxx $x
+					break
+				}
+			}
+		}
+		if {$cxx == {}} {error {failed to detect C++ compiler}}
+		return $cxx
+	}
+
+	# FORTRAN compiler detection
+	proc fc {} {
+		variable fc
+		try {set fc} on error {} {
+			set fc {}
+			foreach x [collect [env FC] gfortran] {
+				if {![catch {exec {*}$x --version}]} {
+					set fc $x
+					break
+				}
+			}
+		}
+		if {$fc == {}} {error {failed to detect FORTRAN compiler}}
+		return $fc
+	}
+
+	# MPI C compiler detection
+	proc mpicc {} {
+		variable mpicc
+		try {set mpicc} on error {} {
+			set mpicc {}
+			foreach x [collect [env MPICC] mpicc] {
+				if {![catch {exec {*}$x --version}]} {
+					set mpicc $x
+					break
+				}
+			}
+		}
+		if {$mpicc == {}} {error {failed to detect MPI C compiler}}
+		return $mpicc
+	}
+
+	# MPI C++ compiler detection
+	proc mpicxx {} {
+		variable mpicxx
+		try {set mpicxx} on error {} {
+			set mpicxx {}
+			foreach x [collect [env MPICXX] mpicxx mpic++] {
+				if {![catch {exec {*}$x --version}]} {
+					set mpicxx $x
+					break
+				}
+			}
+		}
+		if {$mpicxx == {}} {error {failed to detect MPI C++ compiler}}
+		return $mpicxx
+	}
+
+	# MPI FORTRAN compiler detection
+	proc mpifc {} {
+		variable mpifc
+		try {set mpifc} on error {} {
+			set mpifc {}
+			foreach x [collect [env MPIFC] [env MPIFORT] mpifort mpif90 mpif77] {
+				if {![catch {exec {*}$x --version}]} {
+					set mpifc $x
+					break
+				}
+			}
+		}
+		if {$mpifc == {}} {error {failed to detect MPI FORTRAN compiler}}
+		return $mpifc
+	}
+
+	# Create temporary directory
+	proc mktempdir {} {
+		set t [file join $::env(TEMP) [file rootname [file tail [info script]]][expr {int(rand()*9999)}]]
+		file mkdir $t
+		return $t
+	}
+
+	# Delete directory tree
+	proc rmdir {dir} {
+		try {
+			file delete -force $dir
+		} on error {} {
+			# This command fires up a background sanitizing process which does its best to delete
+			# staging directory in spite of executable locks or what's not which can happend on Windows
+			# This code should work in real UNIX environments or UNIX-like Windows environments
+			# such as Cygwin or MSYS(2).
+			exec -ignorestderr sh -c "nohup \${SHELL} -c \" while \[ -d '$dir' \]; do rm -rf '$dir' || sleep 3; done\" > /dev/null 2>&1 &"
+		}
+	}
+
+	# Execute script from a temporary location
+	# Script file is copied to the location along with all residing files
+	# The location gets deleted afterwards
+	proc sandbox {script} {
+		variable stagedir [mktempdir]
+		try {
+			::tcltest::configure {*}$::argv
+			::tcltest::workingDirectory $stagedir
+			file copy -force {*}[glob -directory [file dirname [file normalize [info script]]] -nocomplain *] $stagedir
+			eval $script
+		} finally {
+			::tcltest::cleanupTests
+			rmdir $stagedir
+		}
+	}
+
+	# Obtain compilation and linking flags for the specified packages via PkgConfig
+	proc require {args} {
+		if {[constraint? static]} {set flags --static} else {set flags {}}
+		xflags {*}[lindex [dict get [system [pkg-config] {*}$args --cflags {*}$flags] stdout] 0]
+		ldflags {*}[lindex [dict get [system [pkg-config] {*}$args --libs {*}$flags] stdout] 0]
+		return
+	}
+
+	# Deduce source code language from command line arguments
+	proc deduce-language {opts} {
+		switch -regexp -nocase [lindex $opts [lsearch -glob -not $opts {-*}]] {
+			{\.c$} {return c}
+			{\.(cxx|cpp|cc)$} {return cxx}
+			{\.(f|for|f\d+)$} {return fortran}
+			default {error {failed to deduce source language from the command line agruments}}
+		}
+	}
+
+	# Deduce compilation command from command line arguments
+	proc deduce-compiler-proc {opts} {
+		set lang [deduce-language $opts]
+		if {[constraint? mpi]} {
+			switch $lang {
+				c {return mpicc}
+				cxx {return mpicxx}
+				fortran {return mpifc}
+			}
+		} else {
+			switch $lang {
+				c {return cc}
+				cxx {return cxx}
+				fortran {return fc}
+			}
+		}
+	}
+
+	# Deduce compilation flags command from command line arguments
+	proc deduce-compile-flags-proc {opts} {
+		switch [deduce-language $opts] {
+			c {return cflags}
+			cxx {return cxxflags}
+			fortran {return fflags}
+		}
+	}
+	
+	# C preprocessor command line arguments
+	proc cppflags {args} {
+		variable cppflags
+		try {set cppflags} on error {} {
+			set cppflags [lsqueeze [env CPPFLAGS]]
+			if {![constraint? debug]} {lappend cppflags -DNDEBUG}
+		}
+		lappend cppflags {*}$args
+	}
+
+	# Language-agnostic compilation command line arguments
+	proc xflags {args} {
+		variable xflags
+		try {set xflags} on error {} {
+			set xflags {}
+			if {[constraint? openmp]} {lappend xflags -fopenmp}
+			if {[constraint? thread]} {lappend xflags -pthread}
+			if {[constraint? debug]} {lappend xflags -Og} else {lappend xflags -O2}
+		}
+		lappend xflags {*}$args
+	}
+
+	# C-specific compilation command line arguments
+	proc cflags {args} {
+		variable cflags
+		try {set cflags} on error {} {
+			set cflags [lsqueeze [env CFLAGS]]
+		}
+		lappend cflags {*}$args
+	}
+
+	
+	# C++-specific compilation command line arguments
+	proc cxxflags {args} {
+		variable cxxflags
+		try {set cxxflags} on error {} {
+			set cxxflags [lsqueeze [env CXXFLAGS]]
+		}
+		lappend cxxflags {*}$args
+	}
+
+	# FORTRAN-specific compilation command line arguments
+	proc fflags {args} {
+		variable fflags
+		try {set fflags} on error {} {
+			set fflags [lsqueeze [env FFLAGS]]
+		}
+		lappend fflags {*}$args
+	}
+
+	# Linker command line arguments
+	proc ldflags {args} {
+		variable ldflags
+		try {set ldflags} on error {} {
+			set ldflags [lsqueeze [env LDFLAGS]]
+			if {[constraint? static]} {lappend ldflags -static}
+			if {[constraint? openmp]} {lappend ldflags -fopenmp}
+			if {[constraint? thread]} {lappend ldflags -pthread}
+		}
+		lappend ldflags {*}$args
+	}
+
+	# Linked libraries command line arguments
+	proc libs {args} {
+		variable libs
+		try {set libs} on error {} {
+			set libs [lsqueeze [env LIBS]]
+			if {[constraint? cxx]} {lappend libs -lstdc++}
+			if {[constraint? fortran]} {lappend libs -lgfortran -lquadmath}
+		}
+		lappend libs {*}$args
+	}
+
+	# Perform source code compilation into executable
+	# Returns the executable name
+	proc build {args} {
+		set args [lsqueeze $args]
+		set exe [executable]
+		system {*}[concat \
+			[[deduce-compiler-proc $args]] \
+			-o $exe \
+			[cppflags] \
+			[xflags] \
+			[[deduce-compile-flags-proc $args]] \
+			$args \
+			[ldflags] \
+			[libs] \
+		]
+		return $exe
+	}
+
+	# Perform running of the specified executable with supplied command line arguments
+	proc run {args} {
+		if {[constraint? mpi]} {set runner [mpiexec]} else {set runner {}}
+		system {*}[list $runner {*}$args]
+	}
+
+	# Execute command line built from command line arguments
+	proc system {args} {
+		variable system-count
+		incr system-count
+		set stdout stdout${system-count}
+		set stderr stderr${system-count}
+		set args [lsqueeze $args]
+		set command [join $args]
+		if {[lsearch [::tcltest::verbose] exec] < 0} {set verbose 0} else {set verbose 1}
+		if {$verbose} {::puts [::tcltest::outputChannel] "> $command"}
+		try {
+			exec -ignorestderr -- {*}$args > $stdout 2> $stderr
+			set options {}
+			set status 0
+			set code ok
+		} trap CHILDSTATUS {results options} {
+			set status [lindex [dict get $options -errorcode] 2]
+			set code error
+		} finally {
+			try {
+				set out [read-file $stdout]
+				set err [read-file $stderr]
+			} finally {
+				file delete -force $stdout $stderr
+			}
+		}
+		if {$verbose} {
+			foreach x $out {::puts [::tcltest::outputChannel] $x}
+			if {[llength $out] > 0 && [llength $err] > 0} {::puts [::tcltest::outputChannel] ----}
+			foreach x $err {::puts [::tcltest::outputChannel] $x}
+		}
+		return -code $code [dict create command $command status $status stdout $out stderr $err options $options]
+	}
+
+	# Construct a scalar type ID from the constraints
+	proc x {} {
+		if {[constraint? complex]} {
+			if {[constraint? double]} {return z}
+			if {[constraint? single]} {return c}
+		} else {
+			if {[constraint? double]} {return d}
+			if {[constraint? single]} {return s}
+		}
+		error {failed to contstruct the scalar type}
+	}
+
+	# Construct an execution model ID from the constraints
+	proc y {} {
+		if {[constraint? mpi]} {return m}
+		if {[constraint-any? openmp thread]} {return t}
+		if {[constraint? hybrid]} {return h}
+		return s
+	}
+
+	# Construct an build type ID from the constraints
+	proc z {} {
+		if {[constraint? debug]} {return g}
+		return o
+	}
+
+	# Construct a 3-letter XYZ build code from the constraints
+	proc xyz {} {
+		 return [x][y][z]
+	}
+
+	# Construct the test name based on the constraints set
+	proc name {} {
+		join [list [file rootname [file tail [info script]]] {*}[constraints]] -
+	}
+
+	# Construct new unique executable name
+	proc executable {} {
+		variable build-count
+		variable executable
+		return [set executable [name]-[incr build-count].exe]
+	}
+
+	# Construct human-readable description of the test according to the contraints set
+	proc description {} {
+		set t {}
+		switch [intersection {c cxx fortran} [constraints]] {
+			c {lappend t C}
+			cxx {lappend t C++}
+			fortran {lappend t FORTRAN}
+		}
+		try {
+			switch [y] {
+				s {lappend t sequential}
+				m {lappend t MPI}
+				t {lappend t multithreaded}
+				h {lappend t heterogeneous}
+			}
+		} on error {} {}
+		try {
+			switch [x] {
+				s {lappend t "single precision"}
+				d {lappend t "double precision"}
+				c {lappend t "single precision complex"}
+				z {lappend t "double precision complex"}
+			}
+		} on error {} {}
+		switch [z] {
+			o {lappend t optimized}
+			g {lappend t debugging}
+		}
+		if {[constraint? static]} {lappend t static}
+		join $t
+	}
+
+	# Set constraints
+	proc constraints {args} {
+		variable constraints
+		try {set constraints} on error {} {
+			set constraints {}
+		}
+		lappend constraints {*}[lsqueeze $args]
+	}
+
+	# Return true if any of specified contraints is set
+	proc constraint-any? {args} {
+		foreach ct $args {
+			if {[constraint? $ct]} {return 1}
+		}
+		return 0
+	}
+
+	# Return true if all scpecified constraints are set
+	proc constraint-all? {args} {
+		foreach ct $args {
+			if {![constraint? $ct]} {return 0}
+		}
+		return 1
+	}
+
+	# Return true if specified constraint is set
+	proc constraint? {ct} {
+		variable constraints
+		expr {[lsearch $constraints $ct] >= 0}
+	}
+
+	# Test failure is triggered by throwing an exception
+	::tcltest::customMatch exception {return 1; #}
+
+	# Main test command
+	::np::proc test {{name {}} {description {}} {match {exception}} -- cts script} {
+		foreach v {executable constraints cppflags xflags cflags cxxflags fflags ldflags libs} {variable $v; catch {unset $v}}
+		set cts [constraints {*}$cts]
+		if {$name == {}} {set name [name]}
+		if {$description == {}} {set description "[description] build"}
+		::tcltest::test $name $description -constraints $cts -body $script -match $match
+		# Attempt to delete the created executable if any to conserve space in the stage dir
+		# It's OK for the operation to fail at this point as the executable may still be locked
+		variable executable; try {file delete -force $executable} on error {} {}
+	}
+
+	# To be used in {all.tcl}
+	proc suite {args} {
+		::tcltest::configure -testdir [file dirname [file normalize [info script]]] {*}$args
+		::tcltest::runAllTests
+		::tcltest::cleanupTests
+	}
+
+	# Quick & dirty hack to introduce extra verbosity option(s)
+	# Override the proc from in tcltest-*.tm
+	# Original code corresponds to version 2.5.1
+    proc ::tcltest::AcceptVerbose { level } {
+	set level [AcceptList $level]
+	set levelMap {
+		x exec
+	    l list
+	    p pass
+	    b body
+	    s skip
+	    t start
+	    e error
+	    l line
+	    m msec
+	    u usec
+	}
+	set levelRegexp "^([join [dict values $levelMap] |])\$"
+	if {[llength $level] == 1} {
+	    if {![regexp $levelRegexp $level]} {
+		# translate single characters abbreviations to expanded list
+		set level [string map $levelMap [split $level {}]]
+	    }
+	}
+	set valid [list]
+	foreach v $level {
+	    if {[regexp $levelRegexp $v]} {
+		lappend valid $v
+	    }
+	}
+	return $valid
+    }
+
+	# Read text file and return list of lines
+	proc read-file {file} {
+		set f [open $file r]
+		try {
+			return [split [read -nonewline $f] \n]
+		} finally {
+			close $f
+		}
+	}
+
+	# Return a new list from the specified list entries squashing {} values
+	proc lsqueeze {list} {
+		set out [list]
+		foreach x $list {
+			if {$x != {}} {lappend out $x}
+		}
+		return $out
+	}
+
+	# Return a new list from the specified arguments squashing {} values
+	proc collect {args} {
+		lsqueeze $args
+	}
+
+	# Return intersection of two lists
+	proc intersection {a b} {
+		set x {}
+		foreach i $a {
+			if {[lsearch -exact $b $i] != -1} {lappend x $i}
+		}
+		return $x
+	}
+}


### PR DESCRIPTION
- Install precompiled .mod files for FORTRAN90's USE statement.
- Add TclTest-based test suite to check for C, C++ and FORTRAN basic MPI build & run capability.