### PR TITLE
gtkwave: update to 3.3.109

### DIFF
--- a/mingw-w64-gtkwave/PKGBUILD
+++ b/mingw-w64-gtkwave/PKGBUILD
@@ -1,17 +1,17 @@
 # Contributor Ricky Wu <rickleaf.wu@hotmail.com>
 # Contributor Unai Martinez-Corral <unai.martinezcorral@ehu.eus>
 
-# NOTE: This package installs the GTK3 build by default, but provides GTK2 versions of three binaries too:
-# - gtkwave-gtk2.exe
-# - rtlbrowse-gtk2.exe
-# - twinwave-gtk2.exe
-# However, mingw-w64-*-gtk2 is not a dependency. Users willing to use the GTK2 binaries need to install it explicitly.
+# NOTE: This package installs the GTK2 build by default, but provides GTK3 versions of three binaries too:
+# - gtkwave-gtk3.exe
+# - rtlbrowse-gtk3.exe
+# - twinwave-gtk3.exe
+# However, mingw-w64-*-gtk3 is not a dependency. Users willing to use the GTK3 binaries need to install it explicitly.
 
 _realname=gtkwave
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=3.3.108
-pkgrel=1
+pkgrel=2
 pkgdesc='GtkWave, a fully featured GTK+ based wave viewer which reads VCD, GHW, LXT, LXT2, VZT and FST files (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -20,7 +20,7 @@ license=('GPL')
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
 depends=(
   "${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme"
-  "${MINGW_PACKAGE_PREFIX}-gtk3"
+  "${MINGW_PACKAGE_PREFIX}-gtk2"
   "${MINGW_PACKAGE_PREFIX}-gtk-update-icon-cache"
   "${MINGW_PACKAGE_PREFIX}-tcl"
   "${MINGW_PACKAGE_PREFIX}-tcllib"
@@ -31,7 +31,7 @@ makedepends=(
   'perlxml'
   'intltool'
   "${MINGW_PACKAGE_PREFIX}-gcc"
-  "${MINGW_PACKAGE_PREFIX}-gtk2"
+  "${MINGW_PACKAGE_PREFIX}-gtk3"
 )
 source=("https://gtkwave.sourceforge.io/${_realname}-gtk3-${pkgver}.tar.gz")
 sha256sums=('2ed95ec592a287e4a2fe91f7a10a56769cdf67a8fee353ad81fc7b9cb31f1524')
@@ -65,14 +65,14 @@ build() {
 }
 
 package() {
-  cd "${srcdir}/build-${MINGW_CHOST}"-gtk2
+  cd "${srcdir}/build-${MINGW_CHOST}"-gtk3
   make DESTDIR="${pkgdir}" install
 
   _bin="${pkgdir}/${MINGW_PREFIX}"/bin
   for item in gtkwave rtlbrowse twinwave; do
-    mv "${_bin}/${item}".exe "${_bin}/${item}"-gtk2.exe
+    mv "${_bin}/${item}".exe "${_bin}/${item}"-gtk3.exe
   done
 
-  cd "${srcdir}/build-${MINGW_CHOST}"-gtk3
+  cd "${srcdir}/build-${MINGW_CHOST}"-gtk2
   make DESTDIR="${pkgdir}" install
 }

--- a/mingw-w64-gtkwave/PKGBUILD
+++ b/mingw-w64-gtkwave/PKGBUILD
@@ -10,8 +10,8 @@
 _realname=gtkwave
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=3.3.108
-pkgrel=2
+pkgver=3.3.109
+pkgrel=1
 pkgdesc='GtkWave, a fully featured GTK+ based wave viewer which reads VCD, GHW, LXT, LXT2, VZT and FST files (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -34,7 +34,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-gtk3"
 )
 source=("https://gtkwave.sourceforge.io/${_realname}-gtk3-${pkgver}.tar.gz")
-sha256sums=('2ed95ec592a287e4a2fe91f7a10a56769cdf67a8fee353ad81fc7b9cb31f1524')
+sha256sums=('35461eccd9b8b4470caa78ab9a8f14ecacbcc9eff63033d8dce58093e786deb7')
 
 prepare() {
   cd "${srcdir}/${_realname}-gtk3-${pkgver}"


### PR DESCRIPTION
This PR updates GTKWave to 3.3.109.

At the same time, I had to switch the default back to GTK2, because the GTK3 is barely usable and several users were having a bad experience: gtkwave/gtkwave#61.