### PR TITLE
[new-package] highlight 4.3

### DIFF
--- a/mingw-w64-highlight/001-fix-installation-prefix-and-destdir.patch
+++ b/mingw-w64-highlight/001-fix-installation-prefix-and-destdir.patch
@@ -1,0 +1,15 @@
+--- a/makefile
++++ b/makefile
+@@ -4,10 +4,10 @@
+ # Installation directories:
+ 
+ # Destination directory for installation (intended for packagers)
+-DESTDIR =
++DESTDIR ?=
+ 
+ # Root directory for final installation
+-PREFIX = /usr
++PREFIX ?= /usr
+ 
+ # Data file directory
+ data_dir = ${PREFIX}/share/

--- a/mingw-w64-highlight/002-fix-data-dir-stat.patch
+++ b/mingw-w64-highlight/002-fix-data-dir-stat.patch
@@ -1,0 +1,82 @@
+diff --git a/src/cli/main.cpp b/src/cli/main.cpp
+index 2d9ca92..9779cae 100644
+--- a/src/cli/main.cpp
++++ b/src/cli/main.cpp
+@@ -343,7 +343,7 @@ int HLCmdLineApp::run ( const int argc, const char*argv[] )
+     CmdLineOptions options ( argc, argv );
+ 
+     // set data directory path, where /langDefs and /themes reside
+-    string dataDirPath = ( options.getDataDir().empty() ) ?  Platform::getAppPath() :options.getDataDir();
++    string dataDirPath = options.getDataDir();
+ 
+     if ( options.printVersion() ) {
+         printVersionInfo(options.quietMode());
+diff --git a/src/core/datadir.cpp b/src/core/datadir.cpp
+index 558b66f..a316b6f 100644
+--- a/src/core/datadir.cpp
++++ b/src/core/datadir.cpp
+@@ -52,21 +52,19 @@ void DataDir::initSearchDirectories ( const string &userDefinedDir )
+         possibleDirs.push_back ( hlEnvPath );
+     }
+ 
+-#ifndef _WIN32
+-
+ #ifdef HL_DATA_DIR
+     possibleDirs.push_back ( HL_DATA_DIR );
+-#else
++#elif !defined(_WIN32)
+     possibleDirs.push_back ( LSB_DATA_DIR );
+ #endif
+ 
+ #ifdef HL_CONFIG_DIR
+     possibleDirs.push_back ( HL_CONFIG_DIR);
+-#else
++#elif !defined(_WIN32)
+     possibleDirs.push_back ( LSB_CFG_DIR);
+ #endif
+ 
+-#else
++#if defined(_WIN32) && !defined(HL_DATA_DIR) && !defined(HL_CONFIG_DIR)
+     possibleDirs.push_back(Platform::getAppPath()); //not needed because of fallback in searchFile
+ #endif
+ }
+@@ -132,12 +130,10 @@ const string DataDir::getPluginPath ( )
+ 
+ const string DataDir::getSystemDataPath ( )
+ {
+-#ifndef _WIN32
+ #ifdef HL_DATA_DIR
+     return HL_DATA_DIR;
+-#else
++#elif !defined(_WIN32)
+     return LSB_DATA_DIR;
+-#endif
+ #else
+     return Platform::getAppPath();
+ #endif
+diff --git a/src/core/platform_fs.cpp b/src/core/platform_fs.cpp
+index f2abf35..68b0835 100644
+--- a/src/core/platform_fs.cpp
++++ b/src/core/platform_fs.cpp
+@@ -368,7 +368,9 @@ int wildcmp ( const char *wild, const char *data )
+ bool fileExists(const string &fName)
+ {
+     struct stat fileInfo;
+-    return !stat(fName.c_str(),&fileInfo);
++    const string path = (fName.back() != pathSeparator) ?
++        fName : fName.substr(0, fName.size() - 1);
++    return stat(path.c_str(), &fileInfo) == 0;
+ }
+ 
+ //-D_FILE_OFFSET_BITS=64
+@@ -376,7 +378,9 @@ bool fileExists(const string &fName)
+ 
+ off_t fileSize(const string& fName) {
+     struct stat fileInfo;
+-    if(stat(fName.c_str(), &fileInfo) != 0) {
++    const string path = (fName.back() != pathSeparator) ?
++      fName : fName.substr(0, fName.size() - 1);
++    if (stat(path.c_str(), &fileInfo) != 0) {
+         return 0;
+     }
+     return fileInfo.st_size;

--- a/mingw-w64-highlight/PKGBUILD
+++ b/mingw-w64-highlight/PKGBUILD
@@ -1,0 +1,25 @@
+_realname=highlight
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=4.2
+pkgrel=1
+url="http://www.andre-simon.de/doku/highlight/highlight.html"
+pkgdesc="Fast and flexible source code highlighter (CLI version)"
+license=('GPL')
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+makedepends=("${MINGW_PACKAGE_PREFIX}-lua")
+_commit='80c5735e1f2a525c4f85e5f220c6b3c2bb26c063'
+source=("https://gitlab.com/saalen/highlight/-/archive/${_commit}/highlight-${_commit}.tar.gz")
+sha256sums=('6f9ef2fe18f8bbf97c9a5cdff5b3b061f017d7ce00cb9bb34adf0b9b6c0df6fa')
+options=('strip')
+
+build() {
+  cd "$srcdir/${_realname}-${_commit}/"
+  make
+}
+
+package() {
+  cd "$srcdir/${_realname}-${_commit}/"
+  DESTDIR="${pkgdir}" make install
+}

--- a/mingw-w64-highlight/PKGBUILD
+++ b/mingw-w64-highlight/PKGBUILD
@@ -13,13 +13,16 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-boost")
 source=("https://gitlab.com/saalen/highlight/-/archive/v${pkgver}/highlight-v${pkgver}.tar.bz2"
-        "001-fix-installation-prefix-and-destdir.patch")
+        "001-fix-installation-prefix-and-destdir.patch"
+        "002-fix-data-dir-stat.patch")
 sha256sums=('3377562676ce1aadd97648aa0c4e4e85d26db190a090df49587ae8d2471ca851'
-            '13bfb4f326bd890c14c70c0fb30fc1d9ca7a0a8f0712f1c5e946bb59b942f3bb')
+            '13bfb4f326bd890c14c70c0fb30fc1d9ca7a0a8f0712f1c5e946bb59b942f3bb'
+            '6104c02d1adc1728043c4514bb3105e98e693b28b76d9dd1d2711fe47ea6691d')
 
 prepare() {
   cd "$srcdir/${_realname}-v${pkgver}/"
   patch -p1 -i "${srcdir}"/001-fix-installation-prefix-and-destdir.patch
+  patch -p1 -i "${srcdir}"/002-fix-data-dir-stat.patch
 }
 
 build() {

--- a/mingw-w64-highlight/PKGBUILD
+++ b/mingw-w64-highlight/PKGBUILD
@@ -9,7 +9,8 @@ license=('GPL')
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-lua")
+             "${MINGW_PACKAGE_PREFIX}-lua"
+             "${MINGW_PACKAGE_PREFIX}-boost")
 _commit='80c5735e1f2a525c4f85e5f220c6b3c2bb26c063'
 source=("https://gitlab.com/saalen/highlight/-/archive/${_commit}/highlight-${_commit}.tar.gz")
 sha256sums=('6f9ef2fe18f8bbf97c9a5cdff5b3b061f017d7ce00cb9bb34adf0b9b6c0df6fa')

--- a/mingw-w64-highlight/PKGBUILD
+++ b/mingw-w64-highlight/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=highlight
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=4.2
+pkgver=4.3
 pkgrel=1
 url="http://www.andre-simon.de/doku/highlight/highlight.html"
 pkgdesc="Fast and flexible source code highlighter (CLI version)"
@@ -11,17 +11,16 @@ mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-lua"
              "${MINGW_PACKAGE_PREFIX}-boost")
