### PR TITLE
wxPython4.0: fix building with MinGW toolchain

### DIFF
--- a/mingw-w64-wxPython4.0/0003-Optionally-use-MinGW-toolchain.patch
+++ b/mingw-w64-wxPython4.0/0003-Optionally-use-MinGW-toolchain.patch
@@ -1,0 +1,113 @@
+diff -urN wxPython-4.0.7.post2/buildtools/config.py.orig wxPython-4.0.7.post2/buildtools/config.py
+--- wxPython-4.0.7.post2/buildtools/config.py.orig	2022-07-11 17:17:28.646158400 +0200
++++ wxPython-4.0.7.post2/buildtools/config.py	2022-07-11 17:18:43.541135100 +0200
+@@ -137,13 +137,16 @@
+         self.finishSetup()
+ 
+ 
+-    def finishSetup(self, wx_config=None, debug=None):
++    def finishSetup(self, wx_config=None, debug=None, compiler=None):
+         if wx_config is not None:
+             self.WX_CONFIG = wx_config
+ 
+         if debug is not None:
+             self.debug = debug
+ 
++        if compiler is not None:
++            self.COMPILER = compiler
++
+         #---------------------------------------
+         # MSW specific settings
+         if os.name == 'nt' and  self.COMPILER == 'msvc':
+diff -urN wxPython-4.0.7.post2/wscript.orig wxPython-4.0.7.post2/wscript
+--- wxPython-4.0.7.post2/wscript.orig	2019-11-12 03:54:31.000000000 +0100
++++ wxPython-4.0.7.post2/wscript	2022-07-11 17:22:56.272316400 +0200
+@@ -34,8 +35,7 @@
+ def options(opt):
+     if isWindows:
+         opt.load('msvc')
+-    else:
+-        opt.load('compiler_c compiler_cxx')
++    opt.load('compiler_c compiler_cxx')
+     opt.load('python')
+ 
+     opt.add_option('--debug', dest='debug', action='store_true', default=False,
+@@ -55,6 +55,8 @@
+                    help='On Linux build for gtk2 (default gtk3)')
+     opt.add_option('--gtk3', dest='gtk3', action='store_true', default=True,
+                    help='On Linux build for gtk3')
++    opt.add_option('--no_msvc', dest='use_msvc', action='store_false', default=isWindows,
++                   help='Set to use a MinGW toolchain')
+     opt.add_option('--msvc_arch', dest='msvc_arch', default='x86', action='store',
+                    help='The architecture to target for MSVC builds. Supported values '
+                    'are: "x86" or "x64"')
+@@ -64,7 +66,7 @@
+ 
+ 
+ def configure(conf):
+-    if isWindows:
++    if conf.options.use_msvc:
+         # For now simply choose the compiler version based on the Python
+         # version. We have a chicken-egg problem here. The compiler needs to
+         # be selected before the Python stuff can be configured, but we need
+@@ -97,6 +99,8 @@
+         conf.load('msvc')
+     else:
+         conf.load('compiler_c compiler_cxx')
++        if isWindows:
++            conf.load('winres')
+ 
+     if conf.options.python:
+         conf.env.PYTHON = conf.options.python
+@@ -114,10 +118,12 @@
+     conf.env.debug = conf.options.debug
+     conf.env.msvc_relwithdebug = conf.options.msvc_relwithdebug
+ 
++    conf.env.use_msvc = conf.options.use_msvc
++
+     # Ensure that the headers in siplib and Phoenix's src dir can be found
+     conf.env.INCLUDES_WXPY = ['sip/siplib', 'wx/include', 'src']
+ 
+-    if isWindows:
++    if conf.options.use_msvc:
+         # Windows/MSVC specific stuff
+ 
+         cfg.finishSetup(debug=conf.env.debug)
+@@ -203,7 +209,8 @@
+ 
+         # finish configuring the Config object
+         conf.env.wx_config = conf.options.wx_config
+-        cfg.finishSetup(conf.env.wx_config, conf.env.debug)
++        cfg.finishSetup(conf.env.wx_config, conf.env.debug,
++                        'mingw32' if isWindows and not conf.env.use_msvc else None)
+ 
+         # Check wx-config exists and fetch some values from it
+         rpath = ' --no-rpath' if not conf.options.no_magic else ''
+@@ -542,7 +555,8 @@
+     from distutils.file_util import copy_file
+     from buildtools.config   import opj, updateLicenseFiles
+ 
+-    cfg.finishSetup(bld.env.wx_config)
++    cfg.finishSetup(wx_config=bld.env.wx_config,
++                    compiler='mingw32' if isWindows and not bld.env.use_msvc else None)
+ 
+     if not isWindows:
+         cmd = ' '.join(bld.env.CC) + ' --version'
+@@ -668,7 +688,7 @@
+     open(tgt, "wb").close() # essentially just a unix 'touch' command
+     tgt = opj(cfg.PKGDIR, os.path.basename(src))
+     copy_file(src, tgt, verbose=1)
+-    if isWindows and task.env.msvc_relwithdebug:
++    if task.env.use_msvc and task.env.msvc_relwithdebug:
+         # also copy the .pdb file
+         src = src.replace('.pyd', '.pdb')
+         tgt = opj(cfg.PKGDIR, os.path.basename(src))
+@@ -722,7 +742,7 @@
+ 
+ # Add flags to create .pdb files for debugging with MSVC
+ def addRelwithdebugFlags(bld, moduleName):
+-    if isWindows and bld.env.msvc_relwithdebug:
++    if bld.env.use_msvc and bld.env.msvc_relwithdebug:
+         compile_flags = ['/Zi', '/Fd_tmp_{}.pdb'.format(moduleName)]
+         if sys.version_info > (3,5):
+             # It looks like the /FS flag doesn't exist in the compilers used

