### PR TITLE
eccodes: add eccodes package build

### DIFF
--- a/mingw-w64-eccodes/PKGBUILD
+++ b/mingw-w64-eccodes/PKGBUILD
@@ -1,0 +1,65 @@
+# Contributor: Jeongbin Park <pjb7687@gmail.com>
+
+_realname=eccodes
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=2.19.1
+pkgrel=1
+arch=('any')
+pkgdesc="ECMWF's GRIB and BUFR encoding/decoding library (mingw-w64)"
+depends=("${MINGW_PACKAGE_PREFIX}-netcdf"
+         "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
+         "${MINGW_PACKAGE_PREFIX}-jasper"
+         "${MINGW_PACKAGE_PREFIX}-openjpeg2"
+         "${MINGW_PACKAGE_PREFIX}-libaec"
+         "${MINGW_PACKAGE_PREFIX}-libpng")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "make"
+             "patch"
+             "${MINGW_PACKAGE_PREFIX}-cmake")
+license=('APACHE')
+url="https://confluence.ecmwf.int/display/ECC/ecCodes+Home"
+source=(https://confluence.ecmwf.int/download/attachments/45757960/${_realname}-${pkgver}-Source.tar.gz
+        fix-mingw.patch)
+sha256sums=('9964bed5058e873d514bd4920951122a95963128b12f55aa199d9afbafdd5d4b'
+            'ee7d576af56ae23c954b1ee25562475b6db6e04612c39d7f7a16e8a16eb56c33')
+
+prepare() {
+  cd ${srcdir}/${_realname}-${pkgver}-Source
+  patch -p1 -i ${srcdir}/fix-mingw.patch
+}
+
+build() {
+  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
+  mkdir -p ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
+
+  # CMake options copied from:
+  #   https://github.com/ecmwf/eccodes/blob/master/.appveyor.yml
+  ${MINGW_PREFIX}/bin/cmake \
+    -G"MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DENABLE_FORTRAN=0 \
+    -DENABLE_PYTHON=0 \
+    -DENABLE_NETCDF=1 \
+    -DENABLE_JPG=1 \
+    -DIEEE_LE=1 \
+    -DENABLE_MEMFS=0 \
+    -DENABLE_EXAMPLES=OFF \
+    -DENABLE_TESTS=OFF \
+    ../${_realname}-${pkgver}-Source
+
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR="${pkgdir}" install
+
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/share/licenses/$_realname
+  cp -pf ${srcdir}/${_realname}-${pkgver}-Source/NOTICE \
+    ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}
+  cp -pf ${srcdir}/${_realname}-${pkgver}-Source/LICENSE \
+    ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}
+}

--- a/mingw-w64-eccodes/PKGBUILD
+++ b/mingw-w64-eccodes/PKGBUILD
@@ -27,7 +27,8 @@ sha256sums=('9964bed5058e873d514bd4920951122a95963128b12f55aa199d9afbafdd5d4b'
             'ee7d576af56ae23c954b1ee25562475b6db6e04612c39d7f7a16e8a16eb56c33')
 
 prepare() {
-  tar -xfh ${srcdir}/${_realname}-${pkgver}-Source.tar.gz
+  tar xf ${srcdir}/${_realname}-${pkgver}-Source.tar.gz || \
+  tar xf ${srcdir}/${_realname}-${pkgver}-Source.tar.gz
   cd ${srcdir}/${_realname}-${pkgver}-Source
   patch -p1 -i ${srcdir}/fix-mingw.patch
 }

--- a/mingw-w64-eccodes/PKGBUILD
+++ b/mingw-w64-eccodes/PKGBUILD
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "make"
              "patch"
              "${MINGW_PACKAGE_PREFIX}-cmake")
-license=('APACHE')
+license=('Apache-2.0')
 url="https://confluence.ecmwf.int/display/ECC/ecCodes+Home"
 source=(https://confluence.ecmwf.int/download/attachments/45757960/${_realname}-${pkgver}-Source.tar.gz
         fix-mingw.patch)

