### PR TITLE
argtable: fix build

### DIFF
--- a/mingw-w64-argtable/PKGBUILD
+++ b/mingw-w64-argtable/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.13
 intver=${pkgver//./-}
-pkgrel=1
+pkgrel=2
 pkgdesc="ANSI C library for parsing GNU-style command-line options (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -16,6 +16,11 @@ sha256sums=('8f77e8a7ced5301af6e22f47302fdbc3b1ff41f2b83c43c77ae5ca041771ddbf')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 
 options=('staticlibs' 'strip')
+
+prepare() {
+  cd "${srcdir}"/${_realname}${intver}
+  sed -i.bak 's/EOVERFLOW/MYEOVERFLOW/g' src/arg_int.c
+}
 
 build() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}


### PR DESCRIPTION
This package defines an internal enum to `EOVERFLOW` which already exists. Simply renaming it fixes the build.