### PR TITLE
pdcurses: fix building with clang

### DIFF
--- a/mingw-w64-pdcurses/004-link-implib.patch
+++ b/mingw-w64-pdcurses/004-link-implib.patch
@@ -1,0 +1,15 @@
+--- PDCursesMod-4.1.0/wingui/Makefile.mng.orig	2021-04-30 22:23:42.270025000 -0700
++++ PDCursesMod-4.1.0/wingui/Makefile.mng	2021-04-30 22:24:54.066906800 -0700
+@@ -155,10 +155,10 @@
+ 
+ firework.exe ozdemo.exe newtest.exe ptest.exe rain.exe testcurs.exe  \
+ version.exe worm.exe xmas.exe: %.exe: $(demodir)/%.c
+-	$(CC) $(CFLAGS) -mwindows -o$@ $< $(LIBCURSES) $(EXELIBS)
++	$(CC) $(CFLAGS) -mwindows -o$@ $< $(LIBARCHIVE) $(EXELIBS)
+ 
+ tuidemo.exe: tuidemo.o tui.o
+-	$(LINK) $(LDFLAGS) -mwindows -o$@ tuidemo.o tui.o $(LIBCURSES) $(EXELIBS)
++	$(LINK) $(LDFLAGS) -mwindows -o$@ tuidemo.o tui.o $(LIBARCHIVE) $(EXELIBS)
+ 
+ tui.o: $(demodir)/tui.c $(demodir)/tui.h $(PDCURSES_CURSES_H)
+ 	$(CC) -c $(CFLAGS) -I$(demodir) -o$@ $<

--- a/mingw-w64-pdcurses/PKGBUILD
+++ b/mingw-w64-pdcurses/PKGBUILD
@@ -8,7 +8,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-curses")
 #replaces=("${MINGW_PACKAGE_PREFIX}-ncurses" "${MINGW_PACKAGE_PREFIX}-termcap")
 #conflicts=("${MINGW_PACKAGE_PREFIX}-ncurses" "${MINGW_PACKAGE_PREFIX}-termcap")
 pkgver=4.1.0
-pkgrel=4
+pkgrel=5
 pkgdesc="Curses library on the Win32 API (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -20,17 +20,20 @@ options=('staticlibs' 'strip')
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/Bill-Gray/PDCursesMod/archive/v${pkgver}.tar.gz"
         001-mingw-pdcurses-4.1.0-build.patch
         002-fix-exports.patch
-        003-fix-_bool-was-not-declared.patch)
+        003-fix-_bool-was-not-declared.patch
+        004-link-implib.patch)
 sha256sums=('c6e036c0cb24f7909dbb8fa5011564727cd64a91efd3b7bb3e81c7509d7f5fde'
             '913b5aff09d0ab1a2197f66a98657927d85a0dc3577c2b5e69179148fb2b0242'
             '246f93facdd2703f8b9d0bcd57e89688fd861d34a30facc60a48892b330b08bc'
-            '6f6875068a13988988b8b04300636db4c4f9f543632597232cb2b64a2fd1218b')
+            '6f6875068a13988988b8b04300636db4c4f9f543632597232cb2b64a2fd1218b'
+            '39c6488570cd7b492f636b47972d40ec6e809744daeed85ef415df9c1ae6f3ff')
 
 prepare() {
   cd PDCursesMod-${pkgver}
   patch -p1 -i ${srcdir}/001-mingw-pdcurses-4.1.0-build.patch
   patch -p1 -i ${srcdir}/002-fix-exports.patch
   patch -p1 -i ${srcdir}/003-fix-_bool-was-not-declared.patch
+  patch -p1 -i ${srcdir}/004-link-implib.patch
 }
 
 build() {
@@ -44,7 +47,6 @@ build() {
   pushd wingui-shared-${CARCH}
     make -f Makefile.mng \
       CC=${MINGW_PREFIX}/bin/gcc \
-      LINK=${MINGW_PREFIX}/bin/gcc \
       STRIP=${MINGW_PREFIX}/bin/strip \
       AR=${MINGW_PREFIX}/bin/ar \
       WIDE=Y \
@@ -56,7 +58,6 @@ build() {
   pushd wingui-static-${CARCH}
     make -f Makefile.mng \
       CC=${MINGW_PREFIX}/bin/gcc \
-      LINK=${MINGW_PREFIX}/bin/gcc \
       STRIP=${MINGW_PREFIX}/bin/strip \
       AR=${MINGW_PREFIX}/bin/ar \
       WIDE=Y \


### PR DESCRIPTION
Don't set LINK, it seems to confuse clang/lld, and defaults to $CC anyway

Link to import library, not DLL, for lld compatibility.