### PR TITLE
readline: Fix escape sequence handling in callback mode.

### DIFF
--- a/mingw-w64-readline/0002-event-hook.patch
+++ b/mingw-w64-readline/0002-event-hook.patch
@@ -1,18 +1,29 @@
 --- readline-8.2/input.c.orig	2022-04-08 21:43:24.000000000 +0200
-+++ readline-8.2/input.c	2022-12-01 19:16:34.989739900 +0100
-@@ -176,6 +178,12 @@
++++ readline-8.2/input.c	2022-12-10 14:16:11.171817300 +0100
+@@ -176,6 +176,14 @@
  static unsigned char ibuffer[512];
  static int ibuffer_len = sizeof (ibuffer) - 1;
  
 +#if defined (__MINGW32__)
 +#include <windows.h>
-+static int _win32_getch (int *is_char);
++static int _win32_getch (void);
 +static int _win32_kbhit (void);
++static char _win32_buf[16] = {'0'};
++static int _win32_bufidx = 0;
 +#endif
 +
  #define any_typein (push_index != pop_index)
  
  int
+@@ -187,7 +195,7 @@
+ int
+ _rl_pushed_input_available (void)
+ {
+-  return (push_index != pop_index);
++  return ((push_index != pop_index) || _win32_bufidx > 0);
+ }
+ 
+ /* Return the amount of space available in the buffer for stuffing
 @@ -306,7 +314,7 @@
  #if defined (__MINGW32__)
    /* Use getch/_kbhit to check for available console input, in the same way
@@ -31,22 +42,19 @@
  #endif
  
    return 0;
-@@ -799,6 +807,141 @@
+@@ -799,6 +807,139 @@
    return (c);
  }
  
 +#if defined (__MINGW32__)
 +#define _WIN32_READ_NOCHAR (-2)
-+static char _win32_buf[16] = {'0'};
-+static int _win32_bufidx = 0;
 +
 +static int
-+_win32_getch_internal (int block, int* is_char)
++_win32_getch_internal (int block)
 +{
 +  INPUT_RECORD rec;
 +  DWORD evRead, waitResult;
 +  HANDLE hInput = (HANDLE) _get_osfhandle (fileno (rl_instream));
-+  *is_char = 1;
 +
 +  if (_win32_bufidx > 0)
 +    return _win32_buf[--_win32_bufidx];
@@ -55,17 +63,15 @@
 +
 +  do
 +    {
-+      *is_char = 0;
 +      if (! block)
 +        {
-+          if (WaitForSingleObject(hInput, _keyboard_input_timeout/1000) != WAIT_OBJECT_0)
++          if (WaitForSingleObject (hInput, _keyboard_input_timeout/1000) != WAIT_OBJECT_0)
 +            return _WIN32_READ_NOCHAR;
 +        }
 +
-+      if (!ReadConsoleInputW(hInput, &rec, 1, &evRead) || evRead != 1)
++      if (! ReadConsoleInputW (hInput, &rec, 1, &evRead) || evRead != 1)
 +        return EOF;
 +
-+      *is_char = 1;
 +      switch (rec.EventType)
 +        {
 +          case KEY_EVENT:
@@ -77,33 +83,63 @@
 +                rec.Event.KeyEvent.uChar.UnicodeChar))
 +              {
 +                if (rec.Event.KeyEvent.uChar.UnicodeChar)
-+                  return (int)rec.Event.KeyEvent.uChar.UnicodeChar;
++                  {
++                    int result = (int) rec.Event.KeyEvent.uChar.UnicodeChar;
++                    char charbuf[5] = {0};
++                    wchar_t unicode[2] = {result, 0};
++                    int utf16_code_units = 1;
++                    if ((unicode[0] & 0xF800) == 0xD800)  /* outside BMP */
++                      {
++                        ReadConsoleInputW (hInput, &rec, 1, &evRead);
++                        unicode[1] = (int) rec.Event.KeyEvent.uChar.UnicodeChar;
++                        utf16_code_units++;
++                      }
++                    /* convert to current codepage or UTF-8 byte sequence */
++                    unsigned int codepage = CP_THREAD_ACP;
++                    if (_rl_utf8locale)
++                      codepage = CP_UTF8;
++                    int len = WideCharToMultiByte (codepage, 0,
++                                                   (wchar_t *) &unicode, utf16_code_units,
++                                                   charbuf, 5, NULL, NULL);
++                    /* buffer is read from back to front */
++                    for (int i=0; i<len-1; i++)
++                      _win32_buf[_win32_bufidx++] = (unsigned char) charbuf[len-i-1];
 +
