### PR TITLE
GHA/CI: some changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,11 +15,11 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          { msystem: MINGW64, toolchain: mingw-w64-x86_64-toolchain, can-fail: false, runner: windows-latest },
-          { msystem: MINGW32, toolchain: mingw-w64-i686-toolchain, can-fail: false, runner: windows-latest },
-          { msystem: UCRT64, toolchain: mingw-w64-ucrt-x86_64-toolchain, can-fail: false, runner: windows-latest },
-          { msystem: CLANG64, toolchain: mingw-w64-clang-x86_64-toolchain, can-fail: true, runner: windows-latest },
-          { msystem: CLANG32, toolchain: '', can-fail: true, runner: windows-latest },
+          { msystem: MINGW64, toolchain: mingw-w64-x86_64-toolchain, can-fail: false, runner: windows-2022 },
+          { msystem: MINGW32, toolchain: mingw-w64-i686-toolchain, can-fail: false, runner: windows-2022 },
+          { msystem: UCRT64, toolchain: mingw-w64-ucrt-x86_64-toolchain, can-fail: false, runner: windows-2022 },
+          { msystem: CLANG64, toolchain: mingw-w64-clang-x86_64-toolchain, can-fail: true, runner: windows-2022 },
+          { msystem: CLANG32, toolchain: '', can-fail: true, runner: windows-2022 },
           # { msystem: CLANGARM64, toolchain: '', can-fail: true, runner: ['Windows', 'ARM64'] }
         ]
     name: ${{ matrix.msystem }}
@@ -46,15 +46,12 @@ jobs:
           msystem: ${{ contains(matrix.msystem, 'ARM64') && 'MSYS' || matrix.msystem }}
           install: VCS base-devel pactoys ${{ matrix.toolchain }}
           update: true
-          release: ${{ runner.arch != 'ARM64' }}
-          location: 'D:\M'
+          release: false
 
       - name: Add staging repo
         shell: msys2 {0}
         run: |
           cp /etc/pacman.conf /etc/pacman.conf.bak
-          grep -qF '[clang32]' /etc/pacman.conf || sed -i '1s|^|[clang32]\nInclude = /etc/pacman.d/mirrorlist.mingw\n|' /etc/pacman.conf
-          grep -qF '[clangarm64]' /etc/pacman.conf || sed -i '1s|^|[clangarm64]\nInclude = /etc/pacman.d/mirrorlist.mingw\n|' /etc/pacman.conf
           sed -i '1s|^|[staging]\nServer = https://repo.msys2.org/staging/\nSigLevel = Never\n|' /etc/pacman.conf
 
       - name: Update using staging
@@ -64,8 +61,12 @@ jobs:
 
       - name: Install clang32 toolchain
         if: ${{ matrix.msystem == 'CLANG32' || matrix.msystem == 'CLANGARM64' }}
+        shell: msys2 {0}
         run: |
-          msys2 -c 'pacman --noconfirm --overwrite "*" -S --needed mingw-w64-clang-${{ matrix.msystem == 'CLANG32' && 'i686' || 'aarch64' }}-toolchain'
+          grep -qF '[clang32]' /etc/pacman.conf || sed -i '1s|^|[clang32]\nInclude = /etc/pacman.d/mirrorlist.mingw\n|' /etc/pacman.conf
+          grep -qF '[clangarm64]' /etc/pacman.conf || sed -i '1s|^|[clangarm64]\nInclude = /etc/pacman.d/mirrorlist.mingw\n|' /etc/pacman.conf
+          pacman -Sy
+          pacman --noconfirm --overwrite "*" -S --needed mingw-w64-clang-${{ matrix.msystem == 'CLANG32' && 'i686' || 'aarch64' }}-toolchain
 
       - name: Move Checkout
         run: |
@@ -84,7 +85,7 @@ jobs:
             . shell ${MSYSTEM,,}
             set -e
           fi
-          MINGW_ARCH=${{ matrix.msystem }} ./.ci/ci-build.sh
+          ./.ci/ci-build.sh
 
       - name: "Upload binaries"
         uses: actions/upload-artifact@v2
@@ -94,7 +95,7 @@ jobs:
           path: C:/_/artifacts/*.pkg.tar.*
 
       - name: "Clean up runner"
-        if: ${{ always() }}
+        if: ${{ always() && matrix.msystem == 'CLANGARM64' }}
         continue-on-error: true
         run: |
           If (Test-Path "C:\_") { rm -r -fo "C:\_" }
@@ -104,7 +105,7 @@ jobs:
 
   check:
     needs: [build]
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2


### PR DESCRIPTION
- Move to windows-2022. I think we still have it installed differently than autobuild repo. This change will speedup the action a little bit ~1minute.
- Add clang32 and clangarm64 repo only when needing them.
- Clean up runner only with CLANGARM64 (I could not find a way to detect a self-hosted runner).