### PR TITLE
d-feet: Update to 0.3.16

### DIFF
--- a/mingw-w64-d-feet/PKGBUILD
+++ b/mingw-w64-d-feet/PKGBUILD
@@ -4,8 +4,8 @@
 _realname=d-feet
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.3.15
-pkgrel=6
+pkgver=0.3.16
+pkgrel=1
 pkgdesc="D-Bus debugger for GNOME (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -17,12 +17,11 @@ depends=("${MINGW_PACKAGE_PREFIX}-gtk3"
 makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
              "${MINGW_PACKAGE_PREFIX}-meson"
-             "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-gtk-doc"
              "${MINGW_PACKAGE_PREFIX}-itstool")
 source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz
         001-make-reloc.patch)
-sha256sums=('1fff149ad01ccbd93c927f5733346a9122324b9d367da3adbf4f1a52e47dfdb1'
+sha256sums=('8733ce4b9a9a54ec185b1d85bf4da9d9d11052882a880760ff60f9779b2d1ccb'
             '5f4002b12ddf5c077976f4f20d1664070e9b36c9af0c28b0b89c994e29c59803')
 
 prepare() {
@@ -40,6 +39,7 @@ build() {
     --prefix=${MINGW_PREFIX} \
     --buildtype=plain \
     -Dtests=false \
+    -Dpython=${MINGW_PREFIX}/bin/python.exe \
     "../${_realname}-${pkgver}"
 
   ${MINGW_PREFIX}/bin/ninja
@@ -49,4 +49,8 @@ package() {
   cd "${srcdir}/build-${CARCH}"
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/ninja install
   install -Dm0644 "${srcdir}/${_realname}-${pkgver}"/COPYING ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING
+
+  #fix so the correct interpretter is used
+  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+  sed -e "s|${PREFIX_WIN}/bin/python.exe|${MINGW_PREFIX}/bin/python.exe|g" -i "${pkgdir}${MINGW_PREFIX}/bin/d-feet"
 }


### PR DESCRIPTION
* Remove shebang from d-feet python script.
* Remove redundant makedepends ninja.

Fixes https://github.com/msys2/MINGW-packages/issues/10248