### PR TITLE
readline: use Windows API for event hook

### DIFF
--- a/mingw-w64-readline/0002-event-hook.patch
+++ b/mingw-w64-readline/0002-event-hook.patch
@@ -1,0 +1,159 @@
+diff -ur readline-8.1.3/input.c readline-8.1.4/input.c
+--- readline-8.1.3/input.c	2020-12-19 07:56:01.572775578 -0500
++++ readline-8.1.4/input.c	2020-12-19 07:57:24.608319024 -0500
+@@ -142,6 +142,11 @@
+ static unsigned char ibuffer[512];
+ static int ibuffer_len = sizeof (ibuffer) - 1;
+ 
++#if defined (__MINGW32__)
++static int _win32_getch (void);
++static int _win32_kbhit (void);
++#endif
++
+ #define any_typein (push_index != pop_index)
+ 
+ int
+@@ -268,7 +273,7 @@
+ #if defined (__MINGW32__)
+   /* Use getch/_kbhit to check for available console input, in the same way
+      that we read it normally. */
+-   chars_avail = isatty (tty) ? _kbhit () : 0;
++   chars_avail = isatty (tty) ? _win32_kbhit () : 0;
+    result = 0;
+ #endif
+ 
+@@ -520,6 +525,120 @@
+   return (c);
+ }
+ 
++#if defined (__MINGW32__)
++#define _WIN32_READ_NOCHAR (-2)
++static char _win32_buf[16] = {'0'};
++static int _win32_bufidx = 0;
++
++static int
++_win32_getch_internal (int block)
++{
++  INPUT_RECORD rec;
++  DWORD evRead, waitResult;
++  HANDLE hInput = (HANDLE) _get_osfhandle (fileno (rl_instream));
++
++  if (_win32_bufidx > 0)
++    return _win32_buf[--_win32_bufidx];
++
++  hInput = (HANDLE) _get_osfhandle (fileno (rl_instream));
++
++  do
++    {
++      if (! block)
++        {
++          if (WaitForSingleObject(hInput, _keyboard_input_timeout/1000) != WAIT_OBJECT_0)
++            return _WIN32_READ_NOCHAR;
++        }
++
++      if (!ReadConsoleInput(hInput, &rec, 1, &evRead) || evRead != 1)
++        return EOF;
++
++      switch (rec.EventType)
++        {
++          case KEY_EVENT:
++            if ((rec.Event.KeyEvent.bKeyDown &&
++               (rec.Event.KeyEvent.wVirtualKeyCode < VK_SHIFT ||
++                rec.Event.KeyEvent.wVirtualKeyCode > VK_MENU)) ||
++               (!rec.Event.KeyEvent.bKeyDown &&
++                rec.Event.KeyEvent.wVirtualKeyCode == VK_MENU &&
++                rec.Event.KeyEvent.uChar.AsciiChar))
++              {
++                if (rec.Event.KeyEvent.uChar.AsciiChar)
++                  {
++                    if (rec.Event.KeyEvent.uChar.AsciiChar < 0 ||
++                        (rec.Event.KeyEvent.uChar.AsciiChar < 32 &&
++                         !(rec.Event.KeyEvent.dwControlKeyState & (RIGHT_CTRL_PRESSED|LEFT_CTRL_PRESSED))))
++                      {
++                        char c = rec.Event.KeyEvent.uChar.AsciiChar;
++                        if (GetOEMCP () == GetConsoleCP ())
++                          OemToCharBuff (&c, &c, 1);
++                        return (int)(unsigned char)c;
++                      }
++                    else
++                      return (int)rec.Event.KeyEvent.uChar.UnicodeChar;
++                  }
++                else
++                  switch (rec.Event.KeyEvent.wVirtualKeyCode)
++                    {
++                      case VK_UP:
++                        _win32_buf[_win32_bufidx++] = 'H';
++                        return 0340;
++                      case VK_DOWN:
++                        _win32_buf[_win32_bufidx++] = 'P';
++                        return 0340;
++                      case VK_RIGHT:
++                        _win32_buf[_win32_bufidx++] = 'M';
++                        return 0340;
++                      case VK_LEFT:
++                        _win32_buf[_win32_bufidx++] = 'K';
++                        return 0340;
++                      case VK_HOME:
++                        _win32_buf[_win32_bufidx++] = 'G';
++                        return 0340;
++                      case VK_END:
++                        _win32_buf[_win32_bufidx++] = 'O';
++                        return 0340;
++                      case VK_DELETE:
++                        _win32_buf[_win32_bufidx++] = 'S';
++                        return 0340;
++                      default:
++                        break;
++                    }
++              }
++            break;
++
++          case WINDOW_BUFFER_SIZE_EVENT:
++            rl_resize_terminal ();
++            break;
++
++          default:
++            break;
++        }
++   }
++  while (1);
++}
++
++static int 
++_win32_kbhit (void)
++{
++  int result;
++
++  result = _win32_getch_internal (0);
++  if (result == _WIN32_READ_NOCHAR
++      || result == EOF)
++    return 0;
++  _win32_buf[_win32_bufidx++] = result;
++
++  return _win32_bufidx;
++}
++
++static int
++_win32_getch (void)
++{
++  return _win32_getch_internal (1);
++}
++#endif
++
+ int
+ rl_getc (FILE *stream)
+ {
+@@ -538,7 +658,12 @@
+ 
+ #if defined (__MINGW32__)
+       if (isatty (fileno (stream)))
+-	return (_getch ());	/* "There is no error return." */
++        {
++          int c = _win32_getch ();
++          if (c == 0xe0)
++            rl_execute_next (_win32_getch ());
++          return (c);
++        }
+ #endif
+       result = 0;
+ #if defined (HAVE_PSELECT)

--- a/mingw-w64-readline/PKGBUILD
+++ b/mingw-w64-readline/PKGBUILD
@@ -6,7 +6,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _basever=8.1
 _patchlevel=002
 pkgver=${_basever}.${_patchlevel}
-pkgrel=1
+pkgrel=2
 pkgdesc="MinGW port of readline for editing typed command lines (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -19,7 +19,10 @@ options=('staticlibs' 'strip')
 license=('GPL')
 url="https://cnswww.cns.cwru.edu/php/chet/readline/rltop.html"
 source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${_basever}.tar.gz"{,.sig}
-        "0001-sigwinch.patch")
+        # Patch adopted from https://hg.octave.org/mxe-octave/file/41e50d658de0/src/readline-1-sigwinch.patch
+        "0001-sigwinch.patch"
+        # Patch adopted from https://hg.octave.org/mxe-octave/file/41e50d658de0/src/readline-2-event-hook.patch
+        "0002-event-hook.patch")
 if [ ${_patchlevel} -gt 00 ]; then
     for (( p=1; p<=$((10#${_patchlevel})); p++ )); do
         source=(${source[@]} https://ftp.gnu.org/gnu/${_realname}/${_realname}-${_basever}-patches/readline${_basever//./}-$(printf "%03d" $p){,.sig})
@@ -29,10 +32,19 @@ validpgpkeys=('7C0135FB088AAF6C66C650B9BB5869F064EA74AB')
 sha256sums=('f8ceb4ee131e3232226a17f51b164afc46cd0b9e6cef344be87c65962cb82b02'
             'SKIP'
             '7a21964587484c5aab0d3e614d0131294ac99894d4864c248e4a91b72772ff96'
+            '80caf1ddaf18871efa1b03915c7fa44547bc5116767bcb3eb55ecb0bd0287a3b'
             '682a465a68633650565c43d59f0b8cdf149c13a874682d3c20cb4af6709b9144'
             'SKIP'
             'e55be055a68cb0719b0ccb5edc9a74edcc1d1f689e8a501525b3bc5ebad325dc'
             'SKIP')
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Np1 -i "${srcdir}/$_patch"
+  done
+}
 
 prepare() {
   cd "${srcdir}/readline-${_basever}"
@@ -42,8 +54,9 @@ prepare() {
     patch -Np0 -i ${srcdir}/readline${_basever//./}-$(printf "%03d" $p)
   done
 
-  # Patch adopted from https://hg.octave.org/mxe-octave/file/41e50d658de0/src/readline-1-sigwinch.patch
-  patch -p1 -i ${srcdir}/0001-sigwinch.patch
+  apply_patch_with_msg \
+    0001-sigwinch.patch \
+    0002-event-hook.patch
 
   # Remove RPATH from shared objects (FS#14366)
   sed -i 's|-Wl,-rpath,$(libdir) ||g' support/shobj-conf


### PR DESCRIPTION
When using the GUI of Octave (with `octave --gui`), the `conhost.exe` and `octave-gui.exe` processes load one thread to full capacity whilst doing nothing. When I attach a profiler to `octave-gui.exe` in this state, the majority of the execution time is spent by repeatedly calling `kbhit`.
This can be avoided with the proposed patch for `readline`. IIUC, it replaces the call to `kbhit` with native Windows API calls. If `readline` is built with this patch, the processor load of `octave-gui.exe` and `conhost.exe` goes down to virtually 0 whilst doing nothing in Octave.

I'm not the original author of this patch. But it is used for the Windows installer package of Octave since many years (at least since late 2013). And we didn't notice any adverse effects of it. So, I'd guess it should be pretty save.

See also this recent report downstream: https://octave.discourse.group/t/octave-available-as-msys2-package/1674/5