### PR TITLE
asciidoc: Fix typo

### DIFF
--- a/mingw-w64-asciidoc/PKGBUILD
+++ b/mingw-w64-asciidoc/PKGBUILD
@@ -7,7 +7,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 conflicts=("${MINGW_PACKAGE_PREFIX}-asciidoc-py3-git")
 provides=("${MINGW_PACKAGE_PREFIX}-asciidoc-py3-git")
 pkgver=10.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="AsciiDoc is a text document format for writing notes, documentation, articles, books, ebooks, slideshows, web pages, man pages and blogs (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -17,7 +17,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-libxslt"
          "${MINGW_PACKAGE_PREFIX}-docbook-xsl")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
-source=(asciidoc-py-${pktver}.tar.gz::${url}/archive/refs/tags/${pkgver}.tar.gz)
+source=(asciidoc-py-${pkgver}.tar.gz::${url}/archive/refs/tags/${pkgver}.tar.gz)
 sha256sums=('9a0007de3bc2142e691706b2dbc729dc5958a3290478cf1ffec7cf33d396cb92')
 
 prepare() {


### PR DESCRIPTION
Fix typo in the variable name, which does not affect the process of building the package.