### PR TITLE
ncurses 6.3 - update to l newer version, update PGP key, and use sepa…

### DIFF
--- a/mingw-w64-ncurses/PKGBUILD
+++ b/mingw-w64-ncurses/PKGBUILD
@@ -64,7 +64,9 @@ build() {
     --enable-sp-funcs \
     --enable-term-driver \
     --enable-interop \
-    --enable-widec
+    --enable-widec \
+    --enable-pc-files \
+    --with-pkg-config-libdir=${MINGW_PREFIX}/lib/pkgconfig
 
   make
 }

--- a/mingw-w64-ncurses/PKGBUILD
+++ b/mingw-w64-ncurses/PKGBUILD
@@ -3,11 +3,11 @@
 _realname=ncurses
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-#_base_ver=6.1
-#_date_rev=20190630
-#pkgver=${_base_ver}.${_date_rev}
-pkgver=6.2
-pkgrel=4
+#_base_ver=6.3
+#_date_rev=20211108
+#kgver=${_base_ver}.${_date_rev}
+pkgver=6.3
+pkgrel=1
 pkgdesc="System V Release 4.0 curses emulation library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -16,15 +16,15 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 url="https://www.gnu.org/software/ncurses/"
 license=('MIT')
 options=('staticlibs' 'strip')
-source=(#"${_realname}-${pkgver}.tar.gz"::"https://invisible-mirror.net/archives/ncurses/current/${_realname}-${_base_ver}-${_date_rev}.tgz"
+source=(#"${_realname}-${pkgver}.tar.gz"::"https://invisible-mirror.net/archives/ncurses/current/${_realname}-${_base_ver}.tgz"
         https://ftp.gnu.org/pub/gnu/ncurses/ncurses-${pkgver}.tar.gz{,.sig}
         001-use-libsystre.patch
         002-ncurses-config-win-paths.patch)
-sha256sums=('30306e0c76e0f9f1f0de987cf1c82a5c21e1ce6568b9227f7da5b71cbea86c9d'
+sha256sums=('97fc51ac2b085d4cde31ef4d2c3122c21abc217e9090a43a30fc5ec21684e059'
             'SKIP'
             'd8fb37262372f3e5c9a553bdeff07c8b874bac6f3c416e2a372877cef0af1925'
             '5367d8f49aff92884b9daa014502df13e1812f1b7ee1b3a3cb18139f10039408')
-validpgpkeys=('C52048C0C0748FEE227D47A2702353E0F7E48EDB')
+validpgpkeys=('19882D92DDA4C400C22C0D56CC2AF4472167BE03')
 
 prepare() {
   cd ${_realname}-${pkgver}
@@ -33,8 +33,8 @@ prepare() {
 }
 
 build() {
-  [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}
-  mkdir -p build-${MINGW_CHOST} && cd build-${MINGW_CHOST}
+  [[ -d build-${MSYSTEM} ]] && rm -rf build-${MSYSTEM}
+  mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
 
   # It passes X_OK to access() on Windows which isn't supported with ucrt
   CFLAGS+=" -D__USE_MINGW_ACCESS"
@@ -70,7 +70,7 @@ build() {
 }
 
 package() {
-  cd ${srcdir}/build-${MINGW_CHOST}
+  cd ${srcdir}/build-${MSYSTEM}
   make DESTDIR=${pkgdir} install
   cp -r ${pkgdir}${MINGW_PREFIX}/include/ncursesw ${pkgdir}${MINGW_PREFIX}/include/ncurses
   cp ${pkgdir}${MINGW_PREFIX}/lib/libncursesw.a ${pkgdir}${MINGW_PREFIX}/lib/libncurses.a


### PR DESCRIPTION
…rate paths for all builds.