### PR TITLE
ghdl: update to 1.0.0.r964.g70f3c162b

### DIFF
--- a/mingw-w64-ghdl/PKGBUILD
+++ b/mingw-w64-ghdl/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=ghdl
 pkgbase="mingw-w64-${_realname}"
 pkgname='__placeholder__'
-pkgver=1.0.0.r950.g8d512a44b
+pkgver=1.0.0.r964.g70f3c162b
 pkgrel=1
 pkgdesc='GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL'
 arch=('any')
@@ -12,7 +12,7 @@ groups=("${MINGW_PACKAGE_PREFIX}-eda")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 
-_commit="8d512a44"
+_commit="70f3c162"
 source=("${_realname}::git+https://github.com/ghdl/ghdl.git#commit=${_commit}")
 sha512sums=('SKIP')
 
@@ -75,7 +75,11 @@ _package() {
 
 if [ "${CARCH}" = "x86_64" ]; then
   pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-llvm")
-  makedepends=("${MINGW_PACKAGE_PREFIX}-clang" "${MINGW_PACKAGE_PREFIX}-autotools")
+  makedepends=(
+    "${MINGW_PACKAGE_PREFIX}-clang"
+    "${MINGW_PACKAGE_PREFIX}-autotools"
+    "${MINGW_PACKAGE_PREFIX}-gcc-ada"
+  )
   package() {
     pkgdesc="$pkgdesc (LLVM backend) (mingw-w64)"
     depends=(
@@ -90,7 +94,11 @@ if [ "${CARCH}" = "x86_64" ]; then
 fi
 if [ "${CARCH}" = "i686" ]; then
   pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-mcode")
-  makedepends=("${MINGW_PACKAGE_PREFIX}-cc" "${MINGW_PACKAGE_PREFIX}-autotools")
+  makedepends=(
+    "${MINGW_PACKAGE_PREFIX}-cc"
+    "${MINGW_PACKAGE_PREFIX}-autotools"
+    "${MINGW_PACKAGE_PREFIX}-gcc-ada"
+  )
   package() {
     pkgdesc="$pkgdesc (mcode backend) (mingw-w64)"
     depends=(


### PR DESCRIPTION
I had to add `*-gcc-ada` as makedepends, because gnatmake would not be found otherwise. I thought that both makedepends and depends were installed before executing `build()`. Did the behaviour change?