### PR TITLE
Emacs native compilation

### DIFF
--- a/mingw-w64-emacs-native-compilation/PKGBUILD
+++ b/mingw-w64-emacs-native-compilation/PKGBUILD
@@ -62,11 +62,17 @@ build() {
     --build="${MINGW_CHOST}" \
     --with-modules \
     --without-dbus \
+    --without-pop \
     --with-native-compilation \
     --without-compress-install
 
   # --without-compress-install is needed because we don't have gzip in
   # the mingw binaries.
+
+  # --without-pop is used to prevent emacs from installing a an auxiliary
+  # limited and insecure substitute 'movemail' program. This we be unnessecary
+  # when GNU mailutils become available for MINGW64 and MINGW32. Then 
+  # mailutils should be included in the depends list.
 
   make
 }

--- a/mingw-w64-emacs-native-compilation/PKGBUILD
+++ b/mingw-w64-emacs-native-compilation/PKGBUILD
@@ -19,7 +19,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-universal-ctags-git"
          "${MINGW_PACKAGE_PREFIX}-jansson"
          "${MINGW_PACKAGE_PREFIX}-gnutls"
          "${MINGW_PACKAGE_PREFIX}-libwinpthread"
-		 "${MINGW_PACKAGE_PREFIX}-libgccjit")
+         "${MINGW_PACKAGE_PREFIX}-libgccjit")
 optdepends=("${MINGW_PACKAGE_PREFIX}-giflib"
             "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
             "${MINGW_PACKAGE_PREFIX}-libpng"
@@ -37,7 +37,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "autoconf"
              "texinfo"
              "patch"
-			 "git"
+             "git"
              "${optdepends[@]}")
 provides=("${MINGW_PACKAGE_PREFIX}-emacs-native-compilation")
 conflicts=("${MINGW_PACKAGE_PREFIX}-emacs")
@@ -45,8 +45,7 @@ conflicts=("${MINGW_PACKAGE_PREFIX}-emacs")
 # decompress them. gzip is not available as a mingw binary.
 options=('!zipman')
 source=("emacs-git::git://git.savannah.gnu.org/emacs.git#commit=39bc9bc77066c0c40d2e5fd0769ce3701055a10b")
-# If Savannah access is blocked for reasons, use Github instead.
-# Edit the config file of your local repo copy as well.
+# If Savannah access is blocked for reasons, you can use Github instead.
 #source=("emacs-git::git://github.com/emacs-mirror/emacs.git#commit=39bc9bc77066c0c40d2e5fd0769ce3701055a10b")
 sha256sums=('SKIP')
 

--- a/mingw-w64-emacs-native-compilation/PKGBUILD
+++ b/mingw-w64-emacs-native-compilation/PKGBUILD
@@ -43,7 +43,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-emacs-native-compilation")
 conflicts=("${MINGW_PACKAGE_PREFIX}-emacs")
 # Don't zip info files because the built-in info reader uses gzip to
 # decompress them. gzip is not available as a mingw binary.
-options=('!zipman')
+options=('strip' '!zipman')
 source=("emacs-git::git://git.savannah.gnu.org/emacs.git#commit=39bc9bc77066c0c40d2e5fd0769ce3701055a10b")
 # If Savannah access is blocked for reasons, you can use Github instead.
 #source=("emacs-git::git://github.com/emacs-mirror/emacs.git#commit=39bc9bc77066c0c40d2e5fd0769ce3701055a10b")

--- a/mingw-w64-emacs-native-compilation/PKGBUILD
+++ b/mingw-w64-emacs-native-compilation/PKGBUILD
@@ -3,11 +3,10 @@
 # Maintainer: Oscar Fuentes <ofv@wanadoo.es>
 
 _realname=emacs
-pkgbase=mingw-w64-${_realname}
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-native-compilation"
 pkgver=28.0.50
 pkgrel=1
-pkgdesc="GNU Emacs. Development native-compilation branch."
+pkgdesc="GNU Emacs native-compilation branch (mingw-w64)"
 url="https://www.gnu.org/software/${_realname}/"
 license=('GPL3')
 arch=('any')
@@ -39,7 +38,6 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "patch"
              "git"
              "${optdepends[@]}")
-provides=("${MINGW_PACKAGE_PREFIX}-emacs-native-compilation")
 conflicts=("${MINGW_PACKAGE_PREFIX}-emacs")
 # Don't zip info files because the built-in info reader uses gzip to
 # decompress them. gzip is not available as a mingw binary.

