### PR TITLE
Add findutils

### DIFF
--- a/mingw-w64-findutils/001-add-gnulib-modules.patch
+++ b/mingw-w64-findutils/001-add-gnulib-modules.patch
@@ -1,0 +1,3359 @@
+
+--- a/gl/lib/Makefile.am
++++ b/gl/lib/Makefile.am
+@@ -102,6 +102,7 @@
+ #  parse-datetime \
+ #  pathmax \
+ #  perror \
++#  poll \
+ #  progname \
+ #  quotearg \
+ #  readlink \
+@@ -145,6 +146,7 @@
+ #  warnings \
+ #  wchar \
+ #  wcwidth \
++#  windows-stat-inodes \
+ #  xalloc \
+ #  xalloc-die \
+ #  xgetcwd \
+@@ -2269,6 +2271,42 @@
+ 
+ ## end   gnulib module pipe-posix
+ 
++## begin gnulib module poll
++
++if GL_COND_OBJ_POLL
++libgnulib_a_SOURCES += poll.c
++endif
++
++## end   gnulib module poll
++
++## begin gnulib module poll-h
++
++BUILT_SOURCES += poll.h
++
++# We need the following in order to create <poll.h> when the system
++# doesn't have one.
++poll.h: poll.in.h $(top_builddir)/config.status $(CXXDEFS_H) $(WARN_ON_USE_H)
++	$(gl_V_at)$(SED_HEADER_STDOUT) \
++	      -e 's|@''GUARD_PREFIX''@|GL|g' \
++	      -e 's|@''HAVE_POLL_H''@|$(HAVE_POLL_H)|g' \
++	      -e 's|@''INCLUDE_NEXT''@|$(INCLUDE_NEXT)|g' \
++	      -e 's|@''PRAGMA_SYSTEM_HEADER''@|@PRAGMA_SYSTEM_HEADER@|g' \
++	      -e 's|@''PRAGMA_COLUMNS''@|@PRAGMA_COLUMNS@|g' \
++	      -e 's|@''NEXT_POLL_H''@|$(NEXT_POLL_H)|g' \
++	      -e 's/@''GNULIB_POLL''@/$(GL_GNULIB_POLL)/g' \
++	      -e 's|@''HAVE_WINSOCK2_H''@|$(HAVE_WINSOCK2_H)|g' \
++	      -e 's|@''HAVE_POLL''@|$(HAVE_POLL)|g' \
++	      -e 's|@''REPLACE_POLL''@|$(REPLACE_POLL)|g' \
++	      -e '/definitions of _GL_FUNCDECL_RPL/r $(CXXDEFS_H)' \
++	      -e '/definition of _GL_WARN_ON_USE/r $(WARN_ON_USE_H)' \
++	      $(srcdir)/poll.in.h > $@-t
++	$(AM_V_at)mv $@-t $@
++MOSTLYCLEANFILES += poll.h poll.h-t
++
++EXTRA_DIST += poll.in.h
++
++## end   gnulib module poll-h
++
+ ## begin gnulib module progname
+ 
+ libgnulib_a_SOURCES += progname.h progname.c
+@@ -2461,6 +2499,14 @@
+ 
+ ## end   gnulib module scratch_buffer
+ 
++## begin gnulib module select
++
++if GL_COND_OBJ_SELECT
++libgnulib_a_SOURCES += select.c
++endif
++
++## end   gnulib module select
++
+ ## begin gnulib module selinux-at
+ 
+ libgnulib_a_SOURCES += selinux-at.h selinux-at.c
+@@ -2538,6 +2584,46 @@
+ 
+ ## end   gnulib module setlocale-null
+ 
++## begin gnulib module signal-h
++
++BUILT_SOURCES += signal.h
++
++# We need the following in order to create <signal.h> when the system
++# doesn't have a complete one.
++signal.h: signal.in.h $(top_builddir)/config.status $(CXXDEFS_H) $(ARG_NONNULL_H) $(WARN_ON_USE_H)
++	$(gl_V_at)$(SED_HEADER_STDOUT) \
++	      -e 's|@''GUARD_PREFIX''@|GL|g' \
++	      -e 's|@''INCLUDE_NEXT''@|$(INCLUDE_NEXT)|g' \
++	      -e 's|@''PRAGMA_SYSTEM_HEADER''@|@PRAGMA_SYSTEM_HEADER@|g' \
++	      -e 's|@''PRAGMA_COLUMNS''@|@PRAGMA_COLUMNS@|g' \
++	      -e 's|@''NEXT_SIGNAL_H''@|$(NEXT_SIGNAL_H)|g' \
++	      -e 's/@''GNULIB_PTHREAD_SIGMASK''@/$(GL_GNULIB_PTHREAD_SIGMASK)/g' \
++	      -e 's/@''GNULIB_RAISE''@/$(GL_GNULIB_RAISE)/g' \
++	      -e 's/@''GNULIB_SIGNAL_H_SIGPIPE''@/$(GL_GNULIB_SIGNAL_H_SIGPIPE)/g' \
++	      -e 's/@''GNULIB_SIGPROCMASK''@/$(GL_GNULIB_SIGPROCMASK)/g' \
++	      -e 's/@''GNULIB_SIGACTION''@/$(GL_GNULIB_SIGACTION)/g' \
++	      -e 's|@''HAVE_POSIX_SIGNALBLOCKING''@|$(HAVE_POSIX_SIGNALBLOCKING)|g' \
++	      -e 's|@''HAVE_PTHREAD_SIGMASK''@|$(HAVE_PTHREAD_SIGMASK)|g' \
++	      -e 's|@''HAVE_RAISE''@|$(HAVE_RAISE)|g' \
++	      -e 's|@''HAVE_SIGSET_T''@|$(HAVE_SIGSET_T)|g' \
++	      -e 's|@''HAVE_SIGINFO_T''@|$(HAVE_SIGINFO_T)|g' \
++	      -e 's|@''HAVE_SIGACTION''@|$(HAVE_SIGACTION)|g' \
++	      -e 's|@''HAVE_STRUCT_SIGACTION_SA_SIGACTION''@|$(HAVE_STRUCT_SIGACTION_SA_SIGACTION)|g' \
++	      -e 's|@''HAVE_TYPE_VOLATILE_SIG_ATOMIC_T''@|$(HAVE_TYPE_VOLATILE_SIG_ATOMIC_T)|g' \
++	      -e 's|@''HAVE_SIGHANDLER_T''@|$(HAVE_SIGHANDLER_T)|g' \
++	      -e 's|@''REPLACE_PTHREAD_SIGMASK''@|$(REPLACE_PTHREAD_SIGMASK)|g' \
++	      -e 's|@''REPLACE_RAISE''@|$(REPLACE_RAISE)|g' \
++	      -e '/definitions of _GL_FUNCDECL_RPL/r $(CXXDEFS_H)' \
++	      -e '/definition of _GL_ARG_NONNULL/r $(ARG_NONNULL_H)' \
++	      -e '/definition of _GL_WARN_ON_USE/r $(WARN_ON_USE_H)' \
++	      $(srcdir)/signal.in.h > $@-t
++	$(AM_V_at)mv $@-t $@
++MOSTLYCLEANFILES += signal.h signal.h-t
++
++EXTRA_DIST += signal.in.h
++
++## end   gnulib module signal-h
++
+ ## begin gnulib module size_max
+ 
+ libgnulib_a_SOURCES += size_max.h
+@@ -3369,6 +3455,38 @@
+ 
+ ## end   gnulib module strtoumax
+ 
++## begin gnulib module sys_select
++
++BUILT_SOURCES += sys/select.h
++
++# We need the following in order to create <sys/select.h> when the system
++# doesn't have one that works with the given compiler.
++sys/select.h: sys_select.in.h $(top_builddir)/config.status $(CXXDEFS_H) $(WARN_ON_USE_H)
++	$(AM_V_GEN)$(MKDIR_P) '%reldir%/sys'
++	$(AM_V_at)$(SED_HEADER_STDOUT) \
++	      -e 's|@''GUARD_PREFIX''@|GL|g' \
++	      -e 's|@''INCLUDE_NEXT''@|$(INCLUDE_NEXT)|g' \
++	      -e 's|@''PRAGMA_SYSTEM_HEADER''@|@PRAGMA_SYSTEM_HEADER@|g' \
++	      -e 's|@''PRAGMA_COLUMNS''@|@PRAGMA_COLUMNS@|g' \
++	      -e 's|@''NEXT_SYS_SELECT_H''@|$(NEXT_SYS_SELECT_H)|g' \
++	      -e 's|@''HAVE_SYS_SELECT_H''@|$(HAVE_SYS_SELECT_H)|g' \
++	      -e 's/@''GNULIB_PSELECT''@/$(GL_GNULIB_PSELECT)/g' \
++	      -e 's/@''GNULIB_SELECT''@/$(GL_GNULIB_SELECT)/g' \
++	      -e 's|@''HAVE_WINSOCK2_H''@|$(HAVE_WINSOCK2_H)|g' \
++	      -e 's|@''HAVE_PSELECT''@|$(HAVE_PSELECT)|g' \
++	      -e 's|@''REPLACE_PSELECT''@|$(REPLACE_PSELECT)|g' \
++	      -e 's|@''REPLACE_SELECT''@|$(REPLACE_SELECT)|g' \
++	      -e '/definitions of _GL_FUNCDECL_RPL/r $(CXXDEFS_H)' \
++	      -e '/definition of _GL_WARN_ON_USE/r $(WARN_ON_USE_H)' \
++	      $(srcdir)/sys_select.in.h > $@-t
++	$(AM_V_at)mv $@-t $@
++MOSTLYCLEANFILES += sys/select.h sys/select.h-t
++MOSTLYCLEANDIRS += sys
++
++EXTRA_DIST += sys_select.in.h
++
++## end   gnulib module sys_select
++
+ ## begin gnulib module sys_socket
+ 
+ BUILT_SOURCES += sys/socket.h
+--- a/gl/lib/poll.c
++++ b/gl/lib/poll.c
+@@ -0,0 +1,633 @@
++/* Emulation for poll(2)
++   Contributed by Paolo Bonzini.
++
++   Copyright 2001-2003, 2006-2022 Free Software Foundation, Inc.
++
++   This file is part of gnulib.
++
++   This file is free software: you can redistribute it and/or modify
++   it under the terms of the GNU Lesser General Public License as
++   published by the Free Software Foundation; either version 2.1 of the
++   License, or (at your option) any later version.
++
++   This file is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public License
++   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
++
++/* Tell gcc not to warn about the (nfd < 0) tests, below.  */
++#if (__GNUC__ == 4 && 3 <= __GNUC_MINOR__) || 4 < __GNUC__
++# pragma GCC diagnostic ignored "-Wtype-limits"
++#endif
++
++#include <config.h>
++#include <alloca.h>
++
++#include <sys/types.h>
++
++/* Specification.  */
++#include <poll.h>
++
++#include <errno.h>
++#include <limits.h>
++
++#if defined _WIN32 && ! defined __CYGWIN__
++# define WINDOWS_NATIVE
++# include <winsock2.h>
++# include <windows.h>
++# include <io.h>
++# include <stdio.h>
++# include <conio.h>
++# if GNULIB_MSVC_NOTHROW
++#  include "msvc-nothrow.h"
++# else
++#  include <io.h>
++# endif
++#else
++# include <sys/time.h>
++# include <unistd.h>
++#endif
++
++#include <sys/select.h>
++#include <sys/socket.h>
++
++#ifdef HAVE_SYS_IOCTL_H
++# include <sys/ioctl.h>
++#endif
++#ifdef HAVE_SYS_FILIO_H
++# include <sys/filio.h>
++#endif
++
++#include <time.h>
++
++#include "assure.h"
++
++#ifndef INFTIM
++# define INFTIM (-1)
++#endif
++
++/* BeOS does not have MSG_PEEK.  */
++#ifndef MSG_PEEK
++# define MSG_PEEK 0
++#endif
++
++#ifdef WINDOWS_NATIVE
++
++/* Don't assume that UNICODE is not defined.  */
++# undef GetModuleHandle
++# define GetModuleHandle GetModuleHandleA
++# undef PeekConsoleInput
++# define PeekConsoleInput PeekConsoleInputA
++# undef CreateEvent
++# define CreateEvent CreateEventA
++# undef PeekMessage
++# define PeekMessage PeekMessageA
++# undef DispatchMessage
++# define DispatchMessage DispatchMessageA
++
++/* Do *not* use the function WSAPoll
++   <https://docs.microsoft.com/en-us/windows/desktop/api/winsock2/nf-winsock2-wsapoll>
++   because there is a bug named “Windows 8 Bugs 309411 - WSAPoll does not
++   report failed connections” that Microsoft won't fix.
++   See Daniel Stenberg: "WASPoll is broken"
++   <https://daniel.haxx.se/blog/2012/10/10/wsapoll-is-broken/>.  */
++
++/* Here we need the recv() function from Windows, that takes a SOCKET as
++   first argument, not any possible gnulib override.  */
++# undef recv
++
++/* Here we need the select() function from Windows, because we pass bit masks
++   of SOCKETs, not bit masks of FDs.  */
++# undef select
++
++/* Here we need timeval from Windows since this is what the select() function
++   from Windows requires.  */
++# undef timeval
++
++/* Avoid warnings from gcc -Wcast-function-type.  */
++# define GetProcAddress \
++   (void *) GetProcAddress
++
++static BOOL IsConsoleHandle (HANDLE h)
++{
++  DWORD mode;
++  return GetConsoleMode (h, &mode) != 0;
++}
++
++static BOOL
++IsSocketHandle (HANDLE h)
++{
++  WSANETWORKEVENTS ev;
++
++  if (IsConsoleHandle (h))
++    return FALSE;
++
++  /* Under Wine, it seems that getsockopt returns 0 for pipes too.
++     WSAEnumNetworkEvents instead distinguishes the two correctly.  */
++  ev.lNetworkEvents = 0xDEADBEEF;
++  WSAEnumNetworkEvents ((SOCKET) h, NULL, &ev);
++  return ev.lNetworkEvents != 0xDEADBEEF;
++}
++
++/* Declare data structures for ntdll functions.  */
++typedef struct _FILE_PIPE_LOCAL_INFORMATION {
++  ULONG NamedPipeType;
++  ULONG NamedPipeConfiguration;
++  ULONG MaximumInstances;
++  ULONG CurrentInstances;
++  ULONG InboundQuota;
++  ULONG ReadDataAvailable;
++  ULONG OutboundQuota;
++  ULONG WriteQuotaAvailable;
++  ULONG NamedPipeState;
++  ULONG NamedPipeEnd;
++} FILE_PIPE_LOCAL_INFORMATION, *PFILE_PIPE_LOCAL_INFORMATION;
++
++typedef struct _IO_STATUS_BLOCK
++{
++  union {
++    DWORD Status;
++    PVOID Pointer;
++  } u;
++  ULONG_PTR Information;
++} IO_STATUS_BLOCK, *PIO_STATUS_BLOCK;
++
++typedef enum _FILE_INFORMATION_CLASS {
++  FilePipeLocalInformation = 24
++} FILE_INFORMATION_CLASS, *PFILE_INFORMATION_CLASS;
++
++typedef DWORD (WINAPI *PNtQueryInformationFile)
++         (HANDLE, IO_STATUS_BLOCK *, VOID *, ULONG, FILE_INFORMATION_CLASS);
++
++# ifndef PIPE_BUF
++#  define PIPE_BUF      512
++# endif
++
++/* Compute revents values for file handle H.  If some events cannot happen
++   for the handle, eliminate them from *P_SOUGHT.  */
++
++static int
++windows_compute_revents (HANDLE h, int *p_sought)
++{
++  int i, ret, happened;
++  INPUT_RECORD *irbuffer;
++  DWORD avail, nbuffer;
++  BOOL bRet;
++  IO_STATUS_BLOCK iosb;
++  FILE_PIPE_LOCAL_INFORMATION fpli;
++  static PNtQueryInformationFile NtQueryInformationFile;
++  static BOOL once_only;
++
++  switch (GetFileType (h))
++    {
++    case FILE_TYPE_PIPE:
++      if (!once_only)
++        {
++          NtQueryInformationFile = (PNtQueryInformationFile)
++            GetProcAddress (GetModuleHandle ("ntdll.dll"),
++                            "NtQueryInformationFile");
++          once_only = TRUE;
++        }
++
++      happened = 0;
++      if (PeekNamedPipe (h, NULL, 0, NULL, &avail, NULL) != 0)
++        {
++          if (avail)
++            happened |= *p_sought & (POLLIN | POLLRDNORM);
++        }
++      else if (GetLastError () == ERROR_BROKEN_PIPE)
++        happened |= POLLHUP;
++
++      else
++        {
++          /* It was the write-end of the pipe.  Check if it is writable.
++             If NtQueryInformationFile fails, optimistically assume the pipe is
++             writable.  This could happen on Windows 9x, where
++             NtQueryInformationFile is not available, or if we inherit a pipe
++             that doesn't permit FILE_READ_ATTRIBUTES access on the write end
++             (I think this should not happen since Windows XP SP2; WINE seems
++             fine too).  Otherwise, ensure that enough space is available for
++             atomic writes.  */
++          memset (&iosb, 0, sizeof (iosb));
++          memset (&fpli, 0, sizeof (fpli));
++
++          if (!NtQueryInformationFile
++              || NtQueryInformationFile (h, &iosb, &fpli, sizeof (fpli),
++                                         FilePipeLocalInformation)
++              || fpli.WriteQuotaAvailable >= PIPE_BUF
++              || (fpli.OutboundQuota < PIPE_BUF &&
++                  fpli.WriteQuotaAvailable == fpli.OutboundQuota))
++            happened |= *p_sought & (POLLOUT | POLLWRNORM | POLLWRBAND);
++        }
++      return happened;
++
++    case FILE_TYPE_CHAR:
++      ret = WaitForSingleObject (h, 0);
++      if (!IsConsoleHandle (h))
++        return ret == WAIT_OBJECT_0 ? *p_sought & ~(POLLPRI | POLLRDBAND) : 0;
++
++      nbuffer = avail = 0;
++      bRet = GetNumberOfConsoleInputEvents (h, &nbuffer);
++      if (bRet)
++        {
++          /* Input buffer.  */
++          *p_sought &= POLLIN | POLLRDNORM;
++          if (nbuffer == 0)
++            return POLLHUP;
++          if (!*p_sought)
++            return 0;
++
++          irbuffer = (INPUT_RECORD *) alloca (nbuffer * sizeof (INPUT_RECORD));
++          bRet = PeekConsoleInput (h, irbuffer, nbuffer, &avail);
++          if (!bRet || avail == 0)
++            return POLLHUP;
++
++          for (i = 0; i < avail; i++)
++            if (irbuffer[i].EventType == KEY_EVENT)
++              return *p_sought;
++          return 0;
++        }
++      else
++        {
++          /* Screen buffer.  */
++          *p_sought &= POLLOUT | POLLWRNORM | POLLWRBAND;
++          return *p_sought;
++        }
++
++    default:
++      ret = WaitForSingleObject (h, 0);
++      if (ret == WAIT_OBJECT_0)
++        return *p_sought & ~(POLLPRI | POLLRDBAND);
++
++      return *p_sought & (POLLOUT | POLLWRNORM | POLLWRBAND);
++    }
++}
++
++/* Convert fd_sets returned by select into revents values.  */
++
++static int
++windows_compute_revents_socket (SOCKET h, int sought, long lNetworkEvents)
++{
++  int happened = 0;
++
++  if ((lNetworkEvents & (FD_READ | FD_ACCEPT | FD_CLOSE)) == FD_ACCEPT)
++    happened |= (POLLIN | POLLRDNORM) & sought;
++
++  else if (lNetworkEvents & (FD_READ | FD_ACCEPT | FD_CLOSE))
++    {
++      int r, error;
++
++      char data[64];
++      WSASetLastError (0);
++      r = recv (h, data, sizeof (data), MSG_PEEK);
++      error = WSAGetLastError ();
++      WSASetLastError (0);
++
++      if (r > 0 || error == WSAENOTCONN)
++        happened |= (POLLIN | POLLRDNORM) & sought;
++
++      /* Distinguish hung-up sockets from other errors.  */
++      else if (r == 0 || error == WSAESHUTDOWN || error == WSAECONNRESET
++               || error == WSAECONNABORTED || error == WSAENETRESET)
++        happened |= POLLHUP;
++
++      else
++        happened |= POLLERR;
++    }
++
++  if (lNetworkEvents & (FD_WRITE | FD_CONNECT))
++    happened |= (POLLOUT | POLLWRNORM | POLLWRBAND) & sought;
++
++  if (lNetworkEvents & FD_OOB)
++    happened |= (POLLPRI | POLLRDBAND) & sought;
++
++  return happened;
++}
++
++#else /* !MinGW */
++
++/* Convert select(2) returned fd_sets into poll(2) revents values.  */
++static int
++compute_revents (int fd, int sought, fd_set *rfds, fd_set *wfds, fd_set *efds)
++{
++  int happened = 0;
++  if (FD_ISSET (fd, rfds))
++    {
++      int r;
++      int socket_errno;
++
++# if defined __MACH__ && defined __APPLE__
++      /* There is a bug in Mac OS X that causes it to ignore MSG_PEEK
++         for some kinds of descriptors.  Detect if this descriptor is a
++         connected socket, a server socket, or something else using a
++         0-byte recv, and use ioctl(2) to detect POLLHUP.  */
++      r = recv (fd, NULL, 0, MSG_PEEK);
++      socket_errno = (r < 0) ? errno : 0;
++      if (r == 0 || socket_errno == ENOTSOCK)
++        ioctl (fd, FIONREAD, &r);
++# else
++      char data[64];
++      r = recv (fd, data, sizeof (data), MSG_PEEK);
++      socket_errno = (r < 0) ? errno : 0;
++# endif
++      if (r == 0)
++        happened |= POLLHUP;
++
++      /* If the event happened on an unconnected server socket,
++         that's fine. */
++      else if (r > 0 || ( /* (r == -1) && */ socket_errno == ENOTCONN))
++        happened |= (POLLIN | POLLRDNORM) & sought;
++
++      /* Distinguish hung-up sockets from other errors.  */
++      else if (socket_errno == ESHUTDOWN || socket_errno == ECONNRESET
++               || socket_errno == ECONNABORTED || socket_errno == ENETRESET)
++        happened |= POLLHUP;
++
++      /* some systems can't use recv() on non-socket, including HP NonStop */
++      else if (socket_errno == ENOTSOCK)
++        happened |= (POLLIN | POLLRDNORM) & sought;
++
++      else
++        happened |= POLLERR;
++    }
++
++  if (FD_ISSET (fd, wfds))
++    happened |= (POLLOUT | POLLWRNORM | POLLWRBAND) & sought;
++
++  if (FD_ISSET (fd, efds))
++    happened |= (POLLPRI | POLLRDBAND) & sought;
++
++  return happened;
++}
++#endif /* !MinGW */
++
++int
++poll (struct pollfd *pfd, nfds_t nfd, int timeout)
++{
++#ifndef WINDOWS_NATIVE
++  fd_set rfds, wfds, efds;
++  struct timeval tv;
++  struct timeval *ptv;
++  int maxfd, rc;
++  nfds_t i;
++
++  if (nfd > INT_MAX)
++    {
++      errno = EINVAL;
++      return -1;
++    }
++  /* Don't check directly for NFD greater than OPEN_MAX.  Any practical use
++     of a too-large NFD is caught by one of the other checks below, and
++     checking directly for getdtablesize is too much of a portability
++     and/or performance and/or correctness hassle.  */
++
++  /* EFAULT is not necessary to implement, but let's do it in the
++     simplest case. */
++  if (!pfd && nfd)
++    {
++      errno = EFAULT;
++      return -1;
++    }
++
++  /* convert timeout number into a timeval structure */
++  if (timeout == 0)
++    {
++      ptv = &tv;
++      ptv->tv_sec = 0;
++      ptv->tv_usec = 0;
++    }
++  else if (timeout > 0)
++    {
++      ptv = &tv;
++      ptv->tv_sec = timeout / 1000;
++      ptv->tv_usec = (timeout % 1000) * 1000;
++    }
++  else if (timeout == INFTIM)
++    /* wait forever */
++    ptv = NULL;
++  else
++    {
++      errno = EINVAL;
++      return -1;
++    }
++
++  /* create fd sets and determine max fd */
++  maxfd = -1;
++  FD_ZERO (&rfds);
++  FD_ZERO (&wfds);
++  FD_ZERO (&efds);
++  for (i = 0; i < nfd; i++)
++    {
++      if (pfd[i].fd < 0)
++        continue;
++      if (maxfd < pfd[i].fd)
++        {
++          maxfd = pfd[i].fd;
++          if (FD_SETSIZE <= maxfd)
++            {
++              errno = EINVAL;
++              return -1;
++            }
++        }
++      if (pfd[i].events & (POLLIN | POLLRDNORM))
++        FD_SET (pfd[i].fd, &rfds);
++      /* see select(2): "the only exceptional condition detectable
++         is out-of-band data received on a socket", hence we push
++         POLLWRBAND events onto wfds instead of efds. */
++      if (pfd[i].events & (POLLOUT | POLLWRNORM | POLLWRBAND))
++        FD_SET (pfd[i].fd, &wfds);
++      if (pfd[i].events & (POLLPRI | POLLRDBAND))
++        FD_SET (pfd[i].fd, &efds);
++    }
++
++  /* examine fd sets */
++  rc = select (maxfd + 1, &rfds, &wfds, &efds, ptv);
++  if (rc < 0)
++    return rc;
++
++  /* establish results */
++  rc = 0;
++  for (i = 0; i < nfd; i++)
++    {
++      pfd[i].revents = (pfd[i].fd < 0
++                        ? 0
++                        : compute_revents (pfd[i].fd, pfd[i].events,
++                                           &rfds, &wfds, &efds));
++      rc += pfd[i].revents != 0;
++    }
++
++  return rc;
++#else
++  static struct timeval tv0;
++  static HANDLE hEvent;
++  WSANETWORKEVENTS ev;
++  HANDLE h, handle_array[FD_SETSIZE + 2];
++  DWORD ret, wait_timeout, nhandles;
++  fd_set rfds, wfds, xfds;
++  BOOL poll_again;
++  MSG msg;
++  int rc = 0;
++  nfds_t i;
++
++  if (nfd > INT_MAX || timeout < -1)
++    {
++      errno = EINVAL;
++      return -1;
++    }
++
++  if (!hEvent)
++    hEvent = CreateEvent (NULL, FALSE, FALSE, NULL);
++
++restart:
++  handle_array[0] = hEvent;
++  nhandles = 1;
++  FD_ZERO (&rfds);
++  FD_ZERO (&wfds);
++  FD_ZERO (&xfds);
++
++  /* Classify socket handles and create fd sets. */
++  for (i = 0; i < nfd; i++)
++    {
++      int sought = pfd[i].events;
++      pfd[i].revents = 0;
++      if (pfd[i].fd < 0)
++        continue;
++      if (!(sought & (POLLIN | POLLRDNORM | POLLOUT | POLLWRNORM | POLLWRBAND
++                      | POLLPRI | POLLRDBAND)))
++        continue;
++
++      h = (HANDLE) _get_osfhandle (pfd[i].fd);
++      assure (h != NULL);
++      if (IsSocketHandle (h))
++        {
++          int requested = FD_CLOSE;
++
++          /* see above; socket handles are mapped onto select.  */
++          if (sought & (POLLIN | POLLRDNORM))
++            {
++              requested |= FD_READ | FD_ACCEPT;
++              FD_SET ((SOCKET) h, &rfds);
++            }
++          if (sought & (POLLOUT | POLLWRNORM | POLLWRBAND))
++            {
++              requested |= FD_WRITE | FD_CONNECT;
++              FD_SET ((SOCKET) h, &wfds);
++            }
++          if (sought & (POLLPRI | POLLRDBAND))
++            {
++              requested |= FD_OOB;
++              FD_SET ((SOCKET) h, &xfds);
++            }
++
++          if (requested)
++            WSAEventSelect ((SOCKET) h, hEvent, requested);
++        }
++      else
++        {
++          /* Poll now.  If we get an event, do not poll again.  Also,
++             screen buffer handles are waitable, and they'll block until
++             a character is available.  windows_compute_revents eliminates
++             bits for the "wrong" direction. */
++          pfd[i].revents = windows_compute_revents (h, &sought);
++          if (sought)
++            handle_array[nhandles++] = h;
++          if (pfd[i].revents)
++            timeout = 0;
++        }
++    }
++
++  if (select (0, &rfds, &wfds, &xfds, &tv0) > 0)
++    {
++      /* Do MsgWaitForMultipleObjects anyway to dispatch messages, but
++         no need to call select again.  */
++      poll_again = FALSE;
++      wait_timeout = 0;
++    }
++  else
++    {
++      poll_again = TRUE;
++      if (timeout == INFTIM)
++        wait_timeout = INFINITE;
++      else
++        wait_timeout = timeout;
++    }
++
++  for (;;)
++    {
++      ret = MsgWaitForMultipleObjects (nhandles, handle_array, FALSE,
++                                       wait_timeout, QS_ALLINPUT);
++
++      if (ret == WAIT_OBJECT_0 + nhandles)
++        {
++          /* new input of some other kind */
++          BOOL bRet;
++          while ((bRet = PeekMessage (&msg, NULL, 0, 0, PM_REMOVE)) != 0)
++            {
++              TranslateMessage (&msg);
++              DispatchMessage (&msg);
++            }
++        }
++      else
++        break;
++    }
++
++  if (poll_again)
++    select (0, &rfds, &wfds, &xfds, &tv0);
++
++  /* Place a sentinel at the end of the array.  */
++  handle_array[nhandles] = NULL;
++  nhandles = 1;
++  for (i = 0; i < nfd; i++)
++    {
++      int happened;
++
++      if (pfd[i].fd < 0)
++        continue;
++      if (!(pfd[i].events & (POLLIN | POLLRDNORM |
++                             POLLOUT | POLLWRNORM | POLLWRBAND)))
++        continue;
++
++      h = (HANDLE) _get_osfhandle (pfd[i].fd);
++      if (h != handle_array[nhandles])
++        {
++          /* It's a socket.  */
++          WSAEnumNetworkEvents ((SOCKET) h, NULL, &ev);
++          WSAEventSelect ((SOCKET) h, 0, 0);
++
++          /* If we're lucky, WSAEnumNetworkEvents already provided a way
++             to distinguish FD_READ and FD_ACCEPT; this saves a recv later.  */
++          if (FD_ISSET ((SOCKET) h, &rfds)
++              && !(ev.lNetworkEvents & (FD_READ | FD_ACCEPT)))
++            ev.lNetworkEvents |= FD_READ | FD_ACCEPT;
++          if (FD_ISSET ((SOCKET) h, &wfds))
++            ev.lNetworkEvents |= FD_WRITE | FD_CONNECT;
++          if (FD_ISSET ((SOCKET) h, &xfds))
++            ev.lNetworkEvents |= FD_OOB;
++
++          happened = windows_compute_revents_socket ((SOCKET) h, pfd[i].events,
++                                                     ev.lNetworkEvents);
++        }
++      else
++        {
++          /* Not a socket.  */
++          int sought = pfd[i].events;
++          happened = windows_compute_revents (h, &sought);
++          nhandles++;
++        }
++
++       if ((pfd[i].revents |= happened) != 0)
++        rc++;
++    }
++
++  if (!rc && timeout == INFTIM)
++    {
++      SleepEx (1, TRUE);
++      goto restart;
++    }
++
++  return rc;
++#endif
++}
+--- a/gl/lib/poll.in.h
++++ b/gl/lib/poll.in.h
+@@ -0,0 +1,125 @@
++/* Header for poll(2) emulation
++   Contributed by Paolo Bonzini.
++
++   Copyright 2001-2003, 2007, 2009-2022 Free Software Foundation, Inc.
++
++   This file is part of gnulib.
++
++   This file is free software: you can redistribute it and/or modify
++   it under the terms of the GNU Lesser General Public License as
++   published by the Free Software Foundation; either version 2.1 of the
++   License, or (at your option) any later version.
++
++   This file is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public License
++   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
++
++#ifndef _@GUARD_PREFIX@_POLL_H
++
++#if __GNUC__ >= 3
++@PRAGMA_SYSTEM_HEADER@
++#endif
++@PRAGMA_COLUMNS@
++
++/* The include_next requires a split double-inclusion guard.  */
++#if @HAVE_POLL_H@
++# @INCLUDE_NEXT@ @NEXT_POLL_H@
++#endif
++
++#ifndef _@GUARD_PREFIX@_POLL_H
++#define _@GUARD_PREFIX@_POLL_H
++
++/* On native Windows, get the 'struct pollfd' type and the POLL* macro
++   definitions before we override them.  mingw defines them in <winsock2.h>
++   if _WIN32_WINNT >= 0x0600.  */
++#if @HAVE_WINSOCK2_H@
++# include <winsock2.h>
++#endif
++
++
++/* The definitions of _GL_FUNCDECL_RPL etc. are copied here.  */
++
++/* The definition of _GL_WARN_ON_USE is copied here.  */
++
++
++#if !@HAVE_POLL_H@
++
++# if @HAVE_WINSOCK2_H@
++/* Override the definitions from <winsock2.h>.  */
++#  undef POLLIN
++#  undef POLLPRI
++#  undef POLLOUT
++#  undef POLLERR
++#  undef POLLHUP
++#  undef POLLNVAL
++#  undef POLLRDNORM
++#  undef POLLRDBAND
++#  undef POLLWRNORM
++#  undef POLLWRBAND
++#  define pollfd rpl_pollfd
++# endif
++
++/* fake a poll(2) environment */
++# define POLLIN      0x0001      /* any readable data available   */
++# define POLLPRI     0x0002      /* OOB/Urgent readable data      */
++# define POLLOUT     0x0004      /* file descriptor is writable   */
++# define POLLERR     0x0008      /* some poll error occurred      */
++# define POLLHUP     0x0010      /* file descriptor was "hung up" */
++# define POLLNVAL    0x0020      /* requested events "invalid"    */
++# define POLLRDNORM  0x0040
++# define POLLRDBAND  0x0080
++# define POLLWRNORM  0x0100
++# define POLLWRBAND  0x0200
++
++# if !GNULIB_defined_poll_types
++
++struct pollfd
++{
++  int fd;                       /* which file descriptor to poll */
++  short events;                 /* events we are interested in   */
++  short revents;                /* events found on return        */
++};
++
++typedef unsigned long nfds_t;
++
++#  define GNULIB_defined_poll_types 1
++# endif
++
++/* Define INFTIM only if doing so conforms to POSIX.  */
++# if !defined (_POSIX_C_SOURCE) && !defined (_XOPEN_SOURCE)
++#  define INFTIM (-1)
++# endif
++
++#endif
++
++
++#if @GNULIB_POLL@
++# if @REPLACE_POLL@
++#  if !(defined __cplusplus && defined GNULIB_NAMESPACE)
++#   undef poll
++#   define poll rpl_poll
++#  endif
++_GL_FUNCDECL_RPL (poll, int, (struct pollfd *pfd, nfds_t nfd, int timeout));
++_GL_CXXALIAS_RPL (poll, int, (struct pollfd *pfd, nfds_t nfd, int timeout));
++# else
++#  if !@HAVE_POLL@
++_GL_FUNCDECL_SYS (poll, int, (struct pollfd *pfd, nfds_t nfd, int timeout));
++#  endif
++_GL_CXXALIAS_SYS (poll, int, (struct pollfd *pfd, nfds_t nfd, int timeout));
++# endif
++_GL_CXXALIASWARN (poll);
++#elif defined GNULIB_POSIXCHECK
++# undef poll
++# if HAVE_RAW_DECL_POLL
++_GL_WARN_ON_USE (poll, "poll is unportable - "
++                 "use gnulib module poll for portability");
++# endif
++#endif
++
++
++#endif /* _@GUARD_PREFIX@_POLL_H */
++#endif /* _@GUARD_PREFIX@_POLL_H */
+--- a/gl/lib/select.c
++++ b/gl/lib/select.c
+@@ -0,0 +1,598 @@
++/* Emulation for select(2)
++   Contributed by Paolo Bonzini.
++
++   Copyright 2008-2022 Free Software Foundation, Inc.
++
++   This file is part of gnulib.
++
++   This file is free software: you can redistribute it and/or modify
++   it under the terms of the GNU Lesser General Public License as
++   published by the Free Software Foundation; either version 2.1 of the
++   License, or (at your option) any later version.
++
++   This file is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public License
++   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
++
++#include <config.h>
++
++/* Specification.  */
++#include <sys/select.h>
++
++#if defined _WIN32 && ! defined __CYGWIN__
++/* Native Windows.  */
++
++#include <alloca.h>
++#include <assert.h>
++#include <sys/types.h>
++#include <errno.h>
++#include <limits.h>
++
++#include <winsock2.h>
++#include <windows.h>
++#include <io.h>
++#include <stdio.h>
++#include <conio.h>
++#include <time.h>
++
++/* Get the overridden 'struct timeval'.  */
++#include <sys/time.h>
++
++#if GNULIB_MSVC_NOTHROW
++# include "msvc-nothrow.h"
++#else
++# include <io.h>
++#endif
++
++#undef select
++
++/* Don't assume that UNICODE is not defined.  */
++#undef GetModuleHandle
++#define GetModuleHandle GetModuleHandleA
++#undef PeekConsoleInput
++#define PeekConsoleInput PeekConsoleInputA
++#undef CreateEvent
++#define CreateEvent CreateEventA
++#undef PeekMessage
++#define PeekMessage PeekMessageA
++#undef DispatchMessage
++#define DispatchMessage DispatchMessageA
++
++/* Avoid warnings from gcc -Wcast-function-type.  */
++#define GetProcAddress \
++  (void *) GetProcAddress
++
++struct bitset {
++  unsigned char in[FD_SETSIZE / CHAR_BIT];
++  unsigned char out[FD_SETSIZE / CHAR_BIT];
++};
++
++/* Declare data structures for ntdll functions.  */
++typedef struct _FILE_PIPE_LOCAL_INFORMATION {
++  ULONG NamedPipeType;
++  ULONG NamedPipeConfiguration;
++  ULONG MaximumInstances;
++  ULONG CurrentInstances;
++  ULONG InboundQuota;
++  ULONG ReadDataAvailable;
++  ULONG OutboundQuota;
++  ULONG WriteQuotaAvailable;
++  ULONG NamedPipeState;
++  ULONG NamedPipeEnd;
++} FILE_PIPE_LOCAL_INFORMATION, *PFILE_PIPE_LOCAL_INFORMATION;
++
++typedef struct _IO_STATUS_BLOCK
++{
++  union {
++    DWORD Status;
++    PVOID Pointer;
++  } u;
++  ULONG_PTR Information;
++} IO_STATUS_BLOCK, *PIO_STATUS_BLOCK;
++
++typedef enum _FILE_INFORMATION_CLASS {
++  FilePipeLocalInformation = 24
++} FILE_INFORMATION_CLASS, *PFILE_INFORMATION_CLASS;
++
++typedef DWORD (WINAPI *PNtQueryInformationFile)
++         (HANDLE, IO_STATUS_BLOCK *, VOID *, ULONG, FILE_INFORMATION_CLASS);
++
++#ifndef PIPE_BUF
++#define PIPE_BUF        512
++#endif
++
++static BOOL IsConsoleHandle (HANDLE h)
++{
++  DWORD mode;
++  return GetConsoleMode (h, &mode) != 0;
++}
++
++static BOOL
++IsSocketHandle (HANDLE h)
++{
++  WSANETWORKEVENTS ev;
++
++  if (IsConsoleHandle (h))
++    return FALSE;
++
++  /* Under Wine, it seems that getsockopt returns 0 for pipes too.
++     WSAEnumNetworkEvents instead distinguishes the two correctly.  */
++  ev.lNetworkEvents = 0xDEADBEEF;
++  WSAEnumNetworkEvents ((SOCKET) h, NULL, &ev);
++  return ev.lNetworkEvents != 0xDEADBEEF;
++}
++
++/* Compute output fd_sets for libc descriptor FD (whose Windows handle is
++   H).  */
++
++static int
++windows_poll_handle (HANDLE h, int fd,
++                     struct bitset *rbits,
++                     struct bitset *wbits,
++                     struct bitset *xbits)
++{
++  BOOL read, write, except;
++  int i, ret;
++  INPUT_RECORD *irbuffer;
++  DWORD avail, nbuffer;
++  BOOL bRet;
++  IO_STATUS_BLOCK iosb;
++  FILE_PIPE_LOCAL_INFORMATION fpli;
++  static PNtQueryInformationFile NtQueryInformationFile;
++  static BOOL once_only;
++
++  read = write = except = FALSE;
++  switch (GetFileType (h))
++    {
++    case FILE_TYPE_DISK:
++      read = TRUE;
++      write = TRUE;
++      break;
++
++    case FILE_TYPE_PIPE:
++      if (!once_only)
++        {
++          NtQueryInformationFile = (PNtQueryInformationFile)
++            GetProcAddress (GetModuleHandle ("ntdll.dll"),
++                            "NtQueryInformationFile");
++          once_only = TRUE;
++        }
++
++      if (PeekNamedPipe (h, NULL, 0, NULL, &avail, NULL) != 0)
++        {
++          if (avail)
++            read = TRUE;
++        }
++      else if (GetLastError () == ERROR_BROKEN_PIPE)
++        ;
++
++      else
++        {
++          /* It was the write-end of the pipe.  Check if it is writable.
++             If NtQueryInformationFile fails, optimistically assume the pipe is
++             writable.  This could happen on Windows 9x, where
++             NtQueryInformationFile is not available, or if we inherit a pipe
++             that doesn't permit FILE_READ_ATTRIBUTES access on the write end
++             (I think this should not happen since Windows XP SP2; WINE seems
++             fine too).  Otherwise, ensure that enough space is available for
++             atomic writes.  */
++          memset (&iosb, 0, sizeof (iosb));
++          memset (&fpli, 0, sizeof (fpli));
++
++          if (!NtQueryInformationFile
++              || NtQueryInformationFile (h, &iosb, &fpli, sizeof (fpli),
++                                         FilePipeLocalInformation)
++              || fpli.WriteQuotaAvailable >= PIPE_BUF
++              || (fpli.OutboundQuota < PIPE_BUF &&
++                  fpli.WriteQuotaAvailable == fpli.OutboundQuota))
++            write = TRUE;
++        }
++      break;
++
++    case FILE_TYPE_CHAR:
++      write = TRUE;
++      if (!(rbits->in[fd / CHAR_BIT] & (1 << (fd & (CHAR_BIT - 1)))))
++        break;
++
++      ret = WaitForSingleObject (h, 0);
++      if (ret == WAIT_OBJECT_0)
++        {
++          if (!IsConsoleHandle (h))
++            {
++              read = TRUE;
++              break;
++            }
++
++          nbuffer = avail = 0;
++          bRet = GetNumberOfConsoleInputEvents (h, &nbuffer);
++
++          /* Screen buffers handles are filtered earlier.  */
++          assert (bRet);
++          if (nbuffer == 0)
++            {
++              except = TRUE;
++              break;
++            }
++
++          irbuffer = (INPUT_RECORD *) alloca (nbuffer * sizeof (INPUT_RECORD));
++          bRet = PeekConsoleInput (h, irbuffer, nbuffer, &avail);
++          if (!bRet || avail == 0)
++            {
++              except = TRUE;
++              break;
++            }
++
++          for (i = 0; i < avail; i++)
++            if (irbuffer[i].EventType == KEY_EVENT)
++              read = TRUE;
++        }
++      break;
++
++    default:
++      ret = WaitForSingleObject (h, 0);
++      write = TRUE;
++      if (ret == WAIT_OBJECT_0)
++        read = TRUE;
++
++      break;
++    }
++
++  ret = 0;
++  if (read && (rbits->in[fd / CHAR_BIT] & (1 << (fd & (CHAR_BIT - 1)))))
++    {
++      rbits->out[fd / CHAR_BIT] |= (1 << (fd & (CHAR_BIT - 1)));
++      ret++;
++    }
++
++  if (write && (wbits->in[fd / CHAR_BIT] & (1 << (fd & (CHAR_BIT - 1)))))
++    {
++      wbits->out[fd / CHAR_BIT] |= (1 << (fd & (CHAR_BIT - 1)));
++      ret++;
++    }
++
++  if (except && (xbits->in[fd / CHAR_BIT] & (1 << (fd & (CHAR_BIT - 1)))))
++    {
++      xbits->out[fd / CHAR_BIT] |= (1 << (fd & (CHAR_BIT - 1)));
++      ret++;
++    }
++
++  return ret;
++}
++
++int
++rpl_select (int nfds, fd_set *rfds, fd_set *wfds, fd_set *xfds,
++            struct timeval *timeout)
++#undef timeval
++{
++  static struct timeval tv0;
++  static HANDLE hEvent;
++  HANDLE h, handle_array[FD_SETSIZE + 2];
++  fd_set handle_rfds, handle_wfds, handle_xfds;
++  struct bitset rbits, wbits, xbits;
++  unsigned char anyfds_in[FD_SETSIZE / CHAR_BIT];
++  DWORD ret, wait_timeout, nhandles, nsock, nbuffer;
++  MSG msg;
++  int i, fd, rc;
++  clock_t tend;
++
++  if (nfds > FD_SETSIZE)
++    nfds = FD_SETSIZE;
++
++  if (!timeout)
++    wait_timeout = INFINITE;
++  else
++    {
++      wait_timeout = timeout->tv_sec * 1000 + timeout->tv_usec / 1000;
++
++      /* select is also used as a portable usleep.  */
++      if (!rfds && !wfds && !xfds)
++        {
++          Sleep (wait_timeout);
++          return 0;
++        }
++    }
++
++  if (!hEvent)
++    hEvent = CreateEvent (NULL, FALSE, FALSE, NULL);
++
++  handle_array[0] = hEvent;
++  nhandles = 1;
++  nsock = 0;
++
++  /* Copy descriptors to bitsets.  At the same time, eliminate
++     bits in the "wrong" direction for console input buffers
++     and screen buffers, because screen buffers are waitable
++     and they will block until a character is available.  */
++  memset (&rbits, 0, sizeof (rbits));
++  memset (&wbits, 0, sizeof (wbits));
++  memset (&xbits, 0, sizeof (xbits));
++  memset (anyfds_in, 0, sizeof (anyfds_in));
++  if (rfds)
++    for (i = 0; i < rfds->fd_count; i++)
++      {
++        fd = rfds->fd_array[i];
++        h = (HANDLE) _get_osfhandle (fd);
++        if (IsConsoleHandle (h)
++            && !GetNumberOfConsoleInputEvents (h, &nbuffer))
++          continue;
++
++        rbits.in[fd / CHAR_BIT] |= 1 << (fd & (CHAR_BIT - 1));
++        anyfds_in[fd / CHAR_BIT] |= 1 << (fd & (CHAR_BIT - 1));
++      }
++  else
++    rfds = (fd_set *) alloca (sizeof (fd_set));
++
++  if (wfds)
++    for (i = 0; i < wfds->fd_count; i++)
++      {
++        fd = wfds->fd_array[i];
++        h = (HANDLE) _get_osfhandle (fd);
++        if (IsConsoleHandle (h)
++            && GetNumberOfConsoleInputEvents (h, &nbuffer))
++          continue;
++
++        wbits.in[fd / CHAR_BIT] |= 1 << (fd & (CHAR_BIT - 1));
++        anyfds_in[fd / CHAR_BIT] |= 1 << (fd & (CHAR_BIT - 1));
++      }
++  else
++    wfds = (fd_set *) alloca (sizeof (fd_set));
++
++  if (xfds)
++    for (i = 0; i < xfds->fd_count; i++)
++      {
++        fd = xfds->fd_array[i];
++        xbits.in[fd / CHAR_BIT] |= 1 << (fd & (CHAR_BIT - 1));
++        anyfds_in[fd / CHAR_BIT] |= 1 << (fd & (CHAR_BIT - 1));
++      }
++  else
++    xfds = (fd_set *) alloca (sizeof (fd_set));
++
++  /* Zero all the fd_sets, including the application's.  */
++  FD_ZERO (rfds);
++  FD_ZERO (wfds);
++  FD_ZERO (xfds);
++  FD_ZERO (&handle_rfds);
++  FD_ZERO (&handle_wfds);
++  FD_ZERO (&handle_xfds);
++
++  /* Classify handles.  Create fd sets for sockets, poll the others. */
++  for (i = 0; i < nfds; i++)
++    {
++      if ((anyfds_in[i / CHAR_BIT] & (1 << (i & (CHAR_BIT - 1)))) == 0)
++        continue;
++
++      h = (HANDLE) _get_osfhandle (i);
++      if (!h)
++        {
++          errno = EBADF;
++          return -1;
++        }
++
++      if (IsSocketHandle (h))
++        {
++          int requested = FD_CLOSE;
++
++          /* See above; socket handles are mapped onto select, but we
++             need to map descriptors to handles.  */
++          if (rbits.in[i / CHAR_BIT] & (1 << (i & (CHAR_BIT - 1))))
++            {
++              requested |= FD_READ | FD_ACCEPT;
++              FD_SET ((SOCKET) h, rfds);
++              FD_SET ((SOCKET) h, &handle_rfds);
++            }
++          if (wbits.in[i / CHAR_BIT] & (1 << (i & (CHAR_BIT - 1))))
++            {
++              requested |= FD_WRITE | FD_CONNECT;
++              FD_SET ((SOCKET) h, wfds);
++              FD_SET ((SOCKET) h, &handle_wfds);
++            }
++          if (xbits.in[i / CHAR_BIT] & (1 << (i & (CHAR_BIT - 1))))
++            {
++              requested |= FD_OOB;
++              FD_SET ((SOCKET) h, xfds);
++              FD_SET ((SOCKET) h, &handle_xfds);
++            }
++
++          WSAEventSelect ((SOCKET) h, hEvent, requested);
++          nsock++;
++        }
++      else
++        {
++          handle_array[nhandles++] = h;
++
++          /* Poll now.  If we get an event, do not wait below.  */
++          if (wait_timeout != 0
++              && windows_poll_handle (h, i, &rbits, &wbits, &xbits))
++            wait_timeout = 0;
++        }
++    }
++
++  /* Place a sentinel at the end of the array.  */
++  handle_array[nhandles] = NULL;
++
++  /* When will the waiting period expire?  */
++  if (wait_timeout != INFINITE)
++    tend = clock () + wait_timeout;
++
++restart:
++  if (wait_timeout == 0 || nsock == 0)
++    rc = 0;
++  else
++    {
++      /* See if we need to wait in the loop below.  If any select is ready,
++         do MsgWaitForMultipleObjects anyway to dispatch messages, but
++         no need to call select again.  */
++      rc = select (0, &handle_rfds, &handle_wfds, &handle_xfds, &tv0);
++      if (rc == 0)
++        {
++          /* Restore the fd_sets for the other select we do below.  */
++          memcpy (&handle_rfds, rfds, sizeof (fd_set));
++          memcpy (&handle_wfds, wfds, sizeof (fd_set));
++          memcpy (&handle_xfds, xfds, sizeof (fd_set));
++        }
++      else
++        wait_timeout = 0;
++    }
++
++  /* How much is left to wait?  */
++  if (wait_timeout != INFINITE)
++    {
++      clock_t tnow = clock ();
++      if (tend >= tnow)
++        wait_timeout = tend - tnow;
++      else
++        wait_timeout = 0;
++    }
++
++  for (;;)
++    {
++      ret = MsgWaitForMultipleObjects (nhandles, handle_array, FALSE,
++                                       wait_timeout, QS_ALLINPUT);
++
++      if (ret == WAIT_OBJECT_0 + nhandles)
++        {
++          /* new input of some other kind */
++          BOOL bRet;
++          while ((bRet = PeekMessage (&msg, NULL, 0, 0, PM_REMOVE)) != 0)
++            {
++              TranslateMessage (&msg);
++              DispatchMessage (&msg);
++            }
++        }
++      else
++        break;
++    }
++
++  /* If we haven't done it yet, check the status of the sockets.  */
++  if (rc == 0 && nsock > 0)
++    rc = select (0, &handle_rfds, &handle_wfds, &handle_xfds, &tv0);
++
++  if (nhandles > 1)
++    {
++      /* Count results that are not counted in the return value of select.  */
++      nhandles = 1;
++      for (i = 0; i < nfds; i++)
++        {
++          if ((anyfds_in[i / CHAR_BIT] & (1 << (i & (CHAR_BIT - 1)))) == 0)
++            continue;
++
++          h = (HANDLE) _get_osfhandle (i);
++          if (h == handle_array[nhandles])
++            {
++              /* Not a socket.  */
++              nhandles++;
++              windows_poll_handle (h, i, &rbits, &wbits, &xbits);
++              if (rbits.out[i / CHAR_BIT] & (1 << (i & (CHAR_BIT - 1)))
++                  || wbits.out[i / CHAR_BIT] & (1 << (i & (CHAR_BIT - 1)))
++                  || xbits.out[i / CHAR_BIT] & (1 << (i & (CHAR_BIT - 1))))
++                rc++;
++            }
++        }
++
++      if (rc == 0
++          && (wait_timeout == INFINITE
++              /* If NHANDLES > 1, but no bits are set, it means we've
++                 been told incorrectly that some handle was signaled.
++                 This happens with anonymous pipes, which always cause
++                 MsgWaitForMultipleObjects to exit immediately, but no
++                 data is found ready to be read by windows_poll_handle.
++                 To avoid a total failure (whereby we return zero and
++                 don't wait at all), let's poll in a more busy loop.  */
++              || (wait_timeout != 0 && nhandles > 1)))
++        {
++          /* Sleep 1 millisecond to avoid busy wait and retry with the
++             original fd_sets.  */
++          memcpy (&handle_rfds, rfds, sizeof (fd_set));
++          memcpy (&handle_wfds, wfds, sizeof (fd_set));
++          memcpy (&handle_xfds, xfds, sizeof (fd_set));
++          SleepEx (1, TRUE);
++          goto restart;
++        }
++      if (timeout && wait_timeout == 0 && rc == 0)
++        timeout->tv_sec = timeout->tv_usec = 0;
++    }
++
++  /* Now fill in the results.  */
++  FD_ZERO (rfds);
++  FD_ZERO (wfds);
++  FD_ZERO (xfds);
++  nhandles = 1;
++  for (i = 0; i < nfds; i++)
++    {
++      if ((anyfds_in[i / CHAR_BIT] & (1 << (i & (CHAR_BIT - 1)))) == 0)
++        continue;
++
++      h = (HANDLE) _get_osfhandle (i);
++      if (h != handle_array[nhandles])
++        {
++          /* Perform handle->descriptor mapping.  */
++          SOCKET s = (SOCKET) h;
++          WSAEventSelect (s, NULL, 0);
++          if (FD_ISSET (s, &handle_rfds))
++            FD_SET (i, rfds);
++          if (FD_ISSET (s, &handle_wfds))
++            FD_SET (i, wfds);
++          if (FD_ISSET (s, &handle_xfds))
++            FD_SET (i, xfds);
++        }
++      else
++        {
++          /* Not a socket.  */
++          nhandles++;
++          if (rbits.out[i / CHAR_BIT] & (1 << (i & (CHAR_BIT - 1))))
++            FD_SET (i, rfds);
++          if (wbits.out[i / CHAR_BIT] & (1 << (i & (CHAR_BIT - 1))))
++            FD_SET (i, wfds);
++          if (xbits.out[i / CHAR_BIT] & (1 << (i & (CHAR_BIT - 1))))
++            FD_SET (i, xfds);
++        }
++    }
++
++  return rc;
++}
++
++#else /* ! Native Windows.  */
++
++#include <stddef.h> /* NULL */
++#include <errno.h>
++#include <unistd.h>
++
++#undef select
++
++int
++rpl_select (int nfds, fd_set *rfds, fd_set *wfds, fd_set *xfds,
++            struct timeval *timeout)
++{
++  int i;
++
++  /* FreeBSD 8.2 has a bug: it does not always detect invalid fds.  */
++  if (nfds < 0 || nfds > FD_SETSIZE)
++    {
++      errno = EINVAL;
++      return -1;
++    }
++  for (i = 0; i < nfds; i++)
++    {
++      if (((rfds && FD_ISSET (i, rfds))
++           || (wfds && FD_ISSET (i, wfds))
++           || (xfds && FD_ISSET (i, xfds)))
++          && dup2 (i, i) != i)
++        return -1;
++    }
++
++  /* Interix 3.5 has a bug: it does not support nfds == 0.  */
++  if (nfds == 0)
++    {
++      nfds = 1;
++      rfds = NULL;
++      wfds = NULL;
++      xfds = NULL;
++    }
++  return select (nfds, rfds, wfds, xfds, timeout);
++}
++
++#endif
+--- a/gl/lib/signal.in.h
++++ b/gl/lib/signal.in.h
+@@ -0,0 +1,487 @@
++/* A GNU-like <signal.h>.
++
++   Copyright (C) 2006-2022 Free Software Foundation, Inc.
++
++   This file is free software: you can redistribute it and/or modify
++   it under the terms of the GNU Lesser General Public License as
++   published by the Free Software Foundation; either version 2.1 of the
++   License, or (at your option) any later version.
++
++   This file is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public License
++   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
++
++#if __GNUC__ >= 3
++@PRAGMA_SYSTEM_HEADER@
++#endif
++@PRAGMA_COLUMNS@
++
++#if defined __need_sig_atomic_t || defined __need_sigset_t || defined _GL_ALREADY_INCLUDING_SIGNAL_H || (defined _SIGNAL_H && !defined __SIZEOF_PTHREAD_MUTEX_T)
++/* Special invocation convention:
++   - Inside glibc header files.
++   - On glibc systems we have a sequence of nested includes
++     <signal.h> -> <ucontext.h> -> <signal.h>.
++     In this situation, the functions are not yet declared, therefore we cannot
++     provide the C++ aliases.
++   - On glibc systems with GCC 4.3 we have a sequence of nested includes
++     <csignal> -> </usr/include/signal.h> -> <sys/ucontext.h> -> <signal.h>.
++     In this situation, some of the functions are not yet declared, therefore
++     we cannot provide the C++ aliases.  */
++
++# @INCLUDE_NEXT@ @NEXT_SIGNAL_H@
++
++#else
++/* Normal invocation convention.  */
++
++#ifndef _@GUARD_PREFIX@_SIGNAL_H
++
++#define _GL_ALREADY_INCLUDING_SIGNAL_H
++
++/* Define pid_t, uid_t.
++   Also, mingw defines sigset_t not in <signal.h>, but in <sys/types.h>.
++   On Solaris 10, <signal.h> includes <sys/types.h>, which eventually includes
++   us; so include <sys/types.h> now, before the second inclusion guard.  */
++#include <sys/types.h>
++
++/* The include_next requires a split double-inclusion guard.  */
++#@INCLUDE_NEXT@ @NEXT_SIGNAL_H@
++
++#undef _GL_ALREADY_INCLUDING_SIGNAL_H
++
++#ifndef _@GUARD_PREFIX@_SIGNAL_H
++#define _@GUARD_PREFIX@_SIGNAL_H
++
++/* Mac OS X 10.3, FreeBSD 6.4, OpenBSD 3.8, OSF/1 4.0, Solaris 2.6, Android,
++   OS/2 kLIBC declare pthread_sigmask in <pthread.h>, not in <signal.h>.
++   But avoid namespace pollution on glibc systems.*/
++#if (@GNULIB_PTHREAD_SIGMASK@ || defined GNULIB_POSIXCHECK) \
++    && ((defined __APPLE__ && defined __MACH__) \
++        || defined __FreeBSD__ || defined __OpenBSD__ || defined __osf__ \
++        || defined __sun || defined __ANDROID__ || defined __KLIBC__) \
++    && ! defined __GLIBC__
++# include <pthread.h>
++#endif
++
++/* The definitions of _GL_FUNCDECL_RPL etc. are copied here.  */
++
++/* The definition of _GL_ARG_NONNULL is copied here.  */
++
++/* The definition of _GL_WARN_ON_USE is copied here.  */
++
++/* On AIX, sig_atomic_t already includes volatile.  C99 requires that
++   'volatile sig_atomic_t' ignore the extra modifier, but C89 did not.
++   Hence, redefine this to a non-volatile type as needed.  */
++#if ! @HAVE_TYPE_VOLATILE_SIG_ATOMIC_T@
++# if !GNULIB_defined_sig_atomic_t
++typedef int rpl_sig_atomic_t;
++#  undef sig_atomic_t
++#  define sig_atomic_t rpl_sig_atomic_t
++#  define GNULIB_defined_sig_atomic_t 1
++# endif
++#endif
++
++/* A set or mask of signals.  */
++#if !@HAVE_SIGSET_T@
++# if !GNULIB_defined_sigset_t
++typedef unsigned int sigset_t;
++#  define GNULIB_defined_sigset_t 1
++# endif
++#endif
++
++/* Define sighandler_t, the type of signal handlers.  A GNU extension.  */
++#if !@HAVE_SIGHANDLER_T@
++# ifdef __cplusplus
++extern "C" {
++# endif
++# if !GNULIB_defined_sighandler_t
++typedef void (*sighandler_t) (int);
++#  define GNULIB_defined_sighandler_t 1
++# endif
++# ifdef __cplusplus
++}
++# endif
++#endif
++
++
++#if @GNULIB_SIGNAL_H_SIGPIPE@
++# ifndef SIGPIPE
++/* Define SIGPIPE to a value that does not overlap with other signals.  */
++#  define SIGPIPE 13
++#  define GNULIB_defined_SIGPIPE 1
++/* To actually use SIGPIPE, you also need the gnulib modules 'sigprocmask',
++   'write', 'stdio'.  */
++# endif
++#endif
++
++
++/* Maximum signal number + 1.  */
++#ifndef NSIG
++# if defined __TANDEM
++#  define NSIG 32
++# endif
++#endif
++
++
++#if @GNULIB_PTHREAD_SIGMASK@
++# if @REPLACE_PTHREAD_SIGMASK@
++#  if !(defined __cplusplus && defined GNULIB_NAMESPACE)
++#   undef pthread_sigmask
++#   define pthread_sigmask rpl_pthread_sigmask
++#  endif
++_GL_FUNCDECL_RPL (pthread_sigmask, int,
++                  (int how,
++                   const sigset_t *restrict new_mask,
++                   sigset_t *restrict old_mask));
++_GL_CXXALIAS_RPL (pthread_sigmask, int,
++                  (int how,
++                   const sigset_t *restrict new_mask,
++                   sigset_t *restrict old_mask));
++# else
++#  if !(@HAVE_PTHREAD_SIGMASK@ || defined pthread_sigmask)
++_GL_FUNCDECL_SYS (pthread_sigmask, int,
++                  (int how,
++                   const sigset_t *restrict new_mask,
++                   sigset_t *restrict old_mask));
++#  endif
++_GL_CXXALIAS_SYS (pthread_sigmask, int,
++                  (int how,
++                   const sigset_t *restrict new_mask,
++                   sigset_t *restrict old_mask));
++# endif
++# if __GLIBC__ >= 2
++_GL_CXXALIASWARN (pthread_sigmask);
++# endif
++#elif defined GNULIB_POSIXCHECK
++# undef pthread_sigmask
++# if HAVE_RAW_DECL_PTHREAD_SIGMASK
++_GL_WARN_ON_USE (pthread_sigmask, "pthread_sigmask is not portable - "
++                 "use gnulib module pthread_sigmask for portability");
++# endif
++#endif
++
++
++#if @GNULIB_RAISE@
++# if @REPLACE_RAISE@
++#  if !(defined __cplusplus && defined GNULIB_NAMESPACE)
++#   undef raise
++#   define raise rpl_raise
++#  endif
++_GL_FUNCDECL_RPL (raise, int, (int sig));
++_GL_CXXALIAS_RPL (raise, int, (int sig));
++# else
++#  if !@HAVE_RAISE@
++_GL_FUNCDECL_SYS (raise, int, (int sig));
++#  endif
++_GL_CXXALIAS_SYS (raise, int, (int sig));
++# endif
++# if __GLIBC__ >= 2
++_GL_CXXALIASWARN (raise);
++# endif
++#elif defined GNULIB_POSIXCHECK
++# undef raise
++/* Assume raise is always declared.  */
++_GL_WARN_ON_USE (raise, "raise can crash on native Windows - "
++                 "use gnulib module raise for portability");
++#endif
++
++
++#if @GNULIB_SIGPROCMASK@
++# if !@HAVE_POSIX_SIGNALBLOCKING@
++
++#  ifndef GNULIB_defined_signal_blocking
++#   define GNULIB_defined_signal_blocking 1
++#  endif
++
++/* Maximum signal number + 1.  */
++#  ifndef NSIG
++#   define NSIG 32
++#  endif
++
++/* This code supports only 32 signals.  */
++#  if !GNULIB_defined_verify_NSIG_constraint
++typedef int verify_NSIG_constraint[NSIG <= 32 ? 1 : -1];
++#   define GNULIB_defined_verify_NSIG_constraint 1
++#  endif
++
++# endif
++
++/* When also using extern inline, suppress the use of static inline in
++   standard headers of problematic Apple configurations, as Libc at
++   least through Libc-825.26 (2013-04-09) mishandles it; see, e.g.,
++   <https://lists.gnu.org/r/bug-gnulib/2012-12/msg00023.html>.
++   Perhaps Apple will fix this some day.  */
++#if (defined _GL_EXTERN_INLINE_IN_USE && defined __APPLE__ \
++     && (defined __i386__ || defined __x86_64__))
++# undef sigaddset
++# undef sigdelset
++# undef sigemptyset
++# undef sigfillset
++# undef sigismember
++#endif
++
++/* Test whether a given signal is contained in a signal set.  */
++# if @HAVE_POSIX_SIGNALBLOCKING@
++/* This function is defined as a macro on Mac OS X.  */
++#  if defined __cplusplus && defined GNULIB_NAMESPACE
++#   undef sigismember
++#  endif
++# else
++_GL_FUNCDECL_SYS (sigismember, int, (const sigset_t *set, int sig)
++                                    _GL_ARG_NONNULL ((1)));
++# endif
++_GL_CXXALIAS_SYS (sigismember, int, (const sigset_t *set, int sig));
++_GL_CXXALIASWARN (sigismember);
++
++/* Initialize a signal set to the empty set.  */
++# if @HAVE_POSIX_SIGNALBLOCKING@
++/* This function is defined as a macro on Mac OS X.  */
++#  if defined __cplusplus && defined GNULIB_NAMESPACE
++#   undef sigemptyset
++#  endif
++# else
++_GL_FUNCDECL_SYS (sigemptyset, int, (sigset_t *set) _GL_ARG_NONNULL ((1)));
++# endif
++_GL_CXXALIAS_SYS (sigemptyset, int, (sigset_t *set));
++_GL_CXXALIASWARN (sigemptyset);
++
++/* Add a signal to a signal set.  */
++# if @HAVE_POSIX_SIGNALBLOCKING@
++/* This function is defined as a macro on Mac OS X.  */
++#  if defined __cplusplus && defined GNULIB_NAMESPACE
++#   undef sigaddset
++#  endif
++# else
++_GL_FUNCDECL_SYS (sigaddset, int, (sigset_t *set, int sig)
++                                  _GL_ARG_NONNULL ((1)));
++# endif
++_GL_CXXALIAS_SYS (sigaddset, int, (sigset_t *set, int sig));
++_GL_CXXALIASWARN (sigaddset);
++
++/* Remove a signal from a signal set.  */
++# if @HAVE_POSIX_SIGNALBLOCKING@
++/* This function is defined as a macro on Mac OS X.  */
++#  if defined __cplusplus && defined GNULIB_NAMESPACE
++#   undef sigdelset
++#  endif
++# else
++_GL_FUNCDECL_SYS (sigdelset, int, (sigset_t *set, int sig)
++                                  _GL_ARG_NONNULL ((1)));
++# endif
++_GL_CXXALIAS_SYS (sigdelset, int, (sigset_t *set, int sig));
++_GL_CXXALIASWARN (sigdelset);
++
++/* Fill a signal set with all possible signals.  */
++# if @HAVE_POSIX_SIGNALBLOCKING@
++/* This function is defined as a macro on Mac OS X.  */
++#  if defined __cplusplus && defined GNULIB_NAMESPACE
++#   undef sigfillset
++#  endif
++# else
++_GL_FUNCDECL_SYS (sigfillset, int, (sigset_t *set) _GL_ARG_NONNULL ((1)));
++# endif
++_GL_CXXALIAS_SYS (sigfillset, int, (sigset_t *set));
++_GL_CXXALIASWARN (sigfillset);
++
++/* Return the set of those blocked signals that are pending.  */
++# if !@HAVE_POSIX_SIGNALBLOCKING@
++_GL_FUNCDECL_SYS (sigpending, int, (sigset_t *set) _GL_ARG_NONNULL ((1)));
++# endif
++_GL_CXXALIAS_SYS (sigpending, int, (sigset_t *set));
++_GL_CXXALIASWARN (sigpending);
++
++/* If OLD_SET is not NULL, put the current set of blocked signals in *OLD_SET.
++   Then, if SET is not NULL, affect the current set of blocked signals by
++   combining it with *SET as indicated in OPERATION.
++   In this implementation, you are not allowed to change a signal handler
++   while the signal is blocked.  */
++# if !@HAVE_POSIX_SIGNALBLOCKING@
++#  define SIG_BLOCK   0  /* blocked_set = blocked_set | *set; */
++#  define SIG_SETMASK 1  /* blocked_set = *set; */
++#  define SIG_UNBLOCK 2  /* blocked_set = blocked_set & ~*set; */
++_GL_FUNCDECL_SYS (sigprocmask, int,
++                  (int operation,
++                   const sigset_t *restrict set,
++                   sigset_t *restrict old_set));
++# endif
++_GL_CXXALIAS_SYS (sigprocmask, int,
++                  (int operation,
++                   const sigset_t *restrict set,
++                   sigset_t *restrict old_set));
++_GL_CXXALIASWARN (sigprocmask);
++
++/* Install the handler FUNC for signal SIG, and return the previous
++   handler.  */
++# ifdef __cplusplus
++extern "C" {
++# endif
++# if !GNULIB_defined_function_taking_int_returning_void_t
++typedef void (*_gl_function_taking_int_returning_void_t) (int);
++#  define GNULIB_defined_function_taking_int_returning_void_t 1
++# endif
++# ifdef __cplusplus
++}
++# endif
++# if !@HAVE_POSIX_SIGNALBLOCKING@
++#  if !(defined __cplusplus && defined GNULIB_NAMESPACE)
++#   define signal rpl_signal
++#  endif
++_GL_FUNCDECL_RPL (signal, _gl_function_taking_int_returning_void_t,
++                  (int sig, _gl_function_taking_int_returning_void_t func));
++_GL_CXXALIAS_RPL (signal, _gl_function_taking_int_returning_void_t,
++                  (int sig, _gl_function_taking_int_returning_void_t func));
++# else
++/* On OpenBSD, the declaration of 'signal' may not be present at this point,
++   because it occurs in <sys/signal.h>, not <signal.h> directly.  */
++#  if defined __OpenBSD__
++_GL_FUNCDECL_SYS (signal, _gl_function_taking_int_returning_void_t,
++                  (int sig, _gl_function_taking_int_returning_void_t func));
++#  endif
++_GL_CXXALIAS_SYS (signal, _gl_function_taking_int_returning_void_t,
++                  (int sig, _gl_function_taking_int_returning_void_t func));
++# endif
++# if __GLIBC__ >= 2
++_GL_CXXALIASWARN (signal);
++# endif
++
++# if !@HAVE_POSIX_SIGNALBLOCKING@ && GNULIB_defined_SIGPIPE
++/* Raise signal SIGPIPE.  */
++_GL_EXTERN_C int _gl_raise_SIGPIPE (void);
++# endif
++
++#elif defined GNULIB_POSIXCHECK
++# undef sigaddset
++# if HAVE_RAW_DECL_SIGADDSET
++_GL_WARN_ON_USE (sigaddset, "sigaddset is unportable - "
++                 "use the gnulib module sigprocmask for portability");
++# endif
++# undef sigdelset
++# if HAVE_RAW_DECL_SIGDELSET
++_GL_WARN_ON_USE (sigdelset, "sigdelset is unportable - "
++                 "use the gnulib module sigprocmask for portability");
++# endif
++# undef sigemptyset
++# if HAVE_RAW_DECL_SIGEMPTYSET
++_GL_WARN_ON_USE (sigemptyset, "sigemptyset is unportable - "
++                 "use the gnulib module sigprocmask for portability");
++# endif
++# undef sigfillset
++# if HAVE_RAW_DECL_SIGFILLSET
++_GL_WARN_ON_USE (sigfillset, "sigfillset is unportable - "
++                 "use the gnulib module sigprocmask for portability");
++# endif
++# undef sigismember
++# if HAVE_RAW_DECL_SIGISMEMBER
++_GL_WARN_ON_USE (sigismember, "sigismember is unportable - "
++                 "use the gnulib module sigprocmask for portability");
++# endif
++# undef sigpending
++# if HAVE_RAW_DECL_SIGPENDING
++_GL_WARN_ON_USE (sigpending, "sigpending is unportable - "
++                 "use the gnulib module sigprocmask for portability");
++# endif
++# undef sigprocmask
++# if HAVE_RAW_DECL_SIGPROCMASK
++_GL_WARN_ON_USE (sigprocmask, "sigprocmask is unportable - "
++                 "use the gnulib module sigprocmask for portability");
++# endif
++#endif /* @GNULIB_SIGPROCMASK@ */
++
++
++#if @GNULIB_SIGACTION@
++# if !@HAVE_SIGACTION@
++
++#  if !@HAVE_SIGINFO_T@
++
++#   if !GNULIB_defined_siginfo_types
++
++/* Present to allow compilation, but unsupported by gnulib.  */
++union sigval
++{
++  int sival_int;
++  void *sival_ptr;
++};
++
++/* Present to allow compilation, but unsupported by gnulib.  */
++struct siginfo_t
++{
++  int si_signo;
++  int si_code;
++  int si_errno;
++  pid_t si_pid;
++  uid_t si_uid;
++  void *si_addr;
++  int si_status;
++  long si_band;
++  union sigval si_value;
++};
++typedef struct siginfo_t siginfo_t;
++
++#    define GNULIB_defined_siginfo_types 1
++#   endif
++
++#  endif /* !@HAVE_SIGINFO_T@ */
++
++/* We assume that platforms which lack the sigaction() function also lack
++   the 'struct sigaction' type, and vice versa.  */
++
++#  if !GNULIB_defined_struct_sigaction
++
++struct sigaction
++{
++  union
++  {
++    void (*_sa_handler) (int);
++    /* Present to allow compilation, but unsupported by gnulib.  POSIX
++       says that implementations may, but not must, make sa_sigaction
++       overlap with sa_handler, but we know of no implementation where
++       they do not overlap.  */
++    void (*_sa_sigaction) (int, siginfo_t *, void *);
++  } _sa_func;
++  sigset_t sa_mask;
++  /* Not all POSIX flags are supported.  */
++  int sa_flags;
++};
++#   define sa_handler _sa_func._sa_handler
++#   define sa_sigaction _sa_func._sa_sigaction
++/* Unsupported flags are not present.  */
++#   define SA_RESETHAND 1
++#   define SA_NODEFER 2
++#   define SA_RESTART 4
++
++#   define GNULIB_defined_struct_sigaction 1
++#  endif
++
++_GL_FUNCDECL_SYS (sigaction, int, (int, const struct sigaction *restrict,
++                                   struct sigaction *restrict));
++
++# elif !@HAVE_STRUCT_SIGACTION_SA_SIGACTION@
++
++#  define sa_sigaction sa_handler
++
++# endif /* !@HAVE_SIGACTION@, !@HAVE_STRUCT_SIGACTION_SA_SIGACTION@ */
++
++_GL_CXXALIAS_SYS (sigaction, int, (int, const struct sigaction *restrict,
++                                   struct sigaction *restrict));
++_GL_CXXALIASWARN (sigaction);
++
++#elif defined GNULIB_POSIXCHECK
++# undef sigaction
++# if HAVE_RAW_DECL_SIGACTION
++_GL_WARN_ON_USE (sigaction, "sigaction is unportable - "
++                 "use the gnulib module sigaction for portability");
++# endif
++#endif
++
++/* Some systems don't have SA_NODEFER.  */
++#ifndef SA_NODEFER
++# define SA_NODEFER 0
++#endif
++
++
++#endif /* _@GUARD_PREFIX@_SIGNAL_H */
++#endif /* _@GUARD_PREFIX@_SIGNAL_H */
++#endif
+--- a/gl/lib/sys_select.in.h
++++ b/gl/lib/sys_select.in.h
+@@ -0,0 +1,331 @@
++/* Substitute for <sys/select.h>.
++   Copyright (C) 2007-2022 Free Software Foundation, Inc.
++
++   This file is free software: you can redistribute it and/or modify
++   it under the terms of the GNU Lesser General Public License as
++   published by the Free Software Foundation; either version 2.1 of the
++   License, or (at your option) any later version.
++
++   This file is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public License
++   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
++
++# if __GNUC__ >= 3
++@PRAGMA_SYSTEM_HEADER@
++# endif
++@PRAGMA_COLUMNS@
++
++/* On OSF/1 and Solaris 2.6, <sys/types.h> and <sys/time.h>
++   both include <sys/select.h>.
++   On Cygwin and OpenBSD, <sys/time.h> includes <sys/select.h>.
++   Simply delegate to the system's header in this case.  */
++#if (@HAVE_SYS_SELECT_H@                                                \
++     && !defined _GL_SYS_SELECT_H_REDIRECT_FROM_SYS_TYPES_H             \
++     && ((defined __osf__ && defined _SYS_TYPES_H_                      \
++          && defined _OSF_SOURCE)                                       \
++         || (defined __sun && defined _SYS_TYPES_H                      \
++             && (! (defined _XOPEN_SOURCE || defined _POSIX_C_SOURCE)   \
++                 || defined __EXTENSIONS__))))
++
++# define _GL_SYS_SELECT_H_REDIRECT_FROM_SYS_TYPES_H
++# @INCLUDE_NEXT@ @NEXT_SYS_SELECT_H@
++
++#elif (@HAVE_SYS_SELECT_H@                                              \
++       && (defined _CYGWIN_SYS_TIME_H                                   \
++           || (!defined _GL_SYS_SELECT_H_REDIRECT_FROM_SYS_TIME_H       \
++               && ((defined __osf__ && defined _SYS_TIME_H_             \
++                    && defined _OSF_SOURCE)                             \
++                   || (defined __OpenBSD__ && defined _SYS_TIME_H_)     \
++                   || (defined __sun && defined _SYS_TIME_H             \
++                       && (! (defined _XOPEN_SOURCE                     \
++                              || defined _POSIX_C_SOURCE)               \
++                           || defined __EXTENSIONS__))))))
++
++# define _GL_SYS_SELECT_H_REDIRECT_FROM_SYS_TIME_H
++# @INCLUDE_NEXT@ @NEXT_SYS_SELECT_H@
++
++/* On IRIX 6.5, <sys/timespec.h> includes <sys/types.h>, which includes
++   <sys/bsd_types.h>, which includes <sys/select.h>.  At this point we cannot
++   include <signal.h>, because that includes <internal/signal_core.h>, which
++   gives a syntax error because <sys/timespec.h> has not been completely
++   processed.  Simply delegate to the system's header in this case.  */
++#elif @HAVE_SYS_SELECT_H@ && defined __sgi && (defined _SYS_BSD_TYPES_H && !defined _GL_SYS_SELECT_H_REDIRECT_FROM_SYS_BSD_TYPES_H)
++
++# define _GL_SYS_SELECT_H_REDIRECT_FROM_SYS_BSD_TYPES_H
++# @INCLUDE_NEXT@ @NEXT_SYS_SELECT_H@
++
++/* On OpenBSD 5.0, <pthread.h> includes <sys/types.h>, which includes
++   <sys/select.h>.  At this point we cannot include <signal.h>, because that
++   includes gnulib's pthread.h override, which gives a syntax error because
++   /usr/include/pthread.h has not been completely processed.  Simply delegate
++   to the system's header in this case.  */
++#elif @HAVE_SYS_SELECT_H@ && defined __OpenBSD__ && (defined _PTHREAD_H_ && !defined PTHREAD_MUTEX_INITIALIZER)
++
++# @INCLUDE_NEXT@ @NEXT_SYS_SELECT_H@
++
++#else
++
++#ifndef _@GUARD_PREFIX@_SYS_SELECT_H
++
++/* On many platforms, <sys/select.h> assumes prior inclusion of
++   <sys/types.h>.  Also, mingw defines sigset_t there, instead of
++   in <signal.h> where it belongs.  */
++#include <sys/types.h>
++
++#if @HAVE_SYS_SELECT_H@
++
++/* On OSF/1 4.0, <sys/select.h> provides only a forward declaration
++   of 'struct timeval', and no definition of this type.
++   Also, Mac OS X, AIX, HP-UX, IRIX, Solaris, Interix declare select()
++   in <sys/time.h>.
++   But avoid namespace pollution on glibc systems and "unknown type
++   name" problems on Cygwin.  */
++# if !(defined __GLIBC__ || defined __CYGWIN__)
++#  include <sys/time.h>
++# endif
++
++/* On AIX 7 and Solaris 10, <sys/select.h> provides an FD_ZERO implementation
++   that relies on memset(), but without including <string.h>.
++   But in any case avoid namespace pollution on glibc systems.  */
++# if (defined __OpenBSD__ || defined _AIX || defined __sun || defined __osf__ || defined __BEOS__) \
++     && ! defined __GLIBC__
++#  include <string.h>
++# endif
++
++/* The include_next requires a split double-inclusion guard.  */
++# @INCLUDE_NEXT@ @NEXT_SYS_SELECT_H@
++
++#endif
++
++/* Get definition of 'sigset_t'.
++   But avoid namespace pollution on glibc systems and "unknown type
++   name" problems on Cygwin.
++   On OS/2 kLIBC, sigset_t is defined in <sys/select.h>, too. In addition,
++   if <sys/param.h> is included, <types.h> -> <sys/types.h> -> <sys/select.h>
++   are included. Then <signal.h> -> <pthread.h> are included by GNULIB. By the
++   way, <pthread.h> requires PAGE_SIZE defined in <sys/param.h>. However,
++   <sys/param.h> has not been processed, yet. As a result, 'PAGE_SIZE'
++   undeclared error occurs in <pthread.h>.
++   Do this after the include_next (for the sake of OpenBSD 5.0) but before
++   the split double-inclusion guard (for the sake of Solaris).  */
++#if !((defined __GLIBC__ || defined __CYGWIN__ || defined __KLIBC__) \
++      && !defined __UCLIBC__)
++# include <signal.h>
++#endif
++
++#ifndef _@GUARD_PREFIX@_SYS_SELECT_H
++#define _@GUARD_PREFIX@_SYS_SELECT_H
++
++#if !@HAVE_SYS_SELECT_H@
++/* A platform that lacks <sys/select.h>.  */
++/* Get the 'struct timeval' and 'fd_set' types and the FD_* macros
++   on most platforms.  */
++# include <sys/time.h>
++/* On HP-UX 11, <sys/time.h> provides an FD_ZERO implementation
++   that relies on memset(), but without including <string.h>.  */
++# if defined __hpux
++#  include <string.h>
++# endif
++/* On native Windows platforms:
++   Get the 'fd_set' type.
++   Get the close() declaration before we override it.  */
++# if @HAVE_WINSOCK2_H@
++#  if !defined _GL_INCLUDING_WINSOCK2_H
++#   define _GL_INCLUDING_WINSOCK2_H
++#   include <winsock2.h>
++#   undef _GL_INCLUDING_WINSOCK2_H
++#  endif
++#  include <io.h>
++# endif
++#endif
++
++/* The definitions of _GL_FUNCDECL_RPL etc. are copied here.  */
++
++/* The definition of _GL_WARN_ON_USE is copied here.  */
++
++
++/* Fix some definitions from <winsock2.h>.  */
++
++#if @HAVE_WINSOCK2_H@
++
++# if !GNULIB_defined_rpl_fd_isset
++
++/* Re-define FD_ISSET to avoid a WSA call while we are not using
++   network sockets.  */
++static int
++rpl_fd_isset (SOCKET fd, fd_set * set)
++{
++  u_int i;
++  if (set == NULL)
++    return 0;
++
++  for (i = 0; i < set->fd_count; i++)
++    if (set->fd_array[i] == fd)
++      return 1;
++
++  return 0;
++}
++
++#  define GNULIB_defined_rpl_fd_isset 1
++# endif
++
++# undef FD_ISSET
++# define FD_ISSET(fd, set) rpl_fd_isset(fd, set)
++
++#endif
++
++/* Hide some function declarations from <winsock2.h>.  */
++
++#if @HAVE_WINSOCK2_H@
++# if !defined _@GUARD_PREFIX@_UNISTD_H
++#  if !(defined __cplusplus && defined GNULIB_NAMESPACE)
++#   undef close
++#   define close close_used_without_including_unistd_h
++#  elif !defined __clang__
++    _GL_WARN_ON_USE (close,
++                     "close() used without including <unistd.h>");
++#  endif
++#  if !(defined __cplusplus && defined GNULIB_NAMESPACE)
++#   undef gethostname
++#   define gethostname gethostname_used_without_including_unistd_h
++#  elif !defined __clang__
++    _GL_WARN_ON_USE (gethostname,
++                     "gethostname() used without including <unistd.h>");
++#  endif
++# endif
++# if !defined _@GUARD_PREFIX@_SYS_SOCKET_H
++#  if !(defined __cplusplus && defined GNULIB_NAMESPACE)
++#   undef socket
++#   define socket              socket_used_without_including_sys_socket_h
++#   undef connect
++#   define connect             connect_used_without_including_sys_socket_h
++#   undef accept
++#   define accept              accept_used_without_including_sys_socket_h
++#   undef bind
++#   define bind                bind_used_without_including_sys_socket_h
++#   undef getpeername
++#   define getpeername         getpeername_used_without_including_sys_socket_h
++#   undef getsockname
++#   define getsockname         getsockname_used_without_including_sys_socket_h
++#   undef getsockopt
++#   define getsockopt          getsockopt_used_without_including_sys_socket_h
++#   undef listen
++#   define listen              listen_used_without_including_sys_socket_h
++#   undef recv
++#   define recv                recv_used_without_including_sys_socket_h
++#   undef send
++#   define send                send_used_without_including_sys_socket_h
++#   undef recvfrom
++#   define recvfrom            recvfrom_used_without_including_sys_socket_h
++#   undef sendto
++#   define sendto              sendto_used_without_including_sys_socket_h
++#   undef setsockopt
++#   define setsockopt          setsockopt_used_without_including_sys_socket_h
++#   undef shutdown
++#   define shutdown            shutdown_used_without_including_sys_socket_h
++#  elif !defined __clang__
++    _GL_WARN_ON_USE (socket,
++                     "socket() used without including <sys/socket.h>");
++    _GL_WARN_ON_USE (connect,
++                     "connect() used without including <sys/socket.h>");
++    _GL_WARN_ON_USE (accept,
++                     "accept() used without including <sys/socket.h>");
++    _GL_WARN_ON_USE (bind,
++                     "bind() used without including <sys/socket.h>");
++    _GL_WARN_ON_USE (getpeername,
++                     "getpeername() used without including <sys/socket.h>");
++    _GL_WARN_ON_USE (getsockname,
++                     "getsockname() used without including <sys/socket.h>");
++    _GL_WARN_ON_USE (getsockopt,
++                     "getsockopt() used without including <sys/socket.h>");
++    _GL_WARN_ON_USE (listen,
++                     "listen() used without including <sys/socket.h>");
++    _GL_WARN_ON_USE (recv,
++                     "recv() used without including <sys/socket.h>");
++    _GL_WARN_ON_USE (send,
++                     "send() used without including <sys/socket.h>");
++    _GL_WARN_ON_USE (recvfrom,
++                     "recvfrom() used without including <sys/socket.h>");
++    _GL_WARN_ON_USE (sendto,
++                     "sendto() used without including <sys/socket.h>");
++    _GL_WARN_ON_USE (setsockopt,
++                     "setsockopt() used without including <sys/socket.h>");
++    _GL_WARN_ON_USE (shutdown,
++                     "shutdown() used without including <sys/socket.h>");
++#  endif
++# endif
++#endif
++
++
++#if @GNULIB_PSELECT@
++# if @REPLACE_PSELECT@
++#  if !(defined __cplusplus && defined GNULIB_NAMESPACE)
++#   undef pselect
++#   define pselect rpl_pselect
++#  endif
++_GL_FUNCDECL_RPL (pselect, int,
++                  (int, fd_set *restrict, fd_set *restrict, fd_set *restrict,
++                   struct timespec const *restrict, const sigset_t *restrict));
++_GL_CXXALIAS_RPL (pselect, int,
++                  (int, fd_set *restrict, fd_set *restrict, fd_set *restrict,
++                   struct timespec const *restrict, const sigset_t *restrict));
++# else
++#  if !@HAVE_PSELECT@
++_GL_FUNCDECL_SYS (pselect, int,
++                  (int, fd_set *restrict, fd_set *restrict, fd_set *restrict,
++                   struct timespec const *restrict, const sigset_t *restrict));
++#  endif
++/* Need to cast, because on AIX 7, the second, third, fourth argument may be
++                        void *restrict,   void *restrict,   void *restrict.  */
++_GL_CXXALIAS_SYS_CAST (pselect, int,
++                       (int,
++                        fd_set *restrict, fd_set *restrict, fd_set *restrict,
++                        struct timespec const *restrict,
++                        const sigset_t *restrict));
++# endif
++_GL_CXXALIASWARN (pselect);
++#elif defined GNULIB_POSIXCHECK
++# undef pselect
++# if HAVE_RAW_DECL_PSELECT
++_GL_WARN_ON_USE (pselect, "pselect is not portable - "
++                 "use gnulib module pselect for portability");
++# endif
++#endif
++
++#if @GNULIB_SELECT@
++# if @REPLACE_SELECT@
++#  if !(defined __cplusplus && defined GNULIB_NAMESPACE)
++#   undef select
++#   define select rpl_select
++#  endif
++_GL_FUNCDECL_RPL (select, int,
++                  (int, fd_set *restrict, fd_set *restrict, fd_set *restrict,
++                   struct timeval *restrict));
++_GL_CXXALIAS_RPL (select, int,
++                  (int, fd_set *restrict, fd_set *restrict, fd_set *restrict,
++                   timeval *restrict));
++# else
++_GL_CXXALIAS_SYS (select, int,
++                  (int, fd_set *restrict, fd_set *restrict, fd_set *restrict,
++                   timeval *restrict));
++# endif
++_GL_CXXALIASWARN (select);
++#elif @HAVE_WINSOCK2_H@
++# undef select
++# define select select_used_without_requesting_gnulib_module_select
++#elif defined GNULIB_POSIXCHECK
++# undef select
++# if HAVE_RAW_DECL_SELECT
++_GL_WARN_ON_USE (select, "select is not always POSIX compliant - "
++                 "use gnulib module select for portability");
++# endif
++#endif
++
++
++#endif /* _@GUARD_PREFIX@_SYS_SELECT_H */
++#endif /* _@GUARD_PREFIX@_SYS_SELECT_H */
++#endif /* OSF/1 */
+--- a/gl/m4/gnulib-cache.m4
++++ b/gl/m4/gnulib-cache.m4
+@@ -107,6 +107,7 @@
+ #  parse-datetime \
+ #  pathmax \
+ #  perror \
++#  poll \
+ #  progname \
+ #  quotearg \
+ #  readlink \
+@@ -150,6 +151,7 @@
+ #  warnings \
+ #  wchar \
+ #  wcwidth \
++#  windows-stat-inodes \
+ #  xalloc \
+ #  xalloc-die \
+ #  xgetcwd \
+@@ -232,6 +234,7 @@
+   parse-datetime
+   pathmax
+   perror
++  poll
+   progname
+   quotearg
+   readlink
+@@ -275,6 +278,7 @@
+   warnings
+   wchar
+   wcwidth
++  windows-stat-inodes
+   xalloc
+   xalloc-die
+   xgetcwd
+--- a/gl/m4/gnulib-comp.m4
++++ b/gl/m4/gnulib-comp.m4
+@@ -387,6 +387,10 @@
+   # Code from module perror-tests:
+   # Code from module pipe-posix:
+   # Code from module pipe-posix-tests:
++  # Code from module poll:
++  # Code from module poll-h:
++  # Code from module poll-h-tests:
++  # Code from module poll-tests:
+   # Code from module priv-set:
+   # Code from module priv-set-tests:
+   # Code from module progname:
+@@ -617,6 +621,8 @@
+   # Code from module windows-once:
+   # Code from module windows-recmutex:
+   # Code from module windows-rwlock:
++  # Code from module windows-stat-inodes:
++  # Code from module windows-stat-override:
+   # Code from module windows-thread:
+   # Code from module windows-tls:
+   # Code from module wmemchr:
+@@ -1208,6 +1214,16 @@
+   gl_FUNC_PIPE
+   gl_CONDITIONAL([GL_COND_OBJ_PIPE], [test $HAVE_PIPE = 0])
+   gl_UNISTD_MODULE_INDICATOR([pipe])
++  gl_FUNC_POLL
++  gl_CONDITIONAL([GL_COND_OBJ_POLL],
++                 [test $HAVE_POLL = 0 || test $REPLACE_POLL = 1])
++  AM_COND_IF([GL_COND_OBJ_POLL], [
++    gl_PREREQ_POLL
++  ])
++  gl_POLL_MODULE_INDICATOR([poll])
++  gl_POLL_H
++  gl_POLL_H_REQUIRE_DEFAULTS
++  AC_PROG_MKDIR_P
+   AC_CHECK_DECLS([program_invocation_name], [], [], [#include <errno.h>])
+   AC_CHECK_DECLS([program_invocation_short_name], [], [], [#include <errno.h>])
+   gl_QUOTE
+@@ -1277,6 +1293,9 @@
+   gl_SAVE_CWD
+   gl_SAVEDIR
+   AC_PROG_MKDIR_P
++  gl_FUNC_SELECT
++  gl_CONDITIONAL([GL_COND_OBJ_SELECT], [test $REPLACE_SELECT = 1])
++  gl_SYS_SELECT_MODULE_INDICATOR([select])
+   AC_CHECK_HEADERS([selinux/flask.h])
+   gl_HEADERS_SELINUX_SELINUX_H
+   gl_HEADERS_SELINUX_CONTEXT_H
+@@ -1297,6 +1316,9 @@
+     gl_PREREQ_SETLOCALE_LOCK
+   ])
+   gl_LOCALE_MODULE_INDICATOR([setlocale_null])
++  gl_SIGNAL_H
++  gl_SIGNAL_H_REQUIRE_DEFAULTS
++  AC_PROG_MKDIR_P
+   gl_SIZE_MAX
+   gl_FUNC_SNPRINTF
+   gl_STDIO_MODULE_INDICATOR([snprintf])
+@@ -1460,6 +1482,9 @@
+     gl_PREREQ_STRTOUMAX
+   ])
+   gl_INTTYPES_MODULE_INDICATOR([strtoumax])
++  gl_SYS_SELECT_H
++  gl_SYS_SELECT_H_REQUIRE_DEFAULTS
++  AC_PROG_MKDIR_P
+   gl_SYS_SOCKET_H
+   gl_SYS_SOCKET_H_REQUIRE_DEFAULTS
+   AC_PROG_MKDIR_P
+@@ -1591,6 +1616,12 @@
+   AC_REQUIRE([AC_CANONICAL_HOST])
+   gl_CONDITIONAL([GL_COND_OBJ_WINDOWS_RWLOCK],
+                  [case "$host_os" in mingw*) true;; *) false;; esac])
++  AC_REQUIRE([gl_WINDOWS_STAT_INODES])
++  gl_SYS_STAT_H_REQUIRE_DEFAULTS
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  case "$host_os" in
++    mingw*) gl_MODULE_INDICATOR_INIT_VARIABLE([GNULIB_OVERRIDES_STRUCT_STAT], [1]) ;;
++  esac
+   gl_FUNC_WMEMCHR
+   gl_CONDITIONAL([GL_COND_OBJ_WMEMCHR], [test $HAVE_WMEMCHR = 0])
+   gl_WCHAR_MODULE_INDICATOR([wmemchr])
+@@ -1801,6 +1832,7 @@
+   AC_PROG_MKDIR_P
+   gt_LOCALE_FR
+   gt_LOCALE_FR_UTF8
++  AC_CHECK_HEADERS_ONCE([unistd.h sys/wait.h])
+   gl_PRIV_SET
+   gl_PTHREAD_H
+   gl_PTHREAD_H_REQUIRE_DEFAULTS
+@@ -1851,9 +1883,6 @@
+     gl_PREREQ_SECURE_GETENV
+   ])
+   gl_STDLIB_MODULE_INDICATOR([secure_getenv])
+-  gl_FUNC_SELECT
+-  gl_CONDITIONAL([GL_COND_OBJ_SELECT], [test $REPLACE_SELECT = 1])
+-  gl_SYS_SELECT_MODULE_INDICATOR([select])
+   AC_CHECK_HEADERS_ONCE([sys/wait.h])
+   gl_FUNC_SETLOCALE
+   gl_CONDITIONAL([GL_COND_OBJ_SETLOCALE], [test $REPLACE_SETLOCALE = 1])
+@@ -1875,9 +1904,6 @@
+     gl_PREREQ_SIGACTION
+   ])
+   gl_SIGNAL_MODULE_INDICATOR([sigaction])
+-  gl_SIGNAL_H
+-  gl_SIGNAL_H_REQUIRE_DEFAULTS
+-  AC_PROG_MKDIR_P
+   gl_SIGNALBLOCKING
+   gl_CONDITIONAL([GL_COND_OBJ_SIGPROCMASK], [test $HAVE_POSIX_SIGNALBLOCKING = 0])
+   AM_COND_IF([GL_COND_OBJ_SIGPROCMASK], [
+@@ -1933,9 +1959,6 @@
+   gl_SYS_RANDOM_H
+   gl_SYS_RANDOM_H_REQUIRE_DEFAULTS
+   AC_PROG_MKDIR_P
+-  gl_SYS_SELECT_H
+-  gl_SYS_SELECT_H_REQUIRE_DEFAULTS
+-  AC_PROG_MKDIR_P
+   AC_CHECK_FUNCS_ONCE([shutdown])
+   gl_FUNC_GEN_TEMPNAME
+   gl_MODULE_INDICATOR([tempname])
+@@ -2372,6 +2395,8 @@
+   lib/perror.c
+   lib/pipe-safer.c
+   lib/pipe.c
++  lib/poll.c
++  lib/poll.in.h
+   lib/printf-args.c
+   lib/printf-args.h
+   lib/printf-parse.c
+@@ -2413,12 +2438,14 @@
+   lib/se-label.in.h
+   lib/se-selinux.c
+   lib/se-selinux.in.h
++  lib/select.c
+   lib/selinux-at.c
+   lib/selinux-at.h
+   lib/setenv.c
+   lib/setlocale-lock.c
+   lib/setlocale_null.c
+   lib/setlocale_null.h
++  lib/signal.in.h
+   lib/size_max.h
+   lib/snprintf.c
+   lib/sockets.c
+@@ -2470,6 +2497,7 @@
+   lib/strtoull.c
+   lib/strtoumax.c
+   lib/sys-limits.h
++  lib/sys_select.in.h
+   lib/sys_socket.c
+   lib/sys_socket.in.h
+   lib/sys_stat.in.h
+@@ -2718,6 +2746,8 @@
+   m4/perror.m4
+   m4/pid_t.m4
+   m4/pipe.m4
++  m4/poll.m4
++  m4/poll_h.m4
+   m4/printf.m4
+   m4/priv-set.m4
+   m4/pthread-thread.m4
+@@ -2837,6 +2867,7 @@
+   m4/wctomb.m4
+   m4/wctype_h.m4
+   m4/wcwidth.m4
++  m4/windows-stat-inodes.m4
+   m4/wint_t.m4
+   m4/wmemchr.m4
+   m4/wmempcpy.m4
+@@ -3065,6 +3096,8 @@
+   tests/test-perror.sh
+   tests/test-perror2.c
+   tests/test-pipe.c
++  tests/test-poll-h.c
++  tests/test-poll.c
+   tests/test-priv-set.c
+   tests/test-pthread-thread.c
+   tests/test-pthread.c
+@@ -3235,13 +3268,11 @@
+   tests=lib/sched.in.h
+   tests=lib/sched_yield.c
+   tests=lib/secure_getenv.c
+-  tests=lib/select.c
+   tests=lib/setlocale.c
+   tests=lib/setsockopt.c
+   tests=lib/sig-handler.c
+   tests=lib/sig-handler.h
+   tests=lib/sigaction.c
+-  tests=lib/signal.in.h
+   tests=lib/sigprocmask.c
+   tests=lib/sleep.c
+   tests=lib/socket.c
+@@ -3251,7 +3282,6 @@
+   tests=lib/symlinkat.c
+   tests=lib/sys_ioctl.in.h
+   tests=lib/sys_random.in.h
+-  tests=lib/sys_select.in.h
+   tests=lib/tempname.c
+   tests=lib/tempname.h
+   tests=lib/thread-optim.h
+--- a/gl/m4/poll.m4
++++ b/gl/m4/poll.m4
+@@ -0,0 +1,108 @@
++# poll.m4 serial 20
++dnl Copyright (c) 2003, 2005-2007, 2009-2022 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++
++AC_DEFUN([gl_FUNC_POLL],
++[
++  AC_REQUIRE([gl_POLL_H])
++  AC_REQUIRE([gl_SOCKETS])
++  AC_REQUIRE([AC_CANONICAL_HOST]) dnl for cross-compiles
++  if test $ac_cv_header_poll_h = no; then
++    ac_cv_func_poll=no
++    gl_cv_func_poll=no
++  else
++    AC_CHECK_FUNC([poll],
++      [# Check whether poll() works on special files (like /dev/null) and
++       # and ttys (like /dev/tty). On Mac OS X 10.4.0 and AIX 5.3, it doesn't.
++       AC_RUN_IFELSE([AC_LANG_SOURCE([[
++#include <fcntl.h>
++#include <poll.h>
++]GL_MDA_DEFINES[
++         int main()
++         {
++           int result = 0;
++           struct pollfd ufd;
++           /* Try /dev/null for reading.  */
++           ufd.fd = open ("/dev/null", O_RDONLY);
++           /* If /dev/null does not exist, it's not Mac OS X nor AIX. */
++           if (ufd.fd >= 0)
++             {
++               ufd.events = POLLIN;
++               ufd.revents = 0;
++               if (!(poll (&ufd, 1, 0) == 1 && ufd.revents == POLLIN))
++                 result |= 1;
++             }
++           /* Try /dev/null for writing.  */
++           ufd.fd = open ("/dev/null", O_WRONLY);
++           /* If /dev/null does not exist, it's not Mac OS X nor AIX. */
++           if (ufd.fd >= 0)
++             {
++               ufd.events = POLLOUT;
++               ufd.revents = 0;
++               if (!(poll (&ufd, 1, 0) == 1 && ufd.revents == POLLOUT))
++                 result |= 2;
++             }
++           /* Trying /dev/tty may be too environment dependent.  */
++           return result;
++         }]])],
++         [gl_cv_func_poll=yes],
++         [gl_cv_func_poll=no],
++         [# When cross-compiling, assume that poll() works everywhere except on
++          # Mac OS X or AIX, regardless of its version.
++          AC_EGREP_CPP([MacOSX], [
++#if (defined(__APPLE__) && defined(__MACH__)) || defined(_AIX)
++This is MacOSX or AIX
++#endif
++], [gl_cv_func_poll="guessing no"], [gl_cv_func_poll="guessing yes"])])])
++  fi
++  case "$gl_cv_func_poll" in
++    *yes) ;;
++    *)
++      AC_CHECK_FUNC([poll], [ac_cv_func_poll=yes], [ac_cv_func_poll=no])
++      if test $ac_cv_func_poll = no; then
++        HAVE_POLL=0
++      else
++        REPLACE_POLL=1
++      fi
++      ;;
++  esac
++  if test $HAVE_POLL = 0 || test $REPLACE_POLL = 1; then
++    :
++  else
++    AC_DEFINE([HAVE_POLL], [1],
++      [Define to 1 if you have the 'poll' function and it works.])
++  fi
++
++  dnl Determine the needed libraries.
++  LIB_POLL="$LIBSOCKET"
++  if test $HAVE_POLL = 0 || test $REPLACE_POLL = 1; then
++    case "$host_os" in
++      mingw*)
++        dnl On the MSVC platform, the function MsgWaitForMultipleObjects
++        dnl (used in lib/poll.c) requires linking with -luser32. On mingw,
++        dnl it is implicit.
++        AC_LINK_IFELSE(
++          [AC_LANG_SOURCE([[
++#define WIN32_LEAN_AND_MEAN
++#include <windows.h>
++int
++main ()
++{
++  MsgWaitForMultipleObjects (0, NULL, 0, 0, 0);
++  return 0;
++}]])],
++          [],
++          [LIB_POLL="$LIB_POLL -luser32"])
++        ;;
++    esac
++  fi
++  AC_SUBST([LIB_POLL])
++])
++
++# Prerequisites of lib/poll.c.
++AC_DEFUN([gl_PREREQ_POLL],
++[
++  AC_CHECK_HEADERS_ONCE([sys/ioctl.h sys/filio.h])
++])
+--- a/gl/m4/poll_h.m4
++++ b/gl/m4/poll_h.m4
+@@ -0,0 +1,64 @@
++# poll_h.m4 serial 6
++dnl Copyright (C) 2010-2022 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++
++dnl Written by Bruno Haible.
++
++AC_DEFUN_ONCE([gl_POLL_H],
++[
++  dnl Ensure to expand the default settings once only, before all statements
++  dnl that occur in other macros.
++  AC_REQUIRE([gl_POLL_H_DEFAULTS])
++
++  AC_CHECK_HEADERS_ONCE([poll.h])
++  if test $ac_cv_header_poll_h = yes; then
++    HAVE_POLL_H=1
++  else
++    HAVE_POLL_H=0
++  fi
++  AC_SUBST([HAVE_POLL_H])
++
++  dnl <poll.h> is always overridden, because of GNULIB_POSIXCHECK.
++  gl_CHECK_NEXT_HEADERS([poll.h])
++
++  gl_PREREQ_SYS_H_WINSOCK2 dnl for HAVE_WINSOCK2_H
++
++  dnl Check for declarations of anything we want to poison if the
++  dnl corresponding gnulib module is not in use.
++  gl_WARN_ON_USE_PREPARE([[#include <poll.h>]],
++    [poll])
++])
++
++# gl_POLL_MODULE_INDICATOR([modulename])
++# sets the shell variable that indicates the presence of the given module
++# to a C preprocessor expression that will evaluate to 1.
++# This macro invocation must not occur in macros that are AC_REQUIREd.
++AC_DEFUN([gl_POLL_MODULE_INDICATOR],
++[
++  dnl Ensure to expand the default settings once only.
++  gl_POLL_H_REQUIRE_DEFAULTS
++  gl_MODULE_INDICATOR_SET_VARIABLE([$1])
++  dnl Define it also as a C macro, for the benefit of the unit tests.
++  gl_MODULE_INDICATOR_FOR_TESTS([$1])
++])
++
++# Initializes the default values for AC_SUBSTed shell variables.
++# This macro must not be AC_REQUIREd.  It must only be invoked, and only
++# outside of macros or in macros that are not AC_REQUIREd.
++AC_DEFUN([gl_POLL_H_REQUIRE_DEFAULTS],
++[
++  m4_defun(GL_MODULE_INDICATOR_PREFIX[_POLL_H_MODULE_INDICATOR_DEFAULTS], [
++    gl_MODULE_INDICATOR_INIT_VARIABLE([GNULIB_POLL])
++  ])
++  m4_require(GL_MODULE_INDICATOR_PREFIX[_POLL_H_MODULE_INDICATOR_DEFAULTS])
++  AC_REQUIRE([gl_POLL_H_DEFAULTS])
++])
++
++AC_DEFUN([gl_POLL_H_DEFAULTS],
++[
++  dnl Assume proper GNU behavior unless another module says otherwise.
++  HAVE_POLL=1;          AC_SUBST([HAVE_POLL])
++  REPLACE_POLL=0;       AC_SUBST([REPLACE_POLL])
++])
+--- a/gl/m4/windows-stat-inodes.m4
++++ b/gl/m4/windows-stat-inodes.m4
+@@ -0,0 +1,19 @@
++# windows-stat-inodes.m4 serial 1
++dnl Copyright (C) 2017-2022 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++
++dnl Enable inode identification in 'struct stat' on native Windows platforms.
++dnl Set WINDOWS_STAT_INODES to
++dnl - 0 -> keep the default (dev_t = 32-bit, ino_t = 16-bit),
++dnl - 1 -> override types normally (dev_t = 32-bit, ino_t = 64-bit),
++dnl - 2 -> override types in an extended way (dev_t = 64-bit, ino_t = 128-bit).
++AC_DEFUN([gl_WINDOWS_STAT_INODES],
++[
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  case "$host_os" in
++    mingw*) WINDOWS_STAT_INODES=1 ;;
++    *)      WINDOWS_STAT_INODES=0 ;;
++  esac
++])
+--- a/gnulib-tests/Makefile.am
++++ b/gnulib-tests/Makefile.am
+@@ -1429,6 +1429,23 @@
+ 
+ ## end   gnulib module pipe-posix-tests
+ 
++## begin gnulib module poll-h-tests
++
++TESTS += test-poll-h
++check_PROGRAMS += test-poll-h
++EXTRA_DIST += test-poll-h.c
++
++## end   gnulib module poll-h-tests
++
++## begin gnulib module poll-tests
++
++TESTS += test-poll
++check_PROGRAMS += test-poll
++test_poll_LDADD = $(LDADD) $(LIB_POLL) @LIBSOCKET@ $(INET_PTON_LIB)
++EXTRA_DIST += test-poll.c signature.h macros.h
++
++## end   gnulib module poll-tests
++
+ ## begin gnulib module priv-set
+ 
+ libtests_a_SOURCES += priv-set.c
+@@ -1792,14 +1809,6 @@
+ 
+ ## end   gnulib module secure_getenv
+ 
+-## begin gnulib module select
+-
+-if GL_COND_OBJ_SELECT
+-libtests_a_SOURCES += select.c
+-endif
+-
+-## end   gnulib module select
+-
+ ## begin gnulib module select-tests
+ 
+ TESTS += test-select test-select-in.sh test-select-out.sh
+@@ -1898,46 +1907,6 @@
+ 
+ ## end   gnulib module sigaction-tests
+ 
+-## begin gnulib module signal-h
+-
+-BUILT_SOURCES += signal.h
+-
+-# We need the following in order to create <signal.h> when the system
+-# doesn't have a complete one.
+-signal.h: signal.in.h $(top_builddir)/config.status $(CXXDEFS_H) $(ARG_NONNULL_H) $(WARN_ON_USE_H)
+-	$(gl_V_at)$(SED_HEADER_STDOUT) \
+-	      -e 's|@''GUARD_PREFIX''@|GL|g' \
+-	      -e 's|@''INCLUDE_NEXT''@|$(INCLUDE_NEXT)|g' \
+-	      -e 's|@''PRAGMA_SYSTEM_HEADER''@|@PRAGMA_SYSTEM_HEADER@|g' \
+-	      -e 's|@''PRAGMA_COLUMNS''@|@PRAGMA_COLUMNS@|g' \
+-	      -e 's|@''NEXT_SIGNAL_H''@|$(NEXT_SIGNAL_H)|g' \
+-	      -e 's/@''GNULIB_PTHREAD_SIGMASK''@/$(GL_GNULIB_PTHREAD_SIGMASK)/g' \
+-	      -e 's/@''GNULIB_RAISE''@/$(GL_GNULIB_RAISE)/g' \
+-	      -e 's/@''GNULIB_SIGNAL_H_SIGPIPE''@/$(GL_GNULIB_SIGNAL_H_SIGPIPE)/g' \
+-	      -e 's/@''GNULIB_SIGPROCMASK''@/$(GL_GNULIB_SIGPROCMASK)/g' \
+-	      -e 's/@''GNULIB_SIGACTION''@/$(GL_GNULIB_SIGACTION)/g' \
+-	      -e 's|@''HAVE_POSIX_SIGNALBLOCKING''@|$(HAVE_POSIX_SIGNALBLOCKING)|g' \
+-	      -e 's|@''HAVE_PTHREAD_SIGMASK''@|$(HAVE_PTHREAD_SIGMASK)|g' \
+-	      -e 's|@''HAVE_RAISE''@|$(HAVE_RAISE)|g' \
+-	      -e 's|@''HAVE_SIGSET_T''@|$(HAVE_SIGSET_T)|g' \
+-	      -e 's|@''HAVE_SIGINFO_T''@|$(HAVE_SIGINFO_T)|g' \
+-	      -e 's|@''HAVE_SIGACTION''@|$(HAVE_SIGACTION)|g' \
+-	      -e 's|@''HAVE_STRUCT_SIGACTION_SA_SIGACTION''@|$(HAVE_STRUCT_SIGACTION_SA_SIGACTION)|g' \
+-	      -e 's|@''HAVE_TYPE_VOLATILE_SIG_ATOMIC_T''@|$(HAVE_TYPE_VOLATILE_SIG_ATOMIC_T)|g' \
+-	      -e 's|@''HAVE_SIGHANDLER_T''@|$(HAVE_SIGHANDLER_T)|g' \
+-	      -e 's|@''REPLACE_PTHREAD_SIGMASK''@|$(REPLACE_PTHREAD_SIGMASK)|g' \
+-	      -e 's|@''REPLACE_RAISE''@|$(REPLACE_RAISE)|g' \
+-	      -e '/definitions of _GL_FUNCDECL_RPL/r $(CXXDEFS_H)' \
+-	      -e '/definition of _GL_ARG_NONNULL/r $(ARG_NONNULL_H)' \
+-	      -e '/definition of _GL_WARN_ON_USE/r $(WARN_ON_USE_H)' \
+-	      $(srcdir)/signal.in.h > $@-t
+-	$(AM_V_at)mv $@-t $@
+-MOSTLYCLEANFILES += signal.h signal.h-t
+-
+-EXTRA_DIST += signal.in.h
+-
+-## end   gnulib module signal-h
+-
+ ## begin gnulib module signal-h-tests
+ 
+ TESTS += test-signal-h
+@@ -2335,38 +2304,6 @@
+ 
+ ## end   gnulib module sys_random-tests
+ 
+-## begin gnulib module sys_select
+-
+-BUILT_SOURCES += sys/select.h
+-
+-# We need the following in order to create <sys/select.h> when the system
+-# doesn't have one that works with the given compiler.
+-sys/select.h: sys_select.in.h $(top_builddir)/config.status $(CXXDEFS_H) $(WARN_ON_USE_H)
+-	$(AM_V_GEN)$(MKDIR_P) '%reldir%/sys'
+-	$(AM_V_at)$(SED_HEADER_STDOUT) \
+-	      -e 's|@''GUARD_PREFIX''@|GL|g' \
+-	      -e 's|@''INCLUDE_NEXT''@|$(INCLUDE_NEXT)|g' \
+-	      -e 's|@''PRAGMA_SYSTEM_HEADER''@|@PRAGMA_SYSTEM_HEADER@|g' \
+-	      -e 's|@''PRAGMA_COLUMNS''@|@PRAGMA_COLUMNS@|g' \
+-	      -e 's|@''NEXT_SYS_SELECT_H''@|$(NEXT_SYS_SELECT_H)|g' \
+-	      -e 's|@''HAVE_SYS_SELECT_H''@|$(HAVE_SYS_SELECT_H)|g' \
+-	      -e 's/@''GNULIB_PSELECT''@/$(GL_GNULIB_PSELECT)/g' \
+-	      -e 's/@''GNULIB_SELECT''@/$(GL_GNULIB_SELECT)/g' \
+-	      -e 's|@''HAVE_WINSOCK2_H''@|$(HAVE_WINSOCK2_H)|g' \
+-	      -e 's|@''HAVE_PSELECT''@|$(HAVE_PSELECT)|g' \
+-	      -e 's|@''REPLACE_PSELECT''@|$(REPLACE_PSELECT)|g' \
+-	      -e 's|@''REPLACE_SELECT''@|$(REPLACE_SELECT)|g' \
+-	      -e '/definitions of _GL_FUNCDECL_RPL/r $(CXXDEFS_H)' \
+-	      -e '/definition of _GL_WARN_ON_USE/r $(WARN_ON_USE_H)' \
+-	      $(srcdir)/sys_select.in.h > $@-t
+-	$(AM_V_at)mv $@-t $@
+-MOSTLYCLEANFILES += sys/select.h sys/select.h-t
+-MOSTLYCLEANDIRS += sys
+-
+-EXTRA_DIST += sys_select.in.h
+-
+-## end   gnulib module sys_select
+-
+ ## begin gnulib module sys_select-tests
+ 
+ TESTS += test-sys_select
+--- a/gnulib-tests/test-poll-h.c
++++ b/gnulib-tests/test-poll-h.c
+@@ -0,0 +1,34 @@
++/* Test of <poll.h> substitute.
++   Copyright (C) 2010-2022 Free Software Foundation, Inc.
++
++   This program is free software: you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation, either version 3 of the License, or
++   (at your option) any later version.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
++
++/* Written by Bruno Haible, 2010.  */
++
++#include <config.h>
++
++#include <poll.h>
++
++/* Check that the nfds_t type is defined.  */
++nfds_t a;
++
++/* Check that the various POLL* macros are defined.  */
++int b = POLLIN | POLLPRI | POLLOUT | POLLERR | POLLHUP | POLLNVAL
++        | POLLRDNORM | POLLRDBAND | POLLWRNORM | POLLWRBAND;
++
++int
++main (void)
++{
++  return 0;
++}
+--- a/gnulib-tests/test-poll.c
++++ b/gnulib-tests/test-poll.c
+@@ -0,0 +1,395 @@
++/* Test of poll() function.
++   Copyright (C) 2008-2022 Free Software Foundation, Inc.
++
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation, either version 3, or (at your option)
++   any later version.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with this program; if not, see <https://www.gnu.org/licenses/>.  */
++
++/* Written by Paolo Bonzini.  */
++
++#include <config.h>
++
++/* Specification.  */
++#include <poll.h>
++
++#include "signature.h"
++SIGNATURE_CHECK (poll, int, (struct pollfd[], nfds_t, int));
++
++#include <stdio.h>
++#include <string.h>
++#include <sys/socket.h>
++#include <netinet/in.h>
++#include <arpa/inet.h>
++#include <fcntl.h>
++#include <stdlib.h>
++#include <stdbool.h>
++#include <sys/ioctl.h>
++#include <errno.h>
++
++#include "macros.h"
++
++#if defined _WIN32 && ! defined __CYGWIN__
++# define WINDOWS_NATIVE
++#endif
++
++#ifdef WINDOWS_NATIVE
++#include <io.h>
++#define pipe(x) _pipe(x, 256, O_BINARY)
++#endif
++#ifdef HAVE_UNISTD_H
++#include <unistd.h>
++#endif
++#ifdef HAVE_SYS_WAIT_H
++#include <sys/wait.h>
++#endif
++
++#define TEST_PORT       12345
++
++
++/* Minimal testing infrastructure.  */
++
++static int failures;
++
++static void
++failed (const char *reason)
++{
++  if (++failures > 1)
++    printf ("  ");
++  printf ("failed (%s)\n", reason);
++}
++
++static int
++test (void (*fn) (void), const char *msg)
++{
++  failures = 0;
++  printf ("%s... ", msg);
++  fflush (stdout);
++  fn ();
++
++  if (!failures)
++    printf ("passed\n");
++
++  return failures;
++}
++
++
++/* Funny socket code.  */
++
++static int
++open_server_socket ()
++{
++  int s, x;
++  struct sockaddr_in ia;
++
++  s = socket (AF_INET, SOCK_STREAM, 0);
++
++  x = 1;
++  setsockopt (s, SOL_SOCKET, SO_REUSEPORT, &x, sizeof (x));
++
++  memset (&ia, 0, sizeof (ia));
++  ia.sin_family = AF_INET;
++  inet_pton (AF_INET, "127.0.0.1", &ia.sin_addr);
++  ia.sin_port = htons (TEST_PORT);
++  if (bind (s, (struct sockaddr *) &ia, sizeof (ia)) < 0)
++    {
++      perror ("bind");
++      exit (77);
++    }
++
++  if (listen (s, 1) < 0)
++    {
++      perror ("listen");
++      exit (77);
++    }
++
++  return s;
++}
++
++static int
++connect_to_socket (int blocking)
++{
++  int s;
++  struct sockaddr_in ia;
++
++  s = socket (AF_INET, SOCK_STREAM, 0);
++
++  memset (&ia, 0, sizeof (ia));
++  ia.sin_family = AF_INET;
++  inet_pton (AF_INET, "127.0.0.1", &ia.sin_addr);
++  ia.sin_port = htons (TEST_PORT);
++
++  if (!blocking)
++    {
++#ifdef WINDOWS_NATIVE
++      unsigned long iMode = 1;
++      ioctl (s, FIONBIO, (char *) &iMode);
++
++#elif defined F_GETFL
++      int oldflags = fcntl (s, F_GETFL, NULL);
++
++      if (!(oldflags & O_NONBLOCK))
++        fcntl (s, F_SETFL, oldflags | O_NONBLOCK);
++#endif
++    }
++
++  if (connect (s, (struct sockaddr *) &ia, sizeof (ia)) < 0
++      && (blocking || errno != EINPROGRESS))
++    {
++      perror ("connect");
++      exit (77);
++    }
++
++  return s;
++}
++
++
++/* A slightly more convenient interface to poll(2).  */
++
++static int
++poll1 (int fd, int ev, int time)
++{
++  struct pollfd pfd;
++  int r;
++
++  pfd.fd = fd;
++  pfd.events = ev;
++  pfd.revents = -1;
++  r = poll (&pfd, 1, time);
++  if (r < 0)
++    return r;
++
++  if (pfd.revents & ~(POLLHUP | POLLERR | POLLNVAL | ev))
++    failed ("invalid flag combination (unrequested events)");
++
++  return pfd.revents;
++}
++
++static int
++poll1_nowait (int fd, int ev)
++{
++  return poll1 (fd, ev, 0);
++}
++
++static int
++poll1_wait (int fd, int ev)
++{
++  return poll1 (fd, ev, -1);
++}
++
++
++/* Test poll(2) for TTYs.  */
++
++#ifdef INTERACTIVE
++static void
++test_tty (void)
++{
++  if (poll1_nowait (0, POLLIN | POLLRDNORM) != 0)
++    failed ("can read");
++  if (poll1_nowait (0, POLLOUT) == 0)
++    failed ("cannot write");
++
++  if (poll1_wait (0, POLLIN | POLLRDNORM) == 0)
++    failed ("return with infinite timeout");
++
++  getchar ();
++  if (poll1_nowait (0, POLLIN | POLLRDNORM) != 0)
++    failed ("can read after getc");
++}
++#endif
++
++
++/* Test poll(2) for unconnected nonblocking sockets.  */
++
++static void
++test_connect_first (void)
++{
++  int s = open_server_socket ();
++  struct sockaddr_in ia;
++  socklen_t addrlen;
++
++  int c1, c2;
++
++  if (poll1_nowait (s, POLLIN | POLLRDNORM | POLLRDBAND) != 0)
++    failed ("can read, socket not connected");
++
++  c1 = connect_to_socket (false);
++
++  if (poll1_wait (s, POLLIN | POLLRDNORM | POLLRDBAND) != (POLLIN | POLLRDNORM))
++    failed ("expecting POLLIN | POLLRDNORM on passive socket");
++  if (poll1_nowait (s, POLLIN | POLLRDBAND) != POLLIN)
++    failed ("expecting POLLIN on passive socket");
++  if (poll1_nowait (s, POLLRDNORM | POLLRDBAND) != POLLRDNORM)
++    failed ("expecting POLLRDNORM on passive socket");
++
++  addrlen = sizeof (ia);
++  c2 = accept (s, (struct sockaddr *) &ia, &addrlen);
++  close (s);
++  close (c1);
++  close (c2);
++}
++
++
++/* Test poll(2) for unconnected blocking sockets.  */
++
++static void
++test_accept_first (void)
++{
++#ifndef WINDOWS_NATIVE
++  int s = open_server_socket ();
++  struct sockaddr_in ia;
++  socklen_t addrlen;
++  char buf[3];
++  int c, pid;
++
++  pid = fork ();
++  if (pid < 0)
++    return;
++
++  if (pid == 0)
++    {
++      addrlen = sizeof (ia);
++      c = accept (s, (struct sockaddr *) &ia, &addrlen);
++      ASSERT (c >= 0);
++      close (s);
++      ASSERT (write (c, "foo", 3) == 3);
++      ASSERT (read (c, buf, 3) == 3);
++      shutdown (c, SHUT_RD);
++      close (c);
++      exit (0);
++    }
++  else
++    {
++      close (s);
++      c = connect_to_socket (true);
++      ASSERT (c >= 0);
++      if (poll1_nowait (c, POLLOUT | POLLWRNORM | POLLRDBAND)
++          != (POLLOUT | POLLWRNORM))
++        failed ("cannot write after blocking connect");
++      ASSERT (write (c, "foo", 3) == 3);
++      wait (&pid);
++      if (poll1_wait (c, POLLIN) != POLLIN)
++        failed ("cannot read data left in the socket by closed process");
++      ASSERT (read (c, buf, 3) == 3);
++      ASSERT (write (c, "foo", 3) == 3);
++      int revents = poll1_wait (c, POLLIN | POLLOUT);
++# ifdef __linux__
++      if ((revents & (POLLHUP | POLLERR)) == 0)
++        failed ("expecting POLLHUP after shutdown");
++# else
++      (void) revents;
++# endif
++      close (c);
++    }
++#endif
++}
++
++
++/* Common code for pipes and connected sockets.  */
++
++static void
++test_pair (int rd, int wd)
++{
++  char buf[3];
++  if (poll1_wait (wd, POLLIN | POLLRDNORM | POLLOUT | POLLWRNORM | POLLRDBAND)
++      != (POLLOUT | POLLWRNORM))
++    failed ("expecting POLLOUT | POLLWRNORM before writing");
++  if (poll1_nowait (wd, POLLIN | POLLRDNORM | POLLOUT | POLLRDBAND) != POLLOUT)
++    failed ("expecting POLLOUT before writing");
++  if (poll1_nowait (wd, POLLIN | POLLRDNORM | POLLWRNORM | POLLRDBAND)
++      != POLLWRNORM)
++    failed ("expecting POLLWRNORM before writing");
++
++  ASSERT (write (wd, "foo", 3) == 3);
++  if (poll1_wait (rd, POLLIN | POLLRDNORM) != (POLLIN | POLLRDNORM))
++    failed ("expecting POLLIN | POLLRDNORM after writing");
++  if (poll1_nowait (rd, POLLIN) != POLLIN)
++    failed ("expecting POLLIN after writing");
++  if (poll1_nowait (rd, POLLRDNORM) != POLLRDNORM)
++    failed ("expecting POLLRDNORM after writing");
++
++  ASSERT (read (rd, buf, 3) == 3);
++}
++
++
++/* Test poll(2) on connected sockets.  */
++
++static void
++test_socket_pair (void)
++{
++  struct sockaddr_in ia;
++
++  socklen_t addrlen = sizeof (ia);
++  int s = open_server_socket ();
++  int c1 = connect_to_socket (false);
++  int c2 = accept (s, (struct sockaddr *) &ia, &addrlen);
++  ASSERT (s >= 0);
++  ASSERT (c1 >= 0);
++  ASSERT (c2 >= 0);
++
++  close (s);
++
++  test_pair (c1, c2);
++  close (c1);
++  ASSERT (write (c2, "foo", 3) == 3);
++  int revents = poll1_nowait (c2, POLLIN | POLLOUT);
++#ifdef __linux__
++  if ((revents & (POLLHUP | POLLERR)) == 0)
++    failed ("expecting POLLHUP after shutdown");
++#else
++  (void) revents;
++#endif
++
++  close (c2);
++}
++
++
++/* Test poll(2) on pipes.  */
++
++static void
++test_pipe (void)
++{
++  int fd[2];
++
++  ASSERT (pipe (fd) >= 0);
++  test_pair (fd[0], fd[1]);
++  close (fd[0]);
++  int revents = poll1_wait (fd[1], POLLIN | POLLOUT);
++#if !defined _AIX
++  if ((revents & (POLLHUP | POLLERR)) == 0)
++    failed ("expecting POLLHUP after shutdown");
++#else
++  (void) revents;
++#endif
++
++  close (fd[1]);
++}
++
++
++/* Do them all.  */
++
++int
++main ()
++{
++  int result;
++
++#ifdef INTERACTIVE
++  printf ("Please press Enter\n");
++  test (test_tty, "TTY");
++#endif
++
++  result = test (test_connect_first, "Unconnected socket test");
++  result += test (test_socket_pair, "Connected sockets test");
++  result += test (test_accept_first, "General socket test with fork");
++  result += test (test_pipe, "Pipe test");
++
++  exit (result);
++}
+--- a/xargs/Makefile.am
++++ b/xargs/Makefile.am
+@@ -19,7 +19,7 @@ localedir = $(datadir)/locale
+ bin_PROGRAMS = xargs
+ man_MANS = xargs.1
+ AM_CPPFLAGS = -I.. -I../gl/lib -I$(top_srcdir)/gl/lib -I$(top_srcdir)/lib -DLOCALEDIR=\"$(localedir)\"
+-LDADD = ../lib/libfind.a ../gl/lib/libgnulib.a $(LIB_CLOSE) $(LIBINTL) $(LIB_SETLOCALE_NULL) $(LIB_MBRTOWC)
++LDADD = ../lib/libfind.a ../gl/lib/libgnulib.a $(LIB_CLOSE) $(LIBINTL) $(LIB_SETLOCALE_NULL) $(LIB_MBRTOWC) $(LIB_POLL)
+ EXTRA_DIST = $(man_MANS)
+ SUBDIRS = . testsuite
+ 

