### PR TITLE
Disable assembly on new arches

### DIFF
--- a/mingw-w64-libgcrypt/PKGBUILD
+++ b/mingw-w64-libgcrypt/PKGBUILD
@@ -5,7 +5,7 @@ _realname=libgcrypt
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.9.2
-pkgrel=1
+pkgrel=2
 pkgdesc="General purpose cryptographic library based on the code from GnuPG (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -38,6 +38,14 @@ prepare() {
 }
 
 build() {
+  local -a extra_config
+  case "${CARCH}" in
+    i?86|x86_64)
+      ;;
+    *)
+      extra_config+=(--disable-asm)
+      ;;
+  esac
   [[ -d "${srcdir}/build-${CARCH}" ]] && rm -rf "${srcdir}/build-${CARCH}"
   cp -rf "${srcdir}/${_realname}-${pkgver}" "${srcdir}/build-${CARCH}"
   cd "${srcdir}/build-${CARCH}"
@@ -48,6 +56,7 @@ build() {
     --target=${MINGW_CHOST} \
     --enable-shared \
     --enable-static \
+    "${extra_config[@]}" \
     --with-gpg-error-prefix=${MINGW_PREFIX}
 
   make

--- a/mingw-w64-nettle/PKGBUILD
+++ b/mingw-w64-nettle/PKGBUILD
@@ -4,7 +4,7 @@ _realname=nettle
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.7
-pkgrel=1
+pkgrel=2
 pkgdesc="A low-level cryptographic library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -23,6 +23,14 @@ prepare() {
 }
 
 build() {
+  local -a extra_config
+  case "${CARCH}" in
+    i?86|x86_64)
+      ;;
+    *)
+      extra_config+=(--disable-assembler)
+  esac
+
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
   mkdir -p "${srcdir}/build-${MINGW_CHOST}"
   cd "${srcdir}/build-${MINGW_CHOST}"
@@ -31,6 +39,7 @@ build() {
       --build=${MINGW_CHOST} \
       --host=${MINGW_CHOST} \
       --target=${MINGW_CHOST} \
+      "${extra_config[@]}" \
       --enable-shared \
       --enable-public-key
 

--- a/mingw-w64-openssl/PKGBUILD
+++ b/mingw-w64-openssl/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 _ver=1.1.1k
 # use a pacman compatible version scheme
 pkgver=${_ver/[a-z]/.${_ver//[0-9.]/}}
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
 pkgdesc="The Open Source toolkit for Secure Sockets Layer and Transport Layer Security (mingw-w64)"
@@ -17,10 +17,12 @@ license=('custom:BSD')
 url="https://www.openssl.org"
 noextract=(${_realname}-${_ver}.tar.gz)
 source=(https://www.openssl.org/source/${_realname}-${_ver}.tar.gz{,.asc}
-        'openssl-1.1.1-relocation.patch')
+        'openssl-1.1.1-relocation.patch'
+        'openssl-1.1.1-mingw-arm.patch')
 sha256sums=('892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5'
             'SKIP'
-            '798d1b4dec28429d6cf2081c5b5b23b4344590a9b812e8089842389dbd175b77')
+            '798d1b4dec28429d6cf2081c5b5b23b4344590a9b812e8089842389dbd175b77'
+            'd41fad88631e7b8d2a56662f2166ea97ecbc6369f2ad3eac415182bc9ac9f308')
 
 validpgpkeys=('8657ABB260F056B1E5190839D9C4D26D0E604491'
               '7953AC1FBC3DC8B3B292393ED5E9E43F7DF9EE8C')
@@ -51,7 +53,8 @@ prepare() {
   cd ${srcdir}/${_realname}-${_ver}
 
   apply_patch_with_msg \
-     openssl-1.1.1-relocation.patch
+     openssl-1.1.1-relocation.patch \
+     openssl-1.1.1-mingw-arm.patch
 }
 
 build() {
@@ -66,10 +69,21 @@ build() {
      ${srcdir}/${_realname}-${_ver}/Configure
 #     ${srcdir}/build-${CARCH}/Configure
 
-  _mingw=mingw
-  if $(echo ${CARCH} | grep -q x86_64); then
-    _mingw=mingw64
-  fi
+  case "${CARCH}" in
+    i?86)
+      _mingw=mingw
+      ;;
+    x86_64)
+      _mingw=mingw64
+      ;;
+    armv7)
+      _mingw="mingwarm32 no-asm"
+      ;;
+    aarch64)
+      _mingw="mingwarm64 no-asm"
+      ;;
+  esac
+
   cd "${srcdir}/build-${CARCH}"
   export MSYS2_ARG_CONV_EXCL="--prefix="
   ${srcdir}/${_realname}-${_ver}/Configure \

