### PR TITLE
gcc: Update coroutine header from master

### DIFF
--- a/mingw-w64-curl/0001-Make-cURL-relocatable.patch
+++ b/mingw-w64-curl/0001-Make-cURL-relocatable.patch
@@ -687,7 +687,7 @@ index 945d4e327..981e60d26 100644
  
  /* The last 3 #include files should be in this order */
  #include "curl_printf.h"
-@@ -498,21 +501,54 @@
+@@ -575,21 +575,54 @@
     */
    if(Curl_ssl_backend() != CURLSSLBACKEND_SCHANNEL) {
  #if defined(CURL_CA_BUNDLE)
@@ -701,9 +701,9 @@ index 945d4e327..981e60d26 100644
 +    strncat(relocated_bundle, relative, path_max);
 +    free((void*)relative);
 +    simplify_path(relocated_bundle);
-+    result = Curl_setstropt(&set->str[STRING_SSL_CAFILE_ORIG], relocated_bundle);
++    result = Curl_setstropt(&set->str[STRING_SSL_CAFILE], relocated_bundle);
 +#else
-     result = Curl_setstropt(&set->str[STRING_SSL_CAFILE_ORIG], CURL_CA_BUNDLE);
+     result = Curl_setstropt(&set->str[STRING_SSL_CAFILE], CURL_CA_BUNDLE);
 +#endif /* defined(__MINGW32__) */
      if(result)
        return result;
@@ -729,9 +729,9 @@ index 945d4e327..981e60d26 100644
 +    strncat(relocated_ca_path, relative, path_max);
 +    free((void*)relative);
 +    simplify_path(relocated_ca_path);
-+    result = Curl_setstropt(&set->str[STRING_SSL_CAPATH_ORIG], relocated_ca_path);
++    result = Curl_setstropt(&set->str[STRING_SSL_CAPATH], relocated_ca_path);
 +#else
-     result = Curl_setstropt(&set->str[STRING_SSL_CAPATH_ORIG], CURL_CA_PATH);
+     result = Curl_setstropt(&set->str[STRING_SSL_CAPATH], CURL_CA_PATH);
 +#endif /* defined(__MINGW32__) */
      if(result)
        return result;

--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -13,12 +13,12 @@ fi
 _realname=curl
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}${_namesuff}"
-pkgver=7.75.0
+pkgver=7.76.0
 pkgrel=1
 pkgdesc="Command line tool and library for transferring data with URLs. (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
-url="https://curl.haxx.se/"
+url="https://curl.se/"
 license=("MIT")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
@@ -45,13 +45,13 @@ if [ -n "${_namesuff}" ]; then
   conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 fi
 options=('staticlibs')
-source=("${url}/download/${_realname}-${pkgver}.tar.xz"{,.asc}
+source=("https://github.com/curl/curl/releases/download/${_realname}-${pkgver//./_}/${_realname}-${pkgver}.tar.xz"{,.asc}
         "0001-Make-cURL-relocatable.patch"
         "0002-nghttp2-static.patch"
         "0003-libpsl-static-libs.patch")
-sha256sums=('fe0c49d8468249000bda75bcfdf9e30ff7e9a86d35f1a21f428d79c389d55675'
+sha256sums=('6302e2d75c59cdc6b35ce3fbe716481dd4301841bbb5fd71854653652a014fc8'
             'SKIP'
-            '9f7755cb53b9deceeb9a47c8f09f3e3bb2a01c01ef12da5ab3494a4c1c0c9959'
+            '41e7d1f734cae5fbeea8a84ec4af40c29bf7ffbf156ab290abd57df840312ca1'
             '79eec8a337e375d5102fef884030ceacd163a79e5c495e9a974a6b9a11b60c61'
             '7492d019036b5bec251bfbc3c0b40e5f16d3dd6b2515068835e087a6c21f19ad')
 validpgpkeys=('914C533DF9B2ADA2204F586D78E11C6B279D5C91'  # Daniel Stenberg
@@ -129,7 +129,7 @@ build() {
 package() {
   cd "${srcdir}/build-${CARCH}"
   make DESTDIR="${pkgdir}" install
-  
+
   local PREFIX_DEPS=$(cygpath -am ${MINGW_PREFIX})
   sed -s "s|${PREFIX_DEPS}|${MINGW_PREFIX}|g" -i ${pkgdir}${MINGW_PREFIX}/bin/curl-config
 }

--- a/mingw-w64-gcc/0130-libstdc++-in-out.patch
+++ b/mingw-w64-gcc/0130-libstdc++-in-out.patch
@@ -1,6 +1,6 @@
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/config/locale/dragonfly/c_locale.h gcc-10.1.0/libstdc++-v3/config/locale/dragonfly/c_locale.h
---- gcc-10.1.0-orig/libstdc++-v3/config/locale/dragonfly/c_locale.h	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/config/locale/dragonfly/c_locale.h	2020-05-08 15:27:14.917453700 +0300
+diff -adru a/libstdc++-v3/config/locale/dragonfly/c_locale.h b/libstdc++-v3/config/locale/dragonfly/c_locale.h
+--- a/libstdc++-v3/config/locale/dragonfly/c_locale.h	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/config/locale/dragonfly/c_locale.h	2021-04-09 13:06:24.493112800 +0800
 @@ -55,7 +55,7 @@
    // fall back to the unsafe vsprintf which, in general, can be dangerous
    // and should be avoided.
@@ -22,9 +22,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/config/locale/dragonfly/c_locale.h gcc-1
  #endif
  
      __builtin_va_end(__args);
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/config/locale/generic/c_locale.h gcc-10.1.0/libstdc++-v3/config/locale/generic/c_locale.h
---- gcc-10.1.0-orig/libstdc++-v3/config/locale/generic/c_locale.h	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/config/locale/generic/c_locale.h	2020-05-08 15:27:14.920470300 +0300
+diff -adru a/libstdc++-v3/config/locale/generic/c_locale.h b/libstdc++-v3/config/locale/generic/c_locale.h
+--- a/libstdc++-v3/config/locale/generic/c_locale.h	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/config/locale/generic/c_locale.h	2021-04-09 13:06:24.493112800 +0800
 @@ -53,7 +53,7 @@
    // fall back to the unsafe vsprintf which, in general, can be dangerous
    // and should be avoided.
@@ -46,9 +46,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/config/locale/generic/c_locale.h gcc-10.
  #endif
  
      __builtin_va_end(__args);
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/config/locale/gnu/c_locale.h gcc-10.1.0/libstdc++-v3/config/locale/gnu/c_locale.h
---- gcc-10.1.0-orig/libstdc++-v3/config/locale/gnu/c_locale.h	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/config/locale/gnu/c_locale.h	2020-05-08 15:27:14.923461200 +0300
+diff -adru a/libstdc++-v3/config/locale/gnu/c_locale.h b/libstdc++-v3/config/locale/gnu/c_locale.h
+--- a/libstdc++-v3/config/locale/gnu/c_locale.h	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/config/locale/gnu/c_locale.h	2021-04-09 13:06:24.493112800 +0800
 @@ -67,7 +67,7 @@
    // and should be avoided.
    inline int
@@ -70,10 +70,10 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/config/locale/gnu/c_locale.h gcc-10.1.0/
  #endif
  
      __builtin_va_end(__args);
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/basic_string.h gcc-10.1.0/libstdc++-v3/include/bits/basic_string.h
---- gcc-10.1.0-orig/libstdc++-v3/include/bits/basic_string.h	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/bits/basic_string.h	2020-05-08 15:27:14.939505400 +0300
-@@ -6517,13 +6517,13 @@
+diff -adru a/libstdc++-v3/include/bits/basic_string.h b/libstdc++-v3/include/bits/basic_string.h
+--- a/libstdc++-v3/include/bits/basic_string.h	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/bits/basic_string.h	2021-04-09 13:06:24.087003600 +0800
+@@ -6527,13 +6527,13 @@
  
    template<>
      basic_istream<char>&
@@ -89,10 +89,10 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/basic_string.h gcc-10.1.0/l
  	    wchar_t __delim);
  #endif  
  
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/basic_string.tcc gcc-10.1.0/libstdc++-v3/include/bits/basic_string.tcc
---- gcc-10.1.0-orig/libstdc++-v3/include/bits/basic_string.tcc	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/bits/basic_string.tcc	2020-05-08 15:27:14.947409100 +0300
-@@ -1473,7 +1473,7 @@
+diff -adru a/libstdc++-v3/include/bits/basic_string.tcc b/libstdc++-v3/include/bits/basic_string.tcc
+--- a/libstdc++-v3/include/bits/basic_string.tcc	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/bits/basic_string.tcc	2021-04-09 13:06:24.087003600 +0800
+@@ -1465,7 +1465,7 @@
    // 21.3.7.9 basic_string::getline and operators
    template<typename _CharT, typename _Traits, typename _Alloc>
      basic_istream<_CharT, _Traits>&
@@ -101,7 +101,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/basic_string.tcc gcc-10.1.0
  	       basic_string<_CharT, _Traits, _Alloc>& __str)
      {
        typedef basic_istream<_CharT, _Traits>		__istream_type;
-@@ -1486,7 +1486,7 @@
+@@ -1478,7 +1478,7 @@
  
        __size_type __extracted = 0;
        typename __ios_base::iostate __err = __ios_base::goodbit;
@@ -110,7 +110,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/basic_string.tcc gcc-10.1.0
        if (__cerb)
  	{
  	  __try
-@@ -1495,12 +1495,12 @@
+@@ -1487,12 +1487,12 @@
  	      __str.erase();
  	      _CharT __buf[128];
  	      __size_type __len = 0;	      
@@ -126,7 +126,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/basic_string.tcc gcc-10.1.0
  
  	      while (__extracted < __n
  		     && !_Traits::eq_int_type(__c, __eof)
-@@ -1514,17 +1514,17 @@
+@@ -1506,17 +1506,17 @@
  		    }
  		  __buf[__len++] = _Traits::to_char_type(__c);
  		  ++__extracted;
@@ -147,7 +147,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/basic_string.tcc gcc-10.1.0
  	      __throw_exception_again;
  	    }
  	  __catch(...)
-@@ -1532,20 +1532,20 @@
+@@ -1524,20 +1524,20 @@
  	      // _GLIBCXX_RESOLVE_LIB_DEFECTS
  	      // 91. Description of operator>> and getline() for string<>
  	      // might cause endless loop
@@ -172,7 +172,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/basic_string.tcc gcc-10.1.0
  	    basic_string<_CharT, _Traits, _Alloc>& __str, _CharT __delim)
      {
        typedef basic_istream<_CharT, _Traits>		__istream_type;
-@@ -1557,7 +1557,7 @@
+@@ -1549,7 +1549,7 @@
        __size_type __extracted = 0;
        const __size_type __n = __str.max_size();
        typename __ios_base::iostate __err = __ios_base::goodbit;
@@ -181,7 +181,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/basic_string.tcc gcc-10.1.0
        if (__cerb)
  	{
  	  __try
-@@ -1565,7 +1565,7 @@
+@@ -1557,7 +1557,7 @@
  	      __str.erase();
  	      const __int_type __idelim = _Traits::to_int_type(__delim);
  	      const __int_type __eof = _Traits::eof();
@@ -190,7 +190,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/basic_string.tcc gcc-10.1.0
  
  	      while (__extracted < __n
  		     && !_Traits::eq_int_type(__c, __eof)
-@@ -1573,7 +1573,7 @@
+@@ -1565,7 +1565,7 @@
  		{
  		  __str += _Traits::to_char_type(__c);
  		  ++__extracted;
@@ -199,7 +199,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/basic_string.tcc gcc-10.1.0
  		}
  
  	      if (_Traits::eq_int_type(__c, __eof))
-@@ -1581,14 +1581,14 @@
+@@ -1573,14 +1573,14 @@
  	      else if (_Traits::eq_int_type(__c, __idelim))
  		{
  		  ++__extracted;		  
@@ -216,7 +216,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/basic_string.tcc gcc-10.1.0
  	      __throw_exception_again;
  	    }
  	  __catch(...)
-@@ -1596,14 +1596,14 @@
+@@ -1588,14 +1588,14 @@
  	      // _GLIBCXX_RESOLVE_LIB_DEFECTS
  	      // 91. Description of operator>> and getline() for string<>
  	      // might cause endless loop
@@ -234,9 +234,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/basic_string.tcc gcc-10.1.0
      }
  
    // Inhibit implicit instantiations for required instantiations,
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/istream.tcc gcc-10.1.0/libstdc++-v3/include/bits/istream.tcc
---- gcc-10.1.0-orig/libstdc++-v3/include/bits/istream.tcc	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/bits/istream.tcc	2020-05-08 15:27:14.962363600 +0300
+diff -adru a/libstdc++-v3/include/bits/istream.tcc b/libstdc++-v3/include/bits/istream.tcc
+--- a/libstdc++-v3/include/bits/istream.tcc	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/bits/istream.tcc	2021-04-09 13:06:24.102579900 +0800
 @@ -44,21 +44,21 @@
  
    template<typename _CharT, typename _Traits>
@@ -418,10 +418,10 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/istream.tcc gcc-10.1.0/libs
      }
  
    // Inhibit implicit instantiations for required instantiations,
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/iterator_concepts.h gcc-10.1.0/libstdc++-v3/include/bits/iterator_concepts.h
---- gcc-10.1.0-orig/libstdc++-v3/include/bits/iterator_concepts.h	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/bits/iterator_concepts.h	2020-05-08 17:14:06.085050500 +0300
-@@ -443,13 +443,13 @@
+diff -adru a/libstdc++-v3/include/bits/iterator_concepts.h b/libstdc++-v3/include/bits/iterator_concepts.h
+--- a/libstdc++-v3/include/bits/iterator_concepts.h	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/bits/iterator_concepts.h	2021-04-09 13:06:24.102579900 +0800
+@@ -486,13 +486,13 @@
        using __iter_concept = typename __iter_concept_impl<_Iter>::type;
  
    template<typename _In>
@@ -438,9 +438,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/iterator_concepts.h gcc-10.
        }
        && common_reference_with<iter_reference_t<_In>&&, iter_value_t<_In>&>
        && common_reference_with<iter_reference_t<_In>&&,
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/locale_conv.h gcc-10.1.0/libstdc++-v3/include/bits/locale_conv.h
---- gcc-10.1.0-orig/libstdc++-v3/include/bits/locale_conv.h	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/bits/locale_conv.h	2020-05-08 15:27:14.966323000 +0300
+diff -adru a/libstdc++-v3/include/bits/locale_conv.h b/libstdc++-v3/include/bits/locale_conv.h
+--- a/libstdc++-v3/include/bits/locale_conv.h	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/bits/locale_conv.h	2021-04-09 13:06:24.118223200 +0800
 @@ -315,10 +315,10 @@
        {
  	if (!_M_with_cvtstate)
@@ -487,9 +487,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/locale_conv.h gcc-10.1.0/li
        }
  
        typename _Wide_streambuf::int_type
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/locale_facets.h gcc-10.1.0/libstdc++-v3/include/bits/locale_facets.h
---- gcc-10.1.0-orig/libstdc++-v3/include/bits/locale_facets.h	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/bits/locale_facets.h	2020-05-08 15:27:14.978314200 +0300
+diff -adru a/libstdc++-v3/include/bits/locale_facets.h b/libstdc++-v3/include/bits/locale_facets.h
+--- a/libstdc++-v3/include/bits/locale_facets.h	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/bits/locale_facets.h	2021-04-09 13:06:24.133848700 +0800
 @@ -1988,7 +1988,7 @@
         *  except if the value is 1, sets @a v to true, if the value is 0, sets
         *  @a v to false, and otherwise set err to ios_base::failbit.
@@ -624,9 +624,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/locale_facets.h gcc-10.1.0/
  
      protected:
        /// Destructor.
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/ostream.tcc gcc-10.1.0/libstdc++-v3/include/bits/ostream.tcc
---- gcc-10.1.0-orig/libstdc++-v3/include/bits/ostream.tcc	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/bits/ostream.tcc	2020-05-08 15:27:14.983277300 +0300
+diff -adru a/libstdc++-v3/include/bits/ostream.tcc b/libstdc++-v3/include/bits/ostream.tcc
+--- a/libstdc++-v3/include/bits/ostream.tcc	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/bits/ostream.tcc	2021-04-09 13:06:24.133848700 +0800
 @@ -318,10 +318,10 @@
  
    template<typename _CharT, typename _Traits>
@@ -664,9 +664,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/ostream.tcc gcc-10.1.0/libs
      }
  
    // Inhibit implicit instantiations for required instantiations,
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/ostream_insert.h gcc-10.1.0/libstdc++-v3/include/bits/ostream_insert.h
---- gcc-10.1.0-orig/libstdc++-v3/include/bits/ostream_insert.h	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/bits/ostream_insert.h	2020-05-08 15:27:14.987293800 +0300
+diff -adru a/libstdc++-v3/include/bits/ostream_insert.h b/libstdc++-v3/include/bits/ostream_insert.h
+--- a/libstdc++-v3/include/bits/ostream_insert.h	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/bits/ostream_insert.h	2021-04-09 13:06:24.165094700 +0800
 @@ -41,31 +41,31 @@
  
    template<typename _CharT, typename _Traits>
@@ -764,10 +764,10 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/ostream_insert.h gcc-10.1.0
      }
  
    // Inhibit implicit instantiations for required instantiations,
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/ranges_algo.h gcc-10.1.0/libstdc++-v3/include/bits/ranges_algo.h
---- gcc-10.1.0-orig/libstdc++-v3/include/bits/ranges_algo.h	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/bits/ranges_algo.h	2020-05-08 17:28:57.317446100 +0300
-@@ -1750,7 +1750,7 @@
+diff -adru a/libstdc++-v3/include/bits/ranges_algo.h b/libstdc++-v3/include/bits/ranges_algo.h
+--- a/libstdc++-v3/include/bits/ranges_algo.h	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/bits/ranges_algo.h	2021-04-09 13:06:24.180713200 +0800
+@@ -1752,7 +1752,7 @@
  	&& indirectly_copyable<_Iter, _Out>
  	&& uniform_random_bit_generator<remove_reference_t<_Gen>>
        _Out
