### PR TITLE
geoip2-database: update

### DIFF
--- a/mingw-w64-geoip2-database/PKGBUILD
+++ b/mingw-w64-geoip2-database/PKGBUILD
@@ -3,39 +3,34 @@
 _realname=geoip2-database
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=20190624
+pkgver=20211124
 pkgrel=1
-pkgdesc="GeoLite country geolocation database compiled by MaxMind (mingw-w64)"
+pkgdesc="GeoIP legacy database (based on GeoLite2 data created by MaxMind) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
-url="https://dev.maxmind.com/geoip/geoip2/geolite2/"
+url="https://mailfud.org/geoip-legacy"
 license=('custom:Creative Commons Attribution-ShareAlike 3.0 Unported')
-source=(GeoLite2-City-${pkgver}.tar.gz::https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz
-        GeoLite2-Country-${pkgver}.tar.gz::https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz
-        GeoLite2-ASN-${pkgver}.tar.gz::https://geolite.maxmind.com/download/geoip/database/GeoLite2-ASN.tar.gz)
-noextract=(GeoLite2-City-${pkgver}.tar.gz
-           GeoLite2-Country-${pkgver}.tar.gz
-           GeoLite2-ASN-${pkgver}.tar.gz)
-sha256sums=('491367661ccfda918c606a140154aa10ded8c62eeb64c947dd037efdaba08d94'
-            'cd8640a40a8423464e7f9cad3c814bbe073c72646abb4f98b768be55f2096182'
-            '0fa431a8663984d87f44dbc9ceaa2602abf5a3254ac52bfde27a6f517c4ee018')
-
-prepare() {
-  cd "${srcdir}"
-
-  for _db in GeoLite2-{City,Country,ASN}; do
-    tar --strip-components=1 -xf ${_db}-${pkgver}.tar.gz --wildcards "*/${_db}.mmdb"
-  done
-
-  tar --strip-components=1 -xf GeoLite2-ASN-${pkgver}.tar.gz --wildcards "*/COPYRIGHT.txt" "*/LICENSE.txt"
-}
+source=(${url}/GeoIP.dat.gz
+        ${url}/GeoIPv6.dat.gz
+        ${url}/GeoIPCity.dat.gz
+        ${url}/GeoIPCityv6.dat.gz
+        ${url}/GeoIPASNum.dat.gz
+        ${url}/GeoIPASNumv6.dat.gz
+        ${url}/GeoIPISP.dat.gz
+        ${url}/GeoIPOrg.dat.gz)
+sha256sums=('17cc005ce719b846a46d2248005136ff105d0a36bbde9c03f58a1ba4de0b274b'
+            '5777bb21f864e485cce44aed3a540b36757564adf6c53cb41bbad46d178e0528'
+            'a77f82e60506279bd1af23beca838fee8dcedc1754929cd776382cf8df3606d4'
+            '78e99bf1dcd75e625250c7baa71dfb07cff0705f6ca3d68c06a0c5d212bd9499'
+            'fb7869cb8a24d8bbbf60d156ee69c2c9d14681020f2c5b61f6fc1ae39aed9dde'
+            'a5fb4d75c6ea693d6defff598aa268c78b8c7765075bcaa60c7052458729e35d'
+            '37a3e0974a1c723f85ae28948b53ce3c41967ffac7d4973ecb272c5d8c551505'
+            '7da001628253e069fae2ba6464f3ad7698733d3e5b7193d2a3d7269796bae346')
 
 package() {
   cd "${srcdir}"
 
   install -d "${pkgdir}${MINGW_PREFIX}/share/GeoIP"
-  install -m644 -t "${pkgdir}${MINGW_PREFIX}/share/GeoIP" GeoLite2-{City,Country,ASN}.mmdb
-
-  install -Dm644 COPYRIGHT.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYRIGHT.txt"
-  install -Dm644 LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.txt"
+  install -m644 -t "${pkgdir}${MINGW_PREFIX}/share/GeoIP" GeoIP{,City,ASNum,ISP,Org}.dat
+  install -m644 -t "${pkgdir}${MINGW_PREFIX}/share/GeoIP" GeoIP{,City,ASNum}v6.dat
 }


### PR DESCRIPTION
dev.maxmind.com/geoip/geoip2/geolite2 requires now a subscription to download the databases.
I have fellowed Arch by moving to the new url.