### PR TITLE
mingw-w64-headers: default to win10 on ucrt

### DIFF
--- a/mingw-w64-headers-git/PKGBUILD
+++ b/mingw-w64-headers-git/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 pkgdesc="MinGW-w64 headers for Windows"
 pkgver=9.0.0.6128.07922837
-pkgrel=2
+pkgrel=3
 _commit='0792283787cca8fc27dd38671107c791c87f4db3'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -45,8 +45,8 @@ prepare() {
 
 build() {
   local _default_win32_winnt
-  case "${CARCH}" in
-    i686|x86_64)
+  case "${MSYSTEM}" in
+    MINGW*)
       _default_win32_winnt=0x601
       ;;
     *)


### PR DESCRIPTION
I noticed msys2 now has a ucrt repo, that's great news!

This PR changes the default to win10 when building mingw-w64-headers for ucrt,
based on the inspiration of recent install files fixup 