### PR TITLE
openimageio: fix cmake config file

### DIFF
--- a/mingw-w64-openimageio/0020-set-import-prefix.patch
+++ b/mingw-w64-openimageio/0020-set-import-prefix.patch
@@ -5,12 +5,12 @@
  include(CMakeFindDependencyMacro)
  
 +# Compute the installation prefix relative to this file.
-+get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
-+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
-+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
-+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
-+if(_IMPORT_PREFIX STREQUAL "/")
-+  set(_IMPORT_PREFIX "")
++get_filename_component(_INSTALL_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
++get_filename_component(_INSTALL_PREFIX "${_INSTALL_PREFIX}" PATH)
++get_filename_component(_INSTALL_PREFIX "${_INSTALL_PREFIX}" PATH)
++get_filename_component(_INSTALL_PREFIX "${_INSTALL_PREFIX}" PATH)
++if(_INSTALL_PREFIX STREQUAL "/")
++  set(_INSTALL_PREFIX "")
 +endif()
 +
  # add here all the find_dependency() whenever switching to config based dependencies

--- a/mingw-w64-openimageio/PKGBUILD
+++ b/mingw-w64-openimageio/PKGBUILD
@@ -4,7 +4,7 @@ _realname=openimageio
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.2.18.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A library for reading and writing images, including classes, utilities, and applications (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -36,12 +36,12 @@ depends=("${MINGW_PACKAGE_PREFIX}-boost"
          "${MINGW_PACKAGE_PREFIX}-pugixml"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
-             #"${MINGW_PACKAGE_PREFIX}-qt5"
+             "${MINGW_PACKAGE_PREFIX}-qt5-base"
              "${MINGW_PACKAGE_PREFIX}-python"
              "${MINGW_PACKAGE_PREFIX}-boost"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-pybind11")
-optdepends=(#"${MINGW_PACKAGE_PREFIX}-qt5: iv image viewer"
+optdepends=("${MINGW_PACKAGE_PREFIX}-qt5-base: iv image viewer"
             "${MINGW_PACKAGE_PREFIX}-python: bindings support")
 options=('strip' 'buildflags' '!debug')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/OpenImageIO/oiio/archive/Release-${pkgver}.tar.gz
@@ -55,7 +55,7 @@ sha256sums=('b8dd189fbc97f1b172528e324daa904f74a166bad62c32e7166ca6c866734a29'
             '819668751fbced6dc583eb94c34119131ec13211097fffef2aef11955c4c4770'
             'bc37ea8326f7f5f26068051b537f2491e9554a380e6584bf55aaad111d33eb81'
             '066de45a500ae4eaa5fbdd99bb6ea7904ddc88389ad1d726d629edf5d9527b26'
-            '59db23c0c5e77f05ab9f237dfd967a86af24564132d23424e3c1355d047b10ba')
+            '773e229f01f10a6cd9add1bcf0583f8396ccf752e26c6065f463d78ee93101c9')
 
 prepare() {
   cd ${srcdir}/oiio-Release-${pkgver}
@@ -69,15 +69,15 @@ prepare() {
 }
 
 build() {
+  [[ -d "${srcdir}"/build-${MSYSTEM} ]] && rm -rf "${srcdir}"/build-${MSYSTEM}
+  mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
+
   declare -a extra_config
   if check_option "debug" "n"; then
     extra_config+=("-DCMAKE_BUILD_TYPE=Release")
   else
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
-
-  [[ -d "build-${MINGW_CHOST}" ]] && rm -rf "build-${MINGW_CHOST}"
-  mkdir -p build-${MINGW_CHOST} && cd build-${MINGW_CHOST}
 
   local _pyver=$(${MINGW_PREFIX}/bin/python -c "import sys;sys.stdout.write('.'.join(map(str, sys.version_info[:2])))")
   unset CI GITHUB_ACTIONS # otherwise it forces -Werror
@@ -91,7 +91,7 @@ build() {
     -DUSE_OPENCV=ON \
     -DUSE_FIELD3D=ON \
     -DUSE_OPENGL=ON \
-    -DUSE_QT=OFF \
+    -DUSE_QT=ON \
     -DUSE_FFMPEG=ON \
     -DPYTHON_VERSION=${_pyver} \
     -DUSE_EXTERNAL_PUGIXML=ON \
@@ -104,14 +104,14 @@ build() {
 }
 
 package() {
-  cd "${srcdir}"/build-${MINGW_CHOST}
+  cd "${srcdir}"/build-${MSYSTEM}
 
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --build . --target install
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
 
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
   for _f in "${pkgdir}${MINGW_PREFIX}"/lib/cmake/OpenImageIO/*.cmake; do
-    sed -e "s|${PREFIX_WIN}|\$\{_IMPORT_PREFIX\}|g" -i ${_f}
-    sed -e "s|${MINGW_PREFIX}|\$\{_IMPORT_PREFIX\}|g" -i ${_f}
+    sed -e "s|${PREFIX_WIN}|\$\{_INSTALL_PREFIX\}|g" -i ${_f}
+    sed -e "s|${MINGW_PREFIX}|\$\{_INSTALL_PREFIX\}|g" -i ${_f}
   done
 
   install -Dm644 ${srcdir}/oiio-Release-${pkgver}/LICENSE.md "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.md"


### PR DESCRIPTION
_IMPORT_PREFIX was overwritten by other targets. use _INSTALL_PREFIX instead.

Fixes #10263 