### PR TITLE
mpxout.w (mpx_cleandir): Fix _findfirst handle truncation on x86_64

### DIFF
--- a/mingw-w64-texlive-bin/0004-mpxout-x64.patch
+++ b/mingw-w64-texlive-bin/0004-mpxout-x64.patch
@@ -1,0 +1,14 @@
+Index: mpxout.w
+===================================================================
+diff --git a/texk/web2c/mplibdir/mpxout.w b/texk/web2c/mplibdir/mpxout.w
+--- a/texk/web2c/mplibdir/mpxout.w	(revision 58686)
++++ b/texk/web2c/mplibdir/mpxout.w	(working copy)
+@@ -3869,7 +3869,7 @@
+   char *wrk, *p;
+ #ifdef _WIN32
+   struct _finddata_t c_file;
+-  long hFile;
++  intptr_t hFile;
+ #else
+   struct dirent *entry;
+   DIR *d;

--- a/mingw-w64-texlive-bin/PKGBUILD
+++ b/mingw-w64-texlive-bin/PKGBUILD
@@ -65,6 +65,7 @@ prepare() {
     cd "$srcdir/texlive-source"
     apply_patch_with_msg 0001-Remove-DLUASOCKET_INET_PTON-from-Makefile.patch
     apply_patch_with_msg 0003-runscript-always-quote-args.patch
+    apply_patch_with_msg 0004-mpxout-x64.patch
     # t4ht expects to be un /usr/share/texmf/bin/t4ht (FS#27251)
     sed -i s/SELFAUTOPARENT/TEXMFROOT/ texk/tex4htk/t4ht.c
     autoreconf -fiv

--- a/mingw-w64-texlive-bin/PKGBUILD
+++ b/mingw-w64-texlive-bin/PKGBUILD
@@ -4,7 +4,7 @@ pkgbase=mingw-w64-texlive-bin
 pkgname=("${MINGW_PACKAGE_PREFIX}-texlive-bin" "${MINGW_PACKAGE_PREFIX}-libsynctex")
 pkgver=2021.20210424
 pkgdesc="TeX Live binaries (mingw-w64)"
-pkgrel=6
+pkgrel=7
 license=('GPL')
 arch=('any')
 url='https://tug.org/texlive/'
@@ -44,11 +44,13 @@ source=(
     "texlive-source-${_commit}.tar.gz::https://github.com/Tex-Live/texlive-source/archive/${_commit}.tar.gz"
     "0001-Remove-DLUASOCKET_INET_PTON-from-Makefile.patch"
     "0002-fix-lauchers-mingw32.patch"
-    "0003-runscript-always-quote-args.patch")
+    "0003-runscript-always-quote-args.patch"
+    "0004-mpxout-x64.patch")
 sha256sums=('f17bdf0fba64790151b39bcb1d6d4f0ee97da6bcf15b4c9282ff9056bb8da5ee'
             '86ef2a99b2f0caed42777419837d9b539af1d1c8a101701e539e5467bb88662e'
             'decff8db61302c2a1760cfd4b42aaf0e25fcb7d2b9621cea3ec3f4c2557976a1'
-            '0339fe12b2ec7537ce62d064fffd43e8ee02280ffac3dd012f07dc17a713acdc')
+            '0339fe12b2ec7537ce62d064fffd43e8ee02280ffac3dd012f07dc17a713acdc'
+            '574f04b9f41b579b283b6d86c1b1ee07f97f45b01a12d77953db5eca6572d3da')
 
 apply_patch_with_msg() {
   for _patch in "$@"


### PR DESCRIPTION
Package `mingw-w64-x86_64-texlive-bin`.

When MetaPost calls `mpx_cleandir` to delete temporary auxiliary files (e.g., from running TeX to format a label), it segfaults in `RtlEnterCriticalSection`. This doesn't affect the 32-bit binaries shipped by the TexLive project.

At line 3872 of "mpxout.w" (see <svn://tug.org/texlive/trunk/Build/source/texk/web2c/mplibdir/mpxout.w@58686>), `hFile` is declared as `long`. The handle returned by `_findfirst` is stored there and truncated. Then it is sign-extended and passed to `_findnext`. There is a segfault when it is first dereferenced, which happens in `RtlEnterCriticalSection`.

Presumably this could be fixed by changing `long` to `intptr_t` there, as in this PR, but this is **untested**, as I haven't managed to rebuild the package here.

To reproduce the crash, in a MINGW64 bash shell:

```
pacman -S --needed mingw-w64-x86_64-texlive-metapost
## Uncomment next line *IF* ok to delete and recreate a subdirectory ".temp-build" in the current directory
#rm -rf .temp-build && mkdir .temp-build && cd .temp-build && >temp.mp echo 'beginfig(0); label(btex $x$ etex, (0,0)); endfig; end;' && gdb --quiet -ex run -ex "i r rcx" -ex quit --args mpost temp.mp && cd ..
````

Example output:

```
warning: mingw-w64-x86_64-texlive-metapost-2021.20210519-2 is up to date -- skipping
 there is nothing to do

Reading symbols from mpost...
Starting program: C:\msys64\mingw64\bin\mpost.exe temp.mp
[New Thread 23188.0x3c6c]
[New Thread 23188.0x1970]
[New Thread 23188.0x51e8]
This is MetaPost, version 2.00 (TeX Live 2021/Built by MSYS2 project) (kpathsea version 6.3.3)
(c:/msys64/mingw64/share/texmf-dist/metapost/base/mpost.mp
(c:/msys64/mingw64/share/texmf-dist/metapost/base/plain.mp
Preloading the plain mem file, version 1.005) ) (./temp.mp
Thread 1 received signal SIGSEGV, Segmentation fault.
0x00007ff80157faad in ntdll!RtlEnterCriticalSection () from C:\WINDOWS\SYSTEM32\ntdll.dll
rcx            0x614a8f38          1632276280
```
(The `rcx` value may be positive or negative, depending on bit 31 of the handle returned by `_findfirst`.)
