### PR TITLE
enable a few more clangarm64 packages

### DIFF
--- a/mingw-w64-exiv2/PKGBUILD
+++ b/mingw-w64-exiv2/PKGBUILD
@@ -9,7 +9,7 @@ pkgver=0.27.5
 pkgrel=1
 pkgdesc="Exif/IPTC/Xmp C++ metadata library and tools (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url='https://exiv2.org/'
 license=('GPL-2.0')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
@@ -30,8 +30,8 @@ prepare() {
 
 build() {
   cd "${srcdir}"/${_realname}-${pkgver}
-  [[ -d "${srcdir}"/build-${MINGW_ARCH} ]] && rm -rf "${srcdir}"/build-${MINGW_ARCH}
-  mkdir -p "${srcdir}"/build-${MINGW_ARCH} && cd "${srcdir}"/build-${MINGW_ARCH}
+  [[ -d "${srcdir}"/build-${MSYSTEM} ]] && rm -rf "${srcdir}"/build-${MSYSTEM}
+  mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
 
   declare -a extra_config
   if check_option "debug" "n"; then
@@ -59,7 +59,7 @@ build() {
 }
 
 package() {
-  cd "${srcdir}"/build-${MINGW_ARCH}
+  cd "${srcdir}"/build-${MSYSTEM}
 
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --build . --target install
 

--- a/mingw-w64-gmic/PKGBUILD
+++ b/mingw-w64-gmic/PKGBUILD
@@ -34,8 +34,8 @@ prepare() {
 }
 
 build() {
-  [[ -d "${srcdir}"/build-${MINGW_ARCH} ]] && rm -rf "${srcdir}"/build-${MINGW_ARCH}
-  mkdir -p "${srcdir}"/build-${MINGW_ARCH} && cd "${srcdir}"/build-${MINGW_ARCH}
+  [[ -d "${srcdir}"/build-${MSYSTEM} ]] && rm -rf "${srcdir}"/build-${MSYSTEM}
+  mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
 
   declare -a extra_config
   if check_option "debug" "n"; then
@@ -69,7 +69,7 @@ build() {
 }
 
 package() {
-  cd "${srcdir}"/build-${MINGW_ARCH}
+  cd "${srcdir}"/build-${MSYSTEM}
 
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
 

--- a/mingw-w64-iso-codes/PKGBUILD
+++ b/mingw-w64-iso-codes/PKGBUILD
@@ -4,11 +4,11 @@ _realname=iso-codes
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.9.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Lists of the country, language, and currency names (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
-license=('LGPL')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+license=('LGPL-2.1')
 makedepends=("git" "${MINGW_PACKAGE_PREFIX}-autotools")
 url="https://salsa.debian.org/iso-codes-team/iso-codes"
 _commit=35ae2024024eb8e6603d3034dbbc406594f3874c    # tags/iso-codes-4.9^0
@@ -24,8 +24,8 @@ prepare() {
 }
 
 build() {
-  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
-  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+  [[ -d "${srcdir}"/build-${MSYSTEM} ]] && rm -rf "${srcdir}"/build-${MSYSTEM}
+  mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
   ../${_realname}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
@@ -35,6 +35,7 @@ build() {
 }
 
 package() {
-  cd "${srcdir}"/build-${CARCH}
+  cd "${srcdir}"/build-${MSYSTEM}
   make DESTDIR="${pkgdir}" pkgconfigdir=${MINGW_PREFIX}/lib/pkgconfig install
+  install -Dm644 "${srcdir}/${_realname}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-lcms2/PKGBUILD
+++ b/mingw-w64-lcms2/PKGBUILD
@@ -5,15 +5,15 @@ _realname=lcms2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.13.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Small-footprint color management engine, version 2 (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://www.littlecms.com/"
 license=("MIT")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools")
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+depends=("${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
          "${MINGW_PACKAGE_PREFIX}-libtiff")
 options=('staticlibs' 'strip')
 source=("https://downloads.sourceforge.net/sourceforge/lcms/${_realname}-${pkgver}.tar.gz")
@@ -26,8 +26,8 @@ prepare() {
 }
 
 build() {
-  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
-  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+  [[ -d "${srcdir}"/build-${MSYSTEM} ]] && rm -rf "${srcdir}"/build-${MSYSTEM}
+  mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
 
   ../${_realname}-${pkgver}/configure \
     --build=${MINGW_CHOST} \
@@ -40,7 +40,7 @@ build() {
 }
 
 package() {
-  cd "${srcdir}"/build-${CARCH}
+  cd "${srcdir}"/build-${MSYSTEM}
 
   make DESTDIR="${pkgdir}" install
 

--- a/mingw-w64-libaec/PKGBUILD
+++ b/mingw-w64-libaec/PKGBUILD
@@ -4,13 +4,12 @@ _realname=libaec
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.0.6
-pkgrel=1
+pkgrel=2
 pkgdesc="Adaptive Entropy Coding library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://gitlab.dkrz.de/k202009/libaec"
 license=('BSD-2-Clause')
-depends=("${MINGW_PACKAGE_PREFIX}-crt")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cc")
@@ -29,8 +28,8 @@ prepare() {
 }
 
 build() {
-  [[ -d ${srcdir}/build-${MINGW_ARCH} ]] && rm -rf ${srcdir}/build-${MINGW_ARCH}
-  mkdir -p ${srcdir}/build-${MINGW_ARCH} && cd ${srcdir}/build-${MINGW_ARCH}
+  [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}
+  mkdir -p ${srcdir}/build-${MSYSTEM} && cd ${srcdir}/build-${MSYSTEM}
 
   declare -a extra_config
   if check_option "debug" "n"; then
@@ -51,7 +50,7 @@ build() {
 }
 
 package() {
-  cd ${srcdir}/build-${MINGW_ARCH}
+  cd ${srcdir}/build-${MSYSTEM}
 
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --build . --target install
 

--- a/mingw-w64-libexif/PKGBUILD
+++ b/mingw-w64-libexif/PKGBUILD
@@ -4,12 +4,12 @@ _realname=libexif
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.6.24
-pkgrel=1
+pkgrel=2
 pkgdesc="A library to parse an EXIF file and read the data from those tags (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://libexif.github.io/"
-license=("LGPL")
+license=("LGPL-2.1")
 makedepends=("${MINGW_PACKAGE_PREFIX}-pkg-config" "${MINGW_PACKAGE_PREFIX}-autotools" "${MINGW_PACKAGE_PREFIX}-cc")
 depends=("${MINGW_PACKAGE_PREFIX}-gettext")
 options=(!libtool strip)
@@ -22,8 +22,8 @@ prepare() {
 }
 
 build() {
-  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
-  mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
+  [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
   ../${_realname}-${_realname}-${pkgver//./_}-release/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
@@ -37,7 +37,8 @@ build() {
 }
 
 package() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MSYSTEM}"
   make DESTDIR="${pkgdir}" install
   find "${pkgdir}${MINGW_PREFIX}" -name '*.def' -o -name '*.exp' | xargs -rtl1 rm
+  install -Dm644 "${srcdir}/${_realname}-${_realname}-${pkgver//./_}-release/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-libraqm/PKGBUILD
+++ b/mingw-w64-libraqm/PKGBUILD
@@ -7,7 +7,7 @@ pkgver=0.9.0
 pkgrel=1
 pkgdesc="A library that encapsulates the logic for complex text layout (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://github.com/HOST-Oman/libraqm"
 depends=("${MINGW_PACKAGE_PREFIX}-freetype"
          "${MINGW_PACKAGE_PREFIX}-glib2"

--- a/mingw-w64-libusb/PKGBUILD
+++ b/mingw-w64-libusb/PKGBUILD
@@ -4,12 +4,12 @@ _realname=libusb
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.0.25
-pkgrel=1
+pkgrel=2
 pkgdesc="Library that provides generic access to USB devices (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://libusb.info/"
-license=("LGPL")
+license=("LGPL-2.1")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc" "${MINGW_PACKAGE_PREFIX}-autotools")
 options=('staticlibs' 'strip')
 source=("https://github.com/libusb/libusb/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.bz2"
@@ -33,8 +33,8 @@ prepare() {
 }
 
 build() {
-  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
-  mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
+  [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
@@ -47,11 +47,12 @@ build() {
 }
 
 check() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MSYSTEM}"
   make check || true
 }
 
 package() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MSYSTEM}"
   make DESTDIR="${pkgdir}" install
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-openjpeg2/PKGBUILD
+++ b/mingw-w64-openjpeg2/PKGBUILD
@@ -4,12 +4,12 @@ _realname=openjpeg
 pkgbase=mingw-w64-${_realname}2
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}2"
 pkgver=2.4.0
-pkgrel=2
+pkgrel=3
 pkgdesc="An open source JPEG 2000 codec (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://www.openjpeg.org/"
-license=("BSD")
+license=("BSD-2-Clause")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-lcms2"
          "${MINGW_PACKAGE_PREFIX}-libtiff"
@@ -77,9 +77,9 @@ prepare() {
 
 build() {
   msg "Build static version"
-  [[ -d ${srcdir}/build-static-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-static-${MINGW_CHOST}
-  mkdir ${srcdir}/build-static-${MINGW_CHOST}
-  cd ${srcdir}/build-static-${MINGW_CHOST}
+  [[ -d ${srcdir}/build-static-${MSYSTEM} ]] && rm -rf ${srcdir}/build-static-${MSYSTEM}
+  mkdir ${srcdir}/build-static-${MSYSTEM}
+  cd ${srcdir}/build-static-${MSYSTEM}
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake \
@@ -100,9 +100,9 @@ build() {
   ${MINGW_PREFIX}/bin/cmake --build ./
 
   msg "Build shared version"
-  [[ -d ${srcdir}/build-shared-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-shared-${MINGW_CHOST}
-  mkdir ${srcdir}/build-shared-${MINGW_CHOST}
-  cd ${srcdir}/build-shared-${MINGW_CHOST}
+  [[ -d ${srcdir}/build-shared-${MSYSTEM} ]] && rm -rf ${srcdir}/build-shared-${MSYSTEM}
+  mkdir ${srcdir}/build-shared-${MSYSTEM}
+  cd ${srcdir}/build-shared-${MSYSTEM}
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake \
@@ -126,9 +126,11 @@ build() {
 }
 
 package() {
-  cd "${srcdir}/build-static-${MINGW_CHOST}"
+  cd "${srcdir}/build-static-${MSYSTEM}"
   DESTDIR=${pkgdir} ${MINGW_PREFIX}/bin/cmake --build ./ --target install
 
-  cd "${srcdir}/build-shared-${MINGW_CHOST}"
+  cd "${srcdir}/build-shared-${MSYSTEM}"
   DESTDIR=${pkgdir} ${MINGW_PREFIX}/bin/cmake --build ./ --target install
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-pugixml/PKGBUILD
+++ b/mingw-w64-pugixml/PKGBUILD
@@ -3,61 +3,65 @@
 _realname=pugixml
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.11.4
+pkgver=1.12
 pkgrel=1
 pkgdesc="Light-weight, simple and fast XML parser for C++ with XPath support (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://pugixml.org/"
 license=("MIT")
 depends=()
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-cmake")
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
 source=(https://github.com/zeux/pugixml/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz)
-sha256sums=('8ddf57b65fb860416979a3f0640c2ad45ddddbbafa82508ef0a0af3ce7061716')
+sha256sums=('fd6922a4448ec2f3eb9db415d10a49660e5d84ce20ce66b8a07e72ffc84270a7')
 
 build() {
+  declare -a extra_config
   if check_option "debug" "n"; then
     extra_config+=("-DCMAKE_BUILD_TYPE=Release")
   else
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
-  [[ -d ${srcdir}/build-shared-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-shared-${MINGW_CHOST}
-  mkdir -p ${srcdir}/build-shared-${MINGW_CHOST} && cd ${srcdir}/build-shared-${MINGW_CHOST}
+  [[ -d ${srcdir}/build-shared-${MSYSTEM} ]] && rm -rf ${srcdir}/build-shared-${MSYSTEM}
+  mkdir -p ${srcdir}/build-shared-${MSYSTEM} && cd ${srcdir}/build-shared-${MSYSTEM}
 
   msg "Build shared library"
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe \
-    -G"MSYS Makefiles" \
+    -GNinja \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    ${extra_config} \
+    ${extra_config[@]} \
     -DBUILD_SHARED_LIBS=ON \
     ../${_realname}-${pkgver}
 
-  make
+  ${MINGW_PREFIX}/bin/cmake.exe --build .
 
-  [[ -d ${srcdir}/build-static-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-static-${MINGW_CHOST}
-  mkdir -p ${srcdir}/build-static-${MINGW_CHOST} && cd ${srcdir}/build-static-${MINGW_CHOST}
+  [[ -d ${srcdir}/build-static-${MSYSTEM} ]] && rm -rf ${srcdir}/build-static-${MSYSTEM}
+  mkdir -p ${srcdir}/build-static-${MSYSTEM} && cd ${srcdir}/build-static-${MSYSTEM}
 
   msg "Build static library"
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe \
-    -G"MSYS Makefiles" \
+    -GNinja \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    ${extra_config} \
+    ${extra_config[@]} \
     -DBUILD_SHARED_LIBS=OFF \
     ../${_realname}-${pkgver}
 
-  make
+  ${MINGW_PREFIX}/bin/cmake.exe --build .
 }
 
 package() {
   msg "Install static library"
-  cd "${srcdir}/build-static-${MINGW_CHOST}"
-  make DESTDIR=${pkgdir} install
+  cd "${srcdir}/build-static-${MSYSTEM}"
+  DESTDIR=${pkgdir} ${MINGW_PREFIX}/bin/cmake.exe --install .
 
   msg "Install shared library"
-  cd "${srcdir}/build-shared-${MINGW_CHOST}"
-  make DESTDIR=${pkgdir} install
+  cd "${srcdir}/build-shared-${MSYSTEM}"
+  DESTDIR=${pkgdir} ${MINGW_PREFIX}/bin/cmake.exe --install .
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE.md" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-python-imagecodecs/PKGBUILD
+++ b/mingw-w64-python-imagecodecs/PKGBUILD
@@ -43,24 +43,24 @@ prepare() {
   #  patch -Np1 -i "${srcdir}"/0001-setup-customize.patch
   # popd
 
-  rm -rf python-build-${MINGW_ARCH} || true
-  cp -r "${_realname}-${pkgver}" "python-build-${MINGW_ARCH}"
+  rm -rf python-build-${MSYSTEM} || true
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 
 build() {
-  msg "Python build for ${MINGW_ARCH}"  
-  cd "${srcdir}/python-build-${MINGW_ARCH}"
+  msg "Python build for ${MSYSTEM}"  
+  cd "${srcdir}/python-build-${MSYSTEM}"
   ${MINGW_PREFIX}/bin/python setup.py build
 }
 
 check() {
-  msg "Python test for ${MINGW_ARCH}"
-  cd "${srcdir}/python-build-${MINGW_ARCH}"
+  msg "Python test for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
   ${MINGW_PREFIX}/bin/python setup.py check --strict
 }
 
 package() {
-  cd "${srcdir}/python-build-${MINGW_ARCH}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
     --root="${pkgdir}" --optimize=1 --skip-build

--- a/mingw-w64-python-imageio/PKGBUILD
+++ b/mingw-w64-python-imageio/PKGBUILD
@@ -23,24 +23,24 @@ sha256sums=('760f383717204234f4527c682d91dfee9f34262d75bb0bbbf9a06668ff23f3ba')
 prepare() {
   cd "${srcdir}"
 
-  rm -rf python-build-${MINGW_ARCH} || true
-  cp -r "${_realname}-${pkgver}" "python-build-${MINGW_ARCH}"
+  rm -rf python-build-${MSYSTEM} || true
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 
 build() {
-  msg "Python build for ${MINGW_ARCH}"  
-  cd "${srcdir}/python-build-${MINGW_ARCH}"
+  msg "Python build for ${MSYSTEM}"  
+  cd "${srcdir}/python-build-${MSYSTEM}"
   ${MINGW_PREFIX}/bin/python setup.py build
 }
 
 check() {
-  msg "Python test for ${MINGW_ARCH}"
-  cd "${srcdir}/python-build-${MINGW_ARCH}"
+  msg "Python test for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
   ${MINGW_PREFIX}/bin/python setup.py check --strict
 }
 
 package() {
-  cd "${srcdir}/python-build-${MINGW_ARCH}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
     --root="${pkgdir}" --optimize=1 --skip-build

--- a/mingw-w64-python-tifffile/PKGBUILD
+++ b/mingw-w64-python-tifffile/PKGBUILD
@@ -23,24 +23,24 @@ sha256sums=('85a83c24a214e8baf09da1f85ca5a88b52610142f561ecc2873404ef50a3f6e3')
 prepare() {
   cd "${srcdir}"
 
-  rm -rf python-build-${MINGW_ARCH} || true
-  cp -r "${_realname}-${pkgver}" "python-build-${MINGW_ARCH}"
+  rm -rf python-build-${MSYSTEM} || true
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 
 build() {
-  msg "Python build for ${MINGW_ARCH}"
-  cd "${srcdir}/python-build-${MINGW_ARCH}"
+  msg "Python build for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
   ${MINGW_PREFIX}/bin/python setup.py build
 }
 
 check() {
-  msg "Python test for ${MINGW_ARCH}"
-  cd "${srcdir}/python-build-${MINGW_ARCH}"
+  msg "Python test for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
   ${MINGW_PREFIX}/bin/python setup.py check --strict
 }
 
 package() {
-  cd "${srcdir}/python-build-${MINGW_ARCH}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
     --root="${pkgdir}" --optimize=1 --skip-build


### PR DESCRIPTION
Includes pugixml update to 1.12, lcms2 dependency cleanup, and adding missing licenses.