### PR TITLE
Add package for SuiteSparse 5

### DIFF
--- a/mingw-w64-octave/PKGBUILD
+++ b/mingw-w64-octave/PKGBUILD
@@ -2,7 +2,7 @@ _realname=octave
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=7.3.0
-pkgrel=3
+pkgrel=4
 pkgdesc="GNU Octave: Interactive programming environment for numerical computations (mingw-w64)"
 url="https://www.octave.org"
 license=('spdx:GPL-3.0-or-later')
@@ -21,7 +21,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libgfortran"
          "${MINGW_PACKAGE_PREFIX}-libsndfile"
          "${MINGW_PACKAGE_PREFIX}-pcre"
          "${MINGW_PACKAGE_PREFIX}-qhull"
-         "${MINGW_PACKAGE_PREFIX}-suitesparse"
+         $([[ ${MSYSTEM} == *32 ]] && echo "${MINGW_PACKAGE_PREFIX}-suitesparse5" || echo "${MINGW_PACKAGE_PREFIX}-suitesparse")
          "${MINGW_PACKAGE_PREFIX}-sundials"
          "${MINGW_PACKAGE_PREFIX}-qrupdate"
          "${MINGW_PACKAGE_PREFIX}-qscintilla"

--- a/mingw-w64-suitesparse5/0001-mingw-w64-Use-a-not-lib-as-AR_TARGET-extension.patch
+++ b/mingw-w64-suitesparse5/0001-mingw-w64-Use-a-not-lib-as-AR_TARGET-extension.patch
@@ -1,0 +1,12 @@
+diff -urN SuiteSparse-5.11.0/SuiteSparse_config/SuiteSparse_config.mk.orig SuiteSparse-5.11.0/SuiteSparse_config/SuiteSparse_config.mk
+--- SuiteSparse-5.11.0/SuiteSparse_config/SuiteSparse_config.mk.orig	2022-03-21 19:28:13.026738300 +0100
++++ SuiteSparse-5.11.0/SuiteSparse_config/SuiteSparse_config.mk	2022-03-21 19:31:47.757136900 +0100
+@@ -440,7 +440,7 @@
+ 
+ ifeq ($(UNAME),Windows)
+     # Cygwin Make on Windows
+-    AR_TARGET = $(LIBRARY).lib
++    AR_TARGET = $(LIBRARY).a
+     SO_TARGET  = $(LIBRARY).dll
+     # The following two links are just garbage copies of the real target
+     # they aren't actually supported by this OS

