### PR TITLE
suitesparse: Link against OpenBLAS also in CLANG* environments.

### DIFF
--- a/mingw-w64-suitesparse/PKGBUILD
+++ b/mingw-w64-suitesparse/PKGBUILD
@@ -4,7 +4,7 @@ _realname=suitesparse
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-suitesparse")
 pkgver=5.11.0
-pkgrel=1
+pkgrel=2
 pkgdesc='A suite of sparse matrix algorithms (mingw-w64)'
 url="https://faculty.cse.tamu.edu/davis/suitesparse.html"
 license=('spdx:LGPL-3.0-or-later AND BSD-3-Clause AND LGPL-2.1-or-later AND GPL-2.0-or-later AND LGPL-2.0-or-later AND Apache-2.0 AND GPL-3.0-or-later')
@@ -17,9 +17,8 @@ source=(${_realname}-${pkgver}.tar.gz::"https://github.com/DrTimothyAldenDavis/S
         "0004-mingw-w64-install-static-libs.patch"
         "0005-suitesparse-5.8.1-skip-building-Mongoose-GraphBLAS.patch"
         "0006-suitesparse-5.8.1-fix-mp-link-order.patch")
-depends=($([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] && \
-           echo "${MINGW_PACKAGE_PREFIX}-openblas" ||
-           echo "${MINGW_PACKAGE_PREFIX}-f2cblaslapack" "${MINGW_PACKAGE_PREFIX}-openmp")
+depends=("${MINGW_PACKAGE_PREFIX}-openblas"
+         $([[ ${MINGW_PACKAGE_PREFIX} != *-clang-*86* ]] || echo "${MINGW_PACKAGE_PREFIX}-openmp")
          "${MINGW_PACKAGE_PREFIX}-mpfr"
          "${MINGW_PACKAGE_PREFIX}-metis")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
@@ -82,8 +81,8 @@ build() {
   CXXFLAGS="-DLONGBLAS='long long'"  \
   LDFLAGS="-L${PWD}/lib"             \
   MY_METIS_LIB=-lmetis               \
-  BLAS=$([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] && echo -lopenblas || echo -lblas) \
-  LAPACK=$([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] && echo -lopenblas || echo -llapack) \
+  BLAS=-lopenblas                    \
+  LAPACK=-lopenblas                  \
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     make CMAKE_OPTIONS="-G\"MSYS Makefiles\" -DCMAKE_INSTALL_PREFIX=\"${MINGW_PREFIX}\" -DCMAKE_BUILD_TYPE=Release"
 }
@@ -99,8 +98,8 @@ package() {
   CFLAGS="-DLONGBLAS='long long'"         \
   CXXFLAGS="-DLONGBLAS='long long'"       \
   MY_METIS_LIB=-lmetis                    \
-  BLAS=$([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] && echo -lopenblas || echo -lblas) \
-  LAPACK=$([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] && echo -lopenblas || echo -llapack) \
+  BLAS=-lopenblas                         \
+  LAPACK=-lopenblas                       \
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   make install                          \
     INSTALL="${pkgdir}${MINGW_PREFIX}"  \


### PR DESCRIPTION
The OpenBLAS including C_LAPACK for the CLANG* environments is in staging now. Packages that currently link with "our" f2cblaslapack can be transitioned to linking with OpenBLAS instead. That might result in a performance gain for those packages.