### PR TITLE
petsc and slepc: update to 3.17.1

### DIFF
--- a/mingw-w64-petsc/0002-openblas-clang.patch
+++ b/mingw-w64-petsc/0002-openblas-clang.patch
@@ -1,0 +1,11 @@
+--- petsc-3.17.0/config/BuildSystem/config/packages/openblas.py.orig	2022-03-31 06:40:23.000000000 +0200
++++ petsc-3.17.0/config/BuildSystem/config/packages/openblas.py	2022-05-30 09:24:12.674202500 +0200
+@@ -19,7 +19,7 @@
+     self.functions              = ['openblas_get_config']
+     self.liblist                = [['libopenblas.a']]
+     self.precisions             = ['single','double']
+-    self.buildLanguages         = ['C','FC']
++    self.buildLanguages         = ['C']
+     self.installwithbatch       = 1
+     self.usespthreads           = 0
+ 

--- a/mingw-w64-petsc/PKGBUILD
+++ b/mingw-w64-petsc/PKGBUILD
@@ -32,45 +32,61 @@
 _realname=petsc
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-${_realname}-build")
-pkgver=3.17.0
+pkgver=3.17.1
 pkgrel=1
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 pkgdesc='Sparse iterative (non)linear solver package (mingw-w64)'
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          $([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] && \
-           echo "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran" "${MINGW_PACKAGE_PREFIX}-openblas" || \
-           echo "${MINGW_PACKAGE_PREFIX}-openmp" "${MINGW_PACKAGE_PREFIX}-f2cblaslapack")
-         "${MINGW_PACKAGE_PREFIX}-parmetis"
-         "${MINGW_PACKAGE_PREFIX}-metis"
+           echo "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran" || \
+           echo "${MINGW_PACKAGE_PREFIX}-openmp")
          "${MINGW_PACKAGE_PREFIX}-hwloc"
-         "${MINGW_PACKAGE_PREFIX}-msmpi")
+         "${MINGW_PACKAGE_PREFIX}-metis"
+         "${MINGW_PACKAGE_PREFIX}-msmpi"
+         "${MINGW_PACKAGE_PREFIX}-openblas"
+         "${MINGW_PACKAGE_PREFIX}-parmetis")
 makedepends=('python'
              "${MINGW_PACKAGE_PREFIX}-cc"
              $([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] && echo "${MINGW_PACKAGE_PREFIX}-gcc-fortran"))
 optdepends=("${MINGW_PACKAGE_PREFIX}-tcl: build & run test suite")
 options=('strip' 'staticlibs')
-license=('2-clause BSD')
+license=('spdx:BSD-2-Clause')
 url="https://www.mcs.anl.gov/petsc/"
 source=("https://ftp.mcs.anl.gov/pub/petsc/release-snapshots/${_realname}-lite-${pkgver}.tar.gz"
         'all.tcl'
         'tclbuildtest.tcl'
         'petsc.test'
         'petsc-mat.test'
-        '0001-mpi-detection-override.patch')
+        '0001-mpi-detection-override.patch'
+        '0002-openblas-clang.patch')
 noextract=("${_realname}-lite-${pkgver}.tar.gz")
-sha256sums=('96d5aca684e1ce1425891a620d278773c25611cb144165a93b17531238eaaf8a'
+sha256sums=('c504609d9f532327c20b6363d6a6c7647ebd3c98acfb382c28fcd3852300ddd1'
             'ec5072630e1c0309fe383669e9187790cd135a393c67bc4bc35cf60b0ba396ff'
             '15c7af25b91406d5fe5f26cfe00963b6cfde1c3dd466eb25f1b6fae299934966'
             '9662cc4104726c714f7961aba6f8c93bfb85f3d3f89b4908b0a55aedab41ca31'
             'fc95ca4ddc138d288f047835a68a84a11cb841c6cca146c6ef7d7e63e0836b1a'
-            'bef5353d6d10de492c9832f24b41993c38d1b36a78eb55e7d49089ba72acc05a')
+            'bef5353d6d10de492c9832f24b41993c38d1b36a78eb55e7d49089ba72acc05a'
+            '6f3b455b79b6d22ebf4189594bc9e17ccfbe4ffdd15843a9aa0698efa4a30cc2')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _fname in "$@"
+  do
+    msg2 "Applying ${_fname}"
+    patch -Nbp1 -i "${srcdir}"/${_fname}
+  done
+}
 
 prepare() {
-  mkdir -p $srcdir/build-${MSYSTEM} && cd $srcdir/build-${MSYSTEM}
+  [[ -d "${srcdir}"/build-${MSYSTEM} ]] && rm -rf "${srcdir}"/build-${MSYSTEM}
+  mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
   tar xzf $srcdir/${_realname}-lite-${pkgver}.tar.gz
+
   cd ${_realname}-${pkgver}
-  patch -p1 -i "$srcdir/0001-mpi-detection-override.patch"
+  apply_patch_with_msg \
+    0001-mpi-detection-override.patch \
+    0002-openblas-clang.patch
 }
 
 # Optimized build flavors
