### PR TITLE
python-setuptools: fix arm64

### DIFF
--- a/mingw-w64-python-setuptools/0007-windows-arm64.patch
+++ b/mingw-w64-python-setuptools/0007-windows-arm64.patch
@@ -1,0 +1,11 @@
+--- setuptools-58.2.0/setuptools/command/easy_install.py.orig	2021-10-24 11:48:34.771385900 -0700
++++ setuptools-58.2.0/setuptools/command/easy_install.py	2021-10-24 11:49:03.364600700 -0700
+@@ -2263,7 +2263,7 @@
+     """
+     launcher_fn = '%s.exe' % type
+     if is_64bit():
+-        if get_platform() == "win-arm64":
++        if '(arm64)' in sys.version.lower():
+             launcher_fn = launcher_fn.replace(".", "-arm64.")
+         else:
+             launcher_fn = launcher_fn.replace(".", "-64.")

--- a/mingw-w64-python-setuptools/PKGBUILD
+++ b/mingw-w64-python-setuptools/PKGBUILD
@@ -9,7 +9,7 @@ conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
            "${MINGW_PACKAGE_PREFIX}-python2-setuptools<42.0.2")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=58.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Easily download, build, install, upgrade, and uninstall Python packages (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -25,6 +25,7 @@ source=(${_realname}-${pkgver}.tar.gz::https://pypi.org/packages/source/${_realn
         '0003-MinGW-w64-Look-in-same-dir-as-script-for-exe.patch'
         '0005-execv-warning.patch'
         '0006-fix-tests-path.patch'
+        '0007-windows-arm64.patch'
 )
 checkdepends=(
   "${MINGW_PACKAGE_PREFIX}-python-pytest"
@@ -52,7 +53,8 @@ sha256sums=('2c55bdb85d5bb460bd2e3b12052b677879cffcf46c0c688f2e5bf51d36001145'
             'fa54581e3dddb9f4edd332dedbc101f48939a9ca5878e13cf9cf9b3408bc8c22'
             '39503256652c7c23ce07e26539e8123d269eb5c09f5d9b07e5784b2d7fb8c96f'
             'a356b0663f67a296624d1b178b42437b380b48a4bbe05a560d3bf29e93a4c623'
-            'dbdd96a7ead797b2db9f02dfe19ce853d3775337ccf8fd836377fe3c2a9d1c24')
+            'dbdd96a7ead797b2db9f02dfe19ce853d3775337ccf8fd836377fe3c2a9d1c24'
+            'cb897bc7292a733167fa48b5ca18323d76d3374683a7f5e9986c9df63f5332cc')
 
 prepare() {
   cd "${srcdir}/setuptools-${pkgver}"
@@ -62,6 +64,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0003-MinGW-w64-Look-in-same-dir-as-script-for-exe.patch
   patch -p1 -i ${srcdir}/0005-execv-warning.patch
   patch -p1 -i ${srcdir}/0006-fix-tests-path.patch
+  patch -p1 -i ${srcdir}/0007-windows-arm64.patch
 
   rm -f setuptools/{gui,cli}{-32,-64,-arm64,}.exe
   local _gui_args="-DGUI=1 -mwindows -O2"


### PR DESCRIPTION
They tried to add support upstream, but distutils.util.get_platform doesn't actually return win-arm64.

Fixes #9871 