### PR TITLE
qt-creator: Update to 6.0.2

### DIFF
--- a/mingw-w64-qt-creator/PKGBUILD
+++ b/mingw-w64-qt-creator/PKGBUILD
@@ -5,9 +5,9 @@ _realname=qt-creator
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 __pre=
-_base_ver=6.0.1
+_base_ver=6.0.2
 pkgver=${_base_ver}${_pre}
-pkgrel=2
+pkgrel=1
 pkgdesc='Cross-platform IDE (mingw-w64)'
 url='https://www.qt.io/'
 install=qt-creator-${MSYSTEM}.install
@@ -47,12 +47,14 @@ source=(#https://download.qt.io/development_releases/qtcreator/${_base_ver%.*}/$
         https://download.qt.io/official_releases/qtcreator/${pkgver%.*}/${pkgver}/${_pkgfqn}.tar.xz
         qt-creator-3.2.0-Allow-iOS-plugin-on-any-platform.patch
         qt-creator-5.0.1-fix-library-archive-path.patch
-        003-find-qdoc-qt6.patch)
+        003-find-qdoc-qt6.patch
+        qt-creator-6.0.2-qmldesigner-fix-32bit.patch)
 noextract=(${_pkgfqn}.tar.xz)
-sha256sums=('94ccca750150c731956ad368f69714ed5fd4c3b4cd35e5340df37920bded6f3b'
+sha256sums=('3d173c1a02ce55137a23f294e1a840d7648656e97826067eb29d9df653351bfa'
             '96c14f54577bf6cadf5c12018745666a9e99cd8d6a876c29a28b13599a8cb368'
             '4daf74e55e9b5cae9f05704a98fb832688edf958481cfb2246aecf6b54156e53'
-            '5870c81167909d549c14c2b60acabfae2b0b85e84bae7aa7e383333ff9411a4a')
+            '5870c81167909d549c14c2b60acabfae2b0b85e84bae7aa7e383333ff9411a4a'
+            '1acc72198f47d70bebfcf593ae2a2fe5c34a9d56e971d151d36178a7476286be')
 
 prepare() {
   [[ -d ${srcdir}/${_pkgfqn} ]] && rm -rf ${srcdir}/${_pkgfqn}
@@ -63,6 +65,7 @@ prepare() {
   patch -p1 -i "${srcdir}"/qt-creator-3.2.0-Allow-iOS-plugin-on-any-platform.patch
   patch -p1 -i "${srcdir}"/qt-creator-5.0.1-fix-library-archive-path.patch
   patch -p1 -i "${srcdir}"/003-find-qdoc-qt6.patch
+  patch -p1 -i "${srcdir}"/qt-creator-6.0.2-qmldesigner-fix-32bit.patch
 }
 
 build() {

--- a/mingw-w64-qt-creator/qt-creator-6.0.2-qmldesigner-fix-32bit.patch
+++ b/mingw-w64-qt-creator/qt-creator-6.0.2-qmldesigner-fix-32bit.patch
@@ -1,0 +1,44 @@
+From b3e9f24ed1c0d3c0ee4917d4b449da90e00e888a Mon Sep 17 00:00:00 2001
+From: Marco Bubke <marco.bubke@qt.io>
+Date: Mon, 24 Jan 2022 14:38:29 +0100
+Subject: [PATCH] QmlDesigner: Fix 32 bit
+
+Because std::ptrdiff_t and int are the same under 32 bit the constructor
+is changed to a template. The class is private so it is very unlikely
+that it leads to errors.
+
+Task-number: QTCREATORBUG-26910
+Change-Id: I94c987b9b6d2f04876740ff283a339c0db056cfd
+Reviewed-by: <github-actions-qt-creator@cristianadam.eu>
+Reviewed-by: Christophe Giboudeaux <christophe@krop.fr>
+Reviewed-by: Eike Ziller <eike.ziller@qt.io>
+Reviewed-by: Qt CI Bot <qt_ci_bot@qt-project.org>
+---
+ .../qmldesigner/designercore/projectstorage/storagecache.h    | 11 ++---------
+ 1 file changed, 2 insertions(+), 9 deletions(-)
+
+diff --git a/src/plugins/qmldesigner/designercore/projectstorage/storagecache.h b/src/plugins/qmldesigner/designercore/projectstorage/storagecache.h
+index 747c3d9a07d..27d2905e8e4 100644
+--- a/src/plugins/qmldesigner/designercore/projectstorage/storagecache.h
++++ b/src/plugins/qmldesigner/designercore/projectstorage/storagecache.h
+@@ -67,15 +67,8 @@ class StorageCache
+ 
+         StorageCacheIndex(const char *) = delete;
+ 
+-        constexpr explicit StorageCacheIndex(int id) noexcept
+-            : id{id}
+-        {}
+-
+-        constexpr explicit StorageCacheIndex(std::size_t id) noexcept
+-            : id{static_cast<int>(id)}
+-        {}
+-
+-        constexpr explicit StorageCacheIndex(std::ptrdiff_t id) noexcept
++        template<typename IntegerType>
++        constexpr explicit StorageCacheIndex(IntegerType id) noexcept
+             : id{static_cast<int>(id)}
+         {}
+ 
+-- 
+2.16.3
+


### PR DESCRIPTION
We have troubles when building 32-bit version.

`MINGW32`:
```console
  C:/_/mingw-w64-qt-creator/src/qt-creator-opensource-src-6.0.2/src/plugins/qmldesigner/designercore/projectstorage/storagecache.h:78:28: error: 'constexpr QmlDesigner::StorageCache<Type, ViewType, IndexType, Storage, Mutex, compare, CacheEntry>::StorageCacheIndex::StorageCacheIndex(std::ptrdiff_t)' cannot be overloaded with 'constexpr QmlDesigner::StorageCache<Type, ViewType, IndexType, Storage, Mutex, compare, CacheEntry>::StorageCacheIndex::StorageCacheIndex(int)'
     78 |         constexpr explicit StorageCacheIndex(std::ptrdiff_t id) noexcept
        |                            ^~~~~~~~~~~~~~~~~
  C:/_/mingw-w64-qt-creator/src/qt-creator-opensource-src-6.0.2/src/plugins/qmldesigner/designercore/projectstorage/storagecache.h:70:28: note: previous declaration 'constexpr QmlDesigner::StorageCache<Type, ViewType, IndexType, Storage, Mutex, compare, CacheEntry>::StorageCacheIndex::StorageCacheIndex(int)'
     70 |         constexpr explicit StorageCacheIndex(int id) noexcept
        |                            ^~~~~~~~~~~~~~~~~
  [3102/3731] Building CXX object src/plugins/qmldesigner/CMakeFiles/QmlDesigner.dir/components/connectioneditor/moc_connectionviewwidget.cpp.obj
  ==> ERROR: A failure occurred in build().
  [3103/3731] Building CXX object src/plugins/qmldesigner/CMakeFiles/QmlDesigner.dir/designermcumanager.cpp.obj
      Aborting...
  ninja: build stopped: subcommand failed.
```

`CLANG32`:
```console
  C:/_/mingw-w64-qt-creator/src/qt-creator-opensource-src-6.0.2/src/plugins/qmldesigner/designercore/projectstorage/storagecache.h:78:28: error: constructor cannot be redeclared
          constexpr explicit StorageCacheIndex(std::ptrdiff_t id) noexcept
                             ^
  C:/_/mingw-w64-qt-creator/src/qt-creator-opensource-src-6.0.2/src/plugins/qmldesigner/designercore/projectstorage/storagecache.h:70:28: note: previous definition is here
          constexpr explicit StorageCacheIndex(int id) noexcept
                             ^
  2 warnings and 1 error generated.
  [3232/3731] Building CXX object qmldsgnr/CMakeFiles/QmlDesigner.dir/designermcumanager.cpp.obj
  [3233/3731] Building CXX object qmldsgnr/CMakeFiles/QmlDesigner.dir/qmldesignerplugin.cpp.obj
  ninja: build stopped: subcommand failed.
```

In both case trubles with constructor of class `StorageCacheIndex` defined in `src/plugins/qmldesigner/designercore/projectstorage/storagecache.h` header.