### PR TITLE
scipy: update to 1.8.0

### DIFF
--- a/mingw-w64-python-beniget/PKGBUILD
+++ b/mingw-w64-python-beniget/PKGBUILD
@@ -1,0 +1,36 @@
+# Contributor: Mehdi Chinoune <mehdi.chinoune@hotmail.com>
+
+_realname=beniget
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=0.4.1
+pkgrel=1
+pkgdesc="A static analyzer for Python code (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+url="https://github.com/serge-sans-paille/beniget"
+license=('BSD')
+depends=("${MINGW_PACKAGE_PREFIX}-python-gast")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
+source=("https://pypi.python.org/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('75554b3b8ad0553ce2f607627dad3d95c60c441189875b98e097528f8e23ac0c')
+
+prepare() {
+  rm -rf python-build-${MSYSTEM} | true
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
+}
+
+build() {
+  cd "${srcdir}"/python-build-${MSYSTEM}
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    ${MINGW_PREFIX}/bin/python setup.py build
+}
+
+package() {
+  cd python-build-${MSYSTEM}
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} --root=${pkgdir} --optimize=1
+
+  install -Dm644 LICENSE \
+    "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}

--- a/mingw-w64-python-pythran/001-fix-default-config.patch
+++ b/mingw-w64-python-pythran/001-fix-default-config.patch
@@ -1,0 +1,17 @@
+--- a/pythran/pythran-win32.cfg
++++ b/pythran/pythran-win32.cfg
+@@ -4,9 +4,9 @@
+ include_dirs=
+ libs=
+ library_dirs=
+-cflags=/std:c++14 /w
++cflags=-std=c++11 -fno-math-errno -Wno-unused-function
+ ldflags=
+-blas=pythran-openblas
+-CC=clang-cl.exe
+-CXX=clang-cl.exe
+-ignoreflags=
++blas=blas
++CC=
++CXX=
++ignoreflags=-Wstrict-prototypes

--- a/mingw-w64-python-pythran/PKGBUILD
+++ b/mingw-w64-python-pythran/PKGBUILD
@@ -1,0 +1,48 @@
+# Contributor: Mehdi Chinoune <mehdi.chinoune@hotmail.com>
+
+_realname=pythran
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=0.11.0
+pkgrel=1
+pkgdesc="Ahead of Time compiler for numeric kernels (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+url="https://pythran.readthedocs.io/"
+license=('BSD')
+depends=("${MINGW_PACKAGE_PREFIX}-boost"
+         "${MINGW_PACKAGE_PREFIX}-xsimd"
+         "${MINGW_PACKAGE_PREFIX}-python-beniget"
+         "${MINGW_PACKAGE_PREFIX}-python-gast"
+         "${MINGW_PACKAGE_PREFIX}-python-ply"
+         "${MINGW_PACKAGE_PREFIX}-python-numpy")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+source=("https://pypi.python.org/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz"
+        001-fix-default-config.patch)
+sha256sums=('0b2cba712e09f7630879dff69f268460bfe34a6d6000451b47d598558a92a875'
+            'aa03979a1ede62e1ea19d17eeaa3208afa4ddfa89bc0f70435dca41be7f8730f')
+
+prepare() {
+  cd ${_realname}-${pkgver}
+  patch -p1 -i "${srcdir}"/001-fix-default-config.patch
+
+  rm -rf "${srcdir}"/python-build-${MSYSTEM} | true
+  cp -r "${srcdir}/${_realname}-${pkgver}" "${srcdir}/python-build-${MSYSTEM}"
+}
+
+build() {
+  cd "${srcdir}"/python-build-${MSYSTEM}
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    ${MINGW_PREFIX}/bin/python setup.py build
+}
+
+package() {
+  cd python-build-${MSYSTEM}
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} --root=${pkgdir} --optimize=1
+
+  rm -r "$pkgdir"${MINGW_PREFIX}/lib/python*/site-packages/pythran/{boost,xsimd} # Remove bundled boost and xsimd
+  install -Dm644 LICENSE \
+    "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}

--- a/mingw-w64-python-scipy/PKGBUILD
+++ b/mingw-w64-python-scipy/PKGBUILD
@@ -7,11 +7,11 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=1.6.3
-pkgrel=2
+pkgver=1.8.0
+pkgrel=1
 pkgdesc="SciPy is open-source software for mathematics, science, and engineering (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64')
 url="https://www.scipy.org/"
 license=('BSD')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libgfortran"
@@ -22,6 +22,7 @@ optdepends=(
         "${MINGW_PACKAGE_PREFIX}-python-pillow: for image saving module"
 )
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc-fortran"
+             "${MINGW_PACKAGE_PREFIX}-python-pythran"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-pybind11"
              "${MINGW_PACKAGE_PREFIX}-cc"
@@ -29,15 +30,15 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc-fortran"
 source=(
   "${_realname}-${pkgver}.tar.gz::https://pypi.python.org/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz"
 )
-sha256sums=('a75b014d3294fce26852a9d04ea27b5671d86736beb34acdfc05859246260707')
+sha256sums=('31d4f2d6b724bc9a98e527b5849b8a7e589bf1ea630c33aa563eda912c9ff0bd')
 
 prepare() {
-  rm -rf python-build-${CARCH} | true
-  cp -r "${_realname}-${pkgver}" "python-build-${CARCH}"
+  rm -rf python-build-${MSYSTEM} | true
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 
 build() {
-  cd ${srcdir}/python-build-${CARCH}
+  cd ${srcdir}/python-build-${MSYSTEM}
   # we do not have the C11 header threads.h (build error in vodemodule.c)
   CFLAGS+=" -D__STDC_NO_THREADS__=1"
   CXXFLAGS+=" -D__STDC_NO_THREADS__=1"
@@ -49,7 +50,7 @@ build() {
 }
 
 package() {
-  cd python-build-${CARCH}
+  cd python-build-${MSYSTEM}
   LDFLAGS="${LDFLAGS} -Wall -shared"
 
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \

--- a/mingw-w64-python-scipy/PKGBUILD
+++ b/mingw-w64-python-scipy/PKGBUILD
@@ -29,10 +29,16 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc-fortran"
              "${MINGW_PACKAGE_PREFIX}-cython")
 source=(
   "${_realname}-${pkgver}.tar.gz::https://pypi.python.org/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz"
+  "https://github.com/scipy/scipy/commit/5b6c6b34.patch"
 )
-sha256sums=('31d4f2d6b724bc9a98e527b5849b8a7e589bf1ea630c33aa563eda912c9ff0bd')
+sha256sums=('31d4f2d6b724bc9a98e527b5849b8a7e589bf1ea630c33aa563eda912c9ff0bd'
+            'fdf827700b80c2d286563af1f2c27155adfca49b9d1bed7f8d4ca11b1a851846')
 
 prepare() {
+  cd "${srcdir}"/${_realname}-${pkgver}
+  patch -R -p1 -i "${srcdir}"/5b6c6b34.patch
+
+  cd "${srcdir}"
   rm -rf python-build-${MSYSTEM} | true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }

--- a/mingw-w64-xsimd/PKGBUILD
+++ b/mingw-w64-xsimd/PKGBUILD
@@ -1,0 +1,37 @@
+# Contributor: Mehdi Chinoune <mehdi.chinoune@hotmail.com>
+
+_realname=xsimd
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=8.0.5
+pkgrel=1
+pkgdesc="QuantStack tools library - Multi-dimensional arrays with broadcasting and lazy computing (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+url="https://github.com/QuantStack/xsimd"
+license=(BSD)
+depends=()
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
+source=("${url}/archive/$pkgver.tar.gz")
+sha256sums=('0e1b5d973b63009f06a3885931a37452580dbc8d7ca8ad40d4b8c80d2a0f84d7')
+
+build() {
+  [[ -d "${srcdir}"/build-${MSYSTEM} ]] && rm -rf "${srcdir}"/build-${MSYSTEM}
+  mkdir "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake \
+    -GNinja \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    ../${_realname}-${pkgver}
+
+  ${MINGW_PREFIX}/bin/cmake --build .
+}
+
+package() {
+  DESTDIR="${pkgdir}" cmake --install "${srcdir}"/build-${MSYSTEM}
+  install -Dm644 "${srcdir}"/${_realname}-${pkgver}/LICENSE \
+    "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
For some reason it accepts `config_fc ...` when building but rejects it when installing?