### PR TITLE
binutils: take reproducibility patches from debian

### DIFF
--- a/mingw-w64-binutils/PKGBUILD
+++ b/mingw-w64-binutils/PKGBUILD
@@ -6,7 +6,7 @@ _realname=binutils
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.37
-pkgrel=2
+pkgrel=3
 pkgdesc="A set of programs to assemble and manipulate binary and object files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -24,7 +24,9 @@ source=(https://ftp.gnu.org/gnu/binutils/${_realname}-${pkgver}.tar.xz{,.sig}
         0110-binutils-mingw-gnu-print.patch
         0600-Change-uint-to-unsigned.patch
         2001-ld-option-to-move-default-bases-under-4GB.patch
-        2003-Restore-old-behaviour-of-windres-so-that-options-con.patch)
+        2003-Restore-old-behaviour-of-windres-so-that-options-con.patch
+        reproducible-import-libraries.patch
+        specify-timestamp.patch)
 sha256sums=('820d9724f020a3e69cb337893a0b63c2db161dadcb0e06fc11dc29eb1e84a32c'
             'SKIP'
             '2c99345fc575c3a060d6677537f636c6c4154fac0fde508070f3b6296c1060d4'
@@ -32,7 +34,9 @@ sha256sums=('820d9724f020a3e69cb337893a0b63c2db161dadcb0e06fc11dc29eb1e84a32c'
             '15fd46de15db03aacff360d15be1ddf2d81092db78aae1eb1e60f6756958745d'
             'b6ad3d4e73a2b075538b714c7512c75620b87820370ce138b1c90a9fb091dcca'
             '675ea7c58b8b3fc628ea85843ee7ca7fb10137c2d42dbd407f83002cb98ff22d'
-            'd584f1cd9e94cba0e9b27625c4acc8ad5242cd625c9b44839d42fc116072568c')
+            'd584f1cd9e94cba0e9b27625c4acc8ad5242cd625c9b44839d42fc116072568c'
+            'a094660ec95996c00b598429843b7869037732146442af567ada9f539bd40480'
+            '27696da8ecfff307537a461b205fad44d6abc1fa648fbf839e72a1d3ea71c40a')
 validpgpkeys=('EAF1C276A747E9ED86210CBAC3126D3B4AE55E93'
               '3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F')
 
