### PR TITLE
CI: move continue-on-error from steps to job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
           { msystem: UCRT64, arch: ucrt-x86_64, can-fail: false }
         ]
     name: ${{ matrix.msystem }}
+    continue-on-error: ${{ matrix.can-fail }}
     steps:
 
       - uses: actions/checkout@v2
@@ -50,14 +51,12 @@ jobs:
 
       - name: CI-Build
         shell: msys2 {0}
-        continue-on-error: ${{ matrix.can-fail }}
         run: |
           cd /C/_
           MINGW_ARCH=${{ matrix.msystem }} ./.ci/ci-build.sh
 
       - name: "Upload binaries"
         uses: actions/upload-artifact@v2
-        continue-on-error: ${{ matrix.can-fail }}
         with:
           name: ${{ matrix.msystem }}-packages
           path: C:/_/artifacts/*.pkg.tar.*


### PR DESCRIPTION
See
https://github.blog/changelog/2020-04-15-github-actions-new-workflow-features/#expressions-in-jobcontinue-on-error

https://github.com/msys2/MINGW-packages/commit/4e952a7445daa0fb9df229ea61b69ccee3264d4a#r49357293