### PR TITLE
wxWidgets3.1: Add new wx/filedlgcustomize.h to the list of files installed

### DIFF
--- a/mingw-w64-wxWidgets3.1/PKGBUILD
+++ b/mingw-w64-wxWidgets3.1/PKGBUILD
@@ -19,7 +19,7 @@ _wx_buildver=
 pkgbase=mingw-w64-${_basename}${_wx_basever}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}${_wx_basever}"
 pkgver=${_wx_basever}.7
-pkgrel=1
+pkgrel=2
 pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -46,11 +46,15 @@ source=(
 
   # This is needed to build clang samples in check step
   010-wxWidgets-3.1.6-Redo-manifest-filename-logic.patch
+
+  # git master change that adds wx/filedlgcustomize.h to installation
+  https://github.com/wxWidgets/wxWidgets/commit/96cb1b5d7dd208372bf93d61d5072e43b8233c29.diff
 )
 sha256sums=('3d666e47d86192f085c84089b850c90db7a73a5d26b684b617298d89dce84f19'
             '2b3b183a6a76ad539abc49a41033aa923c13b395c0e55189ba962068781c7135'
             '4a4828f0c9cdc638cffde6a30b5dfb14283719acc9e89e19de8ec2d5a80a5aec'
-            'b30100e03f350e14060923781c3c7979735cc81996a13012bef980a23eb3d20b')
+            'b30100e03f350e14060923781c3c7979735cc81996a13012bef980a23eb3d20b'
+            '4750705c01eeb2b63e85c3a8e9670ebfc18e17e049067de572400181000cde18')
 prepare() {
   cd "${srcdir}"/${_basename}-${pkgver}${_wx_buildver}
 
@@ -62,6 +66,8 @@ prepare() {
   patch -p1 -i "${srcdir}"/005-wxWidgets-3.1.3-Remove-WX_LIBS_STATIC-from-m4.patch
 
   patch -p1 -i "${srcdir}"/010-wxWidgets-3.1.6-Redo-manifest-filename-logic.patch
+
+  patch -p1 -i "${srcdir}"/96cb1b5d7dd208372bf93d61d5072e43b8233c29.diff
 }
 
 build() {


### PR DESCRIPTION

My update to wxPython is complaining about missing wx/filedlgcustomize.h header.
And, wxWidgets git just added a fix that I am working on testing; still a few hours before test is finished.
The patch file is the git commit that is supposed to add the header.

Tim S.