### PR TITLE
crt: Add DirectX libs to aarch64

### DIFF
--- a/mingw-w64-crt-git/0003-DirectX-aarch64.patch
+++ b/mingw-w64-crt-git/0003-DirectX-aarch64.patch
@@ -1,0 +1,203 @@
+diff -bur mingw-w64-c/mingw-w64-crt/libarm64/Makefile.am mingw-w64/mingw-w64-crt/libarm64/Makefile.am
+--- mingw-w64-c/mingw-w64-crt/libarm64/Makefile.am	2022-08-09 20:38:37.579024300 -0600
++++ mingw-w64/mingw-w64-crt/libarm64/Makefile.am	2022-08-09 20:53:43.611208300 -0600
+@@ -56,6 +56,7 @@
+ libarm64_DATA += %reldir%/libd3d10.a
+ libarm64_DATA += %reldir%/libd3d11.a
+ libarm64_DATA += %reldir%/libd3d12.a
++libarm64_DATA += %reldir%/libd3dxof.a
+ libarm64_DATA += %reldir%/libd3dcompiler_47.a
+ libarm64_DATA += %reldir%/libdavclnt.a
+ libarm64_DATA += %reldir%/libdavhlpr.a
+@@ -91,6 +92,39 @@
+ libarm64_DATA += %reldir%/libdsuiext.a
+ libarm64_DATA += %reldir%/libduser.a
+ libarm64_DATA += %reldir%/libdwmapi.a
++libarm64_DATA += %reldir%/libd3dx10_33.a
++libarm64_DATA += %reldir%/libd3dx10_34.a
++libarm64_DATA += %reldir%/libd3dx10_35.a
++libarm64_DATA += %reldir%/libd3dx10_36.a
++libarm64_DATA += %reldir%/libd3dx10_37.a
++libarm64_DATA += %reldir%/libd3dx10_38.a
++libarm64_DATA += %reldir%/libd3dx10_39.a
++libarm64_DATA += %reldir%/libd3dx10_40.a
++libarm64_DATA += %reldir%/libd3dx10_41.a
++libarm64_DATA += %reldir%/libd3dx10_42.a
++libarm64_DATA += %reldir%/libd3dx10_43.a
++libarm64_DATA += %reldir%/libd3dx11_42.a
++libarm64_DATA += %reldir%/libd3dx11_43.a
++libarm64_DATA += %reldir%/libd3dx9_24.a
++libarm64_DATA += %reldir%/libd3dx9_25.a
++libarm64_DATA += %reldir%/libd3dx9_26.a
++libarm64_DATA += %reldir%/libd3dx9_27.a
++libarm64_DATA += %reldir%/libd3dx9_28.a
++libarm64_DATA += %reldir%/libd3dx9_29.a
++libarm64_DATA += %reldir%/libd3dx9_30.a
++libarm64_DATA += %reldir%/libd3dx9_31.a
++libarm64_DATA += %reldir%/libd3dx9_32.a
++libarm64_DATA += %reldir%/libd3dx9_33.a
++libarm64_DATA += %reldir%/libd3dx9_34.a
++libarm64_DATA += %reldir%/libd3dx9_35.a
++libarm64_DATA += %reldir%/libd3dx9_36.a
++libarm64_DATA += %reldir%/libd3dx9_37.a
++libarm64_DATA += %reldir%/libd3dx9_38.a
++libarm64_DATA += %reldir%/libd3dx9_39.a
++libarm64_DATA += %reldir%/libd3dx9_40.a
++libarm64_DATA += %reldir%/libd3dx9_41.a
++libarm64_DATA += %reldir%/libd3dx9_42.a
++libarm64_DATA += %reldir%/libd3dx9_43.a
+ libarm64_DATA += %reldir%/libdwrite.a
+ libarm64_DATA += %reldir%/libdxgi.a
+ libarm64_DATA += %reldir%/libdxva2.a
+diff -bur mingw-w64-c/mingw-w64-crt/Makefile.am mingw-w64/mingw-w64-crt/Makefile.am
+--- mingw-w64-c/mingw-w64-crt/Makefile.am	2022-08-09 20:38:36.395147800 -0600
++++ mingw-w64/mingw-w64-crt/Makefile.am	2022-08-09 21:14:02.140459100 -0600
+@@ -1935,11 +1935,20 @@
+ 
+ dx64_DATA =
+ dx64_DATA += libarm64/libxinput.a
++dx64_DATA += libarm64/libd3dx9.a
++dx64_DATA += libarm64/libd3dx10.a
++dx64_DATA += libarm64/libd3dx11.a
+ dx64_DATA += libarm64/libd3dcompiler.a
+ 
+ libarm64/libxinput.a: lib-common/xinput1_4.def
+ 	$(DTDEFARM64) $<
+-libarm64/libd3dcompiler.a: lib-common/d3dcompiler_47.def
++libarm64/libd3dx9.a: libarm64/$(d3dx9).def
++	$(DTDEFARM64) $<
++libarm64/libd3dx10.a: libarm64/$(d3dx10).def
++	$(DTDEFARM64) $<
++libarm64/libd3dx11.a: libarm64/$(d3dx11).def
++	$(DTDEFARM64) $<
++libarm64/libd3dcompiler.a: lib-common/$(d3dcompiler).def
+ 	$(DTDEFARM64) $<
+ 
+ endif
+diff -bur mingw-w64-c/mingw-w64-crt/Makefile.in mingw-w64/mingw-w64-crt/Makefile.in
+--- mingw-w64-c/mingw-w64-crt/Makefile.in	2022-08-09 20:38:36.453134200 -0600
++++ mingw-w64/mingw-w64-crt/Makefile.in	2022-08-09 21:16:34.572562700 -0600
+@@ -11909,7 +11909,8 @@
+ @LIB64_TRUE@	lib64/libx3daudio.a lib64/libd3dx9.a \
+ @LIB64_TRUE@	lib64/libd3dx10.a lib64/libd3dx11.a \
+ @LIB64_TRUE@	lib64/libd3dcsxd.a lib64/libd3dcompiler.a
+-@LIBARM64_TRUE@dx64_DATA = libarm64/libxinput.a \
++@LIBARM64_TRUE@dx64_DATA = libarm64/libxinput.a libarm64/libd3dx9.a \
++@LIBARM64_TRUE@	libarm64/libd3dx10.a libarm64/libd3dx11.a \
+ @LIBARM64_TRUE@	libarm64/libd3dcompiler.a
+ 
+ # End 64-bit runtime
+@@ -12692,6 +12693,7 @@
+ @LIBARM64_TRUE@	libarm64/libcscapi.a libarm64/libd2d1.a \
+ @LIBARM64_TRUE@	libarm64/libd3d9.a libarm64/libd3d10.a \
+ @LIBARM64_TRUE@	libarm64/libd3d11.a libarm64/libd3d12.a \
++@LIBARM64_TRUE@	libarm64/libd3dxof.a \
+ @LIBARM64_TRUE@	libarm64/libd3dcompiler_47.a \
+ @LIBARM64_TRUE@	libarm64/libdavclnt.a libarm64/libdavhlpr.a \
+ @LIBARM64_TRUE@	libarm64/libdbgeng.a libarm64/libdbghelp.a \
+@@ -12709,40 +12711,56 @@
+ @LIBARM64_TRUE@	libarm64/libdsrole.a libarm64/libdssec.a \
+ @LIBARM64_TRUE@	libarm64/libdssenh.a libarm64/libdsuiext.a \
+ @LIBARM64_TRUE@	libarm64/libduser.a libarm64/libdwmapi.a \
+-@LIBARM64_TRUE@	libarm64/libdwrite.a libarm64/libdxgi.a \
+-@LIBARM64_TRUE@	libarm64/libdxva2.a libarm64/libeappcfg.a \
+-@LIBARM64_TRUE@	libarm64/libeappgnui.a libarm64/libeapphost.a \
+-@LIBARM64_TRUE@	libarm64/libeappprxy.a libarm64/libefsadu.a \
+-@LIBARM64_TRUE@	libarm64/libelscore.a libarm64/libesentprf.a \
+-@LIBARM64_TRUE@	libarm64/libevr.a libarm64/libfdeploy.a \
+-@LIBARM64_TRUE@	libarm64/libfeclient.a libarm64/libfilemgmt.a \
+-@LIBARM64_TRUE@	libarm64/libfltlib.a libarm64/libfmifs.a \
+-@LIBARM64_TRUE@	libarm64/libfontsub.a libarm64/libfwpuclnt.a \
+-@LIBARM64_TRUE@	libarm64/libgdi32.a libarm64/libgetuname.a \
+-@LIBARM64_TRUE@	libarm64/libglu32.a libarm64/libgpedit.a \
+-@LIBARM64_TRUE@	libarm64/libhbaapi.a libarm64/libhid.a \
+-@LIBARM64_TRUE@	libarm64/libhlink.a libarm64/libhotplug.a \
+-@LIBARM64_TRUE@	libarm64/libhtmlhelp.a libarm64/libhtui.a \
+-@LIBARM64_TRUE@	libarm64/libiashlpr.a libarm64/libiassam.a \
+-@LIBARM64_TRUE@	libarm64/libiassvcs.a libarm64/libicm32.a \
+-@LIBARM64_TRUE@	libarm64/libicmp.a libarm64/libicmui.a \
+-@LIBARM64_TRUE@	libarm64/libiernonce.a libarm64/libimagehlp.a \
+-@LIBARM64_TRUE@	libarm64/libimgutil.a libarm64/libimm32.a \
+-@LIBARM64_TRUE@	libarm64/libinetcomm.a libarm64/libinetmib1.a \
+-@LIBARM64_TRUE@	libarm64/libinput.a libarm64/libinseng.a \
+-@LIBARM64_TRUE@	libarm64/libiphlpapi.a libarm64/libipnathlp.a \
+-@LIBARM64_TRUE@	libarm64/libjsproxy.a libarm64/libkdcom.a \
+-@LIBARM64_TRUE@	libarm64/libkeymgr.a libarm64/libks.a \
+-@LIBARM64_TRUE@	libarm64/libksecdd.a libarm64/libktmw32.a \
+-@LIBARM64_TRUE@	libarm64/liblinkinfo.a libarm64/libloadperf.a \
+-@LIBARM64_TRUE@	libarm64/libloghours.a libarm64/liblogoncli.a \
+-@LIBARM64_TRUE@	libarm64/liblz32.a libarm64/libmapi32.a \
+-@LIBARM64_TRUE@	libarm64/libmapistub.a libarm64/libmcicda.a \
+-@LIBARM64_TRUE@	libarm64/libmciseq.a libarm64/libmciwave.a \
+-@LIBARM64_TRUE@	libarm64/libmdminst.a libarm64/libmf3216.a \
+-@LIBARM64_TRUE@	libarm64/libmf.a libarm64/libmfcore.a \
+-@LIBARM64_TRUE@	libarm64/libmfplat.a libarm64/libmfplay.a \
+-@LIBARM64_TRUE@	libarm64/libmfreadwrite.a \
++@LIBARM64_TRUE@	libarm64/libd3dx10_33.a libarm64/libd3dx10_34.a \
++@LIBARM64_TRUE@	libarm64/libd3dx10_35.a libarm64/libd3dx10_36.a \
++@LIBARM64_TRUE@	libarm64/libd3dx10_37.a libarm64/libd3dx10_38.a \
++@LIBARM64_TRUE@	libarm64/libd3dx10_39.a libarm64/libd3dx10_40.a \
++@LIBARM64_TRUE@	libarm64/libd3dx10_41.a libarm64/libd3dx10_42.a \
++@LIBARM64_TRUE@	libarm64/libd3dx10_43.a libarm64/libd3dx11_42.a \
++@LIBARM64_TRUE@	libarm64/libd3dx11_43.a libarm64/libd3dx9_24.a \
++@LIBARM64_TRUE@	libarm64/libd3dx9_25.a libarm64/libd3dx9_26.a \
++@LIBARM64_TRUE@	libarm64/libd3dx9_27.a libarm64/libd3dx9_28.a \
++@LIBARM64_TRUE@	libarm64/libd3dx9_29.a libarm64/libd3dx9_30.a \
++@LIBARM64_TRUE@	libarm64/libd3dx9_31.a libarm64/libd3dx9_32.a \
++@LIBARM64_TRUE@	libarm64/libd3dx9_33.a libarm64/libd3dx9_34.a \
++@LIBARM64_TRUE@	libarm64/libd3dx9_35.a libarm64/libd3dx9_36.a \
++@LIBARM64_TRUE@	libarm64/libd3dx9_37.a libarm64/libd3dx9_38.a \
++@LIBARM64_TRUE@	libarm64/libd3dx9_39.a libarm64/libd3dx9_40.a \
++@LIBARM64_TRUE@	libarm64/libd3dx9_41.a libarm64/libd3dx9_42.a \
++@LIBARM64_TRUE@	libarm64/libd3dx9_43.a libarm64/libdwrite.a \
++@LIBARM64_TRUE@	libarm64/libdxgi.a libarm64/libdxva2.a \
++@LIBARM64_TRUE@	libarm64/libeappcfg.a libarm64/libeappgnui.a \
++@LIBARM64_TRUE@	libarm64/libeapphost.a libarm64/libeappprxy.a \
++@LIBARM64_TRUE@	libarm64/libefsadu.a libarm64/libelscore.a \
++@LIBARM64_TRUE@	libarm64/libesentprf.a libarm64/libevr.a \
++@LIBARM64_TRUE@	libarm64/libfdeploy.a libarm64/libfeclient.a \
++@LIBARM64_TRUE@	libarm64/libfilemgmt.a libarm64/libfltlib.a \
++@LIBARM64_TRUE@	libarm64/libfmifs.a libarm64/libfontsub.a \
++@LIBARM64_TRUE@	libarm64/libfwpuclnt.a libarm64/libgdi32.a \
++@LIBARM64_TRUE@	libarm64/libgetuname.a libarm64/libglu32.a \
++@LIBARM64_TRUE@	libarm64/libgpedit.a libarm64/libhbaapi.a \
++@LIBARM64_TRUE@	libarm64/libhid.a libarm64/libhlink.a \
++@LIBARM64_TRUE@	libarm64/libhotplug.a libarm64/libhtmlhelp.a \
++@LIBARM64_TRUE@	libarm64/libhtui.a libarm64/libiashlpr.a \
++@LIBARM64_TRUE@	libarm64/libiassam.a libarm64/libiassvcs.a \
++@LIBARM64_TRUE@	libarm64/libicm32.a libarm64/libicmp.a \
++@LIBARM64_TRUE@	libarm64/libicmui.a libarm64/libiernonce.a \
++@LIBARM64_TRUE@	libarm64/libimagehlp.a libarm64/libimgutil.a \
++@LIBARM64_TRUE@	libarm64/libimm32.a libarm64/libinetcomm.a \
++@LIBARM64_TRUE@	libarm64/libinetmib1.a libarm64/libinput.a \
++@LIBARM64_TRUE@	libarm64/libinseng.a libarm64/libiphlpapi.a \
++@LIBARM64_TRUE@	libarm64/libipnathlp.a libarm64/libjsproxy.a \
++@LIBARM64_TRUE@	libarm64/libkdcom.a libarm64/libkeymgr.a \
++@LIBARM64_TRUE@	libarm64/libks.a libarm64/libksecdd.a \
++@LIBARM64_TRUE@	libarm64/libktmw32.a libarm64/liblinkinfo.a \
++@LIBARM64_TRUE@	libarm64/libloadperf.a libarm64/libloghours.a \
++@LIBARM64_TRUE@	libarm64/liblogoncli.a libarm64/liblz32.a \
++@LIBARM64_TRUE@	libarm64/libmapi32.a libarm64/libmapistub.a \
++@LIBARM64_TRUE@	libarm64/libmcicda.a libarm64/libmciseq.a \
++@LIBARM64_TRUE@	libarm64/libmciwave.a libarm64/libmdminst.a \
++@LIBARM64_TRUE@	libarm64/libmf3216.a libarm64/libmf.a \
++@LIBARM64_TRUE@	libarm64/libmfcore.a libarm64/libmfplat.a \
++@LIBARM64_TRUE@	libarm64/libmfplay.a libarm64/libmfreadwrite.a \
+ @LIBARM64_TRUE@	libarm64/libmfsensorgroup.a \
+ @LIBARM64_TRUE@	libarm64/libmgmtapi.a libarm64/libmidimap.a \
+ @LIBARM64_TRUE@	libarm64/libmincore.a libarm64/libmlang.a \
+@@ -78465,7 +78483,13 @@
+ 
+ @LIBARM64_TRUE@libarm64/libxinput.a: lib-common/xinput1_4.def
+ @LIBARM64_TRUE@	$(DTDEFARM64) $<
+-@LIBARM64_TRUE@libarm64/libd3dcompiler.a: lib-common/d3dcompiler_47.def
++@LIBARM64_TRUE@libarm64/libd3dx9.a: libarm64/$(d3dx9).def
++@LIBARM64_TRUE@	$(DTDEFARM64) $<
++@LIBARM64_TRUE@libarm64/libd3dx10.a: libarm64/$(d3dx10).def
++@LIBARM64_TRUE@	$(DTDEFARM64) $<
++@LIBARM64_TRUE@libarm64/libd3dx11.a: libarm64/$(d3dx11).def
++@LIBARM64_TRUE@	$(DTDEFARM64) $<
++@LIBARM64_TRUE@libarm64/libd3dcompiler.a: lib-common/$(d3dcompiler).def
+ @LIBARM64_TRUE@	$(DTDEFARM64) $<
+ 
+ # End ARM 64-bit runtime

