### PR TITLE
flac: depend on libssp, and work around no MIN/MAX

### DIFF
--- a/mingw-w64-flac/Do-not-assume-that-sys-param.h-defines-MIN-and-MAX.patch
+++ b/mingw-w64-flac/Do-not-assume-that-sys-param.h-defines-MIN-and-MAX.patch
@@ -1,0 +1,25 @@
+From 4a43f2bd4d7e12b5d994f48e18cf014008d204ce Mon Sep 17 00:00:00 2001
+From: sezero <sezero@users.sourceforge.net>
+Date: Mon, 5 Aug 2019 02:00:40 +0300
+Subject: [PATCH] Do not assume that sys/param.h defines MIN and MAX
+
+One such example is sys/param.h from MinGW.
+---
+ src/libFLAC/include/private/macros.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/libFLAC/include/private/macros.h b/src/libFLAC/include/private/macros.h
+index 02eada455..3a8072ece 100644
+--- a/src/libFLAC/include/private/macros.h
++++ b/src/libFLAC/include/private/macros.h
+@@ -51,8 +51,10 @@
+ /* Whatever other unix that has sys/param.h */
+ #elif defined(HAVE_SYS_PARAM_H)
+ #include <sys/param.h>
++#if defined(MIN) && defined(MAX)
+ #define flac_max(a,b) MAX(a,b)
+ #define flac_min(a,b) MIN(a,b)
++#endif
+ 
+ /* Windows VS has them in stdlib.h.. XXX:Untested */
+ #elif defined(_MSC_VER)

--- a/mingw-w64-flac/PKGBUILD
+++ b/mingw-w64-flac/PKGBUILD
@@ -4,22 +4,28 @@ _realname=flac
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.3.3
-pkgrel=2
+pkgrel=3
 pkgdesc="Free Lossless Audio Codec (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 url="https://flac.sourceforge.io/"
 license=('custom:Xiph' 'LGPL' 'GPL' 'FDL')
-depends=("${MINGW_PACKAGE_PREFIX}-libogg" "${MINGW_PACKAGE_PREFIX}-gcc-libs")
+depends=("${MINGW_PACKAGE_PREFIX}-libogg"
+         "${MINGW_PACKAGE_PREFIX}-libssp"
+         "${MINGW_PACKAGE_PREFIX}-gcc-libs")
 #optdepends=("${MINGW_PACKAGE_PREFIX}-xmms: for using the xmms plugin")
 makedepends=("${MINGW_PACKAGE_PREFIX}-nasm" "${MINGW_PACKAGE_PREFIX}-gcc")
 options=('strip' 'staticlibs')
-source=("https://downloads.xiph.org/releases/flac/flac-${pkgver}.tar.xz")
-sha256sums=('213e82bd716c9de6db2f98bcadbc4c24c7e2efe8c75939a1a84e28539c4e1748')
+source=("https://downloads.xiph.org/releases/flac/flac-${pkgver}.tar.xz"
+        "Do-not-assume-that-sys-param.h-defines-MIN-and-MAX.patch")
+sha256sums=('213e82bd716c9de6db2f98bcadbc4c24c7e2efe8c75939a1a84e28539c4e1748'
+            'feab3c619d3739c620c658bd8ae44a2f39d1f677238ce49606e0175469c1f99f')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
+  # https://github.com/xiph/flac/commit/4a43f2bd4d7e12b5d994f48e18cf014008d204ce
+  patch -Np1 -i "${srcdir}/Do-not-assume-that-sys-param.h-defines-MIN-and-MAX.patch"
   ./autogen.sh
 }
 


### PR DESCRIPTION
flac expected that if sys/param.h exists, that it contains macros MIN and
MAX.  mingw-w64's doesn't appear to, so backport a commit that fixes
that assumption.