### PR TITLE
nextpnr: enable ARCH 'ecp5' (prjtrellis) on MINGW64

### DIFF
--- a/mingw-w64-nextpnr/PKGBUILD
+++ b/mingw-w64-nextpnr/PKGBUILD
@@ -4,24 +4,29 @@ _realname=nextpnr
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.0.r2859.5e53a182
-pkgrel=2
+pkgrel=3
 pkgdesc="Portable FPGA place and route tool (mingw-w64)"
 arch=('any')
 url="https://github.com/YosysHQ/nextpnr"
 license=('ISC')
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
-depends=("${MINGW_PACKAGE_PREFIX}-boost"
-         "${MINGW_PACKAGE_PREFIX}-qt5"
-         "${MINGW_PACKAGE_PREFIX}-python")
-makedepends=("${MINGW_PACKAGE_PREFIX}-boost"
-             "${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-eigen3"
-             "${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-icestorm"
-             "${MINGW_PACKAGE_PREFIX}-openmp"
-             "${MINGW_PACKAGE_PREFIX}-python"
-             "${MINGW_PACKAGE_PREFIX}-qt5"
-             "git")
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-boost"
+  "${MINGW_PACKAGE_PREFIX}-qt5"
+  "${MINGW_PACKAGE_PREFIX}-python"
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-boost"
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+  "${MINGW_PACKAGE_PREFIX}-eigen3"
+  "${MINGW_PACKAGE_PREFIX}-gcc"
+  "${MINGW_PACKAGE_PREFIX}-icestorm"
+  "${MINGW_PACKAGE_PREFIX}-openmp"
+  "${MINGW_PACKAGE_PREFIX}-python"
+  "${MINGW_PACKAGE_PREFIX}-prjtrellis"
+  "${MINGW_PACKAGE_PREFIX}-qt5"
+  "git"
+)
 
 _commit="5e53a18"
 source=("${_realname}::git://github.com/YosysHQ/${_realname}.git#commit=${_commit}")
@@ -35,12 +40,17 @@ pkgver() {
 build() {
   cd "${srcdir}/${_realname}"
 
+  unset _extra-archs
+  if [ "$CARCH" = "x86_64" ]; then
+    _extra_archs=";ecp5"
+  fi
+
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" cmake \
     -G "MSYS Makefiles" \
     -DICESTORM_INSTALL_PREFIX="${MINGW_PREFIX}" \
     -DCMAKE_PREFIX_PATH=${MINGW_PREFIX} \
     -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
-    -DARCH='generic;ice40' \
+    -DARCH="generic;ice40${_extra_archs}" \
     -DBUILD_HEAP=ON \
     -DUSE_OPENMP=ON \
     -DBUILD_PYTHON=ON \

--- a/mingw-w64-nextpnr/PKGBUILD
+++ b/mingw-w64-nextpnr/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=nextpnr
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.0.r2859.5e53a182
-pkgrel=3
+pkgver=0.0.r3229.326b3488
+pkgrel=1
 pkgdesc="Portable FPGA place and route tool (mingw-w64)"
 arch=('any')
 url="https://github.com/YosysHQ/nextpnr"
@@ -28,7 +28,7 @@ makedepends=(
   "git"
 )
 
-_commit="5e53a18"
+_commit="326b3488"
 source=("${_realname}::git://github.com/YosysHQ/${_realname}.git#commit=${_commit}")
 sha256sums=('SKIP')
 


### PR DESCRIPTION
Due to the issues for building ECP5 deps on 32 bits (see #7568), in this PR the architecture is enabled on MINGW64 only. At the same time, the package is updated.