### PR TITLE
libopenmpt: update to 0.4.22

### DIFF
--- a/mingw-w64-libopenmpt/PKGBUILD
+++ b/mingw-w64-libopenmpt/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=libopenmpt
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.4.21
-pkgrel=2
+pkgver=0.4.22
+pkgrel=1
 pkgdesc="A cross-platform C++ and C library to decode tracked music files (modules) into a raw PCM audio stream (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -21,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
 options=('staticlibs' 'strip')
 source=("https://lib.openmpt.org/files/${_realname}/src/${_realname}-${pkgver}+release.autotools.tar.gz")
-sha256sums=('79d24f61858899e0754a9a904931d4ce779396d3adb408dee3be6f172d93410c')
+sha256sums=('f06af96cf3f7f3ad85cfb7da1e4c043f1fbfb520cbf35fd37a0d2fa5cdeb7e95')
 
 build() {
   [[ -d ${srcdir}/build-${CARCH} ]] && rm -rf ${srcdir}/build-${CARCH}


### PR DESCRIPTION
Bugfix release
https://lib.openmpt.org/libopenmpt/2021/07/04/releases-0.5.10-0.4.22-0.3.31/