### PR TITLE
opencv: temporarily drop vtk support on aarch64

### DIFF
--- a/mingw-w64-opencv/PKGBUILD
+++ b/mingw-w64-opencv/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=4.6.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Open Source Computer Vision Library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -44,11 +44,11 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-pylint"
              "${MINGW_PACKAGE_PREFIX}-qt5-base"
              "${MINGW_PACKAGE_PREFIX}-tiny-dnn"
-             "${MINGW_PACKAGE_PREFIX}-vtk"
+             $([[ "${MSYSTEM}" == "CLANGARM64" ]] || echo "${MINGW_PACKAGE_PREFIX}-vtk")
              "${MINGW_PACKAGE_PREFIX}-eigen3"
             )
 optdepends=("${MINGW_PACKAGE_PREFIX}-qt5-base: for the HighGUI module"
-            "${MINGW_PACKAGE_PREFIX}-vtk: opencv_viz module"
+            "$([[ "${MSYSTEM}" == "CLANGARM64" ]] || echo "${MINGW_PACKAGE_PREFIX}-vtk: opencv_viz module")"
             )
 source=("${_realname}-${pkgver}.tar.gz"::https://github.com/opencv/opencv/archive/${pkgver}.tar.gz
         "${_realname}_contrib-${pkgver}.tar.gz"::https://github.com/opencv/opencv_contrib/archive/${pkgver}.tar.gz
@@ -155,6 +155,10 @@ build() {
     extra_config+=("-DCPU_DISPATCH=SSE4_1;SSE4_2;AVX;FP16;AVX2")
   fi
 
+  if [ ${MSYSTEM} != "CLANGARM64" ]; then
+    extra_config+=("-DWITH_VTK=ON" "-DOPENCV_FORCE_VTK=ON")
+  fi
+
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DPYTHON2_PACKAGES_PATH=;-DPYTHON3_PACKAGES_PATH=" \
   ${MINGW_PREFIX}/bin/cmake.exe -Wno-dev \
     -G"Ninja" \
@@ -179,7 +183,6 @@ build() {
     -DWITH_OPENGL=ON \
     -DWITH_OPENJPEG=ON \
     -DWITH_QT=ON \
-    -DWITH_VTK=ON \
     -DWITH_GDAL=OFF \
     -DWITH_GSTREAMER=OFF \
     -DWITH_GTK=OFF \
@@ -194,7 +197,6 @@ build() {
     -DOPENCV_SKIP_CMAKE_ROOT_CONFIG=ON \
     -DOPENCV_FFMPEG_USE_FIND_PACKAGE=ON \
     -DOPENCV_FFMPEG_SKIP_DOWNLOAD=ON \
-    -DOPENCV_FORCE_VTK=ON \
     -DPYTHON_DEFAULT_EXECUTABLE=${MINGW_PREFIX}/bin/python \
     -DPYTHON3_EXECUTABLE=${MINGW_PREFIX}/bin/python \
     -DPYTHON3_PACKAGES_PATH=$(cygpath -u $(${MINGW_PREFIX}/bin/python -c "import sysconfig; print(sysconfig.get_path('purelib'))")) \


### PR DESCRIPTION
vtk gained lots of new deps which aren't built yet there,
so let's disable it for now.