### PR TITLE
gcc: disable stack protector to unbreak libssp

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -24,7 +24,7 @@ pkgver=12.2.0
 #_majorver=${pkgver:0:1}
 #_sourcedir=${_realname}-${_majorver}-${_snapshot}
 _sourcedir=${_realname}-${pkgver}
-pkgrel=5
+pkgrel=6
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -209,6 +209,11 @@ build() {
     '--with-boot-ldflags="-static-libstdc++"'
     '--with-stage1-ldflags="-static-libstdc++"'
   )
+
+  # -fstack-protector-strong breaks libssp
+  # https://github.com/msys2/MINGW-packages/issues/13830
+  # TODO: This can be removed once we drop libssp all together
+  CFLAGS+=" -fno-stack-protector"
 
   ../${_sourcedir}/configure \
     --prefix=${MINGW_PREFIX} \


### PR DESCRIPTION
See #13830