### PR TITLE
gspell: add --enable-installed-tests

### DIFF
--- a/mingw-w64-gspell/PKGBUILD
+++ b/mingw-w64-gspell/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gspell
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.12.0
-pkgrel=3
+pkgrel=4
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 pkgdesc="Spell-checking library for GTK applications (mingw-w64)"
@@ -40,7 +40,8 @@ build() {
     --build=${MINGW_CHOST} \
     --prefix=${MINGW_PREFIX} \
     --libexecdir=${MINGW_PREFIX}/lib \
-    --enable-introspection
+    --enable-introspection \
+    --enable-installed-tests
   make
 }
 


### PR DESCRIPTION
The gspell unit tests need to be installed in order to run successfully.

Otherwise they don't see the hunspell dictionaries (only the en_US one is required for the unit tests).