### PR TITLE
boost: Enable Boost.Python (NumPy)

### DIFF
--- a/mingw-w64-boost/PKGBUILD
+++ b/mingw-w64-boost/PKGBUILD
@@ -12,7 +12,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.78.0
 _boostver=${pkgver//./_}
-pkgrel=1
+pkgrel=2
 pkgdesc="Free peer-reviewed portable C++ source libraries (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -24,7 +24,10 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-xz"
          "${MINGW_PACKAGE_PREFIX}-zstd"
          "${MINGW_PACKAGE_PREFIX}-zlib")
+optdepends=("${MINGW_PACKAGE_PREFIX}-python: For Boost.Python"
+            "${MINGW_PACKAGE_PREFIX}-python-numpy: For Boost.Python (NumPy)")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python"
+             "${MINGW_PACKAGE_PREFIX}-python-numpy"
              "${MINGW_PACKAGE_PREFIX}-cc"
              "lndir")
 options=('strip' 'buildflags' 'staticlibs')

--- a/mingw-w64-boost/PKGBUILD
+++ b/mingw-w64-boost/PKGBUILD
@@ -1,11 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
-if [[ "${MINGW_PREFIX}" =~ /clang.* ]] ; then
-    # _toolset=clang creates dlls names without the `lib' prefix
-    _toolset=gcc
-else
-    _toolset=gcc
-fi
+# mingw logic lives in gcc.jam, so we always need to use the 'gcc' toolset
+_toolset=gcc
 
 _realname=boost
 pkgbase=mingw-w64-${_realname}
@@ -168,9 +164,14 @@ build() {
   local _pyver=$(${MINGW_PREFIX}/bin/python -c "import sys;sys.stdout.write('.'.join(map(str, sys.version_info[:2])))")
 
   echo "using python : ${_pyver} : ${PREFIX_DEPS}/bin/python.exe : ${PREFIX_DEPS}/include/python${_pyver} : ${PREFIX_DEPS}/lib/python${_pyver}/config-${_pyver} ;" >> ./tools/build/src/user-config.jam
-  #echo "using gcc : : ${PREFIX_DEPS}/bin/g++.exe : <rc>${PREFIX_DEPS}/bin/windres.exe ;" >> ./tools/build/src/user-config.jam
+  # configure b2 to use c++ rather than g++, as the latter no longer exists in
+  # clang prefixes
+  echo "using gcc : : ${PREFIX_DEPS}/bin/c++.exe ;" >> ./tools/build/src/user-config.jam
 
-  ./bootstrap.sh --with-icu=${MINGW_PREFIX} --with-python=${MINGW_PREFIX} --with-toolset=$_toolset
+  ./tools/build/src/engine/build.sh --cxx="${CXX}" gcc
+  cp ./tools/build/src/engine/b2 .
+
+  ./bootstrap.sh --with-icu=${MINGW_PREFIX} --with-python=${MINGW_PREFIX} --with-toolset=$_toolset --with-bjam="$(pwd)/b2"
 
   setb2args
   ./b2 $b2args -j$(nproc)


### PR DESCRIPTION
Some libraries will added:

```console
2022-02-09T17:18:05.3661747Z  /mingw64/bin/libboost_math_tr1l-mt.dll
2022-02-09T17:18:05.3673859Z  /mingw64/bin/libboost_math_tr1-mt.dll
2022-02-09T17:18:05.3675776Z  /mingw64/bin/libboost_nowide-mt.dll
2022-02-09T17:18:05.3676521Z +/mingw64/bin/libboost_numpy39-mt.dll
2022-02-09T17:18:05.3677099Z  /mingw64/bin/libboost_prg_exec_monitor-mt.dll
2022-02-09T17:18:05.3677723Z  /mingw64/bin/libboost_program_options-mt.dll
2022-02-09T17:18:05.3678304Z  /mingw64/bin/libboost_python39-mt.dll
2022-02-09T17:18:05.3678775Z @@ -16350,6 +16351,8 @@
2022-02-09T17:18:05.3679653Z  /mingw64/lib/libboost_math_tr1-mt.dll.a
2022-02-09T17:18:05.3680233Z  /mingw64/lib/libboost_nowide-mt.a
2022-02-09T17:18:05.3680741Z  /mingw64/lib/libboost_nowide-mt.dll.a
2022-02-09T17:18:05.3681591Z +/mingw64/lib/libboost_numpy39-mt.a
2022-02-09T17:18:05.3682139Z +/mingw64/lib/libboost_numpy39-mt.dll.a
2022-02-09T17:18:05.3682779Z  /mingw64/lib/libboost_prg_exec_monitor-mt.a
2022-02-09T17:18:05.3683390Z  /mingw64/lib/libboost_prg_exec_monitor-mt.dll.a
2022-02-09T17:18:05.3684222Z  /mingw64/lib/libboost_program_options-mt.a
```