### PR TITLE
texlive-bin: autoreconf for clang support

### DIFF
--- a/mingw-w64-texlive-bin/PKGBUILD
+++ b/mingw-w64-texlive-bin/PKGBUILD
@@ -4,7 +4,7 @@ pkgbase=mingw-w64-texlive-bin
 pkgname=("${MINGW_PACKAGE_PREFIX}-texlive-bin" "${MINGW_PACKAGE_PREFIX}-libsynctex")
 pkgver=2021.20210424
 pkgdesc="TeX Live binaries (mingw-w64)"
-pkgrel=5
+pkgrel=6
 license=('GPL')
 arch=('any')
 url='https://tug.org/texlive/'
@@ -65,7 +65,11 @@ prepare() {
     apply_patch_with_msg 0003-runscript-always-quote-args.patch
     # t4ht expects to be un /usr/share/texmf/bin/t4ht (FS#27251)
     sed -i s/SELFAUTOPARENT/TEXMFROOT/ texk/tex4htk/t4ht.c
-
+    autoreconf -fiv
+    # WTF?
+    pushd texk/chktex
+    autoreconf -fiv
+    popd
 }
 
 build() {
@@ -122,34 +126,36 @@ build() {
    # and ../texk/texlive/w64_mingw_wrapper (for mingw64) wrapper
 
    # first delete *.exe and *.dll from the locations
-   rm ../texk/texlive/w64_mingw_wrapper/*.exe ../texk/texlive/w64_mingw_wrapper/*.dll \
+   rm -f ../texk/texlive/w64_mingw_wrapper/*.exe ../texk/texlive/w64_mingw_wrapper/*.dll \
       ../texk/texlive/w64_mingw_wrapper/context/*.exe ../texk/texlive/w64_mingw_wrapper/context/*.dll
    case ${MINGW_CHOST} in
       i686-w64-mingw32)
          rm -rf ../texk/texlive/w32_wrapper
          cp -r ../texk/texlive/w64_mingw_wrapper ../texk/texlive/w32_wrapper
          cp "libs/lua53/.libs/texlua.dll" ../texk/texlive/w32_wrapper
+         cp "libs/lua53/.libs/libtexlua53.dll.a" ../texk/texlive/w32_wrapper
          cd ../texk/texlive/w32_wrapper
          patch -i "${srcdir}/0002-fix-lauchers-mingw32.patch"
          ;;
       *)
          cp "libs/lua53/.libs/texlua.dll" ../texk/texlive/w64_mingw_wrapper
+         cp "libs/lua53/.libs/libtexlua53.dll.a" ../texk/texlive/w64_mingw_wrapper
          cd ../texk/texlive/w64_mingw_wrapper
          ;;
    esac
    echo '1 ICON "tlmgr.ico"'>texlive.rc
    windres texlive.rc texlive.o
 
-   gcc -Os -s -shared -o runscript.dll runscript_dll.c -L./ -ltexlua
+   gcc -Os -s -shared -Wl,--out-implib=librunscript.dll.a -o runscript.dll runscript_dll.c -L./ -ltexlua53
    gcc -Os -s -o runscript.exe runscript_exe.c texlive.o -L./ -lrunscript
    gcc -mwindows -Os -s -o wrunscript.exe wrunscript_exe.c texlive.o -L./ -lrunscript
 
    cd context
-   gcc -Os -s -shared -o mtxrun.dll mtxrun_dll.c
+   gcc -Os -s -shared -Wl,--out-implib=libmtxrun.dll.a -o mtxrun.dll mtxrun_dll.c
    gcc -Os -s -o mtxrun.exe mtxrun_exe.c -L./ -lmtxrun
    cd ..
    #cleanup
-   rm texlive.rc texlive.o texlua.dll
+   rm texlive.rc texlive.o texlua.dll libtexlua53.dll.a
 }
 
 package_libsynctex() {


### PR DESCRIPTION
Also, autoreconf in texk/chktex specifically because it didn't seem to happen with the top-level autoreconf.  Fixes #9256 

Fix building wrappers with clang, which wants to use import libraries rather than dlls directly.