--- a/mingw-w64-suitesparse5/0002-mingw-w64-Set-SO_OPTS--shared-move-dlls-create-import-libs.patch
+++ b/mingw-w64-suitesparse5/0002-mingw-w64-Set-SO_OPTS--shared-move-dlls-create-import-libs.patch
@@ -1,0 +1,672 @@
+diff -urN SuiteSparse.orig/AMD/Lib/Makefile SuiteSparse/AMD/Lib/Makefile
+--- SuiteSparse.orig/AMD/Lib/Makefile	2017-05-01 17:08:36.145856600 +0100
++++ SuiteSparse/AMD/Lib/Makefile	2017-05-01 16:24:28.606356000 +0100
+@@ -81,28 +81,24 @@
+ #-------------------------------------------------------------------------------
+ 
+ # install AMD
+-install: $(AR_TARGET) $(INSTALL_LIB)/$(SO_TARGET)
++install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
+ 
+-$(INSTALL_LIB)/$(SO_TARGET): $(OBJ)
++$(INSTALL_SO)/$(SO_TARGET): $(OBJ)
+ 	@mkdir -p $(INSTALL_LIB)
+ 	@mkdir -p $(INSTALL_INCLUDE)
+ 	@mkdir -p $(INSTALL_DOC)
+ 	$(CC) $(SO_OPTS) $^ -o $@ $(LDLIBS)
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_PLAIN) )
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_MAIN) )
+ 	$(CP) ../Include/amd.h $(INSTALL_INCLUDE)
+ 	$(CP) ../Doc/AMD_UserGuide.pdf $(INSTALL_DOC)
+ 	$(CP) ../README.txt $(INSTALL_DOC)/AMD_README.txt
+-	chmod 755 $(INSTALL_LIB)/$(SO_TARGET)
++	chmod 755 $(INSTALL_SO)/$(SO_TARGET)
+ 	chmod 644 $(INSTALL_INCLUDE)/amd.h
+ 	chmod 644 $(INSTALL_DOC)/AMD_UserGuide.pdf
+ 	chmod 644 $(INSTALL_DOC)/AMD_README.txt
+ 
+ # uninstall AMD
+ uninstall:
+-	$(RM) $(INSTALL_LIB)/$(SO_TARGET)
+-	$(RM) $(INSTALL_LIB)/$(SO_PLAIN)
+-	$(RM) $(INSTALL_LIB)/$(SO_MAIN)
++	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/amd.h
+ 	$(RM) $(INSTALL_DOC)/AMD_UserGuide.pdf
+ 	$(RM) $(INSTALL_DOC)/AMD_README.txt
+diff -urN SuiteSparse.orig/BTF/Lib/Makefile SuiteSparse/BTF/Lib/Makefile
+--- SuiteSparse.orig/BTF/Lib/Makefile	2017-05-01 17:08:36.159359300 +0100
++++ SuiteSparse/BTF/Lib/Makefile	2017-05-01 16:24:28.616354400 +0100
+@@ -66,25 +66,21 @@
+ #-------------------------------------------------------------------------------
+ 
+ # install BTF
+-install: $(AR_TARGET) $(INSTALL_LIB)/$(SO_TARGET)
++install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
+ 
+-$(INSTALL_LIB)/$(SO_TARGET): $(OBJ)
++$(INSTALL_SO)/$(SO_TARGET): $(OBJ)
+ 	@mkdir -p $(INSTALL_LIB)
+ 	@mkdir -p $(INSTALL_INCLUDE)
+ 	@mkdir -p $(INSTALL_DOC)
+ 	$(CC) $(SO_OPTS) $^ -o $@ $(LDLIBS)
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_PLAIN) )
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_MAIN) )
+ 	$(CP) ../Include/btf.h $(INSTALL_INCLUDE)
+ 	$(CP) ../README.txt $(INSTALL_DOC)/BTF_README.txt
+-	chmod 755 $(INSTALL_LIB)/$(SO_TARGET)
++	chmod 755 $(INSTALL_SO)/$(SO_TARGET)
+ 	chmod 644 $(INSTALL_INCLUDE)/btf.h
+ 	chmod 644 $(INSTALL_DOC)/BTF_README.txt
+ 
+ uninstall:
+-	$(RM) $(INSTALL_LIB)/$(SO_TARGET)
+-	$(RM) $(INSTALL_LIB)/$(SO_PLAIN)
+-	$(RM) $(INSTALL_LIB)/$(SO_MAIN)
++	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/btf.h
+ 	$(RM) $(INSTALL_DOC)/BTF_README.txt
+ 
+diff -urN SuiteSparse.orig/CAMD/Lib/Makefile SuiteSparse/CAMD/Lib/Makefile
+--- SuiteSparse.orig/CAMD/Lib/Makefile	2017-05-01 17:08:36.229858300 +0100
++++ SuiteSparse/CAMD/Lib/Makefile	2017-05-01 16:24:28.628355400 +0100
+@@ -62,28 +62,24 @@
+ #-------------------------------------------------------------------------------
+ 
+ # install CAMD
+-install: $(AR_TARGET) $(INSTALL_LIB)/$(SO_TARGET)
++install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
+ 
+-$(INSTALL_LIB)/$(SO_TARGET): $(OBJ)
++$(INSTALL_SO)/$(SO_TARGET): $(OBJ)
+ 	@mkdir -p $(INSTALL_LIB)
+ 	@mkdir -p $(INSTALL_INCLUDE)
+ 	@mkdir -p $(INSTALL_DOC)
+ 	$(CC) $(SO_OPTS) $^ -o $@ $(LDLIBS)
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_PLAIN) )
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_MAIN) )
+ 	$(CP) ../Include/camd.h $(INSTALL_INCLUDE)
+ 	$(CP) ../Doc/CAMD_UserGuide.pdf $(INSTALL_DOC)
+ 	$(CP) ../README.txt $(INSTALL_DOC)/CAMD_README.txt
+-	chmod 755 $(INSTALL_LIB)/$(SO_TARGET)
++	chmod 755 $(INSTALL_SO)/$(SO_TARGET)
+ 	chmod 644 $(INSTALL_INCLUDE)/camd.h
+ 	chmod 644 $(INSTALL_DOC)/CAMD_UserGuide.pdf
+ 	chmod 644 $(INSTALL_DOC)/CAMD_README.txt
+ 
+ # uninstall CAMD
+ uninstall:
+-	$(RM) $(INSTALL_LIB)/$(SO_TARGET)
+-	$(RM) $(INSTALL_LIB)/$(SO_PLAIN)
+-	$(RM) $(INSTALL_LIB)/$(SO_MAIN)
++	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/camd.h
+ 	$(RM) $(INSTALL_DOC)/CAMD_UserGuide.pdf
+ 	$(RM) $(INSTALL_DOC)/CAMD_README.txt
+diff -urN SuiteSparse.orig/CCOLAMD/Lib/Makefile SuiteSparse/CCOLAMD/Lib/Makefile
+--- SuiteSparse.orig/CCOLAMD/Lib/Makefile	2017-05-01 17:08:36.241860000 +0100
++++ SuiteSparse/CCOLAMD/Lib/Makefile	2017-05-01 16:24:28.640355000 +0100
+@@ -49,25 +49,21 @@
+ 	- $(RM) -r $(PURGE)
+ 
+ # install CCOLAMD
+-install: $(AR_TARGET) $(INSTALL_LIB)/$(SO_TARGET)
++install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
+ 
+-$(INSTALL_LIB)/$(SO_TARGET): $(OBJ)
++$(INSTALL_SO)/$(SO_TARGET): $(OBJ)
+ 	@mkdir -p $(INSTALL_LIB)
+ 	@mkdir -p $(INSTALL_INCLUDE)
+ 	@mkdir -p $(INSTALL_DOC)
+ 	$(CC) $(SO_OPTS) $^ -o $@ $(LDLIBS)
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_PLAIN) )
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_MAIN) )
+ 	$(CP) ../Include/ccolamd.h $(INSTALL_INCLUDE)
+ 	$(CP) ../README.txt $(INSTALL_DOC)/CCOLAMD_README.txt
+-	chmod 755 $(INSTALL_LIB)/$(SO_TARGET)
++	chmod 755 $(INSTALL_SO)/$(SO_TARGET)
+ 	chmod 644 $(INSTALL_INCLUDE)/ccolamd.h
+ 	chmod 644 $(INSTALL_DOC)/CCOLAMD_README.txt
+ 
+ uninstall:
+-	$(RM) $(INSTALL_LIB)/$(SO_TARGET)
+-	$(RM) $(INSTALL_LIB)/$(SO_PLAIN)
+-	$(RM) $(INSTALL_LIB)/$(SO_MAIN)
++	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/ccolamd.h
+ 	$(RM) $(INSTALL_DOC)/CCOLAMD_README.txt
+ 
+diff -urN SuiteSparse.orig/CHOLMOD/Lib/Makefile SuiteSparse/CHOLMOD/Lib/Makefile
+--- SuiteSparse.orig/CHOLMOD/Lib/Makefile	2017-05-01 17:08:36.260357100 +0100
++++ SuiteSparse/CHOLMOD/Lib/Makefile	2017-05-01 16:24:28.650854700 +0100
+@@ -535,29 +535,25 @@
+ #-------------------------------------------------------------------------------
+ 
+ # install CHOLMOD
+-install: $(AR_TARGET) $(INSTALL_LIB)/$(SO_TARGET)
++install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
+ 
+-$(INSTALL_LIB)/$(SO_TARGET): $(OBJ)
++$(INSTALL_SO)/$(SO_TARGET): $(OBJ)
+ 	@mkdir -p $(INSTALL_LIB)
+ 	@mkdir -p $(INSTALL_INCLUDE)
+ 	@mkdir -p $(INSTALL_DOC)
+ 	$(CXX) $(SO_OPTS) $^ -o $@ $(LDLIBS)
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_PLAIN) )
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_MAIN) )
+ 	$(CP) ../Include/cholmod*.h $(INSTALL_INCLUDE)
+ 	$(RM) $(INSTALL_INCLUDE)/cholmod_internal.h
+ 	$(CP) ../Doc/CHOLMOD_UserGuide.pdf $(INSTALL_DOC)
+ 	$(CP) ../README.txt $(INSTALL_DOC)/CHOLMOD_README.txt
+-	chmod 755 $(INSTALL_LIB)/$(SO_TARGET)
++	chmod 755 $(INSTALL_SO)/$(SO_TARGET)
+ 	chmod 644 $(INSTALL_INCLUDE)/cholmod*.h
+ 	chmod 644 $(INSTALL_DOC)/CHOLMOD_UserGuide.pdf
+ 	chmod 644 $(INSTALL_DOC)/CHOLMOD_README.txt
+ 
+ # uninstall CHOLMOD
+ uninstall:
+-	$(RM) $(INSTALL_LIB)/$(SO_TARGET)
+-	$(RM) $(INSTALL_LIB)/$(SO_PLAIN)
+-	$(RM) $(INSTALL_LIB)/$(SO_MAIN)
++	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/cholmod*.h
+ 	$(RM) $(INSTALL_DOC)/CHOLMOD_UserGuide.pdf
+ 	$(RM) $(INSTALL_DOC)/CHOLMOD_README.txt
+diff -urN SuiteSparse.orig/COLAMD/Lib/Makefile SuiteSparse/COLAMD/Lib/Makefile
+--- SuiteSparse.orig/COLAMD/Lib/Makefile	2017-05-01 17:08:36.281357400 +0100
++++ SuiteSparse/COLAMD/Lib/Makefile	2017-05-01 16:24:28.660355300 +0100
+@@ -49,25 +49,21 @@
+ 	- $(RM) -r $(PURGE)
+ 
+ # install COLAMD
+-install: $(AR_TARGET) $(INSTALL_LIB)/$(SO_TARGET)
++install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
+ 
+-$(INSTALL_LIB)/$(SO_TARGET): $(OBJ)
++$(INSTALL_SO)/$(SO_TARGET): $(OBJ)
+ 	@mkdir -p $(INSTALL_LIB)
+ 	@mkdir -p $(INSTALL_INCLUDE)
+ 	@mkdir -p $(INSTALL_DOC)
+ 	$(CC) $(SO_OPTS) $^ -o $@ $(LDLIBS)
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_PLAIN) )
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_MAIN) )
+ 	$(CP) ../Include/colamd.h $(INSTALL_INCLUDE)
+ 	$(CP) ../README.txt $(INSTALL_DOC)/COLAMD_README.txt
+-	chmod 755 $(INSTALL_LIB)/$(SO_TARGET)
++	chmod 755 $(INSTALL_SO)/$(SO_TARGET)
+ 	chmod 644 $(INSTALL_INCLUDE)/colamd.h
+ 	chmod 644 $(INSTALL_DOC)/COLAMD_README.txt
+ 
+ uninstall:
+-	$(RM) $(INSTALL_LIB)/$(SO_TARGET)
+-	$(RM) $(INSTALL_LIB)/$(SO_PLAIN)
+-	$(RM) $(INSTALL_LIB)/$(SO_MAIN)
++	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/colamd.h
+ 	$(RM) $(INSTALL_DOC)/COLAMD_README.txt
+ 
+diff -urN SuiteSparse.orig/CXSparse/Lib/Makefile SuiteSparse/CXSparse/Lib/Makefile
+--- SuiteSparse.orig/CXSparse/Lib/Makefile	2017-05-01 17:08:36.295357600 +0100
++++ SuiteSparse/CXSparse/Lib/Makefile	2017-05-01 16:24:28.669855300 +0100
+@@ -113,26 +113,22 @@
+ 	- $(RM) -r $(PURGE)
+ 
+ # install CXSparse
+-install: $(AR_TARGET) $(INSTALL_LIB)/$(SO_TARGET)
++install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
+ 
+-$(INSTALL_LIB)/$(SO_TARGET): $(CS)
++$(INSTALL_SO)/$(SO_TARGET): $(CS)
+ 	@mkdir -p $(INSTALL_LIB)
+ 	@mkdir -p $(INSTALL_INCLUDE)
+ 	@mkdir -p $(INSTALL_DOC)
+ 	$(CC) $(SO_OPTS) $^ -o $@ $(LDLIBS)
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_PLAIN) )
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_MAIN) )
+ 	$(CP) ../Include/cs.h $(INSTALL_INCLUDE)
+ 	$(CP) ../README.txt $(INSTALL_DOC)/CXSPARSE_README.txt
+-	chmod 755 $(INSTALL_LIB)/$(SO_TARGET)
++	chmod 755 $(INSTALL_SO)/$(SO_TARGET)
+ 	chmod 644 $(INSTALL_INCLUDE)/cs.h
+ 	chmod 644 $(INSTALL_DOC)/CXSPARSE_README.txt
+ 
+ # uninstall CXSparse
+ uninstall:
+-	$(RM) $(INSTALL_LIB)/$(SO_TARGET)
+-	$(RM) $(INSTALL_LIB)/$(SO_PLAIN)
+-	$(RM) $(INSTALL_LIB)/$(SO_MAIN)
++	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/cs.h
+ 	$(RM) $(INSTALL_DOC)/CXSPARSE_README.txt
+ 
+diff -urN SuiteSparse.orig/CXSparse_newfiles/Lib/Makefile SuiteSparse/CXSparse_newfiles/Lib/Makefile
+--- SuiteSparse.orig/CXSparse_newfiles/Lib/Makefile	2017-05-01 17:08:36.309358100 +0100
++++ SuiteSparse/CXSparse_newfiles/Lib/Makefile	2017-05-01 16:24:28.676354900 +0100
+@@ -113,26 +113,22 @@
+ 	- $(RM) -r $(PURGE)
+ 
+ # install CXSparse
+-install: $(AR_TARGET) $(INSTALL_LIB)/$(SO_TARGET)
++install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
+ 
+-$(INSTALL_LIB)/$(SO_TARGET): $(CS)
++$(INSTALL_SO)/$(SO_TARGET): $(CS)
+ 	@mkdir -p $(INSTALL_LIB)
+ 	@mkdir -p $(INSTALL_INCLUDE)
+ 	@mkdir -p $(INSTALL_DOC)
+ 	$(CC) $(SO_OPTS) $^ -o $@ $(LDLIBS)
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_PLAIN) )
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_MAIN) )
+ 	$(CP) ../Include/cs.h $(INSTALL_INCLUDE)
+ 	$(CP) ../README.txt $(INSTALL_DOC)/CXSPARSE_README.txt
+-	chmod 755 $(INSTALL_LIB)/$(SO_TARGET)
++	chmod 755 $(INSTALL_SO)/$(SO_TARGET)
+ 	chmod 644 $(INSTALL_INCLUDE)/cs.h
+ 	chmod 644 $(INSTALL_DOC)/CXSPARSE_README.txt
+ 
+ # uninstall CXSparse
+ uninstall:
+-	$(RM) $(INSTALL_LIB)/$(SO_TARGET)
+-	$(RM) $(INSTALL_LIB)/$(SO_PLAIN)
+-	$(RM) $(INSTALL_LIB)/$(SO_MAIN)
++	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/cs.h
+ 	$(RM) $(INSTALL_DOC)/CXSPARSE_README.txt
+ 
+diff -urN SuiteSparse.orig/GPUQREngine/Lib/Makefile SuiteSparse/GPUQREngine/Lib/Makefile
+--- SuiteSparse.orig/GPUQREngine/Lib/Makefile	2017-05-01 17:08:36.324358000 +0100
++++ SuiteSparse/GPUQREngine/Lib/Makefile	2017-05-01 16:24:28.685855200 +0100
+@@ -129,24 +129,20 @@
+ #-------------------------------------------------------------------------------
+ 
+ # install GPUQREngine.  Note that the include files are not installed.
+-install: $(AR_TARGET) $(INSTALL_LIB)/$(SO_TARGET)
++install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
+ 
+-$(INSTALL_LIB)/$(SO_TARGET): $(OBJS)
++$(INSTALL_SO)/$(SO_TARGET): $(OBJS)
+ 	@mkdir -p $(INSTALL_LIB)
+ 	@mkdir -p $(INSTALL_INCLUDE)
+ 	@mkdir -p $(INSTALL_DOC)
+ 	$(CXX) $(SO_OPTS) $^ -o $@ $(LDLIBS)
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_PLAIN) )
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_MAIN) )
+ 	$(CP) ../README.txt $(INSTALL_DOC)/GPUQRENGINE_README.txt
+-	chmod 755 $(INSTALL_LIB)/$(SO_TARGET)
++	chmod 755 $(INSTALL_SO)/$(SO_TARGET)
+ 	chmod 644 $(INSTALL_DOC)/GPUQRENGINE_README.txt
+ 
+ # uninstall GPUQREngine
+ uninstall:
+-	$(RM) $(INSTALL_LIB)/$(SO_TARGET)
+-	$(RM) $(INSTALL_LIB)/$(SO_PLAIN)
+-	$(RM) $(INSTALL_LIB)/$(SO_MAIN)
++	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_DOC)/GPUQRENGINE_README.txt
+ 
+ #-------------------------------------------------------------------------------
+diff -urN SuiteSparse.orig/KLU/Lib/Makefile SuiteSparse/KLU/Lib/Makefile
+--- SuiteSparse.orig/KLU/Lib/Makefile	2017-05-01 17:08:36.342857200 +0100
++++ SuiteSparse/KLU/Lib/Makefile	2017-05-01 16:24:28.695856500 +0100
+@@ -263,28 +263,24 @@
+ #-------------------------------------------------------------------------------
+ 
+ # install KLU
+-install: $(AR_TARGET) $(INSTALL_LIB)/$(SO_TARGET)
++install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
+ 
+-$(INSTALL_LIB)/$(SO_TARGET): $(OBJ)
++$(INSTALL_SO)/$(SO_TARGET): $(OBJ)
+ 	@mkdir -p $(INSTALL_LIB)
+ 	@mkdir -p $(INSTALL_INCLUDE)
+ 	@mkdir -p $(INSTALL_DOC)
+ 	$(CC) $(SO_OPTS) $^ -o $@ $(LDLIBS)
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_PLAIN) )
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_MAIN) )
+ 	$(CP) ../Include/klu.h $(INSTALL_INCLUDE)
+ 	$(CP) ../Doc/KLU_UserGuide.pdf $(INSTALL_DOC)
+ 	$(CP) ../README.txt $(INSTALL_DOC)/KLU_README.txt
+-	chmod 755 $(INSTALL_LIB)/$(SO_TARGET)
++	chmod 755 $(INSTALL_SO)/$(SO_TARGET)
+ 	chmod 644 $(INSTALL_INCLUDE)/klu.h
+ 	chmod 644 $(INSTALL_DOC)/KLU_UserGuide.pdf
+ 	chmod 644 $(INSTALL_DOC)/KLU_README.txt
+ 
+ # uninstall KLU
+ uninstall:
+-	$(RM) $(INSTALL_LIB)/$(SO_TARGET)
+-	$(RM) $(INSTALL_LIB)/$(SO_PLAIN)
+-	$(RM) $(INSTALL_LIB)/$(SO_MAIN)
++	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/klu.h
+ 	$(RM) $(INSTALL_DOC)/KLU_UserGuide.pdf
+ 	$(RM) $(INSTALL_DOC)/KLU_README.txt
+diff -urN SuiteSparse.orig/LDL/Lib/Makefile SuiteSparse/LDL/Lib/Makefile
+--- SuiteSparse.orig/LDL/Lib/Makefile	2017-05-01 17:08:36.356357000 +0100
++++ SuiteSparse/LDL/Lib/Makefile	2017-05-01 16:24:28.705857500 +0100
+@@ -46,28 +46,24 @@
+ 	- $(RM) -r $(CLEAN)
+ 
+ # install LDL
+-install: $(AR_TARGET) $(INSTALL_LIB)/$(SO_TARGET)
++install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
+ 
+-$(INSTALL_LIB)/$(SO_TARGET): $(OBJ)
++$(INSTALL_SO)/$(SO_TARGET): $(OBJ)
+ 	@mkdir -p $(INSTALL_LIB)
+ 	@mkdir -p $(INSTALL_INCLUDE)
+ 	@mkdir -p $(INSTALL_DOC)
+ 	$(CC) $(SO_OPTS) $^ -o $@ $(LDLIBS)
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_PLAIN) )
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_MAIN) )
+ 	$(CP) ../Include/ldl.h $(INSTALL_INCLUDE)
+ 	$(CP) ../Doc/ldl_userguide.pdf $(INSTALL_DOC)
+ 	$(CP) ../README.txt $(INSTALL_DOC)/LDL_README.txt
+-	chmod 755 $(INSTALL_LIB)/$(SO_TARGET)
++	chmod 755 $(INSTALL_SO)/$(SO_TARGET)
+ 	chmod 644 $(INSTALL_INCLUDE)/ldl.h
+ 	chmod 644 $(INSTALL_DOC)/ldl_userguide.pdf
+ 	chmod 644 $(INSTALL_DOC)/LDL_README.txt
+ 
+ # uninstall LDL
+ uninstall:
+-	$(RM) $(INSTALL_LIB)/$(SO_TARGET)
+-	$(RM) $(INSTALL_LIB)/$(SO_PLAIN)
+-	$(RM) $(INSTALL_LIB)/$(SO_MAIN)
++	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/ldl.h
+ 	$(RM) $(INSTALL_DOC)/ldl_userguide.pdf
+ 	$(RM) $(INSTALL_DOC)/LDL_README.txt
+diff -urN SuiteSparse.orig/Makefile SuiteSparse/Makefile
+--- SuiteSparse.orig/Makefile	2017-05-01 17:08:36.371358100 +0100
++++ SuiteSparse/Makefile	2017-05-01 17:09:24.703869100 +0100
+@@ -63,13 +63,13 @@
+ 	@mkdir -p $(INSTALL_LIB)
+ 	@mkdir -p $(INSTALL_INCLUDE)
+ 	@mkdir -p $(INSTALL_DOC)
+-	- $(CP) lib/libmetis.* $(INSTALL_LIB)
++	- $(CP) lib/libmetis.* $(INSTALL_SO)
+ 	- $(CP) metis-5.1.0/manual/manual.pdf $(INSTALL_DOC)/METIS_manual.pdf
+ 	- $(CP) metis-5.1.0/README.txt $(INSTALL_DOC)/METIS_README.txt
+         # the following is needed only on the Mac, so *.dylib is hardcoded:
+ 	$(SO_INSTALL_NAME) $(INSTALL_LIB)/libmetis.dylib $(INSTALL_LIB)/libmetis.dylib
+ 	- $(CP) include/metis.h $(INSTALL_INCLUDE)
+-	chmod 755 $(INSTALL_LIB)/libmetis.*
++	chmod 755 $(INSTALL_SO)/libmetis.*
+ 	chmod 644 $(INSTALL_INCLUDE)/metis.h
+ 	chmod 644 $(INSTALL_DOC)/METIS_manual.pdf
+ 	chmod 644 $(INSTALL_DOC)/METIS_README.txt
+diff -urN SuiteSparse.orig/RBio/Lib/Makefile SuiteSparse/RBio/Lib/Makefile
+--- SuiteSparse.orig/RBio/Lib/Makefile	2017-05-01 17:08:36.387356800 +0100
++++ SuiteSparse/RBio/Lib/Makefile	2017-05-01 16:24:28.725356200 +0100
+@@ -60,25 +60,21 @@
+ #-------------------------------------------------------------------------------
+ 
+ # install RBio
+-install: $(AR_TARGET) $(INSTALL_LIB)/$(SO_TARGET)
++install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
+ 
+-$(INSTALL_LIB)/$(SO_TARGET): $(OBJ)
++$(INSTALL_SO)/$(SO_TARGET): $(OBJ)
+ 	@mkdir -p $(INSTALL_LIB)
+ 	@mkdir -p $(INSTALL_INCLUDE)
+ 	@mkdir -p $(INSTALL_DOC)
+ 	$(CC) $(SO_OPTS) $^ -o $@ $(LDLIBS)
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_PLAIN) )
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_MAIN) )
+ 	$(CP) ../Include/RBio.h $(INSTALL_INCLUDE)
+ 	$(CP) ../README.txt $(INSTALL_DOC)/RBIO_README.txt
+-	chmod 755 $(INSTALL_LIB)/$(SO_TARGET)
++	chmod 755 $(INSTALL_SO)/$(SO_TARGET)
+ 	chmod 644 $(INSTALL_INCLUDE)/RBio.h
+ 	chmod 644 $(INSTALL_DOC)/RBIO_README.txt
+ 
+ # uninstall RBio
+ uninstall:
+-	$(RM) $(INSTALL_LIB)/$(SO_TARGET)
+-	$(RM) $(INSTALL_LIB)/$(SO_PLAIN)
+-	$(RM) $(INSTALL_LIB)/$(SO_MAIN)
++	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/RBio.h
+ 	$(RM) $(INSTALL_DOC)/RBIO_README.txt
+diff -urN SuiteSparse.orig/SPQR/Lib/Makefile SuiteSparse/SPQR/Lib/Makefile
+--- SuiteSparse.orig/SPQR/Lib/Makefile	2017-05-01 17:08:36.409357700 +0100
++++ SuiteSparse/SPQR/Lib/Makefile	2017-05-01 16:24:28.735855300 +0100
+@@ -242,22 +242,20 @@
+ #-------------------------------------------------------------------------------
+ 
+ # install SPQR
+-install: $(AR_TARGET) $(INSTALL_LIB)/$(SO_TARGET)
++install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
+ 
+-$(INSTALL_LIB)/$(SO_TARGET): $(OBJ)
++$(INSTALL_SO)/$(SO_TARGET): $(OBJ)
+ 	@mkdir -p $(INSTALL_LIB)
+ 	@mkdir -p $(INSTALL_INCLUDE)
+ 	@mkdir -p $(INSTALL_DOC)
+ 	$(CXX) $(SO_OPTS) $^ -o $@ $(LDLIBS)
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_PLAIN) )
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_MAIN) )
+ 	$(CP) ../Include/SuiteSparseQR.hpp $(INSTALL_INCLUDE)
+ 	$(CP) ../Include/SuiteSparseQR_C.h $(INSTALL_INCLUDE)
+ 	$(CP) ../Include/SuiteSparseQR_definitions.h $(INSTALL_INCLUDE)
+ 	$(CP) ../Include/spqr.hpp $(INSTALL_INCLUDE)
+ 	$(CP) ../Doc/spqr_user_guide.pdf $(INSTALL_DOC)
+ 	$(CP) ../README.txt $(INSTALL_DOC)/SPQR_README.txt
+-	chmod 755 $(INSTALL_LIB)/$(SO_TARGET)
++	chmod 755 $(INSTALL_SO)/$(SO_TARGET)
+ 	chmod 644 $(INSTALL_INCLUDE)/SuiteSparseQR.hpp
+ 	chmod 644 $(INSTALL_INCLUDE)/SuiteSparseQR_C.h
+ 	chmod 644 $(INSTALL_INCLUDE)/SuiteSparseQR_definitions.h
+@@ -267,9 +267,7 @@
+ 
+ # uninstall SPQR
+ uninstall:
+-	$(RM) $(INSTALL_LIB)/$(SO_TARGET)
+-	$(RM) $(INSTALL_LIB)/$(SO_PLAIN)
+-	$(RM) $(INSTALL_LIB)/$(SO_MAIN)
++	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/SuiteSparseQR.hpp
+ 	$(RM) $(INSTALL_INCLUDE)/SuiteSparseQR_C.h
+ 	$(RM) $(INSTALL_INCLUDE)/SuiteSparseQR_definitions.h
+diff -urN SuiteSparse.orig/SuiteSparse_config/Makefile SuiteSparse/SuiteSparse_config/Makefile
+--- SuiteSparse.orig/SuiteSparse_config/Makefile	2017-05-01 17:08:36.425858700 +0100
++++ SuiteSparse/SuiteSparse_config/Makefile	2017-05-01 16:24:28.746854300 +0100
+@@ -44,27 +44,22 @@
+ 	- $(RM) -r $(CLEAN)
+ 
+ # install SuiteSparse_config
+-install: $(AR_TARGET) $(INSTALL_LIB)/$(SO_TARGET)
++install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
+ 
+-$(INSTALL_LIB)/$(SO_TARGET): $(OBJ)
++$(INSTALL_SO)/$(SO_TARGET): $(OBJ)
+ 	@mkdir -p $(INSTALL_LIB)
+ 	@mkdir -p $(INSTALL_INCLUDE)
+ 	@mkdir -p $(INSTALL_DOC)
+ 	$(CC) $(SO_OPTS) $^ -o $@ $(LDLIBS)
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_PLAIN) )
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_MAIN) )
+ 	$(CP) SuiteSparse_config.h $(INSTALL_INCLUDE)
+ 	$(CP) README.txt $(INSTALL_DOC)/SUITESPARSECONFIG_README.txt
+-	chmod 755 $(INSTALL_LIB)/$(SO_TARGET)
+-	chmod 755 $(INSTALL_LIB)/$(SO_PLAIN)
++	chmod 755 $(INSTALL_SO)/$(SO_TARGET)
+ 	chmod 644 $(INSTALL_INCLUDE)/SuiteSparse_config.h
+ 	chmod 644 $(INSTALL_DOC)/SUITESPARSECONFIG_README.txt
+ 
+ # uninstall SuiteSparse_config
+ uninstall:
+-	$(RM) $(INSTALL_LIB)/$(SO_TARGET)
+-	$(RM) $(INSTALL_LIB)/$(SO_PLAIN)
+-	$(RM) $(INSTALL_LIB)/$(SO_MAIN)
++	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/SuiteSparse_config.h
+ 	$(RM) $(INSTALL_DOC)/SUITESPARSECONFIG_README.txt
+ 	( cd xerbla ; $(MAKE) uninstall )
+diff -urN SuiteSparse-5.11.0/SuiteSparse_config/SuiteSparse_config.mk.orig SuiteSparse-5.11.0/SuiteSparse_config/SuiteSparse_config.mk
+--- SuiteSparse-5.11.0/SuiteSparse_config/SuiteSparse_config.mk.orig	2022-03-15 00:33:19.000000000 +0100
++++ SuiteSparse-5.11.0/SuiteSparse_config/SuiteSparse_config.mk	2022-03-20 13:25:30.876107144 +0100
+@@ -73,6 +73,7 @@
+     # and documentation in /solo/mydox.
+     INSTALL ?= $(SUITESPARSE)
+     INSTALL_LIB ?= $(INSTALL)/lib
++    INSTALL_SO ?= $(INSTALL)/lib
+     INSTALL_INCLUDE ?= $(INSTALL)/include
+     INSTALL_DOC ?= $(INSTALL)/share/doc/suitesparse-$(SUITESPARSE_VERSION)
+ 
+@@ -349,7 +350,7 @@
+     ifeq ($(UNAME),Linux)
+         # add the posix realtime extensions library: librt
+         LDLIBS += -lrt
+-        LDFLAGS += -Wl,-rpath=$(INSTALL_LIB)
++        LDFLAGS += -Wl,-rpath=$(INSTALL_SO)
+     endif
+ 
+     #---------------------------------------------------------------------------
+@@ -365,7 +366,7 @@
+         LAPACK ?= -framework Accelerate
+         # OpenMP is not yet supported by default in clang
+         CFOPENMP =
+-        LDLIBS += -rpath $(INSTALL_LIB)
++        LDLIBS += -rpath $(INSTALL_SO)
+     endif
+ 
+     #---------------------------------------------------------------------------
+@@ -446,7 +447,8 @@
+     # they aren't actually supported by this OS
+     SO_MAIN   = $(LIBRARY).$(SO_VERSION).dll
+     SO_PLAIN = $(LIBRARY).$(VERSION).dll
+-    SO_OPTS  += -shared
++    SO_OPTS  += -shared -Wl,--out-implib,$(INSTALL_LIB)/$(LIBRARY).dll.a
++    INSTALL_SO = $(INSTALL)/bin
+     SO_INSTALL_NAME = echo
+ else
+     # Mac or Linux/Unix
+@@ -568,6 +570,7 @@
+ 	@echo 'System:                   UNAME=          ' '$(UNAME)'
+ 	@echo 'Install directory:        INSTALL=        ' '$(INSTALL)'
+ 	@echo 'Install libraries in:     INSTALL_LIB=    ' '$(INSTALL_LIB)'
++	@echo 'Install shared libs in:   INSTALL_SO=     ' '$(INSTALL_SO)'
+ 	@echo 'Install include files in: INSTALL_INCLUDE=' '$(INSTALL_INCLUDE)'
+ 	@echo 'Install documentation in: INSTALL_DOC=    ' '$(INSTALL_DOC)'
+ 	@echo 'Optimization level:       OPTIMIZATION=   ' '$(OPTIMIZATION)'
+diff -urN SuiteSparse.orig/SuiteSparse_config/xerbla/Makefile SuiteSparse/SuiteSparse_config/xerbla/Makefile
+--- SuiteSparse.orig/SuiteSparse_config/xerbla/Makefile	2017-05-01 17:08:36.456857300 +0100
++++ SuiteSparse/SuiteSparse_config/xerbla/Makefile	2017-05-01 16:24:28.783354600 +0100
+@@ -53,16 +53,13 @@
+ 	$(COMPILE)
+ 	$(CC) $(SO_OPTS) xerbla.o -o $@
+ 	- $(RM) xerbla.o
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_PLAIN) )
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_MAIN) )
+ 	$(CP) xerbla.h $(INSTALL_INCLUDE)
+-	chmod 755 $(INSTALL_LIB)/$(SO_TARGET)
++	chmod 755 $(INSTALL_SO)/$(SO_TARGET)
+ 	chmod 644 $(INSTALL_INCLUDE)/xerbla.h
+ 
+ # uninstall libcerbla / libxerbla
+ uninstall:
+-	$(RM) $(INSTALL_LIB)/$(SO_TARGET)
+-	$(RM) $(INSTALL_LIB)/$(SO_PLAIN)
++	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/xerbla.h
+ 
+ distclean: purge
+diff -urN SuiteSparse.orig/SuiteSparse_GPURuntime/Lib/Makefile SuiteSparse/SuiteSparse_GPURuntime/Lib/Makefile
+--- SuiteSparse.orig/SuiteSparse_GPURuntime/Lib/Makefile	2017-05-01 17:08:36.470358000 +0100
++++ SuiteSparse/SuiteSparse_GPURuntime/Lib/Makefile	2017-05-01 16:24:28.798856500 +0100
+@@ -70,23 +70,19 @@
+ #-------------------------------------------------------------------------------
+ 
+ # install SuiteSparse_GPURuntime (just the library, not the include files)
+-install: $(AR_TARGET) $(INSTALL_LIB)/$(SO_TARGET)
++install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
+ 
+-$(INSTALL_LIB)/$(SO_TARGET): $(OBJS)
++$(INSTALL_SO)/$(SO_TARGET): $(OBJS)
+ 	@mkdir -p $(INSTALL_LIB)
+ 	@mkdir -p $(INSTALL_INCLUDE)
+ 	@mkdir -p $(INSTALL_DOC)
+ 	$(CXX) $(SO_OPTS) $^ -o $@ $(LDLIBS)
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_PLAIN) )
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_MAIN) )
+ 	$(CP) ../README.txt $(INSTALL_DOC)/GPURUNTIME_README.txt
+-	chmod 755 $(INSTALL_LIB)/$(SO_TARGET)
++	chmod 755 $(INSTALL_SO)/$(SO_TARGET)
+ 	chmod 644 $(INSTALL_DOC)/GPURUNTIME_README.txt
+ 
+ # uninstall SuiteSparse_GPURuntime
+ uninstall:
+-	$(RM) $(INSTALL_LIB)/$(SO_TARGET)
+-	$(RM) $(INSTALL_LIB)/$(SO_PLAIN)
+-	$(RM) $(INSTALL_LIB)/$(SO_MAIN)
++	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_DOC)/GPURUNTIME_README.txt
+ 
+diff -urN SuiteSparse.orig/UMFPACK/Lib/Makefile SuiteSparse/UMFPACK/Lib/Makefile
+--- SuiteSparse.orig/UMFPACK/Lib/Makefile	2017-05-01 17:08:36.484858600 +0100
++++ SuiteSparse/UMFPACK/Lib/Makefile	2017-05-01 16:24:28.812354100 +0100
+@@ -288,20 +288,18 @@
+ 
+ #-------------------------------------------------------------------------------
+ # install UMFPACK
+-install: $(AR_TARGET) $(INSTALL_LIB)/$(SO_TARGET)
++install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
+ 
+-$(INSTALL_LIB)/$(SO_TARGET): $(OBJ)
++$(INSTALL_SO)/$(SO_TARGET): $(OBJ)
+ 	@mkdir -p $(INSTALL_LIB)
+ 	@mkdir -p $(INSTALL_INCLUDE)
+ 	@mkdir -p $(INSTALL_DOC)
+ 	$(CC) $(SO_OPTS) $^ -o $@ $(LDLIBS)
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_PLAIN) )
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_MAIN) )
+ 	$(CP) ../Include/umfpack*.h $(INSTALL_INCLUDE)
+ 	$(CP) ../Doc/UMFPACK_UserGuide.pdf $(INSTALL_DOC)
+ 	$(CP) ../Doc/UMFPACK_QuickStart.pdf $(INSTALL_DOC)
+ 	$(CP) ../README.txt $(INSTALL_DOC)/UMFPACK_README.txt
+-	chmod 755 $(INSTALL_LIB)/$(SO_TARGET)
++	chmod 755 $(INSTALL_SO)/$(SO_TARGET)
+ 	chmod 644 $(INSTALL_INCLUDE)/umfpack*.h
+ 	chmod 644 $(INSTALL_DOC)/UMFPACK_UserGuide.pdf
+ 	chmod 644 $(INSTALL_DOC)/UMFPACK_QuickStart.pdf
+@@ -309,9 +309,7 @@
+ 
+ # uninstall UMFPACK
+ uninstall:
+-	$(RM) $(INSTALL_LIB)/$(SO_TARGET)
+-	$(RM) $(INSTALL_LIB)/$(SO_PLAIN)
+-	$(RM) $(INSTALL_LIB)/$(SO_MAIN)
++	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/umfpack*.h
+ 	$(RM) $(INSTALL_DOC)/UMFPACK_UserGuide.pdf
+ 	$(RM) $(INSTALL_DOC)/UMFPACK_QuickStart.pdf
+
+diff -urN SuiteSparse-5.8.1.orig/SLIP_LU/Lib/Makefile SuiteSparse-5.8.1/SLIP_LU/Lib/Makefile
+--- SuiteSparse-5.8.1.orig/SLIP_LU/Lib/Makefile	2020-07-15 04:04:44.000000000 +0500
++++ SuiteSparse-5.8.1/SLIP_LU/Lib/Makefile	2020-12-22 22:51:56.103420700 +0500
+@@ -63,19 +63,17 @@
+ #-------------------------------------------------------------------------------
+ 
+ # install SLIP_LU
+-install: $(AR_TARGET) $(INSTALL_LIB)/$(SO_TARGET)
++install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
+ 
+-$(INSTALL_LIB)/$(SO_TARGET): $(OBJ)
++$(INSTALL_SO)/$(SO_TARGET): $(OBJ)
+ 	@mkdir -p $(INSTALL_LIB)
+ 	@mkdir -p $(INSTALL_INCLUDE)
+ 	@mkdir -p $(INSTALL_DOC)
+ 	$(CC) $(SO_OPTS) $^ -o $@ $(LDLIBS)
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_PLAIN) )
+-	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_MAIN) )
+ 	$(CP) ../Include/SLIP_LU.h $(INSTALL_INCLUDE)
+ 	$(CP) ../Doc/SLIP_LU_UserGuide.pdf $(INSTALL_DOC)
+ 	$(CP) ../README.md $(INSTALL_DOC)/SLIP_LU_README.md
+-	chmod 755 $(INSTALL_LIB)/$(SO_TARGET)
++	chmod 755 $(INSTALL_SO)/$(SO_TARGET)
+ 	chmod 644 $(INSTALL_INCLUDE)/SLIP_LU.h
+ 	chmod 644 $(INSTALL_DOC)/SLIP_LU_UserGuide.pdf
+ 	chmod 644 $(INSTALL_DOC)/SLIP_LU_README.md

