### PR TITLE
wxWidgets: backport clang on Windows linking fix.

### DIFF
--- a/mingw-w64-wxWidgets/004-wxWidgets-3.0-clang-windows-link.patch
+++ b/mingw-w64-wxWidgets/004-wxWidgets-3.0-clang-windows-link.patch
@@ -1,0 +1,26 @@
+From e8a7bae0a750bcb5d8aadc45629d2c9adaf2106c Mon Sep 17 00:00:00 2001
+From: Vadim Zeitlin <vadim@wxwidgets.org>
+Date: Sun, 21 Jul 2019 21:22:55 +0200
+Subject: [PATCH] Alternative clang on Windows link fix
+
+Remove WXDLLIMPEXP_BASE from wxObjectEventFunctor declaration: this
+class only has inline methods and so doesn't define any functions that
+would need to be exported from the DLL.
+
+---
+ include/wx/event.h   | 2 +-
+ 1 files changed, 1 insertion(+), 1 deletions(-)
+
+diff --git a/include/wx/event.h b/include/wx/event.h
+index c196b72b2754..c13e7336b159 100644
+--- a/include/wx/event.h
++++ b/include/wx/event.h
+@@ -210,7 +210,7 @@ class WXDLLIMPEXP_BASE wxEventFunctor
+ };
+ 
+ // A plain method functor for the untyped legacy event types:
+-class WXDLLIMPEXP_BASE wxObjectEventFunctor : public wxEventFunctor
++class wxObjectEventFunctor : public wxEventFunctor
+ {
+ public:
+     wxObjectEventFunctor(wxObjectEventFunction method, wxEvtHandler *handler)

--- a/mingw-w64-wxWidgets/PKGBUILD
+++ b/mingw-w64-wxWidgets/PKGBUILD
@@ -10,7 +10,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 provides=("${MINGW_PACKAGE_PREFIX}-wxmsw${_wx_basever}")
 pkgbase=mingw-w64-${_realname}
 pkgver=${_wx_basever}.5.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -31,11 +31,13 @@ options=('strip' 'staticlibs' 'buildflags')
 source=(https://github.com/wxWidgets/wxWidgets/releases/download/v${pkgver}/wxWidgets-${pkgver}.tar.bz2
         "001-wxWidgets-3.0.2-relocate-prefix-in-bin-wx-config.patch"
         "002-wxWidgets-3.0.2-relax-abi-compatibility-gcc.patch"
-        "003-wxWidgets-3.0.2-fix-access-sample.patch")
+        "003-wxWidgets-3.0.2-fix-access-sample.patch"
+        "004-wxWidgets-3.0-clang-windows-link.patch")
 sha256sums=('440f6e73cf5afb2cbf9af10cec8da6cdd3d3998d527598a53db87099524ac807'
             '7c3b8f6ba275a448a5e82d64c4914acd5aefb8bbb952389688f3e7167a787c56'
             '3138f7b84bf988892f62167afc6fa640ac154b629b243d86413f7c811e508713'
-            'b8684dca94b288a023a8a3d55ad56bce87570576ead71670a237d909ff1c3625')
+            'b8684dca94b288a023a8a3d55ad56bce87570576ead71670a237d909ff1c3625'
+            'b8b49b1df4a7c53d72c7c117606ac9dc44589da474ca58f0806b107469f33dcb')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
@@ -43,6 +45,11 @@ prepare() {
   patch -p1 -i "${srcdir}"/001-wxWidgets-3.0.2-relocate-prefix-in-bin-wx-config.patch
   patch -p1 -i "${srcdir}"/002-wxWidgets-3.0.2-relax-abi-compatibility-gcc.patch
   patch -p1 -i "${srcdir}"/003-wxWidgets-3.0.2-fix-access-sample.patch
+  # squashed upstream commits
+  # https://github.com/wxWidgets/wxWidgets/commit/c0f2f3801150ea9c6640f3fdced1d9120938f0d7
+  # and
+  # https://github.com/wxWidgets/wxWidgets/commit/e8a7bae0a750bcb5d8aadc45629d2c9adaf2106c
+  patch -p1 -i "${srcdir}"/004-wxWidgets-3.0-clang-windows-link.patch
 }
 
 #check() {


### PR DESCRIPTION
This is a squash of 2 upstream commits (the first was a failed attempt
to fix this).