### PR TITLE
numpy: fix clang build

### DIFF
--- a/mingw-w64-python-numpy/0011-dont-die-if-no-fcompiler.patch
+++ b/mingw-w64-python-numpy/0011-dont-die-if-no-fcompiler.patch
@@ -1,0 +1,41 @@
+--- numpy-1.21.0/numpy/distutils/fcompiler/__init__.py.orig	2021-07-22 19:42:37.638429800 -0700
++++ numpy-1.21.0/numpy/distutils/fcompiler/__init__.py	2021-07-22 19:42:43.012362300 -0700
+@@ -797,21 +797,23 @@
+         try:
+             c = new_fcompiler(plat=platform, compiler=compiler_type,
+                               c_compiler=c_compiler)
+-            c.customize(dist)
+-            v = c.get_version()
+-            if requiref90 and c.compiler_f90 is None:
+-                v = None
+-                new_compiler = c.suggested_f90_compiler
+-                if new_compiler:
+-                    log.warn('Trying %r compiler as suggested by %r '
+-                             'compiler for f90 support.' % (compiler_type,
+-                                                            new_compiler))
+-                    c = new_fcompiler(plat=platform, compiler=new_compiler,
+-                                      c_compiler=c_compiler)
+-                    c.customize(dist)
+-                    v = c.get_version()
+-                    if v is not None:
+-                        compiler_type = new_compiler
++            if c is not None:
++                c.customize(dist)
++                v = c.get_version()
++                if requiref90 and c.compiler_f90 is None:
++                    v = None
++                    new_compiler = c.suggested_f90_compiler
++                    if new_compiler:
++                        log.warn('Trying %r compiler as suggested by %r '
++                                 'compiler for f90 support.' % (compiler_type,
++                                                                new_compiler))
++                        c = new_fcompiler(plat=platform, compiler=new_compiler,
++                                          c_compiler=c_compiler)
++                        if c is not None:
++                            c.customize(dist)
++                            v = c.get_version()
++                            if v is not None:
++                                compiler_type = new_compiler
+             if requiref90 and c.compiler_f90 is None:
+                 raise ValueError('%s does not support compiling f90 codes, '
+                                  'skipping.' % (c.__class__.__name__))

--- a/mingw-w64-python-numpy/0012-clang-no-gcc-workaround.patch
+++ b/mingw-w64-python-numpy/0012-clang-no-gcc-workaround.patch
@@ -1,0 +1,58 @@
+--- numpy-1.21.0/numpy/distutils/command/autodist.py.orig	2021-07-22 19:58:29.268697600 -0700
++++ numpy-1.21.0/numpy/distutils/command/autodist.py	2021-07-22 19:59:01.473946900 -0700
+@@ -62,6 +62,22 @@
+         """)
+     return cmd.try_compile(body, None, None)
+ 
++def check_compiler_clang(cmd):
++    """Check if the compiler is Clang."""
++
++    cmd._check_compiler()
++    body = textwrap.dedent("""
++        int
++        main()
++        {
++        #if (! defined __clang__)
++        #error clang required
++        #endif
++            return 0;
++        }
++        """)
++    return cmd.try_compile(body, None, None)
++
+ 
+ def check_gcc_version_at_least(cmd, major, minor=0, patchlevel=0):
+     """
+--- numpy-1.21.0/numpy/distutils/command/config.py.orig	2021-07-22 19:59:38.526117300 -0700
++++ numpy-1.21.0/numpy/distutils/command/config.py	2021-07-22 20:01:07.256382700 -0700
+@@ -23,7 +23,8 @@
+                                               check_gcc_version_at_least,
+                                               check_inline,
+                                               check_restrict,
+-                                              check_compiler_gcc)
++                                              check_compiler_gcc,
++                                              check_compiler_clang)
+ 
+ LANG_EXT['f77'] = '.f'
+ LANG_EXT['f90'] = '.f90'
+@@ -422,6 +423,10 @@
+         """Return True if the C compiler is gcc"""
+         return check_compiler_gcc(self)
+ 
++    def check_compiler_clang(self):
++        """Return True if the C compiler is clang"""
++        return check_compiler_clang(self)
++
+     def check_gcc_function_attribute(self, attribute, name):
+         return check_gcc_function_attribute(self, attribute, name)
+ 
+--- numpy-1.21.0/numpy/core/setup.py.orig	2021-06-18 14:49:32.241745700 -0700
++++ numpy-1.21.0/numpy/core/setup.py	2021-07-22 20:01:28.394050600 -0700
+@@ -172,6 +172,7 @@
+                 # support on Windows-based platforms
+                 if (sys.platform in ('win32', 'cygwin') and
+                         config.check_compiler_gcc() and
++                        not config.check_compiler_clang() and
+                         not config.check_gcc_version_at_least(8, 4)):
+                     ext.extra_compile_args.extend(
+                             ['-ffixed-xmm%s' % n for n in range(16, 32)])

