### PR TITLE
x264: drop ffmpeg support

### DIFF
--- a/mingw-w64-x264/PKGBUILD
+++ b/mingw-w64-x264/PKGBUILD
@@ -12,7 +12,6 @@ url="https://www.videolan.org/developers/x264.html"
 license=("custom")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools"
-             "${MINGW_PACKAGE_PREFIX}-ffmpeg"
              "${MINGW_PACKAGE_PREFIX}-l-smash"
              $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-ffms2")
               $( [[ "${CARCH}" != "i686" \
@@ -74,7 +73,6 @@ package_x264() {
   # Note: libx264 is stricly not needed, but existing users of the x264 package
   # before the split expect the library to be included
   depends=(
-    "${MINGW_PACKAGE_PREFIX}-ffmpeg"
     "${MINGW_PACKAGE_PREFIX}-l-smash"
     "${MINGW_PACKAGE_PREFIX}-libx264"
     $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-ffms2"))


### PR DESCRIPTION
x264 doesn't require ffmpeg.