### PR TITLE
gettext: fix error when passing "nul" as an output filename

### DIFF
--- a/mingw-w64-gettext/2001-gnulib-open-bug.patch
+++ b/mingw-w64-gettext/2001-gnulib-open-bug.patch
@@ -1,0 +1,71 @@
+diff --git a/lib/supersede.c b/lib/supersede.c
+index 92317f2..a03cc6d 100644
+--- a/lib/supersede.c
++++ b/lib/supersede.c
+@@ -78,6 +78,16 @@ open_supersede (const char *filename, int flags, mode_t mode,
+                 struct supersede_final_action *action)
+ {
+   int fd;
++  /* Extra flags for existing devices.  */
++  int extra_flags =
++    #if defined __sun
++    /* open ("/dev/null", O_TRUNC | O_WRONLY) fails with error EINVAL on Solaris
++       zones.  See <https://www.illumos.org/issues/13035>.  As a workaround, add
++       the O_CREAT flag, although it ought not to be necessary.  */
++    O_CREAT;
++    #else
++    0;
++    #endif
+ 
+   if (supersede_if_exists)
+     {
+@@ -89,7 +99,7 @@ open_supersede (const char *filename, int flags, mode_t mode,
+               && ! S_ISREG (statbuf.st_mode)
+               /* The file exists and is possibly a character device, socket, or
+                  something like that.  */
+-              && ((fd = open (filename, flags, mode)) >= 0
++              && ((fd = open (filename, flags | extra_flags, mode)) >= 0
+                   || errno != ENOENT))
+             {
+               if (fd >= 0)
+@@ -167,7 +177,7 @@ open_supersede (const char *filename, int flags, mode_t mode,
+                         {
+                           /* It is possibly a character device, socket, or
+                              something like that.  */
+-                          fd = open (canon_filename, flags, mode);
++                          fd = open (canon_filename, flags | extra_flags, mode);
+                           if (fd >= 0)
+                             {
+                               free (canon_filename);
+@@ -197,6 +207,28 @@ open_supersede (const char *filename, int flags, mode_t mode,
+               action->final_rename_temp = NULL;
+               action->final_rename_dest = NULL;
+             }
++          #if defined __sun
++          /* Work around <https://www.illumos.org/issues/13035>.  */
++          else if (errno == EINVAL)
++            {
++              struct stat statbuf;
++
++              if (stat (filename, &statbuf) >= 0
++                  && ! S_ISREG (statbuf.st_mode))
++                {
++                  /* The file exists and is possibly a character device, socket,
++                     or something like that.  As a workaround, add the O_CREAT
++                     flag, although it ought not to be necessary.*/
++                  fd = open (filename, flags | extra_flags, mode);
++                  if (fd >= 0)
++                    {
++                      /* The file exists.  */
++                      action->final_rename_temp = NULL;
++                      action->final_rename_dest = NULL;
++                    }
++                }
++            }
++          #endif
+           else if (errno == ENOENT)
+             {
+               /* The file does not exist.  Use a temporary file.  */
+-- 
+cgit v1.1
+

--- a/mingw-w64-gettext/2002-gnulib-open-bug.patch
+++ b/mingw-w64-gettext/2002-gnulib-open-bug.patch
@@ -1,0 +1,34 @@
+diff --git a/lib/supersede.c b/lib/supersede.c
+index a03cc6d..a3dfa4f 100644
+--- a/lib/supersede.c
++++ b/lib/supersede.c
+@@ -80,10 +80,12 @@ open_supersede (const char *filename, int flags, mode_t mode,
+   int fd;
+   /* Extra flags for existing devices.  */
+   int extra_flags =
+-    #if defined __sun
++    #if defined __sun || (defined _WIN32 && !defined __CYGWIN__)
+     /* open ("/dev/null", O_TRUNC | O_WRONLY) fails with error EINVAL on Solaris
+-       zones.  See <https://www.illumos.org/issues/13035>.  As a workaround, add
+-       the O_CREAT flag, although it ought not to be necessary.  */
++       zones.  See <https://www.illumos.org/issues/13035>.
++       Likewise for open ("NUL", O_TRUNC | O_RDWR) on native Windows.
++       As a workaround, add the O_CREAT flag, although it ought not to be
++       necessary.  */
+     O_CREAT;
+     #else
+     0;
+@@ -207,8 +209,8 @@ open_supersede (const char *filename, int flags, mode_t mode,
+               action->final_rename_temp = NULL;
+               action->final_rename_dest = NULL;
+             }
+-          #if defined __sun
+-          /* Work around <https://www.illumos.org/issues/13035>.  */
++          #if defined __sun || (defined _WIN32 && !defined __CYGWIN__)
++          /* See the comment regarding extra_flags, above.  */
+           else if (errno == EINVAL)
+             {
+               struct stat statbuf;
+-- 
+cgit v1.1
+

--- a/mingw-w64-gettext/PKGBUILD
+++ b/mingw-w64-gettext/PKGBUILD
@@ -5,7 +5,7 @@ _realname=gettext
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.21
-pkgrel=2
+pkgrel=3
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://www.gnu.org/software/gettext/"
@@ -26,14 +26,18 @@ source=("https://ftp.gnu.org/pub/gnu/${_realname}/${_realname}-${pkgver}.tar.gz"
         0010-build-Fix-build-failure-on-mingw-formatstring_ruby.patch
         0011-fix-interference-between-libintl-boost-header-files.patch
         122-Use-LF-as-newline-in-envsubst.patch
-        0020-0.21-disable-libtextstyle.patch)
+        0020-0.21-disable-libtextstyle.patch
+        2001-gnulib-open-bug.patch
+        2002-gnulib-open-bug.patch)
 sha256sums=('c77d0da3102aec9c07f43671e60611ebff89a996ef159497ce8e59d075786b12'
             '16741a6250ba49744b01c9986e7164b25d2143dfcee3eeeb422a5e96f3e6cdd5'
             'cbc2f533012d646521afa20f8b256917fce040741ff42cf53fb6dd7123a6670a'
             'c4a85dc6d781d29bdcdc557d8867408f2181d871338f6a1c4b9e6fcd78dc3e7f'
             '41201d74f5f352c4fe219316340521fc3f9a0f3a7c572a3ddd3b8df33d4dab9a'
             'ef9f11a1cd10539d4323c6fcba3013cc503d47366004fe8a99c642dc3ddf2fd0'
-            '544ce0589e9c70f4f75d77c76fd36f88d009ac9cfecb4812a67f878e38ac6418')
+            '544ce0589e9c70f4f75d77c76fd36f88d009ac9cfecb4812a67f878e38ac6418'
+            '41cb9fdd466a304688fe4e192e3b381963dd2831a162592f792cc26fdfc16bc7'
+            '2b4dbb3de850afa108f82b9bf4e74631e2aa35ae7a9addea23c430ed7e03203d')
 validpgpkeys=('462225C3B46F34879FC8496CD605848ED7E69871') #Daiki Ueno
 
 # Helper macros to help make tasks easier #
@@ -58,6 +62,14 @@ prepare() {
   # https://src.fedoraproject.org/rpms/gettext/blob/1b17af56abe8f1ba5df0218a88bb495ce81466b5/f/gettext-0.21-disable-libtextstyle.patch
   apply_patch_with_msg \
     0020-0.21-disable-libtextstyle.patch
+
+  # https://github.com/msys2/MINGW-packages/issues/10520
+  # https://git.savannah.gnu.org/cgit/gnulib.git/commit/?id=fd47c1834c2bcb8772f7a320ab088d802b1ca649
+  # https://git.savannah.gnu.org/cgit/gnulib.git/commit/?id=3fcdcac504be1e4d55cbee0fa185b380712545d7
+  pushd gettext-tools/gnulib-lib
+    patch -Nbp2 -i "${srcdir}/2001-gnulib-open-bug.patch"
+    patch -Nbp2 -i "${srcdir}/2002-gnulib-open-bug.patch"
+  popd
 
   libtoolize --automake --copy --force
   WANT_AUTOMAKE=latest ./autogen.sh --skip-gnulib


### PR DESCRIPTION
For example msgfmt and other tools would fail with "-o nul" which
previously worked.

Backport two gnulib patches which fix this regression.

Fixes #10520