### PR TITLE
ogre3d: try building without bullet

### DIFF
--- a/mingw-w64-ogre3d/PKGBUILD
+++ b/mingw-w64-ogre3d/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=13.4.4
 imgui_ver=1.87
-pkgrel=1
+pkgrel=2
 pkgdesc="A cross-platform 3D game engine (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -22,7 +22,6 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-pugixml"
              "${MINGW_PACKAGE_PREFIX}-qt6-base")
 depends=("${MINGW_PACKAGE_PREFIX}-boost"
-         "${MINGW_PACKAGE_PREFIX}-bullet"
          "${MINGW_PACKAGE_PREFIX}-freetype"
          "${MINGW_PACKAGE_PREFIX}-glsl-optimizer"
          "${MINGW_PACKAGE_PREFIX}-hlsl2glsl"


### PR DESCRIPTION
we don't have clangarm64 bullet yet

see https://github.com/msys2/MINGW-packages/commit/ff42b6fd948d71d52f3d9cc67947a27c8d4e226b#r81349409