### PR TITLE
flang: update to 15.0.1

### DIFF
--- a/mingw-w64-flang/PKGBUILD
+++ b/mingw-w64-flang/PKGBUILD
@@ -2,7 +2,7 @@ _compiler=clang
 _realname=flang
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_version=15.0.0
+_version=15.0.1
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
@@ -33,9 +33,9 @@ source=("https://github.com/llvm/llvm-project/releases/download/${_tag}/flang-${
         "0001-cast-cxx11-narrowing.patch"
         "0002-cmake-22162.patch"
         "0003-do-not-link-to-llvm-dylib.patch")
-sha256sums=('f8bb477821fdd88967e195f247e24b674b36f5472a2562aeb284ac2af77a6b6d'
+sha256sums=('3aead6db126344e78d5a9e837206e8960d97e4ab74718a5bebab93f74b6c23b2'
             'SKIP'
-            '2a3096c6d00f8d2fc588243db1b6a8c283a31e28a02f7e4c435a9a27ccf88e8f'
+            'a660d1b7d4d2ef9759de6ad360d5fa9eed3625a6548068a97df2dd706edf2dd0'
             'SKIP'
             'ba08064d737a2aa173125e88c3900dce804220fb0562596b03130177c2139312'
             '77fb0612217b6af7a122f586a9d0d334cd48bb201509bf72e8f8e6244616e895'


### PR DESCRIPTION
Looks like CLANG64 still fails in CI, so will probably require manual building.  Might need to wait for @lazka before merging to avoid breakage in the queue.