### PR TITLE
doxygen: disable qt dependency/wizard on ucrt.

### DIFF
--- a/mingw-w64-doxygen/PKGBUILD
+++ b/mingw-w64-doxygen/PKGBUILD
@@ -4,7 +4,7 @@ _realname=doxygen
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.9.1
-pkgrel=2
+pkgrel=3
 pkgdesc="A documentation system for C++, C, Java, IDL and PHP (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -16,14 +16,13 @@ depends=(#"${MINGW_PACKAGE_PREFIX}-clang" # we dont want this huge dependency
          "${MINGW_PACKAGE_PREFIX}-libiconv"
          "${MINGW_PACKAGE_PREFIX}-sqlite3"
          "${MINGW_PACKAGE_PREFIX}-xapian-core")
-optdepends=("${MINGW_PACKAGE_PREFIX}-qt5")
 makedepends=(#"${MINGW_PACKAGE_PREFIX}-clang-tools-extra"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              #"${MINGW_PACKAGE_PREFIX}-polly"
              "${MINGW_PACKAGE_PREFIX}-python"
-             "${MINGW_PACKAGE_PREFIX}-qt5"
+             $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* || ${MINGW_PACKAGE_PREFIX} == *-ucrt-* ]] || echo "${MINGW_PACKAGE_PREFIX}-qt5" )
              'flex'
              'bison')
 optdepends=("${MINGW_PACKAGE_PREFIX}-qt5")
@@ -59,7 +58,7 @@ build() {
     -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DCMAKE_BUILD_TYPE=Release \
-    -Dbuild_wizard=ON \
+    -Dbuild_wizard=$( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* || ${MINGW_PACKAGE_PREFIX} == *-ucrt-* ]] && echo "OFF" || echo "ON" ) \
     -Dbuild_search=ON \
     -Duse_sqlite3=ON \
     -Duse_libclang=OFF \


### PR DESCRIPTION
Neither clang nor ucrt has qt5 available yet.