### PR TITLE
openblas: Fix 64-bit indexing version on MINGW64.

### DIFF
--- a/mingw-w64-openblas/001-index64.patch
+++ b/mingw-w64-openblas/001-index64.patch
@@ -1,0 +1,908 @@
+From 3efbf968f15d93ceec5a64bbfbf5e7a46a1afd47 Mon Sep 17 00:00:00 2001
+From: Aisha Tammy <gentoo@aisha.cc>
+Date: Sun, 1 Nov 2020 02:43:56 +0000
+Subject: [PATCH 1/3] create INDEX64 target
+
+---
+ lapack-netlib/BLAS/CMakeLists.txt             |  4 +-
+ lapack-netlib/BLAS/SRC/CMakeLists.txt         |  6 +-
+ lapack-netlib/BLAS/TESTING/CMakeLists.txt     |  2 +-
+ lapack-netlib/BLAS/blas.pc.in                 |  2 +-
+ lapack-netlib/CBLAS/CMakeLists.txt            | 30 +++++-----
+ lapack-netlib/CBLAS/cblas.pc.in               |  4 +-
+ .../CBLAS/cmake/cblas-config-build.cmake.in   |  4 +-
+ .../CBLAS/cmake/cblas-config-install.cmake.in |  8 +--
+ lapack-netlib/CBLAS/examples/CMakeLists.txt   |  4 +-
+ lapack-netlib/CBLAS/examples/cblas_example1.c |  2 +-
+ lapack-netlib/CBLAS/examples/cblas_example2.c |  2 +-
+ lapack-netlib/CBLAS/src/CMakeLists.txt        | 10 ++--
+ lapack-netlib/CBLAS/testing/CMakeLists.txt    | 24 ++++----
+ .../CMAKE/lapack-config-build.cmake.in        |  2 +-
+ .../CMAKE/lapack-config-install.cmake.in      |  2 +-
+ lapack-netlib/CMakeLists.txt                  | 60 ++++++++++++-------
+ lapack-netlib/LAPACKE/CMakeLists.txt          | 36 +++++------
+ .../cmake/lapacke-config-build.cmake.in       |  6 +-
+ .../cmake/lapacke-config-install.cmake.in     |  8 +--
+ lapack-netlib/LAPACKE/example/CMakeLists.txt  |  8 +--
+ lapack-netlib/LAPACKE/lapacke.pc.in           |  4 +-
+ lapack-netlib/SRC/CMakeLists.txt              | 14 ++---
+ lapack-netlib/TESTING/MATGEN/CMakeLists.txt   |  6 +-
+ 23 files changed, 133 insertions(+), 115 deletions(-)
+
+diff --git a/lapack-netlib/BLAS/CMakeLists.txt b/lapack-netlib/BLAS/CMakeLists.txt
+index ee5676fc63..45cec39c22 100644
+--- a/lapack-netlib/BLAS/CMakeLists.txt
++++ b/lapack-netlib/BLAS/CMakeLists.txt
+@@ -2,9 +2,9 @@ add_subdirectory(SRC)
+ if(BUILD_TESTING)
+   add_subdirectory(TESTING)
+ endif()
+-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/blas.pc.in ${CMAKE_CURRENT_BINARY_DIR}/blas.pc @ONLY)
++configure_file(${CMAKE_CURRENT_SOURCE_DIR}/blas.pc.in ${CMAKE_CURRENT_BINARY_DIR}/${BLASLIB}.pc @ONLY)
+ install(FILES
+-  ${CMAKE_CURRENT_BINARY_DIR}/blas.pc
++  ${CMAKE_CURRENT_BINARY_DIR}/${BLASLIB}.pc
+   DESTINATION ${PKG_CONFIG_DIR}
+   COMPONENT Development
+   )
+diff --git a/lapack-netlib/BLAS/SRC/CMakeLists.txt b/lapack-netlib/BLAS/SRC/CMakeLists.txt
+index 41c4804324..0078dca400 100644
+--- a/lapack-netlib/BLAS/SRC/CMakeLists.txt
++++ b/lapack-netlib/BLAS/SRC/CMakeLists.txt
+@@ -97,10 +97,10 @@ if(BUILD_COMPLEX16)
+ endif()
+ list(REMOVE_DUPLICATES SOURCES)
+ 
+-add_library(blas ${SOURCES})
++add_library(${BLASLIB} ${SOURCES})
+ set_target_properties(
+-  blas PROPERTIES
++  ${BLASLIB} PROPERTIES
+   VERSION ${LAPACK_VERSION}
+   SOVERSION ${LAPACK_MAJOR_VERSION}
+   )
+-lapack_install_library(blas)
++lapack_install_library(${BLASLIB})
+diff --git a/lapack-netlib/BLAS/TESTING/CMakeLists.txt b/lapack-netlib/BLAS/TESTING/CMakeLists.txt
+index 9b130db0fd..ae82cf937f 100644
+--- a/lapack-netlib/BLAS/TESTING/CMakeLists.txt
++++ b/lapack-netlib/BLAS/TESTING/CMakeLists.txt
+@@ -2,7 +2,7 @@ macro(add_blas_test name src)
+   get_filename_component(baseNAME ${src} NAME_WE)
+   set(TEST_INPUT "${CMAKE_CURRENT_SOURCE_DIR}/${baseNAME}.in")
+   add_executable(${name} ${src})
+-  target_link_libraries(${name} blas)
++  target_link_libraries(${name} ${BLASLIB})
+   if(EXISTS "${TEST_INPUT}")
+     add_test(NAME BLAS-${name} COMMAND "${CMAKE_COMMAND}"
+       -DTEST=$<TARGET_FILE:${name}>
+diff --git a/lapack-netlib/BLAS/blas.pc.in b/lapack-netlib/BLAS/blas.pc.in
+index 37809773ba..31e11e6389 100644
+--- a/lapack-netlib/BLAS/blas.pc.in
++++ b/lapack-netlib/BLAS/blas.pc.in
+@@ -5,4 +5,4 @@ Name: BLAS
+ Description: FORTRAN reference implementation of BLAS Basic Linear Algebra Subprograms
+ Version: @LAPACK_VERSION@
+ URL: http://www.netlib.org/blas/
+-Libs: -L${libdir} -lblas
++Libs: -L${libdir} -l@BLASLIB@
+diff --git a/lapack-netlib/CBLAS/CMakeLists.txt b/lapack-netlib/CBLAS/CMakeLists.txt
+index 04c5ab795f..da46027aca 100644
+--- a/lapack-netlib/CBLAS/CMakeLists.txt
++++ b/lapack-netlib/CBLAS/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ message(STATUS "CBLAS enable")
+ enable_language(C)
+ 
+-set(LAPACK_INSTALL_EXPORT_NAME cblas-targets)
++set(LAPACK_INSTALL_EXPORT_NAME ${CBLASLIB}-targets)
+ 
+ # Create a header file cblas.h for the routines called in my C programs
+ include(FortranCInterface)
+@@ -42,15 +42,15 @@ if(BUILD_TESTING)
+ endif()
+ 
+ if(NOT BLAS_FOUND)
+-  set(ALL_TARGETS ${ALL_TARGETS} blas)
++  set(ALL_TARGETS ${ALL_TARGETS} ${BLASLIB})
+ endif()
+ 
+ # Export cblas targets from the
+ # install tree, if any.
+ set(_cblas_config_install_guard_target "")
+ if(ALL_TARGETS)
+-  install(EXPORT cblas-targets
+-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cblas-${LAPACK_VERSION}
++  install(EXPORT ${CBLASLIB}-targets
++    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CBLASLIB}-${LAPACK_VERSION}
+     COMPONENT Development
+     )
+   # Choose one of the cblas targets to use as a guard for
+@@ -61,7 +61,7 @@ endif()
+ # Export cblas targets from the build tree, if any.
+ set(_cblas_config_build_guard_target "")
+ if(ALL_TARGETS)
+-  export(TARGETS ${ALL_TARGETS} FILE cblas-targets.cmake)
++  export(TARGETS ${ALL_TARGETS} FILE ${CBLASLIB}-targets.cmake)
+ 
+   # Choose one of the cblas targets to use as a guard
+   # for cblas-config.cmake to load targets from the build tree.
+@@ -69,26 +69,26 @@ if(ALL_TARGETS)
+ endif()
+ 
+ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cblas-config-version.cmake.in
+-  ${LAPACK_BINARY_DIR}/cblas-config-version.cmake @ONLY)
++  ${LAPACK_BINARY_DIR}/${CBLASLIB}-config-version.cmake @ONLY)
+ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cblas-config-build.cmake.in
+-  ${LAPACK_BINARY_DIR}/cblas-config.cmake @ONLY)
++  ${LAPACK_BINARY_DIR}/${CBLASLIB}-config.cmake @ONLY)
+ 
+ 
+-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cblas.pc.in ${CMAKE_CURRENT_BINARY_DIR}/cblas.pc @ONLY)
++configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cblas.pc.in ${CMAKE_CURRENT_BINARY_DIR}/${CBLASLIB}.pc @ONLY)
+   install(FILES
+-  ${CMAKE_CURRENT_BINARY_DIR}/cblas.pc
++  ${CMAKE_CURRENT_BINARY_DIR}/${CBLASLIB}.pc
+   DESTINATION ${PKG_CONFIG_DIR}
+   )
+ 
+ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cblas-config-install.cmake.in
+-  ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/cblas-config.cmake @ONLY)
++  ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${CBLASLIB}-config.cmake @ONLY)
+ install(FILES
+-  ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/cblas-config.cmake
+-  ${LAPACK_BINARY_DIR}/cblas-config-version.cmake
+-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cblas-${LAPACK_VERSION}
++  ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${CBLASLIB}-config.cmake
++  ${LAPACK_BINARY_DIR}/${CBLASLIB}-config-version.cmake
++  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CBLASLIB}-${LAPACK_VERSION}
+   )
+ 
+-#install(EXPORT cblas-targets
+-#  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cblas-${LAPACK_VERSION}
++#install(EXPORT ${CBLASLIB}-targets
++#  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CBLASLIB}-${LAPACK_VERSION}
+ #  COMPONENT Development
+ #  )
+diff --git a/lapack-netlib/CBLAS/cblas.pc.in b/lapack-netlib/CBLAS/cblas.pc.in
+index 7c95ebbb43..882642e6c0 100644
+--- a/lapack-netlib/CBLAS/cblas.pc.in
++++ b/lapack-netlib/CBLAS/cblas.pc.in
+@@ -5,6 +5,6 @@ Name: CBLAS
+ Description: C Standard Interface to BLAS Basic Linear Algebra Subprograms
+ Version: @LAPACK_VERSION@
+ URL: http://www.netlib.org/blas/#_cblas
+-Libs: -L${libdir} -lcblas
++Libs: -L${libdir} -l@CBLASLIB@
+ Cflags: -I${includedir}
+-Requires.private: blas
++Requires.private: @BLASLIB@
+diff --git a/lapack-netlib/CBLAS/cmake/cblas-config-build.cmake.in b/lapack-netlib/CBLAS/cmake/cblas-config-build.cmake.in
+index 3747f041c4..dc21c2d0f3 100644
+--- a/lapack-netlib/CBLAS/cmake/cblas-config-build.cmake.in
++++ b/lapack-netlib/CBLAS/cmake/cblas-config-build.cmake.in
+@@ -4,11 +4,11 @@ find_package(LAPACK NO_MODULE)
+ 
+ # Load lapack targets from the build tree, including lapacke targets.
+ if(NOT TARGET lapacke)
+-  include("@LAPACK_BINARY_DIR@/lapack-targets.cmake")
++  include("@LAPACK_BINARY_DIR@/@LAPACKLIB@-targets.cmake")
+ endif()
+ 
+ # Report cblas header search locations from build tree.
+ set(CBLAS_INCLUDE_DIRS "@LAPACK_BINARY_DIR@/include")
+ 
+ # Report cblas libraries.
+-set(CBLAS_LIBRARIES cblas)
++set(CBLAS_LIBRARIES @CBLASLIB@)
+diff --git a/lapack-netlib/CBLAS/cmake/cblas-config-install.cmake.in b/lapack-netlib/CBLAS/cmake/cblas-config-install.cmake.in
+index 215e28a571..44046a283b 100644
+--- a/lapack-netlib/CBLAS/cmake/cblas-config-install.cmake.in
++++ b/lapack-netlib/CBLAS/cmake/cblas-config-install.cmake.in
+@@ -5,19 +5,19 @@ get_filename_component(_CBLAS_PREFIX "${_CBLAS_PREFIX}" PATH)
+ get_filename_component(_CBLAS_PREFIX "${_CBLAS_PREFIX}" PATH)
+ 
+ # Load the LAPACK package with which we were built.
+-set(LAPACK_DIR "${_CBLAS_PREFIX}/@CMAKE_INSTALL_LIBDIR@/cmake/lapack-@LAPACK_VERSION@")
++set(LAPACK_DIR "${_CBLAS_PREFIX}/@CMAKE_INSTALL_LIBDIR@/cmake/@LAPACKLIB@-@LAPACK_VERSION@")
+ find_package(LAPACK NO_MODULE)
+ 
+ # Load lapacke targets from the install tree.
+-if(NOT TARGET cblas)
+-  include(${_CBLAS_SELF_DIR}/cblas-targets.cmake)
++if(NOT TARGET @CBLASLIB@)
++  include(${_CBLAS_SELF_DIR}/@CBLASLIB@-targets.cmake)
+ endif()
+ 
+ # Report lapacke header search locations.
+ set(CBLAS_INCLUDE_DIRS ${_CBLAS_PREFIX}/include)
+ 
+ # Report lapacke libraries.
+-set(CBLAS_LIBRARIES cblas)
++set(CBLAS_LIBRARIES @CBLASLIB@)
+ 
+ unset(_CBLAS_PREFIX)
+ unset(_CBLAS_SELF_DIR)
+diff --git a/lapack-netlib/CBLAS/examples/CMakeLists.txt b/lapack-netlib/CBLAS/examples/CMakeLists.txt
+index 0241fd1640..74f7d8bb83 100644
+--- a/lapack-netlib/CBLAS/examples/CMakeLists.txt
++++ b/lapack-netlib/CBLAS/examples/CMakeLists.txt
+@@ -1,8 +1,8 @@
+ add_executable(xexample1_CBLAS cblas_example1.c)
+ add_executable(xexample2_CBLAS cblas_example2.c)
+ 
+-target_link_libraries(xexample1_CBLAS cblas)
+-target_link_libraries(xexample2_CBLAS cblas ${BLAS_LIBRARIES})
++target_link_libraries(xexample1_CBLAS ${CBLASLIB})
++target_link_libraries(xexample2_CBLAS ${CBLASLIB} ${BLAS_LIBRARIES})
+ 
+ add_test(example1_CBLAS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/xexample1_CBLAS)
+ add_test(example2_CBLAS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/xexample2_CBLAS)
+diff --git a/lapack-netlib/CBLAS/examples/cblas_example1.c b/lapack-netlib/CBLAS/examples/cblas_example1.c
+index 3d5ed330c7..d89aeadb06 100644
+--- a/lapack-netlib/CBLAS/examples/cblas_example1.c
++++ b/lapack-netlib/CBLAS/examples/cblas_example1.c
+@@ -11,7 +11,7 @@ int main ( )
+ 
+    double *a, *x, *y;
+    double alpha, beta;
+-   int m, n, lda, incx, incy, i;
++   CBLAS_INDEX m, n, lda, incx, incy, i;
+ 
+    Layout = CblasColMajor;
+    transa = CblasNoTrans;
+diff --git a/lapack-netlib/CBLAS/examples/cblas_example2.c b/lapack-netlib/CBLAS/examples/cblas_example2.c
+index d2c28d53f3..e82ae518c4 100644
+--- a/lapack-netlib/CBLAS/examples/cblas_example2.c
++++ b/lapack-netlib/CBLAS/examples/cblas_example2.c
+@@ -9,7 +9,7 @@
+ 
+ int main (int argc, char **argv )
+ {
+-   int rout=-1,info=0,m,n,k,lda,ldb,ldc;
++   CBLAS_INDEX rout=-1,info=0,m,n,k,lda,ldb,ldc;
+    double A[2] = {0.0,0.0},
+           B[2] = {0.0,0.0},
+           C[2] = {0.0,0.0},
+diff --git a/lapack-netlib/CBLAS/src/CMakeLists.txt b/lapack-netlib/CBLAS/src/CMakeLists.txt
+index 90e19f8185..1313e798bb 100644
+--- a/lapack-netlib/CBLAS/src/CMakeLists.txt
++++ b/lapack-netlib/CBLAS/src/CMakeLists.txt
+@@ -113,16 +113,16 @@ if(BUILD_COMPLEX16)
+ endif()
+ list(REMOVE_DUPLICATES SOURCES)
+ 
+-add_library(cblas ${SOURCES})
++add_library(${CBLASLIB} ${SOURCES})
+ set_target_properties(
+-  cblas PROPERTIES
++  ${CBLASLIB} PROPERTIES
+   LINKER_LANGUAGE C
+   VERSION ${LAPACK_VERSION}
+   SOVERSION ${LAPACK_MAJOR_VERSION}
+   )
+-target_include_directories(cblas PUBLIC
++target_include_directories(${CBLASLIB} PUBLIC
+   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+   $<INSTALL_INTERFACE:include>
+ )
+-target_link_libraries(cblas PRIVATE ${BLAS_LIBRARIES})
+-lapack_install_library(cblas)
++target_link_libraries(${CBLASLIB} PRIVATE ${BLAS_LIBRARIES})
++lapack_install_library(${CBLASLIB})
+diff --git a/lapack-netlib/CBLAS/testing/CMakeLists.txt b/lapack-netlib/CBLAS/testing/CMakeLists.txt
+index 2459695b80..34e92a4239 100644
+--- a/lapack-netlib/CBLAS/testing/CMakeLists.txt
++++ b/lapack-netlib/CBLAS/testing/CMakeLists.txt
+@@ -52,9 +52,9 @@ if(BUILD_SINGLE)
+   add_executable(xscblat2 c_sblat2.f ${STESTL2O} ${LAPACK_BINARY_DIR}/include/cblas_test.h)
+   add_executable(xscblat3 c_sblat3.f ${STESTL3O} ${LAPACK_BINARY_DIR}/include/cblas_test.h)
+ 
+-  target_link_libraries(xscblat1 cblas)
+-  target_link_libraries(xscblat2 cblas)
+-  target_link_libraries(xscblat3 cblas)
++  target_link_libraries(xscblat1 ${CBLASLIB})
++  target_link_libraries(xscblat2 ${CBLASLIB})
++  target_link_libraries(xscblat3 ${CBLASLIB})
+ 
+   add_cblas_test(stest1.out ""   xscblat1)
+   add_cblas_test(stest2.out sin2 xscblat2)
+@@ -66,9 +66,9 @@ if(BUILD_DOUBLE)
+   add_executable(xdcblat2 c_dblat2.f ${DTESTL2O} ${LAPACK_BINARY_DIR}/include/cblas_test.h)
+   add_executable(xdcblat3 c_dblat3.f ${DTESTL3O} ${LAPACK_BINARY_DIR}/include/cblas_test.h)
+ 
+-  target_link_libraries(xdcblat1 cblas)
+-  target_link_libraries(xdcblat2 cblas)
+-  target_link_libraries(xdcblat3 cblas)
++  target_link_libraries(xdcblat1 ${CBLASLIB})
++  target_link_libraries(xdcblat2 ${CBLASLIB})
++  target_link_libraries(xdcblat3 ${CBLASLIB})
+ 
+   add_cblas_test(dtest1.out ""   xdcblat1)
+   add_cblas_test(dtest2.out din2 xdcblat2)
+@@ -80,9 +80,9 @@ if(BUILD_COMPLEX)
+   add_executable(xccblat2 c_cblat2.f ${CTESTL2O} ${LAPACK_BINARY_DIR}/include/cblas_test.h)
+   add_executable(xccblat3 c_cblat3.f ${CTESTL3O} ${LAPACK_BINARY_DIR}/include/cblas_test.h)
+ 
+-  target_link_libraries(xccblat1 cblas ${BLAS_LIBRARIES})
+-  target_link_libraries(xccblat2 cblas)
+-  target_link_libraries(xccblat3 cblas)
++  target_link_libraries(xccblat1 ${CBLASLIB} ${BLAS_LIBRARIES})
++  target_link_libraries(xccblat2 ${CBLASLIB})
++  target_link_libraries(xccblat3 ${CBLASLIB})
+ 
+   add_cblas_test(ctest1.out ""   xccblat1)
+   add_cblas_test(ctest2.out cin2 xccblat2)
+@@ -94,9 +94,9 @@ if(BUILD_COMPLEX16)
+   add_executable(xzcblat2 c_zblat2.f ${ZTESTL2O} ${LAPACK_BINARY_DIR}/include/cblas_test.h)
+   add_executable(xzcblat3 c_zblat3.f ${ZTESTL3O} ${LAPACK_BINARY_DIR}/include/cblas_test.h)
+ 
+-  target_link_libraries(xzcblat1 cblas)
+-  target_link_libraries(xzcblat2 cblas)
+-  target_link_libraries(xzcblat3 cblas)
++  target_link_libraries(xzcblat1 ${CBLASLIB})
++  target_link_libraries(xzcblat2 ${CBLASLIB})
++  target_link_libraries(xzcblat3 ${CBLASLIB})
+ 
+   add_cblas_test(ztest1.out ""   xzcblat1)
+   add_cblas_test(ztest2.out zin2 xzcblat2)
+diff --git a/lapack-netlib/CMAKE/lapack-config-build.cmake.in b/lapack-netlib/CMAKE/lapack-config-build.cmake.in
+index f7e0416638..da44a6ae46 100644
+--- a/lapack-netlib/CMAKE/lapack-config-build.cmake.in
++++ b/lapack-netlib/CMAKE/lapack-config-build.cmake.in
+@@ -1,7 +1,7 @@
+ # Load lapack targets from the build tree if necessary.
+ set(_LAPACK_TARGET "@_lapack_config_build_guard_target@")
+ if(_LAPACK_TARGET AND NOT TARGET "${_LAPACK_TARGET}")
+-  include("@LAPACK_BINARY_DIR@/lapack-targets.cmake")
++  include("@LAPACK_BINARY_DIR@/@LAPACKLIB@-targets.cmake")
+ endif()
+ unset(_LAPACK_TARGET)
+ 
+diff --git a/lapack-netlib/CMAKE/lapack-config-install.cmake.in b/lapack-netlib/CMAKE/lapack-config-install.cmake.in
+index 3de7362ea7..77609609cd 100644
+--- a/lapack-netlib/CMAKE/lapack-config-install.cmake.in
++++ b/lapack-netlib/CMAKE/lapack-config-install.cmake.in
+@@ -4,7 +4,7 @@ get_filename_component(_LAPACK_SELF_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+ # Load lapack targets from the install tree if necessary.
+ set(_LAPACK_TARGET "@_lapack_config_install_guard_target@")
+ if(_LAPACK_TARGET AND NOT TARGET "${_LAPACK_TARGET}")
+-  include("${_LAPACK_SELF_DIR}/lapack-targets.cmake")
++  include("${_LAPACK_SELF_DIR}/@LAPACKLIB@-targets.cmake")
+ endif()
+ unset(_LAPACK_TARGET)
+ 
+diff --git a/lapack-netlib/CMakeLists.txt b/lapack-netlib/CMakeLists.txt
+index df43d91b10..a30efbbfe9 100644
+--- a/lapack-netlib/CMakeLists.txt
++++ b/lapack-netlib/CMakeLists.txt
+@@ -44,6 +44,24 @@ endif()
+ # By default static library
+ option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
+ 
++# By default build index32 library
++option(BUILD_INDEX64 "Build Index-64 API libraries" OFF)
++if(BUILD_INDEX64)
++  set(BLASLIB "blas64")
++  set(CBLASLIB "cblas64")
++  set(LAPACKLIB "lapack64")
++  set(LAPACKELIB "lapacke64")
++  set(TMGLIB "tmglib64")
++  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWeirdNEC -DLAPACK_ILP64 -DHAVE_LAPACK_CONFIG_H")
++  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fdefault-integer-8")
++else()
++  set(BLASLIB "blas")
++  set(CBLASLIB "cblas")
++  set(LAPACKLIB "lapack")
++  set(LAPACKELIB "lapacke")
++  set(TMGLIB "tmglib")
++endif()
++
+ include(GNUInstallDirs)
+ 
+ # Updated OSX RPATH settings
+@@ -73,10 +91,10 @@ include(PreventInBuildInstalls)
+ 
+ if(UNIX)
+   if(CMAKE_Fortran_COMPILER_ID STREQUAL Intel)
+-    list(APPEND CMAKE_Fortran_FLAGS "-fp-model strict")
++    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fp-model strict")
+   endif()
+   if(CMAKE_Fortran_COMPILER_ID STREQUAL XL)
+-    list(APPEND CMAKE_Fortran_FLAGS "-qnosave -qstrict=none")
++    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qnosave -qstrict=none")
+   endif()
+ # Delete libmtsk in linking sequence for Sun/Oracle Fortran Compiler.
+ # This library is not present in the Sun package SolarisStudio12.3-linux-x86-bin
+@@ -112,7 +130,7 @@ endif()
+ 
+ 
+ # --------------------------------------------------
+-set(LAPACK_INSTALL_EXPORT_NAME lapack-targets)
++set(LAPACK_INSTALL_EXPORT_NAME ${LAPACKLIB}-targets)
+ 
+ macro(lapack_install_library lib)
+   install(TARGETS ${lib}
+@@ -220,7 +238,7 @@ endif()
+ if(NOT BLAS_FOUND)
+   message(STATUS "Using supplied NETLIB BLAS implementation")
+   add_subdirectory(BLAS)
+-  set(BLAS_LIBRARIES blas)
++  set(BLAS_LIBRARIES ${BLASLIB})
+ else()
+   set(CMAKE_EXE_LINKER_FLAGS
+     "${CMAKE_EXE_LINKER_FLAGS} ${BLAS_LINKER_FLAGS}"
+@@ -279,7 +297,7 @@ endif()
+ # Neither user specified or optimized LAPACK libraries can be used
+ if(NOT LATESTLAPACK_FOUND)
+   message(STATUS "Using supplied NETLIB LAPACK implementation")
+-  set(LAPACK_LIBRARIES lapack)
++  set(LAPACK_LIBRARIES ${LAPACKLIB})
+   add_subdirectory(SRC)
+ else()
+   set(CMAKE_EXE_LINKER_FLAGS
+@@ -371,23 +389,23 @@ include(CPack)
+ # --------------------------------------------------
+ 
+ if(NOT BLAS_FOUND)
+-  set(ALL_TARGETS ${ALL_TARGETS} blas)
++  set(ALL_TARGETS ${ALL_TARGETS} ${BLASLIB})
+ endif()
+ 
+ if(NOT LATESTLAPACK_FOUND)
+-  set(ALL_TARGETS ${ALL_TARGETS} lapack)
++  set(ALL_TARGETS ${ALL_TARGETS} ${LAPACKLIB})
+ endif()
+ 
+ if(BUILD_TESTING OR LAPACKE_WITH_TMG)
+-  set(ALL_TARGETS ${ALL_TARGETS} tmglib)
++  set(ALL_TARGETS ${ALL_TARGETS} ${TMGLIB})
+ endif()
+ 
+ # Export lapack targets, not including lapacke, from the
+ # install tree, if any.
+ set(_lapack_config_install_guard_target "")
+ if(ALL_TARGETS)
+-  install(EXPORT lapack-targets
+-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/lapack-${LAPACK_VERSION}
++  install(EXPORT ${LAPACKLIB}-targets
++    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${LAPACKLIB}-${LAPACK_VERSION}
+     COMPONENT Development
+     )
+ 
+@@ -398,18 +416,18 @@ endif()
+ 
+ # Include cblas in targets exported from the build tree.
+ if(CBLAS)
+-  set(ALL_TARGETS ${ALL_TARGETS} cblas)
++  set(ALL_TARGETS ${ALL_TARGETS} ${CBLASLIB})
+ endif()
+ 
+ # Include lapacke in targets exported from the build tree.
+ if(LAPACKE)
+-  set(ALL_TARGETS ${ALL_TARGETS} lapacke)
++  set(ALL_TARGETS ${ALL_TARGETS} ${LAPACKELIB})
+ endif()
+ 
+ # Export lapack and lapacke targets from the build tree, if any.
+ set(_lapack_config_build_guard_target "")
+ if(ALL_TARGETS)
+-  export(TARGETS ${ALL_TARGETS} FILE lapack-targets.cmake)
++  export(TARGETS ${ALL_TARGETS} FILE ${LAPACKLIB}-targets.cmake)
+ 
+   # Choose one of the lapack or lapacke targets to use as a guard
+   # for lapack-config.cmake to load targets from the build tree.
+@@ -417,30 +435,30 @@ if(ALL_TARGETS)
+ endif()
+ 
+ configure_file(${LAPACK_SOURCE_DIR}/CMAKE/lapack-config-build.cmake.in
+-  ${LAPACK_BINARY_DIR}/lapack-config.cmake @ONLY)
++  ${LAPACK_BINARY_DIR}/${LAPACKLIB}-config.cmake @ONLY)
+ 
+ 
+-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/lapack.pc.in ${CMAKE_CURRENT_BINARY_DIR}/lapack.pc @ONLY)
++configure_file(${CMAKE_CURRENT_SOURCE_DIR}/lapack.pc.in ${CMAKE_CURRENT_BINARY_DIR}/${LAPACKLIB}.pc @ONLY)
+   install(FILES
+-  ${CMAKE_CURRENT_BINARY_DIR}/lapack.pc
++  ${CMAKE_CURRENT_BINARY_DIR}/${LAPACKLIB}.pc
+   DESTINATION ${PKG_CONFIG_DIR}
+   COMPONENT Development
+   )
+ 
+ configure_file(${LAPACK_SOURCE_DIR}/CMAKE/lapack-config-install.cmake.in
+-  ${LAPACK_BINARY_DIR}/CMakeFiles/lapack-config.cmake @ONLY)
++  ${LAPACK_BINARY_DIR}/CMakeFiles/${LAPACKLIB}-config.cmake @ONLY)
+ 
+ include(CMakePackageConfigHelpers)
+ write_basic_package_version_file(
+-  ${LAPACK_BINARY_DIR}/lapack-config-version.cmake
++  ${LAPACK_BINARY_DIR}/${LAPACKLIB}-config-version.cmake
+   VERSION ${LAPACK_VERSION}
+   COMPATIBILITY SameMajorVersion
+   )
+ 
+ install(FILES
+-  ${LAPACK_BINARY_DIR}/CMakeFiles/lapack-config.cmake
+-  ${LAPACK_BINARY_DIR}/lapack-config-version.cmake
+-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/lapack-${LAPACK_VERSION}
++  ${LAPACK_BINARY_DIR}/CMakeFiles/${LAPACKLIB}-config.cmake
++  ${LAPACK_BINARY_DIR}/${LAPACKLIB}-config-version.cmake
++  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${LAPACKLIB}-${LAPACK_VERSION}
+   COMPONENT Development
+   )
+   
+diff --git a/lapack-netlib/LAPACKE/CMakeLists.txt b/lapack-netlib/LAPACKE/CMakeLists.txt
+index 0589a74ba6..60d5ddbe38 100644
+--- a/lapack-netlib/LAPACKE/CMakeLists.txt
++++ b/lapack-netlib/LAPACKE/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ message(STATUS "LAPACKE enable")
+ enable_language(C)
+ 
+-set(LAPACK_INSTALL_EXPORT_NAME lapacke-targets)
++set(LAPACK_INSTALL_EXPORT_NAME ${LAPACKELIB}-targets)
+ 
+ # Create a header file lapacke_mangling.h for the routines called in my C programs
+ include(FortranCInterface)
+@@ -72,28 +72,28 @@ if(LAPACKE_WITH_TMG)
+ endif()
+ list(APPEND SOURCES ${UTILS})
+ 
+-add_library(lapacke ${SOURCES})
++add_library(${LAPACKELIB} ${SOURCES})
+ set_target_properties(
+-  lapacke PROPERTIES
++  ${LAPACKELIB} PROPERTIES
+   LINKER_LANGUAGE C
+   VERSION ${LAPACK_VERSION}
+   SOVERSION ${LAPACK_MAJOR_VERSION}
+   )
+-target_include_directories(lapacke PUBLIC
++target_include_directories(${LAPACKELIB} PUBLIC
+   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+   $<INSTALL_INTERFACE:include>
+ )
+ if(WIN32 AND NOT UNIX)
+-  target_compile_definitions(lapacke PUBLIC HAVE_LAPACK_CONFIG_H LAPACK_COMPLEX_STRUCTURE)
++  target_compile_definitions(${LAPACKELIB} PUBLIC HAVE_LAPACK_CONFIG_H LAPACK_COMPLEX_STRUCTURE)
+   message(STATUS "Windows BUILD")
+ endif()
+ 
+ if(LAPACKE_WITH_TMG)
+-  target_link_libraries(lapacke PRIVATE tmglib)
++  target_link_libraries(${LAPACKELIB} PRIVATE ${TMGLIB})
+ endif()
+-target_link_libraries(lapacke PRIVATE ${LAPACK_LIBRARIES})
++target_link_libraries(${LAPACKELIB} PRIVATE ${LAPACK_LIBRARIES})
+ 
+-lapack_install_library(lapacke)
++lapack_install_library(${LAPACKELIB})
+ install(
+   FILES ${LAPACKE_INCLUDE} ${LAPACK_BINARY_DIR}/include/lapacke_mangling.h
+   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+@@ -105,28 +105,28 @@ if(BUILD_TESTING)
+ endif()
+ 
+ 
+-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/lapacke.pc.in ${CMAKE_CURRENT_BINARY_DIR}/lapacke.pc @ONLY)
++configure_file(${CMAKE_CURRENT_SOURCE_DIR}/lapacke.pc.in ${CMAKE_CURRENT_BINARY_DIR}/${LAPACKELIB}.pc @ONLY)
+ install(FILES
+-  ${CMAKE_CURRENT_BINARY_DIR}/lapacke.pc
++  ${CMAKE_CURRENT_BINARY_DIR}/${LAPACKELIB}.pc
+   DESTINATION ${PKG_CONFIG_DIR}
+   COMPONENT Development
+   )
+ 
+ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/lapacke-config-version.cmake.in
+-  ${LAPACK_BINARY_DIR}/lapacke-config-version.cmake @ONLY)
++  ${LAPACK_BINARY_DIR}/${LAPACKELIB}-config-version.cmake @ONLY)
+ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/lapacke-config-build.cmake.in
+-  ${LAPACK_BINARY_DIR}/lapacke-config.cmake @ONLY)
++  ${LAPACK_BINARY_DIR}/${LAPACKELIB}-config.cmake @ONLY)
+ 
+ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/lapacke-config-install.cmake.in
+-  ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/lapacke-config.cmake @ONLY)
++  ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${LAPACKELIB}-config.cmake @ONLY)
+ install(FILES
+-  ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/lapacke-config.cmake
+-  ${LAPACK_BINARY_DIR}/lapacke-config-version.cmake
+-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/lapacke-${LAPACK_VERSION}
++  ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${LAPACKELIB}-config.cmake
++  ${LAPACK_BINARY_DIR}/${LAPACKELIB}-config-version.cmake
++  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${LAPACKELIB}-${LAPACK_VERSION}
+   COMPONENT Development
+   )
+ 
+-install(EXPORT lapacke-targets
+-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/lapacke-${LAPACK_VERSION}
++install(EXPORT ${LAPACKELIB}-targets
++  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${LAPACKELIB}-${LAPACK_VERSION}
+   COMPONENT Development
+   )
+diff --git a/lapack-netlib/LAPACKE/cmake/lapacke-config-build.cmake.in b/lapack-netlib/LAPACKE/cmake/lapacke-config-build.cmake.in
+index 0a13501726..49ce4770ad 100644
+--- a/lapack-netlib/LAPACKE/cmake/lapacke-config-build.cmake.in
++++ b/lapack-netlib/LAPACKE/cmake/lapacke-config-build.cmake.in
+@@ -3,8 +3,8 @@ set(LAPACK_DIR "@LAPACK_BINARY_DIR@")
+ find_package(LAPACK NO_MODULE)
+ 
+ # Load lapack targets from the build tree, including lapacke targets.
+-if(NOT TARGET lapacke)
+-  include("@LAPACK_BINARY_DIR@/lapack-targets.cmake")
++if(NOT TARGET @LAPACKELIB@)
++  include("@LAPACK_BINARY_DIR@/@LAPACKLIB@-targets.cmake")
+ endif()
+ 
+ # Hint for project building against lapack
+@@ -14,4 +14,4 @@ set(LAPACKE_Fortran_COMPILER_ID ${LAPACK_Fortran_COMPILER_ID})
+ set(LAPACKE_INCLUDE_DIRS "@LAPACK_BINARY_DIR@/include")
+ 
+ # Report lapacke libraries.
+-set(LAPACKE_LIBRARIES lapacke ${LAPACK_LIBRARIES})
++set(LAPACKE_LIBRARIES @LAPACKELIB@ ${LAPACK_LIBRARIES})
+diff --git a/lapack-netlib/LAPACKE/cmake/lapacke-config-install.cmake.in b/lapack-netlib/LAPACKE/cmake/lapacke-config-install.cmake.in
+index 57a5c2b2f3..2e5c36fa15 100644
+--- a/lapack-netlib/LAPACKE/cmake/lapacke-config-install.cmake.in
++++ b/lapack-netlib/LAPACKE/cmake/lapacke-config-install.cmake.in
+@@ -5,12 +5,12 @@ get_filename_component(_LAPACKE_PREFIX "${_LAPACKE_PREFIX}" PATH)
+ get_filename_component(_LAPACKE_PREFIX "${_LAPACKE_PREFIX}" PATH)
+ 
+ # Load the LAPACK package with which we were built.
+-set(LAPACK_DIR "${_LAPACKE_PREFIX}/@CMAKE_INSTALL_LIBDIR@/cmake/lapack-@LAPACK_VERSION@")
++set(LAPACK_DIR "${_LAPACKE_PREFIX}/@CMAKE_INSTALL_LIBDIR@/cmake/@LAPACK@-@LAPACK_VERSION@")
+ find_package(LAPACK NO_MODULE)
+ 
+ # Load lapacke targets from the install tree.
+-if(NOT TARGET lapacke)
+-  include(${_LAPACKE_SELF_DIR}/lapacke-targets.cmake)
++if(NOT TARGET @LAPACKELIB@)
++  include(${_LAPACKE_SELF_DIR}/@LAPACKELIB@-targets.cmake)
+ endif()
+ 
+ # Hint for project building against lapack
+@@ -20,7 +20,7 @@ set(LAPACKE_Fortran_COMPILER_ID ${LAPACK_Fortran_COMPILER_ID})
+ set(LAPACKE_INCLUDE_DIRS ${_LAPACKE_PREFIX}/include)
+ 
+ # Report lapacke libraries.
+-set(LAPACKE_LIBRARIES lapacke ${LAPACK_LIBRARIES})
++set(LAPACKE_LIBRARIES @LAPACKELIB@ ${LAPACK_LIBRARIES})
+ 
+ unset(_LAPACKE_PREFIX)
+ unset(_LAPACKE_SELF_DIR)
+diff --git a/lapack-netlib/LAPACKE/example/CMakeLists.txt b/lapack-netlib/LAPACKE/example/CMakeLists.txt
+index fa75c731c5..27db8ee216 100644
+--- a/lapack-netlib/LAPACKE/example/CMakeLists.txt
++++ b/lapack-netlib/LAPACKE/example/CMakeLists.txt
+@@ -3,10 +3,10 @@ add_executable(xexample_DGESV_colmajor example_DGESV_colmajor.c lapacke_example_
+ add_executable(xexample_DGELS_rowmajor example_DGELS_rowmajor.c lapacke_example_aux.c lapacke_example_aux.h)
+ add_executable(xexample_DGELS_colmajor example_DGELS_colmajor.c lapacke_example_aux.c lapacke_example_aux.h)
+ 
+-target_link_libraries(xexample_DGESV_rowmajor lapacke)
+-target_link_libraries(xexample_DGESV_colmajor lapacke)
+-target_link_libraries(xexample_DGELS_rowmajor lapacke)
+-target_link_libraries(xexample_DGELS_colmajor lapacke)
++target_link_libraries(xexample_DGESV_rowmajor ${LAPACKELIB})
++target_link_libraries(xexample_DGESV_colmajor ${LAPACKELIB})
++target_link_libraries(xexample_DGELS_rowmajor ${LAPACKELIB})
++target_link_libraries(xexample_DGELS_colmajor ${LAPACKELIB})
+ 
+ add_test(example_DGESV_rowmajor ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/xexample_DGESV_rowmajor)
+ add_test(example_DGESV_colmajor ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/xexample_DGESV_colmajor)
+diff --git a/lapack-netlib/LAPACKE/lapacke.pc.in b/lapack-netlib/LAPACKE/lapacke.pc.in
+index 68da739578..0097c2597f 100644
+--- a/lapack-netlib/LAPACKE/lapacke.pc.in
++++ b/lapack-netlib/LAPACKE/lapacke.pc.in
+@@ -5,6 +5,6 @@ Name: LAPACKE
+ Description: C Standard Interface to LAPACK Linear Algebra PACKage
+ Version: @LAPACK_VERSION@
+ URL: http://www.netlib.org/lapack/#_standard_c_language_apis_for_lapack
+-Libs: -L${libdir} -llapacke
++Libs: -L${libdir} -l@LAPACKELIB@
+ Cflags: -I${includedir}
+-Requires.private: lapack
++Requires.private: @LAPACKLIB@
+diff --git a/lapack-netlib/SRC/CMakeLists.txt b/lapack-netlib/SRC/CMakeLists.txt
+index f19bdd3027..bb14591652 100644
+--- a/lapack-netlib/SRC/CMakeLists.txt
++++ b/lapack-netlib/SRC/CMakeLists.txt
+@@ -500,21 +500,21 @@ if(BUILD_COMPLEX16)
+ endif()
+ list(REMOVE_DUPLICATES SOURCES)
+ 
+-add_library(lapack ${SOURCES})
++add_library(${LAPACKLIB} ${SOURCES})
+ set_target_properties(
+-  lapack PROPERTIES
++  ${LAPACKLIB} PROPERTIES
+   VERSION ${LAPACK_VERSION}
+   SOVERSION ${LAPACK_MAJOR_VERSION}
+   )
+ 
+ if(USE_XBLAS)
+-  target_link_libraries(lapack PRIVATE ${XBLAS_LIBRARY})
++  target_link_libraries(${LAPACKLIB} PRIVATE ${XBLAS_LIBRARY})
+ endif()
+-target_link_libraries(lapack PRIVATE ${BLAS_LIBRARIES})
++target_link_libraries(${LAPACKLIB} PRIVATE ${BLAS_LIBRARIES})
+ 
+ if(_is_coverage_build)
+-  target_link_libraries(lapack PRIVATE gcov)
+-  add_coverage(lapack)
++  target_link_libraries(${LAPACKLIB} PRIVATE gcov)
++  add_coverage(${LAPACKLIB})
+ endif()
+ 
+-lapack_install_library(lapack)
++lapack_install_library(${LAPACKLIB})
+diff --git a/lapack-netlib/TESTING/MATGEN/CMakeLists.txt b/lapack-netlib/TESTING/MATGEN/CMakeLists.txt
+index bc986da3a2..3639c0320b 100644
+--- a/lapack-netlib/TESTING/MATGEN/CMakeLists.txt
++++ b/lapack-netlib/TESTING/MATGEN/CMakeLists.txt
+@@ -47,6 +47,6 @@ if(BUILD_COMPLEX16)
+ endif()
+ list(REMOVE_DUPLICATES SOURCES)
+ 
+-add_library(tmglib ${SOURCES})
+-target_link_libraries(tmglib ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
+-lapack_install_library(tmglib)
++add_library(${TMGLIB} ${SOURCES})
++target_link_libraries(${TMGLIB} ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
++lapack_install_library(${TMGLIB})
+
+From 8fe3555792f7a30df787721fe8e9e63883e5b58a Mon Sep 17 00:00:00 2001
+From: "Larson, Eric" <eric.larson@intel.com>
+Date: Fri, 24 Sep 2021 13:03:59 -0700
+Subject: [PATCH 2/3] ILP support
+
+long's in windows are 4 bytes (MSVS, intel compilers). Use int64_t and int32_t
+to ensure 8 byte integers for ILP interface.
+
+support 8 byte integer flag for intel ifort compiler
+---
+ lapack-netlib/CBLAS/include/cblas.h                |  5 +++--
+ lapack-netlib/CBLAS/include/cblas_f77.h            |  8 +++++++-
+ lapack-netlib/CMAKE/CheckLAPACKCompilerFlags.cmake | 13 +++++++++++++
+ lapack-netlib/CMakeLists.txt                       |  2 +-
+ lapack-netlib/LAPACKE/include/lapacke_config.h     |  5 +++--
+ 5 files changed, 27 insertions(+), 6 deletions(-)
+
+diff --git a/lapack-netlib/CBLAS/include/cblas.h b/lapack-netlib/CBLAS/include/cblas.h
+index 9e937964ed..7593064f15 100644
+--- a/lapack-netlib/CBLAS/include/cblas.h
++++ b/lapack-netlib/CBLAS/include/cblas.h
+@@ -1,6 +1,7 @@
+ #ifndef CBLAS_H
+ #define CBLAS_H
+ #include <stddef.h>
++#include <stdint.h>
+ 
+ 
+ #ifdef __cplusplus
+@@ -11,9 +12,9 @@ extern "C" {            /* Assume C declarations for C++ */
+  * Enumerated and derived types
+  */
+ #ifdef WeirdNEC
+-   #define CBLAS_INDEX long
++   #define CBLAS_INDEX int64_t
+ #else
+-    #define CBLAS_INDEX int
++    #define CBLAS_INDEX int32_t
+ #endif
+ 
+ typedef enum {CblasRowMajor=101, CblasColMajor=102} CBLAS_LAYOUT;
+diff --git a/lapack-netlib/CBLAS/include/cblas_f77.h b/lapack-netlib/CBLAS/include/cblas_f77.h
+index 36d4a71180..bb3f3a45dd 100644
+--- a/lapack-netlib/CBLAS/include/cblas_f77.h
++++ b/lapack-netlib/CBLAS/include/cblas_f77.h
+@@ -9,6 +9,8 @@
+ #ifndef CBLAS_F77_H
+ #define CBLAS_F77_H
+ 
++#include <stdint.h>
++
+ #ifdef CRAY
+    #include <fortran.h>
+    #define F77_CHAR _fcd
+@@ -17,8 +19,12 @@
+    #define F77_STRLEN(a) (_fcdlen)
+ #endif
+ 
++#ifndef F77_INT
+ #ifdef WeirdNEC
+-   #define F77_INT long
++   #define F77_INT int64_t
++#else
++   #define F77_INT int32_t
++#endif
+ #endif
+ 
+ #ifdef  F77_CHAR
+diff --git a/lapack-netlib/CMAKE/CheckLAPACKCompilerFlags.cmake b/lapack-netlib/CMAKE/CheckLAPACKCompilerFlags.cmake
+index add0d17975..15a8f01d69 100644
+--- a/lapack-netlib/CMAKE/CheckLAPACKCompilerFlags.cmake
++++ b/lapack-netlib/CMAKE/CheckLAPACKCompilerFlags.cmake
+@@ -14,6 +14,19 @@ macro( CheckLAPACKCompilerFlags )
+ 
+ set( FPE_EXIT FALSE )
+ 
++# FORTRAN ILP default
++if ( FORTRAN_ILP )
++    if( CMAKE_Fortran_COMPILER_ID STREQUAL "Intel" )
++        if ( WIN32 )
++            set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} /integer-size:64")
++        else ()
++            set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -integer-size 64")
++        endif()
++    else()
++        set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fdefault-integer-8")
++    endif()
++endif()
++
+ # GNU Fortran
+ if( CMAKE_Fortran_COMPILER_ID STREQUAL "GNU" )
+   if( "${CMAKE_Fortran_FLAGS}" MATCHES "-ffpe-trap=[izoupd]")
+diff --git a/lapack-netlib/CMakeLists.txt b/lapack-netlib/CMakeLists.txt
+index a30efbbfe9..b704e72c59 100644
+--- a/lapack-netlib/CMakeLists.txt
++++ b/lapack-netlib/CMakeLists.txt
+@@ -53,7 +53,7 @@ if(BUILD_INDEX64)
+   set(LAPACKELIB "lapacke64")
+   set(TMGLIB "tmglib64")
+   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWeirdNEC -DLAPACK_ILP64 -DHAVE_LAPACK_CONFIG_H")
+-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fdefault-integer-8")
++  set(FORTRAN_ILP TRUE)
+ else()
+   set(BLASLIB "blas")
+   set(CBLASLIB "cblas")
+diff --git a/lapack-netlib/LAPACKE/include/lapacke_config.h b/lapack-netlib/LAPACKE/include/lapacke_config.h
+index 8262c3488b..c6542955e2 100644
+--- a/lapack-netlib/LAPACKE/include/lapacke_config.h
++++ b/lapack-netlib/LAPACKE/include/lapacke_config.h
+@@ -49,12 +49,13 @@ extern "C" {
+ #endif /* __cplusplus */
+ 
+ #include <stdlib.h>
++#include <stdint.h>
+ 
+ #ifndef lapack_int
+ #if defined(LAPACK_ILP64)
+-#define lapack_int              long
++#define lapack_int              int64_t
+ #else
+-#define lapack_int              int
++#define lapack_int              int32_t
+ #endif
+ #endif
+ 
+
+From 41561e28c2a36daf49736e3b8b9aa44cc614fe27 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Markus=20M=C3=BCtzel?= <markus.muetzel@gmx.de>
+Date: Thu, 24 Mar 2022 18:11:44 +0100
+Subject: [PATCH 3/3] Add support for Intel Fortran compilers.
+
+Port changes from upstream Reference-LAPACK.
+---
+ cmake/fc.cmake | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/cmake/fc.cmake b/cmake/fc.cmake
+index 9feda9be31..e0cf9d78e6 100644
+--- a/cmake/fc.cmake
++++ b/cmake/fc.cmake
+@@ -67,7 +67,15 @@ if (${F_COMPILER} STREQUAL "GFORTRAN")
+     if (BINARY64)
+       set(FCOMMON_OPT "${FCOMMON_OPT} -m64")
+       if (INTERFACE64)
+-        set(FCOMMON_OPT "${FCOMMON_OPT} -fdefault-integer-8")
++        if (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
++          if (WIN32)
++            set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} /integer-size:64")
++          else ()
++            set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -integer-size 64")
++          endif ()
++        else ()
++          set(FCOMMON_OPT "${FCOMMON_OPT} -fdefault-integer-8")
++        endif ()
+       endif ()
+     else ()
+       set(FCOMMON_OPT "${FCOMMON_OPT} -m32")

--- a/mingw-w64-openblas/PKGBUILD
+++ b/mingw-w64-openblas/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-openblas
 pkgname=("${MINGW_PACKAGE_PREFIX}-openblas"
          $([[ "${CARCH}" == "i686" ]] || echo "${MINGW_PACKAGE_PREFIX}-openblas64"))
 pkgver=0.3.20
-pkgrel=1
+pkgrel=2
 pkgdesc="An optimized BLAS library based on GotoBLAS2 1.13 BSD, providing optimized blas, lapack, and cblas (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -27,9 +27,11 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              )
 options=('!buildflags')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/xianyi/OpenBLAS/archive/v${pkgver}.tar.gz
+        001-index64.patch
         002-lgfortran-requires-lquadmath.patch)
 install=${_realname}.install
 sha256sums=('8495c9affc536253648e942908e88e097f2ec7753ede55aca52e5dead3029e3c'
+            '7a53bfd5ad2573889a63a9f594fe1b2ea2da15db6f88183e928b40adce420e9f'
             'fecd847d029f5fa0d48c685e48e1d5efd413ead14452349fe78a66717fbce3e7')
 
 # Helper macros to help make tasks easier #
@@ -43,6 +45,11 @@ apply_patch_with_msg() {
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
+
+  # https://github.com/xianyi/OpenBLAS/pull/3575
+  apply_patch_with_msg \
+    001-index64.patch \
+
   apply_patch_with_msg \
     002-lgfortran-requires-lquadmath.patch
 }
@@ -91,6 +98,16 @@ build() {
 
     msg2 "Build OpenBLAS with 64-bit indexing"
     _build_openblas "-DBINARY=64 -DINTERFACE64=1"
+  fi
+}
+
+check() {
+  cd "${srcdir}"/build-${MSYSTEM}-32
+  ctest
+
+  if [ "${CARCH}" != "i686" ]; then
+    cd "${srcdir}/build-${MSYSTEM}-64"
+    ctest
   fi
 }
 


### PR DESCRIPTION
`ctest` currently fails for the 64-bit indexing version on MINGW. That is because `long` is used in the C interface when calling the Fortran functions that use 64-bit integers. On Windows 64-bit, `long` is 32-bit wide.

This adds a patch that was proposed upstream (cherry-picked from reference-LAPACK).
