### PR TITLE
CI: source PKGBUILD from a subshell

### DIFF
--- a/.ci/ci-build.sh
+++ b/.ci/ci-build.sh
@@ -25,8 +25,12 @@ message 'Processing changes'
 declare -a skipped_packages=()
 for package in "${packages[@]}"; do
     cd "${package}"
-    mingw_arch=("mingw32" "mingw64" "ucrt64" "clang64")
-    . PKGBUILD
+    readarray -d $'\0' -t mingw_arch < <(\
+        set +eo pipefail
+        mingw_arch=("mingw32" "mingw64" "ucrt64" "clang64")
+        . PKGBUILD
+        [[ "${#mingw_arch[@]}" -gt 0 ]] && printf "%s\0" "${mingw_arch[@]}"
+    )
     if [[ ! " ${mingw_arch[*]} " =~ " ${MSYSTEM,,} " ]]; then
         skipped_packages+=("${package}")
     fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
           { msystem: UCRT64, runner: windows-2022 },
           { msystem: CLANG64, runner: windows-2022 },
           { msystem: CLANG32, runner: windows-2022 },
-          # { msystem: CLANGARM64, can-fail: true, runner: ['Windows', 'ARM64'] }
+          # { msystem: CLANGARM64, runner: ['Windows', 'ARM64'] }
         ]
     name: ${{ matrix.msystem }}
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
This should be safer if there's something in the PKGBUILD that evaluates false.

Also, remove can-fail parameter from commented-out CLANGARM64 matrix entry, now that it is unused.

Ref: https://github.com/msys2/MINGW-packages/pull/10910#discussion_r820151645