### PR TITLE
packages for munt and its mt32emu library.

### DIFF
--- a/mingw-w64-mt32emu/PKGBUILD
+++ b/mingw-w64-mt32emu/PKGBUILD
@@ -1,0 +1,44 @@
+# Maintainer: Some One <some.one@some.email.com>
+
+_realname=mt32emu
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=2.4.0
+pkgrel=1
+pkgdesc="mt32emu is a C/C++ library which allows to emulate (approximately) the Roland MT-32, CM-32L and LAPC-I synthesiser modules."
+arch=('any')
+url="munt.sourceforge.net/"
+license=("LGPL2.1")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake")
+options=('strip' 'staticlibs')
+source=("https://sourceforge.net/projects/munt/files/munt/${pkgver}/munt-${pkgver}.tar.gz")
+sha256sums=('b4f7054df1d3f89e2cc683ff6182c4d0a272daceffc4d27fd968b6eaebcdc9ed')
+
+build() {
+  cd "${srcdir}"/munt-${pkgver}/${_realname}
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake.exe \
+      -G"MSYS Makefiles" \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      "${extra_config[@]}" \
+      ../munt-${pkgver}/${_realname}
+  make
+}
+
+package() {
+  cd "${srcdir}"/build-${CARCH}
+
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --build . --target install
+
+  install -Dm644 ${srcdir}/munt-${pkgver}/${_realname}/COPYING.LESSER.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+}

--- a/mingw-w64-munt/PKGBUILD
+++ b/mingw-w64-munt/PKGBUILD
@@ -1,0 +1,49 @@
+# Maintainer: Some One <some.one@some.email.com>
+
+_realname=munt
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=2.4.0
+pkgrel=1
+pkgdesc="Software synthesizer emulating pre-GM MIDI devices such as the Roland MT-32, CM-32L, CM-64 and LAPC-I"
+arch=('any')
+url="munt.sourceforge.net/"
+license=("LGPL2.1" "GPL3")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-glib2"
+			 "${MINGW_PACKAGE_PREFIX}-portaudio"
+             "${MINGW_PACKAGE_PREFIX}-qt5")
+options=('strip' 'staticlibs')
+source=("https://sourceforge.net/projects/${_realname}/files/${_realname}/${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('b4f7054df1d3f89e2cc683ff6182c4d0a272daceffc4d27fd968b6eaebcdc9ed')
+
+build() {
+  cd "${srcdir}"/${_realname}-${pkgver}
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake.exe \
+      -G"MSYS Makefiles" \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      "${extra_config[@]}" \
+      ../${_realname}-${pkgver}
+  make
+}
+
+package() {
+  cd "${srcdir}"/build-${CARCH}
+
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --build . --target install
+
+  install -Dm644 ${srcdir}/${_realname}-${pkgver}/mt32emu_qt/COPYING.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/mt32emu-qt_LICENSE
+  install -Dm644 ${srcdir}/${_realname}-${pkgver}/mt32emu_smf2wav/COPYING.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/mt32emu-smf2wav_LICENSE
+  install -Dm644 ${srcdir}/${_realname}-${pkgver}/mt32emu/COPYING.LESSER.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/mt32emu_LICENSE
+}


### PR DESCRIPTION
munt builds the two programs mt32emu-qt (a QT5 GUI program), mt32emu-smf2wav (commandline tool) as well as the static lib of libmt32emu. mt32emu builds the shared library libmt32emu for use with other programs.
I've split it up because
- the two munt programs need the static build of the lib and the lib's cmake file explicitly disables building shared when building the two programs (https://github.com/munt/munt/blob/master/mt32emu/CMakeLists.txt#L11)

- the lib has no dependencies, so requiring QT5, glib2, portaudio just for the lib seems excessive to me

Package request #7207

I understand that the policy is rather not split the package but I have found no way to do this. Maybe packages support a second build packaging phase but that is beyond me. But I'll surely look into it if you point me there.
Additionally I'm aware MSYS2 likes to be in sync with Arch Linux (https://aur.archlinux.org/packages/munt/) but from what I can tell this also does not provide the shared lib.