### PR TITLE
tcl: remove unnecessary patch to stdio behavior

### DIFF
--- a/mingw-w64-tcl/009-fix-using-gnu-print.patch
+++ b/mingw-w64-tcl/009-fix-using-gnu-print.patch
@@ -1,15 +1,3 @@
-diff -Naur tcl8.6.5-orig/win/tclWinInt.h tcl8.6.5/win/tclWinInt.h
---- tcl8.6.11-orig/win/tclWinInt.h	2016-02-25 23:12:38.000000000 +0300
-+++ tcl8.6.11/win/tclWinInt.h	2016-03-03 08:47:51.129171100 +0300
-@@ -57,7 +57,7 @@
- #ifndef TCL_Z_MODIFIER
- #   ifdef _WIN64
- #	if defined(__USE_MINGW_ANSI_STDIO) && __USE_MINGW_ANSI_STDIO
--#         define TCL_Z_MODIFIER        "ll"
-+#         define TCL_Z_MODIFIER        "I64"
- #	else
- #         define TCL_Z_MODIFIER        "I"
- #	endif
 diff -Naur tcl8.6.5-orig/win/Makefile.in tcl8.6.5/win/Makefile.in
 --- tcl8.6.11-orig/win/Makefile.in
 +++ tcl8.6.11/win/Makefile.in

--- a/mingw-w64-tcl/PKGBUILD
+++ b/mingw-w64-tcl/PKGBUILD
@@ -5,7 +5,7 @@ _realname=tcl
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=8.6.11
-pkgrel=1
+pkgrel=2
 pkgdesc="The Tcl scripting language (mingw-w64)"
 arch=('any')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-zlib")
@@ -30,7 +30,7 @@ sha256sums=('8c0486668586672c5693d7d95817cb05a18c5ecca2f40e2836b9578064088258'
             '2b0f41f6704aa964dbfafa0a65dd5ce0ab97e82ff5cbbe2a95a2e8d644cc5550'
             '61d3430f82ee60000eab28758eba9663a747b1e79082758cb59e624aead6c517'
             '3ec2702efb1be6873d6ffd2ffb357637588f835f8817ae65cf0373020fcc7359'
-            '4b95c670394da6c7a53e37ada6316ceb3b00df270653198a079b6910cc0570ea')
+            '894afd1d97c25a2f7b21981810026450d44677a46ba07a32c4025783d027c6d7')
 
 prepare() {
   cd "${srcdir}/tcl${pkgver}"


### PR DESCRIPTION
ll and I64 work fine when __USE_MINGW_ANSI_STDIO is set.

We still remove the setting of __USE_MINGW_ANSI_STDIO=0 on Makefile,
since the rest our packages are built with __USE_MINGW_ANSI_STDIO=1.
See
https://core.tcl-lang.org/tcl/tktview/c9759399735f1979a2e7931fd9f00da20f2fbb7e