### PR TITLE
libopenmpt package was updated to 0.6.0 version.

### DIFF
--- a/mingw-w64-libopenmpt/PKGBUILD
+++ b/mingw-w64-libopenmpt/PKGBUILD
@@ -15,6 +15,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-zlib"
           "${MINGW_PACKAGE_PREFIX}-libogg"
           "${MINGW_PACKAGE_PREFIX}-libvorbis"
           "${MINGW_PACKAGE_PREFIX}-portaudio"
+          "${MINGW_PACKAGE_PREFIX}-portaudiocpp"
           "${MINGW_PACKAGE_PREFIX}-libsndfile"
           "${MINGW_PACKAGE_PREFIX}-flac")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
@@ -39,7 +40,6 @@ build() {
     --host=${MINGW_CHOST} \
     --enable-shared \
     --enable-static \
-    --without-portaudiocpp \
     --disable-examples
 
   make

--- a/mingw-w64-libopenmpt/PKGBUILD
+++ b/mingw-w64-libopenmpt/PKGBUILD
@@ -15,7 +15,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-zlib"
           "${MINGW_PACKAGE_PREFIX}-libogg"
           "${MINGW_PACKAGE_PREFIX}-libvorbis"
           "${MINGW_PACKAGE_PREFIX}-portaudio"
-          "${MINGW_PACKAGE_PREFIX}-portaudiocpp"
           "${MINGW_PACKAGE_PREFIX}-libsndfile"
           "${MINGW_PACKAGE_PREFIX}-flac")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"

--- a/mingw-w64-libopenmpt/PKGBUILD
+++ b/mingw-w64-libopenmpt/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libopenmpt
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.4.27
+pkgver=0.6.0
 pkgrel=1
 pkgdesc="A cross-platform C++ and C library to decode tracked music files (modules) into a raw PCM audio stream (mingw-w64)"
 arch=('any')
@@ -21,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools")
 options=('staticlibs' 'strip')
 source=("https://lib.openmpt.org/files/${_realname}/src/${_realname}-${pkgver}+release.autotools.tar.gz")
-sha256sums=('a4c23aaf1914e78d082d71f96cc82d63b0ed30091ed8cf8e8cb6887d4cecfaab')
+sha256sums=('a1fc61283864624d820836ce4d37af4907476cdcd31f6f09a23ba271500025ab')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}+release.autotools"


### PR DESCRIPTION
This update depends on merge request https://github.com/msys2/MINGW-packages/pull/10604 . After then that package is merged, the tests can be run again.