### PR TITLE
[PostGIS] Enable SFCGAL

### DIFF
--- a/mingw-w64-postgis/PKGBUILD
+++ b/mingw-w64-postgis/PKGBUILD
@@ -4,7 +4,7 @@ _realname=postgis
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.1.4
-pkgrel=5
+pkgrel=6
 pkgdesc="Spatial and Geographic objects for PostgreSQL (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -19,7 +19,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-postgresql"
          #"${MINGW_PACKAGE_PREFIX}-protobuf-c"
          "${MINGW_PACKAGE_PREFIX}-proj"
-         "${MINGW_PACKAGE_PREFIX}-gdal")
+         "${MINGW_PACKAGE_PREFIX}-gdal"
+         "${MINGW_PACKAGE_PREFIX}-sfcgal")
 options=('staticlibs' 'strip')
 source=("https://download.osgeo.org/postgis/source/${_realname}-${pkgver}.tar.gz"
         pg_config)


### PR DESCRIPTION
> SFCGAL is a C++ wrapper library around CGAL with the aim of supporting ISO 19107:2013 and OGC Simple Features Access 1.2 for 3D operations.
> SFCGAL provides standard compliant geometry types and operations, that can be accessed from its C or C++ APIs. PostGIS uses the C API, to expose some SFCGAL's functions in spatial databases (cf. PostGIS manual).

SFCGAL has been added in https://github.com/msys2/MINGW-packages/pull/10294

PostGIS can use SFCGAL for some [avanced 2D and 3D functions](https://postgis.net/docs/reference.html#reference_sfcgal)

