### PR TITLE
update llvm packages to 15.0.1

### DIFF
--- a/mingw-w64-libc++/PKGBUILD
+++ b/mingw-w64-libc++/PKGBUILD
@@ -8,11 +8,11 @@ _realname=libc++
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-libunwind")
-_version=15.0.0
+_version=15.0.1
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
-pkgrel=2
+pkgrel=1
 url="https://libcxx.llvm.org/"
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -37,15 +37,15 @@ source=("${_url}/llvm-${pkgver}.src.tar.xz"{,.sig}
         "${_url}/libunwind-${pkgver}.src.tar.xz"{,.sig}
         "https://raw.githubusercontent.com/llvm/llvm-project/${_tag}/runtimes/CMakeLists.txt"
         "https://raw.githubusercontent.com/llvm/llvm-project/${_tag}/runtimes/Components.cmake.in")
-sha256sums=('4cd035b665f3be72382b978543d897238c7faa13d13cdd7d573c2e93f23c10d0'
+sha256sums=('0222beed0080fd07f1ee93c5bbeb2e05420b555b9cda725e3a0c299d8cea7cfa'
             'SKIP'
-            '2a3096c6d00f8d2fc588243db1b6a8c283a31e28a02f7e4c435a9a27ccf88e8f'
+            'a660d1b7d4d2ef9759de6ad360d5fa9eed3625a6548068a97df2dd706edf2dd0'
             'SKIP'
-            'd448b21c8994dd9f373b884651df30c367646f773c046f0538c571c95ed46b6e'
+            'ae38506da0835b4df03444293a42a83224aecc694891fc4d18fba0758cb3c1fc'
             'SKIP'
-            'd07c5cf5ced4204ea607e0e0c062d7e12da70c438e94d57a491b749975f381eb'
+            'b9573d41962d5896e2ad613ff82c4524bcd193bb4d170e2a369e864f393f3e53'
             'SKIP'
-            '1c6fbc35ebe6a1c31a938c22fcd6b5a08e4b2ca9eaac12279010e50e3c91560c'
+            '65af59d7cd4672e2c1793402968f803beb3f91a92ad95f8702610a9a07a5ca10'
             'SKIP'
             'a1c9ef5ee90191b64524528703de8000ee66c6f0a5bb7fe02f760e3073d32fde'
             'bc0974b6555874d3c24295fe8b99b25aea8086158ee4ab87e9a8709191cc7824')

--- a/mingw-w64-lldb/PKGBUILD
+++ b/mingw-w64-lldb/PKGBUILD
@@ -7,7 +7,7 @@ fi
 _realname=lldb
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_version=15.0.0
+_version=15.0.1
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
@@ -35,7 +35,7 @@ _url=https://github.com/llvm/llvm-project/releases/download/${_tag}
 _pkgfn=$_realname-$pkgver.src
 source=($_url/$_pkgfn.tar.xz{,.sig}
         002-fix-api-generator-expression.patch)
-sha256sums=('1086b5fae04472a006e1be620bba851ee17b9722cd2cf2ce5b557fc9d9699f11'
+sha256sums=('0393567db6139d9c0f8889b8230491fb4883d7e4753b1dfa79655f148aa230e6'
             'SKIP'
             'ca897429775137be3d0ccaffb95010e4995aa9003c243ff795645ebac2f61fe1')
 validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Google.

--- a/mingw-w64-openmp/PKGBUILD
+++ b/mingw-w64-openmp/PKGBUILD
@@ -7,7 +7,7 @@ fi
 _realname=openmp
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_version=15.0.0
+_version=15.0.1
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
@@ -31,9 +31,9 @@ source=($_url/$_pkgfn.tar.xz{,.sig}
         ${_url}/cmake-${pkgver}.src.tar.xz{,.sig}
         "001-cast-to-make-gcc-happy.patch"
         "002-hacks-for-static-linking.patch")
-sha256sums=('7ee0d1c6a0426a34f102aa5c3a2c307807a4885ce347cb51fbc7e5effd6891c6'
+sha256sums=('d72ba3d777fca3c3b8923fa595d5a3c7d31ae5a5411e3f1d810a7c5398544f0e'
             'SKIP'
-            '2a3096c6d00f8d2fc588243db1b6a8c283a31e28a02f7e4c435a9a27ccf88e8f'
+            'a660d1b7d4d2ef9759de6ad360d5fa9eed3625a6548068a97df2dd706edf2dd0'
             'SKIP'
             '11352ffbe7559a7170f2abd52b3552c877fbcf8fc82cff77b421e8b130a4dd66'
             '7238f009264bc1b162b73ca3a2a0b224b65ec3ed384304f3e5464032c4c026f4')

--- a/mingw-w64-polly/PKGBUILD
+++ b/mingw-w64-polly/PKGBUILD
@@ -7,7 +7,7 @@ fi
 _realname=polly
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_version=15.0.0
+_version=15.0.1
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
@@ -29,9 +29,9 @@ _url=https://github.com/llvm/llvm-project/releases/download/${_tag}
 _pkgfn=$_realname-$pkgver.src
 source=($_url/$_pkgfn.tar.xz{,.sig}
         ${_url}/cmake-${pkgver}.src.tar.xz{,.sig})
-sha256sums=('7ea79e690615475a87beb5fb99c7b7aea89dc7914cc575c3a1950da623247f44'
+sha256sums=('62d55d9da7ba1f4cbdf2f7b1557746c66af7d7c2aa4a15e0b2b7298b7dff0943'
             'SKIP'
-            '2a3096c6d00f8d2fc588243db1b6a8c283a31e28a02f7e4c435a9a27ccf88e8f'
+            'a660d1b7d4d2ef9759de6ad360d5fa9eed3625a6548068a97df2dd706edf2dd0'
             'SKIP')
 validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Google.
               '474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard


### PR DESCRIPTION
This updates:
* libc++
* lldb
* openmp
* polly

Remaining are:
* libclc (still on 14.x so may need more effort)
* mlir (takes a while so better as its own pull request)
* flang (takes a while so better as its own pull request, after mlir)