### PR TITLE
cairo: fix issue with illegal font names in PDF output

### DIFF
--- a/mingw-w64-cairo/0001-fix-font-names-in-pdf-output.patch
+++ b/mingw-w64-cairo/0001-fix-font-names-in-pdf-output.patch
@@ -1,0 +1,58 @@
+From a3b69a0215fdface0fd5730872a4b3242d979dca Mon Sep 17 00:00:00 2001
+From: Uli Schlachter <psychon@znc.in>
+Date: Tue, 9 Feb 2021 16:54:35 +0100
+Subject: [PATCH] pdf font subset: Generate valid font names
+
+A hash value is encoded in base 26 with upper case letters for font
+names.
+
+Commit ed984146 replaced "numerator = abs (hash);" with "numerator =
+hash;" in this code, because hash has type uint32_t and the compiler
+warned about taking the absolute value of an unsigned value.  However,
+abs() is actually defined to take an int argument. Thus, there was some
+implicit cast.
+
+Since numerator has type long, i.e. is signed, it is now actually
+possible to get an overflow in the implicit cast and then have a
+negative number. The following code is not prepared for this and
+produces non-letters when encoding the hash.
+
+This commit fixes that problem by not using ldiv() and instead using /
+and % to directly compute the needed values. This gets rid of the need
+to convert to type long. Since now everything works with uint32_t, there
+is no more chance for negative numbers messing things up.
+
+Fixes: https://gitlab.freedesktop.org/cairo/cairo/-/issues/449
+Signed-off-by: Uli Schlachter <psychon@znc.in>
+---
+ src/cairo-pdf-surface.c | 8 ++------
+ 1 file changed, 2 insertions(+), 6 deletions(-)
+
+diff --git a/src/cairo-pdf-surface.c b/src/cairo-pdf-surface.c
+index 6da460878..52c49b6d2 100644
+--- a/src/cairo-pdf-surface.c
++++ b/src/cairo-pdf-surface.c
+@@ -5310,18 +5310,14 @@ _create_font_subset_tag (cairo_scaled_font_subset_t	*font_subset,
+ {
+     uint32_t hash;
+     int i;
+-    long numerator;
+-    ldiv_t d;
+ 
+     hash = _hash_data ((unsigned char *) font_name, strlen(font_name), 0);
+     hash = _hash_data ((unsigned char *) (font_subset->glyphs),
+ 		       font_subset->num_glyphs * sizeof(unsigned long), hash);
+ 
+-    numerator = hash;
+     for (i = 0; i < 6; i++) {
+-	d = ldiv (numerator, 26);
+-	numerator = d.quot;
+-        tag[i] = 'A' + d.rem;
++	tag[i] = 'A' + (hash % 26);
++	hash /= 26;
+     }
+     tag[i] = 0;
+ }
+-- 
+GitLab
+

--- a/mingw-w64-cairo/PKGBUILD
+++ b/mingw-w64-cairo/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _commit='156cd3eaaebfd8635517c2baf61fcf3627ff7ec2'
 pkgver=1.17.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Cairo vector graphics library (mingw-w64)"
 arch=('any')
 url="https://cairographics.org/"
@@ -31,9 +31,11 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 optdepends=("${MINGW_PACKAGE_PREFIX}-glib2: libcairo-gobject")
 options=('strip' 'staticlibs')
 source=("https://gitlab.freedesktop.org/cairo/cairo/-/archive/${_commit}/cairo-${_commit}.tar.gz"
+        0001-fix-font-names-in-pdf-output.patch
         0026-create-argb-fonts.all.patch
         0027-win32-print-fix-unbounded-surface-assertion.patch)
 sha256sums=('204215866aa392c27d3e1306f6ea1946a623bf86fff3143f777d1e8bf4383bb0'
+            'a5926f8bca3cb09e41ed8d2a60fb053c4243fdeec2c36c5c7e15d2a784b6ee9a'
             '6db6c44fbdb4926d09afa978fe80430186c4b7b7d255059602b1f94c6a079975'
             '7e244c20eec8c7b287dbee1d34de178d9b0c419dc4c2b11c90eaf626c92bf781')
 
@@ -41,7 +43,11 @@ prepare() {
   mv "${srcdir}/${_realname}-${_commit}" "${srcdir}/${_realname}-${pkgver}"
   cd "${srcdir}/${_realname}-${pkgver}"
 
+  # https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/125
+  patch -p1 -i ${srcdir}/0001-fix-font-names-in-pdf-output.patch
+
   patch -p1 -i ${srcdir}/0026-create-argb-fonts.all.patch
+
   # https://gitlab.freedesktop.org/cairo/cairo/-/issues/131
   patch -p1 -i ${srcdir}/0027-win32-print-fix-unbounded-surface-assertion.patch
 }


### PR DESCRIPTION
See https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/125