### PR TITLE
Update Python Packages

### DIFF
--- a/mingw-w64-python-build/PKGBUILD
+++ b/mingw-w64-python-build/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=build
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=0.3.1
+pkgver=0.3.1.post1
 pkgrel=1
 pkgdesc="A simple, correct PEP517 package builder (mingw-w64)"
 arch=('any')
@@ -11,14 +11,15 @@ url='https://github.com/pypa/build'
 license=('MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-python-packaging"
          "${MINGW_PACKAGE_PREFIX}-python-pep517"
-         "${MINGW_PACKAGE_PREFIX}-python-toml")
+         "${MINGW_PACKAGE_PREFIX}-python-toml"
+         "${MINGW_PACKAGE_PREFIX}-python-virtualenv")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-mock"
             "${MINGW_PACKAGE_PREFIX}-python-filelock"
             "${MINGW_PACKAGE_PREFIX}-python-pytest")
 source=("${_realname}-$pkgver.tar.gz"::"https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
         "0001-pass-ignore_errors-to-shutil.patch")
-sha512sums=('8fa759302272dc9375169852350c079aa8e8d49939b47f06517eef0dfda91d745eb874ada51939735c43c91a7933193f4becc78101eeb170690ef42c7eec492e'
+sha512sums=('2f7df86ff6d932ed84f073d991f41c132e27ec442363762d92cbaa576ad429dafd15af94756c89c887250fee816c9cc18f267611b7dad669137a2dad034389a1'
             '80fb412e0e33e25de1e4b470321316b193a457ce6f89244999ab4ae70ea5cc49f64f34c8666456548af720017f13c61123009a8c8628b5e0627fa7023eea73fb')
 
 

--- a/mingw-w64-python-faker/PKGBUILD
+++ b/mingw-w64-python-faker/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=6.6.3
+pkgver=7.0.0
 pkgrel=1
 pkgdesc="Faker generates fake data for you (mingw-w64)"
 arch=('any')
@@ -21,7 +21,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python-ukpostcodeparser"
 install=${_realname}3-${CARCH}.install
 options=('staticlibs' 'strip' '!debug')
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/joke2k/faker/archive/v${pkgver}.tar.gz")
-sha512sums=('fc6cbe570cff154825a4fdd95ae0d2aba5a5e14ccd5724a827a1dcf0673d0c5c7afaa4e08b9f289b393b302db06c3b163e17ca5d352eaf409753203da501d5c7')
+sha512sums=('e3f747115b431151f3c5bd88000dbbf2343b053f043636a4e65d87a901507ce19d1a07d1d6e7341383c4ac02d43a05aec8edada014f183088dc1004adfcb7a4b')
 
 prepare() {
   cd "${srcdir}"

--- a/mingw-w64-python-hypothesis/PKGBUILD
+++ b/mingw-w64-python-hypothesis/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=6.8.2
+pkgver=6.8.3
 pkgrel=1
 pkgdesc="Advanced Quickcheck style testing library for Python (mingw-w64)"
 arch=('any')
@@ -33,7 +33,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 #              "${MINGW_PACKAGE_PREFIX}-python-pandas")
 options=('staticlibs' 'strip' '!debug')
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/HypothesisWorks/hypothesis/archive/hypothesis-python-${pkgver}.tar.gz")
-sha512sums=('95c345e869695ca9b53f345eaa52d4fb92108a830fd3a3bbe3ed1a8382be233cc56c73a321f3948c947090e89ade1849dfbc72e84b01b3e99f1336f1f5e816a3')
+sha512sums=('83660978dc4ff49a04d7167994821a18c769039c49dcbc515b28591651bb9ab2121e3a7267cb20281efade85003a5808e0898fda5dfe1e4be563a03d4688085c')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {

--- a/mingw-w64-python-importlib-metadata/PKGBUILD
+++ b/mingw-w64-python-importlib-metadata/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=importlib-metadata
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=3.8.0
+pkgver=3.9.1
 pkgrel=1
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}=${pkgver}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
@@ -20,7 +20,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pip"
               "${MINGW_PACKAGE_PREFIX}-python-pytest-runner"
               "${MINGW_PACKAGE_PREFIX}-python-wheel")
 source=("${_realname}-${pkgver}.tar.gz"::"https://files.pythonhosted.org/packages/source/${_realname::1}/${_realname//-/_}/${_realname//-/_}-${pkgver}.tar.gz")
-sha256sums=('9dd89454add8894cc93619426949a58bdad9c1ef42822e46b884e7fc2d2a901e')
+sha256sums=('c9c1b6c7dbc62084f3e6a614a194eb16ded7947736c18e3300125d5c0a7a8b3c')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {

--- a/mingw-w64-python-nuitka/PKGBUILD
+++ b/mingw-w64-python-nuitka/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=0.6.13.1
+pkgver=0.6.13.2
 pkgrel=1
 pkgdesc="Python to native compiler (mingw-w64)"
 arch=('any')
@@ -16,7 +16,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-python")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 source=("http://nuitka.net/releases/Nuitka-${pkgver}.tar.gz")
 noextract=(Nuitka-$pkgver.tar.gz)
-sha256sums=('dd583ec4bc5680c961652c4a6f8a9e47de7458c5af3e5ef4a57a6c604909e0ee')
+sha256sums=('f3934fccd4253b6c5b992b9e0c16c4ec85bdf6cb47978af2f01bd19ee4616086')
 
 prepare() {
   [[ -d $srcdir/${_realname}-${pkgver} ]] && rm -rf ${srcdir}/${_realname}-${pkgver}

--- a/mingw-w64-python-numpy/PKGBUILD
+++ b/mingw-w64-python-numpy/PKGBUILD
@@ -8,7 +8,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=1.20.1
+pkgver=1.20.2
 pkgrel=1
 pkgdesc="Scientific tools for Python (mingw-w64)"
 arch=('any')
@@ -35,7 +35,7 @@ source=(https://github.com/numpy/numpy/releases/download/v${pkgver}/${_realname}
         0008-mingw-gcc-doesnt-support-visibility.patch
         0009-disable-old-mingw-stuff.patch
         0010-mingw-inline-stuff.patch)
-sha256sums=('9bf51d69ebb4ca9239e55bedc2185fe2c0ec222da0adee7ece4125414676846d'
+sha256sums=('c049f410c78e76ffb0af830a8afbdf8baac09897b4152b97b1a3b8345ee338ff'
             '94f111ab238c4a82e8613ed14e4cbeb553eabff26523f576e5fcafdbfdc8ee29'
             '3aacb1d92e7764c9f0f24afa1a97b136a069fcd81d63c9fa55565c40c5a29974'
             '2679482ce9396b551e1e1e7674f373d139b3e8a2f9729026000dd3c581de41d7'

--- a/mingw-w64-python-pytest-checkdocs/PKGBUILD
+++ b/mingw-w64-python-pytest-checkdocs/PKGBUILD
@@ -4,8 +4,8 @@ _pyname=pytest-checkdocs
 _realname=pytest-checkdocs
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=2.4.0
-pkgrel=2
+pkgver=2.5.0
+pkgrel=1
 pkgdesc='check the README when running tests (mingw-w64)'
 arch=('any')
 url="https://github.com/jaraco/pytest-checkdocs"
@@ -20,7 +20,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm"
 )
 source=("${_pyname}-${pkgver}.tar.gz::https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${pkgver}.tar.gz")
-sha256sums=('8cda4912a05db140a42814763e418b6ee0b0da414bae8e85db43bdd371b2372a')
+sha256sums=('f6b9bb97b6ecd4ca880bd478bacbe43f15ea2967d1b7e2a393500b8e5368f1a6')
 
 prepare() {  
   cd "$srcdir"


### PR DESCRIPTION
- python-build: update to 0.3.1.post1
- python-faker: update to 7.0.0
- python-hypothesis: update to 6.8.3
- python-importlib-metadata: update to 3.9.1
- python-nuitka: update to 0.6.13.2
- python-numpy: update to 1.20.2
- python-pytest-checkdocs: update to 2.5.0