### PR TITLE
qrupdate: Require OpenBLAS in pkg-config file

### DIFF
--- a/mingw-w64-qrupdate/PKGBUILD
+++ b/mingw-w64-qrupdate/PKGBUILD
@@ -7,7 +7,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-svn")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-svn")
 pkgver=1.1.5
-pkgrel=1
+pkgrel=2
 pkgdesc="Fortran library for fast updates of QR and Cholesky decompositions (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -65,6 +65,9 @@ package() {
 
   cd "${srcdir}/build-${MSYSTEM}-shared"
   DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
+
+  # Avoid linking to a mixture of reference BLAS/LAPACK and OpenBLAS in dependent projects
+  sed -s "s|Requires: blas, lapack|Requires.private: openblas|g" -i ${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/qrupdate.pc
 
   install -Dm644 "${srcdir}/${_realname}-ng-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
We are building qrupdate with OpenBLAS. However, pkgconf returns the following for it:
```
$ pkgconf --libs qrupdate
-lqrupdate -L/mingw64/lib -lblas -llapack
```
IIUC, this could lead to overlinking when linking the shared library. And probably worse, it could lead to the situation where downstream projects are effectively linking to a mixture of reference BLAS/LAPACK and OpenBLAS.

With the changes from this PR, pkgconf returns the following:
```
$ pkgconf --libs qrupdate
-lqrupdate

$ pkgconf --libs --static qrupdate
-lqrupdate -fopenmp -lopenblas
```