### PR TITLE
suitesparse: stop building for 32-bit

### DIFF
--- a/mingw-w64-suitesparse/PKGBUILD
+++ b/mingw-w64-suitesparse/PKGBUILD
@@ -9,7 +9,10 @@ pkgdesc='A suite of sparse matrix algorithms (mingw-w64)'
 url="https://faculty.cse.tamu.edu/davis/suitesparse.html"
 license=('spdx:LGPL-3.0-or-later AND BSD-3-Clause AND LGPL-2.1-or-later AND GPL-2.0-or-later AND LGPL-2.0-or-later AND Apache-2.0 AND GPL-3.0-or-later')
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+# Large parts of the API are broken on 32-bit.
+# See: https://github.com/DrTimothyAldenDavis/SuiteSparse/issues/221
+# Use mingw-w64-suitesparse5 instead for those environments.
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 depends=("${MINGW_PACKAGE_PREFIX}-openblas"
          "${MINGW_PACKAGE_PREFIX}-omp"
          "${MINGW_PACKAGE_PREFIX}-gmp")
@@ -17,7 +20,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-mpfr")
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/v${pkgver}.tar.gz"
-        "0001-SPEX-Link-to-gmp-after-mpfr.patch"::https://github.com/DrTimothyAldenDavis/SuiteSparse/commit/3b20a70ddf9e7d226ebfd870022b393760c3595d.patch)
+        "0001-SPEX-Link-to-gmp-after-mpfr.patch"::"https://github.com/DrTimothyAldenDavis/SuiteSparse/commit/3b20a70ddf9e7d226ebfd870022b393760c3595d.patch")
 sha256sums=('c5d960cd210279c3c83a27747aca2fdeb2e4a13af42870ca0635739accdc6847'
             'c296e783a973a4bbfbab520ab638518755faf8329b1d7c3ceaa812bc2b2877f0')
 noextract=(${_realname}-${pkgver}.tar.gz)


### PR DESCRIPTION
Large parts of the API of the libraries in SuiteSparse 6.x are broken on 32-bit.
We are building SuiteSparse 5 for 32-bit now. So, stop distributing the (broken) version for those targets.

This assumes that dependers on MINGW32 or CLANG32 will pick up `suitesparse5` (which also provides `suitesparse`). I'm not sure of this will actually be the case.
