### PR TITLE
Add conflicts/replaces for old non-rust clang32 packages

### DIFF
--- a/mingw-w64-libimagequant/PKGBUILD
+++ b/mingw-w64-libimagequant/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libimagequant
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=4.0.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Palette quantization library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -12,6 +12,8 @@ url='https://github.com/ImageOptim/libimagequant'
 license=("GPL3" "MIT")
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-cargo-c")
+conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}2")
+replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}2")
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/ImageOptim/${_realname}/archive/${pkgver}.tar.gz")
 sha256sums=('d121bbfb380a54aca8ea9d973c2e63afcbc1db67db46ea6bc63eeba44d7937c8')
 

--- a/mingw-w64-librsvg/PKGBUILD
+++ b/mingw-w64-librsvg/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
 pkgver=2.55.1
-pkgrel=1
+pkgrel=2
 pkgdesc="SVG rendering library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -71,6 +71,8 @@ build() {
 }
 
 package_librsvg() {
+  conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-2.40")
+  replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-2.40")
   make -C "${srcdir}/build-${MSYSTEM}" DESTDIR="${pkgdir}" install
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING.LIB" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.LIB"
 

--- a/mingw-w64-python-bcrypt/PKGBUILD
+++ b/mingw-w64-python-bcrypt/PKGBUILD
@@ -7,7 +7,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=4.0.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Modern password hashing for your software and your servers (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -20,6 +20,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools-rust"
              "${MINGW_PACKAGE_PREFIX}-python-wheel"
              "${MINGW_PACKAGE_PREFIX}-cc")
+conflicts=("${MINGW_PACKAGE_PREFIX}-python-${_realname}3")
+replaces=("${MINGW_PACKAGE_PREFIX}-python-${_realname}3")
 options=('staticlibs' 'strip' '!debug')
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/pyca/bcrypt/archive/${pkgver}.tar.gz"
         001-disable-abi3.patch)

--- a/mingw-w64-python-cryptography/PKGBUILD
+++ b/mingw-w64-python-cryptography/PKGBUILD
@@ -7,7 +7,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=38.0.3
-pkgrel=1
+pkgrel=2
 pkgdesc="A package designed to expose cryptographic recipes and primitives to Python developers (mingw-w64)"
 url='https://github.com/pyca/cryptography'
 license=('Apache')
@@ -24,6 +24,8 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest-runner"
               #"${MINGW_PACKAGE_PREFIX}-python-cryptography-vectors"
               "${MINGW_PACKAGE_PREFIX}-python-hypothesis"
               "${MINGW_PACKAGE_PREFIX}-python-pytz")
+conflicts=("${MINGW_PACKAGE_PREFIX}-python-${_realname}3")
+replaces=("${MINGW_PACKAGE_PREFIX}-python-${_realname}3")
 source=(https://pypi.io/packages/source/c/cryptography/${_realname}-${pkgver}.tar.gz
         001-disable-abi3.patch)
 sha256sums=('bfbe6ee19615b07a98b1d2287d6a6073f734735b49ee45b11324d85efc4d5cbd'

--- a/mingw-w64-python-pyopenssl/PKGBUILD
+++ b/mingw-w64-python-pyopenssl/PKGBUILD
@@ -7,7 +7,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=22.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Python wrapper module around the OpenSSL library (mingw-w64)"
 url='https://pypi.python.org/pypi/pyOpenSSL'
 license=('LGPL2.1')
@@ -18,6 +18,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-openssl"
          "${MINGW_PACKAGE_PREFIX}-python-six")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest-runner")
+conflicts=("${MINGW_PACKAGE_PREFIX}-python-${_realname}21")
+replaces=("${MINGW_PACKAGE_PREFIX}-python-${_realname}21")
 source=("https://pypi.io/packages/source/p/pyOpenSSL/pyOpenSSL-${pkgver}.tar.gz")
 sha256sums=('7a83b7b272dd595222d672f5ce29aa030f1fb837630ef229f62e72e395ce8968')
 


### PR DESCRIPTION
so users that have then installed get transferred to the new ones