### PR TITLE
python: don't pass -s to LDFLAGS

### DIFF
--- a/mingw-w64-python/PKGBUILD
+++ b/mingw-w64-python/PKGBUILD
@@ -18,7 +18,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 _pybasever=3.8
 pkgver=${_pybasever}.7
-pkgrel=4
+pkgrel=5
 provides=("${MINGW_PACKAGE_PREFIX}-python3=${pkgver}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3"
            "${MINGW_PACKAGE_PREFIX}-python2<2.7.16-7")
@@ -328,9 +328,6 @@ build() {
   CPPFLAGS+=" -I${PREFIX_WIN}/include/ncurses "
 
   declare -a _extra_config
-  if check_option "strip" "y"; then
-    LDFLAGS+=" -s "
-  fi
   if check_option "debug" "n"; then
     CFLAGS+=" -DNDEBUG "
     CXXFLAGS+=" -DNDEBUG "


### PR DESCRIPTION
Not sure why it is there (git history doesn't help).

It results in Python remembering/passing it to setuptools when building extensions
which results in extensions never having debug symbols even if built with "--debug".

Just remove it.