### PR TITLE
qt5-tools: Fix PKGBUILD

### DIFF
--- a/mingw-w64-qt5-tools/PKGBUILD
+++ b/mingw-w64-qt5-tools/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt5-tools
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.15.2+kde+r17
-pkgrel=1
+pkgrel=2
 _commit=33693a928986006d79c1ee743733cde5966ac402
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -47,6 +47,8 @@ pkgver() {
 prepare() {
   cd ${srcdir}/${_pkgfn}
 
+  git revert -n dbe0567470db2b369a9fdb28d9fbac38be3e2d60 # Revert version bump
+
   apply_patch_with_msg \
     001-qt-5.11-mingw-fix-link-qdoc-with-clang.patch \
     002-qt5-windeployqt-fixes.patch \
@@ -72,11 +74,6 @@ build() {
 check() {
   cd build-${MSYSTEM}
   make check -j1 -k
-}
-
-prepare() {
-  cd $_pkgfn
-  git revert -n dbe0567470db2b369a9fdb28d9fbac38be3e2d60 # Revert version bump
 }
 
 package() {


### PR DESCRIPTION
 ~for an unknown reason the prepare() function were skipped!~
the prepare() function was defined twice
Fixes #9475 