### PR TITLE
python-pillow: fix libraqm dependency

### DIFF
--- a/mingw-w64-python-pillow/PKGBUILD
+++ b/mingw-w64-python-pillow/PKGBUILD
@@ -4,7 +4,7 @@ _realname=Pillow
 pkgbase=mingw-w64-python-pillow
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-pillow")
 pkgver=9.2.0
-pkgrel=1
+pkgrel=2
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}=${pkgver}"
           "${MINGW_PACKAGE_PREFIX}-python3-pillow=${pkgver}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
@@ -20,16 +20,15 @@ depends=("${MINGW_PACKAGE_PREFIX}-freetype"
          "${MINGW_PACKAGE_PREFIX}-lcms2"
          "${MINGW_PACKAGE_PREFIX}-libimagequant"
          "${MINGW_PACKAGE_PREFIX}-libjpeg"
+         "${MINGW_PACKAGE_PREFIX}-libraqm"
          "${MINGW_PACKAGE_PREFIX}-libtiff"
          "${MINGW_PACKAGE_PREFIX}-libwebp"
          "${MINGW_PACKAGE_PREFIX}-openjpeg2"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools"
-             "${MINGW_PACKAGE_PREFIX}-libraqm"
              "${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-tk")
-optdepends=("${MINGW_PACKAGE_PREFIX}-tk: for the ImageTK module"
-            "${MINGW_PACKAGE_PREFIX}-libraqm: complex text layout support")
+optdepends=("${MINGW_PACKAGE_PREFIX}-tk: for the ImageTK module")
 options=('staticlibs')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/python-pillow/Pillow/archive/${pkgver}.tar.gz)
 sha256sums=('95836f00972dbf724bf1270178683a0ac4ea23c6c3a980858fc9f2f9456e32ef')


### PR DESCRIPTION
Promoted libraqm to required dependency, due to:
https://pillow.readthedocs.io/en/stable/releasenotes/8.2.0.html#libraqm-and-fribidi-linking