### PR TITLE
qt6-tools: remove conflict with qt5 (qt5-tools).

### DIFF
--- a/mingw-w64-qt6-tools/001-appending-qt6-to-remove-qt5-conflict.patch
+++ b/mingw-w64-qt6-tools/001-appending-qt6-to-remove-qt5-conflict.patch
@@ -1,0 +1,174 @@
+--- a/src/assistant/assistant/CMakeLists.txt.orig	2021-08-04 17:09:41.894341300 +0100
++++ b/src/assistant/assistant/CMakeLists.txt	2021-08-04 17:13:03.889754900 +0100
+@@ -196,3 +196,6 @@
+     doc/qtassistant.qdocconf
+ )
+ 
++set_target_properties(assistant PROPERTIES
++    OUTPUT_NAME "assistant-qt6"
++)
+--- a/src/assistant/qhelpgenerator/CMakeLists.txt.orig	2021-06-18 14:08:32.000000000 +0100
++++ b/src/assistant/qhelpgenerator/CMakeLists.txt	2021-08-05 18:59:06.924765600 +0100
+@@ -25,3 +25,7 @@
+ # QMAKE_TARGET_DESCRIPTION = "Qt Compressed Help File Generator"
+ # QTPLUGIN.platforms = "qminimal"
+ # QTPLUGIN.sqldrivers = "qsqlite"
++
++set_target_properties(${target_name} PROPERTIES
++    OUTPUT_NAME "qhelpgenerator-qt6"
++)
+--- a/src/designer/src/designer/CMakeLists.txt.orig	2021-08-04 17:12:19.505947800 +0100
++++ b/src/designer/src/designer/CMakeLists.txt	2021-08-04 17:12:57.080036300 +0100
+@@ -145,3 +145,7 @@
+ qt_internal_add_docs(designer
+     doc/qtdesigner.qdocconf
+ )
++
++set_target_properties(designer PROPERTIES
++    OUTPUT_NAME "designer-qt6"
++)
+--- a/src/distancefieldgenerator/CMakeLists.txt.orig	2021-06-18 14:08:32.000000000 +0100
++++ b/src/distancefieldgenerator/CMakeLists.txt	2021-08-05 18:53:06.007467400 +0100
+@@ -34,3 +34,6 @@
+     doc/qtdistancefieldgenerator.qdocconf
+ )
+ 
++set_target_properties(qdistancefieldgenerator PROPERTIES
++    OUTPUT_NAME "qdistancefieldgenerator-qt6"
++)
+--- a/src/linguist/lconvert/CMakeLists.txt.orig	2021-08-04 17:14:17.019363400 +0100
++++ b/src/linguist/lconvert/CMakeLists.txt	2021-08-04 17:15:17.616970400 +0100
+@@ -31,3 +31,7 @@
+ #### Keys ignored in scope 1:.:.:lconvert.pro:<TRUE>:
+ # QMAKE_TARGET_DESCRIPTION = "Qt Translation File Converter"
+ # _OPTION = "host_build"
++
++set_target_properties(${target_name} PROPERTIES
++    OUTPUT_NAME "lconvert-qt6"
++)
+--- a/src/linguist/linguist/CMakeLists.txt.orig	2021-08-04 17:15:45.171072400 +0100
++++ b/src/linguist/linguist/CMakeLists.txt	2021-08-04 17:16:20.222761500 +0100
+@@ -175,3 +175,6 @@
+     doc/qtlinguist.qdocconf
+ )
+ 
++set_target_properties(linguist PROPERTIES
++    OUTPUT_NAME "linguist-qt6"
++)
+--- a/src/linguist/lrelease/CMakeLists.txt.orig	2021-08-04 17:17:03.606629500 +0100
++++ b/src/linguist/lrelease/CMakeLists.txt	2021-08-04 17:17:17.835590000 +0100
+@@ -40,3 +40,7 @@
+ # _OPTION = "host_build"
+ # qmake.name = "QMAKE"
+ # qmake.value = "$$shell_path($$QMAKE_QMAKE)"
++
++set_target_properties(${target_name} PROPERTIES
++    OUTPUT_NAME "lrelease-qt6"
++)
+--- a/src/linguist/lupdate/CMakeLists.txt.orig	2021-08-05 18:07:44.905622700 +0100
++++ b/src/linguist/lupdate/CMakeLists.txt	2021-08-05 18:08:35.193541300 +0100
+@@ -107,3 +107,7 @@
+ 
+ #### Keys ignored in scope 9:.:.:lupdate.pro:MINGW:
+ # RC_FILE = "lupdate.rc"
++
++set_target_properties(${target_name} PROPERTIES
++    OUTPUT_NAME lupdate-qt6
++)
+--- a/src/pixeltool/CMakeLists.txt.orig	2021-08-05 18:49:22.424897100 +0100
++++ b/src/pixeltool/CMakeLists.txt	2021-08-05 18:49:53.379811400 +0100
+@@ -28,3 +28,7 @@
+         MACOSX_BUNDLE TRUE
+     )
+ endif()
++
++set_target_properties(pixeltool PROPERTIES
++    OUTPUT_NAME "pixeltool-qt6"
++)
+--- a/src/qdbus/qdbus/CMakeLists.txt.orig	2021-08-05 18:14:41.170192500 +0100
++++ b/src/qdbus/qdbus/CMakeLists.txt	2021-08-05 18:15:06.267751400 +0100
+@@ -20,3 +20,7 @@
+         WIN32_EXECUTABLE FALSE
+     )
+ endif()
++
++set_target_properties(qdbus PROPERTIES
++    OUTPUT_NAME "qdbus-qt6"
++)
+--- a/src/qdbus/qdbusviewer/CMakeLists.txt.orig	2021-06-18 14:08:32.000000000 +0100
++++ b/src/qdbus/qdbusviewer/CMakeLists.txt	2021-08-05 18:48:33.572638700 +0100
+@@ -61,3 +61,7 @@
+         QT_TARGET_RC_ICONS "${CMAKE_CURRENT_SOURCE_DIR}/images/qdbusviewer.ico"
+     )
+ endif()
++
++set_target_properties(qdbusviewer PROPERTIES
++    OUTPUT_NAME "qdbusviewer-qt6"
++)
+--- a/src/qdoc/CMakeLists.txt.orig	2021-06-18 14:08:32.000000000 +0100
++++ b/src/qdoc/CMakeLists.txt	2021-08-05 18:13:58.553751500 +0100
+@@ -131,3 +131,6 @@
+     doc/config/qdoc.qdocconf
+ )
+ 
++set_target_properties(${target_name} PROPERTIES
++    OUTPUT_NAME "qdoc-qt6"
++)
+--- a/src/qtattributionsscanner/CMakeLists.txt.orig	2021-06-18 14:08:32.000000000 +0100
++++ b/src/qtattributionsscanner/CMakeLists.txt	2021-08-05 18:12:42.208014000 +0100
+@@ -26,3 +26,7 @@
+ # QT_FOR_CONFIG = "tools-private"
+ # _OPTION = "host_build"
+ # _REQUIREMENTS = "qtConfig(qtattributionsscanner)"
++
++set_target_properties(${target_name} PROPERTIES
++    OUTPUT_NAME "qtattributionsscanner-qt6"
++)
+--- a/src/qtdiag/CMakeLists.txt.orig	2021-06-18 14:08:32.000000000 +0100
++++ b/src/qtdiag/CMakeLists.txt	2021-08-05 18:48:11.194866700 +0100
+@@ -5,7 +5,6 @@
+ #####################################################################
+ 
+ qt_internal_add_app(qtdiag
+-    INSTALL_VERSIONED_LINK
+     SOURCES
+         main.cpp
+         qtdiag.cpp qtdiag.h
+@@ -54,3 +53,7 @@
+     PUBLIC_LIBRARIES
+         Qt::Network
+ )
++
++set_target_properties(qtdiag PROPERTIES
++    OUTPUT_NAME "qtdiag-qt6"
++)
+--- a/src/qtpaths/CMakeLists.txt.orig	2021-06-18 14:08:32.000000000 +0100
++++ b/src/qtpaths/CMakeLists.txt	2021-08-05 18:55:27.015827500 +0100
+@@ -21,3 +21,7 @@
+         WIN32_EXECUTABLE FALSE
+     )
+ endif()
++
++set_target_properties(qtpaths PROPERTIES
++    OUTPUT_NAME "qtpaths-qt6"
++)
+--- a/src/qtplugininfo/CMakeLists.txt.orig	2021-06-18 14:08:32.000000000 +0100
++++ b/src/qtplugininfo/CMakeLists.txt	2021-08-05 18:54:12.132490900 +0100
+@@ -15,3 +15,7 @@
+ #### Keys ignored in scope 1:.:.:qtplugininfo.pro:<TRUE>:
+ # QT_FOR_CONFIG = "tools-private"
+ # _REQUIREMENTS = "qtConfig(qtplugininfo)"
++
++set_target_properties(qtplugininfo PROPERTIES
++    OUTPUT_NAME "qtplugininfo-qt6"
++)
+--- a/src/windeployqt/CMakeLists.txt.orig	2021-06-18 14:08:32.000000000 +0100
++++ b/src/windeployqt/CMakeLists.txt	2021-08-05 18:10:16.508229300 +0100
+@@ -43,3 +43,7 @@
+     DEFINES
+         QT_RELOCATABLE
+ )
++
++set_target_properties(${target_name} PROPERTIES
++    OUTPUT_NAME "windeployqt-qt6"
++)

