### PR TITLE
gcc: backport some long-jump fixes

### DIFF
--- a/mingw-w64-gcc/1001-Fix-freorder-blocks-and-partition-glitch-with-Window.patch
+++ b/mingw-w64-gcc/1001-Fix-freorder-blocks-and-partition-glitch-with-Window.patch
@@ -1,0 +1,60 @@
+From aef7d09baf91341540e7d468419918d58dd33601 Mon Sep 17 00:00:00 2001
+From: Eric Botcazou <ebotcazou@adacore.com>
+Date: Tue, 30 Nov 2021 10:17:09 +0100
+Subject: [PATCH] Fix -freorder-blocks-and-partition glitch with Windows SEH
+ (continued)
+
+This fixes a thinko in the fix for the -freorder-blocks-and-partition
+glitch with SEH on 64-bit Windows:
+  https://gcc.gnu.org/pipermail/gcc-patches/2021-February/565208.html
+
+Even if no exceptions are active, e.g. in C, we need to consider calls.
+
+gcc/
+	PR target/103274
+	* config/i386/i386.c (ix86_output_call_insn): Beef up comment about
+	nops emitted with SEH.
+	* config/i386/winnt.c (i386_pe_seh_unwind_emit): When switching to
+	the cold section, emit a nop before the directive if the previous
+	active instruction is a call.
+---
+ gcc/config/i386/i386.c  | 6 ++++--
+ gcc/config/i386/winnt.c | 4 ++--
+ 2 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/gcc/config/i386/i386.c b/gcc/config/i386/i386.c
+index 1448f3609c3..8e8c8beb366 100644
+--- a/gcc/config/i386/i386.c
++++ b/gcc/config/i386/i386.c
+@@ -16149,8 +16149,10 @@ ix86_output_call_insn (rtx_insn *insn, rtx call_op)
+ 	    break;
+ 
+ 	  /* If we get to the epilogue note, prevent a catch region from
+-	     being adjacent to the standard epilogue sequence.  If non-
+-	     call-exceptions, we'll have done this during epilogue emission. */
++	     being adjacent to the standard epilogue sequence.  Note that,
++	     if non-call exceptions are enabled, we already did it during
++	     epilogue expansion, or else, if the insn can throw internally,
++	     we already did it during the reorg pass.  */
+ 	  if (NOTE_P (i) && NOTE_KIND (i) == NOTE_INSN_EPILOGUE_BEG
+ 	      && !flag_non_call_exceptions
+ 	      && !can_throw_internal (insn))
+diff --git a/gcc/config/i386/winnt.c b/gcc/config/i386/winnt.c
+index b66263ad243..2d1debf2dbd 100644
+--- a/gcc/config/i386/winnt.c
++++ b/gcc/config/i386/winnt.c
+@@ -1244,9 +1244,9 @@ i386_pe_seh_unwind_emit (FILE *asm_out_file, rtx_insn *insn)
+   seh = cfun->machine->seh;
+   if (NOTE_P (insn) && NOTE_KIND (insn) == NOTE_INSN_SWITCH_TEXT_SECTIONS)
+     {
+-      /* See ix86_seh_fixup_eh_fallthru for the rationale.  */
++      /* See ix86_output_call_insn/seh_fixup_eh_fallthru for the rationale.  */
+       rtx_insn *prev = prev_active_insn (insn);
+-      if (prev && !insn_nothrow_p (prev))
++      if (prev && (CALL_P (prev) || !insn_nothrow_p (prev)))
+ 	fputs ("\tnop\n", asm_out_file);
+       fputs ("\t.seh_endproc\n", asm_out_file);
+       seh->in_cold_section = true;
+-- 
+2.34.1
+

--- a/mingw-w64-gcc/1002-Properly-enable-freorder-blocks-and-partition-on-64-.patch
+++ b/mingw-w64-gcc/1002-Properly-enable-freorder-blocks-and-partition-on-64-.patch
@@ -1,0 +1,46 @@
+From 27e6c84c1f14a8195a3f9fb489c240ecc7a6257d Mon Sep 17 00:00:00 2001
+From: Eric Botcazou <ebotcazou@adacore.com>
+Date: Mon, 10 Jan 2022 12:40:10 +0100
+Subject: [PATCH] Properly enable -freorder-blocks-and-partition on 64-bit
+ Windows
+
+The PR uncovered that -freorder-blocks-and-partition was working by accident
+on 64-bit Windows, i.e. the middle-end was supposed to disable it with SEH.
+After the change installed on mainline, the middle-end properly disables it,
+which is too bad since a significant amount of work went into it for SEH.
+
+gcc/
+	PR target/103465
+	* coretypes.h (unwind_info_type): Swap UI_SEH and UI_TARGET.
+---
+ gcc/coretypes.h | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/gcc/coretypes.h b/gcc/coretypes.h
+index 406572e947d..732c76f5cbf 100644
+--- a/gcc/coretypes.h
++++ b/gcc/coretypes.h
+@@ -227,15 +227,17 @@ enum stack_protector {
+   SPCT_FLAG_EXPLICIT = 4
+ };
+ 
+-/* Types of unwind/exception handling info that can be generated.  */
++/* Types of unwind/exception handling info that can be generated.
++   Note that a UI_TARGET (or larger) setting is considered to be
++   incompatible with -freorder-blocks-and-partition.  */
+ 
+ enum unwind_info_type
+ {
+   UI_NONE,
+   UI_SJLJ,
+   UI_DWARF2,
+-  UI_TARGET,
+-  UI_SEH
++  UI_SEH,
++  UI_TARGET
+ };
+ 
+ /* Callgraph node profile representation.  */
+-- 
+2.34.1
+

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -24,7 +24,7 @@ pkgver=11.2.0
 #_majorver=${pkgver:0:1}
 #_sourcedir=${_realname}-${_majorver}-${_snapshot}
 _sourcedir=${_realname}-${pkgver}
-pkgrel=7
+pkgrel=8
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -66,7 +66,9 @@ source=("https://ftp.gnu.org/gnu/gcc/${_realname}-${pkgver%%+*}/${_realname}-${p
         0140-gcc-8.2.0-diagnostic-color.patch
         0150-gcc-10.2.0-libgcc-ldflags.patch
         0200-add-m-no-align-vector-insn-option-for-i386.patch
-        0300-override-builtin-printf-format.patch)
+        0300-override-builtin-printf-format.patch
+        1001-Fix-freorder-blocks-and-partition-glitch-with-Window.patch
+        1002-Properly-enable-freorder-blocks-and-partition-on-64-.patch)
 sha256sums=('d08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b'
             'SKIP'
             'bce81824fc89e5e62cca350de4c17a27e27a18a1a1ad5ca3492aec1fc5af3234'
@@ -86,7 +88,9 @@ sha256sums=('d08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b'
             '5240a9e731b45c17a164066c7eb193c1fbee9fd8d9a2a5afa2edbcde9510da47'
             '7f0b4e45d933e18c9d8bd2afcd83e4f52e97e2e25dd41bfa0cba755c70e591c7'
             '75c4f764741a1f5ed29adbed1b7085bf4a12a3dd6fb19347f5f63c3831a51953'
-            'b6c401790fce1f5e57a479d7820b11bd13b5711c28d263a25852cee68bcf8fd1')
+            'b6c401790fce1f5e57a479d7820b11bd13b5711c28d263a25852cee68bcf8fd1'
+            '579f7f4921a085cddd23b1282adc4bc3f1bbbd027eb545c86fe3db2a81537776'
+            '675df5cb664e9f0171fa008426c524fe44b04e58476dd1775027cd3bc5ce625b')
 validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.org
               86CFFCA918CF3AF47147588051E8B148A9999C34  # evangelos@foutrelis.com
               13975A70E63C361C73AE69EF6EEB81F8981C74C7  # richard.guenther@gmail.com
@@ -156,6 +160,11 @@ prepare() {
   # Related bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95130
   apply_patch_with_msg \
     0300-override-builtin-printf-format.patch
+
+  # https://github.com/msys2/MINGW-packages/pull/10589#issuecomment-1018478090
+  apply_patch_with_msg \
+    1001-Fix-freorder-blocks-and-partition-glitch-with-Window.patch \
+    1002-Properly-enable-freorder-blocks-and-partition-on-64-.patch
 
   # do not expect ${prefix}/mingw symlink - this should be superceded by
   # 0005-Windows-Don-t-ignore-native-system-header-dir.patch .. but isn't!


### PR DESCRIPTION
as suggested here: https://github.com/msys2/MINGW-packages/pull/10589#issuecomment-1018478090

Both are already on the gcc-11 branch