### PR TITLE
unicorn: Fix python bindings library

### DIFF
--- a/mingw-w64-unicorn/001-bindings-python.patch
+++ b/mingw-w64-unicorn/001-bindings-python.patch
@@ -1,13 +1,28 @@
---- unicorn-2.0.0-rc5/bindings/python/setup.py.orig	2022-01-14 00:15:15.621000000 +0100
-+++ unicorn-2.0.0-rc5/bindings/python/setup.py	2022-01-14 09:15:19.615579000 +0100
-@@ -35,8 +35,8 @@
-     LIBRARY_FILE = "libunicorn.dylib"
-     STATIC_LIBRARY_FILE = None
+diff --git a/bindings/python/setup.py b/bindings/python/setup.py
+index 8c579ad3..28622d30 100755
+--- a/bindings/python/setup.py
++++ b/bindings/python/setup.py
+@@ -35,8 +35,8 @@ if SYSTEM == 'darwin':
+     LIBRARY_FILE = "libunicorn.2.dylib"
+     STATIC_LIBRARY_FILE = "libunicorn.a"
  elif SYSTEM in ('win32', 'cygwin'):
 -    LIBRARY_FILE = "unicorn.dll"
 -    STATIC_LIBRARY_FILE = "unicorn.lib"
 +    LIBRARY_FILE = "libunicorn.dll"
 +    STATIC_LIBRARY_FILE = "libunicorn.a"
  else:
-     LIBRARY_FILE = "libunicorn.so"
-     STATIC_LIBRARY_FILE = None
+     LIBRARY_FILE = "libunicorn.so.2"
+     STATIC_LIBRARY_FILE = "libunicorn.a"
+diff --git a/bindings/python/unicorn/unicorn.py b/bindings/python/unicorn/unicorn.py
+index 2e6a938f..86d3e306 100644
+--- a/bindings/python/unicorn/unicorn.py
++++ b/bindings/python/unicorn/unicorn.py
+@@ -23,7 +23,7 @@ if _python2:
+     range = xrange
+ 
+ _lib = { 'darwin': 'libunicorn.2.dylib',
+-         'win32': 'unicorn.dll',
++         'win32': 'libunicorn.dll',
+          'cygwin': 'cygunicorn.dll',
+          'linux': 'libunicorn.so.2',
+          'linux2': 'libunicorn.so.2' }

--- a/mingw-w64-unicorn/PKGBUILD
+++ b/mingw-w64-unicorn/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-unicorn"
          "${MINGW_PACKAGE_PREFIX}-python-unicorn")
 pkgver=2.0.1.post1
-pkgrel=1
+pkgrel=2
 pkgdesc="A lightweight multi-platform, multi-architecture CPU emulator framework based on QEMU (mingw-w64)"
 url='https://www.unicorn-engine.org/index.html'
 arch=('any')
@@ -22,7 +22,7 @@ source=("${_realname}-${pkgver}.tar.gz::https://github.com/unicorn-engine/unicor
         "001-bindings-python.patch"
         "002-getpagesize-clang.patch")
 sha512sums=('8694d6bc92e3424a8ad050316413d53e56e0f55e7cad7517fb3e98e670a0f1768b060ead8f195da13607cec89a964364f05a8b9d0dc074f4ac5e51026f8343ad'
-            '1d849580a7c79db1090d17b10cf4f5c80e2d545da9e7e2f540e3c59318d343fa8e5176a76ef4e19a2734b96891c0543189693534811c6ad369185461067d0356'
+            '966ba5eeae1e72c400fc7f6a7f3a9b14afb9b0abf02c53e1ca18b7cad9e84705b8fd86fe8f42fd5d59a4bab312986952cc07119f4b1d70d4973850b16f5e1aa9'
             'ba35ee611ee312c851a07533caaf8a7a6c6a398fe3544c9ba843a2e3c333859ef0433fbbee28ff0aaa61893f44cea45691339fcc05779a3837ae5fdbdd87577a')
 
 prepare() {


### PR DESCRIPTION
```bash
$ python -c 'import unicorn'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:/msys64/mingw64/lib/python3.10/site-packages/unicorn/__init__.py", line 4, in <module>
    from .unicorn import Uc, uc_version, uc_arch_supported, version_bind, debug, UcError, __version_
_
  File "C:/msys64/mingw64/lib/python3.10/site-packages/unicorn/unicorn.py", line 114, in <module>
    raise ImportError("ERROR: fail to load the dynamic library.")
ImportError: ERROR: fail to load the dynamic library.
```