### PR TITLE
manim: disable strip option

### DIFF
--- a/mingw-w64-manim/PKGBUILD
+++ b/mingw-w64-manim/PKGBUILD
@@ -4,7 +4,7 @@ _realname=manim
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.17.3
-pkgrel=1
+pkgrel=2
 pkgdesc="Animation engine for explanatory math videos (community edition) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -45,6 +45,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-poetry-core"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-cc")
+options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('f9c7b56aef79989c503e71d6d3aebe65a9400b421e7af8f917d2df1fb157b813')
 


### PR DESCRIPTION
this makes sure the executable generated from the installer actually works
currently, running `manim.exe` I get the error
```
$ manim
Fatal error in launcher: Unable to find an appended archive.
```
this PR fixes that error