### PR TITLE
Standarize GNU AVR toolchain PKGBUILDs

### DIFF
--- a/mingw-w64-avr-binutils/PKGBUILD
+++ b/mingw-w64-avr-binutils/PKGBUILD
@@ -14,30 +14,25 @@ license=('GPL')
 url='https://www.gnu.org/software/binutils/binutils.html'
 groups=("${MINGW_PACKAGE_PREFIX}-${_target}-toolchain")
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools" "${MINGW_PACKAGE_PREFIX}-cc")
-source=(
-    https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.xz{,.sig}
-    "01-avr-size.patch"
-)
-sha256sums=(
-    '1b11659fb49e20e18db460d44485f09442c8c56d5df165de9461eb09c8302f85'
-    'SKIP'
-    '7aed303887a8541feba008943d0331dc95dd90a309575f81b7a195650e4cba1e'
-)
+source=(https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.xz{,.sig}
+        "01-avr-size.patch")
+sha256sums=('1b11659fb49e20e18db460d44485f09442c8c56d5df165de9461eb09c8302f85'
+            'SKIP'
+            '7aed303887a8541feba008943d0331dc95dd90a309575f81b7a195650e4cba1e')
 validpgpkeys=('3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F')
 
 prepare() {
     cd ${srcdir}/${_realname}-${pkgver}
-
-    mkdir ${_realname}-build
 
     # https://github.com/archlinux/svntogit-community/blob/packages/avr-binutils/trunk/avr-size.patch
     patch -p1 -i ../01-avr-size.patch
 }
 
 build() {
-    cd ${srcdir}/${_realname}-${pkgver}/${_realname}-build
+    [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
+    mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
-    ../configure \
+    ../${_realname}-${pkgver}/configure \
         --build=${MINGW_CHOST} \
         --prefix=${MINGW_PREFIX} \
         --target=${_target} \
@@ -49,7 +44,7 @@ build() {
 }
 
 package() {
-    cd ${srcdir}/${_realname}-${pkgver}/${_realname}-build
+    cd "${srcdir}/build-${MSYSTEM}"
 
     make DESTDIR="$pkgdir" install
 

--- a/mingw-w64-avr-gcc/PKGBUILD
+++ b/mingw-w64-avr-gcc/PKGBUILD
@@ -9,32 +9,25 @@ pkgver=8.4.0
 pkgrel=4
 pkgdesc='GNU compiler collection for AVR 8-bit and 32-bit microcontrollers (mingw-w64)'
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64')
 license=('GPL')
 url='https://www.gnu.org/software/gcc/gcc.html'
 options=(!strip)
 groups=("${MINGW_PACKAGE_PREFIX}-${_target}-toolchain")
-depends=(
-    "${MINGW_PACKAGE_PREFIX}-${_target}-binutils"
-    "${MINGW_PACKAGE_PREFIX}-gmp"
-    "${MINGW_PACKAGE_PREFIX}-isl"
-    "${MINGW_PACKAGE_PREFIX}-mpc"
-    "${MINGW_PACKAGE_PREFIX}-mpfr"
-)
+depends=("${MINGW_PACKAGE_PREFIX}-${_target}-binutils"
+         "${MINGW_PACKAGE_PREFIX}-gmp"
+         "${MINGW_PACKAGE_PREFIX}-isl"
+         "${MINGW_PACKAGE_PREFIX}-mpc"
+         "${MINGW_PACKAGE_PREFIX}-mpfr")
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools" "${MINGW_PACKAGE_PREFIX}-cc")
 source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}/${_realname}-${pkgver}.tar.xz")
 sha256sums=('e30a6e52d10e1f27ed55104ad233c30bd1e99cfb5ff98ab022dc941edd1b2dd4')
 
-prepare() {
-    cd ${srcdir}/${_realname}-${pkgver}
-
-    mkdir ${_realname}-build
-}
-
 build() {
-    cd ${srcdir}/${_realname}-${pkgver}/${_realname}-build
+    [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
+    mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
-    ../configure \
+    ../${_realname}-${pkgver}/configure \
         --build=${MINGW_CHOST} \
         --prefix=${MINGW_PREFIX} \
         --target=${_target} \
@@ -51,7 +44,7 @@ build() {
 }
 
 package() {
-    cd ${srcdir}/${_realname}-${pkgver}/${_realname}-build
+    cd "${srcdir}/build-${MSYSTEM}"
 
     make DESTDIR="$pkgdir" install
 

--- a/mingw-w64-avr-gdb/PKGBUILD
+++ b/mingw-w64-avr-gdb/PKGBUILD
@@ -6,7 +6,7 @@ _target=avr
 pkgbase=mingw-w64-${_target}-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_target}-${_realname}
 pkgver=9.2
-pkgrel=3
+pkgrel=4
 pkgdesc='The GNU Debugger for AVR (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -14,23 +14,17 @@ license=('GPL')
 url='https://www.gnu.org/software/gdb/'
 groups=("${MINGW_PACKAGE_PREFIX}-${_target}-toolchain")
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools" "${MINGW_PACKAGE_PREFIX}-cc")
+depends=("${MINGW_PACKAGE_PREFIX}-readline")
 source=(https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.xz{,.sig})
-sha256sums=(
-    '360cd7ae79b776988e89d8f9a01c985d0b1fa21c767a4295e5f88cb49175c555'
-    'SKIP'
-)
+sha256sums=('360cd7ae79b776988e89d8f9a01c985d0b1fa21c767a4295e5f88cb49175c555'
+            'SKIP')
 validpgpkeys=('F40ADB902B24264AA42E50BF92EDB04BFF325CF3') # Joel Brobecker
 
-prepare() {
-    cd ${srcdir}/${_realname}-${pkgver}
-
-    mkdir ${_realname}-build
-}
-
 build() {
-    cd ${srcdir}/${_realname}-${pkgver}/${_realname}-build
+    [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
+    mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
-    ../configure \
+    ../${_realname}-${pkgver}/configure \
         --build=${MINGW_CHOST} \
         --prefix=${MINGW_PREFIX} \
         --target=${_target} \
@@ -46,7 +40,7 @@ build() {
 }
 
 package() {
-    cd ${srcdir}/${_realname}-${pkgver}/${_realname}-build
+    cd "${srcdir}/build-${MSYSTEM}"
 
     make DESTDIR="$pkgdir" install-gdb
 

--- a/mingw-w64-avr-libc/PKGBUILD
+++ b/mingw-w64-avr-libc/PKGBUILD
@@ -9,7 +9,7 @@ pkgver=2.0.0
 pkgrel=3
 pkgdesc='The C runtime library for the AVR family of microcontrollers (mingw-w64)'
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64')
 license=('BSD')
 url='https://savannah.nongnu.org/projects/avr-libc/'
 options=(!strip)
@@ -19,16 +19,12 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-autotools")
 source=("https://download.savannah.gnu.org/releases/${_target}-${_realname}/${_target}-${_realname}-${pkgver}.tar.bz2")
 sha256sums=('b2dd7fd2eefd8d8646ef6a325f6f0665537e2f604ed02828ced748d49dc85b97')
 
-prepare() {
-    cd ${srcdir}/${_target}-${_realname}-${pkgver}
-
-    mkdir ${_realname}-build
-}
-
 build() {
-    cd ${srcdir}/${_target}-${_realname}-${pkgver}/${_realname}-build
+    [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
+    mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
-    ../configure \
+    CC=avr-gcc
+    ../${_target}-${_realname}-${pkgver}/configure \
         --build=${MINGW_CHOST} \
         --host=${_target} \
         --prefix=${MINGW_PREFIX}
@@ -36,7 +32,7 @@ build() {
 }
 
 package() {
-    cd ${srcdir}/${_target}-${_realname}-${pkgver}/${_realname}-build
+    cd "${srcdir}/build-${MSYSTEM}"
 
     make DESTDIR="$pkgdir" install
 }


### PR DESCRIPTION
Do we need to bump pkgrel to produce missing `ucrt64` build of `mingw-w64-avr-gcc`?
It build fine on my machine.

Disabled `mingw-w64-avr-gcc` for Clang because it fork-bombed my machine by recursively spawning tens of thousands compiler processes during: `checking whether compiler driver understands Ada...`