### PR TITLE
mbedtls: Update to 2.26.0

### DIFF
--- a/mingw-w64-mbedtls/PKGBUILD
+++ b/mingw-w64-mbedtls/PKGBUILD
@@ -3,26 +3,25 @@
 _realname=mbedtls
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.16.5
+pkgver=2.26.0
 pkgrel=1
 arch=('any')
 url='https://tls.mbed.org/'
-pkgdesc='mbed TLS is an open source and commercial SSL library licensed by ARM Limited. (mingw-w64)'
+pkgdesc="Portable cryptographic and SSL/TLS library, aka polarssl (mingw-w64)."
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-doxygen"
-             "${MINGW_PACKAGE_PREFIX}-graphviz")
-license=('Apache License 2.0')
-options=('strip' 'staticlibs' 'docs')
-source=(${_realname}-${pkgver}.tar.gz::"https://tls.mbed.org/download/mbedtls-${pkgver}-apache.tgz"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
+license=('Apache')
+options=('strip' '!debug' 'staticlibs')
+source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/ARMmbed/mbedtls/archive/v${pkgver}.tar.gz"
         'symlink-test.patch'
         'dll-location.patch'
         'enable-features.patch')
-sha256sums=('65b4c6cec83e048fd1c675e9a29a394ea30ad0371d37b5742453f74084e7b04d'
-            'd6aa304dbad652da2b1ee8eaf29422309b72633e1b33fe4bb67fc21b529d3bb5'
-            '89eb82f9e9fb456d0595035925d2d512aa2ca9b9e283b9c51d5524bfc8dbf996'
-            '1be88267b045a8728fe4dde663faf328ad788eeefcb43915beeb364b4d2dd2e8')
+sha256sums=('37949e823c7e1f6695fc56858578df355da0770c284b1c1304cfc8b396d539cd'
+            '5c5e684de4e6295b838bd4aa3cb560221ca3b86fceab5632db15d97f6aa1e66f'
+            'c6ed7ebe8bf21148e3f96eef62d1be1f5aacf3bff926dcf0837f2ff1d8fb5b2a'
+            'ca8e32685891e3c167a0cb67ee4525b1889a3f59a0b5b0161deaf2869656a00b')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -32,45 +31,47 @@ prepare() {
 }
 
 build() {
-  cd "${srcdir}/${_realname}-${pkgver}"
-
-  local BUILD_TYPE="Release"
-  if check_option "debug" "y"; then
-    BUILD_TYPE="Debug"
+  declare -a _extra_config
+  if check_option "debug" "n"; then
+    _extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    _extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
-  
-  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
-  mkdir -p ${srcdir}/build-${MINGW_CHOST}
-  cd ${srcdir}/build-${MINGW_CHOST}
-  
+
+  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
+
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-  ${MINGW_PREFIX}/bin/cmake \
-    -G"MSYS Makefiles" \
-    -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G "Ninja" \
+    "${_extra_config[@]}" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    -DCMAKE_C_COMPILER=${MINGW_CHOST}-gcc \
+    -DENABLE_PROGRAMS=ON \
     -DENABLE_TESTING=ON \
-    -DENABLE_PROGRAMS=OFF \
+    -DMBEDTLS_FATAL_WARNINGS=OFF \
     -DUSE_SHARED_MBEDTLS_LIBRARY=ON \
     -DUSE_STATIC_MBEDTLS_LIBRARY=ON \
     ../${_realname}-${pkgver}
-  make
-  # Generate the documentation
-  make apidoc
+
+  ${MINGW_PREFIX}/bin/cmake.exe --build ./
 }
 
 check() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   cp -p library/*.dll tests/ # Tests are dynamically linked
-  make test
+  ${MINGW_PREFIX}/bin/cmake.exe --build ./ --target test || true
 }
 
 package () {
   cd "${srcdir}/build-${MINGW_CHOST}"
-  make DESTDIR=${pkgdir} install
-  
-  # Install the documentation
-  cd "${srcdir}/${_realname}-${pkgver}"
-  mkdir -p "${pkgdir}/${MINGW_PREFIX}/share/doc/${_realname}"
-  cp -Rp apidoc "${pkgdir}/${MINGW_PREFIX}/share/doc/${_realname}/html"
+  DESTDIR=${pkgdir} ${MINGW_PREFIX}/bin/cmake.exe --build ./ --target install
+
+  # rename generic utils
+  local _prog _baseprog
+  for _prog in "$pkgdir${MINGW_PREFIX}"/bin/*.exe; do
+    _baseprog=$(basename "$_prog")
+    mv "$_prog" "${_prog//$_baseprog/mbedtls_$_baseprog}"
+  done
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-mbedtls/dll-location.patch
+++ b/mingw-w64-mbedtls/dll-location.patch
@@ -1,24 +1,13 @@
---- mbedtls-2.1.0/library/CMakeLists.txt.orig	2015-09-04 15:38:26.000000000 +0300
-+++ mbedtls-2.1.0/library/CMakeLists.txt	2015-09-14 17:32:04.783122700 +0300
-@@ -132,7 +132,9 @@
-     target_link_libraries(${mbedtls_static_target} ${libs} ${mbedx509_static_target})
- 
-     install(TARGETS ${mbedtls_static_target} ${mbedx509_static_target} ${mbedcrypto_static_target}
+--- a/library/CMakeLists.txt
++++ b/library/CMakeLists.txt
+@@ -222,7 +222,9 @@
+     target_compile_definitions(${target}
+         PRIVATE ${thirdparty_def})
+     install(TARGETS ${target}
 -            DESTINATION ${LIB_INSTALL_DIR}
 +            RUNTIME DESTINATION "bin"
 +            LIBRARY DESTINATION "lib"
 +            ARCHIVE DESTINATION "lib"
-             PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
- endif(USE_STATIC_MBEDTLS_LIBRARY)
- 
-@@ -150,7 +152,9 @@
-     target_link_libraries(mbedtls ${libs} mbedx509)
- 
-     install(TARGETS mbedtls mbedx509 mbedcrypto
--            DESTINATION ${LIB_INSTALL_DIR}
-+            RUNTIME DESTINATION "bin"
-+            LIBRARY DESTINATION "lib"
-+            ARCHIVE DESTINATION "lib"
-             PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
- endif(USE_SHARED_MBEDTLS_LIBRARY)
+             PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
+ endforeach(target)
  

--- a/mingw-w64-mbedtls/enable-features.patch
+++ b/mingw-w64-mbedtls/enable-features.patch
@@ -1,6 +1,6 @@
---- mbedtls-2.1.1/include/mbedtls/config.h.orig	2015-09-26 18:53:50.950970200 +0300
-+++ mbedtls-2.1.1/include/mbedtls/config.h	2015-09-26 19:01:45.088633900 +0300
-@@ -63,7 +63,7 @@
+--- a/include/mbedtls/config.h
++++ b/include/mbedtls/config.h
+@@ -115,7 +115,7 @@
   *
   * Uncomment if the CPU supports SSE2 (IA-32 specific).
   */
