### PR TITLE
rclone: depend on cc not gcc, makedepend on git

### DIFF
--- a/mingw-w64-rclone/PKGBUILD
+++ b/mingw-w64-rclone/PKGBUILD
@@ -6,14 +6,15 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_librealname}")
 pkgver=1.58.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Cloud-aware file synchonization utility (mingw-w64)'
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' '!clang32' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://rclone.org/'
 license=('MIT')
-makedepends=("${MINGW_PACKAGE_PREFIX}-go"
-             "${MINGW_PACKAGE_PREFIX}-gcc"
+makedepends=("git"
+             "${MINGW_PACKAGE_PREFIX}-go"
+             "${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-tools")
 source=("https://downloads.rclone.org/v${pkgver}/${_realname}-v${pkgver}.tar.gz")
 sha256sums=('8e0c49fad69525d1219415d2f0651fd243ddf02291fd95e91d2b074d4858c31f')


### PR DESCRIPTION
enable for clang32

unfortunately clangarm64 failed with
```
# github.com/rclone/rclone/librclone
.debug_frame+1MB: addpesym: could not map .debug_frame+1MB symbol with non .text or .rdata or .data section
.debug_frame+2MB: addpesym: could not map .debug_frame+2MB symbol with non .text or .rdata or .data section
```
so not enabling that.  (same error as https://github.com/msys2/MINGW-packages/pull/11069#issuecomment-1075774548)