### PR TITLE
gtk3: clang32 depend on adwaita-icon-theme again

### DIFF
--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gtk3
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-gtk-update-icon-cache")
 pkgver=3.24.30
-pkgrel=2
+pkgrel=3
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -18,8 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-sassc"
              "${MINGW_PACKAGE_PREFIX}-libxslt")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
-         $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-i686* || \
-               ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || \
+         $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || \
               echo "${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme" )
          "${MINGW_PACKAGE_PREFIX}-atk"
          "${MINGW_PACKAGE_PREFIX}-cairo"


### PR DESCRIPTION
There's a circular dependency involved, so I don't know if autobuild would be able to figure out to provide adwaita-icon-theme...