@@ -9,16 +9,16 @@
  
  /**
   * \def MBEDTLS_HAVE_TIME
-@@ -170,7 +170,7 @@
+@@ -241,7 +241,7 @@
   *
-  * Uncomment to get warnings on using deprecated functions.
+  * Uncomment to get warnings on using deprecated functions and features.
   */
 -//#define MBEDTLS_DEPRECATED_WARNING
 +#define MBEDTLS_DEPRECATED_WARNING
  
  /**
   * \def MBEDTLS_DEPRECATED_REMOVED
-@@ -721,7 +721,7 @@
+@@ -1184,7 +1184,7 @@
   * Disable if you run into name conflicts and want to really remove the
   * mbedtls_strerror()
   */
@@ -27,7 +27,7 @@
  
  /**
   * \def MBEDTLS_GENPRIME
-@@ -1215,7 +1215,7 @@
+@@ -2090,7 +2090,7 @@
   *
   * Uncomment this to enable pthread mutexes.
   */
@@ -35,8 +35,8 @@
 +#define MBEDTLS_THREADING_PTHREAD
  
  /**
-  * \def MBEDTLS_VERSION_FEATURES
-@@ -2208,7 +2208,7 @@
+  * \def MBEDTLS_USE_PSA_CRYPTO
+@@ -3414,7 +3414,7 @@
   *
   * Enable this layer to allow use of mutexes within mbed TLS
   */

--- a/mingw-w64-mbedtls/symlink-test.patch
+++ b/mingw-w64-mbedtls/symlink-test.patch
@@ -1,7 +1,7 @@
---- mbedtls-2.12.0/CMakeLists.txt.orig	2018-08-04 02:24:09.274851700 +0300
-+++ mbedtls-2.12.0/CMakeLists.txt	2018-08-04 02:24:11.819200100 +0300
-@@ -73,7 +73,7 @@
-     file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/${base_name}" target)
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -149,7 +149,7 @@
+     endif()
  
      if (NOT EXISTS ${link})
 -        if (CMAKE_HOST_UNIX)


### PR DESCRIPTION
Changes:
* Update patches.
* Use GitHub repo for source tarball.
* Use Ninja.
* Enable programs to build.