### PR TITLE
more libssp dependencies

### DIFF
--- a/mingw-w64-arm-none-eabi-gdb/PKGBUILD
+++ b/mingw-w64-arm-none-eabi-gdb/PKGBUILD
@@ -8,7 +8,7 @@ _target=arm-none-eabi
 pkgbase=mingw-w64-${_target}-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_target}-${_realname}")
 pkgver=9.2
-pkgrel=2
+pkgrel=3
 pkgdesc='GNU Tools for ARM Embedded Processors - GDB (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -38,6 +38,7 @@ sha256sums=(
 )
 depends=("${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-libiconv"
+         "${MINGW_PACKAGE_PREFIX}-libssp"
          "${MINGW_PACKAGE_PREFIX}-ncurses"
          "${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-readline"

--- a/mingw-w64-cjson/PKGBUILD
+++ b/mingw-w64-cjson/PKGBUILD
@@ -4,13 +4,14 @@ _realname=cjson
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.7.14
-pkgrel=1
+pkgrel=2
 pkgdesc="Ultralightweight JSON parser in ANSI C (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 url="https://github.com/DaveGamble/cJSON"
 license=('MIT')
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-libssp")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-ninja")

--- a/mingw-w64-gdb/PKGBUILD
+++ b/mingw-w64-gdb/PKGBUILD
@@ -6,15 +6,16 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-multiarch")
 pkgver=10.1
-pkgrel=2
+pkgrel=3
 pkgdesc="GNU Debugger (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 url="https://www.gnu.org/software/gdb/"
 license=('GPL')
-groups=("${MINGW_PACKAGE_PREFIX}-toolchain")
+groups=($( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-toolchain" ))
 depends=("${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-libiconv"
+         "${MINGW_PACKAGE_PREFIX}-libssp"
          "${MINGW_PACKAGE_PREFIX}-ncurses"
          "${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-readline"

--- a/mingw-w64-libressl/PKGBUILD
+++ b/mingw-w64-libressl/PKGBUILD
@@ -4,14 +4,15 @@ _realname=libressl
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=3.1.1
-pkgrel=1
+pkgrel=2
 pkgdesc="LibreSSL Encryption (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 url='https://www.libressl.org/'
 license=('BSD')
 options=('staticlibs' 'strip')
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-libssp")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 source=("https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/${_realname}-${pkgver}.tar.gz"
         "0001-libressl_relocation-msys.patch"


### PR DESCRIPTION
A few more packages that need libssp, that I found in the last run through autobuild.

I also adjusted gdb so that it is not in the toolchain group on clang prefixes.  It should be perfectly safe to install on a clang prefix (unlike gcc or binutils), but lldb is the toolchain's debugger there.