### PR TITLE
inkscape: Add aarch64 support 🏁

### DIFF
--- a/mingw-w64-inkscape/PKGBUILD
+++ b/mingw-w64-inkscape/PKGBUILD
@@ -6,11 +6,11 @@ _realname=inkscape
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.2.1
-pkgrel=3
+pkgrel=4
 _pkg_suffix=2022-07-14_9c6d41e410
 pkgdesc="Vector graphics editor using the SVG file format (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://inkscape.sourceforge.io/"
 license=("GPL" "LGPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
@@ -43,7 +43,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-aspell"
          "${MINGW_PACKAGE_PREFIX}-potrace"
          "${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-scour"
-         $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] && echo "${MINGW_PACKAGE_PREFIX}-openmp"))
+         $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-*86* ]] && echo "${MINGW_PACKAGE_PREFIX}-openmp"))
 optdepends=(#"${MINGW_PACKAGE_PREFIX}-pstoedit: latex formulas"
             "${MINGW_PACKAGE_PREFIX}-texlive-scheme-medium: latex formulas"
             "${MINGW_PACKAGE_PREFIX}-python-numpy: some extensions"
@@ -56,12 +56,14 @@ source=("${_realname}-${pkgver}.tar.xz::https://media.inkscape.org/dl/resources/
         inkscape-1.0.1-unbundle.patch
         inkscape-1.0.1-install-layout.patch
         clang-fix-4.patch
-        fix-detecting-mingw-arch.patch)
+        fix-detecting-mingw-arch.patch
+        fix-detecting-mingw-aarch64.patch)
 sha256sums=('46ce7da0eba7ca4badc1db70e9cbb67e0adf9bb342687dc6e08b5ca21b8d4c1b'
             '67cffe472b93b011f5c5d46b30dfe9ebf7e3426dbe894390802eb225f4965616'
             '131b2e1190637df0554ef1ee8cf46440689584375c117d057ab47d5871c58128'
             '847dee197e295ddc44c8b5c17264666e65b8d311dcf01a9a8abe6a9887f89cca'
-            'de76acd3e42a0b2458e63d048236da5bb6a4fe2ce7427dbc201ca343b208dbf2')
+            'de76acd3e42a0b2458e63d048236da5bb6a4fe2ce7427dbc201ca343b208dbf2'
+            '98c9efe904c19f6c6f5f6d6efd8870b260bbd265e9ce064eefdad57217cd10c5')
 noextract=("${_realname}-${pkgver}.tar.xz")
 
 prepare() {
@@ -77,6 +79,8 @@ prepare() {
   patch -p1 -i ${srcdir}/clang-fix-4.patch
   # https://gitlab.com/inkscape/inkscape/-/merge_requests/4153
   patch -p1 -i ${srcdir}/fix-detecting-mingw-arch.patch
+  # https://gitlab.com/inkscape/inkscape/-/merge_requests/4693
+  patch -p1 -i ${srcdir}/fix-detecting-mingw-aarch64.patch
 }
 
 build() {
@@ -100,6 +104,7 @@ build() {
     -DCMAKE_AR=${MINGW_PREFIX}/bin/ar \
     -DWITH_IMAGE_MAGICK=OFF \
     -DWITH_INTERNAL_CAIRO=OFF \
+    $([[ ${MSYSTEM_CARCH} == aarch64 ]] && echo "-DWITH_OPENMP=OFF") \
     ../${_realname}-${pkgver}
 
   ${MINGW_PREFIX}/bin/cmake --build .

--- a/mingw-w64-inkscape/fix-detecting-mingw-aarch64.patch
+++ b/mingw-w64-inkscape/fix-detecting-mingw-aarch64.patch
@@ -1,0 +1,13 @@
+diff -bur inkscape-1.2.1-c/CMakeScripts/ConfigEnvMinGW.cmake inkscape-1.2.1/CMakeScripts/ConfigEnvMinGW.cmake
+--- inkscape-1.2.1-c/CMakeScripts/ConfigEnvMinGW.cmake	2022-08-11 00:33:58.485844200 -0600
++++ inkscape-1.2.1/CMakeScripts/ConfigEnvMinGW.cmake	2022-08-11 00:38:04.535065300 -0600
+@@ -27,6 +27,9 @@
+ elseif("$ENV{MINGW_CHOST}" STREQUAL "x86_64-w64-mingw32")
+   set(HAVE_MINGW64 ON)
+   set(MINGW_ARCH x86_64-w64-mingw32)
++elseif("$ENV{MINGW_CHOST}" STREQUAL "aarch64-w64-mingw32")
++  set(HAVE_MINGW64 ON)
++  set(MINGW_ARCH aarch64-w64-mingw32)
+ else()
+   message(FATAL_ERROR "Unable to determine MinGW processor architecture. Are you using an unsupported MinGW version?")
+ endif()


### PR DESCRIPTION
Requires #12529  

I had to manually create `libmscms.a` to be able to finish compiling so work is required in the `crt-git` package. This time, unlike the DirectX files, `mscms.dll` does exist in Windows on ARM. 

@lazka You may have to undelete that tweet soon 😊

![image](https://user-images.githubusercontent.com/1100440/184085827-a5aaff30-a0b8-46d5-9473-a51467e98b2f.png)
