### PR TITLE
vapoursynth: Fix loading python module

### DIFF
--- a/mingw-w64-vapoursynth/0002-prevent-portable-python.patch
+++ b/mingw-w64-vapoursynth/0002-prevent-portable-python.patch
@@ -1,0 +1,17 @@
+--- a/src/vsscript/vsscript.cpp
++++ b/src/vsscript/vsscript.cpp
+@@ -41,7 +41,13 @@
+ static PyGILState_STATE s;
+ 
+ static void real_init(void) VS_NOEXCEPT {
+-#ifdef VS_TARGET_OS_WINDOWS
++
++//
++// Search for portable python library only if compiled with
++// MSVC toolchain. In MINGW, shared libraries are already
++// linked with libpython*.dll
++//
++#if defined(VS_TARGET_OS_WINDOWS) && defined(_MSC_VER)
+ #ifdef _WIN64
+     #define VS_INSTALL_REGKEY L"Software\\VapourSynth"
+ #else

--- a/mingw-w64-vapoursynth/PKGBUILD
+++ b/mingw-w64-vapoursynth/PKGBUILD
@@ -4,7 +4,7 @@ _realname=vapoursynth
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=57
-pkgrel=2
+pkgrel=3
 pkgdesc="A video processing framework with simplicity in mind (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -19,13 +19,20 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-sphinx")
 options=(!strip staticlibs)
 source=("vapoursynth-${pkgver}.tar.gz::https://github.com/vapoursynth/vapoursynth/archive/R${pkgver}.tar.gz"
-        "0001-wrong-arguments-to-Mem32-constructor.patch")
+        "0001-wrong-arguments-to-Mem32-constructor.patch"
+        "0002-prevent-portable-python.patch")
 sha256sums=('9bed2ab1823050cfcbdbb1a57414e39507fd6c73f07ee4b5986fcbf0f6cb2d07'
-            '085331d7c81da760b66864ec34647094384514689e7ea9895e7bd34ed9ce9831')
+            '085331d7c81da760b66864ec34647094384514689e7ea9895e7bd34ed9ce9831'
+            'bc75208eb672446a23535455040d0f5a7e49e19e8276773dd9bc30ee87da2e27')
 
 prepare() {
   cd "${srcdir}/${_realname}-R${pkgver}"
-  patch -Nbp1 -i "${srcdir}/0001-wrong-arguments-to-Mem32-constructor.patch"
+  patch -p1 -i "${srcdir}/0001-wrong-arguments-to-Mem32-constructor.patch"
+
+  # Upstream does not support mingw, see
+  # https://github.com/vapoursynth/vapoursynth/pull/841
+  patch -p1 -i "${srcdir}/0002-prevent-portable-python.patch"
+
   autoreconf -vfi
 }
 
@@ -58,4 +65,8 @@ package() {
 
   rm -f ${pkgdir}${MINGW_PREFIX}/lib/vapoursynth/*.dll.a
   rm -f ${pkgdir}${MINGW_PREFIX}/lib/python${_py3ver}/site-packages/*.dll.a
+
+  # Temporary fix
+  cp ${pkgdir}${MINGW_PREFIX}/lib/python${_py3ver}/site-packages/vapoursynth.dll \
+     ${pkgdir}${MINGW_PREFIX}/lib/python${_py3ver}/site-packages/vapoursynth.pyd
 }


### PR DESCRIPTION
Fixes https://github.com/msys2/MINGW-packages/issues/10528 and Fixes https://github.com/msys2/MINGW-packages/issues/6630. Please review.