### PR TITLE
ruby: disable graphviz for clang.

### DIFF
--- a/mingw-w64-ruby/PKGBUILD
+++ b/mingw-w64-ruby/PKGBUILD
@@ -10,7 +10,7 @@ _realname=ruby
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.0.1
-pkgrel=2
+pkgrel=3
 pkgdesc="An object-oriented language for quick and easy programming (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -18,7 +18,7 @@ url="https://www.ruby-lang.org/en"
 license=("BSD, custom")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" 
              "${MINGW_PACKAGE_PREFIX}-doxygen"
-             "${MINGW_PACKAGE_PREFIX}-graphviz"
+             $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-graphviz" )
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-gdbm"


### PR DESCRIPTION
It's not available yet.  It's crashing on clang at this point, but want
to get more eyes on it.

/cc @Biswa96 