### PR TITLE
scipy: install .egg-info from the sdist

### DIFF
--- a/mingw-w64-python-scipy/PKGBUILD
+++ b/mingw-w64-python-scipy/PKGBUILD
@@ -8,7 +8,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=1.9.0
-pkgrel=3
+pkgrel=4
 pkgdesc="SciPy is open-source software for mathematics, science, and engineering (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -33,7 +33,6 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cc"
   "${MINGW_PACKAGE_PREFIX}-cython"
   "${MINGW_PACKAGE_PREFIX}-pkgconf"
-  "${MINGW_PACKAGE_PREFIX}-python-setuptools"
 )
 source=("${_realname}-${pkgver}.tar.gz::https://pypi.python.org/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz"
         "001-no-static-linking.patch")
@@ -65,8 +64,10 @@ package() {
 
   DESTDIR="${pkgdir}" meson install
 
-  python "${srcdir}/${_realname}-${pkgver}/setup.py" install_egg_info --install-dir \
-    "${pkgdir}${MINGW_PREFIX}/lib/python"*"/site-packages"
+  # https://github.com/msys2/MINGW-packages/pull/12386#issuecomment-1201661997
+  _purelib="$(python -c "import sysconfig; print(sysconfig.get_path('purelib'))")"
+  _site_packages="${pkgdir}$(cygpath "${_purelib}")"
+  cp "${srcdir}/${_realname}-${pkgver}/PKG-INFO" "${_site_packages}/${_realname}-${pkgver}.egg-info"
 
   find "${pkgdir}${MINGW_PREFIX}" -name '*.dll.a' -delete
 


### PR DESCRIPTION
this way we don't need setuptools

See https://github.com/msys2/MINGW-packages/pull/12386#issuecomment-1201661997