### PR TITLE
prjtrellis: switch from gcc to clang

### DIFF
--- a/mingw-w64-prjtrellis/PKGBUILD
+++ b/mingw-w64-prjtrellis/PKGBUILD
@@ -4,7 +4,7 @@ _realname=prjtrellis
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.0.r995.da82093
-pkgrel=2
+pkgrel=3
 pkgdesc="Documenting the Lattice ECP5 bit-stream format (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -15,7 +15,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-boost"
          "${MINGW_PACKAGE_PREFIX}-python")
 makedepends=("${MINGW_PACKAGE_PREFIX}-boost"
              "${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-clang"
              "git")
 
 _commit="da820937"
@@ -38,8 +38,11 @@ prepare () {
 
 build() {
   cd "${srcdir}/${_realname}"/libtrellis
-  MSYS2_ARG_CONV_EXCL=- cmake \
+
+  MSYS2_ARG_CONV_EXCL='-DCMAKE_INSTALL_PREFIX=' cmake \
     -G "MSYS Makefiles" \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
     -DCMAKE_PREFIX_PATH=${MINGW_PREFIX} \
     -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
     .


### PR DESCRIPTION
Coming from #8414, it seems that the patch that @mati865 commented did already land in MSYS2. So, this update now works without ugly tweaks.