### PR TITLE
qemu: Update to 6.2.0

### DIFF
--- a/mingw-w64-qemu/PKGBUILD
+++ b/mingw-w64-qemu/PKGBUILD
@@ -1,16 +1,16 @@
 _realname=qemu
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-_base_ver="6.1.0"
+_base_ver="6.2.0"
 # QEMU Versioning of RC-SourcePackage and RC-Version differs
 # e.g. qemu-6.1.0-rc0.tar.xz contains 6.0.90, qemu-6.1.0-rc1.tar.xz contains 6.0.91
 # Unset _rc_no to create Release-Build
 #_rc_no="4"
-_rc_base_ver="6.0.9${_rc_no}"
+_rc_base_ver="6.1.9${_rc_no}"
 _rc_file_ver="rc${_rc_no}"
 _tarname=$( [ -z "${_rc_no}" ] && echo ${_realname}-${_base_ver} || echo ${_realname}-${_base_ver}-${_rc_file_ver} )
 pkgver=$( [ -z "${_rc_no}" ] && echo ${_base_ver} || echo ${_rc_base_ver} )
-pkgrel=2
+pkgrel=1
 pkgdesc="QEMU - a generic and open source machine emulator and virtualizer (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -61,10 +61,10 @@ source=(
   msys2.examples.tests.sh
 )
 sha256sums=(
-  'eebc089db3414bbeedf1e464beda0a7515aad30f73261abc246c9b27503a3c96'
+  '68e15d8e45ac56326e0b9a4afa8b49a3dfe8aba3488221d098c84698bca65b45'
   'SKIP'
-  'cefb3ff87299c104241561aac275bdff6031dbc75ea74d56e1018a9e3ca0e220'
-  '2af9452c5cf16871d99154dece8117925a0c1dab365c1c8766bfcbdd3c5e5ccf'
+  '51625fd83c0a63729942d3dfc6d48be3491a700fe0f7cb8e88935b46081c9016'
+  '75723aade171bfe92082262819624df726f30122ccdd3a194584a3b74320f35d'
 )
 validpgpkeys=('CEACC9E15534EBABB82D3FA03353C9CEF108B584') # Michael Roth <flukshun@gmail.com>
 # tar cannot create links, to keep build running, manual extraction is required
@@ -79,45 +79,15 @@ prepare() {
 }
 
 build() {
-  # Requirements as documented in https://wiki.qemu.org/Hosts/W32#Native_builds_with_MSYS2
-  #   Execution of
-  #     configure --cross-prefix=${CARCH}-w64-mingw32-
-  #   and
-  #   Providing cross-prefixed binaries by copying
-  #     ${CARCH}-w64-mingw32-objcopy.exe using objcopy.exe
-  #     ${CARCH}-w64-mingw32-windres.exe using windres.exe
-  #     ${CARCH}-w64-mingw32-ranlib.exe  using ${CARCH}-w64-mingw32-gcc-ranlib.exe
-  #     ${CARCH}-w64-mingw32-ar.exe      using ${CARCH}-w64-mingw32-gcc-ar.exe
-  #     ${CARCH}-w64-mingw32-nm.exe      using nm.exe
   LDFLAGS+=" -fstack-protector"
   [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
   mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
 
-  # We need to provide all expected cross-prefixed tools without links or copying!
-  # We will also provide undocumented ${CARCH}-w64-mingw32-strip.exe using strip.exe
-  # Msys2 already provides some duplicates in ${MINGW_PREFIX}/bin:
-  #   gcc-ar.exe is ${CARCH}-w64-mingw32-gcc-ar.exe
-  #   gcc-ranlib.exe is ${CARCH}-w64-mingw32-gcc-ranlib.exe
-  # These common, not prefixed exports read by configure fulfill all qemu requirements
-  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
-    export AR=llvm-ar
-    export RANLIB=llvm-ranlib
-  else
-    export AR=gcc-ar
-    export RANLIB=gcc-ranlib
-  fi
-  export NM=nm
-  export OBJCOPY=objcopy
-  export STRIP=strip
-  export WINDRES=windres
-
   # configure failes to create links, which can be ignored
   # qemu enables all features if possible, so keep it simple
-  #  -cross-prefix is necessary for build to succeed
   # For faster testing:
   #TARGETLIST="--target-list=x86_64-softmmu"
   ../${_tarname}/configure $TARGETLIST \
-    --cross-prefix=${CARCH}-w64-mingw32- \
     --prefix=${MINGW_PREFIX} \
     --bindir=bin \
     --datadir=share/qemu \

--- a/mingw-w64-qemu/msys2.readme.txt
+++ b/mingw-w64-qemu/msys2.readme.txt
@@ -73,15 +73,6 @@ Hints
 Issues
 ------
 
-Since 6.1.0:
-
-* Some GuestOSs won't receive input by keyboard and/or mouse
-
-  see https://gitlab.com/qemu-project/qemu/-/issues/501 and
-  see https://gitlab.com/qemu-project/qemu/-/issues/502
-
-  As WA add `-global i8042.kbd-throttle=on` to command line
-
 Since 6.0.0 and earlier:
 
 * Plain WHPX-acceleration shows these messages
@@ -123,12 +114,6 @@ Since 6.0.0 and earlier:
         /mingw64/share/qemu/edk2-x86_64-code.fd > edk2-x86_64.fd
     $ qemu-system-x86_64 -accel whpx -bios edk2-x86_64.fd
     ```
-
-* `qemu-img commit` doesn't commit
-
-  see https://gitlab.com/qemu-project/qemu/-/issues/418
-
-  WA: use qemu-img in WSL
 
 * `qemu-img convert -O vhdx` produces invalid images
 


### PR DESCRIPTION
This PR intends to update qemu to 6.2.0.

https://gitlab.com/qemu-project/qemu/-/commit/984099911275cd4b703e0d9c35b37dd52928acdd fixes native msys2 build on qemu, so --cross-prefix is no longer needed to configure.

Because the first build is done by using prerelease sources, checksums will be added on final release.