### PR TITLE
doxygen: enable for clangarm64

### DIFF
--- a/mingw-w64-doxygen/PKGBUILD
+++ b/mingw-w64-doxygen/PKGBUILD
@@ -4,10 +4,10 @@ _realname=doxygen
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.9.3
-pkgrel=1
+pkgrel=2
 pkgdesc="A documentation system for C++, C, Java, IDL and PHP (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://www.doxygen.nl/"
 options=('strip' 'staticlibs')
 license=('GPL')
@@ -22,7 +22,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              #"${MINGW_PACKAGE_PREFIX}-polly"
              "${MINGW_PACKAGE_PREFIX}-python"
              "${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-qt5-base")
+             $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || \
+               echo "${MINGW_PACKAGE_PREFIX}-qt5-base"))
 optdepends=("${MINGW_PACKAGE_PREFIX}-qt5-base")
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/doxygen/doxygen/archive/Release_${pkgver//./_}.tar.gz
         cmake-mingw.patch
@@ -58,7 +59,8 @@ build() {
     -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DCMAKE_BUILD_TYPE=Release \
-    -Dbuild_wizard=ON \
+    -Dbuild_wizard=$([[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] && \
+                      echo "OFF" || echo "ON") \
     -Dbuild_search=ON \
     -Duse_sqlite3=ON \
     -Duse_libclang=OFF \


### PR DESCRIPTION
Disable wizard, to avoid needing qt5 just yet.