### PR TITLE
netcdf: fix segfault if file cannot be opened

### DIFF
--- a/mingw-w64-netcdf/0001-no-debug-libraries.patch
+++ b/mingw-w64-netcdf/0001-no-debug-libraries.patch
@@ -1,0 +1,48 @@
+diff -urN netcdf-c-4.9.0/cmake/modules/FindZip.cmake.orig netcdf-c-4.9.0/cmake/modules/FindZip.cmake
+--- netcdf-c-4.9.0/cmake/modules/FindZip.cmake.orig	2022-06-23 17:20:15.443959500 +0200
++++ netcdf-c-4.9.0/cmake/modules/FindZip.cmake	2022-06-23 17:20:24.156687000 +0200
+@@ -39,7 +39,7 @@
+                PATHS ${Zip_LIBRARY_DIRS} NO_DEFAULT_PATH)
+ 
+   SET(Zip_LIBRARIES )
+-  IF(Zip_DEBUG_LIBRARY AND Zip_RELEASE_LIBRARY)
++  IF(Zip_DEBUG_LIBRARY AND Zip_RELEASE_LIBRARY AND NOT (Zip_DEBUG_LIBRARY STREQUAL Zip_RELEASE_LIBRARY))
+     SET(Zip_LIBRARIES debug ${Zip_DEBUG_LIBRARY} optimized ${Zip_RELEASE_LIBRARY})
+   ELSEIF(Zip_DEBUG_LIBRARY)
+     SET(Zip_LIBRARIES ${Zip_DEBUG_LIBRARY})
+diff -urN netcdf-c-4.9.0/cmake/modules/FindBlosc.cmake.orig netcdf-c-4.9.0/cmake/modules/FindBlosc.cmake
+--- netcdf-c-4.9.0/cmake/modules/FindBlosc.cmake.orig	2022-06-23 17:59:01.868937600 +0200
++++ netcdf-c-4.9.0/cmake/modules/FindBlosc.cmake	2022-06-23 18:07:01.844880800 +0200
+@@ -39,7 +39,7 @@
+                PATHS ${Blosc_LIBRARY_DIRS} NO_DEFAULT_PATH)
+ 
+   SET(Blosc_LIBRARIES )
+-  IF(Blosc_DEBUG_LIBRARY AND Blosc_RELEASE_LIBRARY)
++  IF(Blosc_DEBUG_LIBRARY AND Blosc_RELEASE_LIBRARY AND NOT (Blosc_DEBUG_LIBRARY STREQUAL Blosc_RELEASE_LIBRARY))
+     SET(Blosc_LIBRARIES debug ${Blosc_DEBUG_LIBRARY} optimized ${Blosc_RELEASE_LIBRARY})
+   ELSEIF(Blosc_DEBUG_LIBRARY)
+     SET(Blosc_LIBRARIES ${Blosc_DEBUG_LIBRARY})
+diff -urN netcdf-c-4.9.0/cmake/modules/FindZstd.cmake.orig netcdf-c-4.9.0/cmake/modules/FindZstd.cmake
+--- netcdf-c-4.9.0/cmake/modules/FindZstd.cmake.orig	2022-06-10 23:04:15.000000000 +0200
++++ netcdf-c-4.9.0/cmake/modules/FindZstd.cmake	2022-06-23 18:10:24.665696300 +0200
+@@ -39,7 +39,7 @@
+                PATHS ${Zstd_LIBRARY_DIRS} NO_DEFAULT_PATH)
+ 
+   SET(Zstd_LIBRARIES )
+-  IF(Zstd_DEBUG_LIBRARY AND Zstd_RELEASE_LIBRARY)
++  IF(Zstd_DEBUG_LIBRARY AND Zstd_RELEASE_LIBRARY AND NOT (Zstd_DEBUG_LIBRARY STREQUAL Zstd_RELEASE_LIBRARY))
+     SET(Zstd_LIBRARIES debug ${Zstd_DEBUG_LIBRARY} optimized ${Zstd_RELEASE_LIBRARY})
+   ELSEIF(Zstd_DEBUG_LIBRARY)
+     SET(Zstd_LIBRARIES ${Zstd_DEBUG_LIBRARY})
+diff -urN netcdf-c-4.9.0/cmake/modules/FindBz2.cmake.orig netcdf-c-4.9.0/cmake/modules/FindBz2.cmake
+--- netcdf-c-4.9.0/cmake/modules/FindBz2.cmake.orig	2022-06-10 23:04:15.000000000 +0200
++++ netcdf-c-4.9.0/cmake/modules/FindBz2.cmake	2022-06-23 18:13:29.254600600 +0200
+@@ -39,7 +39,7 @@
+                PATHS ${Bz2_LIBRARY_DIRS} NO_DEFAULT_PATH)
+ 
+   SET(Bz2_LIBRARIES )
+-  IF(Bz2_DEBUG_LIBRARY AND Bz2_RELEASE_LIBRARY)
++  IF(Bz2_DEBUG_LIBRARY AND Bz2_RELEASE_LIBRARY AND NOT (Bz2_DEBUG_LIBRARY STREQUAL Bz2_RELEASE_LIBRARY))
+     SET(Bz2_LIBRARIES debug ${Bz2_DEBUG_LIBRARY} optimized ${Bz2_RELEASE_LIBRARY})
+   ELSEIF(Bz2_DEBUG_LIBRARY)
+     SET(Bz2_LIBRARIES ${Bz2_DEBUG_LIBRARY})

