### PR TITLE
Zig - mingw support fixed

### DIFF
--- a/mingw-w64-zig/PKGBUILD
+++ b/mingw-w64-zig/PKGBUILD
@@ -3,16 +3,18 @@
 pkgbase=mingw-w64-zig
 pkgname="${MINGW_PACKAGE_PREFIX}-zig"
 pkgver=0.7.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Zig is a general-purpose programming language and toolchain for maintaining robust, optimal, and reusable software. (mingw-w64)'
 arch=('any')
-mingw_arch=('mingw64')
+mingw_arch=('mingw64' 'ucrt64')
 url='https://ziglang.org'
 license=(MIT)
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-lld"
-             "${MINGW_PACKAGE_PREFIX}-clang")
-depends=("${MINGW_PACKAGE_PREFIX}-llvm")
+             )
+depends=("${MINGW_PACKAGE_PREFIX}-llvm"
+         "${MINGW_PACKAGE_PREFIX}-clang"
+         )
 source=("zig-${pkgver}.tar.gz::https://github.com/ziglang/zig/archive/${pkgver}.tar.gz")
 sha512sums=('ad0b36f7b40481aca03940adfd42d34a724922993fc29a23a80412dc087ca6ce4876a400dc9bb7da455564521a88ea205c218988759ff6c56251a08232bfa41a')
 
@@ -24,6 +26,8 @@ build() {
         -DCMAKE_CXX_COMPILER="clang++" \
         -DCMAKE_C_COMPILER="clang" \
         -DCMAKE_BUILD_TYPE=Release \
+        -DZIG_PREFER_CLANG_CPP_DYLIB=true \
+        -DZIG_TARGET_TRIPLE="x86_64-windows-gnu" \
         -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
         -B build-${MINGW_CHOST}
 


### PR DESCRIPTION
- Fix support for mingw libraries, but needs to depend on the [clang-cpp library](https://github.com/ziglang/zig/wiki/Troubleshooting-Build-Issues).
- ucrt64 support added