### PR TITLE
vulkan-loader: Workaround dll name by copying to vulkan-1.dll

### DIFF
--- a/mingw-w64-vulkan-loader/PKGBUILD
+++ b/mingw-w64-vulkan-loader/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-vulkan-loader")
 provides=("${MINGW_PACKAGE_PREFIX}-vulkan")
 replaces=("${MINGW_PACKAGE_PREFIX}-vulkan")
 pkgver=1.3.225
-pkgrel=1
+pkgrel=2
 pkgdesc='Vulkan Installable Client Driver (ICD) Loader (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -79,6 +79,9 @@ build() {
 package() {
   cd ${srcdir}/build-${MSYSTEM}
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install .
+
+  # Workaround: Some programs loads the DLL dynamically with hardcoded vulkan-1.dll name (#2673)
+  cp -v ${pkgdir}${MINGW_PREFIX}/bin/libvulkan-1.dll ${pkgdir}${MINGW_PREFIX}/bin/vulkan-1.dll
 
   install -Dm644 ${srcdir}/${_realname}-${pkgver}/LICENSE.TXT ${pkgdir}${MINGW_PREFIX}/share/licenses/vulkan-loader/LICENSE
 }


### PR DESCRIPTION
Fixes https://github.com/msys2/MINGW-packages/issues/2673