--- a/mingw-w64-crt-git/0003-DirectX-aarch64.patch
+++ b/mingw-w64-crt-git/0003-DirectX-aarch64.patch
@@ -9,65 +9,28 @@ diff -bur mingw-w64-c/mingw-w64-crt/libarm64/Makefile.am mingw-w64/mingw-w64-crt
  libarm64_DATA += %reldir%/libd3dcompiler_47.a
  libarm64_DATA += %reldir%/libdavclnt.a
  libarm64_DATA += %reldir%/libdavhlpr.a
-@@ -91,6 +92,39 @@
+@@ -91,6 +92,8 @@
  libarm64_DATA += %reldir%/libdsuiext.a
  libarm64_DATA += %reldir%/libduser.a
  libarm64_DATA += %reldir%/libdwmapi.a
-+libarm64_DATA += %reldir%/libd3dx10_33.a
-+libarm64_DATA += %reldir%/libd3dx10_34.a
-+libarm64_DATA += %reldir%/libd3dx10_35.a
-+libarm64_DATA += %reldir%/libd3dx10_36.a
-+libarm64_DATA += %reldir%/libd3dx10_37.a
-+libarm64_DATA += %reldir%/libd3dx10_38.a
-+libarm64_DATA += %reldir%/libd3dx10_39.a
-+libarm64_DATA += %reldir%/libd3dx10_40.a
-+libarm64_DATA += %reldir%/libd3dx10_41.a
-+libarm64_DATA += %reldir%/libd3dx10_42.a
-+libarm64_DATA += %reldir%/libd3dx10_43.a
 +libarm64_DATA += %reldir%/libd3dx11_42.a
 +libarm64_DATA += %reldir%/libd3dx11_43.a
