### PR TITLE
cmake: Add patch for findglut

### DIFF
--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -5,7 +5,7 @@ _realname=cmake
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.20.5
-pkgrel=2
+pkgrel=3
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -39,12 +39,14 @@ source=("https://github.com/Kitware/CMake/releases/download/v${pkgver}/${_realna
         "0001-Disable-response-files-for-MSYS-Generator.patch"
         "0002-Do-not-install-Qt-bundle-in-cmake-gui.patch"
         "0004-Output-line-numbers-in-callstacks.patch"
-        "35d3e00e4e9b138dec1d1a646766fc342d04b8f5.patch")
+        "35d3e00e4e9b138dec1d1a646766fc342d04b8f5.patch"
+        "f90d15458a9a98180fcc95158f2ab5d2b1ad3152.patch")
 sha256sums=('12c8040ef5c6f1bc5b8868cede16bb7926c18980f59779e299ab52cbc6f15bb0'
             '25793edcbac05bb6d17fa9947b52ace4a6b5ccccf7758e22ae9ae022ed089061'
             'f6cf6a6f2729db2b9427679acd09520af2cd79fc26900b19a49cead05a55cd1a'
             '15fdf3fb1a0f1c153c8cfbdd2b5c64035b7a04de618bfe61d7d74ced0d6a5c4b'
-            'c4c120046860c014e0da4be959decf330ad8dcdae5a48ebcb8ec59006eb0e625')
+            'c4c120046860c014e0da4be959decf330ad8dcdae5a48ebcb8ec59006eb0e625'
+            'e0dbe6da13372f9817d6451a7d75c5fd9cdf5843a305e80d8803ad76d04434a4')
 
 
 # Helper macros to help make tasks easier #
@@ -73,7 +75,8 @@ prepare() {
     0001-Disable-response-files-for-MSYS-Generator.patch \
     0002-Do-not-install-Qt-bundle-in-cmake-gui.patch \
     0004-Output-line-numbers-in-callstacks.patch \
-    35d3e00e4e9b138dec1d1a646766fc342d04b8f5.patch
+    35d3e00e4e9b138dec1d1a646766fc342d04b8f5.patch \
+    f90d15458a9a98180fcc95158f2ab5d2b1ad3152.patch
 }
 
 build() {

--- a/mingw-w64-cmake/f90d15458a9a98180fcc95158f2ab5d2b1ad3152.patch
+++ b/mingw-w64-cmake/f90d15458a9a98180fcc95158f2ab5d2b1ad3152.patch
@@ -1,0 +1,70 @@
+From f90d15458a9a98180fcc95158f2ab5d2b1ad3152 Mon Sep 17 00:00:00 2001
+From: Christopher Degawa <ccom@randomderp.com>
+Date: Fri, 11 Jun 2021 15:38:44 -0500
+Subject: [PATCH] FindGLUT: Use pkg-config to find flags if available
+
+FindGLUT fails to properly link a static libglut as it does not list
+the dependencies needed.
+
+Signed-off-by: Christopher Degawa <ccom@randomderp.com>
+---
+ Modules/FindGLUT.cmake | 36 +++++++++++++++++++++++++++++++++++-
+ 1 file changed, 35 insertions(+), 1 deletion(-)
+
+diff --git a/Modules/FindGLUT.cmake b/Modules/FindGLUT.cmake
+index 53ff727ed2..dd0975d395 100644
+--- a/Modules/FindGLUT.cmake
++++ b/Modules/FindGLUT.cmake
+@@ -41,6 +41,41 @@ Also defined, but not for general use are:
+ #]=======================================================================]
+ 
+ include(${CMAKE_CURRENT_LIST_DIR}/SelectLibraryConfigurations.cmake)
++include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
++
++function(_add_glut_target_simple)
++  if(TARGET GLUT::GLUT)
++    return()
++  endif()
++  add_library(GLUT::GLUT INTERFACE IMPORTED)
++  if(GLUT_INCLUDE_DIRS)
++    target_include_directories(GLUT::GLUT SYSTEM
++      INTERFACE "${GLUT_INCLUDE_DIRS}")
++  endif()
++  if(GLUT_LIBRARIES)
++    target_link_libraries(GLUT::GLUT INTERFACE ${GLUT_LIBRARIES})
++  endif()
++  if(GLUT_LDFLAGS)
++    target_link_options(GLUT::GLUT INTERFACE ${GLUT_LDFLAGS})
++  endif()
++  if(GLUT_CFLAGS)
++    separate_arguments(GLUT_CFLAGS_SPLIT UNIX_COMMAND "${GLUT_CFLAGS}")
++    target_compile_options(GLUT::GLUT INTERFACE ${GLUT_CFLAGS_SPLIT})
++  endif()
++
++  set_property(TARGET GLUT::GLUT APPEND PROPERTY
++    IMPORTED_LOCATION "${GLUT_glut_LIBRARY}")
++endfunction()
++
++find_package(PkgConfig)
++if(PKG_CONFIG_FOUND)
++  pkg_check_modules(GLUT glut)
++  if(GLUT_FOUND)
++    _add_glut_target_simple()
++    FIND_PACKAGE_HANDLE_STANDARD_ARGS(GLUT REQUIRED_VARS GLUT_FOUND)
++    return()
++  endif()
++endif()
+ 
+ if(WIN32)
+   find_path( GLUT_INCLUDE_DIR NAMES GL/glut.h
+@@ -126,7 +161,6 @@ else()
+ endif()
+ mark_as_advanced(GLUT_glut_LIBRARY)
+ 
+-include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
+ FIND_PACKAGE_HANDLE_STANDARD_ARGS(GLUT REQUIRED_VARS GLUT_glut_LIBRARY GLUT_INCLUDE_DIR)
+ 
+ if (GLUT_FOUND)
+-- 
+GitLab
+


### PR DESCRIPTION
Merged upstream already, so it will probably be dropped in 3.22