### PR TITLE
crt: import patch from Debian to fix prefix collisions when using dlltool

### DIFF
--- a/mingw-w64-crt-git/PKGBUILD
+++ b/mingw-w64-crt-git/PKGBUILD
@@ -4,7 +4,7 @@ _realname=crt
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 pkgver=9.0.0.6272.1db0f476f
-pkgrel=2
+pkgrel=3
 _commit='1db0f476fbfdbb54dc089284fc278957c73cdd05'
 pkgdesc='MinGW-w64 CRT for Windows'
 arch=('any')
@@ -21,10 +21,12 @@ conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 options=('!strip' 'staticlibs' '!buildflags' '!emptydirs')
 source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64#commit=$_commit"
         0001-Allow-to-use-bessel-and-complex-functions-without-un.patch
-        0002-DirectX-9-fixes-for-VLC.patch)
+        0002-DirectX-9-fixes-for-VLC.patch
+        dlltool-temp-prefix.patch)
 sha256sums=('SKIP'
             'd641257f7e1469aff89adc33e57702b75fe9667ca035978f890eae1020b6814c'
-            '09b1c7b62f666a07609af57e10c2b0ad815b78356f4b0f1fb6d827a1109a0ec7')
+            '09b1c7b62f666a07609af57e10c2b0ad815b78356f4b0f1fb6d827a1109a0ec7'
+            '1a91af83dc68863dae9dcbdeeb72ce24fab6684563adc2fb48e152fdc23359cd')
 
 pkgver() {
   cd "${srcdir}/mingw-w64"
@@ -36,6 +38,13 @@ prepare() {
 
   git am --committer-date-is-author-date "${srcdir}/0001-Allow-to-use-bessel-and-complex-functions-without-un.patch"
   git am --committer-date-is-author-date "${srcdir}/0002-DirectX-9-fixes-for-VLC.patch"
+
+  # https://github.com/msys2/MINGW-packages/issues/9363#issuecomment-899108764
+  if [[ $MINGW_PACKAGE_PREFIX != *-clang-* ]]; then
+     patch -p1 -i ${srcdir}/dlltool-temp-prefix.patch
+  fi
+
+  autoreconf -fiv
 }
 
 build() {

--- a/mingw-w64-crt-git/dlltool-temp-prefix.patch
+++ b/mingw-w64-crt-git/dlltool-temp-prefix.patch
@@ -1,0 +1,18 @@
+Description: Specify dlltool's temp prefix
+Author: Stephen Kitt <steve@sk2.org>
+
+By default dlltool uses its pid for the object files it generates.
+Enforcing its temp prefix allows the files it generates to be
+reproducible.
+
+--- a/mingw-w64-crt/Makefile.am
++++ b/mingw-w64-crt/Makefile.am
+@@ -36,7 +36,7 @@
+   DTDEF32=$(GENLIB) $(DLLTOOLFLAGS32) $(AM_DLLTOOLFLAGS)
+   DTDEF64=$(GENLIB) $(DLLTOOLFLAGS64) $(AM_DLLTOOLFLAGS)
+ else
+-  AM_DLLTOOLFLAGS=-k --as=$(AS) --output-lib $@
++  AM_DLLTOOLFLAGS=-k --as=$(AS) --output-lib $@ --temp-prefix $$(basename $@ .a)
+   DLLTOOLFLAGSARM32=-m arm
+   DLLTOOLFLAGSARM64=-m arm64
+   DLLTOOLFLAGS32=--as-flags=--32 -m i386


### PR DESCRIPTION
also helps reproducibility

See https://github.com/msys2/MINGW-packages/issues/9363#issuecomment-899108764