### PR TITLE
graphviz: drop libglade dep

### DIFF
--- a/mingw-w64-graphviz/PKGBUILD
+++ b/mingw-w64-graphviz/PKGBUILD
@@ -4,7 +4,7 @@ _realname=graphviz
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.44.1
-pkgrel=11
+pkgrel=12
 pkgdesc="Graph Visualization Software (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -18,7 +18,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-cairo"
          "${MINGW_PACKAGE_PREFIX}-glib2"
          "${MINGW_PACKAGE_PREFIX}-fontconfig"
          "${MINGW_PACKAGE_PREFIX}-freeglut"
-         "${MINGW_PACKAGE_PREFIX}-libglade"
+         "${MINGW_PACKAGE_PREFIX}-librsvg"
          "${MINGW_PACKAGE_PREFIX}-libgd"
          "${MINGW_PACKAGE_PREFIX}-libpng"
          "${MINGW_PACKAGE_PREFIX}-libsystre"


### PR DESCRIPTION
pulls in gtk2, related to #11813