### PR TITLE
readline: Support entering non-ASCII characters also with other shells

### DIFF
--- a/mingw-w64-readline/0004-locale.patch
+++ b/mingw-w64-readline/0004-locale.patch
@@ -1,10 +1,38 @@
 --- readline-8.2/nls.c.orig	2022-11-22 18:41:48.302144300 +0100
-+++ readline-8.2/nls.c	2022-12-01 19:23:48.168183300 +0100
-@@ -138,11 +138,15 @@
++++ readline-8.2/nls.c	2022-12-03 18:37:54.991412600 +0100
+@@ -49,6 +49,11 @@
+ 
+ #include <ctype.h>
+ 
++#if defined (_WIN32)
++#  include <windows.h>
++#  include <versionhelpers.h>
++#endif
++
+ #include "rldefs.h"
+ #include "readline.h"
+ #include "rlshell.h"
+@@ -109,7 +114,11 @@
+   char *cp;
+   size_t len;
+ 
+-#if HAVE_LANGINFO_CODESET
++#if defined (_WIN32)
++  /* On Windows, the relevant "locale" is the selected codepage of the used
++     console. */
++  return (IsWindows7OrGreater () && (GetConsoleCP () == 65001));
++#elif HAVE_LANGINFO_CODESET
+   cp = nl_langinfo (CODESET);
+   return (STREQ (cp, "UTF-8") || STREQ (cp, "utf8"));
+ #else
+@@ -138,11 +147,18 @@
  #if defined (HAVE_SETLOCALE)
    if (lspec == 0 || *lspec == 0)
      lspec = setlocale (LC_CTYPE, (char *)NULL);
 +#if defined (_WIN32)
++  /* Setting an UTF-8 locale is not a no-op on Windows.  Instead the
++     information about the locale is lost.  Use whatever we got at this
++     point. */
 +  ret = lspec;
 +#else
    if (lspec == 0)

--- a/mingw-w64-readline/PKGBUILD
+++ b/mingw-w64-readline/PKGBUILD
@@ -6,7 +6,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _basever=8.2
 _patchlevel=001
 pkgver=${_basever}.${_patchlevel}
-pkgrel=3
+pkgrel=4
 pkgdesc="MinGW port of readline for editing typed command lines (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -36,7 +36,7 @@ sha256sums=('3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35'
             '2b30dcb0804abb6e7e4f44cd119bddef94c1b1d7ebff43dda401e710eda2fd0f'
             '9f0582a2a33464a2e8e7c9af2fd9d8f55dfa6c93bfa09b06d14709d4845da7ce'
             '6c90a984519f6e5a201c3b107ec5a7319db2a4f7b30f48dd43c0964894fbf3a6'
-            '0eef26bce9af50dbd971da73bfb6dcf53e0f96045c43bc3792b81143c09e5385'
+            '72ed438ae142ba9d5498652dfdf4fb517265bcf9a67199b7c5b35cc24fa25b9e'
             'bbf97f1ec40a929edab5aa81998c1e2ef435436c597754916e6a5868f273aff7'
             'SKIP')
 


### PR DESCRIPTION
Like @lazka rightfully pointed out in msys2/MSYS2-packages/#3338, the POSIX locale variables (like `LC_CTYPE`) might not be set when the shell startup script from MSYS2 isn't used.
To determine whether readline should be using an UTF-8 locale, it is probably better to query the console codepage instead of using the return value of `setlocale (LC_CTYPE, (char *)NULL);` on Windows. The proposed PR is doing that.

With this change (and PR #14405), it is possible to enter non-ASCII characters at the Octave prompt also when starting the program with a double-click on `octave.exe` in `mingw64/bin` (i.e., when the shell startup script didn't run).

Sorry, this took a couple of attempts. But I hope we are getting there now.
