### PR TITLE
mingw-w64: update to 10.0.0

### DIFF
--- a/mingw-w64-crt-git/PKGBUILD
+++ b/mingw-w64-crt-git/PKGBUILD
@@ -3,9 +3,9 @@
 _realname=crt
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
-pkgver=9.0.0.6454.b4445ee52
+pkgver=10.0.0.r0.gaa08f56da
 pkgrel=1
-_commit='b4445ee520dd5041b051fb30ffee00970f50a118'
+_commit='aa08f56da559016f10336dddca85d59f9bdc9e02'
 pkgdesc='MinGW-w64 CRT for Windows'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -29,7 +29,7 @@ sha256sums=('SKIP'
 
 pkgver() {
   cd "${srcdir}/mingw-w64"
-  printf "9.0.0.%s.%s" "$(git rev-list --count $_commit)" "$(git rev-parse --short $_commit)"
+  git describe --long ${_commit} | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//g'
 }
 
 prepare() {

--- a/mingw-w64-headers-git/PKGBUILD
+++ b/mingw-w64-headers-git/PKGBUILD
@@ -4,9 +4,9 @@ _realname=headers
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 pkgdesc="MinGW-w64 headers for Windows"
-pkgver=9.0.0.6454.b4445ee52
+pkgver=10.0.0.r0.gaa08f56da
 pkgrel=1
-_commit='b4445ee520dd5041b051fb30ffee00970f50a118'
+_commit='aa08f56da559016f10336dddca85d59f9bdc9e02'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://mingw-w64.sourceforge.io/"
@@ -25,7 +25,7 @@ sha256sums=('SKIP'
 
 pkgver() {
   cd "${srcdir}/mingw-w64"
-  printf "9.0.0.%s.%s" "$(git rev-list --count $_commit)" "$(git rev-parse --short $_commit)"
+  git describe --long ${_commit} | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//g'
 }
 
 prepare() {

--- a/mingw-w64-libmangle-git/PKGBUILD
+++ b/mingw-w64-libmangle-git/PKGBUILD
@@ -5,9 +5,9 @@ pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=9.0.0.6454.b4445ee52
+pkgver=10.0.0.r0.gaa08f56da
 pkgrel=1
-_commit='b4445ee520dd5041b051fb30ffee00970f50a118'
+_commit='aa08f56da559016f10336dddca85d59f9bdc9e02'
 pkgdesc="MinGW-w64 libmangle"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -26,7 +26,7 @@ sha256sums=('SKIP')
 
 pkgver() {
   cd "${srcdir}/mingw-w64"
-  printf "9.0.0.%s.%s" "$(git rev-list --count $_commit)" "$(git rev-parse --short $_commit)"
+  git describe --long ${_commit} | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//g'
 }
 
 build() {

--- a/mingw-w64-tools-git/PKGBUILD
+++ b/mingw-w64-tools-git/PKGBUILD
@@ -6,9 +6,9 @@ pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=9.0.0.6454.b4445ee52
+pkgver=10.0.0.r0.gaa08f56da
 pkgrel=1
-_commit='b4445ee520dd5041b051fb30ffee00970f50a118'
+_commit='aa08f56da559016f10336dddca85d59f9bdc9e02'
 pkgdesc="MinGW-w64 tools"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -24,7 +24,7 @@ _tools="gendef genlib genidl genpeimg widl" # genstubdll
 
 pkgver() {
   cd "${srcdir}/mingw-w64"
-  printf "9.0.0.%s.%s" "$(git rev-list --count $_commit)" "$(git rev-parse --short $_commit)"
+  git describe --long ${_commit} | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//g'
 }
 
 prepare() {

--- a/mingw-w64-winpthreads-git/PKGBUILD
+++ b/mingw-w64-winpthreads-git/PKGBUILD
@@ -5,9 +5,9 @@
 _realname=winpthreads
 pkgbase=mingw-w64-${_realname}-git
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git" "${MINGW_PACKAGE_PREFIX}-libwinpthread-git")
-pkgver=9.0.0.6454.b4445ee52
+pkgver=10.0.0.r0.gaa08f56da
 pkgrel=1
-_commit='b4445ee520dd5041b051fb30ffee00970f50a118'
+_commit='aa08f56da559016f10336dddca85d59f9bdc9e02'
 pkgdesc="MinGW-w64 winpthreads library"
 url="https://mingw-w64.sourceforge.io/"
 # The main license of `winpthreads' is MIT, but parts of this library are
@@ -31,7 +31,7 @@ sha256sums=('SKIP'
 
 pkgver() {
   cd "${srcdir}/mingw-w64"
-  printf "9.0.0.%s.%s" "$(git rev-list --count $_commit)" "$(git rev-parse --short $_commit)"
+  git describe --long ${_commit} | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//g'
 }
 
 prepare() {

--- a/mingw-w64-winstorecompat-git/PKGBUILD
+++ b/mingw-w64-winstorecompat-git/PKGBUILD
@@ -3,9 +3,9 @@
 _realname=winstorecompat
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
-pkgver=9.0.0.6454.b4445ee52
+pkgver=10.0.0.r0.gaa08f56da
 pkgrel=1
-_commit='b4445ee520dd5041b051fb30ffee00970f50a118'
+_commit='aa08f56da559016f10336dddca85d59f9bdc9e02'
 pkgdesc="MinGW-w64 winRT compat library"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -19,7 +19,7 @@ sha256sums=('SKIP')
 
 pkgver() {
   cd "${srcdir}/mingw-w64"
-  printf "9.0.0.%s.%s" "$(git rev-list --count $_commit)" "$(git rev-parse --short $_commit)"
+  git describe --long ${_commit} | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//g'
 }
 
 prepare() {


### PR DESCRIPTION
I would have updated the pkgver to 10.0.0 even, since this is the commit
officially tagged as v10.0.0, but this package is updated against git
commits so often that tweaking the pkgver function for one version
didn't seem worth the effort.

Take this opportunity to switch pkgver to using git describe, as doing
so when the more significant version numbers don't change would make the
new version compare lower.

The --long argument and sed pattern for git describe comes from the
CMake-git PKGBUILD template.