### PR TITLE
ghostscript: Always build basic output device "bbox".

### DIFF
--- a/mingw-w64-ghostscript/PKGBUILD
+++ b/mingw-w64-ghostscript/PKGBUILD
@@ -4,7 +4,7 @@ _realname=ghostscript
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=9.53.3
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 license=('AGPL' 'custom')
@@ -85,7 +85,7 @@ build()
     --without-x \
     --with-drivers=ALL
 
-  make so
+  make DEVICE_DEVS_EXTRA="soobj/bbox.dev" so
   #make gs.a
 }
 


### PR DESCRIPTION
This is fixing issue #6268 for me.
Change as proposed by @gharveymn there.

The output device "bbox" is working for me. .eps files created with "bbox" look good to me.