### PR TITLE
enable usage of rav1e for clang32 now that it's available

### DIFF
--- a/mingw-w64-ffmpeg/PKGBUILD
+++ b/mingw-w64-ffmpeg/PKGBUILD
@@ -7,7 +7,7 @@ _realname=ffmpeg
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.4.3
-pkgrel=2
+pkgrel=3
 pkgdesc="Complete and free Internet live audio and video broadcasting solution (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -45,7 +45,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-aom"
          "${MINGW_PACKAGE_PREFIX}-opencore-amr"
          "${MINGW_PACKAGE_PREFIX}-openjpeg2"
          "${MINGW_PACKAGE_PREFIX}-opus"
-         $([[ "${MINGW_PACKAGE_PREFIX}" == *clang-i686* || "${MINGW_PACKAGE_PREFIX}" == *clang-aarch64* ]] \
+         $([[ "${MINGW_PACKAGE_PREFIX}" == *clang-aarch64* ]] \
             || echo "${MINGW_PACKAGE_PREFIX}-rav1e")
          "${MINGW_PACKAGE_PREFIX}-rtmpdump"
          "${MINGW_PACKAGE_PREFIX}-SDL2"
@@ -180,8 +180,7 @@ build() {
     )
   fi
 
-  if [[ "${MINGW_PACKAGE_PREFIX}" != *clang-i686* && 
-        "${MINGW_PACKAGE_PREFIX}" != *clang-aarch64* ]]; then
+  if [[ "${MINGW_PACKAGE_PREFIX}" != *clang-aarch64* ]]; then
     common_config+=(
        --enable-librav1e
     )

--- a/mingw-w64-libavif/PKGBUILD
+++ b/mingw-w64-libavif/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libavif
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.11.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Library for encoding and decoding .avif files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -12,8 +12,7 @@ url="https://github.com/AOMediaCodec/libavif"
 license=('spdx:BSD-2-Clause')
 depends=("${MINGW_PACKAGE_PREFIX}-aom"
          "${MINGW_PACKAGE_PREFIX}-dav1d"
-         $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-i686* || \
-               ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || \
+         $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || \
             echo "${MINGW_PACKAGE_PREFIX}-rav1e" )
          $( [[ ${CARCH} != x86_64 ]] || \
             echo "${MINGW_PACKAGE_PREFIX}-svt-av1" )
@@ -49,8 +48,7 @@ build() {
     -DAVIF_BUILD_APPS=ON \
     -DAVIF_CODEC_AOM=ON \
     -DAVIF_CODEC_DAV1D=ON \
-    -DAVIF_CODEC_RAV1E=$( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-i686* || \
-                             ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] &&
+    -DAVIF_CODEC_RAV1E=$( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] &&
                           echo "OFF" || echo "ON" ) \
     -DAVIF_CODEC_SVT=$( [[ ${CARCH} != x86_64 ]] &&
                         echo "OFF" || echo "ON" ) \

--- a/mingw-w64-libheif/PKGBUILD
+++ b/mingw-w64-libheif/PKGBUILD
@@ -29,8 +29,8 @@ source=("https://github.com/strukturag/libheif/releases/download/v${pkgver}/${_r
         "001-pkgconfig-match-autotools.patch"::"https://patch-diff.githubusercontent.com/raw/strukturag/libheif/pull/529.diff"
         "002-cmake-enable-gdk-pixbuf.patch"::"https://patch-diff.githubusercontent.com/raw/strukturag/libheif/pull/647.diff")
 sha256sums=('c20ae01bace39e89298f6352f1ff4a54b415b33b9743902da798e8a1e51d7ca1'
-            '9f9a1ee8161643c44cc7813cdd4d8721ab3e67b5262cf4a29988307fd667f4ae'
-            '9aea63f92de2d71a0d021baf2d31df39f9633b16d715c11572cf54e64bb4a52d')
+            '80d6acd6b2035572c1547673cf73a2c6a83cd42c0a475a1258551a2983b06d9f'
+            '649e6d2635ee1c86a064ee35e9dc81713883ef7275aec439c3200488075260b9')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"

--- a/mingw-w64-libheif/PKGBUILD
+++ b/mingw-w64-libheif/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libheif
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.13.0
-pkgrel=2
+pkgrel=3
 pkgdesc="HEIF image decoder/encoder library and tools (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -22,8 +22,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
          "${MINGW_PACKAGE_PREFIX}-libpng"
          "${MINGW_PACKAGE_PREFIX}-libwinpthread-git"
-         $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-i686* || \
-               ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || \
+         $( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || \
             echo "${MINGW_PACKAGE_PREFIX}-rav1e" )
          "${MINGW_PACKAGE_PREFIX}-x265")
 source=("https://github.com/strukturag/libheif/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz"


### PR DESCRIPTION
Unfortunately, rav1e is still not available for clangarm64 because it makedepends on cargo-c, which has crates that it depends on that still depend on versions of other crates that don't yet support the new -gnullvm targets.