### PR TITLE
new package: python-maturin

### DIFF
--- a/mingw-w64-python-maturin/PKGBUILD
+++ b/mingw-w64-python-maturin/PKGBUILD
@@ -1,0 +1,41 @@
+# Contributor: Raed Rizqie <raed.rizqie@gmail.com>
+
+_realname=maturin
+pkgbase=mingw-w64-python-${_realname}
+pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
+pkgver=0.11.5
+pkgrel=1
+pkgdesc='Build and publish crates with pyo3, rust-cpython and cffi bindings as well as rust binaries as python packages (mingw-w64)'
+url='https://github.com/pyo3/maturin'
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+license=('MIT')
+depends=(
+    ${MINGW_PACKAGE_PREFIX}-python
+    ${MINGW_PACKAGE_PREFIX}-python-toml)
+makedepends=(
+    ${MINGW_PACKAGE_PREFIX}-python-setuptools
+    ${MINGW_PACKAGE_PREFIX}-python-setuptools-rust)
+source=(https://github.com/pyo3/${_realname}/archive/v${pkgver}.tar.gz)
+sha256sums=('33b67e66e725c76eac866c2174cfbe708e77a44d215878474d84bc5f9f6386f3')
+
+prepare() {
+  cd "${srcdir}"
+  rm -rf python-build-${MSYSTEM} | true
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
+}
+
+build() {
+  msg "Python build for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
+  ${MINGW_PREFIX}/bin/python setup.py build
+}
+
+package() {
+  cd "${srcdir}/python-build-${MSYSTEM}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
+    --root=${pkgdir} --optimize=1 --skip-build
+
+  install -Dm644 license-mit ${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE
+}


### PR DESCRIPTION
- needed by `pywinpty`
- lacks clang32 build coz `rust` don't build on clang32