-+libarm64_DATA += %reldir%/libd3dx9_24.a
-+libarm64_DATA += %reldir%/libd3dx9_25.a
-+libarm64_DATA += %reldir%/libd3dx9_26.a
-+libarm64_DATA += %reldir%/libd3dx9_27.a
-+libarm64_DATA += %reldir%/libd3dx9_28.a
-+libarm64_DATA += %reldir%/libd3dx9_29.a
-+libarm64_DATA += %reldir%/libd3dx9_30.a
-+libarm64_DATA += %reldir%/libd3dx9_31.a
-+libarm64_DATA += %reldir%/libd3dx9_32.a
-+libarm64_DATA += %reldir%/libd3dx9_33.a
-+libarm64_DATA += %reldir%/libd3dx9_34.a
-+libarm64_DATA += %reldir%/libd3dx9_35.a
-+libarm64_DATA += %reldir%/libd3dx9_36.a
-+libarm64_DATA += %reldir%/libd3dx9_37.a
-+libarm64_DATA += %reldir%/libd3dx9_38.a
-+libarm64_DATA += %reldir%/libd3dx9_39.a
-+libarm64_DATA += %reldir%/libd3dx9_40.a
-+libarm64_DATA += %reldir%/libd3dx9_41.a
-+libarm64_DATA += %reldir%/libd3dx9_42.a
-+libarm64_DATA += %reldir%/libd3dx9_43.a
  libarm64_DATA += %reldir%/libdwrite.a
  libarm64_DATA += %reldir%/libdxgi.a
  libarm64_DATA += %reldir%/libdxva2.a
 diff -bur mingw-w64-c/mingw-w64-crt/Makefile.am mingw-w64/mingw-w64-crt/Makefile.am
 --- mingw-w64-c/mingw-w64-crt/Makefile.am	2022-08-09 20:38:36.395147800 -0600
 +++ mingw-w64/mingw-w64-crt/Makefile.am	2022-08-09 21:14:02.140459100 -0600
