### PR TITLE
Add libopenmpt package 

### DIFF
--- a/mingw-w64-libopenmpt/PKGBUILD
+++ b/mingw-w64-libopenmpt/PKGBUILD
@@ -12,7 +12,10 @@ license=("BSD")
 depends=("${MINGW_PACKAGE_PREFIX}-zlib"
           "${MINGW_PACKAGE_PREFIX}-mpg123"
           "${MINGW_PACKAGE_PREFIX}-libogg"
-          "${MINGW_PACKAGE_PREFIX}-libvorbis")
+          "${MINGW_PACKAGE_PREFIX}-libvorbis"
+          "${MINGW_PACKAGE_PREFIX}-portaudio"
+          "${MINGW_PACKAGE_PREFIX}-libsndfile"
+          "${MINGW_PACKAGE_PREFIX}-flac")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
 options=('staticlibs' 'strip')

--- a/mingw-w64-libopenmpt/PKGBUILD
+++ b/mingw-w64-libopenmpt/PKGBUILD
@@ -1,0 +1,48 @@
+# Maintainer: Leandro Nini <drfiemost@email.it>
+
+_realname=libopenmpt
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=0.4.17
+pkgrel=1
+pkgdesc="A cross-platform C++ and C library to decode tracked music files (modules) into a raw PCM audio stream (mingw-w64)"
+arch=('any')
+url="https://lib.openmpt.org"
+license=("BSD")
+depends=("${MINGW_PACKAGE_PREFIX}-zlib"
+          "${MINGW_PACKAGE_PREFIX}-mpg123"
+          "${MINGW_PACKAGE_PREFIX}-libogg"
+          "${MINGW_PACKAGE_PREFIX}-libvorbis")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config")
+options=('staticlibs' 'strip')
+source=("https://lib.openmpt.org/files/${_realname}/src/${_realname}-${pkgver}+release.autotools.tar.gz")
+sha256sums=('1df99191400c62dbdfd144f5ffd6aedbfd39fb9c6c47e83355a222632b793593')
+
+build() {
+  [[ -d ${srcdir}/build-${CARCH} ]] && rm -rf ${srcdir}/build-${CARCH}
+  mkdir -p "${srcdir}/build-${CARCH}" && cd "${srcdir}/build-${CARCH}"
+  ../${_realname}-${pkgver}+release.autotools/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --enable-shared \
+    --enable-static \
+    --without-portaudiocpp \
+    --disable-examples
+
+  make
+}
+
+check() {
+  cd "${srcdir}/build-${CARCH}"
+  make check || true
+}
+
+package() {
+  cd "${srcdir}/build-${CARCH}"
+  make DESTDIR="${pkgdir}" install
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}+release.autotools/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
A mod player library, evolved from libmodplug and actively maintained.
I've included the command line frontend which adds extra dependency on portaudio, libsndfile and flac, can be removed if undesired.