### PR TITLE
autoreconf packages missing dlls, through G

### DIFF
--- a/mingw-w64-freetds/PKGBUILD
+++ b/mingw-w64-freetds/PKGBUILD
@@ -5,7 +5,7 @@ _realname=freetds
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.2.6
-pkgrel=1
+pkgrel=2
 pkgdesc="A free implementation of Sybase's DB-Library, CT-Library and ODBC libraries (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -29,6 +29,8 @@ prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/0001-Don-t-use-MSYS2-file-libws2_32.patch
   patch -p1 -i ${srcdir}/0002-Enable-inet_pton-definition-in-MINGW-i686-build.patch
+  # autoreconf to get updated libtool files with clang support
+  autoreconf -fiv
 }
 
 build() {

--- a/mingw-w64-gc/PKGBUILD
+++ b/mingw-w64-gc/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gc
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=8.0.4
-pkgrel=2
+pkgrel=3
 pkgdesc="A garbage collector for C and C++ (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -21,7 +21,8 @@ sha256sums=('436a0ddc67b1ac0b0405b61a9675bca9e075c8156f4debd1d06f3a56c7cd289d')
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
 
-  ./autogen.sh
+  # autoreconf to get updated libtool files with clang support
+  autoreconf -fiv
 }
 
 build() {

--- a/mingw-w64-gtkmm/PKGBUILD
+++ b/mingw-w64-gtkmm/PKGBUILD
@@ -4,17 +4,27 @@ _realname=gtkmm
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.24.5
-pkgrel=2
+pkgrel=3
 pkgdesc="C++ bindings for gtk2 (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 url="https://www.gtkmm.org/"
 license=("LGPL")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
-depends=("${MINGW_PACKAGE_PREFIX}-atkmm" "${MINGW_PACKAGE_PREFIX}-pangomm" "${MINGW_PACKAGE_PREFIX}-gtk2")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "mm-common")
+depends=("${MINGW_PACKAGE_PREFIX}-atkmm"
+         "${MINGW_PACKAGE_PREFIX}-pangomm"
+         "${MINGW_PACKAGE_PREFIX}-gtk2")
 options=(staticlibs strip)
 source=("https://download.gnome.org/sources/gtkmm/${pkgver%.*}/gtkmm-${pkgver}.tar.xz")
 sha256sums=('0680a53b7bf90b4e4bf444d1d89e6df41c777e0bacc96e9c09fc4dd2f5fe6b72')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  # autoreconf to get updated libtool files with clang support
+  autoreconf -fiv
+}
 
 build() {
   CPPFLAGS+=" -D_REENTRANT"

--- a/mingw-w64-gtksourceview2/PKGBUILD
+++ b/mingw-w64-gtksourceview2/PKGBUILD
@@ -4,13 +4,17 @@ _realname=gtksourceview
 pkgbase=mingw-w64-${_realname}2
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}2"
 pkgver=2.10.5
-pkgrel=4
+pkgrel=5
 pkgdesc="A text widget adding syntax highlighting and more to GNOME (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 url="https://www.gnome.org"
 license=("GPL")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config" "intltool")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-gnome-common"
+             "${MINGW_PACKAGE_PREFIX}-gtk-doc"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "intltool")
 depends=("${MINGW_PACKAGE_PREFIX}-gtk2>=2.22.0"
          "${MINGW_PACKAGE_PREFIX}-libxml2>=2.7.7")
 options=(!libtool strip staticlibs)
@@ -20,6 +24,8 @@ sha256sums=('c585773743b1df8a04b1be7f7d90eecdf22681490d6810be54c81a7ae152191e')
 prepare() {
   cd ${_realname}-${pkgver}
   sed -i 's#python#python2#' gtksourceview/language-specs/convert.py
+  # autoreconf to get updated libtool files with clang support
+  autoreconf -fiv
 }
 
 build() {
@@ -31,7 +37,7 @@ build() {
     --host=${MINGW_CHOST} \
     --enable-shared \
     --disable-static \
-    --enable-compile-warnings=maximum
+    --enable-compile-warnings=minimum
 
   make
 }

--- a/mingw-w64-gtksourceviewmm2/PKGBUILD
+++ b/mingw-w64-gtksourceviewmm2/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gtksourceviewmm
 pkgbase="mingw-w64-${_realname}2"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}2"
 pkgver=2.10.3
-pkgrel=3
+pkgrel=4
 pkgdesc="A text widget adding syntax highlighting and more to GNOME (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -12,7 +12,8 @@ url="https://www.gnome.org"
 license=("GPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
-             "intltool")
+             "intltool"
+             "mm-common")
 depends=("${MINGW_PACKAGE_PREFIX}-gtk2>=2.22.0"
          "${MINGW_PACKAGE_PREFIX}-gtkmm"
          "${MINGW_PACKAGE_PREFIX}-gtksourceview2"
@@ -26,6 +27,8 @@ sha256sums=('0000df1b582d7be2e412020c5d748f21c0e6e5074c6b2ca8529985e70479375b'
 prepare() {
   cd ${_realname}-${pkgver}
   patch -b -V simple -p1 -i ${srcdir}/000-C11.patch
+  # autoreconf to get updated libtool files with clang support
+  autoreconf -fiv
 }
 
 build() {


### PR DESCRIPTION
These packages were missing dlls under clang64 that were present under mingw64, due to the version of libtool embedded in the source not knowing how to deal with llvm and clang.  `autoreconf -fiv` to update their copies of libtool.

gtksourceview2 was being difficult, apparently the newer `gnome-common` m4 macros for `GNOME_COMPILE_WARNINGS` wanted to turn on `-Werror=format-security`, but this package would fail with that.  After struggling trying to fix this, just turned warnings from "maximum" to "minimum" which disables this behavior.