### PR TITLE
libusb: fix dll exports on CLANG

### DIFF
--- a/mingw-w64-libusb/PKGBUILD
+++ b/mingw-w64-libusb/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libusb
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.0.24
-pkgrel=3
+pkgrel=4
 pkgdesc="Library that provides generic access to USB devices (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -12,8 +12,10 @@ url="https://libusb.info/"
 license=("LGPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 options=('staticlibs' 'strip')
-source=("https://github.com/libusb/libusb/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.bz2")
-sha256sums=('7efd2685f7b327326dcfb85cee426d9b871fd70e22caa15bb68d595ce2a2b12a')
+source=("https://github.com/libusb/libusb/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.bz2"
+        "fix-dll-exports.patch")
+sha256sums=('7efd2685f7b327326dcfb85cee426d9b871fd70e22caa15bb68d595ce2a2b12a'
+            'e25a317610623df4c020ff904661f52b1de6c9f95f3966aef52cf34886c768b3')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -22,21 +24,14 @@ prepare() {
     sed -e "s/-mwin32//g" -e "s/-Wl,--add-stdcall-alias//g" -i configure.ac
   fi
 
+  patch -Nbp1 -i "${srcdir}/fix-dll-exports.patch"
+
   autoreconf -fiv
 }
 
 build() {
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
   mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
-
-  # Copied from llvm-mingw/wrappers/dlltool-wrapper.sh
-  case ${CARCH} in
-    i686)    M=i386        ;;
-    x86_64)  M=i386:x86-64 ;;
-    armv7)   M=arm         ;;
-    aarch64) M=arm64       ;;
-  esac
-  export DLLTOOLFLAGS="-m ${M}"
 
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \

--- a/mingw-w64-libusb/fix-dll-exports.patch
+++ b/mingw-w64-libusb/fix-dll-exports.patch
@@ -1,0 +1,10 @@
+--- a/libusb/Makefile.am	2020-11-07 20:14:02.000000000 -0800
++++ b/libusb/Makefile.am	2021-10-03 23:25:49.208154100 -0700
+@@ -66,6 +66,7 @@
+ 
+ if OS_WINDOWS
+ OS_SRC = $(OS_WINDOWS_SRC)
++LT_LDFLAGS+= -export-symbols $(srcdir)/libusb-1.0.def
+ 
+ include Makefile.am.extra
+ 


### PR DESCRIPTION
llvm's dlltool/lld do not support --add-stdcall-alias, but libusb already provided a .def file that said exactly what they wanted to be
exported from the DLL (and in fact regenerated their import lib from it).  Convince libtool to actually use that def file.

Also, remove no longer needed switch of platforms for dlltool.

Fixes #9706, fixes #9626 (which means aravis builds for CLANG32 after this fix)