### PR TITLE
mkvtoolnix: update to 73.0.0

### DIFF
--- a/mingw-w64-mkvtoolnix/PKGBUILD
+++ b/mingw-w64-mkvtoolnix/PKGBUILD
@@ -4,11 +4,11 @@ _realname=mkvtoolnix
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-cli"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-gui")
-pkgver=72.0.0
+pkgver=73.0.0
 pkgrel=1
 pkgdesc="Set of tools to create, edit and inspect Matroska files (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw64' 'ucrt64' 'clang64')
 url='https://mkvtoolnix.download/'
 license=('GPLv2')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
@@ -32,7 +32,7 @@ makedepends=("po4a"
              "${MINGW_PACKAGE_PREFIX}-ruby"
              "${MINGW_PACKAGE_PREFIX}-zlib")
 source=(https://mkvtoolnix.download/sources/mkvtoolnix-${pkgver}.tar.xz{,.sig})
-sha256sums=('3bd1005baf397f1d70619c2f2c52af9de8ce75995830e790e429c0943fd08000'
+sha256sums=('f31a129723571b46a974bc5d57d73733c1245ee429afd6ddaf274038e94e2280'
             'SKIP')
 validpgpkeys=('D9199745B0545F2E8197062B0F92290A445B9007') # Moritz Bunkus <moritz@bunkus.org>
 noextract=(mkvtoolnix-${pkgver}.tar.xz)


### PR DESCRIPTION
I have disabled 32bit envs because I am going to drop 32bit from most of Qt6 packages.