### PR TITLE
proj: autoreconf for clang support

### DIFF
--- a/mingw-w64-proj/PKGBUILD
+++ b/mingw-w64-proj/PKGBUILD
@@ -4,7 +4,7 @@ _realname=proj
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=6.3.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Cartographic projection software (PROJ.4) (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -19,6 +19,8 @@ sha256sums=('cb776a70f40c35579ae4ba04fb4a388c1d1ce025a1df6171350dc19f25b80311')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
+  # autoreconf to get updated libtool files for clang
+  autoreconf -fiv
 }
 
 build() {


### PR DESCRIPTION
This allows libgeotiff to build successfully for clang64