### PR TITLE
darktable: update to 3.8.1

### DIFF
--- a/mingw-w64-darktable/001-define-libraw-win32-unicodepaths-libcxx.patch
+++ b/mingw-w64-darktable/001-define-libraw-win32-unicodepaths-libcxx.patch
@@ -1,0 +1,13 @@
+--- a/src/external/LibRaw/libraw/libraw.h
++++ b/src/external/LibRaw/libraw/libraw.h
+@@ -71,6 +71,10 @@
+ #  ifndef LIBRAW_WIN32_UNICODEPATHS
+ #    define LIBRAW_WIN32_UNICODEPATHS
+ #  endif
++# elif _LIBCPP_VERSION
++#  ifndef LIBRAW_WIN32_UNICODEPATHS
++#    define LIBRAW_WIN32_UNICODEPATHS
++#  endif
+ # endif
+ 
+ #endif

--- a/mingw-w64-darktable/10662-libraw.patch
+++ b/mingw-w64-darktable/10662-libraw.patch
@@ -1,0 +1,24 @@
+--- a/src/external/LibRaw/libraw/libraw.h
++++ b/src/external/LibRaw/libraw/libraw.h
+@@ -71,6 +71,10 @@ it under the terms of the one of two licenses as you choose:
+ #  ifndef LIBRAW_WIN32_UNICODEPATHS
+ #    define LIBRAW_WIN32_UNICODEPATHS
+ #  endif
++# elif defined(_LIBCPP_HAS_OPEN_WITH_WCHAR)
++#  ifndef LIBRAW_WIN32_UNICODEPATHS
++#    define LIBRAW_WIN32_UNICODEPATHS
++#  endif
+ # endif
+ 
+ #endif
+--- a/src/external/LibRaw/src/utils/open.cpp
++++ b/src/external/LibRaw/src/utils/open.cpp
+@@ -178,7 +178,7 @@ int LibRaw::open_file(const char *fname)
+ 
+ #if defined(WIN32) || defined(_WIN32)
+ #ifndef LIBRAW_WIN32_UNICODEPATHS
+-int LibRaw::open_file(const wchar_t *, INT64)
++int LibRaw::open_file(const wchar_t *)
+ {
+     return LIBRAW_NOT_IMPLEMENTED;
+ }

--- a/mingw-w64-darktable/10662.patch
+++ b/mingw-w64-darktable/10662.patch
@@ -1,0 +1,64 @@
+From 7cce8deebf6a4e15e2dc9c6202131a1f76cf987e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Milo=C5=A1=20Komar=C4=8Devi=C4=87?=
+ <miloskomarcevic@aim.com>
+Date: Tue, 21 Dec 2021 16:32:45 +0100
+Subject: [PATCH 1/2] Enable UCRT build on Win
+
+---
+ src/win/strptime.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/win/strptime.c b/src/win/strptime.c
+index b6e766bffd3..e08b4db4488 100644
+--- a/src/win/strptime.c
++++ b/src/win/strptime.c
+@@ -389,15 +389,15 @@ char *strptime(const char *buf, const char *fmt, struct tm *tm)
+         }
+         else
+         {
+-          ep = find_string(bp, &i, (const char *const *)tzname, NULL, 2);
++          ep = find_string(bp, &i, (const char *const *)_tzname, NULL, 2);
+           if(ep != NULL)
+           {
+             tm->tm_isdst = i;
+ #ifdef TM_GMTOFF
+-            tm->TM_GMTOFF = -(timezone);
++            tm->TM_GMTOFF = -(_timezone);
+ #endif
+ #ifdef TM_ZONE
+-            tm->TM_ZONE = tzname[i];
++            tm->TM_ZONE = _tzname[i];
+ #endif
+           }
+           bp = ep;
+
+From d563a5899a84a07992aabde7ef0a331e320d7553 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Milo=C5=A1=20Komar=C4=8Devi=C4=87?=
+ <miloskomarcevic@aim.com>
+Date: Wed, 22 Dec 2021 16:29:44 +0100
+Subject: [PATCH 2/2] Enable CLANG64 build on Win
+
+---
+ src/external/LibRaw | 2 +-
+ src/win/win.h       | 7 -------
+ 2 files changed, 1 insertion(+), 8 deletions(-)
+
+diff --git a/src/win/win.h b/src/win/win.h
+index f1d18b314fb..5c25d8f18d7 100644
+--- a/src/win/win.h
++++ b/src/win/win.h
+@@ -1,14 +1,7 @@
+ #pragma once
+ 
+-#ifdef __MSVCRT_VERSION__
+-#undef __MSVCRT_VERSION__
+-#endif
+-#define __MSVCRT_VERSION__ 0x0700
+-
+ #define XMD_H
+ 
+-#undef _WIN32_WINNT
+-#define _WIN32_WINNT 0x0600
+ #include <winsock2.h>
+ #include <windows.h>
+ #include <psapi.h>

--- a/mingw-w64-darktable/PKGBUILD
+++ b/mingw-w64-darktable/PKGBUILD
@@ -43,10 +43,14 @@ depends=("${MINGW_PACKAGE_PREFIX}-dbus-glib"
 # Disable strip option to write backtraces with drmingw
 options=('!strip')
 source=("https://github.com/darktable-org/${_realname}/releases/download/release-${pkgver}/${_realname}-${pkgver}.tar.xz"{,.asc}
-        "001-define-libraw-win32-unicodepaths-libcxx.patch")
+        "001-define-libraw-win32-unicodepaths-libcxx.patch"
+        "10662.patch"
+        "10662-libraw.patch")
 sha256sums=('81ee069054dbde580749b2d3a81cda01b7d169a82ba48731823f3ea560b2bef6'
             'SKIP'
-            'd586d8f56546eba5e70a4ac0ed99e43ce3d82685c48e77e9f40d0563965133e8')
+            'd586d8f56546eba5e70a4ac0ed99e43ce3d82685c48e77e9f40d0563965133e8'
+            'd3cb05d4f569f94e92a1677c5897afc40c00883fa36ca4641313f507477af475'
+            '4616f9c7d87ac93ec399f91e3937b29d4a0609864409a569c42329f229af9b26')
 validpgpkeys=('F10F9686652B0E949FCD94C318DCA123F949BD3B') # Pascal Obry <pascal@obry.net>
 
 apply_patch_with_msg() {
@@ -61,6 +65,11 @@ prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
   apply_patch_with_msg \
     001-define-libraw-win32-unicodepaths-libcxx.patch
+
+  # https://github.com/darktable-org/darktable/pull/10662
+  apply_patch_with_msg \
+    10662.patch \
+    10662-libraw.patch
 }
 
 build() {

--- a/mingw-w64-darktable/PKGBUILD
+++ b/mingw-w64-darktable/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=darktable
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=3.4.1
-pkgrel=4
+pkgver=3.8.1
+pkgrel=1
 pkgdesc="darktable is an open source photography workflow application and raw developer (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -13,6 +13,8 @@ license=('GPL3')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-gettext"
+             "intltool"
              "po4a")
 depends=("${MINGW_PACKAGE_PREFIX}-dbus-glib"
          "${MINGW_PACKAGE_PREFIX}-drmingw"
@@ -37,23 +39,33 @@ depends=("${MINGW_PACKAGE_PREFIX}-dbus-glib"
          "${MINGW_PACKAGE_PREFIX}-osm-gps-map"
          "${MINGW_PACKAGE_PREFIX}-pugixml"
          "${MINGW_PACKAGE_PREFIX}-sqlite3"
-         "${MINGW_PACKAGE_PREFIX}-zlib"
-        )
-# Disable strip option to write backtrces with drmingw
+         "${MINGW_PACKAGE_PREFIX}-zlib")
+# Disable strip option to write backtraces with drmingw
 options=('!strip')
