### PR TITLE
qemu: update to 8.0.0

### DIFF
--- a/mingw-w64-qemu/PKGBUILD
+++ b/mingw-w64-qemu/PKGBUILD
@@ -6,16 +6,16 @@ pkgname=(
   "${MINGW_PACKAGE_PREFIX}-qemu-guest-agent"
   "${MINGW_PACKAGE_PREFIX}-qemu-image-util"
 )
-_base_ver="7.2.0"
+_base_ver="8.0.0"
 # QEMU Versioning of RC-SourcePackage and RC-Version differs
 # e.g. qemu-6.1.0-rc0.tar.xz contains 6.0.90, qemu-6.1.0-rc1.tar.xz contains 6.0.91
 # Unset _rc_no to create Release-Build
 #_rc_no="4"
-_rc_base_ver="7.1.9${_rc_no}"
+_rc_base_ver="7.2.9${_rc_no}"
 _rc_file_ver="rc${_rc_no}"
 _tarname=$( [ -z "${_rc_no}" ] && echo ${_realname}-${_base_ver} || echo ${_realname}-${_base_ver}-${_rc_file_ver} )
 pkgver=$( [ -z "${_rc_no}" ] && echo ${_base_ver} || echo ${_rc_base_ver} )
-pkgrel=4
+pkgrel=1
 pkgdesc="QEMU - a generic and open source machine emulator and virtualizer (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -32,6 +32,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-tools-git"
   "${MINGW_PACKAGE_PREFIX}-cc")
 depends=(
+  "${MINGW_PACKAGE_PREFIX}-angleproject"
   "${MINGW_PACKAGE_PREFIX}-capstone"
   "${MINGW_PACKAGE_PREFIX}-curl"
   "${MINGW_PACKAGE_PREFIX}-cyrus-sasl"
@@ -97,18 +98,14 @@ source=(
   msys2.readme.txt
   msys2.qemu-guest-agent.txt
   msys2.examples.tests.sh
-  0001-fix-setjmp-longjmp-on-windows-arm64.patch::https://gitlab.com/qemu-project/qemu/-/commit/dbd672c87f19949bb62bfb1fb3a97b9729fd7560.patch
-  0002-fix-cache-on-windows-arm64.patch::https://gitlab.com/qemu-project/qemu/-/commit/b3c326029554a7d134e26e749240ba2d8ac288b1.patch
-  0003-fix-extern-G_NORETURN-position.patch::https://gitlab.com/qemu-project/qemu/-/commit/5cb993ff131fca2abef3ce074a20258fd6fce557.patch
 )
-sha256sums=('5b49ce2687744dad494ae90a898c52204a3406e84d072482a1e1be854eeb2157'
-            'SKIP'
-            '51625fd83c0a63729942d3dfc6d48be3491a700fe0f7cb8e88935b46081c9016'
-            'f2f9eeb31023d002f54637a9941ea0d8fae3c6f0a66c05c033857b305bd1470d'
-            'cbd98e3fd555a49604db8c61e829bf803a79c7b7da814971a3947ef9dc0e844e'
-            'a9e8db33a1eae3055a35242532e068a6aa38056b196f4ac9bc244e1d6b0a510a'
-            '80a91bdedd01cc759108ec34e28ea510aae8090f9fd6103b0ddd61a961ab7dc3'
-            '7cf3a4ef3b4a3de9bb3aa8ad9e4e18f51883d34f8ac25b32ae2174e928de18c9')
+sha256sums=(
+  'bb60f0341531181d6cc3969dd19a013d0427a87f918193970d9adb91131e56d0'
+  'SKIP'
+  '51625fd83c0a63729942d3dfc6d48be3491a700fe0f7cb8e88935b46081c9016'
+  'f2f9eeb31023d002f54637a9941ea0d8fae3c6f0a66c05c033857b305bd1470d'
+  '6adfb4c37dc259b216fd327d8da1307cedc970a34ee09b33eab1ba2cecc1ce68'
+)
 validpgpkeys=('CEACC9E15534EBABB82D3FA03353C9CEF108B584') # Michael Roth <flukshun@gmail.com>
 # tar cannot create links, to keep build running, manual extraction is required
 noextract=(${_tarname}.tar.xz)
@@ -117,11 +114,6 @@ prepare() {
   [[ -d "${srcdir}"/${_tarname} ]] && rm -rf "${srcdir}"/${_tarname}
   # tar cannot create links here, therefore hide the failure
   tar -xf "${srcdir}"/${_tarname}.tar.xz -C "${srcdir}" || true
-
-  cd "${srcdir}/${_tarname}"
-  patch -p1 -i ${srcdir}/0001-fix-setjmp-longjmp-on-windows-arm64.patch
-  patch -p1 -i ${srcdir}/0002-fix-cache-on-windows-arm64.patch
-  patch -p1 -i ${srcdir}/0003-fix-extern-G_NORETURN-position.patch
 }
 
 build() {

--- a/mingw-w64-qemu/msys2.examples.tests.sh
+++ b/mingw-w64-qemu/msys2.examples.tests.sh
@@ -680,7 +680,7 @@ function qemuLiveDesktopQemuImgConversions {
 	# Conversion tests with qcow qcow2 qed raw vdi vhdx vmdk vpc
 	download $LIVE_IMAGE_URL
 	local IMG_SIZE=$(qemu-img info "$LIVE_IMAGE_FILE" |
-		grep bytes | sed "s/.*(//" | sed "s/ bytes.*//")
+		grep "virtual.*bytes" | sed "s/.*(//" | sed "s/ bytes.*//")
 
 	local TESTDIR="qemu-img-conversion" FMT
 	mkdir -p $TESTDIR
@@ -875,7 +875,7 @@ function qemuInstalledDesktopGTK {
 
 # Extended VNC-Desktop (HDImage)
 function qemuInstalledDesktopVNC1 {
-	local IMAGE='\Qemu\test\test-usernet.qcow2'
+	local IMAGE='d:\Qemu\test\test-usernet.qcow2'
 	[ -f "$IMAGE" ] || return 0
 	cygwinXlaunch
 	execute qemu-system-x86_64 -M q35 $(accel) -m 1G -pidfile "$PIDFILE" \
@@ -1209,7 +1209,7 @@ function qemu2018day08 {
 	download https://www.qemu-advent-calendar.org/2018/download/day08.tar.xz
 	tar -xf day08.tar.xz
 	cat day08/readme.txt
-	execute qemu-system-i386 -m 32 -M isapc $(accel) -cpu pentium -no-acpi $(pcspk) \
+	execute qemu-system-i386 -m 32 -M isapc,acpi=off $(accel) -cpu pentium $(pcspk) \
 		-net nic,model=ne2k_isa -net user -drive if=ide,file=day08/hd.qcow2
 	removeDir day08
 }


### PR DESCRIPTION
starting with first build on 8.0.0-rc0

the patches for clangarm64 are already included in source code of 8.0.0-rc and thus removed from build