### PR TITLE
mingw-w64-mesa: Check driconf feature requirements

### DIFF
--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -16,13 +16,14 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-llvm"
              "${MINGW_PACKAGE_PREFIX}-spirv-tools"
              "${MINGW_PACKAGE_PREFIX}-vulkan-validation-layers"
              "${MINGW_PACKAGE_PREFIX}-libelf"
-             "${MINGW_PACKAGE_PREFIX}-zstd")
+             "${MINGW_PACKAGE_PREFIX}-zstd"
+             "${MINGW_PACKAGE_PREFIX}-libsystre")
 depends=("${MINGW_PACKAGE_PREFIX}-llvm"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-vulkan-loader")
 optdepends=("${MINGW_PACKAGE_PREFIX}-opengl-man-pages: for the OpenGL API man pages"
             "${MINGW_PACKAGE_PREFIX}-zstd: use ZSTD instead of zlib for certain compression tasks"
-            "${MINGW_PACKAGE_PREFIX}-libsystre: for driconf feature")
+            "${MINGW_PACKAGE_PREFIX}-libsystre: for regex capabilities in driconf")
 url="https://www.mesa3d.org/"
 license=('MIT')
 options=('staticlibs' 'strip')

--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -4,14 +4,13 @@ _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=21.3.3
-pkgrel=1
+pkgrel=2
 pkgdesc="Open-source implementation of the OpenGL specification (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 makedepends=("${MINGW_PACKAGE_PREFIX}-llvm"
              "${MINGW_PACKAGE_PREFIX}-python-mako"
              "${MINGW_PACKAGE_PREFIX}-meson"
-             "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-vulkan-loader"
              "${MINGW_PACKAGE_PREFIX}-spirv-tools"
              "${MINGW_PACKAGE_PREFIX}-vulkan-validation-layers"
@@ -21,7 +20,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-llvm"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-vulkan-loader")
 optdepends=("${MINGW_PACKAGE_PREFIX}-opengl-man-pages: for the OpenGL API man pages"
-            "${MINGW_PACKAGE_PREFIX}-zstd: use ZSTD instead of zlib for certain compression tasks")
+            "${MINGW_PACKAGE_PREFIX}-zstd: use ZSTD instead of zlib for certain compression tasks"
+            "${MINGW_PACKAGE_PREFIX}-libsystre: for driconf feature")
 url="https://www.mesa3d.org/"
 license=('MIT')
 options=('staticlibs' 'strip')

--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -11,6 +11,7 @@ mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 makedepends=("${MINGW_PACKAGE_PREFIX}-llvm"
              "${MINGW_PACKAGE_PREFIX}-python-mako"
              "${MINGW_PACKAGE_PREFIX}-meson"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-vulkan-loader"
              "${MINGW_PACKAGE_PREFIX}-spirv-tools"
              "${MINGW_PACKAGE_PREFIX}-vulkan-validation-layers"


### PR DESCRIPTION
Ref: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/12158

Also ${MINGW_PACKAGE_PREFIX}-pkg-config is part of ${MINGW_PACKAGE_PREFIX}-toolchain so don't bother installing it.