--- a/mingw-w64-wxPython4.0/PKGBUILD
+++ b/mingw-w64-wxPython4.0/PKGBUILD
@@ -8,11 +8,11 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}4.0"
 pkgver=4.0.7.2
 _pkgver="${pkgver%.*}"
 _post="${pkgver##*.}"
-pkgrel=2
+pkgrel=3
 pkgdesc="A wxWidgets GUI toolkit for Python (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
-license=("custom:wxWindows")
+license=("spdx:wxWindows")
 url="https://www.wxpython.org/"
 depends=("${MINGW_PACKAGE_PREFIX}-python"
          $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo \
@@ -27,12 +27,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-doxygen"
              "${MINGW_PACKAGE_PREFIX}-cc"
              'patch'
              # for waf
-             "python" "python-setuptools")
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 options=('strip' 'staticlibs' 'buildflags')
 source=("https://files.pythonhosted.org/packages/source/w/wxPython/wxPython-$_pkgver.post$_post.tar.gz"
         "0001-wscript-wxWidgets-win-from-cygwin.patch"
         "0002-etg-handle-cast.patch"
+        "0003-Optionally-use-MinGW-toolchain.patch"
         "0007-etg-Add-some-missing-private-assignment-operators.patch"
         "0100-etgtools-wxHandleFatalExceptions.patch"
         "0201-wxWidgets.Doxyfile.patch"
@@ -44,6 +45,7 @@ noextract=("${_realname}-$_pkgver.post$_post.tar.gz")
 sha256sums=('5a229e695b64f9864d30a5315e0c1e4ff5e02effede0a07f16e8d856737a0c4e'
             '88cc6c7c9cdb6dd6f8e7a74356b275262f4e8d920d64bae987408ee2ff651bc1'
             '7af6ee0a93cfd5d5a621ed09ba91a42a017c8c42a2ff4936b98bdf4014086359'
+            'dddbf050b84e9bb330cb56f61181555d4e0f083ee68736e0f5b298d910daa0c5'
             'a1dc197b70dbe72b9b8a5298391cc5b1fdc77b295461e8e3d313a0c92096fc39'
             'f2416985340363453c44b62c659d378e345a1e1b28c2173bbad2671a751cf844'
             '5d9c49bde4f60c1a818fb1b25ade2163467349fbf2e074d5fef2058748e88965'
@@ -64,6 +66,7 @@ prepare() {
   # clang doesn't like casting from pointer to smaller integer type (long)
   # https://github.com/wxWidgets/Phoenix/pull/1972
   patch -Np1 -i "${srcdir}/0002-etg-handle-cast.patch"
+  patch -Np1 -i "${srcdir}/0003-Optionally-use-MinGW-toolchain.patch"
   patch -Np1 -i "${srcdir}/0007-etg-Add-some-missing-private-assignment-operators.patch"
   # https://github.com/wxWidgets/Phoenix/commit/3500ac7a9e7377c154a507dd7ea1b5b7bfda8c09
   patch -Np1 -i "${srcdir}/0100-etgtools-wxHandleFatalExceptions.patch"
@@ -98,15 +101,17 @@ build() {
   # The build errors out with 1 or 2 jobs
   local _jobs=${MAKEFLAGS:--j3}
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  CC_NAME=${CC} CXX_NAME=${CXX} \
-  LDFLAGS="${LDFLAGS} $(python-config --ldflags)" \
+  CC_NAME=${CC} CC="${MINGW_PREFIX}/bin/${CC}.exe" \
+  CXX_NAME=${CXX} CXX="${MINGW_PREFIX}/bin/${CXX}.exe" \
+  LDFLAGS="${LDFLAGS} $("${MINGW_PREFIX}/bin/python-config" --ldflags)" \
   PYTHON_CONFIG="${MINGW_PREFIX}/bin/python-config" \
     "${MINGW_PREFIX}/bin/waf" \
       --prefix="${MINGW_PREFIX}" --python="${MINGW_PREFIX}/bin/python.exe" \
-      --check-cxx-compiler=${CXX} --check-c-compiler=${CC} --color=yes --jobs=${_jobs#-j} \
-      --wx_config=wx-config-${_wx_basever} \
+      --no_msvc --check-c-compiler=${CC} --check-cxx-compiler=${CXX} \
+      --color=yes --jobs=${_jobs#-j} \
+      --wx_config="sh.exe ${MINGW_PREFIX}/bin/wx-config-${_wx_basever}" \
       --no_magic --nopyc --nopyo --nopycache \
-        configure build -vv # extra verbose option
+        configure build
 }
 
 package() {


### PR DESCRIPTION
Add wax command line option `--no_msvc` to select a MinGW toolchain on Windows.
IIUC, this allows using more native build tools (instead of MSYS2/Cygwin tools).

See also this upstream PR: https://github.com/wxWidgets/Phoenix/pull/2211