### PR TITLE
python-installer: various fixes

### DIFF
--- a/mingw-w64-python-installer/001-launcher-relative.patch
+++ b/mingw-w64-python-installer/001-launcher-relative.patch
@@ -1,0 +1,11 @@
+--- installer-0.4.0/src/installer/__main__.py.orig	2022-02-06 15:44:54.255000200 +0100
++++ installer-0.4.0/src/installer/__main__.py	2022-02-06 15:44:57.255156900 +0100
+@@ -90,7 +90,7 @@
+     with installer.sources.WheelFile.open(args.wheel) as source:
+         destination = installer.destinations.SchemeDictionaryDestination(
+             get_scheme_dict(source.distribution, prefix=args.prefix),
+-            sys.executable,
++            r'<launcher_dir>\python.exe',
+             installer.utils.get_launcher_kind(),
+             bytecode_optimization_levels=bytecode_levels,
+             destdir=args.destdir,

--- a/mingw-w64-python-installer/PKGBUILD
+++ b/mingw-w64-python-installer/PKGBUILD
@@ -4,7 +4,7 @@ _realname=installer
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=0.4.0
-pkgrel=3
+pkgrel=4
 pkgdesc="A low-level library for installing from a Python wheel distribution (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -14,33 +14,36 @@ depends=("${MINGW_PACKAGE_PREFIX}-python")
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-flit"
   "${MINGW_PACKAGE_PREFIX}-cc"
-  "unzip"
   "git"
 )
 _commit="32836e96e14d85db1f864ab5ff46ceb84b4a7673"
 _launcher_commit="8c455825fc1308d34a1a47238a9eb6d56f732142"
 source=("${_realname}-$pkgver"::"git+https://github.com/pradyunsg/installer.git#commit=${_commit}"
         "simple_launcher"::"git+https://bitbucket.org/vinay.sajip/simple_launcher.git#commit=${_launcher_commit}"
-        "103.patch")
+        "103.patch"
+        "001-launcher-relative.patch")
 sha256sums=('SKIP'
             'SKIP'
-            '861b4ee753b7f3e1cae37e1fa9a96fe65050a7066b6650a153df5d26f10f07c0')
+            '861b4ee753b7f3e1cae37e1fa9a96fe65050a7066b6650a153df5d26f10f07c0'
+            '6dca4eaba0564436775ae3ddcef30152445090f16e995ca8a7b9433364ac97c7')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
   # https://github.com/pradyunsg/installer/pull/103
   patch -Np1 -i "${srcdir}/103.patch"
+
+  patch -Np1 -i "${srcdir}/001-launcher-relative.patch"
 }
 
 build() {
   cd "${srcdir}/simple_launcher"
   windres --input launcher.rc --output resources.res --output-format=coff
 
-  local _gui_cflags="$CFLAGS -mwindows"
-  local _cli_cflags="$CFLAGS"
-  local _gui_lflags="-lshlwapi"
-  local _cli_lflags="-lshlwapi"
+  local _gui_cflags="$CFLAGS $CPPFLAGS -mwindows"
+  local _cli_cflags="$CFLAGS $CPPFLAGS -D_CONSOLE"
+  local _gui_lflags="$LDFLAGS -lshlwapi"
+  local _cli_lflags="$LDFLAGS -lshlwapi"
   case "$MSYSTEM" in
   MINGW*)
     _gui_cflags+=" -mcrtdll=msvcr120"
@@ -68,23 +71,17 @@ build() {
 
   cd "${srcdir}/${_realname}-${pkgver}"
 
-  flit build --no-setup-py
+  rm src/installer/_scripts/*.exe
+  cp "${srcdir}/simple_launcher/"*.exe src/installer/_scripts/
+  git add src/installer/_scripts/
+
+  python -m flit build --no-setup-py
 }
 
 package() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
-  local site_packages="$(python3 -c "import sysconfig; print(sysconfig.get_path('purelib', 'posix_prefix', {'base': ''}), end='')")"
-  local target="${pkgdir}${MINGW_PREFIX}${site_packages}"
-  mkdir -p "${target}"
-  unzip -q "dist/"*.whl -d "${target}"
-
-  # Replace launchers
-  rm "${target}"/installer/_scripts/*.exe
-  cd "${srcdir}/simple_launcher"
-  cp *.exe "${target}"/installer/_scripts/
-
-  # compile Python bytecode
-  ${MINGW_PREFIX}/bin/python -m compileall -d / "${target}"
-  ${MINGW_PREFIX}/bin/python -O -m compileall -d / "${target}"
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+  PYTHONPATH="${srcdir}/${_realname}-${pkgver}/src" \
+    python -m installer --prefix=${MINGW_PREFIX} --destdir="${pkgdir}" dist/*.whl
 }


### PR DESCRIPTION
* always use python.exe in the launcher dir
* pass all build flags to cc
* set _CONSOLE macro when building the console version
* use installer for itself to install