### PR TITLE
crt: replaces/conflicts libssp

### DIFF
--- a/mingw-w64-crt-git/PKGBUILD
+++ b/mingw-w64-crt-git/PKGBUILD
@@ -4,7 +4,7 @@ _realname=crt
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 pkgver=10.0.0.r105.gee5758234
-pkgrel=2
+pkgrel=3
 _commit='ee5758234f77a6b573e415b26a1d387c46717f6b'
 pkgdesc='MinGW-w64 CRT for Windows'
 arch=('any')
@@ -18,7 +18,8 @@ makedepends=("git"
              "${MINGW_PACKAGE_PREFIX}-binutils"
              "${MINGW_PACKAGE_PREFIX}-autotools")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-libssp")
+replaces=("${MINGW_PACKAGE_PREFIX}-libssp")
 options=('!strip' 'staticlibs' '!buildflags' '!emptydirs')
 source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64#commit=$_commit"
         0001-Allow-to-use-bessel-and-complex-functions-without-un.patch


### PR DESCRIPTION
Up until now a full upgrade would result in libssp being updated to a version that only has the DLLs left, but the packages got removed from the repo now, so users upgrading after the removal will get a conflict with the now no-longer-in-the-repo package.

Replace/conflict with it so it gets automatically uninstalled on a system upgrade.

Fixes #13534