### PR TITLE
kicad: depend on wxWidgets 3.2

### DIFF
--- a/mingw-w64-kicad/PKGBUILD
+++ b/mingw-w64-kicad/PKGBUILD
@@ -5,11 +5,11 @@
 # updating this build rule
 
 _realname=kicad
-_wx_basever=3.1
+_wx_basever=3.2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=6.0.11
-pkgrel=1
+pkgrel=2
 pkgdesc="Software for the creation of electronic schematic diagrams and printed circuit board artwork (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')

--- a/mingw-w64-waf/0001-timeout-at-wait-after-kill.patch
+++ b/mingw-w64-waf/0001-timeout-at-wait-after-kill.patch
@@ -1,0 +1,18 @@
+For an unknown reason, python is stuck indefinitely on Popen.wait() after
+the proceses has finished. Add an (arbitrary) timeout of 10 seconds.
+
+diff -urN waf-2.0.25/waflib/Utils.py.orig waf-2.0.25/waflib/Utils.py
+--- waf-2.0.25/waflib/Utils.py.orig	2023-01-01 14:48:32.898348000 +0100
++++ waf-2.0.25/waflib/Utils.py	2023-02-13 18:46:20.965541100 +0100
+@@ -1042,7 +1042,10 @@
+ 		except OSError:
+ 			pass
+ 		else:
+-			k.wait()
++			try:
++				k.wait(10)
++			except Exception:
++				pass
+ # see #1889
+ if (sys.hexversion<0x207000f and not is_win32) or sys.hexversion>=0x306000f:
+ 	atexit.register(atexit_pool)

--- a/mingw-w64-waf/PKGBUILD
+++ b/mingw-w64-waf/PKGBUILD
@@ -3,27 +3,39 @@
 _realname=waf
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.0.20
-pkgrel=6
+pkgver=2.0.25
+pkgrel=1
 pkgdesc="General-purpose build system modelled after Scons (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
-license=('BSD')
+license=('spdx:BSD-3-Clause')
 url="https://waf.io/"
-makedepends=("setconf" "${MINGW_PACKAGE_PREFIX}-cc")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
 depends=("${MINGW_PACKAGE_PREFIX}-python")
 options=('!emptydirs')
-source=("https://waf.io/${_realname}-${pkgver}.tar.bz2"{,.asc})
-validpgpkeys=('8AF22DE5A06822E3474F3C7049B4C67C05277AAA')
-sha256sums=('cce635c2d1a0f93b4f5b811e0452a35b8066e8ccd78632447f5be24c4c3f1a63'
-            'SKIP')
+source=("https://waf.io/${_realname}-${pkgver}.tar.bz2"{,.asc}
+        "0001-timeout-at-wait-after-kill.patch")
+validpgpkeys=('8AF22DE5A06822E3474F3C7049B4C67C05277AAA'
+              '0B3972B2D9E32EAB423D2E0F22BE0C62FFBFA548') # "Thomas Nagy <tnagy@waf.io>"
+sha256sums=('66cff7beed0e77db874e9232cc08874abb3e866c7f0f1f34ba2f959fde44fdd4'
+            'SKIP'
+            '45239bbe8a12f6a0991ca9f4c6ddffb1b9f641199b6c5ab0d9abe038873f2b19')
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Np1 -i "${srcdir}/$_patch"
+  done
+}
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
-  # Extracting license
+  # Extract license
   head -n 30 waf-light | tail -n 25 > LICENSE
