### PR TITLE
libheif: Generate pkgconfig file with autoconf

### DIFF
--- a/mingw-w64-kimageformats-qt5/PKGBUILD
+++ b/mingw-w64-kimageformats-qt5/PKGBUILD
@@ -5,7 +5,7 @@ _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kimageformats"
 pkgver=5.85.0
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 pkgdesc="Plugins to allow QImage to support extra file formats (mingw-w64-qt5${_namesuff})"
@@ -13,6 +13,8 @@ license=('LGPL')
 makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 depends=()
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-libavif"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-libheif"
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}"
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-openexr${_namesuff}"
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-karchive-qt5${_namesuff}>=${pkgver}"
@@ -37,6 +39,7 @@ build() {
     "${_kde_f5_KDE_INSTALL_DIRS[@]}" \
     -DBUILD_QCH=OFF \
     -DBUILD_TESTING=OFF \
+    -DKIMAGEFORMATS_HEIF=ON \
     -DECM_DIR=${MINGW_PREFIX}/share/ECM \
     "${extra_config[@]}" \
     -G'Ninja'

--- a/mingw-w64-libheif/PKGBUILD
+++ b/mingw-w64-libheif/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libheif
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.12.0
-pkgrel=4
+pkgrel=5
 pkgdesc="HEIF image decoder/encoder library and tools (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -67,12 +67,25 @@ build() {
       ../${_realname}-${pkgver}
 
   ${MINGW_PREFIX}/bin/cmake --build .
+
+  # Build pkgconfig file using autoconf because
+  # CMake generates it without ${prefix} variable
+
+  [[ -d "${srcdir}"/build-${CARCH}-pkgconfig ]] && rm -rf "${srcdir}"/build-${CARCH}-pkgconfig
+  mkdir -p "${srcdir}"/build-${CARCH}-pkgconfig && cd "${srcdir}"/build-${CARCH}-pkgconfig
+
+  ../${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST}
 }
 
 package() {
   cd "${srcdir}"/build-${CARCH}
 
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --build . --target install
+
+  cp -v "${srcdir}"/build-${CARCH}-pkgconfig/libheif.pc "${pkgdir}"${MINGW_PREFIX}/lib/pkgconfig
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/examples/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING-examples"


### PR DESCRIPTION
Build pkgconfig file using autoconf because
CMake generates it without ${prefix} variable