### PR TITLE
perl (and C modules): makedepend on gcc-compat on clang

### DIFF
--- a/mingw-w64-perl-math-int64/PKGBUILD
+++ b/mingw-w64-perl-math-int64/PKGBUILD
@@ -5,7 +5,7 @@ _realname="${_perlname,,}"
 pkgbase=mingw-w64-perl-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-perl-${_realname}")
 pkgver=0.54
-pkgrel=3
+pkgrel=4
 pkgdesc="Math::Int64 - Manipulate 64 bits integers in Perl (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -14,7 +14,10 @@ url="https://metacpan.org/release/Math-Int64"
 depends=("${MINGW_PACKAGE_PREFIX}-perl")
 groups=("${MINGW_PACKAGE_PREFIX}-perl-modules")
 options=('!emptydirs')
-makedepends=("${MINGW_PACKAGE_PREFIX}-python" "${MINGW_PACKAGE_PREFIX}-cc")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python"
+             "${MINGW_PACKAGE_PREFIX}-cc"
+             $([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] || \
+               echo "${MINGW_PACKAGE_PREFIX}-gcc-compat"))
 source=(
   "https://www.cpan.org/authors/id/S/SA/SALVA/${_perlname}-${pkgver}.tar.gz"
   "patchmakefile.py"

--- a/mingw-w64-perl-win32-api/PKGBUILD
+++ b/mingw-w64-perl-win32-api/PKGBUILD
@@ -5,7 +5,7 @@ _realname="${_perlname,,}"
 pkgbase=mingw-w64-perl-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-perl-${_realname}")
 pkgver=0.84
-pkgrel=4
+pkgrel=5
 pkgdesc="Perl Win32 API Import Facility (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -17,7 +17,10 @@ depends=(
   "${MINGW_PACKAGE_PREFIX}-perl-math-int64"
 )
 options=('!emptydirs')
-makedepends=("${MINGW_PACKAGE_PREFIX}-python" "${MINGW_PACKAGE_PREFIX}-cc")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python"
+             "${MINGW_PACKAGE_PREFIX}-cc"
+             $([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] || \
+                echo "${MINGW_PACKAGE_PREFIX}-gcc-compat"))
 license=('perl_5')
 source=(
   "https://cpan.metacpan.org/authors/id/B/BU/BULKDD/Win32/${_perlname}-${pkgver}.tar.gz"

--- a/mingw-w64-perl-win32-console/PKGBUILD
+++ b/mingw-w64-perl-win32-console/PKGBUILD
@@ -5,7 +5,7 @@ _realname="${_perlname,,}"
 pkgbase=mingw-w64-perl-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-perl-${_realname}")
 pkgver=0.10
-pkgrel=3
+pkgrel=4
 pkgdesc="Win32 Console and Character Mode Functions (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -15,7 +15,10 @@ depends=(
   "${MINGW_PACKAGE_PREFIX}-perl"
 )
 options=('!emptydirs')
-makedepends=("${MINGW_PACKAGE_PREFIX}-python" "${MINGW_PACKAGE_PREFIX}-cc")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python"
+             "${MINGW_PACKAGE_PREFIX}-cc"
+             $([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] || \
+                echo "${MINGW_PACKAGE_PREFIX}-gcc-compat"))
 license=(perl_5)
 source=(
   "https://cpan.metacpan.org/authors/id/J/JD/JDB/${_perlname}-${pkgver}.tar.gz"

--- a/mingw-w64-perl-win32-shortcut/PKGBUILD
+++ b/mingw-w64-perl-win32-shortcut/PKGBUILD
@@ -5,7 +5,7 @@ _realname="${_perlname,,}"
 pkgbase=mingw-w64-perl-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-perl-${_realname}")
 pkgver=0.08
-pkgrel=3
+pkgrel=4
 pkgdesc="Perl Module to deal with Windows Shortcuts (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -15,7 +15,10 @@ depends=(
   "${MINGW_PACKAGE_PREFIX}-perl"
 )
 options=('!emptydirs')
