### PR TITLE
CI: test building with a larger pagefile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,14 @@ jobs:
           .\procdump64.exe -accepteula -ma -i "${{ runner.temp }}/_dumps"
           .\procdump.exe -accepteula -ma -i "${{ runner.temp }}/_dumps"
 
+      - name: Configure Pagefile
+        if: ${{ matrix.msystem != 'CLANGARM64' }}
+        uses: al-cheb/configure-pagefile-action@86589fd789a4de3e62ba628dda2cb10027b66d67
+        with:
+          minimum-size: 4GB
+          maximum-size: 16GB
+          disk-root: "C:"
+
       - uses: actions/checkout@v3
         with:
           path: temp


### PR DESCRIPTION
It defaults to 1.8GB, bump it a bit so we can build
flang under clang64 which otherwise hits OOM

Use C: since we have 95GB free there and only 12GB on D: