### PR TITLE
cairomm, libsigc++3 autoreconf for clang

### DIFF
--- a/mingw-w64-cairomm/PKGBUILD
+++ b/mingw-w64-cairomm/PKGBUILD
@@ -4,17 +4,23 @@ _realname=cairomm
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.12.2
-pkgrel=2
+pkgrel=3
 pkgdesc="C++ bindings to Cairo vector graphics library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 url="https://www.cairographics.org/"
 license=("LGPL, MPL")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config" "${MINGW_PACKAGE_PREFIX}-glib2")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config" "${MINGW_PACKAGE_PREFIX}-glib2" "mm-common")
 depends=( "${MINGW_PACKAGE_PREFIX}-libsigc++" "${MINGW_PACKAGE_PREFIX}-cairo")
 options=(strip staticlibs)
 source=("https://www.cairographics.org/releases/cairomm-${pkgver}.tar.gz")
 sha256sums=('45c47fd4d0aa77464a75cdca011143fea3ef795c4753f6e860057da5fb8bd599')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  # autoreconf for updated libtool files with clang support
+  autoreconf -fiv
+}
 
 build() {
   CPPFLAGS+=" -D_REENTRANT -D_POSIX_SOURCE"

--- a/mingw-w64-libsigc++3/PKGBUILD
+++ b/mingw-w64-libsigc++3/PKGBUILD
@@ -4,20 +4,22 @@ _realname=libsigc++
 pkgbase=mingw-w64-${_realname}3
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}3"
 pkgver=3.0.3
-pkgrel=2
+pkgrel=3
 pkgdesc="Libsigc++ implements a full callback system for use in widget libraries - V3 (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 url="https://libsigcplusplus.github.io/libsigcplusplus/"
 license=("LGPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "mm-common")
 options=('staticlibs' 'strip')
 source=("https://github.com/libsigcplusplus/libsigcplusplus/releases/download/${pkgver}/${_realname}-${pkgver}.tar.xz")
 sha256sums=('e4f4866a894bdbe053e4fb22ccc6bc4b6851fd31a4746fdd20b2cf6e87c6edb6')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
+  # autoreconf for updated libtool files with clang support
+  autoreconf -fiv
 }
 
 build() {


### PR DESCRIPTION
This (make)depends on new msys2 package 'mm-common' (msys2/MSYS2-packages#2478) to succeed, since that
contains necessary autoconf macros.