### PR TITLE
numpy: remove --skip-build from install step

### DIFF
--- a/mingw-w64-python-numpy/PKGBUILD
+++ b/mingw-w64-python-numpy/PKGBUILD
@@ -9,7 +9,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=1.21.0
-pkgrel=3
+pkgrel=4
 pkgdesc="Scientific tools for Python (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -104,7 +104,7 @@ package() {
 
   cd ${_realname}-py-${CARCH}
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-    ${MINGW_PREFIX}/bin/python setup.py ${_fortran_config} install --prefix=${MINGW_PREFIX} --root="${pkgdir}" --skip-build --optimize=1
+    ${MINGW_PREFIX}/bin/python setup.py ${_fortran_config} install --prefix=${MINGW_PREFIX} --root="${pkgdir}" --optimize=1
 
   install -Dm644 LICENSE.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE.txt
 


### PR DESCRIPTION
The install was missing a few files, including `_numpyconfig.h`.  This is the only thing I can think of that could have caused it.

This does indeed seem to restore the missing files.  Sorry for the breakage, should have paid more attention to the files diff 🤦 