### PR TITLE
gtkwave: update to 3.3.108 and add gtk3 package

### DIFF
--- a/mingw-w64-gtkwave/PKGBUILD
+++ b/mingw-w64-gtkwave/PKGBUILD
@@ -1,27 +1,32 @@
 # Contributor Ricky Wu <rickleaf.wu@hotmail.com>
+# Contributor Unai Martinez-Corral <unai.martinezcorral@ehu.eus>
 
 _realname=gtkwave
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.3.107
-pkgrel=3
-pkgdesc='GTKWave is a fully featured GTK+ based wave viewer for Unix, Win32, and Mac OSX'
+pkgver=3.3.108
+pkgrel=1
+pkgdesc='GtkWave, a fully featured GTK+ based wave viewer which reads VCD, GHW, LXT, LXT2, VZT and FST files (mingw-w64)'
 arch=('any')
 url='https://gtkwave.sourceforge.io/'
 license=('GPL')
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
-depends=("${MINGW_PACKAGE_PREFIX}-gtk2"
-         "${MINGW_PACKAGE_PREFIX}-tk"
-         "${MINGW_PACKAGE_PREFIX}-tklib"
-         "${MINGW_PACKAGE_PREFIX}-tcl"
-         "${MINGW_PACKAGE_PREFIX}-tcllib"
-         "${MINGW_PACKAGE_PREFIX}-gtk-update-icon-cache"
-         "${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme")
-makedepends=('perlxml'
-             'intltool'
-             "${MINGW_PACKAGE_PREFIX}-gcc")
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-gtk2"
+  "${MINGW_PACKAGE_PREFIX}-tk"
+  "${MINGW_PACKAGE_PREFIX}-tklib"
+  "${MINGW_PACKAGE_PREFIX}-tcl"
+  "${MINGW_PACKAGE_PREFIX}-tcllib"
+  "${MINGW_PACKAGE_PREFIX}-gtk-update-icon-cache"
+  "${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme"
+)
+makedepends=(
+  'perlxml'
+  'intltool'
+  "${MINGW_PACKAGE_PREFIX}-gcc"
+)
 source=("https://gtkwave.sourceforge.io/${_realname}-${pkgver}.tar.gz")
-sha256sums=('48fe630b0d42585d702dc967c7db8803c6ba68b465ad6697a68aabc08f8576c5')
+sha256sums=('ece447340442e7ad029713789552e8392b75dd3808c882ac5193d42fce55eb3b')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"

--- a/mingw-w64-gtkwave/PKGBUILD
+++ b/mingw-w64-gtkwave/PKGBUILD
@@ -1,9 +1,15 @@
 # Contributor Ricky Wu <rickleaf.wu@hotmail.com>
 # Contributor Unai Martinez-Corral <unai.martinezcorral@ehu.eus>
 
+# NOTE: This package installs the GTK3 build by default, but provides GTK2 versions of three binaries too:
+# - gtkwave-gtk2.exe
+# - rtlbrowse-gtk2.exe
+# - twinwave-gtk2.exe
+# However, mingw-w64-*-gtk2 is not a dependency. Users willing to use the GTK2 binaries need to install it explicitly.
+
 _realname=gtkwave
 pkgbase=mingw-w64-${_realname}
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=3.3.108
 pkgrel=1
 pkgdesc='GtkWave, a fully featured GTK+ based wave viewer which reads VCD, GHW, LXT, LXT2, VZT and FST files (mingw-w64)'
@@ -12,44 +18,60 @@ url='https://gtkwave.sourceforge.io/'
 license=('GPL')
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
 depends=(
-  "${MINGW_PACKAGE_PREFIX}-gtk2"
-  "${MINGW_PACKAGE_PREFIX}-tk"
-  "${MINGW_PACKAGE_PREFIX}-tklib"
+  "${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme"
+  "${MINGW_PACKAGE_PREFIX}-gtk3"
+  "${MINGW_PACKAGE_PREFIX}-gtk-update-icon-cache"
   "${MINGW_PACKAGE_PREFIX}-tcl"
   "${MINGW_PACKAGE_PREFIX}-tcllib"
-  "${MINGW_PACKAGE_PREFIX}-gtk-update-icon-cache"
-  "${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme"
+  "${MINGW_PACKAGE_PREFIX}-tk"
+  "${MINGW_PACKAGE_PREFIX}-tklib"
 )
 makedepends=(
   'perlxml'
   'intltool'
   "${MINGW_PACKAGE_PREFIX}-gcc"
+  "${MINGW_PACKAGE_PREFIX}-gtk2"
 )
-source=("https://gtkwave.sourceforge.io/${_realname}-${pkgver}.tar.gz")
-sha256sums=('ece447340442e7ad029713789552e8392b75dd3808c882ac5193d42fce55eb3b')
+source=("https://gtkwave.sourceforge.io/${_realname}-gtk3-${pkgver}.tar.gz")
+sha256sums=('2ed95ec592a287e4a2fe91f7a10a56769cdf67a8fee353ad81fc7b9cb31f1524')
 
 prepare() {
-  cd "${srcdir}/${_realname}-${pkgver}"
+  cd "${srcdir}/${_realname}-gtk3-${pkgver}"
   ./autogen.sh
 }
 
-build() {
-  mkdir -p "build-${MINGW_CHOST}"
-  cd "build-${MINGW_CHOST}"
+_build() {
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}-$1"
+  cd "${srcdir}/build-${MINGW_CHOST}-$1"
 
-  ../${_realname}-${pkgver}/configure \
-    --prefix=${MINGW_PREFIX} \
-    --host=${MINGW_CHOST} \
-    --target=${MINGW_CHOST} \
-    --build=${MINGW_CHOST} \
-    --with-tcl=${MINGW_PREFIX}/lib \
-    --with-tk=${MINGW_PREFIX}/lib \
-    --disable-mime-update
+  [ "$1" = 'gtk3' ] && _enableGTK3='--enable-gtk3' || _enableGTK3=''
 
+  ../"${_realname}-gtk3-${pkgver}"/configure \
+    --prefix="${MINGW_PREFIX}" \
+    --host="${MINGW_CHOST}" \
+    --target="${MINGW_CHOST}" \
+    --build="${MINGW_CHOST}" \
+    --with-tcl="${MINGW_PREFIX}"/lib \
+    --with-tk="${MINGW_PREFIX}"/lib \
+    --disable-mime-update $_enableGTK3
   make
+  cd ..
+}
+
+build() {
+  _build gtk2
+  _build gtk3
 }
 
 package() {
-  cd "build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"-gtk2
+  make DESTDIR="${pkgdir}" install
+
+  _bin="${pkgdir}/${MINGW_PREFIX}"/bin
+  for item in gtkwave rtlbrowse twinwave; do
+    mv "${_bin}/${item}".exe "${_bin}/${item}"-gtk2.exe
+  done
+
+  cd "${srcdir}/build-${MINGW_CHOST}"-gtk3
   make DESTDIR="${pkgdir}" install
 }


### PR DESCRIPTION
This PR updates gtkwave to 3.3.108. At the same time, instead of building the gtk2 version only, `*-gtk2` and `*-gtk3` packages are provided. Should `*-gtkwave` be set as an alias of one of those?