### PR TITLE
Gphoto2

### DIFF
--- a/mingw-w64-gphoto2/PKGBUILD
+++ b/mingw-w64-gphoto2/PKGBUILD
@@ -3,11 +3,11 @@
 _realname=gphoto2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.5.26
+pkgver=2.5.27
 pkgrel=1
 pkgdesc="The gphoto2 commandline tool for accessing and controlling digital cameras. (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'clang64')
 url='http://www.gphoto.org/'
 license=('GNU')
 depends=("${MINGW_PACKAGE_PREFIX}-libgphoto2"
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 validpgpkeys=('7C4AFD61D8AAE7570796A5172209D6902F969C95') # Marcus Meissner
 source=("https://sourceforge.net/projects/gphoto/files/gphoto/${pkgver}/${_realname}-${pkgver}.tar.gz"
         "01_gphoto_close_before_rename.patch")
-sha256sums=('3a193cf226ecb3ad1f0622686ab422b5105fa15840798f13c78df50ff45474ef'
+sha256sums=('993175db0354d5b0eb278c72a3e80589ce0cb2141639e43cfabc65981a1f2476'
             'ca4e431c4f2bca1272a6580ebab7d81a82fa38fad07624cc8c6328b458293b19')
 
 prepare() {

--- a/mingw-w64-libgphoto2/PKGBUILD
+++ b/mingw-w64-libgphoto2/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libgphoto2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.5.26
+pkgver=2.5.27
 pkgrel=1
 pkgdesc="libgphoto2 is a free, redistributable, ready to use set of digital camera software applications for Unix-like system (mingw-w64)"
 arch=('any')
@@ -22,7 +22,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 source=(https://sourceforge.net/projects/gphoto/files/libgphoto/${pkgver}/${_realname}-${pkgver}.tar.gz
         libgphoto2-gp_system_filename-fix.patch
         libgphoto2-fix-lumix.patch)
-sha256sums=('3f99ca5cf12a8376e7e17d60e41fe1df90ffb08fbec68450d9beec2452262948'
+sha256sums=('fd48f6f58259ba199e834010aca0af3672ca0223ed0a98ba89ec693a415f242a'
             '27c558cdf88bee6ce1f3f564d6dfbc0b78809c33b98d20c9e58e40e335d7b0dd'
             '08b6d5b56d01daae60afa4f0b924ddff2c6d5ef2a5bf6057c601f1efb7019016')
 validpgpkeys=('7C4AFD61D8AAE7570796A5172209D6902F969C95') # Marcus Meissner 
@@ -47,7 +47,7 @@ build() {
     --host=${MINGW_CHOST}           \
     --with-libusb=no \
     --with-gdlib=auto \
-    --enable-internal-docs
+    --disable-internal-docs
 
   make
 }


### PR DESCRIPTION
This package depends on libgphoto2 2.5.27 for which I also created a [pull request](https://github.com/msys2/MINGW-packages/pull/8477).
