### PR TITLE
pyqt3d: new package

### DIFF
--- a/mingw-w64-pyqt3d/PKGBUILD
+++ b/mingw-w64-pyqt3d/PKGBUILD
@@ -11,7 +11,7 @@ replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
           "${MINGW_PACKAGE_PREFIX}-${_realname}-common")
 pkgver=5.15.2
 pkgrel=2
-pkgdesc="Qt5 bindings for Python (mingw-w64)"
+pkgdesc="Qt5 Qt3D bindings for Python (mingw-w64)"
 arch=('any')
 license=('GPL')
 url="https://riverbankcomputing.com/software/pyqt3d"

--- a/mingw-w64-pyqt3d/PKGBUILD
+++ b/mingw-w64-pyqt3d/PKGBUILD
@@ -34,7 +34,6 @@ build() {
 
   MSYS2_ARG_CONV_EXCL="--api-dir=;" \
   ${MINGW_PREFIX}/bin/sip-build \
-    --confirm-license \
     --no-make \
     --api-dir=${MINGW_PREFIX}/share/qt5/qsci/api/python \
     --qmake=${MINGW_PREFIX}/bin/qmake.exe \

--- a/mingw-w64-pyqt3d/PKGBUILD
+++ b/mingw-w64-pyqt3d/PKGBUILD
@@ -1,0 +1,57 @@
+# Contributor: Melven Roehrig-Zoellner <Melven.Roehrig-Zoellner@DLR.de>
+# mostly copied from ../mingw-w64-python-pyqt5/PKGBUILD
+
+_realname=pyqt3d
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
+           "${MINGW_PACKAGE_PREFIX}-${_realname}-common")
+replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
+          "${MINGW_PACKAGE_PREFIX}-${_realname}-common")
+pkgver=5.15.2
+pkgrel=2
+pkgdesc="Qt5 bindings for Python (mingw-w64)"
+arch=('any')
+license=('GPL')
+url="https://riverbankcomputing.com/software/pyqt3d"
+depends=("${MINGW_PACKAGE_PREFIX}-python-pyqt5")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-sip5>=5.5.0"
+             "${MINGW_PACKAGE_PREFIX}-pyqt-builder>=1.7.0")
+options=('strip' 'staticlibs')
+source=(https://pypi.python.org/packages/source/P/PyQt3D/PyQt3D-${pkgver}.tar.gz)
+sha256sums=('26128ee8ed1f0344ba50347af4b9e23c0ba87bc3ae25e2e7c6f145e34d223d1f')
+
+prepare() {
+ cd "${srcdir}"/PyQt3D-${pkgver}
+
+}
+
+build() {
+  [[ -d python-${MINGW_CHOST} ]] && rm -rf python-${MINGW_CHOST}
+  cp -r PyQt3D-${pkgver} python-${MINGW_CHOST} && cd python-${MINGW_CHOST}
+
+  MSYS2_ARG_CONV_EXCL="--api-dir=;" \
+  ${MINGW_PREFIX}/bin/sip-build \
+    --confirm-license \
+    --no-make \
+    --api-dir=${MINGW_PREFIX}/share/qt5/qsci/api/python \
+    --qmake=${MINGW_PREFIX}/bin/qmake.exe \
+    --verbose
+
+    cd build
+    make V=1
+}
+
+package(){
+  local _pysite=$(cygpath -u $(${MINGW_PREFIX}/bin/python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"))
+  cd python-${MINGW_CHOST}/build
+  # INSTALL_ROOT is needed for the QtDesigner module, the other Makefiles use DESTDIR
+  MSYS2_ARG_CONV_EXCL="${_pysite}" \
+  make DESTDIR="${pkgdir}" INSTALL_ROOT="${pkgdir}" install
+
+  # compile Python bytecode
+  ${MINGW_PREFIX}/bin/python -m compileall -d / "$pkgdir"${MINGW_PREFIX}/lib
+  ${MINGW_PREFIX}/bin/python -O -m compileall -d / "$pkgdir"${MINGW_PREFIX}/lib
+}

--- a/mingw-w64-pyqt3d/PKGBUILD
+++ b/mingw-w64-pyqt3d/PKGBUILD
@@ -4,11 +4,6 @@
 _realname=pyqt3d
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
-           "${MINGW_PACKAGE_PREFIX}-${_realname}-common")
-replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
-          "${MINGW_PACKAGE_PREFIX}-${_realname}-common")
 pkgver=5.15.2
 pkgrel=2
 pkgdesc="Qt5 Qt3D bindings for Python (mingw-w64)"
@@ -19,7 +14,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-python-pyqt5")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-sip5>=5.5.0"
              "${MINGW_PACKAGE_PREFIX}-pyqt-builder>=1.7.0")
-options=('strip' 'staticlibs')
 source=(https://pypi.python.org/packages/source/P/PyQt3D/PyQt3D-${pkgver}.tar.gz)
 sha256sums=('26128ee8ed1f0344ba50347af4b9e23c0ba87bc3ae25e2e7c6f145e34d223d1f')
 
@@ -36,21 +30,14 @@ build() {
   ${MINGW_PREFIX}/bin/sip-build \
     --no-make \
     --api-dir=${MINGW_PREFIX}/share/qt5/qsci/api/python \
-    --qmake=${MINGW_PREFIX}/bin/qmake.exe \
-    --verbose
+    --qmake=${MINGW_PREFIX}/bin/qmake.exe
 
     cd build
-    make V=1
+    make
 }
 
 package(){
-  local _pysite=$(cygpath -u $(${MINGW_PREFIX}/bin/python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"))
   cd python-${MINGW_CHOST}/build
-  # INSTALL_ROOT is needed for the QtDesigner module, the other Makefiles use DESTDIR
-  MSYS2_ARG_CONV_EXCL="${_pysite}" \
-  make DESTDIR="${pkgdir}" INSTALL_ROOT="${pkgdir}" install
 
-  # compile Python bytecode
-  ${MINGW_PREFIX}/bin/python -m compileall -d / "$pkgdir"${MINGW_PREFIX}/lib
-  ${MINGW_PREFIX}/bin/python -O -m compileall -d / "$pkgdir"${MINGW_PREFIX}/lib
+  make DESTDIR="${pkgdir}" INSTALL_ROOT="${pkgdir}" install
 }

--- a/mingw-w64-pyqt5-3d/PKGBUILD
+++ b/mingw-w64-pyqt5-3d/PKGBUILD
@@ -1,11 +1,11 @@
 # Contributor: Melven Roehrig-Zoellner <Melven.Roehrig-Zoellner@DLR.de>
 # mostly copied from ../mingw-w64-python-pyqt5/PKGBUILD
 
-_realname=pyqt3d
+_realname=pyqt5-3d
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=5.15.2
-pkgrel=2
+pkgrel=1
 pkgdesc="Qt5 Qt3D bindings for Python (mingw-w64)"
 arch=('any')
 license=('GPL')


### PR DESCRIPTION
New package for mingw-w64-pyqt3d very much copied from mingw-w64-python-pyqt5.

Tested and worked fine for me...<br>

Locally, I had to remove the --confirm-licence for sip-build though.
In this pull request, the flags are identical to those in the python-qt5 package.