### PR TITLE
libavif: depend on libyuv, svt-av1

### DIFF
--- a/mingw-w64-libavif/PKGBUILD
+++ b/mingw-w64-libavif/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libavif
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.10.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Library for encoding and decoding .avif files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -15,13 +15,15 @@ depends=("${MINGW_PACKAGE_PREFIX}-aom"
          $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-i686* || \
                ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || \
             echo "${MINGW_PACKAGE_PREFIX}-rav1e" )
+         $( [[ ${CARCH} != x86_64 ]] || \
+            echo "${MINGW_PACKAGE_PREFIX}-svt-av1" )
+         "${MINGW_PACKAGE_PREFIX}-libyuv"
          "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
          "${MINGW_PACKAGE_PREFIX}-libpng"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-gdk-pixbuf2"
-             $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || echo "${MINGW_PACKAGE_PREFIX}-nasm" )
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-cc")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/AOMediaCodec/libavif/archive/v${pkgver}.tar.gz")
@@ -54,6 +56,8 @@ build() {
     -DAVIF_CODEC_RAV1E=$( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-i686* || \
                              ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] &&
                           echo "OFF" || echo "ON" ) \
+    -DAVIF_CODEC_SVT=$( [[ ${CARCH} != x86_64 ]] &&
+                        echo "OFF" || echo "ON" ) \
     -DAVIF_BUILD_GDK_PIXBUF=ON \
     -DAVIF_BUILD_TESTS=ON \
     -DAVIF_ENABLE_WERROR=OFF \

--- a/mingw-w64-libyuv/PKGBUILD
+++ b/mingw-w64-libyuv/PKGBUILD
@@ -6,19 +6,20 @@ pkgname=(${MINGW_PACKAGE_PREFIX}-${_realname})
 provides=(${MINGW_PACKAGE_PREFIX}-${_realname}-git)
 conflicts=(${MINGW_PACKAGE_PREFIX}-${_realname}-git)
 replaces=(${MINGW_PACKAGE_PREFIX}-${_realname}-git)
-pkgver=1787.r2266.eb6e7bb6
+pkgver=1834.r2356.98ec7c28
 pkgrel=1
 pkgdesc="YUV conversion and scaling library (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://chromium.googlesource.com/libyuv/libyuv"
-license=('BSD-3-Clause')
+license=('spdx:BSD-3-Clause')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cc"
              'git')
-depends=("${MINGW_PACKAGE_PREFIX}-libjpeg")
-_commit="eb6e7bb63738e29efd82ea3cf2a115238a89fa51"
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-libjpeg")
+_commit="98ec7c28d5f4664d0cf5b7631e82a876ccb11c26"
 source=("${_realname}::git+https://chromium.googlesource.com/${_realname}/${_realname}#commit=${_commit}"
         "libyuv.pc.in"
         "libyuv-jpeg.patch"

--- a/mingw-w64-python-xpra/PKGBUILD
+++ b/mingw-w64-python-xpra/PKGBUILD
@@ -9,7 +9,7 @@ replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
           "${MINGW_PACKAGE_PREFIX}-${_realname}-common")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=4.3.3
-pkgrel=1
+pkgrel=2
 pkgdesc='Remote access client/server software (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')


### PR DESCRIPTION
Also removed the bogus `nasm` dependency and bumped `libyuv` version (+ enabled for clangarm64)