### PR TITLE
petsc: update to 3.16.5

### DIFF
--- a/mingw-w64-petsc/PKGBUILD
+++ b/mingw-w64-petsc/PKGBUILD
@@ -32,21 +32,22 @@
 _realname=petsc
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-${_realname}-build")
-pkgver=3.16.1
+pkgver=3.16.5
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 pkgdesc='Sparse iterative (non)linear solver package (mingw-w64)'
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
-         "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran"	
-         "${MINGW_PACKAGE_PREFIX}-openblas"
+         $([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] && \
+           echo "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran" "${MINGW_PACKAGE_PREFIX}-openblas" || \
+           echo "${MINGW_PACKAGE_PREFIX}-openmp" "${MINGW_PACKAGE_PREFIX}-f2cblaslapack")
          "${MINGW_PACKAGE_PREFIX}-parmetis"
          "${MINGW_PACKAGE_PREFIX}-metis"
          "${MINGW_PACKAGE_PREFIX}-hwloc"
          "${MINGW_PACKAGE_PREFIX}-msmpi")
 makedepends=('python'
              "${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-gcc-fortran")
+             $([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] && echo "${MINGW_PACKAGE_PREFIX}-gcc-fortran"))
 optdepends=("${MINGW_PACKAGE_PREFIX}-tcl: build & run test suite")
 options=('strip' 'staticlibs')
 license=('2-clause BSD')
@@ -58,7 +59,7 @@ source=("https://ftp.mcs.anl.gov/pub/petsc/release-snapshots/${_realname}-lite-$
         'petsc-mat.test'
         '0001-mpi-detection-override.patch')
 noextract=("${_realname}-lite-${pkgver}.tar.gz")
-sha256sums=('909cf7bce7b6a0ddb2580a1ac9502aa01631ec4105c716594c1804f0ee1ea06a'
+sha256sums=('7de8570eeb94062752d82a83208fc2bafc77b3f515023a4c14d8ff9440e66cac'
             'ec5072630e1c0309fe383669e9187790cd135a393c67bc4bc35cf60b0ba396ff'
             '15c7af25b91406d5fe5f26cfe00963b6cfde1c3dd466eb25f1b6fae299934966'
             '9662cc4104726c714f7961aba6f8c93bfb85f3d3f89b4908b0a55aedab41ca31'
@@ -69,82 +70,83 @@ prepare() {
   mkdir -p $srcdir/build-${MSYSTEM} && cd $srcdir/build-${MSYSTEM}
   tar xzf $srcdir/${_realname}-lite-${pkgver}.tar.gz
   cd ${_realname}-${pkgver}
-  for p in ${source[*]:5}; do
-    patch -p1 -i "$srcdir/$p"
-  done
+  patch -p1 -i "$srcdir/0001-mpi-detection-override.patch"
 }
 
 # Optimized build flavors
-builds='dso dto dmo zso zto zmo sso sto smo cso cto cmo'
+builds='dso dto zso zto sso sto cso cto'
+if [[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]]; then
+  builds+=' dmo zmo smo cmo'
+fi
 
 # Additional debugging build flavors, disabled by default due to huge library sizes
 # builds="$builds dsg dtg dmg zsg ztg zmg ssg stg smg csg ctg cmg"
 
 _petsc() {
-  opts="--with-single-library=1 --disable-shared --with-windows-graphics=0 --with-x=0 --with-openblas=1 --with-hwloc=1 --with-openblas-dir=$MINGW_PREFIX"
-  ld=g++
-  pc="openblas hwloc"
-  case "${CARCH}" in
-    i686)
-      xflags=-msse # SSE support is required for proper FP trapping
-      ;;
-  esac
+  opts="--with-single-library=1 --disable-shared --with-windows-graphics=0 --with-x=0 --with-hwloc=1"
+  pc="hwloc"
+  cflags="$CFLAGS"
+  cxxflags="$CXXFLAGS"
+  fflags="$CFLAGS"
+  if [[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]]; then
+    opts+=" --with-openblas=1 --with-openblas-dir=$MINGW_PREFIX"
+    ldflags="-lgfortran -lquadmath"
+    pc+=" openblas"
+  else
+    opts+=" --with-fc=0 --with-blas-lib=libblas.a --with-lapack-lib=liblapack.a"
+    ldflags="-lblas -llapack"
+  fi
+  ld=${CXX}
   iflags=
-  ldflags="-lgfortran -lquadmath"
   desc=
   case $1 in
     ?m?)
-      opts="$opts --with-mpi=1 --with-mpi-compilers=1 --with-pthread=0 --with-openmp=0 --with-metis=1 --with-parmetis=1"
-      pc="$pc parmetis msmpi"
+      opts+=" --with-mpi=1 --with-mpi-compilers=1 --with-pthread=0 --with-openmp=0 --with-metis=1 --with-parmetis=1"
+      pc+=" parmetis msmpi"
       ld=mpicxx
       desc="MPI parallel"
     ;;
     ?t?)
