### PR TITLE
ncurses: fix hack to not use nanosleep 

### DIFF
--- a/mingw-w64-ncurses/PKGBUILD
+++ b/mingw-w64-ncurses/PKGBUILD
@@ -7,7 +7,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 #_date_rev=20211108
 #kgver=${_base_ver}.${_date_rev}
 pkgver=6.3
-pkgrel=3
+pkgrel=4
 pkgdesc="System V Release 4.0 curses emulation library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -50,7 +50,7 @@ build() {
   # It passes X_OK to access() on Windows which isn't supported with ucrt
   CFLAGS+=" -D__USE_MINGW_ACCESS"
   # nanosleep is only defined in pthread library
-  cf_cv_func_nanosleep=no
+  export cf_cv_func_nanosleep=no
 
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \


### PR DESCRIPTION
Fixes https://github.com/msys2/MINGW-packages/issues/11543

export was missing