### PR TITLE
gspell: remove no longer used iso-codes dependency

### DIFF
--- a/mingw-w64-gspell/PKGBUILD
+++ b/mingw-w64-gspell/PKGBUILD
@@ -4,13 +4,12 @@ _realname=gspell
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.12.0
-pkgrel=2
+pkgrel=3
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 pkgdesc="Spell-checking library for GTK applications (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-gtk3"
          "${MINGW_PACKAGE_PREFIX}-icu"
-         "${MINGW_PACKAGE_PREFIX}-iso-codes"
          "${MINGW_PACKAGE_PREFIX}-enchant")
 makedepends=("${MINGW_PACKAGE_PREFIX}-vala"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"


### PR DESCRIPTION
gspell has changed several releases ago its iso-codes dependency to use icu instead.