### PR TITLE
xpm-nox: fix #8548 XPM writes invalid X Pixmap with path as C identifier

### DIFF
--- a/mingw-w64-xpm-nox/001-xpm-nox-4.2.0-mingw-remove-path.patch
+++ b/mingw-w64-xpm-nox/001-xpm-nox-4.2.0-mingw-remove-path.patch
@@ -1,0 +1,25 @@
+diff --git a/lib/WrFFrI.c b/lib/WrFFrI.c
+index 0769f809e8d3c07d3f050a25469a828b73c37e03..1e54fe92ed82c70867367a214e0177d0f53001ea 100644
+--- a/lib/WrFFrI.c
++++ b/lib/WrFFrI.c
+@@ -111,13 +111,19 @@ XpmWriteFileFromXpmImage(filename, image, info)
+ 	name = filename;
+ #else
+ 	if (!(name = rindex(filename, '/'))
+-#ifdef AMIGA
++#if defined(AMIGA) || defined(WIN32)
+ 	    && !(name = rindex(filename, ':'))
+ #endif
+      )
+ 	    name = filename;
+ 	else
+ 	    name++;
++#ifdef WIN32
++	if (s = rindex(name, '\\')) {
++        s++;
++        name = s;
++    }
++#endif
+ #endif
+ 	/* let's try to make a valid C syntax name */
+ 	if (index(name, '.')) {

--- a/mingw-w64-xpm-nox/PKGBUILD
+++ b/mingw-w64-xpm-nox/PKGBUILD
@@ -4,7 +4,7 @@ _realname=xpm-nox
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.2.0
-pkgrel=6
+pkgrel=7
 pkgdesc="X Pixmap library not using X (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -15,14 +15,17 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 options=('strip' 'staticlibs' '!buildflags' '!makeflags')
 source=(ftp://koala.inria.fr/pub/xpm/xpm-nox-${pkgver}.tar.bz2
         xpm-nox-4.2.0-mingw.patch
+        001-xpm-nox-4.2.0-mingw-remove-path.patch
         xpm.pc)
 sha256sums=('a70f25fc6995b5928a908cb9b73f71a83a6b1ac8e59d367550584326f7a2fd60'
             'e44fc91c46dd4aa5b6af92f64216ff5d7df57206a91ddaaf5cc37b2058bba24e'
+            '3b165ca7543ccbcc549c50fd5ee12ba523187f40e29cf906adf603959877c853'
             'f9e8665eb2a3c874ab5814c4b2bd1985d599c5b87da9a87a3ba4d50f3b6e274a')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/xpm-nox-4.2.0-mingw.patch
+  patch -p1 -i ${srcdir}/001-xpm-nox-4.2.0-mingw-remove-path.patch
 }
 
 build() {


### PR DESCRIPTION
The Windows path characters : and \ were not filtered out when writing
the C identifier that is part of the XPM image.
Besides that writing the complete path inside an image can
lead to a C identifier which is too long.

So let's just remove the path and only leave the filename.