### PR TITLE
libatomic_ops: update to 7.8.0

### DIFF
--- a/mingw-w64-libatomic_ops/001-fix-pkgconfig.patch
+++ b/mingw-w64-libatomic_ops/001-fix-pkgconfig.patch
@@ -1,0 +1,13 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -302,8 +302,8 @@
+   # Provide pkg-config metadata.
+   set(prefix "${CMAKE_INSTALL_PREFIX}")
+   set(exec_prefix \${prefix})
+-  set(includedir "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+-  set(libdir "${CMAKE_INSTALL_FULL_LIBDIR}")
++  set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
++  set(libdir "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+   string(REPLACE ";" " " THREADDLLIBS "${THREADDLLIBS_LIST}")
+   # PACKAGE_VERSION is defined above.
+   configure_file(pkgconfig/atomic_ops.pc.in pkgconfig/atomic_ops.pc @ONLY)

--- a/mingw-w64-libatomic_ops/PKGBUILD
+++ b/mingw-w64-libatomic_ops/PKGBUILD
@@ -3,44 +3,63 @@
 _realname=libatomic_ops
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=7.6.14
+pkgver=7.8.0
 pkgrel=1
 pkgdesc="Provides semi-portable access to hardware provided atomic memory operations (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://www.hboehm.info/gc"
-license=('GPL2' 'MIT')
-makedepends=("${MINGW_PACKAGE_PREFIX}-autotools" "${MINGW_PACKAGE_PREFIX}-cc")
-source=("https://github.com/ivmai/${_realname}/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('390f244d424714735b7050d056567615b3b8f29008a663c262fb548f1802d292')
+license=('spdx:GPL-2.0' 'spdx:MIT')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
+source=("https://github.com/ivmai/${_realname}/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz"
+        001-fix-pkgconfig.patch)
+sha256sums=('15676e7674e11bda5a7e50a73f4d9e7d60452271b8acf6fd39a71fefdf89fa31'
+            '4d8a9037a3f6cd831f1cfe9dcb9f51c993b767f0115018306ca547acbdd5b4e8')
 
-prepare(){
-  cd ${srcdir}/${_realname}-${pkgver}
-
-  ./autogen.sh
+prepare() {
+  cd "${srcdir}"/${_realname}-${pkgver}
+  patch -p1 -i "${srcdir}"/001-fix-pkgconfig.patch
 }
 
 build() {
-  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
-  mkdir -p ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
+  mkdir -p ${srcdir}/build-${MSYSTEM} && cd ${srcdir}/build-${MSYSTEM}
 
-  ../${_realname}-${pkgver}/configure \
-    --build=${MINGW_CHOST} \
-    --host=${MINGW_CHOST} \
-    --target=${MINGW_CHOST} \
-    --prefix=${MINGW_PREFIX} \
-    --enable-shared \
-    --enable-static
-  make
+  declare -a _extra_config
+  if check_option "debug" "n"; then
+    _extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    _extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  if [[ ${MSYSTEM} == MINGW64 || ${MSYSTEM} == UCRT64 ]]; then
+    _extra_config+=("-Denable_atomic_intrinsics=OFF")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  "${MINGW_PREFIX}"/bin/cmake.exe \
+    -GNinja \
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+    -DBUILD_SHARED_LIBS=ON \
+    -DCMAKE_SHARED_LIBRARY_NAME_WITH_VERSION=ON \
+    "${_extra_config[@]}" \
+    ../${_realname}-${pkgver}
+
+  "${MINGW_PREFIX}"/bin/cmake.exe --build .
 }
 
 check() {
-  cd ${srcdir}/build-${MINGW_CHOST}
-  PATH="${srcdir}//build-${MINGW_CHOST}/src/.libs:$PATH" make check || true
+  cd ${srcdir}/build-${MSYSTEM}
+  "${MINGW_PREFIX}"/bin/cmake.exe -Dbuild_tests=ON ../${_realname}-${pkgver}
+  "${MINGW_PREFIX}"/bin/cmake.exe --build .
+  "${MINGW_PREFIX}"/bin/ctest || echo "Tests failed"
 }
 
 package() {
-  cd ${srcdir}/build-${MINGW_CHOST}
-  make DESTDIR="${pkgdir}" install
-  install -D -m644 ${srcdir}/${_realname}-${pkgver}/doc/LICENSING.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
+
+  install -D -m644 ${srcdir}/${_realname}-${pkgver}/LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
I tried to build it
- buildflags
- !buildflags
- buildflags + "-mcx16"
- !builflags + "-mcx16"
It always fails with GCC x86_64, I have found many issues about it on GH and Bugzilla none of the is fixed!