### PR TITLE
EDA: update openFPGALoader and verilator

### DIFF
--- a/mingw-w64-nextpnr/PKGBUILD
+++ b/mingw-w64-nextpnr/PKGBUILD
@@ -4,7 +4,7 @@ _realname=nextpnr
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.0.r3900.gfd2d4a8f
-pkgrel=1
+pkgrel=2
 pkgdesc="Portable FPGA place and route tool (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -19,8 +19,8 @@ depends=(
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-boost"
   "${MINGW_PACKAGE_PREFIX}-cmake"
+  "${MINGW_PACKAGE_PREFIX}-clang"
   "${MINGW_PACKAGE_PREFIX}-eigen3"
-  "${MINGW_PACKAGE_PREFIX}-gcc"
   "${MINGW_PACKAGE_PREFIX}-icestorm"
   "${MINGW_PACKAGE_PREFIX}-openmp"
   "${MINGW_PACKAGE_PREFIX}-python"
@@ -48,6 +48,8 @@ build() {
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" cmake \
     -G "MSYS Makefiles" \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
     -DICESTORM_INSTALL_PREFIX="${MINGW_PREFIX}" \
     -DCMAKE_PREFIX_PATH=${MINGW_PREFIX} \
     -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \

--- a/mingw-w64-nextpnr/PKGBUILD
+++ b/mingw-w64-nextpnr/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=nextpnr
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.0.r3900.gfd2d4a8f
-pkgrel=2
+pkgver=0.1.r3900.gfd2d4a8f
+pkgrel=1
 pkgdesc="Portable FPGA place and route tool (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -34,7 +34,7 @@ sha256sums=('SKIP')
 
 pkgver() {
   cd "${_realname}"
-  printf "0.0.r%s.g%s" "$(git rev-list --count ${_commit})" "$(git rev-parse --short=8 ${_commit})"
+  printf "0.1.r%s.g%s" "$(git rev-list --count ${_commit})" "$(git rev-parse --short=8 ${_commit})"
 }
 
 build() {

--- a/mingw-w64-openFPGALoader/PKGBUILD
+++ b/mingw-w64-openFPGALoader/PKGBUILD
@@ -4,14 +4,17 @@ _realname=openFPGALoader
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.6.0
-pkgrel=1
+pkgrel=2
 pkgdesc="openFPGALoader: universal utility for programming FPGA (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://github.com/trabucayre/openFPGALoader"
 license=('Apache-2.0')
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
-depends=("${MINGW_PACKAGE_PREFIX}-libftdi")
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-libftdi"
+  "${MINGW_PACKAGE_PREFIX}-zlib"
+)
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-gcc"
   "${MINGW_PACKAGE_PREFIX}-cmake"

--- a/mingw-w64-openFPGALoader/PKGBUILD
+++ b/mingw-w64-openFPGALoader/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=openFPGALoader
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.6.0
-pkgrel=2
+pkgver=0.6.1
+pkgrel=1
 pkgdesc="openFPGALoader: universal utility for programming FPGA (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -21,7 +21,7 @@ makedepends=(
 )
 
 source=("${_realname}::https://codeload.github.com/trabucayre/openFPGALoader/tar.gz/v${pkgver}")
-sha256sums=('0971db2302e704966d2e29b8d34e95f553cfd8f81e5ab70ec0533f03f219cf49')
+sha256sums=('a862a209d696becff915a77512e6a8c22f92d73480a45cc12273d9ad1db60d23')
 
 build() {
   cd "${srcdir}/${_realname}-${pkgver}"

--- a/mingw-w64-verilator/0001-Fix-MSWIN-compile-error-2681.patch
+++ b/mingw-w64-verilator/0001-Fix-MSWIN-compile-error-2681.patch
@@ -1,0 +1,29 @@
+diff --git a/Changes b/Changes
+index 0cc1c41b..4f1a4c16 100644
+--- a/Changes
++++ b/Changes
+@@ -13,6 +13,8 @@ Verilator 4.217 devel
+
+ **Minor:**
+
++* Fix MSWIN compile error (#2681). [Unai Martinez-Corral]
++
+
+ Verilator 4.216 2021-12-05
+ ==========================
+diff --git a/src/V3File.cpp b/src/V3File.cpp
+index 47cc857d..19a777b2 100644
+--- a/src/V3File.cpp
++++ b/src/V3File.cpp
+@@ -335,7 +335,7 @@ class VInFilterImp final {
+ #ifdef INFILTER_PIPE
+     pid_t m_pid = 0;  // fork() process id
+ #else
+-    const int m_pid = 0;  // fork() process id - always zero as disabled
++    int m_pid = 0;  // fork() process id - always zero as disabled
+ #endif
+     bool m_pidExited = false;
+     int m_pidStatus = 0;
+--
+2.34.1
+

--- a/mingw-w64-verilator/PKGBUILD
+++ b/mingw-w64-verilator/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=verilator
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.214
-pkgrel=2
+pkgver=4.216
+pkgrel=1
 pkgdesc="The fastest free Verilog HDL simulator (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -16,15 +16,18 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 
 source=(
   "${_realname}::https://codeload.github.com/${_realname}/${_realname}/tar.gz/v${pkgver}"
+  '0001-Fix-MSWIN-compile-error-2681.patch'
 )
 sha256sums=(
-  'e14c7f6ffb00a6746ae2a8ea0424e90a1a30067e8ae4c96b8c42689ca1ca0b1f'
+  '64e5093b629a7e96178e3b2494f208955f218dfac6f310a91e4fc07d050c980b'
+  '9a38ccf4f492d804e49cf764e1ada9bbcceccfdba54161af2538ce5d856e6385'
 )
 
 prepare() {
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
   cp -rf "${srcdir}/${_realname}-${pkgver}" "${srcdir}/build-${MINGW_CHOST}"
   cd "${srcdir}/build-${MINGW_CHOST}"
+  patch -p1 -i "${srcdir}"/0001-Fix-MSWIN-compile-error-2681.patch
   sh autoconf
 }
 


### PR DESCRIPTION
openFPGALoader 0.6.1 and verilator 4.216 were released. By the way, the compiler used for building nextpnr is changed from gcc to clang.