@@ -83,18 +99,15 @@ fi
 # builds="$builds dsg dtg dmg zsg ztg zmg ssg stg smg csg ctg cmg"
 
 _petsc() {
-  opts="--with-single-library=1 --disable-shared --with-windows-graphics=0 --with-x=0 --with-hwloc=1"
-  pc="hwloc"
+  opts="--with-single-library=1 --disable-shared --with-windows-graphics=0 --with-x=0 --with-hwloc=1 --with-openblas=1 --with-openblas-dir=$MINGW_PREFIX"
+  pc="hwloc openblas"
   cflags="$CFLAGS"
   cxxflags="$CXXFLAGS"
   fflags="$CFLAGS"
   if [[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]]; then
-    opts+=" --with-openblas=1 --with-openblas-dir=$MINGW_PREFIX"
     ldflags="-lgfortran -lquadmath"
-    pc+=" openblas"
   else
-    opts+=" --with-fc=0 --with-blas-lib=libblas.a --with-lapack-lib=liblapack.a"
-    ldflags="-lblas -llapack"
+    opts+=" --with-fc=0"
   fi
   ld=${CXX}
   iflags=

--- a/mingw-w64-slepc/PKGBUILD
+++ b/mingw-w64-slepc/PKGBUILD
@@ -27,11 +27,11 @@
 _realname=slepc
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=3.16.2
-petsc_pkgver=3.16
+pkgver=3.17.1
+petsc_pkgver=3.17.1
 pkgrel=1
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 pkgdesc="Scalable library for eigenvalue problem computations (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-petsc>=${petsc_pkgver}")
 makedepends=("python"
@@ -40,14 +40,14 @@ makedepends=("python"
              "${MINGW_PACKAGE_PREFIX}-petsc-build>=${petsc_pkgver}")
 optdepends=("${MINGW_PACKAGE_PREFIX}-tcl: build & run test suite")
 options=('strip' 'staticlibs')
-license=('2-clause BSD')
+license=('spdx:BSD-2-Clause')
 url="https://slepc.upv.es/"
 source=("https://slepc.upv.es/download/distrib/${_realname}-${pkgver}.tar.gz"
         'all.tcl'
         'tclbuildtest.tcl'
         'slepc.test')
 noextract=("${_realname}-${pkgver}.tar.gz")
-sha256sums=('3ba58f5005513ae0ab9f3b27579c82d245a82687886eaaa67cad4cd6ba2ca3a1'
+sha256sums=('11386cd3f4c0f9727af3c1c59141cc4bf5f83bdf7c50251de0845e406816f575'
             'ec5072630e1c0309fe383669e9187790cd135a393c67bc4bc35cf60b0ba396ff'
             '15c7af25b91406d5fe5f26cfe00963b6cfde1c3dd466eb25f1b6fae299934966'
             '47237bd53f15e9d204b7c871ef887d9b6d11e0add1409a6eeb1a122f4b302265')
@@ -66,13 +66,16 @@ build() {
     export PETSC_DIR=${MINGW_PREFIX}/src/petsc-${petsc_pkgver}
     /usr/bin/python configure 
     make
-  	(
-  		cd ${build}/lib
-  	  case ${build} in
-    		*o) strip -S *.a ;;
-  	  esac
-  		${CC} -shared -Wl,--enable-auto-import -Wl,--export-all-symbols -o lib${_realname}-${build}.dll -Wl,--out-implib,lib${_realname}.dll.a -Wl,--whole-archive lib${_realname}.a -Wl,--no-whole-archive $(pkg-config msmpi petsc-${build} --libs) $([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] && pkg-config openblas --libs || echo -llapack -lblas)
-  	)
+    (
+      cd ${build}/lib
+      case ${build} in
+        *o) strip -S *.a ;;
+      esac
+      ${CC} -shared -Wl,--enable-auto-import -Wl,--export-all-symbols \
+        -o lib${_realname}-${build}.dll -Wl,--out-implib,lib${_realname}.dll.a \
+        -Wl,--whole-archive lib${_realname}.a -Wl,--no-whole-archive \
+        $(pkg-config msmpi petsc-${build} --libs) $(pkg-config openblas --libs)
+    )
   done
 }
 
@@ -96,20 +99,20 @@ package() {
     cp ex1.c ex1f.F ${pkgdir}${MINGW_PREFIX}/share/test/${_realname}
   )
   for build in ${petsc_builds}; do
-  	(
-  		cd ${build}/lib
-  		mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/${_realname}/${build}
-  		cp *.a ${pkgdir}${MINGW_PREFIX}/lib/${_realname}/${build}
-  		cp *.dll ${pkgdir}${MINGW_PREFIX}/bin
-  	)
-  	(
-  		cd ${build}/include
-  		mkdir -p ${pkgdir}${MINGW_PREFIX}/include/${_realname}/${build}
-                cp *.h ${pkgdir}${MINGW_PREFIX}/include/${_realname}/${build}
-                if [[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]]; then
-  		  cp *.mod ${pkgdir}${MINGW_PREFIX}/include/${_realname}/${build}
-                fi
-  	)
+    (
+      cd ${build}/lib
+      mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/${_realname}/${build}
+      cp *.a ${pkgdir}${MINGW_PREFIX}/lib/${_realname}/${build}
+      cp *.dll ${pkgdir}${MINGW_PREFIX}/bin
+    )
+    (
+      cd ${build}/include
+      mkdir -p ${pkgdir}${MINGW_PREFIX}/include/${_realname}/${build}
+      cp *.h ${pkgdir}${MINGW_PREFIX}/include/${_realname}/${build}
+      if [[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]]; then
+        cp *.mod ${pkgdir}${MINGW_PREFIX}/include/${_realname}/${build}
+      fi
+    )
     case ${build} in
       ?m?) desc="MPI parallel";;
       ?t?) desc="OpenMP multithreaded";;


### PR DESCRIPTION
Also, build with OpenBLAS in clang* environments.