### PR TITLE
openldap: disable building slapd on clang.

### DIFF
--- a/mingw-w64-openldap/PKGBUILD
+++ b/mingw-w64-openldap/PKGBUILD
@@ -4,7 +4,7 @@ _realname=openldap
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.4.57
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 pkgdesc="OpenLDAP Software is an open source implementation of the Lightweight Directory Access Protocol (only client) (mingw-w64)"
@@ -55,6 +55,8 @@ build() {
     --enable-modules=yes \
     --enable-hdb=no \
     --enable-bdb=no \
+    $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] && \
+      echo "--disable-slapd" || true ) \
     CC=${MINGW_PREFIX}/bin/gcc
 
   sed -i "s/#define socklen_t int/\/*#define socklen_t int*\//" include/portable.h


### PR DESCRIPTION
Depends on #9291

slapd has an archaic, byantine linking method that llvm does not
support.  Rather than trying to untangle that, just disable slapd on the
assumption that most consumers of the package only really care about the
library, and maybe the commandline tools, not the server.  #9299 