### PR TITLE
libogg: update to 1.3.5

### DIFF
--- a/mingw-w64-libogg/PKGBUILD
+++ b/mingw-w64-libogg/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=libogg
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.3.4
-pkgrel=3
+pkgver=1.3.5
+pkgrel=1
 pkgdesc="Ogg bitstream and framing library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -15,7 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
 options=('staticlibs' 'strip')
 source=("https://downloads.xiph.org/releases/ogg/${_realname}-${pkgver}.tar.gz"
         "libogg-1.3.4-versioned-dll-cmake.patch")
-sha256sums=('fe5670640bd49e828d64d2879c31cb4dde9758681bb664f9bdbf159a01b0c76e'
+sha256sums=('0eb4b4b9420a0f51db142ba3f9c64b333f826532dc0f48c6410ae51f4799b664'
             '7f635d4ca41c75dc52206749b6346c174c6a028de09604c6d66929bcdabf6c33')
 
 prepare() {


### PR DESCRIPTION
Latest patch release: https://gitlab.xiph.org/xiph/ogg/-/tags/v1.3.5