### PR TITLE
Added unifdef

### DIFF
--- a/mingw-w64-unifdef/PKGBUILD
+++ b/mingw-w64-unifdef/PKGBUILD
@@ -1,0 +1,27 @@
+# Maintainer: Joel Holdsworth <jholdsworth@nvidia.com>
+
+_realname=unifdef
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=2.12
+pkgrel=1
+pkgdesc="Selectively processes conditional C preprocessor directives (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+license=('BSD')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
+url="https://dotat.at/prog/unifdef/"
+source=("https://dotat.at/prog/${_realname}/${_realname}-${pkgver}.tar.xz")
+sha256sums=("43ce0f02ecdcdc723b2475575563ddb192e988c886d368260bc0a63aee3ac400")
+
+build() {
+  cd "${srcdir}"/${_realname}-${pkgver}
+  make -f win32/Makefile.mingw
+}
+
+package() {
+  cd "${srcdir}"/${_realname}-${pkgver}
+  install -Dm755 unifdef.exe ${pkgdir}${MINGW_PREFIX}/bin/unifdef.exe
+  install -Dm755 unifdef.1 ${pkgdir}${MINGW_PREFIX}/share/man/man1/unifdef.1
+  install -Dm644 COPYING ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING
+}


### PR DESCRIPTION
The `unifdef` utility selectively processes conditional C preprocessor `#if` and `#ifdef` directives. It removes from a file both the directives and the additional text that they delimit, while otherwise leaving the file alone.