### PR TITLE
libopenmpt: update to 0.4.27

### DIFF
--- a/mingw-w64-libopenmpt/PKGBUILD
+++ b/mingw-w64-libopenmpt/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libopenmpt
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.4.26
+pkgver=0.4.27
 pkgrel=1
 pkgdesc="A cross-platform C++ and C library to decode tracked music files (modules) into a raw PCM audio stream (mingw-w64)"
 arch=('any')
@@ -21,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-autotools")
 options=('staticlibs' 'strip')
 source=("https://lib.openmpt.org/files/${_realname}/src/${_realname}-${pkgver}+release.autotools.tar.gz")
-sha256sums=('9078aa3a1779868b484fbffdf19daea775654b53224e5c217628a8d2ae777e8d')
+sha256sums=('a4c23aaf1914e78d082d71f96cc82d63b0ed30091ed8cf8e8cb6887d4cecfaab')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}+release.autotools"


### PR DESCRIPTION
New version

https://lib.openmpt.org/libopenmpt/2021/12/23/security-update-0.5.15-releases-0.4.27-0.3.36/
