### PR TITLE
nana: do not optimize for host

### DIFF
--- a/mingw-w64-nana/011-march.patch
+++ b/mingw-w64-nana/011-march.patch
@@ -1,0 +1,13 @@
+diff -Naur nana-1.7.4.orig/build/cmake/compilers.cmake nana-1.7.4/build/cmake/compilers.cmake
+--- nana-1.7.4.orig/build/cmake/compilers.cmake	2020-05-17 00:08:50.000000000 +0200
++++ nana-1.7.4/build/cmake/compilers.cmake	2022-03-11 09:33:12.048159900 +0100
+@@ -16,9 +16,6 @@
+ 
+     target_compile_options(nana PRIVATE  -Wall)
+ 
+-        # todo: set in target property of nana
+-    set(CMAKE_CXX_FLAGS_RELEASE "-O3 -march=native -mtune=native -DNDEBUG")
+-
+     set(THREADS_PREFER_PTHREAD_FLAG ON)               #  todo - test this
+     find_package(Threads REQUIRED)
+     target_link_libraries(nana PRIVATE Threads::Threads)

--- a/mingw-w64-nana/PKGBUILD
+++ b/mingw-w64-nana/PKGBUILD
@@ -4,22 +4,25 @@ _realname=nana
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.7.4
-pkgrel=2
+pkgrel=3
 pkgdesc="An opensource cross-platform GUI library written in modern C++11 for static linking (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://github.com/cnjinhao/${_realname}"
 license=("spdx:BSL-1.0")
-depends=("${MINGW_PACKAGE_PREFIX}-libpng" "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-libpng" "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc" "${MINGW_PACKAGE_PREFIX}-cmake" "${MINGW_PACKAGE_PREFIX}-ninja")
 source=("${_realname}-v${pkgver}.tar.gz"::"https://github.com/cnjinhao/${_realname}/archive/v${pkgver}.tar.gz"
-        010-thread.patch)
+        010-thread.patch
+        011-march.patch)
 sha256sums=('56f7b1ed006c750fccf8ef15ab1e83f96751f2dfdcb68d93e5f712a6c9b58bcb'
-            '91d37c90ff54bfb9d97f3f2eddb12a04d7093af65fe0ba93ddeb1e04583f5659')
+            '91d37c90ff54bfb9d97f3f2eddb12a04d7093af65fe0ba93ddeb1e04583f5659'
+            '38616fc7ffa107a226716e983d1fcaafcd222f51b2129425e4dba9a067ad561d')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   patch -p1 -i ${srcdir}/010-thread.patch
+  patch -p1 -i ${srcdir}/011-march.patch
 }
 
 build() {
@@ -32,7 +35,7 @@ build() {
     -G"Ninja" \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    -DCMAKE_CXX_STANDARD=11 \
+    -DCMAKE_CXX_STANDARD=17 \
     -DNANA_CMAKE_ENABLE_JPEG=YES \
     -DNANA_CMAKE_ENABLE_PNG=YES \
     -DNANA_CMAKE_INSTALL=YES \


### PR DESCRIPTION
Also solves the clamgarm64 build problem (no -march=native support)