### PR TITLE
Change packages to use wxWidgets 3.0.x

### DIFF
--- a/mingw-w64-OpenSceneGraph/PKGBUILD
+++ b/mingw-w64-OpenSceneGraph/PKGBUILD
@@ -1,11 +1,12 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 _realname=OpenSceneGraph
+_wx_basever=3.0
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
 _pkgver=3.6.5
 pkgver=${_pkgver//-/}
-pkgrel=13
+pkgrel=14
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="http://www.openscenegraph.org/"
@@ -38,7 +39,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-boost"
          "${MINGW_PACKAGE_PREFIX}-SDL2"
          "${MINGW_PACKAGE_PREFIX}-poppler"
          "${MINGW_PACKAGE_PREFIX}-python"
-         "${MINGW_PACKAGE_PREFIX}-wxWidgets"
+         "${MINGW_PACKAGE_PREFIX}-wxmsw${_wx_basever}"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 options=('staticlibs' 'strip')
 source=(https://github.com/openscenegraph/OpenSceneGraph/archive/${_realname}-${_pkgver}.tar.gz
@@ -106,6 +107,7 @@ build() {
         -GNinja \
         -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
         -DCMAKE_BUILD_TYPE=${builddir%-${MSYSTEM}} \
+        -DwxWidgets_CONFIG_EXECUTABLE=${MINGW_PREFIX}/bin/wx-config-${_wx_basever} \
         ${_opts} \
         ../${_realname}-${_realname}-${_pkgver}
 

--- a/mingw-w64-plplot/PKGBUILD
+++ b/mingw-w64-plplot/PKGBUILD
@@ -12,7 +12,7 @@ _wx_basever=3.0
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.15.0
-pkgrel=13
+pkgrel=14
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 pkgdesc="Scientific plotting software (mingw-w64)"
@@ -112,6 +112,7 @@ build() {
     -DQHULL_LIBRARY_DIRS=${MINGW_PREFIX}/lib \
     -DQHULL_LIBRARIES=qhullstatic \
     -DGD_INCLUDE_DIR=${MINGW_PREFIX}/include \
+    -DwxWidgets_CONFIG_EXECUTABLE=${MINGW_PREFIX}/bin/wx-config-${_wx_basever} \
     -DDEFAULT_NO_BINDINGS=ON \
     -DENABLE_ada=OFF \
     -DENABLE_cxx=ON \

--- a/mingw-w64-spatialite-gui/PKGBUILD
+++ b/mingw-w64-spatialite-gui/PKGBUILD
@@ -1,11 +1,12 @@
 # Maintainer: Konstantin Podsvirov <konstantin@podsvirov.pro>
 
 _realname=spatialite-gui
+_wx_basever=3.0
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _pkgver=2.1.0-beta1
 pkgver=${_pkgver/-beta1/}
-pkgrel=4
+pkgrel=5
 pkgdesc='spatialite-gui is an open source Graphical User Interface (GUI) tool supporting SpatiaLite (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -17,7 +18,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-libspatialite"
          "${MINGW_PACKAGE_PREFIX}-libxlsxwriter"
          "${MINGW_PACKAGE_PREFIX}-proj"
          "${MINGW_PACKAGE_PREFIX}-virtualpg"
-         "${MINGW_PACKAGE_PREFIX}-wxWidgets")
+         "${MINGW_PACKAGE_PREFIX}-wxmsw${_wx_basever}")
 options=('strip' 'staticlibs')
 _realpath=${_realname/-/_}-${_pkgver}
 source=("${_realpath}.tar.gz::https://www.gaia-gis.it/gaia-sins/${_realname}-sources/${_realpath}.tar.gz"
@@ -41,6 +42,7 @@ build() {
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \
     --build=${MINGW_CHOST} \
+    --with-wxconfig=${MINGW_PREFIX}/bin/wx-config-${_wx_basever} \
     --prefix=${MINGW_PREFIX}
 
   make

--- a/mingw-w64-winsparkle/Makefile
+++ b/mingw-w64-winsparkle/Makefile
@@ -21,11 +21,11 @@ objects:
 	$(CC) -std=c++11 -c -mthreads -D_WIN32_WINNT=0x600 -DUNICODE -D_UNICODE -DBUILDING_WIN_SPARKLE signatureverifier.cpp -I../include
 	$(CC) -std=c++11 -c -mthreads -D_WIN32_WINNT=0x600 -DUNICODE -D_UNICODE -DBUILDING_WIN_SPARKLE threads.cpp          -I../include
 	$(CC) -std=c++11 -c -mthreads -D_WIN32_WINNT=0x600 -DUNICODE -D_UNICODE -DBUILDING_WIN_SPARKLE updatechecker.cpp    -I../include
-	$(CC) -std=c++11 -c -mthreads -D_WIN32_WINNT=0x600 -DUNICODE -D_UNICODE -DBUILDING_WIN_SPARKLE ui.cpp               -I../include $(shell wx-config --cflags)
-	$(CC) -std=c++11 -c -mthreads -D_WIN32_WINNT=0x600 -DUNICODE -D_UNICODE -DBUILDING_WIN_SPARKLE updatedownloader.cpp -I../include $(shell wx-config --cflags)
+	$(CC) -std=c++11 -c -mthreads -D_WIN32_WINNT=0x600 -DUNICODE -D_UNICODE -DBUILDING_WIN_SPARKLE ui.cpp               -I../include $(shell wx-config-3.0 --cflags)
+	$(CC) -std=c++11 -c -mthreads -D_WIN32_WINNT=0x600 -DUNICODE -D_UNICODE -DBUILDING_WIN_SPARKLE updatedownloader.cpp -I../include $(shell wx-config-3.0 --cflags)
 
 static: objects
 	ar rcs libwinsparkle.a *.o
 
 dll: objects translations
-	$(CC) -shared -mthreads -o libwinsparkle.dll *.o translations.res -Wl,--out-implib,libwinsparkle.dll.a -lstdc++ $(shell wx-config --libs core) -lexpat -lcrypto -lssl -lcrypt32 -lwininet -lversion -lole32 -loleaut32 -lrpcrt4 -luuid
+	$(CC) -shared -mthreads -o libwinsparkle.dll *.o translations.res -Wl,--out-implib,libwinsparkle.dll.a -lstdc++ $(shell wx-config-3.0 --libs core) -lexpat -lcrypto -lssl -lcrypt32 -lwininet -lversion -lole32 -loleaut32 -lrpcrt4 -luuid

--- a/mingw-w64-winsparkle/PKGBUILD
+++ b/mingw-w64-winsparkle/PKGBUILD
@@ -1,12 +1,13 @@
 # Maintainer: Diego Sogari <diego.sogari@gmail.com>
 
 _realname=winsparkle
+_wx_basever=3.0
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 pkgver=0.7.0
-pkgrel=1
+pkgrel=2
 pkgdesc='App update framework for Windows, inspired by Sparkle for OS X (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -15,13 +16,13 @@ license=('MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
 depends=("${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-openssl"
-         "${MINGW_PACKAGE_PREFIX}-wxWidgets") # gcc-libs not needed?
+         "${MINGW_PACKAGE_PREFIX}-wxmsw${_wx_basever}") # gcc-libs not needed?
 source=("${_realname}-${pkgver}.zip::https://github.com/vslavik/winsparkle/releases/download/v${pkgver}/WinSparkle-${pkgver}-src.zip"
         001-compile-fixes.patch
         Makefile)
 sha256sums=('748adadd539c7ed3fd8f62d2f960b04d715fedb3e8f328f97decae85f29dc399'
             '7e2f9fb05f7c6191597fa20341e765c2d8c1bec868f0bba4165fee7140bb5afa'
-            '9c86365359d6a20bfb70734b7ed933e3947376cdfda187cf26e963a1512c4281')
+            'b78bd7230eaac2752cdb78877d33753ea8a2749403096637985d7e6108e8712d')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {


### PR DESCRIPTION
These changes make packages use wxWidgets 3.0.x instead of using the version returned by wx-config.
This is needed to prevent these four packages from using wxWidgets 3.2.0 when PR #12007 is applied.

Tim S.