### PR TITLE
setup-msys2: install pactoys instead of pactoys-git

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           msystem: ${{ matrix.msystem }}
-          install: VCS base-devel binutils pactoys-git ${{ matrix.toolchain }}
+          install: VCS base-devel binutils pactoys ${{ matrix.toolchain }}
           update: true
 
       - name: Add staging repo


### PR DESCRIPTION
pactoys-git was replaced by pactoys and removed from repos, I got this error:
` error: target not found: pactoys-git`