### PR TITLE
mingw-w64-tools: set --with-widl-includedir to the default include dir

### DIFF
--- a/mingw-w64-tools-git/PKGBUILD
+++ b/mingw-w64-tools-git/PKGBUILD
@@ -7,7 +7,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=10.0.0.r32.g89bacd2be
-pkgrel=1
+pkgrel=2
 _commit='89bacd2be60fa92dd74d3b5f2074b06a32d8c784'
 pkgdesc="MinGW-w64 tools"
 arch=('any')
@@ -42,7 +42,8 @@ build() {
       --prefix=${MINGW_PREFIX} \
       --build=${MINGW_CHOST} \
       --host=${MINGW_CHOST} \
-      --with-mangle=${MINGW_PREFIX}
+      --with-mangle=${MINGW_PREFIX} \
+      --with-widl-includedir=${MINGW_PREFIX}/include
     make
   done
 }


### PR DESCRIPTION
It defaults to /ucrt64/x86_64-w64-mingw32/include otherwise, which no
longer exists.

See #11547