### PR TITLE
libopenmpt: update to 0.4.26

### DIFF
--- a/mingw-w64-libopenmpt/PKGBUILD
+++ b/mingw-w64-libopenmpt/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libopenmpt
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.4.25
+pkgver=0.4.26
 pkgrel=1
 pkgdesc="A cross-platform C++ and C library to decode tracked music files (modules) into a raw PCM audio stream (mingw-w64)"
 arch=('any')
@@ -21,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
 options=('staticlibs' 'strip')
 source=("https://lib.openmpt.org/files/${_realname}/src/${_realname}-${pkgver}+release.autotools.tar.gz")
-sha256sums=('532c498ffa1c702da61b05d4af525c1d51d7868b08b560019cab8f6c6650a83c')
+sha256sums=('9078aa3a1779868b484fbffdf19daea775654b53224e5c217628a8d2ae777e8d')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}+release.autotools"


### PR DESCRIPTION
New patch version with security fixes

https://lib.openmpt.org/libopenmpt/2021/12/05/security-updates-0.5.14-0.4.26-0.3.35/