### PR TITLE
coin: fix clang build

### DIFF
--- a/mingw-w64-coin/PKGBUILD
+++ b/mingw-w64-coin/PKGBUILD
@@ -4,7 +4,7 @@ _realname=coin
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=4.0.0
-pkgrel=4
+pkgrel=5
 pkgdesc="A high-level 3D graphics toolkit, fully compatible with SGI Open Inventor 2.1 (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -24,13 +24,16 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-openal")
 options=('!strip' 'staticlibs' '!buildflags')
 source=("coin-Coin-${pkgver}.tar.gz::https://github.com/coin3d/coin/archive/Coin-${pkgver}.tar.gz"
-        'coin-4.0.0-use-cpack-off.patch')
+        'coin-4.0.0-use-cpack-off.patch'
+        'coin-4.0.0-exported-struct-needs-tag.patch')
 sha256sums=('b00d2a8e9d962397cf9bf0d9baa81bcecfbd16eef675a98c792f5cf49eb6e805'
-            '247e3f9d8df8cca311019bfb00c550b6f91cc895763e0e1f9384e97a7b64a612')
+            '247e3f9d8df8cca311019bfb00c550b6f91cc895763e0e1f9384e97a7b64a612'
+            '21e10f16d195fbcdafb975f220a5bf6f91246ee4ce48602fb91e9905060f5c84')
 
 prepare() {
   cd "${srcdir}/coin-Coin-${pkgver}"
   patch -p1 -i "${srcdir}/coin-4.0.0-use-cpack-off.patch"
+  patch -p1 -i "${srcdir}/coin-4.0.0-exported-struct-needs-tag.patch"
 }
 
 build() {

--- a/mingw-w64-coin/coin-4.0.0-exported-struct-needs-tag.patch
+++ b/mingw-w64-coin/coin-4.0.0-exported-struct-needs-tag.patch
@@ -1,0 +1,20 @@
+--- coin-Coin-4.0.0/include/Inventor/elements/SoGLLazyElement.h.orig	2021-08-08 22:36:30.241161500 -0700
++++ coin-Coin-4.0.0/include/Inventor/elements/SoGLLazyElement.h	2021-08-08 22:37:21.225549600 -0700
+@@ -74,7 +74,7 @@
+ 
+   void reset(SoState* state, uint32_t bitmask) const;
+ 
+-  typedef struct COIN_DLL_API {
++  struct COIN_DLL_API GLState {
+     uint32_t cachebitmask;
+     uint32_t diffuse;
+     SbColor ambient;
+@@ -97,7 +97,7 @@
+     SbUniqueId diffusenodeid;
+     SbUniqueId transpnodeid;
+     uint32_t reserved[4];
+-  } GLState;
++  };
+ 
+   virtual void setDiffuseElt(SoNode*,  int32_t numcolors,
+                              const SbColor * colors, SoColorPacker * packer);


### PR DESCRIPTION
It was using a C-style idiom of `typedef struct {...} foo;` in C++, which clang
didn't like because they were also trying to export that struct.  Use
C++ style `struct foo {...};` instead.