### PR TITLE
libvirt: depend on libssp

### DIFF
--- a/mingw-w64-libvirt/PKGBUILD
+++ b/mingw-w64-libvirt/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 _pkgdev=7.0.0
 pkgver=${_pkgdev//-/}
-pkgrel=1
+pkgrel=2
 pkgdesc="Windows libvirt virtualization library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -19,6 +19,7 @@ depends=(${MINGW_PACKAGE_PREFIX}-curl
          ${MINGW_PACKAGE_PREFIX}-libgpg-error
          ${MINGW_PACKAGE_PREFIX}-libssh
          ${MINGW_PACKAGE_PREFIX}-libssh2
+         ${MINGW_PACKAGE_PREFIX}-libssp
          ${MINGW_PACKAGE_PREFIX}-libxml2
          ${MINGW_PACKAGE_PREFIX}-portablexdr
          ${MINGW_PACKAGE_PREFIX}-readline


### PR DESCRIPTION
With mingw-w64-clang 12.0.0-5 that's all that's necessary.