### PR TITLE
python-ujson: Update to 4.3.0

### DIFF
--- a/mingw-w64-python-ujson/PKGBUILD
+++ b/mingw-w64-python-ujson/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=ujson
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=4.2.0
+pkgver=4.3.0
 pkgrel=1
 pkgdesc="Ultra fast JSON encoder and decoder for Python (mingw-w64)"
 arch=('any')
@@ -16,7 +16,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools-scm"
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-six"
               "${MINGW_PACKAGE_PREFIX}-python-pytest")
 source=("ultrajson-${pkgver}.tar.gz"::"${url}/archive/${pkgver}.tar.gz")
-sha256sums=('887452dc5a736ccfda64e5771328304e2f5b7d191f73d8eb6f480cdeedbad9ec')
+sha256sums=('12c623b1aa885fa9a6ca45dd64aa6abcdd999197463ef9029fb8cbf2f03bd606')
 
 prepare() {
   cd "${srcdir}"


### PR DESCRIPTION
At release [notes](https://github.com/ultrajson/ultrajson/releases/tag/4.3.0) told that `ARM64` enabled on `Windows`.

@lazka how to check it?