### PR TITLE
qwt: Fix PkgConfig files with Qt6 and Don't generate debug files.

### DIFF
--- a/mingw-w64-qwt/001-release-build.patch
+++ b/mingw-w64-qwt/001-release-build.patch
@@ -5,7 +5,7 @@
      # Enable debug_and_release + build_all if you want to build both.
  
 -    CONFIG           += debug_and_release
-+    CONFIG           += release force_debug_info separate_debug_info
++    CONFIG           += release
      CONFIG           += build_all
  }
  else {

--- a/mingw-w64-qwt/004-pkgconfig-file.patch
+++ b/mingw-w64-qwt/004-pkgconfig-file.patch
@@ -9,13 +9,23 @@
  
      QWT_CONFIG     += QwtPkgConfig
  }
---- qwt-6.2.0/src/src.pro.bak	2021-07-27 05:55:14.566409800 +0100
-+++ qwt-6.2.0/src/src.pro	2021-07-27 05:47:25.643064600 +0100
-@@ -73,6 +73,7 @@
- 
-     QMAKE_PKGCONFIG_NAME = Qwt$${QWT_VER_MAJ}
-     QMAKE_PKGCONFIG_DESCRIPTION = Qt Widgets for Technical Applications
-+    QMAKE_PKGCONFIG_VERSION = $$QWT_VERSION
- 
-     QMAKE_PKGCONFIG_LIBDIR = $${QWT_INSTALL_LIBS}
-     QMAKE_PKGCONFIG_INCDIR = $${QWT_INSTALL_HEADERS}
+--- a/src/src.pro
++++ b/src/src.pro
+@@ -82,14 +82,14 @@
+     greaterThan(QT_MAJOR_VERSION, 4) {
+
+         QMAKE_PKGCONFIG_FILE = Qt$${QT_MAJOR_VERSION}$${QMAKE_PKGCONFIG_NAME}
+-        QMAKE_PKGCONFIG_REQUIRES = Qt5Widgets Qt5Concurrent Qt5PrintSupport
++        QMAKE_PKGCONFIG_REQUIRES = Qt$${QT_MAJOR_VERSION}Widgets Qt$${QT_MAJOR_VERSION}Concurrent Qt$${QT_MAJOR_VERSION}PrintSupport
+
+         contains(QWT_CONFIG, QwtSvg) {
+-            QMAKE_PKGCONFIG_REQUIRES += Qt5Svg
++            QMAKE_PKGCONFIG_REQUIRES += Qt$${QT_MAJOR_VERSION}Svg
+         }
+
+         contains(QWT_CONFIG, QwtOpenGL) {
+-            QMAKE_PKGCONFIG_REQUIRES += Qt5OpenGL
++            QMAKE_PKGCONFIG_REQUIRES += Qt$${QT_MAJOR_VERSION}OpenGL
+         }
+
+         QMAKE_DISTCLEAN += $${DESTDIR}/$${QMAKE_PKGCONFIG_DESTDIR}/$${QMAKE_PKGCONFIG_FILE}.pc

--- a/mingw-w64-qwt/PKGBUILD
+++ b/mingw-w64-qwt/PKGBUILD
@@ -22,13 +22,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-qt5-base"
              "${MINGW_PACKAGE_PREFIX}-cc")
 options=(!strip staticlibs !buildflags)
 source=("https://downloads.sourceforge.net/${_realname}/${_realname}-${pkgver}.tar.bz2"
-        001-separate-debug-info-build.patch
+        001-release-build.patch
         002-link-to-release.patch
         003-qwtconfig-msys2.patch
         004-pkgconfig-file.patch
         005-rename-qwt-to-remove-qt5-qt6-conflict.patch)
 sha256sums=('9194f6513955d0fd7300f67158175064460197abab1a92fa127a67a4b0b71530'
-            'ef39e5669cb6c0441cdb1fe20c3e51a706bfc3eb7f572a3c0a1dde362b0d40a4'
+            '582b8e203243676e92fbebf4e8d078f5adcbe077834976beff00cea53179c74d'
             '6e0101d2c2897c94da6284ba0b929a7a39d82120313e6cd6353fd5e3aaf4b059'
             '92c49c72bc4fc241157dd9662082b0d2bf35f7bdb7de2778632a82f498ee3871'
             'a1722f40222eb358a850f5a2554dfce4e9165c343b136ff60f19e1476ddf17a7'
@@ -94,10 +94,7 @@ package_qwt-qt5() {
     ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-qt5/COPYING
 
   mkdir -p ${pkgdir}${MINGW_PREFIX}/bin/
-  mv "${pkgdir}${MINGW_PREFIX}"/lib/*.{debug,dll} "${pkgdir}${MINGW_PREFIX}"/bin/
-
-  # install debug info
-  #install -Dm644 lib/*.debug -t "${pkgdir}${MINGW_PREFIX}"/bin/
+  mv "${pkgdir}${MINGW_PREFIX}"/lib/*.dll "${pkgdir}${MINGW_PREFIX}"/bin/
 
   local PREFIX_WIN=$(cygpath -am ${pkgdir}${MINGW_PREFIX})
   local PREFIX=$(cygpath -am ${MINGW_PREFIX})
@@ -123,10 +120,7 @@ package_qwt-qt6() {
     ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-qt6/COPYING
 
   mkdir -p ${pkgdir}${MINGW_PREFIX}/bin/
-  mv "${pkgdir}${MINGW_PREFIX}"/lib/*.{debug,dll} "${pkgdir}${MINGW_PREFIX}"/bin/
-
-  # install debug info
-  #install -Dm644 lib/*.debug -t "${pkgdir}${MINGW_PREFIX}"/bin/
+  mv "${pkgdir}${MINGW_PREFIX}"/lib/*.dll "${pkgdir}${MINGW_PREFIX}"/bin/
 
   local PREFIX_WIN=$(cygpath -am ${pkgdir}${MINGW_PREFIX})
   local PREFIX=$(cygpath -am ${MINGW_PREFIX})

--- a/mingw-w64-qwt/PKGBUILD
+++ b/mingw-w64-qwt/PKGBUILD
@@ -7,7 +7,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-qt5"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-qt6")
 pkgver=6.2.0
-pkgrel=5
+pkgrel=6
 pkgdesc="Qt Widgets for Technical Applications (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -31,24 +31,33 @@ sha256sums=('9194f6513955d0fd7300f67158175064460197abab1a92fa127a67a4b0b71530'
             'ef39e5669cb6c0441cdb1fe20c3e51a706bfc3eb7f572a3c0a1dde362b0d40a4'
             '6e0101d2c2897c94da6284ba0b929a7a39d82120313e6cd6353fd5e3aaf4b059'
             '92c49c72bc4fc241157dd9662082b0d2bf35f7bdb7de2778632a82f498ee3871'
-            '442570bf827731c83027451f76b23f4b3ffbf0266d02d507c573ca047b06fc18'
+            'a1722f40222eb358a850f5a2554dfce4e9165c343b136ff60f19e1476ddf17a7'
             '1c8628fb33e151b6aa33e10db76d81f740ea2a65e75c2bc7c6bd287e996bd77f')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying ${_patch}"
+    patch -Nbp1 -i "${srcdir}/${_patch}"
+  done
+}
 
 prepare() {
   cd ${_realname}-${pkgver}
 
-  patch -p1 -i ${srcdir}/001-separate-debug-info-build.patch
-  patch -p1 -i ${srcdir}/002-link-to-release.patch
-  patch -p1 -i ${srcdir}/003-qwtconfig-msys2.patch
-  patch -p1 -i ${srcdir}/004-pkgconfig-file.patch
-  patch -p1 -i ${srcdir}/005-rename-qwt-to-remove-qt5-qt6-conflict.patch
+  apply_patch_with_msg \
+    001-release-build.patch \
+    002-link-to-release.patch \
+    003-qwtconfig-msys2.patch \
+    004-pkgconfig-file.patch \
+    005-rename-qwt-to-remove-qt5-qt6-conflict.patch
 }
 
 build() {
   # qwt-qt5
   [[ -d ${srcdir}/build-${MSYSTEM}-qt5 ]] && rm -rf ${srcdir}/build-${MSYSTEM}-qt5
   cp -rf ${srcdir}/${_realname}-${pkgver} ${srcdir}/build-${MSYSTEM}-qt5
-
   cd ${srcdir}/build-${MSYSTEM}-qt5
 
   local PREFIX_WIN_QT5=$(cygpath -am ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qwt-qt5${MINGW_PREFIX})
@@ -60,7 +69,6 @@ build() {
   # qwt-qt6
   [[ -d ${srcdir}/build-${MSYSTEM}-qt6 ]] && rm -rf ${srcdir}/build-${MSYSTEM}-qt6
   cp -rf ${srcdir}/${_realname}-${pkgver} ${srcdir}/build-${MSYSTEM}-qt6
-
   cd ${srcdir}/build-${MSYSTEM}-qt6
 
   local PREFIX_WIN_QT6=$(cygpath -am ${pkgdirbase}/${MINGW_PACKAGE_PREFIX}-qwt-qt6${MINGW_PREFIX})


### PR DESCRIPTION
Issue reported in https://sourceforge.net/p/qwt/bugs/353
If someone wants debug files we could add two new split packages `qwt-qt5-debug` and `qwt-qt6-debug`