### PR TITLE
Split Qt5 into components

### DIFF
--- a/mingw-w64-qt5-pkgs/0001-adjust-qmake-conf-mingw.patch
+++ b/mingw-w64-qt5-pkgs/0001-adjust-qmake-conf-mingw.patch
@@ -1,0 +1,53 @@
+--- a/mkspecs/common/g++-win32.conf	2019-06-12 23:59:14.000000000 +0300
++++ b/mkspecs/common/g++-win32.conf	2019-06-15 14:48:51.365125400 +0300
+@@ -13,6 +13,9 @@
+ include(gcc-base.conf)
+ include(g++-base.conf)
+ 
++include(angle.conf)
++include(windows-vulkan.conf)
++
+ # modifications to gcc-base.conf and g++-base.conf
+ 
+ MAKEFILE_GENERATOR      = MINGW
+@@ -32,6 +35,7 @@
+ QMAKE_CXXFLAGS_RTTI_ON  = -frtti
+ QMAKE_CXXFLAGS_RTTI_OFF = -fno-rtti
+ QMAKE_CXXFLAGS_EXCEPTIONS_ON = -fexceptions -mthreads
++QMAKE_CXXFLAGS_EXCEPTIONS_OFF = -fno-exceptions
+ 
+ QMAKE_INCDIR            =
+ 
+@@ -58,6 +62,9 @@
+ QMAKE_EXTENSION_STATICLIB = a
+ QMAKE_LIB_EXTENSIONS    = a dll.a
+ 
++PKG_CONFIG              = $${CROSS_COMPILE}pkg-config
++QMAKE_PKG_CONFIG        = $${CROSS_COMPILE}pkg-config
++
+ QMAKE_LIBS              =
+ QMAKE_LIBS_GUI          = -lgdi32 -lcomdlg32 -loleaut32 -limm32 -lwinmm -lws2_32 -lole32 -luuid -luser32 -ladvapi32
+ QMAKE_LIBS_NETWORK      = -lws2_32
+@@ -67,14 +74,12 @@
+ QMAKE_LIBS_COMPAT       = -ladvapi32 -lshell32 -lcomdlg32 -luser32 -lgdi32 -lws2_32
+ QMAKE_LIBS_QT_ENTRY     = -lmingw32 -lqtmain
+ 
+-QMAKE_IDL               = midl
++QMAKE_IDL               = $${CROSS_COMPILE}widl
+ QMAKE_LIB               = $${CROSS_COMPILE}ar -rc
+ QMAKE_RC                = $${CROSS_COMPILE}windres
++QMAKE_DLLTOOL           = $${CROSS_COMPILE}dlltool
+ 
+ QMAKE_STRIP             = $${CROSS_COMPILE}strip
+ QMAKE_STRIPFLAGS_LIB   += --strip-unneeded
+ QMAKE_OBJCOPY           = $${CROSS_COMPILE}objcopy
+ QMAKE_NM                = $${CROSS_COMPILE}nm -P
+-
+-include(angle.conf)
+-include(windows-vulkan.conf)
+--- a/mkspecs/common/windows-vulkan.conf	2019-06-12 23:59:14.000000000 +0300
++++ b/mkspecs/common/windows-vulkan.conf	2019-06-15 14:48:51.365125400 +0300
+@@ -1,2 +1,2 @@
+-load(windows_vulkan_sdk)
++load(win32/windows_vulkan_sdk)
+ QMAKE_LIBS_VULKAN       =

--- a/mingw-w64-qt5-pkgs/0002-qt-5.8.0-fix-sql-libraries-mingw.patch
+++ b/mingw-w64-qt5-pkgs/0002-qt-5.8.0-fix-sql-libraries-mingw.patch
@@ -1,0 +1,49 @@
+--- a/src/plugins/sqldrivers/configure.json	2019-06-12 23:59:14.000000000 +0300
++++ b/src/plugins/sqldrivers/configure.json	2019-06-15 14:54:27.297115400 +0300
+@@ -51,7 +51,7 @@
+             "test": {},
+             "headers": "ibase.h",
+             "sources": [
+-                { "libs": "-lgds32_ms", "condition": "config.win32" },
++                { "libs": "-lfbclient", "condition": "config.win32" },
+                 { "libs": "-lgds", "condition": "!config.win32" }
+             ]
+         },
+@@ -67,6 +67,8 @@
+             },
+             "headers": "mysql.h",
+             "sources": [
++                { "libs": "-lmariadbclient -lssl -lcrypto -lgdi32 -lws2_32 -lpthread -lz -lm", "condition": "config.win32 && !features.shared" },
++                { "libs": "-lmariadb", "condition": "config.win32 && features.shared" },
+                 { "type": "mysqlConfig", "query": "--libs_r", "cleanlibs": true },
+                 { "type": "mysqlConfig", "query": "--libs", "cleanlibs": true },
+                 { "type": "mysqlConfig", "query": "--libs_r", "cleanlibs": false },
+@@ -88,9 +90,9 @@
+             },
+             "headers": "libpq-fe.h",
+             "sources": [
+-                { "type": "pkgConfig", "args": "libpq" },
+                 { "type": "psqlConfig" },
+-                { "type": "psqlEnv", "libs": "-llibpq -lws2_32 -ladvapi32", "condition": "config.win32" },
++                { "type": "psqlEnv", "libs": "-lpq -lintl -lssl -lcrypto -lshell32 -lws2_32 -lsecur32 -liconv", "condition": "config.win32 && !features.shared" },
++                { "type": "psqlEnv", "libs": "-lpq", "condition": "config.win32 && features.shared" },
+                 { "type": "psqlEnv", "libs": "-lpq", "condition": "!config.win32" }
+             ]
+         },
+@@ -214,16 +216,6 @@
+         }
+     },
+ 
+-    "report": [
+-        {
+-            "type": "warning",
+-            "condition": "config.win32 && !config.msvc && features.sql-oci",
+-            "message": "Qt does not support compiling the Oracle database driver with
+-MinGW, due to lack of such support from Oracle. Consider disabling the
+-Oracle driver, as the current build will most likely fail."
+-        }
+-    ],
+-
+     "summary": [
+         {
+             "section": "Qt Sql Drivers",

--- a/mingw-w64-qt5-pkgs/0003-qt-5.8.0-configure-gcc-before-clang.patch
+++ b/mingw-w64-qt5-pkgs/0003-qt-5.8.0-configure-gcc-before-clang.patch
@@ -1,0 +1,11 @@
+--- a/configure.bat	2019-06-12 23:59:14.000000000 +0300
++++ b/configure.bat	2019-06-15 14:56:56.262777100 +0300
+@@ -147,7 +147,7 @@
+ :doneargs
+ 
+ rem Find various executables
+-for %%C in (clang-cl.exe clang.exe cl.exe icl.exe g++.exe perl.exe jom.exe) do set %%C=%%~$PATH:C
++for %%C in (g++.exe clang-cl.exe clang.exe cl.exe icl.exe perl.exe jom.exe) do set %%C=%%~$PATH:C
+ 
+ rem Determine host spec
+ 

--- a/mingw-w64-qt5-pkgs/0004-fix-linking-again-different-static-libs.patch
+++ b/mingw-w64-qt5-pkgs/0004-fix-linking-again-different-static-libs.patch
@@ -1,0 +1,24 @@
+--- a/src/corelib/text/qregularexpression.cpp	2019-06-12 23:59:14.000000000 +0300
++++ b/src/corelib/text/qregularexpression.cpp	2019-06-15 14:59:25.087038500 +0300
+@@ -53,6 +53,10 @@
+ #include <QtCore/qdatastream.h>
+ 
+ #define PCRE2_CODE_UNIT_WIDTH 16
++#ifdef QT_STATIC
++#define PCRE_STATIC
++#define PCRE2_STATIC
++#endif
+ 
+ #include <pcre2.h>
+ 
+--- a/src/network/configure.json	2019-06-12 23:59:14.000000000 +0300
++++ b/src/network/configure.json	2019-06-15 14:59:25.102638600 +0300
+@@ -98,7 +98,7 @@
+                     "condition": "config.msvc"
+                 },
+                 {
+-                    "libs": "-lssl -lcrypto",
++                    "libs": "-lssl -lcrypto -lws2_32 -lcrypt32 -lgdi32",
+                     "condition": "!config.msvc"
+                 }
+             ]

--- a/mingw-w64-qt5-pkgs/0005-qt-5.3.0-win_flex-replace.patch
+++ b/mingw-w64-qt5-pkgs/0005-qt-5.3.0-win_flex-replace.patch
@@ -1,0 +1,39 @@
+--- a/src/angle/src/compiler/preprocessor/preprocessor.pro	2019-06-12 23:59:14.000000000 +0300
++++ b/src/angle/src/compiler/preprocessor/preprocessor.pro	2019-06-15 15:04:23.281562300 +0300
+@@ -44,14 +44,14 @@
+     $$ANGLE_DIR/src/compiler/preprocessor/Token.cpp
+ 
+ # NOTE: 'flex' and 'bison' can be found in qt5/gnuwin32/bin
+-flex.commands = $$addGnuPath(flex) --noline --nounistd --outfile=${QMAKE_FILE_OUT} ${QMAKE_FILE_NAME}
++flex.commands = flex --noline --nounistd --outfile=${QMAKE_FILE_OUT} ${QMAKE_FILE_NAME}
+ flex.output = $${BUILDSUBDIR}${QMAKE_FILE_BASE}.cpp
+ flex.input = FLEX_SOURCES
+ flex.dependency_type = TYPE_C
+ flex.variable_out = GENERATED_SOURCES
+ QMAKE_EXTRA_COMPILERS += flex
+ 
+-bison.commands = $$addGnuPath(bison) --no-lines --skeleton=yacc.c --output=${QMAKE_FILE_OUT} ${QMAKE_FILE_NAME}
++bison.commands = bison --no-lines --skeleton=yacc.c --output=${QMAKE_FILE_OUT} ${QMAKE_FILE_NAME}
+ bison.output = $${BUILDSUBDIR}${QMAKE_FILE_BASE}.cpp
+ bison.input = BISON_SOURCES
+ bison.dependency_type = TYPE_C
+--- a/src/angle/src/compiler/translator.pro	2019-06-12 23:59:14.000000000 +0300
++++ b/src/angle/src/compiler/translator.pro	2019-06-15 15:04:23.297162300 +0300
+@@ -194,7 +194,7 @@
+ 
+ 
+ # NOTE: 'flex' and 'bison' can be found in qt5/gnuwin32/bin
+-flex.commands = $$addGnuPath(flex) --noline --nounistd --outfile=${QMAKE_FILE_OUT} ${QMAKE_FILE_NAME}
++flex.commands = flex --noline --nounistd --outfile=${QMAKE_FILE_OUT}_lex.cpp ${QMAKE_FILE_NAME}
+ flex.output = $${BUILDSUBDIR}${QMAKE_FILE_BASE}_lex.cpp
+ flex.input = FLEX_SOURCES
+ flex.dependency_type = TYPE_C
+@@ -202,7 +202,7 @@
+ QMAKE_EXTRA_COMPILERS += flex
+ 
+ defineReplace(myDirName) { return($$dirname(1)) }
+-bison.commands = $$addGnuPath(bison) --no-lines --skeleton=yacc.c --defines=${QMAKE_FILE_OUT} \
++bison.commands = bison --no-lines --skeleton=yacc.c --defines=${QMAKE_FILE_OUT} \
+                 --output=${QMAKE_FUNC_FILE_OUT_myDirName}$$QMAKE_DIR_SEP${QMAKE_FILE_OUT_BASE}.cpp \
+                 ${QMAKE_FILE_NAME}$$escape_expand(\\n\\t) \
+                 @echo // EOF>>${QMAKE_FUNC_FILE_OUT_myDirName}$$QMAKE_DIR_SEP${QMAKE_FILE_OUT_BASE}.cpp

