### PR TITLE
hiredis: update to 1.0.2 and improve build process

### DIFF
--- a/mingw-w64-hiredis/0001-Add-static-library-target-and-cpack-support.patch
+++ b/mingw-w64-hiredis/0001-Add-static-library-target-and-cpack-support.patch
@@ -1,0 +1,95 @@
+From d7cd69345ff896168e73692280d5bef30702ebdc Mon Sep 17 00:00:00 2001
+From: masariello <masariello@users.noreply.github.com>
+Date: Wed, 22 Jul 2020 14:23:53 +0100
+Subject: [PATCH] Add static library target and cpack support
+
+---
+ CMakeLists.txt | 42 ++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 38 insertions(+), 4 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f86c9b7..a41863c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -41,19 +41,48 @@ IF(WIN32)
+ ENDIF()
+ 
+ ADD_LIBRARY(hiredis SHARED ${hiredis_sources})
++ADD_LIBRARY(hiredis_static STATIC ${hiredis_sources})
+ 
+ SET_TARGET_PROPERTIES(hiredis
+     PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE
+     VERSION "${HIREDIS_SONAME}")
+ IF(WIN32 OR MINGW)
+-    TARGET_LINK_LIBRARIES(hiredis PRIVATE ws2_32)
++    TARGET_LINK_LIBRARIES(hiredis PUBLIC ws2_32 crypt32)
++    TARGET_LINK_LIBRARIES(hiredis_static PUBLIC ws2_32 crypt32)
+ ENDIF()
+ 
+-TARGET_INCLUDE_DIRECTORIES(hiredis PUBLIC $<INSTALL_INTERFACE:.> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
++TARGET_INCLUDE_DIRECTORIES(hiredis PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
++TARGET_INCLUDE_DIRECTORIES(hiredis_static PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+ 
+ CONFIGURE_FILE(hiredis.pc.in hiredis.pc @ONLY)
+ 
+-INSTALL(TARGETS hiredis
++set(CPACK_PACKAGE_VENDOR "Redis")
++set(CPACK_PACKAGE_DESCRIPTION "\
++Hiredis is a minimalistic C client library for the Redis database.
++
++It is minimalistic because it just adds minimal support for the protocol, \
++but at the same time it uses a high level printf-alike API in order to make \
++it much higher level than otherwise suggested by its minimal code base and the \
++lack of explicit bindings for every Redis command.
++
++Apart from supporting sending commands and receiving replies, it comes with a \
++reply parser that is decoupled from the I/O layer. It is a stream parser designed \
++for easy reusability, which can for instance be used in higher level language bindings \
++for efficient reply parsing.
++
++Hiredis only supports the binary-safe Redis protocol, so you can use it with any Redis \
++version >= 1.2.0.
++
++The library comes with multiple APIs. There is the synchronous API, the asynchronous API \
++and the reply parsing API.")
++set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/redis/hiredis")
++set(CPACK_PACKAGE_CONTACT "michael dot grunder at gmail dot com")
++set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
++set(CPACK_RPM_PACKAGE_AUTOREQPROV ON)
++
++include(CPack)
++
++INSTALL(TARGETS hiredis hiredis_static
+     EXPORT hiredis-targets
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+@@ -99,6 +128,8 @@ IF(ENABLE_SSL)
+         ssl.c)
+     ADD_LIBRARY(hiredis_ssl SHARED
+             ${hiredis_ssl_sources})
++    ADD_LIBRARY(hiredis_ssl_static STATIC
++            ${hiredis_ssl_sources})
+ 
+     IF (APPLE)
+         SET_PROPERTY(TARGET hiredis_ssl PROPERTY LINK_FLAGS "-Wl,-undefined -Wl,dynamic_lookup")
+@@ -110,13 +141,16 @@ IF(ENABLE_SSL)
+         VERSION "${HIREDIS_SONAME}")
+ 
+     TARGET_INCLUDE_DIRECTORIES(hiredis_ssl PRIVATE "${OPENSSL_INCLUDE_DIR}")
++    TARGET_INCLUDE_DIRECTORIES(hiredis_ssl_static PRIVATE "${OPENSSL_INCLUDE_DIR}")
++
+     TARGET_LINK_LIBRARIES(hiredis_ssl PRIVATE ${OPENSSL_LIBRARIES})
+     IF (WIN32 OR MINGW)
+         TARGET_LINK_LIBRARIES(hiredis_ssl PRIVATE hiredis)
++        TARGET_LINK_LIBRARIES(hiredis_ssl_static PUBLIC hiredis_static)
+     ENDIF()
+     CONFIGURE_FILE(hiredis_ssl.pc.in hiredis_ssl.pc @ONLY)
+ 
+-    INSTALL(TARGETS hiredis_ssl
++    INSTALL(TARGETS hiredis_ssl hiredis_ssl_static
+         EXPORT hiredis_ssl-targets
+         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-- 
+2.35.1.windows.2
+

--- a/mingw-w64-hiredis/PKGBUILD
+++ b/mingw-w64-hiredis/PKGBUILD
@@ -25,6 +25,8 @@ sha256sums=('e0ab696e2f07deb4252dda45b703d09854e53b9703c7d52182ce5a22616c3819'
             
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
+
+  # https://github.com/redis/hiredis/pull/851
   patch -p1 -i ${srcdir}/0001-Add-static-library-target-and-cpack-support.patch
 }
 

--- a/mingw-w64-hiredis/PKGBUILD
+++ b/mingw-w64-hiredis/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=hiredis
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.0.0
+pkgver=1.0.2
 pkgrel=1
 pkgdesc="Minimalistic C client for Redis"
 arch=('any')
@@ -13,25 +13,36 @@ license=("BSD-3-Clause License")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
             "${MINGW_PACKAGE_PREFIX}-pkg-config"
             "${MINGW_PACKAGE_PREFIX}-cmake"
+            "${MINGW_PACKAGE_PREFIX}-ninja"
             "${MINGW_PACKAGE_PREFIX}-openssl")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-crt"
          "${MINGW_PACKAGE_PREFIX}-openssl")
-source=("https://github.com/redis/hiredis/archive/v${pkgver}.tar.gz")
-sha256sums=('2a0b5fe5119ec973a0c1966bfc4bd7ed39dbce1cb6d749064af9121fe971936f')
+source=("https://github.com/redis/hiredis/archive/v${pkgver}.tar.gz"
+        '0001-Add-static-library-target-and-cpack-support.patch')
+sha256sums=('e0ab696e2f07deb4252dda45b703d09854e53b9703c7d52182ce5a22616c3819'
+            '22461977c6d23bab3d14f9a35f35b65ecaeefa4cf3e520fdff4dd22b0ea0bc24')
             
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
+  patch -p1 -i ${srcdir}/0001-Add-static-library-target-and-cpack-support.patch
 }
 
 build() {
-  cd ${srcdir}/${_realname}-${pkgver}
-  
-  MSYS2_ARG_CONV_EXCL=- cmake . -G"MSYS Makefiles" -DCMAKE_INSTALL_PREFIX=$MINGW_PREFIX -DENABLE_SSL=ON
+  rm -rf "${srcdir}/build-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
+
+  MSYS2_ARG_CONV_EXCL=- \
+    ${MINGW_PREFIX}/bin/cmake ../${_realname}-${pkgver} \
+    -G"Ninja" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=$MINGW_PREFIX \
+    -DENABLE_SSL=ON
+  ${MINGW_PREFIX}/bin/cmake --build .
 }
 
 package() {
-  cd ${srcdir}/${_realname}-${pkgver}
+  cd "${srcdir}/build-${MINGW_CHOST}"
   
-  make install DESTDIR="${pkgdir}"
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --build . --target install
 }


### PR DESCRIPTION
* Separate build directory.
* Build in release mode.
* Use ninja.
* Include a patch from master that adds static libs.