### PR TITLE
groonga: fix clang64 build

### DIFF
--- a/mingw-w64-groonga/PKGBUILD
+++ b/mingw-w64-groonga/PKGBUILD
@@ -4,14 +4,15 @@ _realname=groonga
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=11.0.2
-pkgrel=2
+pkgrel=3
 pkgdesc="An opensource fulltext search engine (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 url="http://groonga.org/"
 license=('LGPL2')
 options=('strip' 'staticlibs')
-source=(https://packages.groonga.org/source/${_realname}/${_realname}-${pkgver}.tar.gz{,.asc})
+source=(https://packages.groonga.org/source/${_realname}/${_realname}-${pkgver}.tar.gz{,.asc}
+        https://github.com/groonga/groonga/commit/269aaf0baee9e0ef57ddff872dafd8ce96033785.patch)
 depends=("${MINGW_PACKAGE_PREFIX}-arrow"
          #"${MINGW_PACKAGE_PREFIX}-libevent"
          "${MINGW_PACKAGE_PREFIX}-luajit"
@@ -28,8 +29,14 @@ depends=("${MINGW_PACKAGE_PREFIX}-arrow"
          "${MINGW_PACKAGE_PREFIX}-zstd")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 sha256sums=('de29cb5648e3c29873d343747d626a5efcb302357dc7bd82dc4df776e2de558c'
+            'SKIP'
             'SKIP')
 validpgpkeys=('2701F317CFCCCB975CADE9C2624CF77434839225') # Groonga Key <packages@groonga.org>
+
+prepare() {
+  cd "${srcdir}"/${_realname}-${pkgver}
+  patch -p1 -i ${srcdir}/269aaf0baee9e0ef57ddff872dafd8ce96033785.patch
+}
 
 build() {
   [[ -d ${srcdir}/build-${CARCH} ]] && rm -rf ${srcdir}/build-${CARCH}


### PR DESCRIPTION
This PR fixes the following error.

```
../../groonga-11.0.2/lib/window_function_executor.cpp:392:22: error: constexpr function never produces a constant expression [-Winvalid-constexpr]
  constexpr uint32_t unpack_source_id_record_id(uint64_t source_id) {
                     ^
../../groonga-11.0.2/lib/window_function_executor.cpp:393:30: note: shift count 32 >= width of type 'unsigned long' (32 bits)
    return source_id & ((1UL << 32) - 1);
                             ^
../../groonga-11.0.2/lib/window_function_executor.cpp:393:30: warning: shift count >= width of type [-Wshift-count-overflow]
    return source_id & ((1UL << 32) - 1);
                                 ^  ~~
```