### PR TITLE
openssl: fix leak when calling relocation related functions multiple times

### DIFF
--- a/mingw-w64-openssl/PKGBUILD
+++ b/mingw-w64-openssl/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 _ver=1.1.1n
 # use a pacman compatible version scheme
 pkgver=${_ver/[a-z]/.${_ver//[0-9.]/}}
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 pkgdesc="The Open Source toolkit for Secure Sockets Layer and Transport Layer Security (mingw-w64)"
@@ -27,7 +27,7 @@ sha256sums=('40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a'
             'SKIP'
             '703cd0cb74e714f9e66d26de11c109dd76fab07e723af8dde56a35ea65102e5f'
             '4f9d325265ef6f4e90ad637dea41afa6995388c921fe961ad5dc895aca10318b'
-            'ca847be6a50c30db96a3323d51e09691c3d302f7d85f3eb61fabe1f08c223659'
+            '581b7d6c5a7f2ba4490fb69ee4816a6e8f9034f72e1a2c8438f3271554379106'
             'd41fad88631e7b8d2a56662f2166ea97ecbc6369f2ad3eac415182bc9ac9f308')
 
 validpgpkeys=('8657ABB260F056B1E5190839D9C4D26D0E604491'

--- a/mingw-w64-openssl/openssl-1.1.1-relocation.patch
+++ b/mingw-w64-openssl/openssl-1.1.1-relocation.patch
@@ -11,10 +11,8 @@ index b515b7318e..f090ff458d 100644
          threads_pthread.c threads_win.c threads_none.c getenv.c \
          o_init.c o_fips.c mem_sec.c init.c {- $target{cpuid_asm_src} -} \
          {- $target{uplink_aux_src} -}
-diff --git a/crypto/engine/eng_list.c b/crypto/engine/eng_list.c
-index 4bc7ea173c..5f881fb2cb 100644
---- a/crypto/engine/eng_list.c
-+++ b/crypto/engine/eng_list.c
+--- openssl-1.1.1n/crypto/engine/eng_list.c.orig	2022-03-15 15:37:47.000000000 +0100
++++ openssl-1.1.1n/crypto/engine/eng_list.c	2022-04-24 19:44:11.950597400 +0200
 @@ -9,6 +9,7 @@
   */
  
@@ -23,7 +21,7 @@ index 4bc7ea173c..5f881fb2cb 100644
  
  /*
   * The linked-list of pointers to engine types. engine_list_head incorporates
-@@ -30,6 +31,20 @@ static ENGINE *engine_list_tail = NULL;
+@@ -36,6 +37,20 @@
   * cleanup.
   */
  
@@ -44,24 +42,25 @@ index 4bc7ea173c..5f881fb2cb 100644
  static void engine_list_cleanup(void)
  {
      ENGINE *iterator = engine_list_head;
-@@ -318,8 +333,10 @@ ENGINE *ENGINE_by_id(const char *id)
+@@ -404,8 +419,13 @@
       * Prevent infinite recursion if we're looking for the dynamic engine.
       */
      if (strcmp(id, "dynamic")) {
 -        if ((load_dir = ossl_safe_getenv("OPENSSL_ENGINES")) == NULL)
 -            load_dir = ENGINESDIR;
 +        if ((load_dir = ossl_safe_getenv("OPENSSL_ENGINES")) == NULL) {
-+            const char * reloc_engines = enginedir_relocation(ENGINESDIR);
-+            load_dir = reloc_engines;
++            static char * reloc = NULL;
++            if (reloc == NULL) {
++                reloc = enginedir_relocation(ENGINESDIR);
++            }
++            load_dir = reloc;
 +        }
          iterator = ENGINE_by_id("dynamic");
          if (!iterator || !ENGINE_ctrl_cmd_string(iterator, "ID", id, 0) ||
              !ENGINE_ctrl_cmd_string(iterator, "DIR_LOAD", "2", 0) ||
-diff --git a/crypto/x509/x509_def.c b/crypto/x509/x509_def.c
-index bfa8d7d852..6fcc1b021a 100644
---- a/crypto/x509/x509_def.c
-+++ b/crypto/x509/x509_def.c
-@@ -9,27 +9,42 @@
+--- openssl-1.1.1n/crypto/x509/x509_def.c.orig	2022-03-15 15:37:47.000000000 +0100
++++ openssl-1.1.1n/crypto/x509/x509_def.c	2022-04-24 19:42:15.123279000 +0200
+@@ -9,27 +9,58 @@
  
  #include <stdio.h>
  #include "internal/cryptlib.h"
@@ -86,25 +85,41 @@ index bfa8d7d852..6fcc1b021a 100644
  const char *X509_get_default_private_dir(void)
  {
 -    return X509_PRIVATE_DIR;
-+    return openssl_relocation(X509_PRIVATE_DIR);
++    static char * reloc = NULL;
++    if (reloc == NULL) {
++        reloc = openssl_relocation(X509_PRIVATE_DIR);
++    }
++    return reloc;
  }
  
  const char *X509_get_default_cert_area(void)
  {
 -    return X509_CERT_AREA;
-+    return openssl_relocation(X509_CERT_AREA);
++    static char * reloc = NULL;
++    if (reloc == NULL) {
++        reloc = openssl_relocation(X509_CERT_AREA);
++    }
++    return reloc;
  }
  
  const char *X509_get_default_cert_dir(void)
  {
 -    return X509_CERT_DIR;
-+    return openssl_relocation(X509_CERT_DIR);
++    static char * reloc = NULL;
++    if (reloc == NULL) {
++        reloc = openssl_relocation(X509_CERT_DIR);
++    }
++    return reloc;
  }
  
  const char *X509_get_default_cert_file(void)
  {
 -    return X509_CERT_FILE;
-+    return openssl_relocation(X509_CERT_FILE);
++    static char * reloc = NULL;
++    if (reloc == NULL) {
++        reloc = openssl_relocation(X509_CERT_FILE);
++    }
++    return reloc;
  }
  
  const char *X509_get_default_cert_dir_env(void)


### PR DESCRIPTION
Instead of relocating every time the getters are called,
relocate only on the first call for each path.

Fixes #11552