### PR TITLE
sqlcipher: update to 4.5.2

### DIFF
--- a/mingw-w64-sqlcipher/PKGBUILD
+++ b/mingw-w64-sqlcipher/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=sqlcipher
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.5.1
+pkgver=4.5.2
 pkgrel=1
 pkgdesc="SQLite extension that provides transparent 256-bit AES encryption of database files"
 arch=('any')
@@ -19,7 +19,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cc")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/${_realname}/${_realname}/archive/v${pkgver}.tar.gz"
         "02-fix-tcl-find.patch")
-sha256sums=('023499516ef2ade14fbcdbe93fb81cc69458ae6cb3544614df8dbef34835b406'
+sha256sums=('6925f012deb5582e39761a7d4816883cc15b41851a8e70b447c223b8ef406e2a'
             'd30c43a28eaeedcafde98d0f9a76fd8d676ee77732c9dc38e028147faa5adca0')
 
 prepare() {


### PR DESCRIPTION
Updates source code baseline to upstream SQLite 3.39.2