### PR TITLE
ghdl: update to 1.0.0.r122.g1c17875a

### DIFF
--- a/mingw-w64-ghdl/PKGBUILD
+++ b/mingw-w64-ghdl/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=ghdl
 pkgbase="mingw-w64-${_realname}"
 pkgname='__placeholder__'
-pkgver=1.0.0.r101.g420a1d3e
+pkgver=1.0.0.r122.g1c17875a
 pkgrel=1
 pkgdesc='GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL'
 arch=('any')
@@ -11,7 +11,7 @@ url='https://github.com/ghdl'
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_commit='420a1d3e'
+_commit='1c17875a'
 source=("${_realname}::git://github.com/ghdl/ghdl.git#commit=${_commit}")
 sha512sums=('SKIP')
 


### PR DESCRIPTION
Update GHDL for providing synth option `raw-vhdl` (added a few days ago).