### PR TITLE
Add mingw-w64-c-toolchain package

### DIFF
--- a/mingw-w64-c-toolchain/PKGBUILD
+++ b/mingw-w64-c-toolchain/PKGBUILD
@@ -1,0 +1,24 @@
+# Maintainer: Christoph Reiter <reiter.christoph@gmail.com>
+
+_realname=c-toolchain
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=2022.01
+pkgrel=1
+pkgdesc="Provides the default environment specific C/C++ toolchain (mingw-w64)"
+url='https://www.msys2.org'
+arch=('any')
+license=('GPL')
+if [[ "${MINGW_PREFIX}" =~ /clang.* ]] ; then
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-clang"
+  "${MINGW_PACKAGE_PREFIX}-lld"
+)
+else
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-gcc"
+  "${MINGW_PACKAGE_PREFIX}-binutils"
+)
+fi
+source=("README.md")
+sha256sums=('692ca371b0ee26618640677272de7918284406a6b379bda7e0d5d8b92da7a29a')

--- a/mingw-w64-c-toolchain/README.md
+++ b/mingw-w64-c-toolchain/README.md
@@ -1,0 +1,2 @@
+This meta package depends on all packages that are needed to build a executable
+with $CC during packaging.

--- a/mingw-w64-mpv/PKGBUILD
+++ b/mingw-w64-mpv/PKGBUILD
@@ -5,7 +5,7 @@ _realname=mpv
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.34.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Video player based on MPlayer/mplayer2 (mingw-w64)"
 url="https://mpv.io/"
 arch=('any')
@@ -35,6 +35,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-ffmpeg"
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-docutils"
              "${MINGW_PACKAGE_PREFIX}-python-rst2pdf"
              "${MINGW_PACKAGE_PREFIX}-vulkan-headers"
+             "${MINGW_PACKAGE_PREFIX}-c-toolchain"
              "perl"
              "python")
 optdepends=("${MINGW_PACKAGE_PREFIX}-youtube-dl: for video-sharing websites playback")


### PR DESCRIPTION
This meta package depends on all packages that are needed to build a executable
with $CC during packaging.

Packages can makedepend on this to get a C compiler.