### PR TITLE
ccache: resurrect patch fixing clang build

### DIFF
--- a/mingw-w64-ccache/010-ucrt.patch
+++ b/mingw-w64-ccache/010-ucrt.patch
@@ -1,0 +1,12 @@
+--- ccache-4.3/src/system.hpp.orig	2021-08-09 16:52:40.484492600 -0700
++++ ccache-4.3/src/system.hpp	2021-08-09 16:54:42.078489200 -0700
+@@ -190,7 +190,9 @@
+ #  define PATH_DELIM ":"
+ #endif
+ 
++#ifndef environ
+ DLLIMPORT extern char** environ;
++#endif
+ 
+ // Work with silly DOS binary open.
+ #ifndef O_BINARY

--- a/mingw-w64-ccache/011-clang-iostream-unittest.patch
+++ b/mingw-w64-ccache/011-clang-iostream-unittest.patch
@@ -1,0 +1,10 @@
+--- ccache-4.3/unittest/test_Win32Util.cpp.orig	2021-05-09 11:39:46.000000000 -0700
++++ ccache-4.3/unittest/test_Win32Util.cpp	2021-08-09 17:04:31.546775500 -0700
+@@ -20,6 +20,7 @@
+ #include "TestUtil.hpp"
+ 
+ #include "third_party/doctest.h"
++#include <iostream>
+ 
+ TEST_SUITE_BEGIN("Win32Util");
+ 

--- a/mingw-w64-ccache/PKGBUILD
+++ b/mingw-w64-ccache/PKGBUILD
@@ -5,7 +5,7 @@ _realname=ccache
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.3
-pkgrel=1
+pkgrel=2
 pkgdesc="Compiler cache that speeds up recompilation by caching previous compilations (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -19,13 +19,19 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-zstd")
 options=('staticlibs' 'strip')
-source=("https://github.com/ccache/ccache/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.xz"{,.asc})
+source=("https://github.com/ccache/ccache/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.xz"{,.asc}
+        "010-ucrt.patch"
+        "011-clang-iostream-unittest.patch")
 sha256sums=('504a0f2184465c306826f035b4bc00bae7500308d6af4abbfb50e33a694989b4'
-            'SKIP')
+            'SKIP'
+            '3a636958680039609b36bb1ef6da1bb77c3ce6e87106f0216e5cf581a36cf485'
+            'bc30f90068a713477f7cc73e2d74da25aea9b092f631c56a15d942e8e5e22438')
 validpgpkeys=('5A939A71A46792CF57866A51996DDA075594ADB8') # Joel Rosdahl <joel@rosdahl.net>
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
+  patch -Nbp1 -i "${srcdir}/010-ucrt.patch"
+  patch -Nbp1 -i "${srcdir}/011-clang-iostream-unittest.patch"
 
 }
 


### PR DESCRIPTION
A patch from #8603 was lost in #9290.  Resurrect it.

Also include <iostream> in test_Win32Util to fix a clang error linking unittest.exe (#8603 mentioned disabling the tests, but #9290 was nice enough to hook them up, so fix them instead).