### PR TITLE
spice-gtk: Enable clang64 build

### DIFF
--- a/mingw-w64-spice-gtk/002-export-symbols.patch
+++ b/mingw-w64-spice-gtk/002-export-symbols.patch
@@ -1,0 +1,63 @@
+diff -Naur spice-gtk-0.39.orig/src/meson.build spice-gtk-0.39/src/meson.build
+--- spice-gtk-0.39.orig/src/meson.build	2020-12-01 17:31:58.770751000 +0100
++++ spice-gtk-0.39/src/meson.build	2021-09-19 14:37:59.316849400 +0200
+@@ -186,9 +186,9 @@
+ spice_gtk_version_script = '-Wl,--version-script=@0@'.format(spice_client_glib_syms_path)
+ spice_gtk_has_version_script = compiler.has_link_argument(spice_gtk_version_script)
+ if not spice_gtk_has_version_script
+-  spice_client_glib_syms = files('spice-glib-sym-file')
+-  spice_client_glib_syms_path = meson.current_source_dir() / 'spice-glib-sym-file'
+-  spice_gtk_version_script = ['-export-symbols', spice_client_glib_syms_path]
++  spice_client_glib_syms = files('spice-glib-sym-file.def')
++  spice_client_glib_syms_path = meson.current_source_dir() / 'spice-glib-sym-file.def'
++  spice_gtk_version_script = ['', spice_client_glib_syms_path]
+ endif
+ 
+ # soversion
+@@ -387,9 +387,9 @@
+   #
+   spice_client_gtk_syms = spice_client_glib_syms
+   if not spice_gtk_has_version_script
+-    spice_client_gtk_syms = files('spice-gtk-sym-file')
+-    spice_client_gtk_syms_path = meson.current_source_dir() / 'spice-gtk-sym-file'
+-    spice_gtk_version_script = ['-export-symbols', spice_client_gtk_syms_path]
++    spice_client_gtk_syms = files('spice-gtk-sym-file.def')
++    spice_client_gtk_syms_path = meson.current_source_dir() / 'spice-gtk-sym-file.def'
++    spice_gtk_version_script = ['', spice_client_gtk_syms_path]
+   endif
+ 
+   # soversion
+diff -Naur spice-gtk-0.39.orig/src/spice-glib-sym-file.def spice-gtk-0.39/src/spice-glib-sym-file.def
+--- spice-gtk-0.39.orig/src/spice-glib-sym-file.def	2020-12-01 17:31:58.774751000 +0100
++++ spice-gtk-0.39/src/spice-glib-sym-file.def	2021-09-19 15:01:17.656147700 +0200
+@@ -1,3 +1,5 @@
++LIBRARY "libspice-client-glib-2.0-8.dll"
++EXPORTS
+ spice_audio_get
+ spice_audio_get_type
+ spice_audio_new
+@@ -151,6 +153,7 @@
+ spice_usb_device_manager_can_redirect_device
+ spice_usb_device_manager_connect_device_async
+ spice_usb_device_manager_connect_device_finish
++spice_usb_device_manager_create_shared_cd_device
+ spice_usb_device_manager_disconnect_device
+ spice_usb_device_manager_disconnect_device_async
+ spice_usb_device_manager_disconnect_device_finish
+@@ -159,6 +162,7 @@
+ spice_usb_device_manager_get_devices_with_filter
+ spice_usb_device_manager_get_type
+ spice_usb_device_manager_is_device_connected
++spice_usb_device_manager_is_device_shared_cd
+ spice_usb_device_manager_is_redirecting
+ spice_usbredir_channel_get_type
+ spice_util_get_debug
+diff -Naur spice-gtk-0.39.orig/src/spice-gtk-sym-file.def spice-gtk-0.39/src/spice-gtk-sym-file.def
+--- spice-gtk-0.39.orig/src/spice-gtk-sym-file.def	2020-12-01 17:31:58.775750900 +0100
++++ spice-gtk-0.39/src/spice-gtk-sym-file.def	2021-09-19 14:49:38.462620100 +0200
+@@ -1,3 +1,5 @@
++LIBRARY "libspice-client-gtk-3.0-5.dll"
++EXPORTS
+ spice_display_get_grab_keys
+ spice_display_get_pixbuf
+ spice_display_get_type

