### PR TITLE
pango: update to 1.50.5

### DIFF
--- a/mingw-w64-pango/PKGBUILD
+++ b/mingw-w64-pango/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=pango
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.50.4
+pkgver=1.50.5
 pkgrel=1
 pkgdesc="A library for layout and rendering of text (mingw-w64)"
 arch=('any')
@@ -27,7 +27,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libthai")
 options=('staticlibs' 'strip' 'emptydirs')
 source=("https://download.gnome.org/sources/pango/${pkgver:0:4}/${_realname}-${pkgver}.tar.xz")
-sha256sums=('f4ad63e87dc2b145300542a4fb004d07a9f91b34152fae0ddbe50ecdd851c162')
+sha256sums=('6d136872da6207fe88c5cd2c95c36bcaf4ed29402b854663a86cd7efe99b0cf5')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"


### PR DESCRIPTION
Hi! I have a question for the msys2 maintainers. Consider the output of Meson at the configure stage:

```
$ MINGW_ARCH=mingw64 makepkg-mingw
==>  MINGW_ARCH: mingw64
  -> Building mingw64...
==> Making package: mingw-w64-pango 1.50.5-1 (Mon Mar  7 14:25:45 2022)
==> Checking runtime dependencies...
==> Checking buildtime dependencies...
==> Retrieving sources...
  -> Downloading pango-1.50.5.tar.xz...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 4191k  100 4191k    0     0   517k      0  0:00:08  0:00:08 --:--:--  390k
==> Validating source files with sha256sums...
    pango-1.50.5.tar.xz ... Passed
==> Extracting sources...
  -> Extracting pango-1.50.5.tar.xz with bsdtar
==> Starting prepare()...
==> Starting build()...
The Meson build system
Version: 0.61.2
Source dir: D:/MINGW-packages/mingw-w64-pango/src/pango-1.50.5
Build dir: D:/MINGW-packages/mingw-w64-pango/src/build-x86_64-w64-mingw32
Build type: native build
Project name: pango
Project version: 1.50.5
C compiler for the host machine: gcc (gcc 11.2.0 "gcc (Rev10, Built by MSYS2 project) 11.2.0")
C linker for the host machine: gcc ld.bfd 2.38
C++ compiler for the host machine: g++ (gcc 11.2.0 "g++ (Rev10, Built by MSYS2 project) 11.2.0")
C++ linker for the host machine: g++ ld.bfd 2.38
Host machine cpu family: x86_64
Host machine cpu: x86_64
Compiler for C supports arguments -Wno-c++11-extensions: NO
Compiler for C supports arguments -Wno-missing-include-dirs: YES
Compiler for C supports arguments -Wno-typedef-redefinition: NO
Compiler for C supports arguments -Wduplicated-branches: YES
Compiler for C supports arguments -Wduplicated-cond: YES
Compiler for C supports arguments -Wformat=2: YES
Compiler for C supports arguments -Wformat-nonliteral: YES
Compiler for C supports arguments -Wformat-security: YES
Compiler for C supports arguments -Wignored-qualifiers: YES
Compiler for C supports arguments -Wimplicit-function-declaration: YES
Compiler for C supports arguments -Wlogical-op: YES
Compiler for C supports arguments -Wmisleading-indentation: YES
Compiler for C supports arguments -Wmissing-format-attribute: YES
Compiler for C supports arguments -Wmissing-include-dirs: YES
Compiler for C supports arguments -Wmissing-noreturn: YES
Compiler for C supports arguments -Wnested-externs: YES
Compiler for C supports arguments -Wold-style-definition: YES
Compiler for C supports arguments -Wpointer-arith: YES
Compiler for C supports arguments -Wshadow: YES
Compiler for C supports arguments -Wstrict-prototypes: YES
Compiler for C supports arguments -Wswitch-default: YES
Compiler for C supports arguments -Wswitch-enum: YES
Compiler for C supports arguments -Wundef: YES
Compiler for C supports arguments -Wuninitialized: YES
Compiler for C supports arguments -Wunused: YES
Compiler for C supports arguments -Werror=address: YES
Compiler for C supports arguments -Werror=array-bounds: YES
Compiler for C supports arguments -Werror=empty-body: YES
Compiler for C supports arguments -Werror=implicit: YES
Compiler for C supports arguments -Werror=implicit-fallthrough: YES
Compiler for C supports arguments -Werror=init-self: YES
Compiler for C supports arguments -Werror=int-to-pointer-cast: YES
Compiler for C supports arguments -Werror=main: YES
Compiler for C supports arguments -Werror=missing-braces: YES
Compiler for C supports arguments -Werror=missing-declarations: YES
Compiler for C supports arguments -Werror=missing-prototypes: YES
Compiler for C supports arguments -Werror=nonnull: YES
Compiler for C supports arguments -Werror=pointer-to-int-cast: YES
Compiler for C supports arguments -Werror=redundant-decls: YES
Compiler for C supports arguments -Werror=return-type: YES
Compiler for C supports arguments -Werror=sequence-point: YES
Compiler for C supports arguments -Werror=trigraphs: YES
Compiler for C supports arguments -Werror=vla: YES
Compiler for C supports arguments -Werror=write-strings: YES
Compiler for C supports arguments -fno-strict-aliasing: YES
Compiler for C supports arguments -Wpointer-arith: YES (cached)
Compiler for C supports arguments -Wmissing-declarations: YES
Compiler for C supports arguments -Wformat=2: YES (cached)
Compiler for C supports arguments -Wformat-nonliteral: YES (cached)
Compiler for C supports arguments -Wformat-security: YES (cached)
Compiler for C supports arguments -Wunused: YES (cached)
Compiler for C supports arguments -Wcast-align: YES
Compiler for C supports arguments -Wmissing-noreturn: YES (cached)
Compiler for C supports arguments -Wmissing-format-attribute: YES (cached)
Compiler for C supports arguments -Wmissing-include-dirs: YES (cached)
Compiler for C supports arguments -Wlogical-op: YES (cached)
Compiler for C supports arguments -Wno-uninitialized: YES
Compiler for C supports arguments -Wno-shadow: YES
Compiler for C supports arguments -Werror=implicit-fallthrough: YES (cached)
Compiler for C supports arguments -Werror=nonnull: YES (cached)
Compiler for C supports arguments -Werror=init-self: YES (cached)
Compiler for C supports arguments -Werror=main: YES (cached)
Compiler for C supports arguments -Werror=missing-braces: YES (cached)
Compiler for C supports arguments -Werror=sequence-point: YES (cached)
Compiler for C supports arguments -Werror=return-type: YES (cached)
Compiler for C supports arguments -Werror=trigraphs: YES (cached)
Compiler for C supports arguments -Werror=array-bounds: YES (cached)
Compiler for C supports arguments -Werror=write-strings: YES (cached)
Compiler for C supports arguments -Werror=address: YES (cached)
Compiler for C supports arguments -Werror=int-to-pointer-cast: YES (cached)
Compiler for C supports arguments -Werror=empty-body: YES (cached)
Compiler for C supports arguments -Werror=write-strings: YES (cached)
Compiler for C supports arguments -Werror=unused-but-set-variable: YES
Compiler for C supports arguments -Wundef: YES (cached)
Compiler for C supports arguments -mms-bitfields: YES
Compiler for C supports arguments -fvisibility=hidden: YES
Checking for function "sysconf" : NO
Checking for function "getpagesize" : YES
Checking for function "flockfile" : NO
Checking for function "strtok_r" : YES
Has header "unistd.h" : YES
Has header "sys/mman.h" : NO
Has header "dirent.h" : YES
Library m found: YES
Found pkg-config: D:\msys64\mingw64\bin/pkg-config.EXE (1.8.0)
Run-time dependency glib-2.0 found: YES 2.70.4
Run-time dependency gobject-2.0 found: YES 2.70.4
Run-time dependency gio-2.0 found: YES 2.70.4
Run-time dependency fribidi found: YES 1.0.11
Run-time dependency libthai found: YES 0.1.29
Checking for function "th_brk_find_breaks" with dependency libthai: YES
Run-time dependency harfbuzz found: YES 3.4.0
Run-time dependency fontconfig found: YES 2.13.96
Message: fontconfig has FcWeightFromOpenTypeDouble: YES
Run-time dependency freetype2 found: YES 24.1.18
Dependency xft skipped: feature xft disabled
Run-time dependency cairo found: YES 1.17.4
Run-time dependency cairo-ft found: YES 1.17.4
Run-time dependency cairo-win32 found: YES 1.17.4
Did not find CMake 'cmake'
Found CMake: NO
Run-time dependency cairo-quartz found: NO (tried pkgconfig and cmake)
Run-time dependency cairo-png found: YES 1.17.4
Run-time dependency cairo-ps found: YES 1.17.4
Run-time dependency cairo-pdf found: YES 1.17.4
Run-time dependency cairo-xlib found: NO (tried pkgconfig and cmake)
Dependency sysprof-capture-4 skipped: feature sysprof disabled
Run-time dependency gi-docgen found: YES 2022.1
Configuring config.h using configuration
Configuring pango-features.h using configuration
Program glib-mkenums found: YES (D:\msys64\mingw64\bin/glib-mkenums.EXE)
Program glib-mkenums found: YES (D:\msys64\mingw64\bin/glib-mkenums.EXE)
Configuring pango.rc using configuration
Windows resource compiler: GNU windres (GNU Binutils) 2.38
Program g-ir-scanner found: YES (D:\msys64\mingw64\bin/g-ir-scanner.EXE)
Run-time dependency harfbuzz-gobject found: YES 3.4.0
Run-time dependency gobject-introspection-1.0 found: YES 1.70.0
Dependency gobject-introspection-1.0 found: YES 1.70.0 (cached)
Program g-ir-scanner found: YES (D:/msys64/mingw64/bin/g-ir-scanner.exe)
Dependency gobject-introspection-1.0 found: YES 1.70.0 (cached)
Program g-ir-compiler found: YES (D:/msys64/mingw64/bin/g-ir-compiler.exe)
Configuring pangoft2.rc using configuration
Library gdi32 found: YES
Configuring pangowin32.rc using configuration
Configuring pangocairo.rc using configuration
Library gdi32 found: YES
Program help2man found: YES (perl -w D:\msys64\usr\bin/help2man)
Program gi-docgen found: YES (D:\msys64\mingw64\bin/gi-docgen.EXE)
Configuring pango.toml using configuration
Configuring pangoft2.toml using configuration
Configuring pangocairo.toml using configuration
Configuring pangoot.toml using configuration
Configuring pangofc.toml using configuration
Build targets in project: 86

pango 1.50.5

    Font backends     : freetype
                        win32

  Features
    Cairo support     : True
    Fontconfig support: True
    Freetype support  : True
    Thai support      : True
    Sysprof support   : False

  Toolchain
    Compiler          : gcc
    Linker            : ld.bfd

  Build
    Debugging         : False
    Optimization      : 0
    Introspection     : True
    Documentation     : True
    Install tests     : False

  Directories
    prefix            : /mingw64
    includedir        : /mingw64/include
    libdir            : /mingw64/lib
    datadir           : /mingw64/share

  User defined options
    auto_features     : enabled
    buildtype         : plain
    default_library   : shared
    prefix            : /mingw64
    wrap_mode         : nofallback
    gtk_doc           : true
    xft               : disabled

Found ninja-1.10.2 at D:\msys64\mingw64\bin/ninja.EXE
```

