### PR TITLE
aws-sdk-cpp: fix for cmake 3.22

### DIFF
--- a/mingw-w64-aws-sdk-cpp/0002-1810-backport-cmake-322-fix.patch
+++ b/mingw-w64-aws-sdk-cpp/0002-1810-backport-cmake-322-fix.patch
@@ -1,0 +1,23 @@
+From 2dfc6133324e321e52f2bf7281bc2310f63ecc97 Mon Sep 17 00:00:00 2001
+From: David Watson <dvd_anstow@hotmail.co.uk>
+Date: Thu, 11 Nov 2021 12:56:38 +0000
+Subject: [PATCH] Fix build break in cmake 3.22.0-rc2
+
+The comparison fails in cmake 3.22.0-rc2 when LIB_SEARCH_PATH is empty. Adding quotes ensures there is always a string to compare to
+---
+ cmake/AWSSDKConfig.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmake/AWSSDKConfig.cmake b/cmake/AWSSDKConfig.cmake
+index 83eac0b3b43..acd51317320 100644
+--- a/cmake/AWSSDKConfig.cmake
++++ b/cmake/AWSSDKConfig.cmake
+@@ -129,7 +129,7 @@ endif()
+ get_filename_component(TEMP_PATH "${AWSSDK_CORE_LIB_FILE}" PATH)
+ get_filename_component(TEMP_NAME "${TEMP_PATH}" NAME)
+ 
+-while (NOT TEMP_NAME STREQUAL ${LIB_SEARCH_PREFIX})
++while (NOT TEMP_NAME STREQUAL "${LIB_SEARCH_PREFIX}")
+     set(TEMP_PLATFORM_PREFIX "${TEMP_NAME}/${TEMP_PLATFORM_PREFIX}")
+     get_filename_component(TEMP_PATH "${TEMP_PATH}" PATH)
+     get_filename_component(TEMP_NAME "${TEMP_PATH}" NAME)

--- a/mingw-w64-aws-sdk-cpp/PKGBUILD
+++ b/mingw-w64-aws-sdk-cpp/PKGBUILD
@@ -4,7 +4,7 @@ _realname=aws-sdk-cpp
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.8.149
-pkgrel=2
+pkgrel=3
 pkgdesc="AWS SDK for C++ (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -18,15 +18,20 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
 options=('strip' '!debug' 'staticlibs')
 source=("${_realname}-${pkgver}.tar.gz"::"${url}/archive/${pkgver}.tar.gz"
         "aws-sdk-cpp-pr-1333.patch"
-        "0001-fix-dll-import-libary-folder.patch")
+        "0001-fix-dll-import-libary-folder.patch"
+        "0002-1810-backport-cmake-322-fix.patch")
 sha256sums=('929401ee268681ad67b4f42cc43e616341aa588699e5ae2cd0ec14d6acced21d'
             '6d923d6eb72213bdfe44c6b41444be1817fbe30c5ef21bdd7c94200d417539f3'
-            '2b37b187b41cb567b702d01bfa6c2eddd0121c28f52a25514e777155ea0b5cd7')
+            '2b37b187b41cb567b702d01bfa6c2eddd0121c28f52a25514e777155ea0b5cd7'
+            'ffa76ca841cb9bea201e2eab9755f7297613091ff279393fdab1a2fbf4192af8')
 
 prepare() {
   cd "${_realname}-${pkgver}"
   patch -Np1 -i "${srcdir}/aws-sdk-cpp-pr-1333.patch"
   patch -Np1 -i "${srcdir}/0001-fix-dll-import-libary-folder.patch"
+
+  # https://github.com/aws/aws-sdk-cpp/pull/1810
+  patch -Np1 -i "${srcdir}/0002-1810-backport-cmake-322-fix.patch"
 
   # For clang
   sed -e "s/-fPIC//g" -e "s/-Werror//g" -i cmake/compiler_settings.cmake


### PR DESCRIPTION
Fixes:

```
CMake Error at D:/a/_temp/msys64/mingw64/lib/cmake/AWSSDK/AWSSDKConfig.cmake:119 (while):
  had incorrect arguments:

    "NOT" "TEMP_NAME" "STREQUAL"
```