### PR TITLE
python-tomli: don't depend on python-build/installer

### DIFF
--- a/mingw-w64-python-tomli/PKGBUILD
+++ b/mingw-w64-python-tomli/PKGBUILD
@@ -4,27 +4,30 @@ _realname=tomli
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=2.0.1
-pkgrel=2
+pkgrel=3
 pkgdesc="A lil' TOML parser (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url='https://github.com/hukkin/tomli'
 license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-python")
-makedepends=(
-  "${MINGW_PACKAGE_PREFIX}-python-build"
-  "${MINGW_PACKAGE_PREFIX}-python-installer"
-  "${MINGW_PACKAGE_PREFIX}-python-flit-core")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest" 
               "${MINGW_PACKAGE_PREFIX}-python-dateutil")
-source=("${_realname}-$pkgver.tar.gz"::"$url/archive/$pkgver.tar.gz")
-sha256sums=('ad22dbc128623e0c156ffaff019f29f456eba8a5d5a05164dd34f63e560449df')
+source=("${_realname}-$pkgver.tar.gz"::"$url/archive/$pkgver.tar.gz"
+        "https://pypi.debian.net/tomli/tomli-$pkgver-py3-none-any.whl"
+        "install_wheel.py")
+sha256sums=('ad22dbc128623e0c156ffaff019f29f456eba8a5d5a05164dd34f63e560449df'
+            '939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc'
+            '668e64f912d6360330c403edb6100b21f6aa6dd6a7803d342fab8c35d8176ad9')
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
-  cd "${srcdir}/python-build-${MSYSTEM}"
+  cd "python-build-${MSYSTEM}"
 
-  python -m build --wheel --skip-dependency-check --no-isolation
+  # Don't use python-build to make bootstrapping easier
+  # python -m build --wheel --skip-dependency-check --no-isolation
+  mkdir dist
+  cp "${srcdir}/tomli-$pkgver-py3-none-any.whl" dist
 }
 
 check() {
@@ -36,8 +39,16 @@ check() {
 package() {
   cd "${srcdir}/python-build-${MSYSTEM}"
 
-  MSYS2_ARG_CONV_EXCL="--prefix=" \
-    python -m installer --prefix=${MINGW_PREFIX} --destdir="${pkgdir}" dist/*.whl
+  # Don't use python-installer to make bootstrapping easier
+  # MSYS2_ARG_CONV_EXCL="--prefix=" \
+  #   python -m installer --prefix=${MINGW_PREFIX} --destdir="${pkgdir}" dist/*.whl
+
+  _pythonpath=`python -c "import sysconfig; print(sysconfig.get_path('platlib'))"`
+  _site_packages="${pkgdir}$(cygpath ${_pythonpath})"
+  mkdir -p "$_site_packages"
+  python "${srcdir}/install_wheel.py" -i"${_site_packages}" dist/*.whl
+  MSYS2_ARG_CONV_EXCL="-p" python -m compileall \
+    -o 0 -o 1 -q -s"${pkgdir}" -p"/" "${pkgdir}${MINGW_PREFIX}/lib/python"*
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
 }

--- a/mingw-w64-python-tomli/install_wheel.py
+++ b/mingw-w64-python-tomli/install_wheel.py
@@ -1,0 +1,33 @@
+import argparse
+import sys
+import sysconfig
+from pathlib import Path
+from zipfile import ZipFile
+
+def extract_wheel(whl_path, dest):
+    print("Installing to", dest)
+    with ZipFile(whl_path) as zf:
+        zf.extractall(dest)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'wheel',
+        type=Path,
+        help=f'wheel to install (.whl file)',
+    )
+    purelib = Path(sysconfig.get_path('purelib')).resolve()
+    parser.add_argument(
+        '--installdir',
+        '-i',
+        type=Path,
+        default=purelib,
+        help=f'installdir directory (defaults to {purelib})',
+    )
+
+    args = parser.parse_args()
+
+    if not args.installdir.is_dir():
+        sys.exit(f"{args.installdir} is not a directory")
+
+    extract_wheel(args.wheel, args.installdir)


### PR DESCRIPTION
install manually for bootstrapping