### PR TITLE
scons: don't install man pages

### DIFF
--- a/mingw-w64-scons/0002-fix-missing-man-pages.patch
+++ b/mingw-w64-scons/0002-fix-missing-man-pages.patch
@@ -1,0 +1,15 @@
+--- scons-4.1.0/setup.cfg.orig	2021-01-31 10:39:55.427287700 +0100
++++ scons-4.1.0/setup.cfg	2021-01-31 10:40:42.658639100 +0100
+@@ -64,12 +64,6 @@
+ * = *.txt, *.rst, *.1
+ SCons.Tool.docbook = *.*
+ 
+-
+-[options.data_files]
+-. = build/doc/man/scons.1
+-    build/doc/man/scons-time.1
+-    build/doc/man/sconsign.1
+-
+ [sdist]
+     dist-dir=build/dist
+ 

--- a/mingw-w64-scons/PKGBUILD
+++ b/mingw-w64-scons/PKGBUILD
@@ -4,7 +4,7 @@ _realname=scons
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=4.1.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Extensible Python-based build utility (mingw-w64)"
 arch=('any')
 license=('MIT')
@@ -12,20 +12,22 @@ url="https://scons.org"
 depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/${_realname}/${_realname}/archive/${pkgver}.tar.gz"
-        "0001-fix-mingw-path.patch")
+        "0001-fix-mingw-path.patch"
+        "0002-fix-missing-man-pages.patch")
 sha256sums=('7662af76d971bae3e9c01e6d025d4ff0f547b64cac081298fc19015c9c242311'
-            '4416b87da2d7e2879d6f2fd13796887b0a0de3dfffb9be3ec2f565f794a72048')
+            '4416b87da2d7e2879d6f2fd13796887b0a0de3dfffb9be3ec2f565f794a72048'
+            '10d673ed98436501a0957704d079af3931633a296cc08b3d3a6708006c903f49')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
   patch -Np1 -i "${srcdir}/0001-fix-mingw-path.patch"
+  patch -Np1 -i "${srcdir}/0002-fix-missing-man-pages.patch"
 }
 
 build() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
-  ${MINGW_PREFIX}/bin/python scripts/scons.py doc
   ${MINGW_PREFIX}/bin/python setup.py build
 }
 

--- a/mingw-w64-scons/PKGBUILD
+++ b/mingw-w64-scons/PKGBUILD
@@ -9,8 +9,8 @@ pkgdesc="Extensible Python-based build utility (mingw-w64)"
 arch=('any')
 license=('MIT')
 url="https://scons.org"
-depends=("${MINGW_PACKAGE_PREFIX}-python"
-         "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+depends=("${MINGW_PACKAGE_PREFIX}-python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/${_realname}/${_realname}/archive/${pkgver}.tar.gz"
         "0001-fix-mingw-path.patch"
         "0002-fix-missing-man-pages.patch")


### PR DESCRIPTION
The ones it creates are broken and require some java tool we don't have.