### PR TITLE
helics: Update to 2.7.0

### DIFF
--- a/mingw-w64-helics/PKGBUILD
+++ b/mingw-w64-helics/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=helics
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.6.1
+pkgver=2.7.0
 pkgrel=1
 pkgdesc="Hierarchical Engine for Large-scale Infrastructure Co-Simulation (mingw-w64)"
 arch=('any')
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-boost")
 options=('!staticlibs' '!strip')
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/GMLC-TDC/HELICS/releases/download/v${pkgver}/HELICS-v${pkgver}-source.tar.gz")
-sha256sums=('4b9a733a568ae8e6492f93abcd43f1aa9c53b233edcbeb0ab188dcc0d73ac928')
+sha256sums=('ad005c0948ef4284417d429112772d0b63ebfbc62c9093c02ac10f4a333d70f4')
 
 #prepare() {
 #  mkdir -p test


### PR DESCRIPTION
Update to the HELICS 2.7.0 release