### PR TITLE
kicad: support subrelease field in wxWidgets version number

### DIFF
--- a/mingw-w64-kicad/001-support-subrelease-field-in-wxwidgets.patch
+++ b/mingw-w64-kicad/001-support-subrelease-field-in-wxwidgets.patch
@@ -1,0 +1,44 @@
+From 048c8b1670934d9939a921ac51a8dd7d2b1c20d8 Mon Sep 17 00:00:00 2001
+From: Ian McInerney <ian.s.mcinerney@ieee.org>
+Date: Mon, 13 Feb 2023 21:24:26 +0000
+Subject: [PATCH] Support subrelease field in wxWidgets cmake detection
+
+Sometimes wxWidgets increments the subrelease to a non-zero value, and
+since wxPython will report a subrelease, we must ensure we can get the
+subrelease from the wx library properly, otherwise configure will fail
+thinking the library isn't the same version as that used by wxPython.
+
+Fixes: https://gitlab.com/kicad/code/kicad/-/issues/13887
+
+(Cherry-picked from b536580119c59fde78e38d8d6388f2540ecb6cf9)
+---
+ cmake/FindwxWidgets.cmake | 13 +++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/cmake/FindwxWidgets.cmake b/cmake/FindwxWidgets.cmake
+index 1cf5a4be538..f22ba488121 100644
+--- a/CMakeModules/FindwxWidgets.cmake
++++ b/CMakeModules/FindwxWidgets.cmake
+@@ -926,8 +926,17 @@ if(wxWidgets_FOUND)
+     "\\2" wxWidgets_VERSION_MINOR "${_wx_version_h}" )
+   string(REGEX REPLACE "^(.*\n)?#define +wxRELEASE_NUMBER +([0-9]+).*"
+     "\\2" wxWidgets_VERSION_PATCH "${_wx_version_h}" )
+-  set(wxWidgets_VERSION_STRING
+-    "${wxWidgets_VERSION_MAJOR}.${wxWidgets_VERSION_MINOR}.${wxWidgets_VERSION_PATCH}" )
++  string(REGEX REPLACE "^(.*\n)?#define +wxSUBRELEASE_NUMBER +([0-9]+).*"
++    "\\2" wxWidgets_VERSION_SUBRELEASE "${_wx_version_h}" )
++
++  if( ${wxWidgets_VERSION_SUBRELEASE} GREATER 0 )
++    set(wxWidgets_VERSION_STRING
++      "${wxWidgets_VERSION_MAJOR}.${wxWidgets_VERSION_MINOR}.${wxWidgets_VERSION_PATCH}.${wxWidgets_VERSION_SUBRELEASE}" )
++  else()
++    set(wxWidgets_VERSION_STRING
++      "${wxWidgets_VERSION_MAJOR}.${wxWidgets_VERSION_MINOR}.${wxWidgets_VERSION_PATCH}" )
++  endif()
++
+   DBG_MSG("wxWidgets_VERSION_STRING:    ${wxWidgets_VERSION_STRING}")
+ endif()
+ 
+-- 
+GitLab
+

--- a/mingw-w64-kicad/PKGBUILD
+++ b/mingw-w64-kicad/PKGBUILD
@@ -2,22 +2,21 @@
 # Contributor: Tim Stahlhut <stahta01@gmail.com>
 
 # Remember to update mingw-w64-kicad-doc and mingw-w64-kicad-library when
-# updating this build rule
+# updating this build rule.
 
 _realname=kicad
 _wx_basever=3.2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=6.0.11
-pkgrel=2
+pkgrel=3
 pkgdesc="Software for the creation of electronic schematic diagrams and printed circuit board artwork (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://www.kicad.org/"
 license=("spdx:GPL-3.0-or-later")
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
-options=('strip' '!debug') # Production build options
-#options=('!strip' 'debug')
+options=('strip' '!debug')
 conflicts=(${MINGW_PACKAGE_PREFIX}-${_realname}-git)
 replaces=(${MINGW_PACKAGE_PREFIX}-${_realname}-git)
 depends=(
@@ -57,6 +56,7 @@ for _doclang in ${_doc[@]}; do
 done
 source=(
   "${_realname}-${pkgver}.tar.gz"::"https://gitlab.com/kicad/code/kicad/-/archive/${pkgver}/kicad-${pkgver}.tar.gz"
+  "001-support-subrelease-field-in-wxwidgets.patch"  # https://gitlab.com/kicad/code/kicad/-/commit/048c8b1670934d9939a921ac51a8dd7d2b1c20d8.patch
   '002-ki-6.0-cmake-fixes-for-MINGW-CLANG.patch'
   '003-ki-6.0-code-fixes-for-GNUC-CLANG.patch'
   '006-ki-6.0-rewrite-kiwin32_rc_for_clang.patch'
@@ -65,6 +65,7 @@ source=(
   '007-ki-6.0-manifest-remove-win10-11-manifest-support.patch'
 )
 sha256sums=('be010730f05e0b4050d326ca30b41107e052ccab2b96936d4791b716819df850'
+            '06832ebf8dd12e8630e6cf1abe349f95a5502c4ac33e20835f2385e3fcaf1b43'
             '45c672d20ae9badb9591f39cffc0191d6eb9a86ebbef53d43475954ffb89fe27'
             'd8d5f4bdd0aa6d8a907710c523f6f95840636cb2ef69e5275c6ed4966f134353'
             'e03dbb58409145c8fb54991d8259f14bc0ba6b21abca24f9b914ec354c9df89c'
@@ -83,6 +84,7 @@ apply_patch_with_msg() {
 prepare() {
   cd ${_realname}-${pkgver}
   apply_patch_with_msg \
+    001-support-subrelease-field-in-wxwidgets.patch \
     002-ki-6.0-cmake-fixes-for-MINGW-CLANG.patch \
     003-ki-6.0-code-fixes-for-GNUC-CLANG.patch \
     005-ki-6.0-Skip-ffloat-store-under-CLANG.patch \


### PR DESCRIPTION
The upstream patch doesn't apply directly because some folder names changed.
