### PR TITLE
leptonica: Upgrade to 1.18.1

### DIFF
--- a/mingw-w64-leptonica/PKGBUILD
+++ b/mingw-w64-leptonica/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=leptonica
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.81.0
+pkgver=1.81.1
 pkgrel=1
 pkgdesc="Leptonica library (mingw-w64)"
 arch=('any')
@@ -20,7 +20,7 @@ depends=(${MINGW_PACKAGE_PREFIX}-gcc-libs
          ${MINGW_PACKAGE_PREFIX}-openjpeg2
          ${MINGW_PACKAGE_PREFIX}-zlib)
 source=(https://github.com/DanBloomberg/leptonica/releases/download/${pkgver}/${_realname}-${pkgver}.tar.gz)
-sha256sums=('d192b055e9bd60b84111023cc980c37390e6d427b194a8fd2bd611543a3bddad')
+sha256sums=('0f4eb315e9bdddd797f4c55fdea4e1f45fca7e3b358a2fc693fd957ce2c43ca9')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -29,28 +29,28 @@ prepare() {
 }
 
 build() {
-  [[ -d "${srcdir}/build-${CARCH}" ]] && rm -rf "${srcdir}/build-${CARCH}"
-  mkdir -p "${srcdir}/build-${CARCH}" && cd "${srcdir}/build-${CARCH}"
+  local _builddir="${srcdir}/build-${MINGW_PACKAGE_PREFIX}"
+  test -d "${_builddir}" && rm -rf "${_builddir}"
+  mkdir -p "${_builddir}" && cd "${_builddir}"
   CFLAGS+=" -DMINIMUM_SEVERITY=L_SEVERITY_WARNING"
   ../${_realname}-${pkgver}/configure -C \
     --disable-dependency-tracking \
     --disable-silent-rules \
-    --build=${MINGW_CHOST} \
-    --host=${MINGW_CHOST} \
-    --target=${MINGW_CHOST} \
-    --prefix=${MINGW_PREFIX}
+    --host="${MINGW_CHOST}" \
+    --prefix="${MINGW_PREFIX}"
   make
 }
 
 check() {
-  cd "${srcdir}/build-${CARCH}"
-  make -j1 check
+  make -j1 check -C "${srcdir}/build-${MINGW_PACKAGE_PREFIX}"
 }
 
 package() {
-  cd "${srcdir}/build-${CARCH}"
-  make DESTDIR="${pkgdir}" install
+  make DESTDIR="${pkgdir}" install -C "${srcdir}/build-${MINGW_PACKAGE_PREFIX}"
 
   # Fix .pc file
   sed -s "s|$(cygpath -m ${MINGW_PREFIX})|${MINGW_PREFIX}|g" -i "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/lept.pc
+
+  install -D -m644 "${srcdir}/${_realname}-${pkgver}/leptonica-license.txt" \
+      "${pkgdir}/${MSYSTEM_PREFIX}/share/licenses/${_realname}/leptonica-license.txt"
 }


### PR DESCRIPTION
@lazka Ok that the CLANG32 dependencies are not available? Or are they to be regenerated?