### PR TITLE
qt6-base : Enable AVX Support

### DIFF
--- a/mingw-w64-qt6-base/008-enable-avx-support.patch
+++ b/mingw-w64-qt6-base/008-enable-avx-support.patch
@@ -1,0 +1,12 @@
+--- a/config.tests/x86_simd/main.cpp
++++ b/config.tests/x86_simd/main.cpp
+@@ -161,9 +161,6 @@
+ #endif
+ 
+ #if T(AVX)
+-#  if defined(__WIN64__) && defined(__GNUC__) && !defined(__clang__)
+-#    error "AVX support is broken in 64-bit MinGW - https://gcc.gnu.org/bugzilla/show_bug.cgi?id=49001"
+-#  endif
+ attribute_target("avx") void test_avx()
+ {
+     __m256d a = _mm256_setzero_pd();

--- a/mingw-w64-qt6-base/PKGBUILD
+++ b/mingw-w64-qt6-base/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
 _qtver=6.2.1
 pkgver=${_qtver/-/}
-pkgrel=2
+pkgrel=3
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://www.qt.io'
@@ -44,7 +44,8 @@ source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/$_qtver/submod
         004-qt-6.2.0-win32-g-Add-QMAKE_EXTENSION_IMPORTLIB-defaulting-to-.patch
         005-Allow-overriding-CMAKE_FIND_LIBRARY_SUFFIXES-to-pref.patch
         006-qt-6.2.0-dont-add-resource-files-to-qmake-libs.patch
-        007-Fix-crashes-in-rasterization-code-using-setjmp.patch)
+        007-Fix-crashes-in-rasterization-code-using-setjmp.patch
+        008-enable-avx-support.patch)
 sha256sums=('2c5f07b5c3ea27d3fc1a46686ea3fb6724f94dddf1fb007de3eb0bdb87429079'
             '78757ddc0685a15df55e17742b74951e634ada305736310bad03823288f45203'
             'b0267f3293984d9fbd012a1b22efe2a0990f95c1ed4a7d6fb46438f8f476f021'
@@ -52,7 +53,8 @@ sha256sums=('2c5f07b5c3ea27d3fc1a46686ea3fb6724f94dddf1fb007de3eb0bdb87429079'
             'e8867fa643823b149b2f1937a4854752aa86191148ae8cf4667e32ed5b97a36c'
             'b644586be741dabf66b79bcc2eed71727739f4b301e0ae7da35506b30605aeb5'
             '4085a10b290b8e3d930de535cbad2ba3e643432cba433aa2b28fe664f86d38a3'
-            '7ca754db6546f0992307e76cf9c5c9e8d4146278b7989fd4df9a8bd45eb62611')
+            '7ca754db6546f0992307e76cf9c5c9e8d4146278b7989fd4df9a8bd45eb62611'
+            'e5d22486bf809d9422103471766f4a11d3090acaf9104cfaf333bad1aa1dcc6c')
 
 # Use the right mkspecs file
 if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
@@ -80,7 +82,8 @@ prepare() {
     004-qt-6.2.0-win32-g-Add-QMAKE_EXTENSION_IMPORTLIB-defaulting-to-.patch \
     005-Allow-overriding-CMAKE_FIND_LIBRARY_SUFFIXES-to-pref.patch \
     006-qt-6.2.0-dont-add-resource-files-to-qmake-libs.patch \
-    007-Fix-crashes-in-rasterization-code-using-setjmp.patch
+    007-Fix-crashes-in-rasterization-code-using-setjmp.patch \
+    008-enable-avx-support.patch
 
   local _ARCH_TUNE=
   local _HARD_FLAGS=


### PR DESCRIPTION
It was blocked with MINGW/GCC 64bit due to AVX misalignment that should be fixed by #9998