### PR TITLE
EDA: fix nextpnr runtime deps; update nextpnr and iverilog

### DIFF
--- a/mingw-w64-iverilog/PKGBUILD
+++ b/mingw-w64-iverilog/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=iverilog
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=11.0.r8940.g71c36d12
+pkgver=11.0.r8956.gf705e7b6
 pkgrel=1
 epoch=1
 pkgdesc="Icarus Verilog, is a Verilog simulation and synthesis tool (mingw-w64)"
@@ -12,17 +12,22 @@ mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 url="http://iverilog.icarus.com/"
 license=('GPLv2+')
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
-depends=("${MINGW_PACKAGE_PREFIX}-bzip2"
-         "${MINGW_PACKAGE_PREFIX}-gcc"
-         "${MINGW_PACKAGE_PREFIX}-readline")
-makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-ghostscript"
-             'git'
-             "${MINGW_PACKAGE_PREFIX}-autotools")
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-bzip2"
+  "${MINGW_PACKAGE_PREFIX}-gcc"
+  "${MINGW_PACKAGE_PREFIX}-readline"
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "autoconf"
+  "man-db"
+  "${MINGW_PACKAGE_PREFIX}-ghostscript"
+  'git'
+)
 
 # NOTE: MSYS2 support was improved/fixed in 'master' (2020/12/04).
 # When 12.0 is tagged/released, this should be changed to use a tarball instead.
-_commit="71c36d12"
+_commit="f705e7b6"
 source=("${_realname}::git+https://github.com/steveicarus/iverilog.git#commit=${_commit}")
 sha256sums=('SKIP')
 

--- a/mingw-w64-nextpnr/PKGBUILD
+++ b/mingw-w64-nextpnr/PKGBUILD
@@ -4,7 +4,7 @@ _realname=nextpnr
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.1.r3958.gc272d28e
-pkgrel=1
+pkgrel=2
 pkgdesc="Portable FPGA place and route tool (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -13,8 +13,9 @@ license=('ISC')
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
 depends=(
   "${MINGW_PACKAGE_PREFIX}-boost"
-  "${MINGW_PACKAGE_PREFIX}-qt5-base"
+  "${MINGW_PACKAGE_PREFIX}-openmp"
   "${MINGW_PACKAGE_PREFIX}-python"
+  "${MINGW_PACKAGE_PREFIX}-qt5-base"
 )
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-boost"
@@ -22,7 +23,6 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-clang"
   "${MINGW_PACKAGE_PREFIX}-eigen3"
   "${MINGW_PACKAGE_PREFIX}-icestorm"
-  "${MINGW_PACKAGE_PREFIX}-openmp"
   "${MINGW_PACKAGE_PREFIX}-python"
   "${MINGW_PACKAGE_PREFIX}-prjtrellis"
   "git"

--- a/mingw-w64-nextpnr/PKGBUILD
+++ b/mingw-w64-nextpnr/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=nextpnr
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.1.r3958.gc272d28e
-pkgrel=2
+pkgver=0.1.r3966.g3d24583b
+pkgrel=1
 pkgdesc="Portable FPGA place and route tool (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -28,7 +28,7 @@ makedepends=(
   "git"
 )
 
-_commit="c272d28e"
+_commit="3d24583b"
 source=("${_realname}::git+https://github.com/YosysHQ/${_realname}.git#commit=${_commit}")
 sha256sums=('SKIP')
 


### PR DESCRIPTION
nextpnr now requires openmp at runtime. This PR updates the recipe. By the way, nextpnr and iverilog are bumped.