### PR TITLE
Fix build error for package mingw-w64-pidgin

### DIFF
--- a/mingw-w64-pidgin/003-build-fixes.patch
+++ b/mingw-w64-pidgin/003-build-fixes.patch
@@ -1,0 +1,12 @@
+diff -aurN 002/configure.ac 003/configure.ac
+--- 002/configure.ac	2021-05-10 13:13:03.400121700 +0800
++++ 003/configure.ac	2021-05-10 14:00:58.051254800 +0800
+@@ -342,7 +342,7 @@
+ AC_ARG_ENABLE(nls, AC_HELP_STRING([--disable-nls], [disable installation of translation files]), enable_i18n="$enableval", enable_i18n=yes)
+ 
+ if test x$enable_i18n = xyes; then
+-	AC_PROG_INTLTOOL
++AC_PROG_INTLTOOL
+ 	GETTEXT_PACKAGE=pidgin
+ 	AC_SUBST(GETTEXT_PACKAGE)
+ 

--- a/mingw-w64-pidgin/PKGBUILD
+++ b/mingw-w64-pidgin/PKGBUILD
@@ -5,7 +5,7 @@ _realname='pidgin'
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.11.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Multi-protocol instant messaging client (mingw-w64)'
 url='https://pidgin.im'
 license=(GPL2 partial:'GPL2+') # GPL2+, but Novell and SILC are GPL2-only
@@ -15,11 +15,12 @@ mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 options=(!libtool strip staticlibs)
 source=("https://downloads.sourceforge.net/${_realname}/${_realname}-${pkgver}.tar.bz2"
         001-autotools-and-fhs.patch
-        002-build-fixes.patch)
+        002-build-fixes.patch
+        003-build-fixes.patch)
 sha256sums=('f72613440586da3bdba6d58e718dce1b2c310adf8946de66d8077823e57b3333'
             'a5341d2afa5ba30f5ba1ec0092a67671ed18055d01ba9febef5983a246b58841'
-            '2e6cdf921bbf09e0952d26cca2e1f1d502d72714419c723ca1ebacfbbbf6fa24')
-
+            '2e6cdf921bbf09e0952d26cca2e1f1d502d72714419c723ca1ebacfbbbf6fa24'
+            'aaf43a3b068632752aec62f67f1b285f66166a48e9195931ca4fa10aac61b748')
 provides=(${MINGW_PACKAGE_PREFIX}-libpurple)
 depends=(${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme
          ${MINGW_PACKAGE_PREFIX}-ca-certificates
@@ -59,9 +60,10 @@ prepare() {
     rm -f pidgin/plugins/win32/transparency/Makefile.am
     rm -f pidgin/plugins/win32/winprefs/Makefile.am
     patch -p1 < "${srcdir}/001-autotools-and-fhs.patch"
-
     patch -p1 < "${srcdir}/002-build-fixes.patch"
+    patch -p1 < "${srcdir}/003-build-fixes.patch"
     libtoolize --force --copy --install
+    automake --add-missing
     autoreconf -f -i
 }
 


### PR DESCRIPTION
Suggested fix for Bug Report #8625: [pidgin] Package failed to build.