### PR TITLE
epstool: Add new package

### DIFF
--- a/mingw-w64-epstool/0001-mingw-buildrule.patch
+++ b/mingw-w64-epstool/0001-mingw-buildrule.patch
@@ -1,0 +1,94 @@
+Add build rules for mingw target.
+
+diff -urN epstool-3.08.orig/makefile epstool-3.08/makefile
+--- epstool-3.08.orig/makefile	2015-01-05 19:01:34.000000000 -0500
++++ epstool-3.08/makefile	2015-01-05 19:54:45.000000000 -0500
+@@ -34,10 +34,12 @@
+ 
+ LONGFILEDEF=
+ LONGFILEMOD=cfile
++WGSVERMOD=wgsver
+ 
+-include $(SRCDIR)/unixcom.mak
++#include $(SRCDIR)/unixcom.mak
++include $(SRCDIR)/mingwcom.mak
+ 
+-EPSOBJPLAT=$(OD)xnodll$(OBJ) $(OD)$(LONGFILEMOD)$(OBJ)
++EPSOBJPLAT=$(OD)xnodll$(OBJ) $(OD)$(LONGFILEMOD)$(OBJ) $(OD)$(WGSVERMOD)$(OBJ)
+ EPSLIB=$(LIBPNGLIBS)
+ 
+ BEGIN=$(OD)lib.rsp
+@@ -45,7 +47,7 @@
+ 
+ include $(SRCDIR)/common.mak
+ 
+-EPSTOOL_ROOT=/usr/local
++EPSTOOL_ROOT=/
+ EPSTOOL_BASE=$(prefix)$(EPSTOOL_ROOT)
+ EPSTOOL_DOCDIR=$(EPSTOOL_BASE)/share/doc/epstool-$(EPSTOOL_VERSION)
+ EPSTOOL_MANDIR=$(EPSTOOL_BASE)/man
+diff -urN epstool-3.08.orig/src/mingwcom.mak epstool-3.08/src/mingwcom.mak
+--- epstool-3.08.orig/src/mingwcom.mak	1969-12-31 19:00:00.000000000 -0500
++++ epstool-3.08/src/mingwcom.mak	2015-01-05 20:00:18.000000000 -0500
+@@ -0,0 +1,61 @@
++# Copyright (C) 2002-2005 Ghostgum Software Pty Ltd.  All rights reserved.
++#
++#  This software is provided AS-IS with no warranty, either express or
++#  implied.
++#
++#  This software is distributed under licence and may not be copied,
++#  modified or distributed except as expressly authorised under the terms
++#  of the licence contained in the file LICENCE in this distribution.
++#
++#  For more information about licensing, please refer to
++#  http://www.ghostgum.com.au/ or contact Ghostsgum Software Pty Ltd, 
++#  218 Gallaghers Rd, Glen Waverley VIC 3150, AUSTRALIA, 
++#  Fax +61 3 9886 6616.
++#
++
++# $Id: unixcom.mak,v 1.2 2005/01/11 11:40:19 ghostgum Exp $
++# Unix mingw makefile
++
++
++INSTALL=install -m 644
++INSTALL_EXE=install -m 755
++
++MAKE=make
++CDEFS=-DNONAG $(LONGFILEDEF)
++GSCDEBUG= -g
++GSCFLAGS= $(CDEFS) -Wall -Wstrict-prototypes -Wmissing-declarations -Wmissing-prototypes -fno-builtin -fno-common -Wcast-qual -Wwrite-strings $(CDEBUG) $(GSCDEBUG) $(RPM_OPT_FLAGS) $(XINCLUDE) $(PFLAGS) $(LIBPNGCFLAGS) $(GTKCFLAGS) -I$(SRCWIN)
++CCAUX=$(TOOL_PREFIX)gcc
++CC=$(TOOL_PREFIX)gcc
++LFLAGS=$(PLINK) $(LIBPNGLIBS) $(GTKLIBS)
++CLINK=$(CC) $(LDFLAGS)
++LINK=$(CC) $(LDFLAGS)
++
++
++COMP=$(CC) -I$(SRCDIR) -I$(OBJDIR) $(CFLAGS) $(GSCFLAGS)
++
++
++NUL=
++DD=/$(NUL)
++SRC=$(SRCDIR)/$(NUL)
++SRCWIN=$(SRCWINDIR)/$(NUL)
++OD=$(OBJDIR)/$(NUL)
++BD=$(BINDIR)/$(NUL)
++OBJ=.o
++EXE=.exe
++CO=-c
++
++FE=-o $(NUL)
++FO=-o $(NUL)
++FEO=-o $(OD)
++FOO=-o $(OD)
++
++CP=cp -f
++RM=rm -f
++RMDIR=rm -rf
++
++default: $(BD)epstool$(EXE)
++
++$(OD)wgsver$(OBJ): $(SRCWIN)wgsver.c $(common_h) $(cdll_h)
++	$(COMP) $(FOO)wgsver$(OBJ) $(CO) $(SRCWIN)wgsver.c
++
++

