### PR TITLE
liblastfm: add proper suffix for the Qt5 version as done in Arch

### DIFF
--- a/mingw-w64-liblastfm/PKGBUILD
+++ b/mingw-w64-liblastfm/PKGBUILD
@@ -5,7 +5,7 @@ _realname=liblastfm
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.0.9
-pkgrel=2
+pkgrel=3
 pkgdesc="A Qt C++ library for the Last.fm webservices https://www.last.fm"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -18,13 +18,16 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake")
 options=(!strip staticlibs !buildflags)
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/lastfm/liblastfm/archive/${pkgver}.tar.gz"
+        liblastfm-include-suffix.patch::"https://github.com/lastfm/liblastfm/commit/480e2ec6.patch"
         versioned-dlls-mingw.patch)
 sha256sums=('5276b5fe00932479ce6fe370ba3213f3ab842d70a7d55e4bead6e26738425f7b'
-            '8a19f0a53277be5929411f3f247bc5d2c380c32b170ba0d0824bce9b7f7b7fa7')
+            'b66614b9508a615e709063074286e7cf6758dd13ab2eea9b2e02897ecba88890'
+            '27b2ebcd93744694768051c4b2e0fd5f351337de5d691acccdad53009b5791e5')
 
 prepare() {
     cd ${srcdir}/${_realname}-${pkgver}
     patch -p0 -i ${srcdir}/versioned-dlls-mingw.patch
+    patch -p1 -i ../liblastfm-include-suffix.patch # add suffix to Qt5 include dir
 }
 
 build() {

--- a/mingw-w64-liblastfm/versioned-dlls-mingw.patch
+++ b/mingw-w64-liblastfm/versioned-dlls-mingw.patch
@@ -4,9 +4,9 @@
      VERSION ${LASTFM_VERSION_STRING}
      SOVERSION ${LASTFM_SOVERSION}
      COMPILE_DEFINITIONS LASTFM_LIB
-+    OUTPUT_NAME lastfm
-+    RUNTIME_OUTPUT_NAME lastfm-${LASTFM_SOVERSION}
-+    ARCHIVE_OUTPUT_NAME lastfm
++    OUTPUT_NAME lastfm5
++    RUNTIME_OUTPUT_NAME lastfm5-${LASTFM_SOVERSION}
++    ARCHIVE_OUTPUT_NAME lastfm5
  )
  
  install(TARGETS lastfm
@@ -17,9 +17,9 @@
      COMPILE_DEFINITIONS LASTFM_FINGERPRINT_LIB
      VERSION ${LASTFM_VERSION_STRING}
      SOVERSION ${LASTFM_SOVERSION}
-+    OUTPUT_NAME lastfm_fingerprint
-+    RUNTIME_OUTPUT_NAME lastfm_fingerprint-${LASTFM_SOVERSION}
-+    ARCHIVE_OUTPUT_NAME lastfm_fingerprint
++    OUTPUT_NAME lastfm_fingerprint5
++    RUNTIME_OUTPUT_NAME lastfm_fingerprint5-${LASTFM_SOVERSION}
++    ARCHIVE_OUTPUT_NAME lastfm_fingerprint5
  )
  
  qt5_use_modules(lastfm_fingerprint Network Sql Xml) 


### PR DESCRIPTION
The include dir and the library name should have a '5' suffix, see https://archlinux.org/packages/extra/x86_64/liblastfm-qt5/

This is what other software expect, i.e. Clementine player:
https://github.com/clementine-player/Clementine/blob/8258c78c0b930e2c227c35075b6ad4b2ac615f17/CMakeLists.txt#L84