--- a/mingw-w64-findutils/002-configure-allow-mountlist.patch
+++ b/mingw-w64-findutils/002-configure-allow-mountlist.patch
@@ -1,0 +1,19 @@
+--- a/gl/m4/mountlist.m4
++++ b/gl/m4/mountlist.m4
+@@ -306,6 +306,16 @@
+   fi
+ 
+   if test -z "$ac_list_mounted_fs"; then
++      # The ezwinports modifications allow mountlist to be used
++      # in mingw or MSVC
++    case "$host_os" in
++          mingw*)
++              ac_list_mounted_fs=found
++              ;;
++    esac
++  fi
++  
++  if test -z "$ac_list_mounted_fs"; then
+     AC_MSG_ERROR([could not determine how to read list of mounted file systems])
+     # FIXME -- no need to abort building the whole package
+     # Can't build mountlist.c or anything that needs its functions

--- a/mingw-w64-findutils/003-replace-grp-pwd.patch
+++ b/mingw-w64-findutils/003-replace-grp-pwd.patch
@@ -1,0 +1,276 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -297,6 +297,40 @@
+ # the ANSI2KNR-filtering rules.
+ #LIBOBJS=`echo $LIBOBJS|sed 's/\.o /\$U.o /g;s/\.o$/\$U.o/'`
+ 
++dnl mingw replacement for pwd.h and grp.h. zzz prefix so this comes last in config.h.in
++AH_VERBATIM([zzz_mingw_pwd_grp_replacement], [
++  /* Replace pwd.h and grp.h for mingw */
++  #ifndef PWD_DEFINED
++  #define PWD_DEFINED
++  /* uid/gid stuff */
++  struct passwd {
++    char *pw_name;
++    uid_t pw_uid;
++    gid_t pw_gid;
++    char *pw_dir;
++    char *pw_shell;
++  };
++  
++  extern struct passwd *getpwent (void);
++  extern void           setpwent (void);
++  extern void           endpwent (void);
++  extern struct passwd *getpwnam (const char *);
++  extern struct passwd *getpwuid (uid_t);
++  
++  struct group {
++    char *gr_name;
++    gid_t gr_gid;
++    char **gr_mem;
++  };
++  
++  extern struct group *getgrent (void);
++  extern void   setgrent (void);
++  extern void   endgrent (void);
++  extern struct group *getgrgid (gid_t);
++  extern struct group *getgrnam (const char *);
++  #endif
++  ])
++  
+ # Note that in the list below, po/Makefile.in should appear before
+ # po/Makefile, so that po/Makefile can be created even if po/Makefile.in
+ # starts off missing.
+ --- a/gl/lib/idcache.c
++++ b/gl/lib/idcache.c
+@@ -22,8 +22,10 @@
+ #include <stddef.h>
+ #include <stdio.h>
+ #include <string.h>
++#if !defined(__MINGW32__) && !defined(_MSC_VER)
+ #include <pwd.h>
+ #include <grp.h>
++#endif
+ 
+ #include <unistd.h>
+ 
+@@ -226,3 +228,149 @@
+   nogroup_alist = tail;
+   return NULL;
+ }
++
++#if defined(__MINGW32__) || defined(_MSC_VER)
++#include <stdlib.h>
++#include <windows.h>
++#include <lmcons.h>
++
++char *
++getlogin (void)
++{
++  static char user_name[UNLEN+1];
++  DWORD  length = sizeof (user_name);
++
++  if (GetUserName (user_name, &length))
++    return user_name;
++  return NULL;
++}
++
++static struct passwd pwentry = {
++  NULL, 0, 0, NULL, NULL
++};
++
++static int pw_count = 0;
++
++struct passwd *
++getpwent (void)
++{
++  if (!pwentry.pw_name)
++    pwentry.pw_name = strdup (getlogin ());
++  if (stricmp (pwentry.pw_name, "administrator") != 0)
++    pwentry.pw_uid = 42;
++  if (!pwentry.pw_dir)
++    {
++      char *home = getenv ("HOME");
++      char *h;
++
++      if (!home)
++	home = "/";
++      pwentry.pw_dir = strdup (home);
++      for (h = pwentry.pw_dir; *h; h++)
++	if (*h == '\\')
++	  *h = '/';
++    }
++  if (!pwentry.pw_shell)
++    {
++      char *shell = getenv ("SHELL");
++      char *s;
++
++      if (!shell)
++	shell = getenv ("ComSpec");
++      if (!shell)
++	shell = getenv ("COMSPEC");
++      if (!shell)
++	shell = "C:/WINDOWS/system32/cmd.exe";
++      pwentry.pw_shell = strdup (shell);
++      for (s = pwentry.pw_shell; *s; s++)
++	if (*s == '\\')
++	  *s = '/';
++    }
++
++  if (pw_count++ == 0)
++    return &pwentry;
++  return NULL;
++}
++
++void
++setpwent (void)
++{
++  pw_count = 0;
++}
++
++void
++endpwent (void)
++{
++  pw_count = 0;
++}
++
++struct passwd *
++getpwnam (const char *name)
++{
++  char *user = getlogin ();
++
++  if (strcmp (user, name))
++    return NULL;
++  setpwent ();
++  return getpwent ();
++}
++
++struct passwd *
++getpwuid (uid_t uid)
++{
++  (void) uid;
++  setpwent ();
++  return getpwent ();
++}
++
++static char *grentry_members[] = {
++  NULL, NULL
++};
++
++static struct group grentry = {
++  "root", 42, &grentry_members[0]
++};
++
++static int gr_count = 0;
++
++struct group *
++getgrent (void)
++{
++  if (!grentry_members[0])
++    grentry_members[0] = getlogin ();
++
++  if (gr_count++ == 0)
++    return &grentry;
++  return NULL;
++}
++
++void
++setgrent (void)
++{
++  gr_count = 0;
++}
++
++void
++endgrent (void)
++{
++  gr_count = 0;
++}
++
++struct group *
++getgrgid (gid_t gid)
++{
++  (void) gid;
++  setgrent ();
++  return getgrent ();
++}
++
++struct group *
++getgrnam (const char *name)
++{
++  if (strcmp (name, grentry.gr_name))
++    return NULL;
++  setgrent ();
++  return getgrent ();
++}
++
++#endif
+--- a/find/parser.c
++++ b/find/parser.c
+@@ -23,9 +23,11 @@
+ #include <ctype.h>
+ #include <errno.h>
+ #include <fcntl.h>
++#if !defined(__MINGW32__) && !defined(_MSC_VER)
+ #include <grp.h>
+-#include <math.h>
+ #include <pwd.h>
++#endif
++#include <math.h>
+ #include <regex.h>
+ #include <sys/stat.h>
+ #include <unistd.h>
+--- a/find/pred.c
++++ b/find/pred.c
+@@ -24,9 +24,11 @@
+ #include <dirent.h>
+ #include <errno.h>
+ #include <fcntl.h>
++#if !defined(__MINGW32__) && !defined(_MSC_VER)
+ #include <grp.h>
+-#include <math.h>
+ #include <pwd.h>
++#endif
++#include <math.h>
+ #include <selinux/selinux.h>
+ #include <stdarg.h>
+ #include <sys/stat.h>
+--- a/find/print.c
++++ b/find/print.c
+@@ -22,9 +22,11 @@
+ #include <assert.h>
+ #include <ctype.h>
+ #include <errno.h>
++#if !defined(__MINGW32__) && !defined(_MSC_VER)
+ #include <grp.h>
+-#include <math.h>
+ #include <pwd.h>
++#endif
++#include <math.h>
+ #include <stdarg.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
+--- a/lib/listfile.c
++++ b/lib/listfile.c
+@@ -21,8 +21,10 @@
+ #include <alloca.h>
+ #include <errno.h>
+ #include <fcntl.h>
++#if !defined(__MINGW32__) && !defined(_MSC_VER)
+ #include <grp.h>
+ #include <pwd.h>
++#endif
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+--- a/locate/locate.c
++++ b/locate/locate.c
+@@ -66,7 +66,9 @@
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <getopt.h>
++#if !defined(__MINGW32__) && !defined(_MSC_VER)
+ #include <grp.h>                /* for setgroups() */
++#endif
+ #include <regex.h>
+ #include <signal.h>
+ #include <stdbool.h>

