### PR TITLE
opus: add lssp to the end of libs.private

### DIFF
--- a/mingw-w64-opus/PKGBUILD
+++ b/mingw-w64-opus/PKGBUILD
@@ -4,7 +4,7 @@ _realname=opus
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.3.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Codec designed for interactive speech and audio transmission over the Internet (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -36,6 +36,8 @@ build() {
     --enable-static
 
   make
+
+  sed -i -e 's/Libs.private.*/& -lssp/' opus.pc
 }
 
 check() {


### PR DESCRIPTION
In theory Fixes https://github.com/msys2/MINGW-packages/issues/8240 as `-lssp` is at the end of `Libs.private:`