### PR TITLE
qemu: remove dependency on libssp

### DIFF
--- a/mingw-w64-ninja/PKGBUILD
+++ b/mingw-w64-ninja/PKGBUILD
@@ -4,7 +4,7 @@ _realname=ninja
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.11.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Ninja is a small build system with a focus on speed (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -13,8 +13,16 @@ license=('Apache')
 depends=()
 options=('strip' 'staticlibs')
 makedepends=("re2c" "${MINGW_PACKAGE_PREFIX}-python" "${MINGW_PACKAGE_PREFIX}-cc")
-source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/ninja-build/ninja/archive/v${pkgver}.tar.gz")
-sha256sums=('31747ae633213f1eda3842686f83c2aa1412e0f5691d1c14dbbcc67fe7400cea')
+source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/ninja-build/ninja/archive/v${pkgver}.tar.gz"
+        "001-Handle-ERROR_DIRECTORY-when-calling-FindFirstFileExA.patch"::"https://patch-diff.githubusercontent.com/raw/ninja-build/ninja/pull/2160.patch")
+sha256sums=('31747ae633213f1eda3842686f83c2aa1412e0f5691d1c14dbbcc67fe7400cea'
+            '855623ffb3199ed5a0a0f750a05f67a9d3285129c1b8e66d045c56bd7d471838')
+
+prepare() {
+  cd "${srcdir}"/ninja-${pkgver}
+  # https://github.com/ninja-build/ninja/pull/2160
+  patch -p1 -i "${srcdir}"/001-Handle-ERROR_DIRECTORY-when-calling-FindFirstFileExA.patch
+}
 
 build() {
   mkdir -p "${pkgdir}${MINGW_PREFIX}"/bin

--- a/mingw-w64-qemu/PKGBUILD
+++ b/mingw-w64-qemu/PKGBUILD
@@ -15,7 +15,7 @@ _rc_base_ver="7.0.9${_rc_no}"
 _rc_file_ver="rc${_rc_no}"
 _tarname=$( [ -z "${_rc_no}" ] && echo ${_realname}-${_base_ver} || echo ${_realname}-${_base_ver}-${_rc_file_ver} )
 pkgver=$( [ -z "${_rc_no}" ] && echo ${_base_ver} || echo ${_rc_base_ver} )
-pkgrel=1
+pkgrel=2
 pkgdesc="QEMU - a generic and open source machine emulator and virtualizer (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -30,8 +30,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-sphinx_rtd_theme"
   "${MINGW_PACKAGE_PREFIX}-autotools"
   "${MINGW_PACKAGE_PREFIX}-tools-git"
-  "${MINGW_PACKAGE_PREFIX}-cc"
-  'perl' 'bison' 'bsdtar')
+  "${MINGW_PACKAGE_PREFIX}-cc")
 depends=(
   "${MINGW_PACKAGE_PREFIX}-capstone"
   "${MINGW_PACKAGE_PREFIX}-curl"
@@ -67,7 +66,6 @@ depends=(
   "${MINGW_PACKAGE_PREFIX}-libslirp"
   "${MINGW_PACKAGE_PREFIX}-libssh"
   "${MINGW_PACKAGE_PREFIX}-libssh2"
-  "${MINGW_PACKAGE_PREFIX}-libssp"
   "${MINGW_PACKAGE_PREFIX}-libtasn1"
   "${MINGW_PACKAGE_PREFIX}-libthai"
   "${MINGW_PACKAGE_PREFIX}-libtiff"
@@ -120,7 +118,6 @@ prepare() {
 }
 
 build() {
-  LDFLAGS+=" -fstack-protector"
   [[ -d "${srcdir}"/build-${MSYSTEM} ]] && rm -rf "${srcdir}"/build-${MSYSTEM}
   mkdir -pv "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
 


### PR DESCRIPTION
Fails at packaging:
```
==> Starting package_mingw-w64-clang-x86_64-qemu()...
ninja: error: FindFirstFileExA(D:/M/msys64/clang64/bin/sphinx-build.EXE): The directory name is invalid.


make: *** [Makefile:162: run-ninja] Error 1
==> ERROR: A failure occurred in package_mingw-w64-clang-x86_64-qemu().
```