### PR TITLE
opusfile: autoreconf for clang

### DIFF
--- a/mingw-w64-opusfile/PKGBUILD
+++ b/mingw-w64-opusfile/PKGBUILD
@@ -4,7 +4,7 @@ _realname=opusfile
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.12
-pkgrel=1
+pkgrel=2
 pkgdesc="Library for opening, seeking, and decoding .opus files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -24,6 +24,8 @@ prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
   patch -p1 -i "${srcdir}"/no-openssl-wincert.patch
+  # autoreconf for clang support
+  autoreconf -fiv
 }
 
 build() {


### PR DESCRIPTION
This package built for clang, but then opus-tools failed to build
because there was only a static libopusurl.

This will allow opus-tools to build under clang, if it is attempted again after this is merged.