### PR TITLE
gcab/gtk-vnc/libgusb: depend on libssp

### DIFF
--- a/mingw-w64-gcab/PKGBUILD
+++ b/mingw-w64-gcab/PKGBUILD
@@ -4,12 +4,13 @@ _realname=gcab
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.4
-pkgrel=1
+pkgrel=2
 pkgdesc="A GObject library to create cabinet files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 url='https://wiki.gnome.org/msitools'
 license=('LGPL')
+depends=("${MINGW_PACKAGE_PREFIX}-libssp")
 makedepends=("${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-vala"

--- a/mingw-w64-gtk-vnc/PKGBUILD
+++ b/mingw-w64-gtk-vnc/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gtk-vnc
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.2.0
-pkgrel=2
+pkgrel=3
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 pkgdesc="VNC viewer widget for GTK+ (mingw-w64)"
@@ -14,6 +14,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-cyrus-sasl"
          "${MINGW_PACKAGE_PREFIX}-gtk3"
          "${MINGW_PACKAGE_PREFIX}-libgcrypt"
          "${MINGW_PACKAGE_PREFIX}-libgpg-error"
+         "${MINGW_PACKAGE_PREFIX}-libssp"
          "${MINGW_PACKAGE_PREFIX}-libview"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"

--- a/mingw-w64-libgusb/PKGBUILD
+++ b/mingw-w64-libgusb/PKGBUILD
@@ -4,11 +4,12 @@ _realname=libgusb
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.3.6
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 pkgdesc="GLib wrapper around libusb1 (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-libusb"
+         "${MINGW_PACKAGE_PREFIX}-libssp"
          "${MINGW_PACKAGE_PREFIX}-glib2")
 makedepends=("${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-meson"
@@ -21,15 +22,18 @@ license=("LGPL")
 url="https://github.com/hughsie/libgusb"
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/hughsie/${_realname}/archive/${pkgver}.tar.gz"
         fix-build.patch
-        introspection-optional.patch)
+        introspection-optional.patch
+        windows-lld-no-version-script.patch)
 sha256sums=('b81b4587243beaafd304fec6047cb803b47f5df382911d4f722ffcfe7239bd59'
             'a3f23ea5e84d6c369492526670d38f0fb77d57a9e93df20d143d079dc6c2cbb8'
-            '0b59e9915d2e8a64d1aee378ac925c6bdbfc45b1960a6f6e9d3843a447c27c85')
+            '0b59e9915d2e8a64d1aee378ac925c6bdbfc45b1960a6f6e9d3843a447c27c85'
+            '5d97cfbecae68849d9d2af889af43748e9d3ded1e8eaf8e3eb1068aeb9059f0b')
 
 prepare() {
   cd ${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/fix-build.patch
   patch -p1 -i ${srcdir}/introspection-optional.patch
+  patch -p1 -i ${srcdir}/windows-lld-no-version-script.patch
 }
 
 build() {

--- a/mingw-w64-libgusb/windows-lld-no-version-script.patch
+++ b/mingw-w64-libgusb/windows-lld-no-version-script.patch
@@ -1,0 +1,11 @@
+--- libgusb-0.3.6/gusb/meson.build.orig	2021-07-11 15:05:09.764745600 -0700
++++ libgusb-0.3.6/gusb/meson.build	2021-07-11 15:07:34.171435400 -0700
+@@ -44,7 +44,7 @@
+ 
+ mapfile = 'libgusb.ver'
+ vflag = []
+-if host_machine.system() not in ['darwin']
++if host_machine.system() not in ['darwin'] and (host_machine.system() != 'windows' or meson.get_compiler('c').get_linker_id() != 'ld.lld')
+   vflag += '-Wl,--version-script,@0@/@1@'.format(meson.current_source_dir(), mapfile)
+ endif
+ gusb = library(


### PR DESCRIPTION
Also, libgusb had a version script option that needed disabling.  Meson seems to expose some useful information so only disabled when on Windows and linker is ld.lld.  Note that my patch adds a meson warning:
```
  WARNING: Project specifies a minimum meson_version '>=0.46.0' but uses features which were added in newer versions:
   * 0.53.0: {'compiler.get_linker_id'}
```

It appears libgusb uses a python script (distributed with meson?) to generate its version script, so it should be possible to make it generate a def file too if someone were so inclined.