### PR TITLE
Revert "binutils: update to 2.40"

### DIFF
--- a/mingw-w64-binutils/0110-binutils-mingw-gnu-print.patch
+++ b/mingw-w64-binutils/0110-binutils-mingw-gnu-print.patch
@@ -1,3 +1,16 @@
+diff --git a/binutils/dwarf.c b/binutils/dwarf.c
+index 1e7f4db7b7c..f33de2a649e 100644
+--- a/binutils/dwarf.c
++++ b/binutils/dwarf.c
+@@ -218,7 +218,7 @@ get_encoded_value (unsigned char **pdata,
+ }
+ 
+ #if SIZEOF_LONG_LONG > SIZEOF_LONG
+-# ifndef __MINGW32__
++# if !defined(__MINGW32__) || defined(__USE_MINGW_ANSI_STDIO)
+ #  define DWARF_VMA_FMT		"ll"
+ #  define DWARF_VMA_FMT_LONG	"%16.16llx"
+ # else
 diff --git a/binutils/strings.c b/binutils/strings.c
 index 44a8e1da644..4010829dc49 100644
 --- a/binutils/strings.c
@@ -33,7 +46,7 @@ diff --git a/gas/as.h b/gas/as.h
 index 14a768f8889..b1f056f115a 100644
 --- a/gas/as.h
 +++ b/gas/as.h
-@@ -433,14 +433,14 @@ typedef struct _pseudo_type pseudo_typeS;
+@@ -413,10 +413,10 @@ typedef struct _pseudo_type pseudo_typeS;
  
  #define PRINTF_LIKE(FCN) \
    void FCN (const char *format, ...) \
@@ -43,11 +56,6 @@ index 14a768f8889..b1f056f115a 100644
    void FCN (const char *file, unsigned int line, const char *format, ...) \
 -    __attribute__ ((__format__ (__printf__, 3, 4)))
 +    __attribute__ ((__format__ (gnu_printf, 3, 4)))
- #define PRINTF_INDENT_LIKE(FCN) \
-   void FCN (const char *file, unsigned int line, unsigned int indent, \
- 	    const char *format, ...) \
--    __attribute__ ((__format__ (__printf__, 4, 5)))
-+    __attribute__ ((__format__ (gnu_printf, 4, 5)))
  
  #else /* __GNUC__ < 2 || defined(VMS) */
  

--- a/mingw-w64-binutils/2001-ld-option-to-move-default-bases-under-4GB.patch
+++ b/mingw-w64-binutils/2001-ld-option-to-move-default-bases-under-4GB.patch
@@ -14,7 +14,7 @@ diff --git a/ld/emultempl/pep.em b/ld/emultempl/pep.em
 index c6fd8b8f8d9..312f8d6d566 100644
 --- a/ld/emultempl/pep.em
 +++ b/ld/emultempl/pep.em
-@@ -132,18 +132,26 @@ fragment <<EOF
+@@ -109,18 +109,26 @@ fragment <<EOF
  #define NT_EXE_IMAGE_BASE \
    ((bfd_vma) (${move_default_addr_high} ? 0x100400000LL \
  					: 0x140000000LL))
@@ -41,15 +41,15 @@ index c6fd8b8f8d9..312f8d6d566 100644
  #else
  #undef  NT_EXE_IMAGE_BASE
  #define NT_EXE_IMAGE_BASE \
-@@ -176,6 +184,7 @@ static int support_old_code = 0;
+@@ -153,6 +161,7 @@ static int support_old_code = 0;
  static lang_assignment_statement_type *image_base_statement = 0;
  static unsigned short pe_dll_characteristics = DEFAULT_DLL_CHARACTERISTICS;
  static bool insert_timestamp = true;
 +static bool high_default_bases = true;
  static const char *emit_build_id;
- #ifdef PDB_H
- static int pdb;
-@@ -310,7 +319,9 @@ enum options
+ 
+ #ifdef DLL_SUPPORT
+@@ -262,7 +271,9 @@ enum options
    OPTION_DISABLE_NO_SEH,
    OPTION_DISABLE_NO_BIND,
    OPTION_DISABLE_WDM_DRIVER,
