### PR TITLE
mpg123: depend on SDL2 instead of SDL

### DIFF
--- a/mingw-w64-mpg123/PKGBUILD
+++ b/mingw-w64-mpg123/PKGBUILD
@@ -4,7 +4,7 @@ _realname=mpg123
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.27.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A console based real time MPEG Audio Player for Layer 1, 2 and 3 (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -13,12 +13,12 @@ license=("LGPL2.1")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-openal"
              "${MINGW_PACKAGE_PREFIX}-portaudio"
-             "${MINGW_PACKAGE_PREFIX}-SDL")
+             "${MINGW_PACKAGE_PREFIX}-SDL2")
 depends=("${MINGW_PACKAGE_PREFIX}-libtool"
          "${MINGW_PACKAGE_PREFIX}-gcc-libs")
 optdepends=("${MINGW_PACKAGE_PREFIX}-openal"
             "${MINGW_PACKAGE_PREFIX}-portaudio"
-            "${MINGW_PACKAGE_PREFIX}-SDL")
+            "${MINGW_PACKAGE_PREFIX}-SDL2")
 options=('strip' 'staticlibs' 'libtool')
 source=("https://www.mpg123.com/download/mpg123-${pkgver}.tar.bz2"{,.sig})
 sha256sums=('52f6ceb962c05db0c043bb27acf5a721381f5f356ac4610e5221f50293891b04'


### PR DESCRIPTION
As a follow up of the last update I've noticed that the configure script looks for SDL2 before the old SDL, so it would be better to upgrade the dependency
