### PR TITLE
flit/tomli: make pip install ignore installed packages

### DIFF
--- a/mingw-w64-python-flit/PKGBUILD
+++ b/mingw-w64-python-flit/PKGBUILD
@@ -8,7 +8,7 @@ pkgname=(
     "${MINGW_PACKAGE_PREFIX}-python-${_realname}-core"
 )
 pkgver=3.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Simplified packaging of Python modules (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -53,6 +53,7 @@ package_python-flit() {
     --compile \
     --no-deps \
     --no-warn-script-location \
+    --ignore-installed \
     --prefix=${MINGW_PREFIX} \
     --root="${pkgdir}"
 
@@ -69,6 +70,7 @@ package_python-flit-core() {
     --compile \
     --no-deps \
     --no-warn-script-location \
+    --ignore-installed \
     --prefix=${MINGW_PREFIX} \
     --root="${pkgdir}"
 

--- a/mingw-w64-python-tomli/PKGBUILD
+++ b/mingw-w64-python-tomli/PKGBUILD
@@ -5,7 +5,7 @@ _realname=tomli
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=1.2.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A lil' TOML parser (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -41,6 +41,7 @@ package() {
     --compile \
     --no-deps \
     --no-warn-script-location \
+    --ignore-installed \
     --prefix=${MINGW_PREFIX} \
     --root="${pkgdir}"
 


### PR DESCRIPTION
Otherwise, if building the same version as is already installed, pip
will not install the wheel into the pkgdir.