### PR TITLE
wxWidgets: Enable wxMediaCtrl and

### DIFF
--- a/mingw-w64-wxWidgets/006-wxWidgets-3.0-Fix-c-11-narrowing-error.patch
+++ b/mingw-w64-wxWidgets/006-wxWidgets-3.0-Fix-c-11-narrowing-error.patch
@@ -1,0 +1,30 @@
+From def588367a4bf83bbd5f9a69d2574b35945a905f Mon Sep 17 00:00:00 2001
+From: Maarten Bent <MaartenBent@users.noreply.github.com>
+Date: Thu, 16 Aug 2018 20:08:56 +0200
+Subject: Fix c++11-narrowing error when using clang on Windows
+
+Case value 0xfffffd9f results in the following error:
+error: case value evaluates to 4294966687, which cannot be narrowed to type
+'DISPID' (aka 'long') [-Wc++11-narrowing]
+
+(cherry picked from commit fd81223a2f878757158b5266c362da71d43abee5)
+---
+ src/msw/mediactrl_am.cpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/msw/mediactrl_am.cpp b/src/msw/mediactrl_am.cpp
+index f5b9ed4a61..674da36e46 100644
+--- a/src/msw/mediactrl_am.cpp
++++ b/src/msw/mediactrl_am.cpp
+@@ -2179,7 +2179,9 @@ void wxAMMediaBackend::Move(int WXUNUSED(x), int WXUNUSED(y),
+ //---------------------------------------------------------------------------
+ void wxAMMediaEvtHandler::OnActiveX(wxActiveXEvent& event)
+ {
+-    switch(event.GetDispatchId())
++    // cast to unsigned long to fix narrowing error with case 0xfffffd9f
++    // when using clang
++    switch (static_cast<unsigned long>(event.GetDispatchId()))
+     {
+ #ifndef __WXWINCE__
+     case 0x00000001: // statechange in IActiveMovie
+-- 

--- a/mingw-w64-wxWidgets/PKGBUILD
+++ b/mingw-w64-wxWidgets/PKGBUILD
@@ -7,10 +7,10 @@
 _realname=wxWidgets
 _wx_basever=3.0
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-provides=("${MINGW_PACKAGE_PREFIX}-wxmsw${_wx_basever}")
+provides=("${MINGW_PACKAGE_PREFIX}-wxmsw${_wx_basever}" "${MINGW_PACKAGE_PREFIX}-wxconfig")
 pkgbase=mingw-w64-${_realname}
 pkgver=${_wx_basever}.5.1
-pkgrel=5
+pkgrel=6
 pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -32,12 +32,14 @@ source=(https://github.com/wxWidgets/wxWidgets/releases/download/v${pkgver}/wxWi
         "001-wxWidgets-3.0.2-relocate-prefix-in-bin-wx-config.patch"
         "002-wxWidgets-3.0.2-relax-abi-compatibility-gcc.patch"
         "003-wxWidgets-3.0.2-fix-access-sample.patch"
-        "004-wxWidgets-3.0-clang-windows-link.patch")
+        "004-wxWidgets-3.0-clang-windows-link.patch"
+        "006-wxWidgets-3.0-Fix-c-11-narrowing-error.patch")
 sha256sums=('440f6e73cf5afb2cbf9af10cec8da6cdd3d3998d527598a53db87099524ac807'
             '7c3b8f6ba275a448a5e82d64c4914acd5aefb8bbb952389688f3e7167a787c56'
             '3138f7b84bf988892f62167afc6fa640ac154b629b243d86413f7c811e508713'
             'b8684dca94b288a023a8a3d55ad56bce87570576ead71670a237d909ff1c3625'
-            'b8b49b1df4a7c53d72c7c117606ac9dc44589da474ca58f0806b107469f33dcb')
+            'b8b49b1df4a7c53d72c7c117606ac9dc44589da474ca58f0806b107469f33dcb'
+            '043c24cab804b972a3fa710182b19f15aff8479a34e031694c17108a64e27d3f')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
@@ -50,6 +52,7 @@ prepare() {
   # and
   # https://github.com/wxWidgets/wxWidgets/commit/e8a7bae0a750bcb5d8aadc45629d2c9adaf2106c
   patch -p1 -i "${srcdir}"/004-wxWidgets-3.0-clang-windows-link.patch
+  patch -p1 -i "${srcdir}"/006-wxWidgets-3.0-Fix-c-11-narrowing-error.patch
 }
 
 #check() {
@@ -77,7 +80,7 @@ build() {
     --enable-unicode \
     --enable-graphics_ctx \
     --enable-accessibility \
-    --disable-mediactrl \
+    --enable-mediactrl \
     --disable-monolithic \
     --disable-mslu \
     --disable-precomp-headers \
@@ -109,7 +112,7 @@ build() {
     --enable-unicode \
     --enable-graphics_ctx \
     --enable-accessibility \
-    --disable-mediactrl \
+    --enable-mediactrl \
     --disable-monolithic \
     --disable-mslu \
     --disable-precomp-headers \
@@ -134,6 +137,9 @@ package() {
   make DESTDIR="${pkgdir}" install
 
   mv ${pkgdir}${MINGW_PREFIX}/lib/*.dll ${pkgdir}${MINGW_PREFIX}/bin
+
+  # create wx-config copy with version file suffix
+  cp ${pkgdir}${MINGW_PREFIX}/bin/wx-config{,-${_wx_basever}}
 
   # Add missing file with exe extension (Likely bug in wxWidgets makefile)
   cp -f ${pkgdir}${MINGW_PREFIX}/bin/wxrc-${_wx_basever} ${pkgdir}${MINGW_PREFIX}/bin/wxrc-${_wx_basever}.exe


### PR DESCRIPTION
add provides wxconfig and wx-config-3.0 script.

Edit: As a side effect the patch I added likely fixes clang32 build; but, since that code was in wxMediaCtrl it likely does not matter.