### PR TITLE
mlir: update to 15.0.0

### DIFF
--- a/mingw-w64-mlir/0001-do-not-link-to-llvm-dylib.patch
+++ b/mingw-w64-mlir/0001-do-not-link-to-llvm-dylib.patch
@@ -1,0 +1,40 @@
+--- a/cmake/modules/AddMLIR.cmake
++++ b/cmake/modules/AddMLIR.cmake
+@@ -300,7 +300,7 @@
+   endforeach()
+ 
+   list(APPEND ARG_DEPENDS mlir-generic-headers)
+-  llvm_add_library(${name} ${LIBTYPE} ${ARG_UNPARSED_ARGUMENTS} ${srcs} DEPENDS ${ARG_DEPENDS} LINK_COMPONENTS ${ARG_LINK_COMPONENTS} LINK_LIBS ${ARG_LINK_LIBS})
++  llvm_add_library(${name} ${LIBTYPE} DISABLE_LLVM_LINK_LLVM_DYLIB ${ARG_UNPARSED_ARGUMENTS} ${srcs} DEPENDS ${ARG_DEPENDS} LINK_COMPONENTS ${ARG_LINK_COMPONENTS} LINK_LIBS ${ARG_LINK_LIBS})
+ 
+   if(TARGET ${name})
+     target_link_libraries(${name} INTERFACE ${LLVM_COMMON_LIBS})
+@@ -352,7 +352,7 @@
+ endfunction(add_mlir_library)
+ 
+ macro(add_mlir_tool name)
+-  llvm_add_tool(MLIR ${ARGV})
++  llvm_add_tool(MLIR ${ARGV} DISABLE_LLVM_LINK_LLVM_DYLIB)
+ endmacro()
+ 
+ # Sets a variable with a transformed list of link libraries such individual
+--- a/tools/mlir-parser-fuzzer/CMakeLists.txt
++++ b/tools/mlir-parser-fuzzer/CMakeLists.txt
+@@ -3,6 +3,7 @@
+   Support
+ )
+ add_llvm_fuzzer(mlir-parser-fuzzer
++  DISABLE_LLVM_LINK_LLVM_DYLIB
+   mlir-parser-fuzzer.cpp
+   DUMMY_MAIN DummyParserFuzzer.cpp
+ )
+--- a/test/CAPI/CMakeLists.txt
++++ b/test/CAPI/CMakeLists.txt
+@@ -7,6 +7,7 @@
+   set(LLVM_LINK_COMPONENTS
+     )
+   add_llvm_executable(${name}
++    DISABLE_LLVM_LINK_LLVM_DYLIB
+     PARTIAL_SOURCES_INTENDED
+     ${ARG_UNPARSED_ARGUMENTS})
+   llvm_update_compile_flags(${name})

