### PR TITLE
nasm: Update to 2.16.01

### DIFF
--- a/mingw-w64-nasm/PKGBUILD
+++ b/mingw-w64-nasm/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=nasm
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.15.05
+pkgver=2.16.01
 pkgrel=1
 pkgdesc="An 80x86 assembler designed for portability and modularity (mingw-w64)"
 arch=('any')
@@ -14,7 +14,7 @@ options=('strip' '!libtool' 'staticlibs' '!makeflags')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools")
 source=(https://www.nasm.us/pub/nasm/releasebuilds/${pkgver}/${_realname}-${pkgver}.tar.xz)
-sha256sums=('3caf6729c1073bf96629b57cee31eeb54f4f8129b01902c73428836550b30a3f')
+sha256sums=('c77745f4802375efeee2ec5c0ad6b7f037ea9c87c92b149a9637ff099f162558')
 
 build() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
@@ -30,6 +30,6 @@ build() {
 
 package() {
   cd ${srcdir}/build-${MINGW_CHOST}
-  make DESTDIR="${pkgdir}" install install_rdf
+  make DESTDIR="${pkgdir}" install
   install -Dm644 ${srcdir}/${_realname}-${pkgver}/LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
from the changelog:
Support for the rdf format has been discontinued and all the RDOFF utilities has been removed.