### PR TITLE
superlu: Enable aarch64 builds

### DIFF
--- a/mingw-w64-superlu/PKGBUILD
+++ b/mingw-w64-superlu/PKGBUILD
@@ -6,7 +6,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.3.0
 pkgrel=1
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 pkgdesc="Sparse direct linear solver (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-openblas")


### PR DESCRIPTION
```
==> Starting check()...
Test project C:/Dev/MINGW-packages/mingw-w64-superlu/src/build-CLANGARM64-static
      Start  1: s_test_9_2_0_LA
 1/24 Test  #1: s_test_9_2_0_LA ..................   Passed    0.03 sec
      Start  2: s_test_9_2_10000000_LA
 2/24 Test  #2: s_test_9_2_10000000_LA ...........   Passed    0.04 sec
      Start  3: s_test_19_2_0_LA
 3/24 Test  #3: s_test_19_2_0_LA .................   Passed    0.03 sec
      Start  4: s_test_19_2_10000000_LA
 4/24 Test  #4: s_test_19_2_10000000_LA ..........   Passed    0.03 sec
      Start  5: s_test_2_0_SP
 5/24 Test  #5: s_test_2_0_SP ....................   Passed    0.03 sec
      Start  6: s_test_2_10000000_SP
 6/24 Test  #6: s_test_2_10000000_SP .............   Passed    0.03 sec
      Start  7: d_test_9_2_0_LA
 7/24 Test  #7: d_test_9_2_0_LA ..................   Passed    0.03 sec
      Start  8: d_test_9_2_10000000_LA
 8/24 Test  #8: d_test_9_2_10000000_LA ...........   Passed    0.04 sec
      Start  9: d_test_19_2_0_LA
 9/24 Test  #9: d_test_19_2_0_LA .................   Passed    0.03 sec
      Start 10: d_test_19_2_10000000_LA
10/24 Test #10: d_test_19_2_10000000_LA ..........   Passed    0.03 sec
      Start 11: d_test_2_0_SP
11/24 Test #11: d_test_2_0_SP ....................   Passed    0.03 sec
      Start 12: d_test_2_10000000_SP
12/24 Test #12: d_test_2_10000000_SP .............   Passed    0.03 sec
      Start 13: c_test_9_2_0_LA
13/24 Test #13: c_test_9_2_0_LA ..................   Passed    0.03 sec
      Start 14: c_test_9_2_10000000_LA
14/24 Test #14: c_test_9_2_10000000_LA ...........   Passed    0.03 sec
      Start 15: c_test_19_2_0_LA
15/24 Test #15: c_test_19_2_0_LA .................   Passed    0.03 sec
      Start 16: c_test_19_2_10000000_LA
16/24 Test #16: c_test_19_2_10000000_LA ..........   Passed    0.03 sec
      Start 17: c_test_2_0_SP
17/24 Test #17: c_test_2_0_SP ....................   Passed    0.04 sec
      Start 18: c_test_2_10000000_SP
18/24 Test #18: c_test_2_10000000_SP .............   Passed    0.03 sec
      Start 19: z_test_9_2_0_LA
19/24 Test #19: z_test_9_2_0_LA ..................   Passed    0.03 sec
      Start 20: z_test_9_2_10000000_LA
20/24 Test #20: z_test_9_2_10000000_LA ...........   Passed    0.03 sec
      Start 21: z_test_19_2_0_LA
21/24 Test #21: z_test_19_2_0_LA .................   Passed    0.03 sec
      Start 22: z_test_19_2_10000000_LA
22/24 Test #22: z_test_19_2_10000000_LA ..........   Passed    0.03 sec
      Start 23: z_test_2_0_SP
23/24 Test #23: z_test_2_0_SP ....................   Passed    0.03 sec
      Start 24: z_test_2_10000000_SP
24/24 Test #24: z_test_2_10000000_SP .............   Passed    0.03 sec

100% tests passed, 0 tests failed out of 24

Total Test time (real) =   0.84 sec
Test project C:/Dev/MINGW-packages/mingw-w64-superlu/src/build-CLANGARM64-shared
      Start  1: s_test_9_2_0_LA
 1/24 Test  #1: s_test_9_2_0_LA ..................   Passed    0.03 sec
      Start  2: s_test_9_2_10000000_LA
 2/24 Test  #2: s_test_9_2_10000000_LA ...........   Passed    0.03 sec
      Start  3: s_test_19_2_0_LA
 3/24 Test  #3: s_test_19_2_0_LA .................   Passed    0.03 sec
      Start  4: s_test_19_2_10000000_LA
 4/24 Test  #4: s_test_19_2_10000000_LA ..........   Passed    0.03 sec
      Start  5: s_test_2_0_SP
 5/24 Test  #5: s_test_2_0_SP ....................   Passed    0.03 sec
      Start  6: s_test_2_10000000_SP
 6/24 Test  #6: s_test_2_10000000_SP .............   Passed    0.03 sec
      Start  7: d_test_9_2_0_LA
 7/24 Test  #7: d_test_9_2_0_LA ..................   Passed    0.03 sec
      Start  8: d_test_9_2_10000000_LA
 8/24 Test  #8: d_test_9_2_10000000_LA ...........   Passed    0.03 sec
      Start  9: d_test_19_2_0_LA
 9/24 Test  #9: d_test_19_2_0_LA .................   Passed    0.03 sec
      Start 10: d_test_19_2_10000000_LA
10/24 Test #10: d_test_19_2_10000000_LA ..........   Passed    0.03 sec
      Start 11: d_test_2_0_SP
11/24 Test #11: d_test_2_0_SP ....................   Passed    0.03 sec
      Start 12: d_test_2_10000000_SP
12/24 Test #12: d_test_2_10000000_SP .............   Passed    0.03 sec
      Start 13: c_test_9_2_0_LA
13/24 Test #13: c_test_9_2_0_LA ..................   Passed    0.03 sec
      Start 14: c_test_9_2_10000000_LA
14/24 Test #14: c_test_9_2_10000000_LA ...........   Passed    0.03 sec
      Start 15: c_test_19_2_0_LA
15/24 Test #15: c_test_19_2_0_LA .................   Passed    0.03 sec
      Start 16: c_test_19_2_10000000_LA
16/24 Test #16: c_test_19_2_10000000_LA ..........   Passed    0.03 sec
      Start 17: c_test_2_0_SP
17/24 Test #17: c_test_2_0_SP ....................   Passed    0.04 sec
      Start 18: c_test_2_10000000_SP
18/24 Test #18: c_test_2_10000000_SP .............   Passed    0.03 sec
      Start 19: z_test_9_2_0_LA
19/24 Test #19: z_test_9_2_0_LA ..................   Passed    0.03 sec
      Start 20: z_test_9_2_10000000_LA
20/24 Test #20: z_test_9_2_10000000_LA ...........   Passed    0.03 sec
      Start 21: z_test_19_2_0_LA
21/24 Test #21: z_test_19_2_0_LA .................   Passed    0.03 sec
      Start 22: z_test_19_2_10000000_LA
22/24 Test #22: z_test_19_2_10000000_LA ..........   Passed    0.03 sec
      Start 23: z_test_2_0_SP
23/24 Test #23: z_test_2_0_SP ....................   Passed    0.03 sec
      Start 24: z_test_2_10000000_SP
24/24 Test #24: z_test_2_10000000_SP .............   Passed    0.03 sec

100% tests passed, 0 tests failed out of 24

Total Test time (real) =   0.83 sec
```