### PR TITLE
mingw-w64-qemu: Fix build with sphinx 4.0.1 and other fixes/enhancements

### DIFF
--- a/mingw-w64-qemu/PKGBUILD
+++ b/mingw-w64-qemu/PKGBUILD
@@ -4,7 +4,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _base_ver=6.0.0
 _rc=
 pkgver=${_base_ver}${_rc//-/.}
-pkgrel=1
+pkgrel=2
 pkgdesc="QEMU - a generic and open source machine emulator and virtualizer (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -124,7 +124,7 @@ package() {
   # Sphinx 4.0.0 puts man pages to docs/(1|7|8)/ and not to docs/ as expected
   # TODO Try to remove with next Qemu release
   find docs -type f -regextype grep -regex "docs/[0-9]/.*" -exec \
-    cp -p {} docs/ \;
+    cp -pv {} docs/ \;
 
   # Install to ${pkgdir}
   make DESTDIR="${pkgdir}" install
@@ -132,47 +132,49 @@ package() {
   # ${MINGW_PREFIX} was installed somewhere below ${pkgdir}, determine ...
   local P_INSTALL=$(find "${pkgdir}" -name "$(basename ${MINGW_PREFIX})" -type d)
   # Move directly to ${pkgdir}, if not already there
-  [ -d "${pkgdir}"/${MINGW_PREFIX} ] || mv "$P_INSTALL" "${pkgdir}"/
+  [ -d "${pkgdir}"/${MINGW_PREFIX} ] || mv -v "$P_INSTALL" "${pkgdir}"/
 
   # To enable usage relative paths for next operations
   cd "${pkgdir}"/${MINGW_PREFIX}
 
   # Move to standard dirs in share/
-  mv lib/qemu/applications share/
-  mv lib/qemu/icons share/
+  mkdir -pv share
+  mv -v lib/qemu/applications share/
+  mv -v lib/qemu/icons share/
 
   # Fix firmware descriptors
   # see https://bugzilla.redhat.com/show_bug.cgi?id=1728652#c7
-  mkdir -p share/qemu
-  mv lib/qemu/firmware share/qemu/
+  mkdir -pv share/qemu
+  mv -v lib/qemu/firmware share/qemu/
   find share/qemu/firmware -type f -exec \
     sed -i "s%\(\"filename\"\s*:\s*\"\).*edk2%\1${MINGW_PREFIX}/lib/qemu/edk2%" {} \;
 
   # For executables in lib/qemu/ create wrappers in bin/
-  mkdir -p bin
+  mkdir -pv bin
   local LIBEXES=$(find lib/qemu -name "*.exe" ! -name "*w.exe")
   local LIBEXE=""
   for LIBEXE in $LIBEXES
   do
     local EXE=$(basename $LIBEXE)
     local WRAPPER=bin/$EXE
-    echo "#!/bin/bash"                                    >> $WRAPPER
-    echo "export PATH=\"${MINGW_PREFIX}/lib/qemu:$PATH\"" >> $WRAPPER
-    echo "exec ${MINGW_PREFIX}/lib/qemu/$EXE \"\$@\""     >> $WRAPPER
+    echo "#!/bin/bash"                                     >> $WRAPPER
+    echo "export PATH=\"${MINGW_PREFIX}/lib/qemu:\$PATH\"" >> $WRAPPER
+    echo "exec ${MINGW_PREFIX}/lib/qemu/$EXE \"\$@\""      >> $WRAPPER
     chmod u+x $WRAPPER
   done
 
   # Add all licenses found in qemu sources to share/licences/qemu/
-  mkdir -p share/licenses/qemu
+  mkdir -pv share/licenses/qemu
   tar -C "${srcdir}"/${_realname}-${pkgver} -c $(
     cd "${srcdir}"/${_realname}-${pkgver} &&
       find -iname "*COPYING*" -or -iname "*LICENSE*" |
       grep -v "\s" |
       egrep -v "meson.(test|msi|doc)" |
       egrep -v "(license.c|relicense.pl|license.doctree|LicenseCheck)"
-    ) | tar -C share/licenses/qemu -x
+    ) | tar -C share/licenses/qemu -xv
 
   # Add msys2 docs
-  cp -p "${srcdir}"/msys2.readme.txt share/doc/qemu/
-  cp -p "${srcdir}"/msys2.examples.tests.sh share/doc/qemu/
+  mkdir -pv share/doc/qemu
+  cp -pv "${srcdir}"/msys2.readme.txt share/doc/qemu/
+  cp -pv "${srcdir}"/msys2.examples.tests.sh share/doc/qemu/
 }

--- a/mingw-w64-qemu/msys2.readme.txt
+++ b/mingw-w64-qemu/msys2.readme.txt
@@ -45,9 +45,10 @@ Known problems with Qemu/win32:
 
 * qemu-system-x86_64 -append root=/dev/hda
 	absolute paths are converted to windows paths in MINGW64 shell
-	and therefore get invalid, which can be mitigated by using a different shell (eg. cygwin).
-	If your msys2 installation is in c:\msys64 and you use MINGW64, then this will do:
-	$ export PATH="/cygdrive/c/msys64/mingw64/lib/qemu:/cygdrive/c/msys64/mingw64/bin:$PATH"
+	and therefore get invalid, which can be mitigated:
+	$ export MSYS2_ARG_CONV_EXCL='*'
 	$ qemu-system-x86_64.exe -append root=/dev/hda
+	$ unset MSYS2_ARG_CONV_EXCL
+	Make sure you do not use any (absolute) paths in the command, which need to be converted
 
 


### PR DESCRIPTION
Build of qemu-6.0.0 fails on staging build because of switch to sphinx 4.0.1:

doc generation fails, because qemu-6.0.0 meson.build can't handle sphinx 4.0.1

qemu build fails because directory share/doc/qemu not created by doc generation

This is fixed by creating each dir in package with mkdir -p before moving/copying.

Other fixes are included as well.