### PR TITLE
asio: Update to 1.20.0

### DIFF
--- a/mingw-w64-asio/PKGBUILD
+++ b/mingw-w64-asio/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=asio
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.18.2
+pkgver=1.20.0
 pkgrel=1
 pkgdesc='Cross-platform C++ library for ASynchronous network I/O (mingw-w64)'
 url='https://think-async.com/Asio/'
@@ -16,19 +16,21 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 _realver=${pkgver//./-}
 _realpath=${_realname}-${_realname}-${_realver}
 source=("${_realpath}.tar.gz::https://github.com/chriskohlhoff/${_realname}/archive/${_realname}-${_realver}.tar.gz")
-sha256sums=('8d67133b89e0f8b212e9f82fdcf1c7b21a978d453811e2cd941c680e72c2ca32')
+sha256sums=('34a8f07be6f54e3753874d46ecfa9b7ab7051c4e3f67103c52a33dfddaea48e6')
 
 prepare() {
   cd ${srcdir}/${_realpath}/${_realname}/
 
-  autoreconf -fiv
+  autoupdate -fv && autoreconf -fiv
 }
 
 build() {
-  cd ${srcdir}/${_realpath}/${_realname}/
+  [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
-  CPPFLAGS+=" -D_WIN32_WINNT=0x601" \
-  ./configure \
+
+  CPPFLAGS+=" -D_WIN32_WINNT=0x0601" \
+  ${srcdir}/${_realpath}/${_realname}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
@@ -39,12 +41,14 @@ build() {
 }
 
 check() {
-  cd ${srcdir}/${_realpath}/${_realname}/
+  cd "${srcdir}/build-${MSYSTEM}"
+
   make check
 }
 
 package() {
-  cd ${srcdir}/${_realpath}/${_realname}/
+  cd "${srcdir}/build-${MSYSTEM}"
+
   make DESTDIR=${pkgdir} install
 
   install -Dm 644 COPYING LICENSE_1_0.txt -t "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"


### PR DESCRIPTION
There is compilation failure for examples `src/examples/cpp14/parallel_group/` because preprocessor macro `ASIO_HAS_POSIX_STREAM_DESCRIPTOR` defined, but why?...