### PR TITLE
openFPGALoader: update to 0.6.0

### DIFF
--- a/mingw-w64-openFPGALoader/PKGBUILD
+++ b/mingw-w64-openFPGALoader/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=openFPGALoader
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.5.0
-pkgrel=2
+pkgver=0.6.0
+pkgrel=1
 pkgdesc="openFPGALoader: universal utility for programming FPGA (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -18,7 +18,7 @@ makedepends=(
 )
 
 source=("${_realname}::https://codeload.github.com/trabucayre/openFPGALoader/tar.gz/v${pkgver}")
-sha256sums=('39c9686bdfcfa96b6bb1d8b37a8a53732372c16cda562036abe9930b61b29e97')
+sha256sums=('0971db2302e704966d2e29b8d34e95f553cfd8f81e5ab70ec0533f03f219cf49')
 
 build() {
   cd "${srcdir}/${_realname}-${pkgver}"


### PR DESCRIPTION
openFPGALoader v0.6.0 was released: https://github.com/trabucayre/openFPGALoader/releases/tag/v0.6.0.

/cc @trabucayre