### PR TITLE
gmp: Do not declare functions as `dllimport`

### DIFF
--- a/mingw-w64-gmp/PKGBUILD
+++ b/mingw-w64-gmp/PKGBUILD
@@ -4,16 +4,18 @@ _realname=gmp
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=6.2.1
-pkgrel=4
+pkgrel=5
 pkgdesc="A free library for arbitrary precision arithmetic (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://gmplib.org/"
 license=('LGPL3' 'GPL')
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools" "${MINGW_PACKAGE_PREFIX}-cc")
-source=(https://gmplib.org/download/gmp-${pkgver}/${_realname}-${pkgver}.tar.xz{,.sig})
+source=(https://gmplib.org/download/gmp-${pkgver}/${_realname}-${pkgver}.tar.xz{,.sig}
+        do-not-use-dllimport.diff)
 sha256sums=('fd4829912cddd12f84181c3451cc752be224643e87fac497b69edddadc49b4f2'
-            'SKIP')
+            'SKIP'
+            '385ab704f82c47f3aecc9141f43c96e7b8de2bf0e654dc457ce0f1a039db2c68')
 validpgpkeys=('343C2FF0FBEE5EC2EDBEF399F3599FF828C67298') # Niels Möller <nisse@lysator.liu.se>"
 
 prepare() {
@@ -21,6 +23,7 @@ prepare() {
   [[ -d ../stash ]] && rm -rf ../stash
   mkdir ../stash
   cp config.{guess,sub} ../stash
+  patch -p2 -i ${srcdir}/do-not-use-dllimport.diff
   autoreconf -fiv
   cp -f ../stash/config.{guess,sub} .
 }

--- a/mingw-w64-gmp/do-not-use-dllimport.diff
+++ b/mingw-w64-gmp/do-not-use-dllimport.diff
@@ -1,0 +1,13 @@
+diff --git a/gmp-6.2.1.orig/gmp-h.in b/gmp-6.2.1/gmp-h.in
+index 3d449d427..942fab4b1 100644
+--- a/gmp-6.2.1.orig/gmp-h.in
++++ b/gmp-6.2.1/gmp-h.in
+@@ -101,7 +101,7 @@ see https://www.gnu.org/licenses/.  */
+ 
+ #if defined (__GNUC__)
+ #define __GMP_DECLSPEC_EXPORT  __declspec(__dllexport__)
+-#define __GMP_DECLSPEC_IMPORT  __declspec(__dllimport__)
++#define __GMP_DECLSPEC_IMPORT
+ #endif
+ #if defined (_MSC_VER) || defined (__BORLANDC__)
+ #define __GMP_DECLSPEC_EXPORT  __declspec(dllexport)


### PR DESCRIPTION
GNU toolchains do not require `dllimport` when calling functions from DLLs. Having `dllimport` by default causes static linking to fail, observed when building GDB.

Signed-off-by: LIU Hao <lh_mouse@126.com>
(cherry picked from commit 91d231a51056c2c429e55ae1546794b93089bb64)
Signed-off-by: LIU Hao <lh_mouse@126.com>