### PR TITLE
New package: hid_bootloader_cli

### DIFF
--- a/mingw-w64-hid-bootloader-cli/01-libusb-compat-header.patch
+++ b/mingw-w64-hid-bootloader-cli/01-libusb-compat-header.patch
@@ -1,0 +1,11 @@
+--- a/hid_bootloader_cli.c
++++ b/hid_bootloader_cli.c
+@@ -188,7 +188,7 @@
+ #if defined(USE_LIBUSB)
+ 
+ // http://libusb.sourceforge.net/doc/index.html
+-#include <usb.h>
++#include <libusb-compat/usb.h>
+ 
+ usb_dev_handle * open_usb_device(int vid, int pid)
+ {

--- a/mingw-w64-hid-bootloader-cli/PKGBUILD
+++ b/mingw-w64-hid-bootloader-cli/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: fauxpark <fauxpark@gmail.com>
+
+_realname=hid_bootloader_cli
+pkgbase=mingw-w64-${_realname//_/-}
+pkgname=${MINGW_PACKAGE_PREFIX}-${_realname//_/-}
+pkgver=210130
+pkgrel=1
+pkgdesc='LUFA HID Bootloader CLI (mingw-w64)'
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+license=('GPL3')
+url='https://github.com/abcminiuser/lufa'
+depends=("${MINGW_PACKAGE_PREFIX}-libusb-compat")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
+source=(
+    "https://github.com/abcminiuser/lufa/archive/refs/tags/LUFA-${pkgver}.tar.gz"
+    "01-libusb-compat-header.patch"
+)
+sha256sums=(
+    '9b56921d59a50099cc6a8026248380a10ff518c8d02b547d6e617f71e6038f57'
+    'e50e36fa4dc5a60a3c0235e66a5e35bbe6eddaf902975e2962fa8ddfbfa0f485'
+)
+
+build() {
+    cd ${srcdir}/lufa-LUFA-${pkgver}/Bootloaders/HID/HostLoaderApp
+
+    patch -p1 -i ${srcdir}/01-libusb-compat-header.patch
+
+    OS=LINUX make hid_bootloader_cli
+}
+
+package() {
+    cd ${srcdir}/lufa-LUFA-${pkgver}/Bootloaders/HID/HostLoaderApp
+
+    install -Dm755 hid_bootloader_cli ${pkgdir}${MINGW_PREFIX}/bin/hid_bootloader_cli
+}

--- a/mingw-w64-hid-bootloader-cli/PKGBUILD
+++ b/mingw-w64-hid-bootloader-cli/PKGBUILD
@@ -21,10 +21,14 @@ sha256sums=(
     'e50e36fa4dc5a60a3c0235e66a5e35bbe6eddaf902975e2962fa8ddfbfa0f485'
 )
 
-build() {
+prepare() {
     cd ${srcdir}/lufa-LUFA-${pkgver}/Bootloaders/HID/HostLoaderApp
 
     patch -p1 -i ${srcdir}/01-libusb-compat-header.patch
+}
+
+build() {
+    cd ${srcdir}/lufa-LUFA-${pkgver}/Bootloaders/HID/HostLoaderApp
 
     OS=LINUX make hid_bootloader_cli
 }


### PR DESCRIPTION
This is a modified version of teensy_loader_cli (#6685) which also supports devices with LUFA's HID bootloader implementation.