### PR TITLE
ode: fix compilation with clang

### DIFF
--- a/mingw-w64-ode/020-float.patch
+++ b/mingw-w64-ode/020-float.patch
@@ -1,0 +1,117 @@
+--- a/ode/demo/demo_basket.cpp
++++ b/ode/demo/demo_basket.cpp
+@@ -159,8 +159,12 @@ static void simLoop (int pause)
+   dsSetColor (1,1,1);
+   const dReal *SPos = dBodyGetPosition(sphbody);
+   const dReal *SRot = dBodyGetRotation(sphbody);
+-  float spos[3] = {SPos[0], SPos[1], SPos[2]};
+-  float srot[12] = { SRot[0], SRot[1], SRot[2], SRot[3], SRot[4], SRot[5], SRot[6], SRot[7], SRot[8], SRot[9], SRot[10], SRot[11] };
++  float spos[3];
++  for (size_t i = 0; i < sizeof(spos); ++i)
++    spos[i] = SPos[i];
++  float srot[12];
++  for (size_t i = 0; i < sizeof(srot); ++i)
++    srot[i] = SRot[i];
+   dsDrawSphere
+   (
+     spos, 
+@@ -174,11 +178,14 @@ static void simLoop (int pause)
+ 
+   const dReal* Pos = dGeomGetPosition(world_mesh);
+   //dIASSERT(dVALIDVEC3(Pos));
+-  float pos[3] = { Pos[0], Pos[1], Pos[2] };
+-
++  float pos[3];
++  for (size_t i = 0; i < sizeof(pos); ++i)
++    pos[i] = Pos[i];
+   const dReal* Rot = dGeomGetRotation(world_mesh);
+   //dIASSERT(dVALIDMAT3(Rot));
+-  float rot[12] = { Rot[0], Rot[1], Rot[2], Rot[3], Rot[4], Rot[5], Rot[6], Rot[7], Rot[8], Rot[9], Rot[10], Rot[11] };
++  float rot[12];
++  for (size_t i = 0; i < sizeof(rot); ++i)
++    rot[i] = Rot[i];
+ 
+   int numi = sizeof(world_indices)  / sizeof(dTriIndex);
+ 
+--- a/ode/demo/demo_cyl.cpp
++++ b/ode/demo/demo_cyl.cpp
+@@ -171,8 +171,13 @@ static void simLoop (int pause)
+ #ifdef BOX
+   const dReal *BPos = dBodyGetPosition(boxbody);
+   const dReal *BRot = dBodyGetRotation(boxbody);
+-  float bpos[3] = {BPos[0], BPos[1], BPos[2]};
+-  float brot[12] = { BRot[0], BRot[1], BRot[2], BRot[3], BRot[4], BRot[5], BRot[6], BRot[7], BRot[8], BRot[9], BRot[10], BRot[11] };
++  float bpos[3];
++  for (size_t i = 0; i < sizeof(bpos); ++i)
++    bpos[i] = BPos[i];
++  float brot[12];
++  for (size_t i = 0; i < sizeof(brot); ++i)
++    brot[i] = BRot[i];
++
+   float sides[3] = {BOXSZ, BOXSZ, BOXSZ};
+   dsDrawBox
+   (
+@@ -184,8 +189,12 @@ static void simLoop (int pause)
+ #ifdef CYL
+   const dReal *CPos = dGeomGetPosition(cylgeom);
+   const dReal *CRot = dGeomGetRotation(cylgeom);
+-  float cpos[3] = {CPos[0], CPos[1], CPos[2]};
+-  float crot[12] = { CRot[0], CRot[1], CRot[2], CRot[3], CRot[4], CRot[5], CRot[6], CRot[7], CRot[8], CRot[9], CRot[10], CRot[11] };
++  float cpos[3];
++  for (size_t i = 0; i < sizeof(cpos); ++i)
++    cpos[i] = CPos[i];
++  float crot[12];
++  for (size_t i = 0; i < sizeof(crot); ++i)
++    crot[i] = CRot[i];
+   dsDrawCylinder
+   ( 
+ //    dBodyGetPosition(cylbody),
+@@ -202,10 +211,14 @@ static void simLoop (int pause)
+   dsSetTexture (DS_NONE);
+ 
+   const dReal* Pos = dGeomGetPosition(world_mesh);
+-  float pos[3] = { Pos[0], Pos[1], Pos[2] };
++  float pos[3];
++  for (size_t i = 0; i < sizeof(pos); ++i)
++    pos[i] = Pos[i];
+ 
+   const dReal* Rot = dGeomGetRotation(world_mesh);
+-  float rot[12] = { Rot[0], Rot[1], Rot[2], Rot[3], Rot[4], Rot[5], Rot[6], Rot[7], Rot[8], Rot[9], Rot[10], Rot[11] };
++  float rot[12];
++  for (size_t i = 0; i < sizeof(rot); ++i)
++    rot[i] = Rot[i];
+ 
+   int numi = sizeof(world_indices)  / sizeof(dTriIndex);
+ 
+--- a/ode/demo/demo_cylvssphere.cpp
++++ b/ode/demo/demo_cylvssphere.cpp
+@@ -151,8 +151,12 @@ static void simLoop (int pause)
+ 
+   const dReal *CPos = dBodyGetPosition(cylbody);
+   const dReal *CRot = dBodyGetRotation(cylbody);
+-  float cpos[3] = {CPos[0], CPos[1], CPos[2]};
+-  float crot[12] = { CRot[0], CRot[1], CRot[2], CRot[3], CRot[4], CRot[5], CRot[6], CRot[7], CRot[8], CRot[9], CRot[10], CRot[11] };
++  float cpos[3];
++  for (size_t i = 0; i < sizeof(cpos); ++i)
++    cpos[i] = CPos[i];
++  float crot[12];
++  for (size_t i = 0; i < sizeof(crot); ++i)
++    crot[i] = CRot[i];
+   dsDrawCylinder
+   (
+     cpos,
+@@ -163,8 +167,12 @@ static void simLoop (int pause)
+ 
+   const dReal *SPos = dBodyGetPosition(sphbody);
+   const dReal *SRot = dBodyGetRotation(sphbody);
+-  float spos[3] = {SPos[0], SPos[1], SPos[2]};
+-  float srot[12] = { SRot[0], SRot[1], SRot[2], SRot[3], SRot[4], SRot[5], SRot[6], SRot[7], SRot[8], SRot[9], SRot[10], SRot[11] };
++  float spos[3];
++  for (size_t i = 0; i < sizeof(spos); ++i)
++    spos[i] = SPos[i];
++  float srot[12];
++  for (size_t i = 0; i < sizeof(srot); ++i)
++    srot[i] = SRot[i];
+   dsDrawSphere
+   (
+     spos,

--- a/mingw-w64-ode/PKGBUILD
+++ b/mingw-w64-ode/PKGBUILD
@@ -4,10 +4,10 @@ _realname=ode
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.16.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A library for simulating articulated rigid body dynamics (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://bitbucket.org/odedevs/ode"
 license=('LGPL', 'BSD')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
@@ -15,8 +15,18 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 options=('strip' 'staticlibs')
-source=("https://bitbucket.org/odedevs/ode/downloads/${_realname}-${pkgver}.tar.gz")
-sha256sums=('b26aebdcb015e2d89720ef48e0cb2e8a3ca77915f89d853893e7cc861f810f22')
+source=("https://bitbucket.org/odedevs/ode/downloads/${_realname}-${pkgver}.tar.gz"
+        '010-float.patch::https://bitbucket.org/odedevs/ode/commits/92eb12af400671ebf90860b4af2d8755262d1b8d/raw'
+        '020-float.patch')
+sha256sums=('b26aebdcb015e2d89720ef48e0cb2e8a3ca77915f89d853893e7cc861f810f22'
+            'f45d4bb8c8fd59148f79500c826d6a0522a456c9cab3fdaa2667ff5fd7248179'
+            'e21c1e9f24b6df5086d5e8927c494c061830c3681b413f79e782f9c0b606b9d3')
+
+prepare() {
+  cd $srcdir/${_realname}-${pkgver}
+  patch -p1 -i ${srcdir}/010-float.patch
+  patch -p1 -i ${srcdir}/020-float.patch
+}
 
 build() {
   cd "${srcdir}"/${_realname}-${pkgver}


### PR DESCRIPTION
Backported upstream patch.

Added clang32 where this was tested.

Signed-off-by: Rosen Penev <rosenp@gmail.com>