### PR TITLE
wxWidgets: suppress error about mismatching C++ ABI version

### DIFF
--- a/mingw-w64-wxWidgets/009-warn-for-compiler-abi-mismatch.patch
+++ b/mingw-w64-wxWidgets/009-warn-for-compiler-abi-mismatch.patch
@@ -1,0 +1,38 @@
+Description: Suppress error about mismatching C++ ABI version
+ In practice, the differences between recent ABI versions don't seem to be
+ incompatible since they apparently only affect obscure corner cases.  So
+ suppress this error so we don't have to rebuild the entire wx world in one
+ go.
+Author: Olly Betts <olly@survex.com>
+Forwarded: no
+Last-Update: 2017-07-26
+
+--- a/src/common/appbase.cpp
++++ b/src/common/appbase.cpp
+@@ -766,6 +766,26 @@
+         msg.Printf(wxT("Mismatch between the program and library build versions detected.\nThe library used %s,\nand %s used %s."),
+                    lib.c_str(), progName.c_str(), prog.c_str());
+ 
++	int l_off = lib.Find("compiler with C++ ABI ");
++	int p_off = prog.Find("compiler with C++ ABI ");
++	if (l_off != wxNOT_FOUND && p_off != wxNOT_FOUND) {
++	    int space;
++	    space = lib.find(',', l_off + 22);
++	    lib.erase(l_off, space - l_off);
++	    space = prog.find(',', p_off + 22);
++	    prog.erase(p_off, space - p_off);
++	    if (lib == prog) {
++		// The only difference is the ABI version, which apparently only
++		// affect obscure cases.  We used to warn here, so at least
++		// there was an indication of what's up if there is a problem
++		// due to ABI incompatibilities, but wxLogWarning() can result
++		// in a pop up dialog with some applications, which is just too
++		// intrusive, so just quietly ignore instead.
++		//wxLogWarning(msg.c_str());
++		return false;
++	    }
++	}
++
+         wxLogFatalError(msg.c_str());
+ 
+         // normally wxLogFatalError doesn't return

--- a/mingw-w64-wxWidgets/PKGBUILD
+++ b/mingw-w64-wxWidgets/PKGBUILD
@@ -10,11 +10,11 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 provides=("${MINGW_PACKAGE_PREFIX}-wxmsw${_wx_basever}" "${MINGW_PACKAGE_PREFIX}-wxconfig")
 pkgbase=mingw-w64-${_realname}
 pkgver=${_wx_basever}.5.1
-pkgrel=10
+pkgrel=11
 pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
-license=("custom:wxWindows")
+license=("spdx:GPL-2.0-or-later AND WxWindows-exception-3.1")
 url="https://www.wxwidgets.org/"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-expat"
@@ -32,11 +32,21 @@ source=(https://github.com/wxWidgets/wxWidgets/releases/download/v${pkgver}/wxWi
         "001-wxWidgets-3.0.2-relocate-prefix-in-bin-wx-config.patch"
         "002-wxWidgets-3.0.2-relax-abi-compatibility-gcc.patch"
         "003-wxWidgets-3.0.2-fix-access-sample.patch"
+        # squashed upstream commits
+        # https://github.com/wxWidgets/wxWidgets/commit/c0f2f3801150ea9c6640f3fdced1d9120938f0d7
+        # and
+        # https://github.com/wxWidgets/wxWidgets/commit/e8a7bae0a750bcb5d8aadc45629d2c9adaf2106c
         "004-wxWidgets-3.0-clang-windows-link.patch"
+        # https://github.com/wxWidgets/wxWidgets/commit/a195bf86a21e9334c68eb5e4a5b0973104553460
         "005-wxWidgets-3.0-gdiplus-math-min-max.patch"
         "006-wxWidgets-3.0-Fix-c-11-narrowing-error.patch"
+        # https://github.com/wxWidgets/wxWidgets/commit/f69dbaa1aebd72652dfb6246bdeaffce4d83933d
+        # with MSVC-specific build config and changes striped
         "007-wxWidgets-3.0-Introduce-msw-arm64-support.patch"
-        "008-wxWidgets-3.0-Add-msw-manifests-for-arm-and-arm64-platforms.patch")
+        # https://github.com/wxWidgets/wxWidgets/commit/c0c22609447c1f982500e997ba663112ac66f5f9
+        "008-wxWidgets-3.0-Add-msw-manifests-for-arm-and-arm64-platforms.patch"
+        # https://salsa.debian.org/freewx-team/wx/blob/wx3.0-debian/debian/patches/warn-for-compiler-abi-mismatch.patch
+        "009-warn-for-compiler-abi-mismatch.patch")
 sha256sums=('440f6e73cf5afb2cbf9af10cec8da6cdd3d3998d527598a53db87099524ac807'
             '03e157c427ff93c8c35b6036795e42fd980d4cb28d3ef1fef9ba6d6a9b7fff04'
             '3138f7b84bf988892f62167afc6fa640ac154b629b243d86413f7c811e508713'
@@ -45,27 +55,31 @@ sha256sums=('440f6e73cf5afb2cbf9af10cec8da6cdd3d3998d527598a53db87099524ac807'
             '4915d09f217270956cad3de7cf0e3fdaec4847cfda46d4b568bde26a8bd5f94a'
             '043c24cab804b972a3fa710182b19f15aff8479a34e031694c17108a64e27d3f'
             'a9f43fca5ab5c8bdcc60933a2bf00fc7ac0f9dfe715fe9eb9f426f413d0a162d'
-            'd21ec13a29644547ff0d688c358a3a7795a0dc15c8e8e9761524212235db47f7')
+            'd21ec13a29644547ff0d688c358a3a7795a0dc15c8e8e9761524212235db47f7'
+            '53501db871290b71967af08b60aedb738c920a307ef9bd32dd19c30498732cf8')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _fname in "$@"
+  do
+    msg2 "Applying ${_fname}"
+    patch -Nbp1 -i "${srcdir}"/${_fname}
+  done
+}
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
 