-_commit='80c5735e1f2a525c4f85e5f220c6b3c2bb26c063'
-source=("https://gitlab.com/saalen/highlight/-/archive/${_commit}/highlight-${_commit}.tar.gz")
-sha256sums=('6f9ef2fe18f8bbf97c9a5cdff5b3b061f017d7ce00cb9bb34adf0b9b6c0df6fa')
+source=("https://gitlab.com/saalen/highlight/-/archive/v${pkgver}/highlight-v${pkgver}.tar.bz2")
+sha256sums=('3377562676ce1aadd97648aa0c4e4e85d26db190a090df49587ae8d2471ca851')
 options=('strip')
 
 build() {
-  cd "$srcdir/${_realname}-${_commit}/"
+  cd "$srcdir/${_realname}-v${pkgver}/"
   make
 }
 
 package() {
-  cd "$srcdir/${_realname}-${_commit}/"
+  cd "$srcdir/${_realname}-v${pkgver}/"
   DESTDIR="${pkgdir}" make install
 }

--- a/mingw-w64-highlight/PKGBUILD
+++ b/mingw-w64-highlight/PKGBUILD
@@ -11,16 +11,24 @@ mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-lua"
              "${MINGW_PACKAGE_PREFIX}-boost")
-source=("https://gitlab.com/saalen/highlight/-/archive/v${pkgver}/highlight-v${pkgver}.tar.bz2")
-sha256sums=('3377562676ce1aadd97648aa0c4e4e85d26db190a090df49587ae8d2471ca851')
-options=('strip')
+source=("https://gitlab.com/saalen/highlight/-/archive/v${pkgver}/highlight-v${pkgver}.tar.bz2"
+        "001-fix-installation-prefix-and-destdir.patch")
+sha256sums=('3377562676ce1aadd97648aa0c4e4e85d26db190a090df49587ae8d2471ca851'
+            '13bfb4f326bd890c14c70c0fb30fc1d9ca7a0a8f0712f1c5e946bb59b942f3bb')
+
+prepare() {
+  cd "$srcdir/${_realname}-v${pkgver}/"
+  patch -p1 -i "${srcdir}"/001-fix-installation-prefix-and-destdir.patch
+}
 
 build() {
-  cd "$srcdir/${_realname}-v${pkgver}/"
-  make
+  cp -r "$srcdir/${_realname}-v${pkgver}/" "${srcdir}"/build-${MSYSTEM}
+  cd "${srcdir}"/build-${MSYSTEM}
+
+  make PREFIX=${MINGW_PREFIX}
 }
 
 package() {
-  cd "$srcdir/${_realname}-v${pkgver}/"
-  DESTDIR="${pkgdir}" make install
+  cd "${srcdir}"/build-${MSYSTEM}
+  DESTDIR="${pkgdir}" PREFIX=${MINGW_PREFIX} make install
 }

