### PR TITLE
gh: update to v2.14.7

### DIFF
--- a/mingw-w64-github-cli/PKGBUILD
+++ b/mingw-w64-github-cli/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=github-cli
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.14.6
+pkgver=2.14.7
 pkgrel=1
 pkgdesc='The GitHub CLI (mingw-w64)'
 arch=('any')
@@ -16,7 +16,7 @@ optdepends=("git: To interact with repositories")
 options=('!strip')
 source=("$_realname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz"
         "gh")
-sha256sums=('60b0697b9b1db52adabaa804967a6b63f9ffbc634c00940d08861101bc1d5610'
+sha256sums=('a1a048714d7c7b237ea05f1fb51b3f3f4cdf90a16c60fa46f1df2eb5d96ce28d'
             '9ee5f2b44b7e9aa751508f02c1020e341e0212a9aa146b7428eb5ffea310be27')
 build() {
     cd "cli-$pkgver"


### PR DESCRIPTION
See https://github.com/cli/cli/releases/tag/v2.14.7 for details.