### PR TITLE
Add back boost CMake configuration files and fix #15021

### DIFF
--- a/mingw-w64-boost/PKGBUILD
+++ b/mingw-w64-boost/PKGBUILD
@@ -8,7 +8,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.81.0
 _boostver=${pkgver//./_}
-pkgrel=3
+pkgrel=4
 pkgdesc="Free peer-reviewed portable C++ source libraries (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -35,7 +35,8 @@ source=(https://boostorg.jfrog.io/artifactory/main/release/${pkgver}/source/boos
         boost-1.57.0-python-libpython_dep.patch
         boost-1.70.0-fix-python-install.patch
         using-mingw-w64-python.patch
-        msys2-mingw-folders-bootstrap.patch)
+        msys2-mingw-folders-bootstrap.patch
+        boost-1.81.0-honor-ICU_ICUxx_NAME-variables-in-remap-library.patch)
 sha256sums=('71feeed900fbccca04a3b4f2f84a7c217186f28a940ed8b7ed4725986baf99fa'
             'b22196b6415f5e1c0fe56b49a12ea7c20073b15a5f31907f363c7be38d70d628'
             'e322e7de83d92b80ebfba023127cbe05a18672234b09df9319767472401e01cc'
@@ -44,7 +45,8 @@ sha256sums=('71feeed900fbccca04a3b4f2f84a7c217186f28a940ed8b7ed4725986baf99fa'
             '01758929643f92530512230d37df9793e6481cd6ce6310e3a79cee5ba287858c'
             '5e5fc9e04482903e1a0e7c6c4e81b57448b8dc86c707d1436d69ddc5010219ff'
             '5c38e08ba63695afa79a29d5d3ea22ef1ecf79f91d48ae922e1a489e83782742'
-            '5117629ee577de0da800b6923675683ba69422cdbe958e70c9081fdc6886402e')
+            '5117629ee577de0da800b6923675683ba69422cdbe958e70c9081fdc6886402e'
+            '9792f6c93bf2912ec45de1a618d7ecde74280c85bf970c5f9ceaecc9e99d5647')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -82,6 +84,12 @@ prepare() {
   # Fix installation of both Python versions
   apply_patch_with_msg \
     boost-1.70.0-fix-python-install.patch
+
+  # See https://github.com/msys2/MINGW-packages/issues/15021. The fix is
+  # provided by Peter Dimov. It will be integrated into a future boost release,
+  # please, remove it if you update the boost version above 1.81.0.
+  apply_patch_with_msg \
+    boost-1.81.0-honor-ICU_ICUxx_NAME-variables-in-remap-library.patch
 }
 
 setb2args() {
@@ -112,7 +120,6 @@ setb2args() {
     --debug-configuration \
     --prefix=${pkgdir}${MINGW_PREFIX} \
     --layout=tagged-1.66 \
-    --no-cmake-config \
     -sHAVE_ICU=1 \
     -sICU_PATH=${MINGW_PREFIX} \
     -sICU_ICUUC_NAME=icuuc \

--- a/mingw-w64-boost/boost-1.81.0-honor-ICU_ICUxx_NAME-variables-in-remap-library.patch
+++ b/mingw-w64-boost/boost-1.81.0-honor-ICU_ICUxx_NAME-variables-in-remap-library.patch
@@ -1,0 +1,43 @@
+--- boost_1_81_0/tools/boost_install/boost-install.jam
++++ boost_1_81_0/tools/boost_install/boost-install.jam
+@@ -71,13 +71,38 @@ local rule remap-library ( lib )
+
+         return "bz2" ;
+
++    case "icuuc" :
++
++        if [ modules.peek : ICU_ICUUC_NAME ]
++        {
++            return [ modules.peek : ICU_ICUUC_NAME ] ;
++        }
++        else
++        {
++            return "icuuc" ;
++        }
++
+     case "icudt" :
+
+-        return "icudata" ;
++        if [ modules.peek : ICU_ICUDT_NAME ]
++        {
++            return [ modules.peek : ICU_ICUDT_NAME ] ;
++        }
++        else
++        {
++            return "icudata" ;
++        }
+
+     case "icuin" :
+
+-        return "icui18n" ;
++        if [ modules.peek : ICU_ICUIN_NAME ]
++        {
++            return [ modules.peek : ICU_ICUIN_NAME ] ;
++        }
++        else
++        {
++            return "icui18n" ;
++        }
+
+     case * :
+


### PR DESCRIPTION
The first attempt to add back CMake configuration files for boost failed because boost installer didn't honor ICU_ICUxx_NAME variables set in PKGBUILD. This commit reinstates CMake configuration files and incorporates a patch provided by Peter Dimov.