### PR TITLE
python-platformdirs: makedep on setuptools-scm

### DIFF
--- a/mingw-w64-python-platformdirs/PKGBUILD
+++ b/mingw-w64-python-platformdirs/PKGBUILD
@@ -4,14 +4,17 @@ _realname=platformdirs
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
 pkgver=2.4.0
-pkgrel=2
+pkgrel=3
 pkgdesc='A small Python module for determining appropriate platform-specific dirs (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 license=('MIT')
 url='https://github.com/platformdirs/platformdirs'
-depends=(${MINGW_PACKAGE_PREFIX}-python)
-makedepends=(${MINGW_PACKAGE_PREFIX}-python-setuptools)
+depends=("${MINGW_PACKAGE_PREFIX}-python")
+makedepends=(
+    "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+    "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm"
+)
 source=("https://github.com/platformdirs/${_realname}/archive/${pkgver}.tar.gz")
 sha256sums=('b4488174a1695029088c34268c51d5115b468c4d08d8787bc48f712852837512')
 


### PR DESCRIPTION
should fix problem related to versioning.
https://github.com/msys2/MINGW-packages/runs/4278274012?check_suite_focus=true#step:6:1017