### PR TITLE
initial mingw package of onqtam/doctest 2.4.6

### DIFF
--- a/mingw-w64-doctest/PKGBUILD
+++ b/mingw-w64-doctest/PKGBUILD
@@ -1,0 +1,49 @@
+_realname=doctest
+pkgbase=mingw-w64-${_realname}
+pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
+pkgver=2.4.6
+pkgrel=1
+pkgdesc='A lightweight C++ header-only unit testing framework (mingw-w64)'
+arch=('any')
+url='https://github.com/onqtam/doctest'
+license=('MIT')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake")
+source=("${url}/archive/${pkgver}.tar.gz")
+sha256sums=('39110778e6baf373ef04342d7cb3fe35da104cb40769103e8a2f0035f5a5f1cb')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+}
+
+build() {
+  mkdir -p "${srcdir}/build-${MSYSTEM}"
+  cd "${srcdir}/build-${MSYSTEM}"
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  cmake -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        -DDOCTEST_WITH_TESTS=off \
+        -G"MSYS Makefiles" \
+        "${extra_config[@]}" \
+        ../${_realname}-${pkgver}
+  make
+}
+
+# check() {
+  # cd "${srcdir}/${pkgname}-${pkgver}/build"
+  # make
+  # ctest -C Release --output-on-failure
+# }
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+  make DESTDIR="${pkgdir}" install
+  install -Dm 0644 "${srcdir}/${_realname}-${pkgver}/LICENSE.txt" \
+    "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
Hey there! This is my first MINGW package, but I've been using PKGBUILD as an AUR packager for years, and maintain doctest in (at least) Fedora and FreeBSD. Hopefully I've followed the guidelines at https://www.msys2.org/wiki/Creating-Packages; let's see what the CI has to say.

This is a C++ header-only unit testing framework. It's used by my project Notcurses (which I'm porting to MINGW as we speak), as well as Wayfire and a few other major ones.