### PR TITLE
check msys2 tessdata location

### DIFF
--- a/mingw-w64-tesseract-ocr/0001-check-msys2-tessdata-location.patch
+++ b/mingw-w64-tesseract-ocr/0001-check-msys2-tessdata-location.patch
@@ -1,0 +1,32 @@
+From f346fcdd7cac201b8620cbfc8f329d0199baa44b Mon Sep 17 00:00:00 2001
+From: Doronin Stanislav <mugisbrows@gmail.com>
+Date: Wed, 21 Dec 2022 00:46:16 +0300
+Subject: [PATCH] check msys2 tessdata location
+
+---
+ src/ccutil/ccutil.cpp | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/src/ccutil/ccutil.cpp b/src/ccutil/ccutil.cpp
+index aad8ef6..18ade02 100644
+--- a/src/ccutil/ccutil.cpp
++++ b/src/ccutil/ccutil.cpp
+@@ -69,6 +69,15 @@ void CCUtil::main_setup(const std::string &argv0, const std::string &basename) {
+           datadir = subdir;
+         }
+       }
++      separator = std::strrchr(path, '\\'); // cdup from bin directory
++      if (separator != nullptr) {
++        *separator = '\0';
++        std::string subdir = path;
++        subdir += "/share/tessdata";
++        if (_access(subdir.c_str(), 0) == 0) {
++          datadir = subdir;
++        }
++      }
+     }
+ #endif /* _WIN32 */
+   }
+-- 
+2.32.0.windows.2
+

--- a/mingw-w64-tesseract-ocr/PKGBUILD
+++ b/mingw-w64-tesseract-ocr/PKGBUILD
@@ -5,7 +5,7 @@ _realname=tesseract-ocr
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.3.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Tesseract OCR (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -23,13 +23,15 @@ depends=(${MINGW_PACKAGE_PREFIX}-asciidoc
          ${MINGW_PACKAGE_PREFIX}-pango
          ${MINGW_PACKAGE_PREFIX}-zlib)
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/tesseract-ocr/tesseract/archive/${pkgver}.tar.gz
-        https://github.com/tesseract-ocr/tessdata_fast/raw/main/osd.traineddata)
+        https://github.com/tesseract-ocr/tessdata_fast/raw/main/osd.traineddata
+        0001-check-msys2-tessdata-location.patch)
 sha256sums=('7e70870f8341e5ea228af2836ce79a36eefa11b01b56177b4a8997f330c014b8'
-            '9cf5d576fcc47564f11265841e5ca839001e7e6f38ff7f7aacf46d15a96b00ff')
+            '9cf5d576fcc47564f11265841e5ca839001e7e6f38ff7f7aacf46d15a96b00ff'
+            'dfa396e9476a03fc8c24ba59394a5dee2c6a604cee44b9b957be4fda0b5e4392')
 
 prepare() {
   cd "${srcdir}/tesseract-${pkgver}"
-
+  patch -p1 -i ${srcdir}/0001-check-msys2-tessdata-location.patch
   ./autogen.sh
 }
 


### PR DESCRIPTION
Tesseract looks for `tessdata` in executable directory, but on msys2 data is located in `dirname(executable)/../share/tessdata` (`${MSYSTEM}/share/tessdata`), as a result if TESSDATA_PREFIX is not set appropirately, tesseract fails to perform ocr saying "Error opening data file".
This little patch simplifies using tesseract right out of msys2 tree.