### PR TITLE
python-sphinx: add new dependency python-importlib-metadata

### DIFF
--- a/mingw-w64-python-sphinx/PKGBUILD
+++ b/mingw-w64-python-sphinx/PKGBUILD
@@ -9,7 +9,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=4.5.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Python documentation generator (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -19,6 +19,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-python-babel"
          "${MINGW_PACKAGE_PREFIX}-python-colorama"
          "${MINGW_PACKAGE_PREFIX}-python-docutils"
          "${MINGW_PACKAGE_PREFIX}-python-imagesize"
+         "${MINGW_PACKAGE_PREFIX}-python-importlib-metadata"
          "${MINGW_PACKAGE_PREFIX}-python-jinja"
          "${MINGW_PACKAGE_PREFIX}-python-packaging"
          "${MINGW_PACKAGE_PREFIX}-python-pygments"


### PR DESCRIPTION
Starting with Sphinx 4.4.0 a dependency 'importlib-metadata' was introduced:	
https://github.com/sphinx-doc/sphinx/commit/6c5c66bbb19cb2dcfdc25da97d4d839eec139db7

The lack of this dependency caused the lack of documentation in #11000 

@Biswa96 Do you agree?