### PR TITLE
7zip: fix clangarm64 build

### DIFF
--- a/mingw-w64-7zip/PKGBUILD
+++ b/mingw-w64-7zip/PKGBUILD
@@ -4,21 +4,26 @@ _realname=7zip
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=22.01
-pkgrel=1
+pkgrel=2
 pkgdesc="A file archiver with a high compression ratio (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://7-zip.org"
 license=('LGPL')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
-source=("$url/a/7z${pkgver//./}-src.tar.xz")
-sha256sums=('393098730c70042392af808917e765945dc2437dee7aae3cfcc4966eb920fbc5')
+source=("$url/a/7z${pkgver//./}-src.tar.xz"
+        "clang-arm-target-fixes.patch")
+sha256sums=('393098730c70042392af808917e765945dc2437dee7aae3cfcc4966eb920fbc5'
+            '96d4f8367a3533377ac16c22b1fd3e00c7cdc902e9957106d2deddfe3529222b')
 
 prepare () {
   case ${MSYSTEM} in
     CLANG*)
-      sed -i 's/-Werror/& -Wno-error=missing-exception-spec -Wno-error=unused-but-set-variable/' */*.mak */*/*.mak;;
+      sed -i 's/-Werror/& -Wno-error=missing-exception-spec -Wno-error=unused-but-set-variable -Wno-error=unknown-attributes/' */*.mak */*/*.mak
+      # This patch can be dropped once we're using Clang 16 or later
+      patch -p0 -i "${srcdir}/clang-arm-target-fixes.patch"
+      ;;
   esac
 }
 

--- a/mingw-w64-7zip/clang-arm-target-fixes.patch
+++ b/mingw-w64-7zip/clang-arm-target-fixes.patch
@@ -1,0 +1,54 @@
+--- C/7zCrc.c	2021-04-01 18:00:00.000000000 +0000
++++ C/7zCrc.c	2022-11-05 05:16:33.444743500 +0000
+@@ -86,7 +86,7 @@
+       #if !defined(__ARM_FEATURE_CRC32)
+         #define __ARM_FEATURE_CRC32 1
+           #if (!defined(__clang__) || (__clang_major__ > 3)) // fix these numbers
+-            #define ATTRIB_CRC __attribute__((__target__("arch=armv8-a+crc")))
++            #define ATTRIB_CRC __attribute__((__target__("crc")))
+           #endif
+       #endif
+       #if defined(__ARM_FEATURE_CRC32)
+--- C/Sha256Opt.c	2021-04-01 18:00:00.000000000 +0000
++++ C/Sha256Opt.c	2022-11-05 04:59:24.409334100 +0000
+@@ -234,7 +234,7 @@
+ 
+ #if defined(__clang__) || defined(__GNUC__)
+   #ifdef MY_CPU_ARM64
+-    #define ATTRIB_SHA __attribute__((__target__("+crypto")))
++    #define ATTRIB_SHA __attribute__((__target__("crypto")))
+   #else
+     #define ATTRIB_SHA __attribute__((__target__("fpu=crypto-neon-fp-armv8")))
+   #endif
+@@ -247,6 +247,10 @@
+ #if defined(_MSC_VER) && defined(MY_CPU_ARM64)
+ #include <arm64_neon.h>
+ #else
++
++#define __ARM_FEATURE_AES
++#define __ARM_FEATURE_SHA2
++#define __ARM_FEATURE_CRYPTO
+ #include <arm_neon.h>
+ #endif
+ 
+--- C/AesOpt.c	2021-04-01 18:00:00.000000000 +0000
++++ C/AesOpt.c	2022-11-05 04:59:52.628006300 +0000
+@@ -528,7 +528,7 @@
+ 
+ #if defined(__clang__) || defined(__GNUC__)
+   #ifdef MY_CPU_ARM64
+-    #define ATTRIB_AES __attribute__((__target__("+crypto")))
++    #define ATTRIB_AES __attribute__((__target__("crypto")))
+   #else
+     #define ATTRIB_AES __attribute__((__target__("fpu=crypto-neon-fp-armv8")))
+   #endif
+@@ -545,6 +545,9 @@
+ #if defined(_MSC_VER) && defined(MY_CPU_ARM64)
+ #include <arm64_neon.h>
+ #else
++#define __ARM_FEATURE_AES
++#define __ARM_FEATURE_SHA2
++#define __ARM_FEATURE_CRYPTO
+ #include <arm_neon.h>
+ #endif
+ 


### PR DESCRIPTION
Add a temporary patch to change ARM64 target attributes to a format clang understands (clang should support the GCC format as of version 16, see https://github.com/msys2/MINGW-packages/pull/13894#issuecomment-1304319971).

Add another `-Wno-error` option, rather than trying to patch out `force_align_arg_pointer` attribute for non-x86.