### PR TITLE
silc-toolkit: fix compilation with clang

### DIFF
--- a/mingw-w64-silc-toolkit/PKGBUILD
+++ b/mingw-w64-silc-toolkit/PKGBUILD
@@ -5,12 +5,12 @@ _realname=silc-toolkit
 pkgbase=mingw-w64-${_realname}
 pkgname=(${MINGW_PACKAGE_PREFIX}-${_realname})
 pkgver=1.1.12
-pkgrel=4
+pkgrel=5
 url="http://silcnet.org/"
 pkgdesc="Secure Internet Live Conferencing (mingw-w64)"
 license=('GPL2' 'BSD')
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 depends=(${MINGW_PACKAGE_PREFIX}-libsystre)
 makedepends=(${MINGW_PACKAGE_PREFIX}-gcc "${MINGW_PACKAGE_PREFIX}-autotools")
 options=('staticlibs' '!emptydirs')
@@ -41,6 +41,7 @@ prepare() {
   patch -p1 -i "${srcdir}"/005-fix-some-compiler-check.patch
   patch -p1 -i "${srcdir}"/006-disable-dllimport-for-silcske.patch
   patch -p1 -i "${srcdir}"/007-ucrt-fixes.patch
+  sed "s/SILC_ADD_CC_FLAGS(SILC_CRYPTO, -fno-regmove)//g" -i configure.ac
   autoreconf -sif
 }
 


### PR DESCRIPTION
Add clang32 support where this was tested.

Signed-off-by: Rosen Penev <rosenp@gmail.com>