### PR TITLE
tklib: update to fix install, download from tcl-lang.org

### DIFF
--- a/mingw-w64-tklib/PKGBUILD
+++ b/mingw-w64-tklib/PKGBUILD
@@ -3,7 +3,12 @@
 _realname=tklib
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.7.r1974.57e720fd
+_hash="29e6d0e6da"
+# Increase every time we refresh the package with a new upstream hash:
+_releasecounter=1
+_basever=0.7.0
+pkgver="$_basever+$_releasecounter.$_hash"
+_dir="Tk_Library_Source_Code-$_hash"
 pkgrel=1
 pkgdesc="A companion to Tcllib, for Tk related packages (mingw-w64)"
 arch=('any')
@@ -11,19 +16,13 @@ conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 url='https://core.tcl.tk/tklib/home'
 license=('BSD')
-_commit='57e720fdc39d569d0ff3c8b7455588e247801022'
 depends=("${MINGW_PACKAGE_PREFIX}-tk"
          "${MINGW_PACKAGE_PREFIX}-tcllib")
-source=("git+https://github.com/tcltk/tklib.git#commit=${_commit}")
-sha256sums=('SKIP')
-
-pkgver() {
-  cd "${_realname}"
-  printf '0.7.r%s.%s' "$(git rev-list --count "${_commit}")" "$(git rev-parse --short "${_commit}")"
-}
+source=("https://core.tcl-lang.org/tklib/tarball/29e6d0e6da/$_dir.tar.gz")
+sha256sums=('d9fae8f16b20cf9ccb4179977468cf6dff167ee2bfe230dee16f923f4bf09a6b')
 
 build() {
-  cd ${srcdir}/${_realname}
+  cd ${srcdir}/${_dir}
   ./configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
@@ -33,7 +32,7 @@ build() {
 }
 
 package() {
-  cd ${srcdir}/${_realname}
+  cd ${srcdir}/${_dir}
   make DESTDIR="${pkgdir}" install
   mkdir -p ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/
   cp license.terms ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING


### PR DESCRIPTION
The install script used on the previous package was defective and
ignored several files. Upstream fixed the problem.

The github mirror lags. Now we download the sources directly from
tcl-lang.org, which contains the central repository.