### PR TITLE
angle: Enable clangarm64

### DIFF
--- a/mingw-w64-angleproject/001-add-mingw-toolchain.patch
+++ b/mingw-w64-angleproject/001-add-mingw-toolchain.patch
@@ -800,12 +800,14 @@ index a5075393b..bc8f4e2c6 100644
    if (current_cpu == "x86") {
      asmflags = [
        # When /safeseh is specified, the linker will only produce an image if it
-@@ -214,6 +215,15 @@ config("compiler") {
+@@ -214,6 +215,17 @@ config("compiler") {
      # the source file is a no-op.
      "/ignore:4221",
    ]
 +  } else {
-+    cflags = [ "-msse3" ]
++    if (current_cpu == "x86" || current_cpu == "x64") {
++      cflags = [ "-msse3" ]
++    }
 +    if (current_cpu == "x86") {
 +      ldflags = [ "-m32" ]
 +      ldflags += [ "-Wl,--enable-stdcall-fixup" ]
@@ -1244,7 +1246,7 @@ index 612938527..c6a9f0f33 100644
    }
  }
  
-@@ -87,3 +92,26 @@ if (target_os == "winuwp") {
+@@ -87,3 +92,29 @@ if (target_os == "winuwp") {
      }
    }
  }
@@ -1264,6 +1266,9 @@ index 612938527..c6a9f0f33 100644
 +      current_os = "win"
 +    }
 +  }
++}
++
++mingw_toolchain("arm64") {
 +}
 +
 +mingw_toolchain("x64") {

--- a/mingw-w64-angleproject/003-angle-src-fixes.patch
+++ b/mingw-w64-angleproject/003-angle-src-fixes.patch
@@ -1,27 +1,25 @@
 diff --git a/src/common/mathutil.h b/src/common/mathutil.h
-index 560929239..7efbd8ede 100644
+index 5609292..2338d2f 100644
 --- a/src/common/mathutil.h
 +++ b/src/common/mathutil.h
-@@ -1027,8 +1027,8 @@ inline uint32_t BitfieldReverse(uint32_t value)
+@@ -1027,7 +1027,7 @@ inline uint32_t BitfieldReverse(uint32_t value)
  }
  
  // Count the 1 bits.
 -#if defined(_MSC_VER) && !defined(__clang__)
