### PR TITLE
slim-simulator: Remove check for Qt version.

### DIFF
--- a/mingw-w64-slim-simulator/0001-Remove-Qt-version-check.patch
+++ b/mingw-w64-slim-simulator/0001-Remove-Qt-version-check.patch
@@ -1,0 +1,19 @@
+Remove unnecessary check for Qt version.
+
+$ diff -urN SLiM/QtSLiM/main.cpp.orig SLiM/QtSLiM/main.cpp
+--- SLiM/QtSLiM/main.cpp.orig	2022-02-12 17:07:41.000000000 +0100
++++ SLiM/QtSLiM/main.cpp	2022-03-10 14:31:11.387185200 +0100
+@@ -192,13 +192,6 @@
+ 
+ int main(int argc, char *argv[])
+ {
+-    // Check that the run-time Qt version matches the compile-time Qt version
+-    if (strcmp(qVersion(), QT_VERSION_STR) != 0)
+-    {
+-        std::cout << "Run-time Qt version " << qVersion() << " does not match compile-time Qt version " << QT_VERSION_STR << std::endl;
+-        exit(EXIT_FAILURE);
+-    }
+-    
+     // Check for running under ASAN and log to confirm it is enabled; see SLiM.pro to enable it
+ #if defined(__has_feature)
+ #  if __has_feature(address_sanitizer)

--- a/mingw-w64-slim-simulator/PKGBUILD
+++ b/mingw-w64-slim-simulator/PKGBUILD
@@ -2,38 +2,57 @@ _realname=slim-simulator
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.7.1
-pkgrel=1
+pkgrel=2
 pkgdesc="SLiM forward simulation software package for population genetics (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
 url="https://messerlab.org/slim/"
-license=("GPL")
-makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+license=("spdx:GPL-3.0-or-later")
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake")
 depends=("${MINGW_PACKAGE_PREFIX}-qt5-base")
-source=("http://benhaller.com/slim/SLiM_pacman.tar.gz" )
-sha256sums=("a9b9ea3e9423deffb35c4e6ecf66ee919266dc37ee7ee7d60d33850f9cd5d4c0")
+source=("https://github.com/MesserLab/SLiM/releases/download/v${pkgver}/SLiM.zip"
+        "0001-Remove-Qt-version-check.patch")
+sha256sums=('af33cb97bb70842443b7e322152b3ed022f5db167c263a69922134eaf9e12d85'
+            '11679c3844de8d86b98f392ed1bf3711b15c7b5cc89eb2639c9e34fce3ede8c1')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _fname in "$@"
+  do
+    msg2 "Applying ${_fname}"
+    patch -Nbp1 -i "${srcdir}"/${_fname}
+  done
+}
+
+prepare() {
+  cd SLiM
+
+  apply_patch_with_msg \
+    0001-Remove-Qt-version-check.patch
+}
 
 build() {
-  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}
+  mkdir -p ${srcdir}/build-${MSYSTEM} && cd ${srcdir}/build-${MSYSTEM}
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake.exe \
       -G"MSYS Makefiles" \
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
       -DBUILD_SLIMGUI=ON \
-      ../SLiM_pacman
+      ../SLiM
 
   ${MINGW_PREFIX}/bin/cmake.exe --build .
 }
 
 package() {
-  cd "${srcdir}"/build-${MINGW_CHOST}
+  cd "${srcdir}"/build-${MSYSTEM}
 
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install .
 
-  install -Dm 644 "${srcdir}/SLiM_pacman/LICENSE" -t "${pkgdir}${MINGW_PREFIX}"/share/licenses/SLiM/
-  install -Dm 644 "${srcdir}/SLiM_pacman/VERSIONS" "${srcdir}/SLiM_pacman"/README.md \
+  install -Dm 644 "${srcdir}/SLiM/LICENSE" -t "${pkgdir}${MINGW_PREFIX}"/share/licenses/SLiM/
+  install -Dm 644 "${srcdir}/SLiM/VERSIONS" "${srcdir}/SLiM"/README.html \
     -t "${pkgdir}${MINGW_PREFIX}"/share/doc/SLiM/
 }


### PR DESCRIPTION
The check for the exact Qt version doesn't seem to be necessary. Usually, the Qt5 libraries are API compatible between minor updates.
If they are not, we'd need to rebuild all dependencies of Qt5 anyway (including slim-simulator).

Fixes #10952.