### PR TITLE
cgns: update to 4.3.0

### DIFF
--- a/mingw-w64-cgns/PKGBUILD
+++ b/mingw-w64-cgns/PKGBUILD
@@ -3,33 +3,35 @@
 _realname=cgns
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.2.0
+pkgver=4.3.0
 pkgrel=1
 pkgdesc="CFD General Notation System library and tools (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://cgns.github.io"
 license=('zlib')
-makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-cc"
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 depends=("${MINGW_PACKAGE_PREFIX}-hdf5")
 source=("${_realname}-${pkgver}.tar.gz"::https://github.com/CGNS/CGNS/archive/v${pkgver}.tar.gz)
-sha256sums=('090ec6cb0916d90c16790183fc7c2bd2bd7e9a5e3764b36c8196ba37bf1dc817')
-
-prepare() {
-  cd ${srcdir}/${_realname}-${pkgver}
-}
+sha256sums=('7709eb7d99731dea0dd1eff183f109eaef8d9556624e3fbc34dc5177afc0a032')
 
 build() {
-  [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}
-  mkdir -p build-${MINGW_CHOST}
-  cd build-${MINGW_CHOST}
+  [[ -d build-${MSYSTEM} ]] && rm -rf build-${MSYSTEM}
+  mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
+
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe \
     -G "Ninja" \
-    -DCMAKE_BUILD_TYPE=Release \
+    ${extra_config[@]} \
     -DCGNS_ENABLE_HDF5=ON \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     ../${_realname}-${pkgver}
@@ -38,8 +40,8 @@ build() {
 }
 
 package() {
-  cd build-${MINGW_CHOST}
-  DESTDIR=${pkgdir} ${MINGW_PREFIX}/bin/cmake.exe --build ./ --target install
+  cd build-${MSYSTEM}
+  DESTDIR=${pkgdir} ${MINGW_PREFIX}/bin/cmake.exe --install .
 
   # license
   install -D -m644 ${srcdir}/${_realname}-${pkgver}/license.txt \


### PR DESCRIPTION
No package depends on cgns, so no need to rebuild anything.