### PR TITLE
slim-simulator: update mingw_arch (eliminate 32-bit). Also update source sha256sums.

### DIFF
--- a/mingw-w64-slim-simulator/PKGBUILD
+++ b/mingw-w64-slim-simulator/PKGBUILD
@@ -2,17 +2,17 @@ _realname=slim-simulator
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.7
-pkgrel=1
+pkgrel=2
 pkgdesc="SLiM forward simulation software package for population genetics (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw64' 'ucrt64' 'clang64')
 url="https://messerlab.org/slim/"
 license=("GPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake")
 depends=("${MINGW_PACKAGE_PREFIX}-qt5-base")
 source=("http://benhaller.com/slim/SLiM_pacman.tar.gz" )
-sha256sums=("003f095120595b2a206fc2d7a451e2189a56639ae7b85a070b76c4ce13def391")
+sha256sums=("5f9c83709666dc0d367b6d8f04e0c42faa1e1b0e0ea549ae6124046f076754ff")
 
 build() {
   mkdir -p "${srcdir}/build-${MINGW_CHOST}"


### PR DESCRIPTION
The source got updated for slim-simulator so I'd like to trigger a rebuild (BTW is there a way to do this automatically without a PR?). I've updated the sha256sums. Also, the developer has informed me that 32-bit builds are not supported so I've removed them from the mingw_arch vector.