### PR TITLE
python-pywraps2: Named component accessors for S2Point

### DIFF
--- a/mingw-w64-s2geometry/0003-s2geometry-0.10.0-python-point-named-component.patch
+++ b/mingw-w64-s2geometry/0003-s2geometry-0.10.0-python-point-named-component.patch
@@ -1,0 +1,45 @@
+From 191fbeef600f39ce799b177a8e56da908e841d27 Mon Sep 17 00:00:00 2001
+From: Konstantin Podsvirov <konstantin@podsvirov.pro>
+Date: Wed, 24 Aug 2022 20:26:14 +0300
+Subject: [PATCH] python: add named component accessors for S2Point (#268)
+
+Expose `S2Point::x()`, `y()`, and `z()` in Python.
+---
+ src/python/pywraps2_test.py | 9 +++++++++
+ src/python/s2_common.i      | 3 +++
+ 2 files changed, 12 insertions(+)
+
+diff --git a/src/python/pywraps2_test.py b/src/python/pywraps2_test.py
+index 95fb6a91..bede900c 100755
+--- a/src/python/pywraps2_test.py
++++ b/src/python/pywraps2_test.py
+@@ -22,6 +22,15 @@
+ 
+ class PyWrapS2TestCase(unittest.TestCase):
+ 
++  def testS2PointFromRawToNamedCorrectly(self):
++      x = 1.0
++      y = 2.0
++      z = 3.0
++      point = s2.S2Point_FromRaw(x, y, z)
++      self.assertEqual(x, point.x())
++      self.assertEqual(y, point.y())
++      self.assertEqual(z, point.z())
++
+   def testContainsIsWrappedCorrectly(self):
+     london = s2.S2LatLngRect(s2.S2LatLng.FromDegrees(51.3368602, 0.4931979),
+                              s2.S2LatLng.FromDegrees(51.7323965, 0.1495211))
+diff --git a/src/python/s2_common.i b/src/python/s2_common.i
+index cfc39de4..2337b04a 100755
+--- a/src/python/s2_common.i
++++ b/src/python/s2_common.i
+@@ -163,6 +163,9 @@ std::vector<S2Polyline *> *out(std::vector<S2Polyline *> temp) {
+ // difficult to wrap correctly.
+ class S2Point {
+  public:
++  double x();
++  double y();
++  double z();
+   double Norm();
+   S2Point Normalize();
+   ~S2Point();

--- a/mingw-w64-s2geometry/PKGBUILD
+++ b/mingw-w64-s2geometry/PKGBUILD
@@ -5,7 +5,7 @@ _pyname=pywraps2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-python-${_pyname}")
 pkgver=0.10.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A library for manipulating geometric shapes (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -20,16 +20,19 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-swig")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/google/s2geometry/archive/v${pkgver}.tar.gz"
         "0001-s2geometry-0.10.0-fix-python-install.patch"
-        "0002-s2geometry-0.10.0-use-math-defines.patch")
+        "0002-s2geometry-0.10.0-use-math-defines.patch"
+        "0003-s2geometry-0.10.0-python-point-named-component.patch")
 sha256sums=('1c17b04f1ea20ed09a67a83151ddd5d8529716f509dde49a8190618d70532a3d'
             'a25e08cdf5aa1559c6d91f8d7c1302a71c2ed70f4ca28d5ae5ee7818bcd881ab'
-            '7e30f275ab8ae9969decb93ac744052cdfb2c86d1b18de29e053edf79f2cb20d')
+            '7e30f275ab8ae9969decb93ac744052cdfb2c86d1b18de29e053edf79f2cb20d'
+            '90577b86d7b9a77c9a2172664065410c83eb5251166f1918de326a435745d7e0')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
 
   patch -Np1 -i "${srcdir}"/0001-s2geometry-0.10.0-fix-python-install.patch
   patch -Np1 -i "${srcdir}"/0002-s2geometry-0.10.0-use-math-defines.patch
+  patch -Np1 -i "${srcdir}"/0003-s2geometry-0.10.0-python-point-named-component.patch
 }
 
 build() {


### PR DESCRIPTION
Upstream patch from https://github.com/google/s2geometry/pull/268