### PR TITLE
graphicsmagick: use omp metapackage, enable for clangarm64

### DIFF
--- a/mingw-w64-graphicsmagick/PKGBUILD
+++ b/mingw-w64-graphicsmagick/PKGBUILD
@@ -4,7 +4,7 @@ _realname=graphicsmagick
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.3.38
-pkgrel=5
+pkgrel=6
 pkgdesc="An image viewing/manipulation program (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -31,10 +31,10 @@ depends=("${MINGW_PACKAGE_PREFIX}-bzip2"
          "${MINGW_PACKAGE_PREFIX}-libwmf"
          "${MINGW_PACKAGE_PREFIX}-libltdl"
          "${MINGW_PACKAGE_PREFIX}-libwinpthread-git"
+         "${MINGW_PACKAGE_PREFIX}-omp"
          "${MINGW_PACKAGE_PREFIX}-xz"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-zstd"
-         $([[ ${MINGW_PACKAGE_PREFIX} != *-clang-*86* ]] || echo "${MINGW_PACKAGE_PREFIX}-openmp"))
          #"${MINGW_PACKAGE_PREFIX}-perl"
 optdepends=("${MINGW_PACKAGE_PREFIX}-ghostscript: for Ghostscript support"
             "${MINGW_PACKAGE_PREFIX}-libjxl: for JPEG XL support")


### PR DESCRIPTION
Related to #13783 