### PR TITLE
unixodbc: get locale charset

### DIFF
--- a/mingw-w64-unixodbc/PKGBUILD
+++ b/mingw-w64-unixodbc/PKGBUILD
@@ -4,7 +4,7 @@ _realname=unixodbc
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.3.11
-pkgrel=2
+pkgrel=3
 pkgdesc="ODBC is an open specification for providing application developers with a predictable API with which to access Data Sources (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -14,14 +14,29 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libltdl"
          "${MINGW_PACKAGE_PREFIX}-libiconv"
          "${MINGW_PACKAGE_PREFIX}-libwinpthread-git")
-makedepends=("${MINGW_PACKAGE_PREFIX}-cc" "${MINGW_PACKAGE_PREFIX}-autotools")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-autotools")
 conflicts=("${MINGW_PACKAGE_PREFIX}-firebird2-git")
-license=('GPL2' 'LGPL2.1')
-source=("http://www.unixodbc.org/unixODBC-${pkgver}.tar.gz")
-sha256sums=('d9e55c8e7118347e3c66c87338856dad1516b490fb7c756c1562a2c267c73b5c')
+license=('spdx:LGPL-2.1-or-later AND GPL-2.0')
+source=("http://www.unixodbc.org/unixODBC-${pkgver}.tar.gz"
+        "0001-get-locale-encoding.patch::https://github.com/lurcher/unixODBC/commit/ef51bd570ff58a04e3d21081ce3ee8ad8facf0ef.patch")
+sha256sums=('d9e55c8e7118347e3c66c87338856dad1516b490fb7c756c1562a2c267c73b5c'
+            '41d4b5a753f552b9ec9d783265c9ab3f0a17771a5563ddeb1ee701972f237363')
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying ${_patch}"
+    patch -Nbp1 -i "${srcdir}/${_patch}"
+  done
+}
 
 prepare() {
   cd "${srcdir}/unixODBC-${pkgver}"
+
+  apply_patch_with_msg \
+    0001-get-locale-encoding.patch
+
   # autoreconf to get updated libtool files with clang support
   autoreconf -fiv
 }
@@ -37,7 +52,6 @@ build() {
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \
     --enable-iconv=yes \
-    --with-iconv-char-enc=GB18030 \
     --enable-static \
     --enable-shared
 


### PR DESCRIPTION
Query the locale charset (also on Windows) instead of hardcoding the used encoding to GB18030 (see #12892).

The patch is heavily "inspired" by the localcharset module of gnulib.

Edit: For a motivation for these changes, please see the comments here: https://github.com/msys2/MINGW-packages/pull/12892#discussion_r961312024
