### PR TITLE
gh: update to v1.10.0

### DIFF
--- a/mingw-w64-github-cli/PKGBUILD
+++ b/mingw-w64-github-cli/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=github-cli
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.9.2
+pkgver=1.10.0
 pkgrel=1
 pkgdesc='The GitHub CLI (mingw-w64)'
 arch=('any')
@@ -17,7 +17,7 @@ optdepends=("git: To interact with repositories")
 options=('!strip')
 source=("$_realname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz"
         "gh")
-sha256sums=('a1d5a326c9311f8d208a0e5b5ba47023c3982494063e34ea10da916f9b8ba5c3'
+sha256sums=('4cced403fa47caf5350db3bcc0b347d018a684601dcfed94af8ad4c8c68afa65'
             '9ee5f2b44b7e9aa751508f02c1020e341e0212a9aa146b7428eb5ffea310be27')
 build() {
     cd "cli-$pkgver"


### PR DESCRIPTION
It was just released: https://github.com/cli/cli/releases/tag/v1.10.0

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
