### PR TITLE
ripgrep: add ripgrep

### DIFF
--- a/mingw-w64-ripgrep/PKGBUILD
+++ b/mingw-w64-ripgrep/PKGBUILD
@@ -1,0 +1,56 @@
+# Maintainer: Christopher Degawa <ccom@randomderp.com>
+
+_realname=ripgrep
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=12.1.1
+pkgrel=1
+pkgdesc='line-oriented search tool that recursively searches your current directory for a regex pattern (mingw-w64)'
+arch=(any)
+mingw_arch=(mingw32 mingw64 ucrt64)
+url=https://github.com/BurntSushi/$_realname
+license=(MIT custom:UNLICENSE)
+depends=()
+makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
+             git)
+source=("${_realname}-${pkgver}::git+https://github.com/BurntSushi/ripgrep.git#tag=12.1.1?signed")
+sha256sums=(SKIP)
+validpgpkeys=(2D8111E141151C072EE9AB9DB2E3A4923F8B0D44) # Andrew Gallant (aka burntsushi)
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}" || return 1
+
+  cargo fetch \
+    --locked
+}
+
+
+build() {
+    cd "${srcdir}/${_realname}-${pkgver}" || return 1
+
+  cargo build \
+    --release \
+    --frozen \
+    --offline
+}
+
+check() {
+  cd "${srcdir}/${_realname}-${pkgver}" || return 1
+
+  cargo test \
+    --release \
+    --frozen
+}
+
+package() {
+  cd "${srcdir}/${_realname}-${pkgver}" || return 1
+
+  cargo install \
+    --frozen \
+    --offline \
+    --no-track \
+    --path . \
+    --root "${pkgdir}${MINGW_PREFIX}"
+
+  install -Dm644 COPYING LICENSE-MIT UNLICENSE -t "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/"
+}


### PR DESCRIPTION
Uses git tag because tar fails with symlinks