### PR TITLE
wireshark: Add package

### DIFF
--- a/mingw-w64-wireshark/PKGBUILD
+++ b/mingw-w64-wireshark/PKGBUILD
@@ -1,0 +1,98 @@
+# Maintainer: Wireshark Core Team <wireshark-dev@wireshark.org>
+
+_realname=wireshark
+_commit=e7d5c49fe1dadfd6393539ba1b4d535087d79abe
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=4.1.0rc0.r1576.ge7d5c49fe1
+pkgrel=1
+pkgdesc="Network traffic and protocol analyzer/sniffer (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64')
+url="https://www.wireshark.org"
+license=('GPL2')
+depends=("${MINGW_PACKAGE_PREFIX}-bcg729"
+         "${MINGW_PACKAGE_PREFIX}-brotli"
+         "${MINGW_PACKAGE_PREFIX}-c-ares"
+         "${MINGW_PACKAGE_PREFIX}-glib2"
+         "${MINGW_PACKAGE_PREFIX}-gnutls"
+         "${MINGW_PACKAGE_PREFIX}-libgcrypt"
+         "${MINGW_PACKAGE_PREFIX}-libilbc"
+         "${MINGW_PACKAGE_PREFIX}-libmaxminddb"
+         "${MINGW_PACKAGE_PREFIX}-libpcap"
+         "${MINGW_PACKAGE_PREFIX}-libsmi"
+         "${MINGW_PACKAGE_PREFIX}-libssh"
+         "${MINGW_PACKAGE_PREFIX}-libxml2"
+         "${MINGW_PACKAGE_PREFIX}-lua51"
+         "${MINGW_PACKAGE_PREFIX}-lz4"
+         "${MINGW_PACKAGE_PREFIX}-minizip"
+         "${MINGW_PACKAGE_PREFIX}-nghttp2"
+         "${MINGW_PACKAGE_PREFIX}-opus"
+         "${MINGW_PACKAGE_PREFIX}-pcre2"
+         "${MINGW_PACKAGE_PREFIX}-qt6-base"
+         "${MINGW_PACKAGE_PREFIX}-qt6-multimedia"
+         "${MINGW_PACKAGE_PREFIX}-qt6-5compat"
+         "${MINGW_PACKAGE_PREFIX}-sbc"
+         "${MINGW_PACKAGE_PREFIX}-snappy"
+         "${MINGW_PACKAGE_PREFIX}-spandsp"
+         "${MINGW_PACKAGE_PREFIX}-speexdsp"
+         "${MINGW_PACKAGE_PREFIX}-zlib"
+         "${MINGW_PACKAGE_PREFIX}-zstd")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-python"
+             "${MINGW_PACKAGE_PREFIX}-qt6-tools"
+             'git')
+source=("${_realname}"::"git+https://gitlab.com/wireshark/wireshark.git#commit=${_commit}")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "${_realname}"
+
+  git describe --long "${_commit}" | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g;s/^v//g'
+}
+
+build() {
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
+
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+  extra_config+=("-DENABLE_WERROR=OFF")
+  extra_config+=("-DENABLE_CCACHE=OFF")
+  extra_config+=("-DUSE_qt6=ON")
+  # Kerberos SDK is not available in the repositories.
+  # Disable autodetection.
+  extra_config+=("-DENABLE_KERBEROS=OFF")
+  # Same for AirPcap.
+  extra_config+=("-DENABLE_AIRPCAP=OFF")
+  # No self-updating, only through pacman.
+  extra_config+=("-DENABLE_WINSPARKLE=OFF")
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    "${MINGW_PREFIX}"/bin/cmake.exe \
+      -GNinja \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      "${extra_config[@]}" \
+      ../${_realname}
+
+  "${MINGW_PREFIX}"/bin/cmake.exe --build .
+}
+
+check() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  "${MINGW_PREFIX}"/bin/cmake.exe --build . --target test
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
+
+  install -Dm644 "${srcdir}/${_realname}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}


### PR DESCRIPTION
Once Wireshark 4.2 is released (probably around october) the package can be changed to follow the stable branch.