### PR TITLE
iverilog: update to 11.0.r8891.18e7406d

### DIFF
--- a/mingw-w64-iverilog/PKGBUILD
+++ b/mingw-w64-iverilog/PKGBUILD
@@ -5,6 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=11.0.r8891.18e7406d
 pkgrel=1
+epoch=1
 pkgdesc="Icarus Verilog, is a Verilog simulation and synthesis tool (mingw-w64)"
 arch=('any')
 url="http://iverilog.icarus.com/"

--- a/mingw-w64-iverilog/PKGBUILD
+++ b/mingw-w64-iverilog/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=iverilog
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=12.0.r8793.96df23c5
-pkgrel=3
+pkgver=11.0.r8891.18e7406d
+pkgrel=1
 pkgdesc="Icarus Verilog, is a Verilog simulation and synthesis tool (mingw-w64)"
 arch=('any')
 url="http://iverilog.icarus.com/"
@@ -19,13 +19,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 
 # NOTE: MSYS2 support was improved/fixed in 'master' (2020/12/04).
 # When 12.0 is tagged/released, this should be changed to use a tarball instead.
-_commit="96df23c"
+_commit="18e7406d"
 source=("${_realname}::git://github.com/steveicarus/iverilog.git#commit=${_commit}")
 sha256sums=('SKIP')
 
 pkgver() {
   cd "${srcdir}/${_realname}"
-  printf "12.0.r%s.%s" "$(git rev-list --count "${_commit}")" "$(git rev-parse --short "${_commit}")"
+  printf "11.0.r%s.%s" "$(git rev-list --count "${_commit}")" "$(git rev-parse --short "${_commit}")"
 }
 
 prepare() {


### PR DESCRIPTION
This should be just a regular update. However, I found that I was incorrectly using `12.0` as the base version. It should be `11.0`. Otherwise, when `12.0` is tagged, existing versions will be considered larger by `vercmp`.

Therefore, I decided to handle it here. What needs to be done so that this "downgrade" is acceptable?