### PR TITLE
Favor shared over static for gmp to build shared for mpfr and mpc

### DIFF
--- a/mingw-w64-gmp/PKGBUILD
+++ b/mingw-w64-gmp/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gmp
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=6.2.1
-pkgrel=3
+pkgrel=4
 pkgdesc="A free library for arbitrary precision arithmetic (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -12,10 +12,9 @@ url="https://gmplib.org/"
 license=('LGPL3' 'GPL')
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools" "${MINGW_PACKAGE_PREFIX}-cc")
 source=(https://gmplib.org/download/gmp-${pkgver}/${_realname}-${pkgver}.tar.xz{,.sig})
-options=('staticlibs')
-validpgpkeys=('343C2FF0FBEE5EC2EDBEF399F3599FF828C67298') # Niels Möller <nisse@lysator.liu.se>"
 sha256sums=('fd4829912cddd12f84181c3451cc752be224643e87fac497b69edddadc49b4f2'
             'SKIP')
+validpgpkeys=('343C2FF0FBEE5EC2EDBEF399F3599FF828C67298') # Niels Möller <nisse@lysator.liu.se>"
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -36,8 +35,11 @@ build() {
       extra_config+=(--disable-assembly)
       ;;
   esac
+
+  CFLAGS+=" -Wno-attributes -Wno-ignored-attributes"
+
   # Build static version
-  mkdir -p "${srcdir}/static-${MINGW_CHOST}" && cd "${srcdir}/static-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/static-${MSYSTEM}" && cd "${srcdir}/static-${MSYSTEM}"
   ../${_realname}-${pkgver}/configure \
     --build=${MINGW_CHOST} \
     --prefix=${MINGW_PREFIX} \
@@ -48,8 +50,9 @@ build() {
   make
 
   # Build shared version
-  mkdir -p "${srcdir}/shared-${MINGW_CHOST}" && cd "${srcdir}/shared-${MINGW_CHOST}"
-  ../${_realname}-${pkgver}/configure --build=${MINGW_CHOST} \
+  mkdir -p "${srcdir}/shared-${MSYSTEM}" && cd "${srcdir}/shared-${MSYSTEM}"
+  ../${_realname}-${pkgver}/configure \
+    --build=${MINGW_CHOST} \
     --prefix=${MINGW_PREFIX} \
     --enable-cxx \
     "${extra_config[@]}" \
@@ -59,16 +62,13 @@ build() {
 }
 
 check() {
-  cd "${srcdir}/static-${MINGW_CHOST}"
+  cd "${srcdir}/static-${MSYSTEM}"
   make check
 }
 
 package() {
-  cd "${srcdir}/static-${MINGW_CHOST}"
+  cd "${srcdir}/static-${MSYSTEM}"
   make DESTDIR="${pkgdir}" install
-
-  cd ${srcdir}/shared-${MINGW_CHOST}
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/{bin,lib}
-  cp .libs/libgmp*.dll ${pkgdir}${MINGW_PREFIX}/bin/
-  cp .libs/libgmp*.dll.a ${pkgdir}${MINGW_PREFIX}/lib/
+  cd "${srcdir}/shared-${MSYSTEM}"
+  make DESTDIR="${pkgdir}" install
 }

--- a/mingw-w64-mpc/PKGBUILD
+++ b/mingw-w64-mpc/PKGBUILD
@@ -4,16 +4,15 @@ _realname=mpc
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.3.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Multiple precision complex arithmetic library (mingw-w64)"
 url='http://www.multiprecision.org'
 license=('LGPL')
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
-depends=("${MINGW_PACKAGE_PREFIX}-mpfr")
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+depends=("${MINGW_PACKAGE_PREFIX}-gmp"
+         "${MINGW_PACKAGE_PREFIX}-mpfr")
 makedepends=(
-  "${MINGW_PACKAGE_PREFIX}-gmp"
-  "${MINGW_PACKAGE_PREFIX}-mpfr"
   "${MINGW_PACKAGE_PREFIX}-autotools"
   "${MINGW_PACKAGE_PREFIX}-cc"
 )
@@ -31,24 +30,24 @@ prepare() {
 }
 
 build() {
-  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
-  mkdir -p ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
+  [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}
+  mkdir -p ${srcdir}/build-${MSYSTEM} && cd ${srcdir}/build-${MSYSTEM}
   ../${_realname}-${pkgver}/configure \
      --build=${MINGW_CHOST} \
     --prefix=${MINGW_PREFIX} \
-    --enable-static \
-    --disable-shared \
+    --disable-static \
+    --enable-shared \
     --with-gmp=${MINGW_PREFIX} \
     --with-mpfr=${MINGW_PREFIX}
   make
 }
 
 check() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MSYSTEM}"
   make check 
 }
 
 package() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MSYSTEM}"
   make DESTDIR="${pkgdir}" install
 }

