### PR TITLE
update Yosys and GHDL

### DIFF
--- a/mingw-w64-ghdl/PKGBUILD
+++ b/mingw-w64-ghdl/PKGBUILD
@@ -1,18 +1,17 @@
 _realname=ghdl
 pkgbase="mingw-w64-${_realname}"
 pkgname='__placeholder__'
-pkgver=0.37.0.r1123.g8ed35277
+pkgver=0.37.0.r1270.gb65ee8c3
 pkgrel=1
-pkgdesc='GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL (mingw-w64)'
+pkgdesc='GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL'
 arch=('any')
 license=('GPL2+')
 url='https://github.com/ghdl'
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-makedepends=("${MINGW_PACKAGE_PREFIX}-clang" "${MINGW_PACKAGE_PREFIX}-gcc-ada")
-_commit='8ed35277'
-source=("ghdl::git://github.com/ghdl/ghdl.git#commit=${_commit}")
+_commit='b65ee8c3'
+source=("${_realname}::git://github.com/ghdl/ghdl.git#commit=${_commit}")
 sha512sums=('SKIP')
 
 pkgver() {
@@ -26,7 +25,7 @@ build() {
 
   if [ "$CARCH" = "i686" ]; then
     echo 'Configuring ghdl-mcode...'
-    ../${_realname}/configure \
+    MSYS2_ARG_CONV_EXCL="--prefix" ../${_realname}/configure \
         --prefix=${MINGW_PREFIX} \
         --enable-checks \
         --enable-libghdl \
@@ -36,7 +35,9 @@ build() {
 
   if [ "$CARCH" = "x86_64" ]; then
     echo 'Configuring ghdl-llvm...'
-    ../${_realname}/configure \
+    export CC=clang
+    export CXX=clang++
+    MSYS2_ARG_CONV_EXCL="--prefix" ../${_realname}/configure \
         --prefix=${MINGW_PREFIX} \
         --enable-checks \
         --enable-libghdl \
@@ -51,13 +52,16 @@ build() {
 check() {
   cd "${srcdir}/build-${CARCH}"
   make install.vpi.local
-  make test
+  make CC=gcc test
 }
 
 _package() {
   cd "${srcdir}"/build-${CARCH}
-  mkdir -p "${pkgdir}${MINGW_PREFIX}/lib"
+  _lib="${pkgdir}${MINGW_PREFIX}"/lib
+  mkdir -p "${_lib}"
   make DESTDIR="${pkgdir}" install
+
+  sed -i -e 's@.*\(/mingw.*\)@\1@' "${_lib}"/libghdl.link
 
   # License
   install -Dm644 ${srcdir}/${_realname}/doc/licenses.rst ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/licenses.rst
@@ -65,26 +69,27 @@ _package() {
 
 if [ "${CARCH}" = "x86_64" ]; then
   pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-llvm")
-
+  makedepends=("${MINGW_PACKAGE_PREFIX}-clang")
   package() {
     pkgdesc="$pkgdesc (LLVM backend) (mingw-w64)"
     depends=(
-      "${MINGW_PACKAGE_PREFIX}-zlib"
+      "${MINGW_PACKAGE_PREFIX}-gcc-ada"
       "${MINGW_PACKAGE_PREFIX}-clang"
       "${MINGW_PACKAGE_PREFIX}-llvm"
+      "${MINGW_PACKAGE_PREFIX}-zlib"
     )
     options=(!emptydirs)
-
     _package
   }
 fi
 if [ "${CARCH}" = "i686" ]; then
   pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-mcode")
-
   package() {
     pkgdesc="$pkgdesc (mcode backend) (mingw-w64)"
-    depends=("${MINGW_PACKAGE_PREFIX}-zlib")
-
+    depends=(
+      "${MINGW_PACKAGE_PREFIX}-gcc-ada"
+      "${MINGW_PACKAGE_PREFIX}-zlib"
+    )
     _package
   }
 fi

--- a/mingw-w64-yosys/PKGBUILD
+++ b/mingw-w64-yosys/PKGBUILD
@@ -1,26 +1,34 @@
 _realname=yosys
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.9.r10463.da1d06d78
+pkgver=0.9.r10474.b0d4c6395
 pkgrel=1
 pkgdesc="A framework for RTL synthesis tools (mingw-w64)"
 arch=('any')
 license=("ISC")
 url="http://www.clifford.at/yosys/"
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
-depends=("${MINGW_PACKAGE_PREFIX}-ghdl"
-         "${MINGW_PACKAGE_PREFIX}-python")
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-ghdl"
+  "${MINGW_PACKAGE_PREFIX}-python"
+)
 checkdepends=("${MINGW_PACKAGE_PREFIX}-iverilog")
-makedepends=('flex'
-             'git'
-             "${MINGW_PACKAGE_PREFIX}-ghdl"
-             "${MINGW_PACKAGE_PREFIX}-python")
+makedepends=(
+  'flex'
+  'git'
+  "${MINGW_PACKAGE_PREFIX}-ghdl"
+  "${MINGW_PACKAGE_PREFIX}-python"
+)
 
-_commit='da1d06d7'
-source=("${_realname}::git://github.com/YosysHQ/${_realname}.git#commit=${_commit}"
-        "ghdl-yosys-plugin::git://github.com/ghdl/ghdl-yosys-plugin.git#commit=6671d04")
-sha256sums=('SKIP'
-            'SKIP')
+_commit='b0d4c63'
+source=(
+  "${_realname}::git://github.com/YosysHQ/${_realname}.git#commit=${_commit}"
+  "ghdl-yosys-plugin::git://github.com/ghdl/ghdl-yosys-plugin.git#commit=6671d04"
+)
+sha256sums=(
+  'SKIP'
+  'SKIP'
+)
 
 pkgver() {
   cd "${_realname}"
@@ -40,7 +48,7 @@ build() {
 
   mv "${srcdir}/ghdl-yosys-plugin"/src frontends/ghdl
   echo "ENABLE_GHDL=1" >> Makefile.conf
-  echo "GHDL_DIR=${MINGW_PREFIX}" >> Makefile.conf
+  echo "GHDL_PREFIX=${MINGW_PREFIX}" >> Makefile.conf
 
   make \
     GIT_REV="${_commit}" \


### PR DESCRIPTION
- A fix was pushed to Yosys, which is related to building the ghdl-yosys-plugin frontend: YosysHQ/yosys#2515. That's not critical for the yosys package on MSYS2, but it's desirable to bump it.

- Python bindings in GHDL were reorganised and reworked to improve usability. Hence, the GHDL package is bumped.

- There is currently an annoying constraint that prevents users/contributors of MSYS2 from building the Yosys PKGBUILD alone. At the moment, it must be built at the same location where GHDL was built. Since GHDL is/was built in CI, Yosys can "only" be built in CI (unless GHDL is built and installed locally before). Find further details in ghdl/ghdl#1570. This PR patches `libghdl.link` for preventing that constraint.

- In GHDL's repo, the LLVM backend is built with clang. There is work in progress for using LLVM on MINGW32 too, but it's not there yet: ghdl/ghdl#1547. In this PR, the MINGW64 package is built with clang.

- ~~GHDL's Python bindings (pyGHDL) were not included in MSYS2 packages yet. They can be used in the repo (through PYTHONPATH) or installed from sources. However, the version of the repo that users checkout should match the version the package was built from. That's because there is a tight relation between the internal AST and the bindings. To avoid users manually finding and retrieving matching git versions, in this PR the GHDL PKGBUILD recipe is extended for generating `mingw-w64-x86_64-python-pyGHDL` and `mingw-w64-i686-python-pyGHDL`.~~

---

- [x] The last commit in this PR, named `TEST`, is for testing purposes only and it'll be removed when the PR is ready to be merged.
- [x] pyGHDL has an entrypoint defined in the `setup.py`, named `ghdl-ls`. That entrypoint is properly created when `mingw-w64-*-python-pyGHDL` is installed (see https://github.com/umarcor/MINGW-packages/runs/1635326267?check_suite_focus=true#step:7:2885).
- ~~[ ] pyGHDL has two Python dependencies: `pydecor` and `pyVHDLModel`. Ideally, those should be installed automatically when `mingw-w64-*-python-pyGHDL` is installed through `pacman`. Those are Python-only packages that can be installed through pip, and which are defined in the `setup.py`. However, it seems not to work as I'd expect, because those packages need to be installed explicitly. I was told in the chat that `pydecor` and `pyVHDLModel` might need to be packaged as MINGW packages too. Shall I do that?~~

/cc @Paebbels