### PR TITLE
ruby: fix clang build

### DIFF
--- a/mingw-w64-ruby/0007-nm-use-full-options.patch
+++ b/mingw-w64-ruby/0007-nm-use-full-options.patch
@@ -1,0 +1,11 @@
+--- ruby-3.0.2/win32/mkexports.rb.orig	2021-08-01 21:20:51.869421200 -0700
++++ ruby-3.0.2/win32/mkexports.rb	2021-08-01 21:21:05.619185400 -0700
+@@ -153,7 +153,7 @@
+   end
+ 
+   def each_line(objs, &block)
+-    IO.foreach("|#{self.class.nm} --extern --defined #{objs.join(' ')}", &block)
++    IO.foreach("|#{self.class.nm} --extern-only --defined-only #{objs.join(' ')}", &block)
+   end
+ 
+   def each_export(objs)

--- a/mingw-w64-ruby/PKGBUILD
+++ b/mingw-w64-ruby/PKGBUILD
@@ -10,7 +10,7 @@ _realname=ruby
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.0.2
-pkgrel=1
+pkgrel=2
 pkgdesc="An object-oriented language for quick and easy programming (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -33,7 +33,8 @@ source=("https://cache.ruby-lang.org/pub/ruby/${pkgver%.*}/${_realname}-${pkgver
         0003-fix-check-types.patch
         0004-rbinstall-destdir.patch
         0005-rbinstall-rake-bash.patch
-        0006-autoconf-set-msvcrt-ver-for-ucrt.patch)
+        0006-autoconf-set-msvcrt-ver-for-ucrt.patch
+        0007-nm-use-full-options.patch)
 ## Populated by the updpkgprovs script
 provides=(
     "${MINGW_PACKAGE_PREFIX}-ruby-minitest=5.14.2"
@@ -130,7 +131,8 @@ sha256sums=('5085dee0ad9f06996a8acec7ebea4a8735e6fac22f22e2d98c3f2bc3bef7e6f1'
             'e5d665cabac8b7fbb0dda9a556c2350190801aa07b3cb90a0d50097ab99272a0'
             '02382ec3b9e42d7dbb58edad3e41c361d98871711bb2f0320082c2acc6a82e2e'
             '85e10228375eea2d80c8e6ebb582eeaf625d8216e4d08a4af8136de1aa3f095e'
-            '66fa809eae07facf2f9e13e92fcde72a4147992e23b399212cc323322419a1bb')
+            '66fa809eae07facf2f9e13e92fcde72a4147992e23b399212cc323322419a1bb'
+            'b250c66bc8b372fb4c53902a6d56c01ad057416e3e368a5c5434d9a4ebdc3819')
 noextract=(${_realname}-${pkgver}.tar.gz)
 
 apply_patch_with_msg() {
@@ -161,7 +163,8 @@ prepare() {
   # 0001-mingw-w64-time-functions.patch
   apply_patch_with_msg \
       0003-fix-check-types.patch \
-      0005-rbinstall-rake-bash.patch
+      0005-rbinstall-rake-bash.patch \
+      0007-nm-use-full-options.patch
     #  patch -p1 -i ${srcdir}/0004-rbinstall-destdir.patch
 
   # Set msvcrt version to 140 which brings hidden ucrt I/O structs
@@ -192,7 +195,9 @@ build() {
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \
-    --disable-werror
+    --disable-werror \
+    $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] && \
+      echo "--with-setjmp-type=setjmp" || true )
   make
 }
 


### PR DESCRIPTION
`__builtin_setjmp`/`__builtin_longjmp` are only meant for internal exception handling usage IIRC, use mingw-w64's setjmp instead.
> The built-in versions are used internally by GCC’s libraries to implement exception handling on some targets. You should use the standard C library functions declared in <setjmp.h> in user code instead of the builtins.

Pass full options --extern-only and --defined-only to nm, llvm-nm doesn't accept the truncated variant.