### PR TITLE
openshadinglanguage: update to 1.11.15.0

### DIFF
--- a/mingw-w64-openshadinglanguage/0020-LLVM-12.patch
+++ b/mingw-w64-openshadinglanguage/0020-LLVM-12.patch
@@ -1,0 +1,48 @@
+From 8682211d0bfe5c4be63a4a003d06037ff9721e66 Mon Sep 17 00:00:00 2001
+From: Luya Tshimbalanga <luya@fedoraproject.org>
+Date: Tue, 28 Sep 2021 10:08:01 -0700
+Subject: [PATCH] Fix compatibility with LLVM 12 and up (#1412)
+
+Upstream LLVM stopped using the compatibility
+spellings of OF_{None,Text,Append} from version 12 and up.
+
+https://reviews.llvm.org/D101650
+
+Signed-off-by: Luya Tshimbalanga <luya@fedoraproject.org>
+---
+ src/liboslexec/llvm_util.cpp | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/liboslexec/llvm_util.cpp b/src/liboslexec/llvm_util.cpp
+index 4bd0dca35..4d0e1752d 100644
+--- a/src/liboslexec/llvm_util.cpp
++++ b/src/liboslexec/llvm_util.cpp
+@@ -1407,7 +1407,9 @@ LLVM_Util::make_jit_execengine (std::string *err,
+ 
+     options.NoZerosInBSS = false;
+     options.GuaranteedTailCallOpt = false;
++#if OSL_LLVM_VERSION < 120
+     options.StackAlignmentOverride = 0;
++#endif
+     options.FunctionSections = true;
+     options.UseInitArray = false;
+     options.FloatABIType = llvm::FloatABI::Default;
+@@ -5385,7 +5387,7 @@ void
+ LLVM_Util::write_bitcode_file (const char *filename, std::string *err)
+ {
+     std::error_code local_error;
+-    llvm::raw_fd_ostream out (filename, local_error, llvm::sys::fs::F_None);
++    llvm::raw_fd_ostream out (filename, local_error, llvm::sys::fs::OF_None);
+     if (! out.has_error()) {
+         llvm::WriteBitcodeToFile (*module(), out);
+         if (err && local_error)
+@@ -5447,7 +5449,9 @@ LLVM_Util::ptx_compile_group (llvm::Module* lib_module, const std::string& name,
+     options.AllowFPOpFusion                        = llvm::FPOpFusion::Fast;
+     options.NoZerosInBSS                           = 0;
+     options.GuaranteedTailCallOpt                  = 0;
++#if OSL_LLVM_VERSION < 120
+     options.StackAlignmentOverride                 = 0;
++#endif
+     options.UseInitArray                           = 0;
+ 
+     llvm::TargetMachine* target_machine = llvm_target->createTargetMachine(

--- a/mingw-w64-openshadinglanguage/0021-LLVM-13.patch
+++ b/mingw-w64-openshadinglanguage/0021-LLVM-13.patch
@@ -1,0 +1,158 @@
+From 1748525ad56a9916af5c4a52f42db7e991a79721 Mon Sep 17 00:00:00 2001
+From: Larry Gritz <lg@larrygritz.com>
+Date: Fri, 8 Oct 2021 19:12:51 -0700
+Subject: [PATCH] Changes to work with LLVM 13
+
+And a few places to let it compile with clang 13's new warnings.
+
+Signed-off-by: Larry Gritz <lg@larrygritz.com>
+---
+ src/include/OSL/llvm_util.h        | 17 +++++++++--
+ src/liboslexec/llvm_util.cpp       | 45 ++++++++++++++++++++++++++----
+ src/liboslexec/runtimeoptimize.cpp |  2 --
+ 4 files changed, 62 insertions(+), 18 deletions(-)
+
+diff --git a/src/include/OSL/llvm_util.h b/src/include/OSL/llvm_util.h
+index fbf091d60..95df9632f 100644
+--- a/src/include/OSL/llvm_util.h
++++ b/src/include/OSL/llvm_util.h
+@@ -802,6 +802,9 @@ class OSLEXECPUBLIC LLVM_Util {
+                     llvm::Value *src, int srcalign, int len);
+ 
+     /// Dereference a pointer:  return *ptr
++    /// type is the type of the thing being pointed to.
++    llvm::Value *op_load (llvm::Type* type, llvm::Value *ptr);
++    // Blind pointer version that's deprecated as of LLVM13:
+     llvm::Value *op_load (llvm::Value *ptr);
+ 
+     llvm::Value *op_gather(llvm::Value *ptr, llvm::Value *index);
+@@ -830,17 +833,25 @@ class OSLEXECPUBLIC LLVM_Util {
+ 
+     /// Generate a GEP (get element pointer) where the element index is an
+     /// llvm::Value, which can be generated from either a constant or a
+-    /// runtime-computed integer element index.
++    /// runtime-computed integer element index. `type` is the type of the data
++    /// we're retrieving.
++    llvm::Value *GEP (llvm::Type* type, llvm::Value *ptr, llvm::Value *elem);
++    // Blind pointer version that's deprecated as of LLVM13:
+     llvm::Value *GEP (llvm::Value *ptr, llvm::Value *elem);
+ 
+     /// Generate a GEP (get element pointer) with an integer element
+-    /// offset.
++    /// offset. `type` is the type of the data we're retrieving.
++    llvm::Value *GEP (llvm::Type* type, llvm::Value *ptr, int elem);
++    // Blind pointer version that's deprecated as of LLVM13:
+     llvm::Value *GEP (llvm::Value *ptr, int elem);
+ 
+     /// Generate a GEP (get element pointer) with two integer element
+     /// offsets.  This is just a special (and common) case of GEP where
+     /// we have a 2-level hierarchy and we have fixed element indices
+-    /// that are known at compile time.
++    /// that are known at compile time.  `type` is the type of the data we're
++    /// retrieving.
++    llvm::Value *GEP (llvm::Type* type, llvm::Value *ptr, int elem1, int elem2);
++    // Blind pointer version that's deprecated as of LLVM13:
+     llvm::Value *GEP (llvm::Value *ptr, int elem1, int elem2);
+ 
+     // Arithmetic ops.  It auto-detects the type (int vs float).
+diff --git a/src/liboslexec/llvm_util.cpp b/src/liboslexec/llvm_util.cpp
+index 4d0e1752d..a1d31fe4d 100644
+--- a/src/liboslexec/llvm_util.cpp
++++ b/src/liboslexec/llvm_util.cpp
+@@ -3595,10 +3595,18 @@ LLVM_Util::op_memcpy (llvm::Value *dst, int dstalign,
+ 
+ 
+ 
++llvm::Value *
++LLVM_Util::op_load (llvm::Type* type, llvm::Value* ptr)
++{
++    return builder().CreateLoad (type, ptr);
++}
++
++
++
+ llvm::Value *
+ LLVM_Util::op_load (llvm::Value *ptr)
+ {
+-    return builder().CreateLoad (ptr);
++    return op_load(ptr->getType()->getPointerElementType(), ptr);
+ }
+ 
+ 
+@@ -4924,10 +4932,27 @@ LLVM_Util::op_store_mask (llvm::Value *llvm_mask, llvm::Value *native_mask_ptr)
+ 
+ 
+ 
++llvm::Value *
++LLVM_Util::GEP (llvm::Type* type, llvm::Value* ptr, llvm::Value* elem)
++{
++    return builder().CreateGEP(type, ptr, elem);
++}
++
++
++
+ llvm::Value *
+ LLVM_Util::GEP (llvm::Value *ptr, llvm::Value *elem)
+ {
+-    return builder().CreateGEP (ptr, elem);
++    return GEP(ptr->getType()->getScalarType()->getPointerElementType(), ptr,
++               elem);
++}
++
++
++
++llvm::Value *
++LLVM_Util::GEP (llvm::Type* type, llvm::Value* ptr, int elem)
++{
++    return builder().CreateConstGEP1_32(type, ptr, elem);
+ }
+ 
+ 
+@@ -4935,7 +4960,16 @@ LLVM_Util::GEP (llvm::Value *ptr, llvm::Value *elem)
+ llvm::Value *
+ LLVM_Util::GEP (llvm::Value *ptr, int elem)
+ {
+-    return builder().CreateConstGEP1_32 (ptr, elem);
++    return GEP(ptr->getType()->getScalarType()->getPointerElementType(), ptr,
++               elem);
++}
++
++
++
++llvm::Value *
++LLVM_Util::GEP(llvm::Type* type, llvm::Value* ptr, int elem1, int elem2)
++{
++    return builder().CreateConstGEP2_32 (type, ptr, elem1, elem2);
+ }
+ 
+ 
+@@ -4943,7 +4977,8 @@ LLVM_Util::GEP (llvm::Value *ptr, int elem)
+ llvm::Value *
+ LLVM_Util::GEP (llvm::Value *ptr, int elem1, int elem2)
+ {
+-    return builder().CreateConstGEP2_32 (nullptr, ptr, elem1, elem2);
++    return GEP(ptr->getType()->getScalarType()->getPointerElementType(), ptr,
++               elem1, elem2);
+ }
+ 
+ 
+diff --git a/src/liboslexec/runtimeoptimize.cpp b/src/liboslexec/runtimeoptimize.cpp
+index dfe554164..da67c712e 100644
+--- a/src/liboslexec/runtimeoptimize.cpp
++++ b/src/liboslexec/runtimeoptimize.cpp
+@@ -2284,7 +2284,6 @@ RuntimeOptimizer::optimize_instance ()
+     // passes, but we have a hard cutoff just to be sure we don't
+     // ever get into an infinite loop from an unforseen cycle where we
+     // end up inadvertently transforming A => B => A => etc.
+-    int totalchanged = 0;
+     int reallydone = 0;   // Force a few passes after we think we're done
+     int npasses = shadingsys().opt_passes();
+     for (m_pass = 0;  m_pass < npasses;  ++m_pass) {
+@@ -2345,7 +2344,6 @@ RuntimeOptimizer::optimize_instance ()
+         // If nothing changed, we're done optimizing.  But wait, it may be
+         // that after re-tracking variable lifetimes, we can notice new
+         // optimizations!  So force another pass, then we're really done.
+-        totalchanged += changed;
+         if (changed < 1) {
+             if (++reallydone > 3)
+                 break;

--- a/mingw-w64-openshadinglanguage/PKGBUILD
+++ b/mingw-w64-openshadinglanguage/PKGBUILD
@@ -5,8 +5,8 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
-pkgver=1.11.14.2
-pkgrel=2
+pkgver=1.11.15.0
+pkgrel=1
 pkgdesc="Advanced shading language for production GI renderers (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -41,8 +41,10 @@ source=(${_realname}-${pkgver}.tar.gz::https://github.com/imageworks/OpenShading
         0013-disable-assert-partio.patch
         0014-fix-testshade-library-name.patch
         0015-llvm-linking.patch
-        0016-OIIO-API.patch)
-sha256sums=('2bd4c7b29993499d0d0f011f71d0eb8e204b67e766b35462fdec1e3858dce981'
+        0016-OIIO-API.patch
+        0020-LLVM-12.patch
+        0021-LLVM-13.patch)
+sha256sums=('a10baa2455405f0a6488a915645dd3d006b8471bae6c269796ba5ba6ce863cbc'
             'e3f6ad09619d122ada129cbc77d7778751abfecef9ac7e0a60d9550c811df643'
             '70d4ce3c69ed072eee0d2bb84cecea5ff9ff35e258a24a7a78ec94e4b626e493'
             '6b1e4065292361c724a53f6961b72ff74dde9349a3c1e42a1ab8e883d902f5e4'
@@ -53,7 +55,9 @@ sha256sums=('2bd4c7b29993499d0d0f011f71d0eb8e204b67e766b35462fdec1e3858dce981'
             'c0d66bd0c38fc3627d8bf17c7f9331ac66a2a02e22820208d81400f2ed01543b'
             '3146942267540de2a3146ef8222d59fdb265dc8fffa3f3a2207bbc851fc99ab8'
             '1b2c1e7faae162078696049f63c2b55e8c111ffeff25abaa49d67877c81a71d1'
-            '01a9e6543159b8c966fa31755781f028b156fb799ae1c8eab94cd8d4c2ce48a6')
+            '01a9e6543159b8c966fa31755781f028b156fb799ae1c8eab94cd8d4c2ce48a6'
+            'd12f2f97565b619a25b243cf9ed67af9a31dbd4bd75262e300bdc89797135ca2'
+            '1f667d8719749b1923c4c1335f7d78c24f139d2a2c76b18d44f32a86e18b2958')
 
 prepare() {
   cd ${srcdir}/OpenShadingLanguage-Release-${pkgver}
@@ -68,6 +72,10 @@ prepare() {
   patch -p1 -i ${srcdir}/0014-fix-testshade-library-name.patch
   patch -p1 -i ${srcdir}/0015-llvm-linking.patch
   patch -p1 -i ${srcdir}/0016-OIIO-API.patch
+  # https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/commit/8682211d0bfe5c4be63a4a003d06037ff9721e66
+  patch -p1 -i ${srcdir}/0020-LLVM-12.patch
+  # https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/pull/1420
+  patch -p1 -i ${srcdir}/0021-LLVM-13.patch
 }
 
 build() {


### PR DESCRIPTION
Also backport a couple of patches (one commited, AcademySoftwareFoundation/OpenShadingLanguage@8682211d0bfe5c4be63a4a003d06037ff9721e66, and one from an open pull request, AcademySoftwareFoundation/OpenShadingLanguage#1420) to fix build with LLVM 12 and 13 respectively.