### PR TITLE
python-nuitka: Add python-setuptools dependency

### DIFF
--- a/mingw-w64-python-nuitka/PKGBUILD
+++ b/mingw-w64-python-nuitka/PKGBUILD
@@ -7,7 +7,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=0.6.19.6
-pkgrel=1
+pkgrel=2
 pkgdesc="Python to native compiler (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -15,7 +15,6 @@ license=('APACHE')
 url="https://www.nuitka.net/"
 depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-setuptools")
-makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 source=("https://nuitka.net/releases/Nuitka-${pkgver}.tar.gz")
 noextract=(Nuitka-$pkgver.tar.gz)
 sha256sums=('cf03d83559546054d28a6ada888d7ef98529d53257d63041b752dd215037a71e')

--- a/mingw-w64-python-nuitka/PKGBUILD
+++ b/mingw-w64-python-nuitka/PKGBUILD
@@ -13,7 +13,8 @@ arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 license=('APACHE')
 url="https://www.nuitka.net/"
-depends=("${MINGW_PACKAGE_PREFIX}-python")
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 source=("https://nuitka.net/releases/Nuitka-${pkgver}.tar.gz")
 noextract=(Nuitka-$pkgver.tar.gz)


### PR DESCRIPTION
[issue #10698 issuecomment-1031809109](https://github.com/msys2/MINGW-packages/issues/10698#issuecomment-1031809109)
python-nuitka: Add python-setuptools dependency