### PR TITLE
[CI] export CC and CXX variables.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,14 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          { msystem: MINGW64, arch: x86_64, can-fail: false },
-          { msystem: MINGW32, arch: i686, can-fail: false },
-          { msystem: UCRT64, arch: ucrt-x86_64, can-fail: false },
-          { msystem: CLANG64, arch: clang-x86_64, can-fail: true }
+          { msystem: MINGW64, arch: x86_64, can-fail: false, CC: gcc, CXX: g++ },
+          { msystem: MINGW32, arch: i686, can-fail: false, CC: gcc, CXX: g++ },
+          { msystem: UCRT64, arch: ucrt-x86_64, can-fail: false, CC: gcc, CXX: g++ },
+          { msystem: CLANG64, arch: clang-x86_64, can-fail: true, CC: clang, CXX: clang++ }
         ]
+    env:
+      CC: ${{ matrix.CC }}
+      CXX: ${{ matrix.CXX }}
     name: ${{ matrix.msystem }}
     steps:
 


### PR DESCRIPTION
It doesn't change much, but at least it will show explicitly the used compiler instead of the alias.