### PR TITLE
gh: upgrade to v2.0.0

### DIFF
--- a/mingw-w64-github-cli/PKGBUILD
+++ b/mingw-w64-github-cli/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=github-cli
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.14.0
+pkgver=2.0.0
 pkgrel=1
 pkgdesc='The GitHub CLI (mingw-w64)'
 arch=('any')
@@ -17,7 +17,7 @@ optdepends=("git: To interact with repositories")
 options=('!strip')
 source=("$_realname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz"
         "gh")
-sha256sums=('1a99050644b4821477aabc7642bbcae8a19b3191e9227cd8078016d78cdd83ac'
+sha256sums=('5d93535395a6684dee1d9d1d3cde859addd76f56581e0111d95a9c685d582426'
             '9ee5f2b44b7e9aa751508f02c1020e341e0212a9aa146b7428eb5ffea310be27')
 build() {
     cd "cli-$pkgver"


### PR DESCRIPTION
For more details, see

	https://github.blog/2021-08-24-github-cli-2-0-includes-extensions/

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
