### PR TITLE
[new-package] oneTBB 2021.4.0

### DIFF
--- a/mingw-w64-onetbb/001-fix-build-with-mingw.patch
+++ b/mingw-w64-onetbb/001-fix-build-with-mingw.patch
@@ -1,0 +1,78 @@
+--- a/src/tbb/allocator.cpp
++++ b/src/tbb/allocator.cpp
+@@ -27,11 +27,11 @@
+ 
+ #include <cstdlib>
+ 
+-#if _WIN32 || _WIN64
+-#include <Windows.h>
++#ifdef _WIN32
++#include <windows.h>
+ #else
+ #include <dlfcn.h>
+-#endif /* _WIN32||_WIN64 */
++#endif
+ 
+ #if __TBB_WEAK_SYMBOLS_PRESENT
+ 
+--- a/src/tbb/dynamic_link.h
++++ b/src/tbb/dynamic_link.h
+@@ -29,8 +29,8 @@
+     and CLOSE_INTERNAL_NAMESPACE to override the following default definitions. **/
+ 
+ #include <cstddef>
+-#if _WIN32
+-#include <Windows.h>
++#ifdef _WIN32
++#include <windows.h>
+ #endif /* _WIN32 */
+ 
+ namespace tbb {
+--- a/test/common/utils_dynamic_libs.h
++++ b/test/common/utils_dynamic_libs.h
+@@ -22,8 +22,8 @@
+ 
+ #if __TBB_DYNAMIC_LOAD_ENABLED
+ 
+-#if _WIN32 || _WIN64
+-#include <Windows.h>
++#ifdef _WIN32
++#include <windows.h>
+ #else
+ #include <dlfcn.h>
+ #endif
+--- a/include/oneapi/tbb/detail/_machine.h
++++ b/include/oneapi/tbb/detail/_machine.h
+@@ -29,7 +29,9 @@
+ #include <intrin.h>
+ #ifdef __TBBMALLOC_BUILD
+ #define WIN32_LEAN_AND_MEAN
++#ifndef NOMINMAX
+ #define NOMINMAX
++#endif
+ #include <windows.h> // SwitchToThread()
+ #endif
+ #ifdef _MSC_VER
+--- a/cmake/compilers/GNU.cmake
++++ b/cmake/compilers/GNU.cmake
+@@ -59,16 +59,16 @@ if ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "mips")
+     set(TBB_TEST_COMPILE_FLAGS ${TBB_TEST_COMPILE_FLAGS} -DTBB_TEST_LOW_WORKLOAD $<$<CONFIG:DEBUG>:-mxgot>)
+ endif()
+ 
+-if (MINGW)
+-    list(APPEND TBB_COMMON_COMPILE_FLAGS -U__STRICT_ANSI__)
+-endif()
+-
+ # For some reason GCC does not instrument code with Thread Sanitizer when lto is enabled and C linker is used.
+ if (NOT TBB_SANITIZE MATCHES "thread")
+     set(TBB_IPO_COMPILE_FLAGS $<$<NOT:$<CONFIG:Debug>>:-flto>)
+     set(TBB_IPO_LINK_FLAGS $<$<NOT:$<CONFIG:Debug>>:-flto>)
+ endif()
+ 
++if (MINGW AND CMAKE_SYSTEM_PROCESSOR MATCHES "i.86")
++    list (APPEND TBB_COMMON_COMPILE_FLAGS -msse2)
++endif ()
++
+ # TBB malloc settings
+ set(TBBMALLOC_LIB_COMPILE_FLAGS -fno-rtti -fno-exceptions)
+ set(TBB_OPENMP_FLAG -fopenmp)