-@@ -1935,11 +1935,20 @@
+@@ -1935,11 +1935,14 @@
  
  dx64_DATA =
  dx64_DATA += libarm64/libxinput.a
-+dx64_DATA += libarm64/libd3dx9.a
-+dx64_DATA += libarm64/libd3dx10.a
 +dx64_DATA += libarm64/libd3dx11.a
  dx64_DATA += libarm64/libd3dcompiler.a
  
  libarm64/libxinput.a: lib-common/xinput1_4.def
  	$(DTDEFARM64) $<
 -libarm64/libd3dcompiler.a: lib-common/d3dcompiler_47.def
-+libarm64/libd3dx9.a: libarm64/$(d3dx9).def
-+	$(DTDEFARM64) $<
-+libarm64/libd3dx10.a: libarm64/$(d3dx10).def
-+	$(DTDEFARM64) $<
 +libarm64/libd3dx11.a: libarm64/$(d3dx11).def
 +	$(DTDEFARM64) $<
 +libarm64/libd3dcompiler.a: lib-common/$(d3dcompiler).def
@@ -82,8 +45,8 @@ diff -bur mingw-w64-c/mingw-w64-crt/Makefile.in mingw-w64/mingw-w64-crt/Makefile
  @LIB64_TRUE@	lib64/libd3dx10.a lib64/libd3dx11.a \
  @LIB64_TRUE@	lib64/libd3dcsxd.a lib64/libd3dcompiler.a
 -@LIBARM64_TRUE@dx64_DATA = libarm64/libxinput.a \
