### PR TITLE
gobject-introspection: don't use -rpath on nt

### DIFF
--- a/mingw-w64-gobject-introspection/0028-no-rpath-on-nt.patch
+++ b/mingw-w64-gobject-introspection/0028-no-rpath-on-nt.patch
@@ -1,0 +1,11 @@
+--- gobject-introspection-1.66.1/giscanner/ccompiler.py.orig	2021-04-28 20:23:22.145710000 -0700
++++ gobject-introspection-1.66.1/giscanner/ccompiler.py	2021-04-28 20:23:26.473853400 -0700
+@@ -208,7 +208,7 @@
+                 args.append('-libpath:' + library_path)
+             else:
+                 args.append('-L' + library_path)
+-                if os.path.isabs(library_path):
++                if os.name != 'nt' and os.path.isabs(library_path):
+                     if libtool:
+                         args.append('-rpath')
+                         args.append(library_path)

--- a/mingw-w64-gobject-introspection/PKGBUILD
+++ b/mingw-w64-gobject-introspection/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-runtime")
 pkgver=1.66.1
-pkgrel=4
+pkgrel=5
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 url="https://live.gnome.org/GObjectIntrospection"
@@ -26,6 +26,7 @@ source=(https://download.gnome.org/sources/gobject-introspection/${pkgver%.*}/${
         0024-Support-passing-arguments-to-g-ir-scanner-through-a-.all.patch
         0026-giscanner-assertions-and-waits.patch
         0027-wait-for-xml-parse-too.patch
+        0028-no-rpath-on-nt.patch
         pyscript2exe.py)
 
 sha256sums=('dd44a55ee5f426ea22b6b89624708f9e8d53f5cc94e5485c15c87cb30e06161d'
@@ -34,6 +35,7 @@ sha256sums=('dd44a55ee5f426ea22b6b89624708f9e8d53f5cc94e5485c15c87cb30e06161d'
             '594a067618922f10bdc5034f290f49d36944df3b970c9604381e2b9058a648da'
             '19ca830262339c4ac9f21bfb8d669ee8e126a949a4237d55656e00c5ae81c451'
             '3f38bdd0dd43d9cf626cbca7c2abd22a7ed0213e6756252c6d467d470d9c5948'
+            '951d0462fb05b1b250608323b3ffe53c4c59919d255c44a8c5eef7fad0dacecf'
             'e57174517b08cf8f9fb4f43a381d342d23d2db3cad661107f35ca21c39b5734d')
 
 prepare() {
@@ -44,6 +46,7 @@ prepare() {
   patch -p1 -i "${srcdir}"/0024-Support-passing-arguments-to-g-ir-scanner-through-a-.all.patch
   patch -p1 -i "${srcdir}"/0026-giscanner-assertions-and-waits.patch
   patch -p1 -i "${srcdir}"/0027-wait-for-xml-parse-too.patch
+  patch -p1 -i "${srcdir}"/0028-no-rpath-on-nt.patch
 }
 
 build() {


### PR DESCRIPTION
lld does not recognize that argument, and it's an ELF thing anyway.