### PR TITLE
clang: fix unnecessary gcc dependency on some split packages

### DIFF
--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -33,7 +33,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-openmp"
          "${MINGW_PACKAGE_PREFIX}-polly")
 pkgver=11.0.0
-pkgrel=6
+pkgrel=7
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 url="https://llvm.org/"
@@ -54,8 +54,9 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake>=3.4.3"
                "${MINGW_PACKAGE_PREFIX}-libc++")
              $([[ "$_generator" == "Ninja" ]] && echo \
                "${MINGW_PACKAGE_PREFIX}-ninja")
+             $([[ "$_compiler" == "gcc" ]] && echo \
+               "${MINGW_PACKAGE_PREFIX}-gcc")
              )
-depends=("${MINGW_PACKAGE_PREFIX}-gcc")
 options=('!debug' 'strip')
 _url=https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkgver}
 source=(${_url}/llvm-${pkgver}.src.tar.xz{,.sig}
@@ -430,6 +431,7 @@ package_clang-tools-extra() {
 package_compiler-rt() {
   pkgdesc="Runtime libraries for Clang and LLVM (mingw-w64)"
   url="https://compiler-rt.llvm.org/"
+  depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 
   cd "${srcdir}"/compiler-rt
   ${_make_cmd} -C ../build-${CARCH}/projects/compiler-rt DESTDIR="${pkgdir}" install
@@ -450,6 +452,7 @@ package_libc++() {
 package_openmp() {
   pkgdesc="OpenMP library (mingw-w64)"
   url="https://openmp.llvm.org/"
+  depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 
   cd "${srcdir}/openmp"
   ${_make_cmd} -C ../build-${CARCH}/projects/openmp DESTDIR="${pkgdir}" install
@@ -467,6 +470,7 @@ package_libc++abi() {
 package_libunwind() {
   pkgdesc='A new implementation of a stack unwinder for C++ exceptions (mingw-w64)'
   url='https://llvm.org/'
+  depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 
   cd "${srcdir}/libunwind"
   ${_make_cmd} -C ../build-libcxx-static-${CARCH}/projects/libunwind DESTDIR="${pkgdir}" install


### PR DESCRIPTION
Split packages not defining a depends will fall back the global one
which I guess was not on purpose.