### PR TITLE
postgresql: update to 14.2

### DIFF
--- a/mingw-w64-postgresql/PKGBUILD
+++ b/mingw-w64-postgresql/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=postgresql
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=14.0
-pkgrel=2
+pkgver=14.2
+pkgrel=1
 pkgdesc="Libraries for use with PostgreSQL (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -31,9 +31,9 @@ source=("https://ftp.postgresql.org/pub/source/v${pkgver}/postgresql-${pkgver}.t
         postgresql-9.4.1-mingw-enable-readline.patch
         postgresql-13.1-disable-wsa-invalid-event-static-assert.patch
         postgresql-13.1-pgevent-def.patch
-        postgresql-14.0-use-mingw-setjmp-on-clang-arm64.patch)
+        postgresql-14.0-use-mingw-setjmp-on-ucrt.patch)
 
-sha256sums=('ee2ad79126a7375e9102c4db77c4acae6ae6ffe3e082403b88826d96d927a122'
+sha256sums=('2cf78b2e468912f8101d695db5340cf313c2e9f68a612fb71427524e8c9a977a'
             '607217b422349770d25af20f88e4a7925e68bb934232dff368c2ee59f24249a4'
             '57c1e9b75c042af591b05b9dda60e6327b5c364bb5adc2675da8a48b47e11b81'
             '1afbe207b0fe8c4178cc3f8cb4e3923c7c000207d22ec4f3875d6358b312a1d5'
@@ -41,7 +41,7 @@ sha256sums=('ee2ad79126a7375e9102c4db77c4acae6ae6ffe3e082403b88826d96d927a122'
             '51c72fbd380d23cf944165405221912a277b9be99e285479772b39cacbbf384f'
             '72c14a78eeafdd3c9a13c3e124b1941b5da090488c7bd73f08b3cd78bacd07d5'
             'ffaecbe5a38877728bddbf307b379b39c645dd1ffe53aa8d84dfa96807494764'
-            '115f78095f1eee394301d939b1536a906189d212ab17c908042ae3954eda33e3')
+            'e65f664644faa5cbd392c575a13bace31799e19d16be64cee362ba0e4a361c23')
 
 prepare() {
   cd ${srcdir}/postgresql-${pkgver}
@@ -52,7 +52,7 @@ prepare() {
   #patch -p1 -i ${srcdir}/postgresql-9.4.1-mingw-enable-readline.patch
   patch -p1 -i ${srcdir}/postgresql-13.1-disable-wsa-invalid-event-static-assert.patch
   patch -p1 -i ${srcdir}/postgresql-13.1-pgevent-def.patch
-  patch -p1 -i ${srcdir}/postgresql-14.0-use-mingw-setjmp-on-clang-arm64.patch
+  patch -p1 -i ${srcdir}/postgresql-14.0-use-mingw-setjmp-on-ucrt.patch
 
   sed -s "s|2\\.69|2\\.71|g" -i configure.ac
   autoreconf -fiv
@@ -94,7 +94,7 @@ build() {
 
 check() {
   cd "${srcdir}/build-${CARCH}"
-  make check || true
+  make check
 }
 
 package() {
@@ -136,9 +136,18 @@ package() {
   # hopefully one day we won't need this hack.
   for f in clusterdb createdb createuser dropdb dropuser initdb pg_basebackup pg_dump pg_dumpall pg_receivewal pg_restore psql reindexdb vacuumdb; do
     mv "${pkgdir}"${MINGW_PREFIX}/bin/${f}.exe "${pkgdir}"${MINGW_PREFIX}/bin/${f}_exe
-    _exename="${f}"
-    echo "#!/usr/bin/env bash" > "${pkgdir}${MINGW_PREFIX}/bin/${_exename}"
-    echo '/usr/bin/winpty "$( dirname ${BASH_SOURCE[0]} )/'${_exename}'.exe" "$@"' >> "${pkgdir}${MINGW_PREFIX}/bin/${_exename}"
+    cat > "${pkgdir}${MINGW_PREFIX}/bin/${f}" <<END
+#!/usr/bin/env bash
+
+EXE="\$( dirname \${BASH_SOURCE[0]} )/${f}.exe"
+
+if [ -t 0 -a -t 1 -a -x /usr/bin/winpty ]; then
+  /usr/bin/winpty \$EXE "\$@"
+else
+  exec \$EXE "\$@"
+fi
+END
+    chmod +x "${pkgdir}${MINGW_PREFIX}/bin/${f}"
     mv "${pkgdir}"${MINGW_PREFIX}/bin/${f}_exe "${pkgdir}"${MINGW_PREFIX}/bin/${f}.exe
   done
 }

--- a/mingw-w64-postgresql/postgresql-14.0-use-mingw-setjmp-on-ucrt.patch
+++ b/mingw-w64-postgresql/postgresql-14.0-use-mingw-setjmp-on-ucrt.patch
@@ -7,17 +7,17 @@ index c8ede08..e445524 100644
   */
  #ifdef WIN32
 -#ifdef __MINGW64__
-+#if defined(__MINGW64__) && (defined(__i386__) || defined(__x86_64__))
++#if defined(__MINGW64__) && !defined(_UCRT)
  typedef intptr_t sigjmp_buf[5];
  #define sigsetjmp(x,y) __builtin_setjmp(x)
  #define siglongjmp __builtin_longjmp
 -#else							/* !__MINGW64__ */
-+#else							/* !(defined(__MINGW64__) && (defined(__i386__) || defined(__x86_64__))) */
++#else							/* !defined(__MINGW64__) || defined(_UCRT) */
  #define sigjmp_buf jmp_buf
  #define sigsetjmp(x,y) setjmp(x)
  #define siglongjmp longjmp
 -#endif							/* __MINGW64__ */
-+#endif							/* defined(__MINGW64__) && (defined(__i386__) || defined(__x86_64__)) */
++#endif							/* defined(__MINGW64__) && !defined(_UCRT) */
  #endif							/* WIN32 */
  
 +


### PR DESCRIPTION
- Use `setjmp` instead of `__builtin_setjmp` on UCRT
- Improve winpty wrappers (based on github-cli)
- tests actually pass, so remove `|| true`