### PR TITLE
clang: Remove unnecessary pkgrel version dependency.

### DIFF
--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -28,7 +28,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
            "${MINGW_PACKAGE_PREFIX}-openmp")
          "${MINGW_PACKAGE_PREFIX}-polly")
 pkgver=12.0.1
-pkgrel=5
+pkgrel=6
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -456,12 +456,12 @@ check() {
 package_clang() {
   pkgdesc="C language family frontend for LLVM (mingw-w64)"
   url="https://clang.llvm.org/"
-  depends=("${MINGW_PACKAGE_PREFIX}-llvm=${pkgver}-${pkgrel}"
+  depends=("${MINGW_PACKAGE_PREFIX}-llvm=${pkgver}"
            $( ((_clangprefix)) && echo \
-             "${MINGW_PACKAGE_PREFIX}-compiler-rt=${pkgver}-${pkgrel}" \
+             "${MINGW_PACKAGE_PREFIX}-compiler-rt=${pkgver}" \
              "${MINGW_PACKAGE_PREFIX}-crt" \
              "${MINGW_PACKAGE_PREFIX}-headers" \
-             "${MINGW_PACKAGE_PREFIX}-lld=${pkgver}-${pkgrel}" \
+             "${MINGW_PACKAGE_PREFIX}-lld=${pkgver}" \
              "${MINGW_PACKAGE_PREFIX}-winpthreads" \
              || echo "${MINGW_PACKAGE_PREFIX}-gcc"))
   provides=($( (( _clangprefix )) && echo \
@@ -474,7 +474,7 @@ package_clang() {
 package_clang-analyzer() {
   pkgdesc="A source code analysis framework (mingw-w64)"
   url="https://clang-analyzer.llvm.org/"
-  depends=("${MINGW_PACKAGE_PREFIX}-clang=${pkgver}-${pkgrel}"
+  depends=("${MINGW_PACKAGE_PREFIX}-clang=${pkgver}"
            "${MINGW_PACKAGE_PREFIX}-python")
 
   DESTDIR="${pkgdir}" cmake --install "${srcdir}/build-${MSYSTEM}/tools/clang/tools/scan-build"
@@ -489,7 +489,7 @@ package_clang-analyzer() {
 package_clang-tools-extra() {
   pkgdesc="Extra tools built using Clang's tooling APIs (mingw-w64)"
   url="https://clang.llvm.org/"
-  depends=("${MINGW_PACKAGE_PREFIX}-clang=${pkgver}-${pkgrel}")
+  depends=("${MINGW_PACKAGE_PREFIX}-clang=${pkgver}")
 
   DESTDIR="${pkgdir}" cmake --install "${srcdir}/build-${MSYSTEM}/tools/clang/tools/extra"
 }
@@ -550,7 +550,7 @@ package_libunwind() {
 package_lld() {
   pkgdesc="Linker tools for LLVM (mingw-w64)"
   url="https://lld.llvm.org/"
-  depends=("${MINGW_PACKAGE_PREFIX}-llvm=${pkgver}-${pkgrel}")
+  depends=("${MINGW_PACKAGE_PREFIX}-llvm=${pkgver}")
   provides=($( (( _clangprefix )) && echo \
              "${MINGW_PACKAGE_PREFIX}-binutils" \
              || true))
@@ -564,7 +564,7 @@ package_lld() {
 package_lldb() {
   pkgdesc="Next generation, high-performance debugger (mingw-w64)"
   url="https://lldb.llvm.org/"
-  depends=("${MINGW_PACKAGE_PREFIX}-clang=${pkgver}-${pkgrel}"
+  depends=("${MINGW_PACKAGE_PREFIX}-clang=${pkgver}"
            "${MINGW_PACKAGE_PREFIX}-libxml2"
            "${MINGW_PACKAGE_PREFIX}-lua"
            "${MINGW_PACKAGE_PREFIX}-python"
@@ -608,7 +608,7 @@ package_llvm() {
 package_polly() {
   pkgdesc="Polly - Polyhedral optimizations for LLVM (mingw-w64)"
   url="https://polly.llvm.org/"
-  depends=("${MINGW_PACKAGE_PREFIX}-llvm=${pkgver}-${pkgrel}")
+  depends=("${MINGW_PACKAGE_PREFIX}-llvm=${pkgver}")
 
   DESTDIR="${pkgdir}" cmake --install "${srcdir}/build-${MSYSTEM}/tools/polly"
   # fix cmake files.


### PR DESCRIPTION
They all built from the same PKGBUILD, no need to mention the version.