### PR TITLE
rust: depend on libxml2

### DIFF
--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -8,7 +8,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-rust-docs")
 pkgver=1.52.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -117,6 +117,7 @@ check() {
 package_rust() {
   depends=("${MINGW_PACKAGE_PREFIX}-gcc"
            "${MINGW_PACKAGE_PREFIX}-curl"
+           "${MINGW_PACKAGE_PREFIX}-libxml2"
            "${MINGW_PACKAGE_PREFIX}-libssh2")
 
   cd "${srcdir}/${CARCH}"


### PR DESCRIPTION
Fixes #8732