### PR TITLE
libssp: new package.

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -28,7 +28,7 @@ pkgver=10.2.0
 #_majorver=${pkgver:0:1}
 #_sourcedir=${_realname}-${_majorver}-${_snapshot}
 _sourcedir=${_realname}-${pkgver}
-pkgrel=10
+pkgrel=11
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -288,6 +288,7 @@ package_gcc-libs() {
            "${MINGW_PACKAGE_PREFIX}-mpc"
            "${MINGW_PACKAGE_PREFIX}-mpfr"
            "${MINGW_PACKAGE_PREFIX}-libwinpthread")
+  provides=("${MINGW_PACKAGE_PREFIX}-libssp")
 
   # Licensing information
 

--- a/mingw-w64-libssp/PKGBUILD
+++ b/mingw-w64-libssp/PKGBUILD
@@ -1,0 +1,59 @@
+# Maintainer: Jeremy Drake <github@jdrake.com>
+# borrowed heavily from https://github.com/mstorsjo/llvm-mingw/blob/22ef26848995f2a3ccd0f1c13a2fcff60613a54b/build-libssp.sh
+
+_realname=libssp
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=7.3.0
+pkgrel=1
+pkgdesc="A library for stack smashing protection (mingw-w64)"
+arch=('any')
+mingw_arch=('clang32' 'clang64' 'clangarm64')
+url="https://gcc.gnu.org"
+license=('LGPL' 'custom')
+makedepends=("${MINGW_PACKAGE_PREFIX}-clang")
+source=("libssp.tar.bz2::https://gitlab.com/watched/gcc-mirror/gcc/-/archive/releases/gcc-7.3.0/gcc-releases-gcc-7.3.0.tar.bz2?path=libssp"
+        "https://gitlab.com/watched/gcc-mirror/gcc/-/raw/releases/gcc-7.3.0/COPYING.RUNTIME"
+        "libssp-Makefile")
+noextract=("libssp.tar.bz2")
+sha256sums=('f5fa12f8e0ec23fa018c9545459255cfc37fb34b7a1661cff2500dd1b116d057'
+            '9d6b43ce4d8de0c878bf16b54d8e7a10d9bd42b75178153e3af6a815bdc90f74'
+            '7936cef86f5128e6e66afc77cd9c815773a29842a921e95680a05ff0fdb515dd')
+
+prepare() {
+  cd "${srcdir}"
+  rm -rf libssp
+  tar -jxf "${srcdir}/libssp.tar.bz2" --strip-components=1
+  cp -f libssp-Makefile libssp/Makefile
+  cd libssp
+  # gcc/libssp's configure script runs checks for flags that clang doesn't
+  # implement. We actually just need to set a few HAVE defines and compile
+  # the .c sources.
+  cp -f config.h.in config.h
+  for i in HAVE_FCNTL_H HAVE_INTTYPES_H HAVE_LIMITS_H HAVE_MALLOC_H \
+    HAVE_MEMMOVE HAVE_MEMORY_H HAVE_MEMPCPY HAVE_STDINT_H HAVE_STDIO_H \
+    HAVE_STDLIB_H HAVE_STRINGS_H HAVE_STRING_H HAVE_STRNCAT HAVE_STRNCPY \
+    HAVE_SYS_STAT_H HAVE_SYS_TYPES_H HAVE_UNISTD_H HAVE_USABLE_VSNPRINTF \
+    HAVE_HIDDEN_VISIBILITY; do
+    cat config.h | sed 's/^#undef '$i'$/#define '$i' 1/' > tmp
+    mv -f tmp config.h
+  done
+  cat ssp/ssp.h.in | sed 's/@ssp_have_usable_vsnprintf@/define/' > ssp/ssp.h
+}
+
+build() {
+  [[ -d "${srcdir}/build-${CARCH}" ]] && rm -rf "${srcdir}/build-${CARCH}"
+  mkdir -p "${srcdir}/build-${CARCH}" && cd "${srcdir}/build-${CARCH}"
+  make -f ../libssp/Makefile
+}
+
+package() {
+  cd "${srcdir}/build-${CARCH}"
+  mkdir -p "${pkgdir}${MINGW_PREFIX}"/{bin,lib}
+  cp -f libssp.a "${pkgdir}${MINGW_PREFIX}/lib"
+  cp -f libssp_nonshared.a "${pkgdir}${MINGW_PREFIX}/lib"
+  cp -f libssp.dll.a "${pkgdir}${MINGW_PREFIX}/lib"
+  cp -f libssp-0.dll "${pkgdir}${MINGW_PREFIX}/bin"
+
+  install -Dm644 "${srcdir}"/COPYING.RUNTIME "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}

--- a/mingw-w64-libssp/libssp-Makefile
+++ b/mingw-w64-libssp/libssp-Makefile
@@ -1,0 +1,24 @@
+SRC_PATH=$(word 1, $(dir $(MAKEFILE_LIST)))
+vpath %.c $(SRC_PATH)
+
+CC = $(CROSS)gcc
+AR = $(CROSS)ar
+
+CFLAGS = -O2 -Wall -Wundef -I$(SRC_PATH) -D_FORTIFY_SOURCE=0 -D__SSP_FORTIFY_LEVEL=0
+
+SOURCES = $(filter-out ssp-local.c, $(patsubst $(SRC_PATH)%,%,$(wildcard $(SRC_PATH)*.c)))
+OBJS = $(SOURCES:%.c=%.o)
+
+all: libssp.a libssp_nonshared.a libssp-0.dll
+
+libssp.a: $(OBJS)
+	$(AR) rcs $@ $+
+
+libssp-0.dll: $(OBJS)
+	$(CC) -shared -o $@ $+ -Wl,--out-implib,libssp.dll.a
+
+libssp_nonshared.a: ssp-local.o
+	$(AR) rcs $@ $+
+
+clean:
+	rm -f *.a *.o *.dll

--- a/mingw-w64-xapian-core/PKGBUILD
+++ b/mingw-w64-xapian-core/PKGBUILD
@@ -3,10 +3,12 @@
 _realname=xapian-core
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-zlib")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-libssp"
+         "${MINGW_PACKAGE_PREFIX}-zlib")
 epoch=1
 pkgver=1.4.17
