### PR TITLE
zbar: Enable pthread.

### DIFF
--- a/mingw-w64-zbar/PKGBUILD
+++ b/mingw-w64-zbar/PKGBUILD
@@ -11,7 +11,8 @@ mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://github.com/mchehab/zbar"
 license=('spdx:LGPL-2.1-or-later')
 depends=("${MINGW_PACKAGE_PREFIX}-imagemagick"
-         "${MINGW_PACKAGE_PREFIX}-libiconv")
+         "${MINGW_PACKAGE_PREFIX}-libiconv"
+         "${MINGW_PACKAGE_PREFIX}-libwinpthread-git")
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-cc")
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/mchehab/zbar/archive/${pkgver}.tar.gz)
@@ -33,6 +34,7 @@ build() {
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \
+    --enable-pthread \
     --without-qt \
     --without-gtk \
     --with-python=no \


### PR DESCRIPTION
This better matches how upstream is configuring in their CI:
https://github.com/mchehab/zbar/blob/master/.github/workflows/ci.yml#L228