### PR TITLE
rrdtool: Disable BUILD_DATE

### DIFF
--- a/mingw-w64-rrdtool/001-rrdtool-1.8.0-BUILD_DATE.patch
+++ b/mingw-w64-rrdtool/001-rrdtool-1.8.0-BUILD_DATE.patch
@@ -1,0 +1,50 @@
+diff --git a/configure.ac b/configure.ac
+index 4d234585..ad3dd0b4 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -693,13 +693,6 @@ fi
+ AC_MSG_CHECKING(Perl Modules to build)
+ AC_MSG_RESULT(${COMP_PERL:-No Perl Modules will be built})
+ 
+-# Use reproducible build date and time
+-if test "$SOURCE_DATE_EPOCH"; then
+-	DATE_FMT="%d %b %Y %H:%M:%S"
+-	BUILD_DATE=$(LC_ALL=C date -u -d "@$SOURCE_DATE_EPOCH" "+$DATE_FMT")
+-	AC_DEFINE_UNQUOTED([BUILD_DATE], ["$BUILD_DATE"], [Use reproducible build date])
+-fi
+-
+ # Options to pass when configuring perl module
+ langpref=$prefix
+ test "$langpref" = '$(DESTDIR)NONE' && langpref='$(DESTDIR)'$ac_default_prefix
+diff --git a/src/rrd_cgi.c b/src/rrd_cgi.c
+index e7eb5be5..241368d0 100644
+--- a/src/rrd_cgi.c
++++ b/src/rrd_cgi.c
+@@ -680,11 +680,7 @@ static char *rrdgetinternal(
+         if (strcasecmp(args[0], "VERSION") == 0) {
+             return stralloc(PACKAGE_VERSION);
+         } else if (strcasecmp(args[0], "COMPILETIME") == 0) {
+-#ifdef BUILD_DATE
+-            return stralloc(BUILD_DATE);
+-#else
+             return stralloc(__DATE__ " " __TIME__);
+-#endif
+         } else {
+             return stralloc("[ERROR: internal unknown argument]");
+         }
+diff --git a/src/rrd_tool.c b/src/rrd_tool.c
+index d598cb1d..f3484bc9 100644
+--- a/src/rrd_tool.c
++++ b/src/rrd_tool.c
+@@ -309,11 +309,7 @@ static void PrintUsage(
+         else if (!strcmp(cmd, "pwd"))
+             help_cmd = C_PWD;
+     }
+-#ifdef BUILD_DATE
+-    fprintf(stdout, _(help_main), PACKAGE_VERSION, BUILD_DATE);
+-#else
+     fprintf(stdout, _(help_main), PACKAGE_VERSION, __DATE__, __TIME__);
+-#endif
+     fflush(stdout);
+     switch (help_cmd) {
+     case C_NONE:

--- a/mingw-w64-rrdtool/PKGBUILD
+++ b/mingw-w64-rrdtool/PKGBUILD
@@ -4,7 +4,7 @@ _realname=rrdtool
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.8.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Round Robin Database (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -15,12 +15,15 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
 depends=("${MINGW_PACKAGE_PREFIX}-glib2"
          "${MINGW_PACKAGE_PREFIX}-pango"
          "${MINGW_PACKAGE_PREFIX}-libxml2")
-source=("https://github.com/oetiker/rrdtool-1.x/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('bd37614137d7a8dc523359648eb2a81631a34fd91a82ed5581916a52c08433f4')
+source=("https://github.com/oetiker/rrdtool-1.x/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz"
+        "001-rrdtool-1.8.0-BUILD_DATE.patch")
+sha256sums=('bd37614137d7a8dc523359648eb2a81631a34fd91a82ed5581916a52c08433f4'
+            'f023d0546bad1bfc5f662bfd26fffb62d5a2f313b4b6af4d8120ed5fc258b475')
 
 prepare() {
   cp -Rf "${srcdir}/${_realname}-${pkgver}" "${srcdir}"/build-${CARCH}
   cd "${srcdir}"/build-${CARCH}
+  patch -p1 -i ${srcdir}/001-rrdtool-1.8.0-BUILD_DATE.patch
   ./bootstrap
 }
 


### PR DESCRIPTION
Disable `BUILD_DATE`, which is currently broken [1]

- Add patch:
  `001-rrdtool-1.8.0-BUILD_DATE.patch`
- Fixes segfault when running "rrdtool --help"

[1] https://github.com/oetiker/rrdtool-1.x/pull/1102#issuecomment-1075586404
