### PR TITLE
fixes for LLD support

### DIFF
--- a/mingw-w64-icu/0024-mingw-no-Bsymbolic.patch
+++ b/mingw-w64-icu/0024-mingw-no-Bsymbolic.patch
@@ -1,0 +1,22 @@
+--- icu/source/config/mh-mingw64.orig	2021-01-31 17:25:18.521418000 -0800
++++ icu/source/config/mh-mingw64	2021-01-31 17:25:53.240156000 -0800
+@@ -52,7 +52,7 @@
+ #LINK.cc=      $(CXX) $(CXXFLAGS) $(LDFLAGS)
+ 
+ ## Shared library options
+-LD_SOOPTIONS= -Wl,-Bsymbolic
++LD_SOOPTIONS=
+ 
+ ## Commands to make a shared library
+ SHLIB.c=	$(CC) $(CFLAGS) $(LDFLAGS) -shared $(LD_SOOPTIONS) -Wl,--enable-auto-import -Wl,--out-implib=$(dir $@)$(notdir $(@:$(SO_TARGET_VERSION_MAJOR).$(SO)=))$(IMPORT_LIB_EXT)#M#
+--- icu/source/config/mh-mingw.orig	2021-01-31 17:26:53.771392200 -0800
++++ icu/source/config/mh-mingw	2021-01-31 17:27:07.349690700 -0800
+@@ -52,7 +52,7 @@
+ #LINK.cc=      $(CXX) $(CXXFLAGS) $(LDFLAGS)
+ 
+ ## Shared library options
+-LD_SOOPTIONS= -Wl,-Bsymbolic
++LD_SOOPTIONS=
+ 
+ ## Commands to make a shared library
+ SHLIB.c=	$(CC) $(CFLAGS) $(LDFLAGS) -shared $(LD_SOOPTIONS) -Wl,--enable-auto-import -Wl,--out-implib=$(dir $@)$(notdir $(@:$(SO_TARGET_VERSION_MAJOR).$(SO)=))$(IMPORT_LIB_EXT)#M#

--- a/mingw-w64-icu/PKGBUILD
+++ b/mingw-w64-icu/PKGBUILD
@@ -6,7 +6,7 @@ _realname=icu
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-${_realname}-debug-libs")
 pkgver=68.2
-pkgrel=2
+pkgrel=3
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
 pkgdesc="International Components for Unicode library (mingw-w64)"
