### PR TITLE
libwmf: don't makedep on gtk2

### DIFF
--- a/mingw-w64-libwmf/PKGBUILD
+++ b/mingw-w64-libwmf/PKGBUILD
@@ -4,14 +4,13 @@ _realname=libwmf
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.2.12
-pkgrel=3
+pkgrel=4
 pkgdesc="Library for Converting Metafile Images (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://wvWare.sourceforge.io/"
 license=("GPL" "LGPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-gtk2"
              "${MINGW_PACKAGE_PREFIX}-autotools")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-freetype"


### PR DESCRIPTION
I can't see why it would be needed. let's see what CI says