### PR TITLE
libc++: merge libc++abi in libc++

### DIFF
--- a/mingw-w64-libc++/PKGBUILD
+++ b/mingw-w64-libc++/PKGBUILD
@@ -7,13 +7,12 @@ fi
 _realname=libc++
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
-         "${MINGW_PACKAGE_PREFIX}-${_realname}abi"
          "${MINGW_PACKAGE_PREFIX}-libunwind")
 _version=15.0.0
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
-pkgrel=1
+pkgrel=2
 url="https://libcxx.llvm.org/"
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -121,29 +120,23 @@ build() {
     -Wno-dev \
     ../runtimes
 
-  cmake --build . -- unwind cxxabi cxx cxx_experimental
+  ${MINGW_PREFIX}/bin/cmake --build . -- unwind cxxabi cxx cxx_experimental
 }
 
 package_libc++() {
   pkgdesc="C++ Standard Library (mingw-w64)"
   url="https://libcxx.llvm.org/"
-  provides=($( (( _clangprefix )) && echo \
+  provides=("${MINGW_PACKAGE_PREFIX}-libc++abi"
+            $( (( _clangprefix )) && echo \
              "${MINGW_PACKAGE_PREFIX}-gcc-libs" \
              || true))
+  conflicts=("${MINGW_PACKAGE_PREFIX}-libc++abi")
+  replaces=("${MINGW_PACKAGE_PREFIX}-libc++abi")
   depends=($( (( _clangprefix )) && echo \
              "${MINGW_PACKAGE_PREFIX}-libunwind" \
              || echo "${MINGW_PACKAGE_PREFIX}-gcc-libs"))
 
-  DESTDIR="${pkgdir}" cmake --build "${srcdir}/build-${MSYSTEM}" --target install-cxx
-}
-
-package_libc++abi() {
-  pkgdesc="C++ Standard Library Support (mingw-w64)"
-  url="https://libcxxabi.llvm.org/"
-  depends=($( (( _clangprefix )) || echo \
-             "${MINGW_PACKAGE_PREFIX}-gcc-libs"))
-
-  DESTDIR="${pkgdir}" cmake --build "${srcdir}/build-${MSYSTEM}" --target install-cxxabi
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --build "${srcdir}/build-${MSYSTEM}" --target install-cxx install-cxxabi
 }
 
 package_libunwind() {


### PR DESCRIPTION
The header file `cxxabi.h` were moved from `libc++` to `libc++abi` which made many packages failed to build.

@mati865 