### PR TITLE
 ngraph-gtk: new upstream release version 6.09.06.

### DIFF
--- a/mingw-w64-ngraph-gtk/PKGBUILD
+++ b/mingw-w64-ngraph-gtk/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=ngraph-gtk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=6.09.05
-pkgrel=2
+pkgver=6.09.06
+pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 pkgdesc="create scientific 2-dimensional graphs (mingw-w64)"
@@ -23,7 +23,7 @@ options=('strip' 'staticlibs')
 license=("GPL")
 url="https://htrb.github.io/ngraph-gtk/"
 source=("https://github.com/htrb/ngraph-gtk/releases/download/v${pkgver}/ngraph-gtk-${pkgver}.tar.gz")
-sha256sums=("1b3f5579ee01a86bb775e651a5b39b54f7ffba7ed7fb4899dc6c77c47b6514ee")
+sha256sums=("919474efaf7d1f093aa478f22bd2546d7cf02a7bc28d9a88aa5b4047c30901fe")
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}


### PR DESCRIPTION
new upstream version 6.09.05 is  released. 