### PR TITLE
lerc: new package

### DIFF
--- a/mingw-w64-lerc/Lerc.pc.cmake
+++ b/mingw-w64-lerc/Lerc.pc.cmake
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+includedir=${prefix}/include
+libdir=${exec_prefix}/lib
+
+Name: Lerc
+Description: Limited Error Raster Compression
+Version: @PROJECT_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lLerc

--- a/mingw-w64-lerc/PKGBUILD
+++ b/mingw-w64-lerc/PKGBUILD
@@ -1,0 +1,57 @@
+# Maintainer: Miloš Komarčević <miloskomarcevic@aim.com>
+
+_realname=lerc
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=3.0
+pkgrel=1
+pkgdesc="Limited Error Raster Compression library (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+url="https://github.com/Esri/lerc"
+license=('Apache-2.0')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
+options=('strip' 'staticlibs')
+source=("${_realname}-${pkgver}.tar.gz"::"${url}/archive/v${pkgver}.tar.gz"
+        "Lerc.pc.cmake"
+        "cmake_config_pc.patch")
+sha256sums=('8c0148f5c22d823eff7b2c999b0781f8095e49a7d3195f13c68c5541dd5740a1'
+            'b40845346ab11c8e2782fc49b8540782ab8040c16cc8e872d9531a42ecb3c8ff'
+            'de3b5cdacf58e56515a05c7c6f9fc526386fbb73c125bc73584cc21847907ef7')
+
+prepare() {
+  cd "${srcdir}"/${_realname}-${pkgver}
+  cp "${srcdir}"/Lerc.pc.cmake "${srcdir}"/${_realname}-${pkgver}
+  patch -p1 -i "${srcdir}"/cmake_config_pc.patch
+}
+
+build() {
+  [[ -d "${srcdir}"/build-${MINGW_ARCH} ]] && rm -rf "${srcdir}"/build-${MINGW_ARCH}
+  mkdir -p "${srcdir}"/build-${MINGW_ARCH} && cd "${srcdir}"/build-${MINGW_ARCH}
+
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake \
+      -GNinja \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      "${extra_config[@]}" \
+      -DBUILD_SHARED_LIBS=ON \
+      ../${_realname}-${pkgver}
+
+  ${MINGW_PREFIX}/bin/cmake --build .
+}
+
+package() {
+  cd "${srcdir}"/build-${MINGW_ARCH}
+
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --build . --target install
+
+  install -Dm644 "${srcdir}"/${_realname}-${pkgver}/LICENSE "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+}

--- a/mingw-w64-lerc/cmake_config_pc.patch
+++ b/mingw-w64-lerc/cmake_config_pc.patch
@@ -1,0 +1,19 @@
+--- lerc-3.0/CMakeLists.txt.orig	2021-08-04 17:33:46.452271800 +0200
++++ lerc-3.0/CMakeLists.txt	2021-08-04 17:46:59.652129400 +0200
+@@ -1,5 +1,5 @@
+ cmake_minimum_required (VERSION 3.11)
+-project (Lerc)
++project (Lerc VERSION 3.0.0)
+ 
+ include(GNUInstallDirs)
+ 
+@@ -32,3 +32,9 @@
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+ )
++
++if(NOT MSVC AND NOT APPLE)
++    configure_file(Lerc.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/Lerc.pc @ONLY)
++    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Lerc.pc
++            DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
++endif()


### PR DESCRIPTION
Yet another codec for libtiff, gdal...

Note: Added pc file matches output library and project name w/ capital "L" (followed e.g. OpenEXR.pc, OpenImageIO.pc etc).