### PR TITLE
libuv: Fix redefinition error with mingw-w64 headers

### DIFF
--- a/mingw-w64-libuv/0001-winapi-fix-redefinition.patch
+++ b/mingw-w64-libuv/0001-winapi-fix-redefinition.patch
@@ -1,0 +1,15 @@
+--- a/src/win/winapi.h
++++ b/src/win/winapi.h
+@@ -4726,12 +4726,6 @@
+                        DWORD        idThread,
+                        UINT         dwflags);
+ 
+-/* From mstcpip.h */
+-typedef struct _TCP_INITIAL_RTO_PARAMETERS {
+-  USHORT Rtt;
+-  UCHAR  MaxSynRetransmissions;
+-} TCP_INITIAL_RTO_PARAMETERS, *PTCP_INITIAL_RTO_PARAMETERS;
+-
+ #ifndef TCP_INITIAL_RTO_NO_SYN_RETRANSMISSIONS
+ # define TCP_INITIAL_RTO_NO_SYN_RETRANSMISSIONS ((UCHAR) -2)
+ #endif

--- a/mingw-w64-libuv/PKGBUILD
+++ b/mingw-w64-libuv/PKGBUILD
@@ -5,7 +5,7 @@ _realname=libuv
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.42.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Cross-platform asynchronous I/O (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -15,10 +15,12 @@ makedepends=()
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 options=('staticlibs' 'strip')
 source=(https://dist.libuv.org/dist/v${pkgver}/libuv-v${pkgver}.tar.gz{,.sign}
-        "string-encoding-uv_os_gethostname.patch::https://github.com/libuv/libuv/commit/95f88f4.patch")
+        "string-encoding-uv_os_gethostname.patch::https://github.com/libuv/libuv/commit/95f88f4.patch"
+        "0001-winapi-fix-redefinition.patch")
 sha256sums=('43129625155a8aed796ebe90b8d4c990a73985ec717de2b2d5d3a23cfe4deb72'
             'SKIP'
-            '18e4c2af57254f0550c684d48b259b54f9bcad27b4286aad1d8c4e5ec0932fc5')
+            '18e4c2af57254f0550c684d48b259b54f9bcad27b4286aad1d8c4e5ec0932fc5'
+            '925567b88d690950af1201153df641cbf0a3161546da33bcc9a2ac215dc3fd6a')
 # PGP key IDs are available from https://github.com/libuv/libuv/blob/v1.x/MAINTAINERS.md
 validpgpkeys=('AEAD0A4B686767751A0E4AEF34A25FB128246514') # Jameson Nash <vtjnash@gmail.com>"
 
@@ -32,6 +34,8 @@ prepare() {
   # https://github.com/msys2/MINGW-packages/issues/9632
 
   patch -R -p1 -i "${srcdir}/string-encoding-uv_os_gethostname.patch"
+
+  patch -p1 -i "${srcdir}/0001-winapi-fix-redefinition.patch"
 
  ./autogen.sh
 }


### PR DESCRIPTION
Fixes https://github.com/msys2/MINGW-packages/issues/9946