### PR TITLE
clang: libprofiler fix and package func tweaks

### DIFF
--- a/mingw-w64-clang/0201-Compiler-RT-Fix-profiler-building-with-MinGW-GCC.patch
+++ b/mingw-w64-clang/0201-Compiler-RT-Fix-profiler-building-with-MinGW-GCC.patch
@@ -1,0 +1,34 @@
+From 879c1db5d24dcb0ac03f9f6282a09996ff3dc291 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Mateusz=20Miku=C5=82a?= <mati865@gmail.com>
+Date: Tue, 25 Aug 2020 10:16:40 +0300
+Subject: [PATCH] [Compiler-RT] Fix profiler building with MinGW GCC
+
+Differential Revision: https://reviews.llvm.org/D86405
+---
+ lib/profile/InstrProfilingPort.h | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/lib/profile/InstrProfilingPort.h b/lib/profile/InstrProfilingPort.h
+index 4493dd512ff0..cb66c5964ad1 100644
+--- a/lib/profile/InstrProfilingPort.h
++++ b/lib/profile/InstrProfilingPort.h
+@@ -24,11 +24,17 @@
+ #define COMPILER_RT_ALWAYS_INLINE __forceinline
+ #define COMPILER_RT_CLEANUP(x)
+ #elif __GNUC__
+-#define COMPILER_RT_ALIGNAS(x) __attribute__((aligned(x)))
++#ifdef _WIN32
++#define COMPILER_RT_FTRUNCATE(f, l) _chsize(fileno(f), l)
++#define COMPILER_RT_VISIBILITY
++#define COMPILER_RT_WEAK __attribute__((selectany))
++#else
++#define COMPILER_RT_FTRUNCATE(f, l) ftruncate(fileno(f), l)
+ #define COMPILER_RT_VISIBILITY __attribute__((visibility("hidden")))
+ #define COMPILER_RT_WEAK __attribute__((weak))
++#endif
++#define COMPILER_RT_ALIGNAS(x) __attribute__((aligned(x)))
+ #define COMPILER_RT_ALLOCA __builtin_alloca
+-#define COMPILER_RT_FTRUNCATE(f,l) ftruncate(fileno(f),l)
+ #define COMPILER_RT_ALWAYS_INLINE inline __attribute((always_inline))
+ #define COMPILER_RT_CLEANUP(x) __attribute__((cleanup(x)))
+ #endif

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -33,7 +33,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-openmp"
          "${MINGW_PACKAGE_PREFIX}-polly")
 pkgver=11.0.0
