### PR TITLE
fritzing: rebuild

### DIFF
--- a/mingw-w64-fritzing/PKGBUILD
+++ b/mingw-w64-fritzing/PKGBUILD
@@ -4,7 +4,7 @@ _realname=fritzing
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.9.9
-pkgrel=1
+pkgrel=2
 pkgdesc="Electronic Design Automation software with a low entry barrier, suited for the needs of makers and hobbyists (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -14,6 +14,7 @@ groups=("${MINGW_PACKAGE_PREFIX}-eda")
 makedepends=("${MINGW_PACKAGE_PREFIX}-boost"
              "${MINGW_PACKAGE_PREFIX}-qt5-tools"
              "${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-pkgconf"
              'git')
 depends=("${MINGW_PACKAGE_PREFIX}-qt5-base"
          "${MINGW_PACKAGE_PREFIX}-qt5-svg"


### PR DESCRIPTION
because it fails in the libgit2 rebuild