### PR TITLE
swig: move languages to checkdepends.

### DIFF
--- a/mingw-w64-swig/PKGBUILD
+++ b/mingw-w64-swig/PKGBUILD
@@ -4,7 +4,7 @@ _realname=swig
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.0.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Generate scripting interfaces to C/C++ code (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -12,10 +12,10 @@ url="http://www.swig.org/"
 license=('custom')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-pcre")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-python"
-             "${MINGW_PACKAGE_PREFIX}-lua"
-             "${MINGW_PACKAGE_PREFIX}-ruby")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python"
+              "${MINGW_PACKAGE_PREFIX}-lua"
+              "${MINGW_PACKAGE_PREFIX}-ruby")
 source=(https://downloads.sourceforge.net/${_realname}/${_realname}-${pkgver}.tar.gz
         001-relocate.patch
         002-fix-python-find.patch)
@@ -45,6 +45,11 @@ build() {
     --without-python \
     --with-python3=${MINGW_PREFIX}/bin/python
   make
+}
+
+check() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make -k check
 }
 
 package() {


### PR DESCRIPTION
The swig docs say that the languages are only necessary to run the test
suite or build the examples, so move them from `makedepends` to
`checkdepends`.

So that `checkdepends` actually means something, add a check function to
run swig's test suite, which takes a long time and is expected to give errors.
Some thought could be given to expanding `checkdepends` in the future,
adding more languages, and also boost.