### PR TITLE
[arm-none-eabi-gcc] Add zstd as required dependency

### DIFF
--- a/mingw-w64-arm-none-eabi-gcc/PKGBUILD
+++ b/mingw-w64-arm-none-eabi-gcc/PKGBUILD
@@ -10,7 +10,7 @@ _enable_ada=yes
 pkgbase=mingw-w64-${_target}-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_target}-${_realname}")
 pkgver=10.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc='GNU Tools for ARM Embedded Processors - GCC (mingw-w64)'
 arch=('any')
 license=('GPL')
@@ -23,6 +23,7 @@ depends=(
     "${MINGW_PACKAGE_PREFIX}-isl"
     "${MINGW_PACKAGE_PREFIX}-mpc"
     "${MINGW_PACKAGE_PREFIX}-zlib"
+    "${MINGW_PACKAGE_PREFIX}-zstd"
 )
 makedepends=(
     "${MINGW_PACKAGE_PREFIX}-gmp"


### PR DESCRIPTION
...Although it is only required at runtime. See #8099. Once again, maybe a too-straightforward patch, might need further investigation on the cause of said dependency.