### PR TITLE
Updated mingw-w64-go package to 1.16

### DIFF
--- a/mingw-w64-go/PKGBUILD
+++ b/mingw-w64-go/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=go
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.15.7
+pkgver=1.16
 pkgrel=1
 pkgdesc="Go Lang (mingw-w64)"
 arch=('any')
@@ -17,7 +17,7 @@ options=('!strip')
 source=("https://storage.googleapis.com/golang/go${pkgver}.src.tar.gz"
         0010-go1.7-proper-go-binary-path.patch
         0011-add-GO_BUILD_VERBOSE.patch)
-sha256sums=('8631b3aafd8ecb9244ec2ffb8a2a8b4983cf4ad15572b9801f7c5b167c1a2abc'
+sha256sums=('7688063d55656105898f323d90a79a39c378d86fe89ae192eb3b7fc46347c95a'
             'af2c10300635ac84e6d870cb40a6481ccb57487fb7a6efad781f20088bec4de8'
             'c7f9a39a4b29668276d5836d2c1e1d5c8017c6dd66b976f519e9f5e85383ab85')
 noextract=(go${pkgver}.src.tar.gz)
@@ -66,6 +66,30 @@ build() {
 
   # ./make.bat
 
+}
+
+check() {
+  cd "${_realname}-${pkgver}"
+
+  test_text="Hello MSYS2!"
+
+  rm -f /tmp/test_main.go
+  echo "package main"                    > /tmp/test_main.go
+  echo "import \"fmt\""                 >> /tmp/test_main.go
+  echo "func main() {"                  >> /tmp/test_main.go
+  echo "fmt.Println(\"${test_text}\")"  >> /tmp/test_main.go
+  echo "}"                              >> /tmp/test_main.go
+
+  ./bin/gofmt.exe -w /tmp/test_main.go
+  ./bin/go.exe build -o /tmp/test_result.exe /tmp/test_main.go
+  output=$(/tmp/test_result.exe)
+
+  if [[ "$output" != "$test_text" ]]; then
+    echo "Output \"${output}\" does not match test-text \"${test_text}\""
+    exit 1
+  fi
+
+  rm -f /tmp/test_main.go /tmp/test_result.exe
 }
 
 package() {


### PR DESCRIPTION
Updated mingw-w64-go to 1.16 . Tested with local projects, working fine.

Added simple check to test `gofmt` and `go build` like described [here](https://golang.org/doc/install/source?download=go1.16.src.tar.gz#testing).