### PR TITLE
github-cli: upgrade to v2.14.1

### DIFF
--- a/mingw-w64-github-cli/PKGBUILD
+++ b/mingw-w64-github-cli/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=github-cli
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.13.0
+pkgver=2.14.1
 pkgrel=1
 pkgdesc='The GitHub CLI (mingw-w64)'
 arch=('any')
@@ -16,7 +16,7 @@ optdepends=("git: To interact with repositories")
 options=('!strip')
 source=("$_realname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz"
         "gh")
-sha256sums=('f8bc46bda990bc9947a26f5505533b86903c96f95047b2dacf7c9534e5b86760'
+sha256sums=('83ea9ae83c7de8f5cf73ee33004e655cbea5665165740511abfda8c0e489f7fa'
             '9ee5f2b44b7e9aa751508f02c1020e341e0212a9aa146b7428eb5ffea310be27')
 build() {
     cd "cli-$pkgver"


### PR DESCRIPTION
See https://github.com/cli/cli/releases/tag/v2.14.0 and https://github.com/cli/cli/releases/tag/v2.14.1 for details.