### PR TITLE
EDA tools: ghdl, yosys, prjtrellis, nextpnr and openFPGALoader

### DIFF
--- a/mingw-w64-ghdl/PKGBUILD
+++ b/mingw-w64-ghdl/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=ghdl
 pkgbase="mingw-w64-${_realname}"
 pkgname='__placeholder__'
-pkgver=1.0.0.r895.g15b84d1fb
+pkgver=1.0.0.r950.g8d512a44b
 pkgrel=1
 pkgdesc='GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL'
 arch=('any')
@@ -12,7 +12,7 @@ groups=("${MINGW_PACKAGE_PREFIX}-eda")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 
-_commit="15b84d1f"
+_commit="8d512a44"
 source=("${_realname}::git+https://github.com/ghdl/ghdl.git#commit=${_commit}")
 sha512sums=('SKIP')
 

--- a/mingw-w64-nextpnr/PKGBUILD
+++ b/mingw-w64-nextpnr/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=nextpnr
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.1.r3900.gfd2d4a8f
+pkgver=0.1.r3958.gc272d28e
 pkgrel=1
 pkgdesc="Portable FPGA place and route tool (mingw-w64)"
 arch=('any')
@@ -28,7 +28,7 @@ makedepends=(
   "git"
 )
 
-_commit="fd2d4a8f"
+_commit="c272d28e"
 source=("${_realname}::git+https://github.com/YosysHQ/${_realname}.git#commit=${_commit}")
 sha256sums=('SKIP')
 
@@ -46,7 +46,7 @@ build() {
     _extra_archs=";ecp5"
   fi
 
-  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" cmake \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" cmake . \
     -G "MSYS Makefiles" \
     -DCMAKE_C_COMPILER=clang \
     -DCMAKE_CXX_COMPILER=clang++ \
@@ -60,8 +60,7 @@ build() {
     -DBUILD_PYTHON=ON \
     -DBUILD_GUI=ON \
     -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
-    -DBUILD_TESTS=ON \
-    .
+    -DBUILD_TESTS=ON
 
   cmake --build . --config Release
 }

--- a/mingw-w64-openFPGALoader/PKGBUILD
+++ b/mingw-w64-openFPGALoader/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=openFPGALoader
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.6.1
+pkgver=0.7.0
 pkgrel=1
 pkgdesc="openFPGALoader: universal utility for programming FPGA (mingw-w64)"
 arch=('any')
@@ -21,7 +21,7 @@ makedepends=(
 )
 
 source=("${_realname}::https://codeload.github.com/trabucayre/openFPGALoader/tar.gz/v${pkgver}")
-sha256sums=('a862a209d696becff915a77512e6a8c22f92d73480a45cc12273d9ad1db60d23')
+sha256sums=('1731e54eabb49c03f58a9ec5c3fea8d5d9123d68268a3e14301bb42604f273a8')
 
 build() {
   cd "${srcdir}/${_realname}-${pkgver}"

--- a/mingw-w64-prjtrellis/PKGBUILD
+++ b/mingw-w64-prjtrellis/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=prjtrellis
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.0.r1029.03e0070
+pkgver=1.0.r1031.2f06397
 pkgrel=1
 pkgdesc="Documenting the Lattice ECP5 bit-stream format (mingw-w64)"
 arch=('any')
@@ -22,7 +22,7 @@ makedepends=(
   "git"
 )
 
-_commit="03e0070f"
+_commit="2f063976"
 source=("${_realname}::git+https://github.com/YosysHQ/${_realname}.git#commit=${_commit}"
         "prjtrellis-db::git+https://github.com/YosysHQ/prjtrellis-db")
 sha256sums=('SKIP'

--- a/mingw-w64-yosys/PKGBUILD
+++ b/mingw-w64-yosys/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=yosys
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.11.r50
+pkgver=0.12.r45
 pkgrel=1
 pkgdesc="A framework for RTL synthesis tools (mingw-w64)"
 arch=('any')
@@ -21,7 +21,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python"
 )
 
-_commit='707d98b0'
+_commit='cfe940a9'
 source=(
   "${_realname}::git+https://github.com/YosysHQ/${_realname}.git#commit=${_commit}"
   "ghdl-yosys-plugin::git+https://github.com/ghdl/ghdl-yosys-plugin.git#commit=09a32cd1"


### PR DESCRIPTION
This is a regular update of some EDA tools.

Although not critical, I saw it's complaining about the license of openFPGALoader: `message: mingw-w64-openFPGALoader: unformatted license ‘Apache-2.0’`. What is the proper string for that case?