### PR TITLE
pygobject: port to meson

### DIFF
--- a/mingw-w64-pygobject/PKGBUILD
+++ b/mingw-w64-pygobject/PKGBUILD
@@ -4,7 +4,7 @@ _realname=pygobject
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-gobject")
 pkgver=3.38.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Python Bindings for GLib/GObject/GIO/GTK+ (mingw-w64)"
 arch=(any)
 url="https://pygobject.readthedocs.io"
@@ -14,7 +14,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-glib2"
          "${MINGW_PACKAGE_PREFIX}-libffi"
          "${MINGW_PACKAGE_PREFIX}-gobject-introspection-runtime")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python"
-             "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-meson"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection")
 provides=("${MINGW_PACKAGE_PREFIX}-pygobject-devel"
           "${MINGW_PACKAGE_PREFIX}-python3-gobject=${pkgver}")
@@ -30,16 +31,22 @@ prepare() {
 }
 
 build() {
-  cd "${srcdir}/${_realname}-${pkgver}"
+  [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}
+  mkdir -p build-${MINGW_CHOST} && cd build-${MINGW_CHOST}
 
-  ${MINGW_PREFIX}/bin/python3 setup.py build
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+  meson \
+    --prefix="${MINGW_PREFIX}" \
+    --wrap-mode=nodownload \
+    --auto-features=enabled \
+    --buildtype=plain \
+    ../${_realname}-${pkgver}
+
+  meson compile
 }
 
 package() {
-  cd "${srcdir}/${_realname}-${pkgver}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
 
-  # --no-compile because older packages didn't install .pyc and adding them
-  # would lead to upgrade conflicts
-  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-    ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" --no-compile
+  DESTDIR="${pkgdir}" meson install
 }


### PR DESCRIPTION
setuptools/distutils currently strip all debug info because it forwards build time flags from python, and meson is less of a mess than setuptools/distutils, so let's switch.