### PR TITLE
clang libtool fixes

### DIFF
--- a/mingw-w64-libssh2/PKGBUILD
+++ b/mingw-w64-libssh2/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libssh2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.9.0
-pkgrel=2
+pkgrel=3
 pkgdesc="A library implementing the SSH2 protocol as defined by Internet Drafts (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -16,13 +16,17 @@ depends=("${MINGW_PACKAGE_PREFIX}-openssl"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 options=('staticlibs' 'strip')
 source=("${url}/download/${_realname}-${pkgver}.tar.gz"
-        fix-pkgconfig.patch)
+        fix-pkgconfig.patch
+        fix-configure-ac.patch)
 sha256sums=('d5fb8bd563305fd1074dda90bd053fb2d29fc4bce048d182f96eaa466dfadafd'
-            '7a6545f6d457ad008aacefe04a60727c02d33927c8a903745bf191f69cc8ba55')
+            '7a6545f6d457ad008aacefe04a60727c02d33927c8a903745bf191f69cc8ba55'
+            '956b2518618646f9134f0eee7c539ebfb3ddeeff48019831b53997464edbf4f1')
 
 prepare() {
   cd ${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/fix-pkgconfig.patch
+  patch -p1 -i ${srcdir}/fix-configure-ac.patch
+  autoreconf -fi
 }
 
 build() {

--- a/mingw-w64-libssh2/fix-configure-ac.patch
+++ b/mingw-w64-libssh2/fix-configure-ac.patch
@@ -1,0 +1,11 @@
+--- libssh2-1.9.0/configure.ac.ORIG	2021-04-12 11:23:19.331827300 -0700
++++ libssh2-1.9.0/configure.ac	2021-04-12 11:23:59.738111400 -0700
+@@ -127,8 +127,6 @@
+ m4_set_foreach([crypto_backends], [backend],
+   [AM_CONDITIONAL(m4_toupper(backend), test "$found_crypto" = "backend")]
+ )
+-m4_undefine([backend])
+-
+ 
+ # libz
+ 

--- a/mingw-w64-libunistring/PKGBUILD
+++ b/mingw-w64-libunistring/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libunistring
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.9.10
-pkgrel=2
+pkgrel=3
 pkgdesc="Library for manipulating Unicode strings and C strings. (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -21,6 +21,7 @@ sha256sums=('a82e5b333339a88ea4608e4635479a1cfb2e01aafb925e1290b65710d43f610b'
 prepare() {
   cd ${srcdir}/libunistring-${pkgver}
   patch -Nbp1 -i ${srcdir}/fix-pointer-casts.patch
+  autoreconf -fiv
 }
 
 build() {

--- a/mingw-w64-pcre/PKGBUILD
+++ b/mingw-w64-pcre/PKGBUILD
@@ -4,7 +4,7 @@ _realname=pcre
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=8.44
-pkgrel=2
+pkgrel=3
 pkgdesc="A library that implements Perl 5-style regular expressions (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -21,6 +21,11 @@ source=(https://ftp.pcre.org/pub/pcre/${_realname}-${pkgver}.tar.bz2{,.sig})
 sha256sums=('19108658b23b3ec5058edc9f66ac545ea19f9537234be1ec62b714c84399366d'
             'SKIP')
 validpgpkeys=('45F68D54BBE23FB3039B46E59766E084FB0F43D8')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  autoreconf -fiv
+}
 
 build() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}


### PR DESCRIPTION
autoreconf in several packages to get updated libtool which supports clang.  Fixes msys2/CLANG-packages#9