### PR TITLE
vala: disable graphviz dependency for clang

### DIFF
--- a/mingw-w64-vala/PKGBUILD
+++ b/mingw-w64-vala/PKGBUILD
@@ -4,10 +4,10 @@ _realname=vala
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.52.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Compiler for the GObject type system (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://wiki.gnome.org/Projects/Vala"
 license=("LGPL")
 makedepends=("help2man"
@@ -17,7 +17,8 @@ makedepends=("help2man"
               $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || \
               echo "${MINGW_PACKAGE_PREFIX}-vala")) # Remove this workaround after vala available
 depends=("${MINGW_PACKAGE_PREFIX}-glib2"
-         "${MINGW_PACKAGE_PREFIX}-graphviz")
+          $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || \
+            echo "${MINGW_PACKAGE_PREFIX}-graphviz")) # Remove this workaround afer graphviz available
 source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz
         001-change-pkg-config-invocations.mingw.patch
         002-use_time_s_functions_on_windows.mingw.patch)
@@ -39,7 +40,9 @@ build() {
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
-    --enable-shared
+    --enable-shared \
+    $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] && \
+      echo "--disable-valadoc" || true) # Remove this workaround afer graphviz available
   make
 }
 


### PR DESCRIPTION
This requires disabling building valadoc.

Also enabled clang32.