### PR TITLE
libslirp: fix bug in 4.6.1

### DIFF
--- a/mingw-w64-libslirp/PKGBUILD
+++ b/mingw-w64-libslirp/PKGBUILD
@@ -3,8 +3,9 @@
 _realname=libslirp
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+# Please remove d7fb54218424c3b2517aee5b391ced0f75386a5d.patch for libslirp > 4.6.1
 pkgver=4.6.1
-pkgrel=1
+pkgrel=2
 pkgdesc="General purpose TCP-IP emulator (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -13,8 +14,15 @@ license=('BSD' 'MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-glib2")
 makedepends=("${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-meson")
-source=("https://gitlab.freedesktop.org/slirp/${_realname}/-/archive/v${pkgver}/${_realname}-v${pkgver}.tar.bz2")
-sha256sums=('3ee27347764c629e10228f7002dd22104e9cc21623d565dc0e7e57ed1b63a70e')
+source=("https://gitlab.freedesktop.org/slirp/${_realname}/-/archive/v${pkgver}/${_realname}-v${pkgver}.tar.bz2"
+        "https://gitlab.freedesktop.org/slirp/libslirp/-/commit/d7fb54218424c3b2517aee5b391ced0f75386a5d.patch")
+sha256sums=('3ee27347764c629e10228f7002dd22104e9cc21623d565dc0e7e57ed1b63a70e'
+            '5ba7b32beae398248ded6aa64fd9c86a663a7e8f8918c387433164ac847296ee')
+
+prepare() {
+  cd "${srcdir}"/${_realname}-v${pkgver}
+  patch -p1 -i "${srcdir}"/d7fb54218424c3b2517aee5b391ced0f75386a5d.patch
+}
 
 build() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}


### PR DESCRIPTION
On performing tests for https://github.com/msys2/MINGW-packages/pull/10098 I realized that test case Qemu Advent Calendar 2020/14 failed (stucks in boot) because of a regression, which was introduced with version 4.6.1 while previously packaged version 4.4.0 workes fine.

Fortunately https://gitlab.freedesktop.org/slirp/libslirp/-/commit/d7fb54218424c3b2517aee5b391ced0f75386a5d solves this issue.