### PR TITLE
verilator: update to 5.002

### DIFF
--- a/mingw-w64-verilator/PKGBUILD
+++ b/mingw-w64-verilator/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=verilator
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.228
+pkgver=5.002
 pkgrel=1
 pkgdesc="The fastest free Verilog HDL simulator (mingw-w64)"
 arch=('any')
@@ -20,7 +20,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 source=(
   "${_realname}.tar.gz::https://codeload.github.com/${_realname}/${_realname}/tar.gz/v${pkgver}"
 )
-sha256sums=('be6af6572757013802be5b0ff9c64cbf509e98066737866abaae692fe04edf09')
+sha256sums=('72d68469fc1262e6288d099062b960a2f65e9425bdb546cba141a2507decd951')
 
 prepare() {
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"


### PR DESCRIPTION
Verilator 5 was released: https://github.com/verilator/verilator-announce/issues/57