### PR TITLE
med: update to 4.1.1

### DIFF
--- a/mingw-w64-gmsh/PKGBUILD
+++ b/mingw-w64-gmsh/PKGBUILD
@@ -5,10 +5,10 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.10.2
 _pkgver2=4_10_2
-pkgrel=1
-pkgdesc="3D finite element mesh generator with a built-in CAD engine and post-processor (mingw-w64)"
+pkgrel=2
+pkgdesc="3D finite element mesh generator with built-in CAD engine and post-processor (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://gmsh.info"
 license=("spdx:GPL-2.0-or-later")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
@@ -41,13 +41,13 @@ prepare() {
 }
 
 build() {
-  [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}
-  mkdir ${srcdir}/build-${MSYSTEM} && cd ${srcdir}/build-${MSYSTEM}
+  [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
+  mkdir "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-    ${MINGW_PREFIX}/bin/cmake \
-      -G"MSYS Makefiles" \
-      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    "${MINGW_PREFIX}"/bin/cmake \
+      -GNinja \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       -DCMAKE_BUILD_TYPE=Release \
       -DENABLE_BUILD_DYNAMIC=1 \
       -DENABLE_BUILD_SHARED=1 \
@@ -59,13 +59,13 @@ build() {
       -DGMSH_RELEASE=1 \
       -DENABLE_CAIRO=1 \
       ../gmsh-gmsh_${_pkgver2}
-  
-  ${MINGW_PREFIX}/bin/cmake --build .
+
+  "${MINGW_PREFIX}"/bin/cmake --build .
 }
 
 package() {
   cd "${srcdir}/build-${MSYSTEM}"
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --build . --target install
-  
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake --install .
+
   mv "${pkgdir}${MINGW_PREFIX}"/lib/*.dll "${pkgdir}${MINGW_PREFIX}"/bin/
 }

--- a/mingw-w64-med/PKGBUILD
+++ b/mingw-w64-med/PKGBUILD
@@ -7,78 +7,90 @@
 _realname=med
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-pkgver=4.1.0
+pkgver=4.1.1
 pkgrel=4
 pkgdesc="Generic pre- and post-processing platform for numerical simulation (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://www.salome-platform.org/downloads/current-version"
-license=('LGPL')
+license=('spdx:LGPL-3.0-or-later')
 depends=("${MINGW_PACKAGE_PREFIX}-hdf5"
-         "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran"
+         $([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] && echo "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran")
          "${MINGW_PACKAGE_PREFIX}-tk")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-gcc-fortran"
+             $([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] && echo "${MINGW_PACKAGE_PREFIX}-gcc-fortran")
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cmake")
 source=("http://files.salome-platform.org/Salome/other/${_realname}-${pkgver}.tar.gz"
         "hdf5-1.12.patch"
         "bin-dest.patch")
-sha256sums=('847db5d6fbc9ce6924cb4aea86362812c9a5ef6b9684377e4dd6879627651fce'
+sha256sums=('dc2b5d54ebf0666e3ff2e974041d2ab0da906061323537023ab165d573389dd0'
             '6c0083bc1b52091357f039b73c9e528c225905568d5ee39008980fc9f6ad1682'
-            '7ba63007a100408d7cdba106607eefcd0396f8984e84bf412e44324814cb1b04')
+            '75f078af79b58d41ccc6f4a2ccf1a0ab4aa50365600d279ef2466456a3bfa67f')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _fname in "$@"
+  do
+    msg2 "Applying ${_fname}"
+    patch -Nbp1 -i "${srcdir}"/${_fname}
+  done
+}
+# =========================================== #
 
 prepare() {
-  cd "${srcdir}/${_realname}-${pkgver}"
-  patch -p1 -i "${srcdir}/hdf5-1.12.patch"
-  patch -p1 -i "${srcdir}/bin-dest.patch"
+  cd "${srcdir}/${_realname}-${pkgver}_SRC"
+  apply_patch_with_msg \
+    hdf5-1.12.patch \
+    bin-dest.patch
   sed -i 's/if H5_VERS_MINOR > 10/if 0/g' src/ci/MEDfileCompatibility.c
 }
 
 build() {
-  #Static Build
-  [[ -d "${srcdir}/build-${MINGW_CHOST}-static" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}-static"
-  mkdir -p "${srcdir}/build-${MINGW_CHOST}-static" && cd "${srcdir}/build-${MINGW_CHOST}-static"
+  # Static Build
+  [[ -d "${srcdir}/build-${MSYSTEM}-static" ]] && rm -rf "${srcdir}/build-${MSYSTEM}-static"
+  mkdir -p "${srcdir}/build-${MSYSTEM}-static" && cd "${srcdir}/build-${MSYSTEM}-static"
   
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-  ${MINGW_PREFIX}/bin/cmake \
-    -G"Ninja" \
+  "${MINGW_PREFIX}"/bin/cmake.exe \
+    -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
     -DMEDFILE_BUILD_SHARED_LIBS=OFF \
     -DMEDFILE_BUILD_STATIC_LIBS=ON \
-    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
     -DCMAKE_C_FLAGS="-DH5_USE_110_API" \
     -DMEDFILE_BUILD_PYTHON=OFF \
     -DMEDFILE_BUILD_TESTS=OFF \
     -DMEDFILE_INSTALL_DOC=OFF \
-    ../${_realname}-${pkgver}
-  ninja
+    ../${_realname}-${pkgver}_SRC
+  "${MINGW_PREFIX}"/bin/cmake --build .
   
-  #Shared Build
-  [[ -d "${srcdir}/build-${MINGW_CHOST}-shared" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}-shared"
-  mkdir -p "${srcdir}/build-${MINGW_CHOST}-shared" && cd "${srcdir}/build-${MINGW_CHOST}-shared"
+  # Shared Build
+  [[ -d "${srcdir}/build-${MSYSTEM}-shared" ]] && rm -rf "${srcdir}/build-${MSYSTEM}-shared"
+  mkdir -p "${srcdir}/build-${MSYSTEM}-shared" && cd "${srcdir}/build-${MSYSTEM}-shared"
   
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-  ${MINGW_PREFIX}/bin/cmake \
-    -G"Ninja" \
+  "${MINGW_PREFIX}"/bin/cmake.exe \
+    -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
     -DMEDFILE_BUILD_SHARED_LIBS=ON \
-    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
     -DCMAKE_C_FLAGS="-DH5_USE_110_API" \
     -DMEDFILE_BUILD_PYTHON=OFF \
     -DMEDFILE_BUILD_TESTS=OFF \
     -DMEDFILE_INSTALL_DOC=OFF \
-    ../${_realname}-${pkgver}
-  ninja
+    ../${_realname}-${pkgver}_SRC
+  "${MINGW_PREFIX}"/bin/cmake --build .
 }
 
 package() {
-  #Static Install
-  cd "${srcdir}/build-${MINGW_CHOST}-static"
-  DESTDIR=${pkgdir} ninja install
+  # Static Install
+  cd "${srcdir}/build-${MSYSTEM}-static"
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
 
-  #Shared Install
-  cd "${srcdir}/build-${MINGW_CHOST}-shared"
-  DESTDIR=${pkgdir} ninja install
-  install -Dm644 ${srcdir}/${_realname}-${pkgver}/COPYING ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+  # Shared Install
+  cd "${srcdir}/build-${MSYSTEM}-shared"
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}_SRC/COPYING.LESSER" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-med/bin-dest.patch
+++ b/mingw-w64-med/bin-dest.patch
@@ -24,58 +24,9 @@
    # Give precendence to the shared object for the linking of 
    # the executable medimport:
    IF(NOT _lib_to_link)
---- med-4.1.0/src/CMakeLists.txt.orig	2020-03-12 16:45:46.000000000 +0100
-+++ med-4.1.0/src/CMakeLists.txt	2020-10-31 09:10:55.720325200 +0100
-@@ -113,7 +113,10 @@
-       SOVERSION 11
-       VERSION   11.0.1)
-     TARGET_LINK_LIBRARIES(medfwrap medC)
--    INSTALL(TARGETS medfwrap EXPORT medfileTargetsF DESTINATION lib${LIB_SUFFIX})
-+    INSTALL(TARGETS medfwrap EXPORT medfileTargetsF
-+            RUNTIME DESTINATION bin
-+            LIBRARY DESTINATION lib${LIB_SUFFIX}
-+            ARCHIVE DESTINATION lib${LIB_SUFFIX})
- 
-     # Add Shared MED library
-     ADD_LIBRARY(med SHARED MEDiterators.c)
-@@ -124,7 +127,10 @@
-     TARGET_LINK_LIBRARIES(med medfwrap)    
-    
-     # Install only the resulting library:
--    INSTALL(TARGETS med EXPORT medTargetsF DESTINATION lib${LIB_SUFFIX})
-+    INSTALL(TARGETS med EXPORT medfileTargetsF
-+            RUNTIME DESTINATION bin
-+            LIBRARY DESTINATION lib${LIB_SUFFIX}
-+            ARCHIVE DESTINATION lib${LIB_SUFFIX})
-   ENDIF()
- 
-   ######### Static Libraries ##########
-@@ -137,7 +143,10 @@
-     ADD_LIBRARY(medfwrap_static STATIC ${medfort_wrap_SOURCES})
-     SET_TARGET_PROPERTIES(medfwrap_static PROPERTIES OUTPUT_NAME medfwrap)
-     TARGET_LINK_LIBRARIES(medfwrap_static medC_static)
--    INSTALL(TARGETS medfwrap_static EXPORT medfileTargetsF DESTINATION lib${LIB_SUFFIX})
-+    INSTALL(TARGETS medfwrap_static EXPORT medfileTargetsF
-+            RUNTIME DESTINATION bin
-+            LIBRARY DESTINATION lib${LIB_SUFFIX}
-+            ARCHIVE DESTINATION lib${LIB_SUFFIX})
-     
-     # Add Static MED library
-     ADD_LIBRARY(med_static STATIC MEDiterators.c)
-@@ -145,7 +154,10 @@
-     TARGET_LINK_LIBRARIES(med_static medfwrap_static)
- 
-     # Install only the resulting library:  
--    INSTALL(TARGETS med_static EXPORT medfileTargetsF DESTINATION lib${LIB_SUFFIX})
-+    INSTALL(TARGETS med_static EXPORT medfileTargetsF
-+            RUNTIME DESTINATION bin
-+            LIBRARY DESTINATION lib${LIB_SUFFIX}
-+            ARCHIVE DESTINATION lib${LIB_SUFFIX})
-   ENDIF()
-   
- ENDIF(CMAKE_Fortran_COMPILER_WORKS)
---- med-4.1.0/src/CMakeLists.txt.orig	2020-10-31 09:11:57.594041300 +0100
-+++ med-4.1.0/src/CMakeLists.txt	2020-10-31 09:15:01.643420300 +0100
+diff -urN med-4.1.1_SRC/src/CMakeLists.txt.orig med-4.1.1_SRC/src/CMakeLists.txt
+--- med-4.1.1_SRC/src/CMakeLists.txt.orig	2021-10-08 13:45:35.000000000 +0200
++++ med-4.1.1_SRC/src/CMakeLists.txt	2022-05-29 17:39:45.281316800 +0200
 @@ -83,7 +83,10 @@
    TARGET_LINK_LIBRARIES(medC ${HDF5_LIBS} ${MPI_LIBS})
    MED_SET_DEFINITIONS(medC NOGDI)
@@ -100,3 +51,51 @@
  ENDIF()
  
  ########################### Fortran stuff ###################################
+@@ -113,7 +119,10 @@
+       SOVERSION 11
+       VERSION   11.1.1)
+     TARGET_LINK_LIBRARIES(medfwrap medC)
+-    INSTALL(TARGETS medfwrap EXPORT ${_export_group} DESTINATION lib${LIB_SUFFIX})
++    INSTALL(TARGETS medfwrap EXPORT ${_export_group}
++            RUNTIME DESTINATION bin
++            LIBRARY DESTINATION lib${LIB_SUFFIX}
++            ARCHIVE DESTINATION lib${LIB_SUFFIX})
+ 
+     # Add Shared MED library
+     ADD_LIBRARY(med SHARED MEDiterators.c)
+@@ -124,7 +133,10 @@
+     TARGET_LINK_LIBRARIES(med medfwrap)    
+    
+     # Install only the resulting library:
+-    INSTALL(TARGETS med EXPORT ${_export_group} DESTINATION lib${LIB_SUFFIX})
++    INSTALL(TARGETS med EXPORT ${_export_group}
++            RUNTIME DESTINATION bin
++            LIBRARY DESTINATION lib${LIB_SUFFIX}
++            ARCHIVE DESTINATION lib${LIB_SUFFIX})
+   ENDIF()
+ 
+   ######### Static Libraries ##########
+@@ -137,7 +149,10 @@
+     ADD_LIBRARY(medfwrap_static STATIC ${medfort_wrap_SOURCES})
+     SET_TARGET_PROPERTIES(medfwrap_static PROPERTIES OUTPUT_NAME medfwrap)
+     TARGET_LINK_LIBRARIES(medfwrap_static medC_static)
+-    INSTALL(TARGETS medfwrap_static EXPORT ${_export_group} DESTINATION lib${LIB_SUFFIX})
++    INSTALL(TARGETS medfwrap_static EXPORT ${_export_group}
++            RUNTIME DESTINATION bin
++            LIBRARY DESTINATION lib${LIB_SUFFIX}
++            ARCHIVE DESTINATION lib${LIB_SUFFIX})
+     
+     # Add Static MED library
+     ADD_LIBRARY(med_static STATIC MEDiterators.c)
+@@ -145,7 +160,10 @@
+     TARGET_LINK_LIBRARIES(med_static medfwrap_static)
+ 
+     # Install only the resulting library:  
+-    INSTALL(TARGETS med_static EXPORT ${_export_group} DESTINATION lib${LIB_SUFFIX})
++    INSTALL(TARGETS med_static EXPORT ${_export_group}
++            RUNTIME DESTINATION bin
++            LIBRARY DESTINATION lib${LIB_SUFFIX}
++            ARCHIVE DESTINATION lib${LIB_SUFFIX})
+   ENDIF()
+   
+ ENDIF(CMAKE_Fortran_COMPILER_WORKS)


### PR DESCRIPTION
Also slightly overhaul the build rule.

It is probably not strictly necessary to rebuild gmsh (its only depend package). But I took the opportunity to build it for clang32 and clang64.