### PR TITLE
mlir, flang: update to 14.0.0

### DIFF
--- a/mingw-w64-flang/0001-cast-cxx11-narrowing.patch
+++ b/mingw-w64-flang/0001-cast-cxx11-narrowing.patch
@@ -1,17 +1,6 @@
---- a/runtime/misc-intrinsic.cpp	2021-10-02 17:25:54.576794400 -0700
-+++ b/runtime/misc-intrinsic.cpp	2021-10-02 17:27:11.031517900 -0700
-@@ -47,7 +47,7 @@
-         "TRANSFER: could not allocate memory for result; STAT=%d", stat);
-   }
-   char *to{result.OffsetElement<char>()};
--  std::size_t resultBytes{size * elementBytes};
-+  std::size_t resultBytes{static_cast<size_t>(size * elementBytes)};
-   const std::size_t sourceElementBytes{source.ElementBytes()};
-   std::size_t sourceElements{source.Elements()};
-   SubscriptValue sourceAt[maxRank];
---- a/lib/Evaluate/constant.cpp	2021-10-02 17:33:29.706776300 -0700
-+++ b/lib/Evaluate/constant.cpp	2021-10-02 17:34:52.363465800 -0700
-@@ -251,7 +251,7 @@
+--- a/lib/Evaluate/constant.cpp	2022-04-04 18:19:29.274848400 -0700
++++ b/lib/Evaluate/constant.cpp	2022-04-04 18:20:50.455510700 -0700
+@@ -274,7 +274,7 @@
      return count;
    } else {
      std::size_t copied{0};
@@ -20,18 +9,29 @@
      ConstantSubscripts sourceSubscripts{source.lbounds()};
      while (copied < count) {
        auto *dest{&values_.at(SubscriptsToOffset(resultSubscripts) * length_)};
---- a/runtime/transformational.cpp	2021-10-02 18:11:08.727836900 -0700
-+++ b/runtime/transformational.cpp	2021-10-02 18:11:56.743494500 -0700
-@@ -183,7 +183,7 @@
+--- a/runtime/command.cpp	2022-04-04 18:19:29.549977300 -0700
++++ b/runtime/command.cpp	2022-04-04 18:59:05.094966300 -0700
+@@ -30,7 +30,7 @@
+   if constexpr (sizeof(std::size_t) <= sizeof(std::int64_t)) {
+     return static_cast<std::int64_t>(length);
+   } else {
+-    std::size_t max{std::numeric_limits<std::int64_t>::max()};
++    std::uint64_t max{std::numeric_limits<std::int64_t>::max()};
+     return length > max ? 0 // Just fail.
+                         : static_cast<std::int64_t>(length);
+   }
+--- a/runtime/transformational.cpp	2022-04-04 18:19:29.605979000 -0700
++++ b/runtime/transformational.cpp	2022-04-04 20:04:31.322600400 -0700
+@@ -184,7 +184,7 @@
    SubscriptValue lb{sourceDim.LowerBound()};
    for (SubscriptValue j{0}; j < extent; ++j) {
      SubscriptValue resultAt{1 + j};
 -    SubscriptValue sourceAt{lb + (j + shift) % extent};
 +    SubscriptValue sourceAt{static_cast<SubscriptValue>(lb + (j + shift) % extent)};
-     if (sourceAt < 0) {
+     if (sourceAt < lb) {
        sourceAt += extent;
      }
-@@ -281,7 +281,7 @@
+@@ -282,7 +282,7 @@
    }
    SubscriptValue lb{source.GetDimension(0).LowerBound()};
    for (SubscriptValue j{1}; j <= extent; ++j) {
@@ -39,4 +39,4 @@
 +    SubscriptValue sourceAt{static_cast<SubscriptValue>(lb + j - 1 + shift)};
      if (sourceAt >= lb && sourceAt < lb + extent) {
        CopyElement(result, &j, source, &sourceAt, terminator);
-     }
+     } else if (boundary) {

--- a/mingw-w64-flang/PKGBUILD
+++ b/mingw-w64-flang/PKGBUILD
@@ -2,7 +2,7 @@ _compiler=clang
 _realname=flang
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=13.0.1
+pkgver=14.0.0
 pkgrel=1
 pkgdesc="Fortran frontend for LLVM (mingw-w64)"
 arch=('any')
@@ -28,9 +28,9 @@ options=('!debug' 'strip')
 source=("https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkgver}/flang-${pkgver}.src.tar.xz"{,.sig}
         "0001-cast-cxx11-narrowing.patch"
         "0002-cmake-22162.patch")
-sha256sums=('129587687253c82de1a3a5eed18c1e12f16c3ad44cb881129b10335555b90778'
+sha256sums=('631deb2ab6308ccc2617370361d3cce4ef6203915cf3bc386f9a79aea921c5a3'
             'SKIP'
-            'f8babd240968599597cf2b906fad44b62e2d92ac7ea144530a3f9542e96e06b1'
+            'ba08064d737a2aa173125e88c3900dce804220fb0562596b03130177c2139312'
             '77fb0612217b6af7a122f586a9d0d334cd48bb201509bf72e8f8e6244616e895')
 validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Google.
               '474E22316ABF4785A88C6E8EA2C794A986419D8A') # Tom Stellard

--- a/mingw-w64-mlir/PKGBUILD
+++ b/mingw-w64-mlir/PKGBUILD
@@ -1,20 +1,15 @@
 # Contributor: Mehdi Chinoune <mehdi.chinoune@hotmail.com>
 
-if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then
-  _clangprefix=1
-fi
-
 _realname=mlir
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=13.0.1
+pkgver=14.0.0
 pkgrel=1
 pkgdesc="Multi-Level IR Compiler Framework for LLVM (mingw-w64)"
 url="https://mlir.llvm.org/"
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 license=("custom:Apache 2.0 with LLVM Exception")
-groups=($( (( _clangprefix )) && echo "${MINGW_PACKAGE_PREFIX}-toolchain"))
 depends=("${MINGW_PACKAGE_PREFIX}-llvm")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
@@ -25,7 +20,7 @@ _pkgfn=$_realname
 _url=https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkgver}
 # No source package for MLIR: https://bugs.llvm.org/show_bug.cgi?id=52248
 source=("${_url}/llvm-project-${pkgver}.src.tar.xz"{,.sig})
-sha256sums=('326335a830f2e32d06d0a36393b5455d17dc73e0bd1211065227ee014f92cbf8'
+sha256sums=('35ce9edbc8f774fe07c8f4acdf89ec8ac695c8016c165dd86b8d10e7cba07e23'
             'SKIP')
 validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Google.
               '474E22316ABF4785A88C6E8EA2C794A986419D8A') # Tom Stellard


### PR DESCRIPTION
Depends on #11087.

Updated patch to fix 32-bit build of flang.

Removed mlir from toolchain group on clang prefixes.  mlir seems to get errors building if an older version is installed, which is not good behavior for something in the toolchain group.  I don't believe there was a strong reason for it to be in the toolchain group in the first place, other than that it was in the clang split package originally and everything in there was.