### PR TITLE
gdal 3.2.2

### DIFF
--- a/mingw-w64-gdal/PKGBUILD
+++ b/mingw-w64-gdal/PKGBUILD
@@ -7,7 +7,7 @@
 _realname=gdal
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.2.0
+pkgver=3.2.2
 pkgrel=2
 pkgdesc="A translator library for raster geospatial data formats (mingw-w64)"
 arch=('any')
@@ -51,7 +51,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-cfitsio"
 options=('strip' 'staticlibs')
 source=(https://download.osgeo.org/${_realname}/${pkgver}/${_realname}-${pkgver}.tar.gz
         001-qhull-reentrant.patch)
-sha256sums=('66dbab444f9fad113245cef241e52c4ab3e1f315e59759820e16a67e94931347'
+sha256sums=('3313e1b0e75de58da4e15a68a9b55e7c04509d3e0e274311dfffe996f6da1a2a'
             'd331a4ca57ba9ecd533d2705273ca89b472902a880eb9edae9d0766bc8034519')
 
 prepare() {

--- a/mingw-w64-gdal/PKGBUILD
+++ b/mingw-w64-gdal/PKGBUILD
@@ -73,6 +73,7 @@ prepare() {
   # bug: http://osgeo-org.1560.x6.nabble.com/gdal-dev-jpeg2000-jasper-error-compiling-gdal-2-1-from-git-release-branch-td5299100.html
   sed -i -e 's@uchar@unsigned char@' frmts/jpeg2000/jpeg2000_vsil_io.cpp
 
+  touch config.rpath
   ./autogen.sh
 }
 


### PR DESCRIPTION
Hmm there seems to be a problem with the new make or autoconf that is unrelated to this update. I confirmed that the same error appears when we try to rebuild the current gdal version.


```
  m4/ax_lib_xerces.m4:37: AX_LIB_XERCES is expanded from...
  configure.ac:4022: the top level
  configure.ac:4046: warning: The macro `AC_HELP_STRING' is obsolete.
  configure.ac:4046: You should run autoupdate.
  ../autoconf-2.71/lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
  m4/ax_lib_expat.m4:37: AX_LIB_EXPAT is expanded from...
  configure.ac:4046: the top level
  configure.ac:4069: warning: The macro `AC_HELP_STRING' is obsolete.
  configure.ac:4069: You should run autoupdate.
  ../autoconf-2.71/lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
  m4/ax_lib_libkml.m4:48: AX_LIB_LIBKML is expanded from...
  configure.ac:4069: the top level
  configure.ac:4158: warning: The macro `AC_HELP_STRING' is obsolete.
  configure.ac:4158: You should run autoupdate.
  ../autoconf-2.71/lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
  m4/ax_oracle_oci.m4:41: AX_LIB_ORACLE_OCI is expanded from...
  configure.ac:4158: the top level
  configure.ac:5590: warning: The macro `AC_CHECKING' is obsolete.
  configure.ac:5590: You should run autoupdate.
  ../autoconf-2.71/lib/autoconf/general.m4:2499: AC_CHECKING is expanded from...
  configure.ac:5590: the top level
  configure.ac:6030: warning: AC_OUTPUT should be used without arguments.
  configure.ac:6030: You should run autoupdate.
  ==> Starting build()...
  configure: loading site script /mingw32/etc/config.site
  configure: error: cannot find required auxiliary files: config.rpath
  ==> ERROR: A failure occurred in build().
      Aborting...
  ==> Removing installed dependenci
```