### PR TITLE
octave: Add `epstool` as optional dependency.

### DIFF
--- a/mingw-w64-octave/PKGBUILD
+++ b/mingw-w64-octave/PKGBUILD
@@ -2,8 +2,8 @@ _realname=octave
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=6.3.0
-pkgrel=4
-pkgdesc="GNU Octave: Interactive programming environment for numerical computations."
+pkgrel=5
+pkgdesc="GNU Octave: Interactive programming environment for numerical computations (mingw-w64)"
 url="https://www.octave.org"
 license=('GPL3')
 arch=('any')
@@ -30,6 +30,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc-fortran"
              "${MINGW_PACKAGE_PREFIX}-fltk"
              "${MINGW_PACKAGE_PREFIX}-portaudio")
 optdepends=('texinfo: for help-support in Octave'
+            "${MINGW_PACKAGE_PREFIX}-epstool: eps output with tight bounding box"
             "${MINGW_PACKAGE_PREFIX}-fltk: alternative plotting and dialogs"
             "${MINGW_PACKAGE_PREFIX}-gnuplot: alternative plotting"
             "${MINGW_PACKAGE_PREFIX}-portaudio: audio support")
@@ -64,6 +65,7 @@ build() {
     --enable-shared --disable-static \
     --disable-docs \
     --enable-relocate-all \
+    --enable-link-all-dependencies \
     --with-blas="-lblas" \
     ac_cv_search_tputs=-ltermcap \
     JAVA_HOME=""


### PR DESCRIPTION
This adds `epstool` to the list of optional dependencies of the octave package.

Octave doesn't currently compile (locally or using the CI) unless it is configured with `--enable-link-all-dependencies`. Without that flag, the compilation ends with a linking error (referring to import symbols to OpenGL functions).
I don't understand why it worked before without that flag or why it requires that flag now. But at least that is fixing the linking error for me. So, I just added that flag to the `PKGBUILD` rules.
