### PR TITLE
clang: enable sanitizers on clang prefix, and large-address-aware on 32-bit

### DIFF
--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -38,7 +38,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
            "${MINGW_PACKAGE_PREFIX}-openmp")
          "${MINGW_PACKAGE_PREFIX}-polly")
 pkgver=11.0.0
-pkgrel=10
+pkgrel=11
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -317,11 +317,13 @@ build() {
       ;& # fall-through
     i?86)
       export ASM_COMPILER="${MINGW_PREFIX}/bin/uasm.exe"
-      platform_config+=(-DCMAKE_ASM_MASM_COMPILER="${ASM_COMPILER}")
+      platform_config+=(-DCMAKE_ASM_MASM_COMPILER="${ASM_COMPILER}"
+        -DCOMPILER_RT_BUILD_SANITIZERS=$( (( _clangprefix )) && echo "ON" || echo "OFF"))
       _projects+=";openmp"
       ;;
     armv7|aarch64)
       platform_config+=(-DCOMPILER_RT_BUILD_MEMPROF=OFF
+        -DCOMPILER_RT_BUILD_SANITIZERS=OFF
         -DCOMPILER_RT_BUILD_XRAY=OFF)
       ;;
   esac
@@ -331,7 +333,6 @@ build() {
     -G"$_generator" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DCMAKE_SYSTEM_IGNORE_PATH=/usr/lib \
-    -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
     -DFFI_INCLUDE_DIR="${FFI_INCLUDE_DIR}" \
     -DLIBCLANG_BUILD_STATIC=ON \
     -DLIBOMP_FORTRAN_MODULES=$( (( _clangprefix )) && echo "OFF" || echo "ON" ) \
@@ -516,6 +517,11 @@ package_compiler-rt() {
 
   cd "${srcdir}"/compiler-rt
   ${_make_cmd} -C ../build-${CARCH}/projects/compiler-rt DESTDIR="${pkgdir}" install
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/bin/"
+  find "${pkgdir}${MINGW_PREFIX}/lib/clang/${pkgver}/lib/windows/" \
+    -name '*.dll' -exec mv '{}' "${pkgdir}${MINGW_PREFIX}/bin/" \;
+  # remove bin dir we created if it is still empty
+  rmdir "${pkgdir}${MINGW_PREFIX}/bin/" 2>/dev/null || true
 }
 
 package_libc++() {

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -274,6 +274,13 @@ build() {
   [[ -d build-${CARCH} ]] && rm -rf build-${CARCH}
   mkdir build-${CARCH} && cd build-${CARCH}
 
+  case "${CARCH}" in
+    i?86|armv7)
+      # lld needs all the address space it can get.
+      LDFLAGS+=" -Wl,--large-address-aware"
+      ;;
+  esac
+
   local -a extra_config
 
   if check_option "debug" "y"; then


### PR DESCRIPTION
Fixes msys2/CLANG-packages#37.  May help msys2/CLANG-packages#34