### PR TITLE
lis: Update to 2.0.29

### DIFF
--- a/mingw-w64-lis/PKGBUILD
+++ b/mingw-w64-lis/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=lis
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.0.28
-pkgrel=2
+pkgver=2.0.29
+pkgrel=1
 pkgdesc='Library of Iterative Solvers for linear systems (mingw-w64)'
 arch=('any')
 depends=("${MINGW_PACKAGE_PREFIX}-libtool"
@@ -14,7 +14,7 @@ options=('!docs')
 license=('BSD')
 url='https://www.ssisc.org/lis/'
 source=(https://www.ssisc.org/lis/dl/${_realname}-${pkgver}.zip)
-sha256sums=('D2D8739AB11B605A62FCA08FD56334C45AB10E7796A44F8243E1A1E3006FE36A')
+sha256sums=('AECF08F79595B3F1A888F153615F099FC2FCF6B90955FFBABA9CD01892D9614D')
 
 prepare() {
   cd ${_realname}-${pkgver}


### PR DESCRIPTION
"Fixed MPI related bug in configure.ac (thanks to Carlo de Falco)."