### PR TITLE
openblas: Create split package with 32-bit and 64-bit indexing

### DIFF
--- a/mingw-w64-openblas/009-cmake-Set-SUFFIX64-also-for-NOFORTRAN.patch
+++ b/mingw-w64-openblas/009-cmake-Set-SUFFIX64-also-for-NOFORTRAN.patch
@@ -1,0 +1,45 @@
+From de2ed6659685576aa7f0652b85070febadba05b2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Markus=20M=C3=BCtzel?= <markus.muetzel@gmx.de>
+Date: Mon, 15 Nov 2021 08:53:52 +0100
+Subject: [PATCH] cmake: Set SUFFIX64 also for NOFORTRAN
+
+---
+ cmake/fc.cmake     | 5 -----
+ cmake/system.cmake | 5 +++++
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/cmake/fc.cmake b/cmake/fc.cmake
+index f7aa4c5c..9feda9be 100644
+--- a/cmake/fc.cmake
++++ b/cmake/fc.cmake
+@@ -3,11 +3,6 @@
+ ## Description: Ported from portion of OpenBLAS/Makefile.system
+ ##              Sets Fortran related variables.
+ 
+-if (INTERFACE64)
+-  set(SUFFIX64 64)
+-  set(SUFFIX64_UNDERSCORE _64)
+-endif()
+-
+ if (${F_COMPILER} STREQUAL "FLANG")
+   set(CCOMMON_OPT "${CCOMMON_OPT} -DF_INTERFACE_FLANG")
+   if (BINARY64 AND INTERFACE64)
+diff --git a/cmake/system.cmake b/cmake/system.cmake
+index bcca91c2..410cf01e 100644
+--- a/cmake/system.cmake
++++ b/cmake/system.cmake
+@@ -239,6 +239,11 @@ include("${PROJECT_SOURCE_DIR}/cmake/arch.cmake")
+ # C Compiler dependent settings
+ include("${PROJECT_SOURCE_DIR}/cmake/cc.cmake")
+ 
++if (INTERFACE64)
++  set(SUFFIX64 64)
++  set(SUFFIX64_UNDERSCORE _64)
++endif()
++
+ if (NOT NOFORTRAN)
+   # Fortran Compiler dependent settings
+   include("${PROJECT_SOURCE_DIR}/cmake/fc.cmake")
+-- 
+2.33.1.windows.1
+

--- a/mingw-w64-openblas/PKGBUILD
+++ b/mingw-w64-openblas/PKGBUILD
@@ -3,9 +3,10 @@
 
 _realname=OpenBLAS
 pkgbase=mingw-w64-openblas
-pkgname="${MINGW_PACKAGE_PREFIX}-openblas"
+pkgname=("${MINGW_PACKAGE_PREFIX}-openblas"
+         $([[ "${CARCH}" == "i686" ]] || echo "${MINGW_PACKAGE_PREFIX}-openblas64"))
 pkgver=0.3.18
-pkgrel=3
+pkgrel=4
 pkgdesc="An optimized BLAS library based on GotoBLAS2 1.13 BSD, providing optimized blas, lapack, and cblas (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -31,7 +32,8 @@ source=(${_realname}-${pkgver}.tar.gz::https://github.com/xianyi/OpenBLAS/archiv
         005-fix-clang32-compile-flags.patch
         006-fix-cmake-detect-clang-64-bits.patch
         007-support-building-both-static-shared.patch
