### PR TITLE
python-numpy: fix infinite loop when writing > 4GiB

### DIFF
--- a/mingw-w64-python-numpy/0013-fix-4GiB-fwrites.patch
+++ b/mingw-w64-python-numpy/0013-fix-4GiB-fwrites.patch
@@ -1,0 +1,14 @@
+diff --git a/numpy/core/src/multiarray/convert.c b/numpy/core/src/multiarray/convert.c
+index 9e0c9fb..57fcbd5 100644
+--- a/numpy/core/src/multiarray/convert.c
++++ b/numpy/core/src/multiarray/convert.c
+@@ -156,7 +156,8 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
+             size = PyArray_SIZE(self);
+             NPY_BEGIN_ALLOW_THREADS;
+ 
+-#if defined (_MSC_VER) && defined(_WIN64)
++#if defined(_MSC_VER) && defined(_WIN64) || \
++    defined(__MINGW32__) || defined(__MINGW64__)
+             /* Workaround Win64 fwrite() bug. Ticket #1660 */
+             {
+                 npy_intp maxsize = 2147483648 / PyArray_DESCR(self)->elsize;

--- a/mingw-w64-python-numpy/PKGBUILD
+++ b/mingw-w64-python-numpy/PKGBUILD
@@ -9,7 +9,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=1.24.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Scientific tools for Python (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -34,7 +34,8 @@ source=(https://github.com/numpy/numpy/releases/download/v${pkgver}/${_realname}
         0007-disable-64bit-experimental-warning.patch
         0008-mingw-gcc-doesnt-support-visibility.patch
         0011-dont-die-if-no-fcompiler.patch
-        0012-clang-no-gcc-workaround.patch)
+        0012-clang-no-gcc-workaround.patch
+        0013-fix-4GiB-fwrites.patch)
 sha256sums=('003a9f530e880cb2cd177cba1af7220b9aa42def9c4afc2a2fc3ee6be7eb2b22'
             '94f111ab238c4a82e8613ed14e4cbeb553eabff26523f576e5fcafdbfdc8ee29'
             '3aacb1d92e7764c9f0f24afa1a97b136a069fcd81d63c9fa55565c40c5a29974'
@@ -44,7 +45,8 @@ sha256sums=('003a9f530e880cb2cd177cba1af7220b9aa42def9c4afc2a2fc3ee6be7eb2b22'
             'cafc924fd11d8653a49970d0cce5b31869cce0e8996a3ae57bcbccca96bc8eb3'
             'c7222c3cd85ff6af515514c5c3b8f3c02144c58c1373dec16683fa455504aa69'
             '87bdd0a47a8662bdb8acaca18452901ee1f42cf08b985443ffb214f7facfdb2d'
-            'e21b48037928d797f46289439116d3585d697de2c58d51119873b47ee5410a92')
+            'e21b48037928d797f46289439116d3585d697de2c58d51119873b47ee5410a92'
+            '5eb2ee50b131c0ca6972c6c93836aaf810a5ce08a8563794682b05c391ab3c07')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -66,7 +68,8 @@ prepare() {
     0007-disable-64bit-experimental-warning.patch \
     0008-mingw-gcc-doesnt-support-visibility.patch \
     0011-dont-die-if-no-fcompiler.patch \
-    0012-clang-no-gcc-workaround.patch
+    0012-clang-no-gcc-workaround.patch \
+    0013-fix-4GiB-fwrites.patch
 
   apply_patch_with_msg \
     0005-mincoming-stack-boundary-32bit-optimized-64bit.patch


### PR DESCRIPTION
Fixes #15856. See also pending [upstream PR](https://github.com/numpy/numpy/pull/23505).