### PR TITLE
crt/headers/winpthreads: clang prefix handling

### DIFF
--- a/mingw-w64-crt-git/PKGBUILD
+++ b/mingw-w64-crt-git/PKGBUILD
@@ -42,6 +42,7 @@ prepare() {
 
 build() {
   msg "Building ${MINGW_CHOST} CRT"
+  local _crt_configure_args
   case "$CARCH" in
     i686)
       _crt_configure_args="--disable-lib64 --enable-lib32"
@@ -49,7 +50,18 @@ build() {
     x86_64)
       _crt_configure_args="--disable-lib32 --enable-lib64"
     ;;
+    armv7)
+      _crt_configure_args="--disable-lib32 --disable-lib64 --enable-libarm32"
+    ;;
+    aarch64)
+      _crt_configure_args="--disable-lib32 --disable-lib64 --disable-libarm32 --enable-libarm64"
+    ;;
   esac
+
+  local _default_msvcrt=msvcrt
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then
+    _default_msvcrt=ucrt
+  fi
 
   [[ -d ${srcdir}/crt-${MINGW_CHOST} ]] && rm -rf ${srcdir}/crt-${MINGW_CHOST}
   mkdir -p ${srcdir}/crt-${MINGW_CHOST} && cd ${srcdir}/crt-${MINGW_CHOST}
@@ -59,6 +71,7 @@ build() {
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \
     --with-sysroot=${MINGW_PREFIX}/${MINGW_CHOST} \
+    --with-default-msvcrt=${_default_msvcrt} \
     --enable-wildcard \
     ${_crt_configure_args}
   make

--- a/mingw-w64-headers-git/PKGBUILD
+++ b/mingw-w64-headers-git/PKGBUILD
@@ -43,6 +43,22 @@ prepare() {
 }
 
 build() {
+  local _default_win32_winnt
+  case "${CARCH}" in
+    i686|x86_64)
+      _default_win32_winnt=0x601
+      ;;
+    *)
+      # assume any new arches added will be at least Win10
+      _default_win32_winnt=0xA00
+      ;;
+  esac
+
+  local _default_msvcrt=msvcrt
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then
+    _default_msvcrt=ucrt
+  fi
+
   msg "Configuring ${MINGW_CHOST} headers"
   [[ -d ${srcdir}/headers-${MINGW_CHOST} ]] && rm -rf ${srcdir}/headers-${MINGW_CHOST}
   mkdir -p ${srcdir}/headers-${MINGW_CHOST} && cd ${srcdir}/headers-${MINGW_CHOST}
@@ -52,7 +68,8 @@ build() {
     --target=${MINGW_CHOST} \
     --prefix=${MINGW_PREFIX}/${MINGW_CHOST} \
     --enable-sdk=all \
-    --with-default-win32-winnt=0x601 \
+    --with-default-win32-winnt=${_default_win32_winnt} \
+    --with-default-msvcrt=${_default_msvcrt} \
     --enable-idl \
     --without-widl
 }

--- a/mingw-w64-winpthreads-git/PKGBUILD
+++ b/mingw-w64-winpthreads-git/PKGBUILD
@@ -84,7 +84,7 @@ _install_licenses() {
   install -Dm644 ${srcdir}/mingw-w64/mingw-w64-libraries/winpthreads/COPYING ${pkgdir}${MINGW_PREFIX}/share/licenses/$1/mingw-w64-libraries/winpthreads/COPYING
 }
 
-package_winpthreads() {
+package_winpthreads-git() {
   depends=("${MINGW_PACKAGE_PREFIX}-crt-git" "${MINGW_PACKAGE_PREFIX}-libwinpthread-git=${pkgver}")
   provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
   conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
@@ -100,7 +100,7 @@ package_winpthreads() {
   _install_licenses ${_realname}
 }
 
-package_libwinpthread() {
+package_libwinpthread-git() {
   provides=("${MINGW_PACKAGE_PREFIX}-libwinpthread")
   conflicts=("${MINGW_PACKAGE_PREFIX}-libwinpthread")
 
@@ -114,23 +114,10 @@ package_libwinpthread() {
 }
 
 # Wrappers for package functions
-
-# 32-bit wrappers
-package_mingw-w64-i686-winpthreads-git() {
-  package_winpthreads
-}
-
-package_mingw-w64-i686-libwinpthread-git() {
-  package_libwinpthread
-}
-
-# 64-bit wrappers
-package_mingw-w64-x86_64-winpthreads-git() {
-  package_winpthreads
-}
-
-package_mingw-w64-x86_64-libwinpthread-git() {
-  package_libwinpthread
-}
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
 
 # [1] https://locklessinc.com/articles/pthreads_on_windows/


### PR DESCRIPTION
My experiments with clang on aarch64 have been going well, I figured it was time to start getting changes reviewed for inclusion back into MINGW-packages.  These packages seemed like a good place to start, being moderately complicated (not like mingw-w64-clang!), but containing representative techniques.

The packages for the existing MINGW_INSTALLS should be unchanged.

If the MINGW_PACKAGE_PREFIX contains `-clang-` (a "clang prefix"), default to ucrt instead of msvcrt.  (This might also be a handy way to detect, say, `-ucrt-` in MINGW_PACKAGE_PREFIX for a gcc+ucrt variant).

If the CARCH is not i686 or x86_64, default WIN32_WINNT to 0xA00 (Windows 10), under the assumption that any new arches will not be relevant for any older versions.

Appropriate crt configure options for armv7 and aarch64 are added.

winpthreads now use the dynamically-generated package wrapper functions.