### PR TITLE
libxml2: backport an unmerged fix for a crash

### DIFF
--- a/mingw-w64-libxml2/0027-decoding-segfault.patch
+++ b/mingw-w64-libxml2/0027-decoding-segfault.patch
@@ -1,0 +1,31 @@
+From 07b1c4c8a736a31ac4b8ae13ea25d50793dfea83 Mon Sep 17 00:00:00 2001
+From: Mike Gorse <mgorse@alum.wpi.edu>
+Date: Fri, 25 Jan 2019 12:55:52 -0600
+Subject: [PATCH] python: return None if PY_IMPORT_STRING returns NULL
+
+PY_IMPORT_STRING might return NULL on python 3 if, ie, a string can't be
+encoded. We should check for this and return None, rather than returning
+NULL. Fixes a NULL pointer dereference when reporting an error with an
+invalid string.
+---
+ python/types.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/python/types.c b/python/types.c
+index 124af565..50951ba3 100644
+--- a/python/types.c
++++ b/python/types.c
+@@ -150,6 +150,10 @@ libxml_charPtrConstWrap(const char *str)
+         return (Py_None);
+     }
+     ret = PY_IMPORT_STRING(str);
++    if (ret == NULL) {
++        Py_INCREF(Py_None);
++        return (Py_None);
++    }
+     return (ret);
+ }
+ 
+-- 
+GitLab
+

--- a/mingw-w64-libxml2/PKGBUILD
+++ b/mingw-w64-libxml2/PKGBUILD
@@ -6,7 +6,7 @@ _realname=libxml2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.9.10
-pkgrel=5
+pkgrel=6
 arch=('any')
 pkgdesc="XML parsing library, version 2 (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
@@ -28,7 +28,8 @@ source=("http://xmlsoft.org/sources/${_realname}-${pkgver}.tar.gz"
         0020-fix-warnings.patch
         0023-fix-sitedir-detection.mingw.patch
         0026-mingw-relocate.patch
-        libxml2-2.9.9-python.patch)
+        libxml2-2.9.9-python.patch
+        0027-decoding-segfault.patch)
 sha256sums=('aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f'
             '9b61db9f5dbffa545f4b8d78422167083a8568c59bd1129f94138f936cf6fc1f'
             'a9457b1a5e7d9499270ccfdeabbf0ca75b0e4643c111a42a5da0d113bae485c5'
@@ -37,7 +38,8 @@ sha256sums=('aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f'
             '4e8377b8bd163cc29056e45f59598e36dc6f00029166bdce4c78a88f1f9b3ed4'
             'e93902af20bee41ca7708280f30a1d087ab8c6f86d18939bdd56789cd1a73531'
             '185033761dbfa2ff206df2adf87abb79d4733b5c84a6c68c429872a0755818d9'
-            '7b9bc59b174da93a547429b2f751047c758657953f6e2fb398e73b5ebf0f55e3')
+            '7b9bc59b174da93a547429b2f751047c758657953f6e2fb398e73b5ebf0f55e3'
+            '0391a4b267ba7251ca74ff2e98bf4c0332a14b618e8147a9341ec5617e45d9d9')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -69,7 +71,12 @@ prepare() {
     0020-fix-warnings.patch \
     0023-fix-sitedir-detection.mingw.patch \
     0026-mingw-relocate.patch \
-    libxml2-2.9.9-python.patch
+    libxml2-2.9.9-python.patch \
+
+  # https://gitlab.gnome.org/GNOME/libxml2/-/issues/64
+  # https://github.com/msys2/MINGW-packages/issues/7955
+   apply_patch_with_msg \
+    0027-decoding-segfault.patch
 
   libtoolize --copy --force
   aclocal


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/libxml2/-/issues/64
https://github.com/msys2/MINGW-packages/issues/7955

I don't know if this fix is good, but it fixes the crash
and hopefully this gets fixed upstream.

Fixes #7955