### PR TITLE
python3.9: don't use os.pathsep for EOF

### DIFF
--- a/mingw-w64-python3.9/0097-Don-t-use-os.pathsep-to-find-EOF.patch
+++ b/mingw-w64-python3.9/0097-Don-t-use-os.pathsep-to-find-EOF.patch
@@ -1,0 +1,27 @@
+From bc0395a45b7f5244e10c18666c654495f661c104 Mon Sep 17 00:00:00 2001
+From: Naveen M K <naveen@syrusdark.website>
+Date: Fri, 18 Jun 2021 12:38:11 +0530
+Subject: [PATCH 97/N] Don't use os.pathsep to find EOF not all distributions
+ in win32 have them as \ instead check using sys.platform
+
+Signed-off-by: Naveen M K <naveen@syrusdark.website>
+---
+ Lib/site.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Lib/site.py b/Lib/site.py
+index b344f03..474ef89 100644
+--- a/Lib/site.py
++++ b/Lib/site.py
+@@ -370,7 +370,7 @@ def setquit():
+     The repr of each object contains a hint at how it works.
+ 
+     """
+-    if os.sep == '\\':
++    if sys.platform == 'win32':
+         eof = 'Ctrl-Z plus Return'
+     else:
+         eof = 'Ctrl-D (i.e. EOF)'
+-- 
+2.32.0
+

--- a/mingw-w64-python3.9/PKGBUILD
+++ b/mingw-w64-python3.9/PKGBUILD
@@ -29,7 +29,7 @@ else
   pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}${_pybasever}")
 fi
 pkgver=${_pybasever}.5
-pkgrel=5
+pkgrel=6
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -149,7 +149,8 @@ source=("https://www.python.org/ftp/python/${pkgver%rc?}/Python-${pkgver}.tar.xz
         0092-extend-MS_WINDOWS-flag.patch
         0093-clang-arm64.patch
         0094-MINGW-stack-reserve.patch
-        0095-Add-support-for-Windows-7-Python-3.9.patch)
+        0095-Add-support-for-Windows-7-Python-3.9.patch
+        0097-Don-t-use-os.pathsep-to-find-EOF.patch)
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -257,7 +258,8 @@ prepare() {
   0092-extend-MS_WINDOWS-flag.patch \
   0093-clang-arm64.patch \
   0094-MINGW-stack-reserve.patch \
-  0095-Add-support-for-Windows-7-Python-3.9.patch
+  0095-Add-support-for-Windows-7-Python-3.9.patch \
+  0097-Don-t-use-os.pathsep-to-find-EOF.patch
  
   autoreconf -vfi
 }
@@ -554,4 +556,5 @@ sha256sums=('0c5a140665436ec3dbfbb79e2dfb6d192655f26ef4a29aeffcb6d1820d716d83'
             'ae1436987fca13801dc65ac1f0a03a8a4cbb684f625ec6f0ccb56e7cfb482a21'
             '07baf5fe0a1fbf65f123de722635b51d8e9306287fa99ca6aea16853fa184663'
             '378ae3dcdce2fdb8f598548c83b0ca39d02dac8f3c7128c455c770cf718bc6bc'
-            '0d131c6dc8689786a8c1c824e844e836e509fb9b0e4c8057fcb2fcb225e417bc')
+            '0d131c6dc8689786a8c1c824e844e836e509fb9b0e4c8057fcb2fcb225e417bc'
+            '2a1a1abbe0864107f8fcec37f44e8c996600cc73f289a4c5447056d340748422')

--- a/mingw-w64-python3.9/update-patches.sh
+++ b/mingw-w64-python3.9/update-patches.sh
@@ -22,7 +22,7 @@ die "Could not remove previous patches"
 source PKGBUILD || die "Can't source PKGBUILD"
 
 base_tag=refs/tags/v$pkgver
-msys2_branch=mingw-$_pybasever
+msys2_branch=mingw-v$pkgver
 url=https://github.com/msys2-contrib/cpython-mingw
 upstream_url=https://github.com/python/cpython
 
@@ -57,7 +57,13 @@ for p in $patches
 do
 	sed -i 's/^\(Subject: \[PATCH [0-9]*\/\)[1-9][0-9]*/\1N/' $p ||
 	die "Could not fix Subject: line in $p"
+	_cmd=$(grep -ci ".github/workflows" $p)
+	if [ "$_cmd" != "0" ]
+	then
+		rm -f $p
+	fi
 done &&
+patches="$(ls -1 0*.patch)" &&
 git add $patches ||
 die "Could not stage new patch set"
 
@@ -70,6 +76,9 @@ die "Could not update the patch set in PKGBUILD"
 
 updpkgsums ||
 die "Could not update the patch set checksums in PKGBUILD"
+
+# bump pkgrel
+sed "s/\(pkgrel\).*/pkgrel=$(($pkgrel + 1))/" -i PKGBUILD
 
 git add PKGBUILD ||
 die "Could not stage updates in PKGBUILD"


### PR DESCRIPTION
Fix a part of https://github.com/msys2/MINGW-packages/issues/8756