### PR TITLE
GTK 2/3: Fix keyboard input when using IMEs

### DIFF
--- a/mingw-w64-gtk2/0023-gdkkeys-win32.c-fix-initialisation-of-key_state-in-u.patch
+++ b/mingw-w64-gtk2/0023-gdkkeys-win32.c-fix-initialisation-of-key_state-in-u.patch
@@ -1,0 +1,28 @@
+From c9753b78854a188ffeeced8fd997e6e5ff7fde70 Mon Sep 17 00:00:00 2001
+From: Jeremy Tan <jtanx@outlook.com>
+Date: Fri, 9 Jul 2021 12:35:44 +0800
+Subject: [PATCH] gdkkeys-win32.c: fix initialisation of key_state in
+ update_keymap
+
+It apparently worked by chance in the past, but now causes e.g.
+alphanumeric characters to be interpreted as half-width katakana
+when using the Japanese IME.
+---
+ gdk/win32/gdkkeys-win32.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/gdk/win32/gdkkeys-win32.c b/gdk/win32/gdkkeys-win32.c
+index 1dcc0f67e6..6f9573d683 100644
+--- a/gdk/win32/gdkkeys-win32.c
++++ b/gdk/win32/gdkkeys-win32.c
+@@ -692,6 +692,7 @@ update_keymap (GdkKeymap *gdk_keymap)
+   if (hkls_len != keymap->layout_handles->len)
+     keymap->keysym_tab = g_renew (guint, keymap->keysym_tab, keysym_tab_size);
+ 
++  memset (key_state, 0, sizeof(key_state));
+   memset (keymap->keysym_tab, 0, keysym_tab_size);
+   g_array_set_size (keymap->layout_handles, hkls_len);
+   g_array_set_size (keymap->options, hkls_len);
+-- 
+2.32.0
+

--- a/mingw-w64-gtk2/PKGBUILD
+++ b/mingw-w64-gtk2/PKGBUILD
@@ -5,7 +5,7 @@ _realname=gtk2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.24.33
-pkgrel=2
+pkgrel=3
 pkgdesc="GTK+ is a multi-platform toolkit (v2) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -42,7 +42,8 @@ source=("https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}.tar
         0011-gir-for-gdkwin32.mingw.patch
         0012-embed-manifest.all.patch
         0013_fix_mouse_events.patch
