### PR TITLE
gegl: Update to 0.4.40

### DIFF
--- a/mingw-w64-gegl/PKGBUILD
+++ b/mingw-w64-gegl/PKGBUILD
@@ -4,8 +4,8 @@
 _realname=gegl
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.4.38
-pkgrel=4
+pkgver=0.4.40
+pkgrel=1
 pkgdesc="Generic Graphics Library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -47,10 +47,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-babl"
          "${MINGW_PACKAGE_PREFIX}-suitesparse")
 #options=('!strip' 'debug')
 noextract=("${_realname}-${pkgver}.tar.xz")
-source=(https://download.gimp.org/pub/gegl/${pkgver%.*}/${_realname}-${pkgver}.tar.xz
-        001-openmp-openexr.patch::https://gitlab.gnome.org/GNOME/gegl/-/commit/d54fc3ccd37f9d769c9a55bd8ec065330e9654f5.diff)
-sha256sums=('e4a33c8430a5042fba8439b595348e71870f0d95fbf885ff553f9020c1bed750'
-            'd72a3c2e1b15a4cc0d6ef3f8d7ca9db7c7ed288000d3c1fc3cb8d6b4fe8a180b')
+source=(https://download.gimp.org/pub/gegl/${pkgver%.*}/${_realname}-${pkgver}.tar.xz)
+sha256sums=('cdde80d15a49dab9a614ef98f804c8ce6e4cfe1339a3c240c34f3fb45436b85d')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -62,19 +60,7 @@ apply_patch_with_msg() {
 
 prepare() {
   tar -xf "${_realname}-${pkgver}.tar.xz" || true
-
-# The tar utility cannot extract gegl_crop.lua and gegl_fill-path.lua from
-# the archive because they are symblic links (to gegl_rectangle.lua and
-# gegl_vector-stroke.lua, respectively.
-#
-# Here we just make copies to work around that.
-
-  cd "${srcdir}/${_realname}-${pkgver}"
-  cp bin/lua/gegl_rectangle.lua bin/lua/gegl_crop.lua
-  cp bin/lua/gegl_vector-stroke.lua bin/lua/gegl_fill-path.lua
-
-  apply_patch_with_msg \
-    001-openmp-openexr.patch
+  tar -xf "${_realname}-${pkgver}.tar.xz" || true
 }
 
 build() {


### PR DESCRIPTION
just extract twice to work around the symlink issue