### PR TITLE
gegl: Depend on libheif directly instead of transitively via vala,graphviz,libgd

### DIFF
--- a/mingw-w64-gegl/PKGBUILD
+++ b/mingw-w64-gegl/PKGBUILD
@@ -5,10 +5,10 @@ _realname=gegl
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.4.38
-pkgrel=2
+pkgrel=3
 pkgdesc="Generic Graphics Library (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://gegl.org/"
 license=('spdx:GPL-3.0-or-later' 'spdx:LGPL-3.0-or-later')
 makedepends=("${MINGW_PACKAGE_PREFIX}-asciidoc"
@@ -31,6 +31,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-babl"
          "${MINGW_PACKAGE_PREFIX}-glib2"
          "${MINGW_PACKAGE_PREFIX}-jasper"
          "${MINGW_PACKAGE_PREFIX}-json-glib"
+         "${MINGW_PACKAGE_PREFIX}-libheif"
          "${MINGW_PACKAGE_PREFIX}-libjpeg"
          "${MINGW_PACKAGE_PREFIX}-libpng"
          "${MINGW_PACKAGE_PREFIX}-libraw"


### PR DESCRIPTION
See discussion in [#12607 ](https://github.com/msys2/MINGW-packages/pull/12607#issuecomment-1221391113)