### PR TITLE
onednn: update to 2.5.3

### DIFF
--- a/mingw-w64-onednn/PKGBUILD
+++ b/mingw-w64-onednn/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=onednn
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-pkgver=2.1.3
-pkgrel=2
+pkgver=2.5.3
+pkgrel=1
 pkgdesc='oneAPI Deep Neural Network Library (oneDNN) (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -12,9 +12,11 @@ url="https://github.com/oneapi-src/oneDNN"
 license=('APACHE')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          $([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-openmp"))
-makedepends=("${MINGW_PACKAGE_PREFIX}-cmake" "${MINGW_PACKAGE_PREFIX}-doxygen" "${MINGW_PACKAGE_PREFIX}-ninja" "${MINGW_PACKAGE_PREFIX}-cc")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
 source=("https://github.com/oneapi-src/oneDNN/archive/v${pkgver}.tar.gz")
-sha256sums=('f652d6d25edf0073ace88700c2182abf2416fa562ced920bf899d887b202c025')
+sha256sums=('0e5cf3b634ba93ef839e72da2cdc1a3affb1eb6f05a7d03349c7fe47ceb35915')
 
 build() {
   [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}
@@ -30,12 +32,11 @@ build() {
     ../oneDNN-$pkgver
 
   ${MINGW_PREFIX}/bin/cmake --build .
-  ${MINGW_PREFIX}/bin/cmake --build . --target doc
 }
 
 package() {
   cd "${srcdir}/build-${MSYSTEM}"
   DESTDIR="$pkgdir" ${MINGW_PREFIX}/bin/cmake --install .
-  cd "${srcdir}/${_realname}-${pkgver}"
-  install -D -m644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+
+  install -D -m644 "${srcdir}"/oneDNN-${pkgver}/LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
We couldn't build documentation because there is no doxyrest.
https://github.com/oneapi-src/oneDNN/blob/v2.5.3/cmake/doc.cmake#L21