### PR TITLE
ttfautohint: delete VERSION file for libc++

### DIFF
--- a/mingw-w64-ttfautohint/PKGBUILD
+++ b/mingw-w64-ttfautohint/PKGBUILD
@@ -4,7 +4,7 @@ _realname=ttfautohint
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.8.3
-pkgrel=4
+pkgrel=5
 pkgdesc="Automated hinting tools for TrueType fonts (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -23,9 +23,8 @@ validpgpkeys=('58E0C111E39F5408C5D3EC76C1A60EACE707FDA5') # Werner Lemberg <wl@g
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
-  # Empty VERSION file for clang
-  echo > .version
-  echo > VERSION
+  # VERSION file is being picked up by #include <version> inside libc++
+  rm -f VERSION
 }
 
 build() {


### PR DESCRIPTION
libc++ has a header <version> and case-insensitive filesystem is causing
VERSION to be picked up instead.