As you can see in the summary, `optimization` is set to 0:

```
  Build
    Debugging         : False
    Optimization      : 0
    Introspection     : True
    Documentation     : True
    Install tests     : False
```

What about adding the argument `--optimization 2` to the Meson invokation? See https://mesonbuild.com/Commands.html

---

When running `makepkg-mingw`, during `check()` a few test fail:

```
==> Starting check()...
ninja: Entering directory `D:/MINGW-packages/mingw-w64-pango/src/build-x86_64-w64-mingw32'
ninja: no work to do.
 1/26 test-coverage           OK              0.26s   2 subtests passed
 2/26 testboundaries          OK              0.25s   1 subtests passed
 3/26 testboundaries_ucd      OK              0.22s   5 subtests passed
 4/26 testcolor               OK              0.18s   3 subtests passed
 5/26 testscript              OK              0.15s   1 subtests passed
 6/26 testmatrix              OK              0.10s   10 subtests passed
 7/26 testlanguage            OK              0.34s   2 subtests passed
 8/26 testtabs                OK              0.35s   3 subtests passed
 9/26 test-ot-tags            OK              0.33s   2 subtests passed
10/26 testcontext             OK              0.27s   6 subtests passed
11/26 testiter                ERROR           0.33s   (exit status 2147483651 or signal 2147483523 SIGinvalid)
>>> srcdir=D:/MINGW-packages/mingw-w64-pango/src/pango-1.50.5/tests G_TEST_BUILDDIR=D:/MINGW-packages/mingw-w64-pango/src/build-x86_64-w64-mingw32/tests G_TEST_SRCDIR=D:/MINGW-packages/mingw-w64-pango/src/pango-1.50.5/tests MALLOC_PERTURB_=41 LC_ALL=en_US.UTF-8 PATH=D:/MINGW-packages/mingw-w64-pango/src/build-x86_64-w64-mingw32/pango;D:\msys64\mingw64\bin;D:\msys64\usr\local\bin;D:\msys64\usr\bin;D:\msys64\usr\bin;C:\Windows\System32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;D:\msys64\usr\bin\site_perl;D:\msys64\usr\bin\vendor_perl;D:\msys64\usr\bin\core_perl;D:\msys64\mingw64\bin\ D:/MINGW-packages/mingw-w64-pango/src/build-x86_64-w64-mingw32/tests/testiter.exe -k --tap

