### PR TITLE
libgcrypt: update to 1.10.0

### DIFF
--- a/mingw-w64-libgcrypt/PKGBUILD
+++ b/mingw-w64-libgcrypt/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=libgcrypt
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.9.4
+pkgver=1.10.0
 pkgrel=1
 pkgdesc="General purpose cryptographic library based on the code from GnuPG (mingw-w64)"
 arch=('any')
@@ -23,7 +23,7 @@ validpgpkeys=('D8692123C4065DEA5E0F3AB5249B39D24F25E3B6'
               '031EC2536E580D8EA286A9F22071B08A33BD3F06'
               '5B80C5754298F0CB55D8ED6ABCEF7E294B092E28'
               '6DAA6E64A76D2840571B4902528897B826403ADA')
-sha256sums=('ea849c83a72454e3ed4267697e8ca03390aee972ab421e7df69dfe42b65caaf7'
+sha256sums=('6a00f5c05caa4c4acc120c46b63857da0d4ff61dc4b4b03933fa8d46013fae81'
             'SKIP'
             '55cf915badebb4b3cfa671eea725aebb77be791aa39a19caef090ded4f38d8eb'
             'd6855fc9b7a3a7fa440be1d9ae3477f8c08524d1aab1a8c7bb26d62b55382f72')


### PR DESCRIPTION
This updates libgcrypt to 1.10.0.