### PR TITLE
libsystre: Copy the dll as libgnurx

### DIFF
--- a/mingw-w64-libsystre/PKGBUILD
+++ b/mingw-w64-libsystre/PKGBUILD
@@ -7,7 +7,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-libgnurx")
 conflicts=("${MINGW_PACKAGE_PREFIX}-libgnurx")
 replaces=("${MINGW_PACKAGE_PREFIX}-libgnurx")
 pkgver=1.0.1
-pkgrel=4
+pkgrel=5
 pkgdesc="Wrapper library around TRE that provides POSIX API (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -42,4 +42,6 @@ package() {
   cd build-${MINGW_CHOST}
   make DESTDIR="${pkgdir}" install
   install -D -m644 "${srcdir}/systre-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  cd "${pkgdir}${MINGW_PREFIX}/bin"
+  ln -sf libsystre-0.dll libgnurx-0.dll
 }


### PR DESCRIPTION
Useful when cross-compiling with mxe, which links against libgnurx.