### PR TITLE
fftw: enable sse2 for clang32

### DIFF
--- a/mingw-w64-fftw/PKGBUILD
+++ b/mingw-w64-fftw/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _pkgver=3.3.9
 pkgver=${_pkgver//-/.}
-pkgrel=2
+pkgrel=3
 pkgdesc="A library for computing the discrete Fourier transform (DFT) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -22,6 +22,9 @@ precision="double float long_double \
 
 build() {
   cd "${srcdir}/${_realname}-${_pkgver}"
+  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-i686* ]]; then
+    CFLAGS+=" -msse2"
+  fi
   for cur in ${precision}; do
     local _config="--enable-sse2 --enable-avx"
     if [ "${cur}" = "float" ]; then

--- a/mingw-w64-fftw/PKGBUILD
+++ b/mingw-w64-fftw/PKGBUILD
@@ -22,6 +22,7 @@ precision="double float long_double \
 
 build() {
   cd "${srcdir}/${_realname}-${_pkgver}"
+  # clang complains when trying to use an sse2 intrinsic if sse2 is not enabled
   if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-i686* ]]; then
     CFLAGS+=" -msse2"
   fi


### PR DESCRIPTION
Clang complains when trying to use sse2 intrinsics when sse2 is not enabled (like on -march=i686, aka pentium pro).

I don't know what other effects this might have, so I only did this on clang32, and I'm guessing there aren't too many non-sse2 machines running around to be bothered if this makes the whole library unable to run on them.