### PR TITLE
openocd: Update to 0.11.0, add capstone dependency

### DIFF
--- a/mingw-w64-openocd/PKGBUILD
+++ b/mingw-w64-openocd/PKGBUILD
@@ -5,8 +5,8 @@
 _realname=openocd
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.10.0
-pkgrel=2
+pkgver=0.11.0
+pkgrel=1
 pkgdesc="OpenOCD - Open On-Chip Debugger (mingw-w64)"
 arch=('any')
 url="http://openocd.org/"
@@ -16,11 +16,12 @@ depends=("${MINGW_PACKAGE_PREFIX}-hidapi"
          "${MINGW_PACKAGE_PREFIX}-libusb"
          "${MINGW_PACKAGE_PREFIX}-libusb-compat"
          "${MINGW_PACKAGE_PREFIX}-libftdi"
-         "${MINGW_PACKAGE_PREFIX}-libjaylink")
+         "${MINGW_PACKAGE_PREFIX}-libjaylink"
+         "${MINGW_PACKAGE_PREFIX}-capstone")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
 source=("https://downloads.sourceforge.net/sourceforge/${_realname}/${_realname}-${pkgver}.tar.bz2")
-sha256sums=("7312e7d680752ac088b8b8f2b5ba3ff0d30e0a78139531847be4b75c101316ae")
+sha256sums=("43a3ce734aff1d3706ad87793a9f3a5371cb0e357f0ffd0a151656b06b3d1e7d")
 
 build() {
   cd "${srcdir}"/${_realname}-${pkgver}


### PR DESCRIPTION
Building not tested, I'm hoping for CI to verify it instead.