### PR TITLE
poppler: fix compilation with clang

### DIFF
--- a/mingw-w64-poppler/010-clang.patch
+++ b/mingw-w64-poppler/010-clang.patch
@@ -1,0 +1,11 @@
+--- a/glib/poppler-private.h
++++ b/glib/poppler-private.h
+@@ -150,7 +150,7 @@ GooString *_poppler_convert_date_time_to_pdf_date(GDateTime *datetime);
+ #define POPPLER_DEFINE_BOXED_TYPE(TypeName, type_name, copy_func, free_func)                                                                                                                                                                   \
+     GType type_name##_get_type(void)                                                                                                                                                                                                           \
+     {                                                                                                                                                                                                                                          \
+-        static volatile gsize g_define_type_id__volatile = 0;                                                                                                                                                                                  \
++        static gsize g_define_type_id__volatile = 0;                                                                                                                                                                                  \
+         if (g_once_init_enter(&g_define_type_id__volatile)) {                                                                                                                                                                                  \
+             GType g_define_type_id = g_boxed_type_register_static(g_intern_static_string(#TypeName), (GBoxedCopyFunc)copy_func, (GBoxedFreeFunc)free_func);                                                                                    \
+             g_once_init_leave(&g_define_type_id__volatile, g_define_type_id);                                                                                                                                                                  \

--- a/mingw-w64-poppler/PKGBUILD
+++ b/mingw-w64-poppler/PKGBUILD
@@ -4,13 +4,14 @@ _realname=poppler
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=20.12.1
-pkgrel=2
+pkgrel==3
 pkgdesc="PDF rendering library based on xpdf 3.0 (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 url="https://poppler.freedesktop.org/"
 license=("GPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-glib2"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
@@ -33,14 +34,17 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-glib2: libpoppler-glib"
             "${MINGW_PACKAGE_PREFIX}-qt5: libpoppler-qt5")
 options=('strip' 'staticlibs')
 source=(https://poppler.freedesktop.org/${_realname}-${pkgver}.tar.xz{,.sig}
+        '010-clang.patch'
         test::git+https://anongit.freedesktop.org/git/poppler/test/#commit=72bff390035819a4ccb54c767265aba2792eaf3b)
 sha256sums=('d0aa2586c0a4296c775f0d2045f28bb95a694113fc995f95350faa12930f7b35'
             'SKIP'
+            '7189564cfbd9f1ea77604aafa9811a3836912a3c945fe6250a33a710c866e52f'
             'SKIP')
 validpgpkeys=('CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7') # "Albert Astals Cid <aacid@kde.org>"
 
 prepare() {
   cd ${_realname}-${pkgver}
+  patch -Np1 -i "${srcdir}/010-clang.patch"
 }
 
 build() {
@@ -49,7 +53,7 @@ build() {
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   "${MINGW_PREFIX}/bin/cmake.exe" -Wno-dev \
-    -G"MSYS Makefiles" \
+    -G"Ninja" \
     -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
     -DENABLE_UNSTABLE_API_ABI_HEADERS=ON \
     -DSPLASH_CMYK=ON \
@@ -67,21 +71,19 @@ build() {
     -DENABLE_GTK_DOC=OFF \
     ../${_realname}-${pkgver}
 
-  CC="${MINGW_PREFIX}/bin/gcc.exe" \
-  PKG_CONFIG_PATH=${MINGW_PREFIX}/lib/pkgconfig \
-  make
+  ${MINGW_PREFIX}/bin/cmake.exe --build ./
 }
 
 check() {
   cd ${srcdir}/build-${MINGW_CHOST}
-  cp libpoppler-98.dll qt5/tests
+  cp libpoppler-105.dll qt5/tests
   cp cpp/libpoppler-cpp-0.dll qt5/tests
   cp qt5/src/libpoppler-qt5-1.dll qt5/tests
 
-  make test
+  ${MINGW_PREFIX}/bin/cmake.exe --build ./ --target test
 }
 
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
-  make DESTDIR="${pkgdir}" install
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --build ./ --target install
 }

--- a/mingw-w64-poppler/PKGBUILD
+++ b/mingw-w64-poppler/PKGBUILD
@@ -4,7 +4,7 @@ _realname=poppler
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=20.12.1
-pkgrel==3
+pkgrel=3
 pkgdesc="PDF rendering library based on xpdf 3.0 (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')


### PR DESCRIPTION
clang doesn't like mismatching volatile pointers.

Signed-off-by: Rosen Penev <rosenp@gmail.com>