-        008-export-only-shared-library.patch)
+        008-export-only-shared-library.patch
+        009-cmake-Set-SUFFIX64-also-for-NOFORTRAN.patch)
 install=${_realname}.install
 sha256sums=('1632c1e8cca62d8bed064b37747e331a1796fc46f688626337362bf0d16aeadb'
             '6a73ee677d8d37509cd08f380b0359ee7fac2595fd64695dd054e838380a6a33'
@@ -40,7 +42,8 @@ sha256sums=('1632c1e8cca62d8bed064b37747e331a1796fc46f688626337362bf0d16aeadb'
             '7c7910039746b505ae182ef5f0e6f18c7ffdfc47e9d11f529840cda25fefc367'
             '238c57cd3d72c04d8322ba0e9dd148c68f5665776b3fcd51a047c45573d8baf4'
             '5db3d553b5cd9539f03b0a5d9820a6da91d4f57e5501ba565741a12a4efeeb8b'
-            '0c539cdf9b02f6c3f956e4b1c30b559997322d1aa45b1226ece601fcec07af91')
+            '0c539cdf9b02f6c3f956e4b1c30b559997322d1aa45b1226ece601fcec07af91'
+            '8500feb12c45e607ac2cbec8d0f8e59f830708fe1c98574db768df1a203d5d77')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -67,11 +70,13 @@ prepare() {
   # https://github.com/xianyi/OpenBLAS/pull/3431
   apply_patch_with_msg \
     008-export-only-shared-library.patch
+  # https://github.com/xianyi/OpenBLAS/pull/3450
+  apply_patch_with_msg \
+    009-cmake-Set-SUFFIX64-also-for-NOFORTRAN.patch
 }
 
-build() {
-  [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
-  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
+_build_openblas() {
+  _idx_opt=$1
 
   declare -a _build_type
   if check_option "debug" "n"; then
@@ -93,13 +98,33 @@ build() {
     -DUSE_THREAD=ON \
     -DNUM_THREADS=64 \
     -DTARGET=CORE2 \
+    ${_idx_opt} \
     ../${_realname}-${pkgver}
 
   cmake --build .
 }
 
-package() {
-  cd "${srcdir}"/build-${MSYSTEM}
+build() {
+  [[ -d "${srcdir}/build-${MSYSTEM}-32" ]] && rm -rf "${srcdir}/build-${MSYSTEM}-32"
+  mkdir -p "${srcdir}/build-${MSYSTEM}-32" && cd "${srcdir}/build-${MSYSTEM}-32"
+
+  msg2 "Build OpenBLAS with 32-bit indexing"
+  _build_openblas ""
+
+
+  if [ "${CARCH}" = "x86_64" ]; then
+    [[ -d "${srcdir}/build-${MSYSTEM}-64" ]] && rm -rf "${srcdir}/build-${MSYSTEM}-64"
+    mkdir -p "${srcdir}/build-${MSYSTEM}-64" && cd "${srcdir}/build-${MSYSTEM}-64"
+
+    msg2 "Build OpenBLAS with 64-bit indexing"
+    _build_openblas "-DBINARY=64 -DINTERFACE64=1"
+  fi
+}
+
+package_openblas() {
+  pkgdesc="An optimized BLAS library based on GotoBLAS2 1.13 BSD, providing optimized blas, lapack, and cblas (mingw-w64)"
+
+  cd "${srcdir}"/build-${MSYSTEM}-32
 
   DESTDIR=${pkgdir} cmake --install .
 
@@ -107,3 +132,29 @@ package() {
   install -Dm0644 ${srcdir}/${_realname}-${pkgver}/LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
   install -Dm0644 ${srcdir}/${_realname}-${pkgver}/lapack-netlib/LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE-lapack
 }
+
+package_openblas64() {
+  pkgdesc="An optimized BLAS library based on GotoBLAS2 1.13 BSD, providing optimized blas, lapack, and cblas with 64-bit indexing (mingw-w64)"
+  provides=()
+  conflicts=()
+  replaces=()
+
+  cd "${srcdir}"/build-${MSYSTEM}-64
+
+  DESTDIR=${pkgdir} cmake --install .
+
+  # Install License
+  install -Dm0644 ${srcdir}/${_realname}-${pkgver}/LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}64/LICENSE
+  install -Dm0644 ${srcdir}/${_realname}-${pkgver}/lapack-netlib/LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}64/LICENSE-lapack
+}
+
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
+
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;


### PR DESCRIPTION
Continuing from #9932.

This adds a version of OpenBLAS with 64-bit indexing in the form of a split package.