### PR TITLE
qt6-base: add runtime dependency on libb2

### DIFF
--- a/mingw-w64-qt6-base/PKGBUILD
+++ b/mingw-w64-qt6-base/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
 _qtver=6.2.3
 pkgver=${_qtver/-/}
-pkgrel=1
+pkgrel=2
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://www.qt.io'
@@ -21,6 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-fontconfig"
              "${MINGW_PACKAGE_PREFIX}-harfbuzz"
              "${MINGW_PACKAGE_PREFIX}-icu"
+             "${MINGW_PACKAGE_PREFIX}-libb2"
              "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
              "${MINGW_PACKAGE_PREFIX}-libpng"
              "${MINGW_PACKAGE_PREFIX}-md4c"
@@ -173,6 +174,7 @@ package_qt6-base() {
            "${MINGW_PACKAGE_PREFIX}-fontconfig"
            "${MINGW_PACKAGE_PREFIX}-harfbuzz"
            "${MINGW_PACKAGE_PREFIX}-icu"
+           "${MINGW_PACKAGE_PREFIX}-libb2"
            "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
            "${MINGW_PACKAGE_PREFIX}-libpng"
            "${MINGW_PACKAGE_PREFIX}-md4c"


### PR DESCRIPTION
qmake6 failed to run (#10813) because of this new dependency.