### PR TITLE
kirigami2-qt5: fix clang build

### DIFF
--- a/mingw-w64-kirigami2-qt5/002-template-dllexport-static.patch
+++ b/mingw-w64-kirigami2-qt5/002-template-dllexport-static.patch
@@ -1,0 +1,38 @@
+--- kirigami2-5.83.0/src/libkirigami/platformtheme.h.orig	2021-09-03 22:52:20.528455700 -0700
++++ kirigami2-5.83.0/src/libkirigami/platformtheme.h	2021-09-03 22:54:51.310277400 -0700
+@@ -352,7 +352,7 @@
+ // of these events.
+ 
+ template<typename T>
+-class KIRIGAMI2_EXPORT PropertyChangedEvent : public QEvent
++class PropertyChangedEvent : public QEvent
+ {
+ public:
+     PropertyChangedEvent(PlatformTheme *theme, const T &previous, const T &current)
+@@ -367,7 +367,7 @@
+     T oldValue;
+     T newValue;
+ 
+-    static QEvent::Type type;
++    static KIRIGAMI2_EXPORT QEvent::Type type;
+ };
+ 
+ using DataChangedEvent = PropertyChangedEvent<std::shared_ptr<PlatformThemeData>>;
+@@ -376,6 +376,17 @@
+ using ColorChangedEvent = PropertyChangedEvent<QColor>;
+ using FontChangedEvent = PropertyChangedEvent<QFont>;
+ 
++template<>
++KIRIGAMI2_EXPORT QEvent::Type DataChangedEvent::type;
++template<>
++KIRIGAMI2_EXPORT QEvent::Type ColorSetChangedEvent::type;
++template<>
++KIRIGAMI2_EXPORT QEvent::Type ColorGroupChangedEvent::type;
++template<>
++KIRIGAMI2_EXPORT QEvent::Type ColorChangedEvent::type;
++template<>
++KIRIGAMI2_EXPORT QEvent::Type FontChangedEvent::type;
++
+ }
+ 
+ } // namespace Kirigami

--- a/mingw-w64-kirigami2-qt5/PKGBUILD
+++ b/mingw-w64-kirigami2-qt5/PKGBUILD
@@ -6,6 +6,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _kde_f5_init_package "${_variant}" "kirigami2"
 pkgver=5.85.0
 pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 pkgdesc="A QtQuick based components set (mingw-w64-qt5${_namesuff})"
@@ -16,10 +17,12 @@ depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}"
 groups=("${MINGW_PACKAGE_PREFIX}-kf5")
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz"{,.sig}
-        "001-cmake-disable-template.patch")
+        "001-cmake-disable-template.patch"
+        "002-template-dllexport-static.patch")
 sha256sums=('33d22381cf6058c3dc54109e31f710f07452ef9baf669d4264659c5c7fd7ad2b'
             'SKIP'
-            '07cb813248ce8f0306eacf7ae8f65f0515dbad2681bd06cb962bf9c8ef553d57')
+            '07cb813248ce8f0306eacf7ae8f65f0515dbad2681bd06cb962bf9c8ef553d57'
+            '93cdeafafbaf5c9fb75bbd8066b68cbf08c2f217dcde9a5a6a4f84f0fadd7c08')
 validpgpkeys=('53E6B47B45CEA3E0D5B7457758D0EE648A48B3BB') # David Faure <faure@kde.org>
 
 prepare() {
@@ -27,6 +30,8 @@ prepare() {
 
   cd ${_basename}-${pkgver}
   patch -p1 -i "${srcdir}/001-cmake-disable-template.patch"
+  # https://bugs.llvm.org/show_bug.cgi?id=38109
+  patch -p1 -i "${srcdir}/002-template-dllexport-static.patch"
 }
 
 build() {


### PR DESCRIPTION
Fix a pretty vexatious issue with a `dllexport`ed template class on clang.  Clang apparently treats a dllexport attribute on a template class as an implicit instantiation (over what template parameters?), which causes an error if there are then explicit specializations.  Instead, only export the member of the class that needs to be exported, which is actually the member being explicitly specialized.

Also add explicit specialization declarations, to satisfy a clang warning.

I originally thought moving the export from the class to the static member would result in different exports from the dll (the vtable, typeinfo, and destructor were being exported by GCC), but a diff of the export table of the mingw64 dll before and after this patch didn't show that.  Also, no dependent package actually imports those symbols (actually, amazingly, no dependent package actually imports the libKF5Kirigami2.dll - I guess they all use qml?)

https://github.com/msys2/MINGW-packages/discussions/7589#discussioncomment-1197007
https://bugs.llvm.org/show_bug.cgi?id=38109
and
https://github.com/msys2/MINGW-packages/pull/9523#issuecomment-912912480