### PR TITLE
new packages: QGIS and qtkeychain-qt5

### DIFF
--- a/mingw-w64-qgis/PKGBUILD
+++ b/mingw-w64-qgis/PKGBUILD
@@ -1,0 +1,64 @@
+
+_realname=qgis
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=3.22.3
+pkgrel=1
+pkgdesc='Geographic Information System (GIS) that supports vector, raster & database formats (mingw-w64)'
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+url='https://qgis.org/'
+license=('GPL')
+depends=("${MINGW_PACKAGE_PREFIX}-protobuf"
+		 "${MINGW_PACKAGE_PREFIX}-qt5"
+		 "${MINGW_PACKAGE_PREFIX}-gdal"
+		 "${MINGW_PACKAGE_PREFIX}-libzip"
+		 "${MINGW_PACKAGE_PREFIX}-qca-qt5"
+		 "${MINGW_PACKAGE_PREFIX}-gsl"
+		 "${MINGW_PACKAGE_PREFIX}-exiv2"
+		 "${MINGW_PACKAGE_PREFIX}-hdf5"
+		 "${MINGW_PACKAGE_PREFIX}-libxml2"
+		 "${MINGW_PACKAGE_PREFIX}-netcdf"
+		 "${MINGW_PACKAGE_PREFIX}-qwt-qt5"
+		 "${MINGW_PACKAGE_PREFIX}-qtkeychain-qt5"
+		 "${MINGW_PACKAGE_PREFIX}-qscintilla"
+		 "${MINGW_PACKAGE_PREFIX}-spatialindex")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake")
+source=("https://qgis.org/downloads/${_realname}-$pkgver.tar.bz2")
+sha256sums=('e7430c3d9cb5782257916834c7898f3d3a5fc7c359b12d5def7cdb437d757893')
+
+prepare() {
+  plain 'No Step'
+}
+
+build() {
+  [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}
+  mkdir ${srcdir}/build-${MSYSTEM}
+  cd ${srcdir}/build-${MSYSTEM}
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake \
+    -DQGIS_BIN_SUBDIR=bin -DQGIS_DATA_SUBDIR=share \
+    -DQGIS_LIBEXEC_SUBDIR=bin \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DQGIS_PLUGIN_SUBDIR=lib/qgis/plugins \
+    -DWITH_QTWEBKIT=OFF \
+    -DWITH_BINDINGS=OFF \
+    -DENABLE_TESTS=OFF \
+    -DUSE_OPENCL=OFF \
+    -DWITH_3D=TRUE \
+    -DWITH_SERVER=FALSE \
+    -DWITH_CUSTOM_WIDGETS=TRUE \
+    -DWITH_PDAL=OFF \
+	-DWITH_GRASS=OFF \ \
+    -DSETUPAPI_LIBRARY=${MINGW_PREFIX}/x86_64-w64-mingw32/lib/libsetupapi.a \
+     -DVERSION_LIBRARY=${MINGW_PREFIX}/x86_64-w64-mingw32/lib/libversion.a \
+	../${_realname}-$pkgver
+	
+  ${MINGW_PREFIX}/bin/cmake --build .
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
+}

--- a/mingw-w64-qtkeychain-qt5/PKGBUILD
+++ b/mingw-w64-qtkeychain-qt5/PKGBUILD
@@ -1,0 +1,30 @@
+
+_realname=qtkeychain-qt5
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.13.2
+pkgrel=1
+pkgdesc='Provides support for secure credentials storage'
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+license=(BSD)
+depends=("${MINGW_PACKAGE_PREFIX}-libsecret" "${MINGW_PACKAGE_PREFIX}-qt5-base")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake" "${MINGW_PACKAGE_PREFIX}-qt5-tools")
+source=(https://github.com/frankosterfeld/qtkeychain/archive/v$pkgver/$pkgname-$pkgver.tar.gz)
+sha256sums=('20beeb32de7c4eb0af9039b21e18370faf847ac8697ab3045906076afbc4caa5')
+
+build() {
+  [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}
+  mkdir ${srcdir}/build-${MSYSTEM}
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake -B build-${MSYSTEM} -S qtkeychain-$pkgver \
+      -G'Ninja' \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX}
+  ${MINGW_PREFIX}/bin/cmake --build build-${MSYSTEM}
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
+}


### PR DESCRIPTION
Hello,

I'd like to propose a new package: QGIS and a new library required by qgis: qtkeychain-qt5.

> QGIS is the leading Free and Open Source Desktop GIS. It allows you to create, edit, visualise, analyse and publish geospatial information on Windows, Mac OS, Linux, BSD and Android (via the QField app). We also provide an OGC Web Server application, a web browser client and developer libraries. The QGIS project is under very active development by an enthusiastic and engaged developer community with good mechanisms for help via stack exchange, mailing lists and (optionally) through a global network of commercial support providers.

https://qgis.org

