### PR TITLE
Add gptfdisk package 1.0.8

### DIFF
--- a/mingw-w64-gptfdisk/0001-makefile-Drop-g-compiler-flag-for-mingw-builds.patch
+++ b/mingw-w64-gptfdisk/0001-makefile-Drop-g-compiler-flag-for-mingw-builds.patch
@@ -1,0 +1,31 @@
+From 19ee7b070aff404018e65b511a6ace360b9a0557 Mon Sep 17 00:00:00 2001
+From: Bin Meng <bmeng.cn@gmail.com>
+Date: Wed, 6 Apr 2022 21:37:42 +0800
+Subject: [PATCH 1/6] makefile: Drop "-g" compiler flag for mingw* builds
+
+At present the makefiles for mac/mingw* builds have the "-g" compiler
+flag, while other platform builds don't.
+
+Let's drop it given "-g" is only useful for a DEBUG build.
+
+Signed-off-by: Bin Meng <bmeng.cn@gmail.com>
+---
+ Makefile.mingw64 | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.mingw64 b/Makefile.mingw64
+index 7e4b32b..4cd1be9 100644
+--- a/Makefile.mingw64
++++ b/Makefile.mingw64
+@@ -2,7 +2,7 @@ CC=/usr/bin/x86_64-w64-mingw32-gcc
+ CXX=/usr/bin/x86_64-w64-mingw32-g++
+ STRIP=/usr/bin/x86_64-w64-mingw32-strip
+ CFLAGS=-O2 -Wall -static -static-libgcc -static-libstdc++  -D_FILE_OFFSET_BITS=64 -g
+-CXXFLAGS=-O2 -Wall -static -static-libgcc -static-libstdc++ -D_FILE_OFFSET_BITS=64 -g
++CXXFLAGS=-O2 -Wall -static -static-libgcc -static-libstdc++ -D_FILE_OFFSET_BITS=64
+ #CXXFLAGS=-O2 -Wall -D_FILE_OFFSET_BITS=64 -I /usr/local/include -I/opt/local/include -g
+ LIB_NAMES=guid gptpart bsd parttypes attributes crc32 mbrpart basicmbr mbr gpt support diskio diskio-windows
+ MBR_LIBS=support diskio diskio-windows basicmbr mbrpart
+-- 
+2.35.1
+

--- a/mingw-w64-gptfdisk/0002-makefile-Switch-to-building-shared-executables-for-m.patch
+++ b/mingw-w64-gptfdisk/0002-makefile-Switch-to-building-shared-executables-for-m.patch
@@ -1,0 +1,49 @@
+From fc973ace22e803c177b3f28daca387190a722508 Mon Sep 17 00:00:00 2001
+From: Bin Meng <bmeng.cn@gmail.com>
+Date: Wed, 6 Apr 2022 21:50:12 +0800
+Subject: [PATCH 2/6] makefile: Switch to building shared executables for
+ mingw* builds
+
+Other platform builds generate shared executables except mingw* builds.
+Switch to building shared executables for mingw* builds for consistency.
+
+With such change, $(CXXFLAGS) is no longer needed in the build rule too.
+
+Signed-off-by: Bin Meng <bmeng.cn@gmail.com>
+---
+ Makefile.mingw64 | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Makefile.mingw64 b/Makefile.mingw64
+index 4cd1be9..615b43b 100644
+--- a/Makefile.mingw64
++++ b/Makefile.mingw64
+@@ -2,7 +2,7 @@ CC=/usr/bin/x86_64-w64-mingw32-gcc
+ CXX=/usr/bin/x86_64-w64-mingw32-g++
+ STRIP=/usr/bin/x86_64-w64-mingw32-strip
+ CFLAGS=-O2 -Wall -static -static-libgcc -static-libstdc++  -D_FILE_OFFSET_BITS=64 -g
+-CXXFLAGS=-O2 -Wall -static -static-libgcc -static-libstdc++ -D_FILE_OFFSET_BITS=64
++CXXFLAGS=-O2 -Wall -D_FILE_OFFSET_BITS=64
+ #CXXFLAGS=-O2 -Wall -D_FILE_OFFSET_BITS=64 -I /usr/local/include -I/opt/local/include -g
+ LIB_NAMES=guid gptpart bsd parttypes attributes crc32 mbrpart basicmbr mbr gpt support diskio diskio-windows
+ MBR_LIBS=support diskio diskio-windows basicmbr mbrpart
+@@ -15,13 +15,13 @@ DEPEND= makedepend $(CFLAGS)
+ all:	gdisk fixparts
+ 
+ gdisk:	$(LIB_OBJS) gdisk.o gpttext.o
+-	$(CXX) $(CXXFLAGS) $(LIB_OBJS) gdisk.o gpttext.o -lrpcrt4 -static-libgcc -o gdisk64.exe
++	$(CXX) $(LIB_OBJS) gdisk.o gpttext.o -lrpcrt4 -o gdisk64.exe
+ 
+ sgdisk: $(LIB_OBJS) sgdisk.o
+-	$(CXX) $(CXXFLAGS) $(LIB_OBJS) sgdisk.o -lpopt -static-libgcc -o sgdisk64.exe
++	$(CXX) $(LIB_OBJS) sgdisk.o -lpopt -o sgdisk64.exe
+ 
+ fixparts: $(MBR_LIB_OBJS) fixparts.o
+-	$(CXX) $(CXXFLAGS) $(MBR_LIB_OBJS) fixparts.o $(LDFLAGS) -static-libgcc -o fixparts64.exe
++	$(CXX) $(MBR_LIB_OBJS) fixparts.o $(LDFLAGS) -o fixparts64.exe
+ 
+ lint:	#no pre-reqs
+ 	lint $(SRCS)
+-- 
+2.35.1
+

