### PR TITLE
boost: detect windows-gnu as mingw

### DIFF
--- a/mingw-w64-boost/PKGBUILD
+++ b/mingw-w64-boost/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.75.0
 _boostver=${pkgver//./_}
-pkgrel=3
+pkgrel=4
 pkgdesc="Free peer-reviewed portable C++ source libraries (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -38,6 +38,7 @@ source=(#https://downloads.sourceforge.net/sourceforge/boost/boost_${_boostver}.
         boost-1.73.0-fix-locale-icu.patch
         boost-1.74-mingw-32bit-enable-tls.patch
         boost-1.75-dont-set-msvcrt-version.patch
+        boost-1.75-mingw-clang.patch
         using-mingw-w64-python.patch
         msys2-mingw-folders-bootstrap.patch)
 sha256sums=('953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb'
@@ -56,6 +57,7 @@ sha256sums=('953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb'
             '5ef2b1011dc960b7f55d4da89bcd75418eb696dce677b9fd0c78632f4109e7d3'
             '15f25653ec71e061cbd3a611a969541c57ea70c1fe95cb0de11f22cc68c7670f'
             'edc8cb076afe5132f2e5a1393e6e65ef3a8740384f36b7b9aa065d53b1182292'
+            '876c64687e4e1c700b5c64971e4cf62792e869b471b8d63cbb721fc057fc612f'
             '0dd6346d369850aad13bf8d9bc2f0abc16d4b0586e34d61fab11f65d3d7fa9d4'
             '5117629ee577de0da800b6923675683ba69422cdbe958e70c9081fdc6886402e')
 
@@ -128,6 +130,9 @@ prepare() {
   # https://github.com/boostorg/log/pull/149
   msg2 "boost-1.75-dont-set-msvcrt-version.patch"
   patch -p1 -i ${srcdir}/boost-1.75-dont-set-msvcrt-version.patch
+
+  msg2 "boost-1.75-mingw-clang.patch"
+  patch -p1 -i ${srcdir}/boost-1.75-mingw-clang.patch
 }
 
 build() {
@@ -147,10 +152,10 @@ build() {
   ./bootstrap.sh --with-icu=${MINGW_PREFIX} --with-python=${MINGW_PREFIX} --with-toolset=gcc
 
   case ${CARCH} in
-    i686)
+    i686|armv7)
       local _model=32
     ;;
-    x86_64)
+    x86_64|aarch64)
       local _model=64
     ;;
   esac
@@ -199,10 +204,10 @@ build() {
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   case ${CARCH} in
-    i686)
+    i686|armv7)
       local _model=32
     ;;
-    x86_64)
+    x86_64|aarch64)
       local _model=64
     ;;
   esac

--- a/mingw-w64-boost/boost-1.75-mingw-clang.patch
+++ b/mingw-w64-boost/boost-1.75-mingw-clang.patch
@@ -1,0 +1,11 @@
+--- boost_1_75_0/tools/build/src/engine/build.sh.orig	2021-01-31 23:59:07.083918500 -0800
++++ boost_1_75_0/tools/build/src/engine/build.sh	2021-01-31 23:59:52.849850400 -0800
+@@ -221,7 +221,7 @@
+             exit 1
+         fi
+         case $machine in
+-        *mingw*)
++        *mingw*|*windows-gnu*)
+         # MinGW insists that its bin directory be in PATH.
+         if test -r ${B2_TOOLSET_ROOT}bin/gcc ; then
+             export PATH=${B2_TOOLSET_ROOT}bin:$PATH


### PR DESCRIPTION
tools/build/engine/build.sh uses `gcc -dumpmachine` to determine the
CHOST, but clang reports <arch>-w64-windows-gnu not <arch>-w64-mingw32
like gcc.

Fixes msys2/CLANG-packages#24
