### PR TITLE
openjepg2: Reapply stdcall for all library type

### DIFF
--- a/mingw-w64-openjpeg2/0006-openjpeg-2.1.0-stdcall-for-all-win.patch
+++ b/mingw-w64-openjpeg2/0006-openjpeg-2.1.0-stdcall-for-all-win.patch
@@ -1,18 +1,69 @@
---- openjpeg-2.1.2/src/lib/openmj2/openjpeg.h.orig	2016-10-02 12:10:38.105864300 -0400
-+++ openjpeg-2.1.2/src/lib/openmj2/openjpeg.h	2016-10-02 12:12:33.009046900 -0400
-@@ -44,6 +44,11 @@
-    Compiler directives
- ==========================================================
- */
-+#if defined(_WIN32)
-+#define OPJ_CALLCONV __stdcall
-+#else
-+#define OPJ_CALLCONV
-+#endif
+--- a/src/lib/openjp2/openjpeg.h
++++ b/src/lib/openjp2/openjpeg.h
+@@ -76,6 +76,12 @@
+ #define OPJ_DEPRECATED(func) func
+ #endif
  
++#if defined(_ARM_)
++#define OPJ_CALLCONV
++#else
++#define OPJ_CALLCONV __stdcall
++#endif
++
  #if defined(OPJ_STATIC) || !defined(_WIN32)
  /* http://gcc.gnu.org/wiki/Visibility */
-@@ -54,9 +59,7 @@
+ #   if !defined(_WIN32) && __GNUC__ >= 4
+@@ -89,9 +95,7 @@
+ #       define OPJ_API
+ #       define OPJ_LOCAL
+ #   endif
+-#   define OPJ_CALLCONV
+ #else
+-#   define OPJ_CALLCONV __stdcall
+ /*
+ The following ifdef block is the standard way of creating macros which make exporting
+ from a DLL simpler. All files within this DLL are compiled with the OPJ_EXPORTS
+--- a/src/lib/openjp3d/openjp3d.h
++++ b/src/lib/openjp3d/openjp3d.h
+@@ -42,6 +42,12 @@
+ ==========================================================
+ */
+ 
++#if defined(_ARM_)
++#define OPJ_CALLCONV
++#else
++#define OPJ_CALLCONV __stdcall
++#endif
++
+ #if defined(OPJ_STATIC) || !defined(_WIN32)
+ /* http://gcc.gnu.org/wiki/Visibility */
+ #if __GNUC__ >= 4
+@@ -51,9 +57,7 @@
+ #define OPJ_API
+ #define OPJ_LOCAL
+ #endif
+-#define OPJ_CALLCONV
+ #else
+-#define OPJ_CALLCONV __stdcall
+ 
+ /*
+ The following ifdef block is the standard way of creating macros which make exporting
+--- a/src/lib/openmj2/openjpeg.h
++++ b/src/lib/openmj2/openjpeg.h
+@@ -45,6 +45,12 @@
+ ==========================================================
+ */
+ 
++#if defined(_ARM_)
++#define OPJ_CALLCONV
++#else
++#define OPJ_CALLCONV __stdcall
++#endif
++
+ #if defined(OPJ_STATIC) || !defined(_WIN32)
+ /* http://gcc.gnu.org/wiki/Visibility */
+ #if __GNUC__ >= 4
+@@ -54,9 +60,7 @@
  #define OPJ_API
  #define OPJ_LOCAL
  #endif
@@ -20,30 +71,5 @@
  #else
 -#define OPJ_CALLCONV __stdcall
  /*
- The following ifdef block is the standard way of creating macros which make exporting 
- from a DLL simpler. All files within this DLL are compiled with the OPJ_EXPORTS
---- openjpeg-2.1.2/src/lib/openjp2/openjpeg.h.orig	2016-09-28 14:18:16.000000000 -0400
-+++ openjpeg-2.1.2/src/lib/openjp2/openjpeg.h	2016-10-01 09:57:29.318921200 -0400
-@@ -76,6 +76,12 @@
- 	#define OPJ_DEPRECATED(func) func
- #endif
- 
-+#if defined(_WIN32) || defined(WIN32)
-+#define OPJ_CALLCONV __stdcall
-+#else
-+#define OPJ_CALLCONV
-+#endif
-+
- #if defined(OPJ_STATIC) || !defined(_WIN32)
- /* http://gcc.gnu.org/wiki/Visibility */
- #	if __GNUC__ >= 4
-@@ -89,9 +95,7 @@
- #		define OPJ_API
- #		define OPJ_LOCAL
- #	endif
--#	define OPJ_CALLCONV
- #else
--#	define OPJ_CALLCONV __stdcall
- /*
- The following ifdef block is the standard way of creating macros which make exporting 
+ The following ifdef block is the standard way of creating macros which make exporting
  from a DLL simpler. All files within this DLL are compiled with the OPJ_EXPORTS

--- a/mingw-w64-openjpeg2/PKGBUILD
+++ b/mingw-w64-openjpeg2/PKGBUILD
@@ -4,7 +4,7 @@ _realname=openjpeg
 pkgbase=mingw-w64-${_realname}2
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}2"
 pkgver=2.4.0
-pkgrel=3
+pkgrel=4
 pkgdesc="An open source JPEG 2000 codec (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -35,7 +35,7 @@ sha256sums=('8702ba68b442657f11aaeb2b338443ca8d5fb95b0d845757968a7be31ef7f16d'
             '0f95f52b6fd662acb84b481a998ec4170369fe94247e0fa227fcda1f6ba18f1b'
             'adade9b29e4292b642d547644e26fab6e193bbfe31d25f07d89a8c35e4d0993d'
             '9df169f03e6e69cba0d7d33592f9eba373a02cd9554b456d3eb9ff3d9135391b'
-            'e8c375faa317c819174b50aa43b6be61c108872661b014738c4a0cfa95aac919'
+            '7b01458772ccc44d0092079bd3de4ee277a721078082ae4a65782c0247523f0f'
             '056676ae6fde36c4f849b0c282bf49a4c63aceaf63d6ee114b4336a240de79bf'
             'b99cfedafbd03687006fbe84a7d74c93aaace40e25250d8a2910d50bc2740cd7')
 
@@ -65,7 +65,10 @@ prepare() {
    0003-versioned-dlls.mingw.patch \
    0004-mingw-disable-java.patch \
    0005-sock-jpip.all.patch
-  #patch -p1 -i ${srcdir}/0006-openjpeg-2.1.0-stdcall-for-all-win.patch
+
+  # Required for static linking in 32 bit, adds stdcall decorations in static libs
+  apply_patch_with_msg \
+    0006-openjpeg-2.1.0-stdcall-for-all-win.patch
 
   # Workaround, src/bin/jp3d is removed in upstream
   apply_patch_with_msg \


### PR DESCRIPTION
This patch was disable in 8edfe204d937edf31b0310c6195de5a337c270b9 commit.
But it fixes static linking with 32 bit ffmpeg. Previously, the stdcall
decoration was only enabled in shared libs but not in static libs. So,
when OPJ_STATIC is enabled the ffmpeg configure fails to check function
without stdcall decoration in 32 bit environment.