### PR TITLE
binutils: Move include and libs back to native directories

### DIFF
--- a/mingw-w64-binutils/PKGBUILD
+++ b/mingw-w64-binutils/PKGBUILD
@@ -6,7 +6,7 @@ _realname=binutils
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.38
-pkgrel=2
+pkgrel=3
 pkgdesc="A set of programs to assemble and manipulate binary and object files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -123,11 +123,6 @@ check() {
 package() {
   cd ${srcdir}/build-${MSYSTEM}
   make DESTDIR=${pkgdir} install
-
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/{lib,include}/${_realname}
-  mv ${pkgdir}${MINGW_PREFIX}/include/*.h ${pkgdir}${MINGW_PREFIX}/include/${_realname}
-  cp ${pkgdir}${MINGW_PREFIX}/include/${_realname}/ansidecl.h ${pkgdir}${MINGW_PREFIX}/include/
-  mv ${pkgdir}${MINGW_PREFIX}/lib/*.a ${pkgdir}${MINGW_PREFIX}/lib/${_realname}
 
   # https://github.com/msys2/MINGW-packages/issues/7890
   rm "${pkgdir}${MINGW_PREFIX}/lib/bfd-plugins/libdep.a"


### PR DESCRIPTION
They were moved to a subdirectory in 047d1d662f (binutils: resolve
conflicts with headers and libs with gdb, Dec 2013). Since then, gdb and
binutils repositories were merged, and gdb does not install these headers
and libs at all, so there is no conflict.

Linux systems have bfd.h, libbfd.a and libiberty.a in include and lib, and
not in a subdirectory.

Also, placing them in a subdirectory requires the users to specify the lib
directory, and have non-portable #include statements (binutils/bfd.h on
MinGW, else bfd.h).

Keep the original locations as symbolic links to maintain backwards
compatibility.