### PR TITLE
clucene: fix compilation with clang

### DIFF
--- a/mingw-w64-clucene/010-pthread.patch
+++ b/mingw-w64-clucene/010-pthread.patch
@@ -1,0 +1,10 @@
+--- a/src/shared/CLucene/LuceneThreads.h
++++ b/src/shared/CLucene/LuceneThreads.h
+@@ -7,6 +7,7 @@
+ #ifndef _LuceneThreads_h
+ #define  _LuceneThreads_h
+ 
++#include <pthread.h>
+ 
+ CL_NS_DEF(util)
+ class CLuceneThreadIdCompare;

--- a/mingw-w64-clucene/020-gcc.patch
+++ b/mingw-w64-clucene/020-gcc.patch
@@ -1,0 +1,20 @@
+--- a/src/shared/cmake/MacroCheckGccVisibility.cmake
++++ b/src/shared/cmake/MacroCheckGccVisibility.cmake
+@@ -15,7 +15,7 @@ macro(MACRO_CHECK_GCC_VISIBILITY GccVisibility)
+    # get the gcc version
+    exec_program(${CMAKE_C_COMPILER} ARGS --version OUTPUT_VARIABLE _gcc_version_info)
+ 
+-   string (REGEX MATCH "[345]\\.[0-9]\\.[0-9]" _gcc_version "${_gcc_version_info}")
++   string (REGEX MATCH "[0-9]+\\.[0-9]\\.[0-9]" _gcc_version "${_gcc_version_info}")
+    if (NOT _gcc_version)
+    
+       # clang reports: clang version 1.1 (trunk 95754)
+@@ -26,7 +26,7 @@ macro(MACRO_CHECK_GCC_VISIBILITY GccVisibility)
+    
+       # gcc on mac just reports: "gcc (GCC) 3.3 20030304 ..." without the patch level, handle this here:
+       if (NOT _gcc_version)
+-        string (REGEX REPLACE ".*\\(GCC\\).* ([34]\\.[0-9]) .*" "\\1.0" _gcc_version "${_gcc_version_info}")
++        string (REGEX REPLACE ".*\\(Rev[0-9], Built by MSYS2 project\\).* ([0-9]+\\.[0-9]\\.[0-9]) .*" "\\1.0" _gcc_version "${_gcc_version_info}")
+       endif (NOT _gcc_version)
+    endif (NOT _gcc_version)
+    

--- a/mingw-w64-clucene/PKGBUILD
+++ b/mingw-w64-clucene/PKGBUILD
@@ -4,22 +4,28 @@ _realname=clucene
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.3.3.4
-pkgrel=1
+pkgrel=2
 pkgdesc="CLucene - a C++ search engine (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://clucene.sourceforge.io/"
 license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-cc" "${MINGW_PACKAGE_PREFIX}-cmake")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc" "${MINGW_PACKAGE_PREFIX}-cmake" "${MINGW_PACKAGE_PREFIX}-ninja")
 depends=("${MINGW_PACKAGE_PREFIX}-boost" "${MINGW_PACKAGE_PREFIX}-zlib")
 source=("https://downloads.sourceforge.net/project/${_realname}/${_realname}-core-unstable/${pkgver:0:3}/${_realname}-core-${pkgver}.tar.gz"
-        "${_realname}-core-${pkgver}.patch")
+        "${_realname}-core-${pkgver}.patch"
+        010-pthread.patch
+        020-gcc.patch)
 sha256sums=('ddfdc433dd8ad31b5c5819cc4404a8d2127472a3b720d3e744e8c51d79732eab'
-            'a3b0bb664231ed5e66384dd606422d7f6d9f0e6181f295056acfbe0b0d4d7c9c')
+            'a3b0bb664231ed5e66384dd606422d7f6d9f0e6181f295056acfbe0b0d4d7c9c'
+            '81f96824bf2ff0dc35288be6fa891df66841110fcd26f59c77025a96b831b637'
+            '821471b0bc4e36571eea1d4d637e1c7881aae4ab18a78fed8be29771e38b58b0')
 
 prepare() {
   cd "${srcdir}/${_realname}-core-${pkgver}"
   patch -Np1 -i "../${_realname}-core-${pkgver}.patch"
+  patch -Np1 -i "../010-pthread.patch"
+  patch -Np1 -i "../020-gcc.patch"
 }
 
 build() {
@@ -29,16 +35,17 @@ build() {
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe \
-    -G"MSYS Makefiles" \
+    -G"Ninja" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DBUILD_STATIC_LIBRARIES=ON \
     -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_STANDARD=98 \
     "../${_realname}-core-${pkgver}"
 
-  make
+  cmake --build .
 }
 
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
-  make DESTDIR="${pkgdir}" install
+  DESTDIR="${pkgdir}" cmake --install .
 }


### PR DESCRIPTION
Changed CXX_STANDARD to 98 as 11 requires stricter list initialization.

Switch to build with Ninja. Faster.

Added pthread patch for UCRT.

Added clang32 where this was tested.

Signed-off-by: Rosen Penev <rosenp@gmail.com>