### PR TITLE
clang: fix Any linker error with multiple compilers

### DIFF
--- a/mingw-w64-clang/0005-Fix-Any-linker-error-with-multiple-compilers.patch
+++ b/mingw-w64-clang/0005-Fix-Any-linker-error-with-multiple-compilers.patch
@@ -1,0 +1,11 @@
+--- a/include/llvm/ADT/Any.h
++++ b/include/llvm/ADT/Any.h
+@@ -124,7 +124,7 @@
+   std::unique_ptr<StorageBase> Storage;
+ };
+ 
+-template <typename T> char Any::TypeId<T>::Id = 0;
++template <typename T> char Any::TypeId<T>::Id = 1;
+ 
+ template <typename T>
+ LLVM_DEPRECATED("Use any_cast(Any*) != nullptr instead", "any_cast")

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -26,7 +26,7 @@ _version=16.0.1
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
-pkgrel=1
+pkgrel=2
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -62,6 +62,7 @@ source=("${_url}/llvm-${pkgver}.src.tar.xz"{,.sig}
         "0002-Revert-CMake-try-creating-symlink-first-on-windows.patch"
         "0003-add-pthread-as-system-lib-for-mingw.patch"
         "0004-enable-emutls-for-mingw.patch"
+        "0005-Fix-Any-linker-error-with-multiple-compilers.patch"
         "0101-link-pthread-with-mingw.patch"
         "0102-Rename-flang-new-flang-experimental-exec-to-flang.patch"
         "0303-ignore-new-bfd-options.patch")
@@ -89,6 +90,7 @@ sha256sums=('17d2142be9ff75c31ad76c53af7409974842545b94aaeac17f38b3b8567b0582'
             '5754c357cfc17769e80d95b673d41b1e54616e2487e037d761a1ac8bb28a2849'
             '7f0c64cd87b61e894be632f180ae5291e1aa9f1d9d382608f659067eeeda7146'
             'ef2ae12a4d6ac7a52d38bb305818b26c830ae42d14468e4b1913157d998b2137'
+            '294756995c1d528f9b5d4b64559edfee151ce0a06bd863a2cafce58a82ce53fd'
             '715cb8862753854b2d9256e0b70003e2d1f57083d83eaeaf5a095fc72b8a4e26'
             'd4b6d171f3fd878b7a21043824c0477235c7acb6a73115a337295724ff8b0d1c'
             'de631ab199a6fe83b3f695350bffaad067a2f95fc2ba9c8fe57dc85665d3653c')
@@ -127,7 +129,8 @@ prepare() {
   cd "${srcdir}/llvm"
   apply_patch_with_msg \
     "0001-Fix-GetHostTriple-for-mingw-w64-in-msys.patch" \
-    "0002-Revert-CMake-try-creating-symlink-first-on-windows.patch"
+    "0002-Revert-CMake-try-creating-symlink-first-on-windows.patch" \
+    "0005-Fix-Any-linker-error-with-multiple-compilers.patch"
 
   if (( ! _clangprefix )); then
     apply_patch_with_msg \

--- a/mingw-w64-clang/README-patches.md
+++ b/mingw-w64-clang/README-patches.md
@@ -14,6 +14,7 @@ Legend:
 - `"0002-Revert-CMake-try-creating-symlink-first-on-windows.patch"` :x: (win symlinks don't play well with pacman packages)
 - `"0003-add-pthread-as-system-lib-for-mingw.patch"` :grey_exclamation:
 - `"0004-enable-emutls-for-mingw.patch"` :grey_exclamation:
+- `"0005-Fix-Any-linker-error-with-multiple-compilers.patch"` :grey_question:
 - `"0101-link-pthread-with-mingw.patch"` :grey_exclamation:
 - `"0301-Add-exceptions-for-Flang-runtime-libraries-on-MinGW.patch"` :upstreamed:
 - `"0303-ignore-new-bfd-options.patch"` :x:


### PR DESCRIPTION
reverts this change: https://github.com/llvm/llvm-project/commit/95b27b2a1e0e9fe0781ec76015b4016b9d04423d

fixes the Rust build, see https://github.com/msys2/MINGW-packages/pull/16847