### PR TITLE
make[critical]: Fix bad timestamps on mingw32

### DIFF
--- a/mingw-w64-make/PKGBUILD
+++ b/mingw-w64-make/PKGBUILD
@@ -12,7 +12,7 @@ _prog_name=mingw32-make
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=4.4
-pkgrel=1
+pkgrel=2
 pkgdesc="GNU make utility to maintain groups of programs (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -26,6 +26,7 @@ source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.gz"
         'make-linebuf-mingw.patch'
         'make-4.3_undef-HAVE_STRUCT_DIRENT_D_TYPE.patch'
         'make-4.2.1-Makefile.am-gcc-only-link-libgnumake-1.dll.a.patch'
+        'make-4.4-timestamps.patch'
         'make-check-load-feature.mak'
         'mk_temp.c')
 sha256sums=('581f4d4e872da74b3941c874215898a7d35802f03732bdccee1d4a7979105d18'
@@ -33,6 +34,7 @@ sha256sums=('581f4d4e872da74b3941c874215898a7d35802f03732bdccee1d4a7979105d18'
             'cbb8c0a1bdd6e8174febce01946bd42da26dfcb73a7338c0a1df89ac6b8e157b'
             '952b8decffb25b6083bbda262578f93f2b480789b9d0baaabb7b3a77d7b86fc1'
             '85f8c3c555079026f3debab350c9ee27a717cdd08eca3f8bf9ac58e78544d21d'
+            'a8a4736e1a575c7a94bd38304401aa11076ccdfc912f175d3264d5e03d597e60'
             '3d6ece384425ff1c3f691efeb7c97e89bb11825bb6648995552dfcb52afe661d'
             '61d4f57c311cf2e27ccf4d1da847216730f304cf17c5c386721182ffe2d4b1aa')
 
@@ -55,6 +57,8 @@ prepare() {
     patch -p1 -i ${srcdir}/make-linebuf-mingw.patch
     patch -p2 -i ${srcdir}/make-4.3_undef-HAVE_STRUCT_DIRENT_D_TYPE.patch
   popd
+  # https://lists.gnu.org/archive/html/bug-make/2022-11/msg00017.html
+  patch -p1 -i ${srcdir}/make-4.4-timestamps.patch
 
   if test "${_autotools}" = "yes"; then
     patch -p1 -i ${srcdir}/make-4.2.1-Makefile.am-gcc-only-link-libgnumake-1.dll.a.patch

--- a/mingw-w64-make/PKGBUILD
+++ b/mingw-w64-make/PKGBUILD
@@ -31,7 +31,7 @@ source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.gz"
 sha256sums=('581f4d4e872da74b3941c874215898a7d35802f03732bdccee1d4a7979105d18'
             '15a86d5143c9ec6337bdd69fecb7c33c36e4fd925528dc1498b0bc4fbd31b0bb'
             'cbb8c0a1bdd6e8174febce01946bd42da26dfcb73a7338c0a1df89ac6b8e157b'
-            '4ba7a15f7092268e4dfe30a7c29aaae5e3c887c158bc2e084ad7d114db0363cc'
+            '952b8decffb25b6083bbda262578f93f2b480789b9d0baaabb7b3a77d7b86fc1'
             '85f8c3c555079026f3debab350c9ee27a717cdd08eca3f8bf9ac58e78544d21d'
             '3d6ece384425ff1c3f691efeb7c97e89bb11825bb6648995552dfcb52afe661d'
             '61d4f57c311cf2e27ccf4d1da847216730f304cf17c5c386721182ffe2d4b1aa')

--- a/mingw-w64-make/make-4.3_undef-HAVE_STRUCT_DIRENT_D_TYPE.patch
+++ b/mingw-w64-make/make-4.3_undef-HAVE_STRUCT_DIRENT_D_TYPE.patch
@@ -3,9 +3,9 @@
 @@ -348,7 +348,7 @@
  /* Define to 1 if `d_type' is a member of `struct dirent'. */
  /* SV 57152: MinGW64 version of dirent doesn't support d_type. */
- #ifndef __MINGW64__
--# define HAVE_STRUCT_DIRENT_D_TYPE 1
-+// # define HAVE_STRUCT_DIRENT_D_TYPE 1
+-#ifndef __MINGW64__
++#ifndef __MINGW32__
+ # define HAVE_STRUCT_DIRENT_D_TYPE 1
  #endif
  
  /* Define to 1 if 'n_un.n_name' is a member of 'struct nlist'. */

--- a/mingw-w64-make/make-4.4-timestamps.patch
+++ b/mingw-w64-make/make-4.4-timestamps.patch
@@ -1,0 +1,37 @@
+From 1f542f915d6a3f8a69a4acae94b01185df7ee2a6 Mon Sep 17 00:00:00 2001
+From: Orgad Shaneh <orgads@gmail.com>
+Date: Wed, 2 Nov 2022 18:23:57 +0200
+Subject: [PATCH] Fix reading file timestamp as 64-bit on MinGW32
+
+Commit 01142a53c9d (Add support for intmax_t) added support for 64-bit
+time_t by defining __MINGW_USE_VC2005_COMPAT. But this only works with
+_stat64 as expected. When stat is used on 32-bit systems, it returns a
+bad timestamp (for example, 72586185920376753).
+
+This triggers the following errors every time make is executed:
+mingw32-make: Warning: File 'Makefile' has modification time 7.3e+16 s in the future
+mingw32-make: warning:  Clock skew detected.  Your build may be incomplete.
+
+and of course, dependencies are completely broken.
+
+Fix by enabling _stat64 also for MinGW.
+---
+ src/remake.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/remake.c b/src/remake.c
+index 4ce3d2a3..83b0b79d 100644
+--- a/src/remake.c
++++ b/src/remake.c
+@@ -37,7 +37,7 @@ this program.  If not, see <https://www.gnu.org/licenses/>.  */
+ #include <windows.h>
+ #include <io.h>
+ #include <sys/stat.h>
+-#if defined(_MSC_VER) && _MSC_VER > 1200
++#if defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER > 1200)
+ /* VC7 or later supprots _stat64 to access 64-bit file size. */
+ #define STAT _stat64
+ #else
+-- 
+2.38.1.windows.1.1.gfa087c7d8f
+


### PR DESCRIPTION
Fixes a critical regression between 4.3 and 4.4.