### PR TITLE
ghdl: update to 1.0.0.r348.g7d5c6c48

### DIFF
--- a/mingw-w64-ghdl/PKGBUILD
+++ b/mingw-w64-ghdl/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=ghdl
 pkgbase="mingw-w64-${_realname}"
 pkgname='__placeholder__'
-pkgver=1.0.0.r257.g82665d42
+pkgver=1.0.0.r348.g7d5c6c48
 pkgrel=1
 pkgdesc='GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL'
 arch=('any')
@@ -11,8 +11,7 @@ url='https://github.com/ghdl'
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_commit='82665d42'
-source=("${_realname}::git://github.com/ghdl/ghdl.git#commit=${_commit}")
+source=("${_realname}::git://github.com/ghdl/ghdl.git#commit=7d5c6c48")
 sha512sums=('SKIP')
 
 pkgver() {


### PR DESCRIPTION
~~Just a regular update.~~

Update pyGHDL.dom, which provides a Document Object Model (DOM) for the VHDL language written in Python: [vhdl/pyVHDLModel](https://github.com/vhdl/pyVHDLModel).