### PR TITLE
starship: update to 1.12.0

### DIFF
--- a/mingw-w64-starship/PKGBUILD
+++ b/mingw-w64-starship/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=starship
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.11.0
+pkgver=1.12.0
 pkgrel=1
 pkgdesc="The cross-shell prompt for astronauts (mingw-w64)"
 arch=('any')
@@ -15,7 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-cmake")
 options=('staticlibs' 'strip')
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/starship/starship/archive/refs/tags/v${pkgver}.tar.gz")
-sha256sums=('7b408ef8a2ab47d7a7d0e120889bf12c8f2a965796f8a027d8b2176287fdec6b')
+sha256sums=('748a0541009b0bee5f51b716d072f244d8d5cb3fb8d768519ed305494ea11e02')
 noextract=("${_realname}-${pkgver}.tar.gz")
 
 prepare() {


### PR DESCRIPTION
Fails to build on 32bit environments, giving that this package is not required by any package I think we could disable it on 32bit envs if no one comes with a fix/workaround.