### PR TITLE
mesa: fixes for UCRT

### DIFF
--- a/mingw-w64-mesa/0003-ucrt-fixes.patch
+++ b/mingw-w64-mesa/0003-ucrt-fixes.patch
@@ -1,0 +1,57 @@
+--- mesa-21.2.4/meson.build.orig	2021-10-16 16:02:38.021997300 -0700
++++ mesa-21.2.4/meson.build	2021-10-16 16:03:24.287545400 -0700
+@@ -1046,8 +1046,6 @@
+       '-D_HAS_EXCEPTIONS=0', # Tell C++ STL to not use exceptions
+       '-DNOMINMAX',
+     ]
+-  else
+-    pre_args += ['-D__MSVCRT_VERSION__=0x0700']
+   endif
+ elif host_machine.system() == 'openbsd'
+   pre_args += '-D_ISOC11_SOURCE'
+--- mesa-21.2.4/src/compiler/spirv/vtn_private.h.orig	2021-10-16 15:28:02.537761600 -0700
++++ mesa-21.2.4/src/compiler/spirv/vtn_private.h	2021-10-16 15:28:05.959391400 -0700
+@@ -41,7 +41,7 @@
+ struct vtn_decoration;
+ 
+ /* setjmp/longjmp is broken on MinGW: https://sourceforge.net/p/mingw-w64/bugs/406/ */
+-#ifdef __MINGW32__
++#if defined(__MINGW32__) && !defined(_UCRT)
+   #define vtn_setjmp __builtin_setjmp
+   #define vtn_longjmp __builtin_longjmp
+ #else
+--- mesa-21.2.4/src/compiler/nir/nir.h.orig	2021-10-14 12:59:05.367845000 -0700
++++ mesa-21.2.4/src/compiler/nir/nir.h	2021-10-16 15:55:09.881268400 -0700
+@@ -54,7 +54,7 @@
+ 
+ #include "nir_opcodes.h"
+ 
+-#if defined(_WIN32) && !defined(snprintf)
++#if defined(_WIN32) && !defined(snprintf) && !defined(_UCRT)
+ #define snprintf _snprintf
+ #endif
+ 
+--- mesa-21.2.4/src/compiler/nir/nir_lower_atomics_to_ssbo.c.orig	2021-10-14 12:59:05.375845200 -0700
++++ mesa-21.2.4/src/compiler/nir/nir_lower_atomics_to_ssbo.c	2021-10-16 15:55:30.818804300 -0700
+@@ -27,10 +27,6 @@
+ #include "nir.h"
+ #include "nir_builder.h"
+ 
+-#if defined(_WIN32) && !defined(snprintf)
+-#define snprintf _snprintf
+-#endif
+-
+ /*
+  * Remap atomic counters to SSBOs, starting from the shader's next SSBO slot
+  * (info.num_ssbos).
+--- mesa-21.2.4/src/gallium/drivers/swr/swr_fence.cpp.orig	2021-10-16 16:29:10.287533700 -0700
++++ mesa-21.2.4/src/gallium/drivers/swr/swr_fence.cpp	2021-10-16 16:29:45.678206500 -0700
+@@ -29,7 +29,7 @@
+ #include "swr_screen.h"
+ #include "swr_fence.h"
+ 
+-#ifdef __APPLE__
++#if defined(__APPLE__) || defined(__MINGW32__)
+ #include <sched.h>
+ #endif
+ 

--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -4,10 +4,10 @@ _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=21.2.4
-pkgrel=2
+pkgrel=3
 pkgdesc="Open-source implementation of the OpenGL specification (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 makedepends=("${MINGW_PACKAGE_PREFIX}-llvm"
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-python-mako"
@@ -28,12 +28,14 @@ options=('staticlibs' 'strip')
 source=(https://mesa.freedesktop.org/archive/${_realname}-${pkgver}.tar.xz{,.sig}
         llvmwrapgen.sh
         0001-swr-llvm-fix-swr-build-with-LLVM-13.patch
-        0002-swr-Fix-build-with-llvm-13.patch)
+        0002-swr-Fix-build-with-llvm-13.patch
+        0003-ucrt-fixes.patch)
 sha256sums=('fe6ede82d1ac02339da3c2ec1820a379641902fd351a52cc01153f76eff85b44'
             'SKIP'
             '69f21522f20c10f5699dfe3e128aa88d4fedde816f6e8df1506d7470c44bf3da'
             'e5aa27b6aba3e75335bbd6d989c52dd42a8435ef87a1453267164e9612daee1a'
-            '37d1c37fd3a8563b9dd78ecd361e5a39440310facd1ed656ca1e12f667b54d6b')
+            '37d1c37fd3a8563b9dd78ecd361e5a39440310facd1ed656ca1e12f667b54d6b'
+            '6baff82b5e80f6f47f7cb54af67efb02c5c4f10e99e3c0fa1dc180e9100f9872')
 validpgpkeys=('8703B6700E7EE06D7A39B8D6EDAE37B02CEB490D') # Emil Velikov <emil.l.velikov@gmail.com>
 validpgpkeys+=('946D09B5E4C9845E63075FF1D961C596A7203456') # Andres Gomez <tanty@igalia.com>
 validpgpkeys+=('E3E8F480C52ADD73B278EE78E1ECBE07D7D70895') # Juan Antonio Suárez Romero (Igalia, S.L.) <jasuarez@igalia.com>"
@@ -52,6 +54,12 @@ case ${MSYSTEM} in
   ;;
   UCRT64)
     _mach=ucrt-x86_64
+  ;;
+  CLANG32)
+    _mach=clang-x86
+  ;;
+  CLANG64)
+    _mach=clang-x86_64
   ;;
 esac
 
@@ -86,6 +94,9 @@ prepare() {
     0001-swr-llvm-fix-swr-build-with-LLVM-13.patch \
     0002-swr-Fix-build-with-llvm-13.patch
 
+  apply_patch_with_msg \
+    0003-ucrt-fixes.patch
+
 # Generate binary wrap for LLVM if llvm-config tool is busted
   if ! [ "$(${MINGW_PREFIX}/bin/llvm-config --has-rtti 2>&1)" = YES ] && ! [ "$(${MINGW_PREFIX}/bin/llvm-config --has-rtti 2>&1)" = NO ]; then
     nollvmconfig=1 llvm_static=false ${srcdir}/llvmwrapgen.sh
@@ -109,7 +120,7 @@ build() {
   -Dvulkan-drivers=swrast"
 
 # Enable RADV driver in x86_64 packages
-  if [ ! ${_mach} = x86 ]; then
+  if [ ! ${CARCH} = i686 ]; then
     buildconf="${buildconf},amd"
   fi
 
@@ -117,7 +128,7 @@ build() {
   -Dgallium-drivers=swrast,zink"
 
 # Enable swr driver in x86_64 packages
-  if [ ! ${_mach} = x86 ]; then
+  if [ ! ${CARCH} = i686 ]; then
     buildconf="${buildconf},swr
     -Dswr-arches=avx,avx2,skx,knl"
   fi


### PR DESCRIPTION
mesa now builds for UCRT64 CLANG64 and CLANG32 🚀 