### PR TITLE
update PDCursesMod 4.3.4

### DIFF
--- a/mingw-w64-pdcurses/PKGBUILD
+++ b/mingw-w64-pdcurses/PKGBUILD
@@ -8,8 +8,8 @@ provides=("${MINGW_PACKAGE_PREFIX}-curses")
 # No replace or conflict as the installed names are different
 #replaces=("${MINGW_PACKAGE_PREFIX}-ncurses" "${MINGW_PACKAGE_PREFIX}-termcap")
 #conflicts=("${MINGW_PACKAGE_PREFIX}-ncurses" "${MINGW_PACKAGE_PREFIX}-termcap")
-pkgver=4.3.3
-pkgrel=2
+pkgver=4.3.4
+pkgrel=1
 pkgdesc="Curses library on the Win32 API (mingw-w64)"
 # ports that are available with this package
 _pdcports="wincon wingui"  # vt is relevant especially for Windows Terminal - look at this later
@@ -22,7 +22,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 options=('staticlibs' 'strip')
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/Bill-Gray/PDCursesMod/archive/v${pkgver}.tar.gz"
         001-mingw-pdcurses-4.3.1-build.patch)
-sha256sums=('d3e06dd1d8c4ddce90aa83028123216df966d0d4873f8f960b79d9b154689090'
+sha256sums=('abbd099a51612200d1bfe236d764e0f0748ee71c3a6bc2c4069447d907d55b82'
             '3f2b76c58abccec4c1f925b182285a753e313de1e8c899510586d0541057a142')
 
 prepare() {


### PR DESCRIPTION
note: This was just done online with a quick check of the sh256 sum, hope that it builds well and assume the version is good...

The [ChangeLog](https://github.com/Bill-Gray/PDCursesMod/blob/master/docs/HISTORY.md#pdcursesmod-434---2022-july-29) looks definitely quite useful!