### PR TITLE
Muntpackagefixed

### DIFF
--- a/mingw-w64-munt-mt32emu/PKGBUILD
+++ b/mingw-w64-munt-mt32emu/PKGBUILD
@@ -1,24 +1,21 @@
 # Maintainer: Some One <some.one@some.email.com>
 
-_realname=munt
+_realname=munt-mt32emu
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.4.0
 pkgrel=1
-pkgdesc="Software synthesizer emulating pre-GM MIDI devices such as the Roland MT-32, CM-32L, CM-64 and LAPC-I"
+pkgdesc="mt32emu is a C/C++ library which allows to emulate (approximately) the Roland MT-32, CM-32L and LAPC-I synthesiser modules."
 arch=('any')
 url="http://munt.sourceforge.net"
-license=("LGPL2.1" "GPL3")
+license=("LGPL2.1")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake")
-depends=("${MINGW_PACKAGE_PREFIX}-glib2"
-         "${MINGW_PACKAGE_PREFIX}-portaudio"
-         "${MINGW_PACKAGE_PREFIX}-qt5")
 options=('staticlibs')
-source=("https://sourceforge.net/projects/${_realname}/files/${_realname}/${pkgver}/${_realname}-${pkgver}.tar.gz")
+source=("https://sourceforge.net/projects/munt/files/munt/${pkgver}/munt-${pkgver}.tar.gz")
 sha256sums=('b4f7054df1d3f89e2cc683ff6182c4d0a272daceffc4d27fd968b6eaebcdc9ed')
 
 build() {
-  cd "${srcdir}"/${_realname}-${pkgver}
+  cd "${srcdir}"/munt-${pkgver}/mt32emu
   [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
   mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
 
@@ -28,22 +25,18 @@ build() {
   else
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
-  
+
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake.exe \
       -G"MSYS Makefiles" \
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
       "${extra_config[@]}" \
-      ../${_realname}-${pkgver}
+      ../munt-${pkgver}/mt32emu
   make
 }
 
 package() {
-  cd "${srcdir}"/build-${CARCH}/mt32emu_qt
+  cd "${srcdir}"/build-${CARCH}
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --build . --target install
-  install -Dm644 ${srcdir}/${_realname}-${pkgver}/mt32emu_qt/COPYING.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/mt32emu-qt_LICENSE
-
-  cd "${srcdir}"/build-${CARCH}/mt32emu_smf2wav
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --build . --target install
-  install -Dm644 ${srcdir}/${_realname}-${pkgver}/mt32emu_smf2wav/COPYING.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/mt32emu-smf2wav_LICENSE
+  install -Dm644 ${srcdir}/munt-${pkgver}/mt32emu/COPYING.LESSER.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
 }

--- a/mingw-w64-munt/PKGBUILD
+++ b/mingw-w64-munt/PKGBUILD
@@ -1,0 +1,64 @@
+# Maintainer: Some One <some.one@some.email.com>
+
+_realname=munt
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=2.4.0
+pkgrel=1
+pkgdesc="Software synthesizer emulating pre-GM MIDI devices such as the Roland MT-32, CM-32L, CM-64 and LAPC-I"
+arch=('any')
+url="http://munt.sourceforge.net"
+license=("LGPL2.1" "GPL3")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake")
+depends=("${MINGW_PACKAGE_PREFIX}-glib2"
+         "${MINGW_PACKAGE_PREFIX}-portaudio"
+         "${MINGW_PACKAGE_PREFIX}-qt5")
+options=('staticlibs')
+source=("https://sourceforge.net/projects/${_realname}/files/${_realname}/${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('b4f7054df1d3f89e2cc683ff6182c4d0a272daceffc4d27fd968b6eaebcdc9ed')
+
+build() {
+  cd "${srcdir}"/${_realname}-${pkgver}
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+  
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake.exe \
+      -G"MSYS Makefiles" \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      "${extra_config[@]}" \
+      ../${_realname}-${pkgver}
+  make
+
+  #shared mt32emu lib
+  mkdir -p "${srcdir}"/build-${CARCH}/libmt32emu && cd "${srcdir}"/build-${CARCH}/libmt32emu
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake.exe \
+      -G"MSYS Makefiles" \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      "${extra_config[@]}" \
+      ../../${_realname}-${pkgver}/mt32emu
+  make
+}
+
+package() {
+  cd "${srcdir}"/build-${CARCH}/mt32emu_qt
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --build . --target install
+  install -Dm644 ${srcdir}/${_realname}-${pkgver}/mt32emu_qt/COPYING.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/mt32emu-qt_LICENSE
+
+  cd "${srcdir}"/build-${CARCH}/mt32emu_smf2wav
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --build . --target install
+  install -Dm644 ${srcdir}/${_realname}-${pkgver}/mt32emu_smf2wav/COPYING.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/mt32emu-smf2wav_LICENSE
+
+  cd "${srcdir}"/build-${CARCH}/libmt32emu
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --build . --target install
+  install -Dm644 ${srcdir}/${_realname}-${pkgver}/mt32emu/COPYING.LESSER.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/mt32emu_LICENSE
+}


### PR DESCRIPTION
Package(s) for Munt.
The first commit is an all in one solution for the Munt project.

The second commit splits off the mt32emu library for people that just need the library and can do without all the QT5, glib2 and portaudio overhead. Several linux distros are also making use of the library like this.

Done as two commits so you can easily decide the course of action you want to take.

Fixing indentation, full url, depends vs makedepends and resubmitting a pull request