### PR TITLE
python-numpy: fix previous patch breaking 32-bit

### DIFF
--- a/mingw-w64-python-numpy/0013-fix-4GiB-fwrites.patch
+++ b/mingw-w64-python-numpy/0013-fix-4GiB-fwrites.patch
@@ -2,13 +2,12 @@ diff --git a/numpy/core/src/multiarray/convert.c b/numpy/core/src/multiarray/con
 index 9e0c9fb..57fcbd5 100644
 --- a/numpy/core/src/multiarray/convert.c
 +++ b/numpy/core/src/multiarray/convert.c
-@@ -156,7 +156,8 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
+@@ -156,7 +156,7 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
              size = PyArray_SIZE(self);
              NPY_BEGIN_ALLOW_THREADS;
  
 -#if defined (_MSC_VER) && defined(_WIN64)
-+#if defined(_MSC_VER) && defined(_WIN64) || \
-+    defined(__MINGW32__) || defined(__MINGW64__)
++#if defined(_WIN64)
              /* Workaround Win64 fwrite() bug. Ticket #1660 */
              {
                  npy_intp maxsize = 2147483648 / PyArray_DESCR(self)->elsize;

--- a/mingw-w64-python-numpy/PKGBUILD
+++ b/mingw-w64-python-numpy/PKGBUILD
@@ -9,7 +9,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=1.24.2
-pkgrel=2
+pkgrel=3
 pkgdesc="Scientific tools for Python (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -46,7 +46,7 @@ sha256sums=('003a9f530e880cb2cd177cba1af7220b9aa42def9c4afc2a2fc3ee6be7eb2b22'
             'c7222c3cd85ff6af515514c5c3b8f3c02144c58c1373dec16683fa455504aa69'
             '87bdd0a47a8662bdb8acaca18452901ee1f42cf08b985443ffb214f7facfdb2d'
             'e21b48037928d797f46289439116d3585d697de2c58d51119873b47ee5410a92'
-            '5eb2ee50b131c0ca6972c6c93836aaf810a5ce08a8563794682b05c391ab3c07')
+            '914376cbf9f4474fd0b49e720a57f22460329c5461f7b35edfb8b07f376e7c53')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {


### PR DESCRIPTION
Whoops! My temporary patch in #16553 broke 32-bit, where `numpy->tofile()` could not write any array of bytes. This update applies to 64-bit only (including UCRT variants), pending upstream changes.