### PR TITLE
qt5-static: patch schannel

### DIFF
--- a/mingw-w64-qt5-static/0310-fix-assimp-not-found.patch
+++ b/mingw-w64-qt5-static/0310-fix-assimp-not-found.patch
@@ -1,0 +1,12 @@
+https://bugreports.qt.io/browse/QTBUG-84037
+--- i686/qtquick3d/src/plugins/assetimporters/assimp/assimp.pro.orig	2020-10-27 09:02:12.000000000 +0100
++++ i686/qtquick3d/src/plugins/assetimporters/assimp/assimp.pro	2020-12-28 00:46:02.767974100 +0100
+@@ -10,7 +10,7 @@
+ include($$OUT_PWD/../qtassetimporters-config.pri)
+ 
+ qtConfig(system-assimp):!if(cross_compile:host_build) {
+-    QMAKE_USE_PRIVATE += assimp
++    QMAKE_USE_PRIVATE += quick3d-assimp
+ } else {
+     include(../../../3rdparty/assimp/assimp.pri)
+ }

--- a/mingw-w64-qt5-static/PKGBUILD
+++ b/mingw-w64-qt5-static/PKGBUILD
@@ -115,7 +115,7 @@ _ver_base=5.15.2
 # use 5.6.1-1 hot fix : only the archive name was changed from *-5.6.1.tar.xz to *-5.6.1-1.tar.xz
 _hotfix=
 pkgver=${_ver_base//-/}
-pkgrel=1
+pkgrel=2
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='https://www.qt.io/'
@@ -178,6 +178,7 @@ makedepends=("bison"
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-clang"
              "${MINGW_PACKAGE_PREFIX}-clang-tools-extra"
+             "${MINGW_PACKAGE_PREFIX}-fxc2"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-python"
              "${MINGW_PACKAGE_PREFIX}-ruby"
@@ -231,7 +232,9 @@ source=(#https://download.qt.io/development_releases/qt/${pkgver%.*}/${_ver_base
         0125-qt5-windeployqt-fixes.patch
         0300-qt-5.8.0-cast-errors.patch
         0302-ugly-hack-disable-qdoc-build.patch
-        0304-qtdeclarative-disable-dx12.patch)
+        0304-qtdeclarative-disable-dx12.patch
+        0310-fix-assimp-not-found.patch
+        'fad2dc11.diff.zip::https://codereview.qt-project.org/changes/qt%2Fqtbase~333051/revisions/1/patch?zip')
 
 # Translates using cygpath according to the ${_make} being used
 # (so either mingw32-make or MSYS2 make can be used)
@@ -330,7 +333,13 @@ prepare() {
     0063-enable-mingw-schannel-alpn.patch \
     0125-qt5-windeployqt-fixes.patch \
     0300-qt-5.8.0-cast-errors.patch \
-    0304-qtdeclarative-disable-dx12.patch
+    0304-qtdeclarative-disable-dx12.patch \
+    0310-fix-assimp-not-found.patch
+
+  # https://codereview.qt-project.org/c/qt/qtbase/+/333051
+  cd qtbase
+  apply_patch_with_msg fad2dc11.diff
+  cd -
 
   # See: https://bugreports.qt.io/browse/QTBUG-37902
   # _ver_num=${_ver_base%%-*}
@@ -442,6 +451,9 @@ build() {
   #if [ "${_variant}" = "-static" ]; then
   #  export OPENSSL_LIBS="-lssl -lcrypto -lws2_32 -lcrypt32 -lgdi32"
   #fi
+
+  # https://github.com/msys2/MSYS2-packages/issues/2282
+  export MSYS2_ARG_CONV_EXCL='--foreign-types='
 
   # Qt manages the compiler flags for release / debug configs separately, so having our own values (-O2) is harmful here ..
   unset CFLAGS
@@ -803,4 +815,6 @@ sha256sums=('3a530d1b243b5dec00bc54937455471aaa3e56849d2593edb8ded07228202240'
             '28ad823dc8b6665de7b552e82411a8b7b25bf716c42597d8dc8644bded63199c'
             '9ea7aeb486023f3aebf1af44603ebd9266009aaeaf91e52c37c8c5154ea3900c'
             '7e57ce20b6707bc3b4a727da3287cadda13a74317d86515358b2535bc15244c7'
-            '052c7035ad9a4fc0321975ba7658fb755bbc0841c7e1d9e88bb0a15e6a90b770')
+            '052c7035ad9a4fc0321975ba7658fb755bbc0841c7e1d9e88bb0a15e6a90b770'
+            '157b97b3e3031d93d93e45368a1c54ebfbf9578116f75f5126e977e5dd518191'
+            '502e61c1a1750f6bbc3aa7149e5e4c5ec96a1c5a91bee290771a35e172b45bb4')

--- a/mingw-w64-qt5/PKGBUILD
+++ b/mingw-w64-qt5/PKGBUILD
@@ -233,7 +233,8 @@ source=(#https://download.qt.io/development_releases/qt/${pkgver%.*}/${_ver_base
         0300-qt-5.8.0-cast-errors.patch
         0302-ugly-hack-disable-qdoc-build.patch
         0304-qtdeclarative-disable-dx12.patch
-        0310-fix-assimp-not-found.patch)
+        0310-fix-assimp-not-found.patch
+        'fad2dc11.diff.zip::https://codereview.qt-project.org/changes/qt%2Fqtbase~333051/revisions/1/patch?zip')
 
 # Translates using cygpath according to the ${_make} being used
 # (so either mingw32-make or MSYS2 make can be used)
@@ -334,6 +335,11 @@ prepare() {
     0300-qt-5.8.0-cast-errors.patch \
     0304-qtdeclarative-disable-dx12.patch \
     0310-fix-assimp-not-found.patch
+
+  # https://codereview.qt-project.org/c/qt/qtbase/+/333051
+  cd qtbase
+  apply_patch_with_msg fad2dc11.diff
+  cd -
 
   # See: https://bugreports.qt.io/browse/QTBUG-37902
   # _ver_num=${_ver_base%%-*}
@@ -810,4 +816,5 @@ sha256sums=('3a530d1b243b5dec00bc54937455471aaa3e56849d2593edb8ded07228202240'
             '9ea7aeb486023f3aebf1af44603ebd9266009aaeaf91e52c37c8c5154ea3900c'
             '7e57ce20b6707bc3b4a727da3287cadda13a74317d86515358b2535bc15244c7'
             '052c7035ad9a4fc0321975ba7658fb755bbc0841c7e1d9e88bb0a15e6a90b770'
-            '157b97b3e3031d93d93e45368a1c54ebfbf9578116f75f5126e977e5dd518191')
+            '157b97b3e3031d93d93e45368a1c54ebfbf9578116f75f5126e977e5dd518191'
+            '502e61c1a1750f6bbc3aa7149e5e4c5ec96a1c5a91bee290771a35e172b45bb4')

--- a/mingw-w64-qt5/PKGBUILD
+++ b/mingw-w64-qt5/PKGBUILD
@@ -115,7 +115,7 @@ _ver_base=5.15.2
 # use 5.6.1-1 hot fix : only the archive name was changed from *-5.6.1.tar.xz to *-5.6.1-1.tar.xz
 _hotfix=
 pkgver=${_ver_base//-/}
-pkgrel=5
+pkgrel=6
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='https://www.qt.io/'


### PR DESCRIPTION
since 5.15 it was chosen to build tls support via schannel
unfortunately this is broken in some cases
add a patch to mitigate that while keeping on using it
(from https://codereview.qt-project.org/c/qt/qtbase/+/333051)

sync up PKGBUILDs