### PR TITLE
use splitpkg template in openscenegraph packages that build

### DIFF
--- a/mingw-w64-OpenSceneGraph/PKGBUILD
+++ b/mingw-w64-OpenSceneGraph/PKGBUILD
@@ -11,7 +11,8 @@ url="http://www.openscenegraph.org/"
 license=("LGPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
-             "${MINGW_PACKAGE_PREFIX}-cmake")
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-cyrus-sasl")
 depends=("${MINGW_PACKAGE_PREFIX}-boost"
          "${MINGW_PACKAGE_PREFIX}-collada-dom-svn"
          "${MINGW_PACKAGE_PREFIX}-curl"
@@ -89,7 +90,7 @@ build() {
   done
 }
 
-package_release() {
+package_OpenSceneGraph() {
   pkgdesc="Open source high performance 3D graphics toolkit (mingw-w64)"
 
   cd Release-${MINGW_CHOST}
@@ -98,7 +99,7 @@ package_release() {
   install -Dm644 ${srcdir}/${_realname}-${_realname}-${_pkgver}/LICENSE.txt "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname}/LICENSE
 }
 
-package_debug() {
+package_OpenSceneGraph-debug() {
   depends=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}")
   options=('staticlibs' '!strip')
   pkgdesc="Open source high performance 3D graphics toolkit (debug) (mingw-w64)"
@@ -113,18 +114,13 @@ package_debug() {
   install -Dm644 ${srcdir}/${_realname}-${_realname}-${_pkgver}/LICENSE.txt "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname}-debug/LICENSE
 }
 
-package_mingw-w64-i686-OpenSceneGraph() {
-  package_release
-}
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
 
-package_mingw-w64-i686-OpenSceneGraph-debug() {
-  package_debug
-}
-
-package_mingw-w64-x86_64-OpenSceneGraph() {
-  package_release
-}
-
-package_mingw-w64-x86_64-OpenSceneGraph-debug() {
-  package_debug
-}
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;

--- a/mingw-w64-osgQt/PKGBUILD
+++ b/mingw-w64-osgQt/PKGBUILD
@@ -40,10 +40,7 @@ package_prog() {
   local _builddir=${_buildtype}-${MINGW_CHOST}
   local _dsuf=
 
-  if [[ "${_buildtype}" == "Release" ]]; then
-    depends=("${MINGW_PACKAGE_PREFIX}-qt5" "${MINGW_PACKAGE_PREFIX}-OpenSceneGraph")
-  else
-    depends=("${MINGW_PACKAGE_PREFIX}-qt5" "${MINGW_PACKAGE_PREFIX}-OpenSceneGraph-debug")
+  if [[ "${_buildtype}" != "Release" ]]; then
     _dsuf=d
   fi
 
@@ -67,18 +64,23 @@ package_prog() {
   fi
 }
 
-package_mingw-w64-i686-osgQt() {
+package_osgQt() {
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5" "${MINGW_PACKAGE_PREFIX}-OpenSceneGraph")
   package_prog Release
 }
 
-package_mingw-w64-i686-osgQt-debug() {
+package_osgQt-debug() {
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5" "${MINGW_PACKAGE_PREFIX}-OpenSceneGraph-debug")
   package_prog Debug
 }
 
-package_mingw-w64-x86_64-osgQt() {
-  package_prog Release
-}
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
 
-package_mingw-w64-x86_64-osgQt-debug() {
-  package_prog Debug
-}
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;

--- a/mingw-w64-osgqtquick-git/PKGBUILD
+++ b/mingw-w64-osgqtquick-git/PKGBUILD
@@ -48,7 +48,7 @@ build() {
     ../osgqtquick
 }
 
-package_release() {
+package_osgQtQuick-git() {
   depends=("${MINGW_PACKAGE_PREFIX}-osgQt"
            "${MINGW_PACKAGE_PREFIX}-qt5"
            "${MINGW_PACKAGE_PREFIX}-OpenSceneGraph")
@@ -60,7 +60,7 @@ package_release() {
   make DESTDIR=${pkgdir} install
 }
 
-package_debug() {
+package_osgQtQuick-debug-git() {
   depends=("${MINGW_PACKAGE_PREFIX}-osgQt-debug"
            "${MINGW_PACKAGE_PREFIX}-qt5"
            "${MINGW_PACKAGE_PREFIX}-${_realname}-git=${pkgver}"
@@ -79,18 +79,13 @@ package_debug() {
   rm -rf ${pkgdir}${MINGW_PREFIX}/share/qt5/qml/*/qmldir
 }
 
-package_mingw-w64-i686-osgQtQuick-git() {
-  package_release
-}
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
 
-package_mingw-w64-i686-osgQtQuick-debug-git() {
-  package_debug
-}
-
-package_mingw-w64-x86_64-osgQtQuick-git() {
-  package_release
-}
-
-package_mingw-w64-x86_64-osgQtQuick-debug-git() {
-  package_debug
-}
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;

--- a/mingw-w64-osgworks-git/PKGBUILD
+++ b/mingw-w64-osgworks-git/PKGBUILD
@@ -60,7 +60,7 @@ build() {
   make
 }
 
-package_release() {
+package_osgworks-git() {
   provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
   conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-${_realname}-svn")
   replaces=(${MINGW_PACKAGE_PREFIX}-${_realname}-svn)
@@ -70,7 +70,7 @@ package_release() {
   make DESTDIR=${pkgdir} install
 }
 
-package_debug() {
+package_osgworks-debug-git() {
   depends=("${MINGW_PACKAGE_PREFIX}-${_realname}-git=${pkgver}" "${MINGW_PACKAGE_PREFIX}-OpenSceneGraph-debug")
   provides=("${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
   conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-debug" "${MINGW_PACKAGE_PREFIX}-${_realname}-debug-svn")
@@ -86,19 +86,13 @@ package_debug() {
   rm -rf ${pkgdir}${MINGW_PREFIX}/share
 }
 
-package_mingw-w64-i686-osgworks-git() {
-  package_release
-}
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
 
-package_mingw-w64-i686-osgworks-debug-git() {
-  package_debug
-}
-
-package_mingw-w64-x86_64-osgworks-git() {
-  package_release
-}
-
-package_mingw-w64-x86_64-osgworks-debug-git() {
-  package_debug
-}
-
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;


### PR DESCRIPTION
Added cyrus-sasl makedepends in OpenSceneGraph, as it failed to build due to missing header, by way of `libvncserver`.  Additional osg* packages failed to build, and will be included in the final PR which updates packages which fail to build.