### PR TITLE
libidn: Update to 1.41

### DIFF
--- a/mingw-w64-libidn/PKGBUILD
+++ b/mingw-w64-libidn/PKGBUILD
@@ -13,7 +13,9 @@ license=('spdx:GPL-3.0-or-later' 'spdx:LGPL-3.0-or-later')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc" "${MINGW_PACKAGE_PREFIX}-autotools" "gtk-doc" "texinfo")
 depends=("${MINGW_PACKAGE_PREFIX}-gettext")
 options=('staticlibs' 'strip')
-source=("https://ftp.gnu.org/gnu/libidn/${_realname}-${pkgver}.tar.gz"{,.sig}
+# it was down, switch back next time:
+# https://ftp.gnu.org/gnu/libidn/${_realname}-${pkgver}.tar.gz"{,.sig}
+source=("https://ftp.halifax.rwth-aachen.de/gnu/libidn/${_realname}-${pkgver}.tar.gz"{,.sig}
         0003-nfkc.c-Fix-Win64-crash.patch
         0004-nfkc.c-Fixed-invalid-var-types.patch)
 sha256sums=('884d706364b81abdd17bee9686d8ff2ae7431c5a14651047c68adf8b31fd8945'

--- a/mingw-w64-libidn/PKGBUILD
+++ b/mingw-w64-libidn/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libidn
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.40
+pkgver=1.41
 pkgrel=1
 pkgdesc="Implementation of the Stringprep, Punycode and IDNA specifications (mingw-w64)"
 arch=('any')
@@ -16,7 +16,7 @@ options=('staticlibs' 'strip')
 source=("https://ftp.gnu.org/gnu/libidn/${_realname}-${pkgver}.tar.gz"{,.sig}
         0003-nfkc.c-Fix-Win64-crash.patch
         0004-nfkc.c-Fixed-invalid-var-types.patch)
-sha256sums=('527f673b8043d7189c056dd478b07af82492ecf118aa3e0ef0dc98c11af79991'
+sha256sums=('884d706364b81abdd17bee9686d8ff2ae7431c5a14651047c68adf8b31fd8945'
             'SKIP'
             '6293c730a98af32a337149a95d848f3c4619df8dc367e0bf0251a509b09f5963'
             '8ae6ad9513fc11bd79cb1ab73f187cb8297bdabd21a2aef3b6526ca17810eda9')


### PR DESCRIPTION
gnu.org server is down, or at least some mirrors

upstream is aware