### PR TITLE
tzdata: Update to 2022b

### DIFF
--- a/mingw-w64-tzdata/PKGBUILD
+++ b/mingw-w64-tzdata/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=tzdata
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2022a
+pkgver=2022b
 pkgrel=1
 pkgdesc="Sources for time zone and daylight saving time data (mingw-w64)"
 arch=('any')
@@ -13,7 +13,7 @@ license=('custom: public domain')
 options=('!emptydirs')
 makedepends=('tzcode')
 source=(https://www.iana.org/time-zones/repository/releases/${_realname}${pkgver}.tar.gz{,.asc})
-sha512sums=('542e4559beac8fd8c4af7d08d816fd12cfe7ffcb6f20bba4ff1c20eba717749ef96e5cf599b2fe03b5b8469c0467f8cb1c893008160da281055a123dd9e810d9'
+sha512sums=('a51418cda50386bc2e82a26201178c282ec225e04867e70a47ef90f42371a4014c70bffebb52ac09ccd893dfa17b0acc782f31527b3579ebdc4a302a9367ddb1'
             'SKIP')
 validpgpkeys=('7E3792A9D8ACF7D633BC1588ED97E90E62AA7E34') # Paul Eggert <eggert@cs.ucla.edu>
 
@@ -30,7 +30,7 @@ package() {
   zic -b fat -d "${pkgdir}${MINGW_PREFIX}"/share/zoneinfo/right -L leapseconds ${_timezones[@]}
   # This creates the posixrules file. We use New York because POSIX requires the daylight savings time rules to be in accordance with US rules.
   zic -b fat -d "${pkgdir}${MINGW_PREFIX}"/share/zoneinfo -p America/New_York
-  install -m444 -t "${pkgdir}${MINGW_PREFIX}"/share/zoneinfo iso3166.tab zone1970.tab zone.tab # zone.tab is depricated and will go soon
+  install -m444 -t "${pkgdir}${MINGW_PREFIX}"/share/zoneinfo iso3166.tab leap-seconds.list zone1970.tab zone.tab # zone.tab is depricated and will go soon
 
   # install license
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname}/LICENSE


### PR DESCRIPTION
install leap-seconds.list like Arch