### PR TITLE
perl-win32-api: fix build with clang

### DIFF
--- a/mingw-w64-perl-win32-api/0001-clang-as-defines.patch
+++ b/mingw-w64-perl-win32-api/0001-clang-as-defines.patch
@@ -1,0 +1,28 @@
+--- Win32-API-0.84/Makefile.PL.orig	2021-07-23 20:34:20.860696500 -0700
++++ Win32-API-0.84/Makefile.PL	2021-07-23 20:35:16.879090500 -0700
+@@ -14,6 +14,7 @@
+ 
+ my $is_64bit_build = ($Config{ptrsize} == 8);
+ my $is_msvc_compiler = ($Config{cc} =~ /cl/);
++my $is_gcc_clang = ($Config{ccname} eq "gcc" && join('', `$Config{cc} --version`)=~/clang version/);
+ 
+ #maybe this CC will banned in the future due to SEGV in DllMain
+ #die "Mingw 3.4.5 will generate unloadble DLLs, upgrade your GCC"
+@@ -134,7 +135,7 @@
+ 	'.($is_64bit_build ? 'ml64' : 'ml').' $(ASFLAGS) $(PERL_DEFINES)  -c $<
+ 
+ .s$(OBJ_EXT):
+-	$(AS) $(ASFLAGS) $(PERL_DEFINES) $< -o $*$(OBJ_EXT)
++	$(AS) $(ASFLAGS) $(PERL_DEFINES) '.($is_gcc_clang ? '-c ' : '').'$< -o $*$(OBJ_EXT)
+ 
+ #target unused
+ #make GCC issue "push" instructions rather than "mov" to esp+offset, this is the magic
+@@ -200,7 +201,7 @@
+     return $dlib.'PERL_DEFINES = '.(@defs?'-D':'').join(' -D', @defs)."\n" if $is_msvc_compiler;
+ #convert -DFOO into GNU AS compatible defines for GNU AS macros
+     my $defs = '';
+-    $defs .= '-defsym '.$_.'=1 ' foreach @defs;
++    $defs .= ($is_gcc_clang?'-Wa,':'').'-defsym'.($is_gcc_clang?',':' ').$_.'=1 ' foreach @defs;
+     return $dlib.'PERL_DEFINES = '.$defs."\n";
+ }
+ 

--- a/mingw-w64-perl-win32-api/PKGBUILD
+++ b/mingw-w64-perl-win32-api/PKGBUILD
@@ -5,7 +5,7 @@ _realname="${_perlname,,}"
 pkgbase=mingw-w64-perl-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-perl-${_realname}")
 pkgver=0.84
-pkgrel=3
+pkgrel=4
 pkgdesc="Perl Win32 API Import Facility (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -22,9 +22,16 @@ license=('perl_5')
 source=(
   "https://cpan.metacpan.org/authors/id/B/BU/BULKDD/Win32/${_perlname}-${pkgver}.tar.gz"
   "patchmakefile.py"
+  "0001-clang-as-defines.patch"
 )
 sha512sums=('61ca8bce67fa9d012668f5b658ea2a777d4643c160edfd106fae431181c877be041c0bffa7ce0b89f06e5e817f6dec1cf790ab6ca94d22d767f870c83519c935'
-            'd7ec5ba4a3d75f674f4028e8a53bc4177ab71a379bc63affebf910e1d5a0e491b6642318218b55ddc4d90e0125d61e4b97626782af57d44522bcb5543fb21cb2')
+            'd7ec5ba4a3d75f674f4028e8a53bc4177ab71a379bc63affebf910e1d5a0e491b6642318218b55ddc4d90e0125d61e4b97626782af57d44522bcb5543fb21cb2'
+            '4d784bfcf8fe4a2c2ce25bdb24fece1ee16994ce4e13d18d19436773d63f2bcfa77360b21d796b5211f7c0a0136e13fe2ce6bd12bcad2802680ce1ecb8739dc5')
+
+prepare() {
+  cd "$srcdir/${_perlname}-${pkgver}"
+  patch -Np1 -i "${srcdir}/0001-clang-as-defines.patch"
+}
 
 build() {
   cd "$srcdir/${_perlname}-${pkgver}"


### PR DESCRIPTION
From #9179, `as` is really an alias of `clang` so it needs `-Wa,-defsym,...` rather than `-defsym ...`, and also needs `-c` to produce .o file.