### PR TITLE
libgpg-error: update to 1.46

### DIFF
--- a/mingw-w64-libgpg-error/PKGBUILD
+++ b/mingw-w64-libgpg-error/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libgpg-error
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.45
+pkgver=1.46
 pkgrel=1
 pkgdesc="Support library for libgcrypt (mingw-w64)"
 arch=('any')
@@ -23,7 +23,7 @@ validpgpkeys=('5B80C5754298F0CB55D8ED6ABCEF7E294B092E28'  # Andre Heinecke (Rele
               '6DAA6E64A76D2840571B4902528897B826403ADA'  # Werner Koch (dist signing 2020)
               'AC8E115BF73E2D8D47FA9908E98E9B2D19C6C8BD'  # Niibe Yutaka (GnuPG Release Key)
               '02F38DFF731FF97CB039A1DA549E695E905BA208') # GnuPG.com (Release Signing Key 2021)
-sha256sums=('570f8ee4fb4bff7b7495cff920c275002aea2147e9a1d220c068213267f80a26'
+sha256sums=('b7e11a64246bbe5ef37748de43b245abd72cfcd53c9ae5e7fc5ca59f1c81268d'
             'SKIP'
             '364da17febff3f6eeffee5a5f1e3ed1b644adeb5ca48a972c5c4675c10238a91'
             '9ccdc567810d58526888fd11c5f7d01101627011840b7b75a91e96aa9e71f49d'


### PR DESCRIPTION
This updates libgpg-error to 1.46.