### PR TITLE
octave: force downgrade to SuiteSparse 5 for 32-bit

### DIFF
--- a/mingw-w64-octave/PKGBUILD
+++ b/mingw-w64-octave/PKGBUILD
@@ -22,7 +22,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libsndfile"
          "${MINGW_PACKAGE_PREFIX}-pcre"
          "${MINGW_PACKAGE_PREFIX}-qhull"
-         $([[ ${MSYSTEM} == *32 ]] && echo "${MINGW_PACKAGE_PREFIX}-suitesparse5" || echo "${MINGW_PACKAGE_PREFIX}-suitesparse")
+         $([[ ${CARCH} == i686 ]] && echo "${MINGW_PACKAGE_PREFIX}-suitesparse5" || echo "${MINGW_PACKAGE_PREFIX}-suitesparse")
          "${MINGW_PACKAGE_PREFIX}-sundials"
          "${MINGW_PACKAGE_PREFIX}-qrupdate"
          "${MINGW_PACKAGE_PREFIX}-qscintilla"

--- a/mingw-w64-octave/PKGBUILD
+++ b/mingw-w64-octave/PKGBUILD
@@ -2,7 +2,7 @@ _realname=octave
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=7.3.0
-pkgrel=5
+pkgrel=6
 pkgdesc="GNU Octave: Interactive programming environment for numerical computations (mingw-w64)"
 url="https://www.octave.org"
 license=('spdx:GPL-3.0-or-later')
@@ -22,7 +22,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libsndfile"
          "${MINGW_PACKAGE_PREFIX}-pcre"
          "${MINGW_PACKAGE_PREFIX}-qhull"
-         "${MINGW_PACKAGE_PREFIX}-suitesparse"
+         $([[ ${MSYSTEM} == *32 ]] && echo "${MINGW_PACKAGE_PREFIX}-suitesparse5" || echo "${MINGW_PACKAGE_PREFIX}-suitesparse")
          "${MINGW_PACKAGE_PREFIX}-sundials"
          "${MINGW_PACKAGE_PREFIX}-qrupdate"
          "${MINGW_PACKAGE_PREFIX}-qscintilla"


### PR DESCRIPTION
Revert back to forcing a downgrade to SuiteSparse 5. Octave uses parts of the API that are broken on 32-bit SuiteSparse 6.