### PR TITLE
python-hid: new package

### DIFF
--- a/mingw-w64-python-hid/PKGBUILD
+++ b/mingw-w64-python-hid/PKGBUILD
@@ -1,0 +1,39 @@
+# Maintainer: fauxpark <fauxpark@gmail.com>
+
+_realname=hid
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=1.0.4
+pkgrel=1
+pkgdesc="Python hidapi bindings in ctypes (aka pyhidapi) (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+url='https://github.com/apmorton/pyhidapi'
+license=('MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-hidapi"
+         "${MINGW_PACKAGE_PREFIX}-python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('f61b0382f37a334bc8ba8604bc84b94875ee4f594fbbaf82b2c3b3e827883fc1')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+}
+
+build() {
+  cd "${srcdir}"
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  "${MINGW_PREFIX}"/bin/python setup.py build
+}
+
+package() {
+  cd "${srcdir}/python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    "${MINGW_PREFIX}"/bin/python setup.py install --prefix="${MINGW_PREFIX}" \
+      --root="${pkgdir}" --optimize=1 --skip-build
+
+  #install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}


### PR DESCRIPTION
License install is commented out for now as it wasn't included in the manifest until recently (https://github.com/apmorton/pyhidapi/pull/44).