### PR TITLE
python-pip: use winpty

### DIFF
--- a/mingw-w64-python-pip/PKGBUILD
+++ b/mingw-w64-python-pip/PKGBUILD
@@ -8,21 +8,30 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=21.0.1
-pkgrel=2
+pkgrel=3
 pkgdesc="The PyPA recommended tool for installing Python packages. (mingw-w64)"
 arch=('any')
 license=('MIT')
 url="https://pip.pypa.io/"
 depends=("${MINGW_PACKAGE_PREFIX}-python"
-         "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+         "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+         "winpty")
 # checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest"
 #               "${MINGW_PACKAGE_PREFIX}-python-scripttest"
 #               "${MINGW_PACKAGE_PREFIX}-python-csv23"
 #               "${MINGW_PACKAGE_PREFIX}-python-cryptography"
 #               "${MINGW_PACKAGE_PREFIX}-python-werkzeug"
 #               "${MINGW_PACKAGE_PREFIX}-python-virtualenv")
-source=(${_realname}-${pkgver}.tar.gz::https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz)
-sha256sums=('99bbde183ec5ec037318e774b0d8ae0a64352fe53b2c7fd630be1d07e94f41e5')
+source=(
+  ${_realname}-${pkgver}.tar.gz::https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz
+  "pip"
+  "pip3"
+  "pip3.8"
+)
+sha256sums=('99bbde183ec5ec037318e774b0d8ae0a64352fe53b2c7fd630be1d07e94f41e5'
+            '58da571aaca0ff9af4e15ef4e4fc71c0875ef852fa0e11aac3ec11fc612e85c5'
+            'dedff8ac199e773e7b135274267f4a888c896b7712df9e490b4ce49c6ee8b62f'
+            '10f1052d161f91c3e1afec3aed8738c1947d378ae6618ab529a3df88996bebfb')
 
 prepare() {
   rm -rf python-build-${CARCH}| true
@@ -42,6 +51,10 @@ build() {
 # }
 package() {
   cd "${srcdir}/python-build-${CARCH}"
+  install -Dm755 "${srcdir}/pip" "${pkgdir}${MINGW_PREFIX}/bin/pip"
+  install -Dm755 "${srcdir}/pip3" "${pkgdir}${MINGW_PREFIX}/bin/pip3"
+  install -Dm755 "${srcdir}/pip3.8" "${pkgdir}${MINGW_PREFIX}/bin/pip3.8"
+  
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
     ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX#\/} --root="${pkgdir}" --optimize=1 --skip-build -v
 

--- a/mingw-w64-python-pip/pip
+++ b/mingw-w64-python-pip/pip
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+PIP_EXE="$( dirname ${BASH_SOURCE[0]} )/pip.exe"
+
+if [ -t 0 -a -t 1 ]; then
+  /usr/bin/winpty $PIP_EXE "$@"
+else
+  exec $PIP_EXE "$@"
+fi

--- a/mingw-w64-python-pip/pip3
+++ b/mingw-w64-python-pip/pip3
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+PIP_EXE="$( dirname ${BASH_SOURCE[0]} )/pip3.exe"
+
+if [ -t 0 -a -t 1 ]; then
+  /usr/bin/winpty $PIP_EXE "$@"
+else
+  exec $PIP_EXE "$@"
+fi

--- a/mingw-w64-python-pip/pip3.8
+++ b/mingw-w64-python-pip/pip3.8
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+PIP_EXE="$( dirname ${BASH_SOURCE[0]} )/pip3.8.exe"
+
+if [ -t 0 -a -t 1 ]; then
+  /usr/bin/winpty $PIP_EXE "$@"
+else
+  exec $PIP_EXE "$@"
+fi


### PR DESCRIPTION
Fixes https://github.com/msys2/MINGW-packages/issues/7650

A temporary workaround that makes pip use winpty which handle keyboard interrupts. This should fix the child process not terminating error as described in https://github.com/msys2/MINGW-packages/issues/7650 also discussed in [discord](https://discord.com/channels/792780131906617355/794220101741838401/815593216329515050).