### PR TITLE
curl: Update to 7.87.0

### DIFF
--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -5,8 +5,8 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-gnutls"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-winssl")
-pkgver=7.86.0
-pkgrel=5
+pkgver=7.87.0
+pkgrel=1
 pkgdesc="Command line tool and library for transferring data with URLs (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -37,20 +37,16 @@ source=("https://github.com/curl/curl/releases/download/${_realname}-${pkgver//.
         "0001-Make-cURL-relocatable.patch"
         "0002-nghttp2-static.patch"
         "0003-libpsl-static-libs.patch"
-        "0004-more-static-fixes.patch"
-        "https://github.com/curl/curl/commit/b7260c4fda95196b2fa16f32b5913f25323e5098.patch")
-sha256sums=('2d61116e5f485581f6d59865377df4463f2e788677ac43222b496d4e49fb627b'
+        "0004-more-static-fixes.patch")
+sha256sums=('ee5f1a1955b0ed413435ef79db28b834ea5f0fb7c8cfb1ce47175cc3bee08fff'
             'SKIP'
             '703cd0cb74e714f9e66d26de11c109dd76fab07e723af8dde56a35ea65102e5f'
             '4f9d325265ef6f4e90ad637dea41afa6995388c921fe961ad5dc895aca10318b'
             'c4e6bfd5b58f944d75293128effbd22fe42ee0131b915d9230ceb3c004c0322d'
             '3ee9c75a3046f86f91290c143170179230c9adc6eabfbb79eb26f708a165b719'
             '7492d019036b5bec251bfbc3c0b40e5f16d3dd6b2515068835e087a6c21f19ad'
-            '590eb65e90e756eaad993d52a101f29091ada2c742c5a607684e88fc5c560d54'
-            '702c3f11cecae2d8cfb3cbc3359c4059e5a87db3b29a93b599f0a83a6e490383')
-validpgpkeys=('914C533DF9B2ADA2204F586D78E11C6B279D5C91'  # Daniel Stenberg
-              '27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2'
-              '4461EAF0F8E9097F48AF0555F9FEAFF9D34A1BDB')
+            '590eb65e90e756eaad993d52a101f29091ada2c742c5a607684e88fc5c560d54')
+validpgpkeys=('27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2')  # Daniel Stenberg
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -68,9 +64,6 @@ prepare() {
 
   cd "${srcdir}/${_realname}-${pkgver}"
   cp -fHv "${srcdir}"/pathtools.[ch] lib/
-
-  # https://github.com/curl/curl/issues/9803
-  patch -Nbp1 -i "${srcdir}/b7260c4fda95196b2fa16f32b5913f25323e5098.patch"
 
   apply_patch_with_msg \
     0001-Make-cURL-relocatable.patch \


### PR DESCRIPTION
drop patch included upstream
remove old keys