### PR TITLE
fzf: new package

### DIFF
--- a/mingw-w64-fzf/PKGBUILD
+++ b/mingw-w64-fzf/PKGBUILD
@@ -1,58 +1,66 @@
 # Maintainer: Wu Zhenyu <wuzy01@qq.com>
 _realname=fzf
 
-pkgbase=mingw-w64-$_realname
-pkgname=$MINGW_PACKAGE_PREFIX-$_realname
+pkgbase="mingw-w64-${_realname}"
+pkgname="$MINGW_PACKAGE_PREFIX-${_realname}"
 pkgver=0.30.0
 pkgrel=1
 pkgdesc='Command-line fuzzy finder (mingw-w64)'
 arch=('any')
 mingw_arch=(mingw64 ucrt64 clang64 clangarm64)
 url='https://github.com/junegunn/fzf'
-license=('MIT')
-makedepends=('git' $MINGW_PACKAGE_PREFIX-go $MINGW_PACKAGE_PREFIX-clang)
-source=("git+https://github.com/junegunn/fzf.git#tag=${pkgver}")
-sha512sums=('SKIP')
+license=('spdx:MIT')
+makedepends=(
+  "$MINGW_PACKAGE_PREFIX-go"
+  "$MINGW_PACKAGE_PREFIX-cc"
+)
+source=("https://github.com/junegunn/fzf/archive/refs/tags/${pkgver}.tar.gz")
+sha256sums=('a3428f510b7136e39104a002f19b2e563090496cb5205fa2e4c5967d34a20124')
 
 prepare() {
-	cd "$srcdir/$_realname"
-	sed -i 's/-w /-w -linkmode external /' Makefile
+  cd "$srcdir/${_realname}-${pkgver}"
+  sed -i 's/-w /-w -linkmode external /' Makefile
 }
 
 build() {
-	cd "$srcdir/$_realname"
-	export CGO_LDFLAGS="${LDFLAGS}"
-	export CGO_CFLAGS="${CFLAGS}"
-	export CGO_CPPFLAGS="${CPPFLAGS}"
-	export CGO_CXXFLAGS="${CXXFLAGS}"
-	export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
+  cd "$srcdir/${_realname}-${pkgver}"
+  export CGO_LDFLAGS="${LDFLAGS}"
+  export CGO_CFLAGS="${CFLAGS}"
+  export CGO_CPPFLAGS="${CPPFLAGS}"
+  export CGO_CXXFLAGS="${CXXFLAGS}"
+  export GOFLAGS="-trimpath -mod=readonly -modcacherw -buildvcs=false"
+  case "${CARCH}" in
+    i686|x86_64)
+      GOFLAGS+=" -buildmode=pie"
+      ;;
+  esac
 
