### PR TITLE
rhash: remove makedepends on ruby

### DIFF
--- a/mingw-w64-rhash/PKGBUILD
+++ b/mingw-w64-rhash/PKGBUILD
@@ -4,12 +4,11 @@ _realname=rhash
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.4.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Great utility for computing hash sums (mingw-w64)"
 arch=('any')
 url='https://sourceforge.net/projects/rhash/'
 depends=("${MINGW_PACKAGE_PREFIX}-gettext")
-makedepends=("${MINGW_PACKAGE_PREFIX}-ruby")
 license=('custom' 'BSD')
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/rhash/RHash/archive/v${pkgver}.tar.gz"
         "${_realname}-${pkgver}.tar.gz.asc"::"https://github.com/rhash/RHash/releases/download/v${pkgver}/v${pkgver}.tar.gz.asc")


### PR DESCRIPTION
This dependency is not present on Arch or Gentoo.