### PR TITLE
Update EDA tools

### DIFF
--- a/mingw-w64-ghdl/PKGBUILD
+++ b/mingw-w64-ghdl/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=ghdl
 pkgbase="mingw-w64-${_realname}"
 pkgname='__placeholder__'
-pkgver=1.0.0.r804.gf11aa2981
+pkgver=1.0.0.r833.gb37ce7900
 pkgrel=1
 pkgdesc='GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL'
 arch=('any')
@@ -12,7 +12,7 @@ groups=("${MINGW_PACKAGE_PREFIX}-eda")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 
-_commit="f11aa298"
+_commit="b37ce790"
 source=("${_realname}::git+https://github.com/ghdl/ghdl.git#commit=${_commit}")
 sha512sums=('SKIP')
 

--- a/mingw-w64-nextpnr/PKGBUILD
+++ b/mingw-w64-nextpnr/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=nextpnr
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.0.r3829.g8b3e6711
+pkgver=0.0.r3875.g3b99db29
 pkgrel=1
 pkgdesc="Portable FPGA place and route tool (mingw-w64)"
 arch=('any')
@@ -28,7 +28,7 @@ makedepends=(
   "git"
 )
 
-_commit="8b3e6711"
+_commit="3b99db29"
 source=("${_realname}::git+https://github.com/YosysHQ/${_realname}.git#commit=${_commit}")
 sha256sums=('SKIP')
 

--- a/mingw-w64-verilator/PKGBUILD
+++ b/mingw-w64-verilator/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=verilator
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.210
+pkgver=4.214
 pkgrel=2
 pkgdesc="The fastest free Verilog HDL simulator (mingw-w64)"
 arch=('any')
@@ -18,7 +18,7 @@ source=(
   "${_realname}::https://codeload.github.com/${_realname}/${_realname}/tar.gz/v${pkgver}"
 )
 sha256sums=(
-  '3a2e6f27a5d80116a268ba054a3be61aca924bc54c5556ea25e75ee974201abb'
+  'e14c7f6ffb00a6746ae2a8ea0424e90a1a30067e8ae4c96b8c42689ca1ca0b1f'
 )
 
 prepare() {

--- a/mingw-w64-yosys/PKGBUILD
+++ b/mingw-w64-yosys/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=yosys
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.10.r10
+pkgver=0.10.r28
 pkgrel=1
 pkgdesc="A framework for RTL synthesis tools (mingw-w64)"
 arch=('any')
@@ -21,10 +21,10 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python"
 )
 
-_commit='f3ef579a'
+_commit='0dd42d40'
 source=(
   "${_realname}::git+https://github.com/YosysHQ/${_realname}.git#commit=${_commit}"
-  "ghdl-yosys-plugin::git+https://github.com/ghdl/ghdl-yosys-plugin.git#commit=45da3277"
+  "ghdl-yosys-plugin::git+https://github.com/ghdl/ghdl-yosys-plugin.git#commit=9e11f71e"
 )
 sha256sums=(
   'SKIP'


### PR DESCRIPTION
Verilator 4.214 was released: https://github.com/verilator/verilator-announce/issues/49.
By the way, some other EDA tools are updated.