### PR TITLE
krita: new package

### DIFF
--- a/mingw-w64-extra-cmake-modules/0001-change-libexecdir-and-datarootdir-to-match-posix.patch
+++ b/mingw-w64-extra-cmake-modules/0001-change-libexecdir-and-datarootdir-to-match-posix.patch
@@ -1,0 +1,35 @@
+From f3763e411e86423927058652b7547dc5138ff12e Mon Sep 17 00:00:00 2001
+From: Naveen M K <naveen521kk@gmail.com>
+Date: Fri, 12 Nov 2021 14:28:20 +0530
+Subject: [PATCH] change libexecdir and datarootdir to match posix
+
+Signed-off-by: Naveen M K <naveen521kk@gmail.com>
+---
+ kde-modules/KDEInstallDirs.cmake | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/kde-modules/KDEInstallDirs.cmake b/kde-modules/KDEInstallDirs.cmake
+index 5b11a42..56ad9ed 100644
+--- a/kde-modules/KDEInstallDirs.cmake
++++ b/kde-modules/KDEInstallDirs.cmake
+@@ -433,7 +433,7 @@ _define_relative(LIBDIR EXECROOTDIR "${_LIBDIR_DEFAULT}"
+     "object code libraries"
+     LIB_INSTALL_DIR)
+ 
+-if(WIN32)
++if(MSVC)
+     _define_relative(LIBEXECDIR BINDIR ""
+         "executables for internal use by programs and libraries"
+         LIBEXEC_INSTALL_DIR)
+@@ -531,7 +531,7 @@ _define_absolute(SHAREDSTATEDIR "com"
+ 
+ 
+ 
+-if (WIN32)
++if (MSVC)
+     _define_relative(DATAROOTDIR BINDIR "data"
+         "read-only architecture-independent data root"
+         SHARE_INSTALL_PREFIX)
+-- 
+2.33.0
+

--- a/mingw-w64-extra-cmake-modules/PKGBUILD
+++ b/mingw-w64-extra-cmake-modules/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=extra-cmake-modules
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=5.85.0
+pkgver=5.87.0
 pkgrel=1
 pkgdesc='Extra CMake modules (mingw-w64)'
 arch=('any')
@@ -19,11 +19,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-python-requests")
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_realname}-${pkgver}.tar.xz"{,.sig}
         "set-AUTOSTATICPLUGINS.patch"
