### PR TITLE
filezilla: fix missing dep sqlite3

### DIFF
--- a/mingw-w64-filezilla/PKGBUILD
+++ b/mingw-w64-filezilla/PKGBUILD
@@ -5,7 +5,7 @@ _wx_basever=3.0
 pkgbase=mingw-w64-filezilla
 pkgname=("${MINGW_PACKAGE_PREFIX}-filezilla")
 pkgver=3.56.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Fast and reliable FTP, FTPS and SFTP client (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -13,6 +13,7 @@ url="https://filezilla-project.org/"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-gnutls"
          "${MINGW_PACKAGE_PREFIX}-libfilezilla"
+         "${MINGW_PACKAGE_PREFIX}-sqlite3"
          "${MINGW_PACKAGE_PREFIX}-wxmsw${_wx_basever}")
 license=('GPL')
 source=("${_realname}-${pkgver}.tar.bz2"::"https://download.filezilla-project.org/client/${_realname}_${pkgver}_src.tar.bz2"


### PR DESCRIPTION
On a fresh install, filezilla fails with
```
MINGW64 ~$ filezilla
C:/msys64/mingw64/bin/filezilla.exe: error while loading shared libraries: wxmsw30u_xrc_gcc_custom.dll: cannot open shared object file: No such file or directory
```

wxmsw30u_xrc_gcc_custom.dll resides in /mingw64/bin, but running filezilla in /mingw64/bin fails with

```
MINGW64 /mingw64/bin$ filezilla
C:/msys64/mingw64/bin/filezilla.exe: error while loading shared libraries: libsqlite3-0.dll: cannot open shared object file: No such file or directory
```