### PR TITLE
qt-creator: rebuild against Qt 6.5.0

### DIFF
--- a/mingw-w64-qt-creator/PKGBUILD
+++ b/mingw-w64-qt-creator/PKGBUILD
@@ -8,7 +8,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-devel")
 _base_ver=10.0.0
 pkgver=${_base_ver/-/}
-pkgrel=2
+pkgrel=3
 pkgdesc='Lightweight, cross-platform integrated development environment (mingw-w64)'
 url='https://www.qt.io/'
 install=qt-creator-${MSYSTEM}.install
@@ -31,12 +31,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-qt6-doc"
              "${MINGW_PACKAGE_PREFIX}-qt6-quicktimeline"
              "${MINGW_PACKAGE_PREFIX}-yaml-cpp")
-#options=('debug' '!strip')
 _pkgfqn="${_realname}-opensource-src-${_base_ver}"
 source=(https://download.qt.io/official_releases/qtcreator/${_base_ver%.*}/${_base_ver}/${_pkgfqn}.tar.xz
         qt-creator-3.2.0-Allow-iOS-plugin-on-any-platform.patch
         qt-creator-5.0.1-fix-library-archive-path.patch)
-# noextract=(${_pkgfqn}.tar.xz)
 sha256sums=('9489829de05893a4628b7b6581af096c48afbd31c932cd8a4db30a90c52197bf'
             '6166817edb9055b98e53f644a41f28a1dbbfc3743931776852753212eee639c3'
             '29d67f88f071abe7a4b589182767b8a697fe4e516d70707bfca88f035883718f')
@@ -50,9 +48,6 @@ apply_patch_with_msg() {
 }
 
 prepare() {
-  # [[ -d ${srcdir}/${_pkgfqn} ]] && rm -rf ${srcdir}/${_pkgfqn}
-  # tar -xJf ${srcdir}/${_pkgfqn}.tar.xz -C "${srcdir}" || true
-
   cd ${srcdir}/${_pkgfqn}
 
   apply_patch_with_msg \


### PR DESCRIPTION
It fixes creating new projects and splitting windows.
fixes #16646 