### PR TITLE
msmpi: Rename import library to .dll.a extension

### DIFF
--- a/mingw-w64-msmpi/PKGBUILD
+++ b/mingw-w64-msmpi/PKGBUILD
@@ -4,7 +4,7 @@ _realname=msmpi
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=10.1.1
-pkgrel=7
+pkgrel=8
 pkgdesc="Microsoft MPI SDK (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -53,9 +53,9 @@ build() {
   [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}
   mkdir -p ${srcdir}/build-${MSYSTEM} && cd ${srcdir}/build-${MSYSTEM}
 
-  # Import library
+  # Import library (.dll.a)
   mkdir -p lib
-  ${MINGW_PREFIX}/bin/dlltool -k -d "$srcdir/msmpi.def.${CARCH}" -l lib/libmsmpi.a
+  ${MINGW_PREFIX}/bin/dlltool -k -d "$srcdir/msmpi.def.${CARCH}" -l lib/libmsmpi.dll.a
 
   # Headers
   mkdir -p include


### PR DESCRIPTION
From the discussion in https://github.com/msys2/MINGW-packages/pull/11607

@mmuetzel @gharveymn @okhlybov