### PR TITLE
openblas: Specify target CPU architecture to restrict advanced SIMD instructions.

### DIFF
--- a/mingw-w64-openblas/PKGBUILD
+++ b/mingw-w64-openblas/PKGBUILD
@@ -5,7 +5,7 @@ _realname=OpenBLAS
 pkgbase=mingw-w64-openblas
 pkgname="${MINGW_PACKAGE_PREFIX}-openblas"
 pkgver=0.3.13
-pkgrel=1
+pkgrel=2
 pkgdesc="An optimized BLAS library based on GotoBLAS2 1.13 BSD, providing optimized blas, lapack, and cblas (mingw-w64)"
 arch=('any')
 url="https://www.openblas.net/"
@@ -49,7 +49,7 @@ build() {
        CC=${MINGW_PREFIX}/bin/gcc                                      \
        FC=${MINGW_PREFIX}/bin/gfortran                                 \
        OPENBLAS_INCLUDE_DIR=${MINGW_PREFIX}/include/${_realname}       \
-       USE_THREAD=1 NUM_THREADS=64
+       USE_THREAD=1 NUM_THREADS=64 TARGET=CORE2
 
   # [[ -d build-${CARCH} ]] && rm -rf build-${CARCH}
   # mkdir -p build-${CARCH} && cd build-${CARCH}


### PR DESCRIPTION
Fixes https://github.com/msys2/MINGW-packages/issues/7827