### PR TITLE
libmpcdec: Install config_win32.h file.

### DIFF
--- a/mingw-w64-libmpcdec/0001-install-config-win32-header.patch
+++ b/mingw-w64-libmpcdec/0001-install-config-win32-header.patch
@@ -1,0 +1,20 @@
+--- a/include/Makefile.am
++++ b/include/Makefile.am
+@@ -4,6 +4,7 @@
+ 
+ nobase_include_HEADERS = \
+ 	mpcdec/config_types.h \
++	mpcdec/config_win32.h \
+ 	mpcdec/decoder.h \
+ 	mpcdec/huffman.h \
+ 	mpcdec/math.h \
+--- a/include/Makefile.in
++++ b/include/Makefile.in
+@@ -172,6 +172,7 @@
+ AUTOMAKE_OPTIONS = foreign
+ nobase_include_HEADERS = \
+ 	mpcdec/config_types.h \
++	mpcdec/config_win32.h \
+ 	mpcdec/decoder.h \
+ 	mpcdec/huffman.h \
+ 	mpcdec/math.h \

--- a/mingw-w64-libmpcdec/PKGBUILD
+++ b/mingw-w64-libmpcdec/PKGBUILD
@@ -4,23 +4,28 @@ _realname=libmpcdec
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.2.6
-pkgrel=3
+pkgrel=4
 pkgdesc="Musepack decoding library (mingw-w64)"
 arch=("any")
 url="https://musepack.net/"
 license=('custom')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
-source=("https://files.musepack.net/source/${_realname}-${pkgver}.tar.bz2")
-sha256sums=('4bd54929a80850754f27b568d7891e1e3e1b8d2f208d371f27d1fda09e6f12a8')
+source=("https://files.musepack.net/source/${_realname}-${pkgver}.tar.bz2"
+        "0001-install-config-win32-header.patch")
+sha256sums=('4bd54929a80850754f27b568d7891e1e3e1b8d2f208d371f27d1fda09e6f12a8'
+            '3087d5a7bcbfa9c2798455636141b3ecf4667d3a4366071fc5721f05e1c9df18')
 
 prepare() {
-  cd ${_realname}-${pkgver}
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  # mpcdec.h includes config_win32.h file (GH#8014)
+  patch -Np1 -i "${srcdir}/0001-install-config-win32-header.patch"
 }
 
 build() {
-  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
-  mkdir ${srcdir}/build-${MINGW_CHOST}
-  cd ${srcdir}/build-${MINGW_CHOST}
+  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
+
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
@@ -33,12 +38,13 @@ build() {
 }
 
 check() {
-  cd build-${MINGW_CHOST}
+  cd "${srcdir}/build-${MINGW_CHOST}"
   make -k check
 }
 
 package() {
-  cd build-${MINGW_CHOST}
+  cd "${srcdir}/build-${MINGW_CHOST}"
   make DESTDIR="${pkgdir}" install
-  install -Dm644 ${srcdir}/${_realname}-${pkgver}/COPYING ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }


### PR DESCRIPTION
mpcdec.h includes config_win32.h file but it is not installed.
So, patch the Makefile.am file to install it.

Fixes https://github.com/msys2/MINGW-packages/issues/8014
