### PR TITLE
New package: python-three-merge

### DIFF
--- a/mingw-w64-python-three-merge/PKGBUILD
+++ b/mingw-w64-python-three-merge/PKGBUILD
@@ -10,6 +10,8 @@ arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 license=('BSD')
 url='https://github.com/spyder-ide/three-merge'
+depends=(
+    ${MINGW_PACKAGE_PREFIX}-python-diff-match-patch)
 makedepends=(
     ${MINGW_PACKAGE_PREFIX}-python
     ${MINGW_PACKAGE_PREFIX}-python-setuptools)


### PR DESCRIPTION
This needs python-diff-match-patch to be installed first, in order to pass the check.