### PR TITLE
h5py: Update to version 3.8.0

### DIFF
--- a/mingw-w64-python-h5py/PKGBUILD
+++ b/mingw-w64-python-h5py/PKGBUILD
@@ -6,8 +6,8 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=3.7.0
-pkgrel=3
+pkgver=3.8.0
+pkgrel=1
 pkgdesc="General-purpose Python bindings for the HDF5 library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -22,21 +22,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cython"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
 source=(https://github.com/h5py/h5py/releases/download/${pkgver}/h5py-${pkgver}.tar.gz
-        001-mingw-python.patch::https://github.com/h5py/h5py/commit/115d5bc2e8bef12c72dfb1ecbc40b2e283d0d05a.patch
-        002-Merge-pull-request-2194-from-h5py-libhdf5-1.14.patch::https://github.com/h5py/h5py/commit/3dc3d7c089acaa4532f43ad2283e65a440ec55ac.patch
         lzf_c.c.patch)
-sha256sums=('22cdc29324f39102c89542845b02241f8c5a7b180bbed8cc0b14ff72a1c0e478'
-            '8dc14d226a3eef0a37fd51df0827fe7115558c10ff29d4e32579f5b4c5f58380'
-            '4bb0380f192ed01e10c905ead78ca80f73909227b5ce9048019aff4bc5dbaf1e'
+sha256sums=('6fead82f0c4000cf38d53f9c030780d81bfa0220218aee13b90b7701c937d95f'
             '6d0126b881b5dcd637146d151341b72aa68eef760092272279072ec0bc4ceca9')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
-  # https://github.com/h5py/h5py/pull/2105
-  patch -p1 -i ${srcdir}/001-mingw-python.patch
-  # https://github.com/h5py/h5py/pull/2194
-  patch -p1 -i ${srcdir}/002-Merge-pull-request-2194-from-h5py-libhdf5-1.14.patch
   patch -p1 -i ${srcdir}/lzf_c.c.patch
 
   cd "${srcdir}"


### PR DESCRIPTION
h5py has been updated to version 3.8.0, integrating some earlier patches:

https://github.com/h5py/h5py/releases/tag/3.8.0

xref: https://github.com/msys2/MINGW-packages/pull/15033