### PR TITLE
package dependency fixes

### DIFF
--- a/mingw-w64-pybind11/PKGBUILD
+++ b/mingw-w64-pybind11/PKGBUILD
@@ -4,7 +4,7 @@ _realname=pybind11
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.6.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A lightweight header-only library that exposes C++ types in Python and vice versa (mingw-w64)"
 url='https://pybind11.readthedocs.org/'
 license=('BSD')
@@ -20,6 +20,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python-sphinx"
              "${MINGW_PACKAGE_PREFIX}-python-sphinx_rtd_theme"
+             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-moderncmakedomain"
              "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-svg2pdfconverter"
              "${MINGW_PACKAGE_PREFIX}-python-pytest")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")

--- a/mingw-w64-starpu/PKGBUILD
+++ b/mingw-w64-starpu/PKGBUILD
@@ -4,11 +4,12 @@ _realname=starpu
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.3.7
-pkgrel=2
+pkgrel=3
 pkgdesc='StarPU is a task programming library for hybrid architectures (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 depends=("${MINGW_PACKAGE_PREFIX}-fftw"
+         "${MINGW_PACKAGE_PREFIX}-libssp"
          "${MINGW_PACKAGE_PREFIX}-libtool")
 makedepends=("${MINGW_PACKAGE_PREFIX}-hwloc")
 options=('!docs')


### PR DESCRIPTION
- pybind11: makedepends on python-sphinxcontrib-moderncmakedomain
- starpu: depends on libssp