### PR TITLE
[CI] Check runtime dependencies

### DIFF
--- a/.ci/ci-build.sh
+++ b/.ci/ci-build.sh
@@ -90,6 +90,13 @@ for package in "${packages[@]}"; do
                     ntldd -R ${binary} | grep -v "ext-ms\|api-ms\|WINDOWS\|Windows\|HvsiFileTrust\|wpaxholder"
                 done
             fi
+            declare -a py_modules=($(pacman -Ql $pkgname | sed -e 's|^[^ ]* ||' | grep -E ${MINGW_PREFIX}/lib/python[0-9]\.[0-9]+/site-packages/.+\.pyd$))
+            if [ "${#py_modules[@]}" -ne 0 ]; then
+                for pyd in ${py_modules[@]}; do
+                    echo "${pyd}:"
+                    ntldd -R ${pyd} | grep -v "ext-ms\|api-ms\|WINDOWS\|Windows\|HvsiFileTrust\|wpaxholder"
+                done
+            fi
             echo "::endgroup::"
 
             echo "::group::[uninstall] ${pkgname}"
@@ -129,6 +136,13 @@ for package in "${packages[@]}"; do
                 for binary in ${binaries[@]}; do
                     echo "${binary}:"
                     ntldd -R ${binary} | grep -v "ext-ms\|api-ms\|WINDOWS\|Windows\|HvsiFileTrust\|wpaxholder"
+                done
+            fi
+            declare -a py_modules=($(pacman -Ql $pkgname | sed -e 's|^[^ ]* ||' | grep -E ${MINGW_PREFIX}/lib/python[0-9]\.[0-9]+/site-packages/.+\.pyd$))
+            if [ "${#py_modules[@]}" -ne 0 ]; then
+                for pyd in ${py_modules[@]}; do
+                    echo "${pyd}:"
+                    ntldd -R ${pyd} | grep -v "ext-ms\|api-ms\|WINDOWS\|Windows\|HvsiFileTrust\|wpaxholder"
                 done
             fi
         done

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,7 @@ jobs:
         shell: msys2 {0}
         id: build
         run: |
+          pacman -S --noconfirm ${MINGW_PACKAGE_PREFIX}-ntldd
           cd /C/_
           if [[ "$MSYSTEM" != "${{ matrix.msystem }}" ]]; then
             MSYSTEM=${{ matrix.msystem }}


### PR DESCRIPTION
This an initial work to check runtime dependencies at buildtime.
It checks runtime dependencies of all the `*.dll` and `*.exe` installed in `${MINGW_PREFIX}/bin`

Questions:
- [ ] Should we check other `*.dll` and `*.exe` files outside of `bin` directory?
I think most of them are just extensions/plugins and their dependencies are mostly listed under `optdepends`.
- [x] Should we check python modules `*.pyd`?

Known issues:
- [x] If `ntldd` could not find all the runtime dependencies it fails immediately, I tried to silent it but I don't have enough experience with shell/bash.
- [ ] Some of the `*.dll` and `*.exe` are optional (depends on optional packages), we could ignore them if we could fix the first issue.
- [ ] Split-packages: How to know if one package is using the runtime dependencies pulled by another independent non-conflicting package.

the qt-svg commit is just a test, I will remove it before marking this PR as ready.