### PR TITLE
spdylay: add makedepends on libxml2

### DIFF
--- a/mingw-w64-spdylay/PKGBUILD
+++ b/mingw-w64-spdylay/PKGBUILD
@@ -5,12 +5,13 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.4.0
 _pkgver=v$pkgver
-pkgrel=2
+pkgrel=3
 pkgdesc="The experimental SPDY protocol version 2, 3 and 3.1 implementation in C (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://tatsuhiro-t.github.io/spdylay/"
 license=('MIT')
+makedepends=("${MINGW_PACKAGE_PREFIX}-libxml2")
 source=("spdylay-${pkgver}.tar.gz::https://github.com/tatsuhiro-t/spdylay/releases/download/${_pkgver}/spdylay-${pkgver}.tar.gz"
          spdylay-1.4.0-fix-zlib.patch)
 sha256sums=('f45641df48f0f8e13fe80166437828201b46f56681b11cd93a614a82ebd5dcba'


### PR DESCRIPTION
It appears to be required for autoreconf (don't know why this didn't fail in CI), but I checked the DLL and it doesn't depend on libxml2 at runtime.