### PR TITLE
wxWidgets: install arm manifests

### DIFF
--- a/mingw-w64-wxWidgets/008-wxWidgets-3.0-Add-msw-manifests-for-arm-and-arm64-platforms.patch
+++ b/mingw-w64-wxWidgets/008-wxWidgets-3.0-Add-msw-manifests-for-arm-and-arm64-platforms.patch
@@ -1,22 +1,41 @@
-From ac3ac83b335d40fc84c3d1edd144134efaa25d4a Mon Sep 17 00:00:00 2001
-From: GH Cao <driver1998.ms@outlook.com>
-Date: Fri, 18 Mar 2022 00:00:17 +0800
-Subject: [PATCH 2/2] Add MSW manifests for ARM and ARM64 platforms
-
-Backported from c0c22609447c1f982500e997ba663112ac66f5f9
----
- include/wx/msw/arm.manifest   | 22 ++++++++++++++++++++++
- include/wx/msw/arm64.manifest | 22 ++++++++++++++++++++++
- include/wx/msw/genrcdefs.h    |  6 +++++-
- include/wx/msw/rcdefs.h       |  8 ++++++++
- include/wx/msw/wx.rc          |  4 ++++
- 5 files changed, 61 insertions(+), 1 deletion(-)
- create mode 100644 include/wx/msw/arm.manifest
- create mode 100644 include/wx/msw/arm64.manifest
-
+diff --git a/Makefile.in b/Makefile.in
+index 67774fc56c..2901470660 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -3252,6 +3252,8 @@ COND_TOOLKIT_MSW_GUI_HDR =  \
+ 	wx/msw/window.h \
+ 	wx/msw/wx.manifest \
+ 	wx/msw/amd64.manifest \
++	wx/msw/arm.manifest \
++	wx/msw/arm64.manifest \
+ 	wx/msw/ia64.manifest \
+ 	wx/msw/wx.rc \
+ 	wx/msw/colours.bmp \
+@@ -3769,6 +3771,8 @@ COND_TOOLKIT_WINCE_GUI_HDR =  \
+ 	wx/msw/window.h \
+ 	wx/msw/wx.manifest \
+ 	wx/msw/amd64.manifest \
++	wx/msw/arm.manifest \
++	wx/msw/arm64.manifest \
+ 	wx/msw/ia64.manifest \
+ 	wx/msw/wx.rc \
+ 	wx/msw/colours.bmp \
+diff --git a/build/bakefiles/files.bkl b/build/bakefiles/files.bkl
+index 10d71d609b..40560b251a 100644
+--- a/build/bakefiles/files.bkl
++++ b/build/bakefiles/files.bkl
+@@ -1923,6 +1923,8 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
+     <!-- Resources must be installed together with headers: -->
+     wx/msw/wx.manifest
+     wx/msw/amd64.manifest
++    wx/msw/arm.manifest
++    wx/msw/arm64.manifest
+     wx/msw/ia64.manifest
+     wx/msw/wx.rc
+     <!-- bitmaps -->
 diff --git a/include/wx/msw/arm.manifest b/include/wx/msw/arm.manifest
 new file mode 100644
-index 0000000..1879db7
+index 0000000000..1879db76af
 --- /dev/null
 +++ b/include/wx/msw/arm.manifest
 @@ -0,0 +1,22 @@
@@ -44,7 +63,7 @@ index 0000000..1879db7
 +</assembly>
 diff --git a/include/wx/msw/arm64.manifest b/include/wx/msw/arm64.manifest
 new file mode 100644
-index 0000000..abcad20
+index 0000000000..abcad20b72
 --- /dev/null
 +++ b/include/wx/msw/arm64.manifest
 @@ -0,0 +1,22 @@
@@ -71,7 +90,7 @@ index 0000000..abcad20
 +</dependency>
 +</assembly>
 diff --git a/include/wx/msw/genrcdefs.h b/include/wx/msw/genrcdefs.h
-index 809419b..50ce8d7 100644
+index 809419b3f9..50ce8d7429 100644
 --- a/include/wx/msw/genrcdefs.h
 +++ b/include/wx/msw/genrcdefs.h
 @@ -23,10 +23,14 @@ EMIT(#define wxUSE_RC_MANIFEST 1)
@@ -91,7 +110,7 @@ index 809419b..50ce8d7 100644
  EMIT(#define WX_CPU_IA64)
  #endif
 diff --git a/include/wx/msw/rcdefs.h b/include/wx/msw/rcdefs.h
-index 8b9ac71..ead5ec2 100644
+index 8b9ac716f9..ead5ec23dd 100644
 --- a/include/wx/msw/rcdefs.h
 +++ b/include/wx/msw/rcdefs.h
 @@ -31,6 +31,14 @@
@@ -110,7 +129,7 @@ index 8b9ac71..ead5ec2 100644
  #endif
  
 diff --git a/include/wx/msw/wx.rc b/include/wx/msw/wx.rc
-index 702861a..7ec9dd7 100644
+index 702861a287..7ec9dd7e02 100644
 --- a/include/wx/msw/wx.rc
 +++ b/include/wx/msw/wx.rc
 @@ -109,6 +109,10 @@ wxBITMAP_STD_COLOURS    BITMAP "wx/msw/colours.bmp"
@@ -124,6 +143,3 @@ index 702861a..7ec9dd7 100644
  #elif defined(WX_CPU_X86)
  wxMANIFEST_ID 24 "wx/msw/wx.manifest"
  #else
--- 
-2.35.1
-

--- a/mingw-w64-wxWidgets/PKGBUILD
+++ b/mingw-w64-wxWidgets/PKGBUILD
@@ -10,7 +10,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 provides=("${MINGW_PACKAGE_PREFIX}-wxmsw${_wx_basever}" "${MINGW_PACKAGE_PREFIX}-wxconfig")
 pkgbase=mingw-w64-${_realname}
 pkgver=${_wx_basever}.5.1
-pkgrel=9
+pkgrel=10
 pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -45,7 +45,7 @@ sha256sums=('440f6e73cf5afb2cbf9af10cec8da6cdd3d3998d527598a53db87099524ac807'
             '4915d09f217270956cad3de7cf0e3fdaec4847cfda46d4b568bde26a8bd5f94a'
             '043c24cab804b972a3fa710182b19f15aff8479a34e031694c17108a64e27d3f'
             'a9f43fca5ab5c8bdcc60933a2bf00fc7ac0f9dfe715fe9eb9f426f413d0a162d'
-            'a209553f73193371087e421dcdd3eacf8e7de17ce4908fa0aeaebf1ba8666cb7')
+            'd21ec13a29644547ff0d688c358a3a7795a0dc15c8e8e9761524212235db47f7')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}


### PR DESCRIPTION
Last time when I enabled clangarm64, I added exe manifests for ARM and ARM64, but they are not actually installed because makefiles are not updated.

This breaks downstream like PCem. (Not sure why FileZilla is not affected, they supply their own manifests?)

3.1.x are fixed upstream on the new 3.1.6 version, so opened https://github.com/msys2/MINGW-packages/pull/11316 for the update.