### PR TITLE
libass: autoreconf for clang

### DIFF
--- a/mingw-w64-libass/PKGBUILD
+++ b/mingw-w64-libass/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libass
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.15.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A portable library for SSA/ASS subtitles rendering (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -19,6 +19,12 @@ depends=("${MINGW_PACKAGE_PREFIX}-fribidi"
 options=('strip' 'staticlibs')
 source=(https://github.com/libass/${_realname}/releases/download/${pkgver}/${_realname}-${pkgver}.tar.xz)
 sha256sums=('1be2df9c4485a57d78bb18c0a8ed157bc87a5a8dd48c661961c625cb112832fd')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  # autoreconf to get updated libtool for clang
+  autoreconf -fiv
+}
 
 build() {
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"


### PR DESCRIPTION
Fixes #10055