### PR TITLE
sip: remove replaces sip4, sip4 still exists as a package

### DIFF
--- a/mingw-w64-sip/PKGBUILD
+++ b/mingw-w64-sip/PKGBUILD
@@ -6,10 +6,9 @@ _realname=sip
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-sip4")
-replaces=("${MINGW_PACKAGE_PREFIX}-sip4"
-          "${MINGW_PACKAGE_PREFIX}-sip5")
+replaces=("${MINGW_PACKAGE_PREFIX}-sip5")
 pkgver=6.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A tool that makes it easy to create Python bindings for C and C++ libraries (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')


### PR DESCRIPTION
My PKGBUILD knowledge is somewhat lacking, but it seems to me that sip should not `replace` sip4, as sip4 still exists as a package (and is necessary to build the latest release of wxPython at least).  Note that sip declares to `conflict` with sip4, but not vice-versa, hopefully that is ok.

Also, the current development branch of wxPython now depends on sip 5.5, so if/when this winds up being released we may need to resurrect the sip5 package, and then remove the `replaces` sip5 here as well.