### PR TITLE
qt6-imageformats: update to 6.3.2

### DIFF
--- a/mingw-w64-qt6-imageformats/001-disable-finding-webp-from-cmake-config-files.patch
+++ b/mingw-w64-qt6-imageformats/001-disable-finding-webp-from-cmake-config-files.patch
@@ -1,0 +1,11 @@
+--- a/cmake/FindWrapWebP.cmake
++++ b/cmake/FindWrapWebP.cmake
+@@ -12,7 +12,7 @@
+     return()
+ endif()
+ 
+-find_package(WebP QUIET)
++find_package(WebP QUIET MODULE)
+ if(TARGET WebP::webp AND TARGET WebP::webpdemux AND TARGET WebP::libwebpmux)
+     set(WrapWebP_FOUND ON)
+     add_library(WrapWebP::WrapWebP INTERFACE IMPORTED)

--- a/mingw-w64-qt6-imageformats/PKGBUILD
+++ b/mingw-w64-qt6-imageformats/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-imageformats
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.3.1
+_qtver=6.3.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -22,11 +22,17 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "rsync")
 options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
-source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('ad0312b8dfbbb67f729bfadbfcd47246ee4a128b717731ba158c41d01fde212f')
+source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz"
+        001-disable-finding-webp-from-cmake-config-files.patch)
+sha256sums=('1dcb8a4cae6c779c3db0b170f78705681a5b6786f0971ed07c618bd03685ce3a'
+            '90c0de75adb82acc9bae387706a63ceab8960e0584b4d69e47785e168a59d402')
+
+prepare() {
+  cd "${srcdir}"/${_pkgfn}
+  patch -p1 -i "${srcdir}"/001-disable-finding-webp-from-cmake-config-files.patch
+}
 
 build() {
-  cd ${srcdir}
   [[ -d build-${MSYSTEM} ]] && rm -rf build-${MSYSTEM}
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
 


### PR DESCRIPTION
Fails!
Reverting #12598 makes it succeed.