### PR TITLE
fftw: fix editing of cmake config files

### DIFF
--- a/mingw-w64-fftw/PKGBUILD
+++ b/mingw-w64-fftw/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _pkgver=3.3.10
 pkgver=${_pkgver//-/.}
-pkgrel=3
+pkgrel=4
 pkgdesc="A library for computing the discrete Fourier transform (DFT) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -97,8 +97,6 @@ build() {
 }
 
 package() {
-  local _SRC_PREFIX=$(cygpath -am ${srcdir}/${_realname}-${_pkgver})
-
   for cur in ${precision}; do
     msg "Installing ${_realname} for ${cur} precision ..."
     cd "${srcdir}"/build-${MSYSTEM}-${cur}
@@ -126,8 +124,9 @@ package() {
         _file_prefix=FFTW3q
         ;;
     esac
-    sed -e "s|IMPORTED_IMPLIB_RELEASE \"${_SRC_PREFIX}|IMPORTED_IMPLIB_RELEASE \"${MINGW_PREFIX}/lib|g" -i ./FFTW3LibraryDepends.cmake
-    sed -e "s|IMPORTED_LOCATION_RELEASE \"${_SRC_PREFIX}|IMPORTED_LOCATION_RELEASE \"${MINGW_PREFIX}/bin|g" -i ./FFTW3LibraryDepends.cmake
+    local _staging_prefix=$(cygpath -am ${srcdir}/build-${MSYSTEM}-${cur})
+    sed -e "s|IMPORTED_IMPLIB_RELEASE \"${_staging_prefix}|IMPORTED_IMPLIB_RELEASE \"${MINGW_PREFIX}/lib|g" -i ./FFTW3LibraryDepends.cmake
+    sed -e "s|IMPORTED_LOCATION_RELEASE \"${_staging_prefix}|IMPORTED_LOCATION_RELEASE \"${MINGW_PREFIX}/bin|g" -i ./FFTW3LibraryDepends.cmake
     install -Dm644 ./FFTW3LibraryDepends.cmake "${pkgdir}"${MINGW_PREFIX}/lib/cmake/${_prec_prefix}/FFTW3LibraryDepends.cmake
     mv "${pkgdir}"${MINGW_PREFIX}/lib/cmake/fftw3/${_file_prefix}*.cmake "${pkgdir}"${MINGW_PREFIX}/lib/cmake/${_prec_prefix}/
   done


### PR DESCRIPTION
The cmake config files installed with the current release of the `fftw` package contain hardcoded paths to the staging directory:
```
# Import target "FFTW3::fftw3" for configuration "Release"
set_property(TARGET FFTW3::fftw3 APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
set_target_properties(FFTW3::fftw3 PROPERTIES
  IMPORTED_IMPLIB_RELEASE "C:/M/mingw-w64-fftw/src/build-MINGW64-double/libfftw3.dll.a"
  IMPORTED_LOCATION_RELEASE "C:/M/mingw-w64-fftw/src/build-MINGW64-double/libfftw3.dll"
  )
```

The result is that attempting to use this package in a CMakeLists file,
```
find_package(FFTW3 REQUIRED)
target_link_libraries(myproject_exe PRIVATE FFTW3::fftw3)
```
results in an error
```
*** No rule to make target 'C:/M/mingw-w64-fftw/src/build-MINGW64-double/libfftw3.dll.a', needed by 'room.exe'.  Stop.
```

There are sed scripts in our PKGBUILD that are intended to replace these paths (see #11919), but they miss their mark. This small PR just fixes the patterns in those sed scripts.
