### PR TITLE
Add the `mingw-w64-7zip` package

### DIFF
--- a/mingw-w64-7zip/PKGBUILD
+++ b/mingw-w64-7zip/PKGBUILD
@@ -23,15 +23,17 @@ prepare () {
 }
 
 build() {
-  cd "${srcdir}"/CPP/7zip/UI/Console
+  cd "${srcdir}"/
 
-  make -f makefile.gcc
+  make -C CPP/7zip/UI/Console -f makefile.gcc
+  make -C CPP/7zip/Bundles/SFXCon -f makefile.gcc
 }
 
 package() {
   cd "${srcdir}"
 
   install -D -m755 CPP/7zip/UI/Console/_o/7z.exe "${pkgdir}"${MINGW_PREFIX}/bin/7z.exe
+  install -D -m755 CPP/7zip/Bundles/SFXCon/_o/7zCon.exe "${pkgdir}"${MINGW_PREFIX}/lib/7zip/7zCon.sfx
 
   install -d "${pkgdir}"${MINGW_PREFIX}/share/doc/7zip
   install -D -m644 DOC/* "${pkgdir}"${MINGW_PREFIX}/share/doc/7zip

--- a/mingw-w64-7zip/PKGBUILD
+++ b/mingw-w64-7zip/PKGBUILD
@@ -1,0 +1,38 @@
+# Maintainer: Johannes Schindelin <johannes.schindelin@gmx.de>
+
+_realname=7zip
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=22.01
+pkgrel=1
+pkgdesc="A file archiver with a high compression ratio (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+url="https://7-zip.org"
+license=('LGPL')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+source=("$url/a/7z${pkgver//./}-src.tar.xz")
+sha256sums=('393098730c70042392af808917e765945dc2437dee7aae3cfcc4966eb920fbc5')
+
+prepare () {
+  case ${MSYSTEM} in
+    CLANG*)
+      sed -i 's/-Werror/& -Wno-error=missing-exception-spec -Wno-error=unused-but-set-variable/' */*.mak */*/*.mak;;
+  esac
+}
+
+build() {
+  cd "${srcdir}"/CPP/7zip/UI/Console
+
+  make -f makefile.gcc
+}
+
+package() {
+  cd "${srcdir}"
+
+  install -D -m755 CPP/7zip/UI/Console/_o/7z.exe "${pkgdir}"${MINGW_PREFIX}/bin/7z.exe
+
+  install -d "${pkgdir}"${MINGW_PREFIX}/share/doc/7zip
+  install -D -m644 DOC/* "${pkgdir}"${MINGW_PREFIX}/share/doc/7zip
+}


### PR DESCRIPTION
MSYS2 does offer the `p7zip` package. But it is an MSYS package (and therefore the executable is slower than it needs to be), and besides, the p7zip project seems to be abandoned since 2016.

In the meantime, the 7-Zip project itself added support for building the command-line tool on Linux, and we can use that very same setup to build a MINGW version, too. So let's do that.

Note that there is only a `7z.exe`, no `7za.exe`. That's because the 7-Zip project never bothered with a shared library ;-)