### PR TITLE
rust: fix clangarm64 build

### DIFF
--- a/mingw-w64-rust/0007-clang-subsystem.patch
+++ b/mingw-w64-rust/0007-clang-subsystem.patch
@@ -66,13 +66,13 @@ diff -urN rustc-1.65.0-src.orig/compiler/rustc_target/src/spec/i686_pc_windows_g
  
      // Mark all dynamic libraries and executables as compatible with the larger 4GiB address
      // space available to x86 Windows binaries on x86_64.
-diff -urN rustc-1.65.0-src.orig/compiler/rustc_target/src/spec/windows_gnu_base.rs rustc-1.65.0-src/compiler/rustc_target/src/spec/windows_gnu_base.rs
---- rustc-1.65.0-src.orig/compiler/rustc_target/src/spec/windows_gnu_base.rs	2022-11-09 21:53:40.397722900 +0100
-+++ rustc-1.65.0-src/compiler/rustc_target/src/spec/windows_gnu_base.rs	2022-11-09 22:07:46.181335200 +0100
-@@ -24,30 +24,10 @@
+diff -urN rustc-1.66.0-src/compiler/rustc_target/src/spec/windows_gnu_base.rs.orig rustc-1.66.0-src/compiler/rustc_target/src/spec/windows_gnu_base.rs
+--- rustc-1.66.0-src/compiler/rustc_target/src/spec/windows_gnu_base.rs.orig    2022-12-12 17:02:12.000000000 +0100
++++ rustc-1.66.0-src/compiler/rustc_target/src/spec/windows_gnu_base.rs 2022-12-16 19:16:58.493546900 +0100
+@@ -24,31 +24,10 @@
          ],
      );
- 
+
 -    // Order of `late_link_args*` was found through trial and error to work with various
 -    // mingw-w64 versions (not tested on the CI). It's expected to change from time to time.
 -    let mingw_libs = &[
@@ -91,26 +91,27 @@ diff -urN rustc-1.65.0-src.orig/compiler/rustc_target/src/spec/windows_gnu_base.
 -        "-luser32",
 -        "-lkernel32",
 -    ];
--    let mut late_link_args = TargetOptions::link_args(LinkerFlavor::Ld, mingw_libs);
--    super::add_link_args(&mut late_link_args, LinkerFlavor::Gcc, mingw_libs);
+-    let mut late_link_args =
+-        TargetOptions::link_args(LinkerFlavor::Gnu(Cc::No, Lld::No), mingw_libs);
+-    super::add_link_args(&mut late_link_args, LinkerFlavor::Gnu(Cc::Yes, Lld::No), mingw_libs);
      // If any of our crates are dynamically linked then we need to use
      // the shared libgcc_s-dw2-1.dll. This is required to support
      // unwinding across DLL boundaries.
 -    let dynamic_unwind_libs = &["-lgcc_s"];
 +    let dynamic_unwind_libs = &["-l:libunwind.dll.a"];
      let mut late_link_args_dynamic =
