### PR TITLE
libdeflate, libpng, libtiff: fix clang build

### DIFF
--- a/mingw-w64-libdeflate/001-libdeflate-makefile-mingw-fix.patch
+++ b/mingw-w64-libdeflate/001-libdeflate-makefile-mingw-fix.patch
@@ -1,20 +1,31 @@
 diff -Naur libdeflate-1.7.orig/Makefile libdeflate-1.7/Makefile
---- libdeflate-1.7.orig/Makefile	2020-11-10 04:29:50.000000000 +0100
-+++ libdeflate-1.7/Makefile	2020-11-12 15:54:02.152338000 +0100
-@@ -85,11 +85,10 @@
+--- libdeflate-1.7.orig/Makefile       2020-11-10 04:29:50.000000000 +0100
++++ libdeflate-1.7/Makefile    2020-11-12 15:54:02.152338000 +0100
+@@ -84,14 +84,18 @@
+ HARD_LINKS         := 1
  
  # Compiling for Windows with MinGW?
- ifneq ($(findstring -mingw,$(shell $(CC) -dumpmachine 2>/dev/null)),)
+-ifneq ($(findstring -mingw,$(shell $(CC) -dumpmachine 2>/dev/null)),)
 -    STATIC_LIB_SUFFIX  := static.lib
++DUMPMACHINE := $(shell $(CC) -dumpmachine 2>/dev/null)
++ifneq ($(findstring -mingw,$(DUMPMACHINE))$(findstring -windows-gnu,$(DUMPMACHINE)),)
      SHARED_LIB         := libdeflate.dll
      SHARED_LIB_SYMLINK :=
      SHARED_LIB_CFLAGS  :=
 -    SHARED_LIB_LDFLAGS := -Wl,--out-implib,libdeflate.lib \
+-                          -Wl,--output-def,libdeflate.def \
+-                          -Wl,--add-stdcall-alias
 +    SHARED_LIB_LDFLAGS := -Wl,--out-implib,libdeflate.dll.a \
-                           -Wl,--output-def,libdeflate.def \
-                           -Wl,--add-stdcall-alias
++                          -Wl,--output-def,libdeflate.def
++    # only if not clang
++    ifeq ($(findstring -windows-gnu,$(DUMPMACHINE)),)
++        SHARED_LIB_LDFLAGS += -Wl,--add-stdcall-alias
++    endif
++
      PROG_SUFFIX        := .exe
-@@ -305,7 +304,8 @@
+     PROG_CFLAGS        := -static -municode
+     HARD_LINKS         :=
+@@ -305,7 +309,8 @@
  install:all
  	install -d $(DESTDIR)$(LIBDIR) $(DESTDIR)$(INCDIR) $(DESTDIR)$(BINDIR)
  	install -m644 $(STATIC_LIB) $(DESTDIR)$(LIBDIR)
@@ -24,7 +35,7 @@ diff -Naur libdeflate-1.7.orig/Makefile libdeflate-1.7/Makefile
  	install -m644 libdeflate.h $(DESTDIR)$(INCDIR)
  	install -m755 gzip$(PROG_SUFFIX) \
  		$(DESTDIR)$(BINDIR)/libdeflate-gzip$(PROG_SUFFIX)
-@@ -318,7 +318,8 @@
+@@ -318,7 +323,8 @@
  
  uninstall:
  	rm -f $(DESTDIR)$(LIBDIR)/$(STATIC_LIB)				\

--- a/mingw-w64-libdeflate/PKGBUILD
+++ b/mingw-w64-libdeflate/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libdeflate
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.7
-pkgrel=1
+pkgrel=2
 pkgdesc="Heavily optimized library for DEFLATE/zlib/gzip compression and decompression (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -14,7 +14,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/ebiggers/libdeflate/archive/v${pkgver}.tar.gz"
         "001-libdeflate-makefile-mingw-fix.patch")
 sha256sums=('a5e6a0a9ab69f40f0f59332106532ca76918977a974e7004977a9498e3f11350'
-            '3416c533717a7dda6acf3e0f111ba9478517a7b98bec41821bd019901742cb9b')
+            '22ff75e0ca7f3f8d3442701a55945b6a9799fe1351aa43c371a86f7399dafb5a')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}

--- a/mingw-w64-libpng/PKGBUILD
+++ b/mingw-w64-libpng/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.6.37
 _apngver=1.6.37
-pkgrel=3
+pkgrel=4
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 pkgdesc="A collection of routines used to create PNG format graphics (mingw-w64)"
@@ -26,6 +26,8 @@ prepare() {
 
   # Add animated PNG (apng) support
   patch -p1 -i "${srcdir}/${_realname}-${_apngver}-apng.patch"
+  # autoreconf to get updated libtool files with clang support
+  autoreconf -fiv
 }
 
 build() {

--- a/mingw-w64-libtiff/PKGBUILD
+++ b/mingw-w64-libtiff/PKGBUILD
@@ -5,7 +5,7 @@ _realname=libtiff
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Library for manipulation of TIFF images (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -15,7 +15,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          #"${MINGW_PACKAGE_PREFIX}-jbigkit"
          "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
          "${MINGW_PACKAGE_PREFIX}-libdeflate"
-         "${MINGW_PACKAGE_PREFIX}-libwebp"
+         $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-libwebp" )
          "${MINGW_PACKAGE_PREFIX}-xz"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-zstd")
@@ -26,6 +26,8 @@ sha256sums=('eb0484e568ead8fa23b513e9b0041df7e327f4ee2d22db5a533929dfc19633cb')
 
 prepare() {
   cd tiff-${pkgver}
+  # autoreconf to get updated libtool files for clang support
+  autoreconf -fiv
 }
 
 build() {


### PR DESCRIPTION
libdeflate:
- Detect mingw as -windows-gnu in addition to -mingw
- Don't include -Wl,--add-stdcall-alias for clang (identified by -windows-gnu)

libpng:
- autoreconf for clang shared library
  ```diff
  --- /dev/fd/63	2021-05-02 02:13:32.000000000 +0000
  +++ /dev/fd/62	2021-05-02 02:13:32.000000000 +0000
  @@ -1,5 +1,6 @@
   /clang64/
   /clang64/bin/
  +/clang64/bin/libpng16-16.dll
   /clang64/bin/libpng16-config
   /clang64/bin/libpng-config
   /clang64/bin/png2pnm.exe
  @@ -18,7 +19,9 @@
   /clang64/include/pnglibconf.h
   /clang64/lib/
   /clang64/lib/libpng.a
  +/clang64/lib/libpng.dll.a
   /clang64/lib/libpng16.a
  +/clang64/lib/libpng16.dll.a
   /clang64/lib/pkgconfig/
   /clang64/lib/pkgconfig/libpng.pc
   /clang64/lib/pkgconfig/libpng16.pc
  ```

libtiff:
- autoreconf for clang support
- disable libwebp dependency to break cycle.  Revert once libwebp is built.

This is enough for libwebp to build for me