### PR TITLE
[New Package] Add Mini-XML

### DIFF
--- a/mingw-w64-mxml/PKGBUILD
+++ b/mingw-w64-mxml/PKGBUILD
@@ -1,0 +1,45 @@
+# Contributor: Carlo Bramini <carlo_bramini@users.sourceforge.net>
+
+_realname=mxml
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=3.2
+pkgrel=1
+pkgdesc="A tiny XML library for reading and writing XML files (mingw-w64)"
+arch=('any')
+url="https://www.msweet.org/mxml/"
+license=('Apache-2.0')
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config")
+options=('strip' 'staticlibs')
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/michaelrsweet/${_realname}/archive/v${pkgver}.tar.gz"
+		${_realname}-${pkgver}.patch)
+sha256sums=('1f9b2a2d0dd27915bf32124ca0c108ad4f4e0daba6d001ad10b6a6a97d0a1c24'
+            '95f8947746e9ee5e7e7fb0b453bc0953e825c1ccf7559936f49b870a95f8c7f6')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  patch -p1 -i ${srcdir}/${_realname}-${pkgver}.patch
+}
+
+build() {
+  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
+  cp -a "../${_realname}-${pkgver}/." .
+
+  ./configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --enable-shared
+
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DSTROOT="${pkgdir}" install
+}

--- a/mingw-w64-mxml/mxml-3.2.patch
+++ b/mingw-w64-mxml/mxml-3.2.patch
@@ -1,0 +1,25 @@
+--- mxml-3.2-org/Makefile.in	2020-10-09 23:37:46.000000000 +0200
++++ mxml-3.2-new/Makefile.in	2021-01-09 22:43:25.610793100 +0100
+@@ -169,6 +169,11 @@
+ 	$(RM) $(BUILDROOT)$(libdir)/libmxml.dylib
+ 	$(LN) libmxml.1.dylib $(BUILDROOT)$(libdir)/libmxml.dylib
+ 
++install-mxml1.dll: mxml1.dll
++	echo Installing $< to $(BUILDROOT)$(libdir)...
++	$(INSTALL_DIR) $(BUILDROOT)$(bindir)
++	$(INSTALL_LIB) $< $(BUILDROOT)$(bindir)
++
+ 
+ #
+ # Uninstall everything...
+@@ -200,6 +205,10 @@
+ 	$(RM) $(BUILDROOT)$(libdir)/libmxml.dylib
+ 	$(RM) $(BUILDROOT)$(libdir)/libmxml.1.dylib
+ 
++uninstall-mxml1.dll:
++	echo Uninstalling mxml1.dll from $(BUILDROOT)$(libdir)...
++	$(RM) $(BUILDROOT)$(bindir)/mxml1.dll
++
+ 
+ #
+ # Figure out lines-of-code...


### PR DESCRIPTION
https://www.msweet.org/mxml/

"Mini-XML is a tiny XML library that you can use to read and write XML and XML-like data files in your application without requiring large non-standard libraries. Mini-XML only requires an ANSI C compatible compiler (GCC works, as do most vendors’ ANSI C compilers) and a make program."
