### PR TITLE
nextpnr: add 0.0.r2859.5e53a182

### DIFF
--- a/mingw-w64-nextpnr/PKGBUILD
+++ b/mingw-w64-nextpnr/PKGBUILD
@@ -1,0 +1,77 @@
+# Maintainer: umarcor <unai.martinezcorral@ehu.eus>
+
+_realname=nextpnr
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.0.r2859.5e53a182
+pkgrel=1
+pkgdesc="Portable FPGA place and route tool (mingw-w64)"
+arch=('any')
+url="https://github.com/YosysHQ/nextpnr"
+license=('ISC')
+groups=("${MINGW_PACKAGE_PREFIX}-eda")
+depends=("${MINGW_PACKAGE_PREFIX}-qt5"
+         "${MINGW_PACKAGE_PREFIX}-python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-boost"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-eigen3"
+             "${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-icestorm"
+             "${MINGW_PACKAGE_PREFIX}-make"
+             "${MINGW_PACKAGE_PREFIX}-openmp"
+             "${MINGW_PACKAGE_PREFIX}-python"
+             "${MINGW_PACKAGE_PREFIX}-qt5"
+             "git")
+
+_commit="5e53a18"
+source=("${_realname}::git://github.com/YosysHQ/${_realname}.git#commit=${_commit}")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "${_realname}"
+  printf "0.0.r%s.%s" "$(git rev-list --count "${_commit}")" "$(git rev-parse --short "${_commit}")"
+}
+
+build() {
+  cd "${srcdir}/${_realname}"
+
+  # TODO:
+  # - add -DBUILD_TESTS=ON
+  # - uncomment make test in check()
+
+  cmake \
+    -G "MinGW Makefiles" \
+    -DCMAKE_PREFIX_PATH=${MINGW_PREFIX} \
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+    -DARCH='ice40' \
+    -DBUILD_HEAP=ON \
+    -DUSE_OPENMP=ON \
+    -DBUILD_PYTHON=ON \
+    -DBUILD_GUI=ON \
+    -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+    .
+
+  cmake --build . --config Release
+}
+
+check() {
+  cd "${srcdir}/${_realname}"
+  #mingw32-make test
+}
+
+package() {
+  cd "${srcdir}/${_realname}"
+
+  # FIXME: the following install target places the binaries
+  # in ${pkgdir}/msys64/mingw64/bin
+  # instead of ${pkgdir}/mingw64/bin
+  #mingw32-make DESTDIR="${pkgdir}" install
+
+  _bin="${pkgdir}${MINGW_PREFIX}/bin"
+  mkdir -p "${_bin}"
+  cp nextpnr-ice40.exe "${_bin}"
+
+  _licenses="${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
+  mkdir -p "${_licenses}"
+  install -m 644 "${srcdir}/${_realname}"/COPYING "${_licenses}"
+}

--- a/mingw-w64-nextpnr/PKGBUILD
+++ b/mingw-w64-nextpnr/PKGBUILD
@@ -10,7 +10,8 @@ arch=('any')
 url="https://github.com/YosysHQ/nextpnr"
 license=('ISC')
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
-depends=("${MINGW_PACKAGE_PREFIX}-qt5"
+depends=("${MINGW_PACKAGE_PREFIX}-boost"
+         "${MINGW_PACKAGE_PREFIX}-qt5"
          "${MINGW_PACKAGE_PREFIX}-python")
 makedepends=("${MINGW_PACKAGE_PREFIX}-boost"
              "${MINGW_PACKAGE_PREFIX}-cmake"
@@ -39,8 +40,9 @@ build() {
   # - add -DBUILD_TESTS=ON
   # - uncomment make test in check()
 
-  cmake \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" cmake \
     -G "MinGW Makefiles" \
+    -DICESTORM_INSTALL_PREFIX="${MINGW_PREFIX}" \
     -DCMAKE_PREFIX_PATH=${MINGW_PREFIX} \
     -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
     -DARCH='ice40' \
@@ -61,15 +63,7 @@ check() {
 
 package() {
   cd "${srcdir}/${_realname}"
-
-  # FIXME: the following install target places the binaries
-  # in ${pkgdir}/msys64/mingw64/bin
-  # instead of ${pkgdir}/mingw64/bin
-  #mingw32-make DESTDIR="${pkgdir}" install
-
-  _bin="${pkgdir}${MINGW_PREFIX}/bin"
-  mkdir -p "${_bin}"
-  cp nextpnr-ice40.exe "${_bin}"
+  mingw32-make DESTDIR="${pkgdir}" install
 
   _licenses="${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
   mkdir -p "${_licenses}"

--- a/mingw-w64-nextpnr/PKGBUILD
+++ b/mingw-w64-nextpnr/PKGBUILD
@@ -35,10 +35,6 @@ pkgver() {
 build() {
   cd "${srcdir}/${_realname}"
 
-  # TODO:
-  # - add -DBUILD_TESTS=ON
-  # - uncomment make test in check()
-
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" cmake \
     -G "MSYS Makefiles" \
     -DICESTORM_INSTALL_PREFIX="${MINGW_PREFIX}" \
@@ -50,6 +46,7 @@ build() {
     -DBUILD_PYTHON=ON \
     -DBUILD_GUI=ON \
     -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+    -DBUILD_TESTS=ON \
     .
 
   cmake --build . --config Release
@@ -57,7 +54,7 @@ build() {
 
 check() {
   cd "${srcdir}/${_realname}"
-  #make test
+  make test
 }
 
 package() {

--- a/mingw-w64-nextpnr/PKGBUILD
+++ b/mingw-w64-nextpnr/PKGBUILD
@@ -18,7 +18,6 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-boost"
              "${MINGW_PACKAGE_PREFIX}-eigen3"
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-icestorm"
-             "${MINGW_PACKAGE_PREFIX}-make"
              "${MINGW_PACKAGE_PREFIX}-openmp"
              "${MINGW_PACKAGE_PREFIX}-python"
              "${MINGW_PACKAGE_PREFIX}-qt5"
@@ -41,7 +40,7 @@ build() {
   # - uncomment make test in check()
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" cmake \
-    -G "MinGW Makefiles" \
+    -G "MSYS Makefiles" \
     -DICESTORM_INSTALL_PREFIX="${MINGW_PREFIX}" \
     -DCMAKE_PREFIX_PATH=${MINGW_PREFIX} \
     -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
@@ -58,12 +57,12 @@ build() {
 
 check() {
   cd "${srcdir}/${_realname}"
-  #mingw32-make test
+  #make test
 }
 
 package() {
   cd "${srcdir}/${_realname}"
-  mingw32-make DESTDIR="${pkgdir}" install
+  make DESTDIR="${pkgdir}" install
 
   _licenses="${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
   mkdir -p "${_licenses}"


### PR DESCRIPTION
This PR adds package `nextpnr` (a portable FPGA place and route tool): [YosysHQ/nextpnr](https://github.com/YosysHQ/nextpnr). It's added to group 'eda'.

Together with Yosys (#7534), it allows synthesising and implementing HDL designs targetting Lattice's ICE40 FPGAs. The GUI (based on Qt5) is enabled.

~~See YosysHQ/nextpnr#546 for a discussion about why `mingw32-make DESTDIR="${pkgdir}" install` is commented out and the assets are copied manually instead.~~