-+@LIBARM64_TRUE@dx64_DATA = libarm64/libxinput.a libarm64/libd3dx9.a \
-+@LIBARM64_TRUE@	libarm64/libd3dx10.a libarm64/libd3dx11.a \
++@LIBARM64_TRUE@dx64_DATA = libarm64/libxinput.a \
++@LIBARM64_TRUE@	libarm64/libd3dx11.a \
  @LIBARM64_TRUE@	libarm64/libd3dcompiler.a
  
  # End 64-bit runtime
@@ -95,7 +58,7 @@ diff -bur mingw-w64-c/mingw-w64-crt/Makefile.in mingw-w64/mingw-w64-crt/Makefile
  @LIBARM64_TRUE@	libarm64/libd3dcompiler_47.a \
  @LIBARM64_TRUE@	libarm64/libdavclnt.a libarm64/libdavhlpr.a \
  @LIBARM64_TRUE@	libarm64/libdbgeng.a libarm64/libdbghelp.a \
-@@ -12709,40 +12711,56 @@
+@@ -12709,40 +12711,42 @@
  @LIBARM64_TRUE@	libarm64/libdsrole.a libarm64/libdssec.a \
  @LIBARM64_TRUE@	libarm64/libdssenh.a libarm64/libdsuiext.a \
  @LIBARM64_TRUE@	libarm64/libduser.a libarm64/libdwmapi.a \
