### PR TITLE
petsc: remove build flavor suffixes from static libraries

### DIFF
--- a/mingw-w64-petsc/PKGBUILD
+++ b/mingw-w64-petsc/PKGBUILD
@@ -33,7 +33,7 @@ _realname=petsc
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-${_realname}-build")
 pkgver=3.15.2
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 pkgdesc='Sparse iterative (non)linear solver package (mingw-w64)'
@@ -154,13 +154,10 @@ build() {
     make PETSC_ARCH=${build} all
   	(
   		cd ${build}/lib
-  		lib=libpetsc-${build}
-  		rm -rf ${lib}.a
   	  case ${build} in
     		*o) strip -S *.a ;;
   	  esac
-      mv libpetsc.a ${lib}.a
-  		${ld} -shared -Wl,--enable-auto-import -Wl,--export-all-symbols -o ${lib}.dll -Wl,--out-implib,${lib}.dll.a -Wl,--whole-archive ${lib}.a -Wl,--no-whole-archive ${ldflags} $(pkg-config ${pc} --libs)
+  		${ld} -shared -Wl,--enable-auto-import -Wl,--export-all-symbols -o lib${_realname}-${build}.dll -Wl,--out-implib,lib${_realname}.dll.a -Wl,--whole-archive lib${_realname}.a -Wl,--no-whole-archive ${ldflags} $(pkg-config ${pc} --libs)
   	)
   done
 }
@@ -204,7 +201,6 @@ _package() {
   		mkdir -p ${pkgdir}${MINGW_PREFIX}/include/${_realname}/${build}
   		cp *.{h,mod} ${pkgdir}${MINGW_PREFIX}/include/${_realname}/${build}
   	)
-    lib=${_realname}-${build}
     echo "
       prefix=${MINGW_PREFIX}
       libdir=\${prefix}/lib/${_realname}
@@ -215,9 +211,9 @@ _package() {
       Description: ${desc} PETSc build
       Requires.private: ${pc}
       Cflags: -I\${includedir}/${build} -I\${includedir} ${iflags}
-      Libs.private: -L\${libdir}/${build} -l${lib} ${ldflags} -lgfortran -lquadmath
-      Libs: -L\${libdir}/${build} -l${lib}
-    " | sed '/^\s*$/d;s/^\s*//' > ${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/${lib}.pc
+      Libs.private: -L\${libdir}/${build} -l${_realname} ${ldflags} -lgfortran -lquadmath
+      Libs: -L\${libdir}/${build} -l${_realname}
+    " | sed '/^\s*$/d;s/^\s*//' > ${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/${_realname}-${build}.pc
   done
 }
 


### PR DESCRIPTION
This patch fixes the integration issue with depending packages such as SLEPc caused by switching to a single static library build.

@gharveymn This should (positively in the end) affect sundials.