### PR TITLE
mesa: libsystre is a required runtime dependency when built with regex

### DIFF
--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -4,7 +4,7 @@ _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=21.3.3
-pkgrel=2
+pkgrel=3
 pkgdesc="Open-source implementation of the OpenGL specification (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -20,10 +20,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-llvm"
              "${MINGW_PACKAGE_PREFIX}-libsystre")
 depends=("${MINGW_PACKAGE_PREFIX}-llvm"
          "${MINGW_PACKAGE_PREFIX}-zlib"
-         "${MINGW_PACKAGE_PREFIX}-vulkan-loader")
+         "${MINGW_PACKAGE_PREFIX}-vulkan-loader"
+         "${MINGW_PACKAGE_PREFIX}-libsystre")
 optdepends=("${MINGW_PACKAGE_PREFIX}-opengl-man-pages: for the OpenGL API man pages"
-            "${MINGW_PACKAGE_PREFIX}-zstd: use ZSTD instead of zlib for certain compression tasks"
-            "${MINGW_PACKAGE_PREFIX}-libsystre: for regex capabilities in driconf")
+            "${MINGW_PACKAGE_PREFIX}-zstd: use ZSTD instead of zlib for certain compression tasks")
 url="https://www.mesa3d.org/"
 license=('MIT')
 options=('staticlibs' 'strip')

--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -8,7 +8,8 @@ pkgrel=3
 pkgdesc="Open-source implementation of the OpenGL specification (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
-makedepends=("${MINGW_PACKAGE_PREFIX}-llvm"
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-llvm"
              "${MINGW_PACKAGE_PREFIX}-python-mako"
              "${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"

--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -9,16 +9,13 @@ pkgdesc="Open-source implementation of the OpenGL specification (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-llvm"
              "${MINGW_PACKAGE_PREFIX}-python-mako"
              "${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
-             "${MINGW_PACKAGE_PREFIX}-vulkan-loader"
              "${MINGW_PACKAGE_PREFIX}-spirv-tools"
              "${MINGW_PACKAGE_PREFIX}-vulkan-validation-layers"
              "${MINGW_PACKAGE_PREFIX}-libelf"
-             "${MINGW_PACKAGE_PREFIX}-zstd"
-             "${MINGW_PACKAGE_PREFIX}-libsystre")
+             "${MINGW_PACKAGE_PREFIX}-zstd")
 depends=("${MINGW_PACKAGE_PREFIX}-llvm"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-vulkan-loader"


### PR DESCRIPTION
I can't believe nobody complained yet as this has been a problem since 67a20110.
![mesa-libsystre-mandatory](https://user-images.githubusercontent.com/1138235/148841585-72b1fb5d-61ca-4d3a-ae89-244507dfbcde.png)
