### PR TITLE
ngraph-gtk: new upstream release version 6.09.03.

### DIFF
--- a/mingw-w64-ngraph-gtk/PKGBUILD
+++ b/mingw-w64-ngraph-gtk/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=ngraph-gtk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=6.09.02
+pkgver=6.09.03
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -23,7 +23,7 @@ options=('strip' 'staticlibs')
 license=("GPL")
 url="https://htrb.github.io/ngraph-gtk/"
 source=("https://github.com/htrb/ngraph-gtk/releases/download/v${pkgver}/ngraph-gtk-${pkgver}.tar.gz")
-sha256sums=("e31e40a5b82b8bd084117ec95ccd499ba48ac61199c8cd616c249c2d08360758")
+sha256sums=("f68cf457cff1905035c2b5b31d6d51aac3f9c81c1fcc8503877690a3988fdbf0")
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}


### PR DESCRIPTION
new upstream release version 6.09.03.