### PR TITLE
smpeg: move gtk2 to `optdepends`

### DIFF
--- a/mingw-w64-smpeg/PKGBUILD
+++ b/mingw-w64-smpeg/PKGBUILD
@@ -4,7 +4,7 @@ _realname=smpeg
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.4.5
-pkgrel=4
+pkgrel=5
 pkgdesc="SDL MPEG Player Library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -12,11 +12,11 @@ url="https://icculus.org/smpeg/"
 license=("LGPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-gtk2"
              "subversion")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
-         "${MINGW_PACKAGE_PREFIX}-glib2"
-         "${MINGW_PACKAGE_PREFIX}-gtk2"
          "${MINGW_PACKAGE_PREFIX}-SDL")
+optdepends=("${MINGW_PACKAGE_PREFIX}-gtk2: for gtv")
 options=('staticlibs' 'strip')
 source=("${_realname}::svn://svn.icculus.org/smpeg/tags/release_${pkgver//./_}"
         no-undefined.patch


### PR DESCRIPTION
Fixes #10931 