### PR TITLE
Use gcc/clang builtins/instrinsics

### DIFF
--- a/mingw-w64-jemalloc/003-mingw-non-x86.patch
+++ b/mingw-w64-jemalloc/003-mingw-non-x86.patch
@@ -1,0 +1,11 @@
+--- jemalloc-5.2.1/include/jemalloc/internal/bit_util.h.orig	2021-01-18 13:05:31.228770900 -0800
++++ jemalloc-5.2.1/include/jemalloc/internal/bit_util.h	2021-01-18 13:06:52.228991500 -0800
+@@ -188,6 +188,8 @@
+ 	return ((8 << LG_SIZEOF_PTR) - 1) - __builtin_clz(x);
+ #elif (LG_SIZEOF_PTR == LG_SIZEOF_LONG)
+ 	return ((8 << LG_SIZEOF_PTR) - 1) - __builtin_clzl(x);
++#elif (LG_SIZEOF_PTR == LG_SIZEOF_LONG_LONG)
++	return ((8 << LG_SIZEOF_PTR) - 1) - __builtin_clzll(x);
+ #else
+ #  error "Unsupported type size for lg_floor()"
+ #endif

--- a/mingw-w64-jemalloc/PKGBUILD
+++ b/mingw-w64-jemalloc/PKGBUILD
@@ -4,7 +4,7 @@ _realname=jemalloc
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=5.2.1
-pkgrel=1
+pkgrel=2
 pkgdesc="General-purpose scalable concurrent malloc implementation (mingw64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -15,15 +15,18 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-docbook-xsl")
 options=(strip staticlibs !debug)
 source=("https://github.com/jemalloc/jemalloc/releases/download/${pkgver}/${_realname}-${pkgver}.tar.bz2"
         001-fix-library-extension.patch
-        002-makefile.patch)
+        002-makefile.patch
+        003-mingw-non-x86.patch)
 sha256sums=('34330e5ce276099e2e8950d9335db5a875689a4c6a56751ef3b1d8c537f887f6'
             '74569f3e709855f53b83212efa7641b1b4b4f84442ba8c0729813bc214f18230'
-            '2d92c7e273a25e4a2f12927a3418c4ff8744962eb941f838e35f94bee46ec841')
+            '2d92c7e273a25e4a2f12927a3418c4ff8744962eb941f838e35f94bee46ec841'
+            '4e04db45cd7f0e06d8d7e35fb43d878050a329c97fe17d472c1ecebe8c24c56d')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/001-fix-library-extension.patch
   patch -p1 -i ${srcdir}/002-makefile.patch
+  patch -p1 -i ${srcdir}/003-mingw-non-x86.patch
 }
 
 build() {

--- a/mingw-w64-libuv/PKGBUILD
+++ b/mingw-w64-libuv/PKGBUILD
@@ -5,7 +5,7 @@ _realname=libuv
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.40.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Cross-platform asynchronous I/O (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -14,11 +14,14 @@ license=("custom")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 options=('staticlibs' 'strip')
-source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/libuv/libuv/archive/v${pkgver}.tar.gz")
-sha256sums=('70fe1c9ba4f2c509e8166c0ca2351000237da573bb6c82092339207a9715ba6b')
+source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/libuv/libuv/archive/v${pkgver}.tar.gz"
+        "libuv-win-atomics-non-x86.patch")
+sha256sums=('70fe1c9ba4f2c509e8166c0ca2351000237da573bb6c82092339207a9715ba6b'
+            'cfdc72694fb8578499eece9cf51102b8cc140d2ab07cd77c1a371b950d2add95')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
+  patch -Np1 -i ../libuv-win-atomics-non-x86.patch
  ./autogen.sh
 }
 

--- a/mingw-w64-libuv/libuv-win-atomics-non-x86.patch
+++ b/mingw-w64-libuv/libuv-win-atomics-non-x86.patch
@@ -1,0 +1,26 @@
+--- libuv-1.40.0/src/win/atomicops-inl.h.orig	2021-01-12 14:43:58.259375600 -0800
++++ libuv-1.40.0/src/win/atomicops-inl.h	2021-01-12 14:49:35.587505100 -0800
+@@ -41,6 +41,8 @@
+ 
+ #else /* GCC */
+ 
++#if defined(__i386__) || defined(__x86_64__)
++
+ /* Mingw-32 version, hopefully this works for 64-bit gcc as well. */
+ static inline char uv__atomic_exchange_set(char volatile* target) {
+   const char one = 1;
+@@ -52,6 +54,14 @@
+   return old_value;
+ }
+ 
++#else
++
++static inline char uv__atomic_exchange_set(char volatile* target) {
++  return __atomic_exchange_n(target, 1, __ATOMIC_SEQ_CST);
++}
++
++#endif
++
+ #endif
+ 
+ #endif /* UV_WIN_ATOMICOPS_INL_H_ */

--- a/mingw-w64-python-cffi/PKGBUILD
+++ b/mingw-w64-python-cffi/PKGBUILD
@@ -7,7 +7,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=1.14.5
-pkgrel=1
+pkgrel=2
 pkgdesc="Foreign Function Interface for Python calling C code (mingw-w64)"
 url='https://cffi.readthedocs.io/'
 license=('MIT')
