### PR TITLE
mcfgthread: Upgrade to v1.3-ga.3

### DIFF
--- a/mingw-w64-mcfgthread/PKGBUILD
+++ b/mingw-w64-mcfgthread/PKGBUILD
@@ -4,14 +4,14 @@ _realname=mcfgthread
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}"-libs)
-pkgver=1.3.2
+pkgver=1.3.3
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://github.com/lhmouse/mcfgthread"
 license=('spdx:LGPL-3.0-or-later' 'custom')
 options=('staticlibs' 'strip' '!buildflags')
-_commit='e1c442af05e76d9ed7ab33c0134bf10d1d563d04'
+_commit='b1fc172e6dfb6c041a0040a3041349475a235189'
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cc"
   "${MINGW_PACKAGE_PREFIX}-autotools"


### PR DESCRIPTION
1. Attempting to join with the calling thread itself, which will always fail, no longer makes it non-joinable.
2. `_MCF_event_await_change()` now returns the current value of an event, which is a byte and is thus always non-negative, instead of zero. This is an ABI break if code checks for success by comparing the result with zero.

https://github.com/lhmouse/mcfgthread/releases/v1.3-ga.3