### PR TITLE
pywin32: workaround broken os.add_dll_directory

### DIFF
--- a/mingw-w64-python-pywin32/010-workaround-broken-add-dll-dir.patch
+++ b/mingw-w64-python-pywin32/010-workaround-broken-add-dll-dir.patch
@@ -1,0 +1,12 @@
+--- pywin32-b301/win32/Lib/pywin32_bootstrap.py.orig	2021-10-10 22:06:51.034000000 +0200
++++ pywin32-b301/win32/Lib/pywin32_bootstrap.py	2021-10-10 22:07:34.878519800 +0200
+@@ -18,7 +18,8 @@
+     # https://docs.python.org/3/reference/import.html#__path__
+     for path in pywin32_system32.__path__:
+         if os.path.isdir(path):
+-            if hasattr(os, "add_dll_directory"):
++            # XXX: https://github.com/msys2-contrib/cpython-mingw/issues/48
++            if 0 and hasattr(os, "add_dll_directory"): 
+                 os.add_dll_directory(path)
+             # This is to ensure the pywin32 path is in the beginning to find the
+             # pywin32 DLLs first and prevent other PATH entries to shadow them

--- a/mingw-w64-python-pywin32/PKGBUILD
+++ b/mingw-w64-python-pywin32/PKGBUILD
@@ -12,7 +12,7 @@ license=('PSF')
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang32' 'clang64' 'clangarm64')
 pkgver=301
-pkgrel=2
+pkgrel=3
 makedepends=(
     ${MINGW_PACKAGE_PREFIX}-python
     ${MINGW_PACKAGE_PREFIX}-python-setuptools
@@ -23,14 +23,16 @@ source=("https://github.com/mhammond/${_realname}/archive/b${pkgver}.zip"
         003-win32-extensions-fix.patch
         004-isapi-fix.patch
         005-swig-fix.patch
-        006-mapi-headers-fix.patch)
+        006-mapi-headers-fix.patch
+        010-workaround-broken-add-dll-dir.patch)
 sha256sums=('b55811d60112aea58c58bbed2ffd92f7be6727cb2400764755c7e6cd9789d210'
             'ad391a53adde1f403e1305bd07fbc24beeb4ee7042af1998cf07e33e1199cfed'
             '23c990db894735cff4f102c028083f0176f4ecafd46dac5c6b1a886a2ce1beef'
             'bd25e7446e02b4e165a499f01dcc233efcebf9d1c1d95d4b23b87bf5d2865b67'
             'd1f07a91cae14e7554ff1cb6b0116cdc8264d08af9bc7e4b14629dd40cc93bde'
             '076cc45da1e5c44ee5530e72766a6aeac222b3db4117043761de5f1ac18f8aeb'
-            'a04e4c8ee86606188c55349c4be755c72a9f03830d6f24828aba6bfa251e030d')
+            'a04e4c8ee86606188c55349c4be755c72a9f03830d6f24828aba6bfa251e030d'
+            '0168b0ea893cd252201dbde6baad6cfa4b382bc76ba65657606b6c76ce78262f')
 
 prepare() {
     cd "${srcdir}/${_realname}-b${pkgver}"
@@ -40,6 +42,9 @@ prepare() {
     patch -p1 < "${startdir}"/004-isapi-fix.patch
     patch -p1 < "${startdir}"/005-swig-fix.patch
     patch -p1 < "${startdir}"/006-mapi-headers-fix.patch
+
+    # FIXME: https://github.com/msys2-contrib/cpython-mingw/issues/48
+    patch -p1 < "${startdir}"/010-workaround-broken-add-dll-dir.patch
 }
 
 build() {


### PR DESCRIPTION
Disable it, so it takes the fallback path used for older Python
versions.

Fixes #9751