-makedepends=("${MINGW_PACKAGE_PREFIX}-python" "${MINGW_PACKAGE_PREFIX}-cc")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python"
+             "${MINGW_PACKAGE_PREFIX}-cc"
+             $([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] || \
+                echo "${MINGW_PACKAGE_PREFIX}-gcc-compat"))
 license=('perl_5')
 source=(
   "https://cpan.metacpan.org/authors/id/J/JD/JDB/${_perlname}-${pkgver}.tar.gz"

--- a/mingw-w64-perl-win32-winerror/PKGBUILD
+++ b/mingw-w64-perl-win32-winerror/PKGBUILD
@@ -5,7 +5,7 @@ _realname="${_perlname,,}"
 pkgbase=mingw-w64-perl-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-perl-${_realname}")
 pkgver=0.04
-pkgrel=3
+pkgrel=4
 pkgdesc="Perl module defining Windows error constants (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -15,7 +15,10 @@ depends=(
   "${MINGW_PACKAGE_PREFIX}-perl"
 )
 options=('!emptydirs')
-makedepends=("${MINGW_PACKAGE_PREFIX}-python" "${MINGW_PACKAGE_PREFIX}-cc")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python"
+             "${MINGW_PACKAGE_PREFIX}-cc"
+             $([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] || \
+                echo "${MINGW_PACKAGE_PREFIX}-gcc-compat"))
 license=('perl_5')
 source=(
   "https://cpan.metacpan.org/authors/id/J/JD/JDB/${_perlname}-${pkgver}.tar.gz"

--- a/mingw-w64-perl-win32api-registry/PKGBUILD
+++ b/mingw-w64-perl-win32api-registry/PKGBUILD
@@ -5,7 +5,7 @@ _realname="${_perlname,,}"
 pkgbase=mingw-w64-perl-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-perl-${_realname}")
 pkgver=0.33
-pkgrel=3
+pkgrel=4
 pkgdesc="Low-level access to Win32 system API calls from WINREG.H (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -15,7 +15,10 @@ depends=(
   "${MINGW_PACKAGE_PREFIX}-perl"
 )
 options=('!emptydirs')
-makedepends=("${MINGW_PACKAGE_PREFIX}-python" "${MINGW_PACKAGE_PREFIX}-cc")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python"
+             "${MINGW_PACKAGE_PREFIX}-cc"
+             $([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] || \
+                echo "${MINGW_PACKAGE_PREFIX}-gcc-compat"))
 license=('perl_5')
 source=(
   "https://cpan.metacpan.org/authors/id/C/CH/CHORNY/${_perlname}-${pkgver}.tar.gz"

--- a/mingw-w64-perl/PKGBUILD
+++ b/mingw-w64-perl/PKGBUILD
@@ -21,14 +21,16 @@ pkgbase="mingw-w64-${_realname}"
 # provides array, then repackage.
 pkgver="5.32.1"
 #       v    ^
-pkgrel=4
+pkgrel=5
 pkgdesc="A highly capable, feature-rich programming language (mingw-w64)"
 url="https://www.perl.org"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 license=("Artistic-1.0-Perl" "GPL-1.0-or-later")
 options=("staticlibs" "strip" "docs" "!purge" "emptydirs")
-makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             $([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] || \
+                echo "${MINGW_PACKAGE_PREFIX}-gcc-compat"))
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-winpthreads"
          "${MINGW_PACKAGE_PREFIX}-make")


### PR DESCRIPTION
Perl's build system apparently keys off of CC being `gcc` to decide whether to use GCC or CL style options, and patching Perl to use `clang` results in an odd mix of GCC and CL style options when building modules.  Rather than digging into that mess, makedepend on gcc-compat package so that Perl can keep on using `gcc`.