### PR TITLE
gdcm: Fix build with clang, use ninja.

### DIFF
--- a/mingw-w64-gdcm/0002-cmake-config-destination.patch
+++ b/mingw-w64-gdcm/0002-cmake-config-destination.patch
@@ -1,6 +1,6 @@
 --- gdcm-2.8.7/CMakeLists.txt.orig	2018-08-21 16:51:28.148990200 +0300
 +++ gdcm-2.8.7/CMakeLists.txt	2018-08-21 16:51:34.909376900 +0300
-@@ -261,7 +261,7 @@
+@@ -252,7 +252,7 @@
  endif()
  
  if(NOT GDCM_INSTALL_PACKAGE_DIR)
@@ -25,7 +25,7 @@
    if(EXISTS ${SELF_DIR}/GDCMExports.cmake)
 --- gdcm-2.8.7/Utilities/gdcmopenjpeg/CMakeLists.txt.orig	2018-08-21 16:55:15.706005700 +0300
 +++ gdcm-2.8.7/Utilities/gdcmopenjpeg/CMakeLists.txt	2018-08-21 16:55:27.280667800 +0300
-@@ -150,7 +150,7 @@
+@@ -162,7 +162,7 @@
    # We could install *.cmake files in share/ however those files contains
    # hardcoded path to libraries on a multi-arch system (fedora/debian) those
    # path will be different (lib/i386-linux-gnu vs lib/x86_64-linux-gnu)

--- a/mingw-w64-gdcm/0008-cmake-use-mingw-getopt.patch
+++ b/mingw-w64-gdcm/0008-cmake-use-mingw-getopt.patch
@@ -1,0 +1,31 @@
+--- a/Applications/Cxx/CMakeLists.txt
++++ b/Applications/Cxx/CMakeLists.txt
+@@ -6,7 +6,7 @@
+ # gdcmanon
+ 
+ 
+-if(WIN32 AND NOT CYGWIN)
++if(WIN32 AND NOT CYGWIN AND NOT MINGW)
+   include_directories(
+     "${GDCM_SOURCE_DIR}/Utilities/getopt"
+   )
+@@ -183,7 +183,7 @@
+   if(GDCM_EXECUTABLE_PROPERTIES)
+     set_target_properties(${exename} PROPERTIES ${GDCM_EXECUTABLE_PROPERTIES})
+   endif()
+-  if(WIN32 AND NOT CYGWIN)
++  if(WIN32 AND NOT CYGWIN AND NOT MINGW)
+     target_link_libraries(${exename} gdcmgetopt)
+   endif()
+   if(NOT GDCM_INSTALL_NO_RUNTIME)
+--- a/Utilities/CMakeLists.txt
++++ b/Utilities/CMakeLists.txt
+@@ -71,7 +71,7 @@
+ # Do getopt
+ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/getopt)
+   APPEND_COPYRIGHT(${CMAKE_CURRENT_SOURCE_DIR}/getopt/COPYING)
+-  if(WIN32 AND NOT CYGWIN)
++  if(WIN32 AND NOT CYGWIN AND NOT MINGW)
+     set(GETOPT_NAMESPACE "GDCMGETOPT")
+     set(GETOPT_INSTALL_NO_LIBRARIES ${GDCM_INSTALL_NO_LIBRARIES})
+     set(GETOPT_INSTALL_BIN_DIR      ${GDCM_INSTALL_BIN_DIR})

--- a/mingw-w64-gdcm/PKGBUILD
+++ b/mingw-w64-gdcm/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gdcm
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.0.8
-pkgrel=2
+pkgrel=3
 pkgdesc="The Grassroots DICOM library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -20,10 +20,10 @@ depends=("${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-openssl"
          "${MINGW_PACKAGE_PREFIX}-poppler"
          "${MINGW_PACKAGE_PREFIX}-zlib")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-docbook-xsl"
