### PR TITLE
lsp-dsp-lib: update to 1.0.1

### DIFF
--- a/mingw-w64-lsp-dsp-lib/PKGBUILD
+++ b/mingw-w64-lsp-dsp-lib/PKGBUILD
@@ -3,28 +3,27 @@
 _realname=lsp-dsp-lib
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.5.14
+pkgver=1.0.1
 pkgrel=1
 pkgdesc='SIMD-optimized library for digital signal processing'
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64')
 options=('strip' 'staticlibs' '!makeflags')
-makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-make")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
 license=('LGPL3')
 url="https://github.com/lsp-plugins/${_realname}"
-source=("https://github.com/lsp-plugins/$_realname/releases/download/$pkgver/$_realname-$pkgver-src.tar.gz")
-sha256sums=('781dae54c934bc11c412a7abbea1321e4ea6513ca24327627b8bfbe5fdb49fbd')
+source=("https://github.com/lsp-plugins/$_realname/releases/download/$pkgver/$_realname-src-$pkgver.tar.gz")
+sha256sums=('78e3c8a3037ad8fd280c1c20f71f7df46e3582630aa2fdef10f984dc61f739a5')
 
 build() {
   cd "${srcdir}/${_realname}"
 
-  if [[ "${MINGW_ARCH}" == *"32" ]]; then
+  architecture=${CARCH}
+  if [[ "${CARCH}" == "i386" ]]; then
     architecture=i586
-  else
-    architecture=x86_64
   fi
-  make config PREFIX=${MINGW_PREFIX} ARCHITECTURE=${architecture}
+
+  make config PREFIX=${MINGW_PREFIX} ARCHITECTURE=${architecture} X_CXX_TOOL=${CXX} X_CC_TOOL=${CC}
   make
 }
 


### PR DESCRIPTION
I tried to fix it on CLANG64, but it uses `partial linking (-r)` to compile source code files first and then linking them to a shared and static libraries. I could find any equivalent for lld.