### PR TITLE
uchardet: Fix pkgconfig file

### DIFF
--- a/mingw-w64-uchardet/0001-fix-pkgconfig-files.patch
+++ b/mingw-w64-uchardet/0001-fix-pkgconfig-files.patch
@@ -1,0 +1,11 @@
+--- a/uchardet.pc.in
++++ b/uchardet.pc.in
+@@ -1,5 +1,6 @@
+-libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+-includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
++prefix=@CMAKE_INSTALL_PREFIX@
++libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
++includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+ 
+ Name: uchardet
+ Description: An encoding detector library ported from Mozilla

--- a/mingw-w64-uchardet/PKGBUILD
+++ b/mingw-w64-uchardet/PKGBUILD
@@ -4,32 +4,43 @@ _realname=uchardet
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.0.7
-pkgrel=1
+pkgrel=2
 pkgdesc="An encoding detector library ported from Mozilla (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://www.freedesktop.org/wiki/Software/uchardet/'
 license=('MPL')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
-makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-cc")
-source=("https://www.freedesktop.org/software/uchardet/releases/${_realname}-${pkgver}.tar.xz")
-sha256sums=('3fc79408ae1d84b406922fa9319ce005631c95ca0f34b205fad867e8b30e45b1')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
+source=("https://www.freedesktop.org/software/uchardet/releases/${_realname}-${pkgver}.tar.xz"
+        0001-fix-pkgconfig-files.patch)
+sha256sums=('3fc79408ae1d84b406922fa9319ce005631c95ca0f34b205fad867e8b30e45b1'
+            'c26a5ebdbeea80f7f28d6ea2405ad86a0a7ceb0782f88bd511c05058b81829d7')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+  patch -p1 -i "${srcdir}/0001-fix-pkgconfig-files.patch"
+}
 
 build() {
-  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -r "${srcdir}/build-${MINGW_CHOST}"
-  mkdir "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
+  [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -r "${srcdir}/build-${MSYSTEM}"
+  mkdir "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-  ${MINGW_PREFIX}/bin/cmake \
-    -G"MSYS Makefiles" \
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G"Ninja" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DCMAKE_BUILD_TYPE=Release \
     ../${_realname}-${pkgver}
-  make
+
+  ${MINGW_PREFIX}/bin/cmake.exe --build ./
 }
 
 package() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
-  make DESTDIR="$pkgdir" install
+  cd "${srcdir}/build-${MSYSTEM}"
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install ./
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }


### PR DESCRIPTION
This enables relocated directories in pkg-config output. e.g. from
-I/mingw64/include/uchardet to -IC:/msys64/mingw64/include/uchardet

Also use ninja instead of make. And install license file.

Please review.