### PR TITLE
Clang update 12.0.1-3

### DIFF
--- a/mingw-w64-clang/0020-llvm-rc-Allow-specifying-language-with-a-leading-0x-.patch
+++ b/mingw-w64-clang/0020-llvm-rc-Allow-specifying-language-with-a-leading-0x-.patch
@@ -1,0 +1,101 @@
+From 46020f6f0c8aa134002208b2ecf0593b04c46d08 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Storsj=C3=B6?= <martin@martin.st>
+Date: Mon, 2 Aug 2021 14:10:22 +0300
+Subject: [PATCH] [llvm-rc] Allow specifying language with a leading 0x prefix
+
+This option is always interpreted strictly as a hexadecimal string,
+even if it has no prefix that indicates the number format, hence
+the existing call to StringRef::getAsInteger(16, ...).
+
+StringRef::getAsInteger(0, ...) consumes a leading "0x" prefix is
+present, but when the radix is specified, the radix shouldn't
+be included.
+
+Both MS rc.exe and GNU windres accept the language with that
+prefix.
+
+Also allow specifying the codepage to llvm-windres with a different
+radix, as GNU windres allows that (but MS rc.exe doesn't).
+
+This fixes https://llvm.org/PR51295.
+
+Differential Revision: https://reviews.llvm.org/D107263
+---
+ test/tools/llvm-rc/codepage.test |  2 ++
+ test/tools/llvm-rc/language.test |  2 ++
+ tools/llvm-rc/llvm-rc.cpp        | 11 +++++++----
+ 3 files changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/test/tools/llvm-rc/codepage.test b/test/tools/llvm-rc/codepage.test
+index 20639d42ecb82..a55764cd4f76a 100644
+--- a/test/tools/llvm-rc/codepage.test
++++ b/test/tools/llvm-rc/codepage.test
+@@ -4,6 +4,8 @@
+ ; RUN: llvm-readobj %t.utf8.res | FileCheck %s --check-prefix=UTF8
+ ; RUN: llvm-windres --no-preprocess --codepage 65001 %p/Inputs/utf8.rc %t.utf8.res
+ ; RUN: llvm-readobj %t.utf8.res | FileCheck %s --check-prefix=UTF8
++; RUN: llvm-windres --no-preprocess --codepage 0xfde9 %p/Inputs/utf8.rc %t.utf8.res
++; RUN: llvm-readobj %t.utf8.res | FileCheck %s --check-prefix=UTF8
+ 
+ ; UTF8:      Resource type (int): STRINGTABLE (ID 6)
+ ; UTF8-NEXT: Resource name (int): 1
+diff --git a/test/tools/llvm-rc/language.test b/test/tools/llvm-rc/language.test
+index 9960ae108dfef..539371057414d 100644
+--- a/test/tools/llvm-rc/language.test
++++ b/test/tools/llvm-rc/language.test
+@@ -6,6 +6,8 @@
+ ; RUN: llvm-readobj %t.res | FileCheck %s
+ ; RUN: llvm-windres --no-preprocess --language 40A %p/Inputs/language.rc %t.res
+ ; RUN: llvm-readobj %t.res | FileCheck %s
++; RUN: llvm-windres --no-preprocess -l 0x40A %p/Inputs/language.rc %t.res
++; RUN: llvm-readobj %t.res | FileCheck %s
+ 
+ ; CHECK:      Resource name (int): 1
+ ; CHECK-NEXT: Data version:
+diff --git a/tools/llvm-rc/llvm-rc.cpp b/tools/llvm-rc/llvm-rc.cpp
+index c7c93ae485d8a..6965b7fb2eed3 100644
+--- a/tools/llvm-rc/llvm-rc.cpp
++++ b/tools/llvm-rc/llvm-rc.cpp
+@@ -270,6 +270,13 @@
+   return true;
+ }
+ 
++static bool consume_front_lower(StringRef &S, const char *Str) {
++  if (!S.startswith_lower(Str))
++    return false;
++  S = S.drop_front(strlen(Str));
++  return true;
++}
++
+ static std::pair<bool, std::string> isWindres(llvm::StringRef Argv0) {
+   StringRef ProgName = llvm::sys::path::stem(Argv0);
+   // x86_64-w64-mingw32-windres -> x86_64-w64-mingw32, windres
+@@ -483,13 +490,14 @@
+   Opts.Params.CodePage = CpWin1252; // Different default
+   if (InputArgs.hasArg(WINDRES_codepage)) {
+     if (InputArgs.getLastArgValue(WINDRES_codepage)
+-            .getAsInteger(10, Opts.Params.CodePage))
++            .getAsInteger(0, Opts.Params.CodePage))
+       fatalError("Invalid code page: " +
+                  InputArgs.getLastArgValue(WINDRES_codepage));
+   }
+   if (InputArgs.hasArg(WINDRES_language)) {
+-    if (InputArgs.getLastArgValue(WINDRES_language)
+-            .getAsInteger(16, Opts.LangId))
++    StringRef Val = InputArgs.getLastArgValue(WINDRES_language);
++    consume_front_lower(Val, "0x");
++    if (Val.getAsInteger(16, Opts.LangId))
+       fatalError("Invalid language id: " +
+                  InputArgs.getLastArgValue(WINDRES_language));
+   }
+@@ -572,7 +580,9 @@
+   }
+   Opts.AppendNull = InputArgs.hasArg(OPT_add_null);
+   if (InputArgs.hasArg(OPT_lang_id)) {
+-    if (InputArgs.getLastArgValue(OPT_lang_id).getAsInteger(16, Opts.LangId))
++    StringRef Val = InputArgs.getLastArgValue(OPT_lang_id);
++    consume_front_lower(Val, "0x");
++    if (Val.getAsInteger(16, Opts.LangId))
+       fatalError("Invalid language id: " +
+                  InputArgs.getLastArgValue(OPT_lang_id));
+   }

