### PR TITLE
netcdf: Rebuild to fix generated cmake and pkgconfig files.

### DIFF
--- a/mingw-w64-netcdf/PKGBUILD
+++ b/mingw-w64-netcdf/PKGBUILD
@@ -4,7 +4,7 @@ _realname=netcdf
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.8.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Interface for scientific data access to large binary data (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -57,8 +57,10 @@ build() {
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=OFF \
     -DENABLE_DLL=OFF \
-    -DENABLE_DAP=ON \
+    -DBUILD_UTILITIES=OFF \
+    -DENABLE_EXAMPLES=OFF \
     -DENABLE_TESTS=OFF \
+    -DENABLE_DAP=ON \
     -DENABLE_NETCDF_4=ON \
     -Wno-dev \
     "${srcdir}/${_realname}-c-${pkgver}"
@@ -73,8 +75,9 @@ build() {
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=ON \
-    -DENABLE_DAP=ON \
+    -DENABLE_EXAMPLES=OFF \
     -DENABLE_TESTS=OFF \
+    -DENABLE_DAP=ON \
     -DENABLE_NETCDF_4=ON \
     -DENABLE_LOGGING=ON \
     -Wno-dev \


### PR DESCRIPTION
FindHDF5 from CMake is now fixed after I have backported a fix from https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7105