### PR TITLE
Fix missing symbols in libx265.a

### DIFF
--- a/mingw-w64-x265/PKGBUILD
+++ b/mingw-w64-x265/PKGBUILD
@@ -5,7 +5,7 @@ _realname=x265
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.5
-pkgrel=2
+pkgrel=3
 pkgdesc='Open Source H265/HEVC video encoder (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -93,6 +93,18 @@ build() {
     -DLINKED_12BIT=ON \
   ../x265_${pkgver}/source
   ${MINGW_PREFIX}/bin/cmake.exe --build .
+  
+  
+  # merge
+  mv libx265.a libx265_main.a
+  ar -M <<EOF
+CREATE libx265.a
+ADDLIB libx265_main.a
+ADDLIB libx265_main10.a
+ADDLIB libx265_main12.a
+SAVE
+END
+EOF  
 }
 
 package() {

--- a/mingw-w64-x265/PKGBUILD
+++ b/mingw-w64-x265/PKGBUILD
@@ -93,8 +93,7 @@ build() {
     -DLINKED_12BIT=ON \
   ../x265_${pkgver}/source
   ${MINGW_PREFIX}/bin/cmake.exe --build .
-  
-  
+
   # merge
   mv libx265.a libx265_main.a
   ar -M <<EOF
@@ -104,7 +103,7 @@ ADDLIB libx265_main10.a
 ADDLIB libx265_main12.a
 SAVE
 END
-EOF  
+EOF
 }
 
 package() {


### PR DESCRIPTION
Thanks to https://github.com/msys2/MINGW-packages/issues/8824#issuecomment-1086783808

@Biswa96
@lazka
@ImperatorS79