--- a/mingw-w64-clang/0107-clang-MinGW-Let-the-last-of-mconsole-mwindows-have-e.patch
+++ b/mingw-w64-clang/0107-clang-MinGW-Let-the-last-of-mconsole-mwindows-have-e.patch
@@ -1,0 +1,52 @@
+From ce49fd024b43bd76b149f984b8f0d16e92b9bb06 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Storsj=C3=B6?= <martin@martin.st>
+Date: Mon, 2 Aug 2021 13:47:40 +0300
+Subject: [PATCH] [clang] [MinGW] Let the last of -mconsole/-mwindows have
+ effect
+
+Don't just check for the existence of one, but check which one was
+specified last, if any.
+
+This fixes https://llvm.org/PR51296.
+
+Differential Revision: https://reviews.llvm.org/D107261
+---
+ lib/Driver/ToolChains/MinGW.cpp | 7 +++++--
+ test/Driver/mingw.cpp           | 7 +++++++
+ 2 files changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/lib/Driver/ToolChains/MinGW.cpp b/lib/Driver/ToolChains/MinGW.cpp
+index 20efbdc237a84..7ba729f36bd87 100644
+--- a/lib/Driver/ToolChains/MinGW.cpp
++++ b/lib/Driver/ToolChains/MinGW.cpp
+@@ -136,10 +136,13 @@ void tools::MinGW::Linker::ConstructJob(Compilation &C, const JobAction &JA,
+     llvm_unreachable("Unsupported target architecture.");
+   }
+ 
+-  if (Args.hasArg(options::OPT_mwindows)) {
++  Arg *SubsysArg =
++      Args.getLastArg(options::OPT_mwindows, options::OPT_mconsole);
++  if (SubsysArg && SubsysArg->getOption().matches(options::OPT_mwindows)) {
+     CmdArgs.push_back("--subsystem");
+     CmdArgs.push_back("windows");
+-  } else if (Args.hasArg(options::OPT_mconsole)) {
++  } else if (SubsysArg &&
++             SubsysArg->getOption().matches(options::OPT_mconsole)) {
+     CmdArgs.push_back("--subsystem");
+     CmdArgs.push_back("console");
+   }
+diff --git a/test/Driver/mingw.cpp b/test/Driver/mingw.cpp
+index 796bde8eebe4c..83b61ba7d33f0 100644
+--- a/test/Driver/mingw.cpp
++++ b/test/Driver/mingw.cpp
+@@ -61,3 +61,10 @@
+ // RUN: %clang -target i686-windows-gnu -E -### %s -municode 2>&1 | FileCheck -check-prefix=CHECK_MINGW_UNICODE %s
+ // CHECK_MINGW_NO_UNICODE-NOT: "-DUNICODE"
+ // CHECK_MINGW_UNICODE: "-DUNICODE"
++
++// RUN: %clang -target i686-windows-gnu -### %s 2>&1 | FileCheck -check-prefix=CHECK_NO_SUBSYS %s
++// RUN: %clang -target i686-windows-gnu -### %s -mwindows -mconsole 2>&1 | FileCheck -check-prefix=CHECK_SUBSYS_CONSOLE %s
++// RUN: %clang -target i686-windows-gnu -### %s -mconsole -mwindows 2>&1 | FileCheck -check-prefix=CHECK_SUBSYS_WINDOWS %s
++// CHECK_NO_SUBSYS-NOT: "--subsystem"
++// CHECK_SUBSYS_CONSOLE: "--subsystem" "console"
++// CHECK_SUBSYS_WINDOWS: "--subsystem" "windows"

--- a/mingw-w64-clang/0318-LLD-MinGW-Accept-joined-format-for-stack.patch
+++ b/mingw-w64-clang/0318-LLD-MinGW-Accept-joined-format-for-stack.patch
@@ -1,0 +1,30 @@
+From 05b025edf4aecf19634e01b0974126e53a927a50 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Mateusz=20Miku=C5=82a?= <mati865@gmail.com>
+Date: Sun, 1 Aug 2021 23:26:25 +0300
+Subject: [PATCH] [LLD][MinGW] Accept joined format for --stack
+
+Postgresql uses `--stack=` in its Makefile.
+
+Downstream issue: https://github.com/msys2/MINGW-packages/pull/9167
+
+Reviewed By: mstorsjo
+
+Differential Revision: https://reviews.llvm.org/D107237
+---
+ MinGW/Options.td       | 2 +-
+ test/MinGW/driver.test | 1 +
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/MinGW/Options.td b/MinGW/Options.td
+index e1a505240cb82..7b250614e434b 100644
+--- a/MinGW/Options.td
++++ b/MinGW/Options.td
+@@ -85,7 +85,7 @@ defm output_def: Eq<"output-def", "Output def file">;
+ defm section_alignment: Eq<"section-alignment", "Set section alignment">;
+ def shared: F<"shared">, HelpText<"Build a shared object">;
+ defm subs: Eq<"subsystem", "Specify subsystem">;
+-def stack: S<"stack">;
++defm stack: Eq<"stack", "Set size of the initial stack">;
+ def strip_all: F<"strip-all">,
+     HelpText<"Omit all symbol information from the output binary">;
+ def strip_debug: F<"strip-debug">,

--- a/mingw-w64-clang/0319-LLD-MinGW-Support-both-opt-value-and-opt-value-for-m.patch
+++ b/mingw-w64-clang/0319-LLD-MinGW-Support-both-opt-value-and-opt-value-for-m.patch
@@ -1,0 +1,80 @@
+From b7fb5b54a93099cf3d7ac64f4a95d9942bc2e6a7 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Storsj=C3=B6?= <martin@martin.st>
+Date: Mon, 2 Aug 2021 11:44:04 +0300
+Subject: [PATCH] [LLD] [MinGW] Support both "--opt value" and "--opt=value"
+ for more options
+
+This does the same fix as D107237 but for a couple more options,
+converting all remaining cases of such options to accept both
+forms, for consistency. This fixes building e.g. openldap, which
+uses --image-base=<value>.
+
+Differential Revision: https://reviews.llvm.org/D107253
+---
+ MinGW/Options.td       | 26 ++++++++++++++------------
+ test/MinGW/driver.test |  2 ++
+ 2 files changed, 16 insertions(+), 12 deletions(-)
+
+diff --git a/MinGW/Options.td b/MinGW/Options.td
+index 7b250614e434b..fb178a1438e55 100644
+--- a/MinGW/Options.td
++++ b/MinGW/Options.td
+@@ -16,6 +16,11 @@ multiclass EqLong<string name, string help> {
+     HelpText<help>;
+ }
+ 
++multiclass EqNoHelp<string name> {
++  def NAME: Separate<["--", "-"], name>;
++  def NAME # _eq: Joined<["--", "-"], name # "=">, Alias<!cast<Separate>(NAME)>;
++}
++
+ multiclass B<string name, string help1, string help2> {
+   def NAME: Flag<["--", "-"], name>, HelpText<help1>;
+   def no_ # NAME: Flag<["--", "-"], "no-" # name>, HelpText<help2>;
+@@ -57,8 +62,8 @@ defm gc_sections: B<"gc-sections",
+     "Remove unused sections",
+     "Don't remove unused sections">;
+ def help: F<"help">, HelpText<"Print option help">;
+-def icf: J<"icf=">, HelpText<"Identical code folding">;
+-def image_base: S<"image-base">, HelpText<"Base address of the program">;
++defm icf: Eq<"icf", "Identical code folding">;
++defm image_base: Eq<"image-base", "Base address of the program">;
+ defm insert_timestamp: B<"insert-timestamp",
+     "Include PE header timestamp",
+     "Don't include PE header timestamp">;
+@@ -109,12 +114,11 @@ def _HASH_HASH_HASH : Flag<["-"], "###">,
+     HelpText<"Print (but do not run) the commands to run for this compilation">;
+ def appcontainer: F<"appcontainer">, HelpText<"Set the appcontainer flag in the executable">;
+ defm delayload: Eq<"delayload", "DLL to load only on demand">;
+-def mllvm: S<"mllvm">;
++defm mllvm: EqNoHelp<"mllvm">;
+ defm pdb: Eq<"pdb", "Output PDB debug info file, chosen implicitly if the argument is empty">;
+ defm thinlto_cache_dir: EqLong<"thinlto-cache-dir",
+   "Path to ThinLTO cached object file directory">;
+-def Xlink : J<"Xlink=">, MetaVarName<"<arg>">,
+-    HelpText<"Pass <arg> to the COFF linker">;
++defm Xlink : Eq<"Xlink", "Pass <arg> to the COFF linker">, MetaVarName<"<arg>">;
+ 
+ // Alias
+ def alias_Bdynamic_call_shared: Flag<["-"], "call_shared">, Alias<Bdynamic>;
+@@ -135,15 +139,13 @@ def: F<"enable-auto-image-base">;
+ def: F<"end-group">;
+ def: Flag<["--"], "full-shutdown">;
+ def: F<"high-entropy-va">;
+-def: S<"major-image-version">;
+-def: S<"minor-image-version">;
++defm: EqNoHelp<"major-image-version">;
++defm: EqNoHelp<"minor-image-version">;
+ def: F<"no-undefined">;
+ def: F<"nxcompat">;
+ def: F<"pic-executable">;
+-def: S<"plugin">;
+-def: J<"plugin=">;
+-def: S<"plugin-opt">;
+-def: J<"plugin-opt=">;
+-def: J<"sysroot">;
++defm: EqNoHelp<"plugin">;
++defm: EqNoHelp<"plugin-opt">;
++defm: EqNoHelp<"sysroot">;
+ def: F<"start-group">;
+ def: F<"tsaware">;

--- a/mingw-w64-clang/0403-HACK-for-clang32-changing-time_t.patch
+++ b/mingw-w64-clang/0403-HACK-for-clang32-changing-time_t.patch
@@ -1,0 +1,31 @@
+--- libcxx/include/chrono~	2021-06-28 09:23:38.000000000 -0700
++++ libcxx/include/chrono	2021-08-04 10:20:15.681435500 -0700
+@@ -1581,6 +1581,9 @@
+     static time_point now() _NOEXCEPT;
+     static time_t     to_time_t  (const time_point& __t) _NOEXCEPT;
+     static time_point from_time_t(time_t __t) _NOEXCEPT;
++#if defined (_LIBCPP_BUILDING_LIBRARY) && defined(__MINGW32__) && defined (_WIN32) && !defined (_WIN64) && !defined(_USE_32BIT_TIME_T)
++    static time_point from_time_t(__time32_t __t) _NOEXCEPT;
++#endif
+ };
+ 
+ #ifndef _LIBCPP_HAS_NO_MONOTONIC_CLOCK
+--- libcxx/src/chrono.cpp~	2021-06-28 09:23:38.000000000 -0700
++++ libcxx/src/chrono.cpp	2021-08-04 00:07:15.334446900 -0700
+@@ -113,6 +113,16 @@
+     return system_clock::time_point(seconds(t));
+ }
+ 
++#if defined(__MINGW32__) && defined (_WIN32) && !defined (_WIN64) && !defined(_USE_32BIT_TIME_T)
++system_clock::time_point
++system_clock::from_time_t(__time32_t t) _NOEXCEPT
++{
++    return system_clock::time_point(seconds(t));
++}
++#endif
++
++
++
+ //
+ // steady_clock
+ //

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -12,8 +12,6 @@ if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then
   _clangprefix=1
   _compiler=clang
 fi
