### PR TITLE
tcllib: Add clangarm64 and update source archive

### DIFF
--- a/mingw-w64-tcllib/PKGBUILD
+++ b/mingw-w64-tcllib/PKGBUILD
@@ -6,18 +6,18 @@ _realname=tcllib
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.21
-pkgrel=1
+pkgrel=2
 pkgdesc="Set of pure-Tcl extensions (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://core.tcl.tk/tcllib/"
 license=('bsd')
 depends=("${MINGW_PACKAGE_PREFIX}-tcl")
-source=(https://github.com/tcltk/tcllib/archive/tcllib-${pkgver/./-}.tar.gz)
-sha256sums=('66932dec154253f4bee7ec98daa7cb8aa5a2985dde4ed3a160541b0597014551')
+source=(https://core.tcl-lang.org/tcllib/uv/tcllib-${pkgver}.tar.gz)
+sha256sums=('46b2bb5ec8049363ae01645af11bda3bdb5db10629e807d81d1ad46cd1bead50')
 
 package(){
-  cd ${srcdir}/tcllib-tcllib-${pkgver/./-}
+  cd ${srcdir}/tcllib-${pkgver}
   tclsh installer.tcl \
     -pkg-path ${pkgdir}${MINGW_PREFIX}/lib/tcllib${pkgver} \
     -app-path ${pkgdir}${MINGW_PREFIX}/bin \


### PR DESCRIPTION
Github mirror's hash changed, so updated package to use the same mirror as upstream (Arch) which has hash matching https://core.tcl-lang.org/tcllib/uv/tcllib-1.21.SHA256