### PR TITLE
libosmscout: depend on cairo

### DIFF
--- a/mingw-w64-libosmscout/PKGBUILD
+++ b/mingw-w64-libosmscout/PKGBUILD
@@ -4,13 +4,14 @@ _realname=libosmscout
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.0.1
-pkgrel=2
+pkgrel=3
 pkgdesc="A Library for offline map rendering, routing and location lookup based on OpenStreetMap data"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 url="https://github.com/Framstag/libosmscout"
 license=('custom:LGPL')
 depends=("${MINGW_PACKAGE_PREFIX}-protobuf"
+         "${MINGW_PACKAGE_PREFIX}-cairo"
          "${MINGW_PACKAGE_PREFIX}-qt5-declarative"
          "${MINGW_PACKAGE_PREFIX}-qt5-svg"
          "${MINGW_PACKAGE_PREFIX}-qt5-location")


### PR DESCRIPTION
the last dependency update lost it, maybe this helps