### PR TITLE
openshadinglanguage: fix cmake config files

### DIFF
--- a/mingw-w64-openshadinglanguage/0001-cmake-config.patch
+++ b/mingw-w64-openshadinglanguage/0001-cmake-config.patch
@@ -1,0 +1,16 @@
+diff -urN OpenShadingLanguage-Release-1.11.17.0/src/cmake/Config.cmake.in.orig OpenShadingLanguage-Release-1.11.17.0/src/cmake/Config.cmake.in
+--- OpenShadingLanguage-Release-1.11.17.0/src/cmake/Config.cmake.in.orig	2022-01-08 03:36:45.000000000 +0100
++++ OpenShadingLanguage-Release-1.11.17.0/src/cmake/Config.cmake.in	2022-07-15 18:55:14.471238200 +0200
+@@ -19,9 +19,9 @@
+ 
+ find_dependency(OpenImageIO @OpenImageIO_VERSION@ REQUIRED)
+ 
+-set_and_check (@PROJECT_NAME@_INCLUDE_DIR "@CMAKE_INSTALL_FULL_INCLUDEDIR@")
+-set_and_check (@PROJECT_NAME@_INCLUDES    "@CMAKE_INSTALL_FULL_INCLUDEDIR@")
+-set_and_check (@PROJECT_NAME@_LIB_DIR     "@CMAKE_INSTALL_FULL_LIBDIR@")
++set_and_check (@PROJECT_NAME@_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@")
++set_and_check (@PROJECT_NAME@_INCLUDES    "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@")
++set_and_check (@PROJECT_NAME@_LIB_DIR     "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@")
+ 
+ #...logic to determine installedPrefix from the own location...
+ #set (@PROJECT_NAME@_CONFIG_DIR  "${installedPrefix}/@CONFIG_INSTALL_DIR@")

--- a/mingw-w64-openshadinglanguage/PKGBUILD
+++ b/mingw-w64-openshadinglanguage/PKGBUILD
@@ -6,7 +6,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 pkgver=1.11.17.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Advanced shading language for production GI renderers (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -32,6 +32,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-cc")
 options=('staticlibs' '!emptydirs' 'strip' '!debug')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/imageworks/OpenShadingLanguage/archive/Release-${pkgver}.tar.gz
+        0001-cmake-config.patch
         0002-dont-add-flex-include-dir.patch
         0003-fix-OIIO-windows.patch
         0005-Fix-cast-from-void-ptr.patch
@@ -42,8 +43,10 @@ source=(${_realname}-${pkgver}.tar.gz::https://github.com/imageworks/OpenShading
         0014-fix-testshade-library-name.patch
         0015-llvm-linking.patch
         0016-OIIO-API.patch
+        # https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/pull/1492
         llvm14.patch)
 sha256sums=('4d23cf742f7917ea534408a1a491da8cfa245eed66b32f32d1a2785cb6a95735'
+            'ac91faa2507685d4cfca544905474d84b946c888e1e1823dc93b6036979db195'
             '70d4ce3c69ed072eee0d2bb84cecea5ff9ff35e258a24a7a78ec94e4b626e493'
             '6b1e4065292361c724a53f6961b72ff74dde9349a3c1e42a1ab8e883d902f5e4'
             '8bc55ff08257d9482d32efe25a416b02acca345897acc46c09c71b6a496e55cc'
@@ -56,22 +59,30 @@ sha256sums=('4d23cf742f7917ea534408a1a491da8cfa245eed66b32f32d1a2785cb6a95735'
             '01a9e6543159b8c966fa31755781f028b156fb799ae1c8eab94cd8d4c2ce48a6'
             '6184b86ef9105d698e6fd0c5f00ca51ef07707db5acff507b124baef96266ab5')
 
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Np1 -i "${srcdir}/$_patch"
+  done
+}
+
 prepare() {
   cd ${srcdir}/OpenShadingLanguage-Release-${pkgver}
 
-  patch -p1 -i ${srcdir}/0002-dont-add-flex-include-dir.patch
-  patch -p1 -i ${srcdir}/0003-fix-OIIO-windows.patch
-  patch -p1 -i ${srcdir}/0005-Fix-cast-from-void-ptr.patch
-  patch -p1 -i ${srcdir}/0007-Fix-bad-casts-with-intptr_t.patch
-  patch -p1 -i ${srcdir}/0010-macros-undef-mingw.patch
-  patch -p1 -i ${srcdir}/0012-isatty-mingw.patch
-  patch -p1 -i ${srcdir}/0013-disable-assert-partio.patch
-  patch -p1 -i ${srcdir}/0014-fix-testshade-library-name.patch
-  patch -p1 -i ${srcdir}/0015-llvm-linking.patch
-  patch -p1 -i ${srcdir}/0016-OIIO-API.patch
-
-  # https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/pull/1492
-  patch -p1 -i ${srcdir}/llvm14.patch
+  apply_patch_with_msg \
+    0001-cmake-config.patch \
+    0002-dont-add-flex-include-dir.patch \
+    0003-fix-OIIO-windows.patch \
+    0005-Fix-cast-from-void-ptr.patch \
+    0007-Fix-bad-casts-with-intptr_t.patch \
+    0010-macros-undef-mingw.patch \
+    0012-isatty-mingw.patch \
+    0013-disable-assert-partio.patch \
+    0014-fix-testshade-library-name.patch \
+    0015-llvm-linking.patch \
+    0016-OIIO-API.patch \
+    llvm14.patch
 }
 
 build() {
@@ -112,7 +123,6 @@ package() {
   cd ${srcdir}//build-${MSYSTEM}
 
   DESTDIR=${pkgdir} cmake --install .
-  mv "${pkgdir}${MINGW_PREFIX}"/lib/*.dll "${pkgdir}${MINGW_PREFIX}"/bin/
 
   mkdir -p "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname}
   install -Dm644 "${srcdir}/OpenShadingLanguage-Release-${pkgver}/LICENSE.md" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.md"


### PR DESCRIPTION
There are two issues with the cmake config files of OSL:
1. One of the files is moved after it is installed. That leaves the cmake files pointing to the wrong locations.
2. A `sed` rule is used to replace the literal prefix of the build system with `${_IMPORT_PREFIX}`. But that variable isn't set in one of the .cmake files.

The file that is moved is a "module" library. IIUC, those are libraries that aren't meant to be linked to. But their symbols should be loaded on runtime. It looks like `cmake` installs those in the `lib` directory (not `bin`). Maybe, it does that for a reason. Instead of trying to change where `cmake` installs "module" libraries (which would probably also lead to consistent .cmake files), this change removes moving that library after it is installed.

It also adds a patch that fixes the other .cmake file.