### PR TITLE
glib2: Fix g_spawn_*() in CLANG builds

### DIFF
--- a/mingw-w64-glib2/0003-glib-spawn-win32.patch
+++ b/mingw-w64-glib2/0003-glib-spawn-win32.patch
@@ -1,0 +1,12 @@
+diff -bur glib-2.74.5-c/glib/gspawn-win32.c glib-2.74.5/glib/gspawn-win32.c
+--- glib-2.74.5-c/glib/gspawn-win32.c	2023-01-26 03:27:35.708738400 -0700
++++ glib-2.74.5/glib/gspawn-win32.c	2023-01-26 03:27:47.429281900 -0700
+@@ -163,7 +163,7 @@
+ 
+ #else
+ 
+-#define safe_wspawnve _spawnve
++#define safe_wspawnve _wspawnve
+ #define safe_wspawnvpe _wspawnvpe
+ 
+ #endif /* _UCRT */

--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -7,7 +7,7 @@ _realname=glib2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.74.5
-pkgrel=1
+pkgrel=2
 url="https://gitlab.gnome.org/GNOME/glib"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -28,6 +28,7 @@ options=('strip' '!debug' 'staticlibs')
 source=("https://download.gnome.org/sources/glib/${pkgver%.*}/glib-${pkgver}.tar.xz"
         0001-Update-g_fopen-g_open-and-g_creat-to-open-with-FILE_.patch
         0002-disable_glib_compile_schemas_warning.patch
+        0003-glib-spawn-win32.patch
         0004-disable-explicit-ms-bitfields.patch
         https://gitlab.gnome.org/GNOME/glib/-/commit/e2560d1681d57e748c6f1d2392963903e1114b6a.patch
         glib-compile-schemas.hook.in
@@ -37,6 +38,7 @@ noextract=("glib-${pkgver}.tar.xz")
 sha256sums=('ceba83a5999ceb31a4c4fc9921207cb9ffffd2ab1d6ec03c162d3f608a5c14c8'
             '51d02360a1ee978fd45e77b84bca9cfbcf080d91986b5c0efe0732779c6a54ec'
             '396c25cfd740ffbb72209133c7b9453173167577265a4bb14502678de8d5a8f9'
+            '23d4eb3223522d280ae3cda6d73147e2ab0fa5bc240815f9a94e4bdbcf1ebf92'
             '3d2585f460f797c67f9e5149d3b3d52ff2481c48fd7cb791a03f5f0e68304d39'
             '3dc49c0a42424b4ff74819757ecfd0a2c6809f9d3080c249ba97451a6197f356'
             '0c3d54636407e0e13429b73959cace626253cd772e1d4870de0fb92b0b99545a'
@@ -58,6 +60,8 @@ prepare() {
 
   apply_patch_with_msg 0001-Update-g_fopen-g_open-and-g_creat-to-open-with-FILE_.patch
   apply_patch_with_msg 0002-disable_glib_compile_schemas_warning.patch
+  # clang g_spawn_*() error backport: https://gitlab.gnome.org/GNOME/glib/-/issues/2900
+  apply_patch_with_msg 0003-glib-spawn-win32.patch
   apply_patch_with_msg 0004-disable-explicit-ms-bitfields.patch
   # clang build error backport: https://gitlab.gnome.org/GNOME/glib/-/issues/2798
   apply_patch_with_msg e2560d1681d57e748c6f1d2392963903e1114b6a.patch


### PR DESCRIPTION
Backports the fix for https://gitlab.gnome.org/GNOME/glib/-/issues/2900