### PR TITLE
file: autoreconf for clang

### DIFF
--- a/mingw-w64-file/PKGBUILD
+++ b/mingw-w64-file/PKGBUILD
@@ -4,7 +4,7 @@ _realname=file
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=5.39
-pkgrel=1
+pkgrel=2
 pkgdesc='Determine the type of a file from its contents (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -23,6 +23,8 @@ options=('strip' '!libtool' 'staticlibs')
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   patch -p1 -i ${srcdir}/0001-file-5.38-mingw-build.patch
+  # autoreconf to get updated libtool files with clang support
+  autoreconf -fiv
 }
 
 build() {


### PR DESCRIPTION
was going to make a PR with a bunch of these, but it seems mingw-w64-file interferes with makepkg and libtool's usage of `file` expecting to be the msys variant.