### PR TITLE
openFPGALoader: update to 0.2.1

### DIFF
--- a/mingw-w64-openFPGALoader/PKGBUILD
+++ b/mingw-w64-openFPGALoader/PKGBUILD
@@ -3,48 +3,42 @@
 _realname=openFPGALoader
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.1.r381.ed7e934
-pkgrel=2
+pkgver=0.2.1
+pkgrel=1
 pkgdesc="openFPGALoader: universal utility for programming FPGA (mingw-w64)"
 arch=('any')
 url="https://github.com/trabucayre/openFPGALoader"
 license=('AGPLv3.0')
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
 depends=("${MINGW_PACKAGE_PREFIX}-libftdi")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-make"
-             "git")
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-gcc"
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+)
 
-_commit="ed7e934"
-source=("openFPGALoader::git://github.com/trabucayre/openFPGALoader.git#commit=${_commit}")
-sha256sums=('SKIP')
-
-pkgver() {
-  cd "openFPGALoader"
-  printf "0.1.r%s.%s" "$(git rev-list --count "${_commit}")" "$(git rev-parse --short "${_commit}")"
-}
+source=("${_realname}::https://codeload.github.com/trabucayre/openFPGALoader/tar.gz/v${pkgver}")
+sha256sums=('b0baa1f696007dc1bb4e1d7c5eaab3bfa13230821e51743dded7cfcc7ddb6431')
 
 build() {
-  cd "${srcdir}/${_realname}"
+  cd "${srcdir}/${_realname}-${pkgver}"
   mkdir build
   cd build
   MSYS2_ARG_CONV_EXCL=- cmake \
-    -G "MinGW Makefiles" \
+    -G "MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
     ../
   cmake --build .
 }
 
 check() {
-  "${srcdir}/${_realname}"/build/openFPGALoader.exe --help
+  "${srcdir}/${_realname}-${pkgver}"/build/openFPGALoader.exe --help
 }
 
 package() {
-  cd "${srcdir}/${_realname}"/build
-  mingw32-make DESTDIR="${pkgdir}" install
+  cd "${srcdir}/${_realname}-${pkgver}"/build
+  make DESTDIR="${pkgdir}" install
 
   _licenses="${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
   mkdir -p "${_licenses}"
-  install -m 644 "${srcdir}"/../../LICENSE "${_licenses}"
+  install -m 644 "${srcdir}/${_realname}-${pkgver}"/LICENSE "${_licenses}"
 }


### PR DESCRIPTION
- Tags are now available, so git is not required.
- MSYS makefiles are used instead of MINGW, therefore, `mingw-w64-*-make` is not required.