### PR TITLE
add glib2 as runtime depends to aravis utils

### DIFF
--- a/mingw-w64-aravis/PKGBUILD
+++ b/mingw-w64-aravis/PKGBUILD
@@ -80,6 +80,7 @@ package_aravis() {
 		"${MINGW_PACKAGE_PREFIX}-libnotify"
 		"${MINGW_PACKAGE_PREFIX}-libxml2"
 		"${MINGW_PACKAGE_PREFIX}-zlib"
+		"${MINGW_PACKAGE_PREFIX}-glib2"
 		"${MINGW_PACKAGE_PREFIX}-libusb"
 		"${MINGW_PACKAGE_PREFIX}-gobject-introspection-runtime"
 	)


### PR DESCRIPTION
Reported here:
https://aravis-project.discourse.group/t/dll-missing-error-when-trying-to-open-arv-camera-test-0-8/450