### PR TITLE
Backport patches to support symbol visibility

### DIFF
--- a/mingw-w64-clang/0011-MinGW-Don-t-currently-set-visibility-hidden-when-bui.patch
+++ b/mingw-w64-clang/0011-MinGW-Don-t-currently-set-visibility-hidden-when-bui.patch
@@ -1,0 +1,40 @@
+From 606348cc72389de481c014afb0f15af7360fc950 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Storsj=C3=B6?= <martin@martin.st>
+Date: Wed, 20 Jul 2022 13:39:33 +0300
+Subject: [PATCH] [MinGW] Don't currently set visibility=hidden when building
+ for MinGW
+
+If we build the Target libraries with -fvisibility=hidden, then
+LLVM_EXTERNAL_VISIBILITY must also be able to override it back
+to default visibility.
+
+Currently, the LLVM_EXTERNAL_VISIBILITY define is a no-op for
+mingw targets, thus set CMAKE_CXX_VISIBILITY_PRESET correspondingly.
+
+This unbreaks the mingw dylib build, if the compiler actually
+takes hidden visiblity into account (e.g. after D130121).
+
+(Later, once hidden visiblity can be used for MinGW targets, we
+can make LLVM_EXTERNAL_VISIBILITY and LLVM_LIBRARY_VISIBILITY expand
+to actual attributes, and reverse this commit.)
+
+Differential Revision: https://reviews.llvm.org/D130200
+---
+ lib/Target/CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/Target/CMakeLists.txt b/lib/Target/CMakeLists.txt
+index 35a8e9ae0f70..c0c2bc36a6e4 100644
+--- a/lib/Target/CMakeLists.txt
++++ b/lib/Target/CMakeLists.txt
+@@ -22,6 +22,7 @@ add_llvm_component_library(LLVMTarget
+ # When building shared objects for each target there are some internal APIs
+ # that are used across shared objects which we can't hide.
+ if (NOT BUILD_SHARED_LIBS AND NOT APPLE AND
++    NOT MINGW AND
+     NOT (${CMAKE_SYSTEM_NAME} MATCHES "AIX") AND
+     NOT DEFINED CMAKE_CXX_VISIBILITY_PRESET)
+   # Set default visibility to hidden, so we don't export all the Target classes
+-- 
+2.37.1.windows.1
+

--- a/mingw-w64-clang/0012-COFF-Emit-embedded-exclude-symbols-directives-for-hi.patch
+++ b/mingw-w64-clang/0012-COFF-Emit-embedded-exclude-symbols-directives-for-hi.patch
@@ -1,0 +1,221 @@
+From c5b3de6745c37dd991430b9b88ff97c35b6fc455 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Storsj=C3=B6?= <martin@martin.st>
+Date: Tue, 19 Jul 2022 00:18:16 +0300
+Subject: [PATCH] [COFF] Emit embedded -exclude-symbols: directives for hidden
+ visibility for MinGW
+
+This works with the automatic export of all symbols; in MinGW mode,
+when a DLL has no explicit dllexports, it exports all symbols (except
+for some that are hardcoded to be excluded, including some toolchain
+libraries).
+
+By hooking up the hidden visibility to the -exclude-symbols: directive,
+the automatic export of all symbols can be controlled in an easier
+way (with a mechanism that doesn't require strict annotation of every
+single symbol, but which allows gradually marking more unnecessary
+symbols as hidden).
+
+The primary use case is dylib builds of LLVM/Clang. These can be done
+in MinGW mode but not in MSVC mode, as MinGW builds can export all
+symbols (and the calling code can use APIs without corresponding
+dllimport directives). However, as all symbols are exported, it can
+easily overflow the max number of exported symbols in a DLL (65536).
+
+In the llvm-mingw distribution, only the X86, ARM and AArch64 backends
+are enabled; for the LLVM 13.0.0 release, libLLVM-13.dll ended up with
+58112 exported symbols. For LLVM 14.0.0, it was 62015 symbols. Current
+builds of the 15.x branch end up at around 64650 symbols - i.e. extremely
+close to the limit.
+
+The msys2 packages of LLVM have had to progressively disable more
+of their backends in their builds, to be able to keep building with a
+dylib.
+
+This allows improving the current mingw dylib situation significantly,
+by using the same hidden visibility options and attributes as on Unix.
+With those in place, a current build of LLVM git main ends up at 35142
+symbols instead of 64650.
+
+For code using hidden visibility, this now requires linking with either
+a current git lld or ld.bfd. (Older lld error out on the unknown
+directives, older ld.bfd will successfully link, but will print huge
+amounts of warnings.)
+
+Differential Revision: https://reviews.llvm.org/D130121
+---
+ lib/IR/Mangler.cpp               | 60 +++++++++++++-------
+ test/CodeGen/X86/mingw-hidden.ll | 81 +++++++++++++++++++++++++++
+ 2 files changed, 121 insertions(+), 20 deletions(-)
+ create mode 100644 test/CodeGen/X86/mingw-hidden.ll
+
+diff --git a/lib/IR/Mangler.cpp b/lib/IR/Mangler.cpp
+index b8e3e40e4c1d..9011f5db6a40 100644
+--- a/lib/IR/Mangler.cpp
++++ b/lib/IR/Mangler.cpp
+@@ -210,18 +210,46 @@ static bool canBeUnquotedInDirective(StringRef Name) {
+ 
+ void llvm::emitLinkerFlagsForGlobalCOFF(raw_ostream &OS, const GlobalValue *GV,
+                                         const Triple &TT, Mangler &Mangler) {
+-  if (!GV->hasDLLExportStorageClass() || GV->isDeclaration())
+-    return;
++  if (GV->hasDLLExportStorageClass() && !GV->isDeclaration()) {
+ 
+-  if (TT.isWindowsMSVCEnvironment())
+-    OS << " /EXPORT:";
+-  else
+-    OS << " -export:";
++    if (TT.isWindowsMSVCEnvironment())
++      OS << " /EXPORT:";
++    else
++      OS << " -export:";
++
++    bool NeedQuotes = GV->hasName() && !canBeUnquotedInDirective(GV->getName());
++    if (NeedQuotes)
++      OS << "\"";
++    if (TT.isWindowsGNUEnvironment() || TT.isWindowsCygwinEnvironment()) {
++      std::string Flag;
++      raw_string_ostream FlagOS(Flag);
++      Mangler.getNameWithPrefix(FlagOS, GV, false);
++      FlagOS.flush();
++      if (Flag[0] == GV->getParent()->getDataLayout().getGlobalPrefix())
++        OS << Flag.substr(1);
++      else
++        OS << Flag;
++    } else {
++      Mangler.getNameWithPrefix(OS, GV, false);
++    }
++    if (NeedQuotes)
++      OS << "\"";
++
++    if (!GV->getValueType()->isFunctionTy()) {
++      if (TT.isWindowsMSVCEnvironment())
++        OS << ",DATA";
++      else
++        OS << ",data";
++    }
++  }
++  if (GV->hasHiddenVisibility() && !GV->isDeclaration() && TT.isOSCygMing()) {
++
++    OS << " -exclude-symbols:";
++
++    bool NeedQuotes = GV->hasName() && !canBeUnquotedInDirective(GV->getName());
++    if (NeedQuotes)
++      OS << "\"";
+ 
+-  bool NeedQuotes = GV->hasName() && !canBeUnquotedInDirective(GV->getName());
+-  if (NeedQuotes)
+-    OS << "\"";
+-  if (TT.isWindowsGNUEnvironment() || TT.isWindowsCygwinEnvironment()) {
+     std::string Flag;
+     raw_string_ostream FlagOS(Flag);
+     Mangler.getNameWithPrefix(FlagOS, GV, false);
+@@ -230,17 +258,9 @@ void llvm::emitLinkerFlagsForGlobalCOFF(raw_ostream &OS, const GlobalValue *GV,
+       OS << Flag.substr(1);
+     else
+       OS << Flag;
+-  } else {
+-    Mangler.getNameWithPrefix(OS, GV, false);
+-  }
+-  if (NeedQuotes)
+-    OS << "\"";
+ 
+-  if (!GV->getValueType()->isFunctionTy()) {
+-    if (TT.isWindowsMSVCEnvironment())
+-      OS << ",DATA";
+-    else
+-      OS << ",data";
++    if (NeedQuotes)
++      OS << "\"";
+   }
+ }
+ 
+diff --git a/test/CodeGen/X86/mingw-hidden.ll b/test/CodeGen/X86/mingw-hidden.ll
+new file mode 100644
+index 000000000000..8958458c55b6
+--- /dev/null
++++ b/test/CodeGen/X86/mingw-hidden.ll
+@@ -0,0 +1,81 @@
++; RUN: llc -mtriple i386-pc-win32 < %s \
++; RUN:    | FileCheck --check-prefixes=CHECK,CHECK-MSVC %s
++; RUN: llc -mtriple i386-pc-mingw32 < %s \
++; RUN:    | FileCheck --check-prefixes=CHECK,CHECK-MINGW %s
++; RUN: llc -mtriple i386-pc-mingw32 < %s \
++; RUN:    | FileCheck --check-prefix=NOTEXPORTED %s
++
++; CHECK: .text
++
++; CHECK: .globl _notHidden
++define void @notHidden() {
++	ret void
++}
++
++; CHECK: .globl _f1
++define hidden void @f1() {
++	ret void
++}
++
++; CHECK: .globl _f2
++define hidden void @f2() unnamed_addr {
++	ret void
++}
++
++declare hidden void @notDefined()
++
++; CHECK: .globl _stdfun@0
++define hidden x86_stdcallcc void @stdfun() nounwind {
++	ret void
++}
++
++; CHECK: .globl _lnk1
++$lnk1 = comdat any
++
++define linkonce_odr hidden void @lnk1() comdat {
++	ret void
++}
++
++; CHECK: .globl _lnk2
++$lnk2 = comdat any
++
++define linkonce_odr hidden void @lnk2() alwaysinline comdat {
++	ret void
++}
++
++; CHECK: .data
++; CHECK: .globl _Var1
++@Var1 = hidden global i32 1, align 4
++
++; CHECK: .rdata,"dr"
++; CHECK: .globl _Var2
++@Var2 = hidden unnamed_addr constant i32 1
++
++; CHECK: .comm _Var3
++@Var3 = common hidden global i32 0, align 4
++
++; CHECK: .globl "_complex-name"
++@"complex-name" = hidden global i32 1, align 4
++
++; CHECK: .globl _complex.name
++@"complex.name" = hidden global i32 1, align 4
++
++
++; Verify items that should not be marked hidden do not appear in the directives.
++; We use a separate check prefix to avoid confusion between -NOT and -SAME.
++; NOTEXPORTED: .section .drectve
++; NOTEXPORTED-NOT: :notHidden
++; NOTEXPORTED-NOT: :notDefined
++
++; CHECK-MSVC-NOT: .section .drectve
++; CHECK-MINGW: .section .drectve
++; CHECK-MINGW: .ascii " -exclude-symbols:f1"
++; CHECK-MINGW: .ascii " -exclude-symbols:f2"
++; CHECK-MINGW: .ascii " -exclude-symbols:stdfun@0"
++; CHECK-MINGW: .ascii " -exclude-symbols:lnk1"
++; CHECK-MINGW: .ascii " -exclude-symbols:lnk2"
++; CHECK-MINGW: .ascii " -exclude-symbols:Var1"
++; CHECK-MINGW: .ascii " -exclude-symbols:Var2"
++; CHECK-MINGW: .ascii " -exclude-symbols:Var3"
++; CHECK-MINGW: .ascii " -exclude-symbols:\"complex-name\""
++; CHECK-MINGW: .ascii " -exclude-symbols:\"complex.name\""
+-- 
+2.37.1.windows.1
+

--- a/mingw-w64-clang/0301-LLD-COFF-Add-support-for-a-new-mingw-specific-embedd.patch
+++ b/mingw-w64-clang/0301-LLD-COFF-Add-support-for-a-new-mingw-specific-embedd.patch
@@ -1,0 +1,176 @@
+From 5d513ef6cf4646e64bbb1d5f8610afd530964588 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Storsj=C3=B6?= <martin@martin.st>
+Date: Mon, 18 Jul 2022 00:11:37 +0300
+Subject: [PATCH] [LLD] [COFF] Add support for a new, mingw specific embedded
+ directive -exclude-symbols:
+
+This is an entirely new embedded directive - extending the GNU ld
+command line option --exclude-symbols to be usable in embedded
+directives too.
+
+(GNU ld.bfd also got support for the same new directive, currently in
+the latest git version, after the 2.39 branch.)
+
+This works as an inverse to the regular embedded dllexport directives,
+for cases when autoexport of all eligible symbols is performed.
+
+Differential Revision: https://reviews.llvm.org/D130120
+---
+ COFF/Driver.cpp                      | 10 +++++++++-
+ COFF/Driver.h                        |  2 ++
+ COFF/DriverUtils.cpp                 |  3 +++
+ COFF/MinGW.cpp                       |  6 ++++--
+ COFF/MinGW.h                         |  5 ++++-
+ test/COFF/exclude-symbols-embedded.s | 24 ++++++++++++++++++++++++
+ 6 files changed, 46 insertions(+), 4 deletions(-)
+ create mode 100644 test/COFF/exclude-symbols-embedded.s
+
+diff --git a/COFF/Driver.cpp b/COFF/Driver.cpp
+index 44406346dcec..11248d2faada 100644
+--- a/COFF/Driver.cpp
++++ b/COFF/Driver.cpp
+@@ -375,6 +375,14 @@ void LinkerDriver::parseDirectives(InputFile *file) {
+   for (StringRef inc : directives.includes)
+     addUndefined(inc);
+ 
++  // Handle /exclude-symbols: in bulk.
++  for (StringRef e : directives.excludes) {
++    SmallVector<StringRef, 2> vec;
++    e.split(vec, ',');
++    for (StringRef sym : vec)
++      excludedSymbols.insert(mangle(sym));
++  }
++
+   // https://docs.microsoft.com/en-us/cpp/preprocessor/comment-c-cpp?view=msvc-160
+   for (auto *arg : directives.args) {
+     switch (arg->getOption().getID()) {
+@@ -1309,7 +1317,7 @@ void LinkerDriver::maybeExportMinGWSymbols(const opt::InputArgList &args) {
+       return;
+   }
+ 
+-  AutoExporter exporter;
++  AutoExporter exporter(excludedSymbols);
+ 
+   for (auto *arg : args.filtered(OPT_wholearchive_file))
+     if (Optional<StringRef> path = doFindFile(arg->getValue()))
+diff --git a/COFF/Driver.h b/COFF/Driver.h
+index 902f122d4ade..3f6f98d1a060 100644
+--- a/COFF/Driver.h
++++ b/COFF/Driver.h
+@@ -53,6 +53,7 @@ extern COFFOptTable optTable;
+ struct ParsedDirectives {
+   std::vector<StringRef> exports;
+   std::vector<StringRef> includes;
++  std::vector<StringRef> excludes;
+   llvm::opt::InputArgList args;
+ };
+ 
+@@ -159,6 +160,7 @@ private:
+   std::vector<MemoryBufferRef> resources;
+ 
+   llvm::StringSet<> directivesExports;
++  llvm::DenseSet<StringRef> excludedSymbols;
+ 
+   COFFLinkerContext &ctx;
+ 
+diff --git a/COFF/DriverUtils.cpp b/COFF/DriverUtils.cpp
+index 505967f09115..ab69551034b9 100644
+--- a/COFF/DriverUtils.cpp
++++ b/COFF/DriverUtils.cpp
+@@ -899,6 +899,9 @@ ParsedDirectives ArgParser::parseDirectives(StringRef s) {
+     else if (tok.startswith_insensitive("/include:") ||
+              tok.startswith_insensitive("-include:"))
+       result.includes.push_back(tok.substr(strlen("/include:")));
++    else if (tok.startswith_insensitive("/exclude-symbols:") ||
++             tok.startswith_insensitive("-exclude-symbols:"))
++      result.excludes.push_back(tok.substr(strlen("/exclude-symbols:")));
+     else {
+       // Copy substrings that are not valid C strings. The tokenizer may have
+       // already copied quoted arguments for us, so those do not need to be
+diff --git a/COFF/MinGW.cpp b/COFF/MinGW.cpp
+index 190f4388902e..0689e44cc363 100644
+--- a/COFF/MinGW.cpp
++++ b/COFF/MinGW.cpp
+@@ -23,7 +23,9 @@ using namespace llvm::COFF;
+ using namespace lld;
+ using namespace lld::coff;
+ 
+-AutoExporter::AutoExporter() {
++AutoExporter::AutoExporter(
++    const llvm::DenseSet<StringRef> &manualExcludeSymbols)
++    : manualExcludeSymbols(manualExcludeSymbols) {
+   excludeLibs = {
+       "libgcc",
+       "libgcc_s",
+@@ -135,7 +137,7 @@ bool AutoExporter::shouldExport(const COFFLinkerContext &ctx,
+   // disallow import symbols.
+   if (!isa<DefinedRegular>(sym) && !isa<DefinedCommon>(sym))
+     return false;
+-  if (excludeSymbols.count(sym->getName()))
++  if (excludeSymbols.count(sym->getName()) || manualExcludeSymbols.count(sym->getName()))
+     return false;
+ 
+   for (StringRef prefix : excludeSymbolPrefixes.keys())
+diff --git a/COFF/MinGW.h b/COFF/MinGW.h
+index af40d1b5a6ec..113cd8327d28 100644
+--- a/COFF/MinGW.h
++++ b/COFF/MinGW.h
+@@ -13,6 +13,7 @@
+ #include "Symbols.h"
+ #include "lld/Common/LLVM.h"
+ #include "llvm/ADT/ArrayRef.h"
++#include "llvm/ADT/DenseSet.h"
+ #include "llvm/ADT/StringSet.h"
+ #include "llvm/Option/ArgList.h"
+ #include <vector>
+@@ -24,7 +25,7 @@ class COFFLinkerContext;
+ // symbols for MinGW.
+ class AutoExporter {
+ public:
+-  AutoExporter();
++  AutoExporter(const llvm::DenseSet<StringRef> &manualExcludeSymbols);
+ 
+   void addWholeArchive(StringRef path);
+   void addExcludedSymbol(StringRef symbol);
+@@ -35,6 +36,8 @@ public:
+   llvm::StringSet<> excludeLibs;
+   llvm::StringSet<> excludeObjects;
+ 
++  const llvm::DenseSet<StringRef> &manualExcludeSymbols;
++
+   bool shouldExport(const COFFLinkerContext &ctx, Defined *sym) const;
+ };
+
+diff --git a/test/COFF/exclude-symbols-embedded.s b/test/COFF/exclude-symbols-embedded.s
+new file mode 100644
+index 000000000000..9ea8ed479d20
+--- /dev/null
++++ b/test/COFF/exclude-symbols-embedded.s
+@@ -0,0 +1,24 @@
++// REQUIRES: x86
++// RUN: llvm-mc -filetype=obj -triple=i686-win32-gnu %s -o %t.o
++
++// RUN: lld-link -lldmingw -dll -out:%t.dll %t.o -noentry
++// RUN: llvm-readobj --coff-exports %t.dll | FileCheck --implicit-check-not=Name: %s
++
++// CHECK: Name:
++// CHECK: Name: sym1
++
++.global _sym1
++_sym1:
++  ret
++
++.global _sym2
++_sym2:
++  ret
++
++.global _sym3
++_sym3:
++  ret
++
++.section .drectve,"yn"
++.ascii " -exclude-symbols:sym2,unknownsym"
++.ascii " -exclude-symbols:unkonwnsym,sym3"
+-- 
+2.37.1.windows.1
+

--- a/mingw-w64-clang/0302-LLD-MinGW-Implement-the-exclude-symbols-option.patch
+++ b/mingw-w64-clang/0302-LLD-MinGW-Implement-the-exclude-symbols-option.patch
@@ -1,0 +1,150 @@
+From d1da6469f9ea9b078276ee2e098241f0440468be Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Storsj=C3=B6?= <martin@martin.st>
+Date: Mon, 18 Jul 2022 23:43:02 +0300
+Subject: [PATCH] [LLD] [MinGW] Implement the --exclude-symbols option
+
+This adds support for the existing GNU ld command line option, which
+allows excluding individual symbols from autoexport (when linking a
+DLL and no symbols are marked explicitly as dllexported).
+
+Differential Revision: https://reviews.llvm.org/D130118
+---
+ COFF/Driver.cpp             |  7 +++++++
+ COFF/MinGW.cpp              |  4 ++++
+ COFF/MinGW.h                |  1 +
+ COFF/Options.td             |  2 ++
+ MinGW/Driver.cpp            |  2 ++
+ MinGW/Options.td            |  2 ++
+ test/COFF/exclude-symbols.s | 20 ++++++++++++++++++++
+ test/MinGW/driver.test      |  4 ++++
+ 8 files changed, 42 insertions(+)
+ create mode 100644 test/COFF/exclude-symbols.s
+
+diff --git a/COFF/Driver.cpp b/COFF/Driver.cpp
+index 4f7b9e469668..44406346dcec 100644
+--- a/COFF/Driver.cpp
++++ b/COFF/Driver.cpp
+@@ -1315,6 +1315,13 @@ void LinkerDriver::maybeExportMinGWSymbols(const opt::InputArgList &args) {
+     if (Optional<StringRef> path = doFindFile(arg->getValue()))
+       exporter.addWholeArchive(*path);
+ 
++  for (auto *arg : args.filtered(OPT_exclude_symbols)) {
++    SmallVector<StringRef, 2> vec;
++    StringRef(arg->getValue()).split(vec, ',');
++    for (StringRef sym : vec)
++      exporter.addExcludedSymbol(mangle(sym));
++  }
++
+   ctx.symtab.forEachSymbol([&](Symbol *s) {
+     auto *def = dyn_cast<Defined>(s);
+     if (!exporter.shouldExport(ctx, def))
+diff --git a/COFF/MinGW.cpp b/COFF/MinGW.cpp
+index 7a3a3853572f..190f4388902e 100644
+--- a/COFF/MinGW.cpp
++++ b/COFF/MinGW.cpp
+@@ -122,6 +122,10 @@ void AutoExporter::addWholeArchive(StringRef path) {
+   excludeLibs.erase(libName);
+ }
+ 
++void AutoExporter::addExcludedSymbol(StringRef symbol) {
++  excludeSymbols.insert(symbol);
++}
++
+ bool AutoExporter::shouldExport(const COFFLinkerContext &ctx,
+                                 Defined *sym) const {
+   if (!sym || !sym->getChunk())
+diff --git a/COFF/MinGW.h b/COFF/MinGW.h
+index 59c2581f661d..af40d1b5a6ec 100644
+--- a/COFF/MinGW.h
++++ b/COFF/MinGW.h
+@@ -27,6 +27,7 @@ public:
+   AutoExporter();
+ 
+   void addWholeArchive(StringRef path);
++  void addExcludedSymbol(StringRef symbol);
+ 
+   llvm::StringSet<> excludeSymbols;
+   llvm::StringSet<> excludeSymbolPrefixes;
+diff --git a/COFF/Options.td b/COFF/Options.td
+index 5135f4ea34af..c728279ef5cc 100644
+--- a/COFF/Options.td
++++ b/COFF/Options.td
+@@ -45,6 +45,8 @@ def diasdkdir : P<"diasdkdir", "Set the location of the DIA SDK">;
+ def entry   : P<"entry", "Name of entry point symbol">;
+ def errorlimit : P<"errorlimit",
+     "Maximum number of errors to emit before stopping (0 = no limit)">;
++def exclude_symbols  : P<"exclude-symbols", "Exclude symbols from automatic export">,
++    MetaVarName<"<symbol[,symbol,...]>">;
+ def export  : P<"export", "Export a function">;
+ // No help text because /failifmismatch is not intended to be used by the user.
+ def failifmismatch : P<"failifmismatch", "">;
+diff --git a/MinGW/Driver.cpp b/MinGW/Driver.cpp
+index 5920a5061d9c..37d2439c3925 100644
+--- a/MinGW/Driver.cpp
++++ b/MinGW/Driver.cpp
+@@ -398,6 +398,8 @@ bool mingw::link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
+     add("-delayload:" + StringRef(a->getValue()));
+   for (auto *a : args.filtered(OPT_wrap))
+     add("-wrap:" + StringRef(a->getValue()));
++  for (auto *a : args.filtered(OPT_exclude_symbols))
++    add("-exclude-symbols:" + StringRef(a->getValue()));
+ 
+   std::vector<StringRef> searchPaths;
+   for (auto *a : args.filtered(OPT_L)) {
+diff --git a/MinGW/Options.td b/MinGW/Options.td
+index bfdd4af28800..cc94b93e388a 100644
+--- a/MinGW/Options.td
++++ b/MinGW/Options.td
+@@ -62,6 +62,8 @@ def enable_stdcall_fixup: F<"enable-stdcall-fixup">,
+ defm entry: Eq<"entry", "Name of entry point symbol">, MetaVarName<"<entry>">;
+ def exclude_all_symbols: F<"exclude-all-symbols">,
+     HelpText<"Don't automatically export any symbols">;
++defm exclude_symbols: Eq<"exclude-symbols",
++    "Exclude symbols from automatic export">, MetaVarName<"<symbol[,symbol,...]>">;
+ def export_all_symbols: F<"export-all-symbols">,
+     HelpText<"Export all symbols even if a def file or dllexport attributes are used">;
+ defm fatal_warnings: B<"fatal-warnings",
+diff --git a/test/COFF/exclude-symbols.s b/test/COFF/exclude-symbols.s
+new file mode 100644
+index 000000000000..cd358712382d
+--- /dev/null
++++ b/test/COFF/exclude-symbols.s
+@@ -0,0 +1,20 @@
++// REQUIRES: x86
++// RUN: llvm-mc -filetype=obj -triple=i686-win32-gnu %s -o %t.o
++
++// RUN: lld-link -lldmingw -dll -out:%t.dll %t.o -noentry -exclude-symbols:sym2,unknownsym -exclude-symbols:unknownsym,sym3
++// RUN: llvm-readobj --coff-exports %t.dll | FileCheck --implicit-check-not=Name: %s
++
++// CHECK: Name:
++// CHECK: Name: sym1
++
++.global _sym1
++_sym1:
++  ret
++
++.global _sym2
++_sym2:
++  ret
++
++.global _sym3
++_sym3:
++  ret
+diff --git a/test/MinGW/driver.test b/test/MinGW/driver.test
+index c67717d1a000..9c56bfa42f6b 100644
+--- a/test/MinGW/driver.test
++++ b/test/MinGW/driver.test
+@@ -321,6 +321,10 @@ RUN: ld.lld -### -m i386pep foo.o -wrap foo1 --wrap foo2 2>&1 | FileCheck -check
+ RUN: ld.lld -### -m i386pep foo.o -wrap=foo1 --wrap=foo2 2>&1 | FileCheck -check-prefix WRAP %s
+ WRAP: -wrap:foo1 -wrap:foo2
+ 
++RUN: ld.lld -### -m i386pep foo.o -exclude-symbols sym1,sym2 --exclude-symbols sym3 2>&1 | FileCheck -check-prefix EXCLUDE_SYMBOLS %s
++RUN: ld.lld -### -m i386pep foo.o -exclude-symbols=sym1,sym2 --exclude-symbols=sym3 2>&1 | FileCheck -check-prefix EXCLUDE_SYMBOLS %s
++EXCLUDE_SYMBOLS: -exclude-symbols:sym1,sym2 -exclude-symbols:sym3
++
+ RUN: ld.lld -### -m i386pep foo.o 2>&1 | FileCheck -check-prefix DEMANGLE %s
+ RUN: ld.lld -### -m i386pep foo.o -demangle 2>&1 | FileCheck -check-prefix DEMANGLE %s
+ RUN: ld.lld -### -m i386pep foo.o --demangle 2>&1 | FileCheck -check-prefix DEMANGLE %s
+-- 
+2.37.1.windows.1
+

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -22,7 +22,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-lld"
          "${MINGW_PACKAGE_PREFIX}-llvm")
 pkgver=14.0.6
-pkgrel=2
+pkgrel=3
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -59,7 +59,11 @@ source=("${_url}/llvm-${pkgver}.src.tar.xz"{,.sig}
         "0008-enable-emutls-for-mingw.patch"
         "0009-export-out-of-tree-mlir-targets.patch"
         "0010-lldb-Fix-building-standalone-LLDB-on-Windows.patch"
+        "0011-MinGW-Don-t-currently-set-visibility-hidden-when-bui.patch"
+        "0012-COFF-Emit-embedded-exclude-symbols-directives-for-hi.patch"
         "0104-link-pthread-with-mingw.patch"
+        "0301-LLD-COFF-Add-support-for-a-new-mingw-specific-embedd.patch"
+        "0302-LLD-MinGW-Implement-the-exclude-symbols-option.patch"
         "0304-ignore-new-bfd-options.patch"
         "0405-Do-not-try-to-build-CTTestTidyModule-for-Windows-with-dylibs.patch")
 # Some patch notes :)
@@ -86,7 +90,11 @@ sha256sums=('050922ecaaca5781fdf6631ea92bc715183f202f9d2f15147226f023414f619a'
             '3837bd707d3d99a742e874d5c59a1e7d5502811d6926319974c5d9db86020039'
             'cb96582194ef80a37cc184e95287920b2df5369e2e5798a64adf6f8bf1c52985'
             '51936b1a1d2a48b19cdc108944fe61cd5f1724a3312a1d2d37f3e3e841b78bc2'
+            '5f57f340d398b69421f6f94de45ff45f99dc4e686bcb7e8d2a7dc85529ed5ba7'
+            '5bb5e31eea8ea2c4eea56f2aae161dfde35caa9800459ae3c785a94654628e57'
             '715cb8862753854b2d9256e0b70003e2d1f57083d83eaeaf5a095fc72b8a4e26'
+            'e6c3b97f733920b0a32e889cd180dd86507bddea09e9c217cd1445c047cd4976'
+            'bd40b6c84d25de5ac5877f2c83ac61d872838bc034df62e98ad16116d23744e0'
             '778e0db0a5b0657ab05e2a81d83241347a4a41af2b0f9903422f651fa58e8d40'
             'a10e5192889501c75db6a41e29df44b2af8502b3ef34c2315789563a5c8e9b85')
 validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Google.
@@ -133,7 +141,9 @@ prepare() {
 
   apply_patch_with_msg \
     "0009-export-out-of-tree-mlir-targets.patch" \
-    "0010-lldb-Fix-building-standalone-LLDB-on-Windows.patch"
+    "0010-lldb-Fix-building-standalone-LLDB-on-Windows.patch" \
+    "0011-MinGW-Don-t-currently-set-visibility-hidden-when-bui.patch" \
+    "0012-COFF-Emit-embedded-exclude-symbols-directives-for-hi.patch"
 
   # Patch clang
   cd "${srcdir}/clang"
@@ -146,7 +156,9 @@ prepare() {
   # Patch lld
   cd "${srcdir}/lld"
   apply_patch_with_msg \
-    "0304-ignore-new-bfd-options.patch"
+    "0304-ignore-new-bfd-options.patch" \
+    "0301-LLD-COFF-Add-support-for-a-new-mingw-specific-embedd.patch" \
+    "0302-LLD-MinGW-Implement-the-exclude-symbols-option.patch"
 
   # Patch clang-tools-extra
   cd "${srcdir}/clang-tools-extra"


### PR DESCRIPTION
In preparation for enabling all targets in LLVM 15 this must be merged first.

Tested with multi stage bootstrap: built CLANG64 version of this PGBUILD, installed resulting packages, built this PKGBUILD again (so this step built LLVM with patched LLVM), installed resulting packages.
Then I rebuilt libc++, mlir and flang, they do not crash so seems good to go.