### PR TITLE
gtk-vnc: Activate installation of expected but missing gvncviewer

### DIFF
--- a/mingw-w64-gtk-vnc/PKGBUILD
+++ b/mingw-w64-gtk-vnc/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gtk-vnc
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.2.0
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 pkgdesc="VNC viewer widget for GTK+ (mingw-w64)"
@@ -26,8 +26,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 options=('strip' 'staticlibs')
 license=("GPL 2.1")
 url="https://www.gnome.org"
-source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz)
-sha256sums=('7aaf80040d47134a963742fb6c94e970fcb6bf52dc975d7ae542b2ef5f34b94a')
+source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz gvncviewer-1.2.0.patch)
+sha256sums=('7aaf80040d47134a963742fb6c94e970fcb6bf52dc975d7ae542b2ef5f34b94a' 'SKIP')
+
+prepare() {
+  cd "${srcdir}"/${_realname}-${pkgver}
+  patch -Np1 < ../gvncviewer-1.2.0.patch
+}
 
 build() {
   [[ -d "${srcdir}"/build-${MINGW_CHOST} ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
@@ -42,6 +47,11 @@ build() {
     "../${_realname}-${pkgver}"
 
   ${MINGW_PREFIX}/bin/ninja
+}
+
+check() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  ${MINGW_PREFIX}/bin/ninja test || true
 }
 
 package() {

--- a/mingw-w64-gtk-vnc/gvncviewer-1.2.0.patch
+++ b/mingw-w64-gtk-vnc/gvncviewer-1.2.0.patch
@@ -1,0 +1,10 @@
+--- gtk-vnc-1.2.0.orig/examples/meson.build	2021-05-18 20:15:39.880321000 +0200
++++ gtk-vnc-1.2.0/examples/meson.build	2021-05-18 20:16:10.914408200 +0200
+@@ -11,5 +11,6 @@
+   c_args: warning_cflags + gtk_vnc_version_check_flags,
+   link_args: warning_ldflags,
+   dependencies: gvncviewer_deps,
+-  install: false,
++  install: true,
++  install_dir: gtk_vnc_bindir,
+ )


### PR DESCRIPTION
Turns out the expected application in the package was hidden like an easter egg