### PR TITLE
gphoto2: Update to 2.5.27, fix ucrt64 build

### DIFF
--- a/mingw-w64-gphoto2/PKGBUILD
+++ b/mingw-w64-gphoto2/PKGBUILD
@@ -26,6 +26,7 @@ sha256sums=('993175db0354d5b0eb278c72a3e80589ce0cb2141639e43cfabc65981a1f2476'
 prepare() {
   cd $srcdir/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/01_gphoto_close_before_rename.patch
+  # https://github.com/gphoto/gphoto2/pull/419
   patch -p1 -i ${srcdir}/gphoto2-check-popt.patch
 }
 

--- a/mingw-w64-gphoto2/PKGBUILD
+++ b/mingw-w64-gphoto2/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gphoto2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.5.26
+pkgver=2.5.27
 pkgrel=1
 pkgdesc="The gphoto2 commandline tool for accessing and controlling digital cameras. (mingw-w64)"
 arch=('any')
@@ -17,13 +17,16 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-libtool")
 validpgpkeys=('7C4AFD61D8AAE7570796A5172209D6902F969C95') # Marcus Meissner
 source=("https://sourceforge.net/projects/gphoto/files/gphoto/${pkgver}/${_realname}-${pkgver}.tar.gz"
-        "01_gphoto_close_before_rename.patch")
-sha256sums=('3a193cf226ecb3ad1f0622686ab422b5105fa15840798f13c78df50ff45474ef'
-            'ca4e431c4f2bca1272a6580ebab7d81a82fa38fad07624cc8c6328b458293b19')
+        "01_gphoto_close_before_rename.patch"
+	"gphoto2-check-popt.patch")
+sha256sums=('993175db0354d5b0eb278c72a3e80589ce0cb2141639e43cfabc65981a1f2476'
+            'ca4e431c4f2bca1272a6580ebab7d81a82fa38fad07624cc8c6328b458293b19'
+            'fdc32ca1291b42f5d0b5f57ec2de47dfa6201bf45342a202ae86eb1caafd45d0')
 
 prepare() {
   cd $srcdir/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/01_gphoto_close_before_rename.patch
+  patch -p1 -i ${srcdir}/gphoto2-check-popt.patch
 }
 
 build() {

--- a/mingw-w64-gphoto2/gphoto2-check-popt.patch
+++ b/mingw-w64-gphoto2/gphoto2-check-popt.patch
@@ -1,0 +1,144 @@
+--- a/gphoto-m4/gp-check-popt.m4.orig	2021-05-02 08:23:25.783794195 +0200
++++ b/gphoto-m4/gp-check-popt.m4	2021-05-02 08:28:34.109849996 +0200
+@@ -62,57 +62,10 @@
+ if test "x$POPT_CFLAGS" = "x" && test "x$POPT_LIBS" = "x"; then
+ 
+ 	# try to find options to compile popt.h
+-	CPPFLAGS_save="$CPPFLAGS"
+ 	popth_found=no
+-        case "$MSYSTEM" in
+-         MINGW32)
+-		if test -n "/mingw32"; then
+-			:
+-		elif test -d "/mingw32/include"; then
+-			CPPFLAGS="-I/mingw32/include ${CPPFLAGS}"
+-		else
+-			continue
+-		fi
+-		ac_cv_header_popt_h=""
+-		unset ac_cv_header_popt_h
+-		AC_CHECK_HEADER([popt.h], [popth_found=yes])
+-         ;;
+-         MINGW64)
+-		if test -n "${popt_prefix}"; then
+-			:
+-		elif test -d "/mingw64/include"; then
+-			CPPFLAGS="-I/mingw64/include ${CPPFLAGS}"
+-		else
+-			continue
+-		fi
+-		ac_cv_header_popt_h=""
+-		unset ac_cv_header_popt_h
+-		AC_CHECK_HEADER([popt.h], [popth_found=yes])
+-         ;;
+-         *)
+-           for popt_prefix in "" /usr /usr/local
+-           do
+-		if test -n "${popt_prefix}"; then
+-			:
+-		elif test -d "${popt_prefix}/include"; then
+-			CPPFLAGS="-I${popt_prefix}/include ${CPPFLAGS}"
+-		else
+-			continue
+-		fi
+-		ac_cv_header_popt_h=""
+-		unset ac_cv_header_popt_h
+-		AC_CHECK_HEADER([popt.h], [popth_found=yes])
+-		if test "$popth_found" = yes; then break; fi
+-	   done
+-         ;;
+-        esac
+-	CPPFLAGS="$CPPFLAGS_save"
++        AC_CHECK_HEADER([popt.h], [popth_found=yes])
+ 	if test "$popth_found" = "yes"; then
+-		if test "$popt_prefix" = ""; then
+-			POPT_CFLAGS=""
+-		else
+-			POPT_CFLAGS="-I${popt_prefix}/include"
+-		fi
++                POPT_CFLAGS=""
+ 	elif test "$require_popt" = "yes"; then
+ 		AC_MSG_ERROR([
+ * Cannot autodetect popt.h
+@@ -122,77 +75,12 @@
+ 	fi
+ 
+ 	# try to find options to link against popt
+-	LDFLAGS_save="$LDFLAGS"
+ 	popt_links=no
+-        case "$MSYSTEM" in
+-         MINGW32)
+-#		for ldir in "" lib; do
+-			popt_libdir="/mingw32/lib"
+-			if test "${popt_libdir}" = "/"; then
+-				popt_libdir=""
+-			elif test -d "${popt_libdir}"; then
+-				LDFLAGS="-L${popt_libdir} ${LDFLAGS}"
+-			else
+-				continue
+-			fi
+-			# Avoid caching of results
+-			ac_cv_lib_popt_poptStuffArgs=""
+-			unset ac_cv_lib_popt_poptStuffArgs
+-			AC_CHECK_LIB([popt], [poptStuffArgs], [popt_links=yes])
+-         ;;
+-         MINGW64)
+-			popt_libdir="/mingw64/lib"
+-			if test "${popt_libdir}" = "/"; then
+-				popt_libdir=""
+-			elif test -d "${popt_libdir}"; then
+-				LDFLAGS="-L${popt_libdir} ${LDFLAGS}"
+-			else
+-				continue
+-			fi
+-			# Avoid caching of results
+-			ac_cv_lib_popt_poptStuffArgs=""
+-			unset ac_cv_lib_popt_poptStuffArgs
+-			AC_CHECK_LIB([popt], [poptStuffArgs], [popt_links=yes])
+-          ;;
+-         *)
+-	    for popt_prefix in /usr "" /usr/local; do
+-		# We could have "/usr" and "lib64" at the beginning of the
+-		# lists. Then the first tested location would
+-		# incidentally be the right one on 64bit systems, and
+-		# thus work around a bug in libtool on 32bit systems:
+-		#
+-		# 32bit libtool doesn't know about 64bit systems, and so the
+-		# compilation will fail when linking a 32bit library from
+-		# /usr/lib to a 64bit binary.
+-		#
+-		# This hack has been confirmed to workwith a
+-		# 32bit Debian Sarge and 64bit Fedora Core 3 system.
+-		for ldir in lib64 "" lib; do
+-			popt_libdir="${popt_prefix}/${ldir}"
+-			if test "${popt_libdir}" = "/"; then
+-				popt_libdir=""
+-			elif test -d "${popt_libdir}"; then
+-				LDFLAGS="-L${popt_libdir} ${LDFLAGS}"
+-			else
+-				continue
+-			fi
+-			# Avoid caching of results
+-			ac_cv_lib_popt_poptStuffArgs=""
+-			unset ac_cv_lib_popt_poptStuffArgs
+-			AC_CHECK_LIB([popt], [poptStuffArgs], [popt_links=yes])
+-			if test "$popt_links" = yes; then break; fi
+-		done
+-		if test "$popt_links" = yes; then break; fi
+-	  done
+-         ;;
+-        esac
+-	LDFLAGS="$LDFLAGS_save"
++        ac_cv_lib_popt_poptStuffArgs=""
++        unset ac_cv_lib_popt_poptStuffArgs
++        AC_CHECK_LIB([popt], [poptStuffArgs], [popt_links=yes])
+ 	if test "$popt_links" = "yes"; then
+-		if test "$popt_libdir" = ""; then
+-			POPT_LIBS="-lpopt"
+-		else
+-			POPT_LIBS="-L${popt_libdir} -lpopt"
+-		fi
++                POPT_LIBS="-lpopt"
+ 		have_popt=yes
+ 	elif test "$require_popt" = "yes"; then
+ 		AC_MSG_ERROR([


### PR DESCRIPTION
The ucrt64 build was failing because the gp-check-popt.m4 macro explicitly tests `MSYSTEM` to be `MINGW32` or `MINGW64`, but not for `UCRT64`. The check is done twice, once for the location of the `popt.h` header file, and once for the library path.
It results in `-I/usr/include` being added to the CPPFLAGS, which causes the compilation to fail. 
I fixed it by adding a test for `UCRT64` and now it works. 
But it is not very robust and will fail if another architecture is added (clang64?).
