### PR TITLE
python-numpy: don't depend on openblas for clangarm64

### DIFF
--- a/mingw-w64-python-numpy/PKGBUILD
+++ b/mingw-w64-python-numpy/PKGBUILD
@@ -22,7 +22,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cython"
              $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || \
                echo "${MINGW_PACKAGE_PREFIX}-gcc-fortran"))
 depends=("${MINGW_PACKAGE_PREFIX}-python"
-         "${MINGW_PACKAGE_PREFIX}-openblas")
+         $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || \
+           echo "${MINGW_PACKAGE_PREFIX}-openblas"))
 optdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest: testsuite")
 #options=('!strip' 'debug')
 source=(https://github.com/numpy/numpy/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz 


### PR DESCRIPTION
See #11768.