### PR TITLE
[libbs2b] Add support for clangarm64

### DIFF
--- a/mingw-w64-libbs2b/PKGBUILD
+++ b/mingw-w64-libbs2b/PKGBUILD
@@ -4,10 +4,10 @@ _realname=libbs2b
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=3.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Bauer stereophonic-to-binaural DSP effect library (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url='https://bs2b.sourceforge.io/'
 license=('MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-libsndfile")
@@ -17,6 +17,10 @@ sha256sums=('6aaafd81aae3898ee40148dd1349aab348db9bfae9767d0e66e0b07ddd4b2528')
 
 prepare() {
   cd "$srcdir"/${_realname}-${pkgver}
+
+  sed -i 's/dist-lzma/dist-xz/g' configure.ac
+
+  autoreconf -fvi
 }
 
 build() {


### PR DESCRIPTION
Needed to run autoreconf for aarch64 to build.