### PR TITLE
octave: link against openblas instead of lapack

### DIFF
--- a/mingw-w64-octave/PKGBUILD
+++ b/mingw-w64-octave/PKGBUILD
@@ -2,7 +2,7 @@ _realname=octave
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=7.3.0
-pkgrel=12
+pkgrel=13
 pkgdesc="GNU Octave: Interactive programming environment for numerical computations (mingw-w64)"
 url="https://www.octave.org"
 license=('spdx:GPL-3.0-or-later')
@@ -10,7 +10,7 @@ arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran")
-         "${MINGW_PACKAGE_PREFIX}-lapack"
+         "${MINGW_PACKAGE_PREFIX}-openblas"
          "${MINGW_PACKAGE_PREFIX}-arpack"
          "${MINGW_PACKAGE_PREFIX}-curl"
          "${MINGW_PACKAGE_PREFIX}-fftw"
@@ -74,6 +74,12 @@ prepare() {
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
 
+  declare -a _extra_config
+  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
+    export F77=${MINGW_PREFIX}/bin/flang
+    _extra_config+=("--enable-fortran-calling-convention=gfortran")
+  fi
+
   # The configure step sometimes hangs for MINGW32 for currently unknown reasons.
   # Add a timeout of 30 minutes (well over what should be needed) to unblock
   # the build system in that case.
@@ -89,6 +95,8 @@ build() {
     --disable-static \
     --enable-relocate-all \
     --enable-link-all-dependencies \
+    --with-blas=-lopenblas \
+    "${_extra_config[@]}" \
     ac_cv_search_tputs=-ltermcap \
     gl_cv_have_weak=no \
     octave_cv_fftw3_threads_lib="-lfftw3_omp" \


### PR DESCRIPTION
This should make octave compute faster. waiting for some tests from @mmuetzel 