### PR TITLE
wslay: build with cmake and ninja

### DIFF
--- a/mingw-w64-wslay/010-winsock.patch
+++ b/mingw-w64-wslay/010-winsock.patch
@@ -1,0 +1,21 @@
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -53,6 +53,9 @@ foreach(target ${WSLAY_TARGETS})
+ 		$<BUILD_INTERFACE:${GEN_INCLUDE_DIR}>
+ 		$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+ 	target_compile_definitions(${target} PRIVATE "HAVE_CONFIG_H")
++	if(HAVE_WINSOCK2_H)
++		target_link_libraries(${target} PRIVATE ws2_32)
++	endif()
+ endforeach()
+ 
+ # install
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -46,5 +46,6 @@ add_executable(wslay_tests ${SOURCES} ${HEADERS}
+ target_include_directories(wslay_tests PRIVATE ${WSLAY_DIR} ${WSLAY_INCLUDE_DIRS} ${CUNIT_INCLUDE_DIRS})
+ target_compile_definitions(wslay_tests PRIVATE ${WSLAY_COMPILE_DEFINITIONS})
+ target_link_libraries(wslay_tests ${CUNIT_LIBRARIES})
++target_link_libraries(wslay_tests ws2_32)
+ add_dependencies(wslay_tests ${WSLAY_TARGET})
+ add_test(NAME wslay_tests COMMAND wslay_tests)

--- a/mingw-w64-wslay/PKGBUILD
+++ b/mingw-w64-wslay/PKGBUILD
@@ -5,46 +5,53 @@ _realname=wslay
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.1.1
-pkgrel=1
+pkgrel=2
 pkgdesc="The WebSocket library in C (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://github.com/tatsuhiro-t/wslay"
 license=("custom")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
-makedepends=("${MINGW_PACKAGE_PREFIX}-cunit"
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-cunit"
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-nettle"
-             "${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-python-sphinx")
 options=('staticlibs' 'strip')
-source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/tatsuhiro-t/wslay/archive/release-${pkgver}.tar.gz")
-sha256sums=('7b9f4b9df09adaa6e07ec309b68ab376c0db2cfd916613023b52a47adfda224a')
+source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/tatsuhiro-t/wslay/archive/release-${pkgver}.tar.gz"
+        "010-winsock.patch")
+sha256sums=('7b9f4b9df09adaa6e07ec309b68ab376c0db2cfd916613023b52a47adfda224a'
+            '5f79f8203be2be1a7963a3671e8d6a416538779e7d53af220845a21a90de3bc5')
 
 prepare() {
   cd "${srcdir}/${_realname}-release-${pkgver}"
-  autoreconf -fiv
+  patch -p1 -i ${srcdir}/010-winsock.patch
 }
 
 build() {
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
   mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
 
-  ../${_realname}-release-${pkgver}/configure \
-    --prefix=${MINGW_PREFIX} \
-    --build=${MINGW_CHOST} \
-    --host=${MINGW_CHOST}
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake.exe \
+      -G"Ninja" \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      -DCMAKE_BUILD_TYPE="Release" \
+      -DWSLAY_SHARED="ON" \
+      -DWSLAY_STATIC="ON" \
+      -DWSLAY_TESTS="ON" \
+      ../${_realname}-release-${pkgver}
 
-  # WARNING: Dirty hack due to absence of conf.py in source directory.
-  #          As it is required by python-sphinx to build man pages.
+  ${MINGW_PREFIX}/bin/cmake.exe --build ./
+}
 
-  cp "${srcdir}/build-${MINGW_CHOST}/doc/sphinx/conf.py" \
-  "${srcdir}/${_realname}-release-${pkgver}/doc/sphinx/conf.py"
-
-  make
+check() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  PATH=$PWD/src:$PATH ${MINGW_PREFIX}/bin/ctest.exe ./ || true
 }
 
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
-  make DESTDIR="${pkgdir}" install
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install .
 }


### PR DESCRIPTION
Faster and more reliable.

Added check() section.

Added patch to fix compilation with cmake.

Signed-off-by: Rosen Penev <rosenp@gmail.com>