-        "tar-force-local.patch")
-sha256sums=('7a4209c3b113dc50250920186a2d30b71870e11ebb92a700a611b423ce6b6634'
+        "tar-force-local.patch"
+        "0001-change-libexecdir-and-datarootdir-to-match-posix.patch")
+sha256sums=('541ca70d8e270614d19d8fd9e55f97b55fa1dc78d6538c6f6757be372ef8bcab'
             'SKIP'
             '8b0a5b5d72802f095086cf2adb30d37dc1033e877c8b7d709b251ec6bf3535ab'
-            '142595fb4d762ed9e1d9f32889076bb308e140ea94646b32d3f8260440bb2893')
+            '142595fb4d762ed9e1d9f32889076bb308e140ea94646b32d3f8260440bb2893'
+            'a2603f6611be21c279a4eeba9abb5125bfca4073dc0d491c18c503e723bbc2bc')
 validpgpkeys=('53E6B47B45CEA3E0D5B7457758D0EE648A48B3BB') # David Faure <faure@kde.org>
 
 prepare() {
@@ -33,6 +35,7 @@ prepare() {
   # installs *.orig files if hunks are in different offset
   patch -Np1 -i "${srcdir}/set-AUTOSTATICPLUGINS.patch"
   patch -Np1 -i "${srcdir}/tar-force-local.patch"
+  patch -Np1 -i "${srcdir}/0001-change-libexecdir-and-datarootdir-to-match-posix.patch"
 }
 
 build() {

--- a/mingw-w64-krita/0001-fix-a-bug-with-libjpeg.patch
+++ b/mingw-w64-krita/0001-fix-a-bug-with-libjpeg.patch
@@ -1,0 +1,29 @@
+From 8e6595319316fd83b1ab424a14a3b4909294c3a5 Mon Sep 17 00:00:00 2001
+From: Naveen M K <naveen521kk@gmail.com>
+Date: Fri, 12 Nov 2021 13:15:37 +0530
+Subject: [PATCH 1/5] fix a bug with libjpeg
+
+Signed-off-by: Naveen M K <naveen521kk@gmail.com>
+---
+ libs/image/kis_painter.h | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/libs/image/kis_painter.h b/libs/image/kis_painter.h
+index 3cf6a97f..caf5462f 100644
+--- a/libs/image/kis_painter.h
++++ b/libs/image/kis_painter.h
+@@ -34,6 +34,11 @@
+ #include <kis_filter_configuration.h>
+ #include <kritaimage_export.h>
+ 
++// https://github.com/msys2/MINGW-packages/issues/10063
++#ifdef interface
++#undef interface
++#endif
++
+ class QPen;
+ class KUndo2Command;
+ class QRect;
+-- 
+2.33.1.windows.1
+

--- a/mingw-w64-krita/0002-don-t-default-to-angle-on-mingw.patch
+++ b/mingw-w64-krita/0002-don-t-default-to-angle-on-mingw.patch
@@ -1,0 +1,33 @@
+From b86889cc45186be62742b8b4b92ff5895289a90d Mon Sep 17 00:00:00 2001
+From: Naveen M K <naveen521kk@gmail.com>
+Date: Fri, 12 Nov 2021 13:16:46 +0530
+Subject: [PATCH 2/5] don't default to angle on mingw
+
+Signed-off-by: Naveen M K <naveen521kk@gmail.com>
+---
+ krita/main.cc | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/krita/main.cc b/krita/main.cc
+index 1f719dc4..66249f5d 100644
+--- a/krita/main.cc
++++ b/krita/main.cc
+@@ -284,11 +284,11 @@ extern "C" int main(int argc, char **argv)
+ 
+         logUsage = kritarc.value("LogUsage", true).toBool();
+ 
+-#ifdef Q_OS_WIN
+-        const QString preferredRendererString = kritarc.value("OpenGLRenderer", "angle").toString();
+-#else
++//#ifdef Q_OS_WIN
++//        const QString preferredRendererString = kritarc.value("OpenGLRenderer", "angle").toString();
++//#else
+         const QString preferredRendererString = kritarc.value("OpenGLRenderer", "auto").toString();
+-#endif
++//#endif
+         preferredRenderer = KisOpenGL::convertConfigToOpenGLRenderer(preferredRendererString);
+ 
+         const KisOpenGL::RendererConfig config =
+-- 
+2.33.1.windows.1
+

--- a/mingw-w64-krita/0003-remove-egl-related-code.patch
+++ b/mingw-w64-krita/0003-remove-egl-related-code.patch
@@ -1,0 +1,180 @@
+From 317ef80cb8d9e513c3c2c49107c8f4e71c434cbc Mon Sep 17 00:00:00 2001
+From: Naveen M K <naveen521kk@gmail.com>
+Date: Fri, 12 Nov 2021 13:17:28 +0530
+Subject: [PATCH 3/5] remove egl related code
+
+Signed-off-by: Naveen M K <naveen521kk@gmail.com>
+---
+ .../ui/opengl/KisScreenInformationAdapter.cpp | 116 +++++++++---------
+ 1 file changed, 58 insertions(+), 58 deletions(-)
+
+diff --git a/libs/ui/opengl/KisScreenInformationAdapter.cpp b/libs/ui/opengl/KisScreenInformationAdapter.cpp
+index e4c3c075..031a9263 100644
+--- a/libs/ui/opengl/KisScreenInformationAdapter.cpp
++++ b/libs/ui/opengl/KisScreenInformationAdapter.cpp
+@@ -33,8 +33,8 @@
+ #include <d3d11.h>
+ #include <wrl/client.h>
+ #include <dxgi1_6.h>
+-#include "EGL/egl.h"
+-#include "EGL/eglext.h"
++// #include "EGL/egl.h"
++// #include "EGL/eglext.h"
+ #endif
+ 
+ namespace {
+@@ -59,9 +59,9 @@ void getProcAddressSafe(QOpenGLContext *context, const char *funcName, FuncType
+     }
+ }
+ 
+-#ifdef Q_OS_WIN
+-typedef const char *(EGLAPIENTRYP PFNEGLQUERYSTRINGPROC) (EGLDisplay dpy, EGLint name);
+-#endif
++// #ifdef Q_OS_WIN
++// typedef const char *(EGLAPIENTRYP PFNEGLQUERYSTRINGPROC) (EGLDisplay dpy, EGLint name);
++// #endif
+ }
+ 
+ 
+@@ -102,75 +102,75 @@ void KisScreenInformationAdapter::Private::initialize(QOpenGLContext *newContext
+             throw EGLException("the context is not OpenGL ES");
+         }
+ 
+-        PFNEGLQUERYSTRINGPROC queryString = nullptr;
+-        getProcAddressSafe(context, "eglQueryString", queryString);
++        // PFNEGLQUERYSTRINGPROC queryString = nullptr;
++        // getProcAddressSafe(context, "eglQueryString", queryString);
+ 
+-        const char* client_extensions = queryString(EGL_NO_DISPLAY, EGL_EXTENSIONS);
+-        const QList<QByteArray> extensions = QByteArray(client_extensions).split(' ');
++        // const char* client_extensions = queryString(EGL_NO_DISPLAY, EGL_EXTENSIONS);
++        // const QList<QByteArray> extensions = QByteArray(client_extensions).split(' ');
+ 
+-        if (!extensions.contains("EGL_ANGLE_platform_angle_d3d") ||
+-            !extensions.contains("EGL_ANGLE_device_creation_d3d11")) {
++        // if (!extensions.contains("EGL_ANGLE_platform_angle_d3d") ||
++        //    !extensions.contains("EGL_ANGLE_device_creation_d3d11")) {
+ 
+-            throw EGLException("the context is not Angle + D3D11");
+-        }
++        //    throw EGLException("the context is not Angle + D3D11");
++        //}
+ 
+-        PFNEGLQUERYDISPLAYATTRIBEXTPROC queryDisplayAttribEXT = nullptr;
+-        PFNEGLQUERYDEVICEATTRIBEXTPROC queryDeviceAttribEXT = nullptr;
++        // PFNEGLQUERYDISPLAYATTRIBEXTPROC queryDisplayAttribEXT = nullptr;
++        // PFNEGLQUERYDEVICEATTRIBEXTPROC queryDeviceAttribEXT = nullptr;
+ 
+-        getProcAddressSafe(context, "eglQueryDisplayAttribEXT", queryDisplayAttribEXT);
+-        getProcAddressSafe(context, "eglQueryDeviceAttribEXT", queryDeviceAttribEXT);
++        // getProcAddressSafe(context, "eglQueryDisplayAttribEXT", queryDisplayAttribEXT);
++        // getProcAddressSafe(context, "eglQueryDeviceAttribEXT", queryDeviceAttribEXT);
+ 
+-        QPlatformNativeInterface *nativeInterface = qGuiApp->platformNativeInterface();
+-        EGLDisplay display = reinterpret_cast<EGLDisplay>(nativeInterface->nativeResourceForContext("egldisplay", context));
++        // QPlatformNativeInterface *nativeInterface = qGuiApp->platformNativeInterface();
++        // EGLDisplay display = reinterpret_cast<EGLDisplay>(nativeInterface->nativeResourceForContext("egldisplay", context));
+ 
+-        if (!display) {
+-            throw EGLException(
+-                QString("couldn't request EGLDisplay handle, display = 0x%1").arg(uintptr_t(display), 0, 16));
+-        }
++        // if (!display) {
++        //     throw EGLException(
++        //         QString("couldn't request EGLDisplay handle, display = 0x%1").arg(uintptr_t(display), 0, 16));
++        // }
+ 
+-        EGLAttrib value = 0;
+-        EGLBoolean result = false;
++        // EGLAttrib value = 0;
++        // EGLBoolean result = false;
+ 
+-        result = queryDisplayAttribEXT(display, EGL_DEVICE_EXT, &value);
++        // result = queryDisplayAttribEXT(display, EGL_DEVICE_EXT, &value);
+ 
+-        if (!result || value == EGL_NONE) {
+-            throw EGLException(
+-               QString("couldn't request EGLDeviceEXT handle, result = 0x%1, value = 0x%2")
+-                   .arg(result, 0, 16).arg(value, 0, 16));
+-        }
++        // if (!result || value == EGL_NONE) {
++        //     throw EGLException(
++        //        QString("couldn't request EGLDeviceEXT handle, result = 0x%1, value = 0x%2")
++        //            .arg(result, 0, 16).arg(value, 0, 16));
++        // }
+ 
+-        EGLDeviceEXT device = reinterpret_cast<EGLDeviceEXT>(value);
++        // EGLDeviceEXT device = reinterpret_cast<EGLDeviceEXT>(value);
+ 
+-        result = queryDeviceAttribEXT(device, EGL_D3D11_DEVICE_ANGLE, &value);
++        // result = queryDeviceAttribEXT(device, EGL_D3D11_DEVICE_ANGLE, &value);
+ 
+-        if (!result || value == EGL_NONE) {
+-            throw EGLException(
+-                QString("couldn't request ID3D11Device pointer, result = 0x%1, value = 0x%2")
+-                    .arg(result, 0, 16).arg(value, 0, 16));
+-        }
+-        ID3D11Device *deviceD3D = reinterpret_cast<ID3D11Device*>(value);
++        // if (!result || value == EGL_NONE) {
++        //     throw EGLException(
++        //         QString("couldn't request ID3D11Device pointer, result = 0x%1, value = 0x%2")
++        //             .arg(result, 0, 16).arg(value, 0, 16));
++        // }
++        // ID3D11Device *deviceD3D = reinterpret_cast<ID3D11Device*>(value);
+ 
+-        {
+-            HRESULT result = 0;
++        // {
++        //     HRESULT result = 0;
+ 
+-            Microsoft::WRL::ComPtr<IDXGIDevice> dxgiDevice;
+-            result = deviceD3D->QueryInterface(__uuidof(IDXGIDevice), (void**)&dxgiDevice);
++        //     Microsoft::WRL::ComPtr<IDXGIDevice> dxgiDevice;
++        //     result = deviceD3D->QueryInterface(__uuidof(IDXGIDevice), (void**)&dxgiDevice);
+ 
+-            if (FAILED(result)) {
+-                throw EGLException(
+-                    QString("couldn't request IDXGIDevice pointer, result = 0x%1").arg(result, 0, 16));
+-            }
++        //     if (FAILED(result)) {
++        //         throw EGLException(
++        //             QString("couldn't request IDXGIDevice pointer, result = 0x%1").arg(result, 0, 16));
++        //     }
+ 
+-            Microsoft::WRL::ComPtr<IDXGIAdapter1> dxgiAdapter;
+-            result = dxgiDevice->GetParent(__uuidof(IDXGIAdapter1), (void**)&dxgiAdapter);
++        //     Microsoft::WRL::ComPtr<IDXGIAdapter1> dxgiAdapter;
++        //     result = dxgiDevice->GetParent(__uuidof(IDXGIAdapter1), (void**)&dxgiAdapter);
+ 
+-            if (FAILED(result)) {
+-                throw EGLException(
+-                    QString("couldn't request IDXGIAdapter1 pointer, result = 0x%1").arg(result, 0, 16));
+-            }
++        //     if (FAILED(result)) {
++        //         throw EGLException(
++        //             QString("couldn't request IDXGIAdapter1 pointer, result = 0x%1").arg(result, 0, 16));
++        //     }
+ 
+-            this->dxgiAdapter = dxgiAdapter;
+-        }
++        //     this->dxgiAdapter = dxgiAdapter;
++        // }
+ 
+ #else
+         throw EGLException("current platform doesn't support fetching display information");
+@@ -179,9 +179,9 @@ void KisScreenInformationAdapter::Private::initialize(QOpenGLContext *newContext
+     } catch (EGLException &e) {
+         this->context = 0;
+         this->errorString = e.what();
+-#ifdef Q_OS_WIN
+-        this->dxgiAdapter.Reset();
+-#endif
++// #ifdef Q_OS_WIN
++//         this->dxgiAdapter.Reset();
++// #endif
+     }
+ }
+ 
+-- 
+2.33.1.windows.1
+

