### PR TITLE
podman: include win-sshproxy

### DIFF
--- a/mingw-w64-podman/PKGBUILD
+++ b/mingw-w64-podman/PKGBUILD
@@ -4,7 +4,7 @@ _realname=podman
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=4.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Tool for running OCI-based containers in pods (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -38,6 +38,7 @@ build() {
 
     make podman-remote
     make docker-docs
+    make win-sshproxy
 }
 
 package() {
@@ -46,4 +47,6 @@ package() {
     make install.remote install.docker-full install.man install.completions DESTDIR="$pkgdir" PREFIX=${MINGW_PREFIX}
     rm -Rf "${pkgdir}${MINGW_PREFIX}/lib"
     sed -i "s|/usr/bin/||g" "${pkgdir}${MINGW_PREFIX}/bin/docker"
+
+    cp bin/windows/win-sshproxy.exe "${pkgdir}${MINGW_PREFIX}/bin"
 }


### PR DESCRIPTION
some commands require it an it needs to be built separately