### PR TITLE
qt5-quickcontrols2: Fix Installation destination

### DIFF
--- a/mingw-w64-qt5-quickcontrols2/PKGBUILD
+++ b/mingw-w64-qt5-quickcontrols2/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _qtver=5.15.2
 pkgver=${_qtver/-/}
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 pkgdesc="Next generation user interface controls based on Qt Quick (mingw-w64)"
@@ -49,7 +49,8 @@ package() {
   find "${srcdir}/build-${MSYSTEM}" -type f \( -name 'Makefile.Release' \) \
       -exec sed -i -e "s|)${PREFIX_WIN:2}|)${MINGW_PREFIX}|g" {} \;
 
-  make INSTALL_ROOT="${pkgdir}" install
+  local PKGDIR=$(cygpath -am ${pkgdir})
+  make INSTALL_ROOT="${PKGDIR}" install
 
   install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_realname}
   install -Dm644 $srcdir/build-${MSYSTEM}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_realname}


### PR DESCRIPTION
Somehow, most of the files were not installed in the right destination.