### PR TITLE
mingw-w64-qemu: Enable 5.2.0, spice support, refactor install locations, documentation

### DIFF
--- a/mingw-w64-qemu/PKGBUILD
+++ b/mingw-w64-qemu/PKGBUILD
@@ -1,5 +1,3 @@
-# Maintainer: Martell Malone <martellmalone@gmail.com>
-
 _realname=qemu
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
@@ -7,88 +5,164 @@ _base_ver=5.2.0
 _rc=
 pkgver=${_base_ver}${_rc//-/.}
 pkgrel=1
-pkgdesc="A generic and open source processor emulator (mingw-w64)"
+pkgdesc="QEMU - a generic and open source machine emulator and virtualizer (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 license=('GPL2' 'LGPL2')
 url="https://qemu.org/"
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-python"
-             'perl' 'bison' 'bsdtar')
-depends=("${MINGW_PACKAGE_PREFIX}-capstone"
-         "${MINGW_PACKAGE_PREFIX}-curl"
-         "${MINGW_PACKAGE_PREFIX}-cyrus-sasl"
-         "${MINGW_PACKAGE_PREFIX}-glib2"
-         "${MINGW_PACKAGE_PREFIX}-gnutls"
-         "${MINGW_PACKAGE_PREFIX}-gtk3"
-         "${MINGW_PACKAGE_PREFIX}-libjpeg"
-         "${MINGW_PACKAGE_PREFIX}-libpng"
-         "${MINGW_PACKAGE_PREFIX}-libssh"
-         "${MINGW_PACKAGE_PREFIX}-libtasn1"
-         "${MINGW_PACKAGE_PREFIX}-libusb"
-         "${MINGW_PACKAGE_PREFIX}-libxml2"
-         "${MINGW_PACKAGE_PREFIX}-lzo2"
-         "${MINGW_PACKAGE_PREFIX}-nettle"
-         "${MINGW_PACKAGE_PREFIX}-pixman"
-         "${MINGW_PACKAGE_PREFIX}-snappy"
-         "${MINGW_PACKAGE_PREFIX}-SDL2"
-         "${MINGW_PACKAGE_PREFIX}-SDL2_image"
-         "${MINGW_PACKAGE_PREFIX}-libslirp"
-         "${MINGW_PACKAGE_PREFIX}-usbredir"
-         "${MINGW_PACKAGE_PREFIX}-zstd")
+# optional features which introduce many dependencies should be added to makedepends
+# for activation and optdepends for information
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-gcc"
+  "${MINGW_PACKAGE_PREFIX}-ninja"
+  "${MINGW_PACKAGE_PREFIX}-python"
+  "${MINGW_PACKAGE_PREFIX}-python-sphinx"
+  "${MINGW_PACKAGE_PREFIX}-spice"
+  'perl' 'bison' 'bsdtar')
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-capstone"
+  "${MINGW_PACKAGE_PREFIX}-curl"
+  "${MINGW_PACKAGE_PREFIX}-cyrus-sasl"
+  "${MINGW_PACKAGE_PREFIX}-glib2"
+  "${MINGW_PACKAGE_PREFIX}-gnutls"
+  "${MINGW_PACKAGE_PREFIX}-gtk3"
+  "${MINGW_PACKAGE_PREFIX}-libjpeg"
+  "${MINGW_PACKAGE_PREFIX}-libnfs"
+  "${MINGW_PACKAGE_PREFIX}-libpng"
+  "${MINGW_PACKAGE_PREFIX}-libslirp"
+  "${MINGW_PACKAGE_PREFIX}-libssh"
+  "${MINGW_PACKAGE_PREFIX}-libtasn1"
+  "${MINGW_PACKAGE_PREFIX}-libusb"
+  "${MINGW_PACKAGE_PREFIX}-libxml2"
+  "${MINGW_PACKAGE_PREFIX}-lzo2"
+  "${MINGW_PACKAGE_PREFIX}-nettle"
+  "${MINGW_PACKAGE_PREFIX}-pixman"
+  "${MINGW_PACKAGE_PREFIX}-SDL2"
+  "${MINGW_PACKAGE_PREFIX}-SDL2_image"
+  "${MINGW_PACKAGE_PREFIX}-snappy"
+  "${MINGW_PACKAGE_PREFIX}-usbredir"
+  "${MINGW_PACKAGE_PREFIX}-zstd"
+)
+optdepends=(
+  "${MINGW_PACKAGE_PREFIX}-spice: to enable spice usage"
+)
 source=(https://download.qemu.org/${_realname}-${pkgver}.tar.xz{,.sig})
-sha256sums=('cb18d889b628fbe637672b0326789d9b0e3b8027e0445b936537c78549df17bc'
-            'SKIP')
+sha256sums=('cb18d889b628fbe637672b0326789d9b0e3b8027e0445b936537c78549df17bc' 'SKIP')
 validpgpkeys=('CEACC9E15534EBABB82D3FA03353C9CEF108B584') # Michael Roth <flukshun@gmail.com>
+# tar cannot create links, to keep build running, manual extraction is required
 noextract=(${_realname}-${pkgver}.tar.xz)
 
 prepare() {
   [[ -d "${srcdir}"/${_realname}-${pkgver} ]] && rm -rf "${srcdir}"/${_realname}-${pkgver}
-  tar -xJf ${srcdir}/${_realname}-${pkgver}.tar.xz -C ${srcdir} || true
+  # tar cannot create links here, therefore hide the failure
+  tar -xf ${srcdir}/${_realname}-${pkgver}.tar.xz -C ${srcdir} || true
 
   cd "${srcdir}/${_realname}-${pkgver}"
 }
 
 build() {
+  # Requirements as documented in https://wiki.qemu.org/Hosts/W32#Native_builds_with_MSYS2
+  #   Execution of
+  #     configure --cross-prefix=${CARCH}-w64-mingw32-
+  #   and
+  #   Providing cross-prefixed binaries by copying
+  #     ${CARCH}-w64-mingw32-objcopy.exe using objcopy.exe
+  #     ${CARCH}-w64-mingw32-windres.exe using windres.exe
+  #     ${CARCH}-w64-mingw32-ranlib.exe  using ${CARCH}-w64-mingw32-gcc-ranlib.exe
+  #     ${CARCH}-w64-mingw32-ar.exe      using ${CARCH}-w64-mingw32-gcc-ar.exe
+  #     ${CARCH}-w64-mingw32-nm.exe      using nm.exe
   LDFLAGS+=" -fstack-protector"
-
-  local -a _extra_config
-  if [[ "$CARCH" = 'x86_64' ]]; then
-    _extra_config+=("--enable-whpx")
-  fi
-
   [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
   mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
 
-  ../${_realname}-${pkgver}/configure \
-      --disable-werror \
-      --disable-kvm \
-      --disable-spice \
-      --disable-libnfs \
-      --enable-capstone=system \
-      --enable-gnutls \
-      --enable-libssh \
-      --enable-lzo \
-      --enable-nettle \
-      --enable-slirp=system \
-      --enable-snappy \
-      --enable-hax \
-      --enable-gtk \
-      --enable-sdl \
-      --enable-zstd \
-      "${_extra_config[@]}" \
-      --prefix=${MINGW_PREFIX} \
-      --bindir=${MINGW_PREFIX}/bin \
-      --datadir=${MINGW_PREFIX}/bin \
-      --firmwarepath=${MINGW_PREFIX}/etc/qemu \
-      --python=${MINGW_PREFIX}/bin/python \
-      --mandir=${MINGW_PREFIX}/share/qemu \
-      --docdir=${MINGW_PREFIX}/share/qemu
+  # We need to provide all expected cross-prefixed tools without links or copying!
+  # We will also provide undocumented ${CARCH}-w64-mingw32-strip.exe using strip.exe
+  # Msys2 already provides some duplicates in ${MINGW_PREFIX}/bin:
+  #   gcc-ar.exe is ${CARCH}-w64-mingw32-gcc-ar.exe
+  #   gcc-ranlib.exe is ${CARCH}-w64-mingw32-gcc-ranlib.exe
+  # These common, not prefixed exports read by configure fulfill all qemu requirements
+  export AR=gcc-ar
+  export NM=nm
+  export OBJCOPY=objcopy
+  export RANLIB=gcc-ranlib
+  export STRIP=strip
+  export WINDRES=windres
 
+  # configure failes to create links, which can be ignored
+  # qemu enables all features if possible, so keep it simple
+  # configuration of paths for win32 is unpredictable:
+  #  => just place into /qemu and relocate in package()
+  # For faster testing:
+  #TARGETLIST="--target-list=x86_64-softmmu"
+  ../${_realname}-${pkgver}/configure $TARGETLIST \
+    --cross-prefix=${CARCH}-w64-mingw32- \
+    --python=${MINGW_PREFIX}/bin/python \
+    --prefix=/qemu
+
+  # Finally build
   make
 }
 
-package() {
+check() {
   cd "${srcdir}"/build-${CARCH}
-  make DESTDIR="${pkgdir}/" install
+  make test
+}
+
+package() {
+  # Install to ${pkgdir}
+  cd "${srcdir}"/build-${CARCH}
+  make DESTDIR="${pkgdir}" install
+
+  # qemu was installed somewhere below ${pkgdir}, determine qemu installation dir
+  local P_QEMU=$(find ${pkgdir} -name qemu -type d)
+
+  # Define and create target dirs for packaing
+  local P_M_LIB="${pkgdir}"/${MINGW_PREFIX}/lib
+  local P_M_BIN="${pkgdir}"/${MINGW_PREFIX}/bin
+  local P_M_SHARE="${pkgdir}"/${MINGW_PREFIX}/share
+  local P_M_MAN="${pkgdir}"/${MINGW_PREFIX}/share/man
+  local P_M_SHARE_QEMU="${pkgdir}"/${MINGW_PREFIX}/share/qemu
+  local P_M_QEMUDOC="${pkgdir}"/${MINGW_PREFIX}/share/doc/qemu
+  local P_M_QEMULICENSES="${pkgdir}"/${MINGW_PREFIX}/share/licenses/qemu
+  mkdir -p $P_M_LIB $P_M_BIN $P_M_SHARE $P_M_MAN $P_M_SHARE_QEMU $P_M_QEMUDOC $P_M_QEMULICENSES
+
+  # Move qemu from installation in $P_QEMU to correct $P_M_* dirs
+  mv $P_QEMU/applications $P_M_SHARE/
+  mv $P_QEMU/locale $P_M_SHARE/
+  mv $P_QEMU/icons $P_M_SHARE/
+  mv $P_QEMU/man* $P_M_MAN/
+  mv $P_QEMU/firmware $P_M_SHARE_QEMU/
+  # collect docs and move to $P_M_QEMUDOC
+  mv $P_QEMU/index.html $P_QEMU/system $P_QEMU/user \
+    $P_QEMU/specs $P_QEMU/tools $P_QEMU/interop \
+    $P_M_QEMUDOC/
+  # Now move the binaries incl keymaps
+  mv $P_QEMU $P_M_LIB/
+  rmdir $(dirname $P_QEMU)
+
+  # Target /xxx/lib
+  local M_LIB=${MINGW_PREFIX}/lib
+  # Fix firmware descriptors in $P_M_SHARE_QEMU/firmware
+  find $P_M_SHARE_QEMU/firmware -type f -exec \
+    sed -i  "s%\(\"filename\": \"\).*edk2%\1$M_LIB/qemu/edk2%" {} \;
+  # For executables in ${MINGGW_PREFIX}/lib/qemu create wrappers in ${MINGGW_PREFIX}/bin
+  local P_M_LIBEXES=$(find $P_M_LIB -name "*.exe" ! -name "*w.exe")
+  local P_M_LIBEXE=""
+  for P_M_LIBEXE in $P_M_LIBEXES
+  do
+    local EXE=$(basename $P_M_LIBEXE)
+    local WRAPPER=$P_M_BIN/$EXE
+    echo "#!/bin/bash"                       >> $WRAPPER
+    echo "export PATH=\"$M_LIB/qemu:$PATH\"" >> $WRAPPER
+    echo "exec $M_LIB/qemu/$EXE \$@"         >> $WRAPPER
+    chmod u+x $WRAPPER
+  done
+
+  # Add all licenses found in qemu sources
+  cd "${srcdir}"/${_realname}-${pkgver}
+  tar -c $(
+    find -iname "*COPYING*" -or -iname "*LICENSE*" |
+      egrep -v "meson.(test|msi|doc)" |
+      egrep -v "(license.c|relicense.pl|license.doctree|LicenseCheck)"
+    ) | tar -C "$P_M_QEMULICENSES" -x
 }

--- a/mingw-w64-qemu/PKGBUILD
+++ b/mingw-w64-qemu/PKGBUILD
@@ -31,6 +31,7 @@ depends=(
   "${MINGW_PACKAGE_PREFIX}-libpng"
   "${MINGW_PACKAGE_PREFIX}-libslirp"
   "${MINGW_PACKAGE_PREFIX}-libssh"
+  "${MINGW_PACKAGE_PREFIX}-libssp"
   "${MINGW_PACKAGE_PREFIX}-libtasn1"
   "${MINGW_PACKAGE_PREFIX}-libusb"
   "${MINGW_PACKAGE_PREFIX}-libxml2"
@@ -154,7 +155,7 @@ package() {
     local WRAPPER=$P_M_BIN/$EXE
     echo "#!/bin/bash"                       >> $WRAPPER
     echo "export PATH=\"$M_LIB/qemu:$PATH\"" >> $WRAPPER
-    echo "exec $M_LIB/qemu/$EXE \$@"         >> $WRAPPER
+    echo "exec $M_LIB/qemu/$EXE \"\$@\""     >> $WRAPPER
     chmod u+x $WRAPPER
   done
 


### PR DESCRIPTION
As already discussed in https://github.com/msys2/MINGW-packages/issues/8567 here my PR for qemu 5.2.0

**Relocation of installation**
{MINGW_PREFIX}/bin/<QEMU_STUFF>
is splitted into
- {MINGW_PREFIX}/lib/qemu
- 	{MINGW_PREFIX}/share/man
- 	{MINGW_PREFIX}/share/locale
- 	{MINGW_PREFIX}/share/icons
- 	{MINGW_PREFIX}/share/applications
- 	{MINGW_PREFIX}/share/doc
- 	{MINGW_PREFIX}/share/licenses
- 	{MINGW_PREFIX}/share/qemu/firmware

Relevant binaries in 
{MINGW_PREFIX}/lib/qemu 
are invocated by identically named wrappers in
{MINGW_PREFIX}/bin

**New feature**
spice is included and can be used if optional dep spice (adds 150MiB extra) is installed
	
**Package split was not done**
qemu binary package adds 750MiB which includes 250MiB for GDI-doubles (e.g. qemu-system-x86_64.exe and its double qemu-system-x86_64w.exe)

Hopefully the builds pass as expected...