### PR TITLE
Fix some qt5 packages

### DIFF
--- a/mingw-w64-qt5-pkgs/PKGBUILD
+++ b/mingw-w64-qt5-pkgs/PKGBUILD
@@ -18,7 +18,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-base"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-script")
 _ver_base=5.15.2
 pkgver=${_ver_base//-/}
-pkgrel=3
+pkgrel=4
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 pkgdesc="A cross-platform application and UI framework (mingw-w64)"
@@ -246,6 +246,7 @@ package_qt5-base() {
            "${MINGW_PACKAGE_PREFIX}-icu"
            "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
            "${MINGW_PACKAGE_PREFIX}-libpng"
+           "${MINGW_PACKAGE_PREFIX}-md4c"
            "${MINGW_PACKAGE_PREFIX}-openssl"
            "${MINGW_PACKAGE_PREFIX}-pcre2"
            "${MINGW_PACKAGE_PREFIX}-sqlite3"

--- a/mingw-w64-qt5-tools/PKGBUILD
+++ b/mingw-w64-qt5-tools/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _qtver=5.15.2
 pkgver=${_qtver/-/}
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 pkgdesc="A cross-platform application and UI framework (Development Tools, QtHelp) (mingw-w64)"
@@ -74,9 +74,9 @@ package() {
 
   # Fix Makefiles
   local PREFIX_WIN=$(cygpath -am ${MINGW_PREFIX})
-  find "${srcdir}/build-${MSYSTEM}" -type f \( -name 'Makefile.Release' \) \
+  find "${srcdir}/build-${MSYSTEM}" -type f \( -name 'Makefile*' \) \
       -exec sed -i -e "s|${PREFIX_WIN:0:2}\$(INSTALL_ROOT|\$(INSTALL_ROOT|g" {} \;
-  find "${srcdir}/build-${MSYSTEM}" -type f \( -name 'Makefile.Release' \) \
+  find "${srcdir}/build-${MSYSTEM}" -type f \( -name 'Makefile*' \) \
       -exec sed -i -e "s|)${PREFIX_WIN:2}|)${MINGW_PREFIX}|g" {} \;
 
   make INSTALL_ROOT="${pkgdir}" install


### PR DESCRIPTION
- qt5-base: missed to add md4c as a dependency.
- qt5-tool: snot all the makefiles installation destinations were fixed.