### PR TITLE
igraph: disable OpenMP support

### DIFF
--- a/mingw-w64-igraph/PKGBUILD
+++ b/mingw-w64-igraph/PKGBUILD
@@ -4,7 +4,7 @@ _realname=igraph
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.10.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Library for the analysis of networks (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -19,8 +19,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-glpk"
          "${MINGW_PACKAGE_PREFIX}-libxml2"
          "${MINGW_PACKAGE_PREFIX}-openblas"
          $([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] && echo \
-           "${MINGW_PACKAGE_PREFIX}-arpack" || echo \
-           "${MINGW_PACKAGE_PREFIX}-openmp"))
+           "${MINGW_PACKAGE_PREFIX}-arpack"))
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
@@ -48,6 +47,7 @@ build() {
         -DIGRAPH_ENABLE_TLS=1 \
         -DIGRAPH_GLPK_SUPPORT=1 \
         -DIGRAPH_GRAPHML_SUPPORT=1 \
+        -DIGRAPH_OPENMP_SUPPORT=OFF \
         -DIGRAPH_WARNINGS_AS_ERRORS=OFF
 
       cmake --build . || cmake --verbose --build .


### PR DESCRIPTION
This PR disables OpenMP support in igraph.

igraph in MSYS2 is currently set up to link to OpenBLAS, both directly and indirectly (through ARPACK). OpenBLAS conflicts with OpenMP, unless it is built specifically to be compatible. Otherwise there is a risk of a hang. See #8399 for details.

To avoid this issue in igraph, we have two choices:

 1. Disable OpenMP
 2. Avoid linking to OpenBLAS (use bundled BLAS or reference BLAS). Since ARPACK in MSYS2 links to OpenBLAS, this means that we must also avoid ARPACK, and use the ARPACK that is bundled with igraph. This is an old version that is less reliable.

The first choice has a smaller impact (fewer igraph functions affected, smaller performance impact, smaller reliability impact), so this is what I recommend.

----

If #8399 is addressed at some point in the future, this change can be reverted. The change I proposed in #8399 has wide impact, so I expect that it will take some time until a decision is reached about it. Until then, it would be nice to have a reliable igraph in MSYS2 that does not hang.