### PR TITLE
mingw-w64-cross-clang: prefixed cross-compiling wrappers for clang

### DIFF
--- a/mingw-w64-cross-clang/PKGBUILD
+++ b/mingw-w64-cross-clang/PKGBUILD
@@ -1,0 +1,93 @@
+declare -g -A _cross_arches=(
+  ["/clang64"]="x86_64-w64-mingw32"
+  ["/clangarm64"]="aarch64-w64-mingw32"
+)
+pkgbase=mingw-w64-cross-clang
+pkgname=($(for _pfx in "${!_cross_arches[@]}"; do
+             if [[ "${_cross_arches[$_pfx]%%-*}" != "${CARCH}" ]]; then
+               echo "${MINGW_PACKAGE_PREFIX}-cross-clang-${_cross_arches[$_pfx]%%-*}"
+             fi
+           done))
+pkgver=19.1.6
+pkgrel=1
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
+license=('ISC')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
+# this is unused in the packages but necessary to make CI happy
+depends=("${MINGW_PACKAGE_PREFIX}-clang=${pkgver}"
+         "${MINGW_PACKAGE_PREFIX}-cross-compiler-rt=${pkgver}")
+source=("native-wrapper.h"
+        "llvm-wrapper.c"
+        "clang-target-wrapper.c"
+        "clang-scan-deps-wrapper.c"
+        "dlltool-wrapper.c"
+        "windres-wrapper.c")
+sha256sums=('c9b63d78a6e45b7ececfcc354d84ae4d452df8afc738c151f3aa37b843f6a338'
+            'b807f9b7ce3c205afc61f917a19d18e007b994b4bb2e8042f0db65976e96a4ec'
+            '67fd935417e9f4c69f44571e0cd219cab06699465a089e3149566c17ef8456ab'
+            'f9c8223a1b9813de4d09f914121ec874568296cf0bf65569e1802b66e784de51'
+            '2adee7d81d71a167d28fc508e8b3427f63e7c064f08ca63fe330476e8ae4a2c8'
+            'b121e52bc752396f887e8e6a97138117fc9c2ee4f7efbe9f5ca2be4f451b6f45')
+build() {
+  CC=${CC:-cc}
+  cd "${srcdir}"
+
+  [[ -d "build-${MSYSTEM}" ]] && rm -rf "build-${MSYSTEM}"
+  mkdir "build-${MSYSTEM}" && cd "build-${MSYSTEM}"
+
+  for _pfx in "${!_cross_arches[@]}"; do
+    if [[ "${_cross_arches[$_pfx]%%-*}" != "${CARCH}" ]]; then
+      MSYS2_ARG_CONV_EXCL="-DSYSROOT=" \
+      $CC $CPPFLAGS $CFLAGS $LDFLAGS -municode -DDEFAULT_TARGET="\"${_cross_arches[$_pfx]}\"" -DSYSROOT="\"${_pfx}\"" ../llvm-wrapper.c -o ${_cross_arches[$_pfx]}-llvm-wrapper.exe
+      MSYS2_ARG_CONV_EXCL="-DSYSROOT=" \
+      $CC $CPPFLAGS $CFLAGS $LDFLAGS -municode -DDEFAULT_TARGET="\"${_cross_arches[$_pfx]}\"" -DSYSROOT="\"${_pfx}\"" ../clang-target-wrapper.c -o ${_cross_arches[$_pfx]}-clang.exe
+      MSYS2_ARG_CONV_EXCL="-DSYSROOT=" \
+      $CC $CPPFLAGS $CFLAGS $LDFLAGS -municode -DDEFAULT_TARGET="\"${_cross_arches[$_pfx]}\"" -DSYSROOT="\"${_pfx}\"" ../clang-scan-deps-wrapper.c -o ${_cross_arches[$_pfx]}-clang-scan-deps.exe
+      MSYS2_ARG_CONV_EXCL="-DSYSROOT=" \
+      $CC $CPPFLAGS $CFLAGS $LDFLAGS -municode -DDEFAULT_TARGET="\"${_cross_arches[$_pfx]}\"" -DSYSROOT="\"${_pfx}\"" ../dlltool-wrapper.c -o ${_cross_arches[$_pfx]}-dlltool.exe
+      MSYS2_ARG_CONV_EXCL="-DSYSROOT=" \
+      $CC $CPPFLAGS $CFLAGS $LDFLAGS -municode -DDEFAULT_TARGET="\"${_cross_arches[$_pfx]}\"" -DSYSROOT="\"${_pfx}\"" ../windres-wrapper.c -o ${_cross_arches[$_pfx]}-windres.exe
+    fi
+  done
+}
+_real_package() {
+  local _pfx="@@@PREFIX@@@"
+  depends=("${MINGW_PACKAGE_PREFIX}-clang=${pkgver}"
+           "${MINGW_PACKAGE_PREFIX}-cross-compiler-rt=${pkgver}"
+           "${MINGW_PACKAGE_PREFIX}-llvm=${pkgver}"
+           "${MINGW_PACKAGE_PREFIX}-lld=${pkgver}"
+           "mingw-w64-clang-${_cross_arches[@@@PREFIX@@@]%%-*}-crt"
+           "mingw-w64-clang-${_cross_arches[@@@PREFIX@@@]%%-*}-headers"
+           "mingw-w64-clang-${_cross_arches[@@@PREFIX@@@]%%-*}-libc++"
+           "mingw-w64-clang-${_cross_arches[@@@PREFIX@@@]%%-*}-libunwind"
+           "mingw-w64-clang-${_cross_arches[@@@PREFIX@@@]%%-*}-winpthreads-git")
+
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/bin"
+  local _tool
+  # c11 c99 ?
+  for _tool in as c++ cc clang clang++ gcc g++; do
+    cp -f ${_cross_arches[$_pfx]}-clang.exe "${pkgdir}${MINGW_PREFIX}/bin/${_cross_arches[$_pfx]}-${_tool}.exe"
+  done
+  for _tool in addr2line ar ranlib nm objcopy readelf strings strip llvm-ar llvm-ranlib; do
+    cp -f ${_cross_arches[$_pfx]}-llvm-wrapper.exe "${pkgdir}${MINGW_PREFIX}/bin/${_cross_arches[$_pfx]}-${_tool}.exe"
+  done
+  # windres and dlltool can't use llvm-wrapper, as that loses the original
+  # target arch prefix
+  for _tool in clang-scan-deps dlltool windres; do
+    cp -f ${_cross_arches[$_pfx]}-${_tool}.exe "${pkgdir}${MINGW_PREFIX}/bin/${_cross_arches[$_pfx]}-${_tool}.exe"
+  done
+
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/share/licenses/${_cross_arches[${_pfx}]}-cross-clang"
+  sed -ne '1,/^ \*\//p' "${srcdir}/native-wrapper.h" > "${pkgdir}${MINGW_PREFIX}/share/licenses/${_cross_arches[${_pfx}]}-cross-clang/LICENSE"
+}
+
+_func="$(declare -f "_real_package")"
+for _pfx in "${!_cross_arches[@]}"; do
+  if [[ "${_cross_arches[$_pfx]%%-*}" != "${CARCH}" ]]; then
+    _func2="${_func//@@@PREFIX@@@/${_pfx}}"
+    eval "${_func2/#_real_package/package_${MINGW_PACKAGE_PREFIX}-cross-clang-${_cross_arches[$_pfx]%%-*}}"
+  fi
+done

