### PR TITLE
oiio: update to 2.2.20, fix clang

### DIFF
--- a/mingw-w64-openimageio/0021-clang-thread-api.patch
+++ b/mingw-w64-openimageio/0021-clang-thread-api.patch
@@ -1,0 +1,15 @@
+diff -Naur oiio-Release-2.2.20.0.orig/src/include/OpenImageIO/thread.h oiio-Release-2.2.20.0/src/include/OpenImageIO/thread.h
+--- oiio-Release-2.2.20.0.orig/src/include/OpenImageIO/thread.h	2022-02-01 18:17:30.000000000 +0100
++++ oiio-Release-2.2.20.0/src/include/OpenImageIO/thread.h	2022-03-02 08:34:16.434944100 +0100
+@@ -92,9 +92,9 @@
+ inline void
+ yield() noexcept
+ {
+-#if defined(__GNUC__)
++#if defined(__GNUC__) && !defined(__clang__)
+     sched_yield();
+-#elif defined(_MSC_VER)
++#elif defined(_MSC_VER) || defined(__clang__)
+     SwitchToThread();
+ #else
+ #    error No yield on this platform.

--- a/mingw-w64-openimageio/PKGBUILD
+++ b/mingw-w64-openimageio/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=openimageio
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.2.18.0
-pkgrel=3
+pkgver=2.2.20.0
+pkgrel=1
 pkgdesc="A library for reading and writing images, including classes, utilities, and applications (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -50,13 +50,15 @@ source=(${_realname}-${pkgver}.tar.gz::https://github.com/OpenImageIO/oiio/archi
         0008-find-openjpeg.patch
         0012-maybe-uninitialized-errors.patch
         0018-link-hdf5.patch
-        0020-set-import-prefix.patch)
-sha256sums=('b8dd189fbc97f1b172528e324daa904f74a166bad62c32e7166ca6c866734a29'
+        0020-set-import-prefix.patch
+        0021-clang-thread-api.patch)
+sha256sums=('859f393e4533dab3b001d881c41fd4e0a3ea114e159f00d7b2aa25fa98e97f99'
             '9e4e21333676268a91c0f4e7676aeab7658e5f748e7e5cfe43a92f0fd7931229'
             '819668751fbced6dc583eb94c34119131ec13211097fffef2aef11955c4c4770'
             'bc37ea8326f7f5f26068051b537f2491e9554a380e6584bf55aaad111d33eb81'
             '066de45a500ae4eaa5fbdd99bb6ea7904ddc88389ad1d726d629edf5d9527b26'
-            '773e229f01f10a6cd9add1bcf0583f8396ccf752e26c6065f463d78ee93101c9')
+            '773e229f01f10a6cd9add1bcf0583f8396ccf752e26c6065f463d78ee93101c9'
+            '9128ce792d6676ff9944807ded2e717a99eb166b4d702ef9b860c1a21c0e64e0')
 
 prepare() {
   cd ${srcdir}/oiio-Release-${pkgver}
@@ -67,6 +69,7 @@ prepare() {
   # I have no idea if this is the right/best way to fix this.
   # Makes openshadinglanguage happy at finding oiio at least
   patch -p1 -i ${srcdir}/0020-set-import-prefix.patch
+  patch -p1 -i ${srcdir}/0021-clang-thread-api.patch
 }
 
 build() {


### PR DESCRIPTION
Checking out /clang64/include/c++/v1/__config_site, it seems the Win32 API is directly used for libc++ std::thread implementation rather than pthreads like it is the case for libstdc++