### PR TITLE
libtiff: enable libwebp dependency for clang32

### DIFF
--- a/mingw-w64-libtiff/PKGBUILD
+++ b/mingw-w64-libtiff/PKGBUILD
@@ -5,7 +5,7 @@ _realname=libtiff
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.3.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Library for manipulation of TIFF images (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -15,8 +15,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-jbigkit"
          "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
          "${MINGW_PACKAGE_PREFIX}-libdeflate"
-         $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-i686* ]] || \
-            [[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || \
+         $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || \
             echo "${MINGW_PACKAGE_PREFIX}-libwebp" )
          "${MINGW_PACKAGE_PREFIX}-xz"
          "${MINGW_PACKAGE_PREFIX}-zlib"


### PR DESCRIPTION
libwebp is now available there.