--- a/mingw-w64-findutils/004-define-limits.patch
+++ b/mingw-w64-findutils/004-define-limits.patch
@@ -1,0 +1,55 @@
+--- a/lib/buildcmd.c
++++ b/lib/buildcmd.c
+@@ -488,7 +488,11 @@
+    * possible value for ARG_MAX on a POSIX compliant system.  See
+    * https://www.opengroup.org/onlinepubs/009695399/basedefs/limits.h.html
+    */
++#if defined(__MINGW32__) || defined(_MSC_VER)
++  ctl->posix_arg_size_min = 2048L;
++#else  
+   ctl->posix_arg_size_min = _POSIX_ARG_MAX;
++#endif
+   ctl->posix_arg_size_max = bc_get_arg_max ();
+ 
+   ctl->exit_if_size_exceeded = 0;
+--- a/lib/fdleak.c
++++ b/lib/fdleak.c
+@@ -115,9 +115,15 @@
+   if (open_max >= 0)
+     return open_max;
+ 
++#if defined(__MINGW32__) || defined(_MSC_VER)
++  open_max = getdtablesize ();
++  if (open_max == -1)
++    open_max = 16;
++#else  
+   open_max = sysconf (_SC_OPEN_MAX);
+   if (open_max == -1)
+     open_max = _POSIX_OPEN_MAX;	/* underestimate */
++#endif
+ 
+   /* We assume if RLIMIT_NOFILE is defined, all the related macros are, too. */
+ #if defined HAVE_GETRLIMIT && defined RLIMIT_NOFILE
+--- a/xargs/xargs.c
++++ b/xargs/xargs.c
+@@ -70,6 +70,20 @@
+ #include "gcc-function-attributes.h"
+ #include "system.h"
+ 
++#if defined(__MINGW32__) || defined(_MSC_VER) || defined(__MSDOS__)
++# include "xgetcwd.h"
++#endif
++
++#if defined(__MINGW32__) || defined(_MSC_VER)
++/* MS docs says the maximum is 32K, but my testing indicates it fails
++   to run a subsidiary at 32760, which is slightly less.  So we play
++   it safe and leave a 50-byte slack.  We add 2K because by stupid
++   Posix rules bc_init_controlinfo will subtract 2K, and we are not
++   Posix.  PATH_MAX is subtracted to leave enough space for the file
++   name of the invoked program itself, and 2 more for the space and
++   terminating null character.  */
++# define ARG_MAX (32700 + 2048 - PATH_MAX - 2)
++#endif
+ 
+ #ifndef LONG_MAX
+ # define LONG_MAX (~(1 << (sizeof (long) * 8 - 1)))

