### PR TITLE
cglm: Fix aarch64 intrin headers

### DIFF
--- a/mingw-w64-cglm/0001-cglm-include-fix-arm64.patch
+++ b/mingw-w64-cglm/0001-cglm-include-fix-arm64.patch
@@ -1,0 +1,11 @@
+--- a/include/cglm/simd/intrin.h
++++ b/include/cglm/simd/intrin.h
+@@ -63,7 +63,7 @@
+ #endif
+ 
+ /* ARM Neon */
+-#if defined(_WIN32)
++#if defined(_MSC_VER)
+ /* TODO: non-ARM stuff already inported, will this be better option */
+ /* #  include <intrin.h> */
+ 

--- a/mingw-w64-cglm/PKGBUILD
+++ b/mingw-w64-cglm/PKGBUILD
@@ -4,7 +4,7 @@ _realname=cglm
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.9.0
-pkgrel=1
+pkgrel=2
 pkgdesc="OpenGL Mathematics (glm) for C (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -16,8 +16,15 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-python-sphinx"
              "${MINGW_PACKAGE_PREFIX}-python-sphinx_rtd_theme")
 options=('!strip' 'staticlibs' '!buildflags')
-source=("${_realname}-${pkgver}.tar.gz::https://github.com/recp/cglm/archive/v${pkgver}.tar.gz")
-sha256sums=('9b688bc52915cdd4ad8b7d4080ef59cc92674d526856d8f16bb3a114db1dd794')
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/recp/cglm/archive/v${pkgver}.tar.gz"
+        0001-cglm-include-fix-arm64.patch)
+sha256sums=('9b688bc52915cdd4ad8b7d4080ef59cc92674d526856d8f16bb3a114db1dd794'
+            '8fe3fbff513bec69cb5eed8d3fbccd9a03bb5e2dfde18c327eaa280d029f9ce8')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+  patch -p1 -i "${srcdir}/0001-cglm-include-fix-arm64.patch"
+}
 
 build() {
   [[ -d "${srcdir}/build-${MSYSTEM}-static" ]] && rm -rf "${srcdir}/build-${MSYSTEM}-static"


### PR DESCRIPTION

    This fixes the following error

    In file included from cglm-0.9.0/src/../include/cglm/simd/intrin.h:71:
    clangarm64/lib/clang/16/include/arm64intr.h:12:15: fatal error: 'arm64intr.h' file not found
     include_next <arm64intr.h>
                  ^~~~~~~~~~~~~

@podsvirov