### PR TITLE
CI: unset VCPKG_ROOT

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,6 +89,7 @@ jobs:
             . shell ${MSYSTEM,,}
             set -e
           fi
+          unset VCPKG_ROOT
           pacman -S --needed --noconfirm ${MINGW_PACKAGE_PREFIX}-ntldd
           MINGW_ARCH=${{ matrix.msystem }} ./.ci/ci-build.sh
 


### PR DESCRIPTION
Recently GHA started defining VCPKG_ROOT environment variable (https://github.com/actions/runner-images/pull/6192).
So unset it to not let it autodetected and interfere with our build jobs.