### PR TITLE
suitesparse: build SPEX with GCC

### DIFF
--- a/mingw-w64-suitesparse/PKGBUILD
+++ b/mingw-w64-suitesparse/PKGBUILD
@@ -4,7 +4,7 @@ _realname=suitesparse
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-suitesparse")
 pkgver=6.0.2
-pkgrel=1
+pkgrel=2
 pkgdesc='A suite of sparse matrix algorithms (mingw-w64)'
 url="https://faculty.cse.tamu.edu/davis/suitesparse.html"
 license=('spdx:LGPL-3.0-or-later AND BSD-3-Clause AND LGPL-2.1-or-later AND GPL-2.0-or-later AND LGPL-2.0-or-later AND Apache-2.0 AND GPL-3.0-or-later')
@@ -12,15 +12,14 @@ arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 depends=("${MINGW_PACKAGE_PREFIX}-openblas"
          "${MINGW_PACKAGE_PREFIX}-omp"
-         "${MINGW_PACKAGE_PREFIX}-gmp"
-         "${MINGW_PACKAGE_PREFIX}-metis")
+         "${MINGW_PACKAGE_PREFIX}-gmp")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-cc"
-             $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* && ${MSYSTEM} != CLANG64 ]] || echo \
-               "${MINGW_PACKAGE_PREFIX}-fc")
              "${MINGW_PACKAGE_PREFIX}-mpfr")
-source=(${_realname}-${pkgver}.tar.gz::"https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/v${pkgver}.tar.gz")
-sha256sums=('c5d960cd210279c3c83a27747aca2fdeb2e4a13af42870ca0635739accdc6847')
+source=(${_realname}-${pkgver}.tar.gz::"https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/v${pkgver}.tar.gz"
+        "0001-SPEX-Link-to-gmp-after-mpfr.patch"::https://github.com/DrTimothyAldenDavis/SuiteSparse/commit/3b20a70ddf9e7d226ebfd870022b393760c3595d.patch)
+sha256sums=('c5d960cd210279c3c83a27747aca2fdeb2e4a13af42870ca0635739accdc6847'
+            'c296e783a973a4bbfbab520ab638518755faf8329b1d7c3ceaa812bc2b2877f0')
 noextract=(${_realname}-${pkgver}.tar.gz)
 
 apply_patch_with_msg() {
@@ -37,10 +36,9 @@ prepare() {
   tar -xzf ${_realname}-${pkgver}.tar.gz || true
 
   cd "${srcdir}"/SuiteSparse-${pkgver}
-  # Disable SPEX on GCC based environments - requires shared mpfr
-  if [[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]]; then
-    sed -i -E "s|(^.*\( cd SPEX)|#\1|g" Makefile
-  fi
+
+  apply_patch_with_msg \
+    0001-SPEX-Link-to-gmp-after-mpfr.patch
 }
 
 build() {
@@ -56,12 +54,12 @@ build() {
   fi
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-    make CMAKE_OPTIONS="-G\"MSYS Makefiles\" -DCMAKE_INSTALL_PREFIX=\"${MINGW_PREFIX}\" ${_extra_config[@]} -DENABLE_CUDA=OFF -DBLA_VENDOR=OpenBLAS"
+    make CMAKE_OPTIONS="-DCMAKE_INSTALL_PREFIX=\"${MINGW_PREFIX}\" ${_extra_config[@]} -DBLA_VENDOR=OpenBLAS"
 }
 
 package() {
   cd "${srcdir}/build-${MSYSTEM}"
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-  make install DESTDIR="${pkgdir}"
+    make install DESTDIR="${pkgdir}"
 }


### PR DESCRIPTION
Use upstream patch to fix linking the SPEX library with gcc.
Also, remove the Fortran compiler as a build dependency.
Remove `metis` from dependencies.
Remove unnecessary `cmake` flags.