--- a/mingw-w64-epstool/0001-mingw-buildrule.patch
+++ b/mingw-w64-epstool/0001-mingw-buildrule.patch
@@ -88,7 +88,7 @@ diff -urN epstool-3.08.orig/src/mingwcom.mak epstool-3.08/src/mingwcom.mak
 +
 +default: $(BD)epstool$(EXE)
 +
-+$(OD)wgsver$(OBJ): $(SRCWIN)wgsver.c $(common_h) $(cdll_h)
++$(OD)wgsver$(OBJ): $(SRCWIN)wgsver.c $(common_h) $(cdll_h) $(OD)lib.rsp
 +	$(COMP) $(FOO)wgsver$(OBJ) $(CO) $(SRCWIN)wgsver.c
 +
 +

--- a/mingw-w64-epstool/0002-buildorder.patch
+++ b/mingw-w64-epstool/0002-buildorder.patch
@@ -1,0 +1,170 @@
+Make sure that folders are created *before* any objects are built.
+
+--- epstool-3.09/src/common.mak.orig	2015-03-15 11:25:28.000000000 +0100
++++ epstool-3.09/src/common.mak	2021-09-10 11:20:14.430895700 +0200
+@@ -80,114 +80,114 @@
+ all: $(BEGIN) $(TARGET)
+ 
+-$(OD)calloc$(OBJ): $(SRC)calloc.c $(common_h)
++$(OD)calloc$(OBJ): $(SRC)calloc.c $(common_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)calloc$(OBJ) $(CO) $(SRC)calloc.c
+ 
+ $(OD)capp$(OBJ): $(SRC)capp.c $(common_h) $(dscparse_h) $(copt_h) \
+  $(capp_h) $(cdll_h) $(cgssrv_h) $(cimg_h) $(cpagec_h) $(cprofile_h) \
+- $(cres_h)
++ $(cres_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)capp$(OBJ) $(CO) $(SRC)capp.c
+ 
+ $(OD)cargs$(OBJ): $(SRC)cargs.c $(common_h) $(dscparse_h) $(capp_h) \
+- $(cargs_h) $(copt_h) $(cview_h)
++ $(cargs_h) $(copt_h) $(cview_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)cargs$(OBJ) $(CO) $(SRC)cargs.c
+ 
+-$(OD)cbmp$(OBJ): $(SRC)cbmp.c $(common_h) $(gdevdsp_h) $(cimg_h)
++$(OD)cbmp$(OBJ): $(SRC)cbmp.c $(common_h) $(gdevdsp_h) $(cimg_h) $(OD)lib.rsp
+ 	$(COMP) $(LIBPNGINC) $(FOO)cbmp$(OBJ) $(CO) $(SRC)cbmp.c
+ 
+-$(OD)ccoord$(OBJ): $(SRC)ccoord.c $(common_h) $(gdevdsp_h) $(cpagec_h)
++$(OD)ccoord$(OBJ): $(SRC)ccoord.c $(common_h) $(gdevdsp_h) $(cpagec_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)ccoord$(OBJ) $(CO) $(SRC)ccoord.c
+ 
+ $(OD)cdisplay$(OBJ): $(SRC)cdisplay.c $(common_h) $(gdevdsp_h) $(errors_h) \
+- $(capp_h) $(cimg_h) $(cdisplay_h) $(cgssrv_h) $(cmsg_h)
++ $(capp_h) $(cimg_h) $(cdisplay_h) $(cgssrv_h) $(cmsg_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)cdisplay$(OBJ) $(CO) $(SRC)cdisplay.c
+ 
+ $(OD)cdoc$(OBJ): $(SRC)cdoc.c $(common_h) $(dscparse_h) $(capp_h) \
+- $(cdoc_h) $(cpdfscan_h) $(cres_h)
++ $(cdoc_h) $(cpdfscan_h) $(cres_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)cdoc$(OBJ) $(CO) $(SRC)cdoc.c
+ 
+ $(OD)ceps$(OBJ): $(SRC)ceps.c $(common_h) $(dscparse_h) \
+  $(gdevdsp_h) $(capp_h) $(cbmp_h) $(cdoc_h) $(ceps_h) $(cimg_h) \
+- $(cmac_h) $(cpdfscan_h) $(cps_h)
++ $(cmac_h) $(cpdfscan_h) $(cps_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)ceps$(OBJ) $(CO) $(SRC)ceps.c
+ 
+-$(OD)cfile$(OBJ): $(SRC)cfile.c $(SRC)cfile.h
++$(OD)cfile$(OBJ): $(SRC)cfile.c $(SRC)cfile.h $(OD)lib.rsp
+ 	$(COMP) $(FOO)cfile$(OBJ) $(CO) $(SRC)cfile.c
+ 
+-$(OD)clfile$(OBJ): $(SRC)clfile.c $(SRC)cfile.h
++$(OD)clfile$(OBJ): $(SRC)clfile.c $(SRC)cfile.h $(OD)lib.rsp
+ 	$(COMP) $(FOO)clfile$(OBJ) $(CO) $(SRC)clfile.c
+ 
+ $(OD)cgsdll$(OBJ): $(SRC)cgsdll.c $(common_h) $(errors_h) $(iapi_h) \
+- $(capp_h) $(cdll_h) $(cgsdll_h)
++ $(capp_h) $(cdll_h) $(cgsdll_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)cgsdll$(OBJ) $(CO) $(SRC)cgsdll.c
+ 
+ $(OD)cgssrv$(OBJ): $(SRC)cgssrv.c $(common_h) $(dscparse_h) \
+  $(errors_h) $(iapi_h) \
+  $(capp_h) $(cdll_h) $(cimg_h) $(copt_h) $(cdisplay_h) $(cdoc_h) \
+- $(cgsdll_h) $(cmsg_h) $(cpdf_h) $(cpdfscan_h) $(cview_h) $(cgssrv_h)
++ $(cgsdll_h) $(cmsg_h) $(cpdf_h) $(cpdfscan_h) $(cview_h) $(cgssrv_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)cgssrv$(OBJ) $(CO) $(SRC)cgssrv.c
+ 
+-$(OD)chist$(OBJ): $(SRC)chist.c $(common_h) $(chist_h)
++$(OD)chist$(OBJ): $(SRC)chist.c $(common_h) $(chist_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)chist$(OBJ) $(CO) $(SRC)chist.c
+ 
+-$(OD)cimg$(OBJ): $(SRC)cimg.c $(common_h) $(gdevdsp_h) $(cimg_h) $(clzw_h)
++$(OD)cimg$(OBJ): $(SRC)cimg.c $(common_h) $(gdevdsp_h) $(cimg_h) $(clzw_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)cimg$(OBJ) $(CO) $(SRC)cimg.c
+ 
+-$(OD)clzw$(OBJ): $(SRC)clzw.c $(clzw_h)
++$(OD)clzw$(OBJ): $(SRC)clzw.c $(clzw_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)clzw$(OBJ) $(CO) $(SRC)clzw.c
+ 
+-$(OD)cmac$(OBJ): $(SRC)cmac.c $(cmac_h) $(common_h)
++$(OD)cmac$(OBJ): $(SRC)cmac.c $(cmac_h) $(common_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)cmac$(OBJ) $(CO) $(SRC)cmac.c
+ 
+-$(OD)cmbcs$(OBJ): $(SRC)cmbcs.c $(common_h)
++$(OD)cmbcs$(OBJ): $(SRC)cmbcs.c $(common_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)cmbcs$(OBJ) $(CO) $(SRC)cmbcs.c
+ 
+-$(OD)copt$(OBJ): $(SRC)copt.c $(common_h) $(dscparse_h) $(copt_h) $(cprofile_h)
++$(OD)copt$(OBJ): $(SRC)copt.c $(common_h) $(dscparse_h) $(copt_h) $(cprofile_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)copt$(OBJ) $(CO) $(SRC)copt.c
+ 
+ $(OD)cpagec$(OBJ): $(SRC)cpagec.c $(common_h) $(dscparse_h) \
+- $(capp_h) $(cgssrv_h) $(cimg_h) $(cpagec_h) $(cpdf_h) $(cview_h)
++ $(capp_h) $(cgssrv_h) $(cimg_h) $(cpagec_h) $(cpdf_h) $(cview_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)cpagec$(OBJ) $(CO) $(SRC)cpagec.c
+ 
+ $(OD)cpdf$(OBJ): $(SRC)cpdf.c $(common_h) $(dscparse_h) \
+- $(capp_h) $(cpdf_h) $(cgssrv_h) $(cview_h)
++ $(capp_h) $(cpdf_h) $(cgssrv_h) $(cview_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)cpdf$(OBJ) $(CO) $(SRC)cpdf.c
+ 
+ $(OD)cpdfscan$(OBJ): $(SRC)cpdfscan.c $(common_h) $(dscparse_h) \
+- $(capp_h) $(cpdfscan_h)
++ $(capp_h) $(cpdfscan_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)cpdfscan$(OBJ) $(CO) $(SRC)cpdfscan.c
+ 
+ $(OD)cpldll$(OBJ): $(SRC)cpldll.c $(common_h) $(errors_h) $(iapi_h) \
+- $(capp_h) $(cdll_h) $(cpldll_h)
++ $(capp_h) $(cdll_h) $(cpldll_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)cpldll$(OBJ) $(CO) $(SRC)cpldll.c
+ 
+ $(OD)cplsrv$(OBJ): $(SRC)cplsrv.c $(common_h) $(dscparse_h) \
+  $(errors_h) $(iapi_h) \
+  $(capp_h) $(cdll_h) $(cimg_h) $(copt_h) $(cdisplay_h) $(cdoc_h) \
+- $(cgsdll_h) $(cmsg_h) $(cpdf_h) $(cpdfscan_h) $(cview_h) $(cgssrv_h)
++ $(cgsdll_h) $(cmsg_h) $(cpdf_h) $(cpdfscan_h) $(cview_h) $(cgssrv_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)cplsrv$(OBJ) $(CO) $(SRC)cplsrv.c
+ 
+-$(OD)cprofile$(OBJ): $(SRC)cprofile.c $(cplat_h) $(cprofile_h)
++$(OD)cprofile$(OBJ): $(SRC)cprofile.c $(cplat_h) $(cprofile_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)cprofile$(OBJ) $(CO) $(SRC)cprofile.c
+ 
+ $(OD)cps$(OBJ): $(SRC)cps.c $(common_h) $(dscparse_h) \
+- $(capp_h) $(cdoc_h)
++ $(capp_h) $(cdoc_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)cps$(OBJ) $(CO) $(SRC)cps.c
+ 
+ $(OD)cvcmd$(OBJ): $(SRC)cvcmd.c $(common_h) $(dscparse_h) \
+  $(copt_h) $(capp_h) $(cdoc_h) $(cgssrv_h) $(chist_h) \
+- $(cmsg_h) $(cpdfscan_h) $(cps_h) $(cres_h) $(cvcmd_h) $(cview_h)
++ $(cmsg_h) $(cpdfscan_h) $(cps_h) $(cres_h) $(cvcmd_h) $(cview_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)cvcmd$(OBJ) $(CO) $(SRC)cvcmd.c
+ 
+ $(OD)cview$(OBJ): $(SRC)cview.c $(common_h) $(dscparse_h) \
+  $(capp_h) $(cdoc_h) $(cgssrv_h) $(chist_h) $(cimg_h) \
+  $(cmsg_h) $(copt_h) $(cpagec_h) $(cpdf_h) $(cpdfscan_h) $(cres_h) \
+- $(cvcmd_h) $(cview_h)
++ $(cvcmd_h) $(cview_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)cview$(OBJ) $(CO) $(SRC)cview.c
+ 
+-$(OD)dscparse$(OBJ): $(SRC)dscparse.c $(dscparse_h)
++$(OD)dscparse$(OBJ): $(SRC)dscparse.c $(dscparse_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)dscparse$(OBJ) $(CO) $(SRC)dscparse.c
+ 
+-$(OD)dscutil$(OBJ): $(SRC)dscutil.c $(dscparse_h)
++$(OD)dscutil$(OBJ): $(SRC)dscutil.c $(dscparse_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)dscutil$(OBJ) $(CO) $(SRC)dscutil.c
+ 
+ $(BD)epstool$(EXE): $(OD)lib.rsp $(EPSOBJS)
+@@ -196,7 +196,7 @@
+ $(OD)epstool$(OBJ): $(SRC)epstool.c $(SRC)common.mak \
+  $(common_h) $(copt_h) $(capp_h) $(cbmp_h) $(cdoc_h) $(cdll_h) \
+  $(ceps_h) $(cimg_h) $(cmac_h) $(cps_h) $(cres_h) \
+- $(dscparse_h) $(errors_h) $(iapi_h) $(gdevdsp_h)
++ $(dscparse_h) $(errors_h) $(iapi_h) $(gdevdsp_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)epstool$(OBJ) $(CO) -DEPSTOOL_VERSION="$(EPSTOOL_VERSION)" -DEPSTOOL_DATE="$(EPSTOOL_DATE)" $(SRC)epstool.c
+ 
+ $(BD)epstest$(EXE): $(OD)lib.rsp $(EPSTESTOBJS)
+@@ -215,10 +215,10 @@
+ 
+ # X11/gtk+ specific
+ 
+-$(OD)xdll$(OBJ): $(SRC)xdll.c $(common_h) $(cdll_h)
++$(OD)xdll$(OBJ): $(SRC)xdll.c $(common_h) $(cdll_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)xdll$(OBJ) $(CO) $(SRC)xdll.c
+ 
+-$(OD)xnodll$(OBJ): $(SRC)xnodll.c $(common_h) $(cdll_h)
++$(OD)xnodll$(OBJ): $(SRC)xnodll.c $(common_h) $(cdll_h) $(OD)lib.rsp
+ 	$(COMP) $(FOO)xnodll$(OBJ) $(CO) $(SRC)xnodll.c
+ 
+ 

