### PR TITLE
virt-viewer: update to 10.0, which uses meson

### DIFF
--- a/mingw-w64-virt-viewer/001-rc-generation-fixes.patch
+++ b/mingw-w64-virt-viewer/001-rc-generation-fixes.patch
@@ -1,0 +1,45 @@
+--- a/src/virt-viewer.rc.in	2021-09-22 14:52:06.958956000 -0700
++++ b/src/virt-viewer.rc.in	2021-09-22 14:52:41.569757700 -0700
+@@ -23,5 +23,5 @@
+     VALUE "Translation", 0x409, 1252
+   END
+ END
+-2 ICON ICONDIR "/virt-viewer.ico"
+-3 RT_MANIFEST MANIFESTDIR "/virt-viewer.manifest"
++2 ICON "@ICOFILE@"
++3 RT_MANIFEST "@MANIFEST@"
+--- a/src/meson.build	2021-09-22 14:46:02.475944600 -0700
++++ b/src/meson.build	2021-09-22 14:51:57.935947800 -0700
+@@ -174,12 +174,15 @@
+ 
+ if host_machine.system() == 'windows'
+   windres = find_program('windres')
+-  runwindres = join_paths(meson.source_root(), 'build-aux', 'run-windres.py')
+ 
++  rc_conf_data = configuration_data()
++  rc_conf_data.merge_from(conf_data)
++  rc_conf_data.set('ICOFILE', icofile.full_path())
++  rc_conf_data.set('MANIFEST', meson.current_source_dir() / 'virt-viewer.manifest')
+   rcfile = configure_file(
+     input: 'virt-viewer.rc.in',
+     output: 'virt-viewer.rc',
+-    configuration: conf_data
++    configuration: rc_conf_data
+   )
+ 
+   rcobj = custom_target(
+@@ -187,12 +190,10 @@
+     input: [rcfile, icofile, 'virt-viewer.manifest'],
+     output: ['virt-viewer-rc.o'],
+     command : [
+-      python3,
+-      runwindres,
+       windres,
+-      join_paths(meson.build_root(), 'icons'),
+-      meson.current_source_dir(),
++      '-i',
+       rcfile,
++      '-o',
+       '@OUTPUT@'
+     ])
+ 

--- a/mingw-w64-virt-viewer/002-check-linker-pie-support.patch
+++ b/mingw-w64-virt-viewer/002-check-linker-pie-support.patch
@@ -1,0 +1,24 @@
+--- a/src/meson.build	2021-09-22 14:46:02.475944600 -0700
++++ b/src/meson.build	2021-09-22 16:47:13.993374500 -0700
+@@ -137,15 +137,19 @@
+   # --nxcompat is to enable NX protection
+   # -pie as --dynamicbase requires relocations
+   gui_security_link_args += [
+-    '-Wl,--dynamicbase,-pie,--nxcompat',
++    '-Wl,--dynamicbase,--nxcompat',
+     '-Wl,-e,@0@WinMainCRTStartup'.format(entry_prefix),
+     '-mwindows',
+   ]
+   cui_security_link_args += [
+-    '-Wl,--dynamicbase,-pie,--nxcompat',
++    '-Wl,--dynamicbase,--nxcompat',
+     '-Wl,-e,@0@WinMainCRTStartup'.format(entry_prefix),
+     '-mconsole',
+   ]
++  if cc.has_link_argument('-Wl,-pie')
++    gui_security_link_args += ['-Wl,-pie']
++    cui_security_link_args += ['-Wl,-pie']
++  endif
+ endif
+ 
+ if libvirt_dep.found()

--- a/mingw-w64-virt-viewer/PKGBUILD
+++ b/mingw-w64-virt-viewer/PKGBUILD
@@ -3,18 +3,19 @@
 _realname=virt-viewer
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=9.0
-pkgrel=2
+pkgver=10.0
+pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 pkgdesc="Displaying the graphical console of a virtual machine (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-spice-gtk"
          "${MINGW_PACKAGE_PREFIX}-gtk-vnc"
+         "${MINGW_PACKAGE_PREFIX}-libssp"
          "${MINGW_PACKAGE_PREFIX}-libvirt"
          "${MINGW_PACKAGE_PREFIX}-libvirt-glib"
          "${MINGW_PACKAGE_PREFIX}-libxml2"
          "${MINGW_PACKAGE_PREFIX}-opus")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+makedepends=("${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-gtk-doc"
              "${MINGW_PACKAGE_PREFIX}-icoutils"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
@@ -23,33 +24,51 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 options=('strip' 'staticlibs')
 license=("LGPL 2.1")
 url="https://virt-manager.org/"
-source=(https://virt-manager.org/download/sources/virt-viewer/virt-viewer-${pkgver}.tar.gz{,.asc})
-sha256sums=('91b43383a0bd4cf3173269e674d65fd205f7c34bc5a8cb4fb3640deb7f1d4825'
-            'SKIP')
+source=(https://virt-manager.org/download/sources/virt-viewer/virt-viewer-${pkgver}.tar.xz{,.asc}
+        001-rc-generation-fixes.patch
+        002-check-linker-pie-support.patch)
+sha256sums=('d23bc0a06e4027c37b8386cfd0286ef37bd738977153740ab1b6b331192389c5'
+            'SKIP'
+            'ef8d364e7f05c799ffd98c798f45dd125ab90d1a5fc116052e9e8b769182a03e'
+            '6a52d3807518536ec605dfd331d8ab0c993ca49d147d84b3e71f0ca0ae9f41dd')
 validpgpkeys=('DAF3A6FDB26B62912D0E8E3FBE86EBB415104FDF') # Daniel P. Berrange
 
 prepare() {
   cd $srcdir/${_realname}-${pkgver}
+
+  patch -Nbp1 -i "${srcdir}/001-rc-generation-fixes.patch"
+  patch -Nbp1 -i "${srcdir}/002-check-linker-pie-support.patch"
 }
 
 build() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
   mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
 
-  ../${_realname}-${pkgver}/configure \
-    --host=${MINGW_CHOST} \
-    --target=${MINGW_CHOST} \
-    --build=${MINGW_CHOST} \
-    --prefix=${MINGW_PREFIX} \
-    --libexecdir=${MINGW_PREFIX}/lib \
-    --with-spice-gtk
+  declare -a _extra_config
+  if check_option "debug" "n"; then
+    _extra_config+=("--buildtype=release")
+  else
+    _extra_config+=("--buildtype=debug")
+  fi
 
-  make
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+  ${MINGW_PREFIX}/bin/meson.exe \
+    --prefix="${MINGW_PREFIX}" \
+    "${_extra_config[@]}" \
+    --wrap-mode=nodownload \
+    --default-library=both \
+    --auto-features=disabled \
+    -Dlibvirt=enabled \
+    -Dvnc=enabled \
+    -Dspice=enabled \
+    "../${_realname}-${pkgver}"
+
+  ${MINGW_PREFIX}/bin/meson.exe compile
 }
 
 package() {
   cd "$srcdir/build-${MINGW_CHOST}"
-  make DESTDIR=$pkgdir install
 
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/meson.exe install
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }


### PR DESCRIPTION
Ran into an issue with llvm-windres: https://bugs.llvm.org/show_bug.cgi?id=51944.  They were already using `configure_file` on the rc file, so patched meson.build to sub in the paths to the files through that instead of trying to combine string constants.