### PR TITLE
asio: Update to 1.21.0

### DIFF
--- a/mingw-w64-asio/PKGBUILD
+++ b/mingw-w64-asio/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=asio
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.18.2
-pkgrel=1
+pkgver=1.21.0
+pkgrel=0
 pkgdesc='Cross-platform C++ library for ASynchronous network I/O (mingw-w64)'
 url='https://think-async.com/Asio/'
 arch=('any')
@@ -16,7 +16,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 _realver=${pkgver//./-}
 _realpath=${_realname}-${_realname}-${_realver}
 source=("${_realpath}.tar.gz::https://github.com/chriskohlhoff/${_realname}/archive/${_realname}-${_realver}.tar.gz")
-sha256sums=('8d67133b89e0f8b212e9f82fdcf1c7b21a978d453811e2cd941c680e72c2ca32')
+sha256sums=('5d2d2dcb7bfb39bff941cabbfc8c27ee322a495470bf0f3a7c5238648cf5e6a9')
 
 prepare() {
   cd ${srcdir}/${_realpath}/${_realname}/


### PR DESCRIPTION
There's a bug fix in this version for an error detecting the availability of `std::aligned_alloc` when using libc++ that affects the clang64 and clang32 builds.