### PR TITLE
clang: llvm-rc don't rewrite default arch

### DIFF
--- a/mingw-w64-clang/0014-llvm-rc-Don-t-rewrite-the-arch-in-the-default-triple.patch
+++ b/mingw-w64-clang/0014-llvm-rc-Don-t-rewrite-the-arch-in-the-default-triple.patch
@@ -1,0 +1,75 @@
+From 882d3b0428073001897e65cb95405ae31bc643fc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Storsj=C3=B6?= <martin@martin.st>
+Date: Fri, 18 Jun 2021 22:59:58 +0300
+Subject: [PATCH] [llvm-rc] Don't rewrite the arch in the default triple unless
+ necessary
+
+When the default target arch isn't one that is supported as a
+windows target, we want to set a suitable architecture (so that
+Clang tests that run plain 'llvm-windres' succeed checks for e.g.
+"#ifdef _WIN32"). But if the default target architecture is
+usable, don't rewrite it. (Rewriting it, by e.g.
+"T.setArch(T.getArch())", normalizes the spelling of the architecture,
+e.g. changing i686 to i386. Such a change can make clang unable
+to find the right sysroot.)
+
+This can't, unfortunately, practically be tested very well because
+it is entirely dependent on the default triple of the llvm build.
+---
+ tools/llvm-rc/llvm-rc.cpp | 19 +++++++++++++------
+ 1 file changed, 13 insertions(+), 6 deletions(-)
+
+diff --git a/tools/llvm-rc/llvm-rc.cpp b/tools/llvm-rc/llvm-rc.cpp
+index 8a4ef95cfabd..b45c7a07309e 100644
+--- a/tools/llvm-rc/llvm-rc.cpp
++++ b/tools/llvm-rc/llvm-rc.cpp
+@@ -145,7 +145,7 @@ ErrorOr<std::string> findClang(const char *Argv0) {
+   return Path;
+ }
+ 
+-Triple::ArchType getDefaultArch(Triple::ArchType Arch) {
++bool isUsableDefaultArch(Triple::ArchType Arch) {
+   switch (Arch) {
+   case Triple::x86:
+   case Triple::x86_64:
+@@ -154,17 +154,23 @@ Triple::ArchType getDefaultArch(Triple::ArchType Arch) {
+   case Triple::aarch64:
+     // These work properly with the clang driver, setting the expected
+     // defines such as _WIN32 etc.
+-    return Arch;
++    return true;
+   default:
+     // Other archs aren't set up for use with windows as target OS, (clang
+-    // doesn't define e.g. _WIN32 etc), so set a reasonable default arch.
+-    return Triple::x86_64;
++    // doesn't define e.g. _WIN32 etc), so with them we need to set a
++    // different default arch.
++    return false;
+   }
+ }
+ 
++Triple::ArchType getDefaultFallbackArch() {
++  return Triple::x86_64;
++}
++
+ std::string getClangClTriple() {
+   Triple T(sys::getDefaultTargetTriple());
+-  T.setArch(getDefaultArch(T.getArch()));
++  if (!isUsableDefaultArch(T.getArch()))
++    T.setArch(getDefaultFallbackArch());
+   T.setOS(Triple::Win32);
+   T.setVendor(Triple::PC);
+   T.setEnvironment(Triple::MSVC);
+@@ -174,7 +180,8 @@ std::string getClangClTriple() {
+ 
+ std::string getMingwTriple() {
+   Triple T(sys::getDefaultTargetTriple());
+-  T.setArch(getDefaultArch(T.getArch()));
++  if (!isUsableDefaultArch(T.getArch()))
++    T.setArch(getDefaultFallbackArch());
+   if (T.isWindowsGNUEnvironment())
+     return T.str();
+   // Write out the literal form of the vendor/env here, instead of
+-- 
+2.25.1
+

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -35,7 +35,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
            "${MINGW_PACKAGE_PREFIX}-openmp")
          "${MINGW_PACKAGE_PREFIX}-polly")
 pkgver=12.0.0
-pkgrel=6
+pkgrel=7
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -76,6 +76,7 @@ source=("https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkgver
         "0011-nm-version-option.patch"
         "0012-windres.patch"
         "0013-Dlltool-use-default-LLVM-target-unless-specified.patch"
+        "0014-llvm-rc-Don-t-rewrite-the-arch-in-the-default-triple.patch"
         "0101-Disable-fPIC-errors.patch"
         "0103-Use-posix-style-path-separators-with-MinGW.patch"
         "0104-link-pthread-with-mingw.patch"
@@ -119,6 +120,7 @@ sha256sums=('9ed1688943a4402d7c904cc4515798cdb20080066efa010fe7e1f2551b423628'
             '5d0d8653c95a2d74a4ae531370c3d0584054d15cfef16eb4c45b1d8e5c0fcb4c'
             'e8a6c9e32848dcb9bc16e509516556ced4a5fe888d9b92929e83d0b55c05647b'
             '567307cb8d2a9072ba521b9daaf448d73ca213d9a4f2f4e07485f4be4ac9881d'
+            '307a7d8a9389e9953f777ef93b19899e0c86b08019af97edd89ec9a50d507c83'
             '63b2bda6a487ec69e257c3b7a14d71f6bec649fca058a5a54804f213d45c7c70'
             '2d1dc7f7cd6bd61f275cd0be6650f3086aee622074ac786ff5a921bf8ecaada2'
             '715cb8862753854b2d9256e0b70003e2d1f57083d83eaeaf5a095fc72b8a4e26'
@@ -166,7 +168,8 @@ prepare() {
     "0010-mbig-obj-for-all.patch" \
     "0011-nm-version-option.patch" \
     "0012-windres.patch" \
-    "0013-Dlltool-use-default-LLVM-target-unless-specified.patch"
+    "0013-Dlltool-use-default-LLVM-target-unless-specified.patch" \
+    "0014-llvm-rc-Don-t-rewrite-the-arch-in-the-default-triple.patch"
 
   if (( ! _clangprefix )); then
     apply_patch_with_msg \


### PR DESCRIPTION
Fixes msys2/CLANG-packages#46

NOTE: this bug causes `CLANG32` to fail to build clang.  It can be built by first downgrading to 12.0.0-5.  @lazka how can this be handled?