### PR TITLE
ninja: use $TERM to decide when to use fancy output, take 2

### DIFF
--- a/mingw-w64-ninja/PKGBUILD
+++ b/mingw-w64-ninja/PKGBUILD
@@ -4,7 +4,7 @@ _realname=ninja
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.11.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Ninja is a small build system with a focus on speed (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -14,7 +14,16 @@ depends=()
 options=('strip' 'staticlibs')
 makedepends=("re2c" "${MINGW_PACKAGE_PREFIX}-python" "${MINGW_PACKAGE_PREFIX}-cc")
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/ninja-build/ninja/archive/v${pkgver}.tar.gz")
-sha256sums=('31747ae633213f1eda3842686f83c2aa1412e0f5691d1c14dbbcc67fe7400cea')
+source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/ninja-build/ninja/archive/v${pkgver}.tar.gz"
+        "obey-term-envvar.patch")
+sha256sums=('31747ae633213f1eda3842686f83c2aa1412e0f5691d1c14dbbcc67fe7400cea'
+            '0d13b9378d981a2ffe52f7f640dda9e0f7804d767738711c9e42cbae45d91918')
+
+prepare() {
+  cd ${srcdir}/ninja-${pkgver}
+  # Submitted upstream: https://github.com/ninja-build/ninja/pull/2190
+  patch -p1 -i $srcdir/obey-term-envvar.patch
+}
 
 build() {
   mkdir -p "${pkgdir}${MINGW_PREFIX}"/bin

--- a/mingw-w64-ninja/obey-term-envvar.patch
+++ b/mingw-w64-ninja/obey-term-envvar.patch
@@ -1,0 +1,56 @@
+From cb3a07e41f3fa8e8bc87cf457751cab123a9b58d Mon Sep 17 00:00:00 2001
+From: Oscar Fuentes <ofv@wanadoo.es>
+Date: Sun, 4 Sep 2022 00:27:12 +0200
+Subject: [PATCH] Enable fancy progress line when $TERM != dumb on Windows
+ (#2171)
+
+---
+ src/line_printer.cc | 18 ++++++++++++++++--
+ 1 file changed, 16 insertions(+), 2 deletions(-)
+
+diff --git a/src/line_printer.cc b/src/line_printer.cc
+index a3d0528..06833e1 100644
+--- a/src/line_printer.cc
++++ b/src/line_printer.cc
+@@ -37,8 +37,10 @@ LinePrinter::LinePrinter() : have_blank_line_(true), console_locked_(false) {
+ #ifndef _WIN32
+   smart_terminal_ = isatty(1) && term && string(term) != "dumb";
+ #else
+-  if (term && string(term) == "dumb") {
+-    smart_terminal_ = false;
++  if (term) {
++    // Assume we are in a terminal emulator.
++    smart_terminal_ = string(term) != "dumb";
++    console_ = INVALID_HANDLE_VALUE;
+   } else {
+     console_ = GetStdHandle(STD_OUTPUT_HANDLE);
+     CONSOLE_SCREEN_BUFFER_INFO csbi;
+@@ -51,6 +53,10 @@ LinePrinter::LinePrinter() : have_blank_line_(true), console_locked_(false) {
+     supports_color_ = clicolor_force && string(clicolor_force) != "0";
+   }
+ #ifdef _WIN32
++  // On Windows it is not possible to distinguish a terminal emulator
++  // from a pipe and ANSI escape sequences break applications that
++  // parse ninja's output (cmake, for instance):
++  supports_color_ = supports_color_ && console_ != INVALID_HANDLE_VALUE;
+   // Try enabling ANSI escape sequence support on Windows 10 terminals.
+   if (supports_color_) {
+     DWORD mode;
+@@ -78,6 +84,14 @@ void LinePrinter::Print(string to_print, LineType type) {
+ 
+   if (smart_terminal_ && type == ELIDE) {
+ #ifdef _WIN32
++    if (console_ == INVALID_HANDLE_VALUE) {
++      // Assume we are in a terminal emulator.
++      to_print = ElideMiddle(to_print, 80);
++      printf("%s", to_print.c_str());
++      fflush(stdout);
++      return;
++    }
++
+     CONSOLE_SCREEN_BUFFER_INFO csbi;
+     GetConsoleScreenBufferInfo(console_, &csbi);
+ 
+-- 
+2.30.2.windows.1
+


### PR DESCRIPTION
... for one-line progress messages on terminal emulators without using hacks such as winpty.

Do no activate color, because ANSI escape sequences breaks CMake.
