### PR TITLE
qt5-quick3d: Disable building with system-assimp

### DIFF
--- a/mingw-w64-qt5-pkgs/PKGBUILD
+++ b/mingw-w64-qt5-pkgs/PKGBUILD
@@ -23,7 +23,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-base"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-script"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-script-debug")
 pkgver=5.15.2+kde+r129
-pkgrel=1
+pkgrel=2
 _commit=9ebeaaa6ecac0c369f0e9a7a603071ff4dc02f28
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -252,6 +252,7 @@ build() {
     -system-sqlite \
     -system-zlib \
     -no-iconv \
+    -assimp qt \
     -release -force-debug-info -separate-debug-info \
     "${_sql_config[@]}"
 


### PR DESCRIPTION
qt5-quick3d does not support the latest assimp 5.1.0