### PR TITLE
qt-creator: Update to 8.0 and backport llvm 15 and mingw-w64 build fixes

### DIFF
--- a/mingw-w64-qt-creator/PKGBUILD
+++ b/mingw-w64-qt-creator/PKGBUILD
@@ -5,9 +5,9 @@ _realname=qt-creator
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 __pre=
-_base_ver=7.0.0
+_base_ver=8.0.1
 pkgver=${_base_ver}${_pre}
-pkgrel=4
+pkgrel=1
 pkgdesc='Cross-platform IDE (mingw-w64)'
 url='https://www.qt.io/'
 install=qt-creator-${MSYSTEM}.install
@@ -42,19 +42,27 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-python"
              "${MINGW_PACKAGE_PREFIX}-qt6-doc"
              "${MINGW_PACKAGE_PREFIX}-qt6-quicktimeline"
-             "${MINGW_PACKAGE_PREFIX}-cc")
+             "${MINGW_PACKAGE_PREFIX}-cc"
+             $([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-libc++abi")
+)
 options=('docs' 'staticlibs') # 'debug' '!strip')
 _pkgfqn="${_realname}-opensource-src-${_base_ver}${__pre}"
 source=(#https://download.qt.io/development_releases/qtcreator/${_base_ver%.*}/${_base_ver}${__pre}/${_pkgfqn}.tar.xz
         https://download.qt.io/official_releases/qtcreator/${pkgver%.*}/${pkgver}/${_pkgfqn}.tar.xz
         qt-creator-3.2.0-Allow-iOS-plugin-on-any-platform.patch
         qt-creator-5.0.1-fix-library-archive-path.patch
-        003-find-qdoc-qt6.patch)
+        003-find-qdoc-qt6.patch
+        https://github.com/qt-creator/qt-creator/commit/c7cdd55dea1f30b4d236d532bdadcf36bd174640.patch
+        https://github.com/qt-creator/qt-creator/commit/a1bfcbf30d493e1e1fab94851fe50fed81cd3d6e.patch
+        https://github.com/qt-creator/qt-creator/commit/5aa8c55f144a976c534a780921b3b6ee0c01488c.patch)
 noextract=(${_pkgfqn}.tar.xz)
-sha256sums=('d39a05e48bb961cfab61135a5ee5503fc4d381c74000b910f36bf0cea37736d9'
+sha256sums=('e2ce200a79c74dcd6367dcbb83c839c1c20b2cc077d6a658639eacde8a4ab865'
             '96c14f54577bf6cadf5c12018745666a9e99cd8d6a876c29a28b13599a8cb368'
             '4daf74e55e9b5cae9f05704a98fb832688edf958481cfb2246aecf6b54156e53'
-            '5870c81167909d549c14c2b60acabfae2b0b85e84bae7aa7e383333ff9411a4a')
+            '5870c81167909d549c14c2b60acabfae2b0b85e84bae7aa7e383333ff9411a4a'
+            '0432d1927f8c7bc8859b991af28e353582506b941ee7f716ec8e7528dd42143a'
+            'c6739453fb5be3db8e15d6cda61a315df6bf8af4f47dcd27617b74e55843c395'
+            '5147f505ed7e4b150cd1ce5b9deca0d43ea9d3175c4cc00b4539299c0e036b1d')
 
 prepare() {
   [[ -d ${srcdir}/${_pkgfqn} ]] && rm -rf ${srcdir}/${_pkgfqn}
@@ -65,6 +73,11 @@ prepare() {
   patch -p1 -i "${srcdir}"/qt-creator-3.2.0-Allow-iOS-plugin-on-any-platform.patch
   patch -p1 -i "${srcdir}"/qt-creator-5.0.1-fix-library-archive-path.patch
   patch -p1 -i "${srcdir}"/003-find-qdoc-qt6.patch
+
+  # backports for mingw-w64 and llvm15
+  patch -p1 -i "${srcdir}"/c7cdd55dea1f30b4d236d532bdadcf36bd174640.patch
+  patch -p1 -i "${srcdir}"/a1bfcbf30d493e1e1fab94851fe50fed81cd3d6e.patch
+  patch -p1 -i "${srcdir}"/5aa8c55f144a976c534a780921b3b6ee0c01488c.patch 
 }
 
 build() {


### PR DESCRIPTION
Updating to 8.0 since that made backporting easier