### PR TITLE
gcc: backport patch for cpuid.h header guard

### DIFF
--- a/mingw-w64-gcc/0204-x86-Add-__cpuidex-and-include-guard-to-cpuid.h.patch
+++ b/mingw-w64-gcc/0204-x86-Add-__cpuidex-and-include-guard-to-cpuid.h.patch
@@ -1,0 +1,90 @@
+From 29e1039ca211c4e3f1053925eda0a81c57cbcb0c Mon Sep 17 00:00:00 2001
+From: "H.J. Lu" <hjl.tools@gmail.com>
+Date: Sat, 18 Jul 2020 04:43:10 -0700
+Subject: [PATCH] x86: Add __cpuidex and include guard to <cpuid.h>
+
+Add
+
+void __cpuidex (int __cpuid_info[4], int __leaf, int __subleaf);
+
+as well as include guard to <cpuid.h>.
+
+gcc/
+
+	PR target/95973
+	PR target/96238
+	* config/i386/cpuid.h: Add include guard.
+	(__cpuidex): New.
+
+gcc/testsuite/
+
+	PR target/95973
+	PR target/96238
+	* gcc.target/i386/pr95973.c: New test.
+---
+ gcc/config/i386/cpuid.h                 | 12 ++++++++++++
+ gcc/testsuite/gcc.target/i386/pr95973.c | 25 +++++++++++++++++++++++++
+ 2 files changed, 37 insertions(+)
+ create mode 100644 gcc/testsuite/gcc.target/i386/pr95973.c
+
+diff --git a/gcc/config/i386/cpuid.h b/gcc/config/i386/cpuid.h
+index 94af4910d3c..bca61d620db 100644
+--- a/gcc/config/i386/cpuid.h
++++ b/gcc/config/i386/cpuid.h
+@@ -21,6 +21,9 @@
+  * <http://www.gnu.org/licenses/>.
+  */
+ 
++#ifndef _CPUID_H_INCLUDED
++#define _CPUID_H_INCLUDED
++
+ /* %eax */
+ #define bit_AVX512BF16	(1 << 5)
+ 
+@@ -313,3 +316,12 @@ __get_cpuid_count (unsigned int __leaf, unsigned int __subleaf,
+   __cpuid_count (__leaf, __subleaf, *__eax, *__ebx, *__ecx, *__edx);
+   return 1;
+ }
++
++static __inline void
++__cpuidex (int __cpuid_info[4], int __leaf, int __subleaf)
++{
++  __cpuid_count (__leaf, __subleaf, __cpuid_info[0], __cpuid_info[1],
++		 __cpuid_info[2], __cpuid_info[3]);
++}
++
++#endif /* _CPUID_H_INCLUDED */
+diff --git a/gcc/testsuite/gcc.target/i386/pr95973.c b/gcc/testsuite/gcc.target/i386/pr95973.c
+new file mode 100644
+index 00000000000..08c7dba8f46
+--- /dev/null
++++ b/gcc/testsuite/gcc.target/i386/pr95973.c
+@@ -0,0 +1,25 @@
++/* { dg-do run } */
++/* { dg-options "-O2 -Wall" } */
++
++#include <cpuid.h>
++#include <cpuid.h>
++
++int
++main ()
++{
++  unsigned int eax, ebx, ecx, edx;
++  int cpuid_info[4];
++
++  if (!__get_cpuid_count (7, 0, &eax, &ebx, &ecx, &edx))
++    return 0;
++
++  __cpuidex (cpuid_info, 7, 0);
++
++  if (cpuid_info[0] != eax
++      || cpuid_info[1] != ebx
++      || cpuid_info[2] != ecx
++      || cpuid_info[3] != edx)
++    __builtin_abort ();
++
++  return 0;
++}
+-- 
+2.32.0
+

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -28,7 +28,7 @@ pkgver=10.3.0
 #_majorver=${pkgver:0:1}
 #_sourcedir=${_realname}-${_majorver}-${_snapshot}
 _sourcedir=${_realname}-${pkgver}
-pkgrel=2
+pkgrel=3
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -76,7 +76,8 @@ source=("https://ftp.gnu.org/gnu/gcc/${_realname}-${pkgver%%+*}/${_realname}-${p
         0150-gcc-10.2.0-libgcc-ldflags.patch
         0160-libbacktrace-seh.patch
         0200-ms_printf-improvements.patch
-        0203-backport-longjmp-fix.patch)
+        0203-backport-longjmp-fix.patch
+        0204-x86-Add-__cpuidex-and-include-guard-to-cpuid.h.patch)
 sha256sums=('64f404c1a650f27fc33da242e1f2df54952e3963a49e06e73f6940f3223ac344'
             'SKIP'
             'bce81824fc89e5e62cca350de4c17a27e27a18a1a1ad5ca3492aec1fc5af3234'
@@ -101,7 +102,8 @@ sha256sums=('64f404c1a650f27fc33da242e1f2df54952e3963a49e06e73f6940f3223ac344'
             '7f0b4e45d933e18c9d8bd2afcd83e4f52e97e2e25dd41bfa0cba755c70e591c7'
             '88c1d65e763e631ad49f9a077ed631f4acac9ef4732e2818ccddaefc883b1811'
             '146ac7aec004a949e42f7da6ff66351790e56094a85f6dbe28ea583b47c8125d'
-            'a1ca2f5dd55823e29f6628dd5027057636cf3d5998c438f365a84f7ec4b7eaa6')
+            'a1ca2f5dd55823e29f6628dd5027057636cf3d5998c438f365a84f7ec4b7eaa6'
+            'a75056bee1e9505a00d1e221971c620cd8a1ec1685efaf50c1702c1c9c345a9c')
 validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.org
               86CFFCA918CF3AF47147588051E8B148A9999C34  # evangelos@foutrelis.com
               13975A70E63C361C73AE69EF6EEB81F8981C74C7  # richard.guenther@gmail.com
@@ -174,6 +176,10 @@ prepare() {
   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100402
   apply_patch_with_msg \
     0203-backport-longjmp-fix.patch
+
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96238
+  apply_patch_with_msg \
+    0204-x86-Add-__cpuidex-and-include-guard-to-cpuid.h.patch
 
   # do not expect ${prefix}/mingw symlink - this should be superceded by
   # 0005-Windows-Don-t-ignore-native-system-header-dir.patch .. but isn't!


### PR DESCRIPTION
/cc @Biswa96 