### PR TITLE
libopenmpt: update to 0.4.25

### DIFF
--- a/mingw-w64-libopenmpt/PKGBUILD
+++ b/mingw-w64-libopenmpt/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libopenmpt
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.4.24
+pkgver=0.4.25
 pkgrel=1
 pkgdesc="A cross-platform C++ and C library to decode tracked music files (modules) into a raw PCM audio stream (mingw-w64)"
 arch=('any')
@@ -21,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
 options=('staticlibs' 'strip')
 source=("https://lib.openmpt.org/files/${_realname}/src/${_realname}-${pkgver}+release.autotools.tar.gz")
-sha256sums=('06a65906904cdebc32bcc6d348c5ecd0ce06d19f48c96a081597db238c652142')
+sha256sums=('532c498ffa1c702da61b05d4af525c1d51d7868b08b560019cab8f6c6650a83c')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}+release.autotools"


### PR DESCRIPTION
New patch version

https://lib.openmpt.org/libopenmpt/2021/11/14/releases-0.5.13-0.4.25-0.3.34/