### PR TITLE
avr-binutils: fix file conflict

### DIFF
--- a/mingw-w64-avr-binutils/PKGBUILD
+++ b/mingw-w64-avr-binutils/PKGBUILD
@@ -6,7 +6,7 @@ _target=avr
 pkgbase=mingw-w64-${_target}-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_target}-${_realname}
 pkgver=2.38
-pkgrel=1
+pkgrel=2
 pkgdesc='GNU Binutils for the AVR target (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -50,7 +50,7 @@ package() {
 
     cd ${pkgdir}${MINGW_PREFIX}
 
-    for info in as bfd binutils gprof ld; do
+    for info in as bfd binutils ctf-spec gprof ld; do
         mv share/info/${info}.info share/info/${_target}-${info}.info
     done
 }


### PR DESCRIPTION
```
error: failed to commit transaction (conflicting files)
mingw-w64-x86_64-avr-binutils: /mingw64/share/info/ctf-spec.info.gz exists in filesystem (owned by mingw-w64-x86_64-binutils)
Errors occurred, no packages were upgraded.
```