### PR TITLE
petsc-build: fix pkg-config and other config files due to leaking $srcdir

### DIFF
--- a/mingw-w64-petsc/PKGBUILD
+++ b/mingw-w64-petsc/PKGBUILD
@@ -33,7 +33,7 @@ _realname=petsc
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-${_realname}-build")
 pkgver=3.17.3
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 pkgdesc='Sparse iterative (non)linear solver package (mingw-w64)'
@@ -97,13 +97,13 @@ builds='dso dto dmo zso zto zmo sso sto smo cso cto cmo'
 
 _petsc() {
   desc=
-  opts="--with-single-library=1 --disable-shared --with-windows-graphics=0 --with-x=0 --with-hwloc=1 --with-openblas=1 --with-openblas-dir=$MINGW_PREFIX"
+  opts="--with-single-library=1 --disable-shared --with-windows-graphics=0 --with-x=0 --with-hwloc=1 --with-openblas=1 --with-openblas-dir=$MINGW_PREFIX --prefix=${MINGW_PREFIX}/src/${_realname}-${pkgver}/$1"
   pc="hwloc openblas"
   iflags=
   cflags="$CFLAGS"
   cxxflags="$CXXFLAGS"
   fflags="$CFLAGS -fallow-invalid-boz -fallow-argument-mismatch -I$MINGW_PREFIX/include"
-  cppflags="$CPPFLAGS"
+  cppflags="$CPPFLAGS -I\${prefix}/../include"
   ldflags="$LDFLAGS"
   pc_libs="$LIBS"
   libs="$LIBS"


### PR DESCRIPTION
It seems that `$srcdir` was being leaked into the pkg-config and other config files, making them unusable. For reference, the current content of `dmo/PETSc.pc` is 

```
prefix=/c/M/mingw-w64-petsc/src/build-MINGW64/petsc-3.17.3/dmo
exec_prefix=${prefix}
includedir=${prefix}/include
libdir=${prefix}/lib
ccompiler=gcc
cflags_extra=-march=x86-64 -mtune=generic -O2 -pipe -fPIC -D__USE_MINGW_ANSI_STDIO=1
cflags_dep=-MMD -MP
ldflag_rpath=-Wl,-rpath,
cxxcompiler=g++
cxxflags_extra=-march=x86-64 -mtune=generic -O2 -pipe  -std=gnu++17
fcompiler=gfortran
fflags_extra=-march=x86-64 -mtune=generic -O2 -pipe -fallow-invalid-boz -fallow-argument-mismatch -I/mingw64/include

Name: PETSc
Description: Library to solve ODEs and algebraic equations
Version: 3.17.3
Cflags: -D__USE_MINGW_ANSI_STDIO=1  -I${includedir} -I/c/M/mingw-w64-petsc/src/build-MINGW64/petsc-3.17.3/include
Libs: -L${libdir} -lpetsc
Libs.private: -L/mingw64/lib -lopenblas -lparmetis -lmetis -lhwloc -lgdi32 -luser32 -ladvapi32 -lkernel32 -lquadmath -lstdc++ -lgfortran -lquadmath -lmsmpi
```

This PR changes that content to

```
prefix=/mingw64/src/petsc-3.17.3/dmo
exec_prefix=${prefix}
includedir=${prefix}/include
libdir=${prefix}/lib
ccompiler=gcc
cflags_extra=-march=x86-64 -mtune=generic -O2 -pipe -fPIC -D__USE_MINGW_ANSI_STDIO=1 -I${prefix}/../include
cflags_dep=-MMD -MP
ldflag_rpath=-Wl,-rpath,
cxxcompiler=g++
cxxflags_extra=-march=x86-64 -mtune=generic -O2 -pipe  -std=gnu++17
fcompiler=gfortran
fflags_extra=-march=x86-64 -mtune=generic -O2 -pipe -fallow-invalid-boz -fallow-argument-mismatch -I/mingw64/include

Name: PETSc
Description: Library to solve ODEs and algebraic equations
Version: 3.17.3
Cflags: -D__USE_MINGW_ANSI_STDIO=1 -I${prefix}/../include  -I${includedir}
Libs: -L${libdir} -lpetsc
Libs.private: -L/mingw64/lib -lopenblas -lparmetis -lmetis -lhwloc -lgdi32 -luser32 -ladvapi32 -lkernel32 -lquadmath -lstdc++ -lgfortran -lquadmath -lmsmpi
```

I'll note that the reason I modify `CPPFLAGS` is because pkg-config seems to have trouble with MSYS absolute paths when in the middle of variables. IE. it is able to handle 

```
Cflags: -D__USE_MINGW_ANSI_STDIO=1 -I${prefix}/../include  -I${includedir}
```

but not 

```
Cflags: -D__USE_MINGW_ANSI_STDIO=1 -I/mingw64/src/petsc-3.17.3/include  -I${includedir}
```

I wanted to avoid a patch, and `CPPFLAGS` seems to accomplish this without affecting the build.