### PR TITLE
ghdl: Update to 3.0.0.r147.g6c56631a7

### DIFF
--- a/mingw-w64-ghdl/PKGBUILD
+++ b/mingw-w64-ghdl/PKGBUILD
@@ -1,8 +1,8 @@
 _realname=ghdl
 pkgbase="mingw-w64-${_realname}"
 pkgname='__placeholder__'
-pkgver=2.0.0.r1392.g19babff18
-pkgrel=2
+pkgver=3.0.0.r147.g6c56631a7
+pkgrel=1
 pkgdesc='GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -12,7 +12,7 @@ groups=("${MINGW_PACKAGE_PREFIX}-eda")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 
-_commit="19babff1"
+_commit="6c56631a711591a26cc3a7e1b2d12417b8d17c66"
 source=("${_realname}::git+https://github.com/ghdl/ghdl.git#commit=${_commit}")
 sha512sums=('SKIP')
 


### PR DESCRIPTION
This adds support for building with clang/llvm v16