### PR TITLE
Update 0, 013-further-fixes.patch, and PKGBUILD

### DIFF
--- a/mingw-w64-graphviz/013-further-fixes.patch
+++ b/mingw-w64-graphviz/013-further-fixes.patch
@@ -1,0 +1,527 @@
+diff -Naur graphviz-2.44.1.a/cmd/gvedit/Makefile.am graphviz-2.44.1.b/cmd/gvedit/Makefile.am
+--- graphviz-2.44.1.a/cmd/gvedit/Makefile.am	2020-06-29 10:47:18.000000000 +0200
++++ graphviz-2.44.1.b/cmd/gvedit/Makefile.am	2021-03-09 10:47:52.227317000 +0100
+@@ -51,7 +51,7 @@
+ .PHONY: mocables
+ mocables: qMakefile
+ 	rm -f $(MOCABLES) # don't use distributed mocables poss from diff version of Qt
+-	$(MAKE) -f qMakefile prefix=${prefix} exec_prefix=${exec_prefix} mocables compiler_rcc_make_all
++	$(MAKE) -f qMakefile prefix=${prefix} exec_prefix=${exec_prefix} mocables
+ 
+ qMakefile: gvedit.pro
+ 	$(QMAKE) -o qMakefile gvedit.pro
+diff -Naur graphviz-2.44.1.a/cmd/gvedit/csettings.cpp graphviz-2.44.1.b/cmd/gvedit/csettings.cpp
+--- graphviz-2.44.1.a/cmd/gvedit/csettings.cpp	2020-06-29 10:47:18.000000000 +0200
++++ graphviz-2.44.1.b/cmd/gvedit/csettings.cpp	2021-03-09 11:51:39.347719500 +0100
+@@ -59,7 +59,7 @@
+     }
+     *s = '\0';
+     path.append(line);
+-    path.append("\\share\\graphviz\\gvedit\\attributes.txt");
++    path.append("\\share\\graphviz\\gvedit\\attrs.txt");
+     return path;
+ }
+ #endif
+@@ -153,7 +153,7 @@
+     loadAttrs(path + "/attrs.txt", WIDGET(QComboBox, cbNameG),
+ 	      WIDGET(QComboBox, cbNameN), WIDGET(QComboBox, cbNameE));
+ #else
+-    if (loadAttrs("../share/graphviz/gvedit/attributes.txt",
++    if (loadAttrs("../share/graphviz/gvedit/attrs.txt",
+ 	      WIDGET(QComboBox, cbNameG), WIDGET(QComboBox, cbNameN),
+ 	      WIDGET(QComboBox, cbNameE))) {
+ 	path = findAttrFile();
+diff -Naur graphviz-2.44.1.a/cmd/gvedit/gvedit.pro.in graphviz-2.44.1.b/cmd/gvedit/gvedit.pro.in
+--- graphviz-2.44.1.a/cmd/gvedit/gvedit.pro.in	2020-06-29 10:47:18.000000000 +0200
++++ graphviz-2.44.1.b/cmd/gvedit/gvedit.pro.in	2021-03-09 10:58:22.077790800 +0100
+@@ -14,7 +14,8 @@
+ 	../..
+ 
+ CONFIG += qt
++QT += widgets
+ HEADERS = @top_srcdir@/cmd/gvedit/mainwindow.h @top_srcdir@/cmd/gvedit/mdichild.h @top_srcdir@/cmd/gvedit/csettings.h @top_srcdir@/cmd/gvedit/imageviewer.h @top_srcdir@/cmd/gvedit/ui_settings.h
+ SOURCES = @top_srcdir@/cmd/gvedit/main.cpp @top_srcdir@/cmd/gvedit/mainwindow.cpp @top_srcdir@/cmd/gvedit/mdichild.cpp @top_srcdir@/cmd/gvedit/csettings.cpp @top_srcdir@/cmd/gvedit/imageviewer.cpp
+-RESOURCES     = @top_srcdir@/cmd/gvedit/mdi.qrc
++RESOURCES = @top_srcdir@/cmd/gvedit/mdi.qrc
+ 
+diff -Naur graphviz-2.44.1.a/configure.ac graphviz-2.44.1.b/configure.ac
+--- graphviz-2.44.1.a/configure.ac	2020-06-29 10:47:18.000000000 +0200
++++ graphviz-2.44.1.b/configure.ac	2021-03-08 07:25:00.008996200 +0100
+@@ -2514,10 +2514,10 @@
+ if test "x$with_gdiplus" != "xyes"; then
+   use_gdiplus="No (disabled by default - Windows only)"
+ else
+-  if test -f "$PLATFORMSDKINCLUDE\GdiPlus.h" -a -f "$PLATFORMSDKLIB\GdiPlus.lib"; then
++  if test -f "$PLATFORMSDKINCLUDE\gdiplus.h" -a -f "$PLATFORMSDKLIB\libgdiplus.a"; then
+     use_gdiplus="Yes"
+     AC_DEFINE_UNQUOTED(HAVE_GDIPLUS,1,[Define if you have the GDI+ framework for Windows])
+-    GDIPLUS_HEADS=`cd "$PLATFORMSDKINCLUDE" && echo GdiPlus*.h`
++    GDIPLUS_HEADS=`cd "$PLATFORMSDKINCLUDE" && echo gdiplus*.h`
+     GDIPLUS_CFLAGS=''
+     GDIPLUS_LIBS=''
+     AC_SUBST([GDIPLUS_HEADS])
+diff -Naur graphviz-2.44.1.a/plugin/gdiplus/Makefile.am graphviz-2.44.1.b/plugin/gdiplus/Makefile.am
+--- graphviz-2.44.1.a/plugin/gdiplus/Makefile.am	2020-06-29 10:47:18.000000000 +0200
++++ graphviz-2.44.1.b/plugin/gdiplus/Makefile.am	2021-03-08 08:22:04.423993400 +0100
+@@ -23,7 +23,7 @@
+ 
+ noinst_HEADERS = FileStream.h gvplugin_gdiplus.h
+ 
+-nodist_libgvplugin_gdiplus_C_la_SOURCES = GdiPlus*.h
++nodist_libgvplugin_gdiplus_C_la_SOURCES = gdiplus*.h
+ libgvplugin_gdiplus_C_la_SOURCES = \
+ 	FileStream.cpp \
+ 	gvdevice_gdiplus.cpp \
+@@ -32,9 +32,9 @@
+ 	gvrender_gdiplus.cpp \
+ 	gvtextlayout_gdiplus.cpp
+ 
+-# libtool doesn't want to run with actual Windows import libs, so we force GdiPlus.lib through to the linker
+-libgvplugin_gdiplus_la_LDFLAGS = -version-info @GVPLUGIN_VERSION_INFO@ -Wl,"$(PLATFORMSDKLIB)\GdiPlus.lib"
+-nodist_libgvplugin_gdiplus_la_SOURCES = GdiPlus*.h
++# libtool doesn't want to run with actual Windows import libs, so we force libgdiplus.a through to the linker
++libgvplugin_gdiplus_la_LDFLAGS = -version-info @GVPLUGIN_VERSION_INFO@ -Wl,"$(PLATFORMSDKLIB)\libgdiplus.a"
++nodist_libgvplugin_gdiplus_la_SOURCES = gdiplus*.h
+ libgvplugin_gdiplus_la_SOURCES = $(libgvplugin_gdiplus_C_la_SOURCES)
+ libgvplugin_gdiplus_la_LIBADD = -lgdi32 -lole32 -lstdc++ -luuid $(top_builddir)/lib/gvc/libgvc.la
+ 
+diff -Naur graphviz-2.44.1.a/tclpkg/Makefile.am graphviz-2.44.1.b/tclpkg/Makefile.am
+--- graphviz-2.44.1.a/tclpkg/Makefile.am	2020-06-29 10:47:19.000000000 +0200
++++ graphviz-2.44.1.b/tclpkg/Makefile.am	2021-03-08 08:41:03.888242700 +0100
+@@ -38,7 +38,7 @@
+ 	-mkdir -p $(DESTDIR)@LUA_INSTALL_DIR@;
+ 	if test -w $(DESTDIR)@LUA_INSTALL_DIR@; then \
+ 		(cd $(DESTDIR)@LUA_INSTALL_DIR@; \
+-			cp -f $(DESTDIR)$(pkgluadir)/libgv_lua.so gv.so;) \
++			cp -f $(DESTDIR)$(pkgluadir)/libgv_lua.dll gv.dll;) \
+ 	else \
+ 		echo "Warning: @LUA_INSTALL_DIR@ is not writable."; \
+ 		echo "Skipping system installation of lua binding."; \
+@@ -48,7 +48,7 @@
+ 	-mkdir -p $(DESTDIR)@PERL_INSTALL_DIR@;
+ 	if test -w $(DESTDIR)@PERL_INSTALL_DIR@; then \
+ 		(cd $(DESTDIR)@PERL_INSTALL_DIR@; \
+-			cp -f $(DESTDIR)$(pkgperldir)/libgv_perl.so gv.so; \
++			cp -f $(DESTDIR)$(pkgperldir)/libgv_perl.dll gv.dll; \
+ 			cp -f $(DESTDIR)$(pkgperldir)/gv.pm gv.pm;) \
+ 	else \
+ 		echo "Warning: @PERL_INSTALL_DIR@ is not writable."; \
+@@ -59,7 +59,7 @@
+ 	-mkdir -p $(DESTDIR)@PHP_INSTALL_DIR@;
+ 	if test -w $(DESTDIR)@PHP_INSTALL_DIR@; then \
+ 		(cd $(DESTDIR)@PHP_INSTALL_DIR@; \
+-			cp -f $(DESTDIR)$(pkgphpdir)/libgv_php.so gv.so;) \
++			cp -f $(DESTDIR)$(pkgphpdir)/libgv_php.dll gv.dll;) \
+ 	else \
+ 		echo "Warning: @PHP_INSTALL_DIR@ is not writable."; \
+ 		echo "Skipping system installation of php binding."; \
+@@ -77,7 +77,7 @@
+ 	-mkdir -p $(DESTDIR)@PYTHON_INSTALL_DIR@;
+ 	if test -w $(DESTDIR)@PYTHON_INSTALL_DIR@; then \
+ 		(cd $(DESTDIR)@PYTHON_INSTALL_DIR@; \
+-			cp -f $(DESTDIR)$(pkgpythondir)/libgv_python.so _gv.so; \
++			cp -f $(DESTDIR)$(pkgpythondir)/libgv_python.dll _gv.dll; \
+ 			cp -f $(DESTDIR)$(pkgpythondir)/gv.py gv.py;) \
+ 	else \
+ 		echo "Warning: @PYTHON_INSTALL_DIR@ is not writable."; \
+@@ -88,7 +88,7 @@
+ 	-mkdir -p $(DESTDIR)@PYTHON2_INSTALL_DIR@;
+ 	if test -w $(DESTDIR)@PYTHON2_INSTALL_DIR@; then \
+ 		(cd $(DESTDIR)@PYTHON2_INSTALL_DIR@; \
+-			cp -f $(DESTDIR)$(pkgpython2dir)/libgv_python2.so _gv.so; \
++			cp -f $(DESTDIR)$(pkgpython2dir)/libgv_python2.dll _gv.dll; \
+ 			cp -f $(DESTDIR)$(pkgpython2dir)/gv.py gv.py;) \
+ 	else \
+ 		echo "Warning: @PYTHON3_INSTALL_DIR@ is not writable."; \
+@@ -99,7 +99,7 @@
+ 	-mkdir -p $(DESTDIR)@PYTHON3_INSTALL_DIR@;
+ 	if test -w $(DESTDIR)@PYTHON3_INSTALL_DIR@; then \
+ 		(cd $(DESTDIR)@PYTHON3_INSTALL_DIR@; \
+-			cp -f $(DESTDIR)$(pkgpython3dir)/libgv_python3.so _gv.so; \
++			cp -f $(DESTDIR)$(pkgpython3dir)/libgv_python3.dll _gv.dll; \
+ 			cp -f $(DESTDIR)$(pkgpython3dir)/gv.py gv.py;) \
+ 	else \
+ 		echo "Warning: @PYTHON3_INSTALL_DIR@ is not writable."; \
+@@ -110,7 +110,7 @@
+ 	-mkdir -p $(DESTDIR)@RUBY_INSTALL_DIR@;
+ 	if test -w $(DESTDIR)@RUBY_INSTALL_DIR@; then \
+ 		(cd $(DESTDIR)@RUBY_INSTALL_DIR@; \
+-			cp -f $(DESTDIR)$(pkgrubydir)/libgv_ruby.so gv.so;) \
++			cp -f $(DESTDIR)$(pkgrubydir)/libgv_ruby.dll gv.dll;) \
+ 	else \
+ 		echo "Warning: @RUBY_INSTALL_DIR@ is not writable."; \
+ 		echo "Skipping system installation of ruby binding."; \
+@@ -136,31 +136,31 @@
+ 	-rm -rf $(DESTDIR)$(pkgiodir);
+ 	-rm -rf $(DESTDIR)$(pkgjavadir);
+ 	-rm -rf $(DESTDIR)$(pkgluadir);
+-	-rm -rf $(DESTDIR)@LUA_INSTALL_DIR@/gv.so;
++	-rm -rf $(DESTDIR)@LUA_INSTALL_DIR@/gv.dll;
+ 	-rm -rf $(DESTDIR)$(pkgocamldir);
+ 	-rm -rf $(DESTDIR)$(pkgperldir);
+-	-rm -rf $(DESTDIR)@PERL_INSTALL_DIR@/gv.so $(DESTDIR)@PERL_INSTALL_DIR@/gv.pm;
++	-rm -rf $(DESTDIR)@PERL_INSTALL_DIR@/gv.dll $(DESTDIR)@PERL_INSTALL_DIR@/gv.pm;
+ 	-rm -rf $(DESTDIR)$(pkgphpdir);
+-	-rm -rf $(DESTDIR)@PHP_INSTALL_DIR@/gv.so $(DESTDIR)@PHP_INSTALL_DATADIR@/gv.php;
++	-rm -rf $(DESTDIR)@PHP_INSTALL_DIR@/gv.dll $(DESTDIR)@PHP_INSTALL_DATADIR@/gv.php;
+ 	-rm -rf $(DESTDIR)$(pkgpythondir);
+-	-rm -rf $(DESTDIR)@PYTHON_INSTALL_DIR@/_gv.so $(DESTDIR)@PYTHON_INSTALL_DIR@/gv.py;
++	-rm -rf $(DESTDIR)@PYTHON_INSTALL_DIR@/_gv.dll $(DESTDIR)@PYTHON_INSTALL_DIR@/gv.py;
+ 	-rm -rf $(DESTDIR)$(pkgpython2dir);
+-	-rm -rf $(DESTDIR)@PYTHON2_INSTALL_DIR@/_gv.so $(DESTDIR)@PYTHON2_INSTALL_DIR@/gv.py;
++	-rm -rf $(DESTDIR)@PYTHON2_INSTALL_DIR@/_gv.dll $(DESTDIR)@PYTHON2_INSTALL_DIR@/gv.py;
+ 	-rm -rf $(DESTDIR)$(pkgpython3dir);
+-	-rm -rf $(DESTDIR)@PYTHON3_INSTALL_DIR@/_gv.so $(DESTDIR)@PYTHON3_INSTALL_DIR@/gv.py;
++	-rm -rf $(DESTDIR)@PYTHON3_INSTALL_DIR@/_gv.dll $(DESTDIR)@PYTHON3_INSTALL_DIR@/gv.py;
+ 	-rm -rf $(DESTDIR)$(pkgpython23dir);
+-	-rm -rf $(DESTDIR)@PYTHON23_INSTALL_DIR@/_gv.so $(DESTDIR)@PYTHON_INSTALL_DIR@/gv.py;
++	-rm -rf $(DESTDIR)@PYTHON23_INSTALL_DIR@/_gv.dll $(DESTDIR)@PYTHON_INSTALL_DIR@/gv.py;
+ 	-rm -rf $(DESTDIR)$(pkgpython24dir);
+-	-rm -rf $(DESTDIR)@PYTHON24_INSTALL_DIR@/_gv.so $(DESTDIR)@PYTHON_INSTALL_DIR@/gv.py;
++	-rm -rf $(DESTDIR)@PYTHON24_INSTALL_DIR@/_gv.dll $(DESTDIR)@PYTHON_INSTALL_DIR@/gv.py;
+ 	-rm -rf $(DESTDIR)$(pkgpython25dir);
+-	-rm -rf $(DESTDIR)@PYTHON25_INSTALL_DIR@/_gv.so $(DESTDIR)@PYTHON_INSTALL_DIR@/gv.py;
++	-rm -rf $(DESTDIR)@PYTHON25_INSTALL_DIR@/_gv.dll $(DESTDIR)@PYTHON_INSTALL_DIR@/gv.py;
+ 	-rm -rf $(DESTDIR)$(pkgpython26dir);
+-	-rm -rf $(DESTDIR)@PYTHON26_INSTALL_DIR@/_gv.so $(DESTDIR)@PYTHON_INSTALL_DIR@/gv.py;
++	-rm -rf $(DESTDIR)@PYTHON26_INSTALL_DIR@/_gv.dll $(DESTDIR)@PYTHON_INSTALL_DIR@/gv.py;
+ 	-rm -rf $(DESTDIR)$(pkgpython27dir);
+-	-rm -rf $(DESTDIR)@PYTHON27_INSTALL_DIR@/_gv.so $(DESTDIR)@PYTHON_INSTALL_DIR@/gv.py;
++	-rm -rf $(DESTDIR)@PYTHON27_INSTALL_DIR@/_gv.dll $(DESTDIR)@PYTHON_INSTALL_DIR@/gv.py;
+ 	-rm -rf $(DESTDIR)$(pkgRdir);
+ 	-rm -rf $(DESTDIR)$(pkgrubydir);
+-	-rm -rf $(DESTDIR)@RUBY_INSTALL_DIR@/gv.so;
++	-rm -rf $(DESTDIR)@RUBY_INSTALL_DIR@/gv.dll;
+ 	-rm -rf $(DESTDIR)$(pkgtcldir);
+ 	-rm -rf $(DESTDIR)@TCL_INSTALL_DIR@/@PACKAGE_NAME@-@PACKAGE_VERSION@;
+ 
+diff -Naur graphviz-2.44.1.a/tclpkg/gv/Makefile.am graphviz-2.44.1.b/tclpkg/gv/Makefile.am
+--- graphviz-2.44.1.a/tclpkg/gv/Makefile.am	2020-06-29 10:47:19.000000000 +0200
++++ graphviz-2.44.1.b/tclpkg/gv/Makefile.am	2021-03-08 09:14:21.217080200 +0100
+@@ -26,7 +26,7 @@
+ nodist_libgv_sharp_la_SOURCES = gv_sharp.cpp $(SHARP_data)
+ libgv_sharp_la_SOURCES = $(BASESOURCES) gv_dummy_init.c
+ libgv_sharp_la_LIBADD = $(BASELIBS) $(SHARP_LIBS) 
+-libgv_sharp_la_LDFLAGS = -module -avoid-version
++libgv_sharp_la_LDFLAGS = -module -avoid-version -no-undefined
+ libgv_sharp_la_CPPFLAGS = $(BASECPPFLAGS) $(SHARP_INCLUDES)
+ $(SHARP_data): gv_sharp.cpp
+ gv_sharp.cpp: gv.i
+@@ -37,7 +37,7 @@
+ nodist_libgv_d_la_SOURCES = gv_d.cpp $(D_data)
+ libgv_d_la_SOURCES = $(BASESOURCES) gv_dummy_init.c
+ libgv_d_la_LIBADD = $(BASELIBS) $(D_LIBS)
+-libgv_d_la_LDFLAGS = -module -avoid-version
++libgv_d_la_LDFLAGS = -module -avoid-version -no-undefined
+ libgv_d_la_CPPFLAGS = $(BASECPPFLAGS) $(D_INCLUDES)
+ # $(D_data): gv_d.cpp
+ gv_d.cpp: gv.i
+@@ -51,7 +51,7 @@
+ nodist_libgv_go_la_SOURCES = gv_go.cpp runtime.h gv.go
+ libgv_go_la_SOURCES = $(BASESOURCES) gv_dummy_init.c
+ libgv_go_la_LIBADD = $(BASELIBS) $(GO_LIBS)
+-libgv_go_la_LDFLAGS = -module -avoid-version
++libgv_go_la_LDFLAGS = -module -avoid-version -no-undefined
+ libgv_go_la_CPPFLAGS = $(BASECPPFLAGS) $(GO_INCLUDES)
+ gv_gc.c gv.go: gv_go.cpp
+ gv_go.cpp: gv.i
+@@ -89,7 +89,7 @@
+ nodist_libgv_guile_la_SOURCES = gv_guile.cpp $(GUILE_data)
+ libgv_guile_la_SOURCES = $(BASESOURCES) gv_dummy_init.c
+ libgv_guile_la_LIBADD = $(BASELIBS) $(GUILE_LIBS)
+-libgv_guile_la_LDFLAGS = -module -avoid-version
++libgv_guile_la_LDFLAGS = -module -avoid-version -no-undefined
+ libgv_guile_la_CPPFLAGS = $(BASECPPFLAGS) $(GUILE_INCLUDES)
+ # $(GUILE_data): gv_guile.cpp
+ gv_guile.cpp: gv.i
+@@ -102,7 +102,7 @@
+ nodist_libgv_io_la_SOURCES = gv_io.cpp $(IO_data)
+ libgv_io_la_SOURCES = $(BASESOURCES) gv_dummy_init.c
+ libgv_io_la_LIBADD = $(BASELIBS) $(IO_LIBS)
+-libgv_io_la_LDFLAGS = -module -avoid-version
++libgv_io_la_LDFLAGS = -module -avoid-version -no-undefined
+ libgv_io_la_CPPFLAGS = $(BASECPPFLAGS) $(IO_INCLUDES)
+ # $(IO_data): gv_io.cpp
+ gv_io.cpp: gv.i
+@@ -114,7 +114,7 @@
+ nodist_libgv_java_la_SOURCES = gv_java.cpp
+ libgv_java_la_SOURCES = $(BASESOURCES)  gv_java_init.c
+ libgv_java_la_LIBADD = $(BASELIBS) $(JAVA_LIBS)
+-libgv_java_la_LDFLAGS = -module -avoid-version $(JNI_EXTRA_LDFLAGS)
++libgv_java_la_LDFLAGS = -module -avoid-version -no-undefined $(JNI_EXTRA_LDFLAGS)
+ libgv_java_la_CPPFLAGS = $(BASECPPFLAGS) $(SWIGJAVA_CPPFLAGS) $(JAVA_INCLUDES)
+ $(JAVA_data): gv_java.cpp
+ gv_java.cpp: gv.i
+@@ -125,7 +125,7 @@
+ nodist_libgv_javascript_la_SOURCES = gv_javascript.cpp $(JAVASCRIPT_data)
+ libgv_javascript_la_SOURCES = $(BASESOURCES) gv_dummy_init.c
+ libgv_javascript_la_LIBADD = $(BASELIBS) $(JAVASCRIPT_LIBS)
+-libgv_javascript_la_LDFLAGS = -module -avoid-version
++libgv_javascript_la_LDFLAGS = -module -avoid-version -no-undefined
+ libgv_javascript_la_CPPFLAGS = $(BASECPPFLAGS) $(JAVASCRIPT_INCLUDES)
+ # $(D_data): gv_javascript.cpp
+ gv_javascript.cpp: gv.i
+@@ -139,7 +139,7 @@
+ nodist_libgv_lua_la_SOURCES = gv_lua.cpp $(LUA_data)
+ libgv_lua_la_SOURCES = $(BASESOURCES) gv_dummy_init.c
+ libgv_lua_la_LIBADD = $(BASELIBS) $(LUA_LIBS)
+-libgv_lua_la_LDFLAGS = -module -avoid-version
++libgv_lua_la_LDFLAGS = -module -avoid-version -no-undefined
+ libgv_lua_la_CPPFLAGS = $(BASECPPFLAGS) $(LUA_INCLUDES)
+ # $(LUA_data): gv_lua.cpp
+ gv_lua.cpp: gv.i
+@@ -157,7 +157,7 @@
+ nodist_libgv_ocaml_la_SOURCES = gv_ocaml.cpp $(OCAML_data)
+ libgv_ocaml_la_SOURCES = $(BASESOURCES) gv_dummy_init.c
+ libgv_ocaml_la_LIBADD = $(BASELIBS) $(OCAML_LIBS)
+-libgv_ocaml_la_LDFLAGS = -module -avoid-version
++libgv_ocaml_la_LDFLAGS = -module -avoid-version -no-undefined
+ libgv_ocaml_la_CPPFLAGS = \
+ 	$(BASECPPFLAGS) \
+ 	$(OCAML_INCLUDES) \
+@@ -182,7 +182,7 @@
+ gv.cmo: gv.ml gv.cmi
+ 	ocamlc -c gv.ml
+ gv.cma: swig.cmo gv.cmo
+-	ocamlc -a -dllib dllgv.so -custom -o gv.cma swig.cmo gv.cmo
++	ocamlc -a -dllib dllgv.dll -custom -o gv.cma swig.cmo gv.cmo
+ gv.cmx: gv.ml gv.cma
+ 	ocamlopt -c gv.ml
+ gv.cmxa: gv.cmx
+@@ -200,7 +200,7 @@
+ nodist_libgv_perl_la_SOURCES = gv_perl.cpp $(PERL_data)
+ libgv_perl_la_SOURCES = $(BASESOURCES) gv_dummy_init.c
+ libgv_perl_la_LIBADD = $(BASELIBS) $(PERL_LIBS)
+-libgv_perl_la_LDFLAGS = -module -avoid-version $(PERL_LD)
++libgv_perl_la_LDFLAGS = -module -avoid-version -no-undefined $(PERL_LD)
+ libgv_perl_la_CPPFLAGS = $(BASECPPFLAGS) $(PERL_CC)
+ $(PERL_data): gv_perl.cpp
+ gv_perl.cpp: gv.i
+@@ -223,7 +223,7 @@
+ nodist_libgv_python_la_SOURCES = gv_python.cpp $(PYTHON_data)
+ libgv_python_la_SOURCES = $(BASESOURCES) gv_dummy_init.c
+ libgv_python_la_LIBADD = $(BASELIBS) $(PYTHON_LIBS)
+-libgv_python_la_LDFLAGS = -module -avoid-version
++libgv_python_la_LDFLAGS = -module -avoid-version -no-undefined
+ libgv_python_la_CPPFLAGS = $(BASECPPFLAGS) $(PYTHON_INCLUDES)
+ $(PYTHON_data): gv_python.cpp
+ gv_python.cpp: gv.i
+@@ -234,7 +234,7 @@
+ nodist_libgv_python2_la_SOURCES = gv_python2.cpp $(PYTHON2_data)
+ libgv_python2_la_SOURCES = $(BASESOURCES) gv_dummy_init.c
+ libgv_python2_la_LIBADD = $(BASELIBS) $(PYTHON2_LIBS)
+-libgv_python2_la_LDFLAGS = -module -avoid-version
++libgv_python2_la_LDFLAGS = -module -avoid-version -no-undefined
+ libgv_python2_la_CPPFLAGS = $(BASECPPFLAGS) $(PYTHON2_INCLUDES)
+ $(PYTHON2_data): gv_python2.cpp
+ gv_python2.cpp: gv.i
+@@ -245,7 +245,7 @@
+ nodist_libgv_python3_la_SOURCES = gv_python3.cpp $(PYTHON3_data)
+ libgv_python3_la_SOURCES = $(BASESOURCES) gv_dummy_init.c
+ libgv_python3_la_LIBADD = $(BASELIBS) $(PYTHON3_LIBS)
+-libgv_python3_la_LDFLAGS = -module -avoid-version
++libgv_python3_la_LDFLAGS = -module -avoid-version -no-undefined
+ libgv_python3_la_CPPFLAGS = $(BASECPPFLAGS) $(PYTHON3_INCLUDES)
+ $(PYTHON3_data): gv_python3.cpp
+ gv_python3.cpp: gv.i
+@@ -256,7 +256,7 @@
+ nodist_libgv_R_la_SOURCES = gv_R.cpp $(R_data)
+ libgv_R_la_SOURCES = $(BASESOURCES) gv_dummy_init.c
+ libgv_R_la_LIBADD = $(BASELIBS) $(R_LIBS)
+-libgv_R_la_LDFLAGS = -module -avoid-version
++libgv_R_la_LDFLAGS = -module -avoid-version -no-undefined
+ libgv_R_la_CPPFLAGS = $(BASECPPFLAGS) $(R_CFLAGS)
+ # $(R_data): gv_R.cpp
+ gv_R.cpp: gv.i
+@@ -267,7 +267,7 @@
+ nodist_libgv_ruby_la_SOURCES = gv_ruby.cpp $(RUBY_data)
+ libgv_ruby_la_SOURCES = $(BASESOURCES) gv_dummy_init.c
+ libgv_ruby_la_LIBADD = $(BASELIBS) $(RUBY_LIBS)
+-libgv_ruby_la_LDFLAGS = -module -avoid-version
++libgv_ruby_la_LDFLAGS = -module -avoid-version -no-undefined
+ libgv_ruby_la_CPPFLAGS = $(BASECPPFLAGS) $(RUBY_CFLAGS)
+ # $(RUBY_data): gv_ruby.cpp
+ gv_ruby.cpp: gv.i
+@@ -278,7 +278,7 @@
+ nodist_libgv_tcl_la_SOURCES = gv_tcl.cpp $(TCL_data)
+ libgv_tcl_la_SOURCES = $(BASESOURCES) gv_tcl_init.c
+ libgv_tcl_la_LIBADD = $(top_builddir)/tclpkg/tclstubs/libtclstubs_C.la $(BASELIBS) $(TCL_LIBS)
+-libgv_tcl_la_LDFLAGS = -module -avoid-version
++libgv_tcl_la_LDFLAGS = -module -avoid-version -no-undefined
+ libgv_tcl_la_CPPFLAGS = $(BASECPPFLAGS) $(TCL_INCLUDES)
+ # $(TCL_data): gv_tcl.cpp
+ gv_tcl.cpp: gv.i
+@@ -504,28 +504,28 @@
+ 	(cd $(DESTDIR)$(pkgjavadir); $(LN_S) -f org/graphviz/libgv_java.$(JSHEXT) ../../libgv.$(JSHEXT); javac -classpath $(DESTDIR)$(libjavadir) gv.java;)
+ endif
+ if WITH_LUA
+-	(cd $(DESTDIR)$(pkgluadir);    rm -f gv.so;  $(LN_S) libgv_lua.so gv.so;)
++	(cd $(DESTDIR)$(pkgluadir);    rm -f gv.dll;  $(LN_S) libgv_lua.dll gv.dll;)
+ endif
+ if WITH_PERL
+-	(cd $(DESTDIR)$(pkgperldir);   rm -f gv.so;  $(LN_S) libgv_perl.so gv.so;)
++	(cd $(DESTDIR)$(pkgperldir);   rm -f gv.dll;  $(LN_S) libgv_perl.dll gv.dll;)
+ endif
+ if WITH_PHP
+-	(cd $(DESTDIR)$(pkgphpdir);   rm -f gv.so;  $(LN_S) libgv_php.so gv.so;)
++	(cd $(DESTDIR)$(pkgphpdir);   rm -f gv.dll;  $(LN_S) libgv_php.dll gv.dll;)
+ endif
+ if WITH_PYTHON
+-	(cd $(DESTDIR)$(pkgpythondir); rm -f _gv.so; $(LN_S) libgv_python.so _gv.so;)
++	(cd $(DESTDIR)$(pkgpythondir); rm -f _gv.dll; $(LN_S) libgv_python.dll _gv.dll;)
+ endif
+ if WITH_PYTHON2
+-	(cd $(DESTDIR)$(pkgpython2dir); rm -f _gv.so; $(LN_S) libgv_python2.so _gv.so;)
++	(cd $(DESTDIR)$(pkgpython2dir); rm -f _gv.dll; $(LN_S) libgv_python2.dll _gv.dll;)
+ endif
+ if WITH_PYTHON3
+-	(cd $(DESTDIR)$(pkgpython3dir); rm -f _gv.so; $(LN_S) libgv_python3.so _gv.so;)
++	(cd $(DESTDIR)$(pkgpython3dir); rm -f _gv.dll; $(LN_S) libgv_python3.dll _gv.dll;)
+ endif
+ if WITH_R
+-	(cd $(DESTDIR)$(pkgRdir);   rm -f gv.so;  $(LN_S) libgv_R.so gv.so;)
++	(cd $(DESTDIR)$(pkgRdir);   rm -f gv.dll;  $(LN_S) libgv_R.dll gv.dll;)
+ endif
+ if WITH_RUBY
+-	(cd $(DESTDIR)$(pkgrubydir);   rm -f gv.so;  $(LN_S) libgv_ruby.so gv.so;)
++	(cd $(DESTDIR)$(pkgrubydir);   rm -f gv.dll;  $(LN_S) libgv_ruby.dll gv.dll;)
+ endif
+ 
+ devtsts: $(DEVTSTS)
+@@ -533,7 +533,7 @@
+ .PHONY: test_sharp
+ test_sharp: libgv_sharp.la
+ 	-(mkdir -p test_sharp; cd test_sharp; \
+-		ln -fs ../.libs/libgv_sharp.so libgv_sharp.so; \
++		ln -fs ../.libs/libgv_sharp.dll libgv_sharp.dll; \
+ 		ln -fs ../$(srcdir)/*.gv ../$(srcdir)/*.cs .; \
+ 		$(SHARP) *.cs -out:test.exe; \
+ 		mono test.exe)
+@@ -541,7 +541,7 @@
+ .PHONY: test_go
+ test_go: libgv_go.la
+ 	-(mkdir -p test_go; cd test_go; \
+-		ln -fs ../.libs/libgv_go.so libgv.so; \
++		ln -fs ../.libs/libgv_go.dll libgv.dll; \
+ 		ln -fs ../$(srcdir)/*.gv ../$(srcdir)/*.go .; \
+ 		$(GO) *.go
+ 		LD_LIBRARY_PATH=. go test)
+@@ -549,14 +549,14 @@
+ .PHONY: test_guile
+ test_guile: libgv_guile.la
+ 	-(mkdir -p test_guile; cd test_guile; \
+-		ln -fs ../.libs/libgv_guile.so libgv.so; \
++		ln -fs ../.libs/libgv_guile.dll libgv.dll; \
+ 		ln -fs ../$(srcdir)/*.gv ../$(srcdir)/*.guile .; \
+ 		$(GUILE) -s test.guile)
+ 
+ .PHONY: test_io
+ test_io: libgv_io.la
+ 	-(mkdir -p test_io; cd test_io; \
+-		ln -fs ../.libs/libgv_io.so libgv.so; \
++		ln -fs ../.libs/libgv_io.dll libgv.dll; \
+ 		ln -fs ../$(srcdir)/*.gv ../$(srcdir)/*.io .; \
+ 		ioc *.io; \
+ 		LD_LIBRARY_PATH=. io test)
+@@ -564,7 +564,7 @@
+ .PHONY: test_java
+ test_java: libgv_java.la
+ 	-(mkdir -p test_java/org/graphviz; cd test_java; \
+-		ln -f ../.libs/libgv_java.so libgv.jnilib; \
++		ln -f ../.libs/libgv_java.dll libgv.jnilib; \
+ 		ln -f ../$(srcdir)/*.java org/graphviz; \
+ 		ln -f ../$(srcdir)/test.java .; \
+ 		ln -f ../$(srcdir)/hello.gv  .; \
+@@ -575,14 +575,14 @@
+ .PHONY: test_lua
+ test_lua: libgv_lua.la
+ 	-(mkdir -p test_lua; cd test_lua; \
+-		ln -fs ../.libs/libgv_lua.so gv.so;\
++		ln -fs ../.libs/libgv_lua.dll gv.dll;\
+ 		ln -fs ../$(srcdir)/*.gv ../$(srcdir)/*.lua .; \
+ 		$(LUA) test.lua)
+ 
+ .PHONY: test_ocaml
+ test_ocaml: libgv_ocaml.la
+ 	-(mkdir -p test_ocaml; cd test_ocaml; \
+-		ln -fs ../.libs/libgv_ocaml.so libgv.so; \
++		ln -fs ../.libs/libgv_ocaml.dll libgv.dll; \
+ 		ln -fs ../$(srcdir)/*.gv ../$(srcdir)/*.ml ../$(srcdir)/*.mli .; \
+ 		ocamlc *.ocaml; \
+ 		LD_LIBRARY_PATH=. ocaml test)
+@@ -590,56 +590,56 @@
+ .PHONY: test_perl
+ test_perl: libgv_perl.la
+ 	-(mkdir -p test_perl; cd test_perl; \
+-		ln -fs ../.libs/libgv_perl.so gv.so; \
++		ln -fs ../.libs/libgv_perl.dll gv.dll; \
+ 		ln -fs ../$(srcdir)/*.gv ../$(srcdir)/*.p[lm] .; \
+ 		$(PERL) ./test.pl)
+ 
+ .PHONY: test_php
+ test_php: libgv_php.la
+ 	-(mkdir -p test_php; cd test_php; \
+-		ln -fs ../.libs/libgv_php.so libgv.so; \
++		ln -fs ../.libs/libgv_php.dll libgv.dll; \
+ 		ln -fs ../$(srcdir)/*.gv ../$(srcdir)/*.php .; \
+ 		$(PHP) ./test.php)
+ 
+ .PHONY: test_python
+ test_python: libgv_python.la
+ 	-(mkdir -p test_python; cd test_python; \
+-		ln -fs ../.libs/libgv_python.so _gv.so; \
++		ln -fs ../.libs/libgv_python.dll _gv.dll; \
+ 		ln -fs ../$(srcdir)/*.gv ../$(srcdir)/*.py .; \
+ 		PYTHONPATH=. $(PYTHON) test.py)
+ 
+ .PHONY: test_python2
+ test_python2: libgv_python2.la
+ 	-(mkdir -p test_python2; cd test_python2; \
+-		ln -fs ../.libs/libgv_python2.so _gv.so; \
++		ln -fs ../.libs/libgv_python2.dll _gv.dll; \
+ 		ln -fs ../$(srcdir)/*.gv ../$(srcdir)/*.py .; \
+ 		PYTHONPATH=. $(PYTHON2) test.py)
+ 
+ .PHONY: test_python3
+ test_python3: libgv_python3.la
+ 	-(mkdir -p test_python3; cd test_python3; \
+-		ln -fs ../.libs/libgv_python3.so _gv.so; \
++		ln -fs ../.libs/libgv_python3.dll _gv.dll; \
+ 		ln -fs ../$(srcdir)/*.gv ../$(srcdir)/*.py .; \
+ 		PYTHONPATH=. $(PYTHON3) test.py)
+ 
+ .PHONY: test_R
+ test_R: libgv_R.la
+ 	-(mkdir -p test_R; cd test_R; \
+-		ln -fs ../.libs/libgv_R.so gv.so; \
++		ln -fs ../.libs/libgv_R.dll gv.dll; \
+ 		ln -fs ../$(srcdir)/*.gv ../$(srcdir)/*.R .; \
+ 		$(R) test.R)
+ 
+ .PHONY: test_ruby
+ test_ruby: libgv_ruby.la
+ 	-(mkdir -p test_ruby; cd test_ruby; \
+-		ln -fs ../.libs/libgv_ruby.so gv.so; \
++		ln -fs ../.libs/libgv_ruby.dll gv.dll; \
+ 		ln -fs ../$(srcdir)/*.gv ../$(srcdir)/*.rb .; \
+ 		$(RUBY) test.rb)
+ 
+ .PHONY: test_tcl
+ test_tcl: libgv_tcl.la
+ 	-(mkdir -p test_tcl; cd test_tcl; \
+-		ln -fs ../.libs/libgv_tcl.so libgv_tcl.so; \
++		ln -fs ../.libs/libgv_tcl.dll libgv_tcl.dll; \
+ 		ln -fs ../$(srcdir)/*.gv ../$(srcdir)/*.tcl .; \
+ 		$(TCLSH) ./test.tcl)
+ 
+diff -Naur graphviz-2.44.1.a/tclpkg/mkpkgindex.sh graphviz-2.44.1.b/tclpkg/mkpkgindex.sh
+--- graphviz-2.44.1.a/tclpkg/mkpkgindex.sh	2020-06-29 10:47:19.000000000 +0200
++++ graphviz-2.44.1.b/tclpkg/mkpkgindex.sh	2021-03-08 08:37:12.139870000 +0100
+@@ -10,6 +10,7 @@
+     libBaseName=`basename $1 .la`
+     case `uname` in
+         CYGWIN*) lib="${libBaseName}.dll"   ;;
++        MINGW*)  lib="${libBaseName}.dll"   ;;
+         Darwin*) lib="${libBaseName}.dylib" ;;
+         HP-UX*)  lib="${libBaseName}.sl"    ;;
+         *)       lib="${libBaseName}.so"    ;;

--- a/mingw-w64-graphviz/PKGBUILD
+++ b/mingw-w64-graphviz/PKGBUILD
@@ -4,7 +4,7 @@ _realname=graphviz
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.44.1
-pkgrel=3
+pkgrel=4
 pkgdesc="Graph Visualization Software (mingw-w64)"
 arch=('any')
 url='https://www.graphviz.org/'
@@ -52,20 +52,22 @@ source=(#${_realname}-${pkgver}::git+https://gitlab.com/graphviz/graphviz.git#ta
         009-fix-warnings.patch
         010-no-extern-time.patch
         011-strcasecmp-mingw.patch
-        012-cast-error.patch)
+        012-cast-error.patch
+        013-further-fixes.patch)
 sha256sums=('8e1b34763254935243ccdb83c6ce108f531876d7a5dfd443f255e6418b8ea313'
             'a64e23a55481ff36641466ef80607bcdc1bbf20f992804620f4a58b5b8c04f8d'
             'd1e7e4dc1b55463123e3ed8f999745bf06078766ee24071be8866ac75fe1309e'
             'bd1d89894af4b89d14cfa028238aa87f0a6044c43f988f39a0c8512ab07285a2'
             'b5ce65be7a0f8012aecdf15229e3db8012ddc78152fa849a54ffe87ca6bfe119'
-            '35ee3d44abcb6d30a10ea5a797b214b19e929a0555297a8dce35e4842c059b15'
+            'e1a091abd87fbd70553909af7627a95bcd0aa041eef2681b0ed7eee9469cee61'
             '8fe551e8fc8c7f048c8c497f983e3bec60ac9489dec307508160199a5162ab3c'
             '6f066e2d08d296355da0e735429ade1a459940225288a70939f547c36562f982'
             '26a80a0071a0821de8019463788e966047551a93451386f5cf209c77cefe65e9'
             '0ac5c4b11297ed751f32ab6e165d75f27d7ec30efc3c26c23b73fbce2b097179'
             '01387eb1c9544b9e8aeb66a6ec23777c5bb3e2770b1672d2596b2b3d550319fd'
             'f9a4aa81bf2f918cc608dc49852c57782b610c2e56fea7e43a53a7c5bd655e90'
-            'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
+            'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+            '9749db36801c0c39e853b2b7112d005993cee9e8e0754ff7c2d606d34f7dd50e')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
@@ -81,36 +83,19 @@ prepare() {
   patch -p1 -i ${srcdir}/010-no-extern-time.patch
   patch -p1 -i ${srcdir}/011-strcasecmp-mingw.patch
   patch -p1 -i ${srcdir}/012-cast-error.patch
+  patch -Np1 -i ${srcdir}/013-further-fixes.patch
 
   ./autogen.sh NOCONFIG
 }
 
 build() {
-  # declare -a extra_config
-  # if check_option "debug" "n"; then
-    # extra_config+=("-DCMAKE_BUILD_TYPE=Release")
-  # else
-    # extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
-  # fi
-
-  # [[ -d build-${MINGW_CHOST} ]] && rm -r build-${MINGW_CHOST}
-  # mkdir build-${MINGW_CHOST} && cd build-${MINGW_CHOST}
-
-  # MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-  # ${MINGW_PREFIX}/bin/cmake.exe \
-    # -G"MSYS Makefiles" \
-    # -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    # ${extra_config} \
-    # ../${_realname}-${pkgver}
-
-  # make
-
   local gd_incdir=$(pkg-config --variable=includedir gdlib)
-  CFLAGS+=" -Wno-sign-conversion -Wno-sign-compare -Wno-conversion -fcommon"
-  CXXFLAGS+=" -Wno-sign-conversion -Wno-sign-compare -Wno-conversion -fcommon"
+  CFLAGS+=" -fpermissive -Wno-sign-conversion -Wno-sign-compare -Wno-conversion -w"
+  CXXFLAGS+=" -fpermissive -Wno-sign-conversion -Wno-sign-compare -Wno-conversion -w"
   [[ -d "${srcdir}"/build-${MINGW_CHOST} ]] && rm -rf "${srcdir}"/build-${MINGW_CHOST}
   mkdir -p "${srcdir}"/build-${MINGW_CHOST} && cd "${srcdir}"/build-${MINGW_CHOST}
-
+  # else the libgdi plugin refuses to link.
+  export lt_cv_deplibs_check_method=${lt_cv_deplibs_check_method='pass_all'}
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
@@ -126,10 +111,14 @@ build() {
     --enable-lua=no \
     --enable-r=no \
     --enable-sharp=no \
-    --enable-swig=no \
+    --enable-swig=yes \
     --enable-java=no \
     --with-webp=yes \
-    --without-qt \
+    --with-gdiplus=yes \
+    --with-smyrna=no \
+    --with-qt \
+    --with-platformsdkincludedir=${MINGW_PREFIX}/${MINGW_CHOST}/include \
+    --with-platformsdklibdir=${MINGW_PREFIX}/${MINGW_CHOST}/lib \
     --with-gdincludedir=${gd_incdir} \
     --enable-shared \
     --disable-static


### PR DESCRIPTION
we can now build the gdiplus plugin with mingw-w64.
swig plugins now work for go and python.
gvedit can also be built and i corrected a small oversight where it was set to look for a non existing attributes.txt which is now named attrs.txt.