### PR TITLE
mcfgthread: Upgrade to 1.3

### DIFF
--- a/mingw-w64-mcfgthread/PKGBUILD
+++ b/mingw-w64-mcfgthread/PKGBUILD
@@ -4,14 +4,14 @@ _realname=mcfgthread
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}"-libs)
-pkgver=1.2
-pkgrel=2
+pkgver=1.3
+pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 url="https://github.com/lhmouse/mcfgthread"
 license=('spdx:LGPL-3.0-or-later' 'custom')
 options=('staticlibs' 'strip' '!buildflags')
-_commit='cfd68c8df854191cabdd172598b5032a1ab3163f'
+_commit='9405c6a8f54e6979f43a0e482eef58eb4ae34a53'
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cc"
   "${MINGW_PACKAGE_PREFIX}-autotools"


### PR DESCRIPTION
This is the required version for building GCC 13 with Objective-C enabled. GCC 13 will support `--enable-threads=mcf` once it is released. Support for LLVM's libc++ has not been tested.

The return value of `std::recursive_mutex::try_lock()` has been fixed.

Reference: https://github.com/lhmouse/mcfgthread/releases/tag/v1.3-ga.1
Signed-off-by: LIU Hao <lh_mouse@126.com>