### PR TITLE
llvm packages: update to 15.0.4

### DIFF
--- a/mingw-w64-libc++/PKGBUILD
+++ b/mingw-w64-libc++/PKGBUILD
@@ -8,7 +8,7 @@ _realname=libc++
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-libunwind")
-_version=15.0.3
+_version=15.0.4
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
@@ -37,15 +37,15 @@ source=("${_url}/llvm-${pkgver}.src.tar.xz"{,.sig}
         "${_url}/libunwind-${pkgver}.src.tar.xz"{,.sig}
         "https://raw.githubusercontent.com/llvm/llvm-project/${_tag}/runtimes/CMakeLists.txt"
         "https://raw.githubusercontent.com/llvm/llvm-project/${_tag}/runtimes/Components.cmake.in")
-sha256sums=('c39aec729662416dcbf0bfe53a9786b34e7d93d02908a0779a2f6d83ad0a4a27'
+sha256sums=('60aca410cae2b92665c0aa769bcd11ed17030b9ecd76115138c97d94a27a992f'
             'SKIP'
-            '21cf3f52c53dc8b8972122ae35a5c18de09c7df693b48b5cd8553c3e3fed090d'
+            '9df45bf3a0a46264d5007485592381bbaf50f034b4155290cb0d917539d8facf'
             'SKIP'
-            'c7db97ec45c9bab9500ff77214e407e1331fa0ebb126ca86d692e4e5292b3e7f'
+            '425160c72644123860dcc5d0e1eef2064cb7c65c19328ab9e0b316dab1fc2af3'
             'SKIP'
-            'f478295ee62fc94339e97754b25da04d26ab8b31315d36236f21912e192b83aa'
+            'c462582026c3d6192406483285d17cc35ead4fb6244f40887eb71342824ea913'
             'SKIP'
-            '0ab6e07bf05359e242e9ea80e4089b819914867fa997a715e324e584bcfdf114'
+            'a424d9357a0428c2be0c9bce8691dffa74fa5d7d6d6ecb2f4297a6c58ccad070'
             'SKIP'
             'a1c9ef5ee90191b64524528703de8000ee66c6f0a5bb7fe02f760e3073d32fde'
             'bc0974b6555874d3c24295fe8b99b25aea8086158ee4ab87e9a8709191cc7824')

--- a/mingw-w64-lldb/PKGBUILD
+++ b/mingw-w64-lldb/PKGBUILD
@@ -7,7 +7,7 @@ fi
 _realname=lldb
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_version=15.0.3
+_version=15.0.4
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
@@ -35,7 +35,7 @@ _url=https://github.com/llvm/llvm-project/releases/download/${_tag}
 _pkgfn=$_realname-$pkgver.src
 source=($_url/$_pkgfn.tar.xz{,.sig}
         002-fix-api-generator-expression.patch)
-sha256sums=('ccca73f5d207c6db4f0683cb321dc65e4b219a7325617c9c9996133981d87478'
+sha256sums=('fe4268698fd964e9e03e50c6490842fcb0e604cca294ea3be46fa1f3918fb6ea'
             'SKIP'
             'ca897429775137be3d0ccaffb95010e4995aa9003c243ff795645ebac2f61fe1')
 validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Google.

--- a/mingw-w64-mlir/PKGBUILD
+++ b/mingw-w64-mlir/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=mlir
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_version=15.0.3
+_version=15.0.4
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
@@ -26,7 +26,7 @@ _url=https://github.com/llvm/llvm-project/releases/download/${_tag}
 source=("${_url}/llvm-project-${pkgver}.src.tar.xz"{,.sig}
         0001-do-not-link-to-llvm-dylib.patch
         0002-Use-hidden-visibility-when-building-for-MinGW-with-Clang.patch)
-sha256sums=('dd07bdab557866344d85ae21bbeca5259d37b4b0e2ebf6e0481f42d1ba0fee88'
+sha256sums=('a3112dca9bdea4095361829910b74fb6b9da8ae6e3500db67c43c540ad6072da'
             'SKIP'
             '21e21fcd76e4dbb48032903b91ee7521051a91122c2a58616a33da02796b0580'
             'f3bce25ac7d339cbe7a94bd1cfd2d634450c261c7a32103aba4ed5f773fd2cfc')

--- a/mingw-w64-openmp/PKGBUILD
+++ b/mingw-w64-openmp/PKGBUILD
@@ -7,11 +7,11 @@ fi
 _realname=openmp
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_version=15.0.3
+_version=15.0.4
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
-pkgrel=3
+pkgrel=1
 pkgdesc="LLVM OpenMP Library (mingw-w64)"
 url="https://openmp.llvm.org/"
 arch=(any)
@@ -34,9 +34,9 @@ source=($_url/$_pkgfn.tar.xz{,.sig}
         "002-hacks-for-static-linking.patch"
         "https://github.com/llvm/llvm-project/commit/cea951dccd9aaa7fee8a60ecf9170d7d3cc35086.patch"
         "D137168.patch")
-sha256sums=('ec7bd70a341bd8d33f2b4be7d9961d609cf2596d7042ae7d288975462b694b5e'
+sha256sums=('1b6f92013e7555759127d84264c3e98eab116a3a5138570058d8507e1513f76e'
             'SKIP'
-            '21cf3f52c53dc8b8972122ae35a5c18de09c7df693b48b5cd8553c3e3fed090d'
+            '9df45bf3a0a46264d5007485592381bbaf50f034b4155290cb0d917539d8facf'
             'SKIP'
             '11352ffbe7559a7170f2abd52b3552c877fbcf8fc82cff77b421e8b130a4dd66'
             '7238f009264bc1b162b73ca3a2a0b224b65ec3ed384304f3e5464032c4c026f4'

--- a/mingw-w64-polly/PKGBUILD
+++ b/mingw-w64-polly/PKGBUILD
@@ -7,7 +7,7 @@ fi
 _realname=polly
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_version=15.0.3
+_version=15.0.4
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
@@ -29,9 +29,9 @@ _url=https://github.com/llvm/llvm-project/releases/download/${_tag}
 _pkgfn=$_realname-$pkgver.src
 source=($_url/$_pkgfn.tar.xz{,.sig}
         ${_url}/cmake-${pkgver}.src.tar.xz{,.sig})
-sha256sums=('d47d81e2d762cc3ddb403470c13d13e5aa299105561ae2396f73c8c38ecde2e9'
+sha256sums=('52e6436099b7470199a671d06f9ecac3eac7ace33d7df90a55799aaa4aa1ba6c'
             'SKIP'
-            '21cf3f52c53dc8b8972122ae35a5c18de09c7df693b48b5cd8553c3e3fed090d'
+            '9df45bf3a0a46264d5007485592381bbaf50f034b4155290cb0d917539d8facf'
             'SKIP')
 validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Google.
               '474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard


### PR DESCRIPTION
except for flang which generally needs to be done on its own.  also, libclc is still at 14.0.6