### PR TITLE
zig: update to 0.10.0

### DIFF
--- a/mingw-w64-zig/001-fix-library-prefix-and-suffix.patch
+++ b/mingw-w64-zig/001-fix-library-prefix-and-suffix.patch
@@ -1,0 +1,20 @@
+--- a/lib/std/target.zig
++++ b/lib/std/target.zig
+@@ -1432,6 +1432,8 @@
+     pub fn staticLibSuffix_os_abi(os_tag: Os.Tag, abi: Abi) [:0]const u8 {
+         if (abi == .msvc) {
+             return ".lib";
++        } else if (abi == .gnu) {
++            return ".a";
+         }
+         switch (os_tag) {
+             .windows, .uefi => return ".lib",
+@@ -1450,6 +1452,8 @@
+     pub fn libPrefix_os_abi(os_tag: Os.Tag, abi: Abi) [:0]const u8 {
+         if (abi == .msvc) {
+             return "";
++        } else if (abi == .gnu) {
++            return "lib";
+         }
+         switch (os_tag) {
+             .windows, .uefi => return "",

--- a/mingw-w64-zig/PKGBUILD
+++ b/mingw-w64-zig/PKGBUILD
@@ -1,42 +1,55 @@
 # Maintainer:  Matheus Catarino <matheus-catarino@hotmail.com>
 
-pkgbase=mingw-w64-zig
-pkgname="${MINGW_PACKAGE_PREFIX}-zig"
-pkgver=0.7.1
-pkgrel=3
+_realname=zig
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.10.0
+pkgrel=1
 pkgdesc='Zig is a general-purpose programming language and toolchain for maintaining robust, optimal, and reusable software. (mingw-w64)'
 arch=('any')
-mingw_arch=()
+mingw_arch=('mingw64' 'ucrt64' 'clang64')
 url='https://ziglang.org'
 license=(MIT)
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-lld"
-             )
+             "${MINGW_PACKAGE_PREFIX}-ninja")
 depends=("${MINGW_PACKAGE_PREFIX}-llvm"
-         "${MINGW_PACKAGE_PREFIX}-clang"
-         )
-source=("zig-${pkgver}.tar.gz::https://github.com/ziglang/zig/archive/${pkgver}.tar.gz")
-sha512sums=('ad0b36f7b40481aca03940adfd42d34a724922993fc29a23a80412dc087ca6ce4876a400dc9bb7da455564521a88ea205c218988759ff6c56251a08232bfa41a')
+         "${MINGW_PACKAGE_PREFIX}-clang")
+source=("https://github.com/ziglang/zig/archive/${pkgver}.tar.gz"
+        "001-fix-library-prefix-and-suffix.patch")
+sha256sums=('805a3789776ed2835c41d12139568a406c9827bb8363a70d6f96340a95ffa8f2'
+            'edb3be903a1da351958e2f0b60a8a591a8a568868d6c51d4a933d73e4fd22777')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -p1 -i "${srcdir}"/001-fix-library-prefix-and-suffix.patch
+}
 
 build() {
-  cd ${srcdir}/zig-${pkgver}
-        MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-        ${MINGW_PREFIX}/bin/cmake \
-        -G"MSYS Makefiles" \
-        -DCMAKE_CXX_COMPILER="clang++" \
-        -DCMAKE_C_COMPILER="clang" \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DZIG_PREFER_CLANG_CPP_DYLIB=true \
-        -DZIG_TARGET_TRIPLE="x86_64-windows-gnu" \
-        -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-        -B build-${MINGW_CHOST}
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
-  cmake --build build-${MINGW_CHOST} --config release --parallel
+  declare -a _extra_config
+  if check_option "debug" "n"; then
+    _extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    _extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  CXXFLAGS+=" -fms-extensions" \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake \
+      -G"Ninja" \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      ${_extra_config[@]} \
+      ../${_realname}-${pkgver}
+
+  ${MINGW_PREFIX}/bin/cmake --build .
 }
 
 package() {
-  cd ${srcdir}/zig-${pkgver}/build-${MINGW_CHOST}
+  cd "${srcdir}"/build-${MSYSTEM}
 
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --build . --target install
-  install -Dm644 "../LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/zig/LICENSE"
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
+
+  install -Dm644 "${srcdir}"/${_realname}-${pkgver}/LICENSE "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
 }


