### PR TITLE
distorm: remove -s option from install

### DIFF
--- a/mingw-w64-distorm/Makefile
+++ b/mingw-w64-distorm/Makefile
@@ -33,9 +33,9 @@ install: ${TARGET}
 	mkdir ${DESTDIR}${INSTALL_PREFIX}
 	mkdir ${DESTDIR}${INSTALL_PREFIX}/bin
 	mkdir ${DESTDIR}${INSTALL_PREFIX}/lib
-	install -s ${TARGET} ${DESTDIR}${INSTALL_PREFIX}/bin
-	install -s ${IMPORTLIB} ${DESTDIR}${INSTALL_PREFIX}/lib
-	install -s ${STATICLIB} ${DESTDIR}${INSTALL_PREFIX}/lib
+	install ${TARGET} ${DESTDIR}${INSTALL_PREFIX}/bin
+	install ${IMPORTLIB} ${DESTDIR}${INSTALL_PREFIX}/lib
+	install ${STATICLIB} ${DESTDIR}${INSTALL_PREFIX}/lib
 
 .c.o:
 	${CC} ${CFLAGS} ${VERSION} -c $< -o $@

--- a/mingw-w64-distorm/PKGBUILD
+++ b/mingw-w64-distorm/PKGBUILD
@@ -4,7 +4,7 @@ _realname=distorm
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.5
-pkgrel=1
+pkgrel=2
 pkgdesc="Powerful disassembler library for x86/AMD64 (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -18,7 +18,7 @@ options=('strip' 'staticlibs')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/gdabah/distorm/archive/v${pkgver}.tar.gz
         Makefile)
 sha256sums=('fd9169871424965b159c9b273adaaa49650d7941776286a0e38ee340e6e1e06d'
-            'c68a5059e925158c7fccfe700a136287b13c10ff19c60ba3fda044cf7fa130b8')
+            'ab6b1147ae861a256f8ee597cfc420acce8d4369a2ef83915afb48a83593ea02')
 
 prepare() {
   cd ${_realname}-${pkgver}


### PR DESCRIPTION
llvm-strip doesn't want to strip .a files, and the PKGBUILD sets the 'strip' option anyway.