### PR TITLE
creduce: drop dependency on perl-Sys-CPU

### DIFF
--- a/mingw-w64-creduce/PKGBUILD
+++ b/mingw-w64-creduce/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 pkgver=2.10.0.r96.g8d56bee
-pkgrel=1
+pkgrel=2
 _commit=8d56bee3e1d2577fc8afd2ecc03b1323d6873404
 pkgdesc="A C program reducer (mingw-w64)"
 depends=('perl-Benchmark-Timer'
@@ -13,7 +13,6 @@ depends=('perl-Benchmark-Timer'
          'perl-File-Which'
          'perl-Getopt-Tabular'
          'perl-Regexp-Common'
-         'perl-Sys-CPU'
          "${MINGW_PACKAGE_PREFIX}-astyle"
          "${MINGW_PACKAGE_PREFIX}-indent"
          "${MINGW_PACKAGE_PREFIX}-clang")


### PR DESCRIPTION
upstream no longer uses it since
https://github.com/csmith-project/creduce/pull/164