### PR TITLE
clang: change LLVM_HOST_TRIPLE

### DIFF
--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -38,7 +38,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
            "${MINGW_PACKAGE_PREFIX}-openmp")
          "${MINGW_PACKAGE_PREFIX}-polly")
 pkgver=11.0.0
-pkgrel=11
+pkgrel=12
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -353,7 +353,7 @@ build() {
     -DLLVM_ENABLE_PROJECTS="${_projects}" \
     -DLLVM_ENABLE_SPHINX=ON \
     -DLLVM_ENABLE_THREADS=ON \
-    -DLLVM_HOST_TRIPLE="${MINGW_CHOST}" \
+    -DLLVM_HOST_TRIPLE="${CARCH}-w64-windows-gnu" \
     -DLLVM_INCLUDE_EXAMPLES=OFF \
     -DLLVM_LINK_LLVM_DYLIB=ON \
     -DLLVM_POLLY_LINK_INTO_TOOLS=OFF \
@@ -409,7 +409,7 @@ build() {
     -DLIBUNWIND_USE_COMPILER_RT=ON
     -DLLVM_ENABLE_LLD=ON
     -DLLVM_ENABLE_PROJECTS="libcxx;libcxxabi;libunwind"
-    -DLLVM_HOST_TRIPLE="${MINGW_CHOST}"
+    -DLLVM_HOST_TRIPLE="${CARCH}-w64-windows-gnu"
     -DPython3_FIND_REGISTRY=NEVER
     -DPython3_ROOT_DIR=${MINGW_PREFIX})
 


### PR DESCRIPTION
LLVM seems to expect `${CARCH}-w64-windows-gnu`, while `${MINGW_CHOST}` is `${CARCH}-w64-mingw32`

Fixes #8517

It may be better to remove setting LLVM_HOST_TRIPLE altogether, but I want to test a native aarch64 build first (and it'll be a while before my Pi is ready to do that) so proposing this in the meantime.