### PR TITLE
package fixes for clang

### DIFF
--- a/mingw-w64-djvulibre/PKGBUILD
+++ b/mingw-w64-djvulibre/PKGBUILD
@@ -4,7 +4,7 @@ _realname=djvulibre
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.5.28
-pkgrel=1
+pkgrel=2
 pkgdesc="Suite to create, manipulate and view DjVu (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -23,6 +23,8 @@ sha256sums=('fcd009ea7654fde5a83600eb80757bd3a76998e47d13c66b54c8db849f8f2edc')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
+  # autoreconf to get updated libtool files for clang
+  autoreconf -fiv
 }
 
 build() {

--- a/mingw-w64-fftw/PKGBUILD
+++ b/mingw-w64-fftw/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _pkgver=3.3.9
 pkgver=${_pkgver//-/.}
-pkgrel=1
+pkgrel=2
 pkgdesc="A library for computing the discrete Fourier transform (DFT) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -17,7 +17,8 @@ options=('staticlibs' 'strip')
 source=("${url}/${_realname}-${_pkgver}.tar.gz")
 sha256sums=('bf2c7ce40b04ae811af714deb512510cc2c17b9ab9d6ddcf49fe4487eea7af3d')
 
-precision="double float long_double quad"
+precision="double float long_double \
+           $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "quad" )"
 
 build() {
   cd "${srcdir}/${_realname}-${_pkgver}"


### PR DESCRIPTION
djvulibre: autoreconf for clang

fftw: disable quad precision build for clang (libquadmath is part of gcc)