### PR TITLE
qt6-tools: Fix windeployqt searching for qmake instead of qmake6

### DIFF
--- a/mingw-w64-qt6-tools/001-appending-qt6-to-remove-qt5-conflict.patch
+++ b/mingw-w64-qt6-tools/001-appending-qt6-to-remove-qt5-conflict.patch
@@ -152,3 +152,25 @@
 +set_target_properties(${target_name} PROPERTIES
 +    OUTPUT_NAME "windeployqt-qt6"
 +)
+--- a/src/shared/winutils/utils.cpp
+--- b/src/shared/winutils/utils.cpp
+@@ -457,7 +457,7 @@
+ 
+ QMap<QString, QString> queryQMakeAll(const QString &qmakeBinary, QString *errorMessage)
+ {
+-    const QString binary = !qmakeBinary.isEmpty() ? qmakeBinary : QStringLiteral("qmake");
++    const QString binary = !qmakeBinary.isEmpty() ? qmakeBinary : QStringLiteral("qmake6");
+     QByteArray stdOut;
+     QByteArray stdErr;
+     unsigned long exitCode = 0;
+--- a/src/windeployqt/main.cpp
+--- b/src/windeployqt/main.cpp
+@@ -1001,7 +1001,7 @@
+     // Run lconvert to concatenate all files into a single named "qt_<prefix>.qm" in the application folder
+     // Use QT_INSTALL_TRANSLATIONS as working directory to keep the command line short.
+     const QString absoluteTarget = QFileInfo(target).absoluteFilePath();
+-    const QString binary = QStringLiteral("lconvert");
++    const QString binary = QStringLiteral("lconvert-qt6");
+     QStringList arguments;
+     for (const QString &prefix : qAsConst(prefixes)) {
+         arguments.clear();

--- a/mingw-w64-qt6-tools/PKGBUILD
+++ b/mingw-w64-qt6-tools/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
 _qtver=6.2.1
 pkgver=${_qtver/-/}
-pkgrel=1
+pkgrel=2
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://www.qt.io'
@@ -17,10 +17,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-qt6-declarative"
              "${MINGW_PACKAGE_PREFIX}-qt6-activeqt"
              "${MINGW_PACKAGE_PREFIX}-clang"
-             "${MINGW_PACKAGE_PREFIX}-clang-analyzer"
              "${MINGW_PACKAGE_PREFIX}-clang-tools-extra"
-             "${MINGW_PACKAGE_PREFIX}-mlir"
-             "${MINGW_PACKAGE_PREFIX}-polly"
              "rsync")
 options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
@@ -28,7 +25,7 @@ source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/$_qtver/submod
         001-appending-qt6-to-remove-qt5-conflict.patch
         002-qt6-windeployqt-fixes.patch)
 sha256sums=('5a856d3d3d5fe6e15dc3f1af707a0ef1df2e687850403fc94af635edb9312bfb'
-            'ebf32bcff5d3bf1e503db8edda7fd7611d5c154a3c9cae730b0266fd37c3f6ae'
+            '0b3fccd70feb0a5787a1711ceb5aa87eaf7e995c3fa43ecb53638b069cf32e75'
             '59837bddb18965fc2994f4321f431101b3e7775b975bd1ac568e50d6d4cc4e3c')
 
 # Helper macros to help make tasks easier #


### PR DESCRIPTION
Fixes #10018 