### PR TITLE
ntldd-git: use $CC instead of gcc when building

### DIFF
--- a/mingw-w64-ntldd-git/PKGBUILD
+++ b/mingw-w64-ntldd-git/PKGBUILD
@@ -4,7 +4,7 @@ _realname=ntldd
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 pkgver=r19.7fb9365
-pkgrel=1
+pkgrel=2
 pkgdesc="Tracks dependencides in Windows PE binaries (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -24,6 +24,7 @@ pkgver() {
 
 build() {
   cd "${srcdir}/${_realname}"
+  sed -i -e 's/^gcc /$CC /' makeldd.sh
   ./makeldd.sh
 }
 


### PR DESCRIPTION
now that clang does not provide a gcc alias