### PR TITLE
kicad: re-enable building support libraries

### DIFF
--- a/mingw-w64-kicad/PKGBUILD
+++ b/mingw-w64-kicad/PKGBUILD
@@ -5,7 +5,7 @@
 # This results in only the core KiCAD package being built and reduces
 # the build time and band width usage because the support libraries
 # do not change very often and are very large.
-_build_support_libraries=no
+_build_support_libraries=yes
 # meta wants to download the other packages which waste time during
 # development; but, needs to be yes after development is over.
 _build_meta=yes
@@ -22,12 +22,12 @@ pkgname=(
   $([[ "$_build_support_libraries" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-packages3D")
 )
 pkgver=5.1.12
-pkgrel=2
+pkgrel=3
 pkgdesc="Software for the creation of electronic schematic diagrams and printed circuit board artwork (mingw-w64)"
 arch=(any)
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://www.kicad.org/"
-license=("GPLv3+")
+license=("spdx:AGPL-3.0-or-later")
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
 depends=(
   "${MINGW_PACKAGE_PREFIX}-boost"
@@ -133,7 +133,7 @@ build() {
     -DPYTHON_ROOT_DIR=${MINGW_PREFIX} \
     ../${_realname}-${pkgver}
 
-  mingw32-make VERBOSE=1
+  mingw32-make
 
   cd "${srcdir}"
   msg2 "Build translations"
@@ -177,6 +177,8 @@ eval "package_${MINGW_PACKAGE_PREFIX}-${_realname}() {
 
   cd \${srcdir}/build-i18n
   mingw32-make DESTDIR=\${pkgdir} install
+
+  install -Dm644 \"\${srcdir}/${_realname}-${pkgver}/LICENSE.AGPLv3\" \"\${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE\"
 }"
 
 eval "package_${MINGW_PACKAGE_PREFIX}-${_realname}-meta() {


### PR DESCRIPTION
Also, build in clang32 environment.

See: #11699