### PR TITLE
grpc: fix clang build

### DIFF
--- a/mingw-w64-grpc/0003-abseil-Include-pthread-header.patch
+++ b/mingw-w64-grpc/0003-abseil-Include-pthread-header.patch
@@ -1,0 +1,11 @@
+--- abseil-cpp/absl/base/internal/thread_identity.cc.orig	2021-05-12 14:51:02.638771000 -0700
++++ abseil-cpp/absl/base/internal/thread_identity.cc	2021-05-12 14:52:20.513767600 -0700
+@@ -14,7 +14,7 @@
+ 
+ #include "absl/base/internal/thread_identity.h"
+ 
+-#ifndef _WIN32
++#if !defined(_WIN32) || defined(__MINGW32__)
+ #include <pthread.h>
+ #include <signal.h>
+ #endif

--- a/mingw-w64-grpc/PKGBUILD
+++ b/mingw-w64-grpc/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.35.0
 _abseil_ver=20200923.3
-pkgrel=2
+pkgrel=3
 pkgdesc="gRPC - Google's high performance, open source, general RPC framework (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -27,11 +27,13 @@ options=('staticlibs' 'strip')
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/grpc/grpc/archive/v${pkgver}.tar.gz"
         "abseil-cpp-${_abseil_ver}.tar.gz::https://github.com/abseil/abseil-cpp/archive/${_abseil_ver}.tar.gz"
         "0001-abseil-Fix-compiler-warnings.patch"
-        "0002-abseil-Remove-librt-library.patch")
+        "0002-abseil-Remove-librt-library.patch"
+        "0003-abseil-Include-pthread-header.patch")
 sha256sums=('27dd2fc5c9809ddcde8eb6fa1fa278a3486566dfc28335fca13eb8df8bd3b958'
             'ebe2ad1480d27383e4bf4211e2ca2ef312d5e6a09eba869fd2e8a5c5d553ded2'
             '9a8d939b5a0978a4b6658aa9061423111ede3d33a330e654e4a977b1eda63c92'
-            'd3ecabcebf64c2211b40e07f376de028ad1b101051cba7e69d77f6074217238d')
+            'd3ecabcebf64c2211b40e07f376de028ad1b101051cba7e69d77f6074217238d'
+            'a948c1be67e752c2e50ea220c38e767d4138e2534d57d863182739d46d5e4e7b')
 noextract=(${_realname}-${pkgver}.tar.gz)
 
 prepare() {
@@ -51,6 +53,8 @@ prepare() {
   cd "${srcdir}/${_realname}-${pkgver}/third_party/abseil-cpp"
   patch -Np1 -i "${srcdir}/0001-abseil-Fix-compiler-warnings.patch"
   patch -Np1 -i "${srcdir}/0002-abseil-Remove-librt-library.patch"
+
+  patch -Np1 -i "${srcdir}/0003-abseil-Include-pthread-header.patch"
 }
 
 build() {
@@ -59,13 +63,9 @@ build() {
 
   # remove __USE_MINGW_ANSI_STDIO=1 define, it breaks grpc string handling for
   # cases like 'gpr_log(GPR_DEBUG, "Failed to free %" PRIuPTR ...'
-  CPPFLAGS=${CPPFLAGS//-D__USE_MINGW_ANSI_STDIO=1/}
-
-  case "${CARCH}" in
-    x86_64)
-      LDFLAGS+=" -Wl,--disable-dynamicbase,--default-image-base-low"
-    ;;
-  esac
+  CPPFLAGS="${CPPFLAGS//-D__USE_MINGW_ANSI_STDIO=1/}"
+  # add STRSAFE_NO_DEPRECATE define, otherwise strsafe breaks libc++ headers
+  CXXFLAGS+=" -DSTRSAFE_NO_DEPRECATE"
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe \
@@ -74,7 +74,7 @@ build() {
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       -DCMAKE_BUILD_TYPE="Release" \
       -DCMAKE_SKIP_RPATH="ON" \
-      -DBUILD_SHARED_LIBS="ON" \
+      -DBUILD_SHARED_LIBS="$( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] && echo "OFF" || echo "ON" )" \
       -DgRPC_ZLIB_PROVIDER="package" \
       -DgRPC_CARES_PROVIDER="package" \
       -DgRPC_PROTOBUF_PROVIDER="package" \


### PR DESCRIPTION
- Remove `--disable-dynamicbase`/`--default-image-base-low` workaround for gcc (weak symbol issue was fixed in binutils)
- Define `STRSAFE_NO_DEPRECATE` to fix conflict with libc++
- Disable shared builds for clang prefix, as there's an attempt to use a TLS variable across DLL boundaries, which is not supported for clang (or visual studio for that matter).  See https://github.com/msys2/MINGW-packages/pull/8653#issuecomment-857408252