--- a/mingw-w64-cross-clang/clang-scan-deps-wrapper.c
+++ b/mingw-w64-cross-clang/clang-scan-deps-wrapper.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2024 Martin Storsjo
+ *
+ * This file is part of llvm-mingw.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "native-wrapper.h"
+
+#ifndef CLANG_SCAN_DEPS
+#define CLANG_SCAN_DEPS "clang-scan-deps"
+#endif
+#ifndef DEFAULT_TARGET
+#define DEFAULT_TARGET "x86_64-w64-mingw32"
+#endif
+#ifndef SYSROOT
+#define SYSROOT "/clang64"
+#endif
+
+int _tmain(int argc, TCHAR *argv[]) {
+    const TCHAR *dir;
+    split_argv(argv[0], &dir, NULL, NULL, NULL);
+
+    int max_arg = argc + 5;
+    const TCHAR **exec_argv = malloc((max_arg + 1) * sizeof(*exec_argv));
+    int arg = 0;
+    exec_argv[arg++] = concat(dir, _T(CLANG_SCAN_DEPS));
+
+    // If changing this wrapper, change clang-scan-deps-wrapper.sh accordingly.
+    int i = 1;
+    int got_flags = 0;
+    TCHAR *cmd_exe = NULL;
+    for (; i < argc; i++) {
+        if (got_flags) {
+            cmd_exe = _tcsdup(argv[i]);
+            exec_argv[arg++] = argv[i];
+            i++;
+            break;
+        } else if (!_tcscmp(argv[i], _T("--"))) {
+            got_flags = 1;
+            exec_argv[arg++] = argv[i];
+        } else {
+            exec_argv[arg++] = argv[i];
+        }
+    }
+
+    if (cmd_exe) {
+        // If cmd_exe is a <triple>-<exe> style command, prefer the
+        // target triple from there, rather than from what we might have
+        // had in our name.
+        TCHAR *sep = _tcsrchrs(cmd_exe, '/', '\\');
+        if (sep)
+            cmd_exe = sep + 1;
+        sep = _tcsrchr(cmd_exe, '.');
+        if (sep)
+            *sep = '\0';
+        TCHAR *dash = _tcsrchr(cmd_exe, '-');
+        const TCHAR *target = NULL;
+        if (dash) {
+            *dash = '\0';
+            const TCHAR *cmd_exe_suffix = dash + 1;
+            if (!_tcscmp(cmd_exe_suffix, _T("clang")) ||
+                !_tcscmp(cmd_exe_suffix, _T("clang++")) ||
+                !_tcscmp(cmd_exe_suffix, _T("gcc")) ||
+                !_tcscmp(cmd_exe_suffix, _T("g++")) ||
+                !_tcscmp(cmd_exe_suffix, _T("c++")) ||
+                !_tcscmp(cmd_exe_suffix, _T("as")) ||
+                !_tcscmp(cmd_exe_suffix, _T("cc")) ||
+                !_tcscmp(cmd_exe_suffix, _T("c99")) ||
+                !_tcscmp(cmd_exe_suffix, _T("c11"))) {
+                target = cmd_exe;
+            }
+        }
+#ifdef _WIN32
+        // On Windows, we want to set our default target even if no target
+        // was found in cmd_exe, as we want to support running with a foreign
+        // clang-scan-deps-real.exe binary, that could have any default.
+        if (!target)
+            target = _T(DEFAULT_TARGET);
+#endif
+
+        if (target) {
+            // If we did find a cmd_exe and have figured out a target, add
+            // -target after cmd_exe.
+            exec_argv[arg++] = _T("-target");
+            exec_argv[arg++] = target;
+            exec_argv[arg++] = _T("-stdlib=libc++");
+            exec_argv[arg++] = _T("--sysroot");
+            exec_argv[arg++] = concat(dir, _T("../..") _T(SYSROOT));
+        }
+    }
+
+    for (; i < argc; i++)
+        exec_argv[arg++] = argv[i];
+
+    exec_argv[arg] = NULL;
+    if (arg > max_arg) {
+        fprintf(stderr, "Too many options added\n");
+        abort();
+    }
+
+    return run_final(exec_argv[0], exec_argv);
+}

