### PR TITLE
ARPACK: Fix libraries for pkg-config file.

### DIFF
--- a/mingw-w64-arpack/0003-blas-lapack-pc.patch
+++ b/mingw-w64-arpack/0003-blas-lapack-pc.patch
@@ -1,0 +1,28 @@
+$ diff -urN arpack-ng-3.8.0/CMakeLists.txt.orig arpack-ng-3.8.0/CMakeLists.txt
+--- arpack-ng-3.8.0/CMakeLists.txt.orig	2022-04-07 18:56:04.575147700 +0200
++++ arpack-ng-3.8.0/CMakeLists.txt	2022-04-07 19:06:38.368200700 +0200
+@@ -213,7 +213,6 @@
+         set_target_properties(BLAS::BLAS PROPERTIES INTERFACE_LINK_LIBRARIES "${BLAS_LIBRARIES}")
+     endif()
+ endif()
+-get_target_property(BLAS_LIBRARIES BLAS::BLAS INTERFACE_LINK_LIBRARIES) # Get variables from target (*.pc/cmake, msg).
+ 
+ if (MPI)
+     if (NOT TARGET MPI::MPI_Fortran) # Search only if not already found by upper CMakeLists.txt
+@@ -265,7 +264,6 @@
+         set_target_properties(LAPACK::LAPACK PROPERTIES INTERFACE_LINK_LIBRARIES "${LAPACK_LIBRARIES}")
+     endif()
+ endif()
+-get_target_property(LAPACK_LIBRARIES LAPACK::LAPACK INTERFACE_LINK_LIBRARIES) # Get variables from target (*.pc/cmake, msg).
+ 
+ if (MPI)
+     set(parpackutil_DIR ${arpack_SOURCE_DIR}/PARPACK/UTIL/)
+@@ -696,7 +694,7 @@
+ set(ARPACK_PC_LIBS_PRIVATE)
+ foreach(lib ${LAPACK_LIBRARIES})
+     get_filename_component(libname ${lib} NAME)
+-    string(REGEX REPLACE "^lib([^.]+).*$" "-l\\1" libname ${libname})
++    string(REGEX REPLACE "^(lib)?([^.]+).*$" "-l\\2" libname ${libname})
+     list(APPEND ARPACK_PC_LIBS_PRIVATE "${libname}")
+ endforeach()
+ string(REPLACE ";" " " ARPACK_PC_LIBS_PRIVATE "${ARPACK_PC_LIBS_PRIVATE}")

--- a/mingw-w64-arpack/PKGBUILD
+++ b/mingw-w64-arpack/PKGBUILD
@@ -9,34 +9,46 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          $([[ "${CARCH}" == "i686" ]] || echo "${MINGW_PACKAGE_PREFIX}-${_realname}64"))
 pkgver=3.8.0
-pkgrel=3
+pkgrel=4
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64')
 pkgdesc="Fortran77 subroutines designed to solve large scale eigenvalue problems (mingw-w64)"
 url='https://forge.scilab.org/index.php/p/arpack-ng/'
-license=('BSD')
+license=('spdx:BSD-3-Clause')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libgfortran")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc-fortran"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cmake"
-	     "${MINGW_PACKAGE_PREFIX}-openblas"
-	     $([[ "${CARCH}" == "i686" ]] || echo "${MINGW_PACKAGE_PREFIX}-openblas64"))
+             "${MINGW_PACKAGE_PREFIX}-openblas"
+             $([[ "${CARCH}" == "i686" ]] || echo "${MINGW_PACKAGE_PREFIX}-openblas64"))
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}-ng")
 options=('!buildflags')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/opencollab/arpack-ng/archive/${pkgver}.tar.gz
         "0001-cmake-relocate-prefix.patch"
-	"0002-cmake-set-SUFFIX64.patch")
-sha256sums=('ADA5AEB3878874383307239C9235B716A8A170C6D096A6625BFD529844DF003D'
+        "0002-cmake-set-SUFFIX64.patch"
+        "0003-blas-lapack-pc.patch")
+sha256sums=('ada5aeb3878874383307239c9235b716a8a170c6d096a6625bfd529844df003d'
             '94b215a281f115bd91e3370487bcfc97a1100aff82196d226927f7e395dc4cff'
-	    '5B6CEC059408FC11E2F4056C73ECBF6CEE17AE23A2CE30F11AA4633286AE8E9C')
+            '5b6cec059408fc11e2f4056c73ecbf6cee17ae23a2ce30f11aa4633286ae8e9c'
+            'f292a44377c02949f3ede48b4521c093982483ff2f85aa90b710457f1dea706b')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _fname in "$@"
+  do
+    msg2 "Applying ${_fname}"
+    patch -Nbp1 -i "${srcdir}"/${_fname}
+  done
+}
 
 prepare() {
   cd "${srcdir}/${_realname}-ng-${pkgver}"
 
   # https://github.com/msys2/MINGW-packages/issues/10151
-  patch -p1 -i "${srcdir}/0001-cmake-relocate-prefix.patch"
-  patch -p1 -i "${srcdir}/0002-cmake-set-SUFFIX64.patch"
-  #./bootstrap
+  apply_patch_with_msg \
+    0001-cmake-relocate-prefix.patch \
+    0002-cmake-set-SUFFIX64.patch \
+    0003-blas-lapack-pc.patch
 }
 
 _build_arpack() {


### PR DESCRIPTION
Don't override libraries that have already been (correctly) set by the corresponding cmake modules.
Libraries (in passed variable) might not start with "lib".

Fixes #11376.