--- a/mingw-w64-gptfdisk/0003-makefile-Fix-the-sgdisk-rule-for-mingw-builds.patch
+++ b/mingw-w64-gptfdisk/0003-makefile-Fix-the-sgdisk-rule-for-mingw-builds.patch
@@ -1,0 +1,42 @@
+From 0302221752afe2074f9614d032fb5caf33f74115 Mon Sep 17 00:00:00 2001
+From: Bin Meng <bmeng.cn@gmail.com>
+Date: Wed, 6 Apr 2022 21:52:41 +0800
+Subject: [PATCH 3/6] makefile: Fix the 'sgdisk' rule for mingw* builds
+
+Currently the sgdisk build rule for mingw* builds is incorrect in
+various aspects:
+
+  * missing an object file gptcl.o for compiling and linking
+  * linking to librpcrt4 library is missing too
+
+With the fix we can enable the sgdisk build by default.
+
+Signed-off-by: Bin Meng <bmeng.cn@gmail.com>
+---
+ Makefile.mingw64 | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Makefile.mingw64 b/Makefile.mingw64
+index 615b43b..3c63340 100644
+--- a/Makefile.mingw64
++++ b/Makefile.mingw64
+@@ -12,13 +12,13 @@ MBR_LIB_OBJS=$(MBR_LIBS:=.o)
+ LIB_HEADERS=$(LIB_NAMES:=.h)
+ DEPEND= makedepend $(CFLAGS)
+ 
+-all:	gdisk fixparts
++all:	gdisk sgdisk fixparts
+ 
+ gdisk:	$(LIB_OBJS) gdisk.o gpttext.o
+ 	$(CXX) $(LIB_OBJS) gdisk.o gpttext.o -lrpcrt4 -o gdisk64.exe
+ 
+-sgdisk: $(LIB_OBJS) sgdisk.o
+-	$(CXX) $(LIB_OBJS) sgdisk.o -lpopt -o sgdisk64.exe
++sgdisk: $(LIB_OBJS) sgdisk.o gptcl.o
++	$(CXX) $(LIB_OBJS) sgdisk.o gptcl.o -lrpcrt4 -lpopt -o sgdisk64.exe
+ 
+ fixparts: $(MBR_LIB_OBJS) fixparts.o
+ 	$(CXX) $(MBR_LIB_OBJS) fixparts.o $(LDFLAGS) -o fixparts64.exe
+-- 
+2.35.1
+

