### PR TITLE
CI: Run prepare step first.

### DIFF
--- a/.ci/ci-build.sh
+++ b/.ci/ci-build.sh
@@ -65,7 +65,8 @@ for package in "${packages[@]}"; do
     echo "::group::[build] ${package}"
     execute 'Clear cache' pacman -Scc --noconfirm
     execute 'Fetch keys' "$DIR/fetch-validpgpkeys.sh"
-    execute 'Building binary' makepkg-mingw --noconfirm --noprogressbar --nocheck --syncdeps --rmdeps --cleanbuild
+    execute 'Prepare' makepkg-mingw --nobuild --nodeps --cleanbuild
+    execute 'Building binary' makepkg-mingw --noconfirm --noprogressbar --nocheck --syncdeps --rmdeps --noextract
     repo-add $PWD/artifacts/ci.db.tar.gz $PWD/$package/*.pkg.tar.*
     pacman -Sy
     cp $PWD/$package/*.pkg.tar.* $PWD/artifacts


### PR DESCRIPTION
This will make CI fails earlier if patches couldn't be applied or checksums are wrong. It helps with automatic updates