### PR TITLE
libdeflate: update to 1.13

### DIFF
--- a/mingw-w64-libdeflate/PKGBUILD
+++ b/mingw-w64-libdeflate/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=libdeflate
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.12
-pkgrel=3
+pkgver=1.13
+pkgrel=1
 pkgdesc="Heavily optimized library for DEFLATE/zlib/gzip compression and decompression (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -13,18 +13,15 @@ license=('spdx:MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
 source=(${_realname}-${pkgver}.tar.gz::"${url}/archive/v${pkgver}.tar.gz"
         "001-libdeflate-makefile-mingw-fix.patch"
-        "002-pkg-config.patch"
-        "https://github.com/ebiggers/libdeflate/commit/bcc3634037caa0212874eaf9a2bf2092ae5d0857.patch")
-sha256sums=('ba89fb167a5ab6bbdfa6ee3b1a71636e8140fa8471cce8a311697584948e4d06'
+        "002-pkg-config.patch")
+sha256sums=('0d81f197dc31dc4ef7b6198fde570f4e8653c77f4698fcb2163d820a9607c838'
             'a5648a9e8d5d64b1a9301ad5f555052c8a8f2967a1a50a422f99fbd4f6a5dc4f'
-            'e0a093985eb05f3b8eb725249e8fc4ec9645cdad8eaafd4a3ce1a0d7a1ef45c5'
-            'fe1d21d063d8ca504ab09b9c28550f9d4572ecf2ab028694b2e6feedbe237391')
+            'e0a093985eb05f3b8eb725249e8fc4ec9645cdad8eaafd4a3ce1a0d7a1ef45c5')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
   patch -p1 -i "${srcdir}"/001-libdeflate-makefile-mingw-fix.patch
   patch -p1 -i "${srcdir}"/002-pkg-config.patch
-  patch -p1 -i "${srcdir}"/bcc3634037caa0212874eaf9a2bf2092ae5d0857.patch
 }
 
 build() {


### PR DESCRIPTION
Just realized the cdecl patch was already there, so need yet to rebuild dependent packages...