### PR TITLE
libdeflate: fix dynamic linking using pkg-config

### DIFF
--- a/mingw-w64-libdeflate/002-pkg-config.patch
+++ b/mingw-w64-libdeflate/002-pkg-config.patch
@@ -1,0 +1,10 @@
+diff -urN libdeflate-1.12/libdeflate.pc.in.orig libdeflate-1.12/libdeflate.pc.in
+--- libdeflate-1.12/libdeflate.pc.in.orig	2022-06-12 21:52:59.000000000 +0200
++++ libdeflate-1.12/libdeflate.pc.in	2022-06-19 15:39:22.766071700 +0200
+@@ -7,4 +7,5 @@
+ Description: Fast implementation of DEFLATE, zlib, and gzip
+ Version: @VERSION@
+ Libs: -L${libdir} -ldeflate
+-Cflags: -I${includedir}
++Cflags: -I${includedir} -DLIBDEFLATE_DLL
++Cflags.private: -ULIBDEFLATE_DLL

--- a/mingw-w64-libdeflate/PKGBUILD
+++ b/mingw-w64-libdeflate/PKGBUILD
@@ -4,21 +4,24 @@ _realname=libdeflate
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.12
-pkgrel=1
+pkgrel=2
 pkgdesc="Heavily optimized library for DEFLATE/zlib/gzip compression and decompression (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url='https://github.com/ebiggers/libdeflate'
-license=('MIT')
+license=('spdx:MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
 source=(${_realname}-${pkgver}.tar.gz::"${url}/archive/v${pkgver}.tar.gz"
-        "001-libdeflate-makefile-mingw-fix.patch")
+        "001-libdeflate-makefile-mingw-fix.patch"
+        "002-pkg-config.patch")
 sha256sums=('ba89fb167a5ab6bbdfa6ee3b1a71636e8140fa8471cce8a311697584948e4d06'
-            'a5648a9e8d5d64b1a9301ad5f555052c8a8f2967a1a50a422f99fbd4f6a5dc4f')
+            'a5648a9e8d5d64b1a9301ad5f555052c8a8f2967a1a50a422f99fbd4f6a5dc4f'
+            'e0a093985eb05f3b8eb725249e8fc4ec9645cdad8eaafd4a3ce1a0d7a1ef45c5')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
   patch -p1 -i "${srcdir}"/001-libdeflate-makefile-mingw-fix.patch
+  patch -p1 -i "${srcdir}"/002-pkg-config.patch
 }
 
 build() {


### PR DESCRIPTION
The header file of libdeflate contains the following comment:
```
/*
 * On Windows, if you want to link to the DLL version of libdeflate, then
 * #define LIBDEFLATE_DLL.  Note that the calling convention is "stdcall".
 */
```

This PR adds a patch for the .pc file that reflects that requirement.
IIUC, the `-U` flag should undo the `-D` flag when linking statically.

This fixes a build error with GDAL.