### PR TITLE
perl: Fix file conflicts

### DIFF
--- a/mingw-w64-perl/PKGBUILD
+++ b/mingw-w64-perl/PKGBUILD
@@ -22,7 +22,7 @@ pkgbase="mingw-w64-${_realname}"
 # provides array, then repackage.
 pkgver="5.32.1"
 #       v    ^
-pkgrel=1
+pkgrel=2
 pkgdesc="A highly capable, feature-rich programming language (mingw-w64)"
 url="https://www.perl.org"
 arch=('any')
@@ -953,7 +953,7 @@ _package_core() {
     local path="$(IFS=':'; echo "${path_arr[*]}")"
 
     msg2 "Adding extra files"
-    local profile="/etc/profile.d/z-${_realname}-${CARCH}.sh"
+    local profile="/etc/profile.d/z-${_realname}-${MINGW_PACKAGE_PREFIX/mingw-w64-}.sh"
     install -Dvm644 <(sed \
             -e "/^\s*local\s\+mypath=/ s/=.*/=\"${path//\//\\\/}\"/" \
             -e "s/@PREFIX@/${MINGW_PREFIX//\//\\\/}/g" \


### PR DESCRIPTION
profile="/etc/profile.d/z-${_realname}-${MINGW_PACKAGE_PREFIX/mingw-w64-}.sh"
/etc/profile.d/z-perl-x86_64.sh exists in filesystem owned by mingw-w64-x86_64-perl.