-         TargetOptions::link_args(LinkerFlavor::Ld, dynamic_unwind_libs);
-     super::add_link_args(&mut late_link_args_dynamic, LinkerFlavor::Gcc, dynamic_unwind_libs);
-@@ -56,7 +36,7 @@
+         TargetOptions::link_args(LinkerFlavor::Gnu(Cc::No, Lld::No), dynamic_unwind_libs);
+     super::add_link_args(
+@@ -61,7 +40,7 @@
      // binaries to be redistributed without the libgcc_s-dw2-1.dll
      // dependency, but unfortunately break unwinding across DLL
      // boundaries when unwinding across FFI boundaries.
 -    let static_unwind_libs = &["-lgcc_eh", "-l:libpthread.a"];
 +    let static_unwind_libs = &["-l:libunwind.a"];
-     let mut late_link_args_static = TargetOptions::link_args(LinkerFlavor::Ld, static_unwind_libs);
-     super::add_link_args(&mut late_link_args_static, LinkerFlavor::Gcc, static_unwind_libs);
- 
-@@ -65,7 +45,8 @@
+     let mut late_link_args_static =
+         TargetOptions::link_args(LinkerFlavor::Gnu(Cc::No, Lld::No), static_unwind_libs);
+     super::add_link_args(
+@@ -75,7 +54,8 @@
          env: "gnu".into(),
          vendor: "pc".into(),
          // FIXME(#13846) this should be enabled for windows
@@ -120,7 +121,7 @@ diff -urN rustc-1.65.0-src.orig/compiler/rustc_target/src/spec/windows_gnu_base.
          linker: Some("gcc".into()),
          dynamic_linking: true,
          dll_prefix: "".into(),
-@@ -80,7 +61,6 @@
+@@ -90,7 +70,6 @@
          pre_link_objects_self_contained: crt_objects::pre_mingw_self_contained(),
          post_link_objects_self_contained: crt_objects::post_mingw_self_contained(),
          link_self_contained: LinkSelfContainedDefault::Mingw,

--- a/mingw-w64-rust/0009-build-gnullvm-targets-natively.patch
+++ b/mingw-w64-rust/0009-build-gnullvm-targets-natively.patch
@@ -86,26 +86,26 @@ diff -urN rustc-1.64.0-src.orig/src/bootstrap/compile.rs rustc-1.64.0-src/src/bo
          || builder.config.llvm_libunwind(target) == LlvmLibunwind::InTree
              && (target.contains("linux") || target.contains("fuchsia"))
      {
---- rustc-1.65.0-src/src/stage0.json.orig	2022-11-05 00:44:34.327573300 +0100
-+++ rustc-1.65.0-src/src/stage0.json	2022-11-05 00:47:26.843070500 +0100
+--- rustc-1.66.0-src/src/stage0.json.orig       2022-12-16 19:54:50.667127800 +0100
++++ rustc-1.66.0-src/src/stage0.json    2022-12-16 19:57:00.631071400 +0100
 @@ -18,10 +18,16 @@
    ],
    "compiler": {
-     "date": "2022-09-22",
--    "version": "1.64.0"
+     "date": "2022-11-03",
+-    "version": "1.65.0"
 +    "version": "1.63.0-dev"
    },
    "rustfmt": null,
    "checksums_sha256": {
-+    "dist/2022-08-11/cargo-1.63.0-dev-aarch64-pc-windows-gnullvm.tar.xz": "5a72ff6d89277c96f72cb7de7f35c4a3b4686b3dc6ea0d4966883e83179db0a8",
++    "dist/2022-08-11/cargo-1.63.0-dev-aarch64-pc-windows-gnullvm.tar.xz":"5a72ff6d89277c96f72cb7de7f35c4a3b4686b3dc6ea0d4966883e83179db0a8",
 +    "dist/2022-08-11/rust-std-1.63.0-dev-aarch64-pc-windows-gnullvm.tar.xz": "0a5087acf06faa2a02ff7f41afb7be42b22575a2ff0b3f790b6bb64418f3ea5d",
 +    "dist/2022-08-11/rustc-1.63.0-dev-aarch64-pc-windows-gnullvm.tar.xz": "96c7877b4821fe7bb4aaa35aa8f2056d19d622902d6583d0aef8a35f3fef8dbb",
 +    "dist/2022-08-11/cargo-1.63.0-dev-x86_64-pc-windows-gnullvm.tar.xz": "71630672ae7964548b0662602ab4457d03016f69dccc5ed61975be395f07eb4e",
 +    "dist/2022-08-11/rust-std-1.63.0-dev-x86_64-pc-windows-gnullvm.tar.xz": "3be870b47a8e5eebb581ba7044b05880bf618d8312364fa65b5fade7a0e80fa3",
 +    "dist/2022-08-11/rustc-1.63.0-dev-x86_64-pc-windows-gnullvm.tar.xz": "ac78352d487641b0367e7b601f53b0497d1fd9f1a90cbad480d8bb5eafe85b4e",
-     "dist/2022-09-22/cargo-1.64.0-aarch64-apple-darwin.tar.gz": "dbb26b73baefc8351a7024f307445758fe1e9c18d83000358c02b80a5b1003b3",
-     "dist/2022-09-22/cargo-1.64.0-aarch64-apple-darwin.tar.xz": "8d987d76039b730086ee303710d93f3ff2abcfe3cb74505d8e68c9f72edaa812",
-     "dist/2022-09-22/cargo-1.64.0-aarch64-pc-windows-msvc.tar.gz": "6b86e2b51fa4471358e128369baff21a216815e90eb3ff70af7271e64438da0a",
+     "dist/2022-11-03/cargo-1.65.0-aarch64-apple-darwin.tar.gz": "40858f3078b277165c191b6478c2aba7bf0010162273e28e9964404993eba188",
+     "dist/2022-11-03/cargo-1.65.0-aarch64-apple-darwin.tar.xz": "71013b8d491a355d0b88a97c9c47e50817cf1b506fc8507cd644d2225ec76356",
+     "dist/2022-11-03/cargo-1.65.0-aarch64-pc-windows-msvc.tar.gz": "5b5b684e028b9a024c137974a4121b355f016d644c635a6d0f4d29814cd1c9d9",
 diff -urN rustc-1.64.0-src.orig/src/test/run-make-fulldeps/reproducible-build/Makefile rustc-1.64.0-src/src/test/run-make-fulldeps/reproducible-build/Makefile
 --- rustc-1.64.0-src.orig/src/test/run-make-fulldeps/reproducible-build/Makefile	2022-10-08 13:19:11.261819200 +0200
 +++ rustc-1.64.0-src/src/test/run-make-fulldeps/reproducible-build/Makefile	2022-10-09 21:34:41.340559100 +0200

--- a/mingw-w64-rust/0010-gnullvm-debuginfo-fix.patch
+++ b/mingw-w64-rust/0010-gnullvm-debuginfo-fix.patch
@@ -1,13 +1,13 @@
---- rustc-1.65.0-src/compiler/rustc_target/src/spec/windows_gnullvm_base.rs.orig	2022-11-02 14:36:24.000000000 +0000
-+++ rustc-1.65.0-src/compiler/rustc_target/src/spec/windows_gnullvm_base.rs	2022-11-05 20:16:01.345559900 +0000
+--- rustc-1.66.0-src/compiler/rustc_target/src/spec/windows_gnullvm_base.rs.orig	2022-12-12 17:02:12.000000000 +0100
++++ rustc-1.66.0-src/compiler/rustc_target/src/spec/windows_gnullvm_base.rs	2022-12-16 18:59:17.072654200 +0100
 @@ -1,4 +1,5 @@
--use crate::spec::{cvs, LinkerFlavor, TargetOptions};
-+use crate::spec::{cvs, DebuginfoKind, LinkerFlavor, SplitDebuginfo, TargetOptions};
+-use crate::spec::{cvs, Cc, LinkerFlavor, Lld, TargetOptions};
++use crate::spec::{cvs, Cc, DebuginfoKind, LinkerFlavor, Lld, SplitDebuginfo, TargetOptions};
 +use std::borrow::Cow;
  
  pub fn opts() -> TargetOptions {
      // We cannot use `-nodefaultlibs` because compiler-rt has to be passed
-@@ -34,7 +35,10 @@
+@@ -36,7 +37,10 @@
          eh_frame_header: false,
          no_default_libraries: false,
          has_thread_local: true,

--- a/mingw-w64-rust/0011-disable-uac-for-installer.patch
+++ b/mingw-w64-rust/0011-disable-uac-for-installer.patch
@@ -1,9 +1,9 @@
-diff -urN rustc-1.64.0-src.orig/Cargo.lock rustc-1.64.0-src/Cargo.lock
---- rustc-1.64.0-src.orig/Cargo.lock	2022-09-19 16:07:21.000000000 +0200
-+++ rustc-1.64.0-src/Cargo.lock	2022-11-08 00:40:11.028288600 +0100
-@@ -1227,6 +1227,12 @@
+diff -urN rustc-1.65.0-src.orig/Cargo.lock rustc-1.65.0-src/Cargo.lock
+--- rustc-1.66.0-src/Cargo.lock.orig    2022-12-12 17:02:12.000000000 +0100
++++ rustc-1.66.0-src/Cargo.lock 2022-12-16 19:40:14.191888000 +0100
+@@ -1189,6 +1189,12 @@
  ]
- 
+
  [[package]]
 +name = "embed-manifest"
 +version = "1.3.1"
@@ -14,10 +14,10 @@ diff -urN rustc-1.64.0-src.orig/Cargo.lock rustc-1.64.0-src/Cargo.lock
  name = "ena"
  version = "0.14.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
-@@ -1911,6 +1917,7 @@
+@@ -1801,6 +1807,7 @@
  dependencies = [
   "anyhow",
-  "clap",
+  "clap 3.2.20",
 + "embed-manifest",
   "flate2",
   "lazy_static",

--- a/mingw-w64-rust/0012-disable-miri.patch
+++ b/mingw-w64-rust/0012-disable-miri.patch
@@ -1,0 +1,15 @@
+--- rustc-1.66.0-src/src/bootstrap/install.rs.orig	2022-12-17 13:15:51.067932500 +0100
++++ rustc-1.66.0-src/src/bootstrap/install.rs	2022-12-17 13:16:15.631649500 +0100
+@@ -200,10 +200,8 @@
+         install_sh(builder, "clippy", self.compiler.stage, Some(self.target), &tarball);
+     };
+     Miri, alias = "miri", Self::should_build(_config), only_hosts: true, {
+-        let tarball = builder
+-            .ensure(dist::Miri { compiler: self.compiler, target: self.target })
+-            .expect("missing miri");
+-        install_sh(builder, "miri", self.compiler.stage, Some(self.target), &tarball);
++        let _tarball = builder
++            .ensure(dist::Miri { compiler: self.compiler, target: self.target });
+     };
+     Rustfmt, alias = "rustfmt", Self::should_build(_config), only_hosts: true, {
+         if let Some(tarball) = builder.ensure(dist::Rustfmt {

--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -11,8 +11,8 @@ fi
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-rust-docs")
-pkgver=1.65.0
-pkgrel=2
+pkgver=1.66.0
+pkgrel=1
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
@@ -43,16 +43,16 @@ source=("https://static.rust-lang.org/dist/${_realname}c-${pkgver}-src.tar.gz"{,
         "0009-build-gnullvm-targets-natively.patch"
         "0010-gnullvm-debuginfo-fix.patch"
         "0011-disable-uac-for-installer.patch")
-sha256sums=('5828bb67f677eabf8c384020582b0ce7af884e1c84389484f7f8d00dd82c0038'
+sha256sums=('3b3cd3ea5a82a266e75d0b35f0b54c16021576d9eb78d384052175a772935a48'
             'SKIP'
             '7cb1773c288ffb1c1e751edc49b1890c84bf9c362742bc5225d19d474edb73a0'
             '36c531c73a2c12b3e66aa22526a404c3f770f1ab7e0e76c55af6fcc1a17e46fe'
             'c4e5ffeef84296d39c3e3e8f807fc8b33ce786b1e4edb21eef26b053586aca27'
-            'ae9ed98e6bd74ee5ea3bbb2a55f4dbb326164fdc8d55a96e65b98dd33bd49813'
+            '0784c4cb3d205ff233e61c89ce2a298b7ad2f68234b13854612d83e085fed569'
             'a214cd8394ab7416fd170c7fa05daf701a5357d38e4e54149370e6efff208e50'
-            'b0a593a1a954dc51cd214e6ac5aabd2d88922202944eaceb7dd077d78d6dae3a'
-            '9c16adfddded1aac5ed812d82768dbe625614162639c05d63a0845e37e74fa0e'
-            '214cd060efd4908d253d78c95e4f6288fdeb56a5dd9303c3718752f32f35af51')
+            '394424aca9553802db667c3fd5cb60a5fb814ac66c5617426a5e78d1ba10d8bf'
+            '84d72369303f377127a5614505c2662b530415246833569030c2578368ee070f'
+            'e72ee077cd62bfc24c592a12ca27242d24ee14237d414c7e8fc4004bf8b031b8')
 validpgpkeys=('108F66205EAEB0AAA8DD5E1C85AB96E6FA1BE5FE'  # Rust Language (Tag and Release Signing Key) <rust-key@rust-lang.org>
               '474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard <tstellar@redhat.com>
               'B6C8F98282B944E3B0D5C2530FC3042E345AD05D') # Hans Wennborg <hans@chromium.org>

--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -29,8 +29,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-python"
              "${MINGW_PACKAGE_PREFIX}-autotools"
              $([[ "$_bootstrapping" == "no" ]] && echo "${MINGW_PACKAGE_PREFIX}-rust")
-             "${MINGW_PACKAGE_PREFIX}-zlib"
-             "git")
+             "${MINGW_PACKAGE_PREFIX}-zlib")
 options=('staticlibs' 'strip')
 #install=rust.install
 noextract=(${_realname}c-${pkgver}-src.tar.gz)

--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -12,7 +12,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-rust-docs")
 pkgver=1.66.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
@@ -185,7 +185,7 @@ build() {
     --disable-codegen-tests \
     --llvm-root=${MINGW_PREFIX} \
     --python=${MINGW_PREFIX}/bin/python \
-    ${_rust_conf}
+    "${_rust_conf[@]}"
 
   if [[ $MINGW_PACKAGE_PREFIX != *-clang-i686 ]]; then
     # Building out of tree is not officially supported so we have to workaround some things like vendored deps

--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -41,7 +41,8 @@ source=("https://static.rust-lang.org/dist/${_realname}c-${pkgver}-src.tar.gz"{,
         "0008-disable-self-contained.patch"
         "0009-build-gnullvm-targets-natively.patch"
         "0010-gnullvm-debuginfo-fix.patch"
-        "0011-disable-uac-for-installer.patch")
+        "0011-disable-uac-for-installer.patch"
+        "0012-disable-miri.patch")
 sha256sums=('3b3cd3ea5a82a266e75d0b35f0b54c16021576d9eb78d384052175a772935a48'
             'SKIP'
             '7cb1773c288ffb1c1e751edc49b1890c84bf9c362742bc5225d19d474edb73a0'
@@ -51,7 +52,8 @@ sha256sums=('3b3cd3ea5a82a266e75d0b35f0b54c16021576d9eb78d384052175a772935a48'
             'a214cd8394ab7416fd170c7fa05daf701a5357d38e4e54149370e6efff208e50'
             '394424aca9553802db667c3fd5cb60a5fb814ac66c5617426a5e78d1ba10d8bf'
             '84d72369303f377127a5614505c2662b530415246833569030c2578368ee070f'
-            'e72ee077cd62bfc24c592a12ca27242d24ee14237d414c7e8fc4004bf8b031b8')
+            'e72ee077cd62bfc24c592a12ca27242d24ee14237d414c7e8fc4004bf8b031b8'
+            'd63aaef586b08aa645ecf94165baf3c40aa7fdd3f266a5728fcf06c2a9d37f73')
 validpgpkeys=('108F66205EAEB0AAA8DD5E1C85AB96E6FA1BE5FE'  # Rust Language (Tag and Release Signing Key) <rust-key@rust-lang.org>
               '474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard <tstellar@redhat.com>
               'B6C8F98282B944E3B0D5C2530FC3042E345AD05D') # Hans Wennborg <hans@chromium.org>
@@ -92,7 +94,8 @@ prepare() {
     0004-unbundle-gcc.patch \
     0005-win32-config.patch \
     0008-disable-self-contained.patch \
-    0010-gnullvm-debuginfo-fix.patch
+    0010-gnullvm-debuginfo-fix.patch \
+    0012-disable-miri.patch
 
   if [[ $MINGW_PACKAGE_PREFIX == *-clang-i686 || $MINGW_PACKAGE_PREFIX == *-clang-x86_64 ]]; then
     apply_patch_with_msg \


### PR DESCRIPTION
The bash array _rust_conf was being used as a 'scalar' (for lack of a
better term), resulting in only the first item being interpolated,
losing the `--enable-vendor` option necessary for a -gnullvm target to
build due to necessary patches to the vendored sources.  Currently, only
clangarm64 uses a gnullvm target, so it was the only one affected.

Addresses https://github.com/msys2/MINGW-packages/pull/14592#issuecomment-1363332277