--- a/mingw-w64-cross-clang/clang-target-wrapper.c
+++ b/mingw-w64-cross-clang/clang-target-wrapper.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2018 Martin Storsjo
+ *
+ * This file is part of llvm-mingw.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "native-wrapper.h"
+
+#ifndef CLANG
+#define CLANG "clang"
+#endif
+#ifndef DEFAULT_TARGET
+#define DEFAULT_TARGET "x86_64-w64-mingw32"
+#endif
+#ifndef SYSROOT
+#define SYSROOT "/clang64"
+#endif
+
+int _tmain(int argc, TCHAR* argv[]) {
+    const TCHAR *dir;
+    const TCHAR *target;
+    const TCHAR *exe;
+    split_argv(argv[0], &dir, NULL, &target, &exe);
+    if (!target)
+        target = _T(DEFAULT_TARGET);
+    TCHAR *arch = _tcsdup(target);
+    TCHAR *dash = _tcschr(arch, '-');
+    if (dash)
+        *dash = '\0';
+    TCHAR *target_os = _tcsrchr(target, '-');
+    if (target_os)
+        target_os++;
+
+    // Check if trying to compile Ada; if we try to do this, invoking clang
+    // would end up invoking <triplet>-gcc with the same arguments, which ends
+    // up in an infinite recursion.
+    for (int i = 1; i < argc - 1; i++) {
+        if (!_tcscmp(argv[i], _T("-x")) && !_tcscmp(argv[i + 1], _T("ada"))) {
+            fprintf(stderr, "Ada is not supported\n");
+            return 1;
+        }
+    }
+
+    int max_arg = argc + 22;
+    const TCHAR **exec_argv = malloc((max_arg + 1) * sizeof(*exec_argv));
+    int arg = 0;
+    if (getenv("CCACHE"))
+        exec_argv[arg++] = _T("ccache");
+    exec_argv[arg++] = concat(dir, _T(CLANG));
+    exec_argv[arg++] = _T("--start-no-unused-arguments");
+
+    // If changing this wrapper, change clang-target-wrapper.sh accordingly.
+    if (!_tcscmp(exe, _T("clang++")) || !_tcscmp(exe, _T("g++")) || !_tcscmp(exe, _T("c++")))
+        exec_argv[arg++] = _T("--driver-mode=g++");
+    else if (!_tcscmp(exe, _T("c99")))
+        exec_argv[arg++] = _T("-std=c99");
+    else if (!_tcscmp(exe, _T("c11")))
+        exec_argv[arg++] = _T("-std=c11");
+
+    if (target_os && !_tcscmp(target_os, _T("mingw32uwp"))) {
+        // the UWP target is for Windows 10
+        exec_argv[arg++] = _T("-D_WIN32_WINNT=0x0A00");
+        exec_argv[arg++] = _T("-DWINVER=0x0A00");
+        // the UWP target can only use Windows Store APIs
+        exec_argv[arg++] = _T("-DWINAPI_FAMILY=WINAPI_FAMILY_APP");
+        // the Windows Store API only supports Windows Unicode (some rare ANSI ones are available)
+        exec_argv[arg++] = _T("-DUNICODE");
+        // force the Universal C Runtime
+        exec_argv[arg++] = _T("-D_UCRT");
+    }
+
+    exec_argv[arg++] = _T("-target");
+    exec_argv[arg++] = target;
+    exec_argv[arg++] = _T("--sysroot");
+    exec_argv[arg++] = concat(dir, _T("../..") _T(SYSROOT));
+    exec_argv[arg++] = _T("-rtlib=compiler-rt");
+    exec_argv[arg++] = _T("-unwindlib=libunwind");
+    exec_argv[arg++] = _T("-stdlib=libc++");
+    exec_argv[arg++] = _T("-fuse-ld=lld");
+    exec_argv[arg++] = _T("--end-no-unused-arguments");
+
+    for (int i = 1; i < argc; i++)
+        exec_argv[arg++] = argv[i];
+
+    if (target_os && !_tcscmp(target_os, _T("mingw32uwp"))) {
+        // Default linker flags; passed after any user specified -l options,
+        // to let the user specified libraries take precedence over these.
+
+        exec_argv[arg++] = _T("--start-no-unused-arguments");
+        // add the minimum runtime to use for UWP targets
+        exec_argv[arg++] = _T("-Wl,-lwindowsapp");
+        // This still requires that the toolchain (in particular, libc++.a) has
+        // been built targeting UCRT originally.
+        exec_argv[arg++] = _T("-Wl,-lucrtapp");
+        exec_argv[arg++] = _T("--end-no-unused-arguments");
+    }
+
+    exec_argv[arg] = NULL;
+    if (arg > max_arg) {
+        fprintf(stderr, "Too many options added\n");
+        abort();
+    }
+
+    return run_final(exec_argv[0], exec_argv);
+}