@@ -133,23 +96,9 @@ diff -bur mingw-w64-c/mingw-w64-crt/Makefile.in mingw-w64/mingw-w64-crt/Makefile
 -@LIBARM64_TRUE@	libarm64/libmf.a libarm64/libmfcore.a \
 -@LIBARM64_TRUE@	libarm64/libmfplat.a libarm64/libmfplay.a \
 -@LIBARM64_TRUE@	libarm64/libmfreadwrite.a \
-+@LIBARM64_TRUE@	libarm64/libd3dx10_33.a libarm64/libd3dx10_34.a \
-+@LIBARM64_TRUE@	libarm64/libd3dx10_35.a libarm64/libd3dx10_36.a \
-+@LIBARM64_TRUE@	libarm64/libd3dx10_37.a libarm64/libd3dx10_38.a \
-+@LIBARM64_TRUE@	libarm64/libd3dx10_39.a libarm64/libd3dx10_40.a \
-+@LIBARM64_TRUE@	libarm64/libd3dx10_41.a libarm64/libd3dx10_42.a \
-+@LIBARM64_TRUE@	libarm64/libd3dx10_43.a libarm64/libd3dx11_42.a \
-+@LIBARM64_TRUE@	libarm64/libd3dx11_43.a libarm64/libd3dx9_24.a \
-+@LIBARM64_TRUE@	libarm64/libd3dx9_25.a libarm64/libd3dx9_26.a \
-+@LIBARM64_TRUE@	libarm64/libd3dx9_27.a libarm64/libd3dx9_28.a \
-+@LIBARM64_TRUE@	libarm64/libd3dx9_29.a libarm64/libd3dx9_30.a \
-+@LIBARM64_TRUE@	libarm64/libd3dx9_31.a libarm64/libd3dx9_32.a \
-+@LIBARM64_TRUE@	libarm64/libd3dx9_33.a libarm64/libd3dx9_34.a \
-+@LIBARM64_TRUE@	libarm64/libd3dx9_35.a libarm64/libd3dx9_36.a \
-+@LIBARM64_TRUE@	libarm64/libd3dx9_37.a libarm64/libd3dx9_38.a \
-+@LIBARM64_TRUE@	libarm64/libd3dx9_39.a libarm64/libd3dx9_40.a \
-+@LIBARM64_TRUE@	libarm64/libd3dx9_41.a libarm64/libd3dx9_42.a \
-+@LIBARM64_TRUE@	libarm64/libd3dx9_43.a libarm64/libdwrite.a \
++@LIBARM64_TRUE@	libarm64/libd3dx11_42.a \
++@LIBARM64_TRUE@	libarm64/libd3dx11_43.a \
++@LIBARM64_TRUE@	libarm64/libdwrite.a \
 +@LIBARM64_TRUE@	libarm64/libdxgi.a libarm64/libdxva2.a \
 +@LIBARM64_TRUE@	libarm64/libeappcfg.a libarm64/libeappgnui.a \
 +@LIBARM64_TRUE@	libarm64/libeapphost.a libarm64/libeappprxy.a \
