### PR TITLE
openmp: add hacks for compiling both shared and static builds

### DIFF
--- a/mingw-w64-openmp/002-hacks-for-static-linking.patch
+++ b/mingw-w64-openmp/002-hacks-for-static-linking.patch
@@ -1,0 +1,46 @@
+diff -Naur openmp-14.0.0.src/runtime/cmake/LibompDefinitions.cmake src/openmp-14.0.0.src/runtime/cmake/LibompDefinitions.cmake
+--- openmp-14.0.0.src/runtime/cmake/LibompDefinitions.cmake	2022-04-21 01:17:04.574642900 -0400
++++ src/openmp-14.0.0.src/runtime/cmake/LibompDefinitions.cmake	2022-04-21 01:17:49.954060500 -0400
+@@ -26,5 +26,7 @@
+   endif()
+ 
+   # CMake doesn't include CPPFLAGS from environment, but we will.
+-  set(${cppflags} ${cppflags_local} ${LIBOMP_CPPFLAGS} $ENV{CPPFLAGS} PARENT_SCOPE)
++  string(REPLACE " " ";" ENV_CPPFLAGS $ENV{CPPFLAGS})
++  set(${cppflags} ${cppflags_local} ${LIBOMP_CPPFLAGS} ${ENV_CPPFLAGS} PARENT_SCOPE)
++  unset(ENV_CPPFLAGS)
+ endfunction()
+diff -Naur openmp-14.0.0.src/runtime/CMakeLists.txt src/openmp-14.0.0.src/runtime/CMakeLists.txt
+--- openmp-14.0.0.src/runtime/CMakeLists.txt	2022-03-14 05:44:55.000000000 -0400
++++ src/openmp-14.0.0.src/runtime/CMakeLists.txt	2022-04-21 01:11:05.925977700 -0400
+@@ -291,10 +291,6 @@
+ set(LIBOMP_ENABLE_SHARED TRUE CACHE BOOL
+   "Shared library instead of static library?")
+ 
+-if(WIN32 AND NOT LIBOMP_ENABLE_SHARED)
+-  libomp_error_say("Static libraries requested but not available on Windows")
+-endif()
+-
+ if(LIBOMP_USE_ITT_NOTIFY AND NOT LIBOMP_ENABLE_SHARED)
+   message(STATUS "ITT Notify not supported for static libraries - forcing ITT Notify off")
+   set(LIBOMP_USE_ITT_NOTIFY FALSE)
+diff -Naur openmp-14.0.0.src/runtime/src/CMakeLists.txt src/openmp-14.0.0.src/runtime/src/CMakeLists.txt
+--- openmp-14.0.0.src/runtime/src/CMakeLists.txt	2022-03-14 05:44:55.000000000 -0400
++++ src/openmp-14.0.0.src/runtime/src/CMakeLists.txt	2022-04-21 01:11:05.931526900 -0400
+@@ -251,14 +251,14 @@
+       set(LIBOMP_IMP_LIB_FILE ${LIBOMP_DEFAULT_LIB_NAME}${CMAKE_IMPORT_LIBRARY_SUFFIX})
+       set(LIBOMP_GENERATED_IMP_LIB_FILENAME ${LIBOMP_DEFAULT_LIB_NAME}${LIBOMP_LIBRARY_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX})
+     endif()
+-  else()
++  elseif(LIBOMP_ENABLE_SHARED)
+     set(LIBOMP_IMP_LIB_FILE ${LIBOMP_LIB_NAME}${CMAKE_IMPORT_LIBRARY_SUFFIX})
+     set(LIBOMP_GENERATED_IMP_LIB_FILENAME ${LIBOMP_LIB_FILE}${CMAKE_STATIC_LIBRARY_SUFFIX})
++    set_target_properties(omp PROPERTIES ARCHIVE_OUTPUT_NAME ${LIBOMP_GENERATED_IMP_LIB_FILENAME})
+   endif()
+   set_target_properties(omp PROPERTIES
+     VERSION ${LIBOMP_VERSION_MAJOR}.${LIBOMP_VERSION_MINOR} # uses /version flag
+     IMPORT_PREFIX "" IMPORT_SUFFIX "" # control generated import library name when building omp
+-    ARCHIVE_OUTPUT_NAME ${LIBOMP_GENERATED_IMP_LIB_FILENAME}
+   )
+ 
+   if(MSVC)