-  # Python 3 fix
-  sed -i '0,/env python/s//python/' waf-light
+
+  apply_patch_with_msg \
+    0001-timeout-at-wait-after-kill.patch
 }
 
 build() {
@@ -49,19 +61,19 @@ EOF
     --tools='compat,compat15,ocaml,go,cython,scala,erlang,cuda,gcj,boost,pep8,eclipse,unity,clang_compilation_database'
 
   install -Dm755 waf "${pkgdir}${MINGW_PREFIX}/bin/waf"
+  install -Dm755 waf.bat "${pkgdir}${MINGW_PREFIX}/bin/waf.bat"
 
   # Force the generation of .waf.admin files
-  cd demos/c
-  "${pkgdir}${MINGW_PREFIX}/bin/waf" configure build >& /dev/null
-  cd ../..
+  cd "${srcdir}/${_realname}-${pkgver}/demos/c"
+  CC_NAME=${CC} CC="${MINGW_PREFIX}/bin/${CC}.exe" \
+  CXX_NAME=${CXX} CXX="${MINGW_PREFIX}/bin/${CXX}.exe" \
+  "${pkgdir}${MINGW_PREFIX}/bin/waf" configure build
 
   # Fix weird directory placement (FS#38216, FS#38300)
   mkdir -p "${pkgdir}${MINGW_PREFIX}/lib/waf"
-  mv "${pkgdir}${MINGW_PREFIX}/bin/.waf3-${pkgver}-"* "${pkgdir}${MINGW_PREFIX}/lib/waf/"
-  setconf "${pkgdir}${MINGW_PREFIX}/bin/waf" base '"${MINGW_PREFIX}/lib/waf"'
+  mv "${pkgdir}${MINGW_PREFIX}/bin/waf3-${pkgver}-"* "${pkgdir}${MINGW_PREFIX}/lib/waf/"
+  sed -s "s|INSTALL=''|INSTALL='${MINGW_PREFIX}/lib/waf'|g" -i "${pkgdir}${MINGW_PREFIX}/bin/waf"
 
-  # Fix shebang line
-  sed -e "s|/usr/bin/python|${MINGW_PREFIX}/bin/python|g" -i "${pkgdir}${MINGW_PREFIX}/bin/waf"
-
+  cd "${srcdir}/${_realname}-${pkgver}"
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-wxPython/301-Revert-some-of-python-sip-changes.patch
+++ b/mingw-w64-wxPython/301-Revert-some-of-python-sip-changes.patch
@@ -10,89 +10,6 @@ Subject: Revert some of sip via python changes
  wscript              |  7 ++++++
  4 files changed, 38 insertions(+), 27 deletions(-)
 
-diff --git a/build.py b/build.py
-index b0c8f122..32891945 100755
---- a/build.py
-+++ b/build.py
-@@ -46,7 +46,6 @@ from buildtools.config  import Config, msg, opj, posixjoin, loadETG, etg2sip, fi
-                                getVcsRev, runcmd, textfile_open, getSipFiles, \
-                                getVisCVersion, getToolsPlatformName, updateLicenseFiles, \
-                                TemporaryDirectory, getMSVCInfo
--from buildtools.wxpysip import sip_runner
- 
- import buildtools.version as version
- 
-@@ -89,6 +88,14 @@ wxICON = 'packaging/docset/mondrian.png'
- 
- # Some tools will be downloaded for the builds. These are the versions and
- # MD5s of the tool binaries currently in use.
-+sipCurrentVersion = '4.19.24'
-+sipMD5 = {
-+    'darwin'   : '2a22cb7a35eb14384b0829593a366c29',
-+    'win32'    : '49e0aa36397d7629fea95418452961fb',
-+    'linux32'  : 'ea773f6fd92d5f23530730428a86df2f',
-+    'linux64'  : 'b44a45191f5f84db10e2ba1c4cecd8ff',
-+}
-+
- wafCurrentVersion = '2.0.22'
- wafMD5 = 'f2e5880ba4ecd06f7991181bdba1138b'
- 
-@@ -629,6 +636,15 @@ def getTool(cmdName, version, MD5, envVar, platformBinary, linuxBits=False):
- 
- # The download and MD5 check only needs to happen once per run, cache the sip
- # cmd value here the first time through.
-+_sipCmd = None
-+def getSipCmd():
-+    global _sipCmd
-+    if _sipCmd is None:
-+        _sipCmd = getTool('sip', sipCurrentVersion, sipMD5, 'SIP', True, True)
-+    return _sipCmd
-+
-+
-+# Same thing for WAF
- _wafCmd = None
- def getWafCmd():
-     global _wafCmd
-@@ -1265,30 +1281,15 @@ def cmd_sip(options, args):
-         if not newer_group(sipFiles, sbf) and os.path.exists(pycode):
-             continue
- 
--        # Leave it turned off for now. TODO: Experiment with this...
--        # pyi_extract = posixjoin(cfg.PKGDIR, base[1:]) + '.pyi'
--        pyi_extract = None
--
--        # SIP extracts are used to pull python snippets and put them into the
--        # module's .py file
--        pycode = 'pycode'+base+':'+pycode
--
--        sip_runner(src_name,
--            abi_version = cfg.SIP_ABI,  # siplib abi version
--            warnings = True,            # enable warning messages
--            docstrings = True,          # enable the automatic generation of docstrings
--            release_gil = True,         # always release and reacquire the GIL
--            sip_module = 'wx.siplib',   # the fully qualified name of the sip module
--            sbf_file=sbf,               # File to write the generated file lists to
--            exceptions = False,         # enable support for exceptions
--            tracing = cfg.SIP_TRACE,    # generate code with tracing enabled
--            sources_dir = tmpdir,       # the name of the code directory
--            extracts = [pycode],        # add <ID:FILE> to the list of extracts to generate
--            pyi_extract=pyi_extract,    # the name of the .pyi stub file
--            include_dirs = [
--                os.path.join(phoenixDir(), 'src'),
--                os.path.join(phoenixDir(), 'sip', 'gen'),
--            ])
-+        # leave this turned off for now...
-+        # typehint = '-y {}'.format(posixjoin(cfg.PKGDIR, base[1:]) + '.pyi')
-+        typehint = ''
-+
-+        pycode = '-X pycode'+base+':'+pycode
-+        sip = getSipCmd()
-+        cmd = '%s %s -c %s -b %s %s %s %s'  % \
-+            (sip, cfg.SIPOPTS, tmpdir, sbf, pycode, typehint, src_name)
-+        runcmd(cmd)
- 
- 
-         classesNeedingClassInfo = { 'sip_corewxTreeCtrl.cpp' : 'wxTreeCtrl', }
 diff --git a/buildtools/config.py b/buildtools/config.py
 index 4482ba9d..bc46412a 100644
 --- a/buildtools/config.py
@@ -133,7 +50,16 @@ diff --git a/wscript b/wscript
 index 4f0d0bf5..9ec28673 100644
 --- a/wscript
 +++ b/wscript
-@@ -302,6 +302,13 @@ def configure(conf):
+@@ -33,7 +33,7 @@
+ 
+ 
+ def options(opt):
+-    if isWindows:
++    if False:
+         opt.load('msvc')
+     opt.load('compiler_c compiler_cxx')
+     opt.load('python')
+@@ -308,6 +308,13 @@
          conf.env.CFLAGS_WXPY.append('-UNDEBUG')
          conf.env.CXXFLAGS_WXPY.append('-UNDEBUG')
  
@@ -147,4 +73,3 @@ index 4f0d0bf5..9ec28673 100644
          # Add basic debug info for all builds
          conf.env.CFLAGS_WXPY.append('-g')
          conf.env.CXXFLAGS_WXPY.append('-g')
--- 

--- a/mingw-w64-wxPython/PKGBUILD
+++ b/mingw-w64-wxPython/PKGBUILD
@@ -2,11 +2,11 @@
 # Contributor: Tim Stahlhut <stahta01@gmail.com>
 
 _realname=wxPython
-_wx_basever=3.1
+_wx_basever=3.2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.1.2a1.dev5434+7d45ee6a
-pkgrel=2
+pkgver=4.2.0
+pkgrel=1
 pkgdesc="A wxWidgets GUI toolkit for Python (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -19,28 +19,23 @@ depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-six"
          "${MINGW_PACKAGE_PREFIX}-wxmsw${_wx_basever}")
 makedepends=("${MINGW_PACKAGE_PREFIX}-doxygen"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-requests"
-             "${MINGW_PACKAGE_PREFIX}-sip4"
+             "${MINGW_PACKAGE_PREFIX}-sip"
              "${MINGW_PACKAGE_PREFIX}-waf"
              "${MINGW_PACKAGE_PREFIX}-cc"
              # for waf
              "python" "python-setuptools")
 options=('strip' 'staticlibs' 'buildflags')
 source=(#"https://files.pythonhosted.org/packages/b0/4d/80d65c37ee60a479d338d27a2895fb15bbba27a3e6bb5b6d72bb28246e99/${_realname}-${pkgver}.tar.gz"
-        "https://wxpython.org/Phoenix/snapshot-builds/${_realname}-${pkgver}.tar.gz"
+        "https://github.com/wxWidgets/Phoenix/releases/download/${_realname}-${pkgver}/${_realname}-${pkgver}.tar.gz"
         '201-Remove-obsolete-entries-from-Doxyfile.patch'
         '301-Revert-some-of-python-sip-changes.patch')
