### PR TITLE
doxygen: reduce optimization level for clang32 to avoid crashes

### DIFF
--- a/mingw-w64-doxygen/PKGBUILD
+++ b/mingw-w64-doxygen/PKGBUILD
@@ -4,7 +4,7 @@ _realname=doxygen
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.9.4
-pkgrel=1
+pkgrel=2
 pkgdesc="A documentation system for C++, C, Java, IDL and PHP (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -51,9 +51,16 @@ build() {
   [[ -d build-${MSYSTEM} ]] && rm -rf build-${MSYSTEM}
   mkdir build-${MSYSTEM} && cd build-${MSYSTEM}
 
+  if [[ "${MSYSTEM}" == "CLANG32" ]]; then
+    # https://github.com/msys2/MINGW-packages/issues/11787
+    extra_config+=("-DCMAKE_CXX_FLAGS_RELEASE=-O1 -DNDEBUG")
+    extra_config+=("-DDCMAKE_C_FLAGS_RELEASE=-O1 -DNDEBUG")
+  fi
+
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake \
     -G"Ninja" \
+    "${extra_config[@]}" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DCMAKE_BUILD_TYPE=Release \
     -Dbuild_wizard=ON \

--- a/mingw-w64-doxygen/PKGBUILD
+++ b/mingw-w64-doxygen/PKGBUILD
@@ -26,10 +26,12 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 optdepends=("${MINGW_PACKAGE_PREFIX}-qt6-base")
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/doxygen/doxygen/archive/Release_${pkgver//./_}.tar.gz
         cmake-mingw.patch
-        "0003-remove-git-version-from-bins.patch")
+        "0003-remove-git-version-from-bins.patch"
+        "https://github.com/doxygen/doxygen/commit/5198966c8d5fec89116d025c74934ac03ea511fa.patch")
 sha256sums=('1b083d15b29817463129ae1ae73b930d883030eeec090ea7a99b3a04fdb51c76'
             '7a74cdd4cfaba3f5521b5179a91eec4ad96c1da89534576be356238809df4aa6'
-            'a57e2e680b0a01496d4f84e275e1095a9f092ede6903c63524f15d28884dd0f5')
+            'a57e2e680b0a01496d4f84e275e1095a9f092ede6903c63524f15d28884dd0f5'
+            '69088155ea397ef2593191c059c00a96767a2a602fdedb8f25b3e6c877f2814d')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -44,7 +46,8 @@ prepare() {
 
   apply_patch_with_msg \
     cmake-mingw.patch \
-    0003-remove-git-version-from-bins.patch
+    0003-remove-git-version-from-bins.patch \
+    5198966c8d5fec89116d025c74934ac03ea511fa.patch
 }
 
 build() {


### PR DESCRIPTION
ucvector_resize() will not initialize the the vecotr otherwise and crash.
Not sure if this is a compiler bug, or something else.

Since this only happens with clang32 reduce to -O1 only there
(-O2 and -O3 crash)

Fixes #11787