### PR TITLE
gtk3: update to 3.24.32

### DIFF
--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -3,9 +3,9 @@
 _realname=gtk3
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-gtk-update-icon-cache")
-pkgver=3.24.31+94+g7394f6c720
+pkgver=3.24.32
 pkgrel=1
-_commit=7394f6c720219435b4c379c38cbce0e77ec642c6
+_commit=57fb729c0e9f8576430d9c0b19d6ea02ef438108
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -55,7 +55,8 @@ apply_patch_with_msg() {
 
 pkgver() {
   cd "${srcdir}/gtk"
-  git describe --tags | sed 's/-/+/g'
+  # Do not consider the 3.24.32.1 tag
+  git describe --tags --exclude 3.24.32.1 --no-exclude 3.24.32 | sed 's/-/+/g'
 }
 
 prepare() {


### PR DESCRIPTION
Note: had to insert a little hack to avoid the 3.24.32.1 tag getting in the way. ~~Let's see if in the meantime it gets deleted in the upstream repo.~~ See https://gitlab.gnome.org/GNOME/gtk/-/tags

EDIT: Actually 3.24.32.1 is not the same as 3.24.32, so I think this PR is good to go