### PR DESCRIPTION
Building failed with
```
  [192/195] Building stage2 object C:/_/mingw-w64-zig/src/build-CLANG64/zig2.o
  FAILED: zig2.o C:/_/mingw-w64-zig/src/build-CLANG64/zig2.o 
  cmd.exe /C "cd /D C:\_\mingw-w64-zig\src\zig && C:\_\mingw-w64-zig\src\build-CLANG64\zig1.exe src/stage1.zig --name zig2 --zig-lib-dir C:/_/mingw-w64-zig/src/zig/lib -femit-bin=C:/_/mingw-w64-zig/src/build-CLANG64/zig2.o -fcompiler-rt -target native -mcpu baseline -lc --pkg-begin build_options C:/_/mingw-w64-zig/src/build-CLANG64/config.zig --pkg-end --pkg-begin compiler_rt C:/_/mingw-w64-zig/src/zig/lib/compiler_rt.zig --pkg-end"
  allocation failed
```
This most probably due to (the pinned issue) https://github.com/ziglang/zig/issues/6485
Restricting building jobs to `1` doesn't help.
In my local build It takes about 8~10 GB of RAM which is more than the total RAM of GHA (7 GB).
It fails locally on both CLANG64 and UCRT64 with similar errors
UCRT64:
<details>
  <summary>Click to expand</summary>

