### PR TITLE
mruby: build with -j1

### DIFF
--- a/mingw-w64-mruby/PKGBUILD
+++ b/mingw-w64-mruby/PKGBUILD
@@ -4,7 +4,7 @@ _realname=mruby
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.1.2
-pkgrel=1
+pkgrel=2
 pkgdesc="mruby is the lightweight implementation of the Ruby language (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -20,7 +20,7 @@ build() {
   cp -rf "${srcdir}/${_realname}-${pkgver}" ${srcdir}/build-${MINGW_CHOST}
   cd ${srcdir}/build-${MINGW_CHOST}
 
-  ./minirake
+  ./minirake -v -j1
 }
 
 package() {


### PR DESCRIPTION
Trying to work around a non-consistent error
```
  C:/_/M/mingw-w64-mruby/src/build-x86_64-w64-mingw32/mrbgems/mruby-compiler/core/y.tab.c:70:9: warning: missing terminating '"' character [-Winvalid-pp-token]
  #line 7 "mrbgems/mruby-compiler/core/parse.y
          ^
  C:/_/M/mingw-w64-mruby/src/build-x86_64-w64-mingw32/mrbgems/mruby-compiler/core/y.tab.c:70:9: error: invalid filename for #line directive
```

Also passed `-v` so there's more build output to see what's going on.

Note I pushed and reverted a pkgrel=2 to test in autobuild, so this may need to wait for another autobuild run to clean up -2 results.