### PR TITLE
qt6-declarative: limit to -j1 in CI for CLANG32

### DIFF
--- a/mingw-w64-qt6-declarative/PKGBUILD
+++ b/mingw-w64-qt6-declarative/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 _qtver=6.1.1
 pkgver=${_qtver/-/}
-pkgrel=1
+pkgrel=2
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://www.qt.io'
@@ -32,7 +32,12 @@ build() {
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     ../${_pkgfn}
 
-  ninja
+  # Hack for clang32 in CI
+  if [[ -n "${CI}" && "${MSYSTEM}" == "CLANG32" ]]; then
+    export CMAKE_BUILD_PARALLEL_LEVEL=1
+  fi
+
+  ${MINGW_PREFIX}/bin/cmake.exe --build ./
 }
 
 package() {


### PR DESCRIPTION
Also switch to cmake --build instead of calling ninja explicitly.

This package built successfully on my 8 logical processor machine, so no workaround for non-CI.