### PR TITLE
gtksourceview3: remove glade catalog to avoid conflict with gtksourceview4

### DIFF
--- a/mingw-w64-gtksourceview3/PKGBUILD
+++ b/mingw-w64-gtksourceview3/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gtksourceview
 pkgbase=mingw-w64-${_realname}3
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}3"
 pkgver=3.24.11
-pkgrel=1
+pkgrel=2
 pkgdesc="A text widget adding syntax highlighting and more to GNOME (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -45,7 +45,7 @@ build() {
     --host=${MINGW_CHOST} \
     --enable-shared \
     --disable-static \
-    --enable-glade-catalog \
+    --disable-glade-catalog \
     --enable-gtk-doc
 
   make
@@ -54,13 +54,6 @@ build() {
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   make -j1 DESTDIR="${pkgdir}" install
-
-  for ff in ${pkgdir}/${MINGW_PREFIX}/bin/libgtksourceview*.dll; do
-    local _reallib=$(basename $ff)
-    _reallib=${_reallib%.dll}
-    _reallib=${_reallib#lib}
-    sed -e "s|library=\"gtksourceview-3.0\"|library=\"${_reallib}\"|g" -i ${pkgdir}/${MINGW_PREFIX}/share/glade/catalogs/gtksourceview.xml
-  done
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }


### PR DESCRIPTION
this removes gtksourceview.xml. Arch does this too.