### PR TITLE
nlohmann-json: Fix pkgconfig file

### DIFF
--- a/mingw-w64-nlohmann-json/0001-fix-pkgconfig-files.patch
+++ b/mingw-w64-nlohmann-json/0001-fix-pkgconfig-files.patch
@@ -1,0 +1,23 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -120,6 +120,7 @@
+ CONFIGURE_FILE(
+     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/pkg-config.pc.in"
+     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
++    @ONLY
+ )
+ 
+ ##
+--- a/cmake/pkg-config.pc.in
++++ b/cmake/pkg-config.pc.in
+@@ -1,4 +1,7 @@
+-Name: ${PROJECT_NAME}
++prefix=@CMAKE_INSTALL_PREFIX@
++includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
++
++Name: @PROJECT_NAME@
+ Description: JSON for Modern C++
+-Version: ${PROJECT_VERSION}
+-Cflags: -I${CMAKE_INSTALL_FULL_INCLUDEDIR}
++Version: @PROJECT_VERSION@
++Cflags: -I${includedir}

--- a/mingw-w64-nlohmann-json/PKGBUILD
+++ b/mingw-w64-nlohmann-json/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=nlohmann-json
 pkgbase=mingw-w64-${_pkgname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_pkgname}"
 pkgver=3.10.5
-pkgrel=1
+pkgrel=2
 pkgdesc="JSON for Modern C++ (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -17,8 +17,15 @@ conflicts=("${MINGW_PACKAGE_PREFIX}-nlohmann_json")
 provides=("${MINGW_PACKAGE_PREFIX}-nlohmann_json")
 replaces=("${MINGW_PACKAGE_PREFIX}-nlohmann_json")
 options=('staticlibs' '!strip' '!buildflags')
-source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/nlohmann/json/archive/v${pkgver}.tar.gz")
-sha256sums=('5daca6ca216495edf89d167f808d1d03c4a4d929cef7da5e10f135ae1540c7e4')
+source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/nlohmann/json/archive/v${pkgver}.tar.gz"
+        "0001-fix-pkgconfig-files.patch")
+sha256sums=('5daca6ca216495edf89d167f808d1d03c4a4d929cef7da5e10f135ae1540c7e4'
+            '49d5e9e3c860a4c348b1d0a74ad38b6d9b30e73c71cfc64ad6f5c70e40c307d0')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+  patch -p1 -i "${srcdir}/0001-fix-pkgconfig-files.patch"
+}
 
 build() {
   [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"


### PR DESCRIPTION
Please review. @podsvirov

* Before:

```
Name: nlohmann_json
Description: JSON for Modern C++
Version: 3.10.4
Cflags: -I/ucrt64/include
```

* After:

```
prefix=/ucrt64
includedir=${prefix}/include

Name: nlohmann_json
Description: JSON for Modern C++
Version: 3.10.5
Cflags: -I${includedir}
```
