### PR TITLE
update: parsec to 3.0.2012

### DIFF
--- a/mingw-w64-parsec/PKGBUILD
+++ b/mingw-w64-parsec/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=parsec
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.1.0.r3811.ge3360fad5
+pkgver=3.0.2012
 pkgrel=1
 pkgdesc='PaRSEC: Parallel Runtime Scheduling and Execution Controller (mingw-w64)'
 arch=('any')
@@ -11,18 +11,17 @@ depends=()
 makedepends=("flex"
              "bison"
              "${MINGW_PACKAGE_PREFIX}-hwloc"
-             "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 license=('custom')
 url='http://icl.utk.edu/parsec/'
-_commit='e3360fad5ecfa91e7e090ecdee0dca37f5708326'
-source=("${_realname}"::"git+https://bitbucket.org/icldistcomp/${_realname}#commit=${_commit}")
-sha256sums=('SKIP')
+source=("${_realname}-${pkgver}.tar.gz::https://bitbucket.org/icldistcomp/parsec/get/${_realname}-${pkgver}.tar.gz")
+sha256sums=('96266C70F2069822097775C7859CE0384A21EF3C1BA7314B627966898EC0D6A6')
 
-pkgver() {
-  cd "${_realname}"
-  git describe --long --tags | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g'
+prepare() {
+    cd ${srcdir}
+    rm -rf ${_realname}-${pkgver}.tar.gz
+    cp -r * ${_realname}-${pkgver}
 }
 
 build() {
@@ -40,17 +39,16 @@ build() {
     -DPARSEC_WITH_DEVEL_HEADERS=ON \
     -DBUILD_SHARED_LIBS=OFF \
     -DPARSEC_DIST_WITH_MPI=OFF \
-    -DEXTRA_LIBS="-lwsock32 -lws2_32" \
     -DBUILD_TESTING=OFF \
-    ../${_realname}
-  ninja
+    ../${_realname}-${pkgver}
+  ${MINGW_PREFIX}/bin/cmake --build .
 }
 
 package() {
   #Static Install
   cd "${srcdir}/build-${MINGW_CHOST}-static"
-  DESTDIR=${pkgdir} ninja install
-  install -Dm644 ${srcdir}/${_realname}/License.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+  DESTDIR=${pkgdir} cmake --build . --target install
+  install -Dm644 ${srcdir}/${_realname}-${pkgver}/License.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
 }
 
 # vim: ts=2 sw=2 et:


### PR DESCRIPTION
Switch from git version to last main releas: https://bitbucket.org/icldistcomp/parsec/downloads/?tab=tags