### PR TITLE
Update GHDL, Yosys and nextpnr

### DIFF
--- a/mingw-w64-ghdl/PKGBUILD
+++ b/mingw-w64-ghdl/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=ghdl
 pkgbase="mingw-w64-${_realname}"
 pkgname='__placeholder__'
-pkgver=1.0.0.r740.g95cbcc921
+pkgver=1.0.0.r804.gf11aa2981
 pkgrel=1
 pkgdesc='GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL'
 arch=('any')
@@ -11,7 +11,8 @@ url='https://github.com/ghdl'
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_commit="95cbcc92"
+
+_commit="f11aa298"
 source=("${_realname}::git+https://github.com/ghdl/ghdl.git#commit=${_commit}")
 sha512sums=('SKIP')
 

--- a/mingw-w64-nextpnr/PKGBUILD
+++ b/mingw-w64-nextpnr/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=nextpnr
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.0.r3788.g67bd349e
+pkgver=0.0.r3829.g8b3e6711
 pkgrel=1
 pkgdesc="Portable FPGA place and route tool (mingw-w64)"
 arch=('any')
@@ -28,7 +28,7 @@ makedepends=(
   "git"
 )
 
-_commit="67bd349e"
+_commit="8b3e6711"
 source=("${_realname}::git+https://github.com/YosysHQ/${_realname}.git#commit=${_commit}")
 sha256sums=('SKIP')
 

--- a/mingw-w64-yosys/PKGBUILD
+++ b/mingw-w64-yosys/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=yosys
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.9.r10947.g551ef85c
+pkgver=0.10.r10
 pkgrel=1
 pkgdesc="A framework for RTL synthesis tools (mingw-w64)"
 arch=('any')
@@ -21,20 +21,15 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python"
 )
 
-_commit='551ef85c'
+_commit='f3ef579a'
 source=(
   "${_realname}::git+https://github.com/YosysHQ/${_realname}.git#commit=${_commit}"
-  "ghdl-yosys-plugin::git+https://github.com/ghdl/ghdl-yosys-plugin.git#commit=98f4594b"
+  "ghdl-yosys-plugin::git+https://github.com/ghdl/ghdl-yosys-plugin.git#commit=45da3277"
 )
 sha256sums=(
   'SKIP'
   'SKIP'
 )
-
-pkgver() {
-  cd "${_realname}"
-  printf "0.9.r%s.g%s" "$(git rev-list --count ${_commit})" "$(git rev-parse --short=8 ${_commit})"
-}
 
 build() {
   cd "${srcdir}/${_realname}"


### PR DESCRIPTION
A regular update of some EDA tools.
Yosys 0.10 was released and a different versioning logic is used now (hardcoded instead of using `pkgver()`).