### PR TITLE
add cppcoro library (header only)

### DIFF
--- a/mingw-w64-cppcoro/PKGBUILD
+++ b/mingw-w64-cppcoro/PKGBUILD
@@ -2,22 +2,22 @@
 _realname=cppcoro
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=r385.69e5754
+pkgver=r390.a87e97f
 pkgrel=1
 pkgdesc=" A library of C++ coroutine abstractions for the coroutines TS (mingw-w64)"
 arch=('any')
 license=("MIT")
 url="https://github.com/lewissbaker/cppcoro"
 makedepends=('git')
-
 _commit='a87e97f'
-source=("${_realname}::https://github.com/lewissbaker/${_realname}.git#commit=${_commit}")     
-md5sums=('SKIP')
+source=("${_realname}::git+https://github.com/lewissbaker/${_realname}.git#commit=${_commit}")
+sha256sums=('SKIP')
 
 pkgver() {
   cd "${srcdir}/${_realname}"
-  printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+  printf "r%s.%s" "$(git rev-list --count "${_commit}")" "$(git rev-parse --short "${_commit}")"
 }
+
 build(){
   # replace all std::experimental with std
 function scan_dir(){

--- a/mingw64-w64-cppcoro/PKGBUILD
+++ b/mingw64-w64-cppcoro/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: https://github.com/cathaysia
+_realname=cppcoro
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=r385.69e5754
+pkgrel=1
+pkgdesc=" A library of C++ coroutine abstractions for the coroutines TS (mingw-w64)"
+arch=('any')
+url="https://github.com/lewissbaker/cppcoro"
+license=("MIT")
+source=("git+https://github.com/Garcia6l20/cppcoro.git")     
+md5sums=('SKIP')
+
+pkgver() {
+  cd "${srcdir}/cppcoro"
+  printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+build(){
+  # replace all std::experimental with std
+function scan_dir(){
+  for file in `ls $1` 
+  do
+      if [ -d $1"/"$file ] 
+      then 
+        scan_dir $1"/"$file
+      else 
+        sed 's/std::experimental/std/g' $1"/"$file | sed 's/experimental\///g' > $1"/"$file
+      fi
+  done
+}
+scan_dir "${srcdir}/cppcoro/include/cppcoro/"
+}
+package() {
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/"
+  cp -r "${srcdir}/cppcoro/include/" "${pkgdir}${MINGW_PREFIX}/include/"
+}

--- a/mingw64-w64-cppcoro/PKGBUILD
+++ b/mingw64-w64-cppcoro/PKGBUILD
@@ -6,13 +6,16 @@ pkgver=r385.69e5754
 pkgrel=1
 pkgdesc=" A library of C++ coroutine abstractions for the coroutines TS (mingw-w64)"
 arch=('any')
-url="https://github.com/lewissbaker/cppcoro"
 license=("MIT")
-source=("git+https://github.com/Garcia6l20/cppcoro.git")     
+url="https://github.com/lewissbaker/cppcoro"
+makedepends=('git')
+
+_commit='a87e97f'
+source=("${_realname}::https://github.com/lewissbaker/${_realname}.git#commit=${_commit}")     
 md5sums=('SKIP')
 
 pkgver() {
-  cd "${srcdir}/cppcoro"
+  cd "${srcdir}/${_realname}"
   printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
 }
 build(){


### PR DESCRIPTION
add support https://github.com/lewissbaker/cppcoro, this can be a header only library, for mingw64, std::experence must be replace, -fcoroutines compile flags must be open.

A built package come here.
[mingw-w64-x86_64-cppcoro-r385.69e5754-1-any.pkg.tar.zip](https://github.com/msys2/MINGW-packages/files/5893208/mingw-w64-x86_64-cppcoro-r385.69e5754-1-any.pkg.tar.zip)


msys/git (or git.exe) was need, but I don't konw how to enable it.