### PR TITLE
python-requests 2.27.1: add charset-normalizer as dependency

### DIFF
--- a/mingw-w64-python-requests/PKGBUILD
+++ b/mingw-w64-python-requests/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=requests
 pkgbase=mingw-w64-python-${_realname}
 pkgver=2.27.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Requests is the only Non-GMO HTTP library for Python, safe for human consumption (mingw-w64)"
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}=${pkgver}")
@@ -16,7 +16,8 @@ license=('Apache')
 url="https://2.python-requests.org"
 depends=("${MINGW_PACKAGE_PREFIX}-python-urllib3"
          "${MINGW_PACKAGE_PREFIX}-python-chardet"
-         "${MINGW_PACKAGE_PREFIX}-python-idna")
+         "${MINGW_PACKAGE_PREFIX}-python-idna"
+         "${MINGW_PACKAGE_PREFIX}-python-charset-normalizer")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest-httpbin"
               "${MINGW_PACKAGE_PREFIX}-python-pytest-mock"


### PR DESCRIPTION
_Originally posted by @naveen521kk in https://github.com/msys2/MINGW-packages/issues/10673#issuecomment-1053557838_

Add missing dependency `python-charset-normalizer` for python-requests 2.27.1.