### PR TITLE
mesa: Update to 21.3.4

### DIFF
--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=21.3.3
-pkgrel=3
+pkgver=21.3.4
+pkgrel=1
 pkgdesc="Open-source implementation of the OpenGL specification (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -12,8 +12,6 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-mako"
              "${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
-             "${MINGW_PACKAGE_PREFIX}-spirv-tools"
-             "${MINGW_PACKAGE_PREFIX}-vulkan-validation-layers"
              "${MINGW_PACKAGE_PREFIX}-libelf"
              "${MINGW_PACKAGE_PREFIX}-zstd")
 depends=("${MINGW_PACKAGE_PREFIX}-llvm"
@@ -21,7 +19,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-llvm"
          "${MINGW_PACKAGE_PREFIX}-vulkan-loader"
          "${MINGW_PACKAGE_PREFIX}-libsystre")
 optdepends=("${MINGW_PACKAGE_PREFIX}-opengl-man-pages: for the OpenGL API man pages"
-            "${MINGW_PACKAGE_PREFIX}-zstd: use ZSTD instead of zlib for certain compression tasks")
+            "${MINGW_PACKAGE_PREFIX}-zstd: use ZSTD instead of zlib for certain compression tasks"
+            "${MINGW_PACKAGE_PREFIX}-vulkan-validation-layers: to debug applications using Vulkan graphics")
 url="https://www.mesa3d.org/"
 license=('MIT')
 options=('staticlibs' 'strip')
@@ -34,7 +33,7 @@ source=(https://mesa.freedesktop.org/archive/${_realname}-${pkgver}.tar.xz{,.sig
         0005-win32-The-opengl-headers-should-install-to-mesa-GL-s.patch
         0006-win32-Fixes-32-bits-visual-studio-module-definition-.patch
         0007-win32-Do-not-use-BUILD_GL32-we-use-def-file-to-expor.patch)
-sha256sums=('ad7f4613ea7c5d08d9fcb5025270199e6ceb9aa99fd72ee572b70342240a8121'
+sha256sums=('77104fd4a93bce69da3b0982f8ee88ba7c4fb98cfc491a669894339cdcd4a67d'
             'SKIP'
             '69f21522f20c10f5699dfe3e128aa88d4fedde816f6e8df1506d7470c44bf3da'
             'e5aa27b6aba3e75335bbd6d989c52dd42a8435ef87a1453267164e9612daee1a'


### PR DESCRIPTION
SPIRV tools is only used when building Microsoft CLC or clover with SPIR-V binary support. None of these build with MSYS2 due to libclc not being available and possibly other unknown reasons.

Vulkan validation layers is only used for debugging and it's not used specifically by Mesa3D.