### PR TITLE
Mark "imagemagick" and "libosmscout" as conflicting packages.

### DIFF
--- a/mingw-w64-libosmscout/PKGBUILD
+++ b/mingw-w64-libosmscout/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libosmscout
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A Library for offline map rendering, routing and location lookup based on OpenStreetMap data"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -30,6 +30,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-qt5-tools")
+# imagemagick also installs "bin/import.exe"
+conflicts=("${MINGW_PACKAGE_PREFIX}-imagemagick")
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/Framstag/libosmscout/archive/${pkgver}.tar.gz)
 sha256sums=('d104bffdfee7a056c86ff962865f5b69f3331be242b5d6a2aa4ccf6b04d2bfd5')
 


### PR DESCRIPTION
They both install "bin/import.exe". I guess they should be marked as conflicting with each other.

See also PR #9931.