--- a/mingw-w64-onetbb/002-do-not-copy-lib.patch
+++ b/mingw-w64-onetbb/002-do-not-copy-lib.patch
@@ -1,0 +1,11 @@
+--- a/src/tbb/CMakeLists.txt
++++ b/src/tbb/CMakeLists.txt
+@@ -123,7 +123,7 @@
+ 
+ tbb_install_target(tbb)
+ 
+-if (WIN32)
++if (MSVC)
+     # Create a copy of target linker file (tbb<ver>[_debug].lib) with legacy name (tbb[_debug].lib)
+     # to support previous user experience for linkage.
+     install(FILES

--- a/mingw-w64-onetbb/003-fix-win32-defs.patch
+++ b/mingw-w64-onetbb/003-fix-win32-defs.patch
@@ -1,0 +1,47 @@
+--- a/src/tbbbind/tbb_bind.cpp
++++ b/src/tbbbind/tbb_bind.cpp
+@@ -405,7 +405,7 @@
+     affinity_masks_container affinity_backup;
+     system_topology::affinity_mask handler_affinity_mask;
+ 
+-#if WIN32
++#ifdef _WIN32
+     affinity_masks_container affinity_buffer;
+     int my_numa_node_id;
+     int my_core_type_id;
+@@ -415,7 +415,7 @@
+ public:
+     binding_handler( std::size_t size, int numa_node_id, int core_type_id, int max_threads_per_core )
+         : affinity_backup(size)
+-#if WIN32
++#ifdef _WIN32
+         , affinity_buffer(size)
+         , my_numa_node_id(numa_node_id)
+         , my_core_type_id(core_type_id)
+@@ -424,7 +424,7 @@
+     {
+         for (std::size_t i = 0; i < size; ++i) {
+             affinity_backup[i] = system_topology::instance().allocate_process_affinity_mask();
+-#if WIN32
++#ifdef _WIN32
+             affinity_buffer[i] = system_topology::instance().allocate_process_affinity_mask();
+ #endif
+         }
+@@ -436,7 +436,7 @@
+     ~binding_handler() {
+         for (std::size_t i = 0; i < affinity_backup.size(); ++i) {
+             system_topology::instance().free_affinity_mask(affinity_backup[i]);
+-#if WIN32
++#ifdef _WIN32
+             system_topology::instance().free_affinity_mask(affinity_buffer[i]);
+ #endif
+         }
+@@ -452,7 +452,7 @@
+ 
+         topology.store_current_affinity_mask(affinity_backup[slot_num]);
+ 
+-#if WIN32
++#ifdef _WIN32
+         // TBBBind supports only systems where NUMA nodes and core types do not cross the border
+         // between several processor groups. So if a certain NUMA node or core type constraint
+         // specified, then the constraints affinity mask will not cross the processor groups' border.

--- a/mingw-w64-onetbb/PKGBUILD
+++ b/mingw-w64-onetbb/PKGBUILD
@@ -1,0 +1,63 @@
+# Contributor: Mehdi Chinoune <mehdi.chinoune@hotmail.com>
+
+_realname=oneTBB
+pkgbase=mingw-w64-onetbb
+pkgname=("${MINGW_PACKAGE_PREFIX}-onetbb")
+pkgver=2021.4.0
+pkgrel=1
+arch=(any)
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+url='https://software.intel.com/en-us/oneapi/onetbb'
+license=("custom")
+pkgdesc='oneAPI Threading Building Blocks (mingw-w64)'
+conflicts=("${MINGW_PACKAGE_PREFIX}-intel-tbb")
+depends=("${MINGW_PACKAGE_PREFIX}-hwloc")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
+options=('!strip')
+source=("https://github.com/oneapi-src/${_realname}/archive/v${pkgver}.tar.gz"
+        001-fix-build-with-mingw.patch
+        002-do-not-copy-lib.patch
+        003-fix-win32-defs.patch)
+sha256sums=('021796c7845e155e616f5ecda16daa606ebb4c6f90b996e5c08aebab7a8d3de3'
+            '1e342350d8655a7930a4ba7e28f654296cdd8f99233c957398f86d66f8a31e3e'
+            '01aa1f98b28874070e24df93ff766d980d66bc17a31e63d42f0e3e8645c972cd'
+            'cd533959fcabe4c4f5452ec349cb25f048b96c8b8e5c560f786553daefd19390')
+
+prepare() {
+  cd ${srcdir}/${_realname}-${pkgver}
+  # https://github.com/oneapi-src/oneTBB/pull/618 for both 001 and 003
+  patch -p1 -i ${srcdir}/001-fix-build-with-mingw.patch
+  patch -p1 -i ${srcdir}/003-fix-win32-defs.patch
+  # https://github.com/oneapi-src/oneTBB/pull/618
+  patch -p1 -i ${srcdir}/002-do-not-copy-lib.patch
+}
+
+build() {
+  cd ${srcdir}
+  [[ -d build-${MSYSTEM} ]] && rm -rf build-${MSYSTEM}
+  mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
+
+  if check_option "debug" "n"; then
+    _build_type="Release"
+  else
+    _build_type="Debug"
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  cmake \
+    -GNinja \
+    -DCMAKE_BUILD_TYPE=${_build_type} \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DTBB_TEST=OFF \
+    -DTBB_STRICT=OFF \
+    -DBUILD_SHARED_LIBS=ON \
+    ../${_realname}-${pkgver}
+
+  cmake --build .
+}
+
+package() {
+  DESTDIR=${pkgdir} cmake --install build-${MSYSTEM}
+  install -Dm644 ${srcdir}/${_realname}-${pkgver}/LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
Which name should we choose for it?
~intel-oneapi-tbb : used by Arch community~
oneTBB : the official project name

~I marked it to provide intel-tbb on clang* as some packages has updated to build with both the intel-tbb and the new one.~
I will try to build the intel-tbb dependants against the new one and see how it works.

Edit: It turns out the most intel-tbb dependants are not updated blender, embree, vtk ..etc and others do not require TBB at all (ogre3d and rocksdb)