### PR TITLE
clang: patch to add version option to nm.

### DIFF
--- a/mingw-w64-clang/0011-nm-version-option.patch
+++ b/mingw-w64-clang/0011-nm-version-option.patch
@@ -1,0 +1,60 @@
+From 0e1e36098005b34ef7df3ca16310ae396483464a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Storsj=C3=B6?= <martin@martin.st>
+Date: Tue, 11 May 2021 09:19:52 +0300
+Subject: [PATCH] [llvm-nm] Support the -V option, print that the tool is
+ compatible with GNU nm
+
+This unlocks some codepaths in libtool.
+---
+ llvm/test/tools/llvm-nm/libtool-version.test |  5 +++++
+ llvm/tools/llvm-nm/llvm-nm.cpp               | 13 +++++++++++++
+ 2 files changed, 18 insertions(+)
+ create mode 100644 llvm/test/tools/llvm-nm/libtool-version.test
+
+diff --git llvm/test/tools/llvm-nm/libtool-version.test llvm/test/tools/llvm-nm/libtool-version.test
+new file mode 100644
+index 0000000000000..8d32634fed615
+--- /dev/null
++++ llvm/test/tools/llvm-nm/libtool-version.test
+@@ -0,0 +1,5 @@
++RUN: llvm-nm -V | FileCheck %s
++RUN: llvm-nm --version | FileCheck %s
++Check that the output of llvm-nm -V (and --version) contains the text
++"GNU" somewhere, to let libtool know that it is compatible with GNU nm.
++CHECK: GNU
+diff --git llvm/tools/llvm-nm/llvm-nm.cpp llvm/tools/llvm-nm/llvm-nm.cpp
+index 914b0a14bfedc..93ed3273c4a4e 100644
+--- llvm/tools/llvm-nm/llvm-nm.cpp
++++ llvm/tools/llvm-nm/llvm-nm.cpp
+@@ -224,6 +224,8 @@ cl::opt<bool> AddInlinedInfo("add-inlinedinfo",
+                                       "TBD(Mach-O) only"),
+                              cl::cat(NMCat));
+ 
++cl::opt<bool> Version("V", cl::desc("Print version info"), cl::cat(NMCat));
++
+ cl::extrahelp HelpResponse("\nPass @FILE as argument to read options from FILE.\n");
+ 
+ bool PrintAddress = true;
+@@ -2230,11 +2232,22 @@ static void dumpSymbolNamesFromFile(std::string &Filename) {
+   }
+ }
+ 
++static void printExtraVersionInfo(raw_ostream &outs) {
++  outs << "llvm-nm, compatible with GNU nm\n";
++}
++
+ int main(int argc, char **argv) {
+   InitLLVM X(argc, argv);
+   cl::HideUnrelatedOptions(NMCat);
++  cl::AddExtraVersionPrinter(printExtraVersionInfo);
+   cl::ParseCommandLineOptions(argc, argv, "llvm symbol table dumper\n");
+ 
++  if (Version) {
++    printExtraVersionInfo(outs());
++    cl::PrintVersionMessage();
++    return 0;
++  }
++
+   // llvm-nm only reads binary files.
+   if (error(sys::ChangeStdinToBinary()))
+     return 1;

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -38,7 +38,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
            "${MINGW_PACKAGE_PREFIX}-openmp")
          "${MINGW_PACKAGE_PREFIX}-polly")
 pkgver=12.0.0
-pkgrel=2
+pkgrel=3
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -76,6 +76,7 @@ source=("https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkgver
         "0005-add-pthread-as-system-lib-for-mingw.patch"
         "0008-enable-emutls-for-mingw.patch"
         "0010-mbig-obj-for-all.patch"
+        "0011-nm-version-option.patch"
         "0104-link-pthread-with-mingw.patch"
         "0304-ignore-new-bfd-options.patch"
         "0305-use-TerminateProcess-instead-of-exit.patch"
@@ -104,6 +105,7 @@ sha256sums=('9ed1688943a4402d7c904cc4515798cdb20080066efa010fe7e1f2551b423628'
             '7f0c64cd87b61e894be632f180ae5291e1aa9f1d9d382608f659067eeeda7146'
             '3837bd707d3d99a742e874d5c59a1e7d5502811d6926319974c5d9db86020039'
             '69798483f26bbcf49905ffdb02cf47b4247b25ddd95bba8ee1d0a3670ce5b093'
+            '5d0d8653c95a2d74a4ae531370c3d0584054d15cfef16eb4c45b1d8e5c0fcb4c'
             '715cb8862753854b2d9256e0b70003e2d1f57083d83eaeaf5a095fc72b8a4e26'
             '778e0db0a5b0657ab05e2a81d83241347a4a41af2b0f9903422f651fa58e8d40'
             'a0e25f683ce7a8e3e19a67e83f8b34e55baa4b91fa24ce6d3275ac98a79623dc'
@@ -136,7 +138,8 @@ prepare() {
       "0001-Use-posix-style-path-separators-with-MinGW.patch" \
       "0002-Fix-GetHostTriple-for-mingw-w64-in-msys.patch" \
       "0004-llvm-config-look-for-unversioned-shared-lib-on-win32.patch" \
-      "0010-mbig-obj-for-all.patch"
+      "0010-mbig-obj-for-all.patch" \
+      "0011-nm-version-option.patch"
 
   if (( ! _clangprefix )); then
     apply_patch_with_msg \

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -77,6 +77,7 @@ source=("https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkgver
         "0008-enable-emutls-for-mingw.patch"
         "0010-mbig-obj-for-all.patch"
         "0011-nm-version-option.patch"
+        "0103-Use-posix-style-path-separators-with-MinGW.patch"
         "0104-link-pthread-with-mingw.patch"
         "0304-ignore-new-bfd-options.patch"
         "0305-use-TerminateProcess-instead-of-exit.patch"
@@ -106,6 +107,7 @@ sha256sums=('9ed1688943a4402d7c904cc4515798cdb20080066efa010fe7e1f2551b423628'
             '3837bd707d3d99a742e874d5c59a1e7d5502811d6926319974c5d9db86020039'
             '69798483f26bbcf49905ffdb02cf47b4247b25ddd95bba8ee1d0a3670ce5b093'
             '5d0d8653c95a2d74a4ae531370c3d0584054d15cfef16eb4c45b1d8e5c0fcb4c'
+            '2d1dc7f7cd6bd61f275cd0be6650f3086aee622074ac786ff5a921bf8ecaada2'
             '715cb8862753854b2d9256e0b70003e2d1f57083d83eaeaf5a095fc72b8a4e26'
             '778e0db0a5b0657ab05e2a81d83241347a4a41af2b0f9903422f651fa58e8d40'
             'a0e25f683ce7a8e3e19a67e83f8b34e55baa4b91fa24ce6d3275ac98a79623dc'
@@ -148,6 +150,8 @@ prepare() {
   fi
 
   cd "${srcdir}/clang"
+  apply_patch_with_msg \
+    "0103-Use-posix-style-path-separators-with-MinGW.patch"
 
   if (( ! _clangprefix )); then
     apply_patch_with_msg \


### PR DESCRIPTION
Fixes msys2/CLANG-packages#39

gnutls is having another issue now with LLVM 12 (which I'm attempting to track down now), but this does fix libidn which had the same nm-parsing issue.

The new gnutls issue is #8646, and the second commit on this PR fixes #8646.