### PR TITLE
lapack: update to 3.10.1

### DIFF
--- a/mingw-w64-lapack/PKGBUILD
+++ b/mingw-w64-lapack/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=lapack
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.10.0
+pkgver=3.10.1
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -15,15 +15,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-gcc-fortran"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 options=('strip' 'staticlibs')
-license=('LGPL')
+license=('spdx:BSD-3-Clause')
 url="https://www.netlib.org/lapack"
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/Reference-LAPACK/lapack/archive/v${pkgver}.tar.gz)
-sha256sums=('328c1bea493a32cac5257d84157dc686cc3ab0b004e2bea22044e0a59f6f8a19')
-
-prepare() {
-  cd "${srcdir}/${_realname}-${pkgver}"
-
-}
+sha256sums=('cd005cd021f144d7d5f7f33c943942db9f03a28d110d6a3b80d718a295f7f714')
 
 build() {
   declare -a _btype
@@ -33,8 +28,8 @@ build() {
     _btype=Release
   fi
 
-  cd "${srcdir}"
-  mkdir -p build-${CARCH} && cd build-${CARCH}
+  [[ -d "${srcdir}/build-${MSYSTEM}-shared" ]] && rm -rf "${srcdir}/build-${MSYSTEM}-shared"
+  mkdir -p "${srcdir}/build-${MSYSTEM}-shared" && cd "${srcdir}/build-${MSYSTEM}-shared"
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake.exe \
       -G"Ninja" \
@@ -43,16 +38,16 @@ build() {
       -DCMAKE_BUILD_TYPE=${_btype} \
       -DBUILD_SHARED_LIBS=ON \
       -DCMAKE_NEED_RESPONSE=ON \
-      -DBUILD_TESTING=OFF \
+      -DBUILD_TESTING=ON \
       -DLAPACKE_WITH_TMG=ON \
       -DCBLAS=ON \
       -DBUILD_DEPRECATED=ON \
       ../${_realname}-${pkgver}
 
-  ${MINGW_PREFIX}/bin/cmake.exe --build ./
+  ${MINGW_PREFIX}/bin/cmake.exe --build .
 
-  cd "${srcdir}"
-  mkdir -p build-${CARCH}s && cd build-${CARCH}s
+  [[ -d "${srcdir}/build-${MSYSTEM}-static" ]] && rm -rf "${srcdir}/build-${MSYSTEM}-static"
+  mkdir -p "${srcdir}/build-${MSYSTEM}-static" && cd "${srcdir}/build-${MSYSTEM}-static"
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake.exe \
       -G"Ninja" \
@@ -60,21 +55,31 @@ build() {
       -DCMAKE_Fortran_COMPILER=${MINGW_PREFIX}/bin/gfortran.exe \
       -DCMAKE_BUILD_TYPE=${_btype} \
       -DBUILD_SHARED_LIBS=OFF \
-      -DBUILD_TESTING=OFF \
+      -DBUILD_TESTING=ON \
       -DLAPACKE_WITH_TMG=ON \
       -DCBLAS=ON \
       -DBUILD_DEPRECATED=ON \
       ../${_realname}-${pkgver}
 
-  ${MINGW_PREFIX}/bin/cmake.exe --build ./
+  ${MINGW_PREFIX}/bin/cmake.exe --build .
+}
+
+check() {
+  # Many of the tests for CBLAS are failing
+
+  cd "${srcdir}/build-${MSYSTEM}-shared"
+  ctest . || true
+
+  cd "${srcdir}/build-${MSYSTEM}-static"
+  ctest . || true
 }
 
 package() {
-  cd "${srcdir}/build-${CARCH}s"
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install ./
+  cd "${srcdir}/build-${MSYSTEM}-static"
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install .
 
-  cd "${srcdir}/build-${CARCH}"
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install ./
+  cd "${srcdir}/build-${MSYSTEM}-shared"
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install .
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
Also correct the license in the package description.

The checks for CBLAS are failing. This is not a regression from this update but already happened (at least) with 3.10.0.
The other tests ("proper" BLAS, LAPACK) are passing.

Tbh, I don't understand the error messages (something about a missing file).

Is it ok to leave the checks in but ignore its result for the time being?
