### PR TITLE
Update OpenCV to 4.5.5 release

### DIFF
--- a/mingw-w64-opencv/0001-mingw-w64-cmake.patch
+++ b/mingw-w64-opencv/0001-mingw-w64-cmake.patch
@@ -1,7 +1,7 @@
-From 82a6d2f0fcb6b0b2f153324fb4f14a52f6873a4f Mon Sep 17 00:00:00 2001
+From fc6fe4b227c850e6de1e5326c092f71f5d512412 Mon Sep 17 00:00:00 2001
 From: "FeRD (Frank Dana)" <ferdnyc@gmail.com>
 Date: Wed, 21 Apr 2021 13:21:12 -0400
-Subject: [PATCH 1/8] mingw-w64-cmake
+Subject: [PATCH 01/12] mingw-w64-cmake
 
 ---
  CMakeLists.txt                  | 32 +++++++++-----------------------
@@ -10,66 +10,67 @@ Subject: [PATCH 1/8] mingw-w64-cmake
  cmake/OpenCVGenPkgconfig.cmake  |  2 +-
  cmake/OpenCVInstallLayout.cmake |  2 +-
  cmake/OpenCVModule.cmake        |  4 +++-
- 6 files changed, 19 insertions(+), 28 deletions(-)
+ 6 files changed, 18 insertions(+), 28 deletions(-)
 
