### PR TITLE
gsm: Update to 1.0.22

### DIFF
--- a/mingw-w64-gsm/0001-adapt-makefile-to.mingw.patch
+++ b/mingw-w64-gsm/0001-adapt-makefile-to.mingw.patch
@@ -111,19 +111,19 @@
  
 -$(TOAST_INSTALL_BIN)/toast:	$(TOAST)
 +$(TOAST_INSTALL_BIN)/toast$(EXEEXT):	$(TOAST)
- 		-rm $@
+ 		-rm $(RMFLAGS) $@
  		cp $(TOAST) $@
  		chmod 755 $@
  
 -$(TOAST_INSTALL_BIN)/untoast:	$(TOAST_INSTALL_BIN)/toast
 +$(TOAST_INSTALL_BIN)/untoast$(EXEEXT):	$(TOAST_INSTALL_BIN)/toast$(EXEEXT)
- 		-rm $@
- 		ln $? $@
+ 		-rm $(RMFLAGS) $@
+ 		$(LN) $? $@
  
 -$(TOAST_INSTALL_BIN)/tcat:	$(TOAST_INSTALL_BIN)/toast
 +$(TOAST_INSTALL_BIN)/tcat$(EXEEXT):	$(TOAST_INSTALL_BIN)/toast$(EXEEXT)
- 		-rm $@
- 		ln $? $@
+ 		-rm $(RMFLAGS) $@
+ 		$(LN) $? $@
  
 --- gsm-1.0-pl13/Makefile.orig	2012-04-15 01:39:20 +0400
 +++ gsm-1.0-pl13/Makefile	2012-04-15 01:40:06 +0400

--- a/mingw-w64-gsm/0003-fix-ln.mingw.patch
+++ b/mingw-w64-gsm/0003-fix-ln.mingw.patch
@@ -12,20 +12,20 @@
 @@ -361,16 +361,15 @@
  
  $(TOAST_INSTALL_BIN)/toast$(EXEEXT):	$(TOAST)
- 		-rm $@
+ 		-rm $(RMFLAGS) $@
 -		cp $(TOAST) $@
 -		chmod 755 $@
 +		/usr/bin/install $(TOAST) $@
  
  $(TOAST_INSTALL_BIN)/untoast$(EXEEXT):	$(TOAST_INSTALL_BIN)/toast$(EXEEXT)
- 		-rm $@
--		ln $? $@
-+		ln -s toast$(EXEEXT) $@
+ 		-rm $(RMFLAGS) $@
+-		$(LN) $? $@
++		$(LN) toast$(EXEEXT) $@
  
  $(TOAST_INSTALL_BIN)/tcat$(EXEEXT):	$(TOAST_INSTALL_BIN)/toast$(EXEEXT)
- 		-rm $@
--		ln $? $@
-+		ln -s toast$(EXEEXT) $@
+ 		-rm $(RMFLAGS) $@
+-		$(LN) $? $@
++		$(LN) toast$(EXEEXT) $@
  
  $(TOAST_INSTALL_MAN)/toast.1:	$(MAN)/toast.1
  		-rm $@

--- a/mingw-w64-gsm/PKGBUILD
+++ b/mingw-w64-gsm/PKGBUILD
@@ -3,28 +3,25 @@
 _realname=gsm
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.0.19
-pkgrel=2
+pkgver=1.0.22
+pkgrel=1
 pkgdesc="Shared libraries for GSM 06.10 lossy speech compression (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="http://www.quut.com/gsm/"
 license=("custom")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-pkg-config"
-              $( [[ "${CARCH}" != "i686" \
-                && "${CARCH}" != "x86_64" ]] \
-                || echo "${MINGW_PACKAGE_PREFIX}-yasm" ))
+             "${MINGW_PACKAGE_PREFIX}-pkgconf")
 options=('strip' 'staticlibs')
 source=("http://www.quut.com/${_realname}/${_realname}-${pkgver}.tar.gz"
         0001-adapt-makefile-to.mingw.patch
         0002-adapt-config-h-to.mingw.patch
         0003-fix-ln.mingw.patch
         0004-use-cc-instead-of-gcc.patch)
-sha256sums=('4903652f68a8c04d0041f0d19b1eb713ddcd2aa011c5e595b3b8bca2755270f6'
-            '041f7a760eba8645e63dc3a83842959b13c07bd53f313f9db6420d5bad8c3a68'
+sha256sums=('f0072e91f6bb85a878b2f6dbf4a0b7c850c4deb8049d554c65340b3bf69df0ac'
+            '654eaac22889157982d216776bf9de9b33a24e0bea4f8f56b7659cb80627dff3'
             '4baaaf5218f384c7ee204da0617d6f95d3e2fc684faf5a80b892f29930939d07'
-            '2985944c5c025822ff1cb4517fdaac87b55ccf967742287e7a8892fa01c66372'
+            '29973fa21c19f68aa4fecc9cb9d622f5d459eb193907c434eed1e05caa4c2321'
             '07a85325c41e9e4e83f1730ccf1d5c1a0a7b4effcda913a0619d2f984aaa8eab')
 
 prepare() {


### PR DESCRIPTION
drop yasm, doesn't seem to be used.
