### PR TITLE
update GnuCOBOL

### DIFF
--- a/mingw-w64-gnucobol/PKGBUILD
+++ b/mingw-w64-gnucobol/PKGBUILD
@@ -3,11 +3,11 @@
 # Contributor: Simon Sobisch <simonsobisch@gnu.org>
 
 _realname=gnucobol
-_realver=3.1.2
+_realver=3.2-rc1
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-pkgver=${_realver}   # not necessarily matches as the rule for the version identifier differ
-pkgrel=4
+pkgver=${_realver//-/_}   # not necessarily matches as the rule for the version identifier differ
+pkgrel=1
 pkgdesc="GnuCOBOL, a free and modern COBOL compiler (mingw-w64)"
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-svn" "${MINGW_PACKAGE_PREFIX}-gnu-cobol-svn")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-svn" "${MINGW_PACKAGE_PREFIX}-gnu-cobol-svn")
@@ -38,12 +38,12 @@ makedepends=(autotools "${MINGW_PACKAGE_PREFIX}-cc")
 checkdepends=(perl) 
 
 # local definitions
-#source=("https://alpha.gnu.org/gnu/${_realname}/${_realname}-${_realver}.tar.xz"{,.sig}
-source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${_realver}.tar.xz"{,.sig}
+source=("https://alpha.gnu.org/gnu/${_realname}/${_realname}-${_realver}.tar.xz"{,.sig}
+#source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${_realver}.tar.xz"{,.sig}
         "cobenv.sh" "cobenv.cmd"
         "https://www.itl.nist.gov/div897/ctg/suites/newcob.val.Z"
         )
-sha256sums=('597005D71FD7D65B90CBE42BBFECD5A9EC0445388639404662E70D53DDF22574'
+sha256sums=('026E01480FA91FAE2B53C20BD118C133234FE1B07409E144FDBE5E17E5A8E6E7'
             SKIP
             'EEDFC170CFD6606527DD701C3CF6BBA2029C33CE694F697F8B7EE527B4ED7F1C'
             '244AFBD011B0C0141753C7259173D9F49F161A97C7252B52369E0CEC50147308'


### PR DESCRIPTION
Note: I haven't tested that locally, so at least the CI check should pass.
I _did_ verified before that 3.2-dev (before rc1) passed more of the checks of the internal testsuite on MSYS2 environments while creating less compiler warnings...

3.2 final is planned for 2023-02-03, but I'd still tend to make this available already. 