--- a/mingw-w64-suitesparse5/0003-mingw-w64-no-CUDA.patch
+++ b/mingw-w64-suitesparse5/0003-mingw-w64-no-CUDA.patch
@@ -1,0 +1,12 @@
+diff -urN SuiteSparse.orig/SuiteSparse_config/SuiteSparse_config.mk SuiteSparse/SuiteSparse_config/SuiteSparse_config.mk
+--- SuiteSparse.orig/SuiteSparse_config/SuiteSparse_config.mk	2017-10-03 20:02:09.070092300 +0800
++++ SuiteSparse/SuiteSparse_config/SuiteSparse_config.mk	2017-10-03 20:23:32.245485700 +0800
+@@ -194,7 +195,7 @@
+ 
+     # CUDA is detected automatically, and used if found.  To disable CUDA,
+     # use CUDA=no
+-    CUDA = auto
++    CUDA = no
+ 
+     ifneq ($(CUDA),no)
+         CUDA_PATH = $(shell which nvcc 2>/dev/null | sed "s/\/bin\/nvcc//")

--- a/mingw-w64-suitesparse5/0004-mingw-w64-install-static-libs.patch
+++ b/mingw-w64-suitesparse5/0004-mingw-w64-install-static-libs.patch
@@ -1,0 +1,278 @@
+diff -urN SuiteSparse.orig/AMD/Lib/Makefile SuiteSparse/AMD/Lib/Makefile
+--- SuiteSparse.orig/AMD/Lib/Makefile	2017-10-27 14:05:20.073277700 -0400
++++ SuiteSparse/AMD/Lib/Makefile	2017-10-27 14:27:09.455884200 -0400
+@@ -82,6 +82,7 @@
+ 
+ # install AMD
+ install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
++	$(CP) $(AR_TARGET) $(INSTALL_LIB)
+ 
+ $(INSTALL_SO)/$(SO_TARGET): $(OBJ)
+ 	@mkdir -p $(INSTALL_LIB)
+@@ -98,6 +99,7 @@
+ 
+ # uninstall AMD
+ uninstall:
++	$(RM) $(INSTALL_LIB)/$(AR_TARGET)
+ 	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/amd.h
+ 	$(RM) $(INSTALL_DOC)/AMD_UserGuide.pdf
+diff -urN SuiteSparse.orig/BTF/Lib/Makefile SuiteSparse/BTF/Lib/Makefile
+--- SuiteSparse.orig/BTF/Lib/Makefile	2017-10-27 14:05:20.081316500 -0400
++++ SuiteSparse/BTF/Lib/Makefile	2017-10-27 14:27:21.347044000 -0400
+@@ -67,6 +67,7 @@
+ 
+ # install BTF
+ install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
++	$(CP) $(AR_TARGET) $(INSTALL_LIB)
+ 
+ $(INSTALL_SO)/$(SO_TARGET): $(OBJ)
+ 	@mkdir -p $(INSTALL_LIB)
+@@ -80,6 +81,7 @@
+ 	chmod 644 $(INSTALL_DOC)/BTF_README.txt
+ 
+ uninstall:
++	$(RM) $(INSTALL_LIB)/$(AR_TARGET)
+ 	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/btf.h
+ 	$(RM) $(INSTALL_DOC)/BTF_README.txt
+diff -urN SuiteSparse.orig/CAMD/Lib/Makefile SuiteSparse/CAMD/Lib/Makefile
+--- SuiteSparse.orig/CAMD/Lib/Makefile	2017-10-27 14:05:20.090337000 -0400
++++ SuiteSparse/CAMD/Lib/Makefile	2017-10-27 14:27:35.585799200 -0400
+@@ -63,6 +63,7 @@
+ 
+ # install CAMD
+ install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
++	$(CP) $(AR_TARGET) $(INSTALL_LIB)
+ 
+ $(INSTALL_SO)/$(SO_TARGET): $(OBJ)
+ 	@mkdir -p $(INSTALL_LIB)
+@@ -79,6 +80,7 @@
+ 
+ # uninstall CAMD
+ uninstall:
++	$(RM) $(INSTALL_LIB)/$(AR_TARGET)
+ 	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/camd.h
+ 	$(RM) $(INSTALL_DOC)/CAMD_UserGuide.pdf
+diff -urN SuiteSparse.orig/CCOLAMD/Lib/Makefile SuiteSparse/CCOLAMD/Lib/Makefile
+--- SuiteSparse.orig/CCOLAMD/Lib/Makefile	2017-10-27 14:05:20.100348700 -0400
++++ SuiteSparse/CCOLAMD/Lib/Makefile	2017-10-27 14:27:49.406174400 -0400
+@@ -50,6 +50,7 @@
+ 
+ # install CCOLAMD
+ install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
++	$(CP) $(AR_TARGET) $(INSTALL_LIB)
+ 
+ $(INSTALL_SO)/$(SO_TARGET): $(OBJ)
+ 	@mkdir -p $(INSTALL_LIB)
+@@ -63,6 +64,7 @@
+ 	chmod 644 $(INSTALL_DOC)/CCOLAMD_README.txt
+ 
+ uninstall:
++	$(RM) $(INSTALL_LIB)/$(AR_TARGET)
+ 	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/ccolamd.h
+ 	$(RM) $(INSTALL_DOC)/CCOLAMD_README.txt
+diff -urN SuiteSparse.orig/CHOLMOD/Lib/Makefile SuiteSparse/CHOLMOD/Lib/Makefile
+--- SuiteSparse.orig/CHOLMOD/Lib/Makefile	2017-10-27 14:05:20.108369700 -0400
++++ SuiteSparse/CHOLMOD/Lib/Makefile	2017-10-27 14:28:03.044074400 -0400
+@@ -536,6 +536,7 @@
+ 
+ # install CHOLMOD
+ install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
++	$(CP) $(AR_TARGET) $(INSTALL_LIB)
+ 
+ $(INSTALL_SO)/$(SO_TARGET): $(OBJ)
+ 	@mkdir -p $(INSTALL_LIB)
+@@ -553,6 +554,7 @@
+ 
+ # uninstall CHOLMOD
+ uninstall:
++	$(RM) $(INSTALL_LIB)/$(AR_TARGET)
+ 	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/cholmod*.h
+ 	$(RM) $(INSTALL_DOC)/CHOLMOD_UserGuide.pdf
+diff -urN SuiteSparse.orig/COLAMD/Lib/Makefile SuiteSparse/COLAMD/Lib/Makefile
+--- SuiteSparse.orig/COLAMD/Lib/Makefile	2017-10-27 14:05:20.116391700 -0400
++++ SuiteSparse/COLAMD/Lib/Makefile	2017-10-27 14:28:14.342235400 -0400
+@@ -50,6 +50,7 @@
+ 
+ # install COLAMD
+ install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
++	$(CP) $(AR_TARGET) $(INSTALL_LIB)
+ 
+ $(INSTALL_SO)/$(SO_TARGET): $(OBJ)
+ 	@mkdir -p $(INSTALL_LIB)
+@@ -63,6 +64,7 @@
+ 	chmod 644 $(INSTALL_DOC)/COLAMD_README.txt
+ 
+ uninstall:
++	$(RM) $(INSTALL_LIB)/$(AR_TARGET)
+ 	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/colamd.h
+ 	$(RM) $(INSTALL_DOC)/COLAMD_README.txt
+diff -urN SuiteSparse.orig/CXSparse/Lib/Makefile SuiteSparse/CXSparse/Lib/Makefile
+--- SuiteSparse.orig/CXSparse/Lib/Makefile	2017-10-27 14:05:20.124412700 -0400
++++ SuiteSparse/CXSparse/Lib/Makefile	2017-10-27 14:28:42.936134900 -0400
+@@ -114,6 +114,7 @@
+ 
+ # install CXSparse
+ install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
++	$(CP) $(AR_TARGET) $(INSTALL_LIB)
+ 
+ $(INSTALL_SO)/$(SO_TARGET): $(CS)
+ 	@mkdir -p $(INSTALL_LIB)
+@@ -128,6 +129,7 @@
+ 
+ # uninstall CXSparse
+ uninstall:
++	$(RM) $(INSTALL_LIB)/$(AR_TARGET)
+ 	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/cs.h
+ 	$(RM) $(INSTALL_DOC)/CXSPARSE_README.txt
+diff -urN SuiteSparse.orig/CXSparse_newfiles/Lib/Makefile SuiteSparse/CXSparse_newfiles/Lib/Makefile
+--- SuiteSparse.orig/CXSparse_newfiles/Lib/Makefile	2017-10-27 14:05:20.132434700 -0400
++++ SuiteSparse/CXSparse_newfiles/Lib/Makefile	2017-10-27 14:28:58.098502000 -0400
+@@ -114,6 +114,7 @@
+ 
+ # install CXSparse
+ install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
++	$(CP) $(AR_TARGET) $(INSTALL_LIB)
+ 
+ $(INSTALL_SO)/$(SO_TARGET): $(CS)
+ 	@mkdir -p $(INSTALL_LIB)
+@@ -128,6 +129,7 @@
+ 
+ # uninstall CXSparse
+ uninstall:
++	$(RM) $(INSTALL_LIB)/$(AR_TARGET)
+ 	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/cs.h
+ 	$(RM) $(INSTALL_DOC)/CXSPARSE_README.txt
+diff -urN SuiteSparse.orig/KLU/Lib/Makefile SuiteSparse/KLU/Lib/Makefile
+--- SuiteSparse.orig/KLU/Lib/Makefile	2017-10-27 14:05:20.150482700 -0400
++++ SuiteSparse/KLU/Lib/Makefile	2017-10-27 14:29:21.673082300 -0400
+@@ -264,6 +264,7 @@
+ 
+ # install KLU
+ install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
++	$(CP) $(AR_TARGET) $(INSTALL_LIB)
+ 
+ $(INSTALL_SO)/$(SO_TARGET): $(OBJ)
+ 	@mkdir -p $(INSTALL_LIB)
+@@ -280,6 +281,7 @@
+ 
+ # uninstall KLU
+ uninstall:
++	$(RM) $(INSTALL_LIB)/$(AR_TARGET)
+ 	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/klu.h
+ 	$(RM) $(INSTALL_DOC)/KLU_UserGuide.pdf
+diff -urN SuiteSparse.orig/LDL/Lib/Makefile SuiteSparse/LDL/Lib/Makefile
+--- SuiteSparse.orig/LDL/Lib/Makefile	2017-10-27 14:05:20.158534300 -0400
++++ SuiteSparse/LDL/Lib/Makefile	2017-10-27 14:29:32.417628700 -0400
+@@ -47,6 +47,7 @@
+ 
+ # install LDL
+ install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
++	$(CP) $(AR_TARGET) $(INSTALL_LIB)
+ 
+ $(INSTALL_SO)/$(SO_TARGET): $(OBJ)
+ 	@mkdir -p $(INSTALL_LIB)
+@@ -63,6 +64,7 @@
+ 
+ # uninstall LDL
+ uninstall:
++	$(RM) $(INSTALL_LIB)/$(AR_TARGET)
+ 	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/ldl.h
+ 	$(RM) $(INSTALL_DOC)/ldl_userguide.pdf
+diff -urN SuiteSparse.orig/RBio/Lib/Makefile SuiteSparse/RBio/Lib/Makefile
+--- SuiteSparse.orig/RBio/Lib/Makefile	2017-10-27 14:05:20.173544900 -0400
++++ SuiteSparse/RBio/Lib/Makefile	2017-10-27 14:29:44.135822900 -0400
+@@ -61,6 +61,7 @@
+ 
+ # install RBio
+ install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
++	$(CP) $(AR_TARGET) $(INSTALL_LIB)
+ 
+ $(INSTALL_SO)/$(SO_TARGET): $(OBJ)
+ 	@mkdir -p $(INSTALL_LIB)
+@@ -75,6 +76,7 @@
+ 
+ # uninstall RBio
+ uninstall:
++	$(RM) $(INSTALL_LIB)/$(AR_TARGET)
+ 	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/RBio.h
+ 	$(RM) $(INSTALL_DOC)/RBIO_README.txt
+diff -urN SuiteSparse.orig/SPQR/Lib/Makefile SuiteSparse/SPQR/Lib/Makefile
+--- SuiteSparse.orig/SPQR/Lib/Makefile	2017-10-27 14:05:20.182568000 -0400
++++ SuiteSparse/SPQR/Lib/Makefile	2017-10-27 14:29:59.827071800 -0400
+@@ -243,6 +243,7 @@
+ 
+ # install SPQR
+ install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
++	$(CP) $(AR_TARGET) $(INSTALL_LIB)
+ 
+ $(INSTALL_SO)/$(SO_TARGET): $(OBJ)
+ 	@mkdir -p $(INSTALL_LIB)
+@@ -265,6 +266,7 @@
+ 
+ # uninstall SPQR
+ uninstall:
++	$(RM) $(INSTALL_LIB)/$(AR_TARGET)
+ 	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/SuiteSparseQR.hpp
+ 	$(RM) $(INSTALL_INCLUDE)/SuiteSparseQR_C.h
+diff -urN SuiteSparse.orig/SuiteSparse_config/Makefile SuiteSparse/SuiteSparse_config/Makefile
+--- SuiteSparse.orig/SuiteSparse_config/Makefile	2017-10-27 14:05:20.189586400 -0400
++++ SuiteSparse/SuiteSparse_config/Makefile	2017-10-27 14:30:14.135924600 -0400
+@@ -45,6 +45,7 @@
+ 
+ # install SuiteSparse_config
+ install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
++	$(CP) $(AR_TARGET) $(INSTALL_LIB)
+ 
+ $(INSTALL_SO)/$(SO_TARGET): $(OBJ)
+ 	@mkdir -p $(INSTALL_LIB)
+@@ -59,6 +60,7 @@
+ 
+ # uninstall SuiteSparse_config
+ uninstall:
++	$(RM) $(INSTALL_LIB)/$(AR_TARGET)
+ 	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/SuiteSparse_config.h
+ 	$(RM) $(INSTALL_DOC)/SUITESPARSECONFIG_README.txt
+diff -urN SuiteSparse.orig/UMFPACK/Lib/Makefile SuiteSparse/UMFPACK/Lib/Makefile
+--- SuiteSparse.orig/UMFPACK/Lib/Makefile	2017-10-27 14:05:20.225681300 -0400
++++ SuiteSparse/UMFPACK/Lib/Makefile	2017-10-27 14:30:29.018341400 -0400
+@@ -289,6 +289,7 @@
+ #-------------------------------------------------------------------------------
+ # install UMFPACK
+ install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
++	$(CP) $(AR_TARGET) $(INSTALL_LIB)
+ 
+ $(INSTALL_SO)/$(SO_TARGET): $(OBJ)
+ 	@mkdir -p $(INSTALL_LIB)
+@@ -307,6 +308,7 @@
+ 
+ # uninstall UMFPACK
+ uninstall:
++	$(RM) $(INSTALL_LIB)/$(AR_TARGET)
+ 	$(RM) $(INSTALL_SO)/$(SO_TARGET)
+ 	$(RM) $(INSTALL_INCLUDE)/umfpack*.h
+ 	$(RM) $(INSTALL_DOC)/UMFPACK_UserGuide.pdf
+
+diff -urN SuiteSparse-5.8.1.orig/SLIP_LU/Lib/Makefile SuiteSparse-5.8.1/SLIP_LU/Lib/Makefile
+--- SuiteSparse-5.8.1.orig/SLIP_LU/Lib/Makefile	2020-12-22 23:20:55.105328700 +0500
++++ SuiteSparse-5.8.1/SLIP_LU/Lib/Makefile	2020-12-22 23:21:21.160938900 +0500
+@@ -64,6 +64,7 @@
+ 
+ # install SLIP_LU
+ install: $(AR_TARGET) $(INSTALL_SO)/$(SO_TARGET)
++	$(CP) $(AR_TARGET) $(INSTALL_LIB)
+ 
+ $(INSTALL_SO)/$(SO_TARGET): $(OBJ)
+ 	@mkdir -p $(INSTALL_LIB)