-pkgrel=5
+pkgrel=6
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 url="https://llvm.org/"
@@ -84,6 +84,7 @@ source=(${_url}/llvm-${pkgver}.src.tar.xz{,.sig}
         "0104-link-pthread-with-mingw.patch"
         "0105-build-libclang-cpp-fix.patch"
         "0106-cmake-Fix-build-of-attribute-plugin-example-on-Windo.patch"
+        "0201-Compiler-RT-Fix-profiler-building-with-MinGW-GCC.patch"
         "0301-LLD-COFF-Error-out-if-creating-a-DLL-with-too-many-e.patch"
         "0302-LLD-Allow-configuring-default-ld.lld-backend.patch"
         "0303-LLD-Ignore-ELF-tests-when-ld.lld-defaults-to-MinGW.patch"
@@ -140,6 +141,7 @@ sha256sums=('913f68c898dfb4a03b397c5e11c6a2f39d0f22ed7665c9cefa87a34423a72469'
             '53646dd01af2862473e9719c5223366486268891ccbff86413943a432a8342e9'
             'a60f7328d84628a56a9f626e4dc26ffd0c35292c79eeba62ac3d4f25aef2fe5c'
             '0098da33ce4cfea2a6b6943c15e769345f89b84ebea28facff4cc8b92a17bc8f'
+            '6fe253d23be73ceccbc6be07ccbbe7561c5338cb71499062c41ffdf1a8b5469e'
             '0b996f438f7c7bf42c789729dfd588a65d5016386e7032e03e8cd52f1dc8bc73'
             'c74c313e442a5b8fed7c6372ac8ff8f3598c9e33db1b520f1297949e18042e55'
             '2e1705274dfc55466cc8977e61d569a685e18ce07895cbec2ccf3b848eafd8ee'
@@ -199,6 +201,10 @@ prepare() {
       "0104-link-pthread-with-mingw.patch" \
       "0105-build-libclang-cpp-fix.patch" \
       "0106-cmake-Fix-build-of-attribute-plugin-example-on-Windo.patch"
+
+  cd "${srcdir}/compiler-rt-${pkgver}.src"
+  apply_patch_with_msg \
+      "0201-Compiler-RT-Fix-profiler-building-with-MinGW-GCC.patch"
 
   cd "${srcdir}/lld-${pkgver}.src"
   apply_patch_with_msg \

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -429,10 +429,10 @@ package_compiler-rt() {
   ${_make_cmd} -C ../build-${CARCH}/projects/compiler-rt DESTDIR="${pkgdir}" install
 }
 
-package_libcxx() {
+package_libc++() {
   pkgdesc="C++ Standard Library (mingw-w64)"
   url="https://libcxx.llvm.org/"
-  depends="${MINGW_PACKAGE_PREFIX}-gcc-libs"
+  depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 
   cd "${srcdir}/libcxx"
   ${_make_cmd} -C ../build-libcxx-shared-${CARCH}/projects/libcxx DESTDIR="${pkgdir}" install
@@ -449,10 +449,10 @@ package_openmp() {
   ${_make_cmd} -C ../build-${CARCH}/projects/openmp DESTDIR="${pkgdir}" install
 }
 
-package_libcxxabi() {
+package_libc++abi() {
   pkgdesc="C++ Standard Library Support (mingw-w64)"
   url="https://libcxxabi.llvm.org/"
-  depends="${MINGW_PACKAGE_PREFIX}-gcc-libs"
+  depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 
   cd "${srcdir}/libcxxabi"
   ${_make_cmd} -C ../build-libcxx-static-${CARCH}/projects/libcxxabi DESTDIR="${pkgdir}" install
@@ -540,98 +540,8 @@ package_polly() {
 }
 
 # Wrappers
-package_mingw-w64-i686-clang(){
-  package_clang
-}
-
-package_mingw-w64-i686-clang-analyzer(){
-  package_clang-analyzer
-}
-
-package_mingw-w64-i686-clang-tools-extra(){
-  package_clang-tools-extra
-}
-
-package_mingw-w64-i686-compiler-rt(){
-  package_compiler-rt
-}
-
-package_mingw-w64-i686-libc++abi(){
-  package_libcxxabi
-}
-
-package_mingw-w64-i686-libc++(){
-  package_libcxx
-}
-
-package_mingw-w64-i686-openmp(){
-  package_openmp
-}
-
-package_mingw-w64-i686-lld(){
-  package_lld
-}
-
-package_mingw-w64-i686-lldb(){
-  package_lldb
-}
-
-package_mingw-w64-i686-libunwind(){
-  package_libunwind
-}
-
-package_mingw-w64-i686-llvm(){
-  package_llvm
-}
-
-package_mingw-w64-i686-polly(){
-  package_polly
-}
-
-package_mingw-w64-x86_64-clang(){
-  package_clang
-}
-
-package_mingw-w64-x86_64-clang-analyzer(){
-  package_clang-analyzer
-}
-
-package_mingw-w64-x86_64-clang-tools-extra(){
-  package_clang-tools-extra
-}
-
-package_mingw-w64-x86_64-compiler-rt(){
-  package_compiler-rt
-}
-
-package_mingw-w64-x86_64-libc++abi(){
-  package_libcxxabi
-}
-
-package_mingw-w64-x86_64-libc++(){
-  package_libcxx
-}
-
-package_mingw-w64-x86_64-openmp(){
-  package_openmp
-}
-
-package_mingw-w64-x86_64-lld(){
-  package_lld
-}
-
-package_mingw-w64-x86_64-lldb(){
-  package_lldb
-}
-
-package_mingw-w64-x86_64-libunwind(){
-  package_libunwind
-}
-
-package_mingw-w64-x86_64-llvm(){
-  package_llvm
-}
-
-package_mingw-w64-x86_64-polly(){
-  package_polly
-}
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done


### PR DESCRIPTION
Supersedes #7753, with a functional change to make it worthwhile to churn such a large package.

Port of msys2/CLANG-packages#13 to MINGW-packages.  I have been running with this patch for a while.

/cc @mati865 