### PR TITLE
libffi: backport support for aarch64 mingw

### DIFF
--- a/mingw-w64-libffi/0001-Fix-building-for-aarch64-windows-with-mingw-toolchai.patch
+++ b/mingw-w64-libffi/0001-Fix-building-for-aarch64-windows-with-mingw-toolchai.patch
@@ -1,0 +1,239 @@
+From 955a5b73059d27eba7db0783bb4769934d8c8a82 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Storsj=C3=B6?= <martin@martin.st>
+Date: Sun, 26 Apr 2020 04:58:33 +0300
+Subject: [PATCH] Fix building for aarch64 windows with mingw toolchains (#555)
+
+* aarch64: Check _WIN32 instead of _M_ARM64 for detecting windows
+
+This fixes building for aarch64 with mingw toolchains. _M_ARM64 is
+predefined by MSVC, while mingw compilers predefine __aarch64__.
+
+In aarch64 specific code, change checks for _M_ARM64 into checks for
+_WIN32.
+
+In arch independent code, check for
+(defined(_M_ARM64) || defined(__aarch64__)) && defined(_WIN32)
+instead of just _M_ARM64.
+
+In src/closures.c, coalesce checks like
+defined(X86_WIN32) || defined(X86_WIN64) || defined(_M_ARM64)
+into plain defined(_WIN32). Technically, this enables code for
+ARM32 windows where it wasn't, but as far as I can see it, those
+codepaths should be fine for that architecture variant as well.
+
+* aarch64: Only use armasm source when building with MSVC
+
+When building for windows/arm64 with clang, the normal gas style .S
+source works fine. sysv.S and win64_armasm.S seem to be functionally
+equivalent, with only differences being due to assembler syntax.
+---
+ configure.host          | 10 ++++++++--
+ src/aarch64/ffi.c       | 14 +++++++-------
+ src/aarch64/ffitarget.h |  8 ++++----
+ src/closures.c          | 12 ++++++------
+ src/prep_cif.c          |  2 +-
+ 5 files changed, 26 insertions(+), 20 deletions(-)
+
+diff --git a/configure.host b/configure.host
+index 9a72cda..947e73b 100644
+--- a/configure.host
++++ b/configure.host
+@@ -8,7 +8,9 @@
+ case "${host}" in
+   aarch64*-*-cygwin* | aarch64*-*-mingw* | aarch64*-*-win* )
+ 	TARGET=ARM_WIN64; TARGETDIR=aarch64
+-	MSVC=1
++	if test "${ax_cv_c_compiler_vendor}" = "microsoft"; then
++	  MSVC=1
++	fi
+ 	;;
+ 
+   aarch64*-*-*)
+@@ -256,7 +258,11 @@ case "${TARGET}" in
+ 	SOURCES="ffi.c sysv_msvc_arm32.S"
+ 	;;
+   ARM_WIN64)
+-	SOURCES="ffi.c win64_armasm.S"
++	if test "$MSVC" = 1; then
++		SOURCES="ffi.c win64_armasm.S"
++	else
++		SOURCES="ffi.c sysv.S"
++	fi
+ 	;;
+   MIPS)
+ 	SOURCES="ffi.c o32.S n32.S"
+diff --git a/src/aarch64/ffi.c b/src/aarch64/ffi.c
+index 1ebf43c..2906c20 100644
+--- a/src/aarch64/ffi.c
++++ b/src/aarch64/ffi.c
+@@ -27,7 +27,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+ #include <ffi.h>
+ #include <ffi_common.h>
+ #include "internal.h"
+-#ifdef _M_ARM64
++#ifdef _WIN32
+ #include <windows.h> /* FlushInstructionCache */
+ #endif
+ 
+@@ -78,7 +78,7 @@ ffi_clear_cache (void *start, void *end)
+   sys_icache_invalidate (start, (char *)end - (char *)start);
+ #elif defined (__GNUC__)
+   __builtin___clear_cache (start, end);
+-#elif defined (_M_ARM64)
++#elif defined (_WIN32)
+   FlushInstructionCache(GetCurrentProcess(), start, (char*)end - (char*)start);
+ #else
+ #error "Missing builtin to flush instruction cache"
+@@ -665,7 +665,7 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *orig_rvalue,
+ 	    if (h)
+ 	      {
+ 		int elems = 4 - (h & 3);
+-#ifdef _M_ARM64 /* for handling armasm calling convention */
++#ifdef _WIN32 /* for handling armasm calling convention */
+                 if (cif->is_variadic)
+                   {
+                     if (state.ngrn + elems <= N_X_ARG_REG)
+@@ -690,7 +690,7 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *orig_rvalue,
+ 		  }
+ 		state.nsrn = N_V_ARG_REG;
+ 		dest = allocate_to_stack (&state, stack, ty->alignment, s);
+-#ifdef _M_ARM64 /* for handling armasm calling convention */
++#ifdef _WIN32 /* for handling armasm calling convention */
+ 	      }
+ #endif /* for handling armasm calling convention */
+ 	      }
+@@ -808,7 +808,7 @@ ffi_prep_closure_loc (ffi_closure *closure,
+   ffi_clear_cache(tramp, tramp + FFI_TRAMPOLINE_SIZE);
+ 
+   /* Also flush the cache for code mapping.  */
+-#ifdef _M_ARM64
++#ifdef _WIN32
+   // Not using dlmalloc.c for Windows ARM64 builds
+   // so calling ffi_data_to_code_pointer() isn't necessary
+   unsigned char *tramp_code = tramp;
+@@ -914,7 +914,7 @@ ffi_closure_SYSV_inner (ffi_cif *cif,
+ 	  if (h)
+ 	    {
+ 	      n = 4 - (h & 3);
+-#ifdef _M_ARM64  /* for handling armasm calling convention */
++#ifdef _WIN32  /* for handling armasm calling convention */
+               if (cif->is_variadic)
+                 {
+                   if (state.ngrn + n <= N_X_ARG_REG)
+@@ -954,7 +954,7 @@ ffi_closure_SYSV_inner (ffi_cif *cif,
+                       avalue[i] = allocate_to_stack(&state, stack,
+                                                    ty->alignment, s);
+                     }
+-#ifdef _M_ARM64  /* for handling armasm calling convention */
++#ifdef _WIN32  /* for handling armasm calling convention */
+                 }
+ #endif  /* for handling armasm calling convention */
+             }
+diff --git a/src/aarch64/ffitarget.h b/src/aarch64/ffitarget.h
+index ecb6d2d..7a8cabe 100644
+--- a/src/aarch64/ffitarget.h
++++ b/src/aarch64/ffitarget.h
+@@ -32,7 +32,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+ #define FFI_SIZEOF_JAVA_RAW  4
+ typedef unsigned long long ffi_arg;
+ typedef signed long long ffi_sarg;
+-#elif defined(_M_ARM64)
++#elif defined(_WIN32)
+ #define FFI_SIZEOF_ARG 8
+ typedef unsigned long long ffi_arg;
+ typedef signed long long ffi_sarg;
+@@ -69,7 +69,7 @@ typedef enum ffi_abi
+ #define FFI_TRAMPOLINE_CLOSURE_OFFSET FFI_TRAMPOLINE_SIZE
+ #endif
+ 
+-#ifdef _M_ARM64
++#ifdef _WIN32
+ #define FFI_EXTRA_CIF_FIELDS unsigned is_variadic
+ #endif
+ 
+@@ -78,13 +78,13 @@ typedef enum ffi_abi
+ #if defined (__APPLE__)
+ #define FFI_TARGET_SPECIFIC_VARIADIC
+ #define FFI_EXTRA_CIF_FIELDS unsigned aarch64_nfixedargs
+-#elif !defined(_M_ARM64)
++#elif !defined(_WIN32)
+ /* iOS and Windows reserve x18 for the system.  Disable Go closures until
+    a new static chain is chosen.  */
+ #define FFI_GO_CLOSURES 1
+ #endif
+ 
+-#ifndef _M_ARM64
++#ifndef _WIN32
+ /* No complex type on Windows */
+ #define FFI_TARGET_HAS_COMPLEX_TYPE
+ #endif
+diff --git a/src/closures.c b/src/closures.c
+index 5120021..12f8268 100644
+--- a/src/closures.c
++++ b/src/closures.c
+@@ -123,7 +123,7 @@ ffi_closure_free (void *ptr)
+ #  define FFI_MMAP_EXEC_WRIT 1
+ #  define HAVE_MNTENT 1
+ # endif
+-# if defined(X86_WIN32) || defined(X86_WIN64) || defined(_M_ARM64) || defined(__OS2__)
++# if defined(_WIN32) || defined(__OS2__)
+ /* Windows systems may have Data Execution Protection (DEP) enabled, 
+    which requires the use of VirtualMalloc/VirtualFree to alloc/free
+    executable memory. */
+@@ -386,7 +386,7 @@ ffi_closure_free (void *ptr)
+ #endif
+ #include <string.h>
+ #include <stdio.h>
+-#if !defined(X86_WIN32) && !defined(X86_WIN64) && !defined(_M_ARM64)
++#if !defined(_WIN32)
+ #ifdef HAVE_MNTENT
+ #include <mntent.h>
+ #endif /* HAVE_MNTENT */
+@@ -512,11 +512,11 @@ static int dlmalloc_trim(size_t) MAYBE_UNUSED;
+ static size_t dlmalloc_usable_size(void*) MAYBE_UNUSED;
+ static void dlmalloc_stats(void) MAYBE_UNUSED;
+ 
+-#if !(defined(X86_WIN32) || defined(X86_WIN64) || defined(_M_ARM64) || defined(__OS2__)) || defined (__CYGWIN__) || defined(__INTERIX)
++#if !(defined(_WIN32) || defined(__OS2__)) || defined (__CYGWIN__) || defined(__INTERIX)
+ /* Use these for mmap and munmap within dlmalloc.c.  */
+ static void *dlmmap(void *, size_t, int, int, int, off_t);
+ static int dlmunmap(void *, size_t);
+-#endif /* !(defined(X86_WIN32) || defined(X86_WIN64) || defined(__OS2__)) || defined (__CYGWIN__) || defined(__INTERIX) */
++#endif /* !(defined(_WIN32) || defined(__OS2__)) || defined (__CYGWIN__) || defined(__INTERIX) */
+ 
+ #define mmap dlmmap
+ #define munmap dlmunmap
+@@ -526,7 +526,7 @@ static int dlmunmap(void *, size_t);
+ #undef mmap
+ #undef munmap
+ 
+-#if !(defined(X86_WIN32) || defined(X86_WIN64) || defined(_M_ARM64) || defined(__OS2__)) || defined (__CYGWIN__) || defined(__INTERIX)
++#if !(defined(_WIN32) || defined(__OS2__)) || defined (__CYGWIN__) || defined(__INTERIX)
+ 
+ /* A mutex used to synchronize access to *exec* variables in this file.  */
+ static pthread_mutex_t open_temp_exec_file_mutex = PTHREAD_MUTEX_INITIALIZER;
+@@ -908,7 +908,7 @@ segment_holding_code (mstate m, char* addr)
+ }
+ #endif
+ 
+-#endif /* !(defined(X86_WIN32) || defined(X86_WIN64) || defined(_M_ARM64) || defined(__OS2__)) || defined (__CYGWIN__) || defined(__INTERIX) */
++#endif /* !(defined(_WIN32) || defined(__OS2__)) || defined (__CYGWIN__) || defined(__INTERIX) */
+ 
+ /* Allocate a chunk of memory with the given size.  Returns a pointer
+    to the writable address, and sets *CODE to the executable
+diff --git a/src/prep_cif.c b/src/prep_cif.c
+index 06c6544..1db3804 100644
+--- a/src/prep_cif.c
++++ b/src/prep_cif.c
+@@ -129,7 +129,7 @@ ffi_status FFI_HIDDEN ffi_prep_cif_core(ffi_cif *cif, ffi_abi abi,
+   cif->rtype = rtype;
+ 
+   cif->flags = 0;
+-#ifdef _M_ARM64
++#if (defined(_M_ARM64) || defined(__aarch64__)) && defined(_WIN32)
+   cif->is_variadic = isvariadic;
+ #endif
+ #if HAVE_LONG_DOUBLE_VARIANT
+-- 
+2.30.0.windows.2
+

--- a/mingw-w64-libffi/0002-Use-__builtin_ffs-instead-of-ffs-554.patch
+++ b/mingw-w64-libffi/0002-Use-__builtin_ffs-instead-of-ffs-554.patch
@@ -1,0 +1,34 @@
+From 392719612558fad818ab021db3628c25e763564d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Storsj=C3=B6?= <martin@martin.st>
+Date: Sun, 26 Apr 2020 04:59:35 +0300
+Subject: [PATCH] Use __builtin_ffs instead of ffs (#554)
+
+USE_BUILTIN_FFS is defined to 1 within __GNUC__, and the __builtin_ffs
+function is available since GCC 3.x at least, while the ffs function
+only exists on some OSes.
+
+This fixes compilation for non-x86 mingw platforms. For x86,
+USE_BUILTIN_FFS is explicitly disabled for windows targets - but
+if USE_BUILTIN_FFS is enabled based on __GNUC__, it should also use
+the builtin which actually is available correspondingly, not dependent
+on the target OS.
+---
+ src/dlmalloc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/dlmalloc.c b/src/dlmalloc.c
+index d63dd36..1aba657 100644
+--- a/src/dlmalloc.c
++++ b/src/dlmalloc.c
+@@ -2371,7 +2371,7 @@ static size_t traverse_and_check(mstate m);
+ 
+ #else /* GNUC */
+ #if  USE_BUILTIN_FFS
+-#define compute_bit2idx(X, I) I = ffs(X)-1
++#define compute_bit2idx(X, I) I = __builtin_ffs(X)-1
+ 
+ #else /* USE_BUILTIN_FFS */
+ #define compute_bit2idx(X, I)\
+-- 
+2.30.0.windows.2
+

--- a/mingw-w64-libffi/0003-win64_armasm-Fix-the-spelling-of-ALIGN-553.patch
+++ b/mingw-w64-libffi/0003-win64_armasm-Fix-the-spelling-of-ALIGN-553.patch
@@ -1,0 +1,25 @@
+From a3a1376c61bf3e7ff7ad0912c4e9612afa362262 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Storsj=C3=B6?= <martin@martin.st>
+Date: Sun, 26 Apr 2020 05:01:03 +0300
+Subject: [PATCH] win64_armasm: Fix the spelling of ALIGN (#553)
+
+---
+ src/aarch64/win64_armasm.S | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/aarch64/win64_armasm.S b/src/aarch64/win64_armasm.S
+index a79f8a8..7fc185b 100644
+--- a/src/aarch64/win64_armasm.S
++++ b/src/aarch64/win64_armasm.S
+@@ -42,7 +42,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+ 	EXPORT	ffi_go_closure_SYSV
+ #endif
+ 
+-	TEXTAREA, ALLIGN=8
++	TEXTAREA, ALIGN=8
+ 
+ /* ffi_call_SYSV
+    extern void ffi_call_SYSV (void *stack, void *frame,
+-- 
+2.30.0.windows.2
+

--- a/mingw-w64-libffi/0004-arm-Fix-the-clang-specific-version-of-the-assembly-5.patch
+++ b/mingw-w64-libffi/0004-arm-Fix-the-clang-specific-version-of-the-assembly-5.patch
@@ -1,0 +1,37 @@
+From 63b533bf1a5f58aebca4ce7a0f717e321485d8f3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Storsj=C3=B6?= <martin@martin.st>
+Date: Sun, 26 Apr 2020 05:02:14 +0300
+Subject: [PATCH] arm: Fix the clang specific version of the assembly (#556)
+
+Also fix the same error in the comment for the non-clang case.
+That typo there seems to have existed since the code was written
+in that form, in e7f15f60e86 - and when the clang specific codepath
+was added in e3d2812ce43, the typo in the comment made it into the
+actual code.
+---
+ src/arm/sysv.S | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/arm/sysv.S b/src/arm/sysv.S
+index 63180a4..74bc53f 100644
+--- a/src/arm/sysv.S
++++ b/src/arm/sysv.S
+@@ -129,11 +129,11 @@ ARM_FUNC_START(ffi_call_VFP)
+ 
+ 	cmp	r3, #3			@ load only d0 if possible
+ #ifdef __clang__
+-	vldrle d0, [sp]
+-	vldmgt sp, {d0-d7}
++	vldrle d0, [r0]
++	vldmgt r0, {d0-d7}
+ #else
+-	ldcle	p11, cr0, [r0]		@ vldrle d0, [sp]
+-	ldcgt	p11, cr0, [r0], {16}	@ vldmgt sp, {d0-d7}
++	ldcle	p11, cr0, [r0]		@ vldrle d0, [r0]
++	ldcgt	p11, cr0, [r0], {16}	@ vldmgt r0, {d0-d7}
+ #endif
+ 	add	r0, r0, #64		@ discard the vfp register args
+ 	/* FALLTHRU */
+-- 
+2.30.0.windows.2
+

--- a/mingw-w64-libffi/PKGBUILD
+++ b/mingw-w64-libffi/PKGBUILD
@@ -5,7 +5,7 @@ _realname=libffi
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.3
-pkgrel=3
+pkgrel=4
 pkgdesc="A portable, high level programming interface to various calling conventions (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -13,11 +13,25 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 options=('staticlibs' 'strip')
 license=('MIT')
 url="https://sourceware.org/libffi"
-source=("https://sourceware.org/pub/libffi/${_realname}-${pkgver}.tar.gz")
-sha256sums=('72fba7922703ddfa7a028d513ac15a85c8d54c8d67f55fa5a4802885dc652056')
+source=("https://sourceware.org/pub/libffi/${_realname}-${pkgver}.tar.gz"
+        0001-Fix-building-for-aarch64-windows-with-mingw-toolchai.patch
+        0002-Use-__builtin_ffs-instead-of-ffs-554.patch
+        0003-win64_armasm-Fix-the-spelling-of-ALIGN-553.patch
+        0004-arm-Fix-the-clang-specific-version-of-the-assembly-5.patch)
+sha256sums=('72fba7922703ddfa7a028d513ac15a85c8d54c8d67f55fa5a4802885dc652056'
+            '1417e8336a3953a0e542abb12723bf27187fb46eb1f2ba76af4e8746689e2e7f'
+            '94f523f536784ced069d6735df4b8cbf4278f826bb48a0f0d91acd27f12cbab4'
+            'cf7e9433538975965071a6b0a9127995d85fe5fcd1d8b1439a71466d9c43ef78'
+            'f93dd4624668f87ffeb063b57a8f32dd9f41564620d4e0662c832ed775a8e8a6')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
+
+  # Upstream patches for aarch64 support, delete in next version
+  patch -Np1 -i "${srcdir}/0001-Fix-building-for-aarch64-windows-with-mingw-toolchai.patch"
+  patch -Np1 -i "${srcdir}/0002-Use-__builtin_ffs-instead-of-ffs-554.patch"
+  patch -Np1 -i "${srcdir}/0003-win64_armasm-Fix-the-spelling-of-ALIGN-553.patch"
+  patch -Np1 -i "${srcdir}/0004-arm-Fix-the-clang-specific-version-of-the-assembly-5.patch"
 }
 
 build() {


### PR DESCRIPTION
This applies 4 upstream commits related to aarch64 mingw support.