### PR TITLE
crt-git: disable dependency tracking

### DIFF
--- a/mingw-w64-crt-git/PKGBUILD
+++ b/mingw-w64-crt-git/PKGBUILD
@@ -80,6 +80,7 @@ build() {
     --with-sysroot=${MINGW_PREFIX}/${MINGW_CHOST} \
     --with-default-msvcrt=${_default_msvcrt} \
     --enable-wildcard \
+    --disable-dependency-tracking \
     ${_crt_configure_args}
   make
 }


### PR DESCRIPTION
Packaging does one-time builds, so dependency information is not utilized.  On ARM64 building the dependency information for this package takes a really long time.

I don't think this is worth yet another rebuild, so not bumping pkgrel, but would be nice to have for future builds