### PR TITLE
lasem: 1. Added CVE-2013-7447.patch to fix an overflow.

### DIFF
--- a/mingw-w64-lasem/CVE-2013-7447.patch
+++ b/mingw-w64-lasem/CVE-2013-7447.patch
@@ -1,0 +1,28 @@
+From 6f2feed780d9139a45c06e1ad399d06a4f351fbf Mon Sep 17 00:00:00 2001
+From: RyuzakiKK <aasonykk@gmail.com>
+Date: Sat, 5 Aug 2017 21:40:55 +0200
+Subject: cairo: Avoid integer overflow CVE-2013-7447
+
+lasem is affected by a possible integer overflow, that was also
+found and patched upstream in gtk+
+https://git.gnome.org/browse/gtk+/commit/?id=894b1ae76a32720f4bb3d39cf460402e3ce331d6
+---
+ src/lsmcairo.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/lsmcairo.c b/src/lsmcairo.c
+index c568fd5..73fb93e 100644
+--- a/src/lsmcairo.c
++++ b/src/lsmcairo.c
+@@ -528,7 +528,7 @@ lsm_cairo_set_source_pixbuf (cairo_t *cairo,
+ 		format = CAIRO_FORMAT_ARGB32;
+ 
+ 	cairo_stride = cairo_format_stride_for_width (format, width);
+-	cairo_pixels = g_malloc (height * cairo_stride);
++	cairo_pixels = g_malloc_n (height, cairo_stride);
+ 	surface = cairo_image_surface_create_for_data ((unsigned char *)cairo_pixels,
+ 						       format,
+ 						       width, height, cairo_stride);
+-- 
+cgit v0.12
+

--- a/mingw-w64-lasem/PKGBUILD
+++ b/mingw-w64-lasem/PKGBUILD
@@ -4,38 +4,52 @@ _realname=lasem
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.4.4
-pkgrel=2
+pkgrel=3
 pkgdesc="Lasem aims to be a C/Gobject based SVG/Mathml renderer (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://wiki.gnome.org/Projects/Lasem"
 license=('LGPL')
 license=('GPL' 'MPL' 'LGPL')
+depends=("${MINGW_PACKAGE_PREFIX}-gtk3")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gobject-introspection"
              "${MINGW_PACKAGE_PREFIX}-gdk-pixbuf2"
              "${MINGW_PACKAGE_PREFIX}-glib2"
              "${MINGW_PACKAGE_PREFIX}-gtk-doc"
              "${MINGW_PACKAGE_PREFIX}-cairo"
              "${MINGW_PACKAGE_PREFIX}-pango"
-             "${MINGW_PACKAGE_PREFIX}-libxml2")
-source=("https://download.gnome.org/sources/${_realname}/${pkgver:0:3}/${_realname}-${pkgver}.tar.xz"
+             "${MINGW_PACKAGE_PREFIX}-libxml2"
+             "${MINGW_PACKAGE_PREFIX}-python"
+             "flex"
+             "bison"
+             "intltool"           
+            )
+source=("https://download.gnome.org/sources/${_realname}/${pkgver:0:3}/${_realname}-$pkgver.tar.xz"
+        CVE-2013-7447.patch
         001-fix-doc-install.patch
-        002-no-undefined.patch)
+        002-no-undefined.patch
+        install-mathml-headers.patch)
 sha256sums=('9bf01fcfdc913ebc05989ac1f5902d52e28e7c31f797e2b6d3d413d4b51bba39'
+            'd9e836934655db45e52f6ab1923866a5010a071c1c62fcbcb6c2fd999e978d2c'
             '9c9321e4f2c841d3b348204519b5e508492521f4c2c512ecfb8a083a06dca1e3'
-            '7f98e6d191c53ffe80235258c5114c78e3e7af889c5c07c79ed4134e2be7e3b8')
+            '7f98e6d191c53ffe80235258c5114c78e3e7af889c5c07c79ed4134e2be7e3b8'
+            'bd106104f239557a7e63b7174516b45ea40492b5f02d5bc8abb55efb7e734034')
 
 prepare() {
   cd "${_realname}-${pkgver}"
+  patch -p1 -i ${srcdir}/CVE-2013-7447.patch
   patch -p1 -i ${srcdir}/001-fix-doc-install.patch
   patch -p1 -i ${srcdir}/002-no-undefined.patch
-  autoreconf -fiv
+  patch -p1 -i ${srcdir}/install-mathml-headers.patch
+  autoreconf -fiv 
 }
 
 build() {
-  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
-  mkdir -p ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
-
+  [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}
+  mkdir -p ${srcdir}/build-${MSYSTEM} && cd ${srcdir}/build-${MSYSTEM}
+  #Force intltool to use the MSYS perl version to avoid LibXML issue
+  #That occurs in the Win32 version of Perl with the intltool.
+  INTLTOOL_PERL=/usr/bin/perl \
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
@@ -47,12 +61,13 @@ build() {
   make
 }
 
-# check() {
-#  #   make check
-# }
+check() {
+   cd "${srcdir}/build-${MSYSTEM}"
+   make check
+}
 
 package() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MSYSTEM}"
   make DESTDIR="${pkgdir}" -j1 install
 
   install -Dm644 ${srcdir}/${_realname}-${pkgver}/COPYING ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING

--- a/mingw-w64-lasem/install-mathml-headers.patch
+++ b/mingw-w64-lasem/install-mathml-headers.patch
@@ -1,0 +1,30 @@
+From: Jakub Jirutka <jakub@jirutka.cz>
+Date: Sat, 25 Mar 2017 00:35:00 +0100
+Subject: [PATCH] Install MathML headers
+
+To be honest, I have no clue why MathML headers are not installed by default.
+However, ruby-mathematical needs them and I'm creating this aport for
+ruby-mathematical, so I'm adding them.
+
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -269,7 +269,7 @@
+ liblasem_@LASEM_API_VERSION@_la_SOURCES +=  $(LASEM_MATHML_HDRS) $(LASEM_SVG_HDRS)
+ liblasem_@LASEM_API_VERSION@_la_SOURCES += lsmmathmlenumtypes.h lsmsvgenumtypes.h
+ 
+-liblasem_@LASEM_API_VERSION@_la_HEADERS = $(LASEM_DOM_HDRS)
++liblasem_@LASEM_API_VERSION@_la_HEADERS = $(LASEM_DOM_HDRS) $(LASEM_MATHML_HDRS)
+ liblasem_@LASEM_API_VERSION@_la_HEADERS += lsmdomenumtypes.h
+ 
+ liblasem_@LASEM_API_VERSION@_la_LDFLAGS = -version-info $(LASEM_LIBTOOL_VERSION)
+--- a/src/Makefile.in
++++ b/src/Makefile.in
+@@ -710,7 +710,7 @@
+ 	$(LASEM_MATHML_HDRS) $(LASEM_SVG_HDRS) lsmmathmlenumtypes.h \
+ 	lsmsvgenumtypes.h
+ liblasem_@LASEM_API_VERSION@_la_HEADERS = $(LASEM_DOM_HDRS) \
+-	lsmdomenumtypes.h
++	$(LASEM_MATHML_HDRS) lsmdomenumtypes.h
+ liblasem_@LASEM_API_VERSION@_la_LDFLAGS = -version-info $(LASEM_LIBTOOL_VERSION)
+ lasem_render_@LASEM_API_VERSION@_SOURCES = \
+ 	lasemrender.c


### PR DESCRIPTION
2. Each toolcain gets it's own build files
3. mathml headers are now included for ruby-mathematical.  Uses patch from Alpine Linux.
4. "make check" testsuite is ran for testing.