### PR TITLE
adwaita-icon-theme: makedepend on gtk3

### DIFF
--- a/mingw-w64-adwaita-icon-theme/PKGBUILD
+++ b/mingw-w64-adwaita-icon-theme/PKGBUILD
@@ -4,12 +4,12 @@ _realname=adwaita-icon-theme
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.38.0
-pkgrel=2
+pkgrel=3
 pkgdesc="GNOME icon theme (mingw-w64)"
 arch=('any')
 url="https://www.gnome.org"
 license=("GPL")
-makedepends=("intltool" "icon-naming-utils")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gtk3")
 depends=("${MINGW_PACKAGE_PREFIX}-hicolor-icon-theme"
          "${MINGW_PACKAGE_PREFIX}-librsvg")
 options=(!libtool strip staticlibs)


### PR DESCRIPTION
the build requires gtk-encode-symbolic-svg.exe

Fixes #7624