### PR TITLE
Update Mesa3D to 21.1.3

### DIFF
--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=21.1.2
+pkgver=21.1.3
 pkgrel=1
 pkgdesc="Open-source implementation of the OpenGL specification (mingw-w64)"
 arch=('any')
@@ -26,7 +26,7 @@ license=('MIT')
 options=('staticlibs' 'strip')
 source=(https://mesa.freedesktop.org/archive/${_realname}-${pkgver}.tar.xz{,.sig}
         llvmwrapgen.sh)
-sha256sums=('23b4b63760561f3a4f98b5be12c6de621e9a6bdf355e087a83d9184cd4e2825f'
+sha256sums=('cbe221282670875ffd762247b6a2c95dcee91d0a34c29802c75ef761fc891e69'
             'SKIP'
             '69f21522f20c10f5699dfe3e128aa88d4fedde816f6e8df1506d7470c44bf3da')
 validpgpkeys=('8703B6700E7EE06D7A39B8D6EDAE37B02CEB490D') # Emil Velikov <emil.l.velikov@gmail.com>
@@ -115,7 +115,8 @@ build() {
   -Dc_args='-march=core2 -pipe' \
   -Dcpp_args='-march=core2 -pipe' \
   -Dc_link_args='-s' \
-  -Dcpp_link_args='-s'
+  -Dcpp_link_args='-s' \
+  -Dmicrosoft-clc=disabled
 
   ${MINGW_PREFIX}/bin/ninja -C ./build/windows-${_mach}
 }


### PR DESCRIPTION
Also explicitly disable CLonD3D12 just to be safe as build may fail in the future if Meson gains the ability to discover clang via cmake with MinGW like it does with MSVC.