### PR TITLE
python-qmk: fix launcher crash

### DIFF
--- a/mingw-w64-python-qmk/PKGBUILD
+++ b/mingw-w64-python-qmk/PKGBUILD
@@ -47,7 +47,7 @@ package() {
   cd "${srcdir}/python-build-${MSYSTEM}"
 
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-    "${MINGW_PREFIX}"/bin/python -m installer --no-compile-bytecode --prefix=${MINGW_PREFIX} \
+    "${MINGW_PREFIX}"/bin/python -m installer --prefix=${MINGW_PREFIX} \
     --destdir="${pkgdir}" dist/*.whl
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"

--- a/mingw-w64-python-qmk/PKGBUILD
+++ b/mingw-w64-python-qmk/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qmk
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=1.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="CLI tool for customizing supported mechanical keyboards. (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -47,13 +47,8 @@ package() {
   cd "${srcdir}/python-build-${MSYSTEM}"
 
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-    "${MINGW_PREFIX}"/bin/python -m pip install dist/*.whl \
-      --compile \
-      --no-deps \
-      --no-warn-script-location \
-      --ignore-installed \
-      --prefix="${MINGW_PREFIX}" \
-      --root="${pkgdir}"
+    "${MINGW_PREFIX}"/bin/python -m installer --no-compile-bytecode --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
 }


### PR DESCRIPTION
Attempting to run `qmk` results in `Fatal error in launcher: U`. The appended Python script had the CI cygpath in its hashbang, but for some reason `makepkg-mingw` didn't pick up on it. I referenced python-jsonschema which also has an .exe launcher.