### PR TITLE
Fix ci-get-build-order with some PKGBUILDs

### DIFF
--- a/.ci/ci-get-build-order.py
+++ b/.ci/ci-get-build-order.py
@@ -47,7 +47,7 @@ def get_pkginfo(package, packageset):
 
     shell = os.environ.get("SHELL", "bash")
     env = {**os.environ, "MINGW_PACKAGE_PREFIX": "mingw-w64"}
-    results = run(shell, "-ce", script, env=env).split("\0")[:-1]
+    results = run(shell, "-c", script, env=env).split("\0")[:-1]
     assert len(props) == len(results), "Length of props matches results"
 
     info = {}
@@ -74,7 +74,7 @@ def get_build_order(packages, toadd=None, ordered=None):
 
         pkg = toadd[package]
         if pkg.processed:
-            print("warning: dependency cycle detected on", package)
+            print("warning: dependency cycle detected on", package, file=sys.stderr)
             continue
         pkg.processed = True
 

--- a/mingw-w64-perl/PKGBUILD
+++ b/mingw-w64-perl/PKGBUILD
@@ -6,7 +6,6 @@
 declare -rga _realname=(perl perl-doc)
 pkgname=()
 declare -gA _pkgname=()
-local _n _p
 for _n in "${_realname[@]}"; do
     _p="${MINGW_PACKAGE_PREFIX}-${_n}"
     _pkgname["${_n}"]="${_p}"


### PR DESCRIPTION
Not all PKGBUILDs source cleanly with `set -e` on (should they?):

```
mingw-w64-blender
mingw-w64-clang
mingw-w64-qt5-static
mingw-w64-rust
mingw-w64-zlib
```

That's because they make use of ternaries like

```
 $([[ "$_variant" == "-shared" ]] && echo \
            $([[ "$_system_assimp" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-assimp") \
            $([[ "$_system_doubleconversion" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-double-conversion") \
...
```

Not sure if anyone has any strong thoughts on whether or not that matters.