### PR TITLE
gh: upgrade to 2.20.0

### DIFF
--- a/mingw-w64-github-cli/PKGBUILD
+++ b/mingw-w64-github-cli/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=github-cli
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.19.0
+pkgver=2.20.0
 pkgrel=1
 pkgdesc='The GitHub CLI (mingw-w64)'
 arch=('any')
@@ -16,7 +16,7 @@ optdepends=("git: To interact with repositories")
 options=('!strip')
 source=("$_realname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz"
         "gh")
-sha256sums=('522aeaa5e1ed885d89cf44fe8e1c84da6a372046d4e173a5cd290821ac5afdc8'
+sha256sums=('d8c16de9dc4ed5b42c84eca1be51f2bd84cb181b6f0cb932b6af4d8b2de8342d'
             '9ee5f2b44b7e9aa751508f02c1020e341e0212a9aa146b7428eb5ffea310be27')
 build() {
     cd "cli-$pkgver"


### PR DESCRIPTION
See https://github.com/cli/cli/releases/tag/v2.20.0 for details.