### PR TITLE
ngraph-gtk: new upstream release (version 6.09.01).

### DIFF
--- a/mingw-w64-ngraph-gtk/PKGBUILD
+++ b/mingw-w64-ngraph-gtk/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=ngraph-gtk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=6.09.00
+pkgver=6.09.01
 pkgrel=1
 arch=('any')
 pkgdesc="create scientific 2-dimensional graphs (mingw-w64)"
@@ -22,7 +22,7 @@ options=('strip' 'staticlibs')
 license=("GPL")
 url="https://htrb.github.io/ngraph-gtk/"
 source=("https://github.com/htrb/ngraph-gtk/releases/download/v${pkgver}/ngraph-gtk-${pkgver}.tar.gz")
-sha256sums=("fa6ca2b0f5e7079cb980f5369fce0403ccc8052773588e4bf1a7d4b1030806fc")
+sha256sums=("217c9a66b565d96fdd2055f00a521e5f0cd7f39e52896399ed684ef0638608bb")
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}


### PR DESCRIPTION
ngraph-gtk: new upstream release (version 6.09.00).