### PR TITLE
ffmpeg: Add libsoxr dependency

### DIFF
--- a/mingw-w64-ffmpeg/PKGBUILD
+++ b/mingw-w64-ffmpeg/PKGBUILD
@@ -7,7 +7,7 @@ _realname=ffmpeg
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.3.1
-pkgrel=7
+pkgrel=8
 pkgdesc="Complete and free Internet live audio and video broadcasting solution (mingw-w64)"
 arch=('any')
 url="https://ffmpeg.org/"
@@ -28,6 +28,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-aom"
          "${MINGW_PACKAGE_PREFIX}-libexif"
          "${MINGW_PACKAGE_PREFIX}-libmfx"
          "${MINGW_PACKAGE_PREFIX}-libmodplug"
+         "${MINGW_PACKAGE_PREFIX}-libsoxr"
          "${MINGW_PACKAGE_PREFIX}-libtheora"
          "${MINGW_PACKAGE_PREFIX}-libvorbis"
          "${MINGW_PACKAGE_PREFIX}-libvpx"
@@ -108,6 +109,7 @@ build() {
     --enable-libopenjpeg
     --enable-libopus
     --enable-librtmp
+    --enable-libsoxr
     --enable-libspeex
     --enable-libsrt
     --enable-libtheora


### PR DESCRIPTION
This enables use of the SoX resampler.

More info: https://trac.ffmpeg.org/wiki/FFmpeg%20and%20the%20SoX%20Resampler