### PR TITLE
readline: define NEED_EXTERN_PC for static linking

### DIFF
--- a/mingw-w64-readline/PKGBUILD
+++ b/mingw-w64-readline/PKGBUILD
@@ -6,7 +6,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _basever=8.2
 _patchlevel=001
 pkgver=${_basever}.${_patchlevel}
-pkgrel=5
+pkgrel=6
 pkgdesc="MinGW port of readline for editing typed command lines (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -71,6 +71,7 @@ prepare() {
 build() {
   [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}
   mkdir -p ${srcdir}/build-${MSYSTEM} && cd ${srcdir}/build-${MSYSTEM}
+  export CFLAGS="$CFLAGS -DNEED_EXTERN_PC=1" # Use extern PC variable from libtermcap
   ../${_realname}-${_basever}/configure \
     --prefix=${MINGW_PREFIX} \
     --host=${MINGW_CHOST} \


### PR DESCRIPTION
tells readline to use the PC variable from libtermcap instead of defining its own. This fixes the multiple definition error when attempting to statically link readline

Fixes https://github.com/msys2/MINGW-packages/issues/8105

I have not tested shared linking, but have tested with compiling mujs' master branch