### PR TITLE
grpc: update to 1.53.0

### DIFF
--- a/mingw-w64-arrow/PKGBUILD
+++ b/mingw-w64-arrow/PKGBUILD
@@ -4,7 +4,7 @@ _realname=arrow
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=11.0.0
-pkgrel=3
+pkgrel=4
 pkgdesc="Apache Arrow is a cross-language development platform for in-memory data (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -55,24 +55,20 @@ validpgpkeys=('35CF82A165DDBBA29B307B7497D7E8647AE7E47B'
               'DB3D3F10215394239119F6F845127976E1E825D4'
               'DF7BAD6652219D7502C87A11CA1AB41406F9DBAD')
 
-cmake_build_type=Release
-meson_build_type=debugoptimized
-
-source_dir=apache-${_realname}-${pkgver}
-cpp_build_dir=build-${MSYSTEM}-cpp
-c_glib_build_dir=build-${MSYSTEM}-c-glib
-
-prepare() {
-  cd "${source_dir}"
-}
+if check_option "debug" "n"; then
+  _cmake_build_type="Release"
+else
+  _cmake_build_type="Debug"
+fi
 
 build() {
-  [[ -d ${cpp_build_dir} ]] && rm -rf ${cpp_build_dir}
-  mkdir -p ${cpp_build_dir} && pushd ${cpp_build_dir}
+  mkdir -p "${srcdir}"/build-${MSYSTEM}-cpp && cd "${srcdir}"/build-${MSYSTEM}-cpp
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake.exe -Wno-dev \
-      ../${source_dir}/cpp \
+      -G Ninja \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      -DCMAKE_BUILD_TYPE=${_cmake_build_type} \
       -DARROW_BUILD_UTILITIES=ON \
       -DARROW_COMPUTE=ON \
       -DARROW_CSV=ON \
@@ -95,46 +91,42 @@ build() {
       -DARROW_WITH_ZLIB=ON \
       -DARROW_WITH_ZSTD=ON \
       -DBOOST_ROOT=${MINGW_PREFIX} \
-      -DCMAKE_BUILD_TYPE=${cmake_build_type} \
-      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
       -DCMAKE_UNITY_BUILD=ON \
       -DPARQUET_BUILD_EXECUTABLES=ON \
       -DPARQUET_REQUIRE_ENCRYPTION=ON \
-      -G Ninja
-  ${MINGW_PREFIX}/bin/cmake --build .
-  popd
+      ../apache-${_realname}-${pkgver}/cpp \
 
-  [[ -d ${c_glib_build_dir} ]] && rm -rf ${c_glib_build_dir}
+  ${MINGW_PREFIX}/bin/cmake --build .
+
+  mkdir -p "${srcdir}"/build-${MSYSTEM}-c-glib && cd "${srcdir}"/build-${MSYSTEM}-c-glib
+
+  declare -a _meson_extra_config
+  if check_option "debug" "n"; then
+    _meson_extra_config+=("--buildtype=release")
+  else
+    _meson_extra_config+=("--buildtype=debug")
+  fi
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
   ${MINGW_PREFIX}/bin/meson setup \
-    ${c_glib_build_dir} \
-    ${source_dir}/c_glib \
-    --buildtype=${meson_build_type} \
     --prefix=${MINGW_PREFIX} \
-    -Darrow_cpp_build_dir=$(pwd)/${cpp_build_dir} \
-    -Darrow_cpp_build_type=${cmake_build_type} \
-    -Dgtk_doc=true
-  sed -i'' -s 's/\r//g' ${c_glib_build_dir}/arrow-glib/version.h
-  PATH=$(pwd)/${cpp_build_dir}/${cmake_build_type}:$PATH \
-    ${MINGW_PREFIX}/bin/meson compile -C ${c_glib_build_dir}
-}
+    ${_meson_extra_config[@]} \
+    -Darrow_cpp_build_dir="${srcdir}"/build-${MSYSTEM}-cpp \
+    -Darrow_cpp_build_type=${_cmake_build_type} \
+    -Dgtk_doc=true \
+    ../apache-${_realname}-${pkgver}/c_glib
 
-check() {
-  # TODO
-  # make -C ${cpp_build_dir} test
+  sed -i'' -s 's/\r//g' arrow-glib/version.h
 
-  # PATH=$(pwd)/${c_glib_build_dir}/arrow-glib:$(pwd)/${cpp_build_dir}/${cmake_build_type}:$PATH \
-  #   ninja -C ${c_glib_build_dir} test
-
-  :
+  PATH="${srcdir}"/build-${MSYSTEM}-cpp/${_cmake_build_type}:$PATH \
+    ${MINGW_PREFIX}/bin/meson compile
 }
 
 package() {
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install ${cpp_build_dir}
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install build-${MSYSTEM}-cpp
 
-  PATH=$(pwd)/${c_glib_build_dir}/arrow-glib:$(pwd)/${cpp_build_dir}/${cmake_build_type}:$PATH \
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/meson install -C ${c_glib_build_dir}
+  PATH="${srcdir}"/build-${MSYSTEM}-c-glib/arrow-glib:"${srcdir}"/build-${MSYSTEM}-cpp/${_cmake_build_type}:$PATH \
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/meson install -C build-${MSYSTEM}-c-glib
 
   # Remove full path reference
   local _PREFIX_WIN="$(cygpath -wm ${MINGW_PREFIX})"

--- a/mingw-w64-grpc/001-fix-building-shared-libraries-with-clang.patch
+++ b/mingw-w64-grpc/001-fix-building-shared-libraries-with-clang.patch
@@ -1,0 +1,151 @@
+diff --git a/src/core/lib/gprpp/time.cc b/src/core/lib/gprpp/time.cc
+index 2c9e96d421..45d4e0f74d 100644
+--- a/src/core/lib/gprpp/time.cc
++++ b/src/core/lib/gprpp/time.cc
+@@ -150,9 +150,13 @@ int64_t TimespanToMillisRoundDown(gpr_timespec ts) {
+ 
+ }  // namespace
+ 
+-thread_local Timestamp::Source* Timestamp::thread_local_time_source_{
++thread_local Timestamp::Source* Timestamp::thread_local_time_source_var_{
+     NoDestructSingleton<GprNowTimeSource>::Get()};
+ 
++Timestamp::Source*& Timestamp::thread_local_time_source_() {
++  return thread_local_time_source_var_;
++}
++
+ Timestamp ScopedTimeCache::Now() {
+   if (!cached_time_.has_value()) {
+     previous()->InvalidateCache();
+diff --git a/src/core/lib/gprpp/time.h b/src/core/lib/gprpp/time.h
+index 557139eb46..dbd2de3f98 100644
+--- a/src/core/lib/gprpp/time.h
++++ b/src/core/lib/gprpp/time.h
+@@ -88,15 +88,15 @@ class Timestamp {
+ 
+   class ScopedSource : public Source {
+    public:
+-    ScopedSource() : previous_(thread_local_time_source_) {
+-      thread_local_time_source_ = this;
++    ScopedSource() : previous_(thread_local_time_source_()) {
++      thread_local_time_source_() = this;
+     }
+     ScopedSource(const ScopedSource&) = delete;
+     ScopedSource& operator=(const ScopedSource&) = delete;
+     void InvalidateCache() override { previous_->InvalidateCache(); }
+ 
+    protected:
+-    ~ScopedSource() { thread_local_time_source_ = previous_; }
++    ~ScopedSource() { thread_local_time_source_() = previous_; }
+     Source* previous() const { return previous_; }
+ 
+    private:
+@@ -112,7 +112,7 @@ class Timestamp {
+   static Timestamp FromCycleCounterRoundUp(gpr_cycle_counter c);
+   static Timestamp FromCycleCounterRoundDown(gpr_cycle_counter c);
+ 
+-  static Timestamp Now() { return thread_local_time_source_->Now(); }
++  static Timestamp Now() { return thread_local_time_source_()->Now(); }
+ 
+   static constexpr Timestamp FromMillisecondsAfterProcessEpoch(int64_t millis) {
+     return Timestamp(millis);
+@@ -160,7 +160,8 @@ class Timestamp {
+   explicit constexpr Timestamp(int64_t millis) : millis_(millis) {}
+ 
+   int64_t millis_ = 0;
+-  static thread_local Timestamp::Source* thread_local_time_source_;
++  static Timestamp::Source*& thread_local_time_source_();
++  static thread_local Timestamp::Source* thread_local_time_source_var_;
+ };
+ 
+ class ScopedTimeCache final : public Timestamp::ScopedSource {
+diff --git a/src/core/lib/iomgr/exec_ctx.cc b/src/core/lib/iomgr/exec_ctx.cc
+index 65cd319d20..b0640badb0 100644
+--- a/src/core/lib/iomgr/exec_ctx.cc
++++ b/src/core/lib/iomgr/exec_ctx.cc
+@@ -56,9 +56,15 @@ static void exec_ctx_sched(grpc_closure* closure) {
+ 
+ namespace grpc_core {
+ 
+-thread_local ExecCtx* ExecCtx::exec_ctx_;
++thread_local ExecCtx* ExecCtx::exec_ctx_var_;
++ExecCtx*& ExecCtx::exec_ctx_() {
++  return exec_ctx_var_;
++}
+ thread_local ApplicationCallbackExecCtx*
+-    ApplicationCallbackExecCtx::callback_exec_ctx_;
++    ApplicationCallbackExecCtx::callback_exec_ctx_var_;
++ApplicationCallbackExecCtx*& ApplicationCallbackExecCtx::callback_exec_ctx_() {
++  return callback_exec_ctx_var_;
++}
+ 
+ bool ExecCtx::Flush() {
+   bool did_something = false;
+diff --git a/src/core/lib/iomgr/exec_ctx.h b/src/core/lib/iomgr/exec_ctx.h
+index 230af79699..d2f4107012 100644
+--- a/src/core/lib/iomgr/exec_ctx.h
++++ b/src/core/lib/iomgr/exec_ctx.h
+@@ -186,7 +186,7 @@ class ExecCtx {
+   void TestOnlySetNow(Timestamp now) { time_cache_.TestOnlySetNow(now); }
+ 
+   /// Gets pointer to current exec_ctx.
+-  static ExecCtx* Get() { return exec_ctx_; }
++  static ExecCtx* Get() { return exec_ctx_(); }
+ 
+   static void Run(const DebugLocation& location, grpc_closure* closure,
+                   grpc_error_handle error);
+@@ -202,7 +202,7 @@ class ExecCtx {
+ 
+  private:
+   /// Set exec_ctx_ to exec_ctx.
+-  static void Set(ExecCtx* exec_ctx) { exec_ctx_ = exec_ctx; }
++  static void Set(ExecCtx* exec_ctx) { exec_ctx_() = exec_ctx; }
+ 
+   grpc_closure_list closure_list_ = GRPC_CLOSURE_LIST_INIT;
+   CombinerData combiner_data_ = {nullptr, nullptr};
+@@ -211,7 +211,8 @@ class ExecCtx {
+   unsigned starting_cpu_ = std::numeric_limits<unsigned>::max();
+ 
+   ScopedTimeCache time_cache_;
+-  static thread_local ExecCtx* exec_ctx_;
++  static thread_local ExecCtx* exec_ctx_var_;
++  static ExecCtx*& exec_ctx_();
+   ExecCtx* last_exec_ctx_ = Get();
+ };
+ 
+@@ -282,7 +283,7 @@ class ApplicationCallbackExecCtx {
+         }
+         (*f->functor_run)(f, f->internal_success);
+       }
+-      callback_exec_ctx_ = nullptr;
++      callback_exec_ctx_() = nullptr;
+       if (!(GRPC_APP_CALLBACK_EXEC_CTX_FLAG_IS_INTERNAL_THREAD & flags_)) {
+         Fork::DecExecCtxCount();
+       }
+@@ -294,14 +295,14 @@ class ApplicationCallbackExecCtx {
+ 
+   uintptr_t Flags() { return flags_; }
+ 
+-  static ApplicationCallbackExecCtx* Get() { return callback_exec_ctx_; }
++  static ApplicationCallbackExecCtx* Get() { return callback_exec_ctx_(); }
+ 
+   static void Set(ApplicationCallbackExecCtx* exec_ctx, uintptr_t flags) {
+     if (Get() == nullptr) {
+       if (!(GRPC_APP_CALLBACK_EXEC_CTX_FLAG_IS_INTERNAL_THREAD & flags)) {
+         Fork::IncExecCtxCount();
+       }
+-      callback_exec_ctx_ = exec_ctx;
++      callback_exec_ctx_() = exec_ctx;
+     }
+   }
+ 
+@@ -326,7 +327,8 @@ class ApplicationCallbackExecCtx {
+   uintptr_t flags_{0u};
+   grpc_completion_queue_functor* head_{nullptr};
+   grpc_completion_queue_functor* tail_{nullptr};
+-  static thread_local ApplicationCallbackExecCtx* callback_exec_ctx_;
++  static thread_local ApplicationCallbackExecCtx* callback_exec_ctx_var_;
++  static ApplicationCallbackExecCtx*& callback_exec_ctx_();
+ };
+ 
+ }  // namespace grpc_core

--- a/mingw-w64-grpc/PKGBUILD
+++ b/mingw-w64-grpc/PKGBUILD
@@ -4,8 +4,9 @@
 _realname=grpc
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.51.1
-pkgrel=4
+pkgver=1.53.0
+pkgrel=1
+_opencensus_proto_ver=0.4.1
 pkgdesc="Google's high performance, open source, general RPC framework (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -21,14 +22,24 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
-source=("${_realname}-${pkgver}.tar.gz::https://github.com/grpc/grpc/archive/v${pkgver}.tar.gz")
-sha256sums=('b55696fb249669744de3e71acc54a9382bea0dce7cd5ba379b356b12b82d4229')
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/grpc/grpc/archive/v${pkgver}.tar.gz"
+        "opencensus-proto-${_opencensus_proto_ver}.tar.gz::https://github.com/census-instrumentation/opencensus-proto/archive/v${_opencensus_proto_ver}.tar.gz"
+        "001-fix-building-shared-libraries-with-clang.patch")
+sha256sums=('9717ffc52120861136e478155c2ff3a9c21740e2244de52fa966f376d7471adf'
+            'e3d89f7f9ed84c9b6eee818c2e9306950519402bf803698b15c310b77ca2f0f3'
+            '022f6424e274620f5337b56fc46217607496870ed5fb197413a44c83961ae388')
 noextract=(${_realname}-${pkgver}.tar.gz)
 
 prepare() {
   tar -xzf "${srcdir}"/${_realname}-${pkgver}.tar.gz -C "${srcdir}" || true
 
   cd "${srcdir}"/${_realname}-${pkgver}
+  # Suggested by @mstorsjo in https://github.com/msys2/MINGW-packages/pull/16378#issuecomment-1481002915
+  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
+    patch -p1 -i "${srcdir}"/001-fix-building-shared-libraries-with-clang.patch
+  fi
+  rm -rf third_party/opencensus-proto
+  mv "${srcdir}"/opencensus-proto-${_opencensus_proto_ver} third_party/opencensus-proto
 }
 
 build() {
@@ -53,13 +64,14 @@ build() {
     ;;
   esac
 
+  CXXFLAGS+=" -w"
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake.exe \
       -Wno-dev \
       -GNinja \
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       "${extra_config[@]}" \
-      -DBUILD_SHARED_LIBS="$( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] && echo OFF || echo ON )" \
+      -DBUILD_SHARED_LIBS=ON \
       -DCMAKE_CXX_STANDARD=17 \
       -DCMAKE_SKIP_RPATH=ON \
       -DgRPC_ZLIB_PROVIDER="package" \


### PR DESCRIPTION
@mstorsjo Could you please investigate this one.

Disabling `disabling-relocation` and enabling `CMAKE_POSITION_INDEPENDENT_CODE` didn't fix building shared grpc++ libs. 