### PR TITLE
gcc: Install libssp.dll.a to lib folder

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -24,7 +24,7 @@ pkgver=12.2.0
 #_majorver=${pkgver:0:1}
 #_sourcedir=${_realname}-${_majorver}-${_snapshot}
 _sourcedir=${_realname}-${pkgver}
-pkgrel=10
+pkgrel=11
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -380,6 +380,7 @@ package_gcc() {
   # cp lib/libvtv*                                         ${pkgdir}${MINGW_PREFIX}/lib/
   cp lib/libstdc++*                                      ${pkgdir}${MINGW_PREFIX}/lib/
   cp lib/libsupc++*                                      ${pkgdir}${MINGW_PREFIX}/lib/
+  cp lib/libssp.dll.a                                    ${pkgdir}${MINGW_PREFIX}/lib/
 
   #mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/lib
   #cp ${srcdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/lib/libgcc_s.a ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/


### PR DESCRIPTION
When working Julia master branch, I saw it wanted "libssp.dll.a". So, I added it to GCC package which has the shared libssp DLL from GCC libs split package. The static libssp was from the CRT package; so, I did not add them to this package.

Tim S.