### PR TITLE
aws-c-common: Update to 0.5.5

### DIFF
--- a/mingw-w64-aws-c-common/PKGBUILD
+++ b/mingw-w64-aws-c-common/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=aws-c-common
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.5.3
+pkgver=0.5.5
 pkgrel=1
 pkgdesc="Core c99 package for AWS SDK for C. Includes cross-platform primitives, configuration, data structures, and error handling (mingw-w64)."
 arch=('any')
@@ -17,7 +17,7 @@ conflicts=("${MINGW_PACKAGE_PREFIX}-aws-sdk-cpp<1.8.149")
 options=('strip' '!debug' 'staticlibs')
 source=("${_realname}-${pkgver}.tar.gz"::"${url}/archive/v${pkgver}.tar.gz")
 noextract=("${_realname}-${pkgver}.tar.gz")
-sha256sums=('9e559bef5a42ae8b20ed41fe07fff65b3fab57958df070d842b8ea011a3ebb50')
+sha256sums=('a60bb8aada37adcc3f66a3c6592723daef1cc17ddf8204956dd8e3f90742501d')
 
 prepare() {
   [[ -d "${srcdir}/${_realname}-${pkgver}" ]] && rm -rf "${srcdir}/${_realname}-${pkgver}"
@@ -26,6 +26,9 @@ prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   sed -i "s/ -Werror//g" cmake/AwsCFlags.cmake cmake/AwsFeatureTests.cmake
   sed -i "s/_MSC_VER/_WIN32/g" include/aws/common/byte_order.inl
+
+  # For clang
+  sed -i "s/-fPIC//g" cmake/AwsCFlags.cmake
 }
 
 build() {


### PR DESCRIPTION
Remove -fPIC compiler option for clang.