```
FAILED: CMakeFiles/stage3 D:/dev/MINGW-packages/mingw-w64-zig/src/build-UCRT64/CMakeFiles/stage3
cmd.exe /C "cd /D D:\dev\MINGW-packages\mingw-w64-zig\src\zig && D:\dev\MINGW-packages\mingw-w64-zig\src\build-UCRT64\zig2.exe build --zig-lib-dir D:/dev/MINGW-packages/mingw-w64-zig/src/zig/lib --prefix /ucrt64 -Dconfig_h=D:/dev/MINGW-packages/mingw-w64-zig/src/build-UCRT64/config.h -Denable-llvm -Denable-stage1 -Drelease -Dstrip -Dskip-install-lib-files=false -Dtarget=native -Dcpu=baseline -Dversion-string=0.10.0-dev.4185+9c2fb6e18"
error(compilation): clang failed with stderr: In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\heap.cpp:8:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/new:92:
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/cstddef:50:9: error: no member named 'nullptr_t' in the global namespace
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\heap.cpp:8:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/new:94:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/exception:85:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/type_traits:452:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__type_traits/is_compound.h:14:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__type_traits/is_fundamental.h:14:
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__type_traits/is_null_pointer.h:24:49: error: use of undeclared identifier 'nullptr_t'
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\heap.cpp:8:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/new:94:
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/exception:149:45: error: field has incomplete type 'std::exception_ptr'
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/exception:144:24: note: definition of 'std::exception_ptr' is not complete until the closing '}'
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/exception:149:5: error: '__abi_tag__' attribute only applies to structs, variables, functions, and namespaces
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__config:650:37: note: expanded from macro '_LIBCPP_INLINE_VISIBILITY'
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__config:634:26: note: expanded from macro '_LIBCPP_HIDE_FROM_ABI'
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\heap.cpp:8:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/new:94:
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/exception:149:55: error: expected ';' at end of declaration list
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\heap.cpp:11:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1/heap.hpp:12:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1/mem.hpp:12:
D:\Programs\msys64_test\ucrt64\include/stdio.h:157:18: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:160:18: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:163:18: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:166:18: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:169:18: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:172:18: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:176:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:180:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:183:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:186:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:189:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:192:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:195:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:198:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:201:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:204:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:208:18: warning: '__format__' attribute argument not supported: ms_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:211:18: warning: '__format__' attribute argument not supported: ms_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:214:18: warning: '__format__' attribute argument not supported: ms_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:218:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:221:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:224:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:227:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:230:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:233:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:264:17: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:275:17: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:289:16: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:300:16: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:311:16: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:328:16: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:335:16: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:342:16: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:356:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:367:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:395:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:408:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:415:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:422:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:450:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:463:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:753:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]

error(compilation): clang failed with stderr: In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\bigint.cpp:8:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1/bigfloat.hpp:12:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1/error.hpp:11:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1/stage2.h:15:
D:\Programs\msys64_test\ucrt64\include/stdio.h:157:18: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:160:18: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:163:18: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:166:18: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:169:18: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:172:18: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:176:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:180:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:183:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:186:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:189:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:192:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:195:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:198:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:201:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:204:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:208:18: warning: '__format__' attribute argument not supported: ms_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:211:18: warning: '__format__' attribute argument not supported: ms_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:214:18: warning: '__format__' attribute argument not supported: ms_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:218:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:221:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:224:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:227:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:230:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:233:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:264:17: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:275:17: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:289:16: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:300:16: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:311:16: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:328:16: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:335:16: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:342:16: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:356:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:367:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:395:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:408:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:415:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:422:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:450:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:463:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\ucrt64\include/stdio.h:753:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\bigint.cpp:15:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/limits:107:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/type_traits:421:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__functional/invoke.h:15:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__type_traits/apply_cv.h:16:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__type_traits/remove_reference.h:13:
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/cstddef:50:9: error: no member named 'nullptr_t' in the global namespace
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\bigint.cpp:15:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/limits:107:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/type_traits:452:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__type_traits/is_compound.h:14:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__type_traits/is_fundamental.h:14:
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__type_traits/is_null_pointer.h:24:49: error: use of undeclared identifier 'nullptr_t'
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\bigint.cpp:16:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/algorithm:1712:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/memory:848:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/allocator.h:18:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/new:94:
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/exception:149:45: error: field has incomplete type 'std::exception_ptr'
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/exception:144:24: note: definition of 'std::exception_ptr' is not complete until the closing '}'
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/exception:149:5: error: '__abi_tag__' attribute only applies to structs, variables, functions, and namespaces
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__config:650:37: note: expanded from macro '_LIBCPP_INLINE_VISIBILITY'
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__config:634:26: note: expanded from macro '_LIBCPP_HIDE_FROM_ABI'
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\bigint.cpp:16:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/algorithm:1712:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/memory:848:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/allocator.h:18:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/new:94:
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/exception:149:55: error: expected ';' at end of declaration list
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\bigint.cpp:16:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/algorithm:1712:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/memory:860:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/shared_ptr.h:28:
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:173:3: error: non-static data member cannot be constexpr; did you intend to make it const?
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__config:689:31: note: expanded from macro '_LIBCPP_CONSTEXPR'
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\bigint.cpp:16:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/algorithm:1712:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/memory:860:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/shared_ptr.h:28:
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:173:32: error: member 'nullptr_t' declared as a template
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:173:42: error: expected ';' at end of declaration list
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:262:25: error: unknown type name 'nullptr_t'
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:395:3: error: non-static data member cannot be constexpr; did you intend to make it const?
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__config:689:31: note: expanded from macro '_LIBCPP_CONSTEXPR'
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\bigint.cpp:16:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/algorithm:1712:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/memory:860:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/shared_ptr.h:28:
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:395:32: error: member 'nullptr_t' declared as a template
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:395:42: error: expected ';' at end of declaration list
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:484:25: error: unknown type name 'nullptr_t'
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:533:14: error: unknown type name 'nullptr_t'
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:533:24: error: cannot initialize a parameter of type 'int' with an rvalue of type 'std::nullptr_t'
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:533:24: note: passing argument to parameter here
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:594:45: error: unknown type name 'nullptr_t'
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:602:12: error: unknown type name 'nullptr_t'
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:610:45: error: unknown type name 'nullptr_t'
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:618:12: error: unknown type name 'nullptr_t'
fatal error: too many errors emitted, stopping now [-ferror-limit=]

D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\heap.cpp:1:1: error: unable to build C object: clang exited with code 1
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\bigint.cpp:1:1: error: unable to build C object: clang exited with code 1
error: zig...
error: The following command exited with error code 1:
D:\dev\MINGW-packages\mingw-w64-zig\src\build-UCRT64\zig2.exe build-exe --stack 33554432 D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1.zig -lc -cflags -std=c++14 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D_GNU_SOURCE -fvisibility-inlines-hidden -fno-exceptions -fno-rtti -Werror=type-limits -Wno-missing-braces -Wno-comment -- D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\analyze.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\astgen.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\bigfloat.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\bigint.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\buffer.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\codegen.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\errmsg.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\error.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\heap.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\ir.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\ir_print.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\mem.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\os.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\parser.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\range_set.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\stage1.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\target.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\tokenizer.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\util.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\softfloat_ext.cpp -cflags -std=c99 -O3 -- D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\parse_f128.c D:\dev\MINGW-packages\mingw-w64-zig\src\zig\zig-cache\o\7c00c1e16bdd6fec2807c161a56239ec\softfloat.lib -lc++ D:\dev\MINGW-packages\mingw-w64-zig\src\build-UCRT64\zigcpp\zigcpp.lib D:\Programs\msys64_test\ucrt64\lib\libclang-cpp.dll.a D:\Programs\msys64_test\ucrt64\lib\liblldMinGW.a D:\Programs\msys64_test\ucrt64\lib\liblldELF.a D:\Programs\msys64_test\ucrt64\lib\liblldCOFF.a D:\Programs\msys64_test\ucrt64\lib\liblldWasm.a D:\Programs\msys64_test\ucrt64\lib\liblldMachO.a D:\Programs\msys64_test\ucrt64\lib\liblldCommon.a -lLLVM-15 -lpsapi -lshell32 -lole32 -luuid -ladvapi32 -lz -lzstd -lxml2 --strip -OReleaseFast --cache-dir D:\dev\MINGW-packages\mingw-w64-zig\src\zig\zig-cache --global-cache-dir C:\Users\mehdi\AppData\Local\zig --name zig -target native-native -mcpu x86_64 --pkg-begin build_options D:\dev\MINGW-packages\mingw-w64-zig\src\zig\zig-cache\options\LCS0va1gUkpCm_xvVNqVwRVInx30Fc7UD1dWM0XFWW-DUEWwAkDmR64FQcNFZanv --pkg-end --pkg-begin compiler_rt D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\empty.zig --pkg-end -I D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src -I D:\dev\MINGW-packages\mingw-w64-zig\src\zig\deps\SoftFloat-3e\source\include -I D:\dev\MINGW-packages\mingw-w64-zig\src\zig\deps\SoftFloat-3e-prebuilt -I D:\Programs\msys64_test\ucrt64\include -D ZIG_LINK_MODE=Static -fno-build-id --zig-lib-dir D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib -fno-lto --enable-cache
error: the following build command failed with exit code 1:
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\zig-cache\o\82d02c7c943034f8c86e5ca411bb850b\build.exe D:\dev\MINGW-packages\mingw-w64-zig\src\build-UCRT64\zig2.exe D:\dev\MINGW-packages\mingw-w64-zig\src\zig D:\dev\MINGW-packages\mingw-w64-zig\src\zig\zig-cache C:\Users\mehdi\AppData\Local\zig --zig-lib-dir D:/dev/MINGW-packages/mingw-w64-zig/src/zig/lib --prefix /ucrt64 -Dconfig_h=D:/dev/MINGW-packages/mingw-w64-zig/src/build-UCRT64/config.h -Denable-llvm -Denable-stage1 -Drelease -Dstrip -Dskip-install-lib-files=false -Dtarget=native -Dcpu=baseline -Dversion-string=0.10.0-dev.4185+9c2fb6e18
ninja: build stopped: subcommand failed.
```