@@ -59,6 +63,11 @@ prepare() {
 
   # https://github.com/msys2/MINGW-packages/pull/9233#issuecomment-889439433
   patch -R -p1 -i "${srcdir}/2003-Restore-old-behaviour-of-windres-so-that-options-con.patch"
+
+  # patches for reproducibility from Debian:
+  # https://salsa.debian.org/mingw-w64-team/binutils-mingw-w64/-/tree/master/debian/patches
+  patch -p2 -i "${srcdir}/reproducible-import-libraries.patch"
+  patch -p2 -i "${srcdir}/specify-timestamp.patch"
 }
 
 build() {
@@ -90,7 +99,8 @@ build() {
     --disable-multilib \
     --enable-install-libiberty \
     --enable-plugins \
-    --disable-shared
+    --disable-shared \
+    --enable-deterministic-archives
 
   make
 }

--- a/mingw-w64-binutils/reproducible-import-libraries.patch
+++ b/mingw-w64-binutils/reproducible-import-libraries.patch
@@ -1,0 +1,16 @@
+Description: Make DLL import libraries reproducible
+Author: Benjamin Moody <benjamin.moody@gmail.com>
+Bug-Debian: https://bugs.debian.org/915055
+
+Index: binutils-mingw-w64/upstream/ld/pe-dll.c
+===================================================================
+--- binutils-mingw-w64.orig/upstream/ld/pe-dll.c	2020-07-09 14:54:20.876479887 +0200
++++ binutils-mingw-w64/upstream/ld/pe-dll.c	2020-07-09 14:54:20.872479808 +0200
+@@ -2870,6 +2870,7 @@
+ 
+   bfd_set_format (outarch, bfd_archive);
+   outarch->has_armap = 1;
++  outarch->flags |= BFD_DETERMINISTIC_OUTPUT;
+ 
+   /* Work out a reasonable size of things to put onto one line.  */
+   ar_head = make_head (outarch);

--- a/mingw-w64-binutils/specify-timestamp.patch
+++ b/mingw-w64-binutils/specify-timestamp.patch
@@ -1,0 +1,136 @@
+Description: Allow the PE timestamp to be specified
+Author: Stephen Kitt <skitt@debian.org>
+
+Index: binutils-mingw-w64/upstream/bfd/peXXigen.c
+===================================================================
+--- binutils-mingw-w64.orig/upstream/bfd/peXXigen.c	2020-07-09 14:54:20.836479103 +0200
++++ binutils-mingw-w64/upstream/bfd/peXXigen.c	2020-07-09 14:55:49.842218292 +0200
+@@ -77,6 +77,9 @@
+ #include <wctype.h>
+ #endif
+ 
++#include <errno.h>
++#include <limits.h>
++
+ /* NOTE: it's strange to be including an architecture specific header
+    in what's supposed to be general (to PE/PEI) code.  However, that's
+    where the definitions are, and they don't vary per architecture
+@@ -876,9 +879,36 @@
+ 
+   /* Use a real timestamp by default, unless the no-insert-timestamp
+      option was chosen.  */
+-  if ((pe_data (abfd)->timestamp) == -1)
+-    H_PUT_32 (abfd, time (0), filehdr_out->f_timdat);
+-  else
++  if ((pe_data (abfd)->timestamp) == -1) {
++    time_t now;
++    char *source_date_epoch;
++    unsigned long long epoch;
++    char *endptr;
++
++    now = time (NULL);
++    source_date_epoch = getenv("SOURCE_DATE_EPOCH");
++    if (source_date_epoch) {
++      errno = 0;
++      epoch = strtoull(source_date_epoch, &endptr, 10);
++      if ((errno == ERANGE && (epoch == ULLONG_MAX || epoch == 0))
++          || (errno != 0 && epoch == 0)) {
++        _bfd_error_handler("Environment variable $SOURCE_DATE_EPOCH: strtoull: %s\n",
++                           strerror(errno));
++      } else if (endptr == source_date_epoch) {
++        _bfd_error_handler("Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n",
++                           endptr);
++      } else if (*endptr != '\0') {
++        _bfd_error_handler("Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n",
++                           endptr);
++      } else if (epoch > ULONG_MAX) {
++        _bfd_error_handler("Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal to: %lu but was found to be: %llu\n",
++                           ULONG_MAX, epoch);
++      } else {
++        now = epoch;
++      }
++    }
++    H_PUT_32 (abfd, now, filehdr_out->f_timdat);
++  } else
+     H_PUT_32 (abfd, pe_data (abfd)->timestamp, filehdr_out->f_timdat);
+ 
+   PUT_FILEHDR_SYMPTR (abfd, filehdr_in->f_symptr,
+Index: binutils-mingw-w64/upstream/ld/pe-dll.c
+===================================================================
+--- binutils-mingw-w64.orig/upstream/ld/pe-dll.c	2020-07-09 14:54:20.836479103 +0200
++++ binutils-mingw-w64/upstream/ld/pe-dll.c	2020-07-09 14:55:21.745669536 +0200
+@@ -27,6 +27,8 @@
+ #include "safe-ctype.h"
+ #include "ctf-api.h"
+ 
++#include <errno.h>
++#include <limits.h>
+ #include <time.h>
+ 
+ #include "ld.h"
+@@ -1218,9 +1220,36 @@
+ 
+   memset (edata_d, 0, edata_sz);
+ 
+-  if (pe_data (abfd)->timestamp == -1)
+-    H_PUT_32 (abfd, time (0), edata_d + 4);
+-  else
++  if (pe_data (abfd)->timestamp == -1) {
++    time_t now;
++    char *source_date_epoch;
++    unsigned long long epoch;
++    char *endptr;
++
++    now = time(NULL);
++    source_date_epoch = getenv("SOURCE_DATE_EPOCH");
++    if (source_date_epoch) {
++      errno = 0;
++      epoch = strtoull(source_date_epoch, &endptr, 10);
++      if ((errno == ERANGE && (epoch == ULLONG_MAX || epoch == 0))
++	  || (errno != 0 && epoch == 0)) {
++	einfo("Environment variable $SOURCE_DATE_EPOCH: strtoull: %s\n",
++	      strerror(errno));
++      } else if (endptr == source_date_epoch) {
++	einfo("Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n",
++	      endptr);
++      } else if (*endptr != '\0') {
++	einfo("Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n",
++	      endptr);
++      } else if (epoch > ULONG_MAX) {
++	einfo("Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal to: %lu but was found to be: %llu\n",
++	      ULONG_MAX, epoch);
++      } else {
++	now = epoch;
++      }
++    }
++    H_PUT_32 (abfd, now, edata_d + 4);
++  } else
+     H_PUT_32 (abfd, pe_data (abfd)->timestamp, edata_d + 4);
+ 
+   if (pe_def_file->version_major != -1)
+Index: binutils-mingw-w64/upstream/ld/emultempl/pe.em
+===================================================================
+--- binutils-mingw-w64.orig/upstream/ld/emultempl/pe.em	2020-07-09 14:54:20.836479103 +0200
++++ binutils-mingw-w64/upstream/ld/emultempl/pe.em	2020-07-09 14:54:37.000000000 +0200
+@@ -304,7 +304,7 @@
+      OPTION_USE_NUL_PREFIXED_IMPORT_TABLES},
+     {"no-leading-underscore", no_argument, NULL, OPTION_NO_LEADING_UNDERSCORE},
+     {"leading-underscore", no_argument, NULL, OPTION_LEADING_UNDERSCORE},
+-    {"insert-timestamp", no_argument, NULL, OPTION_INSERT_TIMESTAMP},
++    {"insert-timestamp", optional_argument, NULL, OPTION_INSERT_TIMESTAMP},
+     {"no-insert-timestamp", no_argument, NULL, OPTION_NO_INSERT_TIMESTAMP},
+ #ifdef DLL_SUPPORT
+     /* getopt allows abbreviations, so we do this to stop it
+Index: binutils-mingw-w64/upstream/ld/emultempl/pep.em
+===================================================================
+--- binutils-mingw-w64.orig/upstream/ld/emultempl/pep.em	2020-07-09 14:54:20.836479103 +0200
++++ binutils-mingw-w64/upstream/ld/emultempl/pep.em	2020-07-09 14:54:37.000000000 +0200
+@@ -323,7 +323,7 @@
+     {"no-bind", no_argument, NULL, OPTION_NO_BIND},
+     {"wdmdriver", no_argument, NULL, OPTION_WDM_DRIVER},
+     {"tsaware", no_argument, NULL, OPTION_TERMINAL_SERVER_AWARE},
+-    {"insert-timestamp", no_argument, NULL, OPTION_INSERT_TIMESTAMP},
++    {"insert-timestamp", optional_argument, NULL, OPTION_INSERT_TIMESTAMP},
+     {"no-insert-timestamp", no_argument, NULL, OPTION_NO_INSERT_TIMESTAMP},
+     {"build-id", optional_argument, NULL, OPTION_BUILD_ID},
+     {"enable-reloc-section", no_argument, NULL, OPTION_ENABLE_RELOC_SECTION},


### PR DESCRIPTION
It's a nice property to have.

They also use --enable-deterministic-archives, so do that too.