-+                *is_char = 0;
++                    return (int) (unsigned char) charbuf[0];
++                  }
++
 +                switch (rec.Event.KeyEvent.wVirtualKeyCode)
 +                  {
++                    /* buffer is read from back to front */
 +                    case VK_UP:
 +                      _win32_buf[_win32_bufidx++] = 'A';
-+                      return 0340;
++                      _win32_buf[_win32_bufidx++] = '[';
++                      return 0x1b;  /* ESC */
 +                    case VK_DOWN:
 +                      _win32_buf[_win32_bufidx++] = 'B';
-+                      return 0340;
++                      _win32_buf[_win32_bufidx++] = '[';
++                      return 0x1b;  /* ESC */
 +                    case VK_RIGHT:
 +                      _win32_buf[_win32_bufidx++] = 'C';
-+                      return 0340;
++                      _win32_buf[_win32_bufidx++] = '[';
++                      return 0x1b;  /* ESC */
 +                    case VK_LEFT:
 +                      _win32_buf[_win32_bufidx++] = 'D';
-+                      return 0340;
++                      _win32_buf[_win32_bufidx++] = '[';
++                      return 0x1b;  /* ESC */
 +                    case VK_HOME:
 +                      _win32_buf[_win32_bufidx++] = 'H';
-+                      return 0340;
++                      _win32_buf[_win32_bufidx++] = '[';
++                      return 0x1b;  /* ESC */
 +                    case VK_END:
 +                      _win32_buf[_win32_bufidx++] = 'F';
-+                      return 0340;
++                      _win32_buf[_win32_bufidx++] = '[';
++                      return 0x1b;  /* ESC */
 +                    case VK_DELETE:
 +                      _win32_buf[_win32_bufidx++] = 8;
 +                      _win32_buf[_win32_bufidx++] = 'C';
-+                      return 0340;
++                      _win32_buf[_win32_bufidx++] = '[';
++                      return 0x1b;  /* ESC */
 +                    default:
 +                      break;
 +                  }
@@ -125,65 +161,35 @@
 +_win32_kbhit (void)
 +{
 +  int result;
-+  int is_char;
 +
-+  result = _win32_getch_internal (0, &is_char);
++  result = _win32_getch_internal (0);
 +  if (result == _WIN32_READ_NOCHAR
 +      || result == EOF)
 +    return 0;
 +
-+  if (is_char)
-+  {
-+      char charbuf[5] = {0};
-+      wchar_t unicode[2] = {result, 0};
-+      int utf16_code_units = 1;
-+      if (unicode[0] & 0xD800) /* outside BMP */
-+        {
-+          unicode[1] = _win32_getch_internal (0, &is_char);
-+          utf16_code_units++;
-+        }
-+      /* convert to current codepage or UTF-8 byte sequence */
-+      unsigned int codepage = CP_THREAD_ACP;
-+      if (_rl_utf8locale)
-+        codepage = CP_UTF8;
-+      int len = WideCharToMultiByte (codepage, 0,
-+                                     (wchar_t *) &unicode, utf16_code_units,
-+                                     charbuf, 5, NULL, NULL);
-+      for (int i=0; i<len; i++)
-+        {
-+          _win32_buf[_win32_bufidx++] = (unsigned char) charbuf[len-i-1];
-+        }
-+    }
-+  else
-+    {
-+      _win32_buf[_win32_bufidx++] = 0x5b;
-+      _win32_buf[_win32_bufidx++] = 0x1b;
-+    }
++  _win32_buf[_win32_bufidx++] = result;
 +
 +  return _win32_bufidx;
 +}
 +
 +static int
-+_win32_getch (int *is_char)
++_win32_getch (void)
 +{
-+  return _win32_getch_internal (1, is_char);
++  return (_win32_getch_internal (1));
 +}
 +#endif
 +
  int
  rl_getc (FILE *stream)
  {
-@@ -818,8 +961,11 @@
+@@ -818,8 +959,8 @@
        /* We know at this point that _rl_caught_signal == 0 */
  
  #if defined (__MINGW32__)
 -      if (isatty (fd)
 -	return (_getch ());	/* "There is no error return." */
 +      if (isatty (fd))
-+        {
-+          int is_char;
-+          return (_win32_getch (&is_char));
-+        }
++        return (_win32_getch ());
  #endif
        result = 0;
  #if defined (HAVE_PSELECT) || defined (HAVE_SELECT)

--- a/mingw-w64-readline/PKGBUILD
+++ b/mingw-w64-readline/PKGBUILD
@@ -6,7 +6,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _basever=8.2
 _patchlevel=001
 pkgver=${_basever}.${_patchlevel}
-pkgrel=4
+pkgrel=5
 pkgdesc="MinGW port of readline for editing typed command lines (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -34,7 +34,7 @@ validpgpkeys=('7C0135FB088AAF6C66C650B9BB5869F064EA74AB')
 sha256sums=('3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35'
             'SKIP'
             '2b30dcb0804abb6e7e4f44cd119bddef94c1b1d7ebff43dda401e710eda2fd0f'
-            '9f0582a2a33464a2e8e7c9af2fd9d8f55dfa6c93bfa09b06d14709d4845da7ce'
+            '52ae0da2769afe2853e3ffad8ae2e22eb8a72ce3ee8f2fc9084cb4dc554b2813'
             '6c90a984519f6e5a201c3b107ec5a7319db2a4f7b30f48dd43c0964894fbf3a6'
             '72ed438ae142ba9d5498652dfdf4fb517265bcf9a67199b7c5b35cc24fa25b9e'
             'bbf97f1ec40a929edab5aa81998c1e2ef435436c597754916e6a5868f273aff7'


### PR DESCRIPTION
Fixes #14484 for me.
Tested with Octave CLI, GUI, and with gdb.
