### PR TITLE
opencv: python bindings depends on qt5-base and vtk

### DIFF
--- a/mingw-w64-opencv/PKGBUILD
+++ b/mingw-w64-opencv/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=4.6.0
-pkgrel=3
+pkgrel=4
 pkgdesc="Open Source Computer Vision Library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -225,7 +225,9 @@ package_opencv() {
 package_python-opencv() {
   pkgdesc='Python bindings for OpenCV (mingw-w64)'
   depends=("${MINGW_PACKAGE_PREFIX}-opencv"
-           "${MINGW_PACKAGE_PREFIX}-python-numpy")
+           "${MINGW_PACKAGE_PREFIX}-python-numpy"
+           "${MINGW_PACKAGE_PREFIX}-qt5-base"
+           $([[ "${MSYSTEM}" == "CLANGARM64" ]] || echo "${MINGW_PACKAGE_PREFIX}-vtk")
   unset optdepends
 
   cd "${srcdir}/build-${MSYSTEM}"


### PR DESCRIPTION
In a cleaner msys2 installation, with `mingw-w64-x86_64-python-opencv 4.6.0-3` installed.
Run:
`python -c "import cv2"`
I get:
ImportError: DLL load failed while importing cv2: N▒o foi poss▒vel encontrar o m▒dulo especificado

After installing qt-base and vtk it works!