### PR TITLE
zlib: fix building with lld

### DIFF
--- a/mingw-w64-zlib/01-zlib-1.2.11-1-buildsys.mingw.patch
+++ b/mingw-w64-zlib/01-zlib-1.2.11-1-buildsys.mingw.patch
@@ -35,7 +35,7 @@
 +        shared_ext=".dll"
 +        SHAREDLIB='cygz.dll'
 +        IMPORTLIB='libz.dll.a'
-+        LDSHARED=${LDSHARED-"$cc -shared -Wl,-export-all -Wl,--enable-auto-image-base -Wl,--out-implib=${IMPORTLIB}"}
++        LDSHARED=${LDSHARED-"$cc -shared -Wl,--export-all-symbols -Wl,--enable-auto-image-base -Wl,--out-implib=${IMPORTLIB}"}
 +        LDSHAREDLIBC=''
          EXE='.exe' ;;
    MINGW* | mingw*)
@@ -50,7 +50,7 @@
 +        shared_ext=".dll"
 +        SHAREDLIB='zlib1.dll'
 +        IMPORTLIB='libz.dll.a'
-+        LDSHARED=${LDSHARED-"$cc -shared -Wl,-export-all -Wl,--enable-auto-image-base -Wl,--out-implib=${IMPORTLIB}"}
++        LDSHARED=${LDSHARED-"$cc -shared -Wl,--export-all-symbols -Wl,--enable-auto-image-base -Wl,--out-implib=${IMPORTLIB}"}
 +        LDSHAREDLIBC=''
          EXE='.exe' ;;
    QNX*)  # This is for QNX6. I suppose that the QNX rule below is for QNX2,QNX4
@@ -176,12 +176,12 @@
 -examplesh$(EXE): example.o $(SHAREDLIBV)
 -	$(CC) $(CFLAGS) -o $@ example.o -L. $(SHAREDLIBV)
 +examplesh$(EXE): example.o $(SHAREDTARGET)
-+	$(CC) $(CFLAGS) -o $@ example.o -L. $(SHAREDTARGET)
++	$(CC) $(CFLAGS) -o $@ example.o -L. $(IMPORTLIB)
  
 -minigzipsh$(EXE): minigzip.o $(SHAREDLIBV)
 -	$(CC) $(CFLAGS) -o $@ minigzip.o -L. $(SHAREDLIBV)
 +minigzipsh$(EXE): minigzip.o $(SHAREDTARGET)
-+	$(CC) $(CFLAGS) -o $@ minigzip.o -L. $(SHAREDTARGET)
++	$(CC) $(CFLAGS) -o $@ minigzip.o -L. $(IMPORTLIB)
  
  example64$(EXE): example64.o $(STATICLIB)
  	$(CC) $(CFLAGS) -o $@ example64.o $(TEST_LDFLAGS)

--- a/mingw-w64-zlib/PKGBUILD
+++ b/mingw-w64-zlib/PKGBUILD
@@ -8,7 +8,7 @@ _realname=zlib
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.2.11
-pkgrel=8
+pkgrel=9
 pkgdesc="Compression library implementing the deflate compression method found in gzip and PKZIP (mingw-w64)"
 arch=('any')
 license=(ZLIB)
@@ -24,7 +24,7 @@ source=("https://zlib.net/current/${_realname}-${pkgver}.tar.gz"
         07-Add-no-undefined-to-link-to-enable-build-shared-vers.patch
         08-Add-bzip2-library-to-pkg-config-file.patch)
 sha256sums=('c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1'
-            'ac91f905b695d71f6c9c471ac98c14a3ed989a1e2b2a3b1171b3f6dc6bfc31b4'
+            'a87e3ee4b78bed24d2fb77660d5e6022b13046e32cf9d11e9109998fd9af3cd4'
             '3d039f42194aade91dadf4174f55fd6db349fd8044db93875bed1042dcfe1f31'
             '3b36fe536a7458af2a9a494d70d24048da10c43423fd620ed93fa0a6ddd14f78'
             '6677eff383727cef5f6d142892fd1c78b5012e080dcede3d0651f96e9330c4e6'


### PR DESCRIPTION
* `-export-all` is not a valid flag, it should be `--export-all-symbols`
* lld does not accept a DLL when linking, it needs the import library

Some discussion at https://github.com/msys2/MINGW-packages/commit/eb8bd3f78fcf62c4adbf7e775e6149b51951d8b9#r45640675