### PR TITLE
python-docutils: create .exe launchers for all scripts

### DIFF
--- a/mingw-w64-python-docutils/PKGBUILD
+++ b/mingw-w64-python-docutils/PKGBUILD
@@ -8,61 +8,53 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=0.18.1
-pkgrel=3
+pkgrel=4
 pkgdesc="Set of tools for processing plaintext docs into formats such as HTML, XML, or LaTeX (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 license=('custom')
 url="https://docutils.sourceforge.io/"
 depends=("${MINGW_PACKAGE_PREFIX}-python")
-makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
-source=(https://downloads.sourceforge.net/${_realname}/${_realname}-${pkgver}.tar.gz)
-sha256sums=('679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06')
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-python-build"
+  "${MINGW_PACKAGE_PREFIX}-python-installer"
+  "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+  "${MINGW_PACKAGE_PREFIX}-python-wheel"
+)
+source=(https://downloads.sourceforge.net/${_realname}/${_realname}-${pkgver}.tar.gz
+        pyscript2exe.py)
+sha256sums=('679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06'
+            'e57174517b08cf8f9fb4f43a381d342d23d2db3cad661107f35ca21c39b5734d')
 noextract=(${_realname}-${pkgver}.tar.gz)
 
 prepare() {
-  [[ -d ${srcdir}/${_realname}-${pkgver} ]] && rm -rf ${srcdir}/${_realname}-${pkgver}
   tar -xzf ${srcdir}/${_realname}-${pkgver}.tar.gz -C ${srcdir} || true
 
-  rm -rf python-build-${MSYSTEM} | true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 
 build() {
-  msg "Python build for ${MSYSTEM}"
   cd "${srcdir}/python-build-${MSYSTEM}"
-  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-      ${MINGW_PREFIX}/bin/python setup.py build --build-lib=build/python
-  find build/python -type f -exec \
-      sed -i "1s,^#! \?/usr/bin/\(env \|\)python$,#!${MINGW_PREFIX}/bin/python," {} \;
+
+  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 check() {
-  export LANG=en_US.UTF-8
-  msg "Python test for ${MSYSTEM}"
   cd "${srcdir}/python-build-${MSYSTEM}"
-  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-       PYTHONPATH="$PWD/build/python/" ${MINGW_PREFIX}/bin/python test/alltests.py
+
+  PYTHONUTF8=1 PYTHONPATH="$PWD/build/python/" ${MINGW_PREFIX}/bin/python test/alltests.py
 }
 
 package() {
   cd "${srcdir}/python-build-${MSYSTEM}"
-  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  ${MINGW_PREFIX}/bin/python setup.py build --build-lib=build/python \
-      install --prefix=${MINGW_PREFIX} --root="${pkgdir}" --optimize=1 --skip-build
 
-  local _mingw_prefix=$(cygpath -am ${MINGW_PREFIX})
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
 
   for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
-    sed -e "s|${_mingw_prefix}/bin/|/usr/bin/env |g" -i ${_f}
-  done
-
-  # symlink without .py
-  for f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
-    ln -s "$(basename $f)" "${pkgdir}${MINGW_PREFIX}/bin/$(basename $f .py)"
-    # fix so the file is a script that can run with no issues on the command-line w/o
-    # specifying an interpreter
-    sed -e "s|/usr/bin/env python.exe|${MINGW_PREFIX}/bin/python.exe|g" -i "${pkgdir}${MINGW_PREFIX}/bin/$(basename $f .py)"
+    ${MINGW_PREFIX}/bin/python \
+      "${srcdir}/pyscript2exe.py" "${_f}"
   done
 
   # setup license

--- a/mingw-w64-python-docutils/pyscript2exe.py
+++ b/mingw-w64-python-docutils/pyscript2exe.py
@@ -1,0 +1,19 @@
+"""
+Creates an exe launcher for Python scripts for the executing interpreter.
+foobar.py -> foobar.exe + foobar-script.py
+"""
+
+import sys
+import re
+import os
+from setuptools.command.easy_install import get_win_launcher
+
+path = sys.argv[1]
+with open(path, "rb") as f:
+    data = f.read()
+with open(path, "wb") as f:
+    f.write(re.sub(b"^#![^\n\r]*", b'', data))
+root, ext = os.path.splitext(path)
+with open(root + ".exe", "wb") as f:
+    f.write(get_win_launcher("cli"))
+os.rename(path, root + "-script.py")


### PR DESCRIPTION
and port to build/installer while at it


motivated by virt-manager calling them without an interpreter
The next docutils will have a central .exe launcher and the old scripts
will be deprecated, so this should fix itself over time.