### PR TITLE
pyside2-qt5 and shiboken2-qt5: Install egg-info

### DIFF
--- a/mingw-w64-pyside2-qt5/PKGBUILD
+++ b/mingw-w64-pyside2-qt5/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}-qt5
 pkgname=(${MINGW_PACKAGE_PREFIX}-${_realname}-qt5)
 pkgdesc="Provides LGPL Qt5 bindings for Python and related tools for binding generation (mingw-w64)"
 pkgver=5.15.2
-pkgrel=5
+pkgrel=6
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 url="https://doc.qt.io/qtforpython-5/"
@@ -19,13 +19,14 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-shiboken2-qt5=${pkgver}")
 options=('staticlibs' 'strip')
-source=(https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-${pkgver}-src/pyside-setup-opensource-src-${pkgver}.tar.xz
+_pkgfqn=pyside-setup-opensource-src-$pkgver
+source=(https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-${pkgver}-src/${_pkgfqn}.tar.xz
         001-pyside.patch)
 sha256sums=('b306504b0b8037079a8eab772ee774b9e877a2d84bab2dbefbe4fa6f83941418'
             'a941b8e289b9825be086b83c326ded18b64ac78c094e013fd1e7fa56d976b3c1')
 
 prepare() {
-  cd "${srcdir}"/pyside-setup-opensource-src-${pkgver}
+  cd "${srcdir}"/$_pkgfqn
   patch -p1 -i ${srcdir}/001-pyside.patch
 }
 
@@ -41,14 +42,14 @@ build() {
     -DBUILD_TESTS=OFF \
     ${_conf} \
     -DPYTHON_EXECUTABLE=${MINGW_PREFIX}/bin/python.exe \
-    ../pyside-setup-opensource-src-${pkgver}/sources/pyside2
+    ../${_pkgfqn}/sources/pyside2
 
   MSYS2_ARG_CONV_EXCL="--include-paths=;--typesystem-paths=" \
   ${MINGW_PREFIX}/bin/cmake.exe --build ./
 }
 
 package() {
-  cd ${srcdir}/build-${MINGW_CHOST}
+  cd "${srcdir}"/build-${MINGW_CHOST}
   DESTDIR=${pkgdir} ${MINGW_PREFIX}/bin/cmake.exe --build ./ --target install
 
   local _PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
@@ -59,4 +60,10 @@ package() {
   for _f in "${pkgdir}${MINGW_PREFIX}"/lib/cmake/PySide2-${pkgver}/*.cmake; do
     sed -e "s|${MINGW_PREFIX}|\$\{_IMPORT_PREFIX\}|g" -i "${_f}"
   done
+
+  # Install egg-info
+  cd "${srcdir}"/$_pkgfqn
+  ${MINGW_PREFIX}/bin/python setup.py egg_info --build-type=pyside2
+  _pythonpath=`${MINGW_PREFIX}/bin/python -c "from sysconfig import get_path; print(get_path('platlib'))"`
+  cp -r pyside2.egg-info "$pkgdir"/$(cygpath ${_pythonpath})
 }

--- a/mingw-w64-shiboken2-qt5/PKGBUILD
+++ b/mingw-w64-shiboken2-qt5/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}-qt5
 pkgname=(${MINGW_PACKAGE_PREFIX}-${_realname}-qt5)
 pkgdesc="CPython bindings generator for C++ libraries (mingw-w64)"
 pkgver=5.15.2
-pkgrel=5
+pkgrel=6
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://doc.qt.io/qtforpython-5/"
@@ -16,10 +16,12 @@ depends=("${MINGW_PACKAGE_PREFIX}-clang"
          "${MINGW_PACKAGE_PREFIX}-qt5")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-libxml2"
              "${MINGW_PACKAGE_PREFIX}-libxslt")
 options=('staticlibs' 'strip')
-source=(https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-${pkgver}-src/pyside-setup-opensource-src-${pkgver}.tar.xz
+_pkgfqn=pyside-setup-opensource-src-$pkgver
+source=(https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-${pkgver}-src/${_pkgfqn}.tar.xz
         001-shiboken.patch
         002-cmake-relative-paths.patch
         003-llvm-paths.patch)
@@ -29,7 +31,7 @@ sha256sums=('b306504b0b8037079a8eab772ee774b9e877a2d84bab2dbefbe4fa6f83941418'
             '0cb712ba34d9951b0c29dc3b71f9c82882064331bd54a4cf0f4c792837932497')
 
 prepare() {
-  cd ${srcdir}/pyside-setup-opensource-src-${pkgver}
+  cd "${srcdir}"/$_pkgfqn
   patch -p1 -i ${srcdir}/001-shiboken.patch
   patch -p1 -i ${srcdir}/002-cmake-relative-paths.patch
   patch -p1 -i ${srcdir}/003-llvm-paths.patch
@@ -49,7 +51,7 @@ build() {
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_TESTS=OFF \
     -DPYTHON_EXECUTABLE=${MINGW_PREFIX}/bin/python.exe \
-    ../pyside-setup-opensource-src-${pkgver}/sources/shiboken2
+    ../${_pkgfqn}/sources/shiboken2
 
   ${MINGW_PREFIX}/bin/cmake.exe --build ./
 }
@@ -66,4 +68,10 @@ package() {
   for _f in "${pkgdir}${MINGW_PREFIX}"/lib/cmake/Shiboken2-${pkgver}/*.cmake; do
     sed -e "s|${MINGW_PREFIX}|\$\{_IMPORT_PREFIX\}|g" -i "${_f}"
   done
+
+  # Install egg-info
+  cd "${srcdir}"/$_pkgfqn
+  ${MINGW_PREFIX}/bin/python setup.py egg_info --build-type=shiboken2
+  _pythonpath=`${MINGW_PREFIX}/bin/python -c "from sysconfig import get_path; print(get_path('platlib'))"`
+  cp -r shiboken2.egg-info "$pkgdir"/$(cygpath ${_pythonpath})
 }


### PR DESCRIPTION
Based on archlinux implementation.
Fixes #8021
Closes #4507