### PR TITLE
boost: Fix incomplete type error when using list with pair

### DIFF
--- a/mingw-w64-boost/PKGBUILD
+++ b/mingw-w64-boost/PKGBUILD
@@ -8,7 +8,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.79.0
 _boostver=${pkgver//./_}
-pkgrel=2
+pkgrel=3
 pkgdesc="Free peer-reviewed portable C++ source libraries (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -38,7 +38,8 @@ source=(https://boostorg.jfrog.io/artifactory/main/release/${pkgver}/source/boos
         boost-1.73.0-fix-locale-icu.patch
         using-mingw-w64-python.patch
         msys2-mingw-folders-bootstrap.patch
-        https://www.boost.org/patches/1_79_0/0001-json-array-erase-relocate.patch)
+        https://www.boost.org/patches/1_79_0/0001-json-array-erase-relocate.patch
+        boost-1.79.0-fix-container-list-pair.patch)
 sha256sums=('475d589d51a7f8b3ba2ba4eda022b170e562ca3b760ee922c146b6c65856ef39'
             '4551ba9edf64c8ccdab4f4890c20e2e8cf6d4ffa1169d251df11e30d25b886b8'
             'b22196b6415f5e1c0fe56b49a12ea7c20073b15a5f31907f363c7be38d70d628'
@@ -50,7 +51,8 @@ sha256sums=('475d589d51a7f8b3ba2ba4eda022b170e562ca3b760ee922c146b6c65856ef39'
             '5ef2b1011dc960b7f55d4da89bcd75418eb696dce677b9fd0c78632f4109e7d3'
             '5c38e08ba63695afa79a29d5d3ea22ef1ecf79f91d48ae922e1a489e83782742'
             '5117629ee577de0da800b6923675683ba69422cdbe958e70c9081fdc6886402e'
-            '0edcb348b9c6f6ab8c67735881dccd9759af852830ffe651ae51248e24ff11ac')
+            '0edcb348b9c6f6ab8c67735881dccd9759af852830ffe651ae51248e24ff11ac'
+            'd4b0764ada72049fc9ff6cd810dcb567777855a68b3ac75066111fda7ba27273')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -102,6 +104,10 @@ prepare() {
   # https://github.com/boostorg/json/issues/692
   apply_patch_with_msg \
     0001-json-array-erase-relocate.patch
+
+  # https://github.com/boostorg/container/pull/222
+  apply_patch_with_msg \
+    boost-1.79.0-fix-container-list-pair.patch
 }
 
 setb2args() {

--- a/mingw-w64-boost/boost-1.79.0-fix-container-list-pair.patch
+++ b/mingw-w64-boost/boost-1.79.0-fix-container-list-pair.patch
@@ -1,0 +1,36 @@
+From 6f9017dc4c39f0d1f7d8cee431c10760539f46ea Mon Sep 17 00:00:00 2001
+From: Orgad Shaneh <orgad.shaneh@audiocodes.com>
+Date: Mon, 6 Jun 2022 15:33:40 +0300
+Subject: [PATCH] Fix incomplete type error when using list with pair
+
+Example:
+
+boost::container::list<std::pair<int, int>> list;
+
+.../boost/container/allocator_traits.hpp:403:11: error: invalid use of incomplete type 'struct boost::container::dtl::pair<int, int>'
+  403 |    {  p->~T(); (void)p;  }
+      |       ~~~~^
+In file included from .../boost/container/detail/node_alloc_holder.hpp:39,
+                 from .../boost/container/list.hpp:34:
+.../boost/container/detail/is_pair.hpp:59:8: note: declaration of 'struct boost::container::dtl::pair<int, int>'
+   59 | struct pair;
+      |        ^~~~
+---
+ boost/container/list.hpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/boost/container/list.hpp b/boost/container/list.hpp
+index 88fa4c3..23015ec 100644
+--- a/boost/container/list.hpp
++++ b/boost/container/list.hpp
+@@ -32,6 +32,7 @@
+ #include <boost/container/detail/iterators.hpp>
+ #include <boost/container/detail/mpl.hpp>
+ #include <boost/container/detail/node_alloc_holder.hpp>
++#include <boost/container/detail/pair.hpp>
+ #include <boost/container/detail/version_type.hpp>
+ #include <boost/container/detail/value_functors.hpp>
+ // move
+-- 
+2.36.1.windows.1
+


### PR DESCRIPTION
Upstream PR: https://github.com/boostorg/container/pull/222

Example:

```
boost::container::list<std::pair<int, int>> list;
```

```
.../boost/container/allocator_traits.hpp:403:11: error: invalid use of
incomplete type 'struct boost::container::dtl::pair<int, int>'
  403 |    {  p->~T(); (void)p;  }
        |       ~~~~^
In file included from .../boost/container/detail/node_alloc_holder.hpp:39,
                 from .../boost/container/list.hpp:34:
.../boost/container/detail/is_pair.hpp:59:8: note: declaration of 'struct boost::container::dtl::pair<int, int>'
   59 | struct pair;
      |        ^~~~
```