### PR TITLE
WIP: boost: fix build on msys64/mingw32

### DIFF
--- a/mingw-w64-boost/PKGBUILD
+++ b/mingw-w64-boost/PKGBUILD
@@ -8,7 +8,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.80.0
 _boostver=${pkgver//./_}
-pkgrel=1
+pkgrel=2
 pkgdesc="Free peer-reviewed portable C++ source libraries (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -91,7 +91,7 @@ prepare() {
 }
 
 setb2args() {
-    case ${CARCH} in
+    case ${MSYSTEM_CARCH} in
     i686|armv7)
       local _model=32
       ;;
@@ -137,7 +137,7 @@ setb2args() {
     -sZLIB_LIBPATH=${MINGW_PREFIX}/lib \
     -d2 \
     -q"
-    if [[ "${CARCH}" == "aarch64" ]]; then
+    if [[ "${MSYSTEM_CARCH}" == "aarch64" ]]; then
       # boost context does not yet have an implementation for Windows ARM64
       # coroutine and fiber depend on context
       b2args+=" --without-context --without-coroutine --without-fiber"


### PR DESCRIPTION
Incomplete, since CFLAGS and CXXFLAGS still have -march=x86_64