### PR TITLE
rawpy: new package, 0.16.0

### DIFF
--- a/mingw-w64-python-rawpy/PKGBUILD
+++ b/mingw-w64-python-rawpy/PKGBUILD
@@ -1,0 +1,51 @@
+# Maintainer: Miloš Komarčević <miloskomarcevic@aim.com>
+
+_realname=rawpy
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=0.16.0
+pkgrel=1
+pkgdesc='RAW image processing for Python, a wrapper for libraw (mingw-w64)'
+arch=('any')
+url='https://github.com/letmaik/rawpy'
+license=('MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-libraw"
+         "${MINGW_PACKAGE_PREFIX}-python-numpy")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-cython")
+options=('staticlibs' 'strip' '!debug')
+source=("python-$_realname-$pkgver.tar.gz"::"${url}/archive/v${pkgver}.tar.gz"
+        "0001-mingw-setup.patch"::"${url}/commit/ca73a19b1e0a0d795708d9007a00b1da20be7bd2.diff")
+sha256sums=('632c23c116cc32f1a50dd201118f4e908a2a137e339001644a22fbe83ebf4b94'
+            'e5d1c1c5367d50804b16bf09681a1b18942309bffe36f16a4b6e97ff9f4b5677')
+
+prepare() {
+  cd "${srcdir}"
+  pushd "${_realname}-${pkgver}"
+    patch -Nbp1 -i ${srcdir}/0001-mingw-setup.patch
+  popd
+
+  rm -rf python-build-${CARCH} | true
+  cp -r "${_realname}-${pkgver}" "python-build-${CARCH}"
+}
+
+build() {
+  msg "Python build for ${CARCH}"  
+  cd "${srcdir}/python-build-${CARCH}"
+  ${MINGW_PREFIX}/bin/python setup.py build
+}
+
+check() {
+  msg "Python test for ${CARCH}"
+  cd "${srcdir}/python-build-${CARCH}"
+  ${MINGW_PREFIX}/bin/python setup.py check --strict
+}
+
+package() {
+  cd "${srcdir}/python-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}


### PR DESCRIPTION
RAW image processing for Python, a wrapper for libraw

No source available on [PyPi](https://pypi.org/project/rawpy/#files) for eventual pip install, only statically linked MSVC wheels.