### PR TITLE
Update libvips to 8.11.2

### DIFF
--- a/mingw-w64-libvips/PKGBUILD
+++ b/mingw-w64-libvips/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libvips
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=8.10.5
+pkgver=8.11.2
 pkgrel=1
 pkgdesc="A fast image processing library with low memory needs (mingw-w64)"
 arch=('any')
@@ -29,14 +29,13 @@ depends=("${MINGW_PACKAGE_PREFIX}-cairo"
          "${MINGW_PACKAGE_PREFIX}-libtiff"
          "${MINGW_PACKAGE_PREFIX}-libwebp"
          "${MINGW_PACKAGE_PREFIX}-matio"
-         "${MINGW_PACKAGE_PREFIX}-opencl-icd-git"
          "${MINGW_PACKAGE_PREFIX}-openexr"
          "${MINGW_PACKAGE_PREFIX}-orc"
          "${MINGW_PACKAGE_PREFIX}-pango"
          "${MINGW_PACKAGE_PREFIX}-poppler")
 options=('staticlibs' 'strip')
 source=("https://github.com/libvips/libvips/releases/download/v${pkgver}/vips-${pkgver}.tar.gz")
-sha256sums=('a4eef2f5334ab6dbf133cd3c6d6394d5bdb3e76d5ea4d578b02e1bc3d9e1cfd8')
+sha256sums=('bb5ab776ee4c61ae94b4496c63ef523ca7367ebceabcba78ceb1bf97b1d36e06')
 
 
 prepare() {


### PR DESCRIPTION
This removes the dependency to `opencl-icd` for two reasons:
- `opencl-icd` is not available in the UCRT64 repository
- I could not find any use of that library within libvips

I hope the UCRT64 build can be triggered that way (in addition to MINGW32+MINGW64).