### PR TITLE
bsdfprocessor: update dependencies

### DIFF
--- a/mingw-w64-bsdfprocessor/PKGBUILD
+++ b/mingw-w64-bsdfprocessor/PKGBUILD
@@ -4,7 +4,7 @@ _realname=bsdfprocessor
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.2.1
-pkgrel=1
+pkgrel=2
 epoch=
 pkgdesc="Application for displaying and editing of BSDF files (mingw-w64)"
 arch=('any')
@@ -14,12 +14,10 @@ license=('MPL2')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-eigen3"
-             "${MINGW_PACKAGE_PREFIX}-libbsdf"
-             "${MINGW_PACKAGE_PREFIX}-qt5"
-             "${MINGW_PACKAGE_PREFIX}-OpenSceneGraph")
+             "${MINGW_PACKAGE_PREFIX}-libbsdf")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
-         "${MINGW_PACKAGE_PREFIX}-qt5"
-         "${MINGW_PACKAGE_PREFIX}-OpenSceneGraph")
+         "${MINGW_PACKAGE_PREFIX}-OpenSceneGraph"
+         "${MINGW_PACKAGE_PREFIX}-osgQt")
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/KimuraRyo/${_realname}/archive/v${pkgver}.tar.gz"
         'optimisations-CMakeLists.txt.patch')
 sha256sums=('5f9325fa887d275453bddbb18c4b794fe0ce83bb439fa486f687c468bf27c4f4'
@@ -31,8 +29,8 @@ prepare() {
 }
 
 build() {
-  [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}
-  mkdir build-${MINGW_CHOST} && cd build-${MINGW_CHOST}
+  [[ -d build-${MSYSTEM} ]] && rm -rf build-${MSYSTEM}
+  mkdir build-${MSYSTEM} && cd build-${MSYSTEM}
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake \
@@ -43,7 +41,7 @@ build() {
     -DCMAKE_CXX_FLAGS=-std=c++11 \
     ../${_realname}-${pkgver}
 
-  make
+  cmake --build .
 }
 
 package() {
@@ -51,5 +49,5 @@ package() {
   cp -f "${srcdir}"/${_realname}-${pkgver}/LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}
 
   mkdir -p ${pkgdir}${MINGW_PREFIX}/bin
-  cp -f "${srcdir}"/build-${MINGW_CHOST}/BSDFProcessor.exe ${pkgdir}${MINGW_PREFIX}/bin/bsdfprocessor.exe
+  cp -f "${srcdir}"/build-${MSYSTEM}/BSDFProcessor.exe ${pkgdir}${MINGW_PREFIX}/bin/bsdfprocessor.exe
 }


### PR DESCRIPTION
This package builds only on MINGW32/64. Ignore the failure on UCRT64 and CLANG32/64.