--- a/mingw-w64-eccodes/PKGBUILD
+++ b/mingw-w64-eccodes/PKGBUILD
@@ -39,6 +39,8 @@ build() {
 
   # CMake options copied from:
   #   https://github.com/ecmwf/eccodes/blob/master/.appveyor.yml
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake \
     -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \

--- a/mingw-w64-eccodes/PKGBUILD
+++ b/mingw-w64-eccodes/PKGBUILD
@@ -22,10 +22,12 @@ license=('APACHE')
 url="https://confluence.ecmwf.int/display/ECC/ecCodes+Home"
 source=(https://confluence.ecmwf.int/download/attachments/45757960/${_realname}-${pkgver}-Source.tar.gz
         fix-mingw.patch)
+noextract=(${_realname}-${pkgver}-Source.tar.gz)
 sha256sums=('9964bed5058e873d514bd4920951122a95963128b12f55aa199d9afbafdd5d4b'
             'ee7d576af56ae23c954b1ee25562475b6db6e04612c39d7f7a16e8a16eb56c33')
 
 prepare() {
+  tar -xfh ${srcdir}/${_realname}-${pkgver}-Source.tar.gz
   cd ${srcdir}/${_realname}-${pkgver}-Source
   patch -p1 -i ${srcdir}/fix-mingw.patch
 }

--- a/mingw-w64-eccodes/PKGBUILD
+++ b/mingw-w64-eccodes/PKGBUILD
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "make"
              "patch"
              "${MINGW_PACKAGE_PREFIX}-cmake")
-license=('Apache-2.0')
+license=('Apache')
 url="https://confluence.ecmwf.int/display/ECC/ecCodes+Home"
 source=(https://confluence.ecmwf.int/download/attachments/45757960/${_realname}-${pkgver}-Source.tar.gz
         fix-mingw.patch)