@@ -27,7 +27,8 @@ source=(#"http://download.icu-project.org/files/icu4c/${pkgver}/icu4c-${pkgver//
         0017-icu-config-versioning.patch
         #0020-workaround-missing-locale.patch
         0021-mingw-static-libraries-without-s.patch
-        0023-fix-twice-include-platform_make_fragment.patch)
+        0023-fix-twice-include-platform_make_fragment.patch
+        0024-mingw-no-Bsymbolic.patch)
 sha256sums=('c79193dee3907a2199b8296a93b52c5cb74332c26f3d167269487680d479d625'
             '4f4787caeccf70607cf0cbde0c005f05f5c6de1543265a927839122405b4054f'
             'e7ecdafe85e18a4a4b5f29bbfde38776521a848e5b65089a2379b90e59f1592d'
@@ -36,7 +37,8 @@ sha256sums=('c79193dee3907a2199b8296a93b52c5cb74332c26f3d167269487680d479d625'
             '87ebe8962f8c387714f2a697a664a0c49aed2331b988548069d0c211abc36e05'
             '3cd5a7b6ca87aae3b53c246286e1b4cee6639b3fec69831f8a1f6930cd92c6c3'
             'd8612f40b1731d9a94290afcf80c896184a2f15b8ae8f23b3643c64f6cabfa2f'
-            '517a4b2308c5d7662768ece12b01b457b83a2cd80d8bf407e593e6412dfbde92')
+            '517a4b2308c5d7662768ece12b01b457b83a2cd80d8bf407e593e6412dfbde92'
+            '3a62ca57c86d0629bd62180f46ac6d57171f6441a18438f140b232c1df4fd4fa')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -65,6 +67,7 @@ prepare() {
   apply_patch_with_msg 0017-icu-config-versioning.patch
   apply_patch_with_msg 0021-mingw-static-libraries-without-s.patch
   apply_patch_with_msg 0023-fix-twice-include-platform_make_fragment.patch
+  apply_patch_with_msg 0024-mingw-no-Bsymbolic.patch
 
   cd source
   autoreconf -vfi

--- a/mingw-w64-libxml2/PKGBUILD
+++ b/mingw-w64-libxml2/PKGBUILD
@@ -6,7 +6,7 @@ _realname=libxml2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.9.10
-pkgrel=7
+pkgrel=8
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
 pkgdesc="XML parsing library, version 2 (mingw-w64)"
@@ -30,7 +30,8 @@ source=("http://xmlsoft.org/sources/${_realname}-${pkgver}.tar.gz"
         0023-fix-sitedir-detection.mingw.patch
         0026-mingw-relocate.patch
         libxml2-2.9.9-python.patch
-        0027-decoding-segfault.patch)
+        0027-decoding-segfault.patch
+        libxml2-disable-version-script.patch)
 sha256sums=('aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f'
             '9b61db9f5dbffa545f4b8d78422167083a8568c59bd1129f94138f936cf6fc1f'
             'a9457b1a5e7d9499270ccfdeabbf0ca75b0e4643c111a42a5da0d113bae485c5'
@@ -40,7 +41,8 @@ sha256sums=('aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f'
             'e93902af20bee41ca7708280f30a1d087ab8c6f86d18939bdd56789cd1a73531'
             '185033761dbfa2ff206df2adf87abb79d4733b5c84a6c68c429872a0755818d9'
             '7b9bc59b174da93a547429b2f751047c758657953f6e2fb398e73b5ebf0f55e3'
-            '0391a4b267ba7251ca74ff2e98bf4c0332a14b618e8147a9341ec5617e45d9d9')
+            '0391a4b267ba7251ca74ff2e98bf4c0332a14b618e8147a9341ec5617e45d9d9'
+            '96f5b4de10b56563da0cb3c8b9ee9a88f89e5385acd66cadf4acab9628dc9848')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -73,6 +75,7 @@ prepare() {
     0023-fix-sitedir-detection.mingw.patch \
     0026-mingw-relocate.patch \
     libxml2-2.9.9-python.patch \
+    libxml2-disable-version-script.patch
 
   # https://gitlab.gnome.org/GNOME/libxml2/-/issues/64
   # https://github.com/msys2/MINGW-packages/issues/7955

--- a/mingw-w64-libxml2/libxml2-disable-version-script.patch
+++ b/mingw-w64-libxml2/libxml2-disable-version-script.patch
@@ -1,0 +1,17 @@
+--- libxml2-2.9.10/configure.ac.orig	2021-01-19 18:13:14.649265300 -0800
++++ libxml2-2.9.10/configure.ac	2021-01-19 22:34:30.711808300 -0800
+@@ -78,14 +78,6 @@
+ dnl then add it
+ dnl
+ VERSION_SCRIPT_FLAGS=
+-# lt_cv_prog_gnu_ld is from libtool 2.+
+-if test "$lt_cv_prog_gnu_ld" = yes; then
+-  VERSION_SCRIPT_FLAGS=-Wl,--version-script=
+-else
+-  case $host in
+-  *-*-sunos*) VERSION_SCRIPT_FLAGS="-Wl,-M -Wl,";;
+-  esac
+-fi
+ AC_SUBST(VERSION_SCRIPT_FLAGS)
+ AM_CONDITIONAL([USE_VERSION_SCRIPT], [test -n "$VERSION_SCRIPT_FLAGS"])
+ 