--- a/mingw-w64-openmp/PKGBUILD
+++ b/mingw-w64-openmp/PKGBUILD
@@ -8,7 +8,7 @@ _realname=openmp
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=14.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="LLVM OpenMP Library (mingw-w64)"
 url="https://openmp.llvm.org/"
 arch=(any)
@@ -25,10 +25,12 @@ options=('!debug' 'strip')
 _url=https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkgver}
 _pkgfn=$_realname-$pkgver.src
 source=($_url/$_pkgfn.tar.xz{,.sig}
-        "001-cast-to-make-gcc-happy.patch")
+        "001-cast-to-make-gcc-happy.patch"
+        "002-hacks-for-static-linking.patch")
 sha256sums=('28a1cbdd3dfdd331e4ed2dda2b4477fc418e455c883bd0d1d6acc331118e4688'
             'SKIP'
-            '11352ffbe7559a7170f2abd52b3552c877fbcf8fc82cff77b421e8b130a4dd66')
+            '11352ffbe7559a7170f2abd52b3552c877fbcf8fc82cff77b421e8b130a4dd66'
+            '7238f009264bc1b162b73ca3a2a0b224b65ec3ed384304f3e5464032c4c026f4')
 validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Google.
               '474E22316ABF4785A88C6E8EA2C794A986419D8A') # Tom Stellard
 
@@ -47,12 +49,12 @@ prepare() {
     apply_patch_with_msg \
       "001-cast-to-make-gcc-happy.patch"
   fi
+  apply_patch_with_msg 002-hacks-for-static-linking.patch
 }
 
 build() {
   cd ${srcdir}
-  [[ -d build-${MSYSTEM} ]] && rm -rf build-${MSYSTEM}
-  mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
+  rm -rf build-${MSYSTEM}-{shared,static}
 
   if check_option "debug" "y"; then
     _build_type="Debug"
@@ -72,22 +74,27 @@ build() {
       ;;
   esac
 
-  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-  ${MINGW_PREFIX}/bin/cmake \
-    -GNinja \
-    -DCMAKE_BUILD_TYPE=${_build_type} \
-    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    -DCMAKE_SYSTEM_IGNORE_PATH=/usr/lib \
-    -DLIBOMP_FORTRAN_MODULES=$( (( _clangprefix )) && echo "OFF" || echo "ON" ) \
-    ${platform_config[@]} \
-    -Wno-dev \
-    ../$_pkgfn
-
-  ${MINGW_PREFIX}/bin/cmake --build .
+  for shared_libs in shared static; do
+    MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake \
+      -GNinja \
+      -DCMAKE_BUILD_TYPE=${_build_type} \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      -DCMAKE_SYSTEM_IGNORE_PATH=/usr/lib \
+      -DLIBOMP_FORTRAN_MODULES="$( (( _clangprefix )) && echo OFF || echo ON )" \
+      -DLIBOMP_ENABLE_SHARED="$( [[ $shared_libs == static ]] && echo OFF || echo ON )" \
+      "${platform_config[@]}" \
+      -Wno-dev \
+      -S $_pkgfn \
+      -B "build-${MSYSTEM}-${shared_libs}"
+    ${MINGW_PREFIX}/bin/cmake --build "build-${MSYSTEM}-${shared_libs}"
+  done
+  unset shared_libs
 }
 
 package() {
-  DESTDIR=${pkgdir} ${MINGW_PREFIX}/bin/cmake --install build-${MSYSTEM}
+  DESTDIR=${pkgdir} ${MINGW_PREFIX}/bin/cmake --install "${srcdir}/build-${MSYSTEM}-shared"
+  DESTDIR=${pkgdir} ${MINGW_PREFIX}/bin/cmake --install "${srcdir}/build-${MSYSTEM}-static"
 
   install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_realname}
   install -Dm644 $_pkgfn/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_realname}


### PR DESCRIPTION
Fixes https://github.com/msys2/MINGW-packages/issues/10269

The first hunk could probably be upstreamed? The main usage for it is if CPPFLAGS is set with spaces inside, e.g. `-DFLAG=1 -DOTHER_FLAG=2` as its current line would result in `-DFLAG="1 -DOTHER_FLAG=2"`

For the second and third, I'm still not sure why static openmp is disabled on Windows, so I have no clue if they can be upstreamed or not