### PR TITLE
gegl: Support aarch64 build

### DIFF
--- a/mingw-w64-gegl/PKGBUILD
+++ b/mingw-w64-gegl/PKGBUILD
@@ -5,22 +5,22 @@ _realname=gegl
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.4.38
-pkgrel=1
+pkgrel=2
 pkgdesc="Generic Graphics Library (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://gegl.org/"
 license=('spdx:GPL-3.0-or-later' 'spdx:LGPL-3.0-or-later')
 makedepends=("${MINGW_PACKAGE_PREFIX}-asciidoc"
              "${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
              "${MINGW_PACKAGE_PREFIX}-gtk-doc"
-             "${MINGW_PACKAGE_PREFIX}-luajit"
+             $([[ ${MSYSTEM_CARCH} == aarch64 ]] || echo "${MINGW_PACKAGE_PREFIX}-luajit")
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
-             "${MINGW_PACKAGE_PREFIX}-ruby"
+             $([[ ${MSYSTEM_CARCH} == aarch64 ]] || echo "${MINGW_PACKAGE_PREFIX}-ruby")
              "${MINGW_PACKAGE_PREFIX}-vala"
              "${MINGW_PACKAGE_PREFIX}-meson"
-             "${MINGW_PACKAGE_PREFIX}-openmp")
+             $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-*86* ]] && echo "${MINGW_PACKAGE_PREFIX}-openmp"))
 depends=("${MINGW_PACKAGE_PREFIX}-babl"
          "${MINGW_PACKAGE_PREFIX}-cairo"
          "${MINGW_PACKAGE_PREFIX}-exiv2"
@@ -83,6 +83,7 @@ build() {
     -Dsdl1=disabled \
     -Dintrospection=true \
     -Ddocs=false \
+    $([[ ${MSYSTEM_CARCH} == aarch64 ]] && echo "-Dlua=disabled") \
     ../${_realname}-${pkgver}
 
   ${MINGW_PREFIX}/bin/meson.exe compile

--- a/mingw-w64-gegl/PKGBUILD
+++ b/mingw-w64-gegl/PKGBUILD
@@ -17,7 +17,6 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-asciidoc"
              "${MINGW_PACKAGE_PREFIX}-gtk-doc"
              $([[ ${MSYSTEM_CARCH} == aarch64 ]] || echo "${MINGW_PACKAGE_PREFIX}-luajit")
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
-             $([[ ${MSYSTEM_CARCH} == aarch64 ]] || echo "${MINGW_PACKAGE_PREFIX}-ruby")
              "${MINGW_PACKAGE_PREFIX}-vala"
              "${MINGW_PACKAGE_PREFIX}-meson"
              $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-*86* ]] && echo "${MINGW_PACKAGE_PREFIX}-openmp"))
@@ -47,8 +46,18 @@ depends=("${MINGW_PACKAGE_PREFIX}-babl"
          "${MINGW_PACKAGE_PREFIX}-suitesparse")
 #options=('!strip' 'debug')
 noextract=("${_realname}-${pkgver}.tar.xz")
-source=(https://download.gimp.org/pub/gegl/${pkgver%.*}/${_realname}-${pkgver}.tar.xz)
-sha256sums=('e4a33c8430a5042fba8439b595348e71870f0d95fbf885ff553f9020c1bed750')
+source=(https://download.gimp.org/pub/gegl/${pkgver%.*}/${_realname}-${pkgver}.tar.xz
+        001-openmp-openexr.patch::https://gitlab.gnome.org/GNOME/gegl/-/commit/d54fc3ccd37f9d769c9a55bd8ec065330e9654f5.diff)
+sha256sums=('e4a33c8430a5042fba8439b595348e71870f0d95fbf885ff553f9020c1bed750'
+            'd72a3c2e1b15a4cc0d6ef3f8d7ca9db7c7ed288000d3c1fc3cb8d6b4fe8a180b')
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying ${_patch}"
+    patch -Nbp1 -i "${srcdir}/${_patch}"
+  done
+}
 
 prepare() {
   tar -xf "${_realname}-${pkgver}.tar.xz" || true
@@ -62,6 +71,9 @@ prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   cp bin/lua/gegl_rectangle.lua bin/lua/gegl_crop.lua
   cp bin/lua/gegl_vector-stroke.lua bin/lua/gegl_fill-path.lua
+
+  apply_patch_with_msg \
+    001-openmp-openexr.patch
 }
 
 build() {
@@ -83,6 +95,7 @@ build() {
     -Dsdl1=disabled \
     -Dintrospection=true \
     -Ddocs=false \
+    $([[ ${MSYSTEM_CARCH} == aarch64 ]] && echo "-Dopenmp=disabled") \
     $([[ ${MSYSTEM_CARCH} == aarch64 ]] && echo "-Dlua=disabled") \
     ../${_realname}-${pkgver}
 


### PR DESCRIPTION
@Biswa96 @Alexpux I'm not sure if ruby and/or openmp are still deps (see https://www.gegl.org/build.html). I was able to build in aarch64 without either and just disabling the dep on lua. 
Should we remove dep on openmp and ruby?
There's not mention of openmp nor ruby on the meson configuration output, even in x64 builds:
```
gegl 0.4.38

  Directories
    prefix          : /clang64
    libdir          : lib

  GEGL docs
    Reference       : False
    Docs            : False

  Optional features
    Build workshop  : False
    Introspection   : True
    Vala support    : True

  Optional build utilities
    asciidoc        : True
    dot             : False
    pygobject       : False
    source-highlight: False
    w3m             : False

  Optional dependencies
    avlibs          : True
    Cairo           : True
    GDKPixbuf       : True
    gexiv2          : True
    Jasper          : True
    lcms            : True
    libnsgif        : True
    libraw          : True
    Luajit          : True
    maxflow         : True
    mrg             : False
    Pango           : True
    pangocairo      : True
    poly2tri-c      : True
    poppler         : True
    OpenEXR         : True
    rsvg            : True
    SDL1            : False
    SDL2            : True
    spiro           : True
    TIFF            : True
    umfpack         : True
    V4L             : False
    V4L2            : False
    webp            : True

  Subprojects
    libnsgif        : YES
    poly2tri-c      : YES

  User defined options
    auto_features   : enabled
    buildtype       : plain
    prefix          : /clang64
    docs            : false
    introspection   : true
    libv4l          : disabled
    libv4l2         : disabled
    mrg             : disabled
    pygobject       : disabled
    sdl1            : disabled
```