@@ -776,7 +776,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/ranges_algo.h gcc-10.1.0/li
  		 iter_difference_t<_Iter> __n, _Gen&& __g) const
        {
  	if constexpr (forward_iterator<_Iter>)
-@@ -1759,7 +1759,7 @@
+@@ -1761,7 +1761,7 @@
  	    // which may take linear time.
  	    auto __lasti = ranges::next(__first, __last);
  	    return std::sample(std::move(__first), std::move(__lasti),
@@ -785,7 +785,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/ranges_algo.h gcc-10.1.0/li
  	  }
  	else
  	  {
-@@ -1770,7 +1770,7 @@
+@@ -1772,7 +1772,7 @@
  	    iter_difference_t<_Iter> __sample_sz = 0;
  	    while (__first != __last && __sample_sz != __n)
  	      {
@@ -794,7 +794,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/ranges_algo.h gcc-10.1.0/li
  		++__first;
  	      }
  	    for (auto __pop_sz = __sample_sz; __first != __last;
-@@ -1778,9 +1778,9 @@
+@@ -1780,9 +1780,9 @@
  	      {
  		const auto __k = __d(__g, __param_type{0, __pop_sz});
  		if (__k < __n)
@@ -806,7 +806,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/ranges_algo.h gcc-10.1.0/li
  	  }
        }
  
-@@ -1789,11 +1789,11 @@
+@@ -1791,11 +1791,11 @@
  	&& indirectly_copyable<iterator_t<_Range>, _Out>
  	&& uniform_random_bit_generator<remove_reference_t<_Gen>>
        _Out
@@ -820,7 +820,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/ranges_algo.h gcc-10.1.0/li
  		       std::forward<_Gen>(__g));
        }
    };
-@@ -2170,11 +2170,11 @@
+@@ -2172,11 +2172,11 @@
  				      projected<iterator_t<_Range2>, _Proj2>>
        constexpr partial_sort_copy_result<borrowed_iterator_t<_Range1>,
  					 borrowed_iterator_t<_Range2>>
