### PR TITLE
Fritzing: update to 0.9.9

### DIFF
--- a/mingw-w64-fritzing/0001-Fix-casts-from-pointer-to-long-to-size_t-instead.patch
+++ b/mingw-w64-fritzing/0001-Fix-casts-from-pointer-to-long-to-size_t-instead.patch
@@ -1,4 +1,4 @@
-From 9aef3ce9fcc050874d870d131a6bbcd635055c10 Mon Sep 17 00:00:00 2001
+From 4c4684b5f37d6f3bc8d8b43a296a23152c1af49a Mon Sep 17 00:00:00 2001
 From: Jeremy Drake <github@jdrake.com>
 Date: Wed, 2 Dec 2020 11:54:32 -0800
 Subject: [PATCH 1/3] Fix casts from pointer to long to size_t instead.
@@ -68,7 +68,7 @@ index 7494ebb5..51c98bf1 100644
  	            .arg(this->m_strokeWidth)
  	            .arg(p.x())
 diff --git a/src/items/itembase.cpp b/src/items/itembase.cpp
-index 9d13ca9b..761b0aaa 100644
+index 854e8a1b..5a9ff141 100644
 --- a/src/items/itembase.cpp
 +++ b/src/items/itembase.cpp
 @@ -1859,7 +1859,7 @@ void ItemBase::debugInfo2(const QString & msg) const
@@ -81,7 +81,7 @@ index 9d13ca9b..761b0aaa 100644
  	                   .arg(this->zValue())
  	                   .arg(this->pos().x())
 diff --git a/src/items/paletteitem.cpp b/src/items/paletteitem.cpp
