### PR TITLE
precice: bump pkgrel

### DIFF
--- a/mingw-w64-precice/PKGBUILD
+++ b/mingw-w64-precice/PKGBUILD
@@ -1,13 +1,17 @@
 # Maintainer: Rafal Brzegowy <rafal.brzegowy@yahoo.com>
+# Contributor: Raed Rizqie <raed.rizqie@gmail.com>
+
+# petsc don't have clang build because it depends on fortran lib,
+# so we have to disable clang for now
 
 _realname=precice
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.3.0
-pkgrel=2
+pkgrel=3
 pkgdesc='A Coupling Library for Partitioned Multi-Physics Simulations on Massively Parallel Systems (mingw-w64)'
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64')
 depends=("${MINGW_PACKAGE_PREFIX}-boost"
          "${MINGW_PACKAGE_PREFIX}-libxml2"
 	 "${MINGW_PACKAGE_PREFIX}-msmpi"


### PR DESCRIPTION
- disable clang (for now)
- petsc don't have clang build because it depends on fortran lib, so we have to disable clang for now
