### PR TITLE
x264: split into libx264 and x264

### DIFF
--- a/mingw-w64-x264/PKGBUILD
+++ b/mingw-w64-x264/PKGBUILD
@@ -2,12 +2,9 @@
 
 _realname=x264
 pkgbase=mingw-w64-${_realname}
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-provides=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
-conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
-replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
+pkgname=("${MINGW_PACKAGE_PREFIX}-libx264" "${MINGW_PACKAGE_PREFIX}-x264")
 pkgver=0.164.r3094.bfc87b7
-pkgrel=1
+pkgrel=2
 pkgdesc="Library for encoding H264/AVC video streams (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -15,13 +12,13 @@ url="https://www.videolan.org/developers/x264.html"
 license=("custom")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-ffmpeg"
+             "${MINGW_PACKAGE_PREFIX}-l-smash"
+             $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-ffms2")
               $( [[ "${CARCH}" != "i686" \
                 && "${CARCH}" != "x86_64" ]] \
                 || echo "${MINGW_PACKAGE_PREFIX}-nasm" )
              "git")
-depends=("${MINGW_PACKAGE_PREFIX}-libwinpthread"
-         "${MINGW_PACKAGE_PREFIX}-l-smash"
-         $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-ffms2"))
 options=('strip' 'staticlibs')
 _commit="bfc87b7a330f75f5c9a21e56081e4b20344f139e"
 source=("${_realname}"::"git+https://code.videolan.org/videolan/${_realname}.git#commit=${_commit}"
@@ -57,9 +54,42 @@ build() {
     --enable-shared
 
   make
+
+  make DESTDIR="${srcdir}/dest/libx264" install
+
+  mkdir -p "${srcdir}/dest/x264"
+  mkdir -p "${srcdir}/dest/x264${MINGW_PREFIX}/bin"
+  mv "${srcdir}/dest/libx264${MINGW_PREFIX}/bin/"*.exe "${srcdir}/dest/x264${MINGW_PREFIX}/bin"
 }
 
-package() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
-  make DESTDIR="${pkgdir}" install
+package_libx264() {
+  depends=()
+
+  cp -r "${srcdir}/dest/libx264/"* "${pkgdir}"
 }
+
+package_x264() {
+  # Note: libx264 is stricly not needed, but existing users of the x264 package
+  # before the split expect the library to be included
+  depends=(
+    "${MINGW_PACKAGE_PREFIX}-ffmpeg"
+    "${MINGW_PACKAGE_PREFIX}-l-smash"
+    "${MINGW_PACKAGE_PREFIX}-libx264"
+    $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-ffms2"))
+  provides=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
+  replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
+
+  cp -r "${srcdir}/dest/x264/"* "${pkgdir}"
+}
+
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
+
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;


### PR DESCRIPTION
the latter depends on ffmpeg, ffms2 and l-smash which users of
the library don't need. This also allows us break some
dependency cyles with ffmpeg.

* remove the libwinpthread dependency which it doesn't
  seem to use anymore.
* note that x264.exe statically links the encoder, so there
  is no dependency to libx264 needed, but we add it anyway,
  to avoid breaking existing users.