### PR TITLE
opencascade: Remove unnecessary batch scripts

### DIFF
--- a/mingw-w64-opencascade/PKGBUILD
+++ b/mingw-w64-opencascade/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=7.7.0
 _pkgver2=V${pkgver//./_}
-pkgrel=5
+pkgrel=6
 pkgdesc='Open CASCADE Technology, 3D modeling & numerical simulation (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -239,6 +239,9 @@ package() {
 
   install -Dm644 "${srcdir}/occt-${_pkgver2}/LICENSE_LGPL_21.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE_LGPL_21.txt"
   install -Dm644 "${srcdir}/occt-${_pkgver2}/OCCT_LGPL_EXCEPTION.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/OCCT_LGPL_EXCEPTION.txt"
+
+  # Remove unnecessary batch scripts (#16304)
+  rm -v "${pkgdir}${MINGW_PREFIX}/bin/"*.bat
 
   # Fix cmake files
   find "${pkgdir}${MINGW_PREFIX}/lib/cmake" -type f \( -name '*.cmake' \) \


### PR DESCRIPTION
The env.bat file get confused with env command in shell. That fails to build qemu.