### PR TITLE
cairo: Import patch to remove glyph bounds check

### DIFF
--- a/mingw-w64-cairo/0031-remove-glyph-bounds-check.patch
+++ b/mingw-w64-cairo/0031-remove-glyph-bounds-check.patch
@@ -1,0 +1,21 @@
+--- a/src/cairo-composite-rectangles.c
++++ b/src/cairo-composite-rectangles.c
+@@ -431,18 +431,6 @@
+     if (! _cairo_composite_rectangles_init (extents, surface, op, source, clip))
+ 	return CAIRO_INT_STATUS_NOTHING_TO_DO;
+ 
+-    /* Computing the exact bbox and the overlap is expensive.
+-     * First perform a cheap test to see if the glyphs are all clipped out.
+-     */
+-    if (extents->is_bounded & CAIRO_OPERATOR_BOUND_BY_MASK &&
+-	_cairo_scaled_font_glyph_approximate_extents (scaled_font,
+-						      glyphs, num_glyphs,
+-						      &extents->mask))
+-    {
+-	if (! _cairo_rectangle_intersect (&extents->bounded, &extents->mask))
+-	    return CAIRO_INT_STATUS_NOTHING_TO_DO;
+-    }
+-
+     status = _cairo_scaled_font_glyph_device_extents (scaled_font,
+ 						      glyphs, num_glyphs,
+ 						      &extents->mask,

--- a/mingw-w64-cairo/PKGBUILD
+++ b/mingw-w64-cairo/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _commit='156cd3eaaebfd8635517c2baf61fcf3627ff7ec2'
 pkgver=1.17.4
-pkgrel=3
+pkgrel=4
 pkgdesc="Cairo vector graphics library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -33,12 +33,14 @@ source=("https://gitlab.freedesktop.org/cairo/cairo/-/archive/${_commit}/cairo-$
         0001-fix-font-names-in-pdf-output.patch
         0026-create-argb-fonts.all.patch
         0027-win32-print-fix-unbounded-surface-assertion.patch
-        0030-ucrt-clang-fixes.patch)
+        0030-ucrt-clang-fixes.patch
+        0031-remove-glyph-bounds-check.patch)
 sha256sums=('204215866aa392c27d3e1306f6ea1946a623bf86fff3143f777d1e8bf4383bb0'
             'a5926f8bca3cb09e41ed8d2a60fb053c4243fdeec2c36c5c7e15d2a784b6ee9a'
             '6db6c44fbdb4926d09afa978fe80430186c4b7b7d255059602b1f94c6a079975'
             '7e244c20eec8c7b287dbee1d34de178d9b0c419dc4c2b11c90eaf626c92bf781'
-            '86c1af2878a20bd3608fc476e4ba1f2451458a5f6f12e457e37b61082c38db82')
+            '86c1af2878a20bd3608fc476e4ba1f2451458a5f6f12e457e37b61082c38db82'
+            'e3beacf74ab3de08af7b4e2b0b3001176d70d8225312efdd0332f3086be06d3c')
 
 prepare() {
   mv "${srcdir}/${_realname}-${_commit}" "${srcdir}/${_realname}-${pkgver}"
@@ -53,6 +55,9 @@ prepare() {
   patch -p1 -i ${srcdir}/0027-win32-print-fix-unbounded-surface-assertion.patch
 
   patch -p1 -i ${srcdir}/0030-ucrt-clang-fixes.patch
+
+  # https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/245
+  patch -p1 -i ${srcdir}/0031-remove-glyph-bounds-check.patch
 }
 
 build() {


### PR DESCRIPTION
Fixes https://github.com/msys2/MINGW-packages/issues/9618