### PR TITLE
crt: enable cfguard for clang environments

### DIFF
--- a/mingw-w64-crt-git/PKGBUILD
+++ b/mingw-w64-crt-git/PKGBUILD
@@ -4,7 +4,7 @@ _realname=crt
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 pkgver=10.0.0.r258.g530c58e17
-pkgrel=1
+pkgrel=2
 _commit='530c58e17adc5bfa1347a71453eca95b248ec683'
 pkgdesc='MinGW-w64 CRT for Windows'
 arch=('any')
@@ -38,21 +38,27 @@ prepare() {
 
 build() {
   msg "Building ${MSYSTEM} CRT"
-  local _crt_configure_args
+
+  declare -a _crt_configure_args
   case "$CARCH" in
     i686)
-      _crt_configure_args="--disable-lib64 --enable-lib32"
+      _crt_configure_args=("--disable-lib64" "--enable-lib32")
     ;;
     x86_64)
-      _crt_configure_args="--disable-lib32 --enable-lib64"
+      _crt_configure_args=("--disable-lib32" "--enable-lib64")
     ;;
     armv7)
-      _crt_configure_args="--disable-lib32 --disable-lib64 --enable-libarm32"
+      _crt_configure_args=("--disable-lib32" "--disable-lib64" "--enable-libarm32")
     ;;
     aarch64)
-      _crt_configure_args="--disable-lib32 --disable-lib64 --disable-libarm32 --enable-libarm64"
+      _crt_configure_args=("--disable-lib32" "--disable-lib64" "--disable-libarm32" "--enable-libarm64")
     ;;
   esac
+
+  # only clang+lld support this at the moment
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then
+    _crt_configure_args+=("--enable-cfguard")
+  fi
 
   local _default_msvcrt=msvcrt
   if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]] || [[ $MINGW_PACKAGE_PREFIX == *-ucrt-* ]]; then
@@ -70,7 +76,7 @@ build() {
     --with-default-msvcrt=${_default_msvcrt} \
     --enable-wildcard \
     --disable-dependency-tracking \
-    ${_crt_configure_args}
+    "${_crt_configure_args[@]}"
 
   make
 }


### PR DESCRIPTION
this is required to use CFG (Control Flow Guard)

tests here: https://github.com/msys2/msys2-tests/pull/34