--- a/mingw-w64-cross-clang/dlltool-wrapper.c
+++ b/mingw-w64-cross-clang/dlltool-wrapper.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2018 Martin Storsjo
+ *
+ * This file is part of llvm-mingw.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "native-wrapper.h"
+
+#ifndef DEFAULT_TARGET
+#define DEFAULT_TARGET "x86_64-w64-mingw32"
+#endif
+
+int _tmain(int argc, TCHAR* argv[]) {
+    const TCHAR *dir;
+    const TCHAR *target;
+    split_argv(argv[0], &dir, NULL, &target, NULL);
+    if (!target)
+        target = _tcsdup(_T(DEFAULT_TARGET));
+    TCHAR *dash = _tcschr(target, '-');
+    if (dash)
+        *dash = '\0';
+
+    int max_arg = argc + 2;
+    const TCHAR **exec_argv = malloc((max_arg + 1) * sizeof(*exec_argv));
+    int arg = 0;
+    exec_argv[arg++] = concat(dir, _T("llvm-dlltool"));
+
+    if (!_tcscmp(target, _T("i686"))) {
+        exec_argv[arg++] = _T("-m");
+        exec_argv[arg++] = _T("i386");
+    } else if (!_tcscmp(target, _T("x86_64"))) {
+        exec_argv[arg++] = _T("-m");
+        exec_argv[arg++] = _T("i386:x86-64");
+    } else if (!_tcscmp(target, _T("armv7"))) {
+        exec_argv[arg++] = _T("-m");
+        exec_argv[arg++] = _T("arm");
+    } else if (!_tcscmp(target, _T("aarch64"))) {
+        exec_argv[arg++] = _T("-m");
+        exec_argv[arg++] = _T("arm64");
+    } else {
+        _ftprintf(stderr, _T("Arch "TS" unsupported\n"), target);
+        return 1;
+    }
+
+    for (int i = 1; i < argc; i++)
+        exec_argv[arg++] = argv[i];
+
+    exec_argv[arg] = NULL;
+    if (arg > max_arg) {
+        fprintf(stderr, "Too many options added\n");
+        abort();
+    }
+
+    return run_final(exec_argv[0], exec_argv);
+}

