### PR TITLE
ocio: fix python module install path

### DIFF
--- a/mingw-w64-opencolorio/0003-fix-python-sitearch.patch
+++ b/mingw-w64-opencolorio/0003-fix-python-sitearch.patch
@@ -1,0 +1,11 @@
+--- OpenColorIO-2.2.0/src/bindings/python/CMakeLists.txt.orig	2022-10-31 23:27:35.000000000 +0100
++++ OpenColorIO-2.2.0/src/bindings/python/CMakeLists.txt	2022-11-10 14:15:28.555728000 +0100
+@@ -227,7 +227,7 @@
+ 		PY_VERSION_PATCH=${Python_VERSION_PATCH}
+ )
+ 
+-if(WIN32)
++if(WIN32 AND NOT MINGW)
+     set(_Python_VARIANT_PATH "${CMAKE_INSTALL_LIBDIR}/site-packages")
+ else()
+     set(_Python_VARIANT_PATH "${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")

--- a/mingw-w64-opencolorio/0004-use-system-minizip.patch
+++ b/mingw-w64-opencolorio/0004-use-system-minizip.patch
@@ -1,0 +1,59 @@
+diff --git a/src/OpenColorIO/OCIOZArchive.cpp b/src/OpenColorIO/OCIOZArchive.cpp
+index 52e292ef..4430b2d8 100644
+--- a/src/OpenColorIO/OCIOZArchive.cpp
++++ b/src/OpenColorIO/OCIOZArchive.cpp
+@@ -17,16 +17,16 @@
+ 
+ #include "OCIOZArchive.h"
+ 
+-#include "minizip-ng/mz.h"
+-#include "minizip-ng/mz_os.h"
+-#include "minizip-ng/mz_strm.h"
+-#include "minizip-ng/mz_strm_buf.h"
+-#include "minizip-ng/mz_strm_mem.h"
+-#include "minizip-ng/mz_strm_os.h"
+-#include "minizip-ng/mz_strm_split.h"
+-#include "minizip-ng/mz_strm_zlib.h"
+-#include "minizip-ng/mz_zip.h"
+-#include "minizip-ng/mz_zip_rw.h"
++#include "mz.h"
++#include "mz_os.h"
++#include "mz_strm.h"
++#include "mz_strm_buf.h"
++#include "mz_strm_mem.h"
++#include "mz_strm_os.h"
++#include "mz_strm_split.h"
++#include "mz_strm_zlib.h"
++#include "mz_zip.h"
++#include "mz_zip_rw.h"
+ 
+ namespace OCIO_NAMESPACE
+ {
+@@ -630,4 +630,4 @@ void CIOPOciozArchive::buildEntries()
+     getEntriesMappingFromArchiveFile(m_archiveAbsPath, m_entries);
+ }
+ 
+-} // namespace OCIO_NAMESPACE
+\ No newline at end of file
++} // namespace OCIO_NAMESPACE
+diff --git a/src/apps/ocioarchive/main.cpp b/src/apps/ocioarchive/main.cpp
+index bf222fc8..190cadee 100644
+--- a/src/apps/ocioarchive/main.cpp
++++ b/src/apps/ocioarchive/main.cpp
+@@ -13,11 +13,11 @@ namespace OCIO = OCIO_NAMESPACE;
+ #include "apputils/argparse.h"
+ 
+ // Config archive functionality.
+-#include "minizip-ng/mz.h"
+-#include "minizip-ng/mz_os.h"
+-#include "minizip-ng/mz_strm.h"
+-#include "minizip-ng/mz_zip.h"
+-#include "minizip-ng/mz_zip_rw.h"
++#include "mz.h"
++#include "mz_os.h"
++#include "mz_strm.h"
++#include "mz_zip.h"
++#include "mz_zip_rw.h"
+ 
+ // Array of non OpenColorIO arguments.
+ static std::vector<std::string> args;

--- a/mingw-w64-opencolorio/0005-Fix-Findminizip-ng.patch
+++ b/mingw-w64-opencolorio/0005-Fix-Findminizip-ng.patch
@@ -1,0 +1,13 @@
+--- a/share/cmake/modules/Findminizip-ng.cmake
++++ b/share/cmake/modules/Findminizip-ng.cmake
+@@ -22,8 +22,8 @@
+     endif()
+ 
+     if (minizip-ng_FOUND)
+-        get_target_property(minizip-ng_LIBRARY MINIZIP::minizip-ng LOCATION)
+-        get_target_property(minizip-ng_INCLUDE_DIR MINIZIP::minizip-ng INTERFACE_INCLUDE_DIRECTORIES)
++        add_library(minizip-ng::minizip-ng ALIAS MINIZIP::minizip-ng)
++        return()
+     else ()
+         list(APPEND _minizip-ng_REQUIRED_VARS minizip-ng_INCLUDE_DIR)
+ 

