### PR TITLE
Add libxmp

### DIFF
--- a/mingw-w64-libxmp/PKGBUILD
+++ b/mingw-w64-libxmp/PKGBUILD
@@ -1,0 +1,35 @@
+_realname=libxmp
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=4.5.0
+pkgrel=1
+pkgdesc="Libxmp is a library that renders module files to PCM data. (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+license=('LGPL')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-autotools")
+optdepends=("${MINGW_PACKAGE_PREFIX}-unrar")
+options=('staticlibs' 'strip')
+source=(https://github.com/libxmp/libxmp/archive/refs/tags/libxmp-${pkgver}.tar.gz)
+sha256sums=('678e66da8761ff65f1e1f023d3b9125d4d6dd66e2c03c6ddb88455c2271cadd1')
+
+prepare() {
+  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
+  mv ${srcdir}/${_realname}-${_realname}-${pkgver} ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
+  autoconf -W none
+  ./configure --enable-static
+}
+
+build() {
+  cd ${srcdir}/build-${MINGW_CHOST}
+
+  make
+  make docs/libxmp.3
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  install -D -m644 "${srcdir}/build-${MINGW_CHOST}/docs/libxmp.3" "${pkgdir}${MINGW_PREFIX}/share/man/man3/libxmp.3"
+  make DESTDIR="${pkgdir}" install
+}

--- a/mingw-w64-libxmp/PKGBUILD
+++ b/mingw-w64-libxmp/PKGBUILD
@@ -8,6 +8,7 @@ arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 license=('LGPL')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-python-docutils"
              "${MINGW_PACKAGE_PREFIX}-autotools")
 optdepends=("${MINGW_PACKAGE_PREFIX}-unrar")
 options=('staticlibs' 'strip')

--- a/mingw-w64-libxmp/PKGBUILD
+++ b/mingw-w64-libxmp/PKGBUILD
@@ -19,12 +19,13 @@ prepare() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
   mv ${srcdir}/${_realname}-${_realname}-${pkgver} ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
   autoconf -W none
-  ./configure --enable-static
 }
 
 build() {
   cd ${srcdir}/build-${MINGW_CHOST}
 
+  ./configure --enable-static
+  
   make
   make docs/libxmp.3
 }


### PR DESCRIPTION
I probably made a lot of mistakes. I don't play well with autotools and the latest release doesn't have Cmake yet. Only tested on MinGW64, relying on checks for the rest.

This has another optional dependency [unmo3](https://github.com/lclevy/unmo3), which we don't have yet.

It should be possible to add libxmp-lite later, if needed.