### PR TITLE
flang: new package split from clang

### DIFF
--- a/mingw-w64-flang/0001-cast-cxx11-narrowing.patch
+++ b/mingw-w64-flang/0001-cast-cxx11-narrowing.patch
@@ -1,0 +1,42 @@
+--- a/runtime/misc-intrinsic.cpp	2021-10-02 17:25:54.576794400 -0700
++++ b/runtime/misc-intrinsic.cpp	2021-10-02 17:27:11.031517900 -0700
+@@ -47,7 +47,7 @@
+         "TRANSFER: could not allocate memory for result; STAT=%d", stat);
+   }
+   char *to{result.OffsetElement<char>()};
+-  std::size_t resultBytes{size * elementBytes};
++  std::size_t resultBytes{static_cast<size_t>(size * elementBytes)};
+   const std::size_t sourceElementBytes{source.ElementBytes()};
+   std::size_t sourceElements{source.Elements()};
+   SubscriptValue sourceAt[maxRank];
+--- a/lib/Evaluate/constant.cpp	2021-10-02 17:33:29.706776300 -0700
++++ b/lib/Evaluate/constant.cpp	2021-10-02 17:34:52.363465800 -0700
+@@ -251,7 +251,7 @@
+     return count;
+   } else {
+     std::size_t copied{0};
+-    std::size_t elementBytes{length_ * sizeof(decltype(values_[0]))};
++    std::size_t elementBytes{static_cast<size_t>(length_ * sizeof(decltype(values_[0])))};
+     ConstantSubscripts sourceSubscripts{source.lbounds()};
+     while (copied < count) {
+       auto *dest{&values_.at(SubscriptsToOffset(resultSubscripts) * length_)};
+--- a/runtime/transformational.cpp	2021-10-02 18:11:08.727836900 -0700
++++ b/runtime/transformational.cpp	2021-10-02 18:11:56.743494500 -0700
+@@ -183,7 +183,7 @@
+   SubscriptValue lb{sourceDim.LowerBound()};
+   for (SubscriptValue j{0}; j < extent; ++j) {
+     SubscriptValue resultAt{1 + j};
+-    SubscriptValue sourceAt{lb + (j + shift) % extent};
++    SubscriptValue sourceAt{static_cast<SubscriptValue>(lb + (j + shift) % extent)};
+     if (sourceAt < 0) {
+       sourceAt += extent;
+     }
+@@ -281,7 +281,7 @@
+   }
+   SubscriptValue lb{source.GetDimension(0).LowerBound()};
+   for (SubscriptValue j{1}; j <= extent; ++j) {
+-    SubscriptValue sourceAt{lb + j - 1 + shift};
++    SubscriptValue sourceAt{static_cast<SubscriptValue>(lb + j - 1 + shift)};
+     if (sourceAt >= lb && sourceAt < lb + extent) {
+       CopyElement(result, &j, source, &sourceAt, terminator);
+     }

--- a/mingw-w64-flang/0002-cmake-22162.patch
+++ b/mingw-w64-flang/0002-cmake-22162.patch
@@ -1,0 +1,13 @@
+--- a/CMakeLists.txt	2021-10-04 13:49:12.582319800 -0700
++++ b/CMakeLists.txt	2021-10-04 13:54:57.833484200 -0700
+@@ -110,7 +110,9 @@
+   # LLVM_INCLUDE_DIRS when merging in the monorepo (Warning from flang headers
+   # should not be suppressed).
+   include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
+-  add_definitions(${LLVM_DEFINITIONS})
++  # https://gitlab.kitware.com/cmake/cmake/-/issues/22162
++  separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
++  add_definitions(${LLVM_DEFINITIONS_LIST})
+ 
+   # LLVM's cmake configuration files currently sneak in a c++11 flag.
+   # We look for it here and remove it from Flang's compile flags to

--- a/mingw-w64-flang/PKGBUILD
+++ b/mingw-w64-flang/PKGBUILD
@@ -1,0 +1,124 @@
+_compiler=gcc
+if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then
+  _clangprefix=1
+  _compiler=clang
+fi
+_realname=flang
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=13.0.0
+pkgrel=1
+pkgdesc="Fortran frontend for LLVM (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+url="https://flang.llvm.org/"
+license=("custom:Apache 2.0 with LLVM Exception")
+groups=($( (( _clangprefix )) && echo "${MINGW_PACKAGE_PREFIX}-toolchain"))
+depends=("${MINGW_PACKAGE_PREFIX}-clang=${pkgver}"
+         "${MINGW_PACKAGE_PREFIX}-llvm=${pkgver}"
+         "${MINGW_PACKAGE_PREFIX}-mlir=${pkgver}")
+makedepends=("${MINGW_PACKAGE_PREFIX}-clang-analyzer=${pkgver}"
+             "${MINGW_PACKAGE_PREFIX}-clang-tools-extra=${pkgver}"
+             "${MINGW_PACKAGE_PREFIX}-cmake>=3.4.3"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-polly=${pkgver}"
+             "gawk"
+             $([[ "$_compiler" == "clang" ]] && echo \
+               "${MINGW_PACKAGE_PREFIX}-compiler-rt" \
+               "${MINGW_PACKAGE_PREFIX}-libc++")
+             $([[ "$_compiler" == "gcc" ]] && echo \
+               "${MINGW_PACKAGE_PREFIX}-gcc")
+             )
+options=('!debug' 'strip')
+source=("https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkgver}/flang-${pkgver}.src.tar.xz"{,.sig}
+        "0001-cast-cxx11-narrowing.patch"
+        "0002-cmake-22162.patch")
+sha256sums=('13bc580342bec32b6158c8cddeb276bd428d9fc8fd23d13179c8aa97bbba37d5'
+            'SKIP'
+            'f8babd240968599597cf2b906fad44b62e2d92ac7ea144530a3f9542e96e06b1'
+            '77fb0612217b6af7a122f586a9d0d334cd48bb201509bf72e8f8e6244616e895')
+validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Google.
+              '474E22316ABF4785A88C6E8EA2C794A986419D8A') # Tom Stellard
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying ${_patch}"
+    patch -Nbp1 -i "${srcdir}/${_patch}"
+  done
+}
+
+prepare() {
+  cd "${srcdir}/flang-${pkgver}.src"
+
+  apply_patch_with_msg \
+    "0001-cast-cxx11-narrowing.patch" \
+    "0002-cmake-22162.patch"
+}
+
+build() {
+  cd "${srcdir}"
+
+  case "${CARCH}" in
+    i?86|armv7)
+      # lld needs all the address space it can get.
+      LDFLAGS+=" -Wl,--large-address-aware"
+      ;;
+  esac
+
+  local -a extra_args
+
+  if check_option "debug" "y"; then
+    extra_args+=(-DCMAKE_BUILD_TYPE=Debug)
+  else
+    extra_args+=(-DCMAKE_BUILD_TYPE=Release)
+  fi
+
+  if [ "${_compiler}" == "clang" ]; then
+    export CC='clang'
+    export CXX='clang++'
+    extra_args+=(-DLLVM_ENABLE_LIBCXX=ON)
+  fi
+
+  # try to figure out a reasonable CMAKE_BUILD_PARALLEL_LEVEL
+  if [ -z "${CMAKE_BUILD_PARALLEL_LEVEL+x}" ]; then
+    # figure about 1 job per 2GB RAM
+    local _jobs=$(awk '{ if ($1 == "MemTotal:") { printf "%.0f", $2/(2*1024*1024) } }' /proc/meminfo)
+    # EXCEPT on GHA, which is being really difficult.
+    if (( _jobs < 1 )) || [ -n "${GITHUB_ACTIONS+x}" ]; then
+      _jobs=1
+    elif (( _jobs > $(nproc) + 2 )); then
+      _jobs=$(( $(nproc) + 2 ))
+    fi
+    export CMAKE_BUILD_PARALLEL_LEVEL=${_jobs}
+  fi
+
+  [[ -d build-${MSYSTEM} ]] && rm -rf build-${MSYSTEM}
+  mkdir build-${MSYSTEM} && cd build-${MSYSTEM}
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -GNinja \
+    -Wno-dev \
+    -DCLANG_DIR=${MINGW_PREFIX}/lib/cmake/clang \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DCMAKE_SYSTEM_IGNORE_PATH=/usr/lib \
+    -DLLVM_ENABLE_ASSERTIONS=OFF \
+    -DLLVM_ENABLE_THREADS=ON \
+    -DLLVM_HOST_TRIPLE="${CARCH}-w64-windows-gnu" \
+    -DLLVM_LINK_LLVM_DYLIB=ON \
+    "${extra_args[@]}" \
+    ../flang-${pkgver}.src
+
+  ${MINGW_PREFIX}/bin/cmake.exe --build .
+}
+
+check() {
+  cd "${srcdir}"/build-${MSYSTEM}
+  ${MINGW_PREFIX}/bin/cmake.exe --build . -- check-flang || true
+}
+
+package() {
+  DESTDIR="${pkgdir}" cmake --install "${srcdir}/build-${MSYSTEM}"
+}


### PR DESCRIPTION
flang takes too much memory to build with default jobs, so split it off into its own package, with logic to reduce parallel jobs based on memory.

It fails to build on 64-bit GCC, but succeeds for CLANG64, CLANG32, and MINGW32.  I don't know if there's some workaround possible for GCC, or if mingw_arch should just not include GCC subsystems.

Also, I've never tried to do anything with the resulting binaries, only getting them to build.