### PR TITLE
grpc: add back LDFLAGS workarounds.

### DIFF
--- a/mingw-w64-grpc/PKGBUILD
+++ b/mingw-w64-grpc/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.35.0
 _abseil_ver=20200923.3
-pkgrel=3
+pkgrel=4
 pkgdesc="gRPC - Google's high performance, open source, general RPC framework (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -66,6 +66,14 @@ build() {
   CPPFLAGS="${CPPFLAGS//-D__USE_MINGW_ANSI_STDIO=1/}"
   # add STRSAFE_NO_DEPRECATE define, otherwise strsafe breaks libc++ headers
   CXXFLAGS+=" -DSTRSAFE_NO_DEPRECATE"
+  case "${MINGW_PACKAGE_PREFIX}" in
+    *-clang-x86_64*)
+    ;;
+    *-x86_64*)
+      # https://github.com/msys2/MINGW-packages/issues/8984
+      LDFLAGS+=" -Wl,--disable-dynamicbase,--default-image-base-low"
+    ;;
+  esac
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe \


### PR DESCRIPTION
`--disable-dynamicbase,--default-image-base-low` appear to still be required.

Fixes #8984