### PR TITLE
prjtrellis: switch from gcc to clang

### DIFF
--- a/mingw-w64-prjtrellis/PKGBUILD
+++ b/mingw-w64-prjtrellis/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=prjtrellis
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.0.r993.7454564
-pkgrel=2
+pkgver=1.0.r995.da82093
+pkgrel=1
 pkgdesc="Documenting the Lattice ECP5 bit-stream format (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-boost"
              "${MINGW_PACKAGE_PREFIX}-clang"
              "git")
 
-_commit="7454564f"
+_commit="da820937"
 source=("${_realname}::git://github.com/YosysHQ/${_realname}.git#commit=${_commit}"
         "prjtrellis-db::git://github.com/YosysHQ/prjtrellis-db")
 sha256sums=('SKIP'

--- a/mingw-w64-prjtrellis/PKGBUILD
+++ b/mingw-w64-prjtrellis/PKGBUILD
@@ -4,7 +4,7 @@ _realname=prjtrellis
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.0.r993.7454564
-pkgrel=1
+pkgrel=2
 pkgdesc="Documenting the Lattice ECP5 bit-stream format (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -15,7 +15,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-boost"
          "${MINGW_PACKAGE_PREFIX}-python")
 makedepends=("${MINGW_PACKAGE_PREFIX}-boost"
              "${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-clang"
              "git")
 
 _commit="7454564f"
@@ -38,8 +38,17 @@ prepare () {
 
 build() {
   cd "${srcdir}/${_realname}"/libtrellis
-  MSYS2_ARG_CONV_EXCL=- cmake \
+
+  case "${CARCH}" in
+    i686)
+      sed -s 's|__GNUC__|__clang__|g' -i /mingw32/i686-w64-mingw32/include/intrin.h
+    ;;
+  esac
+
+  MSYS2_ARG_CONV_EXCL='-DCMAKE_INSTALL_PREFIX=' cmake \
     -G "MSYS Makefiles" \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
     -DCMAKE_PREFIX_PATH=${MINGW_PREFIX} \
     -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
     .


### PR DESCRIPTION
In this PR, prjtrellis is built with clang, instead of using gcc. By the way, it's updated.