### PR TITLE
gcc: fix exceptions handling for ada with mingw32

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -24,7 +24,7 @@ pkgver=11.3.0
 #_majorver=${pkgver:0:1}
 #_sourcedir=${_realname}-${_majorver}-${_snapshot}
 _sourcedir=${_realname}-${pkgver}
-pkgrel=1
+pkgrel=2
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -169,14 +169,16 @@ build() {
 
   case "${CARCH}" in
     i686)
-      local _conf="--disable-sjlj-exceptions --with-dwarf2"
+      extra_config+=(
+        "--disable-sjlj-exceptions"
+        "--with-dwarf2"
+      )
       LDFLAGS+=" -Wl,--large-address-aware"
       local _arch=i686
     ;;
 
     x86_64)
       local _arch=x86-64
-      local _conf=""
     ;;
   esac
 
@@ -193,6 +195,17 @@ build() {
 
   # so libgomp DLL gets built despide static libdl
   export lt_cv_deplibs_check_method='pass_all'
+
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105507#c3
+  # At least with mingw32 + dwarf-2 exceptions there can only be one libgcc in
+  # process, or exceptions will no longer work. Since some of the gcc deps are
+  # linked dynamically like gmp/zlib/zstd and those pull in libgcc we can't
+  # allow libgcc to be linked statically. The default is "-static-libstdc++
+  # -static-libgcc" for both, so we drop "-static-libgcc" here:
+  extra_config+=(
+    '--with-boot-ldflags="-static-libstdc++"'
+    '--with-stage1-ldflags="-static-libstdc++"'
+  )
 
   ../${_sourcedir}/configure \
     --prefix=${MINGW_PREFIX} \
@@ -215,7 +228,6 @@ build() {
     --enable-libstdcxx-filesystem-ts \
     --enable-libstdcxx-time \
     --disable-libstdcxx-pch \
-    ${extra_config} \
     --enable-lto \
     --enable-libgomp \
     --disable-multilib \
@@ -229,8 +241,9 @@ build() {
     --with-{gmp,mpfr,mpc,isl}=${MINGW_PREFIX} \
     --with-pkgversion="Rev${pkgrel}, Built by MSYS2 project" \
     --with-bugurl="https://github.com/msys2/MINGW-packages/issues" \
-    --with-gnu-as --with-gnu-ld \
-    ${_conf}
+    --with-gnu-as \
+    --with-gnu-ld \
+    "${extra_config[@]}"
 
   # While we're debugging -fopenmp problems at least.
   # .. we may as well not strip anything.


### PR DESCRIPTION
At least with mingw32 + dwarf-2 exceptions there can only be one libgcc in
process, or exceptions will no longer work. Since some of the gcc deps are
linked dynamically like gmp/zlib/zstd and those pull in libgcc we can't
allow libgcc to be linked statically. The default is "-static-libstdc++
-static-libgcc" for both, so we drop "-static-libgcc" here.

See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105507#c3

----

And the reason why this only is a problem for ada is that the other GCC target languages currently don't use exceptions.