### PR TITLE
mdloader: fix clang32 build

### DIFF
--- a/mingw-w64-mdloader/0001-incbin-mangle.patch
+++ b/mingw-w64-mdloader/0001-incbin-mangle.patch
@@ -1,0 +1,11 @@
+--- mdloader-1.0.6/incbin/incbin.h	2021-10-18 13:01:43.000000000 -0700
++++ mdloader-1.0.6/incbin/incbin.h	2021-11-11 19:16:00.150012100 -0800
+@@ -148,7 +148,7 @@
+ #  define INCBIN_TYPE(...)
+ #else
+ #  define INCBIN_SECTION         ".section " INCBIN_OUTPUT_SECTION "\n"
+-#  define INCBIN_GLOBAL(NAME)    ".global " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME "\n"
++#  define INCBIN_GLOBAL(NAME)    ".global " INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME "\n"
+ #  if defined(__ghs__)
+ #    define INCBIN_INT           ".word "
+ #  else

--- a/mingw-w64-mdloader/PKGBUILD
+++ b/mingw-w64-mdloader/PKGBUILD
@@ -4,23 +4,31 @@ _realname=mdloader
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=1.0.6
-pkgrel=1
+pkgrel=2
 pkgdesc='Massdrop keyboard firmware loader (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 license=('GPL3')
 url='https://github.com/Massdrop/mdloader'
-source=("https://github.com/Massdrop/mdloader/archive/${pkgver}.tar.gz")
-sha256sums=('1663e1e1f67b48e5d16802587c603092b43aab37020112931a39d6fc65afe94e')
+source=("https://github.com/Massdrop/mdloader/archive/${pkgver}.tar.gz"
+        "0001-incbin-mangle.patch")
+sha256sums=('1663e1e1f67b48e5d16802587c603092b43aab37020112931a39d6fc65afe94e'
+            '4d6daa3880347c280a5e57b1899831cd807f4fbe1e235c2b7ff37d185f2c2b9b')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  patch -Nbp1 -i "${srcdir}/0001-incbin-mangle.patch"
+}
 
 build() {
-    cd ${srcdir}/${_realname}-${pkgver}
+  cd "${srcdir}/${_realname}-${pkgver}"
 
-    make
+  make
 }
 
 package() {
-    cd ${srcdir}/${_realname}-${pkgver}/build
+  cd "${srcdir}/${_realname}-${pkgver}/build"
 
-    install -Dm755 mdloader.exe ${pkgdir}${MINGW_PREFIX}/bin/mdloader.exe
+  install -Dm755 mdloader.exe "${pkgdir}${MINGW_PREFIX}/bin/mdloader.exe"
 }


### PR DESCRIPTION
properly mangle global asm statement.  GCC doesn't care but apparently Clang does.