--- a/mingw-w64-eccodes/fix-mingw.patch
+++ b/mingw-w64-eccodes/fix-mingw.patch
@@ -1,0 +1,179 @@
+diff -urN eccodes-2.19.1-Source-orig/cmake/ecbuild_add_large_file_support.cmake eccodes-2.19.1-Source/cmake/ecbuild_add_large_file_support.cmake
+--- eccodes-2.19.1-Source-orig/cmake/ecbuild_add_large_file_support.cmake	2020-11-02 12:08:23.000000000 +0100
++++ eccodes-2.19.1-Source/cmake/ecbuild_add_large_file_support.cmake	2021-01-12 12:44:46.718252300 +0100
+@@ -17,7 +17,7 @@
+ 
+   if( EC_SIZEOF_OFF_T LESS "8" )
+ 
+-    if( ${CMAKE_SYSTEM_NAME} MATCHES "Linux" OR ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" )
++    if( ${CMAKE_SYSTEM_NAME} MATCHES "Linux" OR ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" OR MINGW)
+       add_definitions( -D_FILE_OFFSET_BITS=64 )
+     elseif( ${CMAKE_SYSTEM_NAME} MATCHES "AIX" )
+       add_definitions( -D_LARGE_FILES=64 )
+diff -urN eccodes-2.19.1-Source-orig/cmake/ecbuild_bundle.cmake eccodes-2.19.1-Source/cmake/ecbuild_bundle.cmake
+--- eccodes-2.19.1-Source-orig/cmake/ecbuild_bundle.cmake	2020-11-02 12:08:23.000000000 +0100
++++ eccodes-2.19.1-Source/cmake/ecbuild_bundle.cmake	2021-01-11 23:29:52.421765400 +0100
+@@ -159,7 +159,7 @@
+       if( DEFINED ${PNAME}_SOURCE )
+         ecbuild_critical( "ecbuild_bundle called with SOURCE for project ${_PAR_PROJECT} but ${PNAME}_SOURCE is defined" )
+       endif()
+-      execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink ${_PAR_SOURCE} ${PROJECT_SOURCE_DIR}/${_PAR_PROJECT} )
++      execute_process( COMMAND ${CMAKE_COMMAND} -E copy ${_PAR_SOURCE} ${PROJECT_SOURCE_DIR}/${_PAR_PROJECT} )
+     endif()
+ 
+     if( NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${_PAR_PROJECT} OR NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${_PAR_PROJECT}/CMakeLists.txt )
+diff -urN eccodes-2.19.1-Source-orig/cmake/ecbuild_declare_project.cmake eccodes-2.19.1-Source/cmake/ecbuild_declare_project.cmake
+--- eccodes-2.19.1-Source-orig/cmake/ecbuild_declare_project.cmake	2020-11-02 12:08:23.000000000 +0100
++++ eccodes-2.19.1-Source/cmake/ecbuild_declare_project.cmake	2021-01-11 23:30:11.597396900 +0100
+@@ -194,7 +194,7 @@
+ 
+   # make sure nothing breaks if INSTALL_LIB_DIR is not lib
+   if( NOT INSTALL_LIB_DIR STREQUAL "lib" AND NOT EXISTS ${CMAKE_BINARY_DIR}/${INSTALL_LIB_DIR} )
+-    execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink lib ${CMAKE_BINARY_DIR}/${INSTALL_LIB_DIR} )
++    execute_process( COMMAND ${CMAKE_COMMAND} -E copy lib ${CMAKE_BINARY_DIR}/${INSTALL_LIB_DIR} )
+   endif()
+ 
+   # ecbuild_debug_var( CMAKE_INSTALL_RPATH )
+diff -urN eccodes-2.19.1-Source-orig/CMakeLists.txt eccodes-2.19.1-Source/CMakeLists.txt
+--- eccodes-2.19.1-Source-orig/CMakeLists.txt	2020-11-09 14:46:27.000000000 +0100
++++ eccodes-2.19.1-Source/CMakeLists.txt	2021-01-12 13:42:58.548836400 +0100
+@@ -309,6 +309,7 @@
+     set( CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE )
+     set( ECCODES_ON_WINDOWS 1 )
+ 
++    if ( NOT MINGW )
+     # Suppress compliler warnings - see ECC-850
+     # Suppress warnings about using 'insecure' functions. Fixing this would require changes all over
+     # the codebase which would damage portability.
+@@ -317,6 +318,7 @@
+     ecbuild_add_c_flags("/D_CRT_NONSTDC_NO_DEPRECATE")
+     # Suppress C4267: warns about possible loss of data when converting 'size_t' to 'int'.
+     ecbuild_add_c_flags("/wd4267")
++    endif()
+ endif()
+ 
+ ###############################################################################
+@@ -350,7 +352,7 @@
+ 
+ add_definitions( -DHAVE_ECCODES_CONFIG_H )
+ 
+-if( CMAKE_COMPILER_IS_GNUCC )
++if( CMAKE_COMPILER_IS_GNUCC AND NOT MINGW )
+     ecbuild_add_c_flags("-pedantic")
+ endif()
+ 
+diff -urN eccodes-2.19.1-Source-orig/definitions/CMakeLists.txt eccodes-2.19.1-Source/definitions/CMakeLists.txt
+--- eccodes-2.19.1-Source-orig/definitions/CMakeLists.txt	2020-11-09 14:46:27.000000000 +0100
++++ eccodes-2.19.1-Source/definitions/CMakeLists.txt	2021-01-12 13:50:10.188344300 +0100
+@@ -45,7 +45,7 @@
+ # link to the definitions. See GRIB-786
+ file( MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/${INSTALL_DATA_DIR} )
+ if( NOT EXISTS "${CMAKE_BINARY_DIR}/${ECCODES_DEFINITION_SUFF}" )
+-  execute_process( COMMAND "${CMAKE_COMMAND}" "-E" "create_symlink"
++  execute_process( COMMAND "${CMAKE_COMMAND}" "-E" "copy"
+     "${CMAKE_CURRENT_SOURCE_DIR}"
+     "${CMAKE_BINARY_DIR}/${ECCODES_DEFINITION_SUFF}" )
+ endif()
+diff -urN eccodes-2.19.1-Source-orig/eccodes_config.h.in eccodes-2.19.1-Source/eccodes_config.h.in
+--- eccodes-2.19.1-Source-orig/eccodes_config.h.in	2020-11-09 14:46:27.000000000 +0100
++++ eccodes-2.19.1-Source/eccodes_config.h.in	2021-01-12 13:05:30.548720700 +0100
+@@ -111,6 +111,8 @@
+ 
+ #cmakedefine HAVE_MEMFS
+ 
++#cmakedefine ECCODES_ON_WINDOWS
++
+ #ifdef HAVE_MEMFS
+ #undef ECCODES_DEFINITION_PATH
+ #define ECCODES_DEFINITION_PATH "/MEMFS/definitions"
+diff -urN eccodes-2.19.1-Source-orig/ifs_samples/CMakeLists.txt eccodes-2.19.1-Source/ifs_samples/CMakeLists.txt
+--- eccodes-2.19.1-Source-orig/ifs_samples/CMakeLists.txt	2020-11-09 14:46:27.000000000 +0100
++++ eccodes-2.19.1-Source/ifs_samples/CMakeLists.txt	2021-01-11 23:33:10.952510700 +0100
+@@ -14,7 +14,7 @@
+   execute_process( COMMAND ${CMAKE_COMMAND} -E make_directory ${destination_build} )
+   foreach( _file ${_samples} )
+     get_filename_component(_filename ${_file} NAME)
+-    execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink
++    execute_process( COMMAND ${CMAKE_COMMAND} -E copy
+        ${_file} ${destination_build}/${_filename} )
+   endforeach()
+ endfunction()
+diff -urN eccodes-2.19.1-Source-orig/samples/CMakeLists.txt eccodes-2.19.1-Source/samples/CMakeLists.txt
+--- eccodes-2.19.1-Source-orig/samples/CMakeLists.txt	2020-11-09 14:46:27.000000000 +0100
++++ eccodes-2.19.1-Source/samples/CMakeLists.txt	2021-01-11 23:33:26.731000300 +0100
+@@ -16,7 +16,7 @@
+ # link to the samples in the build directory. See GRIB-786
+ file( MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/${INSTALL_DATA_DIR} )
+ if( NOT EXISTS "${CMAKE_BINARY_DIR}/${ECCODES_SAMPLES_SUFF}" )
+-  execute_process( COMMAND "${CMAKE_COMMAND}" "-E" "create_symlink"
++  execute_process( COMMAND "${CMAKE_COMMAND}" "-E" "copy"
+     "${CMAKE_CURRENT_SOURCE_DIR}"
+     "${CMAKE_BINARY_DIR}/${ECCODES_SAMPLES_SUFF}" )
+ endif()
+diff -urN eccodes-2.19.1-Source-orig/src/grib_accessor_class_data_g1second_order_general_extended_packing.c eccodes-2.19.1-Source/src/grib_accessor_class_data_g1second_order_general_extended_packing.c
+--- eccodes-2.19.1-Source-orig/src/grib_accessor_class_data_g1second_order_general_extended_packing.c	2020-11-09 14:46:27.000000000 +0100
++++ eccodes-2.19.1-Source/src/grib_accessor_class_data_g1second_order_general_extended_packing.c	2021-01-12 12:51:50.171483600 +0100
+@@ -205,7 +205,7 @@
+ #define MAX_NUMBER_OF_GROUPS 65534
+ #define EFDEBUG 0
+ 
+-static const unsigned long nbits[64] = {
++static const unsigned long long nbits[64] = {
+     0x1, 0x2, 0x4, 0x8,
+     0x10, 0x20, 0x40, 0x80,
+     0x100, 0x200, 0x400, 0x800,
+@@ -226,7 +226,7 @@
+ 
+ static long number_of_bits(grib_handle* h, unsigned long x)
+ {
+-    const unsigned long* n = nbits;
++    const unsigned long long* n = nbits;
+     const int count        = sizeof(nbits) / sizeof(nbits[0]);
+     long i                 = 0;
+     while (x >= *n) {
+diff -urN eccodes-2.19.1-Source-orig/src/grib_accessor_class_second_order_bits_per_value.c eccodes-2.19.1-Source/src/grib_accessor_class_second_order_bits_per_value.c
+--- eccodes-2.19.1-Source-orig/src/grib_accessor_class_second_order_bits_per_value.c	2020-11-09 14:46:27.000000000 +0100
++++ eccodes-2.19.1-Source/src/grib_accessor_class_second_order_bits_per_value.c	2021-01-12 12:51:41.865058600 +0100
+@@ -151,7 +151,7 @@
+         0x40000000, 0x80000000
+ };
+ */
+-static const unsigned long nbits[64] = {
++static const unsigned long long nbits[64] = {
+     0x1, 0x2, 0x4, 0x8,
+     0x10, 0x20, 0x40, 0x80,
+     0x100, 0x200, 0x400, 0x800,
+@@ -172,7 +172,7 @@
+ 
+ static int number_of_bits(unsigned long x, long* result)
+ {
+-    const unsigned long* n = nbits;
++    const unsigned long long* n = nbits;
+     const int count        = sizeof(nbits) / sizeof(nbits[0]);
+     *result                = 0;
+     while (x >= *n) {
+diff -urN eccodes-2.19.1-Source-orig/src/grib_api_internal.h eccodes-2.19.1-Source/src/grib_api_internal.h
+--- eccodes-2.19.1-Source-orig/src/grib_api_internal.h	2020-11-09 14:46:27.000000000 +0100
++++ eccodes-2.19.1-Source/src/grib_api_internal.h	2021-01-12 13:10:44.839587800 +0100
+@@ -86,7 +86,9 @@
+ #define M_PI 3.14159265358979323846
+ #endif
+ 
++#ifdef _MSC_VER
+ #define R_OK 04 /* Needed for Windows */
++#endif
+ 
+ #ifndef F_OK
+ #define F_OK 0
+diff -urN eccodes-2.19.1-Source-orig/src/grib_context.c eccodes-2.19.1-Source/src/grib_context.c
+--- eccodes-2.19.1-Source-orig/src/grib_context.c	2020-11-09 14:46:27.000000000 +0100
++++ eccodes-2.19.1-Source/src/grib_context.c	2021-01-12 13:48:07.382053500 +0100
+@@ -421,7 +421,7 @@
+         /* On UNIX, when we read from a file we get exactly what is in the file on disk.
+          * But on Windows a file can be opened in binary or text mode. In binary mode the system behaves exactly as in UNIX.
+          */
+-#ifdef ECCODES_ON_WINDOWS
++#ifdef _MSC_VER
+         _set_fmode(_O_BINARY);
+ #endif
+ 


### PR DESCRIPTION
Add eccodes, which is ECMWF's GRIB and BUFR encoding/decoding library.
Github repo: https://github.com/ecmwf/eccodes