### PR TITLE
octave: Fix detection of octave binary when installing Octave packages.

### DIFF
--- a/mingw-w64-octave/0002-mk-doc-cache-path.patch
+++ b/mingw-w64-octave/0002-mk-doc-cache-path.patch
@@ -1,0 +1,21 @@
+# HG changeset patch
+# User Markus Mützel <markus.muetzel@gmx.de>
+# Date 1630254948 -7200
+#      Sun Aug 29 18:35:48 2021 +0200
+# Branch stable
+# Node ID d79169008b5cfa61d2728b79ed5ddc7bab144667
+# Parent  754013c3658760136fe473911ba96165a07cb1f5
+mk-doc-cache.pl: Single-quote path (might contain unescaped backslashes).
+
+diff -r 754013c36587 -r d79169008b5c doc/interpreter/mk-doc-cache.pl
+--- a/doc/interpreter/mk-doc-cache.pl	Sun Jul 11 13:19:32 2021 -0400
++++ b/doc/interpreter/mk-doc-cache.pl	Sun Aug 29 18:35:48 2021 +0200
+@@ -99,7 +99,7 @@
+ {
+   my $texi_path = shift;
+ 
+-  my $makeinfo_command = "makeinfo --no-headers --no-warn --force --no-validate --fill-column=1024 $texi_path";
++  my $makeinfo_command = "makeinfo --no-headers --no-warn --force --no-validate --fill-column=1024 '$texi_path'";
+   my $info_text = `$makeinfo_command`;
+ 
+   die "Unable to start makeinfo command '$makeinfo_command'"

--- a/mingw-w64-octave/0003-pkg-octave-binary.patch
+++ b/mingw-w64-octave/0003-pkg-octave-binary.patch
@@ -1,0 +1,23 @@
+# HG changeset patch
+# User Markus Mützel <markus.muetzel@gmx.de>
+# Date 1630238704 -7200
+#      Sun Aug 29 14:05:04 2021 +0200
+# Branch stable
+# Node ID 1f41d3fbc3da24f824683386331d6df27571b357
+# Parent  d79169008b5cfa61d2728b79ed5ddc7bab144667
+pkg: Fall back to calling octave binary if batch file doesn't exist.
+
+diff -r d79169008b5c -r 1f41d3fbc3da scripts/pkg/private/configure_make.m
+--- a/scripts/pkg/private/configure_make.m	Sun Aug 29 18:35:48 2021 +0200
++++ b/scripts/pkg/private/configure_make.m	Sun Aug 29 14:05:04 2021 +0200
+@@ -42,6 +42,10 @@
+                                       sprintf ("octave-config-%s%s", ver, ext));
+     if (ispc () && ! isunix ())
+       octave_binary = fullfile (octave_bindir, sprintf ("octave-%s.bat", ver));
++      if (! exist (octave_binary, "file"))
++        ## Call binary directly if batch file doesn't exist (e.g. in msys2)
++        octave_binary = fullfile (octave_bindir, sprintf ("octave-%s%s", ver, ext));
++      endif
+     else
+       octave_binary = fullfile (octave_bindir, sprintf ("octave-%s%s", ver, ext));
+     endif

--- a/mingw-w64-octave/PKGBUILD
+++ b/mingw-w64-octave/PKGBUILD
@@ -2,7 +2,7 @@ _realname=octave
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=6.3.0
-pkgrel=3
+pkgrel=4
 pkgdesc="GNU Octave: Interactive programming environment for numerical computations."
 url="https://www.octave.org"
 license=('GPL3')
@@ -34,13 +34,19 @@ optdepends=('texinfo: for help-support in Octave'
             "${MINGW_PACKAGE_PREFIX}-gnuplot: alternative plotting"
             "${MINGW_PACKAGE_PREFIX}-portaudio: audio support")
 source=(https://ftp.gnu.org/gnu/octave/octave-$pkgver.tar.gz
-        "0001-binary-install-location.patch")
+        "0001-binary-install-location.patch"
+        "0002-mk-doc-cache-path.patch"
+        "0003-pkg-octave-binary.patch")
 sha512sums=('9582d7a7d84beef2a22d3dfaf45aee4778fc0dfc0ec1831c5bcb863dd0062e996e5b7aaaa40519c23d2c730c3408e26745b9dbf73db5127ebae22da0b2532788'
-            'dc714dbf04dc551cd996b4b1b9bf7816100103fa8c3d7d3633171d36f5d8eb20464fa0cfeee387c882a1fcb81e824d11e68b7f99f2f6b56d1f2ef6b220c8acab')
+            'dc714dbf04dc551cd996b4b1b9bf7816100103fa8c3d7d3633171d36f5d8eb20464fa0cfeee387c882a1fcb81e824d11e68b7f99f2f6b56d1f2ef6b220c8acab'
+            '5742cde34ae9184276c830dab41dccb289991578656353658bf07315d89b1c3870c6c51520d5aae0cec8c7fb12c707a1970aa9dde353b4ab54e515d1d3cf66e0'
+            '96c596fb105589bbfc662211cd62c2ecfea903656b15b54045a6ee852d8c3b3bdc6894bb2f93693f88bb5eab6ad7ed54056b42a0f3cc3832e2be961887e10acf')
 
 prepare() {
   cd "${_realname}-${pkgver}"
   patch -p1 -i "${srcdir}/0001-binary-install-location.patch"
+  patch -p1 -i "${srcdir}/0002-mk-doc-cache-path.patch"
+  patch -p1 -i "${srcdir}/0003-pkg-octave-binary.patch"
 }
 
 build() {
@@ -56,12 +62,13 @@ build() {
     --libexecdir=${MINGW_PREFIX}/lib \
     --sbindir=${MINGW_PREFIX}/bin \
     --enable-shared --disable-static \
+    --disable-docs \
     --enable-relocate-all \
     --with-blas="-lblas" \
     ac_cv_search_tputs=-ltermcap \
     JAVA_HOME=""
 
-  make all
+  PERL5SHELL="bash -l -c" make all
 }
 
 package() {


### PR DESCRIPTION
As reported in #9310, installing an Octave package with `pkg install ...` currently fails.
The proposed changes should be fixing the issue (see `0003-pkg-octave-binary.patch`).

Patching that file of the tarball triggers the build system to re-build the documentation. That doesn't work currently (at least for me, see msys2/msys2-texlive#13).
The additional changes to the build rule and patch `0002-mk-doc-cache-path.patch` should work around that issue.