@@ -834,10 +834,10 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/ranges_algo.h gcc-10.1.0/li
  		       std::move(__comp),
  		       std::move(__proj1), std::move(__proj2));
        }
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/ranges_algobase.h gcc-10.1.0/libstdc++-v3/include/bits/ranges_algobase.h
---- gcc-10.1.0-orig/libstdc++-v3/include/bits/ranges_algobase.h	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/bits/ranges_algobase.h	2020-05-08 17:16:30.310826200 +0300
-@@ -220,34 +220,34 @@
+diff -adru a/libstdc++-v3/include/bits/ranges_algobase.h b/libstdc++-v3/include/bits/ranges_algobase.h
+--- a/libstdc++-v3/include/bits/ranges_algobase.h	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/bits/ranges_algobase.h	2021-04-09 13:06:24.211960800 +0800
+@@ -219,34 +219,34 @@
        using __detail::__is_normal_iterator;
        if constexpr (__is_move_iterator<_Iter> && same_as<_Iter, _Sent>)
  	{
@@ -881,7 +881,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/ranges_algobase.h gcc-10.1.
  	}
        else if constexpr (sized_sentinel_for<_Sent, _Iter>)
  	{
-@@ -363,28 +363,28 @@
+@@ -362,28 +362,28 @@
        if constexpr (__is_reverse_iterator<_Iter> && same_as<_Iter, _Sent>
  		    && __is_reverse_iterator<_Out>)
  	{
@@ -917,9 +917,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/ranges_algobase.h gcc-10.1.
  	}
        else if constexpr (sized_sentinel_for<_Sent, _Iter>)
  	{
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/ranges_uninitialized.h gcc-10.1.0/libstdc++-v3/include/bits/ranges_uninitialized.h
---- gcc-10.1.0-orig/libstdc++-v3/include/bits/ranges_uninitialized.h	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/bits/ranges_uninitialized.h	2020-05-08 17:17:52.556144400 +0300
+diff -adru a/libstdc++-v3/include/bits/ranges_uninitialized.h b/libstdc++-v3/include/bits/ranges_uninitialized.h
+--- a/libstdc++-v3/include/bits/ranges_uninitialized.h	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/bits/ranges_uninitialized.h	2021-04-09 13:06:24.227577300 +0800
 @@ -361,10 +361,10 @@
  	  {
  	    auto __d1 = __ilast - __ifirst;
@@ -946,9 +946,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/ranges_uninitialized.h gcc-
  	  }
  	else
  	  {
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/regex.h gcc-10.1.0/libstdc++-v3/include/bits/regex.h
---- gcc-10.1.0-orig/libstdc++-v3/include/bits/regex.h	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/bits/regex.h	2020-05-08 15:27:14.996242100 +0300
+diff -adru a/libstdc++-v3/include/bits/regex.h b/libstdc++-v3/include/bits/regex.h
+--- a/libstdc++-v3/include/bits/regex.h	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/bits/regex.h	2021-04-09 13:06:24.258821000 +0800
 @@ -1946,7 +1946,7 @@
         */
        template<typename _Out_iter>
@@ -1025,9 +1025,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/regex.h gcc-10.1.0/libstdc+
  		  const basic_regex<_Ch_type, _Rx_traits>& __e,
  		  const _Ch_type* __fmt,
  		  regex_constants::match_flag_type __flags
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/regex.tcc gcc-10.1.0/libstdc++-v3/include/bits/regex.tcc
---- gcc-10.1.0-orig/libstdc++-v3/include/bits/regex.tcc	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/bits/regex.tcc	2020-05-08 16:11:37.031430400 +0300
+diff -adru a/libstdc++-v3/include/bits/regex.tcc b/libstdc++-v3/include/bits/regex.tcc
+--- a/libstdc++-v3/include/bits/regex.tcc	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/bits/regex.tcc	2021-04-09 13:06:24.274441600 +0800
 @@ -352,7 +352,7 @@
    template<typename _Out_iter>
      _Out_iter
@@ -1159,10 +1159,10 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/regex.tcc gcc-10.1.0/libstd
      }
  
    template<typename _Bi_iter,
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/stl_algo.h gcc-10.1.0/libstdc++-v3/include/bits/stl_algo.h
---- gcc-10.1.0-orig/libstdc++-v3/include/bits/stl_algo.h	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/bits/stl_algo.h	2020-05-08 15:27:15.013196800 +0300
-@@ -5758,7 +5758,7 @@
+diff -adru a/libstdc++-v3/include/bits/stl_algo.h b/libstdc++-v3/include/bits/stl_algo.h
+--- a/libstdc++-v3/include/bits/stl_algo.h	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/bits/stl_algo.h	2021-04-09 13:06:24.290065600 +0800
+@@ -5765,7 +5765,7 @@
             typename _Size, typename _UniformRandomBitGenerator>
      _RandomAccessIterator
      __sample(_InputIterator __first, _InputIterator __last, input_iterator_tag,
@@ -1171,7 +1171,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/stl_algo.h gcc-10.1.0/libst
  	     _Size __n, _UniformRandomBitGenerator&& __g)
      {
        using __distrib_type = uniform_int_distribution<_Size>;
-@@ -5767,7 +5767,7 @@
+@@ -5774,7 +5774,7 @@
        _Size __sample_sz = 0;
        while (__first != __last && __sample_sz != __n)
  	{
@@ -1180,7 +1180,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/stl_algo.h gcc-10.1.0/libst
  	  ++__first;
  	}
        for (auto __pop_sz = __sample_sz; __first != __last;
-@@ -5775,9 +5775,9 @@
+@@ -5782,9 +5782,9 @@
  	{
  	  const auto __k = __d(__g, __param_type{0, __pop_sz});
  	  if (__k < __n)
@@ -1192,7 +1192,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/stl_algo.h gcc-10.1.0/libst
      }
  
    /// Selection sampling algorithm.
-@@ -5786,7 +5786,7 @@
+@@ -5793,7 +5793,7 @@
      _OutputIterator
      __sample(_ForwardIterator __first, _ForwardIterator __last,
  	     forward_iterator_tag,
@@ -1201,7 +1201,16 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/stl_algo.h gcc-10.1.0/libst
  	     _Size __n, _UniformRandomBitGenerator&& __g)
      {
        using __distrib_type = uniform_int_distribution<_Size>;
-@@ -5815,7 +5815,7 @@
+@@ -5803,7 +5803,7 @@
+       using __uc_type = common_type_t<typename _Gen::result_type, _USize>;
+ 
+       if (__first == __last)
+-	return __out;
++	return ___out;
+ 
+       __distrib_type __d{};
+       _Size __unsampled_sz = std::distance(__first, __last);
+@@ -5825,7 +5825,7 @@
  	      --__unsampled_sz;
  	      if (__p.first < __n)
  		{
@@ -1210,7 +1219,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/stl_algo.h gcc-10.1.0/libst
  		  --__n;
  		}
  
-@@ -5826,7 +5826,7 @@
+@@ -5836,7 +5836,7 @@
  	      --__unsampled_sz;
  	      if (__p.second < __n)
  		{
@@ -1219,7 +1228,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/stl_algo.h gcc-10.1.0/libst
  		  --__n;
  		}
  
-@@ -5839,10 +5839,10 @@
+@@ -5849,10 +5849,10 @@
        for (; __n != 0; ++__first)
  	if (__d(__g, __param_type{0, --__unsampled_sz}) < __n)
  	  {
@@ -1232,7 +1241,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/stl_algo.h gcc-10.1.0/libst
      }
  
  #if __cplusplus > 201402L
-@@ -5852,7 +5852,7 @@
+@@ -5862,7 +5862,7 @@
             typename _Distance, typename _UniformRandomBitGenerator>
      _SampleIterator
      sample(_PopulationIterator __first, _PopulationIterator __last,
@@ -1241,7 +1250,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/stl_algo.h gcc-10.1.0/libst
  	   _UniformRandomBitGenerator&& __g)
      {
        using __pop_cat = typename
-@@ -5871,7 +5871,7 @@
+@@ -5881,7 +5881,7 @@
  
        typename iterator_traits<_PopulationIterator>::difference_type __d = __n;
        return _GLIBCXX_STD_A::
@@ -1250,9 +1259,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/bits/stl_algo.h gcc-10.1.0/libst
  		 std::forward<_UniformRandomBitGenerator>(__g));
      }
  #endif // C++17
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/experimental/algorithm gcc-10.1.0/libstdc++-v3/include/experimental/algorithm
---- gcc-10.1.0-orig/libstdc++-v3/include/experimental/algorithm	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/experimental/algorithm	2020-05-08 16:12:28.617088800 +0300
+diff -adru a/libstdc++-v3/include/experimental/algorithm b/libstdc++-v3/include/experimental/algorithm
+--- a/libstdc++-v3/include/experimental/algorithm	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/experimental/algorithm	2021-04-09 13:06:24.321284500 +0800
 @@ -59,7 +59,7 @@
             typename _Distance, typename _UniformRandomNumberGenerator>
      _SampleIterator
@@ -1283,10 +1292,10 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/experimental/algorithm gcc-10.1.
  				  _S_randint_engine());
      }
  
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/experimental/internet gcc-10.1.0/libstdc++-v3/include/experimental/internet
---- gcc-10.1.0-orig/libstdc++-v3/include/experimental/internet	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/experimental/internet	2020-05-08 17:30:25.005879100 +0300
-@@ -740,9 +740,9 @@
+diff -adru a/libstdc++-v3/include/experimental/internet b/libstdc++-v3/include/experimental/internet
+--- a/libstdc++-v3/include/experimental/internet	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/experimental/internet	2021-04-09 13:06:24.321284500 +0800
+@@ -751,9 +751,9 @@
      if (__p == nullptr)
        return __make_address_v6(__str, nullptr, __ec);
      char __buf[64];
@@ -1298,7 +1307,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/experimental/internet gcc-10.1.0
        {
  	if (!__skip_leading_zero || *__str != '0')
  	  {
-@@ -750,15 +750,15 @@
+@@ -761,18 +761,18 @@
  	      __skip_leading_zero = true;
  	    else
  	      __skip_leading_zero = false;
@@ -1309,7 +1318,10 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/experimental/internet gcc-10.1.0
        }
 -    if (__out == std::end(__buf))
 +    if (___out == std::end(__buf))
-       __ec = std::make_error_code(std::errc::invalid_argument);
+       {
+ 	__ec = std::make_error_code(std::errc::invalid_argument);
+ 	return {};
+       }
      else
        {
 -	*__out = '\0';
@@ -1317,7 +1329,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/experimental/internet gcc-10.1.0
  	return __make_address_v6(__buf, __p + 1, __ec);
        }
    }
-@@ -774,10 +774,10 @@
+@@ -788,10 +788,10 @@
      if (__pos == string::npos)
        return __make_address_v6(__str.c_str(), nullptr, __ec);
      char __buf[64];
@@ -1330,7 +1342,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/experimental/internet gcc-10.1.0
        {
  	if (!__skip_leading_zero || __str[__n] != '0')
  	  {
-@@ -785,15 +785,15 @@
+@@ -799,18 +799,18 @@
  	      __skip_leading_zero = true;
  	    else
  	      __skip_leading_zero = false;
@@ -1341,7 +1353,10 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/experimental/internet gcc-10.1.0
        }
 -    if (__out == std::end(__buf))
 +    if (___out == std::end(__buf))
-       __ec = std::make_error_code(std::errc::invalid_argument);
+       {
+ 	__ec = std::make_error_code(std::errc::invalid_argument);
+ 	return {};
+       }
      else
        {
 -	*__out = '\0';
@@ -1349,7 +1364,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/experimental/internet gcc-10.1.0
  	return __make_address_v6(__buf, __str.c_str() + __pos + 1, __ec);
        }
    }
-@@ -806,20 +806,20 @@
+@@ -823,20 +823,20 @@
    make_address_v6(string_view __str, error_code& __ec) noexcept
    {
      char __buf[64];
@@ -1375,7 +1390,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/experimental/internet gcc-10.1.0
  		__skip_leading_zero = true;
  	      }
  	  }
-@@ -829,16 +829,16 @@
+@@ -846,19 +846,19 @@
  	      __skip_leading_zero = true;
  	    else
  	      __skip_leading_zero = false;
@@ -1388,7 +1403,10 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/experimental/internet gcc-10.1.0
        }
 -    if (__out == std::end(__buf))
 +    if (___out == std::end(__buf))
