### PR TITLE
python-setuptools: update to 62.6.0

### DIFF
--- a/mingw-w64-python-setuptools/0008-default-stdlib-distutils.patch
+++ b/mingw-w64-python-setuptools/0008-default-stdlib-distutils.patch
@@ -1,0 +1,23 @@
+--- setuptools-62.6.0/_distutils_hack/__init__.py.orig	2022-07-02 19:17:30.834207700 +0530
++++ setuptools-62.6.0/_distutils_hack/__init__.py	2022-07-02 19:18:18.557610400 +0530
+@@ -44,7 +44,7 @@
+     """
+     Allow selection of distutils by environment variable.
+     """
+-    which = os.environ.get('SETUPTOOLS_USE_DISTUTILS', 'local')
++    which = os.environ.get('SETUPTOOLS_USE_DISTUTILS', 'stdlib')
+     return which == 'local'
+ 
+ 
+
+--- setuptools-62.6.0/setup.py.orig	2022-07-02 19:21:11.701978000 +0530
++++ setuptools-62.6.0/setup.py	2022-07-02 19:21:37.757524100 +0530
+@@ -54,7 +54,7 @@
+     _pth_contents = textwrap.dedent("""
+         import os
+         var = 'SETUPTOOLS_USE_DISTUTILS'
+-        enabled = os.environ.get(var, 'local') == 'local'
++        enabled = os.environ.get(var, 'stdlib') == 'local'
+         enabled and __import__('_distutils_hack').add_shim()
+         """).lstrip().replace('\n', '; ')
+ 

--- a/mingw-w64-python-setuptools/PKGBUILD
+++ b/mingw-w64-python-setuptools/PKGBUILD
@@ -8,8 +8,8 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
            "${MINGW_PACKAGE_PREFIX}-python2-setuptools<42.0.2")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=59.8.0
-pkgrel=4
+pkgver=62.6.0
+pkgrel=1
 pkgdesc="Easily download, build, install, upgrade, and uninstall Python packages (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -29,6 +29,7 @@ source=(${_realname}-${pkgver}.tar.gz::https://pypi.org/packages/source/${_realn
         '0005-execv-warning.patch'
         '0006-fix-tests-path.patch'
         '0007-windows-arm64.patch'
+        '0008-default-stdlib-distutils.patch'
 )
 checkdepends=(
   "${MINGW_PACKAGE_PREFIX}-python-pytest"
@@ -50,13 +51,14 @@ checkdepends=(
   "${MINGW_PACKAGE_PREFIX}-python-pytest-virtualenv"
   'git'
 )
-sha256sums=('09980778aa734c3037a47997f28d6db5ab18bdf2af0e49f719bfc53967fd2e82'
+sha256sums=('990a4f7861b31532871ab72331e755b5f14efbe52d336ea7f6118144dd478741'
             '7b196884ac0151801f9638dabbf9a789fa9070a3b07a4c9e625c5523e8d47387'
             'fa54581e3dddb9f4edd332dedbc101f48939a9ca5878e13cf9cf9b3408bc8c22'
             '39503256652c7c23ce07e26539e8123d269eb5c09f5d9b07e5784b2d7fb8c96f'
             'a356b0663f67a296624d1b178b42437b380b48a4bbe05a560d3bf29e93a4c623'
             'dbdd96a7ead797b2db9f02dfe19ce853d3775337ccf8fd836377fe3c2a9d1c24'
-            'cb897bc7292a733167fa48b5ca18323d76d3374683a7f5e9986c9df63f5332cc')
+            'cb897bc7292a733167fa48b5ca18323d76d3374683a7f5e9986c9df63f5332cc'
+            'db9a6e2c18d4adfd7c88d17d28268d57afba8845556c1cf1e5c92f513bf36847')
 
 prepare() {
   cd "${srcdir}/setuptools-${pkgver}"
@@ -67,6 +69,8 @@ prepare() {
   patch -p1 -i ${srcdir}/0005-execv-warning.patch
   patch -p1 -i ${srcdir}/0006-fix-tests-path.patch
   patch -p1 -i ${srcdir}/0007-windows-arm64.patch
+  # until https://github.com/pypa/distutils/issues/34 is fixed
+  patch -p1 -i ${srcdir}/0008-default-stdlib-distutils.patch
 
   cd "${srcdir}"
   cp -r setuptools-${pkgver} setuptools-python-${CARCH}


### PR DESCRIPTION
also default to stdlib distutils as the embedded one doesn't support mingw