--- a/mingw-w64-gptfdisk/0004-makefile-Specify-std-c-14-for-mingw-builds.patch
+++ b/mingw-w64-gptfdisk/0004-makefile-Specify-std-c-14-for-mingw-builds.patch
@@ -1,0 +1,62 @@
+From c797ce13bd4298e087048c3f03883ab40e8a7dd0 Mon Sep 17 00:00:00 2001
+From: Bin Meng <bmeng.cn@gmail.com>
+Date: Wed, 6 Apr 2022 21:56:57 +0800
+Subject: [PATCH 4/6] makefile: Specify -std=c++14 for mingw* builds
+
+The windows executables fail to compile with gcc 11 mingw cross-compile
+toolchain which defaults to '-std=c++17', due to conflicting definitions.
+
+  In file included from /usr/x86_64-w64-mingw32/sys-root/mingw/include/wtypes.h:8,
+                   from /usr/x86_64-w64-mingw32/sys-root/mingw/include/winscard.h:10,
+                   from /usr/x86_64-w64-mingw32/sys-root/mingw/include/windows.h:97,
+                   from /usr/x86_64-w64-mingw32/sys-root/mingw/include/rpc.h:16,
+                   from guid.h:23,
+                   from parttypes.h:16,
+                   from gptpart.h:22,
+                   from gptpart.cc:27:
+  /usr/x86_64-w64-mingw32/sys-root/mingw/include/rpcndr.h:64:11:
+  error:reference to 'byte' is ambiguous
+     64 |   typedef byte cs_byte;
+        |           ^~~~
+  In file included from /usr/x86_64-w64-mingw32/sys-root/mingw/include/c++/bits/stl_algobase.h:61,
+                   from /usr/x86_64-w64-mingw32/sys-root/mingw/include/c++/bits/char_traits.h:39,
+                   from /usr/x86_64-w64-mingw32/sys-root/mingw/include/c++/ios:40,
+                   from /usr/x86_64-w64-mingw32/sys-root/mingw/include/c++/ostream:38,
+                   from /usr/x86_64-w64-mingw32/sys-root/mingw/include/c++/iostream:39,
+                   from gptpart.cc:26:
+  /usr/x86_64-w64-mingw32/sys-root/mingw/include/c++/bits/cpp_type_traits.h:404:30: note: candidates are: 'enum class std::byte'
+    404 |   enum class byte : unsigned char;
+        |                              ^~~~
+
+The issue has been unnoticed so far all the way up to gcc 10, which
+defaulted to '-std=c++14'. But it can still be reproduced with gcc 10
+with an explicit '-std=c++17' flag.
+
+"using namespace std" in header files is considered as a bad practice,
+often known as global namespace pollution. Problems may occur when more
+than one namespace has the same symbol name with signature, then it will
+be ambiguous for the compiler to decide which one to use.
+
+Let's explicitly specify -std=c++14 for mingw* builds.
+
+Signed-off-by: Bin Meng <bmeng.cn@gmail.com>
+---
+ Makefile.mingw64 | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.mingw64 b/Makefile.mingw64
+index 3c63340..14b4b8c 100644
+--- a/Makefile.mingw64
++++ b/Makefile.mingw64
+@@ -2,7 +2,7 @@ CC=/usr/bin/x86_64-w64-mingw32-gcc
+ CXX=/usr/bin/x86_64-w64-mingw32-g++
+ STRIP=/usr/bin/x86_64-w64-mingw32-strip
+ CFLAGS=-O2 -Wall -static -static-libgcc -static-libstdc++  -D_FILE_OFFSET_BITS=64 -g
+-CXXFLAGS=-O2 -Wall -D_FILE_OFFSET_BITS=64
++CXXFLAGS=-O2 -Wall -std=c++14 -D_FILE_OFFSET_BITS=64
+ #CXXFLAGS=-O2 -Wall -D_FILE_OFFSET_BITS=64 -I /usr/local/include -I/opt/local/include -g
+ LIB_NAMES=guid gptpart bsd parttypes attributes crc32 mbrpart basicmbr mbr gpt support diskio diskio-windows
+ MBR_LIBS=support diskio diskio-windows basicmbr mbrpart
+-- 
+2.35.1
+

