### PR TITLE
ghdl: update to 1.0.0.r651.g243bb15e

### DIFF
--- a/mingw-w64-ghdl/PKGBUILD
+++ b/mingw-w64-ghdl/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=ghdl
 pkgbase="mingw-w64-${_realname}"
 pkgname='__placeholder__'
-pkgver=1.0.0.r517.g9262a810
+pkgver=1.0.0.r651.g243bb15e
 pkgrel=1
 pkgdesc='GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL'
 arch=('any')
@@ -11,7 +11,7 @@ url='https://github.com/ghdl'
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-source=("${_realname}::git://github.com/ghdl/ghdl.git#commit=9262a810")
+source=("${_realname}::git://github.com/ghdl/ghdl.git#commit=243bb15e")
 sha512sums=('SKIP')
 
 pkgver() {


### PR DESCRIPTION
During the last week, several significant updates to the Python interface were pushed. This is a regular bump to pick them.