### PR TITLE
Qt5/6-3d: Enable SSE2

### DIFF
--- a/mingw-w64-qt5-3d/PKGBUILD
+++ b/mingw-w64-qt5-3d/PKGBUILD
@@ -4,9 +4,9 @@ _realname=qt5-3d
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-pkgver=5.15.2+kde+r33
-pkgrel=3
-_commit=7edec6e014de27b9dd03f63875c471aac606a918
+pkgver=5.15.2+kde+r35
+pkgrel=1
+_commit=c582550e2b189f1110efd9364187f41caf7c2ac4
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 pkgdesc="C++ and QML APIs for easy inclusion of 3D graphics (mingw-w64)"
@@ -43,7 +43,8 @@ build() {
   export MSYS2_ARG_CONV_EXCL='--foreign-types='
 
   qmake ../${_pkgfn} -- \
-    -system-assimp
+    -system-assimp \
+    -qt3d-simd sse2
 
   make
 }

--- a/mingw-w64-qt6-3d/PKGBUILD
+++ b/mingw-w64-qt6-3d/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
 _qtver=6.2.1
 pkgver=${_qtver/-/}
-pkgrel=1
+pkgrel=2
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://www.qt.io'
@@ -35,6 +35,7 @@ build() {
     -GNinja \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DINPUT_qt3d_simd=sse2 \
     ../${_pkgfn}
 
   cmake --build .


### PR DESCRIPTION
Before someone start complaining, It is just a hint. Look at the build log to be sure.
SSE2 is not enabled for 32 bits environments.