### PR TITLE
Add gst-plugins-rs

### DIFF
--- a/mingw-w64-gst-plugins-rs/PKGBUILD
+++ b/mingw-w64-gst-plugins-rs/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgdesc='GStreamer plugins written in Rust (mingw-w64)' 
 url="https://gitlab.freedesktop.org/gstreamer/$_realname"
-pkgver=0.10.6
+pkgver=0.10.5
 pkgrel=1
 license=('spdx:LGPL-3.0-or-later'
          'spdx:Apache-2.0'
@@ -22,7 +22,7 @@ makedepends=(${MINGW_PACKAGE_PREFIX}-meson
              ${MINGW_PACKAGE_PREFIX}-cargo-c
              ${MINGW_PACKAGE_PREFIX}-python-tomli)
 source=("$url/-/archive/$pkgver/$_realname-$pkgver.tar.bz2")
-sha256sums=('90af993b28f050e2d682582ca1bde440665e75a5fbaec6577cafc609e24f2d92')
+sha256sums=('1d06924fcb25602fa616ffc37457039650f77f24273b61c370feaf76eece3b09')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 arch=(any)
 

--- a/mingw-w64-gst-plugins-rs/PKGBUILD
+++ b/mingw-w64-gst-plugins-rs/PKGBUILD
@@ -1,0 +1,47 @@
+# Maintainer: Mazhar Hussain <realmazharhussain@gmail.com>
+
+_realname=gst-plugins-rs
+pkgbase=mingw-w64-${_realname}
+pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
+pkgdesc='GStreamer plugins written in Rust (mingw-w64)' 
+url="https://gitlab.freedesktop.org/gstreamer/$_realname"
+pkgver=0.10.6
+pkgrel=1
+license=('spdx:LGPL-3.0-or-later'
+         'spdx:Apache-2.0'
+         'spdx:MIT'
+         'spdx:MPL-2.0')
+depends=(${MINGW_PACKAGE_PREFIX}-gtk4
+         ${MINGW_PACKAGE_PREFIX}-libsodium
+         ${MINGW_PACKAGE_PREFIX}-gstreamer
+         ${MINGW_PACKAGE_PREFIX}-dav1d
+         ${MINGW_PACKAGE_PREFIX}-libwebp)
+makedepends=(${MINGW_PACKAGE_PREFIX}-meson
+             ${MINGW_PACKAGE_PREFIX}-rust
+             ${MINGW_PACKAGE_PREFIX}-cargo-c
+             ${MINGW_PACKAGE_PREFIX}-python-tomli)
+source=("$url/-/archive/$pkgver/$_realname-$pkgver.tar.bz2")
+sha256sums=('90af993b28f050e2d682582ca1bde440665e75a5fbaec6577cafc609e24f2d92')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+arch=(any)
+
+build() {
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+  "${MINGW_PREFIX}"/bin/meson setup \
+    --prefix="${MINGW_PREFIX}" \
+    --auto-features=enabled \
+    -D doc=disabled \
+    $_realname-$pkgver \
+    build-${MSYSTEM}
+
+  meson compile -C build-${MSYSTEM}
+}
+
+check() {
+  meson test -C build-${MSYSTEM}
+}
+
+package() {
+  meson install -C build-${MSYSTEM} --destdir="$pkgdir"
+  install -Dm644 $_realname-$pkgver/LICENSE* -t "$pkgdir/$MINGW_PREFIX"/share/licenses/$_realname/
+}

--- a/mingw-w64-gst-plugins-rs/PKGBUILD
+++ b/mingw-w64-gst-plugins-rs/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgdesc='GStreamer plugins written in Rust (mingw-w64)' 
 url="https://gitlab.freedesktop.org/gstreamer/$_realname"
-pkgver=gstreamer-1.22.2
+pkgver=gstreamer+1.22.2
 pkgrel=1
 license=('spdx:LGPL-3.0-or-later'
          'spdx:Apache-2.0'

--- a/mingw-w64-gst-plugins-rs/PKGBUILD
+++ b/mingw-w64-gst-plugins-rs/PKGBUILD
@@ -36,6 +36,8 @@ build() {
     -D audiofx=disabled \
     $_realname-$_version \
     build-${MSYSTEM}
+
+  meson compile -C build-${MSYSTEM}
 }
 
 check() {

--- a/mingw-w64-gst-plugins-rs/PKGBUILD
+++ b/mingw-w64-gst-plugins-rs/PKGBUILD
@@ -6,6 +6,7 @@ pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgdesc='GStreamer plugins written in Rust (mingw-w64)' 
 url="https://gitlab.freedesktop.org/gstreamer/$_realname"
 pkgver=gstreamer+1.22.2
+_version=${pkgver/+/-}
 pkgrel=1
 license=('spdx:LGPL-3.0-or-later'
          'spdx:Apache-2.0'
@@ -21,7 +22,7 @@ makedepends=(${MINGW_PACKAGE_PREFIX}-meson
              ${MINGW_PACKAGE_PREFIX}-rust
              ${MINGW_PACKAGE_PREFIX}-cargo-c
              ${MINGW_PACKAGE_PREFIX}-python-tomli)
-source=("$url/-/archive/$pkgver/$_realname-$pkgver.tar.bz2")
+source=("$url/-/archive/$_version/$_realname-$_version.tar.bz2")
 sha256sums=('42ba4fa5ce3fa32eba198cd4fceb08f5c45b33867f0f11289b2603c04018c589')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 arch=(any)
@@ -32,7 +33,7 @@ build() {
     --prefix="${MINGW_PREFIX}" \
     --auto-features=enabled \
     -D doc=disabled \
-    $_realname-$pkgver \
+    $_realname-$_version \
     build-${MSYSTEM}
 }
 
@@ -42,5 +43,5 @@ check() {
 
 package() {
   meson install -C build-${MSYSTEM} --destdir="$pkgdir"
-  install -Dm644 $_realname-$pkgver/LICENSE* -t "$pkgdir/$MINGW_PREFIX"/share/licenses/$_realname/
+  install -Dm644 $_realname-$_version/LICENSE* -t "$pkgdir/$MINGW_PREFIX"/share/licenses/$_realname/
 }

--- a/mingw-w64-gst-plugins-rs/PKGBUILD
+++ b/mingw-w64-gst-plugins-rs/PKGBUILD
@@ -5,8 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgdesc='GStreamer plugins written in Rust (mingw-w64)' 
 url="https://gitlab.freedesktop.org/gstreamer/$_realname"
-pkgver=gstreamer+1.22.2
-_version=${pkgver/+/-}
+pkgver=0.10.6
 pkgrel=1
 license=('spdx:LGPL-3.0-or-later'
          'spdx:Apache-2.0'
@@ -23,7 +22,7 @@ makedepends=(${MINGW_PACKAGE_PREFIX}-meson
              ${MINGW_PACKAGE_PREFIX}-cargo-c
              ${MINGW_PACKAGE_PREFIX}-python-tomli)
 source=("$url/-/archive/$_version/$_realname-$_version.tar.bz2")
-sha256sums=('42ba4fa5ce3fa32eba198cd4fceb08f5c45b33867f0f11289b2603c04018c589')
+sha256sums=('90af993b28f050e2d682582ca1bde440665e75a5fbaec6577cafc609e24f2d92')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 arch=(any)
 

--- a/mingw-w64-gst-plugins-rs/PKGBUILD
+++ b/mingw-w64-gst-plugins-rs/PKGBUILD
@@ -34,8 +34,6 @@ build() {
     -D doc=disabled \
     $_realname-$pkgver \
     build-${MSYSTEM}
-
-  meson compile -C build-${MSYSTEM}
 }
 
 check() {

--- a/mingw-w64-gst-plugins-rs/PKGBUILD
+++ b/mingw-w64-gst-plugins-rs/PKGBUILD
@@ -26,24 +26,23 @@ sha256sums=('90af993b28f050e2d682582ca1bde440665e75a5fbaec6577cafc609e24f2d92')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 arch=(any)
 
-build() {
-  MSYS2_ARG_CONV_EXCL="--prefix=" \
-  "${MINGW_PREFIX}"/bin/meson setup \
-    --prefix="${MINGW_PREFIX}" \
-    --auto-features=enabled \
-    -D doc=disabled \
-    -D audiofx=disabled \
-    $_realname-$_version \
-    build-${MSYSTEM}
+prepare() {
+  cd $_realname-$pkgver
+  cargo fetch
+}
 
-  meson compile -C build-${MSYSTEM}
+build() {
+  cd $_realname-$pkgver
+  MSYS2_ARG_CONV_EXCL="--prefix=" cargo cbuild --prefix="${MINGW_PREFIX}"
 }
 
 check() {
-  meson test -C build-${MSYSTEM}
+  cd $_realname-$pkgver
+  MSYS2_ARG_CONV_EXCL="--prefix=" cargo ctest --prefix="${MINGW_PREFIX}"
 }
 
 package() {
-  meson install -C build-${MSYSTEM} --destdir="$pkgdir"
+  cd $_realname-$pkgver
+  MSYS2_ARG_CONV_EXCL="--prefix=" cargo cinstall --prefix="${MINGW_PREFIX}" --destdir="$pkgdir"
   install -Dm644 $_realname-$_version/LICENSE* -t "$pkgdir/$MINGW_PREFIX"/share/licenses/$_realname/
 }

--- a/mingw-w64-gst-plugins-rs/PKGBUILD
+++ b/mingw-w64-gst-plugins-rs/PKGBUILD
@@ -17,6 +17,7 @@ depends=(${MINGW_PACKAGE_PREFIX}-gtk4
          ${MINGW_PACKAGE_PREFIX}-dav1d
          ${MINGW_PACKAGE_PREFIX}-libwebp)
 makedepends=(${MINGW_PACKAGE_PREFIX}-meson
+             ${MINGW_PACKAGE_PREFIX}-pkgconf
              ${MINGW_PACKAGE_PREFIX}-rust
              ${MINGW_PACKAGE_PREFIX}-cargo-c
              ${MINGW_PACKAGE_PREFIX}-python-tomli)

--- a/mingw-w64-gst-plugins-rs/PKGBUILD
+++ b/mingw-w64-gst-plugins-rs/PKGBUILD
@@ -33,6 +33,7 @@ build() {
     --prefix="${MINGW_PREFIX}" \
     --auto-features=enabled \
     -D doc=disabled \
+    -D audiofx=disabled \
     $_realname-$_version \
     build-${MSYSTEM}
 }

--- a/mingw-w64-gst-plugins-rs/PKGBUILD
+++ b/mingw-w64-gst-plugins-rs/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgdesc='GStreamer plugins written in Rust (mingw-w64)' 
 url="https://gitlab.freedesktop.org/gstreamer/$_realname"
-pkgver=0.10.5
+pkgver=gstreamer-1.22.2
 pkgrel=1
 license=('spdx:LGPL-3.0-or-later'
          'spdx:Apache-2.0'
@@ -22,7 +22,7 @@ makedepends=(${MINGW_PACKAGE_PREFIX}-meson
              ${MINGW_PACKAGE_PREFIX}-cargo-c
              ${MINGW_PACKAGE_PREFIX}-python-tomli)
 source=("$url/-/archive/$pkgver/$_realname-$pkgver.tar.bz2")
-sha256sums=('1d06924fcb25602fa616ffc37457039650f77f24273b61c370feaf76eece3b09')
+sha256sums=('42ba4fa5ce3fa32eba198cd4fceb08f5c45b33867f0f11289b2603c04018c589')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 arch=(any)
 


### PR DESCRIPTION
Closes #16940.

There is one catch though. The default GitHub Actions VMs/Containers don't have enough storage space to build this package. It requires around 30 GiB free storage space to build (not counting the size of build environment e.g. MSYS).