### PR TITLE
flint: Add new package

### DIFF
--- a/mingw-w64-flint/PKGBUILD
+++ b/mingw-w64-flint/PKGBUILD
@@ -1,0 +1,46 @@
+# Maintainer: Ben Orchard <thefirstmuffinman@gmail.com>
+
+_realname=flint
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=2.8.0
+pkgrel=1
+pkgdesc="Fast Library for Number Theory (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+depends=("${MINGW_PACKAGE_PREFIX}-mpfr"
+         "${MINGW_PACKAGE_PREFIX}-gmp")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
+license=('LGPL2.1')
+url="https://www.flintlib.org/"
+source=(https://www.flintlib.org/${_realname}-${pkgver}.tar.gz)
+sha256sums=('584235cdc39d779d9920eaef16fe084f3c26ffeeea003a3fff64a20a0f33449e')
+
+build() {
+  [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
+  mkdir -p "${srcdir}/build-${MSYSTEM}"
+
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  cmake \
+    -G Ninja \
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_TESTING=true \
+    "../${_realname}-${pkgver}"
+
+  cmake --build .
+}
+
+check() {
+  cd "${srcdir}/build-${MSYSTEM}"
+  cmake --build . --target test
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+  DESTDIR="${pkgdir}" cmake --install .
+  install -Dm0644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
I'm not affiliated with the FLINT project, but got an OK from the primary maintainer to pop this up on MSYS. Relatively common math library that I can't find prebuilt for Windows anywhere.

The `makepkg-mingw` script fails on the 32-bit build, apparently due to a dirty build directory. Is that a problem for CI? I think it'd be solved with a `make clean` in whichever function is for cleanup (`package()`?).