### PR TITLE
Create a virtual package for Fortran Compiler.

### DIFF
--- a/mingw-w64-flang/PKGBUILD
+++ b/mingw-w64-flang/PKGBUILD
@@ -6,12 +6,13 @@ _version=15.0.3
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
-pkgrel=1
+pkgrel=2
 pkgdesc="Fortran frontend for LLVM (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
 url="https://flang.llvm.org/"
 license=("custom:Apache 2.0 with LLVM Exception")
+provides=($([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-fc"))
 depends=("${MINGW_PACKAGE_PREFIX}-clang"
          "${MINGW_PACKAGE_PREFIX}-llvm"
          "${MINGW_PACKAGE_PREFIX}-mlir")
@@ -126,4 +127,5 @@ check() {
 
 package() {
   DESTDIR="${pkgdir}" cmake --install "${srcdir}/build-${MSYSTEM}"
+  cp "${pkgdir}"${MINGW_PREFIX}/bin/flang-new "${pkgdir}"${MINGW_PREFIX}/bin/flang.exe
 }


### PR DESCRIPTION
I have also copied flang-new to flang so It could be detected by CMake without setting `FC` env or `CMAKE_Fortran_COMPILER`.