### PR TITLE
postgis: update to 3.2.1

### DIFF
--- a/mingw-w64-postgis/0001-clang-postgresql.patch
+++ b/mingw-w64-postgis/0001-clang-postgresql.patch
@@ -1,0 +1,11 @@
+diff -urN postgis-3.2.1/postgis/Makefile.in.orig postgis-3.2.1/postgis/Makefile.in
+--- postgis-3.2.1/postgis/Makefile.in.orig	2022-02-13 01:55:42.000000000 +0100
++++ postgis-3.2.1/postgis/Makefile.in	2022-06-14 21:57:44.114299000 +0200
+@@ -178,6 +178,7 @@
+ # may be confusing and out-of-control for the builder of
+ # PostGIS
+ LDFLAGS = @LDFLAGS@
++LIBS = @LIBS@
+ 
+ # If REGRESS=1 passed as a parameter, change the default install paths
+ # so that no prefix is included. This allows us to relocate to a temporary

--- a/mingw-w64-postgis/PKGBUILD
+++ b/mingw-w64-postgis/PKGBUILD
@@ -3,13 +3,13 @@
 _realname=postgis
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.1.4
-pkgrel=5
+pkgver=3.2.1
+pkgrel=1
 pkgdesc="Spatial and Geographic objects for PostgreSQL (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://postgis.net/"
-license=('GPL2')
+license=('spdx:GPL-2.0-or-later')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc" "${MINGW_PACKAGE_PREFIX}-autotools")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-geos"
@@ -22,12 +22,27 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-gdal")
 options=('staticlibs' 'strip')
 source=("https://download.osgeo.org/postgis/source/${_realname}-${pkgver}.tar.gz"
-        pg_config)
-sha256sums=('dc8e3fe8bc532e422f5d724c5a7c437f6555511716f6410d4d2db9762e1a3796'
-            '3cd5a095cd4de7cb7d5f5fa9dbc02dfe02297ae1743c2961e70d9110d214f64f')
+        pg_config
+        0001-clang-postgresql.patch)
+sha256sums=('fbab68dde6ca3934b24ba08c8ab0cff2594f57f93deab41a15c82ae1bb69893e'
+            '3cd5a095cd4de7cb7d5f5fa9dbc02dfe02297ae1743c2961e70d9110d214f64f'
+            '5e3a39bdacbbb6825206df61c49a0479da8d6201ff78423fc0bdbeaf44b70e3d')
+
+apply_patch_with_msg() {
+  for _fname in "$@"
+  do
+    msg2 "Applying ${_fname}"
+    patch -Nbp1 -i "${srcdir}"/${_fname}
+  done
+}
 
 prepare() {
   cd ${_realname}-${pkgver}
+
+  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
+    apply_patch_with_msg \
+      0001-clang-postgresql.patch
+  fi
 
   ./autogen.sh
 }
@@ -35,6 +50,13 @@ prepare() {
 build() {
   [[ -d "${srcdir}"/build-${MSYSTEM} ]] && rm -rf "${srcdir}"/build-${MSYSTEM}
   cp -r ${_realname}-${pkgver} "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
+
+  CXXFLAGS+=" -std=gnu++17"
+
+  # workaround to fix linking PostgreSQL with clang
+  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
+    export LIBS="-lc++"
+  fi
 
   ./configure \
     --prefix=${MINGW_PREFIX} \


### PR DESCRIPTION
Fix compilation with GCC 12.
Workaround issue when trying to link C++ archives with `clang` in PostgreSQL's `Makefile.shlib`.