-             "${MINGW_PACKAGE_PREFIX}-cmake")
+             "${MINGW_PACKAGE_PREFIX}-ninja")
 options=('staticlibs' 'strip')
 source=(#"https://downloads.sourceforge.net/project/gdcm/gdcm%202.x/GDCM%20${pkgver}/gdcm-${pkgver}.tar.bz2"
         gdcm-${pkgver}.tar.gz::https://github.com/malaterre/GDCM/archive/v${pkgver}.tar.gz
@@ -31,13 +31,15 @@ source=(#"https://downloads.sourceforge.net/project/gdcm/gdcm%202.x/GDCM%20${pkg
         0004-fix-find-openssl.patch
         0005-fix-cross-initializing.patch
         0006-openjpeg2-visibility.patch
-        0007-getopt-global-var.patch)
+        0007-getopt-global-var.patch
+        0008-cmake-use-mingw-getopt.patch)
 sha256sums=('47b96be345b1611784f9e65fc39367c7450c9a1ef81c21f8acddfb6207098315'
-            '70b1f693e381f4d8e725db7a71df79f2803809cc7b0ac90ea41b1f3c6238c945'
+            '94e68cbc4d7582e4cc90dccb6762a4c46c3c4b191ee54aa53a79449650e6ccd6'
             '77645101ea8425c601fb0717630b334c8a4ced3ea7f3625c11d338c56529e5fb'
             '018b083e74091776afaef9894fcb1c7554b36828f162bc4c9b2ea2a6b154b159'
             '008635edc8c200b2adf8adf33c3439d39706e9b7ed0e644d7d0ebe18d9a020eb'
-            'ed9c4020bd39cadf4d78c72aa4be5afaf3d0a743406e8bee6c5936299e5d1d33')
+            'ed9c4020bd39cadf4d78c72aa4be5afaf3d0a743406e8bee6c5936299e5d1d33'
+            '85fd9a6a52ec8d6f756022b94545707f1bda1661bf82e2a7d3132ccf85b1ea86')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -46,16 +48,20 @@ prepare() {
   patch -p1 -i ${srcdir}/0005-fix-cross-initializing.patch
   patch -p1 -i ${srcdir}/0006-openjpeg2-visibility.patch
   patch -p1 -i ${srcdir}/0007-getopt-global-var.patch
+
+  #https://github.com/malaterre/GDCM/pull/124
+  patch -p1 -i ${srcdir}/0008-cmake-use-mingw-getopt.patch
 }
 
 build() {
-  msg "Build static version"
+  echo "==> Build static version"
   [[ -d "${srcdir}/build-static-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-static-${MINGW_CHOST}"
   mkdir -p "${srcdir}/build-static-${MINGW_CHOST}" && cd "${srcdir}/build-static-${MINGW_CHOST}"
 
+  CXXFLAGS+=" -Wno-ignored-attributes" \
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-  ${MINGW_PREFIX}/bin/cmake \
-    -G"MSYS Makefiles" \
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G"Ninja" \
     -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_SYSTEM_PREFIX_PATH="${MINGW_PREFIX}" \
@@ -85,17 +91,17 @@ build() {
     -DGDCM_USE_PARAVIEW=OFF \
     -DGDCM_BUILD_APPLICATIONS=ON \
     ../${_realname}-${pkgver}
-  make
 
-  msg "Build shared version"
+  ${MINGW_PREFIX}/bin/cmake.exe --build ./
+
+  echo "==> Build shared version"
   [[ -d "${srcdir}/build-shared-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-shared-${MINGW_CHOST}"
   mkdir -p "${srcdir}/build-shared-${MINGW_CHOST}" && cd "${srcdir}/build-shared-${MINGW_CHOST}"
 
-  LDFLAGS+=" -Wl,--allow-multiple-definition" # Bypass linking with internal getopt and mingw getopt provided
-
+  CXXFLAGS+=" -Wno-ignored-attributes" \
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-  ${MINGW_PREFIX}/bin/cmake \
-    -G"MSYS Makefiles" \
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G"Ninja" \
     -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_SYSTEM_PREFIX_PATH="${MINGW_PREFIX}" \
@@ -125,13 +131,14 @@ build() {
     -DGDCM_USE_PARAVIEW=OFF \
     -DGDCM_BUILD_APPLICATIONS=ON \
     ../${_realname}-${pkgver}
-  make
+
+  ${MINGW_PREFIX}/bin/cmake.exe --build ./
 }
 
 package() {
   cd "${srcdir}/build-static-${MINGW_CHOST}"
-  make DESTDIR="${pkgdir}" install
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --build ./ --target install
 
   cd "${srcdir}/build-shared-${MINGW_CHOST}"
-  make DESTDIR="${pkgdir}" install
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --build ./ --target install
 }


### PR DESCRIPTION
Use CMake to disable getopt linking conflict which replaces the multiple
definition workaround in 28016b68b3c7057c4cee10c66e48402f0396042b commit.