### PR TITLE
Backport fix for building git LLVM

### DIFF
--- a/mingw-w64-cmake/0009-Process-Fix-execute-error-handling-re-working-dir-on-windows.patch
+++ b/mingw-w64-cmake/0009-Process-Fix-execute-error-handling-re-working-dir-on-windows.patch
@@ -1,0 +1,42 @@
+From 4faaa079e3b464643bc90802381119685f5a586d Mon Sep 17 00:00:00 2001
+From: KWSys Upstream <kwrobot@kitware.com>
+Date: Mon, 25 Jan 2021 10:05:14 -0500
+Subject: [PATCH] KWSys 2021-01-25 (10e36d47)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Code extracted from:
+
+    https://gitlab.kitware.com/utils/kwsys.git
+
+at commit 10e36d47415840a0318331733460183152a0feb9 (master).
+
+Upstream Shortlog
+-----------------
+
+Martin Storsjö (1):
+      fca5ad3a Process: Fix execute error handling re working dir on windows
+---
+ Source/kwsys/ProcessWin32.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/Source/kwsys/ProcessWin32.c b/Source/kwsys/ProcessWin32.c
+index 12670762d9..8f01684a1a 100644
+--- a/Source/kwsys/ProcessWin32.c
++++ b/Source/kwsys/ProcessWin32.c
+@@ -962,7 +962,10 @@ void kwsysProcess_Execute(kwsysProcess* cp)
+       kwsysProcessCleanup(cp, GetLastError());
+       return;
+     }
+-    SetCurrentDirectoryW(cp->WorkingDirectory);
++    if (!SetCurrentDirectoryW(cp->WorkingDirectory)) {
++      kwsysProcessCleanup(cp, GetLastError());
++      return;
++    }
+   }
+ 
+   /* Setup the stdin pipe for the first process.  */
+-- 
+GitLab
+

--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -5,7 +5,7 @@ _realname=cmake
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.19.3
-pkgrel=2
+pkgrel=3
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
 url="https://www.cmake.org/"
@@ -35,13 +35,15 @@ source=("https://github.com/Kitware/CMake/releases/download/v${pkgver}/${_realna
         "0003-Disable-response-files-for-MSYS-Generator.patch"
         "0005-Do-not-install-Qt-bundle-in-cmake-gui.patch"
         "0006-pkg-config-Add-dont-define-prefix-when-PKG_CONFIG_WI.patch"
-        "0008-Output-line-numbers-in-callstacks.patch")
+        "0008-Output-line-numbers-in-callstacks.patch"
+        "0009-Process-Fix-execute-error-handling-re-working-dir-on-windows.patch")
 sha256sums=('3faca7c131494a1e34d66e9f8972ff5369e48d419ea8ceaa3dc15b4c11367732'
             '1b68fe64e1b389134db44dc34368713f6e28d3463ab1e7fc3d93857c0459beb7'
             '77763df03e8a9ca66c3f9368fe7e1fc36bb041455733258d73aeb40246a61354'
             '7eb60d12b610c70413412521dcc860d1948c169e721f3525d9be99b3913dc37e'
             'b3905abed55c012108b0254c69cb4027a739f15772500b0a99c400d9dfdf50a7'
-            '94642670c922c9acfade79bc567c6b28f2d2f89e27aa391b562e8c90baa49ce1')
+            '94642670c922c9acfade79bc567c6b28f2d2f89e27aa391b562e8c90baa49ce1'
+            '9796ae9da9cb67fabb37bb13bfed07cf8a36f27b995833e7144dfdc98786b8b1')
 
 
 # Helper macros to help make tasks easier #
@@ -71,7 +73,8 @@ prepare() {
     0003-Disable-response-files-for-MSYS-Generator.patch \
     0005-Do-not-install-Qt-bundle-in-cmake-gui.patch \
     0006-pkg-config-Add-dont-define-prefix-when-PKG_CONFIG_WI.patch \
-    0008-Output-line-numbers-in-callstacks.patch
+    0008-Output-line-numbers-in-callstacks.patch \
+    0009-Process-Fix-execute-error-handling-re-working-dir-on-windows.patch
 }
 
 build() {


### PR DESCRIPTION
Some folks have been hit by an error while building LLVM because of https://gitlab.kitware.com/cmake/cmake/-/issues/21439