### PR TITLE
lensfun: enable SSE2 for 32-bit also.

### DIFF
--- a/mingw-w64-lensfun/PKGBUILD
+++ b/mingw-w64-lensfun/PKGBUILD
@@ -4,7 +4,7 @@ _realname=lensfun
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.3.2
-pkgrel=9
+pkgrel=10
 pkgdesc="Database of photographic lenses and a library that allows advanced access to the database (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -41,7 +41,6 @@ build() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
   mkdir ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
 
-  [[ ${CARCH} == "x86_64" ]] && _ENABLESSE2="-DBUILD_FOR_SSE2=ON"
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DSETUP_PY_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe \
     -G"Ninja" \
@@ -52,8 +51,8 @@ build() {
     -DBUILD_LENSTOOL=ON \
     -DBUILD_TESTS=OFF \
     -DBUILD_FOR_SSE=ON \
+    -DBUILD_FOR_SSE2=ON \
     -DBUILD_DOC=OFF \
-    ${_ENABLESSE2} \
     ../${_realname}-${pkgver}
 
   ${MINGW_PREFIX}/bin/cmake.exe --build ./


### PR DESCRIPTION
Now that march=pentium4 there, SSE2 is required.

Note that clang32 failed in autobuild due to lack of SSE, so will require the pacman update(msys2/MSYS2-packages#2609) to build.