### PR TITLE
rust: update to 1.66.1

### DIFF
--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -11,8 +11,8 @@ fi
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-rust-docs")
-pkgver=1.66.0
-pkgrel=2
+pkgver=1.66.1
+pkgrel=1
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
@@ -43,7 +43,7 @@ source=("https://static.rust-lang.org/dist/${_realname}c-${pkgver}-src.tar.gz"{,
         "0010-gnullvm-debuginfo-fix.patch"
         "0011-disable-uac-for-installer.patch"
         "0012-disable-miri.patch")
-sha256sums=('3b3cd3ea5a82a266e75d0b35f0b54c16021576d9eb78d384052175a772935a48'
+sha256sums=('5b3c933a94c72187705d4ee293198babfdd09442f5937fbd685db3a81f4959ba'
             'SKIP'
             '7cb1773c288ffb1c1e751edc49b1890c84bf9c362742bc5225d19d474edb73a0'
             '36c531c73a2c12b3e66aa22526a404c3f770f1ab7e0e76c55af6fcc1a17e46fe'


### PR DESCRIPTION
see https://blog.rust-lang.org/2023/01/10/cve-2022-46176.html