### PR TITLE
ci-check: Re-install pip if it was removed.

### DIFF
--- a/.ci/ci-check.py
+++ b/.ci/ci-check.py
@@ -83,6 +83,8 @@ def install_package(pkg: typing.Union[typing.List[str], Path]) -> typing.Generat
             "--refresh",
             "--sync",
             "--noconfirm",
+            "--needed",
+            "mingw-w64-x86_64-python-pip",
             get_pkg_name(pkg),
         ]
         uninstall_command = [
@@ -100,6 +102,8 @@ def install_package(pkg: typing.Union[typing.List[str], Path]) -> typing.Generat
                 "--sync",
                 "--refresh",
                 "--noconfirm",
+                "--needed",
+                "mingw-w64-x86_64-python-pip",
                 *pkg,
             ]
             uninstall_command = [


### PR DESCRIPTION
When the `check` job is run with multiple packages, `pip` might be uninstalled when one step is cleaned up with `pacman --remove -cns XXX`. See e.g., https://github.com/msys2/MINGW-packages/pull/9931#issuecomment-1065110743.

IIUC, this change re-installs `pip` when the next package is checked.
I'm not sure if this is the correct place for that. Comments much appreciated.