-pkgrel=1
+pkgrel=2
 pkgdesc='Open source search engine library (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -14,11 +16,15 @@ url='https://www.xapian.org/'
 license=('GPL')
 # xapian config requires libxapian.la
 options=('libtool')
-source=("https://oligarchy.co.uk/xapian/${pkgver}/${_realname}-${pkgver}.tar.xz")
-sha256sums=('b5eb8556dea1b0cad4167a66223522e66d670ec1eba16c7fdc844ed6b652572e')
+source=("https://oligarchy.co.uk/xapian/${pkgver}/${_realname}-${pkgver}.tar.xz"
+        "dont-set-msvcrt-version.patch")
+sha256sums=('b5eb8556dea1b0cad4167a66223522e66d670ec1eba16c7fdc844ed6b652572e'
+            '9ee6e7994395dd3a9ab55bfe192e511d972cf61282f4a46a6bef88d8f8cc19df')
 
 prepare() {
-  cd ${srcdir}/${_realname}-${pkgver}
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -Np1 -i "${srcdir}"/dont-set-msvcrt-version.patch
+  autoreconf -fiv
 }
 
 build() {

--- a/mingw-w64-xapian-core/dont-set-msvcrt-version.patch
+++ b/mingw-w64-xapian-core/dont-set-msvcrt-version.patch
@@ -1,0 +1,11 @@
+--- xapian-core-1.4.17/configure.ac.orig        2021-04-25 22:43:19.302353100 -0700
++++ xapian-core-1.4.17/configure.ac     2021-04-25 22:43:32.114864400 -0700
+@@ -476,7 +476,7 @@
+   *mingw*)
+     dnl For _ftime64() on mingw we need to tell it we're happy to require
+     dnl MSVCRT 6.10 or higher, which isn't too onerous a requirement it seems.
+-    AC_DEFINE([__MSVCRT_VERSION__], [0x0601], [Define on mingw to the minimum msvcrt version to assume])
++    dnl AC_DEFINE([__MSVCRT_VERSION__], [0x0601], [Define on mingw to the minimum msvcrt version to assume])
+     AC_DEFINE([MINGW_HAS_SECURE_API], [1], [Define on mingw to get _s suffixed "secure" functions declared in headers])
+     ;;
+ esac


### PR DESCRIPTION
Provides gcc's libssp for clang prefixes.  Fixes msys2/CLANG-packages#40

Borrowed heavily from llvm-mingw.  Thanks to @mstorsjo!

My thought is that gcc-libs should provide libssp, and then packages that need it can depend on libssp (or makedepend if they link it statically).

gcc prefixes blow up trying to install the package as it conflicts with gcc files.  Don't know what if anything I can do about that.  I tried making it conflict with gcc-libs, but libc++ provides that so it conflicted with libc++ ☹️ 