### PR TITLE
teensy-loader-cli: move patches to prepare()

### DIFF
--- a/mingw-w64-teensy-loader-cli/PKGBUILD
+++ b/mingw-w64-teensy-loader-cli/PKGBUILD
@@ -4,7 +4,7 @@ _realname=teensy_loader_cli
 pkgbase=mingw-w64-${_realname//_/-}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname//_/-}
 pkgver=2.2
-pkgrel=1
+pkgrel=2
 pkgdesc='Command line loader for PJRC Teensy microcontrollers (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -23,11 +23,15 @@ sha256sums=(
     '05ef2838758d7b98c586c1840052f57eedc79e1e360bf5daba7c4e7e173e8ea4'
 )
 
-build() {
+prepare() {
     cd ${srcdir}/${_realname}-${pkgver}
 
     patch -p1 -i ../01-libusb-compat-header.patch
     patch -p1 -i ../02-win32-checks.patch
+}
+
+build() {
+    cd ${srcdir}/${_realname}-${pkgver}
 
     OS=LINUX make teensy_loader_cli
 }


### PR DESCRIPTION
Sorry, I forgot to do this in #10802. Not sure if the pkgrel bump is required as it hasn't been published yet.