### PR TITLE
curl: preserve UNC paths when normalizing/simplifying

### DIFF
--- a/mingw-w64-curl/0001-Make-cURL-relocatable.patch
+++ b/mingw-w64-curl/0001-Make-cURL-relocatable.patch
@@ -22,10 +22,10 @@ Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
  configure.ac         |   1 +
  lib/Makefile.inc     |   5 +-
  lib/curl_config.h.in |   3 +
- lib/pathtools.c      | 533 +++++++++++++++++++++++++++++++++++++++++++++++++++
+ lib/pathtools.c      | 539 +++++++++++++++++++++++++++++++++++++++++++++++++++
  lib/pathtools.h      |  53 +++++
  lib/url.c            |  26 ++-
- 6 files changed, 618 insertions(+), 3 deletions(-)
+ 6 files changed, 624 insertions(+), 3 deletions(-)
  create mode 100644 lib/pathtools.c
  create mode 100644 lib/pathtools.h
 
@@ -80,7 +80,7 @@ new file mode 100644
 index 000000000..c66df924b
 --- /dev/null
 +++ b/lib/pathtools.c
-@@ -0,0 +1,533 @@
+@@ -0,0 +1,539 @@
 +/*
 +      .Some useful path tools.
 +        .ASCII only for now.
@@ -145,7 +145,7 @@ index 000000000..c66df924b
 +    *path_p = '/';
 +  }
 +  /* Replace any '//' with '/' */
-+  path_p = path;
++  path_p = path + !!*path; /* skip first character, if any, to handle UNC paths correctly */
 +  while ((path_p = strstr (path_p, "//")) != NULL)
 +  {
 +    memmove (path_p, path_p + 1, path_size--);
@@ -260,6 +260,12 @@ index 000000000..c66df924b
 +  size_t in_size = strlen (path);
 +  int it_ended_with_a_slash = (path[in_size - 1] == '/') ? 1 : 0;
 +  char * result = path;
++  if (path[0] == '/' && path[1] == '/') {
++    /* preserve UNC path */
++    path++;
++    in_size--;
++    result++;
++  }
 +  sanitise_path(result);
 +  char * result_p = result;
 +

--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -14,7 +14,7 @@ _realname=curl
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}${_namesuff}"
 pkgver=7.77.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Command line tool and library for transferring data with URLs. (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -51,7 +51,7 @@ source=("https://github.com/curl/curl/releases/download/${_realname}-${pkgver//.
         "0003-libpsl-static-libs.patch")
 sha256sums=('0f64582c54282f31c0de9f0a1a596b182776bd4df9a4c4a2a41bbeb54f62594b'
             'SKIP'
-            '41e7d1f734cae5fbeea8a84ec4af40c29bf7ffbf156ab290abd57df840312ca1'
+            'bf160265eafc7d29ab760bfa7a32588ecabf8da2f4d22aac9ef2a080d6d96836'
             '79eec8a337e375d5102fef884030ceacd163a79e5c495e9a974a6b9a11b60c61'
             '7492d019036b5bec251bfbc3c0b40e5f16d3dd6b2515068835e087a6c21f19ad')
 validpgpkeys=('914C533DF9B2ADA2204F586D78E11C6B279D5C91'  # Daniel Stenberg


### PR DESCRIPTION
This is a fixed version of https://github.com/msys2/MINGW-packages/pull/8920.

The code to make cURL relocatable simplifies/normalizes paths, e.g. reducing multiple forward slashes to a single one.

This is okay in general, but at the beginning of the path, a double slash has a special meaning: it denotes a UNC path of the form
`//<host>/<path>`. It would therefore be a mistake to reduce those first two slashes to a single one: otherwise it would refer to the absolute path relative to the current directory's drive.

Original report: https://github.com/git-for-windows/git/issues/3266

So sad that I cannot Cc: the original author of the `pathtools.c` file. 😞 