### PR TITLE
gtkwave: update to 3.3.110

### DIFF
--- a/mingw-w64-gtkwave/PKGBUILD
+++ b/mingw-w64-gtkwave/PKGBUILD
@@ -10,8 +10,8 @@
 _realname=gtkwave
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=3.3.109
-pkgrel=2
+pkgver=3.3.110
+pkgrel=1
 pkgdesc='GtkWave, a fully featured GTK+ based wave viewer which reads VCD, GHW, LXT, LXT2, VZT and FST files (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -34,7 +34,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-gtk3"
 )
 source=("https://gtkwave.sourceforge.io/${_realname}-gtk3-${pkgver}.tar.gz")
-sha256sums=('35461eccd9b8b4470caa78ab9a8f14ecacbcc9eff63033d8dce58093e786deb7')
+sha256sums=('2aedb92156bca2ddd25b138378cace6b1058e57d36d939ef0f79769006b759aa')
 
 prepare() {
   cd "${srcdir}/${_realname}-gtk3-${pkgver}"
@@ -75,7 +75,4 @@ package() {
 
   cd "${srcdir}/build-${MINGW_CHOST}"-gtk2
   make DESTDIR="${pkgdir}" install
-
-  # https://github.com/ghdl/ghdl/issues/1756
-  rm "${_bin}"/ghwdump.exe
 }


### PR DESCRIPTION
Note that ghwdump is now distributed with GHDL, so it was removed from the gtkwave `make install`.