### PR TITLE
Revert "libgphoto2: build without doxygen"

### DIFF
--- a/mingw-w64-libgphoto2/PKGBUILD
+++ b/mingw-w64-libgphoto2/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libgphoto2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.5.29
-pkgrel=2
+pkgrel=3
 pkgdesc="The libgphoto2 camera access and control library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -20,7 +20,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-libsystre"
          "${MINGW_PACKAGE_PREFIX}-curl"
          "${MINGW_PACKAGE_PREFIX}-libltdl")
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
-             "${MINGW_PACKAGE_PREFIX}-cc")
+             "${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-doxygen")
 source=("https://github.com/gphoto/libgphoto2/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.xz"{,.asc}
         "libgphoto2-gp_system_filename-fix.patch"
         "libgphoto2-configure-ws232.patch")


### PR DESCRIPTION
This reverts commit 5b286a621f2f20ad9e0c0bfd808383537bbe78c0.

Try again after #11789