--- a/mingw-w64-gptfdisk/0005-makefile-Avoid-absolute-path-in-CXX-for-mingw-builds.patch
+++ b/mingw-w64-gptfdisk/0005-makefile-Avoid-absolute-path-in-CXX-for-mingw-builds.patch
@@ -1,0 +1,34 @@
+From b0e226cf561d9b646c737a64586be93772e8242a Mon Sep 17 00:00:00 2001
+From: Bin Meng <bmeng.cn@gmail.com>
+Date: Wed, 6 Apr 2022 22:04:04 +0800
+Subject: [PATCH 5/6] makefile: Avoid absolute path in CXX for mingw* builds
+
+At present CXX specifies absolute path for the MinGW GCC compiler.
+But it only applies to MinGW cross compiler on the Linux host.
+On a Windows host with MSYS2, MinGW GCC is normally installed at
+/mingw{32,64}/bin which does not work with current makefile.
+
+Remove the absolute path prefix, as on both Linux and Windows hosts
+MinGW GCC compiler path is already in the PATH environment.
+
+Signed-off-by: Bin Meng <bmeng.cn@gmail.com>
+---
+ Makefile.mingw64 | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile.mingw64 b/Makefile.mingw64
+index 14b4b8c..55fd5ff 100644
+--- a/Makefile.mingw64
++++ b/Makefile.mingw64
+@@ -1,6 +1,6 @@
+ CC=/usr/bin/x86_64-w64-mingw32-gcc
+-CXX=/usr/bin/x86_64-w64-mingw32-g++
+-STRIP=/usr/bin/x86_64-w64-mingw32-strip
++CXX=x86_64-w64-mingw32-g++
++STRIP=x86_64-w64-mingw32-strip
+ CFLAGS=-O2 -Wall -static -static-libgcc -static-libstdc++  -D_FILE_OFFSET_BITS=64 -g
+ CXXFLAGS=-O2 -Wall -std=c++14 -D_FILE_OFFSET_BITS=64
+ #CXXFLAGS=-O2 -Wall -D_FILE_OFFSET_BITS=64 -I /usr/local/include -I/opt/local/include -g
+-- 
+2.35.1
+

--- a/mingw-w64-gptfdisk/0006-makefile-Omit-the-64-suffix-in-the-executable-names.patch
+++ b/mingw-w64-gptfdisk/0006-makefile-Omit-the-64-suffix-in-the-executable-names.patch
@@ -1,0 +1,36 @@
+From a7d165fdf8564d2234103f77df4e2d825bb77f2b Mon Sep 17 00:00:00 2001
+From: Bin Meng <bmeng.cn@gmail.com>
+Date: Thu, 7 Apr 2022 18:06:52 +0800
+Subject: [PATCH 6/6] makefile: Omit the 64 suffix in the executable names
+
+The Windows executable names have 32/64 suffix while others don't.
+
+Signed-off-by: Bin Meng <bmeng.cn@gmail.com>
+---
+ Makefile.mingw64 | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Makefile.mingw64 b/Makefile.mingw64
+index 55fd5ff..d553b9a 100644
+--- a/Makefile.mingw64
++++ b/Makefile.mingw64
+@@ -15,13 +15,13 @@ DEPEND= makedepend $(CFLAGS)
+ all:	gdisk sgdisk fixparts
+ 
+ gdisk:	$(LIB_OBJS) gdisk.o gpttext.o
+-	$(CXX) $(LIB_OBJS) gdisk.o gpttext.o -lrpcrt4 -o gdisk64.exe
++	$(CXX) $(LIB_OBJS) gdisk.o gpttext.o -lrpcrt4 -o gdisk.exe
+ 
+ sgdisk: $(LIB_OBJS) sgdisk.o gptcl.o
+-	$(CXX) $(LIB_OBJS) sgdisk.o gptcl.o -lrpcrt4 -lpopt -o sgdisk64.exe
++	$(CXX) $(LIB_OBJS) sgdisk.o gptcl.o -lrpcrt4 -lpopt -o sgdisk.exe
+ 
+ fixparts: $(MBR_LIB_OBJS) fixparts.o
+-	$(CXX) $(MBR_LIB_OBJS) fixparts.o $(LDFLAGS) -o fixparts64.exe
++	$(CXX) $(MBR_LIB_OBJS) fixparts.o $(LDFLAGS) -o fixparts.exe
+ 
+ lint:	#no pre-reqs
+ 	lint $(SRCS)
+-- 
+2.35.1
+

