### PR TITLE
mcfgthread: Update to v1.3-ga.2

### DIFF
--- a/mingw-w64-mcfgthread/PKGBUILD
+++ b/mingw-w64-mcfgthread/PKGBUILD
@@ -4,14 +4,14 @@ _realname=mcfgthread
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}"-libs)
-pkgver=1.3
+pkgver=1.3.2
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://github.com/lhmouse/mcfgthread"
 license=('spdx:LGPL-3.0-or-later' 'custom')
 options=('staticlibs' 'strip' '!buildflags')
-_commit='9405c6a8f54e6979f43a0e482eef58eb4ae34a53'
+_commit='e1c442af05e76d9ed7ab33c0134bf10d1d563d04'
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cc"
   "${MINGW_PACKAGE_PREFIX}-autotools"


### PR DESCRIPTION
1. On 32-bit targets, the returned pointer of `_MCF_thread_get_data()` is now correctly aligned to a 16-byte boundary.
2. If `_MCF_thread_new()` fails because the size of requested data is too large, it now sets the last-error number to `ERROR_ARITHMETIC_OVERFLOW`, instead of `ERROR_NOT_ENOUGH_MEMORY`.

https://github.com/lhmouse/mcfgthread/releases/tag/v1.3-ga.2
