### PR TITLE
libreplaygain: fix clang64 build

### DIFF
--- a/mingw-w64-libreplaygain/010-no-fpic.patch
+++ b/mingw-w64-libreplaygain/010-no-fpic.patch
@@ -1,0 +1,8 @@
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -3,4 +3,3 @@ METASOURCES = AUTO
+ lib_LTLIBRARIES = libreplaygain.la
+ libreplaygain_la_LDFLAGS = -no-undefined -version-info 1:0:0
+ libreplaygain_la_SOURCES = gain_analysis.c
+-AM_CFLAGS = -fpic
+\ No newline at end of file

--- a/mingw-w64-libreplaygain/PKGBUILD
+++ b/mingw-w64-libreplaygain/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libreplaygain
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=475
-pkgrel=1
+pkgrel=2
 pkgdesc="A library to adjust audio gain (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -12,11 +12,14 @@ url="http://musepack.net/"
 license=("LGPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 options=('staticlibs' 'strip')
-source=("http://files.musepack.net/source/${_realname}_r${pkgver}.tar.gz")
-sha512sums=('b5fce8daf6aa8c8e0adb4c80089b43824b6503cb7d11e0c47c779c57a933b32f0c24722ca3fcf49711199fddcbb92c3fc13876f22418ca1521c7b8e27ba9d409')
+source=("http://files.musepack.net/source/${_realname}_r${pkgver}.tar.gz"
+        "010-no-fpic.patch")
+sha512sums=('b5fce8daf6aa8c8e0adb4c80089b43824b6503cb7d11e0c47c779c57a933b32f0c24722ca3fcf49711199fddcbb92c3fc13876f22418ca1521c7b8e27ba9d409'
+            '4a552e3d37f03162ca1c30715cd36e2e40c2f5f527bd39c9369fe5c823ad60e65996a2d9f5e13d5d05ccb0df0aa25ca41d68892617528e3132fc1b075bfc1f45')
 
 prepare() {
   cd "${srcdir}"/${_realname}_r${pkgver}
+  patch -p1 -i ${srcdir}/010-no-fpic.patch
   autoreconf -i
 }
 


### PR DESCRIPTION
Removed pointless fpic.

Signed-off-by: Rosen Penev <rosenp@gmail.com>