### PR TITLE
angleproject: don't package OpenCL headers

### DIFF
--- a/mingw-w64-angleproject/PKGBUILD
+++ b/mingw-w64-angleproject/PKGBUILD
@@ -6,7 +6,7 @@ _realname=angleproject
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.1.r20194.6c41793f
-pkgrel=1
+pkgrel=2
 pkgdesc='A conformant OpenGL ES implementation for Windows, Mac, Linux, iOS and Android (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -128,6 +128,7 @@ build() {
     angle_enable_abseil=false
     angle_enable_metal=false
     angle_enable_d3d11_compositor_native_window=false
+    angle_enable_cl=false
     chrome_pgo_phase=0
     use_custom_libcxx=false
     use_sysroot=false
@@ -153,6 +154,8 @@ package() {
 
   # Remove KHR include, fixes conflict with mingw-w64
   rm -rf ${pkgdir}${MINGW_PREFIX}/include/KHR
+  # Remove OpenCL headers to avoid file conflict with opencl-headers
+  rm -rf ${pkgdir}${MINGW_PREFIX}/include/CL
 
   install -Dm644 LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
 }


### PR DESCRIPTION
This fixes part of #14803 by not packaging the OpenCL headers.

It's not clear at the moment how to resolve the conflict with the GLES and EGL libraries and headers from the mesa package. So, I just made the current conflict explicit.
It might be possible to remove that conflict again if it can be resolved somehow.
