### PR TITLE
qt6-base: enable dependencies for clang.

### DIFF
--- a/mingw-w64-qt6-base/PKGBUILD
+++ b/mingw-w64-qt6-base/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 _qtver=6.1.2
 pkgver=${_qtver/-/}
-pkgrel=3
+pkgrel=4
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://www.qt.io'
@@ -23,14 +23,14 @@ depends=("${MINGW_PACKAGE_PREFIX}-double-conversion"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 optdepends=("${MINGW_PACKAGE_PREFIX}-libmariadbclient"
             $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-firebird2" )
-            $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-postgresql" ))
+            "${MINGW_PACKAGE_PREFIX}-postgresql")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-xmlstarlet"
              "${MINGW_PACKAGE_PREFIX}-libmariadbclient"
              $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-firebird2" )
-             $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-postgresql" ))
+             "${MINGW_PACKAGE_PREFIX}-postgresql" )
 groups=(${MINGW_PACKAGE_PREFIX}-qt6)
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/$_qtver/submodules/$_pkgfn.tar.xz"
@@ -85,8 +85,6 @@ build() {
     -DQT_FEATURE_fontconfig=ON \
     -DQT_FEATURE_pkg_config=ON \
     -DQT_FEATURE_sql_ibase=OFF \
-    $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] && echo \
-      "-DQT_FEATURE_sql_psql=OFF" || true ) \
     ../${_pkgfn}
 
   export PATH=$PWD/bin:$PATH


### PR DESCRIPTION
As long as it needed rebuilding anyway, get rid of some of the clang workarounds for missing packages which are now present.