### PR TITLE
netcdf: update to 4.9.1

### DIFF
--- a/mingw-w64-netcdf/PKGBUILD
+++ b/mingw-w64-netcdf/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=netcdf
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.9.0
-pkgrel=7
+pkgver=4.9.1
+pkgrel=1
 pkgdesc="Interface for scientific data access to large binary data (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -21,7 +21,7 @@ checkdepends=("unzip")
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/Unidata/netcdf-c/archive/v${pkgver}.tar.gz"
         "0001-no-debug-libraries.patch"
         "0002-no-file.patch")
-sha256sums=('9f4cb864f3ab54adb75409984c6202323d2fc66c003e5308f3cdf224ed41c0a6'
+sha256sums=('4ee8d5f6b50a1eb4ad4c10f24531e36261fd1882410fb08435eb2ddfd49a0908'
             'a16300682b43de63bead0a42211b2219820599a6eb3d60bc83c27f85a1c64711'
             'd6f566945c232f78cce680ddc235c178fc1c5a41e5b8eee067f5b9251e2ea81e')
 
@@ -56,6 +56,8 @@ build() {
   msg2 "Building static libraries"
   mkdir -p "${srcdir}"/build-static-${MSYSTEM} && cd "${srcdir}"/build-static-${MSYSTEM}
 
+  # Disable BYTERANGE because that feature doesn't build with HDF5 1.14 in netCDF 4.9.1
+  # It was disabled by default in netCDF 4.9.0
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   "${MINGW_PREFIX}"/bin/cmake.exe \
     -G"MSYS Makefiles" \
@@ -67,6 +69,7 @@ build() {
     -DENABLE_DAP_REMOTE_TESTS=OFF \
     -DENABLE_DAP=ON \
     -DENABLE_NETCDF_4=ON \
+    -DENABLE_BYTERANGE=OFF \
     -Wno-dev \
     "${srcdir}/${_realname}-c-${pkgver}"
   "${MINGW_PREFIX}"/bin/cmake.exe --build .
@@ -74,6 +77,8 @@ build() {
   msg2 "Building shared libraries"
   mkdir -p "${srcdir}"/build-shared-${MSYSTEM} && cd "${srcdir}"/build-shared-${MSYSTEM}
 
+  # Disable BYTERANGE because that feature doesn't build with HDF5 1.14 in netCDF 4.9.1
+  # It was disabled by default in netCDF 4.9.0
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   "${MINGW_PREFIX}"/bin/cmake.exe \
     -G"MSYS Makefiles" \
@@ -85,6 +90,7 @@ build() {
     -DENABLE_DAP_REMOTE_TESTS=OFF \
     -DENABLE_DAP=ON \
     -DENABLE_NETCDF_4=ON \
+    -DENABLE_BYTERANGE=OFF \
     -DENABLE_LOGGING=ON \
     -Wno-dev \
     "${srcdir}/${_realname}-c-${pkgver}"
@@ -93,8 +99,8 @@ build() {
 
 check() {
   cd "${srcdir}/build-static-${MSYSTEM}"
-  "${MINGW_PREFIX}"/bin/cmake.exe -DENABLE_TESTS ../${_realname}-c-${pkgver}
-  "${MINGW_PREFIX}"/bin/cmake.exe ---build .
+  "${MINGW_PREFIX}"/bin/cmake.exe -DENABLE_TESTS=ON ../${_realname}-c-${pkgver}
+  "${MINGW_PREFIX}"/bin/cmake.exe --build .
   ctest
 }
 


### PR DESCRIPTION
The BYTERANGE feature is enabled by default in netCDF 4.9.1. It was disabled by default in version 4.9.0.
That feature doesn't compile with HDF5 1.14. (It uses parts of the API that changed between version 1.12 and 1.14, and hasn't been updated for the newer API yet.)
Disabling it now doesn't mean that we no longer build a feature that we had before. (We never built it afaict.) But it allows building the remainder of the new version.
