### PR TITLE
mingw-w64-headers-git: add patch for av1 with dxva

### DIFF
--- a/mingw-w64-crt-git/0001-headers-add-AV1-support-to-dxva.h.patch
+++ b/mingw-w64-crt-git/0001-headers-add-AV1-support-to-dxva.h.patch
@@ -1,0 +1,309 @@
+From 4ede80067d321e75ea082f8c7e66fb167052fde9 Mon Sep 17 00:00:00 2001
+From: Steve Lhomme <robux4@ycbcr.xyz>
+Date: Sat, 15 May 2021 15:26:42 +0200
+Subject: [PATCH] headers: add AV1 support to dxva.h
+
+Based on the DXVA AV1 specs
+https://www.microsoft.com/en-us/download/details.aspx?id=101577
+
+The structures and the associated define are available in Windows SDK
+since at least 10.0.20231.0.
+
+The GUIDs were present in previous SDKs as well.
+---
+ mingw-w64-headers/include/dxva.h | 279 +++++++++++++++++++++++++++++++
+ 1 file changed, 279 insertions(+)
+
+diff --git a/mingw-w64-headers/include/dxva.h b/mingw-w64-headers/include/dxva.h
+index 4f18f2e..0bd1990 100644
+--- a/mingw-w64-headers/include/dxva.h
++++ b/mingw-w64-headers/include/dxva.h
+@@ -563,6 +563,285 @@ typedef struct _DXVA_Status_VPx
+     USHORT wNumMbsAffected;
+ } DXVA_Status_VPx, *LPDXVA_Status_VPx;
+ 
++
++#define _DIRECTX_AV1_VA_
++
++/* AV1 decoder GUIDs */
++DEFINE_GUID(DXVA_ModeAV1_VLD_Profile0,           0xb8be4ccb, 0xcf53, 0x46ba, 0x8d, 0x59, 0xd6, 0xb8, 0xa6, 0xda, 0x5d, 0x2a);
++DEFINE_GUID(DXVA_ModeAV1_VLD_Profile1,           0x6936ff0f, 0x45b1, 0x4163, 0x9c, 0xc1, 0x64, 0x6e, 0xf6, 0x94, 0x61, 0x08);
++DEFINE_GUID(DXVA_ModeAV1_VLD_Profile2,           0x0c5f2aa1, 0xe541, 0x4089, 0xbb, 0x7b, 0x98, 0x11, 0x0a, 0x19, 0xd7, 0xc8);
++DEFINE_GUID(DXVA_ModeAV1_VLD_12bit_Profile2,     0x17127009, 0xa00f, 0x4ce1, 0x99, 0x4e, 0xbf, 0x40, 0x81, 0xf6, 0xf3, 0xf0);
++DEFINE_GUID(DXVA_ModeAV1_VLD_12bit_Profile2_420, 0x2d80bed6, 0x9cac, 0x4835, 0x9e, 0x91, 0x32, 0x7b, 0xbc, 0x4f, 0x9e, 0xe8);
++
++/* AV1 picture entry data structure */
++typedef struct _DXVA_PicEntry_AV1 {
++    UINT width;
++    UINT height;
++
++    // Global motion parameters
++    INT wmmat[6];
++    union {
++        struct {
++            UCHAR wminvalid : 1;
++            UCHAR wmtype : 2;
++            UCHAR Reserved : 5;
++        };
++        UCHAR GlobalMotionFlags;
++    };
++    UCHAR Index;
++    USHORT Reserved16Bits;
++} DXVA_PicEntry_AV1, *LPDXVA_PicEntry_AV1;
++
++/* AV1 picture parameters data structure */
++typedef struct _DXVA_PicParams_AV1 {
++    UINT width;
++    UINT height;
++
++    UINT max_width;
++    UINT max_height;
++
++    UCHAR CurrPicTextureIndex;
++    UCHAR superres_denom;
++    UCHAR bitdepth;
++    UCHAR seq_profile;
++
++    // Tiles:
++    struct {
++        UCHAR cols;
++        UCHAR rows;
++        USHORT context_update_id;
++        USHORT widths[64];
++        USHORT heights[64];
++    } tiles;
++
++    // Coding Tools
++    union {
++        struct {
++            UINT use_128x128_superblock : 1;
++            UINT intra_edge_filter : 1;
++            UINT interintra_compound : 1;
++            UINT masked_compound : 1;
++            UINT warped_motion : 1;
++            UINT dual_filter : 1;
++            UINT jnt_comp : 1;
++            UINT screen_content_tools : 1;
++            UINT integer_mv : 1;
++            UINT cdef : 1;
++            UINT restoration : 1;
++            UINT film_grain : 1;
++            UINT intrabc : 1;
++            UINT high_precision_mv : 1;
++            UINT switchable_motion_mode : 1;
++            UINT filter_intra : 1;
++            UINT disable_frame_end_update_cdf : 1;
++            UINT disable_cdf_update : 1;
++            UINT reference_mode : 1;
++            UINT skip_mode : 1;
++            UINT reduced_tx_set : 1;
++            UINT superres : 1;
++            UINT tx_mode : 2;
++            UINT use_ref_frame_mvs : 1;
++            UINT enable_ref_frame_mvs : 1;
++            UINT reference_frame_update : 1;
++            UINT Reserved : 5;
++        };
++        UINT32 CodingParamToolFlags;
++    } coding;
++
++    // Format & Picture Info flags
++    union {
++        struct {
++            UCHAR frame_type : 2;
++            UCHAR show_frame : 1;
++            UCHAR showable_frame : 1;
++            UCHAR subsampling_x : 1;
++            UCHAR subsampling_y : 1;
++            UCHAR mono_chrome : 1;
++            UCHAR Reserved : 1;
++        };
++        UCHAR FormatAndPictureInfoFlags;
++    } format;
++
++    // References
++    UCHAR primary_ref_frame;
++    UCHAR order_hint;
++    UCHAR order_hint_bits;
++
++    DXVA_PicEntry_AV1 frame_refs[7];
++    UCHAR RefFrameMapTextureIndex[8];
++
++    // Loop filter parameters
++    struct {
++        UCHAR filter_level[2];
++        UCHAR filter_level_u;
++        UCHAR filter_level_v;
++
++        UCHAR sharpness_level;
++        union {
++            struct {
++                UCHAR mode_ref_delta_enabled : 1;
++                UCHAR mode_ref_delta_update : 1;
++                UCHAR delta_lf_multi : 1;
++                UCHAR delta_lf_present : 1;
++                UCHAR Reserved : 4;
++            };
++            UCHAR ControlFlags;
++        } DUMMYUNIONNAME;
++        CHAR ref_deltas[8];
++        CHAR mode_deltas[2];
++        UCHAR delta_lf_res;
++        UCHAR frame_restoration_type[3];
++        USHORT log2_restoration_unit_size[3];
++        UINT16 Reserved16Bits;
++    } loop_filter;
++
++    // Quantization
++    struct {
++        union {
++            struct {
++                UCHAR delta_q_present : 1;
++                UCHAR delta_q_res : 2;
++                UCHAR Reserved : 5;
++            };
++            UCHAR ControlFlags;
++        } DUMMYUNIONNAME;
++
++        UCHAR base_qindex;
++        CHAR y_dc_delta_q;
++        CHAR u_dc_delta_q;
++        CHAR v_dc_delta_q;
++        CHAR u_ac_delta_q;
++        CHAR v_ac_delta_q;
++        // using_qmatrix:
++        UCHAR qm_y;
++        UCHAR qm_u;
++        UCHAR qm_v;
++        UINT16 Reserved16Bits;
++    } quantization;
++
++    // Cdef parameters
++    struct {
++        union {
++            struct {
++                UCHAR damping : 2;
++                UCHAR bits : 2;
++                UCHAR Reserved : 4;
++            };
++            UCHAR ControlFlags;
++        } DUMMYUNIONNAME;
++
++        union {
++            struct {
++                UCHAR primary : 6;
++                UCHAR secondary : 2;
++            };
++            UCHAR combined;
++        } y_strengths[8];
++
++        union {
++            struct {
++                UCHAR primary : 6;
++                UCHAR secondary : 2;
++            };
++            UCHAR combined;
++        } uv_strengths[8];
++
++    } cdef;
++
++    UCHAR interp_filter;
++
++    // Segmentation
++    struct {
++        union {
++            struct {
++                UCHAR enabled : 1;
++                UCHAR update_map : 1;
++                UCHAR update_data : 1;
++                UCHAR temporal_update : 1;
++                UCHAR Reserved : 4;
++            };
++            UCHAR ControlFlags;
++        } DUMMYUNIONNAME;
++        UCHAR Reserved24Bits[3];
++
++        union {
++            struct {
++                UCHAR alt_q : 1;
++                UCHAR alt_lf_y_v : 1;
++                UCHAR alt_lf_y_h : 1;
++                UCHAR alt_lf_u : 1;
++                UCHAR alt_lf_v : 1;
++                UCHAR ref_frame : 1;
++                UCHAR skip : 1;
++                UCHAR globalmv : 1;
++            };
++            UCHAR mask;
++        } feature_mask[8];
++
++        SHORT feature_data[8][8];
++
++    } segmentation;
++
++    struct {
++        union {
++            struct {
++                USHORT apply_grain : 1;
++                USHORT scaling_shift_minus8 : 2;
++                USHORT chroma_scaling_from_luma : 1;
++                USHORT ar_coeff_lag : 2;
++                USHORT ar_coeff_shift_minus6 : 2;
++                USHORT grain_scale_shift : 2;
++                USHORT overlap_flag : 1;
++                USHORT clip_to_restricted_range : 1;
++                USHORT matrix_coeff_is_identity : 1;
++                USHORT Reserved : 3;
++            };
++            USHORT ControlFlags;
++        } DUMMYUNIONNAME;
++
++        USHORT grain_seed;
++        UCHAR scaling_points_y[14][2];
++        UCHAR num_y_points;
++        UCHAR scaling_points_cb[10][2];
++        UCHAR num_cb_points;
++        UCHAR scaling_points_cr[10][2];
++        UCHAR num_cr_points;
++        UCHAR ar_coeffs_y[24];
++        UCHAR ar_coeffs_cb[25];
++        UCHAR ar_coeffs_cr[25];
++        UCHAR cb_mult;
++        UCHAR cb_luma_mult;
++        UCHAR cr_mult;
++        UCHAR cr_luma_mult;
++        UCHAR Reserved8Bits;
++        SHORT cb_offset;
++        SHORT cr_offset;
++    } film_grain;
++
++    UINT   Reserved32Bits;
++    UINT   StatusReportFeedbackNumber;
++} DXVA_PicParams_AV1, *LPDXVA_PicParams_AV1;
++
++/* AV1 tile data structure */
++typedef struct _DXVA_Tile_AV1 {
++    UINT   DataOffset;
++    UINT   DataSize;
++    USHORT row;
++    USHORT column;
++    USHORT Reserved16Bits;
++    UCHAR  anchor_frame;
++    UCHAR Reserved8Bits;
++} DXVA_Tile_AV1, *LPDXVA_Tile_AV1;
++
++typedef struct _DXVA_Status_AV1 {
++    UINT  StatusReportFeedbackNumber;
++    DXVA_PicEntry_AV1 CurrPic;
++    UCHAR  bBufType;
++    UCHAR  bStatus;
++    UCHAR  bReserved8Bits;
++    USHORT wNumMbsAffected;
++} DXVA_Status_AV1, *LPDXVA_Status_AV1;
++
+ #include <poppack.h>
+ 
+ typedef enum _DXVA_VideoChromaSubsampling
+-- 
+2.25.1
+

