### PR TITLE
graphviz: fix for clang

### DIFF
--- a/mingw-w64-graphviz/014-gdiplus-no-explicit-libstdc++.patch
+++ b/mingw-w64-graphviz/014-gdiplus-no-explicit-libstdc++.patch
@@ -1,0 +1,11 @@
+--- graphviz-2.44.1/plugin/gdiplus/Makefile.am.orig	2021-08-06 12:14:15.347436800 -0700
++++ graphviz-2.44.1/plugin/gdiplus/Makefile.am	2021-08-06 12:14:48.025434500 -0700
+@@ -34,7 +34,7 @@
+ libgvplugin_gdiplus_la_LDFLAGS = -version-info @GVPLUGIN_VERSION_INFO@ -Wl,"$(PLATFORMSDKLIB)\libgdiplus.a"
+ nodist_libgvplugin_gdiplus_la_SOURCES = gdiplus*.h
+ libgvplugin_gdiplus_la_SOURCES = $(libgvplugin_gdiplus_C_la_SOURCES)
+-libgvplugin_gdiplus_la_LIBADD = -lgdi32 -lole32 -lstdc++ -luuid $(top_builddir)/lib/gvc/libgvc.la
++libgvplugin_gdiplus_la_LIBADD = -lgdi32 -lole32 -luuid $(top_builddir)/lib/gvc/libgvc.la
+ 
+ if WITH_WIN32
+ libgvplugin_gdiplus_la_LDFLAGS += -no-undefined -export-symbols $(top_srcdir)/plugin/gdiplus/gvplugin_gdiplus.def

--- a/mingw-w64-graphviz/015-cast-function-pointer-to-void-pointer.patch
+++ b/mingw-w64-graphviz/015-cast-function-pointer-to-void-pointer.patch
@@ -1,0 +1,11 @@
+--- graphviz-2.44.1/cmd/gvedit/csettings.cpp.orig	2021-08-06 12:37:52.173467700 -0700
++++ graphviz-2.44.1/cmd/gvedit/csettings.cpp	2021-08-06 12:38:22.430465000 -0700
+@@ -43,7 +43,7 @@
+     QString path;
+     MEMORY_BASIC_INFORMATION mbi;
+ 
+-    if (VirtualQuery (&findAttrFile, &mbi, sizeof(mbi)) == 0) {
++    if (VirtualQuery (reinterpret_cast<LPCVOID>(&findAttrFile), &mbi, sizeof(mbi)) == 0) {
+ 	errout << "failed to get handle for executable.\n";
+ 	return path;
+     }

--- a/mingw-w64-graphviz/016-makefile-dont-embed-build-system-path.patch
+++ b/mingw-w64-graphviz/016-makefile-dont-embed-build-system-path.patch
@@ -1,0 +1,12 @@
+--- graphviz-2.44.1/lib/gvpr/Makefile.am.orig	2021-08-06 15:59:16.907659300 -0700
++++ graphviz-2.44.1/lib/gvpr/Makefile.am	2021-08-06 16:03:07.152725300 -0700
+@@ -17,8 +17,7 @@
+ 	-I$(top_srcdir)/lib/common \
+ 	-I$(top_builddir)/lib/common \
+ 	-I$(top_srcdir)/lib/cgraph \
+-	-I$(top_srcdir)/lib/cdt \
+-	-DDFLT_GVPRPATH="\".$(PATH_SEPARATOR)$(pkgdatadir)/gvpr\""
++	-I$(top_srcdir)/lib/cdt
+ 
+ if WITH_WIN32
+ AM_CFLAGS = -DEXPORT_GVPR=1

--- a/mingw-w64-graphviz/PKGBUILD
+++ b/mingw-w64-graphviz/PKGBUILD
@@ -4,7 +4,7 @@ _realname=graphviz
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.44.1
-pkgrel=5
+pkgrel=6
 pkgdesc="Graph Visualization Software (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -34,12 +34,14 @@ makedepends=(#"${MINGW_PACKAGE_PREFIX}-ocaml" not tested yet need to build ocaml
              #"${MINGW_PACKAGE_PREFIX}-lua" problem with distinguishing between the two versions we have and links to the wrong version sigh
              "${MINGW_PACKAGE_PREFIX}-qt5"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
-             "${MINGW_PACKAGE_PREFIX}-python2"
-             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python"
              #"${MINGW_PACKAGE_PREFIX}-ruby" unable to find ruby's pkgconfig file looks for ruby.pc no ruby$(VERSION).pc as it is named now 
+             "${MINGW_PACKAGE_PREFIX}-swig"
              #"${MINGW_PACKAGE_PREFIX}-tcl" needs a path to tclsh.sh
              "${MINGW_PACKAGE_PREFIX}-zlib"
              "git")
