### PR TITLE
New package: liblcf

### DIFF
--- a/mingw-w64-liblcf/PKGBUILD
+++ b/mingw-w64-liblcf/PKGBUILD
@@ -1,0 +1,66 @@
+# Maintainer: Jordan Irwin <antumdeluge@gmail.com>
+
+_realname=liblcf
+pkgbase="mingw-w64-${_realname}"
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.7.0
+pkgrel=1
+pkgdesc="Library to handle RPG Maker 2000/2003 and EasyRPG game data (mingw-w64)"
+arch=("any")
+mingw_arch=("mingw32" "mingw64" "clang32" "clang64" "ucrt64")
+url="https://easyrpg.org/"
+license=("MIT")
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/EasyRPG/liblcf/archive/refs/tags/${pkgver}.tar.gz")
+sha256sums=("a98dca6396f28b1902ae299e66ad40e0ff7fb5052269d6e619d06aaae4d2aeb2")
+depends=("${MINGW_PACKAGE_PREFIX}-expat"
+         "${MINGW_PACKAGE_PREFIX}-icu")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-pkgconf"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-cmake>=3.10")
+
+
+build() {
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  [[ -d "${srcdir}/build-${MSYSTEM}-shared" ]] && rm -rf "${srcdir}/build-${MSYSTEM}-shared"
+  mkdir -p "${srcdir}/build-${MSYSTEM}-shared" && cd "${srcdir}/build-${MSYSTEM}-shared"
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G "Ninja" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DBUILD_SHARED_LIBS=ON \
+    "${extra_config[@]}" \
+    ../${_realname}-${pkgver}
+
+  "${MINGW_PREFIX}/bin/cmake.exe" --build ./
+
+  [[ -d "${srcdir}/build-${MSYSTEM}-static" ]] && rm -rf "${srcdir}/build-${MSYSTEM}-static"
+  mkdir -p "${srcdir}/build-${MSYSTEM}-static" && cd "${srcdir}/build-${MSYSTEM}-static"
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G "Ninja" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DBUILD_SHARED_LIBS=OFF \
+    "${extra_config[@]}" \
+    ../${_realname}-${pkgver}
+
+  "${MINGW_PREFIX}/bin/cmake.exe" --build ./
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}-static"
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}/bin/cmake.exe" --install ./
+
+  cd "${srcdir}/build-${MSYSTEM}-shared"
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}/bin/cmake.exe" --install ./
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
Library to handle RPG Maker 2000/2003 and EasyRPG game data

- Homepage: https://easyrpg.org/
- Upstream: https://github.com/EasyRPG/liblcf
- Current version: 0.7.0

I don't think it is an issue, but I get the following output when building:
```
==> Tidying install...
  -> Removing libtool files...
  -> Purging unwanted files...
  -> Stripping unneeded symbols from binaries and libraries...
...\mingw64\bin\objdump.exe: mingw64/include/lcf/config.h: file format not recognized
...\mingw64\bin\objdump.exe: mingw64/include/lcf/context.h: file format not recognized
...
```

For some reason, `objdump` wants to scan `.h` files.