### PR TITLE
sundials: upgrade to 6.3.0

### DIFF
--- a/mingw-w64-sundials/PKGBUILD
+++ b/mingw-w64-sundials/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=sundials
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=6.2.0
-pkgrel=2
+pkgver=6.3.0
+pkgrel=1
 pkgdesc="SUite of Nonlinear and DIfferential/ALgebraic equation Solvers (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -35,7 +35,7 @@ source=("${_realname}-${pkgver}.tar.gz"::https://github.com/LLNL/sundials/releas
         '0006-sundials-petsc-integration.patch'
         '0007-sundials-6.0.0-superlu-support.patch')
 options=('staticlibs' 'strip')
-sha256sums=('195d5593772fc483f63f08794d79e4bab30c2ec58e6ce4b0fb6bcc0e0c48f31d'
+sha256sums=('89a22bea820ff250aa7239f634ab07fa34efe1d2dcfde29cc8d3af11455ba2a7'
             '7f119fbcc8a630a4e3443e3bba252dafb4b1567ced1bf1389052253529e97ddc'
             '310b9beb86426fd2f817391baf72c0f9aefe9dc31e737daed5cc0280b7693311'
             '30800e35e46f04e0d19b245e2529e2be578043417d9bdf88c536442212cb23de'


### PR DESCRIPTION
Builds just fine.

@mmuetzel Tested building Octave 8.0.0 from around January. I don't have the time to work out the kinks to test on a newer version, but that older version had no issues.