### PR TITLE
libtool: fix rpath linking in clang

### DIFF
--- a/mingw-w64-libtool/0015-Fix-rpath-linking-in-clang.patch
+++ b/mingw-w64-libtool/0015-Fix-rpath-linking-in-clang.patch
@@ -1,0 +1,39 @@
+diff -urN libtool-2.4.6-orig/m4/libtool.m4 libtool-2.4.6/m4/libtool.m4
+--- libtool-2.4.6-orig/m4/libtool.m4	2021-11-06 19:36:48 +0800
++++ libtool-2.4.6/m4/libtool.m4	2021-11-06 19:43:07 +0800
+@@ -5035,7 +5035,7 @@
+     # are reset later if shared libraries are not supported. Putting them
+     # here allows them to be overridden if necessary.
+     runpath_var=LD_RUN_PATH
+-    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath $wl$libdir'
++    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath,$libdir'
+     _LT_TAGVAR(export_dynamic_flag_spec, $1)='$wl--export-dynamic'
+     # ancient GNU ld didn't support --whole-archive et. al.
+     if $LD --help 2>&1 | $GREP 'no-whole-archive' > /dev/null; then
+@@ -5305,7 +5305,7 @@
+ 	  # DT_RUNPATH tag from executables and libraries.  But doing so
+ 	  # requires that you compile everything twice, which is a pain.
+ 	  if $LD --help 2>&1 | $GREP ': supported targets:.* elf' > /dev/null; then
+-	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath $wl$libdir'
++	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath,$libdir'
+ 	    _LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
+ 	    _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags $wl-soname $wl$soname $wl-retain-symbols-file $wl$export_symbols -o $lib'
+ 	  else
+@@ -6391,7 +6391,7 @@
+         _LT_TAGVAR(archive_cmds, $1)='$CC $pic_flag -shared -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-soname $wl$soname -o $lib'
+         _LT_TAGVAR(archive_expsym_cmds, $1)='$CC $pic_flag -shared -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-soname $wl$soname $wl-retain-symbols-file $wl$export_symbols -o $lib'
+ 
+-        _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath $wl$libdir'
++        _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath,$libdir'
+         _LT_TAGVAR(export_dynamic_flag_spec, $1)='$wl--export-dynamic'
+ 
+         # If archive_cmds runs LD, not CC, wlarc should be empty
+@@ -7195,7 +7195,7 @@
+ 		  ;;
+ 	      esac
+ 
+-	      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath $wl$libdir'
++	      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath,$libdir'
+ 	      _LT_TAGVAR(hardcode_libdir_separator, $1)=:
+ 
+ 	      # Commands to make compiler produce verbose output that lists

--- a/mingw-w64-libtool/PKGBUILD
+++ b/mingw-w64-libtool/PKGBUILD
@@ -24,7 +24,8 @@ source=("https://ftp.gnu.org/pub/gnu/libtool/${_realname}-${pkgver}.tar.xz"{,.si
         0011-Pick-up-clang_rt-static-archives-compiler-internal-l.patch
         0012-Prefer-response-files-over-linker-scripts-for-mingw-.patch
         0013-Allow-statically-linking-compiler-support-libraries-.patch
-        0014-Support-llvm-objdump-f-output.patch)
+        0014-Support-llvm-objdump-f-output.patch
+        0015-Fix-rpath-linking-in-clang.patch)
 sha256sums=('7c87a8c2c8c0fc9cd5019e402bed4292462d00a718a7cd5f11218153bf28b26f'
             'SKIP'
             'fe8b80efd34f9385220ebc90aaec945e44de8c343c75719d6ac0d4e472a6eed5'
@@ -36,7 +37,8 @@ sha256sums=('7c87a8c2c8c0fc9cd5019e402bed4292462d00a718a7cd5f11218153bf28b26f'
             'c727b2b017163cfdeca60820d3cff2dac8968c5630745602b150f92b159af313'
             'c95a65e890b1ae6362807abc66809e72cf81aeea5f9f556e38f9752f974bf435'
             '8069e887aeeab7491f15e00547fa66d9b9e86407f5a23f37a6d8c7d165de752e'
-            'db16cd322e0ebc578c906e94b0788810af17ce617c700a50db2e3c598dbbed7e')
+            'db16cd322e0ebc578c906e94b0788810af17ce617c700a50db2e3c598dbbed7e'
+            'd4efd1cb46a0bb2b37e49487dc053a6882f789d3e2023b76c1742b6849896695')
 
 validpgpkeys=('CFE2BE707B538E8B26757D84151308092983D606') #Gary Vaughan (Free Software Developer) <gary@vaughan.pe>
 
@@ -52,11 +54,13 @@ prepare() {
   patch -p1 -i ${srcdir}/0012-Prefer-response-files-over-linker-scripts-for-mingw-.patch
   patch -p1 -i ${srcdir}/0013-Allow-statically-linking-compiler-support-libraries-.patch
   patch -p1 -i ${srcdir}/0014-Support-llvm-objdump-f-output.patch
+  patch -p1 -i ${srcdir}/0015-Fix-rpath-linking-in-clang.patch
 }
 
 build() {
-  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
-  mkdir -p ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
+  [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
+  mkdir -p ${srcdir}/build-${MSYSTEM} && cd ${srcdir}/build-${MSYSTEM}
+
   ../${_realname}-${pkgver}/configure \
       --prefix=${MINGW_PREFIX} \
       --build=${MINGW_CHOST} \
@@ -66,12 +70,12 @@ build() {
 }
 
 #check() {
-#  cd ${srcdir}/build-${MINGW_CHOST}
+#  cd ${srcdir}/build-${MSYSTEM}
 #  make check
 #}
 
 package() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MSYSTEM}"
   make DESTDIR="${pkgdir}" install
   # Because libtool will have queried native compilers,
   # it'll contain native paths, so sed them back again.


### PR DESCRIPTION
clang will fail while linking because of the space after rpath. substitute it with a comma

`-Wl,-rpath -Wl,${libdir}` <- this will fail
`-Wl,-rpath ${libdir}` <- this will fail

`-Wl,-rpath,${libdir}` <- ok
`-rpath ${libdir}` <- ok