### PR TITLE
prjtrellis: no longer build Python library for mingw32

### DIFF
--- a/mingw-w64-prjtrellis/PKGBUILD
+++ b/mingw-w64-prjtrellis/PKGBUILD
@@ -3,13 +3,13 @@
 _realname=prjtrellis
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.0.r1033.3ae21cf
-pkgrel=2
+pkgver=1.2.1
+pkgrel=1
 pkgdesc="Documenting the Lattice ECP5 bit-stream format (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://github.com/YosysHQ/prjtrellis"
-license=('MIT')
+license=('spdx:MIT')
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
 depends=(
   "${MINGW_PACKAGE_PREFIX}-boost"
@@ -22,26 +22,20 @@ makedepends=(
   "git"
 )
 
-_commit="3ae21cf6"
-source=("${_realname}::git+https://github.com/YosysHQ/${_realname}.git#commit=${_commit}"
-        "prjtrellis-db::git+https://github.com/YosysHQ/prjtrellis-db")
-sha256sums=('SKIP'
+_commit_db='35d900a94ff0db152679a67bf6e4fbf40ebc34aa'
+
+source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/YosysHQ/prjtrellis/archive/refs/tags/${pkgver}.tar.gz"
+        "${_realname}-db"::"git+https://github.com/YosysHQ/prjtrellis-db.git#commit=${_commit_db}")
+sha256sums=('561f7881dc6d39c7ac47721e19aed533c230b47a684aa9a0c3dae08cdc3d8dbb'
             'SKIP')
 
-pkgver() {
-  cd "${_realname}"
-  printf "1.0.r%s.%s" "$(git rev-list --count "${_commit}")" "$(git rev-parse --short "${_commit}")"
-}
-
 prepare () {
-  cd "${_realname}"
-  git submodule init
-  git config submodule.database.url $srcdir/prjtrellis-db
-  git submodule update
+  cd "${srcdir}/${_realname}-db"
+  cp -r * "${srcdir}/${_realname}-${pkgver}/database/"
 }
 
 build() {
-  cd "${srcdir}/${_realname}"/libtrellis
+  cd "${srcdir}/${_realname}-${pkgver}"/libtrellis
 
   MSYS2_ARG_CONV_EXCL='-DCMAKE_INSTALL_PREFIX=' cmake \
     -G "MSYS Makefiles" \
@@ -52,7 +46,7 @@ build() {
 }
 
 check() {
-  cd "${srcdir}/${_realname}"/libtrellis
+  cd "${srcdir}/${_realname}-${pkgver}"/libtrellis
   for item in ecpbram ecpmulti ecppack ecppll ecpunpack; do
     echo "> Check $item"
     ./"$item" --help
@@ -60,10 +54,8 @@ check() {
 }
 
 package() {
-  cd "${srcdir}/${_realname}"/libtrellis
+  cd "${srcdir}/${_realname}-${pkgver}"/libtrellis
   make DESTDIR="${pkgdir}" install
 
-  _licenses="${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
-  mkdir -p "${_licenses}"
-  install -m 644 "${srcdir}/${_realname}"/COPYING "${_licenses}"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}"/COPYING "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname}/LICENSE
 }

--- a/mingw-w64-prjtrellis/PKGBUILD
+++ b/mingw-w64-prjtrellis/PKGBUILD
@@ -13,7 +13,7 @@ license=('spdx:MIT')
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
 depends=(
   "${MINGW_PACKAGE_PREFIX}-boost"
-  "${MINGW_PACKAGE_PREFIX}-python"
+  $([[ ${MSYSTEM} == MINGW32 ]] || echo "${MINGW_PACKAGE_PREFIX}-python")  # memory footprint of cc1plus is too large for mingw32
 )
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-boost"
@@ -39,11 +39,16 @@ build() {
   [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
+  if [[ ${MSYSTEM} == MINGW32 ]]; then
+    _python_opt="-DBUILD_PYTHON=OFF"
+  fi
+
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     "${MINGW_PREFIX}"/bin/cmake.exe \
       -GNinja \
       -DCMAKE_PREFIX_PATH="${MINGW_PREFIX}" \
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      ${_python_opt} \
       ../${_realname}-${pkgver}/libtrellis
 
   "${MINGW_PREFIX}"/bin/cmake.exe --build .

--- a/mingw-w64-prjtrellis/PKGBUILD
+++ b/mingw-w64-prjtrellis/PKGBUILD
@@ -36,19 +36,21 @@ prepare () {
 }
 
 build() {
-  cd "${srcdir}/${_realname}-${pkgver}"/libtrellis
+  [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
   MSYS2_ARG_CONV_EXCL='-DCMAKE_INSTALL_PREFIX=' cmake \
     -GNinja \
     -DCMAKE_PREFIX_PATH=${MINGW_PREFIX} \
     -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
-    .
+    ../${_realname}-${pkgver}/libtrellis
 
   "${MINGW_PREFIX}"/bin/cmake.exe --build .
 }
 
 check() {
-  cd "${srcdir}/${_realname}-${pkgver}"/libtrellis
+  cd "${srcdir}/build-${MSYSTEM}"
+
   for item in ecpbram ecpmulti ecppack ecppll ecpunpack; do
     echo "> Check $item"
     ./"$item" --help
@@ -56,7 +58,7 @@ check() {
 }
 
 package() {
-  cd "${srcdir}/${_realname}-${pkgver}"/libtrellis
+  cd "${srcdir}/build-${MSYSTEM}"
 
   DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
 

--- a/mingw-w64-prjtrellis/PKGBUILD
+++ b/mingw-w64-prjtrellis/PKGBUILD
@@ -39,11 +39,12 @@ build() {
   [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
-  MSYS2_ARG_CONV_EXCL='-DCMAKE_INSTALL_PREFIX=' cmake \
-    -GNinja \
-    -DCMAKE_PREFIX_PATH=${MINGW_PREFIX} \
-    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
-    ../${_realname}-${pkgver}/libtrellis
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    "${MINGW_PREFIX}"/bin/cmake.exe \
+      -GNinja \
+      -DCMAKE_PREFIX_PATH="${MINGW_PREFIX}" \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      ../${_realname}-${pkgver}/libtrellis
 
   "${MINGW_PREFIX}"/bin/cmake.exe --build .
 }
@@ -52,7 +53,7 @@ check() {
   cd "${srcdir}/build-${MSYSTEM}"
 
   for item in ecpbram ecpmulti ecppack ecppll ecpunpack; do
-    echo "> Check $item"
+    msg2 "Check $item"
     ./"$item" --help
   done
 }

--- a/mingw-w64-prjtrellis/PKGBUILD
+++ b/mingw-w64-prjtrellis/PKGBUILD
@@ -19,6 +19,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-boost"
   "${MINGW_PACKAGE_PREFIX}-cc"
   "${MINGW_PACKAGE_PREFIX}-cmake"
+  "${MINGW_PACKAGE_PREFIX}-ninja"
   "git"
 )
 
@@ -38,11 +39,12 @@ build() {
   cd "${srcdir}/${_realname}-${pkgver}"/libtrellis
 
   MSYS2_ARG_CONV_EXCL='-DCMAKE_INSTALL_PREFIX=' cmake \
-    -G "MSYS Makefiles" \
+    -GNinja \
     -DCMAKE_PREFIX_PATH=${MINGW_PREFIX} \
     -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
     .
-  make
+
+  "${MINGW_PREFIX}"/bin/cmake.exe --build .
 }
 
 check() {
@@ -55,7 +57,8 @@ check() {
 
 package() {
   cd "${srcdir}/${_realname}-${pkgver}"/libtrellis
-  make DESTDIR="${pkgdir}" install
+
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}"/COPYING "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname}/LICENSE
 }


### PR DESCRIPTION
Build from release tarball.

The memory footprint of `cc1plus` is too large during compilation of `PyTrellis.cpp`. It fails with `cc1plus.exe: out of memory allocating 65536 bytes`. Maybe something in GCC (or Boost?) changed since this was last compiled that makes it require too much memory now. When building in a MINGW64 environment, the memory footprint peaks at about 4.1 GiB. IIUC, the maximum memory footprint for one 32-bit process on Windows is 2 GiB. If the 32-bit executable would require approx. half as much memory as the 64-bit one, that would still be too much (and it looks like it *is* too much).

See also #11837.

@umarcor: Is this change ok?
Does it make sense to skip building the Python library on mingw32 and continue building the remainder? Is that still useful?