### PR TITLE
openimagedenoise: Fix building against TBB 2021

### DIFF
--- a/mingw-w64-openimagedenoise/002-Fix-building-with-TBB-2021.patch
+++ b/mingw-w64-openimagedenoise/002-Fix-building-with-TBB-2021.patch
@@ -1,0 +1,25 @@
+--- a/common/tasking.h
++++ b/common/tasking.h
+@@ -19,7 +19,6 @@
+ #include "thread.h"
+ 
+ #define TBB_PREVIEW_LOCAL_OBSERVER 1
+-#include "tbb/task_scheduler_init.h"
+ #include "tbb/task_scheduler_observer.h"
+ #include "tbb/task_arena.h"
+ #include "tbb/parallel_for.h"
+--- a/core/device.cpp
++++ b/core/device.cpp
+@@ -212,7 +212,12 @@
+ 
+     std::cout << "  Tasking :";
+     std::cout << " TBB" << TBB_VERSION_MAJOR << "." << TBB_VERSION_MINOR;
++  #if TBB_INTERFACE_VERSION >= 12002
++    std::cout << " TBB_header_interface_" << TBB_INTERFACE_VERSION << " TBB_lib_interface_" << TBB_runtime_interface_version();
++  #else
+     std::cout << " TBB_header_interface_" << TBB_INTERFACE_VERSION << " TBB_lib_interface_" << tbb::TBB_runtime_interface_version();
++  #endif
++
+     std::cout << std::endl;
+ 
+     std::cout << std::endl;

--- a/mingw-w64-openimagedenoise/003-use-the-same-_cpuid-as-msvc.patch
+++ b/mingw-w64-openimagedenoise/003-use-the-same-_cpuid-as-msvc.patch
@@ -1,0 +1,31 @@
+--- a/mkl-dnn/src/cpu/xbyak/xbyak_util.h
++++ b/mkl-dnn/src/cpu/xbyak/xbyak_util.h
+@@ -59,8 +59,8 @@
+ #endif
+ 
+ #ifdef XBYAK_INTEL_CPU_SPECIFIC
+-#ifdef _MSC_VER
+-	#if (_MSC_VER < 1400) && defined(XBYAK32)
++#ifdef _WIN32
++	#if defined(_MSC_VER) && (_MSC_VER < 1400) && defined(XBYAK32)
+ 		static inline __declspec(naked) void __cpuid(int[4], int)
+ 		{
+ 			__asm {
+@@ -272,7 +272,7 @@
+ 	static inline void getCpuid(unsigned int eaxIn, unsigned int data[4])
+ 	{
+ #ifdef XBYAK_INTEL_CPU_SPECIFIC
+-	#ifdef _MSC_VER
++	#ifdef _WIN32
+ 		__cpuid(reinterpret_cast<int*>(data), eaxIn);
+ 	#else
+ 		__cpuid(eaxIn, data[0], data[1], data[2], data[3]);
+@@ -285,7 +285,7 @@
+ 	static inline void getCpuidEx(unsigned int eaxIn, unsigned int ecxIn, unsigned int data[4])
+ 	{
+ #ifdef XBYAK_INTEL_CPU_SPECIFIC
+-	#ifdef _MSC_VER
++	#ifdef _WIN32
+ 		__cpuidex(reinterpret_cast<int*>(data), eaxIn, ecxIn);
+ 	#else
+ 		__cpuid_count(eaxIn, ecxIn, data[0], data[1], data[2], data[3]);

--- a/mingw-w64-openimagedenoise/PKGBUILD
+++ b/mingw-w64-openimagedenoise/PKGBUILD
@@ -4,27 +4,32 @@ _realname=openimagedenoise
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.1.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Intel Open Image Denoise library of high-performance, high-quality denoising filters for images rendered with ray tracing (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
 url="https://openimagedenoise.github.io/"
 license=("Apache 2.0")
-depends=("${MINGW_PACKAGE_PREFIX}-intel-tbb")
+depends=("${MINGW_PACKAGE_PREFIX}-tbb")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-python"
              "${MINGW_PACKAGE_PREFIX}-cc"
              "git")
 options=('strip' 'buildflags' '!debug')
-source=(#${_realname}-${pkgver}.tar.gz::https://github.com/OpenImageDenoise/oidn/archive/v${pkgver}.tar.gz
-        ${_realname}-${pkgver}.tar.gz::https://github.com/OpenImageDenoise/oidn/releases/download/v${pkgver}/oidn-${pkgver}.src.tar.gz
-        001-build-fixes.patch)
+source=(${_realname}-${pkgver}.tar.gz::https://github.com/OpenImageDenoise/oidn/releases/download/v${pkgver}/oidn-${pkgver}.src.tar.gz
+        001-build-fixes.patch
+        002-Fix-building-with-TBB-2021.patch
+        003-use-the-same-_cpuid-as-msvc.patch)
 sha256sums=('4dd484abea8a0b3d12d346343fcb1ab7abef8f94318d8c537f69a20c2a75c4eb'
-            'e789c3ef6be360ec42f6b0da805bc424f0e021b093091361d2be53a77946724d')
+            'e789c3ef6be360ec42f6b0da805bc424f0e021b093091361d2be53a77946724d'
+            'ccc7619319e7fef7d3b476e1247e15615ab5441a23d0145f46d305a24fcc9be8'
+            '372c36b5c1ee7ff6472d4e750aeaa92828a2d71de48784a00fef7743136434c2')
 
 prepare() {
   cd ${srcdir}/oidn-${pkgver}
   patch -p1 -i ${srcdir}/001-build-fixes.patch
+  patch -p1 -i ${srcdir}/002-Fix-building-with-TBB-2021.patch
+  patch -p1 -i ${srcdir}/003-use-the-same-_cpuid-as-msvc.patch
 }
 
 build() {
@@ -35,21 +40,26 @@ build() {
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
-  [[ -d "build-${MINGW_CHOST}" ]] && rm -rf "build-${MINGW_CHOST}"
-  mkdir -p build-${MINGW_CHOST} && cd build-${MINGW_CHOST}
+  [[ -d "build-${MSYSTEM}" ]] && rm -rf "build-${MSYSTEM}"
+  mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe \
-    -G"MSYS Makefiles" \
+    -G"Ninja" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     ${extra_config} \
+    -DTBB_INCLUDE_DIR=${MINGW_PREFIX}/include \
+    -DTBB_LIBRARY=${MINGW_PREFIX}/lib/libtbb12.dll.a \
+    -DTBB_LIBRARY_MALLOC=${MINGW_PREFIX}/lib/libtbbmalloc.dll.a \
     ../oidn-${pkgver}
 
-  make
+  ${MINGW_PREFIX}/bin/cmake --build .
 }
 
 package() {
-  cd "${srcdir}"/build-${MINGW_CHOST}
-  make DESTDIR=${pkgdir} install
+  cd "${srcdir}"/build-${MSYSTEM}
+
+  DESTDIR=${pkgdir} ${MINGW_PREFIX}/bin/cmake --install .
+
   install -Dm644 ${srcdir}/oidn-${pkgver}/LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.txt"
 }


### PR DESCRIPTION
This is the latest package depending on `intel-tbb`