### PR TITLE
Update several EDA tools

### DIFF
--- a/mingw-w64-ghdl/PKGBUILD
+++ b/mingw-w64-ghdl/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=ghdl
 pkgbase="mingw-w64-${_realname}"
 pkgname='__placeholder__'
-pkgver=1.0.0
+pkgver=1.0.0.r101.g420a1d3e
 pkgrel=1
 pkgdesc='GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL'
 arch=('any')
@@ -10,14 +10,14 @@ url='https://github.com/ghdl'
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_commit='2fb2384d'
+_commit='420a1d3e'
 source=("${_realname}::git://github.com/ghdl/ghdl.git#commit=${_commit}")
 sha512sums=('SKIP')
 
-#pkgver() {
-#  cd "ghdl"
-#  git describe --long | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//g'
-#}
+pkgver() {
+  cd "ghdl"
+  git describe --long | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//g'
+}
 
 build() {
   [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}

--- a/mingw-w64-icestorm/PKGBUILD
+++ b/mingw-w64-icestorm/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=icestorm
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.0.r772.da52117
-pkgrel=2
+pkgver=0.0.r777.c495861
+pkgrel=1
 pkgdesc="Simple tools for analyzing and creating bitstream files for Lattice iCE40 FPGAs (mingw-w64)"
 arch=('any')
 url="http://www.clifford.at/icestorm/"
@@ -16,7 +16,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "flex"
              "git")
 
-_commit="da52117"
+_commit="c495861c"
 source=("icestorm::git://github.com/YosysHQ/${_realname}.git#commit=${_commit}")
 sha256sums=('SKIP')
 

--- a/mingw-w64-iverilog/PKGBUILD
+++ b/mingw-w64-iverilog/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=iverilog
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=11.0.r8891.18e7406d
+pkgver=11.0.r8897.d8cb29f6
 pkgrel=1
 epoch=1
 pkgdesc="Icarus Verilog, is a Verilog simulation and synthesis tool (mingw-w64)"
@@ -20,7 +20,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 
 # NOTE: MSYS2 support was improved/fixed in 'master' (2020/12/04).
 # When 12.0 is tagged/released, this should be changed to use a tarball instead.
-_commit="18e7406d"
+_commit="d8cb29f6"
 source=("${_realname}::git://github.com/steveicarus/iverilog.git#commit=${_commit}")
 sha256sums=('SKIP')
 

--- a/mingw-w64-prjtrellis/PKGBUILD
+++ b/mingw-w64-prjtrellis/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=prjtrellis
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.0.r977.9b3db7b
+pkgver=1.0.r993.7454564
 pkgrel=1
 pkgdesc="Documenting the Lattice ECP5 bit-stream format (mingw-w64)"
 arch=('any')
@@ -17,7 +17,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-boost"
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "git")
 
-_commit="9b3db7b"
+_commit="7454564f"
 source=("${_realname}::git://github.com/YosysHQ/${_realname}.git#commit=${_commit}"
         "prjtrellis-db::git://github.com/YosysHQ/prjtrellis-db")
 sha256sums=('SKIP'

--- a/mingw-w64-serial-studio/PKGBUILD
+++ b/mingw-w64-serial-studio/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=serial-studio
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.0.16
+pkgver=1.0.20
 pkgrel=1
 pkgdesc="Serial Studio: Multi-purpose serial data visualization & processing program (mingw-w64)"
 arch=('any')

--- a/mingw-w64-verilator/PKGBUILD
+++ b/mingw-w64-verilator/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=verilator
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.108
+pkgver=4.200
 pkgrel=1
 pkgdesc="The fastest free Verilog HDL simulator (mingw-w64)"
 arch=('any')
@@ -14,7 +14,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "flex")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 
 source=("${_realname}::https://codeload.github.com/${_realname}/${_realname}/tar.gz/v${pkgver}")
-sha256sums=('ce521dc57754e5a325ff7000c434ce23674c8e1de30e1f2a6506dc3a33bd7c55')
+sha256sums=('2cd0fd48152f152d0487eaac23803d35ff75e924734435b366a523deb1185407')
 
 prepare() {
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"

--- a/mingw-w64-yosys/PKGBUILD
+++ b/mingw-w64-yosys/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=yosys
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.9.r10550.4e741adda
+pkgver=0.9.r10684.92d5550a9
 pkgrel=1
 pkgdesc="A framework for RTL synthesis tools (mingw-w64)"
 arch=('any')
@@ -20,10 +20,10 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python"
 )
 
-_commit='4e741add'
+_commit='92d5550a'
 source=(
   "${_realname}::git://github.com/YosysHQ/${_realname}.git#commit=${_commit}"
-  "ghdl-yosys-plugin::git://github.com/ghdl/ghdl-yosys-plugin.git#commit=6671d04"
+  "ghdl-yosys-plugin::git://github.com/ghdl/ghdl-yosys-plugin.git#commit=d41b5e1"
 )
 sha256sums=(
   'SKIP'


### PR DESCRIPTION
In this PR several EDA tools are updated: verilator, ghdl, yosys, iverilog, icestorm, prjtrellis and serial-studio.