### PR TITLE
Split package template

### DIFF
--- a/mingw-w64-PKGBUILD-templates/mingw-w64-splitpkg-wrappers-1.0.template
+++ b/mingw-w64-PKGBUILD-templates/mingw-w64-splitpkg-wrappers-1.0.template
@@ -1,0 +1,8 @@
+# vim: set ft=bash :
+
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done

--- a/mingw-w64-brotli/PKGBUILD
+++ b/mingw-w64-brotli/PKGBUILD
@@ -90,26 +90,13 @@ package_brotli-testdata() {
   install -D -m644 "${srcdir}"/brotli-${pkgver}/LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-testdata/LICENSE"
 }
 
-package_mingw-w64-i686-brotli() {
-  package_brotli
-}
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
 
-package_mingw-w64-i686-brotli-testdata() {
-  package_brotli-testdata
-}
-
-package_mingw-w64-i686-python-brotli() {
-  package_python-brotli
-}
-
-package_mingw-w64-x86_64-brotli() {
-  package_brotli
-}
-
-package_mingw-w64-x86_64-brotli-testdata() {
-  package_brotli-testdata
-}
-
-package_mingw-w64-x86_64-python-brotli() {
-  package_python-brotli
-}
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;

--- a/mingw-w64-bullet/PKGBUILD
+++ b/mingw-w64-bullet/PKGBUILD
@@ -46,7 +46,7 @@ build() {
   plain "No step"
 }
 
