### PR TITLE
armadillo: update to 11.0.1

### DIFF
--- a/mingw-w64-armadillo/0003-superlu.patch
+++ b/mingw-w64-armadillo/0003-superlu.patch
@@ -1,0 +1,21 @@
+diff -urN armadillo-11.0.1/cmake_aux/Modules/ARMA_FindSuperLU5.cmake.orig armadillo-11.0.1/cmake_aux/Modules/ARMA_FindSuperLU5.cmake
+--- armadillo-11.0.1/cmake_aux/Modules/ARMA_FindSuperLU5.cmake.orig	2016-06-16 18:24:41.000000000 +0200
++++ armadillo-11.0.1/cmake_aux/Modules/ARMA_FindSuperLU5.cmake	2022-04-20 19:02:20.871178800 +0200
+@@ -6,15 +6,8 @@
+ #  SuperLU_INCLUDE_DIR  - directory of SuperLU headers
+ 
+ find_path(SuperLU_INCLUDE_DIR slu_ddefs.h
+-  /usr/include/superlu/
+-  /usr/include/SuperLU/
+-  /usr/include/
+-  /usr/local/include/superlu/
+-  /usr/local/include/SuperLU/
+-  /usr/local/include/
+-  /opt/local/include/superlu/
+-  /opt/local/include/SuperLU/
+-  /opt/local/include/
++  PATHS ${CMAKE_SYSTEM_INCLUDE_PATH} /usr/include /usr/local/include /opt/local/include
++  PATH_SUFFIXES superlu SuperLU ""
+ )
+ 
+ find_library(SuperLU_LIBRARY

--- a/mingw-w64-armadillo/PKGBUILD
+++ b/mingw-w64-armadillo/PKGBUILD
@@ -3,17 +3,17 @@
 _realname=armadillo
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=11.0.0
+pkgver=11.0.1
 pkgrel=1
 pkgdesc="C++ linear algebra library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://arma.sourceforge.io/"
-license=(MPL2)
+license=(spdx:Apache-2.0)
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-hdf5"
          "${MINGW_PACKAGE_PREFIX}-openblas"
-         $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] && echo "${MINGW_PACKAGE_PREFIX}-f2cblaslapack")
+         "${MINGW_PACKAGE_PREFIX}-superlu"
          $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-arpack")
          )
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
@@ -22,15 +22,32 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
 install=${_realname}-${MSYSTEM}.install
 source=(https://sourceforge.net/projects/arma/files/${_realname}-${pkgver}.tar.xz
         0001-mingw-config-fix.patch
-        0002-fix-pkgconfig-file.patch)
-sha256sums=('7fdd4f041a624cd9bf23c9d84982d9188ec70352fa8ea03461a9d4da1165f0d3'
+        0002-fix-pkgconfig-file.patch
+        0003-superlu.patch)
+sha256sums=('e43d4449376c1fc8b562095431bb82cf9c4ff98a791a22a25d0f96e5e7937c22'
             '772719e60eb2970ecb37844382dbcb6d0439f949c5080f9865798115640b612a'
-            '830adb017e12c0e90671471dc6870a28ee21755a55e95280a04f73c2d65d665b')
+            '830adb017e12c0e90671471dc6870a28ee21755a55e95280a04f73c2d65d665b'
+            '615a7ee7669d5cc54e21a63047b864dfadfb4b7dc6fb0f8f4bd93fe977b08496')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Np1 -i "${srcdir}/$_patch"
+  done
+}
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
-  patch -Np1 -i "${srcdir}/0001-mingw-config-fix.patch"
-  patch -Np1 -i "${srcdir}/0002-fix-pkgconfig-file.patch"
+
+  apply_patch_with_msg \
+    0001-mingw-config-fix.patch \
+    0002-fix-pkgconfig-file.patch
+
+  # https://gitlab.com/conradsnicta/armadillo-code/-/commit/bffb20645919adc52f79e30e940d583bebe3bae0
+  apply_patch_with_msg \
+    0003-superlu.patch
 }
 
 build() {
@@ -42,7 +59,7 @@ build() {
     -G"Ninja" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DCMAKE_BUILD_TYPE=Release \
-    $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo -DOPENBLAS_PROVIDES_LAPACK=ON) \
+    -DOPENBLAS_PROVIDES_LAPACK=ON \
     ../${_realname}-${pkgver}
 
   cmake --build .


### PR DESCRIPTION
Build with SuperLU.
Correct license in description.
Use LAPACK in OpenBLAS also for CLANG* environments.