### PR TITLE
ceres-solver, python-cvxopt: rebuild with suitesparse5 on 32-bit

### DIFF
--- a/mingw-w64-ceres-solver/PKGBUILD
+++ b/mingw-w64-ceres-solver/PKGBUILD
@@ -4,7 +4,7 @@ _realname=ceres-solver
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.1.0
-pkgrel=3
+pkgrel=4
 pkgdesc="A large scale non-linear optimization library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -16,7 +16,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-eigen3"
          "${MINGW_PACKAGE_PREFIX}-glog"
-         "${MINGW_PACKAGE_PREFIX}-suitesparse")
+         $([[ ${MSYSTEM} == *32 ]] && echo "${MINGW_PACKAGE_PREFIX}-suitesparse5" || echo "${MINGW_PACKAGE_PREFIX}-suitesparse"))
 checkdepends=("${MINGW_PACKAGE_PREFIX}-gflags")
 source=("${url}${_realname}-${pkgver}.tar.gz"
         "001-find-openblas.patch")

--- a/mingw-w64-python-cvxopt/PKGBUILD
+++ b/mingw-w64-python-cvxopt/PKGBUILD
@@ -7,7 +7,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=1.3.0
-pkgrel=4
+pkgrel=5
 pkgdesc="Convex optimization based on the Python programming language (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -17,7 +17,7 @@ validpgpkeys=('gpg_KEY')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools" "${MINGW_PACKAGE_PREFIX}-cc")
 depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-openblas"
-         "${MINGW_PACKAGE_PREFIX}-suitesparse"
+         $([[ ${MSYSTEM} == *32 ]] && echo "${MINGW_PACKAGE_PREFIX}-suitesparse5" || echo "${MINGW_PACKAGE_PREFIX}-suitesparse")
          "${MINGW_PACKAGE_PREFIX}-gsl"
          "${MINGW_PACKAGE_PREFIX}-fftw"
          "${MINGW_PACKAGE_PREFIX}-dsdp"


### PR DESCRIPTION
Rebuild the packages with `suitesparse5` on 32-bit that (probably) use the broken API of `suitesparse`.

That leaves the other dependers of `suitesparse` that should probably also be rebuilt with `suitesparse5` on 32-bit to allow installing them in parallel with the packages that require `suitesparse5`.
See also the discussion in #14663.