### PR TITLE
matio and osm-gps-map: autoreconf for clang

### DIFF
--- a/mingw-w64-matio/PKGBUILD
+++ b/mingw-w64-matio/PKGBUILD
@@ -4,7 +4,7 @@ _realname=matio
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.5.21
-pkgrel=1
+pkgrel=2
 pkgdesc="matio is a C library for reading and writing MATLAB MAT files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -20,6 +20,8 @@ sha256sums=('21809177e55839e7c94dada744ee55c1dea7d757ddaab89605776d50122fb065')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
+  # autoreconf to get updated libtool files for clang
+  autoreconf -fiv
 }
 
 build() {

--- a/mingw-w64-osm-gps-map/PKGBUILD
+++ b/mingw-w64-osm-gps-map/PKGBUILD
@@ -4,7 +4,7 @@ _realname=osm-gps-map
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.1.0
-pkgrel=3
+pkgrel=4
 pkgdesc="A Gtk+ Widget for Displaying OpenStreetMap tiles. (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -19,6 +19,7 @@ makedepends=(
     "${MINGW_PACKAGE_PREFIX}-gcc"
     "${MINGW_PACKAGE_PREFIX}-libtool"
     "${MINGW_PACKAGE_PREFIX}-gnome-common"
+    "${MINGW_PACKAGE_PREFIX}-gtk-doc"
 )
 
 source=( https://github.com/nzjrs/osm-gps-map/releases/download/${pkgver}/${_realname}-${pkgver}.tar.gz) 
@@ -26,6 +27,8 @@ sha256sums=('8F2FF865ED9ED9786CC5373C37B341B876958416139D0065EBB785CF88D33586')
 
 prepare() {
     cd "${srcdir}/${_realname}-${pkgver}"
+    # autoreconf to get updated libtool files for clang
+    autoreconf -fiv
 }
 
 build() {


### PR DESCRIPTION
After #10055, checked for more packages missing DLLs on Clang, and found a couple.