### PR TITLE
boost: don't define __MSVCRT_VERSION__

### DIFF
--- a/mingw-w64-boost/PKGBUILD
+++ b/mingw-w64-boost/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.75.0
 _boostver=${pkgver//./_}
-pkgrel=2
+pkgrel=3
 pkgdesc="Free peer-reviewed portable C++ source libraries (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -37,6 +37,7 @@ source=(#https://downloads.sourceforge.net/sourceforge/boost/boost_${_boostver}.
         boost-1.73.0-context-gas_mingw_symbols.patch
         boost-1.73.0-fix-locale-icu.patch
         boost-1.74-mingw-32bit-enable-tls.patch
+        boost-1.75-dont-set-msvcrt-version.patch
         using-mingw-w64-python.patch
         msys2-mingw-folders-bootstrap.patch)
 sha256sums=('953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb'
@@ -54,6 +55,7 @@ sha256sums=('953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb'
             'bb84f3c7fc4b856c2bc2dc5c385152905c51ba8bffffa9371370c41168d55fcc'
             '5ef2b1011dc960b7f55d4da89bcd75418eb696dce677b9fd0c78632f4109e7d3'
             '15f25653ec71e061cbd3a611a969541c57ea70c1fe95cb0de11f22cc68c7670f'
+            'edc8cb076afe5132f2e5a1393e6e65ef3a8740384f36b7b9aa065d53b1182292'
             '0dd6346d369850aad13bf8d9bc2f0abc16d4b0586e34d61fab11f65d3d7fa9d4'
             '5117629ee577de0da800b6923675683ba69422cdbe958e70c9081fdc6886402e')
 
@@ -121,6 +123,11 @@ prepare() {
   
   msg2 "boost-1.74-mingw-32bit-enable-tls.patch"
   patch -p1 -i ${srcdir}/boost-1.74-mingw-32bit-enable-tls.patch
+
+  # https://github.com/boostorg/nowide/pull/130
+  # https://github.com/boostorg/log/pull/149
+  msg2 "boost-1.75-dont-set-msvcrt-version.patch"
+  patch -p1 -i ${srcdir}/boost-1.75-dont-set-msvcrt-version.patch
 }
 
 build() {
@@ -154,12 +161,6 @@ build() {
       local variant=release
   fi
 
-  declare -a extra_config
-  if [[ "$MSYSTEM" == "UCRT64" ]]; then
-    # FIXME: https://github.com/msys2/MINGW-packages/issues/8283
-    extra_config+=('cxxflags=-D_UCRT')
-  fi
-
   ./b2 \
     address-model=${_model} \
     link=shared,static \
@@ -168,7 +169,6 @@ build() {
     threading=multi \
     threadapi=win32 \
     toolset=gcc \
-    ${extra_config} \
     variant=${variant} \
     python=${_pyver} \
     --debug-configuration \
@@ -213,12 +213,6 @@ package() {
       local variant=release
   fi
 
-  declare -a extra_config
-  if [[ "$MSYSTEM" == "UCRT64" ]]; then
-    # FIXME: https://github.com/msys2/MINGW-packages/issues/8283
-    extra_config+=('cxxflags=-D_UCRT')
-  fi
-
   local _pyver=$(${MINGW_PREFIX}/bin/python -c "import sys;sys.stdout.write('.'.join(map(str, sys.version_info[:2])))")
 
   ./b2 \
@@ -228,7 +222,6 @@ package() {
       threading=multi \
       threadapi=win32 \
       toolset=gcc \
-      ${extra_config} \
       variant=${variant} \
       python=${_pyver} \
       --prefix=${pkgdir}${MINGW_PREFIX} \

--- a/mingw-w64-boost/boost-1.75-dont-set-msvcrt-version.patch
+++ b/mingw-w64-boost/boost-1.75-dont-set-msvcrt-version.patch
@@ -1,0 +1,47 @@
+--- boost_1_75_0/boost/log/detail/config.hpp.orig	2021-04-05 16:25:32.003076500 +0200
++++ boost_1_75_0/boost/log/detail/config.hpp	2021-04-05 16:26:08.365696000 +0200
+@@ -17,12 +17,6 @@
+ #ifndef BOOST_LOG_DETAIL_CONFIG_HPP_INCLUDED_
+ #define BOOST_LOG_DETAIL_CONFIG_HPP_INCLUDED_
+ 
+-// This check must be before any system headers are included, or __MSVCRT_VERSION__ may get defined to 0x0600
+-#if defined(__MINGW32__) && !defined(__MSVCRT_VERSION__)
+-// Target MinGW headers to at least MSVC 7.0 runtime by default. This will enable some useful functions.
+-#define __MSVCRT_VERSION__ 0x0700
+-#endif
+-
+ #include <boost/predef/os.h>
+ 
+ // Try including WinAPI config as soon as possible so that any other headers don't include Windows SDK headers
+--- boost_1_75_0/boost/nowide/config.hpp.orig	2021-04-05 16:25:38.162569500 +0200
++++ boost_1_75_0/boost/nowide/config.hpp	2021-04-05 16:26:11.891185000 +0200
+@@ -17,13 +17,6 @@
+ 
+ //! @cond Doxygen_Suppress
+ 
+-// MinGW32 requires a __MSVCRT_VERSION__ defined to make some functions available, e.g. _stat64
+-// Hence define this here to target MSVC 7.0 which has the required functions and do it as early as possible
+-// as including a system header might default this to 0x0600 which is to low
+-#if defined(__MINGW32__) && !defined(__MSVCRT_VERSION__)
+-#define __MSVCRT_VERSION__ 0x0700
+-#endif
+-
+ #if defined(BOOST_ALL_DYN_LINK) || defined(BOOST_NOWIDE_DYN_LINK)
+ #ifdef BOOST_NOWIDE_SOURCE
+ #define BOOST_NOWIDE_DECL BOOST_SYMBOL_EXPORT
+--- boost_1_75_0/libs/nowide/standalone/config.hpp.orig	2021-04-05 16:24:52.922726300 +0200
++++ boost_1_75_0/libs/nowide/standalone/config.hpp	2021-04-05 16:26:20.590768400 +0200
+@@ -11,13 +11,6 @@
+ 
+ #include <boost/nowide/replacement.hpp>
+ 
+-// MinGW32 requires a __MSVCRT_VERSION__ defined to make some functions available, e.g. _stat64
+-// Hence define this here to target MSVC 7.0 which has the required functions and do it as early as possible
+-// as including a system header might default this to 0x0600 which is to low
+-#if defined(__MINGW32__) && !defined(__MSVCRT_VERSION__)
+-#define __MSVCRT_VERSION__ 0x0700
+-#endif
+-
+ #if(defined(__WIN32) || defined(_WIN32) || defined(WIN32)) && !defined(__CYGWIN__)
+ #define NOWIDE_WINDOWS
+ #endif


### PR DESCRIPTION
This is internal and in case it doesn't match the crt just wrong.

Fixes #8283