### PR TITLE
python: use AC_CHECK_TOOL for finding windres

### DIFF
--- a/mingw-w64-python/1800-link-win-resource-files-and-build-pythonw.patch
+++ b/mingw-w64-python/1800-link-win-resource-files-and-build-pythonw.patch
@@ -1,6 +1,26 @@
+--- Python-3.8.7/configure.ac.orig	2021-02-14 08:44:30.296278300 +0100
++++ Python-3.8.7/configure.ac	2021-02-14 08:44:39.824214800 +0100
+@@ -1320,6 +1320,9 @@
+ 
+ AC_MSG_RESULT($LDLIBRARY)
+ 
++AC_SUBST(WINDRES)
++AC_CHECK_TOOL(WINDRES, windres)
++
+ AC_SUBST(AR)
+ AC_CHECK_TOOLS(AR, ar aal, ar)
+ 
 diff -Naur Python-3.8.0-orig/Makefile.pre.in Python-3.8.0/Makefile.pre.in
 --- Python-3.8.0-orig/Makefile.pre.in	2019-10-22 10:04:44.812737000 +0300
 +++ Python-3.8.0/Makefile.pre.in	2019-10-22 10:04:51.177548200 +0300
+@@ -38,6 +38,7 @@
+ MAINCC=		@MAINCC@
+ LINKCC=		@LINKCC@
+ AR=		@AR@
++WINDRES=	@WINDRES@
+ READELF=	@READELF@
+ SOABI=		@SOABI@
+ LDVERSION=	@LDVERSION@
 @@ -249,6 +249,7 @@
  
  PYTHON=		python$(EXE)
@@ -29,13 +49,13 @@ diff -Naur Python-3.8.0-orig/Makefile.pre.in Python-3.8.0/Makefile.pre.in
 +	@echo '#define PYTHON_DLL_NAME "$(DLLLIBRARY)"' >> $@
 +
 +python_exe.o: pythonnt_rc.h $(srcdir)/PC/python_exe.rc
-+	windres -I$(srcdir)/Include -I$(srcdir)/PC -I. $(srcdir)/PC/python_exe.rc $@
++	$(WINDRES) -I$(srcdir)/Include -I$(srcdir)/PC -I. $(srcdir)/PC/python_exe.rc $@
 +
 +pythonw_exe.o: pythonnt_rc.h $(srcdir)/PC/pythonw_exe.rc
-+	windres -I$(srcdir)/Include -I$(srcdir)/PC -I. $(srcdir)/PC/pythonw_exe.rc $@
++	$(WINDRES) -I$(srcdir)/Include -I$(srcdir)/PC -I. $(srcdir)/PC/pythonw_exe.rc $@
 +
 +python_nt.o: pythonnt_rc.h $(srcdir)/PC/python_nt.rc
-+	windres -I$(srcdir)/Include -I$(srcdir)/PC -I. $(srcdir)/PC/python_nt.rc $@
++	$(WINDRES) -I$(srcdir)/Include -I$(srcdir)/PC -I. $(srcdir)/PC/python_nt.rc $@
 +
 +$(BUILDPYTHONW): Programs/python.o $(LIBRARY) $(LDLIBRARY) $(PY3LIBRARY) pythonw_exe.o
 +	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -municode -mwindows -o $@ Programs/python.o $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS) pythonw_exe.o

--- a/mingw-w64-python/PKGBUILD
+++ b/mingw-w64-python/PKGBUILD
@@ -18,7 +18,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 _pybasever=3.8
 pkgver=${_pybasever}.7
-pkgrel=5
+pkgrel=6
 provides=("${MINGW_PACKAGE_PREFIX}-python3=${pkgver}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3"
            "${MINGW_PACKAGE_PREFIX}-python2<2.7.16-7")
@@ -534,7 +534,7 @@ sha256sums=('ddcc1df16bb5b87aa42ec5d20a5b902f2d088caa269b28e01590f97a798ec50a'
             'a9977459a8e6c31f1643da7ede6ac7199dee96559d74188f5c9d3799787ac4fa'
             '7bab1dfb1d5b288e3270a61f9b1892c151f1dd1f8e32c07ae6adc37ef14844bb'
             '551047905350e113384f99e0e929e9381dc0a4ed514ca4ebe279dcdad798edce'
-            '1da319664d39427156488b9b39ff39e33c53ef608f66319fdf9fb9bcdb29020d'
+            'afafaa920fee0bb11fb246b37956c71c0e68dadaf09e27ebdcd7097dd2c0f0ef'
             'fc6164a90f0ca2a9341aaf4448b4334c3393459ca5cbad6d7149f8bcf70da5fe'
             '181672743d9e2449064a1b18764fa400af5d3cd268098e7b7e5069d0b128caa2'
             '6f2032347bb40e2ebe9b3a03062147ffa2f656d47c87821623c3b7d46dc15ddb'


### PR DESCRIPTION
instead of hardcoding it

Fixes #7948