### PR TITLE
Luarocks: use cmd mkdir

### DIFF
--- a/mingw-w64-lua-luarocks/0001-luarocks_msys2_mingw_w64.patch
+++ b/mingw-w64-lua-luarocks/0001-luarocks_msys2_mingw_w64.patch
@@ -41,14 +41,11 @@ diff -Naur luarocks-3.7.0.orig/spec/util/test_env.lua luarocks-3.7.0/spec/util/t
 diff -Naur luarocks-3.7.0.orig/src/luarocks/core/cfg.lua luarocks-3.7.0/src/luarocks/core/cfg.lua
 --- luarocks-3.7.0.orig/src/luarocks/core/cfg.lua	2021-04-13 23:53:36.000000000 +0200
 +++ luarocks-3.7.0/src/luarocks/core/cfg.lua	2021-07-25 17:51:51.829906200 +0200
-@@ -414,6 +414,10 @@
+@@ -414,6 +414,7 @@
           defaults.makefile = "Makefile"
           defaults.cmake_generator = "MSYS Makefiles"
           defaults.local_cache = home.."/.cache/luarocks"
 +		 defaults.variables.PWD = "cd"
-+		 local pipe2 = io.popen("cygpath --windows /usr/bin/mkdir")
-+         defaults.variables.MKDIR = pipe2:read("*l")
-+		 pipe2:close()
           defaults.variables.MAKE = "make"
           defaults.variables.CC = "gcc"
           defaults.variables.RC = "windres"

--- a/mingw-w64-lua-luarocks/PKGBUILD
+++ b/mingw-w64-lua-luarocks/PKGBUILD
@@ -6,7 +6,7 @@ _realname=luarocks
 pkgbase=mingw-w64-lua-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-lua-${_realname}")
 pkgver=3.9.0
-pkgrel=1
+pkgrel=2
 pkgdesc="the package manager for Lua modules (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -21,7 +21,7 @@ options=('staticlibs' 'strip')
 source=("https://luarocks.org/releases/${_realname}-${pkgver}.tar.gz"
 		"0001-luarocks_msys2_mingw_w64.patch")
 sha256sums=('5e840f0224891de96be4139e9475d3b1de7af3a32b95c1bdf05394563c60175f'
-            'c49c465ff088eab4ba5a0c088bcfe746dd3d3c476519820cf6058268a5985126')
+            '4ac1ec6372899693548d2d7d575f312d704b6883b50c8d4d3740f47a8e08eef3')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"


### PR DESCRIPTION
Here comes a fix for the following situation: Luarocks cannot create missing parent directories if the Lua package "lfs" is not installed. 

Steps to reproduce:

1.) Assure that Lua package "lfs" (luafilesystem) is not installed (P.S. uninstallation may by tricky, see below https://github.com/msys2/MINGW-packages/pull/12002#issuecomment-1191235469):
```
$ luarocks remove luafilesystem
$ lua -e 'print(require"lfs")'
C:\msys64\mingw64\bin\lua.exe: (command line):1: module 'lfs' not found:
...
```

2.) Install some package (e.g. "lpeg")
```
$ luarocks remove lpeg
$ luarocks install lpeg
Error: failed making directory C:/msys64/mingw64/lib/luarocks/rocks-5.4/lpeg/1.0.2-1/bin
```

The reason for this is, that Luarocks has a fallback for mkdir if "lfs" is not installed, see the code for Windows:
https://github.com/luarocks/luarocks/blob/ecb63347bf7d44c68210befc9d03c013350c7831/src/luarocks/fs/win32/tools.lua#L36-L44
```
function tools.make_dir(directory)
   assert(directory)
   directory = dir.normalize(directory)
   fs.execute_quiet(vars.MKDIR, directory)
   if not fs.is_dir(directory) then
      return false, "failed making directory "..directory
   end
   return true
end
```

However it is assumed here for Windows, that mkdir creates missing parent directories. Compare the above code with this code for Linux:
https://github.com/luarocks/luarocks/blob/ecb63347bf7d44c68210befc9d03c013350c7831/src/luarocks/fs/unix/tools.lua#L24-L31
```
function tools.make_dir(directory)
   assert(directory)
   local ok, err = fs.execute(vars.MKDIR.." -p", directory)
   if not ok then
      err = "failed making directory "..directory
   end
   return ok, err
end
```

Note the "-p" here.

The problem is caused by:
https://github.com/msys2/MINGW-packages/blob/e09173589270815a80e287dfe7c98e5f8880b7e4/mingw-w64-lua-luarocks/0001-luarocks_msys2_mingw_w64.patch#L48-L51

IMHO this seems to be wrong in several ways, e.g. cygpath is invoked here. This was also discussed in #9037, see https://github.com/msys2/MINGW-packages/issues/9037#issuecomment-875250297

One solution could be to append a " -p" to MKDIR here. The solution in this pull request is to use the cmd mkdir as it is done without the invocation of "cygpath --windows /usr/bin/mkdir".

So IMHO this pull request is only a temporary fix to keep this package working as it is if lfs is not installed. A better solution is needed in the long term. Best would be to make the Luarocks package a "real" mingw package that does also work if not invoked under MSYS environment. 