-source=("https://github.com/darktable-org/${_realname}/releases/download/release-${pkgver}/${_realname}-${pkgver}.tar.xz"{,.asc})
-sha256sums=('7fc3f851da9bcd7c5053ecd09f21aa3eb6103be98a6c58f52010b6f22174941e'
-            'SKIP')
+source=("https://github.com/darktable-org/${_realname}/releases/download/release-${pkgver}/${_realname}-${pkgver}.tar.xz"{,.asc}
+        "001-define-libraw-win32-unicodepaths-libcxx.patch")
+sha256sums=('81ee069054dbde580749b2d3a81cda01b7d169a82ba48731823f3ea560b2bef6'
+            'SKIP'
+            'd586d8f56546eba5e70a4ac0ed99e43ce3d82685c48e77e9f40d0563965133e8')
 validpgpkeys=('F10F9686652B0E949FCD94C318DCA123F949BD3B') # Pascal Obry <pascal@obry.net>
 
-prepare() {
-  cd "${srcdir}/${_realname}-${pkgver}"
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying ${_patch}"
+    patch -Nbp1 -i "${srcdir}/${_patch}"
+  done
+}
 
+prepare() {
+  cd "${srcdir}"/${_realname}-${pkgver}
+  apply_patch_with_msg \
+    001-define-libraw-win32-unicodepaths-libcxx.patch
 }
 
 build() {
-  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
-  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+  [[ -d "${srcdir}"/build-${MSYSTEM} ]] && rm -rf "${srcdir}"/build-${MSYSTEM}
+  mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
 
   declare -a extra_config
   if check_option "debug" "n"; then
@@ -61,8 +73,6 @@ build() {
   else
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
-  
-  LDFLAGS+=" -fopenmp"
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe \
@@ -77,8 +87,8 @@ build() {
 }
 
 package() {
-  cd "${srcdir}"/build-${CARCH}
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --build ./ --target install
+  cd "${srcdir}"/build-${MSYSTEM}
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install .
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
CLANG64 job failed:
```
  ld.lld: error: undefined symbol: _setjmp
  >>> referenced by C:/_/mingw-w64-darktable/src/darktable-3.8.1/src/common/imageio_jpeg.c:134
  >>>               bin/CMakeFiles/lib_darktable.dir/common/imageio_jpeg.c.obj:(dt_imageio_jpeg_decompress_header)
  >>> referenced by C:/_/mingw-w64-darktable/src/darktable-3.8.1/src/common/imageio_jpeg.c:200
  >>>               bin/CMakeFiles/lib_darktable.dir/common/imageio_jpeg.c.obj:(dt_imageio_jpeg_decompress)
  >>> referenced by C:/_/mingw-w64-darktable/src/darktable-3.8.1/src/common/imageio_jpeg.c:212
  >>>               bin/CMakeFiles/lib_darktable.dir/common/imageio_jpeg.c.obj:(dt_imageio_jpeg_decompress)
  >>> referenced 9 more times
```
Any idea how to fix it?