### PR TITLE
freetype: disable harfbuzz on new clang prefixes.

### DIFF
--- a/mingw-w64-freetype/PKGBUILD
+++ b/mingw-w64-freetype/PKGBUILD
@@ -2,15 +2,19 @@
 # Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _with_harfbuzz="yes"
+if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-i686* \
+   || ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]]; then
+  _with_harfbuzz="no"
+fi
 
 _realname=freetype
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.10.4
-pkgrel=3
+pkgrel=4
 pkgdesc="TrueType font rendering library (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://www.freetype.org/"
 license=(GPL2+ custom:FreeType)
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"


### PR DESCRIPTION
Breaks a circular dependency between freetype and harfbuzz.

Also added clang32 to mingw_arch at the same time