### PR TITLE
mesa: Don't install DirectX Headers

### DIFF
--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -4,7 +4,7 @@ _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=22.3.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Open-source implementation of the OpenGL, Vulkan and OpenCL specifications (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -148,7 +148,7 @@ build() {
 
 package() {
   cd ${srcdir}/${_realname}-${pkgver}/build/windows-${_mach}
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/meson install
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/meson install --skip-subprojects
 
 # fix osmesa version in .pc file
   sed -e "s|8.0.0|${pkgver}|g" \


### PR DESCRIPTION
Doing so asks for more package conflict trouble