### PR TITLE
flac: Update to 1.4.2

### DIFF
--- a/mingw-w64-flac/PKGBUILD
+++ b/mingw-w64-flac/PKGBUILD
@@ -3,23 +3,21 @@
 _realname=flac
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.4.1
+pkgver=1.4.2
 pkgrel=1
 pkgdesc="Free Lossless Audio Codec (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
-url="https://flac.sourceforge.io/"
+url="https://xiph.org/flac/"
 license=('custom:Xiph' 'LGPL' 'GPL' 'FDL')
 depends=("${MINGW_PACKAGE_PREFIX}-libogg"
          "${MINGW_PACKAGE_PREFIX}-gettext"
          "${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-ninja"
-             $( [[ "${CARCH}" == "aarch64" ]] \
-                || echo "${MINGW_PACKAGE_PREFIX}-nasm" ))
+             "${MINGW_PACKAGE_PREFIX}-ninja")
 source=("https://downloads.xiph.org/releases/flac/flac-${pkgver}.tar.xz")
-sha256sums=('91303c3e5dfde52c3e94e75976c0ab3ee14ced278ab8f60033a3a12db9209ae6')
+sha256sums=('e322d58a1f48d23d9dd38f432672865f6f79e73a6f9cc5a5f57fcaa83eb5a8e4')
 
 build() {
   declare -a _extra_config
@@ -41,7 +39,6 @@ build() {
     -DBUILD_DOCS=OFF \
     -DBUILD_SHARED_LIBS=OFF \
     -DBUILD_TESTING=OFF \
-    -DWITH_STACK_PROTECTOR=OFF \
     ../${_realname}-${pkgver}
 
   ${MINGW_PREFIX}/bin/cmake.exe --build ./
@@ -58,7 +55,6 @@ build() {
     -DBUILD_DOCS=OFF \
     -DBUILD_SHARED_LIBS=ON \
     -DBUILD_TESTING=OFF \
-    -DWITH_STACK_PROTECTOR=OFF \
     ../${_realname}-${pkgver}
 
   ${MINGW_PREFIX}/bin/cmake.exe --build ./


### PR DESCRIPTION
https://xiph.org/flac/changelog.html

* No longer depends on nasm
* stack protector works now, so stop disabling it