### PR TITLE
uasm: fix build

### DIFF
--- a/mingw-w64-uasm/PKGBUILD
+++ b/mingw-w64-uasm/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=uasm
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=v2.50
+pkgver=2.50.0.623.8d1afb0
 pkgrel=1
 _commit='8d1afb0a040217f87106b0c6b924bf9eb0254a2b'
 pkgdesc="UASM is a free MASM-compatible assembler based on JWasm"
@@ -12,22 +12,29 @@ license=('Watcom-1.0')
 url="https://github.com/Terraspace/UASM"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc")
 options=('strip')
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
-source=("UASM-2.50"::"git+https://github.com/Terraspace/UASM.git#commit=$_commit")
+makedepends=("git" "${MINGW_PACKAGE_PREFIX}-gcc")
+source=("UASM"::"git+https://github.com/Terraspace/UASM.git#commit=$_commit")
 sha256sums=('SKIP')
 
+pkgver() {
+  cd "${srcdir}/UASM"
+  local _ver=$(sed -ne '/#define\s*_UASM_VERSION_STR_\s*"/ { s/^.*"\(.*\)"\s*$/\1/; p; q }' H/globals.h)
+  local _rev=0
+  printf "%s.%s.%s.%s" ${_ver} ${_rev} "$(git rev-list --count $_commit)" "$(git rev-parse --short $_commit)"
+}
+
 prepare() {
-  cd ${srcdir}/UASM-2.50/
+  cd ${srcdir}/UASM/
   rm -rf MinGWR
   sed -i -e 's/^extra_c_flags = .*$/& -fcommon/' GccWin.mak
 }
 
 build() {
-  cd ${srcdir}/UASM-2.50/
+  cd ${srcdir}/UASM/
   make -f GccWin.mak
 }
 
 package() {
-  install -Dm744 ${srcdir}/UASM-2.50/MinGWR/hjwasm.exe "${pkgdir}${MINGW_PREFIX}/bin/${_realname}.exe"
-  install -Dm644 ${srcdir}/UASM-2.50/License.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  install -Dm744 ${srcdir}/UASM/MinGWR/hjwasm.exe "${pkgdir}${MINGW_PREFIX}/bin/${_realname}.exe"
+  install -Dm644 ${srcdir}/UASM/License.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-uasm/PKGBUILD
+++ b/mingw-w64-uasm/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=uasm
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.50.0.623.8d1afb0
+pkgver=2.50.r623.8d1afb0
 pkgrel=1
 _commit='8d1afb0a040217f87106b0c6b924bf9eb0254a2b'
 pkgdesc="UASM is a free MASM-compatible assembler based on JWasm"
@@ -19,8 +19,7 @@ sha256sums=('SKIP')
 pkgver() {
   cd "${srcdir}/UASM"
   local _ver=$(sed -ne '/#define\s*_UASM_VERSION_STR_\s*"/ { s/^.*"\(.*\)"\s*$/\1/; p; q }' H/globals.h)
-  local _rev=0
-  printf "%s.%s.%s.%s" ${_ver} ${_rev} "$(git rev-list --count $_commit)" "$(git rev-parse --short $_commit)"
+  printf "%s.r%s.%s" ${_ver} "$(git rev-list --count $_commit)" "$(git rev-parse --short $_commit)"
 }
 
 prepare() {

--- a/mingw-w64-uasm/PKGBUILD
+++ b/mingw-w64-uasm/PKGBUILD
@@ -5,6 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=v2.50
 pkgrel=1
+_commit='8d1afb0a040217f87106b0c6b924bf9eb0254a2b'
 pkgdesc="UASM is a free MASM-compatible assembler based on JWasm"
 arch=('any')
 license=('Watcom-1.0')
@@ -12,12 +13,13 @@ url="https://github.com/Terraspace/UASM"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc")
 options=('strip')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
-source=(https://github.com/Terraspace/UASM/archive/${pkgver}.tar.gz)
-sha256sums=('2892af8f95bf3e1a8457a550018d9e9b7c07934190b73fb650301ae30074b796')
+source=("UASM-2.50"::"git+https://github.com/Terraspace/UASM.git#commit=$_commit")
+sha256sums=('SKIP')
 
 prepare() {
   cd ${srcdir}/UASM-2.50/
   rm -rf MinGWR
+  sed -i -e 's/^extra_c_flags = .*$/& -fcommon/' GccWin.mak
 }
 
 build() {


### PR DESCRIPTION
Change sources to git repo, pinned to same commit that the package was last built against.

Fix multiple definition errors linking by adding -fcommon to compiler flags.

Fixes #7893

Probably still needs some pkgver adjustment, not sure how to go about that on something that uses branches for versions instead of tags.