### PR TITLE
perl: Update winsock patch to add ip_mreq

### DIFF
--- a/mingw-w64-perl/007-use-winsock-socket-functions.patch
+++ b/mingw-w64-perl/007-use-winsock-socket-functions.patch
@@ -1,99 +1,21 @@
 --- a/cpan/Socket/Socket.xs
 +++ b/cpan/Socket/Socket.xs
-@@ -51,34 +51,6 @@
- # include <ws2tcpip.h>
+@@ -98,6 +98,7 @@
+ 
  #endif
-
--#ifdef WIN32
--
--/* VC 6 with its original headers doesn't know about sockaddr_storage, VC 2003 does*/
--#ifndef _SS_MAXSIZE
--
--#  define _SS_MAXSIZE 128
--#  define _SS_ALIGNSIZE (sizeof(__int64))
--
--#  define _SS_PAD1SIZE (_SS_ALIGNSIZE - sizeof (short))
--#  define _SS_PAD2SIZE (_SS_MAXSIZE - (sizeof (short) + _SS_PAD1SIZE \
--                                                    + _SS_ALIGNSIZE))
--
--struct sockaddr_storage {
--    short ss_family;
--    char __ss_pad1[_SS_PAD1SIZE];
--    __int64 __ss_align;
--    char __ss_pad2[_SS_PAD2SIZE];
--};
--
--typedef int socklen_t;
--
--#define in6_addr in_addr6
--
--#define INET_ADDRSTRLEN  22
--#define INET6_ADDRSTRLEN 65
--
--#endif
--
- /*
-  *  Under Windows, sockaddr_un is defined in afunix.h. Unfortunately
-  *  MinGW and SDKs older than 10.0.17063.0 don't have it, so we have to
-@@ -98,58 +70,6 @@
-
- #endif
-
--static int inet_pton(int af, const char *src, void *dst)
--{
--  struct sockaddr_storage ss;
--  int size = sizeof(ss);
--  ss.ss_family = af; /* per MSDN */
--
--  if (WSAStringToAddress((char*)src, af, NULL, (struct sockaddr *)&ss, &size) != 0)
--    return 0;
--
--  switch(af) {
--    case AF_INET:
--      *(struct in_addr *)dst = ((struct sockaddr_in *)&ss)->sin_addr;
--      return 1;
--    case AF_INET6:
--      *(struct in6_addr *)dst = ((struct sockaddr_in6 *)&ss)->sin6_addr;
--      return 1;
--    default:
--      WSASetLastError(WSAEAFNOSUPPORT);
--      return -1;
--  }
--}
--
--static const char *inet_ntop(int af, const void *src, char *dst, socklen_t size)
--{
--  struct sockaddr_storage ss;
--  unsigned long s = size;
--
--  ZeroMemory(&ss, sizeof(ss));
--  ss.ss_family = af;
--
--  switch(af) {
--    case AF_INET:
--      ((struct sockaddr_in *)&ss)->sin_addr = *(struct in_addr *)src;
--      break;
--    case AF_INET6:
--      ((struct sockaddr_in6 *)&ss)->sin6_addr = *(struct in6_addr *)src;
--      break;
--    default:
--      return NULL;
--  }
--
--  /* cannot directly use &size because of strict aliasing rules */
--  if (WSAAddressToString((struct sockaddr *)&ss, sizeof(ss), NULL, dst, &s) != 0)
--    return NULL;
--  else
--    return dst;
--}
--
--#define HAS_INETPTON
--#define HAS_INETNTOP
--#endif
--
- #ifdef NETWARE
- NETDB_DEFINE_CONTEXT
- NETINET_DEFINE_CONTEXT
+ 
++#ifndef __MINGW64_VERSION_MAJOR
+ static int inet_pton(int af, const char *src, void *dst)
+ {
+   struct sockaddr_storage ss;
+@@ -145,6 +146,7 @@
+   else
+     return dst;
+ }
++#endif /* __MINGW64_VERSION_MAJOR */
+ 
+ #define HAS_INETPTON
+ #define HAS_INETNTOP
 --- a/dist/IO/poll.h
 +++ b/dist/IO/poll.h
 @@ -11,7 +11,11 @@
@@ -111,43 +33,23 @@
  #else
 --- a/win32/config_H.gc
 +++ b/win32/config_H.gc
