### PR TITLE
mpg123: Update to 1.31.2

### DIFF
--- a/mingw-w64-mpg123/PKGBUILD
+++ b/mingw-w64-mpg123/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=mpg123
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.31.1
+pkgver=1.31.2
 pkgrel=1
 pkgdesc="A console based real time MPEG Audio Player for Layer 1, 2 and 3 (mingw-w64)"
 arch=('any')
@@ -19,9 +19,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 optdepends=("${MINGW_PACKAGE_PREFIX}-openal"
             "${MINGW_PACKAGE_PREFIX}-portaudio"
             "${MINGW_PACKAGE_PREFIX}-SDL2")
-options=('strip' 'staticlibs' 'libtool')
 source=("https://sourceforge.net/projects/mpg123/files/mpg123/${pkgver}/mpg123-${pkgver}.tar.bz2"{,.sig})
-sha256sums=('5dcb0936efd44cb583498b6585845206f002a7b19d5066a2683be361954d955a'
+sha256sums=('b17f22905e31f43b6b401dfdf6a71ed11bb7d056f68db449d70b9f9ae839c7de'
             'SKIP')
 validpgpkeys=('D021FF8ECF4BE09719D61A27231C4CBC60D5CAFE') # Thomas Orgis <thomas@orgis.org>
 


### PR DESCRIPTION
and remove libtool files, as I doubt anything still needs them