### PR TITLE
lensfun: let SSE/SSE2 be detected automatically

### DIFF
--- a/mingw-w64-lensfun/PKGBUILD
+++ b/mingw-w64-lensfun/PKGBUILD
@@ -4,7 +4,7 @@ _realname=lensfun
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.3.3
-pkgrel=1
+pkgrel=2
 pkgdesc="Database of photographic lenses and a library that allows advanced access to the database (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -51,8 +51,6 @@ build() {
       -DBUILD_AUXFUN=ON \
       -DBUILD_LENSTOOL=ON \
       -DBUILD_TESTS=OFF \
-      -DBUILD_FOR_SSE=ON \
-      -DBUILD_FOR_SSE2=ON \
       -DBUILD_DOC=OFF \
       ../${_realname}-${pkgver}
 


### PR DESCRIPTION
Should fix CLANGARM64 build