### PR TITLE
ci: explicitly install pactoys-git

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MSYS
-          install: git msys2-devel base-devel binutils ${{ matrix.toolchain }}
+          install: git msys2-devel base-devel binutils pactoys-git ${{ matrix.toolchain }}
           update: true
 
       - name: Add staging repo


### PR DESCRIPTION
For some reason it seems to have stopped being installed, so do it explicitly.

Fixes msys2/MSYS2-packages#2524