-	make
+  FZF_VERSION=${pkgver} FZF_REVISION=tarball make
 }
 
 package() {
-	cd "$srcdir/$_realname"
+  cd "$srcdir/${_realname}-${pkgver}"
 
-	## Man page
-	install -Dm644 man/man1/fzf.1 "$pkgdir"$MINGW_PREFIX/share/man/man1/fzf.1
-	install -Dm644 man/man1/fzf-tmux.1 "$pkgdir"$MINGW_PREFIX/share/man/man1/fzf-tmux.1
+  ## Man page
+  install -Dm644 man/man1/fzf.1 "$pkgdir"$MINGW_PREFIX/share/man/man1/fzf.1
+  install -Dm644 man/man1/fzf-tmux.1 "$pkgdir"$MINGW_PREFIX/share/man/man1/fzf-tmux.1
 
-	## License
-	install -Dm644 LICENSE "$pkgdir"$MINGW_PREFIX/share/licenses/fzf/LICENSE
+  ## License
+  install -Dm644 LICENSE "$pkgdir"$MINGW_PREFIX/share/licenses/fzf/LICENSE
 
-	## Binaries
-	install -dm755 "$pkgdir"$MINGW_PREFIX/bin
-	install -m755 bin/fzf-tmux "$pkgdir"$MINGW_PREFIX/bin/fzf-tmux.exe
-	install -Dm755 target/fzf-* "$pkgdir"$MINGW_PREFIX/bin/fzf.exe
+  ## Binaries
+  install -dm755 "$pkgdir"$MINGW_PREFIX/bin
+  install -m755 bin/fzf-tmux "$pkgdir"$MINGW_PREFIX/bin/fzf-tmux.exe
+  install -Dm755 target/fzf-* "$pkgdir"$MINGW_PREFIX/bin/fzf.exe
 
-	## Completion and keybindings
-	install -dm755 "$pkgdir"$MINGW_PREFIX/share/fzf
-	install -m644 shell/*.bash shell/*.zsh "$pkgdir"$MINGW_PREFIX/share/fzf
+  ## Completion and keybindings
+  install -dm755 "$pkgdir"$MINGW_PREFIX/share/fzf
+  install -m644 shell/*.bash shell/*.zsh "$pkgdir"$MINGW_PREFIX/share/fzf
 
-	## Fish keybindings
-	install -Dm644 shell/key-bindings.fish "$pkgdir"$MINGW_PREFIX/share/fish/vendor_functions.d/fzf_key_bindings.fish
+  ## Fish keybindings
+  install -Dm644 shell/key-bindings.fish "$pkgdir"$MINGW_PREFIX/share/fish/vendor_functions.d/fzf_key_bindings.fish
 
-	## Vim plugin
-	install -Dm644 doc/fzf.txt "$pkgdir"$MINGW_PREFIX/share/vim/vimfiles/doc/fzf.txt
-	install -Dm644 plugin/fzf.vim "$pkgdir"$MINGW_PREFIX/share/vim/vimfiles/plugin/fzf.vim
+  ## Vim plugin
+  install -Dm644 doc/fzf.txt "$pkgdir"$MINGW_PREFIX/share/vim/vimfiles/doc/fzf.txt
+  install -Dm644 plugin/fzf.vim "$pkgdir"$MINGW_PREFIX/share/vim/vimfiles/plugin/fzf.vim
 }

--- a/mingw-w64-fzf/PKGBUILD
+++ b/mingw-w64-fzf/PKGBUILD
@@ -1,0 +1,58 @@
+# Maintainer: Wu Zhenyu <wuzy01@qq.com>
+_realname=fzf
+
+pkgbase=mingw-w64-$_realname
+pkgname=$MINGW_PACKAGE_PREFIX-$_realname
+pkgver=0.30.0
+pkgrel=1
+pkgdesc='Command-line fuzzy finder (mingw-w64)'
+arch=('any')
+mingw_arch=(mingw64 ucrt64 clang64 clangarm64)
+url='https://github.com/junegunn/fzf'
+license=('MIT')
+makedepends=('git' $MINGW_PACKAGE_PREFIX-go $MINGW_PACKAGE_PREFIX-clang)
+source=("git+https://github.com/junegunn/fzf.git#tag=${pkgver}")
+sha512sums=('SKIP')
+
+prepare() {
+	cd "$srcdir/$_realname"
+	sed -i 's/-w /-w -linkmode external /' Makefile
+}
+
+build() {
+	cd "$srcdir/$_realname"
+	export CGO_LDFLAGS="${LDFLAGS}"
+	export CGO_CFLAGS="${CFLAGS}"
+	export CGO_CPPFLAGS="${CPPFLAGS}"
+	export CGO_CXXFLAGS="${CXXFLAGS}"
+	export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
+
+	make
+}
+
+package() {
+	cd "$srcdir/$_realname"
+
+	## Man page
+	install -Dm644 man/man1/fzf.1 "$pkgdir"$MINGW_PREFIX/share/man/man1/fzf.1
+	install -Dm644 man/man1/fzf-tmux.1 "$pkgdir"$MINGW_PREFIX/share/man/man1/fzf-tmux.1
+
+	## License
+	install -Dm644 LICENSE "$pkgdir"$MINGW_PREFIX/share/licenses/fzf/LICENSE
+
+	## Binaries
+	install -dm755 "$pkgdir"$MINGW_PREFIX/bin
+	install -m755 bin/fzf-tmux "$pkgdir"$MINGW_PREFIX/bin/fzf-tmux.exe
+	install -Dm755 target/fzf-* "$pkgdir"$MINGW_PREFIX/bin/fzf.exe
+
+	## Completion and keybindings
+	install -dm755 "$pkgdir"$MINGW_PREFIX/share/fzf
+	install -m644 shell/*.bash shell/*.zsh "$pkgdir"$MINGW_PREFIX/share/fzf
+
+	## Fish keybindings
+	install -Dm644 shell/key-bindings.fish "$pkgdir"$MINGW_PREFIX/share/fish/vendor_functions.d/fzf_key_bindings.fish
+
+	## Vim plugin
+	install -Dm644 doc/fzf.txt "$pkgdir"$MINGW_PREFIX/share/vim/vimfiles/doc/fzf.txt
+	install -Dm644 plugin/fzf.vim "$pkgdir"$MINGW_PREFIX/share/vim/vimfiles/plugin/fzf.vim
+}


### PR DESCRIPTION
If `go test` in check(), it will fail. I guess it is because shell is not cmd.

```

?       github.com/junegunn/fzf [no test files]
--- FAIL: TestReplacePlaceholder (0.01s)
    terminal_test.go:29: expected: echo ^"  foo'bar baz^", actual: echo '  foo'\''bar baz'
    terminal_test.go:29: expected: echo ^"  foo'bar baz^", actual: echo '  foo'\''bar baz'
    terminal_test.go:29: expected: echo ^"foo'bar baz^", actual: echo 'foo'\''bar baz'
    terminal_test.go:29: expected: echo ^"foo'bar baz^", actual: echo 'foo'\''bar baz'
    terminal_test.go:29: expected: echo ^"foo'bar baz^", actual: echo 'foo'\''bar baz'
    terminal_test.go:29: expected: echo ^"  foo'bar baz^" ^"query^", actual: echo '  foo'\''bar baz' 'query'
    terminal_test.go:29: expected: echo ^"foo'bar baz^" ^"FOO'BAR BAZ^"^"query 'string'^"^"foo'bar baz^" ^"FOO'BAR BAZ^", actual: echo 'foo'\''bar baz' 'FOO'\''BAR BAZ''query '\''string'\''''foo'\''bar baz' 'FOO'\''BAR BAZ'
    terminal_test.go:29: expected: echo ^"foo'bar baz^"^"query 'string'^"^"foo'bar baz^", actual: echo 'foo'\''bar baz''query '\''string'\''''foo'\''bar baz'
    terminal_test.go:29: expected: echo ^"foo'bar^"/^"baz^"/^"bazfoo'bar^"/^"baz^"/^"foo'bar^"/^"  foo'bar baz^"/^"foo'bar baz^"/{n.t}/{}/{1}/{q}/^"^", actual: echo 'foo'\''bar'/'baz'/'bazfoo'\''bar'/'baz'/'foo'\''bar'/'  foo'\''bar baz'/'foo'\''bar baz'/{n.t}/{}/{1}/{q}/''
    terminal_test.go:29: expected: echo ^"foo'bar^"/^"baz^"/^"baz^"/^"foo'bar^"/^"foo'bar baz^"/{n.t}/{}/{1}/{q}/^"^", actual: echo 'foo'\''bar'/'baz'/'baz'/'foo'\''bar'/'foo'\''bar baz'/{n.t}/{}/{1}/{q}/''
    terminal_test.go:29: expected: echo ^"foo'bar^" ^"FOO'BAR^"/^"baz^" ^"BAZ^"/^"baz^" ^"BAZ^"/^"foo'bar^" ^"FOO'BAR^"/^"foo'bar baz^" ^"FOO'BAR BAZ^"/{n.t}/{}/{1}/{q}/^"^" ^"^", actual: echo 'foo'\''bar' 'FOO'\''BAR'/'baz' 'BAZ'/'baz' 'BAZ'/'foo'\''bar' 'FOO'\''BAR'/'foo'\''bar baz' 'FOO'\''BAR BAZ'/{n.t}/{}/{1}/{q}/'' ''
    terminal_test.go:29: expected: echo ^"foo'bar^" ^"FOO'BAR^"/^"baz^" ^"BAZ^"/^"baz^" ^"BAZ^"/^"foo'bar^" ^"FOO'BAR^"/^"foo'bar baz^" ^"FOO'BAR BAZ^"/{n.t}/{}/{1}/{q}/^"^" ^"^", actual: echo 'foo'\''bar' 'FOO'\''BAR'/'baz' 'BAZ'/'baz' 'BAZ'/'foo'\''bar' 'FOO'\''BAR'/'foo'\''bar baz' 'FOO'\''BAR BAZ'/{n.t}/{}/{1}/{q}/'' ''
    terminal_test.go:29: expected: echo ^"  foo^", actual: echo '  foo'
    terminal_test.go:29: expected: echo ^"bar baz^", actual: echo 'bar baz'
    terminal_test.go:29: expected: echo ^"  foo'bar baz^", actual: echo '  foo'\''bar baz'
    terminal_test.go:29: expected: echo ^"  foo'bar baz^", actual: echo '  foo'\''bar baz'
    terminal_test.go:29: expected: echo ^"  ^", actual: echo '  '
    terminal_test.go:29: expected: echo ^"'^", actual: echo ''\'''
    terminal_test.go:29: expected: echo ^" ^", actual: echo ' '
    terminal_test.go:29: expected: echo /^"  foo'bar baz^", actual: echo /'  foo'\''bar baz'
    terminal_test.go:29: expected: echo ^"  foo'bar baz^"/^"foo^"/^"bar baz^", actual: echo '  foo'\''bar baz'/'foo'/'bar baz'
    terminal_test.go:29: expected: echo ^"  foo'bar baz^"/^"f^"/^"r b^"/^"'bar b^", actual: echo '  foo'\''bar baz'/'f'/'r b'/''\''bar b'
    terminal_test.go:29: expected: ^"1a^", actual: '1a'
    terminal_test.go:29: expected: ^"1a^", actual: '1a'
    terminal_test.go:29: expected: ^"1a^" ^"2a^" ^"3a^" ^"4a^" ^"5a^" ^"6a^" ^"7a^", actual: '1a' '2a' '3a' '4a' '5a' '6a' '7a'
    terminal_test.go:29: expected: ^"1f^" ^"2f^" ^"3f^" ^"4f^" ^"5f^" ^"6f^" ^"7f^", actual: '1f' '2f' '3f' '4f' '5f' '6f' '7f'
    terminal_test.go:29: expected: ^"1a 1b 1c 1d 1e 1f^", actual: '1a 1b 1c 1d 1e 1f'
    terminal_test.go:29: expected: ^"1a 1b^", actual: '1a 1b'
    terminal_test.go:29: expected: ^"sample query^", actual: 'sample query'
    terminal_test.go:29: expected: ^"1e 1f^", actual: '1e 1f'
    terminal_test.go:29: expected: ^"1a 1b 1c 1d^", actual: '1a 1b 1c 1d'
    terminal_test.go:29: expected: ^"1a 1b ^" ^"2a 2b ^" ^"3a 3b ^" ^"4a 4b ^" ^"5a 5b ^" ^"6a 6b ^" ^"7a 7b ^", actual: '1a 1b ' '2a 2b ' '3a 3b ' '4a 4b ' '5a 5b ' '6a 6b ' '7a 7b '
    terminal_test.go:29: expected: ^"1a 1b 1c 1d 1e 1f^", actual: '1a 1b 1c 1d 1e 1f'
    terminal_test.go:29: expected: ^"1a 1b 1c 1d 1e 1f^" ^"2a 2b 2c 2d 2e 2f^" ^"3a 3b 3c 3d 3e 3f^" ^"4a 4b 4c 4d 4e 4f^" ^"5a 5b 5c 5d 5e 5f^" ^"6a 6b 6c 6d 6e 6f^" ^"7a 7b 7c 7d 7e 7f^", actual: '1a 1b 1c 1d 1e 1f' '2a 2b 2c 2d 2e 2f' '3a 3b 3c 3d 3e 3f' '4a 4b 4c 4d 4e 4f' '5a 5b 5c 5d 5e 5f' '6a 6b 6c 6d 6e 6f' '7a 7b 7c 7d 7e 7f'
    terminal_test.go:29: expected: ^"1a 1b 1c 1d 1e 1f^", actual: '1a 1b 1c 1d 1e 1f'
    terminal_test.go:29: expected: ^"1a 1b^", actual: '1a 1b'
    terminal_test.go:29: expected: ^"1a^", actual: '1a'
    terminal_test.go:29: expected: ^"1a 1b^", actual: '1a 1b'
    terminal_test.go:29: expected: ^"1a 1b 1d^", actual: '1a 1b 1d'
    terminal_test.go:29: expected: ^"1a 1b 1c 1d^", actual: '1a 1b 1c 1d'
    terminal_test.go:29: expected: ^"1a ^", actual: '1a '
    terminal_test.go:29: expected: ^"1a 1b 1c 1d 1e 1f^" ^"2a 2b 2c 2d 2e 2f^" ^"3a 3b 3c 3d 3e 3f^" ^"4a 4b 4c 4d 4e 4f^" ^"5a 5b 5c 5d 5e 5f^" ^"6a 6b 6c 6d 6e 6f^" ^"7a 7b 7c 7d 7e 7f^", actual: '1a 1b 1c 1d 1e 1f' '2a 2b 2c 2d 2e 2f' '3a 3b 3c 3d 3e 3f' '4a 4b 4c 4d 4e 4f' '5a 5b 5c 5d 5e 5f' '6a 6b 6c 6d 6e 6f' '7a 7b 7c 7d 7e 7f'
--- FAIL: TestQuoteEntry (0.00s)
    terminal_test.go:266: Input: \, expected: ^"\\^", actual '\'
    terminal_test.go:266: Input: \", expected: ^"\\\^"^", actual '\"'
    terminal_test.go:266: Input: "C:\Program Files", expected: ^"\^"C:\\Program Files\^"^", actual '"C:\Program Files"'
    terminal_test.go:266: Input: <, expected: ^"^<^", actual '<'
    terminal_test.go:266: Input: (, expected: ^"^(^", actual '('
    terminal_test.go:266: Input: ), expected: ^"^)^", actual ')'
    terminal_test.go:266: Input: @, expected: ^"^@^", actual '@'
    terminal_test.go:266: Input: ', expected: ^"'^", actual ''\'''
    terminal_test.go:266: Input: ", expected: ^"\^"^", actual '"'
    terminal_test.go:266: Input: $HOME, expected: ^"$HOME^", actual '$HOME'
    terminal_test.go:266: Input: '$HOME', expected: ^"'$HOME'^", actual ''\''$HOME'\'''
    terminal_test.go:266: Input: !, expected: ^"^!^", actual '!'
    terminal_test.go:266: Input: C:\Program Files (x86)\, expected: ^"C:\\Program Files ^(x86^)\\^", actual 'C:\Program Files (x86)\'
    terminal_test.go:266: Input: "\\\", expected: ^"\^"\\\\\\\^"^", actual '"\\\"'
    terminal_test.go:266: Input: &, expected: ^"^&^", actual '&'
    terminal_test.go:266: Input: |, expected: ^"^|^", actual '|'
    terminal_test.go:266: Input: %USERPROFILE%, expected: ^"^%USERPROFILE^%^", actual '%USERPROFILE%'
    terminal_test.go:266: Input: $, expected: ^"$^", actual '$'
    terminal_test.go:266: Input: >, expected: ^"^>^", actual '>'
    terminal_test.go:266: Input: ^, expected: ^"^^^", actual '^'
    terminal_test.go:266: Input: %, expected: ^"^%^", actual '%'
--- FAIL: TestWindowsCommands (0.00s)
    terminal_test.go:573: tests[0]:
        gave{
                template: 'type {}',
                query: '',
                allItems: [C:\test.txt <nil>]}
        and got 'type 'C:\test.txt'',
        but want 'type ^"C:\\test.txt^"'
    terminal_test.go:573: tests[1]:
        gave{
                template: 'rg -- "package" {}',
                query: '',
                allItems: [.\test.go <nil>]}
        and got 'rg -- "package" '.\test.go'',
        but want 'rg -- "package" ^".\\test.go^"'
    terminal_test.go:573: tests[2]:
        gave{
                template: 'rg -- {}',
                query: '',
                allItems: [C:\test.txt <nil>]}
        and got 'rg -- 'C:\test.txt'',
        but want 'rg -- ^"C:\\test.txt^"'
    terminal_test.go:573: tests[3]:
        gave{
                template: 'rg -- {}',
                query: '',
                allItems: ["C:\test.txt" <nil>]}
        and got 'rg -- '"C:\test.txt"'',
        but want 'rg -- ^"\^"C:\\test.txt\^"^"'
    terminal_test.go:573: tests[4]:
        gave{
                template: 'notepad++ -n{1} {2}',
                query: '',
                allItems: [12   C:\Work\Test Folder\File.txt <nil>]}
        and got 'notepad++ -n'12' 'C:\Work\Test Folder\File.txt'',
        but want 'notepad++ -n^"12^" ^"C:\\Work\\Test Folder\\File.txt^"'
    terminal_test.go:573: tests[5]:
        gave{
                template: 'cat {}',
                query: '',
                allItems: ["C:\test.txt" <nil>]}
        and got 'cat '"C:\test.txt"'',
        but want 'cat ^"\^"C:\\test.txt\^"^"'
    terminal_test.go:573: tests[6]:
        gave{
                template: 'cmd /c {}',
                query: '',
                allItems: [cat "C:\test.txt" <nil>]}
        and got 'cmd /c 'cat "C:\test.txt"'',
        but want 'cmd /c ^"cat \^"C:\\test.txt\^"^"'
    terminal_test.go:582: tests[7]:
        gave{
                template: 'cmd /c {f}',
                query: '',
                allItems: [cat "C:\test.txt" <nil>]}
        and got 'cmd /c C:\Users\wzy\AppData\Local\Temp\fzf-preview-3697810395',
        but want '^cmd /c .*\fzf-preview-[0-9]{9}$'
--- FAIL: TestPowershellCommands (0.00s)
    terminal_test.go:582: tests[7]:
        gave{
                template: 'powershell -NoProfile -Command {f}',
                query: '',
                allItems: [cat "C:\test.txt" <nil>]}
        and got 'powershell -NoProfile -Command C:\Users\wzy\AppData\Local\Temp\fzf-preview-2188450158',
        but want '^powershell -NoProfile -Command .*\fzf-preview-[0-9]{9}$'
FAIL
FAIL    github.com/junegunn/fzf/src     1.038s
```
