### PR TITLE
boost: backport fix for aligned_alloc and clang 13

### DIFF
--- a/mingw-w64-boost/PKGBUILD
+++ b/mingw-w64-boost/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.77.0
 _boostver=${pkgver//./_}
-pkgrel=2
+pkgrel=3
 pkgdesc="Free peer-reviewed portable C++ source libraries (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -34,7 +34,8 @@ source=(https://boostorg.jfrog.io/artifactory/main/release/${pkgver}/source/boos
         boost-1.74-mingw-32bit-enable-tls.patch
         boost-1.77-process-return.patch
         using-mingw-w64-python.patch
-        msys2-mingw-folders-bootstrap.patch)
+        msys2-mingw-folders-bootstrap.patch
+        aligned_alloc-backport.patch)
 sha256sums=('fc9f85fc030e233142908241af7a846e60630aa7388de9a5fafb1f3a26840854'
             '4551ba9edf64c8ccdab4f4890c20e2e8cf6d4ffa1169d251df11e30d25b886b8'
             'b22196b6415f5e1c0fe56b49a12ea7c20073b15a5f31907f363c7be38d70d628'
@@ -48,7 +49,8 @@ sha256sums=('fc9f85fc030e233142908241af7a846e60630aa7388de9a5fafb1f3a26840854'
             '15f25653ec71e061cbd3a611a969541c57ea70c1fe95cb0de11f22cc68c7670f'
             '004c7eeaa349e11aed8b1ea8090c399aef163518a11cc588846077588b9bbbab'
             '5c38e08ba63695afa79a29d5d3ea22ef1ecf79f91d48ae922e1a489e83782742'
-            '5117629ee577de0da800b6923675683ba69422cdbe958e70c9081fdc6886402e')
+            '5117629ee577de0da800b6923675683ba69422cdbe958e70c9081fdc6886402e'
+            'b61ff3bc4d18bb01c616f358fce3cf7483b2360debdd1f5ff9eef2d8c34f27ae')
 
 prepare() {
   cd "${srcdir}/boost_${_boostver}"
@@ -99,6 +101,9 @@ prepare() {
 
   msg2 "boost-1.77-process-return.patch"
   patch -p1 -i ${srcdir}/boost-1.77-process-return.patch
+
+  # https://github.com/msys2/MINGW-packages/issues/9827#issuecomment-967743745
+  patch -p1 -i ${srcdir}/aligned_alloc-backport.patch
 }
 
 build() {

--- a/mingw-w64-boost/aligned_alloc-backport.patch
+++ b/mingw-w64-boost/aligned_alloc-backport.patch
@@ -1,0 +1,15 @@
+--- boost_1_77_0/boost/asio/detail/config.hpp
++++ boost_1_77_0/boost/asio/detail/config.hpp
+@@ -603,9 +603,11 @@
+ #  if (__cplusplus >= 201703)
+ #   if defined(__clang__)
+ #    if defined(BOOST_ASIO_HAS_CLANG_LIBCXX)
+-#     if (_LIBCPP_STD_VER > 14) && defined(_LIBCPP_HAS_ALIGNED_ALLOC)
++#     if (_LIBCPP_STD_VER > 14) && defined(_LIBCPP_HAS_ALIGNED_ALLOC) \
++        && !defined(_LIBCPP_MSVCRT) && !defined(__MINGW32__)
+ #      define BOOST_ASIO_HAS_STD_ALIGNED_ALLOC 1
+ #     endif // (_LIBCPP_STD_VER > 14) && defined(_LIBCPP_HAS_ALIGNED_ALLOC)
++            //   && !defined(_LIBCPP_MSVCRT) && !defined(__MINGW32__)
+ #    elif defined(_GLIBCXX_HAVE_ALIGNED_ALLOC)
+ #     define BOOST_ASIO_HAS_STD_ALIGNED_ALLOC 1
+ #    endif // defined(_GLIBCXX_HAVE_ALIGNED_ALLOC)


### PR DESCRIPTION
Fixes #9827