### PR TITLE
gcc: add workaround to fix build with newer mingw-w64

### DIFF
--- a/mingw-w64-gcc/0002-Relocate-libintl.patch
+++ b/mingw-w64-gcc/0002-Relocate-libintl.patch
@@ -145,7 +145,7 @@ new file mode 100644
 index 00000000000..5217f304540
 --- /dev/null
 +++ b/intl/canonicalize.c
-@@ -0,0 +1,343 @@
+@@ -0,0 +1,344 @@
 +/* Return the canonical absolute name of a given file.
 +   Copyright (C) 1996, 1997, 1998, 1999, 2000 Free Software Foundation, Inc.
 +   This file is part of the GNU C Library.
@@ -176,6 +176,7 @@ index 00000000000..5217f304540
 +#include <malloc.h>
 +#ifdef __WIN32__
 +# include <stdio.h>
++# define WIN32_LEAN_AND_MEAN
 +# include <windows.h>
 +//# include <gw32.h>
 +#endif /* __WIN32__ */

--- a/mingw-w64-gcc/0003-Windows-Follow-Posix-dir-exists-semantics-more-close.patch
+++ b/mingw-w64-gcc/0003-Windows-Follow-Posix-dir-exists-semantics-more-close.patch
@@ -17,12 +17,13 @@ diff --git a/libcpp/files.cc b/libcpp/files.cc
 index 24208f7b0f8..a740d7a778c 100644
 --- a/libcpp/files.cc
 +++ b/libcpp/files.cc
-@@ -30,6 +30,13 @@ along with this program; see the file COPYING3.  If not see
+@@ -30,6 +30,14 @@ along with this program; see the file COPYING3.  If not see
  #include "md5.h"
  #include <dirent.h>
  
 +/* Needed for stat_st_mode_symlink below */
 +#if defined(_WIN32)
++#  define WIN32_LEAN_AND_MEAN
 +#  include <windows.h>
 +#  define S_IFLNK 0xF000
 +#  define S_ISLNK(m) (((m) & S_IFMT) == S_IFLNK)

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -24,7 +24,7 @@ pkgver=12.2.0
 #_majorver=${pkgver:0:1}
 #_sourcedir=${_realname}-${_majorver}-${_snapshot}
 _sourcedir=${_realname}-${pkgver}
-pkgrel=7
+pkgrel=8
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -70,8 +70,8 @@ source=("https://ftp.gnu.org/gnu/gcc/${_realname}-${pkgver%%+*}/${_realname}-${p
 sha256sums=('e549cf9cf3594a00e27b6589d4322d70e0720cdd213f39beb4181e06926230ff'
             'SKIP'
             'bce81824fc89e5e62cca350de4c17a27e27a18a1a1ad5ca3492aec1fc5af3234'
-            '7ba56b5ce1a63246115b36e1763ac802b8db9817872f6944eae96bf261c77edc'
-            'a5e06776c16723af33dde37d4c95b8635188669a5ca675abb5ba7b3da1c8c562'
+            '2c1a5fdb39d8ecf449632b0ebdd4b41bf9e070aea4093f299513cad95484b5c3'
+            '3f55d6493d459f6b875f750735231df140339b62eb0d2cc5edfbf10332c1bd5f'
             'be1dd73bca4e802df5e263a2b27355c3b42d7298491b94fdcc35e00be2e2cb68'
             '2a208d5b13f370c6b2187c7932a13d6caedfc3722f02afc8e5ee9426fb8e64cc'
             '56832cb8f939fe14eaadf8fb2d4c784012acc87e1661320398b42b7389643bb7'
@@ -215,6 +215,12 @@ build() {
   # https://github.com/msys2/MINGW-packages/issues/13830
   # TODO: This can be removed once we drop libssp all together
   CFLAGS+=" -fno-stack-protector"
+
+  # TODO: remove this with gcc 13.x, which includes a proper fix:
+  # https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=902c755930326cb4405672aa3ea13c35c653cbff
+  CPPFLAGS+=" -DWIN32_LEAN_AND_MEAN"
+  # In addition adaint.c does `#include <accctrl.h>` which pulls in msxml.h, hacky hack:
+  CPPFLAGS+=" -DCOM_NO_WINDOWS_H"
 
   ../${_sourcedir}/configure \
     --prefix=${MINGW_PREFIX} \


### PR DESCRIPTION
See https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=902c755930326cb4405672aa3ea13c35c653cbff