--- a/mingw-w64-highlight/PKGBUILD
+++ b/mingw-w64-highlight/PKGBUILD
@@ -4,12 +4,13 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=4.3
 pkgrel=1
 url="http://www.andre-simon.de/doku/highlight/highlight.html"
-pkgdesc="Fast and flexible source code highlighter (CLI version)"
-license=('GPL')
+pkgdesc="Fast and flexible source code highlighter (CLI version) (mingw-w64)"
+license=('GPLv3')
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-lua")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-lua"
              "${MINGW_PACKAGE_PREFIX}-boost")
 source=("https://gitlab.com/saalen/highlight/-/archive/v${pkgver}/highlight-v${pkgver}.tar.bz2"
         "001-fix-installation-prefix-and-destdir.patch")

--- a/mingw-w64-highlight/PKGBUILD
+++ b/mingw-w64-highlight/PKGBUILD
@@ -8,7 +8,8 @@ pkgdesc="Fast and flexible source code highlighter (CLI version)"
 license=('GPL')
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
-makedepends=("${MINGW_PACKAGE_PREFIX}-lua")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-lua")
 _commit='80c5735e1f2a525c4f85e5f220c6b3c2bb26c063'
 source=("https://gitlab.com/saalen/highlight/-/archive/${_commit}/highlight-${_commit}.tar.gz")
 sha256sums=('6f9ef2fe18f8bbf97c9a5cdff5b3b061f017d7ce00cb9bb34adf0b9b6c0df6fa')


### PR DESCRIPTION
Didn't use the [latest (stable) version 4.2](https://gitlab.com/saalen/highlight/-/releases)'s `.zip`; went for commit SHA instead since no releases were made since [my upstream MinGW patches](https://gitlab.com/saalen/highlight/-/merge_requests/136).