### PR TITLE
qt6-tools: Add clang as a runtime dependency

### DIFF
--- a/mingw-w64-qt6-tools/PKGBUILD
+++ b/mingw-w64-qt6-tools/PKGBUILD
@@ -5,16 +5,16 @@ pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 _qtver=6.1.2
 pkgver=${_qtver/-/}
-pkgrel=1
+pkgrel=2
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://www.qt.io'
 license=(GPL3 LGPL3 FDL custom)
 pkgdesc='A cross-platform application and UI framework (Development Tools, QtHelp) (mingw-w64)'
-depends=("${MINGW_PACKAGE_PREFIX}-qt6-base")
+depends=("${MINGW_PACKAGE_PREFIX}-qt6-base"
+         "${MINGW_PACKAGE_PREFIX}-clang")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
-             "${MINGW_PACKAGE_PREFIX}-clang"
              "${MINGW_PACKAGE_PREFIX}-clang-tools-extra"
              "${MINGW_PACKAGE_PREFIX}-polly"
              "${MINGW_PACKAGE_PREFIX}-qt6-declarative")


### PR DESCRIPTION
the Qt tools build against libclang-cpp