### PR TITLE
cppcoro: Fix sed invocation

### DIFF
--- a/mingw-w64-cppcoro/PKGBUILD
+++ b/mingw-w64-cppcoro/PKGBUILD
@@ -3,7 +3,7 @@ _realname=cppcoro
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=r390.a87e97f
-pkgrel=1
+pkgrel=2
 pkgdesc=" A library of C++ coroutine abstractions for the coroutines TS (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -21,19 +21,9 @@ pkgver() {
 
 build(){
   # replace all std::experimental with std
-function scan_dir(){
-  for file in `ls $1` 
-  do
-      if [ -d $1"/"$file ] 
-      then 
-        scan_dir $1"/"$file
-      else 
-        sed 's/std::experimental/std/g' $1"/"$file | sed 's/experimental\///g' > $1"/"$file
-      fi
-  done
+  find "${srcdir}/cppcoro/include/cppcoro/" -type f -exec sed -e 's/std::experimental/std/g' -e 's|experimental/||g' -i \{\} \+
 }
-scan_dir "${srcdir}/cppcoro/include/cppcoro/"
-}
+
 package() {
   mkdir -p "${pkgdir}${MINGW_PREFIX}/"
   cp -r "${srcdir}/cppcoro/include/" "${pkgdir}${MINGW_PREFIX}/include/"


### PR DESCRIPTION
The current release of the x86_64 cppcoro package (mingw-w64-x86_64-cppcoro-r390.a87e97f-1) has an empty file for `/mingw64/include/cppcoro/broken_promise.hpp` because of a race condition in the sed commands in `PKGBUILD`. This PR is to fix the sed invocation.
