### PR TITLE
gcc: remove libssp static and import lib

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -24,7 +24,7 @@ pkgver=12.2.0
 #_majorver=${pkgver:0:1}
 #_sourcedir=${_realname}-${_majorver}-${_snapshot}
 _sourcedir=${_realname}-${pkgver}
-pkgrel=1
+pkgrel=2
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -342,10 +342,9 @@ package_gcc() {
   cp bin/${MINGW_CHOST}-gcc-nm.exe                      ${pkgdir}${MINGW_PREFIX}/bin/
   cp bin/${MINGW_CHOST}-gcc-ranlib.exe                  ${pkgdir}${MINGW_PREFIX}/bin/
 
-  #cp bin/{libgcc*,libgomp*,libquadmath*,libssp*,libstdc*}.dll ${pkgdir}${MINGW_PREFIX}/bin/
+  #cp bin/{libgcc*,libgomp*,libquadmath*,libstdc*}.dll ${pkgdir}${MINGW_PREFIX}/bin/
   mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/include
   cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/include/*.h        ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/include/
-  cp -r lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/include/ssp     ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/include/
   cp -r lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/include-fixed   ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
   cp -r lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/install-tools   ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
   #cp -r lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/plugin          ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
@@ -365,7 +364,6 @@ package_gcc() {
   cp lib/libgomp*                                        ${pkgdir}${MINGW_PREFIX}/lib/
   # cp lib/libitm*                                         ${pkgdir}${MINGW_PREFIX}/lib/
   cp lib/libquadmath*                                    ${pkgdir}${MINGW_PREFIX}/lib/
-  cp lib/libssp*                                         ${pkgdir}${MINGW_PREFIX}/lib/
   # cp lib/libvtv*                                         ${pkgdir}${MINGW_PREFIX}/lib/
   cp lib/libstdc++*                                      ${pkgdir}${MINGW_PREFIX}/lib/
   cp lib/libsupc++*                                      ${pkgdir}${MINGW_PREFIX}/lib/


### PR DESCRIPTION
but still provide the .DLL.

In combination with #13405 this will make all rebuilds link the libssp stuff against the crt while keeping existing packages already linking against the .DLL working until we rebuild them.

This is an alternative to #13410