### PR TITLE
Tcl/tk arm64 support

### DIFF
--- a/mingw-w64-tcl/010-win-non-x86.patch
+++ b/mingw-w64-tcl/010-win-non-x86.patch
@@ -1,0 +1,29 @@
+--- tcl8.6.11/win/tclWin32Dll.c.orig	2021-01-20 12:26:59.444272100 -0800
++++ tcl8.6.11/win/tclWin32Dll.c	2021-01-20 12:29:33.443038200 -0800
+@@ -667,7 +667,7 @@
+     status = TCL_OK;
+ 
+ #elif defined(__GNUC__)
+-#   if defined(_WIN64)
++#   if defined(__x86_64__)
+     /*
+      * Execute the CPUID instruction with the given index, and store results
+      * off 'regPtr'.
+@@ -696,7 +696,7 @@
+ 	"%eax", "%ebx", "%ecx", "%edx", "%esi", "%edi", "memory");
+     status = TCL_OK;
+ 
+-#   else
++#   elif defined(__i386__)
+ 
+     TCLEXCEPTION_REGISTRATION registration;
+ 
+@@ -783,7 +783,7 @@
+ 
+ #   endif /* !_WIN64 */
+ #elif defined(_MSC_VER)
+-#   if defined(_WIN64)
++#   if defined(_M_X64)
+ 
+     __cpuid(regsPtr, index);
+     status = TCL_OK;

--- a/mingw-w64-tcl/011-win-arm64.patch
+++ b/mingw-w64-tcl/011-win-arm64.patch
@@ -1,0 +1,13 @@
+--- tcl8.6.11/win/tcl.m4.orig	2021-01-20 17:25:46.749753100 -0800
++++ tcl8.6.11/win/tcl.m4	2021-01-20 17:28:04.328075100 -0800
+@@ -758,6 +758,10 @@
+ 		MACHINE="AMD64" ; # assume AMD64 as default 64-bit build
+ 		AC_MSG_RESULT([   Using 64-bit $MACHINE mode])
+ 		;;
++	    arm64)
++		MACHINE="ARM64"
++		AC_MSG_RESULT([   Using 64-bit $MACHINE mode])
++		;;
+ 	    ia64)
+ 		MACHINE="IA64"
+ 		AC_MSG_RESULT([   Using 64-bit $MACHINE mode])

--- a/mingw-w64-tcl/PKGBUILD
+++ b/mingw-w64-tcl/PKGBUILD
@@ -5,7 +5,7 @@ _realname=tcl
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=8.6.11
-pkgrel=2
+pkgrel=3
 pkgdesc="The Tcl scripting language (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -22,7 +22,9 @@ source=("https://downloads.sourceforge.net/sourceforge/tcl/tcl${pkgver}-src.tar.
         005-no-xc.mingw.patch
         007-install.mingw.patch
         008-tcl-8.5.14-hidden.patch
