### PR TITLE
openlibm: Update to 0.7.5

### DIFF
--- a/mingw-w64-openlibm/PKGBUILD
+++ b/mingw-w64-openlibm/PKGBUILD
@@ -3,17 +3,17 @@
 _realname=openlibm
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.7.3
+pkgver=0.7.5
 pkgrel=1
 pkgdesc="High quality system independent, portable, open source libm implementation (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
-url='http://www.openlibm.org'
+url='https://openlibm.org'
 license=('MIT')
 options=('strip' 'staticlibs')
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/JuliaMath/${_realname}/archive/v${pkgver}.tar.gz"
         01-mingw-build.patch)
-sha256sums=('d3bcc4ef21c033a0cc408a30186bb3dbe21219e0c52d328ca70eb688cf867354'
+sha256sums=('be983b9e1e40e696e8bbb7eb8f6376d3ca0ae675ae6d82936540385b0eeec15b'
             '8fc88f5296a5963dc0389da656f299d7ace0a26a79882acc2596b686937a6e70')
 
 # Helper macros to help make tasks easier #


### PR DESCRIPTION
Fixed unresponsive outdated `url`.