@@ -17,12 +17,16 @@ depends=("${MINGW_PACKAGE_PREFIX}-libffi"
          "${MINGW_PACKAGE_PREFIX}-python-pycparser")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest-runner")
-source=("https://foss.heptapod.net/pypy/cffi/-/archive/v${pkgver}/${_realname}-v${pkgver}.tar.bz2")
-sha256sums=('d99690c6fe2efa7b60d0abb3ea6f30fd544d15ee01909328ea2d1991939d4162')
+source=("https://foss.heptapod.net/pypy/cffi/-/archive/v${pkgver}/${_realname}-v${pkgver}.tar.bz2"
+        "mingw-non-x86.patch")
+sha256sums=('d99690c6fe2efa7b60d0abb3ea6f30fd544d15ee01909328ea2d1991939d4162'
+            'c8a8ea2d65932ea0b62eae56dbc8afd6baacaadc7cb284ca0e4edf7ed1460c52')
 
 prepare() {
   cd "${srcdir}"
   cp -r "${_realname}-v${pkgver}" "python-build-${CARCH}"
+  cd "python-build-${CARCH}"
+  patch -Np1 -i "${srcdir}"/mingw-non-x86.patch
 }
 
 build() {

--- a/mingw-w64-python-cffi/mingw-non-x86.patch
+++ b/mingw-w64-python-cffi/mingw-non-x86.patch
@@ -1,0 +1,11 @@
+--- cffi-v1.14.4/setup.py.orig	2021-01-22 18:37:13.453727900 -0800
++++ cffi-v1.14.4/setup.py	2021-01-22 18:38:01.125798300 -0800
+@@ -90,7 +89,7 @@
+             _safe_to_ignore()
+ 
+ def ask_supports_sync_synchronize():
+-    if sys.platform == 'win32' or no_compiler_found:
++    if no_compiler_found:
+         return
+     config = get_config()
+     ok = config.try_link('int main(void) { __sync_synchronize(); return 0; }')

--- a/mingw-w64-z3/005-fix-clang.patch
+++ b/mingw-w64-z3/005-fix-clang.patch
@@ -1,0 +1,11 @@
+--- z3-z3-4.8.9/src/util/hwf.cpp.orig	2021-02-04 20:15:45.155087700 -0800
++++ z3-z3-4.8.9/src/util/hwf.cpp	2021-02-04 20:16:28.030101000 -0800
+@@ -48,7 +48,7 @@
+ // clear to the compiler what instructions should be used. E.g., for sqrt(), the Windows compiler selects
+ // the x87 FPU, even when /arch:SSE2 is on.
+ // Luckily, these are kind of standardized, at least for Windows/Linux/macOS.
+-#if defined(__clang__) || defined(_M_ARM) && defined(_M_ARM64)
++#if defined(_M_ARM) && defined(_M_ARM64)
+ #undef USE_INTRINSICS
+ #endif
+ 

--- a/mingw-w64-z3/PKGBUILD
+++ b/mingw-w64-z3/PKGBUILD
@@ -4,7 +4,7 @@ _realname=z3
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=4.8.9
-pkgrel=1
+pkgrel=2
 pkgdesc="Z3 is a high-performance theorem prover being developed at Microsoft Research (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -16,11 +16,13 @@ options=('strip' 'staticlibs')
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/Z3Prover/z3/archive/z3-${pkgver}.tar.gz"
         001-mingw-fixes.patch
         003-fix-dll-exports.patch
-        004-fix-python-bindings-install.patch)
+        004-fix-python-bindings-install.patch
+        005-fix-clang.patch)
 sha256sums=('c9fd04b9b33be74fffaac3ec2bc2c320d1a4cc32e395203c55126b12a14ff3f4'
             '78554202e1071d5686aed96336ad1020d6249f6d9080c2a7862cb7f72b51379c'
             'ce01668afae8e60c32a0d7937d3f8f67a7dc23aa4270913d157e676d061dfe6a'
-            '7c73e0b6afac99948ca383a709668ae753b8034139332503c8f2d0e310382ac6')
+            '7c73e0b6afac99948ca383a709668ae753b8034139332503c8f2d0e310382ac6'
+            '51c2d1071845efbe29e2b38124d7ce7ef210e8441294cd2d53df65348874118a')
 
 apply_patch_with_msg() {
   for _fname in "$@"
@@ -35,7 +37,8 @@ prepare() {
   apply_patch_with_msg \
     001-mingw-fixes.patch \
     003-fix-dll-exports.patch \
-    004-fix-python-bindings-install.patch
+    004-fix-python-bindings-install.patch \
+    005-fix-clang.patch
 }
 
 build() {


### PR DESCRIPTION
- libuv: on Windows non-x86, use a gcc/clang atomic builtin instead of inline assembly.  Fixes msys2/CLANG-packages#16
- jemalloc: extend gcc/clang builtin options for LLP64 model.  Fixes msys2/CLANG-packages#18
- python-cffi: has a `__sync_synchronize` barrier, which is disabled on i386, x86_64 or WIN32.  ARM has a different memory model than x86, so remove the WIN32 exception and allow `__sync_synchronize` except on i386 or x86_64 (if it compiles).
- z3: some issue on Mac with XCode 5 caused them to disable intrinsics on clang.  They seem to be fine on Windows, and even required on i686, so remove the `__clang__` check.  Fixes msys2/CLANG-packages#27