### PR TITLE
scitilla-gtk3: update to 5.1.4

### DIFF
--- a/mingw-w64-scintilla-gtk3/PKGBUILD
+++ b/mingw-w64-scintilla-gtk3/PKGBUILD
@@ -3,20 +3,19 @@
 _realname=scintilla
 pkgbase=mingw-w64-${_realname}-gtk3
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-gtk3"
-pkgver=5.1.3
+pkgver=5.1.4
 pkgrel=1
 pkgdesc="A text widget adding syntax highlighting and more to GNOME (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://www.scintilla.org/"
 license=("LGPL")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-pkg-config"
-             "${MINGW_PACKAGE_PREFIX}-python3")
+makedepends=("${MINGW_PACKAGE_PREFIX}-pkgconf"
+             "${MINGW_PACKAGE_PREFIX}-python")
 depends=("${MINGW_PACKAGE_PREFIX}-gtk3")
 source=("https://www.scintilla.org/scintilla${pkgver//./}.tgz"
         "scintilla.pc")
-sha256sums=('42252bbd3ad79ddbf86c8403671417e0b546ce431ad13329e6d87f7fe8bafffd'
+sha256sums=('dc825c554989056b2631446c7ca28b147c94c365d923dd0a928ab7a11dd3a365'
             'b8f27ae48cd30790444e6d1e02b117ef0f2bb048516ea7bf69ca48f77c9eea7b')
 
 prepare() {


### PR DESCRIPTION
They offer only the latest release to download. the oldest releases are unreachable.