### PR TITLE
cpputest: fix compilation with clang

### DIFF
--- a/mingw-w64-cpputest/010-timespec.patch
+++ b/mingw-w64-cpputest/010-timespec.patch
@@ -1,0 +1,16 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -40,13 +40,6 @@ if(HAVE_STRDUP)
+ endif(HAVE_STRDUP)
+ 
+ if (MINGW)
+-    # Apply workaround for MinGW timespec redefinition (pthread.h / time.h)
+-    include(CheckStructHasMember)
+-    check_struct_has_member("struct timespec" tv_sec time.h HAVE_STRUCT_TIMESPEC)
+-    if (HAVE_STRUCT_TIMESPEC)
+-        add_definitions(-D_TIMESPEC_DEFINED=1)
+-    endif()
+-
+     if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+         # Apply workaround for static/shared libraries on MinGW C/C++ compiler
+         # Issue occurs with CMake >= 3.9.0, it doesn't filter out gcc,gcc_s,gcc_eh from

--- a/mingw-w64-cpputest/PKGBUILD
+++ b/mingw-w64-cpputest/PKGBUILD
@@ -4,17 +4,25 @@ _realname=cpputest
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Unit testing and mocking framework for C and C++ (mingw-w64)"
 url="https://cpputest.github.io/"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 license=('BSD-3-Clause')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-ninja")
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-cc")
 options=('staticlibs' 'strip')
-source=("https://github.com/cpputest/cpputest/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha512sums=('69f39fffdcd965c871e598118db38ddb74a3e75fd7a7965f8d236029fa891f6fcb6b671147c166ad08482bbd0737537fafe90aa8439a0ab62389f19150cc39d7')
+source=("https://github.com/cpputest/cpputest/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz"
+        "010-timespec.patch")
+sha512sums=('69f39fffdcd965c871e598118db38ddb74a3e75fd7a7965f8d236029fa891f6fcb6b671147c166ad08482bbd0737537fafe90aa8439a0ab62389f19150cc39d7'
+            '0e003df9d1d68a48bfa39e894df57dec09b87e1f25b6bd61ac02b7c6a55b975f873fa9abe649d25fe2bc042b0c027d42705fbc9480e5aa3340a04a1e23b95261')
+
+prepare() {
+  cd "${srcdir}"/${_realname}-${pkgver}
+  patch -p1 -i ${srcdir}/010-timespec.patch
+}
 
 build() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}


### PR DESCRIPTION
Removed outdated MinGW fix.

Signed-off-by: Rosen Penev <rosenp@gmail.com>