### PR TITLE
python-platformdirs: fix versioning

### DIFF
--- a/mingw-w64-python-platformdirs/PKGBUILD
+++ b/mingw-w64-python-platformdirs/PKGBUILD
@@ -4,7 +4,7 @@ _realname=platformdirs
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
 pkgver=2.4.0
-pkgrel=1
+pkgrel=2
 pkgdesc='A small Python module for determining appropriate platform-specific dirs (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -19,6 +19,9 @@ prepare() {
   cd "${srcdir}"
   rm -rf python-build-${MSYSTEM} | true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
+
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}
 }
 
 build() {


### PR DESCRIPTION
this one needs to be updated too.. `pylint` depends on it