### PR TITLE
openblas: limit scope of `no-tree-vectorize` optimization

### DIFF
--- a/mingw-w64-openblas/PKGBUILD
+++ b/mingw-w64-openblas/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-openblas
 pkgname=("${MINGW_PACKAGE_PREFIX}-openblas"
          $([[ "${CARCH}" == "i686" ]] || echo "${MINGW_PACKAGE_PREFIX}-openblas64"))
 pkgver=0.3.21
-pkgrel=2
+pkgrel=3
 pkgdesc="An optimized BLAS library based on GotoBLAS2 1.13 BSD, providing optimized blas, lapack, and cblas (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -27,11 +27,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "dos2unix")
 options=('!buildflags')
 source=(https://github.com/xianyi/OpenBLAS/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz
+        001-gcc-no-tree-vectorize.patch::https://github.com/xianyi/OpenBLAS/commit/739c3c44a77d87d1b08de59bf868250683c0f755.patch
         002-lgfortran-requires-lquadmath.patch
         004-aarch64-detection.patch
         005-fix-pkgconfig-files.patch)
 install=${_realname}.install
 sha256sums=('f36ba3d7a60e7c8bcc54cd9aaa9b1223dd42eaf02c811791c37e8ca707c241ca'
+            'fb27a983cdaf0e46442bc8b39d4afab4fb6bd61526331841a233a1e588d80e0f'
             'fecd847d029f5fa0d48c685e48e1d5efd413ead14452349fe78a66717fbce3e7'
             '70ce007ff4f6c2a127f9835ce9cd85081707cf3bcccddcfaa06817b06f69c941'
             '692131a2784ba8a1855e578fde4799d7bf990b43a620383ded12ed80d47c4a81')
@@ -49,6 +51,7 @@ prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
 
   apply_patch_with_msg \
+    001-gcc-no-tree-vectorize.patch \
     002-lgfortran-requires-lquadmath.patch \
     004-aarch64-detection.patch \
     005-fix-pkgconfig-files.patch
@@ -58,23 +61,8 @@ _build_openblas() {
   _idx_opt=$1
 
   declare -a _build_type
-  declare -a _optimization_opts
   if check_option "debug" "n"; then
-    # See: https://wiki.archlinux.org/title/CMake_package_guidelines#CMake_can_automatically_override_the_default_compiler_optimization_flag
-    _build_type+=("None")
-    if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
-      _optimization_opts=("-DCOMMON_OPT=-O2"
-                          "-DCCOMMON_OPT=-O2"
-                          "-DFCOMMON_OPT=-O2")
-    else
-      # GCC 12 enables `-ftree-vectorize` at optimization level `-O2`.
-      # Library built with that optimization might segfault for some functions.
-      # See https://github.com/msys2/MINGW-packages/issues/12857 and
-      # also see https://github.com/xianyi/OpenBLAS/issues/3740
-      _optimization_opts=("-DCOMMON_OPT=-O2 -fno-tree-vectorize"
-                          "-DCCOMMON_OPT=-O2 -fno-tree-vectorize"
-                          "-DFCOMMON_OPT=-O2 -fno-tree-vectorize")
-    fi
+    _build_type+=("Release")
   else
     _build_type+=("Debug")
   fi
@@ -109,7 +97,6 @@ _build_openblas() {
     -DTARGET=${target} \
     ${_c_lapack_opt} \
     ${_idx_opt} \
-    "${_optimization_opts[@]}" \
     ../${_realname}-${pkgver}
 
   ${MINGW_PREFIX}/bin/cmake --build .


### PR DESCRIPTION
Use patch from upstream to limit the scope of `no-tree-vectorize` optimization to only the files that seem to be affected by the optimization issue in gcc-12 reported in #12857.
