### PR TITLE
gtkspell3: drop gtk2 support

### DIFF
--- a/mingw-w64-gtkspell3/PKGBUILD
+++ b/mingw-w64-gtkspell3/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gtkspell3
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.0.10
-pkgrel=1
+pkgrel=2
 pkgdesc="Provides word-processor-style highlighting and replacement of misspelled words in a GtkTextView widget (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -18,7 +18,6 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-gtk-doc"
              "intltool")
 depends=("${MINGW_PACKAGE_PREFIX}-gtk3"
-         "${MINGW_PACKAGE_PREFIX}-gtk2"
          "${MINGW_PACKAGE_PREFIX}-enchant")
 options=(!libtool strip staticlibs)
 source=(https://sourceforge.net/projects/gtkspell/files/${pkgver}/${_realname}-${pkgver}.tar.xz
@@ -42,7 +41,7 @@ build() {
     --host=${MINGW_CHOST} \
     --enable-shared \
     --disable-static \
-    --enable-gtk2 \
+    --disable-gtk2 \
     --enable-gtk-doc
 
   make


### PR DESCRIPTION
no users and we are trying to get rid of gtk2

Fixes #9500