--- a/mingw-w64-spice-gtk/002-export-symbols.patch
+++ b/mingw-w64-spice-gtk/002-export-symbols.patch
@@ -1,37 +1,56 @@
-diff -Naur spice-gtk-0.39.orig/src/meson.build spice-gtk-0.39/src/meson.build
---- spice-gtk-0.39.orig/src/meson.build	2020-12-01 17:31:58.770751000 +0100
-+++ spice-gtk-0.39/src/meson.build	2021-09-19 14:37:59.316849400 +0200
-@@ -186,9 +186,9 @@
+diff --git a/src/meson.build b/src/meson.build
+index 50e27d9..d3b43e8 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -186,9 +186,8 @@ spice_client_glib_syms_path = meson.current_source_dir() / 'map-file'
  spice_gtk_version_script = '-Wl,--version-script=@0@'.format(spice_client_glib_syms_path)
  spice_gtk_has_version_script = compiler.has_link_argument(spice_gtk_version_script)
  if not spice_gtk_has_version_script
 -  spice_client_glib_syms = files('spice-glib-sym-file')
 -  spice_client_glib_syms_path = meson.current_source_dir() / 'spice-glib-sym-file'
 -  spice_gtk_version_script = ['-export-symbols', spice_client_glib_syms_path]
-+  spice_client_glib_syms = files('spice-glib-sym-file.def')
-+  spice_client_glib_syms_path = meson.current_source_dir() / 'spice-glib-sym-file.def'
-+  spice_gtk_version_script = ['', spice_client_glib_syms_path]
++  spice_client_glib_syms = []
++  spice_gtk_version_script = []
  endif
  
  # soversion
