### PR TITLE
seacas: fix mpi.h conflicts

### DIFF
--- a/mingw-w64-seacas/PKGBUILD
+++ b/mingw-w64-seacas/PKGBUILD
@@ -77,8 +77,9 @@ package() {
   DESTDIR=${pkgdir} cmake --build . --target install
   install -Dm644 "${srcdir}/${_realname}-${_releases}"/LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
   
-  #remove useless files, a "fake" mpi interface that allows us to use MPI-enabled codes/libraries (e.g. zoltan) in an application that is built without MPI, conflict with msmpi:
-  rm -r ${pkgdir}${MINGW_PREFIX}/include/_MPI_UTILITY.h
-  rm -r ${pkgdir}${MINGW_PREFIX}/include/mpi*.h
+  #remove useless file, a "fake" mpi interface that allows us to use MPI-enabled codes/libraries (e.g. zoltan) in an application that is built without MPI, conflict with msmpi:
+  rm -r ${pkgdir}${MINGW_PREFIX}/include/mpi.h
+  #rm -r ${pkgdir}${MINGW_PREFIX}/include/_MPI_UTILITY.h
+  #rm -r ${pkgdir}${MINGW_PREFIX}/include/mpi*.h
   #rm -r ${pkgdir}${MINGW_PREFIX}/lib/libsimpi.a 
 }


### PR DESCRIPTION
Fix this:
```
(1/1) checking for file conflicts                                                                                   [####################################################################] 100%
error: failed to commit transaction (conflicting files)
mingw-w64-x86_64-seacas: /mingw64/include/mpi.h exists in filesystem (owned by mingw-w64-x86_64-msmpi)
Errors occurred, no packages were upgraded.
```

https://github.com/gsjaardema/seacas/issues/238#issuecomment-947858893
