### PR TITLE
qt-imageformats: Enable libmng plugin

### DIFF
--- a/mingw-w64-qt5-imageformats/0001-qmng-fix-build.patch
+++ b/mingw-w64-qt5-imageformats/0001-qmng-fix-build.patch
@@ -1,0 +1,127 @@
+--- a/src/plugins/imageformats/mng/qmnghandler.cpp
++++ b/src/plugins/imageformats/mng/qmnghandler.cpp
+@@ -43,7 +43,11 @@
+ #include "qvariant.h"
+ #include "qcolor.h"
+ 
++#ifdef _WIN32
++#define MNG_USE_DLL
++#else
+ #define MNG_USE_SO
++#endif
+ #include <libmng.h>
+ 
+ QT_BEGIN_NAMESPACE
+@@ -80,7 +84,7 @@
+     QMngHandler *q_ptr;
+ };
+ 
+-static mng_bool myerror(mng_handle /*hMNG*/,
++static mng_bool MNG_DECL myerror(mng_handle /*hMNG*/,
+     mng_int32   iErrorcode,
+     mng_int8    /*iSeverity*/,
+     mng_chunkid iChunkname,
+@@ -99,29 +103,29 @@
+     return MNG_TRUE;
+ }
+ 
+-static mng_ptr myalloc(mng_size_t iSize)
++static mng_ptr MNG_DECL myalloc(mng_size_t iSize)
+ {
+     return (mng_ptr)calloc(1, iSize);
+ }
+ 
+-static void myfree(mng_ptr pPtr, mng_size_t /*iSize*/)
++static void MNG_DECL MNG_DECL myfree(mng_ptr pPtr, mng_size_t /*iSize*/)
+ {
+     free(pPtr);
+ }
+ 
+-static mng_bool myopenstream(mng_handle)
++static mng_bool MNG_DECL myopenstream(mng_handle)
+ {
+     return MNG_TRUE;
+ }
+ 
+-static mng_bool myclosestream(mng_handle hMNG)
++static mng_bool MNG_DECL myclosestream(mng_handle hMNG)
+ {
+     QMngHandlerPrivate *pMydata = reinterpret_cast<QMngHandlerPrivate *>(mng_get_userdata(hMNG));
+     pMydata->haveReadAll = true;
+     return MNG_TRUE;
+ }
+ 
+-static mng_bool myreaddata(mng_handle hMNG,
++static mng_bool MNG_DECL myreaddata(mng_handle hMNG,
+                     mng_ptr    pBuf,
+                     mng_uint32 iSize,
+                     mng_uint32p pRead)
+@@ -130,7 +134,7 @@
+     return pMydata->readData(pBuf, iSize, pRead);
+ }
+ 
+-static mng_bool mywritedata(mng_handle hMNG,
++static mng_bool MNG_DECL mywritedata(mng_handle hMNG,
+                      mng_ptr pBuf,
+                      mng_uint32 iSize,
+                      mng_uint32p pWritten)
+@@ -139,7 +143,7 @@
+     return pMydata->writeData(pBuf, iSize, pWritten);
+ }
+ 
+-static mng_bool myprocessheader(mng_handle hMNG,
++static mng_bool MNG_DECL myprocessheader(mng_handle hMNG,
+                                 mng_uint32 iWidth,
+                                 mng_uint32 iHeight)
+ {
+@@ -147,14 +151,14 @@
+     return pMydata->processHeader(iWidth, iHeight);
+ }
+ 
+-static mng_ptr mygetcanvasline(mng_handle hMNG,
++static mng_ptr MNG_DECL mygetcanvasline(mng_handle hMNG,
+                                mng_uint32 iLinenr)
+ {
+     QMngHandlerPrivate *pMydata = reinterpret_cast<QMngHandlerPrivate *>(mng_get_userdata(hMNG));
+     return (mng_ptr)pMydata->image.scanLine(iLinenr);
+ }
+ 
+-static mng_bool myrefresh(mng_handle /*hMNG*/,
++static mng_bool MNG_DECL myrefresh(mng_handle /*hMNG*/,
+                           mng_uint32 /*iX*/,
+                           mng_uint32 /*iY*/,
+                           mng_uint32 /*iWidth*/,
+@@ -163,13 +167,13 @@
+     return MNG_TRUE;
+ }
+ 
+-static mng_uint32 mygettickcount(mng_handle hMNG)
++static mng_uint32 MNG_DECL mygettickcount(mng_handle hMNG)
+ {
+     QMngHandlerPrivate *pMydata = reinterpret_cast<QMngHandlerPrivate *>(mng_get_userdata(hMNG));
+     return pMydata->elapsed++;
+ }
+ 
+-static mng_bool mysettimer(mng_handle hMNG,
++static mng_bool MNG_DECL mysettimer(mng_handle hMNG,
+                            mng_uint32 iMsecs)
+ {
+     QMngHandlerPrivate *pMydata = reinterpret_cast<QMngHandlerPrivate *>(mng_get_userdata(hMNG));
+@@ -178,7 +182,7 @@
+     return MNG_TRUE;
+ }
+ 
+-static mng_bool myprocessterm(mng_handle hMNG,
++static mng_bool MNG_DECL myprocessterm(mng_handle hMNG,
+                         mng_uint8   iTermaction,
+                         mng_uint8   /*iIteraction*/,
+                         mng_uint32  /*iDelay*/,
+@@ -190,7 +194,7 @@
+     return MNG_TRUE;
+ }
+ 
+-static mng_bool mytrace(mng_handle,
++static mng_bool MNG_DECL mytrace(mng_handle,
+                         mng_int32   iFuncnr,
+                         mng_int32   iFuncseq,
+                         mng_pchar   zFuncname)

--- a/mingw-w64-qt5-imageformats/PKGBUILD
+++ b/mingw-w64-qt5-imageformats/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _qtver=5.15.2
 pkgver=${_qtver/-/}
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 pkgdesc="Plugins for additional image formats: TIFF, MNG, TGA, WBMP (mingw-w64)"
@@ -19,9 +19,15 @@ depends=("${MINGW_PACKAGE_PREFIX}-qt5-base"
 groups=("${MINGW_PACKAGE_PREFIX}-qt5")
 options=('!strip' 'staticlibs' 'ccache')
 _pkgfn="${_realname/5-/}-everywhere-src-${_qtver}"
-source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/$_qtver/submodules/$_pkgfn.tar.xz")
-sha256sums=('bf8285c7ce04284527ab823ddc7cf48a1bb79131db3a7127342167f4814253d7')
+source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/$_qtver/submodules/$_pkgfn.tar.xz"
+        "0001-qmng-fix-build.patch")
+sha256sums=('bf8285c7ce04284527ab823ddc7cf48a1bb79131db3a7127342167f4814253d7'
+            '727602791c21070a08c97c9423a4343e2a44d2f7ea48731b3720da50e4797ea5')
 
+prepare() {
+  cd "${srcdir}/${_pkgfn}"
+  patch -p1 -i "${srcdir}/0001-qmng-fix-build.patch"
+}
 
 build() {
   cd ${srcdir}
@@ -29,11 +35,10 @@ build() {
   mkdir -p build-${MSYSTEM}
   cd build-${MSYSTEM}
 
-  qmake ../${_pkgfn} -- \
-    -jasper \
-    -no-mng \
-    -system-webp \
-    -system-tiff
+  # https://github.com/msys2/MSYS2-packages/issues/2282
+  export MSYS2_ARG_CONV_EXCL='--foreign-types='
+
+  qmake ../${_pkgfn}
 
   make
 }

--- a/mingw-w64-qt6-imageformats/0001-qmng-fix-build.patch
+++ b/mingw-w64-qt6-imageformats/0001-qmng-fix-build.patch
@@ -1,0 +1,127 @@
+--- a/src/plugins/imageformats/mng/qmnghandler.cpp
++++ b/src/plugins/imageformats/mng/qmnghandler.cpp
+@@ -43,7 +43,11 @@
+ #include "qvariant.h"
+ #include "qcolor.h"
+ 
++#ifdef _WIN32
++#define MNG_USE_DLL
++#else
+ #define MNG_USE_SO
++#endif
+ #include <libmng.h>
+ 
+ QT_BEGIN_NAMESPACE
+@@ -80,7 +84,7 @@
+     QMngHandler *q_ptr;
+ };
+ 
+-static mng_bool myerror(mng_handle /*hMNG*/,
++static mng_bool MNG_DECL myerror(mng_handle /*hMNG*/,
+     mng_int32   iErrorcode,
+     mng_int8    /*iSeverity*/,
+     mng_chunkid iChunkname,
+@@ -99,29 +103,29 @@
+     return MNG_TRUE;
+ }
+ 
+-static mng_ptr myalloc(mng_size_t iSize)
++static mng_ptr MNG_DECL myalloc(mng_size_t iSize)
+ {
+     return (mng_ptr)calloc(1, iSize);
+ }
+ 
+-static void myfree(mng_ptr pPtr, mng_size_t /*iSize*/)
++static void MNG_DECL MNG_DECL myfree(mng_ptr pPtr, mng_size_t /*iSize*/)
+ {
+     free(pPtr);
+ }
+ 
+-static mng_bool myopenstream(mng_handle)
++static mng_bool MNG_DECL myopenstream(mng_handle)
+ {
+     return MNG_TRUE;
+ }
+ 
+-static mng_bool myclosestream(mng_handle hMNG)
++static mng_bool MNG_DECL myclosestream(mng_handle hMNG)
+ {
+     QMngHandlerPrivate *pMydata = reinterpret_cast<QMngHandlerPrivate *>(mng_get_userdata(hMNG));
+     pMydata->haveReadAll = true;
+     return MNG_TRUE;
+ }
+ 
+-static mng_bool myreaddata(mng_handle hMNG,
++static mng_bool MNG_DECL myreaddata(mng_handle hMNG,
+                     mng_ptr    pBuf,
+                     mng_uint32 iSize,
+                     mng_uint32p pRead)
+@@ -130,7 +134,7 @@
+     return pMydata->readData(pBuf, iSize, pRead);
+ }
+ 
+-static mng_bool mywritedata(mng_handle hMNG,
++static mng_bool MNG_DECL mywritedata(mng_handle hMNG,
+                      mng_ptr pBuf,
+                      mng_uint32 iSize,
+                      mng_uint32p pWritten)
+@@ -139,7 +143,7 @@
+     return pMydata->writeData(pBuf, iSize, pWritten);
+ }
+ 
+-static mng_bool myprocessheader(mng_handle hMNG,
++static mng_bool MNG_DECL myprocessheader(mng_handle hMNG,
+                                 mng_uint32 iWidth,
+                                 mng_uint32 iHeight)
+ {
+@@ -147,14 +151,14 @@
+     return pMydata->processHeader(iWidth, iHeight);
+ }
+ 
+-static mng_ptr mygetcanvasline(mng_handle hMNG,
++static mng_ptr MNG_DECL mygetcanvasline(mng_handle hMNG,
+                                mng_uint32 iLinenr)
+ {
+     QMngHandlerPrivate *pMydata = reinterpret_cast<QMngHandlerPrivate *>(mng_get_userdata(hMNG));
+     return (mng_ptr)pMydata->image.scanLine(iLinenr);
+ }
+ 
+-static mng_bool myrefresh(mng_handle /*hMNG*/,
++static mng_bool MNG_DECL myrefresh(mng_handle /*hMNG*/,
+                           mng_uint32 /*iX*/,
+                           mng_uint32 /*iY*/,
+                           mng_uint32 /*iWidth*/,
+@@ -163,13 +167,13 @@
+     return MNG_TRUE;
+ }
+ 
+-static mng_uint32 mygettickcount(mng_handle hMNG)
++static mng_uint32 MNG_DECL mygettickcount(mng_handle hMNG)
+ {
+     QMngHandlerPrivate *pMydata = reinterpret_cast<QMngHandlerPrivate *>(mng_get_userdata(hMNG));
+     return pMydata->elapsed++;
+ }
+ 
+-static mng_bool mysettimer(mng_handle hMNG,
++static mng_bool MNG_DECL mysettimer(mng_handle hMNG,
+                            mng_uint32 iMsecs)
+ {
+     QMngHandlerPrivate *pMydata = reinterpret_cast<QMngHandlerPrivate *>(mng_get_userdata(hMNG));
+@@ -178,7 +182,7 @@
+     return MNG_TRUE;
+ }
+ 
+-static mng_bool myprocessterm(mng_handle hMNG,
++static mng_bool MNG_DECL myprocessterm(mng_handle hMNG,
+                         mng_uint8   iTermaction,
+                         mng_uint8   /*iIteraction*/,
+                         mng_uint32  /*iDelay*/,
+@@ -190,7 +194,7 @@
+     return MNG_TRUE;
+ }
+ 
+-static mng_bool mytrace(mng_handle,
++static mng_bool MNG_DECL mytrace(mng_handle,
+                         mng_int32   iFuncnr,
+                         mng_int32   iFuncseq,
+                         mng_pchar   zFuncname)

--- a/mingw-w64-qt6-imageformats/PKGBUILD
+++ b/mingw-w64-qt6-imageformats/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 _qtver=6.1.2
 pkgver=${_qtver/-/}
-pkgrel=1
+pkgrel=2
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://www.qt.io'
@@ -13,13 +13,21 @@ license=(GPL3 LGPL3 FDL custom)
 pkgdesc='Plugins for additional image formats: TIFF, MNG, TGA, WBMP (mingw-w64)'
 depends=("${MINGW_PACKAGE_PREFIX}-qt6-base"
          "${MINGW_PACKAGE_PREFIX}-jasper"
+         "${MINGW_PACKAGE_PREFIX}-libmng"
          "${MINGW_PACKAGE_PREFIX}-libwebp")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 groups=(${MINGW_PACKAGE_PREFIX}-qt6)
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
-source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/$_qtver/submodules/$_pkgfn.tar.xz")
-sha256sums=('958600ed4acf6cc5f74b77e97b4913f3127ccbaadcfce6c1942e775f9f4345a2')
+source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/$_qtver/submodules/$_pkgfn.tar.xz"
+        "0001-qmng-fix-build.patch")
+sha256sums=('958600ed4acf6cc5f74b77e97b4913f3127ccbaadcfce6c1942e775f9f4345a2'
+            '727602791c21070a08c97c9423a4343e2a44d2f7ea48731b3720da50e4797ea5')
+
+prepare() {
+  cd "${srcdir}/${_pkgfn}"
+  patch -p1 -i "${srcdir}/0001-qmng-fix-build.patch"
+}
 
 build() {
   cd ${srcdir}


### PR DESCRIPTION
Wondering why it was disabled for both qt5 and qt6. @MehdiChinoune Review please.