### PR TITLE
osgearth: update to 3.3

### DIFF
--- a/mingw-w64-osgearth/0001-calling-convention.patch
+++ b/mingw-w64-osgearth/0001-calling-convention.patch
@@ -1,0 +1,12 @@
+diff -urN osgearth/src/osgEarth/GLUtils.cpp.orig osgearth/src/osgEarth/GLUtils.cpp
+--- osgearth/src/osgEarth/GLUtils.cpp.orig	2022-06-30 10:52:19.214878200 +0200
++++ osgearth/src/osgEarth/GLUtils.cpp	2022-06-30 12:43:21.697099300 +0200
+@@ -359,7 +359,7 @@
+ #define GL_DEBUG_GROUP_STACK_DEPTH        0x826D
+ #endif
+ 
+-    void s_oe_gldebugproc(
++    void APIENTRY s_oe_gldebugproc(
+         GLenum source,
+         GLenum type,
+         GLuint id,

--- a/mingw-w64-osgearth/PKGBUILD
+++ b/mingw-w64-osgearth/PKGBUILD
@@ -30,8 +30,10 @@ makedepends=("git"
              "${MINGW_PACKAGE_PREFIX}-pkgconf")
 options=('staticlibs' 'strip')
 _tag=${_realname}-${pkgver}
-source=("${_realname}"::"git+https://github.com/gwaldron/osgearth.git#tag=${_tag}")
-sha256sums=('SKIP')
+source=("${_realname}"::"git+https://github.com/gwaldron/osgearth.git#tag=${_tag}"
+        "0001-calling-convention.patch")
+sha256sums=('SKIP'
+            'a17f6e6160b2b399a136090c6b714baeddf41bb3b92c804d571b329e19a32063')
 
 apply_patch_with_msg() {
   for _patch in "$@"

--- a/mingw-w64-osgearth/PKGBUILD
+++ b/mingw-w64-osgearth/PKGBUILD
@@ -4,11 +4,11 @@
 _realname=osgearth
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-pkgver=3.2
-pkgrel=2
+pkgver=3.3
+pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
-license=('LGPL')
+license=('spdx:LGPL-3.0-or-later WITH LGPL-3.0-linking-exception')
 url="http://osgearth.org"
 depends=("${MINGW_PACKAGE_PREFIX}-curl"
          "${MINGW_PACKAGE_PREFIX}-gdal"
@@ -19,49 +19,64 @@ depends=("${MINGW_PACKAGE_PREFIX}-curl"
          "${MINGW_PACKAGE_PREFIX}-protobuf"
          "${MINGW_PACKAGE_PREFIX}-rocksdb"
          "${MINGW_PACKAGE_PREFIX}-sqlite3")
-makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-pkgconf"
+makedepends=("git"
+             "${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-OpenSceneGraph"
              "${MINGW_PACKAGE_PREFIX}-OpenSceneGraph-debug"
              "${MINGW_PACKAGE_PREFIX}-osgQt"
-             "${MINGW_PACKAGE_PREFIX}-osgQt-debug")
+             "${MINGW_PACKAGE_PREFIX}-osgQt-debug"
+             "${MINGW_PACKAGE_PREFIX}-pkgconf")
 options=('staticlibs' 'strip')
-source=("https://github.com/gwaldron/osgearth/archive/${_realname}-${pkgver}.tar.gz")
-sha256sums=('7e1dd643b1f3b8d1ba9561b899c18176af988342b86c42d89a70be924cb747f6')
+_tag=${_realname}-${pkgver}
+source=("${_realname}"::"git+https://github.com/gwaldron/osgearth.git#tag=${_tag}")
+sha256sums=('SKIP')
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying ${_patch}"
+    patch -Nbp1 -i "${srcdir}/${_patch}"
+  done
+}
+
+prepare() {
+  cd "${srcdir}/${_realname}"
+
+  apply_patch_with_msg \
+    0001-calling-convention.patch
+}
 
 build() {
-  _pkgver=${_realname}-${pkgver} # How it's tagged in git
-
   export FREETYPE_DIR=${MINGW_PREFIX}
 
-  for builddir in {Release,Debug}-${MSYSTEM}; do
-    [[ -d ${builddir} ]] && rm -rf ${builddir}
-    mkdir -p ${builddir} && pushd ${builddir}
-      [[ "${builddir%-${MSYSTEM}}" == "Release" ]] && {
+  for buildtype in {Release,Debug}; do
+    [[ -d build-${MSYSTEM}-${buildtype} ]] && rm -rf build-${MSYSTEM}-${buildtype}
+    mkdir -p build-${MSYSTEM}-${buildtype} && pushd build-${MSYSTEM}-${buildtype}
+      [[ "${buildtype}" == "Release" ]] && {
         local _opts=""
       } || {
         local _opts=""
       }
 
-      msg "Building ${builddir%-${MSYSTEM}} version..."
+      msg "Building ${buildtype} version..."
 
       MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-      ${MINGW_PREFIX}/bin/cmake.exe -Wno-dev \
-        -G"Ninja" \
+      "${MINGW_PREFIX}"/bin/cmake.exe -Wno-dev \
+        -GNinja \
         -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-        -DCMAKE_BUILD_TYPE=${builddir%-${MSYSTEM}} \
-        -DOSG_DIR=${MINGW_PREFIX} \
+        -DCMAKE_BUILD_TYPE=${buildtype} \
+        -DOSG_DIR="${MINGW_PREFIX}" \
         -DOSGEARTH_BUILD_EXAMPLES=OFF \
         -DOSGEARTH_BUILD_TESTS=OFF \
         -DOSGEARTH_BUILD_LEGACY_SPLAT_NODEKIT=ON \
         -DOSGEARTH_BUILD_LEVELDB_CACHE=ON \
         -DOSGEARTH_BUILD_ZIP_PLUGIN=ON \
         ${_opts} \
-        ../${_realname}-${_pkgver}
+        ../${_realname}
 
-      cmake --build .
+      "${MINGW_PREFIX}"/bin/cmake.exe --build .
     popd
   done
 }
@@ -71,25 +86,31 @@ package_osgearth() {
             "${MINGW_PACKAGE_PREFIX}-osgQt")
   pkgdesc="A terrain rendering toolkit for OpenSceneGraph (mingw-w64)"
 
-  cd Release-${MSYSTEM}
-  DESTDIR=${pkgdir} cmake --install .
+  cd build-${MSYSTEM}-Release
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
 
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/share/osgearth
-  cp -rf ${srcdir}/${_realname}-${_realname}-${pkgver}/data ${pkgdir}${MINGW_PREFIX}/share/osgearth
+  mv "${pkgdir}${MINGW_PREFIX}"/cmake "${pkgdir}${MINGW_PREFIX}"/lib/cmake
+
+  mkdir -p "${pkgdir}${MINGW_PREFIX}"/share/osgearth
+  cp -rf "${srcdir}"/${_realname}/data "${pkgdir}${MINGW_PREFIX}"/share/osgearth
+
+  install -Dm644 "${srcdir}/${_realname}/LICENSE.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }
 
 package_osgearth-debug() {
-  depends+=("${MINGW_PACKAGE_PREFIX}-OpenSceneGraph-debug"
+  depends+=("${MINGW_PACKAGE_PREFIX}-osgearth"
+            "${MINGW_PACKAGE_PREFIX}-OpenSceneGraph-debug"
             "${MINGW_PACKAGE_PREFIX}-osgQt-debug")
   options=('staticlibs' '!strip')
   pkgdesc="A terrain rendering toolkit for OpenSceneGraph (debug) (mingw-w64)"
 
-  cd Debug-${MSYSTEM}
-  DESTDIR=${pkgdir} cmake --install .
+  cd build-${MSYSTEM}-Debug
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
 
-  rm -rf ${pkgdir}${MINGW_PREFIX}/include
-  rm -rf ${pkgdir}${MINGW_PREFIX}/lib/pkgconfig
-  rm -rf ${pkgdir}${MINGW_PREFIX}/share
+  rm -rf "${pkgdir}${MINGW_PREFIX}"/cmake
+  rm -rf "${pkgdir}${MINGW_PREFIX}"/include
+  rm -rf "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig
+  rm -rf "${pkgdir}${MINGW_PREFIX}"/share
 }
 
 # template start; name=mingw-w64-splitpkg-wrappers; version=1.0;


### PR DESCRIPTION
The release tarball doesn't contain the git submodules. Checkout the tagged git commit instead.

Other than that, just a minor cleanup. And install the license.