### PR TITLE
gh: upgrade to 2.22.1

### DIFF
--- a/mingw-w64-github-cli/PKGBUILD
+++ b/mingw-w64-github-cli/PKGBUILD
@@ -16,7 +16,7 @@ optdepends=("git: To interact with repositories")
 options=('!strip')
 source=("$_realname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz"
         "gh")
-sha256sums=('09cdd1c435d453a0c610f407979ecf8d314aec41d7b8004794f136f05b0fe688'
+sha256sums=('5f36524a97de246932777b7d2a62275cd80d1e812f851f8df2c6ce17919ec185'
             '9ee5f2b44b7e9aa751508f02c1020e341e0212a9aa146b7428eb5ffea310be27')
 build() {
     cd "cli-$pkgver"


### PR DESCRIPTION
See https://github.com/cli/cli/releases/tag/v2.22.1 for details.