### PR TITLE
[new-package] PyQt6 6.1.1

### DIFF
--- a/mingw-w64-pyqt6-sip/PKGBUILD
+++ b/mingw-w64-pyqt6-sip/PKGBUILD
@@ -1,0 +1,34 @@
+# Contributor: Mehdi Chinoune <mehdi.chinoune@hotmail.com>
+
+_realname=pyqt6-sip
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=13.1.0
+pkgrel=1
+pkgdesc="The sip module support for PyQt6 (mingw-w64)"
+arch=('any')
+license=('GPL')
+url="https://riverbankcomputing.com/software/pyqt"
+depends=("${MINGW_PACKAGE_PREFIX}-python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
+source=(https://pypi.python.org/packages/source/P/PyQt6_sip/PyQt6_sip-${pkgver}.tar.gz)
+sha256sums=('7c31073fe8e6cb8a42e85d60d3a096700a9047c772b354d6227dfe965566ec8a')
+
+prepare() {
+  cd "${srcdir}"
+  rm -rf python-build-${MSYSTEM} | true
+  cp -r "PyQt6_sip-${pkgver}" "python-build-${MSYSTEM}"
+}
+
+build() {
+  cd python-build-${MSYSTEM}
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python setup.py build
+}
+
+package(){
+  cd "${srcdir}"/python-build-${MSYSTEM}
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+}

--- a/mingw-w64-pyqt6/001-fix-undefined-reference-stat.patch
+++ b/mingw-w64-pyqt6/001-fix-undefined-reference-stat.patch
@@ -1,0 +1,10 @@
+--- PyQt6-6.1.1/sip/QtCore/qfileinfo.sip.bak	2021-07-25 12:21:33.631438000 +0100
++++ PyQt6-6.1.1/sip/QtCore/qfileinfo.sip	2021-07-25 12:21:58.446476600 +0100
+@@ -92,7 +92,6 @@
+     bool isSymbolicLink() const;
+     bool isShortcut() const;
+     bool isJunction() const;
+-    void stat();
+ };
+ 
+ typedef QList<QFileInfo> QFileInfoList;

--- a/mingw-w64-pyqt6/PKGBUILD
+++ b/mingw-w64-pyqt6/PKGBUILD
@@ -1,0 +1,65 @@
+# Contributor: Mehdi Chinoune <mehdi.chinoune@hotmail.com>
+
+_realname=pyqt6
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=6.1.1
+pkgrel=1
+pkgdesc="Python bindings for the Qt cross platform application toolkit (mingw-w64)"
+arch=('any')
+license=('GPL')
+url="https://riverbankcomputing.com/software/pyqt"
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-pyqt6-sip"
+         "${MINGW_PACKAGE_PREFIX}-qt6-base")
+optdepends=("${MINGW_PACKAGE_PREFIX}-qt6-tools"
+            "${MINGW_PACKAGE_PREFIX}-qt6-svg"
+            "${MINGW_PACKAGE_PREFIX}-qt6-declarative"
+            "${MINGW_PACKAGE_PREFIX}-qt6-quick3d"
+            "${MINGW_PACKAGE_PREFIX}-qt6-shadertools")
+makedepends=("${MINGW_PACKAGE_PREFIX}-sip"
+             "${MINGW_PACKAGE_PREFIX}-pyqt-builder"
+             "${MINGW_PACKAGE_PREFIX}-python-packaging"
+             "${MINGW_PACKAGE_PREFIX}-qt6-tools"
+             "${MINGW_PACKAGE_PREFIX}-qt6-svg"
+             "${MINGW_PACKAGE_PREFIX}-qt6-declarative"
+             "${MINGW_PACKAGE_PREFIX}-qt6-quick3d"
+             "${MINGW_PACKAGE_PREFIX}-qt6-shadertools")
+source=(https://pypi.python.org/packages/source/P/PyQt6/PyQt6-${pkgver}.tar.gz
+        "001-fix-undefined-reference-stat.patch")
+sha256sums=('8775244fa73f94bfe8ae7672b624e2a903a22bc35d7ea42dd830949e2f9e43c7'
+            '7ff75730df39b857fc7e19c6b6d47ba6dc7ffaeab8edb1d8a7540dcf3b9447bd')
+
+prepare() {
+  cd PyQt6-${pkgver}
+
+  patch -p1 -i ${srcdir}/001-fix-undefined-reference-stat.patch
+}
+
+build() {
+  [[ -d python-${MSYSTEM} ]] && rm -rf python-${MSYSTEM}
+  cp -r PyQt6-${pkgver} python-${MSYSTEM} && cd python-${MSYSTEM}
+
+  MSYS2_ARG_CONV_EXCL="--api-dir=;" \
+  ${MINGW_PREFIX}/bin/sip-build \
+    --confirm-license \
+    --no-make \
+    --api-dir=${MINGW_PREFIX}/share/qt6/qsci/api/python \
+    --qmake=${MINGW_PREFIX}/bin/qmake.exe \
+    --verbose
+
+    cd build
+    make V=1
+}
+
+package(){
+  local _pysite=$(cygpath -u $(${MINGW_PREFIX}/bin/python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"))
+  cd python-${MSYSTEM}/build
+  # INSTALL_ROOT is needed for the QtDesigner module, the other Makefiles use DESTDIR
+  MSYS2_ARG_CONV_EXCL="${_pysite}" \
+  make DESTDIR="${pkgdir}" INSTALL_ROOT="${pkgdir}" install
+
+  # compile Python bytecode
+  ${MINGW_PREFIX}/bin/python -m compileall -d / "$pkgdir"${MINGW_PREFIX}/lib
+  ${MINGW_PREFIX}/bin/python -O -m compileall -d / "$pkgdir"${MINGW_PREFIX}/lib
+}


### PR DESCRIPTION
Somehow the reference to QFileInfo::stat was missing from QtCore shared library.
The only way I have found to fix it is to remove its mention from the sip file.