-       __ec = std::make_error_code(std::errc::invalid_argument);
+       {
+ 	__ec = std::make_error_code(std::errc::invalid_argument);
+ 	return {};
+       }
      else
        {
 -	*__out = '\0';
@@ -1396,9 +1414,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/experimental/internet gcc-10.1.0
  	return __make_address_v6(__buf, __scope, __ec);
        }
    }
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/ext/algorithm gcc-10.1.0/libstdc++-v3/include/ext/algorithm
---- gcc-10.1.0-orig/libstdc++-v3/include/ext/algorithm	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/ext/algorithm	2020-05-08 15:27:15.031175400 +0300
+diff -adru a/libstdc++-v3/include/ext/algorithm b/libstdc++-v3/include/ext/algorithm
+--- a/libstdc++-v3/include/ext/algorithm	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/ext/algorithm	2021-04-09 13:06:24.336926700 +0800
 @@ -258,7 +258,7 @@
  	   typename _Distance>
      _OutputIterator
@@ -1509,9 +1527,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/ext/algorithm gcc-10.1.0/libstdc
      }
  
    /**
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/ext/pb_ds/detail/debug_map_base.hpp gcc-10.1.0/libstdc++-v3/include/ext/pb_ds/detail/debug_map_base.hpp
---- gcc-10.1.0-orig/libstdc++-v3/include/ext/pb_ds/detail/debug_map_base.hpp	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/ext/pb_ds/detail/debug_map_base.hpp	2020-05-08 15:27:15.041151800 +0300
+diff -adru a/libstdc++-v3/include/ext/pb_ds/detail/debug_map_base.hpp b/libstdc++-v3/include/ext/pb_ds/detail/debug_map_base.hpp
+--- a/libstdc++-v3/include/ext/pb_ds/detail/debug_map_base.hpp	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/ext/pb_ds/detail/debug_map_base.hpp	2021-04-09 13:06:24.352521200 +0800
 @@ -57,9 +57,9 @@
      // Need std::pair ostream extractor.
      template<typename _CharT, typename _Traits, typename _Tp1, typename _Tp2>
@@ -1524,9 +1542,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/ext/pb_ds/detail/debug_map_base.
  
  #define PB_DS_CLASS_T_DEC \
      template<typename Key, typename Eq_Fn, typename Const_Key_Reference>
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/ext/random.tcc gcc-10.1.0/libstdc++-v3/include/ext/random.tcc
---- gcc-10.1.0-orig/libstdc++-v3/include/ext/random.tcc	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/ext/random.tcc	2020-05-08 15:27:15.056090400 +0300
+diff -adru a/libstdc++-v3/include/ext/random.tcc b/libstdc++-v3/include/ext/random.tcc
+--- a/libstdc++-v3/include/ext/random.tcc	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/ext/random.tcc	2021-04-09 13:06:24.368141600 +0800
 @@ -208,38 +208,38 @@
    namespace {
  
@@ -1584,9 +1602,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/ext/random.tcc gcc-10.1.0/libstd
        }
  
  
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/ext/vstring.tcc gcc-10.1.0/libstdc++-v3/include/ext/vstring.tcc
---- gcc-10.1.0-orig/libstdc++-v3/include/ext/vstring.tcc	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/ext/vstring.tcc	2020-05-08 15:27:15.065086300 +0300
+diff -adru a/libstdc++-v3/include/ext/vstring.tcc b/libstdc++-v3/include/ext/vstring.tcc
+--- a/libstdc++-v3/include/ext/vstring.tcc	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/ext/vstring.tcc	2021-04-09 13:06:24.399411900 +0800
 @@ -549,7 +549,7 @@
    template<typename _CharT, typename _Traits, typename _Alloc,
             template <typename, typename, typename> class _Base>
@@ -1730,9 +1748,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/ext/vstring.tcc gcc-10.1.0/libst
      }      
  
  _GLIBCXX_END_NAMESPACE_VERSION
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/parallel/algo.h gcc-10.1.0/libstdc++-v3/include/parallel/algo.h
---- gcc-10.1.0-orig/libstdc++-v3/include/parallel/algo.h	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/parallel/algo.h	2020-05-08 16:14:08.758653700 +0300
+diff -adru a/libstdc++-v3/include/parallel/algo.h b/libstdc++-v3/include/parallel/algo.h
+--- a/libstdc++-v3/include/parallel/algo.h	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/parallel/algo.h	2021-04-09 13:06:24.399411900 +0800
 @@ -289,67 +289,67 @@
    // Sequential fallback
    template<typename _IIter, typename _OutputIterator>
@@ -2069,9 +2087,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/parallel/algo.h gcc-10.1.0/libst
      }
  
    // Sequential fallback
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/parallel/multiway_merge.h gcc-10.1.0/libstdc++-v3/include/parallel/multiway_merge.h
---- gcc-10.1.0-orig/libstdc++-v3/include/parallel/multiway_merge.h	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/parallel/multiway_merge.h	2020-05-08 15:27:15.079047100 +0300
+diff -adru a/libstdc++-v3/include/parallel/multiway_merge.h b/libstdc++-v3/include/parallel/multiway_merge.h
+--- a/libstdc++-v3/include/parallel/multiway_merge.h	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/parallel/multiway_merge.h	2021-04-09 13:06:24.415033600 +0800
 @@ -1372,7 +1372,7 @@
     *     for (int __j = 0; __i < 10; ++__j)
     *       sequences[__i][__j] = __j;
@@ -2090,9 +2108,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/parallel/multiway_merge.h gcc-10
     *   std::vector<std::pair<int*> > seqs;
     *   for (int __i = 0; __i < 10; ++__i)
     *     { seqs.push(std::make_pair<int*>(sequences[__i],
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/parallel/set_operations.h gcc-10.1.0/libstdc++-v3/include/parallel/set_operations.h
---- gcc-10.1.0-orig/libstdc++-v3/include/parallel/set_operations.h	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/parallel/set_operations.h	2020-05-08 15:27:15.083009600 +0300
+diff -adru a/libstdc++-v3/include/parallel/set_operations.h b/libstdc++-v3/include/parallel/set_operations.h
+--- a/libstdc++-v3/include/parallel/set_operations.h	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/parallel/set_operations.h	2021-04-09 13:06:24.415033600 +0800
 @@ -130,12 +130,12 @@
        }
  
@@ -2161,9 +2179,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/parallel/set_operations.h gcc-10
      };
  
    template<typename _IIter,
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/parallel/unique_copy.h gcc-10.1.0/libstdc++-v3/include/parallel/unique_copy.h
---- gcc-10.1.0-orig/libstdc++-v3/include/parallel/unique_copy.h	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/parallel/unique_copy.h	2020-05-08 15:27:15.087025400 +0300
+diff -adru a/libstdc++-v3/include/parallel/unique_copy.h b/libstdc++-v3/include/parallel/unique_copy.h
+--- a/libstdc++-v3/include/parallel/unique_copy.h	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/parallel/unique_copy.h	2021-04-09 13:06:24.415033600 +0800
 @@ -85,7 +85,7 @@
  	// Check for length without duplicates
  	// Needed for position in output
@@ -2191,9 +2209,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/parallel/unique_copy.h gcc-10.1.
                    }
                }
            }
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/pstl/parallel_backend_serial.h gcc-10.1.0/libstdc++-v3/include/pstl/parallel_backend_serial.h
---- gcc-10.1.0-orig/libstdc++-v3/include/pstl/parallel_backend_serial.h	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/pstl/parallel_backend_serial.h	2020-05-08 17:31:03.377433600 +0300
+diff -adru a/libstdc++-v3/include/pstl/parallel_backend_serial.h b/libstdc++-v3/include/pstl/parallel_backend_serial.h
+--- a/libstdc++-v3/include/pstl/parallel_backend_serial.h	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/pstl/parallel_backend_serial.h	2021-04-09 13:06:24.430626900 +0800
 @@ -110,10 +110,10 @@
            typename _RandomAccessIterator3, typename _Compare, typename _LeafMerge>
  void
@@ -2207,9 +2225,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/pstl/parallel_backend_serial.h g
  }
  
  template <class _ExecutionPolicy, typename _F1, typename _F2>
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/istream gcc-10.1.0/libstdc++-v3/include/std/istream
---- gcc-10.1.0-orig/libstdc++-v3/include/std/istream	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/std/istream	2020-05-08 15:27:15.096048100 +0300
+diff -adru a/libstdc++-v3/include/std/istream b/libstdc++-v3/include/std/istream
+--- a/libstdc++-v3/include/std/istream	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/std/istream	2021-04-09 13:06:24.430626900 +0800
 @@ -738,7 +738,7 @@
    //@{
    /**
@@ -2281,9 +2299,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/istream gcc-10.1.0/libstdc++
    //@}
  
    /**
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/ostream gcc-10.1.0/libstdc++-v3/include/std/ostream
---- gcc-10.1.0-orig/libstdc++-v3/include/std/ostream	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/std/ostream	2020-05-08 16:22:41.690280200 +0300
+diff -adru a/libstdc++-v3/include/std/ostream b/libstdc++-v3/include/std/ostream
+--- a/libstdc++-v3/include/std/ostream	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/std/ostream	2021-04-09 13:06:24.446256700 +0800
 @@ -488,14 +488,14 @@
    //@{
    /**
@@ -2413,9 +2431,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/ostream gcc-10.1.0/libstdc++
  
  #if __cplusplus > 201703L
     // The following deleted overloads prevent formatting strings as
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/thread gcc-10.1.0/libstdc++-v3/include/std/thread
---- gcc-10.1.0-orig/libstdc++-v3/include/std/thread	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/std/thread	2020-05-08 16:26:35.600707900 +0300
+diff -adru a/libstdc++-v3/include/std/thread b/libstdc++-v3/include/std/thread
+--- a/libstdc++-v3/include/std/thread	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/std/thread	2021-04-09 13:06:24.446256700 +0800
 @@ -112,7 +112,7 @@
  
        template<class _CharT, class _Traits>
@@ -2441,9 +2459,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/thread gcc-10.1.0/libstdc++-
      }
  
    /** @namespace std::this_thread
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/tuple gcc-10.1.0/libstdc++-v3/include/std/tuple
---- gcc-10.1.0-orig/libstdc++-v3/include/std/tuple	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/std/tuple	2020-05-08 16:34:58.013623400 +0300
+diff -adru a/libstdc++-v3/include/std/tuple b/libstdc++-v3/include/std/tuple
+--- a/libstdc++-v3/include/std/tuple	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/std/tuple	2021-04-09 13:06:24.446256700 +0800
 @@ -230,23 +230,23 @@
        _Tuple_impl& operator=(const _Tuple_impl&) = delete;
  
@@ -2499,17 +2517,17 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/tuple gcc-10.1.0/libstdc++-v
 -	        std::forward<_Head>(_M_head(__in))) { }
 +	        std::forward<_Head>(_M_head(___in))) { }
  
-       template<typename _Alloc, typename... _UElements>
+       template<typename _Alloc, typename _UHead, typename... _UTails>
  	_GLIBCXX20_CONSTEXPR
  	_Tuple_impl(allocator_arg_t __tag, const _Alloc& __a,
--	            const _Tuple_impl<_Idx, _UElements...>& __in)
-+	            const _Tuple_impl<_Idx, _UElements...>& ___in)
+-		    const _Tuple_impl<_Idx, _UHead, _UTails...>& __in)
++		    const _Tuple_impl<_Idx, _UHead, _UTails...>& ___in)
  	: _Inherited(__tag, __a,
--		     _Tuple_impl<_Idx, _UElements...>::_M_tail(__in)),
-+		     _Tuple_impl<_Idx, _UElements...>::_M_tail(___in)),
- 	  _Base(__use_alloc<_Head, _Alloc, _Head>(__a),
--		_Tuple_impl<_Idx, _UElements...>::_M_head(__in)) { }
-+		_Tuple_impl<_Idx, _UElements...>::_M_head(___in)) { }
+-		     _Tuple_impl<_Idx, _UHead, _UTails...>::_M_tail(__in)),
++		     _Tuple_impl<_Idx, _UHead, _UTails...>::_M_tail(___in)),
+ 	  _Base(__use_alloc<_Head, _Alloc, const _UHead&>(__a),
+-		_Tuple_impl<_Idx, _UHead, _UTails...>::_M_head(__in)) { }
++		_Tuple_impl<_Idx, _UHead, _UTails...>::_M_head(___in)) { }
  
        template<typename _Alloc, typename _UHead, typename... _UTails>
  	_GLIBCXX20_CONSTEXPR
@@ -2612,7 +2630,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/tuple gcc-10.1.0/libstdc++-v
  	_Tuple_impl(allocator_arg_t __tag, const _Alloc& __a,
 -	            const _Tuple_impl<_Idx, _UHead>& __in)
 +	            const _Tuple_impl<_Idx, _UHead>& ___in)
- 	: _Base(__use_alloc<_Head, _Alloc, _Head>(__a),
+ 	: _Base(__use_alloc<_Head, _Alloc, const _UHead&>(__a),
 -		_Tuple_impl<_Idx, _UHead>::_M_head(__in)) { }
 +		_Tuple_impl<_Idx, _UHead>::_M_head(___in)) { }
  
@@ -2659,7 +2677,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/tuple gcc-10.1.0/libstdc++-v
        }
      };
  
-@@ -667,9 +667,9 @@
+@@ -671,9 +671,9 @@
  			   && !__use_other_ctor<const tuple<_UElements...>&>(),
  	       _ImplicitCtor<_Valid, const _UElements&...> = true>
  	constexpr
@@ -2671,7 +2689,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/tuple gcc-10.1.0/libstdc++-v
  	{ }
  
        template<typename... _UElements,
-@@ -677,9 +677,9 @@
+@@ -681,9 +681,9 @@
  			   && !__use_other_ctor<const tuple<_UElements...>&>(),
  	       _ExplicitCtor<_Valid, const _UElements&...> = false>
  	explicit constexpr
@@ -2683,7 +2701,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/tuple gcc-10.1.0/libstdc++-v
  	{ }
  
        template<typename... _UElements,
-@@ -687,18 +687,18 @@
+@@ -691,18 +691,18 @@
  			     && !__use_other_ctor<tuple<_UElements...>&&>(),
  	       _ImplicitCtor<_Valid, _UElements...> = true>
  	constexpr
@@ -2706,7 +2724,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/tuple gcc-10.1.0/libstdc++-v
  
        // Allocator-extended constructors.
  
-@@ -744,13 +744,13 @@
+@@ -748,13 +748,13 @@
  
        template<typename _Alloc>
  	_GLIBCXX20_CONSTEXPR
@@ -2724,7 +2742,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/tuple gcc-10.1.0/libstdc++-v
  
        template<typename _Alloc, typename... _UElements,
  	       bool _Valid = (sizeof...(_Elements) == sizeof...(_UElements))
-@@ -758,9 +758,9 @@
+@@ -762,9 +762,9 @@
  	       _ImplicitCtor<_Valid, const _UElements&...> = true>
  	_GLIBCXX20_CONSTEXPR
  	tuple(allocator_arg_t __tag, const _Alloc& __a,
@@ -2736,7 +2754,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/tuple gcc-10.1.0/libstdc++-v
  	{ }
  
        template<typename _Alloc, typename... _UElements,
-@@ -770,9 +770,9 @@
+@@ -774,9 +774,9 @@
  	_GLIBCXX20_CONSTEXPR
  	explicit
  	tuple(allocator_arg_t __tag, const _Alloc& __a,
@@ -2748,7 +2766,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/tuple gcc-10.1.0/libstdc++-v
  	{ }
  
        template<typename _Alloc, typename... _UElements,
-@@ -781,9 +781,9 @@
+@@ -785,9 +785,9 @@
  	       _ImplicitCtor<_Valid, _UElements...> = true>
  	_GLIBCXX20_CONSTEXPR
  	tuple(allocator_arg_t __tag, const _Alloc& __a,
@@ -2760,7 +2778,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/tuple gcc-10.1.0/libstdc++-v
  	{ }
  
        template<typename _Alloc, typename... _UElements,
-@@ -793,9 +793,9 @@
+@@ -797,9 +797,9 @@
  	_GLIBCXX20_CONSTEXPR
  	explicit
  	tuple(allocator_arg_t __tag, const _Alloc& __a,
@@ -2772,7 +2790,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/tuple gcc-10.1.0/libstdc++-v
  	{ }
  
        // tuple assignment
-@@ -804,10 +804,10 @@
+@@ -808,10 +808,10 @@
        tuple&
        operator=(typename conditional<__assignable<const _Elements&...>(),
  				     const tuple&,
@@ -2785,7 +2803,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/tuple gcc-10.1.0/libstdc++-v
  	return *this;
        }
  
-@@ -815,39 +815,39 @@
+@@ -819,39 +819,39 @@
        tuple&
        operator=(typename conditional<__assignable<_Elements...>(),
  				     tuple&&,
@@ -2833,7 +2851,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/tuple gcc-10.1.0/libstdc++-v
      };
  
  #if __cpp_deduction_guides >= 201606
-@@ -998,60 +998,60 @@
+@@ -1002,60 +1002,60 @@
        template<typename _U1, typename _U2,
  	       _ImplicitCtor<true, const _U1&, const _U2&> = true>
  	constexpr
@@ -2912,7 +2930,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/tuple gcc-10.1.0/libstdc++-v
  
        // Allocator-extended constructors.
  
-@@ -1094,21 +1094,21 @@
+@@ -1098,21 +1098,21 @@
  
        template<typename _Alloc>
  	_GLIBCXX20_CONSTEXPR
@@ -2940,7 +2958,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/tuple gcc-10.1.0/libstdc++-v
  	{ }
  
        template<typename _Alloc, typename _U1, typename _U2,
-@@ -1116,55 +1116,55 @@
+@@ -1120,55 +1120,55 @@
  	explicit
  	_GLIBCXX20_CONSTEXPR
  	tuple(allocator_arg_t __tag, const _Alloc& __a,
@@ -3012,7 +3030,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/tuple gcc-10.1.0/libstdc++-v
  
        // Tuple assignment.
  
-@@ -1172,10 +1172,10 @@
+@@ -1176,10 +1176,10 @@
        tuple&
        operator=(typename conditional<__assignable<const _T1&, const _T2&>(),
  				     const tuple&,
@@ -3025,7 +3043,7 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/tuple gcc-10.1.0/libstdc++-v
  	return *this;
        }
  
-@@ -1183,61 +1183,61 @@
+@@ -1187,61 +1187,61 @@
        tuple&
        operator=(typename conditional<__assignable<_T1, _T2>(),
  				     tuple&&,
@@ -3101,9 +3119,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/tuple gcc-10.1.0/libstdc++-v
      };
  
  
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/utility gcc-10.1.0/libstdc++-v3/include/std/utility
---- gcc-10.1.0-orig/libstdc++-v3/include/std/utility	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/std/utility	2020-05-08 17:18:30.711365300 +0300
+diff -adru a/libstdc++-v3/include/std/utility b/libstdc++-v3/include/std/utility
+--- a/libstdc++-v3/include/std/utility	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/std/utility	2021-04-09 13:06:24.461869800 +0800
 @@ -220,23 +220,23 @@
  
    template<std::size_t _Int, class _Tp1, class _Tp2>
@@ -3136,9 +3154,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/std/utility gcc-10.1.0/libstdc++
  
  #if __cplusplus >= 201402L
  
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/tr1/regex gcc-10.1.0/libstdc++-v3/include/tr1/regex
---- gcc-10.1.0-orig/libstdc++-v3/include/tr1/regex	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/tr1/regex	2020-05-08 15:27:15.152848800 +0300
+diff -adru a/libstdc++-v3/include/tr1/regex b/libstdc++-v3/include/tr1/regex
+--- a/libstdc++-v3/include/tr1/regex	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/tr1/regex	2021-04-09 13:06:24.461869800 +0800
 @@ -2005,7 +2005,7 @@
         */
        template<typename _Out_iter>
