### PR TITLE
ghdl: update to 0.37.0.r1123.g8ed35277

### DIFF
--- a/mingw-w64-ghdl/PKGBUILD
+++ b/mingw-w64-ghdl/PKGBUILD
@@ -1,8 +1,8 @@
 _realname=ghdl
 pkgbase="mingw-w64-${_realname}"
 pkgname='__placeholder__'
-pkgver=0.37.0.r1063.gc5b094bb
-pkgrel=3
+pkgver=0.37.0.r1123.g8ed35277
+pkgrel=1
 pkgdesc='GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL (mingw-w64)'
 arch=('any')
 license=('GPL2+')
@@ -11,7 +11,7 @@ groups=("${MINGW_PACKAGE_PREFIX}-eda")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 makedepends=("${MINGW_PACKAGE_PREFIX}-clang" "${MINGW_PACKAGE_PREFIX}-gcc-ada")
-_commit='c5b094bb'
+_commit='8ed35277'
 source=("ghdl::git://github.com/ghdl/ghdl.git#commit=${_commit}")
 sha512sums=('SKIP')
 


### PR DESCRIPTION
GHDL needs to be bumped, because the AST of libghdl went out of sync with the version available at the moment.