### PR TITLE
ghdl: update to 0.37.0.r1342.geeb25ef2

### DIFF
--- a/mingw-w64-ghdl/PKGBUILD
+++ b/mingw-w64-ghdl/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=ghdl
 pkgbase="mingw-w64-${_realname}"
 pkgname='__placeholder__'
-pkgver=0.37.0.r1270.gb65ee8c3
+pkgver=0.37.0.r1342.geeb25ef2
 pkgrel=1
 pkgdesc='GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL'
 arch=('any')
@@ -10,7 +10,7 @@ url='https://github.com/ghdl'
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_commit='b65ee8c3'
+_commit='eeb25ef2'
 source=("${_realname}::git://github.com/ghdl/ghdl.git#commit=${_commit}")
 sha512sums=('SKIP')
 
@@ -62,6 +62,10 @@ _package() {
   make DESTDIR="${pkgdir}" install
 
   sed -i -e 's@.*\(/mingw.*\)@\1@' "${_lib}"/libghdl.link
+
+  if [ "${CARCH}" = "x86_64" ]; then
+    sed -i -e 's@^-L.*\(/mingw.*\)@-L\1@' "${_lib}"/ghdl/grt.lst
+  fi
 
   # License
   install -Dm644 ${srcdir}/${_realname}/doc/licenses.rst ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/licenses.rst


### PR DESCRIPTION
The libraries included in the package were reworked upstream. Vendor library installation scripts were reworked too (tested on MSYS2, Git for Windows and Powershell, using the MSYS2 packages). This PR picks those enhancements.