### PR TITLE
dnslookup: fix build with go 1.18

### DIFF
--- a/mingw-w64-dnslookup/PKGBUILD
+++ b/mingw-w64-dnslookup/PKGBUILD
@@ -4,18 +4,25 @@ _realname=dnslookup
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.5.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Simple command line utility to make DNS lookups (mingw-w64)'
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://github.com/ameshkov/dnslookup"
 license=('MIT')
-makedepends=("${MINGW_PACKAGE_PREFIX}-go" "${MINGW_PACKAGE_PREFIX}-cc")
-checkdepends=("git")
+makedepends=("${MINGW_PACKAGE_PREFIX}-go" "${MINGW_PACKAGE_PREFIX}-cc" "git")
 optdepends=("git: To interact with repositories")
 options=('!strip')
-source=("$_realname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
-sha256sums=('b09fc07d917cfe3d5b08bdf2e92aa9ee63928d86e3477724656dae5a50683c45')
+source=("$_realname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz"
+        "update-quic-go.patch")
+sha256sums=('b09fc07d917cfe3d5b08bdf2e92aa9ee63928d86e3477724656dae5a50683c45'
+            '133df1412df92e38b6b5b0b3d3fa593b02a5824ea3a23b05a1868422dde8d859')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+  patch -Nbp1 -i "${srcdir}/update-quic-go.patch"
+}
+
 build() {
     cd "${_realname}-$pkgver"
     export GOOS=windows

--- a/mingw-w64-dnslookup/update-quic-go.patch
+++ b/mingw-w64-dnslookup/update-quic-go.patch
@@ -1,0 +1,45 @@
+diff -Nur dnslookup-1.5.1.orig/go.mod dnslookup-1.5.1/go.mod
+--- dnslookup-1.5.1.orig/go.mod	2022-03-23 02:15:33.254764700 +0000
++++ dnslookup-1.5.1/go.mod	2022-03-23 02:16:39.943257500 +0000
+@@ -17,9 +17,10 @@
+ 	github.com/fsnotify/fsnotify v1.5.1 // indirect
+ 	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
+ 	github.com/joomcode/errorx v1.0.3 // indirect
+-	github.com/lucas-clemente/quic-go v0.24.0 // indirect
+-	github.com/marten-seemann/qtls-go1-16 v0.1.4 // indirect
+-	github.com/marten-seemann/qtls-go1-17 v0.1.0 // indirect
++	github.com/lucas-clemente/quic-go v0.26.0 // indirect
++	github.com/marten-seemann/qtls-go1-16 v0.1.5 // indirect
++	github.com/marten-seemann/qtls-go1-17 v0.1.1 // indirect
++	github.com/marten-seemann/qtls-go1-18 v0.1.1 // indirect
+ 	github.com/nxadm/tail v1.4.8 // indirect
+ 	github.com/onsi/ginkgo v1.16.5 // indirect
+ 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
+diff -Nur dnslookup-1.5.1.orig/go.sum dnslookup-1.5.1/go.sum
+--- dnslookup-1.5.1.orig/go.sum	2022-03-23 02:15:33.259423200 +0000
++++ dnslookup-1.5.1/go.sum	2022-03-23 02:16:39.961262500 +0000
+@@ -100,6 +100,8 @@
+ github.com/lucas-clemente/quic-go v0.21.1/go.mod h1:U9kFi5LKbNIlU30dkuM9vxmTxWq4Bvzee/MjBI+07UA=
+ github.com/lucas-clemente/quic-go v0.24.0 h1:ToR7SIIEdrgOhgVTHvPgdVRJfgVy+N0wQAagH7L4d5g=
+ github.com/lucas-clemente/quic-go v0.24.0/go.mod h1:paZuzjXCE5mj6sikVLMvqXk8lJV2AsqtJ6bDhjEfxx0=
++github.com/lucas-clemente/quic-go v0.26.0 h1:ALBQXr9UJ8A1LyzvceX4jd9QFsHvlI0RR6BkV16o00A=
++github.com/lucas-clemente/quic-go v0.26.0/go.mod h1:AzgQoPda7N+3IqMMMkywBKggIFo2KT6pfnlrQ2QieeI=
+ github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
+ github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+ github.com/marten-seemann/qpack v0.2.1/go.mod h1:F7Gl5L1jIgN1D11ucXefiuJS9UMVP2opoCp2jDKb7wc=
+@@ -107,9 +109,15 @@
+ github.com/marten-seemann/qtls-go1-16 v0.1.3/go.mod h1:gNpI2Ol+lRS3WwSOtIUUtRwZEQMXjYK+dQSBFbethAk=
+ github.com/marten-seemann/qtls-go1-16 v0.1.4 h1:xbHbOGGhrenVtII6Co8akhLEdrawwB2iHl5yhJRpnco=
+ github.com/marten-seemann/qtls-go1-16 v0.1.4/go.mod h1:gNpI2Ol+lRS3WwSOtIUUtRwZEQMXjYK+dQSBFbethAk=
++github.com/marten-seemann/qtls-go1-16 v0.1.5 h1:o9JrYPPco/Nukd/HpOHMHZoBDXQqoNtUCmny98/1uqQ=
++github.com/marten-seemann/qtls-go1-16 v0.1.5/go.mod h1:gNpI2Ol+lRS3WwSOtIUUtRwZEQMXjYK+dQSBFbethAk=
+ github.com/marten-seemann/qtls-go1-17 v0.1.0-beta.1.2/go.mod h1:fz4HIxByo+LlWcreM4CZOYNuz3taBQ8rN2X6FqvaWo8=
+ github.com/marten-seemann/qtls-go1-17 v0.1.0 h1:P9ggrs5xtwiqXv/FHNwntmuLMNq3KaSIG93AtAZ48xk=
+ github.com/marten-seemann/qtls-go1-17 v0.1.0/go.mod h1:fz4HIxByo+LlWcreM4CZOYNuz3taBQ8rN2X6FqvaWo8=
++github.com/marten-seemann/qtls-go1-17 v0.1.1 h1:DQjHPq+aOzUeh9/lixAGunn6rIOQyWChPSI4+hgW7jc=
++github.com/marten-seemann/qtls-go1-17 v0.1.1/go.mod h1:C2ekUKcDdz9SDWxec1N/MvcXBpaX9l3Nx67XaR84L5s=
++github.com/marten-seemann/qtls-go1-18 v0.1.1 h1:qp7p7XXUFL7fpBvSS1sWD+uSqPvzNQK43DH+/qEkj0Y=
++github.com/marten-seemann/qtls-go1-18 v0.1.1/go.mod h1:mJttiymBAByA49mhlNZZGrH5u1uXYZJ+RW28Py7f4m4=
+ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+ github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
+ github.com/miekg/dns v1.1.40/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=


### PR DESCRIPTION
enable for clang32 and  clangarm64