### PR TITLE
cmake: depend on ninja

### DIFF
--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -7,7 +7,7 @@ _realname=cmake
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.23.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -36,6 +36,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libarchive"
          "${MINGW_PACKAGE_PREFIX}-libuv"
          "${MINGW_PACKAGE_PREFIX}-rhash"
+         "${MINGW_PACKAGE_PREFIX}-ninja"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 optdepends=("${MINGW_PACKAGE_PREFIX}-qt6-base: CMake Qt GUI"
             "${MINGW_PACKAGE_PREFIX}-emacs: for cmake emacs mode")


### PR DESCRIPTION
We change the default generator to ninja, so we should also
make sure it is always available.

Fixes #11620