### PR TITLE
cmake: bootstrap using system libs.

### DIFF
--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -5,7 +5,7 @@ _realname=cmake
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.20.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -13,12 +13,15 @@ url="https://www.cmake.org/"
 license=("MIT")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-bzip2"
-             "${MINGW_PACKAGE_PREFIX}-emacs"
              "${MINGW_PACKAGE_PREFIX}-ncurses"
              "${MINGW_PACKAGE_PREFIX}-python-sphinx"
-             "${MINGW_PACKAGE_PREFIX}-qt5"
              "${MINGW_PACKAGE_PREFIX}-xz"
-             "${MINGW_PACKAGE_PREFIX}-zstd")
+             "${MINGW_PACKAGE_PREFIX}-zstd"
+             $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || \
+               [[ ${MINGW_PACKAGE_PREFIX} == *-ucrt-* ]] || \
+               echo "${MINGW_PACKAGE_PREFIX}-emacs" \
+                    "${MINGW_PACKAGE_PREFIX}-qt5"))
+
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-pkg-config"
          "${MINGW_PACKAGE_PREFIX}-curl"
@@ -76,16 +79,28 @@ build() {
   mkdir -p "${srcdir}/build-${MINGW_CHOST}"
   cd "${srcdir}/build-${MINGW_CHOST}"
 
+  local -a _qtconfig
+  case "${MINGW_PACKAGE_PREFIX}" in
+    *-clang-*|*-ucrt-*)
+      ;;
+    *)
+      _qtconfig+=("--qt-gui" "--qt-qmake=${MINGW_PREFIX}/bin/qmake.exe")
+      ;;
+  esac
+
   MSYSTEM=MINGW FC=${MINGW_PREFIX}/bin/gfortran.exe \
     "${srcdir}"/${_realname}-${pkgver}/configure  \
     --prefix=${MINGW_PREFIX}                      \
     --system-libs                                 \
-    --qt-gui                                      \
-    --qt-qmake=${MINGW_PREFIX}/bin/qmake.exe      \
     --parallel=${NUMBER_OF_PROCESSORS}            \
     --mandir=share/man                            \
     --docdir=share/doc/cmake                      \
-    --sphinx-man --sphinx-html
+    --sphinx-man --sphinx-html                    \
+    --bootstrap-system-jsoncpp                    \
+    --bootstrap-system-libuv                      \
+    --bootstrap-system-librhash                   \
+    ${_qtconfig[@]}
+
   plain "Start building..."
   make
 }
@@ -101,6 +116,10 @@ package() {
      -DCMAKE_INSTALL_PREFIX:PATH=${pkgdir}${MINGW_PREFIX} \
      -DCMAKE_INSTALL_LOCAL_ONLY:BOOL=OFF -P cmake_install.cmake
   install -d "${pkgdir}${MINGW_PREFIX}"/share/emacs/site-lisp/
-  ${MINGW_PREFIX}/bin/emacs -batch -f batch-byte-compile \
-    "${pkgdir}${MINGW_PREFIX}"/share/emacs/site-lisp/cmake-mode.el
+
+  if [[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] && \
+     [[ ${MINGW_PACKAGE_PREFIX} != *-ucrt-* ]]; then
+    ${MINGW_PREFIX}/bin/emacs -batch -f batch-byte-compile \
+      "${pkgdir}${MINGW_PREFIX}"/share/emacs/site-lisp/cmake-mode.el
+  fi
 }


### PR DESCRIPTION
This causes cmake to use system libs rather than bundled sources when it bootstraps itself.  This probably doesn't matter much, unless one of those libs has been patched for the system (as I need to do for libuv on aarch64).

Also disable some makedepends for ucrt and clang.  I guess I'm not the only one who hasn't gotten qt5 and emacs built 😜 