### PR TITLE
i2pd: update to 2.47.0

### DIFF
--- a/mingw-w64-i2pd/0001-i2pd-makefile.patch
+++ b/mingw-w64-i2pd/0001-i2pd-makefile.patch
@@ -1,19 +1,20 @@
 --- a/Makefile.mingw
 +++ b/Makefile.mingw
-@@ -5,7 +5,6 @@ WINDRES = windres
+@@ -5,7 +5,7 @@ WINDRES = windres
  
  CXXFLAGS := $(CXX_DEBUG) -fPIC -msse
- INCFLAGS = -I$(DAEMON_SRC_DIR) -IWin32
+ INCFLAGS := -I$(DAEMON_SRC_DIR) -IWin32
 -LDFLAGS := ${LD_DEBUG} -static
++LDFLAGS := ${LD_DEBUG}
  
- NEEDED_CXXFLAGS += -std=c++17 -DWIN32_LEAN_AND_MEAN
- 
-@@ -14,7 +13,7 @@ BOOST_SUFFIX = -mt
+ NEEDED_CXXFLAGS += -std=c++17
+ DEFINES += -DWIN32_LEAN_AND_MEAN
+@@ -15,7 +15,7 @@ BOOST_SUFFIX = -mt
  
  # UPNP Support
  ifeq ($(USE_UPNP),yes)
--	CXXFLAGS += -DUSE_UPNP -DMINIUPNP_STATICLIB
-+	CXXFLAGS += -DUSE_UPNP
+-	DEFINES += -DUSE_UPNP -DMINIUPNP_STATICLIB
++	DEFINES += -DUSE_UPNP
  	LDLIBS = -lminiupnpc
  endif
  

--- a/mingw-w64-i2pd/PKGBUILD
+++ b/mingw-w64-i2pd/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=i2pd
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-pkgver=2.46.1
+pkgver=2.47.0
 pkgrel=1
 pkgdesc='A full-featured C++ implementation of the I2P router (mingw-w64)'
 url='https://i2pd.website/'
@@ -16,43 +16,63 @@ depends=("${MINGW_PACKAGE_PREFIX}-boost"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-miniupnpc"
          "${MINGW_PACKAGE_PREFIX}-libwinpthread-git")
-makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/PurpleI2P/i2pd/archive/${pkgver}.tar.gz"
-        "0001-i2pd-makefile.patch")
-sha256sums=('76b41d02a41a03d627fcd7fe695cad7f521b66e99a04ec9678f132a1eb052bb8'
-            '5e9f02036dc544dd4695993a8d8dab088d8470b8d3a118d92702e7f8c8f0e4d9')
+        "0001-i2pd-makefile.patch"
+        "0002-cmake-nonstatic.patch::https://github.com/PurpleI2P/i2pd/commit/8677cd54bd4d145e3bba7044484dcba4eed73a85.patch")
+sha256sums=('c988baf23215c37d5f566b7b2059a3c168c78d157eac6dc04a30ac266c6335f0'
+            '4f0927a0ad735cd0fa30f5ef57f4ac686c07d256ac7f015722a65b0c1b2a0b8f'
+            'ebb8fe70f750da31243db0b907b9aaec08c4463d622b9088de045ef93285c79e')
 noextract=("${_realname}-${pkgver}.tar.gz") # symlinks
 
 prepare() {
   tar -xf "${_realname}-${pkgver}.tar.gz" || true
   cd "${_realname}-${pkgver}"
   patch -Np1 -i "${srcdir}"/0001-i2pd-makefile.patch
+  patch -Np1 -i "${srcdir}"/0002-cmake-nonstatic.patch
 }
 
 build() {
-  cp -rf "${_realname}-${pkgver}" "build-${MSYSTEM}"
-  cd "${srcdir}"/build-${MSYSTEM}
+  [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
-  make USE_UPNP=yes
+  declare -a _extra_config
+  if check_option "debug" "n"; then
+    _extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    _extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G "Ninja" \
+    "${_extra_config[@]}" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DWITH_UPNP=ON \
+    ../${_realname}-${pkgver}/build
+
+  ${MINGW_PREFIX}/bin/cmake.exe --build ./
 }
 
 package() {
   cd "${srcdir}"/build-${MSYSTEM}
 
-  #bin
+  # bin
   install -d "${pkgdir}${MINGW_PREFIX}/bin/"
   cp i2pd.exe "${pkgdir}${MINGW_PREFIX}/bin/"
 
-  #config
+  # config
   install -d "${pkgdir}${MINGW_PREFIX}/etc/i2pd"
-  cp contrib/{i2pd,tunnels}.conf "${pkgdir}${MINGW_PREFIX}/etc/i2pd"
+  cp ../${_realname}-${pkgver}/contrib/{i2pd,tunnels}.conf "${pkgdir}${MINGW_PREFIX}/etc/i2pd"
   install -d "${pkgdir}${MINGW_PREFIX}/etc/i2pd/tunnels.d"
-  cp contrib/tunnels.d/{*.conf,README} "${pkgdir}${MINGW_PREFIX}/etc/i2pd/tunnels.d"
+  cp ../${_realname}-${pkgver}/contrib/tunnels.d/{*.conf,README} "${pkgdir}${MINGW_PREFIX}/etc/i2pd/tunnels.d"
 
   # certificates
   install -d "${pkgdir}${MINGW_PREFIX}/share/i2pd"
-  cp -r contrib/certificates "${pkgdir}${MINGW_PREFIX}/share/i2pd"
+  cp -r ../${_realname}-${pkgver}/contrib/certificates "${pkgdir}${MINGW_PREFIX}/share/i2pd"
 
   # license
-  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
+  install -Dm644 ../${_realname}-${pkgver}/LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
 }


### PR DESCRIPTION
Note: we have added cmake support, but there is no install target for the configs and certificates, that's why `install` done manually.

Patch `0002-cmake-nonstatic.patch` included directly from repository and can be removed in next release.