### PR TITLE
libunifex: add package

### DIFF
--- a/mingw-w64-libunifex/PKGBUILD
+++ b/mingw-w64-libunifex/PKGBUILD
@@ -19,7 +19,7 @@ sha256sums=('SKIP'
 
 pkgver() {
   cd "${srcdir}/${_realname}"
-  printf "r%s.%s" "$(git rev-list --count "d7d191e")" "$(git rev-parse --short "d7d191e")"
+  printf "r%s.%s" "$(git rev-list --count "${_commit}")" "$(git rev-parse --short "${_commit}")"
 }
 
 prepare() {

--- a/mingw-w64-libunifex/PKGBUILD
+++ b/mingw-w64-libunifex/PKGBUILD
@@ -1,0 +1,53 @@
+# Maintainer: https://github.com/bustercopley
+
+_realname=libunifex
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=r564.d7d191e
+pkgrel=1
+pkgdesc="A prototype implementation of the C++ sender/receiver async programming model"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+license=("Apache-2.0")
+url="https://github.com/facebookexperimental/libunifex"
+makedepends=('git' "${MINGW_PACKAGE_PREFIX}-cmake" "${MINGW_PACKAGE_PREFIX}-cc")
+_commit='d7d191e'
+source=("${_realname}::git+https://github.com/facebookexperimental/${_realname}.git#commit=${_commit}"
+       )
+sha256sums=('SKIP'
+           )
+
+pkgver() {
+  cd "${srcdir}/${_realname}"
+  printf "r%s.%s" "$(git rev-list --count "d7d191e")" "$(git rev-parse --short "d7d191e")"
+}
+
+prepare() {
+  cd "${srcdir}/${_realname}"
+}
+
+build(){
+  mkdir -p "${srcdir}/build-${MINGW_ARCH}"
+  cd "${srcdir}/build-${MINGW_ARCH}"
+
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then
+      CXX_FLAGS="-fcoroutines-ts -stdlib=libc++"
+  else
+      CXX_FLAGS="-fcoroutines"
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  cmake -G"MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DCMAKE_CXX_FLAGS:STRING="${CXX_FLAGS}" \
+    -DCMAKE_CXX_STANDARD:STRING=20 \
+    -DCMAKE_BUILD_TYPE=Release \
+    ../${_realname}
+
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_ARCH}"
+  make DESTDIR="${pkgdir}" install
+}


### PR DESCRIPTION
Build [libunifex](https://github.com/facebookexperimental/libunifex).

"The 'libunifex' project is a prototype implementation of the C++ sender/receiver async programming model that is currently being considered for standardisation."

It's a little out of date — recent work on the standardization effort is being done at [wg21_p2300_std_execution](https://github.com/brycelelbach/wg21_p2300_std_execution) — but libunifex is a lot easier to compile.

Patches also [submitted](https://github.com/facebookexperimental/libunifex/pull/391) upstream.