@@ -3157,9 +3175,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/tr1/regex gcc-10.1.0/libstdc++-v
  		  const basic_regex<_Ch_type, _Rx_traits>& __e,
  		  const basic_string<_Ch_type>& __fmt,
  		  regex_constants::match_flag_type __flags
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/tr1/tuple gcc-10.1.0/libstdc++-v3/include/tr1/tuple
---- gcc-10.1.0-orig/libstdc++-v3/include/tr1/tuple	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/tr1/tuple	2020-05-08 15:27:15.170772900 +0300
+diff -adru a/libstdc++-v3/include/tr1/tuple b/libstdc++-v3/include/tr1/tuple
+--- a/libstdc++-v3/include/tr1/tuple	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/tr1/tuple	2021-04-09 13:06:24.477491100 +0800
 @@ -102,26 +102,26 @@
        : _Inherited(__tail...), _M_head(__head) { }
  
@@ -3286,9 +3304,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/tr1/tuple gcc-10.1.0/libstdc++-v
  	  return *this;
  	}
      };
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/tr1/utility gcc-10.1.0/libstdc++-v3/include/tr1/utility
---- gcc-10.1.0-orig/libstdc++-v3/include/tr1/utility	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/tr1/utility	2020-05-08 15:27:15.172801000 +0300
+diff -adru a/libstdc++-v3/include/tr1/utility b/libstdc++-v3/include/tr1/utility
+--- a/libstdc++-v3/include/tr1/utility	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/tr1/utility	2021-04-09 13:06:24.477491100 +0800
 @@ -93,13 +93,13 @@
  
    template<int _Int, class _Tp1, class _Tp2>
