### PR TITLE
vapoursynth: update to R57

### DIFF
--- a/mingw-w64-vapoursynth/PKGBUILD
+++ b/mingw-w64-vapoursynth/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=vapoursynth
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=49
-pkgrel=2
+pkgver=57
+pkgrel=1
 pkgdesc="A video processing framework with simplicity in mind (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -12,27 +12,24 @@ url="https://www.vapoursynth.com/"
 license=('LGPL')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-cython"
-         "${MINGW_PACKAGE_PREFIX}-ffmpeg"
-         "${MINGW_PACKAGE_PREFIX}-imagemagick"
-         "${MINGW_PACKAGE_PREFIX}-libass"
-         "${MINGW_PACKAGE_PREFIX}-libxml2"
          "${MINGW_PACKAGE_PREFIX}-python"
-         "${MINGW_PACKAGE_PREFIX}-tesseract-ocr"
          "${MINGW_PACKAGE_PREFIX}-zimg")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pkgconf"
+             "${MINGW_PACKAGE_PREFIX}-python-sphinx")
 options=(!strip staticlibs)
 source=("vapoursynth-${pkgver}.tar.gz::https://github.com/vapoursynth/vapoursynth/archive/R${pkgver}.tar.gz")
-sha256sums=('126d1e68d3a3e80d1e215c8a2a5dc8773f5fcac70a6c22dadc837bccb603bccd')
+sha256sums=('9bed2ab1823050cfcbdbb1a57414e39507fd6c73f07ee4b5986fcbf0f6cb2d07')
 
 prepare() {
   cd "${srcdir}/${_realname}-R${pkgver}"
-  sed -i 's/inline __forceinline/__forceinline/g' src/core/genericfilters.cpp
   autoreconf -vfi
 }
 
 build() {
-  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
-  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+  [[ -d "${srcdir}"/build-${MSYSTEM} ]] && rm -rf "${srcdir}"/build-${MSYSTEM}
+  mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
+
   ../${_realname}-R${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --host=${MINGW_CHOST} \
@@ -44,10 +41,10 @@ build() {
 }
 
 package() {
-  cd "${srcdir}"/build-${CARCH}
+  cd "${srcdir}"/build-${MSYSTEM}
   make DESTDIR="${pkgdir}" install
 
-  install -Dm644 "${srcdir}/${_realname}-R${pkgver}"/COPYING.LGPLv2.1 ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.LGPLv2.1
+  install -Dm644 "${srcdir}/${_realname}-R${pkgver}"/COPYING.LESSER ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.LESSER
 
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
   for _f in "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/*.pc; do
@@ -58,6 +55,4 @@ package() {
 
   rm -f ${pkgdir}${MINGW_PREFIX}/lib/vapoursynth/*.dll.a
   rm -f ${pkgdir}${MINGW_PREFIX}/lib/python${_py3ver}/site-packages/*.dll.a
-  mv -f ${pkgdir}${MINGW_PREFIX}/lib/bin/*.dll ${pkgdir}${MINGW_PREFIX}/lib/vapoursynth/
-  rm -rf ${pkgdir}${MINGW_PREFIX}/lib/bin
 }


### PR DESCRIPTION
The plugins were moved to their own repos:
see: https://github.com/vapoursynth/vapoursynth/commit/67fa8c5