### PR TITLE
Akira: Avoid open cmd terminal running app

### DIFF
--- a/mingw-w64-akira/Avoid-open-cmd-terminal-running-on-windows.patch
+++ b/mingw-w64-akira/Avoid-open-cmd-terminal-running-on-windows.patch
@@ -1,0 +1,24 @@
+From acee8a1e6b3df5c3d9987dad60cbcc07d5a5ae8a Mon Sep 17 00:00:00 2001
+From: Alberto Fanjul <albertofanjul@gmail.com>
+Date: Wed, 5 May 2021 21:50:07 +0200
+Subject: [PATCH] Avoid open cmd terminal running on windows
+
+---
+ src/meson.build | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/meson.build b/src/meson.build
+index 904c515..ac02bd4 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -155,5 +155,6 @@ executable(
+     asresources,
+     config_header,
+     dependencies: deps,
+-    install: true
++    install: true,
++    win_subsystem: 'windows'
+ )
+-- 
+2.30.1
+

--- a/mingw-w64-akira/PKGBUILD
+++ b/mingw-w64-akira/PKGBUILD
@@ -4,7 +4,7 @@ _realname=akira
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.0.14
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
 pkgdesc="Akira is a native Linux Design application built in Vala and GTK. (mingw-w64)"
@@ -23,8 +23,15 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-meson"
 options=('strip')
 license=("GPL3")
 url="https://github.com/akiraux/Akira"
-source=(https://github.com/akiraux/Akira/archive/refs/tags/v0.0.14.tar.gz)
-sha256sums=('fa6c7c9db686a7c81cb3fb6b462581cec17698d32bd8e6ee6328aa70718a8a62')
+source=(https://github.com/akiraux/Akira/archive/refs/tags/v0.0.14.tar.gz
+        Avoid-open-cmd-terminal-running-on-windows.patch)
+sha256sums=('fa6c7c9db686a7c81cb3fb6b462581cec17698d32bd8e6ee6328aa70718a8a62'
+            'fa8fa4787316a392649884bb621cf23f3114652a50e260470863beb5ef8f3b1d')
+
+prepare() {
+  cd $srcdir/${_realname}-${pkgver}
+  patch -N -p1 -i $srcdir/Avoid-open-cmd-terminal-running-on-windows.patch
+}
 
 build() {
   [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}


### PR DESCRIPTION
As a GUI app, meson build system needs this flag to avoid opening a cmd terminal with app logs