### PR TITLE
qt-creator: Update to 5.0.1

### DIFF
--- a/mingw-w64-qt-creator/PKGBUILD
+++ b/mingw-w64-qt-creator/PKGBUILD
@@ -5,7 +5,7 @@ _realname=qt-creator
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 __pre=
-_base_ver=5.0.0
+_base_ver=5.0.1
 pkgver=${_base_ver}${_pre}
 pkgrel=1
 pkgdesc='Cross-platform IDE (mingw-w64)'
@@ -45,7 +45,7 @@ source=(#https://download.qt.io/development_releases/qtcreator/${_base_ver%.*}/$
         https://download.qt.io/official_releases/qtcreator/${pkgver%.*}/${pkgver}/${_pkgfqn}.tar.xz
         qt-creator-3.2.0-Allow-iOS-plugin-on-any-platform.patch)
 noextract=(${_pkgfqn}.tar.xz)
-sha256sums=('b24b194a2e96f07baf55815264cd898fa0399673bfedd500575098fdf8d70475'
+sha256sums=('cf2123943731d38997bfc30e40475022f26cba49ac3e1fe50ac357af995296a6'
             '96c14f54577bf6cadf5c12018745666a9e99cd8d6a876c29a28b13599a8cb368')
 
 prepare() {
@@ -85,6 +85,7 @@ package() {
   cd ${srcdir}/build-${MSYSTEM}
 
   DESTDIR="${pkgdir}" cmake --install .
+  DESTDIR="${pkgdir}" cmake --install . --component Devel
   DESTDIR="${pkgdir}" cmake --install . --component qch_docs
   DESTDIR="${pkgdir}" cmake --install . --component html_docs
 

--- a/mingw-w64-qt-creator/PKGBUILD
+++ b/mingw-w64-qt-creator/PKGBUILD
@@ -43,10 +43,12 @@ options=('docs' 'staticlibs') # 'debug' '!strip')
 _pkgfqn="${_realname}-opensource-src-${_base_ver}${__pre}"
 source=(#https://download.qt.io/development_releases/qtcreator/${_base_ver%.*}/${_base_ver}${__pre}/${_pkgfqn}.tar.xz
         https://download.qt.io/official_releases/qtcreator/${pkgver%.*}/${pkgver}/${_pkgfqn}.tar.xz
-        qt-creator-3.2.0-Allow-iOS-plugin-on-any-platform.patch)
+        qt-creator-3.2.0-Allow-iOS-plugin-on-any-platform.patch
+        qt-creator-5.0.1-fix-library-archive-path.patch)
 noextract=(${_pkgfqn}.tar.xz)
 sha256sums=('cf2123943731d38997bfc30e40475022f26cba49ac3e1fe50ac357af995296a6'
-            '96c14f54577bf6cadf5c12018745666a9e99cd8d6a876c29a28b13599a8cb368')
+            '96c14f54577bf6cadf5c12018745666a9e99cd8d6a876c29a28b13599a8cb368'
+            '4daf74e55e9b5cae9f05704a98fb832688edf958481cfb2246aecf6b54156e53')
 
 prepare() {
   [[ -d ${srcdir}/${_pkgfqn} ]] && rm -rf ${srcdir}/${_pkgfqn}
@@ -55,6 +57,7 @@ prepare() {
   cd ${srcdir}/${_pkgfqn}
 
   patch -p1 -i "${srcdir}"/qt-creator-3.2.0-Allow-iOS-plugin-on-any-platform.patch
+  patch -p1 -i "${srcdir}"/qt-creator-5.0.1-fix-library-archive-path.patch
 }
 
 build() {

--- a/mingw-w64-qt-creator/qt-creator-5.0.1-fix-library-archive-path.patch
+++ b/mingw-w64-qt-creator/qt-creator-5.0.1-fix-library-archive-path.patch
@@ -1,0 +1,12 @@
+diff -Naur qt-creator-opensource-src-5.0.1-orig/cmake/QtCreatorAPIInternal.cmake qt-creator-opensource-src-5.0.1/cmake/QtCreatorAPIInternal.cmake
+--- qt-creator-opensource-src-5.0.1-orig/cmake/QtCreatorAPIInternal.cmake	2021-09-26 14:01:05.079629000 +0300
++++ qt-creator-opensource-src-5.0.1/cmake/QtCreatorAPIInternal.cmake	2021-09-26 16:43:46.107410400 +0300
+@@ -61,7 +61,7 @@
+   set(_IDE_DATA_PATH "share/qtcreator")
+   set(_IDE_DOC_PATH "share/doc/qtcreator")
+   set(_IDE_BIN_PATH "bin")
+-  set(_IDE_LIBRARY_ARCHIVE_PATH "${_IDE_BIN_PATH}")
++  set(_IDE_LIBRARY_ARCHIVE_PATH "${_IDE_LIBRARY_PATH}")
+ 
+   set(_IDE_HEADER_INSTALL_PATH "include/qtcreator")
+   set(_IDE_CMAKE_INSTALL_PATH "lib/cmake")


### PR DESCRIPTION
Install `Devel` component.

Closes #9664.

~~NOTES~~: The files `*.dll.a` are installed next to the files `*.dll`. Maybe we need to fix this. (Fixed in 7e0f027)