### PR TITLE
added SLiM population genetic simulation software package

### DIFF
--- a/mingw-w64-SLiM/PKGBUILD
+++ b/mingw-w64-SLiM/PKGBUILD
@@ -1,0 +1,31 @@
+_realname=SLiM
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=3.7
+pkgrel=1
+pkgdesc="SLiM forward simulation software package for population genetics (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+url="https://messerlab.org/slim/"
+license=("GPL")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-cmake")
+depends=("${MINGW_PACKAGE_PREFIX}-qt5")
+source=("http://benhaller.com/slim/SLiM_pacman.tar.gz" )
+sha256sums=("003f095120595b2a206fc2d7a451e2189a56639ae7b85a070b76c4ce13def391")
+
+build() {
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  cmake -G "MSYS Makefiles" -DBUILD_SLIMGUI=ON ../SLiM_pacman
+  make
+}
+
+package() {
+
+  install -Dm 755 "${srcdir}/build-${MINGW_CHOST}"/*.exe -t "${pkgdir}${MINGW_PREFIX}"/bin/
+  install -Dm 644 "${srcdir}/SLiM_pacman/LICENSE" -t "${pkgdir}${MINGW_PREFIX}"/share/licenses/SLiM/
+  install -Dm 644 "${srcdir}/SLiM_pacman/VERSIONS" "${srcdir}/SLiM_pacman"/README.md \
+   -t "${pkgdir}${MINGW_PREFIX}"/share/doc/SLiM/
+  
+}


### PR DESCRIPTION
This package installs the forward population genetics simulation software known as SLiM (https://messerlab.org/slim/). This package culminates a big effort to get this software ported to Windows from linux / MacOS. This is my first package submission so hopefully I've done it right. All local testing has passed.