### PR TITLE
md4c: also build static library

### DIFF
--- a/mingw-w64-md4c/PKGBUILD
+++ b/mingw-w64-md4c/PKGBUILD
@@ -4,7 +4,7 @@ _realname=md4c
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgbase="mingw-w64-${_realname}"
 pkgver=0.4.8
-pkgrel=1
+pkgrel=2
 pkgdesc="C Markdown parser implementation compliant to CommonMark specification"
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -23,15 +23,16 @@ prepare() {
 }
 
 build() {
-  [[ -d "${srcdir}/build-${CARCH}" ]] && rm -rf "${srcdir}/build-${CARCH}"
-  mkdir -p "${srcdir}/build-${CARCH}" && cd "${srcdir}/build-${CARCH}"
-
   declare -a extra_config
   if check_option "debug" "n"; then
       extra_config+=("-DCMAKE_BUILD_TYPE=Release")
   else
       extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
+
+  dir_shared="${srcdir}/build-${CARCH}-shared"
+  [[ -d "${dir_shared}" ]] && rm -rf "${dir_shared}"
+  mkdir -p "${dir_shared}" && cd "${dir_shared}"
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   "${MINGW_PREFIX}/bin/cmake" \
@@ -42,12 +43,33 @@ build() {
       "../${_realname}-release-${pkgver}"
 
   ninja
+
+  dir_static="${srcdir}/build-${CARCH}-static"
+  [[ -d "${dir_static}" ]] && rm -rf "${dir_static}"
+  mkdir -p "${dir_static}" && cd "${dir_static}"
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  "${MINGW_PREFIX}/bin/cmake" \
+      -G "Ninja" \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      -DBUILD_SHARED_LIBS=OFF \
+      "${extra_config[@]}" \
+      "../${_realname}-release-${pkgver}"
+
+  ninja
 }
 
 package() {
-  cd "${srcdir}/build-${CARCH}"
+  dir_shared="${srcdir}/build-${CARCH}-shared"
+  dir_static="${srcdir}/build-${CARCH}-static"
+
+  cd "${dir_shared}"
   DESTDIR="${pkgdir}" ninja install
 
+  # static libs
+  install -vDm644 "${dir_static}/src/libmd4c.a" "${pkgdir}${MINGW_PREFIX}/lib/libmd4c.a"
+  install -vDm644 "${dir_static}/src/libmd4c-html.a" "${pkgdir}${MINGW_PREFIX}/lib/libmd4c-html.a"
+
   # license
-  install -Dm644 "${srcdir}/${_realname}-release-${pkgver}/LICENSE.md" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.md"
+  install -vDm644 "${srcdir}/${_realname}-release-${pkgver}/LICENSE.md" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.md"
 }


### PR DESCRIPTION
Simply adds build for static library to be included in package.