### PR TITLE
new packages: sfcgal and pysfcgal

### DIFF
--- a/mingw-w64-python-pysfcgal/PKGBUILD
+++ b/mingw-w64-python-pysfcgal/PKGBUILD
@@ -13,6 +13,7 @@ url='https://gitlab.com/Oslandia/pysfcgal'
 depends=(
     ${MINGW_PACKAGE_PREFIX}-python
     ${MINGW_PACKAGE_PREFIX}-sfcgal
+    ${MINGW_PACKAGE_PREFIX}-python-cffi
 )
 makedepends=(${MINGW_PACKAGE_PREFIX}-python-setuptools
     ${MINGW_PACKAGE_PREFIX}-python-wheel

--- a/mingw-w64-python-pysfcgal/PKGBUILD
+++ b/mingw-w64-python-pysfcgal/PKGBUILD
@@ -17,7 +17,8 @@ depends=(
 )
 makedepends=(${MINGW_PACKAGE_PREFIX}-python-setuptools
     ${MINGW_PACKAGE_PREFIX}-python-wheel
-    ${MINGW_PACKAGE_PREFIX}-python-cffi)
+    ${MINGW_PACKAGE_PREFIX}-python-cffi
+    ${MINGW_PACKAGE_PREFIX}-cc)
 source=(https://gitlab.com/Oslandia/pysfcgal/-/archive/v${pkgver}/pysfcgal-v${pkgver}.tar.gz)
 sha256sums=('a519cdb3a89dea11f92bee91f284cecd56dc88e4b0eda4f37d1c7268c0289980')
 

--- a/mingw-w64-python-pysfcgal/PKGBUILD
+++ b/mingw-w64-python-pysfcgal/PKGBUILD
@@ -8,7 +8,7 @@ pkgrel=1
 pkgdesc='Python SFCGAL binding (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
-license=('MIT')
+license=('spdx:MIT')
 url='https://gitlab.com/Oslandia/pysfcgal'
 depends=(
     ${MINGW_PACKAGE_PREFIX}-python

--- a/mingw-w64-python-pysfcgal/PKGBUILD
+++ b/mingw-w64-python-pysfcgal/PKGBUILD
@@ -1,0 +1,41 @@
+# Maintainer: Loïc Bartoletti <loic.bartoletti@oslandia.com>
+
+_realname=pysfcgal
+pkgbase=mingw-w64-python-${_realname}
+pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
+pkgver=0.1.0
+pkgrel=1
+pkgdesc='Python SFCGAL binding (mingw-w64)'
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+license=('MIT')
+url='https://gitlab.com/Oslandia/pysfcgal'
+depends=(
+    ${MINGW_PACKAGE_PREFIX}-python
+    ${MINGW_PACKAGE_PREFIX}-sfcgal
+)
+makedepends=(${MINGW_PACKAGE_PREFIX}-python-setuptools
+    ${MINGW_PACKAGE_PREFIX}-python-wheel
+    ${MINGW_PACKAGE_PREFIX}-python-cffi)
+source=(https://gitlab.com/Oslandia/pysfcgal/-/archive/v${pkgver}/pysfcgal-v${pkgver}.tar.gz)
+sha256sums=('eed5e422ed94f3c0d7745ecf85892f9f80eb7de5701a648486251727f51a3945')
+
+prepare() {
+  rm -rf python-build-${MSYSTEM} | true
+  cp -r "${_realname}-v${pkgver}" "python-build-${MSYSTEM}"
+}
+
+build() {
+  msg "Python build for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
+  ${MINGW_PREFIX}/bin/python setup.py build
+}
+
+package() {
+  cd "${srcdir}/python-build-${MSYSTEM}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}

--- a/mingw-w64-python-pysfcgal/PKGBUILD
+++ b/mingw-w64-python-pysfcgal/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=pysfcgal
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
-pkgver=0.1.0
+pkgver=1.4.1
 pkgrel=1
 pkgdesc='Python SFCGAL binding (mingw-w64)'
 arch=('any')
@@ -19,7 +19,7 @@ makedepends=(${MINGW_PACKAGE_PREFIX}-python-setuptools
     ${MINGW_PACKAGE_PREFIX}-python-wheel
     ${MINGW_PACKAGE_PREFIX}-python-cffi)
 source=(https://gitlab.com/Oslandia/pysfcgal/-/archive/v${pkgver}/pysfcgal-v${pkgver}.tar.gz)
-sha256sums=('eed5e422ed94f3c0d7745ecf85892f9f80eb7de5701a648486251727f51a3945')
+sha256sums=('a519cdb3a89dea11f92bee91f284cecd56dc88e4b0eda4f37d1c7268c0289980')
 
 prepare() {
   rm -rf python-build-${MSYSTEM} | true

--- a/mingw-w64-sfcgal/PKGBUILD
+++ b/mingw-w64-sfcgal/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=sfcgal
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.4.0
+pkgver=1.4.1
 pkgrel=1
 pkgdesc="Wrapper around CGAL that intents to implement 2D and 3D operations on OGC standards models (mingw-w64)"
 arch=('any')
@@ -21,7 +21,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-mpfr"
          "${MINGW_PACKAGE_PREFIX}-cgal")
 source=(https://gitlab.com/Oslandia/SFCGAL/-/archive/v${pkgver}/SFCGAL-v${pkgver}.tar.gz)
-sha256sums=('5363c4e4a4a75cfbd6c4e9c5ba634f406db400be0afd7cafc92fddae7453b486')
+sha256sums=('1800c8a26241588f11cddcf433049e9b9aea902e923414d2ecef33a3295626c3')
 
 prepare() {
   plain 'No Step'

--- a/mingw-w64-sfcgal/PKGBUILD
+++ b/mingw-w64-sfcgal/PKGBUILD
@@ -10,7 +10,7 @@ arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://www.sfcgal.org/"
 license=("LGPL, GPL")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cgal"

--- a/mingw-w64-sfcgal/PKGBUILD
+++ b/mingw-w64-sfcgal/PKGBUILD
@@ -9,7 +9,7 @@ pkgdesc="Wrapper around CGAL that intents to implement 2D and 3D operations on O
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://www.sfcgal.org/"
-license=("LGPL, GPL")
+license=("spdx:LGPL-2.0-or-later")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"

--- a/mingw-w64-sfcgal/PKGBUILD
+++ b/mingw-w64-sfcgal/PKGBUILD
@@ -12,6 +12,7 @@ url="https://www.sfcgal.org/"
 license=("LGPL, GPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cgal"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
@@ -33,7 +34,7 @@ build() {
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake \
-      -G"MSYS Makefiles" \
+      -G"Ninja" \
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
       -DCMAKE_BUILD_TYPE=Release \
       ../SFCGAL-v${pkgver}

--- a/mingw-w64-sfcgal/PKGBUILD
+++ b/mingw-w64-sfcgal/PKGBUILD
@@ -1,0 +1,47 @@
+# Maintainer: Loïc Bartoletti <loic.bartoletti@oslandia.com>
+
+_realname=sfcgal
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.4.0
+pkgrel=1
+pkgdesc="Wrapper around CGAL that intents to implement 2D and 3D operations on OGC standards models (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+url="https://www.sfcgal.org/"
+license=("LGPL, GPL")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-cgal"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-boost"
+         "${MINGW_PACKAGE_PREFIX}-gmp"
+         "${MINGW_PACKAGE_PREFIX}-mpfr"
+         "${MINGW_PACKAGE_PREFIX}-cgal")
+source=(https://gitlab.com/Oslandia/SFCGAL/-/archive/v${pkgver}/SFCGAL-v${pkgver}.tar.gz)
+sha256sums=('5363c4e4a4a75cfbd6c4e9c5ba634f406db400be0afd7cafc92fddae7453b486')
+
+prepare() {
+  plain 'No Step'
+}
+
+build() {
+  [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}
+  mkdir ${srcdir}/build-${MSYSTEM}
+  cd ${srcdir}/build-${MSYSTEM}
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake \
+      -G"MSYS Makefiles" \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      -DCMAKE_BUILD_TYPE=Release \
+      ../SFCGAL-v${pkgver}
+
+  ${MINGW_PREFIX}/bin/cmake --build .
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
+}


### PR DESCRIPTION
Hello!

I would like to propose two new packages into MSYS2: SFCGAL and pysfcgal.

Some words about SFCGAL:

 > SFCGAL is a C++ wrapper library around CGAL with the aim of supporting ISO 19107:2013 and OGC Simple Features Access 1.2 for 3D operations.
 SFCGAL provides standard compliant geometry types and operations, that can be accessed from its C or C++ APIs. PostGIS uses the C API, to expose some SFCGAL's functions in spatial databases (cf. PostGIS manual). 

http://www.sfcgal.org/

pysfcgal is the python binding of SFCGAL using cffi.


As it's my first PR here, a tiny description about me:

I'm the main maintainer/developer of SFCGAL and pysfcgal, and I'm also a (FreeBSD) package maintainer. I intend to make changes with each new version and if there are bugs.