### PR TITLE
luajit: Fix cc and enhance modules search path with lua5.1 paths

### DIFF
--- a/mingw-w64-luajit/003-lua51-modules-paths.patch
+++ b/mingw-w64-luajit/003-lua51-modules-paths.patch
@@ -1,0 +1,28 @@
+diff -bur LuaJIT-2.1.0-beta3-orig/src/luaconf.h LuaJIT-2.1.0-beta3/src/luaconf.h
+--- LuaJIT-2.1.0-beta3-orig/src/luaconf.h	2023-01-26 22:15:03.558193500 -0700
++++ LuaJIT-2.1.0-beta3/src/luaconf.h	2023-01-26 22:15:17.283052500 -0700
+@@ -18,12 +18,20 @@
+ ** In Windows, any exclamation mark ('!') in the path is replaced by the
+ ** path of the directory of the executable file of the current process.
+ */
+-#define LUA_LDIR	"!\\lua\\"
+-#define LUA_CDIR	"!\\"
++
++/* Paths for modules expecting non-jit lua5.1  */
++#define LUA_LDIR	"!\\..\\share\\lua\\5.1\\"
++#define LUA_CDIR	"!\\..\\lib\\lua\\5.1\\"
++
++#define LUAJIT_LDIR	"!\\lua\\"
++#define LUAJIT_CDIR	"!\\"
+ #define LUA_PATH_DEFAULT \
+-  ".\\?.lua;" LUA_LDIR"?.lua;" LUA_LDIR"?\\init.lua;"
++  ".\\?.lua;" LUAJIT_LDIR"?.lua;" LUAJIT_LDIR"?\\init.lua;" \
++              LUA_LDIR"?.lua;"  LUA_LDIR"?\\init.lua;" \
++              LUA_CDIR"?.lua;"  LUA_CDIR"?\\init.lua"
+ #define LUA_CPATH_DEFAULT \
+-  ".\\?.dll;" LUA_CDIR"?.dll;" LUA_CDIR"loadall.dll"
++  ".\\?.dll;" LUAJIT_CDIR"?.dll;" LUA_CDIR"?.dll;" LUAJIT_CDIR"loadall.dll"
++
+ #else
+ /*
+ ** Note to distribution maintainers: do NOT patch the following lines!

--- a/mingw-w64-luajit/004-fix-default-cc.patch
+++ b/mingw-w64-luajit/004-fix-default-cc.patch
@@ -1,0 +1,12 @@
+diff -bur LuaJIT-2.1.0-beta3-orig/src/Makefile LuaJIT-2.1.0-beta3/src/Makefile
+--- LuaJIT-2.1.0-beta3-orig/src/Makefile	2023-01-26 22:40:03.639259400 -0700
++++ LuaJIT-2.1.0-beta3/src/Makefile	2023-01-26 22:40:18.635694100 -0700
+@@ -24,7 +24,7 @@
+ # removing the '#' in front of them. Make sure you force a full recompile
+ # with "make clean", followed by "make" if you change any options.
+ #
+-DEFAULT_CC = gcc
++DEFAULT_CC = cc
+ #
+ # LuaJIT builds as a native 32 or 64 bit binary by default.
+ CC= $(DEFAULT_CC)

--- a/mingw-w64-luajit/PKGBUILD
+++ b/mingw-w64-luajit/PKGBUILD
@@ -4,7 +4,7 @@ _realname=luajit
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.1.0_beta3
-pkgrel=2
+pkgrel=3
 _sourcedir=${_realname}-${pkgver//_/-}
 pkgdesc="Just-in-time compiler and drop-in replacement for Lua 5.1 (mingw-w64)"
 arch=('any')
@@ -21,15 +21,18 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
 options=('strip' 'staticlibs')
 source=("https://luajit.org/download/LuaJIT-${pkgver//_/-}.tar.gz"
         001-make-import-library.patch
-        002-fix-pkg-config-file.patch)
+        002-fix-pkg-config-file.patch
+        003-lua51-modules-paths.patch)
 sha256sums=('1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3'
             '43084f57315e0d5b55094d71c5f46cf4a5b72d7cecb2f82a409213a598c699e5'
-            '4df486e82b0bbeead01dcf6001e90c51477a3a8ac18611d60d7067f2c7013428')
+            '4df486e82b0bbeead01dcf6001e90c51477a3a8ac18611d60d7067f2c7013428'
+            '184a8da3ebc4a35585285cdbc300ef8e24c2ef41e0ec6d00f0e3607f33765c27')
 
 prepare() {
   cd "${srcdir}/${_sourcedir}"
   patch -p1 -i ${srcdir}/001-make-import-library.patch
   patch -p1 -i ${srcdir}/002-fix-pkg-config-file.patch
+  patch -p1 -i ${srcdir}/003-lua51-modules-paths.patch
   sed -i "s|export PREFIX= /usr/local|export PREFIX="${MINGW_PREFIX}"|g" ${srcdir}/${_sourcedir}/Makefile
 }
 

--- a/mingw-w64-luajit/PKGBUILD
+++ b/mingw-w64-luajit/PKGBUILD
@@ -22,17 +22,20 @@ options=('strip' 'staticlibs')
 source=("https://luajit.org/download/LuaJIT-${pkgver//_/-}.tar.gz"
         001-make-import-library.patch
         002-fix-pkg-config-file.patch
-        003-lua51-modules-paths.patch)
+        003-lua51-modules-paths.patch
+        004-fix-default-cc.patch)
 sha256sums=('1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3'
             '43084f57315e0d5b55094d71c5f46cf4a5b72d7cecb2f82a409213a598c699e5'
             '4df486e82b0bbeead01dcf6001e90c51477a3a8ac18611d60d7067f2c7013428'
-            '184a8da3ebc4a35585285cdbc300ef8e24c2ef41e0ec6d00f0e3607f33765c27')
+            '184a8da3ebc4a35585285cdbc300ef8e24c2ef41e0ec6d00f0e3607f33765c27'
+            '444df1c8ab9c8c348c7c81a7a6bf15d7e02410f4edc38894a65a4bb7ee9a8d68')
 
 prepare() {
   cd "${srcdir}/${_sourcedir}"
   patch -p1 -i ${srcdir}/001-make-import-library.patch
   patch -p1 -i ${srcdir}/002-fix-pkg-config-file.patch
   patch -p1 -i ${srcdir}/003-lua51-modules-paths.patch
+  patch -p1 -i ${srcdir}/004-fix-default-cc.patch
   sed -i "s|export PREFIX= /usr/local|export PREFIX="${MINGW_PREFIX}"|g" ${srcdir}/${_sourcedir}/Makefile
 }
 


### PR DESCRIPTION
Since luajit is meant to be a drop-in replacement for lua5.1 it needs to support searching for modules in the same paths as lua5.1

Fixes https://github.com/msys2/MINGW-packages/issues/15245

```
luajit -e 'print(require("lgi")._VERSION)'
0.9.2
```