### PR TITLE
mingw-w64-tools-git: patch for mingw-enabled bin_to_includedir

### DIFF
--- a/mingw-w64-tools-git/PKGBUILD
+++ b/mingw-w64-tools-git/PKGBUILD
@@ -7,7 +7,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=10.0.0.r0.gaa08f56da
-pkgrel=1
+pkgrel=2
 _commit='aa08f56da559016f10336dddca85d59f9bdc9e02'
 pkgdesc="MinGW-w64 tools"
 arch=('any')
@@ -18,8 +18,14 @@ groups=("${MINGW_PACKAGE_PREFIX}-toolchain")
 makedepends=("git" "${MINGW_PACKAGE_PREFIX}-cc" "${MINGW_PACKAGE_PREFIX}-libmangle" "${MINGW_PACKAGE_PREFIX}-autotools")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 options=('staticlibs' '!emptydirs')
-source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64#commit=$_commit")
-sha256sums=('SKIP')
+source=(
+  "mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64#commit=$_commit"
+  bin_to_includedir.patch
+)
+sha256sums=(
+  'SKIP'
+  '07c772f93adfe783c7b3fb9a1490f12f585d29d4a97c680d476c74929af20506'
+)
 _tools="gendef genlib genidl genpeimg widl" # genstubdll
 
 pkgver() {
@@ -28,7 +34,8 @@ pkgver() {
 }
 
 prepare() {
-  cd "${srcdir}/mingw-w64"
+  cd "${srcdir}"
+  patch -N -p1 < bin_to_includedir.patch
 }
 
 build() {

--- a/mingw-w64-tools-git/bin_to_includedir.patch
+++ b/mingw-w64-tools-git/bin_to_includedir.patch
@@ -1,0 +1,13 @@
+diff -Naur a/mingw-w64/mingw-w64-tools/widl/src/widl.c b/mingw-w64/mingw-w64-tools/widl/src/widl.c
+--- a/mingw-w64/mingw-w64-tools/widl/src/widl.c	2022-04-22 07:43:03.570481500 +0200
++++ b/mingw-w64/mingw-w64-tools/widl/src/widl.c	2022-04-22 07:51:27.411330100 +0200
+@@ -740,6 +740,9 @@
+           strrchr (exe_path, '/')[1] = '\0';
+       }
+       wpp_add_include_path(strmake("%s%s/%s", sysroot, exe_path, BIN_TO_INCLUDEDIR));
++      /* literal BIN_TO_INCLUDEDIR for *.idl and *.tlb */
++      wpp_add_include_path(strmake("%s%s/%s", sysroot, exe_path, "../include"));
++      strarray_add(&dlldirs, strmake("%s%s/%s", sysroot, exe_path, "../include"));
+   }
+ 
+   if (pointer_size)


### PR DESCRIPTION
qemu uses widl via meson with expectation that widl knows its resource directories.

qemu references oaidl.idl, ocidl.idl and stdole2.tlb which reside in $MINGW_PACKAGE_PREFIX/include. $MINGW_PACKAGE_PREFIX/include is neither include nor lib search directory for widl

Because stdole2.tlb needs to be found as well --with-widl-includedir is not sufficient. 
There seems to be no way to transform both parameters -I $MINGW_PACKAGE_PREFIX/include and -L $MINGW_PACKAGE_PREFIX/include to configure options.

This results in the applied patch - which I produced without any recent C/C++ experience. Please keep this in mind while reviewing!

The idea of the patch is: add a well-known directory to the search path, but don't remove any existing (maybe broken) directories from the search path.