### PR TITLE
python-cryptography: update to 38.0.1

### DIFF
--- a/mingw-w64-python-cryptography/001-disable-abi3.patch
+++ b/mingw-w64-python-cryptography/001-disable-abi3.patch
@@ -1,7 +1,7 @@
 --- a/setup.py
 +++ b/setup.py
-@@ -45,12 +45,6 @@
-                 "_rust",
+@@ -48,12 +48,6 @@
+                 "cryptography.hazmat.bindings._rust",
                  "src/rust/Cargo.toml",
                  py_limited_api=True,
 -                # Enable abi3 mode if we're not using PyPy.
@@ -10,6 +10,6 @@
 -                    if platform.python_implementation() == "PyPy"
 -                    else ["pyo3/abi3-py36"]
 -                ),
-                 rust_version=">=1.41.0",
+                 rust_version=">=1.48.0",
              )
          ],

--- a/mingw-w64-python-cryptography/PKGBUILD
+++ b/mingw-w64-python-cryptography/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=37.0.4
+pkgver=38.0.1
 pkgrel=1
 pkgdesc="A package designed to expose cryptographic recipes and primitives to Python developers (mingw-w64)"
 url='https://github.com/pyca/cryptography'
@@ -26,8 +26,8 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest-runner"
               "${MINGW_PACKAGE_PREFIX}-python-pytz")
 source=(https://pypi.io/packages/source/c/cryptography/${_realname}-${pkgver}.tar.gz
         001-disable-abi3.patch)
-sha256sums=('63f9c17c0e2474ccbebc9302ce2f07b55b3b3fcb211ded18a42d5764f5c10a82'
-            'b4ea20359fffc77d8923ae84fc5949930d1ab450b5283695703ebb1ed6069f64')
+sha256sums=('1db3d807a14931fa317f96435695d9ec386be7b84b618cc61cfa5d08b0ae33d7'
+            'def2fee53afa97930c98cf1047f496a926bcf538f20972b14fc36facecd4372b')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -38,6 +38,7 @@ prepare() {
 build() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
+  WINAPI_NO_BUNDLED_LIBRARIES=1 \
   ${MINGW_PREFIX}/bin/python setup.py build
 }
 


### PR DESCRIPTION
Fails to build on CLANG64, a similar issue occured before with GNU ld https://github.com/retep998/winapi-rs/issues/539, but I don't know/understand how It was solved.
I have encountered the same issue when updating starship.

@mati865 