### PR TITLE
wxWidgets3.1: Update to version 3.1.6; and,

### DIFF
--- a/mingw-w64-wxWidgets3.1/001-wxWidgets-3.0.2-relocate-prefix-in-bin-wx-config.patch
+++ b/mingw-w64-wxWidgets3.1/001-wxWidgets-3.0.2-relocate-prefix-in-bin-wx-config.patch
@@ -1,12 +1,10 @@
 --- wxWidgets-3.0.2/wx-config.in.orig	2015-12-12 14:49:36.241974800 +0000
 +++ wxWidgets-3.0.2/wx-config.in	2015-12-12 14:53:06.242503400 +0000
-@@ -401,6 +401,9 @@
+@@ -401,6 +401,7 @@
  
  # Determine the base directories we require.
  prefix=${input_option_prefix-${this_prefix:-@prefix@}}
-+if [ "x${MSYSTEM}" = "xMINGW32" ] || [ "x${MSYSTEM}" = "xMINGW64" ]; then
-+    prefix=$(cygpath -m ${prefix})
-+fi
++prefix=$(cygpath -m ${prefix})
  exec_prefix=${input_option_exec_prefix-${input_option_prefix-${this_exec_prefix:-@exec_prefix@}}}
  wxconfdir="@libdir@/wx/config"
  

--- a/mingw-w64-wxWidgets3.1/010-wxWidgets-3.1.6-Redo-manifest-filename-logic.patch
+++ b/mingw-w64-wxWidgets3.1/010-wxWidgets-3.1.6-Redo-manifest-filename-logic.patch
@@ -1,0 +1,43 @@
+From eeced51b78e1e19772a5876b67841090d3985d43 Mon Sep 17 00:00:00 2001
+From: Tim Stahlhut <stahta01@gmail.com>
+Date: Tue, 17 May 2022 14:44:56 -0400
+Subject: Redo manifest filename logic
+
+---
+ include/wx/msw/wx.rc | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/include/wx/msw/wx.rc b/include/wx/msw/wx.rc
+index 7a6b203f13..a098783908 100644
+--- a/include/wx/msw/wx.rc
++++ b/include/wx/msw/wx.rc
+@@ -106,11 +106,11 @@ wxBITMAP_STD_COLOURS    BITMAP "wx/msw/colours.bmp"
+ #endif
+ 
+ #if !defined(wxUSE_DPI_AWARE_MANIFEST) || wxUSE_DPI_AWARE_MANIFEST == 0
+-    #define wxMANIFEST_DPI .manifest
++    #define wxMANIFEST_DPI wx/msw/wx.manifest
+ #elif wxUSE_DPI_AWARE_MANIFEST == 1
+-    #define wxMANIFEST_DPI _dpi_aware.manifest
++    #define wxMANIFEST_DPI wx/msw/wx_dpi_aware.manifest
+ #elif wxUSE_DPI_AWARE_MANIFEST == 2
+-    #define wxMANIFEST_DPI _dpi_aware_pmv2.manifest
++    #define wxMANIFEST_DPI wx/msw/wx_dpi_aware_pmv2.manifest
+ #endif
+ 
+ #define wxRC_STR(text) wxRC_STR2(text)
+@@ -119,10 +119,11 @@ wxBITMAP_STD_COLOURS    BITMAP "wx/msw/colours.bmp"
+ #define wxRC_CONCAT2(a, b) a ## b
+ 
+ #ifdef __GNUC__
+-    #define wxMANIFEST_FILE "wx/msw/wx" wxRC_STR(wxMANIFEST_DPI)
++    #define wxMANIFEST_FILE wxRC_STR(wxMANIFEST_DPI)
+ #else
+-    #define wxMANIFEST_FILE wxRC_CONCAT(wx/msw/wx, wxMANIFEST_DPI)
++    #define wxMANIFEST_FILE wxMANIFEST_DPI
+ #endif
++
+ wxMANIFEST_ID RT_MANIFEST wxMANIFEST_FILE
+ 
+ #endif // wxUSE_RC_MANIFEST
+-- 

--- a/mingw-w64-wxWidgets3.1/PKGBUILD
+++ b/mingw-w64-wxWidgets3.1/PKGBUILD
@@ -18,8 +18,8 @@ _wx_buildver=
 
 pkgbase=mingw-w64-${_basename}${_wx_basever}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}${_wx_basever}"
