### PR TITLE
clang: Fix emulated TLS for libstdc++ envs

### DIFF
--- a/mingw-w64-clang/0102-fix-emulated-tls.patch
+++ b/mingw-w64-clang/0102-fix-emulated-tls.patch
@@ -1,0 +1,30 @@
+diff --git a/clang/lib/CodeGen/CodeGenModule.cpp b/clang/lib/CodeGen/CodeGenModule.cpp
+index 74c14fed6575..44ffd22b921f 100644
+--- a/lib/CodeGen/CodeGenModule.cpp
++++ b/lib/CodeGen/CodeGenModule.cpp
+@@ -1143,7 +1143,7 @@ static bool shouldAssumeDSOLocal(const CodeGenModule &CGM,
+     // such variables can't be marked as DSO local. (Native TLS variables
+     // can't be dllimported at all, though.)
+     if (GV->isDeclarationForLinker() && isa<llvm::GlobalVariable>(GV) &&
+-        (!GV->isThreadLocal() || CGM.getCodeGenOpts().EmulatedTLS))
++        (!GV->isThreadLocal() || CGM.useEmulatedTLS()))
+       return false;
+   }
+ 
+diff --git a/clang/lib/CodeGen/CodeGenModule.h b/clang/lib/CodeGen/CodeGenModule.h
+index f57afdca4942..b10c392dc1bb 100644
+--- a/lib/CodeGen/CodeGenModule.h
++++ b/lib/CodeGen/CodeGenModule.h
+@@ -746,6 +746,12 @@ public:
+ 
+   const TargetCodeGenInfo &getTargetCodeGenInfo();
+ 
++  bool useEmulatedTLS() const {
++    if (CodeGenOpts.ExplicitEmulatedTLS)
++      return CodeGenOpts.EmulatedTLS;
++    return getTriple().hasDefaultEmulatedTLS();
++  }
++
+   CodeGenTypes &getTypes() { return Types; }
+ 
+   CodeGenVTables &getVTables() { return VTables; }

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -23,7 +23,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-lld"
          "${MINGW_PACKAGE_PREFIX}-llvm")
 pkgver=14.0.6
-pkgrel=4
+pkgrel=5
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -64,6 +64,7 @@ source=("${_url}/llvm-${pkgver}.src.tar.xz"{,.sig}
         "0008-COFF-Emit-embedded-exclude-symbols-directives-for-hi.patch"
         "0009-Use-hidden-visibility-when-building-for-MinGW-with-Clang.patch"
         "0101-link-pthread-with-mingw.patch"
+        "0102-fix-emulated-tls.patch"
         "0301-LLD-COFF-Add-support-for-a-new-mingw-specific-embedd.patch"
         "0302-LLD-MinGW-Implement-the-exclude-symbols-option.patch"
         "0303-ignore-new-bfd-options.patch"
@@ -96,6 +97,7 @@ sha256sums=('050922ecaaca5781fdf6631ea92bc715183f202f9d2f15147226f023414f619a'
             '5bb5e31eea8ea2c4eea56f2aae161dfde35caa9800459ae3c785a94654628e57'
             'f3bce25ac7d339cbe7a94bd1cfd2d634450c261c7a32103aba4ed5f773fd2cfc'
             '715cb8862753854b2d9256e0b70003e2d1f57083d83eaeaf5a095fc72b8a4e26'
+            '3a58bd5243fb082df64c90bd9a4f00c698317f20365d11bbe30fac5dfccd215e'
             'e6c3b97f733920b0a32e889cd180dd86507bddea09e9c217cd1445c047cd4976'
             'bd40b6c84d25de5ac5877f2c83ac61d872838bc034df62e98ad16116d23744e0'
             '778e0db0a5b0657ab05e2a81d83241347a4a41af2b0f9903422f651fa58e8d40'
@@ -156,6 +158,10 @@ prepare() {
     apply_patch_with_msg \
       "0101-link-pthread-with-mingw.patch"
   fi
+
+  # https://github.com/msys2/MINGW-packages/pull/12550#issuecomment-1228506687
+  apply_patch_with_msg \
+    "0102-fix-emulated-tls.patch"
 
   # Patch lld
   cd "${srcdir}/lld"


### PR DESCRIPTION
See https://github.com/msys2/MINGW-packages/pull/12550#issuecomment-1228506687
and https://github.com/msys2/msys2-tests/pull/9