### PR TITLE
pyqt5: disable building tools on 32bit envs

### DIFF
--- a/mingw-w64-pyqt5/PKGBUILD
+++ b/mingw-w64-pyqt5/PKGBUILD
@@ -9,7 +9,7 @@ conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
           "${MINGW_PACKAGE_PREFIX}-${_realname}-common")
 pkgver=5.15.7
-pkgrel=2
+pkgrel=3
 pkgdesc="Qt5 bindings for Python (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -70,14 +70,19 @@ build() {
   [[ -d python-build-${MSYSTEM} ]] && rm -rf python-build-${MSYSTEM}
   cp -r PyQt5-${pkgver} python-build-${MSYSTEM} && cd python-build-${MSYSTEM}
 
+  declare -a _extra_config
+  if [[ ${CARCH} == i686 ]]; then
+    _extra_config+=("--no-tools")
+  fi
+
   MSYS2_ARG_CONV_EXCL="--api-dir=;" \
   ${MINGW_PREFIX}/bin/sip-build \
     --confirm-license \
     --link-full-dll \
     --no-make \
-    --concatenate 2 \
     --api-dir=${MINGW_PREFIX}/share/qt5/qsci/api/python \
     --qmake=${MINGW_PREFIX}/bin/qmake.exe \
+    ${_extra_config[@]} \
     --verbose
 
     cd build


### PR DESCRIPTION
For some unknown reason sip hit an assertion when generating binding for pylupdate.