### PR TITLE
clang: package function tweaks

### DIFF
--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -541,5 +541,7 @@ package_polly() {
 
 # Wrappers
 for _name in "${pkgname[@]}"; do
-  eval "package_${_name}() { package_${_name#${MINGW_PACKAGE_PREFIX}-}; }";
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
 done

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -429,10 +429,10 @@ package_compiler-rt() {
   ${_make_cmd} -C ../build-${CARCH}/projects/compiler-rt DESTDIR="${pkgdir}" install
 }
 
-package_libcxx() {
+package_libc++() {
   pkgdesc="C++ Standard Library (mingw-w64)"
   url="https://libcxx.llvm.org/"
-  depends="${MINGW_PACKAGE_PREFIX}-gcc-libs"
+  depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 
   cd "${srcdir}/libcxx"
   ${_make_cmd} -C ../build-libcxx-shared-${CARCH}/projects/libcxx DESTDIR="${pkgdir}" install
@@ -449,10 +449,10 @@ package_openmp() {
   ${_make_cmd} -C ../build-${CARCH}/projects/openmp DESTDIR="${pkgdir}" install
 }
 
-package_libcxxabi() {
+package_libc++abi() {
   pkgdesc="C++ Standard Library Support (mingw-w64)"
   url="https://libcxxabi.llvm.org/"
-  depends="${MINGW_PACKAGE_PREFIX}-gcc-libs"
+  depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 
   cd "${srcdir}/libcxxabi"
   ${_make_cmd} -C ../build-libcxx-static-${CARCH}/projects/libcxxabi DESTDIR="${pkgdir}" install
@@ -540,98 +540,6 @@ package_polly() {
 }
 
 # Wrappers
-package_mingw-w64-i686-clang(){
-  package_clang
-}
-
-package_mingw-w64-i686-clang-analyzer(){
-  package_clang-analyzer
-}
-
-package_mingw-w64-i686-clang-tools-extra(){
-  package_clang-tools-extra
-}
-
-package_mingw-w64-i686-compiler-rt(){
-  package_compiler-rt
-}
-
-package_mingw-w64-i686-libc++abi(){
-  package_libcxxabi
-}
-
-package_mingw-w64-i686-libc++(){
-  package_libcxx
-}
-
-package_mingw-w64-i686-openmp(){
-  package_openmp
-}
-
-package_mingw-w64-i686-lld(){
-  package_lld
-}
-
-package_mingw-w64-i686-lldb(){
-  package_lldb
-}
-
-package_mingw-w64-i686-libunwind(){
-  package_libunwind
-}
-
-package_mingw-w64-i686-llvm(){
-  package_llvm
-}
-
-package_mingw-w64-i686-polly(){
-  package_polly
-}
-
-package_mingw-w64-x86_64-clang(){
-  package_clang
-}
-
-package_mingw-w64-x86_64-clang-analyzer(){
-  package_clang-analyzer
-}
-
-package_mingw-w64-x86_64-clang-tools-extra(){
-  package_clang-tools-extra
-}
-
-package_mingw-w64-x86_64-compiler-rt(){
-  package_compiler-rt
-}
-
-package_mingw-w64-x86_64-libc++abi(){
-  package_libcxxabi
-}
-
-package_mingw-w64-x86_64-libc++(){
-  package_libcxx
-}
-
-package_mingw-w64-x86_64-openmp(){
-  package_openmp
-}
-
-package_mingw-w64-x86_64-lld(){
-  package_lld
-}
-
-package_mingw-w64-x86_64-lldb(){
-  package_lldb
-}
-
-package_mingw-w64-x86_64-libunwind(){
-  package_libunwind
-}
-
-package_mingw-w64-x86_64-llvm(){
-  package_llvm
-}
-
-package_mingw-w64-x86_64-polly(){
-  package_polly
-}
+for _name in "${pkgname[@]}"; do
+  eval "package_${_name}() { package_${_name#${MINGW_PACKAGE_PREFIX}-}; }";
+done


### PR DESCRIPTION
Fix depends is not an array in libc++/libc++abi

Fix name libcxx -> libc++.

Use for loop to generate package function wrappers, suggested in https://github.com/msys2/MSYS2-packages/pull/2304#issuecomment-765891946