### PR TITLE
port-scanner: Fix building with clang.

### DIFF
--- a/mingw-w64-port-scanner/0001-use-CC-from-environment.patch
+++ b/mingw-w64-port-scanner/0001-use-CC-from-environment.patch
@@ -1,0 +1,29 @@
+Needs a C compiler - not a C++ compiler
+
+$ diff -urN threaded-port-scanner-1.3/Makefile.orig threaded-port-scanner-1.3/Makefile
+--- threaded-port-scanner-1.3/Makefile.orig	2022-03-10 18:26:08.589870300 +0100
++++ threaded-port-scanner-1.3/Makefile	2022-03-10 18:27:22.299557300 +0100
+@@ -1,17 +1,17 @@
+-CXX := gcc
+-CXXFLAGS := -std=gnu99 -O2 -Wall -ggdb
++CC ?= gcc
++CFLAGS := -std=gnu99 -O2 -Wall -ggdb
+     
+ OBJECTS	:= main.o net.o pathtools.o
+     
+ pscan: $(OBJECTS)
+-	$(CXX) $(OBJECTS) -lws2_32 -o pscan
++	$(CC) $(OBJECTS) -lws2_32 -o pscan
+     
+ main.o: main.c pathtools.h
+-	$(CXX) $(INCLUDES) $(CXXFLAGS) -c main.c -o main.o
++	$(CC) $(INCLUDES) $(CFLAGS) -c main.c -o main.o
+     
+ net.o: net.c
+-	$(CXX) $(CXXFLAGS) -c net.c -o net.o
++	$(CC) $(CFLAGS) -c net.c -o net.o
+ 
+ pathtools.o: pathtools.c pathtools.h
+-	$(CXX) $(CXXFLAGS) -c pathtools.c -o pathtools.o
++	$(CC) $(CFLAGS) -c pathtools.c -o pathtools.o
+ 

--- a/mingw-w64-port-scanner/PKGBUILD
+++ b/mingw-w64-port-scanner/PKGBUILD
@@ -4,7 +4,7 @@ _realname=port-scanner
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.3
-pkgrel=4
+pkgrel=5
 pkgdesc="A multi threaded TCP port scanner from SecPoint.com (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -14,11 +14,22 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
 source=("https://www.secpoint.com/freetools/threaded-port-scanner-${pkgver}.zip"
         "pathtools.c"
         "pathtools.h"
-        "paths.patch")
+        "paths.patch"
+        "0001-use-CC-from-environment.patch")
 sha256sums=('768c595fba7ba7e81da35e1bba1118bf08a1d689c6e419804d2109fc64177436'
             '6f1016e6647b6340fdceefaf24ff391f4c0ea3c785ddf70c9794ca2356797888'
             '6ce4dcf4ef6c4bce48dbcb6f1b5226baf79f74ac76719fb0c06419a0aadb37a3'
-            'e27fad5161752247259e271c30aa49ea7eb18fd9f9b4f92553332c5cbb031db8')
+            'e27fad5161752247259e271c30aa49ea7eb18fd9f9b4f92553332c5cbb031db8'
+            '66c18874119a4c36116f579f13b97aab538db399be61001f105a56ea1daeb03b')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _fname in "$@"
+  do
+    msg2 "Applying ${_fname}"
+    patch -Nbp1 -i "${srcdir}"/${_fname}
+  done
+}
 
 prepare() {
   test ! -d "${startdir}/../mingw-w64-pathtools" || {
@@ -29,18 +40,23 @@ prepare() {
   cd "${srcdir}/threaded-port-scanner-${pkgver}"
   cp -fHv "${srcdir}"/pathtools.[ch] ./
 
-  patch -p1 -i "${srcdir}/paths.patch" # also adds -lws2_32
-  mkdir -p "${srcdir}/build-${CARCH}"
-  cp * "${srcdir}/build-${CARCH}"
+  apply_patch_with_msg \
+    paths.patch \
+    0001-use-CC-from-environment.patch
+
+  [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
+  mkdir -p "${srcdir}/build-${MSYSTEM}"
+  cp * "${srcdir}/build-${MSYSTEM}"
 }
 
 build() {
-  cd "${srcdir}/build-${CARCH}"
+  cd "${srcdir}/build-${MSYSTEM}"
+
   make
 }
 
 package() {
-  cd "${srcdir}/build-${CARCH}"
+  cd "${srcdir}/build-${MSYSTEM}"
   install -Dm755 pscan.exe "${pkgdir}${MINGW_PREFIX}/bin/pscan.exe"
   install -Dm644 oui.txt "${pkgdir}${MINGW_PREFIX}/share/port-scanner/oui.txt"
   install -Dm644 port-numbers.txt "${pkgdir}${MINGW_PREFIX}/share/port-scanner/port-numbers.txt"


### PR DESCRIPTION
The clang C compiler is no longer installed with the alias `gcc`. Adapt the build rules for that change.