--- a/mingw-w64-openssl/openssl-1.1.1-mingw-arm.patch
+++ b/mingw-w64-openssl/openssl-1.1.1-mingw-arm.patch
@@ -1,0 +1,57 @@
+--- openssl-1.1.1i/Configurations/10-main.conf.ORIG	2021-01-16 16:36:58.560632200 -0800
++++ openssl-1.1.1i/Configurations/10-main.conf	2021-01-16 16:40:28.966865000 -0800
+@@ -1433,7 +1433,53 @@
+         multilib         => "64",
+         apps_aux_src     => add("win32_init.c"),
+     },
+-
++    "mingwarm32" => {
++        inherit_from     => [ "BASE_unix", asm("armv4_asm")],
++        CC               => "gcc",
++        CFLAGS           => picker(default => "-Wall",
++                                   debug   => "-g -O0",
++                                   release => "-O3 -fomit-frame-pointer"),
++        cppflags         => combine("-DUNICODE -D_UNICODE -DWIN32_LEAN_AND_MEAN",
++                                    threads("-D_MT")),
++        lib_cppflags     => "-DL_ENDIAN",
++        sys_id           => "MINGWARM32",
++        ex_libs          => add("-lws2_32 -lgdi32 -lcrypt32"),
++        bn_ops           => "BN_LLONG EXPORT_VAR_AS_FN",
++        thread_scheme    => "winthreads",
++        perlasm_scheme   => "coff",
++        dso_scheme       => "win32",
++        shared_target    => "mingw-shared",
++        shared_cppflags  => add("_WINDLL"),
++        shared_ldflag    => "-static-libgcc",
++        shared_extension => ".dll",
++        multilib         => "",
++        apps_aux_src     => add("win32_init.c"),
++        # "WOW" stands for "Windows on Windows", and that word engages
++        # some installation path heuristics in unix-Makefile.tmpl...
++        build_scheme     => add("WOW", { separator => undef }),
++    },
++    "mingwarm64" => {
++        inherit_from     => [ "BASE_unix", asm("aarch64_asm")],
++        CC               => "gcc",
++        CFLAGS           => picker(default => "-Wall",
++                                   debug   => "-g -O0",
++                                   release => "-O3 -fomit-frame-pointer"),
++        cppflags         => combine("-DUNICODE -D_UNICODE -DWIN32_LEAN_AND_MEAN",
++                                    threads("-D_MT")),
++        lib_cppflags     => "-DL_ENDIAN",
++        sys_id           => "MINGWARM64",
++        ex_libs          => add("-lws2_32 -lgdi32 -lcrypt32"),
++        bn_ops           => "SIXTY_FOUR_BIT EXPORT_VAR_AS_FN",
++        thread_scheme    => "winthreads",
++        perlasm_scheme   => "coff",
++        dso_scheme       => "win32",
++        shared_target    => "mingw-shared",
++        shared_cppflags  => add("_WINDLL"),
++        shared_ldflag    => "-static-libgcc",
++        shared_extension => ".dll",
++        multilib         => "",
++        apps_aux_src     => add("win32_init.c"),
++    },
+ #### UEFI
+     "UEFI" => {
+         inherit_from     => [ "BASE_unix" ],


### PR DESCRIPTION
Arches can be added to case statements once assembly support is added.

Openssl is a little different, and specifically handles arm because it 'needs' to know 32 vs 64-bit.