### PR TITLE
Add neofetch

### DIFF
--- a/mingw-w64-neofetch/PKGBUILD
+++ b/mingw-w64-neofetch/PKGBUILD
@@ -1,0 +1,22 @@
+
+_realname=neofetch
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=7.1.0
+pkgrel=1
+pkgdesc="neofetch - A command-line system information tool written in bash 3.2+"
+arch=('any')
+license=('MIT')
+url='https://github.com/dylanaraps/neofetch'
+depends=('git')
+source=("${_realname}-${pkgver}.tar.gz"::"$url/archive/$pkgver.tar.gz")
+# noextract=("${_realname}-${pkgver}.tar.gz")
+sha256sums=('58a95e6b714e41efc804eca389a223309169b2def35e57fa934482a6b47c27e7')
+
+
+
+package() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  make PREFIX=${pkgdir}/usr install
+  install -Dm644 LICENSE.md "${pkgdir}/usr/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
Neofetch is a command-line system information tool written in bash 3.2
https://github.com/dylanaraps/neofetch

I originally opened a [pull request](https://github.com/msys2/MSYS2-packages/pull/2385) against msys2/MSYS2-packages, but I don't think that is the correct place for it.