### PR TITLE
ngspice: fix clang build

### DIFF
--- a/mingw-w64-ngspice/PKGBUILD
+++ b/mingw-w64-ngspice/PKGBUILD
@@ -12,7 +12,7 @@ _realname=ngspice
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=34
-pkgrel=1
+pkgrel=2
 pkgdesc="Mixed-level/Mixed-signal circuit simulator based on Spice3f5, Cider1b1, and Xspice (mingw-w64)"
 url='https://ngspice.sourceforge.io/'
 license=('BSD')
@@ -31,11 +31,19 @@ makedepends=(
 source=(
   "https://downloads.sourceforge.net/project/${_realname}/ng-spice-rework/${pkgver}/${_realname}-${pkgver}.tar.gz"
   "https://downloads.sourceforge.net/project/${_realname}/ng-spice-rework/${pkgver}/${_realname}-doc-${pkgver}.tar.gz"
+  "no-explicit-lstdc++.patch"
 )
 sha256sums=(
   '2263fffc6694754972af7072ef01cfe62ac790800dad651bc290bfcae79bd7b5'
   'cbe7a42c4e3730ce86f2bdcc5c2eb95192e7daadf99e1c039b02dceaf7a12743'
+  '26c34504e11ee753855da3b6d5ff44f0247dbcedb9eb6fe5efcf6f50f2927c97'
 )
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -Np1 -i "${srcdir}/no-explicit-lstdc++.patch"
+  autoreconf -fiv
+}
 
 build() {
   [[ -d "${srcdir}/build-shared-${CARCH}" ]] && rm -rf "${srcdir}/build-shared-${CARCH}"
@@ -44,6 +52,9 @@ build() {
   # FS#45230, create so lib
   # shared lib sets flags and modifies headers, needs dedicated pass
   # adding --with-readline disables libngspice-0.dll
+  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
+    LDFLAGS+=" -lomp"
+  fi
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
@@ -59,6 +70,8 @@ build() {
   [[ -d "${srcdir}/build-static-${CARCH}" ]] && rm -rf "${srcdir}/build-static-${CARCH}"
   mkdir -p "${srcdir}/build-static-${CARCH}" && cd "${srcdir}/build-static-${CARCH}"
 
+  # gcc is being weird
+  LDFLAGS+=" -lgdi32"
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \

--- a/mingw-w64-ngspice/no-explicit-lstdc++.patch
+++ b/mingw-w64-ngspice/no-explicit-lstdc++.patch
@@ -1,0 +1,42 @@
+--- ngspice-34/configure.ac.orig	2021-06-01 14:13:02.841416700 -0700
++++ ngspice-34/configure.ac	2021-06-01 14:13:32.380022600 -0700
+@@ -772,7 +772,7 @@
+ AM_CONDITIONAL([NO_HELP], [test "x$has_no_help" = xtrue])
+ 
+ # Additional libs of hicum group
+-AC_CHECK_LIB(stdc++, main, XTRALIBS="$XTRALIBS -lstdc++",,)
++dnl AC_CHECK_LIB(stdc++, main, XTRALIBS="$XTRALIBS -lstdc++",,)
+ AC_SUBST(XTRALIBS, $XTRALIBS)
+ 
+ LIBS="$LIBS $XTRALIBS"
+--- ngspice-34/src/Makefile.am.orig	2021-06-01 14:42:50.696457300 -0700
++++ ngspice-34/src/Makefile.am	2021-06-01 14:45:07.914478200 -0700
+@@ -111,6 +111,8 @@
+ 	conf.h \
+ 	ngspice.c
+ 
++nodist_EXTRA_ngspice_SOURCES = dummy.cpp
++
+ ngspice_CPPFLAGS = $(AM_CPPFLAGS) -DSIMULATOR
+ 
+ if WINGUI
+@@ -125,7 +125,8 @@
+ 
+ if WINGUI
+ ngspice_LDADD += \
+-	frontend/wdisp/libwindisp.la
++	frontend/wdisp/libwindisp.la \
++	-lgdi32 -lcomdlg32
+ endif
+ 
+ ngspice_LDADD += \
+@@ -573,7 +573,8 @@
+ libngspice_la_CFLAGS = -shared
+ 
+ libngspice_la_LDFLAGS =  -shared
+-libngspice_la_LDFLAGS +=  -lstdc++
++#libngspice_la_LDFLAGS +=  -lstdc++
++nodist_EXTRA_libngspice_la_SOURCES = dummy.cpp
+ 
+ if SHWIN
+ libngspice_la_LDFLAGS += -Wl,--output-def=ngspice.def  -Wl,--out-implib=ngspice.dll.a


### PR DESCRIPTION
This started out just being an autoreconf, but turned into a can of worms...

ngspice was trying to explicitly link in libstdc++, which causes issues with Clang prefix (which uses libc++ but pretends to have libstdc++) and libtool (that goes looking for the actual files, which it can't find).  The reason that ngspice probably does this is that libtool decided to link it as C instead of C++.  Work around this as documented in https://www.gnu.org/software/automake/manual/html_node/Libtool-Convenience-Libraries.html by inventing a "dummy" C++ source file that does not actually have to exist.

After that, for some reason it seemed to not try to link gdi32 and comdlg32 into static ngspice.exe.  Explicitly add them to LDADD.

That worked for Clang, but GCC decided to still complain about a couple of references in gdi32, so also add it to LDFLAGS in the PKGBUILD.

Whew