### PR TITLE
jasper: Fix pkgconfig file

### DIFF
--- a/mingw-w64-jasper/002-pkg-config-static.patch
+++ b/mingw-w64-jasper/002-pkg-config-static.patch
@@ -1,12 +1,20 @@
-diff -urN jasper-version-3.0.4/build/jasper.pc.in.orig jasper-version-3.0.4/build/jasper.pc.in
---- jasper-version-3.0.4/build/jasper.pc.in.orig	2022-06-03 06:10:20.000000000 +0200
-+++ jasper-version-3.0.4/build/jasper.pc.in	2022-06-10 21:14:16.617225600 +0200
-@@ -5,5 +5,8 @@
+--- a/build/jasper.pc.in
++++ b/build/jasper.pc.in
+@@ -1,9 +1,15 @@
+-libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+-includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
++prefix=@CMAKE_INSTALL_PREFIX@
++exec_prefix=${prefix}
++libdir=${exec_prefix}/lib
++includedir=${prefix}/include
+ 
+ Name: JasPer
  Description: Image Processing/Coding Tool Kit with JPEG-2000 Support
  Version: @JAS_VERSION@
  
-+Requires.private: libheif libjpeg
++# Add libheif if it is present in dependencies
++Requires.private: libjpeg
  Libs: -L${libdir} -ljasper
-+Libs.private: -lpthread -lgcc_s
++Libs.private: -lpthread
  Cflags: -I${includedir}/jasper -I${includedir}
 +Cflags.private: -DLIBJASPER_STATIC_DEFINE

--- a/mingw-w64-jasper/PKGBUILD
+++ b/mingw-w64-jasper/PKGBUILD
@@ -4,7 +4,7 @@ _realname=jasper
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=3.0.6
-pkgrel=1
+pkgrel=2
 pkgdesc="Reference implementation of JPEG-2000 Part-1 codec (ISO/IEC 15444-5) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -27,7 +27,7 @@ source=(${_realname}-${pkgver}.tar.gz::https://github.com/mdadams/jasper/archive
 sha256sums=('c79961bc00158f5b5dc5f5fcfa792fde9bebb024432689d0f9e3f95a097d0ec3'
             'f51377e9b3e4faaa6b17b2d5fcf6f6d94fe2916a65dc9c78b5a99b891f5726dc'
             '89f7653884c93e1cb32271c59213551d1231674bd12df00331c302971d5ac489'
-            'be74cfb8b18d764616317f210c95f0f3a42972e9fc4350cfa6a04f3c3c660096'
+            'e8469188f53af7e9b5077ef7b0d77fde2c73d4d37d80cd1764857fced2f57bd5'
             'aef39fbaf65c0453a785eb563253f2bb66806ddbebcd836b8bd8dce67c7059eb')
 
 apply_patch_with_msg() {


### PR DESCRIPTION
* Remove libheif from Requires.private field because it is not present as a dependency.
* Add prefix field to fix path relocation.
* Remove gcc_s from Libs.private because it is for gcc only.