### PR TITLE
libtiff: disable libwebp dependency for new clang prefixes

### DIFF
--- a/mingw-w64-libtiff/PKGBUILD
+++ b/mingw-w64-libtiff/PKGBUILD
@@ -5,17 +5,19 @@ _realname=libtiff
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.3.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Library for manipulation of TIFF images (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="http://www.simplesystems.org/libtiff/"
 license=(MIT)
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-jbigkit"
          "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
          "${MINGW_PACKAGE_PREFIX}-libdeflate"
-         "${MINGW_PACKAGE_PREFIX}-libwebp"
+         $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-i686* ]] || \
+            [[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || \
+            echo "${MINGW_PACKAGE_PREFIX}-libwebp" )
          "${MINGW_PACKAGE_PREFIX}-xz"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-zstd")


### PR DESCRIPTION
CLANG32 and CLANGARM64 do not yet have libwebp.  Due to a circular
dependency between libwebp and libtiff, the dependency needs to be
disabled here to enable building.  While CLANGARM64 is not yet
attempting to build these packages, it seems to make sense to include it
here now.

Also enabled libtiff for CLANG32