### PR TITLE
Add `Cflags.private` to fribidi.pc

### DIFF
--- a/mingw-w64-fribidi/PKGBUILD
+++ b/mingw-w64-fribidi/PKGBUILD
@@ -4,7 +4,7 @@ _realname=fribidi
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.0.12
-pkgrel=1
+pkgrel=2
 pkgdesc="A Free Implementation of the Unicode Bidirectional Algorithm (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -12,56 +12,79 @@ license=('LGPL')
 url="https://github.com/fribidi/fribidi/"
 depends=()
 options=('strip' '!libtool' 'staticlibs')
-makedepends=("${MINGW_PACKAGE_PREFIX}-meson"
-             "${MINGW_PACKAGE_PREFIX}-ninja"
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-cc")
-source=(${_realname}-${pkgver}.tar.gz::"https://github.com/fribidi/fribidi/archive/v${pkgver}.tar.gz")
-sha256sums=('2e9e859876571f03567ac91e5ed3b5308791f31cda083408c2b60fa1fe00a39d')
+source=(${_realname}-${pkgver}.tar.gz::"https://github.com/fribidi/fribidi/archive/v${pkgver}.tar.gz"
+        fribidi-add-cflags-private.patch
+        fribidi-disable-doc.patch)
+sha256sums=('2e9e859876571f03567ac91e5ed3b5308791f31cda083408c2b60fa1fe00a39d'
+            '9af5b2c25387f9146b56a79b7cb8ab4c138fe40ad69a4283c069b008b786575b'
+            '3adfbdee6766245b5cb6632805af571069dd26b2a2a238e9fb4e98982d087e32')
+            
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  apply_patch_with_msg \
+   fribidi-add-cflags-private.patch \
+   fribidi-disable-doc.patch
+   
+  autoreconf -fi
+  
+}
 
 build() {
   mkdir -p build-${MSYSTEM}-static
   cd build-${MSYSTEM}-static
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-  ${MINGW_PREFIX}/bin/meson.exe \
-      --prefix=${MINGW_PREFIX} \
-      --buildtype plain \
-      --prefix=${MINGW_PREFIX} \
-       -Ddocs=false \
-       --default-library static \
-      ../${_realname}-${pkgver}
-
-  ${MINGW_PREFIX}/bin/meson.exe compile
+  ../${_realname}-${pkgver}/configure \
+            --prefix=${MINGW_PREFIX} \
+            --build=${MINGW_CHOST} \
+            --host=${MINGW_CHOST} \
+            --target=${MINGW_CHOST} \
+            --enable-static=yes \
+            --enable-shared=no \
+            --enable-debug=no
+ 
+  make
 
   cd ..
   mkdir -p build-${MSYSTEM}-shared
   cd build-${MSYSTEM}-shared
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-  ${MINGW_PREFIX}/bin/meson.exe \
-      --prefix=${MINGW_PREFIX} \
-      --buildtype plain \
-      --prefix=${MINGW_PREFIX} \
-       -Ddocs=false \
-       --default-library shared \
-      ../${_realname}-${pkgver}
-
-  ${MINGW_PREFIX}/bin/meson.exe compile
+  ../${_realname}-${pkgver}/configure \
+            --prefix=${MINGW_PREFIX} \
+            --build=${MINGW_CHOST} \
+            --host=${MINGW_CHOST} \
+            --target=${MINGW_CHOST} \
+            --enable-static=no \
+            --enable-shared=yes \
+            --enable-debug=no
+            
+  make
 }
 
 check() {
   cd build-${MSYSTEM}-shared
 
-  meson test
+  make check
 }
 
 package() {
   cd ${srcdir}/build-${MSYSTEM}-static
-  meson install --destdir="${pkgdir}"
+  make DESTDIR="${pkgdir}/" install
 
   cd ${srcdir}/build-${MSYSTEM}-shared
-  meson install --destdir="${pkgdir}"
+  make DESTDIR="${pkgdir}/" install
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-fribidi/fribidi-add-cflags-private.patch
+++ b/mingw-w64-fribidi/fribidi-add-cflags-private.patch
@@ -1,0 +1,7 @@
+--- ../fribidi.pc.in	2022-04-20 03:47:13.000000000 +0800
++++ ./fribidi.pc.in	2022-10-02 08:59:15.961248300 +0800
+@@ -12,3 +12,4 @@
+ @ENABLE_SHARED_TRUE@Cflags: -I${includedir}/@PACKAGE@
+ @ENABLE_SHARED_TRUE@CFLAGS.private: @FRIBIDI_CPPFLAGS@
+ @ENABLE_SHARED_FALSE@Cflags: -I${includedir}/@PACKAGE@ @FRIBIDI_CPPFLAGS@
++Cflags.private: -DFRIBIDI_LIB_STATIC

--- a/mingw-w64-fribidi/fribidi-disable-doc.patch
+++ b/mingw-w64-fribidi/fribidi-disable-doc.patch
@@ -1,0 +1,21 @@
+--- ../configure.ac	2022-04-20 03:47:13.000000000 +0800
++++ ./configure.ac	2022-10-02 12:31:13.726779200 +0800
+@@ -171,7 +171,6 @@
+ 		 gen.tab/Makefile
+ 		 lib/Makefile
+ 		 bin/Makefile
+-		 doc/Makefile
+ 		 test/Makefile
+ 		 test/unicode-conformance/Makefile])
+ AC_OUTPUT
+--- ../Makefile.am	2022-04-20 03:47:13.000000000 +0800
++++ ./Makefile.am	2022-10-02 12:50:40.140477800 +0800
+@@ -4,7 +4,7 @@
+ ACLOCAL_AMFLAGS = -I m4
+ 
+ ## The order of subdirs is important, don't change without a reason.
+-SUBDIRS = gen.tab lib bin doc test
++SUBDIRS = gen.tab lib bin test
+ 
+ EXTRA_DIST = autogen.sh ChangeLog.old \
+ 	meson.build meson_options.txt bin/meson.build doc/meson.build \


### PR DESCRIPTION
Switch to autotools due to meson's pkgconfg module do not support `Cflags.private`.

Add `Cflags.private: -DFRIBIDI_LIB_STATIC` to `fribidi.pc` should fix `libavfilter.a` link against `libfribidi.dll`.

![fribidi](https://user-images.githubusercontent.com/13523412/193439573-a65563e1-1a50-4f37-831d-d8a412fb0c6b.png)


#8824