### PR TITLE
vigra: workaround for python-nose issue

### DIFF
--- a/mingw-w64-vigra/PKGBUILD
+++ b/mingw-w64-vigra/PKGBUILD
@@ -5,12 +5,12 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.11.1
 _pkgver=${pkgver//./-}
-pkgrel=9
+pkgrel=10
 pkgdesc="vigra - Generic Programming for Computer Vision (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
 url='https://ukoethe.github.io/vigra/'
-license=('MIT X11')
+license=('spdx:X11')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-boost"
          "${MINGW_PACKAGE_PREFIX}-fftw"
@@ -101,7 +101,7 @@ build() {
 
 check() {
   cd "${srcdir}/build-${MSYSTEM}"
-  #make check
+  # make check
 }
 
 package() {
@@ -109,7 +109,7 @@ package() {
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
 
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
-  for _f in "${pkgdir}${MINGW_PREFIX}"/lib/cmake/{vigra,vigranumpy}/*.cmake; do
+  for _f in "${pkgdir}${MINGW_PREFIX}"/lib/cmake/vigra/*.cmake; do
     sed -e "s|${PREFIX_WIN}|\$\{_IMPORT_PREFIX\}|g" -i ${_f}
     sed -e "s|${MINGW_PREFIX}|\$\{_IMPORT_PREFIX\}|g" -i ${_f}
   done


### PR DESCRIPTION
There seems to be an issue with python-nose during the configuration step of vigra that eventually leads to it being built without numpy:
```
-- Searching for Python numpy: ok
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:/msys64/mingw64/lib/python3.10/site-packages/nose/__init__.py", line 1, in <module>
    from nose.core import collector, main, run, run_exit, runmodule
  File "C:/msys64/mingw64/lib/python3.10/site-packages/nose/core.py", line 11, in <module>
    from nose.config import Config, all_config_files
  File "C:/msys64/mingw64/lib/python3.10/site-packages/nose/config.py", line 68
    except ConfigParser.Error, exc:
           ^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: multiple exception types must be parenthesized
-- Could NOT find Python nosetests ('import nose' failed)
[...]
--   Vigranumpy dependencies not found (vigranumpy disabled)
```

The packaging step fails because vigranumpy wasn't built.

I don't know enough about the Python ecosystem to actually fix the issue with python-nose. But these changes avoid the error in the packaging step.
