### PR TITLE
igraph: enable openmp support for mingw32 again

### DIFF
--- a/mingw-w64-igraph/PKGBUILD
+++ b/mingw-w64-igraph/PKGBUILD
@@ -4,7 +4,7 @@ _realname=igraph
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.10.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Library for the analysis of networks (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -36,10 +36,6 @@ build() {
     _extra_config+=("-DCMAKE_BUILD_TYPE=Release")
   else
     _extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
-  fi
-
-  if [[ ${MSYSTEM} == MINGW32 ]]; then
-    _extra_config+=("-DIGRAPH_OPENMP_SUPPORT=OFF")
   fi
 
   for libtype in 'static' 'shared'; do


### PR DESCRIPTION
now that openblas is built with openmp support it should no longer be broken, see
https://github.com/msys2/MINGW-packages/pull/13267#issuecomment-1295254523