### PR TITLE
armadillo: Use LAPACK from f2cblaslapack for clang builds.

### DIFF
--- a/mingw-w64-armadillo/PKGBUILD
+++ b/mingw-w64-armadillo/PKGBUILD
@@ -13,6 +13,7 @@ license=(MPL2)
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-hdf5"
          $([[ ${MSYSTEM} == CLANG32 ]] || echo "${MINGW_PACKAGE_PREFIX}-openblas")
+         $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] && echo "${MINGW_PACKAGE_PREFIX}-f2cblaslapack")
          $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-arpack")
          )
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
@@ -38,7 +39,6 @@ build() {
     -G"Ninja" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DCMAKE_BUILD_TYPE=Release \
-    $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo -DLAPACK_NAMES=openblas) \
     ../${_realname}-${pkgver}
 
   cmake --build .

--- a/mingw-w64-armadillo/PKGBUILD
+++ b/mingw-w64-armadillo/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=armadillo
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=10.8.0
+pkgver=10.8.1
 pkgrel=1
 pkgdesc="C++ linear algebra library (mingw-w64)"
 arch=('any')
@@ -12,7 +12,7 @@ url="https://arma.sourceforge.io/"
 license=(MPL2)
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-hdf5"
-         $([[ ${MSYSTEM} == CLANG32 ]] || echo "${MINGW_PACKAGE_PREFIX}-openblas")
+         "${MINGW_PACKAGE_PREFIX}-openblas"
          $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] && echo "${MINGW_PACKAGE_PREFIX}-f2cblaslapack")
          $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-arpack")
          )
@@ -22,7 +22,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
 install=${_realname}-${MSYSTEM}.install
 source=(https://sourceforge.net/projects/arma/files/${_realname}-${pkgver}.tar.xz
         0001-mingw-config-fix.patch)
-sha256sums=('7c5d2fd4bba095733829f7fe03d4a74e732b81c75dd4d40001163487c967d5bc'
+sha256sums=('5087ab5a2268e5ce71798c1afcb6d1fb246463f8dc88a60db49a083600f98332'
             '772719e60eb2970ecb37844382dbcb6d0439f949c5080f9865798115640b612a')
 
 prepare() {
@@ -39,6 +39,7 @@ build() {
     -G"Ninja" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DCMAKE_BUILD_TYPE=Release \
+    $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo -DOPENBLAS_PROVIDES_LAPACK=ON) \
     ../${_realname}-${pkgver}
 
   cmake --build .


### PR DESCRIPTION
Depends on #10601. Replaces #10566. Fixes #10556. 