--- a/mingw-w64-epstool/PKGBUILD
+++ b/mingw-w64-epstool/PKGBUILD
@@ -3,23 +3,27 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.09
 pkgrel=1
-license=("GPL 2")
+license=("GPL2")
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
-pkgdesc="utility to create or extract preview images in EPS files, fix bounding boxes and convert to bitmaps"
+pkgdesc="utility to create or extract preview images in EPS files, fix bounding boxes and convert to bitmaps (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-ghostscript")
 makedepends=()
 url="http://www.ghostgum.com.au/software/epstool.htm"
 source=(http://www.ghostgum.com.au/download/${_realname}-${pkgver}.tar.gz
-        "0001-mingw-buildrule.patch")
+        "0001-mingw-buildrule.patch"
+        "0002-buildorder.patch")
 sha256sums=('e3538857e0c8c21a5a6cbd28fba75d71825318daea6525a4d20e385d758ca847'
-            'ace0835a4ab156f4ea78f8b9bf76490f2a84889bd790ed46a4bc7d7d0820e8d5')
+            '11d587e3733b34cc3f4ba776cc3e8a02e431df7060b0461986d80fb9cebfdad2'
+            '5203a48cb6d4ea444e3865327bcedb143085aba900cb3a00d499c606da005853')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
 
   # patch from https://hg.octave.org/mxe-octave/file/c30da1cd5e3b/src/mingw-epstool-1-fixes.patch
   rm -rf src/mingwcom.mak && patch -p1 -i "${srcdir}/0001-mingw-buildrule.patch"
