### PR TITLE
stxxl: fix the clang build

### DIFF
--- a/mingw-w64-stxxl-git/PKGBUILD
+++ b/mingw-w64-stxxl-git/PKGBUILD
@@ -4,14 +4,18 @@ _realname=stxxl
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 pkgver=1.4.1.387.gb9e44f0e
-pkgrel=1
+pkgrel=2
 _commit=b9e44f0ecba7d7111fbb33f3330c3e53f2b75236
 pkgdesc="Standard Template Library for Extra Large Data Sets (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 url="https://stxxl.sourceforge.io/"
 license=('custom:Boost')
-makedepends=("${MINGW_PACKAGE_PREFIX}-cc" "${MINGW_PACKAGE_PREFIX}-cmake" 'git')
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+  "${MINGW_PACKAGE_PREFIX}-ninja"
+  'git')
 options=('strip' 'staticlibs')
 source=("${_realname}"::"git+https://github.com/stxxl/stxxl.git#commit=$_commit"
         001-cmake-files-location.patch
@@ -38,21 +42,22 @@ build() {
   CXXFLAGS+=" -Wno-deprecated-copy" \
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake \
-    -G"MSYS Makefiles" \
+    -GNinja \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DCMAKE_BUILD_TYPE=Release \
-    -DUSE_GNU_PARALLEL=ON \
     -DBUILD_SHARED_LIBS=ON \
     -DBUILD_STATIC_LIBS=ON \
+    -DUSE_STD_THREADS=ON \
     ../${_realname}
 
-  make
+  "${MINGW_PREFIX}"/bin/cmake.exe --build .
 }
 
 
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
-  make DESTDIR=${pkgdir} install
+
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
 
   mkdir -p "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
   install -Dm644 ../${_realname}/LICENSE_1_0.txt \


### PR DESCRIPTION
* let cmake detect if gnu parallel is supported
* switch to std threads, to avoid build errors with clang+pthreads
  (I hope this is ok?)