### PR TITLE
fix gdl dock object notify missing bugs

### DIFF
--- a/mingw-w64-gdl/001-dock_object_notify.patch
+++ b/mingw-w64-gdl/001-dock_object_notify.patch
@@ -1,0 +1,20 @@
+--- gdl-3.40.0/gdl/gdl-dock-object.c	2023-03-28 08:52:43.529641800 +0800
++++ gdl-3.40.0/gdl/gdl-dock-object-ricky.c	2023-03-28 08:48:42.480513900 +0800
+@@ -220,7 +220,7 @@ gdl_dock_object_class_init (GdlDockObjec
+         g_param_spec_string ("long-name", _("Long name"),
+                              _("Human readable name for the dock object"),
+                              NULL,
+-                             G_PARAM_READWRITE | G_PARAM_CONSTRUCT);
++                             G_PARAM_READWRITE);
+ 
+     g_object_class_install_property (
+         object_class, PROP_LONG_NAME, properties[PROP_LONG_NAME]);
+@@ -234,7 +234,7 @@ gdl_dock_object_class_init (GdlDockObjec
+         g_param_spec_string ("stock-id", _("Stock Icon"),
+                              _("Stock icon for the dock object"),
+                              NULL,
+-                             G_PARAM_READWRITE | G_PARAM_CONSTRUCT);
++                             G_PARAM_READWRITE);
+ 
+     g_object_class_install_property (
+         object_class, PROP_STOCK_ID, properties[PROP_STOCK_ID]);

--- a/mingw-w64-gdl/PKGBUILD
+++ b/mingw-w64-gdl/PKGBUILD
@@ -5,7 +5,7 @@ _realname=gdl
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=3.40.0
-pkgrel=2
+pkgrel=3
 pkgdesc="GNOME Docking Library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -20,11 +20,14 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-vala"
              "${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools")
 options=('strip' 'staticlibs')
-source=(https://download.gnome.org/sources/${_realname}/${pkgver:0:4}/${_realname}-${pkgver}.tar.xz)
-sha256sums=('3641d4fd669d1e1818aeff3cf9ffb7887fc5c367850b78c28c775eba4ab6a555')
+source=(https://download.gnome.org/sources/${_realname}/${pkgver:0:4}/${_realname}-${pkgver}.tar.xz
+        '001-dock_object_notify.patch')
+sha256sums=('3641d4fd669d1e1818aeff3cf9ffb7887fc5c367850b78c28c775eba4ab6a555'
+            'df1ada98c546bdba1452c9d2d8111887b4d2e08fbe6de6d13b7b533a5e994764')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
+  patch -b -V simple -p1 -i ${srcdir}/001-dock_object_notify.patch
   autoreconf -fiv
 }
 


### PR DESCRIPTION
gdl can't emit dock object notify when change dock object property in glib 2.74 and above, this a patch to fix it