### PR TITLE
libopenmpt: update to 0.4.23

### DIFF
--- a/mingw-w64-libopenmpt/PKGBUILD
+++ b/mingw-w64-libopenmpt/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=libopenmpt
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.4.22
-pkgrel=2
+pkgver=0.4.23
+pkgrel=1
 pkgdesc="A cross-platform C++ and C library to decode tracked music files (modules) into a raw PCM audio stream (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -21,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
 options=('staticlibs' 'strip')
 source=("https://lib.openmpt.org/files/${_realname}/src/${_realname}-${pkgver}+release.autotools.tar.gz")
-sha256sums=('f06af96cf3f7f3ad85cfb7da1e4c043f1fbfb520cbf35fd37a0d2fa5cdeb7e95')
+sha256sums=('29697b7106db19fabead72cb9e02dcddef785d4496f24d119326e48178a719ac')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}+release.autotools"


### PR DESCRIPTION
Update to libopenmpt 0.4.23 (security update)
https://lib.openmpt.org/libopenmpt/2021/08/22/security-updates-0.5.11-0.4.23-0.3.32/