### PR TITLE
libopenmpt: update to 0.4.24

### DIFF
--- a/mingw-w64-libopenmpt/PKGBUILD
+++ b/mingw-w64-libopenmpt/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libopenmpt
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.4.23
+pkgver=0.4.24
 pkgrel=1
 pkgdesc="A cross-platform C++ and C library to decode tracked music files (modules) into a raw PCM audio stream (mingw-w64)"
 arch=('any')
@@ -21,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
 options=('staticlibs' 'strip')
 source=("https://lib.openmpt.org/files/${_realname}/src/${_realname}-${pkgver}+release.autotools.tar.gz")
-sha256sums=('29697b7106db19fabead72cb9e02dcddef785d4496f24d119326e48178a719ac')
+sha256sums=('06a65906904cdebc32bcc6d348c5ecd0ce06d19f48c96a081597db238c652142')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}+release.autotools"


### PR DESCRIPTION
security update
https://lib.openmpt.org/libopenmpt/2021/10/04/security-updates-0.5.12-0.4.24-0.3.33/