</details>

CLANG64:

<details>
  <summary>Click to expand</summary>

```
FAILED: CMakeFiles/stage3 D:/dev/MINGW-packages/mingw-w64-zig/src/build-CLANG64/CMakeFiles/stage3
cmd.exe /C "cd /D D:\dev\MINGW-packages\mingw-w64-zig\src\zig && D:\dev\MINGW-packages\mingw-w64-zig\src\build-CLANG64\zig2.exe build --zig-lib-dir D:/dev/MINGW-packages/mingw-w64-zig/src/zig/lib --prefix /clang64 -Dconfig_h=D:/dev/MINGW-packages/mingw-w64-zig/src/build-CLANG64/config.h -Denable-llvm -Denable-stage1 -Drelease -Dstrip -Dskip-install-lib-files -Dtarget=native -Dcpu=baseline -Dversion-string=0.10.0-dev.4185+9c2fb6e18"
error(compilation): clang failed with stderr: In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\heap.cpp:8:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/new:92:
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/cstddef:50:9: error: no member named 'nullptr_t' in the global namespace
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\heap.cpp:8:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/new:94:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/exception:85:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/type_traits:452:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__type_traits/is_compound.h:14:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__type_traits/is_fundamental.h:14:
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__type_traits/is_null_pointer.h:24:49: error: use of undeclared identifier 'nullptr_t'
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\heap.cpp:8:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/new:94:
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/exception:149:45: error: field has incomplete type 'std::exception_ptr'
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/exception:144:24: note: definition of 'std::exception_ptr' is not complete until the closing '}'
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/exception:149:5: error: '__abi_tag__' attribute only applies to structs, variables, functions, and namespaces
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__config:650:37: note: expanded from macro '_LIBCPP_INLINE_VISIBILITY'
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__config:634:26: note: expanded from macro '_LIBCPP_HIDE_FROM_ABI'
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\heap.cpp:8:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/new:94:
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/exception:149:55: error: expected ';' at end of declaration list
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\heap.cpp:11:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1/heap.hpp:12:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1/mem.hpp:12:
D:\Programs\msys64_test\clang64\include/stdio.h:157:18: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:160:18: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:163:18: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:166:18: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:169:18: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:172:18: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:176:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:180:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:183:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:186:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:189:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:192:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:195:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:198:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:201:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:204:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:208:18: warning: '__format__' attribute argument not supported: ms_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:211:18: warning: '__format__' attribute argument not supported: ms_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:214:18: warning: '__format__' attribute argument not supported: ms_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:218:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:221:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:224:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:227:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:230:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:233:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:264:17: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:275:17: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:289:16: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:300:16: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:311:16: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:328:16: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:335:16: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:342:16: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:356:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:367:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:395:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:408:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:415:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:422:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:450:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:463:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:753:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]

error(compilation): clang failed with stderr: In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\bigint.cpp:8:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1/bigfloat.hpp:12:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1/error.hpp:11:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1/stage2.h:15:
D:\Programs\msys64_test\clang64\include/stdio.h:157:18: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:160:18: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:163:18: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:166:18: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:169:18: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:172:18: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:176:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:180:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:183:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:186:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:189:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:192:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:195:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:198:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:201:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:204:18: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:208:18: warning: '__format__' attribute argument not supported: ms_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:211:18: warning: '__format__' attribute argument not supported: ms_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:214:18: warning: '__format__' attribute argument not supported: ms_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:218:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:221:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:224:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:227:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:230:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:233:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:264:17: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:275:17: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:289:16: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:300:16: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:311:16: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:328:16: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:335:16: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:342:16: warning: '__format__' attribute argument not supported: gnu_scanf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:356:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:367:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:395:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:408:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:415:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:422:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:450:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:463:16: warning: '__format__' attribute argument not supported: gnu_printf [-Wignored-attributes]
D:\Programs\msys64_test\clang64\include/stdio.h:753:18: warning: '__format__' attribute argument not supported: ms_printf [-Wignored-attributes]
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\bigint.cpp:15:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/limits:107:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/type_traits:421:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__functional/invoke.h:15:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__type_traits/apply_cv.h:16:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__type_traits/remove_reference.h:13:
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/cstddef:50:9: error: no member named 'nullptr_t' in the global namespace
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\bigint.cpp:15:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/limits:107:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/type_traits:452:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__type_traits/is_compound.h:14:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__type_traits/is_fundamental.h:14:
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__type_traits/is_null_pointer.h:24:49: error: use of undeclared identifier 'nullptr_t'
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\bigint.cpp:16:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/algorithm:1712:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/memory:848:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/allocator.h:18:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/new:94:
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/exception:149:45: error: field has incomplete type 'std::exception_ptr'
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/exception:144:24: note: definition of 'std::exception_ptr' is not complete until the closing '}'
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/exception:149:5: error: '__abi_tag__' attribute only applies to structs, variables, functions, and namespaces
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__config:650:37: note: expanded from macro '_LIBCPP_INLINE_VISIBILITY'
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__config:634:26: note: expanded from macro '_LIBCPP_HIDE_FROM_ABI'
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\bigint.cpp:16:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/algorithm:1712:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/memory:848:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/allocator.h:18:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/new:94:
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/exception:149:55: error: expected ';' at end of declaration list
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\bigint.cpp:16:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/algorithm:1712:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/memory:860:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/shared_ptr.h:28:
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:173:3: error: non-static data member cannot be constexpr; did you intend to make it const?
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__config:689:31: note: expanded from macro '_LIBCPP_CONSTEXPR'
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\bigint.cpp:16:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/algorithm:1712:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/memory:860:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/shared_ptr.h:28:
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:173:32: error: member 'nullptr_t' declared as a template
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:173:42: error: expected ';' at end of declaration list
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:262:25: error: unknown type name 'nullptr_t'
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:395:3: error: non-static data member cannot be constexpr; did you intend to make it const?
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__config:689:31: note: expanded from macro '_LIBCPP_CONSTEXPR'
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\bigint.cpp:16:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/algorithm:1712:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/memory:860:
In file included from D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/shared_ptr.h:28:
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:395:32: error: member 'nullptr_t' declared as a template
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:395:42: error: expected ';' at end of declaration list
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:484:25: error: unknown type name 'nullptr_t'
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:533:14: error: unknown type name 'nullptr_t'
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:533:24: error: cannot initialize a parameter of type 'int' with an rvalue of type 'std::nullptr_t'
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:533:24: note: passing argument to parameter here
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:594:45: error: unknown type name 'nullptr_t'
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:602:12: error: unknown type name 'nullptr_t'
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:610:45: error: unknown type name 'nullptr_t'
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib\libcxx\include/__memory/unique_ptr.h:618:12: error: unknown type name 'nullptr_t'
fatal error: too many errors emitted, stopping now [-ferror-limit=]

D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\heap.cpp:1:1: error: unable to build C object: clang exited with code 1
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\bigint.cpp:1:1: error: unable to build C object: clang exited with code 1
error: zig...
error: The following command exited with error code 1:
D:\dev\MINGW-packages\mingw-w64-zig\src\build-CLANG64\zig2.exe build-exe --stack 33554432 D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1.zig -lc -cflags -std=c++14 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D_GNU_SOURCE -fvisibility-inlines-hidden -fno-exceptions -fno-rtti -Werror=type-limits -Wno-missing-braces -Wno-comment -- D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\analyze.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\astgen.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\bigfloat.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\bigint.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\buffer.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\codegen.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\errmsg.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\error.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\heap.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\ir.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\ir_print.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\mem.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\os.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\parser.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\range_set.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\stage1.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\target.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\tokenizer.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\util.cpp D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\softfloat_ext.cpp -cflags -std=c99 -O3 -- D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\stage1\parse_f128.c D:\dev\MINGW-packages\mingw-w64-zig\src\zig\zig-cache\o\7c00c1e16bdd6fec2807c161a56239ec\softfloat.lib -lc++ D:\dev\MINGW-packages\mingw-w64-zig\src\build-CLANG64\zigcpp\zigcpp.lib D:\Programs\msys64_test\clang64\lib\libclang-cpp.dll.a D:\Programs\msys64_test\clang64\lib\liblldMinGW.a D:\Programs\msys64_test\clang64\lib\liblldELF.a D:\Programs\msys64_test\clang64\lib\liblldCOFF.a D:\Programs\msys64_test\clang64\lib\liblldWasm.a D:\Programs\msys64_test\clang64\lib\liblldMachO.a D:\Programs\msys64_test\clang64\lib\liblldCommon.a -lLLVM-15 -lpsapi -lshell32 -lole32 -luuid -ladvapi32 -lz -lzstd -lxml2 --strip -OReleaseFast --cache-dir D:\dev\MINGW-packages\mingw-w64-zig\src\zig\zig-cache --global-cache-dir C:\Users\mehdi\AppData\Local\zig --name zig -target native-native -mcpu x86_64 --pkg-begin build_options D:\dev\MINGW-packages\mingw-w64-zig\src\zig\zig-cache\options\LCS0va1gUkpCm_xvVNqVwRVInx30Fc7UD1dWM0XFWW-DUEWwAkDmR64FQcNFZanv --pkg-end --pkg-begin compiler_rt D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src\empty.zig --pkg-end -I D:\dev\MINGW-packages\mingw-w64-zig\src\zig\src -I D:\dev\MINGW-packages\mingw-w64-zig\src\zig\deps\SoftFloat-3e\source\include -I D:\dev\MINGW-packages\mingw-w64-zig\src\zig\deps\SoftFloat-3e-prebuilt -I D:\Programs\msys64_test\clang64\include -D ZIG_LINK_MODE=Static -fno-build-id --zig-lib-dir D:\dev\MINGW-packages\mingw-w64-zig\src\zig\lib -fno-lto --enable-cache
error: the following build command failed with exit code 1:
D:\dev\MINGW-packages\mingw-w64-zig\src\zig\zig-cache\o\82d02c7c943034f8c86e5ca411bb850b\build.exe D:\dev\MINGW-packages\mingw-w64-zig\src\build-CLANG64\zig2.exe D:\dev\MINGW-packages\mingw-w64-zig\src\zig D:\dev\MINGW-packages\mingw-w64-zig\src\zig\zig-cache C:\Users\mehdi\AppData\Local\zig --zig-lib-dir D:/dev/MINGW-packages/mingw-w64-zig/src/zig/lib --prefix /clang64 -Dconfig_h=D:/dev/MINGW-packages/mingw-w64-zig/src/build-CLANG64/config.h -Denable-llvm -Denable-stage1 -Drelease -Dstrip -Dskip-install-lib-files -Dtarget=native -Dcpu=baseline -Dversion-string=0.10.0-dev.4185+9c2fb6e18
ninja: build stopped: subcommand failed.
```

</details>

Maybe we should report that to zig project!