### PR TITLE
spice-gtk: disable smartcard support for clangarm64

### DIFF
--- a/mingw-w64-spice-gtk/PKGBUILD
+++ b/mingw-w64-spice-gtk/PKGBUILD
@@ -4,9 +4,9 @@ _realname=spice-gtk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.41
-pkgrel=1
+pkgrel=2
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 pkgdesc="GTK3 widget for SPICE clients (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-cyrus-sasl"
          "${MINGW_PACKAGE_PREFIX}-dbus-glib"
@@ -21,7 +21,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-cyrus-sasl"
          "${MINGW_PACKAGE_PREFIX}-pixman"
          "${MINGW_PACKAGE_PREFIX}-spice-protocol"
          "${MINGW_PACKAGE_PREFIX}-usbredir"
-         "${MINGW_PACKAGE_PREFIX}-libcacard"
+         $([[ "${MSYSTEM}" == "CLANGARM64" ]] || echo "${MINGW_PACKAGE_PREFIX}-libcacard")
          "${MINGW_PACKAGE_PREFIX}-vala")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-meson"
@@ -53,6 +53,11 @@ build() {
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
   mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
 
+  declare -a extra_config
+  if [[ "${MSYSTEM}" == "CLANGARM64" ]]; then
+      extra_config+=("-Dsmartcard=disabled")
+  fi
+
   MSYS2_ARG_CONV_EXCL="--prefix=" \
   ${MINGW_PREFIX}/bin/meson.exe \
     --prefix="${MINGW_PREFIX}" \
@@ -61,6 +66,7 @@ build() {
     --auto-features=enabled \
     -Dlibcap-ng=disabled \
     -Dpolkit=disabled \
+    "${extra_config[@]}" \
     -Dspice-common:manual=false \
     "../${_realname}-${pkgver}"
 

--- a/mingw-w64-virt-viewer/PKGBUILD
+++ b/mingw-w64-virt-viewer/PKGBUILD
@@ -6,7 +6,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=11.0
 pkgrel=2
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 pkgdesc="Displaying the graphical console of a virtual machine (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-spice-gtk"
          "${MINGW_PACKAGE_PREFIX}-gtk-vnc"


### PR DESCRIPTION
the libcacard deps don't build on arm64 yet. I disabled clangarm64 in 5d2b28e684d4d5, this lets us revert that.