### PR TITLE
kicad: separate build rules for core application and support libraries

### DIFF
--- a/mingw-w64-kicad-library/PKGBUILD
+++ b/mingw-w64-kicad-library/PKGBUILD
@@ -1,0 +1,115 @@
+# Support libraries for KiCad
+
+_realname=kicad
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-footprints"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-symbols"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-templates"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-packages3D"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-meta")
+pkgver=5.1.12
+pkgrel=1
+pkgdesc="Support libraries for KiCad (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+url='https://www.kicad.org/'
+license=("spdx:AGPL-3.0-or-later")
+groups=("${MINGW_PACKAGE_PREFIX}-eda")
+depends=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
+options=('!strip')
+source=("${_realname}-footprints-${pkgver}.tar.gz"::"https://gitlab.com/kicad/libraries/kicad-footprints/-/archive/${pkgver}/kicad-footprints-${pkgver}.tar.gz"
+        "${_realname}-symbols-${pkgver}.tar.gz"::"https://gitlab.com/kicad/libraries/kicad-symbols/-/archive/${pkgver}/kicad-symbols-${pkgver}.tar.gz"
+        "${_realname}-templates-${pkgver}.tar.gz"::"https://gitlab.com/kicad/libraries/kicad-templates/-/archive/${pkgver}/kicad-templates-${pkgver}.tar.gz"
+        "${_realname}-packages3D-${pkgver}.tar.gz"::"https://gitlab.com/kicad/libraries/kicad-packages3D/-/archive/${pkgver}/kicad-packages3D-${pkgver}.tar.gz")
+sha256sums=('d16742054ee5eacb7db916280960be7a5218d11b0b2201fa6cb6d61ee34652ec'
+            'f641e121a53cc2b7d2fe25fea88a4b1f14701a068c7243fdc0efa129497b332f'
+            '7b07b82b424875bfde34c6529b8524446bc8c4d608f48739380179520496596f'
+            '2752bb2cced9686e6edf043c6829db53ff4ae4c0e52d8318602da9cde82d0652')
+
+build() {
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  for _s in "footprints" "symbols" "templates" "packages3D"; do
+    msg2 "Build kicad-${_s}"
+    [[ -d "${srcdir}"/build-${_s}-${MSYSTEM} ]] && rm -rf "${srcdir}"/build-${_s}-${MSYSTEM}
+    mkdir -p "${srcdir}/build-${_s}-${MSYSTEM}" && cd "${srcdir}/build-${_s}-${MSYSTEM}"
+
+    MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+      "${MINGW_PREFIX}"/bin/cmake.exe \
+        -GNinja \
+        -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+        "${extra_config[@]}" \
+        ../${_realname}-${_s}-${pkgver}
+
+    "${MINGW_PREFIX}"/bin/cmake.exe --build .
+  done
+}
+
+package_footprints() {
+  pkgdesc="KiCad footprint libraries (mingw-w64)"
+  conflicts=(${MINGW_PACKAGE_PREFIX}-${_realname}-footprints-git)
+  replaces=(${MINGW_PACKAGE_PREFIX}-${_realname}-footprints-git)
+
+  cd "${srcdir}/build-footprints-${MSYSTEM}"
+
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
+}
+
+package_symbols() {
+  pkgdesc="KiCad symbol libraries (mingw-w64)"
+  conflicts=(${MINGW_PACKAGE_PREFIX}-${_realname}-symbols-git)
+  replaces=(${MINGW_PACKAGE_PREFIX}-${_realname}-symbols-git)
+
+  cd "${srcdir}/build-symbols-${MSYSTEM}"
+
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
+}
+
+package_templates() {
+  pkgdesc="KiCad template libraries (mingw-w64)"
+  conflicts=(${MINGW_PACKAGE_PREFIX}-${_realname}-templates-git)
+  replaces=(${MINGW_PACKAGE_PREFIX}-${_realname}-templates-git)
+
+  cd "${srcdir}/build-templates-${MSYSTEM}"
+
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
+}
+
+package_packages3D() {
+  pkgdesc="KiCad 3D model libraries (mingw-w64)"
+  conflicts=(${MINGW_PACKAGE_PREFIX}-${_realname}-packages3D-git)
+  replaces=(${MINGW_PACKAGE_PREFIX}-${_realname}-packages3D-git)
+
+  cd "${srcdir}/build-packages3D-${MSYSTEM}"
+
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
+}
+
+package_meta() {
+  pkgdesc="Meta package for KiCad containing the core application and support libraries (mingw-w64)"
+
+  depends=(${MINGW_PACKAGE_PREFIX}-${_realname}
+           ${MINGW_PACKAGE_PREFIX}-${_realname}-footprints
+           ${MINGW_PACKAGE_PREFIX}-${_realname}-symbols
+           ${MINGW_PACKAGE_PREFIX}-${_realname}-templates
+           ${MINGW_PACKAGE_PREFIX}-${_realname}-packages3D)
+  optdepends=()
+}
+
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
+
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-${_realname}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;