-@@ -387,9 +387,9 @@
+@@ -207,7 +206,8 @@ spice_client_glib_lib = library('spice-client-glib-2.0', spice_client_glib_sourc
+                                 include_directories : spice_gtk_include,
+                                 link_args : [spice_gtk_version_script],
+                                 link_depends : spice_client_glib_syms,
+-                                dependencies : spice_glib_deps)
++                                dependencies : spice_glib_deps,
++                                vs_module_defs : 'spice-glib-sym-file.def')
+ 
+ spice_client_glib_dep = declare_dependency(sources : [spice_marshals[1], spice_client_glib_enums[1]],
+                                            link_with : spice_client_glib_lib,
+@@ -386,11 +386,6 @@ if spice_gtk_has_gtk
+   # libspice-client-gtk.so
    #
    spice_client_gtk_syms = spice_client_glib_syms
-   if not spice_gtk_has_version_script
+-  if not spice_gtk_has_version_script
 -    spice_client_gtk_syms = files('spice-gtk-sym-file')
 -    spice_client_gtk_syms_path = meson.current_source_dir() / 'spice-gtk-sym-file'
 -    spice_gtk_version_script = ['-export-symbols', spice_client_gtk_syms_path]
-+    spice_client_gtk_syms = files('spice-gtk-sym-file.def')
-+    spice_client_gtk_syms_path = meson.current_source_dir() / 'spice-gtk-sym-file.def'
-+    spice_gtk_version_script = ['', spice_client_gtk_syms_path]
-   endif
+-  endif
  
    # soversion
-diff -Naur spice-gtk-0.39.orig/src/spice-glib-sym-file.def spice-gtk-0.39/src/spice-glib-sym-file.def
---- spice-gtk-0.39.orig/src/spice-glib-sym-file.def	2020-12-01 17:31:58.774751000 +0100
-+++ spice-gtk-0.39/src/spice-glib-sym-file.def	2021-09-19 15:01:17.656147700 +0200
-@@ -1,3 +1,5 @@
-+LIBRARY "libspice-client-glib-2.0-8.dll"
+   # http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
+@@ -407,7 +402,8 @@ if spice_gtk_has_gtk
+                                  install : true,
+                                  link_args : [spice_gtk_version_script],
+                                  link_depends : spice_client_gtk_syms,
+-                                 dependencies : [spice_client_glib_dep, spice_gtk_deps, spice_wayland_deps])
++                                 dependencies : [spice_client_glib_dep, spice_gtk_deps, spice_wayland_deps],
++                                 vs_module_defs : 'spice-gtk-sym-file.def')
+ 
+   spice_client_gtk_dep = declare_dependency(sources : spice_widget_enums[1],
+                                             link_with : spice_client_gtk_lib,
+diff --git a/src/spice-glib-sym-file.def b/src/spice-glib-sym-file.def
+index 2cc80aa..baa63bd 100644
+--- a/src/spice-glib-sym-file.def
++++ b/src/spice-glib-sym-file.def
+@@ -1,3 +1,4 @@
 +EXPORTS
  spice_audio_get
  spice_audio_get_type
@@ -52,11 +71,11 @@ diff -Naur spice-gtk-0.39.orig/src/spice-glib-sym-file.def spice-gtk-0.39/src/sp
  spice_usb_device_manager_is_redirecting
  spice_usbredir_channel_get_type
  spice_util_get_debug
-diff -Naur spice-gtk-0.39.orig/src/spice-gtk-sym-file.def spice-gtk-0.39/src/spice-gtk-sym-file.def
---- spice-gtk-0.39.orig/src/spice-gtk-sym-file.def	2020-12-01 17:31:58.775750900 +0100
-+++ spice-gtk-0.39/src/spice-gtk-sym-file.def	2021-09-19 14:49:38.462620100 +0200
-@@ -1,3 +1,5 @@
-+LIBRARY "libspice-client-gtk-3.0-5.dll"
+diff --git a/src/spice-gtk-sym-file.def b/src/spice-gtk-sym-file.def
+index 5ba57cb..34ad225 100644
+--- a/src/spice-gtk-sym-file.def
++++ b/src/spice-gtk-sym-file.def
+@@ -1,3 +1,4 @@
 +EXPORTS
  spice_display_get_grab_keys
  spice_display_get_pixbuf

--- a/mingw-w64-spice-gtk/PKGBUILD
+++ b/mingw-w64-spice-gtk/PKGBUILD
@@ -36,7 +36,7 @@ source=(https://www.spice-space.org/download/gtk/${_realname}-${pkgver}.tar.xz{,
 sha256sums=('23acbee197eaaec9bce6e6bfd885bd8f79708332639243ff04833020865713cd'
             'SKIP'
             '8bb6f1896df080746736a74200f094bae4f48ac766d46a1793a761728fb01202'
-            'SKIP')
+            '3295af8a5656adad24c2b3f8858d458597f14acb00bb5782412c2a115cacf507')
 validpgpkeys=('206D3B352F566F3B0E6572E997D9123DE37A484F') # Victor Toso de Carvalho <me@victortoso.com>
 
 prepare() {
@@ -69,7 +69,7 @@ build() {
     -Dspice-common:manual=false \
     "../${_realname}-${pkgver}"
 
-  ${MINGW_PREFIX}/bin/meson.exe compile --verbose
+  ${MINGW_PREFIX}/bin/meson.exe compile
 }
 
 check() {

--- a/mingw-w64-spice-gtk/PKGBUILD
+++ b/mingw-w64-spice-gtk/PKGBUILD
@@ -4,7 +4,7 @@ _realname=spice-gtk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.39
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 pkgdesc="GTK3 widget for SPICE clients (mingw-w64)"
@@ -31,15 +31,20 @@ options=('strip' '!debug' 'staticlibs')
 license=("GPL 2")
 url="https://www.spice-space.org/"
 source=(https://www.spice-space.org/download/gtk/${_realname}-${pkgver}.tar.xz{,.sig}
-        001-win.patch)
+        001-win.patch
+        002-export-symbols.patch)
 sha256sums=('23acbee197eaaec9bce6e6bfd885bd8f79708332639243ff04833020865713cd'
             'SKIP'
-            '8bb6f1896df080746736a74200f094bae4f48ac766d46a1793a761728fb01202')
+            '8bb6f1896df080746736a74200f094bae4f48ac766d46a1793a761728fb01202'
+            'SKIP')
 validpgpkeys=('206D3B352F566F3B0E6572E997D9123DE37A484F') # Victor Toso de Carvalho <me@victortoso.com>
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/001-win.patch
+  cp -p src/spice-glib-sym-file src/spice-glib-sym-file.def
+  cp -p src/spice-gtk-sym-file src/spice-gtk-sym-file.def
+  patch -p1 -i ${srcdir}/002-export-symbols.patch
 }
 
 build() {
@@ -64,7 +69,7 @@ build() {
     -Dspice-common:manual=false \
     "../${_realname}-${pkgver}"
 
-  ${MINGW_PREFIX}/bin/meson.exe compile
+  ${MINGW_PREFIX}/bin/meson.exe compile --verbose
 }
 
 check() {


### PR DESCRIPTION
clang64 build currently fails with
```
[122/141] "clang" @src/libspice-client-glib-2.0-8.dll.rsp
FAILED: src/libspice-client-glib-2.0-8.dll 
"clang" @src/libspice-client-glib-2.0-8.dll.rsp
lld-link: error: C:/Qemu/tools/hyperv/src/msys2/pkg/mingw-w64-spice-gtk/src/spice-gtk-0.39/src/spice-glib-sym-file: unknown file type
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```
I've tried to fix it by renaming spice-glib-sym-file to spice-glib-sym-file.def (also in meson.build), but this led to further errors.

As far as I've understood, -export-symbols is optional, because by default all symbols are exported.
The new patch removes the parts from meson.build, which add the -export-symbols to the linking command. 
I've tested locally created mingw64 and clang64 packages by using produced spicy with qemu. Using remote-viewer with qemu in mingw64 was successful, too (remote-viewer's package virt-viewer is the only package which really depends on spice-gtk).

@jeremyd2019 @Biswa96 @lazka 
Please have a look at my naive attempt, because I am not really sure if that approach is OK.