### PR TITLE
openblas: More consistent condition for 64-bit idx

### DIFF
--- a/mingw-w64-openblas/PKGBUILD
+++ b/mingw-w64-openblas/PKGBUILD
@@ -112,7 +112,7 @@ build() {
   _build_openblas ""
 
 
-  if [ "${CARCH}" = "x86_64" ]; then
+  if [ "${CARCH}" != "i686" ]; then
     [[ -d "${srcdir}/build-${MSYSTEM}-64" ]] && rm -rf "${srcdir}/build-${MSYSTEM}-64"
     mkdir -p "${srcdir}/build-${MSYSTEM}-64" && cd "${srcdir}/build-${MSYSTEM}-64"
 


### PR DESCRIPTION
Use same condition for calling the actual build rule that is used for defining the package name for the 64-bit indexing version of OpenBLAS.

No rebuild is required currently. So, I didn't bump the `pkgrel`. I hope that is ok.