### PR TITLE
cargo-c: Enable aarch64 and add lib prefix to import library output name

### DIFF
--- a/mingw-w64-cargo-c/001-add-lib-prefix-on-windows-gnu.patch
+++ b/mingw-w64-cargo-c/001-add-lib-prefix-on-windows-gnu.patch
@@ -1,0 +1,22 @@
+--- a/src/build.rs
++++ b/src/build.rs
+@@ -232,7 +232,7 @@
+             dlltool_command.arg("-D").arg(format!("{}.dll", name));
+             dlltool_command
+                 .arg("-l")
+-                .arg(targetdir.join(format!("{}.dll.a", name)));
++                .arg(targetdir.join(format!("lib{}.dll.a", name)));
+             dlltool_command
+                 .arg("-d")
+                 .arg(targetdir.join(format!("{}.def", name)));
+--- a/src/build_targets.rs
++++ b/src/build_targets.rs
+@@ -103,7 +103,7 @@
+                 let impl_lib = if env == "msvc" {
+                     targetdir.join(format!("{}.dll.lib", lib_name))
+                 } else {
+-                    targetdir.join(format!("{}.dll.a", lib_name))
++                    targetdir.join(format!("lib{}.dll.a", lib_name))
+                 };
+                 let def = targetdir.join(format!("{}.def", lib_name));
+                 (shared_lib, static_lib, Some(impl_lib), Some(def))

--- a/mingw-w64-cargo-c/002-accept-windows-gnu-aarch64.patch
+++ b/mingw-w64-cargo-c/002-accept-windows-gnu-aarch64.patch
@@ -1,0 +1,10 @@
+--- a/src/build.rs
++++ b/src/build.rs
+@@ -223,6 +223,7 @@
+             let binutils_arch = match arch.as_str() {
+                 "x86_64" => "i386:x86-64",
+                 "x86" => "i386",
++                "aarch64" => "arm64",
+                 _ => unimplemented!("Windows support for {} is not implemented yet.", arch),
+             };
+ 

--- a/mingw-w64-cargo-c/PKGBUILD
+++ b/mingw-w64-cargo-c/PKGBUILD
@@ -4,7 +4,7 @@ _realname=cargo-c
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.9.15
-pkgrel=1
+pkgrel=2
 pkgdesc='A cargo subcommand to build and install C-ABI compatibile dynamic and static libraries (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang32' 'clang64' 'clangarm64')
@@ -16,13 +16,20 @@ depends=("${MINGW_PACKAGE_PREFIX}-curl"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/lu-zero/cargo-c/archive/v${pkgver}.tar.gz"
-        "${_realname}-${pkgver}.Cargo.lock"::"https://github.com/lu-zero/cargo-c/releases/download/v${pkgver}/Cargo.lock")
+        "${_realname}-${pkgver}.Cargo.lock"::"https://github.com/lu-zero/cargo-c/releases/download/v${pkgver}/Cargo.lock"
+        001-add-lib-prefix-on-windows-gnu.patch
+        002-accept-windows-gnu-aarch64.patch)
 sha256sums=('ba29e662c2419ce12e4d5a9d0b05c057378088f474bc9316238c0a621b488299'
-            '90453e28af7052126f3f452061ba667e2cf52dcd0b2c76bb900fb4b60ddd2d91')
+            '90453e28af7052126f3f452061ba667e2cf52dcd0b2c76bb900fb4b60ddd2d91'
+            '80b0e0d5713d5eb74b62433386642ee87daeab8952dbbbb3ad4b54a4f53a4c6d'
+            '7c056b2110fbc8a3ce05739797185a60cbb7cf575cb26387ad13b0fe35a61039')
 
 prepare() {
     cp "${srcdir}/${_realname}-${pkgver}.Cargo.lock" "${_realname}-${pkgver}/Cargo.lock"
     cd "${srcdir}/${_realname}-${pkgver}"
+
+    patch -p1 -i "${srcdir}"/001-add-lib-prefix-on-windows-gnu.patch
+    patch -p1 -i "${srcdir}"/002-accept-windows-gnu-aarch64.patch
 
     cargo fetch \
         --locked

--- a/mingw-w64-libimagequant/PKGBUILD
+++ b/mingw-w64-libimagequant/PKGBUILD
@@ -4,10 +4,10 @@ _realname=libimagequant
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=4.0.4
-pkgrel=2
+pkgrel=3
 pkgdesc="Palette quantization library (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url='https://github.com/ImageOptim/libimagequant'
 license=("GPL3" "MIT")
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
@@ -39,8 +39,7 @@ package() {
     --prefix=${MINGW_PREFIX} \
     --manifest-path build-${MSYSTEM}/imagequant-sys/Cargo.toml
 
-  # Workaround for import lib
-  mv ${pkgdir}${MINGW_PREFIX}/lib/{,lib}imagequant.dll.a
+  # Remove def file
   rm -f ${pkgdir}${MINGW_PREFIX}/lib/*.def
 
   mkdir -p "${pkgdir}"${MINGW_PREFIX}/share/doc/libimagequant

--- a/mingw-w64-rav1e/PKGBUILD
+++ b/mingw-w64-rav1e/PKGBUILD
@@ -4,16 +4,16 @@ _realname=rav1e
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.6.1
-pkgrel=1
+pkgrel=2
 pkgdesc='An AV1 encoder focused on speed and safety (mingw-w64)'
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url=https://github.com/xiph/rav1e/
 license=('spdx:BSD-2-Clause')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
-makedepends=("${MINGW_PACKAGE_PREFIX}-nasm"
-             "${MINGW_PACKAGE_PREFIX}-rust"
-             "${MINGW_PACKAGE_PREFIX}-cargo-c")
+makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
+             "${MINGW_PACKAGE_PREFIX}-cargo-c"
+             ([[ "${CARCH}" == "aarch64"  ]] || echo "${MINGW_PACKAGE_PREFIX}-nasm"))
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/xiph/rav1e/archive/v${pkgver}.tar.gz"
         https://github.com/xiph/rav1e/releases/download/v${pkgver}/Cargo.lock)
 sha256sums=('dd12132ad9dac229ce00a9caad132c4ad23d7db2b3ad4b5a59e89658fee04d9a'
@@ -70,8 +70,7 @@ package() {
       --prefix="${MINGW_PREFIX}" \
       --destdir="${pkgdir}"
 
-  # Workaround for import lib
-  mv ${pkgdir}${MINGW_PREFIX}/lib/{,lib}rav1e.dll.a
+  # Remove def file
   rm -f ${pkgdir}${MINGW_PREFIX}/lib/*.def
 
   install -Dm644 LICENSE PATENTS -t "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/"


### PR DESCRIPTION
packages get bigger on GCC based env, It's not related to the patches because It's the same when rebuilding without any patch.