### PR TITLE
add missing mingw_arch to PKGBUILDs

### DIFF
--- a/mingw-w64-doctest/PKGBUILD
+++ b/mingw-w64-doctest/PKGBUILD
@@ -5,6 +5,7 @@ pkgver=2.4.6
 pkgrel=1
 pkgdesc='A lightweight C++ header-only unit testing framework (mingw-w64)'
 arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://github.com/onqtam/doctest'
 license=('MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake")

--- a/mingw-w64-ideviceinstaller/PKGBUILD
+++ b/mingw-w64-ideviceinstaller/PKGBUILD
@@ -7,6 +7,7 @@ pkgver=1.1.1
 pkgrel=1
 pkgdesc='Manage apps of iOS devices (mingw-w64)'
 arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://www.libimobiledevice.org/'
 license=('GPL2+')
 source=("${_realname}-${pkgver}.tar.gz"::https://github.com/libimobiledevice/ideviceinstaller/archive/${pkgver}.tar.gz)

--- a/mingw-w64-libopenmpt-modplug/PKGBUILD
+++ b/mingw-w64-libopenmpt-modplug/PKGBUILD
@@ -7,6 +7,7 @@ pkgver=0.8.9.0
 pkgrel=2
 pkgdesc="A compat layer/bridge from libmodplug to libopenmpt (mingw-w64)"
 arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://lib.openmpt.org"
 license=("BSD")
 depends=("${MINGW_PACKAGE_PREFIX}-libopenmpt")

--- a/mingw-w64-libopenmpt-modplug/PKGBUILD
+++ b/mingw-w64-libopenmpt-modplug/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libopenmpt-modplug
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.8.9.0
-pkgrel=2
+pkgrel=3
 pkgdesc="A compat layer/bridge from libmodplug to libopenmpt (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -18,6 +18,12 @@ provides=("${MINGW_PACKAGE_PREFIX}-libmodplug")
 options=('staticlibs' 'strip')
 source=("https://lib.openmpt.org/files/${_realname}/${_realname}-${pkgver}-openmpt1.tar.gz")
 sha256sums=('ecce1a0eecfdb0b5824cab89c270dce59596295a2c17c2b043215ecf4d7c4ff7')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}-openmpt1"
+  # autoreconf to get updated libtool files with clang support
+  autoreconf -fiv
+}
 
 build() {
   [[ -d ${srcdir}/build-${CARCH} ]] && rm -rf ${srcdir}/build-${CARCH}

--- a/mingw-w64-pyqt6-sip/PKGBUILD
+++ b/mingw-w64-pyqt6-sip/PKGBUILD
@@ -7,6 +7,7 @@ pkgver=13.1.0
 pkgrel=1
 pkgdesc="The sip module support for PyQt6 (mingw-w64)"
 arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 license=('GPL')
 url="https://riverbankcomputing.com/software/pyqt"
 depends=("${MINGW_PACKAGE_PREFIX}-python")

--- a/mingw-w64-pyqt6/PKGBUILD
+++ b/mingw-w64-pyqt6/PKGBUILD
@@ -4,7 +4,7 @@ _realname=pyqt6
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=6.1.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Python bindings for the Qt cross platform application toolkit (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -46,7 +46,7 @@ build() {
     --confirm-license \
     --no-make \
     --api-dir=${MINGW_PREFIX}/share/qt6/qsci/api/python \
-    --qmake=${MINGW_PREFIX}/bin/qmake.exe \
+    --qmake=${MINGW_PREFIX}/bin/qmake6.exe \
     --verbose
 
     cd build

--- a/mingw-w64-pyqt6/PKGBUILD
+++ b/mingw-w64-pyqt6/PKGBUILD
@@ -7,6 +7,7 @@ pkgver=6.1.1
 pkgrel=1
 pkgdesc="Python bindings for the Qt cross platform application toolkit (mingw-w64)"
 arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 license=('GPL')
 url="https://riverbankcomputing.com/software/pyqt"
 depends=("${MINGW_PACKAGE_PREFIX}-python"

--- a/mingw-w64-python-click-default-group/PKGBUILD
+++ b/mingw-w64-python-click-default-group/PKGBUILD
@@ -8,6 +8,7 @@ pkgver=1.2.2
 pkgrel=2
 pkgdesc='Extends click.Group to invoke a command without explicit subcommand name (mingw-w64)'
 arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://github.com/sublee/click-default-group/"
 license=('BSD')
 depends=(

--- a/mingw-w64-python-cloup/PKGBUILD
+++ b/mingw-w64-python-cloup/PKGBUILD
@@ -8,6 +8,7 @@ pkgver=0.7.1
 pkgrel=2
 pkgdesc='Option groups and subcommand help sections for pallets/click (mingw-w64)'
 arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://github.com/janLuke/cloup"
 license=('MIT')
 depends=(

--- a/mingw-w64-python-moderngl-window/PKGBUILD
+++ b/mingw-w64-python-moderngl-window/PKGBUILD
@@ -8,6 +8,7 @@ pkgver=2.3.0
 pkgrel=2
 pkgdesc='A cross platform helper library for ModernGL making window creation and resource loading simple (mingw-w64)'
 arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://github.com/moderngl/moderngl_window"
 license=('MIT')
 depends=(

--- a/mingw-w64-python-multipledispatch/PKGBUILD
+++ b/mingw-w64-python-multipledispatch/PKGBUILD
@@ -8,6 +8,7 @@ pkgver=0.6.0
 pkgrel=2
 pkgdesc='Multiple dispatch (mingw-w64)'
 arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://pypi.org/project/multipledispatch/"
 license=('BSD')
 depends=(

--- a/mingw-w64-python-pyrr/PKGBUILD
+++ b/mingw-w64-python-pyrr/PKGBUILD
@@ -8,6 +8,7 @@ pkgver=0.10.3
 pkgrel=2
 pkgdesc='3D mathematical functions using NumPy (mingw-w64)'
 arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://github.com/adamlwgriffiths/Pyrr"
 license=('BSD')
 depends=(

--- a/mingw-w64-python-tzdata/PKGBUILD
+++ b/mingw-w64-python-tzdata/PKGBUILD
@@ -7,6 +7,7 @@ pkgver=2021.1
 pkgrel=1
 pkgdesc=" Python package wrapping the IANA time zone database (mingw-w64)"
 arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://github.com/python/tzdata'
 license=('Apache-2.0')
 depends=("${MINGW_PACKAGE_PREFIX}-python")

--- a/mingw-w64-sqlitebrowser/PKGBUILD
+++ b/mingw-w64-sqlitebrowser/PKGBUILD
@@ -8,6 +8,7 @@ pkgrel=3
 pkgdesc='SQLite Database browser is a Qt GUI editor for SQLite databases (mingw-w64)'
 url='https://sqlitebrowser.org/'
 arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 license=('GPL3')
 depends=("${MINGW_PACKAGE_PREFIX}-qt5-base"
          "${MINGW_PACKAGE_PREFIX}-sqlite3")

--- a/mingw-w64-talkatu/PKGBUILD
+++ b/mingw-w64-talkatu/PKGBUILD
@@ -5,6 +5,7 @@ pkgver=0.1.0.r419.ebabd7682683
 pkgrel=1
 pkgdesc="Gtk+ widgets for chat software (mingw-w64)"
 arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://keep.imfreedom.org/talkatu/talkatu'
 license=('GPL2')
 depends=(

--- a/mingw-w64-texlive-bin/PKGBUILD
+++ b/mingw-w64-texlive-bin/PKGBUILD
@@ -7,6 +7,7 @@ pkgdesc="TeX Live binaries (mingw-w64)"
 pkgrel=9
 license=('GPL')
 arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 url='https://tug.org/texlive/'
 makedepends=(
     "${MINGW_PACKAGE_PREFIX}-perl"

--- a/mingw-w64-tzdata/PKGBUILD
+++ b/mingw-w64-tzdata/PKGBUILD
@@ -7,6 +7,7 @@ pkgver=2021a
 pkgrel=1
 pkgdesc="Sources for time zone and daylight saving time data (mingw-w64)"
 arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://www.iana.org/time-zones"
 license=('custom: public domain')
 options=('!emptydirs')

--- a/mingw-w64-vala-language-server/PKGBUILD
+++ b/mingw-w64-vala-language-server/PKGBUILD
@@ -7,6 +7,7 @@ pkgver=0.48.3
 pkgrel=3
 pkgdesc="Vala Language Server for the Vala programming language (mingw-w64)"
 arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://github.com/Prince781/vala-language-server"
 license=("LGPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-vala>=0.48.12"

--- a/mingw-w64-wwrando/PKGBUILD
+++ b/mingw-w64-wwrando/PKGBUILD
@@ -7,6 +7,7 @@ pkgver=1.9.0
 pkgrel=4
 pkgdesc="Wind Waker Randomizer (mingw-w64)"
 arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://github.com/LagoLunatic/wwrando"
 license=('MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-python" "${MINGW_PACKAGE_PREFIX}-pyside2-qt5" "${MINGW_PACKAGE_PREFIX}-python-yaml" "${MINGW_PACKAGE_PREFIX}-python-pillow")


### PR DESCRIPTION
These packages were being overlooked by my script to enable packages for clang32, as it only looked to add clang32 to mingw_arch, not add mingw_arch if it wasn't present.

Of course, nothing comes easy, so a couple of packages needed fixing to build:
* libopenmpt-modplug: autoreconf for clang
* pyqt6: use qmake6.exe instead of qmake.exe which isn't present

These are all enabled for clang32, except for texlive-bin, as it is indirectly blocked by lack of rust