### PR TITLE
New package: bscan-spi-bitstreams

### DIFF
--- a/mingw-w64-bscan-spi-bitstreams/PKGBUILD
+++ b/mingw-w64-bscan-spi-bitstreams/PKGBUILD
@@ -10,21 +10,12 @@ mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://github.com/quartiq/bscan_spi_bitstreams"
 license=('MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-openocd")
-source=("${_realname}.zip::https://github.com/quartiq/bscan_spi_bitstreams/archive/refs/heads/master.zip")
+source=("${_realname}.zip::https://github.com/quartiq/bscan_spi_bitstreams/archive/bee624d.zip")
 sha256sums=('bbdf9e51b94502a10119c3aa22f1e7c21c0d25273436e2749782c119e980c87e')
 
-prepare(){
-  cd ${srcdir}
-  mv bscan_spi_bitstreams-master ${_realname} 
-}
-
-build() {
-  cd ${srcdir}/${_realname}
-}
-
 package() {
-  cd ${srcdir}/${_realname}
+  cd ${srcdir}/bscan_spi_bitstreams-bee624dda0b8b44a31a527be14bc9a0c65d589a4
   mkdir -p "${pkgdir}${MINGW_PREFIX}/share/bscan-spi-bitstreams"
-  install -Dm755 *.bit "${pkgdir}${MINGW_PREFIX}/share/bscan-spi-bitstreams"
+  install -Dm644 *.bit "${pkgdir}${MINGW_PREFIX}/share/bscan-spi-bitstreams"
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-bscan-spi-bitstreams/PKGBUILD
+++ b/mingw-w64-bscan-spi-bitstreams/PKGBUILD
@@ -11,7 +11,7 @@ mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://github.com/quartiq/bscan_spi_bitstreams"
 license=('MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-openocd")
-source=("${_realname}.zip::https://github.com/quartiq/bscan_spi_bitstreams/archive/bee624d.zip")
+source=("${_realname}.zip::https://github.com/quartiq/bscan_spi_bitstreams/archive/bee624dda0b8b44a31a527be14bc9a0c65d589a4.zip")
 sha256sums=('8cdbf549adee9766c591b6fee258a41a93cc2378579e9b3b71073c2a2c3c614f')
 
 package() {

--- a/mingw-w64-bscan-spi-bitstreams/PKGBUILD
+++ b/mingw-w64-bscan-spi-bitstreams/PKGBUILD
@@ -3,6 +3,7 @@
 _realname=bscan-spi-bitstreams
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.0
 pkgrel=1
 pkgdesc="JTAG-SPI proxy bitstreams to be used with the OpenOCD jtagspi flash driver"
 arch=('any')
@@ -11,7 +12,7 @@ url="https://github.com/quartiq/bscan_spi_bitstreams"
 license=('MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-openocd")
 source=("${_realname}.zip::https://github.com/quartiq/bscan_spi_bitstreams/archive/bee624d.zip")
-sha256sums=('bbdf9e51b94502a10119c3aa22f1e7c21c0d25273436e2749782c119e980c87e')
+sha256sums=('8cdbf549adee9766c591b6fee258a41a93cc2378579e9b3b71073c2a2c3c614f')
 
 package() {
   cd ${srcdir}/bscan_spi_bitstreams-bee624dda0b8b44a31a527be14bc9a0c65d589a4

--- a/mingw-w64-bscan-spi-bitstreams/PKGBUILD
+++ b/mingw-w64-bscan-spi-bitstreams/PKGBUILD
@@ -24,7 +24,7 @@ build() {
 
 package() {
   cd ${srcdir}/${_realname}
-  mkdir "${pkgdir}${MINGW_PREFIX}/share/bscan-spi-bitstreams"
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/share/bscan-spi-bitstreams"
   install -Dm755 *.bit "${pkgdir}${MINGW_PREFIX}/share/bscan-spi-bitstreams"
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-bscan-spi-bitstreams/PKGBUILD
+++ b/mingw-w64-bscan-spi-bitstreams/PKGBUILD
@@ -24,7 +24,7 @@ build() {
 
 package() {
   cd ${srcdir}/${_realname}
-  mkdir "${pkgdir}${MINGW_PREFIX}/bin"
-  install -Dm755 *.bit "${pkgdir}${MINGW_PREFIX}/bin"
+  mkdir "${pkgdir}${MINGW_PREFIX}/share/bscan-spi-bitstreams"
+  install -Dm755 *.bit "${pkgdir}${MINGW_PREFIX}/share/bscan-spi-bitstreams"
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-bscan-spi-bitstreams/PKGBUILD
+++ b/mingw-w64-bscan-spi-bitstreams/PKGBUILD
@@ -9,8 +9,7 @@ arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://github.com/quartiq/bscan_spi_bitstreams"
 license=('MIT')
-depends=("${MINGW_PACKAGE_PREFIX}-openocd"
-         "${MINGW_PACKAGE_PREFIX}-artiq")
+depends=("${MINGW_PACKAGE_PREFIX}-openocd")
 source=("${_realname}.zip::https://github.com/quartiq/bscan_spi_bitstreams/archive/refs/heads/master.zip")
 sha256sums=('bbdf9e51b94502a10119c3aa22f1e7c21c0d25273436e2749782c119e980c87e')
 
@@ -24,8 +23,8 @@ build() {
 }
 
 package() {
-  mkdir -p "${pkgdir}${MINGW_PREFIX}/bin"
-  cp "${srcdir}/${_realname}"/*.bit "${pkgdir}${MINGW_PREFIX}/bin"
   cd ${srcdir}/${_realname}
+  mkdir "${pkgdir}${MINGW_PREFIX}/bin"
+  install -Dm755 *.bit "${pkgdir}${MINGW_PREFIX}/bin"
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-bscan-spi-bitstreams/PKGBUILD
+++ b/mingw-w64-bscan-spi-bitstreams/PKGBUILD
@@ -1,0 +1,31 @@
+# Contributor: Liu Pak Hin <wl@m-labs.hk>
+
+_realname=bscan-spi-bitstreams
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgrel=1
+pkgdesc="JTAG-SPI proxy bitstreams to be used with the OpenOCD jtagspi flash driver"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+url="https://github.com/quartiq/bscan_spi_bitstreams"
+license=('MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-openocd"
+         "${MINGW_PACKAGE_PREFIX}-artiq")
+source=("${_realname}.zip::https://github.com/quartiq/bscan_spi_bitstreams/archive/refs/heads/master.zip")
+sha256sums=('bbdf9e51b94502a10119c3aa22f1e7c21c0d25273436e2749782c119e980c87e')
+
+prepare(){
+  cd ${srcdir}
+  mv bscan_spi_bitstreams-master ${_realname} 
+}
+
+build() {
+  cd ${srcdir}/${_realname}
+}
+
+package() {
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/bin"
+  cp "${srcdir}/${_realname}"/*.bit "${pkgdir}${MINGW_PREFIX}/bin"
+  cd ${srcdir}/${_realname}
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
JTAG-SPI proxy bitstreams to be used with the OpenOCD jtagspi flash driver