### PR TITLE
nextpnr: add ARCH 'ecp5' (prjtrellis)

### DIFF
--- a/mingw-w64-nextpnr/PKGBUILD
+++ b/mingw-w64-nextpnr/PKGBUILD
@@ -28,9 +28,19 @@ makedepends=(
   "git"
 )
 
+if [ "$CARCH" = "i686" ]; then
+  makedepends+=(
+    "${MINGW_PACKAGE_PREFIX}-prjtrellis"
+    "mingw-w64-x86_64-prjtrellis"
+    "mingw-w64-x86_64-cmake"
+  )
+fi
+
 _commit="fd2d4a8f"
-source=("${_realname}::git+https://github.com/YosysHQ/${_realname}.git#commit=${_commit}")
-sha256sums=('SKIP')
+source=("${_realname}::git+https://github.com/YosysHQ/${_realname}.git#commit=${_commit}"
+        'build_chipdbs.sh')
+sha256sums=('SKIP'
+            'SKIP')
 
 pkgver() {
   cd "${_realname}"
@@ -41,17 +51,15 @@ build() {
   cd "${srcdir}/${_realname}"
   git submodule update --init --recursive
 
-  unset _extra-archs
-  if [ "$CARCH" = "x86_64" ]; then
-    _extra_archs=";ecp5"
-  fi
+  MSYSTEM=mingw64 \
+  CHERE_INVOKING=1 \
+  bash -leo pipefail "${srcdir}"/build_chipdbs.sh "$MINGW_PREFIX"
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" cmake \
     -G "MSYS Makefiles" \
-    -DICESTORM_INSTALL_PREFIX="${MINGW_PREFIX}" \
     -DCMAKE_PREFIX_PATH=${MINGW_PREFIX} \
     -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
-    -DARCH="generic;ice40${_extra_archs}" \
+    -DARCH='generic;ice40;ecp5' \
     -DBUILD_HEAP=ON \
     -DUSE_OPENMP=ON \
     -DUSE_IPO=OFF \

--- a/mingw-w64-nextpnr/build_chipdbs.sh
+++ b/mingw-w64-nextpnr/build_chipdbs.sh
@@ -1,0 +1,17 @@
+
+
+export PATH=/mingw64/bin:$PATH
+
+env
+
+uname -a
+
+cd ice40
+cmake -G "MSYS Makefiles" -DICESTORM_INSTALL_PREFIX="$1" .
+make
+cd ..
+
+cd ecp5
+cmake -G "MSYS Makefiles" -DTRELLIS_INSTALL_PREFIX="$1" .
+make
+cd ..


### PR DESCRIPTION
As commented in https://github.com/msys2/MINGW-packages/pull/7509#issuecomment-752734673, one of the components of nextpnr-ecp5 needs more that 4GB to be build. Therefore, it cannot be done in a 32 bit memory space.

The proposed workaround is to use a script and call it in a MINGW64 shell (even on MINGW32 builds) (see https://github.com/lazka/MSYS2-packages/blob/fa0ba92d8608a0393574eb7febd26025a2a7e45b/pacman/makepkg-mingw#L111-L113). However, doing so requires `x86_64-cmake` and `x86_64-prjtrellis` to be available on the MINGW32 build. That's because MINGW32 and MINGW64 jobs are independent in CI, so the MINGW32 build cannot reuse an artifact from the MINGW64 job.