### PR TITLE
CI: uncomment clangarm64 and staging from pacman.conf

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,8 +65,8 @@ jobs:
         shell: msys2 {0}
         run: |
           cp /etc/pacman.conf /etc/pacman.conf.bak
-          grep -qF '[clangarm64]' /etc/pacman.conf || sed -i '1s|^|[clangarm64]\nInclude = /etc/pacman.d/mirrorlist.mingw\n|' /etc/pacman.conf
-          sed -i '1s|^|[staging]\nServer = https://repo.msys2.org/staging/\nSigLevel = Never\n|' /etc/pacman.conf
+          grep -qFx '[clangarm64]' /etc/pacman.conf || sed -i '/^# \[clangarm64\]/,/^$/ s|^# ||g' /etc/pacman.conf
+          grep -qFx '[staging]' /etc/pacman.conf || sed -i '/^# \[staging\]/,/^$/ s|^# ||g' /etc/pacman.conf
 
       - name: Update using staging
         run: |


### PR DESCRIPTION
 instead of adding from scratch.

staging would have been fine because it was added to pacman.conf unconditionally, but the grep for clangarm64 was matching the commented-out section.  Add grep `-x` option to match whole line only (so won't match commented-out section), and use sed to remove leading `# ` from start of section to first blank line.