### PR TITLE
ruby: add clangarm64 target

### DIFF
--- a/mingw-w64-ruby/0009-windows-arm64.patch
+++ b/mingw-w64-ruby/0009-windows-arm64.patch
@@ -1,0 +1,29 @@
+--- a/configure.ac	2022-09-17 20:44:42.375546800 +0200
++++ b/configure.ac	2022-09-17 20:49:48.224691700 +0200
+@@ -2541,6 +2541,9 @@
+         [*86-mingw*], [
+             coroutine_type=win32
+         ],
++        [aarch64-mingw*], [
++            coroutine_type=arm64
++        ],
+         [arm*-linux*], [
+             coroutine_type=arm32
+         ],
+--- a/vm_dump.c	2022-04-12 13:11:15.000000000 +0200
++++ b/vm_dump.c	2022-09-17 20:52:16.559409600 +0200
+@@ -701,6 +701,14 @@
+ 		    frame.AddrFrame.Offset = context.Rbp;
+ 		    frame.AddrStack.Mode = AddrModeFlat;
+ 		    frame.AddrStack.Offset = context.Rsp;
++#elif defined(__aarch64__)
++		    mac = IMAGE_FILE_MACHINE_ARM64;
++		    frame.AddrPC.Mode = AddrModeFlat;
++		    frame.AddrPC.Offset = context.Pc;
++		    frame.AddrFrame.Mode = AddrModeFlat;
++		    frame.AddrFrame.Offset = context.Fp;
++		    frame.AddrStack.Mode = AddrModeFlat;
++		    frame.AddrStack.Offset = context.Sp;
+ #else	/* i386 */
+ 		    mac = IMAGE_FILE_MACHINE_I386;
+ 		    frame.AddrPC.Mode = AddrModeFlat;

--- a/mingw-w64-ruby/PKGBUILD
+++ b/mingw-w64-ruby/PKGBUILD
@@ -13,7 +13,7 @@ pkgver=3.1.2
 pkgrel=2
 pkgdesc="An object-oriented language for quick and easy programming (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://www.ruby-lang.org/en"
 license=("BSD, custom")
 makedepends=("${MINGW_PACKAGE_PREFIX}-doxygen"
@@ -33,7 +33,8 @@ options=('staticlibs' 'strip')
 source=("https://cache.ruby-lang.org/pub/ruby/${pkgver%.*}/${_realname}-${pkgver}.tar.gz"
         0003-fix-check-types.patch
         0007-nm-use-full-options.patch
-        0008-ucrt-32-win11-insns.patch)
+        0008-ucrt-32-win11-insns.patch
+        0009-windows-arm64.patch)
 ## Populated by the updpkgprovs script
 provides=(
     "${MINGW_PACKAGE_PREFIX}-ruby-debug=1.4.0"
@@ -127,7 +128,8 @@ provides=(
 sha256sums=('61843112389f02b735428b53bb64cf988ad9fb81858b8248e22e57336f24a83e'
             'e5d665cabac8b7fbb0dda9a556c2350190801aa07b3cb90a0d50097ab99272a0'
             'b250c66bc8b372fb4c53902a6d56c01ad057416e3e368a5c5434d9a4ebdc3819'
-            'c9f816baf5b2803e017924c7eeef6a478beb76247d6d4b39a2424c8d34687b2b')
+            'c9f816baf5b2803e017924c7eeef6a478beb76247d6d4b39a2424c8d34687b2b'
+            'f3a61f6d600bb962f23e4ff1c0857120630541d8fcb542957dc0848b00a39690')
 noextract=(${_realname}-${pkgver}.tar.gz)
 
 apply_patch_with_msg() {
@@ -157,7 +159,8 @@ prepare() {
   apply_patch_with_msg \
       0003-fix-check-types.patch \
       0007-nm-use-full-options.patch \
-      0008-ucrt-32-win11-insns.patch
+      0008-ucrt-32-win11-insns.patch \
+      0009-windows-arm64.patch
 
   autoreconf -fi
 }


### PR DESCRIPTION
This enables the `clangarm64` target. The build is currently failing with `unexpected ucrtbase.dll`. I saw [this related issue](https://github.com/msys2/MINGW-packages/issues/10896#issuecomment-1058356607) and would appreciate getting some pointers on how to fix this in a similar way that was done in [this PR](https://github.com/msys2/MINGW-packages/pull/10898). Happy to provide an upstream PR once we have this working. CC @jeremyd2019 🙏🏼 

```
configure: ruby library version = 3.1.0
configure: creating ./config.status
config.status: creating GNUmakefile
config.status: creating Makefile
---
Configuration summary for ruby version 3.1.2

   * Installation prefix: /clangarm64
   * exec prefix:         ${prefix}
   * arch:                aarch64-mingw-ucrt
   * site arch:           aarch64-ucrt
   * RUBY_BASE_NAME:      ruby
   * enable shared:       yes
   * ruby lib prefix:     ${libdir}/${RUBY_BASE_NAME}
   * site libraries path: ${rubylibprefix}/${sitearch}
   * vendor path:         ${rubylibprefix}/vendor_ruby
   * target OS:           mingw32
   * compiler:            clang
   * with pthread:        no
   * with coroutine:      arm64
   * enable shared libs:  yes
   * dynamic library ext: so
   * CFLAGS:              -fdeclspec ${optflags} ${debugflags} ${warnflags}
   * LDFLAGS:             -L. -pipe
   * DLDFLAGS:            -pipe \
                          -Wl,--enable-auto-image-base,--enable-auto-import
   * optflags:            -O3 -fno-omit-frame-pointer -fno-fast-math
   * debugflags:          -ggdb3
   * warnflags:           -Wall -Wextra -Wdeprecated-declarations \
                          -Wdivision-by-zero \
                          -Wimplicit-function-declaration -Wimplicit-int \
                          -Wmisleading-indentation -Wpointer-arith \
                          -Wshorten-64-to-32 -Wwrite-strings \
                          -Wold-style-definition -Wmissing-noreturn \
                          -Wno-cast-function-type \
                          -Wno-constant-logical-operand -Wno-long-long \
                          -Wno-missing-field-initializers \
                          -Wno-overlength-strings -Wno-parentheses-equality \
                          -Wno-self-assign -Wno-tautological-compare \
                          -Wno-unused-parameter -Wno-unused-value \
                          -Wunused-variable -Wextra-tokens -Wundef
   * strip command:       llvm-strip -S -x
   * install doc:         rdoc
   * JIT support:         yes
   * man page type:       doc

---
```

the error:

```
linking miniruby.exe
generating encdb.h
unexpected ucrtbase.dll
unexpected ucrtbase.dll
unexpected ucrtbase.dll
make: *** [uncommon.mk:1178: builtin_binary.inc] Error 1
make: *** Waiting for unfinished jobs....
make: *** [uncommon.mk:841: .rbconfig.time] Error 1
make: *** [uncommon.mk:1129: encdb.h] Error 1
==> ERROR: A failure occurred in build().
    Aborting...
```