### PR TITLE
Remove conflict between qt6-base and qt5 (qt5-base)

### DIFF
--- a/mingw-w64-qt6-base/001-append-qt6-to-tools-to-remove-conflict-qt5-qt6.patch
+++ b/mingw-w64-qt6-base/001-append-qt6-to-tools-to-remove-conflict-qt5-qt6.patch
@@ -1,0 +1,37 @@
+--- qtbase-everywhere-src-6.1.2/qmake/CMakeLists.txt.orig	2021-06-08 15:49:53.000000000 +0100
++++ qtbase-everywhere-src-6.1.2/qmake/CMakeLists.txt	2021-08-02 10:24:03.628516800 +0100
+@@ -9,7 +9,6 @@
+     NO_QT # special case
+     TOOLS_TARGET Core # special case
+     USER_FACING
+-    INSTALL_VERSIONED_LINK
+     SOURCES
+         ../src/3rdparty/pcre2/src/config.h
+         ../src/3rdparty/pcre2/src/pcre2.h
+@@ -287,3 +286,6 @@
+ )
+ # special case end
+ 
++set_target_properties(${target_name} PROPERTIES
++    OUTPUT_NAME qmake-qt6
++)
+--- qtbase-everywhere-src-6.1.2/src/tools/qdbuscpp2xml/CMakeLists.txt.orig	2021-08-02 10:24:50.196403800 +0100
++++ qtbase-everywhere-src-6.1.2/src/tools/qdbuscpp2xml/CMakeLists.txt	2021-08-02 10:23:57.815567300 +0100
+@@ -47,3 +47,7 @@
+ # qt_internal_extend_target(qdbuscpp2xml CONDITION force_bootstrap [...])
+ # qt_internal_extend_target(qdbuscpp2xml CONDITION NOT force_bootstrap [...])
+ # special case end
++
++set_target_properties(${target_name} PROPERTIES
++    OUTPUT_NAME qdbuscpp2xml-qt6
++)
+--- qtbase-everywhere-src-6.1.2/src/tools/qdbusxml2cpp/CMakeLists.txt.orig	2021-08-02 10:25:12.425454600 +0100
++++ qtbase-everywhere-src-6.1.2/src/tools/qdbusxml2cpp/CMakeLists.txt	2021-08-02 10:23:40.018161000 +0100
+@@ -35,3 +35,7 @@
+ # qt_internal_extend_target(qdbusxml2cpp CONDITION NOT QT_FEATURE_commandlineparser AND NOT force_bootstrap [...])
+ # qt_internal_extend_target(qdbusxml2cpp CONDITION force_bootstrap [...])
+ # special case end
++
++set_target_properties(${target_name} PROPERTIES
++    OUTPUT_NAME qdbusxml2cpp-qt6
++)

--- a/mingw-w64-qt6-base/PKGBUILD
+++ b/mingw-w64-qt6-base/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 _qtver=6.1.2
 pkgver=${_qtver/-/}
-pkgrel=2
+pkgrel=3
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://www.qt.io'
@@ -24,9 +24,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-double-conversion"
 optdepends=("${MINGW_PACKAGE_PREFIX}-libmariadbclient"
             $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-firebird2" )
             $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-postgresql" ))
-conflicts=("${MINGW_PACKAGE_PREFIX}-qt5"
-           "${MINGW_PACKAGE_PREFIX}-qt5-debug"
-           "${MINGW_PACKAGE_PREFIX}-qt5-static")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
@@ -36,8 +33,26 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-postgresql" ))
 groups=(${MINGW_PACKAGE_PREFIX}-qt6)
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
-source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/$_qtver/submodules/$_pkgfn.tar.xz")
-sha256sums=('b9c4061c1c7999c42c315fc5b0f4f654067b4186066dd729bbcf1bdce8d781c8')
+source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/$_qtver/submodules/$_pkgfn.tar.xz"
+        001-append-qt6-to-tools-to-remove-conflict-qt5-qt6.patch)
+sha256sums=('b9c4061c1c7999c42c315fc5b0f4f654067b4186066dd729bbcf1bdce8d781c8'
+            '4c1f512c5cb86e1a03079ec666d8ba523b66ee8e18297b1333a21cfebb51874f')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying ${_patch}"
+    patch -Nbp1 -i "${srcdir}/${_patch}"
+  done
+}
+
+prepare() {
+  cd $srcdir/${_pkgfn}
+
+  apply_patch_with_msg \
+    001-append-qt6-to-tools-to-remove-conflict-qt5-qt6.patch
+}
 
 build() {
   cd ${srcdir}
@@ -84,4 +99,16 @@ package() {
 
   install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_realname}
   install -Dm644 $_pkgfn/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_realname}
+
+  # Restore qmake6
+  ln -s ${pkgdir}${MINGW_PREFIX}/bin/qmake-qt6 ${pkgdir}${MINGW_PREFIX}/bin/qmake6.exe
+
+  # Fix *.pri, *.bat and *.cmake files
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  find "${pkgdir}${MINGW_PREFIX}/share/qt6" -type f \( -name '*.pri' -o -name '*.bat' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+  find "${pkgdir}${MINGW_PREFIX}/bin" -type f \( -name '*.bat' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+  find "${pkgdir}${MINGW_PREFIX}/lib/cmake" -type f \( -name '*.cmake' \) \
+      -exec sed -i -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
 }

--- a/mingw-w64-qt6-tools/PKGBUILD
+++ b/mingw-w64-qt6-tools/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 _qtver=6.1.2
 pkgver=${_qtver/-/}
-pkgrel=2
+pkgrel=3
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://www.qt.io'
@@ -13,6 +13,8 @@ license=(GPL3 LGPL3 FDL custom)
 pkgdesc='A cross-platform application and UI framework (Development Tools, QtHelp) (mingw-w64)'
 depends=("${MINGW_PACKAGE_PREFIX}-qt6-base"
          "${MINGW_PACKAGE_PREFIX}-clang")
+conflicts=("${MINGW_PACKAGE_PREFIX}-qt5"
+           "${MINGW_PACKAGE_PREFIX}-qt5-debug")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-clang-tools-extra"


### PR DESCRIPTION
Rename some tools by appending "-qt6" to avoid conflict with qt5 (qt5-base)