### PR TITLE
opencascade: Add patches from Debian Science Team

### DIFF
--- a/mingw-w64-opencascade/0002-GeomPlate_BuildAveragePlane-BasePlan-Don-t-set-yvect.patch
+++ b/mingw-w64-opencascade/0002-GeomPlate_BuildAveragePlane-BasePlan-Don-t-set-yvect.patch
@@ -1,0 +1,23 @@
+Subject: [PATCH 2/7] GeomPlate_BuildAveragePlane: BasePlan: Don't set yvector to zero. See Following:
+From: blobfish <blobfish@gmx.com>
+
+Date: Tue, 29 Sep 2020 06:36:13 -0400
+
+    When we return, the yvector is crossed with x and we crash.
+    The z vector is passed in and we calculate the x vector, so just cross those 2 in this case to get y.
+
+---
+ src/GeomPlate/GeomPlate_BuildAveragePlane.cxx | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/src/GeomPlate/GeomPlate_BuildAveragePlane.cxx
++++ b/src/GeomPlate/GeomPlate_BuildAveragePlane.cxx
+@@ -436,7 +436,7 @@
+           || ((Abs(n2)<=myTol)&&(Abs(n3)<=myTol))
+           || ((Abs(n1)<=myTol)&&(Abs(n3)<=myTol))) {
+       myOX.SetCoord(V3(1),V3(2),V3(3));
+-      myOY.SetCoord(0,0,0);
++      myOY = OZ ^ myOX;
+     }
+     else {
+       myOX.SetCoord(V3(1),V3(2),V3(3));

--- a/mingw-w64-opencascade/0003-BRepFill_Filling-WireFromList-We-can-t-assume-that-a.patch
+++ b/mingw-w64-opencascade/0003-BRepFill_Filling-WireFromList-We-can-t-assume-that-a.patch
@@ -1,0 +1,40 @@
+Subject: [PATCH 3/7] BRepFill_Filling: WireFromList: We can't assume that a connected edge was found and the iterator is valid or we will crash on Edges.Remove
+From: blobfish <blobfish@gmx.com>
+
+Date: Tue, 29 Sep 2020 06:41:32 -0400
+
+
+---
+ src/BRepFill/BRepFill_Filling.cxx | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+--- a/src/BRepFill/BRepFill_Filling.cxx
++++ b/src/BRepFill/BRepFill_Filling.cxx
+@@ -105,6 +105,7 @@
+   while (!Edges.IsEmpty())
+   {
+     TopTools_ListIteratorOfListOfShape itl(Edges);
++    bool found = false;
+     for (; itl.More(); itl.Next())
+     {
+       anEdge = TopoDS::Edge(itl.Value());
+@@ -127,11 +128,17 @@
+           anEdge.Reverse();
+           V2 = V3;
+         }
++        found = true;
+         break;
+       }
+     }
+-    BB.Add(aWire, anEdge);
+-    Edges.Remove(itl);
++    if (found)
++    {
++      BB.Add(aWire, anEdge);
++      Edges.Remove(itl);
++    }
++    else
++      break;
+   }
+ 
+   aWire.Closed(Standard_True);

