### PR TITLE
groonga: Update to 11.0.7

### DIFF
--- a/mingw-w64-groonga/PKGBUILD
+++ b/mingw-w64-groonga/PKGBUILD
@@ -3,66 +3,52 @@
 _realname=groonga
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=11.0.2
-pkgrel=3
+pkgver=11.0.7
+pkgrel=1
 pkgdesc="An opensource fulltext search engine (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://groonga.org/"
 license=('LGPL2')
 options=('strip' 'staticlibs')
-source=(https://packages.groonga.org/source/${_realname}/${_realname}-${pkgver}.tar.gz{,.asc}
-        https://github.com/groonga/groonga/commit/269aaf0baee9e0ef57ddff872dafd8ce96033785.patch)
+source=(https://packages.groonga.org/source/${_realname}/${_realname}-${pkgver}.tar.gz{,.asc})
 depends=("${MINGW_PACKAGE_PREFIX}-arrow"
-         #"${MINGW_PACKAGE_PREFIX}-libevent"
-         "${MINGW_PACKAGE_PREFIX}-luajit"
          "${MINGW_PACKAGE_PREFIX}-lz4"
-         "${MINGW_PACKAGE_PREFIX}-msgpack-c"
-         "${MINGW_PACKAGE_PREFIX}-onigmo"
-         "${MINGW_PACKAGE_PREFIX}-openssl"
-         "${MINGW_PACKAGE_PREFIX}-pcre"
-         "${MINGW_PACKAGE_PREFIX}-rapidjson"
          "${MINGW_PACKAGE_PREFIX}-mecab"
          "${MINGW_PACKAGE_PREFIX}-mecab-naist-jdic"
-         "${MINGW_PACKAGE_PREFIX}-zeromq"
+         "${MINGW_PACKAGE_PREFIX}-msgpack-c"
+         "${MINGW_PACKAGE_PREFIX}-onigmo"
+         "${MINGW_PACKAGE_PREFIX}-xxhash"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-zstd")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
-sha256sums=('de29cb5648e3c29873d343747d626a5efcb302357dc7bd82dc4df776e2de558c'
-            'SKIP'
+makedepends=("git"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-rapidjson"
+             "${MINGW_PACKAGE_PREFIX}-ruby"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
+sha256sums=('296aa2924d54a8a9cf9e1a82a201c352c30c84fea3f8652a49d0e2cc94ffee60'
             'SKIP')
 validpgpkeys=('2701F317CFCCCB975CADE9C2624CF77434839225') # Groonga Key <packages@groonga.org>
-
-prepare() {
-  cd "${srcdir}"/${_realname}-${pkgver}
-  patch -p1 -i ${srcdir}/269aaf0baee9e0ef57ddff872dafd8ce96033785.patch
-}
 
 build() {
   [[ -d ${srcdir}/build-${CARCH} ]] && rm -rf ${srcdir}/build-${CARCH}
   mkdir -p ${srcdir}/build-${CARCH} && cd ${srcdir}/build-${CARCH}
 
-  ../${_realname}-${pkgver}/configure \
-    --prefix=${MINGW_PREFIX} \
-    --build=${MINGW_CHOST} \
-    --host=${MINGW_CHOST} \
-    --target=${MINGW_CHOST} \
-    --disable-libedit \
-    --with-mecab \
-    --with-onigmo=system \
-    --without-kytea \
-    --without-cutter \
-    --without-libevent \
-    --disable-benchmark \
-    --disable-groonga-httpd \
-    --enable-mruby
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake.exe \
+      ../${_realname}-${pkgver} \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      -DGRN_WITH_APACHE_ARROW=ON \
+      -DGRN_WITH_MRUBY=ON \
+      -G Ninja
 
-  make
+  ninja
 }
 
 package() {
   cd ${srcdir}/build-${CARCH}
-  make DESTDIR="${pkgdir}" install
+  DESTDIR="${pkgdir}" ninja install
 
   local PREFIX_DEPS=$(cygpath -am ${MINGW_PREFIX})
   pushd "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig"
@@ -71,5 +57,7 @@ package() {
   done
   popd
 
-  install -Dm644 ${srcdir}/${_realname}-${pkgver}/COPYING "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+  install -Dm644 \
+    ${srcdir}/${_realname}-${pkgver}/COPYING \
+    "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }


### PR DESCRIPTION
We use CMake + Ninja instead of Make + Autotools in this PR.
Because Ninja is faster than make.