### PR TITLE
gtk2: fixes for clang

### DIFF
--- a/mingw-w64-gtk2/0024-gtk-update-icon-cache-rc-quote.patch
+++ b/mingw-w64-gtk2/0024-gtk-update-icon-cache-rc-quote.patch
@@ -1,0 +1,11 @@
+--- gtk+-2.24.33/gtk/Makefile.am.orig	2021-07-10 23:22:04.765107300 -0700
++++ gtk+-2.24.33/gtk/Makefile.am	2021-07-10 23:22:27.889752400 -0700
+@@ -1128,7 +1128,7 @@
+ 	 echo '</assembly>' ) >$@
+ 
+ $(GTK_UPDATE_ICON_CACHE_RC):
+-	(echo -e '#include <winbase.h>\nCREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST '$(GTK_UPDATE_ICON_CACHE_MANIFEST)) >$@
++	(echo -e '#include <winbase.h>\nCREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "'$(GTK_UPDATE_ICON_CACHE_MANIFEST)'"') >$@
+ 
+ $(GTK_UPDATE_ICON_CACHE_MANIFEST_OBJECT): $(GTK_UPDATE_ICON_CACHE_RC) $(GTK_UPDATE_ICON_CACHE_MANIFEST)
+ 	$(WINDRES) --input $< --output $@ --output-format=coff

--- a/mingw-w64-gtk2/PKGBUILD
+++ b/mingw-w64-gtk2/PKGBUILD
@@ -5,7 +5,7 @@ _realname=gtk2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.24.33
-pkgrel=3
+pkgrel=4
 pkgdesc="GTK+ is a multi-platform toolkit (v2) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -43,7 +43,8 @@ source=("https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}.tar
         0012-embed-manifest.all.patch
         0013_fix_mouse_events.patch
         0022-icontheme-win32-detect-SVG-files-by-extension.patch
-        0023-gdkkeys-win32.c-fix-initialisation-of-key_state-in-u.patch)
+        0023-gdkkeys-win32.c-fix-initialisation-of-key_state-in-u.patch
+        0024-gtk-update-icon-cache-rc-quote.patch)
 
 sha256sums=('ac2ac757f5942d318a311a54b0c80b5ef295f299c2a73c632f6bfb1ff49cc6da'
             'b77a427df55a14182c10ad7e683b4d662df2846fcd38df2aa8918159d6be3ae2'
@@ -57,7 +58,8 @@ sha256sums=('ac2ac757f5942d318a311a54b0c80b5ef295f299c2a73c632f6bfb1ff49cc6da'
             '4bc70de68084585dcf2b5a7e4abe32a789360fc2be97a9c94ba3b52dac89ad93'
             'f6d731acecf6e35e4ec9739a6d949d2d045c9396c4564283ee6ec935ec690e24'
             'b0f18b85d2fd47057c266887848be1f1c0b6171a1ee6d52a33df7af6e0abb8b0'
-            '68f9c7ea1a548a5d700aa4ad17bb961815ad59cc8d05fc1af156ef680da24a15')
+            '68f9c7ea1a548a5d700aa4ad17bb961815ad59cc8d05fc1af156ef680da24a15'
+            '9c6e2646b22c9dc1725595dbd5fedcaa71ea85ddb5611a1bccc130a00e9e7e30')
 
 prepare() {
   cd gtk+-${pkgver}
@@ -74,6 +76,9 @@ prepare() {
   
   # https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/3741
   patch -p1 -i ${srcdir}/0023-gdkkeys-win32.c-fix-initialisation-of-key_state-in-u.patch
+
+  # https://github.com/msys2/MINGW-packages/issues/9130
+  patch -p1 -i ${srcdir}/0024-gtk-update-icon-cache-rc-quote.patch
 
   autoreconf -fi
 }
@@ -94,6 +99,7 @@ build() {
     --enable-shared \
     --enable-introspection \
     --disable-glibtest \
+    --disable-visibility \
     --with-included-immodules=ime
 
   make


### PR DESCRIPTION
- pass --disable-visibility to configure, fixes gdk linker errors
- patch gtk-update-icon-cache.rc generation to quote manifest filename

Fixes #8493 - it built locally, 🤞 for clang32 when it gets enabled.