### PR TITLE
libgphoto2: Update to 2.5.27

### DIFF
--- a/mingw-w64-libgphoto2/PKGBUILD
+++ b/mingw-w64-libgphoto2/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libgphoto2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.5.26
+pkgver=2.5.27
 pkgrel=1
 pkgdesc="libgphoto2 is a free, redistributable, ready to use set of digital camera software applications for Unix-like system (mingw-w64)"
 arch=('any')
@@ -21,16 +21,19 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-doxygen")
 source=(https://sourceforge.net/projects/gphoto/files/libgphoto/${pkgver}/${_realname}-${pkgver}.tar.gz
         libgphoto2-gp_system_filename-fix.patch
-        libgphoto2-fix-lumix.patch)
-sha256sums=('3f99ca5cf12a8376e7e17d60e41fe1df90ffb08fbec68450d9beec2452262948'
+        libgphoto2-fix-lumix.patch
+	libgphoto2-configure-ws232.patch)
+sha256sums=('fd48f6f58259ba199e834010aca0af3672ca0223ed0a98ba89ec693a415f242a'
             '27c558cdf88bee6ce1f3f564d6dfbc0b78809c33b98d20c9e58e40e335d7b0dd'
-            '08b6d5b56d01daae60afa4f0b924ddff2c6d5ef2a5bf6057c601f1efb7019016')
+            '08b6d5b56d01daae60afa4f0b924ddff2c6d5ef2a5bf6057c601f1efb7019016'
+            'fcda293776f18cd506f3aed09b8e0a969c7dbf390574b4b8c3c8377e827dbf8a')
 validpgpkeys=('7C4AFD61D8AAE7570796A5172209D6902F969C95') # Marcus Meissner 
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   patch -Np1 -i "${srcdir}/libgphoto2-gp_system_filename-fix.patch"
   patch -Np1 -i "${srcdir}/libgphoto2-fix-lumix.patch"
+  patch -Np1 -i "${srcdir}/libgphoto2-configure-ws232.patch"
   autoreconf -fiv
 }
 
@@ -47,7 +50,8 @@ build() {
     --host=${MINGW_CHOST}           \
     --with-libusb=no \
     --with-gdlib=auto \
-    --enable-internal-docs
+    --disable-internal-docs
+
 
   make
 }

--- a/mingw-w64-libgphoto2/libgphoto2-configure-ws232.patch
+++ b/mingw-w64-libgphoto2/libgphoto2-configure-ws232.patch
@@ -1,0 +1,16 @@
+--- libgphoto2-2.5.27.orig/configure.ac	2021-02-21 12:03:28.000000000 +0100
++++ libgphoto2-2.5.27/configure.ac	2021-04-28 14:12:43.674282500 +0200
+@@ -326,13 +326,11 @@
+ AC_SUBST(LIBWS232)
+ AC_ARG_WITH([ws232], AS_HELP_STRING([--without-ws232], [Build without ws2_32 library (default: no)]))
+ AS_IF([test "x$with_ws232" != "xno"], [
+-	AC_CHECK_LIB(ws2_32,WSAStartup,[
+ 		AC_CHECK_HEADER(winsock.h,[
+ 			AC_DEFINE(HAVE_LIBWS232,1,[define if we found LIBWS232 and its headers])
+ 			LIBWS232="-lws2_32"
+ 			libws232_msg="yes"
+ 		])
+-	])
+ ])
+ GP_CONFIG_MSG([Winsocket support (for PTP/IP)],[${libws232_msg}])
+ 


### PR DESCRIPTION
I disabled the generation of internal documentation in the configure because it cause the build to fail.
