### PR TITLE
python-importlib-metadata: update to 4.12.0

### DIFF
--- a/mingw-w64-python-importlib-metadata/PKGBUILD
+++ b/mingw-w64-python-importlib-metadata/PKGBUILD
@@ -4,8 +4,8 @@
 _realname=importlib-metadata
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=4.11.1
-pkgrel=2
+pkgver=4.12.0
+pkgrel=1
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}=${pkgver}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
@@ -24,7 +24,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pip"
               "${MINGW_PACKAGE_PREFIX}-python-pytest-runner"
               "${MINGW_PACKAGE_PREFIX}-python-wheel")
 source=("${_realname}-${pkgver}.tar.gz"::"https://files.pythonhosted.org/packages/source/${_realname::1}/${_realname//-/_}/${_realname//-/_}-${pkgver}.tar.gz")
-sha256sums=('175f4ee440a0317f6e8d81b7f8d4869f93316170a65ad2b007d2929186c8052c')
+sha256sums=('637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {


### PR DESCRIPTION
I can't do nothing about `cx-freeze` dependency on `setuptools<61`.