### PR TITLE
libxslt: Fix build failure and date/time issue in libxslt

### DIFF
--- a/mingw-w64-libxslt/0009-fix-xml2-config-check-in-configure.patch
+++ b/mingw-w64-libxslt/0009-fix-xml2-config-check-in-configure.patch
@@ -1,0 +1,24 @@
+From 90c34c8bb90e095a8a8fe8b2ce368bd9ff1837cc Mon Sep 17 00:00:00 2001
+From: Nick Wellnhofer <wellnhofer@aevum.de>
+Date: Fri, 15 Nov 2019 11:53:11 +0100
+Subject: [PATCH] Fix xml2-config check in configure script
+
+A 'print' option has never been supported. After a recent change to
+libxml2, invalid options cause xml2-config to fail.
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 3da57b18..585b9d7c 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -548,7 +548,7 @@ dnl make sure xml2-config is executable,
+ dnl test version and init our variables
+ dnl
+ 
+-if test "x$LIBXML_LIBS" = "x" && ${XML_CONFIG} --libs print > /dev/null 2>&1
++if test "x$LIBXML_LIBS" = "x" && ${XML_CONFIG} --libs > /dev/null 2>&1
+ then
+     AC_MSG_CHECKING(for libxml libraries >= $LIBXML_REQUIRED_VERSION)
+     XMLVERS=`$XML_CONFIG --version`

--- a/mingw-w64-libxslt/PKGBUILD
+++ b/mingw-w64-libxslt/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libxslt
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.1.34
-pkgrel=3
+pkgrel=4
 pkgdesc="XML stylesheet transformation library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -23,7 +23,8 @@ source=("http://xmlsoft.org/sources/${_realname}-${pkgver}.tar.gz"
         '0002-python-linking-on.mingw.patch'
         '0003-fix-concurrent-directory-creation.all.patch'
         '0004-add-missing-include-for-python.all.patch'
-        '0008-fix-warnings.patch')
+        '0008-fix-warnings.patch'
+        '0009-fix-xml2-config-check-in-configure.patch')
 sha256sums=('98b1bd46d6792925ad2dfe9a87452ea2adebf69dcb9919ffd55bf926a7f93f7f'
             '3d56e8ae1fbf817f495ecb0afe223d7a001ef4787ce52e1c57cc7b32499e95d6'
             '76029b76c6a1670f85ecb3db6b299cfe468a65b1718880cb8b82c6813cc63ea9'
@@ -31,7 +32,8 @@ sha256sums=('98b1bd46d6792925ad2dfe9a87452ea2adebf69dcb9919ffd55bf926a7f93f7f'
             '152f1f549406d049648020246bf770deea612b26835f4cfee79611cd3ac99763'
             'fc23bd3c9e62a28cb1c020cebc83ca7532a5a7a21c2e4748b72d13ac7716a851'
             '1da234751e2bd337a0991a0f90272bbf83b6cbd8945208825fa3d9dd580020e6'
-            '7578654016d89e9a292860201199e8bffeb78b3aa819e8baecad7cf9305bdb67')
+            '7578654016d89e9a292860201199e8bffeb78b3aa819e8baecad7cf9305bdb67'
+            '27bd05d3dab2a9848fc70e6894e904b15f260d3ced6ae4e0f4a616711f87c1c3')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -61,7 +63,8 @@ prepare() {
     "0002-python-linking-on.mingw.patch" \
     "0003-fix-concurrent-directory-creation.all.patch" \
     "0004-add-missing-include-for-python.all.patch" \
-    "0008-fix-warnings.patch"
+    "0008-fix-warnings.patch" \
+    "0009-fix-xml2-config-check-in-configure.patch"
 
   autoreconf -fi
 }


### PR DESCRIPTION
This new patch was applied upstream almost two years ago here:
  https://gitlab.gnome.org/GNOME/libxslt/-/commit/90c34c8bb90e095a8a8fe8b2ce368bd9ff1837cc

Without the patch a clean UCRT64 build (no previously installed UCRT64 packages) fails with:
```
  checking for x86_64-w64-mingw32-xml2-config... no
  checking for xml2-config... /ucrt64/bin/xml2-config
  configure: error: Could not find libxml2 anywhere, check ftp://xmlsoft.org/.
```

I verified, that the build issue is currently present on my local system as well as on github: https://github.com/larskanis/MINGW-packages/runs/2861341540?check_suite_focus=true

With this patch the build succeeds: https://github.com/larskanis/MINGW-packages/runs/2858716280?check_suite_focus=true

In addition to the build failure the current UCRT64 package `mingw-w64-ucrt-x86_64-libxslt-1.1.34-3-any.pkg.tar.zst` doesn't support date/time functions, which are usually part of libxslt. I don't know how this package was built and why this package doesn't support them, but I verified that both the local package and the github action artifact produced by this PR fix the issue. Therefore I'd like to ask for merging this PR and rebuilding the package libxslt.

The MINGW 32/64 packages support date/time functions in contrast to the UCRT64 package.

The original issue was raised by the nokogiri project in the following issue: https://github.com/sparklemotion/nokogiri/pull/2272#issuecomment-863283296
