### PR TITLE
glib-networking: Update to 2.76.0

### DIFF
--- a/mingw-w64-glib-networking/PKGBUILD
+++ b/mingw-w64-glib-networking/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=glib-networking
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.74.0
-pkgrel=2
+pkgver=2.76.0
+pkgrel=1
 pkgdesc="Network-related GIO modules for glib (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -23,7 +23,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 replaces=("${MINGW_PACKAGE_PREFIX}-glib-openssl")
 conflicts=("${MINGW_PACKAGE_PREFIX}-glib-openssl")
 source=("https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz")
-sha256sums=('1f185aaef094123f8e25d8fa55661b3fd71020163a0174adb35a37685cda613b')
+sha256sums=('149a05a179e629a538be25662aa324b499d7c4549c5151db5373e780a1bf1b9a')
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
@@ -33,7 +33,6 @@ build() {
     --prefix="${MINGW_PREFIX}" \
     --buildtype plain \
     --wrap-mode=nodownload \
-    --default-library=both \
     --auto-features=enabled \
     -Dopenssl=enabled \
     ../${_realname}-${pkgver}


### PR DESCRIPTION
Upstream doesn't build any static libs and now fails for library=both, so disable it.

Upstream disabled environment proxy module support by default, this should be handled by libproxy anyway.