### PR TITLE
rrdtool: Update and add patch

### DIFF
--- a/mingw-w64-rrdtool/001-rrdtool-1.8.0-BUILD_DATE.patch
+++ b/mingw-w64-rrdtool/001-rrdtool-1.8.0-BUILD_DATE.patch
@@ -1,50 +1,53 @@
+From e59f703bbcc0af949ee365206426b6394c340c6f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Wolfgang=20St=C3=B6ggl?= <c72578@yahoo.de>
+Date: Wed, 23 Mar 2022 17:58:45 +0100
+Subject: [PATCH] Fix BUILD_DATE in rrdtool help output
+
+- This is a followup to #1102
+- Fixes segfault when running "rrdtool --help"
+- Change DATE_FMT to the same date format as the __DATE__ macro [1]:
+  mmm dd yyyy
+
+[1] https://gcc.gnu.org/onlinedocs/cpp/Standard-Predefined-Macros.html
+---
+ configure.ac   | 2 +-
+ src/rrd_tool.c | 8 ++++++++
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+
 diff --git a/configure.ac b/configure.ac
-index 4d234585..ad3dd0b4 100644
+index 4d234585..5169b0d4 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -693,13 +693,6 @@ fi
- AC_MSG_CHECKING(Perl Modules to build)
- AC_MSG_RESULT(${COMP_PERL:-No Perl Modules will be built})
+@@ -695,7 +695,7 @@ AC_MSG_RESULT(${COMP_PERL:-No Perl Modules will be built})
  
--# Use reproducible build date and time
--if test "$SOURCE_DATE_EPOCH"; then
+ # Use reproducible build date and time
+ if test "$SOURCE_DATE_EPOCH"; then
 -	DATE_FMT="%d %b %Y %H:%M:%S"
