### PR TITLE
bug_report template: try to simplify it a bit

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -4,10 +4,29 @@ labels: [bug]
 body:
   - type: textarea
     attributes:
-      label: Description
-      description: A clear and concise description of what the bug is, and why you consider it to be a bug.
+      label: Description / Steps to reproduce the issue
+      description: A clear and concise description of what the bug is, and why you consider it to be a bug, and steps for how to reproduce it
+      placeholder: |
+        A description with steps to reproduce the issue.
+        1. Step 1
+        2. Step 2
     validations:
       required: true
+
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: A description of what you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Actual behavior
+      description: A description of what is actually happening.
+    validations:
+      required: true
+
   - type: checkboxes
     attributes:
       label: Verification
@@ -15,13 +34,15 @@ body:
       options:
         - label: I have verified that my MSYS2 is up-to-date before submitting the report (see https://www.msys2.org/docs/updating/)
           required: true
-  - type: textarea
+
+  - type: input
     attributes:
       label: Windows Version
-      description: Please run `cmd.exe /c ver` to get the build of Windows you are on.
-      placeholder: "Microsoft Windows [Version 10.0.19042.867]"
+      description: Please run `uname` to get the build of Windows you are on.
+      placeholder: "MSYS_NT-10.0-22621"
     validations:
       required: true
+
   - type: checkboxes
     attributes:
       label: MINGW environments affected
@@ -33,27 +54,7 @@ body:
         - label: CLANG64
         - label: CLANG32
         - label: CLANGARM64
-  - type: textarea
-    attributes:
-      label: Expected behavior
-      description: A description of what you expected to happen.
-    validations:
-        required: true
-  - type: textarea
-    attributes:
-      label: Actual behavior
-      description: A description of what is actually happening.
-    validations:
-        required: true
-  - type: textarea
-    attributes:
-      label: Repro steps
-      placeholder: |
-        A description with steps to reproduce the issue.
-        1. Step 1
-        2. Step 2
-    validations:
-        required: true
+
   - type: input
     attributes:
       label: Are you willing to submit a PR?


### PR DESCRIPTION
There are two main changes:

* Description and reproduction steps are merged at the top, so users don't descripe the bug and then later on have to fill out the steps again, possibly writing the same things twice slightly differently. This flow feels more natural imo.

* Recomend "uname" instead of "cmd.exe /c ver", the later is tricky because of path conversion of "/c", and uname has the same info basically.

Preview: https://github.com/msys2/MINGW-packages/blob/752ef871dd33074c33257a5e37ac02b5e7a2b010/.github/ISSUE_TEMPLATE/bug_report.yml