### PR TITLE
postgresql: fix clang build

### DIFF
--- a/mingw-w64-postgresql/PKGBUILD
+++ b/mingw-w64-postgresql/PKGBUILD
@@ -4,10 +4,10 @@ _realname=postgresql
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=13.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Libraries for use with PostgreSQL (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://www.postgresql.org/"
 license=('custom:PostgreSQL')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
@@ -28,13 +28,20 @@ source=("https://ftp.postgresql.org/pub/source/v${pkgver}/postgresql-${pkgver}.t
         postgresql-9.5.1-pl-perl.patch
         postgresql-9.5.1-pl-python.patch
         postgresql-9.4.1-pl-tcl.patch
-        postgresql-9.4.1-mingw-enable-readline.patch)
+        postgresql-9.4.1-mingw-enable-readline.patch
+        postgresql-13.1-disable-wsa-invalid-event-static-assert.patch
+        postgresql-13.1-Wl-stack.patch
+        postgresql-13.1-pgevent-def.patch)
+
 sha256sums=('12345c83b89aa29808568977f5200d6da00f88a035517f925293355432ffe61f'
             '607217b422349770d25af20f88e4a7925e68bb934232dff368c2ee59f24249a4'
             '57c1e9b75c042af591b05b9dda60e6327b5c364bb5adc2675da8a48b47e11b81'
             '1afbe207b0fe8c4178cc3f8cb4e3923c7c000207d22ec4f3875d6358b312a1d5'
             'ab9c42374b4e8a01b598810b19b583d9ee7bf5c43c39c019f66b62aacac38926'
-            '51c72fbd380d23cf944165405221912a277b9be99e285479772b39cacbbf384f')
+            '51c72fbd380d23cf944165405221912a277b9be99e285479772b39cacbbf384f'
+            '72c14a78eeafdd3c9a13c3e124b1941b5da090488c7bd73f08b3cd78bacd07d5'
+            'c7edaff8e6cc012d6f29c91fd4c9356e8b2c1313fdd398bb6302f8f271c45426'
+            'ffaecbe5a38877728bddbf307b379b39c645dd1ffe53aa8d84dfa96807494764')
 
 prepare() {
   cd ${srcdir}/postgresql-${pkgver}
@@ -43,6 +50,9 @@ prepare() {
   patch -p1 -i ${srcdir}/postgresql-9.5.1-pl-python.patch
   patch -p1 -i ${srcdir}/postgresql-9.4.1-pl-tcl.patch
   #patch -p1 -i ${srcdir}/postgresql-9.4.1-mingw-enable-readline.patch
+  patch -p1 -i ${srcdir}/postgresql-13.1-disable-wsa-invalid-event-static-assert.patch
+  patch -p1 -i ${srcdir}/postgresql-13.1-Wl-stack.patch
+  patch -p1 -i ${srcdir}/postgresql-13.1-pgevent-def.patch
 
   sed -s "s|2\\.69|2\\.71|g" -i configure.in
   autoreconf -fiv
@@ -50,6 +60,11 @@ prepare() {
 
 build() {
   [[ -d "${srcdir}/build-${CARCH}" ]] && rm -rf "${srcdir}/build-${CARCH}"
+  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-i686* ]]; then
+    # clang on i686 without sse2 is not supported by postgresql
+    # https://www.postgresql.org/message-id/20180904221627.r4c3gp4pimzz4hyp%40alap3.anarazel.de
+    CFLAGS+=" -msse2"
+  fi
   mkdir -p "${srcdir}/build-${CARCH}" && cd "${srcdir}/build-${CARCH}"
   export PYTHON=${MINGW_PREFIX}/bin/python
   ../postgresql-${pkgver}/configure \
@@ -75,6 +90,11 @@ build() {
   #  make -C ${dir}
   #done
   make
+}
+
+check() {
+  cd "${srcdir}/build-${CARCH}"
+  make check || true
 }
 
 package() {

--- a/mingw-w64-postgresql/postgresql-13.1-Wl-stack.patch
+++ b/mingw-w64-postgresql/postgresql-13.1-Wl-stack.patch
@@ -1,0 +1,11 @@
+--- postgresql-13.1/src/backend/Makefile.orig	2021-07-17 14:36:59.770624700 -0700
++++ postgresql-13.1/src/backend/Makefile	2021-07-17 14:37:26.364523200 -0700
+@@ -85,7 +85,7 @@
+ LIBS += -lsecur32
+ 
+ postgres: $(OBJS) $(WIN32RES)
+-	$(CC) $(CFLAGS) $(call expand_subsys,$(OBJS)) $(WIN32RES) $(LDFLAGS) $(LDFLAGS_EX) -Wl,--stack=$(WIN32_STACK_RLIMIT) -Wl,--export-all-symbols -Wl,--out-implib=libpostgres.dll.a $(LIBS) -o $@$(X)
++	$(CC) $(CFLAGS) $(call expand_subsys,$(OBJS)) $(WIN32RES) $(LDFLAGS) $(LDFLAGS_EX) -Wl,--stack,$(WIN32_STACK_RLIMIT) -Wl,--export-all-symbols -Wl,--out-implib=libpostgres.dll.a $(LIBS) -o $@$(X)
+ 
+ # libpostgres.a is actually built in the preceding rule, but we need this to
+ # ensure it's newer than postgres; see notes in src/backend/parser/Makefile

--- a/mingw-w64-postgresql/postgresql-13.1-disable-wsa-invalid-event-static-assert.patch
+++ b/mingw-w64-postgresql/postgresql-13.1-disable-wsa-invalid-event-static-assert.patch
@@ -1,0 +1,11 @@
+--- postgresql-13.1/src/backend/storage/ipc/latch.c.orig	2021-07-17 14:09:21.786258600 -0700
++++ postgresql-13.1/src/backend/storage/ipc/latch.c	2021-07-17 14:10:01.364376500 -0700
+@@ -677,7 +677,7 @@
+ 	 * pending signals are serviced.
+ 	 */
+ 	set->handles[0] = pgwin32_signal_event;
+-	StaticAssertStmt(WSA_INVALID_EVENT == NULL, "");
++	/*StaticAssertStmt(WSA_INVALID_EVENT == NULL, "");*/
+ #endif
+ 
+ 	return set;

--- a/mingw-w64-postgresql/postgresql-13.1-pgevent-def.patch
+++ b/mingw-w64-postgresql/postgresql-13.1-pgevent-def.patch
@@ -1,0 +1,12 @@
+--- postgresql-13.1/src/bin/pgevent/Makefile.orig	2021-07-18 16:38:12.660763100 -0700
++++ postgresql-13.1/src/bin/pgevent/Makefile	2021-07-18 16:38:41.035766900 -0700
+@@ -29,6 +29,9 @@
+ 
+ include $(top_srcdir)/src/Makefile.shlib
+ 
++libpgeventdll.def: pgevent.def
++	cp -f $< $@
++
+ pgmsgevent.o: pgmsgevent.rc win32ver.rc
+ 	$(WINDRES) $< -o $@ --include-dir=$(top_builddir)/src/include --include-dir=$(top_srcdir)/src/include --include-dir=$(srcdir) --include-dir=.
+ 


### PR DESCRIPTION
use `-Wl,--stack,` instead of `-Wl,--stack=`

comment out static assert on `WSA_INVALID_EVENT` that clang thought was not a compile-time constant.

copy pre-packaged pgevent.def instead of using the (broken) auto-generated version (see 
https://github.com/postgres/postgres/blob/64a1f225654f8866422010ff28e0d3384ae4c3af/src/bin/pgevent/README#L15-L18)