### PR TITLE
[CI] Remove packages from single PKGBUILD at once

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: msys2/setup-msys2@v2
         with:
-          msystem: MSYS
+          msystem: ${{ matrix.msystem }}
           install: git msys2-devel base-devel binutils pactoys-git ${{ matrix.toolchain }}
           update: true
 


### PR DESCRIPTION
1- Sometimes a single PKGBUILD produce many packages, which make it not possible to remove an earlier (alphabetically) package before its dependent package, so that package will stay installed.

2- Ensure that the toolchain is installed in case the previous package is a part of it and get removed.