### PR TITLE
bc: update to 1.07.1

### DIFF
--- a/mingw-w64-bc/0001-use-rand-on-windows.patch
+++ b/mingw-w64-bc/0001-use-rand-on-windows.patch
@@ -1,0 +1,15 @@
+diff -Naur bc-1.07.1/bc/execute.c bc-1.07.1/bc/execute.c
+--- bc-1.07.1/bc/execute.c	2017-04-07 17:20:02.000000000 -0500
++++ bc-1.07.1/bc/execute.c	2022-01-10 19:57:06.369303434 -0600
+@@ -293,7 +293,11 @@
+ 
+ 	case 'X': /* Random function. */
+ 	  push_copy (_zero_);
++#ifdef _WIN32
++	  bc_int2num (&ex_stack->s_num, rand());
++#else
+ 	  bc_int2num (&ex_stack->s_num, random());
++#endif
+ 	  break;
+ 	}
+ 	break;

--- a/mingw-w64-bc/0002-fix-fix-libmath_h.patch
+++ b/mingw-w64-bc/0002-fix-fix-libmath_h.patch
@@ -1,0 +1,12 @@
+diff -Naur bc-1.07.1/bc/Makefile.am bc-1.07.1/bc/Makefile.am
+--- bc-1.07.1/bc/Makefile.am	2017-04-07 15:09:29.000000000 -0500
++++ bc-1.07.1/bc/Makefile.am	2022-01-10 20:23:24.853298247 -0600
+@@ -36,7 +36,7 @@
+ 	$(MAKE) global.o
+ 	$(LINK) -o fbc $(fbcOBJ) global.o $(LIBBC) $(LIBL) $(READLINELIB) $(LIBS)
+ 	./fbc -c $(srcdir)/libmath.b </dev/null >libmath.h
+-	$(srcdir)/fix-libmath_h
++	sh $(srcdir)/fix-libmath_h
+ 	rm -f ./fbc ./global.o
+ 
+ sbcOBJ = main.o sbc.o scan.o execute.o global.o load.o storage.o util.o \

--- a/mingw-w64-bc/0003-use-binary-io.patch
+++ b/mingw-w64-bc/0003-use-binary-io.patch
@@ -1,0 +1,26 @@
+diff -Naur bc-1.07.1-orig/bc/main.c bc-1.07.1/bc/main.c
+--- bc-1.07.1-orig/bc/main.c	2017-04-07 17:20:02.000000000 -0500
++++ bc-1.07.1/bc/main.c	2022-01-10 22:00:50.009302332 -0600
+@@ -33,6 +33,10 @@
+ #include "proto.h"
+ #include "getopt.h"
+ 
++#ifdef _WIN32
++#include <io.h>
++#include <fcntl.h>
++#endif
+ 
+ /* Variables for processing multiple files. */
+ static char first_file;
+@@ -171,7 +175,10 @@
+   if (isatty(0) && isatty(1)) 
+     interactive = TRUE;
+ 
+-#ifdef HAVE_SETVBUF
++#ifdef _WIN32
++  _setmode(_fileno(stdout), _O_BINARY);
++  (void)setvbuf(stdout, NULL, _IONBF, 0);
++#elif defined(HAVE_SETVBUF)
+   /* attempt to simplify interaction with applications such as emacs */
+   (void) setvbuf(stdout, NULL, _IOLBF, 0);
+ #endif

--- a/mingw-w64-bc/PKGBUILD
+++ b/mingw-w64-bc/PKGBUILD
@@ -4,28 +4,41 @@
 _realname=bc
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.06
-pkgrel=2
+pkgver=1.07.1
+pkgrel=1
 pkgdesc='bc is an arbitrary precision numeric processing language (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://www.gnu.org/software/bc/'
 license=('GPL3')
 options=('strip' '!libtool' 'staticlibs')
-makedepends=("${MINGW_PACKAGE_PREFIX}-autotools" "${MINGW_PACKAGE_PREFIX}-cc")
-source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('4ef6d9f17c3c0d92d8798e35666175ecd3d8efac4009d6457b5c99cea72c0e33')
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools" "${MINGW_PACKAGE_PREFIX}-cc" "ed")
+depends=("${MINGW_PACKAGE_PREFIX}-readline")
+source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.gz"
+        "0001-use-rand-on-windows.patch"
+        "0002-fix-fix-libmath_h.patch"
+        "0003-use-binary-io.patch")
+sha256sums=('62adfca89b0a1c0164c2cdca59ca210c1d44c3ffc46daf9931cf4942664cb02a'
+            'd0203c9cbe9764ddb4ef50f5c2bda6f0b0483d01d2c5e8722be5826c28300f71'
+            'c1c638e5387dd81ac210ed1bc68e4e09e23a18b0fd992ff03dbe5e1390ff3706'
+            '1c796bb531b1d516e0170d4bd88ff8c6869d41132736eab27da4fcc9e6fdfad2')
 
 prepare() {
   cd $srcdir/${_realname}-${pkgver}
+  patch -p1 -i "${srcdir}"/0001-use-rand-on-windows.patch
+  patch -p1 -i "${srcdir}"/0002-fix-fix-libmath_h.patch
+  patch -p1 -i "${srcdir}"/0003-use-binary-io.patch
+  autoreconf -fiv
 }
 
 build() {
   cd $srcdir/${_realname}-${pkgver}
-  ./configure --prefix=${MINGW_PREFIX} \
+  ./configure \
+    --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
-    --target=${MINGW_CHOST}
+    --target=${MINGW_CHOST} \
+    --with-readline
 
   make
 }


### PR DESCRIPTION
Introduces 3 new patches

- 0001-use-rand-on-windows.patch replaces the usage of posix's `random()` with simple `rand()`
- 0002-fix-fix-libmath_h.patch prepends a shell script that lacks a shebang or .sh suffix with sh
- 0003-use-binary-io.patch fixes an issue where due to printf being in TEXT mode, the lines are trailed with `\r\n` instead of `\n` breaking ed along with an issue where due to the buffering, running
    ```bash
    bc -l
    warranty
    ```
    doesn't print anything until you exited the program, unless you used winpty

I have no clue how it will interact with emacs as I don't know how emacs interacts with bc