### PR TITLE
gh: update to v2.3.0

### DIFF
--- a/mingw-w64-github-cli/PKGBUILD
+++ b/mingw-w64-github-cli/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=github-cli
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.2.0
+pkgver=2.3.0
 pkgrel=1
 pkgdesc='The GitHub CLI (mingw-w64)'
 arch=('any')
@@ -17,7 +17,7 @@ optdepends=("git: To interact with repositories")
 options=('!strip')
 source=("$_realname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz"
         "gh")
-sha256sums=('597c6c1cde4484164e9320af0481e33cfad2330a02315b4c841bdc5b7543caec'
+sha256sums=('56bcf353adc17c386377ffcdfc980cbaff36123a1c1132ba09c3c51a7d1c9b82'
             '9ee5f2b44b7e9aa751508f02c1020e341e0212a9aa146b7428eb5ffea310be27')
 build() {
     cd "cli-$pkgver"


### PR DESCRIPTION
For details, see https://github.com/cli/cli/releases/tag/v2.3.0

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
