### PR TITLE
mcfgthread: Update to v1.5-beta.1

### DIFF
--- a/mingw-w64-mcfgthread/PKGBUILD
+++ b/mingw-w64-mcfgthread/PKGBUILD
@@ -4,14 +4,14 @@ _realname=mcfgthread
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}"-libs)
-pkgver=1.4.1
+pkgver=1.5.0
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://github.com/lhmouse/mcfgthread"
 license=('spdx:LGPL-3.0-or-later' 'custom')
 options=('staticlibs' 'strip' '!buildflags')
-_commit='66326556e26f07872c797bbdbea5e398de32e66d'
+_commit='fa18d75a1762d3a0269ee1566f70aebfb5a36017'
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cc"
   "${MINGW_PACKAGE_PREFIX}-autotools"


### PR DESCRIPTION
TLS and per-thread exit callbacks are now functional in threads that have been created by other libraries, e.g. by CreateThread() or pthread_create(). (https://github.com/lhmouse/mcfgthread/issues/81)