### PR TITLE
gr: update to 0.71.2

### DIFF
--- a/mingw-w64-gr/PKGBUILD
+++ b/mingw-w64-gr/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=gr
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.71.1
-pkgrel=2
+pkgver=0.71.2
+pkgrel=1
 pkgdesc="A graphics library for visualisation applications (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -24,13 +24,14 @@ depends=("${MINGW_PACKAGE_PREFIX}-bzip2"
          "${MINGW_PACKAGE_PREFIX}-qt6-base"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-zeromq")
-makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-ninja"
-             "${MINGW_PACKAGE_PREFIX}-cc")
-options=("staticlibs" "strip" "!buildflags")
-source=("${_realname}-${pkgver}.tar.gz::https://github.com/sciapp/gr/archive/v${pkgver}.tar.gz")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/sciapp/gr/archive/v${pkgver}.tar.gz"
+        001-fix-building-on-mingw-w64.patch::https://github.com/sciapp/gr/commit/448ce768.patch)
+sha256sums=('1b6f05a0e1043ef00998fa9bec120c90a01220551e9b094653a56ee38a4bbd1c'
+            '64f51f36c213cf1215c89a42e9c1eaf60cd61582078ba69de28fb2e9f0e37a0b')
 noextract=("${_realname}-${pkgver}.tar.gz")
-sha256sums=('b8434f1678371b56e6ea6f1cd30bde008d624dc2e68559b4972a157e409a3d55')
 
 prepare() {
   # We can't use bsdtar to extract the archive because the archive includes
@@ -38,6 +39,7 @@ prepare() {
   rm -rf "${_realname}-${pkgver}"
   tar -xf "${_realname}-${pkgver}.tar.gz" || true
   cd "${srcdir}/${_realname}-${pkgver}"
+  patch -p1 -i ${srcdir}/001-fix-building-on-mingw-w64.patch
 
   # Set version manually, otherwise it resets to zero
   echo "${pkgver}" > version.txt
@@ -69,6 +71,5 @@ package() {
   cd "${srcdir}/build-${MSYSTEM}"
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install .
 
-  cd "${srcdir}/${_realname}-${pkgver}"
-  install -Dm644 LICENSE.md "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.md"
+  install -Dm644 "${srcdir}"/${_realname}-${pkgver}/LICENSE.md "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.md"
 }


### PR DESCRIPTION
got errors like this:
```
  [220/222] Building CXX object CMakeFiles/grplot.dir/lib/grm/grplot/util.cxx.obj
  FAILED: CMakeFiles/grplot.dir/lib/grm/grplot/util.cxx.obj 
  D:\M\msys64\clang64\bin\clang++.exe -DGR_STATIC_LIB -DHAVE_ZLIB -DMINGW_HAS_SECURE_API=1 -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NEEDS_QMAIN -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DUNICODE -DWIN32 -DWIN64 -DWINVER=0x0A00 -D_ENABLE_EXTENDED_ALIGNED_STORAGE -D_UNICODE -D_WIN32_WINNT=0x0A00 -D_WIN64 -IC:/_/mingw-w64-gr/src/build-CLANG64/grplot_autogen/include -IC:/_/mingw-w64-gr/src/gr-0.71.2/lib/grm/include -IC:/_/mingw-w64-gr/src/gr-0.71.2/lib/grm/src -IC:/_/mingw-w64-gr/src/gr-0.71.2/lib/gks -IC:/_/mingw-w64-gr/src/gr-0.71.2/lib/gr -IC:/_/mingw-w64-gr/src/gr-0.71.2/lib/gr3 -isystem D:/M/msys64/clang64/include/qt6/QtWidgets -isystem D:/M/msys64/clang64/include/qt6 -isystem D:/M/msys64/clang64/include/qt6/QtCore -isystem D:/M/msys64/clang64/share/qt6/mkspecs/win32-clang-g++ -isystem D:/M/msys64/clang64/include/qt6/QtGui -isystem D:/M/msys64/clang64/include/freetype2 -O3 -DNDEBUG -fno-exceptions -Werror=implicit -pthread -std=c++17 -MD -MT CMakeFiles/grplot.dir/lib/grm/grplot/util.cxx.obj -MF CMakeFiles\grplot.dir\lib\grm\grplot\util.cxx.obj.d -o CMakeFiles/grplot.dir/lib/grm/grplot/util.cxx.obj -c C:/_/mingw-w64-gr/src/gr-0.71.2/lib/grm/grplot/util.cxx
  In file included from C:/_/mingw-w64-gr/src/gr-0.71.2/lib/grm/grplot/util.cxx:23:
  In file included from D:/M/msys64/clang64/include/c++/v1/array:127:
  In file included from D:/M/msys64/clang64/include/c++/v1/algorithm:1711:
  D:/M/msys64/clang64/include/c++/v1/cstring:72:9: error: no member named 'strcpy_instead_use_StringCbCopyA_or_StringCchCopyA' in the global namespace
  using ::strcpy _LIBCPP_USING_IF_EXISTS;
        ~~^
  D:/M/msys64/clang64/include/strsafe.h:1931:16: note: expanded from macro 'strcpy'
  #define strcpy strcpy_instead_use_StringCbCopyA_or_StringCchCopyA;
                 ^
  In file included from C:/_/mingw-w64-gr/src/gr-0.71.2/lib/grm/grplot/util.cxx:23:
  In file included from D:/M/msys64/clang64/include/c++/v1/array:127:
  In file included from D:/M/msys64/clang64/include/c++/v1/algorithm:1711:
  D:/M/msys64/clang64/include/c++/v1/cstring:74:9: error: no member named 'strcat_instead_use_StringCbCatA_or_StringCchCatA' in the global namespace
  using ::strcat _LIBCPP_USING_IF_EXISTS;
        ~~^
  D:/M/msys64/clang64/include/strsafe.h:1937:16: note: expanded from macro 'strcat'
  #define strcat strcat_instead_use_StringCbCatA_or_StringCchCatA;
                 ^
  In file included from C:/_/mingw-w64-gr/src/gr-0.71.2/lib/grm/grplot/util.cxx:25:
  In file included from D:/M/msys64/clang64/include/c++/v1/iostream:41:
  In file included from D:/M/msys64/clang64/include/c++/v1/ios:221:
  In file included from D:/M/msys64/clang64/include/c++/v1/__locale:19:
  In file included from D:/M/msys64/clang64/include/c++/v1/mutex:191:
  In file included from D:/M/msys64/clang64/include/c++/v1/__mutex_base:20:
  In file included from D:/M/msys64/clang64/include/c++/v1/system_error:151:
  In file included from D:/M/msys64/clang64/include/c++/v1/string:536:
  In file included from D:/M/msys64/clang64/include/c++/v1/__string/char_traits.h:21:
```
@Biswa96 Are `*_instead_use_StringCb*_or_StringCch*` defined on mingw-w64?, I couldn't find them anywhere in mingw-w64 source (other than the file mentioned in the error message).