### PR TITLE
Update fpm: move git to optdepends

### DIFF
--- a/mingw-w64-fpm/PKGBUILD
+++ b/mingw-w64-fpm/PKGBUILD
@@ -4,13 +4,17 @@ _realname=fpm
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.4.0
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
 pkgdesc="Fortran package manager (mingw-w64)"
 url="https://github.com/fortran-lang/fpm"
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran" "git")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc-fortran" "${MINGW_PACKAGE_PREFIX}-curl")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc-fortran"
+             "${MINGW_PACKAGE_PREFIX}-curl"
+             "git")
+optdepends=("git: Support for fetching projects with git")
 options=('strip')
 license=('MIT')
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/fortran-lang/fpm/archive/refs/tags/v${pkgver}.tar.gz")
@@ -25,6 +29,7 @@ build() {
 }
 
 package() {
-  cd "${srcdir}/${_realname}-${pkgver}/build_${CARCH}"
-  install -Dm755 bin/fpm "${pkgdir}"${MINGW_PREFIX}/bin/fpm
+  cd "${srcdir}/${_realname}-${pkgver}"
+  install -Dm755 build_${CARCH}/bin/fpm "${pkgdir}"${MINGW_PREFIX}/bin/fpm
+  install -Dm644 LICENSE "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
 }


### PR DESCRIPTION
git is not required for the basic functionality of fpm.

cc @zoziha