### PR TITLE
GTK3: update to 3.24.31+44+g0e09bb75b5

### DIFF
--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -3,14 +3,16 @@
 _realname=gtk3
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-gtk-update-icon-cache")
-pkgver=3.24.31
+pkgver=3.24.31+44+g0e09bb75b5
 pkgrel=1
+_commit=0e09bb75b54cfccc62de2a0539de9cf5ece4461b
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://www.gtk.org/"
 license=("LGPL")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+makedepends=("git"
+             "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-gtk-doc"
              "${MINGW_PACKAGE_PREFIX}-meson"
@@ -29,17 +31,15 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-pango"
          "${MINGW_PACKAGE_PREFIX}-shared-mime-info")
 options=('strip' '!debug' 'staticlibs')
-source=("https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}.tar.xz"
+source=("git+https://gitlab.gnome.org/GNOME/gtk.git#commit=$_commit"
         "0003-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch"
         "0004-Disable-low-level-keyboard-hook.patch"
-        "https://gitlab.gnome.org/GNOME/gtk/-/raw/3.24.31/gdk/win32/gdkkeys-win32.h"
         "gtk-query-immodules-3.0.hook.in"
         "gtk-update-icon-cache.hook.in"
         "gtk-update-icon-cache.script.in")
-sha256sums=('423c3e7fdb4c459ee889e35fd4d71fd2623562541c1041b11c07e5ad1ff10bf9'
+sha256sums=('SKIP'
             'b84a7f38f0af80680bee143d431f2a7bae53899efb337de0f67a1b4d9b59fa02'
             'e553083298495f9581ae1454b1046a22b83e81862311b30de984057eec859708'
-            '540c9fbca675a787377b9ba832df1acb0e870088e0c0bb2484312dc9754797a0'
             'adbe57eb726d882bba7a031ab8fb1788e7cd03cbf713823fd0f99d3cb380b97c'
             '56a566739c4f153f3c924b2bfe5ec7aaca469e15c023810cd7c5f57036d1a258'
             'b6306c6e117e879a60febc8e398a5a181325255a2e2c785c77222664b683f9dd')
@@ -53,11 +53,13 @@ apply_patch_with_msg() {
   done
 }
 
-prepare() {
-  cd "${srcdir}/gtk+-${pkgver}"
+pkgver() {
+  cd "${srcdir}/gtk"
+  git describe --tags | sed 's/-/+/g'
+}
 
-  # https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/4270
-  cp "${srcdir}/gdkkeys-win32.h" ./gdk/win32
+prepare() {
+  cd "${srcdir}/gtk"
 
   # https://gitlab.gnome.org/GNOME/gtk/issues/760
   apply_patch_with_msg \
@@ -90,7 +92,7 @@ build() {
     "${extra_config[@]}" \
     -Dbroadway_backend=true \
     -Dman=true \
-    "../gtk+-${pkgver}"
+    "../gtk"
 
   meson compile
 }
@@ -116,7 +118,7 @@ package_gtk3() {
   mv ${pkgdir}${MINGW_PREFIX}/bin/gtk-update-icon-cache "$srcdir"
   mv ${pkgdir}${MINGW_PREFIX}/share/man/man1/gtk-update-icon-cache.1 "$srcdir"
 
-  install -Dm644 "${srcdir}/gtk+-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+  install -Dm644 "${srcdir}/gtk/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }
 
 package_gtk-update-icon-cache() {


### PR DESCRIPTION
Contains an important [fix](https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/4327) for the upcoming Inkscape release and a [crash fix](https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/4326) for Horizon EDA.

I have compared this with the previous package and everything looks right to me 🙂 