@@ -60,7 +60,7 @@ index c6fd8b8f8d9..312f8d6d566 100644
  };
  
  static void
-@@ -402,6 +413,10 @@ gld${EMULATION_NAME}_add_options
+@@ -351,6 +362,10 @@ gld${EMULATION_NAME}_add_options
      {"disable-no-bind", no_argument, NULL, OPTION_DISABLE_NO_BIND},
      {"disable-wdmdriver", no_argument, NULL, OPTION_DISABLE_WDM_DRIVER},
      {"disable-tsaware", no_argument, NULL, OPTION_DISABLE_TERMINAL_SERVER_AWARE},
@@ -71,18 +71,18 @@ index c6fd8b8f8d9..312f8d6d566 100644
      {NULL, no_argument, NULL, 0}
    };
  
-@@ -538,6 +553,10 @@ gld${EMULATION_NAME}_list_options (FILE *file)
-   fprintf (file, _("  --[disable-]wdmdriver              Driver uses the WDM model\n"));
+@@ -488,6 +503,10 @@ gld_${EMULATION_NAME}_list_options (FILE *file)
    fprintf (file, _("  --[disable-]tsaware                Image is Terminal Server aware\n"));
    fprintf (file, _("  --build-id[=STYLE]                 Generate build ID\n"));
+ #endif
 +#if defined(TARGET_IS_i386pep) || ! defined(DLL_SUPPORT)
 +  fprintf (file, _("  --default-image-base-low           Default image bases under 4GB\n"));
 +  fprintf (file, _("  --default-image-base-high          Default image bases over  4GB\n"));
 +#endif
- #ifdef PDB_H
-   fprintf (file, _("  --pdb=[FILENAME]                   Generate PDB file\n"));
- #endif
-@@ -949,6 +968,12 @@ gld${EMULATION_NAME}_handle_option (int optc)
+ }
+ 
+ 
+@@ -895,6 +914,12 @@ gld${EMULATION_NAME}_handle_option (int optc)
        if (strcmp (optarg, "none"))
  	emit_build_id = xstrdup (optarg);
        break;
@@ -92,10 +92,10 @@ index c6fd8b8f8d9..312f8d6d566 100644
 +    case OPTION_DEFAULT_IMAGE_BASE_HIGH:
 +      high_default_bases = true;
 +      break;
- #ifdef PDB_H
-     case OPTION_PDB:
-       pdb = 1;
-@@ -995,7 +1020,14 @@ static bfd_vma
+     }
+ 
+   /*  Set DLLCharacteristics bits  */
+@@ -934,7 +959,14 @@ static bfd_vma
  compute_dll_image_base (const char *ofile)
  {
    bfd_vma hash = (bfd_vma) strhash (ofile);
@@ -111,7 +111,7 @@ index c6fd8b8f8d9..312f8d6d566 100644
  }
  #endif
  
