### PR TITLE
gettext: do include the libintl_*wprintf() functions

### DIFF
--- a/mingw-w64-gettext/0001-printf.c-guard-the-wprintf-functions-by-the-correct-.patch
+++ b/mingw-w64-gettext/0001-printf.c-guard-the-wprintf-functions-by-the-correct-.patch
@@ -1,0 +1,57 @@
+From b7b09177379f2ee8a56bcd9c98635d4f513d9807 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Mon, 10 Jan 2022 23:18:34 +0100
+Subject: [PATCH] printf.c: guard the *wprintf() functions by the correct
+ constant
+
+In dcaf8c4d7 (Cygwin portability., 2003-09-17), the *wprintf() family of
+functions in `gettext-runtime/intl/printf.c` were no longer guarded by
+the constant `HAVE_WPRINTF`, but instead by `HAVE_FWPRINTF`.
+
+This apparently worked even if the corresponding part in
+`gettext-runtime/intl/libgnuintl.h.in` uses `HAVE_WPRINTF` to guard the
+_declarations_ of those functions.
+
+However, in d84f20745 (Make sure that libintl.h declares the *wprintf
+overrides on Windows., 2019-04-08), gettext introduced a change where it
+would look for `wprintf()` instead of `fwprintf()`. As a consequence it
+would no longer define the `HAVE_FWPRINTF` constant at all.
+
+GCC apparently interprets `#if HAVE_FWPRINTF` as `#if 0` if the constant
+has not even been defined.
+
+This leads to the funny situation that previously, the *wprintf()
+functions would be defined, but not be declared. Whereas now the
+functions are not defined, but declared.
+
+Also funny: Cygwin did not even export the `fwprintf()` function until
+2009, as per Cygwin's 45e20e47ba (cygwin.din: Export wprintf,
+fwprintf, swprintf, vwprintf, vfwprintf, vswprintf. [...] , 2009-03-06),
+while the `wprintf()` function was exported already in 2003. So the
+Cygwin portability patch from 2003 seems to have turned off _all_ of the
+*wprintf() functions in gettext.
+
+Let's revert that "portability" patch, as it now only does harm and has
+no benefit anymore.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ gettext-runtime/intl/printf.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gettext-runtime/intl/printf.c b/gettext-runtime/intl/printf.c
+index d327c5ebc..651b3aba0 100644
+--- a/gettext-runtime/intl/printf.c
++++ b/gettext-runtime/intl/printf.c
+@@ -310,7 +310,7 @@ libintl_asprintf (char **resultp, const char *format, ...)
+ 
+ #endif
+ 
+-#if HAVE_FWPRINTF
++#if HAVE_WPRINTF
+ 
+ #include <wchar.h>
+ 
+-- 
+2.34.1.windows.1
+

--- a/mingw-w64-gettext/PKGBUILD
+++ b/mingw-w64-gettext/PKGBUILD
@@ -5,7 +5,7 @@ _realname=gettext
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.21
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://www.gnu.org/software/gettext/"
@@ -21,12 +21,14 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-ncurses"
              "${MINGW_PACKAGE_PREFIX}-cc")
 options=('strip' 'staticlibs')
 source=("https://ftp.gnu.org/pub/gnu/${_realname}/${_realname}-${pkgver}.tar.gz"
+	0001-printf.c-guard-the-wprintf-functions-by-the-correct-.patch
         0005-Fix-compilation-of-pthread_sigmask.c.patch
         0010-build-Fix-build-failure-on-mingw-formatstring_ruby.patch
         0011-fix-interference-between-libintl-boost-header-files.patch
         122-Use-LF-as-newline-in-envsubst.patch
         0020-0.21-disable-libtextstyle.patch)
 sha256sums=('c77d0da3102aec9c07f43671e60611ebff89a996ef159497ce8e59d075786b12'
+            '16741a6250ba49744b01c9986e7164b25d2143dfcee3eeeb422a5e96f3e6cdd5'
             'cbc2f533012d646521afa20f8b256917fce040741ff42cf53fb6dd7123a6670a'
             'c4a85dc6d781d29bdcdc557d8867408f2181d871338f6a1c4b9e6fcd78dc3e7f'
             '41201d74f5f352c4fe219316340521fc3f9a0f3a7c572a3ddd3b8df33d4dab9a'
@@ -47,6 +49,7 @@ prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
   apply_patch_with_msg \
+    0001-printf.c-guard-the-wprintf-functions-by-the-correct-.patch \
     0005-Fix-compilation-of-pthread_sigmask.c.patch \
     0010-build-Fix-build-failure-on-mingw-formatstring_ruby.patch \
     0011-fix-interference-between-libintl-boost-header-files.patch \


### PR DESCRIPTION
These functions are declared in `libintl.h`, but not included in `libintl-8.dll`. All programs that use gettext and also call `swprintf()` won't build. See e.g. [this build failure](https://github.com/git-for-windows/git-sdk-64/runs/4756702638?check_suite_focus=true#step:8:672).

Let's fix that.

Fun fact: in v0.19.8.1, those functions were included in the library, but not declared in the header.
In v0.21 the were _not_ included in the library, but they _were_ declared in the header.

So we're actually fixing a long-standing bug here.