### PR TITLE
openmp: provide "omp" only in clang envs

### DIFF
--- a/mingw-w64-openmp/PKGBUILD
+++ b/mingw-w64-openmp/PKGBUILD
@@ -11,14 +11,14 @@ _version=15.0.4
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
-pkgrel=1
+pkgrel=2
 pkgdesc="LLVM OpenMP Library (mingw-w64)"
 url="https://openmp.llvm.org/"
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 license=("custom:Apache 2.0 with LLVM Exception")
 groups=($( (( _clangprefix )) && echo "${MINGW_PACKAGE_PREFIX}-toolchain"))
-provides=("${MINGW_PACKAGE_PREFIX}-omp")
+provides=($( (( _clangprefix )) && echo "${MINGW_PACKAGE_PREFIX}-omp"))
 depends=($( (( _clangprefix )) || echo "${MINGW_PACKAGE_PREFIX}-gcc-libs"))
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"


### PR DESCRIPTION
We want "omp" to point to the "default openmp" package, but currently both gcc-libs and openmp provide it there.