### PR TITLE
binutils: Add patch for thin static libraries (fix #10860)

### DIFF
--- a/mingw-w64-binutils/0001-Revert-check-thin-archive-element-file-size.patch
+++ b/mingw-w64-binutils/0001-Revert-check-thin-archive-element-file-size.patch
@@ -1,0 +1,41 @@
+From 581c5ba435538c23fe63d6884ff885b7ef333568 Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Tue, 1 Mar 2022 21:54:34 +1030
+Subject: [PATCH] Revert "Check thin archive element file size against archive
+ header"
+
+This reverts commit 48e3e6aec8a4f37d00ea6c0da3ab45e76490e3db.
+
+	PR 28929
+	* archive.c (_bfd_get_elt_at_filepos): Don't check thin archive
+	element file size.
+---
+ bfd/archive.c | 12 +-----------
+ 1 file changed, 1 insertion(+), 11 deletions(-)
+
+diff --git a/bfd/archive.c b/bfd/archive.c
+index ffaec7e2231..9ad61adc615 100644
+--- a/bfd/archive.c
++++ b/bfd/archive.c
+@@ -717,17 +717,7 @@ _bfd_get_elt_at_filepos (bfd *archive, file_ptr filepos,
+ 	 open the external file as a bfd.  */
+       bfd_set_error (bfd_error_no_error);
+       n_bfd = open_nested_file (filename, archive);
+-      if (n_bfd != NULL)
+-	{
+-	  ufile_ptr size = bfd_get_size (n_bfd);
+-	  if (size != 0 && size != new_areldata->parsed_size)
+-	    {
+-	      bfd_set_error (bfd_error_malformed_archive);
+-	      bfd_close (n_bfd);
+-	      n_bfd = NULL;
+-	    }
+-	}
+-      else
++      if (n_bfd == NULL)
+ 	{
+ 	  switch (bfd_get_error ())
+ 	    {
+-- 
+2.27.0
+

--- a/mingw-w64-binutils/PKGBUILD
+++ b/mingw-w64-binutils/PKGBUILD
@@ -6,7 +6,7 @@ _realname=binutils
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.38
-pkgrel=1
+pkgrel=2
 pkgdesc="A set of programs to assemble and manipulate binary and object files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -19,6 +19,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools")
 options=('staticlibs' '!distcc' '!ccache')
 source=(https://ftp.gnu.org/gnu/binutils/${_realname}-${pkgver}.tar.xz{,.sig}
+        0001-Revert-check-thin-archive-element-file-size.patch
         0002-check-for-unusual-file-harder.patch
         0010-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch
         0110-binutils-mingw-gnu-print.patch
@@ -28,6 +29,7 @@ source=(https://ftp.gnu.org/gnu/binutils/${_realname}-${pkgver}.tar.xz{,.sig}
         specify-timestamp.patch)
 sha256sums=('e316477a914f567eccc34d5d29785b8b0f5a10208d36bbacedcc39048ecfe024'
             'SKIP'
+            '8df34481c39811f31bc5c37a733ae30cafc8a87d8c57d2e5f745193198c687b8'
             '2c99345fc575c3a060d6677537f636c6c4154fac0fde508070f3b6296c1060d4'
             '4e8ac055df61b1b5d6ae29dc87e1154737c2e87c7b244b44866702cabf1a5d18'
             '702635038b245709aa2cf6016c25f6bbf8a53d4cfb5b21f3d5bfe6309b10acb7'
@@ -48,6 +50,13 @@ apply_patch_with_msg() {
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
+
+  # Fixes https://github.com/msys2/MINGW-packages/issues/10860
+  # Already merged upstream as 2d92604cd3, please remove this
+  # patch when upgrading to a later version than 2.38.
+  apply_patch_with_msg \
+    0001-Revert-check-thin-archive-element-file-size.patch \
+
   apply_patch_with_msg \
     0002-check-for-unusual-file-harder.patch \
     0010-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch \


### PR DESCRIPTION
Fixes https://github.com/msys2/MINGW-packages/issues/10860