--- a/mingw-w64-findutils/005-skip-undefined-symbols.patch
+++ b/mingw-w64-findutils/005-skip-undefined-symbols.patch
@@ -1,0 +1,46 @@
+--- a/locate/locate.c
++++ b/locate/locate.c
+@@ -1513,6 +1537,7 @@
+                 |O_LARGEFILE
+ #endif
+                 );
++#if defined HAVE_FCNTL
+   if (fd >= 0)
+     {
+       /* Make sure it won't survive an exec */
+@@ -1522,6 +1547,7 @@
+           fd = -1;
+         }
+     }
++#endif
+   return fd;
+ }
+ 
+--- a/xargs/xargs.c
++++ b/xargs/xargs.c
+@@ -421,8 +435,12 @@
+   void (*act_on_init_result)(void) = noop;
+   enum BC_INIT_STATUS bcstatus;
+   enum { XARGS_POSIX_HEADROOM = 2048u };
++#ifdef SIGUSR1
++# ifdef SIGUSR2
+   struct sigaction sigact;
+-
++# endif /* SIGUSR2 */
++#endif /* SIGUSR1 */
++  
+   /* We #define __STDC_LIMIT_MACROS above for its side effect on
+    * <limits.h>, but we use it here to avoid getting what would
+    * otherwise be a spurious compiler warning. */
+@@ -827,8 +845,10 @@
+   bc_state.argbuf = xmalloc (bc_ctl.arg_max + 1);
+ 
+   /* Make sure to listen for the kids.  */
++#ifdef SIGCHLD
+   signal (SIGCHLD, SIG_DFL);
+-
++#endif
++  
+   if (!bc_ctl.replace_pat)
+     {
+       for (; optind < argc; optind++)

--- a/mingw-w64-findutils/006-disable-globbing.patch
+++ b/mingw-w64-findutils/006-disable-globbing.patch
@@ -1,0 +1,58 @@
+--- a/find/ftsfind.c
++++ b/find/ftsfind.c
+@@ -62,6 +62,26 @@
+ 
+ #undef  STAT_MOUNTPOINTS
+ 
++#ifdef __MINGW32__
++/* Starting with MSVCRT.DLL v8.x (Vista and later versions) Microsoft
++   changed their implementation of command-line wildcard globbing,
++   such that even wildcards enclosed in quotes are globbed.  To make
++   Find work on all versions of Windows, we must disable command-line
++   globbing, otherwise Find errors out on commands such as
++
++     find . -name "*.c"
++
++   Contrary to the ezwinports variant, it seems like fts is then
++   taking care of the expansion.  */
++
++#include <dirent.h>
++#include <fnmatch.h>
++# ifdef _W64
++   int _dowildcard = 0;
++# else
++   int _CRT_glob = 0;
++# endif
++#endif
+ 
+ /* FTS_TIGHT_CYCLE_CHECK tries to work around Savannah bug #17877
+  * (but actually using it doesn't fix the bug).
+--- a/locate/locate.c
++++ b/locate/locate.c
+@@ -105,6 +107,26 @@
+ #include "printquoted.h"
+ #include "splitstring.h"
+ 
++#ifdef __MINGW32__
++/* Starting with MSVCRT.DLL v8.x (Vista and later versions) Microsoft
++   changed their implementation of command-line wildcard globbing,
++   such that even wildcards enclosed in quotes are globbed.  To make
++   Find work on all versions of Windows, we must disable command-line
++   globbing, otherwise Find errors out on commands such as
++
++     find . -name "*.c"
++
++   Contrary to the ezwinports variant, it seems like fts is then
++   taking care of the expansion.  */
++
++#include <dirent.h>
++#include <fnmatch.h>
++# ifdef _W64
++   int _dowildcard = 0;
++# else
++   int _CRT_glob = 0;
++# endif
++#endif
+ 
+ /* Warn if a database is older than this.  8 days allows for a weekly
+    update that takes up to a day to perform.  */

--- a/mingw-w64-findutils/007-replace-fork.patch
+++ b/mingw-w64-findutils/007-replace-fork.patch
@@ -1,0 +1,310 @@
+--- a/find/defs.h
++++ b/find/defs.h
+@@ -343,6 +343,9 @@
+ 
+ /* find library function declarations.  */
+ 
++/* xgetcwd.c */
++char *xgetcwd (void);
++
+ /* find global function declarations.  */
+ 
+ /* SymlinkOption represents the choice of
+--- a/find/exec.c
++++ b/find/exec.c
+@@ -277,6 +277,91 @@
+   return ok;
+ }
+ 
++#ifdef __MINGW32__
++
++/* More sensible spawnvp function: the library one requires arguments
++   with embedded special characters to be quoted.  */
++static char **
++quote_spawn_args (const char * const *argv)
++{
++  /* These characters should include anything that is special to _any_
++     program, including both Windows and Unixy shells.  */
++  const char need_quotes[] = " \t#;\"\'*?[]&|<>|(){}$`^";
++  int i = 0;
++  char **qargv;
++
++  while (argv[i])
++    i++;
++  qargv = malloc ((i + 1)*sizeof(argv[0]));
++
++  if (!qargv)
++    return NULL;
++  for (i = 0; argv[i]; i++)
++    {
++      if (strpbrk (argv[i], need_quotes))
++	{
++	  size_t len = strlen (argv[i]) + 3;
++	  const char *p = argv[i];
++	  char *q;
++
++	  for ( ; *p; p++)
++	    {
++	      if (*p == '\"')
++		len++;
++	    }
++	  qargv[i] = xmalloc (len);
++	  (qargv[i])[0] = '\"';
++	  for (p = argv[i], q = qargv[i] + 1; *p; p++)
++	    {
++	      if (*p == '\"')
++		*q++ = '\\';
++	      *q++ = *p;
++	    }
++	  memcpy (q, "\"", 2);
++	}
++      else
++	qargv[i] = strdup (argv[i]);
++#if 0
++      printf ("%d: `%s'\n", i, qargv[i]);
++#endif
++    }
++  qargv[i] = NULL;
++
++  return qargv;
++}
++
++static void
++free_args (char **args)
++{
++  if (args)
++    {
++      int i;
++
++      for (i = 0; args[i]; i++)
++	free (args[i]);
++      free (args);
++    }
++}
++
++int
++w32_spawnvp (int mode, const char *cmd, const char * const *argv)
++{
++  int ret;
++  char **qargv = quote_spawn_args (argv);
++
++  if (!qargv)
++    qargv = (char **)argv;
++#ifdef __MINGW64__
++  ret = spawnvp (mode, cmd, (char * const *)qargv);
++#else
++  ret = spawnvp (mode, cmd, (const char * const *)qargv);
++#endif
++
++  free_args (qargv);
++  return ret;
++}
++
++#endif	/* __MINGW32__ */
+ 
+ int
+ launch (struct buildcmd_control *ctl, void *usercontext, int argc, char **argv)
+@@ -309,9 +394,63 @@
+   if (first_time)
+     {
+       first_time = 0;
++#ifdef SIGCHLD
+       signal (SIGCHLD, SIG_DFL);
++#endif
+     }
++  
++#if defined(__MINGW32__) || defined(_MSC_VER) || defined(__MSDOS__)
++{
++  char *cwd;
++  int wait_ret = 0;
++  cwd = xgetcwd ();
+ 
++  assert (NULL != execp->wd_for_exec);
++  if (!prep_child_for_exec (execp->close_stdin, execp->wd_for_exec))
++    {
++      _exit (1);
++    }
++  else
++    {
++      if (fd_leak_check_is_enabled ())
++        {
++          complain_about_leaky_fds ();
++        }
++    }
++#ifdef __MSDOS__
++  child_pid = spawnvp (P_WAIT, argv[0], argv);
++  if (child_pid == -1)
++    error (0, errno, "%s", argv[0]);
++  execp->last_child_status |= (child_pid & 0xff);
++#else
++#ifdef __MINGW32__
++  child_pid = w32_spawnvp (_P_NOWAIT, argv[0],
++			   (const char * const *)argv);
++#else
++  child_pid = spawnvp (_P_NOWAIT, argv[0],
++		       (const char * const *)argv);
++#endif
++  if (child_pid == -1)
++    error (0, errno, "%s", argv[0]);
++  else
++    wait_ret = _cwait (&execp->last_child_status, child_pid, 0);
++  if (wait_ret == -1)
++    {
++      error (0, errno, _("error waiting for %s"), argv[0]);
++      state.exit_status = 1;
++      return 0;		/* FAIL */
++    }
++#endif
++  
++  if (chdir (cwd) < 0)
++    {
++      error (0, errno, "%s", cwd);
++      _exit (1);
++    }
++  if (cwd)
++	  free (cwd);
++}
++#else /* _WIN32 */
+   child_pid = fork ();
+   if (child_pid == -1)
+     die (EXIT_FAILURE, errno, _("cannot fork"));
+@@ -351,6 +490,7 @@
+ 	  return 0;		/* FAIL */
+ 	}
+     }
++#endif /* _WIN32 */ 
+ 
+   if (WIFSIGNALED (execp->last_child_status))
+     {
+--- a/xargs/xargs.c
++++ b/xargs/xargs.c
+@@ -1244,13 +1268,15 @@
+ 
+      We use 0 here in order to avoid generating a data structure that appears
+      to indicate that we (the child) have a child. */
++#if !defined(__MINGW32__) && !defined(_MSC_VER)
+   unsigned int slot = add_proc (0);
+   set_slot_var (slot);
++#endif
+ 
+   if (!keep_stdin || open_tty)
+     {
+       int fd;
+       const char *inputfile = open_tty ? "/dev/tty" : "/dev/null";
+ 
+       close (0);
+       if ((fd = open (inputfile, O_RDONLY)) < 0)
+@@ -1315,7 +1345,33 @@
+     {
+       if (!query_before_executing && print_command)
+ 	print_args (false);
+-
++#if defined(__MINGW32__) || defined(_MSC_VER) || defined(__MSDOS__)
++      {
++	char *cwd = xgetcwd ();
++	int e;
++	prep_child_for_exec();
++#ifdef __MSDOS__
++	child = spawnvp (P_WAIT, argv[0], argv);
++#else
++	while ((child = spawnvp (_P_NOWAIT, argv[0],
++# ifdef __MINGW64__
++				 (char * const *)argv)) < 0
++# else
++				 (const char * const *)argv)) < 0
++# endif
++	       && errno == ENOMEM && procs_executing)
++	  wait_for_proc (false, 1u);
++#endif
++	e = errno;	/* errno will be clobbered by wait_for_proc and chdir */
++	chdir (cwd);
++	if (cwd)
++	  free (cwd);
++	if (child == -1 && !(e == ENOENT || e == ENOEXEC))
++	  error (0, e, "%s", argv[0]);
++      }
++      add_proc (child);
++    }
++#else
+       /* Before forking, reap any already-exited child. We do this so
+ 	 that we don't leave unreaped children around while we build a
+ 	 new command line.  For example this command will spend most
+@@ -1458,6 +1515,7 @@
+ 	} /* switch on bytes read */
+       close (fd[0]);
+     }
++#endif
+   return 1;			/* Success */
+ }
+ 
+@@ -1512,12 +1570,45 @@
+ static void
+ wait_for_proc (bool all, unsigned int minreap)
+ {
++#if defined(__MSDOS__)
++  if (procs_executing)
++	procs_executing--;
++#else
+   unsigned int reaped = 0;
+ 
+   while (procs_executing)
+     {
+       unsigned int i;
+       int status;
++
++#if defined(__MINGW32__) || defined(_MSC_VER)
++      do
++	{
++	  for (i = 0; i < pids_alloc; i++)
++	    {
++	      DWORD waited, dstatus;
++
++	      if (!pids[i])
++		continue;
++	      if (pids[i] == -1) /* spawnvp failed */
++		{
++		  status = 127;	/* mimic Unixy shell */
++		  break;
++		}
++	      waited = WaitForSingleObject ((HANDLE)pids[i], 10UL);
++	      if (waited == WAIT_OBJECT_0) /* this process finished */
++		{
++		  GetExitCodeProcess ((HANDLE)pids[i], &dstatus);
++		  CloseHandle ((HANDLE)pids[i]);
++		  status = dstatus;
++		  break;
++		}
++	      else if (waited == WAIT_FAILED)
++		error (1, errno, _("error waiting for child process"));
++	    }
++	}
++      while (i == pids_alloc);	/* A child died that we didn't start? */    
++#else      
+       pid_t pid;
+       int wflags = 0;
+ 
+@@ -1589,7 +1680,8 @@
+ 	    }
+ 	  break;
+ 	}
+-
++#endif
++      
+       /* Remove the child from the list.  */
+       pids[i] = 0;
+       procs_executing--;
+@@ -1606,7 +1698,14 @@
+ 	       _("%s: terminated by signal %d"), bc_state.cmd_argv[0], WTERMSIG (status));
+       if (WEXITSTATUS (status) != 0)
+ 	child_error = XARGS_EXIT_CLIENT_EXIT_NONZERO;
++
++      
++#if defined(__MINGW32__) || defined(_MSC_VER)
++      if (!all)
++	break;
++#endif
+     }
++#endif
+ }
+ 
+ /* Wait for all child processes to finish.  */

