### PR TITLE
python-tornado: update to 6.2.0

### DIFF
--- a/mingw-w64-python-maturin/001-fix-default-target-on-mingw-32bit.patch
+++ b/mingw-w64-python-maturin/001-fix-default-target-on-mingw-32bit.patch
@@ -1,0 +1,11 @@
+--- a/maturin/__init__.py
++++ b/maturin/__init__.py
+@@ -41,7 +41,7 @@
+     if platform.system().lower() == "windows" and platform.machine().lower() == "amd64":
+         pointer_width = struct.calcsize("P") * 8
+         if pointer_width == 32:
+-            return ["--target", "i686-pc-windows-msvc"]
++            return ["--target", "i686-pc-windows-gnu"]
+     return []
+ 
+ 

--- a/mingw-w64-python-maturin/PKGBUILD
+++ b/mingw-w64-python-maturin/PKGBUILD
@@ -4,7 +4,7 @@ _realname=maturin
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
 pkgver=0.13.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Build and publish crates with pyo3, rust-cpython and cffi bindings as well as rust binaries as python packages (mingw-w64)'
 url='https://github.com/pyo3/maturin'
 arch=('any')
@@ -18,8 +18,16 @@ makedepends=(
     ${MINGW_PACKAGE_PREFIX}-python-installer
     ${MINGW_PACKAGE_PREFIX}-python-wheel
     ${MINGW_PACKAGE_PREFIX}-python-setuptools-rust)
-source=("${_realname}-${pkgver}.tar.gz::https://github.com/pyo3/${_realname}/archive/v${pkgver}.tar.gz")
-sha256sums=('b44a22c65ccb00f25c53540889ee0358f79a40673adee38e8c75411deef60576')
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/pyo3/${_realname}/archive/v${pkgver}.tar.gz"
+        "001-fix-default-target-on-mingw-32bit.patch")
+sha256sums=('b44a22c65ccb00f25c53540889ee0358f79a40673adee38e8c75411deef60576'
+            '5d363f2540f84651439f47782c9d60ababde58f7187b09945040f3795745bf45')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  patch -Np1 -i "${srcdir}/001-fix-default-target-on-mingw-32bit.patch"
+}
 
 build() {
   msg "Python build for ${MSYSTEM}"

--- a/mingw-w64-python-pywinpty/PKGBUILD
+++ b/mingw-w64-python-pywinpty/PKGBUILD
@@ -1,0 +1,50 @@
+# Contributor: Mehdi Chinoune <mehdi.chinoune@hotmail.com>
+
+_realname=pywinpty
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=2.0.6
+pkgrel=1
+pkgdesc="Pseudo terminal support for Windows from Python. (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+url='https://github.com/andfoy/pywinpty'
+license=('MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-maturin"
+             "${MINGW_PACKAGE_PREFIX}-rust")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('a91a77d23f29a58b44f62a9474a31ed67df1277cddb69665275f8d22429046ac')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  sed -i "s|msvc|gnu|g" Cargo.toml
+}
+
+build() {
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+check() {
+  cd "${srcdir}/python-build-${MSYSTEM}"
+
+# The test command will usually depend upon what is contained in the tox.ini file
+# or in the [testenv:py] section of the pyproject.toml file.
+  ${MINGW_PREFIX}/bin/python -m pytest
+}
+
+package() {
+  cd "${srcdir}/python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}

--- a/mingw-w64-python-terminado/PKGBUILD
+++ b/mingw-w64-python-terminado/PKGBUILD
@@ -6,37 +6,42 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=0.9.2
-pkgrel=3
+pkgver=0.15.0
+pkgrel=1
 pkgdesc="Terminals served to term.js using Tornado websockets (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
-url='https://github.com/takluyver/terminado'
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+url='https://github.com/jupyter/terminado'
 license=('Apache')
 depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-tornado"
-         "${MINGW_PACKAGE_PREFIX}-python-ptyprocess")
-makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
-source=("${_realname}-${pkgver}.tar.gz::https://files.pythonhosted.org/packages/source/t/terminado/terminado-${pkgver}.tar.gz")
-sha256sums=('89e6d94b19e4bc9dce0ffd908dfaf55cc78a9bf735934e915a4a96f65ac9704c')
-
-prepare() {
-  rm -rf python-build-${CARCH} | true
-  cp -r "${_realname}-${pkgver}" "python-build-${CARCH}"
-}
+         "${MINGW_PACKAGE_PREFIX}-python-pywinpty")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-hatchling")
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('ab4eeedccfcc1e6134bfee86106af90852c69d602884ea3a1e8ca6d4486e9bfe')
 
 build() {
-  cd "${srcdir}/python-build-${CARCH}"
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
 
-  ${MINGW_PREFIX}/bin/python setup.py build
+  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+check() {
+  cd "${srcdir}/python-build-${MSYSTEM}"
+
+# The test command will usually depend upon what is contained in the tox.ini file
+# or in the [testenv:py] section of the pyproject.toml file.
+  ${MINGW_PREFIX}/bin/python -m pytest
 }
 
 package() {
-  cd "${srcdir}/python-build-${CARCH}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
 
-  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
-    --root="${pkgdir}" --optimize=1 --skip-build
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
 
-  install -D -m644 "LICENSE" ${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
 }

--- a/mingw-w64-python-tornado/PKGBUILD
+++ b/mingw-w64-python-tornado/PKGBUILD
@@ -6,8 +6,8 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=6.1.0
-pkgrel=2
+pkgver=6.2.0
+pkgrel=1
 pkgdesc="open source version of the scalable, non-blocking web server and tools (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -17,7 +17,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-python")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-cc")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/tornadoweb/tornado/archive/v${pkgver}.tar.gz")
-sha256sums=('53a4300b786998c516fcacb76a00db6200829bf1d9b8d57e3c150bfd262e2bc8')
+sha256sums=('c2e902e4771eb90b057c7629fa239a59ecae63052919c3b5e61253f2c8a5f0d6')
 noextract=("${_realname}-${pkgver}.tar.gz")
 
 prepare() {


### PR DESCRIPTION
I disabled CLANG32 in `python-pywinpty` and `python-terminado` because of the unavailability of `rust`. 