### PR TITLE
glibmm: fix build with clang

### DIFF
--- a/mingw-w64-glibmm/PKGBUILD
+++ b/mingw-w64-glibmm/PKGBUILD
@@ -4,7 +4,7 @@ _realname=glibmm
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.66.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Glib-- (glibmm) is a C++ interface for glib (V2.66) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -15,12 +15,17 @@ depends=("${MINGW_PACKAGE_PREFIX}-glib2"
 makedepends=("${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
 options=('strip' '!debug' 'staticlibs')
-source=("https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz")
-sha256sums=('69bd6b5327716ca2f511ab580a969fd7bf0cd2c24ce15e1d0e530592d3ff209c')
+source=("https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz"
+        "glibmm-2.66.1-no-export-deleted-methods.patch")
+sha256sums=('69bd6b5327716ca2f511ab580a969fd7bf0cd2c24ce15e1d0e530592d3ff209c'
+            'a4ff330529d457b5be05eeab31d0cba5bc073b35b8c05ac5ab1dffb3a79d3751')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
+  # work around error building under clang
+  # https://gitlab.gnome.org/GNOME/glibmm/-/issues/92
+  patch -Np1 -i "${srcdir}/glibmm-2.66.1-no-export-deleted-methods.patch"
   # glibmm_binding test can not be built due to linking error
   sed '/glibmm_binding/d' -i tests/meson.build
 }

--- a/mingw-w64-glibmm/glibmm-2.66.1-no-export-deleted-methods.patch
+++ b/mingw-w64-glibmm/glibmm-2.66.1-no-export-deleted-methods.patch
@@ -1,0 +1,13 @@
+--- glibmm-2.66.1/glib/glibmm/ustring.h.orig	2021-05-30 14:58:12.510847400 -0700
++++ glibmm-2.66.1/glib/glibmm/ustring.h	2021-05-30 14:58:43.260848700 -0700
+@@ -1076,8 +1076,8 @@
+ {
+ public:
+   // noncopyable
+-  GLIBMM_API FormatStream(const ustring::FormatStream&) = delete;
+-  GLIBMM_API FormatStream& operator=(const ustring::FormatStream&) = delete;
++  FormatStream(const ustring::FormatStream&) = delete;
++  FormatStream& operator=(const ustring::FormatStream&) = delete;
+ 
+ private:
+ #ifdef GLIBMM_HAVE_WIDE_STREAM


### PR DESCRIPTION
Don't try to dllexport deleted methods.

https://gitlab.gnome.org/GNOME/glibmm/-/issues/92