### PR TITLE
swi-prolog: remove openjpeg dependency

### DIFF
--- a/mingw-w64-swi-prolog/PKGBUILD
+++ b/mingw-w64-swi-prolog/PKGBUILD
@@ -4,7 +4,7 @@ _realname=swi-prolog
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=9.0.4
-pkgrel=2
+pkgrel=3
 pkgdesc="Prolog environment (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw64' 'mingw32' 'ucrt64' 'clang64' 'clang32')
@@ -26,7 +26,6 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-db"
              "${MINGW_PACKAGE_PREFIX}-pcre2"
              "${MINGW_PACKAGE_PREFIX}-xpm-nox"
-             "${MINGW_PACKAGE_PREFIX}-openjpeg"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
 source=("https://www.swi-prolog.org/download/stable/src/swipl-${pkgver}.tar.gz"
         "01-test_pipe.patch"


### PR DESCRIPTION
from what I see this isn't used and there is also no reference to it in the swi-prolog source.