### PR TITLE
Add more setuptools_scm dependency

### DIFF
--- a/mingw-w64-python-jaraco.path/PKGBUILD
+++ b/mingw-w64-python-jaraco.path/PKGBUILD
@@ -5,7 +5,7 @@ _realname=jaraco.path
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=3.3.1
-pkgrel=1
+pkgrel=2
 pkgdesc='miscellaneous path functions (mingw-w64)'
 arch=('any')
 url="https://github.com/jaraco/jaraco.path"
@@ -15,6 +15,7 @@ depends=(
 )
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+  "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm"
 )
 source=("${_pyname}-${pkgver}.tar.gz::https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${pkgver}.tar.gz")
 sha256sums=('11b75001e622c280bfa73331513ec4271c59217e9b21f471aecd2287d1051bf1')
@@ -23,6 +24,7 @@ prepare() {
   cd "$srcdir"
   rm -rf python-build-${CARCH} | true
   cp -r "${_pyname//_/-}-$pkgver" "python-build-${CARCH}"
+  export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}
 }
 
 build() {

--- a/mingw-w64-python-pytest-checkdocs/PKGBUILD
+++ b/mingw-w64-python-pytest-checkdocs/PKGBUILD
@@ -5,7 +5,7 @@ _realname=pytest-checkdocs
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=2.4.0
-pkgrel=1
+pkgrel=2
 pkgdesc='check the README when running tests (mingw-w64)'
 arch=('any')
 url="https://github.com/jaraco/pytest-checkdocs"
@@ -17,6 +17,7 @@ depends=(
 )
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+  "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm"
 )
 source=("${_pyname}-${pkgver}.tar.gz::https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${pkgver}.tar.gz")
 sha256sums=('8cda4912a05db140a42814763e418b6ee0b0da414bae8e85db43bdd371b2372a')
@@ -25,6 +26,7 @@ prepare() {
   cd "$srcdir"
   rm -rf python-build-${CARCH} | true
   cp -r "${_pyname//_/-}-$pkgver" "python-build-${CARCH}"
+  export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}
 }
 
 build() {

--- a/mingw-w64-python-pytest-enabler/PKGBUILD
+++ b/mingw-w64-python-pytest-enabler/PKGBUILD
@@ -5,7 +5,7 @@ _realname=pytest-enabler
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=1.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Enable installed pytest plugins (mingw-w64)'
 arch=('any')
 url="https://github.com/jaraco/pytest-enabler"
@@ -18,6 +18,7 @@ depends=(
 )
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+  "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm"
 )
 source=("${_pyname}-${pkgver}.tar.gz::https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${pkgver}.tar.gz")
 sha256sums=('5176390cb1e31a7da260e2669ea9d2e9f4da762c51bb2f568220788dd0d3bba0')
@@ -26,6 +27,7 @@ prepare() {
   cd "$srcdir"
   rm -rf python-build-${CARCH} | true
   cp -r "${_pyname//_/-}-$pkgver" "python-build-${CARCH}"
+  export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}
 }
 
 build() {

--- a/mingw-w64-python-pytest-shutil/PKGBUILD
+++ b/mingw-w64-python-pytest-shutil/PKGBUILD
@@ -5,7 +5,7 @@ _realname=pytest-shutil
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=1.7.0
-pkgrel=1
+pkgrel=2
 pkgdesc='A goodie-bag of unix shell and environment tools for py.test (mingw-w64)'
 arch=('any')
 url="https://github.com/manahl/pytest-plugins"
@@ -21,6 +21,7 @@ depends=(
 )
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+  "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm"
 )
 source=("${_pyname}-${pkgver}.tar.gz::https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${pkgver}.tar.gz")
 sha256sums=('d8165261de76e7508505c341d94c02b113dc963f274543abca74dbfabd021261')
@@ -29,6 +30,7 @@ prepare() {
   cd "$srcdir"
   rm -rf python-build-${CARCH} | true
   cp -r "${_pyname//_/-}-$pkgver" "python-build-${CARCH}"
+  export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}
 }
 
 build() {

--- a/mingw-w64-python-pytest-shutil/PKGBUILD
+++ b/mingw-w64-python-pytest-shutil/PKGBUILD
@@ -22,6 +22,7 @@ depends=(
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-setuptools"
   "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm"
+  "${MINGW_PACKAGE_PREFIX}-python-setuptools-git"
 )
 source=("${_pyname}-${pkgver}.tar.gz::https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${pkgver}.tar.gz")
 sha256sums=('d8165261de76e7508505c341d94c02b113dc963f274543abca74dbfabd021261')

--- a/mingw-w64-python-pytest-virtualenv/PKGBUILD
+++ b/mingw-w64-python-pytest-virtualenv/PKGBUILD
@@ -5,7 +5,7 @@ _realname=pytest-virtualenv
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=1.7.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Virtualenv fixture for py.test (mingw-w64)'
 arch=('any')
 url="https://github.com/manahl/pytest-plugins"
@@ -18,6 +18,7 @@ depends=(
 )
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+  "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm"
 )
 source=("${_pyname}-${pkgver}.tar.gz::https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${pkgver}.tar.gz")
 sha256sums=('2270ee8822111ec25db48e9d9f2efec32e68483a015b14cd0d92aeccc6ff820f')
@@ -26,6 +27,7 @@ prepare() {
   cd "$srcdir"
   rm -rf python-build-${CARCH} | true
   cp -r "${_pyname//_/-}-$pkgver" "python-build-${CARCH}"
+  export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}
 }
 
 build() {

--- a/mingw-w64-python-pytest-virtualenv/PKGBUILD
+++ b/mingw-w64-python-pytest-virtualenv/PKGBUILD
@@ -19,6 +19,7 @@ depends=(
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-setuptools"
   "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm"
+  "${MINGW_PACKAGE_PREFIX}-python-setuptools-git"
 )
 source=("${_pyname}-${pkgver}.tar.gz::https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${pkgver}.tar.gz")
 sha256sums=('2270ee8822111ec25db48e9d9f2efec32e68483a015b14cd0d92aeccc6ff820f')


### PR DESCRIPTION
Fixes the packages which failed to build in autobuild

on a side note, it seems weird that this CI over here doesn't check for these. `setuptools_scm` was installed in one package and is reused everywhere in this CI while not in the autobuild which seems to be weird, and needs to be fixed.