### PR TITLE
Octave: Prepare to detect incompatible API of SUNDIALS 6.

### DIFF
--- a/mingw-w64-octave/0006-sundials-6-check.patch
+++ b/mingw-w64-octave/0006-sundials-6-check.patch
@@ -1,0 +1,39 @@
+# HG changeset patch
+# User Markus Mützel <markus.muetzel@gmx.de>
+# Date 1640340250 -3600
+#      Fri Dec 24 11:04:10 2021 +0100
+# Branch stable
+# Node ID 653493339a8a8a3bc4e0e937646fb3ea8fa9cd62
+# Parent  bbf3eb5d3c2f68c6734d635bff11d2e656623679
+Check for changed API in SUNDIALS version 6.0 (bug #61701).
+
+* m4/acinclude.m4 (OCTAVE_CHECK_SUNDIALS_COMPATIBLE_API): Check for API using
+SUNContext object. It isn't supported yet.
+
+diff -r bbf3eb5d3c2f -r 653493339a8a m4/acinclude.m4
+--- a/m4/acinclude.m4	Fri Dec 24 08:56:04 2021 +0100
++++ b/m4/acinclude.m4	Fri Dec 24 11:04:10 2021 +0100
+@@ -2681,7 +2681,7 @@
+   dnl API tests above failed. For now, always test for ida_direct.h.
+   AC_CHECK_HEADERS([ida/ida_direct.h ida_direct.h])
+   dnl Each of these is a deprecated analog to the functions listed above.
+-  AC_CHECK_FUNCS([IDADlsSetJacFn IDADlsSetLinearSolver SUNDenseLinearSolver])
++  AC_CHECK_FUNCS([IDADlsSetJacFn IDADlsSetLinearSolver SUNDenseLinearSolver SUNContext_Create])
+   LIBS=$ac_octave_save_LIBS
+   AC_MSG_CHECKING([whether SUNDIALS API provides the necessary functions])
+   if test "x$ac_cv_func_IDASetJacFn" = xyes \
+@@ -2696,6 +2696,14 @@
+     octave_have_sundials_compatible_api=no
+   fi
+   AC_MSG_RESULT([$octave_have_sundials_compatible_api])
++  dnl Octave doesn't yet support the SUNContext API introduced in SUNDIALS 6.0.
++  dnl For now, check for that API and de-activate features if it is found.
++  dnl FIXME: Properly support that API.
++  AC_MSG_CHECKING([whether SUNDIALS API uses SUNContext object])
++  AC_MSG_RESULT([$ac_cv_func_SUNContext_Create])
++  if test "x$ac_cv_func_SUNContext_Create" = xyes; then
++    octave_have_sundials_compatible_api=no
++  fi
+   if test $octave_have_sundials_compatible_api = no; then
+     warn_sundials_disabled="SUNDIALS libraries do not provide an API that is compatible with Octave.  The solvers ode15i and ode15s will be disabled."
+     OCTAVE_CONFIGURE_WARNING([warn_sundials_disabled])

--- a/mingw-w64-octave/PKGBUILD
+++ b/mingw-w64-octave/PKGBUILD
@@ -40,13 +40,15 @@ source=(https://ftp.gnu.org/gnu/octave/octave-$pkgver.tar.gz
         "0002-mk-doc-cache-path.patch"
         "0003-pkg-octave-binary.patch"
         "0004-spawn-p_wait.patch"
-        "0005-makeinfo-perl.patch")
+        "0005-makeinfo-perl.patch"
+        "0006-sundials-6-check.patch")
 sha512sums=('91ff031f6dfff8506fa738fd4f1f07276501fdfe003f8ed992cccf91da14d9d33da6d08923322b0dae5f5b696b49856b0f5c5065e26b0701b0d1630173807435'
             'dc714dbf04dc551cd996b4b1b9bf7816100103fa8c3d7d3633171d36f5d8eb20464fa0cfeee387c882a1fcb81e824d11e68b7f99f2f6b56d1f2ef6b220c8acab'
             '5742cde34ae9184276c830dab41dccb289991578656353658bf07315d89b1c3870c6c51520d5aae0cec8c7fb12c707a1970aa9dde353b4ab54e515d1d3cf66e0'
             '96c596fb105589bbfc662211cd62c2ecfea903656b15b54045a6ee852d8c3b3bdc6894bb2f93693f88bb5eab6ad7ed54056b42a0f3cc3832e2be961887e10acf'
             '1dd71764e3ad88c3c7e3bcfd24a0d4fd1873496a4564f7e0817230f73957345776c43f41bb1c394613cacf48b0d741555f99240047ae285cb8461031e8ac7bb8'
-            'dc99ad8eb214746633d14ce09edddc20f6dd73929f1c556538157e5e4d7210b4045b35a42bd70ebb31c0652aca6c53c720178826b125b19c5cfde9fe8e6c36f8')
+            'dc99ad8eb214746633d14ce09edddc20f6dd73929f1c556538157e5e4d7210b4045b35a42bd70ebb31c0652aca6c53c720178826b125b19c5cfde9fe8e6c36f8'
+            'f6a5afc35cb9b988079871222d6e58a32519f6fdae39fbbb7ed86c80b1a94869a8cda3face076719dc4b5c3a2bad9f0a7caf0428bc400e6a14c179ed14e24970')
 
 prepare() {
   cd "${_realname}-${pkgver}"
@@ -55,6 +57,10 @@ prepare() {
   patch -p1 -i "${srcdir}/0003-pkg-octave-binary.patch"
   patch -p1 -i "${srcdir}/0004-spawn-p_wait.patch"
   patch -p1 -i "${srcdir}/0005-makeinfo-perl.patch"
+  # see https://savannah.gnu.org/bugs/index.php?61701
+  patch -p1 -i "${srcdir}/0006-sundials-6-check.patch"
+
+  autoreconf -fi
 }
 
 build() {


### PR DESCRIPTION
The added patch doesn't actually add support for the changed API in SUNDIALS 6. But it detects the new API and allows to still build Octave even if SUNDIALS in the new version is installed (by not using it at all).
This should be enough to no longer block PR #10370.

We'll try and add support for SUNDIALS 6 in upstream Octave in time for Octave 7 which is currently planned to be released at some time in early 2022.

I didn't yet bump the pkgrel because there's no need to rebuild Octave at this point in time. It should be bumped when SUNDIALS is updated to version 6.