### PR TITLE
Don't strip Rust package

### DIFF
--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -8,7 +8,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-rust-docs")
 pkgver=1.56.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -28,7 +28,8 @@ makedepends=("bison"
              "${MINGW_PACKAGE_PREFIX}-python"
              $([[ "$_bootstrapping" == "no" ]] && echo "${MINGW_PACKAGE_PREFIX}-rust")
              "${MINGW_PACKAGE_PREFIX}-zlib")
-options=('staticlibs')
+# Bug in strip breaks the DLLs: https://github.com/msys2/MINGW-packages/issues/9655
+options=('staticlibs' '!strip')
 #install=rust.install
 noextract=(${_realname}c-${pkgver}-src.tar.gz)
 source=("https://static.rust-lang.org/dist/${_realname}c-${pkgver}-src.tar.gz"{,.asc}
@@ -123,11 +124,10 @@ build() {
 
 check() {
   cd "${srcdir}/${MSYSTEM}"
-  # it might fail on Windows
   DEP_NGHTTP_ROOT=${MINGW_PREFIX} \
   DEP_OPENSSL_ROOT=${MINGW_PREFIX} \
   DEP_Z_ROOT=${MINGW_PREFIX} \
-  ${MINGW_PREFIX}/bin/python ../${_realname}c-${pkgver}-src/x.py test --stage 2 || true
+  ${MINGW_PREFIX}/bin/python ../${_realname}c-${pkgver}-src/x.py test --stage 2 --exclude src/test/debuginfo
 }
 
 


### PR DESCRIPTION
I don't know whether `makepkge` uses `strip` from `msys` or `clangXY` subsystem but it clearly has bug and breaks DLLs in some cases.

Fixes https://github.com/msys2/MINGW-packages/issues/9655