### PR TITLE
GDB: Fix internal error when printing C++ pointer-to-member

### DIFF
--- a/mingw-w64-gdb/0006-Fix-internal-error-when-printing-C-pointer-to-member.patch
+++ b/mingw-w64-gdb/0006-Fix-internal-error-when-printing-C-pointer-to-member.patch
@@ -1,0 +1,31 @@
+From 040995e47edccdaad1aaa90b718920572c533146 Mon Sep 17 00:00:00 2001
+From: Orgad Shaneh <orgad.shaneh@audiocodes.com>
+Date: Thu, 30 Jun 2022 16:06:46 +0300
+Subject: [PATCH] Fix internal error when printing C++ pointer-to-member
+
+https://sourceware.org/bugzilla/show_bug.cgi?id=29294
+
+Suggested-by: Tom de Vries <tdevries@suse.de>
+---
+ gdb/cp-valprint.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/gdb/cp-valprint.c b/gdb/cp-valprint.c
+index 8e2b631c839..4833817d791 100644
+--- a/gdb/cp-valprint.c
++++ b/gdb/cp-valprint.c
+@@ -636,7 +636,10 @@ cp_find_class_member (struct type **self_p, int *fieldno,
+ 
+   for (i = TYPE_N_BASECLASSES (self); i < len; i++)
+     {
+-      LONGEST bitpos = self->field (i).loc_bitpos ();
++      field &f = self->field (i);
++      if (f.loc_kind () != FIELD_LOC_KIND_BITPOS)
++       continue;
++      LONGEST bitpos = f.loc_bitpos ();
+ 
+       QUIT;
+       if (offset == bitpos)
+-- 
+2.37.0.windows.1
+

--- a/mingw-w64-gdb/PKGBUILD
+++ b/mingw-w64-gdb/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-multiarch")
 pkgver=12.1
-pkgrel=2
+pkgrel=3
 pkgdesc="GNU Debugger (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -36,7 +36,8 @@ source=(https://ftp.gnu.org/gnu/gdb/${_realname}-${pkgver}.tar.xz{,.sig}
         '0002-Fix-using-gnu-print.patch'
         '0003-configure-Disable-static-linking-with-standard-libs.patch'
         '0004-Python-Configure-path-fixes.patch'
-        '0005-W32-Always-check-USERPROFILE-if-HOME-is-not-set.patch')
+        '0005-W32-Always-check-USERPROFILE-if-HOME-is-not-set.patch'
+        '0006-Fix-internal-error-when-printing-C-pointer-to-member.patch')
 validpgpkeys=('F40ADB902B24264AA42E50BF92EDB04BFF325CF3')
 sha256sums=('0e1793bf8f2b54d53f46dea84ccfd446f48f81b297b28c4f7fc017b818d69fed'
             'SKIP'
@@ -44,7 +45,8 @@ sha256sums=('0e1793bf8f2b54d53f46dea84ccfd446f48f81b297b28c4f7fc017b818d69fed'
             'c60e867fb74f7985b5ac5337a07cc697b4a4ffe19fb6e52f7c377e29c8413a4a'
             '0eb291cd81f7392610d16a83f436a30d3384a99661c6b6ffd1bfb243d5aee6dd'
             '7ef9c6e238a4e232bc689e15e48ee2d8045542c47f0b156d9fc92a7c14e6757e'
-            '39d1cb2a1be8d60c16404ad96882f10cd3ebd942d8b7af62a7416a230a50de93')
+            '39d1cb2a1be8d60c16404ad96882f10cd3ebd942d8b7af62a7416a230a50de93'
+            '839dd8b02c24e03154cb94faeb3b46bce794461463c5a280c7fc616f34360ff4')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
@@ -59,6 +61,7 @@ prepare() {
 
   patch -p1 -i ${srcdir}/0004-Python-Configure-path-fixes.patch
   patch -p1 -i ${srcdir}/0005-W32-Always-check-USERPROFILE-if-HOME-is-not-set.patch
+  patch -p1 -i ${srcdir}/0006-Fix-internal-error-when-printing-C-pointer-to-member.patch
 
   # hack! - libiberty configure tests for header files using "$CPP $CPPFLAGS"
   sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" libiberty/configure


### PR DESCRIPTION
https://sourceware.org/bugzilla/show_bug.cgi?id=29294

Suggested-by: Tom de Vries <tdevries@suse.de>