### PR TITLE
dosbox: update to 0.79.0

### DIFF
--- a/mingw-w64-dosbox/PKGBUILD
+++ b/mingw-w64-dosbox/PKGBUILD
@@ -4,7 +4,7 @@ _realname=dosbox
 _forkname=dosbox-staging
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.78.1
+pkgver=0.79.0
 pkgrel=1
 pkgdesc="Emulator with builtin DOS for running DOS Games (mingw-w64)"
 arch=('any')
@@ -20,20 +20,22 @@ depends=(
     "${MINGW_PACKAGE_PREFIX}-zlib"
     "${MINGW_PACKAGE_PREFIX}-libslirp"
     "${MINGW_PACKAGE_PREFIX}-munt-mt32emu"
+    "${MINGW_PACKAGE_PREFIX}-speexdsp"
+    "${MINGW_PACKAGE_PREFIX}-iir"
 )
 makedepends=("${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
 source=("https://github.com/dosbox-staging/dosbox-staging/archive/refs/tags/v${pkgver}.tar.gz")
-sha256sums=('dcd93ce27f5f3f31e7022288f7cbbc1f1f6eb7cc7150c2c085eeff8ba76c3690')
+sha256sums=('4c45dff631b6edbcec76f88be6e800b373d0303ef66189a6769a5a18fef106f2')
 
 prepare() {
   cd "${srcdir}/${_forkname}-${pkgver}"
 }
 
 build() {
-  mkdir -p build-${MINGW_CHOST} && cd build-${MINGW_CHOST}
+  mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
 
   declare -a extra_config
   if check_option "debug" "n"; then
@@ -43,27 +45,29 @@ build() {
   fi
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-  meson \
+  ${MINGW_PREFIX}/bin/meson \
     --prefix="${MINGW_PREFIX}" \
     --wrap-mode=nodownload \
     --auto-features=enabled \
     "${extra_config[@]}" \
     -Dunit_tests=disabled \
+    -Dsystem_libraries='fluidsynth','mt32emu','slirp','zlib','iir','speexdsp' \
+    -Ddefault_library=shared \
     ../${_forkname}-${pkgver}
 
-  meson compile
+  ${MINGW_PREFIX}/bin/meson compile
 }
 
 check() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MSYSTEM}"
 
-  meson test
+  ${MINGW_PREFIX}/bin/meson test
 }
 
 package() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MSYSTEM}"
 
-  DESTDIR="${pkgdir}" meson install
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/meson install
 
   install -Dm644 "${srcdir}/${_forkname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-iir/PKGBUILD
+++ b/mingw-w64-iir/PKGBUILD
@@ -1,0 +1,56 @@
+# Contributor: Mehdi Chinoune <mehdi.chinoune@hotmail.com>
+
+_realname=iir
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.9.3
+pkgrel=1
+pkgdesc="DSP IIR realtime filter library written in C++ (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+url='https://github.com/berndporr/iir1'
+license=('MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+source=("https://github.com/berndporr/iir1/archive/${pkgver}/${_realname}1-${pkgver}.tar.gz")
+sha256sums=('de241ef7a3e5ae8e1309846fe820a2e18978aa3df3922bd83c2d75a0fcf4e78f')
+
+prepare() {
+  cd "${srcdir}"/${_realname}1-${pkgver}
+}
+
+build() {
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
+
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    "${MINGW_PREFIX}"/bin/cmake.exe \
+      -GNinja \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      "${extra_config[@]}" \
+      ../${_realname}1-${pkgver}
+
+  "${MINGW_PREFIX}"/bin/cmake.exe --build .
+}
+
+check() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  "${MINGW_PREFIX}"/bin/ctest | true
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
+
+  install -Dm644 "${srcdir}/${_realname}1-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
On GCC base environments the install size has increased a lot (3X~4X):
```diff
  -Download Size   : 1292.46 KiB
  -Installed Size  : 4271.22 KiB
  -Packager        : CI (msys2/msys2-autobuild/3e28396a/1716885985)
  -Build Date      : Wed, Jan 19, 2022  9:20:30 AM
  -Validated By    : MD5 Sum  SHA-256 Sum  Signature
  +Compressed Size : 1604.82 KiB
  +Installed Size  : 154406.62 KiB
```