--- a/mingw-w64-suitesparse5/0005-suitesparse-5.8.1-skip-building-Mongoose-GraphBLAS.patch
+++ b/mingw-w64-suitesparse5/0005-suitesparse-5.8.1-skip-building-Mongoose-GraphBLAS.patch
@@ -1,0 +1,86 @@
+diff -urN SuiteSparse-5.11.0/Makefile.orig SuiteSparse-5.11.0/Makefile
+--- SuiteSparse-5.11.0/Makefile.orig	2022-03-15 00:33:19.000000000 +0100
++++ SuiteSparse-5.11.0/Makefile	2022-03-20 13:51:19.924606309 +0100
+@@ -16,7 +16,7 @@
+ # installs all libraries SuiteSparse/lib.
+ go: metis
+ 	( cd SuiteSparse_config && $(MAKE) )
+-	( cd Mongoose && $(MAKE) CMAKE_OPTIONS='$(CMAKE_OPTIONS)' )
++#	( cd Mongoose && $(MAKE) CMAKE_OPTIONS='$(CMAKE_OPTIONS)' )
+ 	( cd AMD && $(MAKE) )
+ 	( cd BTF && $(MAKE) )
+ 	( cd CAMD && $(MAKE) )
+@@ -34,7 +34,7 @@
+ 	( cd GPUQREngine && $(MAKE) )
+ endif
+ 	( cd SPQR && $(MAKE) )
+-	( cd GraphBLAS && $(MAKE) JOBS=$(JOBS) CMAKE_OPTIONS='$(CMAKE_OPTIONS)' )
++#	( cd GraphBLAS && $(MAKE) JOBS=$(JOBS) CMAKE_OPTIONS='$(CMAKE_OPTIONS)' )
+ 	( cd SLIP_LU && $(MAKE) )
+ #	( cd PIRO_BAND && $(MAKE) )
+ #	( cd SKYLINE_SVD && $(MAKE) )
+@@ -44,7 +42,7 @@
+ #       sudo make install INSTALL=/usr/local
+ # See SuiteSparse/README.md for more details.
+ # (note that CSparse is not installed; CXSparse is installed instead)
+-install: metisinstall gbinstall moninstall
++install: metisinstall
+ 	( cd SuiteSparse_config && $(MAKE) install )
+ 	# ( cd Mongoose  && $(MAKE) CMAKE_OPTIONS='$(CMAKE_OPTIONS)' install )
+ 	( cd AMD && $(MAKE) install )
+@@ -93,8 +89,6 @@
+ 	$(RM) $(INSTALL_DOC)/SuiteSparse_README.md
+ 	( cd SuiteSparse_config && $(MAKE) uninstall )
+ 	- ( cd metis-5.1.0 && $(MAKE) uninstall )
+-	- ( cd GraphBLAS && $(MAKE) uninstall )
+-	- ( cd Mongoose  && $(MAKE) uninstall )
+ 	( cd AMD && $(MAKE) uninstall )
+ 	( cd CAMD && $(MAKE) uninstall )
+ 	( cd COLAMD && $(MAKE) uninstall )
+@@ -126,7 +120,7 @@
+ # the static library
+ library: metis
+ 	( cd SuiteSparse_config && $(MAKE) )
+-	( cd Mongoose  && $(MAKE) CMAKE_OPTIONS='$(CMAKE_OPTIONS)' library )
++#	( cd Mongoose  && $(MAKE) CMAKE_OPTIONS='$(CMAKE_OPTIONS)' library )
+ 	( cd AMD && $(MAKE) library )
+ 	( cd BTF && $(MAKE) library )
+ 	( cd CAMD && $(MAKE) library )
+@@ -144,7 +137,7 @@
+ 	( cd GPUQREngine && $(MAKE) library )
+ endif
+ 	( cd SPQR && $(MAKE) library )
+-	( cd GraphBLAS && $(MAKE) JOBS=$(JOBS) CMAKE_OPTIONS='$(CMAKE_OPTIONS)' library )
++#	( cd GraphBLAS && $(MAKE) JOBS=$(JOBS) CMAKE_OPTIONS='$(CMAKE_OPTIONS)' library )
+ 	( cd SLIP_LU && $(MAKE) library )
+ #	( cd PIRO_BAND && $(MAKE) library )
+ #	( cd SKYLINE_SVD && $(MAKE) library )
+@@ -154,7 +146,7 @@
+ # both the dynamic and static libraries.
+ static: metis
+ 	( cd SuiteSparse_config && $(MAKE) static )
+-	( cd Mongoose  && $(MAKE) CMAKE_OPTIONS='$(CMAKE_OPTIONS)' static )
++#	( cd Mongoose  && $(MAKE) CMAKE_OPTIONS='$(CMAKE_OPTIONS)' static )
+ 	( cd AMD && $(MAKE) static )
+ 	( cd BTF && $(MAKE) static )
+ 	( cd CAMD && $(MAKE) static )
+@@ -172,7 +163,7 @@
+ 	( cd GPUQREngine && $(MAKE) static )
+ endif
+ 	( cd SPQR && $(MAKE) static )
+-	( cd GraphBLAS && $(MAKE) JOBS=$(JOBS) CMAKE_OPTIONS='$(CMAKE_OPTIONS)' static )
++#	( cd GraphBLAS && $(MAKE) JOBS=$(JOBS) CMAKE_OPTIONS='$(CMAKE_OPTIONS)' static )
+ 	( cd SLIP_LU && $(MAKE) static )
+ #	( cd PIRO_BAND && $(MAKE) static )
+ #	( cd SKYLINE_SVD && $(MAKE) static )
+@@ -233,8 +219,8 @@
+ 
+ # Create the PDF documentation
+ docs:
+-	( cd GraphBLAS && $(MAKE) docs )
+-	( cd Mongoose  && $(MAKE) docs )
++#	( cd GraphBLAS && $(MAKE) docs )
++#	( cd Mongoose  && $(MAKE) docs )
+ 	( cd AMD && $(MAKE) docs )
+ 	( cd CAMD && $(MAKE) docs )
+ 	( cd KLU && $(MAKE) docs )

