### PR TITLE
SDL2_mixer: fix use-after-free in music_fluidsynth.c

### DIFF
--- a/mingw-w64-SDL2_mixer/0199-Fixed-use-after-free-in-music_fluidsynth.c.patch
+++ b/mingw-w64-SDL2_mixer/0199-Fixed-use-after-free-in-music_fluidsynth.c.patch
@@ -1,0 +1,28 @@
+From 6160668079f91d57a5d7bf0b40ffdd843be70daf Mon Sep 17 00:00:00 2001
+From: Sam Lantinga <slouken@libsdl.org>
+Date: Wed, 20 Jan 2021 10:17:10 -0800
+Subject: [PATCH 199/199] Fixed use-after-free in music_fluidsynth.c
+
+Tom M.
+
+There is a dangerous use-after-free in FLUIDSYNTH_Delete(): the settings object is deleted **before** the synth. Since the settings have been created first to initialize the synth, you must first delete the synth and then delete the settings. This currently crashes all applications that use fluidsynth 2.1.6 and SDL2_mixer. Please apply the attached patch and release a bug fix release.
+
+Originally reported at https://github.com/FluidSynth/fluidsynth/issues/748
+---
+ src/codecs/music_fluidsynth.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/music_fluidsynth.c
++++ b/music_fluidsynth.c
+@@ -273,9 +273,10 @@ static void FLUIDSYNTH_Stop(void *contex
+ static void FLUIDSYNTH_Delete(void *context)
+ {
+     FLUIDSYNTH_Music *music = (FLUIDSYNTH_Music *)context;
++    fluid_settings_t *settings = fluidsynth.fluid_synth_get_settings(music->synth);
+     fluidsynth.delete_fluid_player(music->player);
+-    fluidsynth.delete_fluid_settings(fluidsynth.fluid_synth_get_settings(music->synth));
+     fluidsynth.delete_fluid_synth(music->synth);
++    fluidsynth.delete_fluid_settings(settings);
+     SDL_free(music);
+ }
+ 

--- a/mingw-w64-SDL2_mixer/PKGBUILD
+++ b/mingw-w64-SDL2_mixer/PKGBUILD
@@ -4,7 +4,7 @@ _realname=SDL2_mixer
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.0.4
-pkgrel=4
+pkgrel=5
 pkgdesc="A simple multi-channel audio mixer (Version 2) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -23,16 +23,19 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 options=('staticlibs' 'strip')
 source=("$url/release/${_realname}-${pkgver}.zip"
         SDL2_mixer-2.0.1-find_lib.mingw.patch
-        SDL2_mixer-2.0.1-libtool_windres.mingw.patch)
+        SDL2_mixer-2.0.1-libtool_windres.mingw.patch
+        0199-Fixed-use-after-free-in-music_fluidsynth.c.patch)
 sha256sums=('9affb8c7bf6fbffda0f6906bfb99c0ea50dca9b188ba9e15be90042dc03c5ded'
             '8c906b09cb9318b54dac6b63eff49e63fb83bf1fc97219581b720709723ce5c1'
-            '86fa38c76b834ea28d40c95d4639cf7896f449fe92a4348d21da641106a53132')
+            '86fa38c76b834ea28d40c95d4639cf7896f449fe92a4348d21da641106a53132'
+            '3640f1023825ec6683956e58e980897fa67963b1a10477721ebe5ab09c490cdb')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
   patch -Np1 -i ${srcdir}/SDL2_mixer-2.0.1-find_lib.mingw.patch
   patch -Np1 -i ${srcdir}/SDL2_mixer-2.0.1-libtool_windres.mingw.patch
+  patch -Np1 -i ${srcdir}/0199-Fixed-use-after-free-in-music_fluidsynth.c.patch
   autoconf
 }
 


### PR DESCRIPTION
https://www.fluidsynth.org/news/2021/01/23/sdl2-mixer-bug/