### PR TITLE
ngraph-gtk: new upstream release version 6.09.05.

### DIFF
--- a/mingw-w64-ngraph-gtk/PKGBUILD
+++ b/mingw-w64-ngraph-gtk/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=ngraph-gtk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=6.09.04
+pkgver=6.09.05
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -23,11 +23,11 @@ options=('strip' 'staticlibs')
 license=("GPL")
 url="https://htrb.github.io/ngraph-gtk/"
 source=("https://github.com/htrb/ngraph-gtk/releases/download/v${pkgver}/ngraph-gtk-${pkgver}.tar.gz")
-sha256sums=("53c12455e5ae2d9322a70cd52de2fa78afed440b47b70e93ce8675eccf594d72")
+sha256sums=("1b3f5579ee01a86bb775e651a5b39b54f7ffba7ed7fb4899dc6c77c47b6514ee")
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
-  AUTOPOINT='initltoolize --automake --copy' autoreconf -if
+  autoreconf -if
 }
 
 build() {


### PR DESCRIPTION
new upstream version 6.09.05 is  released. 