--- a/mingw-w64-python-numpy/PKGBUILD
+++ b/mingw-w64-python-numpy/PKGBUILD
@@ -9,19 +9,20 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=1.21.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Scientific tools for Python (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 license=('BSD')
 url="https://www.numpy.org/"
 makedepends=("${MINGW_PACKAGE_PREFIX}-cython"
-             "${MINGW_PACKAGE_PREFIX}-openblas"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python-pytest"
-             "${MINGW_PACKAGE_PREFIX}-gcc-fortran")
-depends=("${MINGW_PACKAGE_PREFIX}-openblas"
-         "${MINGW_PACKAGE_PREFIX}-python")
+             $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || \
+               echo "${MINGW_PACKAGE_PREFIX}-gcc-fortran"))
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || \
+           echo "${MINGW_PACKAGE_PREFIX}-openblas"))
 optdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest: testsuite")
 #options=('!strip' 'debug')
 source=(https://github.com/numpy/numpy/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz 
@@ -34,7 +35,9 @@ source=(https://github.com/numpy/numpy/releases/download/v${pkgver}/${_realname}
         0007-disable-64bit-experimental-warning.patch
         0008-mingw-gcc-doesnt-support-visibility.patch
         0009-disable-old-mingw-stuff.patch
-        0010-mingw-inline-stuff.patch)
+        0010-mingw-inline-stuff.patch
+        0011-dont-die-if-no-fcompiler.patch
+        0012-clang-no-gcc-workaround.patch)
 sha256sums=('b662c841b29848c04d9134f31dbaa7d4c8e673f45bb3a5f28d02f49c424d558a'
             '94f111ab238c4a82e8613ed14e4cbeb553eabff26523f576e5fcafdbfdc8ee29'
             '3aacb1d92e7764c9f0f24afa1a97b136a069fcd81d63c9fa55565c40c5a29974'
@@ -45,7 +48,9 @@ sha256sums=('b662c841b29848c04d9134f31dbaa7d4c8e673f45bb3a5f28d02f49c424d558a'
             'cafc924fd11d8653a49970d0cce5b31869cce0e8996a3ae57bcbccca96bc8eb3'
             'c7222c3cd85ff6af515514c5c3b8f3c02144c58c1373dec16683fa455504aa69'
             '22ca44e7f5d01b2bcb805251f5964026e92c55400d4c17055e10268bdc93849e'
-            'ffa3eb1b65ffeb1aece369e2e3e56092013c0a0b64c67e6166cece622e526ff3')
+            'ffa3eb1b65ffeb1aece369e2e3e56092013c0a0b64c67e6166cece622e526ff3'
+            '87bdd0a47a8662bdb8acaca18452901ee1f42cf08b985443ffb214f7facfdb2d'
+            '86eceee1ec86934d416c52fe8197c09c644b9f27ab93454a849e065b1ddac12f')
 
 prepare() {
   cd ${_realname}-${pkgver}
@@ -61,6 +66,8 @@ prepare() {
   patch -Np1 -i ${srcdir}/0008-mingw-gcc-doesnt-support-visibility.patch
   patch -Np1 -i ${srcdir}/0009-disable-old-mingw-stuff.patch
   patch -Np1 -i ${srcdir}/0010-mingw-inline-stuff.patch
+  patch -Np1 -i ${srcdir}/0011-dont-die-if-no-fcompiler.patch
+  patch -Np1 -i ${srcdir}/0012-clang-no-gcc-workaround.patch
   cd ..
 
   cp -a ${_realname}-${pkgver} ${_realname}-py-${CARCH}
@@ -72,9 +79,14 @@ build() {
   # See: https://sourceforge.net/p/mingw-w64/mailman/message/36287627/
   export CFLAGS="$CFLAGS -fno-asynchronous-unwind-tables"
 
+  local _fortran_config=""
+  if [[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]]; then
+    _fortran_config="config_fc --fcompiler=gnu95"
+  fi
+
   cd ${_realname}-py-${CARCH}
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-    ${MINGW_PREFIX}/bin/python setup.py config_fc --fcompiler=gnu95 build
+    ${MINGW_PREFIX}/bin/python setup.py ${_fortran_config} build
 }
 
 package() {
@@ -85,9 +97,14 @@ package() {
   export LDFLAGS="$LDFLAGS -shared"
   export CFLAGS="$CFLAGS -fno-asynchronous-unwind-tables"
 
+  local _fortran_config=""
+  if [[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]]; then
+    _fortran_config="config_fc --fcompiler=gnu95"
+  fi
+
   cd ${_realname}-py-${CARCH}
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-    ${MINGW_PREFIX}/bin/python setup.py config_fc --fcompiler=gnu95 install --prefix=${MINGW_PREFIX} --root="${pkgdir}" --optimize=1
+    ${MINGW_PREFIX}/bin/python setup.py ${_fortran_config} install --prefix=${MINGW_PREFIX} --root="${pkgdir}" --skip-build --optimize=1
 
   install -Dm644 LICENSE.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE.txt
 


### PR DESCRIPTION
Disable BLAS and fortran.  Numpy states both are optional to build, but had an issue in their build scripts if fortran wasn't found.

Add an explicit clang check to a GCC bug workaround for GCC < 8.4, because clang pretends to be a really old GCC version (like 4.x).

We could conceivably use a different BLAS library, if there's a compatible one that doesn't require fortran, but I'm not familiar with them.