### PR TITLE
clang: Force win32 threads for libc++abi

### DIFF
--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -38,7 +38,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
            "${MINGW_PACKAGE_PREFIX}-openmp")
          "${MINGW_PACKAGE_PREFIX}-polly")
 pkgver=12.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -295,6 +295,8 @@ build() {
       -DCMAKE_RANLIB=${srcdir}/build-${MSYSTEM}/bin/llvm-ranlib)
   fi
 
+  # Force win32 threads for libc++abi
+  export CXXFLAGS="${CXXFLAGS} -D_LIBCPP_HAS_THREAD_API_WIN32"
   COMMON_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX}
     -DCMAKE_SYSTEM_IGNORE_PATH=/usr/lib
     -DLIBCXX_ENABLE_EXPERIMENTAL_LIBRARY=ON


### PR DESCRIPTION
This was removed with the update to 12 but is still needed.

See #8640