### PR TITLE
ffmpeg: Update to 4.4

### DIFF
--- a/mingw-w64-ffmpeg/PKGBUILD
+++ b/mingw-w64-ffmpeg/PKGBUILD
@@ -6,8 +6,8 @@
 _realname=ffmpeg
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.3.2
-pkgrel=3
+pkgver=4.4
+pkgrel=1
 pkgdesc="Complete and free Internet live audio and video broadcasting solution (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -44,7 +44,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-aom"
          "${MINGW_PACKAGE_PREFIX}-speex"
          "${MINGW_PACKAGE_PREFIX}-srt"
          "${MINGW_PACKAGE_PREFIX}-vulkan"
-         "${MINGW_PACKAGE_PREFIX}-wavpack"
          "${MINGW_PACKAGE_PREFIX}-x264"
          "${MINGW_PACKAGE_PREFIX}-x265"
          "${MINGW_PACKAGE_PREFIX}-xvidcore"
@@ -56,7 +55,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-dlfcn"
 source=(https://ffmpeg.org/releases/${_realname}-${pkgver}.tar.xz{,.asc}
         "0005-Win32-Add-path-relocation-to-frei0r-plugins-search.patch")
 validpgpkeys=('FCF986EA15E6E293A5644F10B4322F04D67658D8')
-sha256sums=('46e4e64f1dd0233cbc0934b9f1c0da676008cad34725113fb7f802cfa84ccddb'
+sha256sums=('06b10a183ce5371f915c6bb15b7b1fffbe046e8275099c96affc29e17645d909'
             'SKIP'
             'b32cad81226d8a72d99fc9cb509acb6a0533378bd351da65391945d7e0e81746')
 
@@ -109,7 +108,6 @@ build() {
     --enable-libwebp
     --enable-libxml2
     --enable-openal
-    --enable-libwavpack
     --enable-pic
     --enable-postproc
     --enable-runtime-cpudetect


### PR DESCRIPTION
drops external libwavpack support (uses an internal one now):
https://github.com/FFmpeg/FFmpeg/commit/45070eec4c089b06947f07e25cdb1bc8b2102553

though some disagree: https://hydrogenaud.io/index.php?topic=120038.0