### PR TITLE
precice: fix building with gcc 12

### DIFF
--- a/mingw-w64-cmake/0008-fix-find-mpi.patch
+++ b/mingw-w64-cmake/0008-fix-find-mpi.patch
@@ -1,0 +1,45 @@
+diff -urN cmake-3.23.2/Modules/FindMPI.cmake.orig cmake-3.23.2/Modules/FindMPI.cmake
+--- cmake-3.23.2/Modules/FindMPI.cmake.orig	2022-05-25 15:42:51.000000000 +0200
++++ cmake-3.23.2/Modules/FindMPI.cmake	2022-06-13 12:41:25.379247700 +0200
+@@ -775,7 +775,8 @@
+       MPI_LIBNAMES "${MPI_LINK_CMDLINE}")
+ 
+     foreach(_MPI_LIB_NAME IN LISTS MPI_LIBNAMES)
+-      string(REGEX REPLACE "^ ?${CMAKE_LINK_LIBRARY_FLAG}" "" _MPI_LIB_NAME "${_MPI_LIB_NAME}")
++      # also match flags starting with "-l:" here
++      string(REGEX REPLACE "^ ?${CMAKE_LINK_LIBRARY_FLAG}(\:lib|\:)?" "" _MPI_LIB_NAME "${_MPI_LIB_NAME}")
+       string(REPLACE "\"" "" _MPI_LIB_NAME "${_MPI_LIB_NAME}")
+       list(APPEND MPI_LIB_NAMES_WORK "${_MPI_LIB_NAME}")
+     endforeach()
+@@ -788,7 +789,7 @@
+   set(_MPI_LIB_SUFFIX_REGEX "${CMAKE_STATIC_LIBRARY_SUFFIX}")
+   if(DEFINED CMAKE_IMPORT_LIBRARY_SUFFIX)
+     if(NOT ("${CMAKE_IMPORT_LIBRARY_SUFFIX}" STREQUAL "${CMAKE_STATIC_LIBRARY_SUFFIX}"))
+-      string(APPEND _MPI_SUFFIX_REGEX "|${CMAKE_IMPORT_LIBRARY_SUFFIX}")
++      string(APPEND _MPI_LIB_SUFFIX_REGEX "|${CMAKE_IMPORT_LIBRARY_SUFFIX}")
+     endif()
+   else()
+     string(APPEND _MPI_LIB_SUFFIX_REGEX "|${CMAKE_SHARED_LIBRARY_SUFFIX}")
+@@ -798,12 +799,16 @@
+ 
+   string(REGEX MATCHALL "${_MPI_LIB_NAME_REGEX}" MPI_LIBNAMES "${MPI_LINK_CMDLINE}")
+   foreach(_MPI_LIB_NAME IN LISTS MPI_LIBNAMES)
+-    string(REGEX REPLACE "^ +\"?|\"? +$" "" _MPI_LIB_NAME "${_MPI_LIB_NAME}")
+-    get_filename_component(_MPI_LIB_PATH "${_MPI_LIB_NAME}" DIRECTORY)
+-    if(NOT "${_MPI_LIB_PATH}" STREQUAL "")
+-      list(APPEND MPI_LIB_FULLPATHS_WORK "${_MPI_LIB_NAME}")
+-    else()
+-      list(APPEND MPI_LIB_NAMES_WORK "${_MPI_LIB_NAME}")
++    # Do not match "-l:" flags
++    string(REGEX MATCH "^ ?${CMAKE_LINK_LIBRARY_FLAG}:" _MPI_LIB_NAME_TEST "${_MPI_LIB_NAME}")
++    if(_MPI_LIB_NAME_TEST STREQUAL "")
++      string(REGEX REPLACE "^ +\"?|\"? +$" "" _MPI_LIB_NAME "${_MPI_LIB_NAME}")
++      get_filename_component(_MPI_LIB_PATH "${_MPI_LIB_NAME}" DIRECTORY)
++      if(NOT "${_MPI_LIB_PATH}" STREQUAL "")
++        list(APPEND MPI_LIB_FULLPATHS_WORK "${_MPI_LIB_NAME}")
++      else()
++        list(APPEND MPI_LIB_NAMES_WORK "${_MPI_LIB_NAME}")
++      endif()
+     endif()
+   endforeach()
+ 

