### PR TITLE
 GnuCOBOL package update

### DIFF
--- a/mingw-w64-gnucobol/PKGBUILD
+++ b/mingw-w64-gnucobol/PKGBUILD
@@ -7,7 +7,7 @@ _realver=3.1.2
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=${_realver}   # not necessarily matches as the rule for the version identifier differ
-pkgrel=3
+pkgrel=4
 pkgdesc="GnuCOBOL, a free and modern COBOL compiler (mingw-w64)"
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-svn" "${MINGW_PACKAGE_PREFIX}-gnu-cobol-svn")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-svn" "${MINGW_PACKAGE_PREFIX}-gnu-cobol-svn")
@@ -32,30 +32,28 @@ depends=("${MINGW_PACKAGE_PREFIX}-cc"
 #            "${MINGW_PACKAGE_PREFIX}-cjson: support for JSON GENERATE"
 #            "${MINGW_PACKAGE_PREFIX}-json-c: support for JSON GENERATE"
 #            "${MINGW_PACKAGE_PREFIX}-libxml2: support for XML GENERATE")
-makedepends=("${MINGW_PACKAGE_PREFIX}-autotools" "${MINGW_PACKAGE_PREFIX}-cc")
-#FIXME deactivated for now as cobc.exe is not found during make test
-#checkdepends=("${MINGW_PACKAGE_PREFIX}-perl")
+# Note: any autotools would work, but for multiple packages the common one would be best
+makedepends=(autotools "${MINGW_PACKAGE_PREFIX}-cc")
+# Note: it actually needs the one from the build environment (MSYS)
+checkdepends=(perl) 
 
 # local definitions
 #source=("https://alpha.gnu.org/gnu/${_realname}/${_realname}-${_realver}.tar.xz"{,.sig}
 source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${_realver}.tar.xz"{,.sig}
         "cobenv.sh" "cobenv.cmd"
-#FIXME deactivated for now as cobc.exe is not found during make test
-#       "https://www.itl.nist.gov/div897/ctg/suites/newcob.val.Z"
+        "https://www.itl.nist.gov/div897/ctg/suites/newcob.val.Z"
         )
 sha256sums=('597005D71FD7D65B90CBE42BBFECD5A9EC0445388639404662E70D53DDF22574'
             SKIP
             'EEDFC170CFD6606527DD701C3CF6BBA2029C33CE694F697F8B7EE527B4ED7F1C'
             '244AFBD011B0C0141753C7259173D9F49F161A97C7252B52369E0CEC50147308'
-#FIXME deactivated for now as cobc.exe is not found during make test
-#           '1E9A92DDBD5D730CBEB764281F7810C22B18E0163985B09675393AB22BBD61F9'
+            '1E9A92DDBD5D730CBEB764281F7810C22B18E0163985B09675393AB22BBD61F9'
             )
 validpgpkeys=('B9459D0CA8A740B323235CDF13E96B53C005604E')
 
 prepare() {
   cd "${_realname}-${_realver}"
-# FIXME deactivated for now as cobc.exe is not found during make test
-# cp ${srcdir}/newcob.val.Z tests/cobol85/
+  cp ${srcdir}/newcob.val.Z tests/cobol85/
 }
 
 build() {
@@ -66,6 +64,7 @@ build() {
   cd build-${CARCH}
   ../configure \
     CPPLAGS="-D__USE_MINGW_ANSI_STDIO=1" \
+    PERL="/usr/bin/perl" \
     --with-db --without-vbisam --without-disam --without-cisam \
     --with-xml2 --with-json=cjson --with-curses=ncursesw \
     --build=${MINGW_CHOST} \
@@ -91,9 +90,7 @@ check() {
   #       of the system (check for --jobs=N / -jN and take N over here)
   #make check TESTSUITEFLAGS="--jobs=$(($(nproc)+1))"
   make check || echo "warning, not all internal tests passed"
-  #FIXME deactivated for now as cobc.exe is not found during make test
-  #export PATH=${MINGW_PREFIX}/bin:$PATH  # needed to get correct perl?
-  #make test  || echo "warning, not all NIST tests passed"
+  PATH=/usr/bin:$PATH make test  || echo "warning, not all NIST tests passed"
 }
 
 package() {


### PR DESCRIPTION
run the NIST85 tests ... currently only works if msys perl is first in PATH (fix from GC 3.2)

as this is only about the check definition and GC 3.2 is "in sight" a pull may not be necessary now