### PR TITLE
gdal: fix UCRT build

### DIFF
--- a/mingw-w64-gdal/002-dont-define-msvcrt-version.patch
+++ b/mingw-w64-gdal/002-dont-define-msvcrt-version.patch
@@ -1,0 +1,18 @@
+--- gdal-3.3.2/port/cpl_port.h.orig	2021-10-18 10:57:01.393925700 -0700
++++ gdal-3.3.2/port/cpl_port.h	2021-10-18 10:57:27.784506600 -0700
+@@ -113,15 +113,6 @@
+ /*      MinGW stuff                                                     */
+ /* ==================================================================== */
+ 
+-/* We need __MSVCRT_VERSION__ >= 0x0700 to have "_aligned_malloc" */
+-/* Latest versions of mingw32 define it, but with older ones, */
+-/* we need to define it manually */
+-#if defined(__MINGW32__)
+-#ifndef __MSVCRT_VERSION__
+-#define __MSVCRT_VERSION__ 0x0700
+-#endif
+-#endif
+-
+ /* Needed for std=c11 on Solaris to have strcasecmp() */
+ #if defined(GDAL_COMPILATION) && defined(__sun__) && (__STDC_VERSION__ + 0) >= 201112L && (_XOPEN_SOURCE + 0) < 600
+ #ifdef _XOPEN_SOURCE

--- a/mingw-w64-gdal/PKGBUILD
+++ b/mingw-w64-gdal/PKGBUILD
@@ -78,6 +78,9 @@ prepare() {
   sed -i -e 's@uchar@unsigned char@' frmts/jpeg2000/jpeg2000_vsil_io.cpp
 
   touch config.rpath
+  # for some reason autogen.sh's libtoolize call is commented out
+  # but we need updated libtool for clang support
+  libtoolize --force --copy
   ./autogen.sh
 }
 

--- a/mingw-w64-gdal/PKGBUILD
+++ b/mingw-w64-gdal/PKGBUILD
@@ -8,7 +8,7 @@ _realname=gdal
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.3.2
-pkgrel=2
+pkgrel=3
 pkgdesc="A translator library for raster geospatial data formats (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -51,13 +51,16 @@ depends=("${MINGW_PACKAGE_PREFIX}-cfitsio"
 #optdepends=("${MINGW_PACKAGE_PREFIX}-postgresql")
 options=('strip' 'staticlibs')
 source=(https://download.osgeo.org/${_realname}/${pkgver}/${_realname}-${pkgver}.tar.xz
-        001-qhull-reentrant.patch)
+        001-qhull-reentrant.patch
+        002-dont-define-msvcrt-version.patch)
 sha256sums=('630e34141cf398c3078d7d8f08bb44e804c65bbf09807b3610dcbfbc37115cc3'
-            'd331a4ca57ba9ecd533d2705273ca89b472902a880eb9edae9d0766bc8034519')
+            'd331a4ca57ba9ecd533d2705273ca89b472902a880eb9edae9d0766bc8034519'
+            '2eb8b8d7321f5a75cc7ff29bf63ae8bda1c900f463b6577bac109503346275f4')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/001-qhull-reentrant.patch
+  patch -p1 -i ${srcdir}/002-dont-define-msvcrt-version.patch
 
   cd ${srcdir}
   [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}

--- a/mingw-w64-gdal/PKGBUILD
+++ b/mingw-w64-gdal/PKGBUILD
@@ -85,6 +85,9 @@ build() {
   cd "${srcdir}/build-${MSYSTEM}"
 
   CFLAGS+=" -fno-strict-aliasing"
+  # somehow the configure test for redeclaring sprintf succeeds but
+  # then errors during the build with clang.
+  CPPFLAGS+=" -DDONT_DEPRECATE_SPRINTF"
 
   ./configure \
     --build=${MINGW_CHOST} \


### PR DESCRIPTION
Don't define `__MSVCRT_VERSION__` to `0x0700` - that's the default for MINGW*, and is lower than 0x0E00 for UCRT, turning off some functions in the headers (like quick_exit and at_quick_exit).  Fixes #9617