### PR TITLE
curl: preserve UNC paths when normalizing/simplifying

### DIFF
--- a/mingw-w64-curl/0001-Make-cURL-relocatable.patch
+++ b/mingw-w64-curl/0001-Make-cURL-relocatable.patch
@@ -22,10 +22,10 @@ Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
  configure.ac         |   1 +
  lib/Makefile.inc     |   5 +-
  lib/curl_config.h.in |   3 +
- lib/pathtools.c      | 533 +++++++++++++++++++++++++++++++++++++++++++++++++++
+ lib/pathtools.c      | 539 +++++++++++++++++++++++++++++++++++++++++++++++++++
  lib/pathtools.h      |  53 +++++
  lib/url.c            |  26 ++-
- 6 files changed, 618 insertions(+), 3 deletions(-)
+ 6 files changed, 624 insertions(+), 3 deletions(-)
  create mode 100644 lib/pathtools.c
  create mode 100644 lib/pathtools.h
 
@@ -80,7 +80,7 @@ new file mode 100644
 index 000000000..c66df924b
 --- /dev/null
 +++ b/lib/pathtools.c
-@@ -0,0 +1,533 @@
+@@ -0,0 +1,539 @@
 +/*
 +      .Some useful path tools.
 +        .ASCII only for now.
@@ -145,7 +145,7 @@ index 000000000..c66df924b
 +    *path_p = '/';
 +  }
 +  /* Replace any '//' with '/' */
-+  path_p = path;
++  path_p = path + !!*path; /* skip first character, if any, to handle UNC paths correctly */
 +  while ((path_p = strstr (path_p, "//")) != NULL)
 +  {
 +    memmove (path_p, path_p + 1, path_size--);
@@ -260,6 +260,14 @@ index 000000000..c66df924b
 +  size_t in_size = strlen (path);
 +  int it_ended_with_a_slash = (path[in_size - 1] == '/') ? 1 : 0;
 +  char * result = path;
++  char * result_p;
++  char const ** toks;
++  if (path[0] == '/' && path[1] == '/') {
++    /* preserve UNC path */
++    path++;
++    in_size--;
++    result++;
++  }
 +  sanitise_path(result);
 +  char * result_p = result;
 +


### PR DESCRIPTION
The code to make cURL relocatable simplifies/normalizes paths, e.g. reducing multiple forward slashes to a single one.

This is okay in general, but at the beginning of the path, a double slash has a special meaning: it denotes a UNC path of the form
`//<host>/<path>`. It would therefore be a mistake to reduce those first two slashes to a single one: otherwise it would refer to the absolute path relative to the current directory's drive.

Original report: https://github.com/git-for-windows/git/issues/3266

So sad that I cannot Cc: the original author of the `pathtools.c` file. 😞 