--	BUILD_DATE=$(LC_ALL=C date -u -d "@$SOURCE_DATE_EPOCH" "+$DATE_FMT")
--	AC_DEFINE_UNQUOTED([BUILD_DATE], ["$BUILD_DATE"], [Use reproducible build date])
--fi
--
- # Options to pass when configuring perl module
- langpref=$prefix
- test "$langpref" = '$(DESTDIR)NONE' && langpref='$(DESTDIR)'$ac_default_prefix
-diff --git a/src/rrd_cgi.c b/src/rrd_cgi.c
-index e7eb5be5..241368d0 100644
---- a/src/rrd_cgi.c
-+++ b/src/rrd_cgi.c
-@@ -680,11 +680,7 @@ static char *rrdgetinternal(
-         if (strcasecmp(args[0], "VERSION") == 0) {
-             return stralloc(PACKAGE_VERSION);
-         } else if (strcasecmp(args[0], "COMPILETIME") == 0) {
--#ifdef BUILD_DATE
--            return stralloc(BUILD_DATE);
--#else
-             return stralloc(__DATE__ " " __TIME__);
--#endif
-         } else {
-             return stralloc("[ERROR: internal unknown argument]");
-         }
++	DATE_FMT="%b %d %Y %H:%M:%S"
+ 	BUILD_DATE=$(LC_ALL=C date -u -d "@$SOURCE_DATE_EPOCH" "+$DATE_FMT")
+ 	AC_DEFINE_UNQUOTED([BUILD_DATE], ["$BUILD_DATE"], [Use reproducible build date])
+ fi
 diff --git a/src/rrd_tool.c b/src/rrd_tool.c
-index d598cb1d..f3484bc9 100644
+index 930d0827..cc6119d9 100644
 --- a/src/rrd_tool.c
 +++ b/src/rrd_tool.c
-@@ -309,11 +309,7 @@ static void PrintUsage(
-         else if (!strcmp(cmd, "pwd"))
-             help_cmd = C_PWD;
-     }
--#ifdef BUILD_DATE
--    fprintf(stdout, _(help_main), PACKAGE_VERSION, BUILD_DATE);
--#else
-     fprintf(stdout, _(help_main), PACKAGE_VERSION, __DATE__, __TIME__);
--#endif
-     fflush(stdout);
-     switch (help_cmd) {
-     case C_NONE:
+@@ -45,11 +45,19 @@ static void PrintUsage(
+     char *cmd)
+ {
+ 
++#ifdef BUILD_DATE
++    const char *help_main =
++        N_("RRDtool %s"
++           "  Copyright by Tobias Oetiker <tobi@oetiker.ch>\n"
++           "               Compiled %s\n\n"
++           "Usage: rrdtool [options] command command_options\n");
++#else
+     const char *help_main =
+         N_("RRDtool %s"
+            "  Copyright by Tobias Oetiker <tobi@oetiker.ch>\n"
+            "               Compiled %s %s\n\n"
+            "Usage: rrdtool [options] command command_options\n");
++#endif
+ 
+     const char *help_list =
+         N_

--- a/mingw-w64-rrdtool/002-rrdtool-1.8.0-rrd_first.patch
+++ b/mingw-w64-rrdtool/002-rrdtool-1.8.0-rrd_first.patch
@@ -1,0 +1,32 @@
+From b74a0d64e00770384d025e40becdb2ed83c04c0c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Wolfgang=20St=C3=B6ggl?= <c72578@yahoo.de>
+Date: Fri, 1 Apr 2022 19:14:49 +0200
+Subject: [PATCH] Fix unsigned integer overflow in rrdtool first
+
+This fixes a signed/unsigned conversion bug in the calculation of
+"then". Background info:
+pdp_cnt and pdp_step are both unsigned long, whereas timer is signed.
+When multiplying signed and unsigned integers (same size), a signed is
+implicitly typecast to unsigned.
+
+- A similar fix has already been applied to rrd_dump.c
+  in commit e193975
+- Resolves #1140
+---
+ src/rrd_first.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/rrd_first.c b/src/rrd_first.c
+index 0e93397c..a696c5c3 100644
+--- a/src/rrd_first.c
++++ b/src/rrd_first.c
+@@ -113,7 +113,8 @@ time_t rrd_first_r(
+     then = (rrd.live_head->last_up -
+             rrd.live_head->last_up %
+             (rrd.rra_def[rraindex].pdp_cnt * rrd.stat_head->pdp_step)) +
+-        (timer * rrd.rra_def[rraindex].pdp_cnt * rrd.stat_head->pdp_step);
++        (timer * (long) rrd.rra_def[rraindex].pdp_cnt *
++         (long) rrd.stat_head->pdp_step);
+   err_close:
+     rrd_close(rrd_file);
+   err_free:

--- a/mingw-w64-rrdtool/PKGBUILD
+++ b/mingw-w64-rrdtool/PKGBUILD
@@ -4,7 +4,7 @@ _realname=rrdtool
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.8.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Round Robin Database (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -16,14 +16,19 @@ depends=("${MINGW_PACKAGE_PREFIX}-glib2"
          "${MINGW_PACKAGE_PREFIX}-pango"
          "${MINGW_PACKAGE_PREFIX}-libxml2")
 source=("https://github.com/oetiker/rrdtool-1.x/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz"
-        "001-rrdtool-1.8.0-BUILD_DATE.patch")
+        "001-rrdtool-1.8.0-BUILD_DATE.patch"
+        "002-rrdtool-1.8.0-rrd_first.patch")
 sha256sums=('bd37614137d7a8dc523359648eb2a81631a34fd91a82ed5581916a52c08433f4'
-            'f023d0546bad1bfc5f662bfd26fffb62d5a2f313b4b6af4d8120ed5fc258b475')
+            '000269cb37db0be8c01b14931c5594238408537ea208d2304bd58c3494fa7bad'
+            '0fd1199d8415d700c962707b82ff3065fa05b21bca5e8f7e83bdcc98acfbcde1')
 
 prepare() {
   cp -Rf "${srcdir}/${_realname}-${pkgver}" "${srcdir}"/build-${CARCH}
   cd "${srcdir}"/build-${CARCH}
+  # https://github.com/oetiker/rrdtool-1.x/commit/e59f703
   patch -p1 -i ${srcdir}/001-rrdtool-1.8.0-BUILD_DATE.patch
+  # https://github.com/oetiker/rrdtool-1.x/commit/b74a0d6
+  patch -p1 -i ${srcdir}/002-rrdtool-1.8.0-rrd_first.patch
   ./bootstrap
 }
 


### PR DESCRIPTION
- Update patch to the upstream solution:
  `001-rrdtool-1.8.0-BUILD_DATE.patch`
- Add patch:
  `002-rrdtool-1.8.0-rrd_first.patch`
  This fixes an integer overflow in `rrd_first()`, which appeared in
  `mingw-w64-x86_64` and `mingw-w64-ucrt-x86_64` builds of rrdtool.
  Remark: `mingw-w64-i686` was not affected.
