### PR TITLE
ruby: add clangarm64 patch (still broken)

### DIFF
--- a/mingw-w64-ruby/0009-windows-arm64.patch
+++ b/mingw-w64-ruby/0009-windows-arm64.patch
@@ -1,0 +1,29 @@
+--- a/configure.ac	2022-09-17 20:44:42.375546800 +0200
++++ b/configure.ac	2022-09-17 20:49:48.224691700 +0200
+@@ -2541,6 +2541,9 @@
+         [*86-mingw*], [
+             coroutine_type=win32
+         ],
++        [aarch64-mingw*], [
++            coroutine_type=arm64
++        ],
+         [arm*-linux*], [
+             coroutine_type=arm32
+         ],
+--- a/vm_dump.c	2022-04-12 13:11:15.000000000 +0200
++++ b/vm_dump.c	2022-09-17 20:52:16.559409600 +0200
+@@ -701,6 +701,14 @@
+ 		    frame.AddrFrame.Offset = context.Rbp;
+ 		    frame.AddrStack.Mode = AddrModeFlat;
+ 		    frame.AddrStack.Offset = context.Rsp;
++#elif defined(__aarch64__)
++		    mac = IMAGE_FILE_MACHINE_ARM64;
++		    frame.AddrPC.Mode = AddrModeFlat;
++		    frame.AddrPC.Offset = context.Pc;
++		    frame.AddrFrame.Mode = AddrModeFlat;
++		    frame.AddrFrame.Offset = context.Fp;
++		    frame.AddrStack.Mode = AddrModeFlat;
++		    frame.AddrStack.Offset = context.Sp;
+ #else	/* i386 */
+ 		    mac = IMAGE_FILE_MACHINE_I386;
+ 		    frame.AddrPC.Mode = AddrModeFlat;

--- a/mingw-w64-ruby/PKGBUILD
+++ b/mingw-w64-ruby/PKGBUILD
@@ -31,7 +31,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 source=("https://cache.ruby-lang.org/pub/ruby/${pkgver%.*}/${_realname}-${pkgver}.tar.gz"
         0003-fix-check-types.patch
         0007-nm-use-full-options.patch
-        0008-ucrt-32-win11-insns.patch)
+        0008-ucrt-32-win11-insns.patch
+        0009-windows-arm64.patch)
 ## Populated by the updpkgprovs script
 provides=(
     "${MINGW_PACKAGE_PREFIX}-ruby-debug=1.6.3"
@@ -125,7 +126,8 @@ provides=(
 sha256sums=('5ea498a35f4cd15875200a52dde42b6eb179e1264e17d78732c3a57cd1c6ab9e'
             'e5d665cabac8b7fbb0dda9a556c2350190801aa07b3cb90a0d50097ab99272a0'
             'b250c66bc8b372fb4c53902a6d56c01ad057416e3e368a5c5434d9a4ebdc3819'
-            'c9f816baf5b2803e017924c7eeef6a478beb76247d6d4b39a2424c8d34687b2b')
+            'c9f816baf5b2803e017924c7eeef6a478beb76247d6d4b39a2424c8d34687b2b'
+            'f3a61f6d600bb962f23e4ff1c0857120630541d8fcb542957dc0848b00a39690')
 noextract=(${_realname}-${pkgver}.tar.gz)
 
 apply_patch_with_msg() {
@@ -155,7 +157,8 @@ prepare() {
   apply_patch_with_msg \
       0003-fix-check-types.patch \
       0007-nm-use-full-options.patch \
-      0008-ucrt-32-win11-insns.patch
+      0008-ucrt-32-win11-insns.patch \
+      0009-windows-arm64.patch
 
   autoreconf -fi
 }


### PR DESCRIPTION
This is #13115, but only the patch