### PR TITLE
python-spyder: update to 5.3.0

### DIFF
--- a/mingw-w64-python-ipykernel/PKGBUILD
+++ b/mingw-w64-python-ipykernel/PKGBUILD
@@ -6,8 +6,8 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=5.5.5
-pkgrel=2
+pkgver=6.10.0
+pkgrel=1
 pkgdesc="The ipython kernel for Jupyter (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -24,30 +24,30 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest"
               "${MINGW_PACKAGE_PREFIX}-python-mock"
               "${MINGW_PACKAGE_PREFIX}-python-nose")
-#install=ipython3-${CARCH}.install
-source=("${_realname}-${pkgver}.tar.gz::https://github.com/ipython/${_realname}/archive/${pkgver}.tar.gz")
-sha256sums=('82585b4067b38f3b3bf09a233b7bc9e6c6f51446693ad14d302f06ff35189990')
+#install=ipython3-${MSYSTEM}.install
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/ipython/${_realname}/archive/v${pkgver}.tar.gz")
+sha256sums=('b4b245e6cd36de454e45150ca584b1fa7a2a5b2330ff5434b42e5ad611bacd36')
 
 prepare() {
   cd "${srcdir}"
-  rm -rf python-build-${CARCH} | true
-  cp -r "${_realname}-${pkgver}" "python-build-${CARCH}"
+  rm -rf python-build-${MSYSTEM} | true
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 
 build() {
-  msg "Python build for ${CARCH}"
-  cd "${srcdir}/python-build-${CARCH}"
+  msg "Python build for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
   ${MINGW_PREFIX}/bin/python setup.py build
 }
 
 check() {
-  msg "Python test for ${CARCH}"
-  cd "${srcdir}/python-build-${CARCH}"
+  msg "Python test for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
   ${MINGW_PREFIX}/bin/python -m pytest || warning "Tests failed"
 }
 
 package() {
-  cd "${srcdir}/python-build-${CARCH}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
     --root="${pkgdir}" --optimize=1 --skip-build

--- a/mingw-w64-python-ipython/PKGBUILD
+++ b/mingw-w64-python-ipython/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=7.30.1
+pkgver=7.32.0
 pkgrel=1
 pkgdesc="An enhanced Interactive Python shell (mingw-w64)"
 arch=('any')
@@ -39,30 +39,28 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python-requests"
               "${MINGW_PACKAGE_PREFIX}-python-ipykernel"
               "${MINGW_PACKAGE_PREFIX}-python-numpy")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/ipython/ipython/archive/${pkgver}.tar.gz")
-sha256sums=('8713645726f48e1f6c6989b7cd80afdc8b9eed0cc1bec3387d875b374ad68d65')
+sha256sums=('a4f70dc6cdfd3198beaad54851622e184d0dc724f4f3baa0ec8eed46742e15f9')
 
 prepare() {
   cd "${srcdir}"
-  rm -rf python-build-${CARCH} | true
-  cp -r "${_realname}-${pkgver}" "python-build-${CARCH}"
+  rm -rf python-build-${MSYSTEM} | true
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 
 build() {
-  msg "Python build for ${CARCH}"  
-  cd "${srcdir}/python-build-${CARCH}"
+  msg "Python build for ${MSYSTEM}"  
+  cd "${srcdir}/python-build-${MSYSTEM}"
   ${MINGW_PREFIX}/bin/python setup.py build
 }
 
 check() {
-  msg "Python test for ${CARCH}"
-  cd "${srcdir}/python-build-${CARCH}"
+  msg "Python test for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
   ${MINGW_PREFIX}/bin/python -m test || warning "Tests fail"
 }
 
 package() {
-  cd "${srcdir}/python-build-${CARCH}"
-  # see https://github.com/ipython/ipython/issues/2057
-  #export LC_ALL=en_US.UTF-8
+  cd "${srcdir}/python-build-${MSYSTEM}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
     ${MINGW_PREFIX}/bin/python setup.py install \
      --prefix=${MINGW_PREFIX} --root=${pkgdir} --optimize=1 --skip-build

--- a/mingw-w64-python-lsp-black/PKGBUILD
+++ b/mingw-w64-python-lsp-black/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=lsp-black
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
-pkgver=1.0.0
+pkgver=1.2.0
 pkgrel=1
 pkgdesc='Black plugin for the Python LSP Server (mingw-w64)'
 arch=('any')
@@ -18,7 +18,7 @@ depends=(
 makedepends=(
     ${MINGW_PACKAGE_PREFIX}-python-setuptools)
 source=(https://github.com/python-lsp/python-${_realname}/archive/v${pkgver}.tar.gz)
-sha256sums=('76e23e09e342b572c94b42a9d8c3cf10c3a1b1aed9969bd6817cb085e214432e')
+sha256sums=('2eac50f70397d1abea33f7ba53122d41cf2b50633132648243775bd03b3d76c6')
 
 prepare() {
   cd "${srcdir}"

--- a/mingw-w64-python-lsp-server/PKGBUILD
+++ b/mingw-w64-python-lsp-server/PKGBUILD
@@ -1,10 +1,10 @@
 # Contributor: Raed Rizqie <raed.rizqie@gmail.com>
 
-_realname=lsp-server
-pkgbase=mingw-w64-python-${_realname}
-pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
-pkgver=1.3.3
-pkgrel=2
+_realname=python-lsp-server
+pkgbase=mingw-w64-${_realname}
+pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
+pkgver=1.4.1
+pkgrel=1
 pkgdesc='Python Language Server for the Language Server Protocol (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -28,13 +28,15 @@ depends=(
     ${MINGW_PACKAGE_PREFIX}-python-ujson
     ${MINGW_PACKAGE_PREFIX}-python-yapf
 )
-makedepends=(${MINGW_PACKAGE_PREFIX}-python-setuptools)
-source=(https://github.com/python-lsp/python-${_realname}/archive/v${pkgver}.tar.gz)
-sha256sums=('c37b89b4ba3dda15c20e3845be2dfef947d62c26fb3f58a086570603b1896d2d')
+makedepends=(${MINGW_PACKAGE_PREFIX}-python-setuptools
+             ${MINGW_PACKAGE_PREFIX}-python-setuptools-scm
+             ${MINGW_PACKAGE_PREFIX}-python-wheel)
+source=(https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz)
+sha256sums=('be7f83298af9f0951a93972cafc9db04fd7cf5c05f20812515275f0ba70e342f')
 
 prepare() {
   rm -rf python-build-${MSYSTEM} | true
-  cp -r "python-${_realname}-${pkgver}" "python-build-${MSYSTEM}"
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 
 build() {
@@ -54,5 +56,5 @@ package() {
     sed -e '1 { s/^#!.*$// }' -i "${_f}"
   done
 
-  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-python-qtconsole/PKGBUILD
+++ b/mingw-w64-python-qtconsole/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=5.2.1
+pkgver=5.3.0
 pkgrel=1
 pkgdesc="A rich Qt-based console for working with Jupyter kernels, supporting rich media output, session export, and more (mingw-w64)"
 arch=('any')
@@ -19,7 +19,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-pyqt5")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/jupyter/qtconsole/archive/${pkgver}.tar.gz")
-sha256sums=('90e6eedb84f1e3ddc775599d9f14fe7fb68e55f2b849e9006a5c4706f869f7c4')
+sha256sums=('d443da3ce2954322b65956ec674ad83161cbaac819bd8928083ca2f2997c8e25')
 
 prepare() {
   cd "${srcdir}"

--- a/mingw-w64-python-qtpy/PKGBUILD
+++ b/mingw-w64-python-qtpy/PKGBUILD
@@ -3,34 +3,35 @@
 _realname=qtpy
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=1.9.0
-pkgrel=3
+pkgver=2.0.1
+pkgrel=1
 pkgdesc='Provides an uniform layer to support PyQt5, PyQt4 and PySide with a single codebase (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://github.com/spyder-ide/qtpy/"
 license=('MIT')
-depends=("${MINGW_PACKAGE_PREFIX}-python")
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-packaging")
 optdepends=("${MINGW_PACKAGE_PREFIX}-python-pyqt5: Qt5 Python bindings"
-"${MINGW_PACKAGE_PREFIX}-pyside2-qt5: PySide Qt5 Python bindings")
+            "${MINGW_PACKAGE_PREFIX}-pyside2-qt5: PySide Qt5 Python bindings")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 source=("$_realname-${pkgver}.tar.gz::https://github.com/spyder-ide/${_realname}/archive/v${pkgver}.tar.gz")
-sha256sums=('a6783acab8f7f7b04026c7da19c65bf904d69629d06d951cb7b9344468270c5b')
+sha256sums=('905e801ee0c5fa65c8e0cff1067f99f9c25f69014a5e0674011ce53894f7132b')
 
-prepare() {  
+prepare() {
   cd "$srcdir"
-  rm -rf python-build-${CARCH} | true
-  cp -r "${_realname}-${pkgver}" "python-build-${CARCH}"
+  rm -rf python-build-${MSYSTEM} | true
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 
 build() {
-  msg "Python build for ${CARCH}"  
-  cd "${srcdir}/python-build-${CARCH}"
+  msg "Python build for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
   ${MINGW_PREFIX}/bin/python setup.py build
 }
 
 package() {
-  cd "${srcdir}/python-build-${CARCH}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
     --root="${pkgdir}" --optimize=1 --skip-build

--- a/mingw-w64-python-spyder-kernels/PKGBUILD
+++ b/mingw-w64-python-spyder-kernels/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=spyder-kernels
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
-pkgver=2.2.0
+pkgver=2.3.0
 pkgrel=1
 pkgdesc='Jupyter Kernels for the Spyder console (mingw-w64)'
 arch=('any')
@@ -20,7 +20,7 @@ depends=(
 makedepends=(
     ${MINGW_PACKAGE_PREFIX}-python-setuptools)
 source=("https://github.com/spyder-ide/${_realname}/archive/v${pkgver}.tar.gz")
-sha256sums=('d82b216b731743f0f63ad5d74a95b49d0c8d101dd33453384cac4c38ae8bf8e7')
+sha256sums=('3fbf18088fdd3c4d3ca1923790b2537d08f52bb7e616a15a544534ef8e22d05f')
 
 prepare() {
   cd "${srcdir}"

--- a/mingw-w64-python-spyder/PKGBUILD
+++ b/mingw-w64-python-spyder/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=spyder
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
-pkgver=5.2.1
+pkgver=5.3.0
 pkgrel=1
 pkgdesc='The Scientific Python Development Environment (mingw-w64)'
 arch=('any')
@@ -62,8 +62,8 @@ optdepends=(
 makedepends=(${MINGW_PACKAGE_PREFIX}-python-setuptools)
 source=(https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz
         spyder-requirements-fix.patch)
-sha256sums=('b318a70a75acd200018a547d2ff2d2f55e7507054469d0c77ec6f967ac3c2d28'
-            '3f3fd7988cc8000b65cf2b73e6f1a5c7e660570205438d17f68b20ee16c7c8d0')
+sha256sums=('820085bd851d526e5f552a5366837f3a134f24040ec9e870ad0a6b613ce9adb7'
+            'b903a2249ca801de30b00461ccb09c7db66053ba72c7b8081b53ca270f035956')
 
 prepare() {
   rm -rf python-build-${MSYSTEM} | true

--- a/mingw-w64-python-spyder/spyder-requirements-fix.patch
+++ b/mingw-w64-python-spyder/spyder-requirements-fix.patch
@@ -1,7 +1,6 @@
-diff -urN spyder-5.2.0-orig/setup.py spyder-5.2.0/setup.py
---- spyder-5.2.0-orig/setup.py	2021-11-26 00:43:42.420508300 +0800
-+++ spyder-5.2.0/setup.py	2021-11-26 01:41:05.600446900 +0800
-@@ -95,7 +95,7 @@
+--- a/setup.py
++++ b/setup.py
+@@ -97,7 +97,7 @@
                        ('share/metainfo',
                         ['scripts/org.spyder_ide.spyder.appdata.xml'])]
      elif os.name == 'nt':
@@ -10,13 +9,11 @@ diff -urN spyder-5.2.0-orig/setup.py spyder-5.2.0/setup.py
                                     'img_src/spyder_reset.ico'])]
      else:
          data_files = []
-@@ -225,8 +225,7 @@
-     'pylint>=2.5.0',
-     'python-lsp-black>=1.0.0',
+@@ -227,7 +227,6 @@
+     'python-lsp-black>=1.2.0',
      'pyls-spyder>=0.4.0',
--    'pyqt5<5.13',
--    'pyqtwebengine<5.13',
-+    'pyqt5>=5.13',
-     'python-lsp-server[all]>=1.3.2,<1.4.0',
+     'pyqt5<5.16',
+-    'pyqtwebengine<5.16',
+     'python-lsp-server[all]>=1.4.1,<1.5.0',
      'pyxdg>=0.26;platform_system=="Linux"',
      'pyzmq>=17',


### PR DESCRIPTION
The latest version of ipykernel is 6.11.0 but I think it requires setuptools>60
The latest version of ipython is 8.1.0, but spyder only accepts ipython<8.0