### PR TITLE
wxPython: rebuild against split wxwidgets packages

### DIFF
--- a/mingw-w64-wxPython/PKGBUILD
+++ b/mingw-w64-wxPython/PKGBUILD
@@ -6,7 +6,7 @@ _wx_basever=3.1
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.1.2a1.dev5434+7d45ee6a
-pkgrel=2
+pkgrel=3
 pkgdesc="A wxWidgets GUI toolkit for Python (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -17,12 +17,13 @@ depends=("${MINGW_PACKAGE_PREFIX}-python"
            "${MINGW_PACKAGE_PREFIX}-python-numpy" )
          "${MINGW_PACKAGE_PREFIX}-python-pillow"
          "${MINGW_PACKAGE_PREFIX}-python-six"
-         "${MINGW_PACKAGE_PREFIX}-wxmsw${_wx_basever}")
+         "${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-msw-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-doxygen"
              "${MINGW_PACKAGE_PREFIX}-python-requests"
              "${MINGW_PACKAGE_PREFIX}-sip4"
              "${MINGW_PACKAGE_PREFIX}-waf"
              "${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-msw"
              # for waf
              "python" "python-setuptools")
 options=('strip' 'staticlibs' 'buildflags')


### PR DESCRIPTION
will likely fail until staging is ready

edit: failed because upstream removed the tarball... I guess we need to  update to 4.2.0