### PR TITLE
octave: change console codepage to UTF-8

### DIFF
--- a/mingw-w64-octave/0001-console-codepage.patch
+++ b/mingw-w64-octave/0001-console-codepage.patch
@@ -1,0 +1,121 @@
+# HG changeset patch
+# User Markus Mützel <markus.muetzel@gmx.de>
+# Date 1670071302 -3600
+#      Sat Dec 03 13:41:42 2022 +0100
+# Branch stable
+# Node ID ea0b06534a370ad65bd1b8ec0140289eef153585
+# Parent  59422a6fbd915d2115b35f8a7e762008083f401d
+Windows: Set console input and output codepages to UTF-8 if supported.
+
+* src/main-cli.cc (main), src/main-gui.cc (main): Temporary set the input and
+output codepage for the console to UTF-8. That is needed so that non-ASCII
+characters entered at the CLI are correctly stored as UTF-8 in Octave character
+arrays, and so that UTF-8 encoded character arrays are correctly displayed in
+the CLI.
+
+diff -r 59422a6fbd91 -r ea0b06534a37 src/main-cli.cc
+--- a/src/main-cli.cc	Fri Dec 02 21:34:15 2022 -0800
++++ b/src/main-cli.cc	Sat Dec 03 13:41:42 2022 +0100
+@@ -36,6 +36,8 @@
+ #  include <vector>
+ #  include <locale>
+ #  include <codecvt>
++#  include <windows.h>
++#  include <versionhelpers.h>
+ #endif
+ 
+ #include "liboctave-build-info.h"
+@@ -105,6 +107,20 @@
+     argv[i_arg] = &argv_str[i_arg][0];
+   argv[argc] = nullptr;
+ 
++  unsigned int old_console_codepage = 0;
++  unsigned int old_console_output_codepage = 0;
++
++  if (IsWindows7OrGreater ())
++    {
++      // save old console input and output codepages
++      old_console_codepage = GetConsoleCP ();
++      old_console_output_codepage = GetConsoleOutputCP ();
++
++      // set console input and output codepages to UTF-8
++      SetConsoleCP (65001);
++      SetConsoleOutputCP (65001);
++    }
++
+ #else
+ int
+ main (int argc, char **argv)
+@@ -118,5 +134,18 @@
+ 
+   octave::cli_application app (argc, argv);
+ 
+-  return app.execute ();
++  int ret = app.execute ();
++
++#if defined (OCTAVE_USE_WINDOWS_API) && defined (_UNICODE)
++  if (IsWindows7OrGreater ())
++    {
++      // restore previous console input and output codepages
++      if (old_console_codepage)
++        SetConsoleCP (old_console_codepage);
++      if (old_console_output_codepage)
++        SetConsoleOutputCP (old_console_output_codepage);
++    }
++#endif
++
++  return ret;
+ }
+diff -r 59422a6fbd91 -r ea0b06534a37 src/main-gui.cc
+--- a/src/main-gui.cc	Fri Dec 02 21:34:15 2022 -0800
++++ b/src/main-gui.cc	Sat Dec 03 13:41:42 2022 +0100
+@@ -36,6 +36,8 @@
+ #  include <vector>
+ #  include <locale>
+ #  include <codecvt>
++#  include <windows.h>
++#  include <versionhelpers.h>
+ #endif
+ 
+ #include "liboctave-build-info.h"
+@@ -118,6 +120,20 @@
+     argv[i_arg] = &argv_str[i_arg][0];
+   argv[argc] = nullptr;
+ 
++  unsigned int old_console_codepage = 0;
++  unsigned int old_console_output_codepage = 0;
++
++  if (IsWindows7OrGreater ())
++    {
++      // save old console input and output codepages
++      old_console_codepage = GetConsoleCP ();
++      old_console_output_codepage = GetConsoleOutputCP ();
++
++      // set console input and output codepages to UTF-8
++      SetConsoleCP (65001);
++      SetConsoleOutputCP (65001);
++    }
++
+ #else
+ int
+ main (int argc, char **argv)
+@@ -129,5 +145,18 @@
+ 
+   octave::qt_application app (argc, argv);
++
++  int ret = app.execute ();
+ 
+-  return app.execute ();
++#if defined (OCTAVE_USE_WINDOWS_API) && defined (_UNICODE)
++  if (IsWindows7OrGreater ())
++    {
++      // restore previous console input and output codepages
++      if (old_console_codepage)
++        SetConsoleCP (old_console_codepage);
++      if (old_console_output_codepage)
++        SetConsoleOutputCP (old_console_output_codepage);
++    }
++#endif
++
++  return ret;
+ }

--- a/mingw-w64-octave/PKGBUILD
+++ b/mingw-w64-octave/PKGBUILD
@@ -2,7 +2,7 @@ _realname=octave
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=7.3.0
-pkgrel=1
+pkgrel=2
 pkgdesc="GNU Octave: Interactive programming environment for numerical computations (mingw-w64)"
 url="https://www.octave.org"
 license=('spdx:GPL-3.0-or-later')
@@ -39,18 +39,31 @@ optdepends=('texinfo: for help-support in Octave'
             "${MINGW_PACKAGE_PREFIX}-gnuplot: alternative plotting"
             "${MINGW_PACKAGE_PREFIX}-portaudio: audio support")
 source=(https://ftp.gnu.org/gnu/octave/octave-$pkgver.tar.xz{,.sig}
+        "0001-console-codepage.patch"  # see: https://hg.savannah.gnu.org/hgweb/octave/rev/ea0b06534a37
         "0002-mk-doc-cache-path.patch"
         "0005-makeinfo-perl.patch")
 validpgpkeys=('DBD9C84E39FE1AAE99F04446B05F05B75D36644B')  # John W. Eaton
 sha512sums=('1399d7010cbd4e83d6dc60ab8cc2abb20e64a762e905a00066e6331c5350df93b4ff8f2670fd52fc183918cea21bc176cb263ca71080de6e4041f5e0ea21558e'
             'SKIP'
+            '3d840246486fabc02d01eb40a742e8e4b050b73426308f09c986779054d045868df7b943e4057e86c3cdfc3157915548f4cf336b143aac632253053d1bec3129'
             '5742cde34ae9184276c830dab41dccb289991578656353658bf07315d89b1c3870c6c51520d5aae0cec8c7fb12c707a1970aa9dde353b4ab54e515d1d3cf66e0'
             'c2796f1d83208595c4f52f27d14f3bedc64d95a514089108726b5a2de20296bdfb195f545e7045a322eebef4ce387b0f05547e071c74dfa5478f5689d0f207bd')
 
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Np1 -i "${srcdir}/$_patch"
+  done
+}
+
 prepare() {
   cd "${_realname}-${pkgver}"
-  patch -p1 -i "${srcdir}/0002-mk-doc-cache-path.patch"
-  patch -p1 -i "${srcdir}/0005-makeinfo-perl.patch"
+
+  apply_patch_with_msg \
+    0001-console-codepage.patch \
+    0002-mk-doc-cache-path.patch \
+    0005-makeinfo-perl.patch
 }
 
 build() {


### PR DESCRIPTION
Unfortunately, I messed up the upstream commit. So, we need a slightly different change.

See also: msys2/MSYS2-packages#3338
