### PR TITLE
baobab: update to 40.0

### DIFF
--- a/mingw-w64-baobab/0001-Build-GUI-application-on-windows.patch
+++ b/mingw-w64-baobab/0001-Build-GUI-application-on-windows.patch
@@ -1,0 +1,26 @@
+From 3788939047d3450668e74c26c51f9091fcf05522 Mon Sep 17 00:00:00 2001
+From: Gabriel Rauter <rauter.gabriel@gmail.com>
+Date: Tue, 4 May 2021 11:16:28 +0200
+Subject: [PATCH 2/2] Build GUI application on windows
+
+Add win_subsystem: 'windows' keyword argument to the baobab executable
+in meson so it builds a GUI instead of a TUI on Windows.
+Needs meson >= 0.56
+---
+ src/meson.build | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/meson.build b/src/meson.build
+index b857f3d..d094418 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -49,5 +49,6 @@ executable('baobab', baobab_sources,
+   c_args: baobab_c_args,
+   dependencies: baobab_dependencies,
+   export_dynamic: true,
++  win_subsystem: 'windows',
+   install: true
+ )
+-- 
+2.31.1
+

--- a/mingw-w64-baobab/0001-Fix-application-icon-name-in-baobab-main-window.ui.patch
+++ b/mingw-w64-baobab/0001-Fix-application-icon-name-in-baobab-main-window.ui.patch
@@ -1,0 +1,27 @@
+From cb4216a709e9364e3c17ddebd7cdfb9a85089391 Mon Sep 17 00:00:00 2001
+From: Gabriel Rauter <rauter.gabriel@gmail.com>
+Date: Sat, 22 Aug 2020 10:53:58 +0200
+Subject: [PATCH] Fix application icon name in baobab-main-window.ui
+
+Use the correct named icon for the window. This is needed to get the
+right icon on mingw builds.
+---
+ data/ui/baobab-main-window.ui | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/data/ui/baobab-main-window.ui b/data/ui/baobab-main-window.ui
+index b677cb5..2590abc 100644
+--- a/data/ui/baobab-main-window.ui
++++ b/data/ui/baobab-main-window.ui
+@@ -64,7 +64,7 @@
+   </object>
+   <template class="BaobabWindow" parent="HdyApplicationWindow">
+     <property name="title" translatable="yes">Disk Usage Analyzer</property>
+-    <property name="icon_name">baobab</property>
++    <property name="icon_name">org.gnome.baobab</property>
+     <child>
+       <object class="GtkBox" id="vbox">
+       <property name="orientation">vertical</property>
+-- 
+2.31.1
+

--- a/mingw-w64-baobab/PKGBUILD
+++ b/mingw-w64-baobab/PKGBUILD
@@ -21,8 +21,20 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-meson")
 options=('strip' 'staticlibs')
 license=("GPL2")
-source=("https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz")
-sha256sums=('a6aeaa2c327a997fe0d5f443ce95b785e2ba6e338fb0a026cb7dc7d7d688d1a7')
+source=("https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz"
+        "0001-Fix-application-icon-name-in-baobab-main-window.ui.patch"
+        "0001-Build-GUI-application-on-windows.patch")
+sha256sums=('a6aeaa2c327a997fe0d5f443ce95b785e2ba6e338fb0a026cb7dc7d7d688d1a7'
+            '53b44512790623b318c07584ea72c85acaf5c1280c00dde8969e863010cb183c'
+            '29fdd3e63e1b87dc9b88ee23674bda6bdd127828a8c542279ae4185a1e72f6b7')
+
+prepare() {
+    cd "${_realname}-${pkgver}"
+    # https://gitlab.gnome.org/GNOME/baobab/-/merge_requests/23
+    patch --forward --strip=1 --input="${srcdir}/0001-Fix-application-icon-name-in-baobab-main-window.ui.patch"
+    # https://gitlab.gnome.org/GNOME/baobab/-/merge_requests/32
+    patch --forward --strip=1 --input="${srcdir}/0001-Build-GUI-application-on-windows.patch"
+}
 
 build() {
   [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}

--- a/mingw-w64-baobab/PKGBUILD
+++ b/mingw-w64-baobab/PKGBUILD
@@ -3,14 +3,15 @@
 _realname=baobab
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.38.0
-pkgrel=2
+pkgver=40.0
+pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
 pkgdesc="A graphical directory tree analyzer (mingw-w64)"
 url="https://wiki.gnome.org/Apps/DiskUsageAnalyzer"
 depends=("${MINGW_PACKAGE_PREFIX}-gsettings-desktop-schemas"
          "${MINGW_PACKAGE_PREFIX}-gobject-introspection-runtime"
+         "${MINGW_PACKAGE_PREFIX}-libhandy"
          "${MINGW_PACKAGE_PREFIX}-librsvg")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-vala"
@@ -21,7 +22,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 options=('strip' 'staticlibs')
 license=("GPL2")
 source=("https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz")
-sha256sums=('048468147860816b97f15d50b3c84e9acf0539c1441cfeb63703d112e8728329')
+sha256sums=('a6aeaa2c327a997fe0d5f443ce95b785e2ba6e338fb0a026cb7dc7d7d688d1a7')
 
 build() {
   [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}


### PR DESCRIPTION
Updates baobab to 40.0 and adds patches to fix icon and to build a Windows GUI application instead of a Windows TUI application.