### PR TITLE
pytest-shutil: depend on python-path

### DIFF
--- a/mingw-w64-python-pytest-shutil/PKGBUILD
+++ b/mingw-w64-python-pytest-shutil/PKGBUILD
@@ -5,7 +5,7 @@ _realname=pytest-shutil
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=1.7.0
-pkgrel=3
+pkgrel=4
 pkgdesc='A goodie-bag of unix shell and environment tools for py.test (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -16,7 +16,7 @@ depends=(
   "${MINGW_PACKAGE_PREFIX}-python-execnet"
   "${MINGW_PACKAGE_PREFIX}-python-contextlib2"
   "${MINGW_PACKAGE_PREFIX}-python-pytest"
-  "${MINGW_PACKAGE_PREFIX}-python-path.py"
+  "${MINGW_PACKAGE_PREFIX}-python-path"
   "${MINGW_PACKAGE_PREFIX}-python-mock"
   "${MINGW_PACKAGE_PREFIX}-python-termcolor"
 )
@@ -30,6 +30,8 @@ sha256sums=('d8165261de76e7508505c341d94c02b113dc963f274543abca74dbfabd021261')
 
 prepare() {  
   cd "$srcdir"
+  sed -i 's/path.py/path/g' "${_pyname//_/-}-$pkgver/setup.py"
+
   rm -rf python-build-${CARCH} | true
   cp -r "${_pyname//_/-}-$pkgver" "python-build-${CARCH}"
   export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}


### PR DESCRIPTION
and not path.py, which is only needed for Python <3.5