### PR TITLE
MinHook: fix dlltool usage

### DIFF
--- a/mingw-w64-MinHook/010-dlltool.patch
+++ b/mingw-w64-MinHook/010-dlltool.patch
@@ -1,0 +1,11 @@
+--- a/build/MinGW/Makefile
++++ b/build/MinGW/Makefile
+@@ -17,7 +17,7 @@ all: MinHook.dll libMinHook.dll.a libMinHook.a
+ libMinHook.a: $(OBJS)
+ 	$(AR) r $@ $^
+ libMinHook.dll.a: MinHook.dll dll_resources/MinHook.def
+-	$(DLLTOOL) --dllname MinHook.dll --def dll_resources/MinHook.def --output-lib $@
++	$(DLLTOOL) -D MinHook.dll -d dll_resources/MinHook.def -l $@
+ MinHook.dll: $(OBJS) dll_resources/MinHook.res dll_resources/MinHook.def
+ 	$(CCLD) -o $@ -shared $(LDFLAGS) $^
+ 

--- a/mingw-w64-MinHook/PKGBUILD
+++ b/mingw-w64-MinHook/PKGBUILD
@@ -4,16 +4,23 @@ _realname=MinHook
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.3.3
-pkgrel=1
+pkgrel=2
 pkgdesc="The Minimalistic x86/x64 API Hooking Library for Windows (mingw-w64)"
 url="https://github.com/TsudaKageyu/minhook"
 license=('BSD')
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 options=('staticlibs' '!libtool')
-source=(${_realname}-${pkgver}.tar.g::"https://github.com/TsudaKageyu/${_realname}/archive/v${pkgver}.tar.gz")
-sha256sums=('5bec16358ec9086d4593124bf558635e89135abea2c76e5761ecaf09f4546b19')
+source=(${_realname}-${pkgver}.tar.g::"https://github.com/TsudaKageyu/${_realname}/archive/v${pkgver}.tar.gz"
+        010-dlltool.patch)
+sha256sums=('5bec16358ec9086d4593124bf558635e89135abea2c76e5761ecaf09f4546b19'
+            '535b782019d27ea80b76546ae43d7b7386ef54de70eec5852655a8c7ad3be20c')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -p1 -i "${srcdir}/010-dlltool.patch"
+}
 
 build() {
   cd "${srcdir}/${_realname}-${pkgver}"


### PR DESCRIPTION
llvm-dlltool doesn't support the full versions of these options.

Also added clang32 (which this was tested on) and clangarm64.

Signed-off-by: Rosen Penev <rosenp@gmail.com>