### PR TITLE
[DRAFT] rust: update to pre-release 1.69.0

### DIFF
--- a/mingw-w64-rust/0007-clang-subsystem.patch
+++ b/mingw-w64-rust/0007-clang-subsystem.patch
@@ -149,7 +149,7 @@ diff -urN rustc-1.65.0-src.orig/src/bootstrap/bootstrap.py rustc-1.65.0-src/src/
                  rust_stamp.write(key)
  
 +            gcc_libs_hack = os.environ.get('GCC_LIBS_HACK')
-+            gcc_libs_hack_dest = '{}/rustlib/{}/lib'.format(lib_dir, self.build)
++            gcc_libs_hack_dest = '{}/lib/rustlib/{}/lib'.format(bin_root, self.build)
 +            shutil.copy(gcc_libs_hack + '/libgcc.a', gcc_libs_hack_dest)
 +            shutil.copy(gcc_libs_hack + '/libgcc_eh.a', gcc_libs_hack_dest)
 +            shutil.copy(gcc_libs_hack + '/libgcc_s.a', gcc_libs_hack_dest)

--- a/mingw-w64-rust/0012-revert-install-llvm-tools.patch
+++ b/mingw-w64-rust/0012-revert-install-llvm-tools.patch
@@ -1,13 +1,13 @@
---- rustc-1.68.0-src/src/bootstrap/builder.rs.orig      2023-03-10 00:18:09.133777400 +0100
-+++ rustc-1.68.0-src/src/bootstrap/builder.rs   2023-03-10 00:20:20.432594200 +0100
+--- rustc-1.69.0-src/src/bootstrap/builder.rs.orig      2023-04-18 21:29:21.272202100 +0200
++++ rustc-1.69.0-src/src/bootstrap/builder.rs   2023-04-18 21:48:36.051349700 +0200
 @@ -779,7 +779,6 @@
                  install::RustDemangler,
                  install::Clippy,
                  install::Miri,
 -                install::LlvmTools,
-                 install::Analysis,
                  install::Src,
                  install::Rustc
+             ),
 --- rustc-1.68.0-src/src/bootstrap/install.rs.orig	2023-03-09 23:19:26.790173000 +0100
 +++ rustc-1.68.0-src/src/bootstrap/install.rs	2023-03-09 23:28:09.326654400 +0100
 @@ -209,12 +209,6 @@

--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -11,7 +11,7 @@ fi
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-rust-docs")
-pkgver=1.68.2
+pkgver=1.69.0
 pkgrel=1
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
@@ -33,7 +33,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
 options=('staticlibs' 'strip')
 #install=rust.install
 noextract=(${_realname}c-${pkgver}-src.tar.gz)
-source=("https://static.rust-lang.org/dist/${_realname}c-${pkgver}-src.tar.gz"{,.asc}
+#source=("https://static.rust-lang.org/dist/${_realname}c-${pkgver}-src.tar.gz"{,.asc}
+source=("https://dev-static.rust-lang.org/dist/2023-04-17/${_realname}c-${pkgver}-src.tar.gz"{,.asc}
         "0001-rustc-llvm-fix-libs.patch"
         "0004-unbundle-gcc.patch"
         "0005-win32-config.patch"
@@ -41,15 +42,15 @@ source=("https://static.rust-lang.org/dist/${_realname}c-${pkgver}-src.tar.gz"{,
         "0008-disable-self-contained.patch"
         "0011-disable-uac-for-installer.patch"
         "0012-revert-install-llvm-tools.patch")
-sha256sums=('93339c23f7cd4d0c45db58e18b4c6e16d6070f4277aad9d2492d23294bf32e96'
+sha256sums=('fb05971867ad6ccabbd3720279f5a94b99f61024923187b56bb5c455fa3cf60f'
             'SKIP'
             '7cb1773c288ffb1c1e751edc49b1890c84bf9c362742bc5225d19d474edb73a0'
             '36c531c73a2c12b3e66aa22526a404c3f770f1ab7e0e76c55af6fcc1a17e46fe'
             'c4e5ffeef84296d39c3e3e8f807fc8b33ce786b1e4edb21eef26b053586aca27'
-            '0784c4cb3d205ff233e61c89ce2a298b7ad2f68234b13854612d83e085fed569'
+            '4af633d35e034fc2ea080b3df0f1c66c5cb31ec590c3e59dd7dddfe21faa2764'
             'a214cd8394ab7416fd170c7fa05daf701a5357d38e4e54149370e6efff208e50'
             'e72ee077cd62bfc24c592a12ca27242d24ee14237d414c7e8fc4004bf8b031b8'
-            '7122afd200518a39e4ff84cd6366bebd0e432970bb0215bdf669c7088df70794')
+            'fc14094d0a0fde559be647fd9063260592378ac38d88a640b24ee85a1400be0c')
 validpgpkeys=('108F66205EAEB0AAA8DD5E1C85AB96E6FA1BE5FE'  # Rust Language (Tag and Release Signing Key) <rust-key@rust-lang.org>
               '474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard <tstellar@redhat.com>
               'B6C8F98282B944E3B0D5C2530FC3042E345AD05D') # Hans Wennborg <hans@chromium.org>


### PR DESCRIPTION
see https://blog.rust-lang.org/inside-rust/2023/04/17/1.69.0-prerelease.html