### PR TITLE
flang: Update to 14.0.3

### DIFF
--- a/mingw-w64-flang/PKGBUILD
+++ b/mingw-w64-flang/PKGBUILD
@@ -2,17 +2,17 @@ _compiler=clang
 _realname=flang
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=14.0.0
+pkgver=14.0.3
 pkgrel=1
 pkgdesc="Fortran frontend for LLVM (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://flang.llvm.org/"
 license=("custom:Apache 2.0 with LLVM Exception")
-depends=("${MINGW_PACKAGE_PREFIX}-clang=${pkgver}"
-         "${MINGW_PACKAGE_PREFIX}-llvm=${pkgver}"
-         "${MINGW_PACKAGE_PREFIX}-mlir=${pkgver}")
-makedepends=("${MINGW_PACKAGE_PREFIX}-clang-tools-extra=${pkgver}"
+depends=("${MINGW_PACKAGE_PREFIX}-clang"
+         "${MINGW_PACKAGE_PREFIX}-llvm"
+         "${MINGW_PACKAGE_PREFIX}-mlir")
+makedepends=("${MINGW_PACKAGE_PREFIX}-clang-tools-extra"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-lld"
              "${MINGW_PACKAGE_PREFIX}-ninja"
@@ -28,7 +28,7 @@ options=('!debug' 'strip')
 source=("https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkgver}/flang-${pkgver}.src.tar.xz"{,.sig}
         "0001-cast-cxx11-narrowing.patch"
         "0002-cmake-22162.patch")
-sha256sums=('631deb2ab6308ccc2617370361d3cce4ef6203915cf3bc386f9a79aea921c5a3'
+sha256sums=('dad71b9095e7a1618f2ce5a78b3bc08e82f0a289d6de4e7686f903401f700648'
             'SKIP'
             'ba08064d737a2aa173125e88c3900dce804220fb0562596b03130177c2139312'
             '77fb0612217b6af7a122f586a9d0d334cd48bb201509bf72e8f8e6244616e895')


### PR DESCRIPTION
It wasn't installable because it hard depends on clang 14.0.0.
Update and remove the overly strict version requirement.