### PR TITLE
[Port] cmdpack

### DIFF
--- a/mingw-w64-cmdpack/PKGBUILD
+++ b/mingw-w64-cmdpack/PKGBUILD
@@ -1,0 +1,32 @@
+# Maintainer: Sarah Ottinger <schalaalexiazeal@gmail.com>
+
+_realname=cmdpack
+pkgbase=mingw-w64-${_realname}
+pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
+pkgver=1.06
+pkgrel=1
+pkgdesc='These are a set of utilities originally released by Neill Corlett (mingw-w64)'
+arch=('any')
+url="https://github.com/chungy/cmdpack"
+license=('GPL3')
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+makedepends=("${MINGW_PACKAGE_PREFIX}-asciidoc")
+source=("https://github.com/chungy/cmdpack/archive/$pkgver.tar.gz")
+sha256sums=('6ce7029c0f2b0fbc6a1e26fb3ad8003ed18836aa3ef35f148ec51cde0b703307')
+
+prepare() {
+  cd "$srcdir"
+  rm -rf build-${CARCH} | true
+  cp -r "${_realname}-$pkgver" "build-${CARCH}"
+}
+
+build() {
+  cd "${srcdir}/build-${CARCH}"
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${CARCH}"
+  make DESTDIR="$pkgdir" prefix=${MINGW_PREFIX} install
+  install -D -m644 COPYING "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}


### PR DESCRIPTION
cmdpack is a nifty little set of tools I've found use in for the past few years. Though prebuilt binaries exist for Windows, I preferred to have them built by my MinGW-w64/MSYS2 installation