### PR TITLE
update url for mingw-w64-isl

### DIFF
--- a/mingw-w64-isl/PKGBUILD
+++ b/mingw-w64-isl/PKGBUILD
@@ -13,7 +13,7 @@ url="https://isl.gforge.inria.fr/"
 makedepends=("${MINGW_PACKAGE_PREFIX}-gmp" "${MINGW_PACKAGE_PREFIX}-autotools")
 options=('staticlibs')
 license=('MIT')
-source=("http://isl.gforge.inria.fr/${_realname}-${pkgver}.tar.xz"
+source=("https://libisl.sourceforge.io/${_realname}-${pkgver}.tar.xz"
         isl-0.14.1-no-undefined.patch)
 sha256sums=('043105cc544f416b48736fff8caf077fb0663a717d06b1113f16e391ac99ebad'
             '83655a7202f0a0dcce1782d4b365252bf1ad12a522b7ad82ab578ee5ec46433b')

--- a/mingw-w64-isl/PKGBUILD
+++ b/mingw-w64-isl/PKGBUILD
@@ -10,7 +10,9 @@ arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://isl.gforge.inria.fr/"
 #depends=("${MINGW_PACKAGE_PREFIX}-gmp")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gmp" "${MINGW_PACKAGE_PREFIX}-autotools")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-gmp"
+             "${MINGW_PACKAGE_PREFIX}-autotools")
 options=('staticlibs')
 license=('MIT')
 source=("https://libisl.sourceforge.io/${_realname}-${pkgver}.tar.xz"


### PR DESCRIPTION
isl.gforge.inria.fr is down.
See also:
https://github.com/niXman/mingw-builds/pull/570/commits/c0a872b60c9fea5a7149bdf17e58fbf186a65467
https://groups.google.com/g/isl-development/c/JGaMo2VUu_8