### PR TITLE
adol-c: add openmp dependency

### DIFF
--- a/mingw-w64-adol-c/PKGBUILD
+++ b/mingw-w64-adol-c/PKGBUILD
@@ -4,12 +4,14 @@ _realname=adol-c
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.7.2
-pkgrel=3
+pkgrel=4
 pkgdesc='Automatic Differentiation of Algorithms written in C/C++ (mingw-w64)'
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 depends=("${MINGW_PACKAGE_PREFIX}-boost")
-makedepends=("${MINGW_PACKAGE_PREFIX}-autotools" "${MINGW_PACKAGE_PREFIX}-cc")
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
+             $([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-openmp")
+             "${MINGW_PACKAGE_PREFIX}-cc")
 license=('EPL')
 url='https://github.com/coin-or/ADOL-C'
 source=(https://github.com/coin-or/ADOL-C/archive/releases/${pkgver}.tar.gz)
@@ -24,6 +26,9 @@ build() {
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
   mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
 
+  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
+    LDFLAGS+=" -lomp"
+  fi
   ../${_realname}-releases-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --enable-static \


### PR DESCRIPTION
Needed for clang builds.

Signed-off-by: Rosen Penev <rosenp@gmail.com>