### PR TITLE
Fix Python "prefix" value.

### DIFF
--- a/mingw-w64-python/5001-fix-getpath-prefix.patch
+++ b/mingw-w64-python/5001-fix-getpath-prefix.patch
@@ -1,0 +1,10 @@
+--- Python-3.8.7/Makefile.pre.in.old	2021-01-15 17:27:43.202384900 +0100
++++ Python-3.8.7/Makefile.pre.in	2021-01-15 18:15:32.881231400 +0100
+@@ -778,6 +778,7 @@
+ 	      -o $@ $(srcdir)/Modules/getbuildinfo.c
+ 
+ Modules/getpath.o: $(srcdir)/Modules/getpath.c Makefile
++	MSYS2_ARG_CONV_EXCL="-DPREFIX=;-DEXEC_PREFIX=" \
+ 	$(CC) -c $(PY_CORE_CFLAGS) -DPYTHONPATH='"$(PYTHONPATH)"' \
+ 		-DPREFIX='"$(prefix)"' \
+ 		-DEXEC_PREFIX='"$(exec_prefix)"' \

--- a/mingw-w64-python/PKGBUILD
+++ b/mingw-w64-python/PKGBUILD
@@ -18,7 +18,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 _pybasever=3.8
 pkgver=${_pybasever}.7
-pkgrel=2
+pkgrel=3
 provides=("${MINGW_PACKAGE_PREFIX}-python3=${pkgver}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3"
            "${MINGW_PACKAGE_PREFIX}-python2<2.7.16-7")
@@ -136,6 +136,7 @@ source=("https://www.python.org/ftp/python/${pkgver%rc?}/Python-${pkgver}.tar.xz
         3010-workaround-missing-lconv-members-mingw.patch
         3011-fix-build-testinternalcapi.patch
         5000-warnings-fixes.patch
+        5001-fix-getpath-prefix.patch
         smoketests.py)
 
 # Helper macros to help make tasks easier #
@@ -308,6 +309,8 @@ prepare() {
 
   apply_patch_with_msg 3011-fix-build-testinternalcapi.patch
 
+  apply_patch_with_msg 5001-fix-getpath-prefix.patch
+
   autoreconf -vfi
 }
 
@@ -381,7 +384,7 @@ build() {
   # We patch importlib which is embedded in C headers, so regenerate them
   make regen-importlib
 
-  make
+  make -j$(nproc)
 
   # Add missing venvlauncher files (issue #7014)
   # FIXME: build these from PC/launcher.c instead
@@ -558,4 +561,5 @@ sha256sums=('ddcc1df16bb5b87aa42ec5d20a5b902f2d088caa269b28e01590f97a798ec50a'
             'd7bbac08482c68d7c45afb5ab7b76832e93ab0490524238eae5886535f35cb4a'
             '005381222cfef42ccc21151845b6d43d25c861f35c2192e5e23c2a14df7938f0'
             '24151631c3e70306ae92ffb8fea38992a752cd0a76771a5e53445f56c2be1f00'
+            'f8461af85761e8999fdf1d7753ebc7b04ab4985ef131af4d6098bb4db6c1c9a6'
             '589ad07c257aba8296df4de7f181a91bd498615f02ce5bc85231535cd25ebf3f')


### PR DESCRIPTION
Fixes #7599
After investigating, I found that libpython gets its prefix value from a PREFIX macro passed to getpath.c during compilation.
The bad news:
1- bug not fixed.
2- Some tests failed
The good news:
1- we know now from where did libpython get its prefix value.
1- The failure message shows a mingw path.
```
Python path configuration:
  PYTHONHOME = (not set)
  PYTHONPATH = (not set)
  program name = 'D:/dev/Bugs/python_mingw/build/main.exe'
  isolated = 0
  environment = 1
  user site = 1
  import site = 1
  sys._base_executable = 'D:/dev/Bugs/python_mingw/build/main.exe'
  sys.base_prefix = '/mingw64'
  sys.base_exec_prefix = '/mingw64'
  sys.executable = 'D:/dev/Bugs/python_mingw/build/main.exe'
  sys.prefix = '/mingw64'
  sys.exec_prefix = '/mingw64'
  sys.path = [
    '/mingw64/lib/python38.zip',
    '/mingw64/lib/python3.8',
    '/mingw64/lib/lib-dynload',
  ]
Could not find platform independent libraries <prefix>
Could not find platform dependent libraries <exec_prefix>
Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]
Fatal Python error: init_fs_encoding: failed to get the Python codec of the filesystem encoding
Python runtime state: core initialized
ModuleNotFoundError: No module named 'encodings'

Current thread 0x00002a98 (most recent call first):
<no Python frame>
```
I think the program failed because it treats those paths as absolute.

Maybe someone can investigate more and get a better fix.