### PR TITLE
Update Qt5 reverse dependencies (4/n)

### DIFF
--- a/mingw-w64-opencascade/PKGBUILD
+++ b/mingw-w64-opencascade/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=7.5.2
 _pkgver2=V${pkgver//./_}
-pkgrel=1
+pkgrel=2
 pkgdesc='Open CASCADE Technology, 3D modeling & numerical simulation (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -18,7 +18,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-tk"
          "${MINGW_PACKAGE_PREFIX}-ffmpeg"
          "${MINGW_PACKAGE_PREFIX}-rapidjson"
          "${MINGW_PACKAGE_PREFIX}-openvr")
-makedepends=("${MINGW_PACKAGE_PREFIX}-qt5"
+makedepends=("${MINGW_PACKAGE_PREFIX}-qt5-base"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-doxygen")
@@ -28,7 +28,7 @@ source=("opencascade-${pkgver}.tgz::https://git.dev.opencascade.org/gitweb/?p=oc
         "0001-fix-compile-openvr.patch")
 sha256sums=('1A32D2B0D6D3C236163CB45139221FB198F0F3CDAD56606C5B1C9A2A8869B3AC'
          'SKIP')
-		 
+
 prepare() {
   cd "${srcdir}"/occt-${_pkgver2}
   patch -p1 -i "${srcdir}"/0001-fix-compile-openvr.patch
@@ -86,12 +86,12 @@ build() {
     -D3RDPARTY_TBBMALLOC_DLL="${MINGW_PREFIX}/bin/tbbmalloc.dll"
     -D3RDPARTY_TBBMALLOC_LIBRARY_DIR="${MINGW_PREFIX}/lib/"
     -D3RDPARTY_TBBMALLOC_LIBRARY="${MINGW_PREFIX}/lib/libtbbmalloc.dll.a"
-    -DUSE_VTK=1	
+    -DUSE_VTK=1
   )
 
   #Static Build
-  [[ -d "${srcdir}/build-${MINGW_CHOST}-static" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}-static"
-  mkdir -p "${srcdir}/build-${MINGW_CHOST}-static" && cd "${srcdir}/build-${MINGW_CHOST}-static"
+  [[ -d "${srcdir}/build-${MSYSTEM}-static" ]] && rm -rf "${srcdir}/build-${MSYSTEM}-static"
+  mkdir -p "${srcdir}/build-${MSYSTEM}-static" && cd "${srcdir}/build-${MSYSTEM}-static"
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake \
@@ -110,13 +110,13 @@ build() {
     -D3RDPARTY_FFMPEG_LIBRARY_swscale="${MINGW_PREFIX}/lib/libswscale.a" \
     -D3RDPARTY_FREEIMAGE_LIBRARY="${MINGW_PREFIX}/lib/libfreeimage.a" \
     -D3RDPARTY_OPENVR_LIBRARY_openvr_api="${MINGW_PREFIX}/lib/libopenvr_api.a" \
-    ../occt-${_pkgver2}	
-	
+    ../occt-${_pkgver2}
+
     ${MINGW_PREFIX}/bin/cmake --build .
 
   #Shared Build
-  [[ -d "${srcdir}/build-${MINGW_CHOST}-shared" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}-shared"
-  mkdir -p "${srcdir}/build-${MINGW_CHOST}-shared" && cd "${srcdir}/build-${MINGW_CHOST}-shared"
+  [[ -d "${srcdir}/build-${MSYSTEM}-shared" ]] && rm -rf "${srcdir}/build-${MSYSTEM}-shared"
+  mkdir -p "${srcdir}/build-${MSYSTEM}-shared" && cd "${srcdir}/build-${MSYSTEM}-shared"
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake \
@@ -136,18 +136,18 @@ build() {
     -D3RDPARTY_FREEIMAGE_LIBRARY="${MINGW_PREFIX}/lib/libfreeimage.dll.a" \
     -D3RDPARTY_OPENVR_LIBRARY_openvr_api="${MINGW_PREFIX}/lib/libopenvr_api.dll.a" \
     ../occt-${_pkgver2}
-	
+
     ${MINGW_PREFIX}/bin/cmake --build .
 }
 
 package() {
   #Static Install
-  cd "${srcdir}/build-${MINGW_CHOST}-static"
+  cd "${srcdir}/build-${MSYSTEM}-static"
   DESTDIR=${pkgdir} cmake --build . --target install
-  
+
   #Shared Install
-  cd "${srcdir}/build-${MINGW_CHOST}-shared"
+  cd "${srcdir}/build-${MSYSTEM}-shared"
   DESTDIR=${pkgdir} cmake --build . --target install
-  
+
   install -Dm644 ${srcdir}/occt-${_pkgver2}/LICENSE_LGPL_21.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
 }

--- a/mingw-w64-osgQt/PKGBUILD
+++ b/mingw-w64-osgQt/PKGBUILD
@@ -4,7 +4,7 @@ _realname=osgQt
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
 pkgver=3.5.7
-pkgrel=7
+pkgrel=8
 pkgdesc="OpenSceneGraph Qt5 Modules (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -15,7 +15,7 @@ makedepends=("make"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-OpenSceneGraph"
              "${MINGW_PACKAGE_PREFIX}-OpenSceneGraph-debug"
-             "${MINGW_PACKAGE_PREFIX}-qt5")
+             "${MINGW_PACKAGE_PREFIX}-qt5-base")
 options=(!strip staticlibs !buildflags)
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/openscenegraph/osgQt/archive/${pkgver}.tar.gz
         001-qt5-render-issue.patch
@@ -66,12 +66,12 @@ package_prog() {
 }
 
 package_osgQt() {
-  depends=("${MINGW_PACKAGE_PREFIX}-qt5" "${MINGW_PACKAGE_PREFIX}-OpenSceneGraph")
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-base" "${MINGW_PACKAGE_PREFIX}-OpenSceneGraph")
   package_prog Release
 }
 
 package_osgQt-debug() {
-  depends=("${MINGW_PACKAGE_PREFIX}-qt5" "${MINGW_PACKAGE_PREFIX}-OpenSceneGraph-debug")
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-base" "${MINGW_PACKAGE_PREFIX}-OpenSceneGraph-debug")
   package_prog Debug
 }
 

--- a/mingw-w64-osgqtquick-git/PKGBUILD
+++ b/mingw-w64-osgqtquick-git/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}-git
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git" "${MINGW_PACKAGE_PREFIX}-${_realname}-debug-git")
 _ver_base=2.0.0
 pkgver=2.0.0.r172
-pkgrel=4
+pkgrel=5
 pkgdesc="OpenSceneGraph QML Modules (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -16,7 +16,7 @@ makedepends=("make"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-osgQt"
              "${MINGW_PACKAGE_PREFIX}-osgQt-debug"
-             "${MINGW_PACKAGE_PREFIX}-qt5")
+             "${MINGW_PACKAGE_PREFIX}-qt5-declarative")
 options=(!strip staticlibs !buildflags)
 source=(${_realname}::git+https://github.com/podsvirov/osgqtquick.git#branch=develop)
 sha256sums=('SKIP')
@@ -51,7 +51,7 @@ build() {
 
 package_osgQtQuick-git() {
   depends=("${MINGW_PACKAGE_PREFIX}-osgQt"
-           "${MINGW_PACKAGE_PREFIX}-qt5"
+           "${MINGW_PACKAGE_PREFIX}-qt5-declarative"
            "${MINGW_PACKAGE_PREFIX}-OpenSceneGraph")
   provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
   conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-${_realname}-svn")
@@ -63,7 +63,7 @@ package_osgQtQuick-git() {
 
 package_osgQtQuick-debug-git() {
   depends=("${MINGW_PACKAGE_PREFIX}-osgQt-debug"
-           "${MINGW_PACKAGE_PREFIX}-qt5"
+           "${MINGW_PACKAGE_PREFIX}-qt5-declarative"
            "${MINGW_PACKAGE_PREFIX}-${_realname}-git=${pkgver}"
            "${MINGW_PACKAGE_PREFIX}-OpenSceneGraph-debug")
   provides=("${MINGW_PACKAGE_PREFIX}-${_realname}-debug")

--- a/mingw-w64-vtk/PKGBUILD
+++ b/mingw-w64-vtk/PKGBUILD
@@ -5,7 +5,7 @@ _realname=vtk
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=8.2.0
-pkgrel=7
+pkgrel=8
 pkgdesc="A software system for 3D computer graphics, image processing and visualization (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -30,7 +30,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libxml2"
          "${MINGW_PACKAGE_PREFIX}-lz4"
          "${MINGW_PACKAGE_PREFIX}-pugixml"
-         "${MINGW_PACKAGE_PREFIX}-qt5"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
@@ -38,13 +37,18 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-libmariadbclient"
              "${MINGW_PACKAGE_PREFIX}-postgresql"
              "${MINGW_PACKAGE_PREFIX}-python"
-             "${MINGW_PACKAGE_PREFIX}-tk")
+             "${MINGW_PACKAGE_PREFIX}-tk"
+             "${MINGW_PACKAGE_PREFIX}-qt5-base"
+             "${MINGW_PACKAGE_PREFIX}-qt5-winextras"
+             "${MINGW_PACKAGE_PREFIX}-qt5-tools")
 optdepends=("${MINGW_PACKAGE_PREFIX}-boost: InfovisBoost and InfovisBoostGraphAlgorithms modules"
             "${MINGW_PACKAGE_PREFIX}-libmariadbclient: interface to MariaDB"
             "${MINGW_PACKAGE_PREFIX}-postgresql: interface to PostgreSQL"
             "${MINGW_PACKAGE_PREFIX}-python: Python bindings"
             "${MINGW_PACKAGE_PREFIX}-python-matplotlib: Matplotlib renderer"
-            "${MINGW_PACKAGE_PREFIX}-tk: TCL bindings, Python Tk widgets")
+            "${MINGW_PACKAGE_PREFIX}-tk: TCL bindings, Python Tk widgets"
+            "${MINGW_PACKAGE_PREFIX}-qt-base"
+            "${MINGW_PACKAGE_PREFIX}-qt-winextras")
 source=(https://www.vtk.org/files/release/${pkgver%.*}/VTK-${pkgver}.tar.gz
         "001-vtk-mingw-w64.patch"
         "004-fix-linking-rendering-tk.patch"
@@ -97,8 +101,8 @@ build() {
     _cmakeopts=('-DVTK_USE_64BIT_IDS=ON')
   }
 
-  [[ -d ${srcdir}/build-${CARCH} ]] && rm -rf ${srcdir}/build-${CARCH}
-  mkdir -p ${srcdir}/build-${CARCH} && cd ${srcdir}/build-${CARCH}
+  [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}
+  mkdir -p ${srcdir}/build-${MSYSTEM} && cd ${srcdir}/build-${MSYSTEM}
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DVTK_INSTALL_QT_PLUGIN_DIR=;-DVTK_INSTALL_TCL_DIR=" \
   "${MINGW_PREFIX}/bin/cmake.exe" -Wno-dev \
@@ -164,7 +168,7 @@ build() {
 }
 
 package() {
-  cd "${srcdir}/build-${CARCH}"
+  cd "${srcdir}/build-${MSYSTEM}"
   make -j1 DESTDIR="${pkgdir}" install
 
   local PREFIX_DEPS=$(cygpath -am ${MINGW_PREFIX})


### PR DESCRIPTION
- osgqt
- osgqtquick
- opencascade
- vtk

all of these packages are not available for ucrt64 and clang subsystems, just ignore the failure on those subsystems.