### PR TITLE
Add Duktape

### DIFF
--- a/mingw-w64-duktape/PKGBUILD
+++ b/mingw-w64-duktape/PKGBUILD
@@ -1,0 +1,50 @@
+_realname=duktape
+pkgbase=mingw-w64-${_pkgname}
+pkgname="${MINGW_PACKAGE_PREFIX}-duktape"
+pkgver=2.7.0
+_dirname=${_realname}-${pkgver}
+pkgrel=1
+url="http://duktape.org/"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+pkgdesc="Embeddable Javascript engine"
+license=("MIT")
+depends=("${MINGW_PACKAGE_PREFIX}-crt-git")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+options=(staticlibs !strip !buildflags)
+source=(
+	"http://duktape.org/duktape-${pkgver}.tar.xz"
+	"duktape.pc"
+	)
+sha256sums=('90f8d2fa8b5567c6899830ddef2c03f3c27960b11aca222fa17aa7ac613c2890'
+            '5a888e877d3ae2c752aba75a88587c22a4ef96b428a53f7b9b435799c758a55a')
+
+_architectures="${MINGW_PACKAGE_PREFIX}"
+
+build() {
+  for _arch in ${_architectures}; do
+    mkdir -p "${srcdir}/${pkgname}-${pkgver}-build-${_arch}"
+    pushd "${srcdir}/${_dirname}" > /dev/null
+    gcc src/duktape.c -std=c99 -O2 -c -o duktape.o
+    ar rcs libduktape.a duktape.o
+    pushd "../${pkgname}-${pkgver}-build-${_arch}" > /dev/null
+    mv "${srcdir}/${_dirname}/libduktape.a" "libduktape.a"
+    rm "${srcdir}/${_dirname}/duktape.o"
+    popd > /dev/null
+    popd > /dev/null
+  done
+}
+
+package() {
+  for _arch in ${_architectures}; do
+    pushd "${srcdir}/${pkgname}-${pkgver}-build-${_arch}" > /dev/null
+    install -Dm644 "libduktape.a" "$pkgdir/usr/${_arch}/lib/libduktape.a"
+    install -Dm644 "${srcdir}/${_dirname}/src/duk_config.h" "$pkgdir/usr/${_arch}/include/duk_config.h"
+    install -Dm644 "${srcdir}/${_dirname}/src/duktape.h" "$pkgdir/usr/${_arch}/include/duktape.h"
+    find "$pkgdir/usr/${_arch}" -name '*.exe' | xargs -rtl1 rm
+    find "$pkgdir/usr/${_arch}" -name '*.dll' | xargs -rtl1 ${_arch}-strip --strip-unneeded
+    find "$pkgdir/usr/${_arch}" -name '*.a' -o -name '*.dll' | xargs -rtl1 strip -g
+    rm -rf "$pkgdir/usr/${_arch}/share"
+    popd > /dev/null
+  done
+}

--- a/mingw-w64-duktape/PKGBUILD
+++ b/mingw-w64-duktape/PKGBUILD
@@ -25,7 +25,7 @@ build() {
   for _arch in ${_architectures}; do
     mkdir -p "${srcdir}/${pkgname}-${pkgver}-build-${_arch}"
     pushd "${srcdir}/${_dirname}" > /dev/null
-    gcc src/duktape.c -std=c99 -O2 -c -o duktape.o
+    cc src/duktape.c -std=c99 -O2 -c -o duktape.o
     ar rcs libduktape.a duktape.o
     pushd "../${pkgname}-${pkgver}-build-${_arch}" > /dev/null
     mv "${srcdir}/${_dirname}/libduktape.a" "libduktape.a"

--- a/mingw-w64-duktape/duktape.pc
+++ b/mingw-w64-duktape/duktape.pc
@@ -1,0 +1,10 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: duktape
+Description: Embeddable Javascript engine
+Version: 2.7.0
+Libs: -L${libdir} -lduktape
+Cflags: -I${includedir}


### PR DESCRIPTION
I was in need of this [tool](duktape.org) for a project and found it was not in the MSYS2 repos. I started with the [Arch Linux](https://archlinux.org/packages/community/x86_64/duktape/) package as a base, then went on to make sure it built on the different MSYSTEMs (with the exception of CLANGARM64, I couldn't get it to work there). I am not able to maintain this package, but want it to be available for anyone else needing to use Duktape.