### PR TITLE
indent: Fix endless file read loop

### DIFF
--- a/mingw-w64-indent/PKGBUILD
+++ b/mingw-w64-indent/PKGBUILD
@@ -6,7 +6,7 @@ _realname=indent
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.2.12
-pkgrel=2
+pkgrel=3
 pkgdesc="C language source code formatting program (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -18,13 +18,15 @@ source=(https://ftp.gnu.org/gnu/indent/${_realname}-${pkgver}.tar.gz{,.sig}
         indent-2.2.11-segfault.patch
         indent-2.2.11-disable-documentation.patch
         indent-2.2.11-win32-wildexp-automake-support.patch
-        indent-2.2.12-disable-texinfo2man.patch)
+        indent-2.2.12-disable-texinfo2man.patch
+        indent-2.2.12-fix-file-read-loop.patch)
 sha256sums=('e77d68c0211515459b8812118d606812e300097cfac0b4e9fb3472664263bb8b'
             'SKIP'
             '63c66b49831a90c5191cd3295d17a4e1888d8fa2a0b02589448de3b78d4e0293'
             '624ae1c52b01e52dfd4417bb160ef606342f25548fbd90c58ef4962367179750'
             'd0ecfbc7cbf694b4222545bbd19d1b81f320ee9f5a2d5bfc86f27fe365f63145'
-            'b8489a9dd7e4983f63ba6960bc3b1d8f51dd6ae08c29c6e8a9878491d0bf5e11')
+            'b8489a9dd7e4983f63ba6960bc3b1d8f51dd6ae08c29c6e8a9878491d0bf5e11'
+            'c96f9a9a80be3fc9d53ea44369865e8ddc10187cc875a0dffcfa423a25be679a')
 validpgpkeys=('782130B4C9944247977B82FD6EA4D2311A2D268D')
 
 # Helper macros to help make tasks easier #
@@ -55,7 +57,8 @@ prepare() {
     indent-2.2.11-segfault.patch \
     indent-2.2.11-disable-documentation.patch \
     indent-2.2.11-win32-wildexp-automake-support.patch \
-    indent-2.2.12-disable-texinfo2man.patch
+    indent-2.2.12-disable-texinfo2man.patch \
+    indent-2.2.12-fix-file-read-loop.patch
 
   autoreconf -vfi
 }

--- a/mingw-w64-indent/indent-2.2.12-fix-file-read-loop.patch
+++ b/mingw-w64-indent/indent-2.2.12-fix-file-read-loop.patch
@@ -1,0 +1,27 @@
+--- a/src/code_io.c
++++ b/src/code_io.c
+@@ -203,9 +203,9 @@ extern file_buffer_ty * read_file(
+      * bytes in a 16-bit world...
+      */
+   
+-    unsigned int size = 0, size_to_read = 0;
++    unsigned int size = 0, size_to_read = 0, size_sum = 0;
+ #else
+-    ssize_t size = 0;
++    ssize_t size = 0, size_sum = 0;
+     size_t size_to_read = 0;
+ #endif
+ 
+@@ -284,8 +284,12 @@ extern file_buffer_ty * read_file(
+             xfree(fileptr.data);
+             fatal (_("Error reading input file %s"), filename);
+         }
++        if (size == 0)
++            break;
+         size_to_read -= size;
++        size_sum += size;
+     }
++    size = size_sum;
+     
+     if (close(fd) < 0)
+     {


### PR DESCRIPTION
Indent 2.2.12 would end up in an endless loop if indenting a file with CR/LF line endings.

This happens when the file is read, where all CR/LF line endings are converted to LF only. This results in fewer bytes read than the file size indicates. A while loop keeps trying to read the "missing" bytes, but read returns 0.
This fix stops the while loop when there is no more to read.
