### PR TITLE
Add python-fypp package build file

### DIFF
--- a/mingw-w64-python-fypp/PKGBUILD
+++ b/mingw-w64-python-fypp/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: Sebastian Ehlert <awvwgk@disroot.org>
+
+_pyname=fypp
+_realname=${_pyname}
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=3.1
+pkgrel=1
+pkgdesc="Python powered Fortran preprocessor (mingw-w64)"
+url="https://fypp.readthedocs.io/"
+license=("BSD-2-Clause")
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+depends=("${MINGW_PACKAGE_PREFIX}-python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
+source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/aradi/fypp/archive/${pkgver}.tar.gz")
+sha256sums=('0f66e849869632978a8a0623ee510bb860a74004fdabfbfb542656c6c1a7eb5a')
+
+prepare() {
+  cd ${srcdir}
+  rm -rf python-build-${CARCH} | true
+  cp -r "${_pyname}-${pkgver}" "python-build-${CARCH}"
+}
+
+build() {
+  msg "Python build for ${CARCH}"
+  cd "${srcdir}/python-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+      ${MINGW_PREFIX}/bin/python setup.py build
+}
+
+package() {
+  cd "${srcdir}/python-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" --optimize=1 --skip-build
+}


### PR DESCRIPTION
Adds package files for Python based preprocessor and meta-programming engine for Fortran (https://fypp.readthedocs.io/en/stable/)