### PR TITLE
libtiff: Update 4.2.0

### DIFF
--- a/mingw-w64-libtiff/PKGBUILD
+++ b/mingw-w64-libtiff/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=libtiff
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.1.0
+pkgver=4.2.0
 pkgrel=1
 pkgdesc="Library for manipulation of TIFF images (mingw-w64)"
 arch=('any')
@@ -13,14 +13,15 @@ license=(MIT)
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          #"${MINGW_PACKAGE_PREFIX}-jbigkit"
          "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
-         #"${MINGW_PACKAGE_PREFIX}-webp"
+         "${MINGW_PACKAGE_PREFIX}-libdeflate"
+         "${MINGW_PACKAGE_PREFIX}-libwebp"
          "${MINGW_PACKAGE_PREFIX}-xz"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-zstd")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 options=('staticlibs' 'strip')
 source=(http://download.osgeo.org/libtiff/tiff-${pkgver}.tar.gz)
-sha256sums=('5d29f32517dadb6dbcd1255ea5bbc93a2b54b94fbf83653b4d65c7d6775b8634')
+sha256sums=('eb0484e568ead8fa23b513e9b0041df7e327f4ee2d22db5a533929dfc19633cb')
 
 prepare() {
   cd tiff-${pkgver}
@@ -42,7 +43,8 @@ build() {
     --enable-shared \
     --enable-cxx \
     --disable-jbig \
-    --disable-webp \
+    --enable-webp \
+    --enable-libdeflate \
     --without-x
 
   make


### PR DESCRIPTION
Enable libdeflate, which is new and default in this release.

and webp, because it's default and it seems to work, so why not.