### PR TITLE
qbittorrent: Update to 4.4.1

### DIFF
--- a/mingw-w64-qbittorrent/002-winconf-prepare-env-for-mingw.patch
+++ b/mingw-w64-qbittorrent/002-winconf-prepare-env-for-mingw.patch
@@ -20,23 +20,3 @@
  
  # Man page
  nogui {
---- a/winconf.pri
-+++ b/winconf.pri
-@@ -23,7 +23,7 @@
-     DEFINES += NDEBUG
- }
- 
--win32-g++* {
-+win32-g++*|win32-clang-g++* {
-     CONFIG(debug, debug|release) {
-         # Make sure binary is not relocatable, otherwise debugging will fail
-         QMAKE_LFLAGS -= -Wl,--dynamicbase
-@@ -58,7 +58,7 @@
- 
- # Stack trace support can be enabled in 'conf.pri'
- stacktrace {
--    win32-g++* {
-+    win32-g++*|win32-clang-g++* {
-         contains(QMAKE_HOST.arch, x86) {
-             # i686 arch requires frame pointer preservation
-             QMAKE_CXXFLAGS += -fno-omit-frame-pointer

--- a/mingw-w64-qbittorrent/003-no-file-offset-bits-64.patch
+++ b/mingw-w64-qbittorrent/003-no-file-offset-bits-64.patch
@@ -1,0 +1,10 @@
+--- qbittorrent-4.4.1/winconf.pri.orig	2022-02-19 22:13:21.460000000 +0100
++++ qbittorrent-4.4.1/winconf.pri	2022-02-19 22:13:25.989851400 +0100
+@@ -29,7 +29,6 @@
+         QMAKE_LFLAGS -= -Wl,--dynamicbase
+     }
+ 
+-    DEFINES += _FILE_OFFSET_BITS=64
+     DEFINES += __USE_W32_SOCKETS
+ 
+     QMAKE_CXXFLAGS += -std=c++17

--- a/mingw-w64-qbittorrent/PKGBUILD
+++ b/mingw-w64-qbittorrent/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=qbittorrent
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-pkgver=4.3.9
+pkgver=4.4.1
 pkgrel=1
 pkgdesc="An advanced BitTorrent client programmed in C++, based on Qt toolkit and libtorrent-rasterbar (mingw-w64)"
 arch=('any')
@@ -22,30 +22,27 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-cc")
 source=("https://downloads.sourceforge.net/sourceforge/qbittorrent/${_realname}-${pkgver}.tar.xz"{,.asc}
         001-PROCESS_CLASS_INFORMATION-require-win8.patch
-        002-winconf-prepare-env-for-mingw.patch)
-sha256sums=('16ebe2e761922b3fb21c35d2bccc5d4b4b0a3e853434bcaddbbc00c72003d880'
+        002-winconf-prepare-env-for-mingw.patch
+        003-no-file-offset-bits-64.patch)
+sha256sums=('1386f000ce1d791469c3ea03e3951ca25f67f534e66896592bd12357dda9a8ec'
             'SKIP'
             'a89b2830259203734e30c02f40104bf2898ced576543a5b0edc559fe1884e0b4'
-            '7c9fabb9cfc1b721803868be719daee448100ef97e8ba8fbd7b144e8af235bf3')
+            '9a617170437982b7273264384e03e6dccf8a794356b7228e88ba6cc9cbaf9e80'
+            'd1ff16cd4cd955532bc0db98c8f3714003e0dc1daaab8f2eee8c51c687ca413b')
 validpgpkeys=('D8F3DA77AAC6741053599C136E4A2D025B7CC9A2') # sledgehammer_999 <hammered999@gmail.com>
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   patch -p0 -i ${srcdir}/001-PROCESS_CLASS_INFORMATION-require-win8.patch
 
-  # prepare env for mingw
-  # sed -i 's/unix:!macx:/unix|win32-g++:/g' "src/src.pro"
-  # sed -i 's/!haiku/#!haiku/g' "unixconf.pri"
   patch -Np1 -i "${srcdir}/002-winconf-prepare-env-for-mingw.patch"
+
+  # This defines "stat" which clashes with libtorrent headers and breaks the build.
+  # From what I see off_t isn't used in the code, so this shouldn't change anything
+  patch -Np1 -i "${srcdir}/003-no-file-offset-bits-64.patch"
 }
 
 build() {
-
-  # See https://github.com/msys2/MINGW-packages/issues/9827
-  if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then
-    CXXFLAGS+=" -DBOOST_ASIO_DISABLE_STD_ALIGNED_ALLOC"
-  fi
-
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
   cp -rf ${_realname}-${pkgver} build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
 


### PR DESCRIPTION
* patches partly removed because of https://github.com/qbittorrent/qBittorrent/pull/15115
* remove workaround for boost which is patched in boost
* remove outdated comments
* add patch to disable _FILE_OFFSET_BITS which leads to macro clashes