### PR TITLE
Python: Use `-O3` level optimization

### DIFF
--- a/mingw-w64-python/PKGBUILD
+++ b/mingw-w64-python/PKGBUILD
@@ -355,7 +355,7 @@ build() {
     _extra_config+=("--enable-optimizations")
     # PGO should be done with -O3
     CFLAGS="${CFLAGS/-O2/-O3}"
-    CFLAGS+=$([[ ${MINGW_PACKAGE_PREFIX} == *-clang* ]] || echo " -ffat-lto-objects")
+    # CFLAGS+=$([[ ${MINGW_PACKAGE_PREFIX} == *-clang* ]] || echo " -ffat-lto-objects")
     # FIXME: https://github.com/msys2-contrib/cpython-mingw/issues/10
     # _extra_config+=("--with-lto")
   else

--- a/mingw-w64-python/PKGBUILD
+++ b/mingw-w64-python/PKGBUILD
@@ -353,8 +353,10 @@ build() {
   declare -a _extra_config
   if check_option "debug" "n"; then
     _extra_config+=("--enable-optimizations")
+
     # PGO should be done with -O3
-    CFLAGS="${CFLAGS/-O2/-O3}"
+    # CFLAGS="${CFLAGS/-O2/-O3}"
+    CFLAGS+=" -O3"
     # CFLAGS+=$([[ ${MINGW_PACKAGE_PREFIX} == *-clang* ]] || echo " -ffat-lto-objects")
     # FIXME: https://github.com/msys2-contrib/cpython-mingw/issues/10
     # _extra_config+=("--with-lto")

--- a/mingw-w64-python/PKGBUILD
+++ b/mingw-w64-python/PKGBUILD
@@ -353,11 +353,8 @@ build() {
   declare -a _extra_config
   if check_option "debug" "n"; then
     _extra_config+=("--enable-optimizations")
-
-    # PGO should be done with -O3
-    # CFLAGS="${CFLAGS/-O2/-O3}"
+    # Upstream defaults to -O3, so we can do too
     CFLAGS+=" -O3"
-    # CFLAGS+=$([[ ${MINGW_PACKAGE_PREFIX} == *-clang* ]] || echo " -ffat-lto-objects")
     # FIXME: https://github.com/msys2-contrib/cpython-mingw/issues/10
     # _extra_config+=("--with-lto")
   else

--- a/mingw-w64-python/PKGBUILD
+++ b/mingw-w64-python/PKGBUILD
@@ -353,6 +353,9 @@ build() {
   declare -a _extra_config
   if check_option "debug" "n"; then
     _extra_config+=("--enable-optimizations")
+    # PGO should be done with -O3
+    CFLAGS="${CFLAGS/-O2/-O3}"
+    CFLAGS+=$([[ ${MINGW_PACKAGE_PREFIX} == *-clang* ]] || echo " -ffat-lto-objects")
     # FIXME: https://github.com/msys2-contrib/cpython-mingw/issues/10
     # _extra_config+=("--with-lto")
   else

--- a/mingw-w64-python/PKGBUILD
+++ b/mingw-w64-python/PKGBUILD
@@ -22,7 +22,7 @@ else
   pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}${_pybasever}")
 fi
 pkgver=${_pybasever}.5
-pkgrel=1
+pkgrel=2
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')

--- a/mingw-w64-python/update-patches.sh
+++ b/mingw-w64-python/update-patches.sh
@@ -8,7 +8,7 @@ die () {
 }
 
 cd "$(dirname "$0")" ||
-die "Could not cd to mingw-w64-python3.9/"
+die "Could not cd to mingw-w64-python3.10/"
 
 git rev-parse --verify HEAD >/dev/null &&
 git update-index -q --ignore-submodules --refresh &&


### PR DESCRIPTION
Python now is compiled with `-O2` level optimization, which makes it obviously slower than official python compiled by MSVC with the max optimization level.

For a simple test:
``` python
from timeit import default_timer as timer
import os

def plus():
    a = 0
    for x in range(100000000):
        a += 1

def minus():
    a = 100000000
    for x in range(100000000):
        a -= 1

def multiply():
    a = 1
    for x in range(100000000):
        a *= 1.00000003

def divide():
    a = 1000000000
    for x in range(100000000):
        a /= 1.00000003

if __name__ == '__main__':
    s = timer()
    plus()
    e = timer()
    print('Plus:',round(100000000/(e-s)/1000000,2),'M/s')
    s = timer()
    minus()
    e = timer()
    print('Minus:',round(100000000/(e-s)/1000000,2),'M/s')
    s = timer()
    multiply()
    e = timer()
    print('Multiply:',round(100000000/(e-s)/1000000,2),'M/s')
    s = timer()
    divide()
    e = timer()
    print('Divide:',round(100000000/(e-s)/1000000,2),'M/s')
    
    input("\nPlease press \"Enter\" key to exit . . .")
```

Official python built with MSVC:
``` powershell
Plus: 39.06 M/s
Minus: 36.23 M/s
Multiply: 36.65 M/s
Divide: 38.08 M/s

Please press "Enter" key to exit . . .
```

Python in MSYS2(UCRT64) with `-O2` level optimization:
``` powershell
Plus: 32.37 M/s
Minus: 32.86 M/s
Multiply: 32.84 M/s
Divide: 32.52 M/s

Please press "Enter" key to exit . . .
```

Python in MSYS2(UCRT64) with `-O3` level optimization:
``` powershell
Plus: 38.3 M/s
Minus: 37.98 M/s
Multiply: 41.9 M/s
Divide: 38.33 M/s

Please press "Enter" key to exit . . .
```

And **archlinux** also used [**`-O3`** level optimization](https://github.com/archlinux/svntogit-packages/blob/dff680229ec36d8a4a2fe75fb225c8ae94142806/trunk/PKGBUILD#L43), so we may change to `-O3` optimization for performance.