### PR TITLE
gcc: add include guard to cpuid.h

### DIFF
--- a/mingw-w64-gcc/0205-x86-Add-include-gard-to-cpuid.h.patch
+++ b/mingw-w64-gcc/0205-x86-Add-include-gard-to-cpuid.h.patch
@@ -1,0 +1,20 @@
+diff --git a/gcc/config/i386/cpuid.h b/gcc/config/i386/cpuid.h
+index 94af4910d3c..bca61d620db 100644
+--- a/gcc/config/i386/cpuid.h
++++ b/gcc/config/i386/cpuid.h
+@@ -21,6 +21,9 @@
+  * <http://www.gnu.org/licenses/>.
+  */
+ 
++#ifndef _CPUID_H_INCLUDED
++#define _CPUID_H_INCLUDED
++
+ /* %eax */
+ #define bit_AVX512BF16	(1 << 5)
+ 
+@@ -313,3 +316,5 @@ __get_cpuid_count (unsigned int __leaf, unsigned int __subleaf,
+   __cpuid_count (__leaf, __subleaf, *__eax, *__ebx, *__ecx, *__edx);
+   return 1;
+ }
++
++#endif /* _CPUID_H_INCLUDED */

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -28,7 +28,7 @@ pkgver=10.3.0
 #_majorver=${pkgver:0:1}
 #_sourcedir=${_realname}-${_majorver}-${_snapshot}
 _sourcedir=${_realname}-${pkgver}
-pkgrel=4
+pkgrel=5
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -77,7 +77,8 @@ source=("https://ftp.gnu.org/gnu/gcc/${_realname}-${pkgver%%+*}/${_realname}-${p
         0160-libbacktrace-seh.patch
         0200-ms_printf-improvements.patch
         0203-backport-longjmp-fix.patch
-        0204-Change-EH-pointer-encodings-to-PC-relative-on-Window.patch)
+        0204-Change-EH-pointer-encodings-to-PC-relative-on-Window.patch
+        0205-x86-Add-include-gard-to-cpuid.h.patch)
 sha256sums=('64f404c1a650f27fc33da242e1f2df54952e3963a49e06e73f6940f3223ac344'
             'SKIP'
             'bce81824fc89e5e62cca350de4c17a27e27a18a1a1ad5ca3492aec1fc5af3234'
@@ -103,7 +104,8 @@ sha256sums=('64f404c1a650f27fc33da242e1f2df54952e3963a49e06e73f6940f3223ac344'
             '88c1d65e763e631ad49f9a077ed631f4acac9ef4732e2818ccddaefc883b1811'
             '146ac7aec004a949e42f7da6ff66351790e56094a85f6dbe28ea583b47c8125d'
             'a1ca2f5dd55823e29f6628dd5027057636cf3d5998c438f365a84f7ec4b7eaa6'
-            '56d748847f4982e9b9681f37016a06c260b193a174c89eda86a0a909b4a964bf')
+            '56d748847f4982e9b9681f37016a06c260b193a174c89eda86a0a909b4a964bf'
+            'c23545205b9d2492ed54990b611ff4e4e28a0b90d311c8fabfea609731485801')
 validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.org
               86CFFCA918CF3AF47147588051E8B148A9999C34  # evangelos@foutrelis.com
               13975A70E63C361C73AE69EF6EEB81F8981C74C7  # richard.guenther@gmail.com
@@ -180,6 +182,10 @@ prepare() {
   # https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=8ce35e4c066b68d0cbc656b000ece84f7ea7741a
   apply_patch_with_msg \
     0204-Change-EH-pointer-encodings-to-PC-relative-on-Window.patch
+
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96238
+  apply_patch_with_msg \
+    0205-x86-Add-include-gard-to-cpuid.h.patch
 
   # do not expect ${prefix}/mingw symlink - this should be superceded by
   # 0005-Windows-Don-t-ignore-native-system-header-dir.patch .. but isn't!


### PR DESCRIPTION
Applies just the include guard parts of the patch from #9032, to avoid
the conflict with mingw-w64 defining `__cpuidex`.