### PR TITLE
cairo: remove librsvg dep, fix ucrt build

### DIFF
--- a/mingw-w64-cairo/0030-ucrt-clang-fixes.patch
+++ b/mingw-w64-cairo/0030-ucrt-clang-fixes.patch
@@ -1,0 +1,11 @@
+--- cairo-1.17.4/src/cairo-compiler-private.h.orig	2021-05-04 17:46:38.073000000 +0200
++++ cairo-1.17.4/src/cairo-compiler-private.h	2021-05-04 17:50:50.920604000 +0200
+@@ -203,7 +203,7 @@
+ #define popen _popen
+ #define strdup _strdup
+ #define unlink _unlink
+-#if _MSC_VER < 1900
++#if (defined(_MSC_VER) && _MSC_VER < 1900)
+   #define vsnprintf _vsnprintf
+   #define snprintf _snprintf
+ #endif

--- a/mingw-w64-cairo/PKGBUILD
+++ b/mingw-w64-cairo/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _commit='156cd3eaaebfd8635517c2baf61fcf3627ff7ec2'
 pkgver=1.17.4
-pkgrel=2
+pkgrel=3
 pkgdesc="Cairo vector graphics library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -14,9 +14,7 @@ url="https://cairographics.org/"
 license=(LGPL2.1 MPL1.1)
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-glib2"
-             "${MINGW_PACKAGE_PREFIX}-librsvg"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
-             "${MINGW_PACKAGE_PREFIX}-gtk-doc"
              "${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "git"
@@ -34,11 +32,13 @@ options=('strip' 'staticlibs')
 source=("https://gitlab.freedesktop.org/cairo/cairo/-/archive/${_commit}/cairo-${_commit}.tar.gz"
         0001-fix-font-names-in-pdf-output.patch
         0026-create-argb-fonts.all.patch
-        0027-win32-print-fix-unbounded-surface-assertion.patch)
+        0027-win32-print-fix-unbounded-surface-assertion.patch
+        0030-ucrt-clang-fixes.patch)
 sha256sums=('204215866aa392c27d3e1306f6ea1946a623bf86fff3143f777d1e8bf4383bb0'
             'a5926f8bca3cb09e41ed8d2a60fb053c4243fdeec2c36c5c7e15d2a784b6ee9a'
             '6db6c44fbdb4926d09afa978fe80430186c4b7b7d255059602b1f94c6a079975'
-            '7e244c20eec8c7b287dbee1d34de178d9b0c419dc4c2b11c90eaf626c92bf781')
+            '7e244c20eec8c7b287dbee1d34de178d9b0c419dc4c2b11c90eaf626c92bf781'
+            '86c1af2878a20bd3608fc476e4ba1f2451458a5f6f12e457e37b61082c38db82')
 
 prepare() {
   mv "${srcdir}/${_realname}-${_commit}" "${srcdir}/${_realname}-${pkgver}"
@@ -51,6 +51,8 @@ prepare() {
 
   # https://gitlab.freedesktop.org/cairo/cairo/-/issues/131
   patch -p1 -i ${srcdir}/0027-win32-print-fix-unbounded-surface-assertion.patch
+
+  patch -p1 -i ${srcdir}/0030-ucrt-clang-fixes.patch
 }
 
 build() {


### PR DESCRIPTION
librsvg is only needed for tests which we don't build