### PR TITLE
gh: update to v2.4.0

### DIFF
--- a/mingw-w64-github-cli/PKGBUILD
+++ b/mingw-w64-github-cli/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=github-cli
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.3.0
+pkgver=2.4.0
 pkgrel=1
 pkgdesc='The GitHub CLI (mingw-w64)'
 arch=('any')
@@ -17,7 +17,7 @@ optdepends=("git: To interact with repositories")
 options=('!strip')
 source=("$_realname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz"
         "gh")
-sha256sums=('56bcf353adc17c386377ffcdfc980cbaff36123a1c1132ba09c3c51a7d1c9b82'
+sha256sums=('3c87db4d9825a342fc55bd7f27461099dd46291aea4a4a29bb95d3c896403f94'
             '9ee5f2b44b7e9aa751508f02c1020e341e0212a9aa146b7428eb5ffea310be27')
 build() {
     cd "cli-$pkgver"


### PR DESCRIPTION
For details, see https://github.com/cli/cli/releases/tag/v2.4.0

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
