### PR TITLE
octave: Add timeout to configure step.

### DIFF
--- a/mingw-w64-octave/PKGBUILD
+++ b/mingw-w64-octave/PKGBUILD
@@ -57,6 +57,10 @@ build() {
   mkdir -p build-${MSYSTEM}
   cd build-${MSYSTEM}
 
+  # The configure step sometimes hangs for MINGW32 for currently unknown reasons.
+  # Add a timeout of 30 minutes (well over what should be needed) to unblock
+  # the build system in that case.
+  timeout 30m \
   ../${_realname}-${pkgver}/configure \
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \


### PR DESCRIPTION
This is only to unblock the build system in a case something similar to what happened in #11529 should occur again in the future. Nothing changed in the build rules that would actually affect the resulting binaries. No need to bump the pkgrel for this probably.