### PR TITLE
usbredir: Update to 0.13.0; port to meson

### DIFF
--- a/mingw-w64-usbredir/0001-fix-callback-call-conv.patch
+++ b/mingw-w64-usbredir/0001-fix-callback-call-conv.patch
@@ -1,0 +1,11 @@
+--- usbredir-0.13.0/tools/usbredirect.c.orig	2023-03-20 19:51:42.646876200 +0100
++++ usbredir-0.13.0/tools/usbredirect.c	2023-03-20 19:50:33.779099000 +0100
+@@ -221,7 +221,7 @@
+ }
+ 
+ #if LIBUSBX_API_VERSION >= 0x01000107
+-static void
++static void LIBUSB_CALL
+ debug_libusb_cb(libusb_context *ctx, enum libusb_log_level level, const char *msg)
+ {
+     GLogLevelFlags glog_level;

--- a/mingw-w64-usbredir/PKGBUILD
+++ b/mingw-w64-usbredir/PKGBUILD
@@ -3,42 +3,54 @@
 _realname=usbredir
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.8.0
+pkgver=0.13.0
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 pkgdesc="Parser for the usbredir protocol (mingw-w64)"
-depends=("${MINGW_PACKAGE_PREFIX}-libusb")
-makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
-             "${MINGW_PACKAGE_PREFIX}-cc")
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-libusb"
+  "${MINGW_PACKAGE_PREFIX}-glib2"
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-meson"
+  "${MINGW_PACKAGE_PREFIX}-ninja"
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-pkgconf"
+)
 options=('strip' 'staticlibs')
-license=("GPL 2")
+license=("spdx:GPL-2.0-or-later AND LGPL-2.1-or-later")
 url="https://www.spice-space.org/"
-source=(https://www.spice-space.org/download/usbredir/${_realname}-${pkgver}.tar.bz2)
-sha256sums=('87bc9c5a81c982517a1bec70dc8d22e15ae197847643d58f20c0ced3c38c5e00')
+source=(https://www.spice-space.org/download/usbredir/${_realname}-${pkgver}.tar.xz
+        "0001-fix-callback-call-conv.patch")
+sha256sums=('4ba6faa02c0ae6deeb4c53883d66ab54b3a5899bead42ce4ded9568b9a7dc46e'
+            '27365d5ca6a1c85bed705a1ea0785082f036f99d7f3a11d9e13317da8f89d163')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
+
+  # fails to build for 32bit otherwise because it's expecting __stdcall
+  patch -p1 -i "${srcdir}/0001-fix-callback-call-conv.patch"
 }
 
 build() {
-  [[ -d "${srcdir}"/build-${MINGW_CHOST} ]] && rm -rf "${srcdir}"/build-${MINGW_CHOST}
-  mkdir -p build-${MINGW_CHOST}
-  cd build-${MINGW_CHOST}
+  mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
 
-  ../${_realname}-${pkgver}/configure \
-    --prefix=${MINGW_PREFIX} \
-    --libexecdir=${MINGW_PREFIX}/lib \
-    --host=${MINGW_CHOST} \
-    --target=${MINGW_CHOST} \
-    --build=${MINGW_CHOST}
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    meson setup \
+      --prefix="${MINGW_PREFIX}" \
+      --wrap-mode=nodownload \
+      --auto-features=enabled \
+      --buildtype=plain \
+      ../${_realname}-${pkgver}
 
-  make
+  meson compile
 }
 
 package() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
-  make DESTDIR=${pkgdir} install
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  DESTDIR="${pkgdir}" meson install
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING.LIB" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.LIB"


### PR DESCRIPTION
This drops the static libs, but both users of this don't need them, so should be fine.