### PR TITLE
python-sphinx_rtd_theme: update to 1.0.0

### DIFF
--- a/mingw-w64-python-sphinx/PKGBUILD
+++ b/mingw-w64-python-sphinx/PKGBUILD
@@ -9,7 +9,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=4.5.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Python documentation generator (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -19,6 +19,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-python-babel"
          "${MINGW_PACKAGE_PREFIX}-python-colorama"
          "${MINGW_PACKAGE_PREFIX}-python-docutils"
          "${MINGW_PACKAGE_PREFIX}-python-imagesize"
+         "${MINGW_PACKAGE_PREFIX}-python-importlib-metadata"
          "${MINGW_PACKAGE_PREFIX}-python-jinja"
          "${MINGW_PACKAGE_PREFIX}-python-packaging"
          "${MINGW_PACKAGE_PREFIX}-python-pygments"
@@ -43,25 +44,25 @@ sha256sums=('7bf8ca9637a4ee15af412d1a1d9689fec70523a68ca9bb9127c2f3eeb344e2e6')
 prepare() {
   cd ${srcdir}/${_pyname}-${pkgver}
   # docutils
-  sed -i 's/<0.18/<0.19/' setup.py
+  sed -i 's/docutils>=0.14,<0.18/docutils>=0.14,<0.18.2/' setup.py
 
   cd ${srcdir}
-  cp -r "${_pyname}-${pkgver}" "python-build-${CARCH}"
+  cp -r "${_pyname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 
 build() {
-  cd "${srcdir}/python-build-${CARCH}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
   ${MINGW_PREFIX}/bin/python setup.py build
 }
 
 check() {
-  cd "${srcdir}/python-build-${CARCH}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
   #2 failed, 1165 passed, 21 skipped, 3 xfailed, 30 xpassed, 3 warnings
   ${MINGW_PREFIX}/bin/py.test || warning "test failed"
 }
 
 package() {
-  cd "${srcdir}/python-build-${CARCH}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" -O1 --skip-build
 

--- a/mingw-w64-python-sphinx_rtd_theme/PKGBUILD
+++ b/mingw-w64-python-sphinx_rtd_theme/PKGBUILD
@@ -6,36 +6,41 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=0.4.3
-pkgrel=2
+pkgver=1.0.0
+pkgrel=1
 pkgdesc="Python Sphinx Read The Docs Theme (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 license=('MIT')
 url='https://github.com/snide/sphinx_rtd_theme'
-depends=("${MINGW_PACKAGE_PREFIX}-python")
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-docutils"
+         "${MINGW_PACKAGE_PREFIX}-python-sphinx")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('staticlibs')
 source=("https://pypi.org/packages/source/s/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('728607e34d60456d736cc7991fd236afb828b21b82f956c5ea75f94c8414040a')
+sha256sums=('eec6d497e4c2195fa0e8b2016b337532b8a699a68bcb22a512870e16925c6a5c')
 
 prepare() {
-  cd ${srcdir}
-  cp -r ${_realname}-${pkgver} python-build-${CARCH}
+  cd "${srcdir}/${_realname}-${pkgver}"
+  sed -e "s|docutils<0.18|docutils<0.18.2|g" -i setup.py
+
+  rm -rf "${srcdir}/python-build-${MSYSTEM}" | true
+  cp -r "${srcdir}/${_realname}-${pkgver}" "${srcdir}/python-build-${MSYSTEM}"
 }
 
 build() {
-  cd "${srcdir}/python-build-${CARCH}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
   ${MINGW_PREFIX}/bin/python setup.py build
 }
 
 check() {
-  cd "${srcdir}/python-build-${CARCH}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
   ${MINGW_PREFIX}/bin/python setup.py test
 }
 
 package() {
-  cd "${srcdir}/python-build-${CARCH}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
     ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" -O1 --skip-build
 


### PR DESCRIPTION
I could do nothing about `docutils` dependency that has been already updated to 0.18.1