--- a/mingw-w64-findutils/008-lib-regextype-rename-context-enum.patch
+++ b/mingw-w64-findutils/008-lib-regextype-rename-context-enum.patch
@@ -1,0 +1,47 @@
+--- a/lib/regextype.c
++++ b/lib/regextype.c
+@@ -49,15 +49,15 @@
+   {
+    { "findutils-default",     CONTEXT_FINDUTILS, RE_SYNTAX_EMACS|RE_DOT_NEWLINE  },
+    { "ed",                    CONTEXT_GENERIC,   RE_SYNTAX_ED                    },
+-   { "emacs",                 CONTEXT_ALL,       RE_SYNTAX_EMACS                 },
+-   { "gnu-awk",               CONTEXT_ALL,       RE_SYNTAX_GNU_AWK               },
+-   { "grep",                  CONTEXT_ALL,       RE_SYNTAX_GREP                  },
+-   { "posix-awk",             CONTEXT_ALL,       RE_SYNTAX_POSIX_AWK             },
+-   { "awk",                   CONTEXT_ALL,       RE_SYNTAX_AWK                   },
+-   { "posix-basic",           CONTEXT_ALL,       RE_SYNTAX_POSIX_BASIC           },
+-   { "posix-egrep",           CONTEXT_ALL,       RE_SYNTAX_POSIX_EGREP           },
+-   { "egrep",                 CONTEXT_ALL,       RE_SYNTAX_EGREP                 },
+-   { "posix-extended",        CONTEXT_ALL,       RE_SYNTAX_POSIX_EXTENDED        },
++   { "emacs",                 CONTEXT_FINDUTILS_OR_GENERIC,       RE_SYNTAX_EMACS                 },
++   { "gnu-awk",               CONTEXT_FINDUTILS_OR_GENERIC,       RE_SYNTAX_GNU_AWK               },
++   { "grep",                  CONTEXT_FINDUTILS_OR_GENERIC,       RE_SYNTAX_GREP                  },
++   { "posix-awk",             CONTEXT_FINDUTILS_OR_GENERIC,       RE_SYNTAX_POSIX_AWK             },
++   { "awk",                   CONTEXT_FINDUTILS_OR_GENERIC,       RE_SYNTAX_AWK                   },
++   { "posix-basic",           CONTEXT_FINDUTILS_OR_GENERIC,       RE_SYNTAX_POSIX_BASIC           },
++   { "posix-egrep",           CONTEXT_FINDUTILS_OR_GENERIC,       RE_SYNTAX_POSIX_EGREP           },
++   { "egrep",                 CONTEXT_FINDUTILS_OR_GENERIC,       RE_SYNTAX_EGREP                 },
++   { "posix-extended",        CONTEXT_FINDUTILS_OR_GENERIC,       RE_SYNTAX_POSIX_EXTENDED        },
+    { "posix-minimal-basic",   CONTEXT_GENERIC,   RE_SYNTAX_POSIX_MINIMAL_BASIC   },
+    { "sed",                   CONTEXT_GENERIC,   RE_SYNTAX_SED                   },
+    /*    ,{ "posix-common",   CONTEXT_GENERIC,  _RE_SYNTAX_POSIX_COMMON   } */
+--- a/lib/regextype.h
++++ b/lib/regextype.h
+@@ -29,7 +29,7 @@
+ enum {
+   CONTEXT_FINDUTILS = 1u,
+   CONTEXT_GENERIC   = 2u,
+-  CONTEXT_ALL = CONTEXT_GENERIC|CONTEXT_FINDUTILS,
++  CONTEXT_FINDUTILS_OR_GENERIC = CONTEXT_GENERIC|CONTEXT_FINDUTILS,
+ };
+ 
+ 
+@@ -52,7 +52,7 @@
+  */
+ int get_regex_type_synonym(unsigned int ix, unsigned int context);
+ 
+-/* Returns one of CONTEXT_FINDUTILS, CONTEXT_GENERIC or CONTEXT_ALL.
++/* Returns one of CONTEXT_FINDUTILS, CONTEXT_GENERIC or CONTEXT_FINDUTILS_OR_GENERIC.
+  * This identifies whether this regular expression type index is relevant for,
+  * respectively, findutils, general callers, or all callers.
+  */

--- a/mingw-w64-findutils/009-lib-fdleak-disable-check.patch
+++ b/mingw-w64-findutils/009-lib-fdleak-disable-check.patch
@@ -1,0 +1,17 @@
+--- a/lib/fdleak.c
++++ b/lib/fdleak.c
+@@ -390,6 +396,7 @@
+   int no_leaks = 1;
+   const int leaking_fd = find_first_leaked_fd (non_cloexec_fds, num_cloexec_fds);
+ 
++#if !defined(__MINGW32__) && !defined(_MSC_VER)
+   if (leaking_fd >= 0)
+     {
+       no_leaks = 0;
+@@ -399,5 +406,6 @@
+ 	       "way to reproduce this problem."),
+ 	     leaking_fd);
+     }
++#endif
+   assert (no_leaks);
+ }

