### PR TITLE
aws-sdk-cpp: Add AWS lambda

### DIFF
--- a/mingw-w64-aws-sdk-cpp/PKGBUILD
+++ b/mingw-w64-aws-sdk-cpp/PKGBUILD
@@ -4,7 +4,7 @@ _realname=aws-sdk-cpp
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.9.241
-pkgrel=1
+pkgrel=2
 pkgdesc="AWS SDK for C++ (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -54,7 +54,7 @@ build() {
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       -DCMAKE_PREFIX_PATH="${MINGW_PREFIX}" \
       -DCMAKE_MODULE_PATH="${MINGW_PREFIX}"/lib/cmake \
-      -DBUILD_ONLY="config;identity-management;s3;sts;transfer" \
+      -DBUILD_ONLY="config;identity-management;lambda;s3;sts;transfer" \
       -DENABLE_UNITY_BUILD=ON \
       -DENABLE_TESTING=OFF \
       -DBUILD_DEPS=OFF \

--- a/mingw-w64-aws-sdk-cpp/PKGBUILD
+++ b/mingw-w64-aws-sdk-cpp/PKGBUILD
@@ -74,7 +74,7 @@ build() {
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       -DCMAKE_PREFIX_PATH="${MINGW_PREFIX}" \
       -DCMAKE_MODULE_PATH="${MINGW_PREFIX}"/lib/cmake \
-      -DBUILD_ONLY="config;identity-management;s3;sts;transfer" \
+      -DBUILD_ONLY="config;identity-management;lambda;s3;sts;transfer" \
       -DENABLE_UNITY_BUILD=ON \
       -DENABLE_TESTING=OFF \
       -DBUILD_DEPS=OFF \


### PR DESCRIPTION
Currently, the AWS SDK for C++ package does not support all features.

By including AWS lambda in the list of supported features, I will be able to use the package for my AWS lambda needs