### PR TITLE
python-qtconsole: update to 5.2.0

### DIFF
--- a/mingw-w64-python-qtconsole/PKGBUILD
+++ b/mingw-w64-python-qtconsole/PKGBUILD
@@ -6,38 +6,38 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=5.0.2
-pkgrel=2
+pkgver=5.2.0
+pkgrel=1
 pkgdesc="A rich Qt-based console for working with Jupyter kernels, supporting rich media output, session export, and more (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://jupyter.org/"
 license=('BSD')
 depends=("${MINGW_PACKAGE_PREFIX}-python"
-         "${MINGW_PACKAGE_PREFIX}-python-jupyter_core"
          "${MINGW_PACKAGE_PREFIX}-python-jupyter_client"
+         "${MINGW_PACKAGE_PREFIX}-python-jupyter_core"
          "${MINGW_PACKAGE_PREFIX}-python-pyqt5")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/jupyter/qtconsole/archive/${pkgver}.tar.gz")
-sha256sums=('ca748e93d8d452f0ac36bd30701bc3ccf610420e3c18e6eb861a525cba45f18f')
+sha256sums=('f03b249e1e1f4fe97e23e3732ffc9bd4fcf3ba48b6a6c444e90e9d92f8aa128e')
 
 prepare() {
   cd "${srcdir}"
-  rm -rf python-build-${CARCH} | true
-  cp -r "${_realname}-${pkgver}" "python-build-${CARCH}"
+  rm -rf python-build-${MSYSTEM} | true
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 
 build() {
-  cd "${srcdir}/python-build-${CARCH}"
+  msg "Python build for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
   ${MINGW_PREFIX}/bin/python setup.py build
 }
 
 package() {
-  cd "${srcdir}/python-build-${CARCH}"
-
+  cd "${srcdir}/python-build-${MSYSTEM}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  ${MINGW_PREFIX}/bin/python setup.py install \
-    --prefix=${MINGW_PREFIX} --root=${pkgdir} --optimize=0 --skip-build
+  ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
+     --root=${pkgdir} --optimize=1 --skip-build
 
   find "${pkgdir}/" -name "*.pyc" -delete
   find "${pkgdir}/" -type d -empty -delete


### PR DESCRIPTION
reverse dependency failure (spyder)