### PR TITLE
python-qstylizer: fix versioning

### DIFF
--- a/mingw-w64-python-qstylizer/PKGBUILD
+++ b/mingw-w64-python-qstylizer/PKGBUILD
@@ -4,40 +4,44 @@ _realname=qstylizer
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
 pkgver=0.2.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Qt stylesheet generation utility for PyQt/PySide (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 license=('MIT')
 url='https://github.com/blambright/qstylizer'
 depends=(
-    ${MINGW_PACKAGE_PREFIX}-python-pyqt5
-    ${MINGW_PACKAGE_PREFIX}-python-inflection
-    ${MINGW_PACKAGE_PREFIX}-python-tinycss2
-    ${MINGW_PACKAGE_PREFIX}-python-pywin32
-    ${MINGW_PACKAGE_PREFIX}-python-jupyter_core)
-makedepends=(
     ${MINGW_PACKAGE_PREFIX}-python
+    ${MINGW_PACKAGE_PREFIX}-python-inflection
+    ${MINGW_PACKAGE_PREFIX}-python-jupyter_core
+    ${MINGW_PACKAGE_PREFIX}-python-pyqt5
+    ${MINGW_PACKAGE_PREFIX}-python-pywin32
+    ${MINGW_PACKAGE_PREFIX}-python-tinycss2
+)
+makedepends=(
     ${MINGW_PACKAGE_PREFIX}-python-pip
+    ${MINGW_PACKAGE_PREFIX}-python-setuptools
     ${MINGW_PACKAGE_PREFIX}-python-wheel
-    ${MINGW_PACKAGE_PREFIX}-python-setuptools)
+)
 source=("https://github.com/blambright/${_realname}/archive/${pkgver}.tar.gz")
 sha256sums=('1f6d29207f7dc3644fd2270cc6ebce2f764d6017c66cb300d725abd1725e74b1')
 
 prepare() {
-  cd "${srcdir}"
-  rm -rf python-build-${CARCH} | true
-  cp -r "${_realname}-${pkgver}" "python-build-${CARCH}"
+  rm -rf python-build-${MSYSTEM} | true
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
+
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}
 }
 
 build() {
-  msg "Python build for ${CARCH}"
-  cd "${srcdir}/python-build-${CARCH}"
+  msg "Python build for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
   ${MINGW_PREFIX}/bin/python setup.py build
 }
 
 package() {
-  cd "${srcdir}/python-build-${CARCH}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
     --root="${pkgdir}" --optimize=1 --skip-build


### PR DESCRIPTION
check failed because of reverse dependency (spyder)