--- a/mingw-w64-cross-clang/llvm-wrapper.c
+++ b/mingw-w64-cross-clang/llvm-wrapper.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018 Martin Storsjo
+ *
+ * This file is part of llvm-mingw.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "native-wrapper.h"
+
+int _tmain(int argc, TCHAR* argv[]) {
+    const TCHAR *dir;
+    const TCHAR *exe;
+    const TCHAR *basename, *target;
+    split_argv(argv[0], &dir, &basename, &target, &exe);
+    if (_tcsncmp(exe, _T("llvm-"), 5))
+        exe = concat(_T("llvm-"), exe);
+    TCHAR *exe_path = concat(dir, exe);
+
+    return run_final(exe_path, (const TCHAR *const *) argv);
+}

--- a/mingw-w64-cross-clang/native-wrapper.h
+++ b/mingw-w64-cross-clang/native-wrapper.h
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2018 Martin Storsjo
+ *
+ * This file is part of llvm-mingw.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifdef UNICODE
+#define _UNICODE
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <ctype.h>
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <tchar.h>
+#include <windows.h>
+#include <process.h>
+#define EXECVP_CAST
+#else
+#include <unistd.h>
+typedef char TCHAR;
+#define _T(x) x
+#define _tcsrchr strrchr
+#define _tcschr strchr
+#define _tcsdup strdup
+#define _tcscpy strcpy
+#define _tcslen strlen
+#define _tcscmp strcmp
+#define _tcsncmp strncmp
+#define _tperror perror
+#define _texecvp execvp
+#define _tmain main
+#define _ftprintf fprintf
+#define _vftprintf vfprintf
+#define _tunlink unlink
+#define EXECVP_CAST (char **)
+#endif
+
+#ifdef _UNICODE
+#define TS "%ls"
+#else
+#define TS "%s"
+#endif
+
+#ifdef _WIN32
+static inline const TCHAR *escape(const TCHAR *str) {
+    // If we don't need to escape anything, just return the input string
+    // as is.
+    if (!_tcschr(str, ' ') && !_tcschr(str, '"'))
+        return str;
+    TCHAR *out = malloc((_tcslen(str) * 2 + 3) * sizeof(*out));
+    TCHAR *ptr = out;
+    int i;
+    *ptr++ = '"';
+    for (i = 0; str[i]; i++) {
+        if (str[i] == '"') {
+            int j = i - 1;
+            // Before all double quotes, backslashes need to be escaped, but
+            // not elsewhere.
+            while (j >= 0 && str[j--] == '\\')
+                *ptr++ = '\\';
+            // Escape the next double quote.
+            *ptr++ = '\\';
+        }
+        *ptr++ = str[i];
+    }
+    // Any final backslashes, before the quote around the whole argument,
+    // need to be doubled.
+    int j = i - 1;
+    while (j >= 0 && str[j--] == '\\')
+        *ptr++ = '\\';
+    *ptr++ = '"';
+    *ptr++ = '\0';
+    return out;
+}
+
+static inline TCHAR *concat(const TCHAR *prefix, const TCHAR *suffix);
+
+static TCHAR *make_response_file(const TCHAR **argv) {
+    if (!argv[1])
+        return NULL;
+    TCHAR *temp_path = malloc(MAX_PATH * sizeof(*temp_path));
+    if (GetTempPath(MAX_PATH, temp_path) == 0)
+        return NULL;
+    TCHAR *rsp_file = malloc(MAX_PATH * sizeof(*rsp_file));
+    if (GetTempFileName(temp_path, _T("ctw"), 0, rsp_file) == 0)
+        return NULL;
+
+    FILE *f = _tfopen(rsp_file, _T("w, ccs=UNICODE"));
+    for (int i = 1; argv[i]; i++)
+        _ftprintf(f, _T(TS"\n"), argv[i]);
+    fclose(f);
+    argv[1] = escape(concat(_T("@"), rsp_file));
+    argv[2] = NULL;
+    return rsp_file;
+}
+
+static inline int _tspawnvp_escape(int mode, const TCHAR *filename, const TCHAR * const *argv) {
+    int num_args = 0;
+    while (argv[num_args])
+        num_args++;
+    const TCHAR **escaped_argv = malloc((num_args + 1) * sizeof(*escaped_argv));
+    int total = 0;
+    for (int i = 0; argv[i]; i++) {
+        escaped_argv[i] = escape(argv[i]);
+        total += 1 + _tcslen(escaped_argv[i]);
+    }
+    escaped_argv[num_args] = NULL;
+    const TCHAR *temp_file = NULL;
+    if (total > 32000) {
+        // If we are getting close to the limit, write the arguments to
+        // a temporary response file.
+        temp_file = make_response_file(escaped_argv);
+        if (temp_file)
+            total = _tcslen(escaped_argv[0]) + _tcslen(escaped_argv[1]) + 2;
+    }
+    int ret = _tspawnvp(mode, filename, escaped_argv);
+    if (temp_file)
+        DeleteFile(temp_file);
+    return ret;
+}
+#else
+static inline int _tcsicmp(const TCHAR *a, const TCHAR *b) {
+    while (*a && tolower(*a) == tolower(*b)) {
+        a++;
+        b++;
+    }
+    return *a - *b;
+}
+#endif
+
+static inline TCHAR *concat(const TCHAR *prefix, const TCHAR *suffix) {
+    int prefixlen = _tcslen(prefix);
+    int suffixlen = _tcslen(suffix);
+    TCHAR *buf = malloc((prefixlen + suffixlen + 1) * sizeof(*buf));
+    _tcscpy(buf, prefix);
+    _tcscpy(buf + prefixlen, suffix);
+    return buf;
+}
+
+static inline TCHAR *_tcsrchrs(const TCHAR *str, TCHAR char1, TCHAR char2) {
+    TCHAR *ptr1 = _tcsrchr(str, char1);
+    TCHAR *ptr2 = _tcsrchr(str, char2);
+    if (!ptr1)
+        return ptr2;
+    if (!ptr2)
+        return ptr1;
+    if (ptr1 < ptr2)
+        return ptr2;
+    return ptr1;
+}
+
+static inline void split_argv(const TCHAR *argv0, const TCHAR **dir_ptr, const TCHAR **basename_ptr, const TCHAR **target_ptr, const TCHAR **exe_ptr) {
+    const TCHAR *sep = _tcsrchrs(argv0, '/', '\\');
+    TCHAR *dir = _tcsdup(_T(""));
+    const TCHAR *basename = argv0;
+    if (sep) {
+        dir = _tcsdup(argv0);
+        dir[sep + 1 - argv0] = '\0';
+        basename = sep + 1;
+    }
+#ifdef _WIN32
+    TCHAR module_path[8192];
+    GetModuleFileName(NULL, module_path, sizeof(module_path)/sizeof(module_path[0]));
+    // Try to resolve the given tool name into its long form. If the caller
+    // called us with a short form executable name, e.g. C__~1.EXE instead of
+    // c++.exe, we need to resolve the original name, so that the wrapper
+    // can invoke the right tool with the right arguments.
+    //
+    // CMake/Ninja generates such tool names when the tools are located in
+    // a path with spaces.
+    TCHAR long_path[8192];
+    int long_path_ret = GetLongPathName(module_path, long_path, sizeof(long_path)/sizeof(long_path[0]));
+    if (long_path_ret > 0 && long_path_ret < sizeof(long_path)/sizeof(long_path[0])) {
+        sep = _tcsrchrs(long_path, '/', '\\');
+        if (sep)
+            basename = _tcsdup(sep + 1);
+    }
+    TCHAR *sep2 = _tcsrchr(module_path, '\\');
+    if (sep2) {
+        sep2[1] = '\0';
+        dir = _tcsdup(module_path);
+    }
+#endif
+    basename = _tcsdup(basename);
+    TCHAR *period = _tcschr(basename, '.');
+    if (period)
+        *period = '\0';
+    TCHAR *target = _tcsdup(basename);
+    TCHAR *dash = _tcsrchr(target, '-');
+    const TCHAR *exe = basename;
+    if (dash) {
+        *dash = '\0';
+        exe = dash + 1;
+        // Handle [<target>-]llvm-<tool> as exe=llvm-<tool>
+        TCHAR *dash2 = _tcsrchr(target, '-');
+        if (dash2 && !_tcscmp(dash2, _T("-llvm"))) {
+            // Found <target>-llvm-<tool>; move the llvm- prefix to
+            // exe. Convert the original dash which we overwrote with '\0'
+            // back into a dash and split the string at the preceding dash.
+            *dash = '-';
+            *dash2 = '\0';
+            exe = dash2 + 1;
+        } else if (!_tcscmp(target, _T("llvm"))) {
+            // Found llvm-<tool>; don't treat "llvm" as target but move
+            // it to the exe part.
+            exe = basename;
+            target = NULL;
+        }
+    } else {
+        target = NULL;
+    }
+
+    if (dir_ptr)
+        *dir_ptr = dir;
+    if (basename_ptr)
+        *basename_ptr = basename;
+    if (target_ptr)
+        *target_ptr = target;
+    if (exe_ptr)
+        *exe_ptr = exe;
+}
+
+static inline int run_final(const TCHAR *executable, const TCHAR *const *argv) {
+#ifdef _WIN32
+    int ret = _tspawnvp_escape(_P_WAIT, executable, argv);
+    if (ret == -1) {
+        _tperror(executable);
+        return 1;
+    }
+    return ret;
+#else
+    // On unix, exec() runs the target executable within this same process,
+    // making the return code propagate implicitly.
+    // Windows doesn't have such mechanisms, and the exec() family of functions
+    // makes the calling process exit immediately and always returning
+    // a zero return. This doesn't work for our case where we need the
+    // return code propagated.
+    _texecvp(executable, EXECVP_CAST argv);
+
+    _tperror(executable);
+    return 1;
+#endif
+}

