### PR TITLE
 mesa: Update to 22.3.2

### DIFF
--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -3,9 +3,9 @@
 _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=22.3.1
+pkgver=22.3.2
 pkgrel=1
-pkgdesc="Open-source implementation of the OpenGL specification (mingw-w64)"
+pkgdesc="Open-source implementation of the OpenGL, Vulkan and OpenCL specifications (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 makedepends=("git"
@@ -33,7 +33,7 @@ options=('staticlibs' 'strip')
 source=(https://mesa.freedesktop.org/archive/${_realname}-${pkgver}.tar.xz{,.sig}
         llvmwrapgen.sh
         0005-win32-The-opengl-headers-should-install-to-mesa-GL-s.patch)
-sha256sums=('3c9cd611c0859d307aba0659833386abdca4c86162d3c275ba5be62d16cf31eb'
+sha256sums=('c15df758a8795f53e57f2a228eb4593c22b16dffd9b38f83901f76cd9533140b'
             'SKIP'
             '69f21522f20c10f5699dfe3e128aa88d4fedde816f6e8df1506d7470c44bf3da'
             '7f7874b89103c98dc0006bb64d209b5c0afa5a72b27e5e3d9f366a9609881714')

--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -104,14 +104,14 @@ build() {
   --prefix=${MINGW_PREFIX}
   --buildtype=release
   --backend=ninja
-  -Dshared-glapi=enabled
-  -Degl=enabled
-  -Dgles1=enabled
-  -Dgles2=enabled
+  -Dshared-glapi=disabled
+  -Degl=disabled
+  -Dgles1=disabled
+  -Dgles2=disabled
   -Dllvm=enabled
   -Dshared-llvm=enabled
   -Dosmesa=true
-  -Dbuild-tests=true
+  -Dbuild-tests=false
   -Dvulkan-drivers=swrast,amd"
 
 # Disable dozen when building with clang. Build fails.


### PR DESCRIPTION
- Disable GLES and EGL as MSYS2 provides angleproject (#14803), a far superior implementation;
- Disable shared glapi as it's not needed without GLES and EGL;
- Stop building unit tests since they aren't packaged.