-        0022-icontheme-win32-detect-SVG-files-by-extension.patch)
+        0022-icontheme-win32-detect-SVG-files-by-extension.patch
+        0023-gdkkeys-win32.c-fix-initialisation-of-key_state-in-u.patch)
 
 sha256sums=('ac2ac757f5942d318a311a54b0c80b5ef295f299c2a73c632f6bfb1ff49cc6da'
             'b77a427df55a14182c10ad7e683b4d662df2846fcd38df2aa8918159d6be3ae2'
@@ -55,7 +56,8 @@ sha256sums=('ac2ac757f5942d318a311a54b0c80b5ef295f299c2a73c632f6bfb1ff49cc6da'
             '10569e2bc2afe6ab320dcb4b0e708ddd8235244ec0daff05ca518cb8463f2924'
             '4bc70de68084585dcf2b5a7e4abe32a789360fc2be97a9c94ba3b52dac89ad93'
             'f6d731acecf6e35e4ec9739a6d949d2d045c9396c4564283ee6ec935ec690e24'
-            'b0f18b85d2fd47057c266887848be1f1c0b6171a1ee6d52a33df7af6e0abb8b0')
+            'b0f18b85d2fd47057c266887848be1f1c0b6171a1ee6d52a33df7af6e0abb8b0'
+            '68f9c7ea1a548a5d700aa4ad17bb961815ad59cc8d05fc1af156ef680da24a15')
 
 prepare() {
   cd gtk+-${pkgver}
@@ -69,6 +71,9 @@ prepare() {
   #patch -p1 -i ${srcdir}/0012-embed-manifest.all.patch
   patch -p1 -i ${srcdir}/0013_fix_mouse_events.patch
   patch -p1 -i ${srcdir}/0022-icontheme-win32-detect-SVG-files-by-extension.patch
+  
+  # https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/3741
+  patch -p1 -i ${srcdir}/0023-gdkkeys-win32.c-fix-initialisation-of-key_state-in-u.patch
 
   autoreconf -fi
 }

--- a/mingw-w64-gtk3/0005-gdkkeys-win32.c-fix-initialisation-of-key_state-in-u.patch
+++ b/mingw-w64-gtk3/0005-gdkkeys-win32.c-fix-initialisation-of-key_state-in-u.patch
@@ -1,0 +1,28 @@
+From 73038543106f8af8f41132f4a245056a94322c92 Mon Sep 17 00:00:00 2001
+From: Jeremy Tan <jtanx@outlook.com>
+Date: Fri, 9 Jul 2021 12:35:44 +0800
+Subject: [PATCH] gdkkeys-win32.c: fix initialisation of key_state in
+ update_keymap
+
+It apparently worked by chance in the past, but now causes e.g.
+alphanumeric characters to be interpreted as half-width katakana
+when using the Japanese IME.
+---
+ gdk/win32/gdkkeys-win32.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/gdk/win32/gdkkeys-win32.c b/gdk/win32/gdkkeys-win32.c
+index b4753e1f79..4ef8c4b102 100644
+--- a/gdk/win32/gdkkeys-win32.c
++++ b/gdk/win32/gdkkeys-win32.c
+@@ -692,6 +692,7 @@ update_keymap (GdkKeymap *gdk_keymap)
+   if (hkls_len != keymap->layout_handles->len)
+     keymap->keysym_tab = g_renew (guint, keymap->keysym_tab, keysym_tab_size);
+ 
++  memset (key_state, 0, sizeof(key_state));
+   memset (keymap->keysym_tab, 0, keysym_tab_size);
+   g_array_set_size (keymap->layout_handles, hkls_len);
+   g_array_set_size (keymap->options, hkls_len);
+-- 
+2.32.0
+

--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gtk3
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-gtk-update-icon-cache")
 pkgver=3.24.29
-pkgrel=1
+pkgrel=2
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -32,6 +32,7 @@ source=("https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}.tar
         "0002-Revert-Quartz-Set-the-popup-menu-type-hint-before-re.patch"
         "0003-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch"
         "0004-Disable-low-level-keyboard-hook.patch"
+        "0005-gdkkeys-win32.c-fix-initialisation-of-key_state-in-u.patch"
         "gtk-query-immodules-3.0.hook.in"
         "gtk-update-icon-cache.hook.in"
         "gtk-update-icon-cache.script.in")
@@ -39,6 +40,7 @@ sha256sums=('f57ec4ade8f15cab0c23a80dcaee85b876e70a8823d9105f067ce335a8268caa'
             '5cdebb11098d241da955d4662904215275fa7a54d52877cc38c4ff4a3087fafd'
             'b84a7f38f0af80680bee143d431f2a7bae53899efb337de0f67a1b4d9b59fa02'
             'e553083298495f9581ae1454b1046a22b83e81862311b30de984057eec859708'
+            'a95bc0b5f5ca4fbbe8f74bad633b9cbe9d79c7fd280be82088454ecb2c31b300'
             'adbe57eb726d882bba7a031ab8fb1788e7cd03cbf713823fd0f99d3cb380b97c'
             '56a566739c4f153f3c924b2bfe5ec7aaca469e15c023810cd7c5f57036d1a258'
             'b6306c6e117e879a60febc8e398a5a181325255a2e2c785c77222664b683f9dd')
@@ -53,6 +55,9 @@ prepare() {
   patch -p1 -i "${srcdir}"/0003-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch
 
   patch -p1 -i "${srcdir}"/0004-Disable-low-level-keyboard-hook.patch
+
+  # https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/3741
+  patch -p1 -i "${srcdir}"/0005-gdkkeys-win32.c-fix-initialisation-of-key_state-in-u.patch
 }
 
 build() {


### PR DESCRIPTION
Upstream issues: 
* https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/3741/
* https://github.com/fontforge/fontforge/issues/4577

Definitely required for GTK2, GTK3 seems to deal with IMEs differently and avoids this particular code path, but the underlying GDK calls are still affected. 

e.g. to reproduce (this is against the 32 bit mingw builds - may be relevant because behaviour is dependent on uninitialised state):

* Set keyboard layout to the Japanese IME in half-width alphanumeric/direct input mode
* Open gtk-demo (GTK2 demo)
* Open the 'Dialog and Message boxes' demo
* Type some characters in the text boxes - observe half-width katakana instead of alphanumeric input