### PR TITLE
harfbuzz: Update to 3.0.0

### DIFF
--- a/mingw-w64-harfbuzz/PKGBUILD
+++ b/mingw-w64-harfbuzz/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=harfbuzz
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.9.1
+pkgver=3.0.0
 pkgrel=1
 pkgdesc="OpenType text shaping engine (mingw-w64)"
 arch=('any')
@@ -30,7 +30,7 @@ options=('strip' 'staticlibs')
 optdepends=("${MINGW_PACKAGE_PREFIX}-icu: harfbuzz-icu support"
             "${MINGW_PACKAGE_PREFIX}-cairo: hb-view program")
 source=("https://github.com/harfbuzz/harfbuzz/archive/${pkgver}.tar.gz")
-sha256sums=('f997abd0e3b90647408bfb01af2383b5fc9557af20137e7c2deaf2fa13705dc8')
+sha256sums=('55f7e36671b8c5569b6438f80efed2fd663298f785ad2819e115b35b5587ef69')
 noextract=("${pkgver}.tar.gz")
 
 prepare() {


### PR DESCRIPTION
See https://github.com/harfbuzz/harfbuzz/releases/tag/3.0.0

This only changed API/ABI for libharfbuzz-subset-0.dll and we have no
users of that in the repo, so no rebuilds required.