### PR TITLE
qpdf: update to 10.6.3

### DIFF
--- a/mingw-w64-qpdf/0003-install-rule.patch
+++ b/mingw-w64-qpdf/0003-install-rule.patch
@@ -1,17 +1,6 @@
-From a442dea41491cc92e7913a036ba4e8c36f884c57 Mon Sep 17 00:00:00 2001
-From: oltolm <oleg.tolmatcev@gmail.com>
-Date: Thu, 20 Sep 2018 14:33:11 +0200
-Subject: [PATCH] install rule
-
----
- make/installwin.mk | 15 +++++++--------
- 1 file changed, 7 insertions(+), 8 deletions(-)
-
-diff --git a/make/installwin.mk b/make/installwin.mk
-index 960cc51..3a61563 100644
 --- a/make/installwin.mk
 +++ b/make/installwin.mk
-@@ -1,26 +1,25 @@
+@@ -1,21 +1,19 @@
 -DEST=$(INSTALL_DIR)/$(PACKAGE_TARNAME)-$(PACKAGE_VERSION)
 +DEST=$(DESTDIR)/$(prefix)
  IMPORT_LIB_NAME := $(call libname,qpdf)
@@ -23,9 +12,7 @@ index 960cc51..3a61563 100644
  	mkdir $(DEST)/lib
  	mkdir $(DEST)/include
  	mkdir $(DEST)/include/qpdf
--	mkdir $(DEST)/doc
-+	mkdir -p $(DEST)/share/doc/qpdf
-+	mkdir -p $(DEST)/share/licenses/qpdf
++	mkdir $(DEST)/share
  	cp libqpdf/$(OUTPUT_DIR)/$(IMPORT_LIB_NAME) $(DEST)/lib
  	cp libqpdf/$(OUTPUT_DIR)/qpdf*.dll $(DEST)/bin
 -	perl copy_dlls libqpdf/$(OUTPUT_DIR)/qpdf*.dll $(DEST)/bin $(OBJDUMP) $(WINDOWS_WORDSIZE)
@@ -34,17 +21,7 @@ index 960cc51..3a61563 100644
  	cp qpdf/$(OUTPUT_DIR)/fix-qdf.exe $(DEST)/bin
  	cp include/qpdf/*.h $(DEST)/include/qpdf
  	cp include/qpdf/*.hh $(DEST)/include/qpdf
--	cp doc/stylesheet.css $(DEST)/doc
-+	cp doc/stylesheet.css $(DEST)/share/doc/qpdf
- 	if [ -f doc/qpdf-manual.html ]; then \
--	    cp doc/qpdf-manual.html $(DEST)/doc; \
-+	    cp doc/qpdf-manual.html $(DEST)/share/doc/qpdf; \
+ 	if [ -d doc ]; then \
+-	    cp -r doc $(DEST); \
++	    cp -r doc $(DEST)/share; \
  	fi
- 	if [ -f doc/qpdf-manual.pdf ]; then \
--	    cp doc/qpdf-manual.pdf $(DEST)/doc; \
-+	    cp doc/qpdf-manual.pdf $(DEST)/share/doc/qpdf; \
- 	fi
-+	cp Artistic-2.0 $(DEST)/share/licenses/qpdf
--- 
-2.19.0.windows.1
-

--- a/mingw-w64-qpdf/PKGBUILD
+++ b/mingw-w64-qpdf/PKGBUILD
@@ -3,18 +3,20 @@
 _realname=qpdf
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=10.4.0
+pkgver=10.6.3
 pkgrel=1
 pkgdesc="QPDF: A Content-Preserving PDF Transformation System (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64')
 url="https://github.com/qpdf/qpdf"
 license=('custom:Artistic-2.0' 'Apache')
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
-             "${MINGW_PACKAGE_PREFIX}-cc")
+             "${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-python-sphinx")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-gnutls"
          "${MINGW_PACKAGE_PREFIX}-libjpeg"
+         "${MINGW_PACKAGE_PREFIX}-openssl"
          "${MINGW_PACKAGE_PREFIX}-pcre"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 #https://sourceforge.net/projects/${_realname}/files/${_realname}/${pkgver}/${_realname}-${pkgver}.tar.gz
@@ -22,11 +24,11 @@ source=(https://github.com/qpdf/qpdf/releases/download/release-${_realname}-${pk
         "0001-fix-printf-on-mingw-w64.patch"
         "0002-enable-advapi32-mingw.patch"
         "0003-install-rule.patch")
-sha512sums=('7a17cc2b3168bb60ac05d01b585d34d94f62e44e309b86635351b2564bc2c3b7846d3a008ae0d6c068bce3b1d9c42d3a3ab40de3f85a1ec4952280cf8321a041'
+sha512sums=('c584b7443984b0f28eec2fbff054096b9a14a10858dda0c6b370d7a19e34c395ee15a8dc0770d3d85773281cd79944f029fb3bfad55833a2c32ff7e1a751c149'
             'SKIP'
             '8d02655546e2e8182b3ac8df0387d4e34d1e86ee44d1311f5349fd8f82a328583785f2c99feee4c65db2569629b76a0b6edeb5b9bbf3b6b01d3708847a1f15bf'
             '485f108e96b92e76620fcf8e3ddc350d67c5458eea0adcd6a5e11d29fa980c7d9672f832aaec644b39f57674fa505a8d5748059a6b0da027be38b1a7ed01036e'
-            '4b93c1af24d5afc84445b00563da0ab60d46654830104690e53844dc1bdb278ac39d8a059c12501f34afb31411a53e2b46f3f953e690f582e3561a9eeb9131a5')
+            'd5a33db34d066766476bff0e021ec75cae982fc27a7bb2adab10a9084c6e688ac7d23020d4c73f48880eb9a6bff81152897893ae97f0bd9da82c79b751c772db')
 validpgpkeys=('C2C96B10011FE009E6D1DF828A75D10998012C7E') # Jay Berkenbilt <ejb@ql.org>
 
 prepare() {
@@ -39,8 +41,8 @@ prepare() {
 }
 
 build() {
-  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
-  cp -rf ${_realname}-${pkgver} build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
+  [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}
+  cp -rf ${_realname}-${pkgver} build-${MSYSTEM} && cd ${srcdir}/build-${MSYSTEM}
 
   ./configure \
     --prefix=${MINGW_PREFIX} \
@@ -53,16 +55,17 @@ build() {
     --disable-test-compare-images \
     --enable-external-libs \
     --with-buildrules=mingw
+
   make
 }
 
 check() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MSYSTEM}"
   PATH=$PWD/libqpdf/build:$PATH make check || true
 }
 
 package() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MSYSTEM}"
   make DESTDIR=${pkgdir} install
   install -Dm644 libqpdf.pc "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/libqpdf.pc"
 }


### PR DESCRIPTION
I couldn't find out why It fails on CLANG64.
The library built successfully, but lld couldn't find it when linking programs.