### PR TITLE
OpenBLAS: Build C_LAPACK in CLANG* environments.

### DIFF
--- a/mingw-w64-openblas/PKGBUILD
+++ b/mingw-w64-openblas/PKGBUILD
@@ -6,12 +6,12 @@ pkgbase=mingw-w64-openblas
 pkgname=("${MINGW_PACKAGE_PREFIX}-openblas"
          $([[ "${CARCH}" == "i686" ]] || echo "${MINGW_PACKAGE_PREFIX}-openblas64"))
 pkgver=0.3.20
-pkgrel=2
+pkgrel=3
 pkgdesc="An optimized BLAS library based on GotoBLAS2 1.13 BSD, providing optimized blas, lapack, and cblas (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://www.openblas.net/"
-license=('BSD')
+license=('spdx:BSD-3-Clause')
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-openblas-git")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}"
@@ -24,15 +24,17 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cc"
              $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-gcc-fortran")
-             )
+             "dos2unix")
 options=('!buildflags')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/xianyi/OpenBLAS/archive/v${pkgver}.tar.gz
         001-index64.patch
-        002-lgfortran-requires-lquadmath.patch)
+        002-lgfortran-requires-lquadmath.patch
+        003-f2c-LAPACK.patch::https://github.com/xianyi/OpenBLAS/commit/b7873605d4a3eb66a0488b54b3dc1dd7d4b79170.patch)
 install=${_realname}.install
 sha256sums=('8495c9affc536253648e942908e88e097f2ec7753ede55aca52e5dead3029e3c'
             '7a53bfd5ad2573889a63a9f594fe1b2ea2da15db6f88183e928b40adce420e9f'
-            'fecd847d029f5fa0d48c685e48e1d5efd413ead14452349fe78a66717fbce3e7')
+            'fecd847d029f5fa0d48c685e48e1d5efd413ead14452349fe78a66717fbce3e7'
+            'b915bb5912fbff8fef9f513deb6130e3b196123016ccfcd40f0a637a2ca3011b')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -44,6 +46,7 @@ apply_patch_with_msg() {
 }
 
 prepare() {
+  dos2unix "${srcdir}"/003-f2c-LAPACK.patch
   cd ${srcdir}/${_realname}-${pkgver}
 
   # https://github.com/xianyi/OpenBLAS/pull/3575
@@ -51,7 +54,8 @@ prepare() {
     001-index64.patch \
 
   apply_patch_with_msg \
-    002-lgfortran-requires-lquadmath.patch
+    002-lgfortran-requires-lquadmath.patch \
+    003-f2c-LAPACK.patch
 }
 
 _build_openblas() {
@@ -62,6 +66,10 @@ _build_openblas() {
     _build_type+=("Release")
   else
     _build_type+=("Debug")
+  fi
+
+  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
+    _c_lapack_opt="-DC_LAPACK=ON"
   fi
 
   unset CFLAGS
@@ -78,6 +86,7 @@ _build_openblas() {
     -DUSE_THREAD=ON \
     -DNUM_THREADS=64 \
     -DTARGET=CORE2 \
+    ${_c_lapack_opt} \
     ${_idx_opt} \
     ../${_realname}-${pkgver}
 


### PR DESCRIPTION
https://github.com/xianyi/OpenBLAS/pull/3539 used f2c on a current version of reference LAPACK with manual post-processing to add a version of netlib LAPACK that can be compiled without a Fortran compiler.
This PR adds those changes for the CLANG* environments.

The PR is pretty large and it is still marked as WIP. But it seems to be compiling without major problems in the CLANG64 and CLANG32 environments.

I tested in CLANG64 by compiling igraph linking to this patched version of OpenBLAS (instead of f2cblaslapack). It compiles correctly and passes all tests.

Looking forward, we could transition the packages that currently link to the BLAS/LAPACK libraries from f2cblaslapack to this modified version of OpenBLAS.

As an even longer term goal, would it be possible to establish some kind of mechanism similar to Ubuntu's "alternatives" that would allow switching between different BLAS/LAPACK implementations on the user side?
