### PR TITLE
fltk: Update to 1.3.7

### DIFF
--- a/mingw-w64-fltk/PKGBUILD
+++ b/mingw-w64-fltk/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=fltk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.3.6
+pkgver=1.3.7
 pkgrel=1
 pkgdesc="C++ user interface toolkit (mingw-w64)"
 arch=('any')
@@ -23,7 +23,7 @@ options=('strip' 'staticlibs' 'buildflags')
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/${_realname}/${_realname}/archive/release-${pkgver}.tar.gz"
         "0001-cmake-fix-install.patch"
         "0002-uuid-mod.patch")
-sha256sums=('20801eedafdfff8d23041cc6e52cb37056c0c673847d972d258ede5fe9711512'
+sha256sums=('019f65810fb0ea5acac14c852193e8f374e822e6a3034a3c80ed8676f6f3a090'
             '2d474bf2587d35aca548c542c897c0add7b19ca427b513419634ce334984c395'
             'd236e644590c913aaed5ca216d2cb5e1010314a7ea078a8131175e342a60ff4b')
 


### PR DESCRIPTION
Like as [1.3.6](https://www.fltk.org/articles.php?L1754) the [1.3.7](https://www.fltk.org/articles.php?L1765) patch release has no any `ABI` changes (just for notes).