### PR TITLE
binutils-handle-windows-nul

### DIFF
--- a/mingw-w64-binutils/PKGBUILD
+++ b/mingw-w64-binutils/PKGBUILD
@@ -6,7 +6,7 @@ _realname=binutils
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.39
-pkgrel=2
+pkgrel=3
 pkgdesc="A set of programs to assemble and manipulate binary and object files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -29,6 +29,8 @@ source=(https://ftp.gnu.org/gnu/binutils/${_realname}-${pkgver}.tar.xz{,.sig}
         specify-timestamp.patch
         "37513c1efbe5e8e1863f8ddf078cd395aa663388.patch::https://sourceware.org/git/?p=binutils-gdb.git;a=patch;h=37513c1efbe5e8e1863f8ddf078cd395aa663388"
         "61f6b650f9bb7fd276b45427b9202f3263465376.patch::https://sourceware.org/git/?p=binutils-gdb.git;a=patch;h=61f6b650f9bb7fd276b45427b9202f3263465376"
+        libiberty-unlink-handle-windows-nul.patch
+        bfd-real-fopen-handle-windows-nul.patch
 )
 sha256sums=('645c25f563b8adc0a81dbd6a41cffbf4d37083a382e02d5d3df4f65c09516d00'
             'SKIP'
@@ -41,7 +43,9 @@ sha256sums=('645c25f563b8adc0a81dbd6a41cffbf4d37083a382e02d5d3df4f65c09516d00'
             'a094660ec95996c00b598429843b7869037732146442af567ada9f539bd40480'
             '27696da8ecfff307537a461b205fad44d6abc1fa648fbf839e72a1d3ea71c40a'
             'b2f159fe91da6ca4f6c2d91dba09883d777533bc952898939ac8185aa712ef5c'
-            '3d1ab4038c28afb27bfa89702ec86ce5e1b852523aa0e550e1ad35d1452b7804')
+            '3d1ab4038c28afb27bfa89702ec86ce5e1b852523aa0e550e1ad35d1452b7804'
+            '7ccbd418695733c50966068fa9755a6abb156f53af23701d2bc097c63e9e0030'
+            'dda1cf0c1825283a8b3708d1a4087dd650f4fbc3f8aa571e211cfe3e1458c8f8')
 validpgpkeys=('EAF1C276A747E9ED86210CBAC3126D3B4AE55E93'
               '3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F')
 
@@ -83,6 +87,18 @@ prepare() {
   # https://salsa.debian.org/mingw-w64-team/binutils-mingw-w64/-/tree/master/debian/patches
   patch -p2 -i "${srcdir}/reproducible-import-libraries.patch"
   patch -p2 -i "${srcdir}/specify-timestamp.patch"
+
+  # Handle Windows nul device
+  # https://github.com/msys2/MINGW-packages/issues/1840
+  # https://github.com/msys2/MINGW-packages/issues/10520
+  # https://github.com/msys2/MINGW-packages/issues/14725
+
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108276
+  # https://gcc.gnu.org/pipermail/gcc-patches/2023-January/609487.html
+  patch -p1 -i "${srcdir}/libiberty-unlink-handle-windows-nul.patch"
+
+  # https://sourceware.org/bugzilla/show_bug.cgi?id=29947
+  patch -p1 -i "${srcdir}/bfd-real-fopen-handle-windows-nul.patch"
 }
 
 build() {

--- a/mingw-w64-binutils/bfd-real-fopen-handle-windows-nul.patch
+++ b/mingw-w64-binutils/bfd-real-fopen-handle-windows-nul.patch
@@ -1,0 +1,14 @@
+--- a/bfd/bfdio.c	Fri Jul  8 15:16:47 2022
++++ b/bfd/bfdio.c	Mon Dec 26 19:39:11 2022
+@@ -150,6 +150,11 @@
+    wcscpy (fullPath, prefix);
+ 
+    int        prefixLen = sizeof(prefix) / sizeof(wchar_t);
++
++   /* Do not add prefix for null device */
++   if (stricmp (filename, "nul") == 0)
++    prefixLen = 1;
++
+    wchar_t *  fullPathOffset = fullPath + prefixLen - 1;
+ 
+    GetFullPathNameW (partPath, fullPathWSize, fullPathOffset, lpFilePart);

--- a/mingw-w64-binutils/libiberty-unlink-handle-windows-nul.patch
+++ b/mingw-w64-binutils/libiberty-unlink-handle-windows-nul.patch
@@ -1,0 +1,15 @@
+--- a/libiberty/unlink-if-ordinary.c
++++ b/libiberty/unlink-if-ordinary.c
+@@ -62,6 +62,12 @@ was made to unlink the file because it is special.
+ int
+ unlink_if_ordinary (const char *name)
+ {
++/* MS-Windows 'stat' function (and in turn, S_ISREG)
++   reports the null device as a regular file.  */
++#ifdef _WIN32
++  if (stricmp (name, "nul") == 0)
++    return 1;
++#endif
+   struct stat st;
+ 
+   if (lstat (name, &st) == 0


### PR DESCRIPTION
`S_ISREG` doesn't work correctly for Windows nul device.
No need to add `\\.\` prefix twice when accessing Windows nul device.

This fixes https://github.com/msys2/MINGW-packages/issues/14725

I'm not a C programmer and not that familiar with msys2 ecosystem. Please let me know if I missed something.