### PR TITLE
libvips: update to 8.12.2

### DIFF
--- a/mingw-w64-libvips/PKGBUILD
+++ b/mingw-w64-libvips/PKGBUILD
@@ -3,28 +3,31 @@
 _realname=libvips
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=8.12.1
-pkgrel=2
+pkgver=8.12.2
+pkgrel=1
 pkgdesc="A fast image processing library with low memory needs (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
-url="https://libvips.github.io/libvips/"
+url="https://libvips.org/"
 license=("LGPL-2.1")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
              "${MINGW_PACKAGE_PREFIX}-gtk-doc"
              "${MINGW_PACKAGE_PREFIX}-openmp"
              "${MINGW_PACKAGE_PREFIX}-autotools")
-depends=("${MINGW_PACKAGE_PREFIX}-cairo"
+depends=("${MINGW_PACKAGE_PREFIX}-aom"
+         "${MINGW_PACKAGE_PREFIX}-cairo"
          "${MINGW_PACKAGE_PREFIX}-cfitsio"
+         "${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-fftw"
-         "${MINGW_PACKAGE_PREFIX}-giflib"
          "${MINGW_PACKAGE_PREFIX}-glib2"
          "${MINGW_PACKAGE_PREFIX}-gobject-introspection-runtime"
          "${MINGW_PACKAGE_PREFIX}-imagemagick"
          "${MINGW_PACKAGE_PREFIX}-lcms2"
+         "${MINGW_PACKAGE_PREFIX}-libde265"
          "${MINGW_PACKAGE_PREFIX}-libexif"
          "${MINGW_PACKAGE_PREFIX}-libgsf"
+         "${MINGW_PACKAGE_PREFIX}-libheif"
          "${MINGW_PACKAGE_PREFIX}-libimagequant"
          "${MINGW_PACKAGE_PREFIX}-libpng"
          "${MINGW_PACKAGE_PREFIX}-librsvg"
@@ -32,12 +35,15 @@ depends=("${MINGW_PACKAGE_PREFIX}-cairo"
          "${MINGW_PACKAGE_PREFIX}-libwebp"
          "${MINGW_PACKAGE_PREFIX}-matio"
          "${MINGW_PACKAGE_PREFIX}-openexr"
+         "${MINGW_PACKAGE_PREFIX}-openjpeg"
          "${MINGW_PACKAGE_PREFIX}-orc"
          "${MINGW_PACKAGE_PREFIX}-pango"
-         "${MINGW_PACKAGE_PREFIX}-poppler")
+         "${MINGW_PACKAGE_PREFIX}-poppler"
+         "${MINGW_PACKAGE_PREFIX}-x265")
+
 options=('staticlibs' 'strip')
 source=("https://github.com/libvips/libvips/releases/download/v${pkgver}/vips-${pkgver}.tar.gz")
-sha256sums=('474d8439244cd26c504812fd623259f806c32553b38d2a54798c9766135f5a5c')
+sha256sums=('565252992aff2c7cd10c866c7a58cd57bc536e03924bde29ae0f0cb9e074010b')
 
 
 prepare() {
@@ -57,7 +63,7 @@ build() {
     --target=${MINGW_CHOST} \
     --enable-shared \
     --disable-static \
-    --without-openslide
+    --disable-deprecated
 
   make
 }

--- a/mingw-w64-libvips/PKGBUILD
+++ b/mingw-w64-libvips/PKGBUILD
@@ -15,8 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-gtk-doc"
              "${MINGW_PACKAGE_PREFIX}-openmp"
              "${MINGW_PACKAGE_PREFIX}-autotools")
-depends=("${MINGW_PACKAGE_PREFIX}-aom"
-         "${MINGW_PACKAGE_PREFIX}-cairo"
+depends=("${MINGW_PACKAGE_PREFIX}-cairo"
          "${MINGW_PACKAGE_PREFIX}-cfitsio"
          "${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-fftw"
@@ -24,7 +23,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-aom"
          "${MINGW_PACKAGE_PREFIX}-gobject-introspection-runtime"
          "${MINGW_PACKAGE_PREFIX}-imagemagick"
          "${MINGW_PACKAGE_PREFIX}-lcms2"
-         "${MINGW_PACKAGE_PREFIX}-libde265"
          "${MINGW_PACKAGE_PREFIX}-libexif"
          "${MINGW_PACKAGE_PREFIX}-libgsf"
          "${MINGW_PACKAGE_PREFIX}-libheif"
@@ -38,8 +36,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-aom"
          "${MINGW_PACKAGE_PREFIX}-openjpeg"
          "${MINGW_PACKAGE_PREFIX}-orc"
          "${MINGW_PACKAGE_PREFIX}-pango"
-         "${MINGW_PACKAGE_PREFIX}-poppler"
-         "${MINGW_PACKAGE_PREFIX}-x265")
+         "${MINGW_PACKAGE_PREFIX}-poppler")
 
 options=('staticlibs' 'strip')
 source=("https://github.com/libvips/libvips/releases/download/v${pkgver}/vips-${pkgver}.tar.gz")


### PR DESCRIPTION
Plus:

- update project URL
- add support for HEIC
- add support for AVIF
- add support for jpeg2000
- don't build the old vips7 API (saves a few kb)
- remove giflib (libvips now has its own GIF reader)