### PR TITLE
igraph: Update to 0.9.0

### DIFF
--- a/mingw-w64-igraph/0001-igraph-0.9.0-link-libm-only-when-needed.patch
+++ b/mingw-w64-igraph/0001-igraph-0.9.0-link-libm-only-when-needed.patch
@@ -1,0 +1,35 @@
+--- a/etc/cmake/dependencies.cmake	2021-03-16 09:36:45.888000200 +0100
++++ b/etc/cmake/dependencies.cmake	2021-03-16 09:38:50.702227000 +0100
+@@ -4,6 +4,8 @@
+ # for tests
+ include(FindThreads)
+
++include(CheckSymbolExists)
++
+ macro(find_dependencies)
+   # Declare the list of dependencies that _may_ be vendored and those that may not
+   set(VENDORABLE_DEPENDENCIES BLAS CXSparse GLPK LAPACK ARPACK GMP)
+@@ -103,5 +105,22 @@
+   set(HAVE_GMP ${GMP_FOUND})
+   set(HAVE_LIBXML ${LIBXML2_FOUND})
+
+-  find_library(MATH_LIBRARY m)
++  if(NOT DEFINED CACHE{NEED_LINKING_AGAINST_LIBM})
++    check_symbol_exists(sinh "math.h" SINH_FUNCTION_EXISTS)
++    if(NOT SINH_FUNCTION_EXISTS)
++        unset(SINH_FUNCTION_EXISTS CACHE)
++        list(APPEND CMAKE_REQUIRED_LIBRARIES m)
++        check_symbol_exists(sinh "math.h" SINH_FUNCTION_EXISTS)
++        if(SINH_FUNCTION_EXISTS)
++            set(NEED_LINKING_AGAINST_LIBM True CACHE BOOL "" FORCE)
++        else()
++            message(FATAL_ERROR "Failed making the sinh() function available")
++        endif()
++    endif()
++  endif()
++
++  if(NEED_LINKING_AGAINST_LIBM)
++    find_library(MATH_LIBRARY m)
++  endif()
++
+ endmacro()

--- a/mingw-w64-igraph/PKGBUILD
+++ b/mingw-w64-igraph/PKGBUILD
@@ -2,47 +2,56 @@
 _realname=igraph
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.8.5
+pkgver=0.9.0
 pkgrel=1
 pkgdesc="Library for the analysis of networks (mingw-w64)"
 arch=('any')
 url="https://igraph.org"
 license=('GPL')
-source=(https://github.com/igraph/igraph/releases/download/${pkgver}/igraph-${pkgver}.tar.gz)
-sha256sums=('2e5da63a2b8e9bb497893a17cf77c691df1739c298664f8adb1310a01218f95b')
-depends=("${MINGW_PACKAGE_PREFIX}-glpk"
-         "${MINGW_PACKAGE_PREFIX}-gmp"
-         "${MINGW_PACKAGE_PREFIX}-zlib"
-         "${MINGW_PACKAGE_PREFIX}-libxml2")
-makedepends=(flex bison)
-
+source=("https://github.com/igraph/igraph/releases/download/${pkgver}/igraph-${pkgver}.tar.gz"
+        '0001-igraph-0.9.0-link-libm-only-when-needed.patch')
+sha256sums=('012e5d5a50420420588c33ec114c6b3000ccde544db3f25c282c1931c462ad7a'
+            'c84862f28bf07b145eeb3c2ebe65e1a8c5efadb1513cb8f897934f9c95244bd2')
+depends=("${MINGW_PACKAGE_PREFIX}-libxml2"
+         "${MINGW_PACKAGE_PREFIX}-zlib")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake")
 
 _srcdir=${_realname}-${pkgver}
 _builddir=build-${pkgver}-${MINGW_PACKAGE_PREFIX}
 
 prepare() {
   cd ${_srcdir}
-
-  autoreconf -vfi
-
-  # remove the file testsuite in source tree to force 'make check'
-  # to generate it from scratch.
-  test -f tests/testsuite || rm -f tests/testsuite
+  patch -p1 -b -i "${srcdir}/0001-igraph-0.9.0-link-libm-only-when-needed.patch"
 }
 
 build() {
   mkdir -p ${_builddir}
-  cd ${_builddir}
-  ../${_srcdir}/configure -C \
-    --enable-tls             \
-    YFLAGS=-Wall
+  pushd ${_builddir}
+    MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake ../${_srcdir} \
+      -G 'MSYS Makefiles' \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DIGRAPH_GLPK_SUPPORT=1 \
+      -DIGRAPH_GRAPHML_SUPPORT=1 \
+      -DIGRAPH_VERIFY_FINALLY_STACK=1 \
+      -DIGRAPH_USE_INTERNAL_ARPACK=1 \
+      -DIGRAPH_USE_INTERNAL_BLAS=1 \
+      -DIGRAPH_USE_INTERNAL_CXSPARSE=1 \
+      -DIGRAPH_USE_INTERNAL_GLPK=1 \
+      -DIGRAPH_USE_INTERNAL_GMP=1 \
+      -DIGRAPH_USE_INTERNAL_LAPACK=1
 
-  make V=0 || make
+    make || make VERBOSE=1
+  popd
 }
 
 check() {
-  # igraph 0.8.5: all tests succeeded
-  make V=0 -C ${_builddir} check TESTSUITEFLAGS=-j
+  # igraph 0.9.0: all tests succeeded
+  pushd ${_builddir}
+    make build_tests
+    ${MINGW_PREFIX}/bin/ctest --output-on-failure
+  popd
 }
 
 package() {


### PR DESCRIPTION
* PKGBUILD
  - upgrade to 0.9.0
  - move mandatorily from build system autoconf to cmake
  - use internal libraries to reduce package dependencies
  - remove unneccessary make dependencies 'bison' and 'flex'
  - fix link bug by removing explicit link against libm (using patch)
* 0001-igraph-0.9.0-link-libm-only-when-needed.patch
  - patch checking if explicit link against libm is needed fixing link error