### PR TITLE
opencv: update to 4.5.4

### DIFF
--- a/mingw-w64-ceres-solver/PKGBUILD
+++ b/mingw-w64-ceres-solver/PKGBUILD
@@ -4,14 +4,14 @@ _realname=ceres-solver
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.0.0
-pkgrel=2
+pkgrel=3
 pkgdesc="A large scale non-linear optimization library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 url="http://ceres-solver.org/"
 license=('New BSD license')
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-cmake")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
 depends=("${MINGW_PACKAGE_PREFIX}-eigen3"
          "${MINGW_PACKAGE_PREFIX}-glog"
          "${MINGW_PACKAGE_PREFIX}-suitesparse")
@@ -30,26 +30,25 @@ prepare() {
 }
 
 build() {
-  rm -rf "${srcdir}/build-${MINGW_CHOST}"
-  mkdir "${srcdir}/build-${MINGW_CHOST}"
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}
+  mkdir -p ${srcdir}/build-${MSYSTEM} && cd ${srcdir}/build-${MSYSTEM}
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe \
-    -G"MSYS Makefiles" \
+    -G"Ninja" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DBUILD_SHARED_LIBS=YES \
     "../${_realname}-${pkgver}"
 
-  make
+  cmake --build .
 }
 
 check() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
-  make test
+  cd "${srcdir}/build-${MSYSTEM}"
+  ctest --output-on-failure
 }
 
 package() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
-  make DESTDIR="${pkgdir}" install
+  cd "${srcdir}/build-${MSYSTEM}"
+  DESTDIR="${pkgdir}" cmake --install .
 }

