### PR TITLE
gdb: add missing dependencies

### DIFF
--- a/mingw-w64-gdb/PKGBUILD
+++ b/mingw-w64-gdb/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-multiarch")
 pkgver=11.2
-pkgrel=1
+pkgrel=2
 pkgdesc="GNU Debugger (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -14,8 +14,10 @@ url="https://www.gnu.org/software/gdb/"
 license=('GPL')
 groups=($( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-toolchain" ))
 depends=("${MINGW_PACKAGE_PREFIX}-expat"
+         "${MINGW_PACKAGE_PREFIX}-gmp"
          "${MINGW_PACKAGE_PREFIX}-libiconv"
          "${MINGW_PACKAGE_PREFIX}-libssp"
+         "${MINGW_PACKAGE_PREFIX}-mpfr"
          "${MINGW_PACKAGE_PREFIX}-ncurses"
          "${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-readline"
@@ -24,9 +26,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-expat"
 optdepends=("${MINGW_PACKAGE_PREFIX}-python-pygments: for syntax highlighting")
 checkdepends=('dejagnu' 'bc')
 # gmp, mpfr and xz (lzma) are linked statically
-makedepends=("${MINGW_PACKAGE_PREFIX}-gmp"
-             "${MINGW_PACKAGE_PREFIX}-iconv"
-             "${MINGW_PACKAGE_PREFIX}-mpfr"
+makedepends=("${MINGW_PACKAGE_PREFIX}-iconv"
              "${MINGW_PACKAGE_PREFIX}-xz"
              "${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-cc")


### PR DESCRIPTION
When I tried to launch gdb on CLANG64 I got this message:
```
$ gdb makhber
D:/Programs/msys64/clang64/bin/gdb.exe: error while loading shared libraries: libunwind.dll: cannot open shared object file: No such file or directory
```
so I run ntldd
```
$ ntldd gdb
        libreadline8.dll => D:\Programs\msys64\clang64\bin\libreadline8.dll (0x00000000004d0000)
        libintl-8.dll => D:\Programs\msys64\clang64\bin\libintl-8.dll (0x00000000001d0000)
        libpython3.9.dll => D:\Programs\msys64\clang64\bin\libpython3.9.dll (0x0000000001850000)
        WS2_32.dll => C:\WINDOWS\SYSTEM32\WS2_32.dll (0x0000000001480000)
        libmpfr-6.dll => not found
        libgmp-10.dll => D:\Programs\msys64\clang64\bin\libgmp-10.dll (0x00000000004d0000)
        libxxhash.dll => D:\Programs\msys64\clang64\bin\libxxhash.dll (0x00000000001d0000)
        libc++.dll => D:\Programs\msys64\clang64\bin\libc++.dll (0x0000000001290000)
        libunwind.dll => D:\Programs\msys64\clang64\bin\libunwind.dll (0x00000000001d0000)
        KERNEL32.dll => C:\WINDOWS\SYSTEM32\KERNEL32.dll (0x0000000001290000)
        USER32.dll => C:\WINDOWS\SYSTEM32\USER32.dll (0x0000000001290000)
        bcrypt.dll => C:\WINDOWS\SYSTEM32\bcrypt.dll (0x0000000001430000)
```
Both gmp and mpfr are runtime dependencies of gdb.