### PR TITLE
ucl: remove -fPIC

### DIFF
--- a/mingw-w64-ucl/PKGBUILD
+++ b/mingw-w64-ucl/PKGBUILD
@@ -4,7 +4,7 @@ _realname=ucl
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.03
-pkgrel=1
+pkgrel=2
 pkgdesc="Portable lossless data compression library written in ANSI C (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -37,7 +37,7 @@ build() {
   cd "${srcdir}"/${_realname}-${pkgver}
   [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
   mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
-  CFLAGS+=" -std=gnu90 -fPIC"
+  CFLAGS+=" -std=gnu90"
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \


### PR DESCRIPTION
Another low-hanging -fPIC removal, for building with clang