### PR TITLE
Create a virtual package for OpenMP - Part1

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -24,7 +24,7 @@ pkgver=12.2.0
 #_majorver=${pkgver:0:1}
 #_sourcedir=${_realname}-${_majorver}-${_snapshot}
 _sourcedir=${_realname}-${pkgver}
-pkgrel=4
+pkgrel=5
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -271,7 +271,8 @@ package_gcc-libs() {
            "${MINGW_PACKAGE_PREFIX}-mpc"
            "${MINGW_PACKAGE_PREFIX}-mpfr"
            "${MINGW_PACKAGE_PREFIX}-libwinpthread")
-  provides=("${MINGW_PACKAGE_PREFIX}-libssp")
+  provides=("${MINGW_PACKAGE_PREFIX}-libssp"
+            "${MINGW_PACKAGE_PREFIX}-omp")
 
   # Licensing information
 
@@ -422,6 +423,7 @@ package_gcc-fortran() {
   pkgdesc="GNU Compiler Collection (Fortran) for MinGW-w64"
   depends=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}-${pkgrel}"
            "${MINGW_PACKAGE_PREFIX}-${_realname}-libgfortran=${pkgver}-${pkgrel}")
+  provides=("${MINGW_PACKAGE_PREFIX}-fc")
 
   mkdir -p ${pkgdir}${MINGW_PREFIX}/{bin,lib,share}
 


### PR DESCRIPTION
Also provides a virtual package for Fortran Compiler "fc".

I have chosen `omp` because `openmp` is already the name of LLVM OpenMP.
Should we create a separate package `libgomp` or leave it as it is and make `gcc-libs` provides `omp`.

