### PR TITLE
soqt: Fix SoQt.pc

### DIFF
--- a/mingw-w64-soqt/PKGBUILD
+++ b/mingw-w64-soqt/PKGBUILD
@@ -4,7 +4,7 @@ _realname=soqt
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.6.0
-pkgrel=2
+pkgrel=3
 pkgdesc="A Qt Gui-toolkit binding for Coin (mingw-w64)"
 arch=('any')
 url="https://github.com/coin3d/soqt"
@@ -50,6 +50,8 @@ build() {
     -DCMAKE_BUILD_TYPE=Release \
     -DSOQT_BUILD_DOCUMENTATION=ON \
     -DSOQT_BUILD_TESTS=OFF \
+    -DSOQT_EXTRA_LDFLAGS=-lSoQt \
+    -DSOQT_EXTRA_CFLAGS=-DSOQT_DLL \
     ../soqt-SoQt-${pkgver}
 
   make


### PR DESCRIPTION
The missing -lSoQt part will be added to Libs section.
The missing -DSOQT_DLL part will be added to Cflags section.