### PR TITLE
libbotan: Update to 2.19.2

### DIFF
--- a/mingw-w64-libbotan/PKGBUILD
+++ b/mingw-w64-libbotan/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libbotan
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.18.2
+pkgver=2.19.2
 pkgrel=4
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -29,7 +29,7 @@ source=("https://botan.randombit.net/releases/Botan-${pkgver}.tar.xz"{,.asc}
         '002-winsock-link.patch'
         '003-enable-shared.patch')
 noextract=("Botan-${pkgver}.tar.xz")
-sha256sums=('541a3b13f1b9d30f977c6c1ae4c7bfdfda763cda6e44de807369dce79f42307e'
+sha256sums=('3af5f17615c6b5cd8b832d269fb6cb4d54ec64f9eb09ddbf1add5093941b4d75'
             'SKIP'
             'c4dfd71c7e6a9592e2a95634e3fabfc071c1110a96ba218c4a3565fa14cb34da'
             '12f676d9c8f66decd7dc52a6a70f0c044737636837c79ae02f96d8d5a2168c46'


### PR DESCRIPTION
I just updated botan from 2.18.2 to 2.19.2 which was released on 2022-06-03