### PR TITLE
python support for clang and arm64

### DIFF
--- a/mingw-w64-python-setuptools/0007-windows-arm64.patch
+++ b/mingw-w64-python-setuptools/0007-windows-arm64.patch
@@ -1,0 +1,14 @@
+--- setuptools-54.1.1/setuptools/command/easy_install.py.orig	2021-03-10 14:19:23.791845300 -0800
++++ setuptools-54.1.1/setuptools/command/easy_install.py	2021-03-10 14:22:46.433526300 -0800
+@@ -2263,7 +2263,10 @@
+     """
+     launcher_fn = '%s.exe' % type
+     if is_64bit():
+-        launcher_fn = launcher_fn.replace(".", "-64.")
++        if '(arm64)' in sys.version.lower():
++            launcher_fn = launcher_fn.replace(".", "-arm64.")
++        else:
++            launcher_fn = launcher_fn.replace(".", "-64.")
+     else:
+         launcher_fn = launcher_fn.replace(".", "-32.")
+     return resource_string('setuptools', launcher_fn)

--- a/mingw-w64-python-setuptools/PKGBUILD
+++ b/mingw-w64-python-setuptools/PKGBUILD
@@ -9,7 +9,7 @@ conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
            "${MINGW_PACKAGE_PREFIX}-python2-setuptools<42.0.2")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=56.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Easily download, build, install, upgrade, and uninstall Python packages (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -25,6 +25,7 @@ source=(${_realname}-${pkgver}.tar.gz::https://pypi.org/packages/source/${_realn
         '0003-MinGW-w64-Look-in-same-dir-as-script-for-exe.patch'
         '0005-execv-warning.patch'
         '0006-fix-tests-path.patch'
+        '0007-windows-arm64.patch'
 )
 checkdepends=(
   "${MINGW_PACKAGE_PREFIX}-python-pytest"
@@ -52,7 +53,8 @@ sha256sums=('08a1c0f99455307c48690f00d5c2ac2c1ccfab04df00454fef854ec145b81302'
             'fa54581e3dddb9f4edd332dedbc101f48939a9ca5878e13cf9cf9b3408bc8c22'
             '39503256652c7c23ce07e26539e8123d269eb5c09f5d9b07e5784b2d7fb8c96f'
             'a356b0663f67a296624d1b178b42437b380b48a4bbe05a560d3bf29e93a4c623'
-            'dbdd96a7ead797b2db9f02dfe19ce853d3775337ccf8fd836377fe3c2a9d1c24')
+            'dbdd96a7ead797b2db9f02dfe19ce853d3775337ccf8fd836377fe3c2a9d1c24'
+            'e6f9b6fc068a449c433150d936118114d50a71afb01b71291065d6a811d817e7')
 
 prepare() {
   cd "${srcdir}/setuptools-${pkgver}"
@@ -62,24 +64,34 @@ prepare() {
   patch -p1 -i ${srcdir}/0003-MinGW-w64-Look-in-same-dir-as-script-for-exe.patch
   patch -p1 -i ${srcdir}/0005-execv-warning.patch
   patch -p1 -i ${srcdir}/0006-fix-tests-path.patch
+  patch -p1 -i ${srcdir}/0007-windows-arm64.patch
 
-  rm setuptools/{gui,cli}{-32,-64,}.exe
+  rm -f setuptools/{gui,cli}{-32,-64,-arm64,}.exe
   local _gui_args="-DGUI=1 -mwindows -O2"
   local _cli_args="-DGUI=0 -O2"
   if check_option "strip" "y"; then
     _gui_args+=" -s"
     _cli_args+=" -s"
   fi
-  if [[ "${MINGW_CHOST}" == "i686-w64-mingw32" ]]; then
-    gcc $_cli_args -o setuptools/cli-32.exe launcher.c
-    gcc $_gui_args -o setuptools/gui-32.exe launcher.c
-    cp setuptools/cli-32.exe setuptools/cli.exe
-    cp setuptools/gui-32.exe setuptools/gui.exe
-  else
-    gcc $_cli_args -o setuptools/cli-64.exe launcher.c
-    gcc $_gui_args -o setuptools/gui-64.exe launcher.c
-  fi
-
+  case "${MINGW_CHOST}" in
+    i686-w64-mingw32)
+      gcc $_cli_args -o setuptools/cli-32.exe launcher.c
+      gcc $_gui_args -o setuptools/gui-32.exe launcher.c
+      cp setuptools/cli-32.exe setuptools/cli.exe
+      cp setuptools/gui-32.exe setuptools/gui.exe
+      ;;
+    x86_64-w64-mingw32)
+      gcc $_cli_args -o setuptools/cli-64.exe launcher.c
+      gcc $_gui_args -o setuptools/gui-64.exe launcher.c
+      ;;
+    aarch64-w64-mingw32)
+      gcc $_cli_args -o setuptools/cli-arm64.exe launcher.c
+      gcc $_gui_args -o setuptools/gui-arm64.exe launcher.c
+      ;;
+    *)
+      echo "Unsupported CHOST ${MINGW_CHOST}" && false
+      ;;
+  esac
 
   cd "${srcdir}"
   cp -r setuptools-${pkgver} setuptools-python-${CARCH}

--- a/mingw-w64-python/4000-clang-arm64.patch
+++ b/mingw-w64-python/4000-clang-arm64.patch
@@ -1,0 +1,46 @@
+--- Python-3.8.7/Python/getcompiler.c.orig	2021-01-21 00:00:29.237009400 -0800
++++ Python-3.8.7/Python/getcompiler.c	2021-01-21 00:08:07.812256200 -0800
+@@ -7,7 +7,7 @@
+ 
+ // Note the __clang__ conditional has to come before the __GNUC__ one because
+ // clang pretends to be GCC.
+-#if defined(__clang__)
++#if defined(__clang__) && !defined(_WIN32)
+ #define COMPILER "\n[Clang " __clang_version__ "]"
+ #elif defined(__GNUC__)
+ /* To not break compatibility with things that determine
+@@ -18,6 +18,8 @@
+ #define COMP_SEP " "
+ #if defined(__x86_64__)
+ #define ARCH_SUFFIX " 64 bit (AMD64)"
++#elif defined(__aarch64__)
++#define ARCH_SUFFIX " 64 bit (ARM64)"
+ #else
+ #define ARCH_SUFFIX " 32 bit"
+ #endif
+@@ -25,7 +27,14 @@
+ #define COMP_SEP "\n"
+ #define ARCH_SUFFIX ""
+ #endif
++#if defined(__clang__)
++#define str(x) #x
++#define xstr(x) str(x)
++#define COMPILER COMP_SEP "[GCC Clang " xstr(__clang_major__) "." \
++        xstr(__clang_minor__) "." xstr(__clang_patchlevel__) ARCH_SUFFIX "]"
++#else
+ #define COMPILER COMP_SEP "[GCC " __VERSION__ ARCH_SUFFIX "]"
++#endif
+ // Generic fallbacks.
+ #elif defined(__cplusplus)
+ #define COMPILER "[C++]"
+--- Python-3.8.7/Lib/distutils/cygwinccompiler.py~	2021-01-21 00:32:02.844891200 -0800
++++ Python-3.8.7/Lib/distutils/cygwinccompiler.py	2021-01-21 10:58:17.540398500 -0800
+@@ -396,7 +396,7 @@
+         return (CONFIG_H_UNCERTAIN,
+                 "couldn't read '%s': %s" % (fn, exc.strerror))
+ 
+-RE_VERSION = re.compile(br'[\D\s]*(\d+\.\d+(\.\d+)*)[\D\s]*$')
++RE_VERSION = re.compile(br'[\D\s]*(\d+\.\d+(\.\d+)*)[\D\s]*')
+ 
+ def _find_exe_version(cmd):
+     """Find the version of an executable by running `cmd` in the shell.

