### PR TITLE
extrac-cmake-modules: update to 5.87.0

### DIFF
--- a/mingw-w64-extra-cmake-modules/0001-change-libexecdir-and-datarootdir-to-match-posix.patch
+++ b/mingw-w64-extra-cmake-modules/0001-change-libexecdir-and-datarootdir-to-match-posix.patch
@@ -1,0 +1,35 @@
+From f3763e411e86423927058652b7547dc5138ff12e Mon Sep 17 00:00:00 2001
+From: Naveen M K <naveen521kk@gmail.com>
+Date: Fri, 12 Nov 2021 14:28:20 +0530
+Subject: [PATCH] change libexecdir and datarootdir to match posix
+
+Signed-off-by: Naveen M K <naveen521kk@gmail.com>
+---
+ kde-modules/KDEInstallDirs.cmake | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/kde-modules/KDEInstallDirs.cmake b/kde-modules/KDEInstallDirs.cmake
+index 5b11a42..56ad9ed 100644
+--- a/kde-modules/KDEInstallDirs.cmake
++++ b/kde-modules/KDEInstallDirs.cmake
+@@ -433,7 +433,7 @@ _define_relative(LIBDIR EXECROOTDIR "${_LIBDIR_DEFAULT}"
+     "object code libraries"
+     LIB_INSTALL_DIR)
+ 
+-if(WIN32)
++if(MSVC)
+     _define_relative(LIBEXECDIR BINDIR ""
+         "executables for internal use by programs and libraries"
+         LIBEXEC_INSTALL_DIR)
+@@ -531,7 +531,7 @@ _define_absolute(SHAREDSTATEDIR "com"
+ 
+ 
+ 
+-if (WIN32)
++if (MSVC)
+     _define_relative(DATAROOTDIR BINDIR "data"
+         "read-only architecture-independent data root"
+         SHARE_INSTALL_PREFIX)
+-- 
+2.33.0
+

--- a/mingw-w64-extra-cmake-modules/PKGBUILD
+++ b/mingw-w64-extra-cmake-modules/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=extra-cmake-modules
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=5.85.0
+pkgver=5.87.0
 pkgrel=1
 pkgdesc='Extra CMake modules (mingw-w64)'
 arch=('any')
@@ -19,11 +19,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-python-requests")
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_realname}-${pkgver}.tar.xz"{,.sig}
         "set-AUTOSTATICPLUGINS.patch"
-        "tar-force-local.patch")
-sha256sums=('7a4209c3b113dc50250920186a2d30b71870e11ebb92a700a611b423ce6b6634'
+        "tar-force-local.patch"
+        "0001-change-libexecdir-and-datarootdir-to-match-posix.patch")
+sha256sums=('541ca70d8e270614d19d8fd9e55f97b55fa1dc78d6538c6f6757be372ef8bcab'
             'SKIP'
             '8b0a5b5d72802f095086cf2adb30d37dc1033e877c8b7d709b251ec6bf3535ab'
-            '142595fb4d762ed9e1d9f32889076bb308e140ea94646b32d3f8260440bb2893')
+            '142595fb4d762ed9e1d9f32889076bb308e140ea94646b32d3f8260440bb2893'
+            'a2603f6611be21c279a4eeba9abb5125bfca4073dc0d491c18c503e723bbc2bc')
 validpgpkeys=('53E6B47B45CEA3E0D5B7457758D0EE648A48B3BB') # David Faure <faure@kde.org>
 
 prepare() {
@@ -33,6 +35,7 @@ prepare() {
   # installs *.orig files if hunks are in different offset
   patch -Np1 -i "${srcdir}/set-AUTOSTATICPLUGINS.patch"
   patch -Np1 -i "${srcdir}/tar-force-local.patch"
+  patch -Np1 -i "${srcdir}/0001-change-libexecdir-and-datarootdir-to-match-posix.patch"
 }
 
 build() {


### PR DESCRIPTION
Also, fix data-dir. 
Found this while working on Krita #10066 
Should I rebuild all its reverse deps so that nothing is installed on `/mingw64/bin/data`?