### PR TITLE
sdl2: Fix sdl2-config to return win32 path

### DIFF
--- a/mingw-w64-SDL2/001-fix-cmake-target-relocation.patch
+++ b/mingw-w64-SDL2/001-fix-cmake-target-relocation.patch
@@ -1,6 +1,6 @@
 --- SDL2-2.0.12/CMakeLists.txt.orig	2020-04-11 16:44:16.343880000 +0300
 +++ SDL2-2.0.12/CMakeLists.txt	2020-04-11 16:48:12.677114500 +0300
-@@ -2343,12 +2343,12 @@
+@@ -2343,19 +2343,19 @@
  set(EXTRA_CFLAGS ${_EXTRA_CFLAGS})
  
  # Compat helpers for the configuration files
@@ -15,7 +15,17 @@
  
    set(prefix ${CMAKE_INSTALL_PREFIX})
  
-@@ -2674,7 +2674,7 @@
+   set(exec_prefix "\${prefix}")
+-  set(libdir "${CMAKE_INSTALL_FULL_LIBDIR}")
+-  set(bindir "${CMAKE_INSTALL_FULL_BINDIR}")
+-  set(includedir "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
++  set(libdir "\${exec_prefix}/lib${LIB_SUFFIX}")
++  set(bindir "\${exec_prefix}/bin")
++  set(includedir "\${prefix}/include")
+   if(SDL_STATIC)
+     set(ENABLE_STATIC_TRUE "")
+     set(ENABLE_STATIC_FALSE "#")
+@@ -2667,7 +2667,7 @@
    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
  
  ##### Export files #####

--- a/mingw-w64-SDL2/PKGBUILD
+++ b/mingw-w64-SDL2/PKGBUILD
@@ -5,7 +5,7 @@ _realname=SDL2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.0.16
-pkgrel=1
+pkgrel=2
 pkgdesc="A library for portable low-level access to a video framebuffer, audio output, mouse, and keyboard (Version 2) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -25,7 +25,7 @@ source=("https://libsdl.org/release/SDL2-${pkgver}.tar.gz"
         003-fix-static-library-name.patch
         005-sdl-config-win-paths.patch)
 sha256sums=('65be9ff6004034b5b2ce9927b5a4db1814930f169c4b2dae0a1e4697075f287b'
-            'e37bfcfa7322669381ec9da7145e61db45a856c4e026740047eaf7078a086046'
+            '1444952eaaf04042c27ae07f21657e468972f7571ae006527fc13beb43edbe62'
             '4a3906a9b9989dba4967454512921660e0fb275c35263d8ef7d7b34fa5a95e57'
             '07c9a68f91c05f75533069a610e8f9c58c6ed04d7bd60293ef9d22d3af3c97d6'
             '258b2e90da4bd38f61fab37f35cee25b84a45c4bb25d27bc0c05f57ab26d7d64')
@@ -33,6 +33,8 @@ validpgpkeys=('1528635D8053A57F77D1E08630A59377A7763BE6') # Sam Lantinga
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
+
+  # Fixes sdl-config https://github.com/msys2/MINGW-packages/issues/9881
   patch -p1 -i ${srcdir}/001-fix-cmake-target-relocation.patch
   patch -p1 -i ${srcdir}/002-fix-link-order.patch
   patch -p1 -i ${srcdir}/003-fix-static-library-name.patch


### PR DESCRIPTION
Fixes https://github.com/msys2/MINGW-packages/issues/9881