-pkgver=${_wx_basever}.5
-pkgrel=6
+pkgver=${_wx_basever}.6
+pkgrel=1
 pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -43,10 +43,14 @@ source=(
 
   # the wxTeam rejected this patch
   005-wxWidgets-3.1.3-Remove-WX_LIBS_STATIC-from-m4.patch
+
+  # This is needed to build clang samples in check step
+  010-wxWidgets-3.1.6-Redo-manifest-filename-logic.patch
 )
-sha256sums=('d7b3666de33aa5c10ea41bb9405c40326e1aeb74ee725bb88f90f1d50270a224'
-            '7c3b8f6ba275a448a5e82d64c4914acd5aefb8bbb952389688f3e7167a787c56'
-            '4a4828f0c9cdc638cffde6a30b5dfb14283719acc9e89e19de8ec2d5a80a5aec')
+sha256sums=('4980e86c6494adcd527a41fc0a4e436777ba41d1893717d7b7176c59c2061c25'
+            '2b3b183a6a76ad539abc49a41033aa923c13b395c0e55189ba962068781c7135'
+            '4a4828f0c9cdc638cffde6a30b5dfb14283719acc9e89e19de8ec2d5a80a5aec'
+            'b30100e03f350e14060923781c3c7979735cc81996a13012bef980a23eb3d20b')
 prepare() {
   cd "${srcdir}"/${_basename}-${pkgver}${_wx_buildver}
 
@@ -56,12 +60,15 @@ prepare() {
   # This patch is not really needed; but, WX_LIBS_STATIC does not work correctly under MSys2
   # Removed it to see if anything breaks or if anything is fixed.
   patch -p1 -i "${srcdir}"/005-wxWidgets-3.1.3-Remove-WX_LIBS_STATIC-from-m4.patch
+
+  patch -p1 -i "${srcdir}"/010-wxWidgets-3.1.6-Redo-manifest-filename-logic.patch
 }
 
 build() {
   ####
   # Configure options added to support other software:
   #   --enable-graphics_ctx     codelite
+  #   --enable-graphics-d2d     codeblocks
   #
   # Configure options added to check for build issues
   #   --disable-precomp-headers
@@ -122,6 +129,7 @@ build() {
     --enable-permissive \
     --enable-unicode \
     --enable-graphics_ctx \
+    --enable-graphics-d2d \
     --enable-accessibility \
     --disable-monolithic \
     --disable-precomp-headers \
@@ -151,6 +159,7 @@ build() {
     --enable-permissive \
     --enable-unicode \
     --enable-graphics_ctx \
+    --enable-graphics-d2d \
     --enable-accessibility \
     --disable-monolithic \
     --disable-precomp-headers \
@@ -165,16 +174,17 @@ build() {
   make #VERBOSE=1 -j1
 }
 
-#check() {
-  #cd "${srcdir}/build-${CARCH}-shared/tests"    && make -k --jobs=1 || true
+check() {
+#  cd "${srcdir}/build-${CARCH}-shared/tests"    && make -k --jobs=1 || true
 
-  #cd "${srcdir}/build-${CARCH}-shared/samples"  && make -k --jobs=1 || true
-#}
+  cd "${srcdir}/build-${CARCH}-shared/samples"  && make -k --jobs=1 || true
+}
 
 package() {
   pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX (mingw-w64)"
   provides=("${MINGW_PACKAGE_PREFIX}-wxWidgets${_wx_basever}")
   conflicts=("${MINGW_PACKAGE_PREFIX}-wxWidgets${_wx_basever}")
+  replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}${_wx_basever}-git")
   depends=(
     "${MINGW_PACKAGE_PREFIX}-gcc-libs"
     "${MINGW_PACKAGE_PREFIX}-expat"


### PR DESCRIPTION
Removed MSYSTEM guard in "wx-config.in",
the other option of adding all the other environments 
like CLANG64 was advised against in the prior PR.
Redo manifest filename logic in "wx/msw/wx.rc".
The prior manifest logic failed to work under Clang64;
When building samples during check.
Add replaces "wxmsw3.1-git" package.
Add "enable-graphics-d2d" to help support Code::Blocks IDE.
Enable check code to build DLL samples.