### PR TITLE
arrow: fix clang32 build.

### DIFF
--- a/mingw-w64-arrow/0002-cast-initializer-list.patch
+++ b/mingw-w64-arrow/0002-cast-initializer-list.patch
@@ -1,0 +1,43 @@
+From f64fb07ddbe70969533cc947e2815d40454c5c2d Mon Sep 17 00:00:00 2001
+From: jeremyd2019 <github@jdrake.com>
+Date: Sun, 22 Aug 2021 19:57:03 -0700
+Subject: [PATCH] Update numpy_convert.cc
+
+add static_cast to initializer list to avoid C++11 narrowing error in Clang.
+
+error: non-constant-expression cannot be narrowed from type 'int64_t' (aka 'long long') to 'int' in initializer list [-Wc++11-narrowing]
+---
+ cpp/src/arrow/python/numpy_convert.cc | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/cpp/src/arrow/python/numpy_convert.cc b/cpp/src/arrow/python/numpy_convert.cc
+index bf4afb2a0a11..eedf257f9d9c 100644
+--- a/cpp/src/arrow/python/numpy_convert.cc
++++ b/cpp/src/arrow/python/numpy_convert.cc
+@@ -322,7 +322,7 @@ Status SparseCOOTensorToNdarray(const std::shared_ptr<SparseCOOTensor>& sparse_t
+   // Wrap tensor data
+   OwnedRef result_data;
+   RETURN_NOT_OK(SparseTensorDataToNdarray(
+-      *sparse_tensor, {sparse_tensor->non_zero_length(), 1}, base, result_data.ref()));
++      *sparse_tensor, {static_cast<npy_intp>(sparse_tensor->non_zero_length()), 1}, base, result_data.ref()));
+ 
+   // Wrap indices
+   PyObject* result_coords;
+@@ -362,7 +362,7 @@ Status SparseCSXMatrixToNdarray(const std::shared_ptr<SparseTensor>& sparse_tens
+   // Wrap tensor data
+   OwnedRef result_data;
+   RETURN_NOT_OK(SparseTensorDataToNdarray(
+-      *sparse_tensor, {sparse_tensor->non_zero_length(), 1}, base, result_data.ref()));
++      *sparse_tensor, {static_cast<npy_intp>(sparse_tensor->non_zero_length()), 1}, base, result_data.ref()));
+ 
+   *out_data = result_data.detach();
+   *out_indptr = result_indptr.detach();
+@@ -391,7 +391,7 @@ Status SparseCSFTensorToNdarray(const std::shared_ptr<SparseCSFTensor>& sparse_t
+   // Wrap tensor data
+   OwnedRef result_data;
+   RETURN_NOT_OK(SparseTensorDataToNdarray(
+-      *sparse_tensor, {sparse_tensor->non_zero_length(), 1}, base, result_data.ref()));
++      *sparse_tensor, {static_cast<npy_intp>(sparse_tensor->non_zero_length()), 1}, base, result_data.ref()));
+ 
+   // Wrap indices
+   int ndim = static_cast<int>(sparse_index.indices().size());

--- a/mingw-w64-arrow/PKGBUILD
+++ b/mingw-w64-arrow/PKGBUILD
@@ -4,7 +4,7 @@ _realname=arrow
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.0.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Apache Arrow is a cross-language development platform for in-memory data (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -39,9 +39,11 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-boost"
              "${MINGW_PACKAGE_PREFIX}-rapidjson")
 options=("staticlibs" "strip" "!buildflags")
 source=("apache-arrow-${pkgver}.tar.gz"::"https://www.apache.org/dyn/closer.lua?action=download&filename=arrow/arrow-${pkgver}/apache-arrow-${pkgver}.tar.gz"
-        "0001-detect-version-script-flag.patch")
+        "0001-detect-version-script-flag.patch"
+        "0002-cast-initializer-list.patch")
 sha256sums=('c3b4313eca594c20f761a836719721aaf0760001af896baec3ab64420ff9910a'
-            'fb5c3709d0a43ca0c58d25ce6a157e641b90a5a64801b58f58495daab32efc9d')
+            'fb5c3709d0a43ca0c58d25ce6a157e641b90a5a64801b58f58495daab32efc9d'
+            'f372d62ac4bbf167c0f123e43e96afa2ed0b228325f074ec9ebff5f66bf96f60')
 
 cmake_build_type=release
 meson_build_type=debugoptimized
@@ -55,6 +57,8 @@ prepare() {
 
   # https://github.com/apache/arrow/pull/10848
   patch -Np1 -i "${srcdir}/0001-detect-version-script-flag.patch"
+  # https://github.com/apache/arrow/pull/10975
+  patch -Np1 -i "${srcdir}/0002-cast-initializer-list.patch"
 }
 
 build() {


### PR DESCRIPTION
Explicitly cast in initializer list to avoid C++11-narrowing error.