### PR TITLE
Split wxsvg Into Multiple Packages Built Against Different wxWidgets Versions

### DIFF
--- a/mingw-w64-wxSVG/PKGBUILD
+++ b/mingw-w64-wxSVG/PKGBUILD
@@ -4,7 +4,7 @@ _realname=wxsvg
 _wx_basever=3.2
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-wx${_wx_basever}"
 pkgbase="mingw-w64-${_realname}"
-pkgver=1.5.23
+pkgver=1.5.24
 pkgrel=1
 pkgdesc="A C++ library to create, manipulate and render SVG files (mingw-w64)"
 arch=(any)
@@ -25,7 +25,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-msw")
 source=("https://downloads.sourceforge.net/project/wxsvg/wxsvg/${pkgver}/wxsvg-${pkgver}.tar.bz2"
         "gcc11-fix.patch")
-sha256sums=('3f07361facc7d18cc19a940dd73c78142ed5eec38c14d993a85bf0c061dcabb9'
+sha256sums=('ae473291f8d0a5feafa06cd270c826c6bead4bceb2b9dd6fcecf2db7c25e2482'
             'ac7b984f9ce4f051858ada88284545f4373b27a0b1200fe9f646467bd6c9f3bd')
 extractdir="${_realname}-${pkgver}"
 builddir="build-${CARCH}"


### PR DESCRIPTION
- replaces package `wxsvg` with `wxsvg-wx3.0`
- adds package `wxsvg-wx3.1`
- adds package `wxsvg-wx3.2`