### PR TITLE
Add ffmpeg4.4

### DIFF
--- a/mingw-w64-ffmpeg4.4/0001-get_cabac_inline_x86-Dont-inline-if-32-bit-clang-on-windows.patch
+++ b/mingw-w64-ffmpeg4.4/0001-get_cabac_inline_x86-Dont-inline-if-32-bit-clang-on-windows.patch
@@ -1,0 +1,38 @@
+From 8990c5869e27fcd43b53045f87ba251f42e7d293 Mon Sep 17 00:00:00 2001
+From: Christopher Degawa <ccom@randomderp.com>
+Date: Tue, 17 Aug 2021 10:35:39 -0500
+Subject: [PATCH] get_cabac_inline_x86: Don't inline if 32-bit clang on windows
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fixes https://trac.ffmpeg.org/ticket/8903
+
+relevant https://github.com/msys2/MINGW-packages/discussions/9258
+
+Signed-off-by: Christopher Degawa <ccom@randomderp.com>
+Signed-off-by: Martin Storsjö <martin@martin.st>
+---
+ libavcodec/x86/cabac.h | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/libavcodec/x86/cabac.h b/libavcodec/x86/cabac.h
+index 53d74c541e22..b046a56a6b7e 100644
+--- a/libavcodec/x86/cabac.h
++++ b/libavcodec/x86/cabac.h
+@@ -177,8 +177,13 @@
+ 
+ #if HAVE_7REGS && !BROKEN_COMPILER
+ #define get_cabac_inline get_cabac_inline_x86
+-static av_always_inline int get_cabac_inline_x86(CABACContext *c,
+-                                                 uint8_t *const state)
++static
++#if defined(_WIN32) && !defined(_WIN64) && defined(__clang__)
++av_noinline
++#else
++av_always_inline
++#endif
++int get_cabac_inline_x86(CABACContext *c, uint8_t *const state)
+ {
+     int bit, tmp;
+ #ifdef BROKEN_RELOCATIONS

--- a/mingw-w64-ffmpeg4.4/0002-gcc-12.patch
+++ b/mingw-w64-ffmpeg4.4/0002-gcc-12.patch
@@ -1,0 +1,16 @@
+Building the assembler code in libavcodec/x86/cabac.h is broken for i386
+with GCC 12.1.
+Remove this patch once this is fixed either in ffmpeg or in GCC.
+
+diff -urN ffmpeg-4.4.2/libavcodec/x86/cabac.h.orig ffmpeg-4.4.2/libavcodec/x86/cabac.h
+--- ffmpeg-4.4.2/libavcodec/x86/cabac.h.orig	2022-05-22 15:09:32.786149500 +0200
++++ ffmpeg-4.4.2/libavcodec/x86/cabac.h	2022-05-22 18:35:06.885673200 +0200
+@@ -29,7 +29,7 @@
+ #include "libavutil/x86/asm.h"
+ #include "config.h"
+ 
+-#if   (defined(__i386) && defined(__clang__) && (__clang_major__<2 || (__clang_major__==2 && __clang_minor__<10)))\
++#if   (defined(__i386) && (!defined(__clang__) || (defined(__clang__) && (__clang_major__<2 || (__clang_major__==2 && __clang_minor__<10)))))\
+    || (                  !defined(__clang__) && defined(__llvm__) && __GNUC__==4 && __GNUC_MINOR__==2 && __GNUC_PATCHLEVEL__<=1)\
+    || (defined(__INTEL_COMPILER) && defined(_MSC_VER))
+ #       define BROKEN_COMPILER 1

--- a/mingw-w64-ffmpeg4.4/0003-fix-clang32-build.patch
+++ b/mingw-w64-ffmpeg4.4/0003-fix-clang32-build.patch
@@ -1,0 +1,11 @@
+--- ffmpeg-4.4.3/libavutil/hwcontext_vulkan.c.orig	2022-10-21 07:43:58.074260200 +0200
++++ ffmpeg-4.4.3/libavutil/hwcontext_vulkan.c	2022-10-21 07:44:11.546170700 +0200
+@@ -862,7 +862,7 @@
+ 
+     av_freep(&cmd->queues);
+     av_freep(&cmd->bufs);
+-    cmd->pool = NULL;
++    cmd->pool = VK_NULL_HANDLE;
+ }
+ 
+ static VkCommandBuffer get_buf_exec_ctx(AVHWFramesContext *hwfc, VulkanExecCtx *cmd)

