### PR TITLE
Convert wxWidgets based packages to using single local variable to version of wxWidgets

### DIFF
--- a/mingw-w64-codelite/PKGBUILD
+++ b/mingw-w64-codelite/PKGBUILD
@@ -8,10 +8,10 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 pkgver=15.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Open-source, cross platform IDE for the C/C++ programming languages (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 license=('GPL')
 url="https://www.codelite.org/"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
@@ -99,7 +99,7 @@ build() {
     -DCL_PREFIX=${MINGW_PREFIX} \
     -DENABLE_CLANG=1 \
     -DWITH_WEBVIEW=1 \
-    -DwxWidgets_CONFIG_EXECUTABLE=${MINGW_PREFIX}/bin/wx-config \
+    -DwxWidgets_CONFIG_EXECUTABLE=${MINGW_PREFIX}/bin/wx-config-${_wx_basever} \
     -DwxWidgets_wxrc_EXECUTABLE=${MINGW_PREFIX}/bin/wxrc-${_wx_basever} \
     "${extra_config[@]}" \
     ../${_realname}-${pkgver}

--- a/mingw-w64-filezilla/PKGBUILD
+++ b/mingw-w64-filezilla/PKGBUILD
@@ -1,10 +1,11 @@
 # Maintainer: Andrew Sun <adsun701@gmail.com>
 
 _realname=FileZilla
+_wx_basever=3.0
 pkgbase=mingw-w64-filezilla
 pkgname=("${MINGW_PACKAGE_PREFIX}-filezilla")
 pkgver=3.51.0
-pkgrel=3
+pkgrel=4
 pkgdesc="Fast and reliable FTP, FTPS and SFTP client (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -12,7 +13,7 @@ url="https://lib.filezilla-project.org/"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-gnutls"
          "${MINGW_PACKAGE_PREFIX}-libfilezilla"
-         "${MINGW_PACKAGE_PREFIX}-wxWidgets")
+         "${MINGW_PACKAGE_PREFIX}-wxmsw${_wx_basever}")
 license=('GPL')
 source=("${_realname}-${pkgver}.tar.bz2"::"https://download.filezilla-project.org/client/${_realname}_${pkgver}_src.tar.bz2"
         "0001-fix-datadir-lookup.patch"
@@ -40,7 +41,7 @@ build() {
     --disable-manualupdatecheck \
     --disable-autoupdatecheck \
     --with-pugixml=builtin \
-    --with-wx-config=${MINGW_PREFIX}/bin/wx-config
+    --with-wx-config=${MINGW_PREFIX}/bin/wx-config-${_wx_basever}
 
   make
 }

--- a/mingw-w64-gnuplot/PKGBUILD
+++ b/mingw-w64-gnuplot/PKGBUILD
@@ -4,13 +4,14 @@
 # as it doesnt contain reference for GdipFontFamilyCachedGenericSansSerif
 
 _realname=gnuplot
+_wx_basever=3.0
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=5.4.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Plotting package which outputs to X11, PostScript, PNG, GIF, and others (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='http://www.gnuplot.info/'
 license=('custom')
 depends=("${MINGW_PACKAGE_PREFIX}-cairo"
@@ -20,7 +21,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-cairo"
          "${MINGW_PACKAGE_PREFIX}-libgd"
          "${MINGW_PACKAGE_PREFIX}-pango"
          "${MINGW_PACKAGE_PREFIX}-readline"
-         "${MINGW_PACKAGE_PREFIX}-wxWidgets")
+         "${MINGW_PACKAGE_PREFIX}-wxmsw${_wx_basever}")
 #optdepends=("${MINGW_PACKAGE_PREFIX}-qt5")
 #makedepends=("${MINGW_PACKAGE_PREFIX}-qt5")
 options=('strip' 'staticlibs')

--- a/mingw-w64-plplot/PKGBUILD
+++ b/mingw-w64-plplot/PKGBUILD
@@ -8,12 +8,13 @@
 # Had to define PLD_png and etc to ON to get libGD to be searched.
 
 _realname=plplot
+_wx_basever=3.0
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.15.0
-pkgrel=7
+pkgrel=8
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 pkgdesc="Scientific plotting software (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-cairo"
          "${MINGW_PACKAGE_PREFIX}-gcc-libs"
@@ -25,7 +26,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-cairo"
          "${MINGW_PACKAGE_PREFIX}-python3-numpy"
          "${MINGW_PACKAGE_PREFIX}-shapelib"
          "${MINGW_PACKAGE_PREFIX}-tk"
-         "${MINGW_PACKAGE_PREFIX}-wxWidgets"
+         "${MINGW_PACKAGE_PREFIX}-wxmsw${_wx_basever}"
          "${MINGW_PACKAGE_PREFIX}-qhull"
         )
 makedepends=("${MINGW_PACKAGE_PREFIX}-libgd"

--- a/mingw-w64-wxSVG/PKGBUILD
+++ b/mingw-w64-wxSVG/PKGBUILD
@@ -1,16 +1,17 @@
 # Maintainer: Jordan Irwin <antumdeluge@gmail.com>
 
 _realname=wxsvg
+_wx_basever=3.0
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgbase="mingw-w64-${_realname}"
 pkgver=1.5.22
-pkgrel=3
+pkgrel=4
 pkgdesc="A C++ library to create, manipulate and render SVG files (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="http://wxsvg.sourceforge.net/"
 license=("custom:wxWindows")
-depends=("${MINGW_PACKAGE_PREFIX}-wxWidgets"
+depends=("${MINGW_PACKAGE_PREFIX}-wxmsw${_wx_basever}"
          "${MINGW_PACKAGE_PREFIX}-cairo"
          "${MINGW_PACKAGE_PREFIX}-pango"
          "${MINGW_PACKAGE_PREFIX}-expat"
@@ -39,6 +40,7 @@ build() {
       --host=${MINGW_CHOST} \
       --target=${MINGW_CHOST} \
       --build=${MINGW_CHOST} \
+      --with-wx-config=${MINGW_PREFIX}/bin/wx-config-${_wx_basever} \
       --enable-shared \
       --enable-static
   make


### PR DESCRIPTION
This change will make it easier to change to wxWidgets version 3.2 when it is released sometime this decade. Or to version 3.1.

I also added 'clang32' as a arch if missing.

Tim S.
