### PR TITLE
Disable stripping gi-docgen

### DIFF
--- a/mingw-w64-gi-docgen/PKGBUILD
+++ b/mingw-w64-gi-docgen/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gi-docgen
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2023.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Documentation tool for GObject-based libraries (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -31,6 +31,7 @@ makedepends=(
 checkdepends=(
   "${MINGW_PACKAGE_PREFIX}-python-flake8"
 )
+options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('88adeda9cbf882569479701eada009afa5d94fa29d728653ec388c32035f7fa3')
 


### PR DESCRIPTION
Current version does not work and throws:
Fatal error in launcher: Unable to find an appended archive.

Fix this by disabling strip.