+
+  patch -p1 -i "${srcdir}/0002-buildorder.patch"
 }
 
 build() {

--- a/mingw-w64-epstool/PKGBUILD
+++ b/mingw-w64-epstool/PKGBUILD
@@ -1,0 +1,35 @@
+_realname=epstool
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=3.09
+pkgrel=1
+license=("GPL 2")
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+pkgdesc="utility to create or extract preview images in EPS files, fix bounding boxes and convert to bitmaps"
+depends=("${MINGW_PACKAGE_PREFIX}-ghostscript")
+makedepends=()
+url="http://www.ghostgum.com.au/software/epstool.htm"
+source=(http://www.ghostgum.com.au/download/${_realname}-${pkgver}.tar.gz
+        "0001-mingw-buildrule.patch")
+sha256sums=('e3538857e0c8c21a5a6cbd28fba75d71825318daea6525a4d20e385d758ca847'
+            'ace0835a4ab156f4ea78f8b9bf76490f2a84889bd790ed46a4bc7d7d0820e8d5')
+
+prepare() {
+  cd ${srcdir}/${_realname}-${pkgver}
+
+  # patch from https://hg.octave.org/mxe-octave/file/c30da1cd5e3b/src/mingw-epstool-1-fixes.patch
+  rm -rf src/mingwcom.mak && patch -p1 -i "${srcdir}/0001-mingw-buildrule.patch"
+}
+
+build() {
+  cd ${srcdir}/${_realname}-${pkgver}
+
+  make prefix="${pkgdir}/${MINGW_PREFIX}"
+}
+
+package() {
+  cd ${srcdir}/${_realname}-${pkgver}
+
+  make prefix="${pkgdir}/${MINGW_PREFIX}" install
+}


### PR DESCRIPTION
Add build rules for `epstool`.

I'd like to add that tool as an optional dependency to octave. It is needed to save .eps graphics with tight binding box. But octave doesn't re-build currently (missing OpenGL symbols IIUC).
I'll probably open an issue later when I better understand what is causing that.

For the time being, it would be nice if you could add the `epstool` package anyway.