### PR TITLE
imagemagick: Fix path relocation

### DIFF
--- a/mingw-w64-imagemagick/001-7.0.4.1-relocate.patch
+++ b/mingw-w64-imagemagick/001-7.0.4.1-relocate.patch
@@ -48,25 +48,25 @@ diff -aur ImageMagick-7.0.1-3/MagickCore/configure.c.orig ImageMagick-7.0.1-3/Ma
  #if defined(MAGICKCORE_INSTALLED_SUPPORT)
  #if defined(MAGICKCORE_SHARE_PATH)
 -  (void) AppendValueToLinkedList(paths,ConstantString(MAGICKCORE_SHARE_PATH));
-+  char *sharedir = single_path_relocation(MAGICKCORE_EXECUTABLE_PATH, MAGICKCORE_SHARE_PATH);
++  char *sharedir = single_path_relocation_lib(MAGICKCORE_EXECUTABLE_PATH, MAGICKCORE_SHARE_PATH);
 +  (void) AppendValueToLinkedList(paths,ConstantString(sharedir));
  #endif
  #if defined(MAGICKCORE_SHAREARCH_PATH)
 -  (void) AppendValueToLinkedList(paths,ConstantString(
 -    MAGICKCORE_SHAREARCH_PATH));
-+  char *sharearchdir = single_path_relocation(MAGICKCORE_EXECUTABLE_PATH, MAGICKCORE_SHAREARCH_PATH);
++  char *sharearchdir = single_path_relocation_lib(MAGICKCORE_EXECUTABLE_PATH, MAGICKCORE_SHAREARCH_PATH);
 +  (void) AppendValueToLinkedList(paths,ConstantString(sharearchdir));
  #endif
  #if defined(MAGICKCORE_CONFIGURE_PATH)
 -  (void) AppendValueToLinkedList(paths,ConstantString(
 -    MAGICKCORE_CONFIGURE_PATH));
-+  char *configdir = single_path_relocation(MAGICKCORE_EXECUTABLE_PATH, MAGICKCORE_CONFIGURE_PATH);
++  char *configdir = single_path_relocation_lib(MAGICKCORE_EXECUTABLE_PATH, MAGICKCORE_CONFIGURE_PATH);
 +  (void) AppendValueToLinkedList(paths,ConstantString(configdir));
  #endif
  #if defined(MAGICKCORE_DOCUMENTATION_PATH)
 -  (void) AppendValueToLinkedList(paths,ConstantString(
 -    MAGICKCORE_DOCUMENTATION_PATH));
-+  char *docdir = single_path_relocation(MAGICKCORE_EXECUTABLE_PATH, MAGICKCORE_DOCUMENTATION_PATH);
++  char *docdir = single_path_relocation_lib(MAGICKCORE_EXECUTABLE_PATH, MAGICKCORE_DOCUMENTATION_PATH);
 +  (void) AppendValueToLinkedList(paths,ConstantString(docdir));
  #endif
 -#if defined(MAGICKCORE_WINDOWS_SUPPORT) && !(defined(MAGICKCORE_CONFIGURE_PATH) || defined(MAGICKCORE_SHARE_PATH))
@@ -86,6 +86,37 @@ diff -aur ImageMagick-7.0.1-3/MagickCore/Makefile.am.orig ImageMagick-7.0.1-3/Ma
    MagickCore/pixel.c \
    MagickCore/pixel.h \
    MagickCore/pixel-accessor.h \
