### PR TITLE
msmpi: static linking fix

### DIFF
--- a/mingw-w64-msmpi/PKGBUILD
+++ b/mingw-w64-msmpi/PKGBUILD
@@ -4,7 +4,7 @@ _realname=msmpi
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=10.1.1
-pkgrel=8
+pkgrel=9
 pkgdesc="Microsoft MPI SDK (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -33,7 +33,7 @@ source=(
   'tclbuildtest.tcl'
   'msmpi.test'
 )
-sha256sums=('5d9a3d7b0e5ec90bbede8009b0f8bc82ae5c2fe18d998bbbafa9b14c9e06a0bf'
+sha256sums=('e3c5eb06f5ac4a46853c29954e3b249937a77b3ebed75eb11abab9b286dd93ea'
             'baee3f18f38650e7182956baa0d3d8f8e5c26d8603ccee4871a4dbd160c13660'
             'f3384eeb848164e518edfd2b2b9ff1d0f33e267efd5811d5a7c5f79ef7a0a81e'
             '38e7be31ad555570f6122058317c08504472b8cfd0a198cdad827519b941ba2c'
@@ -105,7 +105,7 @@ package() {
     Version: ${pkgver}
     Description: ${pkgdesc}
     Cflags: -I\${includedir}
-    Libs: -L\${libdir} -l${_realname}
+    Libs: -L\${libdir} -l:libmsmpi.dll.a
   " | sed '/^\s*$/d;s/^\s*//' > "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/${_realname}.pc"
 
 }

--- a/mingw-w64-msmpi/mpi.c
+++ b/mingw-w64-msmpi/mpi.c
@@ -41,7 +41,7 @@ int main(int argc, char** argv) {
 #endif
 	if(!show) for(int x = 1; x < argc; ++x) args[i++] = argv[x];
 	args[i++] = lpath;
-	args[i++] = "-lmsmpi";
+	args[i++] = "-l:libmsmpi.dll.a";
 	args[i] = NULL;
 	if(show) {
 		for(int x = 0; args[x]; ++x) printf("%s ", args[x]);


### PR DESCRIPTION
A follow-up to #11794.

1. Thin archives tend to be fragile.
   - Library stripping destroys thin archives.
   - LLVM's AR seems to produce broken (empty) thin archives.

2. Fixing the `mpi**` drivers is not an option as *-Bdynamic* is a command line -wise option which affects all libraries that follow it, either explicitly specified or implicitly added by the linker. This effectively defeats production of statically linked MPI binaries with `mpi** -static` without severe drivers modifications.

3. No way to use *-Bdynamic* in .pc files for the same reason as in [2].

~~The bottom line: the best option is simply to have `.a` and `.dll.a` archives with the same contents and to let compiler pick the appropriate version based on the supplied options.~~

**UPD**

The `-l:` solution works for both GCC and Clang.