### PR TITLE
qemu: Bump for rebuild to reinclude docs after build dep fix

### DIFF
--- a/mingw-w64-qemu/PKGBUILD
+++ b/mingw-w64-qemu/PKGBUILD
@@ -4,7 +4,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _base_ver=6.0.0
 _rc=
 pkgver=${_base_ver}${_rc//-/.}
-pkgrel=2
+pkgrel=3
 pkgdesc="QEMU - a generic and open source machine emulator and virtualizer (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -120,8 +120,8 @@ check() {
 package() {
   cd "${srcdir}"/build-${CARCH}
 
-  # Fix failure of make install introduced by Sphinx 4.0.0
-  # Sphinx 4.0.0 puts man pages to docs/(1|7|8)/ and not to docs/ as expected
+  # Fix failure of make install introduced by Sphinx >=4.0.0
+  # Sphinx >=4.0.0 puts man pages to docs/(1|7|8)/ and not to docs/ as expected
   # TODO Try to remove with next Qemu release
   find docs -type f -regextype grep -regex "docs/[0-9]/.*" -exec \
     cp -pv {} docs/ \;


### PR DESCRIPTION
This PR bumps pkgrel to build once more after fix of https://github.com/msys2/MINGW-packages/issues/8685 finally reached the repository.

Additionally the examples I provided recently were improved: no more deprecations on execution and more information