--- a/mingw-w64-opencv/PKGBUILD
+++ b/mingw-w64-opencv/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=opencv
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.5.2
-pkgrel=4
+pkgver=4.5.4
+pkgrel=1
 pkgdesc="Open Source Computer Vision Library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -13,7 +13,6 @@ license=("BSD")
 # 4.5.0 doesn't support ceres 2.x, wait for >4.5.0
 depends=(#"${MINGW_PACKAGE_PREFIX}-gst-plugins-base
          "${MINGW_PACKAGE_PREFIX}-ceres-solver"
-         "${MINGW_PACKAGE_PREFIX}-intel-tbb"
          "${MINGW_PACKAGE_PREFIX}-jasper"
          "${MINGW_PACKAGE_PREFIX}-freetype"
          "${MINGW_PACKAGE_PREFIX}-gflags"
@@ -30,14 +29,15 @@ depends=(#"${MINGW_PACKAGE_PREFIX}-gst-plugins-base
          "${MINGW_PACKAGE_PREFIX}-openjpeg2"
          "${MINGW_PACKAGE_PREFIX}-openexr"
          "${MINGW_PACKAGE_PREFIX}-protobuf"
+         "${MINGW_PACKAGE_PREFIX}-tbb"
          "${MINGW_PACKAGE_PREFIX}-tesseract-ocr"
          "${MINGW_PACKAGE_PREFIX}-zlib"
-         #"${MINGW_PACKAGE_PREFIX}-qt5"
          #"${MINGW_PACKAGE_PREFIX}-gtkglext"
          #"${MINGW_PACKAGE_PREFIX}-gtk2"
          )
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
-             #"${MINGW_PACKAGE_PREFIX}-qt5"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-qt5-base"
              "${MINGW_PACKAGE_PREFIX}-ffmpeg"
              "${MINGW_PACKAGE_PREFIX}-python-numpy"
              "${MINGW_PACKAGE_PREFIX}-python-flake8"
@@ -55,6 +55,7 @@ optdepends=(#"${MINGW_PACKAGE_PREFIX}-ceres-solver: SFM module"
             #"${MINGW_PACKAGE_PREFIX}-tesseract-ocr: opencv_text module"
             #"${MINGW_PACKAGE_PREFIX}-ogre3d: ovis module"
             #"${MINGW_PACKAGE_PREFIX}-vtk: opencv_viz module"
+            "${MINGW_PACKAGE_PREFIX}-qt5-base: for the HighGUI module"
             )
 source=("${_realname}-${pkgver}.tar.gz"::https://github.com/opencv/opencv/archive/${pkgver}.tar.gz
         "${_realname}_contrib-${pkgver}.tar.gz"::https://github.com/opencv/opencv_contrib/archive/${pkgver}.tar.gz
@@ -67,13 +68,14 @@ source=("${_realname}-${pkgver}.tar.gz"::https://github.com/opencv/opencv/archiv
         '0012-make-header-usable-with-C-compiler.patch'
         '0014-python-install-path.patch'
         '0015-windres-cant-handle-spaces-in-defines.patch'
+        'https://github.com/opencv/opencv/commit/bac1c6d.patch'
         '0101-somehow-uint-not-detected.patch'
         '0102-mingw-w64-have-sincos.patch'
         '0103-sfm-module-linking.patch'
         '0104-rgbd-module-missing-include.patch'
         '0105-wechat-iconv-dependency.patch')
-sha256sums=('ae258ed50aa039279c3d36afdea5c6ecf762515836b27871a8957c610d0424f8'
-            '9f52fd3114ac464cb4c9a2a6a485c729a223afb57b9c24848484e55cef0b5c2a'
+sha256sums=('c20bb83dd790fc69df9f105477e24267706715a9d3c705ca1e7f613c7b3bad3d'
+            'ad74b440b4539619dc9b587995a16b691246023d45e34097c73e259f72de9f81'
             'e50a477ca9fb613400ba276099bb3be6af8f1bfb277ea86459f0d635c24d218f'
             '400f17bde074677566660b1baab52842c1a3d7024129a2d75af6015f6b55ba4f'
             '480e45906b54c5b6079f437de50ebf2152a83860327613048b53d038526b8ad2'
@@ -83,6 +85,7 @@ sha256sums=('ae258ed50aa039279c3d36afdea5c6ecf762515836b27871a8957c610d0424f8'
             '9f918a974e9d5227fce3702b1f38716a7fb79586dda9256b5df44dcc0f858c3b'
             '0c310a580d6700601d4b4f824b849c0f0d64d3953e249f04c6a91f15aa8bee0a'
             '11522ffedb22980ba8d09ff715a25327fe14806e55588bffa761e39e1d035ea5'
+            '7fd1c7d0b6362ca1a1fbe60dc89178c8036e1159ab78e9f259698cdf1688a760'
             '7d2ff25f97c84b59793502786dd64e25c8ca991b0523ffea56b45ce031e80c3f'
             '2001804c5245af1894a308d6521f9cd044fb6dbd713b6e2e45106399a409c14d'
             '0422317096007b72ab4928b48762da4252addf3e4f8066ba94e29344f5975ab8'
@@ -119,7 +122,8 @@ prepare() {
         0010-find-libpng-header.patch \
         0012-make-header-usable-with-C-compiler.patch \
         0014-python-install-path.patch \
-        0015-windres-cant-handle-spaces-in-defines.patch
+        0015-windres-cant-handle-spaces-in-defines.patch \
+        bac1c6d.patch
 
   cd "${srcdir}/${_realname}_contrib-${pkgver}"
   apply_patch_with_msg \
@@ -131,8 +135,8 @@ prepare() {
 }
 
 build() {
-  [[ -d ${srcdir}/build-${CARCH} ]] && rm -rf ${srcdir}/build-${CARCH}
-  mkdir -p ${srcdir}/build-${CARCH} && cd ${srcdir}/build-${CARCH}
+  [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}
+  mkdir -p ${srcdir}/build-${MSYSTEM} && cd ${srcdir}/build-${MSYSTEM}
 
   CFLAGS+=" -D_POSIX_SOURCE -Wno-attributes"
   CXXFLAGS+=" -D_POSIX_SOURCE -Wno-attributes"
@@ -141,9 +145,25 @@ build() {
   export OpenBLAS_HOME=${MINGW_PREFIX}
   export TINYDNN_ROOT=${MINGW_PREFIX}/include/tiny_dnn
 
+  local -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  local -a _cpu_dispatch="SSE4_1;SSE4_2;FP16;AVX"
+  if [ ${CARCH} == "x86_64" ]; then
+    _cpu_dispatch+=";AVX2"
+    if [ ${MSYSTEM} != "CLANG64" ]; then
+      _cpu_dispatch+=";AVX512_SKX" # Fails on clang64!
+    fi
+  fi
+  extra_config+=('-DCPU_DISPATCH="${_cpu_dispatch}"')
+
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DPYTHON2_PACKAGES_PATH=;-DPYTHON3_PACKAGES_PATH=" \
   ${MINGW_PREFIX}/bin/cmake.exe -Wno-dev \
-    -G"MSYS Makefiles" \
+    -G"Ninja" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DWITH_OPENCL=ON \
     -DWITH_OPENGL=ON \
@@ -159,7 +179,7 @@ build() {
     -DINSTALL_C_EXAMPLES=OFF \
     -DINSTALL_PYTHON_EXAMPLES=OFF \
     -DWITH_GTK=OFF \
-    -DWITH_QT=OFF \
+    -DWITH_QT=ON \
     -DWITH_VTK=OFF \
     -DWITH_GDAL=OFF \
     -DWITH_MSMF=OFF \
@@ -168,7 +188,6 @@ build() {
     -DWITH_OPENJPEG=ON \
     -DWITH_OPENCL_D3D11_NV=OFF \
     -DOPENCV_SKIP_PYTHON_LOADER=ON \
-    -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_SKIP_RPATH=ON \
     -DENABLE_PRECOMPILED_HEADERS=OFF \
     -DOPENCV_EXTRA_MODULES_PATH=../${_realname}_contrib-${pkgver}/modules \
@@ -182,14 +201,15 @@ build() {
     -DOPENCV_GENERATE_PKGCONFIG=ON \
     -DOPENCV_PYTHON_INSTALL_PATH=lib \
     -DOPENCV_SKIP_CMAKE_ROOT_CONFIG=ON \
+    ${extra_config[@]} \
     ../${_realname}-${pkgver}
 
-  make
+  cmake --build .
 }
 
 package() {
-  cd "${srcdir}/build-${CARCH}"
-  make DESTDIR=${pkgdir} install
+  cd "${srcdir}/build-${MSYSTEM}"
+  DESTDIR=${pkgdir} cmake --install .
 
   # install missing headers https://github.com/opencv/opencv/issues/13201
   for _module in imgcodecs videoio photo; do


### PR DESCRIPTION
Before someone complains about AVX* stuff. Those options are enabled by default https://github.com/opencv/opencv/blob/4.5.4/cmake/OpenCVCompilerOptimizations.cmake#L310, I have just added that option to disable AVX512_SKX for CLANG64, As it failed for some reason.