### PR TITLE
python-xpra: update dependencies.

### DIFF
--- a/mingw-w64-python-xpra/PKGBUILD
+++ b/mingw-w64-python-xpra/PKGBUILD
@@ -9,7 +9,7 @@ replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
           "${MINGW_PACKAGE_PREFIX}-${_realname}-common")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=4.3.4
-pkgrel=5
+pkgrel=6
 pkgdesc='Remote access client/server software (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -24,6 +24,7 @@ depends=(
     ${MINGW_PACKAGE_PREFIX}-libyuv
     ${MINGW_PACKAGE_PREFIX}-python
     ${MINGW_PACKAGE_PREFIX}-python-comtypes
+    ${MINGW_PACKAGE_PREFIX}-python-gobject
     ${MINGW_PACKAGE_PREFIX}-python-lz4
     ${MINGW_PACKAGE_PREFIX}-python-pillow
     ${MINGW_PACKAGE_PREFIX}-python-pyopengl
@@ -32,6 +33,7 @@ depends=(
     ${MINGW_PACKAGE_PREFIX}-libx264)
 optdepends=(
     "${MINGW_PACKAGE_PREFIX}-libnotify: notification support"
+    "${MINGW_PACKAGE_PREFIX}-gstreamer: audio/video streaming support"
     "${MINGW_PACKAGE_PREFIX}-gst-plugins-bad: extra audio codecs"
     "${MINGW_PACKAGE_PREFIX}-gst-plugins-ugly: extra audio codecs"
     "${MINGW_PACKAGE_PREFIX}-gst-plugins-good: extra audio codecs"
@@ -44,7 +46,8 @@ optdepends=(
     "${MINGW_PACKAGE_PREFIX}-python-ldap3: LDAP authentication via python-ldap3"
     "${MINGW_PACKAGE_PREFIX}-python-cryptography: AES packet encryption"
     "${MINGW_PACKAGE_PREFIX}-python-zeroconf: mDNS support"
-    "${MINGW_PACKAGE_PREFIX}-python-nvidia-ml: nvidia GPU support")
+    "${MINGW_PACKAGE_PREFIX}-python-nvidia-ml: nvidia GPU support"
+    "${MINGW_PACKAGE_PREFIX}-python-pyopengl-accelerate: OpenGL-accelerate support")
 makedepends=(
     ${MINGW_PACKAGE_PREFIX}-brotli
     ${MINGW_PACKAGE_PREFIX}-cython


### PR DESCRIPTION
xpra needs `python-gobject` to start.

`gstreamer` and `python-pyopengl-accelerate` are added to optional dependencies because xpra warns about that.