### PR TITLE
mcfgthread: Update to 1.4-ga.1

### DIFF
--- a/mingw-w64-mcfgthread/PKGBUILD
+++ b/mingw-w64-mcfgthread/PKGBUILD
@@ -4,14 +4,14 @@ _realname=mcfgthread
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}"-libs)
-pkgver=1.3.3
+pkgver=1.4.1
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://github.com/lhmouse/mcfgthread"
 license=('spdx:LGPL-3.0-or-later' 'custom')
 options=('staticlibs' 'strip' '!buildflags')
-_commit='b1fc172e6dfb6c041a0040a3041349475a235189'
+_commit='66326556e26f07872c797bbdbea5e398de32e66d'
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cc"
   "${MINGW_PACKAGE_PREFIX}-autotools"
@@ -27,11 +27,16 @@ prepare() {
 
   mkdir -p m4
   autoreconf -ifv
+
+  pushd test_c++
+  mkdir -p m4
+  autoreconf -ifv
+  popd
 }
 
 build() {
-  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
-  mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
+  [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
   export CFLAGS+=' -Os -g'
 
@@ -39,7 +44,6 @@ build() {
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
-    --target=${MINGW_CHOST} \
     --disable-pch
 
   make
@@ -49,8 +53,20 @@ build() {
 }
 
 check() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MSYSTEM}"
   make check
+
+  # Run c++ tests, which have to be configured separately after C
+  # libraries have been built.
+  mkdir -p test_c++
+  pushd test_c++
+
+  ../../${_realname}/test_c++/configure \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST}
+
+  make check
+  popd
 }
 
 package_mcfgthread() {


### PR DESCRIPTION
1. Use `build-${MSYSTEM}` as build directories, like other packages.
2. Remove the useless `--target` for `configure`.
3. Add C++ tests.

For the record: Some i686 test programs on my Windows 10 machine fail because the result of `QueryPerformanceCounter()` occasionally goes backwards. It is of course unexpected but I don't know whether it's a Windows bug or normal behavior. All the x86_64 tests pass without such issues.

