### PR TITLE
pkgconf: Remove leading slashes in --list-all output

### DIFF
--- a/mingw-w64-pkgconf/0007-list-all-leading-slash.patch
+++ b/mingw-w64-pkgconf/0007-list-all-leading-slash.patch
@@ -1,0 +1,24 @@
+From ab404bc25b94b638ee2d5bb7047e03b28da71787 Mon Sep 17 00:00:00 2001
+From: Ryan Scott <ryan.gl.scott@gmail.com>
+Date: Wed, 3 Feb 2021 06:54:52 -0500
+Subject: [PATCH] Fix #209
+
+This commit fixes #209 by applying the suggestion from
+https://github.com/pkgconf/pkgconf/issues/209#issuecomment-771609136.
+---
+ libpkgconf/pkg.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libpkgconf/pkg.c b/libpkgconf/pkg.c
+index 02c990d..f302df3 100644
+--- a/libpkgconf/pkg.c
++++ b/libpkgconf/pkg.c
+@@ -391,7 +391,7 @@ pkgconf_pkg_new_from_file(pkgconf_client_t *client, const char *filename, FILE *
+ 	 */
+ 	char *mungeptr;
+ 	if ((mungeptr = strrchr(idptr, '/')) != NULL)
+-		idptr = mungeptr++;
++		idptr = ++mungeptr;
+ #endif
+
+ 	pkg->id = strdup(idptr);

--- a/mingw-w64-pkgconf/PKGBUILD
+++ b/mingw-w64-pkgconf/PKGBUILD
@@ -4,7 +4,7 @@ _realname=pkgconf
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.7.3
-pkgrel=5
+pkgrel=6
 pkgdesc='pkg-config compatible utility which does not depend on glib'
 url='https://github.com/pkgconf/pkgconf'
 arch=('any')
@@ -22,13 +22,15 @@ source=(https://distfiles.dereferenced.org/pkgconf/$_realname-$pkgver.tar.gz
         0003-size-t-format.patch
         0004-fix-prefix-dirsep.patch
         0005-fix-version-validate.patch
-        0006-printf-format.patch)
+        0006-printf-format.patch
+        0007-list-all-leading-slash.patch)
 sha256sums=('d040859b36880323209f347c7c936e40a748ee63e123e43a771791a64165d6b1'
             '9af1f0600ca15e5f285ba54f4cb334f5d7e00f1bc21b6f571d71acd747f303b6'
             '1db5975d6b1db946ba1d71cc3cf390dec567899a89d7ef53f56f24f0058cdbe3'
             '8b2dd7551f9d6be9b202718fdcc6c526c5557831a703b617fc862a609be14450'
             'bddc97d669f7eda5d0e5b4fa023d684c394ff0f1cd5c9ccc38ecb514d9be2809'
-            'a7efeef61b4af1c0813d9d8a211cde669a3e3fa2c97ed21e55487667769c567a')
+            'a7efeef61b4af1c0813d9d8a211cde669a3e3fa2c97ed21e55487667769c567a'
+            'df199a82318e82952b3f6adb643623167dae179042991b7c6b0502ced760a312')
 
 prepare() {
   cd ${srcdir}/$_realname-$pkgver
@@ -42,6 +44,7 @@ prepare() {
 
   patch -p1 -i ${srcdir}/0005-fix-version-validate.patch
   patch -p1 -i ${srcdir}/0006-printf-format.patch
+  patch -p1 -i ${srcdir}/0007-list-all-leading-slash.patch
 }
 
 build() {


### PR DESCRIPTION
This fixes a `pkgconf`, observed in pkgconf/pkgconf#209, where the output of `pkgconf --list-all` would mistakenly print out package names with leading slashes, e.g.,

```
$ ./pkgconf.exe --list-all
/bzip2                         bzip2 - Lossless, block-sorting data compression
/expat                         expat - expat XML parser
...
```

This interferes with tools like `cabal-install`, which parse the output of `pkgconf --list-all` (or `pkg-config --list-all`) and assume that each line begins with an alphanumeric package name.

pkgconf/pkgconf#209 was fixed upstream in pkgconf/pkgconf#210, but it may be a while for another version of `pkgconf` is released (see https://github.com/pkgconf/pkgconf/pull/210#issuecomment-776663093). In the meantime, this incorporates the patch from pkgconf/pkgconf#210 into `MINGW-packages`.