### PR TITLE
devcon-git: update and fix compilation

### DIFF
--- a/mingw-w64-devcon-git/PKGBUILD
+++ b/mingw-w64-devcon-git/PKGBUILD
@@ -7,14 +7,16 @@ pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=r233.8b17cf3
+pkgver=r540.f0adcda0
 pkgrel=1
+_commit='f0adcda012820b1cd44a8b3a1953baf478029738'
 pkgdesc='Search for and manipulate devices (mingw-w64)'
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://github.com/Microsoft/Windows-driver-samples/tree/master/setup/devcon'
 license=('custom')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "binutils"
              "patch")
 depends=()
 options=('strip')

--- a/mingw-w64-devcon-git/PKGBUILD
+++ b/mingw-w64-devcon-git/PKGBUILD
@@ -20,14 +20,14 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "patch")
 depends=()
 options=('strip')
-source=("wds::git+https://github.com/Microsoft/Windows-driver-samples"
+source=("wds::git+https://github.com/Microsoft/Windows-driver-samples#commit=${_commit}"
         "02-driverspecs.patch")
 sha256sums=('SKIP'
             'b67d69e0623c79e10346afe357178618a8341a2cff3ce1ada0ed284280760856')
 
 pkgver() {
   cd ${srcdir}/wds
-  printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+  printf "r%s.%s" "$(git rev-list --count "${_commit}")" "$(git rev-parse --short "${_commit}")"
 }
 
 prepare() {


### PR DESCRIPTION
binutils is needed to make.

Signed-off-by: Rosen Penev <rosenp@gmail.com>