### PR TITLE
osgworks-git: support relocation

### DIFF
--- a/mingw-w64-osgworks-git/PKGBUILD
+++ b/mingw-w64-osgworks-git/PKGBUILD
@@ -5,14 +5,18 @@ pkgbase=mingw-w64-${_realname}-git
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git" "${MINGW_PACKAGE_PREFIX}-${_realname}-debug-git")
 _ver_base=3.1.0
 pkgver=3.1.0.444
-pkgrel=3
+pkgrel=4
 pkgdesc="A toolkit for OpenSceneGraph applications (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
-license=('custom')
+license=('spdx:LGPL-2.1')
 url="https://github.com/mccdo/osgworks/"
-depends=("${MINGW_PACKAGE_PREFIX}-OpenSceneGraph" "${MINGW_PACKAGE_PREFIX}-vrpn")
-makedepends=("git" "${MINGW_PACKAGE_PREFIX}-cc" "${MINGW_PACKAGE_PREFIX}-cmake")
+depends=("${MINGW_PACKAGE_PREFIX}-OpenSceneGraph"
+         "${MINGW_PACKAGE_PREFIX}-vrpn")
+makedepends=("git"
+             "${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
 options=(!strip staticlibs !buildflags)
 source=("${_realname}"::"git+https://github.com/mccdo/osgworks.git"
         "osg-3.3.x.patch"
@@ -36,29 +40,31 @@ prepare() {
 }
 
 build() {
-  [[ -d ${srcdir}/build-release ]] && rm -rf ${srcdir}/build-release
-  mkdir -p ${srcdir}/build-release && cd ${srcdir}/build-release
+  msg2 "Building release"
+  [[ -d "${srcdir}"/build-${MSYSTEM}-release ]] && rm -rf "${srcdir}"/build-${MSYSTEM}-release
+  mkdir -p "${srcdir}"/build-${MSYSTEM}-release && cd "${srcdir}"/build-${MSYSTEM}-release
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-  ${MINGW_PREFIX}/bin/cmake.exe \
-    -G"MSYS Makefiles" \
-    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+  "${MINGW_PREFIX}"/bin/cmake.exe \
+    -GNinja \
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
     -DCMAKE_BUILD_TYPE=Release \
     ../${_realname}
 
-  make
+  "${MINGW_PREFIX}"/bin/cmake.exe --build .
 
-  [[ -d ${srcdir}/build-debug ]] && rm -rf ${srcdir}/build-debug
-  mkdir -p ${srcdir}/build-debug && cd ${srcdir}/build-debug
+  msg2 "Building debug"
+  [[ -d "${srcdir}"/build-${MSYSTEM}-debug ]] && rm -rf "${srcdir}"/build-${MSYSTEM}-debug
+  mkdir -p "${srcdir}"/build-${MSYSTEM}-debug && cd "${srcdir}"/build-${MSYSTEM}-debug
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-  ${MINGW_PREFIX}/bin/cmake.exe \
-    -G"MSYS Makefiles" \
-    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+  "${MINGW_PREFIX}"/bin/cmake.exe \
+    -GNinja \
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
     -DCMAKE_BUILD_TYPE=Debug \
     ../${_realname}
 
-  make
+  "${MINGW_PREFIX}"/bin/cmake.exe --build .
 }
 
 package_osgworks-git() {
@@ -66,9 +72,13 @@ package_osgworks-git() {
   conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-${_realname}-svn")
   replaces=(${MINGW_PACKAGE_PREFIX}-${_realname}-svn)
 
-  cd ${srcdir}/build-release
+  cd "${srcdir}"/build-${MSYSTEM}-release
 
-  make DESTDIR=${pkgdir} install
+  DESTDIR=${pkgdir} "${MINGW_PREFIX}"/bin/cmake.exe --install .
+
+  # support relocation
+  local MINGW_PREFIX_W=$(cygpath -m "${MINGW_PREFIX}")
+  sed -i "s#${MINGW_PREFIX_W}#\${_IMPORT_PREFIX}#g" "${pkgdir}${MINGW_PREFIX}"/lib/osgworks-targets-release.cmake
 }
 
 package_osgworks-debug-git() {
@@ -77,9 +87,9 @@ package_osgworks-debug-git() {
   conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-debug" "${MINGW_PACKAGE_PREFIX}-${_realname}-debug-svn")
   replaces=(${MINGW_PACKAGE_PREFIX}-${_realname}-debug-svn)
 
-  cd ${srcdir}/build-debug
+  cd "${srcdir}"/build-${MSYSTEM}-debug
 
-  make DESTDIR=${pkgdir} install
+  DESTDIR=${pkgdir} "${MINGW_PREFIX}"/bin/cmake.exe --install .
 
   rm -rf ${pkgdir}${MINGW_PREFIX}/include
   rm -rf ${pkgdir}${MINGW_PREFIX}/lib/flagpoll


### PR DESCRIPTION
Also use ninja generator in build rule.

This prevent errors caused by the hardcoded paths in the .cmake file when re-building dependent packages (e.g., `osgbullet-git`) locally.