--- a/mingw-w64-netcdf/0002-no-file.patch
+++ b/mingw-w64-netcdf/0002-no-file.patch
@@ -1,0 +1,12 @@
+diff -urN netcdf-c-4.9.0/libsrc/posixio.c.orig netcdf-c-4.9.0/libsrc/posixio.c
+--- netcdf-c-4.9.0/libsrc/posixio.c.orig	2022-06-23 18:56:53.650461800 +0200
++++ netcdf-c-4.9.0/libsrc/posixio.c	2022-06-23 18:57:11.850400400 +0200
+@@ -1634,7 +1634,7 @@
+ #endif
+ 	if(fd < 0)
+ 	{
+-		status = errno;
++		status = errno ? errno : ENOENT;
+ 		goto unwind_new;
+ 	}
+ 	*((int *)&nciop->fd) = fd; /* cast away const */

--- a/mingw-w64-netcdf/PKGBUILD
+++ b/mingw-w64-netcdf/PKGBUILD
@@ -4,20 +4,26 @@ _realname=netcdf
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.9.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Interface for scientific data access to large binary data (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
-license=('custom')
+license=('spdx:BSD-3-Clause')
 url="https://www.unidata.ucar.edu/software/netcdf/"
-depends=("${MINGW_PACKAGE_PREFIX}-curl"
+depends=("${MINGW_PACKAGE_PREFIX}-blosc"
+         "${MINGW_PACKAGE_PREFIX}-curl"
          "${MINGW_PACKAGE_PREFIX}-hdf5"
-         "${MINGW_PACKAGE_PREFIX}-zlib")
+         "${MINGW_PACKAGE_PREFIX}-libzip")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake")
 checkdepends=("unzip")
-source=(${_realname}-${pkgver}.tar.gz::"https://github.com/Unidata/netcdf-c/archive/v${pkgver}.tar.gz")
-sha256sums=('9f4cb864f3ab54adb75409984c6202323d2fc66c003e5308f3cdf224ed41c0a6')
+# options=(debug !strip)
+source=(${_realname}-${pkgver}.tar.gz::"https://github.com/Unidata/netcdf-c/archive/v${pkgver}.tar.gz"
+        "0001-no-debug-libraries.patch"
+        "0002-no-file.patch")
+sha256sums=('9f4cb864f3ab54adb75409984c6202323d2fc66c003e5308f3cdf224ed41c0a6'
+            'a16300682b43de63bead0a42211b2219820599a6eb3d60bc83c27f85a1c64711'
+            'd6f566945c232f78cce680ddc235c178fc1c5a41e5b8eee067f5b9251e2ea81e')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -31,18 +37,31 @@ apply_patch_with_msg() {
 prepare() {
   cd "${srcdir}/${_realname}-c-${pkgver}"
 
-  #apply_patch_with_msg *.patch
+  apply_patch_with_msg \
+    0001-no-debug-libraries.patch \
+    0002-no-file.patch
 }
 
 build() {
-  [[ -d ${srcdir}/build-static-${MSYSTEM} ]] && rm -rf ${srcdir}/build-static-${MSYSTEM}
-  mkdir -p ${srcdir}/build-static-${MSYSTEM} && cd ${srcdir}/build-static-${MSYSTEM}
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  # disable multitude of warnings
+  CFLAGS+=" -Wno-sign-conversion -Wno-float-conversion"
+
+  msg2 "Building static libraries"
+  [[ -d "${srcdir}"/build-static-${MSYSTEM} ]] && rm -rf "${srcdir}"/build-static-${MSYSTEM}
+  mkdir -p "${srcdir}"/build-static-${MSYSTEM} && cd "${srcdir}"/build-static-${MSYSTEM}
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-  cmake \
-    -G "MSYS Makefiles" \
-    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    -DCMAKE_BUILD_TYPE=Release \
+  "${MINGW_PREFIX}"/bin/cmake.exe \
+    -G"MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+    "${extra_config[@]}" \
     -DBUILD_SHARED_LIBS=OFF \
     -DENABLE_DLL=OFF \
     -DENABLE_TESTS=ON \
@@ -51,16 +70,17 @@ build() {
     -DENABLE_NETCDF_4=ON \
     -Wno-dev \
     "${srcdir}/${_realname}-c-${pkgver}"
-  cmake --build .
+  "${MINGW_PREFIX}"/bin/cmake.exe --build .
 
-  [[ -d ${srcdir}/build-shared-${MSYSTEM} ]] && rm -rf ${srcdir}/build-shared-${MSYSTEM}
-  mkdir -p ${srcdir}/build-shared-${MSYSTEM} && cd ${srcdir}/build-shared-${MSYSTEM}
+  msg2 "Building shared libraries"
+  [[ -d "${srcdir}"/build-shared-${MSYSTEM} ]] && rm -rf "${srcdir}"/build-shared-${MSYSTEM}
+  mkdir -p "${srcdir}"/build-shared-${MSYSTEM} && cd "${srcdir}"/build-shared-${MSYSTEM}
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-  cmake \
-    -G "MSYS Makefiles" \
-    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    -DCMAKE_BUILD_TYPE=Release \
+  "${MINGW_PREFIX}"/bin/cmake.exe \
+    -G"MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+    "${extra_config[@]}" \
     -DBUILD_SHARED_LIBS=ON \
     -DENABLE_EXAMPLES=OFF \
     -DENABLE_TESTS=OFF \
@@ -70,7 +90,7 @@ build() {
     -DENABLE_LOGGING=ON \
     -Wno-dev \
     "${srcdir}/${_realname}-c-${pkgver}"
-  cmake --build .
+  "${MINGW_PREFIX}"/bin/cmake.exe --build .
 }
 
 check() {
@@ -79,12 +99,12 @@ check() {
 }
 
 package() {
-  DESTDIR=${pkgdir} cmake --install build-static-${MSYSTEM}
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install build-static-${MSYSTEM}
 
-  DESTDIR=${pkgdir} cmake --install build-shared-${MSYSTEM}
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install build-shared-${MSYSTEM}
 
-  install -Dm644 ${srcdir}/${_realname}-c-${pkgver}/COPYRIGHT \
-    ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYRIGHT
+  install -Dm644 "${srcdir}"/${_realname}-c-${pkgver}/COPYRIGHT \
+    "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname}/COPYRIGHT
 
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
   for _f in "${pkgdir}${MINGW_PREFIX}"/lib/cmake/netCDF/*.cmake; do


### PR DESCRIPTION
It looks like `errno` isn't set when file cannot be opened. Set it manually instead.
Fixes #11918.

Also fix some linker flags that get messed up if the detected debug library is the same as the release library.