### PR TITLE
wined3d: add -fcommon to CFLAGS

### DIFF
--- a/mingw-w64-wined3d/PKGBUILD
+++ b/mingw-w64-wined3d/PKGBUILD
@@ -5,7 +5,7 @@ _realname=wine
 pkgbase=mingw-w64-wined3d
 pkgname="${MINGW_PACKAGE_PREFIX}-wined3d"
 pkgver=3.8
-pkgrel=1
+pkgrel=2
 pkgdesc="Direct3D to OpenGL translator (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -79,7 +79,7 @@ build() {
     --without-zlib \
     --without-x \
     $_extra \
-    CFLAGS="-O2 -DUSE_WIN32_OPENGL -DWINE_NOWINSOCK"
+    CFLAGS="-O2 -DUSE_WIN32_OPENGL -DWINE_NOWINSOCK -fcommon"
   make LN_S='ln -s' dlls/d3d8 dlls/d3d9 dlls/d3d10 dlls/d3d10core dlls/dxgi dlls/wined3d
 }
 


### PR DESCRIPTION
This should have been required for gcc 10, but is definitely required
for clang.

Note on `CLANG*` this requires mingw-w64-clang >= 12.0.0-6 for the fix for msys2/CLANG-packages#43