--- a/mingw-w64-lua/PKGBUILD
+++ b/mingw-w64-lua/PKGBUILD
@@ -7,7 +7,7 @@ _realname=lua
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.4.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A powerful light-weight programming language designed for extending applications. (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -20,12 +20,14 @@ source=("${url}/ftp/lua-${pkgver}.tar.gz"
         '0001-When-running-Win32-version-of-luac-on-mintty-or-othe.patch'
         '0002-Add-Wl-out-implib-liblua.dll.a-to-AR.patch'
         '0003-Fix-LUA_-DIR-for-MSYS2-FHS-layout.patch'
+        'link-implib.patch'
         'LICENSE')
 sha256sums=('11570d97e9d7303c0a59567ed1ac7c648340cd0db10d5fd594c09223ef2f524f'
             'ca9252633e782b8f85d6a94ea4f6babd4fe30bd759085b373160b1878e36ff78'
             '9b3c36d1b4001b12306419cf93fa3f0309957865a8d589577838d35d747fb07c'
             'f5b754096ba8117e9e7dedb2e4ecf7b57ab2747e284c14cd51b2cb3353bee3e0'
             'bae70ef5c4a470527da6696351c9fb90284c6e5739fd2d12d408e5a135a3f1dd'
+            '046de390e803121bca31c9e63e0738cce228cec788cd88d5adcbc727f0f429f9'
             '142fb08b41a807b192b4b2c166696a1830a1c97967e5099ad0e579bf500e1da4')
 
 prepare() {
@@ -35,6 +37,7 @@ prepare() {
   patch -p1 -i "${srcdir}/0001-When-running-Win32-version-of-luac-on-mintty-or-othe.patch"
   patch -p1 -i "${srcdir}/0002-Add-Wl-out-implib-liblua.dll.a-to-AR.patch"
   patch -p1 -i "${srcdir}/0003-Fix-LUA_-DIR-for-MSYS2-FHS-layout.patch"
+  patch -p1 -i "${srcdir}/link-implib.patch"
 }
 
 build() {

--- a/mingw-w64-lua/link-implib.patch
+++ b/mingw-w64-lua/link-implib.patch
@@ -1,0 +1,32 @@
+--- lua-5.4.2/src/Makefile.orig	2021-03-14 15:42:23.960106400 -0700
++++ lua-5.4.2/src/Makefile	2021-03-14 15:45:16.163223400 -0700
+@@ -33,6 +33,7 @@
+ PLATS= guess aix bsd c89 freebsd generic linux linux-readline macosx mingw posix solaris
+ 
+ LUA_A=	liblua.a
++LUA_LA=	liblua.a
+ CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o ltm.o lundump.o lvm.o lzio.o iscygpty.o
+ LIB_O=	lauxlib.o lbaselib.o lcorolib.o ldblib.o liolib.o lmathlib.o loadlib.o loslib.o lstrlib.o ltablib.o lutf8lib.o linit.o
+ BASE_O= $(CORE_O) $(LIB_O) $(MYOBJS)
+@@ -61,10 +62,10 @@
+ 	$(RANLIB) $@
+ 
+ $(LUA_T): $(LUA_O) $(LUA_A)
+-	$(CC) -o $@ $(LDFLAGS) $(LUA_O) $(LUA_A) $(LIBS)
++	$(CC) -o $@ $(LDFLAGS) $(LUA_O) $(LUA_LA) $(LIBS)
+ 
+ $(LUAC_T): $(LUAC_O) $(LUA_A)
+-	$(CC) -o $@ $(LDFLAGS) $(LUAC_O) $(LUA_A) $(LIBS)
++	$(CC) -o $@ $(LDFLAGS) $(LUAC_O) $(LUA_LA) $(LIBS)
+ 
+ test:
+ 	./lua -v
+@@ -127,7 +128,7 @@
+ 	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_MACOSX -DLUA_USE_READLINE" SYSLIBS="-lreadline"
+ 
+ mingw:
+-	$(MAKE) "LUA_A=lua54.dll" "LUA_T=lua.exe" \
++	$(MAKE) "LUA_A=lua54.dll" "LUA_LA=liblua.dll.a" "LUA_T=lua.exe" \
+ 	"AR=$(CC) -shared -Wl,--out-implib,liblua.dll.a -o" "RANLIB=strip --strip-unneeded" \
+ 	"SYSCFLAGS=-DLUA_BUILD_AS_DLL" "SYSLIBS=" "SYSLDFLAGS=-s" lua.exe
+ 	$(MAKE) "LUAC_T=luac.exe" luac.exe

--- a/mingw-w64-mpdecimal/PKGBUILD
+++ b/mingw-w64-mpdecimal/PKGBUILD
@@ -4,7 +4,7 @@ _realname=mpdecimal
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.5.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Package for correctly-rounded arbitrary precision decimal floating point arithmetic (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -20,6 +20,7 @@ sha256sums=('15417edc8e12a57d1d9d75fa7e3f22b158a3b98f44db9d694cfd2acde8dfa0ca'
 prepare() {
   cd $srcdir/${_realname}-${pkgver}
   patch -Nbp1 -i ${srcdir}/mpdecimal-2.5.0-msys-mingw.patch
+  sed -i -e '/FLAGS_SHARED\s*=/ s/ -fPIC//' libmpdec{,++}/Makefile.in
   autoreconf -fiv
 }
 

--- a/mingw-w64-sqlite3/Makefile.ext.in
+++ b/mingw-w64-sqlite3/Makefile.ext.in
@@ -27,7 +27,7 @@ DLLS            = $(patsubst %.c,$(DLL_PREFIX)%$(DLL_SUFFIX).dll,$(notdir $(CSRC
 CC              = @CC@
 CPPFLAGS        = -I$(top_builddir) -I$(top_srcdir)/src
 CFLAGS          = -pedantic
-LIBS            = -Wl,--no-undefined -L$(top_builddir)/.libs -lsqlite3 -lz
+LIBS            = -L$(top_builddir)/.libs -lsqlite3 -lz
 
 .PHONY        : all
 all           : $(DLLS)

--- a/mingw-w64-sqlite3/PKGBUILD
+++ b/mingw-w64-sqlite3/PKGBUILD
@@ -9,7 +9,7 @@ _sqlite_year=2021
 _amalgamationver=3350400
 _docver=${_amalgamationver}
 pkgver=3.35.4
-pkgrel=1
+pkgrel=2
 pkgdesc="A C library that implements an SQL database engine (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -31,7 +31,7 @@ source=(https://www.sqlite.org/${_sqlite_year}/sqlite-src-${_amalgamationver}.zi
         LICENSE)
 sha256sums=('77007915a87ccc8a653d5f3d2d3a3cca89807641965c2a6e2958bea964ea02a4'
             'd001f9581d9858a37bf0f86007d6c103659ca9fc07414bbc965f94df43720c27'
-            '6e3994c2e10af6fdc70530778c674bfcf6df65a257dd10cfdfb4f34b399de004'
+            '047d1b173657dd19ad00c4bc398a8dd617836b1c2fa08864f5aaee9f781d4366'
             '5ca42f1f92abfb61bacc9ff60f5836cc56e2ce2af52264f918cb06c3d566d562'
             '0b76663a90e034f3d7f2af5bfada4cedec5ebc275361899eccc5c18e6f01ff1f')
 options=('!strip' 'staticlibs' '!buildflags')


### PR DESCRIPTION
- mpdecimal: remove `-fPIC`, unsupported on Windows. (I guess that's for clang, not lld.  Oops)  Fixes msys2/CLANG-packages#5
- sqlite3: remove `--no-undefined` linker option, which is unknown to lld on Windows (Windows doesn't allow undefined symbols in shared libraries)  Fixes msys2/CLANG-packages#10
- libxml2: patch out version script linker option, unsupported on Windows.  Fixes msys2/CLANG-packages#19
- lua: link to import library, lld does not support linking directly to a DLL.
- icu: remove `-Bsymbolic` linker flag, which lld on Windows does not accept.  It appears to be an ELF-specific option.  Fixes msys2/CLANG-packages#22