### PR TITLE
binutils: add prefixed executables

### DIFF
--- a/mingw-w64-binutils/PKGBUILD
+++ b/mingw-w64-binutils/PKGBUILD
@@ -6,7 +6,7 @@ _realname=binutils
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.38
-pkgrel=3
+pkgrel=4
 pkgdesc="A set of programs to assemble and manipulate binary and object files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -128,6 +128,13 @@ package() {
   rm "${pkgdir}${MINGW_PREFIX}/lib/bfd-plugins/libdep.a"
 
   find ${pkgdir}${MINGW_PREFIX}/share -type f -iname "opcodes.mo" -o -iname "bfd.mo" | xargs -rtl1 rm
+  
+  pushd ${pkgdir}${MINGW_PREFIX}/bin
+  for x in *.exe; do 
+     t=${MINGW_CHOST}-${x}
+     cp $x $t && echo "cp $x -> $t"
+  done
+  popd
 
   install -Dm644 ${srcdir}/${_realname}-${pkgver}/COPYING      ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING
   install -Dm644 ${srcdir}/${_realname}-${pkgver}/COPYING.LIB  ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.LIB


### PR DESCRIPTION
Fixed https://github.com/msys2/MSYS2-packages/issues/2595 by copying executables and add prefix.