--- a/mingw-w64-krita/0004-fix-python.patch
+++ b/mingw-w64-krita/0004-fix-python.patch
@@ -1,0 +1,28 @@
+From 6b787380ce8f98bd27b4352d9435df9436be0a83 Mon Sep 17 00:00:00 2001
+From: Naveen M K <naveen521kk@gmail.com>
+Date: Fri, 12 Nov 2021 13:17:41 +0530
+Subject: [PATCH 4/5] fix python
+
+Signed-off-by: Naveen M K <naveen521kk@gmail.com>
+---
+ CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e06a3bd0..8501a448 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -234,8 +234,8 @@ if(MINGW)
+     if(ENABLE_PYTHON_2)
+         message(FATAL_ERROR "Python 2.7 is not supported on Windows at the moment.")
+     else(ENABLE_PYTHON_2)
+-        find_package(PythonInterp 3.8 EXACT)
+-        find_package(PythonLibs 3.8 EXACT)
++        find_package(PythonInterp 3.8)
++        find_package(PythonLibs 3.8)
+     endif(ENABLE_PYTHON_2)
+     if (PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND)
+         if(ENABLE_PYTHON_2)
+-- 
+2.33.1.windows.1
+

--- a/mingw-w64-krita/0005-don-t-install-installer.patch
+++ b/mingw-w64-krita/0005-don-t-install-installer.patch
@@ -1,0 +1,28 @@
+From d4c24332d5ba3df3a7d7505525b18e9535ccef05 Mon Sep 17 00:00:00 2001
+From: Naveen M K <naveen521kk@gmail.com>
+Date: Fri, 12 Nov 2021 13:30:52 +0530
+Subject: [PATCH 5/5] don't install installer
+
+Signed-off-by: Naveen M K <naveen521kk@gmail.com>
+---
+ CMakeLists.txt | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8501a448..b2e196d9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -917,10 +917,6 @@ configure_file(config-ocio.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config-ocio.h )
+ check_function_exists(powf HAVE_POWF)
+ configure_file(config-powf.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config-powf.h)
+ 
+-if(WIN32)
+-    include(${CMAKE_CURRENT_LIST_DIR}/packaging/windows/installer/ConfigureInstallerNsis.cmake)
+-endif()
+-
+ message("\nBroken tests:")
+ foreach(tst ${KRITA_BROKEN_TESTS})
+     message("    * ${tst}")
+-- 
+2.33.1.windows.1
+