--- a/mingw-w64-cross-clang/windres-wrapper.c
+++ b/mingw-w64-cross-clang/windres-wrapper.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2018 Martin Storsjo
+ *
+ * This file is part of llvm-mingw.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "native-wrapper.h"
+
+#ifndef DEFAULT_TARGET
+#define DEFAULT_TARGET "x86_64-w64-mingw32"
+#endif
+#ifndef SYSROOT
+#define SYSROOT "/clang64"
+#endif
+
+int _tmain(int argc, TCHAR* argv[]) {
+    const TCHAR *dir;
+    const TCHAR *target;
+    split_argv(argv[0], &dir, NULL, &target, NULL);
+    if (!target)
+        target = _T(DEFAULT_TARGET);
+
+    int max_arg = argc + 4;
+    const TCHAR **exec_argv = malloc((max_arg + 1) * sizeof(*exec_argv));
+    int arg = 0;
+    exec_argv[arg++] = concat(dir, _T("llvm-windres"));
+    exec_argv[arg++] = _T("--target");
+    exec_argv[arg++] = target;
+    exec_argv[arg++] = _T("--preprocessor-arg");
+    /* something is eating backslashes */
+    TCHAR * p = (TCHAR *)dir;
+    while ((p = _tcschr(p, _T('\\'))))
+        *p = _T('/');
+    exec_argv[arg++] = concat(_T("--sysroot="), concat(dir, _T("../..") _T(SYSROOT)));
+
+    for (int i = 1; i < argc; i++)
+        exec_argv[arg++] = argv[i];
+
+    exec_argv[arg] = NULL;
+    if (arg > max_arg) {
+        fprintf(stderr, "Too many options added\n");
+        abort();
+    }
+
+    return run_final(exec_argv[0], exec_argv);
+}

