### PR TITLE
mlpack: enable openmp for clang builds

### DIFF
--- a/mingw-w64-mlpack/PKGBUILD
+++ b/mingw-w64-mlpack/PKGBUILD
@@ -11,6 +11,7 @@ mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://mlpack.org/'
 license=('BSD')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         $([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-openmp")
          "${MINGW_PACKAGE_PREFIX}-armadillo"
          "${MINGW_PACKAGE_PREFIX}-boost"
          "${MINGW_PACKAGE_PREFIX}-ensmallen"


### PR DESCRIPTION
Testing hypothesis in #10649 that OpenMP will automatically be enabled if the dependency is supplied.