### PR TITLE
flang: Fix c_long_double value on aarch64

### DIFF
--- a/mingw-w64-flang/0005-Fix-c_long_double-value-on-mingw-aarch64.patch
+++ b/mingw-w64-flang/0005-Fix-c_long_double-value-on-mingw-aarch64.patch
@@ -1,0 +1,11 @@
+--- a/module/iso_c_binding.f90
++++ b/module/iso_c_binding.f90
+@@ -56,7 +56,7 @@
+ #if __x86_64__
+     c_long_double = 10
+ #else
+-    c_long_double = 16
++    c_long_double = 8
+ #endif
+ 
+   integer, parameter :: &

--- a/mingw-w64-flang/PKGBUILD
+++ b/mingw-w64-flang/PKGBUILD
@@ -6,7 +6,7 @@ _version=16.0.0
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
-pkgrel=1
+pkgrel=2
 pkgdesc="Fortran frontend for LLVM (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -35,7 +35,8 @@ source=("${_url}/${_pkgfn}.tar.xz"{,.sig}
         "0001-cast-cxx11-narrowing.patch"
         "0002-cmake-22162.patch"
         "0003-do-not-link-to-llvm-dylib.patch"
-        "0004-do-not-clock_gettime-on-mingw.patch")
+        "0004-do-not-clock_gettime-on-mingw.patch"
+        "0005-Fix-c_long_double-value-on-mingw-aarch64.patch")
 sha256sums=('2734b4bb13080b874b0b83c203f611e805ed56a284ce080cf8bcdbfa2a064ff2'
             'SKIP'
             '04e62ab7d0168688d9102680adf8eabe7b04275f333fe20eef8ab5a3a8ea9fcc'
@@ -43,7 +44,8 @@ sha256sums=('2734b4bb13080b874b0b83c203f611e805ed56a284ce080cf8bcdbfa2a064ff2'
             'ba08064d737a2aa173125e88c3900dce804220fb0562596b03130177c2139312'
             '77fb0612217b6af7a122f586a9d0d334cd48bb201509bf72e8f8e6244616e895'
             '8d70b33d20d74801aeee82173944fed3b33ae185031537e1b50a640238f7a988'
-            'b02c962bd71832d64542f8b3793e824ac99f5797a3821767eb40875c2f3e4f6f')
+            'b02c962bd71832d64542f8b3793e824ac99f5797a3821767eb40875c2f3e4f6f'
+            'a1811227e2a26c2786b0c8577528580e679111f6c0889afea57d08333e2d5e4f')
 validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Google.
               '474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard
               'D574BD5D1D0E98895E3BF90044F2485E45D59042') # Tobias Hieta
@@ -64,7 +66,8 @@ prepare() {
     "0001-cast-cxx11-narrowing.patch" \
     "0002-cmake-22162.patch" \
     "0003-do-not-link-to-llvm-dylib.patch" \
-    "0004-do-not-clock_gettime-on-mingw.patch"
+    "0004-do-not-clock_gettime-on-mingw.patch" \
+    "0005-Fix-c_long_double-value-on-mingw-aarch64.patch"
 }
 
 build() {


### PR DESCRIPTION
@hmartinez82 Could you build it on clangarm64.
Please compile this file test.f90
```Fortran
program test
  use iso_c_binding
  print *, 'c_long_double =', c_long_double
end program
```
```
$flang test.f90 -o test
$./test
```
The output should be ` c_long_double= 8` on clangarm64