### PR TITLE
openFPGALoader: update to 0.5.0

### DIFF
--- a/mingw-w64-openFPGALoader/PKGBUILD
+++ b/mingw-w64-openFPGALoader/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=openFPGALoader
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.4.0
+pkgver=0.5.0
 pkgrel=2
 pkgdesc="openFPGALoader: universal utility for programming FPGA (mingw-w64)"
 arch=('any')
@@ -18,7 +18,7 @@ makedepends=(
 )
 
 source=("${_realname}::https://codeload.github.com/trabucayre/openFPGALoader/tar.gz/v${pkgver}")
-sha256sums=('f2a67761a6fc66b5f1ba61618ea73852e3d4d7ea7166f32ea0a3274a908c6d11')
+sha256sums=('39c9686bdfcfa96b6bb1d8b37a8a53732372c16cda562036abe9930b61b29e97')
 
 build() {
   cd "${srcdir}/${_realname}-${pkgver}"


### PR DESCRIPTION
A new release was tagged yesterday: https://github.com/trabucayre/openFPGALoader/releases/tag/v0.5.0. This is a regular bump.

/cc @trabucayre