--- a/mingw-w64-ffmpeg4.4/PKGBUILD
+++ b/mingw-w64-ffmpeg4.4/PKGBUILD
@@ -1,0 +1,218 @@
+# Maintainer: Alexey Pavlov <Alexpux@gmail.com>
+# Contributor: Zach Bacon <11doctorwhocanada@gmail.com>
+# Contributor: wirx6 <wirx654@gmail.com>
+# Contributor: Ray Donnelly <mingw.android@gmail.com>
+
+_realname=ffmpeg
+pkgbase="mingw-w64-${_realname}4.4"
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}4.4"
+pkgver=4.4.3
+pkgrel=1
+pkgdesc="Complete solution to record, convert and stream audio and video (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+url="https://ffmpeg.org/"
+license=('spdx:GPL-3.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-aom"
+         "${MINGW_PACKAGE_PREFIX}-bzip2"
+         "${MINGW_PACKAGE_PREFIX}-fribidi"
+         "${MINGW_PACKAGE_PREFIX}-fontconfig"
+         "${MINGW_PACKAGE_PREFIX}-dav1d"
+         "${MINGW_PACKAGE_PREFIX}-gmp"
+         "${MINGW_PACKAGE_PREFIX}-gnutls"
+         "${MINGW_PACKAGE_PREFIX}-gsm"
+         "${MINGW_PACKAGE_PREFIX}-lame"
+         "${MINGW_PACKAGE_PREFIX}-libass"
+         "${MINGW_PACKAGE_PREFIX}-libbluray"
+         "${MINGW_PACKAGE_PREFIX}-libcaca"
+         "${MINGW_PACKAGE_PREFIX}-libexif"
+         "${MINGW_PACKAGE_PREFIX}-libgme"
+         "${MINGW_PACKAGE_PREFIX}-libiconv"
+         $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || echo "${MINGW_PACKAGE_PREFIX}-libmfx")
+         "${MINGW_PACKAGE_PREFIX}-libmodplug"
+         "${MINGW_PACKAGE_PREFIX}-libssh"
+         "${MINGW_PACKAGE_PREFIX}-librsvg"
+         "${MINGW_PACKAGE_PREFIX}-libsoxr"
+         "${MINGW_PACKAGE_PREFIX}-libtheora"
+         "${MINGW_PACKAGE_PREFIX}-libvorbis"
+         "${MINGW_PACKAGE_PREFIX}-libvpx"
+         "${MINGW_PACKAGE_PREFIX}-libwebp"
+         "${MINGW_PACKAGE_PREFIX}-libxml2"
+         "${MINGW_PACKAGE_PREFIX}-openal"
+         "${MINGW_PACKAGE_PREFIX}-opencore-amr"
+         "${MINGW_PACKAGE_PREFIX}-openjpeg2"
+         "${MINGW_PACKAGE_PREFIX}-opus"
+         "${MINGW_PACKAGE_PREFIX}-rav1e"
+         "${MINGW_PACKAGE_PREFIX}-rtmpdump"
+         "${MINGW_PACKAGE_PREFIX}-SDL2"
+         "${MINGW_PACKAGE_PREFIX}-speex"
+         "${MINGW_PACKAGE_PREFIX}-srt"
+         $([[ "${CARCH}" != "x86_64" ]] || echo "${MINGW_PACKAGE_PREFIX}-svt-av1")
+         "${MINGW_PACKAGE_PREFIX}-vid.stab"
+         "${MINGW_PACKAGE_PREFIX}-vulkan"
+         "${MINGW_PACKAGE_PREFIX}-libx264"
+         "${MINGW_PACKAGE_PREFIX}-x265"
+         "${MINGW_PACKAGE_PREFIX}-xvidcore"
+         "${MINGW_PACKAGE_PREFIX}-zimg"
+         "${MINGW_PACKAGE_PREFIX}-zlib")
+conflicts=("${MINGW_PACKAGE_PREFIX}-ffmpeg<5")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-pkgconf"
+             "${MINGW_PACKAGE_PREFIX}-dlfcn"
+             $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || echo "${MINGW_PACKAGE_PREFIX}-amf-headers")
+             $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || echo "${MINGW_PACKAGE_PREFIX}-ffnvcodec-headers")
+             $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || echo "${MINGW_PACKAGE_PREFIX}-nasm"))
+source=(https://ffmpeg.org/releases/${_realname}-${pkgver}.tar.xz{,.asc}
+        https://github.com/FFmpeg/FFmpeg/commit/c6fdbe26ef30fff817581e5ed6e078d96111248a.patch
+        # Backport from https://github.com/FFmpeg/FFmpeg/commit/8990c5869e27fcd43b53045f87ba251f42e7d293
+        "0001-get_cabac_inline_x86-Dont-inline-if-32-bit-clang-on-windows.patch"
+        "0002-gcc-12.patch"
+        "0003-fix-clang32-build.patch")
+validpgpkeys=('FCF986EA15E6E293A5644F10B4322F04D67658D8')
+sha256sums=('6c5b6c195e61534766a0b5fe16acc919170c883362612816d0a1c7f4f947006e'
+            'SKIP'
+            '8de70945eeb6a998b9188494a242ba06847b475b9674fcfec48436d99fcbea7f'
+            'b19edf64c3daff6acebeb2e45be4e13c5ee035fd24ba1bf9e77a5376efe83628'
+            '84b9fcaa188eef15201a105a44c53d647e4fb800a5032336e0948d6bed2cbc1b'
+            '06481611d3449e2cc4f4759d2e0ad5b1ce2c4f313d0b63d4cb0a51d9fe02a424')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _fname in "$@"
+  do
+    msg2 "Applying ${_fname}"
+    patch -Nbp1 -i "${srcdir}"/${_fname}
+  done
+}
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  apply_patch_with_msg \
+    c6fdbe26ef30fff817581e5ed6e078d96111248a.patch \
+    0001-get_cabac_inline_x86-Dont-inline-if-32-bit-clang-on-windows.patch \
+    0002-gcc-12.patch \
+    0003-fix-clang32-build.patch
+}
+
+build() {
+  local -a common_config
+  common_config+=(
+    --incdir="${MINGW_PREFIX}/include/ffmpeg4.4" \
+    --libdir="${MINGW_PREFIX}/lib/ffmpeg4.4" \
+    --disable-debug
+    --disable-stripping
+    --disable-doc
+    --enable-dxva2
+    --enable-d3d11va
+    --enable-fontconfig
+    --enable-gmp
+    --enable-gnutls
+    --enable-gpl
+    --enable-iconv
+    --enable-libaom
+    --enable-libass
+    --enable-libbluray
+    --enable-libcaca
+    --enable-libdav1d
+    --enable-libfreetype
+    --enable-libfribidi
+    --enable-libgme
+    --enable-libgsm
+    --enable-libmodplug
+    --enable-libmp3lame
+    --enable-libopencore_amrnb
+    --enable-libopencore_amrwb
+    --enable-libopenjpeg
+    --enable-libopus
+    --enable-librsvg
+    --enable-librtmp
+    --enable-libssh
+    --enable-libsoxr
+    --enable-libspeex
+    --enable-libsrt
+    --enable-libtheora
+    --enable-libvidstab
+    --enable-libvorbis
+    --enable-libx264
+    --enable-libx265
+    --enable-libxvid
+    --enable-libvpx
+    --enable-libwebp
+    --enable-libxml2
+    --enable-libzimg
+    --enable-openal
+    --enable-pic
+    --enable-postproc
+    --enable-runtime-cpudetect
+    --enable-swresample
+    --enable-version3
+    --enable-vulkan
+    --enable-zlib
+    --enable-librav1e
+  )
+
+  if [[ "${CARCH}" == "x86_64" ]]; then
+    common_config+=(
+       --enable-libsvtav1
+    )
+  fi
+
+  if [[ "${MINGW_PACKAGE_PREFIX}" != *clang-aarch64* ]]; then
+    common_config+=(
+        --enable-libmfx
+        --enable-amf
+        --enable-nvenc
+    )
+  fi
+
+  for _variant in -static -shared; do
+    [[ -d "${srcdir}/build-${MSYSTEM}${_variant}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}${_variant}"
+    mkdir -p "${srcdir}/build-${MSYSTEM}${_variant}" && cd "${srcdir}/build-${MSYSTEM}${_variant}"
+    if [[ ${_variant} == -static ]]; then
+      ENABLE_VARIANT="--enable-static --pkg-config-flags=--static"
+    else
+      ENABLE_VARIANT=--enable-shared
+    fi
+    ../${_realname}-${pkgver}/configure \
+      --prefix=${MINGW_PREFIX} \
+      --target-os=mingw32 \
+      --arch=${CARCH%%-*} \
+      --cc=${CC} \
+      --cxx=${CXX} \
+      "${common_config[@]}" \
+      --logfile=config.log \
+      ${ENABLE_VARIANT}
+
+    make
+  done
+}
+
+check() {
+  for _variant in -static -shared; do
+    cd "${srcdir}/build-${MSYSTEM}${_variant}"
+    # workaround for conflict with SDL main(), use it if you have SDL installed
+    # make check CC_C="-c -Umain"
+    make check || true
+  done
+}
+
+package() {
+  for _variant in -static -shared; do
+    cd "${srcdir}/build-${MSYSTEM}${_variant}"
+    make DESTDIR="${pkgdir}" install
+  done
+  
+  rm -f ${pkgdir}/${MINGW_PREFIX}/lib/ffmpeg4.4/*.def
+  rm -f ${pkgdir}/${MINGW_PREFIX}/bin/*.lib
+  rm -f ${pkgdir}/${MINGW_PREFIX}/bin/*.exe
+  rm -rf ${pkgdir}/${MINGW_PREFIX}/share
+
+  local PREFIX_DEPS=$(cygpath -am ${MINGW_PREFIX})
+  find ${pkgdir}${MINGW_PREFIX}/lib/ffmpeg4.4/pkgconfig -name *.pc -exec sed -i -e"s|${PREFIX_DEPS}|${MINGW_PREFIX}|g" {} \;
+
+  # https://github.com/pkgconf/pkgconf/issues/286
+  find ${pkgdir}${MINGW_PREFIX}/lib/ffmpeg4.4/pkgconfig -name *.pc -exec sed -i -e"s|libdir=${MINGW_PREFIX}/|libdir=${MINGW_PREFIX}/../|g" {} \;
+  find ${pkgdir}${MINGW_PREFIX}/lib/ffmpeg4.4/pkgconfig -name *.pc -exec sed -i -e"s|includedir=${MINGW_PREFIX}/|includedir=${MINGW_PREFIX}/../|g" {} \;
+}

--- a/mingw-w64-ffmpeg4.4/c6fdbe26ef30fff817581e5ed6e078d96111248a.patch
+++ b/mingw-w64-ffmpeg4.4/c6fdbe26ef30fff817581e5ed6e078d96111248a.patch
@@ -1,0 +1,28 @@
+From c6fdbe26ef30fff817581e5ed6e078d96111248a Mon Sep 17 00:00:00 2001
+From: dvhh <dvhh-at-yahoo.com@ffmpeg.org>
+Date: Sat, 18 Jun 2022 01:46:12 +0900
+Subject: [PATCH] configure: fix SDL2 version check for pkg_config fallback
+
+pkg_config fallback for SDL2 use 2.1.0 as max (excluded) version
+where the pkg_config specify 3.0.0
+Correcting fallback version to be in line with the pkg_config version
+
+Signed-off-by: dvhh <dvhh@yahoo.com>
+Signed-off-by: Marton Balint <cus@passwd.hu>
+---
+ configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure b/configure
+index 7d5c4900bf8c..0558e937ca75 100755
+--- a/configure
++++ b/configure
+@@ -6756,7 +6756,7 @@ if enabled sdl2; then
+         sdl2_cflags=$("${SDL2_CONFIG}" --cflags)
+         sdl2_extralibs=$("${SDL2_CONFIG}" --libs)
+         test_cpp_condition SDL.h "(SDL_MAJOR_VERSION<<16 | SDL_MINOR_VERSION<<8 | SDL_PATCHLEVEL) >= 0x020001" $sdl2_cflags &&
+-        test_cpp_condition SDL.h "(SDL_MAJOR_VERSION<<16 | SDL_MINOR_VERSION<<8 | SDL_PATCHLEVEL) < 0x020100" $sdl2_cflags &&
++        test_cpp_condition SDL.h "(SDL_MAJOR_VERSION<<16 | SDL_MINOR_VERSION<<8 | SDL_PATCHLEVEL) < 0x030000" $sdl2_cflags &&
+         check_func_headers SDL_events.h SDL_PollEvent $sdl2_extralibs $sdl2_cflags &&
+             enable sdl2
+     fi


### PR DESCRIPTION
The goal of this package is to provide ffmpeg 4.4.x and not conflict with ffmpeg 5.x etc.

Compared to the current 4.4 package this removes the frei0r-plugins dependency, since there is a dep cycle via frei0r-plugins -> opencv

edit:

```
# for packages switching to this:
depends=("${MINGW_PACKAGE_PREFIX}-ffmpeg4.4")
export PKG_CONFIG_PATH="${MINGW_PREFIX}/lib/ffmpeg4.4/pkgconfig:$PKG_CONFIG_PATH"
```