### PR TITLE
GMP: optimized instructions for all x86 chips

### DIFF
--- a/mingw-w64-gmp/PKGBUILD
+++ b/mingw-w64-gmp/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gmp
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=6.2.1
-pkgrel=2
+pkgrel=3
 pkgdesc="A free library for arbitrary precision arithmetic (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -30,6 +30,7 @@ build() {
   local -a extra_config
   case "$CARCH" in
     i?86|x86_64)
+      extra_config+=(--enable-fat)
       ;;
     *)
       extra_config+=(--disable-assembly)


### PR DESCRIPTION
from https://gmplib.org/manual/Build-Options:

> # CPU types
> In general, if you want a library that runs as fast as possible, you should configure GMP for the exact CPU type your system uses. However, this may mean the binaries won’t run on older members of the family, and might run slower on other members, older or newer. The best idea is always to build GMP for the exact machine type you intend to run it on.
[...]
**x86 family**: ‘i386’, ‘i486’, ‘i586’, ‘pentium’, ‘pentiummmx’, ‘pentiumpro’, ‘pentium2’, ‘pentium3’, ‘pentium4’, ‘k6’, ‘k62’, ‘k63’, ‘athlon’, ‘amd64’, ‘viac3’, ‘viac32’
**Other**: ‘arm’, ‘sh’, ‘sh2’, ‘vax’, 
CPUs not listed will use generic C code.
> # Generic C Build
>If some of the assembly code causes problems, or if otherwise desired, the generic C code can be selected with the configure `--disable-assembly`.  
Note that this will run quite slowly, but it should be portable and should at least make it possible to get something running if all else fails.
>
> # Fat binary, `--enable-fat`
> Using `--enable-fat` selects a “fat binary” build on x86, where optimized low level subroutines are chosen at runtime according to the CPU detected. This means more code, but gives good performance on all x86 chips. (This option might become available for more architectures in the future.)

Currently we disable assembly for all architectures but x86, so on these other architectures libgmp "will run quite slowly" there. I'm not sure if this is really necessary, other than x86 we only target arm and that should be portable enough, shouldn't it? [... but that's not the point of this PR]

For x86 we don't specify any of the cpu-types and therefore the best matching of the build machine will be used. I have no clue what the build machine actually has, but it is very likely not the best match for every x86 processor because this isn't possible.
This PR therefore adds `--enable-fat` so _every_ x86 cpu's instruction are included and the difference between the build machine and the machine of all x86 users doesn't matter for a direct slowdown.