### PR TITLE
python3.9: reserve 2MB of stack space

### DIFF
--- a/mingw-w64-python3.9/4010-MINGW-stack-reserve.patch
+++ b/mingw-w64-python3.9/4010-MINGW-stack-reserve.patch
@@ -1,0 +1,14 @@
+--- Python-3.9.5/configure.ac.orig	2021-06-03 15:49:37.703127100 -0700
++++ Python-3.9.5/configure.ac	2021-06-03 16:28:45.151498200 -0700
+@@ -3062,6 +3062,11 @@
+ 	VxWorks*)
+ 		LINKFORSHARED='--export-dynamic';;
+ 	esac
++	case $host in
++	*-*-mingw*)
++		# for https://bugs.python.org/issue40458 on MINGW
++		LINKFORSHARED="-Wl,--stack,2000000";;
++	esac
+ fi
+ AC_MSG_RESULT($LINKFORSHARED)
+ 

--- a/mingw-w64-python3.9/PKGBUILD
+++ b/mingw-w64-python3.9/PKGBUILD
@@ -29,7 +29,7 @@ else
   pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}${_pybasever}")
 fi
 pkgver=${_pybasever}.5
-pkgrel=2
+pkgrel=3
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -146,6 +146,7 @@ source=("https://www.python.org/ftp/python/${pkgver%rc?}/Python-${pkgver}.tar.xz
         3011-fix-build-testinternalcapi.patch
         3020-extend-MS_WINDOWS-flag.patch
         4000-clang-arm64.patch
+        4010-MINGW-stack-reserve.patch
         5000-warnings-fixes.patch
         smoketests.py)
 
@@ -315,6 +316,9 @@ prepare() {
 
   apply_patch_with_msg 4000-clang-arm64.patch
 
+  # https://bugs.python.org/issue40458
+  apply_patch_with_msg 4010-MINGW-stack-reserve.patch
+
   autoreconf -vfi
 }
 
@@ -331,10 +335,6 @@ check() {
 
 build() {
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
-
-  if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then
-    export CC=clang CXX=clang++
-  fi
 
   CFLAGS+=" -fwrapv -D__USE_MINGW_ANSI_STDIO=1 -D_WIN32_WINNT=0x0601"
   CXXFLAGS+=" -fwrapv -D__USE_MINGW_ANSI_STDIO=1 -D_WIN32_WINNT=0x0601"
@@ -611,5 +611,6 @@ sha256sums=('0c5a140665436ec3dbfbb79e2dfb6d192655f26ef4a29aeffcb6d1820d716d83'
             '005381222cfef42ccc21151845b6d43d25c861f35c2192e5e23c2a14df7938f0'
             'b6b3f8f2c809dc7ef43bc26306516edf4a5d1e038343ad8c7a45f666011c2e8b'
             '717167e9ca5563e04103871a3e489dd1cef77a83c5c6d20e7bda6dced7f3fc42'
+            '1b774cdd7d0999cbd6a20c490f1eebe24c25ce8618845ce0fc41f8447008aec7'
             '07877afd83c941c125064bebea8bdf6f94c15b24ebceaf1e100c05a4f93d782b'
             '7188e017a1efba4a87cb64a38b63ed2d8a469e2e74c3fd35b6538d5bc6e370e5')


### PR DESCRIPTION
https://bugs.python.org/issue40458 was happening on CLANG64 (test_pickle was crashing due to Windows stack overflow exception)

Also, get rid of no-longer-needed setting of CC and CXX for clang support (no longer needed after msys2/MSYS2-packages#2501)