### PR TITLE
libraw: force use of OpenMP

### DIFF
--- a/mingw-w64-libraw/LibRaw_force-openmp.patch
+++ b/mingw-w64-libraw/LibRaw_force-openmp.patch
@@ -1,0 +1,22 @@
+diff --git a/libraw/libraw_types.h b/libraw/libraw_types.h
+index 53d1ab96..1492f06c 100644
+--- a/libraw/libraw_types.h
++++ b/libraw/libraw_types.h
+@@ -47,6 +47,9 @@ typedef unsigned __int64 uint64_t;
+ 
+ #if defined(_OPENMP)
+ 
++#if defined(LIBRAW_FORCE_OPENMP)
++#define LIBRAW_USE_OPENMP
++#else
+ #if defined(_WIN32)
+ #if defined(_MSC_VER) &&                                                       \
+     (_MSC_VER >= 1600 || (_MSC_VER == 1500 && _MSC_FULL_VER >= 150030729))
+@@ -67,6 +70,7 @@ typedef unsigned __int64 uint64_t;
+ #define LIBRAW_USE_OPENMP
+ #endif
+ #endif
++#endif
+ 
+ #ifdef LIBRAW_USE_OPENMP
+ #include <omp.h>

--- a/mingw-w64-libraw/PKGBUILD
+++ b/mingw-w64-libraw/PKGBUILD
@@ -1,4 +1,5 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Miloš Komarčević <miloskomarcevic@aim.com>
 
 _realname=LibRaw
 pkgbase=mingw-w64-libraw
@@ -7,7 +8,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.20.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Library for reading RAW files obtained from digital photo cameras (mingw-w64)"
 arch=('any')
 url="https://www.libraw.org/"
@@ -21,22 +22,25 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 options=('staticlibs' 'strip')
 source=("https://www.libraw.org/data/${_realname}-${pkgver}.tar.gz"
-        "LibRaw_obsolete-macros.patch")
+        "LibRaw_obsolete-macros.patch"
+        "LibRaw_force-openmp.patch")
 sha256sums=('dc1b486c2003435733043e4e05273477326e51c3ea554c6864a4eafaff1004a6'
-            '4a31c0ee066f43915beff6f7959b6b2cd246d390720df379bfc047d4cedb6a8f')
+            '4a31c0ee066f43915beff6f7959b6b2cd246d390720df379bfc047d4cedb6a8f'
+            '50ad9fc6b91ed8ed5072d508024e9b745b3c9cfcb5d867db98fd1a3b01a9d326')
 
 prepare() {
-  cd "${srcdir}/${_realname}-${pkgver}"
+  cd "${srcdir}"/${_realname}-${pkgver}
   patch -p1 -i "${srcdir}/LibRaw_obsolete-macros.patch"
+  patch -p1 -i "${srcdir}/LibRaw_force-openmp.patch"
 
   autoreconf -ifv
 }
 
 build() {
-  [[ -d "${srcdir}/build-${CARCH}" ]] && rm -rf "${srcdir}/build-${CARCH}"
-  mkdir -p "${srcdir}/build-${CARCH}" && cd "${srcdir}/build-${CARCH}"
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
 
-  CPPFLAGS+=" -DLIBRAW_NODLL"
+  CPPFLAGS+=" -DLIBRAW_FORCE_OPENMP"
   ../${_realname}-${pkgver}/configure \
       --prefix=${MINGW_PREFIX} \
       --build=${MINGW_CHOST} \
@@ -46,6 +50,9 @@ build() {
 }
 
 package() {
-  cd "${srcdir}/build-${CARCH}"
+  cd "${srcdir}"/build-${CARCH}
+
   make install DESTDIR="${pkgdir}"
+
+  install -Dm644 ${srcdir}/${_realname}-${pkgver}/LICENSE.LGPL ${pkgdir}${MINGW_PREFIX}/share/licenses/libraw/LICENSE
 }

--- a/mingw-w64-libraw/PKGBUILD
+++ b/mingw-w64-libraw/PKGBUILD
@@ -31,6 +31,7 @@ sha256sums=('dc1b486c2003435733043e4e05273477326e51c3ea554c6864a4eafaff1004a6'
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
   patch -p1 -i "${srcdir}/LibRaw_obsolete-macros.patch"
+  # From https://github.com/LibRaw/LibRaw/commit/4c954948ba2de262b9cb23a1843fb8651aa3dcc1
   patch -p1 -i "${srcdir}/LibRaw_force-openmp.patch"
 
   autoreconf -ifv
@@ -54,5 +55,5 @@ package() {
 
   make install DESTDIR="${pkgdir}"
 
-  install -Dm644 ${srcdir}/${_realname}-${pkgver}/LICENSE.LGPL ${pkgdir}${MINGW_PREFIX}/share/licenses/libraw/LICENSE
+  install -Dm644 "${srcdir}"/${_realname}-${pkgver}/LICENSE.LGPL "${pkgdir}"${MINGW_PREFIX}/share/licenses/libraw/LICENSE
 }


### PR DESCRIPTION
See https://github.com/LibRaw/LibRaw/pull/378#issuecomment-770166755

This takes only the relevant part of the upstream commit.