--- a/mingw-w64-krita/PKGBUILD
+++ b/mingw-w64-krita/PKGBUILD
@@ -1,0 +1,115 @@
+# Maintainer: Naveen M K <naveen521kk@gmail.com>
+
+_realname=krita
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=4.4.8
+pkgrel=1
+pkgdesc="Edit and paint images (mingw-w64)"
+arch=('any')
+url='https://krita.org'
+license=(GPL3)
+validpgpkeys=(
+    '05D00A8B73A686789E0A156858B9596C722EA3BD'  # Boudewijn Rempt <foundation@krita.org>
+    'E9FB29E74ADEACC5E3035B8AB69EB4CF7468332F'  # Dmitry Kazakov (main key) <dimula73@gmail.com>
+    '064182440C674D9F8D0F6F8B4DA79EDA231C852B') # Stichting Krita Foundation <foundation@krita.org>
+
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+    "${MINGW_PACKAGE_PREFIX}-ninja"
+    "${MINGW_PACKAGE_PREFIX}-python"
+    "${MINGW_PACKAGE_PREFIX}-extra-cmake-modules"
+    "${MINGW_PACKAGE_PREFIX}-kdoctools-qt5"
+    "${MINGW_PACKAGE_PREFIX}-boost"
+    "${MINGW_PACKAGE_PREFIX}-eigen3"
+    "${MINGW_PACKAGE_PREFIX}-poppler"
+    "${MINGW_PACKAGE_PREFIX}-python-pyqt5"
+    "${MINGW_PACKAGE_PREFIX}-libheif"
+    "${MINGW_PACKAGE_PREFIX}-sip"
+    "${MINGW_PACKAGE_PREFIX}-qt5-tools"
+)
+depends=(
+    "${MINGW_PACKAGE_PREFIX}-qt5"
+    "${MINGW_PACKAGE_PREFIX}-kitemviews-qt5"
+    "${MINGW_PACKAGE_PREFIX}-kitemmodels-qt5"
+    "${MINGW_PACKAGE_PREFIX}-ki18n-qt5"
+    "${MINGW_PACKAGE_PREFIX}-kcompletion-qt5"
+    "${MINGW_PACKAGE_PREFIX}-kguiaddons-qt5"
+    "${MINGW_PACKAGE_PREFIX}-qt5-svg"
+    "${MINGW_PACKAGE_PREFIX}-qt5-multimedia"
+    "${MINGW_PACKAGE_PREFIX}-quazip"
+    "${MINGW_PACKAGE_PREFIX}-gsl"
+    "${MINGW_PACKAGE_PREFIX}-libraw"
+    "${MINGW_PACKAGE_PREFIX}-exiv2"
+    "${MINGW_PACKAGE_PREFIX}-openexr"
+    "${MINGW_PACKAGE_PREFIX}-fftw"
+    "${MINGW_PACKAGE_PREFIX}-giflib"
+    "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
+    "${MINGW_PACKAGE_PREFIX}-opencolorio"
+    "${MINGW_PACKAGE_PREFIX}-hicolor-icon-theme"
+    "${MINGW_PACKAGE_PREFIX}-kcoreaddons-qt5"
+    "${MINGW_PACKAGE_PREFIX}-kwindowsystem-qt5"
+    "${MINGW_PACKAGE_PREFIX}-icoutils"
+)
+source=(
+    "https://download.kde.org/stable/krita/$pkgver/$_realname-$pkgver.tar.gz"
+    "0001-fix-a-bug-with-libjpeg.patch"
+    "0002-don-t-default-to-angle-on-mingw.patch"
+    "0003-remove-egl-related-code.patch"
+    "0004-fix-python.patch"
+    "0005-don-t-install-installer.patch"
+)
+sha256sums=('bcc68a5711d92515d6553611a0bddd53f3259843fd3534b9b3e535d7ed430df8'
+    'cece456da61a4a16fabfb5a04ea59f3228441d16d548b92f4c2203fa080fb9cc'
+    'a095ecda834053eb0afd6d7dba90d1638941fdd5feba5ebd412538fa13511a2d'
+    '524d8aae99086c51dd1255f483f1c6be7e02e7a250d4ab215eecc74ded83e073'
+    '442a2d6197d38264a38ef1c893f9f0ba94b11e2d5f93156fe68d11cee66872e0'
+    '5969a6a153b8f612122ffd2c63bdb115b86273c444054c2f4c9bb37b0fdc6ee6')
+
+prepare() {
+    cd "${srcdir}"/${_realname}-${pkgver}
+    patch -Np1 -i "${srcdir}/0001-fix-a-bug-with-libjpeg.patch"
+    patch -Np1 -i "${srcdir}/0002-don-t-default-to-angle-on-mingw.patch"
+    patch -Np1 -i "${srcdir}/0003-remove-egl-related-code.patch"
+    patch -Np1 -i "${srcdir}/0004-fix-python.patch"
+    patch -Np1 -i "${srcdir}/0005-don-t-install-installer.patch"
+}
+
+build() {
+    cd "${srcdir}"/${_realname}-${pkgver}
+    [[ -d "${srcdir}"/build-${MSYSTEM} ]] && rm -rf "${srcdir}"/build-${MSYSTEM}
+    mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
+
+    declare -a extra_config
+    if check_option "debug" "n"; then
+        extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+    else
+        extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+    fi
+
+    MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+        ${MINGW_PREFIX}/bin/cmake.exe \
+        -GNinja \
+        -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+        "${extra_config[@]}" \
+        -DBUILD_{SHARED,STATIC}_LIBS=ON \
+        -DBUILD_TESTING=OFF \
+        -DBUILD_KRITA_QT_DESIGNER_PLUGINS=ON \
+        -Wno-dev \
+        ../${_realname}-${pkgver}
+
+    ${MINGW_PREFIX}/bin/cmake.exe --build .
+}
+
+check() {
+    cd "${srcdir}"/build-${MSYSTEM}
+
+    cmake --build . --target test
+}
+
+package() {
+    cd "${srcdir}"/build-${MSYSTEM}
+
+    DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install .
+
+    install -Dm644 ${srcdir}/${_realname}-${pkgver}/COPYING ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING
+}