--- a/mingw-w64-mlir/0002-Use-hidden-visibility-when-building-for-MinGW-with-Clang.patch
+++ b/mingw-w64-mlir/0002-Use-hidden-visibility-when-building-for-MinGW-with-Clang.patch
@@ -1,0 +1,88 @@
+From 2c2fb0c7375061147711cd21396d79faad7dfdfb Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Storsj=C3=B6?= <martin@martin.st>
+Date: Mon, 18 Jul 2022 14:13:05 +0300
+Subject: [PATCH] [llvm] Use hidden visibility when building for MinGW with
+ Clang
+
+Since c5b3de6745c37dd991430b9b88ff97c35b6fc455 (git main,
+August 11th), Clang does generate working hidden visibility
+on MinGW targets. Using that reduces the number of exports from
+a dylib build of LLVM significantly, which is vital for fitting
+within the limit of 64k exported symbols from a DLL.
+
+It's essential that if we set CMAKE_CXX_VISIBILITY_PRESET=hidden
+(which passes -fvisibility=hidden on the command line), we also
+must define LLVM_EXTERNAL_VISIBILITY consistently to override
+it. (If there are mismatches, e.g. setting hidden visibility generally
+but never overriding it back to default for the symbols that do need
+to be exported, we'd get broken builds in such configurations.)
+
+We don't want to be using __attribute__((visibility("hidden"))) on
+MinGW with GCC, because GCC produces a warning about it. (GCC hasn't
+warned about the command line options that set hidden visibility
+though.) Clang has historically not warned about either of them, so
+it is harmless to use the hidden visibility when building with older
+Clang (so we don't need to detect the exact version of Clang/LLVM where
+it has an effect).
+
+This reduces the number of exported symbols for a dylib build of LLVM;
+previously libLLVM exported around 64650 symbols (when the maximum is
+65536) when the ARM, AArch64 and X86 targets were enabled. If enabling
+more targets (or if building with e.g. assertions enabled), it would
+exceed the limit. Now with visibility flags in use, the same build
+with ARM, AArch64 and X86 ends up at around 35k exported symbols.
+
+Differential Revision: https://reviews.llvm.org/D131661
+---
+ cmake/modules/HandleLLVMOptions.cmake | 7 +++++--
+ include/llvm/Support/Compiler.h       | 5 +++--
+ lib/Target/CMakeLists.txt             | 2 +-
+ 3 files changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/cmake/modules/HandleLLVMOptions.cmake b/cmake/modules/HandleLLVMOptions.cmake
+index dba96d1f0815d..ba525e62f3966 100644
+--- a/cmake/modules/HandleLLVMOptions.cmake
++++ b/cmake/modules/HandleLLVMOptions.cmake
+@@ -351,8 +351,11 @@ if( LLVM_ENABLE_PIC )
+   endif()
+ endif()
+ 
+-if(NOT WIN32 AND NOT CYGWIN AND NOT (${CMAKE_SYSTEM_NAME} MATCHES "AIX"))
+-  # MinGW warns if -fvisibility-inlines-hidden is used.
++if((NOT (${CMAKE_SYSTEM_NAME} MATCHES "AIX")) AND
++   (NOT (WIN32 OR CYGWIN) OR (MINGW AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")))
++  # GCC for MinGW does nothing about -fvisibility-inlines-hidden, but warns
++  # about use of the attributes. As long as we don't use the attributes (to
++  # override the default) we shouldn't set the command line options either.
+   # GCC on AIX warns if -fvisibility-inlines-hidden is used and Clang on AIX doesn't currently support visibility.
+   check_cxx_compiler_flag("-fvisibility-inlines-hidden" SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG)
+   append_if(SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG "-fvisibility-inlines-hidden" CMAKE_CXX_FLAGS)
+diff --git a/include/llvm/Support/Compiler.h b/include/llvm/Support/Compiler.h
+index c4cfea1fb3c8b..bf299bc1d0d7f 100644
+--- a/include/llvm/Support/Compiler.h
++++ b/include/llvm/Support/Compiler.h
+@@ -113,8 +113,9 @@
+ /// LLVM_EXTERNAL_VISIBILITY - classes, functions, and variables marked with
+ /// this attribute will be made public and visible outside of any shared library
+ /// they are linked in to.
+-#if __has_attribute(visibility) && !defined(__MINGW32__) &&                    \
+-    !defined(__CYGWIN__) && !defined(_WIN32)
++#if __has_attribute(visibility) &&                                             \
++    (!(defined(_WIN32) || defined(__CYGWIN__)) ||                              \
++     (defined(__MINGW32__) && defined(__clang__)))
+ #define LLVM_LIBRARY_VISIBILITY __attribute__ ((visibility("hidden")))
+ #if defined(LLVM_BUILD_LLVM_DYLIB) || defined(LLVM_BUILD_SHARED_LIBS)
+ #define LLVM_EXTERNAL_VISIBILITY __attribute__((visibility("default")))
+diff --git a/lib/Target/CMakeLists.txt b/lib/Target/CMakeLists.txt
+index c0c2bc36a6e47..0fec6d1fb6901 100644
+--- a/lib/Target/CMakeLists.txt
++++ b/lib/Target/CMakeLists.txt
+@@ -22,7 +22,7 @@ add_llvm_component_library(LLVMTarget
+ # When building shared objects for each target there are some internal APIs
+ # that are used across shared objects which we can't hide.
+ if (NOT BUILD_SHARED_LIBS AND NOT APPLE AND
+-    NOT MINGW AND
++    (NOT (WIN32 OR CYGWIN) OR (MINGW AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")) AND
+     NOT (${CMAKE_SYSTEM_NAME} MATCHES "AIX") AND
+     NOT DEFINED CMAKE_CXX_VISIBILITY_PRESET)
+   # Set default visibility to hidden, so we don't export all the Target classes

--- a/mingw-w64-mlir/PKGBUILD
+++ b/mingw-w64-mlir/PKGBUILD
@@ -3,7 +3,10 @@
 _realname=mlir
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=14.0.6
+_version=15.0.0
+_rc=""
+_tag=llvmorg-${_version}${_rc}
+pkgver=${_version}${_rc/-/}
 pkgrel=1
 pkgdesc="Multi-Level IR Compiler Framework for LLVM (mingw-w64)"
 url="https://mlir.llvm.org/"
@@ -14,23 +17,32 @@ depends=("${MINGW_PACKAGE_PREFIX}-llvm")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-python-sphinx"
-             "${MINGW_PACKAGE_PREFIX}-cc")
+             "${MINGW_PACKAGE_PREFIX}-clang"
+             $([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-libc++abi"))
 options=('!debug' 'strip')
 _pkgfn=$_realname
-_url=https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkgver}
-# No source package for MLIR: https://bugs.llvm.org/show_bug.cgi?id=52248
-source=("${_url}/llvm-project-${pkgver}.src.tar.xz"{,.sig})
-sha256sums=('8b3cfd7bc695bd6cea0f37f53f0981f34f87496e79e2529874fd03a2f9dd3a8a'
-            'SKIP')
+_url=https://github.com/llvm/llvm-project/releases/download/${_tag}
+# No source package for MLIR: https://github.com/llvm/llvm-project/issues/51590
+source=("${_url}/llvm-project-${pkgver}.src.tar.xz"{,.sig}
+        0001-do-not-link-to-llvm-dylib.patch
+        0002-Use-hidden-visibility-when-building-for-MinGW-with-Clang.patch)
+sha256sums=('caaf8100365b6ebafc39fea803e902ca3ff38b4d5327b9927097808d32964db7'
+            'SKIP'
+            '21e21fcd76e4dbb48032903b91ee7521051a91122c2a58616a33da02796b0580'
+            'f3bce25ac7d339cbe7a94bd1cfd2d634450c261c7a32103aba4ed5f773fd2cfc')
 validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Google.
-              '474E22316ABF4785A88C6E8EA2C794A986419D8A') # Tom Stellard
+              '474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard
+              'D574BD5D1D0E98895E3BF90044F2485E45D59042') # Tobias Hieta
 noextract=(llvm-project-${pkgver}.src.tar.xz)
 
 prepare() {
   plain "Extracting llvm-project-${pkgver}.src.tar.xz due to symlink(s) without pre-existing target(s)"
-  cd "${srcdir}"
   rm -rf mlir || true
   tar --strip-components=1 -xJf ${srcdir}/llvm-project-${pkgver}.src.tar.xz -C ${srcdir} || true
+  cd "${srcdir}"/mlir
+  patch -p1 -i "${srcdir}"/0001-do-not-link-to-llvm-dylib.patch
+  cd "${srcdir}"/llvm
+  patch -p1 -i "${srcdir}"/0002-Use-hidden-visibility-when-building-for-MinGW-with-Clang.patch
 }
 
 build() {
@@ -44,33 +56,33 @@ build() {
     _build_type="Release"
   fi
 
+  CC=${MINGW_PREFIX}/bin/clang \
+  CXX=${MINGW_PREFIX}/bin/clang++ \
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-  cmake \
+  ${MINGW_PREFIX}/bin/cmake \
     -GNinja \
     -DCMAKE_BUILD_TYPE=${_build_type} \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DCMAKE_SYSTEM_IGNORE_PATH=/usr/lib \
     -DLLVM_HOST_TRIPLE="${CARCH}-w64-windows-gnu" \
     -DPython3_EXECUTABLE=${MINGW_PREFIX}/bin/python.exe \
-    -DPython3_FIND_REGISTRY=NEVER \
-    -DPython3_ROOT_DIR=${MINGW_PREFIX} \
-    -DLLVM_ENABLE_SPHINX=ON \
     -DLLVM_LINK_LLVM_DYLIB=ON \
     -DLLVM_BUILD_LLVM_DYLIB=ON \
     -DMLIR_LINK_MLIR_DYLIB=ON \
     -DLLVM_BUILD_TOOLS=ON \
     -DLLVM_BUILD_UTILS=ON \
-    -DLLVM_INSTALL_UTILS=ON \
     -DLLVM_ENABLE_PIC=ON \
-    -DMLIR_INCLUDE_TESTS=ON \
+    -DMLIR_INCLUDE_TESTS=OFF \
+    -DCMAKE_C_VISIBILITY_PRESET=hidden \
+    -DCMAKE_CXX_VISIBILITY_PRESET=hidden \
     -Wno-dev \
     ../$_pkgfn
 
-  cmake --build .
+  ${MINGW_PREFIX}/bin/cmake --build .
 }
 
 package() {
-  DESTDIR="${pkgdir}" cmake --install build-${MSYSTEM}
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install build-${MSYSTEM}
 
   install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_realname}
   install -Dm644 ${srcdir}/${_realname}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_realname}


### PR DESCRIPTION
MINGW64:
```
  [1397/1397] Linking CXX shared library bin\libMLIR.dll
  FAILED: bin/libMLIR.dll tools/mlir-shlib/libMLIR.dll.a 
  cmd.exe /C "cd . && D:\M\msys64\mingw64\bin\clang++.exe -march=x86-64 -mtune=generic -O2 -pipe -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -ffunction-sections -fdata-sections -Werror=mismatched-tags -O3 -DNDEBUG  -pipe   -Wl,--gc-sections -shared -o bin\libMLIR.dll -Wl,--out-implib,tools\mlir-shlib\libMLIR.dll.a -Wl,--major-image-version,0,--minor-image-version,0 @CMakeFiles\MLIR.rsp  && cd ."
  D:/M/msys64/mingw64/bin/ld: error: export ordinal too large: 98873
  clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```
CLANG64:
```
  [1389/1397] Linking CXX shared library bin\libMLIR.dll
  FAILED: bin/libMLIR.dll tools/mlir-shlib/libMLIR.dll.a 
  cmd.exe /C "cd . && D:\M\msys64\clang64\bin\clang++.exe -march=x86-64 -mtune=generic -O2 -pipe -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -ffunction-sections -fdata-sections -Werror=mismatched-tags -O3 -DNDEBUG  -pipe   -Wl,--gc-sections -shared -o bin\libMLIR.dll -Wl,--out-implib,tools\mlir-shlib\libMLIR.dll.a -Wl,--major-image-version,0,--minor-image-version,0 @CMakeFiles\MLIR.rsp  && cd ."
  ld.lld: error: too many exported symbols (got 77100, max 65535)
  
  clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```
Should we disable building `libMLIR.dll`?
@mati865 
@mstorsjo 