### PR TITLE
ogre3d: Fix samples plugin not exporting symbols to be loaded by SampleBrowser

### DIFF
--- a/mingw-w64-ogre3d/015-export-symbols-samples-plugin.patch
+++ b/mingw-w64-ogre3d/015-export-symbols-samples-plugin.patch
@@ -1,0 +1,12 @@
+diff -bur ogre-13.4.4-c/Samples/Common/include/SamplePlugin.h ogre-13.4.4/Samples/Common/include/SamplePlugin.h
+--- ogre-13.4.4-c/Samples/Common/include/SamplePlugin.h	2022-08-06 14:44:00.000000000 -0600
++++ ogre-13.4.4/Samples/Common/include/SamplePlugin.h	2022-08-16 22:43:44.863604600 -0600
+@@ -35,7 +35,7 @@
+ #if defined( OGRE_STATIC_LIB )
+ #  define _OgreSampleExport
+ #else
+-#  if (OGRE_PLATFORM == OGRE_PLATFORM_WIN32 || OGRE_PLATFORM == OGRE_PLATFORM_WINRT) && !defined(__MINGW32__)
++#  if (OGRE_PLATFORM == OGRE_PLATFORM_WIN32 || OGRE_PLATFORM == OGRE_PLATFORM_WINRT)
+ #    define _OgreSampleExport __declspec(dllexport)
+ #  elif defined ( OGRE_GCC_VISIBILITY )
+ #   define _OgreSampleExport  __attribute__ ((visibility("default")))

--- a/mingw-w64-ogre3d/PKGBUILD
+++ b/mingw-w64-ogre3d/PKGBUILD
@@ -27,7 +27,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-boost"
          "${MINGW_PACKAGE_PREFIX}-glsl-optimizer"
          "${MINGW_PACKAGE_PREFIX}-hlsl2glsl"
          "${MINGW_PACKAGE_PREFIX}-SDL2"
-         "${MINGW_PACKAGE_PREFIX}-pugixml"
          "${MINGW_PACKAGE_PREFIX}-tinyxml"
          "${MINGW_PACKAGE_PREFIX}-winpthreads"
          "${MINGW_PACKAGE_PREFIX}-zlib")
@@ -35,7 +34,7 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-assimp"
             "${MINGW_PACKAGE_PREFIX}-freeimage"
             "${MINGW_PACKAGE_PREFIX}-openexr"
             "${MINGW_PACKAGE_PREFIX}-python: python bindings"
-            "${MINGW_PACKAGE_PREFIX}-pugixml"
+            "${MINGW_PACKAGE_PREFIX}-pugixml: XML converter"
             "${MINGW_PACKAGE_PREFIX}-qt6-base: integration with the Qt Library for window creation and input")
 options=('staticlibs' '!strip') # '!buildflags'
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/OGRECave/ogre/archive/v${pkgver}.tar.gz"

--- a/mingw-w64-ogre3d/PKGBUILD
+++ b/mingw-w64-ogre3d/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=13.4.4
 imgui_ver=1.87
-pkgrel=1
+pkgrel=2
 pkgdesc="A cross-platform 3D game engine (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -43,13 +43,15 @@ source=(${_realname}-${pkgver}.tar.gz::"https://github.com/OGRECave/ogre/archive
         002-link-shared-freeimage.patch
         004-use-mingw-w64-directx.patch
         010-missing-include.patch
-        014-install-pkhconfig-and-fix-plugin-extension.patch)
+        014-install-pkhconfig-and-fix-plugin-extension.patch
+        015-export-symbols-samples-plugin.patch)
 sha256sums=('7cf05dbb3acbfc9326daecb60429a8ae9ce7625fb425e6a29de00cf77454596f'
             'b54ceb35bda38766e36b87c25edf7a1cd8fd2cb8c485b245aedca6fb85645a20'
             '67966d6e0791c5804ed5cbec116594ebb72e9633118c31458dfa16181fdd01b2'
             'c7ca64dbd9a8f3f0271c12739807021a5c0782d254c4142c6e86746a96a44438'
             'd4e812fceb3dadc20c85857e3e624654cbc6bd4ebd20990fed2e5e84adfa9272'
-            '3794f51c0752492dd02f2b7fc150f210fe0b2b6ee8d8dc72740c009f258c55da')
+            '3794f51c0752492dd02f2b7fc150f210fe0b2b6ee8d8dc72740c009f258c55da'
+            '004842e88cbbc76d09356fbddf5bc123b1b0fc7b2e64b8677b2a2316df7d9099')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -66,7 +68,8 @@ prepare() {
     002-link-shared-freeimage.patch \
     004-use-mingw-w64-directx.patch \
     010-missing-include.patch \
-    014-install-pkhconfig-and-fix-plugin-extension.patch
+    014-install-pkhconfig-and-fix-plugin-extension.patch \
+    015-export-symbols-samples-plugin.patch
 }
 
 build() {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1100440/185039928-954f5809-ae64-4ad8-8dd1-3ac558211f37.png)
