### PR TITLE
dav1d: update to 0.9.0

### DIFF
--- a/mingw-w64-dav1d/PKGBUILD
+++ b/mingw-w64-dav1d/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=dav1d
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.8.2
+pkgver=0.9.0
 pkgrel=1
 pkgdesc="AV1 cross-platform decoder focused on speed and correctness (mingw-w64)"
 arch=('any')
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 options=('staticlibs' 'strip' 'emptydirs')
 source=("https://downloads.videolan.org/pub/videolan/dav1d/${pkgver}/dav1d-${pkgver}.tar.xz"{,.asc})
-sha256sums=('3dd91d96b44e9d8ba7e82ad9e730d6c579ab5e19edca0db857a60f5ae6a0eb13'
+sha256sums=('cfae88e8067c9b2e5b96d95a7a00155c353376fe9b992a96b4336e0eab19f9f6'
             'SKIP')
 validpgpkeys=('65F7C6B4206BD057A7EB73787180713BE58D1ADC') # VideoLAN Release Signing Key
 


### PR DESCRIPTION
Only a single addition to the API, so backwards compatible (minor version change)

https://code.videolan.org/videolan/dav1d/-/commit/a98f5e6056568de9125c1fbb4f63f525b95e30b1