### PR TITLE
libevent and tor for clang64

### DIFF
--- a/mingw-w64-libevent/PKGBUILD
+++ b/mingw-w64-libevent/PKGBUILD
@@ -5,7 +5,7 @@ _realname=libevent
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.1.12
-pkgrel=1
+pkgrel=2
 pkgdesc="An event notification library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -25,6 +25,8 @@ prepare() {
   # to make transmission work, taken from:
   # https://github.com/transmission/libevent/commit/72e50166aaa2c3b3c35e336039df7101bd418264
   patch -p1 -i ${srcdir}/event2-02-win32.patch
+  # autoreconf to get updated libtool files for clang support
+  autoreconf -fiv
 }
 
 build() {

--- a/mingw-w64-tor/PKGBUILD
+++ b/mingw-w64-tor/PKGBUILD
@@ -4,13 +4,14 @@ _realname=tor
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.4.5.7
-pkgrel=1
+pkgrel=2
 pkgdesc="Anonymizing overlay network (mingw-w64)"
 url="https://www.torproject.org/"
 license=('BSD')
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 depends=("${MINGW_PACKAGE_PREFIX}-libevent"
+         "${MINGW_PACKAGE_PREFIX}-libssp"
          "${MINGW_PACKAGE_PREFIX}-openssl"
          "${MINGW_PACKAGE_PREFIX}-xz"
          "${MINGW_PACKAGE_PREFIX}-zlib"


### PR DESCRIPTION
libevent:
- autoreconf to get updated libtool files with clang support

tor:
- depend on libssp