### PR TITLE
msmpi: Replace gcc/g++ by cc/c++

### DIFF
--- a/mingw-w64-msmpi/PKGBUILD
+++ b/mingw-w64-msmpi/PKGBUILD
@@ -4,7 +4,7 @@ _realname=msmpi
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=10.1.1
-pkgrel=6
+pkgrel=7
 pkgdesc="Microsoft MPI SDK (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -33,7 +33,7 @@ source=(
   'tclbuildtest.tcl'
   'msmpi.test'
 )
-sha256sums=('8284306d3d86a29904ce55b6a91a982470b0648821da0a563a34977a542e30e4'
+sha256sums=('5d9a3d7b0e5ec90bbede8009b0f8bc82ae5c2fe18d998bbbafa9b14c9e06a0bf'
             'baee3f18f38650e7182956baa0d3d8f8e5c26d8603ccee4871a4dbd160c13660'
             'f3384eeb848164e518edfd2b2b9ff1d0f33e267efd5811d5a7c5f79ef7a0a81e'
             '38e7be31ad555570f6122058317c08504472b8cfd0a198cdad827519b941ba2c'

--- a/mingw-w64-msmpi/mpi.c
+++ b/mingw-w64-msmpi/mpi.c
@@ -3,10 +3,10 @@
 #include <windows.h>
 
 #if defined(CC)
-	#define C "gcc.exe"
+	#define C "cc.exe"
 	#define E "MPICC"
 #elif defined(CXX)
-	#define C "g++.exe"
+	#define C "c++.exe"
 	#define E "MPICXX"
 #elif defined(FC)
 	#define C "gfortran.exe"


### PR DESCRIPTION
fixes #10798 