### PR TITLE
CI: don't run on master branch on any fork.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    if: ${{ github.repository != 'msys2/MINGW-packages' || github.event_name != 'push' || github.ref != 'refs/heads/master'}}
+    if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master'}}
     runs-on: windows-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
Per discussion on discord, most use their master branch to mirror
upstream, and do not need CI to run when they sync.