--- a/mingw-w64-kicad/PKGBUILD
+++ b/mingw-w64-kicad/PKGBUILD
@@ -1,34 +1,23 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 # Contributor: Tim Stahlhut <stahta01@gmail.com>
 
-# After building and uploading with pkgrel=1 setting to no is suggested;
-# This results in only the core KiCAD package being built and reduces
-# the build time and band width usage because the support libraries
-# do not change very often and are very large.
-_build_support_libraries=yes
-# meta wants to download the other packages which waste time during
-# development; but, needs to be yes after development is over.
-_build_meta=yes
+# Remember to update mingw-w64-kicad-doc and mingw-w64-kicad-library when
+# updating this build rule
 
 _realname=kicad
 _wx_basever=3.0
 pkgbase=mingw-w64-${_realname}
-pkgname=(
-  "${MINGW_PACKAGE_PREFIX}-${_realname}"
-  $([[ "$_build_meta" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-meta")
-  $([[ "$_build_support_libraries" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-footprints")
-  $([[ "$_build_support_libraries" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-symbols")
-  $([[ "$_build_support_libraries" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-templates")
-  $([[ "$_build_support_libraries" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-packages3D")
-)
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=5.1.12
-pkgrel=3
+pkgrel=4
 pkgdesc="Software for the creation of electronic schematic diagrams and printed circuit board artwork (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://www.kicad.org/"
 license=("spdx:AGPL-3.0-or-later")
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
+conflicts=(${MINGW_PACKAGE_PREFIX}-${_realname}-git)
+replaces=(${MINGW_PACKAGE_PREFIX}-${_realname}-git)
 depends=(
   "${MINGW_PACKAGE_PREFIX}-boost"
   "${MINGW_PACKAGE_PREFIX}-curl"
@@ -49,10 +38,20 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cmake"
   "${MINGW_PACKAGE_PREFIX}-cc"
   "${MINGW_PACKAGE_PREFIX}-doxygen"
-  "${MINGW_PACKAGE_PREFIX}-make"
-  "${MINGW_PACKAGE_PREFIX}-pkg-config"
+  "${MINGW_PACKAGE_PREFIX}-ninja"
+  "${MINGW_PACKAGE_PREFIX}-pkgconf"
   "${MINGW_PACKAGE_PREFIX}-swig"
 )
+optdepends=(
+  "${MINGW_PACKAGE_PREFIX}-kicad-footprints: for footprint libraries"
+  "${MINGW_PACKAGE_PREFIX}-kicad-symbols: for symbol libraries"
+  "${MINGW_PACKAGE_PREFIX}-kicad-templates: for template libraries"
+  "${MINGW_PACKAGE_PREFIX}-kicad-packages3D: for 3D model libraries"
+)
+_doc=("ca" "de" "en" "es" "fr" "id" "it" "ja" "nl" "pl" "ru" "zh")
+for _doclang in ${_doc[@]}; do
+  optdepends+=("${MINGW_PACKAGE_PREFIX}-${_realname}-doc-${_doclang}: for documentation (${_doclang})");
+done
 source=(
   '001-fix-FindwxWidgets.cmake.patch'
   '002-cmake-fixes-for-MINGW-CLANG.patch'
@@ -62,14 +61,6 @@ source=(
   "${_realname}-${pkgver}.tar.gz"::"https://gitlab.com/kicad/code/kicad/-/archive/${pkgver}/kicad-${pkgver}.tar.gz"
   "${_realname}-i18n-${pkgver}.tar.gz"::"https://gitlab.com/kicad/code/kicad-i18n/-/archive/${pkgver}/kicad-i18n-${pkgver}.tar.gz"
 )
-if [ "$_build_support_libraries" == "yes" ]; then
-  source+=(
-    "${_realname}-footprints-${pkgver}.tar.gz"::"https://gitlab.com/kicad/libraries/kicad-footprints/-/archive/${pkgver}/kicad-footprints-${pkgver}.tar.gz"
-    "${_realname}-symbols-${pkgver}.tar.gz"::"https://gitlab.com/kicad/libraries/kicad-symbols/-/archive/${pkgver}/kicad-symbols-${pkgver}.tar.gz"
-    "${_realname}-templates-${pkgver}.tar.gz"::"https://gitlab.com/kicad/libraries/kicad-templates/-/archive/${pkgver}/kicad-templates-${pkgver}.tar.gz"
-    "${_realname}-packages3D-${pkgver}.tar.gz"::"https://gitlab.com/kicad/libraries/kicad-packages3D/-/archive/${pkgver}/kicad-packages3D-${pkgver}.tar.gz"
-  )
-fi
 sha256sums=('3fe6d1126dc3a4e3d720714fc08ca8d10771f3d38f2a2118b95f9ca41ace0c2d'
             'b7bac9a0968575470daba671a9732a1e277d707a6e5bc15edbee85d22e9b223d'
             '7b8898a49a405509e35ed785735668e9837e1db7492b0fc2c80175b1ed153cbb'
@@ -77,15 +68,6 @@ sha256sums=('3fe6d1126dc3a4e3d720714fc08ca8d10771f3d38f2a2118b95f9ca41ace0c2d'
             '3f586437c79185afdfa6c70defe60788bb5e5286e6ab6b7d9dfa2451b825bfd5'
             '101cc025e55cb3cc047debe5e4b1ac1fa116ceed147fef1bc275d8e21f76aa3f'
             'bdaad9a89f2f0454f48a6e183cd2cce953b7f519ce79324858b25c74ce8789c5')
-if [ "$_build_support_libraries" == "yes" ]; then
-  sha256sums+=(
-            'd16742054ee5eacb7db916280960be7a5218d11b0b2201fa6cb6d61ee34652ec'
-            'f641e121a53cc2b7d2fe25fea88a4b1f14701a068c7243fdc0efa129497b332f'
-            '7b07b82b424875bfde34c6529b8524446bc8c4d608f48739380179520496596f'
-            '2752bb2cced9686e6edf043c6829db53ff4ae4c0e52d8318602da9cde82d0652')
-fi
-_doc=("ca" "de" "en" "es" "fr" "id" "it" "ja" "nl" "pl" "ru" "zh")
- _sub=("footprints" "symbols" "templates" "packages3D")
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -107,93 +89,59 @@ prepare() {
 }
 
 build() {
-  cd "${srcdir}"
-  msg2 "Build kicad"
-  [[ -d build-${MSYSTEM} ]] && rm -rf build-${MSYSTEM}
-  mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
+  msg2 "Build KiCad"
+  [[ -d "${srcdir}"/build-${MSYSTEM} ]] && rm -rf "${srcdir}"/build-${MSYSTEM}
+  mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
+
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;DCMAKE_PREFIX_PATH=;DEFAULT_INSTALL_PATH=" \
-  cmake \
-    -G"MinGW Makefiles" \
-    -DCMAKE_PREFIX_PATH=${MINGW_PREFIX} \
-    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DDEFAULT_INSTALL_PATH=${MINGW_PREFIX} \
-    -DOPENSSL_ROOT_DIR=${MINGW_PREFIX} \
-    -DwxWidgets_CONFIG_EXECUTABLE=${MINGW_PREFIX}/bin/wx-config-${_wx_basever} \
-    -DKICAD_USE_OCC="$( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] && echo "OFF" || echo "ON" )" \
-    -DOCC_INCLUDE_DIR=${MINGW_PREFIX}/include/opencascade \
-    -DKICAD_SCRIPTING=ON \
-    -DKICAD_SCRIPTING_MODULES=ON \
-    -DKICAD_SCRIPTING_PYTHON3=ON \
-    -DKICAD_SCRIPTING_WXPYTHON=ON \
-    -DKICAD_SCRIPTING_WXPYTHON_PHOENIX=ON \
-    -DPYTHON_EXECUTABLE=${MINGW_PREFIX}/bin/python.exe \
-    -DPYTHON_INCLUDE_DIR=$(${MINGW_PREFIX}/bin/python.exe -c "from sysconfig import get_paths as gp; print(gp()[\"include\"])") \
-    -DPYTHON_ROOT_DIR=${MINGW_PREFIX} \
-    ../${_realname}-${pkgver}
+    "${MINGW_PREFIX}"/bin/cmake.exe \
+      -GNinja \
+      -DCMAKE_PREFIX_PATH="${MINGW_PREFIX}" \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      "${extra_config[@]}" \
+      -DDEFAULT_INSTALL_PATH="${MINGW_PREFIX}" \
+      -DOPENSSL_ROOT_DIR="${MINGW_PREFIX}" \
+      -DwxWidgets_CONFIG_EXECUTABLE="${MINGW_PREFIX}"/bin/wx-config-${_wx_basever} \
+      -DKICAD_USE_OCC="$( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] && echo "OFF" || echo "ON" )" \
+      -DOCC_INCLUDE_DIR="${MINGW_PREFIX}"/include/opencascade \
+      -DKICAD_SCRIPTING=ON \
+      -DKICAD_SCRIPTING_MODULES=ON \
+      -DKICAD_SCRIPTING_PYTHON3=ON \
+      -DKICAD_SCRIPTING_WXPYTHON=ON \
+      -DKICAD_SCRIPTING_WXPYTHON_PHOENIX=ON \
+      -DPYTHON_EXECUTABLE="${MINGW_PREFIX}"/bin/python.exe \
+      -DPYTHON_INCLUDE_DIR=$("${MINGW_PREFIX}"/bin/python.exe -c "from sysconfig import get_paths as gp; print(gp()[\"include\"])") \
+      -DPYTHON_ROOT_DIR="${MINGW_PREFIX}" \
+      ../${_realname}-${pkgver}
 
-  mingw32-make
+  "${MINGW_PREFIX}"/bin/cmake.exe --build .
 
-  cd "${srcdir}"
   msg2 "Build translations"
-  [[ -d build-i18n ]] && rm -rf build-i18n
-  mkdir -p build-i18n && cd build-i18n
+  [[ -d "${srcdir}"/build-i18n-${MSYSTEM} ]] && rm -rf "${srcdir}"/build-i18n-${MSYSTEM}
+  mkdir -p "${srcdir}"/build-i18n-${MSYSTEM} && cd "${srcdir}"/build-i18n-${MSYSTEM}
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-  cmake \
-    -G "MinGW Makefiles" \
-    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    ../${_realname}-i18n-${pkgver}
+    "${MINGW_PREFIX}"/bin/cmake.exe \
+      -GNinja \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      ../${_realname}-i18n-${pkgver}
 
-  if [ "$_build_support_libraries" == "yes" ]; then
-    for _s in ${_sub[@]}; do
-      cd ${srcdir}
-      msg2 "Build ${_s}"
-      [[ -d build-${_s} ]] && rm -rf build-${_s}
-      mkdir -p build-${_s} && cd build-${_s}
-
-      MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-      cmake \
-        -G "MinGW Makefiles" \
-        -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-      ../${_realname}-${_s}-${pkgver}
-    done
-  fi
+  "${MINGW_PREFIX}"/bin/cmake.exe --build .
 }
 
-for _doclang in ${_doc[@]}; do _doc_pkg+=("\"${MINGW_PACKAGE_PREFIX}-${_realname}-doc-${_doclang}: Documentation for KiCad (mingw-w64)\""); done
-for _feature in ${_sub[@]}; do _sub_pkg+=("\"${MINGW_PACKAGE_PREFIX}-${_realname}-${_feature}\""); done
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
 
-eval "package_${MINGW_PACKAGE_PREFIX}-${_realname}() {
+  cd "${srcdir}/build-i18n-${MSYSTEM}"
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
 
-  msg2 \"Package kicad\"
-  optdepends+=(${_doc_pkg[@]} ${_sub_pkg[@]})
-  conflicts=(${MINGW_PACKAGE_PREFIX}-${_realname}-git)
-  replaces=(${MINGW_PACKAGE_PREFIX}-${_realname}-git)
-
-  cd \${srcdir}/build-${MSYSTEM}
-  mingw32-make DESTDIR=\${pkgdir} install
-
-  cd \${srcdir}/build-i18n
-  mingw32-make DESTDIR=\${pkgdir} install
-
-  install -Dm644 \"\${srcdir}/${_realname}-${pkgver}/LICENSE.AGPLv3\" \"\${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE\"
-}"
-
-eval "package_${MINGW_PACKAGE_PREFIX}-${_realname}-meta() {
-  depends=(${MINGW_PACKAGE_PREFIX}-${_realname}
-           ${_sub_pkg[@]})
-}"
-
-for _part in ${_sub[@]}; do
-  eval "package_${MINGW_PACKAGE_PREFIX}-${_realname}-${_part}() {
-    options=('!strip')
-    depends=(${MINGW_PACKAGE_PREFIX}-${_realname})
-    conflicts=(${MINGW_PACKAGE_PREFIX}-${_realname}-${_part}-git)
-    replaces=(${MINGW_PACKAGE_PREFIX}-${_realname}-${_part}-git)
-    msg2 \"Package ${_part}\"
-    cd \${srcdir}/build-${_part}
-    mingw32-make DESTDIR=\${pkgdir} install
-  }"
-done
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE.AGPLv3" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
Overhaul build rules.

This is also how ArchLinux packages KiCad:
https://github.com/archlinux/svntogit-community/blob/packages/kicad/trunk/PKGBUILD
https://github.com/archlinux/svntogit-community/blob/packages/kicad-library/trunk/PKGBUILD

This change would allow to, e.g., bump the pkgrel of the core application without the need to rebuild the huge support libraries.

See #11751.