--- a/mingw-w64-qt5-pkgs/0006-qt-5.3.0-win32-g-Enable-static-builds.patch
+++ b/mingw-w64-qt5-pkgs/0006-qt-5.3.0-win32-g-Enable-static-builds.patch
@@ -1,0 +1,22 @@
+--- a/mkspecs/common/g++-win32.conf	2019-06-15 14:54:16.704696800 +0300
++++ b/mkspecs/common/g++-win32.conf	2019-06-15 15:06:52.137023700 +0300
+@@ -49,6 +49,7 @@
+ QMAKE_LFLAGS_CONSOLE    = -Wl,-subsystem,console
+ QMAKE_LFLAGS_WINDOWS    = -Wl,-subsystem,windows
+ QMAKE_LFLAGS_DLL        = -shared
++QMAKE_LFLAGS_STATIC_LIB = -static
+ QMAKE_LFLAGS_GCSECTIONS = -Wl,--gc-sections
+ equals(QMAKE_HOST.os, Windows) {
+     QMAKE_LINK_OBJECT_MAX = 10
+--- a/mkspecs/features/default_post.prf	2019-06-12 23:59:14.000000000 +0300
++++ b/mkspecs/features/default_post.prf	2019-06-15 15:06:52.137023700 +0300
+@@ -87,8 +87,8 @@
+     enable_gdb_index: QMAKE_LFLAGS += $$QMAKE_LFLAGS_GDB_INDEX
+ }
+ 
++static: QMAKE_LFLAGS += $$QMAKE_LFLAGS_STATIC_LIB
+ dll:win32: QMAKE_LFLAGS += $$QMAKE_LFLAGS_DLL
+-static:mac: QMAKE_LFLAGS += $$QMAKE_LFLAGS_STATIC_LIB
+ staticlib:unix {
+     QMAKE_CFLAGS += $$QMAKE_CFLAGS_STATIC_LIB
+     QMAKE_CXXFLAGS += $$QMAKE_CXXFLAGS_STATIC_LIB

--- a/mingw-w64-qt5-pkgs/0007-qt-5.3.0-win32-g-Add-QMAKE_EXTENSION_IMPORTLIB-defaulting-to-.patch
+++ b/mingw-w64-qt5-pkgs/0007-qt-5.3.0-win32-g-Add-QMAKE_EXTENSION_IMPORTLIB-defaulting-to-.patch
@@ -1,0 +1,95 @@
+--- a/mkspecs/common/g++-win32.conf	2019-06-15 15:09:10.556066900 +0300
++++ b/mkspecs/common/g++-win32.conf	2019-06-15 15:09:21.226485600 +0300
+@@ -61,7 +61,7 @@
+ QMAKE_EXTENSION_SHLIB   = dll
+ QMAKE_PREFIX_STATICLIB  = lib
+ QMAKE_EXTENSION_STATICLIB = a
+-QMAKE_LIB_EXTENSIONS    = a dll.a
++QMAKE_EXTENSION_IMPORTLIB = dll.a
+ 
+ PKG_CONFIG              = $${CROSS_COMPILE}pkg-config
+ QMAKE_PKG_CONFIG        = $${CROSS_COMPILE}pkg-config
+--- a/mkspecs/features/create_cmake.prf
++++ b/mkspecs/features/create_cmake.prf
+@@ -332,8 +332,14 @@ mac {
+         CMAKE_WINMAIN_FILE_LOCATION_DEBUG = libqtmain$${QT_LIBINFIX}$${debug_suffix}.a
+         CMAKE_WINMAIN_FILE_LOCATION_RELEASE = libqtmain$${QT_LIBINFIX}.a
+
+-        CMAKE_IMPLIB_FILE_LOCATION_DEBUG = lib$${CMAKE_QT_STEM}$${debug_suffix}.a
+-        CMAKE_IMPLIB_FILE_LOCATION_RELEASE = lib$${CMAKE_QT_STEM}.a
++        !isEmpty(CMAKE_STATIC_TYPE) {
++            CMAKE_IMPLIB_FILE_LOCATION_DEBUG = lib$${CMAKE_QT_STEM}$${debug_suffix}.a
++            CMAKE_IMPLIB_FILE_LOCATION_RELEASE = lib$${CMAKE_QT_STEM}.a
++        } else {
++            isEmpty(QMAKE_EXTENSION_IMPORTLIB): QMAKE_EXTENSION_IMPORTLIB = dll.a
++            CMAKE_IMPLIB_FILE_LOCATION_DEBUG = lib$${CMAKE_QT_STEM}$${debug_suffix}.$${QMAKE_EXTENSION_IMPORTLIB}
++            CMAKE_IMPLIB_FILE_LOCATION_RELEASE = lib$${CMAKE_QT_STEM}.$${QMAKE_EXTENSION_IMPORTLIB}
++        }
+     } else {
+         CMAKE_WINMAIN_FILE_LOCATION_DEBUG = qtmain$${QT_LIBINFIX}$${debug_suffix}.lib
+         CMAKE_WINMAIN_FILE_LOCATION_RELEASE = qtmain$${QT_LIBINFIX}.lib
+--- a/mkspecs/features/qt.prf	2019-06-12 23:59:14.000000000 +0300
++++ b/mkspecs/features/qt.prf	2019-06-15 15:09:21.226485600 +0300
+@@ -216,8 +216,12 @@
+                 LIBS$$var_sfx += -framework $$framework
+             } else {
+                 lib = $$MODULE_MODULE$$qtPlatformTargetSuffix()
+-                win32|contains(MODULE_CONFIG, staticlib) {
+-                    lib = $$MODULE_LIBS/$$QMAKE_PREFIX_STATICLIB$${lib}.$$QMAKE_EXTENSION_STATICLIB
++                win32 {
++                    contains(MODULE_CONFIG, staticlib) {
++                        lib = $$MODULE_LIBS/$$QMAKE_PREFIX_STATICLIB$${lib}.$$QMAKE_EXTENSION_STATICLIB
++                    } else {
++                        lib = $$MODULE_LIBS/$$QMAKE_PREFIX_STATICLIB$${lib}.$$QMAKE_EXTENSION_IMPORTLIB
++                    }
+                     PRE_TARGETDEPS += $$lib
+                 } else {
+                     lib = $$MODULE_LIBS/$$QMAKE_PREFIX_SHLIB$${lib}.$$QMAKE_EXTENSION_SHLIB
+--- a/qmake/generators/win32/winmakefile.cpp	2019-06-12 23:59:14.000000000 +0300
++++ b/qmake/generators/win32/winmakefile.cpp	2019-06-15 15:09:21.226485600 +0300
+@@ -99,10 +99,16 @@
+ bool
+ Win32MakefileGenerator::findLibraries(bool linkPrl, bool mergeLflags)
+ {
+-    ProStringList impexts = project->values("QMAKE_LIB_EXTENSIONS");
+-    if (impexts.isEmpty())
+-        impexts = project->values("QMAKE_EXTENSION_STATICLIB");
+-    QVector<LibrarySearchPath> dirs;
++    ProStringList impexts;
++    if (project->isActiveConfig("staticlib")) {
++        impexts.append(project->values("QMAKE_EXTENSION_STATICLIB"));
++    } else {
++        impexts.append(project->values("QMAKE_EXTENSION_IMPORTLIB"));
++        impexts.append(project->values("QMAKE_EXTENSION_STATICLIB"));
++    }
++    QVector<LibrarySearchPath> dirs;
++    QString qt_prefix_libs = project->propertyValue(ProKey("QT_INSTALL_LIBS")).toQString();
++    dirs.append(qt_prefix_libs);
+     int libidx = 0;
+     for (const ProString &dlib : project->values("QMAKE_DEFAULT_LIBDIRS"))
+         dirs.append(LibrarySearchPath(dlib.toQString()));
+@@ -283,9 +289,12 @@
+     if (!project->values("QMAKE_APP_FLAG").isEmpty()) {
+         project->values("TARGET_EXT").append(".exe");
+     } else if (project->isActiveConfig("shared")) {
++        ProString impext = project->first("QMAKE_EXTENSION_IMPORTLIB");
++        if (impext.isEmpty())
++          impext = project->first("QMAKE_PREFIX_STATICLIB");
+         project->values("LIB_TARGET").prepend(project->first("QMAKE_PREFIX_STATICLIB")
+                                               + project->first("TARGET") + project->first("TARGET_VERSION_EXT")
+-                                              + '.' + project->first("QMAKE_EXTENSION_STATICLIB"));
++                                              + '.' + impext);
+         project->values("TARGET_EXT").append(project->first("TARGET_VERSION_EXT") + "."
+                 + project->first("QMAKE_EXTENSION_SHLIB"));
+         project->values("TARGET").first() = project->first("QMAKE_PREFIX_SHLIB") + project->first("TARGET");
+--- a/src/corelib/global/qlibraryinfo.cpp    2020-01-24 09:18:55.394378700 +0000
++++ b/src/corelib/global/qlibraryinfo.cpp  2020-01-24 09:18:01.235198900 +0000
+@@ -596,7 +596,7 @@
+         const QLatin1Char slash('/');
+ #if defined(Q_CC_MINGW)
+         const QString implibPrefix = QStringLiteral("lib");
+-        const QString implibSuffix = QStringLiteral(".a");
++        const QString implibSuffix = QStringLiteral(".dll.a");
+ #else
+         const QString implibPrefix;
+         const QString implibSuffix = QStringLiteral(".lib");

--- a/mingw-w64-qt5-pkgs/0008-qt-5.8.0-mingw-dbus-and-pkg-config.patch
+++ b/mingw-w64-qt5-pkgs/0008-qt-5.8.0-mingw-dbus-and-pkg-config.patch
@@ -1,0 +1,49 @@
+--- a/configure.json	2019-06-12 23:59:14.000000000 +0300
++++ b/configure.json	2019-06-15 15:11:51.548349600 +0300
+@@ -190,18 +190,20 @@
+         "dbus": {
+             "label": "D-Bus >= 1.2",
+             "test": {
+-                "main": "(void) dbus_bus_get_private(DBUS_BUS_SYSTEM, (DBusError *)NULL);"
++                "main": "(void) dbus_bus_get_private(DBUS_BUS_SYSTEM, (DBusError *)NULL);",
++                "qmake": "static: DEFINES += DBUS_STATIC_BUILD"
+             },
+             "headers": "dbus/dbus.h",
+             "sources": [
+-                { "type": "pkgConfig", "args": "dbus-1 >= 1.2" },
++                { "type": "pkgConfig", "args": "dbus-1 >= 1.2", "condition": "features.shared" },
++                { "type": "pkgConfig", "args": "--static dbus-1 >= 1.2", "condition": "!features.shared" },
+                 {
+                     "libs": "",
+                     "builds": {
+-                        "debug": "-ldbus-1d",
++                        "debug": "-ldbus-1",
+                         "release": "-ldbus-1"
+                     },
+-                    "condition": "config.win32"
++                    "condition": "config.win32 && features.shared"
+                 },
+                 { "libs": "-ldbus-1", "condition": "!config.win32" }
+             ]
+@@ -766,7 +768,7 @@
+         },
+         "pkg-config": {
+             "label": "Using pkg-config",
+-            "autoDetect": "!config.darwin && !config.win32",
++            "autoDetect": "!config.darwin && !config.msvc",
+             "condition": "tests.pkg-config",
+             "output": [
+                 "publicFeature",
+--- a/src/dbus/qdbus_symbols_p.h	2019-06-12 23:59:14.000000000 +0300
++++ b/src/dbus/qdbus_symbols_p.h	2019-06-15 15:11:51.563949700 +0300
+@@ -57,6 +57,10 @@
+ 
+ #ifndef QT_NO_DBUS
+ 
++#ifdef QT_STATIC
++#  define DBUS_STATIC_BUILD
++#endif
++
+ #ifdef QT_LINKED_LIBDBUS
+ #  include <dbus/dbus.h>
+ #else

--- a/mingw-w64-qt5-pkgs/0009-qt-5.8.0-win32-g++-use-qpa-genericunixfontdatabase.patch
+++ b/mingw-w64-qt5-pkgs/0009-qt-5.8.0-win32-g++-use-qpa-genericunixfontdatabase.patch
@@ -1,0 +1,11 @@
+--- a/src/platformsupport/fontdatabases/fontdatabases.pro	2019-06-12 23:59:14.000000000 +0300
++++ b/src/platformsupport/fontdatabases/fontdatabases.pro	2019-06-15 15:14:20.763611800 +0300
+@@ -15,7 +15,7 @@
+     include($$PWD/freetype/freetype.pri)
+ }
+ 
+-unix {
++-unix|win32-g++|win32-clang-g++ {
+     include($$PWD/genericunix/genericunix.pri)
+     qtConfig(fontconfig) {
+         include($$PWD/fontconfig/fontconfig.pri)

--- a/mingw-w64-qt5-pkgs/0010-qt-5.8.0-force-using-make-on-msys.patch
+++ b/mingw-w64-qt5-pkgs/0010-qt-5.8.0-force-using-make-on-msys.patch
@@ -1,0 +1,16 @@
+--- a/mkspecs/features/configure_base.prf	2019-06-12 23:59:14.000000000 +0300
++++ b/mkspecs/features/configure_base.prf	2019-06-15 15:19:20.285137900 +0300
+@@ -10,10 +10,10 @@
+ !isEmpty(QMAKE_MAKE) {
+     # We were called recursively. Use the same make.
+ } else: if(equals(MAKEFILE_GENERATOR, UNIX)|equals(MAKEFILE_GENERATOR, MINGW)) {
+-    !equals(QMAKE_HOST.os, Windows): \
+-        QMAKE_MAKE = make
+-    else: \
++    equals(QMAKE_HOST.os, Windows):isEmpty(QMAKE_SH): \
+         QMAKE_MAKE = mingw32-make
++    else: \
++        QMAKE_MAKE = make
+ } else: if(equals(MAKEFILE_GENERATOR, MSVC.NET)|equals(MAKEFILE_GENERATOR, MSBUILD)) {
+     QMAKE_MAKE = nmake
+ } else {

--- a/mingw-w64-qt5-pkgs/0011-qt-5.8.0-Revert-untangle-use-of-system-vs.-shell-path-list-se.patch
+++ b/mingw-w64-qt5-pkgs/0011-qt-5.8.0-Revert-untangle-use-of-system-vs.-shell-path-list-se.patch
@@ -1,0 +1,72 @@
+--- a/mkspecs/features/default_post.prf	2019-06-15 15:09:10.556066900 +0300
++++ b/mkspecs/features/default_post.prf	2019-06-15 15:21:47.611796700 +0300
+@@ -113,8 +113,8 @@
+ 
+ breakpad {
+     load(resolve_target)
+-    DEBUGFILENAME = $$shell_quote($$system_path($$QMAKE_RESOLVED_TARGET))
+-    PROJECTPATH = $$shell_quote($$system_path($$OUT_PWD))
++    DEBUGFILENAME = $$shell_quote($$shell_path($$QMAKE_RESOLVED_TARGET))
++    PROJECTPATH = $$shell_quote($$shell_path($$OUT_PWD))
+ 
+     !isEmpty(QMAKE_POST_LINK):QMAKE_POST_LINK = $$QMAKE_POST_LINK$$escape_expand(\\n\\t)
+     QMAKE_POST_LINK = $$QMAKE_POST_LINK$$quote($${QT_BREAKPAD_ROOT_PATH}$${QMAKE_DIR_SEP}qtbreakpadsymbols $$DEBUGFILENAME $$PROJECTPATH)
+--- a/mkspecs/features/incredibuild_xge.prf	2019-06-12 23:59:14.000000000 +0300
++++ b/mkspecs/features/incredibuild_xge.prf	2019-06-15 15:21:47.611796700 +0300
+@@ -3,6 +3,6 @@
+     EOC = $$escape_expand(\\r\\h)
+ 
+     for(xge, INCREDIBUILD_XGE) {
+-        $${xge}.commands = Rem IncrediBuild_AllowRemote $$EOC Rem IncrediBuild_OutputFile $$system_path($${xge}.output) $$EOC $$eval($${xge}.commands)
++        $${xge}.commands = Rem IncrediBuild_AllowRemote $$EOC Rem IncrediBuild_OutputFile $$shell_path($${xge}.output) $$EOC $$eval($${xge}.commands)
+     }
+ }
+--- a/mkspecs/features/java.prf	2019-06-12 23:59:14.000000000 +0300
++++ b/mkspecs/features/java.prf	2019-06-15 15:21:47.611796700 +0300
+@@ -28,7 +28,7 @@
+ javac_source_version = $$ANDROID_JAVAC_SOURCE_VERSION
+ isEmpty(javac_source_version): javac_source_version = 7
+ 
+-javac.commands = javac -source $$javac_source_version -target $$javac_target_version -Xlint:unchecked -bootclasspath $$ANDROID_JAR_FILE -cp $$shell_quote($$system_path($$join(JAVACLASSPATH, $$DIRLIST_SEPARATOR))) -d $$shell_quote($$CLASS_DIR) ${QMAKE_FILE_IN}
++javac.commands = javac -source $$javac_source_version -target $$javac_target_version -Xlint:unchecked -bootclasspath $$ANDROID_JAR_FILE -cp $$shell_quote($$shell_path($$join(JAVACLASSPATH, $$DIRLIST_SEPARATOR))) -d $$shell_quote($$CLASS_DIR) ${QMAKE_FILE_IN}
+ 
+ # Force rebuild every time, because we don't know the paths of the destination files
+ # as they depend on the code.
+--- a/mkspecs/features/testcase.prf	2019-06-12 23:59:14.000000000 +0300
++++ b/mkspecs/features/testcase.prf	2019-06-15 15:21:47.611796700 +0300
+@@ -85,8 +85,7 @@
+ # Allow for custom arguments to tests
+ $${type}.commands += $(TESTARGS)
+ 
+-!isEmpty(TESTRUN_CWD):!contains(TESTRUN_CWD, ^\\./?): \
+-    $${type}.commands = $$QMAKE_CD $$shell_path($$TESTRUN_CWD) && $$eval($${type}.commands)
++    $${type}.commands = $$QMAKE_CD $$system_path($$TESTRUN_CWD) && $$eval($${type}.commands)
+ 
+ # If the test is marked as insignificant, discard the exit code
+ insignificant_test: $${type}.commands = -$$eval($${type}.commands)
+--- a/mkspecs/features/win32/windeployqt.prf	2019-06-12 23:59:14.000000000 +0300
++++ b/mkspecs/features/win32/windeployqt.prf	2019-06-15 15:21:47.627396700 +0300
+@@ -3,9 +3,9 @@
+ build_pass {
+     load(resolve_target)
+ 
+-    isEmpty(WINDEPLOYQT_OPTIONS): WINDEPLOYQT_OPTIONS = -qmldir $$shell_quote($$system_path($$_PRO_FILE_PWD_))
+-    WINDEPLOYQT_TARGET = $$shell_quote($$system_path($$QMAKE_RESOLVED_TARGET))
+-    WINDEPLOYQT_OUTPUT = $$shell_quote($$system_path($$dirname(QMAKE_RESOLVED_TARGET)/$$basename(TARGET).windeployqt))
++    isEmpty(WINDEPLOYQT_OPTIONS): WINDEPLOYQT_OPTIONS = -qmldir $$shell_quote($$shell_path($$_PRO_FILE_PWD_))
++    WINDEPLOYQT_TARGET = $$shell_quote($$shell_path($$QMAKE_RESOLVED_TARGET))
++    WINDEPLOYQT_OUTPUT = $$shell_quote($$shell_path($$dirname(QMAKE_RESOLVED_TARGET)/$$basename(TARGET).windeployqt))
+     windeployqt.target = windeployqt
+     windeployqt.commands = $$QMAKE_WINDEPLOYQT $$WINDEPLOYQT_OPTIONS -list target $$WINDEPLOYQT_TARGET > $$WINDEPLOYQT_OUTPUT
+ 
+--- a/qtbase.pro	2019-06-12 23:59:14.000000000 +0300
++++ b/qtbase.pro	2019-06-15 15:21:47.627396700 +0300
+@@ -57,7 +57,7 @@
+ # qtPrepareTool() to find the non-installed syncqt.
+ prefix_build|!equals(PWD, $$OUT_PWD) {
+ 
+-    cmd = perl -w $$system_path($$PWD/bin/syncqt.pl)
++    cmd = perl -w $$shell_path($$PWD/bin/syncqt.pl)
+ 
+     TOOL_PRI = $$OUT_PWD/mkspecs/modules/qt_tool_syncqt.pri
+ 

--- a/mingw-w64-qt5-pkgs/0012-qt-5.8.0-Revert-fix-quoting-and-path-separators-in-qtPrepareT.patch
+++ b/mingw-w64-qt5-pkgs/0012-qt-5.8.0-Revert-fix-quoting-and-path-separators-in-qtPrepareT.patch
@@ -1,0 +1,78 @@
+--- a/mkspecs/features/qt_functions.prf	2019-06-12 23:59:14.000000000 +0300
++++ b/mkspecs/features/qt_functions.prf	2019-06-15 15:24:17.668460200 +0300
+@@ -85,40 +85,36 @@
+ 
+ # variable, default, [suffix for variable for system() use], [prepare primary variable for system() use]
+ defineTest(qtPrepareTool) {
+-    cmd = $$eval(QT_TOOL.$${2}.binary)
+-    isEmpty(cmd) {
+-        cmd = $$[QT_HOST_BINS]/$$2
+-        exists($${cmd}.pl) {
+-            $${1}_EXE = $${cmd}.pl
+-            cmd = perl -w $$system_path($${cmd}.pl)
++    $$1 = $$eval(QT_TOOL.$${2}.binary)
++    isEmpty($$1) {
++        $$1 = $$[QT_HOST_BINS]/$$2
++        exists($$eval($$1).pl) {
++            $${1}_EXE =  $$eval($$1).pl
++            $$1 = perl -w $$eval($$1).pl
+         } else: contains(QMAKE_HOST.os, Windows) {
+-            $${1}_EXE = $${cmd}.exe
+-            cmd = $$system_path($${cmd}.exe)
++            $${1}_EXE = $$eval($$1).exe
++            $$1 = $$eval($$1).exe
+         } else:contains(QMAKE_HOST.os, Darwin) {
+-            BUNDLENAME = $${cmd}.app/Contents/MacOS/$$2
++            BUNDLENAME = $$eval($$1).app/Contents/MacOS/$$2
+             exists($$BUNDLENAME) {
+-                cmd = $$BUNDLENAME
++                $$1 = $$BUNDLENAME
+             }
+-            $${1}_EXE = $$cmd
++            $${1}_EXE = $$eval($$1).exe
+         } else {
+-            $${1}_EXE = $$cmd
++            $${1}_EXE = $$eval($$1).exe
+         }
+     } else {
+-        $${1}_EXE = $$last(cmd)
++        $${1}_EXE = $$last($$eval($$1))
+     }
+     export($${1}_EXE)
+     QT_TOOL_ENV += $$eval(QT_TOOL.$${2}.envvars)
+     QT_TOOL_NAME = $$2
+     !isEmpty(3)|!isEmpty(4) {
+-        $$1$$3 =
+-        for (arg, cmd): \
+-            $$1$$3 += $$system_quote($$arg)
++        $$1$$3 = $$system_path($$eval($$1))
+         qtAddTargetEnv($$1$$3, QT_TOOL.$${2}.depends, system)
+     }
+     isEmpty(4) {
+-        $$1 =
+-        for (arg, cmd): \
+-            $$1 += $$shell_quote($$arg)
++        $$1 = $$shell_path($$eval($$1))
+         qtAddTargetEnv($$1, QT_TOOL.$${2}.depends, )
+     }
+ }
+--- a/mkspecs/features/qt_tool.prf	2019-06-12 23:59:14.000000000 +0300
++++ b/mkspecs/features/qt_tool.prf	2019-06-15 15:24:17.668460200 +0300
+@@ -50,15 +50,14 @@
+             module_envvars =
+         }
+ 
+-        bin = $$system_path($$QMAKE_RESOLVED_TARGET)
++        bin = $$QMAKE_RESOLVED_TARGET
+     } else {
+         bin = $${HOST_QT_TOOLS}/$${TARGET}
+         equals(QMAKE_HOST.os, Windows): bin = $${bin}.exe
+-        bin = $$system_path($$bin)
+     }
+ 
+     TOOL_PRI_CONT = \
+-        "QT_TOOL.$${MODULE}.binary = $$val_escape(bin)" \
++        "QT_TOOL.$${MODULE}.binary = $$bin" \
+         "QT_TOOL.$${MODULE}.depends =$$join(MODULE_DEPENDS, " ", " ")" \
+         $$module_envvars
+     write_file($$TOOL_PRI, TOOL_PRI_CONT)|error()

--- a/mingw-w64-qt5-pkgs/0013-qt-5.3.1-workaround-ansidecl-h-PTR-define-conflict.patch
+++ b/mingw-w64-qt5-pkgs/0013-qt-5.3.1-workaround-ansidecl-h-PTR-define-conflict.patch
@@ -1,0 +1,24 @@
+--- a/src/network/kernel/qdnslookup.h	2019-06-12 23:59:14.000000000 +0300
++++ b/src/network/kernel/qdnslookup.h	2019-06-15 15:26:47.147922800 +0300
+@@ -196,6 +196,10 @@
+     };
+     Q_ENUM(Error)
+ 
++#ifdef PTR
++#define PTR_OLD_DEFINE PTR
++#undef PTR
++#endif
+     enum Type
+     {
+         A = 1,
+@@ -209,6 +213,10 @@
+         TXT = 16
+     };
+     Q_ENUM(Type)
++// Set PTR back what it previously contained.
++#ifdef PTR_OLD_DEFINE
++#define PTR PTR_OLD_DEFINE
++#endif
+ 
+     explicit QDnsLookup(QObject *parent = nullptr);
+     QDnsLookup(Type type, const QString &name, QObject *parent = nullptr);

--- a/mingw-w64-qt5-pkgs/0014-qt-5.3.2-dont-add-resource-files-to-qmake-libs.patch
+++ b/mingw-w64-qt5-pkgs/0014-qt-5.3.2-dont-add-resource-files-to-qmake-libs.patch
@@ -1,0 +1,11 @@
+--- a/qmake/generators/win32/mingw_make.cpp	2019-06-12 23:59:14.000000000 +0300
++++ b/qmake/generators/win32/mingw_make.cpp	2019-06-15 15:34:10.657701800 +0300
+@@ -147,7 +147,7 @@
+ 
+     processVars();
+ 
+-    project->values("LIBS") += project->values("RES_FILE");
++    project->values("OBJECTS") += project->values("RES_FILE");
+ 
+     if (project->isActiveConfig("dll")) {
+         QString destDir = "";

--- a/mingw-w64-qt5-pkgs/0015-qt-5.3.2-win32-qt5-static-cmake-link-ws2_32-and--static.patch
+++ b/mingw-w64-qt5-pkgs/0015-qt-5.3.2-win32-qt5-static-cmake-link-ws2_32-and--static.patch
@@ -1,0 +1,18 @@
+--- a/src/corelib/Qt5CoreConfigExtras.cmake.in	2019-06-12 23:59:14.000000000 +0300
++++ b/src/corelib/Qt5CoreConfigExtras.cmake.in	2019-06-15 15:36:39.653563500 +0300
+@@ -183,6 +183,15 @@
+ endif()
+ 
+ _qt5_Core_check_file_exists(${_Qt5CTestMacros})
++
++get_target_property(_libType Qt5::Core TYPE)
++if(_libType STREQUAL \"STATIC_LIBRARY\" AND WIN32)
++    set(_isExe $<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>)
++    # INTERFACE_LINK_LIBRARIES is used to pass a linker flag (-static)
++    #                                      and a library (ws2_32)
++    set_property(TARGET Qt5::Core APPEND PROPERTY INTERFACE_LINK_LIBRARIES \"$<${_isExe}:-static;ws2_32>\")
++    unset(_isExe)
++endif()
+ 
+ # Create versionless tool targets.
+ foreach(__qt_tool qmake moc rcc)

--- a/mingw-w64-qt5-pkgs/0016-qt-5.4.2-win32-Avoid-platformNativeInterface-segfaults-with-minimal-platform.patch
+++ b/mingw-w64-qt5-pkgs/0016-qt-5.4.2-win32-Avoid-platformNativeInterface-segfaults-with-minimal-platform.patch
@@ -1,0 +1,53 @@
+--- a/src/widgets/dialogs/qmessagebox.cpp	2019-06-12 23:59:14.000000000 +0300
++++ b/src/widgets/dialogs/qmessagebox.cpp	2019-06-15 15:58:57.794713900 +0300
+@@ -77,9 +77,11 @@
+ #if defined(Q_OS_WIN) && !defined(Q_OS_WINRT)
+ HMENU qt_getWindowsSystemMenu(const QWidget *w)
+ {
+-    if (QWindow *window = QApplicationPrivate::windowForWidget(w))
+-        if (void *handle = QGuiApplication::platformNativeInterface()->nativeResourceForWindow("handle", window))
+-            return GetSystemMenu(reinterpret_cast<HWND>(handle), false);
++    if (QGuiApplication::platformNativeInterface()) {
++        if (QWindow *window = QApplicationPrivate::windowForWidget(w))
++            if (void *handle = QGuiApplication::platformNativeInterface()->nativeResourceForWindow("handle", window))
++                return GetSystemMenu(reinterpret_cast<HWND>(handle), false);
++    }
+     return 0;
+ }
+ #endif
+--- a/src/widgets/dialogs/qwizard_win.cpp	2019-06-12 23:59:14.000000000 +0300
++++ b/src/widgets/dialogs/qwizard_win.cpp	2019-06-15 15:58:57.810314000 +0300
+@@ -176,10 +176,11 @@
+         // The dynamic property takes effect when creating the platform window.
+         window->setProperty("_q_windowsCustomMargins", customMarginsV);
+         // If a platform window exists, change via native interface.
+-        if (QPlatformWindow *platformWindow = window->handle()) {
+-            QGuiApplication::platformNativeInterface()->
+-                setWindowProperty(platformWindow, QStringLiteral("WindowsCustomMargins"),
+-                                  customMarginsV);
++        if (QGuiApplication::platformNativeInterface()) {
++            if (QPlatformWindow *platformWindow = window->handle())
++                QGuiApplication::platformNativeInterface()->
++                    setWindowProperty(platformWindow, QStringLiteral("WindowsCustomMargins"),
++                                      customMarginsV);
+         }
+     }
+ }
+@@ -578,6 +579,8 @@
+ // wizard is a child window.
+ HDC QVistaHelper::backingStoreDC(const QWidget *wizard, QPoint *offset)
+ {
++    if (!QGuiApplication::platformNativeInterface())
++        return static_cast<HDC>(0);
+     HDC hdc = static_cast<HDC>(QGuiApplication::platformNativeInterface()->nativeResourceForBackingStore(QByteArrayLiteral("getDC"), wizard->backingStore()));
+     *offset = QPoint(0, 0);
+     if (!wizard->windowHandle())
+@@ -592,7 +595,7 @@
+     // Do not use winId() as this enforces native children of the parent
+     // widget when called before show() as happens when calling setWizardStyle().
+     if (QWindow *window = wizard->windowHandle())
+-        if (window->handle())
++        if (window->handle() && QGuiApplication::platformNativeInterface())
+             if (void *vHwnd = QGuiApplication::platformNativeInterface()->nativeResourceForWindow(QByteArrayLiteral("handle"), window))
+                 return static_cast<HWND>(vHwnd);
+     qWarning().nospace() << "Failed to obtain HWND for wizard.";

--- a/mingw-w64-qt5-pkgs/0017-qt-5.8.0-win32-do-not-use-fontconfig.patch
+++ b/mingw-w64-qt5-pkgs/0017-qt-5.8.0-win32-do-not-use-fontconfig.patch
@@ -1,0 +1,11 @@
+--- a/src/plugins/platforms/minimal/qminimalintegration.cpp	2019-06-12 23:59:14.000000000 +0300
++++ b/src/plugins/platforms/minimal/qminimalintegration.cpp	2019-06-15 16:01:25.262773000 +0300
+@@ -162,7 +162,7 @@
+ #endif
+ 
+         if (!m_fontDatabase) {
+-#if QT_CONFIG(fontconfig)
++#if QT_CONFIG(fontconfig) && !defined(Q_OS_WIN)
+             m_fontDatabase = new QGenericUnixFontDatabase;
+ #else
+             m_fontDatabase = QPlatformIntegration::fontDatabase();

--- a/mingw-w64-qt5-pkgs/0018-win32-dont-need-flatpack-theme.patch
+++ b/mingw-w64-qt5-pkgs/0018-win32-dont-need-flatpack-theme.patch
@@ -1,0 +1,10 @@
+--- a/src/plugins/platformthemes/platformthemes.pro	2019-06-12 23:59:14.000000000 +0300
++++ b/src/plugins/platformthemes/platformthemes.pro	2019-06-15 16:08:52.312758200 +0300
+@@ -1,6 +1,6 @@
+ TEMPLATE = subdirs
+ QT_FOR_CONFIG += widgets-private
+ 
+-qtConfig(dbus):qtConfig(regularexpression):qtConfig(mimetype): SUBDIRS += xdgdesktopportal
++qtConfig(dbus):qtConfig(regularexpression):qtConfig(mimetype):!win32: SUBDIRS += xdgdesktopportal
+ 
+ qtHaveModule(widgets):qtConfig(gtk3): SUBDIRS += gtk3

--- a/mingw-w64-qt5-pkgs/0019-qt-5.11-static_icu.patch
+++ b/mingw-w64-qt5-pkgs/0019-qt-5.11-static_icu.patch
@@ -1,0 +1,13 @@
+--- a/src/corelib/configure.json	2019-06-12 23:59:14.000000000 +0300
++++ b/src/corelib/configure.json	2019-06-15 16:11:20.481818500 +0300
+@@ -108,8 +108,8 @@
+             "sources": [
+                 {
+                     "builds": {
+-                        "debug": "-lsicuind -lsicuucd -lsicudtd",
+-                        "release": "-lsicuin -lsicuuc -lsicudt"
++                        "debug": "-licuin -licuuc -licudt",
++                        "release": "-licuin -licuuc -licudt"
+                     },
+                     "condition": "config.win32 && !features.shared"
+                 },

--- a/mingw-w64-qt5-pkgs/0020-fix-and-enable-iconv-codec.patch
+++ b/mingw-w64-qt5-pkgs/0020-fix-and-enable-iconv-codec.patch
@@ -1,0 +1,61 @@
+--- a/src/corelib/codecs/qiconvcodec.cpp	2019-06-12 23:59:14.000000000 +0300
++++ b/src/corelib/codecs/qiconvcodec.cpp	2019-06-15 16:13:47.730477100 +0300
+@@ -47,7 +47,6 @@
+ #include <errno.h>
+ #include <locale.h>
+ #include <stdio.h>
+-#include <dlfcn.h>
+ 
+ // unistd.h is needed for the _XOPEN_UNIX macro
+ #include <unistd.h>
+@@ -180,7 +179,7 @@
+     IconvState *state = *pstate;
+     size_t inBytesLeft = len;
+     // best case assumption, each byte is converted into one UTF-16 character, plus 2 bytes for the BOM
+-#if !QT_CONFIG(posix_libiconv)
++#if !QT_CONFIG(posix_libiconv) && !defined(Q_OS_WIN)
+     // GNU doesn't disagree with POSIX :/
+     const char *inBytes = chars;
+ #else
+@@ -279,7 +278,7 @@
+     size_t outBytesLeft = sizeof buf;
+     size_t inBytesLeft = sizeof bom;
+ 
+-#if !QT_CONFIG(posix_libiconv)
++#if !QT_CONFIG(posix_libiconv) && !defined(Q_OS_WIN)
+     const char **inBytesPtr = const_cast<const char **>(&inBytes);
+ #else
+     char **inBytesPtr = &inBytes;
+@@ -301,7 +300,7 @@
+     char *outBytes;
+     size_t inBytesLeft;
+ 
+-#if !QT_CONFIG(posix_libiconv)
++#if !QT_CONFIG(posix_libiconv) && !defined(Q_OS_WIN)
+     const char **inBytesPtr = const_cast<const char **>(&inBytes);
+ #else
+     char **inBytesPtr = &inBytes;
+diff -Naur a/src/corelib/configure.json b/src/corelib/configure.json
+--- a/src/corelib/configure.json	2019-06-15 16:13:37.106858400 +0300
++++ b/src/corelib/configure.json	2019-06-15 16:13:47.730477100 +0300
+@@ -72,7 +72,7 @@
+             "test": {
+                 "main": [
+                     "iconv_t x = iconv_open(\"\", \"\");",
+-                    "const char *inp;",
++                    "char *inp;",
+                     "char *outp;",
+                     "size_t inbytes, outbytes;",
+                     "iconv(x, &inp, &inbytes, &outp, &outbytes);",
+@@ -673,9 +673,9 @@
+         },
+         "gnu-libiconv": {
+             "label": "GNU iconv",
+-            "enable": "input.iconv == 'gnu'",
++            "enable": "'enabling via -gnu-iconv fails' == 'enabling via -gnu-iconv fails'",
+             "disable": "input.iconv == 'posix' || input.iconv == 'sun' || input.iconv == 'no'",
+-            "condition": "!config.win32 && !config.qnx && !config.android && !config.darwin && !features.posix-libiconv && !features.sun-libiconv && libs.gnu_iconv",
++            "condition": "!config.qnx && !config.android && !config.darwin && !features.posix-libiconv && !features.sun-libiconv && libs.gnu_iconv",
+             "output": [ "privateFeature" ]
+         },
+         "icu": {

--- a/mingw-w64-qt5-pkgs/0021-enable-mingw-schannel-alpn.patch
+++ b/mingw-w64-qt5-pkgs/0021-enable-mingw-schannel-alpn.patch
@@ -1,0 +1,11 @@
+--- a/tests/auto/network/ssl/qsslsocket/tst_qsslsocket.cpp	2020-05-08 11:37:16.957106100 +0300
++++ b/tests/auto/network/ssl/qsslsocket/tst_qsslsocket.cpp	2020-05-08 11:37:23.967427600 +0300
+@@ -82,7 +82,7 @@
+ #define ALPN_SUPPORTED 1
+ #endif
+ 
+-#if QT_CONFIG(schannel) && !defined(Q_CC_MINGW)
++#if QT_CONFIG(schannel)
+ #define ALPN_SUPPORTED 1
+ #endif
+ 

--- a/mingw-w64-qt5-pkgs/0022-qt-5.8.0-cast-errors.patch
+++ b/mingw-w64-qt5-pkgs/0022-qt-5.8.0-cast-errors.patch
@@ -1,0 +1,11 @@
+--- a/src/plugins/platforms/direct2d/qwindowsdirect2dintegration.cpp	2019-06-12 23:59:14.000000000 +0300
++++ b/src/plugins/platforms/direct2d/qwindowsdirect2dintegration.cpp	2019-06-15 16:23:35.775510000 +0300
+@@ -78,7 +78,7 @@
+                     UINT size;
+                     DWORD *fi;
+ 
+-                    if (VerQueryValue(info.constData(), __TEXT("\\"),
++                    if (VerQueryValue(info.data(), __TEXT("\\"),
+                                       reinterpret_cast<void **>(&fi), &size) && size) {
+                         const VS_FIXEDFILEINFO *verInfo = reinterpret_cast<const VS_FIXEDFILEINFO *>(fi);
+                         return QVersionNumber{HIWORD(verInfo->dwFileVersionMS), LOWORD(verInfo->dwFileVersionMS),

--- a/mingw-w64-qt5-pkgs/0023-schannel-fix-incomplete-downloads.patch
+++ b/mingw-w64-qt5-pkgs/0023-schannel-fix-incomplete-downloads.patch
@@ -1,0 +1,59 @@
+From fad2dc11f026a9863460cc7e8b42c992b4d9e899 Mon Sep 17 00:00:00 2001
+From: Mårten Nordheim <marten.nordheim@qt.io>
+Date: Fri, 05 Feb 2021 18:41:51 +0100
+Subject: [PATCH] Schannel: Fix incomplete downloads with read buffer restricted
+
+When the read buffer has a max size we do our best not to exceed it.
+Usually there's no problem and we just read more when the next
+tcp frame arrives. However if there's data leftover after the last
+tcp frame arrived then we won't receive any more data. To counter
+this QSslSocket would try to invoke QSslSocketPrivate::transmit
+indirectly if there were any bytes available on the plain socket.
+The problem is that with Schannel the last few remaining bytes
+would not be in the plain socket, but in the 'intermediateBuffer'.
+So let's make QSslSocket aware of that.
+
+Fixes: QTBUG-90625
+Pick-to: 5.15 6.0 6.1
+Change-Id: If56e4cce558f99c9a08a1f6818e005a887712ef2
+---
+
+diff --git a/src/network/ssl/qsslsocket.cpp b/src/network/ssl/qsslsocket.cpp
+index ffbb4d6..67f9b58 100644
+--- a/src/network/ssl/qsslsocket.cpp
++++ b/src/network/ssl/qsslsocket.cpp
+@@ -1950,7 +1950,7 @@
+ #endif
+     } else {
+         // possibly trigger another transmit() to decrypt more data from the socket
+-        if (d->plainSocket->bytesAvailable())
++        if (d->plainSocket->bytesAvailable() || d->hasUndecryptedData())
+             QMetaObject::invokeMethod(this, "_q_flushReadBuffer", Qt::QueuedConnection);
+         else if (d->state != QAbstractSocket::ConnectedState)
+             return maxlen ? qint64(-1) : qint64(0);
+diff --git a/src/network/ssl/qsslsocket_p.h b/src/network/ssl/qsslsocket_p.h
+index 6bd6cc0..1d6881d 100644
+--- a/src/network/ssl/qsslsocket_p.h
++++ b/src/network/ssl/qsslsocket_p.h
+@@ -224,6 +224,8 @@
+ 
+ protected:
+     bool verifyErrorsHaveBeenIgnored();
++    // Only implemented/useful in Schannel for now
++    virtual bool hasUndecryptedData() { return false; };
+     bool paused;
+     bool flushTriggered;
+     bool systemOrSslErrorDetected = false;
+diff --git a/src/network/ssl/qsslsocket_schannel_p.h b/src/network/ssl/qsslsocket_schannel_p.h
+index 57c8c75..30f5a96 100644
+--- a/src/network/ssl/qsslsocket_schannel_p.h
++++ b/src/network/ssl/qsslsocket_schannel_p.h
+@@ -123,6 +123,8 @@
+ 
+     bool rootCertOnDemandLoadingAllowed();
+ 
++    bool hasUndecryptedData() override { return intermediateBuffer.size() > 0; }
++
+     SecPkgContext_ConnectionInfo connectionInfo = {};
+     SecPkgContext_StreamSizes streamSizes = {};
+ 

--- a/mingw-w64-qt5-pkgs/0101-qt-5.3.0-fix-examples-building.patch
+++ b/mingw-w64-qt5-pkgs/0101-qt-5.3.0-fix-examples-building.patch
@@ -1,0 +1,11 @@
+--- a/examples/qml/tutorials/extending-qml/chapter6-plugins/import/import.pro	2019-05-28 15:19:15.000000000 +0300
++++ b/examples/qml/tutorials/extending-qml/chapter6-plugins/import/import.pro	2019-06-15 15:16:50.399074600 +0300
+@@ -5,7 +5,7 @@
+ QML_IMPORT_NAME = Charts
+ QML_IMPORT_MAJOR_VERSION = 1
+ 
+-DESTDIR = ../$$QML_IMPORT_NAME
++DESTDIR = ../$$QML_IMPORT_NAME/
+ TARGET = $$qtLibraryTarget(chartsplugin)
+ 
+ HEADERS += piechart.h \

--- a/mingw-w64-qt5-pkgs/0102-qtdeclarative-disable-dx12.patch
+++ b/mingw-w64-qt5-pkgs/0102-qtdeclarative-disable-dx12.patch
@@ -1,0 +1,8 @@
+--- a/src/plugins/scenegraph/scenegraph.pro.orig	2020-09-30 14:53:07.204896900 +0300
++++ b/src/plugins/scenegraph/scenegraph.pro	2020-09-30 14:53:20.732242800 +0300
+@@ -1,5 +1,4 @@
+ TEMPLATE = subdirs
+ QT_FOR_CONFIG += quick
+-qtConfig(d3d12): SUBDIRS += d3d12
+ qtConfig(openvg): SUBDIRS += openvg
+ 

--- a/mingw-w64-qt5-pkgs/0201-qt-5.11-mingw-fix-link-qdoc-with-clang.patch
+++ b/mingw-w64-qt5-pkgs/0201-qt-5.11-mingw-fix-link-qdoc-with-clang.patch
@@ -1,0 +1,229 @@
+--- a/src/qdoc/configure.pri	2020-10-22 20:11:38.000000000 +0300
++++ b/src/qdoc/configure.pri	2020-12-17 11:56:43.613359500 +0300
+@@ -104,16 +104,171 @@
+     }
+ 
+     # note: llvm_config only exits on unix
+-    llvm_config = $$clangInstallDir/bin/llvm-config
++    win32 {
++        llvm_config = $$clangInstallDir/bin/llvm-config.exe
++    } else {
++        llvm_config = $$clangInstallDir/bin/llvm-config
++    }
+     exists($$llvm_config) {
+-        CLANG_LIBDIR = $$system("$$llvm_config --libdir 2>/dev/null")
+-        CLANG_INCLUDEPATH = $$system("$$llvm_config --includedir 2>/dev/null")
+-        output = $$system("$$llvm_config --version 2>/dev/null")
++        CLANG_LIBDIR = $$system("$$llvm_config --libdir")
++        CLANG_INCLUDEPATH = $$system("$$llvm_config --includedir")
++        output = $$system("$$llvm_config --version")
+         CLANG_VERSION = $$extractVersion($$output)
++        LLVM_COMPONENTS = $$system("$$llvm_config --libs")
++        LLVM_SYSTEM_LIBS = $$system("$$llvm_config --system-libs")
+     } else {
+         CLANG_LIBDIR = $$clangInstallDir/lib
+         CLANG_INCLUDEPATH = $$clangInstallDir/include
+         CLANG_VERSION = $$findLLVMVersionFromLibDir($$CLANG_LIBDIR)
++        LLVM_COMPONENTS =  -lLLVMAArch64AsmParser \
++                           -lLLVMAArch64CodeGen \
++                           -lLLVMAArch64Desc \
++                           -lLLVMAArch64Disassembler \
++                           -lLLVMAArch64Info \
++                           -lLLVMAArch64Utils \
++                           -lLLVMAggressiveInstCombine \
++                           -lLLVMAMDGPUAsmParser \
++                           -lLLVMAMDGPUCodeGen \
++                           -lLLVMAMDGPUDesc \
++                           -lLLVMAMDGPUDisassembler \
++                           -lLLVMAMDGPUInfo \
++                           -lLLVMAMDGPUUtils \
++                           -lLLVMAnalysis \
++                           -lLLVMARMAsmParser \
++                           -lLLVMARMCodeGen \
++                           -lLLVMARMDesc \
++                           -lLLVMARMDisassembler \
++                           -lLLVMARMInfo \
++                           -lLLVMARMUtils \
++                           -lLLVMAsmParser \
++                           -lLLVMAsmPrinter \
++                           -lLLVMAVRAsmParser \
++                           -lLLVMAVRCodeGen \
++                           -lLLVMAVRDesc \
++                           -lLLVMAVRDisassembler \
++                           -lLLVMAVRInfo \
++                           -lLLVMBinaryFormat \
++                           -lLLVMBitReader \
++                           -lLLVMBitstreamReader \
++                           -lLLVMBitWriter \
++                           -lLLVMBPFAsmParser \
++                           -lLLVMBPFCodeGen \
++                           -lLLVMBPFDesc \
++                           -lLLVMBPFDisassembler \
++                           -lLLVMBPFInfo \
++                           -lLLVMCFGuard \
++                           -lLLVMCodeGen \
++                           -lLLVMCore \
++                           -lLLVMCoroutines \
++                           -lLLVMCoverage \
++                           -lLLVMDebugInfoCodeView \
++                           -lLLVMDebugInfoDWARF \
++                           -lLLVMDebugInfoGSYM \
++                           -lLLVMDebugInfoMSF \
++                           -lLLVMDebugInfoPDB \
++                           -lLLVMDemangle \
++                           -lLLVMDlltoolDriver \
++                           -lLLVMExecutionEngine \
++                           -lLLVMExtensions \
++                           -lLLVMFrontendOpenACC \
++                           -lLLVMFrontendOpenMP \
++                           -lLLVMFuzzMutate \
++                           -lLLVMGlobalISel \
++                           -lLLVMHexagonAsmParser \
++                           -lLLVMHexagonCodeGen \
++                           -lLLVMHexagonDesc \
++                           -lLLVMHexagonDisassembler \
++                           -lLLVMHexagonInfo \
++                           -lLLVMInstCombine \
++                           -lLLVMInstrumentation \
++                           -lLLVMInterpreter \
++                           -lLLVMipo \
++                           -lLLVMIRReader \
++                           -lLLVMJITLink \
++                           -lLLVMLanaiAsmParser \
++                           -lLLVMLanaiCodeGen \
++                           -lLLVMLanaiDesc \
++                           -lLLVMLanaiDisassembler \
++                           -lLLVMLanaiInfo \
++                           -lLLVMLibDriver \
++                           -lLLVMLineEditor \
++                           -lLLVMLinker \
++                           -lLLVMLTO \
++                           -lLLVMMC \
++                           -lLLVMMCDisassembler \
++                           -lLLVMMCJIT \
++                           -lLLVMMCParser \
++                           -lLLVMMipsAsmParser \
++                           -lLLVMMipsCodeGen \
++                           -lLLVMMipsDesc \
++                           -lLLVMMipsDisassembler \
++                           -lLLVMMipsInfo \
++                           -lLLVMMIRParser \
++                           -lLLVMMSP430AsmParser \
++                           -lLLVMMSP430CodeGen \
++                           -lLLVMMSP430Desc \
++                           -lLLVMMSP430Disassembler \
++                           -lLLVMMSP430Info \
++                           -lLLVMNVPTXAsmParser \
++                           -lLLVMNVPTXCodeGen \
++                           -lLLVMNVPTXDesc \
++                           -lLLVMNVPTXInfo \
++                           -lLLVMObjCARCOpts \
++                           -lLLVMObject \
++                           -lLLVMObjectYAML \
++                           -lLLVMOption \
++                           -lLLVMOrcError \
++                           -lLLVMOrcJIT \
++                           -lLLVMPasses \
++                           -lLLVMPowerPCAsmParser \
++                           -lLLVMPowerPCCodeGen \
++                           -lLLVMPowerPCDesc \
++                           -lLLVMPowerPCDisassembler \
++                           -lLLVMPowerPCInfo \
++                           -lLLVMProfileData \
++                           -lLLVMRemarks \
++                           -lLLVMRISCVAsmParser \
++                           -lLLVMRISCVCodeGen \
++                           -lLLVMRISCVDesc \
++                           -lLLVMRISCVDisassembler \
++                           -lLLVMRISCVInfo \
++                           -lLLVMRISCVUtils \
++                           -lLLVMRuntimeDyld \
++                           -lLLVMScalarOpts \
++                           -lLLVMSelectionDAG \
++                           -lLLVMSparcAsmParser \
++                           -lLLVMSparcCodeGen \
++                           -lLLVMSparcDesc \
++                           -lLLVMSparcDisassembler \
++                           -lLLVMSparcInfo \
++                           -lLLVMSupport \
++                           -lLLVMSymbolize \
++                           -lLLVMSystemZAsmParser \
++                           -lLLVMSystemZCodeGen \
++                           -lLLVMSystemZDesc \
++                           -lLLVMSystemZDisassembler \
++                           -lLLVMSystemZInfo \
++                           -lLLVMTableGen \
++                           -lLLVMTarget \
++                           -lLLVMTextAPI \
++                           -lLLVMTransformUtils \
++                           -lLLVMVectorize \
++                           -lLLVMWebAssemblyAsmParser \
++                           -lLLVMWebAssemblyAsmCodegen \
++                           -lLLVMWebAssemblyAsmDesc \
++                           -lLLVMWebAssemblyAsmDisassembler \
++                           -lLLVMWebAssemblyAsmInfo \
++                           -lLLVMWindowsManifest \
++                           -lLLVMX86AsmParser \
++                           -lLLVMX86CodeGen \
++                           -lLLVMX86Desc \
++                           -lLLVMX86Disassembler \
++                           -lLLVMX86Info \
++                           -lLLVMXCoreCodeGen \
++                           -lLLVMXCoreDesc \
++                           -lLLVMXCoreDisassembler \
++                           -lLLVMXCoreInfo \
++                           -lLLVMXRay
+     }
+     isEmpty(CLANG_VERSION) {
+         !isEmpty(LLVM_INSTALL_DIR): \
+@@ -134,7 +289,7 @@
+ 
+     isEmpty(QDOC_USE_STATIC_LIBCLANG) {
+         equals(QMAKE_HOST.os, Windows): \
+-            CLANG_LIBS += -llibclang -ladvapi32 -lshell32
++            CLANG_LIBS += -lclang -ladvapi32 -lshell32
+         else: \
+             CLANG_LIBS += -lclang
+     } else {
+@@ -153,6 +308,8 @@
+                 -lclangBasic \
+                 -lclangCodeGen \
+                 -lclangCrossTU \
++                -lclangDependencyScanning \
++                -lclangDirectoryWatcher \
+                 -lclangDriver \
+                 -lclangDynamicASTMatchers \
+                 -lclangEdit \
+@@ -160,6 +317,7 @@
+                 -lclangFrontend \
+                 -lclangFrontendTool \
+                 -lclangHandleCXX \
++                -lclangHandleLLVM \
+                 -lclangIndex \
+                 -lclangLex \
+                 -lclangParse \
+@@ -170,9 +328,14 @@
+                 -lclangStaticAnalyzerCheckers \
+                 -lclangStaticAnalyzerCore \
+                 -lclangStaticAnalyzerFrontend \
++                -lclangTesting \
+                 -lclangTooling \
+                 -lclangToolingASTDiff \
+-                -lclangToolingCore
++                -lclangToolingCore \
++                -lclangToolingRefactoring \
++                -lclangToolingSyntax \
++                -lclangTransformer \
++                $${LLVM_COMPONENTS}
+ 
+         versionIsAtLeast($$CLANG_VERSION, "10.0.0") {
+             equals(QMAKE_HOST.os, Windows): \
+@@ -227,7 +390,7 @@
+         CLANG_LIBS += $$split(LLVM_LIBS_STRING, " ")
+ 
+         !equals(QMAKE_HOST.os, Darwin):!msvc: CLANG_LIBS+=-Wl,--end-group
+-        equals(QMAKE_HOST.os, Windows): CLANG_LIBS += -lversion
++        equals(QMAKE_HOST.os, Windows): CLANG_LIBS += -lz3 -lgomp -lpsapi -lshell32 -lole32 -luuid -ladvapi32 -lversion
+     }
+ 
+     !versionIsAtLeast($$CLANG_VERSION, "3.9.0") {

--- a/mingw-w64-qt5-pkgs/0202-qt5-windeployqt-fixes.patch
+++ b/mingw-w64-qt5-pkgs/0202-qt5-windeployqt-fixes.patch
@@ -1,0 +1,38 @@
+--- a/src/windeployqt/main.cpp	2019-05-23 15:20:43.000000000 +0300
++++ b/src/windeployqt/main.cpp	2019-06-15 16:21:08.744251700 +0300
+@@ -1091,7 +1091,7 @@
+     QStringList result;
+     switch (platform) {
+     case WindowsDesktopMinGW: { // MinGW: Add runtime libraries
+-        static const char *minGwRuntimes[] = {"*gcc_", "*stdc++", "*winpthread"};
++        static const char *minGwRuntimes[] = {"*gcc_s_", "*stdc++", "*winpthread"};
+         const QString gcc = findInPath(QStringLiteral("g++.exe"));
+         if (gcc.isEmpty()) {
+             std::wcerr << "Warning: Cannot find GCC installation directory. g++.exe must be in the path.\n";
+@@ -1253,7 +1253,7 @@
+         *errorMessage = QDir::toNativeSeparators(options.binaries.first()) +  QStringLiteral(" does not seem to be a Qt executable.");
+         return result;
+     }
+-
++#if 0
+     // Some Windows-specific checks: Qt5Core depends on ICU when configured with "-icu". Other than
+     // that, Qt5WebKit has a hard dependency on ICU.
+     if (options.platform & WindowsBased)  {
+@@ -1285,7 +1285,7 @@
+             } // !icuLibs.isEmpty()
+         } // Qt5Core/Qt5WebKit
+     } // Windows
+-
++#endif
+     // Scan Quick2 imports
+     QmlImportScanResult qmlScanResult;
+     if (options.quickImports && usesQml2) {
+@@ -1634,8 +1634,6 @@
+     const QMap<QString, QString> qmakeVariables = queryQMakeAll(&errorMessage);
+     const QString xSpec = qmakeVariables.value(QStringLiteral("QMAKE_XSPEC"));
+     options.platform = platformFromMkSpec(xSpec);
+-    if (options.platform == WindowsDesktopMinGW || options.platform == WindowsDesktopMsvc)
+-        options.compilerRunTime = true;
+ 
+     {   // Command line
+         QCommandLineParser parser;

--- a/mingw-w64-qt5-pkgs/0203-ugly-hack-disable-qdoc-build.patch
+++ b/mingw-w64-qt5-pkgs/0203-ugly-hack-disable-qdoc-build.patch
@@ -1,0 +1,13 @@
+--- a/src/qdoc/configure.pri.orig	2019-06-18 13:42:33.146847400 +0300
++++ b/src/qdoc/configure.pri	2019-06-18 13:48:47.103371000 +0300
+@@ -38,6 +38,10 @@
+ }
+ 
+ defineTest(qtConfTest_libclang) {
++    isEmpty(QDOC_SKIP_BUILD): QDOC_SKIP_BUILD = $$(QDOC_SKIP_BUILD)
++    !isEmpty(QDOC_SKIP_BUILD) {
++        return(false)
++    }
+     isEmpty(QDOC_USE_STATIC_LIBCLANG): QDOC_USE_STATIC_LIBCLANG = $$(QDOC_USE_STATIC_LIBCLANG)
+ 
+     equals(QMAKE_HOST.os, Windows) {

--- a/mingw-w64-qt5-pkgs/0301-fix-static-build-big-resources.patch
+++ b/mingw-w64-qt5-pkgs/0301-fix-static-build-big-resources.patch
@@ -1,0 +1,10 @@
+--- a/src/imports/materiallib/plugin.pro	2020-03-20 14:35:20.514180400 +0300
++++ b/src/imports/materiallib/plugin.pro	2020-03-20 14:35:29.698282300 +0300
+@@ -1,6 +1,7 @@
+ CXX_MODULE = qml
+ TARGET = qtquick3dmaterialplugin
+ TARGETPATH = QtQuick3D/Materials
++CONFIG += resources_big
+ QT += quick qml quick3d-private
+ IMPORT_VERSION = 1.$$QT_MINOR_VERSION
+ QML_FILES = \

--- a/mingw-w64-qt5-pkgs/0302-fix-assimp-not-found.patch
+++ b/mingw-w64-qt5-pkgs/0302-fix-assimp-not-found.patch
@@ -1,0 +1,12 @@
+https://bugreports.qt.io/browse/QTBUG-84037
+--- a/src/plugins/assetimporters/assimp/assimp.pro.orig	2020-10-27 09:02:12.000000000 +0100
++++ b/src/plugins/assetimporters/assimp/assimp.pro	2020-12-28 00:46:02.767974100 +0100
+@@ -10,7 +10,7 @@
+ include($$OUT_PWD/../qtassetimporters-config.pri)
+ 
+ qtConfig(system-assimp):!if(cross_compile:host_build) {
+-    QMAKE_USE_PRIVATE += assimp
++    QMAKE_USE_PRIVATE += quick3d-assimp
+ } else {
+     include(../../../3rdparty/assimp/assimp.pri)
+ }

--- a/mingw-w64-qt5-pkgs/0401-qt-5.9.1-disable-qtlocation-mapboxgl-plugin.patch
+++ b/mingw-w64-qt5-pkgs/0401-qt-5.9.1-disable-qtlocation-mapboxgl-plugin.patch
@@ -1,0 +1,11 @@
+--- a/src/plugins/geoservices/geoservices.pro	2019-05-23 15:20:43.000000000 +0300
++++ b/src/plugins/geoservices/geoservices.pro	2019-06-15 16:03:54.523835200 +0300
+@@ -8,7 +8,7 @@
+ qtConfig(geoservices_itemsoverlay): SUBDIRS += itemsoverlay
+ qtConfig(geoservices_osm): SUBDIRS += osm
+ 
+-qtConfig(geoservices_mapboxgl) {
++qtConfig(geoservices_mapboxgl):!mingw {
+     !exists(../../3rdparty/mapbox-gl-native/mapbox-gl-native.pro) {
+         warning("Submodule mapbox-gl-native does not exist. Run 'git submodule update --init' on qtlocation.")
+     } else {

--- a/mingw-w64-qt5-pkgs/0501-qt-5.3.0-fix-examples-building.patch
+++ b/mingw-w64-qt5-pkgs/0501-qt-5.3.0-fix-examples-building.patch
@@ -1,0 +1,22 @@
+--- a/examples/sensors/grue/import/import.pro	2019-05-23 15:20:42.000000000 +0300
++++ b/examples/sensors/grue/import/import.pro	2019-06-15 15:16:50.399074600 +0300
+@@ -4,7 +4,7 @@
+ TARGET = $$qtLibraryTarget(declarative_grue)
+ 
+ macos: DESTDIR = ../grue_app.app/Contents/MacOS/Grue
+-else: DESTDIR = ../Grue
++else: DESTDIR = ../Grue/
+ 
+ QT = core gui qml sensors
+ 
+--- a/examples/sensors/sensor_explorer/import/import.pro	2019-05-23 15:20:42.000000000 +0300
++++ b/examples/sensors/sensor_explorer/import/import.pro	2019-06-15 15:16:50.414674600 +0300
+@@ -4,7 +4,7 @@
+ TARGET = $$qtLibraryTarget(declarative_explorer)
+ 
+ macos: DESTDIR = ../sensor_explorer.app/Contents/MacOS/Explorer
+-else: DESTDIR = ../Explorer
++else: DESTDIR = ../Explorer/
+ 
+ QT += qml sensors
+ 

--- a/mingw-w64-qt5-pkgs/PKGBUILD
+++ b/mingw-w64-qt5-pkgs/PKGBUILD
@@ -1,0 +1,1738 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Maintainer: Ray Donnelly <mingw.android@gmail.com>
+
+# Use the right mkspecs file
+if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
+  _platform=win32-clang-g++
+else
+  _platform=win32-g++
+fi
+
+_realname=qt5
+pkgbase="mingw-w64-${_realname}"
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-3d"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-activeqt"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-base"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-charts"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-connectivity"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-datavis3d"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-declarative"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-gamepad"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-graphicaleffects"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-imageformats"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-location"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-lottie"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-multimedia"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-networkauth"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-purchasing"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-quick3d"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-quickcontrols"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-quickcontrols2"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-quicktimeline"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-remoteobjects"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-script"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-scxml"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-sensors"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-serialbus"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-serialport"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-speech"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-svg"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-tools"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-translations"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-virtualkeyboard"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-webchannel"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-webglplugin"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-websockets"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-webview"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-winextras"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-xmlpatterns")
+_ver_base=5.15.2
+pkgver=${_ver_base//-/}
+pkgrel=1
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+pkgdesc="A cross-platform application and UI framework (mingw-w64)"
+url='https://www.qt.io/'
+license=('GPL3' 'LGPL' 'FDL' 'custom')
+makedepends=("${MINGW_PACKAGE_PREFIX}-clang"
+             "${MINGW_PACKAGE_PREFIX}-clang-tools-extra"
+             "${MINGW_PACKAGE_PREFIX}-fxc2"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-python"
+             "${MINGW_PACKAGE_PREFIX}-make"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-z3"
+             "${MINGW_PACKAGE_PREFIX}-assimp"
+             "${MINGW_PACKAGE_PREFIX}-double-conversion"
+             "${MINGW_PACKAGE_PREFIX}-dbus"
+             "${MINGW_PACKAGE_PREFIX}-fontconfig"
+             "${MINGW_PACKAGE_PREFIX}-freetype"
+             "${MINGW_PACKAGE_PREFIX}-harfbuzz"
+             "${MINGW_PACKAGE_PREFIX}-jasper"
+             "${MINGW_PACKAGE_PREFIX}-libjpeg"
+             "${MINGW_PACKAGE_PREFIX}-libmng"
+             "${MINGW_PACKAGE_PREFIX}-libpng"
+             "${MINGW_PACKAGE_PREFIX}-libtiff"
+             "${MINGW_PACKAGE_PREFIX}-libxml2"
+             "${MINGW_PACKAGE_PREFIX}-libxslt"
+             "${MINGW_PACKAGE_PREFIX}-libwebp"
+             "${MINGW_PACKAGE_PREFIX}-openssl"
+             $([[ ${MSYSTEM} == CLANG32 ]] || echo "${MINGW_PACKAGE_PREFIX}-openal")
+             "${MINGW_PACKAGE_PREFIX}-pcre2"
+             "${MINGW_PACKAGE_PREFIX}-sqlite3"
+             $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-vulkan")
+             "${MINGW_PACKAGE_PREFIX}-xpm-nox"
+             "${MINGW_PACKAGE_PREFIX}-zlib"
+             "${MINGW_PACKAGE_PREFIX}-icu"
+             "${MINGW_PACKAGE_PREFIX}-icu-debug-libs"
+             "${MINGW_PACKAGE_PREFIX}-libmariadbclient"
+             $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-firebird2")
+             $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-postgresql") )
+groups=("${MINGW_PACKAGE_PREFIX}-qt5")
+options=('!strip' 'staticlibs' 'ccache')
+_pkgfqn="qt-everywhere-src-${_ver_base}"
+noextract=(${_pkgfqn}.tar.xz)
+source=(https://download.qt.io/official_releases/qt/${pkgver%.*}/${_ver_base}/single/${_pkgfqn}.tar.xz
+        0001-adjust-qmake-conf-mingw.patch
+        0002-qt-5.8.0-fix-sql-libraries-mingw.patch
+        0003-qt-5.8.0-configure-gcc-before-clang.patch
+        0004-fix-linking-again-different-static-libs.patch
+        0005-qt-5.3.0-win_flex-replace.patch
+        0006-qt-5.3.0-win32-g-Enable-static-builds.patch
+        0007-qt-5.3.0-win32-g-Add-QMAKE_EXTENSION_IMPORTLIB-defaulting-to-.patch
+        0008-qt-5.8.0-mingw-dbus-and-pkg-config.patch
+        0009-qt-5.8.0-win32-g++-use-qpa-genericunixfontdatabase.patch
+        0010-qt-5.8.0-force-using-make-on-msys.patch
+        0011-qt-5.8.0-Revert-untangle-use-of-system-vs.-shell-path-list-se.patch
+        0012-qt-5.8.0-Revert-fix-quoting-and-path-separators-in-qtPrepareT.patch
+        0013-qt-5.3.1-workaround-ansidecl-h-PTR-define-conflict.patch
+        0014-qt-5.3.2-dont-add-resource-files-to-qmake-libs.patch
+        0015-qt-5.3.2-win32-qt5-static-cmake-link-ws2_32-and--static.patch
+        0016-qt-5.4.2-win32-Avoid-platformNativeInterface-segfaults-with-minimal-platform.patch
+        0017-qt-5.8.0-win32-do-not-use-fontconfig.patch
+        0018-win32-dont-need-flatpack-theme.patch
+        0019-qt-5.11-static_icu.patch
+        0020-fix-and-enable-iconv-codec.patch
+        0021-enable-mingw-schannel-alpn.patch
+        0022-qt-5.8.0-cast-errors.patch
+        0023-schannel-fix-incomplete-downloads.patch
+        0101-qt-5.3.0-fix-examples-building.patch
+        0102-qtdeclarative-disable-dx12.patch
+        0201-qt-5.11-mingw-fix-link-qdoc-with-clang.patch
+        0202-qt5-windeployqt-fixes.patch
+        0203-ugly-hack-disable-qdoc-build.patch
+        0301-fix-static-build-big-resources.patch
+        0302-fix-assimp-not-found.patch
+        0401-qt-5.9.1-disable-qtlocation-mapboxgl-plugin.patch
+        0501-qt-5.3.0-fix-examples-building.patch)
+# Some patch notes :
+#0001-0099 -> qtbase
+#0101-0199 -> qtdeclarative
+#0201-0299 -> qttools
+#0301-0399 -> qtquick3d
+#0401-0499 -> qtlocation
+#0501-0599 -> qtsensors
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying ${_patch}"
+    patch -Nbp1 -i "${srcdir}/${_patch}"
+  done
+}
+
+prepare() {
+  [[ -d ${srcdir}/${_pkgfqn} ]] && rm -rf ${srcdir}/${_pkgfqn}
+  tar -xJf ${srcdir}/${_pkgfqn}.tar.xz -C ${srcdir} --exclude=${_pkgfqn}/{qtandroidextras,qtmacextras,qtwayland,qtwebengine,qtx11extras} || true
+
+  cd ${srcdir}/${_pkgfqn}
+
+  # MSYS2 gperf cannot handle \r\n.
+  find . -name "*.gperf" -exec dos2unix "{}" \;
+
+  cd qtbase
+  apply_patch_with_msg \
+    0001-adjust-qmake-conf-mingw.patch \
+    0002-qt-5.8.0-fix-sql-libraries-mingw.patch \
+    0003-qt-5.8.0-configure-gcc-before-clang.patch \
+    0004-fix-linking-again-different-static-libs.patch \
+    0005-qt-5.3.0-win_flex-replace.patch \
+    0006-qt-5.3.0-win32-g-Enable-static-builds.patch \
+    0007-qt-5.3.0-win32-g-Add-QMAKE_EXTENSION_IMPORTLIB-defaulting-to-.patch \
+    0008-qt-5.8.0-mingw-dbus-and-pkg-config.patch \
+    0009-qt-5.8.0-win32-g++-use-qpa-genericunixfontdatabase.patch \
+    0010-qt-5.8.0-force-using-make-on-msys.patch \
+    0011-qt-5.8.0-Revert-untangle-use-of-system-vs.-shell-path-list-se.patch \
+    0012-qt-5.8.0-Revert-fix-quoting-and-path-separators-in-qtPrepareT.patch \
+    0013-qt-5.3.1-workaround-ansidecl-h-PTR-define-conflict.patch \
+    0014-qt-5.3.2-dont-add-resource-files-to-qmake-libs.patch \
+    0015-qt-5.3.2-win32-qt5-static-cmake-link-ws2_32-and--static.patch \
+    0016-qt-5.4.2-win32-Avoid-platformNativeInterface-segfaults-with-minimal-platform.patch \
+    0017-qt-5.8.0-win32-do-not-use-fontconfig.patch \
+    0018-win32-dont-need-flatpack-theme.patch \
+    0019-qt-5.11-static_icu.patch \
+    0020-fix-and-enable-iconv-codec.patch \
+    0021-enable-mingw-schannel-alpn.patch \
+    0022-qt-5.8.0-cast-errors.patch \
+    0023-schannel-fix-incomplete-downloads.patch
+
+  cd ../qtdeclarative
+  apply_patch_with_msg \
+    0101-qt-5.3.0-fix-examples-building.patch \
+    0102-qtdeclarative-disable-dx12.patch
+
+  cd ../qttools
+  apply_patch_with_msg \
+    0201-qt-5.11-mingw-fix-link-qdoc-with-clang.patch \
+    0202-qt5-windeployqt-fixes.patch \
+    0203-ugly-hack-disable-qdoc-build.patch
+
+  cd ../qtquick3d
+  apply_patch_with_msg \
+    0301-fix-static-build-big-resources.patch \
+    0302-fix-assimp-not-found.patch
+
+  cd ../qtlocation
+  apply_patch_with_msg \
+    0401-qt-5.9.1-disable-qtlocation-mapboxgl-plugin.patch
+
+  cd ../qtsensors
+  apply_patch_with_msg \
+    0501-qt-5.3.0-fix-examples-building.patch
+
+  cd ..
+  local _ARCH_TUNE=
+  local _HARD_FLAGS=
+  case ${MINGW_CHOST} in
+    i686*)
+      _ARCH_TUNE="-march=i686 -mtune=core2"
+      _HARD_FLAGS="-Wl,--dynamicbase,--nxcompat,--no-seh"
+    ;;
+    x86_64*)
+      _ARCH_TUNE="-march=nocona -mtune=core2"
+      _HARD_FLAGS="-Wl,--dynamicbase,--high-entropy-va,--nxcompat,--default-image-base-high"
+    ;;
+  esac
+
+  BIGOBJ_FLAGS="-Wa,-mbig-obj"
+
+  # Append these ones ..
+  sed -i "s|^QMAKE_CFLAGS .*= \(.*\)$|QMAKE_CFLAGS            = \1 ${_ARCH_TUNE} ${BIGOBJ_FLAGS}|g" qtbase/mkspecs/${_platform}/qmake.conf
+  sed -i "s|^QMAKE_LFLAGS           +=\(.*\)$|QMAKE_LFLAGS            += \1 ${_HARD_FLAGS}|g" qtbase/mkspecs/common/gcc-base.conf
+
+  # To keep the build folder name quite small (PATH_MAX limit)
+  # the source folder (long) is renamed to $MSYSTEM (MINGW64, MINGW32 ...)
+  cd ${srcdir}
+  [[ -d ${MSYSTEM} ]] && rm -rf ${MSYSTEM}
+  sleep 5
+  mv ${_pkgfqn} ${MSYSTEM}
+}
+
+build() {
+  local _buildpkgdir=${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5/${MINGW_PREFIX}
+  mkdir -p ${_buildpkgdir}
+  local QTDIR_WIN=$(cygpath -am ${_buildpkgdir})
+
+  cd ${MSYSTEM}
+
+  local -a _sql_config
+  if [[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]]; then
+    _sql_config+=("-plugin-sql-ibase")
+    _sql_config+=("-plugin-sql-psql")
+  fi
+  _sql_config+=("-plugin-sql-mysql")
+  _sql_config+=("-plugin-sql-odbc")
+
+  # https://github.com/msys2/MSYS2-packages/issues/2282
+  export MSYS2_ARG_CONV_EXCL='--foreign-types='
+
+  # Qt manages the compiler flags for release / debug configs separately, so having our own values (-O2) is harmful here ..
+  unset CFLAGS
+  unset CXXFLAGS
+  unset LDFLAGS
+  unset QMAKESPEC
+  unset XQMAKESPEC
+  unset QMAKEPATH
+  unset QMAKEFEATURES
+
+  export PATH="${srcdir}/${MSYSTEM}/qtbase/bin:${srcdir}/${MSYSTEM}/qtbase/lib:${PATH}"
+  export LLVM_INSTALL_DIR=${MINGW_PREFIX}
+  export VULKAN_SDK=${MINGW_PREFIX}
+
+  ./configure.bat \
+    -prefix ${QTDIR_WIN} \
+    -datadir ${QTDIR_WIN}/share/qt5 \
+    -archdatadir ${QTDIR_WIN}/share/qt5 \
+    -nomake examples \
+    -nomake tests \
+    -opensource \
+    -confirm-license \
+    -platform ${_platform} \
+    -shared \
+    -make-tool make \
+    -I${MINGW_PREFIX}/include/mariadb \
+    -opengl desktop \
+    -dbus \
+    -fontconfig \
+    -icu \
+    -jasper \
+    -openssl \
+    -system-assimp \
+    -system-doubleconversion \
+    -system-freetype \
+    -system-harfbuzz \
+    -system-libjpeg \
+    -system-libpng \
+    -system-pcre \
+    -system-sqlite \
+    -system-tiff \
+    -system-webp \
+    -system-zlib \
+    -no-gstreamer \
+    -no-iconv \
+    -no-mng \
+    -no-wmf \
+    "${_sql_config[@]}"
+
+  make
+}
+
+check() {
+  cd ${MSYSTEM}
+  make check -j1 -k
+}
+
+package_qt5-3d() {
+  _component=qt5-3d
+  pkgdesc="C++ and QML APIs for easy inclusion of 3D graphics (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative"
+           "${MINGW_PACKAGE_PREFIX}-assimp")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-activeqt() {
+  _component=qt5-activeqt
+  pkgdesc="Qt5 ActiveQt Module - ActiveX components (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-base() {
+  _component=qt5-base
+  pkgdesc="A cross-platform application and UI framework (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-double-conversion"
+           "${MINGW_PACKAGE_PREFIX}-dbus"
+           "${MINGW_PACKAGE_PREFIX}-fontconfig"
+           "${MINGW_PACKAGE_PREFIX}-freetype"
+           "${MINGW_PACKAGE_PREFIX}-harfbuzz"
+           "${MINGW_PACKAGE_PREFIX}-icu"
+           "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
+           "${MINGW_PACKAGE_PREFIX}-libpng"
+           "${MINGW_PACKAGE_PREFIX}-openssl"
+           "${MINGW_PACKAGE_PREFIX}-pcre2"
+           "${MINGW_PACKAGE_PREFIX}-sqlite3"
+           $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-vulkan")
+           "${MINGW_PACKAGE_PREFIX}-zlib")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-libmariadbclient"
+              "${MINGW_PACKAGE_PREFIX}-firebird2"
+              "${MINGW_PACKAGE_PREFIX}-postgresql")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-qt5"
+             "${MINGW_PACKAGE_PREFIX}-qt5-debug"
+             "${MINGW_PACKAGE_PREFIX}-qt6-base")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-charts() {
+  _component=qt5-charts
+  pkgdesc="Provides a set of easy to use chart components (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-base")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-connectivity() {
+  _component=qt5-connectivity
+  pkgdesc="Provides access to Bluetooth hardware (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-base")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-datavis3d() {
+  _component=qt5-datavis3d
+  pkgdesc="Qt Data Visualization module (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-base")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-declarative() {
+  _component=qt5-declarative
+  pkgdesc="Classes for QML and JavaScript languages (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-base")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-gamepad() {
+  _component=qt5-gamepad
+  pkgdesc="Adds support for getting events from gamepad devices (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-base")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-graphicaleffects() {
+  _component=qt5-graphicaleffects
+  pkgdesc="Graphical effects for use with Qt Quick 2 (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+}
+
+package_qt5-imageformats() {
+  _component=qt5-imageformats
+  pkgdesc="Plugins for additional image formats: TIFF, MNG, TGA, WBMP (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-base"
+           "${MINGW_PACKAGE_PREFIX}-jasper"
+           "${MINGW_PACKAGE_PREFIX}-libmng"
+           "${MINGW_PACKAGE_PREFIX}-libtiff"
+           "${MINGW_PACKAGE_PREFIX}-libwebp")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+}
+
+package_qt5-location() {
+  _component=qt5-location
+  pkgdesc="Provides access to position, satellite and area monitoring classes (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-lottie() {
+  _component=qt5-lottie
+  pkgdesc="A family of player software for a certain json-based file format for describing 2d vector graphics animations (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-base")
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+}
+
+package_qt5-multimedia() {
+  _component=qt5-multimedia
+  pkgdesc="Classes for audio, video, radio and camera functionality (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-base"
+           $([[ ${MSYSTEM} == CLANG32 ]] || echo "${MINGW_PACKAGE_PREFIX}-openal")
+           )
+  optdepends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-networkauth() {
+  _component=qt5-networkauth
+  pkgdesc="Network authentication module (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-base")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-purchasing() {
+  _component=qt5-purchasing
+  pkgdesc="Qt In-App Purchasing API (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-base")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-quick3d() {
+  _component=qt5-quick3d
+  pkgdesc="Qt module and API for defining 3D content in Qt Quick (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-assimp")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-quickcontrols() {
+  _component=qt5-quickcontrols
+  pkgdesc="Reusable Qt Quick based UI controls to create classic desktop-style user interfaces (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+}
+
+package_qt5-quickcontrols2() {
+  _component=qt5-quickcontrols2
+  pkgdesc="Next generation user interface controls based on Qt Quick (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-qt5-graphicaleffects")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-quicktimeline() {
+  _component=qt5-quicktimeline
+  pkgdesc="Qt module for keyframe-based timeline construction (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+}
+
+package_qt5-remoteobjects() {
+  _component=qt5-remoteobjects
+  pkgdesc="Inter-process communication (IPC) module developed for Qt (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-base")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-script() {
+  _component=qt5-script
+  pkgdesc="Classes for making Qt applications scriptable. Provided for Qt 4.x compatibility (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-base")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-scxml() {
+  _component=qt5-scxml
+  pkgdesc="Static and runtime integration of SCXML models into Qt code (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-sensors() {
+  _component=qt5-sensors
+  pkgdesc="Provides access to sensor hardware and motion gesture recognition (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-base")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-serialbus() {
+  _component=qt5-serialbus
+  pkgdesc="Qt module for general purpose serial bus access (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-serialport")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-serialport() {
+  _component=qt5-serialport
+  pkgdesc="Provides access to hardware and virtual serial ports (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-base")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-speech() {
+  _component=qt5-speech
+  pkgdesc="Qt module to make text to speech and speech recognition easy (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-multimedia")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-svg() {
+  _component=qt5-svg
+  pkgdesc="Classes for displaying the contents of SVG files (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-base")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-tools() {
+  _component=qt5-tools
+  pkgdesc="A cross-platform application and UI framework (Development Tools, QtHelp) (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-base")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-clang")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-translations() {
+  _component=qt5-translations
+  pkgdesc="A cross-platform application and UI framework (Translations) (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-base")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+}
+
+package_qt5-virtualkeyboard() {
+  _component=qt5-virtualkeyboard
+  pkgdesc="Virtual keyboard framework (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative"
+           "${MINGW_PACKAGE_PREFIX}-qt5-svg")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-webchannel() {
+  _component=qt5-webchannel
+  pkgdesc="Provides access to QObject or QML objects from HTML clients for seamless integration of Qt applications with HTML/JavaScript clients (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-webglplugin() {
+  _component=qt5-webglplugin
+  pkgdesc="QPA plugin for running an application via a browser using streamed WebGL commands (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative"
+           "${MINGW_PACKAGE_PREFIX}-qt5-websockets")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+}
+
+package_qt5-websockets() {
+  _component=qt5-websockets
+  pkgdesc="Provides WebSocket communication compliant with RFC 6455 (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-base")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-webview() {
+  _component=qt5-webview
+  pkgdesc="Provides a way to display web content in a QML application (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-webchannel"
+           "${MINGW_PACKAGE_PREFIX}-qt5-libxslt")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-winextras() {
+  _component=qt5-winextras
+  pkgdesc="Provides platform-specific APIs for Windows (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-base")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+package_qt5-xmlpatterns() {
+  _component=qt5-xmlpatterns
+  pkgdesc="Support for XPath, XQuery, XSLT and XML schema validation (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-base")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative")
+
+  cd ${MSYSTEM}/${_component/5-/}
+
+  make install
+  cd ${pkgdir}/..
+  rm -r ${MINGW_PACKAGE_PREFIX}-${_component}
+  mv ${MINGW_PACKAGE_PREFIX}-qt5 ${MINGW_PACKAGE_PREFIX}-${_component}
+
+  install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+  install -Dm644 $srcdir/${MSYSTEM}/${_component/5-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_component}
+
+  # Remove dlls from lib/
+  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+
+  # Remove *.orig files
+  find "${pkgdir}${MINGW_PREFIX}" -type f -name "*.orig" -exec rm -f {} \;
+
+  # Fix paths in *.pri, *.prl and *.pc files
+  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qt5${MINGW_PREFIX})
+  local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
+
+  find "${pkgdir}${MINGW_PREFIX}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+}
+
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;
+
+sha256sums=('3a530d1b243b5dec00bc54937455471aaa3e56849d2593edb8ded07228202240'
+            'f7dcfedfb25777c22211208084fed8b62f03ba9c5d5ce387682aeed10f79a654'
+            'e0a535278057f42e43952405e567c23cc493ef6badeeb3bbce0154953cd545a5'
+            'e7252bdc92fa75f067e4beafbf3c844fca3a4bd16d14ac5344256f022a9214d5'
+            '02a3b24c02a6797b706582198ab1177648c2653e8870dcdddc5856d6cd629d49'
+            '013401295022dbad73df0355124758d337da71b99253461bb84bc7c9320e27e6'
+            '61cb036d39a12abc5f98fc2afdc41694471413171e79debd3cd5f464d74dad32'
+            '1ca4be5aefe731af2c9229ed97e8c6231d735a64c655768f6ef677a932ce2019'
+            '0fb18899437e86bdbea1750a892b18bef76bdf9b85e504afcb65e7f49f421ff0'
+            '3a8de25edb2a4643583ad5fa2743475b60fffad931be25314b4067be2413bca4'
+            '49eee16b318f1ac8d5ddf45f294b9f88e05c2f7f7ad2808f281961200d61c6cf'
+            '9fafed377f435493dd72b1b8f49ca25580f5b3d4100528a5c4ca18d10627dfd7'
+            '69f7b27d7c23731e73500e058ec69e7504740d102244f15959977355814de9c5'
+            '41acd8702a33a1d2f5e93c7e940c41aaa335aa728bc5562e799ef6077aa00433'
+            '274d24f9cd84a7fae5e2c5836c8a3a6108ef2c04c1b8c8e97a11b70975b98ddf'
+            'ce0c7e6dcc5af61c7d7db2bbe8921ab3861fd9380be9af62933f8d29cb577d53'
+            '58556b73b3fcbddd5658832f012760e3a86637bdd9e6324596b6ecd69981a985'
+            '4b2f54549743864e831e57d45269a7d84182d68cbc5f5277daa29167c046ae52'
+            '606e6e4888e2efc8e971258ec3cdf43b32c6dac9bdba22ed89ca9571adeb365d'
+            'c88c558f3388ab2fa7df57e403324e92abdfbdf72a87c849af337720f52baa8b'
+            'c9bdd0ce5f30c6eb940675e45e14179bbab41b743e88cec4679c20dc2d8c9cbf'
+            'fec3f368973c004c3fccea4e9d816eb42c02dcb2355714d5c833c8b74b428f11'
+            '5397862593005d9af4b218396c4a3975b0e0f039992562ffef4672c0738c4df0'
+            '961090b78b8f586a4d9819b45dcce3db3d54bede3d69ced098e9feaeaab936aa'
+            '3363a009bbc3eb3f3a128988a3826859bf6259e0fd8150fda608ac99f5d28ea7'
+            '0640935893e8c4f0801f3f976a8b5fbcfa94c9d929488fef01e88ad6c64edff1'
+            'aff15370d18498ee1cc73f027b3fc76cc899b3cd1f79c3ed3bbda50b927dec33'
+            '5009ef5c9812f6f6ba6d69d6b2a90b5caa43cf0ef46bf36ac507c672e697e5a1'
+            '1927c71175f758914abc485506bb162f3eac5e0816a00be66a78562b168095f0'
+            'c0b2ed679d9938e10a0791f0cbb6242880d9d852c4879064613d6831e0e9b079'
+            'd304e4a30d4ada18baa368b21b316fe88206a4769e10afd4bcc0792912efb4b1'
+            '8601d8d67647ac2c3a4043171ff29ef18ae5ba9d92cc72f529582c6bfd3658e1'
+            'a5d95118576d456f8ff94eeda6740536766177b339ea2b09edde9f9f332f0e41')


### PR DESCRIPTION
It doesn't reduce the buildtime, but it will help with the dependencies of other packages on Qt5 where they will not forced to install the whole qt5.