### PR TITLE
Add Fortran-stdlib PKGBUILD

### DIFF
--- a/mingw-w64-fortran-stdlib/PKGBUILD
+++ b/mingw-w64-fortran-stdlib/PKGBUILD
@@ -1,0 +1,42 @@
+# Maintainer: ZUO Zhihua <zuo.zhihua@qq.com>
+
+_realname=fortran-stdlib
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.2.1
+pkgrel=1
+pkgdesc="Fortran Standard Library"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64')
+url="https://github.com/fortran-lang/stdlib"
+license=('MIT')
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-libwinpthread"
+         "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran")
+makedepends=("${MINGW_PACKAGE_PREFIX}-fc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-python-fypp")
+options=('strip')
+source=(${_realname}-${pkgver}.tar.gz::"https://github.com/fortran-lang/stdlib/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('add8f1fa8d36757a9fef4141ebeec2386b70728ba6bb3d15e99221b9cf442f8d')
+
+build() {
+  cd "${srcdir}/stdlib-${pkgver}"
+  mkdir -p build && cd build
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    "${MINGW_PREFIX}"/bin/cmake.exe \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      -DBUILD_TESTING=off \
+      -DCMAKE_MAXIMUM_RANK=4 \
+      -G Ninja \
+      -DBUILD_SHARED_LIBS=ON \
+      ..
+  ninja
+}
+
+package() {
+  cd "${srcdir}/stdlib-${pkgver}/build"
+  DESTDIR="${pkgdir}" ninja install
+}

--- a/mingw-w64-fortran-stdlib/PKGBUILD
+++ b/mingw-w64-fortran-stdlib/PKGBUILD
@@ -5,26 +5,23 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.2.1
 pkgrel=1
-pkgdesc="Fortran Standard Library"
+pkgdesc="Fortran Standard Library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
 url="https://github.com/fortran-lang/stdlib"
-license=('MIT')
-provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libwinpthread"
-         "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran")
+         $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran"))
 makedepends=("${MINGW_PACKAGE_PREFIX}-fc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-python-fypp")
-options=('strip')
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/fortran-lang/stdlib/archive/refs/tags/v${pkgver}.tar.gz")
 sha256sums=('add8f1fa8d36757a9fef4141ebeec2386b70728ba6bb3d15e99221b9cf442f8d')
 
 build() {
-  cd "${srcdir}/stdlib-${pkgver}"
-  mkdir -p build && cd build
+  mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     "${MINGW_PREFIX}"/bin/cmake.exe \
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
@@ -32,11 +29,11 @@ build() {
       -DCMAKE_MAXIMUM_RANK=4 \
       -G Ninja \
       -DBUILD_SHARED_LIBS=ON \
-      ..
-  ninja
+      ../stdlib-${pkgver}
+  ${MINGW_PREFIX}/bin/cmake --build .
 }
 
 package() {
-  cd "${srcdir}/stdlib-${pkgver}/build"
-  DESTDIR="${pkgdir}" ninja install
+  cd "${srcdir}/build-${MSYSTEM}"
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
 }


### PR DESCRIPTION
[Fortran-stdlib](https://github.com/fortran-lang/stdlib) is a community standard library for fortran-lang.

1. `clang32`, `clang64`, and `clangarm64` are not supported because they do not have `gfortran`.
2. ~~Currently `ming64-w64-python-fypp` is invalid due to a unknown bug, so this PR uses `pip` to install `fypp`.~~