--- a/mingw-w64-emacs-native-compilation/PKGBUILD
+++ b/mingw-w64-emacs-native-compilation/PKGBUILD
@@ -74,7 +74,7 @@ build() {
   # when GNU mailutils become available for MINGW64 and MINGW32. Then 
   # mailutils should be included in the depends list.
 
-  make
+  make --jobs=1
 }
 
 package() {

--- a/mingw-w64-emacs-native-compilation/PKGBUILD
+++ b/mingw-w64-emacs-native-compilation/PKGBUILD
@@ -1,0 +1,93 @@
+# Maintainer: Wolfgang Ramos <wolfgang@ramos.arhuis.de>
+# Maintainer: Haroogan <Haroogan@gmail.com>
+# Maintainer: Oscar Fuentes <ofv@wanadoo.es>
+
+_realname=emacs
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=28.0.50
+pkgrel=1
+pkgdesc="GNU Emacs. Development native-compilation branch."
+url="https://www.gnu.org/software/${_realname}/"
+license=('GPL3')
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64')
+depends=("${MINGW_PACKAGE_PREFIX}-universal-ctags-git"
+         "${MINGW_PACKAGE_PREFIX}-zlib"
+         "${MINGW_PACKAGE_PREFIX}-xpm-nox"
+         "${MINGW_PACKAGE_PREFIX}-harfbuzz"
+         "${MINGW_PACKAGE_PREFIX}-jansson"
+         "${MINGW_PACKAGE_PREFIX}-gnutls"
+         "${MINGW_PACKAGE_PREFIX}-libwinpthread"
+		 "${MINGW_PACKAGE_PREFIX}-libgccjit")
+optdepends=("${MINGW_PACKAGE_PREFIX}-giflib"
+            "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
+            "${MINGW_PACKAGE_PREFIX}-libpng"
+            "${MINGW_PACKAGE_PREFIX}-librsvg"
+            "${MINGW_PACKAGE_PREFIX}-libtiff"
+	    # ImageMagick is considered unsafe and unstable. See
+	    # INSTALL file on Emacs top source directory. If
+	    # ImageMagick support is restored, check if the patch in
+	    # image.c.diff is still necessary:
+            # "${MINGW_PACKAGE_PREFIX}-imagemagick"
+            "${MINGW_PACKAGE_PREFIX}-libxml2")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "make"
+             "autoconf"
+             "texinfo"
+             "patch"
+			 "git"
+             "${optdepends[@]}")
+provides=("${MINGW_PACKAGE_PREFIX}-emacs-native-compilation")
+conflicts=("${MINGW_PACKAGE_PREFIX}-emacs")
+# Don't zip info files because the built-in info reader uses gzip to
+# decompress them. gzip is not available as a mingw binary.
+options=('!zipman')
+source=("emacs-git::git://git.savannah.gnu.org/emacs.git#commit=39bc9bc77066c0c40d2e5fd0769ce3701055a10b")
+# If Savannah access is blocked for reasons, use Github instead.
+# Edit the config file of your local repo copy as well.
+#source=("emacs-git::git://github.com/emacs-mirror/emacs.git#commit=39bc9bc77066c0c40d2e5fd0769ce3701055a10b")
+sha256sums=('SKIP')
+
+prepare() {
+  cd "emacs-git"
+  ./autogen.sh
+}
+
+build() {
+  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
+  cd "build-${MINGW_CHOST}"
+
+  ../emacs-git/configure \
+    --prefix="${MINGW_PREFIX}" \
+    --build="${MINGW_CHOST}" \
+    --with-modules \
+    --without-dbus \
+	--with-native-compilation \
+    --without-compress-install
+
+  # --without-compress-install is needed because we don't have gzip in
+  # the mingw binaries.
+
+  make
+}
+
+package() {
+  cd "build-${MINGW_CHOST}"
+  make DESTDIR="${pkgdir}" install
+  rm -f "${pkgdir}${MINGW_PREFIX}/bin/ctags.exe"
+  rm -f "${pkgdir}${MINGW_PREFIX}/share/man/man1/ctags.1.gz"
+
+  local dir="${pkgdir}${MINGW_PREFIX}/share/${_realname}"
+        dir="${dir}/$(ls -1 ${dir} | grep -E '([0-9]+\.[0-9]+)(\.[0-9]+)?')/src"
+
+  mkdir -p "${dir}"
+  cd "${srcdir}/emacs-git/src"
+  cp *.c *.h *.m "${dir}"
+}
+
+# TODO:
+# Patch `shell-file-name' default in the C source code similarly to
+# `source-directory'.

