### PR TITLE
x11docker: add 6.7.0

### DIFF
--- a/mingw-w64-x11docker/PKGBUILD
+++ b/mingw-w64-x11docker/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: umarcor <unai.martinezcorral@ehu.eus>
+
+_realname=x11docker
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=6.7.0
+pkgrel=1
+pkgdesc="Run GUI applications and desktops in docker (mingw-w64)"
+arch=('any')
+url="https://github.com/mviereck/x11docker"
+license=("MIT")
+
+source=(
+  "${_realname}.tgz::https://codeload.github.com/mviereck/${_realname}/tar.gz/v${pkgver}"
+  "runx::git://github.com/mviereck/runx.git#commit=908ee52d"
+)
+sha256sums=(
+  'fd41bfb86bd4db20dc5de5132a03caf426db6f940475b933126af926e5532995'
+  'SKIP'
+)
+
+package() {
+  _bin="${pkgdir}${MINGW_PREFIX}/bin"
+  mkdir -p "${_bin}"
+
+  _x11docker="${srcdir}/${_realname}-${pkgver}"
+  install -m 755 "${_x11docker}"/x11docker "${_bin}"
+  install -m 755 "${_x11docker}"/x11docker-gui "${_bin}"
+
+  install -m 755 "${srcdir}"/runx/runx "${_bin}"
+
+  _licenses="${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
+  mkdir -p "${_licenses}"
+  install -m 644 "${_x11docker}"/LICENSE.txt "${_licenses}"/x11docker-LICENSE
+  install -m 644 "${srcdir}"/runx/LICENSE "${_licenses}"/runx-LICENSE
+}


### PR DESCRIPTION
This PR adds [x11docker](https://github.com/mviereck/x11docker), a utility for running GUI applications in Docker containers. It allows starting X servers and setting container options for using them automatically. For instance, `x11docker --runx --no-auth ghdl/ext gtkwave` or `x11docker --runx --no-auth aptman/dbhi:bionic-octave octave`. It requires Docker Desktop and VcxSrv or Cygwin/X or xpra.