### PR TITLE
Disable `strip` for libc++

### DIFF
--- a/mingw-w64-libc++/PKGBUILD
+++ b/mingw-w64-libc++/PKGBUILD
@@ -22,7 +22,11 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-lld"
              "${MINGW_PACKAGE_PREFIX}-compiler-rt"
              "${MINGW_PACKAGE_PREFIX}-python")
-options=('!debug' '!strip') # GNU's strip breaks the library #11553
+options=('!debug')
+if [[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]]; then
+  # GNU's strip breaks the library #11553
+  options+=('!strip')
+fi
 _url=https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkgver}
 source=("${_url}/llvm-${pkgver}.src.tar.xz"{,.sig}
         "${_url}/libcxx-${pkgver}.src.tar.xz"{,.sig}

--- a/mingw-w64-libc++/PKGBUILD
+++ b/mingw-w64-libc++/PKGBUILD
@@ -10,7 +10,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}abi"
          "${MINGW_PACKAGE_PREFIX}-libunwind")
 pkgver=14.0.4
-pkgrel=1
+pkgrel=2
 url="https://libcxx.llvm.org/"
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -22,7 +22,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-lld"
              "${MINGW_PACKAGE_PREFIX}-compiler-rt"
              "${MINGW_PACKAGE_PREFIX}-python")
-options=('!debug' 'strip')
+options=('!debug' '!strip') # GNU's strip breaks the library #11553
 _url=https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkgver}
 source=("${_url}/llvm-${pkgver}.src.tar.xz"{,.sig}
         "${_url}/libcxx-${pkgver}.src.tar.xz"{,.sig}


### PR DESCRIPTION
Since nobody wanted to work on manual stripping with `llvm-strip` lets just disable it. Size increase is only 0.75 MiB (all packages combined) and it might be also helpful for debugging.

Fixes https://github.com/msys2/MINGW-packages/issues/11553