### PR TITLE
odt2txt: fix messed up depends

### DIFF
--- a/mingw-w64-odt2txt/PKGBUILD
+++ b/mingw-w64-odt2txt/PKGBUILD
@@ -10,9 +10,9 @@ url="https://github.com/dstosberg/odt2txt/"
 license=("GPL2")
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
-depends=("mingw-w64-${CARCH}-libiconv"
-         "mingw-w64-${CARCH}-libzip"
-         "mingw-w64-${CARCH}-pcre")
+depends=("${MINGW_PACKAGE_PREFIX}-libiconv"
+         "${MINGW_PACKAGE_PREFIX}-libzip"
+         "${MINGW_PACKAGE_PREFIX}-pcre")
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/dstosberg/odt2txt/archive/v${pkgver}.tar.gz"
         "0001-Compile-for-Msys2.patch")
 sha256sums=('23a889109ca9087a719c638758f14cc3b867a5dcf30a6c90bf6a0985073556dd'


### PR DESCRIPTION
was not using ${MINGW_PACKAGE_PREFIX}