+optdepends=("${MINGW_PACKAGE_PREFIX}-qt5: gvedit"
+            "${MINGW_PACKAGE_PREFIX}-python: for python modules")
 options=('strip')
 install=${_realname}-${MSYSTEM}.install
 source=(#${_realname}-${pkgver}::git+https://gitlab.com/graphviz/graphviz.git#tag=stable_release_${pkgver}
@@ -56,7 +58,10 @@ source=(#${_realname}-${pkgver}::git+https://gitlab.com/graphviz/graphviz.git#ta
         010-no-extern-time.patch
         011-strcasecmp-mingw.patch
         012-cast-error.patch
-        013-further-fixes.patch)
+        013-further-fixes.patch
+        014-gdiplus-no-explicit-libstdc++.patch
+        015-cast-function-pointer-to-void-pointer.patch
+        016-makefile-dont-embed-build-system-path.patch)
 sha256sums=('8e1b34763254935243ccdb83c6ce108f531876d7a5dfd443f255e6418b8ea313'
             'a64e23a55481ff36641466ef80607bcdc1bbf20f992804620f4a58b5b8c04f8d'
             'd1e7e4dc1b55463123e3ed8f999745bf06078766ee24071be8866ac75fe1309e'
@@ -70,7 +75,10 @@ sha256sums=('8e1b34763254935243ccdb83c6ce108f531876d7a5dfd443f255e6418b8ea313'
             '01387eb1c9544b9e8aeb66a6ec23777c5bb3e2770b1672d2596b2b3d550319fd'
             'f9a4aa81bf2f918cc608dc49852c57782b610c2e56fea7e43a53a7c5bd655e90'
             'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
-            '2cc48cd408a2949391e5e5232b107300978a82c31eaf54a35a4d87d3a503c643')
+            '2cc48cd408a2949391e5e5232b107300978a82c31eaf54a35a4d87d3a503c643'
+            '97a2655d52632b77700adeade13c9608e516676b5092fbc9786a0fcd557f6656'
+            'c6a52798aef381cea84d2e0299ae7ffdd992b0663eff3d903b3aa5e7c34964ca'
+            'a0b2fa94f5aa4042684525c0463b1e180fcd37fc5f1ca80265cd9e72b2d17225')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
@@ -87,6 +95,12 @@ prepare() {
   patch -p1 -i ${srcdir}/011-strcasecmp-mingw.patch
   patch -p1 -i ${srcdir}/012-cast-error.patch
   patch -Np1 -i ${srcdir}/013-further-fixes.patch
+  patch -Np1 -i ${srcdir}/014-gdiplus-no-explicit-libstdc++.patch
+  patch -Np1 -i ${srcdir}/015-cast-function-pointer-to-void-pointer.patch
+  # This is a hack to work around an error in ucrt64.  The proper solution
+  # would be to use mingw-w64-pathtools to construct the default path relative
+  # to the exe.
+  patch -Np1 -i ${srcdir}/016-makefile-dont-embed-build-system-path.patch
 
   ./autogen.sh NOCONFIG
 }
@@ -133,4 +147,11 @@ package() {
   cd ${srcdir}/build-${MINGW_CHOST}
 
   make DESTDIR=${pkgdir} install
+  # WTF happened here?
+  local _winprefix="$(cygpath -m ${MINGW_PREFIX})"
+  local _broken_path="${pkgdir}${_winprefix}"
+  if [ -d "${_broken_path}" ]; then
+    cp -Rf "${_broken_path}"/* "${pkgdir}${MINGW_PREFIX}"
+    rm -rf "${pkgdir}${_winprefix%%/*}"
+  fi
 }


### PR DESCRIPTION
Depends on #9291

Fixes #9253 (inasmuch as a discussion can be fixed).

NOTE: This contains a patch to remove defining the default include search path for `gvpr`.  The old behavior wound up embedding an absolute Windows path in the binary, and doing so in a broken way that the compiler thought the backslashes were trying to escape characters!  With that define missing, the source defines it to `"."`, so it will by default only search the current directory for includes.  This would wind up matching what it did before, because the other default path entry was gobbledygook.  The *correct* fix would be to pull in mingw-w64-pathtools, and construct the default path entry relative to the exe.  I've already spent more time on graphviz than I was planning to, so I'll leave that for a future effort.