-#_generator="MSYS Makefiles"
-_generator="Ninja"
 _realname=clang
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
@@ -30,7 +28,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
            "${MINGW_PACKAGE_PREFIX}-openmp")
          "${MINGW_PACKAGE_PREFIX}-polly")
 pkgver=12.0.1
-pkgrel=2
+pkgrel=3
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -42,6 +40,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake>=3.4.3"
              "${MINGW_PACKAGE_PREFIX}-libffi"
              "${MINGW_PACKAGE_PREFIX}-libxml2"
              "${MINGW_PACKAGE_PREFIX}-lua"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-python-sphinx"
              "${MINGW_PACKAGE_PREFIX}-python"
@@ -54,8 +53,6 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake>=3.4.3"
                "${MINGW_PACKAGE_PREFIX}-clang" \
                "${MINGW_PACKAGE_PREFIX}-compiler-rt" \
                "${MINGW_PACKAGE_PREFIX}-libc++")
-             $([[ "$_generator" == "Ninja" ]] && echo \
-               "${MINGW_PACKAGE_PREFIX}-ninja")
              $([[ "$_compiler" == "gcc" ]] && echo \
                "${MINGW_PACKAGE_PREFIX}-gcc")
              )
@@ -327,7 +324,7 @@ build() {
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe \
-    -G"$_generator" \
+    -GNinja \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DCMAKE_SYSTEM_IGNORE_PATH=/usr/lib \
     -DFFI_INCLUDE_DIR="${FFI_INCLUDE_DIR}" \
@@ -353,17 +350,6 @@ build() {
     "${platform_config[@]}" \
     "${extra_config[@]}" \
     ../llvm
-
-  # sed away the bad windows style command line parameters (they are translated by msys from /bad to c:\msys\bad
-  # Ninja doesn't need fixing them.
-  if [[ "$_generator" != "Ninja" ]]; then
-    case "${CARCH}" in
-      i?86|x86_64)
-        sed -i.orig 's/\/c \/Fo/-c -Fo/' projects/openmp/runtime/src/CMakeFiles/omp.dir/build.make
-        sed -i.orig 's/\/safeseh \/coff/-safeseh -coff/' projects/openmp/runtime/src/CMakeFiles/omp.dir/build.make
-        ;;
-    esac
-  fi
 
   ${MINGW_PREFIX}/bin/cmake.exe --build .
 
@@ -405,7 +391,7 @@ build() {
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe \
-    -G"$_generator" \
+    -GNinja \
     -DCMAKE_CXX_FLAGS="${CXXFLAGS} -D_LIBCPP_BUILDING_LIBRARY -U_LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS" \
     -DLIBCXX_ENABLE_EXPERIMENTAL_LIBRARY=OFF \
     -DLIBCXX_ENABLE_SHARED=ON \
@@ -424,7 +410,7 @@ build() {
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe \
-    -G"$_generator" \
+    -GNinja \
     -DCMAKE_CXX_FLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS" \
     -DLIBCXX_ENABLE_SHARED=OFF \
     -DLIBCXX_ENABLE_STATIC=ON \

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -100,6 +100,7 @@ source=("https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkgver
         "0319-LLD-MinGW-Support-both-opt-value-and-opt-value-for-m.patch"
         "0401-libcxx-fs.patch"
         "0402-make-the-visibility-attributes-consistent-for-__narr.patch"
+        "0403-HACK-for-clang32-changing-time_t.patch"
         "0601-libunwind-Install-the-DLL-when-doing-ninja-install.patch"
         "0710-backport-05b3716.patch"
         "0901-cast-to-make-gcc-happy.patch")
@@ -157,6 +158,7 @@ sha256sums=('129cb25cd13677aad951ce5c2deb0fe4afc1e9d98950f53b51bdcfb5a73afa0e'
             'e7eee06ac4a794f674e4de86e02fb9ab54700018054da61d78fb922469eb6516'
             '6cb5d425e36b24a8eb2776ba0e297ea0a986a4086f96a0e60ca3a4ebc1a9d386'
             '3abb69e6dc9ad367240409d2df3c3cd6ddc89325de994195fc7222493baaaa44'
+            '987651ebbd30d94da01be43636bf2738448f9cce8927137ecd002643ab270eea'
             '9ab6c628eccf0155cebdc73e4f5297820bef54d8f30022ed0c1cbb6ab8ad67b8'
             '63b09e0b58a3a100fdd348b5f38f594e3c94cd54030a13b821f7a91ece3e1de0'
             '11352ffbe7559a7170f2abd52b3552c877fbcf8fc82cff77b421e8b130a4dd66')
@@ -242,6 +244,12 @@ prepare() {
   apply_patch_with_msg \
     "0401-libcxx-fs.patch" \
     "0402-make-the-visibility-attributes-consistent-for-__narr.patch"
+
+  # XXX HACK for clang32 to allow the change of time_t from 32 to 64-bits
+  if [[ "${MSYSTEM}" == "CLANG32" ]]; then
+    apply_patch_with_msg \
+      "0403-HACK-for-clang32-changing-time_t.patch"
+  fi
 
   cd "${srcdir}/libunwind"
   apply_patch_with_msg \
@@ -352,6 +360,39 @@ build() {
     -DLIBUNWIND_USE_COMPILER_RT=ON
     -DLLVM_ENABLE_LLD=ON
     -DLLVM_ENABLE_PROJECTS="libcxx;libcxxabi;libunwind")
+
+  # XXX HACK for clang32 to allow the change of time_t from 32 to 64-bits
+  if [[ "${MSYSTEM}" == "CLANG32" ]]; then
+    [[ -d build-libcxx-shared-HACK ]] && rm -rf build-libcxx-shared-HACK
+    [[ -d bin-HACK ]] && rm -rf bin-HACK
+    [[ -d lib-HACK ]] && rm -rf lib-HACK
+    mkdir bin-HACK
+    mkdir lib-HACK
+    mkdir build-libcxx-shared-HACK && cd build-libcxx-shared-HACK
+
+    MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake.exe \
+      -GNinja \
+      -DCMAKE_CXX_FLAGS="${CXXFLAGS} -D_LIBCPP_BUILDING_LIBRARY -U_LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS" \
+      -DLIBCXX_ENABLE_EXPERIMENTAL_LIBRARY=OFF \
+      -DLIBCXX_ENABLE_SHARED=ON \
+      -DLIBCXX_ENABLE_STATIC=OFF \
+      -DLIBUNWIND_ENABLE_SHARED=ON \
+      -DLIBUNWIND_ENABLE_STATIC=OFF \
+      "${common_cmake_args[@]}" \
+      "${libcxx_config[@]}" \
+      ../llvm
+
+    ${MINGW_PREFIX}/bin/cmake.exe --build . -- unwind cxx
+
+    cp lib/libc++.dll ../bin-HACK
+    cp lib/libc++.dll.a ../lib-HACK
+    cp lib/libc++abi.a ../lib-HACK
+    export PATH="${srcdir}/bin-HACK:$PATH"
+    export LDFLAGS+=" -L$(cygpath -m "${srcdir}/lib-HACK")"
+
+    cd "${srcdir}"
+  fi
 
   [[ -d build-${MSYSTEM} ]] && rm -rf build-${MSYSTEM}
   mkdir build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -262,9 +262,6 @@ prepare() {
 build() {
   cd "${srcdir}"
 
-  [[ -d build-${MSYSTEM} ]] && rm -rf build-${MSYSTEM}
-  mkdir build-${MSYSTEM} && cd build-${MSYSTEM}
-
   case "${CARCH}" in
     i?86|armv7)
       # lld needs all the address space it can get.
@@ -272,7 +269,7 @@ build() {
       ;;
   esac
 
-  local -a extra_config
+  local -a platform_config
   local -a common_cmake_args
 
   if check_option "debug" "y"; then
@@ -282,6 +279,9 @@ build() {
     common_cmake_args+=(-DCMAKE_BUILD_TYPE=Release)
   fi
   common_cmake_args+=(-Wno-dev
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX}
+    -DCMAKE_SYSTEM_IGNORE_PATH=/usr/lib
+    -DLLVM_HOST_TRIPLE="${CARCH}-w64-windows-gnu"
     -DPython3_EXECUTABLE=${MINGW_PREFIX}/bin/python.exe
     -DPython3_FIND_REGISTRY=NEVER
     -DPython3_ROOT_DIR=${MINGW_PREFIX})
@@ -293,7 +293,7 @@ build() {
   if [ "${_compiler}" == "clang" ]; then
     export CC='clang'
     export CXX='clang++'
-    extra_config+=(-DCOMPILER_RT_USE_BUILTINS_LIBRARY=ON
+    platform_config+=(-DCOMPILER_RT_USE_BUILTINS_LIBRARY=ON
       -DLLVM_ENABLE_LIBCXX=ON)
   fi
 
@@ -301,7 +301,7 @@ build() {
     # A bit hacky but it works
     local _clang_links="clang++;clang-cpp;as;c++;cc;cpp;g++;gcc;${MINGW_CHOST}-cc;${MINGW_CHOST}-c++;${MINGW_CHOST}-clang;${MINGW_CHOST}-clang++;${MINGW_CHOST}-g++;${MINGW_CHOST}-gcc"
 
-    extra_config+=(-DCLANG_DEFAULT_RTLIB=compiler-rt
+    platform_config+=(-DCLANG_DEFAULT_RTLIB=compiler-rt
       -DCLANG_DEFAULT_UNWINDLIB=libunwind
       -DCLANG_DEFAULT_CXX_STDLIB=libc++
       -DCLANG_DEFAULT_LINKER=lld
@@ -311,7 +311,6 @@ build() {
   fi
 
   local _projects="clang;clang-tools-extra;compiler-rt;lld;lldb;polly"
-  local -a platform_config
 
   case "${CARCH}" in
     x86_64)
@@ -331,11 +330,35 @@ build() {
       ;;
   esac
 
+  local -a libcxx_config
+  if (( _clangprefix )); then
+    libcxx_config+=(-DLIBCXX_USE_COMPILER_RT=ON
+      -DLIBCXXABI_USE_COMPILER_RT=ON
+      -DLIBCXXABI_USE_LLVM_UNWINDER=ON)
+  else
+    # Use newly built compiler for libcxx/libunwind because GCC/binutils doesn't play nicely
+    libcxx_config+=(-DCMAKE_AR="${srcdir}/build-${MSYSTEM}/bin/llvm-ar.exe"
+      -DCMAKE_ASM_COMPILER="${srcdir}/build-${MSYSTEM}/bin/clang.exe"
+      -DCMAKE_C_COMPILER="${srcdir}/build-${MSYSTEM}/bin/clang.exe"
+      -DCMAKE_CXX_COMPILER="${srcdir}/build-${MSYSTEM}/bin/clang++.exe"
+      -DCMAKE_RANLIB="${srcdir}/build-${MSYSTEM}/bin/llvm-ranlib.exe")
+  fi
+
+  libcxx_config+=(-DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON
+    -DLIBCXX_HAS_WIN32_THREAD_API=ON
+    -DLIBCXXABI_HAS_WIN32_THREAD_API=ON
+    -DLIBCXXABI_ENABLE_SHARED=OFF
+    -DLIBCXXABI_ENABLE_STATIC=ON
+    -DLIBUNWIND_USE_COMPILER_RT=ON
+    -DLLVM_ENABLE_LLD=ON
+    -DLLVM_ENABLE_PROJECTS="libcxx;libcxxabi;libunwind")
+
+  [[ -d build-${MSYSTEM} ]] && rm -rf build-${MSYSTEM}
+  mkdir build-${MSYSTEM} && cd build-${MSYSTEM}
+
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe \
     -GNinja \
-    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    -DCMAKE_SYSTEM_IGNORE_PATH=/usr/lib \
     -DFFI_INCLUDE_DIR="${FFI_INCLUDE_DIR}" \
     -DLIBCLANG_BUILD_STATIC=ON \
     -DLIBOMP_FORTRAN_MODULES=$( (( _clangprefix )) && echo "OFF" || echo "ON" ) \
@@ -349,7 +372,6 @@ build() {
     -DLLVM_ENABLE_PROJECTS="${_projects}" \
     -DLLVM_ENABLE_SPHINX=ON \
     -DLLVM_ENABLE_THREADS=ON \
-    -DLLVM_HOST_TRIPLE="${CARCH}-w64-windows-gnu" \
     -DLLVM_INCLUDE_EXAMPLES=OFF \
     -DLLVM_INSTALL_UTILS=ON \
     -DLLVM_LINK_LLVM_DYLIB=ON \
@@ -357,7 +379,6 @@ build() {
     -DLLDB_EMBED_PYTHON_HOME=OFF \
     "${common_cmake_args[@]}" \
     "${platform_config[@]}" \
-    "${extra_config[@]}" \
     ../llvm
 
   ${MINGW_PREFIX}/bin/cmake.exe --build .
@@ -368,30 +389,6 @@ build() {
   sed -i.orig '/\(clang\|lld\|lldb\|polly\)\/cmake_install.cmake/d' tools/cmake_install.cmake
   sed -i.orig '/\(extra\|scan-build\|scan-view\)\/cmake_install.cmake/d' tools/clang/tools/cmake_install.cmake
   sed -i.orig '/\(compiler-rt\|libcxxabi\|libcxx\|openmp\|libunwind\)\/cmake_install.cmake/d' projects/cmake_install.cmake
-
-  # Use newly built compiler because GCC/binutils doesn't play nicely
-  if (( _clangprefix )); then
-    common_cmake_args+=(-DLIBCXX_USE_COMPILER_RT=ON
-      -DLIBCXXABI_USE_COMPILER_RT=ON
-      -DLIBCXXABI_USE_LLVM_UNWINDER=ON)
-  else
-    export CC="${srcdir}/build-${MSYSTEM}/bin/clang"
-    export CXX="${srcdir}/build-${MSYSTEM}/bin/clang++"
-    common_cmake_args+=(-DCMAKE_AR=${srcdir}/build-${MSYSTEM}/bin/llvm-ar
-      -DCMAKE_RANLIB=${srcdir}/build-${MSYSTEM}/bin/llvm-ranlib)
-  fi
-
-  common_cmake_args+=(-DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX}
-    -DCMAKE_SYSTEM_IGNORE_PATH=/usr/lib
-    -DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON
-    -DLIBCXX_HAS_WIN32_THREAD_API=ON
-    -DLIBCXXABI_HAS_WIN32_THREAD_API=ON
-    -DLIBCXXABI_ENABLE_SHARED=OFF
-    -DLIBCXXABI_ENABLE_STATIC=ON
-    -DLIBUNWIND_USE_COMPILER_RT=ON
-    -DLLVM_ENABLE_LLD=ON
-    -DLLVM_ENABLE_PROJECTS="libcxx;libcxxabi;libunwind"
-    -DLLVM_HOST_TRIPLE="${CARCH}-w64-windows-gnu")
 
   cd "${srcdir}"
 
@@ -408,6 +405,7 @@ build() {
     -DLIBUNWIND_ENABLE_SHARED=ON \
     -DLIBUNWIND_ENABLE_STATIC=OFF \
     "${common_cmake_args[@]}" \
+    "${libcxx_config[@]}" \
     ../llvm
 
   ${MINGW_PREFIX}/bin/cmake.exe --build . -- unwind cxx
@@ -427,6 +425,7 @@ build() {
     -DLIBUNWIND_ENABLE_SHARED=OFF \
     -DLIBUNWIND_ENABLE_STATIC=ON \
     "${common_cmake_args[@]}" \
+    "${libcxx_config[@]}" \
     ../llvm
 
   ${MINGW_PREFIX}/bin/cmake.exe --build . -- unwind cxxabi cxx cxx_experimental

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -74,6 +74,7 @@ source=("https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkgver
         "0017-X86-Teach-X86FloatingPoint-s-handleCall-to-only-eras.patch"
         "0018-llvm-rc-Allow-dashes-as-part-of-resource-name-strings.patch"
         "0019-MinGW-Mark-a-number-of-library-functions-unavailable.patch"
+        "0020-llvm-rc-Allow-specifying-language-with-a-leading-0x-.patch"
         "0101-Disable-fPIC-errors.patch"
         "0103-Use-posix-style-path-separators-with-MinGW.patch"
         "0104-link-pthread-with-mingw.patch"
@@ -132,6 +133,7 @@ sha256sums=('129cb25cd13677aad951ce5c2deb0fe4afc1e9d98950f53b51bdcfb5a73afa0e'
             '8f98770616e9c0457b8e7dd39c01550e300237d3973da96b827f4b4a9eca07f8'
             'e7eb5fdaa0c12122be7f801adf9cf748de806843c6c4e65bb28d042e94e78d88'
             '8a5a038cdbfdcf56a021cb53bbb6b00328c792d632a12dad99d9df0f33a91461'
+            'eefcb3c172d27d3691a7f33b1676d14ebdaa41311567e408635cf1ae8d671136'
             '63b2bda6a487ec69e257c3b7a14d71f6bec649fca058a5a54804f213d45c7c70'
             '2d1dc7f7cd6bd61f275cd0be6650f3086aee622074ac786ff5a921bf8ecaada2'
             '715cb8862753854b2d9256e0b70003e2d1f57083d83eaeaf5a095fc72b8a4e26'
@@ -194,7 +196,8 @@ prepare() {
     "0016-llvm-rc-Make-commas-in-user-data-structs-optional.patch" \
     "0017-X86-Teach-X86FloatingPoint-s-handleCall-to-only-eras.patch" \
     "0018-llvm-rc-Allow-dashes-as-part-of-resource-name-strings.patch" \
-    "0019-MinGW-Mark-a-number-of-library-functions-unavailable.patch"
+    "0019-MinGW-Mark-a-number-of-library-functions-unavailable.patch" \
+    "0020-llvm-rc-Allow-specifying-language-with-a-leading-0x-.patch"
 
   if (( ! _clangprefix )); then
     apply_patch_with_msg \

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -79,6 +79,7 @@ source=("https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkgver
         "0104-link-pthread-with-mingw.patch"
         "0105-Dont-mark-emutls-variables-as-DSO-local.patch"
         "0106-Rename-a-template-parameter-that-conflicted-with-a-c.patch"
+        "0107-clang-MinGW-Let-the-last-of-mconsole-mwindows-have-e.patch"
         "0201-Provide-a-SEH-specific-__gcc_personality_seh0.patch"
         "0301-fix-including-the-personality-function-for-dwarf.patch"
         "0302-ignore-no-undefined-flag.patch"
@@ -95,6 +96,8 @@ source=("https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkgver
         "0315-LLD-COFF-Fix-up-missing-stdcall-decorations-in-MinGW.patch"
         "0316-LLD-COFF-Avoid-thread-exhaustion-on-32-bit-Windows-h.patch"
         "0317-LLD-COFF-Make-export-all-symbols-work-as-intended-fo.patch"
+        "0318-LLD-MinGW-Accept-joined-format-for-stack.patch"
+        "0319-LLD-MinGW-Support-both-opt-value-and-opt-value-for-m.patch"
         "0401-libcxx-fs.patch"
         "0402-make-the-visibility-attributes-consistent-for-__narr.patch"
         "0601-libunwind-Install-the-DLL-when-doing-ninja-install.patch"
@@ -133,6 +136,7 @@ sha256sums=('129cb25cd13677aad951ce5c2deb0fe4afc1e9d98950f53b51bdcfb5a73afa0e'
             '715cb8862753854b2d9256e0b70003e2d1f57083d83eaeaf5a095fc72b8a4e26'
             '7a3453dfdb6992fc226f7e44522e8098c7eab8a80ed8ba7dbda9764f3a5eb191'
             'a96a51c27ced621502cfd1bad7cecf52117234501099670fe63b6e130876d8c6'
+            '86c23280ca6db91c6a3bab530328ba16b330892db6651fb135a567b851ee910e'
             '70382de2120c1de08f86400576188ecd3759612eb8457f2d8be936eb6fa2765f'
             'c4d778c90569a80c3b8fe7c7c53430d456f83f4a65f393f862184375bcb77bc8'
             '0b6756ce06b6439aa9c620ac95e169a08e130b5a50e07eb15eecd3e1e8a0a7af'
@@ -149,6 +153,8 @@ sha256sums=('129cb25cd13677aad951ce5c2deb0fe4afc1e9d98950f53b51bdcfb5a73afa0e'
             '58b3b2954c8e798e21c1a6f10e2f9e7bd8b20cf8a6fa618497657bfc48eaf355'
             '4c854eb5c5e0dcbd60bb6da7aa4296c0fe1d015a8b5866cfa6b0d16fad2e42e6'
             'cad3256c9a21708ad2f98f51c1d372a42f88c94c46699b6a0458ca03e7b3a928'
+            '0225905758f4eb14e07c5708a144ec3bb238debe7ebbd075ec7f13b51bbdf726'
+            'e7eee06ac4a794f674e4de86e02fb9ab54700018054da61d78fb922469eb6516'
             '6cb5d425e36b24a8eb2776ba0e297ea0a986a4086f96a0e60ca3a4ebc1a9d386'
             '3abb69e6dc9ad367240409d2df3c3cd6ddc89325de994195fc7222493baaaa44'
             '9ab6c628eccf0155cebdc73e4f5297820bef54d8f30022ed0c1cbb6ab8ad67b8'
@@ -199,7 +205,8 @@ prepare() {
     "0101-Disable-fPIC-errors.patch" \
     "0103-Use-posix-style-path-separators-with-MinGW.patch" \
     "0105-Dont-mark-emutls-variables-as-DSO-local.patch" \
-    "0106-Rename-a-template-parameter-that-conflicted-with-a-c.patch"
+    "0106-Rename-a-template-parameter-that-conflicted-with-a-c.patch" \
+    "0107-clang-MinGW-Let-the-last-of-mconsole-mwindows-have-e.patch"
 
   if (( ! _clangprefix )); then
     apply_patch_with_msg \
@@ -227,7 +234,9 @@ prepare() {
     "0314-LLD-COFF-Support-linking-directly-against-DLLs-in-Mi.patch" \
     "0315-LLD-COFF-Fix-up-missing-stdcall-decorations-in-MinGW.patch" \
     "0316-LLD-COFF-Avoid-thread-exhaustion-on-32-bit-Windows-h.patch" \
-    "0317-LLD-COFF-Make-export-all-symbols-work-as-intended-fo.patch"
+    "0317-LLD-COFF-Make-export-all-symbols-work-as-intended-fo.patch" \
+    "0318-LLD-MinGW-Accept-joined-format-for-stack.patch" \
+    "0319-LLD-MinGW-Support-both-opt-value-and-opt-value-for-m.patch"
 
   cd "${srcdir}/libcxx"
   apply_patch_with_msg \

--- a/mingw-w64-clang/README-patches.md
+++ b/mingw-w64-clang/README-patches.md
@@ -28,6 +28,7 @@ Legend:
 - `"0104-link-pthread-with-mingw.patch"` :grey_exclamation:
 - `"0105-Dont-mark-emutls-variables-as-DSO-local.patch"` :arrow_down_small:
 - `"0106-Rename-a-template-parameter-that-conflicted-with-a-c.patch"` :arrow_down_small:
+- `"0107-clang-MinGW-Let-the-last-of-mconsole-mwindows-have-e.patch"` :arrow_down_small:
 - `"0201-Provide-a-SEH-specific-__gcc_personality_seh0.patch"` :arrow_down_small:
 - `"0301-fix-including-the-personality-function-for-dwarf.patch"` :arrow_down_small:
 - `"0302-ignore-no-undefined-flag.patch"` :arrow_up_small:
@@ -44,6 +45,8 @@ Legend:
 - `"0315-LLD-COFF-Fix-up-missing-stdcall-decorations-in-MinGW.patch"` :arrow_down_small:
 - `"0316-LLD-COFF-Avoid-thread-exhaustion-on-32-bit-Windows-h.patch"` :arrow_down_small:
 - `"0317-LLD-COFF-Make-export-all-symbols-work-as-intended-fo.patch"` :arrow_down_small:
+- `"0318-LLD-MinGW-Accept-joined-format-for-stack.patch"` :arrow_down_small:
+- `"0319-LLD-MinGW-Support-both-opt-value-and-opt-value-for-m.patch"` :arrow_down_small:
 - `"0401-libcxx-fs.patch"` :arrow_down_small:
 - `"0402-make-the-visibility-attributes-consistent-for-__narr.patch"` :arrow_down_small:
 - `"0601-libunwind-Install-the-DLL-when-doing-ninja-install.patch"` :arrow_down_small:

--- a/mingw-w64-clang/README-patches.md
+++ b/mingw-w64-clang/README-patches.md
@@ -49,6 +49,7 @@ Legend:
 - `"0319-LLD-MinGW-Support-both-opt-value-and-opt-value-for-m.patch"` :arrow_down_small:
 - `"0401-libcxx-fs.patch"` :arrow_down_small:
 - `"0402-make-the-visibility-attributes-consistent-for-__narr.patch"` :arrow_down_small:
+- `"0403-HACK-for-clang32-changing-time_t.patch"` :x::grey_exclamation:
 - `"0601-libunwind-Install-the-DLL-when-doing-ninja-install.patch"` :arrow_down_small:
 - `"0710-backport-05b3716.patch"` :arrow_down_small:
 - `"0901-cast-to-make-gcc-happy.patch"` :grey_exclamation:

--- a/mingw-w64-clang/README-patches.md
+++ b/mingw-w64-clang/README-patches.md
@@ -23,6 +23,7 @@ Legend:
 - `"0017-X86-Teach-X86FloatingPoint-s-handleCall-to-only-eras.patch"` :arrow_down_small:
 - `"0018-llvm-rc-Allow-dashes-as-part-of-resource-name-strings.patch"` :arrow_down_small:
 - `"0019-MinGW-Mark-a-number-of-library-functions-unavailable.patch"` :arrow_down_small:
+- `"0020-llvm-rc-Allow-specifying-language-with-a-leading-0x-.patch"` :arrow_down_small:
 - `"0101-Disable-fPIC-errors.patch"` :x:
 - `"0103-Use-posix-style-path-separators-with-MinGW.patch"` :x::x::x: - this one is really imporant
 - `"0104-link-pthread-with-mingw.patch"` :grey_exclamation:


### PR DESCRIPTION
- Removed switch for using `MSYS Makefiles` generator instead of `Ninja`.  Now that clang32 linking is more reliable this shouldn't be necessary anymore.
- backport patches to allow `--stack` and `--image-base` to work with = as well as space between them and their value
- backport patch to allow a later `-mconsole` to override `-mwindows`, for https://github.com/msys2/MINGW-packages/pull/9201#issuecomment-890403294
- backport patch to allow `0x` prefix to language ID on `llvm-rc` and `llvm-windres` command line, for #9253
- cleaned up cmake arg variables.  There were several, that were not entirely clear how they were used.  Now, there are 
  - `common_cmake_args` are args common to all cmake invocations,
  - `platform_config` are args specific to the main llvm build (generally platform-specific, hence the name), and
  - `libcxx_config` are args common to the libc++/libunwind shared and static builds.

**HACK** added to libc++ to export overloads for 32-bit time_t when building with 64-bit time_t on clang32.  This is required to allow both new binaries built with 64-bit time_t and old ones built with 32-bit time_t to use the same libc++.dll.  This situation happens when building clang itself, so build a shared libc++ first, and override PATH and LDFLAGS to get it used during the build.  This is a **temporary** workaround for the broken state of ABI that we are currently in.  Fixes #9285