@@ -186,15 +135,11 @@ diff -bur mingw-w64-c/mingw-w64-crt/Makefile.in mingw-w64/mingw-w64-crt/Makefile
  @LIBARM64_TRUE@	libarm64/libmfsensorgroup.a \
  @LIBARM64_TRUE@	libarm64/libmgmtapi.a libarm64/libmidimap.a \
  @LIBARM64_TRUE@	libarm64/libmincore.a libarm64/libmlang.a \
-@@ -78465,7 +78483,13 @@
+@@ -78465,7 +78483,9 @@
  
  @LIBARM64_TRUE@libarm64/libxinput.a: lib-common/xinput1_4.def
  @LIBARM64_TRUE@	$(DTDEFARM64) $<
 -@LIBARM64_TRUE@libarm64/libd3dcompiler.a: lib-common/d3dcompiler_47.def
-+@LIBARM64_TRUE@libarm64/libd3dx9.a: libarm64/$(d3dx9).def
-+@LIBARM64_TRUE@	$(DTDEFARM64) $<
-+@LIBARM64_TRUE@libarm64/libd3dx10.a: libarm64/$(d3dx10).def
-+@LIBARM64_TRUE@	$(DTDEFARM64) $<
 +@LIBARM64_TRUE@libarm64/libd3dx11.a: libarm64/$(d3dx11).def
 +@LIBARM64_TRUE@	$(DTDEFARM64) $<
 +@LIBARM64_TRUE@libarm64/libd3dcompiler.a: lib-common/$(d3dcompiler).def

