### PR TITLE
ghdl: update to 1.0.0.r257.g82665d42

### DIFF
--- a/mingw-w64-ghdl/PKGBUILD
+++ b/mingw-w64-ghdl/PKGBUILD
@@ -2,7 +2,7 @@ _realname=ghdl
 pkgbase="mingw-w64-${_realname}"
 pkgname='__placeholder__'
 pkgver=1.0.0.r199.gda51617a
-pkgrel=1
+pkgrel=2
 pkgdesc='GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -31,7 +31,7 @@ build() {
         --enable-checks \
         --enable-libghdl \
         --enable-synth \
-        LDFLAGS="-static"
+        LDFLAGS="-static -Wl,--stack=8388608"
   fi
 
   if [ "$CARCH" = "x86_64" ]; then

--- a/mingw-w64-ghdl/PKGBUILD
+++ b/mingw-w64-ghdl/PKGBUILD
@@ -1,8 +1,8 @@
 _realname=ghdl
 pkgbase="mingw-w64-${_realname}"
 pkgname='__placeholder__'
-pkgver=1.0.0.r199.gda51617a
-pkgrel=2
+pkgver=1.0.0.r257.g82665d42
+pkgrel=1
 pkgdesc='GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -11,7 +11,7 @@ url='https://github.com/ghdl'
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_commit='da51617a'
+_commit='82665d42'
 source=("${_realname}::git://github.com/ghdl/ghdl.git#commit=${_commit}")
 sha512sums=('SKIP')
 


### PR DESCRIPTION
This PR brings several recent updates to GHDL:

- Allow exporting Verilog from VHDL (for synthesis).
- Provide `libghw.dll` and `ghwdump` by default.
- The stack size was increased for the mcode (MINGW32) backend: ghdl/ghdl#1749.