### PR TITLE
KF5: Fix plugin directory using template function

### DIFF
--- a/mingw-w64-kcompletion-qt5/PKGBUILD
+++ b/mingw-w64-kcompletion-qt5/PKGBUILD
@@ -5,7 +5,7 @@ _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kcompletion"
 pkgver=5.100.0
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 pkgdesc="Text completion helpers and widgets for Qt (mingw-w64)"
@@ -35,18 +35,12 @@ build() {
   cd build-${MSYSTEM}${_variant}
   if [ "${_variant}" = "-static" ]; then
     extra_config+=( -DBUILD_SHARED_LIBS=NO )
-    QT5_PREFIX=${MINGW_PREFIX}/qt5-static
-    export PATH=${QT5_PREFIX}/bin:"$PATH"
-  else
-    QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
+  _kde_f5_build_env
     ${MINGW_PREFIX}/bin/cmake.exe ../${_basename}-${pkgver} \
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
-      -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
+      "${_kde_f5_KDE_INSTALL_DIRS[@]}" \
       -DBUILD_QCH=OFF \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \

--- a/mingw-w64-kdewebkit-qt5/PKGBUILD
+++ b/mingw-w64-kdewebkit-qt5/PKGBUILD
@@ -5,7 +5,7 @@ _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kdewebkit"
 pkgver=5.100.0
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 pkgdesc="KDE Integration for QtWebKit (mingw-w64)"
@@ -35,18 +35,12 @@ build() {
   cd build-${MSYSTEM}${_variant}
   if [ "${_variant}" = "-static" ]; then
     extra_config+=( -DBUILD_SHARED_LIBS=NO )
-    QT5_PREFIX=${MINGW_PREFIX}/qt5-static
-    export PATH=${QT5_PREFIX}/bin:"$PATH"
-  else
-    QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
+  _kde_f5_build_env
     ${MINGW_PREFIX}/bin/cmake.exe ../${_basename}-${pkgver} \
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
-      -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
+      "${_kde_f5_KDE_INSTALL_DIRS[@]}" \
       -DBUILD_QCH=OFF \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \

--- a/mingw-w64-kiconthemes-qt5/PKGBUILD
+++ b/mingw-w64-kiconthemes-qt5/PKGBUILD
@@ -5,7 +5,7 @@ _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kiconthemes"
 pkgver=5.100.0
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 pkgdesc="Support for icon themes (mingw-w64)"
@@ -37,18 +37,12 @@ build() {
   cd build-${MSYSTEM}${_variant}
   if [ "${_variant}" = "-static" ]; then
     extra_config+=( -DBUILD_SHARED_LIBS=NO )
-    QT5_PREFIX=${MINGW_PREFIX}/qt5-static
-    export PATH=${QT5_PREFIX}/bin:"$PATH"
-  else
-    QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
+  _kde_f5_build_env
     ${MINGW_PREFIX}/bin/cmake.exe ../${_basename}-${pkgver} \
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
-      -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
+      "${_kde_f5_KDE_INSTALL_DIRS[@]}" \
       -DBUILD_QCH=OFF \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \

--- a/mingw-w64-kitemviews-qt5/PKGBUILD
+++ b/mingw-w64-kitemviews-qt5/PKGBUILD
@@ -5,7 +5,7 @@ _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kitemviews"
 pkgver=5.100.0
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 pkgdesc="Widget addons for Qt Model/View (mingw-w64)"
@@ -35,19 +35,13 @@ build() {
   cd build-${MSYSTEM}${_variant}
   if [ "${_variant}" = "-static" ]; then
     extra_config+=( -DBUILD_SHARED_LIBS=NO )
-    QT5_PREFIX=${MINGW_PREFIX}/qt5-static
-    export PATH=${QT5_PREFIX}/bin:"$PATH"
-  else
-    QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
+  _kde_f5_build_env
     ${MINGW_PREFIX}/bin/cmake.exe \
       -G "Ninja" \
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
-      -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
+      "${_kde_f5_KDE_INSTALL_DIRS[@]}" \
       -DBUILD_QCH=OFF \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \

--- a/mingw-w64-kplotting-qt5/PKGBUILD
+++ b/mingw-w64-kplotting-qt5/PKGBUILD
@@ -5,7 +5,7 @@ _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kplotting"
 pkgver=5.100.0
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 pkgdesc="Lightweight plotting framework for Qt (mingw-w64)"
@@ -35,19 +35,13 @@ build() {
   cd build-${MSYSTEM}${_variant}
   if [ "${_variant}" = "-static" ]; then
     extra_config+=( -DBUILD_SHARED_LIBS=NO )
-    QT5_PREFIX=${MINGW_PREFIX}/qt5-static
-    export PATH=${QT5_PREFIX}/bin:"$PATH"
-  else
-    QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
+  _kde_f5_build_env
     ${MINGW_PREFIX}/bin/cmake.exe \
       -G "Ninja" \
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
-      -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
+      "${_kde_f5_KDE_INSTALL_DIRS[@]}" \
       -DBUILD_QCH=OFF \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \

--- a/mingw-w64-ktextwidgets-qt5/PKGBUILD
+++ b/mingw-w64-ktextwidgets-qt5/PKGBUILD
@@ -5,7 +5,7 @@ _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "ktextwidgets"
 pkgver=5.100.0
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 pkgdesc="Advanced text editing widgets (mingw-w64)"
@@ -38,18 +38,12 @@ build() {
   cd build-${MSYSTEM}${_variant}
   if [ "${_variant}" = "-static" ]; then
     extra_config+=( -DBUILD_SHARED_LIBS=NO )
-    QT5_PREFIX=${MINGW_PREFIX}/qt5-static
-    export PATH=${QT5_PREFIX}/bin:"$PATH"
-  else
-    QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
+  _kde_f5_build_env
     ${MINGW_PREFIX}/bin/cmake.exe ../${_basename}-${pkgver} \
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
-      -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
+      "${_kde_f5_KDE_INSTALL_DIRS[@]}" \
       -DBUILD_QCH=OFF \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \

--- a/mingw-w64-kwidgetsaddons-qt5/PKGBUILD
+++ b/mingw-w64-kwidgetsaddons-qt5/PKGBUILD
@@ -5,7 +5,7 @@ _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kwidgetsaddons"
 pkgver=5.100.0
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 pkgdesc="Addons to QtWidgets (mingw-w64)"
@@ -35,19 +35,13 @@ build() {
   cd build-${MSYSTEM}${_variant}
   if [ "${_variant}" = "-static" ]; then
     extra_config+=( -DBUILD_SHARED_LIBS=NO )
-    QT5_PREFIX=${MINGW_PREFIX}/qt5-static
-    export PATH=${QT5_PREFIX}/bin:"$PATH"
-  else
-    QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
+  _kde_f5_build_env
     ${MINGW_PREFIX}/bin/cmake.exe \
       -G "Ninja" \
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
-      -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
+      "${_kde_f5_KDE_INSTALL_DIRS[@]}" \
       -DBUILD_QCH=OFF \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \

--- a/mingw-w64-kxmlgui-qt5/PKGBUILD
+++ b/mingw-w64-kxmlgui-qt5/PKGBUILD
@@ -4,7 +4,7 @@ _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kxmlgui"
 pkgver=5.100.0
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 pkgdesc="User configurable main windows (mingw-w64)"
@@ -35,18 +35,12 @@ build() {
   cd build-${MSYSTEM}${_variant}
   if [ "${_variant}" = "-static" ]; then
     extra_config+=( -DBUILD_SHARED_LIBS=NO )
-    QT5_PREFIX=${MINGW_PREFIX}/qt5-static
-    export PATH=${QT5_PREFIX}/bin:"$PATH"
-  else
-    QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
+  _kde_f5_build_env
     ${MINGW_PREFIX}/bin/cmake.exe ../${_basename}-${pkgver} \
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
-      -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
+      "${_kde_f5_KDE_INSTALL_DIRS[@]}" \
       -DBUILD_QCH=OFF \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \


### PR DESCRIPTION
This install plugin directory in prefix/share/qt5/plugins instead of
prefix/lib/plugins. The prefix/share/qt5/plugins path is returned from
'qtpath --plugin-dir' command.

Fixes https://github.com/msys2/MINGW-packages/issues/10158
Similar as https://github.com/msys2/MINGW-packages/pull/4523