### PR TITLE
gtk4: fix clang32 build

### DIFF
--- a/mingw-w64-gtk4/PKGBUILD
+++ b/mingw-w64-gtk4/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gtk4
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.4.0
-pkgrel=2
+pkgrel=3
 pkgdesc="GObject-based multi-platform GUI toolkit (v4) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -30,15 +30,21 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-ffmpeg"
          "${MINGW_PACKAGE_PREFIX}-shared-mime-info")
 source=("https://download.gnome.org/sources/gtk/${pkgver:0:3}/gtk-${pkgver}.tar.xz"
-        "3887.patch")
+        "3887.patch"
+        "include-stdlib.patch")
 sha256sums=('e0a1508f441686c3a20dfec48af533b19a4b2e017c18eaee31dccdb7d292505b'
-            '70efcdf6affc8efa7a4e8c03054d46eced3b3c4a401a43da57dc0157e9b71899')
+            '70efcdf6affc8efa7a4e8c03054d46eced3b3c4a401a43da57dc0157e9b71899'
+            '8de14123a4e49b5228c6d469f569272c6950401febe0add29ab01e25254d4677')
+
 
 prepare() {
   cd "${srcdir}/gtk-${pkgver}"
 
   # https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/3887
   patch -p1 -i "${srcdir}"/3887.patch
+
+  # fix for clang32 implicitly-defined malloc
+  patch -Nbp1 -i "${srcdir}"/include-stdlib.patch
 }
 
 build() {

--- a/mingw-w64-gtk4/include-stdlib.patch
+++ b/mingw-w64-gtk4/include-stdlib.patch
@@ -1,0 +1,10 @@
+--- gtk-4.4.0/gtk/gtklabel.c.orig	2021-08-31 19:42:49.109667900 -0700
++++ gtk-4.4.0/gtk/gtklabel.c	2021-08-31 19:43:16.454960100 -0700
+@@ -55,6 +55,7 @@
+ #include "gtkjoinedmenuprivate.h"
+ 
+ #include <math.h>
++#include <stdlib.h>
+ #include <string.h>
+ 
+ /**


### PR DESCRIPTION
```
  ../gtk-4.4.0/gtk/gtklabel.c:3178:14: error: implicitly declaring library function 'malloc' with type 'void *(unsigned int)' [-Werror,-Wimplicit-function-declaration]
    new_text = malloc (strlen (text) + 1);
               ^
  ../gtk-4.4.0/gtk/gtklabel.c:3178:14: note: include the header <stdlib.h> or explicitly provide a declaration for 'malloc'
  1 error generated.
```

I don't know why this didn't fail anywhere else but clang32