### PR TITLE
The gst-plugins-bad wrongly pulls in GPL dependencies, despite saying it is LGPL licensed

### DIFF
--- a/mingw-w64-gst-plugins-bad/PKGBUILD
+++ b/mingw-w64-gst-plugins-bad/PKGBUILD
@@ -27,7 +27,6 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cairo"
   "${MINGW_PACKAGE_PREFIX}-chromaprint"
   "${MINGW_PACKAGE_PREFIX}-curl"
-  "${MINGW_PACKAGE_PREFIX}-faad2"
   "${MINGW_PACKAGE_PREFIX}-faac"
   "${MINGW_PACKAGE_PREFIX}-fdk-aac"
   "${MINGW_PACKAGE_PREFIX}-fluidsynth"
@@ -69,7 +68,6 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-srt"
   "${MINGW_PACKAGE_PREFIX}-vo-amrwbenc"
   "${MINGW_PACKAGE_PREFIX}-webrtc-audio-processing"
-  "${MINGW_PACKAGE_PREFIX}-x265"
   "${MINGW_PACKAGE_PREFIX}-zbar"
 )
 source=(${url}/src/${_realname}/${_realname}-${pkgver}.tar.xz
@@ -143,7 +141,6 @@ build() {
     -Dsvthevcenc=disabled \
     -Dzxing=disabled \
     -Dasio=disabled \
-    -Dgpl=enabled \
     -Dgs=disabled \
     -Disac=disabled \
     -Dldac=disabled \
@@ -184,7 +181,6 @@ package_gst-plugins-bad() {
     "${MINGW_PACKAGE_PREFIX}-cairo"
     "${MINGW_PACKAGE_PREFIX}-chromaprint"
     "${MINGW_PACKAGE_PREFIX}-curl"
-    "${MINGW_PACKAGE_PREFIX}-faad2"
     "${MINGW_PACKAGE_PREFIX}-faac"
     "${MINGW_PACKAGE_PREFIX}-fdk-aac"
     "${MINGW_PACKAGE_PREFIX}-fluidsynth"
@@ -225,7 +221,6 @@ package_gst-plugins-bad() {
     "${MINGW_PACKAGE_PREFIX}-srt"
     "${MINGW_PACKAGE_PREFIX}-vo-amrwbenc"
     "${MINGW_PACKAGE_PREFIX}-webrtc-audio-processing"
-    "${MINGW_PACKAGE_PREFIX}-x265"
     "${MINGW_PACKAGE_PREFIX}-zbar"
     "${MINGW_PACKAGE_PREFIX}-opencv"
   )


### PR DESCRIPTION
The (A)GPL licensed plugins in gst-plugins-bad, according to: https://github.com/freedesktop/gstreamer

    dts (DTS audio decoder plugin)
    faad (Free AAC audio decoder plugin)
    iqa (Image quality assessment plugin based on dssim-c)
    mpeg2enc (MPEG-2 video encoder plugin)
    mplex (audio/video multiplexer plugin)
    ofa (Open Fingerprint Architecture library plugin)
    resindvd (Resin DVD playback plugin)
    x265 (HEVC/H.265 video encoder plugin)

At the moment it wrongly pulls in these two:

faad2
x265 

I'm also not sure why it specifically disabled certain GPL libs, but sets gpl=enabled? I'm guessing the lib-specific disablings are a holdover from before the gpl flag was added.