### PR TITLE
mlpack: add cereal, remove cotire

### DIFF
--- a/mingw-w64-mlpack/PKGBUILD
+++ b/mingw-w64-mlpack/PKGBUILD
@@ -4,7 +4,7 @@ _realname=mlpack
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.4.2
-pkgrel=1
+pkgrel=2
 pkgdesc='An intuitive, fast, scalable C++ machine learning library (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -13,21 +13,20 @@ license=('BSD')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-armadillo"
          "${MINGW_PACKAGE_PREFIX}-boost"
+         "${MINGW_PACKAGE_PREFIX}-cereal"
          "${MINGW_PACKAGE_PREFIX}-ensmallen"
          "${MINGW_PACKAGE_PREFIX}-stb")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
-             "${MINGW_PACKAGE_PREFIX}-cotire"
              "${MINGW_PACKAGE_PREFIX}-doxygen")
 source=("https://www.mlpack.org/files/${_realname}-${pkgver}.tar.gz"
         "0001-mingw-w64-cmake.patch")
 sha256sums=('9e5c4af5c276c86a0dcc553289f6fe7b1b340d61c1e59844b53da0debedbb171'
             'ee4c4e01799e831ac3447dd97eb1c947d14dcb1d6cf9bdee0181df5cf6e69491')
-_src="${_realname}-${pkgver}"
 
 prepare() {
-  cd "${srcdir}/${_src}"
+  cd "${srcdir}/${_realname}-${pkgver}"
   patch -Np1 -i "${srcdir}/0001-mingw-w64-cmake.patch"
 }
 
@@ -41,7 +40,7 @@ build() {
     _build_type="Release"
   fi
 
-  LDFLAGS+=" -Wl,--export-all-symbols"
+  LDFLAGS+=" -Wl,--export-all-symbols,-no-undefined"
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe -Wno-dev \
@@ -51,7 +50,7 @@ build() {
     -DBUILD_SHARED_LIBS=ON \
     -DBUILD_TESTS=OFF \
     -DBUILD_PYTHON_BINDINGS=OFF \
-    ../${_src}
+    ../${_realname}-${pkgver}
 
   cmake --build .
 }
@@ -60,8 +59,8 @@ package() {
   cd "${srcdir}/build-${MSYSTEM}"
   DESTDIR=${pkgdir} cmake --install .
 
-  install -Dm644 "${srcdir}/${_src}/COPYRIGHT.txt" \
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYRIGHT.txt" \
     "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYRIGHT.txt"
-  install -Dm644 "${srcdir}/${_src}/LICENSE.txt" \
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE.txt" \
     "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.txt"
 }


### PR DESCRIPTION
cereal is listed as dependency on https://github.com/mlpack/mlpack

>  Armadillo      >= 9.800
  Boost (math_c99, spirit) >= 1.58.0
  CMake          >= 3.6
  ensmallen      >= 2.10.0
  cereal         >= 1.1.2

adding cotire as makedepends will conflicts with cmake. i think mlpack uses its internal cotire anyway..