### PR TITLE
librime: link in icu

### DIFF
--- a/mingw-w64-librime/PKGBUILD
+++ b/mingw-w64-librime/PKGBUILD
@@ -4,13 +4,14 @@ _realname=librime
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.5.3
-pkgrel=2
+pkgrel=3
 pkgdesc="Rime Input Method Engine Library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 url="https://github.com/rime/librime"
 license=('BSD')
 depends=("${MINGW_PACKAGE_PREFIX}-boost"
+         "${MINGW_PACKAGE_PREFIX}-icu"
          "${MINGW_PACKAGE_PREFIX}-leveldb"
          "${MINGW_PACKAGE_PREFIX}-marisa"
          "${MINGW_PACKAGE_PREFIX}-opencc"
@@ -50,6 +51,7 @@ build() {
     -DBUILD_TEST=OFF \
     -DBOOST_USE_CXX11=ON \
     -DBUILD_STATIC=ON \
+    -DBUILD_WITH_ICU=ON \
     -DENABLE_LOGGING="no" \
     -DCMAKE_CXX_STANDARD_LIBRARIES="-lbcrypt" \
     "../${_realname}-${pkgver}"


### PR DESCRIPTION
boost brings in a dependency on icu, so this needs to link it too or
there are undefined symbols.

This failed for gcc as well as clang, I guess boost started pulling in
icu at some point after this was built?