### PR TITLE
slim-simulator: Update to version 3.7.1

### DIFF
--- a/mingw-w64-slim-simulator/PKGBUILD
+++ b/mingw-w64-slim-simulator/PKGBUILD
@@ -1,8 +1,8 @@
 _realname=slim-simulator
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.7
-pkgrel=2
+pkgver=3.7.1
+pkgrel=1
 pkgdesc="SLiM forward simulation software package for population genetics (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -12,7 +12,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake")
 depends=("${MINGW_PACKAGE_PREFIX}-qt5-base")
 source=("http://benhaller.com/slim/SLiM_pacman.tar.gz" )
-sha256sums=("5f9c83709666dc0d367b6d8f04e0c42faa1e1b0e0ea549ae6124046f076754ff")
+sha256sums=("a9b9ea3e9423deffb35c4e6ecf66ee919266dc37ee7ee7d60d33850f9cd5d4c0")
 
 build() {
   mkdir -p "${srcdir}/build-${MINGW_CHOST}"


### PR DESCRIPTION
This just updates `slim-simulator` to the newest version. Didn't require any changes except for the sha256sums of course.