### PR TITLE
python-scipy: don't set long-double-64

### DIFF
--- a/mingw-w64-python-scipy/002-no-long-double-64.patch
+++ b/mingw-w64-python-scipy/002-no-long-double-64.patch
@@ -1,0 +1,10 @@
+--- scipy-1.9.0/scipy/meson.build.orig	2022-08-02 08:50:49.182475300 +0200
++++ scipy-1.9.0/scipy/meson.build	2022-08-03 08:08:17.971413600 +0200
+@@ -10,7 +10,6 @@
+     add_global_link_arguments(gcc_link_args, language: ['c', 'cpp'])
+     # Force gcc to float64 long doubles for compatibility with MSVC
+     # builds, for C only.
+-    add_global_arguments('-mlong-double-64', language: 'c')
+     # Make fprintf("%zd") work (see https://github.com/rgommers/scipy/issues/118)
+     add_global_arguments('-D__USE_MINGW_ANSI_STDIO=1', language: ['c', 'cpp'])
+     # Manual add of MS_WIN64 macro when not using MSVC.

--- a/mingw-w64-python-scipy/PKGBUILD
+++ b/mingw-w64-python-scipy/PKGBUILD
@@ -8,7 +8,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=1.9.0
-pkgrel=4
+pkgrel=5
 pkgdesc="SciPy is open-source software for mathematics, science, and engineering (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -35,14 +35,17 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-pkgconf"
 )
 source=("${_realname}-${pkgver}.tar.gz::https://pypi.python.org/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz"
-        "001-no-static-linking.patch")
+        "001-no-static-linking.patch"
+        "002-no-long-double-64.patch")
 sha256sums=('c0dfd7d2429452e7e94904c6a3af63cbaa3cf51b348bd9d35b42db7e9ad42791'
-            'b47c052ed40cbbe7412a927ee92925292196fe712d29a60755e198c5e9c68fca')
+            'b47c052ed40cbbe7412a927ee92925292196fe712d29a60755e198c5e9c68fca'
+            '0015d24c5392575718c595a965abf0fdcd2c1e1396f6069bb663787ddf9f7f91')
 
 prepare() {
   cd "${_realname}-${pkgver}"
 
   patch -Np1 -i "${srcdir}/001-no-static-linking.patch"
+  patch -Np1 -i "${srcdir}/002-no-long-double-64.patch"
 }
 
 build() {


### PR DESCRIPTION
According to https://github.com/msys2/MINGW-packages/issues/12409
this leads to errors/crashes.

It also isn't there in the setuptools build.

Fixes #12409