### PR TITLE
usql: makedepends on checkdepends

### DIFF
--- a/mingw-w64-usql/PKGBUILD
+++ b/mingw-w64-usql/PKGBUILD
@@ -4,15 +4,16 @@ _realname=usql
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.8.1
-pkgrel=1
+pkgrel=2
 pkgdesc="SQL parser engine for C++ (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 url="https://github.com/cybergarage/usql"
 license=('custom')
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 depends=("${MINGW_PACKAGE_PREFIX}-antlr3")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-boost")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" \
+             "${checkdepends[@]}")
 source=("${_realname}-${pkgver}.tar.gz::https://codeload.github.com/cybergarage/usql/tar.gz/${pkgver}"
         "${_realname}-${pkgver}.patch")
 sha256sums=('a4d928692bdf4e7380dde40ae09c4ed4a3cdb8ae0b3b7ab5a268d884e45d9add'


### PR DESCRIPTION
checkdepends are only installed when check is going to be run, but the tests are built in build() regardless.