### PR TITLE
arpack: Fix cmake file to relocate prefix

### DIFF
--- a/mingw-w64-arpack/0001-cmake-relocate-prefix.patch
+++ b/mingw-w64-arpack/0001-cmake-relocate-prefix.patch
@@ -1,0 +1,18 @@
+--- a/arpack-ng-config.cmake.in
++++ b/arpack-ng-config.cmake.in
+@@ -11,6 +11,15 @@
+ #   add_executable(main main.f)
+ #   target_link_libraries(main PARPACK::PARPACK)
+ 
++# Compute the installation prefix relative to this file.
++get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
++get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
++get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
++get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
++if(_IMPORT_PREFIX STREQUAL "/")
++  set(_IMPORT_PREFIX "")
++endif()
++
+ # Create local variables.
+ set(prefix "@prefix@")
+ set(exec_prefix "@exec_prefix@")

--- a/mingw-w64-arpack/PKGBUILD
+++ b/mingw-w64-arpack/PKGBUILD
@@ -8,7 +8,7 @@ _realname=arpack
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.8.0
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 pkgdesc="Fortran77 subroutines designed to solve large scale eigenvalue problems (mingw-w64)"
@@ -18,12 +18,17 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libgfortran"
          "${MINGW_PACKAGE_PREFIX}-openblas")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc-fortran")
 provides=("${MINGW_PACKAGE_PREFIX}-arpack-ng")
-source=(${_realname}-${pkgver}.tar.gz::https://github.com/opencollab/arpack-ng/archive/${pkgver}.tar.gz)
-sha256sums=('ADA5AEB3878874383307239C9235B716A8A170C6D096A6625BFD529844DF003D')
+source=(${_realname}-${pkgver}.tar.gz::https://github.com/opencollab/arpack-ng/archive/${pkgver}.tar.gz
+        "0001-cmake-relocate-prefix.patch")
+sha256sums=('ada5aeb3878874383307239c9235b716a8a170c6d096a6625bfd529844df003d'
+            '94b215a281f115bd91e3370487bcfc97a1100aff82196d226927f7e395dc4cff')
 
 prepare() {
- cd "${srcdir}/${_realname}-ng-${pkgver}"
- ./bootstrap
+  cd "${srcdir}/${_realname}-ng-${pkgver}"
+
+  # https://github.com/msys2/MINGW-packages/issues/10151
+  patch -p1 -i "${srcdir}/0001-cmake-relocate-prefix.patch"
+  ./bootstrap
 }
 
 build() {
@@ -36,15 +41,16 @@ build() {
     --host=${MINGW_CHOST} \
     --enable-static \
     --enable-shared \
+    --enable-icb \
     --with-blas=openblas
 
   make
 }
 
-#check() {
-#  cd "${srcdir}"/build-${CARCH}
-#  make check
-#}
+check() {
+  cd "${srcdir}"/build-${CARCH}
+  make check || true
+}
 
 package() {
   cd "${srcdir}"/build-${CARCH}
@@ -52,4 +58,10 @@ package() {
   make DESTDIR="${pkgdir}"/ install
   install -Dm644 ${srcdir}/${_realname}-ng-${pkgver}/COPYING \
     ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING
+
+  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+  for _f in "${pkgdir}${MINGW_PREFIX}"/lib/cmake/${_realname}-ng/*.cmake; do
+    sed -e "s|${PREFIX_WIN}|\$\{_IMPORT_PREFIX\}|g" -i ${_f}
+    sed -e "s|${MINGW_PREFIX}|\$\{_IMPORT_PREFIX\}|g" -i ${_f}
+  done
 }


### PR DESCRIPTION
Changes:
  * Enable ICB for arpack header files.
  * Enable check function.
  * Add patch file to relocate prefix.
  * Use sed to replace MINGE_PREFIX with _IMPORT_PREFIX.

Fixes https://github.com/msys2/MINGW-packages/issues/10151