### PR TITLE
clang: backport a couple more patches

### DIFF
--- a/mingw-w64-clang/0018-llvm-rc-Allow-dashes-as-part-of-resource-name-strings.patch
+++ b/mingw-w64-clang/0018-llvm-rc-Allow-dashes-as-part-of-resource-name-strings.patch
@@ -1,0 +1,94 @@
+From 0a1683f8cc0df2889f1d86da7a795914f07e5599 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Storsj=C3=B6?= <martin@martin.st>
+Date: Fri, 23 Jul 2021 00:36:05 +0300
+Subject: [PATCH] [llvm-rc] Allow dashes as part of resource name strings
+
+This matches what MS rc.exe allows in practice. I'm not aware of
+any legal syntax case that are broken by allowing dashes as part
+of what the tokenizer considers an Identifier - but I'm not
+very well versed in the RC syntax either, can @amccarth think of
+any case that would be broken by this?
+
+This fixes downstream bug
+https://github.com/msys2/MINGW-packages/issues/9180.
+
+Additionally, rc.exe allows such resource name strings to be surrounded
+by quotes, ending up with e.g.
+
+    Resource name (string): "QUOTEDNAME"
+
+(i.e., the quotes end up as part of the string), which llvm-rc doesn't
+support yet either. (I'm not aware of such cases in the wild though,
+but resource string names with dashes do exist.)
+
+This also allows including files with unquoted paths, with filenames
+containing dashes (which fixes
+https://github.com/msys2/MINGW-packages/issues/9130, which has been
+worked around differently so far).
+
+Differential Revision: https://reviews.llvm.org/D106598
+---
+ test/tools/llvm-rc/Inputs/resname-string.rc | 2 ++
+ test/tools/llvm-rc/Inputs/tokens.rc         | 1 +
+ test/tools/llvm-rc/resname-string.test      | 5 +++++
+ test/tools/llvm-rc/tokenizer.test           | 1 +
+ tools/llvm-rc/ResourceScriptToken.cpp       | 2 +-
+ 5 files changed, 10 insertions(+), 1 deletion(-)
+ create mode 100644 test/tools/llvm-rc/Inputs/resname-string.rc
+ create mode 100644 test/tools/llvm-rc/resname-string.test
+
+diff --git a/test/tools/llvm-rc/Inputs/resname-string.rc b/test/tools/llvm-rc/Inputs/resname-string.rc
+new file mode 100644
+index 0000000000000..7132a1124aa2e
+--- /dev/null
++++ b/test/tools/llvm-rc/Inputs/resname-string.rc
+@@ -0,0 +1,2 @@
++stringname RCDATA { "foo" }
++name-with-dashes/and/slashes RCDATA { "foo" }
+diff --git a/test/tools/llvm-rc/Inputs/tokens.rc b/test/tools/llvm-rc/Inputs/tokens.rc
+index 217d6017a9d74..6a781202a7e37 100644
+--- a/test/tools/llvm-rc/Inputs/tokens.rc
++++ b/test/tools/llvm-rc/Inputs/tokens.rc
+@@ -1,5 +1,6 @@
+ ﻿1 + 2 - 3214L & 0x120894 032173 2|&~+(-7){0xabcdef 0xABCDEFl} Begin End
+ He11o LLVM
++identifier-with-dashes
+ 
+ "RC string test.",L"Another RC string test.'&{",42,100
+ 
+diff --git a/test/tools/llvm-rc/resname-string.test b/test/tools/llvm-rc/resname-string.test
+new file mode 100644
+index 0000000000000..d41a6a49642d5
+--- /dev/null
++++ b/test/tools/llvm-rc/resname-string.test
+@@ -0,0 +1,5 @@
++; RUN: llvm-rc -no-preprocess /FO %t.res -- %p/Inputs/resname-string.rc
++; RUN: llvm-readobj %t.res | FileCheck %s
++
++; CHECK: Resource name (string): STRINGNAME
++; CHECK: Resource name (string): NAME-WITH-DASHES/AND/SLASHES
+diff --git a/test/tools/llvm-rc/tokenizer.test b/test/tools/llvm-rc/tokenizer.test
+index eb2233c89d725..8486f8bd78690 100644
+--- a/test/tools/llvm-rc/tokenizer.test
++++ b/test/tools/llvm-rc/tokenizer.test
+@@ -27,6 +27,7 @@
+ ; CHECK-NEXT:  BlockEnd: End
+ ; CHECK-NEXT:  Identifier: He11o
+ ; CHECK-NEXT:  Identifier: LLVM
++; CHECK-NEXT:  Identifier: identifier-with-dashes
+ ; CHECK-NEXT:  String: "RC string test."
+ ; CHECK-NEXT:  Comma: ,
+ ; CHECK-NEXT:  String: L"Another RC string test.'&{"
+diff --git a/tools/llvm-rc/ResourceScriptToken.cpp b/tools/llvm-rc/ResourceScriptToken.cpp
+index 6ce75f7e4bbbb..a8f40abdf8a68 100644
+--- a/tools/llvm-rc/ResourceScriptToken.cpp
++++ b/tools/llvm-rc/ResourceScriptToken.cpp
+@@ -288,7 +288,7 @@ bool Tokenizer::canContinueIdentifier() const {
+   assert(!streamEof());
+   const char CurChar = Data[Pos];
+   return std::isalnum(CurChar) || CurChar == '_' || CurChar == '.' ||
+-         CurChar == '/' || CurChar == '\\';
++         CurChar == '/' || CurChar == '\\' || CurChar == '-';
+ }
+ 
+ bool Tokenizer::canStartInt() const {

--- a/mingw-w64-clang/0019-MinGW-Mark-a-number-of-library-functions-unavailable.patch
+++ b/mingw-w64-clang/0019-MinGW-Mark-a-number-of-library-functions-unavailable.patch
@@ -1,0 +1,124 @@
+From c5638a71d805330294e9b6e2c670e1ed7420b63a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Storsj=C3=B6?= <martin@martin.st>
+Date: Fri, 21 May 2021 00:47:39 +0300
+Subject: [PATCH] [MinGW] Mark a number of library functions unavailable for
+ mingw targets
+
+These functions were marked unavailable for MSVC targets before,
+within an "T.isOSWindows() && !T.isOSCygMing()" block, but these ones
+are unavailable on MinGW targets too.
+
+This avoids generating calls to stpcpy for MinGW targets, which has
+been happening since 6dbf0cfcf789365493f70ae69df8a7a59be41c75 (in
+some cases).
+
+This fixes https://github.com/mstorsjo/llvm-mingw/issues/201.
+
+Differential Revision: https://reviews.llvm.org/D102946
+---
+ lib/Analysis/TargetLibraryInfo.cpp       | 48 ++++++++++---------
+ test/Transforms/InstCombine/sprintf-1.ll |  1 +
+ 2 files changed, 27 insertions(+), 22 deletions(-)
+
+diff --git a/lib/Analysis/TargetLibraryInfo.cpp b/lib/Analysis/TargetLibraryInfo.cpp
+index 153ba073cc10b..05088c189ca22 100644
+--- a/lib/Analysis/TargetLibraryInfo.cpp
++++ b/lib/Analysis/TargetLibraryInfo.cpp
+@@ -352,59 +352,63 @@ static void initialize(TargetLibraryInfoImpl &TLI, const Triple &T,
+     // Win32 does not support these functions, but
+     // they are generally available on POSIX-compliant systems.
+     TLI.setUnavailable(LibFunc_access);
++    TLI.setUnavailable(LibFunc_chmod);
++    TLI.setUnavailable(LibFunc_closedir);
++    TLI.setUnavailable(LibFunc_fdopen);
++    TLI.setUnavailable(LibFunc_fileno);
++    TLI.setUnavailable(LibFunc_fseeko);
++    TLI.setUnavailable(LibFunc_fstat);
++    TLI.setUnavailable(LibFunc_ftello);
++    TLI.setUnavailable(LibFunc_gettimeofday);
++    TLI.setUnavailable(LibFunc_memccpy);
++    TLI.setUnavailable(LibFunc_mkdir);
++    TLI.setUnavailable(LibFunc_open);
++    TLI.setUnavailable(LibFunc_opendir);
++    TLI.setUnavailable(LibFunc_pclose);
++    TLI.setUnavailable(LibFunc_popen);
++    TLI.setUnavailable(LibFunc_read);
++    TLI.setUnavailable(LibFunc_rmdir);
++    TLI.setUnavailable(LibFunc_stat);
++    TLI.setUnavailable(LibFunc_strcasecmp);
++    TLI.setUnavailable(LibFunc_strncasecmp);
++    TLI.setUnavailable(LibFunc_unlink);
++    TLI.setUnavailable(LibFunc_utime);
++    TLI.setUnavailable(LibFunc_write);
++  }
++
++  if (T.isOSWindows() && !T.isWindowsCygwinEnvironment()) {
++    // These functions aren't available in either MSVC or MinGW environments.
+     TLI.setUnavailable(LibFunc_bcmp);
+     TLI.setUnavailable(LibFunc_bcopy);
+     TLI.setUnavailable(LibFunc_bzero);
+-    TLI.setUnavailable(LibFunc_chmod);
+     TLI.setUnavailable(LibFunc_chown);
+-    TLI.setUnavailable(LibFunc_closedir);
+     TLI.setUnavailable(LibFunc_ctermid);
+-    TLI.setUnavailable(LibFunc_fdopen);
+     TLI.setUnavailable(LibFunc_ffs);
+-    TLI.setUnavailable(LibFunc_fileno);
+     TLI.setUnavailable(LibFunc_flockfile);
+-    TLI.setUnavailable(LibFunc_fseeko);
+-    TLI.setUnavailable(LibFunc_fstat);
+     TLI.setUnavailable(LibFunc_fstatvfs);
+-    TLI.setUnavailable(LibFunc_ftello);
+     TLI.setUnavailable(LibFunc_ftrylockfile);
+     TLI.setUnavailable(LibFunc_funlockfile);
+     TLI.setUnavailable(LibFunc_getitimer);
+     TLI.setUnavailable(LibFunc_getlogin_r);
+     TLI.setUnavailable(LibFunc_getpwnam);
+-    TLI.setUnavailable(LibFunc_gettimeofday);
+     TLI.setUnavailable(LibFunc_htonl);
+     TLI.setUnavailable(LibFunc_htons);
+     TLI.setUnavailable(LibFunc_lchown);
+     TLI.setUnavailable(LibFunc_lstat);
+-    TLI.setUnavailable(LibFunc_memccpy);
+-    TLI.setUnavailable(LibFunc_mkdir);
+     TLI.setUnavailable(LibFunc_ntohl);
+     TLI.setUnavailable(LibFunc_ntohs);
+-    TLI.setUnavailable(LibFunc_open);
+-    TLI.setUnavailable(LibFunc_opendir);
+-    TLI.setUnavailable(LibFunc_pclose);
+-    TLI.setUnavailable(LibFunc_popen);
+     TLI.setUnavailable(LibFunc_pread);
+     TLI.setUnavailable(LibFunc_pwrite);
+-    TLI.setUnavailable(LibFunc_read);
+     TLI.setUnavailable(LibFunc_readlink);
+     TLI.setUnavailable(LibFunc_realpath);
+-    TLI.setUnavailable(LibFunc_rmdir);
+     TLI.setUnavailable(LibFunc_setitimer);
+-    TLI.setUnavailable(LibFunc_stat);
+     TLI.setUnavailable(LibFunc_statvfs);
+     TLI.setUnavailable(LibFunc_stpcpy);
+     TLI.setUnavailable(LibFunc_stpncpy);
+-    TLI.setUnavailable(LibFunc_strcasecmp);
+-    TLI.setUnavailable(LibFunc_strncasecmp);
+     TLI.setUnavailable(LibFunc_times);
+     TLI.setUnavailable(LibFunc_uname);
+-    TLI.setUnavailable(LibFunc_unlink);
+     TLI.setUnavailable(LibFunc_unsetenv);
+-    TLI.setUnavailable(LibFunc_utime);
+     TLI.setUnavailable(LibFunc_utimes);
+-    TLI.setUnavailable(LibFunc_write);
+   }
+ 
+   switch (T.getOS()) {
+diff --git a/test/Transforms/InstCombine/sprintf-1.ll b/test/Transforms/InstCombine/sprintf-1.ll
+index 187488d9ce78e..704d51724e06b 100644
+--- a/test/Transforms/InstCombine/sprintf-1.ll
++++ b/test/Transforms/InstCombine/sprintf-1.ll
+@@ -4,6 +4,7 @@
+ ; RUN: opt < %s -instcombine -S | FileCheck %s
+ ; RUN: opt < %s -mtriple xcore-xmos-elf -instcombine -S | FileCheck %s -check-prefixes=CHECK,CHECK-IPRINTF
+ ; RUN: opt < %s -mtriple=i386-pc-windows-msvc -instcombine -S | FileCheck %s --check-prefixes=CHECK,WIN
++; RUN: opt < %s -mtriple=i386-mingw32 -instcombine -S | FileCheck %s --check-prefixes=CHECK,WIN
+ 
+ target datalayout = "e-p:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:32:64-f32:32:32-f64:32:64-v64:64:64-v128:128:128-a0:0:64-f80:128:128"
+ 

--- a/mingw-w64-clang/0317-LLD-COFF-Make-export-all-symbols-work-as-intended-fo.patch
+++ b/mingw-w64-clang/0317-LLD-COFF-Make-export-all-symbols-work-as-intended-fo.patch
@@ -1,0 +1,52 @@
+From 9dbc4b09afd4427c2def829f0c8283f732e654a0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Storsj=C3=B6?= <martin@martin.st>
+Date: Sun, 18 Jul 2021 22:52:32 +0300
+Subject: [PATCH] [LLD] [COFF] Make -export-all-symbols work as intended for
+ EXEs
+
+If some symbols are marked with dllexport, we still want to export
+all symbols if -export-all-symbols is specified. Previously, this
+only worked as it should for DLL output, not for EXE.
+
+This should fix downstream bug
+https://github.com/msys2/MINGW-packages/issues/9163.
+
+Differential Revision: https://reviews.llvm.org/D106245
+---
+ COFF/Driver.cpp        | 6 +++---
+ test/COFF/export-all.s | 4 ++++
+ 2 files changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/COFF/Driver.cpp b/COFF/Driver.cpp
+index 8e1292f0a5e8e..9ba0db31507f2 100644
+--- a/COFF/Driver.cpp
++++ b/COFF/Driver.cpp
+@@ -1203,10 +1203,10 @@ void LinkerDriver::convertResources() {
+ // -exclude-all-symbols option, so that lld-link behaves like link.exe rather
+ // than MinGW in the case that nothing is explicitly exported.
+ void LinkerDriver::maybeExportMinGWSymbols(const opt::InputArgList &args) {
+-  if (!config->dll)
+-    return;
+-
+   if (!args.hasArg(OPT_export_all_symbols)) {
++    if (!config->dll)
++      return;
++
+     if (!config->exports.empty())
+       return;
+     if (args.hasArg(OPT_exclude_all_symbols))
+diff --git a/test/COFF/export-all.s b/test/COFF/export-all.s
+index 079d0a25d79b8..b370dbe92079e 100644
+--- a/test/COFF/export-all.s
++++ b/test/COFF/export-all.s
+@@ -61,6 +61,10 @@ __imp__unexported:
+ # RUN: llvm-readobj --coff-exports %t.dll | FileCheck -check-prefix=CHECK2 %s
+ # RUN: cat %t.def | FileCheck -check-prefix=CHECK2-DEF %s
+ 
++# RUN: lld-link -safeseh:no -out:%t.exe %t.obj -lldmingw -export-all-symbols -output-def:%t.def -entry:_DllMainCRTStartup
++# RUN: llvm-readobj --coff-exports %t.exe | FileCheck -check-prefix=CHECK2 %s
++# RUN: cat %t.def | FileCheck -check-prefix=CHECK2-DEF %s
++
+ # Note, this will actually export _DllMainCRTStartup as well, since
+ # it uses the standard spelling in this object file, not the MinGW one.
+ 

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -76,6 +76,7 @@ source=("https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkgver
         "0016-llvm-rc-Make-commas-in-user-data-structs-optional.patch"
         "0017-X86-Teach-X86FloatingPoint-s-handleCall-to-only-eras.patch"
         "0018-llvm-rc-Allow-dashes-as-part-of-resource-name-strings.patch"
+        "0019-MinGW-Mark-a-number-of-library-functions-unavailable.patch"
         "0101-Disable-fPIC-errors.patch"
         "0103-Use-posix-style-path-separators-with-MinGW.patch"
         "0104-link-pthread-with-mingw.patch"
@@ -129,6 +130,7 @@ sha256sums=('129cb25cd13677aad951ce5c2deb0fe4afc1e9d98950f53b51bdcfb5a73afa0e'
             'f1fa4f06d55afeb2d7f010745d2871d8a6a43140b2abaae173e142e3595aa8ef'
             '8f98770616e9c0457b8e7dd39c01550e300237d3973da96b827f4b4a9eca07f8'
             'e7eb5fdaa0c12122be7f801adf9cf748de806843c6c4e65bb28d042e94e78d88'
+            '8a5a038cdbfdcf56a021cb53bbb6b00328c792d632a12dad99d9df0f33a91461'
             '63b2bda6a487ec69e257c3b7a14d71f6bec649fca058a5a54804f213d45c7c70'
             '2d1dc7f7cd6bd61f275cd0be6650f3086aee622074ac786ff5a921bf8ecaada2'
             '715cb8862753854b2d9256e0b70003e2d1f57083d83eaeaf5a095fc72b8a4e26'
@@ -186,7 +188,8 @@ prepare() {
     "0015-Use-TerminateProcess-to-exit-without-running-destruc.patch" \
     "0016-llvm-rc-Make-commas-in-user-data-structs-optional.patch" \
     "0017-X86-Teach-X86FloatingPoint-s-handleCall-to-only-eras.patch" \
-    "0018-llvm-rc-Allow-dashes-as-part-of-resource-name-strings.patch"
+    "0018-llvm-rc-Allow-dashes-as-part-of-resource-name-strings.patch" \
+    "0019-MinGW-Mark-a-number-of-library-functions-unavailable.patch"
 
   if (( ! _clangprefix )); then
     apply_patch_with_msg \

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -30,7 +30,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
            "${MINGW_PACKAGE_PREFIX}-openmp")
          "${MINGW_PACKAGE_PREFIX}-polly")
 pkgver=12.0.1
-pkgrel=1
+pkgrel=2
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -75,6 +75,7 @@ source=("https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkgver
         "0015-Use-TerminateProcess-to-exit-without-running-destruc.patch"
         "0016-llvm-rc-Make-commas-in-user-data-structs-optional.patch"
         "0017-X86-Teach-X86FloatingPoint-s-handleCall-to-only-eras.patch"
+        "0018-llvm-rc-Allow-dashes-as-part-of-resource-name-strings.patch"
         "0101-Disable-fPIC-errors.patch"
         "0103-Use-posix-style-path-separators-with-MinGW.patch"
         "0104-link-pthread-with-mingw.patch"
@@ -95,6 +96,7 @@ source=("https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkgver
         "0314-LLD-COFF-Support-linking-directly-against-DLLs-in-Mi.patch"
         "0315-LLD-COFF-Fix-up-missing-stdcall-decorations-in-MinGW.patch"
         "0316-LLD-COFF-Avoid-thread-exhaustion-on-32-bit-Windows-h.patch"
+        "0317-LLD-COFF-Make-export-all-symbols-work-as-intended-fo.patch"
         "0401-libcxx-fs.patch"
         "0402-make-the-visibility-attributes-consistent-for-__narr.patch"
         "0601-libunwind-Install-the-DLL-when-doing-ninja-install.patch"
@@ -126,6 +128,7 @@ sha256sums=('129cb25cd13677aad951ce5c2deb0fe4afc1e9d98950f53b51bdcfb5a73afa0e'
             '29b698b06ce1b5a6e8a0850914d335dd30d99a9b4feb1ff9617e69a3038453f1'
             'f1fa4f06d55afeb2d7f010745d2871d8a6a43140b2abaae173e142e3595aa8ef'
             '8f98770616e9c0457b8e7dd39c01550e300237d3973da96b827f4b4a9eca07f8'
+            'e7eb5fdaa0c12122be7f801adf9cf748de806843c6c4e65bb28d042e94e78d88'
             '63b2bda6a487ec69e257c3b7a14d71f6bec649fca058a5a54804f213d45c7c70'
             '2d1dc7f7cd6bd61f275cd0be6650f3086aee622074ac786ff5a921bf8ecaada2'
             '715cb8862753854b2d9256e0b70003e2d1f57083d83eaeaf5a095fc72b8a4e26'
@@ -146,6 +149,7 @@ sha256sums=('129cb25cd13677aad951ce5c2deb0fe4afc1e9d98950f53b51bdcfb5a73afa0e'
             'cc3084b66df118f0b55fef5e0424094ccd8f0101e34a7a6b03d0a93e6da3d7bd'
             '58b3b2954c8e798e21c1a6f10e2f9e7bd8b20cf8a6fa618497657bfc48eaf355'
             '4c854eb5c5e0dcbd60bb6da7aa4296c0fe1d015a8b5866cfa6b0d16fad2e42e6'
+            'cad3256c9a21708ad2f98f51c1d372a42f88c94c46699b6a0458ca03e7b3a928'
             '6cb5d425e36b24a8eb2776ba0e297ea0a986a4086f96a0e60ca3a4ebc1a9d386'
             '3abb69e6dc9ad367240409d2df3c3cd6ddc89325de994195fc7222493baaaa44'
             '9ab6c628eccf0155cebdc73e4f5297820bef54d8f30022ed0c1cbb6ab8ad67b8'
@@ -181,7 +185,8 @@ prepare() {
     "0014-llvm-rc-Don-t-rewrite-the-arch-in-the-default-triple.patch" \
     "0015-Use-TerminateProcess-to-exit-without-running-destruc.patch" \
     "0016-llvm-rc-Make-commas-in-user-data-structs-optional.patch" \
-    "0017-X86-Teach-X86FloatingPoint-s-handleCall-to-only-eras.patch"
+    "0017-X86-Teach-X86FloatingPoint-s-handleCall-to-only-eras.patch" \
+    "0018-llvm-rc-Allow-dashes-as-part-of-resource-name-strings.patch"
 
   if (( ! _clangprefix )); then
     apply_patch_with_msg \
@@ -221,7 +226,8 @@ prepare() {
     "0313-LLD-COFF-Fix-handling-of-LTO-comdats.patch" \
     "0314-LLD-COFF-Support-linking-directly-against-DLLs-in-Mi.patch" \
     "0315-LLD-COFF-Fix-up-missing-stdcall-decorations-in-MinGW.patch" \
-    "0316-LLD-COFF-Avoid-thread-exhaustion-on-32-bit-Windows-h.patch"
+    "0316-LLD-COFF-Avoid-thread-exhaustion-on-32-bit-Windows-h.patch" \
+    "0317-LLD-COFF-Make-export-all-symbols-work-as-intended-fo.patch"
 
   cd "${srcdir}/libcxx"
   apply_patch_with_msg \

--- a/mingw-w64-clang/README-patches.md
+++ b/mingw-w64-clang/README-patches.md
@@ -21,6 +21,7 @@ Legend:
 - `"0015-Use-TerminateProcess-to-exit-without-running-destruc.patch"` :arrow_down_small:
 - `"0016-llvm-rc-Make-commas-in-user-data-structs-optional.patch"` :arrow_down_small:
 - `"0017-X86-Teach-X86FloatingPoint-s-handleCall-to-only-eras.patch"` :arrow_down_small:
+- `"0018-llvm-rc-Allow-dashes-as-part-of-resource-name-strings.patch"` :arrow_down_small:
 - `"0101-Disable-fPIC-errors.patch"` :x:
 - `"0103-Use-posix-style-path-separators-with-MinGW.patch"` :x::x::x: - this one is really imporant
 - `"0104-link-pthread-with-mingw.patch"` :grey_exclamation:
@@ -41,6 +42,7 @@ Legend:
 - `"0314-LLD-COFF-Support-linking-directly-against-DLLs-in-Mi.patch"` :arrow_down_small:
 - `"0315-LLD-COFF-Fix-up-missing-stdcall-decorations-in-MinGW.patch"` :arrow_down_small:
 - `"0316-LLD-COFF-Avoid-thread-exhaustion-on-32-bit-Windows-h.patch"` :arrow_down_small:
+- `"0317-LLD-COFF-Make-export-all-symbols-work-as-intended-fo.patch"` :arrow_down_small:
 - `"0401-libcxx-fs.patch"` :arrow_down_small:
 - `"0402-make-the-visibility-attributes-consistent-for-__narr.patch"` :arrow_down_small:
 - `"0601-libunwind-Install-the-DLL-when-doing-ninja-install.patch"` :arrow_down_small:

--- a/mingw-w64-clang/README-patches.md
+++ b/mingw-w64-clang/README-patches.md
@@ -22,6 +22,7 @@ Legend:
 - `"0016-llvm-rc-Make-commas-in-user-data-structs-optional.patch"` :arrow_down_small:
 - `"0017-X86-Teach-X86FloatingPoint-s-handleCall-to-only-eras.patch"` :arrow_down_small:
 - `"0018-llvm-rc-Allow-dashes-as-part-of-resource-name-strings.patch"` :arrow_down_small:
+- `"0019-MinGW-Mark-a-number-of-library-functions-unavailable.patch"` :arrow_down_small:
 - `"0101-Disable-fPIC-errors.patch"` :x:
 - `"0103-Use-posix-style-path-separators-with-MinGW.patch"` :x::x::x: - this one is really imporant
 - `"0104-link-pthread-with-mingw.patch"` :grey_exclamation:


### PR DESCRIPTION
- Make -export-all-symbols work as intended for EXEs.  Fixes #9163 (llvm/llvm-project@9dbc4b09afd4427c2def829f0c8283f732e654a0)
- Allow dashes as part of resource name strings.  Fixes #9180, fixes #9130 (llvm/llvm-project@0a1683f8cc0df2889f1d86da7a795914f07e5599)
- Mark a number of library functions unavailable for mingw targets.  Fixes #9242 (llvm/llvm-project@c5638a7)