### PR TITLE
MINGW_INSTALLS is deprecated, use MINGW_ARCH instead

### DIFF
--- a/.ci/ci-generate-srcinfo.py
+++ b/.ci/ci-generate-srcinfo.py
@@ -124,7 +124,7 @@ def get_srcinfo_for_pkgbuild(args: Tuple[str, str]) -> Optional[CacheTuple]:
         if mode == "mingw":
             for name in get_mingw_arch_list(pkgbuild_path):
                 env = os.environ.copy()
-                env["MINGW_INSTALLS"] = name
+                env["MINGW_ARCH"] = name
                 srcinfos[name] = subprocess.check_output(
                     [bash, "/usr/bin/makepkg-mingw",
                     "--printsrcinfo", "-p", git_path],

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
         continue-on-error: ${{ matrix.can-fail }}
         run: |
           cd /C/_
-          MINGW_INSTALLS=${{ matrix.msystem }} ./.ci/ci-build.sh
+          MINGW_ARCH=${{ matrix.msystem }} ./.ci/ci-build.sh
 
       - name: "Upload binaries"
         uses: actions/upload-artifact@v2

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You have two options if you want to use these packages:
  Assuming you have a properly installed MSYS2 environment and build tools, you can build any package using the following command:
  ```
     cd ${package-name}
-    MINGW_INSTALLS=mingw64 makepkg-mingw -sLf
+    MINGW_ARCH=mingw64 makepkg-mingw -sLf
  ```
  After that you can install the freshly built package(s) with the following command:
  ```

--- a/mingw-w64-wxWidgets3.1/PKGBUILD
+++ b/mingw-w64-wxWidgets3.1/PKGBUILD
@@ -8,7 +8,7 @@
 #
 ####
 # Normal 64 bit build command
-#   MINGW_INSTALLS=mingw64 makepkg-mingw -sLf
+#   MINGW_ARCH=mingw64 makepkg-mingw -sLf
 
 _basename=wxWidgets
 _realname=wxmsw


### PR DESCRIPTION
Update the scripts used in CI, for avoiding warnings due to the deprecated MINGW_INSTALLS envvar.