### PR TITLE
python-jsonschema: update to 4.5.1

### DIFF
--- a/mingw-w64-python-jsonschema/PKGBUILD
+++ b/mingw-w64-python-jsonschema/PKGBUILD
@@ -6,53 +6,51 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=4.4.0
-pkgrel=3
+pkgver=4.5.1
+pkgrel=1
 pkgdesc="An implementation of JSON Schema validation for Python (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
-url="https://pypi.python.org/pypi/jsonschema"
+url="https://github.com/python-jsonschema/jsonschema"
 license=('MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-python"
-         "${MINGW_PACKAGE_PREFIX}-python-setuptools"
          "${MINGW_PACKAGE_PREFIX}-python-attrs"
+         "${MINGW_PACKAGE_PREFIX}-python-importlib-metadata"
          "${MINGW_PACKAGE_PREFIX}-python-pyrsistent"
-         "${MINGW_PACKAGE_PREFIX}-python-six"
-         "${MINGW_PACKAGE_PREFIX}-python-importlib-metadata")
+         "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm"
              "${MINGW_PACKAGE_PREFIX}-python-wheel")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
 options=('!strip')
-source=("${_realname}-${pkgver}.tar.gz::https://github.com/Julian/jsonschema/archive/v${pkgver}.tar.gz")
-sha256sums=('b32c22ba26c67227699085c933d53a3c868937e6f5baa642f886d0d6b1f3aaf3')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('7c6d882619340c3347a1bf7315e147e6d3dae439033ae6383d6acb908c101dfc')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} || true
-  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
+  cd "${srcdir}/${_realname}-${pkgver}"
 
   # Set version for setuptools_scm
   export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}
 }
 
 build() {
-  msg "Python build for ${MSYSTEM}"
-  cd "${srcdir}/python-build-${MSYSTEM}"
+  cd "${srcdir}"
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
 
   ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 check() {
-  msg "Python test for ${MSYSTEM}"
   cd "${srcdir}/python-build-${MSYSTEM}"
+
   ${MINGW_PREFIX}/bin/python -m pytest
 }
 
 package() {
   cd "${srcdir}/python-build-${MSYSTEM}"
 
-  MSYS2_ARG_CONV_EXCL="--prefix=" \
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
     ${MINGW_PREFIX}/bin/python -m installer --no-compile-bytecode --prefix=${MINGW_PREFIX} \
     --destdir="${pkgdir}" dist/*.whl
 


### PR DESCRIPTION
Also:
 - Aligned closer to template
 - Removed python-six dependency (https://github.com/python-jsonschema/jsonschema/commit/027feac3cd6d2970ec56d08c566cef66731b637e)

Only one test failing, not sure if it matters:
```
>       self.assertIn(f"{os.sep}someNonexistentFile.json'", error)
E       AssertionError: "/someNonexistentFile.json'" not found in "<urlopen error [WinError 2] The system cannot find the file specified: 'D:\\\\Git\\\\mingw-packages\\\\mingw-w64-python-jsonschema\\\\src\\\\someNonexistentFile.json'>"
```