--- a/mingw-w64-findutils/010-find-util-fix-get-statinfo.patch
+++ b/mingw-w64-findutils/010-find-util-fix-get-statinfo.patch
@@ -1,0 +1,57 @@
+--- a/find/util.c
++++ b/find/util.c
+@@ -67,6 +67,9 @@
+   };
+ #define N_DEBUGASSOC (sizeof(debugassoc)/sizeof(debugassoc[0]))
+ 
++#ifdef __MINGW32__
++static int w32_symlink_p (const char *);
++#endif
+ 
+ 
+ 
+@@ -263,6 +266,12 @@
+ 	}
+       else
+ 	{
++#if defined(__MINGW32__) || defined(_MSC_VER)
++      if (errno == ENOENT
++	  && ((pathname && strlen (pathname) > FILENAME_MAX)
++	      || (name && strlen (name) > FILENAME_MAX)))
++	errno = ENAMETOOLONG;
++#endif    
+ 	  if (!options.ignore_readdir_race || (errno != ENOENT) )
+ 	    {
+ 	      nonfatal_target_file_error (errno, pathname);
+@@ -272,6 +281,12 @@
+     }
+   state.have_stat = true;
+   state.have_type = true;
++#if defined(__MINGW32__) || defined(_MSC_VER)
++  /* Don't treat NTFS symlinks to directories as directories, because
++     we lack the machinery to detect possible infinite loops.  */
++  if (S_ISDIR (p->st_mode) && w32_symlink_p (name))
++    p->st_mode &= ~(_S_IFDIR);
++#endif
+   state.type = p->st_mode;
+ 
+   return 0;
+@@ -1174,3 +1189,17 @@
+   /*NOTREACHED*/
+   abort ();
+ }
++
++#if defined(__MINGW32__) || defined(_MSC_VER)
++#define WIN32_LEAN_AND_MEAN
++#include <windows.h>
++
++static int
++w32_symlink_p (const char *fn)
++{
++  DWORD attrs = GetFileAttributes (fn);
++
++  return (attrs != (DWORD)-1 && (attrs & 0x400) != 0);
++}
++
++#endif
+

