### PR TITLE
openFPGALoader: update to 0.9.0

### DIFF
--- a/mingw-w64-openFPGALoader/PKGBUILD
+++ b/mingw-w64-openFPGALoader/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=openFPGALoader
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.8.0
+pkgver=0.9.0
 pkgrel=1
 pkgdesc="openFPGALoader: universal utility for programming FPGA (mingw-w64)"
 arch=('any')
@@ -22,7 +22,7 @@ makedepends=(
 )
 
 source=("${_realname}::https://codeload.github.com/trabucayre/openFPGALoader/tar.gz/v${pkgver}")
-sha256sums=('1d94c2b40c4d6b22d4099ef48b7ed4cb3f3ebfc73f36b1e87c739418a7d3045d')
+sha256sums=('1555b7ba1eb5f98d4c7a0d77c1ed7ab54214e942b8c562264e74b5d3997e0dd3')
 
 build() {
   cd "${srcdir}/${_realname}-${pkgver}"


### PR DESCRIPTION
openFPGALoader v0.9.0 was released: https://github.com/trabucayre/openFPGALoader/releases/tag/v0.9.0

/c @trabucayre