### PR TITLE
Upgrade Rust to 1.59

### DIFF
--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -7,7 +7,7 @@ _bootstrapping=yes
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-rust-docs")
-pkgver=1.58.1
+pkgver=1.59.0
 pkgrel=1
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
@@ -37,7 +37,7 @@ source=("https://static.rust-lang.org/dist/${_realname}c-${pkgver}-src.tar.gz"{,
         "0005-win32-config.patch"
         "0007-clang-subsystem.patch"
         "0008-disable-self-contained.patch")
-sha256sums=('a839afdd3625d6f3f3c4c10b79813675d1775c460d14be1feaf33a6c829c07c7'
+sha256sums=('a7c8eeaee85bfcef84c96b02b3171d1e6540d15179ff83dddd9eafba185f85f9'
             'SKIP'
             '8c9c37f2ff3bee7d9ac520c66d3f37fd7f002012ddca4ddeeab2b009f520e4ce'
             '6cc3234644768e24824e455d6304585c717ae25aa53ebf9cf1f1dea87bf869b7'


### PR DESCRIPTION
All tests are green (didn't test excluded ones but since we use LLVM without Rust patches they are unlikely to pass) for me locally in CLANG64 subsystem.