### PR TITLE
qt6-static: rebuild for llvm/clang 14 (and build fixes)

### DIFF
--- a/mingw-w64-qt6-static/PKGBUILD
+++ b/mingw-w64-qt6-static/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}-static
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-static")
 _qtver=6.2.1
 pkgver=${_qtver/-/}
-pkgrel=1
+pkgrel=2
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://www.qt.io'
@@ -33,10 +33,7 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-clang")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-clang"
-             "${MINGW_PACKAGE_PREFIX}-clang-analyzer"
              "${MINGW_PACKAGE_PREFIX}-clang-tools-extra"
-             "${MINGW_PACKAGE_PREFIX}-mlir"
-             "${MINGW_PACKAGE_PREFIX}-polly"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-xmlstarlet"
              "${MINGW_PACKAGE_PREFIX}-vulkan-headers"

--- a/mingw-w64-qt6-static/PKGBUILD
+++ b/mingw-w64-qt6-static/PKGBUILD
@@ -178,7 +178,7 @@ build() {
     -DFEATURE_system_assimp=OFF \
     -DFEATURE_system_doubleconversion=OFF \
     -DFEATURE_system_freetype=ON \
-    -DFEATURE_system_harfbuzz=OFF \
+    -DFEATURE_system_harfbuzz=ON \
     -DFEATURE_hunspell=OFF \
     -DFEATURE_system_hunspell=OFF \
     -DFEATURE_system_jpeg=ON \

--- a/mingw-w64-qt6-static/PKGBUILD
+++ b/mingw-w64-qt6-static/PKGBUILD
@@ -214,7 +214,7 @@ build() {
     -DLIBPNG_DEPENDENCIES="-lz" \
     -DGLIB2_DEPENDENCIES="-lintl;-lws2_32;-lole32;-lwinmm;-lshlwapi;-lm" \
     -DFREETYPE_DEPENDENCIES="-lbz2;-lharfbuzz;-lfreetype;-lbrotlidec;-lbrotlicommon" \
-    -DHARFBUZZ_DEPENDENCIES="-lglib-2.0;-lintl;-lws2_32;;-lgdi32;-lole32;-lwinmm;-lshlwapi;-lintl;-lm;-lfreetype;-lgraphite2;-lrpcrt4" \
+    -DHARFBUZZ_DEPENDENCIES="-lglib-2.0;-lintl;-lws2_32;-lusp10;-lgdi32;-lole32;-lwinmm;-lshlwapi;-lintl;-lm;-lfreetype;-lgraphite2;-lrpcrt4" \
     -DLIBBROTLIDEC_DEPENDENCIES="-lbrotlicommon" \
     -DLIBBROTLIENC_DEPENDENCIES="-lbrotlicommon" \
     -DLIBBROTLICOMMON_DEPENDENCIES="" \


### PR DESCRIPTION
prune some makedepends that were only there due to messed up llvm cmake files, which have been cleaned up by building llvm projects separately.

turn on system harfbuzz.  It's already being pulled in via freetype, apparently, because I get
```
 ld.lld: error: duplicate symbol: hb_font_funcs_create
 >>> defined at libQt6BundledHarfbuzz.a(hb-font.cc.obj)
 >>> defined at libharfbuzz.a(hb-font.cc.obj)
```
add -lusp10 to HARFBUZZ_DEPENDENCIES.  This is a system DLL import library, was getting a couple of undefined symbols when linking.