### PR TITLE
new package: python-typing-extensions

### DIFF
--- a/mingw-w64-python-typing-extensions/PKGBUILD
+++ b/mingw-w64-python-typing-extensions/PKGBUILD
@@ -1,0 +1,37 @@
+# Contributor: Raed Rizqie <raed.rizqie@gmail.com>
+
+_realname=typing
+pkgbase=mingw-w64-python-${_realname}-extensions
+pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}-extensions
+pkgver=3.10.0.2
+pkgrel=1
+pkgdesc='Backported and Experimental Type Hints for Python 3.5+ (mingw-w64)'
+url='https://github.com/python/typing'
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+license=('PSF')
+depends=(${MINGW_PACKAGE_PREFIX}-python)
+makedepends=(${MINGW_PACKAGE_PREFIX}-python-setuptools)
+source=(https://github.com/python/${_realname}/archive/${pkgver}.tar.gz)
+sha256sums=('f77651a11ed494a8444520c812d208f62dfa18a5b6d591ffed29d5719bf79975')
+
+prepare() {
+  cd "${srcdir}"
+  rm -rf python-build-${MSYSTEM} | true
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
+}
+
+build() {
+  msg "Python build for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
+  ${MINGW_PREFIX}/bin/python setup.py build
+}
+
+package() {
+  cd "${srcdir}/python-build-${MSYSTEM}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
+    --root=${pkgdir} --optimize=1 --skip-build
+
+  install -Dm644 LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE
+}


### PR DESCRIPTION
newer `astroid` requires `typing-extensions`