### PR TITLE
xalan-c: fix compilation with clang

### DIFF
--- a/mingw-w64-xalan-c/04-no-std-file.patch
+++ b/mingw-w64-xalan-c/04-no-std-file.patch
@@ -1,0 +1,11 @@
+--- a/src/xalanc/PlatformSupport/XalanFileOutputStream.hpp
++++ b/src/xalanc/PlatformSupport/XalanFileOutputStream.hpp
+@@ -41,8 +41,6 @@
+ namespace XALAN_CPP_NAMESPACE {
+ 
+ 
+-using std::FILE;
+-
+ class XALAN_PLATFORMSUPPORT_EXPORT XalanFileOutputStream : public XalanOutputStream
+ {
+ public :

--- a/mingw-w64-xalan-c/PKGBUILD
+++ b/mingw-w64-xalan-c/PKGBUILD
@@ -4,7 +4,7 @@ _realname=xalan-c
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.12
-pkgrel=2
+pkgrel=3
 pkgdesc="An XSLT processing library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -12,6 +12,7 @@ url="https://xalan.apache.org/xalan-c"
 license=('APACHE')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-doxygen"
              "${MINGW_PACKAGE_PREFIX}-tools")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
@@ -21,17 +22,20 @@ options=('!libtool' 'strip')
 source=(https://archive.apache.org/dist/xalan/xalan-c/sources/xalan_c-${pkgver}.tar.gz
         01-mingw-icu.patch
         02-mingw-as-msvc.patch
-        03-install-layout.patch)
+        03-install-layout.patch
+        04-no-std-file.patch)
 sha256sums=('ee7d4b0b08c5676f5e586c7154d94a5b32b299ac3cbb946e24c4375a25552da7'
             '64ca2fb25114fd9c35c0a0815c7308ab3222eb421965892a402c4f30d23f180b'
             '8ccef1339fcfb6472861545295a9cb72a6b8da3a81407d082a5df51ac5f5c8e0'
-            '35f2cf6b4aefb29c1c88f94b808c07a2b2845c025f236b38f4e31b5e378ba874')
+            '35f2cf6b4aefb29c1c88f94b808c07a2b2845c025f236b38f4e31b5e378ba874'
+            '0b2bcce90c90261e309a7d3914631f91deaca00930acda487c9b828c581ea968')
 
 prepare(){
   cd "${srcdir}"/${_realname//-/_}-${pkgver}
   patch -p1 -i ${srcdir}/01-mingw-icu.patch
   patch -p1 -i ${srcdir}/02-mingw-as-msvc.patch
   patch -p1 -i ${srcdir}/03-install-layout.patch
+  patch -p1 -i ${srcdir}/04-no-std-file.patch
 }
 
 build() {
@@ -47,18 +51,18 @@ build() {
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe \
-    -G"MSYS Makefiles" \
+    -G"Ninja" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     ${extra_config} \
     -DBUILD_SHARED_LIBS=ON \
     ../${_realname//-/_}-${pkgver}
 
-  make
+  ninja
 }
 
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
-  make DESTDIR=${pkgdir} install
+  DESTDIR=${pkgdir} ninja install
 
   install -Dm644 ${srcdir}/${_realname//-/_}-${pkgver}/LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
libcxx as configured does not have std::FILE

Signed-off-by: Rosen Penev <rosenp@gmail.com>