### PR TITLE
readline: fully spell out --export-all-symbols

### DIFF
--- a/mingw-w64-readline/PKGBUILD
+++ b/mingw-w64-readline/PKGBUILD
@@ -6,7 +6,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _basever=8.0
 _patchlevel=004
 pkgver=${_basever}.${_patchlevel}
-pkgrel=1
+pkgrel=2
 pkgdesc="MinGW port of readline for editing typed command lines (mingw-w64)"
 arch=('any')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
@@ -48,6 +48,8 @@ prepare() {
 
   # Remove RPATH from shared objects (FS#14366)
   sed -i 's|-Wl,-rpath,$(libdir) ||g' support/shobj-conf
+  # Fully spell out linker option
+  sed -i 's|-Wl,--export-all |-Wl,--export-all-symbols |g' support/shobj-conf
 }
 
 build() {


### PR DESCRIPTION
Fixes linking with lld.