### PR TITLE
gdb: change multiarch dependency to match gdb exact version

### DIFF
--- a/mingw-w64-gdb/PKGBUILD
+++ b/mingw-w64-gdb/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-multiarch")
 pkgver=13.1
-pkgrel=2
+pkgrel=3
 pkgdesc="GNU Debugger (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -136,7 +136,7 @@ package_gdb() {
 
 package_gdb-multiarch() {
   pkgdesc="GNU Debugger (supports all targets)"
-  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}")
 
   builddir=${srcdir}/build-${MSYSTEM}-multiarch
   cd ${builddir}


### PR DESCRIPTION
It uses artifacts from gdb package, so they must match.