### PR TITLE
mcfgthread: Add `!buildflags` in options

### DIFF
--- a/mingw-w64-mcfgthread/PKGBUILD
+++ b/mingw-w64-mcfgthread/PKGBUILD
@@ -5,12 +5,12 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}"-libs)
 pkgver=1.2
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 url="https://github.com/lhmouse/mcfgthread"
 license=('spdx:LGPL-3.0-or-later' 'custom')
-options=('staticlibs' 'strip')
+options=('staticlibs' 'strip' '!buildflags')
 _commit='cfd68c8df854191cabdd172598b5032a1ab3163f'
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cc"
@@ -33,7 +33,7 @@ build() {
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
   mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
 
-  export CFLAGS+=' -Os'
+  export CFLAGS+=' -Os -g'
 
   ../${_realname}/configure \
     --prefix=${MINGW_PREFIX} \


### PR DESCRIPTION
Recently, `-D_FORTIFY_SOURCE=2` has been added into the default CFLAGS. As thislibrary has to be built before the CRT, where those overflow checking routines have not been available, it is necessary to build without default flags.