### PR TITLE
breeze-icons-qt5: try to convince cmake to use mingw python

### DIFF
--- a/mingw-w64-breeze-icons-qt5/PKGBUILD
+++ b/mingw-w64-breeze-icons-qt5/PKGBUILD
@@ -4,7 +4,7 @@ _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "breeze-icons"
 pkgver=5.82.0
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 pkgdesc="Breeze icon themes (mingw-w64-qt5${_namesuff})"
@@ -42,6 +42,9 @@ build() {
     -DBUILD_QCH=OFF \
     -DBUILD_TESTING=OFF \
     -DECM_DIR=${MINGW_PREFIX}/share/ECM \
+    -DPython_EXECUTABLE=${MINGW_PREFIX}/bin/python.exe \
+    -DPython_ROOT_DIR=${MINGW_PREFIX} \
+    -DPython_FIND_REGISTRY=NEVER \
     "${extra_config[@]}" \
     ../${_basename}-${pkgver}
 


### PR DESCRIPTION
It needs python with lxml to build 24px icons.  Unfortunately once it's finding the right python, actually building the icons is failing with a file not found error.

```
  Traceback (most recent call last):
    File "C:/_/mingw-w64-breeze-icons-qt5/src/breeze-icons-5.75.0/generate-24px-versions.py", line 193, in <module>
      sys.exit(main())
    File "C:/_/mingw-w64-breeze-icons-qt5/src/breeze-icons-5.75.0/generate-24px-versions.py", line 174, in main
      tree.write(file_destination, method="xml", pretty_print=True, exclusive=True)
    File "src/lxml/etree.pyx", line 2057, in lxml.etree._ElementTree.write
    File "src/lxml/serializer.pxi", line 746, in lxml.etree._tofilelike
    File "src/lxml/serializer.pxi", line 813, in lxml.etree._create_output_buffer
    File "src/lxml/serializer.pxi", line 803, in lxml.etree._create_output_buffer
  FileNotFoundError: [Errno 2] No such file or directory
  make[2]: *** [icons-dark/CMakeFiles/breeze-generate-24px-versions-dark.dir/build.make:71: icons-dark/CMakeFiles/breeze-generate-24px-versions-dark] Error 1
```