### PR TITLE
wxwidgets3.2: Change base-libs to common-libs

### DIFF
--- a/mingw-w64-wxwidgets3.2/PKGBUILD
+++ b/mingw-w64-wxwidgets3.2/PKGBUILD
@@ -8,13 +8,13 @@ _wx_buildver=
 pkgbase=mingw-w64-${_realname,,}${_wx_basever}
 pkgname=("${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-common"
          "${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-msw-cb_headers"
-         "${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-base-libs"
+         "${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-common-libs"
          "${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-msw-libs"
          "${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-gtk3-libs"
          "${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-msw"
          "${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-gtk3")
 pkgver=${_wx_basever}.0
-pkgrel=2
+pkgrel=3
 pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -291,8 +291,9 @@ check() {
 #  cd "${srcdir}"/build-gtk3-${MSYSTEM}-shared/tests     && make -k --jobs=1 # || true
 }
 
-package_wxwidgets3.2-base-libs() {
+package_wxwidgets3.2-common-libs() {
   pkgdesc="wxBase shared libraries for wxwidgets ${_wx_basever} (mingw-w64)"
+  conflicts=("${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-base-libs")
   depends=("${MINGW_PACKAGE_PREFIX}-expat"
            "${MINGW_PACKAGE_PREFIX}-pcre2"
            "${MINGW_PACKAGE_PREFIX}-libsecret")
@@ -349,7 +350,7 @@ package_wxwidgets3.2-msw() {
 
 package_wxwidgets3.2-msw-libs() {
   pkgdesc="wxMSW shared libraries for wxwidgets ${_wx_basever} (mingw-w64)"
-  depends=("${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-base-libs"
+  depends=("${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-common-libs"
            "${MINGW_PACKAGE_PREFIX}-libpng"
            "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
            "${MINGW_PACKAGE_PREFIX}-libtiff")
@@ -391,7 +392,7 @@ package_wxwidgets3.2-gtk3() {
 
 package_wxwidgets3.2-gtk3-libs() {
   pkgdesc="GTK+3 implementated shared libraries for wxwidgets ${_wx_basever} (mingw-w64)"
-  depends=("${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-base-libs"
+  depends=("${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-common-libs"
            "${MINGW_PACKAGE_PREFIX}-gtk3"
            "${MINGW_PACKAGE_PREFIX}-libnotify")
 
@@ -403,7 +404,7 @@ package_wxwidgets3.2-gtk3-libs() {
 
 package_wxwidgets3.2-common() {
   pkgdesc="Static libraries and headers for wxWidgets ${_wx_basever} (mingw-w64)"
-  depends=("${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-base-libs")
+  depends=("${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-common-libs")
   provides=("${MINGW_PACKAGE_PREFIX}-wxwidgets-common")
   conflicts=("${MINGW_PACKAGE_PREFIX}-wxwidgets-common")
 
@@ -431,7 +432,7 @@ package_wxwidgets3.2-common() {
 
 package_wxwidgets3.2-msw-cb_headers() {
   pkgdesc="private wxWidgets ${_wx_basever} MSW headers needed by Code::Blocks (mingw-w64)"
-  depends=()
+  depends=("${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-common")
 
   mkdir -p ${pkgdir}${MINGW_PREFIX}/include/wx-${_wx_basever}/wx/msw/private
   cd ${pkgdir}${MINGW_PREFIX}/include/wx-${_wx_basever}/wx/msw/private


### PR DESCRIPTION
And, add depends wxwidgets3.2-common to wxwidgets3.2-msw-cb_headers.