### PR TITLE
install-depends fix: arv-viewer needs videoflip GStreamer plugin, whi…

### DIFF
--- a/mingw-w64-aravis/PKGBUILD
+++ b/mingw-w64-aravis/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=(
 	"${MINGW_PACKAGE_PREFIX}-${_realname}-gst"
 )
 pkgver=0.8.22
-pkgrel=2
+pkgrel=3
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 pkgdesc="A vision library for genicam based cameras"

--- a/mingw-w64-aravis/PKGBUILD
+++ b/mingw-w64-aravis/PKGBUILD
@@ -96,7 +96,7 @@ package_aravis-gst() {
 	depends=(
 		"${MINGW_PACKAGE_PREFIX}-aravis"
 		"${MINGW_PACKAGE_PREFIX}-gtk3"
-		"${MINGW_PACKAGE_PREFIX}-gst-plugins-base"
+		"${MINGW_PACKAGE_PREFIX}-gst-plugins-good"
 		"${MINGW_PACKAGE_PREFIX}-gstreamer"
 	)
 	# DESTDIR="$_TMP" ${MINGW_PREFIX}/bin/meson install


### PR DESCRIPTION
…ch is in -good plugins

(-base is still sufficient for building)