### PR TITLE
extra-cmake-modules: pass --force-local to GNU tar

### DIFF
--- a/mingw-w64-extra-cmake-modules/PKGBUILD
+++ b/mingw-w64-extra-cmake-modules/PKGBUILD
@@ -5,7 +5,7 @@ _realname=extra-cmake-modules
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.84.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Extra CMake modules (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -18,15 +18,18 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-python-sphinx"
              "${MINGW_PACKAGE_PREFIX}-python-requests")
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_realname}-${pkgver}.tar.xz"{,.sig}
-        "set-AUTOSTATICPLUGINS.patch")
+        "set-AUTOSTATICPLUGINS.patch"
+        "tar-force-local.patch")
 sha256sums=('bb085ef2e177c182ff46988516b6b31849d1497beb2ff5301165ad2ba12a1c41'
             'SKIP'
-            'a246d25065ac7472b3a4e5995b3c6cb32081ffa21c7de7455006398431e6c886')
+            'a246d25065ac7472b3a4e5995b3c6cb32081ffa21c7de7455006398431e6c886'
+            'a57f57a8734326eac06efcf8d7e749b79d4035b644a95ddefd4dfda96c3b5428')
 validpgpkeys=('53E6B47B45CEA3E0D5B7457758D0EE648A48B3BB') # David Faure <faure@kde.org>
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   patch -Np1 -i "${srcdir}/set-AUTOSTATICPLUGINS.patch"
+  patch -Np1 -i "${srcdir}/tar-force-local.patch"
 }
 
 build() {

--- a/mingw-w64-extra-cmake-modules/tar-force-local.patch
+++ b/mingw-w64-extra-cmake-modules/tar-force-local.patch
@@ -1,0 +1,20 @@
+--- extra-cmake-modules-5.84.0/kde-modules/KDEPackageAppTemplates.cmake.orig	2021-09-01 19:40:22.261765400 -0700
++++ extra-cmake-modules-5.84.0/kde-modules/KDEPackageAppTemplates.cmake	2021-09-01 19:41:32.902015700 -0700
+@@ -88,7 +88,7 @@
+         # NOTE: we also pass `--sort=name` here to check if the tar exe supports that
+         #       this feature was only added in gnu tar v1.28
+         execute_process(
+-            COMMAND ${_tar_executable} --sort=name --version
++            COMMAND ${_tar_executable} --sort=name --force-local --version
+             TIMEOUT 3
+             RESULT_VARIABLE _tar_exit
+             OUTPUT_VARIABLE _tar_version
+@@ -118,7 +118,7 @@
+                 COMMAND ${_tar_executable} ARGS -c
+                    --exclude .kdev_ignore --exclude .svn --sort=name --mode=go=rX,u+rw,a-s --owner=root
+                    --pax-option=exthdr.name=%d/PaxHeaders/%f,atime:=0,ctime:=0
+-                   --group=root --numeric-owner -j -v -f ${_template} .
++                   --group=root --numeric-owner -j -v --force-local -f ${_template} .
+                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${_templateName}
+                 DEPENDS ${_subdirs_entries}
+             )

--- a/mingw-w64-kparts-qt5/PKGBUILD
+++ b/mingw-w64-kparts-qt5/PKGBUILD
@@ -5,7 +5,7 @@ _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kparts"
 pkgver=5.75.0
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 pkgdesc="Document centric plugin system (mingw-w64-qt5${_namesuff})"


### PR DESCRIPTION
It looks for GNU tar, and if found uses it instead of cmake tar functionality, in order to produce a "reproducible" tar file.  Unfortunately, GNU tar assumes a filename with a colon in it is a remote file (`host:path`), not a Windows drive letter (`X:\path`).  Pass the `--force-local` option to tell it not to make that assumption.

If somebody with an account with KDE wants to send that [upstream](https://invent.kde.org/frameworks/extra-cmake-modules/-/blob/master/kde-modules/KDEPackageAppTemplates.cmake), that'd be great.