@@ -3307,9 +3325,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/tr1/utility gcc-10.1.0/libstdc++
  }
  
  _GLIBCXX_END_NAMESPACE_VERSION
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/tr2/bool_set gcc-10.1.0/libstdc++-v3/include/tr2/bool_set
---- gcc-10.1.0-orig/libstdc++-v3/include/tr2/bool_set	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/tr2/bool_set	2020-05-08 15:27:15.176798500 +0300
+diff -adru a/libstdc++-v3/include/tr2/bool_set b/libstdc++-v3/include/tr2/bool_set
+--- a/libstdc++-v3/include/tr2/bool_set	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/tr2/bool_set	2021-04-09 13:06:24.493112800 +0800
 @@ -131,18 +131,18 @@
  
      template<typename CharT, typename Traits>
@@ -3333,9 +3351,9 @@ diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/tr2/bool_set gcc-10.1.0/libstdc+
  	if (__c >= _S_false && __c < _S_empty)
  	  __b._M_b = static_cast<_Bool_set_val>(__c);
        }
-diff -Naur gcc-10.1.0-orig/libstdc++-v3/include/tr2/bool_set.tcc gcc-10.1.0/libstdc++-v3/include/tr2/bool_set.tcc
---- gcc-10.1.0-orig/libstdc++-v3/include/tr2/bool_set.tcc	2020-05-07 13:50:02.000000000 +0300
-+++ gcc-10.1.0/libstdc++-v3/include/tr2/bool_set.tcc	2020-05-08 15:27:15.180745900 +0300
+diff -adru a/libstdc++-v3/include/tr2/bool_set.tcc b/libstdc++-v3/include/tr2/bool_set.tcc
+--- a/libstdc++-v3/include/tr2/bool_set.tcc	2021-04-08 19:56:30.000000000 +0800
++++ b/libstdc++-v3/include/tr2/bool_set.tcc	2021-04-09 13:06:24.493112800 +0800
 @@ -100,9 +100,9 @@
         *  @param  v  Value to format and insert.
         *  @return  Iterator after reading.

--- a/mingw-w64-gcc/0171-Revert-libstdc-Make-coroutine_handle-_Promise-from_a.patch
+++ b/mingw-w64-gcc/0171-Revert-libstdc-Make-coroutine_handle-_Promise-from_a.patch
@@ -1,0 +1,27 @@
+From 00bfaee64181c100b5f29b89b94c7180b5af363f Mon Sep 17 00:00:00 2001
+From: Richard Copley <buster@buster.me.uk>
+Date: Sun, 11 Apr 2021 14:40:17 +0100
+Subject: [PATCH 1/4] Revert "libstdc++: Make
+ coroutine_handle<_Promise>::from_address() noexcept [PR 99021]"
+
+This reverts commit fa183497cf25b604f5b76bc16766f30f5ec7e05b.
+---
+ libstdc++-v3/include/std/coroutine | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libstdc++-v3/include/std/coroutine b/libstdc++-v3/include/std/coroutine
+index 21bdd1b2f04..468d1107557 100644
+--- a/libstdc++-v3/include/std/coroutine
++++ b/libstdc++-v3/include/std/coroutine
+@@ -197,7 +197,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+       }
+ 
+     // 17.12.3.2, export/import
+-    constexpr static coroutine_handle from_address(void* __a) noexcept
++    constexpr static coroutine_handle from_address(void* __a)
+     {
+       coroutine_handle __self;
+       __self._M_fr_ptr = __a;
+-- 
+2.31.0.windows.1
+

--- a/mingw-w64-gcc/0172-libstdc-Remove-inheritance-from-std-coroutine_handle.patch
+++ b/mingw-w64-gcc/0172-libstdc-Remove-inheritance-from-std-coroutine_handle.patch
@@ -1,0 +1,341 @@
+From 72874b2ddd227279930d1521946bbeee5d46fa46 Mon Sep 17 00:00:00 2001
+From: Jonathan Wakely <jwakely@redhat.com>
+Date: Tue, 20 Oct 2020 11:18:35 +0100
+Subject: [PATCH 2/4] libstdc++: Remove inheritance from
+ std::coroutine_handle<> [LWG 3460]
+
+This removes the coroutine_handle<> base class from the primary template
+and the noop_coroutine_promise explicit specialization. To preserve the
+API various members are added, as they are no longer inherited from the
+base class.
+
+I've also tweaked some indentation and formatting, and replaced
+subclause numbers from the standard with stable names like
+[coroutine.handle.con].
+
+libstdc++-v3/ChangeLog:
+
+	* include/std/coroutine (coroutine_handle<_Promise>): Remove
+	base class. Add constructors, conversions, accessors etc. as
+	proposed for LWG 3460.
+	(coroutine_handle<noop_coroutine_promise>): Likewise.
+	* testsuite/18_support/coroutines/lwg3460.cc: New test.
+---
+ libstdc++-v3/include/std/coroutine            | 145 +++++++++++-------
+ .../18_support/coroutines/lwg3460.cc          |  54 +++++++
+ 2 files changed, 144 insertions(+), 55 deletions(-)
+ create mode 100644 libstdc++-v3/testsuite/18_support/coroutines/lwg3460.cc
+
+diff --git a/libstdc++-v3/include/std/coroutine b/libstdc++-v3/include/std/coroutine
+index 468d1107557..6e1cf141579 100644
+--- a/libstdc++-v3/include/std/coroutine
++++ b/libstdc++-v3/include/std/coroutine
+@@ -87,7 +87,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+     coroutine_handle<void>
+     {
+     public:
+-      // 17.12.3.1, construct/reset
++      // [coroutine.handle.con], construct/reset
+       constexpr coroutine_handle() noexcept : _M_fr_ptr(0) {}
+ 
+       constexpr coroutine_handle(std::nullptr_t __h) noexcept
+@@ -101,7 +101,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+       }
+ 
+     public:
+-      // 17.12.3.2, export/import
++      // [coroutine.handle.export.import], export/import
+       constexpr void* address() const noexcept { return _M_fr_ptr; }
+ 
+       constexpr static coroutine_handle from_address(void* __a) noexcept
+@@ -112,7 +112,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+       }
+ 
+     public:
+-      // 17.12.3.3, observers
++      // [coroutine.handle.observers], observers
+       constexpr explicit operator bool() const noexcept
+       {
+ 	return bool(_M_fr_ptr);
+@@ -120,7 +120,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+ 
+       bool done() const noexcept { return __builtin_coro_done(_M_fr_ptr); }
+ 
+-      // 17.12.3.4, resumption
++      // [coroutine.handle.resumption], resumption
+       void operator()() const { resume(); }
+ 
+       void resume() const { __builtin_coro_resume(_M_fr_ptr); }
+@@ -131,10 +131,10 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+       void* _M_fr_ptr;
+   };
+ 
+-  // 17.12.3.6 Comparison operators
+-  /// [coroutine.handle.compare]
+-  constexpr bool operator==(coroutine_handle<> __a,
+-			    coroutine_handle<> __b) noexcept
++  // [coroutine.handle.compare], comparison operators
++
++  constexpr bool
++  operator==(coroutine_handle<> __a, coroutine_handle<> __b) noexcept
+   {
+     return __a.address() == __b.address();
+   }
+@@ -142,76 +142,107 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+ #if _COROUTINES_USE_SPACESHIP
+   constexpr strong_ordering
+   operator<=>(coroutine_handle<> __a, coroutine_handle<> __b) noexcept
+-  { return std::compare_three_way()(__a.address(), __b.address()); }
++  {
++    return std::compare_three_way()(__a.address(), __b.address());
++  }
+ #else
+   // These are to enable operation with std=c++14,17.
+-  constexpr bool operator!=(coroutine_handle<> __a,
+-			    coroutine_handle<> __b) noexcept
++  constexpr bool
++  operator!=(coroutine_handle<> __a, coroutine_handle<> __b) noexcept
+   {
+     return !(__a == __b);
+   }
+ 
+-  constexpr bool operator<(coroutine_handle<> __a,
+-			   coroutine_handle<> __b) noexcept
++  constexpr bool
++  operator<(coroutine_handle<> __a, coroutine_handle<> __b) noexcept
+   {
+     return less<void*>()(__a.address(), __b.address());
+   }
+ 
+-  constexpr bool operator>(coroutine_handle<> __a,
+-			   coroutine_handle<> __b) noexcept
++  constexpr bool
++  operator>(coroutine_handle<> __a, coroutine_handle<> __b) noexcept
+   {
+     return __b < __a;
+   }
+ 
+-  constexpr bool operator<=(coroutine_handle<> __a,
+-			    coroutine_handle<> __b) noexcept
++  constexpr bool
++  operator<=(coroutine_handle<> __a, coroutine_handle<> __b) noexcept
+   {
+     return !(__a > __b);
+   }
+ 
+-  constexpr bool operator>=(coroutine_handle<> __a,
+-			    coroutine_handle<> __b) noexcept
++  constexpr bool
++  operator>=(coroutine_handle<> __a, coroutine_handle<> __b) noexcept
+   {
+     return !(__a < __b);
+   }
+ #endif
+ 
+   template <typename _Promise>
+-    struct coroutine_handle : coroutine_handle<>
++    struct coroutine_handle
+     {
+-      // 17.12.3.1, construct/reset
+-      using coroutine_handle<>::coroutine_handle;
++      // [coroutine.handle.con], construct/reset
+ 
+-      static coroutine_handle from_promise(_Promise& p)
++      constexpr coroutine_handle() noexcept { }
++
++      constexpr coroutine_handle(nullptr_t) noexcept { }
++
++      static coroutine_handle
++      from_promise(_Promise& __p)
+       {
+ 	coroutine_handle __self;
+ 	__self._M_fr_ptr
+-	  = __builtin_coro_promise((char*) &p, __alignof(_Promise), true);
++	  = __builtin_coro_promise((char*) &__p, __alignof(_Promise), true);
+ 	return __self;
+       }
+ 
+-      coroutine_handle& operator=(std::nullptr_t) noexcept
++      coroutine_handle& operator=(nullptr_t) noexcept
+       {
+-	coroutine_handle<>::operator=(nullptr);
++	_M_fr_ptr = nullptr;
+ 	return *this;
+       }
+ 
+-    // 17.12.3.2, export/import
+-    constexpr static coroutine_handle from_address(void* __a)
+-    {
+-      coroutine_handle __self;
+-      __self._M_fr_ptr = __a;
+-      return __self;
+-    }
++      // [coroutine.handle.export.import], export/import
+ 
+-    // 17.12.3.5, promise accesss
+-    _Promise& promise() const
+-    {
+-      void* __t
+-	= __builtin_coro_promise (this->_M_fr_ptr, __alignof(_Promise), false);
+-      return *static_cast<_Promise*>(__t);
+-    }
+-  };
++      constexpr void* address() const noexcept { return _M_fr_ptr; }
++
++      constexpr static coroutine_handle from_address(void* __a)
++      {
++	coroutine_handle __self;
++	__self._M_fr_ptr = __a;
++	return __self;
++      }
++
++      // [coroutine.handle.conv], conversion
++      constexpr operator coroutine_handle<>() const noexcept
++      { return coroutine_handle<>::from_address(address()); }
++
++      // [coroutine.handle.observers], observers
++      constexpr explicit operator bool() const noexcept
++      {
++	return bool(_M_fr_ptr);
++      }
++
++      bool done() const noexcept { return __builtin_coro_done(_M_fr_ptr); }
++
++      // [coroutine.handle.resumption], resumption
++      void operator()() const { resume(); }
++
++      void resume() const { __builtin_coro_resume(_M_fr_ptr); }
++
++      void destroy() const { __builtin_coro_destroy(_M_fr_ptr); }
++
++      // [coroutine.handle.promise], promise access
++      _Promise& promise() const
++      {
++	void* __t
++	  = __builtin_coro_promise (_M_fr_ptr, __alignof(_Promise), false);
++	return *static_cast<_Promise*>(__t);
++      }
++
++    private:
++      void* _M_fr_ptr = nullptr;
++    };
+ 
+   /// [coroutine.noop]
+   struct noop_coroutine_promise
+@@ -231,35 +262,39 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+   // 17.12.4.1 Class noop_coroutine_promise
+   /// [coroutine.promise.noop]
+   template <>
+-    struct coroutine_handle<noop_coroutine_promise> : public coroutine_handle<>
++    struct coroutine_handle<noop_coroutine_promise>
+     {
+-      using _Promise = noop_coroutine_promise;
++      // _GLIBCXX_RESOLVE_LIB_DEFECTS
++      // 3460. Unimplementable noop_coroutine_handle guarantees
++      // [coroutine.handle.noop.conv], conversion
++      constexpr operator coroutine_handle<>() const noexcept
++      { return coroutine_handle<>::from_address(address()); }
+ 
+-    public:
+-      // 17.12.4.2.1, observers
++      // [coroutine.handle.noop.observers], observers
+       constexpr explicit operator bool() const noexcept { return true; }
+ 
+       constexpr bool done() const noexcept { return false; }
+ 
+-      // 17.12.4.2.2, resumption
++      // [coroutine.handle.noop.resumption], resumption
+       void operator()() const noexcept {}
+ 
+       void resume() const noexcept {}
+ 
+       void destroy() const noexcept {}
+ 
+-      // 17.12.4.2.3, promise access
+-      _Promise& promise() const
+-      {
+-	return *static_cast<_Promise*>(
+-	  __builtin_coro_promise(this->_M_fr_ptr, __alignof(_Promise), false));
+-      }
++      // [coroutine.handle.noop.promise], promise access
++      noop_coroutine_promise& promise() const noexcept
++      { return __noop_coro_fr.__p; }
++
++      // [coroutine.handle.noop.address], address
++      constexpr void* address() const noexcept { return _M_fr_ptr; }
+ 
+-      // 17.12.4.2.4, address
+     private:
+-      friend coroutine_handle<noop_coroutine_promise> noop_coroutine() noexcept;
++      friend coroutine_handle noop_coroutine() noexcept;
++
++      coroutine_handle() = default;
+ 
+-      coroutine_handle() noexcept { this->_M_fr_ptr = (void*) &__noop_coro_fr; }
++      void* _M_fr_ptr = (void*) &__noop_coro_fr;
+     };
+ 
+   using noop_coroutine_handle = coroutine_handle<noop_coroutine_promise>;
+diff --git a/libstdc++-v3/testsuite/18_support/coroutines/lwg3460.cc b/libstdc++-v3/testsuite/18_support/coroutines/lwg3460.cc
+new file mode 100644
+index 00000000000..14a94ded95b
+--- /dev/null
++++ b/libstdc++-v3/testsuite/18_support/coroutines/lwg3460.cc
+@@ -0,0 +1,54 @@
++// Copyright (C) 2020 Free Software Foundation, Inc.
++//
++// This file is part of the GNU ISO C++ Library.  This library is free
++// software; you can redistribute it and/or modify it under the
++// terms of the GNU General Public License as published by the
++// Free Software Foundation; either version 3, or (at your option)
++// any later version.
++
++// This library is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++
++// You should have received a copy of the GNU General Public License along
++// with this library; see the file COPYING3.  If not see
++// <http://www.gnu.org/licenses/>.
++
++// { dg-options "-std=gnu++2a" }
++// { dg-do compile { target c++2a } }
++
++#include <coroutine>
++
++void
++test01()
++{
++  // LWG 3460. Unimplementable noop_coroutine_handle guarantees
++
++  static_assert( std::is_convertible_v<std::noop_coroutine_handle&,
++				       std::coroutine_handle<>> );
++  static_assert( ! std::is_convertible_v<std::noop_coroutine_handle&,
++					 std::coroutine_handle<>&> );
++  static_assert( ! std::is_assignable_v<std::noop_coroutine_handle&,
++					std::coroutine_handle<>> );
++
++  std::noop_coroutine_handle h = std::noop_coroutine();
++  std::coroutine_handle<> h2 = h;
++  h2();		// no-op
++  h2.resume();	// no-op
++  h2.destroy();	// no-op
++}
++
++void
++test02()
++{
++  // LWG 3469. Precondition of coroutine_handle::promise may be insufficient
++
++  struct P1 { };
++  struct P2 { };
++
++  static_assert( ! std::is_assignable_v<std::coroutine_handle<P1>&,
++					std::coroutine_handle<>> );
++  static_assert( ! std::is_assignable_v<std::coroutine_handle<P1>&,
++					std::coroutine_handle<P2>> );
++}
+-- 
+2.31.0.windows.1
+