-@@ -1020,13 +1052,25 @@ gld${EMULATION_NAME}_set_symbols (void)
+@@ -959,13 +991,25 @@ gld_${EMULATION_NAME}_set_symbols (void)
  #ifdef DLL_SUPPORT
  	  init[IMAGEBASEOFF].value = (pep_enable_auto_image_base
  				      ? compute_dll_image_base (output_filename)

--- a/mingw-w64-binutils/3001-Fix-a-conflict-between-the-linker-s-need-to-rename-s.patch
+++ b/mingw-w64-binutils/3001-Fix-a-conflict-between-the-linker-s-need-to-rename-s.patch
@@ -1,0 +1,334 @@
+From e6e9400d720e5451662550aa818e123a17b9230e Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Wed, 3 Aug 2022 13:31:57 +0100
+Subject: [PATCH] Fix a conflict between the linker's need to rename some PE
+ format input libraries and the BFD library's file caching mechanism.
+
+	PR 29389
+bfd	* bfd.c (BFD_CLOSED_BY_CACHE): New bfd flag.
+	* cache.c (bfd_cache_delete): Set BFD_CLOSED_BY_DELETE on the
+	closed bfd.
+	(bfd_cache_lookup_worker): Clear BFD_CLOSED_BY_DELETE on the newly
+	reopened bfd.
+	* opncls.c (bfd_set_filename): Refuse to change the name of a bfd
+	that has been closed by bfd_cache_delete.  Mark changed bfds as
+	uncacheable.
+	* bfd-in2.h: Regenerate.
+
+ld	* ldlang.h (lang_input_statement_struct): Add sort_key field.
+	* emultempl/pe.em (after_open): If multiple import libraries refer
+	to the same bfd, store their names in the sort_key field.
+	* emultempl/pep.em (after_open): Likewise.
+	* ldlang.c (sort_filename): New function.  Returns the filename to
+	be used when sorting input files.
+	(wild_sort): Use the sort_filename function.
+---
+ bfd/bfd-in2.h       |  2 ++
+ bfd/bfd.c           |  2 ++
+ bfd/cache.c         |  8 ++++++--
+ bfd/opncls.c        | 24 +++++++++++++++++++++---
+ ld/emultempl/pe.em  | 25 ++++++++++++++-----------
+ ld/emultempl/pep.em | 25 ++++++++++++++-----------
+ ld/ldlang.c         | 43 ++++++++++++++++++++++---------------------
+ ld/ldlang.h         |  2 ++
+ 8 files changed, 83 insertions(+), 48 deletions(-)
+
+diff --git a/bfd/bfd-in2.h b/bfd/bfd-in2.h
+index 8e815bab624..21561ea2a50 100644
+--- a/bfd/bfd-in2.h
++++ b/bfd/bfd-in2.h
+@@ -6654,6 +6654,8 @@ struct bfd
+   /* Put pathnames into archives (non-POSIX).  */
+ #define BFD_ARCHIVE_FULL_PATH  0x100000
+ 
++#define BFD_CLOSED_BY_CACHE    0x200000
++
+   /* Flags bits to be saved in bfd_preserve_save.  */
+ #define BFD_FLAGS_SAVED \
+   (BFD_IN_MEMORY | BFD_COMPRESS | BFD_DECOMPRESS | BFD_LINKER_CREATED \
+diff --git a/bfd/bfd.c b/bfd/bfd.c
+index a2f294da983..d9760536b90 100644
+--- a/bfd/bfd.c
++++ b/bfd/bfd.c
+@@ -176,6 +176,8 @@ CODE_FRAGMENT
+ .  {* Put pathnames into archives (non-POSIX).  *}
+ .#define BFD_ARCHIVE_FULL_PATH  0x100000
+ .
++.#define BFD_CLOSED_BY_CACHE    0x200000
++.
+ .  {* Flags bits to be saved in bfd_preserve_save.  *}
+ .#define BFD_FLAGS_SAVED \
+ .  (BFD_IN_MEMORY | BFD_COMPRESS | BFD_DECOMPRESS | BFD_LINKER_CREATED \
+diff --git a/bfd/cache.c b/bfd/cache.c
+index 8a6d359a789..73b68c7aff9 100644
+--- a/bfd/cache.c
++++ b/bfd/cache.c
+@@ -177,6 +177,7 @@ bfd_cache_delete (bfd *abfd)
+ 
+   abfd->iostream = NULL;
+   --open_files;
++  abfd->flags |= BFD_CLOSED_BY_CACHE;
+ 
+   return ret;
+ }
+@@ -265,10 +266,13 @@ bfd_cache_lookup_worker (bfd *abfd, enum cache_flag flag)
+ 	   && !(flag & CACHE_NO_SEEK_ERROR))
+     bfd_set_error (bfd_error_system_call);
+   else
+-    return (FILE *) abfd->iostream;
++    {
++      abfd->flags &= ~BFD_CLOSED_BY_CACHE;
++      return (FILE *) abfd->iostream;
++    }
+ 
+   /* xgettext:c-format */
+-  _bfd_error_handler (_("reopening %pB: %s\n"),
++  _bfd_error_handler (_("reopening %pB: %s"),
+ 		      abfd, bfd_errmsg (bfd_get_error ()));
+   return NULL;
+ }
+diff --git a/bfd/opncls.c b/bfd/opncls.c
+index f0ca9048f68..a5bc2de3648 100644
+--- a/bfd/opncls.c
++++ b/bfd/opncls.c
+@@ -2107,10 +2107,28 @@ bfd_set_filename (bfd *abfd, const char *filename)
+ {
+   size_t len = strlen (filename) + 1;
+   char *n = bfd_alloc (abfd, len);
+-  if (n)
++
++  if (n == NULL)
++    return NULL;
++
++  if (abfd->filename != NULL)
+     {
+-      memcpy (n, filename, len);
+-      abfd->filename = n;
++      /* PR 29389.  If we attempt to rename a file that has been closed due
++	 to caching, then we will not be able to reopen it later on.  */
++      if (abfd->iostream == NULL && (abfd->flags & BFD_CLOSED_BY_CACHE))
++	{
++	  bfd_set_error (bfd_error_invalid_operation);
++	  return NULL;
++	}
++
++      /* Similarly if we attempt to close a renamed file because the
++	 cache is now full, we will not be able to reopen it later on.  */
++      if (abfd->iostream != NULL)
++	abfd->cacheable = 0;
+     }
++
++  memcpy (n, filename, len);
++  abfd->filename = n;
++
+   return n;
+ }
+diff --git a/ld/emultempl/pe.em b/ld/emultempl/pe.em
+index 3c6a07e8e86..237d7c875c9 100644
+--- a/ld/emultempl/pe.em
++++ b/ld/emultempl/pe.em
+@@ -1583,6 +1583,7 @@ gld_${EMULATION_NAME}_after_open (void)
+ 		      {
+ 			struct bfd_symbol *s;
+ 			struct bfd_link_hash_entry * blhe;
++			bfd *other_bfd;
+ 			const char *other_bfd_filename;
+ 
+ 			s = (relocs[i]->sym_ptr_ptr)[0];
+@@ -1599,20 +1600,25 @@ gld_${EMULATION_NAME}_after_open (void)
+ 			    || blhe->type != bfd_link_hash_defined)
+ 			  continue;
+ 
++			other_bfd = blhe->u.def.section->owner;
++			if (other_bfd->my_archive == is->the_bfd->my_archive)
++			  continue;
++
+ 			other_bfd_filename
+-			  = blhe->u.def.section->owner->my_archive
+-			    ? bfd_get_filename (blhe->u.def.section->owner->my_archive)
+-			    : bfd_get_filename (blhe->u.def.section->owner);
++			  = (other_bfd->my_archive
++			     ? bfd_get_filename (other_bfd->my_archive)
++			     : bfd_get_filename (other_bfd));
+ 
+ 			if (filename_cmp (bfd_get_filename
+ 					    (is->the_bfd->my_archive),
+ 					  other_bfd_filename) == 0)
+ 			  continue;
+ 
+-			/* Rename this implib to match the other one.  */
+-			if (!bfd_set_filename (is->the_bfd->my_archive,
+-					       other_bfd_filename))
+-			  einfo ("%F%P: %pB: %E\n", is->the_bfd);
++			/* Sort this implib to match the other one.  */
++			lang_input_statement_type *arch_is
++			  = bfd_usrdata (is->the_bfd->my_archive);
++			arch_is->sort_key = other_bfd_filename;
++			break;
+ 		      }
+ 
+ 		    free (relocs);
+@@ -1719,10 +1725,7 @@ gld_${EMULATION_NAME}_after_open (void)
+ 		  = xmalloc (strlen (bfd_get_filename (is->the_bfd)) + 3);
+ 		sprintf (new_name, "%s.%c",
+ 			 bfd_get_filename (is->the_bfd), seq);
+-		is->filename = bfd_set_filename (is->the_bfd, new_name);
+-		free (new_name);
+-		if (!is->filename)
+-		  einfo ("%F%P: %pB: %E\n", is->the_bfd);
++		is->sort_key = new_name;
+ 	      }
+ 	  }
+       }
+diff --git a/ld/emultempl/pep.em b/ld/emultempl/pep.em
+index 848daa16746..dcfd7432bb1 100644
+--- a/ld/emultempl/pep.em
++++ b/ld/emultempl/pep.em
+@@ -1547,6 +1547,7 @@ gld_${EMULATION_NAME}_after_open (void)
+ 		      {
+ 			struct bfd_symbol *s;
+ 			struct bfd_link_hash_entry * blhe;
++			bfd *other_bfd;
+ 			const char *other_bfd_filename;
+ 
+ 			s = (relocs[i]->sym_ptr_ptr)[0];
+@@ -1563,20 +1564,25 @@ gld_${EMULATION_NAME}_after_open (void)
+ 			    || blhe->type != bfd_link_hash_defined)
+ 			  continue;
+ 
++			other_bfd = blhe->u.def.section->owner;
++			if (other_bfd->my_archive == is->the_bfd->my_archive)
++			  continue;
++
+ 			other_bfd_filename
+-			  = blhe->u.def.section->owner->my_archive
+-			    ? bfd_get_filename (blhe->u.def.section->owner->my_archive)
+-			    : bfd_get_filename (blhe->u.def.section->owner);
++			  = (other_bfd->my_archive
++			     ? bfd_get_filename (other_bfd->my_archive)
++			     : bfd_get_filename (other_bfd));
+ 
+ 			if (filename_cmp (bfd_get_filename
+ 					    (is->the_bfd->my_archive),
+ 					  other_bfd_filename) == 0)
+ 			  continue;
+ 
+-			/* Rename this implib to match the other one.  */
+-			if (!bfd_set_filename (is->the_bfd->my_archive,
+-					       other_bfd_filename))
+-			  einfo ("%F%P: %pB: %E\n", is->the_bfd);
++			/* Sort this implib to match the other one.  */
++			lang_input_statement_type *arch_is
++			  = bfd_usrdata (is->the_bfd->my_archive);
++			arch_is->sort_key = other_bfd_filename;
++			break;
+ 		      }
+ 
+ 		    free (relocs);
+@@ -1683,10 +1689,7 @@ gld_${EMULATION_NAME}_after_open (void)
+ 		  = xmalloc (strlen (bfd_get_filename (is->the_bfd)) + 3);
+ 		sprintf (new_name, "%s.%c",
+ 			 bfd_get_filename (is->the_bfd), seq);
+-		is->filename = bfd_set_filename (is->the_bfd, new_name);
+-		free (new_name);
+-		if (!is->filename)
+-		  einfo ("%F%P: %pB: %E\n", is->the_bfd);
++		is->sort_key = new_name;
+ 	      }
+ 	  }
+       }
+diff --git a/ld/ldlang.c b/ld/ldlang.c
+index df4c43ce9f4..64033038067 100644
+--- a/ld/ldlang.c
++++ b/ld/ldlang.c
+@@ -1125,6 +1125,7 @@ new_afile (const char *name,
+   p->flags.add_DT_NEEDED_for_regular = input_flags.add_DT_NEEDED_for_regular;
+   p->flags.whole_archive = input_flags.whole_archive;
+   p->flags.sysrooted = input_flags.sysrooted;
++  p->sort_key = NULL;
+ 
+   switch (file_type)
+     {
+@@ -2734,6 +2735,17 @@ lang_add_section (lang_statement_list_type *ptr,
+   new_section->pattern = pattern;
+ }
+ 
++/* PE puts the sort key in the input statement.  */
++
++static const char *
++sort_filename (bfd *abfd)
++{
++  lang_input_statement_type *is = bfd_usrdata (abfd);
++  if (is->sort_key)
++    return is->sort_key;
++  return bfd_get_filename (abfd);
++}
++
+ /* Handle wildcard sorting.  This returns the lang_input_section which
+    should follow the one we are going to create for SECTION and FILE,
+    based on the sorting requirements of WILD.  It returns NULL if the
+@@ -2773,28 +2785,17 @@ wild_sort (lang_wild_statement_type *wild,
+ 	     the archive and then the name of the file within the
+ 	     archive.  */
+ 
+-	  if (file->the_bfd != NULL
+-	      && file->the_bfd->my_archive != NULL)
+-	    {
+-	      fn = bfd_get_filename (file->the_bfd->my_archive);
+-	      fa = true;
+-	    }
++	  fa = file->the_bfd->my_archive != NULL;
++	  if (fa)
++	    fn = sort_filename (file->the_bfd->my_archive);
+ 	  else
+-	    {
+-	      fn = file->filename;
+-	      fa = false;
+-	    }
++	    fn = sort_filename (file->the_bfd);
+ 
+-	  if (ls->section->owner->my_archive != NULL)
+-	    {
+-	      ln = bfd_get_filename (ls->section->owner->my_archive);
+-	      la = true;
+-	    }
++	  la = ls->section->owner->my_archive != NULL;
++	  if (la)
++	    ln = sort_filename (ls->section->owner->my_archive);
+ 	  else
+-	    {
+-	      ln = bfd_get_filename (ls->section->owner);
+-	      la = false;
+-	    }
++	    ln = sort_filename (ls->section->owner);
+ 
+ 	  i = filename_cmp (fn, ln);
+ 	  if (i > 0)
+@@ -2805,9 +2806,9 @@ wild_sort (lang_wild_statement_type *wild,
+ 	  if (fa || la)
+ 	    {
+ 	      if (fa)
+-		fn = file->filename;
++		fn = sort_filename (file->the_bfd);
+ 	      if (la)
+-		ln = bfd_get_filename (ls->section->owner);
++		ln = sort_filename (ls->section->owner);
+ 
+ 	      i = filename_cmp (fn, ln);
+ 	      if (i > 0)
+diff --git a/ld/ldlang.h b/ld/ldlang.h
+index 0d057c9bee9..307488fa9dd 100644
+--- a/ld/ldlang.h
++++ b/ld/ldlang.h
+@@ -302,6 +302,8 @@ typedef struct lang_input_statement_struct
+      Usually the same as filename, but for a file spec'd with
+      -l this is the -l switch itself rather than the filename.  */
+   const char *local_sym_name;
++  /* Name to use when sorting.  */
++  const char *sort_key;
+   /* Extra search path. Used to find a file relative to the
+      directory of the current linker script.  */
+   const char *extra_search_path;
+-- 
+2.37.1
+

--- a/mingw-w64-binutils/PKGBUILD
+++ b/mingw-w64-binutils/PKGBUILD
@@ -5,37 +5,45 @@
 _realname=binutils
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.40
-pkgrel=1
+pkgver=2.39
+pkgrel=3
 pkgdesc="A set of programs to assemble and manipulate binary and object files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
 url="https://www.gnu.org/software/binutils/"
 license=('GPL')
 groups=("${MINGW_PACKAGE_PREFIX}-toolchain")
-depends=("${MINGW_PACKAGE_PREFIX}-zstd")
+depends=("${MINGW_PACKAGE_PREFIX}-libiconv"
+         "${MINGW_PACKAGE_PREFIX}-zlib")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools")
-source=(https://ftp.gnu.org/gnu/binutils/${_realname}-${pkgver}.tar.bz2{,.sig}
+options=('staticlibs' '!distcc' '!ccache')
+source=(https://ftp.gnu.org/gnu/binutils/${_realname}-${pkgver}.tar.xz{,.sig}
         0002-check-for-unusual-file-harder.patch
         0010-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch
         0110-binutils-mingw-gnu-print.patch
         2001-ld-option-to-move-default-bases-under-4GB.patch
         2003-Restore-old-behaviour-of-windres-so-that-options-con.patch
+        3001-Fix-a-conflict-between-the-linker-s-need-to-rename-s.patch
         reproducible-import-libraries.patch
         specify-timestamp.patch
+        "37513c1efbe5e8e1863f8ddf078cd395aa663388.patch::https://sourceware.org/git/?p=binutils-gdb.git;a=patch;h=37513c1efbe5e8e1863f8ddf078cd395aa663388"
+        "61f6b650f9bb7fd276b45427b9202f3263465376.patch::https://sourceware.org/git/?p=binutils-gdb.git;a=patch;h=61f6b650f9bb7fd276b45427b9202f3263465376"
         libiberty-unlink-handle-windows-nul.patch
         bfd-real-fopen-handle-windows-nul.patch
 )
-sha256sums=('f8298eb153a4b37d112e945aa5cb2850040bcf26a3ea65b5a715c83afe05e48a'
+sha256sums=('645c25f563b8adc0a81dbd6a41cffbf4d37083a382e02d5d3df4f65c09516d00'
             'SKIP'
             '2c99345fc575c3a060d6677537f636c6c4154fac0fde508070f3b6296c1060d4'
             '4e8ac055df61b1b5d6ae29dc87e1154737c2e87c7b244b44866702cabf1a5d18'
-            '5f3fc3949172d2d6e7cd595f9359077e012391a8c3c2aebc02e30fa656ded833'
-            '328ed91bdc9c729ab19f2a566d2d1cbb5ac1beb4775bd71d85e9777b4ed4c17a'
+            'de0a5fe11e75a2ea1bdb154670db028e2158ada74a17d6c67950464dc4e912e3'
+            '675ea7c58b8b3fc628ea85843ee7ca7fb10137c2d42dbd407f83002cb98ff22d'
             'd584f1cd9e94cba0e9b27625c4acc8ad5242cd625c9b44839d42fc116072568c'
+            '44ca688607d4e2dc1d7e70fee7803f3a0f4a0e10ad44c616c7c491cb6bfc90b9'
             'a094660ec95996c00b598429843b7869037732146442af567ada9f539bd40480'
             '27696da8ecfff307537a461b205fad44d6abc1fa648fbf839e72a1d3ea71c40a'
+            'b2f159fe91da6ca4f6c2d91dba09883d777533bc952898939ac8185aa712ef5c'
+            '3d1ab4038c28afb27bfa89702ec86ce5e1b852523aa0e550e1ad35d1452b7804'
             '7ccbd418695733c50966068fa9755a6abb156f53af23701d2bc097c63e9e0030'
             'dda1cf0c1825283a8b3708d1a4087dd650f4fbc3f8aa571e211cfe3e1458c8f8')
 validpgpkeys=('EAF1C276A747E9ED86210CBAC3126D3B4AE55E93'
@@ -64,6 +72,16 @@ prepare() {
 
   # https://github.com/msys2/MINGW-packages/pull/9233#issuecomment-889439433
   patch -R -p1 -i "${srcdir}/2003-Restore-old-behaviour-of-windres-so-that-options-con.patch"
+
+  # Backport from master:
+  # https://sourceware.org/bugzilla/show_bug.cgi?id=29389
+  apply_patch_with_msg "3001-Fix-a-conflict-between-the-linker-s-need-to-rename-s.patch"
+
+  # Backport from master:
+  # https://sourceware.org/pipermail/binutils/2022-July/121902.html
+  apply_patch_with_msg \
+    37513c1efbe5e8e1863f8ddf078cd395aa663388.patch \
+    61f6b650f9bb7fd276b45427b9202f3263465376.patch
 
   # patches for reproducibility from Debian:
   # https://salsa.debian.org/mingw-w64-team/binutils-mingw-w64/-/tree/master/debian/patches


### PR DESCRIPTION
This reverts commit 594c064fd4150f4fad50e1ec19f86af58e5357fd.

This breaks building a number of applications. Cf https://github.com/msys2/MINGW-packages/issues/15469