### PR TITLE
octave: Fix using wrapper executable `octave.exe`

### DIFF
--- a/mingw-w64-octave/0004-spawn-p_wait.patch
+++ b/mingw-w64-octave/0004-spawn-p_wait.patch
@@ -1,0 +1,43 @@
+# HG changeset patch
+# User Markus Mützel <markus.muetzel@gmx.de>
+# Date 1635333328 -7200
+#      Wed Oct 27 13:15:28 2021 +0200
+# Branch stable
+# Node ID 42110084b7a814201ff1d442ee65a3162bbff26c
+# Parent  1f41d3fbc3da24f824683386331d6df27571b357
+Don't use P_OVERLAY to spawn main process from wrapper executable on Windows.
+
+* liboctave/wrappers/unistd-wrappers.c (octave_execv_wrapper): Spawning a
+  process with P_OVERLAY returns the control to the terminal on Windows. Instead
+  wait for the child process to finish in the wrapper executable.
+* src/main.in.cc: Only print error message for status = -1 on Windows.
+
+diff -r 1f41d3fbc3da -r 42110084b7a8 liboctave/wrappers/unistd-wrappers.c
+--- a/liboctave/wrappers/unistd-wrappers.c	Sun Aug 29 14:05:04 2021 +0200
++++ b/liboctave/wrappers/unistd-wrappers.c	Wed Oct 27 13:15:28 2021 +0200
+@@ -252,9 +252,9 @@
+ 
+   char **sanitized_argv = prepare_spawn (argv);
+ 
+-  int status = spawnv (P_OVERLAY, file, sanitized_argv);
++  int status = spawnv (P_WAIT, file, sanitized_argv);
+ 
+-  // This only happens if spawnv fails.
++  // This happens when the spawned process terminates.
+ 
+   char **p = sanitized_argv;
+   while (*p)
+diff -r 1f41d3fbc3da -r 42110084b7a8 src/main.in.cc
+--- a/src/main.in.cc	Sun Aug 29 14:05:04 2021 +0200
++++ b/src/main.in.cc	Wed Oct 27 13:15:28 2021 +0200
+@@ -186,6 +186,10 @@
+ {
+   int status = octave_execv_wrapper (file.c_str (), argv);
+ 
++#if defined (OCTAVE_USE_WINDOWS_API)
++  // The above wrapper uses spawn(P_WAIT,...) instead of exec on Windows.
++  if (status == -1)
++#endif
+   std::cerr << argv[0] << ": failed to exec '" << file << "'" << std::endl;
+ 
+   return status;

--- a/mingw-w64-octave/0005-makeinfo-perl.patch
+++ b/mingw-w64-octave/0005-makeinfo-perl.patch
@@ -1,0 +1,20 @@
+# HG changeset patch
+# User Markus Mützel <markus.muetzel@gmx.de>
+# Date 1635334220 -7200
+#      Wed Oct 27 13:30:20 2021 +0200
+# Node ID c74f2b48ad9f4898e0654e0f6359e322a2393620
+# Parent  d3731abd4cd20fe7f1623fe258d2b2e62d829572
+Set up for correctly exacuting makinfo perl script on mingw.
+
+* scripts/startup/site-rcfile: The perl script cannot be executed on mingw using
+  the shebang mechanism. Set up for calling it with perl explicitly instead.
+
+diff -r d3731abd4cd2 -r c74f2b48ad9f scripts/startup/site-rcfile
+--- a/scripts/startup/site-rcfile	Fri Oct 22 13:19:03 2021 +0200
++++ b/scripts/startup/site-rcfile	Wed Oct 27 13:30:20 2021 +0200
+@@ -5,3 +5,5 @@
+ ##
+ ## This file contain commands that should be executed each time Octave starts
+ ## for every user at this site.
++
++makeinfo_program (sprintf ("%s && cd %s/../usr/bin && perl makeinfo", OCTAVE_HOME ()(1:2), OCTAVE_HOME ()));

--- a/mingw-w64-octave/PKGBUILD
+++ b/mingw-w64-octave/PKGBUILD
@@ -2,7 +2,7 @@ _realname=octave
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=6.3.0
-pkgrel=5
+pkgrel=6
 pkgdesc="GNU Octave: Interactive programming environment for numerical computations (mingw-w64)"
 url="https://www.octave.org"
 license=('GPL3')
@@ -37,17 +37,23 @@ optdepends=('texinfo: for help-support in Octave'
 source=(https://ftp.gnu.org/gnu/octave/octave-$pkgver.tar.gz
         "0001-binary-install-location.patch"
         "0002-mk-doc-cache-path.patch"
-        "0003-pkg-octave-binary.patch")
+        "0003-pkg-octave-binary.patch"
+        "0004-spawn-p_wait.patch"
+        "0005-makeinfo-perl.patch")
 sha512sums=('9582d7a7d84beef2a22d3dfaf45aee4778fc0dfc0ec1831c5bcb863dd0062e996e5b7aaaa40519c23d2c730c3408e26745b9dbf73db5127ebae22da0b2532788'
             'dc714dbf04dc551cd996b4b1b9bf7816100103fa8c3d7d3633171d36f5d8eb20464fa0cfeee387c882a1fcb81e824d11e68b7f99f2f6b56d1f2ef6b220c8acab'
             '5742cde34ae9184276c830dab41dccb289991578656353658bf07315d89b1c3870c6c51520d5aae0cec8c7fb12c707a1970aa9dde353b4ab54e515d1d3cf66e0'
-            '96c596fb105589bbfc662211cd62c2ecfea903656b15b54045a6ee852d8c3b3bdc6894bb2f93693f88bb5eab6ad7ed54056b42a0f3cc3832e2be961887e10acf')
+            '96c596fb105589bbfc662211cd62c2ecfea903656b15b54045a6ee852d8c3b3bdc6894bb2f93693f88bb5eab6ad7ed54056b42a0f3cc3832e2be961887e10acf'
+            '1dd71764e3ad88c3c7e3bcfd24a0d4fd1873496a4564f7e0817230f73957345776c43f41bb1c394613cacf48b0d741555f99240047ae285cb8461031e8ac7bb8'
+            'dc99ad8eb214746633d14ce09edddc20f6dd73929f1c556538157e5e4d7210b4045b35a42bd70ebb31c0652aca6c53c720178826b125b19c5cfde9fe8e6c36f8')
 
 prepare() {
   cd "${_realname}-${pkgver}"
   patch -p1 -i "${srcdir}/0001-binary-install-location.patch"
   patch -p1 -i "${srcdir}/0002-mk-doc-cache-path.patch"
   patch -p1 -i "${srcdir}/0003-pkg-octave-binary.patch"
+  patch -p1 -i "${srcdir}/0004-spawn-p_wait.patch"
+  patch -p1 -i "${srcdir}/0005-makeinfo-perl.patch"
 }
 
 build() {
@@ -75,9 +81,6 @@ build() {
 
 package() {
   make -C "build-${MSYSTEM}" DESTDIR="${pkgdir}" install
-
-  # override default command for running "makeinfo" in init file
-  echo 'makeinfo_program (sprintf ("%s && cd %s/../usr/bin && perl makeinfo", OCTAVE_HOME ()(1:2), OCTAVE_HOME ()));' >> "${pkgdir}/${MINGW_PREFIX}/share/octave/site/m/startup/octaverc"
 
   # Remove full path reference
   local _PREFIX_WIN="$(cygpath -wm ${MINGW_PREFIX})"


### PR DESCRIPTION
`spawn` with `P_OVERLAY` works differently on Windows than on POSIX. Use `spawn` with `P_WAIT` instead.

Use patch to have a working `makeinfo` earlier (when building). This is a necessary change to build the documentation once (or if) https://github.com/msys2/msys2-texlive/issues/16 gets fixed.