### PR TITLE
scotch: update to 6.1.3 

### DIFF
--- a/mingw-w64-scotch/PKGBUILD
+++ b/mingw-w64-scotch/PKGBUILD
@@ -41,7 +41,7 @@ build() {
 }
 
 package() {
-  cd "${srcdir}/${_realname}_${pkgver}"
+  cd "${srcdir}/${_realname}-v${pkgver}"
   mkdir -p ${pkgdir}${MINGW_PREFIX}/{bin,lib,include}
   mkdir -p "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig"
   echo "

--- a/mingw-w64-scotch/PKGBUILD
+++ b/mingw-w64-scotch/PKGBUILD
@@ -1,11 +1,10 @@
 # Contributor: Oleg A. Khlybov <fougas@mail.ru>
 
 _realname=scotch
-
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgdesc='Graph partitioning and sparse matrix ordering package (mingw-w64)'
-pkgver=6.1.1
+pkgver=6.1.3
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -14,27 +13,27 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc" "${MINGW_PACKAGE_PREFIX}-libgnurx")
 options=('strip' 'staticlibs')
 license=('CeCILL-C')
 url="https://www.labri.fr/perso/pelegrin/scotch/"
-source=("https://gforge.inria.fr/frs/download.php/file/38443/${_realname}_${pkgver}.tar.gz"
+source=("https://gitlab.inria.fr/scotch/scotch/-/archive/v6.1.3/${_realname}-v${pkgver}.tar.gz"
 		"0001-makefile.inc.patch"
 		"0002-pipe-fix.patch"
 		"0003-thread-fix.patch"
 		"0004-dummysizes-regex.patch"
 )
-sha256sums=('39052F59FF474A4A69CEFC25CF3CAF8429400889DEBA010EE6403CA188F8B311'
+sha256sums=('4E54F056199E6C23D46581D448FCFE2285987E5554A0AA527F7931684EF2809E'
             '2c55b1e99a8d40c976e7147aa9102db2d1c489da1b760e526b424bf5ffd12716'
             '49d87533321504a9594d7bb4659fbced5afadd2fc0d73f0577b0b3ad47cc7d0f'
             '8a02cea7cdc3c685776012b2bb42cec8c5e98c435bdf1ffd62abf5ab6def9fbb'
             '92908a6598d333a35a3b76650c111a082304e9dfff7c9bc0667d6af62de47c14')
 
 prepare() {
-  cd "${srcdir}/${_realname}_${pkgver}"
+  cd "${srcdir}/${_realname}-v${pkgver}"
   for p in ${source[*]:1}; do
 	patch -p1 -i "$srcdir/$p"
   done
 }
 
 build() {
-  cd "${srcdir}/${_realname}_${pkgver}/src"
+  cd "${srcdir}/${_realname}-v${pkgver}/src"
   make -j1 scotch ptscotch esmumps ptesmumps
   cd ../lib
   gcc -shared -o lib${_realname}.dll -Wl,--enable-auto-import -Wl,--export-all-symbols -Wl,--output-def,lib${_realname}.def -Wl,--out-implib,lib${_realname}.dll.a -Wl,--whole-archive lib${_realname}.a lib${_realname}err.a -Wl,--no-whole-archive

--- a/mingw-w64-scotch/PKGBUILD
+++ b/mingw-w64-scotch/PKGBUILD
@@ -13,7 +13,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc" "${MINGW_PACKAGE_PREFIX}-libgnurx")
 options=('strip' 'staticlibs')
 license=('CeCILL-C')
 url="https://www.labri.fr/perso/pelegrin/scotch/"
-source=("https://gitlab.inria.fr/scotch/scotch/-/archive/v6.1.3/${_realname}-v${pkgver}.tar.gz"
+source=("https://gitlab.inria.fr/scotch/scotch/-/archive/v${pkgver}/${_realname}-v${pkgver}.tar.gz"
 		"0001-makefile.inc.patch"
 		"0002-pipe-fix.patch"
 		"0003-thread-fix.patch"


### PR DESCRIPTION
There is also a new version 7.0.1 available but it requires more skills (CMake support is now fully functional)