### PR TITLE
Update ghdl, yosys, prjtrellis, nextpnr, iverilog, scopehal-apps and ecpprog

### DIFF
--- a/mingw-w64-ecpprog/PKGBUILD
+++ b/mingw-w64-ecpprog/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=ecpprog
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.0.r29.d654a4d
-pkgrel=2
+pkgver=0.0.r34.83fff6f
+pkgrel=1
 pkgdesc="ecpprog: basic driver for FTDI based JTAG probes, to program ECP5 FPGAs (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -12,10 +12,12 @@ url="https://github.com/gregdavill/ecpprog"
 license=('ISC')
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
 depends=("${MINGW_PACKAGE_PREFIX}-libftdi")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
-             "git")
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-gcc"
+  "git"
+)
 
-_commit="d654a4d"
+_commit="83fff6f4"
 source=("ecpprog::git://github.com/gregdavill/ecpprog#commit=${_commit}")
 sha256sums=('SKIP')
 

--- a/mingw-w64-ghdl/PKGBUILD
+++ b/mingw-w64-ghdl/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=ghdl
 pkgbase="mingw-w64-${_realname}"
 pkgname='__placeholder__'
-pkgver=1.0.0.r348.g7d5c6c48
+pkgver=1.0.0.r517.g9262a810
 pkgrel=1
 pkgdesc='GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL'
 arch=('any')
@@ -11,7 +11,7 @@ url='https://github.com/ghdl'
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-source=("${_realname}::git://github.com/ghdl/ghdl.git#commit=7d5c6c48")
+source=("${_realname}::git://github.com/ghdl/ghdl.git#commit=9262a810")
 sha512sums=('SKIP')
 
 pkgver() {

--- a/mingw-w64-iverilog/PKGBUILD
+++ b/mingw-w64-iverilog/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=iverilog
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=11.0.r8897.d8cb29f6
+pkgver=11.0.r8912.6b127432
 pkgrel=1
 epoch=1
 pkgdesc="Icarus Verilog, is a Verilog simulation and synthesis tool (mingw-w64)"
@@ -21,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 
 # NOTE: MSYS2 support was improved/fixed in 'master' (2020/12/04).
 # When 12.0 is tagged/released, this should be changed to use a tarball instead.
-_commit="d8cb29f6"
+_commit="6b127432"
 source=("${_realname}::git://github.com/steveicarus/iverilog.git#commit=${_commit}")
 sha256sums=('SKIP')
 

--- a/mingw-w64-nextpnr/PKGBUILD
+++ b/mingw-w64-nextpnr/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=nextpnr
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.0.r3600.9df05c4f
+pkgver=0.0.r3694.c6aa51a2
 pkgrel=1
 pkgdesc="Portable FPGA place and route tool (mingw-w64)"
 arch=('any')
@@ -29,7 +29,7 @@ makedepends=(
   "git"
 )
 
-_commit="9df05c4f"
+_commit="c6aa51a2"
 source=("${_realname}::git://github.com/YosysHQ/${_realname}.git#commit=${_commit}")
 sha256sums=('SKIP')
 

--- a/mingw-w64-prjtrellis/PKGBUILD
+++ b/mingw-w64-prjtrellis/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=prjtrellis
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.0.r1002.0e6a320
-pkgrel=2
+pkgver=1.0.r1025.dff1cbc
+pkgrel=1
 pkgdesc="Documenting the Lattice ECP5 bit-stream format (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-boost"
              "${MINGW_PACKAGE_PREFIX}-clang"
              "git")
 
-_commit="0e6a3204"
+_commit="dff1cbcb"
 source=("${_realname}::git://github.com/YosysHQ/${_realname}.git#commit=${_commit}"
         "prjtrellis-db::git://github.com/YosysHQ/prjtrellis-db")
 sha256sums=('SKIP'

--- a/mingw-w64-scopehal-apps/PKGBUILD
+++ b/mingw-w64-scopehal-apps/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=scopehal-apps
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.0.0.r1213.g5855e49
+pkgver=0.0.0.r1264.gdcc6550
 pkgrel=1
 pkgdesc="scopehal-apps: applications for libscopehal (mingw-w64)"
 arch=('any')
@@ -25,7 +25,7 @@ makedepends=(
   "make"
 )
 
-source=("${_realname}::git://github.com/azonenberg/scopehal-apps.git#commit=5855e493")
+source=("${_realname}::git://github.com/azonenberg/scopehal-apps.git#commit=dcc65508")
 sha256sums=('SKIP')
 
 pkgver() {

--- a/mingw-w64-yosys/PKGBUILD
+++ b/mingw-w64-yosys/PKGBUILD
@@ -1,8 +1,8 @@
 _realname=yosys
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.9.r10805.c6681508f
-pkgrel=2
+pkgver=0.9.r10855.9af88951b
+pkgrel=1
 pkgdesc="A framework for RTL synthesis tools (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -21,7 +21,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python"
 )
 
-_commit='c6681508'
+_commit='9af88951'
 source=(
   "${_realname}::git://github.com/YosysHQ/${_realname}.git#commit=${_commit}"
   "ghdl-yosys-plugin::git://github.com/ghdl/ghdl-yosys-plugin.git#commit=98f4594b"


### PR DESCRIPTION
This PR updates several EDA packages at once.

I believe this is an interesting PR for triggering a corner case in CI:

MINGW64 is the only environment where all the tools can be built. Almost all of them are available on MINGW32. However, due to the order, yosys is not tested/built on MINGW32. Precisely, scopehal-apps is built before yosys, but it fails on MINGW32. Since yosys does not depend on scopehal-apps, it should be built regardless of the other one failing.

Similarly, on UCRT64, ghdl fails so all the packages scheduled after it are not tested/built.

I believe these issues are not relevant for the autobuilder, so this PR can be merged.

@Biswa96 with regard to msys2/MINGW-packages#8956, this is a practical example of why it might be desirable to bump packages one-by-one.