### PR TITLE
emacs-pdf-tools-server: update to 0.91

### DIFF
--- a/mingw-w64-emacs-pdf-tools-server/PKGBUILD
+++ b/mingw-w64-emacs-pdf-tools-server/PKGBUILD
@@ -3,12 +3,12 @@
 _realname=emacs-pdf-tools-server
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.80.r235.ga8847b7
-pkgrel=2
+pkgver=0.91
+pkgrel=1
 pkgdesc="Emacs support library for PDF files"
-_commit="a8847b75d3487d60e27762816bdbdd23b6dc1c11"
-source=("${_realname}::git+https://github.com/vedang/pdf-tools.git#commit=${_commit}")
-sha256sums=("SKIP")
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/vedang/pdf-tools/archive/refs/tags/v${pkgver}.tar.gz")
+noextract=(${_realname}-${pkgver}.tar.gz)
+sha256sums=("93f88d27e7910b76ffe2c506670d685b41c0b2cd3086543971d0c700c9eadee3")
 arch=("any")
 url="https://github.com/vedang/pdf-tools"
 license=("GPL3")
@@ -22,23 +22,24 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-emacs"
              "${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools")
 
-pkgver() {
-  cd "${srcdir}/${_realname}"
-
-  git describe --long "${_commit}" | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//g'
-}
-
 prepare() {
-  cd "${srcdir}/${_realname}/server"
+  # Workaround for symlinks in tarball and the different package and git repo
+  # names.
+  mkdir -p "${srcdir}/${_realname}-${pkgver}"
+  tar xzf "${srcdir}/${_realname}-${pkgver}.tar.gz" \
+    -C "${srcdir}/${_realname}-${pkgver}" \
+    --strip-components=1 \
+    --exclude "README*"
+
+  cd "${srcdir}/${_realname}-${pkgver}/server"
 
   autoreconf -fvi
 }
 
 build() {
-  cd "${srcdir}/${_realname}"
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
-  ../"${_realname}"/server/configure \
+  ../"${_realname}-${pkgver}"/server/configure \
     --prefix="${MINGW_PREFIX}" \
     --build="${MINGW_CHOST}" \
     --host="${MINGW_CHOST}" \


### PR DESCRIPTION
This PR switches from git to tarballs and updates the package to the latest release.