### PR TITLE
sqlite: Update to 3.39.2

### DIFF
--- a/mingw-w64-sqlite3/PKGBUILD
+++ b/mingw-w64-sqlite3/PKGBUILD
@@ -7,9 +7,9 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-sqlite-docs")
 _sqlite_year=2022
-_amalgamationver=3390100
+_amalgamationver=3390200
 _docver=${_amalgamationver}
-pkgver=3.39.1
+pkgver=3.39.2
 pkgrel=1
 pkgdesc="A C library that implements an SQL database engine (mingw-w64)"
 arch=('any')
@@ -26,12 +26,12 @@ source=(https://www.sqlite.org/${_sqlite_year}/sqlite-src-${_amalgamationver}.zi
         Makefile.ext.in
         README.md.in
         LICENSE)
-sha256sums=('366c7abbee5dbe8882cd7578a61a6ed3f5d08c5f6de3535a0003125b4646cc57'
-            'ab062e44c83276d4672379f428d049df373cef184c09ba19521925d32d5c86a7'
+sha256sums=('e933d77000f45f3fbc8605f0050586a3013505a8de9b44032bd00ed72f1586f0'
+            '50f08a09e8858b023f24b59963e0559e1cf2e24a0c4d9ca61f35414a900d409e'
             '4a8a87289253529cf04c916e5743c8727a5506b5185bc9bd4070b42037e8ae20'
             '5ca42f1f92abfb61bacc9ff60f5836cc56e2ce2af52264f918cb06c3d566d562'
             '0b76663a90e034f3d7f2af5bfada4cedec5ebc275361899eccc5c18e6f01ff1f')
-options=('!strip' 'staticlibs' '!buildflags')
+options=('staticlibs' '!buildflags')
 
 sqlite_tools="sqlite3_analyzer.exe dbhash.exe sqldiff.exe"
 


### PR DESCRIPTION
And enable stripping again. It's unclear why it was disabled 9 years ago.