### PR TITLE
Improve Flashrom build

### DIFF
--- a/mingw-w64-flashrom/PKGBUILD
+++ b/mingw-w64-flashrom/PKGBUILD
@@ -4,7 +4,7 @@ _realname=flashrom
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Utility for detecting, reading, writing, verifying and erasing flash chips (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -15,7 +15,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-libftdi"
          "${MINGW_PACKAGE_PREFIX}-libwinpthread-git")
 makedepends=("${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-pkg-config")
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "patch")
 source=("https://github.com/flashrom/flashrom/archive/refs/tags/v${pkgver}.tar.gz"
         0001-meson-check-version-script.patch)
 sha256sums=('a5bac412cefb87bb426912fed46ccc38799d088a9b92dbe7bac38c5df016d9b2'
@@ -26,6 +27,9 @@ prepare() {
 
   # Workaround: DEF file should be used instead of MAP file
   patch -p1 -i "${srcdir}/0001-meson-check-version-script.patch"
+
+  # Required for `flashrom --version` to report correctly.
+  printf "VERSION = v${pkgver};\nMAN_DATE = $(date -u -r flashrom.8.tmpl +%Y-%m-%dT%H:%M:%SZ);" > versioninfo.inc
 }
 
 build() {


### PR DESCRIPTION
Three changes have been made to the `PKGBUILD` for Flashrom:
* A `versioninfo.inc` is now created. Previously when running `flashrom --version`, it would report `flashrom unknown; on Windows 10.0` – with this change, it now correctly reports `flashrom v1.2; on Windows 10.0`.
* As `patch` doesn't come with MSYS2, it has been added to `makedepends` so that it doesn't need to be installed manually. `patch` is part of `base-devel`, however, so let me know if `base-devel` packages are exempt from `PKGBUILD` and I'll make the necessary change.
* Bumped `pkgrel` to 3.