### PR TITLE
ghdl: update to 1.0.0

### DIFF
--- a/mingw-w64-ghdl/PKGBUILD
+++ b/mingw-w64-ghdl/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=ghdl
 pkgbase="mingw-w64-${_realname}"
 pkgname='__placeholder__'
-pkgver=0.37.0.r1370.g7135caee
+pkgver=1.0.0
 pkgrel=1
 pkgdesc='GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL'
 arch=('any')
@@ -10,14 +10,14 @@ url='https://github.com/ghdl'
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_commit='7135caee'
+_commit='2fb2384d'
 source=("${_realname}::git://github.com/ghdl/ghdl.git#commit=${_commit}")
 sha512sums=('SKIP')
 
-pkgver() {
-  cd "ghdl"
-  git describe --long | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//g'
-}
+#pkgver() {
+#  cd "ghdl"
+#  git describe --long | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//g'
+#}
 
 build() {
   [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}


### PR DESCRIPTION
After almost 20 years of development, GHDL 1.0.0 was tagged! :tada:

I didn't remove `pkgver()`, because I expect it to be required in future updates.

@lazka, is there any problem with releasing `1.0.0` and the next update being something such as `1.0.0.r75.g55555555`?