--- a/mingw-w64-opencolorio/PKGBUILD
+++ b/mingw-w64-opencolorio/PKGBUILD
@@ -6,33 +6,37 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 pkgver=2.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A color management framework for visual effects and animation (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://opencolorio.org/"
 license=('spdx:BSD-3-Clause')
-depends=("${MINGW_PACKAGE_PREFIX}-boost"
-         "${MINGW_PACKAGE_PREFIX}-expat"
+depends=("${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-freeglut"
+         "${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-glew"
          "${MINGW_PACKAGE_PREFIX}-imath"
-         "${MINGW_PACKAGE_PREFIX}-libwinpthread-git"
          "${MINGW_PACKAGE_PREFIX}-lcms2"
-         "${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-openexr"
          "${MINGW_PACKAGE_PREFIX}-yaml-cpp")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-pybind11"
              "${MINGW_PACKAGE_PREFIX}-pystring"
+             "${MINGW_PACKAGE_PREFIX}-python"
              "${MINGW_PACKAGE_PREFIX}-openimageio"
              "${MINGW_PACKAGE_PREFIX}-openshadinglanguage"
              "${MINGW_PACKAGE_PREFIX}-zlib")
+optdepends=("${MINGW_PACKAGE_PREFIX}-python: Python bindings")
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/imageworks/OpenColorIO/archive/v${pkgver}.tar.gz
-        0002-install-pc.patch)
+        0002-install-pc.patch
+        0003-fix-python-sitearch.patch)
 sha256sums=('81e3b6e0e432d20347b6396c376f9fbeceac31c2cbefe2882d83112a5b0a8123'
-            'ba79929436bfffb0710335e43197b7c730089e2d9213f60c22416584dbcf2a4a')
+            'ba79929436bfffb0710335e43197b7c730089e2d9213f60c22416584dbcf2a4a'
+            '73660c114f5adfd6c089d0e91ae776601734e8b1ad4f6e773867d7eee4a1a5fb')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -45,7 +49,8 @@ apply_patch_with_msg() {
 prepare() {
   cd ${_realname}-${pkgver}
   apply_patch_with_msg \
-    0002-install-pc.patch
+    0002-install-pc.patch \
+    0003-fix-python-sitearch.patch
 }
 
 build() {
@@ -67,6 +72,7 @@ build() {
     -DCMAKE_CXX_STANDARD=14 \
     -DOCIO_BUILD_TESTS=OFF \
     -DOCIO_BUILD_GPU_TESTS=OFF \
+    -DPython_EXECUTABLE=${MINGW_PREFIX}/bin/python.exe \
     ../${_realname}-${pkgver}
 
   "${MINGW_PREFIX}"/bin/cmake.exe --build .

--- a/mingw-w64-opencolorio/PKGBUILD
+++ b/mingw-w64-opencolorio/PKGBUILD
@@ -18,6 +18,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-glew"
          "${MINGW_PACKAGE_PREFIX}-imath"
          "${MINGW_PACKAGE_PREFIX}-lcms2"
+         "${MINGW_PACKAGE_PREFIX}-minizip-ng"
          "${MINGW_PACKAGE_PREFIX}-openexr"
          "${MINGW_PACKAGE_PREFIX}-yaml-cpp")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
@@ -33,10 +34,14 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 optdepends=("${MINGW_PACKAGE_PREFIX}-python: Python bindings")
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/imageworks/OpenColorIO/archive/v${pkgver}.tar.gz
         0002-install-pc.patch
-        0003-fix-python-sitearch.patch)
+        0003-fix-python-sitearch.patch
+        0004-use-system-minizip.patch
+        0005-Fix-Findminizip-ng.patch)
 sha256sums=('81e3b6e0e432d20347b6396c376f9fbeceac31c2cbefe2882d83112a5b0a8123'
             'ba79929436bfffb0710335e43197b7c730089e2d9213f60c22416584dbcf2a4a'
-            '73660c114f5adfd6c089d0e91ae776601734e8b1ad4f6e773867d7eee4a1a5fb')
+            '73660c114f5adfd6c089d0e91ae776601734e8b1ad4f6e773867d7eee4a1a5fb'
+            'f5dc391070526d8e4ded4ac981c5754080cb9e03897d72b1918ae94ff18cbf1a'
+            'c35f7299b1c2887673a8bacd30b69501fdba044e5df9709b07a962fc3d2840cd')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -50,7 +55,9 @@ prepare() {
   cd ${_realname}-${pkgver}
   apply_patch_with_msg \
     0002-install-pc.patch \
-    0003-fix-python-sitearch.patch
+    0003-fix-python-sitearch.patch \
+    0004-use-system-minizip.patch \
+    0005-Fix-Findminizip-ng.patch
 }
 
 build() {


### PR DESCRIPTION
Reported upstream: https://github.com/AcademySoftwareFoundation/OpenColorIO/issues/1724

Also sorted out deps.