--- a/mingw-w64-opencascade/0004-BRepFill_Filling-Curve-constraints-confused-by-impli.patch
+++ b/mingw-w64-opencascade/0004-BRepFill_Filling-Curve-constraints-confused-by-impli.patch
@@ -1,0 +1,54 @@
+Subject: [PATCH 4/7] BRepFill_Filling: Curve constraints confused by implicit cast from GeomAbs_Shape to Standard_Integer
+From: blobfish <blobfish@gmx.com>
+
+Date: Tue, 29 Sep 2020 07:47:55 -0400
+
+
+---
+ src/BRepFill/BRepFill_Filling.cxx | 15 ++++++++++++---
+ 1 file changed, 12 insertions(+), 3 deletions(-)
+
+--- a/src/BRepFill/BRepFill_Filling.cxx
++++ b/src/BRepFill/BRepFill_Filling.cxx
+@@ -333,13 +333,22 @@
+       CurFace = SeqOfConstraints(i).myFace;
+       CurOrder = SeqOfConstraints(i).myOrder;
+       
++      // this silently defaults to C0 with an invalid value, 
++      // where before an exception would be
++      // thrown out of curve constraints. Good, Bad?
++      Standard_Integer orderAdapt = 0;
++      if (CurOrder == GeomAbs_G1)
++        orderAdapt = 1;
++      else if (CurOrder == GeomAbs_G2)
++        orderAdapt = 2;
++      
+       if (CurFace.IsNull()) {
+ 	if (CurOrder == GeomAbs_C0) {
+ 	  Handle( BRepAdaptor_HCurve ) HCurve = new BRepAdaptor_HCurve();
+ 	  HCurve->ChangeCurve().Initialize( CurEdge );
+ 	  const Handle(Adaptor3d_HCurve)& aHCurve = HCurve; // to avoid ambiguity
+ 	  Constr = new BRepFill_CurveConstraint(aHCurve,
+-						CurOrder,
++						orderAdapt,
+ 						myNbPtsOnCur,
+ 						myTol3d );
+ 	}
+@@ -363,7 +372,7 @@
+ 	  Handle (Adaptor3d_HCurveOnSurface) HCurvOnSurf = new Adaptor3d_HCurveOnSurface( CurvOnSurf );
+ 	  
+ 	  Constr = new GeomPlate_CurveConstraint(HCurvOnSurf,
+-						 CurOrder,
++						 orderAdapt,
+ 						 myNbPtsOnCur,
+ 						 myTol3d,
+ 						 myTolAng,
+@@ -383,7 +392,7 @@
+ 	  Handle (Adaptor3d_HCurveOnSurface) HCurvOnSurf = new Adaptor3d_HCurveOnSurface( CurvOnSurf );
+ 
+ 	  Constr = new BRepFill_CurveConstraint( HCurvOnSurf,
+-						 CurOrder,
++						 orderAdapt,
+ 						 myNbPtsOnCur,
+ 						 myTol3d,
+ 						 myTolAng,

--- a/mingw-w64-opencascade/0005-BRepFill_Filling-Don-t-even-attempt-to-build-with-em.patch
+++ b/mingw-w64-opencascade/0005-BRepFill_Filling-Don-t-even-attempt-to-build-with-em.patch
@@ -1,0 +1,25 @@
+Subject: [PATCH 5/7] BRepFill_Filling: Don't even attempt to build with empty boundary
+From: blobfish <blobfish@gmx.com>
+
+Date: Thu, 1 Oct 2020 10:06:35 -0400
+
+
+---
+ src/BRepFill/BRepFill_Filling.cxx | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+--- a/src/BRepFill/BRepFill_Filling.cxx
++++ b/src/BRepFill/BRepFill_Filling.cxx
+@@ -590,6 +590,12 @@
+   GeomPlate_BuildPlateSurface thebuild( myDegree, myNbPtsOnCur, myNbIter,
+                                         myTol2d, myTol3d, myTolAng, myTolCurv, myAnisotropie );
+ 
++  if (myBoundary.IsEmpty())
++  {
++    myIsDone = Standard_False;
++    return;
++  }
++  
+   myBuilder = thebuild;
+   TopoDS_Edge CurEdge;
+   TopoDS_Face CurFace;

--- a/mingw-w64-opencascade/0006-BRepOffset_Tool-TryProject-Check-return-of-BRepLib-B.patch
+++ b/mingw-w64-opencascade/0006-BRepOffset_Tool-TryProject-Check-return-of-BRepLib-B.patch
@@ -1,0 +1,22 @@
+Subject: [PATCH 6/7] BRepOffset_Tool: TryProject: Check return of BRepLib::BuildCurve3d. Might be degenerate edge, so no curve
+From: blobfish <blobfish@gmx.com>
+
+Date: Mon, 18 Jan 2021 22:26:33 -0500
+
+
+---
+ src/BRepOffset/BRepOffset_Tool.cxx | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/src/BRepOffset/BRepOffset_Tool.cxx
++++ b/src/BRepOffset/BRepOffset_Tool.cxx
+@@ -1894,7 +1894,8 @@
+     TopoDS_Edge CurE     = TopoDS::Edge(it.Value());
+     Handle(Geom_Curve) C = BRep_Tool::Curve(CurE,L,f,l);
+     if (C.IsNull()) {
+-      BRepLib::BuildCurve3d(CurE,BRep_Tool::Tolerance(CurE));
++      if (!BRepLib::BuildCurve3d(CurE,BRep_Tool::Tolerance(CurE)))
++        continue;
+       C  = BRep_Tool::Curve(CurE,L,f,l);
+     }
+     C = new Geom_TrimmedCurve(C,f,l);

--- a/mingw-w64-opencascade/0007-ChFi3d_Builder-PerformIntersectionAtEnd-Check-max-nu.patch
+++ b/mingw-w64-opencascade/0007-ChFi3d_Builder-PerformIntersectionAtEnd-Check-max-nu.patch
@@ -1,0 +1,20 @@
+Subject: [PATCH 7/7] ChFi3d_Builder: PerformIntersectionAtEnd: Check max number of faces
+From: blobfish <blobfish@gmx.com>
+
+Date: Mon, 18 Jan 2021 22:47:56 -0500
+
+
+---
+ src/ChFi3d/ChFi3d_Builder_C1.cxx | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/src/ChFi3d/ChFi3d_Builder_C1.cxx
++++ b/src/ChFi3d/ChFi3d_Builder_C1.cxx
+@@ -2018,6 +2018,7 @@
+       if ((possible1 && possible2) || (!possible1 && !possible2) || (nbarete > 4)) {
+ 	while (!trouve) {
+ 	  nb++;
++    if (nb>=nn) throw Standard_Failure("IntersectionAtEnd : the max number of faces reached");
+ 	  if (nb!=1) F3=Face[nb-2];
+ 	  Face[nb-1]=F3;
+ 	  if (CV1.Arc().IsSame(edgelibre1))

--- a/mingw-w64-opencascade/0008-Add-error-checking-to-chamfer-and-fillet-code.patch
+++ b/mingw-w64-opencascade/0008-Add-error-checking-to-chamfer-and-fillet-code.patch
@@ -1,0 +1,252 @@
+From 124f0d742ca49f2e897f27f4595b1079c9266f8e Mon Sep 17 00:00:00 2001
+From: Chris Hennes <chennes@gmail.com>
+Date: Sat, 30 Jan 2021 17:58:39 -0600
+Subject: [PATCH] Add error-checking to chamfer and fillet code
+
+---
+ src/ChFi3d/ChFi3d_Builder_0.cxx     |  9 +++++++++
+ src/ChFi3d/ChFi3d_Builder_C1.cxx    | 24 ++++++++++++++++++++++++
+ src/ChFi3d/ChFi3d_Builder_CnCrn.cxx | 14 +++++++++++++-
+ 3 files changed, 46 insertions(+), 1 deletion(-)
+
+--- a/src/ChFi3d/ChFi3d_Builder_0.cxx
++++ b/src/ChFi3d/ChFi3d_Builder_0.cxx
+@@ -4394,6 +4394,9 @@
+     if (!Fcur.IsSame(F1)) {
+       F=Fcur;trouve=Standard_True;}
+   }
++  if (trouve == Standard_False) {
++      throw Standard_Failure("Failed to find element.");
++  }
+ } 
+ //=======================================================================
+ //function : cherche_element
+@@ -4433,6 +4436,9 @@
+       }
+     }
+   }
++  if (trouve == Standard_False) {
++      throw Standard_Failure("Failed to find edge.");
++  }
+ } 
+ //=======================================================================
+ //function : cherche_edge
+@@ -4477,6 +4483,9 @@
+       }
+     }
+   }
++  if (trouve == Standard_False) {
++      throw Standard_Failure("Failed to find element.");
++  }
+ }
+ 
+ //=======================================================================
+--- a/src/ChFi3d/ChFi3d_Builder_C1.cxx
++++ b/src/ChFi3d/ChFi3d_Builder_C1.cxx
+@@ -338,6 +338,7 @@
+     return Standard_False;
+ 
+   Handle(Geom2d_Curve) gpcprol = BRep_Tool::CurveOnSurface(Eprol,Fprol,uf,ul);
++  if (gpcprol.IsNull()) throw Standard_Failure("Failed to create curve.");
+   Handle(Geom2dAdaptor_HCurve) pcprol = new Geom2dAdaptor_HCurve(gpcprol);
+   Standard_Real partemp = BRep_Tool::Parameter(Vtx,Eprol);
+ 
+@@ -822,11 +823,13 @@
+     if (onsame && IFopArc == 1) pfac1 = p2dbout;
+     else {
+       Hc1 = BRep_Tool::CurveOnSurface(CV1.Arc(),Fv,Ubid,Ubid);
++      if (Hc1.IsNull()) throw Standard_Failure("Failed to create curve.");
+       pfac1 = Hc1->Value(CV1.ParameterOnArc());
+     }
+     if (onsame && IFopArc == 2) pfac2 = p2dbout;
+     else {
+       Hc2 = BRep_Tool::CurveOnSurface(CV2.Arc(),Fv,Ubid,Ubid);
++      if (Hc2.IsNull()) throw Standard_Failure("Failed to create curve.");
+       pfac2 = Hc2->Value(CV2.ParameterOnArc());
+     }
+     if (Fi1.LineIndex() != 0) {
+@@ -868,6 +871,7 @@
+ 
+       //Standard_Real Ubid,Vbid;
+       Handle (Geom_Curve) C=BRep_Tool::Curve(edgecouture,Ubid,Vbid);
++      if (C.IsNull()) throw Standard_Failure("Failed to create curve.");
+       Handle(Geom_TrimmedCurve) Ctrim=new Geom_TrimmedCurve (C,Ubid,Vbid);
+       GeomAdaptor_Curve cur1(Ctrim->BasisCurve());
+       GeomAdaptor_Curve cur2(Cc);
+@@ -1050,6 +1054,7 @@
+         Standard_Real first, last, prm1, prm2;
+         Standard_Boolean onfirst, FirstToPar;
+         Handle(Geom2d_Curve) Hc = BRep_Tool::CurveOnSurface( CV[i].Arc(), Fv, first, last );
++        if (Hc.IsNull()) throw Standard_Failure("Failed to create curve.");
+         pfac1 = Hc->Value( CV[i].ParameterOnArc() );
+         PcF = Pc->Value( Udeb );
+         PcL = Pc->Value( Ufin );
+@@ -1101,6 +1106,7 @@
+         TopoDS_Edge aLocalEdge = CV[i].Arc();
+         aLocalEdge.Reverse();
+         Handle(Geom2d_Curve) HcR = BRep_Tool::CurveOnSurface( aLocalEdge, Fv, first, last );
++        if (HcR.IsNull()) throw Standard_Failure("Failed to create curve.");
+         Interfc = ChFi3d_FilCurveInDS( indcurv, indface, HcR, aLocalEdge.Orientation() );
+         DStr.ChangeShapeInterferences(indface).Append( Interfc );
+         //modify degenerated edge
+@@ -1126,6 +1132,7 @@
+         {
+           Standard_Real fd, ld;
+           Handle(Geom2d_Curve) Cd = BRep_Tool::CurveOnSurface( Edeg, Fv, fd, ld );
++          if (Cd.IsNull()) throw Standard_Failure("Failed to create curve.");
+           Handle(Geom2d_TrimmedCurve) tCd = Handle(Geom2d_TrimmedCurve)::DownCast(Cd);
+           if (! tCd.IsNull())
+             Cd = tCd->BasisCurve();
+@@ -1244,9 +1251,11 @@
+     const ChFiDS_FaceInterference& Fiop = Fd->Interference(IFopArc);
+     gp_Pnt2d pop1, pop2, pv1, pv2;
+     Hc = BRep_Tool::CurveOnSurface(Arcprol,Fop,Ubid,Ubid);
++    if (Hc.IsNull()) throw Standard_Failure("Failed to create curve.");
+     pop1 = Hc->Value(parVtx);
+     pop2 = Fiop.PCurveOnFace()->Value(Fiop.Parameter(isfirst));
+     Hc = BRep_Tool::CurveOnSurface(Arcprol,Fv,Ubid,Ubid);
++    if (Hc.IsNull()) throw Standard_Failure("Failed to create curve.");
+     pv1 = Hc->Value(parVtx);
+     pv2 = p2dbout;
+     ChFi3d_Recale(Bs,pv1,pv2,1);
+@@ -1436,6 +1445,9 @@
+       }
+     }
+   }
++  if (trouve == Standard_False) {
++      throw Standard_Failure("Failed to find face.");
++  }
+ }
+ 
+ //=======================================================================
+@@ -1466,6 +1478,9 @@
+                {Edge=Ecur1;trouve=Standard_True;}
+             }
+       }
++  if (trouve == Standard_False) {
++      throw Standard_Failure("Failed to find edge.");
++  }
+ }
+ 
+ //=======================================================================
+@@ -2147,6 +2162,7 @@
+ 
+     if (nb==1) {
+       Hc1 = BRep_Tool::CurveOnSurface(Edge[0],Face[0],Ubid,Ubid);
++      if (Hc1.IsNull()) throw Standard_Failure("Failed to create curve.");
+       if (isOnSame1) {
+         // update interference param on Fi1 and point of CV1
+         if (prolface[0]) Bs.Initialize(faceprol[0], Standard_False);
+@@ -2219,6 +2235,7 @@
+ 
+       Handle(Geom_Curve) C;
+       C=BRep_Tool::Curve(E2,Ubid,Vbid);
++      if (C.IsNull()) throw Standard_Failure("Failed to create curve.");
+       Handle(Geom_TrimmedCurve) Ctrim = new Geom_TrimmedCurve(C,Ubid,Vbid);
+       Standard_Real Utrim,Vtrim;
+       Utrim=Ctrim->BasisCurve()->FirstParameter();
+@@ -2344,7 +2361,9 @@
+ 	  paredge2=inters.Point(nbp).W();
+ 	  if (!extend) {
+ 	    cfacemoins1=BRep_Tool::CurveOnSurface(E2,F,u2,v2);
++        if (cfacemoins1.IsNull()) throw Standard_Failure("Failed to create curve.");
+ 	    cface=BRep_Tool::CurveOnSurface(E2,Face[nb],u2,v2);
++        if (cface.IsNull()) throw Standard_Failure("Failed to create curve.");
+ 	    cfacemoins1->D0(paredge2,pfac2);
+ 	    cface->D0(paredge2,pint);
+ 	  }
+@@ -4010,11 +4029,13 @@
+     if( IFopArc == 1) pfac1 = p2dbout;
+     else {
+       Hc1 = BRep_Tool::CurveOnSurface(CV1.Arc(),Fv,Ubid,Ubid);
++      if (Hc1.IsNull()) throw Standard_Failure("Failed to create curve.");
+       pfac1 = Hc1->Value(CV1.ParameterOnArc());
+     }
+     if(IFopArc == 2) pfac2 = p2dbout;
+     else {
+       Hc2 = BRep_Tool::CurveOnSurface(CV2.Arc(),Fv,Ubid,Ubid);
++      if (Hc2.IsNull()) throw Standard_Failure("Failed to create curve.");
+       pfac2 = Hc2->Value(CV2.ParameterOnArc());
+     }
+     if(Fi1.LineIndex() != 0){
+@@ -4054,6 +4075,7 @@
+ 
+       //Standard_Real Ubid,Vbid;
+       Handle (Geom_Curve) C=BRep_Tool::Curve(edgecouture,Ubid,Vbid);
++      if (C.IsNull()) throw Standard_Failure("Failed to create curve.");
+       Handle(Geom_TrimmedCurve) Ctrim=new Geom_TrimmedCurve (C,Ubid,Vbid);
+       GeomAdaptor_Curve cur1(Ctrim->BasisCurve());
+       GeomAdaptor_Curve cur2(Cc);
+@@ -4284,9 +4306,11 @@
+ //  Modified by skv - Thu Aug 21 11:55:58 2008 OCC20222 End
+     //fin modif
+     Hc = BRep_Tool::CurveOnSurface(Arcprolbis,Fop,Ubid,Ubid);
++    if (Hc.IsNull()) throw Standard_Failure("Failed to create curve.");
+     pop1 = Hc->Value(parVtx);
+     pop2 = Fiop.PCurveOnFace()->Value(Fiop.Parameter(isfirst));
+     Hc = BRep_Tool::CurveOnSurface(Arcprol,Fv,Ubid,Ubid);
++    if (Hc.IsNull()) throw Standard_Failure("Failed to create curve.");
+     //modif
+     parVtx = BRep_Tool::Parameter(Vtx,Arcprol);
+     //fin modif
+--- a/src/ChFi3d/ChFi3d_Builder_CnCrn.cxx
++++ b/src/ChFi3d/ChFi3d_Builder_CnCrn.cxx
+@@ -291,6 +291,9 @@
+       {Edge=Ecur1;trouve=Standard_True;}
+     }
+   }
++  if (trouve == Standard_False) {
++      throw Standard_Failure("Failed to find edge.");
++  }
+ }
+ 
+ //=======================================================================
+@@ -332,6 +335,7 @@
+   Handle (Geom_Curve) c1,c2;
+   if (sharpicmoins) {
+     c1=BRep_Tool::Curve(Eviveicmoins,up1,up2);
++    if (c1.IsNull()) throw Standard_Failure("Failed to create curve.");
+   }
+   else {
+     if (jficmoins==1) 
+@@ -341,6 +345,7 @@
+   }
+   if (sharpicplus){
+     c2=BRep_Tool::Curve(Eviveicplus,up1,up2);
++    if (c2.IsNull()) throw Standard_Failure("Failed to create curve.");
+   }
+   else {
+     jfp=3-jficplus;   
+@@ -414,8 +419,10 @@
+             }
+             Eproj.Append(E1);
+             proj1=BRep_Tool::CurveOnSurface(E1,F,up1,up2);
++            if (proj1.IsNull()) throw Standard_Failure("Failed to create curve.");
+             proj2d.Append(new Geom2d_TrimmedCurve(proj1,up1,up2));
+             proj1c=BRep_Tool::Curve(E1,up1,up2);
++            if (proj1c.IsNull()) throw Standard_Failure("Failed to create curve.");
+             cproj.Append(new Geom_TrimmedCurve(proj1c,up1,up2));
+             if (error>BRep_Tool::Tolerance(E1)) error=BRep_Tool::Tolerance(E1);
+           }
+@@ -2459,15 +2466,20 @@
+ 	Pf=BRep_Tool::Pnt(Vf);
+ 	Pl=BRep_Tool::Pnt(Vl);
+ 	para=parcom.Value(nb);
+-	Pcom=BRep_Tool::Curve(TopoDS::Edge(Ecom.Value(nb)),up1,up2)->Value(para);
++	Handle(Geom_Curve) result = BRep_Tool::Curve(TopoDS::Edge(Ecom.Value(nb)),up1,up2);
++        if (result.IsNull()) throw Standard_Failure("Failed to create curve.");
++	Pcom=result->Value(para);
++
+ 	if (Pf.Distance(BRep_Tool::Pnt(V1))< Pl.Distance(BRep_Tool::Pnt(V1)))
+ 	  orvt=TopAbs_FORWARD;
+ 	if (!Eproj.Value(nb).IsNull())  {
+ 	  n3d++;
+ 	  proj=BRep_Tool::CurveOnSurface(TopoDS::Edge(Eproj.Value(nb)),
+ 					 TopoDS::Face(Fproj.Value(nb)),up1,up2);
++      if (proj.IsNull()) throw Standard_Failure("Failed to create curve.");
+ 	  proj2d=new Geom2d_TrimmedCurve(proj,up1,up2);
+ 	  projc=BRep_Tool::Curve(TopoDS::Edge(Eproj.Value(nb)),up1,up2);
++      if (projc.IsNull()) throw Standard_Failure("Failed to create curve.");
+ 	  cproj=new Geom_TrimmedCurve(projc,up1,up2);
+ 	  pardeb=cproj->FirstParameter();
+ 	  parfin=cproj->LastParameter();

--- a/mingw-w64-opencascade/PKGBUILD
+++ b/mingw-w64-opencascade/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=7.5.2
 _pkgver2=V${pkgver//./_}
-pkgrel=2
+pkgrel=3
 pkgdesc='Open CASCADE Technology, 3D modeling & numerical simulation (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -25,13 +25,52 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-qt5-base"
 license=('custom')
 url='https://www.opencascade.org'
 source=("opencascade-${pkgver}.tgz::https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=refs/tags/${_pkgver2};sf=tgz"
-        "0001-fix-compile-openvr.patch")
-sha256sums=('1A32D2B0D6D3C236163CB45139221FB198F0F3CDAD56606C5B1C9A2A8869B3AC'
-         'SKIP')
+        "0001-fix-compile-openvr.patch"
+        
+        # The following patches are ported from the Debian Science Team
+        # https://salsa.debian.org/science-team/opencascade/-/tree/master/debian/patches
+
+        # Source: https://salsa.debian.org/science-team/opencascade/-/blob/master/debian/patches/0002-GeomPlate_BuildAveragePlane-BasePlan-Don-t-set-yvect.patch
+        "0002-GeomPlate_BuildAveragePlane-BasePlan-Don-t-set-yvect.patch"
+        
+        # Source: https://salsa.debian.org/science-team/opencascade/-/blob/master/debian/patches/0003-BRepFill_Filling-WireFromList-We-can-t-assume-that-a.patch
+        "0003-BRepFill_Filling-WireFromList-We-can-t-assume-that-a.patch"
+        
+        # Source: https://salsa.debian.org/science-team/opencascade/-/blob/master/debian/patches/0004-BRepFill_Filling-Curve-constraints-confused-by-impli.patch
+        "0004-BRepFill_Filling-Curve-constraints-confused-by-impli.patch"
+        
+        # Source: https://salsa.debian.org/science-team/opencascade/-/blob/master/debian/patches/0005-BRepFill_Filling-Don-t-even-attempt-to-build-with-em.patch
+        "0005-BRepFill_Filling-Don-t-even-attempt-to-build-with-em.patch"
+        
+        # Source: https://salsa.debian.org/science-team/opencascade/-/blob/master/debian/patches/0006-BRepOffset_Tool-TryProject-Check-return-of-BRepLib-B.patch
+        "0006-BRepOffset_Tool-TryProject-Check-return-of-BRepLib-B.patch"
+        
+        # Source: https://salsa.debian.org/science-team/opencascade/-/blob/master/debian/patches/0007-ChFi3d_Builder-PerformIntersectionAtEnd-Check-max-nu.patch
+        "0007-ChFi3d_Builder-PerformIntersectionAtEnd-Check-max-nu.patch"
+        
+        # Source: http://git.dev.opencascade.org/gitweb/?p=occt.git;a=commitdiff;h=329e5df986519164083d78b28ae62d1a3b10fa6a
+        "0008-Add-error-checking-to-chamfer-and-fillet-code.patch") # 0008 is scheduled for inclusion in OCCT 7.6.0
+      
+sha256sums=('1a32d2b0d6d3c236163cb45139221fb198f0f3cdad56606c5b1c9a2a8869b3ac'
+            '0bbba5858e3e478759dac3d4802f821ec633304a63aeef542e0e4e0e0674e205'
+            '9e72d389359899d959fa66b131c9871c15a136bb600c246fcf7e05910d277335'
+            'f126465de547d606c4af2e95bd550ba7d5528d53a9b73693078952f9a40b3cae'
+            'b62b1c5195254d5f80d913f0f5a6a009638f0aa697e2a84da58e3cf19bf0c958'
+            'cfffe467050af56c65e3d6bd1827041661c9e29858b7c83089427f2905a078b2'
+            'd39ce849914e6349161675b9d412351684eb6af4bed1aa31afbdc54fa153a532'
+            '148a70486a83328fc26845549fa3f175533c481525e26ce0079c8a8e0eab66fa'
+            '50a0b216da456c6add6a20d411b9dced18e9905e42738609ecca72099992c8e4')
 
 prepare() {
   cd "${srcdir}"/occt-${_pkgver2}
   patch -p1 -i "${srcdir}"/0001-fix-compile-openvr.patch
+  patch -p1 -i "${srcdir}"/0002-GeomPlate_BuildAveragePlane-BasePlan-Don-t-set-yvect.patch
+  patch -p1 -i "${srcdir}"/0003-BRepFill_Filling-WireFromList-We-can-t-assume-that-a.patch
+  patch -p1 -i "${srcdir}"/0004-BRepFill_Filling-Curve-constraints-confused-by-impli.patch
+  patch -p1 -i "${srcdir}"/0005-BRepFill_Filling-Don-t-even-attempt-to-build-with-em.patch
+  patch -p1 -i "${srcdir}"/0006-BRepOffset_Tool-TryProject-Check-return-of-BRepLib-B.patch
+  patch -p1 -i "${srcdir}"/0007-ChFi3d_Builder-PerformIntersectionAtEnd-Check-max-nu.patch
+  patch -p1 -i "${srcdir}"/0008-Add-error-checking-to-chamfer-and-fillet-code.patch
 }
 
 build() {


### PR DESCRIPTION
Add the seven patches that the Debian Science Team is currently applying to the Buster package for OpenCASCADE. The first six are exactly the same patches that made it into the Buster release. The seventh has been updated to match the actual patch accepted to the upstream for OCCT 7.6. Most of the patches are courtesy of "blobfish <blobfish@gmx.com>". The last is courtesy of "Chris Hennes <chennes@gmail.com>" (me).

Ref 1:
https://salsa.debian.org/science-team/opencascade/-/tree/master/debian/patches

Ref 2:
http://git.dev.opencascade.org/gitweb/?p=occt.git;a=commitdiff;h=329e5df986519164083d78b28ae62d1a3b10fa6a