### PR TITLE
spyder-kernels: update to 2.2.0

### DIFF
--- a/mingw-w64-python-spyder-kernels/PKGBUILD
+++ b/mingw-w64-python-spyder-kernels/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=spyder-kernels
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
-pkgver=2.1.3
-pkgrel=2
+pkgver=2.2.0
+pkgrel=1
 pkgdesc='Jupyter Kernels for the Spyder console (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -16,12 +16,11 @@ depends=(
     ${MINGW_PACKAGE_PREFIX}-python-ipykernel
     ${MINGW_PACKAGE_PREFIX}-python-ipython
     ${MINGW_PACKAGE_PREFIX}-python-jupyter_client
-    ${MINGW_PACKAGE_PREFIX}-python-jupyter_core
     ${MINGW_PACKAGE_PREFIX}-python-pyzmq)
 makedepends=(
     ${MINGW_PACKAGE_PREFIX}-python-setuptools)
 source=("https://github.com/spyder-ide/${_realname}/archive/v${pkgver}.tar.gz")
-sha256sums=('529d75968a3bcfe9c9389c8c703aea116a4d1c100b28f0135217c07186f7024e')
+sha256sums=('d82b216b731743f0f63ad5d74a95b49d0c8d101dd33453384cac4c38ae8bf8e7')
 
 prepare() {
   cd "${srcdir}"
@@ -32,7 +31,6 @@ prepare() {
 build() {
   msg "Python build for ${MSYSTEM}"
   cd "${srcdir}/python-build-${MSYSTEM}"
-  sed -i "s/jupyter-client>=5.3.4,<7/jupyter-client>=5.3.4/g" setup.py
   ${MINGW_PREFIX}/bin/python setup.py build
 }
 


### PR DESCRIPTION
reverse dep test failure