### PR TITLE
python-numba: update to 0.56.0

### DIFF
--- a/mingw-w64-python-numba/PKGBUILD
+++ b/mingw-w64-python-numba/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=numba
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=0.55.2
-pkgrel=2
+pkgver=0.56.0
+pkgrel=1
 pkgdesc='NumPy aware dynamic Python compiler using LLVM (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -21,18 +21,18 @@ options=('!emptydirs')
 source=(numba-$pkgver.tar.gz::"https://github.com/numba/numba/archive/$pkgver.tar.gz"
         "omppool.patch"
         "setup.patch")
-sha256sums=('1b44f7c193e838eb14a16ab8423df7b60a5ddad5b250e779fd5ab1c7c42e9355'
+sha256sums=('58653ee67ecf198ae82ff1c30f4313d5c5ee931ddd8429badf11ed2b9c149110'
             '48c7004ccf353278d8c822e5482183e73bd7eb8b48235c48175213ae2232ee24'
-            'd60de705fb4a4517ab43e371f1da9b2b660387760a7db9b0526f2f5ab84d4693')
+            '967ed0d6d5012218322ce9389a5e5f7977ee459365d9b0e717c0cdb69abe0431')
 
 prepare() {
-  cd "$srcdir"
-  rm -rf python-build-${MSYSTEM} | true
-  pushd "${_realname}-${pkgver}"
+  cd "$srcdir/${_realname}-${pkgver}"
 	patch -p1 -i "${srcdir}/omppool.patch"
 	patch -p1 -i "${srcdir}/setup.patch"
 	sed -i "s,_MSC_VER,_WIN32," numba/np/ufunc/workqueue.c
-  popd
+
+  cd "${srcdir}"
+  rm -rf python-build-${MSYSTEM} | true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-numba/setup.patch
+++ b/mingw-w64-python-numba/setup.patch
@@ -1,6 +1,15 @@
---- a/setup.py.old	2020-08-12 13:00:24.000000000 -0700
-+++ a/setup.py	2020-08-13 14:43:57.723209700 -0700
-@@ -178,9 +178,9 @@
+--- a/setup.py
++++ a/setup.py
+@@ -23,7 +23,7 @@
+ max_python_version = "3.11"  # exclusive
+ min_numpy_build_version = "1.11"
+ min_numpy_run_version = "1.18"
+-max_numpy_run_version = "1.23"
++max_numpy_run_version = "1.24"
+ min_llvmlite_version = "0.39.0dev0"
+ max_llvmlite_version = "0.40"
+ 
+@@ -236,9 +236,9 @@
      # Set various flags for use in TBB and openmp. On OSX, also find OpenMP!
      have_openmp = True
      if sys.platform.startswith('win'):


### PR DESCRIPTION
numba 0.56.0 requires llvmlite>=0.39 which itself doesn't support any LLVM>11!