### PR TITLE
gtkwave: do not install ghwdump

### DIFF
--- a/mingw-w64-gtkwave/PKGBUILD
+++ b/mingw-w64-gtkwave/PKGBUILD
@@ -11,7 +11,7 @@ _realname=gtkwave
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=3.3.109
-pkgrel=1
+pkgrel=2
 pkgdesc='GtkWave, a fully featured GTK+ based wave viewer which reads VCD, GHW, LXT, LXT2, VZT and FST files (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -75,4 +75,7 @@ package() {
 
   cd "${srcdir}/build-${MINGW_CHOST}"-gtk2
   make DESTDIR="${pkgdir}" install
+
+  # https://github.com/ghdl/ghdl/issues/1756
+  rm "${_bin}"/ghwdump.exe
 }


### PR DESCRIPTION
As discussed in https://github.com/ghdl/ghdl/issues/1756, recently ghwdump was added to the GHDL package. The same binary was provided by package GTKWave already. Therefore, there is now a conflict that prevents users of these packages from updating their MSYS2 installations.

After getting feedback from GHDL and GTKWave maintainers and contributors, this PR removes the ghwdump binary from the GTKWave package.