### PR TITLE
gobject-introspection: fix gir/typelib generation with llvm/clang

### DIFF
--- a/mingw-w64-gobject-introspection/1001-resolve_windows_libs-add-llvm-support.patch
+++ b/mingw-w64-gobject-introspection/1001-resolve_windows_libs-add-llvm-support.patch
@@ -1,0 +1,86 @@
+From 644ebb1360667506ed5531fd4bc2d86df4521512 Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Tue, 19 Jul 2022 09:23:00 +0200
+Subject: [PATCH] resolve_windows_libs: add llvm support
+
+---
+ giscanner/ccompiler.py | 48 +++++++++++++++++++++++++++++++++---------
+ 1 file changed, 38 insertions(+), 10 deletions(-)
+
+diff --git a/giscanner/ccompiler.py b/giscanner/ccompiler.py
+index 7a1e9393..2912fe0e 100644
+--- a/giscanner/ccompiler.py
++++ b/giscanner/ccompiler.py
+@@ -95,6 +95,41 @@ def customize_compiler(compiler):
+         compiler.shared_lib_extension = shlib_suffix
+ 
+ 
++def resolve_mingw_lib(implib, libtool=None):
++    """Returns a DLL name given a path to an import lib
++
++    /full/path/to/libgtk-3.dll.a -> libgtk-3-0.dll
++    """
++
++    args = []
++    if libtool:
++        args.extend(libtool)
++        args.append('--mode=execute')
++
++    # Figure out if we have a gcc toolchain or llvm one
++    dlltool = os.environ.get('DLLTOOL', 'dlltool.exe')
++    dlltool_output = subprocess.run(
++        [dlltool], stdout=subprocess.PIPE,
++        stderr=subprocess.STDOUT,
++        universal_newlines=True).stdout
++    is_llvm = 'llvm-dlltool' in dlltool_output
++
++    if not is_llvm:
++        # gcc dlltool provides this via --identify
++        dlltool_args = args + [dlltool, '--identify']
++        output = subprocess.check_output(dlltool_args + [implib], universal_newlines=True)
++        for line in output.splitlines():
++            return line
++    else:
++        # for llvm we need to parse the output of nm
++        # https://github.com/msys2/MINGW-packages/issues/11994#issuecomment-1176691216
++        output = subprocess.check_output(args + ['nm', implib], universal_newlines=True)
++        for line in output.splitlines():
++            if line.endswith(':'):
++                return line[:-1]
++    return None
++
++
+ # Flags that retain macros in preprocessed output.
+ FLAGS_RETAINING_MACROS = ['-g3', '-ggdb3', '-gstabs3', '-gcoff3', '-gxcoff3', '-gvms3']
+ 
+@@ -341,10 +376,6 @@ class CCompiler(object):
+         # When we are not using Visual C++ nor clang-cl (i.e. we are using GCC)...
+         else:
+             libtool = utils.get_libtool_command(options)
+-            if libtool:
+-                args.extend(libtool)
+-                args.append('--mode=execute')
+-            args.extend([os.environ.get('DLLTOOL', 'dlltool.exe'), '--identify'])
+             proc = subprocess.Popen([self.compiler_cmd, '-print-search-dirs'],
+                                     stdout=subprocess.PIPE)
+             o, e = proc.communicate()
+@@ -400,13 +431,10 @@ class CCompiler(object):
+                             tmp_fileobj.close()
+                             os.unlink(tmp_filename)
+                         else:
+-                            proc = subprocess.Popen(args + [implib],
+-                                                    stdout=subprocess.PIPE)
+-                            o, e = proc.communicate()
+-                            for line in o.decode('ascii').splitlines():
+-                                shlibs.append(line)
++                            shlib = resolve_mingw_lib(implib, libtool)
++                            if shlib is not None:
++                                shlibs.append(shlib)
+                                 found = True
+-                                break
+             if not found:
+                 not_resolved.append(lib)
+         if len(not_resolved) > 0:
+-- 
+2.37.1
+

--- a/mingw-w64-gobject-introspection/PKGBUILD
+++ b/mingw-w64-gobject-introspection/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-runtime")
 pkgver=1.72.0
-pkgrel=2
+pkgrel=3
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://live.gnome.org/GObjectIntrospection"
@@ -26,6 +26,7 @@ source=(https://download.gnome.org/sources/gobject-introspection/${pkgver%.*}/${
         0024-Support-passing-arguments-to-g-ir-scanner-through-a-.all.patch
         0026-giscanner-assertions-and-waits.patch
         0028-no-rpath-on-nt.patch
+        1001-resolve_windows_libs-add-llvm-support.patch
         pyscript2exe.py)
 
 sha256sums=('02fe8e590861d88f83060dd39cda5ccaa60b2da1d21d0f95499301b186beaabc'
@@ -34,6 +35,7 @@ sha256sums=('02fe8e590861d88f83060dd39cda5ccaa60b2da1d21d0f95499301b186beaabc'
             '594a067618922f10bdc5034f290f49d36944df3b970c9604381e2b9058a648da'
             '5b13c3571ef9ccceb96b4add46f907a1f099d3da5819e8cc5fbf5e8aab5f5da3'
             '951d0462fb05b1b250608323b3ffe53c4c59919d255c44a8c5eef7fad0dacecf'
+            'c1f2a5bb0723e821b16b48fad38c0de79c9e51b27103288a3cd00525e44689cb'
             'e57174517b08cf8f9fb4f43a381d342d23d2db3cad661107f35ca21c39b5734d')
 
 prepare() {
@@ -44,6 +46,7 @@ prepare() {
   patch -p1 -i "${srcdir}"/0024-Support-passing-arguments-to-g-ir-scanner-through-a-.all.patch
   patch -p1 -i "${srcdir}"/0026-giscanner-assertions-and-waits.patch
   patch -p1 -i "${srcdir}"/0028-no-rpath-on-nt.patch
+  patch -p1 -i "${srcdir}"/1001-resolve_windows_libs-add-llvm-support.patch
 }
 
 build() {


### PR DESCRIPTION
g-i tries to lookup the DLL name based on the import lib but failed to
do so with clang. llvm-dlltool doesn't have an "--identify" option,
so parse "nm" output instead.

Fixes #11994