### PR TITLE
openssl: backport ASM support for Windows on ARM64.

### DIFF
--- a/mingw-w64-openssl/001-support-aarch64.patch
+++ b/mingw-w64-openssl/001-support-aarch64.patch
@@ -10,10 +10,10 @@
 +        sys_id           => "MINGWARM64",
 +        bn_ops           => add("SIXTY_FOUR_BIT"),
 +        asm_arch         => 'aarch64',
-+        uplink_arch      => undef,
-+        perlasm_scheme   => "coff",
++        uplink_arch      => 'armv8',
++        perlasm_scheme   => "win64",
 +        shared_rcflag    => "",
-+        multilib         => "",
++        multilib         => "-arm64",
 +    },
 +
  #### UEFI

--- a/mingw-w64-openssl/003-backport-win-arm64-asm-support.patch
+++ b/mingw-w64-openssl/003-backport-win-arm64-asm-support.patch
@@ -1,0 +1,149 @@
+From b863e1e4c69068e4166bdfbbf9f04bb07991dd40 Mon Sep 17 00:00:00 2001
+From: Everton Constantino <everton.constantino@linaro.org>
+Date: Thu, 27 Oct 2022 15:07:48 -0300
+Subject: [PATCH] Add two new build targets to enable the possibility of using
+ clang-cl as an assembler for Windows on Arm builds and also clang-cl as the
+ compiler as well. Make appropriate changes to armcap source and peralsm
+ scripts.
+
+Reviewed-by: Paul Dale <pauli@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+Reviewed-by: Hugo Landau <hlandau@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/19523)
+---
+ Configurations/50-win-clang-cl.conf  | 35 ++++++++++++++++++++++++++++
+ Configurations/windows-makefile.tmpl |  2 +-
+ crypto/armcap.c                      | 25 ++++++++++++++++++--
+ crypto/perlasm/arm-xlate.pl          | 11 +++++++++
+ 4 files changed, 70 insertions(+), 3 deletions(-)
+ create mode 100644 Configurations/50-win-clang-cl.conf
+
+diff --git a/Configurations/50-win-clang-cl.conf b/Configurations/50-win-clang-cl.conf
+new file mode 100644
+index 000000000000..cfc96ef159c0
+--- /dev/null
++++ b/Configurations/50-win-clang-cl.conf
+@@ -0,0 +1,35 @@
++## -*- mode: perl; -*-
++# Windows on Arm clang-cl targets.
++#
++
++my %targets = (
++    "VC-WIN64-CLANGASM-ARM" => {
++        inherit_from    => [ "VC-noCE-common" ],
++        defines         => add("_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE",
++                               "OPENSSL_SYS_WIN_CORE"),
++        bn_ops          => "SIXTY_FOUR_BIT RC4_CHAR",
++        multilib        => "-arm64",
++        asm_arch        => "aarch64",
++        AS        => "clang-cl.exe",
++        ASFLAGS   => "/nologo /Zi",
++        asflags   => "/c",
++        asoutflag => "/Fo",
++        perlasm_scheme => "win64",
++        uplink_arch      => 'armv8',
++    },
++    "VC-CLANG-WIN64-CLANGASM-ARM" => {
++        CC => "clang-cl",
++        inherit_from    => [ "VC-noCE-common" ],
++        defines         => add("_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE",
++                               "OPENSSL_SYS_WIN_CORE"),
++        bn_ops          => "SIXTY_FOUR_BIT RC4_CHAR",
++        multilib        => "-arm64",
++        asm_arch        => "aarch64",
++        AS        => "clang-cl.exe",
++        ASFLAGS   => "/nologo /Zi",
++        asflags   => "/c",
++        asoutflag => "/Fo",
++        perlasm_scheme => "win64",
++        uplink_arch      => 'armv8',
++    },
++);
+diff --git a/Configurations/windows-makefile.tmpl b/Configurations/windows-makefile.tmpl
+index 5d41af41bca2..f9c58eae94f7 100644
+--- a/Configurations/windows-makefile.tmpl
++++ b/Configurations/windows-makefile.tmpl
+@@ -780,7 +780,7 @@ EOF
+           }
+           return <<"EOF";
+ $target: "$gen0" $deps
+-	\$(CPP) $incs $cppflags $defs "$gen0" > \$@.i
++	\$(CPP) /D__ASSEMBLER__ $incs $cppflags $defs "$gen0" > \$@.i
+ 	move /Y \$@.i \$@
+ EOF
+       } elsif ($gen0 =~ m|^.*\.in$|) {
+--- openssl-3.0.7/crypto/armcap.c.orig	2023-01-30 19:41:29.283585100 +0000
++++ openssl-3.0.7/crypto/armcap.c	2023-01-30 19:44:08.641014300 +0000
+@@ -17,6 +17,9 @@
+ #include <sys/sysctl.h>
+ #endif
+ #include "internal/cryptlib.h"
++#ifdef _WIN32
++#include <windows.h>
++#endif
+ 
+ #include "arm_arch.h"
+ 
+@@ -24,7 +27,25 @@
+ unsigned int OPENSSL_arm_midr = 0;
+ unsigned int OPENSSL_armv8_rsa_neonized = 0;
+ 
+-#if __ARM_MAX_ARCH__<7
++#ifdef _WIN32
++void OPENSSL_cpuid_setup(void)
++{
++    OPENSSL_armcap_P |= ARMV7_NEON;
++    OPENSSL_armv8_rsa_neonized = 1;
++    if (IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE)) {
++        // These are all covered by one call in Windows
++        OPENSSL_armcap_P |= ARMV8_AES;
++        OPENSSL_armcap_P |= ARMV8_PMULL;
++        OPENSSL_armcap_P |= ARMV8_SHA1;
++        OPENSSL_armcap_P |= ARMV8_SHA256;
++    }
++}
++
++uint32_t OPENSSL_rdtsc(void)
++{
++    return 0;
++}
++#elif __ARM_MAX_ARCH__<7
+ void OPENSSL_cpuid_setup(void)
+ {
+ }
+diff --git a/crypto/perlasm/arm-xlate.pl b/crypto/perlasm/arm-xlate.pl
+index a90885905c0f..df10ddc7fabb 100755
+--- a/crypto/perlasm/arm-xlate.pl
++++ b/crypto/perlasm/arm-xlate.pl
+@@ -22,6 +22,7 @@
+ ################################################################
+ my $arch = sub {
+     if ($flavour =~ /linux/)	{ ".arch\t".join(',',@_); }
++    elsif ($flavour =~ /win64/) { ".arch\t".join(',',@_); }
+     else			{ ""; }
+ };
+ my $fpu = sub {
+@@ -37,6 +38,7 @@
+ };
+ my $hidden = sub {
+     if ($flavour =~ /ios/)	{ ".private_extern\t".join(',',@_); }
++    elsif ($flavour =~ /win64/) { ""; }
+     else			{ ".hidden\t".join(',',@_); }
+ };
+ my $comm = sub {
+@@ -85,6 +87,15 @@
+ 					"#endif";
+ 				  }
+ 			        }
++    elsif ($flavour =~ /win64/) { if (join(',',@_) =~ /(\w+),%function/) {
++                # See https://sourceware.org/binutils/docs/as/Pseudo-Ops.html
++                # Per https://docs.microsoft.com/en-us/windows/win32/debug/pe-format#coff-symbol-table,
++                # the type for functions is 0x20, or 32.
++                ".def $1\n".
++                "   .type 32\n".
++                ".endef";
++            }
++        }
+     else			{ ""; }
+ };
+ my $size = sub {

--- a/mingw-w64-openssl/PKGBUILD
+++ b/mingw-w64-openssl/PKGBUILD
@@ -4,7 +4,7 @@ _realname=openssl
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=3.0.7
-pkgrel=3
+pkgrel=4
 pkgdesc="The Open Source toolkit for Secure Sockets Layer and Transport Layer Security (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -17,12 +17,14 @@ options=('!buildflags')
 source=("https://www.openssl.org/source/openssl-${pkgver}.tar.gz"{,.asc}
         '001-support-aarch64.patch'
         '002-relocation.patch'
+        '003-backport-win-arm64-asm-support.patch'
         'pathtools.c'
         'pathtools.h')
 sha256sums=('83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e'
             'SKIP'
-            'd612e8005d2a311595004059244cfe2ff2c5d30ea80cca2a092963057f421b4c'
+            '21b96771b401442570e885c2d5689a359a91e86dcbf5511db3667202b6c1fa8a'
             '4ae060cdae09cbff4d49d38cfe2724a8fb9c4ec8082988830de60cfb2de98ceb'
+            '93c17b03b1661dae36af5c2a42865a54b342a9dd1967697c1692bbe8bd14b8fa'
             '703cd0cb74e714f9e66d26de11c109dd76fab07e723af8dde56a35ea65102e5f'
             '4f9d325265ef6f4e90ad637dea41afa6995388c921fe961ad5dc895aca10318b')
 
@@ -49,7 +51,8 @@ prepare() {
 
   apply_patch_with_msg \
      001-support-aarch64.patch \
-     002-relocation.patch
+     002-relocation.patch \
+     003-backport-win-arm64-asm-support.patch
 
   test ! -d "${startdir}/../mingw-w64-pathtools" || {
     cmp "${startdir}/../mingw-w64-pathtools/pathtools.c" "${srcdir}/pathtools.c" &&
@@ -75,7 +78,7 @@ build() {
       _mingw=mingw64
       ;;
     aarch64)
-      _mingw="mingwarm64 no-asm"
+      _mingw=mingwarm64
       ;;
   esac
 


### PR DESCRIPTION
Based on https://github.com/openssl/openssl/commit/b863e1e4c69068e4166bdfbbf9f04bb07991dd40, which seems to have been cherry-picked to the openssl-3.1 branch but not 3.0.

The armcap.c change did not apply cleanly to 3.0 (apparently it was not yet including `unistd.h`), so I updated that hunk of the patch.

```diff
diff -u b863e1e4c69068e4166bdfbbf9f04bb07991dd40.patch 003-backport-win-arm64-asm-support.patch
--- b863e1e4c69068e4166bdfbbf9f04bb07991dd40.patch      2023-01-30 17:30:30.269591000 -0800
+++ 003-backport-win-arm64-asm-support.patch    2023-01-30 17:12:24.855600100 -0800
@@ -72,23 +72,19 @@
        move /Y \$@.i \$@
  EOF
        } elsif ($gen0 =~ m|^.*\.in$|) {
-diff --git a/crypto/armcap.c b/crypto/armcap.c
-index 0aa11baed4b9..a43f17304b02 100644
---- a/crypto/armcap.c
-+++ b/crypto/armcap.c
-@@ -17,15 +17,36 @@
+--- openssl-3.0.7/crypto/armcap.c.orig 2023-01-30 19:41:29.283585100 +0000
++++ openssl-3.0.7/crypto/armcap.c      2023-01-30 19:44:08.641014300 +0000
+@@ -17,6 +17,9 @@
  #include <sys/sysctl.h>
  #endif
  #include "internal/cryptlib.h"
-+#ifndef _WIN32
- #include <unistd.h>
--
-+#else
++#ifdef _WIN32
 +#include <windows.h>
 +#endif
+
  #include "arm_arch.h"

- unsigned int OPENSSL_armcap_P = 0;
+@@ -24,7 +27,25 @@
  unsigned int OPENSSL_arm_midr = 0;
  unsigned int OPENSSL_armv8_rsa_neonized = 0;

```