### PR TITLE
python-tzdata: add package

### DIFF
--- a/mingw-w64-python-tzdata/PKGBUILD
+++ b/mingw-w64-python-tzdata/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: Christoph Reiter <reiter.christoph@gmail.com>
+
+_realname=tzdata
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=2021.1
+pkgrel=1
+pkgdesc=" Python package wrapping the IANA time zone database (mingw-w64)"
+arch=('any')
+url='https://github.com/python/tzdata'
+license=('Apache-2.0')
+depends=("${MINGW_PACKAGE_PREFIX}-python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('e19c7351f887522a1ac739d21041e592ddde6dd1b764fdefa8f7b2b3551d3d38')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  echo "from setuptools import setup; setup()" > setup.py
+}
+
+build() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  ${MINGW_PREFIX}/bin/python setup.py build
+}
+
+package() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+}


### PR DESCRIPTION
Required by the zoneinfo module in the stdlib, see https://github.com/msys2-contrib/cpython-mingw/issues/32