### PR TITLE
libc++: set _WIN32_WINNT to win7

### DIFF
--- a/mingw-w64-libc++/PKGBUILD
+++ b/mingw-w64-libc++/PKGBUILD
@@ -12,7 +12,7 @@ _version=15.0.5
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
-pkgrel=1
+pkgrel=2
 url="https://libcxx.llvm.org/"
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -75,6 +75,15 @@ build() {
     _build_type="Release"
   fi
 
+  # Targeting Win 7 will just lead to libc++ looking
+  # up new APIs at runtime, so there is no downside really
+  local _win32_winnt
+  if [[ ${MSYSTEM} == CLANGARM64 ]]; then
+      _win32_winnt=0xA00 # Windows 10
+  else
+      _win32_winnt=0x601 # Windows 7
+  fi
+
   local -a libcxx_config
   if (( _clangprefix )); then
     libcxx_config+=(-DLIBCXX_USE_COMPILER_RT=ON
@@ -87,6 +96,7 @@ build() {
     -DCMAKE_C_COMPILER="${MINGW_PREFIX}/bin/clang.exe"
     -DCMAKE_CXX_COMPILER="${MINGW_PREFIX}/bin/clang++.exe"
     -DCMAKE_RANLIB="${MINGW_PREFIX}/bin/llvm-ranlib.exe"
+    -DCMAKE_CXX_FLAGS="-D_WIN32_WINNT=${_win32_winnt}"
     -DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON
     -DLIBCXX_HAS_WIN32_THREAD_API=ON
     -DLIBCXX_INCLUDE_BENCHMARKS=OFF


### PR DESCRIPTION
This leads to libc++ looking up GetSystemTimePreciseAsFileTime at runtime and continue working on Win7.

While we don't want to support win7 anymore, it's better to phase it out slowly and not right away at the toolchain libs level.

See https://github.com/msys2/MINGW-packages/pull/14452#issuecomment-1354606536