### PR TITLE
ecm: remove dependency on png2ico

### DIFF
--- a/mingw-w64-extra-cmake-modules/PKGBUILD
+++ b/mingw-w64-extra-cmake-modules/PKGBUILD
@@ -5,15 +5,14 @@ _realname=extra-cmake-modules
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.98.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Extra CMake modules (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url='https://invent.kde.org/frameworks/extra-cmake-modules'
 license=('LGPL')
 groups=("${MINGW_PACKAGE_PREFIX}-kf5")
-depends=("${MINGW_PACKAGE_PREFIX}-cmake"
-         "${MINGW_PACKAGE_PREFIX}-png2ico")
+depends=("${MINGW_PACKAGE_PREFIX}-cmake")
 makedepends=("${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-python-sphinx"
              "${MINGW_PACKAGE_PREFIX}-python-requests")


### PR DESCRIPTION
Removed two years ago https://invent.kde.org/frameworks/extra-cmake-modules/-/merge_requests/7