### PR TITLE
gcc: fix libgomp crashing in various places

### DIFF
--- a/mingw-w64-gcc/1001-libgomp-use-_aligned_free-in-gomp_aligned_free-if-ne.patch
+++ b/mingw-w64-gcc/1001-libgomp-use-_aligned_free-in-gomp_aligned_free-if-ne.patch
@@ -1,0 +1,36 @@
+From 2f8227361a671f41b21fdd70ee40866c5f32ee86 Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Fri, 27 May 2022 10:42:08 +0200
+Subject: [PATCH 1/2] libgomp: use _aligned_free in gomp_aligned_free()if
+ needed
+
+gomp_aligned_alloc() currently uses the Windows aligned allocation API
+_aligned_malloc() when available, but unlike other APIs on other platform
+this one allocates memory that can't be freed with free(), but requires
+the special _aligned_free() or things can crash.
+
+Fix by using _aligned_free() in gomp_aligned_free() if gomp_aligned_alloc()
+uses _aligned_malloc().
+---
+ libgomp/alloc.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/libgomp/alloc.c b/libgomp/alloc.c
+index a2a25befdf3..67569192130 100644
+--- a/libgomp/alloc.c
++++ b/libgomp/alloc.c
+@@ -105,7 +105,11 @@ void
+ gomp_aligned_free (void *ptr)
+ {
+ #ifdef GOMP_HAVE_EFFICIENT_ALIGNED_ALLOC
++#ifdef HAVE__ALIGNED_MALLOC
++  _aligned_free (ptr);
++#else
+   free (ptr);
++#endif
+ #else
+   if (ptr)
+     free (((void **) ptr)[-1]);
+-- 
+2.36.1
+

--- a/mingw-w64-gcc/1002-libgomp-don-t-use-GOMP_USE_ALIGNED_WORK_SHARES-on-Wi.patch
+++ b/mingw-w64-gcc/1002-libgomp-don-t-use-GOMP_USE_ALIGNED_WORK_SHARES-on-Wi.patch
@@ -1,0 +1,37 @@
+From 8aa5b026a777cf038fe3f14b9e23b9b638c2f7ae Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Fri, 27 May 2022 10:45:34 +0200
+Subject: [PATCH 2/2] libgomp: don't use GOMP_USE_ALIGNED_WORK_SHARES on
+ Windows
+
+In case GOMP_USE_ALIGNED_WORK_SHARES is defined, various places
+use gomp_aligned_alloc() instead of normal allocations, but then don't
+use gomp_aligned_free() in the end, but normal free.
+
+On most platforms this doesn't make a difference, but on Windows
+gomp_aligned_alloc() and free() can't be mixed and free() might crash.
+
+Work around this for now by disabling GOMP_USE_ALIGNED_WORK_SHARES
+in those cases and add a note on what needs to be done to fix it.
+---
+ libgomp/libgomp.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/libgomp/libgomp.h b/libgomp/libgomp.h
+index b9e03919993..7b33465754c 100644
+--- a/libgomp/libgomp.h
++++ b/libgomp/libgomp.h
+@@ -95,7 +95,9 @@ enum memmodel
+ #define GOMP_HAVE_EFFICIENT_ALIGNED_ALLOC 1
+ #endif
+ 
+-#if defined(GOMP_HAVE_EFFICIENT_ALIGNED_ALLOC) && !defined(__AMDGCN__)
++/* FIXME: Disabled for HAVE__ALIGNED_MALLOC because that needs matching gomp_aligned_free() calls
++   for every gomp_aligned_alloc() and that's still missing in various places */
++#if defined(GOMP_HAVE_EFFICIENT_ALIGNED_ALLOC) && !defined(__AMDGCN__) && !defined(HAVE__ALIGNED_MALLOC)
+ #define GOMP_USE_ALIGNED_WORK_SHARES 1
+ #endif
+ 
+-- 
+2.36.1
+

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -24,7 +24,7 @@ pkgver=12.1.0
 #_majorver=${pkgver:0:1}
 #_sourcedir=${_realname}-${_majorver}-${_snapshot}
 _sourcedir=${_realname}-${pkgver}
-pkgrel=1
+pkgrel=2
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -66,7 +66,9 @@ source=("https://ftp.gnu.org/gnu/gcc/${_realname}-${pkgver%%+*}/${_realname}-${p
         0021-PR14940-Allow-a-PCH-to-be-mapped-to-a-different-addr.patch
         0140-gcc-8.2.0-diagnostic-color.patch
         0200-add-m-no-align-vector-insn-option-for-i386.patch
-        0300-override-builtin-printf-format.patch)
+        0300-override-builtin-printf-format.patch
+        1001-libgomp-use-_aligned_free-in-gomp_aligned_free-if-ne.patch
+        1002-libgomp-don-t-use-GOMP_USE_ALIGNED_WORK_SHARES-on-Wi.patch)
 sha256sums=('62fd634889f31c02b64af2c468f064b47ad1ca78411c45abe6ac4b5f8dd19c7b'
             'SKIP'
             'dde2624440918a47646feb9dc60baf9fc259a420c65ee0a1a2a8cd2dd585bb6e'
@@ -86,7 +88,9 @@ sha256sums=('62fd634889f31c02b64af2c468f064b47ad1ca78411c45abe6ac4b5f8dd19c7b'
             'a4b4f7e97635ddf0443ee17cd093b9d10953f97eb290466999585d02ef8bf72d'
             '9faee4294ca31e272c597e8d0f224f5c24700aa99474c9f0549800ae91e9ced1'
             'ce832a1be7271a2249e4dd46647474b37cf51f578678d9bd9433b32aacefb528'
-            '0d82cf1d748c9f1d4d3c7ee43ca3be1b6efbd431dc13ce652ae00ee489d67eec')
+            '0d82cf1d748c9f1d4d3c7ee43ca3be1b6efbd431dc13ce652ae00ee489d67eec'
+            'cc36ba5232ac15520dd20a466faec00098d558a1d4b5057f36ee957c69508223'
+            '5ea3dcd6a0050607ebea7efb2e42b06995b85e7ad33777ecf359940bd0beda36')
 validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.org
               86CFFCA918CF3AF47147588051E8B148A9999C34  # evangelos@foutrelis.com
               13975A70E63C361C73AE69EF6EEB81F8981C74C7  # richard.guenther@gmail.com
@@ -154,6 +158,11 @@ prepare() {
   # Related bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95130
   apply_patch_with_msg \
     0300-override-builtin-printf-format.patch
+
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105745
+  apply_patch_with_msg \
+    1001-libgomp-use-_aligned_free-in-gomp_aligned_free-if-ne.patch \
+    1002-libgomp-don-t-use-GOMP_USE_ALIGNED_WORK_SHARES-on-Wi.patch
 
   # do not expect ${prefix}/mingw symlink - this should be superceded by
   # 0005-Windows-Don-t-ignore-native-system-header-dir.patch .. but isn't!


### PR DESCRIPTION
It has started to mix _aligned_malloc() with normal free() which
isn't supported on Windows and crashes.

This adds some temporary fixes. Upstream might fix this differently though,
we'll see.

Fixes #11729