### PR TITLE
sqlite3: Update to 3.35.1

### DIFF
--- a/mingw-w64-sqlite3/PKGBUILD
+++ b/mingw-w64-sqlite3/PKGBUILD
@@ -5,9 +5,9 @@
 _realname=sqlite3
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-_amalgamationver=3350000
+_amalgamationver=3350100
 _docver=${_amalgamationver}
-pkgver=3.35.0
+pkgver=3.35.1
 pkgrel=1
 pkgdesc="A C library that implements an SQL database engine (mingw-w64)"
 arch=('any')
@@ -27,8 +27,8 @@ source=(https://www.sqlite.org/2021/sqlite-src-${_amalgamationver}.zip
         Makefile.ext.in
         README.md.in
         LICENSE)
-sha256sums=('c72dea7b8148a4c1b00145c9aab52317cffbfb46b6179c476f6e41d4f87c6af2'
-            '27433ffad8f056c98616a2c3dd4d55a2a997e9bee068630c4f43b6ae75413602'
+sha256sums=('8cb60d7cc55c410fcd6990fe92802fda02760efa4fe3569a677e3e8dcdf8b107'
+            '3bb955ea75606e735955aa0b680d72d91cde367b6d3e38ee14b88a588deb6a4f'
             '6e3994c2e10af6fdc70530778c674bfcf6df65a257dd10cfdfb4f34b399de004'
             '5ca42f1f92abfb61bacc9ff60f5836cc56e2ce2af52264f918cb06c3d566d562'
             '0b76663a90e034f3d7f2af5bfada4cedec5ebc275361899eccc5c18e6f01ff1f')


### PR DESCRIPTION
The patch release `3.35.1` contains [bug](https://www.sqlite.org/src/info/1c24a659e6d7f3a1)  fix and documentation improvements.