### PR TITLE
cmake: Remove hardcoded gcc/g++ from MinGW/MSYS Makefiles

### DIFF
--- a/mingw-w64-cmake/0007-No-hardcoded-gcc-with-MINGW-or-MSYS-Makefiles.patch
+++ b/mingw-w64-cmake/0007-No-hardcoded-gcc-with-MINGW-or-MSYS-Makefiles.patch
@@ -1,0 +1,53 @@
+--- a/Source/cmGlobalMinGWMakefileGenerator.cxx
++++ b/Source/cmGlobalMinGWMakefileGenerator.cxx
+@@ -29,23 +29,11 @@
+   locations.push_back(cmSystemTools::GetProgramPath(makeProgram));
+   locations.push_back("/mingw/bin");
+   locations.push_back("c:/mingw/bin");
+-  std::string tgcc = cmSystemTools::FindProgram("gcc", locations);
+-  std::string gcc = "gcc.exe";
+-  if (!tgcc.empty()) {
+-    gcc = tgcc;
+-  }
+-  std::string tgxx = cmSystemTools::FindProgram("g++", locations);
+-  std::string gxx = "g++.exe";
+-  if (!tgxx.empty()) {
+-    gxx = tgxx;
+-  }
+   std::string trc = cmSystemTools::FindProgram("windres", locations);
+   std::string rc = "windres.exe";
+   if (!trc.empty()) {
+     rc = trc;
+   }
+-  mf->AddDefinition("CMAKE_GENERATOR_CC", gcc);
+-  mf->AddDefinition("CMAKE_GENERATOR_CXX", gxx);
+   mf->AddDefinition("CMAKE_GENERATOR_RC", rc);
+   this->cmGlobalUnixMakefileGenerator3::EnableLanguage(l, mf, optional);
+ }
+--- a/Source/cmGlobalMSYSMakefileGenerator.cxx
++++ b/Source/cmGlobalMSYSMakefileGenerator.cxx
+@@ -51,24 +51,12 @@
+   locations.push_back(makeloc);
+   locations.push_back("/mingw/bin");
+   locations.push_back("c:/mingw/bin");
+-  std::string tgcc = cmSystemTools::FindProgram("gcc", locations);
+-  std::string gcc = "gcc.exe";
+-  if (!tgcc.empty()) {
+-    gcc = tgcc;
+-  }
+-  std::string tgxx = cmSystemTools::FindProgram("g++", locations);
+-  std::string gxx = "g++.exe";
+-  if (!tgxx.empty()) {
+-    gxx = tgxx;
+-  }
+   std::string trc = cmSystemTools::FindProgram("windres", locations);
+   std::string rc = "windres.exe";
+   if (!trc.empty()) {
+     rc = trc;
+   }
+   mf->AddDefinition("MSYS", "1");
+-  mf->AddDefinition("CMAKE_GENERATOR_CC", gcc);
+-  mf->AddDefinition("CMAKE_GENERATOR_CXX", gxx);
+   mf->AddDefinition("CMAKE_GENERATOR_RC", rc);
+   this->cmGlobalUnixMakefileGenerator3::EnableLanguage(l, mf, optional);
+ 

--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -6,8 +6,8 @@ _bootstrap=0
 _realname=cmake
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.23.1
-pkgrel=3
+pkgver=3.23.2
+pkgrel=1
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -50,7 +50,7 @@ source=("https://github.com/Kitware/CMake/releases/download/v${pkgver}/${_realna
         "0006-fix-find-glut.patch"
         "https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7162.patch"
         "0007-No-hardcoded-gcc-with-MINGW-or-MSYS-Makefiles.patch")
-sha256sums=('33fd10a8ec687a4d0d5b42473f10459bb92b3ae7def2b745dc10b192760869f3'
+sha256sums=('f316b40053466f9a416adf981efda41b160ca859e97f6a484b447ea299ff26aa'
             '25793edcbac05bb6d17fa9947b52ace4a6b5ccccf7758e22ae9ae022ed089061'
             'f6cf6a6f2729db2b9427679acd09520af2cd79fc26900b19a49cead05a55cd1a'
             '15fdf3fb1a0f1c153c8cfbdd2b5c64035b7a04de618bfe61d7d74ced0d6a5c4b'

--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -7,7 +7,7 @@ _realname=cmake
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.23.1
-pkgrel=2
+pkgrel=3
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -48,7 +48,8 @@ source=("https://github.com/Kitware/CMake/releases/download/v${pkgver}/${_realna
         "0005-Default-to-ninja-generator.patch"
         "https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7105.patch"
         "0006-fix-find-glut.patch"
-        "https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7162.patch")
+        "https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7162.patch"
+        "0007-No-hardcoded-gcc-with-MINGW-or-MSYS-Makefiles.patch")
 sha256sums=('33fd10a8ec687a4d0d5b42473f10459bb92b3ae7def2b745dc10b192760869f3'
             '25793edcbac05bb6d17fa9947b52ace4a6b5ccccf7758e22ae9ae022ed089061'
             'f6cf6a6f2729db2b9427679acd09520af2cd79fc26900b19a49cead05a55cd1a'
@@ -56,7 +57,8 @@ sha256sums=('33fd10a8ec687a4d0d5b42473f10459bb92b3ae7def2b745dc10b192760869f3'
             '426818278090704d2a12f62ef3dfd94c47b11fa2784bb842989b7f6a09ee7aa2'
             '5b96f14a455b46f08aea1631407528ad5238150cc4087beecad40f3afca10214'
             '04d526b1ec86de7e633d0a802cef8452e33bc18c8425aa2065dc901a7c868026'
-            'bfff814b848c51e9733af7c435a51a9ff2ccfdf862b5a70113dc0a71c0360b13')
+            'bfff814b848c51e9733af7c435a51a9ff2ccfdf862b5a70113dc0a71c0360b13'
+            '62074a0de9ac9a9224ffda01992aaa34e5f7fa2e2c6b1cb327ebe9b452452364')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -93,6 +95,9 @@ prepare() {
   # We want cmake to default to something useful and not MSVC
   apply_patch_with_msg \
     0005-Default-to-ninja-generator.patch
+  # Remove hardcoded gcc/g++ for MSYS/MinGW Makefiles generators
+  apply_patch_with_msg \
+    0007-No-hardcoded-gcc-with-MINGW-or-MSYS-Makefiles.patch
 }
 
 build() {


### PR DESCRIPTION
Fixes #11710 