### PR TITLE
Add package "GNU Octave"

### DIFF
--- a/mingw-w64-octave/0001-binary-install-location.patch
+++ b/mingw-w64-octave/0001-binary-install-location.patch
@@ -1,0 +1,45 @@
+# HG changeset patch
+# User Markus Mützel <markus.muetzel@gmx.de>
+# Date 1628329289 -7200
+#      Sat Aug 07 11:41:29 2021 +0200
+# Branch stable
+# Node ID 5a2de6e9d0f66361abfee17823030cd56fe51ef3
+# Parent  116dbaba5a74d79892b8f7d97d0d28a8a0686a7d
+Install all binaries in bin directory.
+
+If these binaries are installed in the archlib directory, it looks like they
+cannot find the libraries that are installed in the bin directory. Install
+them in the bin directory as well.
+
+diff -r 116dbaba5a74 -r 5a2de6e9d0f6 build-aux/subst-config-vals.in.sh
+--- a/build-aux/subst-config-vals.in.sh	Sat Jul 31 16:07:45 2021 +0200
++++ b/build-aux/subst-config-vals.in.sh	Sat Aug 07 11:41:29 2021 +0200
+@@ -250,7 +250,7 @@
+   -e "s|%NO_EDIT_WARNING%|DO NOT EDIT!  Generated automatically by subst-config-vals.|" \
+   -e "s|%NO_OCT_FILE_STRIP%|${NO_OCT_FILE_STRIP}|" \
+   -e "s|%OCTAVE_API_VERSION%|\"${api_version}\"|" \
+-  -e "s|%OCTAVE_ARCHLIBDIR%|\"${archlibdir}\"|" \
++  -e "s|%OCTAVE_ARCHLIBDIR%|\"${bindir}\"|" \
+   -e "s|%OCTAVE_BINDIR%|\"${bindir}\"|" \
+   -e "s|%OCTAVE_BINDIR%|\"${bindir}\"|" \
+   -e "s|%OCTAVE_CANONICAL_HOST_TYPE%|\"${canonical_host_type}\"|" \
+diff -r 116dbaba5a74 -r 5a2de6e9d0f6 src/module.mk
+--- a/src/module.mk	Sat Jul 31 16:07:45 2021 +0200
++++ b/src/module.mk	Sat Aug 07 11:41:29 2021 +0200
+@@ -43,14 +43,14 @@
+ OCTAVE_VERSION_LINKS += %reldir%/octave-cli-$(version)$(EXEEXT)
+ 
+ if AMCOND_BUILD_QT_GUI
+-  archlib_PROGRAMS += %reldir%/octave-gui
++  bin_PROGRAMS += %reldir%/octave-gui
+   OCTAVE_VERSION_LINKS += %reldir%/octave-gui-$(version)$(EXEEXT)
+ 
+   OCTAVE_INTERPRETER_TARGETS += %reldir%/octave-gui$(EXEEXT)
+ endif
+ 
+ if AMCOND_BUILD_QT_GUI
+-  archlib_PROGRAMS += %reldir%/octave-svgconvert
++  bin_PROGRAMS += %reldir%/octave-svgconvert
+   OCTAVE_INTERPRETER_TARGETS += %reldir%/octave-svgconvert$(EXEEXT)
+ endif
+ 