12/26 test-ellipsize          OK              0.36s   3 subtests passed
13/26 test-bidi               OK              0.48s   6 subtests passed
14/26 test-itemize            SKIP            0.38s   0 subtests passed
15/26 test-shape              SKIP            0.37s
16/26 testattributes          OK              0.31s   35 subtests passed
17/26 test-font               ERROR           0.37s   (exit status 2147483651 or signal 2147483523 SIGinvalid)
>>> srcdir=D:/MINGW-packages/mingw-w64-pango/src/pango-1.50.5/tests G_TEST_BUILDDIR=D:/MINGW-packages/mingw-w64-pango/src/build-x86_64-w64-mingw32/tests G_TEST_SRCDIR=D:/MINGW-packages/mingw-w64-pango/src/pango-1.50.5/tests MALLOC_PERTURB_=122 LC_ALL=en_US.UTF-8 PATH=D:/MINGW-packages/mingw-w64-pango/src/build-x86_64-w64-mingw32/pango;D:\msys64\mingw64\bin;D:\msys64\usr\local\bin;D:\msys64\usr\bin;D:\msys64\usr\bin;C:\Windows\System32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;D:\msys64\usr\bin\site_perl;D:\msys64\usr\bin\vendor_perl;D:\msys64\usr\bin\core_perl;D:\msys64\mingw64\bin\ D:/MINGW-packages/mingw-w64-pango/src/build-x86_64-w64-mingw32/tests/test-font.exe -k --tap