--- a/mingw-w64-suitesparse5/0006-suitesparse-5.8.1-fix-mp-link-order.patch
+++ b/mingw-w64-suitesparse5/0006-suitesparse-5.8.1-fix-mp-link-order.patch
@@ -1,0 +1,12 @@
+diff -urN SuiteSparse-5.8.1.orig/SLIP_LU/Lib/Makefile SuiteSparse-5.8.1/SLIP_LU/Lib/Makefile
+--- SuiteSparse-5.8.1.orig/SLIP_LU/Lib/Makefile	2020-07-15 04:04:44.000000000 +0500
++++ SuiteSparse-5.8.1/SLIP_LU/Lib/Makefile	2020-12-22 19:10:14.936075900 +0500
+@@ -20,7 +20,7 @@
+ # CFLAGS += -Wall -Wextra -Wpedantic -Werror
+ 
+ # SLIP_LU depends on SuiteSparse_config, AMD, COLAMD, M, GMP, and MPFR
+-LDLIBS += -lsuitesparseconfig -lamd -lcolamd -lm -lgmp -lmpfr
++LDLIBS += -lsuitesparseconfig -lamd -lcolamd -lm -lmpfr -lgmp
+ 
+ C = $(CC) $(CF) -I../Include -I../../COLAMD/Include -I../../AMD/Include -I../../SuiteSparse_config
+ 

