### PR TITLE
fftw: enable avx-128-fma/avx2/avx512

### DIFF
--- a/mingw-w64-fftw/PKGBUILD
+++ b/mingw-w64-fftw/PKGBUILD
@@ -5,13 +5,15 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _pkgver=3.3.10
 pkgver=${_pkgver//-/.}
-pkgrel=1
+pkgrel=2
 pkgdesc="A library for computing the discrete Fourier transform (DFT) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://www.fftw.org/"
 license=("GPL")
-makedepends=("${MINGW_PACKAGE_PREFIX}-pkg-config")
+makedepends=("${MINGW_PACKAGE_PREFIX}-pkg-config"
+             $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || \
+               echo "${MINGW_PACKAGE_PREFIX}-gcc-fortran"))
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 options=('staticlibs' 'strip')
 source=("https://www.fftw.org/${_realname}-${_pkgver}.tar.gz")
@@ -21,26 +23,34 @@ precision="double float long_double \
            $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "quad" )"
 
 build() {
-  cd "${srcdir}/${_realname}-${_pkgver}"
   # clang complains when trying to use an sse2 intrinsic if sse2 is not enabled
   if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-i686* ]]; then
     CFLAGS+=" -msse2"
   fi
+
   for cur in ${precision}; do
-    local _config="--enable-sse2 --enable-avx"
+    [[ -d ${srcdir}/${MSYSTEM}-${cur} ]] && rm -rf ${srcdir}/${MSYSTEM}-${cur}
+    mkdir -p ${srcdir}/${MSYSTEM}-${cur} && cd ${srcdir}/${MSYSTEM}-${cur}
+
+    msg "Building ${_realname} with ${cur} ..."
+
+    local -a _config=""
+    if [[ ${MINGW_PACKAGE_PREFIX} != *-clang-aarch64* ]]; then
+      _config+="--enable-sse2 --enable-avx --enable-avx-128-fma --enable-avx2"
+    fi
+    if [ $CARCH = x86_64 ]; then
+      _config+=" --enable-avx512"
+    fi
+
     if [ "${cur}" = "float" ]; then
-      _config="${_config} --enable-float"
+      _config+=" --enable-float"
     elif [ "${cur}" = "long_double" ]; then
       _config="--enable-long-double"
     elif [ "${cur}" = "quad" ]; then
       _config="--enable-quad-precision"
     fi
-    [[ -d ${MINGW_CHOST}-${cur} ]] && rm -rf ${MINGW_CHOST}-${cur}
-    mkdir -p ${MINGW_CHOST}-${cur}
-    pushd ${MINGW_CHOST}-${cur} > /dev/null
-    msg "Building ${_realname} with ${cur} ..."
 
-    ../configure \
+    ../${_realname}-${_pkgver}/configure \
       --prefix=${MINGW_PREFIX} \
       --build=${MINGW_CHOST} \
       --host=${MINGW_CHOST} \
@@ -52,19 +62,14 @@ build() {
       --with-our-malloc \
       --with-g77-wrappers \
       --with-windows-f77-mangling
+
     make
-
-    popd > /dev/null
-
   done
 }
 
 package() {
-  cd "${srcdir}/${_realname}-${_pkgver}"
   for cur in ${precision}; do
-    pushd ${MINGW_CHOST}-${cur} > /dev/null
-    msg "Instaling ${_realname} with ${cur} ..."
-    make DESTDIR="${pkgdir}" install
-    popd > /dev/null
+    msg "Installing ${_realname} with ${cur} ..."
+    make DESTDIR="${pkgdir}" install -C ${srcdir}/${MSYSTEM}-${cur}
   done
 }


### PR DESCRIPTION
> you can compile with--enable-avx and the code will still run on a CPU without AVX support

http://fftw.org/fftw3_doc/Installation-on-Unix.html#Installation-on-Unix