### PR TITLE
intel-tbb: fix for clang, update to 2020.3

### DIFF
--- a/mingw-w64-intel-tbb/PKGBUILD
+++ b/mingw-w64-intel-tbb/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=intel-tbb
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2020.2
-pkgrel=2
+pkgver=2020.3
+pkgrel=1
 epoch=1
 pkgdesc='High level abstract threading library (mingw-w64)'
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
@@ -13,17 +13,26 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-make")
 options=('!strip' 'staticlibs')
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://www.threadingbuildingblocks.org/'
 license=('Apache')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/intel/tbb/archive/v${pkgver}.tar.gz
-        "tbb-cmake-config.patch")
-sha256sums=('4804320e1e6cbe3a5421997b52199e3c1a3829b2ecb6489641da4b8e32faf500'
-            'f5aa6bb43a69a46a0cec4d2b3e84e7e6e102b3becd1b58d496e8ee035829dc85')
+        "tbb-cmake-config.patch"
+        "tbb-dont-set-crt-version-for-ucrt.patch"
+        "tbb-clang.patch")
+sha256sums=('ebc4f6aa47972daed1f7bf71d100ae5bf6931c2e3144cf299c8cc7d041dca2f3'
+            'f5aa6bb43a69a46a0cec4d2b3e84e7e6e102b3becd1b58d496e8ee035829dc85'
+            'a24719087f206fccccb032e26e3c684d2281da6bfe24e7cd69681493c800ad3a'
+            '329c17c66fa11422b4402017943a8ca83c208c003fc5a769904b4149152300ab')
 
 prepare () {
   cd ${srcdir}/oneTBB-${pkgver}
   patch -p1 -i ${srcdir}/tbb-cmake-config.patch
+  patch -p1 -i ${srcdir}/tbb-dont-set-crt-version-for-ucrt.patch
+
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then
+    patch -p1 -i ${srcdir}/tbb-clang.patch
+  fi
 }
 
 build() {

--- a/mingw-w64-intel-tbb/tbb-clang.patch
+++ b/mingw-w64-intel-tbb/tbb-clang.patch
@@ -1,0 +1,27 @@
+diff --git a/build/windows.gcc.inc b/build/windows.gcc.inc
+index eef1c1b8..ed82791e 100644
+--- a/build/windows.gcc.inc
++++ b/build/windows.gcc.inc
+@@ -59,7 +59,7 @@ TEST_WARNING_KEY = -Wextra -Wshadow -Wcast-qual -Woverloaded-virtual -Wnon-virtu
+ WARNING_SUPPRESS = -Wno-parentheses -Wno-uninitialized -Wno-non-virtual-dtor
+ DYLIB_KEY = -shared
+ LIBDL =
+-EXPORT_KEY = -Wl,--version-script,
++EXPORT_KEY = -Wl,--output-def=
+ LIBS = -lpsapi
+ BIGOBJ_KEY = -Wa,-mbig-obj
+ 
+@@ -77,13 +77,6 @@ ifeq (ok,$(call detect_js,/minversion gcc 4.8))
+     RTM_KEY = -mrtm
+ endif
+ 
+-# gcc 6.0 and later have -flifetime-dse option that controls
+-# elimination of stores done outside the object lifetime
+-ifeq (ok,$(call detect_js,/minversion gcc 6.0))
+-    # keep pre-contruction stores for zero initialization
+-    DSE_KEY = -flifetime-dse=1
+-endif
+-
+ ifeq ($(cfg), release)
+         CPLUS_FLAGS = -g -O2
+ endif

--- a/mingw-w64-intel-tbb/tbb-dont-set-crt-version-for-ucrt.patch
+++ b/mingw-w64-intel-tbb/tbb-dont-set-crt-version-for-ucrt.patch
@@ -1,0 +1,13 @@
+diff --git a/build/windows.gcc.inc b/build/windows.gcc.inc
+index eef1c1b8..cbf4d581 100644
+--- a/build/windows.gcc.inc
++++ b/build/windows.gcc.inc
+@@ -95,7 +95,7 @@ CPLUS_FLAGS += -DUSE_WINTHREAD
+ CPLUS_FLAGS += -D_WIN32_WINNT=$(_WIN32_WINNT)
+ 
+ # MinGW specific
+-CPLUS_FLAGS += -DMINGW_HAS_SECURE_API=1 -D__MSVCRT_VERSION__=0x0700 -msse -mthreads
++CPLUS_FLAGS += -DMINGW_HAS_SECURE_API=1 -msse -mthreads
+ 
+ CONLY = gcc
+ debugger = gdb


### PR DESCRIPTION
by @revelator from https://github.com/msys2/MINGW-packages/discussions/7589#discussioncomment-1226161 noone picked it up so i thought i might aswell
also updates to 2020.3, there are newer versions upstream but they are backwards incompatible, and beyond the scope of getting it to build for clang