### PR TITLE
vlc: remove implicit dependency on libssp

### DIFF
--- a/mingw-w64-vlc/PKGBUILD
+++ b/mingw-w64-vlc/PKGBUILD
@@ -11,7 +11,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 pkgver=3.0.17.4
-pkgrel=3
+pkgrel=4
 pkgdesc="A multi-platform MPEG, VCD/DVD, and DivX player (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -214,15 +214,14 @@ prepare() {
 }
 
 build() {
-  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
-  mkdir -p ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
+  [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}
+  mkdir -p ${srcdir}/build-${MSYSTEM} && cd ${srcdir}/build-${MSYSTEM}
 
   # Hack getting private QtGui directory
   local _qtver=$(qmake -query QT_VERSION)
   local _qtguiinc=$(pkg-config Qt5Gui --variable=includedir)
   local _privdir=${_qtguiinc}/QtGui/${_qtver}/QtGui
   CPPFLAGS+=" -I${_privdir}"
-  LDFLAGS+=" -fstack-protector"
 
   # Workaround multiple definitions of GUIDs
   LDFLAGS+=" -Wl,--allow-multiple-definition"
@@ -299,7 +298,6 @@ build() {
   # --enable-mmx \
 
   else
-    LIBS=" -lssp" \
     BUILDCC="${CC}" \
     ${srcdir}/${_realname}-${pkgver}/configure \
       --prefix=${MINGW_PREFIX} \
@@ -326,7 +324,7 @@ build() {
 }
 
 package() {
-  cd ${srcdir}/build-${MINGW_CHOST}
+  cd ${srcdir}/build-${MSYSTEM}
 
   #todo: fix install for winrt build
   make DESTDIR="${pkgdir}" install


### PR DESCRIPTION
It was provided through libdsm