### PR TITLE
binutils: remove libdep.a which leads to errors when using ar

### DIFF
--- a/mingw-w64-binutils/PKGBUILD
+++ b/mingw-w64-binutils/PKGBUILD
@@ -6,7 +6,7 @@ _realname=binutils
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.36.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A set of programs to assemble and manipulate binary and object files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -108,6 +108,9 @@ package() {
   cp ${pkgdir}${MINGW_PREFIX}/include/ansidecl.h ${pkgdir}${MINGW_PREFIX}/${MINGW_CHOST}/include/
   mv ${pkgdir}${MINGW_PREFIX}/include/*.h ${pkgdir}${MINGW_PREFIX}/include/${_realname}
   mv ${pkgdir}${MINGW_PREFIX}/lib/*.a ${pkgdir}${MINGW_PREFIX}/lib/${_realname}
+
+  # https://github.com/msys2/MINGW-packages/issues/7890
+  rm "${pkgdir}${MINGW_PREFIX}/lib/bfd-plugins/libdep.a"
 
   find ${pkgdir}${MINGW_PREFIX}/share -type f -iname "opcodes.mo" -o -iname "bfd.mo" | xargs -rtl1 rm
 


### PR DESCRIPTION
Not sure if this needs to be fixed or just isn't useful on Windows.

Fixes #7890