### PR TITLE
tiled: New package

### DIFF
--- a/mingw-w64-tiled/0001-tiled-1.9.2-windows-layout.patch
+++ b/mingw-w64-tiled/0001-tiled-1.9.2-windows-layout.patch
@@ -1,0 +1,158 @@
+diff --git a/qbs/imports/TiledPlugin.qbs b/qbs/imports/TiledPlugin.qbs
+index 6b835638b..a581b9b2c 100644
+--- a/qbs/imports/TiledPlugin.qbs
++++ b/qbs/imports/TiledPlugin.qbs
+@@ -37,7 +37,7 @@ DynamicLibrary {
+     Group {
+         qbs.install: true
+         qbs.installDir: {
+-            if (qbs.targetOS.contains("windows"))
++            if (project.windowsLayout)
+                 return "plugins/tiled"
+             else if (qbs.targetOS.contains("macos"))
+                 return "Tiled.app/Contents/PlugIns"
+diff --git a/qbs/imports/TiledQtGuiApplication.qbs b/qbs/imports/TiledQtGuiApplication.qbs
+index 9301573b4..b63c06cbb 100644
+--- a/qbs/imports/TiledQtGuiApplication.qbs
++++ b/qbs/imports/TiledQtGuiApplication.qbs
+@@ -29,7 +29,7 @@ QtGuiApplication {
+     Group {
+         qbs.install: true
+         qbs.installDir: {
+-            if (qbs.targetOS.contains("windows")) {
++            if (project.windowsLayout) {
+                 return "";
+             } else if (qbs.targetOS.contains("darwin")) {
+                 // Non-bundle applications are installed into the main Tiled.app bundle
+diff --git a/src/libtiled/libtiled.qbs b/src/libtiled/libtiled.qbs
+index c1d72ae74..104743512 100644
+--- a/src/libtiled/libtiled.qbs
++++ b/src/libtiled/libtiled.qbs
+@@ -37,6 +37,9 @@ DynamicLibrary {
+         if (project.staticZstd || pkgConfigZstd.found)
+             defs.push("TILED_ZSTD_SUPPORT");
+ 
++        if (project.windowsLayout)
++            defs.push("TILED_WINDOWS_LAYOUT");
++
+         return defs;
+     }
+     cpp.dynamicLibraries: {
+@@ -201,7 +204,10 @@ DynamicLibrary {
+         qbs.install: true
+         qbs.installDir: {
+             if (qbs.targetOS.contains("windows"))
+-                return ""
++                if (project.windowsLayout)
++                    return ""
++                else
++                    return "bin"
+             else
+                 return "lib"
+         }
+diff --git a/src/libtiled/pluginmanager.cpp b/src/libtiled/pluginmanager.cpp
+index 86a6bbd63..bfb2abd85 100644
+--- a/src/libtiled/pluginmanager.cpp
++++ b/src/libtiled/pluginmanager.cpp
+@@ -189,7 +189,7 @@ void PluginManager::loadPlugins()
+     QString pluginPath = QCoreApplication::applicationDirPath();
+ #endif
+ 
+-#if defined(Q_OS_WIN32)
++#if defined(TILED_WINDOWS_LAYOUT)
+     pluginPath += QStringLiteral("/plugins/tiled");
+ #elif defined(Q_OS_MAC)
+     pluginPath += QStringLiteral("/../PlugIns");
+diff --git a/src/libtiledquick/libtiledquick.qbs b/src/libtiledquick/libtiledquick.qbs
+index 656f146d1..f9cbb02d2 100644
+--- a/src/libtiledquick/libtiledquick.qbs
++++ b/src/libtiledquick/libtiledquick.qbs
+@@ -69,7 +69,10 @@ DynamicLibrary {
+         qbs.install: true
+         qbs.installDir: {
+             if (qbs.targetOS.contains("windows"))
+-                return ""
++                if (project.windowsLayout)
++                    return ""
++                else
++                    return "bin"
+             else
+                 return "lib"
+         }
+diff --git a/src/tiled/languagemanager.cpp b/src/tiled/languagemanager.cpp
+index 72979831d..2d7295da7 100644
+--- a/src/tiled/languagemanager.cpp
++++ b/src/tiled/languagemanager.cpp
+@@ -42,7 +42,7 @@ LanguageManager::LanguageManager()
+     , mAppTranslator(nullptr)
+ {
+     mTranslationsDir = QCoreApplication::applicationDirPath();
+-#if defined(Q_OS_WIN32)
++#if defined(TILED_WINDOWS_LAYOUT)
+     mTranslationsDir += QStringLiteral("/translations");
+ #elif defined(Q_OS_MAC)
+     mTranslationsDir += QStringLiteral("/../Translations");
+diff --git a/src/tiled/libtilededitor.qbs b/src/tiled/libtilededitor.qbs
+index 422df509d..1d707d7b5 100644
+--- a/src/tiled/libtilededitor.qbs
++++ b/src/tiled/libtilededitor.qbs
+@@ -52,6 +52,9 @@ DynamicLibrary {
+         if (project.snapshot)
+             defs.push("TILED_SNAPSHOT");
+ 
++        if (project.windowsLayout)
++            defs.push("TILED_WINDOWS_LAYOUT");
++
+         if (qbs.targetOS.contains("linux") && project.dbus && Qt.dbus.present)
+             defs.push("TILED_ENABLE_DBUS");
+ 
+@@ -596,7 +599,10 @@ DynamicLibrary {
+         qbs.install: true
+         qbs.installDir: {
+             if (qbs.targetOS.contains("windows"))
+-                return ""
++                if (project.windowsLayout)
++                    return ""
++                else
++                    return "bin"
+             else
+                 return "lib"
+         }
+diff --git a/src/tiledquick/tiledquick.qbs b/src/tiledquick/tiledquick.qbs
+index 832435244..5c72a3cc2 100644
+--- a/src/tiledquick/tiledquick.qbs
++++ b/src/tiledquick/tiledquick.qbs
+@@ -47,7 +47,7 @@ QtGuiApplication {
+         condition: !qbs.targetOS.contains("darwin")
+         qbs.install: true
+         qbs.installDir: {
+-            if (qbs.targetOS.contains("windows"))
++            if (project.windowsLayout)
+                 return ""
+             else
+                 return "bin"
+diff --git a/tiled.qbs b/tiled.qbs
+index 2ffb30fbb..059b06070 100644
+--- a/tiled.qbs
++++ b/tiled.qbs
+@@ -13,6 +13,7 @@ Project {
+     property bool installHeaders: false
+     property bool useRPaths: true
+     property bool windowsInstaller: false
++    property bool windowsLayout: qbs.targetOS.contains("windows")
+     property bool staticZstd: false
+     property bool sentry: false
+     property bool dbus: true
+diff --git a/translations/translations.qbs b/translations/translations.qbs
+index 52af2d080..81b49af71 100644
+--- a/translations/translations.qbs
++++ b/translations/translations.qbs
+@@ -18,7 +18,7 @@ Product {
+         fileTagsFilter: product.type
+         qbs.install: true
+         qbs.installDir: {
+-            if (qbs.targetOS.contains("windows"))
++            if (project.windowsLayout)
+                 return "translations"
+             else if (qbs.targetOS.contains("macos"))
+                 return "Tiled.app/Contents/Translations"

--- a/mingw-w64-tiled/PKGBUILD
+++ b/mingw-w64-tiled/PKGBUILD
@@ -1,0 +1,76 @@
+# Maintainer: Konstantin Podsvirov <konstantin@podsvirov.pro>
+
+_realname=tiled
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.9.2
+pkgrel=1
+pkgdesc='A general purpose tile map editor, built to be flexible and easy to use (mingw-w64)'
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64')
+url='https://www.mapeditor.org'
+license=('GPL')
+depends=("${MINGW_PACKAGE_PREFIX}-qt5-base"
+         "${MINGW_PACKAGE_PREFIX}-gtk-update-icon-cache"
+         "${MINGW_PACKAGE_PREFIX}-shared-mime-info"
+         "${MINGW_PACKAGE_PREFIX}-qt5-declarative"
+         "${MINGW_PACKAGE_PREFIX}-qt5-quickcontrols2"
+         "${MINGW_PACKAGE_PREFIX}-qt5-svg"
+         "${MINGW_PACKAGE_PREFIX}-zstd")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-qt5-tools"
+             #"${MINGW_PACKAGE_PREFIX}-python"
+             "${MINGW_PACKAGE_PREFIX}-qbs")
+optdepends=(#"${MINGW_PACKAGE_PREFIX}-python: Python plugin"
+            "${MINGW_PACKAGE_PREFIX}-qt5-imageformats: Support for additional image formats (including WebP)")
+source=("$_realname-$pkgver.tar.gz::https://github.com/mapeditor/tiled/archive/v${pkgver}.tar.gz"
+        '0001-tiled-1.9.2-windows-layout.patch')
+sha256sums=('6332db65acc867a53be3c2e700c7934cdb96bc1436f465212f55594af9b3d2aa'
+            '4797d052641417e514fad15cb335be94b55cc35d9aae76644831a048edfce211')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  
+  patch -Np1 -i "${srcdir}/0001-tiled-1.9.2-windows-layout.patch"
+}
+
+build() {
+  msg "Build for ${MSYSTEM}"
+
+  rm -rf build-${MSYSTEM} | true
+  cp -r "${srcdir}/${_realname}-${pkgver}" "${srcdir}/build-${MSYSTEM}"
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then
+    _profile=clang
+  else
+    _profile=mingw
+  fi
+
+  #export PYTHONHOME="${MINGW_PREFIX}"/bin
+  export MSYS2_ARG_CONV_EXCL="qbs.installPrefix:"
+
+  msg "Create profile $_profile"
+  "${MINGW_PREFIX}"/bin/qbs.exe setup-toolchains \
+    --type $_profile \
+    "${MINGW_PREFIX}"/bin/c++.exe $_profile
+
+  "${MINGW_PREFIX}"/bin/qbs.exe resolve \
+    profile:$_profile \
+    qbs.installPrefix:"${MINGW_PREFIX}" \
+    qbs.buildVariant:release \
+    projects.Tiled.windowsLayout:false \
+    projects.Tiled.installHeaders:true
+
+  "${MINGW_PREFIX}"/bin/qbs.exe build
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  "${MINGW_PREFIX}"/bin/qbs.exe install --install-root "${pkgdir}"
+
+  for _file in COPYING LICENSE.{APACHE,BSD,GPL}
+  do
+    install -Dm644 "${_file}" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/${_file}"
+  done
+}


### PR DESCRIPTION
With [Tiled](https://www.mapeditor.org/) we can make and edit levels, that can be read by [pytmx](https://packages.msys2.org/base/mingw-w64-python-pytmx) and rendered by [pygame](https://packages.msys2.org/base/mingw-w64-python-pygame).
And looks like it's will be first package in distro that use [qbs](https://packages.msys2.org/base/mingw-w64-qbs) for make.