-      opts="$opts --with-mpi=0 --with-pthread=0 --with-openmp=1"
+      opts+=" --with-cc=${CC} --with-cxx=${CXX} --with-mpi=0 --with-pthread=0 --with-openmp=1"
       iflags="$iflags -I\${includedir}/mpiuni"
       ldflags="-fopenmp $ldflags"
       desc="OpenMP multithreaded"
     ;;
     ?s?)
-      opts="$opts --with-mpi=0 --with-pthread=0 --with-openmp=0"
+      opts+=" --with-cc=${CC} --with-cxx=${CXX} --with-mpi=0 --with-pthread=0 --with-openmp=0"
       iflags="$iflags -I\${includedir}/mpiuni"
       desc="Sequential"
     ;;
   esac
   case $1 in
     z*|d*)
-      opts="$opts --with-precision=double"
-      desc="$desc double precision"
+      opts+=" --with-precision=double"
+      desc+=" double precision"
     ;;
     c*|s*)
-      opts="$opts --with-precision=single"
-      desc="$desc single precision"
+      opts+=" --with-precision=single"
+      desc+=" single precision"
     ;;
   esac
   case $1 in
     d*|s*)
-      opts="$opts --with-scalar-type=real"
+      opts+=" --with-scalar-type=real"
     ;;
     z*|c*)
-      opts="$opts --with-scalar-type=complex"
-      desc="$desc complex"
+      opts+=" --with-scalar-type=complex"
+      desc+=" complex"
     ;;
   esac
   case $1 in
     *o)
-      opts="$opts --with-debugging=0"
-      cflags="$CFLAGS $xflags"
-      cxxflags="$CXXFLAGS $xflags"
-      fflags="$CFLAGS $xflags"
-      options=('strip' 'staticlibs')
+      opts+=" --with-debugging=0"
     ;;
     *g)
-      opts="$opts --with-debugging=1"
+      opts+=" --with-debugging=1"
       debug="-g -Og"
-      cflags="$CFLAGS $debug $xflags"
-      cxxflags="$CXXFLAGS $debug $xflags"
-      fflags="$CFLAGS $debug $xflags"
-      options=('!strip' 'staticlibs')
+      cflags+=" $debug"
+      cxxflags+=" $debug"
+      fflags+=" $debug"
     ;;
   esac
 }
@@ -156,13 +158,13 @@ build() {
     export PETSC_DIR=`pwd`
     /usr/bin/python configure --PETSC_ARCH=${build} ${opts} CFLAGS="$cflags" FFLAGS="$fflags" CXXFLAGS="$cxxflags" CPPFLAGS="$CPPFLAGS" LDFLAGS="$LDFLAGS" MAKEFLAGS="$MAKEFLAGS"
     make PETSC_ARCH=${build} all
-  	(
-  		cd ${build}/lib
-  	  case ${build} in
-    		*o) strip -S *.a ;;
-  	  esac
-  		${ld} -shared -Wl,--enable-auto-import -Wl,--export-all-symbols -o lib${_realname}-${build}.dll -Wl,--out-implib,lib${_realname}.dll.a -Wl,--whole-archive lib${_realname}.a -Wl,--no-whole-archive ${ldflags} $(pkg-config ${pc} --libs)
-  	)
+    (
+      cd ${build}/lib
+      case ${build} in
+        *o) strip -S *.a ;;
+      esac
+      ${ld} -shared -Wl,--enable-auto-import -Wl,--export-all-symbols -o lib${_realname}-${build}.dll -Wl,--out-implib,lib${_realname}.dll.a -Wl,--whole-archive lib${_realname}.a -Wl,--no-whole-archive ${ldflags} $(pkg-config ${pc} --libs)
+    )
   done
 }
 
@@ -194,17 +196,20 @@ _package() {
   )
   for build in ${builds}; do
     _petsc ${build}
-  	(
-  		cd ${build}/lib
-  		mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/${_realname}/${build}
-  		cp *.a ${pkgdir}${MINGW_PREFIX}/lib/${_realname}/${build}
-  		cp *.dll ${pkgdir}${MINGW_PREFIX}/bin
-  	)
-  	(
-  		cd ${build}/include
-  		mkdir -p ${pkgdir}${MINGW_PREFIX}/include/${_realname}/${build}
-  		cp *.{h,mod} ${pkgdir}${MINGW_PREFIX}/include/${_realname}/${build}
-  	)
+    (
+      cd ${build}/lib
+      mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/${_realname}/${build}
+      cp *.a ${pkgdir}${MINGW_PREFIX}/lib/${_realname}/${build}
+      cp *.dll ${pkgdir}${MINGW_PREFIX}/bin
+    )
+    (
+      cd ${build}/include
+      mkdir -p ${pkgdir}${MINGW_PREFIX}/include/${_realname}/${build}
+      cp *.h ${pkgdir}${MINGW_PREFIX}/include/${_realname}/${build}
+      if [[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]]; then
+        cp *.mod ${pkgdir}${MINGW_PREFIX}/include/${_realname}/${build}
+      fi
+    )
     echo "
       prefix=${MINGW_PREFIX}
       libdir=\${prefix}/lib/${_realname}


### PR DESCRIPTION
It also fix building on clang64, but without MPI which I failed to fix unfortunately.