### PR TITLE
Vala: update to v0.56.4

### DIFF
--- a/mingw-w64-vala/PKGBUILD
+++ b/mingw-w64-vala/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=vala
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.56.3
-pkgrel=2
+pkgver=0.56.4
+pkgrel=1
 pkgdesc="Compiler for the GObject type system (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -19,7 +19,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-glib2"
          "${MINGW_PACKAGE_PREFIX}-graphviz")
 source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz
         0001-relocate-plugin-path.patch)
-sha256sums=('e1066221bf7b89cb1fa7327a3888645cb33b604de3bf45aa81132fd040b699bf'
+sha256sums=('862c41d938543ed3d8d86c8219a61087797193defee8da0c50caf49993c66b6a'
             '266756afe0fa2871800e2d4cbf5db5c9e9e68abd52f7f694f077c7e425bc2772')
 
 prepare() {


### PR DESCRIPTION
This minor version has some specific fix for windows platform, [see also the vala's release note](https://gitlab.gnome.org/GNOME/vala/-/commit/fbf513c52806e253b3dde68f477e1eca8ac38cd1).