### PR TITLE
embree: enable clangarm64 support

### DIFF
--- a/mingw-w64-embree/PKGBUILD
+++ b/mingw-w64-embree/PKGBUILD
@@ -4,7 +4,7 @@ _realname=embree
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.13.5
-pkgrel=2
+pkgrel=3
 pkgdesc="High Performance Ray Tracing Kernels Intel Corporation (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -16,13 +16,16 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-cc")
 options=('strip' 'buildflags' '!debug')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/embree/embree/archive/v${pkgver}.tar.gz
-        001-build-fixes.patch)
+        001-build-fixes.patch
+        https://github.com/embree/embree/pull/412.patch)
 sha256sums=('b8c22d275d9128741265537c559d0ea73074adbf2f2b66b0a766ca52c52d665b'
-            '5ee91fb07f373b3a83f26f9f9fa3ab80661a9f0b7e1c3f4a23eb572f631fa37f')
-
+            '5ee91fb07f373b3a83f26f9f9fa3ab80661a9f0b7e1c3f4a23eb572f631fa37f'
+            '8bc0c0635ec0969eb60768fa9d0682096d96d17bf818eb995700f5f64601df14')
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/001-build-fixes.patch
+  # Windows ARM64 support
+  patch -p1 -i ${srcdir}/412.patch
 
   mv kernels/embree.rc{,.orig}
   iconv -f UTF-16LE -t UTF-8 kernels/embree.rc.orig > kernels/embree.rc
@@ -43,6 +46,12 @@ build() {
     extra_config+=("-DEMBREE_ISA_AVX512=ON")
   else
     extra_config+=("-DEMBREE_ISA_AVX512=OFF")
+  fi
+
+  if [[ "${CARCH}" == "aarch64" ]]; then
+    extra_config+=("-DEMBREE_ARM=ON")
+  else
+    extra_config+=("-DEMBREE_ARM=OFF")
   fi
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \


### PR DESCRIPTION
Patches based on https://github.com/embree/embree/pull/412.