### PR TITLE
prjtrellis: don't force clang

### DIFF
--- a/mingw-w64-prjtrellis/PKGBUILD
+++ b/mingw-w64-prjtrellis/PKGBUILD
@@ -4,7 +4,7 @@ _realname=prjtrellis
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.0.r1031.2f06397
-pkgrel=1
+pkgrel=2
 pkgdesc="Documenting the Lattice ECP5 bit-stream format (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -17,8 +17,8 @@ depends=(
 )
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-boost"
+  "${MINGW_PACKAGE_PREFIX}-cc"
   "${MINGW_PACKAGE_PREFIX}-cmake"
-  "${MINGW_PACKAGE_PREFIX}-clang"
   "git"
 )
 
@@ -45,8 +45,6 @@ build() {
 
   MSYS2_ARG_CONV_EXCL='-DCMAKE_INSTALL_PREFIX=' cmake \
     -G "MSYS Makefiles" \
-    -DCMAKE_C_COMPILER=clang \
-    -DCMAKE_CXX_COMPILER=clang++ \
     -DCMAKE_PREFIX_PATH=${MINGW_PREFIX} \
     -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
     .


### PR DESCRIPTION
According to #10547, and tested by several users, using GCC instead of clang does fix the issues with an early check introduced in mingw-w64-crt. This PR changes prjtrellis not to use clang on the default where GCC is the default.

/cc @Biswa96 @stnolting @sylefeb 