### PR TITLE
openmp: backport arm64 build fixes

### DIFF
--- a/mingw-w64-openmp/D137168.patch
+++ b/mingw-w64-openmp/D137168.patch
@@ -1,0 +1,44 @@
+diff --git a/openmp/runtime/src/dllexports b/openmp/runtime/src/dllexports
+--- a/openmp/runtime/src/dllexports
++++ b/openmp/runtime/src/dllexports
+@@ -1243,7 +1243,6 @@
+     %ifdef IS_IA_ARCH
+     __kmpc_atomic_float10_max              2139
+     __kmpc_atomic_float10_min              2140
+-    %endif
+     __kmpc_atomic_float10_max_cpt          2141
+     __kmpc_atomic_float10_min_cpt          2142
+ 
+@@ -1263,6 +1262,7 @@
+     __kmpc_atomic_val_2_cas_cpt            2156
+     __kmpc_atomic_val_4_cas_cpt            2157
+     __kmpc_atomic_val_8_cas_cpt            2158
++    %endif
+ 
+ %endif
+ 
+diff --git a/openmp/runtime/src/kmp_os.h b/openmp/runtime/src/kmp_os.h
+--- a/openmp/runtime/src/kmp_os.h
++++ b/openmp/runtime/src/kmp_os.h
+@@ -456,7 +456,7 @@
+ 
+ // Synchronization primitives
+ 
+-#if KMP_ASM_INTRINS && KMP_OS_WINDOWS
++#if KMP_ASM_INTRINS && KMP_OS_WINDOWS && !(KMP_ARCH_AARCH64 && defined(__GNUC__))
+ 
+ #if KMP_MSVC_COMPAT && !KMP_COMPILER_CLANG
+ #pragma intrinsic(InterlockedExchangeAdd)
+diff --git a/openmp/runtime/src/kmp_utility.cpp b/openmp/runtime/src/kmp_utility.cpp
+--- a/openmp/runtime/src/kmp_utility.cpp
++++ b/openmp/runtime/src/kmp_utility.cpp
+@@ -370,7 +370,7 @@
+         case 'I':
+         case 'i': {
+           pid_t id = getpid();
+-#if KMP_ARCH_X86_64 && defined(__MINGW32__)
++#if (KMP_ARCH_X86_64 || KMP_ARCH_AARCH64) && defined(__MINGW32__)
+           snp_result = KMP_SNPRINTF(pos, end - pos + 1, "%0*lld", width, id);
+ #else
+           snp_result = KMP_SNPRINTF(pos, end - pos + 1, "%0*d", width, id);
+

--- a/mingw-w64-openmp/PKGBUILD
+++ b/mingw-w64-openmp/PKGBUILD
@@ -11,11 +11,11 @@ _version=15.0.3
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
-pkgrel=2
+pkgrel=3
 pkgdesc="LLVM OpenMP Library (mingw-w64)"
 url="https://openmp.llvm.org/"
 arch=(any)
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 license=("custom:Apache 2.0 with LLVM Exception")
 groups=($( (( _clangprefix )) && echo "${MINGW_PACKAGE_PREFIX}-toolchain"))
 provides=("${MINGW_PACKAGE_PREFIX}-omp")
@@ -31,13 +31,17 @@ _pkgfn=$_realname-$pkgver.src
 source=($_url/$_pkgfn.tar.xz{,.sig}
         ${_url}/cmake-${pkgver}.src.tar.xz{,.sig}
         "001-cast-to-make-gcc-happy.patch"
-        "002-hacks-for-static-linking.patch")
+        "002-hacks-for-static-linking.patch"
+        "https://github.com/llvm/llvm-project/commit/cea951dccd9aaa7fee8a60ecf9170d7d3cc35086.patch"
+        "D137168.patch")
 sha256sums=('ec7bd70a341bd8d33f2b4be7d9961d609cf2596d7042ae7d288975462b694b5e'
             'SKIP'
             '21cf3f52c53dc8b8972122ae35a5c18de09c7df693b48b5cd8553c3e3fed090d'
             'SKIP'
             '11352ffbe7559a7170f2abd52b3552c877fbcf8fc82cff77b421e8b130a4dd66'
-            '7238f009264bc1b162b73ca3a2a0b224b65ec3ed384304f3e5464032c4c026f4')
+            '7238f009264bc1b162b73ca3a2a0b224b65ec3ed384304f3e5464032c4c026f4'
+            '159f038084d3999d0329db33f283b3440c47db7b2f1587fd0d158450647669a5'
+            '9e50acee4bf4aff2b3f5091c33ab7b7a1e9608cb863e2434554d2333522f4a40')
 validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Google.
               '474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard
               'D574BD5D1D0E98895E3BF90044F2485E45D59042') # Tobias Hieta
@@ -60,6 +64,11 @@ prepare() {
       "001-cast-to-make-gcc-happy.patch"
   fi
   apply_patch_with_msg 002-hacks-for-static-linking.patch
+
+  # https://github.com/llvm/llvm-project/issues/56349
+  patch -Nbp2 -i "${srcdir}/cea951dccd9aaa7fee8a60ecf9170d7d3cc35086.patch"
+  # https://reviews.llvm.org/D137168
+  patch -Nbp2 -i "${srcdir}/D137168.patch"
 }
 
 build() {


### PR DESCRIPTION
And try to enable for clangarm64 again.

There is a report of potential brokenness here:
https://reviews.llvm.org/D137168#3909400
so we should be careful building things with it.

#13818