### PR TITLE
libopenmpt: update to 0.6.2

### DIFF
--- a/mingw-w64-libopenmpt/PKGBUILD
+++ b/mingw-w64-libopenmpt/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libopenmpt
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.6.1
+pkgver=0.6.2
 pkgrel=1
 pkgdesc="A cross-platform C++ and C library to decode tracked music files (modules) into a raw PCM audio stream (mingw-w64)"
 arch=('any')
@@ -21,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools")
 options=('staticlibs' 'strip')
 source=("https://lib.openmpt.org/files/${_realname}/src/${_realname}-${pkgver}+release.autotools.tar.gz")
-sha256sums=('c0bada4bebfc707961111bdb5ff6bbe337f5d71e837e8278f2e362a909eb925b')
+sha256sums=('50c0d62ff2d9afefa36cce9f29042cb1fb8d4f0b386b81a0fc7734f35e21e6b6')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}+release.autotools"


### PR DESCRIPTION
Security release:
* [Sec] Possible out-of-bounds write in malformed IT / XM / MPTM files using the internal LFO plugin. (r17076)
* [Sec] Possible out-of-bounds read when using Amiga BLEP interpolation with extremely high-pitched notes. (r17078, r17079)

https://lib.openmpt.org/libopenmpt/2022/03/13/security-updates-0.6.2-0.5.17-0.4.30-0.3.38/