-  patch -p1 -i "${srcdir}"/001-wxWidgets-3.0.2-relocate-prefix-in-bin-wx-config.patch
-  patch -p1 -i "${srcdir}"/002-wxWidgets-3.0.2-relax-abi-compatibility-gcc.patch
-  patch -p1 -i "${srcdir}"/003-wxWidgets-3.0.2-fix-access-sample.patch
-  # squashed upstream commits
-  # https://github.com/wxWidgets/wxWidgets/commit/c0f2f3801150ea9c6640f3fdced1d9120938f0d7
-  # and
-  # https://github.com/wxWidgets/wxWidgets/commit/e8a7bae0a750bcb5d8aadc45629d2c9adaf2106c
-  patch -p1 -i "${srcdir}"/004-wxWidgets-3.0-clang-windows-link.patch
-  # https://github.com/wxWidgets/wxWidgets/commit/a195bf86a21e9334c68eb5e4a5b0973104553460
-  patch -p1 -i "${srcdir}"/005-wxWidgets-3.0-gdiplus-math-min-max.patch
-  patch -p1 -i "${srcdir}"/006-wxWidgets-3.0-Fix-c-11-narrowing-error.patch
-  # https://github.com/wxWidgets/wxWidgets/commit/f69dbaa1aebd72652dfb6246bdeaffce4d83933d
-  # with MSVC-specific build config and changes striped
-  patch -p1 -i "${srcdir}"/007-wxWidgets-3.0-Introduce-msw-arm64-support.patch
-  # https://github.com/wxWidgets/wxWidgets/commit/c0c22609447c1f982500e997ba663112ac66f5f9
-  patch -p1 -i "${srcdir}"/008-wxWidgets-3.0-Add-msw-manifests-for-arm-and-arm64-platforms.patch
+  apply_patch_with_msg \
+    001-wxWidgets-3.0.2-relocate-prefix-in-bin-wx-config.patch \
+    002-wxWidgets-3.0.2-relax-abi-compatibility-gcc.patch \
+    003-wxWidgets-3.0.2-fix-access-sample.patch \
+    004-wxWidgets-3.0-clang-windows-link.patch \
+    005-wxWidgets-3.0-gdiplus-math-min-max.patch \
+    006-wxWidgets-3.0-Fix-c-11-narrowing-error.patch \
+    007-wxWidgets-3.0-Introduce-msw-arm64-support.patch \
+    008-wxWidgets-3.0-Add-msw-manifests-for-arm-and-arm64-platforms.patch \
+    009-warn-for-compiler-abi-mismatch.patch
 
   # autoreconf to get updated libtool files, for aarch64 support
   pushd src/tiff


### PR DESCRIPTION
Adding that patch was proposed by @Biswa96 in #11759 (and before by @jeremyd2019 in #9913). Other distributions (e.g., Debian and ArchLinux) are using the same patch. So, I'd guess it might be save for MSYS2 as well.

Fixes #11759.