-@@ -1953,7 +1953,7 @@
+@@ -1942,11 +1958,11 @@
  #define	HAS_SOCKET		/**/
  /*#define	HAS_SOCKETPAIR	/ **/
  /*#define	HAS_SOCKADDR_SA_LEN	/ **/
 -/*#define	HAS_SOCKADDR_IN6	/ **/
 +#define	HAS_SOCKADDR_IN6	/ **/
  #define	HAS_SIN6_SCOPE_ID	/**/
- /*#define	HAS_IP_MREQ	/ **/
- /*#define	HAS_IP_MREQ_SOURCE	/ **/
-@@ -2763,13 +2763,13 @@
-  *	This symbol, if defined, indicates that the inet_ntop() function
-  *	is available to parse IPv4 and IPv6 strings.
-  */
--/*#define HAS_INETNTOP		/ **/
-+#define HAS_INETNTOP		/ **/
+-/*#define	HAS_IP_MREQ	/ **/
+-/*#define	HAS_IP_MREQ_SOURCE	/ **/
+-/*#define	HAS_IPV6_MREQ	/ **/
++#define	HAS_IP_MREQ	/ **/
++#define	HAS_IP_MREQ_SOURCE	/ **/
++#define	HAS_IPV6_MREQ	/ **/
+ /*#define	HAS_IPV6_MREQ_SOURCE	/ **/
  
- /* HAS_INETPTON:
-  *	This symbol, if defined, indicates that the inet_pton() function
-  *	is available to parse IPv4 and IPv6 strings.
-  */
--/*#define HAS_INETPTON		/ **/
-+#define HAS_INETPTON		/ **/
- 
- /* HAS_INT64_T:
-  *     This symbol will defined if the C compiler supports int64_t.
---- a/win32/config_H.vc
-+++ b/win32/config_H.vc
-@@ -1944,7 +1944,7 @@
- #define	HAS_SOCKET		/**/
- /*#define	HAS_SOCKETPAIR	/ **/
- /*#define	HAS_SOCKADDR_SA_LEN	/ **/
--/*#define	HAS_SOCKADDR_IN6	/ **/
-+#define	HAS_SOCKADDR_IN6	/ **/
- #define	HAS_SIN6_SCOPE_ID	/**/
- /*#define	HAS_IP_MREQ	/ **/
- /*#define	HAS_IP_MREQ_SOURCE	/ **/
-@@ -2754,13 +2754,13 @@
+ /* USE_STAT_BLOCKS:
+@@ -2752,13 +2768,13 @@
   *	This symbol, if defined, indicates that the inet_ntop() function
   *	is available to parse IPv4 and IPv6 strings.
   */
@@ -165,7 +67,7 @@
   *     This symbol will defined if the C compiler supports int64_t.
 --- a/win32/config.gc
 +++ b/win32/config.gc
-@@ -303,8 +303,8 @@
+@@ -304,12 +304,12 @@
  d_inc_version_list='undef'
  d_index='undef'
  d_inetaton='undef'
@@ -174,36 +76,21 @@
 +d_inetntop='define'
 +d_inetpton='define'
  d_int64_t='undef'
- d_ip_mreq='undef'
- d_ip_mreq_source='undef'
-@@ -523,7 +523,7 @@
+-d_ip_mreq='undef'
+-d_ip_mreq_source='undef'
+-d_ipv6_mreq='undef'
++d_ip_mreq='define'
++d_ip_mreq_source='define'
++d_ipv6_mreq='define'
+ d_ipv6_mreq_source='undef'
+ d_isascii='define'
+ d_isblank='undef'
+@@ -525,7 +525,7 @@
  d_sin6_scope_id='define'
  d_sitearch='define'
  d_snprintf='define'
 -d_sockaddr_in6='undef'
 +d_sockaddr_in6='define'
  d_sockaddr_sa_len='undef'
+ d_sockaddr_storage='define'
  d_sockatmark='undef'
