### PR TITLE
glib2: disable explicit `-mms-bitfields` in pkgconfig cflags

### DIFF
--- a/mingw-w64-glib2/0004-disable-explicit-ms-bitfields.patch
+++ b/mingw-w64-glib2/0004-disable-explicit-ms-bitfields.patch
@@ -1,0 +1,15 @@
+--- a/meson.build
++++ b/meson.build
+@@ -2316,12 +2316,6 @@
+ win32_cflags = []
+ win32_ldflags = []
+ if host_system == 'windows' and cc.get_id() != 'msvc' and cc.get_id() != 'clang-cl'
+-  # Ensure MSVC-compatible struct packing convention is used when
+-  # compiling for Win32 with gcc. It is used for the whole project and exposed
+-  # in glib-2.0.pc.
+-  win32_cflags = ['-mms-bitfields']
+-  add_project_arguments(win32_cflags, language : 'c')
+-
+   # Win32 API libs, used only by libglib and exposed in glib-2.0.pc
+   win32_ldflags = ['-lws2_32', '-lole32', '-lwinmm', '-lshlwapi', '-luuid']
+ elif host_system == 'cygwin'

--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -7,7 +7,7 @@ _realname=glib2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.72.3
-pkgrel=2
+pkgrel=3
 url="https://gitlab.gnome.org/GNOME/glib"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -29,6 +29,7 @@ source=("https://download.gnome.org/sources/glib/${pkgver%.*}/glib-${pkgver}.tar
         0001-Update-g_fopen-g_open-and-g_creat-to-open-with-FILE_.patch
         0002-disable_glib_compile_schemas_warning.patch
         0003-gtestutils-include-stdlib.patch
+        0004-disable-explicit-ms-bitfields.patch
         glib-compile-schemas.hook.in
         gio-querymodules.hook.in
         pyscript2exe.py)
@@ -36,6 +37,7 @@ sha256sums=('4a39a2f624b8512d500d5840173eda7fa85f51c109052eae806acece85d345f0'
             '51d02360a1ee978fd45e77b84bca9cfbcf080d91986b5c0efe0732779c6a54ec'
             '396c25cfd740ffbb72209133c7b9453173167577265a4bb14502678de8d5a8f9'
             '3c91273acd9c836adbc3fd7d175368d6c484984305979c1c9254140d949b8bb7'
+            '3d2585f460f797c67f9e5149d3b3d52ff2481c48fd7cb791a03f5f0e68304d39'
             '0c3d54636407e0e13429b73959cace626253cd772e1d4870de0fb92b0b99545a'
             'f18d27d98709dba8c5f9756672baaf0158fb4353c9edbdc2e80021f88ff34ced'
             'e57174517b08cf8f9fb4f43a381d342d23d2db3cad661107f35ca21c39b5734d')
@@ -57,6 +59,8 @@ prepare() {
 
   # https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2613
   apply_patch_with_msg 0003-gtestutils-include-stdlib.patch
+
+  apply_patch_with_msg 0004-disable-explicit-ms-bitfields.patch
 }
 
 build() {


### PR DESCRIPTION
As noted here: https://github.com/msys2/MINGW-packages/pull/12776#issuecomment-1231211803
It seems this flag is not needed as it has been the default for many versions now. As such the patch in Transmission can be rendered unnecessary.