### PR TITLE
pastix: enable clang64

### DIFF
--- a/mingw-w64-pastix/PKGBUILD
+++ b/mingw-w64-pastix/PKGBUILD
@@ -4,10 +4,10 @@ _realname=pastix
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=6.2.2
-pkgrel=1
+pkgrel=2
 pkgdesc='High performance parallel solver for very large sparse linear systems based on direct methods (mingw-w64)'
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 depends=("${MINGW_PACKAGE_PREFIX}-openblas"
          "${MINGW_PACKAGE_PREFIX}-hwloc"
          "${MINGW_PACKAGE_PREFIX}-metis"
@@ -45,6 +45,7 @@ build() {
       -DPASTIX_WITH_MPI=OFF \
       -DBUILD_DOCUMENTATION=OFF \
       -DBUILD_TESTING=OFF \
+      -DPASTIX_WITH_FORTRAN=$([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] && echo "ON" || echo "OFF") \
       ${_arch_opt} \
       ../${_realname}-${pkgver}
 
@@ -68,6 +69,7 @@ build() {
       -DBUILD_DOCUMENTATION=OFF \
       -DBUILD_TESTING=OFF \
       -DBUILD_SHARED_LIBS=ON \
+      -DPASTIX_WITH_FORTRAN=$([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] && echo "ON" || echo "OFF") \
       ${_arch_opt} \
       ../${_realname}-${pkgver}
 


### PR DESCRIPTION
Due to a bug on clang the fortran interface has been disabled (only for clang).

Error description: https://gitlab.inria.fr/solverstack/pastix/-/issues/59