### PR TITLE
new packages python-pymi and python-os-win

### DIFF
--- a/mingw-w64-python-os-win/PKGBUILD
+++ b/mingw-w64-python-os-win/PKGBUILD
@@ -1,0 +1,69 @@
+# Maintainer: Jeremy Drake <github@jdrake.com>
+
+_realname=os-win
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=5.9.0
+pkgrel=1
+pkgdesc="Windows/Hyper-V Python library for OpenStack projects (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+url='https://opendev.org/openstack/os-win'
+license=('spdx:Apache-2.0')
+depends=("${MINGW_PACKAGE_PREFIX}-python-pbr"
+         "${MINGW_PACKAGE_PREFIX}-python-eventlet"
+         "${MINGW_PACKAGE_PREFIX}-python-oslo-concurrency"
+         "${MINGW_PACKAGE_PREFIX}-python-oslo-config"
+         "${MINGW_PACKAGE_PREFIX}-python-oslo-log"
+         "${MINGW_PACKAGE_PREFIX}-python-oslo-utils"
+         "${MINGW_PACKAGE_PREFIX}-python-oslo-i18n"
+         "${MINGW_PACKAGE_PREFIX}-python-pymi"
+         "${MINGW_PACKAGE_PREFIX}-python-wmi")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python-wheel")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-hacking"
+              "${MINGW_PACKAGE_PREFIX}-python-coverage"
+              "${MINGW_PACKAGE_PREFIX}-python-ddt"
+              "${MINGW_PACKAGE_PREFIX}-python-oslotest"
+              "${MINGW_PACKAGE_PREFIX}-python-stestr"
+              "${MINGW_PACKAGE_PREFIX}-python-testscenarios"
+              "${MINGW_PACKAGE_PREFIX}-python-testtools")
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
+        'iscsidsc-optional.patch')
+sha256sums=('4d4ad5122060cdd1312d6909921c7280c7159fa6811a966fa11688fc141808c0'
+            'd42fbecedc662000097f500ea41a16f55bba114382aa9ffd6dca2da1e08189c7')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  # there is no arm64 iscsidsc.dll
+  patch -Nbp1 -i "${srcdir}/iscsidsc-optional.patch"
+}
+
+build() {
+  msg "Python build for ${MSYSTEM}"
+  cd "${srcdir}"
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+check() {
+  msg "Python test for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
+
+  ${MINGW_PREFIX}/bin/stestr run -t ./os_win/tests
+}
+
+package() {
+  msg "Python install for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}

--- a/mingw-w64-python-os-win/iscsidsc-optional.patch
+++ b/mingw-w64-python-os-win/iscsidsc-optional.patch
@@ -1,0 +1,17 @@
+diff -Nur os-win-5.9.0/os_win/utils/winapi/libs/iscsidsc.py python-build-CLANGARM64/os_win/utils/winapi/libs/iscsidsc.py
+--- os-win-5.9.0/os_win/utils/winapi/libs/iscsidsc.py	2023-02-10 16:29:54.000000000 +0000
++++ python-build-CLANGARM64/os_win/utils/winapi/libs/iscsidsc.py	2023-04-03 23:29:53.452842500 +0000
+@@ -184,6 +184,7 @@
+ 
+ 
+ def register():
++  try:
+     global lib_handle
+     lib_handle = ctypes.windll.iscsidsc
+ 
+@@ -265,3 +266,5 @@
+         wintypes.PWCHAR
+     ]
+     lib_handle.ReportIScsiTargetsW.restype = wintypes.ULONG
++  except FileNotFoundError:
++    pass

--- a/mingw-w64-python-pymi/0001-pymi-fix-mingw-compiler-error.patch
+++ b/mingw-w64-python-pymi/0001-pymi-fix-mingw-compiler-error.patch
@@ -1,0 +1,145 @@
+diff -Nur PyMI-1.0.6.orig/MI/MI++.cpp PyMI-1.0.6/MI/MI++.cpp
+--- PyMI-1.0.6.orig/MI/MI++.cpp	2020-05-20 11:59:25.000000000 +0000
++++ PyMI-1.0.6/MI/MI++.cpp	2023-04-03 17:35:16.838667100 +0000
+@@ -38,7 +38,7 @@
+             Instance instance((MI_Instance*)extError, false);
+             if(IsInstanceOf(instance, L"MSFT_WmiError"))
+             {
+-                MI_Char* message = instance[L"Message"]->m_value.string;
++                const MI_Char* message = instance[L"Message"]->m_value.string;
+                 message = message ? message : L"";
+ 
+                 auto errorCode = instance[L"error_code"]->m_value.uint32;
+diff -Nur PyMI-1.0.6.orig/MI/targetver.h PyMI-1.0.6/MI/targetver.h
+--- PyMI-1.0.6.orig/MI/targetver.h	2020-05-20 11:59:25.000000000 +0000
++++ PyMI-1.0.6/MI/targetver.h	2023-04-03 17:39:44.483731200 +0000
+@@ -5,4 +5,6 @@
+ // If you wish to build your application for a previous Windows platform, include WinSDKVer.h and
+ // set the _WIN32_WINNT macro to the platform you wish to support before including SDKDDKVer.h.
+ 
++#define _WIN32_WINNT 0x0a00
++
+ #include <SDKDDKVer.h>
+diff -Nur PyMI-1.0.6.orig/PyMI/Class.cpp PyMI-1.0.6/PyMI/Class.cpp
+--- PyMI-1.0.6.orig/PyMI/Class.cpp	2020-05-20 11:59:25.000000000 +0000
++++ PyMI-1.0.6/PyMI/Class.cpp	2023-04-03 17:36:45.449775600 +0000
+@@ -112,7 +112,7 @@
+ {
+     try
+     {
+-        std::wstring& className = self->miClass->GetClassName();
++        std::wstring className = self->miClass->GetClassName();
+         return PyUnicode_FromWideChar(className.c_str(), className.length());
+     }
+     catch (std::exception& ex)
+@@ -126,7 +126,7 @@
+ {
+     try
+     {
+-        std::wstring& nameSpace = self->miClass->GetNameSpace();
++        std::wstring nameSpace = self->miClass->GetNameSpace();
+         return PyUnicode_FromWideChar(nameSpace.c_str(), nameSpace.length());
+     }
+     catch (std::exception& ex)
+@@ -140,7 +140,7 @@
+ {
+     try
+     {
+-        std::wstring& serverName = self->miClass->GetServerName();
++        std::wstring serverName = self->miClass->GetServerName();
+         return PyUnicode_FromWideChar(serverName.c_str(), serverName.length());
+     }
+     catch (std::exception& ex)
+diff -Nur PyMI-1.0.6.orig/PyMI/Instance.cpp PyMI-1.0.6/PyMI/Instance.cpp
+--- PyMI-1.0.6.orig/PyMI/Instance.cpp	2020-05-20 11:59:25.000000000 +0000
++++ PyMI-1.0.6/PyMI/Instance.cpp	2023-04-03 17:37:12.355261900 +0000
+@@ -212,7 +212,7 @@
+ {
+     try
+     {
+-        std::wstring& className = self->instance->GetClassName();
++        std::wstring className = self->instance->GetClassName();
+         return PyUnicode_FromWideChar(className.c_str(), className.length());
+     }
+     catch (std::exception& ex)
+@@ -226,7 +226,7 @@
+ {
+     try
+     {
+-        std::wstring& nameSpace = self->instance->GetNameSpace();
++        std::wstring nameSpace = self->instance->GetNameSpace();
+         return PyUnicode_FromWideChar(nameSpace.c_str(), nameSpace.length());
+     }
+     catch (std::exception& ex)
+@@ -240,7 +240,7 @@
+ {
+     try
+     {
+-        std::wstring& serverName = self->instance->GetServerName();
++        std::wstring serverName = self->instance->GetServerName();
+         return PyUnicode_FromWideChar(serverName.c_str(), serverName.length());
+     }
+     catch (std::exception& ex)
+diff -Nur PyMI-1.0.6.orig/PyMI/targetver.h PyMI-1.0.6/PyMI/targetver.h
+--- PyMI-1.0.6.orig/PyMI/targetver.h	2020-05-20 11:59:25.000000000 +0000
++++ PyMI-1.0.6/PyMI/targetver.h	2023-04-03 17:40:02.251730000 +0000
+@@ -5,4 +5,6 @@
+ // If you wish to build your application for a previous Windows platform, include WinSDKVer.h and
+ // set the _WIN32_WINNT macro to the platform you wish to support before including SDKDDKVer.h.
+ 
++#define _WIN32_WINNT 0x0a00
++
+ #include <SDKDDKVer.h>
+diff -Nur PyMI-1.0.6.orig/PyMI/Utils.cpp PyMI-1.0.6/PyMI/Utils.cpp
+--- PyMI-1.0.6.orig/PyMI/Utils.cpp	2020-05-20 11:59:25.000000000 +0000
++++ PyMI-1.0.6/PyMI/Utils.cpp	2023-04-03 17:44:27.883315600 +0000
+@@ -3,6 +3,7 @@
+ #include "Utils.h"
+ #include "instance.h"
+ #include <codecvt>
++#include <locale>
+ 
+ #include <datetime.h>
+ 
+@@ -151,7 +152,7 @@
+         throw MI::Exception(L"PyUnicode_AsWideChar failed");
+     }
+ 
+-    auto& value = std::wstring(w, len);
++    auto value = std::wstring(w, len);
+     delete[] w;
+     return value;
+ }
+@@ -167,9 +168,9 @@
+     try
+     {
+ #ifdef IS_PY3K
+-        auto& value = Py2WString(pyStrValue);
++        auto value = Py2WString(pyStrValue);
+ #else
+-        auto& value = std::string(PyString_AsString(pyStrValue));
++        auto value = std::string(PyString_AsString(pyStrValue));
+ #endif
+         Py_DECREF(pyStrValue);
+         return MI::MIValue::FromString(value);
+@@ -372,7 +373,7 @@
+                 pyObj = PyList_GetItem(pyValue, i);
+             }
+ 
+-            auto& tmpValue = Py2MI(pyObj, itemType);
++            auto tmpValue = Py2MI(pyObj, itemType);
+             value->SetArrayItem(*tmpValue, (unsigned)i);
+         }
+         return value;
+diff -Nur PyMI-1.0.6.orig/setup.py PyMI-1.0.6/setup.py
+--- PyMI-1.0.6.orig/setup.py	2020-05-25 12:11:25.000000000 +0000
++++ PyMI-1.0.6/setup.py	2023-04-03 17:21:10.626872900 +0000
+@@ -37,7 +37,7 @@
+     return Compiler(None, dry_run, force)
+ 
+ 
+-ccompiler.new_compiler = new_compiler
++#ccompiler.new_compiler = new_compiler
+ 
+ 
+ # Setuptools requires relative paths

--- a/mingw-w64-python-pymi/PKGBUILD
+++ b/mingw-w64-python-pymi/PKGBUILD
@@ -1,0 +1,56 @@
+# Maintainer: Jeremy Drake <github@jdrake.com>
+
+_realname=PyMI
+pkgbase=mingw-w64-python-${_realname,,}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname,,}")
+pkgver=1.0.6
+pkgrel=1
+pkgdesc="Windows Management Infrastructure API for Python (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+url='https://github.com/cloudbase/PyMI'
+license=('spdx:Apache-2.0')
+depends=("${MINGW_PACKAGE_PREFIX}-python-pbr"
+         "${MINGW_PACKAGE_PREFIX}-python-six")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python-wheel")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest"
+              "${MINGW_PACKAGE_PREFIX}-python-testtools")
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
+        "0001-pymi-fix-mingw-compiler-error.patch")
+sha256sums=('1aba919c1ba61f0de287c8dccd02a843db5a4c8daacfd049add5c792072b634e'
+            'bcef96de4372db04e1a1ddfb42dc36a1ab38924f549d3355245d272aadd3bafe')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -Nbp1 -i "${srcdir}/0001-pymi-fix-mingw-compiler-error.patch"
+}
+
+build() {
+  msg "Python build for ${MSYSTEM}"
+  cd "${srcdir}"
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+check() {
+  msg "Python test for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
+
+  pytest
+}
+
+package() {
+  msg "Python install for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname,,}/LICENSE"
+}


### PR DESCRIPTION
pymi is a dependency of os-win, which is a library from openstack for managing hyper-v.

Draft until the patches for mingw-w64 are applied and the packages are updated, not worth carrying a downstream patch over.