### PR TITLE
Add `jj`, an experimental DVCS

### DIFF
--- a/mingw-w64-jj/PKGBUILD
+++ b/mingw-w64-jj/PKGBUILD
@@ -1,0 +1,62 @@
+# Maintainer: Johannes Schindelin <johannes.schindelin@gmx.de>
+
+_realname=jj
+_commit=c59dcd76a4e085de85577df7c515bcf7884c8373
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver="0.2.0".586.c59dcd7
+pkgrel=1
+pkgdesc='Jujutsu (an experimental VCS)'
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+url="https://github.com/martinvonz/jj"
+license=('Apache2.0')
+makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
+source=("git+https://github.com/martinvonz/jj#commit=${_commit}")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "${_realname}"
+  test ! -f "$(git rev-parse --git-path shallow)" || git -c http.sslbackend fetch --unshallow
+  rev_version="$(git blame -lsL '/^version *=/,+1' Cargo.toml)"
+  rev=${rev_version%% *}
+  version=${rev_version##*=}
+  printf "%s.%s.%s" "${version// /}" "$(git rev-list --count $rev.. -- .)" "$(git rev-parse --short HEAD)"
+}
+
+prepare() {
+  if test ! -d build-${MSYSTEM}
+  then
+    git -C ${_realname} worktree add --detach "$PWD/build-${MSYSTEM}"
+  else
+    git -C build-${MSYSTEM} reset --hard $(git -C ${_realname} rev-parse HEAD)
+  fi
+  ${MINGW_PREFIX}/bin/cargo fetch \
+    --locked \
+	--manifest-path build-${MSYSTEM}/Cargo.toml
+}
+
+build() {
+  ${MINGW_PREFIX}/bin/cargo build \
+	--release \
+	--frozen \
+	--manifest-path build-${MSYSTEM}/Cargo.toml
+}
+
+check() {
+  ${MINGW_PREFIX}/bin/cargo test \
+	--release \
+	--frozen \
+	--manifest-path build-${MSYSTEM}/Cargo.toml
+}
+
+package() {
+  ${MINGW_PREFIX}/bin/cargo install \
+	--frozen \
+	--offline \
+	--no-track \
+	--path build-${MSYSTEM} \
+	--root ${pkgdir}${MINGW_PREFIX}
+
+  install -Dm644 build-${MSYSTEM}/LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
[`jj`](https://github.com/martinvonz/jj) (also known as Jujutsu) currently comes with two backends, one that uses Git's native storage, making it interoperable with Git.