### PR TITLE
xpra 4.2.3

### DIFF
--- a/mingw-w64-python-xpra/PKGBUILD
+++ b/mingw-w64-python-xpra/PKGBUILD
@@ -50,8 +50,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-python-cairo"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-pygobject-devel")
-source=("https://xpra.org/src/xpra-${pkgver}.tar.xz")
-sha512sums=('8a771a243678b66ce83d5d9bd1301d04eb41433d51d48bd6664c97432f7cefc1b888fbe170d8af5c8b727c7d321964c3ac6b54cd8e8d13ba22592ad362ce7a70')
+source=("https://xpra.org/src/xpra-${pkgver}.tar.xz"{,.gpg})
+sha512sums=('8a771a243678b66ce83d5d9bd1301d04eb41433d51d48bd6664c97432f7cefc1b888fbe170d8af5c8b727c7d321964c3ac6b54cd8e8d13ba22592ad362ce7a70'
+            'SKIP')
+validpgpkeys=('C11C0A4DF702EDF6C04F458C18ADB31CF18AD6BB') # Antoine Martin <antoine@nagafix.co.uk>
 
 prepare() {
   cd "${srcdir}"


### PR DESCRIPTION
* bump version
* update minor path changes
* remove unbundled html5 client which now lives here: https://github.com/Xpra-org/xpra-html5