### PR TITLE
[RFC] wxwidgets3.2: Add package version 3.2.0

### DIFF
--- a/mingw-w64-wxwidgets3.2/001-wxWidgets-3.0.2-relocate-prefix-in-bin-wx-config.patch
+++ b/mingw-w64-wxwidgets3.2/001-wxWidgets-3.0.2-relocate-prefix-in-bin-wx-config.patch
@@ -1,0 +1,10 @@
+--- wxWidgets-3.0.2/wx-config.in.orig	2015-12-12 14:49:36.241974800 +0000
++++ wxWidgets-3.0.2/wx-config.in	2015-12-12 14:53:06.242503400 +0000
+@@ -401,6 +401,7 @@
+ 
+ # Determine the base directories we require.
+ prefix=${input_option_prefix-${this_prefix:-@prefix@}}
++prefix=$(cygpath -m ${prefix})
+ exec_prefix=${input_option_exec_prefix-${input_option_prefix-${this_exec_prefix:-@exec_prefix@}}}
+ wxconfdir="@libdir@/wx/config"
+ 

--- a/mingw-w64-wxwidgets3.2/005-wxWidgets-3.1.3-Remove-WX_LIBS_STATIC-from-m4.patch
+++ b/mingw-w64-wxwidgets3.2/005-wxWidgets-3.1.3-Remove-WX_LIBS_STATIC-from-m4.patch
@@ -1,0 +1,79 @@
+From 68d9676bc0c56ff0112c1ced8061eb75871834a3 Mon Sep 17 00:00:00 2001
+From: Tim Stahlhut <stahta01@gmail.com>
+Date: Sat, 1 Jun 2019 19:10:57 -0400
+Subject: Remove WX_LIBS_STATIC support
+
+---
+ wxwin.m4 | 27 ++++++---------------------
+ 1 file changed, 6 insertions(+), 21 deletions(-)
+
+diff --git a/wxwin.m4 b/wxwin.m4
+index 68cf880fb6..a4d93a21de 100644
+--- a/wxwin.m4
++++ b/wxwin.m4
+@@ -145,15 +145,15 @@ dnl WX_CONFIG_CHECK(VERSION, [ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND
+ dnl                  [, WX-LIBS [, ADDITIONAL-WX-CONFIG-FLAGS
+ dnl                  [, WX-OPTIONAL-LIBS]]]]])
+ dnl
+-dnl Test for wxWidgets, and define WX_C*FLAGS, WX_LIBS and WX_LIBS_STATIC
+-dnl (the latter is for static linking against wxWidgets). Set WX_CONFIG_NAME
+-dnl environment variable to override the default name of the wx-config script
+-dnl to use. Set WX_CONFIG_PATH to specify the full path to wx-config - in this
++dnl Test for wxWidgets, and define WX_C*FLAGS and WX_LIBS
++dnl Set WX_CONFIG_NAME environment variable to override
++dnl the default name of the wx-config script to use.
++dnl Set WX_CONFIG_PATH to specify the full path to wx-config - in this
+ dnl case the macro won't even waste time on tests for its existence.
+ dnl
+ dnl Optional WX-LIBS argument contains comma- or space-separated list of
+-dnl wxWidgets libraries to link against. If it is not specified then WX_LIBS
+-dnl and WX_LIBS_STATIC will contain flags to link with all of the core
++dnl wxWidgets libraries to link against. If it is not specified then
++dnl WX_LIBS will contain flags to link with all of the core
+ dnl wxWidgets libraries.
+ dnl
+ dnl Optional ADDITIONAL-WX-CONFIG-FLAGS argument is appended to wx-config
+@@ -248,18 +248,6 @@ AC_DEFUN([WX_CONFIG_CHECK],
+       fi
+       WX_LIBS=`$WX_CONFIG_WITH_ARGS --libs $4 $wx_optional_libs`
+ 
+-      dnl is this even still appropriate?  --static is a real option now
+-      dnl and WX_CONFIG_WITH_ARGS is likely to contain it if that is
+-      dnl what the user actually wants, making this redundant at best.
+-      dnl For now keep it in case anyone actually used it in the past.
+-      AC_MSG_CHECKING([for wxWidgets static library])
+-      WX_LIBS_STATIC=`$WX_CONFIG_WITH_ARGS --static --libs $4 $wx_optional_libs 2>/dev/null`
+-      if test "x$WX_LIBS_STATIC" = "x"; then
+-        AC_MSG_RESULT(no)
+-      else
+-        AC_MSG_RESULT(yes)
+-      fi
+-
+       dnl starting with version 2.2.6 wx-config has --cppflags argument
+       wx_has_cppflags=""
+       if test $wx_config_major_version -gt 2; then
+@@ -329,7 +317,6 @@ AC_DEFUN([WX_CONFIG_CHECK],
+        WX_CPPFLAGS=""
+        WX_CXXFLAGS=""
+        WX_LIBS=""
+-       WX_LIBS_STATIC=""
+        WX_RESCOMP=""
+ 
+        if test ! -z "$5"; then
+@@ -365,7 +352,6 @@ AC_DEFUN([WX_CONFIG_CHECK],
+     WX_CPPFLAGS=""
+     WX_CXXFLAGS=""
+     WX_LIBS=""
+-    WX_LIBS_STATIC=""
+     WX_RESCOMP=""
+ 
+     ifelse([$3], , :, [$3])
+@@ -378,7 +364,6 @@ AC_DEFUN([WX_CONFIG_CHECK],
+   AC_SUBST(WX_CFLAGS_ONLY)
+   AC_SUBST(WX_CXXFLAGS_ONLY)
+   AC_SUBST(WX_LIBS)
+-  AC_SUBST(WX_LIBS_STATIC)
+   AC_SUBST(WX_VERSION)
+   AC_SUBST(WX_RESCOMP)
+ 
+-- 

--- a/mingw-w64-wxwidgets3.2/010-wxWidgets-3.1.6-Redo-manifest-filename-logic.patch
+++ b/mingw-w64-wxwidgets3.2/010-wxWidgets-3.1.6-Redo-manifest-filename-logic.patch
@@ -1,0 +1,43 @@
+From eeced51b78e1e19772a5876b67841090d3985d43 Mon Sep 17 00:00:00 2001
+From: Tim Stahlhut <stahta01@gmail.com>
+Date: Tue, 17 May 2022 14:44:56 -0400
+Subject: Redo manifest filename logic
+
+---
+ include/wx/msw/wx.rc | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/include/wx/msw/wx.rc b/include/wx/msw/wx.rc
+index 7a6b203f13..a098783908 100644
+--- a/include/wx/msw/wx.rc
++++ b/include/wx/msw/wx.rc
+@@ -106,11 +106,11 @@ wxBITMAP_STD_COLOURS    BITMAP "wx/msw/colours.bmp"
+ #endif
+ 
+ #if !defined(wxUSE_DPI_AWARE_MANIFEST) || wxUSE_DPI_AWARE_MANIFEST == 0
+-    #define wxMANIFEST_DPI .manifest
++    #define wxMANIFEST_DPI wx/msw/wx.manifest
+ #elif wxUSE_DPI_AWARE_MANIFEST == 1
+-    #define wxMANIFEST_DPI _dpi_aware.manifest
++    #define wxMANIFEST_DPI wx/msw/wx_dpi_aware.manifest
+ #elif wxUSE_DPI_AWARE_MANIFEST == 2
+-    #define wxMANIFEST_DPI _dpi_aware_pmv2.manifest
++    #define wxMANIFEST_DPI wx/msw/wx_dpi_aware_pmv2.manifest
+ #endif
+ 
+ #define wxRC_STR(text) wxRC_STR2(text)
+@@ -119,10 +119,11 @@ wxBITMAP_STD_COLOURS    BITMAP "wx/msw/colours.bmp"
+ #define wxRC_CONCAT2(a, b) a ## b
+ 
+ #ifdef __GNUC__
+-    #define wxMANIFEST_FILE "wx/msw/wx" wxRC_STR(wxMANIFEST_DPI)
++    #define wxMANIFEST_FILE wxRC_STR(wxMANIFEST_DPI)
+ #else
+-    #define wxMANIFEST_FILE wxRC_CONCAT(wx/msw/wx, wxMANIFEST_DPI)
++    #define wxMANIFEST_FILE wxMANIFEST_DPI
+ #endif
++
+ wxMANIFEST_ID RT_MANIFEST wxMANIFEST_FILE
+ 
+ #endif // wxUSE_RC_MANIFEST
+-- 

--- a/mingw-w64-wxwidgets3.2/101-wxWidgets-3.2.0-Fix-wxGTK-win-build.patch
+++ b/mingw-w64-wxwidgets3.2/101-wxWidgets-3.2.0-Fix-wxGTK-win-build.patch
@@ -1,0 +1,13 @@
+diff --git a/src/generic/splitter.cpp b/src/generic/splitter.cpp
+index 3d6e64586842..0bb7daa65b44 100644
+--- a/src/generic/splitter.cpp
++++ b/src/generic/splitter.cpp
+@@ -80,7 +80,7 @@ static bool IsLive(wxSplitterWindow* wnd)
+     return true; // Mac can't paint outside paint event - always need live mode
+ #else
+     // wxClientDC doesn't work with Wayland neither, so check if we're using it.
+-    #if defined(__WXGTK3__)
++    #if defined(__WXGTK3__) && defined(__UNIX__)
+         switch ( wxGetDisplayInfo().type )
+         {
+             case wxDisplayNone:

--- a/mingw-w64-wxwidgets3.2/PKGBUILD
+++ b/mingw-w64-wxwidgets3.2/PKGBUILD
@@ -1,0 +1,530 @@
+# Maintainer: Tim Stahlhut <stahta01@gmail.com>
+
+_realname=wxWidgets
+_wx_basever=3.2
+# Example _wx_buildver value is "-rc"
+_wx_buildver=
+
+pkgbase=mingw-w64-${_realname}3.2
+pkgname=("${MINGW_PACKAGE_PREFIX}-libwxbase${_wx_basever}"
+#         "${MINGW_PACKAGE_PREFIX}-libwxbase${_wx_basever}-wxconfig"
+         "${MINGW_PACKAGE_PREFIX}-libwxmsw${_wx_basever}"
+         "${MINGW_PACKAGE_PREFIX}-libwxmsw${_wx_basever}-dev"
+         "${MINGW_PACKAGE_PREFIX}-libwxmsw${_wx_basever}-wxconfig"
+         "${MINGW_PACKAGE_PREFIX}-libwxgtk${_wx_basever}-gtk3"
+         "${MINGW_PACKAGE_PREFIX}-libwxgtk${_wx_basever}-gtk3-dev"
+         "${MINGW_PACKAGE_PREFIX}-libwxgtk${_wx_basever}-gtk3-wxconfig"
+         "${MINGW_PACKAGE_PREFIX}-wx${_wx_basever}-i18n"
+         "${MINGW_PACKAGE_PREFIX}-wx${_wx_basever}-cb_headers"
+         "${MINGW_PACKAGE_PREFIX}-wx${_wx_basever}-headers"
+         "${MINGW_PACKAGE_PREFIX}-wx${_wx_basever}-common")
+pkgver=${_wx_basever}.0
+pkgrel=1
+pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+url="https://wxwidgets.org/"
+license=('custom:wxWindows')
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-autotools"
+  "patch"
+  "${MINGW_PACKAGE_PREFIX}-libpng"
+  "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
+  "${MINGW_PACKAGE_PREFIX}-libtiff"
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-gtk3"
+  "${MINGW_PACKAGE_PREFIX}-pkg-config"
+  "${MINGW_PACKAGE_PREFIX}-libsecret"
+  "${MINGW_PACKAGE_PREFIX}-libnotify"
+  "${MINGW_PACKAGE_PREFIX}-pcre2"
+)
+options=('strip' 'staticlibs' 'buildflags' '!debug')
+#options=('!strip' 'staticlibs' 'buildflags' 'debug') # Best options for debugging CodeLite crashes
+source=(
+  https://github.com/wxWidgets/wxWidgets/releases/download/v${pkgver}${_wx_buildver}/${_realname}-${pkgver}${_wx_buildver}.tar.bz2
+
+  # https://github.com/wxWidgets/wxWidgets/pull/22633
+  101-wxWidgets-3.2.0-Fix-wxGTK-win-build.patch
+
+  # This patch is a MSys2 run-time patch
+  001-wxWidgets-3.0.2-relocate-prefix-in-bin-wx-config.patch
+
+  # the wxTeam rejected this patch
+  005-wxWidgets-3.1.3-Remove-WX_LIBS_STATIC-from-m4.patch
+
+  # This is needed to build clang samples in check step
+  010-wxWidgets-3.1.6-Redo-manifest-filename-logic.patch
+)
+sha256sums=('356e9b55f1ae3d58ae1fed61478e9b754d46b820913e3bfbc971c50377c1903a'
+            'c9cd9120948a2216e6d3f46538eeacb5235678911b30c48336ee5074e7cf9840'
+            '2b3b183a6a76ad539abc49a41033aa923c13b395c0e55189ba962068781c7135'
+            '4a4828f0c9cdc638cffde6a30b5dfb14283719acc9e89e19de8ec2d5a80a5aec'
+            'b30100e03f350e14060923781c3c7979735cc81996a13012bef980a23eb3d20b')
+prepare() {
+  cd "${srcdir}"/${_realname}-${pkgver}${_wx_buildver}
+
+  # https://github.com/wxWidgets/wxWidgets/pull/22633
+  # PR waiting to be applied
+  patch -p1 -i "${srcdir}"/101-wxWidgets-3.2.0-Fix-wxGTK-win-build.patch
+
+  # Fix MSys2 Run-Time wx-config bug.
+  patch -p1 -i "${srcdir}"/001-wxWidgets-3.0.2-relocate-prefix-in-bin-wx-config.patch
+
+  # This patch is not really needed; but, WX_LIBS_STATIC does not work correctly under MSys2
+  # Removed it to see if anything breaks or if anything is fixed.
+  patch -p1 -i "${srcdir}"/005-wxWidgets-3.1.3-Remove-WX_LIBS_STATIC-from-m4.patch
+
+  patch -p1 -i "${srcdir}"/010-wxWidgets-3.1.6-Redo-manifest-filename-logic.patch
+}
+
+build() {
+  ####
+  # Configure options added to support other software:
+  #   --enable-graphics_ctx     codelite
+  #   --enable-graphics-d2d     codeblocks
+  #
+  # Configure options added to check for build issues
+  #   --disable-precomp-headers
+  #
+  # Configure options added to avoid possible future issues
+  #   --with-cxx=17
+  #   --enable-std_string
+  #   --enable-std_iostreams
+  #   --enable-std_containers_compat
+  #
+  # Configure options added to avoid warnings:
+  #   --with-regex=builtin
+  #
+  # Configure options known to cause build errors:
+  #   --disable-regkey                                compile error
+  #
+  # Configure options known to cause build errors under wxGTK/Win:
+  #   --with-opengl                                   configure error
+  #   --enable-accessibility                          compile error
+  #     "wxUSE_ACCESSIBILITY is currently only supported under wxMSW"
+  #
+  # Configure options added to avoid wxGTK/Win build errors:
+  #   --without-opengl
+  #
+  ####
+
+  if check_option "buildflags" "y"; then
+  # Remove the -O and -ggdb options to avoid configuration warnings
+  # from the normal settings found in /etc/makepkg_mingw??.conf
+
+    CXXFLAGS=${CXXFLAGS/-Og }
+    CXXFLAGS=${CXXFLAGS/-O2 }
+    CXXFLAGS=${CXXFLAGS/-ggdb }
+
+    CFLAGS=${CFLAGS/-Og }
+    CFLAGS=${CFLAGS/-O2 }
+    CFLAGS=${CFLAGS/-ggdb }
+  fi
+
+  local -a _debug_options=()
+
+  if check_option "debug" "y"; then
+    _debug_options+=("--enable-debug=yes")
+    _debug_options+=("--enable-debug_gdb")
+  else
+    _debug_options+=("--enable-optimise")
+  fi
+
+  #echo "_debug_options := ${_debug_options[@]}"
+
+  [[ -d "${srcdir}"/build-gtk3-${MSYSTEM}-shared ]] && rm -rf "${srcdir}"/build-gtk3-${MSYSTEM}-shared
+  mkdir -p "${srcdir}"/build-gtk3-${MSYSTEM}-shared && cd "${srcdir}"/build-gtk3-${MSYSTEM}-shared
+
+  ../${_realname}-${pkgver}${_wx_buildver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --build=${MINGW_CHOST} \
+    "${_debug_options[@]}" \
+    --without-xtest \
+    --enable-shared \
+    --enable-std_string \
+    --enable-std_iostreams \
+    --enable-std_containers_compat \
+    --enable-iff \
+    --disable-permissive \
+    --enable-unicode \
+    --enable-graphics_ctx \
+    --enable-graphics-d2d \
+    --disable-monolithic \
+    --disable-precomp-headers \
+    --with-gtk=3 \
+    --with-cxx=17 \
+    --with-libpng=sys \
+    --with-libjpeg=sys \
+    --with-libtiff=sys \
+    --with-zlib=sys \
+    --with-expat=sys \
+    --with-regex=builtin \
+    --with-liblzma \
+    --without-opengl
+
+  make #VERBOSE=1
+
+  [[ -d "${srcdir}"/build-gtk3-${MSYSTEM}-static ]] && rm -rf "${srcdir}"/build-gtk3-${MSYSTEM}-static
+  mkdir -p "${srcdir}"/build-gtk3-${MSYSTEM}-static && cd "${srcdir}"/build-gtk3-${MSYSTEM}-static
+
+  ../${_realname}-${pkgver}${_wx_buildver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --build=${MINGW_CHOST} \
+    "${_debug_options[@]}" \
+    --without-xtest \
+    --disable-shared \
+    --enable-std_string \
+    --enable-std_iostreams \
+    --enable-std_containers_compat \
+    --enable-iff \
+    --disable-permissive \
+    --enable-unicode \
+    --enable-graphics_ctx \
+    --enable-graphics-d2d \
+    --disable-monolithic \
+    --disable-precomp-headers \
+    --with-gtk=3 \
+    --with-cxx=17 \
+    --with-libpng=builtin \
+    --with-libjpeg=builtin \
+    --with-libtiff=builtin \
+    --with-zlib=builtin \
+    --with-expat=builtin \
+    --with-regex=builtin \
+    --with-liblzma \
+    --without-opengl
+
+  make #VERBOSE=1 -j1
+
+  [[ -d "${srcdir}"/build-msw-${MSYSTEM}-shared ]] && rm -rf "${srcdir}"/build-msw-${MSYSTEM}-shared
+  mkdir -p "${srcdir}"/build-msw-${MSYSTEM}-shared && cd "${srcdir}"/build-msw-${MSYSTEM}-shared
+
+  ../${_realname}-${pkgver}${_wx_buildver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --build=${MINGW_CHOST} \
+    "${_debug_options[@]}" \
+    --enable-shared \
+    --enable-std_string \
+    --enable-std_iostreams \
+    --enable-std_containers_compat \
+    --enable-iff \
+    --disable-permissive \
+    --enable-unicode \
+    --enable-graphics_ctx \
+    --enable-graphics-d2d \
+    --enable-accessibility \
+    --disable-monolithic \
+    --disable-precomp-headers \
+    --with-msw \
+    --with-cxx=17 \
+    --with-opengl \
+    --with-libpng=sys \
+    --with-libjpeg=sys \
+    --with-libtiff=sys \
+    --with-zlib=sys \
+    --with-expat=sys \
+    --with-regex=builtin \
+    --with-liblzma
+
+  make #VERBOSE=1
+
+
+  [[ -d "${srcdir}"/build-msw-${MSYSTEM}-static ]] && rm -rf "${srcdir}"/build-msw-${MSYSTEM}-static
+  mkdir -p "${srcdir}"/build-msw-${MSYSTEM}-static && cd "${srcdir}"/build-msw-${MSYSTEM}-static
+
+  ../${_realname}-${pkgver}${_wx_buildver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --build=${MINGW_CHOST} \
+    "${_debug_options[@]}" \
+    --disable-shared \
+    --enable-std_string \
+    --enable-std_iostreams \
+    --enable-std_containers_compat \
+    --enable-iff \
+    --disable-permissive \
+    --enable-unicode \
+    --enable-graphics_ctx \
+    --enable-graphics-d2d \
+    --enable-accessibility \
+    --disable-monolithic \
+    --disable-precomp-headers \
+    --with-msw \
+    --with-cxx=17 \
+    --with-opengl \
+    --with-libpng=builtin \
+    --with-libjpeg=builtin \
+    --with-libtiff=builtin \
+    --with-zlib=builtin \
+    --with-expat=builtin \
+    --with-regex=builtin \
+    --with-liblzma
+
+  make #VERBOSE=1 -j1
+}
+
+check() {
+  cd "${srcdir}/build-msw-${MSYSTEM}-shared/samples"    && make -k --jobs=1 || true
+#  cd "${srcdir}/build-msw-${MSYSTEM}-shared/tests"      && make -k --jobs=1 || true
+
+#  cd "${srcdir}"/build-gtk3-${MSYSTEM}-shared/samples   && make -k --jobs=1 # || true
+#  cd "${srcdir}"/build-gtk3-${MSYSTEM}-shared/tests     && make -k --jobs=1 # || true
+}
+
+package_libwxbase3.2() {
+  pkgdesc="wxBase shared libraries for wxwidgets ${_wx_basever} (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-expat"
+           "${MINGW_PACKAGE_PREFIX}-pcre2"
+           "${MINGW_PACKAGE_PREFIX}-libsecret")
+
+  cd "${srcdir}"/build-msw-${MSYSTEM}-shared
+  make DESTDIR="${pkgdir}" install
+
+  rm    "$pkgdir"${MINGW_PREFIX}/bin/wx-config
+  rm    "$pkgdir"${MINGW_PREFIX}/bin/*.exe
+  rm    "$pkgdir"${MINGW_PREFIX}/bin/wxmsw*.dll
+  rm -r "$pkgdir"${MINGW_PREFIX}/share
+  rm -r "$pkgdir"${MINGW_PREFIX}/include
+  rm -r "$pkgdir"${MINGW_PREFIX}/lib
+}
+
+package_libwxmsw3.2-dev() {
+  pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-libwxmsw${_wx_basever}"
+           "${MINGW_PACKAGE_PREFIX}-libwxbase${_wx_basever}"
+           "${MINGW_PACKAGE_PREFIX}-wx${_wx_basever}-i18n"
+           "${MINGW_PACKAGE_PREFIX}-wx${_wx_basever}-headers")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-libwxmsw${_wx_basever}-wxconfig"
+              "${MINGW_PACKAGE_PREFIX}-wx${_wx_basever}-common")
+  provides=("${MINGW_PACKAGE_PREFIX}-wxWidgets${_wx_basever}"
+            "${MINGW_PACKAGE_PREFIX}-wxmsw${_wx_basever}")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-wxWidgets${_wx_basever}")
+
+  #cd "${srcdir}"/build-base-${MSYSTEM}-static
+  #make DESTDIR="${pkgdir}" install-wxconfig
+
+  #cd "${srcdir}"/build-base-${MSYSTEM}-shared
+  #make DESTDIR="${pkgdir}" install-wxconfig
+
+  cd "${srcdir}"/build-msw-${MSYSTEM}-static
+  make DESTDIR="${pkgdir}" install
+
+  cd "${srcdir}"/build-msw-${MSYSTEM}-shared
+  make DESTDIR="${pkgdir}" install
+
+  # Replace real full path with psuedo full path;
+  # this seems to be needed sometime, but not always.
+  # It is likely related to the MSys2 installation path
+  local MINGW_PREFIX_WIN=$(cygpath -am ${MINGW_PREFIX})
+  sed -s "s|-L${MINGW_PREFIX_WIN}/lib|-L${MINGW_PREFIX}/lib|g" -i "${pkgdir}${MINGW_PREFIX}/bin/wx-config"
+  sed -s "s|-L${MINGW_PREFIX_WIN}/lib|-L${MINGW_PREFIX}/lib|g" -i "${pkgdir}${MINGW_PREFIX}/lib/wx/config/msw-unicode-${_wx_basever}"
+  sed -s "s|-L${MINGW_PREFIX_WIN}/lib|-L${MINGW_PREFIX}/lib|g" -i "${pkgdir}${MINGW_PREFIX}/lib/wx/config/msw-unicode-static-${_wx_basever}"
+
+  # create wx-config copy with version file suffix
+  cp ${pkgdir}${MINGW_PREFIX}/bin/wx-config{,-${_wx_basever}}
+
+  rm    "$pkgdir"${MINGW_PREFIX}/bin/wxrc.exe
+  rm    "$pkgdir"${MINGW_PREFIX}/bin/*.dll
+  rm    "$pkgdir"${MINGW_PREFIX}/bin/wx-config
+  rm -r "$pkgdir"${MINGW_PREFIX}/share
+  rm -r "$pkgdir"${MINGW_PREFIX}/include
+}
+
+package_libwxmsw3.2() {
+  pkgdesc="wxMSW shared libraries for wxwidgets ${_wx_basever} (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-libwxbase${_wx_basever}")
+
+  cd "${srcdir}"/build-msw-${MSYSTEM}-shared
+  make DESTDIR="${pkgdir}" install
+
+  rm    "$pkgdir"${MINGW_PREFIX}/bin/wx-config
+  rm    "$pkgdir"${MINGW_PREFIX}/bin/*.exe
+  rm    "$pkgdir"${MINGW_PREFIX}/bin/wxbase*.dll
+  rm -r "$pkgdir"${MINGW_PREFIX}/share
+  rm -r "$pkgdir"${MINGW_PREFIX}/include
+  rm -r "$pkgdir"${MINGW_PREFIX}/lib
+}
+
+package_libwxgtk3.2-gtk3-dev() {
+  pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX using GTK3 (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-libwxgtk${_wx_basever}-gtk3"
+           "${MINGW_PACKAGE_PREFIX}-libwxbase${_wx_basever}"
+           "${MINGW_PACKAGE_PREFIX}-wx${_wx_basever}-i18n"
+           "${MINGW_PACKAGE_PREFIX}-wx${_wx_basever}-headers")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-libwxgtk${_wx_basever}-gtk3-wxconfig"
+              "${MINGW_PACKAGE_PREFIX}-wx${_wx_basever}-common")
+  provides=("${MINGW_PACKAGE_PREFIX}-wxWidgets${_wx_basever}")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-wxWidgets${_wx_basever}")
+
+  cd "${srcdir}"/build-gtk3-${MSYSTEM}-static
+  make DESTDIR="${pkgdir}" install
+
+  cd "${srcdir}"/build-gtk3-${MSYSTEM}-shared
+  make DESTDIR="${pkgdir}" install
+
+  # Replace real full path with psuedo full path;
+  # this seems to be needed sometime, but not always.
+  # It is likely related to the MSys2 installation path
+  local MINGW_PREFIX_WIN=$(cygpath -am ${MINGW_PREFIX})
+  sed -s "s|-L${MINGW_PREFIX_WIN}/lib|-L${MINGW_PREFIX}/lib|g" -i "${pkgdir}${MINGW_PREFIX}/bin/wx-config"
+  sed -s "s|-L${MINGW_PREFIX_WIN}/lib|-L${MINGW_PREFIX}/lib|g" -i "${pkgdir}${MINGW_PREFIX}/lib/wx/config/gtk3-unicode-${_wx_basever}"
+  sed -s "s|-L${MINGW_PREFIX_WIN}/lib|-L${MINGW_PREFIX}/lib|g" -i "${pkgdir}${MINGW_PREFIX}/lib/wx/config/gtk3-unicode-static-${_wx_basever}"
+
+  # create wx-config copy with version file suffix
+  cp ${pkgdir}${MINGW_PREFIX}/bin/wx-config{,-${_wx_basever}}
+
+  rm    "$pkgdir"${MINGW_PREFIX}/bin/wxrc.exe
+  rm    "$pkgdir"${MINGW_PREFIX}/bin/*.dll
+  rm    "$pkgdir"${MINGW_PREFIX}/bin/wx-config
+  rm -r "$pkgdir"${MINGW_PREFIX}/share
+  rm -r "$pkgdir"${MINGW_PREFIX}/include
+}
+
+package_libwxgtk3.2-gtk3() {
+  pkgdesc="wxGTK/GTK3 shared libraries for wxwidgets ${_wx_basever} (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-libwxbase${_wx_basever}")
+
+  cd "${srcdir}"/build-gtk3-${MSYSTEM}-shared
+  make DESTDIR="${pkgdir}" install
+
+  rm    "$pkgdir"${MINGW_PREFIX}/bin/wx-config
+  rm    "$pkgdir"${MINGW_PREFIX}/bin/*.exe
+  rm    "$pkgdir"${MINGW_PREFIX}/bin/wxbase*.dll
+  rm -r "$pkgdir"${MINGW_PREFIX}/share
+  rm -r "$pkgdir"${MINGW_PREFIX}/include
+  rm -r "$pkgdir"${MINGW_PREFIX}/lib
+}
+
+package_wx3.2-headers() {
+  pkgdesc="Common headers for wxwidgets ${_wx_basever} (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-expat"
+           "${MINGW_PACKAGE_PREFIX}-pcre2"
+           "${MINGW_PACKAGE_PREFIX}-libsecret")
+
+  # Not sure if the static needs to be installed
+  cd "${srcdir}"/build-msw-${MSYSTEM}-static
+  make DESTDIR="${pkgdir}" install
+
+  cd "${srcdir}"/build-msw-${MSYSTEM}-shared
+  make DESTDIR="${pkgdir}" install
+
+  rm -r "$pkgdir"${MINGW_PREFIX}/bin
+  rm -r "$pkgdir"${MINGW_PREFIX}/share
+  rm -r "$pkgdir"${MINGW_PREFIX}/lib
+
+  # License files
+  cd "${srcdir}"/${_realname}-${pkgver}${_wx_buildver}/docs
+  install -Dm644 preamble.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}${_wx_basever}/preamble.txt"
+  install -Dm644 licence.txt  "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}${_wx_basever}/licence.txt"
+  install -Dm644 licendoc.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}${_wx_basever}/licendoc.txt"
+  install -Dm644 lgpl.txt     "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}${_wx_basever}/lgpl.txt"
+  install -Dm644 gpl.txt      "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}${_wx_basever}/gpl.txt"
+  install -Dm644 xserver.txt  "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}${_wx_basever}/xserver.txt"
+}
+
+package_libwxmsw3.2-wxconfig() {
+  pkgdesc="wx-config scripts for wxMSW/wxWidgets ${_wx_basever} (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-libwxmsw${_wx_basever}-dev")
+  provides=("${MINGW_PACKAGE_PREFIX}-wxconfig")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-wxconfig")
+
+  cd "${srcdir}"/build-msw-${MSYSTEM}-static
+  make DESTDIR="${pkgdir}" install-wxconfig
+  mv ${pkgdir}${MINGW_PREFIX}/bin/wx-config{,-static}
+
+  cd "${srcdir}"/build-msw-${MSYSTEM}-shared
+  make DESTDIR="${pkgdir}" install-wxconfig
+
+  # Replace real full path with psuedo full path;
+  # this seems to be needed sometime, but not always.
+  # It is likely related to the MSys2 installation path
+  local MINGW_PREFIX_WIN=$(cygpath -am ${MINGW_PREFIX})
+  sed -s "s|-L${MINGW_PREFIX_WIN}/lib|-L${MINGW_PREFIX}/lib|g" -i "${pkgdir}${MINGW_PREFIX}/bin/wx-config"
+  sed -s "s|-L${MINGW_PREFIX_WIN}/lib|-L${MINGW_PREFIX}/lib|g" -i "${pkgdir}${MINGW_PREFIX}/bin/wx-config-static"
+
+  # Remove secondary wx-config files
+  rm -f ${pkgdir}${MINGW_PREFIX}/lib/wx/config/msw-unicode-${_wx_basever}
+  rm -f ${pkgdir}${MINGW_PREFIX}/lib/wx/config/msw-unicode-static-${_wx_basever}
+}
+
+package_libwxgtk3.2-gtk3-wxconfig() {
+  pkgdesc="wx-config scripts for wxGTK/wxWidgets ${_wx_basever} (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-libwxgtk${_wx_basever}-gtk3-dev")
+  provides=("${MINGW_PACKAGE_PREFIX}-wxconfig")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-wxconfig")
+
+  cd "${srcdir}"/build-gtk3-${MSYSTEM}-static
+  make DESTDIR="${pkgdir}" install-wxconfig
+  mv ${pkgdir}${MINGW_PREFIX}/bin/wx-config{,-static}
+
+  cd "${srcdir}"/build-gtk3-${MSYSTEM}-shared
+  make DESTDIR="${pkgdir}" install-wxconfig
+
+  # Replace real full path with psuedo full path;
+  # this seems to be needed sometime, but not always.
+  # It is likely related to the MSys2 installation path
+  local MINGW_PREFIX_WIN=$(cygpath -am ${MINGW_PREFIX})
+  sed -s "s|-L${MINGW_PREFIX_WIN}/lib|-L${MINGW_PREFIX}/lib|g" -i "${pkgdir}${MINGW_PREFIX}/bin/wx-config"
+  sed -s "s|-L${MINGW_PREFIX_WIN}/lib|-L${MINGW_PREFIX}/lib|g" -i "${pkgdir}${MINGW_PREFIX}/bin/wx-config-static"
+
+  # Remove secondary wx-config files
+  rm -f ${pkgdir}${MINGW_PREFIX}/lib/wx/config/gtk3-unicode-${_wx_basever}
+  rm -f ${pkgdir}${MINGW_PREFIX}/lib/wx/config/gtk3-unicode-static-${_wx_basever}
+}
+
+package_wx3.2-i18n() {
+  pkgdesc="internationalization for wxWidgets ${_wx_basever} (mingw-w64)"
+  depends=()
+
+  cd "${srcdir}"/build-msw-${MSYSTEM}-shared
+  make DESTDIR="${pkgdir}" install
+  rm -fr ${pkgdir}${MINGW_PREFIX}/{bin,include,lib}
+  rm -fr ${pkgdir}${MINGW_PREFIX}/share/{aclocal,bakefile,licenses}
+}
+
+package_wx3.2-common() {
+  pkgdesc="Bakefiles presets, wxwin.m4, and wxrc for wxWidgets ${_wx_basever} (mingw-w64)"
+  depends=()
+  provides=("${MINGW_PACKAGE_PREFIX}-wx-common")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-wx-common")
+
+  cd "${srcdir}"/build-msw-${MSYSTEM}-shared
+  make DESTDIR="${pkgdir}" install-wxrc
+
+  rm    "$pkgdir"${MINGW_PREFIX}/bin/wxrc-${_wx_basever}.exe
+
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/share/bakefile/presets
+  cd ${pkgdir}${MINGW_PREFIX}/share/bakefile/presets
+  cp ${srcdir}/${_realname}-${pkgver}${_wx_buildver}/build/bakefiles/wxpresets/presets/*.* ./
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}${_wx_buildver}/wxwin.m4" -t ${pkgdir}${MINGW_PREFIX}/share/aclocal
+}
+
+package_wx3.2-cb_headers() {
+  pkgdesc="private wxWidgets MSW headers needed by Code::Blocks (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-wx${_wx_basever}-headers")
+
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/include/wx-${_wx_basever}/wx/msw/private
+  cd ${pkgdir}${MINGW_PREFIX}/include/wx-${_wx_basever}/wx/msw/private
+  cp ${srcdir}/${_realname}-${pkgver}${_wx_buildver}/include/wx/msw/private/comptr.h ./
+  cp ${srcdir}/${_realname}-${pkgver}${_wx_buildver}/include/wx/msw/private/graphicsd2d.h ./
+  cp ${srcdir}/${_realname}-${pkgver}${_wx_buildver}/include/wx/msw/private/keyboard.h ./
+}
+
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
+
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;

--- a/mingw-w64-wxwidgets3.2/PKGBUILD
+++ b/mingw-w64-wxwidgets3.2/PKGBUILD
@@ -9,10 +9,10 @@ pkgbase=mingw-w64-${_realname}3.2
 pkgname=("${MINGW_PACKAGE_PREFIX}-libwxbase${_wx_basever}"
 #         "${MINGW_PACKAGE_PREFIX}-libwxbase${_wx_basever}-wxconfig"
          "${MINGW_PACKAGE_PREFIX}-libwxmsw${_wx_basever}"
-         "${MINGW_PACKAGE_PREFIX}-libwxmsw${_wx_basever}-dev"
+         "${MINGW_PACKAGE_PREFIX}-libwxmsw${_wx_basever}-devel"
          "${MINGW_PACKAGE_PREFIX}-libwxmsw${_wx_basever}-wxconfig"
          "${MINGW_PACKAGE_PREFIX}-libwxgtk${_wx_basever}-gtk3"
-         "${MINGW_PACKAGE_PREFIX}-libwxgtk${_wx_basever}-gtk3-dev"
+         "${MINGW_PACKAGE_PREFIX}-libwxgtk${_wx_basever}-gtk3-devel"
          "${MINGW_PACKAGE_PREFIX}-libwxgtk${_wx_basever}-gtk3-wxconfig"
          "${MINGW_PACKAGE_PREFIX}-wx${_wx_basever}-i18n"
          "${MINGW_PACKAGE_PREFIX}-wx${_wx_basever}-cb_headers"
@@ -295,7 +295,7 @@ package_libwxbase3.2() {
   rm -r "$pkgdir"${MINGW_PREFIX}/lib
 }
 
-package_libwxmsw3.2-dev() {
+package_libwxmsw3.2-devel() {
   pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX (mingw-w64)"
   depends=("${MINGW_PACKAGE_PREFIX}-libwxmsw${_wx_basever}"
            "${MINGW_PACKAGE_PREFIX}-libwxbase${_wx_basever}"
@@ -352,7 +352,7 @@ package_libwxmsw3.2() {
   rm -r "$pkgdir"${MINGW_PREFIX}/lib
 }
 
-package_libwxgtk3.2-gtk3-dev() {
+package_libwxgtk3.2-gtk3-devel() {
   pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX using GTK3 (mingw-w64)"
   depends=("${MINGW_PACKAGE_PREFIX}-libwxgtk${_wx_basever}-gtk3"
            "${MINGW_PACKAGE_PREFIX}-libwxbase${_wx_basever}"
@@ -431,7 +431,7 @@ package_wx3.2-headers() {
 
 package_libwxmsw3.2-wxconfig() {
   pkgdesc="wx-config scripts for wxMSW/wxWidgets ${_wx_basever} (mingw-w64)"
-  depends=("${MINGW_PACKAGE_PREFIX}-libwxmsw${_wx_basever}-dev")
+  depends=("${MINGW_PACKAGE_PREFIX}-libwxmsw${_wx_basever}-devel")
   provides=("${MINGW_PACKAGE_PREFIX}-wxconfig")
   conflicts=("${MINGW_PACKAGE_PREFIX}-wxconfig")
 
@@ -456,7 +456,7 @@ package_libwxmsw3.2-wxconfig() {
 
 package_libwxgtk3.2-gtk3-wxconfig() {
   pkgdesc="wx-config scripts for wxGTK/wxWidgets ${_wx_basever} (mingw-w64)"
-  depends=("${MINGW_PACKAGE_PREFIX}-libwxgtk${_wx_basever}-gtk3-dev")
+  depends=("${MINGW_PACKAGE_PREFIX}-libwxgtk${_wx_basever}-gtk3-devel")
   provides=("${MINGW_PACKAGE_PREFIX}-wxconfig")
   conflicts=("${MINGW_PACKAGE_PREFIX}-wxconfig")
 

--- a/mingw-w64-wxwidgets3.2/design_goals.txt
+++ b/mingw-w64-wxwidgets3.2/design_goals.txt
@@ -1,0 +1,8 @@
+Primary design goal allow wxMSW 3.0 DLL applications, 
+wxMSW 3.2 DLL applications, and wxGTK 3.2 DLL applications to be
+installed at the same time.
+
+Secondary design goal allow wxWidgets 3.0 applications and 
+wxWidgets 3.2 applications to be developed at the same time. Note, it
+will not be possible to develop wxGTK and wxMSW at the same time. The
+makedepends of wxGTK 3.2 and wxMSW 3.2 will conflict.

--- a/mingw-w64-wxwidgets3.2/package_notes.txt
+++ b/mingw-w64-wxwidgets3.2/package_notes.txt
@@ -1,0 +1,26 @@
+Reference links
+    https://packages.msys2.org/base/mingw-w64-wxWidgets
+    https://www.msys2.org/wiki/Creating-Packages/
+
+Based on packages found at these URLs
+    https://archlinux.org/packages/extra/x86_64/wxwidgets-gtk3/
+    https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-wxWidgets
+    https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-wxWidgets3.1
+    https://packages.debian.org/source/bullseye/wxwidgets3.0
+
+The split package names are based on Debian package names.
+    libwxgtk3.2-gtk3           holds the wxGTK shared libraries
+    libwxgtk3.2-gtk3-dev       holds the wxGTK static and import libraries and other files
+    libwxgtk3.2-gtk3-wxconfig  holds the wxGTK wx-config and wx-config-static scripts
+    libwxmsw3.2                holds the wxMSW shared libraries
+    libwxmsw3.2-dev            holds the wxMSW static and import libraries and other files
+    libwxmsw3.2-wxconfig       holds the wxMSW wx-config and wx-config-static scripts
+    libwxbase3.2               holds the wxBase shared non GUI libraries from wxMSW build
+    wx3.2-common               holds the files that are the same for all ports of the same version
+
+wxWidgets terms
+    toolkit     examples gtk2 and gtk3
+    port        examples wxMSW, wxBASE and wxGTK
+    platform    examples Windows and Linux
+
+Warning: MSW sometimes means the wxMSW port and sometimes means the Windows platform

--- a/mingw-w64-wxwidgets3.2/package_notes.txt
+++ b/mingw-w64-wxwidgets3.2/package_notes.txt
@@ -9,11 +9,12 @@ Based on packages found at these URLs
     https://packages.debian.org/source/bullseye/wxwidgets3.0
 
 The split package names are based on Debian package names.
+Except "-dev" is replaced by "-devel".
     libwxgtk3.2-gtk3           holds the wxGTK shared libraries
-    libwxgtk3.2-gtk3-dev       holds the wxGTK static and import libraries and other files
+    libwxgtk3.2-gtk3-devel     holds the wxGTK static and import libraries and other files
     libwxgtk3.2-gtk3-wxconfig  holds the wxGTK wx-config and wx-config-static scripts
     libwxmsw3.2                holds the wxMSW shared libraries
-    libwxmsw3.2-dev            holds the wxMSW static and import libraries and other files
+    libwxmsw3.2-devel          holds the wxMSW static and import libraries and other files
     libwxmsw3.2-wxconfig       holds the wxMSW wx-config and wx-config-static scripts
     libwxbase3.2               holds the wxBase shared non GUI libraries from wxMSW build
     wx3.2-common               holds the files that are the same for all ports of the same version

--- a/mingw-w64-wxwidgets3.2/wxGTK_usage_notes.txt
+++ b/mingw-w64-wxwidgets3.2/wxGTK_usage_notes.txt
@@ -1,0 +1,21 @@
+Suggested usage notes:
+
+${MINGW_PACKAGE_PREFIX}-libwxgtk3.2-gtk3 installs the wxGTK DLLs. And,
+when creating an MinGW package, this package should be added to depends,
+unless the package only needs static wxGTK libraries.
+
+${MINGW_PACKAGE_PREFIX}-libwxgtk3.2-gtk3-dev installs the wxGTK packages
+normally needed to build an wxGTK project. And, when creating an MinGW
+package, this package should be added to makedepends. This package
+installs wx-config-3.2 and wxrc-3.2 which is normally enough for
+building projects.
+
+${MINGW_PACKAGE_PREFIX}-libwxgtk3.2-gtk3-wxconfig installs the wxGTK
+configuration scripts wx-config and wx-config-static. If these scripts
+are needed, install this package. And, when creating an MinGW package,
+this package may need to be added to makedepends.
+
+${MINGW_PACKAGE_PREFIX}-wx3.2-common installs the bakefiles presets,
+wxwin.m4, and wxrc.exe files. If these files are needed, install this
+package. And, when creating an MinGW package, this package may need to
+be added to makedepends.

--- a/mingw-w64-wxwidgets3.2/wxGTK_usage_notes.txt
+++ b/mingw-w64-wxwidgets3.2/wxGTK_usage_notes.txt
@@ -4,10 +4,10 @@ ${MINGW_PACKAGE_PREFIX}-libwxgtk3.2-gtk3 installs the wxGTK DLLs. And,
 when creating an MinGW package, this package should be added to depends,
 unless the package only needs static wxGTK libraries.
 
-${MINGW_PACKAGE_PREFIX}-libwxgtk3.2-gtk3-dev installs the wxGTK packages
-normally needed to build an wxGTK project. And, when creating an MinGW
-package, this package should be added to makedepends. This package
-installs wx-config-3.2 and wxrc-3.2 which is normally enough for
+${MINGW_PACKAGE_PREFIX}-libwxgtk3.2-gtk3-devel installs the wxGTK
+packages normally needed to build an wxGTK project. And, when creating
+an MinGW package, this package should be added to makedepends. This
+package installs wx-config-3.2 and wxrc-3.2 which is normally enough for
 building projects.
 
 ${MINGW_PACKAGE_PREFIX}-libwxgtk3.2-gtk3-wxconfig installs the wxGTK

--- a/mingw-w64-wxwidgets3.2/wxMSW_usage_notes.txt
+++ b/mingw-w64-wxwidgets3.2/wxMSW_usage_notes.txt
@@ -1,0 +1,29 @@
+Suggested usage notes:
+
+${MINGW_PACKAGE_PREFIX}-libwxmsw3.2 installs the wxMSW DLLs. And, when
+creating an MinGW package, this package should be added to depends,
+unless the package only needs static wxMSW libraries.
+
+${MINGW_PACKAGE_PREFIX}-libwxmsw3.2-dev installs the wxMSW packages
+normally needed to build an wxMSW project. And, when creating an MinGW
+package, this package should be added to makedepends. This package
+installs wx-config-3.2 and wxrc-3.2 which is normally enough for
+building projects.
+
+${MINGW_PACKAGE_PREFIX}-libwxmsw3.2-wxconfig installs the wxMSW
+configuration scripts wx-config and wx-config-static. If these scripts
+are needed, install this package. And, when creating an MinGW package,
+this package may need to be added to makedepends.
+
+${MINGW_PACKAGE_PREFIX}-wx3.2-common installs the bakefiles presets,
+wxwin.m4, and wxrc.exe files. If these files are needed, install this
+package. And, when creating an MinGW package, this package may need to
+be added to makedepends.
+
+${MINGW_PACKAGE_PREFIX}-wx3.2-cb_headers installs headers needed to
+build Code::Blocks.
+
+${MINGW_PACKAGE_PREFIX}-wxmsw3.2 is an alias for
+${MINGW_PACKAGE_PREFIX}-libwxmsw3.2-dev please as you update any
+package replace it with ${MINGW_PACKAGE_PREFIX}-libwxmsw3.2-dev and/or
+${MINGW_PACKAGE_PREFIX}-libwxmsw3.2.

--- a/mingw-w64-wxwidgets3.2/wxMSW_usage_notes.txt
+++ b/mingw-w64-wxwidgets3.2/wxMSW_usage_notes.txt
@@ -4,7 +4,7 @@ ${MINGW_PACKAGE_PREFIX}-libwxmsw3.2 installs the wxMSW DLLs. And, when
 creating an MinGW package, this package should be added to depends,
 unless the package only needs static wxMSW libraries.
 
-${MINGW_PACKAGE_PREFIX}-libwxmsw3.2-dev installs the wxMSW packages
+${MINGW_PACKAGE_PREFIX}-libwxmsw3.2-devel installs the wxMSW packages
 normally needed to build an wxMSW project. And, when creating an MinGW
 package, this package should be added to makedepends. This package
 installs wx-config-3.2 and wxrc-3.2 which is normally enough for
@@ -24,6 +24,6 @@ ${MINGW_PACKAGE_PREFIX}-wx3.2-cb_headers installs headers needed to
 build Code::Blocks.
 
 ${MINGW_PACKAGE_PREFIX}-wxmsw3.2 is an alias for
-${MINGW_PACKAGE_PREFIX}-libwxmsw3.2-dev please as you update any
-package replace it with ${MINGW_PACKAGE_PREFIX}-libwxmsw3.2-dev and/or
+${MINGW_PACKAGE_PREFIX}-libwxmsw3.2-devel please as you update any
+package replace it with ${MINGW_PACKAGE_PREFIX}-libwxmsw3.2-devel and/or
 ${MINGW_PACKAGE_PREFIX}-libwxmsw3.2.


### PR DESCRIPTION
I decided that renaming wxWidgets3.1 was not a good idea; because other people might be using it for production work. Adding this package should allow the users to decide when to switch wxWidgets versions.

Please give feedback on this package; once this package is ready; I plan to change wxWidget 3.0 and 3.1 into split packages.

Edit: I still need to test that this package works; plan is to build KiCAD 6.0.6 using it.
Edit2: Found and fixed the first error building wxPython 4.2.0a1; once that builds will work on building KiCAD
Edit3: The CI server refuses to build KiCAD; so, I am trying to build CodeLite 16.1.0; but, it segfaults when ran.
It looks to be wxWidgets 3.2.0 issue; so, working on determining if it is an CodeLite or wx issue before continuing. 
Edit4: It was a known CodeLite issue; when upgrading CodeLite version and CodeLite program segfaults before display is shown delete the AppData codelite settings folder is often needed.
Edit5: Codelite builds and runs okay after I remove wxcrafter it seems to have problems with wxWidgets 3.2.0

Tim S.