### PR TITLE
libvirt: Enable docs with meson workaround

### DIFF
--- a/mingw-w64-libvirt/PKGBUILD
+++ b/mingw-w64-libvirt/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 _pkgdev=9.1.0
 pkgver=${_pkgdev//-/}
-pkgrel=1
+pkgrel=2
 pkgdesc="Windows libvirt virtualization library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -97,11 +97,11 @@ build() {
     -Daudit=disabled \
     -Ddtrace=disabled \
     -Dtests=disabled \
-    -Ddocs=disabled \
     -Dexpensive_tests=disabled \
     ../${_realname}-${_pkgdev%-*}
 
-  ${MINGW_PREFIX}/bin/meson compile
+  # Workaround for meson issues with docs for virt-manager (#11864 and #16090)
+  ${MINGW_PREFIX}/bin/meson compile || ${MINGW_PREFIX}/bin/meson compile -j1
 }
 
 check() {


### PR DESCRIPTION
Docs are required for virt-manager, reported by @1480c1 