### PR TITLE
libgpg-error: Install gpg-error-config script explicitly

### DIFF
--- a/mingw-w64-libgpg-error/PKGBUILD
+++ b/mingw-w64-libgpg-error/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libgpg-error
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.46
-pkgrel=1
+pkgrel=2
 pkgdesc="Support library for libgcrypt (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -47,6 +47,7 @@ build() {
       --build=${MINGW_CHOST} \
       --host=${MINGW_CHOST} \
       --target=${MINGW_CHOST} \
+      --enable-install-gpg-error-config \
       --enable-shared \
       --enable-static
 


### PR DESCRIPTION
This is required for old packages like libbdplus.
Fixes https://github.com/msys2/MINGW-packages/issues/13539