### PR TITLE
opencascade: Build static libraries only on MINGW64

### DIFF
--- a/mingw-w64-opencascade/PKGBUILD
+++ b/mingw-w64-opencascade/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=7.7.0
 _pkgver2=V${pkgver//./_}
-pkgrel=2
+pkgrel=3
 pkgdesc='Open CASCADE Technology, 3D modeling & numerical simulation (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -165,15 +165,23 @@ build() {
     )
   fi
 
+  declare -a _extra_config
+  if check_option "debug" "n"; then
+    _extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    _extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  if [[ "${MSYSTEM}" == "MINGW64" ]]; then
+
   msg2 "Building static libraries"
-  [[ -d "${srcdir}/build-${MSYSTEM}-static" ]] && rm -rf "${srcdir}/build-${MSYSTEM}-static"
   mkdir -p "${srcdir}/build-${MSYSTEM}-static" && cd "${srcdir}/build-${MSYSTEM}-static"
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake -Wno-dev \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -GNinja \
-    -DCMAKE_BUILD_TYPE="Release" \
+    "${_extra_config[@]}" \
     -DINSTALL_DIR_LAYOUT="Unix" \
     -DBUILD_LIBRARY_TYPE="Static" \
     "${common_config[@]}" \
@@ -191,15 +199,15 @@ build() {
 
   ${MINGW_PREFIX}/bin/cmake --build .
 
-  msg2 "Building shared libraries"
-  [[ -d "${srcdir}/build-${MSYSTEM}-shared" ]] && rm -rf "${srcdir}/build-${MSYSTEM}-shared"
+  fi
+
   mkdir -p "${srcdir}/build-${MSYSTEM}-shared" && cd "${srcdir}/build-${MSYSTEM}-shared"
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -GNinja \
-    -DCMAKE_BUILD_TYPE="Release" \
+    "${_extra_config[@]}" \
     -DINSTALL_DIR_LAYOUT="Unix" \
     -DBUILD_LIBRARY_TYPE="Shared" \
     "${common_config[@]}" \
@@ -218,13 +226,15 @@ build() {
 }
 
 package() {
-  # Static Install
-  cd "${srcdir}/build-${MSYSTEM}-static"
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --build . --target install
+  if [[ "${MSYSTEM}" == "MINGW64" ]]; then
+    # Static Install
+    cd "${srcdir}/build-${MSYSTEM}-static"
+    DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
+  fi
 
   # Shared Install
   cd "${srcdir}/build-${MSYSTEM}-shared"
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --build . --target install
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
 
   install -Dm644 "${srcdir}/occt-${_pkgver2}/LICENSE_LGPL_21.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE_LGPL_21.txt"
   install -Dm644 "${srcdir}/occt-${_pkgver2}/OCCT_LGPL_EXCEPTION.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/OCCT_LGPL_EXCEPTION.txt"


### PR DESCRIPTION
occ takes a huge time to build unneeded static libraries.
Dependent packages (kicad, gmsh and OSG) don't need them.