--- a/mingw-w64-emacs-native-compilation/PKGBUILD
+++ b/mingw-w64-emacs-native-compilation/PKGBUILD
@@ -75,6 +75,11 @@ build() {
   # mailutils should be included in the depends list.
 
   make --jobs=1
+  
+  # Limiting the number of jobs to one fixed strange issues with GitHub CI 
+  # (aka workflows). When using an unlimited number of jobs GitHub CI
+  # stopped without detectable reason at a random point somewhere in the 
+  # second half of the build step.
 }
 
 package() {

--- a/mingw-w64-emacs-native-compilation/PKGBUILD
+++ b/mingw-w64-emacs-native-compilation/PKGBUILD
@@ -65,7 +65,7 @@ build() {
     --build="${MINGW_CHOST}" \
     --with-modules \
     --without-dbus \
-	--with-native-compilation \
+    --with-native-compilation \
     --without-compress-install
 
   # --without-compress-install is needed because we don't have gzip in

--- a/mingw-w64-emacs-native-compilation/PKGBUILD
+++ b/mingw-w64-emacs-native-compilation/PKGBUILD
@@ -3,6 +3,7 @@
 # Maintainer: Oscar Fuentes <ofv@wanadoo.es>
 
 _realname=emacs
+pkgbase=mingw-w64-${_realname}-native-compilation
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-native-compilation"
 pkgver=28.0.50
 pkgrel=1
@@ -18,6 +19,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-universal-ctags-git"
          "${MINGW_PACKAGE_PREFIX}-jansson"
          "${MINGW_PACKAGE_PREFIX}-gnutls"
          "${MINGW_PACKAGE_PREFIX}-libwinpthread"
+		 "${MINGW_PACKAGE_PREFIX}-gnupg"
          "${MINGW_PACKAGE_PREFIX}-libgccjit")
 optdepends=("${MINGW_PACKAGE_PREFIX}-giflib"
             "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
@@ -42,9 +44,9 @@ conflicts=("${MINGW_PACKAGE_PREFIX}-emacs")
 # Don't zip info files because the built-in info reader uses gzip to
 # decompress them. gzip is not available as a mingw binary.
 options=('strip' '!zipman')
-source=("emacs-git::git://git.savannah.gnu.org/emacs.git#commit=39bc9bc77066c0c40d2e5fd0769ce3701055a10b")
+source=("emacs-git::git://git.savannah.gnu.org/emacs.git#branch=feature/native-comp")
 # If Savannah access is blocked for reasons, you can use Github instead.
-#source=("emacs-git::git://github.com/emacs-mirror/emacs.git#commit=39bc9bc77066c0c40d2e5fd0769ce3701055a10b")
+#source=("emacs-git::git://github.com/emacs-mirror/emacs.git#branch=feature/native-comp")
 sha256sums=('SKIP')
 
 prepare() {
@@ -62,7 +64,6 @@ build() {
     --build="${MINGW_CHOST}" \
     --with-modules \
     --without-dbus \
-    --without-pop \
     --with-native-compilation \
     --without-compress-install
 

--- a/mingw-w64-emacs-native-compilation/image.c.diff
+++ b/mingw-w64-emacs-native-compilation/image.c.diff
@@ -1,0 +1,11 @@
+--- src/image.c.orig	2014-10-15 14:18:29.088716000 +0200
++++ src/image.c	2014-10-15 15:54:12.407522800 +0200
+@@ -7862,7 +7862,7 @@
+   };
+ 
+ #if defined HAVE_NTGUI && defined WINDOWSNT
+-static bool init_imagemagick_functions (void);
++#define init_imagemagick_functions NULL
+ #else
+ #define init_imagemagick_functions NULL
+ #endif


### PR DESCRIPTION
I added a `PKGBUILD` for building Emacs `native-compilation` development branch. I am building it from the most recent commit on the `native-comp` branch available at the time I created the `PKGBUILD` file  (instead of building the branch head itself). I chose to do it that way in order to get reproducible build results.

I have almost no experience with writing `PKGBUILD` files. So any feedback is welcome. I created my `PKGBUILD` by adjusting the Emacs release version `PKGBUILD` file. Thus I hope it got most things right (and of course I already successfully built and started Emacs with native-compilation on my machine).

I would appreciate it if this recipe could make it into the official repository :)