### PR TITLE
add recipe for swi-prolog (mingw32, mingw64, ucrt64)

### DIFF
--- a/mingw-w64-swi-prolog/PKGBUILD
+++ b/mingw-w64-swi-prolog/PKGBUILD
@@ -9,7 +9,7 @@ pkgdesc="Prolog environment (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw64' 'mingw32' 'ucrt64')
 url="https://www.swi-prolog.org/"
-license=("BSD-2-Clause")
+license=("FreeBSD")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-gmp"
@@ -23,7 +23,7 @@ optdepends=()
 options=()
 source=(${_realname}-${pkgver}.tar.gz::https://www.swi-prolog.org/download/stable/src/swipl-${pkgver}.tar.gz)
 conflicts=()
-provides=("${MINGW_PACKAGE_PREFIX}-swi-prolog")
+provides=()
 noextract=(${_realname}-${pkgver}.tar.gz)
 sha256sums=('be21bd3d6d1c9f3e9b0d8947ca6f3f5fd56922a3819cae03251728f3e1a6f389')
 
@@ -31,23 +31,6 @@ prepare() {
   cd ${srcdir}
   rm -rf swipl-${pkgver}
   tar -xzvf ${_realname}-${pkgver}.tar.gz || true
-  echo '--- swipl-8.4.2/packages/cmake/PrologPackage.cmake  2022-03-17 15:47:46 +0000' > patch.txt
-  echo '+++ swipl-8.4.2/packages/cmake/PrologPackage.cmake  2022-03-17 15:47:15 +0000' >> patch.txt
-  echo '@@ -216,6 +216,7 @@' >> patch.txt
-  echo '' >> patch.txt
-  echo ' function(install_dll)' >> patch.txt
-  echo ' if(WIN32)' >> patch.txt
-  echo '+  if(NOT WIN32_DLLS STRMATCH "")' >> patch.txt
-  echo '   set(dlls)' >> patch.txt
-  echo '' >> patch.txt
-  echo '   foreach(lib ${ARGN})' >> patch.txt
-  echo '@@ -251,6 +252,7 @@' >> patch.txt
-  echo '        DESTINATION ${CMAKE_BINARY_DIR}/src)' >> patch.txt
-  echo '   install(FILES ${dlls}' >> patch.txt
-  echo '\t   DESTINATION ${SWIPL_INSTALL_ARCH_EXE})' >> patch.txt
-  echo '+  endif()' >> patch.txt
-  echo ' endif()' >> patch.txt
-  echo ' endfunction()' >> patch.txt
   patch -p0 < ../patch.txt
   cd "${srcdir}/swipl-${pkgver}"
 }

--- a/mingw-w64-swi-prolog/PKGBUILD
+++ b/mingw-w64-swi-prolog/PKGBUILD
@@ -1,0 +1,73 @@
+# Maintainer: Matthias Gondan <Matthias.Gondan-Rochon@uibk.ac.at>
+
+_realname=swi-prolog
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=8.4.2
+pkgrel=1
+pkgdesc="Prolog environment (mingw-w64)"
+arch=(any)
+mingw_arch=('mingw64' 'mingw32' 'ucrt64')
+url="https://www.swi-prolog.org/"
+license=("BSD-2-Clause")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-gmp"
+             "${MINGW_PACKAGE_PREFIX}-libarchive"
+             "${MINGW_PACKAGE_PREFIX}-libyaml"
+             "${MINGW_PACKAGE_PREFIX}-db"
+             "${MINGW_PACKAGE_PREFIX}-pcre"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+optdepends=()
+options=()
+source=(${_realname}-${pkgver}.tar.gz::https://www.swi-prolog.org/download/stable/src/swipl-${pkgver}.tar.gz)
+conflicts=()
+provides=("${MINGW_PACKAGE_PREFIX}-swi-prolog")
+noextract=(${_realname}-${pkgver}.tar.gz)
+sha256sums=('be21bd3d6d1c9f3e9b0d8947ca6f3f5fd56922a3819cae03251728f3e1a6f389')
+
+prepare() {
+  cd ${srcdir}
+  rm -rf swipl-${pkgver}
+  tar -xzvf ${_realname}-${pkgver}.tar.gz || true
+  echo '--- swipl-8.4.2/packages/cmake/PrologPackage.cmake  2022-03-17 15:47:46 +0000' > patch.txt
+  echo '+++ swipl-8.4.2/packages/cmake/PrologPackage.cmake  2022-03-17 15:47:15 +0000' >> patch.txt
+  echo '@@ -216,6 +216,7 @@' >> patch.txt
+  echo '' >> patch.txt
+  echo ' function(install_dll)' >> patch.txt
+  echo ' if(WIN32)' >> patch.txt
+  echo '+  if(NOT WIN32_DLLS STRMATCH "")' >> patch.txt
+  echo '   set(dlls)' >> patch.txt
+  echo '' >> patch.txt
+  echo '   foreach(lib ${ARGN})' >> patch.txt
+  echo '@@ -251,6 +252,7 @@' >> patch.txt
+  echo '        DESTINATION ${CMAKE_BINARY_DIR}/src)' >> patch.txt
+  echo '   install(FILES ${dlls}' >> patch.txt
+  echo '\t   DESTINATION ${SWIPL_INSTALL_ARCH_EXE})' >> patch.txt
+  echo '+  endif()' >> patch.txt
+  echo ' endif()' >> patch.txt
+  echo ' endfunction()' >> patch.txt
+  patch -p0 < ../patch.txt
+  cd "${srcdir}/swipl-${pkgver}"
+}
+
+build() {
+  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake \
+    -G"MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DMINGW_ROOT=${MINGW_PREFIX} \
+    -DWIN32_DLLS="" \
+    -DSWIPL_PACKAGES_X=OFF \
+    -DINSTALL_DOCUMENTATION=OFF \
+    ../swipl-${pkgver}
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR=${pkgdir} install
+}

--- a/mingw-w64-swi-prolog/PKGBUILD
+++ b/mingw-w64-swi-prolog/PKGBUILD
@@ -45,6 +45,7 @@ build() {
     -DMINGW_ROOT=${MINGW_PREFIX} \
     -DWIN32_DLLS="" \
     -DSWIPL_PACKAGES_X=OFF \
+    -DSWIPL_PACKAGES_JAVA=OFF \
     -DINSTALL_DOCUMENTATION=OFF \
     ../swipl-${pkgver}
   make

--- a/mingw-w64-swi-prolog/patch.txt
+++ b/mingw-w64-swi-prolog/patch.txt
@@ -1,0 +1,17 @@
+--- swipl-8.4.2/packages/cmake/PrologPackage.cmake	2022-03-17 15:47:46 +0000
++++ swipl-8.4.2/packages/cmake/PrologPackage.cmake	2022-03-17 15:47:15 +0000
+@@ -216,6 +216,7 @@
+ 
+ function(install_dll)
+ if(WIN32)
++  if(NOT "${WIN32_DLLS}" STREQUAL "")
+   set(dlls)
+ 
+   foreach(lib ${ARGN})
+@@ -251,6 +252,7 @@
+        DESTINATION ${CMAKE_BINARY_DIR}/src)
+   install(FILES ${dlls}
+ 	  DESTINATION ${SWIPL_INSTALL_ARCH_EXE})
++  endif()
+ endif()
+ endfunction()


### PR DESCRIPTION
This recipe is for a mingw32/mingw64/ucrt64 of the SWI-Prolog programming language.

Two issues will be solved in future versions:
* a little patch that is needed to avoid overwriting dlls that are already installed on the MinGW system (e.g., zlib1.dll). I have already made the respective PR to SWI-Prologs development version.
* Some of the installed dlls match the source folders. I have reported this potential problem to the SWI-Prolog developers.

Best regards,

Matthias