### PR TITLE
qt6-multimedia: Fix building with WMF feature

### DIFF
--- a/mingw-w64-qt6-multimedia/PKGBUILD
+++ b/mingw-w64-qt6-multimedia/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
 _qtver=6.2.0
 pkgver=${_qtver/-/}
-pkgrel=2
+pkgrel=3
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://www.qt.io'
@@ -19,8 +19,20 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "rsync")
 options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
-source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/$_qtver/submodules/$_pkgfn.tar.xz")
-sha256sums=('f12b96e6da2ebfe84105c0cb6e96fbc6bda012de8998ec5c96b58c85dcb40b4f')
+source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/$_qtver/submodules/$_pkgfn.tar.xz"
+        "fix-wmf-feature.patch::https://github.com/qt/qtmultimedia/commit/a199c50.patch"
+        "fix-function-decl.patch::https://github.com/qt/qtmultimedia/commit/3c74340.patch")
+sha256sums=('f12b96e6da2ebfe84105c0cb6e96fbc6bda012de8998ec5c96b58c85dcb40b4f'
+            '30e7eab87475d1613ea906e7a2aff567de821b6a0cdfa284a039a89b16b1047c'
+            '325f6cce2a0bea49ecac002c49a83e4b49fa9ba8b1512601051c01fe014811bf')
+
+prepare() {
+  cd "${_pkgfn}"
+
+  # These are already in 6.2.1 branch
+  patch -p1 -i "${srcdir}/fix-wmf-feature.patch"
+  patch -p1 -i "${srcdir}/fix-function-decl.patch"
+}
 
 build() {
   cd ${srcdir}
@@ -32,6 +44,7 @@ build() {
     -GNinja \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DFEATURE_wmf=ON \
     ../${_pkgfn}
 
   cmake --build .


### PR DESCRIPTION
Import some patches from upstream 6.2.1 branch. Fixes https://github.com/msys2/MINGW-packages/issues/9736