### PR TITLE
[WIP] rust: enable for clangarm64

### DIFF
--- a/mingw-w64-rust/0009-windows-aarch64.patch
+++ b/mingw-w64-rust/0009-windows-aarch64.patch
@@ -1,0 +1,79 @@
+diff --unified --recursive --text --color --new-file rustc-1.57.0-src-orig/compiler/rustc_target/src/spec/aarch64_pc_windows_gnu.rs rustc-1.57.0-src/compiler/rustc_target/src/spec/aarch64_pc_windows_gnu.rs
+--- rustc-1.57.0-src-orig/compiler/rustc_target/src/spec/aarch64_pc_windows_gnu.rs	1970-01-01 01:00:00.000000000 +0100
++++ rustc-1.57.0-src/compiler/rustc_target/src/spec/aarch64_pc_windows_gnu.rs	2021-12-27 13:57:28.788805700 +0100
+@@ -0,0 +1,19 @@
++use crate::spec::{LinkerFlavor, Target};
++
++pub fn target() -> Target {
++    let mut base = super::windows_gnu_base::opts();
++    base.cpu = "aarch64".to_string();
++    let gcc_pre_link_args = base.pre_link_args.entry(LinkerFlavor::Gcc).or_default();
++    gcc_pre_link_args.push("-march=armv8-a".to_string());
++    base.max_atomic_width = Some(64);
++    base.linker = Some("aarch64-w64-mingw32-gcc".to_string());
++
++    Target {
++        llvm_target: "aarch64-pc-windows-gnu".to_string(),
++        pointer_width: 64,
++        data_layout: "e-m:w-p:64:64-i32:32-i64:64-i128:128-n32:64-S128"
++            .to_string(),
++        arch: "aarch64".to_string(),
++        options: base,
++    }
++}
+diff --unified --recursive --text --color --new-file rustc-1.57.0-src-orig/compiler/rustc_target/src/spec/mod.rs rustc-1.57.0-src/compiler/rustc_target/src/spec/mod.rs
+--- rustc-1.57.0-src-orig/compiler/rustc_target/src/spec/mod.rs	2021-12-27 14:59:42.808072600 +0100
++++ rustc-1.57.0-src/compiler/rustc_target/src/spec/mod.rs	2021-12-22 21:09:44.380299300 +0100
+@@ -867,6 +867,7 @@
+ 
+     ("x86_64-unknown-illumos", x86_64_unknown_illumos),
+ 
++    ("aarch64-pc-windows-gnu", aarch64_pc_windows_gnu),
+     ("x86_64-pc-windows-gnu", x86_64_pc_windows_gnu),
+     ("i686-pc-windows-gnu", i686_pc_windows_gnu),
+     ("i686-uwp-windows-gnu", i686_uwp_windows_gnu),
+diff --unified --recursive --text --color --new-file rustc-1.57.0-src-orig/src/bootstrap/dist.rs rustc-1.57.0-src/src/bootstrap/dist.rs
+--- rustc-1.57.0-src-orig/src/bootstrap/dist.rs	2021-12-27 15:13:05.924314600 +0100
++++ rustc-1.57.0-src/src/bootstrap/dist.rs	2021-12-23 13:52:15.601313500 +0100
+@@ -167,6 +167,8 @@
+         "i686-w64-mingw32-gcc.exe"
+     } else if target == "x86_64-pc-windows-gnu" {
+         "x86_64-w64-mingw32-gcc.exe"
++    } else if target == "aarch64-pc-windows-gnu" {
++        "aarch64-w64-mingw32-gcc.exe"
+     } else {
+         "gcc.exe"
+     };
+diff --unified --recursive --text --color --new-file rustc-1.57.0-src-orig/src/build_helper/lib.rs rustc-1.57.0-src/src/build_helper/lib.rs
+--- rustc-1.57.0-src-orig/src/build_helper/lib.rs	2021-12-27 15:13:10.995914000 +0100
++++ rustc-1.57.0-src/src/build_helper/lib.rs	2021-12-23 12:19:46.911909200 +0100
+@@ -114,6 +114,7 @@
+         "x86_64-pc-windows-msvc" => "x86_64-pc-win32",
+         "i686-pc-windows-gnu" => "i686-w64-mingw32",
+         "x86_64-pc-windows-gnu" => "x86_64-w64-mingw32",
++        "aarch64-pc-windows-gnu" => "aarch64-w64-mingw32",
+         s => s,
+     }
+ }
+diff --unified --recursive --text --color --new-file rustc-1.57.0-src-orig/vendor/cc/src/lib.rs rustc-1.57.0-src/vendor/cc/src/lib.rs
+--- rustc-1.57.0-src-orig/vendor/cc/src/lib.rs	2021-12-27 15:13:19.541445300 +0100
++++ rustc-1.57.0-src/vendor/cc/src/lib.rs	2021-12-23 12:11:51.987855000 +0100
+@@ -2477,6 +2477,7 @@
+             .as_ref()
+             .map(|s| s.trim_right_matches('-').to_owned());
+         cross_compile.or(match &target[..] {
++            "aarch64-pc-windows-gnu" => Some("aarch64-w64-mingw32"),
+             "aarch64-unknown-linux-gnu" => Some("aarch64-linux-gnu"),
+             "aarch64-unknown-linux-musl" => Some("aarch64-linux-musl"),
+             "aarch64-unknown-netbsd" => Some("aarch64--netbsd"),
+diff --unified --recursive --text --color --new-file rustc-1.57.0-src-orig/vendor/cc-1.0.69/src/lib.rs rustc-1.57.0-src/vendor/cc-1.0.69/src/lib.rs
+--- rustc-1.57.0-src-orig/vendor/cc-1.0.69/src/lib.rs	2021-12-27 15:13:22.484442100 +0100
++++ rustc-1.57.0-src/vendor/cc-1.0.69/src/lib.rs	2021-12-23 12:12:28.214647000 +0100
+@@ -2379,6 +2379,7 @@
+             .as_ref()
+             .map(|s| s.trim_right_matches('-').to_owned());
+         cross_compile.or(match &target[..] {
++            "aarch64-pc-windows-gnu" => Some("aarch64-w64-mingw32"),
+             "aarch64-unknown-linux-gnu" => Some("aarch64-linux-gnu"),
+             "aarch64-unknown-linux-musl" => Some("aarch64-linux-musl"),
+             "aarch64-unknown-netbsd" => Some("aarch64--netbsd"),

--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -36,14 +36,16 @@ source=("https://static.rust-lang.org/dist/${_realname}c-${pkgver}-src.tar.gz"{,
         "0004-unbundle-gcc.patch"
         "0005-win32-config.patch"
         "0007-clang-subsystem.patch"
-        "0008-disable-self-contained.patch")
+        "0008-disable-self-contained.patch"
+        "aarch64-pc-windows-gnu.json")
 sha256sums=('3546f9c3b91b1f8b8efd26c94d6b50312c08210397b4072ed2748e2bd4445c1a'
             'SKIP'
             'c706841ace2ef76fd1004b9c0486ea9ef7d99073c5ce2884e4c97fa4a7beab25'
             '6cc3234644768e24824e455d6304585c717ae25aa53ebf9cf1f1dea87bf869b7'
             'c4e5ffeef84296d39c3e3e8f807fc8b33ce786b1e4edb21eef26b053586aca27'
             '9e2e2eb9c0684f329b1ce6598fcb66727abf84121087b24670a9cfc44a514888'
-            '29f84cb8e05ce304e102e28912a3b4464add406a8ec37a6c6d717b9b7d81b67b')
+            '29f84cb8e05ce304e102e28912a3b4464add406a8ec37a6c6d717b9b7d81b67b'
+            'c65f9fb96ab98b18b38cfb1e55ccf40b903afc57dfedd70d8b2e0b1459ada101')
 validpgpkeys=('108F66205EAEB0AAA8DD5E1C85AB96E6FA1BE5FE'  # Rust Language (Tag and Release Signing Key) <rust-key@rust-lang.org>
               '474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard <tstellar@redhat.com>
               'B6C8F98282B944E3B0D5C2530FC3042E345AD05D') # Hans Wennborg <hans@chromium.org>
@@ -66,6 +68,8 @@ prepare() {
 build() {
   [[ -d "${srcdir}/${MSYSTEM}" ]] && rm -rf "${srcdir}/${MSYSTEM}"
   mkdir -p "${srcdir}/${MSYSTEM}" && cd "${srcdir}/${MSYSTEM}"
+
+  cp "${srcdir}/aarch64-pc-windows-gnu.json" .
 
   # The ultimate hack to let the bootstrap compiler use libgcc* libs
   if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then
@@ -92,8 +96,8 @@ build() {
     --localstatedir=${MINGW_PREFIX}/var/lib \
     --build=$OSTYPE \
     --host=$OSTYPE \
-    --target=$OSTYPE \
-    --release-channel=stable \
+    --target=aarch64-pc-windows-gnu \
+    --release-channel=nightly \
     --enable-ninja \
     --enable-extended \
     --disable-codegen-tests \
@@ -104,7 +108,8 @@ build() {
   DEP_NGHTTP_ROOT=${MINGW_PREFIX} \
   DEP_OPENSSL_ROOT=${MINGW_PREFIX} \
   DEP_Z_ROOT=${MINGW_PREFIX} \
-  ${MINGW_PREFIX}/bin/python ../${_realname}c-${pkgver}-src/x.py build --verbose --stage 2
+  RUST_BACKTRACE=full \
+  ${MINGW_PREFIX}/bin/python ../${_realname}c-${pkgver}-src/x.py build --verbose --stage 2 --target aarch64-pc-windows-gnu
 
   #create the install at a temporary directory
   DEP_NGHTTP_ROOT=${MINGW_PREFIX} \

--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -37,6 +37,7 @@ source=("https://static.rust-lang.org/dist/${_realname}c-${pkgver}-src.tar.gz"{,
         "0005-win32-config.patch"
         "0007-clang-subsystem.patch"
         "0008-disable-self-contained.patch"
+        "0009-windows-aarch64.patch"
         "aarch64-pc-windows-gnu.json")
 sha256sums=('3546f9c3b91b1f8b8efd26c94d6b50312c08210397b4072ed2748e2bd4445c1a'
             'SKIP'
@@ -45,7 +46,8 @@ sha256sums=('3546f9c3b91b1f8b8efd26c94d6b50312c08210397b4072ed2748e2bd4445c1a'
             'c4e5ffeef84296d39c3e3e8f807fc8b33ce786b1e4edb21eef26b053586aca27'
             '9e2e2eb9c0684f329b1ce6598fcb66727abf84121087b24670a9cfc44a514888'
             '29f84cb8e05ce304e102e28912a3b4464add406a8ec37a6c6d717b9b7d81b67b'
-            'c65f9fb96ab98b18b38cfb1e55ccf40b903afc57dfedd70d8b2e0b1459ada101')
+            'dcf33adc873394444fa9ef4098cd73a66d26a60e1b5b946a88449bee4372faf7'
+            '8a9b997bfd8817a29ef5efb082e7dfb79d6c0d6566ec0a1a462b6b58b9e06d81')
 validpgpkeys=('108F66205EAEB0AAA8DD5E1C85AB96E6FA1BE5FE'  # Rust Language (Tag and Release Signing Key) <rust-key@rust-lang.org>
               '474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard <tstellar@redhat.com>
               'B6C8F98282B944E3B0D5C2530FC3042E345AD05D') # Hans Wennborg <hans@chromium.org>
@@ -59,6 +61,7 @@ prepare() {
   patch -p1 -i "${srcdir}/0004-unbundle-gcc.patch"
   patch -p1 -i "${srcdir}/0005-win32-config.patch"
   patch -p1 -i "${srcdir}/0008-disable-self-contained.patch"
+  patch -p1 -i "${srcdir}/0009-windows-aarch64.patch"
 
   if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then
     patch -p1 -i "${srcdir}/0007-clang-subsystem.patch"

--- a/mingw-w64-rust/aarch64-pc-windows-gnu.json
+++ b/mingw-w64-rust/aarch64-pc-windows-gnu.json
@@ -1,0 +1,138 @@
+{
+    "abi-return-struct-as-int": true,
+    "allows-weak-linkage": false,
+    "arch": "aarch64",
+    "cpu": "aarch64",
+    "crt-objects-fallback": "mingw",
+    "data-layout": "e-m:w-p:64:64-i32:32-i64:64-i128:128-n32:64-S128",
+    "dll-prefix": "",
+    "dll-suffix": ".dll",
+    "dynamic-linking": true,
+    "eh-frame-header": false,
+    "emit-debug-gdb-scripts": false,
+    "env": "gnu",
+    "exe-suffix": ".exe",
+    "executables": true,
+    "is-builtin": false,
+    "is-like-windows": true,
+    "late-link-args-dynamic": {
+        "gcc": [
+            "-l:libunwind.dll.a"
+        ],
+        "ld.lld": [
+            "-l:libunwind.dll.a"
+        ]
+    },
+    "late-link-args-static": {
+        "gcc": [
+            "-l:libunwind.a"
+        ],
+        "ld.lld": [
+            "-l:libunwind.a"
+        ]
+    },
+    "linker": "aarch64-w64-mingw32-gcc",
+    "llvm-target": "aarch64-pc-windows-gnu",
+    "max-atomic-width": 64,
+    "no-default-libraries": false,
+    "os": "windows",
+    "post-link-objects": {
+        "dynamic-dylib": [
+            "rsend.o"
+        ],
+        "dynamic-nopic-exe": [
+            "rsend.o"
+        ],
+        "dynamic-pic-exe": [
+            "rsend.o"
+        ],
+        "static-dylib": [
+            "rsend.o"
+        ],
+        "static-nopic-exe": [
+            "rsend.o"
+        ],
+        "static-pic-exe": [
+            "rsend.o"
+        ]
+    },
+    "post-link-objects-fallback": {
+        "dynamic-dylib": [
+            "rsend.o"
+        ],
+        "dynamic-nopic-exe": [
+            "rsend.o"
+        ],
+        "dynamic-pic-exe": [
+            "rsend.o"
+        ],
+        "static-dylib": [
+            "rsend.o"
+        ],
+        "static-nopic-exe": [
+            "rsend.o"
+        ],
+        "static-pic-exe": [
+            "rsend.o"
+        ]
+    },
+    "pre-link-args": {
+        "gcc": [
+            "-fno-use-linker-plugin",
+            "-Wl,--dynamicbase",
+            "-Wl,--disable-auto-image-base"
+        ]
+    },
+    "pre-link-objects": {
+        "dynamic-dylib": [
+            "rsbegin.o"
+        ],
+        "dynamic-nopic-exe": [
+            "rsbegin.o"
+        ],
+        "dynamic-pic-exe": [
+            "rsbegin.o"
+        ],
+        "static-dylib": [
+            "rsbegin.o"
+        ],
+        "static-nopic-exe": [
+            "rsbegin.o"
+        ],
+        "static-pic-exe": [
+            "rsbegin.o"
+        ]
+    },
+    "pre-link-objects-fallback": {
+        "dynamic-dylib": [
+            "dllcrt2.o",
+            "rsbegin.o"
+        ],
+        "dynamic-nopic-exe": [
+            "crt2.o",
+            "rsbegin.o"
+        ],
+        "dynamic-pic-exe": [
+            "crt2.o",
+            "rsbegin.o"
+        ],
+        "static-dylib": [
+            "dllcrt2.o",
+            "rsbegin.o"
+        ],
+        "static-nopic-exe": [
+            "crt2.o",
+            "rsbegin.o"
+        ],
+        "static-pic-exe": [
+            "crt2.o",
+            "rsbegin.o"
+        ]
+    },
+    "requires-uwtable": true,
+    "target-family": [
+        "windows"
+    ],
+    "target-pointer-width": "64",
+    "vendor": "pc"
+}


### PR DESCRIPTION
Related to https://github.com/msys2/MINGW-packages/issues/9046

_I'm currently doing this work on an 8-core Intel i7-9700 with 32GB RAM instead of my Surface Pro X because of the project size and long build times_

This is some first work to get Rust to compile for Windows arm64. This is a bit tricky as it's a massive project to build (and I ran into long path issues as well - moved the project to `C:\_` for that). I learned the following about the Rust build process so far:

- A stage0 compiler is downloaded as indicated in `mingw-w64-rust\src\rustc-1.57.0-src\src\stage0.json`. In this case it downloads `dist/2021-11-01/cargo-1.56.1-x86_64-pc-windows-gnu.tar.gz`
- Rust will bootstrap the stage0 and stage1 compiler for `x86_64-pc-windows-gnu`
- Rust will try to use that compiler to target `aarch64-pc-windows-gnu`

The build currently fails at the last step where it tries to find `crt2.o` but fails. I added the `COPYING {} TO {}` manually as I only saw the panic show up without any further context or details.

```
COPYING C:/msys64/clang64/bin\llvm-dwp.exe TO C:\_\_\src\CLANG64\build\x86_64-pc-windows-gnu\stage2\lib\rustlib\x86_64-pc-windows-gnu\bin\rust-llvm-dwp.exe
  c Sysroot { compiler: Compiler { stage: 2, host: TargetSelection { triple: "x86_64-pc-windows-gnu", file: None } } }
COPYING C:\_\_\src\CLANG64\build\x86_64-pc-windows-gnu\stage1-rustc\x86_64-pc-windows-gnu\release\rustc-main.exe TO C:\_\_\src\CLANG64\build\x86_64-pc-windows-gnu\stage2\bin\rustc.exe
< Assemble { target_compiler: Compiler { stage: 2, host: TargetSelection { triple: "x86_64-pc-windows-gnu", file: None } } }
> Std { target: TargetSelection { triple: "aarch64-pc-windows-gnu", file: None }, compiler: Compiler { stage: 2, host: TargetSelection { triple: "x86_64-pc-windows-gnu", file: None } } }
  > StartupObjects { compiler: Compiler { stage: 2, host: TargetSelection { triple: "x86_64-pc-windows-gnu", file: None } }, target: TargetSelection { triple: "aarch64-pc-windows-gnu", file
    > Libdir { compiler: Compiler { stage: 2, host: TargetSelection { triple: "x86_64-pc-windows-gnu", file: None } }, target: TargetSelection { triple: "aarch64-pc-windows-gnu", file: None
      c Sysroot { compiler: Compiler { stage: 2, host: TargetSelection { triple: "x86_64-pc-windows-gnu", file: None } } }
    < Libdir { compiler: Compiler { stage: 2, host: TargetSelection { triple: "x86_64-pc-windows-gnu", file: None } }, target: TargetSelection { triple: "aarch64-pc-windows-gnu", file: None
COPYING C:\_\_\src\CLANG64\build\aarch64-pc-windows-gnu\native\rtstartup\rsbegin.o TO C:\_\_\src\CLANG64\build\x86_64-pc-windows-gnu\stage2\lib\rustlib\aarch64-pc-windows-gnu\lib\rsbegin.o
COPYING C:\_\_\src\CLANG64\build\aarch64-pc-windows-gnu\native\rtstartup\rsend.o TO C:\_\_\src\CLANG64\build\x86_64-pc-windows-gnu\stage2\lib\rustlib\aarch64-pc-windows-gnu\lib\rsend.o
  < StartupObjects { compiler: Compiler { stage: 2, host: TargetSelection { triple: "x86_64-pc-windows-gnu", file: None } }, target: TargetSelection { triple: "aarch64-pc-windows-gnu", file
  c Assemble { target_compiler: Compiler { stage: 2, host: TargetSelection { triple: "x86_64-pc-windows-gnu", file: None } } }
  c Libdir { compiler: Compiler { stage: 2, host: TargetSelection { triple: "x86_64-pc-windows-gnu", file: None } }, target: TargetSelection { triple: "aarch64-pc-windows-gnu", file: None }
COPYING crt2.o TO C:\_\_\src\CLANG64\build\x86_64-pc-windows-gnu\stage2\lib\rustlib\aarch64-pc-windows-gnu\lib\self-contained\crt2.o
thread 'main' panicked at 'src.symlink_metadata() failed with Het systeem kan het opgegeven bestand niet vinden. (os error 2)', src\bootstrap\lib.rs:1326:24
```