### PR TITLE
nuspell: fix unused dependencies

### DIFF
--- a/mingw-w64-nuspell/PKGBUILD
+++ b/mingw-w64-nuspell/PKGBUILD
@@ -2,17 +2,15 @@ _realname=nuspell
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.2.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Fast and safe spellchecking C++ library (mingw-w64)"
 arch=('any')
 url="https://nuspell.github.io/"
 license=(LGPL3+)
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-catch"
-             "${MINGW_PACKAGE_PREFIX}-ruby-ronn")
-depends=("${MINGW_PACKAGE_PREFIX}-icu"
-         "${MINGW_PACKAGE_PREFIX}-boost")
+             "${MINGW_PACKAGE_PREFIX}-catch")
+depends=("${MINGW_PACKAGE_PREFIX}-icu")
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/nuspell/nuspell/archive/v${pkgver}.tar.gz")
 sha256sums=('01804d490bec517748ee49fa2f1249f4c99380c26335e32082cdaa02b5b2b4dc')
 sha512sums=('ae9157e9753868c002ed69a765fb705d29d993f3940e11efbc2699778a8b1abee2eb7daa0ff51187b899d6935a215a24662e5b52ec1ef5c644e90a0245f7583d')


### PR DESCRIPTION
Extra unused dependencies are removed from PKGBUILD.