- diff --git a/CMakeLists.txt b/CMakeLists.txt
- index 5a0c62e..6c15139 100644
- --- a/CMakeLists.txt
- +++ b/CMakeLists.txt
- @@ -189,20 +189,6 @@ if(UNIX AND NOT ANDROID)
-    endif()
-  endif()
-  
- -# Add these standard paths to the search paths for FIND_PATH
- -# to find include files from these locations first
- -if(MINGW)
- -  if(EXISTS /mingw)
- -      list(APPEND CMAKE_INCLUDE_PATH /mingw)
- -  endif()
- -  if(EXISTS /mingw32)
- -      list(APPEND CMAKE_INCLUDE_PATH /mingw32)
- -  endif()
- -  if(EXISTS /mingw64)
- -      list(APPEND CMAKE_INCLUDE_PATH /mingw64)
- -  endif()
- -endif()
- -
-  # ----------------------------------------------------------------------------
-  # OpenCV cmake options
-  # ----------------------------------------------------------------------------
- @@ -211,14 +197,14 @@ OCV_OPTION(OPENCV_ENABLE_NONFREE "Enable non-free algorithms" OFF)
-  
-  # 3rd party libs
-  OCV_OPTION(OPENCV_FORCE_3RDPARTY_BUILD   "Force using 3rdparty code from source" OFF)
- -OCV_OPTION(BUILD_ZLIB               "Build zlib from source"             (WIN32 OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
- -OCV_OPTION(BUILD_TIFF               "Build libtiff from source"          (WIN32 OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
- -OCV_OPTION(BUILD_OPENJPEG           "Build OpenJPEG from source"         (WIN32 OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
- -OCV_OPTION(BUILD_JASPER             "Build libjasper from source"        (WIN32 OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
- -OCV_OPTION(BUILD_JPEG               "Build libjpeg from source"          (WIN32 OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
- -OCV_OPTION(BUILD_PNG                "Build libpng from source"           (WIN32 OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
- -OCV_OPTION(BUILD_OPENEXR            "Build openexr from source"          (((WIN32 OR ANDROID OR APPLE) AND NOT WINRT) OR OPENCV_FORCE_3RDPARTY_BUILD) )
- -OCV_OPTION(BUILD_WEBP               "Build WebP from source"             (((WIN32 OR ANDROID OR APPLE) AND NOT WINRT) OR OPENCV_FORCE_3RDPARTY_BUILD) )
- +OCV_OPTION(BUILD_ZLIB               "Build zlib from source"             (MSVC OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
- +OCV_OPTION(BUILD_TIFF               "Build libtiff from source"          (MSVC OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
- +OCV_OPTION(BUILD_OPENJPEG           "Build OpenJPEG from source"         (MSVC OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
- +OCV_OPTION(BUILD_JASPER             "Build libjasper from source"        (MSVC OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
- +OCV_OPTION(BUILD_JPEG               "Build libjpeg from source"          (MSVC OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
- +OCV_OPTION(BUILD_PNG                "Build libpng from source"           (MSVC OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
- +OCV_OPTION(BUILD_OPENEXR            "Build openexr from source"          (((WIN32 OR ANDROID OR APPLE) AND NOT WINRT AND NOT MINGW) OR OPENCV_FORCE_3RDPARTY_BUILD) )
- +OCV_OPTION(BUILD_WEBP               "Build WebP from source"             (((WIN32 OR ANDROID OR APPLE) AND NOT WINRT AND NOT MINGW) OR OPENCV_FORCE_3RDPARTY_BUILD) )
-  OCV_OPTION(BUILD_TBB                "Download and build TBB from source" (ANDROID OR OPENCV_FORCE_3RDPARTY_BUILD) )
-  OCV_OPTION(BUILD_IPP_IW             "Build IPP IW from source"           (NOT MINGW OR OPENCV_FORCE_3RDPARTY_BUILD) IF (X86_64 OR X86) AND NOT WINRT )
-  OCV_OPTION(BUILD_ITT                "Build Intel ITT from source"
- @@ -981,7 +967,7 @@ if(NOT OPENCV_LICENSE_FILE)
-  endif()
-  
-  # for UNIX it does not make sense as LICENSE and readme will be part of the package automatically
- -if(ANDROID OR NOT UNIX)
- +if((ANDROID OR NOT UNIX) AND NOT MINGW)
-    install(FILES ${OPENCV_LICENSE_FILE}
-          PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
-          DESTINATION ./ COMPONENT libs)
-index 4ff02a7..e3bd127 100644
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f05adb3..3bf2db8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -195,20 +195,6 @@ if(UNIX AND NOT ANDROID)
+   endif()
+ endif()
+ 
+-# Add these standard paths to the search paths for FIND_PATH
+-# to find include files from these locations first
+-if(MINGW)
+-  if(EXISTS /mingw)
+-      list(APPEND CMAKE_INCLUDE_PATH /mingw)
+-  endif()
+-  if(EXISTS /mingw32)
+-      list(APPEND CMAKE_INCLUDE_PATH /mingw32)
+-  endif()
+-  if(EXISTS /mingw64)
+-      list(APPEND CMAKE_INCLUDE_PATH /mingw64)
+-  endif()
+-endif()
+-
+ # ----------------------------------------------------------------------------
+ # OpenCV cmake options
+ # ----------------------------------------------------------------------------
+@@ -217,14 +203,14 @@ OCV_OPTION(OPENCV_ENABLE_NONFREE "Enable non-free algorithms" OFF)
+ 
+ # 3rd party libs
+ OCV_OPTION(OPENCV_FORCE_3RDPARTY_BUILD   "Force using 3rdparty code from source" OFF)
+-OCV_OPTION(BUILD_ZLIB               "Build zlib from source"             (WIN32 OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
+-OCV_OPTION(BUILD_TIFF               "Build libtiff from source"          (WIN32 OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
+-OCV_OPTION(BUILD_OPENJPEG           "Build OpenJPEG from source"         (WIN32 OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
+-OCV_OPTION(BUILD_JASPER             "Build libjasper from source"        (WIN32 OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
+-OCV_OPTION(BUILD_JPEG               "Build libjpeg from source"          (WIN32 OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
+-OCV_OPTION(BUILD_PNG                "Build libpng from source"           (WIN32 OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
+-OCV_OPTION(BUILD_OPENEXR            "Build openexr from source"          (OPENCV_FORCE_3RDPARTY_BUILD) )
+-OCV_OPTION(BUILD_WEBP               "Build WebP from source"             (((WIN32 OR ANDROID OR APPLE) AND NOT WINRT) OR OPENCV_FORCE_3RDPARTY_BUILD) )
++OCV_OPTION(BUILD_ZLIB               "Build zlib from source"             (MSVC OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
++OCV_OPTION(BUILD_TIFF               "Build libtiff from source"          (MSVC OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
++OCV_OPTION(BUILD_OPENJPEG           "Build OpenJPEG from source"         (MSVC OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
++OCV_OPTION(BUILD_JASPER             "Build libjasper from source"        (MSVC OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
++OCV_OPTION(BUILD_JPEG               "Build libjpeg from source"          (MSVC OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
++OCV_OPTION(BUILD_PNG                "Build libpng from source"           (MSVC OR ANDROID OR APPLE OR OPENCV_FORCE_3RDPARTY_BUILD) )
++OCV_OPTION(BUILD_OPENEXR            "Build openexr from source"          (((WIN32 OR ANDROID OR APPLE) AND NOT WINRT AND NOT MINGW) OR OPENCV_FORCE_3RDPARTY_BUILD) )
++OCV_OPTION(BUILD_WEBP               "Build WebP from source"             (((WIN32 OR ANDROID OR APPLE) AND NOT WINRT AND NOT MINGW) OR OPENCV_FORCE_3RDPARTY_BUILD) )
+ OCV_OPTION(BUILD_TBB                "Download and build TBB from source" (ANDROID OR OPENCV_FORCE_3RDPARTY_BUILD) )
+ OCV_OPTION(BUILD_IPP_IW             "Build IPP IW from source"           (NOT MINGW OR OPENCV_FORCE_3RDPARTY_BUILD) IF (X86_64 OR X86) AND NOT WINRT )
+ OCV_OPTION(BUILD_ITT                "Build Intel ITT from source"
+@@ -1006,7 +992,7 @@ if(NOT OPENCV_LICENSE_FILE)
+ endif()
+ 
+ # for UNIX it does not make sense as LICENSE and readme will be part of the package automatically
+-if(ANDROID OR NOT UNIX)
++if((ANDROID OR NOT UNIX) AND NOT MINGW)
+   install(FILES ${OPENCV_LICENSE_FILE}
+         PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+         DESTINATION ./ COMPONENT libs)
+diff --git a/cmake/OpenCVDetectPython.cmake b/cmake/OpenCVDetectPython.cmake
+index 6e7bb18..61cf494 100644
 --- a/cmake/OpenCVDetectPython.cmake
 +++ b/cmake/OpenCVDetectPython.cmake
 @@ -176,7 +176,7 @@ if(NOT ${found})
@@ -78,14 +79,14 @@ index 4ff02a7..e3bd127 100644
      if(NOT ANDROID AND NOT IOS)
 -      if(CMAKE_HOST_UNIX)
 +      if(CMAKE_HOST_UNIX OR MINGW)
-         execute_process(COMMAND ${_executable} -c "from distutils.sysconfig import *; print(get_python_lib())"
+         execute_process(COMMAND ${_executable} -c "from sysconfig import *; print(get_path('purelib'))"
                          RESULT_VARIABLE _cvpy_process
                          OUTPUT_VARIABLE _std_packages_path
 diff --git a/cmake/OpenCVFindOpenEXR.cmake b/cmake/OpenCVFindOpenEXR.cmake
-index ef633e8..02faa39 100644
+index 0df626a..5e498eb 100644
 --- a/cmake/OpenCVFindOpenEXR.cmake
 +++ b/cmake/OpenCVFindOpenEXR.cmake
-@@ -13,7 +13,9 @@ SET(OPENEXR_LIBRARIES "")
+@@ -29,7 +29,9 @@ SET(OPENEXR_LIBRARIES "")
  SET(OPENEXR_LIBSEARCH_SUFFIXES "")
  file(TO_CMAKE_PATH "$ENV{ProgramFiles}" ProgramFiles_ENV_PATH)
  
@@ -123,10 +124,10 @@ index d5f3579..4722de0 100644
    if(DEFINED OpenCV_RUNTIME AND DEFINED OpenCV_ARCH)
      ocv_update(OPENCV_INSTALL_BINARIES_PREFIX "${OpenCV_ARCH}/${OpenCV_RUNTIME}/")
 diff --git a/cmake/OpenCVModule.cmake b/cmake/OpenCVModule.cmake
-index 224953a..33b5d79 100644
+index 9981620..92a0076 100644
 --- a/cmake/OpenCVModule.cmake
 +++ b/cmake/OpenCVModule.cmake
-@@ -963,7 +963,9 @@ macro(_ocv_create_module)
+@@ -996,7 +996,9 @@ macro(_ocv_create_module)
    endif()
  
    set_target_properties(${the_module} PROPERTIES
@@ -138,4 +139,5 @@ index 224953a..33b5d79 100644
      COMPILE_PDB_NAME "${the_module}${OPENCV_DLLVERSION}"
      COMPILE_PDB_NAME_DEBUG "${the_module}${OPENCV_DLLVERSION}${OPENCV_DEBUG_POSTFIX}"
 -- 
-2.31.1
+2.35.1
+

--- a/mingw-w64-opencv/0004-generate-proper-pkg-config-file.patch
+++ b/mingw-w64-opencv/0004-generate-proper-pkg-config-file.patch
@@ -11,7 +11,7 @@ diff --git a/cmake/OpenCVUtils.cmake b/cmake/OpenCVUtils.cmake
 index f42ad0b..b81ebc0 100644
 --- a/cmake/OpenCVUtils.cmake
 +++ b/cmake/OpenCVUtils.cmake
-@@ -1604,9 +1604,11 @@ endfunction()
+@@ -1635,9 +1635,11 @@ endfunction()
  macro(ocv_get_libname var_name)
    get_filename_component(__libname "${ARGN}" NAME)
    # libopencv_core.so.3.3 -> opencv_core

--- a/mingw-w64-opencv/0008-mingw-w64-cmake-lib-path.patch
+++ b/mingw-w64-opencv/0008-mingw-w64-cmake-lib-path.patch
@@ -1,6 +1,17 @@
---- opencv-3.4.2/cmake/templates/OpenCVConfig.root-WIN32.cmake.in.orig	2018-08-07 08:36:12.076932700 +0300
-+++ opencv-3.4.2/cmake/templates/OpenCVConfig.root-WIN32.cmake.in	2018-08-07 08:38:01.530193100 +0300
-@@ -63,6 +63,7 @@
+From cc32190e1ac4cf49ede7154575079f1914ffd5ef Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?U=C4=9Fur=20Kurnaz?= <bay.ugur.kurnaz@gmail.com>
+Date: Fri, 18 Mar 2022 17:45:08 +0100
+Subject: [PATCH 05/12] mingw-w64-cmake-lib-path
+
+---
+ cmake/templates/OpenCVConfig.root-WIN32.cmake.in | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/cmake/templates/OpenCVConfig.root-WIN32.cmake.in b/cmake/templates/OpenCVConfig.root-WIN32.cmake.in
+index b0f254e..67d427a 100644
+--- a/cmake/templates/OpenCVConfig.root-WIN32.cmake.in
++++ b/cmake/templates/OpenCVConfig.root-WIN32.cmake.in
+@@ -63,6 +63,7 @@ function(check_one_config RES)
      return()
    endif()
    set(candidates)
@@ -8,7 +19,7 @@
    if(OpenCV_STATIC)
      list(APPEND candidates "${OpenCV_ARCH}/${OpenCV_RUNTIME}/staticlib")
    endif()
-@@ -73,6 +74,9 @@
+@@ -73,6 +74,9 @@ function(check_one_config RES)
      list(APPEND candidates "gpu/${OpenCV_ARCH}/${OpenCV_RUNTIME}/staticlib")
    endif()
    list(APPEND candidates "${OpenCV_ARCH}/${OpenCV_RUNTIME}/lib")
@@ -18,3 +29,6 @@
    foreach(c ${candidates})
      set(p "${OpenCV_CONFIG_PATH}/${c}")
      if(EXISTS "${p}/OpenCVConfig.cmake")
+-- 
+2.35.1
+

--- a/mingw-w64-opencv/0012-make-header-usable-with-C-compiler.patch
+++ b/mingw-w64-opencv/0012-make-header-usable-with-C-compiler.patch
@@ -11,7 +11,7 @@ diff --git a/modules/core/include/opencv2/core/cvdef.h b/modules/core/include/op
 index 535883e..0ab8447 100644
 --- a/modules/core/include/opencv2/core/cvdef.h
 +++ b/modules/core/include/opencv2/core/cvdef.h
-@@ -766,6 +766,7 @@ __CV_ENUM_FLAGS_BITWISE_XOR_EQ   (EnumType, EnumType)
+@@ -805,6 +805,7 @@ __CV_ENUM_FLAGS_BITWISE_XOR_EQ   (EnumType, EnumType)
  #endif
  
  // Integer types portatibility
@@ -19,7 +19,7 @@ index 535883e..0ab8447 100644
  #ifdef OPENCV_STDINT_HEADER
  #include OPENCV_STDINT_HEADER
  #elif defined(__cplusplus)
-@@ -808,6 +809,9 @@ typedef ::uint64_t uint64_t;
+@@ -847,6 +848,9 @@ typedef ::uint64_t uint64_t;
  #else // pure C
  #include <stdint.h>
  #endif

--- a/mingw-w64-opencv/0014-python-install-path.patch
+++ b/mingw-w64-opencv/0014-python-install-path.patch
@@ -11,7 +11,7 @@ diff --git a/modules/python/common.cmake b/modules/python/common.cmake
 index 6a438fd..080bec8 100644
 --- a/modules/python/common.cmake
 +++ b/modules/python/common.cmake
-@@ -128,7 +128,7 @@ else()
+@@ -138,7 +138,7 @@ else()
    set(PYTHON_INSTALL_CONFIGURATIONS "")
  endif()
  

--- a/mingw-w64-opencv/0015-windres-cant-handle-spaces-in-defines.patch
+++ b/mingw-w64-opencv/0015-windres-cant-handle-spaces-in-defines.patch
@@ -11,7 +11,7 @@ diff --git a/modules/core/CMakeLists.txt b/modules/core/CMakeLists.txt
 index b2797ab..794b2e8 100644
 --- a/modules/core/CMakeLists.txt
 +++ b/modules/core/CMakeLists.txt
-@@ -127,7 +127,7 @@ elseif(HAVE_CXX11 OR DEFINED OPENCV_ALLOCATOR_STATS_COUNTER_TYPE)
+@@ -128,7 +128,7 @@ elseif(HAVE_CXX11 OR DEFINED OPENCV_ALLOCATOR_STATS_COUNTER_TYPE)
    endif()
    if(DEFINED OPENCV_ALLOCATOR_STATS_COUNTER_TYPE)
      message(STATUS "Allocator metrics storage type: '${OPENCV_ALLOCATOR_STATS_COUNTER_TYPE}'")

--- a/mingw-w64-opencv/0016-find_package_pfkconfig-msys.patch
+++ b/mingw-w64-opencv/0016-find_package_pfkconfig-msys.patch
@@ -1,0 +1,49 @@
+From b7f463beb6257a25c028697d64a731b04d5eae2d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?U=C4=9Fur=20Kurnaz?= <bay.ugur.kurnaz@gmail.com>
+Date: Fri, 18 Mar 2022 18:21:39 +0100
+Subject: [PATCH 10/12] find_package_pfkconfig-msys
+
+---
+ CMakeLists.txt | 26 ++++++++++++++++++++++++++
+ 1 file changed, 26 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3bf2db8..220fecd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -195,6 +195,32 @@ if(UNIX AND NOT ANDROID)
+   endif()
+ endif()
+ 
++message(STATUS "==========================================")
++message(STATUS "UNIX : ${UNIX}")
++message(STATUS "WIN32 : ${WIN32}")
++message(STATUS "MINGW : ${MINGW}")
++message(STATUS "MSYS : ${MSYS}")
++message(STATUS "CYGWIN : ${CYGWIN}")
++message(STATUS "CMAKE_SYSTEM : ${CMAKE_SYSTEM}")
++message(STATUS "CMAKE_SYSTEM_NAME : ${CMAKE_SYSTEM_NAME}")
++message(STATUS "X86 : ${X86}")
++message(STATUS "X86_64 : ${X86_64}")
++message(STATUS "CMAKE_SYSTEM_PROCESSOR: ${CMAKE_SYSTEM_PROCESSOR}")
++message(STATUS "CMAKE_POSITION_INDEPENDENT_CODE: ${CMAKE_POSITION_INDEPENDENT_CODE}")
++message(STATUS "BUILD_SHARED_LIBS : ${BUILD_SHARED_LIBS}")
++message(STATUS "CMAKE_PREFIX_PATH : ${CMAKE_PREFIX_PATH}")
++message(STATUS "CMAKE_MODULE_PATH : ${CMAKE_MODULE_PATH}")
++message(STATUS "CMAKE_BUILD_TYPE : ${CMAKE_BUILD_TYPE}")
++message(STATUS "CMAKE_INSTALL_PREFIX : ${CMAKE_INSTALL_PREFIX}")
++message(STATUS "CMAKE_TOOLCHAIN_FILE : ${CMAKE_TOOLCHAIN_FILE}")
++message(STATUS "CMAKE_EXPORT_COMPILE_COMMANDS : ${CMAKE_EXPORT_COMPILE_COMMANDS}")
++message(STATUS "CMAKE_LIBRARY_PATH: ${CMAKE_LIBRARY_PATH}")
++message(STATUS "==========================================")
++
++if (MSYS)
++  find_package(PkgConfig REQUIRED)
++endif()
++
+ # ----------------------------------------------------------------------------
+ # OpenCV cmake options
+ # ----------------------------------------------------------------------------
+-- 
+2.35.1
+

--- a/mingw-w64-opencv/0017-detect_gstreamer_with_pkg_config_first.patch
+++ b/mingw-w64-opencv/0017-detect_gstreamer_with_pkg_config_first.patch
@@ -1,0 +1,58 @@
+From 696df8fe54bd8f1bb0580a6d11597916af883166 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?U=C4=9Fur=20Kurnaz?= <bay.ugur.kurnaz@gmail.com>
+Date: Fri, 18 Mar 2022 18:22:46 +0100
+Subject: [PATCH 11/12] detect_gstreamer_with_pkg_config_first
+
+---
+ modules/videoio/cmake/detect_gstreamer.cmake | 30 ++++++++++----------
+ 1 file changed, 15 insertions(+), 15 deletions(-)
+
+diff --git a/modules/videoio/cmake/detect_gstreamer.cmake b/modules/videoio/cmake/detect_gstreamer.cmake
+index fc6c347..cc827e2 100644
+--- a/modules/videoio/cmake/detect_gstreamer.cmake
++++ b/modules/videoio/cmake/detect_gstreamer.cmake
+@@ -1,4 +1,19 @@
+ # --- GStreamer ---
++if(NOT HAVE_GSTREAMER AND PKG_CONFIG_FOUND)
++  ocv_check_modules(GSTREAMER_base gstreamer-base-1.0)
++  ocv_check_modules(GSTREAMER_app gstreamer-app-1.0)
++  ocv_check_modules(GSTREAMER_riff gstreamer-riff-1.0)
++  ocv_check_modules(GSTREAMER_pbutils gstreamer-pbutils-1.0)
++  ocv_check_modules(GSTREAMER_video gstreamer-video-1.0)
++  ocv_check_modules(GSTREAMER_audio gstreamer-audio-1.0)
++  if(GSTREAMER_base_FOUND AND GSTREAMER_app_FOUND AND GSTREAMER_riff_FOUND AND GSTREAMER_pbutils_FOUND AND GSTREAMER_video_FOUND AND GSTREAMER_audio_FOUND)
++    set(HAVE_GSTREAMER TRUE)
++    set(GSTREAMER_VERSION ${GSTREAMER_base_VERSION})  # informational
++    set(GSTREAMER_LIBRARIES ${GSTREAMER_base_LIBRARIES} ${GSTREAMER_app_LIBRARIES} ${GSTREAMER_riff_LIBRARIES} ${GSTREAMER_pbutils_LIBRARIES} ${GSTREAMER_video_LIBRARIES} ${GSTREAMER_audio_LIBRARIES})
++    set(GSTREAMER_INCLUDE_DIRS ${GSTREAMER_base_INCLUDE_DIRS} ${GSTREAMER_app_INCLUDE_DIRS} ${GSTREAMER_riff_INCLUDE_DIRS} ${GSTREAMER_pbutils_INCLUDE_DIRS} ${GSTREAMER_video_INCLUDE_DIRS} ${GSTREAMER_audio_INCLUDE_DIRS})
++  endif()
++endif()
++
+ if(NOT HAVE_GSTREAMER AND WIN32)
+   set(env_paths "${GSTREAMER_DIR}" ENV GSTREAMER_ROOT)
+   if(X86_64)
+@@ -87,21 +102,6 @@ if(NOT HAVE_GSTREAMER AND WIN32)
+   endif()
+ endif()
+ 
+-if(NOT HAVE_GSTREAMER AND PKG_CONFIG_FOUND)
+-  ocv_check_modules(GSTREAMER_base gstreamer-base-1.0)
+-  ocv_check_modules(GSTREAMER_app gstreamer-app-1.0)
+-  ocv_check_modules(GSTREAMER_riff gstreamer-riff-1.0)
+-  ocv_check_modules(GSTREAMER_pbutils gstreamer-pbutils-1.0)
+-  ocv_check_modules(GSTREAMER_video gstreamer-video-1.0)
+-  ocv_check_modules(GSTREAMER_audio gstreamer-audio-1.0)
+-  if(GSTREAMER_base_FOUND AND GSTREAMER_app_FOUND AND GSTREAMER_riff_FOUND AND GSTREAMER_pbutils_FOUND AND GSTREAMER_video_FOUND AND GSTREAMER_audio_FOUND)
+-    set(HAVE_GSTREAMER TRUE)
+-    set(GSTREAMER_VERSION ${GSTREAMER_base_VERSION})  # informational
+-    set(GSTREAMER_LIBRARIES ${GSTREAMER_base_LIBRARIES} ${GSTREAMER_app_LIBRARIES} ${GSTREAMER_riff_LIBRARIES} ${GSTREAMER_pbutils_LIBRARIES} ${GSTREAMER_video_LIBRARIES} ${GSTREAMER_audio_LIBRARIES})
+-    set(GSTREAMER_INCLUDE_DIRS ${GSTREAMER_base_INCLUDE_DIRS} ${GSTREAMER_app_INCLUDE_DIRS} ${GSTREAMER_riff_INCLUDE_DIRS} ${GSTREAMER_pbutils_INCLUDE_DIRS} ${GSTREAMER_video_INCLUDE_DIRS} ${GSTREAMER_audio_INCLUDE_DIRS})
+-  endif()
+-endif()
+-
+ if(HAVE_GSTREAMER)
+   ocv_add_external_target(gstreamer "${GSTREAMER_INCLUDE_DIRS}" "${GSTREAMER_LIBRARIES}" "HAVE_GSTREAMER")
+ endif()
+-- 
+2.35.1
+

--- a/mingw-w64-opencv/0018-highgui_link_opengl_libraries.patch
+++ b/mingw-w64-opencv/0018-highgui_link_opengl_libraries.patch
@@ -1,0 +1,25 @@
+From b91f7354d4243663c5b10eb3846e13e80256ce90 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?U=C4=9Fur=20Kurnaz?= <bay.ugur.kurnaz@gmail.com>
+Date: Fri, 18 Mar 2022 18:28:16 +0100
+Subject: [PATCH 12/12] highgui_link_opengl_libraries
+
+---
+ modules/highgui/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/modules/highgui/CMakeLists.txt b/modules/highgui/CMakeLists.txt
+index 0d63d42..1986bb1 100644
+--- a/modules/highgui/CMakeLists.txt
++++ b/modules/highgui/CMakeLists.txt
+@@ -271,7 +271,7 @@ if(APPLE)
+   add_apple_compiler_options(${the_module})
+ endif()
+ 
+-if(OPENCV_HIGHGUI_BUILTIN_BACKEND STREQUAL "WIN32UI" AND HAVE_OPENGL AND OPENGL_LIBRARIES)
++if(HAVE_OPENGL AND OPENGL_LIBRARIES)
+   ocv_target_link_libraries(${the_module} PRIVATE "${OPENGL_LIBRARIES}")
+ endif()
+ 
+-- 
+2.35.1
+

--- a/mingw-w64-opencv/0019-build_msmf_with_mingw.patch
+++ b/mingw-w64-opencv/0019-build_msmf_with_mingw.patch
@@ -1,0 +1,100 @@
+From e7839e6621722e62d2f619a658845f876acf4b2e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?U=C4=9Fur=20Kurnaz?= <bay.ugur.kurnaz@gmail.com>
+Date: Sun, 20 Mar 2022 14:26:35 +0100
+Subject: [PATCH 13/13] build_msmf_with_mingw
+
+---
+ modules/videoio/cmake/detect_msmf.cmake |  6 ++++--
+ modules/videoio/src/cap_msmf.cpp        | 25 +++++++++++++++++++++----
+ 2 files changed, 25 insertions(+), 6 deletions(-)
+
+diff --git a/modules/videoio/cmake/detect_msmf.cmake b/modules/videoio/cmake/detect_msmf.cmake
+index aebc226..f431d19 100644
+--- a/modules/videoio/cmake/detect_msmf.cmake
++++ b/modules/videoio/cmake/detect_msmf.cmake
+@@ -14,9 +14,11 @@ if(HAVE_MSMF)
+       set(HAVE_MSMF_DXVA TRUE)
+     endif()
+   endif()
+-  set(defs "HAVE_MSMF")
++  set(defs "HAVE_MSMF" "STRSAFE_NO_DEPRECATE")
++  set(libs "-levr -lmf -lmfplat -lmfplay -lmfreadwrite -lmfuuid -lshlwapi")
+   if(HAVE_MSMF_DXVA)
+     list(APPEND defs "HAVE_MSMF_DXVA")
++    list(APPEND libs "-ld3d11 -ldxgi -ldxva2")
+   endif()
+-  ocv_add_external_target(msmf "" "" "${defs}")
++  ocv_add_external_target(msmf "" "${libs}" "${defs}")
+ endif()
+diff --git a/modules/videoio/src/cap_msmf.cpp b/modules/videoio/src/cap_msmf.cpp
+index d782369..fd633c0 100644
+--- a/modules/videoio/src/cap_msmf.cpp
++++ b/modules/videoio/src/cap_msmf.cpp
+@@ -37,10 +37,12 @@
+ #include <string>
+ #include <algorithm>
+ #include <deque>
++#include <locale>
+ #include <stdio.h>
+ #include <stdarg.h>
+ #include <string.h>
+ 
++
+ #ifdef _MSC_VER
+ #pragma warning(disable:4503)
+ #pragma comment(lib, "mfplat")
+@@ -57,7 +59,7 @@
+ typedef HRESULT (WINAPI *FN_MFCreateDXGIDeviceManager)(UINT *resetToken, IMFDXGIDeviceManager **ppDeviceManager);
+ static bool pMFCreateDXGIDeviceManager_initialized = false;
+ static FN_MFCreateDXGIDeviceManager pMFCreateDXGIDeviceManager = NULL;
+-static void init_MFCreateDXGIDeviceManager()
++static void  init_MFCreateDXGIDeviceManager()
+ {
+     HMODULE h = LoadLibraryExA("mfplat.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
+     if (h)
+@@ -68,7 +70,16 @@ static void init_MFCreateDXGIDeviceManager()
+ }
+ #endif
+ #pragma comment(lib, "Shlwapi.lib")
++#else
++#ifdef HAVE_MSMF_DXVA
++//MFCreateDXGIDeviceManager is already declared in mfapi.h and defined in mfplat.dll
++typedef HRESULT (WINAPI *FN_MFCreateDXGIDeviceManager)(UINT *resetToken, IMFDXGIDeviceManager **ppDeviceManager);
++static bool pMFCreateDXGIDeviceManager_initialized = true;
++static FN_MFCreateDXGIDeviceManager pMFCreateDXGIDeviceManager = &MFCreateDXGIDeviceManager;
++static void  init_MFCreateDXGIDeviceManager() {}
+ #endif
++#endif
++
+ 
+ #include <mferror.h>
+ #include <comdef.h>
+@@ -150,8 +161,14 @@ public:
+         return p->QueryInterface(__uuidof(U), reinterpret_cast<void**>((T**)&lp));
+     }
+ private:
+-    _COM_SMARTPTR_TYPEDEF(T, __uuidof(T));
+-    TPtr p;
++    class _com_IIID_wrapper {
++    public:
++        typedef T Interface;
++        static T *GetInterfacePtr() throw() { return NULL; }
++        static T& GetInterface() throw() { return *GetInterfacePtr(); }
++        static const IID& GetIID() throw() { return __uuidof(T); }
++    };
++    _COM_SMARTPTR<_com_IIID_wrapper> p;
+ };
+ 
+ #define _ComPtr ComPtr
+@@ -1016,7 +1033,7 @@ bool CvCapture_MSMF::configureHW(bool enable)
+                                 DXGI_ADAPTER_DESC desc;
+                                 if (SUCCEEDED(adapter->GetDesc(&desc))) {
+                                     std::wstring name(desc.Description);
+-                                    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> conv;
++                                    std::wstring_convert< std::codecvt_utf8_utf16<wchar_t> > conv;
+                                     CV_LOG_INFO(NULL, "MSMF: Using D3D11 video acceleration on GPU device: " << conv.to_bytes(name));
+                                 }
+                             }
+-- 
+2.35.1
+

--- a/mingw-w64-opencv/0105-wechat-iconv-dependency.patch
+++ b/mingw-w64-opencv/0105-wechat-iconv-dependency.patch
@@ -11,9 +11,9 @@ diff --git a/modules/wechat_qrcode/CMakeLists.txt b/modules/wechat_qrcode/CMakeL
 index 210f4a0d..3d02c7bb 100644
 --- a/modules/wechat_qrcode/CMakeLists.txt
 +++ b/modules/wechat_qrcode/CMakeLists.txt
-@@ -1,6 +1,16 @@
- set(the_description "WeChat QR code Detector")
- ocv_define_module(wechat_qrcode opencv_core opencv_imgproc opencv_dnn WRAP java objc python js)
+@@ -11,6 +11,16 @@ if(CMAKE_VERSION VERSION_GREATER "3.11")
+   endif()
+ endif()
  
 +# iconv support isn't automatic on some systems
 +if(CMAKE_VERSION VERSION_GREATER 3.11)

--- a/mingw-w64-opencv/PKGBUILD
+++ b/mingw-w64-opencv/PKGBUILD
@@ -3,62 +3,96 @@
 _realname=opencv
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.5.2
-pkgrel=4
+pkgver=4.5.5
+pkgrel=9
 pkgdesc="Open Source Computer Vision Library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 url="https://opencv.org/"
-license=("BSD")
-# 4.5.0 doesn't support ceres 2.x, wait for >4.5.0
-depends=(#"${MINGW_PACKAGE_PREFIX}-gst-plugins-base
-         "${MINGW_PACKAGE_PREFIX}-ceres-solver"
-         "${MINGW_PACKAGE_PREFIX}-intel-tbb"
-         "${MINGW_PACKAGE_PREFIX}-jasper"
-         "${MINGW_PACKAGE_PREFIX}-freetype"
-         "${MINGW_PACKAGE_PREFIX}-gflags"
-         "${MINGW_PACKAGE_PREFIX}-glog"
-         "${MINGW_PACKAGE_PREFIX}-harfbuzz"
-         "${MINGW_PACKAGE_PREFIX}-hdf5"
-         "${MINGW_PACKAGE_PREFIX}-libiconv"
-         "${MINGW_PACKAGE_PREFIX}-libjpeg"
-         "${MINGW_PACKAGE_PREFIX}-libpng"
-         "${MINGW_PACKAGE_PREFIX}-libtiff"
-         "${MINGW_PACKAGE_PREFIX}-libwebp"
-         "${MINGW_PACKAGE_PREFIX}-ogre3d"
-         "${MINGW_PACKAGE_PREFIX}-openblas"
-         "${MINGW_PACKAGE_PREFIX}-openjpeg2"
-         "${MINGW_PACKAGE_PREFIX}-openexr"
-         "${MINGW_PACKAGE_PREFIX}-protobuf"
-         "${MINGW_PACKAGE_PREFIX}-tesseract-ocr"
-         "${MINGW_PACKAGE_PREFIX}-zlib"
-         #"${MINGW_PACKAGE_PREFIX}-qt5"
-         #"${MINGW_PACKAGE_PREFIX}-gtkglext"
-         #"${MINGW_PACKAGE_PREFIX}-gtk2"
-         )
-makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
-             #"${MINGW_PACKAGE_PREFIX}-qt5"
-             "${MINGW_PACKAGE_PREFIX}-ffmpeg"
-             "${MINGW_PACKAGE_PREFIX}-python-numpy"
-             "${MINGW_PACKAGE_PREFIX}-python-flake8"
-             "${MINGW_PACKAGE_PREFIX}-python-pylint"
-             "${MINGW_PACKAGE_PREFIX}-tiny-dnn"
-             #"${MINGW_PACKAGE_PREFIX}-vtk"
-             "${MINGW_PACKAGE_PREFIX}-cereal"
-             "${MINGW_PACKAGE_PREFIX}-cc"
-            )
-optdepends=(#"${MINGW_PACKAGE_PREFIX}-ceres-solver: SFM module"
-            #"${MINGW_PACKAGE_PREFIX}-gflags: SFM module"
-            #"${MINGW_PACKAGE_PREFIX}-glog: SFM module"
-            "${MINGW_PACKAGE_PREFIX}-ffmpeg: support to read and write video files"
-            "${MINGW_PACKAGE_PREFIX}-python-numpy: Python 3.x interface"
-            #"${MINGW_PACKAGE_PREFIX}-hdf5: opencv_hdf module"
-            #"${MINGW_PACKAGE_PREFIX}-tesseract-ocr: opencv_text module"
-            #"${MINGW_PACKAGE_PREFIX}-ogre3d: ovis module"
-            #"${MINGW_PACKAGE_PREFIX}-vtk: opencv_viz module"
-            )
+license=("BSD;GPL")
+depends=(
+  # imgcodec
+  "${MINGW_PACKAGE_PREFIX}-zlib"
+  "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
+  "${MINGW_PACKAGE_PREFIX}-libwebp"
+  "${MINGW_PACKAGE_PREFIX}-libpng"
+  "${MINGW_PACKAGE_PREFIX}-libtiff"
+  "${MINGW_PACKAGE_PREFIX}-openjpeg2"
+  "${MINGW_PACKAGE_PREFIX}-jasper"
+  "${MINGW_PACKAGE_PREFIX}-openexr"
+  "${MINGW_PACKAGE_PREFIX}-gdal"
+  "${MINGW_PACKAGE_PREFIX}-gdcm"
+
+  # highgui
+  #"${MINGW_PACKAGE_PREFIX}-gtk3"
+  #"${MINGW_PACKAGE_PREFIX}-gtk2"
+  #"${MINGW_PACKAGE_PREFIX}-gtkglext"
+  #"${MINGW_PACKAGE_PREFIX}-qt5-base"
+  #"${MINGW_PACKAGE_PREFIX}-qt6-base"
+  #"${MINGW_PACKAGE_PREFIX}-vtk"
+
+  # videoio
+  #"${MINGW_PACKAGE_PREFIX}-gst-plugins-base"
+  #"${MINGW_PACKAGE_PREFIX}-ffmpeg"
+  #"${MINGW_PACKAGE_PREFIX}-libmfx"
+  #"${MINGW_PACKAGE_PREFIX}-gphoto2"
+
+  # core
+  "${MINGW_PACKAGE_PREFIX}-intel-tbb"
+  "${MINGW_PACKAGE_PREFIX}-eigen3"
+  "${MINGW_PACKAGE_PREFIX}-lapack"
+  "${MINGW_PACKAGE_PREFIX}-openblas"
+
+  # dnn
+  "${MINGW_PACKAGE_PREFIX}-protobuf"
+  "${MINGW_PACKAGE_PREFIX}-tiny-dnn"
+
+  # sfm module
+  "${MINGW_PACKAGE_PREFIX}-ceres-solver"
+  "${MINGW_PACKAGE_PREFIX}-gflags"
+  "${MINGW_PACKAGE_PREFIX}-glog"
+  "${MINGW_PACKAGE_PREFIX}-suitesparse"
+
+  # extra modules
+  #"${MINGW_PACKAGE_PREFIX}-ogre3d"
+  #"${MINGW_PACKAGE_PREFIX}-vulkan"
+  #"${MINGW_PACKAGE_PREFIX}-julia"
+  "${MINGW_PACKAGE_PREFIX}-tesseract-ocr"
+  "${MINGW_PACKAGE_PREFIX}-harfbuzz"
+  "${MINGW_PACKAGE_PREFIX}-freetype"
+  "${MINGW_PACKAGE_PREFIX}-hdf5"
+
+  # python
+  "${MINGW_PACKAGE_PREFIX}-python-numpy"
+  #"${MINGW_PACKAGE_PREFIX}-python-pylint"
+  #"${MINGW_PACKAGE_PREFIX}-python-flake8"
+  
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-ccache"
+
+)
+optdepends=(
+  #"${MINGW_PACKAGE_PREFIX}-ceres-solver: SFM module"
+  #"${MINGW_PACKAGE_PREFIX}-gflags: SFM module"
+  #"${MINGW_PACKAGE_PREFIX}-glog: SFM module"
+  #"${MINGW_PACKAGE_PREFIX}-ffmpeg: support to read and write video files"
+  #"${MINGW_PACKAGE_PREFIX}-tesseract-ocr: opencv_text module"
+  #"${MINGW_PACKAGE_PREFIX}-qt5-base: gui backend"
+  #"${MINGW_PACKAGE_PREFIX}-gtk3: gui backend"
+  #"${MINGW_PACKAGE_PREFIX}-gtk2: gui backend"
+  #"${MINGW_PACKAGE_PREFIX}-vtk: opencv_viz module"
+  #"${MINGW_PACKAGE_PREFIX}-ogre3d: ovis module"
+  #"${MINGW_PACKAGE_PREFIX}-vulkan: vulkan framework"
+  #"${MINGW_PACKAGE_PREFIX}-protobuf"
+  #"${MINGW_PACKAGE_PREFIX}-tiny-dnn"
+  #"${MINGW_PACKAGE_PREFIX}-python-numpy"
+)
 source=("${_realname}-${pkgver}.tar.gz"::https://github.com/opencv/opencv/archive/${pkgver}.tar.gz
         "${_realname}_contrib-${pkgver}.tar.gz"::https://github.com/opencv/opencv_contrib/archive/${pkgver}.tar.gz
+
         '0001-mingw-w64-cmake.patch'
         '0002-solve_deg3-underflow.patch'
         '0003-issue-4107.patch'
@@ -68,27 +102,40 @@ source=("${_realname}-${pkgver}.tar.gz"::https://github.com/opencv/opencv/archiv
         '0012-make-header-usable-with-C-compiler.patch'
         '0014-python-install-path.patch'
         '0015-windres-cant-handle-spaces-in-defines.patch'
+        '0016-find_package_pfkconfig-msys.patch'
+        '0017-detect_gstreamer_with_pkg_config_first.patch'
+        '0018-highgui_link_opengl_libraries.patch'
+        '0019-build_msmf_with_mingw.patch'
+
         '0101-somehow-uint-not-detected.patch'
         '0102-mingw-w64-have-sincos.patch'
         '0103-sfm-module-linking.patch'
-        '0104-rgbd-module-missing-include.patch'
-        '0105-wechat-iconv-dependency.patch')
-sha256sums=('ae258ed50aa039279c3d36afdea5c6ecf762515836b27871a8957c610d0424f8'
-            '9f52fd3114ac464cb4c9a2a6a485c729a223afb57b9c24848484e55cef0b5c2a'
-            'e50a477ca9fb613400ba276099bb3be6af8f1bfb277ea86459f0d635c24d218f'
-            '400f17bde074677566660b1baab52842c1a3d7024129a2d75af6015f6b55ba4f'
-            '480e45906b54c5b6079f437de50ebf2152a83860327613048b53d038526b8ad2'
-            'fcb3a4a469b09475dc2dad0c49bcaade8b80aa155eeaf0645398a77cd8c940cc'
-            '7398e66f80be37382bd427b5eb3a1201a23113c14e71435a44df8779ea1b8a34'
-            'd6ad5a0865eefe662ca4c7aceb6aa7b1fd5fcd27e1e65ca839d442f054095e69'
-            '9f918a974e9d5227fce3702b1f38716a7fb79586dda9256b5df44dcc0f858c3b'
-            '0c310a580d6700601d4b4f824b849c0f0d64d3953e249f04c6a91f15aa8bee0a'
-            '11522ffedb22980ba8d09ff715a25327fe14806e55588bffa761e39e1d035ea5'
-            '7d2ff25f97c84b59793502786dd64e25c8ca991b0523ffea56b45ce031e80c3f'
-            '2001804c5245af1894a308d6521f9cd044fb6dbd713b6e2e45106399a409c14d'
-            '0422317096007b72ab4928b48762da4252addf3e4f8066ba94e29344f5975ab8'
-            'c6c92cf39dfe45b8fb41d80ac0de3cd304e8b695420b307fd4320a105d8fe9f4'
-            '3cf6a17b234ddf4f20e042acce329823e970aa06873d63652fa132c46ee56739')
+        #'0104-rgbd-module-missing-include.patch'
+        '0105-wechat-iconv-dependency.patch'
+		)
+sha256sums=('a1cfdcf6619387ca9e232687504da996aaa9f7b5689986b8331ec02cb61d28ad'
+			'a97c2eaecf7a23c6dbd119a609c6d7fae903e5f9ff5f1fe678933e01c67a6c11'
+
+      '3d31b0eb6f66ec314017db221655f917c126d026a7c0220b9620818793cfe4f2' #0001-mingw-w64-cmake.patch
+      '400f17bde074677566660b1baab52842c1a3d7024129a2d75af6015f6b55ba4f' #0002-solve_deg3-underflow.patch
+      '480e45906b54c5b6079f437de50ebf2152a83860327613048b53d038526b8ad2' #0003-issue-4107.patch
+      'bab4362a9651553c5d608c7d0d81a9dec6c7f400a1e004562ed96f4d121093ee' #0004-generate-proper-pkg-config-file.patch
+      '4ee5f28b72834871bbf300a06c5f13a1f12f7d35d1b44b64b03b8347fe56b512' #0008-mingw-w64-cmake-lib-path.patch
+      'd6ad5a0865eefe662ca4c7aceb6aa7b1fd5fcd27e1e65ca839d442f054095e69' #0010-find-libpng-header.patch
+      'bbd4bd0783df8851ffa9faf4e1a6d26b90d4e4a39e118e444d17a1d0a3fd27ca' #0012-make-header-usable-with-C-compiler.patch
+      '754eae1dfe0e8f1e1ea96a5bcdc44b25bedc2f8780f0ed058a8d1270b4f5572c' #0014-python-install-path.patch
+      '113235a691576232614515d18569e016ec720f67093be79291bb4db1a36bf140' #0015-windres-cant-handle-spaces-in-defines.patch
+      'e696e6efa983c45b03e518d994108eff9e10d42e959c2b2904695081d2392f61' #0016-find_package_pfkconfig-msys.patch
+      '3125493590a61a1d07d6bf4c47c31125a15a9858e9486a9a07be159e3557c3fa' #0017-detect_gstreamer_with_pkg_config_first.patch
+      'a4ff9f0784c060843192eb7dc400c2ff7517153bbfe0235313733d7b616910dd' #0018-highgui_link_opengl_libraries.patch
+      '1fe30547263d76c6afbe48ab34226c0b39ccb4011c8817dc89b4d79f641b424f' #0019-build_msmf_with_mingw.patch
+
+      '7d2ff25f97c84b59793502786dd64e25c8ca991b0523ffea56b45ce031e80c3f' #0101-somehow-uint-not-detected.patch
+      '2001804c5245af1894a308d6521f9cd044fb6dbd713b6e2e45106399a409c14d' #0102-mingw-w64-have-sincos.patch
+      '0422317096007b72ab4928b48762da4252addf3e4f8066ba94e29344f5975ab8' #0103-sfm-module-linking.patch
+      #'c6c92cf39dfe45b8fb41d80ac0de3cd304e8b695420b307fd4320a105d8fe9f4' #0104-rgbd-module-missing-include.patch
+      '5c087f6bacc2de581901e55bc984e24c240140d4132ae87063c3a99b016f5247' #0105-wechat-iconv-dependency.patch
+			)
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -111,78 +158,122 @@ del_file_exists() {
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
-  apply_patch_with_msg \
-        0001-mingw-w64-cmake.patch \
-        0002-solve_deg3-underflow.patch \
-        0003-issue-4107.patch \
-        0004-generate-proper-pkg-config-file.patch \
-        0008-mingw-w64-cmake-lib-path.patch \
-        0010-find-libpng-header.patch \
-        0012-make-header-usable-with-C-compiler.patch \
-        0014-python-install-path.patch \
-        0015-windres-cant-handle-spaces-in-defines.patch
+  apply_patch_with_msg 0001-mingw-w64-cmake.patch
+  apply_patch_with_msg 0002-solve_deg3-underflow.patch
+  apply_patch_with_msg 0003-issue-4107.patch
+  apply_patch_with_msg 0004-generate-proper-pkg-config-file.patch
+  apply_patch_with_msg 0008-mingw-w64-cmake-lib-path.patch
+  apply_patch_with_msg 0010-find-libpng-header.patch
+  apply_patch_with_msg 0012-make-header-usable-with-C-compiler.patch
+  apply_patch_with_msg 0014-python-install-path.patch
+  apply_patch_with_msg 0015-windres-cant-handle-spaces-in-defines.patch
+  apply_patch_with_msg 0016-find_package_pfkconfig-msys.patch
+  apply_patch_with_msg 0017-detect_gstreamer_with_pkg_config_first.patch
+  apply_patch_with_msg 0018-highgui_link_opengl_libraries.patch
+  apply_patch_with_msg 0019-build_msmf_with_mingw.patch
 
   cd "${srcdir}/${_realname}_contrib-${pkgver}"
-  apply_patch_with_msg \
-        0101-somehow-uint-not-detected.patch \
-        0102-mingw-w64-have-sincos.patch \
-        0103-sfm-module-linking.patch \
-        0104-rgbd-module-missing-include.patch \
-        0105-wechat-iconv-dependency.patch
+  apply_patch_with_msg 0101-somehow-uint-not-detected.patch
+  apply_patch_with_msg 0102-mingw-w64-have-sincos.patch
+  apply_patch_with_msg 0103-sfm-module-linking.patch
+  #apply_patch_with_msg 0104-rgbd-module-missing-include.patch
+  apply_patch_with_msg 0105-wechat-iconv-dependency.patch  
 }
 
 build() {
   [[ -d ${srcdir}/build-${CARCH} ]] && rm -rf ${srcdir}/build-${CARCH}
   mkdir -p ${srcdir}/build-${CARCH} && cd ${srcdir}/build-${CARCH}
 
-  CFLAGS+=" -D_POSIX_SOURCE -Wno-attributes"
-  CXXFLAGS+=" -D_POSIX_SOURCE -Wno-attributes"
+#  CFLAGS+=" -D_POSIX_SOURCE -Wno-attributes"
+#  CXXFLAGS+=" -D_POSIX_SOURCE -Wno-attributes"
+#  CFLAGS+=" -D_POSIX_SOURCE -w -lopengl32 -lglu32 -lmf -ldxva2"
+#  CXXFLAGS+=" -D_POSIX_SOURCE -w -lopengl32 -lglu32 -lmf -ldxva2"
+  CFLAGS+=" -D_POSIX_SOURCE -w -flarge-source-files"
+  CXXFLAGS+=" -D_POSIX_SOURCE -w -flarge-source-files"
 
   export OpenEXR_HOME=${MINGW_PREFIX}
   export OpenBLAS_HOME=${MINGW_PREFIX}
+  export TBBROOT=${MINGW_PREFIX}
   export TINYDNN_ROOT=${MINGW_PREFIX}/include/tiny_dnn
+  #export ANT_DIR=C:/etc/apache-ant-1.10.12
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DPYTHON2_PACKAGES_PATH=;-DPYTHON3_PACKAGES_PATH=" \
   ${MINGW_PREFIX}/bin/cmake.exe -Wno-dev \
     -G"MSYS Makefiles" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    -DWITH_OPENCL=ON \
-    -DWITH_OPENGL=ON \
-    -DWITH_TBB=ON \
-    -DWITH_XINE=OFF \
+    -DENABLE_PRECOMPILED_HEADERS=ON \
+    -DENABLE_CCACHE=ON \
+    -DOPENCV_SKIP_CMAKE_ROOT_CONFIG=ON \
+    -DOPENCV_ENABLE_PKG_CONFIG=ON \
+    -DOPENCV_GENERATE_PKGCONFIG=ON \
+    -DOPENCV_GENERATE_SETUPVARS=ON \
+    -DOPENCV_ENABLE_MEMORY_SANITIZER=ON \
+    -DOPENCV_ENABLE_ALLOCATOR_STATS=ON \
+    -DOPENCV_ALLOCATOR_STATS_COUNTER_TYPE=int64_t \
     -DBUILD_WITH_DEBUG_INFO=OFF \
+    -DBUILD_SHARED_LIBS=ON \
+    -DBUILD_opencv_apps=ON \
     -DBUILD_DOCS=OFF \
     -DBUILD_TESTS=OFF \
     -DBUILD_PERF_TESTS=OFF \
-    -DBUILD_PROTOBUF=OFF \
-    -DPROTOBUF_UPDATE_FILES=ON \
     -DBUILD_EXAMPLES=OFF \
     -DINSTALL_C_EXAMPLES=OFF \
     -DINSTALL_PYTHON_EXAMPLES=OFF \
+    -DOPENCV_ENABLE_NONFREE=ON \
+    -DOPENCV_EXTRA_MODULES_PATH=../${_realname}_contrib-${pkgver}/modules \
+    -DWITH_PNG=ON \
+    -DWITH_JPEG=ON \
+    -DWITH_TIFF=ON \
+    -DWITH_WEBP=ON \
+    -DWITH_OPENJPEG=ON \
+    -DWITH_JASPER=ON \
+    -DWITH_OPENEXR=ON \
+    -DWITH_IMGCODEC_HDR=ON \
+    -DWITH_IMGCODEC_SUNRASTER=ON \
+    -DWITH_IMGCODEC_PXM=ON \
+    -DWITH_IMGCODEC_PFM=ON \
+    -DWITH_GDAL=ON \
+    -DWITH_GDCM=ON \
+    -DVIDEOIO_ENABLE_PLUGINS=OFF \
+    -DWITH_FFMPEG=OFF \
+    -DWITH_GSTREAMER=OFF \
+    -DWITH_MSMF=ON \
+    -DWITH_MSMF_DXVA=ON \
+    -DWITH_DSHOW=ON \
+    -DWITH_MFX=OFF \
+    -DWITH_GPHOTO2=OFF \
+    -DHIGHGUI_ENABLE_PLUGINS=OFF \
+    -DWITH_WIN32UI=ON \
     -DWITH_GTK=OFF \
     -DWITH_QT=OFF \
     -DWITH_VTK=OFF \
-    -DWITH_GDAL=OFF \
-    -DWITH_MSMF=OFF \
-    -DWITH_FFMPEG=ON \
-    -DWITH_GSTREAMER=OFF \
-    -DWITH_OPENJPEG=ON \
-    -DWITH_OPENCL_D3D11_NV=OFF \
+    -DWITH_OPENGL=ON \
+    -DWITH_DIRECTX=ON \
+    -DPARALLEL_ENABLE_PLUGINS=ON \
+    -DWITH_TBB=ON \
+    -DWITH_CUDA=OFF \
+    -DWITH_OPENCL=ON \
+    -DWITH_INF_ENGINE=ON \
+    -DOPENCV_DNN_OPENCL=ON \
+    -DWITH_EIGEN=ON \
+    -DWITH_OPENBLAS=ON \
+    -DWITH_PROTOBUF=ON \
+    -DPROTOBUF_UPDATE_FILES=OFF \
+    -DWITH_VULKAN=OFF \
+    -DWITH_JULIA=OFF \
+    -DBUILD_opencv_bioinspired=ON \
     -DOPENCV_SKIP_PYTHON_LOADER=ON \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_SKIP_RPATH=ON \
-    -DENABLE_PRECOMPILED_HEADERS=OFF \
-    -DOPENCV_EXTRA_MODULES_PATH=../${_realname}_contrib-${pkgver}/modules \
     -DBUILD_opencv_python2=OFF \
     -DBUILD_opencv_python3=ON \
     -DPYTHON_DEFAULT_EXECUTABLE=${MINGW_PREFIX}/bin/python \
     -DPYTHON3_EXECUTABLE=${MINGW_PREFIX}/bin/python \
     -DPYTHON3_PACKAGES_PATH=$(cygpath -u $(${MINGW_PREFIX}/bin/python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")) \
     -DOPENCV_PYTHON3_VERSION=$(${MINGW_PREFIX}/bin/python -c "import sys;sys.stdout.write('.'.join(map(str, sys.version_info[:2])))") \
-    -DBUILD_opencv_bioinspired=OFF \
-    -DOPENCV_GENERATE_PKGCONFIG=ON \
     -DOPENCV_PYTHON_INSTALL_PATH=lib \
-    -DOPENCV_SKIP_CMAKE_ROOT_CONFIG=ON \
+    -DBUILD_JAVA=OFF \
+    -DOPENCV_JNI_INSTALL_PATH=lib \
     ../${_realname}-${pkgver}
 
   make


### PR DESCRIPTION
updated to OpenCV 4.5.5, it builds and works fine on mingw64/ucrt64 (not staging). clang64 doesn't seem to work on my computer utf-8 characters are strangely added to file names and clang++ build fail.

this pull request is cleaner, some deps have been removed because I think they were too havy (even with some cyclique deps on opencv) and not really of any use (if someone needs them, they simply can rebuild the package to fit their needs).

python biding fails if any of depencies are not installed (even optional), thus I simply removed deps that are not relevant, and added python-numpy as dep, so that one can do opencv mock more easily.

there is an opened issue #11005,  for building on clang64.

I'm not sure of license concern, please someone with  better knowledge to have a look.