### PR TITLE
openssl: Export CC and CXX before calling configure and make.

### DIFF
--- a/mingw-w64-openssl/PKGBUILD
+++ b/mingw-w64-openssl/PKGBUILD
@@ -10,8 +10,11 @@ pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 pkgdesc="The Open Source toolkit for Secure Sockets Layer and Transport Layer Security (mingw-w64)"
-depends=("${MINGW_PACKAGE_PREFIX}-ca-certificates" "${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-zlib")
-makedepends=("${MINGW_PACKAGE_PREFIX}-cc" "${MINGW_PACKAGE_PREFIX}-autotools")
+depends=("${MINGW_PACKAGE_PREFIX}-ca-certificates"
+         "${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-zlib")
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-cc")
 options=('strip' '!buildflags' 'staticlibs')
 license=('custom:BSD')
 url="https://www.openssl.org"
@@ -56,16 +59,16 @@ prepare() {
 }
 
 build() {
-  rm -rf ${srcdir}/build-${CARCH}
+  rm -rf ${srcdir}/build-${MSYSTEM}
 
   # No support for out-of-source builds
-  mkdir -p ${srcdir}/build-${CARCH}
-#  cp -a ${srcdir}/${_realname}-${_ver}/* ${srcdir}/build-${CARCH}
+  mkdir -p ${srcdir}/build-${MSYSTEM}
+#  cp -a ${srcdir}/${_realname}-${_ver}/* ${srcdir}/build-${MSYSTEM}
 
   # Use mingw cflags instead of hardcoded ones
   sed -i -e '/^"mingw"/ s/-fomit-frame-pointer -O3 -Wall/-O2 -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions --param=ssp-buffer-size=4/' \
      ${srcdir}/${_realname}-${_ver}/Configure
-#     ${srcdir}/build-${CARCH}/Configure
+#     ${srcdir}/build-${MSYSTEM}/Configure
 
   case "${CARCH}" in
     i?86)
@@ -82,7 +85,10 @@ build() {
       ;;
   esac
 
-  cd "${srcdir}/build-${CARCH}"
+  export CC=${MINGW_PREFIX}/bin/cc.exe
+  export CXX=${MINGW_PREFIX}/bin/c++.exe
+
+  cd "${srcdir}/build-${MSYSTEM}"
   export MSYS2_ARG_CONV_EXCL="--prefix="
   ${srcdir}/${_realname}-${_ver}/Configure \
     --prefix=${MINGW_PREFIX} \
@@ -103,12 +109,12 @@ build() {
 }
 
 check() {
-  cd "${srcdir}/build-${CARCH}"
+  cd "${srcdir}/build-${MSYSTEM}"
   make VERBOSE=1 test
 }
 
 package() {
-  cd "${srcdir}/build-${CARCH}"
+  cd "${srcdir}/build-${MSYSTEM}"
   mkdir -p "${pkgdir}${MINGW_PREFIX}"/bin
   mkdir -p "${pkgdir}${MINGW_PREFIX}"/include/openssl
   mkdir -p "${pkgdir}${MINGW_PREFIX}"/lib/engines-1_1


### PR DESCRIPTION
Fixes #10681.