### PR TITLE
OpenAI updates

### DIFF
--- a/mingw-w64-ffmpeg-python/PKGBUILD
+++ b/mingw-w64-ffmpeg-python/PKGBUILD
@@ -1,11 +1,14 @@
 # Maintainer: Sarah Ottinger <schalaalexiazeal@gmail.com>
 
 _realname=ffmpeg-python
-pkgbase=mingw-w64-python-${_realname}
-pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.2.0
 pkgrel=1
 pkgdesc='Python bindings for FFmpeg - with complex filtering support (mingw-w64)'
+provides=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+conflicts=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+replaces=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 arch=('any')
 url="https://github.com/kkroening/ffmpeg-python"
 license=('Apache')
@@ -43,5 +46,5 @@ package() {
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
     --root="${pkgdir}" --optimize=1 --skip-build
-  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-python-pytest-mock/PKGBUILD
+++ b/mingw-w64-python-pytest-mock/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=pytest-mock
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=3.4.0
+pkgver=3.5.0
 pkgrel=1
 pkgdesc='Thin-wrapper around the mock package for easier use with py.test (mingw-w64)'
 arch=('any')
@@ -12,7 +12,7 @@ license=('LGPL3')
 depends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools-scm")
 source=("${_realname}-$pkgver.tar.gz::https://github.com/pytest-dev/pytest-mock/archive/v$pkgver.tar.gz")
-sha256sums=('e23de2c0033e7fd5a4b74d5df2b4013a9987b087b563c91cc55e1decc6af132b')
+sha256sums=('36b45039d5fc4086200c53242f59cd1f9f10ec6a9ada5c93f5d64fc2d4427b70')
 
 export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
 

--- a/mingw-w64-python-trimesh/PKGBUILD
+++ b/mingw-w64-python-trimesh/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=trimesh
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=3.8.19
+pkgver=3.9.1
 pkgrel=1
 pkgdesc='Trimesh is a pure Python (2.7-3.4+) library for loading and using triangular meshes with an emphasis on watertight surfaces. (mingw-w64)'
 arch=('any')
@@ -15,7 +15,7 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-python-networkx: graph operations"
 "${MINGW_PACKAGE_PREFIX}-python-scipy: convex hulls"
 "${MINGW_PACKAGE_PREFIX}-python-pyglet: preview windows")
 source=("https://files.pythonhosted.org/packages/source/${_realname::1}/$_realname/$_realname-$pkgver.tar.gz")
-sha256sums=('e2ec4fc75bddf46fd494a9c95adc0bf0fe6f667cae242ead99955ad659d6e375')
+sha256sums=('d19cbdb830a17297aa218ba6ce4955fc11b4b553414289cfd71f58f8144cc91f')
 
 prepare() {  
   cd "$srcdir"


### PR DESCRIPTION
Updated:
- ffmpeg-python: renamed from `python-ffmpeg-python` for less redundancy, reflects AUR package name
- python-pytest-mock 3.5
- python-trimesh 3.9.1