### PR TITLE
ruby: patch ucrtbase pattern for 32-bit on Win11/Server2022.

### DIFF
--- a/mingw-w64-ruby/0008-ucrt-32-win11-insns.patch
+++ b/mingw-w64-ruby/0008-ucrt-32-win11-insns.patch
@@ -1,0 +1,27 @@
+--- ruby-3.0.3/win32/win32.c.orig	2022-03-02 21:05:21.156322300 -0800
++++ ruby-3.0.3/win32/win32.c	2022-03-02 21:39:06.816904200 -0800
+@@ -2566,15 +2566,21 @@
+ # else /* x86 */
+     /* pop ebp */
+ #  define FUNCTION_BEFORE_RET_MARK "\x5d"
++    /* leave */
++#  define FUNCTION_BEFORE_RET_MARK_2 "\xc9"
+ #  define FUNCTION_SKIP_BYTES 0
+     /* mov eax,dword ptr [eax*4+100EB430h] */
+ #  define PIOINFO_MARK "\x8B\x04\x85"
+ # endif
+     if (p) {
+-        for (pend += 10; pend < p + 300; pend++) {
++        for (pend += 10; pend < p + 500; pend++) {
+             // find end of function
+-            if (memcmp(pend, FUNCTION_BEFORE_RET_MARK, sizeof(FUNCTION_BEFORE_RET_MARK) - 1) == 0 &&
+-                *(pend + (sizeof(FUNCTION_BEFORE_RET_MARK) - 1) + FUNCTION_SKIP_BYTES) & FUNCTION_RET == FUNCTION_RET) {
++            if ((memcmp(pend, FUNCTION_BEFORE_RET_MARK, sizeof(FUNCTION_BEFORE_RET_MARK) - 1) == 0
++# ifdef FUNCTION_BEFORE_RET_MARK_2
++                || memcmp(pend, FUNCTION_BEFORE_RET_MARK_2, sizeof(FUNCTION_BEFORE_RET_MARK_2) - 1) == 0
++# endif
++                ) &&
++                *(pend + (sizeof(FUNCTION_BEFORE_RET_MARK) - 1) + FUNCTION_SKIP_BYTES) == (char)FUNCTION_RET) {
+                 // search backwards from end of function
+                 for (pend -= (sizeof(PIOINFO_MARK) - 1); pend > p; pend--) {
+                     if (memcmp(pend, PIOINFO_MARK, sizeof(PIOINFO_MARK) - 1) == 0) {

--- a/mingw-w64-ruby/PKGBUILD
+++ b/mingw-w64-ruby/PKGBUILD
@@ -10,7 +10,7 @@ _realname=ruby
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.0.3
-pkgrel=1
+pkgrel=2
 pkgdesc="An object-oriented language for quick and easy programming (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -35,7 +35,8 @@ source=("https://cache.ruby-lang.org/pub/ruby/${pkgver%.*}/${_realname}-${pkgver
         0004-rbinstall-destdir.patch
         0005-rbinstall-rake-bash.patch
         0006-autoconf-set-msvcrt-ver-for-ucrt.patch
-        0007-nm-use-full-options.patch)
+        0007-nm-use-full-options.patch
+        0008-ucrt-32-win11-insns.patch)
 ## Populated by the updpkgprovs script
 provides=(
     "${MINGW_PACKAGE_PREFIX}-ruby-minitest=5.14.2"
@@ -133,7 +134,8 @@ sha256sums=('3586861cb2df56970287f0fd83f274bd92058872d830d15570b36def7f1a92ac'
             '02382ec3b9e42d7dbb58edad3e41c361d98871711bb2f0320082c2acc6a82e2e'
             '85e10228375eea2d80c8e6ebb582eeaf625d8216e4d08a4af8136de1aa3f095e'
             '687563af2d02443139984f2aabebc3a0436d683a84ebe208916a4ce327c5d289'
-            'b250c66bc8b372fb4c53902a6d56c01ad057416e3e368a5c5434d9a4ebdc3819')
+            'b250c66bc8b372fb4c53902a6d56c01ad057416e3e368a5c5434d9a4ebdc3819'
+            '29f6389fe5bd1506ec856aa1f1a77ff513e6a33ac0245eec0fdce0765ea2e79c')
 noextract=(${_realname}-${pkgver}.tar.gz)
 
 apply_patch_with_msg() {
@@ -165,7 +167,8 @@ prepare() {
   apply_patch_with_msg \
       0003-fix-check-types.patch \
       0005-rbinstall-rake-bash.patch \
-      0007-nm-use-full-options.patch
+      0007-nm-use-full-options.patch \
+      0008-ucrt-32-win11-insns.patch
     #  patch -p1 -i ${srcdir}/0004-rbinstall-destdir.patch
 
   # Set msvcrt version to 140 which brings hidden ucrt I/O structs


### PR DESCRIPTION
Fixes #10896.  For now.  At least in the case I saw and tested.  This is some messed up code.