### PR TITLE
Update Yosys, prjtrellis and nextpnr

### DIFF
--- a/mingw-w64-nextpnr/PKGBUILD
+++ b/mingw-w64-nextpnr/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=nextpnr
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.0.r3229.326b3488
+pkgver=0.0.r3600.9df05c4f
 pkgrel=1
 pkgdesc="Portable FPGA place and route tool (mingw-w64)"
 arch=('any')
@@ -29,7 +29,7 @@ makedepends=(
   "git"
 )
 
-_commit="326b3488"
+_commit="9df05c4f"
 source=("${_realname}::git://github.com/YosysHQ/${_realname}.git#commit=${_commit}")
 sha256sums=('SKIP')
 
@@ -40,6 +40,7 @@ pkgver() {
 
 build() {
   cd "${srcdir}/${_realname}"
+  git submodule update --init --recursive
 
   unset _extra-archs
   if [ "$CARCH" = "x86_64" ]; then
@@ -54,6 +55,7 @@ build() {
     -DARCH="generic;ice40${_extra_archs}" \
     -DBUILD_HEAP=ON \
     -DUSE_OPENMP=ON \
+    -DUSE_IPO=OFF \
     -DBUILD_PYTHON=ON \
     -DBUILD_GUI=ON \
     -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \

--- a/mingw-w64-prjtrellis/PKGBUILD
+++ b/mingw-w64-prjtrellis/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=prjtrellis
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.0.r995.da82093
-pkgrel=3
+pkgver=1.0.r1002.0e6a320
+pkgrel=1
 pkgdesc="Documenting the Lattice ECP5 bit-stream format (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-boost"
              "${MINGW_PACKAGE_PREFIX}-clang"
              "git")
 
-_commit="da820937"
+_commit="0e6a3204"
 source=("${_realname}::git://github.com/YosysHQ/${_realname}.git#commit=${_commit}"
         "prjtrellis-db::git://github.com/YosysHQ/prjtrellis-db")
 sha256sums=('SKIP'

--- a/mingw-w64-yosys/PKGBUILD
+++ b/mingw-w64-yosys/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=yosys
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.9.r10702.0ccc7229c
+pkgver=0.9.r10805.c6681508f
 pkgrel=1
 pkgdesc="A framework for RTL synthesis tools (mingw-w64)"
 arch=('any')
@@ -21,7 +21,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python"
 )
 
-_commit='0ccc7229'
+_commit='c6681508'
 source=(
   "${_realname}::git://github.com/YosysHQ/${_realname}.git#commit=${_commit}"
   "ghdl-yosys-plugin::git://github.com/ghdl/ghdl-yosys-plugin.git#commit=98f4594b"


### PR DESCRIPTION
This PR updates Yosys, prjtrellis and nextpnr. Since Yosys depends on GHDL, it is desirable to wait until that one is uploaded (https://packages.msys2.org/package/mingw-w64-x86_64-ghdl-llvm?repo=mingw64) before merging this PR. For that reason, I'll keep it as a draft.