### PR TITLE
python-lsp-server: Reallow newlest depends

### DIFF
--- a/mingw-w64-python-lsp-server/0001-python-lsp-server-1.5.0-allow-newlest-depends.patch
+++ b/mingw-w64-python-lsp-server/0001-python-lsp-server-1.5.0-allow-newlest-depends.patch
@@ -1,3 +1,5 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 8cce90e..18cf2db 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
 @@ -13,7 +13,7 @@ readme = "README.md"
@@ -8,4 +10,42 @@
 +    "jedi>=0.17.2",
      "python-lsp-jsonrpc>=1.0.0",
      "pluggy>=1.0.0",
-     "ujson>=3.0.0",
+     "docstring-to-markdown",
+@@ -27,26 +27,26 @@ Homepage = "https://github.com/python-lsp/python-lsp-server"
+ 
+ [project.optional-dependencies]
+ all = [
+-    "autopep8>=1.6.0,<1.7.0",
+-    "flake8>=5.0.0,<5.1.0",
+-    "mccabe>=0.7.0,<0.8.0",
+-    "pycodestyle>=2.9.0,<2.10.0",
++    "autopep8>=1.6.0",
++    "flake8>=5.0.0",
++    "mccabe>=0.7.0",
++    "pycodestyle>=2.9.0",
+     "pydocstyle>=2.0.0",
+-    "pyflakes>=2.5.0,<2.6.0",
++    "pyflakes>=2.5.0",
+     "pylint>=2.5.0",
+     "rope>=0.10.5",
+     "yapf",
+     "whatthepatch"
+ ]
+-autopep8 = ["autopep8>=1.6.0,<1.7.0"]
+-flake8 = ["flake8>=5.0.0,<5.1.0"]
+-mccabe = ["mccabe>=0.7.0,<0.8.0"]
+-pycodestyle = ["pycodestyle>=2.9.0,<2.10.0"]
++autopep8 = ["autopep8>=1.6.0"]
++flake8 = ["flake8>=5.0.0"]
++mccabe = ["mccabe>=0.7.0"]
++pycodestyle = ["pycodestyle>=2.9.0"]
+ pydocstyle = ["pydocstyle>=2.0.0"]
+-pyflakes = ["pyflakes>=2.5.0,<2.6.0"]
++pyflakes = ["pyflakes>=2.5.0"]
+ pylint = ["pylint>=2.5.0"]
+ rope = ["rope>0.10.5"]
+-yapf = ["yapf", "whatthepatch>=1.0.2,<2.0.0"]
++yapf = ["yapf", "whatthepatch>=1.0.2"]
+ websockets = ["websockets>=10.3"]
+ test = [
+     "pylint>=2.5.0",

--- a/mingw-w64-python-lsp-server/PKGBUILD
+++ b/mingw-w64-python-lsp-server/PKGBUILD
@@ -4,7 +4,7 @@ _realname=python-lsp-server
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=1.6.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Python Language Server for the Language Server Protocol (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -27,7 +27,7 @@ options=(!strip)
 source=(https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz
         0001-python-lsp-server-1.5.0-allow-newlest-depends.patch)
 sha256sums=('d75cdff9027c4212e5b9e861e9a0219219c8e2c69508d9f24949951dabd0dc1b'
-            'c5c56c0db01f0ca6f10f8980eccf8e6454064972390b729cf382e30599039988')
+            '2400912138fbec557a03ca1161c4ed4821ba6f17b8aef0f4f1ad4ff88175e0d3')
 
 prepare() {
   cd "${_realname}-${pkgver}"


### PR DESCRIPTION
For example, version of the `autopep8` module currently is `2.0.0`.