### PR TITLE
gtk3: provide a gtk-update-icon-cache.exe

### DIFF
--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -4,13 +4,13 @@ _realname=gtk3
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-gtk-update-icon-cache")
 pkgver=3.24.34+87+g8bbc24c165
-pkgrel=2
+pkgrel=3
 _commit=8bbc24c16533934745b5650a5aaad872c30d394d
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://www.gtk.org/"
-license=("LGPL")
+license=("spdx:LGPL-2.1-or-later")
 makedepends=("git"
              "${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
@@ -41,7 +41,7 @@ sha256sums=('SKIP'
             'e553083298495f9581ae1454b1046a22b83e81862311b30de984057eec859708'
             'adbe57eb726d882bba7a031ab8fb1788e7cd03cbf713823fd0f99d3cb380b97c'
             '56a566739c4f153f3c924b2bfe5ec7aaca469e15c023810cd7c5f57036d1a258'
-            'b6306c6e117e879a60febc8e398a5a181325255a2e2c785c77222664b683f9dd')
+            'ad431cedaa2c4a20db35c753c89b85b45c67872004255762094277d27eb7c18a')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -144,8 +144,7 @@ package_gtk-update-icon-cache() {
 
   install -Dt "${pkgdir}${MINGW_PREFIX}/bin" gtk-update-icon-cache
   install -Dt "${pkgdir}${MINGW_PREFIX}/share/man/man1" gtk-update-icon-cache.1
-  mv ${pkgdir}${MINGW_PREFIX}/bin/gtk-update-icon-cache{,-3.0}.exe
-  mv ${pkgdir}${MINGW_PREFIX}/share/man/man1/gtk-update-icon-cache{,-3.0}.1
+  cp ${pkgdir}${MINGW_PREFIX}/bin/gtk-update-icon-cache{,-3.0}.exe
 }
 
 # template start; name=mingw-w64-splitpkg-wrappers; version=1.0;

--- a/mingw-w64-gtk3/gtk-update-icon-cache.script.in
+++ b/mingw-w64-gtk3/gtk-update-icon-cache.script.in
@@ -2,7 +2,7 @@
 
 while read -r f; do
   if [[ -e "${f}index.theme" ]]; then
-    @MINGW_PREFIX@/bin/gtk-update-icon-cache-3.0.exe -q "$f"
+    @MINGW_PREFIX@/bin/gtk-update-icon-cache.exe -q "$f"
   elif [[ -d $f ]]; then
     rm -f "${f}icon-theme.cache"
     rmdir --ignore-fail-on-non-empty "$f"


### PR DESCRIPTION
It's the name downstream projects expect.
Keep the versioned name for backwards compat still.

Fixes #12527