### PR TITLE
mingw-w64-libmicrohttpd: update to 0.9.74

### DIFF
--- a/mingw-w64-libmicrohttpd/PKGBUILD
+++ b/mingw-w64-libmicrohttpd/PKGBUILD
@@ -6,37 +6,25 @@
 _realname=libmicrohttpd
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.9.72
-pkgrel=4
+pkgver=0.9.74
+pkgrel=1
 pkgdesc="GNU libmicrohttpd is a small C library that is supposed to make it easy to run an HTTP server as part of another application (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://www.gnu.org/software/libmicrohttpd"
 license=("LGPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-curl")
 depends=("${MINGW_PACKAGE_PREFIX}-gnutls")
-source=("https://ftp.gnu.org/gnu/libmicrohttpd/${_realname}-${pkgver}.tar.gz"{,.sig}
-        "010-as.patch::https://git.gnunet.org/libmicrohttpd.git/patch/?id=21be8eccb987b6d5fe05d3827ff97c23b8e630cc"
-        "020-fix-exp.patch::https://git.gnunet.org/libmicrohttpd.git/patch/?id=de383203d4d7921bf331510bc898ab88c5844731"
-        "030-correction.patch::https://git.gnunet.org/libmicrohttpd.git/patch/?id=2cd73a76cb18d2760d3802709b56e7598a5e651f")
+source=("https://ftp.gnu.org/gnu/libmicrohttpd/${_realname}-${pkgver}.tar.gz"{,.sig})
 validpgpkeys=('D8423BCB326C7907033929C7939E6BE1E29FC3CC'  # Christian Grothoff <christian@grothoff.org>
               'EA812DBEFA5A7EF17DA8F2C1460A317C3326D2AE') # Karlson2k (Evgeny Grin) <k2k@narod.ru>
-sha256sums=('0ae825f8e0d7f41201fd44a0df1cf454c1cb0bc50fe9d59c26552260264c2ff8'
-            'SKIP'
-            'ed07c0ca89c44523f1efa9fe21b02e0b0cf2851f6ec151eee4e33eb67cc12b41'
-            '247addd1fda8a275eb5c68b4d0ee19aae6351636735af8babb091fd4a62945d3'
-            'a5239dfb89b1e441c13fd0571911771cd40f1b88e8a1ef869eadaeb58ea56fe1')
+sha256sums=('42035d0261373324bfb434018f4ab892514b10253d1af232e41b4cc2c11e650b'
+            'SKIP')
 
 prepare() {
   cd ${_realname}-${pkgver}
-  patch -p1 -i ${srcdir}/010-as.patch
-  patch -p1 -i ${srcdir}/020-fix-exp.patch
-  patch -p1 -i ${srcdir}/030-correction.patch
-  # autoreconf to get updated libtool files with clang support
-  autoreconf -fiv
 }
 
 build() {
@@ -50,7 +38,6 @@ build() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
   mkdir -p ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
   ../${_realname}-${pkgver}/configure \
-    CPPFLAGS="${CPPFLAGS} -D_WIN32_WINNT=0x0601" \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
@@ -65,8 +52,7 @@ build() {
 
 check() {
   cd "${srcdir}/build-${MINGW_CHOST}"
-  cd src/microhttpd/ # Run only basic tests until curl fix crash in curl_global_cleanup ()
-  make -j1 check
+  make -j4 check
 }
 
 package() {


### PR DESCRIPTION
* Removed patches (integrated upstream)
* Enabled full testing (curl was fixed many versions ago)
* Upstream defaults to Vista+, no need for CPPFLAGS