### PR TITLE
clustal-omega: autoreconf due to clang failures

### DIFF
--- a/mingw-w64-clustal-omega/PKGBUILD
+++ b/mingw-w64-clustal-omega/PKGBUILD
@@ -4,7 +4,7 @@ _realname=clustal-omega
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.2.4
-pkgrel=2
+pkgrel=3
 pkgdesc="Fast, scalable generation multiple sequence alignments (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -18,6 +18,11 @@ makedepends=("automake"
              "${MINGW_PACKAGE_PREFIX}-gcc")
 
 options=('staticlibs' 'strip')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  autoreconf -fiv
+}
 
 build() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}


### PR DESCRIPTION
rebuild decided to fail due to it trying to call autoconf/automake during build.  Do an explicit autoreconf so the versions all match.