### PR TITLE
Add back CMake configuration files

### DIFF
--- a/mingw-w64-boost/PKGBUILD
+++ b/mingw-w64-boost/PKGBUILD
@@ -8,7 +8,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.81.0
 _boostver=${pkgver//./_}
-pkgrel=1
+pkgrel=2
 pkgdesc="Free peer-reviewed portable C++ source libraries (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -25,7 +25,8 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-python: For Boost.Python"
 makedepends=("${MINGW_PACKAGE_PREFIX}-python"
              "${MINGW_PACKAGE_PREFIX}-python-numpy"
              "${MINGW_PACKAGE_PREFIX}-cc"
-             "lndir")
+             "lndir"
+             "patch")
 options=('strip' 'buildflags' 'staticlibs')
 source=(https://boostorg.jfrog.io/artifactory/main/release/${pkgver}/source/boost_${_boostver}.tar.bz2
         boost-1.63.0-python-test-PyImport_AppendInittab.patch
@@ -112,7 +113,6 @@ setb2args() {
     --debug-configuration \
     --prefix=${pkgdir}${MINGW_PREFIX} \
     --layout=tagged-1.66 \
-    --no-cmake-config \
     -sHAVE_ICU=1 \
     -sICU_PATH=${MINGW_PREFIX} \
     -sICU_ICUUC_NAME=icuuc \

--- a/mingw-w64-boost/PKGBUILD
+++ b/mingw-w64-boost/PKGBUILD
@@ -25,8 +25,7 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-python: For Boost.Python"
 makedepends=("${MINGW_PACKAGE_PREFIX}-python"
              "${MINGW_PACKAGE_PREFIX}-python-numpy"
              "${MINGW_PACKAGE_PREFIX}-cc"
-             "lndir"
-             "patch")
+             "lndir")
 options=('strip' 'buildflags' 'staticlibs')
 source=(https://boostorg.jfrog.io/artifactory/main/release/${pkgver}/source/boost_${_boostver}.tar.bz2
         boost-1.63.0-python-test-PyImport_AppendInittab.patch


### PR DESCRIPTION
Boost provides CMake configuration files. These files are the ultimate truth about how Boost libraries are to be compiled. It's better to rely on them, then on CMake provided FindBoost.cmake module. The latter can become stale, or it can contain bugs, which will make users dependent on the ability of CMake authors to fix it. Boost provided configuration files are always up-to-date and tested with the version we are installing.