### PR TITLE
python-distlib: link launcher against msvcrt under MINGW32/64

### DIFF
--- a/mingw-w64-python-distlib/003-launcher-secure-api-shim.patch
+++ b/mingw-w64-python-distlib/003-launcher-secure-api-shim.patch
@@ -1,0 +1,85 @@
+--- distlib-0.3.4/PC/launcher.c.orig	2022-06-05 10:51:32.831156800 +0200
++++ distlib-0.3.4/PC/launcher.c	2022-06-05 10:51:39.799617800 +0200
+@@ -30,6 +30,82 @@
+ #include <stdio.h>
+ #include <windows.h>
+ #include <Shlwapi.h>
++#include <errno.h>
++
++static errno_t _mingw__wdupenv_s(wchar_t **buffer, size_t *numberOfElements,
++                                 const wchar_t *varname) {
++  size_t requiredSize = 0;
++  errno_t status = 0;
++  wchar_t *tmpBuffer = NULL;
++
++  // Reuse the error cases of _wgetenv_s
++  if (buffer == NULL) {
++    return _wgetenv_s(&requiredSize, NULL, 1, L"");
++  }
++
++  // XXX: We could reuse the error case of _wgetenv_s() here too, but it doesn't
++  // error out in case of NULL varname, despite saying so in the docs.
++  // So do it manually, which means no invalid parameter handler is called
++  if (varname == NULL) {
++    *buffer = NULL;
++    if (numberOfElements) {
++      *numberOfElements = 0;
++    }
++    errno = EINVAL;
++    return EINVAL;
++  }
++
++  while (1) {
++    // Implemented in a loop since the env var could change/get removed
++    // between allocating and fetching, so we have to retry.
++
++    if (requiredSize != 0) {
++      tmpBuffer = (wchar_t *)malloc(requiredSize * sizeof(wchar_t));
++      if (tmpBuffer == NULL) {
++        *buffer = NULL;
++        if (numberOfElements) {
++          *numberOfElements = 0;
++        }
++        return ENOMEM;
++      }
++    } else {
++      tmpBuffer = NULL;
++    }
++
++    status = _wgetenv_s(&requiredSize, tmpBuffer, requiredSize, varname);
++    if (status == 0 && requiredSize == 0) {
++      // env var doesn't exist
++      free(tmpBuffer);
++      tmpBuffer = NULL;
++      break;
++    } else if (status == 0 && tmpBuffer == NULL) {
++      // first call for getting the buffer size
++      continue;
++    } else if (status == ERANGE) {
++      // retry with larger buffer
++      free(tmpBuffer);
++      tmpBuffer = NULL;
++    } else {
++      // either we failed, or we are done
++      break;
++    }
++  };
++
++  if (status != 0) {
++    free(tmpBuffer);
++  } else {
++    *buffer = tmpBuffer;
++    if (numberOfElements) {
++      *numberOfElements = requiredSize;
++    }
++  }
++
++  return status;
++}
++
++#if defined(__MINGW32__) && !defined(_UCRT)
++#define _wdupenv_s _mingw__wdupenv_s
++#endif
+ 
+ #pragma comment (lib, "Shlwapi.lib")
+ 

--- a/mingw-w64-python-distlib/PKGBUILD
+++ b/mingw-w64-python-distlib/PKGBUILD
@@ -8,7 +8,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=0.3.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Low-level components of distutils2/packaging (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -17,13 +17,18 @@ license=('FSF')
 depends=("${MINGW_PACKAGE_PREFIX}-python")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools" "${MINGW_PACKAGE_PREFIX}-cc")
 options=('staticlibs' 'strip' '!debug')
-source=("https://files.pythonhosted.org/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.zip")
-sha256sums=('e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579')
+source=("https://files.pythonhosted.org/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.zip"
+        "003-launcher-secure-api-shim.patch")
+sha256sums=('e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579'
+            'f90de01cd05cf901e9ac375e5f92727b83cb90ce3847d6ac0a18e504cd3793ca')
 
 prepare() {
   cd "${srcdir}"
   rm -rf python-build-${CARCH} | true
   cp -r "${_realname}-${pkgver}" "python-build-${CARCH}"
+
+  cd "python-build-${CARCH}"
+  patch -Np1 -i "${srcdir}/003-launcher-secure-api-shim.patch"
 
   # Set version for setuptools_scm
   export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}
@@ -41,12 +46,7 @@ build() {
     _gui_cflags+=" -s"
     _cli_cflags+=" -s"
   fi
-  case "$MSYSTEM" in
-  MINGW*)
-    _gui_cflags+=" -mcrtdll=msvcr120"
-    _cli_cflags+=" -mcrtdll=msvcr120"
-    ;;
-  esac
+
   windres --input PC/launcher.rc --output PC/resources.res --output-format=coff
 
   case "${MINGW_CHOST}" in


### PR DESCRIPTION
By implementing _wdupenv_s() via _wgetenv_s() in case it isn't available.
We already do the same thing in python-installer.

See #12035