### PR TITLE
Bumped version of ***-python-coverage to v6.3.2.

### DIFF
--- a/mingw-w64-python-coverage/PKGBUILD
+++ b/mingw-w64-python-coverage/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=6.2
+pkgver=6.3.2
 pkgrel=1
 pkgdesc="Code coverage measurement for Python (mingw-w64)"
 arch=('any')
@@ -16,7 +16,7 @@ license=('Apache 2.0')
 depends=("${MINGW_PACKAGE_PREFIX}-python")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools" "${MINGW_PACKAGE_PREFIX}-cc")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/nedbat/coveragepy/archive/refs/tags/${pkgver}.tar.gz")
-sha256sums=('0d60b736f73f8d01200807a77533f513c8bbd81c855880b18ae7344dbdafbbf2')
+sha256sums=('9c59f138b335f1cc60ff0b0bc623d7e9051f042e0068285b6c6fbc7f891da2cf')
 
 prepare() {
   cd "${srcdir}"


### PR DESCRIPTION
This PR updates `***-python-coverage` from v6.2 to v6.3.2.

> **Note:**  
> The SHA256 was computed offline based on the downloaded `*.tar.gz` file.  
> Is there a way to get the official SHA256 from GitHub, so the *chain of trust* is not interrupted?  
> /cc @MehdiChinoune 

------------
Related issues:
* https://github.com/msys2/MINGW-packages/issues/10877