### PR TITLE
emacs: some hacky patches to make it work on ucrt64

### DIFF
--- a/mingw-w64-emacs/001-ucrt.patch
+++ b/mingw-w64-emacs/001-ucrt.patch
@@ -1,0 +1,37 @@
+--- emacs-28.1/nt/cmdproxy.c.orig	2022-06-23 19:24:10.845481100 +0200
++++ emacs-28.1/nt/cmdproxy.c	2022-06-23 19:24:19.271132900 +0200
+@@ -35,6 +35,10 @@
+ #include <string.h>  /* strlen */
+ #include <ctype.h>   /* isspace, isalpha */
+ 
++#ifdef _UCRT
++#define _snprintf snprintf
++#endif
++
+ /* We don't want to include stdio.h because we are already duplicating
+    lots of it here */
+ extern int _snprintf (char *buffer, size_t count, const char *format, ...);
+--- emacs-28.1/src/sysdep.c.orig	2022-06-23 20:59:02.252891700 +0200
++++ emacs-28.1/src/sysdep.c	2022-06-23 21:05:31.998322600 +0200
+@@ -2693,7 +2693,9 @@
+   if (close_stream (stdout) != 0)
+     {
++#ifndef _UCRT // XXX: close_stream(stdout) fails for some reason
+       emacs_perror ("Write error to standard output");
+       _exit (EXIT_FAILURE);
++#endif
+     }
+ 
+   /* Do not close stderr if addresses are being sanitized, as the
+@@ -2702,7 +2704,11 @@
+   if (err | (ADDRESS_SANITIZER
+ 	     ? fflush (stderr) != 0 || ferror (stderr)
+ 	     : close_stream (stderr) != 0))
++#ifndef _UCRT // XXX: close_stream(stderr) fails for some reason
+     _exit (EXIT_FAILURE);
++#else
++    ;
++#endif
+ }
+ 
+ #ifndef DOS_NT

--- a/mingw-w64-emacs/PKGBUILD
+++ b/mingw-w64-emacs/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Haroogan <Haroogan@gmail.com>
 # Maintainer: Oscar Fuentes <ofv@wanadoo.es>
 
-_enable_jit=$([[ "${MINGW_PREFIX}" =~ /mingw.* ]] && echo yes)
+_enable_jit=$([[ "${MINGW_PREFIX}" =~ /clang.* ]] || echo yes)
 _realname=emacs
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
@@ -36,10 +36,12 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 # Don't zip info files because the built-in info reader uses gzip to
 # decompress them. gzip is not available as a mingw binary.
 options=('strip' '!zipman')
-source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.xz"{,.sig})
+source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.xz"{,.sig}
+        "001-ucrt.patch")
 # source=("https://alpha.gnu.org/gnu/${_realname}/pretest/${_realname}-${pkgver}.tar.xz"{,.sig})
 sha256sums=('28b1b3d099037a088f0a4ca251d7e7262eab5ea1677aabffa6c4426961ad75e1'
-            'SKIP')
+            'SKIP'
+            'e1347064ec30094e21679764f784fa7557738946485359041473e6e9d7f3c3dc')
 validpgpkeys=('28D3BED851FDF3AB57FEF93C233587A47C207910'
 	      '17E90D521672C04631B1183EE78DAE0F3115E06B'
 	      'E6C9029C363AD41D787A8EBB91C1262F01EB8D39'
@@ -47,6 +49,9 @@ validpgpkeys=('28D3BED851FDF3AB57FEF93C233587A47C207910'
 
 prepare() {
   cd "${_realname}-${pkgver}"
+
+  patch -Np1 -i "${srcdir}/001-ucrt.patch"
+
   ./autogen.sh
 }
 


### PR DESCRIPTION
for both stdout and stderr fclose fail during atexit as if they
were already closed. the function in theory has a workaround for that
in that it will continue if errno is EBADF, but fclose doesn't set that
on Windows.

This shows at least what is missing/broken if upstream wants to have a look.