### PR TITLE
embree: enable clangarm64 support

### DIFF
--- a/mingw-w64-embree/002-fix-clangarm64-build.patch
+++ b/mingw-w64-embree/002-fix-clangarm64-build.patch
@@ -1,0 +1,101 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index aec0817..7978cc8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -173,6 +173,10 @@ SET(EMBREE_TBB_COMPONENT "tbb" CACHE STRING "The TBB component/library name.")
+ 
+ IF (WIN32)
+   SET_PROPERTY(CACHE EMBREE_TASKING_SYSTEM PROPERTY STRINGS TBB INTERNAL PPL)
++  IF (CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
++    MESSAGE(STATUS "Building for Windows ARM64")
++    SET(EMBREE_ARM ON)
++  ENDIF()
+ ELSE()
+   SET_PROPERTY(CACHE EMBREE_TASKING_SYSTEM PROPERTY STRINGS TBB INTERNAL)
+ ENDIF()
+diff --git a/common/simd/arm/sse2neon.h b/common/simd/arm/sse2neon.h
+index 4341666..d97f801 100644
+--- a/common/simd/arm/sse2neon.h
++++ b/common/simd/arm/sse2neon.h
+@@ -1731,10 +1731,12 @@ FORCE_INLINE __m128 _mm_div_ss(__m128 a, __m128 b)
+ 
+ // Free aligned memory that was allocated with _mm_malloc.
+ // https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_free
++#if !(defined _WIN32 && defined __has_include && __has_include(<mm_malloc.h>))
+ FORCE_INLINE void _mm_free(void *addr)
+ {
+     free(addr);
+ }
++#endif
+ 
+ // Macro: Get the flush zero bits from the MXCSR control and status register.
+ // The flush zero may contain any of the following flags: _MM_FLUSH_ZERO_ON or
+@@ -1916,6 +1918,7 @@ FORCE_INLINE __m128i _mm_loadu_si64(const void *p)
+ // Allocate aligned blocks of memory.
+ // https://software.intel.com/en-us/
+ //         cpp-compiler-developer-guide-and-reference-allocating-and-freeing-aligned-memory-blocks
++#if !(defined _WIN32 && defined __has_include && __has_include(<mm_malloc.h>))
+ FORCE_INLINE void *_mm_malloc(size_t size, size_t align)
+ {
+     void *ptr;
+@@ -1927,6 +1930,7 @@ FORCE_INLINE void *_mm_malloc(size_t size, size_t align)
+         return ptr;
+     return NULL;
+ }
++#endif
+ 
+ // Conditionally store 8-bit integer elements from a into memory using mask
+ // (elements are not stored when the highest bit is not set in the corresponding
+@@ -5954,7 +5958,7 @@ FORCE_INLINE void _mm_storeu_si32(void *p, __m128i a)
+ FORCE_INLINE void _mm_stream_pd(double *p, __m128d a)
+ {
+ #if __has_builtin(__builtin_nontemporal_store)
+-    __builtin_nontemporal_store(a, (float32x4_t *) p);
++    __builtin_nontemporal_store(a, (float64x2_t *) p);
+ #elif defined(__aarch64__)
+     vst1q_f64(p, vreinterpretq_f64_m128d(a));
+ #else
+diff --git a/common/sys/intrinsics.h b/common/sys/intrinsics.h
+index 2c2f6ec..21e9878 100644
+--- a/common/sys/intrinsics.h
++++ b/common/sys/intrinsics.h
+@@ -89,7 +89,7 @@ namespace embree
+ #endif
+   }
+   
+-#if defined(__X86_64__)
++#if defined(__X86_64__) || defined (__aarch64__)
+   __forceinline size_t bsf(size_t v) {
+ #if defined(__AVX2__) 
+     return _tzcnt_u64(v);
+@@ -113,7 +113,7 @@ namespace embree
+     return i;
+   }
+   
+-#if defined(__X86_64__)
++#if defined(__X86_64__) || defined(__aarch64__)
+   __forceinline size_t bscf(size_t& v) 
+   {
+     size_t i = bsf(v);
+@@ -138,7 +138,7 @@ namespace embree
+ #endif
+   }
+   
+-#if defined(__X86_64__)
++#if defined(__X86_64__) || defined(__aarch64__)
+   __forceinline size_t bsr(size_t v) {
+ #if defined(__AVX2__) 
+     return 63 -_lzcnt_u64(v);
+diff --git a/include/embree3/rtcore_common.h b/include/embree3/rtcore_common.h
+index 894628e..f403fcd 100644
+--- a/include/embree3/rtcore_common.h
++++ b/include/embree3/rtcore_common.h
+@@ -12,7 +12,7 @@
+ RTC_NAMESPACE_BEGIN
+ 
+ #if defined(_WIN32)
+-#if defined(_M_X64)
++#if defined(_M_X64) || defined(_M_ARM64)
+ typedef long long ssize_t;
+ #else
+ typedef int ssize_t;

--- a/mingw-w64-embree/PKGBUILD
+++ b/mingw-w64-embree/PKGBUILD
@@ -4,10 +4,10 @@ _realname=embree
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.13.5
-pkgrel=2
+pkgrel=3
 pkgdesc="High Performance Ray Tracing Kernels Intel Corporation (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://www.embree.org/"
 license=("spdx:Apache-2.0")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
@@ -16,13 +16,16 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-cc")
 options=('strip' 'buildflags' '!debug')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/embree/embree/archive/v${pkgver}.tar.gz
-        001-build-fixes.patch)
+        001-build-fixes.patch
+        002-fix-clangarm64-build.patch)
 sha256sums=('b8c22d275d9128741265537c559d0ea73074adbf2f2b66b0a766ca52c52d665b'
-            '5ee91fb07f373b3a83f26f9f9fa3ab80661a9f0b7e1c3f4a23eb572f631fa37f')
+            '5ee91fb07f373b3a83f26f9f9fa3ab80661a9f0b7e1c3f4a23eb572f631fa37f'
+            'e787805be257d25b8b96db256d2fe4da244b922e9edb58fb35160e78fd55f064')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/001-build-fixes.patch
+  patch -p1 -i ${srcdir}/002-fix-clangarm64-build.patch
 
   mv kernels/embree.rc{,.orig}
   iconv -f UTF-16LE -t UTF-8 kernels/embree.rc.orig > kernels/embree.rc


### PR DESCRIPTION
Patches based on https://github.com/embree/embree/pull/414.