### PR TITLE
Makedepend tweaks

### DIFF
--- a/mingw-w64-gdk-pixbuf2/PKGBUILD
+++ b/mingw-w64-gdk-pixbuf2/PKGBUILD
@@ -16,7 +16,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
              "${MINGW_PACKAGE_PREFIX}-meson"
-             "${MINGW_PACKAGE_PREFIX}-gi-docgen")
+             "${MINGW_PACKAGE_PREFIX}-gi-docgen"
+             "tar")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-glib2>=2.37.2"
          "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"

--- a/mingw-w64-jbigkit/PKGBUILD
+++ b/mingw-w64-jbigkit/PKGBUILD
@@ -12,7 +12,7 @@ mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://www.cl.cam.ac.uk/~mgk25/jbigkit/"
 license=(GPL2)
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+makedepends=("libtool" "${MINGW_PACKAGE_PREFIX}-gcc")
 options=('staticlibs' 'strip')
 source=("https://www.cl.cam.ac.uk/~mgk25/download/${_realname}-${pkgver}.tar.gz"
         allNewMainMakefile.all.patch


### PR DESCRIPTION
jbigkit uses libtool directly.  gdk-pixbuf2 uses tar to extract its source archive.