### PR TITLE
curl: update to 7.77.0

### DIFF
--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -13,7 +13,7 @@ fi
 _realname=curl
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}${_namesuff}"
-pkgver=7.76.1
+pkgver=7.77.0
 pkgrel=1
 pkgdesc="Command line tool and library for transferring data with URLs. (mingw-w64)"
 arch=('any')
@@ -49,7 +49,7 @@ source=("https://github.com/curl/curl/releases/download/${_realname}-${pkgver//.
         "0001-Make-cURL-relocatable.patch"
         "0002-nghttp2-static.patch"
         "0003-libpsl-static-libs.patch")
-sha256sums=('64bb5288c39f0840c07d077e30d9052e1cbb9fa6c2dc52523824cc859e679145'
+sha256sums=('0f64582c54282f31c0de9f0a1a596b182776bd4df9a4c4a2a41bbeb54f62594b'
             'SKIP'
             '41e7d1f734cae5fbeea8a84ec4af40c29bf7ffbf156ab290abd57df840312ca1'
             '79eec8a337e375d5102fef884030ceacd163a79e5c495e9a974a6b9a11b60c61'
@@ -74,34 +74,31 @@ build() {
   else
     extra_config+=( --disable-debug )
   fi
-  mkdir -p "${srcdir}/build-${CARCH}"
+
   local -a _variant_config
   if [ "${_variant}" = "-winssl" ]; then
-    _variant_config+=("--without-ssl")
-    _variant_config+=("--without-gnutls")
-    _variant_config+=("--with-winssl")
+    _variant_config+=("--with-schannel")
     _variant_config+=('--without-nghttp2')
     _variant_config+=("--without-ca-bundle")
     _variant_config+=("--without-ca-path")
     _variant_config+=("--without-librtmp")
   elif [ "${_variant}" = "-gnutls" ]; then
     _variant_config+=("--with-default-ssl-backend=gnutls")
-    _variant_config+=("--without-ssl")
     _variant_config+=("--with-gnutls")
-    _variant_config+=("--with-winssl")
+    _variant_config+=("--with-schannel")
     _variant_config+=('--without-nghttp2')
     _variant_config+=("--with-ca-bundle=${MINGW_PREFIX}/ssl/certs/ca-bundle.crt")
     _variant_config+=("--with-librtmp")
   elif [ "${_variant}" = "-openssl" ]; then
     _variant_config+=("--with-default-ssl-backend=openssl")
-    _variant_config+=("--without-gnutls")
-    _variant_config+=("--with-ssl")
-    _variant_config+=("--with-winssl")
+    _variant_config+=("--with-openssl")
+    _variant_config+=("--with-schannel")
     _variant_config+=("--with-ca-bundle=${MINGW_PREFIX}/ssl/certs/ca-bundle.crt")
-    _variant_config+=("--with-nghttp2=${MINGW_PREFIX}/")
+    _variant_config+=("--with-nghttp2=${MINGW_PREFIX}")
     _variant_config+=("--without-librtmp")
   fi
-  cd "${srcdir}/build-${CARCH}"
+
+  mkdir -p "${srcdir}/build-static-${MSYSTEM}" && cd "${srcdir}/build-static-${MSYSTEM}"
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
@@ -109,6 +106,30 @@ build() {
     --target=${MINGW_CHOST} \
     --without-random \
     --enable-static \
+    --disable-shared \
+    --enable-sspi \
+    --enable-ldap \
+    --enable-ldaps \
+    --with-brotli \
+    --with-ldap-lib=wldap32 \
+    --with-libmetalink=${MINGW_PREFIX} \
+    --with-libssh2 \
+    --with-zstd \
+    "${_variant_config[@]}" \
+    "${extra_config[@]}"
+# there's a bug with zsh completion generation script and Windows.
+# curl has to specified with the file extension.
+  sed -i "s|\/curl > \$\@|\/curl\$\{EXEEXT\} > \$\@|" scripts/Makefile
+  make
+
+  mkdir -p "${srcdir}/build-shared-${MSYSTEM}" && cd "${srcdir}/build-shared-${MSYSTEM}"
+  ../${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --without-random \
+    --disable-static \
     --enable-shared \
     --enable-sspi \
     --enable-ldap \
@@ -127,7 +148,10 @@ build() {
 }
 
 package() {
-  cd "${srcdir}/build-${CARCH}"
+  cd "${srcdir}/build-static-${MSYSTEM}"
+  make DESTDIR="${pkgdir}" install
+
+  cd "${srcdir}/build-shared-${MSYSTEM}"
   make DESTDIR="${pkgdir}" install
 
   local PREFIX_DEPS=$(cygpath -am ${MINGW_PREFIX})


### PR DESCRIPTION
adapt `_variant_config` to https://github.com/curl/curl/pull/6897

also separate static and shared builds because `0002-nghttp2-static.patch` only works with shared build disabled.  Fixes #8774