### PR TITLE
fritzing: use new split qt5 packages

### DIFF
--- a/mingw-w64-fritzing/PKGBUILD
+++ b/mingw-w64-fritzing/PKGBUILD
@@ -4,7 +4,7 @@ _realname=fritzing
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.9.6
-pkgrel=2
+pkgrel=3
 pkgdesc="Electronic Design Automation software with a low entry barrier, suited for the needs of makers and hobbyists (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -12,8 +12,11 @@ url="https://github.com/fritzing/fritzing-app"
 license=('GPL' 'CCPL:cc-by-sa-3.0')
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
 makedepends=("${MINGW_PACKAGE_PREFIX}-boost"
+             "${MINGW_PACKAGE_PREFIX}-qt5-tools"
              'git')
-depends=("${MINGW_PACKAGE_PREFIX}-qt5"
+depends=("${MINGW_PACKAGE_PREFIX}-qt5-base"
+         "${MINGW_PACKAGE_PREFIX}-qt5-serialport"
+         "${MINGW_PACKAGE_PREFIX}-qt5-svg"
          "${MINGW_PACKAGE_PREFIX}-libgit2"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 # Fritzing updates its parts repo online from the master branch, so the latest


### PR DESCRIPTION
Figured I'd help out on the effort on the one package I know about building.  This uses `lrelease` as part of building, which seems to be part of qt5-tools, so added that as a makedepends.