--- a/mingw-w64-suitesparse5/PKGBUILD
+++ b/mingw-w64-suitesparse5/PKGBUILD
@@ -17,7 +17,7 @@ source=(${_realname}-${pkgver}.tar.gz::"https://github.com/DrTimothyAldenDavis/S
         "0004-mingw-w64-install-static-libs.patch"
         "0005-suitesparse-5.8.1-skip-building-Mongoose-GraphBLAS.patch"
         "0006-suitesparse-5.8.1-fix-mp-link-order.patch")
-provides=("${MINGW_PACKAGE_PREFIX}-suitesparse")
+provides=("${MINGW_PACKAGE_PREFIX}-suitesparse=${pkgver}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-suitesparse")
 replaces=("${MINGW_PACKAGE_PREFIX}-suitesparse")
 depends=("${MINGW_PACKAGE_PREFIX}-openblas"

--- a/mingw-w64-suitesparse5/PKGBUILD
+++ b/mingw-w64-suitesparse5/PKGBUILD
@@ -19,7 +19,6 @@ source=(${_realname}-${pkgver}.tar.gz::"https://github.com/DrTimothyAldenDavis/S
         "0006-suitesparse-5.8.1-fix-mp-link-order.patch")
 provides=("${MINGW_PACKAGE_PREFIX}-suitesparse=${pkgver}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-suitesparse")
-replaces=("${MINGW_PACKAGE_PREFIX}-suitesparse")
 depends=("${MINGW_PACKAGE_PREFIX}-openblas"
          "${MINGW_PACKAGE_PREFIX}-omp"
          "${MINGW_PACKAGE_PREFIX}-mpfr"

--- a/mingw-w64-suitesparse5/PKGBUILD
+++ b/mingw-w64-suitesparse5/PKGBUILD
@@ -9,7 +9,7 @@ pkgdesc='A suite of sparse matrix algorithms (mingw-w64)'
 url="https://faculty.cse.tamu.edu/davis/suitesparse.html"
 license=('spdx:LGPL-3.0-or-later AND BSD-3-Clause AND LGPL-2.1-or-later AND GPL-2.0-or-later AND LGPL-2.0-or-later AND Apache-2.0 AND GPL-3.0-or-later')
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+mingw_arch=('mingw32' 'clang32')
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/v${pkgver}.tar.gz"
         "0001-mingw-w64-Use-a-not-lib-as-AR_TARGET-extension.patch"
         "0002-mingw-w64-Set-SO_OPTS--shared-move-dlls-create-import-libs.patch"

--- a/mingw-w64-suitesparse5/PKGBUILD
+++ b/mingw-w64-suitesparse5/PKGBUILD
@@ -1,0 +1,113 @@
+# Maintainer: Ray Donnelly <mingw.android@gmail.com>
+
+_realname=suitesparse5
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-suitesparse5")
+pkgver=5.13.0
+pkgrel=1
+pkgdesc='A suite of sparse matrix algorithms (mingw-w64)'
+url="https://faculty.cse.tamu.edu/davis/suitesparse.html"
+license=('spdx:LGPL-3.0-or-later AND BSD-3-Clause AND LGPL-2.1-or-later AND GPL-2.0-or-later AND LGPL-2.0-or-later AND Apache-2.0 AND GPL-3.0-or-later')
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+source=(${_realname}-${pkgver}.tar.gz::"https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/v${pkgver}.tar.gz"
+        "0001-mingw-w64-Use-a-not-lib-as-AR_TARGET-extension.patch"
+        "0002-mingw-w64-Set-SO_OPTS--shared-move-dlls-create-import-libs.patch"
+        "0003-mingw-w64-no-CUDA.patch"
+        "0004-mingw-w64-install-static-libs.patch"
+        "0005-suitesparse-5.8.1-skip-building-Mongoose-GraphBLAS.patch"
+        "0006-suitesparse-5.8.1-fix-mp-link-order.patch")
+provides=("${MINGW_PACKAGE_PREFIX}-suitesparse")
+conflicts=("${MINGW_PACKAGE_PREFIX}-suitesparse")
+replaces=("${MINGW_PACKAGE_PREFIX}-suitesparse")
+depends=("${MINGW_PACKAGE_PREFIX}-openblas"
+         "${MINGW_PACKAGE_PREFIX}-omp"
+         "${MINGW_PACKAGE_PREFIX}-mpfr"
+         "${MINGW_PACKAGE_PREFIX}-metis")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+noextract=(${_realname}-${pkgver}.tar.gz)
+options=('staticlibs')
+sha256sums=('59c6ca2959623f0c69226cf9afb9a018d12a37fab3a8869db5f6d7f83b6b147d'
+            'fa2ec5c66213c6ab15b68c5a2f846786649db524b050dfafb083a21628f8d348'
+            '130e0d7261f8f05e23ca92495f4f120182725392297eb6ef10d2d51408a54131'
+            '8a94c54322323773442c2c60f54795d402d64ac126e2a1a67e48a0075f8571fa'
+            'e0faab259d5c474c6af51c9b471f645810a308a1c83976275b1969e81e7d8390'
+            '8628100f41800e0e4238a8f949fb99e8667e0b58208130606881612d7172835e'
+            '1cf6cd948e5178cbcb16bb0d3c97829311250dedda1e9dcbe0c85dd6bdc4461e')
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Np1 -i "${srcdir}/$_patch"
+  done
+}
+
+prepare() {
+  cd ${srcdir}
+  rm -rf SuiteSparse-${pkgver}
+  tar -xzf ${_realname}-${pkgver}.tar.gz || true
+
+  cd "${srcdir}"/SuiteSparse-${pkgver}
+
+  apply_patch_with_msg \
+    0001-mingw-w64-Use-a-not-lib-as-AR_TARGET-extension.patch \
+    0002-mingw-w64-Set-SO_OPTS--shared-move-dlls-create-import-libs.patch \
+    0003-mingw-w64-no-CUDA.patch \
+    0004-mingw-w64-install-static-libs.patch \
+    0005-suitesparse-5.8.1-skip-building-Mongoose-GraphBLAS.patch \
+    0006-suitesparse-5.8.1-fix-mp-link-order.patch
+}
+
+build() {
+  [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
+  cp -rf "${srcdir}/SuiteSparse-${pkgver}" "${srcdir}/build-${MSYSTEM}"
+
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  # This avoids needing to use a very large patch (we still get diffs but
+  # that is down to a bug in format string handling somewhere where-by an
+  # extra 0-padding value is emitted in exponents of scientific floats).
+  [[ -d "${PWD}/bin" ]] || mkdir "${PWD}/bin"
+  echo "#!/usr/bin/env bash"                         > "${PWD}/bin/diff"
+  echo "/usr/bin/diff --strip-trailing-cr \"\$@\""  >> "${PWD}/bin/diff"
+
+  # This avoids needing to use another very large patch.
+  [[ -d "${PWD}/lib" ]] || mkdir "${PWD}/lib"
+  ar cru "${PWD}/lib/librt.a"
+
+  PATH="${PWD}/bin:${PATH}" \
+  CC=${CC} \
+  CXX=${CXX} \
+  CFLAGS="-DLONGBLAS='long long'" \
+  CXXFLAGS="-DLONGBLAS='long long'" \
+  LDFLAGS="-L${PWD}/lib" \
+  MY_METIS_LIB=-lmetis \
+  BLAS=-lopenblas \
+  LAPACK=-lopenblas \
+  CFOPENMP="-fopenmp" \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    make CMAKE_OPTIONS="-G\"MSYS Makefiles\" -DCMAKE_INSTALL_PREFIX=\"${MINGW_PREFIX}\" -DCMAKE_BUILD_TYPE=Release"
+}
+
+package() {
+  mkdir -p "${pkgdir}${MINGW_PREFIX}"/{bin,lib,include} || true
+
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  PATH=${PWD}/bin:"${PATH}" \
+  CC=${CC} \
+  CXX=${CXX} \
+  CFLAGS="-DLONGBLAS='long long'" \
+  CXXFLAGS="-DLONGBLAS='long long'" \
+  MY_METIS_LIB=-lmetis \
+  BLAS=-lopenblas \
+  LAPACK=-lopenblas \
+  CFOPENMP="-fopenmp" \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  make install \
+    INSTALL="${pkgdir}${MINGW_PREFIX}" \
+    DESTDIR="${pkgdir}" \
+    CMAKE_OPTIONS="-G\"MSYS Makefiles\" -DCMAKE_INSTALL_PREFIX=\"${MINGW_PREFIX}\" -DCMAKE_BUILD_TYPE=Release"
+}


### PR DESCRIPTION
This addresses #14658.

Most of the libraries in SuiteSparse have an API that can be categorized into two groups: One narrow indexing API and one wide indexing API. In version 5 and version 6, the narrow indexing API uses 32-bit integers. In version 5, the wide indexing API used 64-bit integers on 64-bit platforms and 32-bit integers on 32-bit platforms. In version 6, the wide indexing API uses 64-bit independent of the platform. That cannot work for 32-bit platforms. Indices must not be larger than `sizeof(void *)`. That means half of the API is broken on 32-bit platforms for those libraries.

Some libraries (e.g., SPQR) have only the wide indexing API. That means, they are completely broken on 32-bit platforms.

This PR adds a package that is basically the version of SuiteSparse as it was packaged before the update to version 6.
It currently reverts to SuiteSparse 5 only for 32-bit Octave. A couple of other packages probably also need to be rebuilt with the older version of SuiteSparse (likely `ceres-solver` and `python-cvxopt`). The other dependers don't need to be *rebuilt*. But they should probably still *depend* on SuiteSparse 5 for their 32-bit packages.

I'm not sure if the approach in this PR is the right way to handle this situation.
I'd be happy for any feedback.
