### PR TITLE
octave: Fix mkoctfile with default settings. Fix pkgconfig files.

### DIFF
--- a/mingw-w64-octave/PKGBUILD
+++ b/mingw-w64-octave/PKGBUILD
@@ -2,7 +2,7 @@ _realname=octave
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=6.3.0
-pkgrel=1
+pkgrel=2
 pkgdesc="GNU Octave: Interactive programming environment for numerical computations."
 url="https://www.octave.org"
 license=('GPL3')
@@ -56,12 +56,10 @@ build() {
     --libexecdir=${MINGW_PREFIX}/lib \
     --sbindir=${MINGW_PREFIX}/bin \
     --enable-shared --disable-static \
+    --enable-relocate-all \
     --with-blas="-lblas" \
     ac_cv_search_tputs=-ltermcap \
-    JAVA_HOME="" \
-    CC=${MINGW_PREFIX}/bin/gcc \
-    CXX=${MINGW_PREFIX}/bin/g++ \
-    F77=${MINGW_PREFIX}/bin/gfortran
+    JAVA_HOME=""
 
   make all
 }
@@ -70,5 +68,11 @@ package() {
   make -C "build-${MINGW_CHOST}" DESTDIR="${pkgdir}" install
 
   # override default command for running "makeinfo" in init file
-  echo 'makeinfo_program ("cd %MSYSTEM_PREFIX%/../usr/bin && perl makeinfo");' >> "${pkgdir}/${MINGW_PREFIX}/share/octave/site/m/startup/octaverc"
+  echo 'makeinfo_program (sprintf ("%s && cd %s/../usr/bin && perl makeinfo", OCTAVE_HOME ()(1:2), OCTAVE_HOME ()));' >> "${pkgdir}/${MINGW_PREFIX}/share/octave/site/m/startup/octaverc"
+
+  # Remove full path reference
+  local _PREFIX_WIN="$(cygpath -wm ${MINGW_PREFIX})"
+  for pcfile in "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/*.pc; do
+    sed -s "s|${_PREFIX_WIN}|${MINGW_PREFIX}|g" -i "${pcfile}"
+  done
 }


### PR DESCRIPTION
Like @gharveymn noticed in #9310, `mkoctfile` doesn't work with default settings and `octave.pc` leaks paths from the build system.

The proposed change fixes both issues for me.

Is it ok to configure with `CXX=${MINGW_CHOST}-g++` and Co. when building Octave? Most other PKGBUILD rules seem to use `CXX=${MINGW_PREFIX}/bin/g++`. Is there a particular reason for that?