### PR TITLE
python-cryptography: fix _with_rust=no build

### DIFF
--- a/mingw-w64-python-cryptography/0002-move-setuptools-rust-import.patch
+++ b/mingw-w64-python-cryptography/0002-move-setuptools-rust-import.patch
@@ -1,0 +1,50 @@
+--- cryptography-3.4.4/setup.py.orig	2021-02-15 20:10:23.508341000 -0800
++++ cryptography-3.4.4/setup.py	2021-02-15 20:11:12.508362500 -0800
+@@ -10,22 +10,6 @@
+ 
+ from setuptools import find_packages, setup
+ 
+-try:
+-    from setuptools_rust import RustExtension
+-except ImportError:
+-    print(
+-        """
+-        =============================DEBUG ASSISTANCE==========================
+-        If you are seeing an error here please try the following to
+-        successfully install cryptography:
+-
+-        Upgrade to the latest pip and try again. This will fix errors for most
+-        users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
+-        =============================DEBUG ASSISTANCE==========================
+-        """
+-    )
+-    raise
+-
+ 
+ base_dir = os.path.dirname(__file__)
+ src_dir = os.path.join(base_dir, "src")
+@@ -47,7 +31,24 @@
+ 
+ if os.environ.get("CRYPTOGRAPHY_DONT_BUILD_RUST"):
+     rust_extensions = []
++    setup_requirements = setup_requirements[:-1]
+ else:
++    try:
++        from setuptools_rust import RustExtension
++    except ImportError:
++        print(
++            """
++            =============================DEBUG ASSISTANCE==========================
++            If you are seeing an error here please try the following to
++            successfully install cryptography:
++    
++            Upgrade to the latest pip and try again. This will fix errors for most
++            users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
++            =============================DEBUG ASSISTANCE==========================
++            """
++        )
++        raise
++
+     rust_extensions = [
+         RustExtension(
+             "_rust",

--- a/mingw-w64-python-cryptography/PKGBUILD
+++ b/mingw-w64-python-cryptography/PKGBUILD
@@ -1,6 +1,12 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 _with_rust="yes"
+if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then
+  # rust doesn't support aarch64-pc-windows-gnu (msys2/CLANG-packages#28)
+  # and it apparently hardcodes libgcc (msys2/CLANG-packages#29), so disable
+  # it in all clang prefixes
+  _with_rust="no"
+fi
 
 _realname=cryptography
 pkgbase=mingw-w64-python-${_realname}
@@ -29,15 +35,19 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest-runner"
               "${MINGW_PACKAGE_PREFIX}-python-hypothesis"
               "${MINGW_PACKAGE_PREFIX}-python-pytz")
 source=(https://pypi.io/packages/source/c/cryptography/${_realname}-${pkgver}.tar.gz
-        0001-update-pyo3.patch)
+        0001-update-pyo3.patch
+        0002-move-setuptools-rust-import.patch)
 sha256sums=('ee5e19f0856b6fbbdbab15c2787ca65d203801d2d65d0b8de6218f424206c848'
-            '07a9af241298fb19353a4329de779865a413cd2e9f041b12b49e2998bf6ab933')
+            '07a9af241298fb19353a4329de779865a413cd2e9f041b12b49e2998bf6ab933'
+            '7374d57ae28eefe78394f2d6d983adf7d216c040c3b4bac8e83e4f5132c51fa2')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
   # https://github.com/PyO3/pyo3/pull/1423
   patch -Np1 -i "${srcdir}"/0001-update-pyo3.patch
+  # don't fail for lack of setuptools-rust if not building rust
+  patch -Np1 -i "${srcdir}"/0002-move-setuptools-rust-import.patch
 }
 
 build() {


### PR DESCRIPTION
Don't fail _with_rust=no build for lack of setuptools-rust

rust doesn't support aarch64-pc-windows-gnu (msys2/CLANG-packages#28)
and it apparently hardcodes libgcc (msys2/CLANG-packages#29), so disable
it in all clang prefixes