### PR TITLE
CI: don't install msys2-devel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           msystem: ${{ matrix.msystem }}
-          install: VCS msys2-devel base-devel binutils pactoys-git ${{ matrix.toolchain }}
+          install: VCS base-devel binutils pactoys-git ${{ matrix.toolchain }}
           update: true
 
       - name: Add staging repo


### PR DESCRIPTION
These tools are not present in autobuild, and may cause confusion with the proper MINGW tools.

Fixes #9479