### PR TITLE
leptonica, tesseract-ocr clang fixes

### DIFF
--- a/mingw-w64-leptonica/PKGBUILD
+++ b/mingw-w64-leptonica/PKGBUILD
@@ -4,7 +4,7 @@ _realname=leptonica
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.80.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Leptonica library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -25,6 +25,8 @@ sha256sums=('ec9c46c2aefbb960fb6a6b7f800fe39de48343437b6ce08e30a8d9688ed14ba4')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
+  # autoreconf to get updated libtool files with clang support
+  autoreconf -fiv
 }
 
 build() {

--- a/mingw-w64-tesseract-ocr/PKGBUILD
+++ b/mingw-w64-tesseract-ocr/PKGBUILD
@@ -5,7 +5,7 @@ _realname=tesseract-ocr
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.1.1
-pkgrel=6
+pkgrel=7
 pkgdesc="Tesseract OCR (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -22,12 +22,15 @@ depends=(${MINGW_PACKAGE_PREFIX}-cairo
          ${MINGW_PACKAGE_PREFIX}-zlib)
 options=('!libtool' 'strip')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/tesseract-ocr/tesseract/archive/${pkgver}.tar.gz
-        https://github.com/tesseract-ocr/tessdata_fast/raw/master/osd.traineddata)
+        https://github.com/tesseract-ocr/tessdata_fast/raw/master/osd.traineddata
+        tesseract-no-as-needed.patch)
 sha256sums=('2a66ff0d8595bff8f04032165e6c936389b1e5727c3ce5a27b3e059d218db1cb'
-            '9cf5d576fcc47564f11265841e5ca839001e7e6f38ff7f7aacf46d15a96b00ff')
+            '9cf5d576fcc47564f11265841e5ca839001e7e6f38ff7f7aacf46d15a96b00ff'
+            '60aa311301015e78a96edb228db160fe10784e074f45ef3d7e6ecbc8d52eb388')
 
 prepare() {
   cd "${srcdir}/tesseract-${pkgver}"
+  patch -p1 -i "${srcdir}/tesseract-no-as-needed.patch"
 
   ./autogen.sh
 }

--- a/mingw-w64-tesseract-ocr/tesseract-no-as-needed.patch
+++ b/mingw-w64-tesseract-ocr/tesseract-no-as-needed.patch
@@ -1,0 +1,11 @@
+--- tesseract-4.1.1/src/api/Makefile.am.orig	2021-05-05 11:01:16.091542600 -0700
++++ tesseract-4.1.1/src/api/Makefile.am	2021-05-05 11:04:58.638484300 -0700
+@@ -103,7 +103,7 @@
+ if T_WIN
+ tesseract_LDADD += -ltiff
+ tesseract_LDADD += -lws2_32
+-libtesseract_la_LDFLAGS += -no-undefined -Wl,--as-needed -lws2_32
++libtesseract_la_LDFLAGS += -no-undefined -lws2_32
+ endif
+ if ADD_RT
+ tesseract_LDADD += -lrt


### PR DESCRIPTION
leptonica: autoreconf for clang support

tesseract-ocr: remove `-Wl,--as-needed` linker flag 
according to mesonbuild/meson#4230 this flag and `-Wl,--no-undefined` are silently ignored by binutils LD, but they cause
errors on LLD so remove them.

Unfortunately this is not sufficient for tesseract-ocr to build under clang64, after these fixes it hits #8554 