### PR TITLE
gtk2: remove gtk-update-icon-cache

### DIFF
--- a/mingw-w64-gtk2/PKGBUILD
+++ b/mingw-w64-gtk2/PKGBUILD
@@ -5,7 +5,7 @@ _realname=gtk2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.24.33
-pkgrel=5
+pkgrel=6
 pkgdesc="GTK+ is a multi-platform toolkit (v2) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -26,7 +26,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-gdk-pixbuf2>=2.21.0"
          "${MINGW_PACKAGE_PREFIX}-glib2>=2.28.0"
          "${MINGW_PACKAGE_PREFIX}-pango>=1.20"
-         "${MINGW_PACKAGE_PREFIX}-gtk-update-icon-cache"
          "${MINGW_PACKAGE_PREFIX}-shared-mime-info")
 #optdepends=("${MINGW_PACKAGE_PREFIX}-gnome-icon-theme: Default icon theme")
 install=gtk2-${MSYSTEM}.install
@@ -108,6 +107,10 @@ build() {
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   make -j1 DESTDIR="${pkgdir}" install
+
+  # Provided by a gtk3/4 split package instead
+  rm "${pkgdir}${MINGW_PREFIX}/bin/gtk-update-icon-cache"
+
   install -Dm644 "${srcdir}/gtkrc" "${pkgdir}${MINGW_PREFIX}/share/gtk-2.0/gtkrc.example"
   find "${pkgdir}${MINGW_PREFIX}" -name '*.def' -o -name '*.exp' | xargs -rtl1 rm
   install -Dm644 "${srcdir}/gtk+-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"


### PR DESCRIPTION
We want to provide this command via the gtk-update-icon-cache package
which is currently built via gtk3 (maybe gtk4 in the future), so remove it
in gtk2 to avoid conflicts.

Also remove the dependency on the gtk-update-icon-cache package, since
gtk2 doesn't install any icons, so no need to trigger the cache hook.

See #12527