### PR TITLE
Add new package Bcg729

### DIFF
--- a/mingw-w64-bcg729/PKGBUILD
+++ b/mingw-w64-bcg729/PKGBUILD
@@ -1,0 +1,46 @@
+# Maintainer: Wireshark Core Team <wireshark-dev@wireshark.org>
+
+_realname=bcg729
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.1.1
+pkgrel=1
+pkgdesc="Encoder and decoder of the ITU G.729 Annex A/B speech codec (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+url='https://www.linphone.org/technical-corner/bcg729/overview'
+license=('GPL2')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+source=("https://github.com/BelledonneCommunications/bcg729/archive/${pkgver}/${pkgname}-${pkgver}.tar.gz")
+sha256sums=('68599a850535d1b182932b3f86558ac8a76d4b899a548183b062956c5fdc916d')
+
+build() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
+
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    "${MINGW_PREFIX}"/bin/cmake.exe \
+      -GNinja \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      "${extra_config[@]}" \
+      ../${_realname}-${pkgver}
+
+  "${MINGW_PREFIX}"/bin/cmake.exe --build .
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.txt"
+}

--- a/mingw-w64-bcg729/PKGBUILD
+++ b/mingw-w64-bcg729/PKGBUILD
@@ -9,7 +9,7 @@ pkgdesc="Encoder and decoder of the ITU G.729 Annex A/B speech codec (mingw-w64)
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://www.linphone.org/technical-corner/bcg729/overview'
-license=('GPL2')
+license=('spdx:GPL-3.0-or-later')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cc")


### PR DESCRIPTION
Bcg729 is an opensource implementation of both encoder and decoder of the ITU G729 Annex A/B speech codec.

URL: https://github.com/BelledonneCommunications/bcg729