### PR TITLE
Drop python-importlib-metadata dependency from some python packages

### DIFF
--- a/mingw-w64-python-cmd2/PKGBUILD
+++ b/mingw-w64-python-cmd2/PKGBUILD
@@ -7,14 +7,13 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=2.4.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Extra features for standard library's cmd module (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://github.com/python-cmd2/cmd2'
 license=('MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-python-attrs"
-         "${MINGW_PACKAGE_PREFIX}-python-importlib-metadata"
          "${MINGW_PACKAGE_PREFIX}-python-pyperclip"
          "${MINGW_PACKAGE_PREFIX}-python-typing_extensions"
          "${MINGW_PACKAGE_PREFIX}-python-pyreadline3"

--- a/mingw-w64-python-cx-freeze/PKGBUILD
+++ b/mingw-w64-python-cx-freeze/PKGBUILD
@@ -13,7 +13,7 @@ conflicts=("${MINGW_PACKAGE_PREFIX}-python3-cx_Freeze"
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-cx_Freeze"
           "${MINGW_PACKAGE_PREFIX}-python-cx_Freeze")
 pkgver=6.11.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Creates standalone executables from Python scripts, with the same performance (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -21,7 +21,6 @@ license=('PSF')
 url="https://github.com/marcelotduarte/cx_Freeze/"
 depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-cx-logging"
-         "${MINGW_PACKAGE_PREFIX}-python-importlib-metadata"
          "${MINGW_PACKAGE_PREFIX}-python-lief"
          "${MINGW_PACKAGE_PREFIX}-python-packaging")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"

--- a/mingw-w64-python-flask/PKGBUILD
+++ b/mingw-w64-python-flask/PKGBUILD
@@ -4,7 +4,7 @@ _realname=flask
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=2.1.3
-pkgrel=1
+pkgrel=2
 pkgdesc='Micro webdevelopment framework for Python (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -13,8 +13,7 @@ license=('spdx:BSD-3-Clause')
 depends=("${MINGW_PACKAGE_PREFIX}-python-click"
          "${MINGW_PACKAGE_PREFIX}-python-itsdangerous"
          "${MINGW_PACKAGE_PREFIX}-python-jinja"
-         "${MINGW_PACKAGE_PREFIX}-python-werkzeug"
-         "${MINGW_PACKAGE_PREFIX}-python-importlib-metadata")
+         "${MINGW_PACKAGE_PREFIX}-python-werkzeug")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 source=("${_realname}-$pkgver.tar.gz::https://github.com/pallets/flask/archive/${pkgver}.tar.gz")
 sha256sums=('1b8c4be6e3608282824a8a01116a7215e240f46f6cf995c1ec1c53a3820ece39')

--- a/mingw-w64-python-markdown/PKGBUILD
+++ b/mingw-w64-python-markdown/PKGBUILD
@@ -8,13 +8,13 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=3.4.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Python implementation of John Gruber's Markdown (mingw-w64)"
 url='https://pypi.python.org/pypi/Markdown'
 license=('spdx:BSD-3-Clause')
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
-depends=("${MINGW_PACKAGE_PREFIX}-python-importlib-metadata")
+depends=("${MINGW_PACKAGE_PREFIX}-python")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-pbr"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-yaml")

--- a/mingw-w64-python-path/PKGBUILD
+++ b/mingw-w64-python-path/PKGBUILD
@@ -4,7 +4,7 @@ _realname=path
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=16.4.0
-pkgrel=2
+pkgrel=3
 provides=("${MINGW_PACKAGE_PREFIX}-python3-path=${pkgver}"
           "${MINGW_PACKAGE_PREFIX}-python-path.py")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-path"
@@ -16,8 +16,7 @@ url="https://pypi.org/project/path/"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 license=('MIT')
-depends=("${MINGW_PACKAGE_PREFIX}-python"
-         "${MINGW_PACKAGE_PREFIX}-python-importlib-metadata")
+depends=("${MINGW_PACKAGE_PREFIX}-python")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"

--- a/mingw-w64-python-pytest/PKGBUILD
+++ b/mingw-w64-python-pytest/PKGBUILD
@@ -7,7 +7,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=7.1.2
-pkgrel=2
+pkgrel=3
 pkgdesc='simple powerful testing with Python (mingw-w64)'
 url='https://pytest.org/'
 license=('MIT')
@@ -16,7 +16,6 @@ mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 depends=("${MINGW_PACKAGE_PREFIX}-python-atomicwrites"
          "${MINGW_PACKAGE_PREFIX}-python-attrs"
          "${MINGW_PACKAGE_PREFIX}-python-colorama"
-         "${MINGW_PACKAGE_PREFIX}-python-importlib-metadata"
          "${MINGW_PACKAGE_PREFIX}-python-iniconfig"
          "${MINGW_PACKAGE_PREFIX}-python-packaging"
          "${MINGW_PACKAGE_PREFIX}-python-pluggy"

--- a/mingw-w64-python-sphinx/PKGBUILD
+++ b/mingw-w64-python-sphinx/PKGBUILD
@@ -9,7 +9,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=5.1.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Python documentation generator (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -19,7 +19,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-python-babel"
          "${MINGW_PACKAGE_PREFIX}-python-colorama"
          "${MINGW_PACKAGE_PREFIX}-python-docutils"
          "${MINGW_PACKAGE_PREFIX}-python-imagesize"
-         "${MINGW_PACKAGE_PREFIX}-python-importlib-metadata"
          "${MINGW_PACKAGE_PREFIX}-python-jinja"
          "${MINGW_PACKAGE_PREFIX}-python-packaging"
          "${MINGW_PACKAGE_PREFIX}-python-pygments"

--- a/mingw-w64-python-versioningit/PKGBUILD
+++ b/mingw-w64-python-versioningit/PKGBUILD
@@ -4,14 +4,13 @@ _realname=versioningit
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=2.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Versioning It with your Version In Git (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url='https://github.com/jwodder/versioningit'
 license=('spdx:MIT')
-depends=("${MINGW_PACKAGE_PREFIX}-python-importlib-metadata"
-         "${MINGW_PACKAGE_PREFIX}-python-packaging"
+depends=("${MINGW_PACKAGE_PREFIX}-python-packaging"
          "${MINGW_PACKAGE_PREFIX}-python-tomli")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"


### PR DESCRIPTION
https://github.com/python-cmd2/cmd2/blob/2.4.2/setup.py#L47
https://github.com/marcelotduarte/cx_Freeze/blob/v6.11.1/setup.cfg#L45
https://github.com/pallets/flask/blob/2.1.3/setup.py#L11
https://github.com/Python-Markdown/markdown/blob/master/setup.py#L77
https://github.com/jaraco/path/blob/v16.4.0/setup.cfg#L23
https://github.com/pytest-dev/pytest/blob/7.1.2/setup.cfg#L52
https://github.com/sphinx-doc/sphinx/blob/v5.1.1/setup.py#L30
https://github.com/jwodder/versioningit/blob/v2.0.0/setup.cfg#L54

The only two packages that still depends on it are:
https://github.com/rst2pdf/rst2pdf/blob/0.99/setup.py#L32
https://github.com/jaraco/pytest-checkdocs/blob/v2.7.1/setup.cfg#L23