### PR TITLE
openssl: fix modulesdir relocation

### DIFF
--- a/mingw-w64-openssl/002-relocation.patch
+++ b/mingw-w64-openssl/002-relocation.patch
@@ -123,3 +123,51 @@
  }
  
  const char *X509_get_default_cert_dir_env(void)
+--- openssl-3.0.7/crypto/provider_core.c.orig	2023-01-18 22:01:41.310870400 +0100
++++ openssl-3.0.7/crypto/provider_core.c	2023-01-18 22:06:16.605142900 +0100
+@@ -29,6 +29,7 @@
+ #include "internal/bio.h"
+ #include "internal/core.h"
+ #include "provider_local.h"
++#include "pathtools.h"
+ #ifndef FIPS_MODULE
+ # include <openssl/self_test.h>
+ #endif
+@@ -822,6 +823,21 @@
+     return 0;
+ }
+ 
++static char * modulesdir_relocation(const char *path)
++{
++  char exe_path[PATH_MAX];
++  get_executable_path (NULL, &exe_path[0], sizeof(exe_path)/sizeof(exe_path[0]));
++  if (strrchr (exe_path, '/') != NULL)
++  {
++     strrchr (exe_path, '/')[1] = '\0';
++  }
++  char * rel_to_datadir = get_relative_path (OPENSSLBIN, path);
++  strcat (exe_path, rel_to_datadir);
++  free(rel_to_datadir);
++  simplify_path (&exe_path[0]);
++  return malloc_copy_string(exe_path);
++}
++
+ /*
+  * Internal version that doesn't affect the store flags, and thereby avoid
+  * locking.  Direct callers must remember to set the store flags when
+@@ -882,8 +898,13 @@
+ 
+             if (load_dir == NULL) {
+                 load_dir = ossl_safe_getenv("OPENSSL_MODULES");
+-                if (load_dir == NULL)
+-                    load_dir = MODULESDIR;
++                if (load_dir == NULL) {
++                    static char * reloc = NULL;
++                    if (reloc == NULL) {
++                        reloc = modulesdir_relocation(MODULESDIR);
++                    }
++                    load_dir = reloc;
++                }
+             }
+ 
+             DSO_ctrl(prov->module, DSO_CTRL_SET_FLAGS,

--- a/mingw-w64-openssl/PKGBUILD
+++ b/mingw-w64-openssl/PKGBUILD
@@ -4,7 +4,7 @@ _realname=openssl
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=3.0.7
-pkgrel=1
+pkgrel=2
 pkgdesc="The Open Source toolkit for Secure Sockets Layer and Transport Layer Security (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -22,7 +22,7 @@ source=("https://www.openssl.org/source/openssl-${pkgver}.tar.gz"{,.asc}
 sha256sums=('83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e'
             'SKIP'
             'd612e8005d2a311595004059244cfe2ff2c5d30ea80cca2a092963057f421b4c'
-            '5bb4c03af10f5faed8680d6089a6347659b31719057d41bc07a8e7e300437dd5'
+            '4ae060cdae09cbff4d49d38cfe2724a8fb9c4ec8082988830de60cfb2de98ceb'
             '703cd0cb74e714f9e66d26de11c109dd76fab07e723af8dde56a35ea65102e5f'
             '4f9d325265ef6f4e90ad637dea41afa6995388c921fe961ad5dc895aca10318b')
 


### PR DESCRIPTION
openssl 3 added a new path from which DLLs can be loaded at runtime, currently the "legacy.dll".

This code path was missing the relocation support and looking for the CI build path instead, resulting in code that tried to load the legacy providers to fail (examples: python-cryptography, transmission)

It can also be reproduced via:
   openssl list -provider legacy -providers

Add relocation support to MODULESDIR to fix this.