### PR TITLE
ghdl: update to 0.37.0.r1370.g7135caee

### DIFF
--- a/mingw-w64-ghdl/PKGBUILD
+++ b/mingw-w64-ghdl/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=ghdl
 pkgbase="mingw-w64-${_realname}"
 pkgname='__placeholder__'
-pkgver=0.37.0.r1342.geeb25ef2
+pkgver=0.37.0.r1370.g7135caee
 pkgrel=1
 pkgdesc='GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL'
 arch=('any')
@@ -10,7 +10,7 @@ url='https://github.com/ghdl'
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_commit='eeb25ef2'
+_commit='7135caee'
 source=("${_realname}::git://github.com/ghdl/ghdl.git#commit=${_commit}")
 sha512sums=('SKIP')
 


### PR DESCRIPTION
A fix was pushed, which prevents crashes (abortions) when loading shared libraries generated by GHDL, from Python.

Ref: https://github.com/ghdl/ghdl-cosim/actions/runs/514080866