### PR TITLE
openocd: remove libusb-compat dependency

### DIFF
--- a/mingw-w64-openocd/PKGBUILD
+++ b/mingw-w64-openocd/PKGBUILD
@@ -6,7 +6,7 @@ _realname=openocd
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.12.0
-pkgrel=1
+pkgrel=2
 pkgdesc="OpenOCD - Open On-Chip Debugger (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -15,7 +15,6 @@ license=("GPLv2")
 options=('!ccache')
 depends=("${MINGW_PACKAGE_PREFIX}-hidapi"
          "${MINGW_PACKAGE_PREFIX}-libusb"
-         "${MINGW_PACKAGE_PREFIX}-libusb-compat"
          "${MINGW_PACKAGE_PREFIX}-libftdi"
          "${MINGW_PACKAGE_PREFIX}-libjaylink"
          "${MINGW_PACKAGE_PREFIX}-capstone")


### PR DESCRIPTION
Since 0.12.0 no drivers in OpenOCD need libusb0 API, so remove the dependency.