### PR TITLE
Workaround for issue on clang64 and some debug code.    Clang warns a…

### DIFF
--- a/mingw-w64-libtool/0015-Support-llvm-Wformat-nonliteral.patch
+++ b/mingw-w64-libtool/0015-Support-llvm-Wformat-nonliteral.patch
@@ -1,0 +1,25 @@
+--- libtool-2.4.6/build-aux/ltmain.in.orig	2021-08-29 04:58:24.267126800 -0400
++++ libtool-2.4.6/build-aux/ltmain.in	2021-08-29 05:04:21.377405000 -0400
+@@ -4270,6 +4270,11 @@ strendzap (char *str, const char *pat)
+   return str;
+ }
+ 
++#ifdef __clang__
++#pragma clang diagnostic push
++#pragma clang diagnostic ignored "-Wformat-nonliteral"
++#endif
++
+ void
+ lt_debugprintf (const char *file, int line, const char *fmt, ...)
+ {
+@@ -4296,6 +4301,10 @@ lt_error_core (int exit_status, const ch
+     exit (exit_status);
+ }
+ 
++#ifdef __clang__
++#pragma clang diagnostic pop    
++#endif   
++
+ void
+ lt_fatal (const char *file, int line, const char *message, ...)
+ {

--- a/mingw-w64-libtool/PKGBUILD
+++ b/mingw-w64-libtool/PKGBUILD
@@ -5,7 +5,7 @@ _realname=libtool
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.4.6
-pkgrel=20
+pkgrel=21
 pkgdesc="A system independent dlopen wrapper for GNU libtool (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -24,7 +24,8 @@ source=("https://ftp.gnu.org/pub/gnu/libtool/${_realname}-${pkgver}.tar.xz"{,.si
         0011-Pick-up-clang_rt-static-archives-compiler-internal-l.patch
         0012-Prefer-response-files-over-linker-scripts-for-mingw-.patch
         0013-Allow-statically-linking-compiler-support-libraries-.patch
-        0014-Support-llvm-objdump-f-output.patch)
+        0014-Support-llvm-objdump-f-output.patch
+        0015-Support-llvm-Wformat-nonliteral.patch)
 sha256sums=('7c87a8c2c8c0fc9cd5019e402bed4292462d00a718a7cd5f11218153bf28b26f'
             'SKIP'
             'fe8b80efd34f9385220ebc90aaec945e44de8c343c75719d6ac0d4e472a6eed5'
@@ -36,22 +37,24 @@ sha256sums=('7c87a8c2c8c0fc9cd5019e402bed4292462d00a718a7cd5f11218153bf28b26f'
             'c727b2b017163cfdeca60820d3cff2dac8968c5630745602b150f92b159af313'
             'c95a65e890b1ae6362807abc66809e72cf81aeea5f9f556e38f9752f974bf435'
             '8069e887aeeab7491f15e00547fa66d9b9e86407f5a23f37a6d8c7d165de752e'
-            'db16cd322e0ebc578c906e94b0788810af17ce617c700a50db2e3c598dbbed7e')
+            'db16cd322e0ebc578c906e94b0788810af17ce617c700a50db2e3c598dbbed7e'
+            '50b30761a2d00fba719d2a54d3bcb3fb6a2940f1741c0448d463a1a8d96f34af')
 
 validpgpkeys=('CFE2BE707B538E8B26757D84151308092983D606') #Gary Vaughan (Free Software Developer) <gary@vaughan.pe>
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
-  patch -p1 -i ${srcdir}/0002-cygwin-mingw-Create-UAC-manifest-files.mingw.patch
-  patch -p1 -i ${srcdir}/0003-Pass-various-runtime-library-flags-to-GCC.mingw.patch
-  patch -p1 -i ${srcdir}/0005-Fix-seems-to-be-moved.patch
-  patch -p1 -i ${srcdir}/0006-Fix-strict-ansi-vs-posix.patch
-  patch -p1 -i ${srcdir}/0007-fix-cr-for-awk-in-configure.all.patch
-  patch -p1 -i ${srcdir}/0008-tests.patch
-  patch -p1 -i ${srcdir}/0011-Pick-up-clang_rt-static-archives-compiler-internal-l.patch
-  patch -p1 -i ${srcdir}/0012-Prefer-response-files-over-linker-scripts-for-mingw-.patch
-  patch -p1 -i ${srcdir}/0013-Allow-statically-linking-compiler-support-libraries-.patch
-  patch -p1 -i ${srcdir}/0014-Support-llvm-objdump-f-output.patch
+  patch -bp1 -i ${srcdir}/0002-cygwin-mingw-Create-UAC-manifest-files.mingw.patch
+  patch -bp1 -i ${srcdir}/0003-Pass-various-runtime-library-flags-to-GCC.mingw.patch
+  patch -bp1 -i ${srcdir}/0005-Fix-seems-to-be-moved.patch
+  patch -bp1 -i ${srcdir}/0006-Fix-strict-ansi-vs-posix.patch
+  patch -bp1 -i ${srcdir}/0007-fix-cr-for-awk-in-configure.all.patch
+  patch -bp1 -i ${srcdir}/0008-tests.patch
+  patch -bp1 -i ${srcdir}/0011-Pick-up-clang_rt-static-archives-compiler-internal-l.patch
+  patch -bp1 -i ${srcdir}/0012-Prefer-response-files-over-linker-scripts-for-mingw-.patch
+  patch -bp1 -i ${srcdir}/0013-Allow-statically-linking-compiler-support-libraries-.patch
+  patch -bp1 -i ${srcdir}/0014-Support-llvm-objdump-f-output.patch
+  patch -bp1 -i ${srcdir}/0015-Support-llvm-Wformat-nonliteral.patch
 }
 
 build() {


### PR DESCRIPTION
…nd will sometimes generate an error  if the format string is not not a litteral constant ( -Wformat-nonliteral ).  That causes some packages to fail to compile.  Note that this warning is correct but I consider it harmless in libtool since it is used by libraries for testing and debuggng.  libtool really should be properly fixed for this.