### PR TITLE
libglade: update for python3 support

### DIFF
--- a/mingw-w64-libglade/PKGBUILD
+++ b/mingw-w64-libglade/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libglade
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.6.4
-pkgrel=5
+pkgrel=6
 pkgdesc="Allows you to load glade interface files in a program at runtime (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -13,9 +13,10 @@ license=('LGPL')
 depends=("${MINGW_PACKAGE_PREFIX}-gtk2>=2.16.0"
          "${MINGW_PACKAGE_PREFIX}-libxml2>=2.7.3")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-gtk-doc"
+             "${MINGW_PACKAGE_PREFIX}-python"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
-optdepends=("${MINGW_PACKAGE_PREFIX}-python2: libglade-convert script")
+optdepends=("${MINGW_PACKAGE_PREFIX}-python: libglade-convert script")
 options=('staticlibs' 'strip')
 source=(https://download.gnome.org/sources/${_realname}/2.6/${_realname}-${pkgver}.tar.bz2
         libglade-2.0.1-nowarning.patch
@@ -40,7 +41,7 @@ build() {
   cp -r "${srcdir}/${_realname}-${pkgver}" "${srcdir}/build-${MINGW_CHOST}"
   cd "${srcdir}/build-${MINGW_CHOST}"
 
-  PYTHON=${MINGW_PREFIX}/bin/python2 \
+  PYTHON=${MINGW_PREFIX}/bin/python \
   ./configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
@@ -48,6 +49,8 @@ build() {
     --target=${MINGW_CHOST}
 
   make
+  2to3 --no-diffs -w libglade-convert
+  sed -i -e 's/^\t/        /g' libglade-convert
 }
 
 package() {


### PR DESCRIPTION
There's just one standalone python script, so just run 2to3 over it, and fix up mixed tabs and spaces indentation errors.

configure has an error about missing `GNOME_COMMON_INIT`, but it has that when gnome-common is installed too, so didn't add it to makedepends.