### PR TITLE
sdl2_mixer: Fix static library and linking with FLAC

### DIFF
--- a/mingw-w64-SDL2_mixer/PKGBUILD
+++ b/mingw-w64-SDL2_mixer/PKGBUILD
@@ -4,7 +4,7 @@ _realname=SDL2_mixer
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.0.4
-pkgrel=6
+pkgrel=7
 pkgdesc="A simple multi-channel audio mixer (Version 2) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -40,30 +40,54 @@ prepare() {
 }
 
 build() {
-  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
-  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
-  cd "${srcdir}/build-${MINGW_CHOST}/"
   export lt_cv_deplibs_check_method='pass_all'
+
+  local -a _common_config
+  _common_config+=(
+    --disable-music-ogg-shared
+    --disable-music-flac-shared
+    --enable-music-mp3
+    --disable-music-mp3-mad-gpl
+    --enable-music-mp3-mpg123
+    --disable-music-mp3-mpg123-shared
+    --enable-music-opus
+    --disable-music-opus-shared
+  )
+
+  [[ -d "${srcdir}/build-${MSYSTEM}-static" ]] && rm -rf "${srcdir}/build-${MSYSTEM}-static"
+  mkdir -p "${srcdir}/build-${MSYSTEM}-static" && cd "${srcdir}/build-${MSYSTEM}-static"
+
+  CPPFLAGS+=" -DFLAC__NO_DLL" \
+  ../${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --disable-shared \
+    --enable-static \
+    "${_common_config[@]}"
+
+  make
+
+  [[ -d "${srcdir}/build-${MSYSTEM}-shared" ]] && rm -rf "${srcdir}/build-${MSYSTEM}-shared"
+  mkdir -p "${srcdir}/build-${MSYSTEM}-shared" && cd "${srcdir}/build-${MSYSTEM}-shared"
+
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
     --enable-shared \
-    --enable-static \
-    --disable-music-ogg-shared \
-    --disable-music-flac-shared \
-    --enable-music-mp3 \
-    --disable-music-mp3-mad-gpl \
-    --enable-music-mp3-mpg123 \
-    --disable-music-mp3-mpg123-shared \
-    --enable-music-opus \
-    --disable-music-opus-shared
+    --disable-static \
+    "${_common_config[@]}"
 
   make
 }
 
 package() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MSYSTEM}-static"
   make DESTDIR="${pkgdir}" install
+
+  cd "${srcdir}/build-${MSYSTEM}-shared"
+  make DESTDIR="${pkgdir}" install
+
   install -Dm644 "${srcdir}"/${_realname}-${pkgver}/COPYING.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
dllimport attribute is not added if FLAC__NO_DLL is defined.

Fixes https://github.com/msys2/MINGW-packages/issues/10869