### PR TITLE
sse2neon: add package

### DIFF
--- a/mingw-w64-sse2neon/PKGBUILD
+++ b/mingw-w64-sse2neon/PKGBUILD
@@ -1,0 +1,29 @@
+# Maintainer: GH Cao
+
+_realname=sse2neon
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.5.1
+pkgrel=1
+pkgdesc="sse2neon - A translator from Intel SSE intrinsics to Arm/Aarch64 NEON implementation (mingw-w64)"
+arch=('any')
+mingw_arch=('clangarm64')
+url='https://github.com/DLTcollab/sse2neon'
+license=('MIT')
+source=("https://github.com/DLTcollab/${_realname}/archive/refs/tags/v${pkgver}.tar.gz"
+        "https://github.com/DLTcollab/sse2neon/pull/541.patch")
+sha256sums=('4001e2dfb14fcf3831211581ed83bcc83cf6a3a69f638dcbaa899044a351bb2a'
+            '1e38236ec4e1f1bd1576f63397d3880adfdd4a84fa1ed85e1c70c2d9626e2d9e')
+
+prepare() {
+  cd ${srcdir}/${_realname}-${pkgver}
+
+  # Windows Support
+  patch -p1 -i ${srcdir}/541.patch
+}
+
+package() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/sse2neon.h" "${pkgdir}${MINGW_PREFIX}/include/${_realname}/sse2neon.h"
+}


### PR DESCRIPTION
This is a SSE to NEON translation library, therefore clangarm64 only.
Needed by blender.