### PR TITLE
iso-codes: Update to 4.12.0

### DIFF
--- a/mingw-w64-iso-codes/PKGBUILD
+++ b/mingw-w64-iso-codes/PKGBUILD
@@ -3,19 +3,16 @@
 _realname=iso-codes
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.11.0
+pkgver=4.12.0
 pkgrel=1
 pkgdesc="Lists of the country, language, and currency names (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 license=('spdx:LGPL-2.1-or-later')
-makedepends=("git" "${MINGW_PACKAGE_PREFIX}-autotools" "${MINGW_PACKAGE_PREFIX}-python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools" "${MINGW_PACKAGE_PREFIX}-python")
 url="https://salsa.debian.org/iso-codes-team/iso-codes"
 source=(https://salsa.debian.org/iso-codes-team/iso-codes/-/archive/v${pkgver}/iso-codes-v${pkgver}.tar.gz)
-sha256sums=('408f799df4135468fa7ca35eb6b05c4004bea443d81ca58b89b2e482401a82bb')
-validpgpkeys=('D1CB8F39BC5DED24C5D2C78C1302F1F036EBEB19' #Dr. Tobias Quathamer <t.quathamer@mailbox.org>
-              '1302F1F036EBEB19' #Dr. Tobias Quathamer <t.quathamer@mailbox.org>
-              'F972A168A2703B34CC23E09FD4E5EDACC0143D2D') # Christian Perrier <christian.perrier@onera.fr>
+sha256sums=('ead53ac6cb000a726350eda10381b2339e7bed0680924d761d63f28f32da94b5')
 
 prepare() {
   cd ${_realname}-v${pkgver}


### PR DESCRIPTION
* drop pgpkeys, there no longer is a signature file
* drop git makedep, we use a tarball