--#    if defined(_M_IX86) || defined(_M_X64)
-+#if defined(_WIN32) && !defined(__clang__)
-+#    if defined(_M_IX86) || defined(_M_X64) || defined(__i386__) || defined(__x86_64__)
++#if defined(ANGLE_PLATFORM_WINDOWS) && !defined(__clang__)
+ #    if defined(_M_IX86) || defined(_M_X64)
  namespace priv
  {
- // Check POPCNT instruction support and cache the result.
-@@ -1071,7 +1071,7 @@ inline int BitCount(uint64_t bits)
- {
-     if (priv::kHasPopcnt)
-     {
--#        if defined(_M_X64)
-+#        if defined(_M_X64) || defined(__x86_64__)
-         return static_cast<int>(__popcnt64(bits));
- #        else   // x86
-         return static_cast<int>(__popcnt(static_cast<uint32_t>(bits >> 32)) +
+@@ -1104,7 +1104,7 @@ inline int BitCount(uint64_t bits)
+     return static_cast<int>(vget_lane_u64(vpaddl_u32(vpaddl_u16(vpaddl_u8(vsum))), 0));
+ }
+ #    endif  // defined(_M_IX86) || defined(_M_X64)
+-#endif      // defined(_MSC_VER) && !defined(__clang__)
++#endif      // defined(ANGLE_PLATFORM_WINDOWS) && !defined(__clang__)
+ 
+ #if defined(ANGLE_PLATFORM_POSIX) || defined(__clang__)
+ inline int BitCount(uint32_t bits)
 diff --git a/src/common/serializer/JsonSerializer.cpp b/src/common/serializer/JsonSerializer.cpp
 index 0028331d9..e675c406b 100644
 --- a/src/common/serializer/JsonSerializer.cpp

--- a/mingw-w64-angleproject/PKGBUILD
+++ b/mingw-w64-angleproject/PKGBUILD
@@ -6,10 +6,10 @@ _realname=angleproject
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.1.r20194.6c41793f
-pkgrel=3
+pkgrel=4
 pkgdesc='A conformant OpenGL ES implementation for Windows, Mac, Linux, iOS and Android (mingw-w64)'
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url='https://chromium.googlesource.com/angle/angle'
 license=('spdx:BSD-3-Clause')
 depends=("${MINGW_PACKAGE_PREFIX}-jsoncpp"
@@ -41,9 +41,9 @@ sha256sums=('SKIP'
             'SKIP'
             'SKIP'
             'SKIP'
-            '06dccfcdfe271177574572aa0601c61e1724f9b0ed939f399048323bf9e02be3'
+            '71f7cf9110a2a3b7fb5c4117bc4aca0629839da024c8320a1ffd4b76f893ce32'
             'd73b808fe69914ee9d9934fad79389706af2c1ac280c1c0296d1046c482febad'
-            '0bd71b129c4c067bd73116aa21c0fb59d7a930ded6ab8b28d59aeb538b44bfd4'
+            'a096c2d8bb458c372998c209fef8ebd51b65c6410ad70aed627f230f3dec7b03'
             'bf878de3203a62e2a7f81bd4cd79237adc74804b4b692d9277da005ed56d4f2a'
             '86013781c2700219d4f64d7ac34ad16c40fcca9a641371385f67f642e23c643b'
             'f0fb05348bf2de599eff35e2d35e3336b9720b6bd2799af9d186c05ff45d34f0'
@@ -112,7 +112,9 @@ build() {
   fi
 
   local _arch=x64
-  if [[ ${CARCH} == i686 ]]; then
+  if [[ ${CARCH} == aarch64 ]]; then
+    _arch=arm64
+  elif [[ ${CARCH} == i686 ]]; then
     _arch=x86
   fi
 

--- a/mingw-w64-gn/004-add-arm64-arch.patch
+++ b/mingw-w64-gn/004-add-arm64-arch.patch
@@ -1,0 +1,13 @@
+diff --git a/src/util/sys_info.cc b/src/util/sys_info.cc
+index c8dc590a..2cc624f0 100644
+--- a/src/util/sys_info.cc
++++ b/src/util/sys_info.cc
+@@ -44,6 +44,8 @@ std::string OperatingSystemArchitecture() {
+   SYSTEM_INFO system_info = {};
+   ::GetNativeSystemInfo(&system_info);
+   switch (system_info.wProcessorArchitecture) {
++    case PROCESSOR_ARCHITECTURE_ARM64:
++      return "arm64";
+     case PROCESSOR_ARCHITECTURE_INTEL:
+       return "x86";
+     case PROCESSOR_ARCHITECTURE_AMD64:

--- a/mingw-w64-gn/PKGBUILD
+++ b/mingw-w64-gn/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gn
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=0.2073.70d6c608
-pkgrel=2
+pkgrel=3
 pkgdesc='Meta-build system that generates build files for Ninja (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -19,11 +19,13 @@ _commit=70d6c60823c0233a0f35eccc25b2b640d2980bdc
 source=(git+https://gn.googlesource.com/gn#commit=$_commit
         001-build-fixes.patch
         002-add-missing-header.patch
-        003-remove-msvc-flags.patch)
+        003-remove-msvc-flags.patch
+        004-add-arm64-arch.patch)
 sha256sums=('SKIP'
             'ad74a5b70eae85a380e040f41c529b3684625094dbf7367d997a15294a6355dd'
             'd41ea264f389a34b3030ab5fb39107475a0e913123802dee241a20e1e5ecb1a5'
-            '5aec933502008cbe9baabcf57e7899e8153e29c1dea646a52ac71b8eb9306801')
+            '5aec933502008cbe9baabcf57e7899e8153e29c1dea646a52ac71b8eb9306801'
+            'f2b66b481336de86b237b5d6062784323e6f359313a8063a9d670d9356e742d6')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -44,7 +46,8 @@ prepare() {
   apply_patch_with_msg \
   001-build-fixes.patch \
   002-add-missing-header.patch \
-  003-remove-msvc-flags.patch
+  003-remove-msvc-flags.patch \
+  004-add-arm64-arch.patch
 }
 
 build() {

--- a/mingw-w64-libepoxy/PKGBUILD
+++ b/mingw-w64-libepoxy/PKGBUILD
@@ -4,15 +4,14 @@ _realname=libepoxy
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.5.10
-pkgrel=2
+pkgrel=3
 pkgdesc="A library for handling OpenGL function pointer management for you (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://github.com/anholt/libepoxy"
 license=("spdx:MIT")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
-         $([[ "${MSYSTEM}" == "CLANGARM64" ]] || echo "${MINGW_PACKAGE_PREFIX}-angleproject")
-)
+         "${MINGW_PACKAGE_PREFIX}-angleproject")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-python"
@@ -32,17 +31,12 @@ build() {
   [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
-  local -a extra_config
-  if [ "${MSYSTEM}" != "CLANGARM64" ]; then
-    extra_config+=("-Degl=yes")
-  fi
-
   MSYS2_ARG_CONV_EXCL="--prefix=" \
   ${MINGW_PREFIX}/bin/meson.exe \
     --prefix="${MINGW_PREFIX}" \
     --buildtype plain \
     -Ddefault_library=both \
-    ${extra_config[@]} \
+    -Degl=yes \
     ../${_realname}-${pkgver}
 
   ${MINGW_PREFIX}/bin/meson.exe compile


### PR DESCRIPTION
* Remove patch for adding D3D11_CLIP_OR_CULL_DISTANCE_COUNT symbol.
* Define ANGLE_PLATFORM_WINDOWS instead of _WIN32.
* Add arm64 target for mingw toolchain gn file.
* Use -msse3 flag for x86 and x86_64 only.