### PR TITLE
gdb: add patch

### DIFF
--- a/mingw-w64-gdb/0006-Handle-unwinding-from-SEGV-on-Windows.patch
+++ b/mingw-w64-gdb/0006-Handle-unwinding-from-SEGV-on-Windows.patch
@@ -1,0 +1,46 @@
+[PATCH] Handle unwinding from SEGV on Windows
+
+PR win32/30255 points out that a call to a NULL function pointer will
+leave gdb unable to "bt" on Windows.
+
+I tracked this down to the amd64 windows unwinder.  If we treat this
+scenario as if it were a leaf function, unwinding works fine.
+
+I'm not completely sure this patch is the best way.  I considered
+having it check for 'pc==0' -- but then I figured this could affect
+any inaccessible PC, not just the special 0 value.
+
+No test case because I can't run dejagnu tests on Windows.  I tested
+this by hand using the test case in the bug.
+
+Bug: https://sourceware.org/bugzilla/show_bug.cgi?id=30255
+---
+ gdb/amd64-windows-tdep.c | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/gdb/amd64-windows-tdep.c b/gdb/amd64-windows-tdep.c
+index 07df64bed60..9d69ec282d2 100644
+--- a/gdb/amd64-windows-tdep.c
++++ b/gdb/amd64-windows-tdep.c
+@@ -1098,13 +1098,14 @@ amd64_windows_frame_cache (frame_info_ptr this_frame, void **this_cache)
+   cache->sp = extract_unsigned_integer (buf, 8, byte_order);
+   cache->pc = pc;
+ 
++  /* If we can't find the unwind info, keep trying as though this is a
++     leaf function.  This situation can happen when PC==0, see
++     https://sourceware.org/bugzilla/show_bug.cgi?id=30255.  */
+   if (amd64_windows_find_unwind_info (gdbarch, pc, &unwind_info,
+ 				      &cache->image_base,
+ 				      &cache->start_rva,
+-				      &cache->end_rva))
+-    return cache;
+-
+-  if (unwind_info == 0)
++				      &cache->end_rva)
++      || unwind_info == 0)
+     {
+       /* Assume a leaf function.  */
+       cache->prev_sp = cache->sp + 8;
+-- 
+2.39.1
+

--- a/mingw-w64-gdb/PKGBUILD
+++ b/mingw-w64-gdb/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-multiarch")
 pkgver=13.1
-pkgrel=3
+pkgrel=4
 pkgdesc="GNU Debugger (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -34,7 +34,8 @@ source=(https://ftp.gnu.org/gnu/gdb/${_realname}-${pkgver}.tar.xz{,.sig}
         '0002-Fix-using-gnu-print.patch'
         '0003-configure-Disable-static-linking-with-standard-libs.patch'
         '0004-Python-Configure-path-fixes.patch'
-        '0005-W32-Always-check-USERPROFILE-if-HOME-is-not-set.patch')
+        '0005-W32-Always-check-USERPROFILE-if-HOME-is-not-set.patch'
+        '0006-Handle-unwinding-from-SEGV-on-Windows.patch')
 validpgpkeys=('F40ADB902B24264AA42E50BF92EDB04BFF325CF3')
 sha256sums=('115ad5c18d69a6be2ab15882d365dda2a2211c14f480b3502c6eba576e2e95a0'
             'SKIP'
@@ -42,7 +43,8 @@ sha256sums=('115ad5c18d69a6be2ab15882d365dda2a2211c14f480b3502c6eba576e2e95a0'
             'cf12bce0b988765ecac26a6895238c48ef9676d6fc01f986f75dcbc8bd8d3f07'
             '0eb291cd81f7392610d16a83f436a30d3384a99661c6b6ffd1bfb243d5aee6dd'
             '7ef9c6e238a4e232bc689e15e48ee2d8045542c47f0b156d9fc92a7c14e6757e'
-            '39d1cb2a1be8d60c16404ad96882f10cd3ebd942d8b7af62a7416a230a50de93')
+            '39d1cb2a1be8d60c16404ad96882f10cd3ebd942d8b7af62a7416a230a50de93'
+            '5d0086ed36649c8faeb46efe5aeaf9ca6b6602a8d90ea72e1feb2436b1396acc')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -70,6 +72,10 @@ prepare() {
     0004-Python-Configure-path-fixes.patch \
     0005-W32-Always-check-USERPROFILE-if-HOME-is-not-set.patch
 
+  # https://sourceware.org/bugzilla/show_bug.cgi?id=30255
+  apply_patch_with_msg \
+    0006-Handle-unwinding-from-SEGV-on-Windows.patch
+
   # hack! - libiberty configure tests for header files using "$CPP $CPPFLAGS"
   sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" libiberty/configure
 }
@@ -91,12 +97,23 @@ do_build() {
   CFLAGS+=" -I${MINGW_PREFIX}/include/ncurses"
   CXXFLAGS+=" -I${MINGW_PREFIX}/include/ncurses"
 
+  declare -a _extra_config
+  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
+    # Fix compilation with clang 16. Consider removing once fixed upstream.
+    CFLAGS+=" -Wno-enum-constexpr-conversion"
+    CXXFLAGS+=" -Wno-enum-constexpr-conversion"
+
+    # Checking for a working Ada compiler takes very long and ultimately fails.
+    _extra_config+=("acx_cv_cc_gcc_supports_ada=no")
+  fi
+
   ../${_realname}-${pkgver}/configure \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \
     --prefix=${MINGW_PREFIX} \
     $2 \
+    ${_extra_config[@]} \
     --enable-64-bit-bfd \
     --disable-werror \
     --disable-win32-registry \


### PR DESCRIPTION
Fixes the issue described in https://gitlab.com/inkscape/inkscape/-/issues/4031#note_1231250877. GDB is unable to retrieve any information regarding the callstack of the debugged program. Hence one may think that a stack corruption is going on, but instead it's just a call of a NULL function pointer.

Also fix compilation with clang 16 as suggested by @mmuetzel. See https://discourse.llvm.org/t/clang-16-notice-of-potentially-breaking-changes/65562 for more info

Reference https://sourceware.org/pipermail/gdb-patches/2023-March/198196.html