### PR TITLE
tiledb: fix compilation with clang

### DIFF
--- a/mingw-w64-tiledb/PKGBUILD
+++ b/mingw-w64-tiledb/PKGBUILD
@@ -4,7 +4,7 @@ _realname=tiledb
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.2.4
-pkgrel=2
+pkgrel=3
 pkgdesc="Storage management library for sparse and dense array data (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -61,6 +61,7 @@ build() {
     "${extra_config[@]}" \
     -DTILEDB_STATIC=ON \
     -DTILEDB_S3=ON \
+    -DTILEDB_WERROR=OFF \
     -DBUILD_SHARED_LIBS=OFF \
     ../${_realname}-${pkgver}
 
@@ -78,6 +79,7 @@ build() {
     "${extra_config[@]}" \
     -DTILEDB_STATIC=OFF \
     -DTILEDB_S3=ON \
+    -DTILEDB_WERROR=OFF \
     -DBUILD_SHARED_LIBS=ON \
     ../${_realname}-${pkgver}
 


### PR DESCRIPTION
Just needs -Werror disabled.

Signed-off-by: Rosen Penev <rosenp@gmail.com>