### PR TITLE
mhook: fix compilation with clang

### DIFF
--- a/mingw-w64-mhook/010-char.patch
+++ b/mingw-w64-mhook/010-char.patch
@@ -1,0 +1,11 @@
+--- a/tests/mhook-test.cpp
++++ b/tests/mhook-test.cpp
+@@ -121,7 +121,7 @@ ULONG WINAPI HookNtClose(HANDLE hHandle) {
+ //
+ 
+ #ifndef _MSC_VER
+-int main(int argc, WCHAR* argv[])
++int main(int argc, CHAR* argv[])
+ #else
+ int wmain(int argc, WCHAR* argv[])
+ #endif

--- a/mingw-w64-mhook/PKGBUILD
+++ b/mingw-w64-mhook/PKGBUILD
@@ -4,9 +4,9 @@ _realname=mhook
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=r7.a159eed
-pkgrel=1
+pkgrel=2
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 pkgdesc="An API hooking library (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
@@ -15,12 +15,19 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
 options=('strip' 'staticlibs')
 license=('custom')
 url="https://github.com/SirAnthony/mhook"
-source=("${_realname}"::"git+https://github.com/SirAnthony/mhook.git")
-sha256sums=('SKIP')
+source=("${_realname}"::"git+https://github.com/SirAnthony/mhook.git"
+        010-char.patch)
+sha256sums=('SKIP'
+            '2874a5fdbb7ee717c001a7f2cee0f4fa9f60a38bc7ce1589d978b237b1cec884')
 
 pkgver() {
   cd "${srcdir}/${_realname}"
   printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+prepare() {
+  cd "${srcdir}/${_realname}"
+  patch -p1 -i ${srcdir}/010-char.patch
 }
 
 build() {


### PR DESCRIPTION
main function must be char**.

Signed-off-by: Rosen Penev <rosenp@gmail.com>