### PR TITLE
yaml-cpp: fix compilation with clang64

### DIFF
--- a/mingw-w64-yaml-cpp/010-no-fPIC.patch
+++ b/mingw-w64-yaml-cpp/010-no-fPIC.patch
@@ -1,0 +1,10 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -156,7 +156,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR
+ 	set(GCC_EXTRA_OPTIONS "")
+ 	#
+ 	if(YAML_BUILD_SHARED_LIBS)
+-		set(GCC_EXTRA_OPTIONS "${GCC_EXTRA_OPTIONS} -fPIC")
+ 	endif()
+ 	#
+ 	set(FLAG_TESTED "-Wextra -Wshadow -Weffc++ -pedantic -pedantic-errors")

--- a/mingw-w64-yaml-cpp/PKGBUILD
+++ b/mingw-w64-yaml-cpp/PKGBUILD
@@ -4,7 +4,7 @@ _realname=yaml-cpp
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.6.3
-pkgrel=3
+pkgrel=4
 pkgdesc="A YAML parser and emitter in C++ matching the YAML 1.2 spec (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -16,13 +16,16 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
 options=('staticlibs' 'strip')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/jbeder/yaml-cpp/archive/${_realname}-${pkgver}.tar.gz
-        mingw-install-pkgconfig.patch)
+        mingw-install-pkgconfig.patch
+        010-no-fPIC.patch)
 sha256sums=('77ea1b90b3718aa0c324207cb29418f5bced2354c2e483a9523d98c3460af1ed'
-            '872d28cfb8cfc0280de846e80359c1ae3987afc8095b653df1a4e18daa7dcf72')
+            '872d28cfb8cfc0280de846e80359c1ae3987afc8095b653df1a4e18daa7dcf72'
+            '597da9ea350a4c13e07ce3f0fd5f66b40209610644762ee55b1435103375ae24')
 
 prepare() {
   cd ${srcdir}/${_realname}-${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/mingw-install-pkgconfig.patch
+  patch -p1 -i ${srcdir}/010-no-fPIC.patch
 }
 
 build() {
@@ -34,6 +37,7 @@ build() {
   ${MINGW_PREFIX}/bin/cmake.exe \
     -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
     -DYAML_BUILD_SHARED_LIBS=ON \
     -DYAML_CPP_BUILD_TESTS=OFF \
     ../${_realname}-${_realname}-${pkgver}


### PR DESCRIPTION
fPIC was causing issues. Fix by using the CMAKE variable instead.

Signed-off-by: Rosen Penev <rosenp@gmail.com>