### PR TITLE
glpk: update to 5.0

### DIFF
--- a/mingw-w64-glpk/PKGBUILD
+++ b/mingw-w64-glpk/PKGBUILD
@@ -3,21 +3,22 @@
 _realname=glpk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.65
-pkgrel=3
+pkgver=5.0
+pkgrel=1
 pkgdesc="GNU Linear Programming Kit: solve LP, MIP and other problems (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://www.gnu.org/software/glpk/glpk.html"
-license=('GPL')
+license=('spdx:GPL-3.0-or-later')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-gmp")
-makedepends=("${MINGW_PACKAGE_PREFIX}-autotools" "${MINGW_PACKAGE_PREFIX}-cc")
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-cc")
 options=('staticlibs' 'strip')
 source=("https://ftp.gnu.org/gnu/glpk/glpk-${pkgver}.tar.gz"
         'timeval-64bit.patch'
         'fix-platform-check.patch')
-sha256sums=('4281e29b628864dfe48d393a7bedd781e5b475387c20d8b0158f329994721a10'
+sha256sums=('4a1013eebb50f728fc601bdd833b0b2870333c3b3e5a816eeba921d95bec6f15'
             '2d09d58139fd85d695f5b2933ec750adf0b438a1e9a53dee1b264b80dd2e0f6a'
             '9a866c1e14f7a200a46b83c78b9f2d207167633e6ef0c51341008f07ee677d8a')
 
@@ -30,8 +31,8 @@ prepare () {
 }
 
 build() {
-  [[ -d build-${MSYSTEM} ]] && rm -rf build-${MSYSTEM}
-  mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
+  [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
@@ -53,4 +54,6 @@ check() {
 package() {
   cd "${srcdir}/build-${MSYSTEM}"
   make DESTDIR="${pkgdir}" install
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
According to package grokker, one symbol was removed with the update. So, rebuilding dependencies, too.

I took the opportunity to build python-cvxopt with OpenBLAS also for the CLANG environments. That might result in better performance on some operations.