### PR TITLE
llvm: fix system libs for llvm-config

### DIFF
--- a/mingw-w64-clang/0010-fix-system-libs-zstd.patch
+++ b/mingw-w64-clang/0010-fix-system-libs-zstd.patch
@@ -1,0 +1,17 @@
+--- llvm/lib/Support/CMakeLists.txt.orig	2022-09-05 11:48:03.000000000 +0200
++++ llvm/lib/Support/CMakeLists.txt	2022-09-16 16:13:11.264434200 +0200
+@@ -300,11 +303,12 @@
+   # CMAKE_BUILD_TYPE is only meaningful to single-configuration generators.
+   if(CMAKE_BUILD_TYPE)
+     string(TOUPPER ${CMAKE_BUILD_TYPE} build_type)
+-    get_property(zstd_library TARGET zstd::libzstd_shared PROPERTY LOCATION_${build_type})
++    get_property(zstd_library TARGET zstd::libzstd_shared PROPERTY IMPORTED_IMPLIB_${build_type})
+   endif()
+   if(NOT zstd_library)
+-    get_property(zstd_library TARGET zstd::libzstd_shared PROPERTY LOCATION)
++    get_property(zstd_library TARGET zstd::libzstd_shared PROPERTY IMPORTED_IMPLIB)
+   endif()
++  get_library_name(${zstd_library} zstd_library)
+   set(llvm_system_libs ${llvm_system_libs} "${zstd_library}")
+ endif()
+ 

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -26,7 +26,7 @@ _version=15.0.0
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
-pkgrel=1
+pkgrel=2
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -66,6 +66,7 @@ source=("${_url}/llvm-${pkgver}.src.tar.xz"{,.sig}
         "0005-export-out-of-tree-mlir-targets.patch"
         "0008-COFF-Emit-embedded-exclude-symbols-directives-for-hi.patch"
         "0009-Use-hidden-visibility-when-building-for-MinGW-with-Clang.patch"
+        "0010-fix-system-libs-zstd.patch"
         "0101-link-pthread-with-mingw.patch"
         "0102-fix-emulated-tls.patch"
         "0303-ignore-new-bfd-options.patch")
@@ -96,6 +97,7 @@ sha256sums=('4cd035b665f3be72382b978543d897238c7faa13d13cdd7d573c2e93f23c10d0'
             'cb96582194ef80a37cc184e95287920b2df5369e2e5798a64adf6f8bf1c52985'
             '5bb5e31eea8ea2c4eea56f2aae161dfde35caa9800459ae3c785a94654628e57'
             'f3bce25ac7d339cbe7a94bd1cfd2d634450c261c7a32103aba4ed5f773fd2cfc'
+            'bd53c6ad00e369cd6cb938e6ecd20b5952765987cd97807083e671d4192ced48'
             '715cb8862753854b2d9256e0b70003e2d1f57083d83eaeaf5a095fc72b8a4e26'
             '3a58bd5243fb082df64c90bd9a4f00c698317f20365d11bbe30fac5dfccd215e'
             '778e0db0a5b0657ab05e2a81d83241347a4a41af2b0f9903422f651fa58e8d40')
@@ -146,6 +148,9 @@ prepare() {
     "0005-export-out-of-tree-mlir-targets.patch" \
     "0008-COFF-Emit-embedded-exclude-symbols-directives-for-hi.patch" \
     "0009-Use-hidden-visibility-when-building-for-MinGW-with-Clang.patch"
+
+  # https://github.com/msys2/MINGW-packages/issues/13108
+  apply_patch_with_msg 0010-fix-system-libs-zstd.patch
 
   # Patch clang
   cd "${srcdir}/clang"


### PR DESCRIPTION
For some reason it added an absolute path there instead of the library. Fix it with my limited cmake knowledge..

Fixes #13108