--- a/mingw-w64-octave/PKGBUILD
+++ b/mingw-w64-octave/PKGBUILD
@@ -1,0 +1,74 @@
+_realname=octave
+pkgbase=mingw-w64-${_realname}
+pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
+pkgver=6.3.0
+pkgrel=1
+pkgdesc="GNU Octave: Interactive programming environment for numerical computations."
+url="https://www.octave.org"
+license=('GPL3')
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libgfortran"
+         "${MINGW_PACKAGE_PREFIX}-lapack"
+         "${MINGW_PACKAGE_PREFIX}-arpack"
+         "${MINGW_PACKAGE_PREFIX}-curl"
+         "${MINGW_PACKAGE_PREFIX}-fftw"
+         "${MINGW_PACKAGE_PREFIX}-ghostscript"
+         "${MINGW_PACKAGE_PREFIX}-gl2ps"
+         "${MINGW_PACKAGE_PREFIX}-glpk"
+         "${MINGW_PACKAGE_PREFIX}-graphicsmagick"
+         "${MINGW_PACKAGE_PREFIX}-hdf5"
+         "${MINGW_PACKAGE_PREFIX}-libsndfile"
+         "${MINGW_PACKAGE_PREFIX}-qhull"
+         "${MINGW_PACKAGE_PREFIX}-suitesparse"
+         "${MINGW_PACKAGE_PREFIX}-sundials"
+         "${MINGW_PACKAGE_PREFIX}-qrupdate"
+         "${MINGW_PACKAGE_PREFIX}-qscintilla"
+         "${MINGW_PACKAGE_PREFIX}-qt5")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc-fortran"
+             "${MINGW_PACKAGE_PREFIX}-gnuplot"
+             "${MINGW_PACKAGE_PREFIX}-fltk"
+             "${MINGW_PACKAGE_PREFIX}-portaudio")
+optdepends=('texinfo: for help-support in Octave'
+            "${MINGW_PACKAGE_PREFIX}-fltk: alternative plotting and dialogs"
+            "${MINGW_PACKAGE_PREFIX}-gnuplot: alternative plotting"
+            "${MINGW_PACKAGE_PREFIX}-portaudio: audio support")
+source=(https://ftp.gnu.org/gnu/octave/octave-$pkgver.tar.gz
+        "0001-binary-install-location.patch")
+sha512sums=('9582d7a7d84beef2a22d3dfaf45aee4778fc0dfc0ec1831c5bcb863dd0062e996e5b7aaaa40519c23d2c730c3408e26745b9dbf73db5127ebae22da0b2532788'
+            'dc714dbf04dc551cd996b4b1b9bf7816100103fa8c3d7d3633171d36f5d8eb20464fa0cfeee387c882a1fcb81e824d11e68b7f99f2f6b56d1f2ef6b220c8acab')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+  patch -p1 -i "${srcdir}/0001-binary-install-location.patch"
+}
+
+build() {
+  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
+  mkdir -p build-${MINGW_CHOST}
+  cd build-${MINGW_CHOST}
+
+  ../${_realname}-${pkgver}/configure \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --build=${MINGW_CHOST} \
+    --prefix=${MINGW_PREFIX} \
+    --libexecdir=${MINGW_PREFIX}/lib \
+    --sbindir=${MINGW_PREFIX}/bin \
+    --enable-shared --disable-static \
+    --with-blas="-lblas" \
+    ac_cv_search_tputs=-ltermcap \
+    JAVA_HOME="" \
+    CC=${MINGW_PREFIX}/bin/gcc \
+    CXX=${MINGW_PREFIX}/bin/g++ \
+    F77=${MINGW_PREFIX}/bin/gfortran
+
+  make all
+}
+
+package() {
+  make -C "build-${MINGW_CHOST}" DESTDIR="${pkgdir}" install
+
+  # override default command for running "makeinfo" in init file
+  echo 'makeinfo_program ("cd %MSYSTEM_PREFIX%/../usr/bin && perl makeinfo");' >> "${pkgdir}/${MINGW_PREFIX}/share/octave/site/m/startup/octaverc"
+}

--- a/mingw-w64-octave/PKGBUILD
+++ b/mingw-w64-octave/PKGBUILD
@@ -7,7 +7,7 @@ pkgdesc="GNU Octave: Interactive programming environment for numerical computati
 url="https://www.octave.org"
 license=('GPL3')
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libgfortran"
          "${MINGW_PACKAGE_PREFIX}-lapack"
          "${MINGW_PACKAGE_PREFIX}-arpack"


### PR DESCRIPTION
This is the first time, I try to get a package added to MSYS2. So, I hope this is ok. Any feedback is very welcome.

GNU Octave is a high-level interpreted language, primarily intended for numerical computations. It provides capabilities for the numerical solution of linear and nonlinear problems, and for performing other numerical experiments. It also provides extensive graphics capabilities for data visualization and manipulation. Octave is normally used through its interactive command line interface, but it can also be used to write non-interactive programs. The Octave language is quite similar to Matlab so that most programs are easily portable.

See: https://www.octave.org

I hope that it is eligible to be included in MSYS2.

I tried to keep the `PKGBUILD` file in line with the ones I found for other packages.

I tried building it for mingw64 locally and it seems to be working for me. I haven't tried the other architectures.
