### PR TITLE
Update OpenCV to 4.5.5 release - fixes import cv2

### DIFF
--- a/mingw-w64-opencv/0001-opencv-4.5.5-patch-mingw.patch
+++ b/mingw-w64-opencv/0001-opencv-4.5.5-patch-mingw.patch
@@ -1,0 +1,293 @@
+From 36b1168d068a346aacdc1edaf0c860284e97227a Mon Sep 17 00:00:00 2001
+From: Ugur Kurnaz <ugur.kurnaz@free.fr>
+Date: Sat, 5 Mar 2022 20:08:27 +0100
+Subject: [PATCH] opencv-4.5.5-patch-mingw
+
+---
+ CMakeLists.txt                                | 32 ++++++-------------
+ cmake/OpenCVCompilerOptions.cmake             |  1 -
+ cmake/OpenCVDetectPython.cmake                |  2 +-
+ cmake/OpenCVFindLibsGrfmt.cmake               |  4 +--
+ cmake/OpenCVFindOpenEXR.cmake                 |  4 ++-
+ cmake/OpenCVGenPkgconfig.cmake                |  2 +-
+ cmake/OpenCVInstallLayout.cmake               |  2 +-
+ cmake/OpenCVModule.cmake                      |  4 ++-
+ cmake/OpenCVUtils.cmake                       |  4 ++-
+ .../OpenCVConfig.root-WIN32.cmake.in          |  4 +++
+ modules/calib3d/src/polynom_solver.cpp        |  2 +-
+ modules/core/CMakeLists.txt                   |  2 +-
+ modules/core/include/opencv2/core/cvdef.h     |  4 +++
+ modules/imgcodecs/src/grfmt_png.cpp           |  2 +-
+ modules/python/common.cmake                   |  2 +-
+ 15 files changed, 35 insertions(+), 36 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f05adb3..3bf2db8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -195,20 +195,6 @@ if(UNIX AND NOT ANDROID)
+   endif()
+ endif()
+ 
+-# Add these standard paths to the search paths for FIND_PATH
+-# to find include files from these locations first
+-if(MINGW)
+-  if(EXISTS /mingw)
+-      list(APPEND CMAKE_INCLUDE_PATH /mingw)
+-  endif()
+-  if(EXISTS /mingw32)
+-      list(APPEND CMAKE_INCLUDE_PATH /mingw32)
+-  endif()
+-  if(EXISTS /mingw64)
+-      list(APPEND CMAKE_INCLUDE_PATH /mingw64)
+-  endif()
+-endif()
+-
+ # ----------------------------------------------------------------------------
+ # OpenCV cmake options
+ # ----------------------------------------------------------------------------
+@@ -217,14 +203,14 @@ OCV_OPTION(OPENCV_ENABLE_NONFREE "Enable non-free algorithms" OFF)
+ 
+ # 3rd party libs
+ OCV_OPTION(OPENCV_FORCE_3RDPARTY_BUILD   "Force using 3rdparty code from source" OFF)
+-OCV_OPTION(BUILD_ZLIB               "Build zlib from source"             (WIN32 OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
+-OCV_OPTION(BUILD_TIFF               "Build libtiff from source"          (WIN32 OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
+-OCV_OPTION(BUILD_OPENJPEG           "Build OpenJPEG from source"         (WIN32 OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
+-OCV_OPTION(BUILD_JASPER             "Build libjasper from source"        (WIN32 OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
+-OCV_OPTION(BUILD_JPEG               "Build libjpeg from source"          (WIN32 OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
+-OCV_OPTION(BUILD_PNG                "Build libpng from source"           (WIN32 OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
+-OCV_OPTION(BUILD_OPENEXR            "Build openexr from source"          (OPENCV_FORCE_3RDPARTY_BUILD) )
+-OCV_OPTION(BUILD_WEBP               "Build WebP from source"             (((WIN32 OR ANDROID OR APPLE) AND NOT WINRT) OR OPENCV_FORCE_3RDPARTY_BUILD) )
++OCV_OPTION(BUILD_ZLIB               "Build zlib from source"             (MSVC OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
++OCV_OPTION(BUILD_TIFF               "Build libtiff from source"          (MSVC OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
++OCV_OPTION(BUILD_OPENJPEG           "Build OpenJPEG from source"         (MSVC OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
++OCV_OPTION(BUILD_JASPER             "Build libjasper from source"        (MSVC OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
++OCV_OPTION(BUILD_JPEG               "Build libjpeg from source"          (MSVC OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
++OCV_OPTION(BUILD_PNG                "Build libpng from source"           (MSVC OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
++OCV_OPTION(BUILD_OPENEXR            "Build openexr from source"          (((WIN32 OR ANDROID OR APPLE) AND NOT WINRT AND NOT MINGW) OR OPENCV_FORCE_3RDPARTY_BUILD) )
++OCV_OPTION(BUILD_WEBP               "Build WebP from source"             (((WIN32 OR ANDROID OR APPLE) AND NOT WINRT AND NOT MINGW) OR OPENCV_FORCE_3RDPARTY_BUILD) )
+ OCV_OPTION(BUILD_TBB                "Download and build TBB from source" (ANDROID OR OPENCV_FORCE_3RDPARTY_BUILD) )
+ OCV_OPTION(BUILD_IPP_IW             "Build IPP IW from source"           (NOT MINGW OR OPENCV_FORCE_3RDPARTY_BUILD) IF (X86_64 OR X86) AND NOT WINRT )
+ OCV_OPTION(BUILD_ITT                "Build Intel ITT from source"
+@@ -1006,7 +992,7 @@ if(NOT OPENCV_LICENSE_FILE)
+ endif()
+ 
+ # for UNIX it does not make sense as LICENSE and readme will be part of the package automatically
+-if(ANDROID OR NOT UNIX)
++if((ANDROID OR NOT UNIX) AND NOT MINGW)
+   install(FILES ${OPENCV_LICENSE_FILE}
+         PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+         DESTINATION ./ COMPONENT libs)
+diff --git a/cmake/OpenCVCompilerOptions.cmake b/cmake/OpenCVCompilerOptions.cmake
+index 037c7fb..ea6498e 100644
+--- a/cmake/OpenCVCompilerOptions.cmake
++++ b/cmake/OpenCVCompilerOptions.cmake
+@@ -120,7 +120,6 @@ if(CV_GCC OR CV_CLANG)
+     add_extra_compiler_option(-Wall)
+   endif()
+   add_extra_compiler_option(-Werror=return-type)
+-  add_extra_compiler_option(-Werror=non-virtual-dtor)
+   add_extra_compiler_option(-Werror=address)
+   add_extra_compiler_option(-Werror=sequence-point)
+   add_extra_compiler_option(-Wformat)
+diff --git a/cmake/OpenCVDetectPython.cmake b/cmake/OpenCVDetectPython.cmake
+index 6e7bb18..61cf494 100644
+--- a/cmake/OpenCVDetectPython.cmake
++++ b/cmake/OpenCVDetectPython.cmake
+@@ -176,7 +176,7 @@ if(NOT ${found})
+     endif()
+ 
+     if(NOT ANDROID AND NOT IOS)
+-      if(CMAKE_HOST_UNIX)
++      if(CMAKE_HOST_UNIX OR MINGW)
+         execute_process(COMMAND ${_executable} -c "from sysconfig import *; print(get_path('purelib'))"
+                         RESULT_VARIABLE _cvpy_process
+                         OUTPUT_VARIABLE _std_packages_path
+diff --git a/cmake/OpenCVFindLibsGrfmt.cmake b/cmake/OpenCVFindLibsGrfmt.cmake
+index 95d1d92..a0e2e55 100644
+--- a/cmake/OpenCVFindLibsGrfmt.cmake
++++ b/cmake/OpenCVFindLibsGrfmt.cmake
+@@ -228,9 +228,9 @@ if(WITH_PNG)
+     include(FindPNG)
+     if(PNG_FOUND)
+       include(CheckIncludeFile)
+-      check_include_file("${PNG_PNG_INCLUDE_DIR}/libpng/png.h" HAVE_LIBPNG_PNG_H)
++      check_include_file("${PNG_PNG_INCLUDE_DIR}/libpng16/png.h" HAVE_LIBPNG_PNG_H)
+       if(HAVE_LIBPNG_PNG_H)
+-        ocv_parse_header("${PNG_PNG_INCLUDE_DIR}/libpng/png.h" PNG_VERSION_LINES PNG_LIBPNG_VER_MAJOR PNG_LIBPNG_VER_MINOR PNG_LIBPNG_VER_RELEASE)
++        ocv_parse_header("${PNG_PNG_INCLUDE_DIR}/libpng16/png.h" PNG_VERSION_LINES PNG_LIBPNG_VER_MAJOR PNG_LIBPNG_VER_MINOR PNG_LIBPNG_VER_RELEASE)
+       else()
+         ocv_parse_header("${PNG_PNG_INCLUDE_DIR}/png.h" PNG_VERSION_LINES PNG_LIBPNG_VER_MAJOR PNG_LIBPNG_VER_MINOR PNG_LIBPNG_VER_RELEASE)
+       endif()
+diff --git a/cmake/OpenCVFindOpenEXR.cmake b/cmake/OpenCVFindOpenEXR.cmake
+index 0df626a..5e498eb 100644
+--- a/cmake/OpenCVFindOpenEXR.cmake
++++ b/cmake/OpenCVFindOpenEXR.cmake
+@@ -29,7 +29,9 @@ SET(OPENEXR_LIBRARIES "")
+ SET(OPENEXR_LIBSEARCH_SUFFIXES "")
+ file(TO_CMAKE_PATH "$ENV{ProgramFiles}" ProgramFiles_ENV_PATH)
+ 
+-if(WIN32)
++if(MINGW)
++    SET(OPENEXR_ROOT $ENV{OpenEXR_HOME} CACHE STRING "Path to the OpenEXR install folder")
++elseif(MSVC)
+     SET(OPENEXR_ROOT "C:/Deploy" CACHE STRING "Path to the OpenEXR \"Deploy\" folder")
+     if(X86_64)
+         SET(OPENEXR_LIBSEARCH_SUFFIXES x64/Release x64 x64/Debug)
+diff --git a/cmake/OpenCVGenPkgconfig.cmake b/cmake/OpenCVGenPkgconfig.cmake
+index 43d6a87..8d36b74 100644
+--- a/cmake/OpenCVGenPkgconfig.cmake
++++ b/cmake/OpenCVGenPkgconfig.cmake
+@@ -103,7 +103,7 @@ add_custom_target(gen-pkgconfig ALL SOURCES "${CMAKE_BINARY_DIR}/unix-install/${
+ add_dependencies(developer_scripts gen-pkgconfig)
+ 
+ 
+-if(UNIX AND NOT ANDROID)
++if((UNIX AND NOT ANDROID) OR MINGW)
+   install(FILES ${CMAKE_BINARY_DIR}/unix-install/${OPENCV_PC_FILE_NAME} DESTINATION ${OPENCV_LIB_INSTALL_PATH}/pkgconfig COMPONENT dev)
+ endif()
+ 
+diff --git a/cmake/OpenCVInstallLayout.cmake b/cmake/OpenCVInstallLayout.cmake
+index d5f3579..4722de0 100644
+--- a/cmake/OpenCVInstallLayout.cmake
++++ b/cmake/OpenCVInstallLayout.cmake
+@@ -20,7 +20,7 @@ if(ANDROID)
+   ocv_update(OPENCV_JNI_INSTALL_PATH            "${OPENCV_LIB_INSTALL_PATH}")
+   ocv_update(OPENCV_JNI_BIN_INSTALL_PATH        "${OPENCV_JNI_INSTALL_PATH}")
+ 
+-elseif(WIN32 AND CMAKE_HOST_SYSTEM_NAME MATCHES Windows)
++elseif(MSVC AND CMAKE_HOST_SYSTEM_NAME MATCHES Windows)
+ 
+   if(DEFINED OpenCV_RUNTIME AND DEFINED OpenCV_ARCH)
+     ocv_update(OPENCV_INSTALL_BINARIES_PREFIX "${OpenCV_ARCH}/${OpenCV_RUNTIME}/")
+diff --git a/cmake/OpenCVModule.cmake b/cmake/OpenCVModule.cmake
+index 9981620..92a0076 100644
+--- a/cmake/OpenCVModule.cmake
++++ b/cmake/OpenCVModule.cmake
+@@ -996,7 +996,9 @@ macro(_ocv_create_module)
+   endif()
+ 
+   set_target_properties(${the_module} PROPERTIES
+-    OUTPUT_NAME "${the_module}${OPENCV_DLLVERSION}"
++    OUTPUT_NAME "${the_module}"
++    RUNTIME_OUTPUT_NAME "${the_module}${OPENCV_DLLVERSION}"
++    ARCHIVE_OUTPUT_NAME "${the_module}"
+     DEBUG_POSTFIX "${OPENCV_DEBUG_POSTFIX}"
+     COMPILE_PDB_NAME "${the_module}${OPENCV_DLLVERSION}"
+     COMPILE_PDB_NAME_DEBUG "${the_module}${OPENCV_DLLVERSION}${OPENCV_DEBUG_POSTFIX}"
+diff --git a/cmake/OpenCVUtils.cmake b/cmake/OpenCVUtils.cmake
+index d7097fd..3df0d3f 100644
+--- a/cmake/OpenCVUtils.cmake
++++ b/cmake/OpenCVUtils.cmake
+@@ -1635,9 +1635,11 @@ endfunction()
+ macro(ocv_get_libname var_name)
+   get_filename_component(__libname "${ARGN}" NAME)
+   # libopencv_core.so.3.3 -> opencv_core
+-  string(REGEX REPLACE "^lib(.+)\\.(a|so|dll)(\\.[.0-9]+)?$" "\\1" __libname "${__libname}")
++  string(REGEX REPLACE "^lib(.+)\\.(a|so)(\\.[.0-9]+)?$" "\\1" __libname "${__libname}")
+   # MacOSX: libopencv_core.3.3.1.dylib -> opencv_core
+   string(REGEX REPLACE "^lib(.+[^.0-9])\\.([.0-9]+\\.)?dylib$" "\\1" __libname "${__libname}")
++  # Windows/MINGW: libopencv_core331.dll -> opencv_core
++  string(REGEX REPLACE "^lib(.+[^.0-9])([0-9]+\\.)?dll$" "\\1" __libname "${__libname}")
+   set(${var_name} "${__libname}")
+ endmacro()
+ 
+diff --git a/cmake/templates/OpenCVConfig.root-WIN32.cmake.in b/cmake/templates/OpenCVConfig.root-WIN32.cmake.in
+index b0f254e..67d427a 100644
+--- a/cmake/templates/OpenCVConfig.root-WIN32.cmake.in
++++ b/cmake/templates/OpenCVConfig.root-WIN32.cmake.in
+@@ -63,6 +63,7 @@ function(check_one_config RES)
+     return()
+   endif()
+   set(candidates)
++  if(MSVC)
+   if(OpenCV_STATIC)
+     list(APPEND candidates "${OpenCV_ARCH}/${OpenCV_RUNTIME}/staticlib")
+   endif()
+@@ -73,6 +74,9 @@ function(check_one_config RES)
+     list(APPEND candidates "gpu/${OpenCV_ARCH}/${OpenCV_RUNTIME}/staticlib")
+   endif()
+   list(APPEND candidates "${OpenCV_ARCH}/${OpenCV_RUNTIME}/lib")
++  else()
++  list(APPEND candidates "lib")
++  endif()
+   foreach(c ${candidates})
+     set(p "${OpenCV_CONFIG_PATH}/${c}")
+     if(EXISTS "${p}/OpenCVConfig.cmake")
+diff --git a/modules/calib3d/src/polynom_solver.cpp b/modules/calib3d/src/polynom_solver.cpp
+index 5025199..d8779a7 100644
+--- a/modules/calib3d/src/polynom_solver.cpp
++++ b/modules/calib3d/src/polynom_solver.cpp
+@@ -59,7 +59,7 @@ int solve_deg3(double a, double b, double c, double d,
+   double D = Q3 + R * R;
+   double b_a_3 = (1. / 3.) * b_a;
+ 
+-  if (Q == 0) {
++  if (Q3 == 0) {
+     if(R == 0) {
+       x0 = x1 = x2 = - b_a_3;
+       return 3;
+diff --git a/modules/core/CMakeLists.txt b/modules/core/CMakeLists.txt
+index b78bb98..654fceb 100644
+--- a/modules/core/CMakeLists.txt
++++ b/modules/core/CMakeLists.txt
+@@ -128,7 +128,7 @@ elseif(HAVE_CXX11 OR DEFINED OPENCV_ALLOCATOR_STATS_COUNTER_TYPE)
+   endif()
+   if(DEFINED OPENCV_ALLOCATOR_STATS_COUNTER_TYPE)
+     message(STATUS "Allocator metrics storage type: '${OPENCV_ALLOCATOR_STATS_COUNTER_TYPE}'")
+-    add_definitions("-DOPENCV_ALLOCATOR_STATS_COUNTER_TYPE=${OPENCV_ALLOCATOR_STATS_COUNTER_TYPE}")
++    # add_definitions("-DOPENCV_ALLOCATOR_STATS_COUNTER_TYPE=\"${OPENCV_ALLOCATOR_STATS_COUNTER_TYPE}\"")
+   endif()
+ endif()
+ 
+diff --git a/modules/core/include/opencv2/core/cvdef.h b/modules/core/include/opencv2/core/cvdef.h
+index f785f32..b557f08 100644
+--- a/modules/core/include/opencv2/core/cvdef.h
++++ b/modules/core/include/opencv2/core/cvdef.h
+@@ -805,6 +805,7 @@ __CV_ENUM_FLAGS_BITWISE_XOR_EQ   (EnumType, EnumType)
+ #endif
+ 
+ // Integer types portatibility
++#if defined __cplusplus
+ #ifdef OPENCV_STDINT_HEADER
+ #include OPENCV_STDINT_HEADER
+ #elif defined(__cplusplus)
+@@ -847,6 +848,9 @@ typedef ::uint64_t uint64_t;
+ #else // pure C
+ #include <stdint.h>
+ #endif
++#else
++#include <stdint.h>
++#endif
+ 
+ #ifdef __cplusplus
+ namespace cv
+diff --git a/modules/imgcodecs/src/grfmt_png.cpp b/modules/imgcodecs/src/grfmt_png.cpp
+index 9e1a2d4..bfb23d1 100644
+--- a/modules/imgcodecs/src/grfmt_png.cpp
++++ b/modules/imgcodecs/src/grfmt_png.cpp
+@@ -59,7 +59,7 @@
+ #endif
+ 
+ #ifdef HAVE_LIBPNG_PNG_H
+-#include <libpng/png.h>
++#include <libpng16/png.h>
+ #else
+ #include <png.h>
+ #endif
+diff --git a/modules/python/common.cmake b/modules/python/common.cmake
+index c5df8bc..99a85e3 100644
+--- a/modules/python/common.cmake
++++ b/modules/python/common.cmake
+@@ -138,7 +138,7 @@ else()
+   set(PYTHON_INSTALL_CONFIGURATIONS "")
+ endif()
+ 
+-if(WIN32)
++if(MSVC)
+   set(PYTHON_INSTALL_ARCHIVE "")
+ else()
+   set(PYTHON_INSTALL_ARCHIVE ARCHIVE DESTINATION ${${PYTHON}_PACKAGES_PATH} COMPONENT python)
+-- 
+2.35.1
+

--- a/mingw-w64-opencv/0101-opencv_contrib-4.5.5-patch-mingw.patch
+++ b/mingw-w64-opencv/0101-opencv_contrib-4.5.5-patch-mingw.patch
@@ -1,0 +1,100 @@
+From 69f73e2ab9e8d787b46ff9fa43792650067044e9 Mon Sep 17 00:00:00 2001
+From: Ugur Kurnaz <ugur.kurnaz@free.fr>
+Date: Sat, 5 Mar 2022 20:15:53 +0100
+Subject: [PATCH] opencv_contrib-4.5.5-patch-mingw
+
+---
+ modules/rgbd/src/dynafu.cpp                            |  1 +
+ .../libmv_light/libmv/correspondence/CMakeLists.txt    |  2 +-
+ .../libmv_light/libmv/multiview/robust_estimation.h    |  4 ++--
+ modules/sfm/src/libmv_light/libmv/numeric/numeric.h    |  4 ++--
+ modules/wechat_qrcode/CMakeLists.txt                   | 10 ++++++++++
+ 5 files changed, 16 insertions(+), 5 deletions(-)
+
+diff --git a/modules/rgbd/src/dynafu.cpp b/modules/rgbd/src/dynafu.cpp
+index 002be7b..45e55ff 100644
+--- a/modules/rgbd/src/dynafu.cpp
++++ b/modules/rgbd/src/dynafu.cpp
+@@ -24,6 +24,7 @@
+ # include <windows.h>
+ #endif
+ # include <GL/gl.h>
++# include <GL/glext.h>
+ #endif
+ 
+ // GL Extention definitions missing from standard Win32 gl.h
+diff --git a/modules/sfm/src/libmv_light/libmv/correspondence/CMakeLists.txt b/modules/sfm/src/libmv_light/libmv/correspondence/CMakeLists.txt
+index 95dbebe..c571386 100644
+--- a/modules/sfm/src/libmv_light/libmv/correspondence/CMakeLists.txt
++++ b/modules/sfm/src/libmv_light/libmv/correspondence/CMakeLists.txt
+@@ -12,6 +12,6 @@ TARGET_LINK_LIBRARIES(correspondence LINK_PRIVATE ${GLOG_LIBRARIES} multiview)
+ IF(TARGET Eigen3::Eigen)
+   TARGET_LINK_LIBRARIES(correspondence LINK_PUBLIC Eigen3::Eigen)
+ ENDIF()
+-
++TARGET_LINK_LIBRARIES(correspondence LINK_PRIVATE opencv_imgcodecs)
+ 
+ LIBMV_INSTALL_LIB(correspondence)
+diff --git a/modules/sfm/src/libmv_light/libmv/multiview/robust_estimation.h b/modules/sfm/src/libmv_light/libmv/multiview/robust_estimation.h
+index a677c5d..7b20eef 100644
+--- a/modules/sfm/src/libmv_light/libmv/multiview/robust_estimation.h
++++ b/modules/sfm/src/libmv_light/libmv/multiview/robust_estimation.h
+@@ -54,10 +54,10 @@ class MLEScorer {
+   double threshold_;
+ };
+ 
+-static uint IterationsRequired(int min_samples,
++static unsigned int IterationsRequired(int min_samples,
+                         double outliers_probability,
+                         double inlier_ratio) {
+-  return static_cast<uint>(
++  return static_cast<unsigned int>(
+       log(outliers_probability) / log(1.0 - pow(inlier_ratio, min_samples)));
+ }
+ 
+diff --git a/modules/sfm/src/libmv_light/libmv/numeric/numeric.h b/modules/sfm/src/libmv_light/libmv/numeric/numeric.h
+index dde7e81..9e7927e 100644
+--- a/modules/sfm/src/libmv_light/libmv/numeric/numeric.h
++++ b/modules/sfm/src/libmv_light/libmv/numeric/numeric.h
+@@ -33,7 +33,7 @@
+ #include <Eigen/QR>
+ #include <Eigen/SVD>
+ 
+-#if !defined(__MINGW64__)
++#if !defined(__MINGW32__)
+ #  if defined(_WIN32) || defined(__APPLE__) || \
+       defined(__FreeBSD__) || defined(__NetBSD__)
+ static void sincos(double x, double *sinx, double *cosx) {
+@@ -41,7 +41,7 @@ static void sincos(double x, double *sinx, double *cosx) {
+   *cosx = cos(x);
+ }
+ #  endif
+-#endif  // !__MINGW64__
++#endif  // !__MINGW32__
+ 
+ #if (defined(_WIN32)) && !defined(__MINGW32__)
+ inline long lround(double d) {
+diff --git a/modules/wechat_qrcode/CMakeLists.txt b/modules/wechat_qrcode/CMakeLists.txt
+index d38d9cc..d7f49e0 100644
+--- a/modules/wechat_qrcode/CMakeLists.txt
++++ b/modules/wechat_qrcode/CMakeLists.txt
+@@ -11,6 +11,16 @@ if(CMAKE_VERSION VERSION_GREATER "3.11")
+   endif()
+ endif()
+ 
++# iconv support isn't automatic on some systems
++if(CMAKE_VERSION VERSION_GREATER 3.11)
++  find_package(Iconv QUIET)
++  if(Iconv_FOUND)
++    ocv_target_link_libraries(${the_module} Iconv::Iconv)
++  else()
++    ocv_target_compile_definitions(${the_module} PRIVATE "NO_ICONV=1")
++  endif()
++endif()
++
+ # need to change
+ set(wechat_qrcode_commit_hash "a8b69ccc738421293254aec5ddb38bd523503252")
+ set(hash_detect_caffemodel "238e2b2d6f3c18d6c3a30de0c31e23cf")
+-- 
+2.35.1
+

--- a/mingw-w64-opencv/PKGBUILD
+++ b/mingw-w64-opencv/PKGBUILD
@@ -57,7 +57,7 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-ceres-solver: SFM module"
             "${MINGW_PACKAGE_PREFIX}-ogre3d: ovis module"
             "${MINGW_PACKAGE_PREFIX}-vtk: opencv_viz module"
             )
-source=("${_realname}-${pkgver}.tar.gz"::sgz
+source=("${_realname}-${pkgver}.tar.gz"::https://github.com/opencv/opencv/archive/${pkgver}.tar.gz
         "${_realname}_contrib-${pkgver}.tar.gz"::https://github.com/opencv/opencv_contrib/archive/${pkgver}.tar.gz
         '0001-opencv-4.5.5-patch-mingw.patch'
         '0101-opencv_contrib-4.5.5-patch-mingw.patch'

--- a/mingw-w64-opencv/PKGBUILD
+++ b/mingw-w64-opencv/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=opencv
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.5.2
-pkgrel=4
+pkgver=4.5.5
+pkgrel=3
 pkgdesc="Open Source Computer Vision Library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -43,52 +43,30 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-python-flake8"
              "${MINGW_PACKAGE_PREFIX}-python-pylint"
              "${MINGW_PACKAGE_PREFIX}-tiny-dnn"
-             #"${MINGW_PACKAGE_PREFIX}-vtk"
+             "${MINGW_PACKAGE_PREFIX}-vtk"
              "${MINGW_PACKAGE_PREFIX}-cereal"
              "${MINGW_PACKAGE_PREFIX}-cc"
             )
-optdepends=(#"${MINGW_PACKAGE_PREFIX}-ceres-solver: SFM module"
-            #"${MINGW_PACKAGE_PREFIX}-gflags: SFM module"
-            #"${MINGW_PACKAGE_PREFIX}-glog: SFM module"
+optdepends=("${MINGW_PACKAGE_PREFIX}-ceres-solver: SFM module"
+            "${MINGW_PACKAGE_PREFIX}-gflags: SFM module"
+            "${MINGW_PACKAGE_PREFIX}-glog: SFM module"
             "${MINGW_PACKAGE_PREFIX}-ffmpeg: support to read and write video files"
             "${MINGW_PACKAGE_PREFIX}-python-numpy: Python 3.x interface"
-            #"${MINGW_PACKAGE_PREFIX}-hdf5: opencv_hdf module"
-            #"${MINGW_PACKAGE_PREFIX}-tesseract-ocr: opencv_text module"
-            #"${MINGW_PACKAGE_PREFIX}-ogre3d: ovis module"
-            #"${MINGW_PACKAGE_PREFIX}-vtk: opencv_viz module"
+            "${MINGW_PACKAGE_PREFIX}-hdf5: opencv_hdf module"
+            "${MINGW_PACKAGE_PREFIX}-tesseract-ocr: opencv_text module"
+            "${MINGW_PACKAGE_PREFIX}-ogre3d: ovis module"
+            "${MINGW_PACKAGE_PREFIX}-vtk: opencv_viz module"
             )
-source=("${_realname}-${pkgver}.tar.gz"::https://github.com/opencv/opencv/archive/${pkgver}.tar.gz
+source=("${_realname}-${pkgver}.tar.gz"::sgz
         "${_realname}_contrib-${pkgver}.tar.gz"::https://github.com/opencv/opencv_contrib/archive/${pkgver}.tar.gz
-        '0001-mingw-w64-cmake.patch'
-        '0002-solve_deg3-underflow.patch'
-        '0003-issue-4107.patch'
-        '0004-generate-proper-pkg-config-file.patch'
-        '0008-mingw-w64-cmake-lib-path.patch'
-        '0010-find-libpng-header.patch'
-        '0012-make-header-usable-with-C-compiler.patch'
-        '0014-python-install-path.patch'
-        '0015-windres-cant-handle-spaces-in-defines.patch'
-        '0101-somehow-uint-not-detected.patch'
-        '0102-mingw-w64-have-sincos.patch'
-        '0103-sfm-module-linking.patch'
-        '0104-rgbd-module-missing-include.patch'
-        '0105-wechat-iconv-dependency.patch')
-sha256sums=('ae258ed50aa039279c3d36afdea5c6ecf762515836b27871a8957c610d0424f8'
-            '9f52fd3114ac464cb4c9a2a6a485c729a223afb57b9c24848484e55cef0b5c2a'
-            'e50a477ca9fb613400ba276099bb3be6af8f1bfb277ea86459f0d635c24d218f'
-            '400f17bde074677566660b1baab52842c1a3d7024129a2d75af6015f6b55ba4f'
-            '480e45906b54c5b6079f437de50ebf2152a83860327613048b53d038526b8ad2'
-            'fcb3a4a469b09475dc2dad0c49bcaade8b80aa155eeaf0645398a77cd8c940cc'
-            '7398e66f80be37382bd427b5eb3a1201a23113c14e71435a44df8779ea1b8a34'
-            'd6ad5a0865eefe662ca4c7aceb6aa7b1fd5fcd27e1e65ca839d442f054095e69'
-            '9f918a974e9d5227fce3702b1f38716a7fb79586dda9256b5df44dcc0f858c3b'
-            '0c310a580d6700601d4b4f824b849c0f0d64d3953e249f04c6a91f15aa8bee0a'
-            '11522ffedb22980ba8d09ff715a25327fe14806e55588bffa761e39e1d035ea5'
-            '7d2ff25f97c84b59793502786dd64e25c8ca991b0523ffea56b45ce031e80c3f'
-            '2001804c5245af1894a308d6521f9cd044fb6dbd713b6e2e45106399a409c14d'
-            '0422317096007b72ab4928b48762da4252addf3e4f8066ba94e29344f5975ab8'
-            'c6c92cf39dfe45b8fb41d80ac0de3cd304e8b695420b307fd4320a105d8fe9f4'
-            '3cf6a17b234ddf4f20e042acce329823e970aa06873d63652fa132c46ee56739')
+        '0001-opencv-4.5.5-patch-mingw.patch'
+        '0101-opencv_contrib-4.5.5-patch-mingw.patch'
+		)
+sha256sums=('a1cfdcf6619387ca9e232687504da996aaa9f7b5689986b8331ec02cb61d28ad'
+			'a97c2eaecf7a23c6dbd119a609c6d7fae903e5f9ff5f1fe678933e01c67a6c11'
+			'9564bfd40fb92522c557c0322ac212eda8219b009835f322f2dad7bfd95cb918'
+			'c1552113d76bd2df6aa69bfede6400ff8182931510588c82501f731e4608e4ee'
+			)
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -111,32 +89,20 @@ del_file_exists() {
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
-  apply_patch_with_msg \
-        0001-mingw-w64-cmake.patch \
-        0002-solve_deg3-underflow.patch \
-        0003-issue-4107.patch \
-        0004-generate-proper-pkg-config-file.patch \
-        0008-mingw-w64-cmake-lib-path.patch \
-        0010-find-libpng-header.patch \
-        0012-make-header-usable-with-C-compiler.patch \
-        0014-python-install-path.patch \
-        0015-windres-cant-handle-spaces-in-defines.patch
+  apply_patch_with_msg 0001-opencv-4.5.5-patch-mingw.patch
 
   cd "${srcdir}/${_realname}_contrib-${pkgver}"
-  apply_patch_with_msg \
-        0101-somehow-uint-not-detected.patch \
-        0102-mingw-w64-have-sincos.patch \
-        0103-sfm-module-linking.patch \
-        0104-rgbd-module-missing-include.patch \
-        0105-wechat-iconv-dependency.patch
+  apply_patch_with_msg 0101-opencv_contrib-4.5.5-patch-mingw.patch
 }
 
 build() {
   [[ -d ${srcdir}/build-${CARCH} ]] && rm -rf ${srcdir}/build-${CARCH}
   mkdir -p ${srcdir}/build-${CARCH} && cd ${srcdir}/build-${CARCH}
 
-  CFLAGS+=" -D_POSIX_SOURCE -Wno-attributes"
-  CXXFLAGS+=" -D_POSIX_SOURCE -Wno-attributes"
+#  CFLAGS+=" -D_POSIX_SOURCE -Wno-attributes"
+#  CXXFLAGS+=" -D_POSIX_SOURCE -Wno-attributes"
+  CFLAGS+=" -D_POSIX_SOURCE -w"
+  CXXFLAGS+=" -D_POSIX_SOURCE -w"
 
   export OpenEXR_HOME=${MINGW_PREFIX}
   export OpenBLAS_HOME=${MINGW_PREFIX}


### PR DESCRIPTION
updated opencv to release 4.5.5.
patches for mingw have just been adapted to new version of opencv, without further analysis if adaptation (WIN32=>MINGW) is needed elsewhere.
some patches seems to be included in new release of 4.5.5 (applied without verbosing anything nor complaining of failure).

this update has fixed 'import cv2' in python scripts not working with previous version (4.5.2). I didn't use much opencv and opencv_python functionalities, so only basic tests have been done in both C++ and python.