### PR TITLE
Add static library generation for libexiv2

### DIFF
--- a/mingw-w64-exiv2/PKGBUILD
+++ b/mingw-w64-exiv2/PKGBUILD
@@ -65,6 +65,7 @@ build() {
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
+  CPPFLAGS="$CPPFLAGS -DCURL_STATICLIB" \
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake \
       -GNinja \

--- a/mingw-w64-exiv2/PKGBUILD
+++ b/mingw-w64-exiv2/PKGBUILD
@@ -6,7 +6,7 @@ _realname=exiv2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.27.6
-pkgrel=1
+pkgrel=2
 pkgdesc="Exif/IPTC/Xmp C++ metadata library and tools (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -26,8 +26,9 @@ source=(${_realname}-${pkgver}.tar.gz::"https://github.com/Exiv2/${_realname}/ar
 sha256sums=('f16ee5ff08b6994c66106109417857f13e711fca100ac43c6a403d4f02b59602')
 
 build() {
-  [[ -d "${srcdir}"/build-${MSYSTEM} ]] && rm -rf "${srcdir}"/build-${MSYSTEM}
-  mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
+  #shared
+  [[ -d "${srcdir}"/build-shared-${MSYSTEM} ]] && rm -rf "${srcdir}"/build-shared-${MSYSTEM}
+  mkdir -p "${srcdir}"/build-shared-${MSYSTEM} && cd "${srcdir}"/build-shared-${MSYSTEM}
 
   declare -a extra_config
   if check_option "debug" "n"; then
@@ -52,10 +53,42 @@ build() {
       ../${_realname}-${pkgver}
 
   ${MINGW_PREFIX}/bin/cmake --build .
+  
+  #static
+  [[ -d "${srcdir}"/build-static-${MSYSTEM} ]] && rm -rf "${srcdir}"/build-static-${MSYSTEM}
+  mkdir -p "${srcdir}"/build-static-${MSYSTEM} && cd "${srcdir}"/build-static-${MSYSTEM}
+
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake \
+      -GNinja \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      "${extra_config[@]}" \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DEXIV2_ENABLE_VIDEO=ON \
+      -DEXIV2_ENABLE_NLS=ON \
+      -DEXIV2_ENABLE_WIN_UNICODE=ON \
+      -DEXIV2_BUILD_SAMPLES=OFF \
+      -DEXIV2_ENABLE_WEBREADY=ON \
+      -DEXIV2_ENABLE_CURL=ON \
+      -DEXIV2_ENABLE_BMFF=ON \
+      ../${_realname}-${pkgver}
+
+  ${MINGW_PREFIX}/bin/cmake --build .
 }
 
 package() {
-  cd "${srcdir}"/build-${MSYSTEM}
+  cd "${srcdir}"/build-shared-${MSYSTEM}
+
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
+  
+  cd "${srcdir}"/build-static-${MSYSTEM}
 
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
 

--- a/mingw-w64-exiv2/PKGBUILD
+++ b/mingw-w64-exiv2/PKGBUILD
@@ -65,12 +65,13 @@ build() {
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
-  CPPFLAGS="$CPPFLAGS -DCURL_STATICLIB" \
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake \
       -GNinja \
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
       "${extra_config[@]}" \
+      -DCMAKE_CXX_FLAGS="-DCURL_STATICLIB" \
+      -DCMAKE_C_FLAGS="-DCURL_STATICLIB" \
       -DBUILD_SHARED_LIBS=OFF \
       -DEXIV2_ENABLE_VIDEO=ON \
       -DEXIV2_ENABLE_NLS=ON \
@@ -85,11 +86,11 @@ build() {
 }
 
 package() {
-  cd "${srcdir}"/build-shared-${MSYSTEM}
+  cd "${srcdir}"/build-static-${MSYSTEM}
 
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
   
-  cd "${srcdir}"/build-static-${MSYSTEM}
+  cd "${srcdir}"/build-shared-${MSYSTEM}
 
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
 


### PR DESCRIPTION
some how qt6-static related to it, so it's better to have a static library
![无标题](https://user-images.githubusercontent.com/13523412/213432321-239e5b9e-9e36-480d-aae0-a6dead60d5bd.png)