--- a/mingw-w64-gptfdisk/PKGBUILD
+++ b/mingw-w64-gptfdisk/PKGBUILD
@@ -1,0 +1,52 @@
+# Maintainer: Bin Meng <bmeng.cn@gmail.com>
+
+_realname=gptfdisk
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.0.8
+pkgrel=1
+pkgdesc="A text-mode partitioning tool that works on GUID Partition Table (GPT) disks (mingw-w64)"
+arch=('x86_64')
+mingw_arch=('mingw64' 'ucrt64')
+url="https://www.rodsbooks.com/gdisk/"
+license=('GPL2')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
+depends=("${MINGW_PACKAGE_PREFIX}-popt")
+options=('strip')
+source=(https://downloads.sourceforge.net/project/${_realname}/${_realname}/$pkgver/${_realname}-$pkgver.tar.gz
+        "0001-makefile-Drop-g-compiler-flag-for-mingw-builds.patch"
+        "0002-makefile-Switch-to-building-shared-executables-for-m.patch"
+        "0003-makefile-Fix-the-sgdisk-rule-for-mingw-builds.patch"
+        "0004-makefile-Specify-std-c-14-for-mingw-builds.patch"
+        "0005-makefile-Avoid-absolute-path-in-CXX-for-mingw-builds.patch"
+        "0006-makefile-Omit-the-64-suffix-in-the-executable-names.patch")
+sha256sums=('95d19856f004dabc4b8c342b2612e8d0a9eebdd52004297188369f152e9dc6df'
+            '782a3623c68991a1b2803075969e5e1db92b2b717b02207c27aa874e1005ee9b'
+            'df978d029bfc5215c42e832b4105fb5e55f90f411dca4f21250af057328b62d9'
+            '96d67859cc8c52551263c7116031193acd03720d745f89a6e014e685b1cba5fd'
+            '210b7bc9e3bec002e81daec379c6719e468a725beed1c74f998d77a9b014faff'
+            '432d647bd28be95346631693bfc63775821766c8a64bd2b0e3976dde73f581d0'
+            '6807d045f22d023a1d6778463fcced2727ffc8e10abccbb7a8df274e296bf091')
+
+prepare() {
+  cd "$srcdir/${_realname}-$pkgver"
+  patch -p1 -i $srcdir/0001-makefile-Drop-g-compiler-flag-for-mingw-builds.patch
+  patch -p1 -i $srcdir/0002-makefile-Switch-to-building-shared-executables-for-m.patch
+  patch -p1 -i $srcdir/0003-makefile-Fix-the-sgdisk-rule-for-mingw-builds.patch
+  patch -p1 -i $srcdir/0004-makefile-Specify-std-c-14-for-mingw-builds.patch
+  patch -p1 -i $srcdir/0005-makefile-Avoid-absolute-path-in-CXX-for-mingw-builds.patch
+  patch -p1 -i $srcdir/0006-makefile-Omit-the-64-suffix-in-the-executable-names.patch
+}
+
+build() {
+  cd "$srcdir/${_realname}-$pkgver"
+  make -f Makefile.mingw64
+}
+
+package() {
+  cd "$srcdir/${_realname}-$pkgver"
+  install -d "$pkgdir${MINGW_PREFIX}"/{bin,share/{doc/gdisk,man/man8}}
+  install -t "$pkgdir${MINGW_PREFIX}/bin" {,s}gdisk.exe fixparts.exe
+  install -m644 -t "$pkgdir${MINGW_PREFIX}/share/man/man8" {{,s}gdisk,fixparts}.8
+  install -m644 -t "$pkgdir${MINGW_PREFIX}/share/doc/gdisk" README NEWS
+}


### PR DESCRIPTION
This adds a new package for mingw64: gptfdisk.

It includes text-mode partitioning tools that work on GUID Partition
Table (GPT) disks.

The following tools are included:

  - gdisk.exe
  - sgdisk.exe
  - fixparts.exe

Signed-off-by: Bin Meng <bmeng.cn@gmail.com>