--- a/mingw-w64-crt-git/PKGBUILD
+++ b/mingw-w64-crt-git/PKGBUILD
@@ -4,7 +4,7 @@ _realname=crt
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 pkgver=10.0.0.r62.gafef638c3
-pkgrel=1
+pkgrel=2
 _commit='afef638c345a62c9e53f5c5409044eeb470e79e7'
 pkgdesc='MinGW-w64 CRT for Windows'
 arch=('any')
@@ -22,10 +22,12 @@ conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 options=('!strip' 'staticlibs' '!buildflags' '!emptydirs')
 source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64#commit=$_commit"
         0001-Allow-to-use-bessel-and-complex-functions-without-un.patch
-        0002-DirectX-9-fixes-for-VLC.patch)
+        0002-DirectX-9-fixes-for-VLC.patch
+        0003-DirectX-aarch64.patch)
 sha256sums=('SKIP'
             'd641257f7e1469aff89adc33e57702b75fe9667ca035978f890eae1020b6814c'
-            '09b1c7b62f666a07609af57e10c2b0ad815b78356f4b0f1fb6d827a1109a0ec7')
+            '09b1c7b62f666a07609af57e10c2b0ad815b78356f4b0f1fb6d827a1109a0ec7'
+            '07792e407ba982ab932e0e7d9d228c5be2e3706aac048e0ff56b9d039dc9f5e9')
 
 pkgver() {
   cd "${srcdir}/mingw-w64"
@@ -37,6 +39,12 @@ prepare() {
 
   git apply "${srcdir}/0001-Allow-to-use-bessel-and-complex-functions-without-un.patch"
   git apply "${srcdir}/0002-DirectX-9-fixes-for-VLC.patch"
+  patch -p1 -i "${srcdir}/0003-DirectX-aarch64.patch"
+
+  # Add DirectX library definition files
+  if [[ $MSYSTEM_CARCH == aarch64 ]]; then
+    cp ./mingw-w64-crt/lib64/d3dx*.def ./mingw-w64-crt/libarm64
+  fi
 }
 
 build() {

--- a/mingw-w64-crt-git/PKGBUILD
+++ b/mingw-w64-crt-git/PKGBUILD
@@ -27,7 +27,7 @@ source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64#commit=$
 sha256sums=('SKIP'
             'd641257f7e1469aff89adc33e57702b75fe9667ca035978f890eae1020b6814c'
             '09b1c7b62f666a07609af57e10c2b0ad815b78356f4b0f1fb6d827a1109a0ec7'
-            '07792e407ba982ab932e0e7d9d228c5be2e3706aac048e0ff56b9d039dc9f5e9')
+            '6265dc2c8aec6568b846d0907ab17fa0af5431049a923fe2b846d7dbfe80402b')
 
 pkgver() {
   cd "${srcdir}/mingw-w64"


### PR DESCRIPTION
Fixes #12516 , but this should be fixed upstream. There's no code compilation involved. Its just adding new .def files to create .a files from. 
cc @Biswa96 How can I get in touch with the upstream maintainers? 