### PR TITLE
Update portmidi with more recent portmedia release

### DIFF
--- a/mingw-w64-portmidi/PKGBUILD
+++ b/mingw-w64-portmidi/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=portmidi
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=217
-pkgrel=2
+pkgver=234
+pkgrel=1
 pkgdesc="Platform independent library for real-time MIDI input/output (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -14,13 +14,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
-source=("https://downloads.sourceforge.net/portmedia/portmidi/${pkgver}/portmidi-src-${pkgver}.zip"
+source=("https://sourceforge.net/projects/portmedia/files/portmedia-code-r${pkgver}.zip"
         enable-install-on-windows.patch)
-sha256sums=('08e9a892bd80bdb1115213fb72dc29a7bf2ff108b378180586aa65f3cfd42e0f'
+sha256sums=('d737d3f10a70ad6a79fd8a6556015bacf8e8223d4ef8b79a621ec6ac1e44f1bc'
             'fabd4660901f16d4c97ab1a8d1346b946e9dc06b3158cb237dbf14264895c53e')
 
 prepare() {
-  cd portmidi
+  cd portmedia-code-r${pkgver}/portmidi/trunk
   patch -p1 -i "${srcdir}/enable-install-on-windows.patch"
 }
 
@@ -40,7 +40,7 @@ build() {
     -DJAVA_INCLUDE_PATH= \
     -DJAVA_INCLUDE_PATH2= \
     -DJAVA_JVM_LIBRARY= \
-    ../portmidi
+    ../portmedia-code-r${pkgver}/portmidi/trunk
 
   make -t pmjni
   make
@@ -56,5 +56,6 @@ package() {
   done
 
   # install license
-  install -Dm0755 "${srcdir}/portmidi/license.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/license.txt"
+  install -Dm0755 "${srcdir}/portmedia-code-r${pkgver}/portmidi/trunk/license.txt" \
+    "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/license.txt"
 }


### PR DESCRIPTION
Portmidi is no longer maintained as a standalone package,
but is maintained as part of the larger portmedia release.