### PR TITLE
add package for Lua5.3

### DIFF
--- a/mingw-w64-lua53/LICENSE
+++ b/mingw-w64-lua53/LICENSE
@@ -1,0 +1,30 @@
+License
+
+Lua is free software distributed under the terms of the MIT license
+reproduced below; it may be used for any purpose, including commercial
+purposes, at absolutely no cost without having to ask us. The only
+requirement is that if you do use Lua, then you should give us credit
+by including the appropriate copyright notice somewhere in your
+product or its documentation.
+
+    Copyright © 1994–2015 Lua.org, PUC-Rio.
+
+    Permission is hereby granted, free of charge, to any person
+    obtaining a copy of this software and associated documentation
+    files (the "Software"), to deal in the Software without
+    restriction, including without limitation the rights to use, copy,
+    modify, merge, publish, distribute, sublicense, and/or sell copies
+    of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions: 
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software. 
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.  

--- a/mingw-w64-lua53/PKGBUILD
+++ b/mingw-w64-lua53/PKGBUILD
@@ -85,7 +85,11 @@ package() {
   install -Dm644 lua.pc "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/lua5.3.pc
 
   # Install the documentation
-  install -d "${pkgdir}${MINGW_PREFIX}"/share/doc/lua
-  install -m644 doc/*.{gif,png,css,html} "${pkgdir}${MINGW_PREFIX}"/share/doc/lua
+  install -d "${pkgdir}${MINGW_PREFIX}"/share/doc/$_realname
+  install -m644 doc/*.{gif,png,css,html} "${pkgdir}${MINGW_PREFIX}"/share/doc/$_realname
   install -Dm644 ../LICENSE "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+
+  cd "${pkgdir}${MINGW_PREFIX}"/share/man/man1
+  mv lua.1 lua5.3.1
+  mv luac.1 luac5.3.1
 }

--- a/mingw-w64-lua53/PKGBUILD
+++ b/mingw-w64-lua53/PKGBUILD
@@ -1,0 +1,91 @@
+# Maintainer: Jakob Wenzel <wenzel@neobotix.de>
+# Contributor: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: David Macek <david.macek.0@gmail.com>
+# Contributor: Felix Huettner <huettner94@gmx.de>
+
+_realname=lua53
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=5.3.6
+pkgrel=1
+pkgdesc="A powerful light-weight programming language designed for extending applications. Version 5.3.x (mingw-w64)"
+arch=('any')
+url="https://www.lua.org/"
+license=('MIT')
+depends=('winpty')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+options=('staticlibs' 'strip' 'emptydirs')
+source=("${url}/ftp/lua-${pkgver}.tar.gz"
+        'lua.pc'
+        'searchpath.patch'
+        'implib.patch'
+        'LICENSE')
+sha256sums=('fc5fd69bb8736323f026672b1b7235da613d7177e72558893a0bdcd320466d60'
+            'ca9252633e782b8f85d6a94ea4f6babd4fe30bd759085b373160b1878e36ff78'
+            '3a915911ae680ac3670d6bf96973799baaa7d9c58e6003878eb4369983acc0db'
+            '744cb6bf6fb96ef65ee103d917eac679c983b6c02b7e643ba5b985d41b86aa87'
+            '142fb08b41a807b192b4b2c166696a1830a1c97967e5099ad0e579bf500e1da4')
+
+prepare() {
+  cd "${srcdir}/lua-${pkgver}"
+  cp "${srcdir}/lua.pc" .
+  sed -r -e '/^LUA_(SO|A|T)=/ s/lua/lua5.3/' \
+    -e '/^LUAC_T=/ s/luac/luac5.3/' \
+    -e 's/lua.exe/lua5.3.exe/' \
+    -e 's/luac.exe/luac5.3.exe/' \
+    -e 's/luac.exe/luac5.3.exe/' \
+    -i src/Makefile
+  patch -p0 -i "${srcdir}/implib.patch"
+  patch -p1 -i "${srcdir}/searchpath.patch"
+}
+
+build() {
+  [[ -d "${srcdir}/build-${CARCH}" ]] && rm -rf "${srcdir}/build-${CARCH}"
+  cp -rf "${srcdir}/lua-${pkgver}" "${srcdir}/build-${CARCH}"
+  cd "${srcdir}/build-${CARCH}"
+  sed -e "s|%VER%|${pkgver%.*}|g;s|%REL%|${pkgver}|g" \
+    -e 's:llua:llua5.3:' \
+    -e 's:/include:/include/lua5.3:' \
+    -e "s|/usr|${MINGW_PREFIX}|g" \
+    -i lua.pc
+
+  make -j1 \
+    AR="ar rcu" \
+    RANLIB="ranlib" \
+    STRIP="strip" \
+    CC="${MINGW_CHOST}-gcc" \
+    mingw
+}
+
+package() {
+  cd "${srcdir}/build-${CARCH}"
+  make \
+    TO_BIN="lua5.3.exe luac5.3.exe lua53.dll" \
+    TO_LIB="liblua5.3.a liblua5.3.dll.a" \
+    INSTALL_TOP="${pkgdir}${MINGW_PREFIX}" \
+    INSTALL_INC="${pkgdir}${MINGW_PREFIX}"/include/lua5.3 \
+    INSTALL_MAN="${pkgdir}${MINGW_PREFIX}"/share/man/man1 \
+    install
+
+  # Use winpty to wrap the exe when executed from bash. Please don't move this into a patch as hopefully one day we won't need this hack.
+  local _exename="lua5.3"
+  local _execname="luac5.3"
+  #handle lua.exe and make lua script and symlink equivilant
+  mv "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}.exe "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}_exe
+  echo "#!/usr/bin/env bash" > "${pkgdir}${MINGW_PREFIX}/bin/${_exename}"
+  echo '/usr/bin/winpty "$( dirname ${BASH_SOURCE[0]} )/'${_exename}'.exe" "$@"' >> "${pkgdir}${MINGW_PREFIX}/bin/${_exename}"
+  mv "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}_exe "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}.exe
+
+  #handle luac.exe and make luac script and symlink equivilant
+  mv "${pkgdir}"${MINGW_PREFIX}/bin/${_execname}.exe "${pkgdir}"${MINGW_PREFIX}/bin/${_execname}_exe
+  echo "#!/usr/bin/env bash" > "${pkgdir}${MINGW_PREFIX}/bin/${_execname}"
+  echo '/usr/bin/winpty "$( dirname ${BASH_SOURCE[0]} )/'${_execname}'.exe" "$@"' >> "${pkgdir}${MINGW_PREFIX}/bin/${_execname}"
+  mv "${pkgdir}"${MINGW_PREFIX}/bin/${_execname}_exe "${pkgdir}"${MINGW_PREFIX}/bin/${_execname}.exe
+
+  install -Dm644 lua.pc "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/lua5.3.pc
+
+  # Install the documentation
+  install -d "${pkgdir}${MINGW_PREFIX}"/share/doc/lua
+  install -m644 doc/*.{gif,png,css,html} "${pkgdir}${MINGW_PREFIX}"/share/doc/lua
+  install -Dm644 ../LICENSE "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+}

--- a/mingw-w64-lua53/implib.patch
+++ b/mingw-w64-lua53/implib.patch
@@ -1,0 +1,11 @@
+--- src/Makefile.orig	2023-02-15 08:58:22.205723900 +0100
++++ src/Makefile	2023-02-15 09:01:51.544746000 +0100
+@@ -114,7 +114,7 @@
+ 
+ mingw:
+ 	$(MAKE) "LUA_A=lua53.dll" "LUA_T=lua5.3.exe" \
+-	"AR=$(CC) -shared -o" "RANLIB=strip --strip-unneeded" \
++	"AR=$(CC) -shared -Wl,--out-implib=liblua5.3.dll.a -o" "RANLIB=strip --strip-unneeded" \
+ 	"SYSCFLAGS=-DLUA_BUILD_AS_DLL" "SYSLIBS=" "SYSLDFLAGS=-s" lua5.3.exe
+ 	$(MAKE) "LUAC_T=luac5.3.exe" luac.exe
+ 

--- a/mingw-w64-lua53/lua.pc
+++ b/mingw-w64-lua53/lua.pc
@@ -1,0 +1,20 @@
+V=%VER%
+R=%REL%
+
+prefix=/usr
+INSTALL_BIN=${prefix}/bin
+INSTALL_INC=${prefix}/include
+INSTALL_LIB=${prefix}/lib
+INSTALL_MAN=${prefix}/man/man1
+INSTALL_LMOD=${prefix}/share/lua/${V}
+INSTALL_CMOD=${prefix}/lib/lua/${V}
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: Lua
+Description: An Extensible Extension Language
+Version: ${R}
+Requires: 
+Libs: -L${libdir} -llua -lm
+Cflags: -I${includedir}

--- a/mingw-w64-lua53/searchpath.patch
+++ b/mingw-w64-lua53/searchpath.patch
@@ -1,0 +1,14 @@
+--- lua-5.3.3/src/luaconf.h.orig	2016-05-01 16:06:09.000000000 -0400
++++ lua-5.3.3/src/luaconf.h	2016-10-06 08:03:00.436714600 -0400
+@@ -173,8 +173,9 @@
+ ** In Windows, any exclamation mark ('!') in the path is replaced by the
+ ** path of the directory of the executable file of the current process.
+ */
+-#define LUA_LDIR	"!\\lua\\"
+-#define LUA_CDIR	"!\\"
++#define LUA_VDIR	LUA_VERSION_MAJOR "." LUA_VERSION_MINOR "\\"
++#define LUA_LDIR	"!\\..\\share\\lua\\" LUA_VDIR
++#define LUA_CDIR	"!\\..\\lib\\lua\\" LUA_VDIR
+ #define LUA_SHRDIR	"!\\..\\share\\lua\\" LUA_VDIR "\\"
+ #define LUA_PATH_DEFAULT  \
+ 		LUA_LDIR"?.lua;"  LUA_LDIR"?\\init.lua;" \


### PR DESCRIPTION
For a cross operating system project we needed a Lua 5.3 package (older Ubuntus do not ship Lua 5.4 yet). I don't know what the policy on version specific packages is but I thought it might be useful to some people. If you don't want to integrate the package, I can just close the PR and leave it here for future users to find.

Inspiration taken from the `mingw-w64-lua` and `mingw-w64-lua51` packages.