### PR TITLE
freeimage: ucrt fixes

### DIFF
--- a/mingw-w64-freeimage/FreeImage-3.17.0_mingw-makefiles.patch
+++ b/mingw-w64-freeimage/FreeImage-3.17.0_mingw-makefiles.patch
@@ -115,7 +115,7 @@ diff -rupN FreeImage/Makefile.gnu FreeImage-new/Makefile.gnu
 -ifeq ($(shell sh -c 'uname -m 2>/dev/null || echo not'),x86_64)
 -	override CFLAGS += -fPIC
 -endif
-+override CFLAGS += $(INCLUDE) -D__ANSI__ -DFREEIMAGE_EXPORTS -I/mingw32/include/jxrlib -I/mingw64/include/jxrlib $(shell ${PKGCONFIG} --cflags OpenEXR libopenjp2 libraw libpng libtiff-4 libwebp libwebpmux zlib)
++override CFLAGS += $(INCLUDE) -D__ANSI__ -DFREEIMAGE_EXPORTS -I$(shell ${PKGCONFIG} --variable pc_system_includedirs pkg-config)/jxrlib $(shell ${PKGCONFIG} --cflags OpenEXR libopenjp2 libraw libpng libtiff-4 libwebp libwebpmux zlib)
 +override LDFLAGS += -ljpeg -ljpegxr -ljxrglue $(shell ${PKGCONFIG} --libs OpenEXR libopenjp2 libraw libpng libtiff-4 libwebp libwebpmux zlib)
  
  TARGET  = freeimage

--- a/mingw-w64-freeimage/PKGBUILD
+++ b/mingw-w64-freeimage/PKGBUILD
@@ -7,7 +7,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=3.18.0
-pkgrel=5
+pkgrel=6
 pkgdesc="Library project for developers who would like to support popular graphics image formats (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -32,7 +32,7 @@ source=("https://downloads.sourceforge.net/sourceforge/freeimage/${_realname}${p
         'FreeImage-3.18.0_unbundle.patch'
         'freeimage-libraw-0.20.patch')
 sha256sums=('f41379682f9ada94ea7b34fe86bf9ee00935a3147be41b6569c9605a53e438fd'
-            'df3845a61b45fdb0426c4466e48e2478e63effb721cb0b1f2521952390c57290'
+            'c68da81f38e122943c3c1f0d42b67766a326a7dcfa99fe523ac2fc74e6cec965'
             '029960951b743bbf78557d78cd3ac5c417146b169f65aaf9fc2c7a914a87611b'
             '71c25974c25dfced11b08206aae6e759675b53bae061be5f34fa1107beec9233')
 


### PR DESCRIPTION
don't hardcode the include prefix