### PR TITLE
emacs: Add upstream patch to fix build with latest mingw-w64-headers-git

### DIFF
--- a/mingw-w64-emacs/PKGBUILD
+++ b/mingw-w64-emacs/PKGBUILD
@@ -5,7 +5,7 @@ _realname=emacs
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=27.2
-pkgrel=2
+pkgrel=3
 pkgdesc="The extensible, customizable, self-documenting, real-time display editor (mingw-w64)"
 url="https://www.gnu.org/software/${_realname}/"
 license=('GPL3')
@@ -39,14 +39,18 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 # Don't zip info files because the built-in info reader uses gzip to
 # decompress them. gzip is not available as a mingw binary.
 options=('strip' '!zipman')
-source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.xz"{,.sig})
+source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.xz"{,.sig}
+	"https://github.com/emacs-mirror/emacs/commit/4c3abb3dd105e075bf1cf55e3fe8b5ec2ac8e6cc.patch"
+	)
 sha256sums=('b4a7cc4e78e63f378624e0919215b910af5bb2a0afc819fad298272e9f40c1b9'
-            'SKIP')
+            'SKIP'
+            'cd948fbd1c09c21e8c4d00ee5facd43bb329204f71c84a576052cdf1b7ebca3f')
 validpgpkeys=('28D3BED851FDF3AB57FEF93C233587A47C207910'
 	      'E6C9029C363AD41D787A8EBB91C1262F01EB8D39')
 
 prepare() {
   cd "${_realname}-${pkgver}"
+  patch -p1 -i "${srcdir}"/4c3abb3dd105e075bf1cf55e3fe8b5ec2ac8e6cc.patch
   ./autogen.sh
 }
 


### PR DESCRIPTION
Add upstream patch to fix build with latest mingw-w64-headers-git.
