### PR TITLE
neon: fix configure test for stdcall function

### DIFF
--- a/mingw-w64-neon/PKGBUILD
+++ b/mingw-w64-neon/PKGBUILD
@@ -4,7 +4,7 @@ _realname=neon
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.31.2
-pkgrel=1
+pkgrel=2
 pkgdesc="HTTP and WebDAV client library with a C interface (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -16,14 +16,18 @@ depends=("${MINGW_PACKAGE_PREFIX}-expat"
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 options=('libtool' 'staticlibs') # FS#16067
 source=(https://notroj.github.io/neon/${_realname}-${pkgver}.tar.gz
-        neon-0.30.2-mingw-w64.patch)
+        neon-0.30.2-mingw-w64.patch
+        neon-0.31.2-configure-stdcall.patch)
 sha256sums=('cf1ee3ac27a215814a9c80803fcee4f0ede8466ebead40267a9bd115e16a8678'
-            'a1e19dcd755784168542930a0e351506eb1bfc5d941904aa970f81b5b489a95d')
+            'a1e19dcd755784168542930a0e351506eb1bfc5d941904aa970f81b5b489a95d'
+            '1eb9e381ad8ed975dafcc1718c7ef32e0b33a7d591939be614db2d799c57d336')
 validpgpkeys=('190555472DCC589BEF01609C608A86DF9833CC49') #Joe Orton <joe@manyfish.uk>
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
-  patch -p1 -i ${srcdir}/neon-0.30.2-mingw-w64.patch
+  patch -p1 -i "${srcdir}/neon-0.30.2-mingw-w64.patch"
+  # https://github.com/notroj/neon/commit/43a9b7e0d72ee97dcdbc102254ada20278eac80b
+  patch -p1 -i "${srcdir}/neon-0.31.2-configure-stdcall.patch"
 
   ./autogen.sh
   #autoreconf -fi

--- a/mingw-w64-neon/neon-0.31.2-configure-stdcall.patch
+++ b/mingw-w64-neon/neon-0.31.2-configure-stdcall.patch
@@ -1,0 +1,51 @@
+From 43a9b7e0d72ee97dcdbc102254ada20278eac80b Mon Sep 17 00:00:00 2001
+From: Christopher Degawa <ccom@randomderp.com>
+Date: Wed, 23 Sep 2020 16:31:17 +0000
+Subject: [PATCH] macros/neon.m4: add prologue to NE_SEARCH_LIBS
+
+This check kept on failing with 32-bit windows gcc and clang
+
+This does remove the on-by-default `__stdcall` for ws2_32, but instead
+uses the proper <winsock2.h> header
+
+Signed-off-by: Christopher Degawa <ccom@randomderp.com>
+---
+ macros/neon.m4 | 19 +++++++++++++++----
+ 1 file changed, 15 insertions(+), 4 deletions(-)
+
+diff --git a/macros/neon.m4 b/macros/neon.m4
+index ccdc4a6..9a2deaa 100644
+--- a/macros/neon.m4
++++ b/macros/neon.m4
+@@ -371,16 +371,27 @@ ne_cv_libsfor_$1="not found"
+ for lib in $2; do
+     # The w32api libraries link using the stdcall calling convention.
+     case ${lib}-${ne_cv_os_uname} in
+-    ws2_32-MINGW*) ne__code="__stdcall $1();" ;;
+-    *) ne__code="$1();" ;;
++    ws2_32-MINGW*)
++      ne__prologue="#include <winsock2.h>"
++      case $1 in
++      socket) ne__code="socket(0,0,0);" ;;
++      gethostbyname) ne__code="gethostbyname(\"\")" ;;
++      *) ne__code="$1();" ;;
++      esac
++      ;;
++    *)
++      ne__prologue=""
++      ne__code="$1();"
++      ;;
+     esac
+ 
++
+     LIBS="$ne_sl_save_LIBS -l$lib $NEON_LIBS"
+-    AC_LINK_IFELSE([AC_LANG_PROGRAM([], [$ne__code])],
++    AC_LINK_IFELSE([AC_LANG_PROGRAM([$ne__prologue], [$ne__code])],
+                    [ne_cv_libsfor_$1="-l$lib"; break])
+     m4_if($3, [], [], dnl If $3 is specified, then...
+               [LIBS="$ne_sl_save_LIBS -l$lib $3 $NEON_LIBS"
+-               AC_LINK_IFELSE([AC_LANG_PROGRAM([], [$ne__code])], 
++               AC_LINK_IFELSE([AC_LANG_PROGRAM([$ne__prologue], [$ne__code])],
+                               [ne_cv_libsfor_$1="-l$lib $3"; break])])
+ done
+ LIBS=$ne_sl_save_LIBS])])


### PR DESCRIPTION
They were applying __stdcall to an implicitly declared function call.
Instead, include the header and call the function normally.