### PR TITLE
sqlite(3.35.1): amend config

### DIFF
--- a/mingw-w64-sqlite3/PKGBUILD
+++ b/mingw-w64-sqlite3/PKGBUILD
@@ -5,10 +5,11 @@
 _realname=sqlite3
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+_sqlite_year=2021
 _amalgamationver=3350100
 _docver=${_amalgamationver}
 pkgver=3.35.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A C library that implements an SQL database engine (mingw-w64)"
 arch=('any')
 license=(PublicDomain)
@@ -22,8 +23,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-readline"
          "${MINGW_PACKAGE_PREFIX}-tcl")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
-source=(https://www.sqlite.org/2021/sqlite-src-${_amalgamationver}.zip
-        https://www.sqlite.org/2021/sqlite-doc-${_docver}.zip
+source=(https://www.sqlite.org/${_sqlite_year}/sqlite-src-${_amalgamationver}.zip
+        https://www.sqlite.org/${_sqlite_year}/sqlite-doc-${_docver}.zip
         Makefile.ext.in
         README.md.in
         LICENSE)
@@ -55,6 +56,7 @@ build() {
             -DSQLITE_DISABLE_DIRSYNC=1 \
             -DSQLITE_ENABLE_DBSTAT_VTAB=1 \
             -DSQLITE_SOUNDEX=1 \
+            -DSQLITE_ENABLE_MATH_FUNCTIONS \
   "
 
   CFLAGS+=" -fexceptions -fno-strict-aliasing ${SQLITE_OPTIONS}"
@@ -68,7 +70,6 @@ build() {
     --disable-editline \
     --enable-readline \
     --enable-all \
-    --enable-rtree \
     --enable-session \
     --with-readline-inc=-I${MINGW_PREFIX}/include \
     --with-tcl=${MINGW_PREFIX}/lib \
@@ -82,6 +83,12 @@ build() {
   # build extensions
   ./config.status --file=ext/misc/Makefile:../Makefile.ext.in
   make -C ext/misc
+}
+
+check() {
+  cd "${srcdir}/build-${_amalgamationver}-${MINGW_CHOST}"
+  # This test run lasts very loooong ... despite the target name
+  make quicktest || true
 }
 
 package() {


### PR DESCRIPTION
* PKGBUILD:
  - remove redundant configure flag '--enable-rtree' (implied by
    '--enable-all')
  - add CFLAG 'SQLITE_ENABLE_MATH_FUNCTIONS' introduced with 3.35.0 to
    activate math functions in sqlite.exe
  - add check function