### PR TITLE
bin2header: update to 0.3.0

### DIFF
--- a/mingw-w64-bin2header/PKGBUILD
+++ b/mingw-w64-bin2header/PKGBUILD
@@ -3,15 +3,15 @@
 _realname=bin2header
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.2.0
-pkgrel=2
-pkgdesc='Binary file to C/C++ header converter (mingw-w64)'
-arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+pkgver=0.3.0
+pkgrel=1
+pkgdesc="Binary file to C/C++ header converter (mingw-w64)"
+arch=("any")
+mingw_arch=("mingw32" "mingw64" "ucrt64" "clang64" "clang32")
 url="https://github.com/AntumDeluge/${_realname}"
-license=('MIT')
+license=("MIT")
 source=("${url}/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.xz")
-sha256sums=('f7bfd28e43bc00f6f505e74bfda582e992a673b09a38a891447cb508427f6d9b')
+sha256sums=("605098476a23cacfae5bded5a51bb64a574798cd76aae0dd722f886c091f533e")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"


### PR DESCRIPTION
Release info: https://github.com/AntumDeluge/bin2header/releases/tag/v0.3.0