### PR TITLE
spooles: add new patch, enable clang

### DIFF
--- a/mingw-w64-spooles/PKGBUILD
+++ b/mingw-w64-spooles/PKGBUILD
@@ -18,6 +18,7 @@ url="https://www.netlib.org/linalg/spooles"
 license=('custom')
 source=("https://www.netlib.org/linalg/${_realname}/${_realname}.${pkgver}.tgz"
         spooles.patch
+        # Patch from (spooles-1): https://aur.archlinux.org/cgit/aur.git/tree/spooles-1.patch?h=spooles
         spooles-1.patch
         LICENSE)
 sha256sums=('a84559a0e987a1e423055ef4fdf3035d55b65bbe4bf915efaa1a35bef7f8c5dd'

--- a/mingw-w64-spooles/PKGBUILD
+++ b/mingw-w64-spooles/PKGBUILD
@@ -6,19 +6,23 @@ _realname=spooles
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.2
-pkgrel=4
+pkgrel=5
 pkgdesc="SParse Object Oriented Linear Equations Solver (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64')
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-libgfortran")
-makedepends=("${MINGW_PACKAGE_PREFIX}-perl")
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang32' 'clang64')
+depends=($([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran"))
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-ghostscript"
+             "${MINGW_PACKAGE_PREFIX}-perl")
 url="https://www.netlib.org/linalg/spooles"
 license=('custom')
 source=("https://www.netlib.org/linalg/${_realname}/${_realname}.${pkgver}.tgz"
         spooles.patch
+        spooles-1.patch
         LICENSE)
 sha256sums=('a84559a0e987a1e423055ef4fdf3035d55b65bbe4bf915efaa1a35bef7f8c5dd'
             '58a92b0336f8e2f9b32be9b68f86e02196eb7c075a627fcf828f4f2a2ba1990d'
+            '364C07247A6486EA86925B4FFDC0BB05022894E27C23C187F6A9725792BD4FEF'
             'BCC3FC307C8B7FD8259CCA785F1AB6A5203D45EA51C5859D41DEFEA5C0E8820A')
 noextract=("${_realname}.${pkgver}.tgz")
 
@@ -28,10 +32,11 @@ prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   tar -xzf "${srcdir}/${_realname}.${pkgver}.tgz"
   patch -Np1 -i "${srcdir}"/spooles.patch
+  patch -Np1 -i "${srcdir}"/spooles-1.patch
 }
 
 build() {
-  make lib -C "${srcdir}/${_realname}-${pkgver}"
+  make CC=${CC} CFLAGS="$CFLAGS -Wno-error=format-security" lib -C "${srcdir}/${_realname}-${pkgver}"
 }
 
 package() {
@@ -53,5 +58,7 @@ package() {
   # Fix permissions
   cd ${pkgdir}${MINGW_PREFIX}/include/spooles
   chmod -R oug+r *
+  cd ${pkgdir}${MINGW_PREFIX}/lib
+  chmod oug+r *
   install -Dm644 "${srcdir}"/LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
 }

--- a/mingw-w64-spooles/PKGBUILD
+++ b/mingw-w64-spooles/PKGBUILD
@@ -58,7 +58,5 @@ package() {
   # Fix permissions
   cd ${pkgdir}${MINGW_PREFIX}/include/spooles
   chmod -R oug+r *
-  cd ${pkgdir}${MINGW_PREFIX}/lib
-  chmod oug+r *
   install -Dm644 "${srcdir}"/LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
 }

--- a/mingw-w64-spooles/spooles-1.patch
+++ b/mingw-w64-spooles/spooles-1.patch
@@ -1,0 +1,179 @@
+diff -Nur spooles.old/ETree/src/transform.c spooles/ETree/src/transform.c
+--- spooles.old/ETree/src/transform.c	1998-12-07 19:47:00.000000000 +0100
++++ spooles/ETree/src/transform.c	2021-05-30 18:20:28.087479400 +0200
+@@ -1,6 +1,7 @@
+ /*  transform.c  */
+ 
+ #include "../ETree.h"
++#include <stdint.h>
+ 
+ #define MYDEBUG 0
+ 
+@@ -291,7 +292,7 @@
+    remap the nzeros[] vector
+    -------------------------
+ */
+-temp = IVinit(nfront, NULL) ;
++temp = IVinit(nfront, (int)(uintptr_t)NULL) ;
+ IVcopy(nfront, temp, nzeros) ;
+ IV_setSize(nzerosIV, nnew) ;
+ nzeros = IV_entries(nzerosIV) ;
+@@ -453,7 +454,7 @@
+    remap the nzeros[] vector
+    -------------------------
+ */
+-temp = IVinit(nfront, NULL) ;
++temp = IVinit(nfront, (int)(uintptr_t)NULL) ;
+ IVcopy(nfront, temp, nzeros) ;
+ IV_setSize(nzerosIV, nnew) ;
+ nzeros = IV_entries(nzerosIV) ;
+@@ -614,7 +615,7 @@
+    remap the nzeros[] vector
+    -------------------------
+ */
+-temp = IVinit(nfront, NULL) ;
++temp = IVinit(nfront, (int)(uintptr_t)NULL) ;
+ IVcopy(nfront, temp, nzeros) ;
+ IV_setSize(nzerosIV, nnew) ;
+ nzeros = IV_entries(nzerosIV) ;
+diff -Nur spooles.old/Utilities/src/iohb.c spooles/Utilities/src/iohb.c
+--- spooles.old/Utilities/src/iohb.c	1998-09-19 16:35:21.000000000 +0200
++++ spooles/Utilities/src/iohb.c	2021-05-30 18:20:20.030812863 +0200
+@@ -215,6 +215,7 @@
+ /*---------------------------------------------------------------------*/
+ 
+ #include "../Utilities.h"
++#include <stdint.h>
+ 
+ static int ParseIfmt(char* fmt, int* perline, int* width) ;
+ static int ParseRfmt(char* fmt, int* perline, int* width, 
+@@ -266,7 +267,7 @@
+                   &Ptrcrd, &Indcrd, &Valcrd, &Rhscrd, Rhstype);
+     fclose(in_file);
+     *Type = mat_type;
+-    *(*Type+3) = (char) NULL;
++    *(*Type+3) = (char)(uintptr_t) NULL;
+     *M    = Nrow;
+     *N    = Ncol;
+     *nz   = Nnzero;
+@@ -308,8 +309,8 @@
+     if ( sscanf(line,"%*s") < 0 ) 
+         IOHBTerminate("iohb.c: Null (or blank) first line of HB file.\n");
+     (void) sscanf(line, "%72c%8[^\n]", Title, Key);
+-    *(Key+8) = (char) NULL;
+-    *(Title+72) = (char) NULL;
++    *(Key+8) = (char)(uintptr_t) NULL;
++    *(Title+72) = (char)(uintptr_t) NULL;
+ 
+ /*  Second line:  */
+     fgets(line, BUFSIZ, in_file);
+@@ -344,10 +345,10 @@
+     if ( sscanf(line, "%*16c%*16c%20c",Valfmt) != 1) 
+         IOHBTerminate("iohb.c: Invalid format info, line 4 of Harwell-Boeing file.\n"); 
+     sscanf(line, "%*16c%*16c%*20c%20c",Rhsfmt);
+-    *(Ptrfmt+16) = (char) NULL;
+-    *(Indfmt+16) = (char) NULL;
+-    *(Valfmt+20) = (char) NULL;
+-    *(Rhsfmt+20) = (char) NULL;
++    *(Ptrfmt+16) = (char)(uintptr_t) NULL;
++    *(Indfmt+16) = (char)(uintptr_t) NULL;
++    *(Valfmt+20) = (char)(uintptr_t) NULL;
++    *(Rhsfmt+20) = (char)(uintptr_t) NULL;
+    
+ /*  (Optional) Fifth line: */
+     if (*Rhscrd != 0 )
+@@ -454,7 +455,7 @@
+ 
+     ThisElement = (char *) malloc(Ptrwidth+1);
+     if ( ThisElement == NULL ) IOHBTerminate("Insufficient memory for ThisElement.");
+-    *(ThisElement+Ptrwidth) = (char) NULL;
++    *(ThisElement+Ptrwidth) = (char)(uintptr_t) NULL;
+     count=0;
+     for (i=0;i<Ptrcrd;i++)
+     {
+@@ -477,7 +478,7 @@
+ 
+     ThisElement = (char *) malloc(Indwidth+1);
+     if ( ThisElement == NULL ) IOHBTerminate("Insufficient memory for ThisElement.");
+-    *(ThisElement+Indwidth) = (char) NULL;
++    *(ThisElement+Indwidth) = (char)(uintptr_t) NULL;
+     count = 0;
+     for (i=0;i<Indcrd;i++)
+     {
+@@ -505,7 +506,7 @@
+ 
+     ThisElement = (char *) malloc(Valwidth+1);
+     if ( ThisElement == NULL ) IOHBTerminate("Insufficient memory for ThisElement.");
+-    *(ThisElement+Valwidth) = (char) NULL;
++    *(ThisElement+Valwidth) = (char)(uintptr_t) NULL;
+     count = 0;
+     for (i=0;i<Valcrd;i++)
+     {
+@@ -705,7 +706,7 @@
+ 
+   ThisElement = (char *) malloc(Rhswidth+1);
+   if ( ThisElement == NULL ) IOHBTerminate("Insufficient memory for ThisElement.");
+-  *(ThisElement+Rhswidth) = (char) NULL;
++  *(ThisElement+Rhswidth) = (char)(uintptr_t) NULL;
+   for (rhsi=0;rhsi<Nrhs;rhsi++) {
+ 
+     for (i=0;i<Nentries;i++) {
+@@ -1018,7 +1019,7 @@
+ 
+     ThisElement = (char *) malloc(Ptrwidth+1);
+     if ( ThisElement == NULL ) IOHBTerminate("Insufficient memory for ThisElement.");
+-    *(ThisElement+Ptrwidth) = (char) NULL;
++    *(ThisElement+Ptrwidth) = (char)(uintptr_t) NULL;
+     count=0; 
+     for (i=0;i<Ptrcrd;i++)
+     {
+@@ -1041,7 +1042,7 @@
+ 
+     ThisElement = (char *) malloc(Indwidth+1);
+     if ( ThisElement == NULL ) IOHBTerminate("Insufficient memory for ThisElement.");
+-    *(ThisElement+Indwidth) = (char) NULL;
++    *(ThisElement+Indwidth) = (char)(uintptr_t) NULL;
+     count = 0;
+     for (i=0;i<Indcrd;i++)
+     {
+@@ -1069,7 +1070,7 @@
+ 
+     ThisElement = (char *) malloc(Valwidth+1);
+     if ( ThisElement == NULL ) IOHBTerminate("Insufficient memory for ThisElement.");
+-    *(ThisElement+Valwidth) = (char) NULL;
++    *(ThisElement+Valwidth) = (char)(uintptr_t) NULL;
+     count = 0;
+     for (i=0;i<Valcrd;i++)
+     {
+@@ -1629,7 +1630,7 @@
+        while ( strchr(tmp2+1,')') != NULL ) {
+           tmp2 = strchr(tmp2+1,')');
+        }
+-       *(tmp2+1) = (int) NULL;
++       *(tmp2+1) = (int)(uintptr_t) NULL;
+     }
+     if (strchr(fmt,'P') != NULL)  /* Remove any scaling factor, which */
+     {                             /* affects output only, not input */
+@@ -1639,11 +1640,11 @@
+         tmp3 = strchr(fmt,'(')+1;
+         len = tmp-tmp3;
+         tmp2 = tmp3;
+-        while ( *(tmp2+len) != (int) NULL ) {
++        while ( *(tmp2+len) != (int)(uintptr_t) NULL ) {
+            *tmp2=*(tmp2+len);
+            tmp2++; 
+         }
+-        *(strchr(fmt,')')+1) = (int) NULL;
++        *(strchr(fmt,')')+1) = (int)(uintptr_t) NULL;
+       }
+     }
+     if (strchr(fmt,'E') != NULL) { 
+@@ -1706,7 +1707,7 @@
+     SubS = (char *)malloc(len+1);
+     if ( SubS == NULL ) IOHBTerminate("Insufficient memory for SubS.");
+     for (i=0;i<len;i++) SubS[i] = S[pos+i];
+-    SubS[len] = (char) NULL;
++    SubS[len] = (char)(uintptr_t) NULL;
+     } else {
+       SubS = NULL;
+     }


### PR DESCRIPTION
spooles: enable clang, new patch file from archlinux added because error occurs (clang):

```
transform.c:294:23: error: incompatible pointer to integer conversion passing 'void *' to
      parameter of type 'int' [-Wint-conversion]
temp = IVinit(nfront, NULL) ;
                      ^~~~
```

Patch from: https://aur.archlinux.org/cgit/aur.git/tree/spooles-1.patch?h=spooles