### PR TITLE
kicad: update to 7.0.2

### DIFF
--- a/mingw-w64-kicad-doc/PKGBUILD
+++ b/mingw-w64-kicad-doc/PKGBUILD
@@ -15,7 +15,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-ca"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-pl"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-ru"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-zh")
-pkgver=7.0.0
+pkgver=7.0.2
 pkgrel=1
 pkgdesc="Documentation for KiCad (mingw-w64)"
 arch=(any)
@@ -27,7 +27,7 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-kicad-meta"
             "${MINGW_PACKAGE_PREFIX}-kicad")
 
 source=("https://kicad-downloads.s3.cern.ch/docs/kicad-doc-${pkgver}.tar.gz")
-sha256sums=('04cad356fd19b46e70eaa6e3365d94c326e4237d80c09394208fd4662e756465')
+sha256sums=('e97f0848226101591973c2447377585d0a578acccd605e4d8f9b37a24c1b19bc')
 
 build_lang() {
   cd "${srcdir}/kicad-doc-${pkgver}/share/doc/kicad/help"

--- a/mingw-w64-kicad-library/PKGBUILD
+++ b/mingw-w64-kicad-library/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-footprints"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-templates"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-packages3D"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-meta")
-pkgver=7.0.0
+pkgver=7.0.2
 pkgrel=1
 pkgdesc="Support libraries for KiCad (mingw-w64)"
 arch=('any')
@@ -23,10 +23,10 @@ source=("https://gitlab.com/kicad/libraries/kicad-footprints/-/archive/${pkgver}
         "https://gitlab.com/kicad/libraries/kicad-symbols/-/archive/${pkgver}/kicad-symbols-${pkgver}.tar.bz2"
         "https://gitlab.com/kicad/libraries/kicad-templates/-/archive/${pkgver}/kicad-templates-${pkgver}.tar.bz2"
         "https://gitlab.com/kicad/libraries/kicad-packages3D/-/archive/${pkgver}/kicad-packages3D-${pkgver}.tar.bz2")
-sha256sums=('c344f1bf92d4161845117757197de83b1722391f2830d7d698a5879f6677e884'
-            '3042b1d9f64f1d96e276361cc99bd695d8c9a88d0cc34a0815d9cc68e7243dfe'
-            'ea358574c6e6de3d5a946abd16bf18b767cd8efa47b98edac0c334de839b5984'
-            '28e53e23b18b434702bcf0c0462f44e7c866f9dd0fed3ab60291057f8bfd7ff9')
+sha256sums=('81ba4e1a48a4a741e3860d2e6b305a1002aea41c9ce168db13f9c7650198e374'
+            'd0f9aed81172e14da899d90e2ead6ef8c4d515da3a3847a26bab22db4a7e4528'
+            '2ca6de284aa6d1567173d3d5ef10bb7f416cc919b7a9cae438ebb36ced15df74'
+            'a436414b9466db3aacfbe3efedfc784bcec2d2839789234fc65414069a9e470d')
 
 build() {
   declare -a extra_config

--- a/mingw-w64-kicad/PKGBUILD
+++ b/mingw-w64-kicad/PKGBUILD
@@ -8,7 +8,7 @@ _realname=kicad
 _wx_basever=3.2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=7.0.0
+pkgver=7.0.2
 pkgrel=1
 pkgdesc="Software for the creation of electronic schematic diagrams and printed circuit board artwork (mingw-w64)"
 arch=(any)
@@ -56,20 +56,16 @@ for _doclang in ${_doc[@]}; do
 done
 source=(
   "https://gitlab.com/kicad/code/kicad/-/archive/${pkgver}/kicad-${pkgver}.tar.bz2"
-  "001-support-subrelease-field-in-wxwidgets.patch"::"https://gitlab.com/kicad/code/kicad/-/commit/048c8b16.patch"
   '002-ki-6.0-cmake-fixes-for-MINGW-CLANG.patch'
   '003-ki-6.0-code-fixes-for-GNUC-CLANG.patch'
   '006-ki-6.0-rewrite-kiwin32_rc_for_clang.patch'
-  '005-ki-6.0-Skip-ffloat-store-under-CLANG.patch'
   # This is not a patch to use with standard production builds
   '007-ki-6.0-manifest-remove-win10-11-manifest-support.patch'
 )
-sha256sums=('f0e188c67a1044c6cc884b66b25717326d93ec896194c0963c2fb79b35943d72'
-            'f66c551457800d4794ba6a4817037aacafffe9644a2718f5c6652fc430f1bc18'
+sha256sums=('9d7a370ebbd2f7f0603d395d2b3b8c14f5e0ed71441c03895591fb776c4ce38e'
             '2924a86849c02aecd21cded0bd2069353fca33c3364f9b41f9bfdd80e19085cf'
             'd8d5f4bdd0aa6d8a907710c523f6f95840636cb2ef69e5275c6ed4966f134353'
             'e03dbb58409145c8fb54991d8259f14bc0ba6b21abca24f9b914ec354c9df89c'
-            'f9cd1cbbafe98a76e0bd7cb61ab76b05b5a2c22848dd5ea8042c06e0c4864288'
             '550397b8d2ba66b924933020e409e868d3e4b2352a235f329798bc631b9fd28f')
 
 # Helper macros to help make tasks easier #
@@ -84,10 +80,8 @@ apply_patch_with_msg() {
 prepare() {
   cd ${_realname}-${pkgver}
   apply_patch_with_msg \
-    001-support-subrelease-field-in-wxwidgets.patch \
     002-ki-6.0-cmake-fixes-for-MINGW-CLANG.patch \
     003-ki-6.0-code-fixes-for-GNUC-CLANG.patch \
-    005-ki-6.0-Skip-ffloat-store-under-CLANG.patch \
     006-ki-6.0-rewrite-kiwin32_rc_for_clang.patch
   # This patch is needed for old Intel GPU drivers and should not be
   # used for the production version of the package


### PR DESCRIPTION
Remove the patches that have been applied/fixed upstream.

Downloading the libraries was rather unreliable from my end. And it took several attempts to get valid archives. Let's see how the CI will fare.

There will likely be a circular dependency between the main application and the libraries. It should be possible to build them in any order.
Is there a way to have a dependency only for *runtime* but not for *build time*? Like a "reverse makedepends"?
