### PR TITLE
xmlsec: fix mscng/mscrypto configure tests

### DIFF
--- a/mingw-w64-xmlsec/03-fix-ms-configure-tests.patch
+++ b/mingw-w64-xmlsec/03-fix-ms-configure-tests.patch
@@ -1,0 +1,25 @@
+--- xmlsec-xmlsec-1_2_31/configure.ac.orig	2021-07-26 13:01:32.687310200 -0700
++++ xmlsec-xmlsec-1_2_31/configure.ac	2021-07-26 13:02:41.013435300 -0700
+@@ -1569,7 +1569,7 @@
+             #include <windows.h>
+             #include <wincrypt.h>
+         ]],[[
+-            int main () { CertOpenStore(0,0,0,0,0);; return(0); }
++            CertOpenStore(0,0,0,0,0);
+         ]])
+     ],[
+         MSCRYPTO_FOUND=yes
+@@ -1640,11 +1640,8 @@
+             #include <windows.h>
+             #include <wincrypt.h>
+         ]],[[
+-            int main () {
+-                BCRYPT_ALG_HANDLE hAlg;
+-                BCryptOpenAlgorithmProvider(&hAlg, BCRYPT_SHA256_ALGORITHM, NULL, 0);
+-                return(0);
+-            }
++            BCRYPT_ALG_HANDLE hAlg;
++            BCryptOpenAlgorithmProvider(&hAlg, BCRYPT_SHA256_ALGORITHM, NULL, 0);
+         ]])
+     ],[
+         MSCNG_FOUND=yes

--- a/mingw-w64-xmlsec/PKGBUILD
+++ b/mingw-w64-xmlsec/PKGBUILD
@@ -4,7 +4,7 @@ _realname=xmlsec
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.2.31
-pkgrel=1
+pkgrel=2
 pkgdesc="XML Security Library is a C library based on LibXML2 (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -20,15 +20,18 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-libtool")
 source=(https://github.com/lsh123/xmlsec/archive/${_realname}-${pkgver//./_}.tar.gz
         01-include-openssl-last.patch
-        02-make-new-wincrypt-functions-available.patch)
+        02-make-new-wincrypt-functions-available.patch
+        03-fix-ms-configure-tests.patch)
 sha256sums=('3d975c7c945b6f8f84e956934b562f794fa6b469d78d913190d3a1c32d1a3ddb'
             '015473ce9ad0110ebf4a43be3d3046b5616345799879512d5da22a71b4cecc35'
-            'c3297ca54a8baa50a880da35d546868faf7579d0b60b143385892034927fb9f3')
+            'c3297ca54a8baa50a880da35d546868faf7579d0b60b143385892034927fb9f3'
+            'ba3c26a56440833a1e5832fc46e66ffffe19802d65d7384b96aabe28a2c630cf')
 
 prepare() {
   cd "${srcdir}/${_realname}-${_realname}-${pkgver//./_}"
   patch -p1 -i ${srcdir}/01-include-openssl-last.patch
   patch -p1 -i ${srcdir}/02-make-new-wincrypt-functions-available.patch
+  patch -p1 -i ${srcdir}/03-fix-ms-configure-tests.patch
   autoreconf -fiv 
 }
 


### PR DESCRIPTION
looking at file diffs between clang64 and mingw64, noticed mscrypto and mscng were missing on clang.  The issue was that the configure tests were nesting a `main` function inside a `main` function, and clang didn't like that.  Remove the extraneous `main` function around the configure tests.