### PR TITLE
ncurses: build with __USE_MINGW_ACCESS to fix the ucrt build

### DIFF
--- a/mingw-w64-ncurses/PKGBUILD
+++ b/mingw-w64-ncurses/PKGBUILD
@@ -7,7 +7,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 #_date_rev=20190630
 #pkgver=${_base_ver}.${_date_rev}
 pkgver=6.2
-pkgrel=2
+pkgrel=3
 pkgdesc="System V Release 4.0 curses emulation library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -35,6 +35,9 @@ prepare() {
 build() {
   [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}
   mkdir -p build-${MINGW_CHOST} && cd build-${MINGW_CHOST}
+
+  # It passes X_OK to access() on Windows which isn't supported with ucrt
+  CFLAGS+=" -D__USE_MINGW_ACCESS"
 
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \


### PR DESCRIPTION
ncurses calls access() with X_OK in various places which isn't supported
on Windows. mingw-w64 ships with a wrapper which does if __USE_MINGW_ACCESS
is defined, so use that for now.