### PR TITLE
CI: add a diff of package info to [diff] group

### DIFF
--- a/.ci/ci-build.sh
+++ b/.ci/ci-build.sh
@@ -55,6 +55,9 @@ for package in "${packages[@]}"; do
             echo "::endgroup::"
 
             echo "::group::[diff] ${pkgname}"
+            message "Package info diff for ${pkgname}"
+            diff -Nur <(pacman -Si "${pkgname}") <(pacman -Qip "${pkg}") || true
+
             message "File listing diff for ${pkgname}"
             diff -Nur <(pacman -Fl "$pkgname" | sed -e 's|^[^ ]* |/|' | sort) <(pacman -Ql "$pkgname" | sed -e 's|^[^/]*||' | sort) || true
             echo "::endgroup::"
@@ -75,8 +78,11 @@ for package in "${packages[@]}"; do
         echo "::group::[diff] ${package}"
         cd "$package"
         for pkg in *.pkg.tar.*; do
-            message "File listing diff for ${pkg}"
             pkgname="$(echo "$pkg" | rev | cut -d- -f4- | rev)"
+            message "Package info diff for ${pkgname}"
+            diff -Nur <(pacman -Si "${pkgname}") <(pacman -Qip "${pkg}") || true
+
+            message "File listing diff for ${pkgname}"
             diff -Nur <(pacman -Fl "$pkgname" | sed -e 's|^[^ ]* |/|' | sort) <(pacman -Ql "$pkgname" | sed -e 's|^[^/]*||' | sort) || true
         done
         cd - > /dev/null


### PR DESCRIPTION
In #9502 it occurred to me that it would be useful to see package metadata in CI.  This diffs package info from the sync db and package info from the newly-built package file.

For an existing package, this looks like:
```diff
[36m[MSYS2 CI](B[m mingw-w64-qt5-pkgs: Package info diff for mingw-w64-clang-x86_64-qt5-base

--- /dev/fd/63	2021-08-31 19:41:26.000000000 +0000
+++ /dev/fd/62	2021-08-31 19:41:26.000000000 +0000
@@ -1,6 +1,5 @@
-Repository      : clang64
 Name            : mingw-w64-clang-x86_64-qt5-base
-Version         : 5.15.2+kde+r94-4
+Version         : 5.15.2+kde+r96-1
 Description     : A cross-platform application and UI framework (mingw-w64)
 Architecture    : any
 URL             : https://www.qt.io/
@@ -13,9 +12,11 @@
                   mingw-w64-clang-x86_64-postgresql
 Conflicts With  : None
 Replaces        : None
-Download Size   : 153.53 MiB
-Installed Size  : 1145.91 MiB
-Packager        : CI (msys2-autobuild/b738d090/1181184518)
-Build Date      : Mon, Aug 30, 2021  6:57:04 AM
-Validated By    : MD5 Sum  SHA-256 Sum  Signature
+Compressed Size : 22.97 MiB
+Installed Size  : 146.52 MiB
+Packager        : Unknown Packager
+Build Date      : Tue, Aug 31, 2021  5:52:46 PM
+Install Script  : No
+Validated By    : None
+Signatures      : None
 
```

For a new package:
```diff
[36m[MSYS2 CI](B[m mingw-w64-qt5-pkgs: Package info diff for mingw-w64-clang-x86_64-qt5-base-debug

error: package 'mingw-w64-clang-x86_64-qt5-base-debug' was not found
--- /dev/fd/63	2021-08-31 19:41:35.000000000 +0000
+++ /dev/fd/62	2021-08-31 19:41:35.000000000 +0000
@@ -0,0 +1,20 @@
+Name            : mingw-w64-clang-x86_64-qt5-base-debug
+Version         : 5.15.2+kde+r96-1
+Description     : A cross-platform application and UI framework (mingw-w64)
+Architecture    : any
+URL             : https://www.qt.io/
+Licenses        : GPL3  LGPL  FDL  custom
+Groups          : mingw-w64-clang-x86_64-qt5-debug
+Provides        : None
+Depends On      : mingw-w64-clang-x86_64-qt5-base
+Optional Deps   : None
+Conflicts With  : None
+Replaces        : None
+Compressed Size : 129.77 MiB
+Installed Size  : 999.38 MiB
+Packager        : Unknown Packager
+Build Date      : Tue, Aug 31, 2021  5:52:46 PM
+Install Script  : No
+Validated By    : None
+Signatures      : None
+
```

Note that even with no metadata changes there will still be differences, due to differences in the output between `-Si` and `-Qip`:
`-Si` has "Repository", difference in name between "Download Size" vs "Compressed Size" (though they are the same value), and `-Qip` includes "Install Script" and "Signatures".