### PR TITLE
mingw-w64-riscv64-unknown-elf-newlib: Add support for 'ucrt64' and

### DIFF
--- a/mingw-w64-riscv64-unknown-elf-newlib/PKGBUILD
+++ b/mingw-w64-riscv64-unknown-elf-newlib/PKGBUILD
@@ -3,20 +3,20 @@
 
 _realname=newlib
 _target=riscv64-unknown-elf
-_gccver=10.1.0
+_gccver=12.1.0
 
 pkgbase=mingw-w64-${_target}-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_target}-${_realname}")
 pkgver=3.3.0
-pkgrel=2
+pkgrel=3
 pkgdesc='GNU Tools for RISC-V Embedded Processors - Newlib (mingw-w64)'
 arch=('any')
-mingw_arch=('mingw32' 'mingw64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64')
 url="https://sourceware.org/newlib/"
 license=('Various')
 groups=("${MINGW_PACKAGE_PREFIX}-${_target}-toolchain")
 depends=("${MINGW_PACKAGE_PREFIX}-${_target}-binutils")
-makedepends=("${MINGW_PACKAGE_PREFIX}-autotools")
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools" "${MINGW_PACKAGE_PREFIX}-cc")
 options=('staticlibs' '!strip' '!emptydirs')
 source=(
     "https://sourceware.org/pub/newlib/newlib-${pkgver}.tar.gz"
@@ -24,7 +24,7 @@ source=(
 )
 sha256sums=(
     '58dd9e3eaedf519360d92d84205c3deef0b3fc286685d1c562e245914ef72c66'
-    'b6898a23844b656f1b68691c5c012036c2e694ac4b53a8918d4712ad876e7ea2'
+    '62fd634889f31c02b64af2c468f064b47ad1ca78411c45abe6ac4b5f8dd19c7b'
 )
 noextract=("newlib-${pkgver}.tar.gz")
 
@@ -34,19 +34,19 @@ prepare() {
     tar -xf newlib-${pkgver}.tar.gz
 
     cd ${srcdir}/gcc-${_gccver}
-    mkdir gcc-build-${MINGW_CHOST}
-    mkdir gcc-install-${MINGW_CHOST}
+    mkdir gcc-build-${MSYSTEM}
+    mkdir gcc-install-${MSYSTEM}
 
     cd ${srcdir}/newlib-${pkgver}
-    mkdir {newlib,nano}-build-${MINGW_CHOST}
+    mkdir {newlib,nano}-build-${MSYSTEM}
 }
 
 # Newlib is required to build GCC, but GCC is also required to compile newlib
 # So we must build a minimal GCC first, to avoid the circular dependency
 _build_gcc() {
-    cd ${srcdir}/gcc-${_gccver}/gcc-build-${MINGW_CHOST}
+    cd ${srcdir}/gcc-${_gccver}/gcc-build-${MSYSTEM}
 
-    cp -a ${MINGW_PREFIX}/${_target} ${srcdir}/gcc-${_gccver}/gcc-install-${MINGW_CHOST}
+    cp -a ${MINGW_PREFIX}/${_target} ${srcdir}/gcc-${_gccver}/gcc-install-${MSYSTEM}
 
     local _GCC_LDFLAGS="${LDFLAGS} -Wl,--disable-dynamicbase"
     if [ "${CARCH}" = 'x86_64' ]; then
@@ -80,21 +80,21 @@ _build_gcc() {
         --enable-multilib \
         --with-host-libstdcxx="-static-libgcc -Wl,-Bstatic,-lstdc++,-Bdynamic -lm" \
         --with-sysroot=${MINGW_PREFIX} \
-        --with-build-sysroot=${srcdir}/gcc-${_gccver}/gcc-install-${MINGW_CHOST} \
+        --with-build-sysroot=${srcdir}/gcc-${_gccver}/gcc-install-${MSYSTEM} \
         --with-build-time-tools=${MINGW_PREFIX}/${_target}/bin \
         LDFLAGS="${_GCC_LDFLAGS}"
 
     make all-gcc
-    make DESTDIR=${srcdir}/gcc-${_gccver}/gcc-install-${MINGW_CHOST} install-gcc
+    make DESTDIR=${srcdir}/gcc-${_gccver}/gcc-install-${MSYSTEM} install-gcc
 }
 
 build() {
     _build_gcc
 
-    cd ${srcdir}/newlib-${pkgver}/newlib-build-${MINGW_CHOST}
+    cd ${srcdir}/newlib-${pkgver}/newlib-build-${MSYSTEM}
 
     ../configure \
-        PATH="${srcdir}/gcc-${_gccver}/gcc-install-${MINGW_CHOST}/bin:${PATH}" \
+        PATH="${srcdir}/gcc-${_gccver}/gcc-install-${MSYSTEM}/bin:${PATH}" \
         --build=${MINGW_CHOST} \
         --host=${MINGW_CHOST} \
         --target=${_target} \
@@ -104,12 +104,12 @@ build() {
         --enable-newlib-io-c99-formats \
         --enable-newlib-register-fini \
         --disable-nls
-    make PATH="${srcdir}/gcc-${_gccver}/gcc-install-${MINGW_CHOST}/bin:${PATH}"
+    make PATH="${srcdir}/gcc-${_gccver}/gcc-install-${MSYSTEM}/bin:${PATH}"
 
-    cd ${srcdir}/newlib-${pkgver}/nano-build-${MINGW_CHOST}
+    cd ${srcdir}/newlib-${pkgver}/nano-build-${MSYSTEM}
 
     ../configure \
-        PATH="${srcdir}/gcc-${_gccver}/gcc-install-${MINGW_CHOST}/bin:${PATH}" \
+        PATH="${srcdir}/gcc-${_gccver}/gcc-install-${MSYSTEM}/bin:${PATH}" \
         --build=${MINGW_CHOST} \
         --host=${MINGW_CHOST} \
         --target=${_target} \
@@ -125,22 +125,22 @@ build() {
 		--enable-newlib-nano-formatted-io \
 		--disable-newlib-supplied-syscalls \
         --disable-nls
-    make PATH="${srcdir}/gcc-${_gccver}/gcc-install-${MINGW_CHOST}/bin:${PATH}"
+    make PATH="${srcdir}/gcc-${_gccver}/gcc-install-${MSYSTEM}/bin:${PATH}"
 }
 
 package() {
     cd ${pkgdir}
 
-    cd ${srcdir}/newlib-${pkgver}/nano-build-${MINGW_CHOST}
+    cd ${srcdir}/newlib-${pkgver}/nano-build-${MSYSTEM}
 
-    make DESTDIR=${pkgdir} PATH="${srcdir}/gcc-${_gccver}/gcc-install-${MINGW_CHOST}/bin:${PATH}" install
+    make DESTDIR=${pkgdir} PATH="${srcdir}/gcc-${_gccver}/gcc-install-${MSYSTEM}/bin:${PATH}" install
 
     find ${pkgdir} -regex ".*/lib\(c\|g\|rdimon\|gloss\)\.a" -exec rename .a _nano.a '{}' \;
     install -Dm644 -t ${pkgdir}${MINGW_PREFIX}/${_target}/include/newlib-nano ${pkgdir}${MINGW_PREFIX}/${_target}/include/newlib.h
 
-    cd ${srcdir}/newlib-${pkgver}/newlib-build-${MINGW_CHOST}
+    cd ${srcdir}/newlib-${pkgver}/newlib-build-${MSYSTEM}
 
-    make DESTDIR=${pkgdir} PATH="${srcdir}/gcc-${_gccver}/gcc-install-${MINGW_CHOST}/bin:${PATH}" install
+    make DESTDIR=${pkgdir} PATH="${srcdir}/gcc-${_gccver}/gcc-install-${MSYSTEM}/bin:${PATH}" install
 
     find ${pkgdir}${MINGW_PREFIX}/${_target}/lib \( -name "*.a" -or -name "*.o" \) -exec ${_target}-objcopy -R .comment -R .note -R .debug_info -R .debug_aranges -R .debug_pubnames -R .debug_pubtypes -R .debug_abbrev -R .debug_line -R .debug_str -R .debug_ranges -R .debug_loc '{}' \;
 }


### PR DESCRIPTION
use GCC 12.1.0 to build newlib.