### PR TITLE
gr: adjust for wcstok changes in mingw-w64

### DIFF
--- a/mingw-w64-gr/0001-support-mingw-wcstok.patch
+++ b/mingw-w64-gr/0001-support-mingw-wcstok.patch
@@ -1,0 +1,43 @@
+diff -Nur gr-0.71.7-orig/lib/gks/font.c gr-0.71.7/lib/gks/font.c
+--- gr-0.71.7-orig/lib/gks/font.c	2023-02-13 11:01:28.000000000 +0100
++++ gr-0.71.7/lib/gks/font.c	2023-02-24 09:41:12.781512700 +0100
+@@ -15,7 +15,6 @@
+ 
+ #if defined(_WIN32)
+ #define STRSAFE_NO_DEPRECATE
+-#define _CRT_NON_CONFORMING_WCSTOK
+ #define __STRSAFE__NO_INLINE
+ #include <windows.h>
+ #include <strsafe.h>
+diff -Nur gr-0.71.7-orig/lib/gks/ft.c gr-0.71.7/lib/gks/ft.c
+--- gr-0.71.7-orig/lib/gks/ft.c	2023-02-13 11:01:28.000000000 +0100
++++ gr-0.71.7/lib/gks/ft.c	2023-02-24 09:45:53.250842700 +0100
+@@ -340,6 +340,10 @@
+ static int ft_find_font(const ft_path_char_t *filename, ft_path_char_t *result)
+ {
+ #if defined(_WIN32)
++  #ifndef _UCRT
++    #define wcstok(strToken, strDelimit, context) wcstok(strToken, strDelimit)
++  #endif
++
+   const ft_path_char_t **font_directory;
+   ft_path_char_t abspath[MAXPATHLEN];
+   ft_path_char_t env[MAXPATHLEN];
+@@ -354,14 +358,15 @@
+   /* search paths from `GKS_FONT_DIRS` environment variable */
+   if (GetEnvironmentVariableW(L"GKS_FONT_DIRS", env, MAXPATHLEN))
+     {
+-      gks_font_dir = wcstok(env, delim);
++      wchar_t *buffer;
++      gks_font_dir = wcstok(env, delim, &buffer);
+       while (gks_font_dir)
+         {
+           if (ft_search_file_in_dir(gks_font_dir, filename, result, 0))
+             {
+               return 1;
+             }
+-          gks_font_dir = wcstok(NULL, delim);
++          gks_font_dir = wcstok(NULL, delim, &buffer);
+         }
+     }
+ 

--- a/mingw-w64-gr/PKGBUILD
+++ b/mingw-w64-gr/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gr
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.71.7
-pkgrel=2
+pkgrel=3
 pkgdesc="A graphics library for visualisation applications (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -27,8 +27,10 @@ depends=("${MINGW_PACKAGE_PREFIX}-bzip2"
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
-source=("${_realname}-${pkgver}.tar.gz::https://github.com/sciapp/gr/archive/v${pkgver}.tar.gz")
-sha256sums=('781bd832e55939daa7362f86476b67eaa4158beacfdeadb8c4d41be0dab10c54')
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/sciapp/gr/archive/v${pkgver}.tar.gz"
+        "0001-support-mingw-wcstok.patch")
+sha256sums=('781bd832e55939daa7362f86476b67eaa4158beacfdeadb8c4d41be0dab10c54'
+            'c3209d0ea7816b24549766cce3dabe21b81d1f4ddc9dd752b132a1db9c79f8be')
 noextract=("${_realname}-${pkgver}.tar.gz")
 
 prepare() {
@@ -42,6 +44,8 @@ prepare() {
   # Set version manually, otherwise it resets to zero
   echo "${pkgver}" > version.txt
   sed -i "s|\${GR_VERSION}|${pkgver}|g" CMakeLists.txt
+
+  patch -p1 -i "${srcdir}/0001-support-mingw-wcstok.patch"
 }
 
 build() {


### PR DESCRIPTION
likely broken before, but
https://github.com/mingw-w64/mingw-w64/commit/40134887fb81f5be451b5c4c uncovered it, resulting in a build error.