--- a/mingw-w64-qt6-tools/PKGBUILD
+++ b/mingw-w64-qt6-tools/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 _qtver=6.1.2
 pkgver=${_qtver/-/}
-pkgrel=3
+pkgrel=4
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://www.qt.io'
@@ -13,8 +13,6 @@ license=(GPL3 LGPL3 FDL custom)
 pkgdesc='A cross-platform application and UI framework (Development Tools, QtHelp) (mingw-w64)'
 depends=("${MINGW_PACKAGE_PREFIX}-qt6-base"
          "${MINGW_PACKAGE_PREFIX}-clang")
-conflicts=("${MINGW_PACKAGE_PREFIX}-qt5"
-           "${MINGW_PACKAGE_PREFIX}-qt5-debug")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-clang-tools-extra"
@@ -22,8 +20,26 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-qt6-declarative")
 groups=(${MINGW_PACKAGE_PREFIX}-qt6)
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
-source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/$_qtver/submodules/$_pkgfn.tar.xz")
-sha256sums=('a0520097ac1f898381c4512fb55ba5aa187d8e4e06ed0dcd2cbe265cd037989b')
+source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/$_qtver/submodules/$_pkgfn.tar.xz"
+        001-appending-qt6-to-remove-qt5-conflict.patch)
+sha256sums=('a0520097ac1f898381c4512fb55ba5aa187d8e4e06ed0dcd2cbe265cd037989b'
+            '28f375f74775dda69c0a62a58081c9a336c628c5771e3b3c02ab03017cae12e0')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying ${_patch}"
+    patch -Nbp1 -i "${srcdir}/${_patch}"
+  done
+}
+
+prepare() {
+  cd $srcdir/${_pkgfn}
+
+  apply_patch_with_msg \
+    001-appending-qt6-to-remove-qt5-conflict.patch
+}
 
 build() {
   cd ${srcdir}
@@ -45,6 +61,9 @@ build() {
 
 package() {
   DESTDIR=${pkgdir} cmake --install build-${MSYSTEM}
+
+  # Restore qtdiag6
+  ln -s ${pkgdir}${MINGW_PREFIX}/bin/qtdiag-qt6 ${pkgdir}${MINGW_PREFIX}/bin/qtdiag6.exe
 
   install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_realname}
   install -Dm644 $_pkgfn/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_realname}


### PR DESCRIPTION
I haven't bump the pkgrel as the package is not uploaded yet to the stable repos.