### PR TITLE
qt5: don't makedepend on ruby

### DIFF
--- a/mingw-w64-qt5/PKGBUILD
+++ b/mingw-w64-qt5/PKGBUILD
@@ -115,7 +115,7 @@ _ver_base=5.15.2
 # use 5.6.1-1 hot fix : only the archive name was changed from *-5.6.1.tar.xz to *-5.6.1-1.tar.xz
 _hotfix=
 pkgver=${_ver_base//-/}
-pkgrel=7
+pkgrel=8
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
@@ -182,7 +182,6 @@ makedepends=("bison"
              "${MINGW_PACKAGE_PREFIX}-fxc2"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-python"
-             "${MINGW_PACKAGE_PREFIX}-ruby"
              "${MINGW_PACKAGE_PREFIX}-make"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              $([[ "$_variant" == "-static" ]] && echo \


### PR DESCRIPTION
according to the docs it's only needed for building qtwebkit which
is a different package.