### PR TITLE
CI: don't override MINGW_PACKAGE_PREFIX when getting build order.

### DIFF
--- a/.ci/ci-get-build-order.py
+++ b/.ci/ci-get-build-order.py
@@ -47,8 +47,7 @@ def get_pkginfo(package, packageset):
         script += f"echo \"${{{prop}[@]}}\" && printf '\\0'\n"
 
     shell = os.environ.get("SHELL", "bash")
-    env = {**os.environ, "MINGW_PACKAGE_PREFIX": "mingw-w64"}
-    results = run(shell, "-c", script, env=env).split("\0")[:-1]
+    results = run(shell, "-c", script).split("\0")[:-1]
     assert len(props) == len(results), "Length of props matches results"
 
     info = {}


### PR DESCRIPTION
This doesn't seem to be necessary after
6913cd7f417fe98b7db2fe7f7571bf71629a4c77, and causes issues with
packages that attempt to dynamically adjust their metadata.

See https://github.com/msys2/MINGW-packages/pull/11143#issuecomment-1086697564