--- a/mingw-w64-crt-git/PKGBUILD
+++ b/mingw-w64-crt-git/PKGBUILD
@@ -4,7 +4,7 @@ _realname=crt
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 pkgver=9.0.0.6215.788f57701
-pkgrel=1
+pkgrel=2
 _commit='788f5770193c7943e58bc4fdad7ff772d1eeaca1'
 pkgdesc='MinGW-w64 CRT for Windows'
 arch=('any')
@@ -21,10 +21,12 @@ conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 options=('!strip' 'staticlibs' '!buildflags' '!emptydirs')
 source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64#commit=$_commit"
         0001-Allow-to-use-bessel-and-complex-functions-without-un.patch
-        0002-DirectX-9-fixes-for-VLC.patch)
+        0002-DirectX-9-fixes-for-VLC.patch
+        0001-headers-add-AV1-support-to-dxva.h.patch)
 sha256sums=('SKIP'
             'd641257f7e1469aff89adc33e57702b75fe9667ca035978f890eae1020b6814c'
-            '09b1c7b62f666a07609af57e10c2b0ad815b78356f4b0f1fb6d827a1109a0ec7')
+            '09b1c7b62f666a07609af57e10c2b0ad815b78356f4b0f1fb6d827a1109a0ec7'
+            '273ce6dd765f3a6caf3b8a0021f34ee41647ac8e08767e93b06b7d187d430979')
 
 pkgver() {
   cd "${srcdir}/mingw-w64"
@@ -36,6 +38,7 @@ prepare() {
 
   git am --committer-date-is-author-date "${srcdir}/0001-Allow-to-use-bessel-and-complex-functions-without-un.patch"
   git am --committer-date-is-author-date "${srcdir}/0002-DirectX-9-fixes-for-VLC.patch"
+  git am --committer-date-is-author-date "${srcdir}/0001-headers-add-AV1-support-to-dxva.h.patch"
 }
 
 build() {

--- a/mingw-w64-headers-git/0001-headers-add-AV1-support-to-dxva.h.patch
+++ b/mingw-w64-headers-git/0001-headers-add-AV1-support-to-dxva.h.patch
@@ -1,0 +1,309 @@
+From 4ede80067d321e75ea082f8c7e66fb167052fde9 Mon Sep 17 00:00:00 2001
+From: Steve Lhomme <robux4@ycbcr.xyz>
+Date: Sat, 15 May 2021 15:26:42 +0200
+Subject: [PATCH] headers: add AV1 support to dxva.h
+
+Based on the DXVA AV1 specs
+https://www.microsoft.com/en-us/download/details.aspx?id=101577
+
+The structures and the associated define are available in Windows SDK
+since at least 10.0.20231.0.
+
+The GUIDs were present in previous SDKs as well.
+---
+ mingw-w64-headers/include/dxva.h | 279 +++++++++++++++++++++++++++++++
+ 1 file changed, 279 insertions(+)
+
+diff --git a/mingw-w64-headers/include/dxva.h b/mingw-w64-headers/include/dxva.h
+index 4f18f2e..0bd1990 100644
+--- a/mingw-w64-headers/include/dxva.h
++++ b/mingw-w64-headers/include/dxva.h
+@@ -563,6 +563,285 @@ typedef struct _DXVA_Status_VPx
+     USHORT wNumMbsAffected;
+ } DXVA_Status_VPx, *LPDXVA_Status_VPx;
+ 
++
++#define _DIRECTX_AV1_VA_
++
++/* AV1 decoder GUIDs */
++DEFINE_GUID(DXVA_ModeAV1_VLD_Profile0,           0xb8be4ccb, 0xcf53, 0x46ba, 0x8d, 0x59, 0xd6, 0xb8, 0xa6, 0xda, 0x5d, 0x2a);
++DEFINE_GUID(DXVA_ModeAV1_VLD_Profile1,           0x6936ff0f, 0x45b1, 0x4163, 0x9c, 0xc1, 0x64, 0x6e, 0xf6, 0x94, 0x61, 0x08);
++DEFINE_GUID(DXVA_ModeAV1_VLD_Profile2,           0x0c5f2aa1, 0xe541, 0x4089, 0xbb, 0x7b, 0x98, 0x11, 0x0a, 0x19, 0xd7, 0xc8);
++DEFINE_GUID(DXVA_ModeAV1_VLD_12bit_Profile2,     0x17127009, 0xa00f, 0x4ce1, 0x99, 0x4e, 0xbf, 0x40, 0x81, 0xf6, 0xf3, 0xf0);
++DEFINE_GUID(DXVA_ModeAV1_VLD_12bit_Profile2_420, 0x2d80bed6, 0x9cac, 0x4835, 0x9e, 0x91, 0x32, 0x7b, 0xbc, 0x4f, 0x9e, 0xe8);
++
++/* AV1 picture entry data structure */
++typedef struct _DXVA_PicEntry_AV1 {
++    UINT width;
++    UINT height;
++
++    // Global motion parameters
++    INT wmmat[6];
++    union {
++        struct {
++            UCHAR wminvalid : 1;
++            UCHAR wmtype : 2;
++            UCHAR Reserved : 5;
++        };
++        UCHAR GlobalMotionFlags;
++    };
++    UCHAR Index;
++    USHORT Reserved16Bits;
++} DXVA_PicEntry_AV1, *LPDXVA_PicEntry_AV1;
++
++/* AV1 picture parameters data structure */
++typedef struct _DXVA_PicParams_AV1 {
++    UINT width;
++    UINT height;
++
++    UINT max_width;
++    UINT max_height;
++
++    UCHAR CurrPicTextureIndex;
++    UCHAR superres_denom;
++    UCHAR bitdepth;
++    UCHAR seq_profile;
++
++    // Tiles:
++    struct {
++        UCHAR cols;
++        UCHAR rows;
++        USHORT context_update_id;
++        USHORT widths[64];
++        USHORT heights[64];
++    } tiles;
++
++    // Coding Tools
++    union {
++        struct {
++            UINT use_128x128_superblock : 1;
++            UINT intra_edge_filter : 1;
++            UINT interintra_compound : 1;
++            UINT masked_compound : 1;
++            UINT warped_motion : 1;
++            UINT dual_filter : 1;
++            UINT jnt_comp : 1;
++            UINT screen_content_tools : 1;
++            UINT integer_mv : 1;
++            UINT cdef : 1;
++            UINT restoration : 1;
++            UINT film_grain : 1;
++            UINT intrabc : 1;
++            UINT high_precision_mv : 1;
++            UINT switchable_motion_mode : 1;
++            UINT filter_intra : 1;
++            UINT disable_frame_end_update_cdf : 1;
++            UINT disable_cdf_update : 1;
++            UINT reference_mode : 1;
++            UINT skip_mode : 1;
++            UINT reduced_tx_set : 1;
++            UINT superres : 1;
++            UINT tx_mode : 2;
++            UINT use_ref_frame_mvs : 1;
++            UINT enable_ref_frame_mvs : 1;
++            UINT reference_frame_update : 1;
++            UINT Reserved : 5;
++        };
++        UINT32 CodingParamToolFlags;
++    } coding;
++
++    // Format & Picture Info flags
++    union {
++        struct {
++            UCHAR frame_type : 2;
++            UCHAR show_frame : 1;
++            UCHAR showable_frame : 1;
++            UCHAR subsampling_x : 1;
++            UCHAR subsampling_y : 1;
++            UCHAR mono_chrome : 1;
++            UCHAR Reserved : 1;
++        };
++        UCHAR FormatAndPictureInfoFlags;
++    } format;
++
++    // References
++    UCHAR primary_ref_frame;
++    UCHAR order_hint;
++    UCHAR order_hint_bits;
++
++    DXVA_PicEntry_AV1 frame_refs[7];
++    UCHAR RefFrameMapTextureIndex[8];
++
++    // Loop filter parameters
++    struct {
++        UCHAR filter_level[2];
++        UCHAR filter_level_u;
++        UCHAR filter_level_v;
++
++        UCHAR sharpness_level;
++        union {
++            struct {
++                UCHAR mode_ref_delta_enabled : 1;
++                UCHAR mode_ref_delta_update : 1;
++                UCHAR delta_lf_multi : 1;
++                UCHAR delta_lf_present : 1;
++                UCHAR Reserved : 4;
++            };
++            UCHAR ControlFlags;
++        } DUMMYUNIONNAME;
++        CHAR ref_deltas[8];
++        CHAR mode_deltas[2];
++        UCHAR delta_lf_res;
++        UCHAR frame_restoration_type[3];
++        USHORT log2_restoration_unit_size[3];
++        UINT16 Reserved16Bits;
++    } loop_filter;
++
++    // Quantization
++    struct {
++        union {
++            struct {
++                UCHAR delta_q_present : 1;
++                UCHAR delta_q_res : 2;
++                UCHAR Reserved : 5;
++            };
++            UCHAR ControlFlags;
++        } DUMMYUNIONNAME;
++
++        UCHAR base_qindex;
++        CHAR y_dc_delta_q;
++        CHAR u_dc_delta_q;
++        CHAR v_dc_delta_q;
++        CHAR u_ac_delta_q;
++        CHAR v_ac_delta_q;
++        // using_qmatrix:
++        UCHAR qm_y;
++        UCHAR qm_u;
++        UCHAR qm_v;
++        UINT16 Reserved16Bits;
++    } quantization;
++
++    // Cdef parameters
++    struct {
++        union {
++            struct {
++                UCHAR damping : 2;
++                UCHAR bits : 2;
++                UCHAR Reserved : 4;
++            };
++            UCHAR ControlFlags;
++        } DUMMYUNIONNAME;
++
++        union {
++            struct {
++                UCHAR primary : 6;
++                UCHAR secondary : 2;
++            };
++            UCHAR combined;
++        } y_strengths[8];
++
++        union {
++            struct {
++                UCHAR primary : 6;
++                UCHAR secondary : 2;
++            };
++            UCHAR combined;
++        } uv_strengths[8];
++
++    } cdef;
++
++    UCHAR interp_filter;
++
++    // Segmentation
++    struct {
++        union {
++            struct {
++                UCHAR enabled : 1;
++                UCHAR update_map : 1;
++                UCHAR update_data : 1;
++                UCHAR temporal_update : 1;
++                UCHAR Reserved : 4;
++            };
++            UCHAR ControlFlags;
++        } DUMMYUNIONNAME;
++        UCHAR Reserved24Bits[3];
++
++        union {
++            struct {
++                UCHAR alt_q : 1;
++                UCHAR alt_lf_y_v : 1;
++                UCHAR alt_lf_y_h : 1;
++                UCHAR alt_lf_u : 1;
++                UCHAR alt_lf_v : 1;
++                UCHAR ref_frame : 1;
++                UCHAR skip : 1;
++                UCHAR globalmv : 1;
++            };
++            UCHAR mask;
++        } feature_mask[8];
++
++        SHORT feature_data[8][8];
++
++    } segmentation;
++
++    struct {
++        union {
++            struct {
++                USHORT apply_grain : 1;
++                USHORT scaling_shift_minus8 : 2;
++                USHORT chroma_scaling_from_luma : 1;
++                USHORT ar_coeff_lag : 2;
++                USHORT ar_coeff_shift_minus6 : 2;
++                USHORT grain_scale_shift : 2;
++                USHORT overlap_flag : 1;
++                USHORT clip_to_restricted_range : 1;
++                USHORT matrix_coeff_is_identity : 1;
++                USHORT Reserved : 3;
++            };
++            USHORT ControlFlags;
++        } DUMMYUNIONNAME;
++
++        USHORT grain_seed;
++        UCHAR scaling_points_y[14][2];
++        UCHAR num_y_points;
++        UCHAR scaling_points_cb[10][2];
++        UCHAR num_cb_points;
++        UCHAR scaling_points_cr[10][2];
++        UCHAR num_cr_points;
++        UCHAR ar_coeffs_y[24];
++        UCHAR ar_coeffs_cb[25];
++        UCHAR ar_coeffs_cr[25];
++        UCHAR cb_mult;
++        UCHAR cb_luma_mult;
++        UCHAR cr_mult;
++        UCHAR cr_luma_mult;
++        UCHAR Reserved8Bits;
++        SHORT cb_offset;
++        SHORT cr_offset;
++    } film_grain;
++
++    UINT   Reserved32Bits;
++    UINT   StatusReportFeedbackNumber;
++} DXVA_PicParams_AV1, *LPDXVA_PicParams_AV1;
++
++/* AV1 tile data structure */
++typedef struct _DXVA_Tile_AV1 {
++    UINT   DataOffset;
++    UINT   DataSize;
++    USHORT row;
++    USHORT column;
++    USHORT Reserved16Bits;
++    UCHAR  anchor_frame;
++    UCHAR Reserved8Bits;
++} DXVA_Tile_AV1, *LPDXVA_Tile_AV1;
++
++typedef struct _DXVA_Status_AV1 {
++    UINT  StatusReportFeedbackNumber;
++    DXVA_PicEntry_AV1 CurrPic;
++    UCHAR  bBufType;
++    UCHAR  bStatus;
++    UCHAR  bReserved8Bits;
++    USHORT wNumMbsAffected;
++} DXVA_Status_AV1, *LPDXVA_Status_AV1;
++
+ #include <poppack.h>
+ 
+ typedef enum _DXVA_VideoChromaSubsampling
+-- 
+2.25.1
+

--- a/mingw-w64-headers-git/PKGBUILD
+++ b/mingw-w64-headers-git/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 pkgdesc="MinGW-w64 headers for Windows"
 pkgver=9.0.0.6215.788f57701
-pkgrel=1
+pkgrel=2
 _commit='788f5770193c7943e58bc4fdad7ff772d1eeaca1'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -18,10 +18,12 @@ conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 options=('!strip' '!libtool' '!emptydirs')
 source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64#commit=$_commit"
         0001-Allow-to-use-bessel-and-complex-functions-without-un.patch
-        0002-DirectX-9-fixes-for-VLC.patch)
+        0002-DirectX-9-fixes-for-VLC.patch
+        0001-headers-add-AV1-support-to-dxva.h.patch)
 sha256sums=('SKIP'
             'd641257f7e1469aff89adc33e57702b75fe9667ca035978f890eae1020b6814c'
-            '09b1c7b62f666a07609af57e10c2b0ad815b78356f4b0f1fb6d827a1109a0ec7')
+            '09b1c7b62f666a07609af57e10c2b0ad815b78356f4b0f1fb6d827a1109a0ec7'
+            '273ce6dd765f3a6caf3b8a0021f34ee41647ac8e08767e93b06b7d187d430979')
 
 pkgver() {
   cd "${srcdir}/mingw-w64"
@@ -33,6 +35,7 @@ prepare() {
 
   git am --committer-date-is-author-date "${srcdir}/0001-Allow-to-use-bessel-and-complex-functions-without-un.patch"
   git am --committer-date-is-author-date "${srcdir}/0002-DirectX-9-fixes-for-VLC.patch"
+  git am --committer-date-is-author-date "${srcdir}/0001-headers-add-AV1-support-to-dxva.h.patch"
 
   cd ${srcdir}/mingw-w64/mingw-w64-headers
   touch include/windows.*.h include/wincrypt.h include/prsht.h


### PR DESCRIPTION
Adds a patch that is currently not in mingw-w64 nor wine for adding av1
decoding support via dxva. This is useful for FFmpeg to decode using
their hwaccel.

From https://www.winehq.org/pipermail/wine-devel/2020-September/173175.html and used in https://github.com/BtbN/FFmpeg-Builds/commit/0df2644223a5d3f775b4e25d027a3dc4446caefe