### PR TITLE
Shotcut: fix translation, enable clang64 & clangarm64

### DIFF
--- a/mingw-w64-mlt/PKGBUILD
+++ b/mingw-w64-mlt/PKGBUILD
@@ -5,10 +5,10 @@ _realname=mlt
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=7.12.0
-pkgrel=1
+pkgrel=2
 pkgdesc="An open source multimedia framework (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://www.mltframework.org"
 license=('spdx:LGPL-2.1-or-later')
 _plugins_deps=("${MINGW_PACKAGE_PREFIX}-ffmpeg"
@@ -42,11 +42,13 @@ optdepends=("${_plugins_deps[@]}")
 source=(https://github.com/mltframework/mlt/releases/download/v${pkgver}/mlt-${pkgver}.tar.gz
         0001-cmake-fix-libs-install.patch
         0002-cmake-install-manpage.patch
-        0003-cmake-fix-x86-detection.patch)
+        0003-cmake-fix-x86-detection.patch
+        https://github.com/mltframework/mlt/pull/856.patch)
 sha256sums=('48b385e83cbd5bf68bfc88631273868fbee36a41b3b7e2acd97f12b095b0083c'
             '3b93a3c15e56a3d80fdf68934ab2f51e73661b785e97334e7271278272937a4a'
             '88ddba2695d8c0cfb7e0b0be01a3caeb47c2ba2ea0677f489cc7dd2a7844885c'
-            '500e518bdb3892dbdceab9e03e43a148b83c0000d3088f131d22b013b24fda48')
+            '500e518bdb3892dbdceab9e03e43a148b83c0000d3088f131d22b013b24fda48'
+            '665445603db14d73c6501e41117d17ff3a4dca6583bbd5e5f9182fa2de2ff528')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -61,7 +63,8 @@ prepare() {
   apply_patch_with_msg \
     0001-cmake-fix-libs-install.patch \
     0002-cmake-install-manpage.patch \
-    0003-cmake-fix-x86-detection.patch
+    0003-cmake-fix-x86-detection.patch \
+    856.patch
 }
 
 build() {

--- a/mingw-w64-shotcut/0001-fix-translation-on-msys2.patch
+++ b/mingw-w64-shotcut/0001-fix-translation-on-msys2.patch
@@ -1,0 +1,37 @@
+diff --git a/src/main.cpp b/src/main.cpp
+index 0c4b8cf..e835ad3 100644
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -270,8 +270,15 @@ public:
+         dir.cd("shotcut");
+         dir.cd("translations");
+ #elif defined(Q_OS_WIN)
+-        dir.cd("share");
+-        dir.cd("translations");
++        if (dir.cd("share")) {
++            dir.cd("translations");
++        } else {
++            // MSYS2 uses a filesystem layout similar to *nix
++            dir.cdUp();
++            dir.cd("share");
++            dir.cd("shotcut");
++            dir.cd("translations");
++        }
+ #else
+         dir.cdUp();
+         dir.cd("share");
+diff --git a/translations/CMakeLists.txt b/translations/CMakeLists.txt
+index 952ce95..e56fda2 100644
+--- a/translations/CMakeLists.txt
++++ b/translations/CMakeLists.txt
+@@ -58,8 +58,8 @@ add_custom_target(translations COMMAND
+ qt5_add_translation(QM_FILES ${TS_FILES})
+ add_custom_target(qm ALL DEPENDS ${QM_FILES})
+ 
+-if(UNIX AND NOT APPLE)
++# if(UNIX AND NOT APPLE)
+   include(GNUInstallDirs)
+   install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/ DESTINATION ${CMAKE_INSTALL_DATADIR}/shotcut/translations
+     FILES_MATCHING PATTERN "*.qm" PATTERN CMakeFiles EXCLUDE)
+-endif()
++# endif()

--- a/mingw-w64-shotcut/PKGBUILD
+++ b/mingw-w64-shotcut/PKGBUILD
@@ -4,10 +4,10 @@ _realname=shotcut
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=22.10.22
-pkgrel=2
+pkgrel=3
 pkgdesc='Cross-platform Qt based Video Editor (mingw-w64)'
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://www.shotcut.org/'
 license=('spdx:GPL-3.0-or-later')
 depends=("${MINGW_PACKAGE_PREFIX}-ffmpeg"
@@ -24,12 +24,15 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-qt5-tools")
-source=("${_realname}-${pkgver}.tar.gz::https://github.com/mltframework/shotcut/archive/v${pkgver}.tar.gz")
-sha256sums=('c294a3fd808918701b7d2a04c7515905038c4e82edded298737aa186638486fc')
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/mltframework/shotcut/archive/v${pkgver}.tar.gz"
+        0001-fix-translation-on-msys2.patch)
+sha256sums=('c294a3fd808918701b7d2a04c7515905038c4e82edded298737aa186638486fc'
+            '28becf4b8a4e0fac1221b3b372881a76a95f27af0a28e3d7599efefd0158aae3')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
+  patch -Np1 -i "${srcdir}/0001-fix-translation-on-msys2.patch"
 }
 
 build() {


### PR DESCRIPTION
On Windows, shotcut loads translation files from the executable directory ($PREFIX/bin), also the translation files are not installed, and meant to be manually copied after build.

While MSYS2 uses a filesystem layout similar to *nix, with data files in $PREFIX/share.

So patch the initialization code to match.
