### PR TITLE
darktable: Fix building with the latest updates

### DIFF
--- a/mingw-w64-darktable/003-disable-gamepad.patch
+++ b/mingw-w64-darktable/003-disable-gamepad.patch
@@ -1,0 +1,20 @@
+--- a/src/libs/CMakeLists.txt
++++ b/src/libs/CMakeLists.txt
+@@ -97,7 +97,7 @@
+   add_library(midi MODULE "tools/midi.c")
+   target_link_libraries (midi ${PORTMIDI_LIBRARY})
+ endif()
+-
++#[[
+ find_package(SDL2)
+ if(SDL2_INCLUDE_DIRS)
+  add_definitions("-DHAVE_SDL")
+@@ -106,7 +106,7 @@
+   add_library(gamepad MODULE "tools/gamepad.c")
+   target_link_libraries(gamepad ${SDL2_LIBRARIES})
+ endif()
+-
++]]
+ if(BUILD_BATTERY_INDICATOR)
+   add_library(battery_indicator MODULE "tools/battery_indicator.c")
+ endif()

--- a/mingw-w64-darktable/PKGBUILD
+++ b/mingw-w64-darktable/PKGBUILD
@@ -4,7 +4,7 @@ _realname=darktable
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=4.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="darktable is an open source photography workflow application and raw developer (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -46,11 +46,13 @@ depends=("${MINGW_PACKAGE_PREFIX}-dbus-glib"
 options=('!strip')
 source=("https://github.com/darktable-org/${_realname}/releases/download/release-${pkgver}/${_realname}-${pkgver}.tar.xz"{,.asc}
         "001-define-libraw-win32-unicodepaths-libcxx.patch"
-        "002-aarch64-mingw.patch")
+        "002-aarch64-mingw.patch"
+        "003-disable-gamepad.patch")
 sha256sums=('1416f8f59717e65a6220541aaa12eacca93888ce5176f2c9ab6c17b9cc53cc2d'
             'SKIP'
             'd586d8f56546eba5e70a4ac0ed99e43ce3d82685c48e77e9f40d0563965133e8'
-            'f350ecb20cab030180e5809f9fc7a0296a245f3461cf04f746c9bcbd87d12f86')
+            'f350ecb20cab030180e5809f9fc7a0296a245f3461cf04f746c9bcbd87d12f86'
+            '85f648d9d3c9bf39f17862cc120676456ee0a32c2c17f11c083057179647534a')
 validpgpkeys=('F10F9686652B0E949FCD94C318DCA123F949BD3B') # Pascal Obry <pascal@obry.net>
 
 apply_patch_with_msg() {
@@ -65,7 +67,8 @@ prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
   apply_patch_with_msg \
     001-define-libraw-win32-unicodepaths-libcxx.patch \
-    002-aarch64-mingw.patch
+    002-aarch64-mingw.patch \
+    003-disable-gamepad.patch
 }
 
 build() {


### PR DESCRIPTION
Disable gamepad for now.
Fixes #12874 