### PR TITLE
CI: use -u (unbuffered) option to python

### DIFF
--- a/.github/workflows/generate-srcinfo.yml
+++ b/.github/workflows/generate-srcinfo.yml
@@ -30,7 +30,7 @@ jobs:
           # XXX: we don't need the toolchains for --printsrcinfo, but makepkg-mingw complains if gcc doesn't exist
           touch /mingw64/bin/gcc.exe /mingw32/bin/gcc.exe /ucrt64/bin/gcc.exe /clang64/bin/clang.exe /clang32/bin/clang.exe
           curl --fail -L --retry 5 -o srcinfo.json "https://github.com/$GITHUB_REPOSITORY/releases/download/srcinfo-cache/srcinfo.json"
-          python .ci/ci-generate-srcinfo.py --time-limit 19800 mingw . srcinfo.json
+          python -u .ci/ci-generate-srcinfo.py --time-limit 19800 mingw . srcinfo.json
 
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
for generate-srcinfo.  It prints out as it parses each PKGBUILD, but that's never seen while the job is running.