- d_sockatmarkproto='undef'
---- a/win32/config.vc
-+++ b/win32/config.vc
-@@ -303,8 +303,8 @@
- d_inc_version_list='undef'
- d_index='undef'
- d_inetaton='undef'
--d_inetntop='undef'
--d_inetpton='undef'
-+d_inetntop='define'
-+d_inetpton='define'
- d_int64_t='undef'
- d_ip_mreq='undef'
- d_ip_mreq_source='undef'
-@@ -523,7 +523,7 @@
- d_sin6_scope_id='define'
- d_sitearch='define'
- d_snprintf='define'
--d_sockaddr_in6='undef'
-+d_sockaddr_in6='define'
- d_sockaddr_sa_len='undef'
- d_sockatmark='undef'
- d_sockatmarkproto='undef'

--- a/mingw-w64-perl/008-ucrt-stdio-internals.patch
+++ b/mingw-w64-perl/008-ucrt-stdio-internals.patch
@@ -1,6 +1,6 @@
 --- a/win32/win32.h
 +++ b/win32/win32.h
-@@ -355,14 +355,30 @@
+@@ -347,14 +347,30 @@
  /* Note: PERLIO_FILE_ptr/base/cnt are not actually used for GCC or <VS2015
   * since FILE_ptr/base/cnt do the same thing anyway but it doesn't hurt to
   * define them all here for completeness. */
@@ -39,7 +39,7 @@
  
  #endif
  
-@@ -644,7 +660,7 @@
+@@ -636,7 +652,7 @@
   * #if above).)
   */
  #if ! (_MSC_VER < 1400 || (_MSC_VER >= 1500 && _MSC_VER <= 1700) \
@@ -48,7 +48,7 @@
  /* size of ioinfo struct is determined at runtime */
  #  define WIN32_DYN_IOINFO_SIZE
  #endif
-@@ -653,32 +669,18 @@
+@@ -645,32 +661,18 @@
  /*
   * Control structure for lowio file handles
   */
@@ -92,7 +92,7 @@
  } ioinfo;
  #else
  typedef intptr_t ioinfo;
-@@ -687,13 +689,13 @@
+@@ -679,13 +681,13 @@
  /*
   * Array of arrays of control structures for lowio files.
   */
@@ -110,7 +110,7 @@
   * Definition of IOINFO_ARRAY_ELTS, the number of elements in ioinfo array
 --- a/win32/config.gc
 +++ b/win32/config.gc
-@@ -1066,11 +1066,11 @@
+@@ -1073,11 +1073,11 @@
  startsh='#!/bin/sh'
  static_ext=' '
  stdchar='char'
@@ -171,7 +171,7 @@
  /* DOUBLESIZE:
 --- a/win32/win32sck.c
 +++ b/win32/win32sck.c
-@@ -59,6 +59,8 @@
+@@ -60,6 +60,8 @@
  
  #ifdef WIN32_DYN_IOINFO_SIZE
  EXTERN_C Size_t w32_ioinfo_size;

--- a/mingw-w64-perl/PKGBUILD
+++ b/mingw-w64-perl/PKGBUILD
@@ -22,7 +22,7 @@ pkgbase="mingw-w64-${_realname}"
 # provides array, then repackage.
 pkgver="5.32.1"
 #       v    ^
-pkgrel=2
+pkgrel=3
 pkgdesc="A highly capable, feature-rich programming language (mingw-w64)"
 url="https://www.perl.org"
 arch=('any')
@@ -696,8 +696,8 @@ sha256sums=('57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309'
             '39dbdca9647e0e72733801e078d0d262940afea8bd48b767c224746e18e6f939'
             'ecf7d1e70976b25aad329ef7f77ddd6ba6c2efed3b94e30946e250d03cdd6d2e'
             'ff00fed8cd056e36d7f02a43f06feee10911fc2750773f139136426fb9af8b11'
-            '418bfaa6500c569a2587039518405479c83c39b453ddba92259a534a43b6a01d'
-            'ecccee8865a54dde2a8834b02036c4f328f612ce0ba88edbba34e3198bfb6b59')
+            'b05767965076b59585343f3ea242baebeca2128c9485694155468664add023d0'
+            'a54a67a4b66f396a0db8353b29d4af381b6485253ad510eb0f1895f57d17d231')
 
 declare -rg _build="build-${CARCH}-${_realname}-${pkgver}"
 declare -gA _destdir=()


### PR DESCRIPTION
Changes:
  * Check mingw-w64 to disable the conflicting inet_pton and inet_ntop.
  * Enable ip_mreq, ipv6_mreq and ip_mreq_source in Socket module.
  * Remove the unneeded hunks for MSVC.
  * Rebase patches.