### PR TITLE
clang: make path::native use preferred separator

### DIFF
--- a/mingw-w64-clang/0001-Use-posix-style-path-separators-with-MinGW.patch
+++ b/mingw-w64-clang/0001-Use-posix-style-path-separators-with-MinGW.patch
@@ -3,11 +3,12 @@ From: =?UTF-8?q?Mateusz=20Miku=C5=82a?= <mati865@gmail.com>
 Date: Sun, 22 Nov 2020 17:49:19 +0100
 Subject: [PATCH 2/2] Use posix style path separators with MinGW
 
+Co-authored-by: Jeremy Drake <github@jdrake.com>
 ---
- lib/Support/Path.cpp            | 4 ++++
+ lib/Support/Path.cpp            | 8 +++++++-
  lib/Support/Windows/Path.inc    | 5 +++++
  lib/Support/Windows/Program.inc | 7 ++++++-
- 3 files changed, 15 insertions(+), 1 deletion(-)
+ 3 files changed, 18 insertions(+), 2 deletions(-)
 
 diff --git a/lib/Support/Path.cpp b/lib/Support/Path.cpp
 index 37b3086fddf..8ab8e33f248 100644
@@ -24,6 +25,17 @@ index 37b3086fddf..8ab8e33f248 100644
      return '/';
    }
  
+@@ -549,7 +551,9 @@
+   if (Path.empty())
+     return;
+   if (real_style(style) == Style::windows) {
+-    std::replace(Path.begin(), Path.end(), '/', '\\');
++    std::replace_if(Path.begin(), Path.end(),
++                    std::bind(is_separator, std::placeholders::_1, style),
++                    preferred_separator(style));
+     if (Path[0] == '~' && (Path.size() == 1 || is_separator(Path[1], style))) {
+       SmallString<128> PathHome;
+       home_directory(PathHome);
 @@ -611,8 +613,10 @@ bool is_separator(char value, Style style) {
  }
  

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -348,6 +348,8 @@ build() {
       -DLIBCXXABI_USE_LLVM_UNWINDER=ON)
   else
     # Use newly built compiler for libcxx/libunwind because GCC/binutils doesn't play nicely
+    # TODO: is it safe to do this on clangprefix too?  I remember running into
+    # issues trying it (which is why this is in the "else" case)
     libcxx_config+=(-DCMAKE_AR="${srcdir}/build-${MSYSTEM}/bin/llvm-ar.exe"
       -DCMAKE_ASM_COMPILER="${srcdir}/build-${MSYSTEM}/bin/clang.exe"
       -DCMAKE_C_COMPILER="${srcdir}/build-${MSYSTEM}/bin/clang.exe"
@@ -363,39 +365,6 @@ build() {
     -DLIBUNWIND_USE_COMPILER_RT=ON
     -DLLVM_ENABLE_LLD=ON
     -DLLVM_ENABLE_PROJECTS="libcxx;libcxxabi;libunwind")
-
-  # XXX HACK for clang32 to allow the change of time_t from 32 to 64-bits
-  if [[ "${MSYSTEM}" == "CLANG32" ]]; then
-    [[ -d build-libcxx-shared-HACK ]] && rm -rf build-libcxx-shared-HACK
-    [[ -d bin-HACK ]] && rm -rf bin-HACK
-    [[ -d lib-HACK ]] && rm -rf lib-HACK
-    mkdir bin-HACK
-    mkdir lib-HACK
-    mkdir build-libcxx-shared-HACK && cd build-libcxx-shared-HACK
-
-    MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-    ${MINGW_PREFIX}/bin/cmake.exe \
-      -GNinja \
-      -DCMAKE_CXX_FLAGS="${CXXFLAGS} -D_LIBCPP_BUILDING_LIBRARY -U_LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS" \
-      -DLIBCXX_ENABLE_EXPERIMENTAL_LIBRARY=OFF \
-      -DLIBCXX_ENABLE_SHARED=ON \
-      -DLIBCXX_ENABLE_STATIC=OFF \
-      -DLIBUNWIND_ENABLE_SHARED=ON \
-      -DLIBUNWIND_ENABLE_STATIC=OFF \
-      "${common_cmake_args[@]}" \
-      "${libcxx_config[@]}" \
-      ../llvm
-
-    ${MINGW_PREFIX}/bin/cmake.exe --build . -- unwind cxx
-
-    cp lib/libc++.dll ../bin-HACK
-    cp lib/libc++.dll.a ../lib-HACK
-    cp lib/libc++abi.a ../lib-HACK
-    export PATH="${srcdir}/bin-HACK:$PATH"
-    export LDFLAGS+=" -L$(cygpath -m "${srcdir}/lib-HACK")"
-
-    cd "${srcdir}"
-  fi
 
   [[ -d build-${MSYSTEM} ]] && rm -rf build-${MSYSTEM}
   mkdir build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -28,7 +28,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
            "${MINGW_PACKAGE_PREFIX}-openmp")
          "${MINGW_PACKAGE_PREFIX}-polly")
 pkgver=12.0.1
-pkgrel=4
+pkgrel=5
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -118,7 +118,7 @@ source=("https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkgver
 #0901-0999 -> openmp
 sha256sums=('129cb25cd13677aad951ce5c2deb0fe4afc1e9d98950f53b51bdcfb5a73afa0e'
             'SKIP'
-            '988a22053c1cc3fa52b1242b3a7cec591ca69b57eb5531c37ce9c74157db62a0'
+            'd793340dbdcf375e80b45641f5f532a2adbdece2a5e185e211f509ff5c7c9938'
             '8831c6ea72baa315b20e5f1a9008a9bf4098ba8a18d5331f05216604489063a4'
             '7e7974bbe9ef754be544e5a2a78ab43a1d898c7c9601e7b8d53f8d900df16977'
             '7f0c64cd87b61e894be632f180ae5291e1aa9f1d9d382608f659067eeeda7146'


### PR DESCRIPTION
llvm::sys::path::native previously replaced all `/` with `\`, but the patch intended to prefer `/` for MinGW missed this one.  Replace all separators with the preferred separator instead.  This fixes automake detecting that clang generates "gcc3"-style dependency makefile fragments.

Remove early build of shared libc++ for clang32.  This was a hack to recover from the changed `time_t` size, but the patched libc++ with both 32 and 64-bit `time_t` exports is in the repos now so it isn't necessary anymore.

I intend to leave the hack adding the extra 32-bit `time_t` export in libc++.dll until llvm 13 just in case, but all users of the symbol should already be rebuilt in the repo.