### PR TITLE
clutter-gtk: compile with meson

### DIFF
--- a/mingw-w64-clutter-gtk/PKGBUILD
+++ b/mingw-w64-clutter-gtk/PKGBUILD
@@ -4,15 +4,16 @@ _realname=clutter-gtk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.8.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Clutter integration with GTK+ (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://blogs.gnome.org/clutter"
 license=("LGPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
-             "${MINGW_PACKAGE_PREFIX}-autotools")
+             "${MINGW_PACKAGE_PREFIX}-meson"
+             "${MINGW_PACKAGE_PREFIX}-gtk-doc")
 depends=("${MINGW_PACKAGE_PREFIX}-gtk3"
          "${MINGW_PACKAGE_PREFIX}-clutter")
 options=(!libtool strip staticlibs)
@@ -21,38 +22,26 @@ source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname
 sha256sums=('521493ec038973c77edcb8bc5eac23eed41645117894aaee7300b2487cb42b06'
             '837624b334fa432d6f1a1c346060f102c17c9ba24e277d21b0e4bbe6396d0043')
 
-prepare() {
-  cd ${_realname}-${pkgver}
-
-  patch -p1 -i ${srcdir}/0002-msys-fix-introspection-build.patch
-
-  autoreconf -fvi
-  #NOCONFIGURE=1 ./autogen.sh
-}
-
 build() {
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
   mkdir -p "${srcdir}/build-${MINGW_CHOST}"
   cd "${srcdir}/build-${MINGW_CHOST}"
 
-  mkdir -p doc/html
-  cp -rf ../${_realname}-${pkgver}/doc/html/* doc/html
-
-  ../${_realname}-${pkgver}/configure \
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+  meson \
     --prefix=${MINGW_PREFIX} \
-    --build=${MINGW_CHOST} \
-    --host=${MINGW_CHOST} \
-    --disable-static \
-    --enable-shared \
-    --enable-silent-rules \
-    --disable-gtk-doc
+    --wrap-mode=nodownload \
+    --auto-features=enabled \
+    --buildtype=plain \
+    -Denable_docs=true \
+    "../${_realname}-${pkgver}"
 
-  make
+  meson compile
 }
 
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
-  make -j1 DESTDIR="${pkgdir}" install
+  DESTDIR="${pkgdir}" meson install
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }


### PR DESCRIPTION
Speeds up compilation and removes need for autotools patch.

Added clang32 where this was compiled on.

Signed-off-by: Rosen Penev <rosenp@gmail.com>