### PR TITLE
try limiting clang32 to -j1 for packages known to have address space issues with lld

### DIFF
--- a/mingw-w64-aom/PKGBUILD
+++ b/mingw-w64-aom/PKGBUILD
@@ -4,7 +4,7 @@ _realname=aom
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.1.1
-pkgrel=3
+pkgrel=4
 pkgdesc='AV1 codec library (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -50,6 +50,11 @@ build() {
     extra_config+=("-DCMAKE_BUILD_TYPE=Release")
   else
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  # Hack for clang32 in CI
+  if [[ -n "${CI}" && "${MSYSTEM}" == "CLANG32" ]]; then
+    export CMAKE_BUILD_PARALLEL_LEVEL=1
   fi
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \

--- a/mingw-w64-assimp/PKGBUILD
+++ b/mingw-w64-assimp/PKGBUILD
@@ -4,7 +4,7 @@ _realname=assimp
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.0.1
-pkgrel=7
+pkgrel=8
 pkgdesc="Portable Open Source library to import various well-known 3D model formats in an uniform manner (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -50,6 +50,11 @@ build() {
     -DASSIMP_BUILD_TESTS=OFF \
     -DDirectX_DXERR_LIBRARY=${MINGW_PREFIX}/${MINGW_CHOST}/lib/libdxerr9.a \
     ../${_realname}-${pkgver}
+
+  # Hack for clang32 in CI
+  if [[ -n "${CI}" && "${MSYSTEM}" == "CLANG32" ]]; then
+    export CMAKE_BUILD_PARALLEL_LEVEL=1
+  fi
 
   ${MINGW_PREFIX}/bin/cmake.exe --build ./
 }

--- a/mingw-w64-wxWidgets/PKGBUILD
+++ b/mingw-w64-wxWidgets/PKGBUILD
@@ -10,7 +10,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 provides=("${MINGW_PACKAGE_PREFIX}-wxmsw${_wx_basever}")
 pkgbase=mingw-w64-${_realname}
 pkgver=${_wx_basever}.5.1
-pkgrel=2
+pkgrel=3
 pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -64,6 +64,11 @@ build() {
   #CXXFLAGS+=" -std=gnu++11"
   [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
   mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+
+  # Hack for clang32 in CI
+  if [[ -n "${CI}" && "${MSYSTEM}" == "CLANG32" ]]; then
+    unset MAKEFLAGS
+  fi
 
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \

--- a/mingw-w64-wxWidgets3.1/PKGBUILD
+++ b/mingw-w64-wxWidgets3.1/PKGBUILD
@@ -19,7 +19,7 @@ _wx_buildver=
 pkgbase=mingw-w64-${_basename}${_wx_basever}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}${_wx_basever}"
 pkgver=${_wx_basever}.5
-pkgrel=1
+pkgrel=2
 pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -105,6 +105,11 @@ build() {
   fi
 
   #echo "_debug_options := ${_debug_options[@]}"
+
+  # Hack for clang32 in CI
+  if [[ -n "${CI}" && "${MSYSTEM}" == "CLANG32" ]]; then
+    unset MAKEFLAGS
+  fi
 
   [[ -d "${srcdir}"/build-${CARCH}-shared ]] && rm -rf "${srcdir}"/build-${CARCH}-shared
   mkdir -p "${srcdir}"/build-${CARCH}-shared && cd "${srcdir}"/build-${CARCH}-shared

--- a/mingw-w64-xalan-c/PKGBUILD
+++ b/mingw-w64-xalan-c/PKGBUILD
@@ -4,7 +4,7 @@ _realname=xalan-c
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.12
-pkgrel=3
+pkgrel=4
 pkgdesc="An XSLT processing library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -57,12 +57,17 @@ build() {
     -DBUILD_SHARED_LIBS=ON \
     ../${_realname//-/_}-${pkgver}
 
-  ninja
+  # Hack for clang32 in CI
+  if [[ -n "${CI}" && "${MSYSTEM}" == "CLANG32" ]]; then
+    export CMAKE_BUILD_PARALLEL_LEVEL=1
+  fi
+
+  ${MINGW_PREFIX}/bin/cmake.exe --build ./
 }
 
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
-  DESTDIR=${pkgdir} ninja install
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --build ./ --target install
 
   install -Dm644 ${srcdir}/${_realname//-/_}-${pkgver}/LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
This passed in CI on my fork.  The PR will give it another test in CI, and then hopefully it will work under autobuild.  (`aom` without these changes would succeed in CI but fail under autobuild.)