### PR TITLE
Upgrade flit

### DIFF
--- a/mingw-w64-python-flit/PKGBUILD
+++ b/mingw-w64-python-flit/PKGBUILD
@@ -10,60 +10,20 @@ arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url='https://github.com/takluyver/flit'
 license=('BSD')
-depends=("${MINGW_PACKAGE_PREFIX}-python" 
+depends=("${MINGW_PACKAGE_PREFIX}-python"
         "${MINGW_PACKAGE_PREFIX}-python-tomli"
         "${MINGW_PACKAGE_PREFIX}-python-tomli-w")
-checkdepends=("${MINGW_PACKAGE_PREFIX}-python-requests"
-              "${MINGW_PACKAGE_PREFIX}-python-coverage"
-              "${MINGW_PACKAGE_PREFIX}-python-docutils"
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-coverage"
+              "${MINGW_PACKAGE_PREFIX}-python-responses"
               "${MINGW_PACKAGE_PREFIX}-python-testpath"
               "${MINGW_PACKAGE_PREFIX}-python-pytest"
-             "${MINGW_PACKAGE_PREFIX}-python-pytest-cov"
-              )
-makedepends=("${MINGW_PACKAGE_PREFIX}-python"
-             "${MINGW_PACKAGE_PREFIX}-python-atomicwrites"
-             "${MINGW_PACKAGE_PREFIX}-python-attrs"
-             "${MINGW_PACKAGE_PREFIX}-python-babel"
-             "${MINGW_PACKAGE_PREFIX}-python-certifi"
-             "${MINGW_PACKAGE_PREFIX}-python-chardet"
-             "${MINGW_PACKAGE_PREFIX}-python-colorama"             
-             "${MINGW_PACKAGE_PREFIX}-python-coverage"
-             "${MINGW_PACKAGE_PREFIX}-python-docutils"
-             "${MINGW_PACKAGE_PREFIX}-python-idna"
-             "${MINGW_PACKAGE_PREFIX}-python-imagesize"
-             "${MINGW_PACKAGE_PREFIX}-python-iniconfig"
-             "${MINGW_PACKAGE_PREFIX}-python-packaging"
-             "${MINGW_PACKAGE_PREFIX}-python-pip"
-             "${MINGW_PACKAGE_PREFIX}-python-pluggy"
-             "${MINGW_PACKAGE_PREFIX}-python-py"
-             "${MINGW_PACKAGE_PREFIX}-python-pygments-github-lexers"
-             "${MINGW_PACKAGE_PREFIX}-python-pyparsing"
+              "${MINGW_PACKAGE_PREFIX}-python-pytest-cov")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-pygments-github-lexers"
              "${MINGW_PACKAGE_PREFIX}-python-pyproject2setuppy"
-             "${MINGW_PACKAGE_PREFIX}-python-pytest"
-             "${MINGW_PACKAGE_PREFIX}-python-pytest-cov"
-             "${MINGW_PACKAGE_PREFIX}-python-pytz"
-             "${MINGW_PACKAGE_PREFIX}-python-jinja"
-             "${MINGW_PACKAGE_PREFIX}-python-markupsafe"
-             "${MINGW_PACKAGE_PREFIX}-python-testpath"
-             "${MINGW_PACKAGE_PREFIX}-python-requests"
-             "${MINGW_PACKAGE_PREFIX}-python-responses"
-             "${MINGW_PACKAGE_PREFIX}-python-pytz"
-             "${MINGW_PACKAGE_PREFIX}-python-six"
-             "${MINGW_PACKAGE_PREFIX}-python-sphinx-alabaster-theme"
+             "${MINGW_PACKAGE_PREFIX}-python-sphinx"
              "${MINGW_PACKAGE_PREFIX}-python-sphinx_rtd_theme"
-             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-applehelp"
-             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-devhelp"
-             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-github-alt"
-             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-htmlhelp"
-             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-jsmath" 
-             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-qthelp" 
-             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-serializinghtml" 
-             "${MINGW_PACKAGE_PREFIX}-python-six"             
-             "${MINGW_PACKAGE_PREFIX}-python-snowballstemmer"            
-             "${MINGW_PACKAGE_PREFIX}-python-tomli"
-             "${MINGW_PACKAGE_PREFIX}-python-tomli-w"
-             "${MINGW_PACKAGE_PREFIX}-python-urllib3")           
-source=("${_realname}-$pkgver.tar.gz::$url/archive/$pkgver.tar.gz")
+             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-github-alt")           
+source=("${_realname}-$pkgver.tar.gz"::"$url/archive/$pkgver.tar.gz")
 sha512sums=('76a713df9a85e686b5a9516b01b02779ce9e62e5bb189724d4fb62c42324ce1607d9de334c1fa88e95a10089aebba804fac0214fcbed0c47b8fc057732d63339')
 
 prepare() {
@@ -78,9 +38,6 @@ prepare() {
   if [[ -f tests/test_sdist.py ]];then
     rm -f tests/test_sdist.py
   fi
-  msg "flit_core bootstrap"
-  ${MINGW_PREFIX}/bin/python bootstrap_dev.py
- 
 }
 
 build() {

--- a/mingw-w64-python-flit/PKGBUILD
+++ b/mingw-w64-python-flit/PKGBUILD
@@ -7,6 +7,7 @@ pkgver=3.5.1
 pkgrel=1
 pkgdesc='Simplified packaging of Python modules (mingw-w64)'
 arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url='https://github.com/takluyver/flit'
 license=('BSD')
 depends=("${MINGW_PACKAGE_PREFIX}-python" 
@@ -149,6 +150,7 @@ package_python-flit-core() {
     sed -e "s|$srcdir||g" -i {} \;
 }
 
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
 for _name in "${pkgname[@]}"; do
   _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
   _func="$(declare -f "${_short}")"

--- a/mingw-w64-python-flit/PKGBUILD
+++ b/mingw-w64-python-flit/PKGBUILD
@@ -2,7 +2,6 @@
 
 _realname=flit
 pkgbase=mingw-w64-python-${_realname}
-pkgbase=${MINGW_PACKAGE_PREFIX}-python-$_realname
 pkgname=(${MINGW_PACKAGE_PREFIX}-python-$_realname{,-core})
 pkgver=3.5.1
 pkgrel=1

--- a/mingw-w64-python-flit/PKGBUILD
+++ b/mingw-w64-python-flit/PKGBUILD
@@ -1,89 +1,158 @@
-# Maintainer: Naveen M K <naveen521kk@gmail.com>
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
 
-_pyname=flit
 _realname=flit
 pkgbase=mingw-w64-python-${_realname}
-pkgname=(
-    "${MINGW_PACKAGE_PREFIX}-python-${_realname}"
-    "${MINGW_PACKAGE_PREFIX}-python-${_realname}-core"
-)
-pkgver=3.2.0
-pkgrel=2
+pkgbase=${MINGW_PACKAGE_PREFIX}-python-$_realname
+pkgname=(${MINGW_PACKAGE_PREFIX}-python-$_realname{,-core})
+pkgver=3.5.1
+pkgrel=1
 pkgdesc='Simplified packaging of Python modules (mingw-w64)'
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
-url="https://github.com/takluyver/flit"
+url='https://github.com/takluyver/flit'
 license=('BSD')
-depends=(
-  "${MINGW_PACKAGE_PREFIX}-python"
-  "${MINGW_PACKAGE_PREFIX}-python-toml"
-)
-makedepends=(
-  "${MINGW_PACKAGE_PREFIX}-python-build"
-  "${MINGW_PACKAGE_PREFIX}-python-pip"
-)
-source=("$pkgbase-$pkgver.tar.gz::$url/archive/$pkgver.tar.gz")
-sha512sums=('b40768fb4b0b2a2e3116ac790dfa629da5a57cda34b10abb8ce6a8febcc3436795d5122dcfa3db2c6d07d493f00391d2ca7300112561c8ff2a0b04d77c879662')
+depends=("${MINGW_PACKAGE_PREFIX}-python" 
+        "${MINGW_PACKAGE_PREFIX}-python-tomli"
+        "${MINGW_PACKAGE_PREFIX}-python-tomli-w")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-requests"
+              "${MINGW_PACKAGE_PREFIX}-python-coverage"
+              "${MINGW_PACKAGE_PREFIX}-python-docutils"
+              "${MINGW_PACKAGE_PREFIX}-python-testpath"
+              "${MINGW_PACKAGE_PREFIX}-python-pytest"
+             "${MINGW_PACKAGE_PREFIX}-python-pytest-cov"
+              )
+makedepends=("${MINGW_PACKAGE_PREFIX}-python"
+             "${MINGW_PACKAGE_PREFIX}-python-atomicwrites"
+             "${MINGW_PACKAGE_PREFIX}-python-attrs"
+             "${MINGW_PACKAGE_PREFIX}-python-babel"
+             "${MINGW_PACKAGE_PREFIX}-python-certifi"
+             "${MINGW_PACKAGE_PREFIX}-python-chardet"
+             "${MINGW_PACKAGE_PREFIX}-python-colorama"             
+             "${MINGW_PACKAGE_PREFIX}-python-coverage"
+             "${MINGW_PACKAGE_PREFIX}-python-docutils"
+             "${MINGW_PACKAGE_PREFIX}-python-idna"
+             "${MINGW_PACKAGE_PREFIX}-python-imagesize"
+             "${MINGW_PACKAGE_PREFIX}-python-iniconfig"
+             "${MINGW_PACKAGE_PREFIX}-python-packaging"
+             "${MINGW_PACKAGE_PREFIX}-python-pip"
+             "${MINGW_PACKAGE_PREFIX}-python-pluggy"
+             "${MINGW_PACKAGE_PREFIX}-python-py"
+             "${MINGW_PACKAGE_PREFIX}-python-pygments-github-lexers"
+             "${MINGW_PACKAGE_PREFIX}-python-pyparsing"
+             "${MINGW_PACKAGE_PREFIX}-python-pyproject2setuppy"
+             "${MINGW_PACKAGE_PREFIX}-python-pytest"
+             "${MINGW_PACKAGE_PREFIX}-python-pytest-cov"
+             "${MINGW_PACKAGE_PREFIX}-python-pytz"
+             "${MINGW_PACKAGE_PREFIX}-python-jinja"
+             "${MINGW_PACKAGE_PREFIX}-python-markupsafe"
+             "${MINGW_PACKAGE_PREFIX}-python-testpath"
+             "${MINGW_PACKAGE_PREFIX}-python-requests"
+             "${MINGW_PACKAGE_PREFIX}-python-responses"
+             "${MINGW_PACKAGE_PREFIX}-python-pytz"
+             "${MINGW_PACKAGE_PREFIX}-python-six"
+             "${MINGW_PACKAGE_PREFIX}-python-sphinx-alabaster-theme"
+             "${MINGW_PACKAGE_PREFIX}-python-sphinx_rtd_theme"
+             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-applehelp"
+             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-devhelp"
+             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-github-alt"
+             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-htmlhelp"
+             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-jsmath" 
+             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-qthelp" 
+             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-serializinghtml" 
+             "${MINGW_PACKAGE_PREFIX}-python-six"             
+             "${MINGW_PACKAGE_PREFIX}-python-snowballstemmer"            
+             "${MINGW_PACKAGE_PREFIX}-python-tomli"
+             "${MINGW_PACKAGE_PREFIX}-python-tomli-w"
+             "${MINGW_PACKAGE_PREFIX}-python-urllib3")           
+source=("${_realname}-$pkgver.tar.gz::$url/archive/$pkgver.tar.gz")
+sha512sums=('76a713df9a85e686b5a9516b01b02779ce9e62e5bb189724d4fb62c42324ce1607d9de334c1fa88e95a10089aebba804fac0214fcbed0c47b8fc057732d63339')
 
 prepare() {
-  cd "$srcdir"
-  rm -rf python-build-${CARCH} | true
-  cp -r "${_pyname//_/-}-$pkgver" "python-build-${CARCH}"
+
+ rm -rf python-build-${MSYSTEM} || true
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
+
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}
+
+  cd "${srcdir}/python-build-${MSYSTEM}"
+  if [[ -f tests/test_sdist.py ]];then
+    rm -f tests/test_sdist.py
+  fi
+  msg "flit_core bootstrap"
+  ${MINGW_PREFIX}/bin/python bootstrap_dev.py
+ 
 }
 
 build() {
-  cd "${srcdir}/python-build-${CARCH}/flit_core"
-  ${MINGW_PREFIX}/bin/python -m build . -x -n -w
+  cd "${srcdir}/python-build-${MSYSTEM}/flit_core"
+  msg "Build flit_core"
+  ${MINGW_PREFIX}/bin/python -m pyproject2setuppy.main build
+  
+  cd "${srcdir}/python-build-${MSYSTEM}"
+  msg "Build flit"
+  PYTHONPATH=flit_core ${MINGW_PREFIX}/bin/python -m pyproject2setuppy.main build
+  cd doc
+  make dirhtml man
+}
 
-  cd "${srcdir}/python-build-${CARCH}"
-  PYTHONPATH=flit_core  ${MINGW_PREFIX}/bin/python -m build . -x -n -w  
-  cp flit_core/dist/*.whl dist/
+check() {
+  cd "${srcdir}/python-build-${MSYSTEM}"
+# 9 failed, 172 passed, 5 skipped, 1 warning in 13.73s  
+  PYTHONPATH=flit_core ${MINGW_PREFIX}/bin/python -m pytest  --cov=flit --cov=flit_core/flit_core || true
 }
 
 package_python-flit() {
-  depends+=(
-    "${MINGW_PACKAGE_PREFIX}-python-flit-core"
-    "${MINGW_PACKAGE_PREFIX}-python-requests" 
-    "${MINGW_PACKAGE_PREFIX}-python-docutils"
-  ) 
+  pkgdesc+=' (mingw-w64)'
+  depends+=("${MINGW_PACKAGE_PREFIX}-python-flit-core"
+            "${MINGW_PACKAGE_PREFIX}-python-requests"
+            "${MINGW_PACKAGE_PREFIX}-python-docutils")
 
-  cd "${srcdir}/python-build-${CARCH}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  ${MINGW_PREFIX}/bin/python -m pip install dist/flit-${pkgver}-py3-none-any.whl \
-    --compile \
-    --no-deps \
-    --no-warn-script-location \
-    --ignore-installed \
-    --prefix=${MINGW_PREFIX} \
-    --root="${pkgdir}"
-
-  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+  PYTHONPATH=flit_core \
+   ${MINGW_PREFIX}/bin/python -m pyproject2setuppy.main install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build  
+  
+  install -Dm 644 LICENSE "$pkgdir${MINGW_PREFIX}"/share/licenses/${_realname}/LICENSE
+  
+  mkdir -p "$pkgdir${MINGW_PREFIX}"/share/doc/${_realname}
+  cp -r doc/_build/dirhtml/* "$pkgdir${MINGW_PREFIX}"/share/doc/${_realname}
+  
+  mkdir -p "$pkgdir${MINGW_PREFIX}"/share/man/man1
+  cp -r doc/_build/man/*.1 "$pkgdir${MINGW_PREFIX}"/share/man/man1
+  
+  # remove shebang line
+  
+  for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*-script.py; do
+    sed -e '1 { s/^#!.*$// }' -i ${_f}
+  done
+ 
+  find "$pkgdir" -name "*.json" -exec \
+    sed -e "s|$srcdir||g" -i {} \;  
 }
-
 
 package_python-flit-core() {
-  pkgdesc+='Simplified packaging of Python modules (core backend) (mingw-w64)'
-  
-  cd "${srcdir}/python-build-${CARCH}"
-  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  ${MINGW_PREFIX}/bin/python -m pip install dist/flit_core-${pkgver}-py3-none-any.whl \
-    --compile \
-    --no-deps \
-    --no-warn-script-location \
-    --ignore-installed \
-    --prefix=${MINGW_PREFIX} \
-    --root="${pkgdir}"
+  pkgdesc+=' (core backend) (mingw-w64)'
 
-  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}-core/LICENSE"
+  cd "${srcdir}/python-build-${MSYSTEM}/flit_core"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    ${MINGW_PREFIX}/bin/python -m pyproject2setuppy.main install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build  
+  
+  install -Dm 644 ../LICENSE "$pkgdir${MINGW_PREFIX}"/share/licenses/${_realname}-core/LICENSE
+
+  # installing tests to a subdir of your project might not conflict the toplevel, but
+  # don't do it anyway...
+  rm -rf "$pkgdir"${MINGW_PREFIX}/lib/python*/site-packages/flit_core/tests/
+  
+  find "$pkgdir" -name "*.json" -exec \
+    sed -e "s|$srcdir||g" -i {} \;
 }
 
-# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
-# vim: set ft=bash :
-
-# generate wrappers
 for _name in "${pkgname[@]}"; do
   _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
   _func="$(declare -f "${_short}")"
   eval "${_func/#${_short}/package_${_name}}"
 done
-# template end;
+

--- a/mingw-w64-python-flit/PKGBUILD
+++ b/mingw-w64-python-flit/PKGBUILD
@@ -113,4 +113,4 @@ for _name in "${pkgname[@]}"; do
   _func="$(declare -f "${_short}")"
   eval "${_func/#${_short}/package_${_name}}"
 done
-
+# template end;

--- a/mingw-w64-python-py/PKGBUILD
+++ b/mingw-w64-python-py/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=py
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=1.10.0
-pkgrel=2
+pkgver=1.11.0
+pkgrel=1
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}=${pkgver}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
@@ -21,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools"
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
 options=('staticlibs' 'strip' '!debug')
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/pytest-dev/py/archive/${pkgver}.tar.gz")
-sha256sums=('72620e8d9b28f85f475e833de86a3f4fd1aab21ea883e2ea5f2be55d8bc31f9e')
+sha256sums=('73845c6278da21cebd41d90e363da84aa93e9dd3485d00f7ced540fedbd41054')
 
 prepare() {
   cd "${srcdir}"

--- a/mingw-w64-python-pygments-github-lexers/LICENSE
+++ b/mingw-w64-python-pygments-github-lexers/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2013, liluo
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+  Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/mingw-w64-python-pygments-github-lexers/PKGBUILD
+++ b/mingw-w64-python-pygments-github-lexers/PKGBUILD
@@ -1,0 +1,44 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_realname=pygments-github-lexers
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=0.0.5
+pkgrel=1
+pkgdesc="Pygments Github custom lexers. (mingw-w64)"
+arch=('any')
+url='https://github.com/liluo/pygments-github-lexers'
+license=('BSD')
+depends=("${MINGW_PACKAGE_PREFIX}-python" 
+         "${MINGW_PACKAGE_PREFIX}-python-pygments")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
+        "LICENSE")
+sha256sums=('aaca57e77cd6fcfce8d6ee97a998962eebf7fbb810519a8ebde427c62823e133'
+            '6593a71d433e2e4c9ef686c7ed0803faa661124ef3b50a0bac7e829034666c2f')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  ## (OPTIONAL) Only if setuptools-scm is used
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}
+}
+
+build() {
+  cd "${srcdir}"
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  "${MINGW_PREFIX}"/bin/python setup.py build
+}
+
+package() {
+  cd "${srcdir}/python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    "${MINGW_PREFIX}"/bin/python setup.py install --prefix="${MINGW_PREFIX}" \
+      --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 ${srcdir}/LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}

--- a/mingw-w64-python-pygments-github-lexers/PKGBUILD
+++ b/mingw-w64-python-pygments-github-lexers/PKGBUILD
@@ -7,6 +7,7 @@ pkgver=0.0.5
 pkgrel=1
 pkgdesc="Pygments Github custom lexers. (mingw-w64)"
 arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url='https://github.com/liluo/pygments-github-lexers'
 license=('BSD')
 depends=("${MINGW_PACKAGE_PREFIX}-python" 

--- a/mingw-w64-python-sphinxcontrib-github-alt/PKGBUILD
+++ b/mingw-w64-python-sphinxcontrib-github-alt/PKGBUILD
@@ -1,0 +1,80 @@
+# Maintainer: Some One <some.one@some.email.com>
+#
+# https://github.com/jupyter/sphinxcontrib_github_alt/archive/refs/tags/1.2.tar.gz
+#
+_realname=sphinxcontrib-github-alt
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=1.2
+pkgrel=1
+pkgdesc="Link to GitHub issues, pull requests, commits and users from Sphinx docs. (mingw-w64)"
+arch=('any')
+url='https://github.com/jupyter/sphinxcontrib_github_alt'
+license=('BSD')
+depends=("${MINGW_PACKAGE_PREFIX}-python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python"
+             "${MINGW_PACKAGE_PREFIX}-python-alabaster"
+             "${MINGW_PACKAGE_PREFIX}-python-atomicwrites"
+             "${MINGW_PACKAGE_PREFIX}-python-babel"
+             "${MINGW_PACKAGE_PREFIX}-python-coverage"
+             "${MINGW_PACKAGE_PREFIX}-python-docutils"
+             "${MINGW_PACKAGE_PREFIX}-python-imagesize"
+             "${MINGW_PACKAGE_PREFIX}-python-pluggy"
+             "${MINGW_PACKAGE_PREFIX}-python-py"
+             "${MINGW_PACKAGE_PREFIX}-python-pygments-github-lexers"
+             "${MINGW_PACKAGE_PREFIX}-python-pyparsing"
+             "${MINGW_PACKAGE_PREFIX}-python-pyproject2setuppy"
+             "${MINGW_PACKAGE_PREFIX}-python-pytest"
+             "${MINGW_PACKAGE_PREFIX}-python-pytest-cov"
+             "${MINGW_PACKAGE_PREFIX}-python-jinja2"
+             "${MINGW_PACKAGE_PREFIX}-python-markupsafe"
+             "${MINGW_PACKAGE_PREFIX}-python-testpath"
+             "${MINGW_PACKAGE_PREFIX}-python-requests"
+             "${MINGW_PACKAGE_PREFIX}-python-pytz"
+             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-applehelp"
+             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-devhelp"
+             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-github-alt"
+             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-htmlhelp"
+             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-jsmath" 
+             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-qthelp" 
+             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-serializinghtml" 
+             "${MINGW_PACKAGE_PREFIX}-python-six"             
+             "${MINGW_PACKAGE_PREFIX}-python-snowballstemmer"
+             
+
+             "${MINGW_PACKAGE_PREFIX}-python-tomli"
+             "${MINGW_PACKAGE_PREFIX}-python-tomli-w"
+
+            )
+source=("${_realname}-${pkgver}.tar.gz"::"$url/archive/refs/tags/${pkgver}.tar.gz")
+sha256sums=('7a85ad988f7b7cdc230d58854c31acab1308a75016b9c453bf76bfc0598cbbac')
+
+prepare() {
+  cd "${srcdir}/${_realname//-/_}-${pkgver}"
+  ## (OPTIONAL) Only if setuptools-scm is used
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}
+}
+
+build() {
+  cd "${srcdir}"
+  cp -r "${_realname//-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  "${MINGW_PREFIX}"/bin/python -m pyproject2setuppy.main build
+}
+
+check() {
+  cd "${srcdir}/python-build-${MSYSTEM}"
+
+  "${MINGW_PREFIX}"/bin/python -m pyproject2setuppy.main check
+}
+
+package() {
+  cd "${srcdir}/python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    "${MINGW_PREFIX}"/bin/python  -m pyproject2setuppy.main install --prefix="${MINGW_PREFIX}" \
+      --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 COPYING.md "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}

--- a/mingw-w64-python-sphinxcontrib-github-alt/PKGBUILD
+++ b/mingw-w64-python-sphinxcontrib-github-alt/PKGBUILD
@@ -1,7 +1,5 @@
-# Maintainer: Some One <some.one@some.email.com>
-#
-# https://github.com/jupyter/sphinxcontrib_github_alt/archive/refs/tags/1.2.tar.gz
-#
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
 _realname=sphinxcontrib-github-alt
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
@@ -9,43 +7,13 @@ pkgver=1.2
 pkgrel=1
 pkgdesc="Link to GitHub issues, pull requests, commits and users from Sphinx docs. (mingw-w64)"
 arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url='https://github.com/jupyter/sphinxcontrib_github_alt'
 license=('BSD')
-depends=("${MINGW_PACKAGE_PREFIX}-python")
-makedepends=("${MINGW_PACKAGE_PREFIX}-python"
-             "${MINGW_PACKAGE_PREFIX}-python-alabaster"
-             "${MINGW_PACKAGE_PREFIX}-python-atomicwrites"
-             "${MINGW_PACKAGE_PREFIX}-python-babel"
-             "${MINGW_PACKAGE_PREFIX}-python-coverage"
-             "${MINGW_PACKAGE_PREFIX}-python-docutils"
-             "${MINGW_PACKAGE_PREFIX}-python-imagesize"
-             "${MINGW_PACKAGE_PREFIX}-python-pluggy"
-             "${MINGW_PACKAGE_PREFIX}-python-py"
-             "${MINGW_PACKAGE_PREFIX}-python-pygments-github-lexers"
-             "${MINGW_PACKAGE_PREFIX}-python-pyparsing"
-             "${MINGW_PACKAGE_PREFIX}-python-pyproject2setuppy"
-             "${MINGW_PACKAGE_PREFIX}-python-pytest"
-             "${MINGW_PACKAGE_PREFIX}-python-pytest-cov"
-             "${MINGW_PACKAGE_PREFIX}-python-jinja2"
-             "${MINGW_PACKAGE_PREFIX}-python-markupsafe"
-             "${MINGW_PACKAGE_PREFIX}-python-testpath"
-             "${MINGW_PACKAGE_PREFIX}-python-requests"
-             "${MINGW_PACKAGE_PREFIX}-python-pytz"
-             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-applehelp"
-             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-devhelp"
-             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-github-alt"
-             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-htmlhelp"
-             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-jsmath" 
-             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-qthelp" 
-             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-serializinghtml" 
-             "${MINGW_PACKAGE_PREFIX}-python-six"             
-             "${MINGW_PACKAGE_PREFIX}-python-snowballstemmer"
-             
-
-             "${MINGW_PACKAGE_PREFIX}-python-tomli"
-             "${MINGW_PACKAGE_PREFIX}-python-tomli-w"
-
-            )
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-docutils"
+         "${MINGW_PACKAGE_PREFIX}-python-sphinx")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-pyproject2setuppy")
 source=("${_realname}-${pkgver}.tar.gz"::"$url/archive/refs/tags/${pkgver}.tar.gz")
 sha256sums=('7a85ad988f7b7cdc230d58854c31acab1308a75016b9c453bf76bfc0598cbbac')
 
@@ -61,12 +29,6 @@ build() {
   cp -r "${_realname//-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
 
   "${MINGW_PREFIX}"/bin/python -m pyproject2setuppy.main build
-}
-
-check() {
-  cd "${srcdir}/python-build-${MSYSTEM}"
-
-  "${MINGW_PREFIX}"/bin/python -m pyproject2setuppy.main check
 }
 
 package() {


### PR DESCRIPTION
*) Use pyproject2setppy to compile flit
*) include documentation in dirhtml form and in man form
*) List all packages that were listed when I ran a bootstrap stcript
*) Upgrade python-py
*) Add new packages,  mingw-w64-python-pygments-github-lexers and mingw-w64-python-sphinxcontrib-github-alt to for syntax-highlighting in documentation