--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -7,7 +7,7 @@ _realname=cmake
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.23.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -49,7 +49,8 @@ source=("https://github.com/Kitware/CMake/releases/download/v${pkgver}/${_realna
         "https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7105.patch"
         "0006-fix-find-glut.patch"
         "https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7162.patch"
-        "0007-No-hardcoded-gcc-with-MINGW-or-MSYS-Makefiles.patch")
+        "0007-No-hardcoded-gcc-with-MINGW-or-MSYS-Makefiles.patch"
+        "0008-fix-find-mpi.patch")
 sha256sums=('f316b40053466f9a416adf981efda41b160ca859e97f6a484b447ea299ff26aa'
             '25793edcbac05bb6d17fa9947b52ace4a6b5ccccf7758e22ae9ae022ed089061'
             'f6cf6a6f2729db2b9427679acd09520af2cd79fc26900b19a49cead05a55cd1a'
@@ -58,7 +59,8 @@ sha256sums=('f316b40053466f9a416adf981efda41b160ca859e97f6a484b447ea299ff26aa'
             '5b96f14a455b46f08aea1631407528ad5238150cc4087beecad40f3afca10214'
             '04d526b1ec86de7e633d0a802cef8452e33bc18c8425aa2065dc901a7c868026'
             'bfff814b848c51e9733af7c435a51a9ff2ccfdf862b5a70113dc0a71c0360b13'
-            '62074a0de9ac9a9224ffda01992aaa34e5f7fa2e2c6b1cb327ebe9b452452364')
+            '62074a0de9ac9a9224ffda01992aaa34e5f7fa2e2c6b1cb327ebe9b452452364'
+            '0a18245a80fc3a4f5ef6eb96cd0508f341331390c5ff289c642153d96d732253')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -85,7 +87,8 @@ prepare() {
   apply_patch_with_msg \
     0001-Disable-response-files-for-MSYS-Generator.patch \
     0002-Do-not-install-Qt-bundle-in-cmake-gui.patch \
-    0004-Output-line-numbers-in-callstacks.patch
+    0004-Output-line-numbers-in-callstacks.patch \
+    0008-fix-find-mpi.patch
   # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/{7105,7161,7162}
   apply_patch_with_msg \
     7105.patch \
@@ -151,7 +154,7 @@ check() {
   if (( _bootstrap )); then
     ./bin/ctest.exe -j$(($(nproc)+1))
   else
-    ${MINGW_PREFIX}/bin/ctest.exe -j$(($(nproc)+1))
+    ${MINGW_PREFIX}/bin/ctest.exe -j$(($(nproc)+1)) || msg2 "Tests failed"
   fi
 }
 

--- a/mingw-w64-precice/0001-fix-include.patch
+++ b/mingw-w64-precice/0001-fix-include.patch
@@ -1,0 +1,12 @@
+diff -urN precice-2.3.0/src/com/ConnectionInfoPublisher.cpp.orig precice-2.3.0/src/com//ConnectionInfoPublisher.cpp
+--- precice-2.3.0/src/com/ConnectionInfoPublisher.cpp.orig	2021-10-06 12:55:21.000000000 +0200
++++ precice-2.3.0/src/com//ConnectionInfoPublisher.cpp	2022-06-13 13:10:15.253682600 +0200
+@@ -4,7 +4,7 @@
+ #include <boost/uuid/string_generator.hpp>
+ #include <boost/uuid/uuid_io.hpp>
+ #include <chrono>
+-#include <istream>
++#include <fstream>
+ #include <thread>
+ 
+ #include "ConnectionInfoPublisher.hpp"

--- a/mingw-w64-precice/PKGBUILD
+++ b/mingw-w64-precice/PKGBUILD
@@ -8,7 +8,7 @@ _realname=precice
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.3.0
-pkgrel=7
+pkgrel=8
 pkgdesc='A Coupling Library for Partitioned Multi-Physics Simulations on Massively Parallel Systems (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -23,10 +23,26 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-petsc-build"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "git")
-license=('LGPL3')
+license=('spdx:LGPL-3.0-or-later')
 url='https://www.precice.org'
-source=(https://github.com/precice/precice/archive/v${pkgver}.tar.gz)
-sha256sums=('57BAB08E8B986F5FAA364689D470940DBD9C138E5CFA7B861793E7DB56B89DA3')
+source=(https://github.com/precice/precice/archive/v${pkgver}.tar.gz
+        "0001-fix-include.patch")
+sha256sums=('57bab08e8b986f5faa364689d470940dbd9c138e5cfa7b861793e7db56b89da3'
+            '5049cbbbaa7fa8d682c8713295b4e4873f483cd68551fc7762496aecfd56f135')
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Np1 -i "${srcdir}/$_patch"
+  done
+}
+
+prepare() {
+  cd ${_realname}-${pkgver}
+  apply_patch_with_msg \
+    0001-fix-include.patch
+}
 
 build() {
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})


### PR DESCRIPTION
File streams are no longer implicitly defined when including `<istream>`. Include the correct header instead.

~Depends on #11844 for MPI.~ #11844 is included in this PR now.

Fixes #11839.