### PR TITLE
openssl: backport fix for broken EC code with clang 14

### DIFF
--- a/mingw-w64-openssl/18258.patch
+++ b/mingw-w64-openssl/18258.patch
@@ -1,0 +1,80 @@
+From 0b8f1c51e8068ae86c285610cab73409d26b6341 Mon Sep 17 00:00:00 2001
+From: Pauli <pauli@openssl.org>
+Date: Fri, 6 May 2022 16:59:26 +1000
+Subject: [PATCH 1/2] bn_nist: fix strict aliasing problem
+
+As of clang-14 the strict aliasing is causing code to magically disappear.
+By explicitly inlining the code, the aliasing problem evaporates.
+
+Fixes #18225
+---
+ crypto/bn/bn_nist.c | 32 +++++++++++++++++++++-----------
+ 1 file changed, 21 insertions(+), 11 deletions(-)
+
+diff --git a/crypto/bn/bn_nist.c b/crypto/bn/bn_nist.c
+index aea8a6e65d99..3b80d73f1cc9 100644
+--- a/crypto/bn/bn_nist.c
++++ b/crypto/bn/bn_nist.c
+@@ -249,17 +249,27 @@ const BIGNUM *BN_get0_nist_prime_521(void)
+     return &ossl_bignum_nist_p_521;
+ }
+ 
+-static void nist_cp_bn_0(BN_ULONG *dst, const BN_ULONG *src, int top, int max)
+-{
+-    int i;
+-
+-#ifdef BN_DEBUG
+-    (void)ossl_assert(top <= max);
+-#endif
+-    for (i = 0; i < top; i++)
+-        dst[i] = src[i];
+-    for (; i < max; i++)
+-        dst[i] = 0;
++/*
++ * To avoid more recent compilers (specifically clang-14) from treating this
++ * code as a violation of the strict aliasing conditions and omiting it, this
++ * cannot be declared as a function.  Moreover, the dst parameter cannot be
++ * cached in a local since this no longer references the union and again falls
++ * foul of the strict aliasing criteria.  Refer to #18225 for the initial
++ * diagnostics and llvm/llvm-project#55255 for the later discussions with the
++ * LLVM developers.
++ *
++ * This function was inlined regardless, so there is no space cost to be
++ * paid for making it a macro.
++ */
++#define nist_cp_bn_0(dst, src_in, top, max) \
++{                                           \
++    int ii;                                 \
++    const BN_ULONG *src = src_in;           \
++                                            \
++    for (ii = 0; ii < top; ii++)            \
++        (dst)[ii] = src[ii];                \
++    for (; ii < max; ii++)                  \
++        (dst)[ii] = 0;                      \
+ }
+ 
+ static void nist_cp_bn(BN_ULONG *dst, const BN_ULONG *src, int top)
+
+From c287c267268a18748285fdb55e6cb46c8d5832ca Mon Sep 17 00:00:00 2001
+From: Pauli <pauli@openssl.org>
+Date: Fri, 6 May 2022 18:14:12 +1000
+Subject: [PATCH 2/2] fixup! bn_nist: fix strict aliasing problem
+
+---
+ crypto/bn/bn_nist.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/crypto/bn/bn_nist.c b/crypto/bn/bn_nist.c
+index 3b80d73f1cc9..5b6d4e7e4dff 100644
+--- a/crypto/bn/bn_nist.c
++++ b/crypto/bn/bn_nist.c
+@@ -256,7 +256,8 @@ const BIGNUM *BN_get0_nist_prime_521(void)
+  * cached in a local since this no longer references the union and again falls
+  * foul of the strict aliasing criteria.  Refer to #18225 for the initial
+  * diagnostics and llvm/llvm-project#55255 for the later discussions with the
+- * LLVM developers.
++ * LLVM developers.  The problem boils down to if an array in the union is
++ * converted to a pointer or if it is used directly.
+  *
+  * This function was inlined regardless, so there is no space cost to be
+  * paid for making it a macro.

--- a/mingw-w64-openssl/PKGBUILD
+++ b/mingw-w64-openssl/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 _ver=1.1.1o
 # use a pacman compatible version scheme
 pkgver=${_ver/[a-z]/.${_ver//[0-9.]/}}
-pkgrel=2
+pkgrel=3
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 pkgdesc="The Open Source toolkit for Secure Sockets Layer and Transport Layer Security (mingw-w64)"
@@ -22,13 +22,15 @@ source=(https://www.openssl.org/source/${_realname}-${_ver}.tar.gz{,.asc}
         'pathtools.c'
         'pathtools.h'
         'openssl-1.1.1-relocation.patch'
-        'openssl-1.1.1-mingw-arm.patch')
+        'openssl-1.1.1-mingw-arm.patch'
+        '18258.patch')
 sha256sums=('9384a2b0570dd80358841464677115df785edb941c71211f75076d72fe6b438f'
             'SKIP'
             '703cd0cb74e714f9e66d26de11c109dd76fab07e723af8dde56a35ea65102e5f'
             '4f9d325265ef6f4e90ad637dea41afa6995388c921fe961ad5dc895aca10318b'
             'cc8941f93678a53bcef89c9feda5bd16588f69290891b1ea59a654743dc04ea1'
-            'd41fad88631e7b8d2a56662f2166ea97ecbc6369f2ad3eac415182bc9ac9f308')
+            'd41fad88631e7b8d2a56662f2166ea97ecbc6369f2ad3eac415182bc9ac9f308'
+            'ba793c8e9cf7bfbd995784e972bfeea56cdb0265ceef9bcd93fad28b67e2349e')
 
 validpgpkeys=('8657ABB260F056B1E5190839D9C4D26D0E604491'
               '7953AC1FBC3DC8B3B292393ED5E9E43F7DF9EE8C')
@@ -56,6 +58,11 @@ prepare() {
   apply_patch_with_msg \
      openssl-1.1.1-relocation.patch \
      openssl-1.1.1-mingw-arm.patch
+
+  # Fix EC code being broken with Clang 14
+  # https://github.com/openssl/openssl/pull/18258
+  apply_patch_with_msg \
+    18258.patch
 }
 
 build() {


### PR DESCRIPTION
Some UB results in broken code starting with Clang 14. This only
affects the no-asm case, which is only used for our arm64 build.

This resulted in runtime errors such as:

```
19560:error:1012606B:elliptic curve routines:EC_POINT_set_affine_coordinates:point is not on curve:../openssl-1.1.1o/crypto/ec/ec_lib.c:813:
19560:error:100AF010:elliptic curve routines:ec_group_new_from_data:EC lib:../openssl-1.1.1o/crypto/ec/ec_curve.c:3083:
19560:error:100AE081:elliptic curve routines:EC_GROUP_new_by_curve_name:unknown group:../openssl-1.1.1o/crypto/ec/ec_curve.c:3159:
19560:error:100D7010:elliptic curve routines:eckey_pub_decode:EC lib:../openssl-1.1.1o/crypto/ec/ec_ameth.c:168:
19560:error:0B09407D:x509 certificate routines:x509_pubkey_decode:public key decode error:../openssl-1.1.1o/crypto/x509/x_pubkey.c:125:
```

Patch taken from https://github.com/openssl/openssl/pull/18258

(untested if it really fixes the issue, we'll see when rebuilding ca-certificates)