### PR TITLE
libpng: Fix building on CLANG environements

### DIFF
--- a/mingw-w64-libpng/PKGBUILD
+++ b/mingw-w64-libpng/PKGBUILD
@@ -31,9 +31,9 @@ prepare() {
 }
 
 build() {
-  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
-  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
+
   ../"${_realname}-${pkgver}"/configure \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
@@ -41,7 +41,9 @@ build() {
     --prefix=${MINGW_PREFIX} \
     --enable-shared --enable-static \
     as_ln_s="cp -pR"
+
   make
+
   msg2 "Build contributed programs"
   mkdir -p ".libs/contrib/pngminus" && cd ".libs/contrib/pngminus"
   cp -r "${srcdir}/${_realname}-${pkgver}/contrib/pngminus"/* .
@@ -51,8 +53,8 @@ build() {
 # we have to link to libpng16.dll.a or libpng16.a if building 
 # statically. When building the static programs, we might also
 # want to build with the static version of zlib.
-  make PNGINC="-I${srcdir}/${_realname}-${pkgver} -I${srcdir}/build-${MINGW_CHOST}" \
-    CC="${MINGW_PREFIX}/bin/gcc" \
+  make PNGINC="-I${srcdir}/${_realname}-${pkgver} -I${srcdir}/build-${MSYSTEM}" \
+    CC="${MINGW_PREFIX}/bin/cc" \
     PNGLIB_SHARED="-L../.. -lpng16" \
     PNGLIB_STATIC="../../libpng16.a" \
     ZLIB_STATIC="${MINGW_PREFIX}/lib/libz.a" \
@@ -62,13 +64,13 @@ build() {
 }
 
 check() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MSYSTEM}"
 
   make check
 }
 
 package () {
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MSYSTEM}"
   make install DESTDIR="${pkgdir}"
 
   install -D -m644 "${srcdir}/libpng-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"


### PR DESCRIPTION
Fixes #12688 
I haven't bump the `pkgrel` because I haven't added any patch, enable any feature or change any functionality.