--- a/mingw-w64-cross-compiler-rt/PKGBUILD
+++ b/mingw-w64-cross-compiler-rt/PKGBUILD
@@ -1,0 +1,92 @@
+declare -g -A _cross_arches=(
+  ["/clang64"]="x86_64-w64-mingw32"
+  ["/clangarm64"]="aarch64-w64-mingw32"
+)
+_realname=compiler-rt
+pkgbase=mingw-w64-cross-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-cross-${_realname}")
+pkgver=19.1.6
+pkgrel=1
+arch=("any")
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url="https://llvm.org/"
+license=("spdx:Apache-2.0 WITH LLVM-exception")
+makedepends=("${MINGW_PACKAGE_PREFIX}-clang"
+             "${MINGW_PACKAGE_PREFIX}-cmake>=3.4.3"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
+
+for _pfx in "${!_cross_arches[@]}"; do
+  if [[ "${_cross_arches[$_pfx]%%-*}" != "${CARCH}" ]]; then
+    makedepends+=(mingw-w64-clang-${_cross_arches[$_pfx]%%-*}-headers-git)
+  fi
+done
+
+options=('!debug' '!strip' 'staticlibs' '!buildflags')
+_url=https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkgver}
+source=("${_url}/${_realname}-${pkgver}.src.tar.xz"{,.sig}
+        "${_url}/cmake-${pkgver}.src.tar.xz"{,.sig})
+
+sha256sums=('0d4f312e1419152282c267e6b6a1fa5914a7a0c753a5e926bee1c8c28e614ae4'
+            'SKIP'
+            '9c7ec82d9a240dc2287b8de89d6881bb64ceea0dcd6ce133c34ef65bda22d99e'
+            'SKIP')
+validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Google.
+              '474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard
+              'D574BD5D1D0E98895E3BF90044F2485E45D59042') # Tobias Hieta
+
+prepare() {
+  cd "${srcdir}"
+  rm -rf cmake
+  mv cmake-$pkgver.src cmake
+}
+
+build() {
+  local _build_type _arch _pfx
+  if check_option "debug" "y"; then
+    _build_type="Debug"
+  else
+    _build_type="Release"
+  fi
+
+  for _pfx in "${!_cross_arches[@]}"; do
+    _arch="${_cross_arches[$_pfx]%%-*}"
+    if [[ "${_arch}" != "${CARCH}" ]]; then
+      cd "${srcdir}"
+      [[ -d "build-${_arch}" ]] && rm -rf "build-${_arch}"
+      mkdir "build-${_arch}" && cd "build-${_arch}"
+      MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+      ${MINGW_PREFIX}/bin/cmake.exe \
+        -GNinja \
+        -DCMAKE_BUILD_TYPE=${_build_type} \
+        -DCMAKE_{ASM,C,CXX}_COMPILER_TARGET="${_cross_arches[$_pfx]}" \
+        -DCMAKE_{ASM,C,CXX}_COMPILER_WORKS=ON \
+        -DCMAKE_SIZEOF_VOID_P=$( [[ "$_pfx" == *32 ]] && echo 4 || echo 8 ) \
+        -DCMAKE_SYSROOT="${_pfx}" \
+        -DCMAKE_INSTALL_PREFIX="$(clang -print-resource-dir | cygpath -uf -)" \
+        -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER \
+        -DCMAKE_FIND_ROOT_PATH_MODE_{LIBRARY,INCLUDE,PACKAGE}=ONLY \
+        -DCMAKE_AR="${MINGW_PREFIX}/bin/llvm-ar.exe" \
+        -DCMAKE_ASM_COMPILER="${MINGW_PREFIX}/bin/clang.exe" \
+        -DCMAKE_C_COMPILER="${MINGW_PREFIX}/bin/clang.exe" \
+        -DCMAKE_CXX_COMPILER="${MINGW_PREFIX}/bin/clang++.exe" \
+        -DCMAKE_RANLIB="${MINGW_PREFIX}/bin/llvm-ranlib.exe" \
+        -DCOMPILER_RT_BUILD_{LIBFUZZER,MEMPROF,ORC,PROFILE,SANITIZERS,XRAY}=OFF \
+        -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
+        -DCOMPILER_RT_USE_BUILTINS_LIBRARY=ON \
+	-DLLVM_DIR="${MINGW_PREFIX}/lib/cmake/llvm" \
+        ../${_realname}-$pkgver.src
+      cmake --build .
+    fi
+  done
+}
+
+package() {
+  local _arch _pfx
+  for _pfx in "${!_cross_arches[@]}"; do
+    _arch="${_cross_arches[$_pfx]%%-*}"
+    if [[ "${_arch}" != "${CARCH}" ]]; then
+      DESTDIR="${pkgdir}" cmake --install "${srcdir}/build-${_arch}"
+    fi
+  done
+  rm -rf "${pkgdir}$(clang -print-resource-dir | cygpath -uf -)/include"
+}


### PR DESCRIPTION
Related to discussion #8736.

Based on wrappers from [llvm-mingw](https://github.com/mstorsjo/llvm-mingw).  Also adds a package that provides "foreign" compiler-rt libs.

The clang wrapper could be simplified (have some of the options removed) if the package is only provided for CLANG*.  I haven't tested them under MINGW*.