### PR TITLE
curl: fix .pc file for static linking

### DIFF
--- a/mingw-w64-curl/0004-more-static-fixes.patch
+++ b/mingw-w64-curl/0004-more-static-fixes.patch
@@ -1,0 +1,24 @@
+diff -urN curl-7.84.0/libcurl.pc.in.orig curl-7.84.0/libcurl.pc.in
+--- curl-7.84.0/libcurl.pc.in.orig	2022-06-22 11:49:29.000000000 +0200
++++ curl-7.84.0/libcurl.pc.in	2022-06-30 18:10:26.835823300 +0200
+@@ -36,6 +36,8 @@
+ URL: https://curl.se/
+ Description: Library to transfer files with ftp, http, etc.
+ Version: @CURLVERSION@
++Requires.private: libidn2 libbrotlidec
+ Libs: -L${libdir} -lcurl @LIBCURL_NO_SHARED@
+ Libs.private: @LIBCURL_LIBS@
+ Cflags: -I${includedir} @CPPFLAG_CURL_STATICLIB@
++Cflags.private: -DCURL_STATICLIB
+diff -urN curl-7.84.0/configure.ac.orig curl-7.84.0/configure.ac
+--- curl-7.84.0/configure.ac.orig	2022-06-30 18:13:08.954675200 +0200
++++ curl-7.84.0/configure.ac	2022-06-30 18:18:29.024823500 +0200
+@@ -1914,7 +1914,7 @@
+ 
+ dnl link required libraries for USE_WIN32_CRYPTO or USE_SCHANNEL
+ if test "x$USE_WIN32_CRYPTO" = "x1" -o "x$USE_SCHANNEL" = "x1"; then
+-  LIBS="-ladvapi32 -lcrypt32 $LIBS"
++  LIBS="-ladvapi32 -lcrypt32 -lbcrypt $LIBS"
+ fi
+ 
+ case "x$OPENSSL_ENABLED$GNUTLS_ENABLED$NSS_ENABLED$MBEDTLS_ENABLED$WOLFSSL_ENABLED$SCHANNEL_ENABLED$SECURETRANSPORT_ENABLED$BEARSSL_ENABLED$AMISSL_ENABLED$RUSTLS_ENABLED"

--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -6,12 +6,12 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-gnutls"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-winssl")
 pkgver=7.84.0
-pkgrel=1
-pkgdesc="Command line tool and library for transferring data with URLs. (mingw-w64)"
+pkgrel=2
+pkgdesc="Command line tool and library for transferring data with URLs (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://curl.se/"
-license=("MIT")
+license=("spdx:MIT")
 _cert_depends=("${MINGW_PACKAGE_PREFIX}-ca-certificates"
                "${MINGW_PACKAGE_PREFIX}-libssh2")
 _openssl_depends=("${MINGW_PACKAGE_PREFIX}-openssl"
@@ -36,17 +36,27 @@ source=("https://github.com/curl/curl/releases/download/${_realname}-${pkgver//.
         "pathtools.h"
         "0001-Make-cURL-relocatable.patch"
         "0002-nghttp2-static.patch"
-        "0003-libpsl-static-libs.patch")
+        "0003-libpsl-static-libs.patch"
+        "0004-more-static-fixes.patch")
 sha256sums=('2d118b43f547bfe5bae806d8d47b4e596ea5b25a6c1f080aef49fbcd817c5db8'
             'SKIP'
             '703cd0cb74e714f9e66d26de11c109dd76fab07e723af8dde56a35ea65102e5f'
             '4f9d325265ef6f4e90ad637dea41afa6995388c921fe961ad5dc895aca10318b'
             'c4e6bfd5b58f944d75293128effbd22fe42ee0131b915d9230ceb3c004c0322d'
             '79eec8a337e375d5102fef884030ceacd163a79e5c495e9a974a6b9a11b60c61'
-            '7492d019036b5bec251bfbc3c0b40e5f16d3dd6b2515068835e087a6c21f19ad')
+            '7492d019036b5bec251bfbc3c0b40e5f16d3dd6b2515068835e087a6c21f19ad'
+            '590eb65e90e756eaad993d52a101f29091ada2c742c5a607684e88fc5c560d54')
 validpgpkeys=('914C533DF9B2ADA2204F586D78E11C6B279D5C91'  # Daniel Stenberg
               '27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2'
               '4461EAF0F8E9097F48AF0555F9FEAFF9D34A1BDB')
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying ${_patch}"
+    patch -Nbp1 -i "${srcdir}/${_patch}"
+  done
+}
 
 prepare() {
   test ! -d "${startdir}/../mingw-w64-pathtools" || {
@@ -56,9 +66,13 @@ prepare() {
 
   cd "${srcdir}/${_realname}-${pkgver}"
   cp -fHv "${srcdir}"/pathtools.[ch] lib/
-  patch -p1 -i "${srcdir}/0001-Make-cURL-relocatable.patch"
-  patch -p1 -i "${srcdir}/0002-nghttp2-static.patch"
-  patch -p1 -i "${srcdir}/0003-libpsl-static-libs.patch"
+
+  apply_patch_with_msg \
+    0001-Make-cURL-relocatable.patch \
+    0002-nghttp2-static.patch \
+    0003-libpsl-static-libs.patch \
+    0004-more-static-fixes.patch
+
   autoreconf -vfi
 }
 
@@ -98,6 +112,8 @@ do_build() {
     _variant_config+=("--without-librtmp")
   fi
 
+  msg2 "Building static library"
+  [[ -d "${_destdir}-static" ]] && rm -rf "${_destdir}-static"
   mkdir -p "${_destdir}-static" && cd "${_destdir}-static"
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
@@ -118,10 +134,12 @@ do_build() {
     "${_variant_config[@]}" \
     "${extra_config[@]}"
 # there's a bug with zsh completion generation script and Windows.
-# curl has to specified with the file extension.
+# curl has to be specified with the file extension.
   sed -i "s|\/curl > \$\@|\/curl\$\{EXEEXT\} > \$\@|" scripts/Makefile
   make
 
+  msg2 "Building shared library"
+  [[ -d "${_destdir}-shared" ]] && rm -rf "${_destdir}-shared"
   mkdir -p "${_destdir}-shared" && cd "${_destdir}-shared"
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
@@ -142,7 +160,7 @@ do_build() {
     "${_variant_config[@]}" \
     "${extra_config[@]}"
 # there's a bug with zsh completion generation script and Windows.
-# curl has to specified with the file extension.
+# curl has to be specified with the file extension.
   sed -i "s|\/curl > \$\@|\/curl\$\{EXEEXT\} > \$\@|" scripts/Makefile
   make
 }
@@ -163,6 +181,8 @@ do_package() {
   local PREFIX_DEPS=$(cygpath -am ${MINGW_PREFIX})
   sed -s "s|${PREFIX_DEPS}|${MINGW_PREFIX}|g" -i ${pkgdir}${MINGW_PREFIX}/bin/curl-config
   sed -s "s|${PREFIX_DEPS}|${MINGW_PREFIX}|g" -i ${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/libcurl.pc
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }
 
 package_curl() {


### PR DESCRIPTION
The patch is partly based on the one in MSYS-packages:
https://github.com/msys2/MSYS2-packages/blob/e687cc056aff2a98ad42f506102bb776af4e04d1/curl/0001-more-static-fixes.patch

Install license file.

Fixes #11953.