### PR TITLE
rocksdb: update to 7.9.2

### DIFF
--- a/mingw-w64-rocksdb/0001-disable-static-assert-ClockHandle-size.patch
+++ b/mingw-w64-rocksdb/0001-disable-static-assert-ClockHandle-size.patch
@@ -1,11 +1,11 @@
 --- a/cache/clock_cache.cc
 +++ b/cache/clock_cache.cc
-@@ -23,8 +23,6 @@
+@@ -138,8 +138,6 @@
+     usage_ += size_t{GetTableSize()} * sizeof(HandleImpl);
+   }
  
- namespace hyper_clock_cache {
+-  static_assert(sizeof(HandleImpl) == 64U,
+-                "Expecting size / alignment with common cache line size");
+ }
  
--static_assert(sizeof(ClockHandle) == 64U,
--              "Expecting size / alignment with common cache line size");
- 
- ClockHandleTable::ClockHandleTable(int hash_bits, bool initial_charge_metadata)
-     : length_bits_(hash_bits),
+ HyperClockTable::~HyperClockTable() {

--- a/mingw-w64-rocksdb/PKGBUILD
+++ b/mingw-w64-rocksdb/PKGBUILD
@@ -3,11 +3,11 @@
 _realname=rocksdb
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=7.8.3
+pkgver=7.9.2
 pkgrel=1
 pkgdesc='Embedded key-value store for fast storage (mingw-w64)'
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://rocksdb.org/"
 license=('spdx:Apache-2.0' 'spdx:GPL-2.0-or-later')
 depends=("${MINGW_PACKAGE_PREFIX}-bzip2"
@@ -18,12 +18,11 @@ depends=("${MINGW_PACKAGE_PREFIX}-bzip2"
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cc")
-options=('staticlibs' 'strip')
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/facebook/${_realname}/archive/v${pkgver}.tar.gz"
         "0001-disable-static-assert-ClockHandle-size.patch"
         "0004-fix-generating-and-install-import-lib.patch")
-sha256sums=('b85408a374770897332bf15e51620a5f35720dd416a4749e3899057f9cfaf84d'
-            'edcc78e99b15a9c8541c19797eab62433ab850542b600737ec26c8d0eafb54da'
+sha256sums=('886378093098a1b2521b824782db7f7dd86224c232cf9652fcaf88222420b292'
+            '88ff72a587f9fe2ed30730663efb672ea94d8e2034f821efc89c286b9954851c'
             '0498c674a27ab03a07b85a0570a4734540cc89605548586e46cd7e71109d0c29')
 
 prepare() {


### PR DESCRIPTION
Fails to build on clang32 because It enables an SSE4.2 instruction unavailable on 32bit.