### PR TITLE
bin2header: update to 0.3.1

### DIFF
--- a/mingw-w64-bin2header/PKGBUILD
+++ b/mingw-w64-bin2header/PKGBUILD
@@ -3,15 +3,15 @@
 _realname=bin2header
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.3.0
+pkgver=0.3.1
 pkgrel=1
-pkgdesc="Binary file to C/C++ header converter (mingw-w64)"
-arch=("any")
-mingw_arch=("mingw32" "mingw64" "ucrt64" "clang64" "clang32")
+pkgdesc='Binary file to C/C++ header converter (mingw-w64)'
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://github.com/AntumDeluge/${_realname}"
-license=("MIT")
+license=('MIT')
 source=("${url}/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.xz")
-sha256sums=("605098476a23cacfae5bded5a51bb64a574798cd76aae0dd722f886c091f533e")
+sha256sums=('faf4f6069794e664bb5f39f156b45bd53ab36545c707cb4148bef58cff2a6018')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"


### PR DESCRIPTION
https://github.com/AntumDeluge/bin2header/releases/tag/v0.3.1