### PR TITLE
avr-binutils: set libdir

### DIFF
--- a/mingw-w64-avr-binutils/PKGBUILD
+++ b/mingw-w64-avr-binutils/PKGBUILD
@@ -6,7 +6,7 @@ _target=avr
 pkgbase=mingw-w64-${_target}-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_target}-${_realname}
 pkgver=2.38
-pkgrel=2
+pkgrel=3
 pkgdesc='GNU Binutils for the AVR target (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -36,6 +36,7 @@ build() {
         --build=${MINGW_CHOST} \
         --prefix=${MINGW_PREFIX} \
         --target=${_target} \
+        --libdir=${MINGW_PREFIX}/lib/${_target} \
         --disable-nls \
         --disable-debug \
         --disable-dependency-tracking \


### PR DESCRIPTION
Fixing another (potential) conflict by placing libdep under an `avr` directory inside lib.