### PR TITLE
libffi: disable symbol versioning

### DIFF
--- a/mingw-w64-libffi/PKGBUILD
+++ b/mingw-w64-libffi/PKGBUILD
@@ -5,7 +5,7 @@ _realname=libffi
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.3
-pkgrel=2
+pkgrel=3
 pkgdesc="A portable, high level programming interface to various calling conventions (mingw-w64)"
 arch=('any')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
@@ -27,7 +27,8 @@ build() {
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
     --enable-shared \
-    --enable-static
+    --enable-static \
+    --disable-symvers
   make
 }
 


### PR DESCRIPTION
Fixes linking with lld.