### PR TITLE
starpu: fix 32bit build with clang v16

### DIFF
--- a/mingw-w64-starpu/0001-fix-callback-missing-stdcall.patch
+++ b/mingw-w64-starpu/0001-fix-callback-missing-stdcall.patch
@@ -1,0 +1,74 @@
+diff -ur starpu-1.4.0/socl/src/cl_buildprogram.c starpu-1.4.0-new/socl/src/cl_buildprogram.c
+--- starpu-1.4.0/socl/src/cl_buildprogram.c	2023-03-27 10:12:59.000000000 +0200
++++ starpu-1.4.0-new/socl/src/cl_buildprogram.c	2023-03-30 10:40:46.467421400 +0200
+@@ -80,7 +80,7 @@
+ 		 cl_uint              num_devices,
+ 		 const cl_device_id * device_list,
+ 		 const char *         options,
+-		 void (*pfn_notify)(cl_program program, void * user_data),
++		 void (CL_CALLBACK *pfn_notify)(cl_program program, void * user_data),
+ 		 void *               user_data)
+ {
+ 	struct bp_data *data;
+diff -ur starpu-1.4.0/socl/src/cl_createcontext.c starpu-1.4.0-new/socl/src/cl_createcontext.c
+--- starpu-1.4.0/socl/src/cl_createcontext.c	2023-03-27 10:12:59.000000000 +0200
++++ starpu-1.4.0-new/socl/src/cl_createcontext.c	2023-03-30 10:33:26.239963400 +0200
+@@ -38,7 +38,7 @@
+ soclCreateContext(const cl_context_properties * properties,
+ 		  cl_uint                       num_devices,
+ 		  const cl_device_id *          devices,
+-		  void (*pfn_notify)(const char *, const void *, size_t, void *),
++		  void (CL_CALLBACK *pfn_notify)(const char *, const void *, size_t, void *),
+ 		  void *                        user_data,
+ 		  cl_int *                      errcode_ret)
+ {
+diff -ur starpu-1.4.0/socl/src/cl_createcontextfromtype.c starpu-1.4.0-new/socl/src/cl_createcontextfromtype.c
+--- starpu-1.4.0/socl/src/cl_createcontextfromtype.c	2023-03-27 10:12:59.000000000 +0200
++++ starpu-1.4.0-new/socl/src/cl_createcontextfromtype.c	2023-03-30 10:41:00.807622200 +0200
+@@ -22,7 +22,7 @@
+ CL_API_ENTRY cl_context CL_API_CALL
+ soclCreateContextFromType(const cl_context_properties * properties,
+ 			  cl_device_type                device_type,
+-			  void (*pfn_notify)(const char *, const void *, size_t, void *),
++			  void (CL_CALLBACK *pfn_notify)(const char *, const void *, size_t, void *),
+ 			  void *                        user_data,
+ 			  cl_int *                      errcode_ret)
+ {
+diff -ur starpu-1.4.0/socl/src/socl.h starpu-1.4.0-new/socl/src/socl.h
+--- starpu-1.4.0/socl/src/socl.h	2023-03-27 10:12:59.000000000 +0200
++++ starpu-1.4.0-new/socl/src/socl.h	2023-03-30 10:40:36.315942400 +0200
+@@ -113,7 +113,7 @@
+ {
+ 	CL_ENTITY;
+ 
+-	void (*pfn_notify)(const char *, const void *, size_t, void *);
++	void (CL_CALLBACK *pfn_notify)(const char *, const void *, size_t, void *);
+ 	void *user_data;
+ 
+ 	/* Associated devices */
+@@ -330,14 +330,14 @@
+ soclCreateContext(const cl_context_properties * /* properties */,
+ 		  cl_uint                       /* num_devices */,
+ 		  const cl_device_id *          /* devices */,
+-		  void (*pfn_notify)(const char *, const void *, size_t, void *) /* pfn_notify */,
++		  void (CL_CALLBACK *pfn_notify)(const char *, const void *, size_t, void *) /* pfn_notify */,
+ 		  void *                        /* user_data */,
+ 		  cl_int *                      /* errcode_ret */) CL_API_SUFFIX__VERSION_1_0;
+ 
+ extern CL_API_ENTRY cl_context CL_API_CALL
+ soclCreateContextFromType(const cl_context_properties * /* properties */,
+ 			  cl_device_type                /* device_type */,
+-			  void (*pfn_notify)(const char *, const void *, size_t, void *) /* pfn_notify */,
++			  void (CL_CALLBACK *pfn_notify)(const char *, const void *, size_t, void *) /* pfn_notify */,
+ 			  void *                        /* user_data */,
+ 			  cl_int *                      /* errcode_ret */) CL_API_SUFFIX__VERSION_1_0;
+ 
+@@ -487,7 +487,7 @@
+ 		 cl_uint              /* num_devices */,
+ 		 const cl_device_id * /* device_list */,
+ 		 const char *         /* options */,
+-		 void (*pfn_notify)(cl_program /* program */, void * /* user_data */),
++		 void (CL_CALLBACK *pfn_notify)(cl_program /* program */, void * /* user_data */),
+ 		 void *               /* user_data */) CL_API_SUFFIX__VERSION_1_0;
+ 
+ extern CL_API_ENTRY cl_int CL_API_CALL

--- a/mingw-w64-starpu/PKGBUILD
+++ b/mingw-w64-starpu/PKGBUILD
@@ -4,7 +4,7 @@ _realname=starpu
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.4.0
-pkgrel=1
+pkgrel=2
 pkgdesc='StarPU is a task programming library for hybrid architectures (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -21,11 +21,16 @@ makedepends=(
 options=('!docs')
 license=('LGPL')
 url='https://starpu.gitlabpages.inria.fr'
-source=(https://files.inria.fr/starpu/${_realname}-${pkgver}/${_realname}-${pkgver}.tar.gz)
-sha256sums=('5058127761A0604606A852FD6D20B07040D5FBD9F798C5383E49F336B4EEACA1')
+source=(https://files.inria.fr/starpu/${_realname}-${pkgver}/${_realname}-${pkgver}.tar.gz
+        "0001-fix-callback-missing-stdcall.patch")
+sha256sums=('5058127761a0604606a852fd6d20b07040d5fbd9f798c5383e49f336b4eeaca1'
+            '0c03204c893e2e00879e9a14f29696e5a3f9adf7af1092ca01e747f01b272512')
 
 prepare() {
   cd ${_realname}-${pkgver}
+
+  patch -Np1 -i "${srcdir}/0001-fix-callback-missing-stdcall.patch"
+
   autoreconf -fiv
 }
 


### PR DESCRIPTION
it rightfully complains the the callback calling convention doesn't match