--- a/mingw-w64-gcc/0173-libstdc-Define-noop-coroutine-details-private-and-in.patch
+++ b/mingw-w64-gcc/0173-libstdc-Define-noop-coroutine-details-private-and-in.patch
@@ -1,0 +1,129 @@
+From 94e47f87500b5b7e7fb12fe5ea39899b239ae073 Mon Sep 17 00:00:00 2001
+From: Jonathan Wakely <jwakely@redhat.com>
+Date: Tue, 20 Oct 2020 11:19:58 +0100
+Subject: [PATCH 3/4] libstdc++: Define noop coroutine details private and
+ inline [PR 95917]
+
+This moves the __noop_coro_frame type, the __noop_coro_fr global
+variable, and the __dummy_resume_destroy function from namespace scope,
+replacing them with private members of the specialization
+coroutine_handle<noop_coroutine_promise>.
+
+The function and variable are also declared inline, so that they
+generate no code unless used.
+
+libstdc++-v3/ChangeLog:
+
+	PR libstdc++/95917
+	* include/std/coroutine (__noop_coro_frame): Replace with
+	noop_coroutine_handle::__frame.
+	(__dummy_resume_destroy): Define inline in __frame.
+	(__noop_coro_fr): Replace with noop_coroutine_handle::_S_fr
+	and define as inline.
+	* testsuite/18_support/coroutines/95917.cc: New test.
+---
+ libstdc++-v3/include/std/coroutine            | 30 ++++++++++--------
+ .../testsuite/18_support/coroutines/95917.cc  | 31 +++++++++++++++++++
+ 2 files changed, 48 insertions(+), 13 deletions(-)
+ create mode 100644 libstdc++-v3/testsuite/18_support/coroutines/95917.cc
+
+diff --git a/libstdc++-v3/include/std/coroutine b/libstdc++-v3/include/std/coroutine
+index 6e1cf141579..2b635b982e0 100644
+--- a/libstdc++-v3/include/std/coroutine
++++ b/libstdc++-v3/include/std/coroutine
+@@ -249,16 +249,6 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+   {
+   };
+ 
+-  void __dummy_resume_destroy() __attribute__((__weak__));
+-  void __dummy_resume_destroy() {}
+-
+-  struct __noop_coro_frame
+-  {
+-    void (*__r)() = __dummy_resume_destroy;
+-    void (*__d)() = __dummy_resume_destroy;
+-    struct noop_coroutine_promise __p;
+-  } __noop_coro_fr __attribute__((__weak__));
+-
+   // 17.12.4.1 Class noop_coroutine_promise
+   /// [coroutine.promise.noop]
+   template <>
+@@ -284,7 +274,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+ 
+       // [coroutine.handle.noop.promise], promise access
+       noop_coroutine_promise& promise() const noexcept
+-      { return __noop_coro_fr.__p; }
++      { return _S_fr.__p; }
+ 
+       // [coroutine.handle.noop.address], address
+       constexpr void* address() const noexcept { return _M_fr_ptr; }
+@@ -292,13 +282,27 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+     private:
+       friend coroutine_handle noop_coroutine() noexcept;
+ 
+-      coroutine_handle() = default;
++      struct __frame
++      {
++	static void __dummy_resume_destroy() { }
++
++	void (*__r)() = __dummy_resume_destroy;
++	void (*__d)() = __dummy_resume_destroy;
++	struct noop_coroutine_promise __p;
++      };
++
++      static __frame _S_fr;
+ 
+-      void* _M_fr_ptr = (void*) &__noop_coro_fr;
++      explicit coroutine_handle() noexcept = default;
++
++      void* _M_fr_ptr = &_S_fr;
+     };
+ 
+   using noop_coroutine_handle = coroutine_handle<noop_coroutine_promise>;
+ 
++  inline noop_coroutine_handle::__frame
++  noop_coroutine_handle::_S_fr{};
++
+   inline noop_coroutine_handle noop_coroutine() noexcept
+   {
+     return noop_coroutine_handle();
+diff --git a/libstdc++-v3/testsuite/18_support/coroutines/95917.cc b/libstdc++-v3/testsuite/18_support/coroutines/95917.cc
+new file mode 100644
+index 00000000000..5c9cf57e001
+--- /dev/null
++++ b/libstdc++-v3/testsuite/18_support/coroutines/95917.cc
+@@ -0,0 +1,31 @@
++// Copyright (C) 2020 Free Software Foundation, Inc.
++//
++// This file is part of the GNU ISO C++ Library.  This library is free
++// software; you can redistribute it and/or modify it under the
++// terms of the GNU General Public License as published by the
++// Free Software Foundation; either version 3, or (at your option)
++// any later version.
++
++// This library is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++
++// You should have received a copy of the GNU General Public License along
++// with this library; see the file COPYING3.  If not see
++// <http://www.gnu.org/licenses/>.
++
++// { dg-options "-std=gnu++2a -g0" }
++// { dg-do compile { target c++2a } }
++// { dg-final { scan-assembler-not "dummy_resume_destroy" } }
++// { dg-final { scan-assembler-not "noop_coro" } }
++
++#include <coroutine>
++
++// PR libstdc++/95917
++
++void
++test01()
++{
++  std::coroutine_handle<> h;
++}
+-- 
+2.31.0.windows.1
+

--- a/mingw-w64-gcc/0174-libstdc-Make-coroutine_handle-_Promise-from_address-.patch
+++ b/mingw-w64-gcc/0174-libstdc-Make-coroutine_handle-_Promise-from_address-.patch
@@ -1,0 +1,34 @@
+From d48fe33782baea82af9e445fe3fc21eaa22e2f34 Mon Sep 17 00:00:00 2001
+From: Jonathan Wakely <jwakely@redhat.com>
+Date: Tue, 9 Feb 2021 11:23:29 +0000
+Subject: [PATCH 4/4] libstdc++: Make
+ coroutine_handle<_Promise>::from_address() noexcept [PR 99021]
+
+The coroutine_handle<void>::from_address(void*) version is already
+noexcept, and they do the same thing. Make them consistent.
+
+libstdc++-v3/ChangeLog:
+
+	PR libstdc++/99021
+	* include/std/coroutine (coroutine_handle<P>::from_address): Add
+	noexcept.
+---
+ libstdc++-v3/include/std/coroutine | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libstdc++-v3/include/std/coroutine b/libstdc++-v3/include/std/coroutine
+index 2b635b982e0..f0a8bdb6840 100644
+--- a/libstdc++-v3/include/std/coroutine
++++ b/libstdc++-v3/include/std/coroutine
+@@ -206,7 +206,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+ 
+       constexpr void* address() const noexcept { return _M_fr_ptr; }
+ 
+-      constexpr static coroutine_handle from_address(void* __a)
++      constexpr static coroutine_handle from_address(void* __a) noexcept
+       {
+ 	coroutine_handle __self;
+ 	__self._M_fr_ptr = __a;
+-- 
+2.31.0.windows.1
+

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -75,6 +75,10 @@ source=("https://ftp.gnu.org/gnu/gcc/${_realname}-${pkgver%%+*}/${_realname}-${p
         0140-gcc-8.2.0-diagnostic-color.patch
         0150-gcc-10.2.0-libgcc-ldflags.patch
         0160-libbacktrace-seh.patch
+        0171-Revert-libstdc-Make-coroutine_handle-_Promise-from_a.patch
+        0172-libstdc-Remove-inheritance-from-std-coroutine_handle.patch
+        0173-libstdc-Define-noop-coroutine-details-private-and-in.patch
+        0174-libstdc-Make-coroutine_handle-_Promise-from_address-.patch
         0200-ms_printf-improvements.patch)
 sha256sums=('64f404c1a650f27fc33da242e1f2df54952e3963a49e06e73f6940f3223ac344'
             'SKIP'
@@ -99,6 +103,10 @@ sha256sums=('64f404c1a650f27fc33da242e1f2df54952e3963a49e06e73f6940f3223ac344'
             '5240a9e731b45c17a164066c7eb193c1fbee9fd8d9a2a5afa2edbcde9510da47'
             '7f0b4e45d933e18c9d8bd2afcd83e4f52e97e2e25dd41bfa0cba755c70e591c7'
             '88c1d65e763e631ad49f9a077ed631f4acac9ef4732e2818ccddaefc883b1811'
+            '672a62438e8630d6ed4b88a73f65f8f8a2a64998286890400c1bdf857661792d'
+            'b1347e005ff1327ccc7848f20d86472797597587354329dee5b9c0a1ce40e24f'
+            'acdca821ba09d65fc9b54d1780f7c8a0771635c90825c957fa582a20b7c7e4e6'
+            '938a0ca21ba6d3594079eb4f343ae63071fe8f05adaf90b610741d1313a8a0e4'
             '146ac7aec004a949e42f7da6ff66351790e56094a85f6dbe28ea583b47c8125d')
 validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.org
               86CFFCA918CF3AF47147588051E8B148A9999C34  # evangelos@foutrelis.com
@@ -163,6 +171,14 @@ prepare() {
   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96948
   apply_patch_with_msg \
     0160-libbacktrace-seh.patch
+
+  # avoid linker errors when including <coroutine> more than once
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99907
+  apply_patch_with_msg \
+    0171-Revert-libstdc-Make-coroutine_handle-_Promise-from_a.patch \
+    0172-libstdc-Remove-inheritance-from-std-coroutine_handle.patch \
+    0173-libstdc-Define-noop-coroutine-details-private-and-in.patch \
+    0174-libstdc-Make-coroutine_handle-_Promise-from_address-.patch
 
   # https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=c51f1e7427e6a5ae2a6d82b5a790df77a3adc99a
   apply_patch_with_msg \

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -24,11 +24,11 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          $([[ "$_enable_jit" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-libgccjit")
         )
 #_snapshot=20181214
-pkgver=10.2.0
+pkgver=10.3.0
 #_majorver=${pkgver:0:1}
 #_sourcedir=${_realname}-${_majorver}-${_snapshot}
 _sourcedir=${_realname}-${pkgver}
-pkgrel=10
+pkgrel=1
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -67,7 +67,6 @@ source=("https://ftp.gnu.org/gnu/gcc/${_realname}-${pkgver%%+*}/${_realname}-${p
         0011-Enable-shared-gnat-implib.patch
         0012-Handle-spaces-in-path-for-default-manifest.patch
         0014-gcc-9-branch-clone_function_name_1-Retain-any-stdcall-suffix.patch
-        0015-makedeps-properly-handle-win-paths.patch
         0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
         0021-gcc-config-i386-mingw32.h-Ensure-lmsvcrt-precede-lke.patch
         0022-jit-port-libgccjit-to-Windows.patch
@@ -77,7 +76,7 @@ source=("https://ftp.gnu.org/gnu/gcc/${_realname}-${pkgver%%+*}/${_realname}-${p
         0150-gcc-10.2.0-libgcc-ldflags.patch
         0160-libbacktrace-seh.patch
         0200-ms_printf-improvements.patch)
-sha256sums=('b8dd4368bb9c7f0b98188317ee0254dd8cc99d1e3a18d0ff146c855fe16c1d8c'
+sha256sums=('64f404c1a650f27fc33da242e1f2df54952e3963a49e06e73f6940f3223ac344'
             'SKIP'
             'bce81824fc89e5e62cca350de4c17a27e27a18a1a1ad5ca3492aec1fc5af3234'
             '1247e81571c908548b4d9aaa3df1ad8fd73aad7b81e7eafea12d53bbada70e94'
@@ -92,12 +91,11 @@ sha256sums=('b8dd4368bb9c7f0b98188317ee0254dd8cc99d1e3a18d0ff146c855fe16c1d8c'
             '3402f11c3edb3a2b0f27f7159c476879e1e6cddb05ac0327968d89ea245044c7'
             '11dd5388a1e1c0a2bc8bc3824726598784b9b9e0896a3d77950ba6a4569f1128'
             '21e31addcf13bc6fa6650b02ed0f2e195a1226260ae48c536840cc9230de2cfc'
-            '4233a8d893787413b316de3ac320fd65c46844d463b98c0a98fdc17100cca505'
             '276ecc392c777d4b17d771a987e80dca50ff25d8f65671d5de139be73997064b'
             'c7359f4c7015bc1fb02bc13449fa9826669273bd1f0663ba898decb67e8487fc'
             '61554e1ace26a7638a029c87ca360de9d8efbbe258f2fe84c0635a6c446d19a9'
             '35715ec552eb262dc9d7cb8ee70215bacce47e7281ee4f45bd959fdeadac56e1'
-            '055289699c4222ef0b8125abdc8c9ceeff0712876c86e6d552a056fbacc14284'
+            '90c17d738e168a3cfd1379ea3b54ea9defd1e68aee33cd9966ee7562485f4910'
             '5240a9e731b45c17a164066c7eb193c1fbee9fd8d9a2a5afa2edbcde9510da47'
             '7f0b4e45d933e18c9d8bd2afcd83e4f52e97e2e25dd41bfa0cba755c70e591c7'
             '88c1d65e763e631ad49f9a077ed631f4acac9ef4732e2818ccddaefc883b1811'
@@ -145,7 +143,6 @@ prepare() {
     0011-Enable-shared-gnat-implib.patch \
     0012-Handle-spaces-in-path-for-default-manifest.patch \
     0014-gcc-9-branch-clone_function_name_1-Retain-any-stdcall-suffix.patch \
-    0015-makedeps-properly-handle-win-paths.patch \
     0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch \
     0021-gcc-config-i386-mingw32.h-Ensure-lmsvcrt-precede-lke.patch \
     0022-jit-port-libgccjit-to-Windows.patch \
@@ -231,6 +228,7 @@ build() {
     --with-native-system-header-dir=${MINGW_PREFIX}/${MINGW_CHOST}/include \
     --libexecdir=${MINGW_PREFIX}/lib \
     --enable-bootstrap \
+    --enable-checking=release \
     --with-arch=${_arch} \
     --with-tune=generic \
     --enable-languages=${_languages} \
@@ -243,17 +241,14 @@ build() {
     --enable-libstdcxx-time=yes \
     --disable-libstdcxx-pch \
     ${extra_config} \
-    --disable-isl-version-check \
     --enable-lto \
     --enable-libgomp \
     --disable-multilib \
-    --enable-checking=release \
     --disable-rpath \
     --disable-win32-registry \
     --disable-nls \
     --disable-werror \
     --disable-symvers \
-    --disable-plugin \
     --with-libiconv \
     --with-system-zlib \
     --with-{gmp,mpfr,mpc,isl}=${MINGW_PREFIX} \

--- a/mingw-w64-zstd/PKGBUILD
+++ b/mingw-w64-zstd/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=zstd
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.4.8
-pkgrel=2
+pkgver=1.4.9
+pkgrel=1
 pkgdesc="Zstandard - Fast real-time compression algorithm (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -14,18 +14,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cmake")
 source=("https://github.com/facebook/zstd/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz"
-        zstd-1.4.0-fileio-mingw.patch
-        0001-fix-pkgconf-escaping.patch)
-sha256sums=('32478297ca1500211008d596276f5367c54198495cf677e9439f4791a4c69f24'
-            '210e57fc4bff62e1af1ca8a3da3960de32a91255ba62b057c6bed5b3a7ebb3d5'
-            '0501c078581f6439e3de178b5a58183e7bbf738b2cef3a6e0be39eb0d82a806f')
+        zstd-1.4.0-fileio-mingw.patch)
+sha256sums=('29ac74e19ea28659017361976240c4b5c5c24db3b89338731a6feb97c038d293'
+            '210e57fc4bff62e1af1ca8a3da3960de32a91255ba62b057c6bed5b3a7ebb3d5')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   patch -Np1 -i "${srcdir}/zstd-1.4.0-fileio-mingw.patch"
-
-  # https://github.com/facebook/zstd/pull/2462
-  patch -Np1 -i "${srcdir}/0001-fix-pkgconf-escaping.patch"
 }
 
 build() {
@@ -38,7 +33,7 @@ build() {
   else
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
-  
+
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake \
       -GNinja \


### PR DESCRIPTION
Third patch prevents multiple definition errors when including header "coroutine" in more than one translation unit. Applying the other two intermediate commits to simplify patch management.