### PR TITLE
ncurses: Use predefined variables in pkgconfig files

### DIFF
--- a/mingw-w64-ncurses/PKGBUILD
+++ b/mingw-w64-ncurses/PKGBUILD
@@ -4,7 +4,7 @@ _realname=ncurses
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=6.3
-pkgrel=5
+pkgrel=6
 pkgdesc="System V Release 4.0 curses emulation library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -81,4 +81,10 @@ package() {
   make DESTDIR=${pkgdir} install
   cp -r ${pkgdir}${MINGW_PREFIX}/include/ncursesw ${pkgdir}${MINGW_PREFIX}/include/ncurses
   cp ${pkgdir}${MINGW_PREFIX}/lib/libncursesw.a ${pkgdir}${MINGW_PREFIX}/lib/libncurses.a
+
+  # Use predefined variables in pkgconfig files (#13958)
+  for pcfile in "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/*.pc; do
+    sed -s "s|${MINGW_PREFIX}/include|\${includedir}|g" -i "${pcfile}"
+    sed -s "s|${MINGW_PREFIX}/lib|\${libdir}|g" -i "${pcfile}"
+  done
 }


### PR DESCRIPTION
Fixes https://github.com/msys2/MINGW-packages/issues/13958