### PR TITLE
verilator: update to 5.012

### DIFF
--- a/mingw-w64-verilator/PKGBUILD
+++ b/mingw-w64-verilator/PKGBUILD
@@ -7,7 +7,8 @@ pkgver=5.012
 pkgrel=1
 pkgdesc="The fastest free Verilog HDL simulator (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+# Not enough memory on GitHub's runners to build 'clang32'.
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://www.veripool.org/projects/verilator/wiki/Intro"
 license=("LGPL")
 groups=("${MINGW_PACKAGE_PREFIX}-eda")

--- a/mingw-w64-verilator/PKGBUILD
+++ b/mingw-w64-verilator/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=verilator
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=5.008
+pkgver=5.012
 pkgrel=1
 pkgdesc="The fastest free Verilog HDL simulator (mingw-w64)"
 arch=('any')
@@ -20,7 +20,7 @@ makedepends=(
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 
 source=("${_realname}-${pkgver}.tar.gz::https://codeload.github.com/${_realname}/${_realname}/tar.gz/v${pkgver}")
-sha256sums=('1d19f4cd186eec3dfb363571e3fe2e6d3377386ead6febc6ad45402f0634d2a6')
+sha256sums=('db19a7d7615b37d9108654e757427e4c3f44e6e973ed40dd5e0e80cc6beb8467')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}

--- a/mingw-w64-verilator/PKGBUILD
+++ b/mingw-w64-verilator/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=verilator
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=5.006
+pkgver=5.008
 pkgrel=1
 pkgdesc="The fastest free Verilog HDL simulator (mingw-w64)"
 arch=('any')
@@ -11,14 +11,16 @@ mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://www.veripool.org/projects/verilator/wiki/Intro"
 license=("LGPL")
 groups=("${MINGW_PACKAGE_PREFIX}-eda")
-makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-autotools"
-             "${MINGW_PACKAGE_PREFIX}-python"
-             "help2man")
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-autotools"
+  "${MINGW_PACKAGE_PREFIX}-python"
+  "help2man"
+)
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 
-source=("${_realname}-${pkgver}.tar.gz::https://github.com/${_realname}/${_realname}/archive/v${pkgver}.tar.gz")
-sha256sums=('eb4ca4157ba854bc78c86173c58e8bd13311984e964006803dd45dc289450cfe')
+source=("${_realname}-${pkgver}.tar.gz::https://codeload.github.com/${_realname}/${_realname}/tar.gz/v${pkgver}")
+sha256sums=('1d19f4cd186eec3dfb363571e3fe2e6d3377386ead6febc6ad45402f0634d2a6')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}


### PR DESCRIPTION
Verilator 5.008 was released: https://github.com/verilator/verilator-announce/issues/60