### PR TITLE
highway: update to 0.17.0

### DIFF
--- a/mingw-w64-highway/PKGBUILD
+++ b/mingw-w64-highway/PKGBUILD
@@ -3,20 +3,20 @@
 _realname=highway
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.16.0
+pkgver=0.17.0
 pkgrel=1
 pkgdesc="C++ library for SIMD (Single Instruction, Multiple Data) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url='https://github.com/google/highway'
-license=('Apache-2.0')
+license=('spdx:Apache-2.0')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 #checkdepends=("${MINGW_PACKAGE_PREFIX}-gtest")
 source=("${_realname}-${pkgver}.tar.gz"::"${url}/archive/refs/tags/${pkgver}.tar.gz")
-sha256sums=('746c9578446be6c5286e8846c5f0d4118c0c1f04219c401abadcb8a5f2051893')
+sha256sums=('25158fd5c090b70ecea47fc246c860d150f07f801d2434e1e51ec14a6c15822c')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
@@ -34,7 +34,9 @@ build() {
   [[ -d "${srcdir}"/build-${MSYSTEM}-static ]] && rm -rf "${srcdir}"/build-${MSYSTEM}-static
   mkdir -p "${srcdir}"/build-${MSYSTEM}-static && cd "${srcdir}"/build-${MSYSTEM}-static
 
-  CXXFLAGS+=" -DHWY_COMPILE_ALL_ATTAINABLE"
+  if [[ "${MINGW_PACKAGE_PREFIX}" != *clang-aarch64* ]]; then
+    CXXFLAGS+=" -DHWY_BASELINE_TARGETS=HWY_EMU128"
+  fi
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake \
       -GNinja \
@@ -50,7 +52,9 @@ build() {
   [[ -d "${srcdir}"/build-${MSYSTEM}-shared ]] && rm -rf "${srcdir}"/build-${MSYSTEM}-shared
   mkdir -p "${srcdir}"/build-${MSYSTEM}-shared && cd "${srcdir}"/build-${MSYSTEM}-shared
 
-  CXXFLAGS+=" -DHWY_COMPILE_ALL_ATTAINABLE"
+  if [[ "${MINGW_PACKAGE_PREFIX}" != *clang-aarch64* ]]; then
+    CXXFLAGS+=" -DHWY_BASELINE_TARGETS=HWY_EMU128"
+  fi
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake \
       -GNinja \
@@ -67,7 +71,7 @@ build() {
 #check() {
 #  cd "${srcdir}"/build-${MSYSTEM}-static
 #
-#  cmake --build . --target test
+#  ${MINGW_PREFIX}/bin/cmake --build . --target test
 #}
 
 package() {


### PR DESCRIPTION
This should now be built the same way libjxl CI does it (they upgraded to 0.17 recently as well). @Biswa96 @novomesk @thebombzen @Jehan @ccicnce113424

Obviously, only libjxl master can benefit from this version for debundling, not the currently packaged 0.6.1...