### PR TITLE
qbittorrent: Update to 4.3.7

### DIFF
--- a/mingw-w64-qbittorrent/PKGBUILD
+++ b/mingw-w64-qbittorrent/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=qbittorrent
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-pkgver=4.3.6
+pkgver=4.3.7
 pkgrel=1
 pkgdesc="An advanced BitTorrent client programmed in C++, based on Qt toolkit and libtorrent-rasterbar (mingw-w64)"
 arch=('any')
@@ -19,7 +19,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-pkg-config")
 source=("https://downloads.sourceforge.net/sourceforge/qbittorrent/${_realname}-${pkgver}.tar.xz"{,.asc}
         001-PROCESS_CLASS_INFORMATION-require-win8.patch
         002-winconf-prepare-env-for-mingw.patch)
-sha256sums=('d3094fa799bb901b81df6e380974bf4e38602fe1a7bfb268013ddffa30a7b16f'
+sha256sums=('42cc7abaa8a0900d20705d467cfd86732796dd22cf15c98f13bde468059cdf32'
             'SKIP'
             'a89b2830259203734e30c02f40104bf2898ced576543a5b0edc559fe1884e0b4'
             '7c9fabb9cfc1b721803868be719daee448100ef97e8ba8fbd7b144e8af235bf3')


### PR DESCRIPTION
Trables to linking only with `clang32` [there](https://github.com/msys2/MINGW-packages/pull/9298/checks?check_run_id=3256506995#step:9:3153).
Can anyone fix this?