### PR TITLE
coin: Fix Coin.pc

### DIFF
--- a/mingw-w64-coin/PKGBUILD
+++ b/mingw-w64-coin/PKGBUILD
@@ -4,7 +4,7 @@ _realname=coin
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=4.0.0
-pkgrel=3
+pkgrel=4
 pkgdesc="A high-level 3D graphics toolkit, fully compatible with SGI Open Inventor 2.1 (mingw-w64)"
 arch=('any')
 url="https://github.com/coin3d/coin"
@@ -54,6 +54,7 @@ build() {
     -DOPENAL_RUNTIME_LINKING=OFF \
     -DZLIB_RUNTIME_LINKING=OFF \
     -DGLU_RUNTIME_LINKING=OFF \
+    -DCOIN_EXTRA_CFLAGS=-DCOIN_DLL \
     ${_cmake_opts} \
     ../coin-Coin-${pkgver}
 


### PR DESCRIPTION
The missing -DCOIN_DLL part will be added to Cflags section.