### PR DESCRIPTION
- build's successfully but fails to run.
- run's only when setting env var `QT_QPA_PLATFORMTHEME=windowsvista` don't know why. Backtrace
<details>
<summary>gdb backtrace</summary>

```
#0  QPalette::QPalette (this=0x7023dfe300, p=...) at kernel/qpalette.cpp:655
#1  0x00007fffd1564433 in QGuiApplicationPrivate::basePalette (
    this=<optimized out>) at kernel/qguiapplication.cpp:3441
#2  QGuiApplicationPrivate::setPalette (palette=...)
    at kernel/qguiapplication.cpp:3415
#3  0x00007fffd1569575 in QGuiApplicationPrivate::updatePalette ()
    at kernel/qguiapplication.cpp:3387
#4  QGuiApplicationPrivate::updatePalette ()
    at kernel/qguiapplication.cpp:3381
#5  0x00007fffd156a6a0 in QGuiApplicationPrivate::init (this=0x26228711a60)
    at kernel/qguiapplication.cpp:1617
#6  0x00007fffd156b534 in QGuiApplication::QGuiApplication (
    this=0x26228714d80, argc=@0x7023dfe62c: 1, argv=0x7023dfe618,
    flags=331522)
    at ../../include/QtGui/../../src/gui/kernel/qguiapplication.h:203
#7  0x00007fff6a79def6 in KisOpenGLModeProber::probeFormat (
    this=0x7fff6bc72bc0 <(anonymous namespace)::Q_QGS_s_instance::innerFunction()::holder>, rendere
rConfig=..., adjustGlobalState=true)
    at C:/dev/src/krita-4.4.8/libs/ui/opengl/KisOpenGLModeProber.cpp:184
#8  0x00007fff6a78b3d3 in KisOpenGL::selectSurfaceConfig (
    preferredRenderer=KisOpenGL::RendererAuto,
    preferredRootSurfaceFormat=KisConfig::BT709_G22, enableDebug=false)
    at C:/dev/src/krita-4.4.8/libs/ui/opengl/kis_opengl.cpp:736
#9  0x00007ff786b6277c in main (argc=1, argv=0x262285e4c20)
    at C:/dev/src/krita-4.4.8/krita/main.cc:295

```
</details>

Probally some is broken either in qt or in krita.