### PR TITLE
inkscape: Disable internal cairo dependency

### DIFF
--- a/mingw-w64-inkscape/PKGBUILD
+++ b/mingw-w64-inkscape/PKGBUILD
@@ -6,7 +6,7 @@ _realname=inkscape
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.2.1
-pkgrel=1
+pkgrel=2
 _pkg_suffix=2022-07-14_9c6d41e410
 pkgdesc="Vector graphics editor using the SVG file format (mingw-w64)"
 arch=('any')
@@ -17,9 +17,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-boost"
-             "${MINGW_PACKAGE_PREFIX}-autotools"
-             "${MINGW_PACKAGE_PREFIX}-gtk-doc"
-             "intltool" "git")
+             "intltool")
 depends=("${MINGW_PACKAGE_PREFIX}-aspell"
          "${MINGW_PACKAGE_PREFIX}-double-conversion"
          "${MINGW_PACKAGE_PREFIX}-gc"
@@ -60,7 +58,7 @@ source=("${_realname}-${pkgver}.tar.xz::https://media.inkscape.org/dl/resources/
         clang-fix-4.patch
         fix-detecting-mingw-arch.patch)
 sha256sums=('46ce7da0eba7ca4badc1db70e9cbb67e0adf9bb342687dc6e08b5ca21b8d4c1b'
-            '92387251c1740f1a57cde9e587cc673ef1600813617bd2c9db65598c324a24d4'
+            '67cffe472b93b011f5c5d46b30dfe9ebf7e3426dbe894390802eb225f4965616'
             '131b2e1190637df0554ef1ee8cf46440689584375c117d057ab47d5871c58128'
             '847dee197e295ddc44c8b5c17264666e65b8d311dcf01a9a8abe6a9887f89cca'
             'de76acd3e42a0b2458e63d048236da5bb6a4fe2ce7427dbc201ca343b208dbf2')
@@ -101,6 +99,7 @@ build() {
     -DBUILD_TESTING=OFF \
     -DCMAKE_AR=${MINGW_PREFIX}/bin/ar \
     -DWITH_IMAGE_MAGICK=OFF \
+    -DWITH_INTERNAL_CAIRO=OFF \
     ../${_realname}-${pkgver}
 
   ${MINGW_PREFIX}/bin/cmake --build .

--- a/mingw-w64-inkscape/inkscape-1.0.1-unbundle.patch
+++ b/mingw-w64-inkscape/inkscape-1.0.1-unbundle.patch
@@ -11,3 +11,14 @@
  # -----------------------------------------------------------------------------
  # Uninstall Target
  # -----------------------------------------------------------------------------
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -133,7 +133,7 @@
+ mark_as_advanced(WITH_FUZZ)
+ option(WITH_MANPAGE_COMPRESSION "gzips manpages if gzip is available" ON)
+ mark_as_advanced(WITH_MANPAGE_COMPRESSION)
+-cmake_dependent_option(WITH_INTERNAL_CAIRO "Use a patched version of cairo" OFF "UNIX" ON)
++cmake_dependent_option(WITH_INTERNAL_CAIRO "Use a patched version of cairo" OFF "MINGW" ON)
+ 
+ option(ENABLE_BINRELOC "Enable relocatable binaries" OFF)
+ 


### PR DESCRIPTION
Inkscape links with system cairo package by default. But the bundled
cairo adds APIs which are not present in system one. This may cause
unexpected crashes.