### PR TITLE
readline: Fix regression in patch 001

### DIFF
--- a/mingw-w64-readline/0002-event-hook.patch
+++ b/mingw-w64-readline/0002-event-hook.patch
@@ -1,7 +1,7 @@
-diff -ur readline-8.1.3/input.c readline-8.1.4/input.c
---- readline-8.1.3/input.c	2020-12-19 07:56:01.572775578 -0500
-+++ readline-8.1.4/input.c	2020-12-19 07:57:24.608319024 -0500
-@@ -142,6 +142,11 @@
+diff -urN readline-8.2/input.c.orig readline-8.2/input.c
+--- readline-8.2/input.c.orig	2022-04-08 21:43:24.000000000 +0200
++++ readline-8.2/input.c	2022-11-22 16:54:55.099070500 +0100
+@@ -176,6 +176,11 @@
  static unsigned char ibuffer[512];
  static int ibuffer_len = sizeof (ibuffer) - 1;
  
@@ -13,7 +13,7 @@ diff -ur readline-8.1.3/input.c readline-8.1.4/input.c
  #define any_typein (push_index != pop_index)
  
  int
-@@ -268,7 +273,7 @@
+@@ -306,7 +311,7 @@
  #if defined (__MINGW32__)
    /* Use getch/_kbhit to check for available console input, in the same way
       that we read it normally. */
@@ -22,7 +22,16 @@ diff -ur readline-8.1.3/input.c readline-8.1.4/input.c
     result = 0;
  #endif
  
-@@ -520,6 +525,120 @@
+@@ -404,7 +409,7 @@
+ 
+ #if defined (__MINGW32__)
+   if (isatty (tty))
+-    return (_kbhit ());
++    return (_win32_kbhit ());
+ #endif
+ 
+   return 0;
+@@ -799,6 +804,120 @@
    return (c);
  }
  
@@ -143,7 +152,8 @@ diff -ur readline-8.1.3/input.c readline-8.1.4/input.c
  int
  rl_getc (FILE *stream)
  {
-@@ -819,7 +939,12 @@
+@@ -818,8 +937,13 @@
+       /* We know at this point that _rl_caught_signal == 0 */
  
  #if defined (__MINGW32__)
 -      if (isatty (fd)

--- a/mingw-w64-readline/0004-locale.patch
+++ b/mingw-w64-readline/0004-locale.patch
@@ -1,0 +1,13 @@
+--- readline-8.2/nls.c.orig	2022-08-15 15:38:51.000000000 +0200
++++ readline-8.2/nls.c	2022-11-22 18:37:21.816799800 +0100
+@@ -141,8 +141,10 @@
+   if (lspec == 0)
+     lspec = "";
+   ret = setlocale (LC_CTYPE, lspec);	/* ok, since it does not change locale */
++#if !defined (__MINGW32__)
+   if (ret == 0 || *ret == 0)
+     ret = setlocale (LC_CTYPE, (char *)NULL);
++#endif
+   if (ret == 0 || *ret == 0)
+     ret = RL_DEFAULT_LOCALE;
+ #else

--- a/mingw-w64-readline/PKGBUILD
+++ b/mingw-w64-readline/PKGBUILD
@@ -6,7 +6,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _basever=8.2
 _patchlevel=001
 pkgver=${_basever}.${_patchlevel}
-pkgrel=1
+pkgrel=2
 pkgdesc="MinGW port of readline for editing typed command lines (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -23,7 +23,8 @@ source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${_basever}.tar.gz"{,
         "0001-sigwinch.patch"
         # Patch adopted from https://hg.octave.org/mxe-octave/file/41e50d658de0/src/readline-2-event-hook.patch
         "0002-event-hook.patch"
-        "0003-fd_set.patch")
+        "0003-fd_set.patch"
+        "0004-locale.patch")
 if [ ${_patchlevel} -gt 00 ]; then
     for (( p=1; p<=$((10#${_patchlevel})); p++ )); do
         source=(${source[@]} https://ftp.gnu.org/gnu/${_realname}/${_realname}-${_basever}-patches/readline${_basever//./}-$(printf "%03d" $p){,.sig})
@@ -33,8 +34,9 @@ validpgpkeys=('7C0135FB088AAF6C66C650B9BB5869F064EA74AB')
 sha256sums=('3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35'
             'SKIP'
             '2b30dcb0804abb6e7e4f44cd119bddef94c1b1d7ebff43dda401e710eda2fd0f'
-            '72affc06e992c8bd9efc531a1b6ea309eaf6143144e7f98cadbc8bdf05b3eae9'
+            '7d8aa943e915ccbf7723710c52e9d73135ff129456e83cb114f627c298d33eaf'
             '6c90a984519f6e5a201c3b107ec5a7319db2a4f7b30f48dd43c0964894fbf3a6'
+            '62b62aae03c16c321c12c614004c3a0eb4d1f6ec29d813d7ad6ae7f88bfbc7b9'
             'bbf97f1ec40a929edab5aa81998c1e2ef435436c597754916e6a5868f273aff7'
             'SKIP')
 
@@ -57,7 +59,8 @@ prepare() {
   apply_patch_with_msg \
     0001-sigwinch.patch \
     0002-event-hook.patch \
-    0003-fd_set.patch
+    0003-fd_set.patch \
+    0004-locale.patch
 
   # Remove RPATH from shared objects (FS#14366)
   sed -i 's|-Wl,-rpath,$(libdir) ||g' support/shobj-conf


### PR DESCRIPTION
This fixes #14213 for me.

It looks like the issue was caused by part of the upstream patch 001. If I understand its intention correctly, the main goal is to have a valid fallback locale in case detecting it (with `setlocale`) fails. That should still be the case with the proposed change.

Also thank you to @lostbard for his hints in https://savannah.gnu.org/bugs/index.php?63400.