18/26 cxx-test                SKIP            0.32s
19/26 test-harfbuzz           OK              0.41s   1 subtests passed
20/26 test-break              SKIP            0.37s   0 subtests passed
21/26 testmisc                ERROR           0.31s   (exit status 2147483651 or signal 2147483523 SIGinvalid)
>>> srcdir=D:/MINGW-packages/mingw-w64-pango/src/pango-1.50.5/tests G_TEST_BUILDDIR=D:/MINGW-packages/mingw-w64-pango/src/build-x86_64-w64-mingw32/tests MALLOC_PERTURB_=171 G_TEST_SRCDIR=D:/MINGW-packages/mingw-w64-pango/src/pango-1.50.5/tests LC_ALL=en_US.UTF-8 PATH=D:/MINGW-packages/mingw-w64-pango/src/build-x86_64-w64-mingw32/pango;D:\msys64\mingw64\bin;D:\msys64\usr\local\bin;D:\msys64\usr\bin;D:\msys64\usr\bin;C:\Windows\System32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;D:\msys64\usr\bin\site_perl;D:\msys64\usr\bin\vendor_perl;D:\msys64\usr\bin\core_perl;D:\msys64\mingw64\bin\ D:/MINGW-packages/mingw-w64-pango/src/build-x86_64-w64-mingw32/tests/testmisc.exe -k --tap

22/26 testserialize           OK              1.43s   7 subtests passed
23/26 test-layout             SKIP            1.39s   0 subtests passed
24/26 test-pangocairo-threads ERROR           1.60s   exit status 1
>>> srcdir=D:/MINGW-packages/mingw-w64-pango/src/pango-1.50.5/tests G_TEST_BUILDDIR=D:/MINGW-packages/mingw-w64-pango/src/build-x86_64-w64-mingw32/tests MALLOC_PERTURB_=197 G_TEST_SRCDIR=D:/MINGW-packages/mingw-w64-pango/src/pango-1.50.5/tests LC_ALL=en_US.UTF-8 PATH=D:/MINGW-packages/mingw-w64-pango/src/build-x86_64-w64-mingw32/pango;D:\msys64\mingw64\bin;D:\msys64\usr\local\bin;D:\msys64\usr\bin;D:\msys64\usr\bin;C:\Windows\System32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;D:\msys64\usr\bin\site_perl;D:\msys64\usr\bin\vendor_perl;D:\msys64\usr\bin\core_perl;D:\msys64\mingw64\bin\ D:/MINGW-packages/mingw-w64-pango/src/build-x86_64-w64-mingw32/tests/test-pangocairo-threads.exe -k --tap

25/26 markup-parse            OK              6.47s   122 subtests passed
26/26 testrandom              OK              9.02s   6 subtests passed


Ok:                 17
Expected Fail:      0
Fail:               4
Unexpected Pass:    0
Skipped:            5
Timeout:            0

Full log written to D:/MINGW-packages/mingw-w64-pango/src/build-x86_64-w64-mingw32/meson-logs/testlog.txt
```

I am going to look into fixing that