### PR TITLE
Fix building qt6 on clang64.

### DIFF
--- a/mingw-w64-qt6-base/PKGBUILD
+++ b/mingw-w64-qt6-base/PKGBUILD
@@ -22,8 +22,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-double-conversion"
          "${MINGW_PACKAGE_PREFIX}-sqlite3"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 optdepends=("${MINGW_PACKAGE_PREFIX}-libmariadbclient"
-            "${MINGW_PACKAGE_PREFIX}-firebird2"
-            "${MINGW_PACKAGE_PREFIX}-postgresql")
+            $( [[ ${MSYSTEM} == "CLANG64" ]] || echo "${MINGW_PACKAGE_PREFIX}-firebird2" )
+            $( [[ ${MSYSTEM} == "CLANG64" ]] || echo "${MINGW_PACKAGE_PREFIX}-postgresql" ))
 conflicts=("${MINGW_PACKAGE_PREFIX}-qt5"
            "${MINGW_PACKAGE_PREFIX}-qt5-debug"
            "${MINGW_PACKAGE_PREFIX}-qt5-static")
@@ -32,8 +32,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-xmlstarlet"
              "${MINGW_PACKAGE_PREFIX}-libmariadbclient"
-             "${MINGW_PACKAGE_PREFIX}-firebird2"
-             "${MINGW_PACKAGE_PREFIX}-postgresql")
+             $( [[ ${MSYSTEM} == "CLANG64" ]] || echo "${MINGW_PACKAGE_PREFIX}-firebird2" )
+             $( [[ ${MSYSTEM} == "CLANG64" ]] || echo "${MINGW_PACKAGE_PREFIX}-postgresql" ))
 groups=(${MINGW_PACKAGE_PREFIX}-qt6)
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/$_qtver/submodules/$_pkgfn.tar.xz")


### PR DESCRIPTION
Qt6 depends (optional) on firebird2 and postgresql which are broken on clang64.