### PR TITLE
libjaylink-git: fix clang compilation

### DIFF
--- a/mingw-w64-libjaylink-git/010-socket.patch
+++ b/mingw-w64-libjaylink-git/010-socket.patch
@@ -1,0 +1,55 @@
+--- a/libjaylink/discovery_tcp.c
++++ b/libjaylink/discovery_tcp.c
+@@ -228,7 +228,11 @@ static struct jaylink_device *probe_device(struct jaylink_context *ctx,
+ JAYLINK_PRIV int discovery_tcp_scan(struct jaylink_context *ctx)
+ {
+ 	int ret;
++#ifdef _WIN32
++	SOCKET sock;
++#else
+ 	int sock;
++#endif
+ 	int opt_value;
+ 	fd_set rfds;
+ 	struct sockaddr_in addr;
+@@ -241,7 +245,7 @@ JAYLINK_PRIV int discovery_tcp_scan(struct jaylink_context *ctx)
+ 
+ 	sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+ 
+-	if (sock < 0) {
++	if (sock == INVALID_SOCKET) {
+ 		log_err(ctx, "Failed to create discovery socket.");
+ 		return JAYLINK_ERR;
+ 	}
+--- a/libjaylink/transport_tcp.c
++++ b/libjaylink/transport_tcp.c
+@@ -231,7 +231,11 @@ JAYLINK_PRIV int transport_tcp_open(struct jaylink_device_handle *devh)
+ 	struct jaylink_device *dev;
+ 	struct addrinfo hints;
+ 	struct addrinfo *info;
++#ifdef _WIN32
++	SOCKET sock;
++#else
+ 	int sock;
++#endif
+ 
+ 	dev = devh->dev;
+ 	ctx = dev->ctx;
+@@ -264,7 +268,7 @@ JAYLINK_PRIV int transport_tcp_open(struct jaylink_device_handle *devh)
+ 	for (struct addrinfo *rp = info; rp != NULL; rp = rp->ai_next) {
+ 		sock = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+ 
+-		if (sock < 0)
++		if (sock == INVALID_SOCKET)
+ 			continue;
+ 
+ 		if (!connect(sock, info->ai_addr, info->ai_addrlen))
+@@ -276,7 +280,7 @@ JAYLINK_PRIV int transport_tcp_open(struct jaylink_device_handle *devh)
+ 
+ 	freeaddrinfo(info);
+ 
+-	if (sock < 0) {
++	if (sock == INVALID_SOCKET) {
+ 		log_err(ctx, "Failed to open device.");
+ 		cleanup_handle(devh);
+ 		return JAYLINK_ERR;

--- a/mingw-w64-libjaylink-git/PKGBUILD
+++ b/mingw-w64-libjaylink-git/PKGBUILD
@@ -6,10 +6,10 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=r175.cfccbc9
-pkgrel=1
+pkgrel=2
 pkgdesc="Shared library written in C to access SEGGER J-Link and compatible devices (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://gitlab.zapb.de/libjaylink/libjaylink"
 license=("GPLv2+")
 depends=("${MINGW_PACKAGE_PREFIX}-libusb")
@@ -18,8 +18,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "git")
 options=('staticlibs' 'strip')
 _commit="cfccbc9d6763733f1d14dff3c2dc5b75aaef136b"
-source=("git+https://gitlab.zapb.de/libjaylink/libjaylink.git#commit=${_commit}")
-sha256sums=('SKIP')
+source=("git+https://gitlab.zapb.de/libjaylink/libjaylink.git#commit=${_commit}"
+        "010-socket.patch")
+sha256sums=('SKIP'
+            '260dba4fe44e8fc9a11eaa712cfcaa133d2e7386f25127b8b5e0e24169c4d027')
 
 pkgver() {
   cd "${srcdir}/${_realname}"
@@ -28,6 +30,7 @@ pkgver() {
 
 prepare() {
   cd ${_realname}
+  patch -p1 -i ${srcdir}/010-socket.patch
   ./autogen.sh
 }
 

--- a/mingw-w64-libusb/010-cdecl.patch
+++ b/mingw-w64-libusb/010-cdecl.patch
@@ -1,0 +1,22 @@
+--- a/libusb/core.c
++++ b/libusb/core.c
+@@ -2181,7 +2181,7 @@ void API_EXPORTED libusb_set_log_cb(libusb_context *ctx, libusb_log_cb cb,
+  * on this platform
+  * \returns LIBUSB_ERROR_NOT_FOUND if LIBUSB_OPTION_USE_USBDK is valid on this platform but UsbDk is not available
+  */
+-int API_EXPORTED libusb_set_option(libusb_context *ctx,
++int _cdecl libusb_set_option(libusb_context *ctx,
+ 	enum libusb_option option, ...)
+ {
+ 	int arg = 0, r = LIBUSB_SUCCESS;
+--- a/libusb/libusb.h
++++ b/libusb/libusb.h
+@@ -2126,7 +2126,7 @@ enum libusb_option {
+ 	LIBUSB_OPTION_MAX = 3
+ };
+ 
+-int LIBUSB_CALL libusb_set_option(libusb_context *ctx, enum libusb_option option, ...);
++int __cdecl libusb_set_option(libusb_context *ctx, enum libusb_option option, ...);
+ 
+ #if defined(__cplusplus)
+ }

--- a/mingw-w64-libusb/PKGBUILD
+++ b/mingw-w64-libusb/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libusb
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.0.24
-pkgrel=4
+pkgrel=5
 pkgdesc="Library that provides generic access to USB devices (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -13,9 +13,11 @@ license=("LGPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-autotools")
 options=('staticlibs' 'strip')
 source=("https://github.com/libusb/libusb/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.bz2"
-        "fix-dll-exports.patch")
+        "fix-dll-exports.patch"
+        "010-cdecl.patch")
 sha256sums=('7efd2685f7b327326dcfb85cee426d9b871fd70e22caa15bb68d595ce2a2b12a'
-            'e25a317610623df4c020ff904661f52b1de6c9f95f3966aef52cf34886c768b3')
+            'e25a317610623df4c020ff904661f52b1de6c9f95f3966aef52cf34886c768b3'
+            '89f47f73705c231eb766ae2ba7357c7569b8b6ff5881e274a4c0ed02c877833b')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -25,6 +27,7 @@ prepare() {
   fi
 
   patch -Nbp1 -i "${srcdir}/fix-dll-exports.patch"
+  patch -Nbp1 -i "${srcdir}/010-cdecl.patch"
 
   autoreconf -fiv
 }


### PR DESCRIPTION
wrong type for socket.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

I noticed there's actually an error in libusb where stdcall is used for a variadic function.