### PR TITLE
mingw-w64: use git apply

### DIFF
--- a/mingw-w64-crt-git/PKGBUILD
+++ b/mingw-w64-crt-git/PKGBUILD
@@ -35,8 +35,8 @@ pkgver() {
 prepare() {
   cd ${srcdir}/mingw-w64
 
-  git am --committer-date-is-author-date "${srcdir}/0001-Allow-to-use-bessel-and-complex-functions-without-un.patch"
-  git am --committer-date-is-author-date "${srcdir}/0002-DirectX-9-fixes-for-VLC.patch"
+  git apply "${srcdir}/0001-Allow-to-use-bessel-and-complex-functions-without-un.patch"
+  git apply "${srcdir}/0002-DirectX-9-fixes-for-VLC.patch"
 }
 
 build() {

--- a/mingw-w64-headers-git/PKGBUILD
+++ b/mingw-w64-headers-git/PKGBUILD
@@ -31,8 +31,8 @@ pkgver() {
 prepare() {
   cd ${srcdir}/mingw-w64
 
-  git am --committer-date-is-author-date "${srcdir}/0001-Allow-to-use-bessel-and-complex-functions-without-un.patch"
-  git am --committer-date-is-author-date "${srcdir}/0002-DirectX-9-fixes-for-VLC.patch"
+  git apply "${srcdir}/0001-Allow-to-use-bessel-and-complex-functions-without-un.patch"
+  git apply "${srcdir}/0002-DirectX-9-fixes-for-VLC.patch"
 
   cd ${srcdir}/mingw-w64/mingw-w64-headers
   touch include/windows.*.h include/wincrypt.h include/prsht.h

--- a/mingw-w64-tools-git/PKGBUILD
+++ b/mingw-w64-tools-git/PKGBUILD
@@ -29,7 +29,6 @@ pkgver() {
 
 prepare() {
   cd "${srcdir}/mingw-w64"
-  #git am "${srcdir}/0001-widl-Relocate-DEFAULT_INCLUDE_DIR.patch"
 }
 
 build() {

--- a/mingw-w64-winpthreads-git/PKGBUILD
+++ b/mingw-w64-winpthreads-git/PKGBUILD
@@ -37,7 +37,7 @@ pkgver() {
 prepare() {
   cd "${srcdir}/mingw-w64"
   [[ -f mingw-w64-libraries/winpthreads/src/libgcc/dll_frame_info.c ]] && rm -rf mingw-w64-libraries/winpthreads/src/libgcc/dll_frame_info.c
-  git am --committer-date-is-author-date "${srcdir}"/0001-Define-__-de-register_frame_info-in-fake-libgcc_s.patch
+  git apply "${srcdir}"/0001-Define-__-de-register_frame_info-in-fake-libgcc_s.patch
 
   cd "${srcdir}"/mingw-w64/mingw-w64-libraries/winpthreads
   autoreconf -vfi


### PR DESCRIPTION
instead of git am which requires a committer config

pkgver doesn't depend on HEAD, so this shouldn't change anything