-build_release() {
+package_bullet() {
   depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
            "${MINGW_PACKAGE_PREFIX}-freeglut"
            "${MINGW_PACKAGE_PREFIX}-openvr")
@@ -81,7 +81,7 @@ build_release() {
   done
 }
 
-build_debug() {
+package_bullet-debug() {
   depends=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}-${pkgrel}")
 
   [[ -d build-debug ]] && rm -rf build-debug
@@ -110,18 +110,13 @@ build_debug() {
 
 }
 
-package_mingw-w64-i686-bullet() {
-  build_release
-}
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
 
-package_mingw-w64-i686-bullet-debug() {
-  build_debug
-}
-
-package_mingw-w64-x86_64-bullet() {
-  build_release
-}
-
-package_mingw-w64-x86_64-bullet-debug() {
-  build_debug
-}
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;

--- a/mingw-w64-capstone/PKGBUILD
+++ b/mingw-w64-capstone/PKGBUILD
@@ -46,9 +46,6 @@ package_capstone() {
   install -Dm644 "${srcdir}/${_realname}-${_pkgver}/LICENSE.TXT" -t "${pkgdir}/${MINGW_PREFIX}/share/licenses/${_realname}"
 }
 
-package_mingw-w64-i686-capstone()   { package_capstone; }
-package_mingw-w64-x86_64-capstone() { package_capstone; }
-
 package_python-capstone() {
   depends=("${MINGW_PACKAGE_PREFIX}-capstone"
            "${MINGW_PACKAGE_PREFIX}-python")
@@ -64,5 +61,13 @@ package_python-capstone() {
   install -Dm644 "${srcdir}/${_realname}-${_pkgver}/LICENSE.TXT" -t "${pkgdir}/${MINGW_PREFIX}/share/licenses/python-${_realname}"
 }
 
-package_mingw-w64-i686-python-capstone()   { package_python-capstone; }
-package_mingw-w64-x86_64-python-capstone() { package_python-capstone; }
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
+
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;

--- a/mingw-w64-dlib/PKGBUILD
+++ b/mingw-w64-dlib/PKGBUILD
@@ -113,18 +113,13 @@ package_python-dlib() {
     ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" --optimize=1 --skip-build
 }
 
-package_mingw-w64-i686-dlib() {
-  package_dlib
-}
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
 
-package_mingw-w64-x86_64-dlib() {
-  package_dlib
-}
-
-package_mingw-w64-i686-python-dlib() {
-  package_python-dlib
-}
-
-package_mingw-w64-x86_64-python-dlib() {
-  package_python-dlib
-}
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;

--- a/mingw-w64-gdb/PKGBUILD
+++ b/mingw-w64-gdb/PKGBUILD
@@ -136,18 +136,13 @@ package_gdb-multiarch() {
   strip -o ${destdir}/gdbserver-multiarch.exe ${srcdir}/build-${MINGW_CHOST}-multiarch/gdbserver/gdbserver.exe
 }
 
-package_mingw-w64-i686-gdb() {
-  package_gdb
-}
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
 
-package_mingw-w64-i686-gdb-multiarch() {
-  package_gdb-multiarch
-}
-
-package_mingw-w64-x86_64-gdb() {
-  package_gdb
-}
-
-package_mingw-w64-x86_64-gdb-multiarch() {
-  package_gdb-multiarch
-}
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;

--- a/mingw-w64-gobject-introspection/PKGBUILD
+++ b/mingw-w64-gobject-introspection/PKGBUILD
@@ -109,22 +109,13 @@ package_gobject-introspection-runtime() {
   install -Dt "${pkgdir}${MINGW_PREFIX}/lib/girepository-1.0" "${tmp_install}${MINGW_PREFIX}/lib/girepository-1.0/"*.typelib
 }
 
-package_mingw-w64-i686-gobject-introspection()
-{
-  package_gobject-introspection
-}
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
 
-package_mingw-w64-i686-gobject-introspection-runtime()
-{
-  package_gobject-introspection-runtime
-}
-
-package_mingw-w64-x86_64-gobject-introspection()
-{
-  package_gobject-introspection
-}
-
-package_mingw-w64-x86_64-gobject-introspection-runtime()
-{
-  package_gobject-introspection-runtime
-}
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;

--- a/mingw-w64-hyphen/PKGBUILD
+++ b/mingw-w64-hyphen/PKGBUILD
@@ -100,19 +100,13 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-hyphen: offers hyphenation library function
 
 }
 
-package_mingw-w64-i686-hyphen() {
-  package_hyphen
-}
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
 
-package_mingw-w64-i686-hyphen-en() {
-  package_hyphen-en
-}
-
-package_mingw-w64-x86_64-hyphen() {
-  package_hyphen
-}
-
-package_mingw-w64-x86_64-hyphen-en() {
-  package_hyphen-en
-}
-
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;

--- a/mingw-w64-icu/PKGBUILD
+++ b/mingw-w64-icu/PKGBUILD
@@ -140,18 +140,13 @@ package_icu-debug-libs() {
   rm -rf "${pkgdir}${MINGW_PREFIX}"/bin/icu-config
 }
 
-package_mingw-w64-i686-icu() {
-  package_icu
-}
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
 
-package_mingw-w64-i686-icu-debug-libs() {
-  package_icu-debug-libs
-}
-
-package_mingw-w64-x86_64-icu() {
-  package_icu
-}
-
-package_mingw-w64-x86_64-icu-debug-libs() {
-  package_icu-debug-libs
-}
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;

--- a/mingw-w64-libiconv/PKGBUILD
+++ b/mingw-w64-libiconv/PKGBUILD
@@ -56,7 +56,7 @@ check() {
   make check || true
 }
 
-_package_libiconv() {
+package_libiconv() {
   pkgdesc='Character encoding conversion library (mingw-w64)'
   license=(LGPL2 documentation:'GPL3') # This is LGPL except for documentation, see README
 
@@ -81,7 +81,7 @@ _package_libiconv() {
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/libcharset/COPYING.LIB" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/libcharset/COPYING.LIB"
 }
 
-_package_iconv() {
+package_iconv() {
   pkgdesc='Character encoding conversion utility (mingw-w64)'
   depends=("${MINGW_PACKAGE_PREFIX}-libiconv=${pkgver}-${pkgrel}"
            "${MINGW_PACKAGE_PREFIX}-gettext")
@@ -100,7 +100,13 @@ _package_iconv() {
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/iconv/COPYING"
 }
 
-package_mingw-w64-i686-iconv()      { _package_iconv;    }
-package_mingw-w64-i686-libiconv()   { _package_libiconv; }
-package_mingw-w64-x86_64-iconv()    { _package_iconv;    }
-package_mingw-w64-x86_64-libiconv() { _package_libiconv; }
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
+
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;

--- a/mingw-w64-lua-bitop/PKGBUILD
+++ b/mingw-w64-lua-bitop/PKGBUILD
@@ -22,15 +22,7 @@ build() {
   gcc -O2 -fPIC $(pkg-config --cflags lua5.1) -shared -o bit.dll bit.c $(pkg-config --libs lua5.1)
 }
 
-package_mingw-w64-lua51-bitop() {
+package() {
   cd LuaBitOp-${pkgver}
   install -Dm755 bit.dll "${pkgdir}${MINGW_PREFIX}/lib/lua/5.1/bit.dll"
-}
-
-package_mingw-w64-x86_64-lua51-bitop() {
-  package_mingw-w64-lua51-bitop
-}
-
-package_mingw-w64-i686-lua51-bitop() {
-  package_mingw-w64-lua51-bitop
 }

--- a/mingw-w64-lua-lpeg/PKGBUILD
+++ b/mingw-w64-lua-lpeg/PKGBUILD
@@ -49,7 +49,7 @@ check() {
   make test
 }
 
-package_mingw-w64-lua-lpeg() {
+package_lua-lpeg() {
   pkgdesc='Pattern-matching library for Lua (mingw-w64)'
   depends=("${MINGW_PACKAGE_PREFIX}-lua")
 
@@ -61,7 +61,7 @@ package_mingw-w64-lua-lpeg() {
   install -Dm644 "${srcdir}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/lua-lpeg/LICENSE"
 }
 
-package_mingw-w64-lua51-lpeg() {
+package_lua51-lpeg() {
   pkgdesc='Pattern-matching library for Lua 5.1 (mingw-w64)'
   depends=("${MINGW_PACKAGE_PREFIX}-lua51")
 
@@ -71,18 +71,13 @@ package_mingw-w64-lua51-lpeg() {
   install -Dm644 "${srcdir}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/lua51-lpeg/LICENSE"
 }
 
-package_mingw-w64-i686-lua-lpeg() {
-  package_mingw-w64-lua-lpeg
-}
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
 
-package_mingw-w64-x86_64-lua-lpeg() {
-    package_mingw-w64-lua-lpeg
-}
-
-package_mingw-w64-i686-lua51-lpeg() {
-    package_mingw-w64-lua51-lpeg
-}
-
-package_mingw-w64-x86_64-lua51-lpeg() {
-    package_mingw-w64-lua51-lpeg
-}
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;

--- a/mingw-w64-lua-mpack/PKGBUILD
+++ b/mingw-w64-lua-mpack/PKGBUILD
@@ -23,7 +23,7 @@ build() {
   gcc -O2 -fPIC -DMPACK_USE_SYSTEM $(pkg-config --cflags lua5.1) -shared -o mpack.dll.5.1 lmpack.c $(pkg-config --libs lua5.1) -lmpack
 }
 
-package_mingw-w64-lua-mpack() {
+package_lua-mpack() {
   pkgdesc='Msgpack serialization library for Lua (mingw-w64)'
   depends=("${MINGW_PACKAGE_PREFIX}-lua" "${MINGW_PACKAGE_PREFIX}-libmpack")
 
@@ -33,7 +33,7 @@ package_mingw-w64-lua-mpack() {
   install -Dm644 LICENSE-MIT "${pkgdir}${MINGW_PREFIX}/share/licenses/lua-lmpack/LICENSE"
 }
 
-package_mingw-w64-lua51-mpack() {
+package_lua51-mpack() {
   pkgdesc='Msgpack serialization library for Lua 5.1 (mingw-w64)'
   depends=("${MINGW_PACKAGE_PREFIX}-lua51" "${MINGW_PACKAGE_PREFIX}-libmpack")
 
@@ -42,18 +42,13 @@ package_mingw-w64-lua51-mpack() {
   install -Dm644 LICENSE-MIT "${pkgdir}${MINGW_PREFIX}/share/licenses/lua51-mpack/LICENSE"
 }
 
-package_mingw-w64-i686-lua-mpack() {
-  package_mingw-w64-lua-mpack
-}
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
 
-package_mingw-w64-x86_64-lua-mpack() {
-    package_mingw-w64-lua-mpack
-}
-
-package_mingw-w64-i686-lua51-mpack() {
-    package_mingw-w64-lua51-mpack
-}
-
-package_mingw-w64-x86_64-lua51-mpack() {
-    package_mingw-w64-lua51-mpack
-}
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;

--- a/mingw-w64-ocaml/PKGBUILD
+++ b/mingw-w64-ocaml/PKGBUILD
@@ -92,7 +92,7 @@ build() {
   make flexlink.opt
 }
 
-package_mingw-w64-x86_64-ocaml() {
+package_ocaml() {
   cd "${srcdir}/${_realname}-${pkgver}"
   make DESTDIR="${pkgdir}" install
 
@@ -106,11 +106,7 @@ package_mingw-w64-x86_64-ocaml() {
   rm -rf "${pkgdir}${MINGW_PREFIX}/bin/flexlink.exe"
 }
 
-package_mingw-w64-i686-ocaml() {
-  package_mingw-w64-x86_64-ocaml
-}
-
-package_mingw-w64-x86_64-ocaml-compiler-libs() {
+package_ocaml-compiler-libs() {
 pkgdesc="Several modules used internally by the OCaml compiler (mingw-w64)"
 license=('Q Public Licence 1.0')
 depends=("${MINGW_PACKAGE_PREFIX}-${_realname}")
@@ -132,6 +128,13 @@ optdepends=()
   rm -rf "${pkgdir}${MINGW_PREFIX}/bin/flexlink.exe"
 }
 
-package_mingw-w64-i686-ocaml-compiler-libs() {
-  package_mingw-w64-x86_64-ocaml-compiler-libs
-}
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
+
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;

--- a/mingw-w64-openexr/PKGBUILD
+++ b/mingw-w64-openexr/PKGBUILD
@@ -112,26 +112,13 @@ package_pyilmbase() {
   cp ${srcdir}/build-${MINGW_CHOST}/python${_py3ver//./_}/*.pyd ${pkgdir}${MINGW_PREFIX}/lib/python${_py3ver}/site-packages/
 }
 
-package_mingw-w64-i686-ilmbase() {
-  package_ilmbase
-}
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
 
-package_mingw-w64-i686-openexr() {
-  package_openexr
-}
-
-package_mingw-w64-i686-pyilmbase() {
-  package_pyilmbase
-}
-
-package_mingw-w64-x86_64-ilmbase() {
-  package_ilmbase
-}
-
-package_mingw-w64-x86_64-openexr() {
-  package_openexr
-}
-
-package_mingw-w64-x86_64-pyilmbase() {
-  package_pyilmbase
-}
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;

--- a/mingw-w64-pygobject2/PKGBUILD
+++ b/mingw-w64-pygobject2/PKGBUILD
@@ -80,18 +80,13 @@ package_pygobject2-devel() {
   mv ${srcdir}/devel${MINGW_PREFIX} "${pkgdir}/"
 }
 
-package_mingw-w64-i686-pygobject2-devel() {
-  package_pygobject2-devel
-}
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
 
-package_mingw-w64-x86_64-pygobject2-devel() {
-  package_pygobject2-devel
-}
-
-package_mingw-w64-i686-python2-gobject2() {
-  package_python2-gobject2
-}
-
-package_mingw-w64-x86_64-python2-gobject2() {
-  package_python2-gobject2
-}
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;

--- a/mingw-w64-qscintilla/PKGBUILD
+++ b/mingw-w64-qscintilla/PKGBUILD
@@ -86,20 +86,13 @@ package_python-qscintilla() {
   make INSTALL_ROOT="${pkgdir}" install -j1
 }
 
-### Wrappers
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
 
-package_mingw-w64-i686-qscintilla() {
-  package_qscintilla
-}
-
-package_mingw-w64-i686-python-qscintilla() {
-  package_python-qscintilla
-}
-
-package_mingw-w64-x86_64-qscintilla() {
-  package_qscintilla
-}
-
-package_mingw-w64-x86_64-python-qscintilla() {
-  package_python-qscintilla
-}
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;

--- a/mingw-w64-scite/PKGBUILD
+++ b/mingw-w64-scite/PKGBUILD
@@ -40,7 +40,7 @@ build() {
   windir=1 CC="${MINGW_PREFIX}/bin/gcc" CXX="${MINGW_PREFIX}/bin/g++" make -C scite/win32
 }
 
-package_mingw-w64-scite() {
+package_scite() {
   pkgdesc="Editor with facilities for building and running programs (mingw-w64)"
   depends=("${MINGW_PACKAGE_PREFIX}-glib2"
            "${MINGW_PACKAGE_PREFIX}-gtk3")
@@ -74,7 +74,7 @@ package_mingw-w64-scite() {
   cp scite/lua/COPYRIGHT "${pkgdir}"${MINGW_PREFIX}/share/licenses/scite/LICENSE-lua
 }
 
-package_mingw-w64-scite-defaults() {
+package_scite-defaults() {
   pkgdesc="Default language files for the SciTE editor (mingw-w64)"
   depends=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}")
 
@@ -85,18 +85,13 @@ package_mingw-w64-scite-defaults() {
   rm -f "${pkgdir}"${MINGW_PREFIX}/share/scite/SciTEGlobal.properties
 }
 
-package_mingw-w64-i686-scite() {
-  package_mingw-w64-scite
-}
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
 
-package_mingw-w64-i686-scite-defaults() {
-  package_mingw-w64-scite-defaults
-}
-
-package_mingw-w64-x86_64-scite() {
-  package_mingw-w64-scite
-}
-
-package_mingw-w64-x86_64-scite-defaults() {
-  package_mingw-w64-scite-defaults
-}
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;

--- a/mingw-w64-unicorn/PKGBUILD
+++ b/mingw-w64-unicorn/PKGBUILD
@@ -70,7 +70,13 @@ package_python-unicorn() {
   install -Dm 644 sample* shellcode.py -t "${pkgdir}${MINGW_PREFIX}/share/doc/python-${_realname}/samples"
 }
 
-package_mingw-w64-i686-unicorn()   { package_unicorn; }
-package_mingw-w64-x86_64-unicorn() { package_unicorn; }
-package_mingw-w64-i686-python-unicorn()   { package_python-unicorn; }
-package_mingw-w64-x86_64-python-unicorn() { package_python-unicorn; }
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
+
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;

--- a/mingw-w64-winpthreads-git/PKGBUILD
+++ b/mingw-w64-winpthreads-git/PKGBUILD
@@ -113,11 +113,15 @@ package_libwinpthread-git() {
   _install_licenses libwinpthread
 }
 
-# Wrappers for package functions
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
+
+# generate wrappers
 for _name in "${pkgname[@]}"; do
   _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
   _func="$(declare -f "${_short}")"
   eval "${_func/#${_short}/package_${_name}}"
 done
+# template end;
 
 # [1] https://locklessinc.com/articles/pthreads_on_windows/

--- a/mingw-w64-wxWidgets3.1/PKGBUILD
+++ b/mingw-w64-wxWidgets3.1/PKGBUILD
@@ -183,7 +183,7 @@ build() {
   #cd "${srcdir}/build-${CARCH}-shared/samples"  && make -k --jobs=1 || true
 #}
 
-_package_wxmsw() {
+package() {
   pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX (mingw-w64)"
   provides=("${MINGW_PACKAGE_PREFIX}-wxWidgets${_wx_basever}")
   conflicts=("${MINGW_PACKAGE_PREFIX}-wxWidgets${_wx_basever}")
@@ -230,6 +230,3 @@ _package_wxmsw() {
   install -Dm644 gpl.txt      "${pkgdir}${MINGW_PREFIX}/share/licenses/${_basename}${_wx_basever}/gpl.txt"
   install -Dm644 xserver.txt  "${pkgdir}${MINGW_PREFIX}/share/licenses/${_basename}${_wx_basever}/xserver.txt"
 }
-
-package_mingw-w64-i686-wxmsw3.1() { _package_wxmsw; }
-package_mingw-w64-x86_64-wxmsw3.1() { _package_wxmsw; }


### PR DESCRIPTION
This adds a template, `mingw-w64-splitpkg-wrappers`, to mingw-w64-PKGBUILD-templates, and converts a selection of small-ish packages to use it.  This was done by adding the line
```bash
# template input; name=mingw-w64-splitpkg-wrappers; version=1.0;
```
to each PKGBUILD file, and then running
```bash
git diff --name-only | while IFS= read -r line; do
  pushd `dirname $line`
  makepkg-template --template-dir ../mingw-w64-PKGBUILD-templates/
  popd
done
```

If this is an acceptable approach, I can do the remaining packages, split into CI-sized pull requests.