### PR TITLE
openlibm: fix clang32 build

### DIFF
--- a/mingw-w64-openlibm/02-mingw-clang-symbol.patch
+++ b/mingw-w64-openlibm/02-mingw-clang-symbol.patch
@@ -1,0 +1,13 @@
+--- openlibm-0.7.5/src/cdefs-compat.h	2021-02-17 09:04:36.000000000 -0800
++++ openlibm-0.7.5/src/cdefs-compat.h	2021-08-25 17:59:51.875525300 -0700
+@@ -61,8 +61,8 @@
+ #elif defined(__clang__) /* CLANG */
+ #ifdef __STDC__
+ #define openlibm_weak_reference(sym,alias)     \
+-    __asm__(".weak_reference " #alias); \
+-    __asm__(".set " #alias ", " #sym)
++    __asm__(".weak_reference " __MINGW64_STRINGIFY(__MINGW_USYMBOL(alias))); \
++    __asm__(".set " __MINGW64_STRINGIFY(__MINGW_USYMBOL(alias)) ", " __MINGW64_STRINGIFY(__MINGW_USYMBOL(sym)))
+ #else
+ #define openlibm_weak_reference(sym,alias)     \
+     __asm__(".weak_reference alias");\

--- a/mingw-w64-openlibm/PKGBUILD
+++ b/mingw-w64-openlibm/PKGBUILD
@@ -4,7 +4,7 @@ _realname=openlibm
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.7.5
-pkgrel=1
+pkgrel=2
 pkgdesc="High quality system independent, portable, open source libm implementation (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -12,9 +12,11 @@ url='https://openlibm.org'
 license=('MIT')
 options=('strip' 'staticlibs')
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/JuliaMath/${_realname}/archive/v${pkgver}.tar.gz"
-        01-mingw-build.patch)
+        01-mingw-build.patch
+        02-mingw-clang-symbol.patch)
 sha256sums=('be983b9e1e40e696e8bbb7eb8f6376d3ca0ae675ae6d82936540385b0eeec15b'
-            '8fc88f5296a5963dc0389da656f299d7ace0a26a79882acc2596b686937a6e70')
+            '8fc88f5296a5963dc0389da656f299d7ace0a26a79882acc2596b686937a6e70'
+            'a81c645d04f53d228d81f2c1b250822c5fc4e8630dd593fa9dd90bc32876c198')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -37,7 +39,8 @@ del_file_exists() {
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
-  apply_patch_with_msg 01-mingw-build.patch
+  apply_patch_with_msg 01-mingw-build.patch \
+                       02-mingw-clang-symbol.patch
 }
 
 build() {
@@ -45,7 +48,12 @@ build() {
   cp -rf "${srcdir}/${_realname}-${pkgver}" "${srcdir}/build-${CARCH}"
 
   cd "${srcdir}/build-${CARCH}"
-  make prefix=${MINGW_PREFIX} USEGCC=1
+  local _compilersetting="USEGCC=1"
+  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
+    _compilersetting="USECLANG=1"
+  fi
+
+  make prefix=${MINGW_PREFIX} ${_compilersetting}
 }
 
 check() {


### PR DESCRIPTION
Was running into link errors due to the need to prefix symbols with `_` for i686.  I get the impression the `__MINGW` prefixed macros for doing this were only intended to be used internally in the mingw-w64 headers, but they do what I need for a quick hack.  I opened JuliaMath/openlibm#237 to hopefully figure out a more reasonable way to do this upstream.