### PR TITLE
Passing NO_AVX512=1 Instead of TARGET=CORE2 should allow AVX2 and AVX to be used by OpenBLAS yet forbid AVX512

### DIFF
--- a/mingw-w64-openblas/PKGBUILD
+++ b/mingw-w64-openblas/PKGBUILD
@@ -5,7 +5,7 @@ _realname=OpenBLAS
 pkgbase=mingw-w64-openblas
 pkgname="${MINGW_PACKAGE_PREFIX}-openblas"
 pkgver=0.3.13
-pkgrel=2
+pkgrel=3
 pkgdesc="An optimized BLAS library based on GotoBLAS2 1.13 BSD, providing optimized blas, lapack, and cblas (mingw-w64)"
 arch=('any')
 url="https://www.openblas.net/"
@@ -49,7 +49,7 @@ build() {
        CC=${MINGW_PREFIX}/bin/gcc                                      \
        FC=${MINGW_PREFIX}/bin/gfortran                                 \
        OPENBLAS_INCLUDE_DIR=${MINGW_PREFIX}/include/${_realname}       \
-       USE_THREAD=1 NUM_THREADS=64 TARGET=CORE2
+       USE_THREAD=1 NUM_THREADS=64 NO_AVX512 = 1
 
   # [[ -d build-${CARCH} ]] && rm -rf build-${CARCH}
   # mkdir -p build-${CARCH} && cd build-${CARCH}

--- a/mingw-w64-openblas/PKGBUILD
+++ b/mingw-w64-openblas/PKGBUILD
@@ -49,7 +49,7 @@ build() {
        CC=${MINGW_PREFIX}/bin/gcc                                      \
        FC=${MINGW_PREFIX}/bin/gfortran                                 \
        OPENBLAS_INCLUDE_DIR=${MINGW_PREFIX}/include/${_realname}       \
-       USE_THREAD=1 NUM_THREADS=64 NO_AVX512 = 1
+       USE_THREAD=1 NUM_THREADS=64 NO_AVX512=1
 
   # [[ -d build-${CARCH} ]] && rm -rf build-${CARCH}
   # mkdir -p build-${CARCH} && cd build-${CARCH}


### PR DESCRIPTION
Prevents AVX512 without destroying other instruction sets.

I cannot test directly on my machine (stuck using GCC 8.3 for R reasons) but having built OpenBLAS from source for many years, I do not think this will be problematic and will save many advanced instructions set outside of AVX512