+--- a/MagickCore/magick-config.h
++++ b/MagickCore/magick-config.h
+@@ -155,8 +155,8 @@
+ # if defined (_WIN32) || defined (_WIN64) || defined (__MSDOS__) || defined (__DJGPP__) || defined (__OS2__)
+    /* Use Windows separators on all _WIN32 defining
+       environments, except Cygwin. */
+-#  define MAGICKCORE_DIR_SEPARATOR_CHAR		'\\'
+-#  define MAGICKCORE_DIR_SEPARATOR		"\\"
++#  define MAGICKCORE_DIR_SEPARATOR_CHAR		'/'
++#  define MAGICKCORE_DIR_SEPARATOR		"/"
+ #  define MAGICKCORE_PATH_SEPARATOR_CHAR	';'
+ #  define MAGICKCORE_PATH_SEPARATOR		";"
+ # endif
+@@ -180,7 +180,7 @@ extern "C" {
+ #endif
+  
+ #ifndef MAGICKCORE_MODULES_PATH
+-#  define MAGICKCORE_MODULES_PATH MAGICKCORE_LIBRARY_PATH MAGICKCORE_DIR_SEPARATOR MAGICKCORE_MODULES_DIRNAME
++#  define MAGICKCORE_MODULES_PATH MAGICKCORE_LIBRARY_PATH MAGICKCORE_MODULES_DIRNAME
+ #endif
+  
+ #ifndef MAGICKCORE_MODULES_RELATIVE_PATH
+@@ -219,7 +219,7 @@ extern "C" {
+ #endif
+  
+ #ifndef MAGICKCORE_SHAREARCH_PATH
+-#  define MAGICKCORE_SHAREARCH_PATH MAGICKCORE_LIBRARY_PATH MAGICKCORE_DIR_SEPARATOR MAGICKCORE_SHAREARCH_DIRNAME MAGICKCORE_DIR_SEPARATOR
++#  define MAGICKCORE_SHAREARCH_PATH MAGICKCORE_LIBRARY_PATH MAGICKCORE_SHAREARCH_DIRNAME MAGICKCORE_DIR_SEPARATOR
+ #endif
+  
+ #ifndef MAGICKCORE_SHAREARCH_RELATIVE_PATH
 diff -aur ImageMagick-7.0.1-3/MagickCore/module.c.orig ImageMagick-7.0.1-3/MagickCore/module.c > patch
 --- ImageMagick-7.0.1-3/MagickCore/module.c.orig	2016-05-11 15:53:23 -0400
 +++ ImageMagick-7.0.1-3/MagickCore/module.c	2016-05-11 16:00:26 -0400
@@ -104,7 +135,7 @@ diff -aur ImageMagick-7.0.1-3/MagickCore/module.c.orig ImageMagick-7.0.1-3/Magic
 -      if (module_path == (char *) NULL)
 -        module_path=AcquireString(MAGICKCORE_CODER_PATH);
 +      if (module_path == (char *) NULL) {
-+        char * coderdir = single_path_relocation(MAGICKCORE_EXECUTABLE_PATH, MAGICKCORE_CODER_PATH);
++        char * coderdir = single_path_relocation_lib(MAGICKCORE_EXECUTABLE_PATH, MAGICKCORE_CODER_PATH);
 +        module_path=AcquireString(coderdir);
 +      }
  #endif
@@ -117,7 +148,7 @@ diff -aur ImageMagick-7.0.1-3/MagickCore/module.c.orig ImageMagick-7.0.1-3/Magic
 -      if (module_path == (char *) NULL)
 -        module_path=AcquireString(MAGICKCORE_FILTER_PATH);
 +      if (module_path == (char *) NULL) {
-+        char * coderdir = single_path_relocation(MAGICKCORE_EXECUTABLE_PATH, MAGICKCORE_FILTER_PATH);
++        char * coderdir = single_path_relocation_lib(MAGICKCORE_EXECUTABLE_PATH, MAGICKCORE_FILTER_PATH);
 +        module_path=AcquireString(coderdir);
 +      }
  #endif
@@ -128,13 +159,13 @@ diff -aur ImageMagick-7.0.1-3/MagickCore/module.c.orig ImageMagick-7.0.1-3/Magic
          default:
          {
 -          directory=MAGICKCORE_CODER_PATH;
-+          directory=single_path_relocation(MAGICKCORE_EXECUTABLE_PATH, MAGICKCORE_CODER_PATH);
++          directory=single_path_relocation_lib(MAGICKCORE_EXECUTABLE_PATH, MAGICKCORE_CODER_PATH);
            break;
          }
          case MagickImageFilterModule:
          {
 -          directory=MAGICKCORE_FILTER_PATH;
-+          directory=single_path_relocation(MAGICKCORE_EXECUTABLE_PATH, MAGICKCORE_FILTER_PATH);
++          directory=single_path_relocation_lib(MAGICKCORE_EXECUTABLE_PATH, MAGICKCORE_FILTER_PATH);
            break;
          }
        }

--- a/mingw-w64-imagemagick/PKGBUILD
+++ b/mingw-w64-imagemagick/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
 _basever=7.1.0
 _rc=-39
 pkgver=${_basever}${_rc//-/.} # pkgver doesn't have "," "/", "-" and space.
-pkgrel=5
+pkgrel=6
 pkgdesc="An image viewing/manipulation program (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -74,7 +74,7 @@ sha256sums=('a82c632449a790b6ad78d281b94bdb17a6054ed8afd4f2f21e8304b1f2d2416f'
             'SKIP'
             '703cd0cb74e714f9e66d26de11c109dd76fab07e723af8dde56a35ea65102e5f'
             '4f9d325265ef6f4e90ad637dea41afa6995388c921fe961ad5dc895aca10318b'
-            'c7e800e125720826404d28b65304d39c18b0938465188f5abfd22f1c37c46bd3'
+            '121320efe4120158a0b8216d67fc79b4b200b67e2ee7227d44b5e1f1190e0379'
             '09610fdcecf95dec2c174095bf8cbcdc10ae09e8db558b991c487a23635ffebc'
             '04614b787f9329ea7f6bbd94edd264bbfd0f9b6e1e981a107b181369d425c4b1')
 #Lexie Parsimoniae (ImageMagick code signing key) <lexie.parsimoniae@imagemagick.org>


### PR DESCRIPTION
* Use unix-like directory separator to prevent escaping character.
* Relocate paths with respect to DLL instead of calling executable. This helps to run executable from any directory.

Fixes https://github.com/msys2/MINGW-packages/issues/3444 @kmilos 