-noextract=("${_realname}-${pkgver}.tar.gz")
-sha256sums=('9ab0b6a42d6bb6eacd45ba70f0e9940af56e1711596374c72b4a9110761e36db'
+sha256sums=('03452bf02f182fae78c030ac12aadedb0c5a5b63257b887dfe5689f028730984'
             '97b5c9dd353f2c570b7a940585868c1127d10a96a3442cd96706359410494aa8'
-            '84f836f22f4bbe3f0644040188997fe82ad8db2d4ece6ae081f99d405aff7aa5')
+            '50feb203bcbee757adb844c970ecadebe3dbbab2114cab88988b79464663347f')
 
 prepare() {
-  plain "Extracting ${_realname}-${pkgver}.tar.gz due to symlink(s) without pre-existing target(s)"
-  cd "${srcdir}"
-  [[ -d ${_realname}-${pkgver} ]] && rm -rf ${_realname}-${pkgver}
-  tar zxf "${srcdir}/${_realname}-${pkgver}.tar.gz" || true
-
   cd "${srcdir}/${_realname}-${pkgver}"
   rm -f etg/{_,}webkit.py sip/gen/{_,}webkit.sip
 
@@ -65,23 +60,27 @@ build() {
   SIP="${MINGW_PREFIX}/bin/sip" \
   DOXYGEN="${MINGW_PREFIX}/bin/doxygen" \
   WX_CONFIG="${MINGW_PREFIX}/bin/wx-config-${_wx_basever}" \
-    "${MINGW_PREFIX}/bin/python" build.py \
-      --prefix="${MINGW_PREFIX}" --python="${MINGW_PREFIX}/bin/python.exe" \
-      --release --use_syswx --no_msedge --nodoc --cairo -vv \
-      --no_allmo --no_magic --regenerate_sysconfig \
-        dox touch etg sip
+  ${MINGW_PREFIX}/bin/python -m build \
+    --prefix="${MINGW_PREFIX}" --python="${MINGW_PREFIX}/bin/python.exe" \
+    --release --use_syswx --no_msedge --nodoc --cairo -vv \
+    --no_allmo --no_magic --regenerate_sysconfig \
+    dox touch etg sip
 
   local _jobs=${MAKEFLAGS:--j1}
+  # Use MSYS2 Python because, with mingw-w64 Python, waf has issues using
+  # the wx-config* shell script.
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  CC_NAME=${CC} CXX_NAME=${CXX} \
-  LDFLAGS="${LDFLAGS} $(python-config --ldflags)" \
+  CC_NAME=${CC} CC="${MINGW_PREFIX}/bin/${CC}.exe" \
+  CXX_NAME=${CXX} CXX="${MINGW_PREFIX}/bin/${CXX}.exe" \
+  LDFLAGS="${LDFLAGS} $("${MINGW_PREFIX}/bin/python-config" --ldflags)" \
   PYTHON_CONFIG="${MINGW_PREFIX}/bin/python-config" \
-    "${MINGW_PREFIX}/bin/waf" \
-      --prefix="${MINGW_PREFIX}" --python="${MINGW_PREFIX}/bin/python.exe" \
-      --check-cxx-compiler=${CXX} --check-c-compiler=${CC} --color=yes --jobs=${_jobs#-j} \
-      --wx_config=wx-config-${_wx_basever} \
-      --no_magic --nopyc --nopyo --nopycache \
-        configure build
+  /usr/bin/python "${MINGW_PREFIX}/bin/waf" \
+    --prefix="${MINGW_PREFIX}" --python="${MINGW_PREFIX}/bin/python.exe" \
+    --no_msvc --check-c-compiler=${CC} --check-cxx-compiler=${CXX} \
+    --color=yes --jobs=${_jobs#-j} \
+    --wx_config="sh.exe ${MINGW_PREFIX}/bin/wx-config-${_wx_basever}" \
+    --no_magic --nopyc --nopyo --nopycache \
+    configure build
 }
 
 package() {


### PR DESCRIPTION
This PR updates the wxWidgets dependency of Kicad to version 3.2.
To avoid conflicts, wxPython also needs to depend on wxWidgets 3.2 for this to work. The alpha tarball from which wxPython was built the last time is no longer available. So, I updated to the latest stable release wxPython (Phoenix) 4.2.0.

IIUC, these are the last dependers on wxWidgets 3.1. Afaict, that was (only) a development version that we needed intermediately to build some package (Kicad?). @MehdiChinoune already moved all other dependent packages to wxWidgets 3.2 afaict. `wxWidgets3.1` can probably be removed if this PR is merged. (I can also remove it as part of this PR if you prefer.)

`waf` (that is used as a build tool for wxPython) has troubles calling the `wx-config` shell script when using a mingw Python. It works when using the MSYS2 Python (but needs some hints to correctly detect the C and C++ compilers). Additionally, it gets stuck when waiting for a pipe to close. I added a patch with a dirty workaround to just ignore that after a timeout.
I tried to update `waf` to the latest version to check if those issues are resolved. But it turned out to still be the same. I kept the waf update in this PR anyway (although it is not strictly needed - but the patch with the workaround is needed anyway).