### PR TITLE
Update EDA tools GHDL, Yosys, NextPnR and Scopehal

### DIFF
--- a/mingw-w64-ghdl/PKGBUILD
+++ b/mingw-w64-ghdl/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=ghdl
 pkgbase="mingw-w64-${_realname}"
 pkgname='__placeholder__'
-pkgver=1.0.0.r833.gb37ce7900
+pkgver=1.0.0.r849.gc56db2336
 pkgrel=1
 pkgdesc='GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL'
 arch=('any')
@@ -12,7 +12,7 @@ groups=("${MINGW_PACKAGE_PREFIX}-eda")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 
-_commit="b37ce790"
+_commit="c56db233"
 source=("${_realname}::git+https://github.com/ghdl/ghdl.git#commit=${_commit}")
 sha512sums=('SKIP')
 

--- a/mingw-w64-iverilog/PKGBUILD
+++ b/mingw-w64-iverilog/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=iverilog
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=11.0.r8925.gef01dd1e
+pkgver=11.0.r8934.g0e3682a1
 pkgrel=1
 epoch=1
 pkgdesc="Icarus Verilog, is a Verilog simulation and synthesis tool (mingw-w64)"
@@ -21,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 
 # NOTE: MSYS2 support was improved/fixed in 'master' (2020/12/04).
 # When 12.0 is tagged/released, this should be changed to use a tarball instead.
-_commit="ef01dd1e"
+_commit="0e3682a1"
 source=("${_realname}::git+https://github.com/steveicarus/iverilog.git#commit=${_commit}")
 sha256sums=('SKIP')
 

--- a/mingw-w64-nextpnr/PKGBUILD
+++ b/mingw-w64-nextpnr/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=nextpnr
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.0.r3875.g3b99db29
+pkgver=0.0.r3884.g06d58e6e
 pkgrel=1
 pkgdesc="Portable FPGA place and route tool (mingw-w64)"
 arch=('any')
@@ -28,7 +28,7 @@ makedepends=(
   "git"
 )
 
-_commit="3b99db29"
+_commit="06d58e6e"
 source=("${_realname}::git+https://github.com/YosysHQ/${_realname}.git#commit=${_commit}")
 sha256sums=('SKIP')
 

--- a/mingw-w64-scopehal-apps/PKGBUILD
+++ b/mingw-w64-scopehal-apps/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=scopehal-apps
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.0.0.r1279.gd95666c9
+pkgver=0.0.0.r1299.g57609c32
 pkgrel=1
 pkgdesc="scopehal-apps: applications for libscopehal (mingw-w64)"
 arch=('any')
@@ -23,7 +23,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cmake"
   "${MINGW_PACKAGE_PREFIX}-ninja"
 )
-_commit='d95666c9'
+_commit='57609c32'
 source=("${_realname}::git+https://github.com/azonenberg/scopehal-apps.git#commit=${_commit}")
 sha256sums=('SKIP')
 

--- a/mingw-w64-yosys/PKGBUILD
+++ b/mingw-w64-yosys/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=yosys
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.10.r28
+pkgver=0.10.r71
 pkgrel=1
 pkgdesc="A framework for RTL synthesis tools (mingw-w64)"
 arch=('any')
@@ -21,7 +21,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python"
 )
 
-_commit='0dd42d40'
+_commit='11e58d54'
 source=(
   "${_realname}::git+https://github.com/YosysHQ/${_realname}.git#commit=${_commit}"
   "ghdl-yosys-plugin::git+https://github.com/ghdl/ghdl-yosys-plugin.git#commit=9e11f71e"


### PR DESCRIPTION
This is a regular update.