### PR TITLE
libgnomecanvas: autoreconf for clang

### DIFF
--- a/mingw-w64-libgnomecanvas/PKGBUILD
+++ b/mingw-w64-libgnomecanvas/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libgnomecanvas
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.30.3
-pkgrel=3
+pkgrel=4
 pkgdesc="The GNOME canvas library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -13,6 +13,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gtk2"
          "${MINGW_PACKAGE_PREFIX}-libart_lgpl"
          "${MINGW_PACKAGE_PREFIX}-libglade")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-gtk-doc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "intltool")
 url='https://developer.gnome.org/libgnomecanvas/stable/GnomeCanvas.html'
@@ -22,6 +23,8 @@ sha256sums=('a8ca85e734ab03ecf1fba7d99e01ae2541d0df539c69a7da9414cde928c116da')
 
 prepare() {
   cd $srcdir/${_realname}-${pkgver}
+  # autoreconf to get libtool files with clang support
+  autoreconf -fiv
 }
 
 build() {


### PR DESCRIPTION
This was built for clang64 after libglade was available, but was missing DLLs.  Autoreconf to fix.

This is another old GTK2 library that no packages in the repo depend on, so may be a candidate for removal.  But, as long as it's here, it may as well build properly.