### PR TITLE
pyqt-builder: remove extra output when queried variable is empty

### DIFF
--- a/mingw-w64-pyqt-builder/001-mingw-python.patch
+++ b/mingw-w64-pyqt-builder/001-mingw-python.patch
@@ -43,16 +43,12 @@
                      '}'])
  
          # Add any installables from the buildable.
-@@ -501,7 +505,11 @@
-                     raise UserException(
+@@ -501,6 +505,8 @@
                              "Unexpected output from qmake: '{0}'".format(line))
  
--                name, value = tokens
-+                if sysconfig._POSIX_BUILD and "MSYSTEM" in os.environ:
-+                    name = tokens[0]
-+                    value = os.popen(' '.join(['cygpath', '--unix', tokens[1]])).readline().strip()
-+                else:
-+                    name, value = tokens
+                 name, value = tokens
++                if sysconfig._POSIX_BUILD and "MSYSTEM" in os.environ and value != "":
++                    value = os.popen(' '.join(['cygpath', '--unix', value])).readline().strip()
              else:
                  name = tokens
                  value = None

--- a/mingw-w64-pyqt-builder/PKGBUILD
+++ b/mingw-w64-pyqt-builder/PKGBUILD
@@ -5,7 +5,7 @@ _realname=pyqt-builder
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.12.2
-pkgrel=4
+pkgrel=5
 pkgdesc="The PEP 517 compliant PyQt build system (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -19,7 +19,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
 source=("https://pypi.io/packages/source/P/PyQt-builder/PyQt-builder-${pkgver}.tar.gz"
         001-mingw-python.patch)
 sha256sums=('f62bb688d70e0afd88c413a8d994bda824e6cebd12b612902d1945c5a67edcd7'
-            'dad5b3ddd7bfaeeb3787842a80a583adeeae3b12a3eb6ff98f06930342796b71')
+            '33475c8c5ba85dbcd7de8108bfca8095c6f25206eb33b3f7a24cb43d3c1ac169')
 
 prepare() {
   cd ${_realname}-${pkgver}
@@ -43,9 +43,10 @@ package() {
   ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
     --root="${pkgdir}" --optimize=1 --skip-build
 
-  # Remove python.exe full path reference
-  PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
-  sed -s "s|${PREFIX_WIN}/bin/||g" -i "${pkgdir}${MINGW_PREFIX}/bin/pyqt-bundle-script.py"
+  for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*-script.py; do
+    # Remove shebang line
+    sed -e '1 { s/^#!.*$// }' -i "${_f}"
+  done
 
   # Delete bundled MSVC DLLs
   rm -rf "${pkgdir}"/${MINGW_PREFIX}/lib/python*/site-packages/pyqtbuild/bundle/dlls


### PR DESCRIPTION
Fixes #11701