### PR TITLE
pywin32: fix problematic patch

### DIFF
--- a/mingw-w64-python-pywin32/002-com-extensions-fix.patch
+++ b/mingw-w64-python-pywin32/002-com-extensions-fix.patch
@@ -203,15 +203,6 @@ diff -Naur pywin32-b302-orig/com/win32com/src/include/PythonCOMServer.h pywin32-
                                                   REFIID iid)                                                     \
      {                                                                                                            \
          if (ppResult == NULL)                                                                                    \
-@@ -46,7 +46,7 @@
-     virtual IID GetIID(void) { return theIID; }                                                                  \
-     virtual void *ThisAsIID(IID iid)                                                                             \
-     {                                                                                                            \
--        if (this == NULL)                                                                                        \
-+        if (this->ThisAsIID(iid) == NULL)                                                                        \
-             return NULL;                                                                                         \
-         if (iid == theIID)                                                                                       \
-             return (IInterface *)this;                                                                           \
 @@ -134,7 +134,7 @@
  
      // Basically just PYGATEWAY_MAKE_SUPPORT(PyGatewayBase, IDispatch, IID_IDispatch);
@@ -1365,3 +1356,17 @@ diff -Naur pywin32-b302-orig/com/win32comext/taskscheduler/src/PyIScheduledWorkI
  
      HRESULT hr;
      PY_INTERFACE_PRECALL;
+--- pywin32-b302/com/win32comext/ifilter/src/stdafx.h.orig      2021-10-22 17:41
+:56.227210500 -0700
++++ pywin32-b302/com/win32comext/ifilter/src/stdafx.h   2021-10-22 17:44:57.1090
+84600 -0700
+@@ -13,7 +13,9 @@
+ #include <Filter.h>
+ #include <Filterr.h>
+
++#ifndef __MINGW32__
+ #define MISSING_PROPSTG
++#endif
+ #ifdef MISSING_PROPSTG
+ // Ack - NTQuery.h is failing with the Vista SDK - pull in what we need
+ // Problem is missing propstg.h, and all the work-arounds are uglier than

--- a/mingw-w64-python-pywin32/PKGBUILD
+++ b/mingw-w64-python-pywin32/PKGBUILD
@@ -12,7 +12,7 @@ license=('PSF')
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 pkgver=302
-pkgrel=2
+pkgrel=3
 depends=("${MINGW_PACKAGE_PREFIX}-python")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 source=(https://github.com/mhammond/${_realname}/archive/b${pkgver}.zip
@@ -25,7 +25,7 @@ source=(https://github.com/mhammond/${_realname}/archive/b${pkgver}.zip
         010-workaround-broken-add-dll-dir.patch)
 sha256sums=('33547aa989573dc615bf69c9cc589ef8aefe7ec3858009faf1c26d59f73e4a30'
             '9e1e4d28b1fe89ac6e189b46d047d84619f00ba282fa3b85b8ff2ac3ec54963b'
-            'db43a7fb22f836cac413d7c3c386bbfb470528991369530418dda8c47d3bf03d'
+            'cf83477989cfa3cd72199102af8a89fb2ca9ecf6b9c823aae91f326f2997567f'
             '4ed4f5a99d9be5ef6869ba50e40cca8f977f053624ec85fee8bcba41889096cf'
             '82f7745c4eef1e7c3262f6de71655967090c981c542a2e3b0544fda1649be68b'
             'a364eb52c9e0098516bb08ca5abb687fff4ee1c2e6d4a53dcbe91e60a6820879'


### PR DESCRIPTION
Remove infinite recursion from ThisAsIID method.  Disable a workaround
for broken header in Vista SDK that is not broken in MINGW-w64.

/cc @raedrizqie 