### PR TITLE
Update fpm to version 0.6.0

### DIFF
--- a/mingw-w64-fpm/PKGBUILD
+++ b/mingw-w64-fpm/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=fpm
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.5.0
+pkgver=0.6.0
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -18,8 +18,8 @@ options=('strip')
 license=('MIT')
 source=(${_realname}-${pkgver}.zip::"${url}/releases/download/v${pkgver}/fpm-${pkgver}.zip"
         ${_realname}-${pkgver}.F90::"${url}/releases/download/v${pkgver}/fpm-${pkgver}.F90")
-sha256sums=('e4a06956d2300f9aa1d06bd3323670480e946549617582e32684ded6921a921e'
-            '53bba4d3d09d875d513ed4309a3defe414fa727dbcdeb38e4fdcf094e19c0257')
+sha256sums=('365516f66b116a112746af043e8eccb3d854d6feb1fad0507c570433dacbf7be'
+            '17a809d512618ddb083b1d8c546a2d98e704b10484f607df7b0b231ddc8ff277')
 noextract=(${_realname}-${pkgver}.F90)
 
 build() {


### PR DESCRIPTION
Update for release at https://github.com/fortran-lang/fpm/releases/tag/v0.6.0