### PR TITLE
qt6-base: improve clang32 non-CI parallelism check

### DIFF
--- a/mingw-w64-qt6-base/PKGBUILD
+++ b/mingw-w64-qt6-base/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 _qtver=6.1.1
 pkgver=${_qtver/-/}
-pkgrel=2
+pkgrel=3
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://www.qt.io'
@@ -80,7 +80,8 @@ build() {
   if [[ "${MSYSTEM}" == "CLANG32" ]]; then
     if [[ -n "${CI}" ]]; then
       export CMAKE_BUILD_PARALLEL_LEVEL=1
-    else
+    elif [[ -z "${CMAKE_BUILD_PARALLEL_LEVEL}" ]] && \
+         (( $(nproc) > 3 )); then
       export CMAKE_BUILD_PARALLEL_LEVEL=4
     fi
   fi


### PR DESCRIPTION
Don't override CMAKE_BUILD_PARALLEL_LEVEL to 4 if
CMAKE_BUILD_PARALLEL_LEVEL is already defined (assume the user knows
what they're doing), or if there are fewer than 4 processors (so the
default may be lower than 4).

From discussion on https://github.com/msys2/MINGW-packages/commit/c6704b662fbc82960f2f128dc5b89d2bea3cc7b8#commitcomment-52842651.  Suggestions welcome