### PR TITLE
qt6-base: Fix UNICODE definitions in cmake interface.

### DIFF
--- a/mingw-w64-qt6-base/012-fix-unicode-definitions-in-cmake-interface.patch
+++ b/mingw-w64-qt6-base/012-fix-unicode-definitions-in-cmake-interface.patch
@@ -1,0 +1,13 @@
+See discussion at https://bugreports.qt.io/browse/QTBUG-103019
+
+--- a/cmake/QtFlagHandlingHelpers.cmake
++++ b/cmake/QtFlagHandlingHelpers.cmake
+@@ -269,7 +269,7 @@ function(qt_internal_enable_unicode_defines)
+         set(no_unicode_condition
+             "$<NOT:$<BOOL:$<TARGET_PROPERTY:QT_NO_UNICODE_DEFINES>>>")
+         target_compile_definitions(Platform
+-            INTERFACE "$<${no_unicode_condition}:UNICODE;_UNICODE>")
++            INTERFACE "$<${no_unicode_condition}:UNICODE$<SEMICOLON>_UNICODE>")
+     endif()
+ endfunction()
+ 

--- a/mingw-w64-qt6-base/PKGBUILD
+++ b/mingw-w64-qt6-base/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
 _qtver=6.4.2
 pkgver=${_qtver/-/}
-pkgrel=4
+pkgrel=5
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url='https://www.qt.io'
@@ -49,6 +49,7 @@ source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/subm
         009-qfileinfo-undefine-mingw-stat.patch
         010-export-some-constexpr-variables.patch
         011-qt6-windeployqt-fixes.patch
+        012-fix-unicode-definitions-in-cmake-interface.patch
         https://download.qt.io/official_releases/qt/6.4/CVE-2023-24607-qtbase-6.4.diff)
 sha256sums=('a88bc6cedbb34878a49a622baa79cace78cfbad4f95fdbd3656ddb21c705525d'
             '458abcfe837f5df607b130ee8edcb34d303ab36cfdf30c0a0f989cb7280f1472'
@@ -61,6 +62,7 @@ sha256sums=('a88bc6cedbb34878a49a622baa79cace78cfbad4f95fdbd3656ddb21c705525d'
             '97a00b185fe6a952eeb3b8b154996e0527fd78a75150e908cd6acd61676fd453'
             'e9dcf3275163b7dd73f613f2929b10551649c8df80677fafd873b5e31430b43a'
             'd22d0aa70803bc8bfd98e235dc9c7d381336247def24d4afe77e0044ebc6aafe'
+            'b217dad1b9ebf212f4d0d5c88140c26c491373e66d3ae88cb98deb5d688e59b0'
             'a2a7b54afb3f5c6c8b7245f2d0fbfbc2f01da69739dff6a0ab979424a6881cd7')
 
 # Use the right mkspecs file
@@ -93,6 +95,11 @@ prepare() {
     009-qfileinfo-undefine-mingw-stat.patch \
     011-qt6-windeployqt-fixes.patch \
     CVE-2023-24607-qtbase-6.4.diff
+
+  # For: https://github.com/msys2/MINGW-packages/issues/15801
+  # See: https://bugreports.qt.io/browse/QTBUG-103019
+  apply_patch_with_msg \
+    012-fix-unicode-definitions-in-cmake-interface.patch
 
   if [[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]]; then
     apply_patch_with_msg \


### PR DESCRIPTION
Also fixes the CFLAGS in the generated `Qt6Platform.pc` file.

See #15801.