### PR TITLE
silc-toolkit: remove unsupported compiler flag

### DIFF
--- a/mingw-w64-geany/0003-export.patch
+++ b/mingw-w64-geany/0003-export.patch
@@ -1,0 +1,1130 @@
+diff --git a/scintilla/gtk/ScintillaGTK.cxx b/scintilla/gtk/ScintillaGTK.cxx
+index 659eb763..f252efa7 100644
+--- a/scintilla/gtk/ScintillaGTK.cxx
++++ b/scintilla/gtk/ScintillaGTK.cxx
+@@ -3008,13 +3008,11 @@ sptr_t ScintillaGTK::DirectFunction(
+ }
+ 
+ /* legacy name for scintilla_object_send_message */
+-GEANY_API_SYMBOL
+ sptr_t scintilla_send_message(ScintillaObject *sci, unsigned int iMessage, uptr_t wParam, sptr_t lParam) {
+ 	ScintillaGTK *psci = static_cast<ScintillaGTK *>(sci->pscin);
+ 	return psci->WndProc(iMessage, wParam, lParam);
+ }
+ 
+-GEANY_API_SYMBOL
+ gintptr scintilla_object_send_message(ScintillaObject *sci, unsigned int iMessage, uptr_t wParam, sptr_t lParam) {
+ 	return scintilla_send_message(sci, iMessage, wParam, lParam);
+ }
+@@ -3026,7 +3024,6 @@ extern void Platform_Initialise();
+ extern void Platform_Finalise();
+ 
+ /* legacy name for scintilla_object_get_type */
+-GEANY_API_SYMBOL
+ GType scintilla_get_type() {
+ 	static GType scintilla_type = 0;
+ 	try {
+@@ -3056,7 +3053,6 @@ GType scintilla_get_type() {
+ 	return scintilla_type;
+ }
+ 
+-GEANY_API_SYMBOL
+ GType scintilla_object_get_type() {
+ 	return scintilla_get_type();
+ }
+@@ -3162,7 +3158,6 @@ static void scintilla_init(ScintillaObject *sci) {
+ }
+ 
+ /* legacy name for scintilla_object_new */
+-GEANY_API_SYMBOL
+ GtkWidget *scintilla_new() {
+ 	GtkWidget *widget = GTK_WIDGET(g_object_new(scintilla_get_type(), nullptr));
+ 	gtk_widget_set_direction(widget, GTK_TEXT_DIR_LTR);
+@@ -3170,7 +3165,6 @@ GtkWidget *scintilla_new() {
+ 	return widget;
+ }
+ 
+-GEANY_API_SYMBOL
+ GtkWidget *scintilla_object_new() {
+ 	return scintilla_new();
+ }
+@@ -3193,7 +3187,6 @@ void scintilla_release_resources(void) {
+ static void *copy_(void *src) { return src; }
+ static void free_(void *) { }
+ 
+-GEANY_API_SYMBOL
+ GType scnotification_get_type(void) {
+ 	static gsize type_id = 0;
+ 	if (g_once_init_enter(&type_id)) {
+diff --git a/scintilla/include/ScintillaWidget.h b/scintilla/include/ScintillaWidget.h
+index 1721f65d..b968f039 100644
+--- a/scintilla/include/ScintillaWidget.h
++++ b/scintilla/include/ScintillaWidget.h
+@@ -42,23 +42,23 @@ struct _ScintillaClass {
+ 	void (* notify) (ScintillaObject *sci, int id, SCNotification *scn);
+ };
+ 
+-GType		scintilla_object_get_type		(void);
+-GtkWidget*	scintilla_object_new			(void);
+-gintptr		scintilla_object_send_message	(ScintillaObject *sci, unsigned int iMessage, guintptr wParam, gintptr lParam);
++G_MODULE_EXPORT GType		scintilla_object_get_type		(void);
++G_MODULE_EXPORT GtkWidget*	scintilla_object_new			(void);
++G_MODULE_EXPORT gintptr		scintilla_object_send_message		(ScintillaObject *sci, unsigned int iMessage, guintptr wParam, gintptr lParam);
+ 
+ 
+-GType		scnotification_get_type			(void);
++G_MODULE_EXPORT GType		scnotification_get_type			(void);
+ #define SCINTILLA_TYPE_NOTIFICATION        (scnotification_get_type())
+ 
+ #ifndef G_IR_SCANNING
+ /* The legacy names confuse the g-ir-scanner program */
+ typedef struct _ScintillaClass  ScintillaClass;
+ 
+-GType		scintilla_get_type	(void);
+-GtkWidget*	scintilla_new		(void);
+-void		scintilla_set_id	(ScintillaObject *sci, uptr_t id);
+-sptr_t		scintilla_send_message	(ScintillaObject *sci,unsigned int iMessage, uptr_t wParam, sptr_t lParam);
+-void		scintilla_release_resources(void);
++G_MODULE_EXPORT GType			scintilla_get_type	(void);
++G_MODULE_EXPORT GtkWidget*		scintilla_new		(void);
++G_MODULE_EXPORT	void			scintilla_set_id	(ScintillaObject *sci, uptr_t id);
++G_MODULE_EXPORT sptr_t			scintilla_send_message	(ScintillaObject *sci,unsigned int iMessage, uptr_t wParam, sptr_t lParam);
++G_MODULE_EXPORT void			scintilla_release_resources(void);
+ #endif
+ 
+ #define SCINTILLA_NOTIFY "sci-notify"
+diff --git a/src/build.h b/src/build.h
+index f9d720d0..47a1a3b2 100644
+--- a/src/build.h
++++ b/src/build.h
+@@ -60,16 +60,21 @@ typedef enum GeanyBuildCmdEntries
+ 	GEANY_BC_CMDENTRIES_COUNT	/**< Count of entries */
+ } GeanyBuildCmdEntries;
+ 
++G_MODULE_EXPORT
+ void build_activate_menu_item(const GeanyBuildGroup grp, const guint cmd);
+ 
++G_MODULE_EXPORT
+ const gchar *build_get_current_menu_item(const GeanyBuildGroup grp, const guint cmd,
+                                          const GeanyBuildCmdEntries field);
+ 
++G_MODULE_EXPORT
+ void build_remove_menu_item(const GeanyBuildSource src, const GeanyBuildGroup grp, const gint cmd);
+ 
++G_MODULE_EXPORT
+ void build_set_menu_item(const GeanyBuildSource src, const GeanyBuildGroup grp,
+                          const guint cmd, const GeanyBuildCmdEntries field, const gchar *value);
+ 
++G_MODULE_EXPORT
+ guint build_get_group_count(const GeanyBuildGroup grp);
+ 
+ 
+diff --git a/src/dialogs.c b/src/dialogs.c
+index 5fe792e7..ea289462 100644
+--- a/src/dialogs.c
++++ b/src/dialogs.c
+@@ -663,7 +663,6 @@ static gboolean show_save_as_gtk(GeanyDocument *doc)
+  *
+  *  @return @c TRUE if the file was saved, otherwise @c FALSE.
+  **/
+-GEANY_API_SYMBOL
+ gboolean dialogs_show_save_as(void)
+ {
+ 	GeanyDocument *doc = document_get_current();
+@@ -725,7 +724,6 @@ static void show_msgbox_dialog(GtkWidget *dialog, GtkMessageType type, GtkWindow
+  *  @param text Printf()-style format string.
+  *  @param ... Arguments for the @a text format string.
+  **/
+-GEANY_API_SYMBOL
+ void dialogs_show_msgbox(GtkMessageType type, const gchar *text, ...)
+ {
+ #ifndef G_OS_WIN32
+diff --git a/src/dialogs.h b/src/dialogs.h
+index 90ffeb8d..41bbbd77 100644
+--- a/src/dialogs.h
++++ b/src/dialogs.h
+@@ -33,15 +33,20 @@
+ 
+ G_BEGIN_DECLS
+ 
++G_MODULE_EXPORT
+ gboolean dialogs_show_question(const gchar *text, ...) G_GNUC_PRINTF (1, 2);
+ 
++G_MODULE_EXPORT
+ void dialogs_show_msgbox(GtkMessageType type, const gchar *text, ...) G_GNUC_PRINTF (2, 3);
+ 
++G_MODULE_EXPORT
+ gboolean dialogs_show_save_as(void);
+ 
++G_MODULE_EXPORT
+ gboolean dialogs_show_input_numeric(const gchar *title, const gchar *label_text,
+ 	gdouble *value, gdouble min, gdouble max, gdouble step);
+ 
++G_MODULE_EXPORT
+ gchar *dialogs_show_input(const gchar *title, GtkWindow *parent,
+ 	const gchar *label_text, const gchar *default_text);
+ 
+diff --git a/src/document.h b/src/document.h
+index 4533d260..278997b3 100644
+--- a/src/document.h
++++ b/src/document.h
+@@ -72,6 +72,7 @@ GeanyFilePrefs;
+ 
+ 
+ #define GEANY_TYPE_DOCUMENT (document_get_type())
++G_MODULE_EXPORT
+ GType document_get_type (void);
+ 
+ /**
+@@ -171,56 +172,81 @@ GeanyDocument;
+ 	(G_LIKELY((doc)->file_name != NULL) ? ((doc)->file_name) : GEANY_STRING_UNTITLED)
+ 
+ 
++G_MODULE_EXPORT
+ GeanyDocument* document_new_file(const gchar *filename, GeanyFiletype *ft, const gchar *text);
+ 
++G_MODULE_EXPORT
+ GeanyDocument *document_get_current(void);
+ 
++G_MODULE_EXPORT
+ GeanyDocument *document_get_from_notebook_child(GtkWidget *page);
+ 
++G_MODULE_EXPORT
+ GeanyDocument* document_get_from_page(guint page_num);
+ 
++G_MODULE_EXPORT
+ GeanyDocument* document_find_by_filename(const gchar *utf8_filename);
+ 
++G_MODULE_EXPORT
+ GeanyDocument* document_find_by_real_path(const gchar *realname);
+ 
++G_MODULE_EXPORT
+ gboolean document_save_file(GeanyDocument *doc, gboolean force);
+ 
++G_MODULE_EXPORT
+ GeanyDocument* document_open_file(const gchar *locale_filename, gboolean readonly,
+ 		GeanyFiletype *ft, const gchar *forced_enc);
+ 
++G_MODULE_EXPORT
+ void document_open_files(const GSList *filenames, gboolean readonly, GeanyFiletype *ft,
+ 		const gchar *forced_enc);
+ 
++G_MODULE_EXPORT
+ gboolean document_remove_page(guint page_num);
+ 
++G_MODULE_EXPORT
+ gboolean document_reload_force(GeanyDocument *doc, const gchar *forced_enc);
+ 
++G_MODULE_EXPORT
+ void document_set_encoding(GeanyDocument *doc, const gchar *new_encoding);
+ 
++G_MODULE_EXPORT
+ void document_set_text_changed(GeanyDocument *doc, gboolean changed);
+ 
++G_MODULE_EXPORT
+ void document_set_filetype(GeanyDocument *doc, GeanyFiletype *type);
+ 
++G_MODULE_EXPORT
+ gboolean document_close(GeanyDocument *doc);
+ 
++G_MODULE_EXPORT
+ GeanyDocument *document_index(gint idx);
+ 
++G_MODULE_EXPORT
+ gboolean document_save_file_as(GeanyDocument *doc, const gchar *utf8_fname);
+ 
++G_MODULE_EXPORT
+ void document_rename_file(GeanyDocument *doc, const gchar *new_filename);
+ 
++G_MODULE_EXPORT
+ const GdkColor *document_get_status_color(GeanyDocument *doc);
+ 
++G_MODULE_EXPORT
+ gchar *document_get_basename_for_display(GeanyDocument *doc, gint length);
+ 
++G_MODULE_EXPORT
+ gint document_get_notebook_page(GeanyDocument *doc);
+ 
++G_MODULE_EXPORT
+ gint document_compare_by_display_name(gconstpointer a, gconstpointer b);
+ 
++G_MODULE_EXPORT
+ gint document_compare_by_tab_order(gconstpointer a, gconstpointer b);
+ 
++G_MODULE_EXPORT
+ gint document_compare_by_tab_order_reverse(gconstpointer a, gconstpointer b);
+ 
++G_MODULE_EXPORT
+ GeanyDocument *document_find_by_id(guint id);
+ 
+ 
+diff --git a/src/editor.c b/src/editor.c
+index c60a897e..e38c4a67 100644
+--- a/src/editor.c
++++ b/src/editor.c
+@@ -4728,7 +4728,6 @@ gboolean editor_goto_line(GeanyEditor *editor, gint line_no, gint offset)
+  *
+  *  @since 0.20
+  **/
+-GEANY_API_SYMBOL
+ gboolean editor_goto_pos(GeanyEditor *editor, gint pos, gboolean mark)
+ {
+ 	g_return_val_if_fail(editor, FALSE);
+@@ -5335,7 +5334,6 @@ const gchar *editor_find_snippet(GeanyEditor *editor, const gchar *snippet_name)
+  * @param pos .
+  * @param snippet .
+  */
+-GEANY_API_SYMBOL
+ void editor_insert_snippet(GeanyEditor *editor, gint pos, const gchar *snippet)
+ {
+ 	GString *pattern;
+@@ -5353,7 +5351,6 @@ static void         free_(void *doc) { }
+  * Gets the GType of GeanyEditor
+  *
+  * @return the GeanyEditor type */
+-GEANY_API_SYMBOL
+ GType editor_get_type (void);
+ 
+ G_DEFINE_BOXED_TYPE(GeanyEditor, editor, copy_, free_);
+diff --git a/src/editor.h b/src/editor.h
+index 347f6d0f..0559d877 100644
+--- a/src/editor.h
++++ b/src/editor.h
+@@ -143,6 +143,7 @@ GeanyEditorPrefs;
+ 
+ 
+ #define GEANY_TYPE_EDITOR (editor_get_type())
++G_MODULE_EXPORT
+ GType editor_get_type (void);
+ 
+ /** Editor-owned fields for each document. */
+@@ -161,38 +162,54 @@ typedef struct GeanyEditor
+ GeanyEditor;
+ 
+ 
++G_MODULE_EXPORT
+ const GeanyIndentPrefs *editor_get_indent_prefs(GeanyEditor *editor);
+ 
++G_MODULE_EXPORT
+ ScintillaObject *editor_create_widget(GeanyEditor *editor);
+ 
++G_MODULE_EXPORT
+ void editor_indicator_set_on_range(GeanyEditor *editor, gint indic, gint start, gint end);
+ 
++G_MODULE_EXPORT
+ void editor_indicator_set_on_line(GeanyEditor *editor, gint indic, gint line);
+ 
++G_MODULE_EXPORT
+ void editor_indicator_clear(GeanyEditor *editor, gint indic);
+ 
++G_MODULE_EXPORT
+ void editor_set_indent_type(GeanyEditor *editor, GeanyIndentType type);
+ 
++G_MODULE_EXPORT
+ void editor_set_indent_width(GeanyEditor *editor, gint width);
+ 
++G_MODULE_EXPORT
+ gchar *editor_get_word_at_pos(GeanyEditor *editor, gint pos, const gchar *wordchars);
+ 
++G_MODULE_EXPORT
+ const gchar *editor_get_eol_char_name(GeanyEditor *editor);
+ 
++G_MODULE_EXPORT
+ gint editor_get_eol_char_len(GeanyEditor *editor);
+ 
++G_MODULE_EXPORT
+ const gchar *editor_get_eol_char(GeanyEditor *editor);
+ 
++G_MODULE_EXPORT
+ void editor_insert_text_block(GeanyEditor *editor, const gchar *text,
+ 	 						  gint insert_pos, gint cursor_index,
+ 	 						  gint newline_indent_size, gboolean replace_newlines);
+ 
++G_MODULE_EXPORT
+ gint editor_get_eol_char_mode(GeanyEditor *editor);
+ 
++G_MODULE_EXPORT
+ gboolean editor_goto_pos(GeanyEditor *editor, gint pos, gboolean mark);
+ 
++G_MODULE_EXPORT
+ const gchar *editor_find_snippet(GeanyEditor *editor, const gchar *snippet_name);
+ 
++G_MODULE_EXPORT
+ void editor_insert_snippet(GeanyEditor *editor, gint pos, const gchar *snippet);
+ 
+ 
+diff --git a/src/encodings.h b/src/encodings.h
+index 786adbc2..cf677369 100644
+--- a/src/encodings.h
++++ b/src/encodings.h
+@@ -125,13 +125,16 @@ typedef enum
+ }
+ GeanyEncodingIndex;
+ 
++G_MODULE_EXPORT
+ gchar *encodings_convert_to_utf8(const gchar *buffer, gssize size, gchar **used_encoding);
+ 
+ /* Converts a string from the given charset to UTF-8.
+  * If fast is set, no further checks are performed. */
++G_MODULE_EXPORT
+ gchar *encodings_convert_to_utf8_from_charset(const gchar *buffer, gssize size,
+ 											  const gchar *charset, gboolean fast);
+ 
++G_MODULE_EXPORT
+ const gchar* encodings_get_charset_from_index(gint idx);
+ 
+ G_END_DECLS
+diff --git a/src/filetypes.h b/src/filetypes.h
+index 43fbeb59..a0f83983 100644
+--- a/src/filetypes.h
++++ b/src/filetypes.h
+@@ -178,18 +178,24 @@ GeanyFiletype;
+ #define filetypes	((GeanyFiletype **)GEANY(filetypes_array)->pdata)
+ 
+ 
++G_MODULE_EXPORT
+ GeanyFiletype *filetypes_detect_from_file(const gchar *utf8_filename);
+ 
++G_MODULE_EXPORT
+ GeanyFiletype *filetypes_lookup_by_name(const gchar *name);
+ 
++G_MODULE_EXPORT
+ GeanyFiletype *filetypes_index(gint idx);
+ 
++G_MODULE_EXPORT
+ const gchar *filetypes_get_display_name(GeanyFiletype *ft);
+ 
++G_MODULE_EXPORT
+ const GSList *filetypes_get_sorted_by_name(void);
+ 
+ #define GEANY_TYPE_FILETYPE (filetype_get_type())
+ 
++G_MODULE_EXPORT
+ GType filetype_get_type (void);
+ 
+ #ifdef GEANY_PRIVATE
+diff --git a/src/geanyobject.h b/src/geanyobject.h
+index e6cb9880..851a7b99 100644
+--- a/src/geanyobject.h
++++ b/src/geanyobject.h
+@@ -92,7 +92,9 @@ struct _GeanyObjectClass
+ 	GObjectClass parent_class;
+ };
+ 
++G_MODULE_EXPORT
+ GType		geany_object_get_type	(void);
++G_MODULE_EXPORT
+ GObject*	geany_object_new		(void);
+ 
+ G_END_DECLS
+diff --git a/src/highlighting.h b/src/highlighting.h
+index 73079472..a2367450 100644
+--- a/src/highlighting.h
++++ b/src/highlighting.h
+@@ -45,12 +45,17 @@ typedef struct GeanyLexerStyle
+ GeanyLexerStyle;
+ 
+ 
++G_MODULE_EXPORT
+ const GeanyLexerStyle *highlighting_get_style(gint ft_id, gint style_id);
+ 
++G_MODULE_EXPORT
+ void highlighting_set_styles(ScintillaObject *sci, GeanyFiletype *ft);
+ 
++G_MODULE_EXPORT
+ gboolean highlighting_is_string_style(gint lexer, gint style);
++G_MODULE_EXPORT
+ gboolean highlighting_is_comment_style(gint lexer, gint style);
++G_MODULE_EXPORT
+ gboolean highlighting_is_code_style(gint lexer, gint style);
+ 
+ 
+diff --git a/src/keybindings.h b/src/keybindings.h
+index 0b7f6c09..d2a452f1 100644
+--- a/src/keybindings.h
++++ b/src/keybindings.h
+@@ -281,21 +281,27 @@ enum GeanyKeyBindingID
+ };
+ 
+ 
++G_MODULE_EXPORT
+ void keybindings_send_command(guint group_id, guint key_id);
+ 
++G_MODULE_EXPORT
+ GeanyKeyBinding *keybindings_set_item(GeanyKeyGroup *group, gsize key_id,
+ 		GeanyKeyCallback callback, guint key, GdkModifierType mod,
+ 		const gchar *name, const gchar *label, GtkWidget *menu_item);
+ 
++G_MODULE_EXPORT
+ GeanyKeyBinding *keybindings_set_item_full(GeanyKeyGroup *group, gsize key_id,
+ 		guint key, GdkModifierType mod, const gchar *kf_name, const gchar *label,
+ 		GtkWidget *menu_item, GeanyKeyBindingFunc func, gpointer pdata,
+ 		GDestroyNotify destroy_notify);
+ 
++G_MODULE_EXPORT
+ GeanyKeyBinding *keybindings_get_item(GeanyKeyGroup *group, gsize key_id);
+ 
++G_MODULE_EXPORT
+ GdkModifierType keybindings_get_modifiers(GdkModifierType mods);
+ 
++G_MODULE_EXPORT
+ void keybindings_load_keyfile(void);
+ 
+ #ifdef GEANY_PRIVATE
+diff --git a/src/main.h b/src/main.h
+index 34f471ac..369f3404 100644
+--- a/src/main.h
++++ b/src/main.h
+@@ -23,13 +23,17 @@
+ #define GEANY_MAIN_H 1
+ 
+ #include <glib.h>
++#include <gmodule.h>
+ 
+ G_BEGIN_DECLS
+ 
++G_MODULE_EXPORT
+ void main_reload_configuration(void);
+ 
++G_MODULE_EXPORT
+ void main_locale_init(const gchar *locale_dir, const gchar *gettext_package);
+ 
++G_MODULE_EXPORT
+ gboolean main_is_realized(void);
+ 
+ 
+diff --git a/src/msgwindow.h b/src/msgwindow.h
+index 07b06dbc..eacabdef 100644
+--- a/src/msgwindow.h
++++ b/src/msgwindow.h
+@@ -51,20 +51,29 @@ typedef enum
+ } MessageWindowTabNum;
+ 
+ 
++G_MODULE_EXPORT
+ void msgwin_status_add(const gchar *format, ...) G_GNUC_PRINTF (1, 2);
++G_MODULE_EXPORT
+ void msgwin_status_add_string(const gchar *msg);
+ 
++G_MODULE_EXPORT
+ void msgwin_compiler_add(gint msg_color, const gchar *format, ...) G_GNUC_PRINTF (2, 3);
++G_MODULE_EXPORT
+ void msgwin_compiler_add_string(gint msg_color, const gchar *msg);
+ 
++G_MODULE_EXPORT
+ void msgwin_msg_add(gint msg_color, gint line, GeanyDocument *doc, const gchar *format, ...)
+ 			G_GNUC_PRINTF (4, 5);
++G_MODULE_EXPORT
+ void msgwin_msg_add_string(gint msg_color, gint line, GeanyDocument *doc, const char *msg);
+ 
++G_MODULE_EXPORT
+ void msgwin_clear_tab(gint tabnum);
+ 
++G_MODULE_EXPORT
+ void msgwin_switch_tab(gint tabnum, gboolean show);
+ 
++G_MODULE_EXPORT
+ void msgwin_set_messages_dir(const gchar *messages_dir);
+ 
+ 
+diff --git a/src/navqueue.h b/src/navqueue.h
+index 49d9fd03..5519bdeb 100644
+--- a/src/navqueue.h
++++ b/src/navqueue.h
+@@ -33,6 +33,7 @@
+ 
+ G_BEGIN_DECLS
+ 
++G_MODULE_EXPORT
+ gboolean navqueue_goto_line(GeanyDocument *old_doc, GeanyDocument *new_doc, gint line);
+ 
+ 
+diff --git a/src/plugindata.h b/src/plugindata.h
+index 6e4dc2ee..a33e0dc2 100644
+--- a/src/plugindata.h
++++ b/src/plugindata.h
+@@ -306,12 +306,17 @@ struct GeanyPluginFuncs
+ 	void        (*cleanup)   (GeanyPlugin *plugin, gpointer pdata);
+ };
+ 
++
++G_MODULE_EXPORT
+ gboolean geany_plugin_register(GeanyPlugin *plugin, gint api_version,
+                                gint min_api_version, gint abi_version);
++G_MODULE_EXPORT
+ gboolean geany_plugin_register_full(GeanyPlugin *plugin, gint api_version,
+                                     gint min_api_version, gint abi_version,
+                                     gpointer data, GDestroyNotify free_func);
++G_MODULE_EXPORT
+ gpointer geany_plugin_get_data(const GeanyPlugin *plugin);
++G_MODULE_EXPORT
+ void geany_plugin_set_data(GeanyPlugin *plugin, gpointer data, GDestroyNotify free_func);
+ 
+ /** Convenience macro to register a plugin.
+@@ -397,6 +402,7 @@ struct GeanyProxyFuncs
+ 	void		(*unload)    (GeanyPlugin *proxy, GeanyPlugin *subplugin, gpointer load_data, gpointer pdata);
+ };
+ 
++G_MODULE_EXPORT
+ gint geany_plugin_register_proxy(GeanyPlugin *plugin, const gchar **extensions);
+ 
+ /* Deprecated aliases */
+diff --git a/src/pluginutils.h b/src/pluginutils.h
+index f34fa2b0..13cfffff 100644
+--- a/src/pluginutils.h
++++ b/src/pluginutils.h
+@@ -34,41 +34,55 @@ G_BEGIN_DECLS
+ struct GeanyPlugin;
+ struct GeanyDocument;
+ 
++G_MODULE_EXPORT
+ gint geany_api_version(void);
+ 
++G_MODULE_EXPORT
+ void plugin_add_toolbar_item(struct GeanyPlugin *plugin, GtkToolItem *item);
+ 
++G_MODULE_EXPORT
+ void plugin_module_make_resident(struct GeanyPlugin *plugin);
+ 
++G_MODULE_EXPORT
+ void plugin_signal_connect(struct GeanyPlugin *plugin,
+ 		GObject *object, const gchar *signal_name, gboolean after,
+ 		GCallback callback, gpointer user_data);
+ 
++G_MODULE_EXPORT
+ guint plugin_timeout_add(struct GeanyPlugin *plugin, guint interval, GSourceFunc function,
+ 		gpointer data);
+ 
++G_MODULE_EXPORT
+ guint plugin_timeout_add_seconds(struct GeanyPlugin *plugin, guint interval, GSourceFunc function,
+ 		gpointer data);
+ 
++G_MODULE_EXPORT
+ guint plugin_idle_add(struct GeanyPlugin *plugin, GSourceFunc function, gpointer data);
+ 
++G_MODULE_EXPORT
+ struct GeanyKeyGroup *plugin_set_key_group(struct GeanyPlugin *plugin,
+ 		const gchar *section_name, gsize count, GeanyKeyGroupCallback callback);
+ 
++G_MODULE_EXPORT
+ GeanyKeyGroup *plugin_set_key_group_full(struct GeanyPlugin *plugin,
+ 		const gchar *section_name, gsize count, GeanyKeyGroupFunc cb, gpointer pdata, GDestroyNotify destroy_notify);
+ 
++G_MODULE_EXPORT
+ void plugin_show_configure(struct GeanyPlugin *plugin);
+ 
++G_MODULE_EXPORT
+ void plugin_builder_connect_signals(struct GeanyPlugin *plugin,
+ 	GtkBuilder *builder, gpointer user_data);
+ 
++G_MODULE_EXPORT
+ gpointer plugin_get_document_data(struct GeanyPlugin *plugin,
+ 	struct GeanyDocument *doc, const gchar *key);
+ 
++G_MODULE_EXPORT
+ void plugin_set_document_data(struct GeanyPlugin *plugin, struct GeanyDocument *doc,
+ 	const gchar *key, gpointer data);
+ 
++G_MODULE_EXPORT
+ void plugin_set_document_data_full(struct GeanyPlugin *plugin,
+ 	struct GeanyDocument *doc, const gchar *key, gpointer data,
+ 	GDestroyNotify free_func);
+diff --git a/src/project.h b/src/project.h
+index 4fdacb65..4e20cfab 100644
+--- a/src/project.h
++++ b/src/project.h
+@@ -24,6 +24,7 @@
+ 
+ #include <glib.h>
+ #include <glib-object.h>
++#include <gmodule.h>
+ 
+ G_BEGIN_DECLS
+ 
+@@ -47,6 +48,7 @@ typedef struct GeanyProject
+ GeanyProject;
+ 
+ 
++G_MODULE_EXPORT
+ void project_write_config(void);
+ 
+ 
+diff --git a/src/sciwrappers.h b/src/sciwrappers.h
+index f74e2322..716479ac 100644
+--- a/src/sciwrappers.h
++++ b/src/sciwrappers.h
+@@ -39,72 +39,124 @@ sptr_t sci_send_message_internal (const gchar *file, guint line, ScintillaObject
+ # endif
+ #endif
+ 
++G_MODULE_EXPORT
+ void 				sci_set_text				(ScintillaObject *sci,  const gchar *text);
++G_MODULE_EXPORT
+ gboolean			sci_has_selection			(ScintillaObject *sci);
++G_MODULE_EXPORT
+ void 				sci_end_undo_action			(ScintillaObject *sci);
++G_MODULE_EXPORT
+ void 				sci_start_undo_action		(ScintillaObject *sci);
+ 
++G_MODULE_EXPORT
+ void				sci_set_marker_at_line		(ScintillaObject *sci, gint line_number, gint marker);
++G_MODULE_EXPORT
+ void				sci_delete_marker_at_line	(ScintillaObject *sci, gint line_number, gint marker);
++G_MODULE_EXPORT
+ gboolean 			sci_is_marker_set_at_line	(ScintillaObject *sci, gint line, gint marker);
+ 
++G_MODULE_EXPORT
+ gint 				sci_get_col_from_position	(ScintillaObject *sci, gint position);
++G_MODULE_EXPORT
+ gint 				sci_get_line_from_position	(ScintillaObject *sci, gint position);
++G_MODULE_EXPORT
+ gint 				sci_get_position_from_line	(ScintillaObject *sci, gint line);
++G_MODULE_EXPORT
+ gint 				sci_get_current_position	(ScintillaObject *sci);
++G_MODULE_EXPORT
+ void 				sci_set_current_position	(ScintillaObject *sci, gint position, gboolean scroll_to_caret);
+ 
++G_MODULE_EXPORT
+ gint				sci_get_selection_start		(ScintillaObject *sci);
++G_MODULE_EXPORT
+ gint				sci_get_selection_end		(ScintillaObject *sci);
++G_MODULE_EXPORT
+ void 				sci_replace_sel				(ScintillaObject *sci, const gchar *text);
++G_MODULE_EXPORT
+ gint				sci_get_selection_mode		(ScintillaObject *sci);
++G_MODULE_EXPORT
+ void				sci_set_selection_mode		(ScintillaObject *sci, gint mode);
++G_MODULE_EXPORT
+ void 				sci_set_selection_start		(ScintillaObject *sci, gint position);
++G_MODULE_EXPORT
+ void				sci_set_selection_end		(ScintillaObject *sci, gint position);
+ 
++G_MODULE_EXPORT
+ gint				sci_get_length				(ScintillaObject *sci);
++G_MODULE_EXPORT
+ gchar*				sci_get_contents			(ScintillaObject *sci, gint buffer_len);
++G_MODULE_EXPORT
+ gint				sci_get_selected_text_length(ScintillaObject *sci);
++G_MODULE_EXPORT
+ gchar*				sci_get_selection_contents	(ScintillaObject *sci);
++G_MODULE_EXPORT
+ gchar*				sci_get_line				(ScintillaObject *sci, gint line_num);
++G_MODULE_EXPORT
+ gint 				sci_get_line_length			(ScintillaObject *sci, gint line);
++G_MODULE_EXPORT
+ gint				sci_get_line_count			(ScintillaObject *sci);
+ 
++G_MODULE_EXPORT
+ gint				sci_get_line_end_position	(ScintillaObject *sci, gint line);
+ 
++G_MODULE_EXPORT
+ gboolean			sci_get_line_is_visible		(ScintillaObject *sci, gint line);
++G_MODULE_EXPORT
+ void				sci_ensure_line_is_visible	(ScintillaObject *sci, gint line);
+ 
++G_MODULE_EXPORT
+ gint				sci_get_tab_width			(ScintillaObject *sci);
++G_MODULE_EXPORT
+ gchar				sci_get_char_at				(ScintillaObject *sci, gint pos);
+ 
++G_MODULE_EXPORT
+ void				sci_scroll_caret			(ScintillaObject *sci);
++G_MODULE_EXPORT
+ gint				sci_find_text				(ScintillaObject *sci, gint flags, struct Sci_TextToFind *ttf);
++G_MODULE_EXPORT
+ void				sci_set_font				(ScintillaObject *sci, gint style, const gchar *font, gint size);
++G_MODULE_EXPORT
+ void				sci_goto_line				(ScintillaObject *sci, gint line, gboolean unfold);
++G_MODULE_EXPORT
+ gint				sci_get_style_at			(ScintillaObject *sci, gint position);
++G_MODULE_EXPORT
+ gchar*				sci_get_contents_range		(ScintillaObject *sci, gint start, gint end);
++G_MODULE_EXPORT
+ void				sci_insert_text				(ScintillaObject *sci, gint pos, const gchar *text);
+ 
++G_MODULE_EXPORT
+ void				sci_set_target_start		(ScintillaObject *sci, gint start);
++G_MODULE_EXPORT
+ void				sci_set_target_end			(ScintillaObject *sci, gint end);
++G_MODULE_EXPORT
+ gint				sci_replace_target			(ScintillaObject *sci, const gchar *text, gboolean regex);
+ 
++G_MODULE_EXPORT
+ gint				sci_get_lexer				(ScintillaObject *sci);
++G_MODULE_EXPORT
+ void				sci_send_command			(ScintillaObject *sci, gint cmd);
+ 
++G_MODULE_EXPORT
+ gint				sci_get_current_line		(ScintillaObject *sci);
+ 
++G_MODULE_EXPORT
+ void				sci_indicator_set			(ScintillaObject *sci, gint indic);
++G_MODULE_EXPORT
+ void				sci_indicator_clear			(ScintillaObject *sci, gint pos, gint len);
+ 
++G_MODULE_EXPORT
+ void				sci_set_line_indentation	(ScintillaObject *sci, gint line, gint indent);
++G_MODULE_EXPORT
+ gint				sci_get_line_indentation	(ScintillaObject *sci, gint line);
++G_MODULE_EXPORT
+ gint				sci_find_matching_brace		(ScintillaObject *sci, gint pos);
+ 
+ #ifndef GEANY_DISABLE_DEPRECATED
++G_MODULE_EXPORT
+ void				sci_get_text				(ScintillaObject *sci, gint len, gchar *text) GEANY_DEPRECATED_FOR(sci_get_contents);
++G_MODULE_EXPORT
+ void				sci_get_selected_text		(ScintillaObject *sci, gchar *text) GEANY_DEPRECATED_FOR(sci_get_selection_contents);
++G_MODULE_EXPORT
+ void				sci_get_text_range			(ScintillaObject *sci, gint start, gint end, gchar *text) GEANY_DEPRECATED_FOR(sci_get_contents_range);
+ #endif	/* GEANY_DISABLE_DEPRECATED */
+ 
+diff --git a/src/search.h b/src/search.h
+index 7c7474ba..b55b84ef 100644
+--- a/src/search.h
++++ b/src/search.h
+@@ -28,6 +28,7 @@
+ #define GEANY_SEARCH_H 1
+ 
+ #include <glib.h>
++#include <gmodule.h>
+ 
+ 
+ G_BEGIN_DECLS
+@@ -79,6 +80,7 @@ typedef struct GeanyMatchInfo
+ }
+ GeanyMatchInfo;
+ 
++G_MODULE_EXPORT
+ void search_show_find_in_files_dialog(const gchar *dir);
+ 
+ 
+diff --git a/src/spawn.h b/src/spawn.h
+index ccfca269..10bdaf04 100644
+--- a/src/spawn.h
++++ b/src/spawn.h
+@@ -23,6 +23,7 @@
+ #define GEANY_SPAWN_H 1
+ 
+ #include <glib.h>
++#include <gmodule.h>
+ 
+ #ifdef G_OS_WIN32
+ # define SPAWN_WIFEXITED(status) TRUE
+@@ -38,10 +39,13 @@
+ 
+ G_BEGIN_DECLS
+ 
++G_MODULE_EXPORT
+ gboolean spawn_check_command(const gchar *command_line, gboolean execute, GError **error);
+ 
++G_MODULE_EXPORT
+ gboolean spawn_kill_process(GPid pid, GError **error);
+ 
++G_MODULE_EXPORT
+ gboolean spawn_async(const gchar *working_directory, const gchar *command_line, gchar **argv,
+ 	gchar **envp, GPid *child_pid, GError **error);
+ 
+@@ -79,6 +83,7 @@ typedef enum
+  */
+ typedef void (*SpawnReadFunc)(GString *string, GIOCondition condition, gpointer data);
+ 
++G_MODULE_EXPORT
+ gboolean spawn_with_callbacks(const gchar *working_directory, const gchar *command_line,
+ 	gchar **argv, gchar **envp, SpawnFlags spawn_flags, GIOFunc stdin_cb, gpointer stdin_data,
+ 	SpawnReadFunc stdout_cb, gpointer stdout_data, gsize stdout_max_length,
+@@ -95,8 +100,10 @@ typedef struct _SpawnWriteData
+ 	gsize size;         /**< Size of the data. */
+ } SpawnWriteData;
+ 
++G_MODULE_EXPORT
+ gboolean spawn_write_data(GIOChannel *channel, GIOCondition condition, SpawnWriteData *data);
+ 
++G_MODULE_EXPORT
+ gboolean spawn_sync(const gchar *working_directory, const gchar *command_line, gchar **argv,
+ 	gchar **envp, SpawnWriteData *stdin_data, GString *stdout_data, GString *stderr_data,
+ 	gint *exit_status, GError **error);
+diff --git a/src/stash.h b/src/stash.h
+index 24fc65f0..dd9d449d 100644
+--- a/src/stash.h
++++ b/src/stash.h
+@@ -32,62 +32,83 @@ typedef struct StashGroup StashGroup;
+  * stash_group_display() and stash_group_update(). */
+ typedef gconstpointer StashWidgetID;
+ 
++G_MODULE_EXPORT
+ GType stash_group_get_type(void);
+ 
++G_MODULE_EXPORT
+ StashGroup *stash_group_new(const gchar *name);
+ 
++G_MODULE_EXPORT
+ void stash_group_add_boolean(StashGroup *group, gboolean *setting,
+ 		const gchar *key_name, gboolean default_value);
+ 
++G_MODULE_EXPORT
+ void stash_group_add_integer(StashGroup *group, gint *setting,
+ 		const gchar *key_name, gint default_value);
+ 
++G_MODULE_EXPORT
+ void stash_group_add_string(StashGroup *group, gchar **setting,
+ 		const gchar *key_name, const gchar *default_value);
+ 
++G_MODULE_EXPORT
+ void stash_group_add_string_vector(StashGroup *group, gchar ***setting,
+ 		const gchar *key_name, const gchar **default_value);
+ 
++G_MODULE_EXPORT
+ void stash_group_load_from_key_file(StashGroup *group, GKeyFile *keyfile);
+ 
++G_MODULE_EXPORT
+ void stash_group_save_to_key_file(StashGroup *group, GKeyFile *keyfile);
+ 
++G_MODULE_EXPORT
+ void stash_group_free(StashGroup *group);
+ 
++G_MODULE_EXPORT
+ gboolean stash_group_load_from_file(StashGroup *group, const gchar *filename);
+ 
++G_MODULE_EXPORT
+ gint stash_group_save_to_file(StashGroup *group, const gchar *filename,
+ 		GKeyFileFlags flags);
+ 
+ /* *** GTK-related functions *** */
+ 
++G_MODULE_EXPORT
+ void stash_group_add_toggle_button(StashGroup *group, gboolean *setting,
+ 		const gchar *key_name, gboolean default_value, StashWidgetID widget_id);
+ 
++G_MODULE_EXPORT
+ void stash_group_add_radio_buttons(StashGroup *group, gint *setting,
+ 		const gchar *key_name, gint default_value,
+ 		StashWidgetID widget_id, gint enum_id, ...) G_GNUC_NULL_TERMINATED;
+ 
++G_MODULE_EXPORT
+ void stash_group_add_spin_button_integer(StashGroup *group, gint *setting,
+ 		const gchar *key_name, gint default_value, StashWidgetID widget_id);
+ 
++G_MODULE_EXPORT
+ void stash_group_add_combo_box(StashGroup *group, gint *setting,
+ 		const gchar *key_name, gint default_value, StashWidgetID widget_id);
+ 
++G_MODULE_EXPORT
+ void stash_group_add_combo_box_entry(StashGroup *group, gchar **setting,
+ 		const gchar *key_name, const gchar *default_value, StashWidgetID widget_id);
+ 
++G_MODULE_EXPORT
+ void stash_group_add_entry(StashGroup *group, gchar **setting,
+ 		const gchar *key_name, const gchar *default_value, StashWidgetID widget_id);
+ 
++G_MODULE_EXPORT
+ void stash_group_add_widget_property(StashGroup *group, gpointer setting,
+ 		const gchar *key_name, gpointer default_value, StashWidgetID widget_id,
+ 		const gchar *property_name, GType type);
+ 
++G_MODULE_EXPORT
+ void stash_group_display(StashGroup *group, GtkWidget *owner);
+ 
++G_MODULE_EXPORT
+ void stash_group_update(StashGroup *group, GtkWidget *owner);
+ 
++G_MODULE_EXPORT
+ void stash_group_free_settings(StashGroup *group);
+ 
+ 
+diff --git a/src/symbols.h b/src/symbols.h
+index a245518e..e0a4a971 100644
+--- a/src/symbols.h
++++ b/src/symbols.h
+@@ -28,6 +28,7 @@
+ 
+ G_BEGIN_DECLS
+ 
++G_MODULE_EXPORT
+ const gchar *symbols_get_context_separator(gint ft_id);
+ 
+ 
+diff --git a/src/templates.h b/src/templates.h
+index 6ee7d515..10999857 100644
+--- a/src/templates.h
++++ b/src/templates.h
+@@ -49,6 +49,7 @@ typedef struct GeanyTemplatePrefs
+ GeanyTemplatePrefs;
+ 
+ 
++G_MODULE_EXPORT
+ gchar *templates_get_template_fileheader(gint filetype_idx, const gchar *fname);
+ 
+ 
+diff --git a/src/ui_utils.h b/src/ui_utils.h
+index a0fb3ebc..5d4ec60d 100644
+--- a/src/ui_utils.h
++++ b/src/ui_utils.h
+@@ -98,50 +98,71 @@ GeanyMainWidgets;
+ #define GEANY_STOCK_BUILD "geany-build"
+ 
+ 
++G_MODULE_EXPORT
+ GtkWidget *ui_dialog_vbox_new(GtkDialog *dialog);
+ 
++G_MODULE_EXPORT
+ void ui_set_statusbar(gboolean log, const gchar *format, ...) G_GNUC_PRINTF (2, 3);
+ 
++G_MODULE_EXPORT
+ void ui_table_add_row(GtkTable *table, gint row, ...) G_GNUC_NULL_TERMINATED;
+ 
++G_MODULE_EXPORT
+ GtkWidget *ui_path_box_new(const gchar *title, GtkFileChooserAction action, GtkEntry *entry);
+ 
++G_MODULE_EXPORT
+ GtkWidget *ui_button_new_with_image(const gchar *stock_id, const gchar *text);
+ 
++G_MODULE_EXPORT
+ void ui_add_document_sensitive(GtkWidget *widget);
+ 
++G_MODULE_EXPORT
+ GtkWidget *ui_image_menu_item_new(const gchar *stock_id, const gchar *label);
+ 
++G_MODULE_EXPORT
+ GtkWidget *ui_lookup_widget(GtkWidget *widget, const gchar *widget_name);
+ 
++G_MODULE_EXPORT
+ void ui_progress_bar_start(const gchar *text);
+ 
++G_MODULE_EXPORT
+ void ui_progress_bar_stop(void);
+ 
++G_MODULE_EXPORT
+ void ui_entry_add_clear_icon(GtkEntry *entry);
+ 
++G_MODULE_EXPORT
+ void ui_menu_add_document_items(GtkMenu *menu, GeanyDocument *active, GCallback callback);
+ 
++G_MODULE_EXPORT
+ void ui_menu_add_document_items_sorted(GtkMenu *menu, GeanyDocument *active,
+ 		GCallback callback, GCompareFunc sort_func);
+ 
++G_MODULE_EXPORT
+ void ui_widget_modify_font_from_string(GtkWidget *wid, const gchar *str);
+ 
++G_MODULE_EXPORT
+ gboolean ui_is_keyval_enter_or_return(guint keyval);
+ 
++G_MODULE_EXPORT
+ gint ui_get_gtk_settings_integer(const gchar *property_name, gint default_value);
+ 
++G_MODULE_EXPORT
+ void ui_combo_box_add_to_history(GtkComboBoxText *combo_entry,
+ 		const gchar *text, gint history_len);
+ 
++G_MODULE_EXPORT
+ const gchar *ui_lookup_stock_label(const gchar *stock_id);
+ 
++G_MODULE_EXPORT
+ void ui_tree_view_set_tooltip_text_column(GtkTreeView *tree_view, gint column);
+ 
+ 
+ #ifndef GEANY_DISABLE_DEPRECATED
++G_MODULE_EXPORT
+ GtkWidget *ui_frame_new_with_alignment(const gchar *label_text, GtkWidget **alignment) GEANY_DEPRECATED;
+ 
++G_MODULE_EXPORT
+ void ui_widget_set_tooltip_text(GtkWidget *widget, const gchar *text) GEANY_DEPRECATED_FOR(gtk_widget_set_tooltip_text);
+ #endif	/* GEANY_DISABLE_DEPRECATED */
+ 
+diff --git a/src/utils.h b/src/utils.h
+index 63904a43..5df6dda2 100644
+--- a/src/utils.h
++++ b/src/utils.h
+@@ -30,6 +30,7 @@
+ #include <time.h>
+ 
+ #include <glib.h>
++#include <gmodule.h>
+ #include <gdk/gdk.h> /* for GdkColor */
+ 
+ G_BEGIN_DECLS
+@@ -159,59 +160,83 @@ G_BEGIN_DECLS
+ #define foreach_range(i, size) \
+ 	for (i = 0; i < size; i++)
+ 
+-
++G_MODULE_EXPORT
+ gboolean utils_str_equal(const gchar *a, const gchar *b);
+ 
++G_MODULE_EXPORT
+ guint utils_string_replace_all(GString *haystack, const gchar *needle, const gchar *replace);
+ 
++G_MODULE_EXPORT
+ GSList *utils_get_file_list(const gchar *path, guint *length, GError **error);
+ 
++G_MODULE_EXPORT
+ GSList *utils_get_file_list_full(const gchar *path, gboolean full_path, gboolean sort, GError **error);
+ 
++G_MODULE_EXPORT
+ gint utils_write_file(const gchar *filename, const gchar *text);
+ 
++G_MODULE_EXPORT
+ gchar *utils_get_locale_from_utf8(const gchar *utf8_text);
+ 
++G_MODULE_EXPORT
+ gchar *utils_get_utf8_from_locale(const gchar *locale_text);
+ 
++G_MODULE_EXPORT
+ gchar *utils_remove_ext_from_filename(const gchar *filename);
+ 
++G_MODULE_EXPORT
+ gint utils_mkdir(const gchar *path, gboolean create_parent_dirs);
+ 
++G_MODULE_EXPORT
+ gboolean utils_get_setting_boolean(GKeyFile *config, const gchar *section, const gchar *key, const gboolean default_value);
+ 
++G_MODULE_EXPORT
+ gint utils_get_setting_integer(GKeyFile *config, const gchar *section, const gchar *key, const gint default_value);
+ 
++G_MODULE_EXPORT
+ gchar *utils_get_setting_string(GKeyFile *config, const gchar *section, const gchar *key, const gchar *default_value);
+ 
++G_MODULE_EXPORT
+ gboolean utils_spawn_sync(const gchar *dir, gchar **argv, gchar **env, GSpawnFlags flags,
+ 						  GSpawnChildSetupFunc child_setup, gpointer user_data, gchar **std_out,
+ 						  gchar **std_err, gint *exit_status, GError **error);
+ 
++G_MODULE_EXPORT
+ gboolean utils_spawn_async(const gchar *dir, gchar **argv, gchar **env, GSpawnFlags flags,
+ 						   GSpawnChildSetupFunc child_setup, gpointer user_data, GPid *child_pid,
+ 						   GError **error);
+ 
++G_MODULE_EXPORT
+ gint utils_str_casecmp(const gchar *s1, const gchar *s2);
+ 
++G_MODULE_EXPORT
+ gchar *utils_get_date_time(const gchar *format, time_t *time_to_use);
+ 
++G_MODULE_EXPORT
+ void utils_open_browser(const gchar *uri);
+ 
++G_MODULE_EXPORT
+ guint utils_string_replace_first(GString *haystack, const gchar *needle, const gchar *replace);
+ 
++G_MODULE_EXPORT
+ gchar *utils_str_middle_truncate(const gchar *string, guint truncate_length);
+ 
++G_MODULE_EXPORT
+ gchar *utils_str_remove_chars(gchar *string, const gchar *chars);
+ 
++G_MODULE_EXPORT
+ gchar **utils_copy_environment(const gchar **exclude_vars, const gchar *first_varname, ...) G_GNUC_NULL_TERMINATED;
+ 
++G_MODULE_EXPORT
+ gchar *utils_find_open_xml_tag(const gchar sel[], gint size);
+ 
++G_MODULE_EXPORT
+ const gchar *utils_find_open_xml_tag_pos(const gchar sel[], gint size);
+ 
++G_MODULE_EXPORT
+ gchar *utils_get_real_path(const gchar *file_name);
+ 
++G_MODULE_EXPORT
+ gchar **utils_strv_shorten_file_list(gchar **file_names, gssize file_names_len);
+ 
+ #ifdef GEANY_PRIVATE


### PR DESCRIPTION
Not supported by clang.

Add clang32 and clangarm64 as they should now work.

Signed-off-by: Rosen Penev <rosenp@gmail.com>