### PR TITLE
libheif: update to 1.14.2

### DIFF
--- a/mingw-w64-libheif/PKGBUILD
+++ b/mingw-w64-libheif/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libheif
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.14.1
+pkgver=1.14.2
 pkgrel=1
 pkgdesc="HEIF image decoder/encoder library and tools (mingw-w64)"
 arch=('any')
@@ -13,7 +13,6 @@ license=('spdx:LGPL-3.0' 'MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-gdk-pixbuf2"
-             "${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-cc")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-aom"
@@ -26,7 +25,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
             echo "${MINGW_PACKAGE_PREFIX}-svt-av1" )
          "${MINGW_PACKAGE_PREFIX}-x265")
 source=("https://github.com/strukturag/libheif/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('0634646587454f95e9638ca472a37321aa519fca2ec7405d0e02a74d7ee581db')
+sha256sums=('d016905e247d6952cd7ee4f9b90957350b6a6caa466bc76fdfe6eb302b6d088c')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -54,27 +53,12 @@ build() {
       ../${_realname}-${pkgver}
 
   ${MINGW_PREFIX}/bin/cmake --build .
-
-  # Build pkgconfig file using autoconf because
-  # CMake generates it without ${prefix} variable
-
-  [[ -d "${srcdir}"/build-${MSYSTEM}-pkgconfig ]] && rm -rf "${srcdir}"/build-${MSYSTEM}-pkgconfig
-  mkdir -p "${srcdir}"/build-${MSYSTEM}-pkgconfig && cd "${srcdir}"/build-${MSYSTEM}-pkgconfig
-
-  ../${_realname}-${pkgver}/configure \
-    --prefix=${MINGW_PREFIX} \
-    --build=${MINGW_CHOST} \
-    --host=${MINGW_CHOST} \
-    --enable-svt=$( [[ ${CARCH} != x86_64 ]] &&
-                    echo no|| echo yes )
 }
 
 package() {
   cd "${srcdir}"/build-${MSYSTEM}
 
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --build . --target install
-
-  cp -v "${srcdir}"/build-${MSYSTEM}-pkgconfig/libheif.pc "${pkgdir}"${MINGW_PREFIX}/lib/pkgconfig
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/examples/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING-examples"


### PR DESCRIPTION
Removed the pc file workaround, it's been dealt with upstream already.