### PR TITLE
ghdl: update to 2.0.0.r1392.g19babff18

### DIFF
--- a/mingw-w64-ghdl/PKGBUILD
+++ b/mingw-w64-ghdl/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=ghdl
 pkgbase="mingw-w64-${_realname}"
 pkgname='__placeholder__'
-pkgver=2.0.0.r870.g1cc85c578
+pkgver=2.0.0.r1392.g19babff18
 pkgrel=1
 pkgdesc='GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL'
 arch=('any')
@@ -12,7 +12,7 @@ groups=("${MINGW_PACKAGE_PREFIX}-eda")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 
-_commit="1cc85c57"
+_commit="19babff1"
 source=("${_realname}::git+https://github.com/ghdl/ghdl.git#commit=${_commit}")
 sha512sums=('SKIP')
 


### PR DESCRIPTION
Some months went by since we last updated it: #13819.