### PR TITLE
Win64 AVX misalignment bug patch #1209

### DIFF
--- a/mingw-w64-binutils/PKGBUILD
+++ b/mingw-w64-binutils/PKGBUILD
@@ -60,6 +60,15 @@ prepare() {
 
   # https://sourceware.org/pipermail/binutils/2021-April/116019.html
   apply_patch_with_msg 0500-fix-weak-undef-symbols-after-image-base-change.patch
+  
+  # https://github.com/msys2/MSYS2-packages/issues/1209
+  # x86_64 Win64 AVX opcode patch for vmovapd, vmovaps, vmovdqa*
+  # unconditionally replace these aligned instructions with matching unaligned instructions
+  # aligned non-temporal streaming instructions unchanged
+  if [ "${CARCH}" = "x86_64" ]; then
+    sed -i '/vmovapd/s/0x6628/0x6610/g;/vmovaps/s/0x28/0x10/g;/vmovdqa/s/0x666f/0xf36f/g;/vmovdqa/s/0x666F/0xF36F/g' opcodes/i386-opc.tbl
+    sed -i '/vmovapd/s/0x6628/0x6610/g;/vmovaps/s/0x28/0x10/g;/vmovdqa/s/0x666f/0xf36f/g;/vmovdqa/s/0x666F/0xF36F/g' opcodes/i386-tbl.h
+  fi
 }
 
 build() {


### PR DESCRIPTION
MINGW64 and UCRT64: https://github.com/msys2/MSYS2-packages/issues/1209

Unconditionally replaces the opcodes for aligned AVX instructions with the opcodes of matching unaligned instructions in the assembler stage. There should be no loss of performance for aligned memory accesses on moderate modern processors. Unaligned memory access will not segfault anymore.

So-called not-temporal streaming instructions are not handled in this PR as they have no unaligned counterpart. These instructions are used much less commonly used. Falling back to SSE2 streaming instructions is the recommended approach for this use case.

