### PR TITLE
openblas: remove -Os workaround for aarch64

### DIFF
--- a/mingw-w64-openblas/PKGBUILD
+++ b/mingw-w64-openblas/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-openblas
 pkgname=("${MINGW_PACKAGE_PREFIX}-openblas"
          $([[ "${CARCH}" == "i686" ]] || echo "${MINGW_PACKAGE_PREFIX}-openblas64"))
 pkgver=0.3.21
-pkgrel=4
+pkgrel=5
 pkgdesc="An optimized BLAS library based on GotoBLAS2 1.13 BSD, providing optimized blas, lapack, and cblas (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -71,13 +71,6 @@ _build_openblas() {
     _build_type="Release"
   else
     _build_type="Debug"
-  fi
-
-  # https://github.com/msys2/MINGW-packages/issues/13128
-  # MinSizeRel sets -Os, which seems to work around the compiler crash
-  # at least with the provided reproducer
-  if [[ ${MINGW_PACKAGE_PREFIX} == *-aarch64 ]]; then
-    _build_type="MinSizeRel"
   fi
 
   declare _c_lapack_opt


### PR DESCRIPTION
this should no longer be required since #13666