### PR TITLE
libclc: update to 15.0.4

### DIFF
--- a/mingw-w64-libclc/PKGBUILD
+++ b/mingw-w64-libclc/PKGBUILD
@@ -3,12 +3,15 @@
 _realname=libclc
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=14.0.6
+_version=15.0.4
+_rc=""
+_tag=llvmorg-${_version}${_rc}
+pkgver=${_version}${_rc/-/}
 pkgrel=1
 pkgdesc='Library requirements of the OpenCL C programming language (mingw-w64)'
+url='https://libclc.llvm.org/'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
-url='https://libclc.llvm.org/'
 license=('spdx:MIT')
 depends=()
 makedepends=("${MINGW_PACKAGE_PREFIX}-clang"
@@ -17,14 +20,18 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-clang"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-python"
              "${MINGW_PACKAGE_PREFIX}-spirv-llvm-translator")
-source=(https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkgver}/libclc-${pkgver}.src.tar.xz{,.sig}
+_url=https://github.com/llvm/llvm-project/releases/download/${_tag}
+_pkgfn=$_realname-$pkgver.src
+source=($_url/$_pkgfn.tar.xz{,.sig}
         0001-cmake-copy-instead-symlink.patch
         0002-fix-pkgconfig-file.patch)
-sha256sums=('c9b183160ec093b4bd4a24517ab97b30110418b8d904a849c415dc647b345f95'
+sha256sums=('00cc092947ef533999db42d18a4134f6ee1d74a60f5c84387ef28ca9e02e2a16'
             'SKIP'
             'a50ec126a708251d6264e9bad4fc3868be28f192d20f9436b64deec7096eb499'
             'f0c995d679214dbb1248f15365c6d26440efa0afc76402172068456f99109c25')
-validpgpkeys=('474E22316ABF4785A88C6E8EA2C794A986419D8A') # Tom Stellard <tstellar@redhat.com>
+validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Google.
+              '474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard
+              'D574BD5D1D0E98895E3BF90044F2485E45D59042') # Tobias Hieta
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}.src"


### PR DESCRIPTION
This package was out of sync with the other llvm-project packages.  This brings it back up to date, and makes the format of the PKGBUILD a little closer.

I don't use libclc, and don't have a way to know if it works or not... It builds (but with a lot of warnings!)