### PR TITLE
cmake: fix FindGLEW module

### DIFF
--- a/mingw-w64-cmake/0009-fix-find-glew.patch
+++ b/mingw-w64-cmake/0009-fix-find-glew.patch
@@ -1,0 +1,30 @@
+--- cmake-3.23.2/Modules/FindGLEW.cmake.orig	2022-05-25 15:42:51.000000000 +0200
++++ cmake-3.23.2/Modules/FindGLEW.cmake	2022-06-19 19:38:40.745804600 +0200
+@@ -68,6 +68,27 @@
+ 
+ if(GLEW_FOUND)
+   find_package_handle_standard_args(GLEW DEFAULT_MSG GLEW_CONFIG)
++  get_target_property(GLEW_INCLUDE_DIRS GLEW::GLEW INTERFACE_INCLUDE_DIRECTORIES)
++  set(GLEW_INCLUDE_DIR ${GLEW_INCLUDE_DIRS})
++  get_target_property(_GLEW_DEFS GLEW::GLEW INTERFACE_COMPILE_DEFINITIONS)
++  if("${_GLEW_DEFS}" MATCHES "GLEW_STATIC")
++    get_target_property(GLEW_LIBRARY_DEBUG GLEW::GLEW IMPORTED_LOCATION_DEBUG)
++    get_target_property(GLEW_LIBRARY_RELEASE GLEW::GLEW IMPORTED_LOCATION_RELEASE)
++  else()
++    get_target_property(GLEW_LIBRARY_DEBUG GLEW::GLEW IMPORTED_IMPLIB_DEBUG)
++    get_target_property(GLEW_LIBRARY_RELEASE GLEW::GLEW IMPORTED_IMPLIB_RELEASE)
++  endif()
++  get_target_property(_GLEW_LINK_INTERFACE GLEW::GLEW IMPORTED_LINK_INTERFACE_LIBRARIES_RELEASE) # same for debug and release
++  list(APPEND GLEW_LIBRARIES ${_GLEW_LINK_INTERFACE})
++  list(APPEND GLEW_LIBRARY ${_GLEW_LINK_INTERFACE})
++  select_library_configurations(GLEW)
++  if("${_GLEW_DEFS}" MATCHES "GLEW_STATIC")
++    set(GLEW_STATIC_LIBRARIES ${GLEW_LIBRARIES})
++  else()
++    set(GLEW_SHARED_LIBRARIES ${GLEW_LIBRARIES})
++  endif()
++  unset(_GLEW_DEFS)
++  unset(_GLEW_LINK_INTERFACE)
+   return()
+ endif()
+ 

--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -7,7 +7,7 @@ _realname=cmake
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.23.2
-pkgrel=2
+pkgrel=3
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -50,7 +50,8 @@ source=("https://github.com/Kitware/CMake/releases/download/v${pkgver}/${_realna
         "0006-fix-find-glut.patch"
         "https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7162.patch"
         "0007-No-hardcoded-gcc-with-MINGW-or-MSYS-Makefiles.patch"
-        "0008-fix-find-mpi.patch")
+        "0008-fix-find-mpi.patch"
+        "0009-fix-find-glew.patch")
 sha256sums=('f316b40053466f9a416adf981efda41b160ca859e97f6a484b447ea299ff26aa'
             '25793edcbac05bb6d17fa9947b52ace4a6b5ccccf7758e22ae9ae022ed089061'
             'f6cf6a6f2729db2b9427679acd09520af2cd79fc26900b19a49cead05a55cd1a'
@@ -60,7 +61,8 @@ sha256sums=('f316b40053466f9a416adf981efda41b160ca859e97f6a484b447ea299ff26aa'
             '04d526b1ec86de7e633d0a802cef8452e33bc18c8425aa2065dc901a7c868026'
             'bfff814b848c51e9733af7c435a51a9ff2ccfdf862b5a70113dc0a71c0360b13'
             '62074a0de9ac9a9224ffda01992aaa34e5f7fa2e2c6b1cb327ebe9b452452364'
-            '0a18245a80fc3a4f5ef6eb96cd0508f341331390c5ff289c642153d96d732253')
+            '0a18245a80fc3a4f5ef6eb96cd0508f341331390c5ff289c642153d96d732253'
+            'a66254d1385e3a70e45cacd20bfea0e376493b72c9c41657f9ce40296b646c26')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -88,7 +90,8 @@ prepare() {
     0001-Disable-response-files-for-MSYS-Generator.patch \
     0002-Do-not-install-Qt-bundle-in-cmake-gui.patch \
     0004-Output-line-numbers-in-callstacks.patch \
-    0008-fix-find-mpi.patch
+    0008-fix-find-mpi.patch \
+    0009-fix-find-glew.patch
   # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/{7105,7161,7162}
   apply_patch_with_msg \
     7105.patch \


### PR DESCRIPTION
This avoids an issue with some packages (e.g., `mingw-w64-osgearth`) because some of the variables the documentation promises (e.g., `GLEW_LIBRARIES`) aren't set:
https://cmake.org/cmake/help/latest/module/FindGLEW.html

See also this report upstream:
https://gitlab.kitware.com/cmake/cmake/-/issues/19662#note_665760

And this related workaround:
https://github.com/microsoft/vcpkg/blob/master/ports/glew/vcpkg-cmake-wrapper.cmake
