### PR TITLE
cfitsio: needs epoch

### DIFF
--- a/mingw-w64-cfitsio/PKGBUILD
+++ b/mingw-w64-cfitsio/PKGBUILD
@@ -5,6 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.48
 pkgrel=1
+epoch=1
 pkgdesc="A library of C and Fortran subroutines for reading and writing data files in FITS (Flexible Image Transport System) data format (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')


### PR DESCRIPTION
3.48 > 3.450

MINGW32 & MINGW64 are stuck at the older version, while UCRT64 and CLANG64 have just the newer one built