### PR TITLE
meld: Add upstream patches to fix building and GUI

### DIFF
--- a/mingw-w64-meld3/1001-meld-build-fix-i18n-usage.patch
+++ b/mingw-w64-meld3/1001-meld-build-fix-i18n-usage.patch
@@ -1,0 +1,34 @@
+From cc7746c141d976a4779cf868774fae1fe7627a6d Mon Sep 17 00:00:00 2001
+From: Silvio Fricke <silvio.fricke@gmail.com>
+Date: Thu, 13 Jan 2022 16:06:58 +0100
+Subject: [PATCH] build: fix i18n usage on data/meson.build for meson 0.61.0
+
+With the latest meson the code doesn't compile anymore and reports an
+error:
+
+	meld/data/meson.build:34:0: ERROR: Function does not take positional arguments.
+
+This patch tries to fix that problem.
+
+Close #645
+
+Signed-off-by: Silvio Fricke <silvio.fricke@gmail.com>
+---
+ data/meson.build | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/data/meson.build b/data/meson.build
+index 01949188..de099d3b 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -32,7 +32,6 @@ if desktop_file_validate.found()
+ endif
+ 
+ appdata_file = i18n.merge_file(
+-  'appdata',
+   input: configure_file(
+     input: files('org.gnome.meld.appdata.xml.in.in'),
+     output: 'org.gnome.meld.appdata.xml.in',
+-- 
+GitLab
+

--- a/mingw-w64-meld3/1002-meld-import-emblem-new-from-evolution.patch
+++ b/mingw-w64-meld3/1002-meld-import-emblem-new-from-evolution.patch
@@ -1,0 +1,85 @@
+From f850cdf3eaf0f08abea003d5fae118a5e92a3d61 Mon Sep 17 00:00:00 2001
+From: Jan Tojnar <jtojnar@gmail.com>
+Date: Fri, 29 Apr 2022 23:00:12 +0200
+Subject: [PATCH] Import emblem-new from Evolution
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Emblems are considered deprecated since GNOME 3.32:
+https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/commit/7f3f91f9c210ee240885c7d370c8ff3485c3a17b
+and `emblem-new` has been removed in GNOME 42:
+https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/commit/becf0674bb631bb2f2e092e1fb0f4d55cf380de7
+
+This will cause Meld to complain loudly on vanilla GNOME, even breaking the file tree view:
+
+	Traceback (most recent call last):
+	  File "/nix/store/i9gy3x995nn7js4xipzw01gysq4fh5zz-meld-3.21.1/lib/python3.9/site-packages/meld/ui/emblemcellrenderer.py", line 100, in do_render
+	    pixbuf = self._get_pixbuf(self.emblem_name, self._emblem_size)
+	  File "/nix/store/i9gy3x995nn7js4xipzw01gysq4fh5zz-meld-3.21.1/lib/python3.9/site-packages/meld/ui/emblemcellrenderer.py", line 64, in _get_pixbuf
+	    pixbuf = icon_theme.load_icon(name, size, 0).copy()
+	gi.repository.GLib.GError: gtk-icon-theme-error-quark: Icon 'emblem-new' not present in theme Adwaita (0)
+
+	cairo.Error: Context.restore() without matching Context.save()
+
+`emblem-default-symbolic` and `emblem-symbolic-link` are still available.
+
+Let’s bundle it with Meld as suggested.
+
+Though, for improved contrast on GNOME 42’s blue folder icons,
+let’s take the emblem from Evolution.
+
+https://gitlab.gnome.org/GNOME/evolution/-/issues/1811#note_1423465
+---
+ .../icons/scalable/emblems/emblem-new.svg     | 26 +++++++++++++++++++
+ meld/resources/meld.gresource.xml             |  1 +
+ 2 files changed, 27 insertions(+)
+ create mode 100644 meld/resources/icons/scalable/emblems/emblem-new.svg
+
+diff --git a/meld/resources/icons/scalable/emblems/emblem-new.svg b/meld/resources/icons/scalable/emblems/emblem-new.svg
+new file mode 100644
+index 00000000..b3971210
+--- /dev/null
++++ b/meld/resources/icons/scalable/emblems/emblem-new.svg
+@@ -0,0 +1,26 @@
++<?xml version="1.0" encoding="UTF-8" standalone="no"?>
++<!-- Created with Inkscape (http://www.inkscape.org/) -->
++
++<svg
++   width="16"
++   height="16"
++   viewBox="0 0 4.2333332 4.2333335"
++   version="1.1"
++   id="svg5"
++   xmlns="http://www.w3.org/2000/svg"
++   xmlns:svg="http://www.w3.org/2000/svg">
++  <defs
++     id="defs2" />
++  <circle
++     style="opacity:1;fill:#d7eef4;stroke-width:0.396874;stroke-linecap:round;paint-order:markers stroke fill"
++     id="path1283"
++     cx="2.1166666"
++     cy="2.1166666"
++     r="1.984375" />
++  <circle
++     style="opacity:1;fill:#0044aa;fill-opacity:1;stroke-width:0.357187;stroke-linecap:round;paint-order:markers stroke fill"
++     id="path1285"
++     cx="2.1166666"
++     cy="2.1166666"
++     r="1.4287499" />
++</svg>
+diff --git a/meld/resources/meld.gresource.xml b/meld/resources/meld.gresource.xml
+index 689955e3..34b07e65 100644
+--- a/meld/resources/meld.gresource.xml
++++ b/meld/resources/meld.gresource.xml
+@@ -13,6 +13,7 @@
+     <file>icons/16x16/actions/meld-change-apply-right.png</file>
+     <file>icons/16x16/actions/meld-change-copy.png</file>
+     <file>icons/16x16/actions/meld-change-delete.png</file>
++    <file preprocess="xml-stripblanks">icons/scalable/emblems/emblem-new.svg</file>
+     <file>meld.css</file>
+     <file>ui/about-dialog.ui</file>
+     <file>ui/appwindow.ui</file>
+-- 
+GitLab
+

--- a/mingw-w64-meld3/PKGBUILD
+++ b/mingw-w64-meld3/PKGBUILD
@@ -5,7 +5,7 @@ _realname=meld
 pkgbase=mingw-w64-${_realname}3
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}3"
 pkgver=3.21.0
-pkgrel=7
+pkgrel=8
 pkgdesc="Visual diff and merge tool (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -23,14 +23,20 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-itstool"
              "${MINGW_PACKAGE_PREFIX}-meson")
 source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz
-        '0001-relocate.patch')
+        '0001-relocate.patch'
+        '1001-meld-build-fix-i18n-usage.patch'
+        '1002-meld-import-emblem-new-from-evolution.patch')
 sha256sums=('b680114d5ab793324549fd58f4eb202d8e280c0633a0b765ede6dfb34160a81b'
-            'e39b45a26867c8233cdf4427ae67deb028bcbfb92321976ca0aaf7c1cbd38f45')
+            'e39b45a26867c8233cdf4427ae67deb028bcbfb92321976ca0aaf7c1cbd38f45'
+            '0bca370f540006150ec24826b419560c176024995b4ed459770b9c7507502822'
+            'cb0218256dda15377f4aab976d0b54ca6874de215f1ba28b940150dbf3c5741c')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
   patch -p1 -i "${srcdir}/0001-relocate.patch"
+  patch -p1 -i "${srcdir}/1001-meld-build-fix-i18n-usage.patch"
+  patch -p1 -i "${srcdir}/1002-meld-import-emblem-new-from-evolution.patch"
 }
 
 build() {


### PR DESCRIPTION
After the adwaita-icon-theme 42.0 update, meld couldn't find `${MSYSTEM_PREFIX}/share/icons/Adwaita/8x8/legacy/emblem-new.png`, which messed up the GUI. This has already been fixed [in meld](https://gitlab.gnome.org/GNOME/meld/-/merge_requests/83). The upstream build fix corresponds to https://github.com/mesonbuild/meson/issues/9441. PR tested locally, see screenshots.

![bad](https://user-images.githubusercontent.com/32682705/169401745-5f3f75f1-474e-4ef9-a7fc-0cd81e131648.png)
![good](https://user-images.githubusercontent.com/32682705/169401769-593b99f1-2098-4b91-b819-2d9b8590f7c8.png)

BTW, meson was looking for `desktop-file-validate`; it doesn't seem to use it though, so I didn't bother adding desktop-file-utils to `makedepends`. I'll leave that to the maintainers.