### PR TITLE
Build wxSVG against wxWidgets 3.2

### DIFF
--- a/mingw-w64-wxSVG/PKGBUILD
+++ b/mingw-w64-wxSVG/PKGBUILD
@@ -1,16 +1,19 @@
 # Maintainer: Jordan Irwin <antumdeluge@gmail.com>
 
 _realname=wxsvg
-_wx_basever=3.0
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+_wx_basever=3.2
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-wx${_wx_basever}"
 pkgbase="mingw-w64-${_realname}"
 pkgver=1.5.23
-pkgrel=2
+pkgrel=1
 pkgdesc="A C++ library to create, manipulate and render SVG files (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://wxsvg.sourceforge.io/"
 license=("custom:wxWindows")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 depends=("${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-msw-libs"
          "${MINGW_PACKAGE_PREFIX}-cairo"
          "${MINGW_PACKAGE_PREFIX}-pango"


### PR DESCRIPTION
- updates wxSVG to be built against wxWidgets 3.2
- changes package name to `wxsvg-wx3.2`

There are conflicts between wxWidgets packages, so multiple wxSVG packages cannot be built from a single `PKGBUILD` script. See: #12559

**Edit:** Until the wxWidgets version conflicts can be fixed, wxSVG can only be built against one version, or there would have to be unique `PKGBUILD` scripts for each version. See: [wxsvg_multi_pkgbuild](https://github.com/AntumDeluge/MINGW-packages/tree/wxsvg_multi_pkgbuild)