### PR TITLE
python-winsdk: Enable building on all mingw arch

### DIFF
--- a/mingw-w64-python-winsdk/PKGBUILD
+++ b/mingw-w64-python-winsdk/PKGBUILD
@@ -4,10 +4,10 @@ _realname=winsdk
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=1.0.0b9
-pkgrel=1
+pkgrel=2
 pkgdesc="Python package with bindings for Windows SDK (mingw-w64)"
 arch=('any')
-mingw_arch=('clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url='https://github.com/pywinrt/python-winsdk'
 license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-python")
@@ -19,13 +19,6 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-cc")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('207d35f9ab445521d4f060b5c1f2181660390cd3db27b32961af7438478fb226')
-
-prepare() {
-  cd "${srcdir}/${_realname}-${pkgver}"
-
-  # Remove due to the lack of required headers
-  rm pywinrt/winsdk/src/py.Windows.Graphics.Capture.Interop.cpp
-}
 
 build() {
   msg "Python build for ${MSYSTEM}"


### PR DESCRIPTION
I don't have an arm64 computer with Windows, so I couldn't test clangarm64.