### PR TITLE
scipy: install egg-info

### DIFF
--- a/mingw-w64-python-scipy/PKGBUILD
+++ b/mingw-w64-python-scipy/PKGBUILD
@@ -8,7 +8,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=1.9.0
-pkgrel=2
+pkgrel=3
 pkgdesc="SciPy is open-source software for mathematics, science, and engineering (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -33,6 +33,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cc"
   "${MINGW_PACKAGE_PREFIX}-cython"
   "${MINGW_PACKAGE_PREFIX}-pkgconf"
+  "${MINGW_PACKAGE_PREFIX}-python-setuptools"
 )
 source=("${_realname}-${pkgver}.tar.gz::https://pypi.python.org/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz"
         "001-no-static-linking.patch")
@@ -63,6 +64,9 @@ package() {
   cd "${srcdir}/build-${MSYSTEM}"
 
   DESTDIR="${pkgdir}" meson install
+
+  python "${srcdir}/${_realname}-${pkgver}/setup.py" install_egg_info --install-dir \
+    "${pkgdir}${MINGW_PREFIX}/lib/python"*"/site-packages"
 
   find "${pkgdir}${MINGW_PREFIX}" -name '*.dll.a' -delete
 


### PR DESCRIPTION
The meson build seems to be missing it, so work around it letting
setuptools handle it.