### PR TITLE
scintilla-gtk3: update to 5.1.3

### DIFF
--- a/mingw-w64-scintilla-gtk3/PKGBUILD
+++ b/mingw-w64-scintilla-gtk3/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=scintilla
 pkgbase=mingw-w64-${_realname}-gtk3
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-gtk3"
-pkgver=4.4.6
-pkgrel=2
+pkgver=5.1.3
+pkgrel=1
 pkgdesc="A text widget adding syntax highlighting and more to GNOME (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -14,45 +14,37 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-python3")
 depends=("${MINGW_PACKAGE_PREFIX}-gtk3")
-source=("https://www.scintilla.org/scintilla446.tgz"
+source=("https://www.scintilla.org/scintilla${pkgver//./}.tgz"
         "scintilla.pc")
-sha256sums=('2df9306ec4539f4fe13f86bab8f2419ba90464933d7cca846d7bb6e7046ec2dc'
-            '140186d83987804dd7ccb8b8099499dc1daf63362d64122fe8b97a8d9278c72f')
+sha256sums=('42252bbd3ad79ddbf86c8403671417e0b546ce431ad13329e6d87f7fe8bafffd'
+            'b8f27ae48cd30790444e6d1e02b117ef0f2bb048516ea7bf69ca48f77c9eea7b')
 
 prepare() {
   cd ${_realname}
-  
   export windir=${WINDIR}
 }
 
-build() {  
+build() {
   cd ${srcdir}/${_realname}/gtk
   make GTK3=1 PREFIX='${MINGW_PREFIX}' BUILD='${MINGW_CHOST}' HOST='${MINGW_CHOST}' TARGET='${MINGW_CHOST}'
-  
+
   cp -f "${srcdir}/${_realname}.pc" "${srcdir}/${_realname}/bin/${_realname}.pc"
   sed -i -e "s#@prefix@#${MINGW_PREFIX}#g" "${srcdir}/${_realname}/bin/${_realname}.pc"
+  sed -i -e "s#@version@#${pkgver}#g" "${srcdir}/${_realname}/bin/${_realname}.pc"
 }
 
-package() {  
+package() {
   # pkg-config
   install -Dm644 "${srcdir}/${_realname}.pc" "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/${_realname}-gtk3.pc"
-  
+
   # library
-  install -Dm644 "${srcdir}/${_realname}/bin/liblexilla.a" "${pkgdir}${MINGW_PREFIX}/lib/liblexilla.a"
   install -Dm644 "${srcdir}/${_realname}/bin/scintilla.a" "${pkgdir}${MINGW_PREFIX}/lib/scintilla.a"
-  install -Dm644 "${srcdir}/${_realname}/bin/lexilla.dll" "${pkgdir}${MINGW_PREFIX}/bin/lexilla.dll"
   install -Dm644 "${srcdir}/${_realname}/bin/libscintilla.dll" "${pkgdir}${MINGW_PREFIX}/bin/libscintilla.dll"
-  
+
   # include
-  install -Dm644 "${srcdir}/${_realname}/include/ILexer.h" "${pkgdir}${MINGW_PREFIX}/include/${_realname}/ILexer.h"
-  install -Dm644 "${srcdir}/${_realname}/include/ILoader.h" "${pkgdir}${MINGW_PREFIX}/include/${_realname}/ILoader.h"
-  install -Dm644 "${srcdir}/${_realname}/include/Platform.h" "${pkgdir}${MINGW_PREFIX}/include/${_realname}/Platform.h"
-  install -Dm644 "${srcdir}/${_realname}/include/Sci_Position.h" "${pkgdir}${MINGW_PREFIX}/include/${_realname}/Sci_Position.h"
-  install -Dm644 "${srcdir}/${_realname}/include/SciLexer.h" "${pkgdir}${MINGW_PREFIX}/include/${_realname}/SciLexer.h"
-  install -Dm644 "${srcdir}/${_realname}/include/Scintilla.h" "${pkgdir}${MINGW_PREFIX}/include/${_realname}/Scintilla.h"
-  install -Dm644 "${srcdir}/${_realname}/include/Scintilla.iface" "${pkgdir}${MINGW_PREFIX}/include/${_realname}/Scintilla.iface"
-  install -Dm644 "${srcdir}/${_realname}/include/ScintillaWidget.h" "${pkgdir}${MINGW_PREFIX}/include/${_realname}/ScintillaWidget.h"
-  
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/include/${_realname}
+  install -Dm644 ${srcdir}/${_realname}/include/*.h ${pkgdir}${MINGW_PREFIX}/include/${_realname}
+
   # License
   install -Dm644 "${srcdir}/${_realname}/License.txt" "${pkgdir}${MINGW_PREFIX}/share/${_realname}/License.txt"
   install -Dm644 "${srcdir}/${_realname}/version.txt" "${pkgdir}${MINGW_PREFIX}/share/${_realname}/version.txt"

--- a/mingw-w64-scintilla-gtk3/scintilla.pc
+++ b/mingw-w64-scintilla-gtk3/scintilla.pc
@@ -5,7 +5,7 @@ includedir=${prefix}/include
 
 Name: Scintilla
 Description: Scintilla editing component.
-Version: 4.4.6
+Version: @version@
 Requires: gtk+-3.0
 Libs: -L${libdir} -lscintilla
 Cflags: -I${includedir}/scintilla


### PR DESCRIPTION
```
Release 5.0.0

Released 5 March 2021.
First version that separates Lexilla from Scintilla. Each of the 3 projects now has a separate history page but history before 5.0.0 remains combined.
```
https://www.scintilla.org/ScintillaHistory.html