### PR TITLE
github cli v1.9.1

### DIFF
--- a/mingw-w64-github-cli/PKGBUILD
+++ b/mingw-w64-github-cli/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=github-cli
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.9.0
+pkgver=1.9.1
 pkgrel=1
 pkgdesc='The GitHub CLI (mingw-w64)'
 arch=('any')
@@ -17,7 +17,7 @@ optdepends=("git: To interact with repositories")
 options=('!strip')
 source=("$_realname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz"
         "gh")
-sha256sums=('662654baa32550527b97faf38c34254bafe9b7889dc65451cbec3d6dacee2a06'
+sha256sums=('5fd35b156a0528ad4e8b68c7058fccf340cca08b0cabd36d872ab855476fb02e'
             '9ee5f2b44b7e9aa751508f02c1020e341e0212a9aa146b7428eb5ffea310be27')
 build() {
     cd "cli-$pkgver"


### PR DESCRIPTION
That was fast. The .0 version came out only yesterday...

And we may want to wait a couple of days, as [v1.9.2 might be needed soon, too](https://github.com/cli/cli/issues/3431).

[EDIT] @lazka [suggested](https://github.com/msys2/MINGW-packages/pull/8376#issuecomment-820988630) that it's not a burden to have a quick release cadence, so I'll mark this as ready to review.