### PR TITLE
graphviz: drop gtk2 dependency

### DIFF
--- a/mingw-w64-graphviz/PKGBUILD
+++ b/mingw-w64-graphviz/PKGBUILD
@@ -4,7 +4,7 @@ _realname=graphviz
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.44.1
-pkgrel=9
+pkgrel=10
 pkgdesc="Graph Visualization Software (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -16,8 +16,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-cairo"
          "${MINGW_PACKAGE_PREFIX}-freetype"
          "${MINGW_PACKAGE_PREFIX}-ghostscript"
          "${MINGW_PACKAGE_PREFIX}-glib2"
-         "${MINGW_PACKAGE_PREFIX}-gtk2"
-         "${MINGW_PACKAGE_PREFIX}-gtkglext"
          "${MINGW_PACKAGE_PREFIX}-fontconfig"
          "${MINGW_PACKAGE_PREFIX}-freeglut"
          "${MINGW_PACKAGE_PREFIX}-libglade"
@@ -135,6 +133,8 @@ build() {
     --with-webp=yes \
     --with-gdiplus=yes \
     --with-smyrna=no \
+    --with-gtk=no \
+    --with-gtkglext=no \
     --with-qt \
     --with-platformsdkincludedir=${MINGW_PREFIX}/${MINGW_CHOST}/include \
     --with-platformsdklibdir=${MINGW_PREFIX}/${MINGW_CHOST}/lib \

--- a/mingw-w64-graphviz/PKGBUILD
+++ b/mingw-w64-graphviz/PKGBUILD
@@ -135,6 +135,7 @@ build() {
     --with-smyrna=no \
     --with-gtk=no \
     --with-gtkglext=no \
+    --with-gdk=no \
     --with-qt \
     --with-platformsdkincludedir=${MINGW_PREFIX}/${MINGW_CHOST}/include \
     --with-platformsdklibdir=${MINGW_PREFIX}/${MINGW_CHOST}/lib \


### PR DESCRIPTION
We want to get rid of gtk2 eventually