--- a/mingw-w64-findutils/011-find-parser-fix-defines.patch
+++ b/mingw-w64-findutils/011-find-parser-fix-defines.patch
@@ -1,0 +1,15 @@
+--- a/find/parser.c
++++ b/find/parser.c
+@@ -71,10 +73,10 @@
+ 
+ 
+ #ifndef HAVE_ENDGRENT
+-# define endgrent ()
++# define endgrent()
+ #endif
+ #ifndef HAVE_ENDPWENT
+-# define endpwent ()
++# define endpwent()
+ #endif
+ 
+ static bool parse_accesscheck   (const struct parser_table*, char *argv[], int *arg_ptr);

--- a/mingw-w64-findutils/012-find-parser-fix-path-safety.patch
+++ b/mingw-w64-findutils/012-find-parser-fix-path-safety.patch
@@ -1,0 +1,27 @@
+--- a/find/parser.c
++++ b/find/parser.c
+@@ -2836,7 +2838,11 @@
+ check_path_safety (const char *action)
+ {
+   const char *path = getenv ("PATH");
+-  const char *path_separators = ":";
++#if defined(__MINGW32__) || defined(_MSC_VER)
++  const char *path_separators = ";";
++#else
++  const char *path_separators = ":";  
++#endif
+   size_t pos, len;
+ 
+   if (NULL == path)
+@@ -2864,7 +2870,11 @@
+ 		 "or leading or trailing colons)"),
+ 	       action);
+ 	}
++#if defined(__MINGW32__) || defined(_MSC_VER)     
++      else if (path[pos+1] != ':')
++#else
+       else if (path[pos] != '/')
++#endif
+ 	{
+ 	  char *relpath = strndup (&path[pos], len);
+ 	  die (EXIT_FAILURE, 0,

--- a/mingw-w64-findutils/013-find-print-fix-time-format.patch
+++ b/mingw-w64-findutils/013-find-print-fix-time-format.patch
@@ -1,0 +1,28 @@
+--- a/find/print.c
++++ b/find/print.c
+@@ -511,8 +513,10 @@
+       buf_size = 1u;
+       buf = xmalloc (buf_size);
+     }
++#if !defined(__MINGW32__) || defined(_UCRT)
+   while (true)
+     {
++#endif      
+       /* I'm not sure that Solaris will return 0 when the buffer is too small.
+        * Therefore we do not check for (buf_used != 0) as the termination
+        * condition.
+@@ -567,9 +571,14 @@
+         }
+       else
+         {
++#if defined(__MINGW32__) && !defined(_UCRT)
++          return 0;
++        }
++#else
+           buf = x2nrealloc (buf, &buf_size, sizeof *buf);
+         }
+     }
++#endif      
+ }
+ 
+ /* Return a static string formatting the time WHEN according to the

--- a/mingw-w64-findutils/014-locate-skip-privs.patch
+++ b/mingw-w64-findutils/014-locate-skip-privs.patch
@@ -1,0 +1,18 @@
+--- a/locate/locate.c
++++ b/locate/locate.c
+@@ -1440,6 +1462,7 @@
+ static int
+ drop_privs (void)
+ {
++#if !defined(__MINGW32__) && !defined(_MSC_VER)
+   const char * what = "failed";
+   const uid_t orig_euid = geteuid ();
+   const uid_t uid       = getuid ();
+@@ -1523,6 +1546,7 @@
+     {
+       /* deliberate infinite loop */
+     }
++#endif
+ }
+ 
+ static int

