### PR TITLE
waf: default compilers to the corresponding package MinGW system

### DIFF
--- a/mingw-w64-waf/PKGBUILD
+++ b/mingw-w64-waf/PKGBUILD
@@ -4,7 +4,7 @@ _realname=waf
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.0.20
-pkgrel=5
+pkgrel=6
 pkgdesc="General-purpose build system modelled after Scons (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -37,7 +37,15 @@ build() {
 package() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
+  prelude=$(cat <<'EOF'
+	import waflib.Tools.compiler_c, waflib.Tools.compiler_cxx
+	waflib.Tools.compiler_c.c_compiler['win32'] = ['gcc', 'clang', 'msvc']
+	waflib.Tools.compiler_cxx.cxx_compiler['win32'] = ['g++', 'clang++', 'msvc']
+EOF
+  )
+
   ${MINGW_PREFIX}/bin/python ./waf-light install -f --destdir="${pkgdir}" \
+    --prelude="${prelude}" \
     --tools='compat,compat15,ocaml,go,cython,scala,erlang,cuda,gcj,boost,pep8,eclipse,unity,clang_compilation_database'
 
   install -Dm755 waf "${pkgdir}${MINGW_PREFIX}/bin/waf"


### PR DESCRIPTION
Currently, when running mingw64/waf on a default install, waf will use the default C and C++ compilers for the win32 platform configured in waf, which are [msvc, gcc, clang] and [msvc, g++, clang++].

This means that waf tries to use msvc first when compiling waf projects. This is not what the user want: instead, it should use the appropriate MinGW system compiler, eg gcc on mingw64.

This currently requires the user to work around the issue by systematically adding --check-c-compiler to point waf to the appropriate compiler depending on the MinGW system, eg gcc on mingw64.

This patch fixes the issue by changing the default C and C++ compiler order in waf, to move the corresponding MinGW compiler to the head of the list. For example, on the mingw32 and mingw64 architectures, gcc should be used first instead of msvc.

This is done by using the preamble build-time option of waf which enables users to add a small Python preamble that is evaluated for every project before their wscript file. In this preamble, we update the c_compiler and cxx_compiler values.