### PR TITLE
gdb: fix multiarch package

### DIFF
--- a/mingw-w64-gdb/PKGBUILD
+++ b/mingw-w64-gdb/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-multiarch")
 pkgver=13.1
-pkgrel=1
+pkgrel=2
 pkgdesc="GNU Debugger (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -138,10 +138,15 @@ package_gdb-multiarch() {
   pkgdesc="GNU Debugger (supports all targets)"
   depends=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 
+  builddir=${srcdir}/build-${MSYSTEM}-multiarch
+  cd ${builddir}
+  make DESTDIR=${builddir}/inst install-gdb install-gdbserver
+
   destdir=${pkgdir}${MINGW_PREFIX}/bin
+  bindir=${builddir}/inst${MINGW_PREFIX}/bin
   mkdir -p $destdir
-  strip -o ${destdir}/gdb-multiarch.exe ${srcdir}/build-${MSYSTEM}-multiarch/gdb/gdb.exe
-  strip -o ${destdir}/gdbserver-multiarch.exe ${srcdir}/build-${MSYSTEM}-multiarch/gdbserver/gdbserver.exe
+  cp -p ${bindir}/gdb.exe ${destdir}/gdb-multiarch.exe
+  cp -p ${bindir}/gdbserver.exe ${destdir}/gdbserver-multiarch.exe
 }
 
 # template start; name=mingw-w64-splitpkg-wrappers; version=1.0;


### PR DESCRIPTION
The real executable is in gdb/.libs/gdb.exe, gdb/gdb.exe executes it. Install it properly and copy from the install target.