### PR TITLE
Update python-pip to 20.3.3

### DIFF
--- a/mingw-w64-python-pip/PKGBUILD
+++ b/mingw-w64-python-pip/PKGBUILD
@@ -6,8 +6,8 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=20.2.4
-pkgrel=2
+pkgver=20.3.3
+pkgrel=1
 pkgdesc="An easy_install replacement for installing pypi python packages (mingw-w64)"
 arch=('any')
 license=('MIT')
@@ -30,9 +30,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-python-appdirs"
          "${MINGW_PACKAGE_PREFIX}-python-setuptools"
          "${MINGW_PACKAGE_PREFIX}-python-six"
          "${MINGW_PACKAGE_PREFIX}-python-toml"
-         "${MINGW_PACKAGE_PREFIX}-python-webencodings"
-         # add these until https://github.com/pypa/pip/issues/5354#issuecomment-672678167 is resolved
-         "${MINGW_PACKAGE_PREFIX}-python-pyopenssl")
+         "${MINGW_PACKAGE_PREFIX}-python-webencodings")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-sphinx")
 # checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest"
 #               "${MINGW_PACKAGE_PREFIX}-python-scripttest"
@@ -41,11 +39,9 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-sphinx")
 #               "${MINGW_PACKAGE_PREFIX}-python-werkzeug"
 #               "${MINGW_PACKAGE_PREFIX}-python-virtualenv")
 install=${_realname}3-${CARCH}.install
-source=(${_realname}-${pkgver}.tar.gz::https://github.com/pypa/pip/archive/${pkgver}.tar.gz
-        "pip-fix-unbundle.patch::https://github.com/pypa/pip/commit/b215120b5ab1315c963ee409b720753ac690c7f6.patch")
+source=(${_realname}-${pkgver}.tar.gz::https://github.com/pypa/pip/archive/${pkgver}.tar.gz)
 noextract=(${_realname}-${pkgver}.tar.gz)
-sha256sums=('f3a068a9ff1986747514dd07f0a465a5a498c9f426c3198fa88f8a208c98d6a4'
-            'eef6395a9c044e48013e5d4bd06aa96db0fc1884d859c48ebe304bedec6bdb1e')
+sha256sums=('016f8d509871b72fb05da911db513c11059d8a99f4591dda3050a3cf83a29a79')
 
 shopt -s extglob
 
@@ -64,7 +60,6 @@ prepare() {
   rm -rf python-build-${CARCH}| true
   cp -r "${_realname}-${pkgver}" "python-build-${CARCH}"
   cd "python-build-${CARCH}"
-  patch -p1 -i ../pip-fix-unbundle.patch
 }
 
 build() {


### PR DESCRIPTION
This PR updates pip to version 20.3.3 and removes patches that were fixed upstream.