### PR TITLE
ffmpeg: cleanups

### DIFF
--- a/mingw-w64-ffmpeg/PKGBUILD
+++ b/mingw-w64-ffmpeg/PKGBUILD
@@ -7,16 +7,14 @@ _realname=ffmpeg
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.4.3
-pkgrel=5
-pkgdesc="Complete and free Internet live audio and video broadcasting solution (mingw-w64)"
+pkgrel=6
+pkgdesc="Complete solution to record, convert and stream audio and video (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://ffmpeg.org/"
 license=('spdx:GPL-3.0-or-later')
-options=('staticlibs' 'strip')
 depends=("${MINGW_PACKAGE_PREFIX}-aom"
          "${MINGW_PACKAGE_PREFIX}-bzip2"
-         # "${MINGW_PACKAGE_PREFIX}-celt" # provided by opus, not in development
          "${MINGW_PACKAGE_PREFIX}-frei0r-plugins"
          "${MINGW_PACKAGE_PREFIX}-fribidi"
          "${MINGW_PACKAGE_PREFIX}-fontconfig"
@@ -45,8 +43,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-aom"
          "${MINGW_PACKAGE_PREFIX}-opencore-amr"
          "${MINGW_PACKAGE_PREFIX}-openjpeg2"
          "${MINGW_PACKAGE_PREFIX}-opus"
-         $([[ "${MINGW_PACKAGE_PREFIX}" == *clang-aarch64* ]] \
-            || echo "${MINGW_PACKAGE_PREFIX}-rav1e")
+         "${MINGW_PACKAGE_PREFIX}-rav1e"
          "${MINGW_PACKAGE_PREFIX}-rtmpdump"
          "${MINGW_PACKAGE_PREFIX}-SDL2"
          "${MINGW_PACKAGE_PREFIX}-speex"
@@ -113,13 +110,11 @@ prepare() {
 }
 
 build() {
-  # Fix using SRT headers
-  CFLAGS+=" -DWIN32"
-  CXXFLAGS+=" -DWIN32"
-
   local -a common_config
   common_config+=(
     --disable-debug
+    --disable-stripping
+    --disable-doc
     --enable-dxva2
     --enable-d3d11va
     --enable-fontconfig
@@ -167,18 +162,12 @@ build() {
     --enable-version3
     --enable-vulkan
     --enable-zlib
-    --disable-doc
+    --enable-librav1e
   )
 
   if [[ "${CARCH}" == "x86_64" ]]; then
     common_config+=(
        --enable-libsvtav1
-    )
-  fi
-
-  if [[ "${MINGW_PACKAGE_PREFIX}" != *clang-aarch64* ]]; then
-    common_config+=(
-       --enable-librav1e
     )
   fi
 
@@ -206,12 +195,9 @@ build() {
       --cxx=${CXX} \
       "${common_config[@]}" \
       --logfile=config.log \
-      ${ENABLE_VARIANT} ||
-      {
-        cat config.log
-        exit 1
-      }
-    make VERBOSE=1
+      ${ENABLE_VARIANT}
+
+    make
   done
 }
 
@@ -220,7 +206,7 @@ check() {
     cd "${srcdir}/build-${MSYSTEM}${_variant}"
     # workaround for conflict with SDL main(), use it if you have SDL installed
     # make check CC_C="-c -Umain"
-    make check VERBOSE=1 || true
+    make check || true
   done
 }
 
@@ -232,8 +218,6 @@ package() {
   
   rm -f ${pkgdir}/${MINGW_PREFIX}/lib/*.def
   rm -f ${pkgdir}/${MINGW_PREFIX}/bin/*.lib
-
-  #find ${pkgdir}${MINGW_PREFIX}/bin -type f -name "*.exe" -exec objcopy --subsystem console {} \;
 
   local PREFIX_DEPS=$(cygpath -am ${MINGW_PREFIX})
   find ${pkgdir}${MINGW_PREFIX}/lib/pkgconfig -name *.pc -exec sed -i -e"s|${PREFIX_DEPS}|${MINGW_PREFIX}|g" {} \;


### PR DESCRIPTION
* sync pkgdesc from Arch
* remove default options
* remove commented out parts
* rav1e is available for clangarm64 now
* libsrt headers now use _WIN32, so remove the workaround
* disable stripping, leave it to makepkg
* don't exit on build errors, and don't enable verbose mode