### PR TITLE
python-pip: default to install --user by default

### DIFF
--- a/mingw-w64-python-pip/PKGBUILD
+++ b/mingw-w64-python-pip/PKGBUILD
@@ -7,7 +7,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=21.0
-pkgrel=1
+pkgrel=2
 pkgdesc="An easy_install replacement for installing pypi python packages (mingw-w64)"
 arch=('any')
 license=('MIT')
@@ -39,9 +39,11 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-sphinx")
 #               "${MINGW_PACKAGE_PREFIX}-python-werkzeug"
 #               "${MINGW_PACKAGE_PREFIX}-python-virtualenv")
 install=${_realname}3-${CARCH}.install
-source=(${_realname}-${pkgver}.tar.gz::https://github.com/pypa/pip/archive/${pkgver}.tar.gz)
+source=(${_realname}-${pkgver}.tar.gz::https://github.com/pypa/pip/archive/${pkgver}.tar.gz
+        "set_user_default.patch")
 noextract=(${_realname}-${pkgver}.tar.gz)
-sha256sums=('332ca4c404906773bb9d6b96a08758cd2be105d85117e147d29264c54b3dc358')
+sha256sums=('332ca4c404906773bb9d6b96a08758cd2be105d85117e147d29264c54b3dc358'
+            'fdad6ae07326ec81ddae7c62fa70d2fd7a08776a6686d138369a321255f14b08')
 
 shopt -s extglob
 
@@ -50,6 +52,12 @@ prepare() {
   # where dirs are not removed after being used.
   rm -rf ${_realname}-${pkgver}/tests/data/packages/symlinks/docs || true 2> /dev/nul
   bsdtar zxf ${_realname}-${pkgver}.tar.gz || true
+
+  # https://salsa.debian.org/python-team/packages/python-pip/-/blob/master/debian/patches/set_user_default.patch
+  # minus the `os.geteuid` part
+  cd ${_realname}-${pkgver}
+  patch -Np1 -i "${srcdir}/set_user_default.patch"
+  cd ..
 
   # specify that third-party stuff should not be bundled.  This is from Archlinux
   rm -rf ${_realname}-${pkgver}/src/pip/_vendor/!(__init__.py)

--- a/mingw-w64-python-pip/set_user_default.patch
+++ b/mingw-w64-python-pip/set_user_default.patch
@@ -1,0 +1,107 @@
+From: Barry Warsaw <barry@python.org>
+Date: Wed, 10 Feb 2016 11:18:37 -0500
+Subject: Default to --user in non-virtual environments.
+
+When running as a normal user in a non-virtual environment, default to
+--user.  When inside virtual environments, when running as root or when
+--prefix or --target are specified, keep the default behavior.
+
+Author: Didier Roche <didrocks@ubuntu.com>,
+        Barry Warsaw <barry@debian.org>,
+        Anatoly techtonik <techtonik@gmail.com>,
+        Andrej Shadura <andrewsh@debian.org>
+Bug: https://github.com/pypa/pip/issues/1668
+Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=725848
+Bug-Ubuntu: https://bugs.launchpad.net/ubuntu/+source/pip/+bug/1419695
+
+Patch-Name: set_user_default.patch
+---
+ docs/html/user_guide.rst              |  8 +++++---
+ src/pip/_internal/commands/install.py | 32 +++++++++++++++++++++++++++++---
+ 2 files changed, 34 insertions(+), 6 deletions(-)
+
+diff --git a/docs/html/user_guide.rst b/docs/html/user_guide.rst
+index 702a97d..e73305d 100644
+--- a/docs/html/user_guide.rst
++++ b/docs/html/user_guide.rst
+@@ -600,9 +600,11 @@ With Python 2.6 came the `"user scheme" for installation
+ which means that all Python distributions support an alternative install
+ location that is specific to a user.  The default location for each OS is
+ explained in the python documentation for the `site.USER_BASE
+-<https://docs.python.org/3/library/site.html#site.USER_BASE>`_ variable.
+-This mode of installation can be turned on by specifying the :ref:`--user
+-<install_--user>` option to ``pip install``.
++<https://docs.python.org/3/library/site.html#site.USER_BASE>`_ variable.  This mode
++of installation is the default on Debian and derivative systems (--user has no
++effect) when inside non-virtual environments, and when the script is run as
++non-root. This behavior can be turned off by specifying the
++:ref:`--system <install_--system>` option to ``pip install``.
+ 
+ Moreover, the "user scheme" can be customized by setting the
+ ``PYTHONUSERBASE`` environment variable, which updates the value of
+diff --git a/src/pip/_internal/commands/install.py b/src/pip/_internal/commands/install.py
+index 8c2c32f..8471f12 100644
+--- a/src/pip/_internal/commands/install.py
++++ b/src/pip/_internal/commands/install.py
+@@ -46,6 +46,7 @@ if MYPY_CHECK_RUNNING:
+     from pip._internal.req.req_install import InstallRequirement
+     from pip._internal.wheel_builder import BinaryAllowedPredicate
+ 
++from pip._internal.locations import running_under_virtualenv
+ 
+ logger = logging.getLogger(__name__)
+ 
+@@ -110,11 +111,14 @@ class InstallCommand(RequirementCommand):
+             help="Install to the Python user install directory for your "
+                  "platform. Typically ~/.local/, or %APPDATA%\\Python on "
+                  "Windows. (See the Python documentation for site.USER_BASE "
+-                 "for full details.)")
++                 "for full details.)  On Debian systems, this is the "
++                 "default when running outside of a virtual environment "
++                 "and not as root.")
++
+         self.cmd_opts.add_option(
+             '--no-user',
+-            dest='use_user_site',
+-            action='store_false',
++            dest='use_system_location',
++            action='store_true',
+             help=SUPPRESS_HELP)
+         self.cmd_opts.add_option(
+             '--root',
+@@ -131,6 +135,13 @@ class InstallCommand(RequirementCommand):
+             help="Installation prefix where lib, bin and other top-level "
+                  "folders are placed")
+ 
++        self.cmd_opts.add_option(
++            '--system',
++            dest='use_system_location',
++            action='store_true',
++            help="Install using the system scheme (overrides --user on "
++                 "Debian systems)")
++
+         self.cmd_opts.add_option(cmdoptions.build_dir())
+ 
+         self.cmd_opts.add_option(cmdoptions.src())
+@@ -240,6 +251,21 @@ class InstallCommand(RequirementCommand):
+ 
+         cmdoptions.check_dist_restriction(options, check_target=True)
+ 
++        if options.python_version:
++            python_versions = [options.python_version]
++        else:
++            python_versions = None
++
++        # compute install location defaults
++        if (not options.use_user_site and not options.prefix_path and not
++                options.target_dir and not options.use_system_location):
++            if not running_under_virtualenv():
++                options.use_user_site = True
++
++        if options.use_system_location:
++            options.use_user_site = False
++
++        options.src_dir = os.path.abspath(options.src_dir)
+         install_options = options.install_options or []
+ 
+         logger.debug("Using %s", get_pip_version())


### PR DESCRIPTION
This makes `pip install` not install things to pacman managed files by default.

This is what Debian uses.

Adds a new `--system` option which gives the old behavior.

Fixes #6158