### PR TITLE
Python updates

### DIFF
--- a/mingw-w64-python-black/PKGBUILD
+++ b/mingw-w64-python-black/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=black
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=21.4b0
+pkgver=21.4b1
 pkgrel=1
 pkgdesc='Uncompromising Python code formatter (mingw-w64)'
 arch=('any')
@@ -23,7 +23,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools"
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-aiohttp-cors")
 options=('!emptydirs')
 source=("https://files.pythonhosted.org/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('915d916c48646dbe8040d5265cff7111421a60a3dfe7f7e07273176a57c24a34')
+sha256sums=('20d326de75d13be6290925a95c94a9f368aca2f71cb7b753a938a5ae20f34a37')
 
 prepare() {
   cd "$srcdir"

--- a/mingw-w64-python-boto3/PKGBUILD
+++ b/mingw-w64-python-boto3/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=boto3
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=1.17.59
+pkgver=1.17.60
 pkgrel=1
 pkgdesc='The AWS SDK for Python (mingw-w64)'
 arch=('any')
@@ -13,7 +13,7 @@ license=('Apache')
 depends=("${MINGW_PACKAGE_PREFIX}-python-s3transfer")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 source=("https://github.com/boto/boto3/archive/$pkgver.tar.gz")
-sha256sums=('91c84d86527db63f1a39dc7f64ebf211b9ab0856f0a19a7213a3f7f7c8486993')
+sha256sums=('a6389639136d0b2f13f4448dc0324a1a1ef8dd24040e548a44335e6d44237776')
 
 prepare() {  
   cd "$srcdir"

--- a/mingw-w64-python-botocore/PKGBUILD
+++ b/mingw-w64-python-botocore/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=botocore
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=1.20.59
+pkgver=1.20.60
 pkgrel=1
 pkgdesc='A low-level interface to a growing number of Amazon Web Services (mingw-w64)'
 arch=('any')
@@ -13,7 +13,7 @@ license=('Apache')
 depends=("${MINGW_PACKAGE_PREFIX}-python-dateutil" "${MINGW_PACKAGE_PREFIX}-python-docutils" "${MINGW_PACKAGE_PREFIX}-python-jmespath" "${MINGW_PACKAGE_PREFIX}-python-urllib3")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 source=("$url/archive/$pkgver.tar.gz")
-sha256sums=('a6bb4b2b24ae6936ae61e7811b3881c0edc6335cb56f7e23631ec3b81edb39f0')
+sha256sums=('b314272143d4c796d2023bab56ac02abde33332871bf6f3a215ffdceb62a59a7')
 
 prepare() {  
   cd "$srcdir"

--- a/mingw-w64-python-cachetools/PKGBUILD
+++ b/mingw-w64-python-cachetools/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=cachetools
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=4.2.1
+pkgver=4.2.2
 pkgrel=1
 pkgdesc='Extensible memoizing collections and decorators (mingw-w64)'
 arch=('any')
@@ -14,7 +14,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-python")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest-runner")
 source=("${_realname}-$pkgver.tar.gz::https://github.com/tkem/cachetools/archive/v$pkgver.tar.gz")
-sha256sums=('077bb90fd7937f6628931e6b0b0e86e43fab5475b35d3b3729d8102124d8509c')
+sha256sums=('d9b4bb657c8f90e847af6d08bc1d9aa6e365605fe202412098d4ca895db09b0f')
 
 prepare() {  
   cd "$srcdir"

--- a/mingw-w64-python-cattrs/PKGBUILD
+++ b/mingw-w64-python-cattrs/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=cattrs
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=1.5.0
+pkgver=1.6.0
 pkgrel=1
 pkgdesc='Complex custom class converters for attrs (mingw-w64)'
 arch=('any')
@@ -14,7 +14,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-python")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!emptydirs')
 source=("https://files.pythonhosted.org/packages/source/${_realname::1}/$_realname/$_realname-$pkgver.tar.gz")
-sha256sums=('a6233d0ce33d48ac71ef818f8e0b9309a89496b359994c4dfe9ad211c1f6d0a3')
+sha256sums=('3e2cd5dc8a1006d5da53ddcbf4f0b1dd3a21e294323b257678d0a96721f8253a')
 
 prepare() {  
   cd "$srcdir"

--- a/mingw-w64-python-requests-mock/PKGBUILD
+++ b/mingw-w64-python-requests-mock/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=requests-mock
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=1.8.0
+pkgver=1.9.1
 pkgrel=1
 pkgdesc='A mock of useful classes and functions to be used with python-requests. (mingw-w64)'
 arch=('any')
@@ -19,7 +19,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python-mock"
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-pbr")
 options=('!emptydirs')
 source=("https://github.com/jamielennox/requests-mock/archive/$pkgver.tar.gz")
-sha256sums=('fa16afb95caef3e7e5b89de542c4349feaa4624b8cd6854cd1e4e0e7bb03efde')
+sha256sums=('f2acb7cc01b23acd3c6d8b9878370bffc338da33d467835c8297d64daa590a33')
 
 export PBR_VERSION=$pkgver
 

--- a/mingw-w64-python-responses/PKGBUILD
+++ b/mingw-w64-python-responses/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=responses
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=0.13.2
+pkgver=0.13.3
 pkgrel=1
 pkgdesc='A utility library for mocking out the `requests` Python library. (mingw-w64)'
 arch=('any')
@@ -14,7 +14,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-python-biscuits" "${MINGW_PACKAGE_PREFIX}-pyth
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-mypy" "${MINGW_PACKAGE_PREFIX}-python-flake8" "${MINGW_PACKAGE_PREFIX}-python-pytest-cov" "${MINGW_PACKAGE_PREFIX}-python-pytest-localserver" "${MINGW_PACKAGE_PREFIX}-python-pytest-runner")
 source=("${_realname}-$pkgver.tar.gz::https://github.com/getsentry/responses/archive/$pkgver.tar.gz")
-sha256sums=('0c3a53ebcb85a4999ce456f82ddae292d48bd105977f898a7a9488e64364aecf')
+sha256sums=('d5d8a9e844d014df9384278a715560c91d8375f567013a581aa51fc7251904ba')
 
 prepare() {  
   cd "$srcdir"

--- a/mingw-w64-python-trimesh/PKGBUILD
+++ b/mingw-w64-python-trimesh/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=trimesh
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=3.9.14
+pkgver=3.9.15
 pkgrel=1
 pkgdesc='Trimesh is a pure Python (2.7-3.4+) library for loading and using triangular meshes with an emphasis on watertight surfaces. (mingw-w64)'
 arch=('any')
@@ -17,7 +17,7 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-python-networkx: graph operations"
 "${MINGW_PACKAGE_PREFIX}-python-scipy: convex hulls"
 "${MINGW_PACKAGE_PREFIX}-python-pyglet: preview windows")
 source=("https://files.pythonhosted.org/packages/source/${_realname::1}/$_realname/$_realname-$pkgver.tar.gz")
-sha256sums=('c0387e3d300a51e62fb1ead1a439ab5774eb9b723097af26f7ebe70086a27ab9')
+sha256sums=('fa33ec83bcf550e5dd0e6654fc4258520bc90deb59303324ecdeeef74ec020b9')
 
 prepare() {  
   cd "$srcdir"


### PR DESCRIPTION
- python-black 21.4b1
- python-boto3 1.17.60
- python-botocore 1.20.60
- python-cachetools 4.2.2
- python-cattrs 1.6
- python-requests-mock 1.9.1
- python-responses 0.13.3
- python-trimesh 3.9.15