### PR TITLE
Add new abseil-cpp PKGBUILD

### DIFF
--- a/mingw-w64-abseil-cpp/PKGBUILD
+++ b/mingw-w64-abseil-cpp/PKGBUILD
@@ -9,9 +9,10 @@ pkgdesc="A collection of open source C++ libraries taken from the most fundament
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://abseil.io"
-license=('Apache')
+license=('spdx:Apache-2.0')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-ninja")
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+	     "${MINGW_PACKAGE_PREFIX}-cc")
 source=("https://github.com/abseil/abseil-cpp/archive/$pkgver/$_realname-$pkgver.tar.gz")
 sha256sums=('dcf71b9cba8dc0ca9940c4b316a0c796be8fab42b070bb6b7cab62b48f0e66c4')
 

--- a/mingw-w64-abseil-cpp/PKGBUILD
+++ b/mingw-w64-abseil-cpp/PKGBUILD
@@ -1,0 +1,38 @@
+# Maintainer: Michał Łukowski <michal.lukowski@gmail.com>
+
+_realname=abseil-cpp
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=20211102.0
+pkgrel=1
+pkgdesc="A collection of open source C++ libraries taken from the most fundamental pieces of Google’s internal codebase, designed to extend the standard C ++ library. (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+url="https://abseil.io"
+license=('Apache')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
+source=("https://github.com/abseil/abseil-cpp/archive/$pkgver/$_realname-$pkgver.tar.gz")
+sha256sums=('dcf71b9cba8dc0ca9940c4b316a0c796be8fab42b070bb6b7cab62b48f0e66c4')
+
+build() {
+  [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake \
+    -GNinja \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DCMAKE_BUILD_TYPE=Release \
+	-DCMAKE_CXX_STANDARD=17 \
+    -DBUILD_SHARED_LIBS=ON \
+    ../${_realname}-${pkgver}
+
+  cmake --build .
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  DESTDIR="${pkgdir}" cmake --install .
+}


### PR DESCRIPTION
Description form [abseil.io](https://abseil.io/): "Abseil is an open source collection of C++ libraries drawn from the most fundamental pieces of Google’s internal codebase. "

PKGBUILD based on [archlinux](https://github.com/archlinux/svntogit-community/blob/packages/abseil-cpp/trunk/PKGBUILD) repository.