### PR TITLE
tme: Update to 0.12rc10

### DIFF
--- a/mingw-w64-tme/PKGBUILD
+++ b/mingw-w64-tme/PKGBUILD
@@ -1,39 +1,34 @@
 # Maintainer: Ruben Agin <phabrics@phabrics.com>
-
 _realname=tme
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.12rc9
+pkgver=0.12rc10
 pkgrel=1
 pkgdesc="The Machine Emulator, or ${_realname}, provides a general-purpose framework for computer emulation. (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 license=('GPL3')
-url="https://osdn.net/users/phabrics/pf/${_realname}/wiki/FrontPage"
+url="http://nme.osdn.io"
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
 	     "bison"
 	     "texinfo")
-depends=("${MINGW_PACKAGE_PREFIX}-gtk3"
+depends=("${MINGW_PACKAGE_PREFIX}-gtk4"
 	 "${MINGW_PACKAGE_PREFIX}-libvncserver"
 	 "${MINGW_PACKAGE_PREFIX}-libltdl")
-source=("https://osdn.net/users/phabrics/pf/${_realname}/dl/${_realname}-${pkgver}.tar.xz")
-sha256sums=('28499e869f09e1f3c8ca76ed97f29bd647db3cd015e09c660dfe30193bed7763')
+source=("https://osdn.net/dl/nme/${_realname}-${pkgver}.tar.xz")
+sha256sums=('e2c90f7c63de196c7bf52c9b06f17e2ab9db86fa86d8c3ff3ee2360fb20914f8')
+options=('libtool')
 
 build()
 {
     mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
-    if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
-        CFLAGS+=" -Wno-int-conversion"
-    fi
-
     ../"${_realname}-${pkgver}"/configure \
       --prefix="${MINGW_PREFIX}" \
       --build="${MINGW_CHOST}" \
       --host="${MINGW_CHOST}" \
-      --target="${MINGW_CHOST}" \
       --enable-hosts="gtk rfb openvpn"
 
     make

--- a/mingw-w64-tme/PKGBUILD
+++ b/mingw-w64-tme/PKGBUILD
@@ -30,7 +30,8 @@ build()
       --prefix="${MINGW_PREFIX}" \
       --build="${MINGW_CHOST}" \
       --host="${MINGW_CHOST}" \
-      --enable-hosts="gtk rfb openvpn"
+      --enable-hosts="gtk rfb openvpn" \
+      --disable-ltdl-install
 
     make
 }

--- a/mingw-w64-tme/PKGBUILD
+++ b/mingw-w64-tme/PKGBUILD
@@ -12,6 +12,7 @@ url="http://nme.osdn.io"
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
+	     "${MINGW_PACKAGE_PREFIX}-SDL2"
 	     "bison"
 	     "texinfo")
 depends=("${MINGW_PACKAGE_PREFIX}-gtk4"


### PR DESCRIPTION
Release Candidate 10 of version 0.12. The major update with this release is upgrade support to GTK4 as a front-end GUI host. GTK3 is still supported for backward compatibility. Various other bug fixes for compiling & running have been added as well.