-index 3c6c14ba..382326df 100644
+index b1f3740d..66a65fac 100644
 --- a/src/items/paletteitem.cpp
 +++ b/src/items/paletteitem.cpp
 @@ -200,7 +200,7 @@ void PaletteItem::makeOneKin(qint64 & id, ViewLayer::ViewLayerID viewLayerID, Vi
@@ -94,7 +94,7 @@ index 3c6c14ba..382326df 100644
  		addLayerKin(lkpi);
  		id++;
 diff --git a/src/sketch/sketchwidget.cpp b/src/sketch/sketchwidget.cpp
-index a7486b8f..34137460 100644
+index e4526630..810de05b 100644
 --- a/src/sketch/sketchwidget.cpp
 +++ b/src/sketch/sketchwidget.cpp
 @@ -958,7 +958,7 @@ ItemBase * SketchWidget::findItem(long id) {
@@ -116,5 +116,5 @@ index a7486b8f..34137460 100644
  	// this is a hack to try to workaround a Qt 4.7 crash in QGraphicsSceneFindItemBspTreeVisitor::visit
  	// when using a custom boundingRect, after deleting an item, it still appears on the visit list.
 -- 
-2.31.1.windows.1
+2.33.0.windows.2
 

--- a/mingw-w64-fritzing/0002-qmake-fixes-for-mingw.patch
+++ b/mingw-w64-fritzing/0002-qmake-fixes-for-mingw.patch
@@ -1,4 +1,4 @@
-From 46060b16fd66e6db9306ea06514fa2f23b38c1f6 Mon Sep 17 00:00:00 2001
+From 1fa77d4c23584dba05d884d58e0ba0b2fd682f48 Mon Sep 17 00:00:00 2001
 From: Jeremy Drake <github@jdrake.com>
 Date: Wed, 2 Dec 2020 12:00:03 -0800
 Subject: [PATCH 2/3] qmake fixes for mingw.
@@ -10,12 +10,12 @@ Mostly want it to act like unix.
  2 files changed, 27 insertions(+), 20 deletions(-)
 
 diff --git a/phoenix.pro b/phoenix.pro
-index 2abf6d0d..a4482772 100644
+index dab1ba21..61ded217 100644
 --- a/phoenix.pro
 +++ b/phoenix.pro
-@@ -33,7 +33,7 @@ CONFIG += c++14
- # TODO: Verify flags for clang and msvc builds
- QMAKE_CXXFLAGS += -O3 -fno-omit-frame-pointer
+@@ -33,7 +33,7 @@ unix {
+     QMAKE_CXXFLAGS += -O3 -fno-omit-frame-pointer
+ }
  
 -unix:!macx {
 +if(unix:!macx)|mingw {
@@ -86,7 +86,7 @@ index 2abf6d0d..a4482772 100644
          !contains(DEFINES, QUAZIP_INSTALLED) {
              LIBS += -lz
 diff --git a/pri/libgit2detect.pri b/pri/libgit2detect.pri
-index f8dae314..5fbd177f 100644
+index 66b3e0d0..f0db8984 100644
 --- a/pri/libgit2detect.pri
 +++ b/pri/libgit2detect.pri
 @@ -34,7 +34,7 @@ if ($$LIBGIT_STATIC) {
@@ -98,8 +98,8 @@ index f8dae314..5fbd177f 100644
      contains(QMAKE_TARGET.arch, x86_64) {
          LIBGIT2LIB = "$$_PRO_FILE_PWD_/../libgit2/build64/Release"
      } else {
-@@ -51,7 +51,7 @@ win32 {
-     message($$PKGCONFIG)
+@@ -50,7 +50,7 @@ win32 {
+     LIBS += -L$$LIBGIT2LIB -lgit2
  }
  
 -unix {
@@ -108,5 +108,5 @@ index f8dae314..5fbd177f 100644
          LIBGIT2LIB = $$_PRO_FILE_PWD_/../libgit2/build
          exists($$LIBGIT2LIB/libgit2.a) {
 -- 
-2.31.1.windows.1
+2.33.0.windows.2
 

--- a/mingw-w64-fritzing/0003-Look-in-.-share-fritzing-from-bin-dir-on-mingw.patch
+++ b/mingw-w64-fritzing/0003-Look-in-.-share-fritzing-from-bin-dir-on-mingw.patch
@@ -1,4 +1,4 @@
-From ebbc071ed53eef7778f5b526763c128ab7b34c6b Mon Sep 17 00:00:00 2001
+From 6a35d412da0e3dac2735d7eaa5d05c9f67213f9f Mon Sep 17 00:00:00 2001
 From: Jeremy Drake <github@jdrake.com>
 Date: Wed, 2 Dec 2020 23:07:02 -0800
 Subject: [PATCH 3/3] Look in ../share/fritzing from bin dir on mingw.
@@ -32,5 +32,5 @@ index 5914924b..a6d97603 100644
  			candidates.append(dir.absolutePath());
  			if (dir.cdUp()) {
 -- 
-2.31.1.windows.1
+2.33.0.windows.2
 

--- a/mingw-w64-fritzing/PKGBUILD
+++ b/mingw-w64-fritzing/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=fritzing
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.9.6
-pkgrel=3
+pkgver=0.9.9
+pkgrel=1
 pkgdesc="Electronic Design Automation software with a low entry barrier, suited for the needs of makers and hobbyists (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -21,8 +21,10 @@ depends=("${MINGW_PACKAGE_PREFIX}-qt5-base"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 # Fritzing updates its parts repo online from the master branch, so the latest
 # master commit should be fine here
-_partscommit='e79a69765026f3fda8aab1b3e7a4952c28047a62'
-source=("${_realname}"::"git+https://github.com/fritzing/fritzing-app.git#tag=${pkgver}"
+_partscommit='640fa25650211afccd369f960375ade8ec3e8653'
+_appcommit='f0af53a9077f7cdecef31d231b85d8307de415d4'
+# Fritzing seems not to be tagging its releases anymore.  https://aur.archlinux.org/packages/fritzing#comment-822991
+source=("${_realname}"::"git+https://github.com/fritzing/fritzing-app.git#commit=$_appcommit"
         "${_realname}-parts"::"git+https://github.com/fritzing/fritzing-parts.git#commit=$_partscommit"
         0001-Fix-casts-from-pointer-to-long-to-size_t-instead.patch
         0002-qmake-fixes-for-mingw.patch
@@ -30,9 +32,9 @@ source=("${_realname}"::"git+https://github.com/fritzing/fritzing-app.git#tag=${
         system-libgit2.patch)
 sha256sums=('SKIP'
             'SKIP'
-            'f06de3f2cd642df40a6239db3736a0fe4f1ed6bc87a4d99a1fc893ae7e71fd67'
-            'ccbb2b66b8cb7a7fd1a19117062b430753c265587d7dbf0d2289627fcedc3fa2'
-            'c7e9352acc9e12fcb056dda9d32c9d594aa096b83f61725007ebb2a2cc91b50b'
+            '6d1a0d3a4daf775bff3f592e548430fccad8ac90f6573970bb4bf299ec344763'
+            '3f101f91cdaf3ce40e74a38a48d94535a7dc1126126374ce043b946039b8f056'
+            'b367dc68cc4dd4468650fe122117ae93b5d21b3301018c0920ce13219dd6f522'
             'b9fcdd41207a5d8fd67d44c5d4b3348e25464815431a91b61111b1fd91f1495f')
 
 prepare() {


### PR DESCRIPTION
Apparently the author is not being very good about keeping the github
repo up to date, and has not tagged the last few releases.  Commit hashes from https://aur.archlinux.org/packages/fritzing