### PR TITLE
python-colour-science: update to 0.3.16

### DIFF
--- a/mingw-w64-python-colour-science/PKGBUILD
+++ b/mingw-w64-python-colour-science/PKGBUILD
@@ -1,43 +1,46 @@
 # Contributor: Brien Dieterle <briend@gmail.com>
+# Contributor: Miloš Komarčević <miloskomarcevic@aim.com>
 
 _realname=colour-science
 _pypkgname=colour
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-conflicts=("${MINGW_PACKAGE_PREFIX}-python-${_pypkgname}")
-pkgver=0.3.13
+pkgver=0.3.16
 pkgrel=1
 pkgdesc="Python library for a multitude of colour science applications (mingw-w64)"
 arch=('any')
-license=('BSD-3-Clause')
 url="https://pypi.python.org/pypi/colour-science"
-depends=("${MINGW_PACKAGE_PREFIX}-python"
+license=('BSD-3-Clause')
+depends=("${MINGW_PACKAGE_PREFIX}-python-imageio"
          "${MINGW_PACKAGE_PREFIX}-python-scipy"
          "${MINGW_PACKAGE_PREFIX}-python-six")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
-checkdepends=("${MINGW_PACKAGE_PREFIX}-python-nose")
-options=('staticlibs')
+conflicts=("${MINGW_PACKAGE_PREFIX}-python-${_pypkgname}")
+options=('staticlibs' 'strip' '!debug')
 source=("${_pypkgname}-${pkgver}.tar.gz"::"https://github.com/colour-science/colour/archive/v${pkgver}.tar.gz")
-sha256sums=('397914e44a4401594ee3cc3a317fe8620c5ceeed184dfded92e6af97cedadf55')
+sha256sums=('66926ede9bc8180ba86b83b487c6d0a58e87646b3a4e53bb549a4eae7372d11e')
 
 prepare() {
   cd "${srcdir}"
+
+  rm -rf python-build-${CARCH} | true
   cp -r "${_pypkgname}-${pkgver}" "python-build-${CARCH}"
 }
 
 build() {
+  msg "Python build for ${CARCH}"
   cd "${srcdir}/python-build-${CARCH}"
   ${MINGW_PREFIX}/bin/python setup.py build
 }
 
 check() {
+  msg "Python test for ${CARCH}"
   cd "${srcdir}/python-build-${CARCH}"
-  ${MINGW_PREFIX}/bin/nosetests
+  ${MINGW_PREFIX}/bin/python setup.py check --strict
 }
 
 package() {
   cd "${srcdir}/python-build-${CARCH}"
-
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
     --root="${pkgdir}" --optimize=1 --skip-build


### PR DESCRIPTION
Also align w/ template and remove `nosetests` (0 were being run) in favour of generic Python packaging check.