### PR TITLE
add scopehal-apps

### DIFF
--- a/mingw-w64-ffts/PKGBUILD
+++ b/mingw-w64-ffts/PKGBUILD
@@ -1,0 +1,51 @@
+# Maintainer: umarcor <unai.martinezcorral@ehu.eus>
+
+_realname=ffts
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.0.0.r799.gfe86885
+pkgrel=1
+pkgdesc="ffts: The Fastest Fourier Transform in the South  (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+url="https://github.com/anthonix/ffts"
+license=('custom')
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-gcc"
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+)
+
+_commit='fe86885e'
+source=("${_realname}::git://github.com/anthonix/ffts.git#commit=${_commit}")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "${_realname}"
+  echo '0.0.0.r'"$(git rev-list --count HEAD)"'.g'"$(git describe --all --long | sed 's/^.*-g\(.*\)/\1/')"
+}
+
+build() {
+  cd "${srcdir}/${_realname}"
+  mkdir build
+  cd build
+  MSYS2_ARG_CONV_EXCL=-DCMAKE_INSTALL_PREFIX= cmake \
+    -G "MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+    -DENABLE_SHARED=ON \
+    ../
+  cmake --build .
+}
+
+package() {
+  cd "${srcdir}/${_realname}"/build
+  make DESTDIR="${pkgdir}" install
+
+  _pre="${pkgdir}${MINGW_PREFIX}"
+
+  mkdir "${_pre}"/bin
+  mv "${_pre}"/lib/*.dll "${_pre}"/bin/
+
+  _licenses="${_pre}/share/licenses/${_realname}"
+  mkdir -p "${_licenses}"
+  install -m 644 "${srcdir}/${_realname}"/COPYRIGHT "${_licenses}"
+}

--- a/mingw-w64-scopehal-apps/PKGBUILD
+++ b/mingw-w64-scopehal-apps/PKGBUILD
@@ -1,0 +1,67 @@
+# Maintainer: umarcor <unai.martinezcorral@ehu.eus>
+
+_realname=scopehal-apps
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.0.0.r1124.g6b1e125
+pkgrel=1
+pkgdesc="scopehal-apps: applications for libscopehal (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+url="https://github.com/azonenberg/scopehal-apps"
+license=('BSD-3-Clause')
+groups=("${MINGW_PACKAGE_PREFIX}-eda")
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-glm"
+  "${MINGW_PACKAGE_PREFIX}-libsigc++"
+  "${MINGW_PACKAGE_PREFIX}-gtkmm3"
+  "${MINGW_PACKAGE_PREFIX}-yaml-cpp"
+  "${MINGW_PACKAGE_PREFIX}-glew"
+  "${MINGW_PACKAGE_PREFIX}-ffts"
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-gcc"
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+  "make"
+)
+
+source=("${_realname}::git://github.com/azonenberg/scopehal-apps.git#commit=6b1e125e")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "${_realname}"
+  echo '0.0.0.r'"$(git rev-list --count HEAD)"'.g'"$(git describe --all --long | sed 's/^.*-g\(.*\)/\1/')"
+}
+
+build() {
+  cd "${srcdir}/${_realname}"
+
+  git remote set-url origin git://github.com/azonenberg/scopehal-apps
+  git submodule update --init --recursive
+
+  mkdir build
+  cd build
+  MSYS2_ARG_CONV_EXCL=-DCMAKE_INSTALL_PREFIX= cmake \
+    -G "MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+    -DBUILD_TESTING=OFF \
+    ../
+  cmake --build .
+}
+
+check() {
+  "${srcdir}/${_realname}"/build/src/glscopeclient/glscopeclient.exe --help
+}
+
+package() {
+  cd "${srcdir}/${_realname}"/build
+  make DESTDIR="${pkgdir}" install
+  _bin=""${pkgdir}${MINGW_PREFIX}"/bin/"
+
+  # FIXME: copying/installing this library should be fixed upstream (https://github.com/azonenberg/scopehal-apps)
+  install -m 644 lib/log/liblog.dll "$_bin"
+
+  _licenses="${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
+  mkdir -p "${_licenses}"
+  install -m 644 "${srcdir}/${_realname}"/LICENSE "${_licenses}"
+}

--- a/mingw-w64-scopehal-apps/PKGBUILD
+++ b/mingw-w64-scopehal-apps/PKGBUILD
@@ -3,11 +3,11 @@
 _realname=scopehal-apps
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.0.0.r1124.g6b1e125
+pkgver=0.0.0.r1135.g07cd746
 pkgrel=1
 pkgdesc="scopehal-apps: applications for libscopehal (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64')
 url="https://github.com/azonenberg/scopehal-apps"
 license=('BSD-3-Clause')
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
@@ -25,7 +25,7 @@ makedepends=(
   "make"
 )
 
-source=("${_realname}::git://github.com/azonenberg/scopehal-apps.git#commit=6b1e125e")
+source=("${_realname}::git://github.com/azonenberg/scopehal-apps.git#commit=07cd7467")
 sha256sums=('SKIP')
 
 pkgver() {
@@ -56,10 +56,6 @@ check() {
 package() {
   cd "${srcdir}/${_realname}"/build
   make DESTDIR="${pkgdir}" install
-  _bin=""${pkgdir}${MINGW_PREFIX}"/bin/"
-
-  # FIXME: copying/installing this library should be fixed upstream (https://github.com/azonenberg/scopehal-apps)
-  install -m 644 lib/log/liblog.dll "$_bin"
 
   _licenses="${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
   mkdir -p "${_licenses}"


### PR DESCRIPTION
This PR adds [azonenberg/scopehal-apps](https://github.com/azonenberg/scopehal-apps): glscopeclient and other client applications for libscopehal. [azonenberg/scopehal](https://github.com/azonenberg/scopehal) is an oscilloscope / logic analyzer platform abstraction library. scopehal-apps depends on [anthonix/ffts](https://github.com/anthonix/ffts). Therefore, in this PR package ffts is added too.

Build instructions on MSYS2 are provided in https://www.antikernel.net/temp/glscopeclient-manual.pdf (sec 3.4.2).

I'm unsure about some decisions, so I'll mark this as a draft for now.

@azonenberg would you mind helping me answer the following questions?

- Are the `depends` and `makedepends` lists of scopehal-apps correct?
- ~~Why is FTTS built with `DENABLE_SHARED=ON`, if scopehal-apps uses the static file?~~ (azonenberg/scopehal-docs#28)
- ~~The `lib/scopeprotocols/kernels` shown in step 6. a) of the  scopehal-apps documentation seems not to exist?~~
- ~~Would it be possible to copy all the exes/dlls as part of `make install`, instead of having to copy them manually afterwards?~~ azonenberg/scopehal-apps#355
- ~~Is it worth distributing scopehal as a package? Currently, this PR includes a package for ffts and a package for scopehal-apps.~~ https://github.com/msys2/MINGW-packages/pull/8676#issuecomment-842185936