-        009-fix-using-gnu-print.patch)
+        009-fix-using-gnu-print.patch
+        010-win-non-x86.patch
+        011-win-arm64.patch)
 
 sha256sums=('8c0486668586672c5693d7d95817cb05a18c5ecca2f40e2836b9578064088258'
             'cfcf9b3816f8bb063b514ac7f63a5ba73108f27e16fdf8e8312dc5f0683083f6'
@@ -31,7 +33,9 @@ sha256sums=('8c0486668586672c5693d7d95817cb05a18c5ecca2f40e2836b9578064088258'
             '2b0f41f6704aa964dbfafa0a65dd5ce0ab97e82ff5cbbe2a95a2e8d644cc5550'
             '61d3430f82ee60000eab28758eba9663a747b1e79082758cb59e624aead6c517'
             '3ec2702efb1be6873d6ffd2ffb357637588f835f8817ae65cf0373020fcc7359'
-            '894afd1d97c25a2f7b21981810026450d44677a46ba07a32c4025783d027c6d7')
+            '894afd1d97c25a2f7b21981810026450d44677a46ba07a32c4025783d027c6d7'
+            'b8156d191a3cf5a62678536bc9be4f026b9e3bef5c8dc0f9b78ab021fac89478'
+            '51dc29f822ad7af721d1dd6d13700856c21da30c70c9c2aa688f69a950965113')
 
 prepare() {
   cd "${srcdir}/tcl${pkgver}"
@@ -45,6 +49,8 @@ prepare() {
   # https://core.tcl-lang.org/tcl/tktview/c9759399735f1979a2e7931fd9f00da20f2fbb7e
   # is resolved:
   patch -Np1 -i "${srcdir}/009-fix-using-gnu-print.patch"
+  patch -Np1 -i "${srcdir}/010-win-non-x86.patch"
+  patch -Np1 -i "${srcdir}/011-win-arm64.patch"
 
   # Using the static libgcc library is problematic when sharing
   # resources across dynamic link libraries, so we must use
@@ -61,7 +67,8 @@ build() {
     extra_config="--enable-symbols"
   fi
   local enable64bit=
-  [[ "${MINGW_CHOST}" = "x86_64-w64-mingw32" ]] && enable64bit='--enable-64bit'
+  [[ "${MINGW_CHOST}" = "x86_64-w64-mingw32" ]] && enable64bit='--enable-64bit=amd64'
+  [[ "${MINGW_CHOST}" = "aarch64-w64-mingw32" ]] && enable64bit='--enable-64bit=arm64'
 
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
   mkdir -p ${srcdir}/build-${MINGW_CHOST}

--- a/mingw-w64-tk/010-win-non-x86.patch
+++ b/mingw-w64-tk/010-win-non-x86.patch
@@ -1,0 +1,29 @@
+--- tk8.6.11/win/tkWin32Dll.c.orig	2021-01-20 20:00:07.218455000 -0800
++++ tk8.6.11/win/tkWin32Dll.c	2021-01-20 20:02:10.905928500 -0800
+@@ -123,7 +123,7 @@
+ 	 */
+ 
+ #ifdef HAVE_NO_SEH
+-#   ifdef __WIN64
++#   ifdef __x86_64__
+ 	__asm__ __volatile__ (
+ 
+ 	    /*
+@@ -193,7 +193,7 @@
+ 	    "%rax", "%rbx", "%rcx", "%rdx", "%rsi", "%rdi", "memory"
+ 	);
+ 
+-#   else
++#   elif defined(__i386__)
+ 	__asm__ __volatile__ (
+ 
+ 	    /*
+@@ -264,6 +264,8 @@
+ 	    "%eax", "%ebx", "%ecx", "%edx", "%esi", "%edi", "memory"
+ 	);
+ 
++#   else
++	TkFinalize(NULL);
+ #   endif
+ #else /* HAVE_NO_SEH */
+ 	__try {

--- a/mingw-w64-tk/011-win-arm64.patch
+++ b/mingw-w64-tk/011-win-arm64.patch
@@ -1,0 +1,13 @@
+--- tcl8.6.11/win/tcl.m4.orig	2021-01-20 17:25:46.749753100 -0800
++++ tcl8.6.11/win/tcl.m4	2021-01-20 17:28:04.328075100 -0800
+@@ -758,6 +758,10 @@
+ 		MACHINE="AMD64" ; # assume AMD64 as default 64-bit build
+ 		AC_MSG_RESULT([   Using 64-bit $MACHINE mode])
+ 		;;
++	    arm64)
++		MACHINE="ARM64"
++		AC_MSG_RESULT([   Using 64-bit $MACHINE mode])
++		;;
+ 	    ia64)
+ 		MACHINE="IA64"
+ 		AC_MSG_RESULT([   Using 64-bit $MACHINE mode])

--- a/mingw-w64-tk/PKGBUILD
+++ b/mingw-w64-tk/PKGBUILD
@@ -7,7 +7,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _basever=8.6.11
 _patch=.1
 pkgver=${_basever}${_patch}
-pkgrel=1
+pkgrel=2
 pkgdesc="A windowing toolkit for use with tcl (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -20,12 +20,16 @@ source=("https://downloads.sourceforge.net/sourceforge/tcl/${_realname}${pkgver}
         003-fix-forbidden-colon-in-paths.mingw.patch
         004-install-man.mingw.patch
         006-prevent-tclStubsPtr-segfault.patch
-        008-dont-link-shared-with--static-libgcc.patch)
+        008-dont-link-shared-with--static-libgcc.patch
+        010-win-non-x86.patch
+        011-win-arm64.patch)
 sha256sums=('006cab171beeca6a968b6d617588538176f27be232a2b334a0e96173e89909be'
             '5347487af0e736dbb51425b22ed308840faf75b44c070623baa55f78dac3d053'
             '8516749dd73c084ece7b9df6d1ba5708e652e8ba39cad59120c7f909f61747f0'
             '0029fde6782ce7635e9957412d3e36a7e76d304399d57d64a42818f93e705621'
-            'a16406e8519ab681bba0915e35b23a7f91cf978934b0a4ebdc7e949e87f0c877')
+            'a16406e8519ab681bba0915e35b23a7f91cf978934b0a4ebdc7e949e87f0c877'
+            '2892e65d77b87c8336591d1fc10e35ad94ce73cf8c0a8f1968ec7b8bccce0b1a'
+            '51dc29f822ad7af721d1dd6d13700856c21da30c70c9c2aa688f69a950965113')
 
 prepare() {
   cd "${srcdir}/${_realname}${_basever}"
@@ -33,6 +37,8 @@ prepare() {
   patch -p1 -i "${srcdir}"/004-install-man.mingw.patch
   patch -p1 -i "${srcdir}"/006-prevent-tclStubsPtr-segfault.patch
   patch -p1 -i "${srcdir}"/008-dont-link-shared-with--static-libgcc.patch
+  patch -p1 -i "${srcdir}"/010-win-non-x86.patch
+  patch -p1 -i "${srcdir}"/011-win-arm64.patch
 
   cd win && autoreconf -fi
 }
@@ -44,6 +50,7 @@ build() {
   fi
   local enable64bit=
   [[ "${MINGW_CHOST}" = 'x86_64-w64-mingw32' ]] && enable64bit='--enable-64bit'
+  [[ "${MINGW_CHOST}" = 'aarch64-w64-mingw32' ]] && enable64bit='--enable-64bit=arm64'
 
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
   mkdir -p ${srcdir}/build-${MINGW_CHOST}


### PR DESCRIPTION
- tcl: only support `cpuid` on Windows on x86
- tk: only wrap `TkFinalize` call from DllMain in SEH on x86.  This may need to be revisited if crashes start showing up at dll unload, but I don't know how to do that.
- both: teach `configure` about ARM64.  Conveniently the identical patch applies to both.

Fixes msys2/CLANG-packages#20