### PR TITLE
apr-util: rebuild

### DIFF
--- a/mingw-w64-apr-util/PKGBUILD
+++ b/mingw-w64-apr-util/PKGBUILD
@@ -4,7 +4,7 @@ _realname=apr-util
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.6.1
-pkgrel=3
+pkgrel=4
 pkgdesc="The Apache Portable Runtime (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -44,7 +44,7 @@ build() {
   [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}
   mkdir -p build-${MINGW_CHOST}
   cd build-${MINGW_CHOST}
-  APRUTIL_LDFLAGS+=" -L${MINGW_PREFIX}/${MINGW_CHOST}/lib -R${MINGW_PREFIX}/${MINGW_CHOST}/lib" \
+
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \


### PR DESCRIPTION
without referencing ${MINGW_PREFIX}/${MINGW_CHOST}