### PR TITLE
python-numpy: Fix discovered MachAr

### DIFF
--- a/mingw-w64-python-numpy/0013-fix-discovered-machar.patch
+++ b/mingw-w64-python-numpy/0013-fix-discovered-machar.patch
@@ -1,0 +1,47 @@
+From 4756c54e13154bcbc7ae2612874f03a0ccbaa9af Mon Sep 17 00:00:00 2001
+From: Sebastian Berg <sebastian@sipsolutions.net>
+Date: Tue, 21 Jun 2022 13:42:09 -0700
+Subject: [PATCH] BUG: Fix discovered MachAr (still used within valgrind)
+
+This fixes the missing attributes.  I tested the warning and fix
+on valgrind itself.
+These attributes were added in gh-18536 but the fallback path was
+not checked there.
+
+Replaces gh-21813, although something more like it may make sense
+if it allows us to just delete MachAr completely.
+---
+ numpy/core/_machar.py   | 2 ++
+ numpy/core/getlimits.py | 5 +++--
+ 2 files changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/numpy/core/_machar.py b/numpy/core/_machar.py
+index ace19a429f7..3cc7db2784d 100644
+--- a/numpy/core/_machar.py
++++ b/numpy/core/_machar.py
+@@ -326,7 +326,9 @@ def _do_init(self, float_conv, int_conv, float_to_float, float_to_str, title):
+         self.tiny = self.xmin
+         self.huge = self.xmax
+         self.smallest_normal = self.xmin
++        self._str_smallest_normal = float_to_str(self.xmin)
+         self.smallest_subnormal = float_to_float(smallest_subnormal)
++        self._str_smallest_subnormal = float_to_str(smallest_subnormal)
+ 
+         import math
+         self.precision = int(-math.log10(float_to_float(self.eps)))
+diff --git a/numpy/core/getlimits.py b/numpy/core/getlimits.py
+index ab4a4d2be69..4149a5303bc 100644
+--- a/numpy/core/getlimits.py
++++ b/numpy/core/getlimits.py
+@@ -343,8 +343,9 @@ def _get_machar(ftype):
+         return ma_like
+     # Fall back to parameter discovery
+     warnings.warn(
+-        'Signature {} for {} does not match any known type: '
+-        'falling back to type probe function'.format(key, ftype),
++        f'Signature {key} for {ftype} does not match any known type: '
++        'falling back to type probe function.\n'
++        'This warnings indicates broken support for the dtype!',
+         UserWarning, stacklevel=2)
+     return _discovered_machar(ftype)
+ 

--- a/mingw-w64-python-numpy/PKGBUILD
+++ b/mingw-w64-python-numpy/PKGBUILD
@@ -9,7 +9,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=1.22.4
-pkgrel=2
+pkgrel=3
 pkgdesc="Scientific tools for Python (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -37,7 +37,8 @@ source=(https://github.com/numpy/numpy/releases/download/v${pkgver}/${_realname}
         0008-mingw-gcc-doesnt-support-visibility.patch
         0010-mingw-inline-stuff.patch
         0011-dont-die-if-no-fcompiler.patch
-        0012-clang-no-gcc-workaround.patch)
+        0012-clang-no-gcc-workaround.patch
+        0013-fix-discovered-machar.patch)
 sha256sums=('b4308198d0e41efaa108e57d69973398439c7299a9d551680cdd603cf6d20709'
             '94f111ab238c4a82e8613ed14e4cbeb553eabff26523f576e5fcafdbfdc8ee29'
             '3aacb1d92e7764c9f0f24afa1a97b136a069fcd81d63c9fa55565c40c5a29974'
@@ -49,7 +50,8 @@ sha256sums=('b4308198d0e41efaa108e57d69973398439c7299a9d551680cdd603cf6d20709'
             'c7222c3cd85ff6af515514c5c3b8f3c02144c58c1373dec16683fa455504aa69'
             'ae47d0c8adbae798ca1675ae9c0a35146bad00c6b5734f713cd76c01832e5436'
             '87bdd0a47a8662bdb8acaca18452901ee1f42cf08b985443ffb214f7facfdb2d'
-            '86eceee1ec86934d416c52fe8197c09c644b9f27ab93454a849e065b1ddac12f')
+            '86eceee1ec86934d416c52fe8197c09c644b9f27ab93454a849e065b1ddac12f'
+            '11928abb63b9e15c2b9696ed3111fffbd7a375eb156c16c1341392baba2f5046')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -73,7 +75,8 @@ prepare() {
     0008-mingw-gcc-doesnt-support-visibility.patch \
     0010-mingw-inline-stuff.patch \
     0011-dont-die-if-no-fcompiler.patch \
-    0012-clang-no-gcc-workaround.patch
+    0012-clang-no-gcc-workaround.patch \
+    0013-fix-discovered-machar.patch
 
   apply_patch_with_msg \
     0005-mincoming-stack-boundary-32bit-optimized-64bit.patch


### PR DESCRIPTION
Applied upstreamed [patch](https://github.com/numpy/numpy/pull/21815) that closes [issue](https://github.com/numpy/numpy/issues/21827).