--- a/mingw-w64-python/PKGBUILD
+++ b/mingw-w64-python/PKGBUILD
@@ -18,7 +18,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 _pybasever=3.8
 pkgver=${_pybasever}.9
-pkgrel=1
+pkgrel=2
 provides=("${MINGW_PACKAGE_PREFIX}-python3=${pkgver}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3"
            "${MINGW_PACKAGE_PREFIX}-python2<2.7.16-7")
@@ -135,6 +135,7 @@ source=("https://www.python.org/ftp/python/${pkgver%rc?}/Python-${pkgver}.tar.xz
         3001-pathlib-path-sep.patch
         3011-fix-build-testinternalcapi.patch
         3020-extend-MS_WINDOWS-flag.patch
+        4000-clang-arm64.patch
         5000-warnings-fixes.patch
         smoketests.py)
 
@@ -302,6 +303,9 @@ prepare() {
   apply_patch_with_msg 3011-fix-build-testinternalcapi.patch
 
   apply_patch_with_msg 3020-extend-MS_WINDOWS-flag.patch
+
+  apply_patch_with_msg 4000-clang-arm64.patch
+
   autoreconf -vfi
 }
 
@@ -318,6 +322,10 @@ check() {
 
 build() {
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then
+    export CC=clang CXX=clang++
+  fi
 
   CFLAGS+=" -fwrapv -D__USE_MINGW_ANSI_STDIO=1 -D_WIN32_WINNT=0x0601"
   CXXFLAGS+=" -fwrapv -D__USE_MINGW_ANSI_STDIO=1 -D_WIN32_WINNT=0x0601"
@@ -350,9 +358,6 @@ build() {
   export ac_cv_have_decl_RTLD_MEMBER=no
   export ac_cv_have_decl_RTLD_NODELETE=no
   export ac_cv_have_decl_RTLD_NOLOAD=no
-
-  # mktime with mingw-w64+ucrt is just an inline function
-  export ac_cv_func_mktime=yes
 
   [[ -d "${srcdir}/build-${CARCH}" ]] && rm -rf "${srcdir}/build-${CARCH}"
   mkdir -p "${srcdir}/build-${CARCH}" && cd "${srcdir}/build-${CARCH}"
@@ -550,5 +555,6 @@ sha256sums=('5e391f3ec45da2954419cab0beaefd8be38895ea5ce33577c3ec14940c4b9572'
             '6efc39323d14239f2a55576a8b3f32cb79eeefdd5881ba813493c14be2939f3c'
             '005381222cfef42ccc21151845b6d43d25c861f35c2192e5e23c2a14df7938f0'
             'b6b3f8f2c809dc7ef43bc26306516edf4a5d1e038343ad8c7a45f666011c2e8b'
+            '717167e9ca5563e04103871a3e489dd1cef77a83c5c6d20e7bda6dced7f3fc42'
             '24151631c3e70306ae92ffb8fea38992a752cd0a76771a5e53445f56c2be1f00'
             '7188e017a1efba4a87cb64a38b63ed2d8a469e2e74c3fd35b6538d5bc6e370e5')


### PR DESCRIPTION
Many places check for the string 'GCC' in sys.version to identify a 'posix' build, so make Clang masquerade as GCC.  Also, Clang's __VERSION__ string is very long (including the git repo and commit hash), which caused python to truncate sys.version so that the `64-bit (AMD64)` or `(ARM64)` was missing.  Add some preprocessor hackery to generate a simple 3 part version number.

Speaking of `(ARM64)` tag, teach python-setuptools to recognize that and provide -arm64 variants of the launcher exes.

Remove anchor from regex for extracting version number from -v/--version output.  The presence of a git commit hash in LLD's ld -v output was confusing it.  This doesn't seem entirely safe, but solves the immediate problem.

set CC to clang on clang prefix, to enable python's configure tests to enable its already existing support for PGO/LTO.

Remove mktime workaround now that mingw-w64 exports that symbol.

Fixes msys2/CLANG-packages#14