### PR TITLE
Vala: fix backslash disaster

### DIFF
--- a/mingw-w64-vala/0010-fix-backslash-disaster.patch
+++ b/mingw-w64-vala/0010-fix-backslash-disaster.patch
@@ -1,0 +1,13 @@
+diff --git a/ccode/valaccodelinedirective.vala b/ccode/valaccodelinedirective.vala
+index c5e61114b..31cc3ab7e 100644
+--- a/ccode/valaccodelinedirective.vala
++++ b/ccode/valaccodelinedirective.vala
+@@ -37,7 +37,7 @@ public class Vala.CCodeLineDirective : CCodeNode {
+ 	public int line_number { get; set; }
+ 
+ 	public CCodeLineDirective (string _filename, int _line) {
+-		filename = _filename;
++		filename = _filename.replace ("\\", "\\\\");
+ 		line_number = _line;
+ 	}
+ 

--- a/mingw-w64-vala/PKGBUILD
+++ b/mingw-w64-vala/PKGBUILD
@@ -23,7 +23,7 @@ source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname
         0010-fix-backslash-disaster.patch)
 sha256sums=('66c9619bb17859fd1ac3aba0a57970613e38fd2a1ee30541174260c9fb90124c'
             '266756afe0fa2871800e2d4cbf5db5c9e9e68abd52f7f694f077c7e425bc2772'
-            'b85b93415510eb6cadb8005fb7b6be6ce6c4041fcb7b735d0999682e9ea63e86')
+            '93c97ea5416b58a870c11649a378caddb5343b6305fe0740ebe899c78aa08b34')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}

--- a/mingw-w64-vala/PKGBUILD
+++ b/mingw-w64-vala/PKGBUILD
@@ -4,7 +4,7 @@ _realname=vala
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.56.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Compiler for the GObject type system (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -19,15 +19,20 @@ depends=("${MINGW_PACKAGE_PREFIX}-glib2"
           $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || \
             echo "${MINGW_PACKAGE_PREFIX}-graphviz")) # Remove this workaround afer graphviz available
 source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz
-        0001-relocate-plugin-path.patch)
+        0001-relocate-plugin-path.patch
+        0010-fix-backslash-disaster.patch)
 sha256sums=('66c9619bb17859fd1ac3aba0a57970613e38fd2a1ee30541174260c9fb90124c'
-            '266756afe0fa2871800e2d4cbf5db5c9e9e68abd52f7f694f077c7e425bc2772')
+            '266756afe0fa2871800e2d4cbf5db5c9e9e68abd52f7f694f077c7e425bc2772'
+            'b85b93415510eb6cadb8005fb7b6be6ce6c4041fcb7b735d0999682e9ea63e86')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
 
   # https://gitlab.gnome.org/GNOME/vala/-/issues/1302
   patch -p1 -i "${srcdir}/0001-relocate-plugin-path.patch"
+
+  # https://gitlab.gnome.org/GNOME/vala/-/issues/1353
+  patch -p1 -i "${srcdir}/0010-fix-backslash-disaster.patch"
 
   autoreconf -ivf
 }


### PR DESCRIPTION
Temporarily fix the backslash disaster until vala merges the patch and releases the next version.

See also:
[related issue](https://gitlab.gnome.org/GNOME/vala/-/issues/1353)
[related PR](https://gitlab.gnome.org/GNOME/vala/-/merge_requests/254)