### PR TITLE
mathgl: update to 8.0.1

### DIFF
--- a/mingw-w64-mathgl/001-fix-cmake-files.patch
+++ b/mingw-w64-mathgl/001-fix-cmake-files.patch
@@ -1,16 +1,36 @@
---- mathgl-2.4.2/CMakeLists.txt.orig	2018-07-10 16:04:53 +0000
-+++ mathgl-2.4.2/CMakeLists.txt	2018-07-10 16:06:21 +0000
-@@ -39,7 +39,7 @@ endif(CMAKE_BUILD_TYPE STREQUAL "Debug")
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -46,7 +46,7 @@
  set(MathGL_INSTALL_LIB_DIR "lib" CACHE PATH "Installation directory for libraries")
  set(MathGL_INSTALL_BIN_DIR "bin" CACHE PATH "Installation directory for executables")
  set(MathGL_INSTALL_INCLUDE_DIR "include" CACHE PATH "Installation directory for headers")
 -if(WIN32 AND NOT CYGWIN)
-+if(WIN32 AND NOT CYGWIN AND NOT MSYS AND NOT MINGW)
-   set(DEF_INSTALL_CMAKE_DIR cmake)
++if(MSVC)
+ 	set(DEF_INSTALL_CMAKE_DIR cmake)
  else()
-   set(DEF_INSTALL_CMAKE_DIR lib/cmake/mathgl)
---- mathgl-2.4.2/scripts/CMakeLists.txt.orig	2018-03-21 12:48:20.000000000 -0400
-+++ mathgl-2.4.2/scripts/CMakeLists.txt	2018-07-10 23:10:20.640414400 -0400
+ 	set(DEF_INSTALL_CMAKE_DIR lib/cmake/mathgl2)
+@@ -293,16 +293,16 @@
+ set(MGL_CGI_PATH "${CMAKE_INSTALL_PREFIX}/${MGL_CGI_PATH_INSTALL}")
+ set(MGL_DEF_FONT "STIX" CACHE STRING "Set default font name")
+ 
+-if(NOT WIN32)
++if(NOT MSVC)
+ #	set(MGL_CGI_PATH "${CMAKE_INSTALL_PREFIX}/share/mathgl")
+ 	set(MGL_DATA_PATH "${CMAKE_INSTALL_PREFIX}/share/mathgl")
+ 	set(MGL_DOC_PATH "${CMAKE_INSTALL_PREFIX}/share/doc/mathgl")
+ 	set(MGL_MAN_PATH "${CMAKE_INSTALL_PREFIX}/share/man")
+ 	set(MGL_INFO_PATH "${CMAKE_INSTALL_PREFIX}/share/info")
+ 	set(MGL_FONT_PATH "${MGL_DATA_PATH}/fonts")
+-else(NOT WIN32)
++else()
+ 	set(MGL_FONT_PATH "${CMAKE_INSTALL_PREFIX}/fonts")
+-endif(NOT WIN32)
++endif()
+ 
+ include(CheckFunctionExists)
+ include(CMakePushCheckState)
+--- a/scripts/CMakeLists.txt
++++ b/scripts/CMakeLists.txt
 @@ -11,13 +11,13 @@ if(enable-dep-dll)
  	install(SCRIPT install-deps.cmake)
  endif(enable-dep-dll)

--- a/mingw-w64-mathgl/PKGBUILD
+++ b/mingw-w64-mathgl/PKGBUILD
@@ -3,35 +3,36 @@
 _realname=mathgl
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.4.4
-pkgrel=6
+pkgver=8.0.1
+pkgrel=1
 pkgdesc="Library for high-quality scientific graphics (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://mathgl.sourceforge.io/"
 license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-ninja"
-             "${MINGW_PACKAGE_PREFIX}-cc")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
 depends=("${MINGW_PACKAGE_PREFIX}-giflib"
          "${MINGW_PACKAGE_PREFIX}-gsl"
+         "${MINGW_PACKAGE_PREFIX}-gettext"
          "${MINGW_PACKAGE_PREFIX}-hdf5"
          "${MINGW_PACKAGE_PREFIX}-fltk"
          "${MINGW_PACKAGE_PREFIX}-freeglut"
-         "${MINGW_PACKAGE_PREFIX}-libharu"
          "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
          "${MINGW_PACKAGE_PREFIX}-libpng"
+         "${MINGW_PACKAGE_PREFIX}-libwinpthread-git"
          "${MINGW_PACKAGE_PREFIX}-qt5-base"
-         "${MINGW_PACKAGE_PREFIX}-qtwebkit")
+         "${MINGW_PACKAGE_PREFIX}-zlib")
          #"${MINGW_PACKAGE_PREFIX}-wxWidgets"
 source=("${_realname}-${pkgver}.tar.gz::https://downloads.sourceforge.net/${_realname}/${_realname}-${pkgver}.tar.gz"
-        "${_realname}-2.4.2.patch")
-sha256sums=('0e5977196635962903eaff9b2f759e5b89108339b6e71427036c92bfaf3149e9'
-            '3ee9d25a5de4db07ad43412eb69d95cfb7e6ef88f3ea4a5036810efd81ea9f9c')
+        "001-fix-cmake-files.patch")
+sha256sums=('ca84bf9480c39ed3112e920c16ce3d8f2898698f62896f3a57714128622a55aa'
+            '27c6d40f04e3a10d40490c42fac6560a9f304bfbdba45614e7de6f830a8bb820')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
-  patch -Np1 -i "${srcdir}/${_realname}-2.4.2.patch"
+  patch -Np1 -i "${srcdir}/001-fix-cmake-files.patch"
 }
 
 build() {
@@ -64,12 +65,13 @@ build() {
     -Denable-png=ON \
     -Denable-qt5=ON \
     -Denable-openmp=OFF \
+    -DGLUT_glut_LIBRARY_RELEASE=${MINGW_PREFIX}/lib/libfreeglut.dll.a \
     "../${_realname}-${pkgver}"
 
     # -Denable-pdf=ON
     # -Denable-wx=ON
 
-  ${MINGW_PREFIX}/bin/cmake.exe --build ./
+  ${MINGW_PREFIX}/bin/cmake.exe --build .
 }
 
 package() {
@@ -78,7 +80,7 @@ package() {
 
   # fixup references in associated cmake modules
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
-  for _ff in ${pkgdir}${MINGW_PREFIX}/lib/cmake/mathgl/*.cmake; do
+  for _ff in ${pkgdir}${MINGW_PREFIX}/lib/cmake/mathgl2/*.cmake; do
     sed -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${_ff}
   done
 }


### PR DESCRIPTION
This is the second time I have to pass `-DGLUT_glut_LIBRARY_RELEASE=${MINGW_PREFIX}/lib/libfreeglut.dll.a` to cmake to prevent it from picking `libglut.a` on `i686` environments.

Maybe building `libglut.a` should be disabled everywhere!
#437
#10915 