### PR TITLE
smpeg{,2}: libtool hack

### DIFF
--- a/mingw-w64-smpeg/PKGBUILD
+++ b/mingw-w64-smpeg/PKGBUILD
@@ -4,7 +4,7 @@ _realname=smpeg
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.4.5
-pkgrel=2
+pkgrel=3
 pkgdesc="SDL MPEG Player Library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -17,13 +17,16 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-SDL")
 options=('staticlibs' 'strip')
 source=("${_realname}::svn://svn.icculus.org/smpeg/tags/release_${pkgver//./_}"
-        no-undefined.patch)
+        no-undefined.patch
+        clang-libtool-tweak.patch)
 sha256sums=('SKIP'
-            'd9c89f26abb9c5c6341876a613dac805e3c4ded590c99668104fcc453a4f412d')
+            'd9c89f26abb9c5c6341876a613dac805e3c4ded590c99668104fcc453a4f412d'
+            '0193f2f287b72372ec066f1057309e3ebf036c45473fecffea7cd7005ed23bc5')
 
 prepare() {
   cd "${srcdir}"/${_realname}
   patch -p1 -i ${srcdir}/no-undefined.patch
+  patch -p1 -i ${srcdir}/clang-libtool-tweak.patch
   ./autogen.sh
 }
 
@@ -33,6 +36,7 @@ build() {
   cd "${srcdir}/build-${MINGW_CHOST}/"
 
   CFLAGS+=" -Wno-error=narrowing"
+  lt_cv_deplibs_check_method=pass_all \
   ../${_realname}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \

--- a/mingw-w64-smpeg/clang-libtool-tweak.patch
+++ b/mingw-w64-smpeg/clang-libtool-tweak.patch
@@ -1,0 +1,11 @@
+--- smpeg/acinclude/libtool.m4~	2021-08-08 11:05:04.022380400 -0700
++++ smpeg/acinclude/libtool.m4	2021-08-08 14:24:36.675795800 -0700
+@@ -6419,7 +6419,7 @@
+   for p in `eval "$output_verbose_link_cmd"`; do
+     case $p in
+ 
+-    -L* | -R* | -l*)
++    -L* | -R* | -l* | */libclang_rt.*.a)
+        # Some compilers place space between "-{L,R}" and the path.
+        # Remove the space.
+        if test $p = "-L" ||

--- a/mingw-w64-smpeg2/PKGBUILD
+++ b/mingw-w64-smpeg2/PKGBUILD
@@ -4,7 +4,7 @@ _realname=smpeg2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.0.0
-pkgrel=5
+pkgrel=6
 pkgdesc="SDL2 MPEG Player Library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -13,11 +13,14 @@ license=("LGPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "subversion")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-SDL2")
 options=('staticlibs' 'strip')
-source=("${_realname}::svn://svn.icculus.org/smpeg/tags/release_${pkgver//./_}")
-sha256sums=('SKIP')
+source=("${_realname}::svn://svn.icculus.org/smpeg/tags/release_${pkgver//./_}"
+        "clang-libtool-tweak.patch")
+sha256sums=('SKIP'
+            '0193f2f287b72372ec066f1057309e3ebf036c45473fecffea7cd7005ed23bc5')
 
 prepare() {
   cd "${srcdir}"/${_realname}
+  patch -p1 -i "${srcdir}/clang-libtool-tweak.patch"
   ./autogen.sh
 }
 
@@ -27,6 +30,7 @@ build() {
   cd "${srcdir}/build-${MINGW_CHOST}/"
 
   CFLAGS+=" -Wno-error=narrowing"
+  lt_cv_deplibs_check_method=pass_all \
   ../${_realname}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \

--- a/mingw-w64-smpeg2/clang-libtool-tweak.patch
+++ b/mingw-w64-smpeg2/clang-libtool-tweak.patch
@@ -1,0 +1,11 @@
+--- smpeg/acinclude/libtool.m4~	2021-08-08 11:05:04.022380400 -0700
++++ smpeg/acinclude/libtool.m4	2021-08-08 14:24:36.675795800 -0700
+@@ -6419,7 +6419,7 @@
+   for p in `eval "$output_verbose_link_cmd"`; do
+     case $p in
+ 
+-    -L* | -R* | -l*)
++    -L* | -R* | -l* | */libclang_rt.*.a)
+        # Some compilers place space between "-{L,R}" and the path.
+        # Remove the space.
+        if test $p = "-L" ||


### PR DESCRIPTION
These do not work when updating their bundled libtool files with the newer ones from MSYS2-packages, so instead apply the minimal patch to let it use compiler-rt, and use `lt_cv_deplibs_check_method=pass_all` to work around the other clang issues with libtool.  Fixes #9317

Note CI fails building the source package, apparently because the sources are from svn.
