### PR TITLE
mecab: don't explicitly link to libstdc++

### DIFF
--- a/mingw-w64-mecab/PKGBUILD
+++ b/mingw-w64-mecab/PKGBUILD
@@ -4,7 +4,7 @@ _realname=mecab
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.996
-pkgrel=3
+pkgrel=4
 pkgdesc="Yet another Japanese morphological analyzer (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -28,6 +28,7 @@ prepare() {
   patch -p1 -i ${srcdir}/mecab-0.996.diff
   patch -p1 -i ${srcdir}/mecab-0.996-iconv.patch
   patch -p1 -i ${srcdir}/mecab-0.996-naist-jdic.patch
+  sed -i.orig -e '/^AC_CHECK_LIB(stdc++/d' configure.in
   mkdir -p m4
   autoreconf --force
   libtoolize --install


### PR DESCRIPTION
clang claims to be able to link to it, but libtool reveals the truth
that libstdc++ doesn't exist for clang prefixes.

Fixes #8549