--- a/mingw-w64-mpc/PKGBUILD
+++ b/mingw-w64-mpc/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=mpc
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.3.0
-pkgrel=3
+pkgver=1.3.1
+pkgrel=1
 pkgdesc="Multiple precision complex arithmetic library (mingw-w64)"
 url='http://www.multiprecision.org'
 license=('LGPL')
@@ -16,18 +16,10 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-autotools"
   "${MINGW_PACKAGE_PREFIX}-cc"
 )
-source=(https://ftp.gnu.org/gnu/mpc/${_realname}-${pkgver}.tar.gz{,.sig}
-        "https://gitlab.inria.fr/mpc/mpc/-/commit/e944aa454e60cbff8ab4e8c70dd974083398378f.patch")
-sha256sums=('0e3b12181d37207230f5a7a7ddcfc22abfc5fc9c05825e1a65401a489a432a2a'
-            'SKIP'
-            '4742820c759a913cf6471511859cda14ec88265d939ee5f5abf9566446a7ee51')
+source=(https://ftp.gnu.org/gnu/mpc/${_realname}-${pkgver}.tar.gz{,.sig})
+sha256sums=('ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8'
+            'SKIP')
 validpgpkeys=('AD17A21EF8AED8F1CC02DBD9F7D5C9BF765C61E3')
-
-prepare() {
-  cd "${_realname}-${pkgver}"
-
-  patch -Np1 -i "${srcdir}/e944aa454e60cbff8ab4e8c70dd974083398378f.patch"
-}
 
 build() {
   [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}

--- a/mingw-w64-mpfr/PKGBUILD
+++ b/mingw-w64-mpfr/PKGBUILD
@@ -6,12 +6,13 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 _pkgver=4.1.1
 pkgver=${_pkgver}.p1
-pkgrel=1
+pkgrel=2
 pkgdesc="Multiple-precision floating-point library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 license=('spdx:LGPL-3.0-or-later')
-depends=("${MINGW_PACKAGE_PREFIX}-gmp")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-gmp")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools")
 source=(https://ftp.gnu.org/gnu/mpfr/${_realname}-${_pkgver}.tar.xz{,.sig}
@@ -29,25 +30,25 @@ prepare() {
 }
 
 build() {
-  [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}
-  mkdir -p build-${MINGW_CHOST} && cd build-${MINGW_CHOST}
+  [[ -d build-${MSYSTEM} ]] && rm -rf build-${MSYSTEM}
+  mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
 
   ../${_realname}-${_pkgver}/configure \
     --build=${MINGW_CHOST} \
     --prefix=${MINGW_PREFIX} \
-    --enable-static \
-    --disable-shared \
+    --disable-static \
+    --enable-shared \
     --with-gmp=${MINGW_PREFIX}
 
   make
 }
 
 check() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MSYSTEM}"
   make check
 }
 
 package() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MSYSTEM}"
   make DESTDIR="${pkgdir}" install
 }


### PR DESCRIPTION
This is my last attempt to build shared libraries for mpfr and mpc.
I have proposed this change before but @jeremyd2019 said that we shloud keep gmp as it is and the issue comes from mpfr and mpc being too strict, but It turns out It wasn't the case and he was wrong about that.
I think building shared libraries should be prioritized over static ones, If there is a conflict. So if someone wants static mpfr and mpc then he should find the solution.