### PR TITLE
meson: don't pass rpath to gtk-doc on Windows

### DIFF
--- a/mingw-w64-meson/0004-fix-gtk-doc.patch
+++ b/mingw-w64-meson/0004-fix-gtk-doc.patch
@@ -1,6 +1,15 @@
---- meson-0.55.1/mesonbuild/scripts/gtkdochelper.py.orig	2020-08-15 18:27:05.000000000 +0200
-+++ meson-0.55.1/mesonbuild/scripts/gtkdochelper.py	2020-08-21 14:48:07.741232700 +0200
-@@ -64,7 +64,7 @@
+--- meson-0.57.2/mesonbuild/scripts/gtkdochelper.py.orig	2021-04-29 12:15:43.756190700 -0700
++++ meson-0.57.2/mesonbuild/scripts/gtkdochelper.py	2021-04-29 12:17:17.646837400 -0700
+@@ -16,7 +16,7 @@
+ import subprocess
+ import shutil
+ import argparse
+-from ..mesonlib import MesonException, Popen_safe, is_windows, is_cygwin, split_args
++from ..mesonlib import MesonException, Popen_safe, is_windows, is_cygwin, join_args, split_args
+ from . import destdir_join
+ import typing as T
+ 
+@@ -65,7 +65,7 @@
              library_paths.extend(env['LD_LIBRARY_PATH'].split(os.pathsep))
          env['LD_LIBRARY_PATH'] = os.pathsep.join(library_paths)
  
@@ -9,3 +18,31 @@
          cmd.insert(0, sys.executable)
  
      # Put stderr into stdout since we want to print it out anyway.
+@@ -149,6 +149,15 @@
+ 
+     if gobject_typesfile:
+         scanobjs_cmd = [options.gtkdoc_scangobj] + scanobjs_args
++
++        library_paths = []
++        for ldflag in split_args(ldflags):
++            if ldflag.startswith('-Wl,-rpath,'):
++                library_paths.append(ldflag[11:])
++
++        if is_windows():
++            ldflags = join_args((arg for arg in split_args(ldflags) if not arg.startswith('-Wl,-rpath,')))
++
+         scanobjs_cmd += ['--types=' + gobject_typesfile,
+                          '--module=' + module,
+                          '--run=' + run,
+@@ -158,11 +167,6 @@
+                          '--ld=' + ld,
+                          '--output-dir=' + abs_out]
+ 
+-        library_paths = []
+-        for ldflag in split_args(ldflags):
+-            if ldflag.startswith('-Wl,-rpath,'):
+-                library_paths.append(ldflag[11:])
+-
+         gtkdoc_run_check(scanobjs_cmd, build_root, library_paths)
+ 
+     # Make docbook files

--- a/mingw-w64-meson/PKGBUILD
+++ b/mingw-w64-meson/PKGBUILD
@@ -4,7 +4,7 @@ _realname=meson
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.57.2
-pkgrel=1
+pkgrel=2
 pkgdesc="High-productivity build system (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -23,7 +23,7 @@ source=("https://github.com/mesonbuild/${_realname}/releases/download/${pkgver}/
 sha256sums=('3a83e7b1c5de94fa991ec34d9b198d94f38ed699d3524cb0fdf3b99fd23d4cc5'
             '5805aed0a117536eb16dd8eef978c6be57c2471b655ede63e25517c28b4f4cf0'
             '675e79a0fc78b4236f5b803ffd2e745cb2ff125c9b4a03657773915183a4e19a'
-            'ca14c322dd18e7c0614fda1ec8ba42ba5148305e641612e0290e4a350c042adf'
+            '0f9177102976bbcbdf50c1da49842783a0c77be939e839f1bf91dcaba6a5cdee'
             '0682a36cb75e545a78b81293303835a16171f25baf949905dc08029436efff84'
             '9cb31b97a22251f98a2ff80fd5cbea6a62a65a03b8ebae1c827496e68cbe7b20')
 


### PR DESCRIPTION
Unfortunately, meson parses -Wl,-rpath args itself to set the PATH, so I
couldn't keep it from generating them, I had to filter them out after it
did its handling.

This allows graphene and json-glib to build for me on clang64 (which failed in autobuild recently due to this issue)