### PR TITLE
qt5-quickcontrols2: update to 5.15.8

### DIFF
--- a/mingw-w64-qt5-quickcontrols2/PKGBUILD
+++ b/mingw-w64-qt5-quickcontrols2/PKGBUILD
@@ -4,22 +4,20 @@ _realname=qt5-quickcontrols2
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=5.15.7
-pkgver=${_qtver}+kde+r5
-pkgrel=2
-_commit=9ff77702cc3649cbaf94046742d682d77cdea698
+_qtver=5.15.8
+pkgver=${_qtver}+kde+r7
+pkgrel=1
+_commit=56ce8233382a091a8476c831edd416b5f704ae4f
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 pkgdesc="Next generation user interface controls based on Qt Quick (mingw-w64)"
 url='https://www.qt.io/'
 license=('GPL3' 'LGPL' 'FDL' 'custom')
-makedepends=("${MINGW_PACKAGE_PREFIX}-qt5-imageformats"
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-qt5-declarative"
-             "${MINGW_PACKAGE_PREFIX}-qt5-graphicaleffects"
-             "${MINGW_PACKAGE_PREFIX}-cc"
              "git"
              "rsync")
-options=('!strip' 'staticlibs' 'ccache')
+options=('!strip')
 _pkgfn="${_realname/5-/}"
 source=(git+https://invent.kde.org/qt/qt/$_pkgfn#commit=$_commit)
 sha256sums=('SKIP')
@@ -30,16 +28,13 @@ pkgver() {
 }
 
 build() {
-  cd ${srcdir}
   [[ -d build-${MSYSTEM} ]] && rm -rf build-${MSYSTEM}
-  mv ${_pkgfn} build-${MSYSTEM} && cd build-${MSYSTEM}
+  mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
 
-  # https://github.com/msys2/MSYS2-packages/issues/2282
-  export MSYS2_ARG_CONV_EXCL='*'
+  qmake ../${_pkgfn}
 
-  qmake
-
-  make
+  MSYS2_ARG_CONV_EXCL='*' \
+    make
 }
 
 check() {
@@ -48,9 +43,8 @@ check() {
 }
 
 package_qt5-quickcontrols2() {
-  depends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative"
-           "${MINGW_PACKAGE_PREFIX}-qt5-graphicaleffects")
-  optdepends=("${MINGW_PACKAGE_PREFIX}-qt5-imageformats")
+  depends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-qt5-graphicaleffects")
   groups=("${MINGW_PACKAGE_PREFIX}-qt5")
 
   cd build-${MSYSTEM}
@@ -66,7 +60,7 @@ package_qt5-quickcontrols2() {
   make INSTALL_ROOT="${PKGDIR}" install
 
   install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_realname}
-  install -Dm644 $srcdir/build-${MSYSTEM}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_realname}
+  install -Dm644 $srcdir/${_pkgfn}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_realname}
 
   # Seperate debug-info files
   mv -f "${pkgdir}${MINGW_PREFIX}/lib"/*.debug "${pkgdir}${MINGW_PREFIX}/bin"/ || true
@@ -92,7 +86,6 @@ package_qt5-quickcontrols2() {
 
 package_qt5-quickcontrols2-debug() {
   depends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative-debug"
-           "${MINGW_PACKAGE_PREFIX}-qt5-graphicaleffects-debug"
            "${MINGW_PACKAGE_PREFIX}-${_realname}")
   groups=("${MINGW_PACKAGE_PREFIX}-qt5-debug")
 


### PR DESCRIPTION
The only qt5 package that needs `MSYS2_ARG_CONV_EXCL='*'` to builds.