--- a/mingw-w64-findutils/015-xargs-fix-tty-streams.patch
+++ b/mingw-w64-findutils/015-xargs-fix-tty-streams.patch
@@ -1,0 +1,28 @@
+--- a/xargs/xargs.c
++++ b/xargs/xargs.c
+@@ -1173,7 +1173,11 @@
+ 
+       if (!tty_stream)
+ 	{
++#if defined(__MINGW32__) || defined(_MSC_VER)
++	  tty_stream = fopen_cloexec_for_read_only ("CON");
++#else
+ 	  tty_stream = fopen_cloexec_for_read_only ("/dev/tty");
++#endif
+ 	  if (!tty_stream)
+ 	    die (EXIT_FAILURE, errno,
+ 		 _("failed to open /dev/tty for reading"));
+@@ -1252,8 +1256,12 @@
+   if (!keep_stdin || open_tty)
+     {
+       int fd;
++#if defined(__MINGW32__) || defined(_MSC_VER)
++      const char *inputfile = open_tty ? "CON" : "NUL";
++#else
+       const char *inputfile = open_tty ? "/dev/tty" : "/dev/null";
+-
++#endif
++      
+       close (0);
+       if ((fd = open (inputfile, O_RDONLY)) < 0)
+ 	{

--- a/mingw-w64-findutils/016-fix-clang-linking.patch
+++ b/mingw-w64-findutils/016-fix-clang-linking.patch
@@ -1,0 +1,43 @@
+--- a/gnulib-tests/Makefile.am
++++ b/gnulib-tests/Makefile.am
+@@ -1093,7 +1093,7 @@
+ ## begin gnulib module localcharset-tests
+ 
+ noinst_PROGRAMS += test-localcharset
+-test_localcharset_LDADD = $(LDADD) $(LIB_SETLOCALE)
++test_localcharset_LDADD = $(LDADD) $(LIB_SETLOCALE) -lwinpthread
+ EXTRA_DIST += test-localcharset.c
+ 
+ ## end   gnulib module localcharset-tests
+--- a/find/Makefile.am
++++ b/find/Makefile.am
+@@ -26,6 +26,8 @@
+ find_SOURCES     = ftsfind.c
+ man_MANS         = find.1
+ 
++find_LDFLAGS     = -pthread
++
+ EXTRA_DIST = defs.h sharefile.h print.h $(man_MANS)
+ AM_CPPFLAGS = -I../gl/lib -I$(top_srcdir)/lib -I$(top_srcdir)/gl/lib -DLOCALEDIR=\"$(localedir)\"
+ LDADD = libfindtools.a ../lib/libfind.a ../gl/lib/libgnulib.a $(LIBINTL) $(LIB_CLOCK_GETTIME) $(LIB_EACCESS) $(LIB_SELINUX) $(LIB_CLOSE) $(MODF_LIBM) $(FINDLIBS) $(GETHOSTNAME_LIB) $(LIB_EACCESS) $(LIB_SETLOCALE_NULL) $(LIB_MBRTOWC)
+--- a/locate/Makefile.am
++++ b/locate/Makefile.am
+@@ -33,6 +33,8 @@
+ locate_SOURCES = locate.c word_io.c
+ nodist_locate_TEXINFOS = dblocation.texi
+ 
++locate_LDFLAGS = -pthread
++
+ AM_CPPFLAGS = -I$(top_srcdir)/lib -I../gl/lib -I$(top_srcdir)/gl/lib -DLOCATE_DB=\"$(LOCATE_DB)\" -DLOCALEDIR=\"$(localedir)\"
+ 
+ LDADD = ../lib/libfind.a ../gl/lib/libgnulib.a $(LIB_CLOSE) $(LIBINTL) $(LIB_SETLOCALE_NULL) $(LIB_MBRTOWC)
+--- a/xargs/Makefile.am
++++ b/xargs/Makefile.am
+@@ -18,6 +18,7 @@
+ localedir = $(datadir)/locale
+ bin_PROGRAMS = xargs
+ man_MANS = xargs.1
++xargs_LDFLAGS = -pthread
+ AM_CPPFLAGS = -I.. -I../gl/lib -I$(top_srcdir)/gl/lib -I$(top_srcdir)/lib -DLOCALEDIR=\"$(localedir)\"
+ LDADD = ../lib/libfind.a ../gl/lib/libgnulib.a $(LIB_CLOSE) $(LIBINTL) $(LIB_SETLOCALE_NULL) $(LIB_MBRTOWC) $(LIB_POLL)
+ EXTRA_DIST = $(man_MANS)

--- a/mingw-w64-findutils/PKGBUILD
+++ b/mingw-w64-findutils/PKGBUILD
@@ -78,11 +78,19 @@ build() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
   export gl_cv_have_weak=no
+  
+  if [[ "${MSYSTEM}" == "MINGW32" ]]; then
+      YEAR_2038="--disable-year2038"
+  else         
+      YEAR_2038=
+  fi
+
   ./configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
-    --target=${MINGW_CHOST}
+    --target=${MINGW_CHOST} \
+    $YEAR_2038
 
   make
 }

--- a/mingw-w64-findutils/PKGBUILD
+++ b/mingw-w64-findutils/PKGBUILD
@@ -1,0 +1,98 @@
+# Maintainer: Cyril Arnould <cyril.arnould@outlook.com>
+
+_realname=findutils
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=4.9.0
+pkgrel=1
+pkgdesc="GNU utilities to locate files"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+license=('GPL3')
+depends=("${MINGW_PACKAGE_PREFIX}-gettext"
+         "${MINGW_PACKAGE_PREFIX}-libiconv"
+         "${MINGW_PACKAGE_PREFIX}-libwinpthread-git")
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-gcc")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-diffutils")
+url="https://www.gnu.org/software/findutils"
+source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.xz"{,.sig}
+        "001-add-gnulib-modules.patch"               
+        "002-configure-allow-mountlist.patch"        
+        "003-replace-grp-pwd.patch"                  
+        "004-define-limits.patch"                    
+        "005-skip-undefined-symbols.patch"                 
+        "006-disable-globbing.patch"                 
+        "007-replace-fork.patch"                
+        "008-lib-regextype-rename-context-enum.patch"
+        "009-lib-fdleak-disable-check.patch"         
+        "010-find-util-fix-get-statinfo.patch"       
+        "011-find-parser-fix-defines.patch"          
+        "012-find-parser-fix-path-safety.patch"          
+        "013-find-print-fix-time-format.patch"          
+        "014-locate-skip-privs.patch"          
+        "015-xargs-fix-tty-streams.patch"          
+        "016-fix-clang-linking.patch")
+sha256sums=('a2bfb8c09d436770edc59f50fa483e785b161a3b7b9d547573cb08065fd462fe'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP')
+validpgpkeys=('A5189DB69C1164D33002936646502EF796917195')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -Np1 -i "${srcdir}/001-add-gnulib-modules.patch"               
+  patch -Np1 -i "${srcdir}/002-configure-allow-mountlist.patch"        
+  patch -Np1 -i "${srcdir}/003-replace-grp-pwd.patch"                  
+  patch -Np1 -i "${srcdir}/004-define-limits.patch"                    
+  patch -Np1 -i "${srcdir}/005-skip-undefined-symbols.patch"                 
+  patch -Np1 -i "${srcdir}/006-disable-globbing.patch"                 
+  patch -Np1 -i "${srcdir}/007-replace-fork.patch"                
+  patch -Np1 -i "${srcdir}/008-lib-regextype-rename-context-enum.patch"
+  patch -Np1 -i "${srcdir}/009-lib-fdleak-disable-check.patch"         
+  patch -Np1 -i "${srcdir}/010-find-util-fix-get-statinfo.patch"       
+  patch -Np1 -i "${srcdir}/011-find-parser-fix-defines.patch"          
+  patch -Np1 -i "${srcdir}/012-find-parser-fix-path-safety.patch"          
+  patch -Np1 -i "${srcdir}/013-find-print-fix-time-format.patch"          
+  patch -Np1 -i "${srcdir}/014-locate-skip-privs.patch"          
+  patch -Np1 -i "${srcdir}/015-xargs-fix-tty-streams.patch"          
+  patch -Np1 -i "${srcdir}/016-fix-clang-linking.patch"
+  autoreconf -fi  
+}
+
+build() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  export gl_cv_have_weak=no
+  ./configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST}
+
+  make
+}
+
+check() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  make check
+}
+
+package() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  make DESTDIR=${pkgdir} install
+}


### PR DESCRIPTION
Patch 001 adds the poll and windows-stat-inodes gnulib modules. The poll module provides the poll functionality that is absent on mingw. windows-stat-inodes ensures the -inum option of find is working properly. The modules have been taken from the same gnulib commit that is linked in the findutils 4.9.0 release (v0.1-5153-g6ef3d78333).

Patch 002 modifies the configure script to allow using the mountlist module on mingw. The code doesn't compile without it but it also doesn't seem broken. The mountlist module also specifies that using the header is fine on unsupported systems.

Patches 003, 004, 006, 007, 010 and 015 have been adapted from Eli Zaretskii's ezwinports:

https://sourceforge.net/projects/ezwinports/files

Patches 005, 009, 013 and 014 disable features that had not been implemented yet in the 4.2.30 findutils release that ezwinports is based on. I also don't know how I'd implement them; they are all based on functionality that is not available on mingw as far as I can tell.

Patches 008 and 011 are fairly straightforward compilation error fixes.

Patch 009 tries to address the differences in how the PATH environment variable is separated on Windows.

Patch 016 fixes linking on clang builds.

Note that not all of the tests pass. I could provide patches for some of them if this is preferable, but for others I think there's no use case on Windows. I keep a write-up here:

https://github.com/cyrilarnould/findutils/blob/2ccb0be2c1c70d791f051d24b9dba73e64bdb446/README-mingw