### PR TITLE
gcc: Remove libssp-0.dll (v2)

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -24,7 +24,7 @@ pkgver=13.1.0
 #_majorver=${pkgver:0:1}
 #_sourcedir=${_realname}-${_majorver}-${_snapshot}
 _sourcedir=${_realname}-${pkgver}
-pkgrel=3
+pkgrel=4
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -210,11 +210,6 @@ build() {
     '--with-stage1-ldflags="-static-libstdc++"'
   )
 
-  # -fstack-protector-strong breaks libssp
-  # https://github.com/msys2/MINGW-packages/issues/13830
-  # TODO: This can be removed once we drop libssp all together
-  CFLAGS+=" -fno-stack-protector"
-
   # In addition adaint.c does `#include <accctrl.h>` which pulls in msxml.h, hacky hack:
   CPPFLAGS+=" -DCOM_NO_WINDOWS_H"
 
@@ -242,6 +237,7 @@ build() {
     --disable-libstdcxx-pch \
     --enable-lto \
     --enable-libgomp \
+    --disable-libssp \
     --disable-multilib \
     --disable-rpath \
     --disable-win32-registry \
@@ -283,8 +279,7 @@ build() {
 package_gcc-libs() {
   pkgdesc="GNU Compiler Collection (libraries) for MinGW-w64"
   depends=("${MINGW_PACKAGE_PREFIX}-libwinpthread")
-  provides=("${MINGW_PACKAGE_PREFIX}-libssp"
-            "${MINGW_PACKAGE_PREFIX}-omp")
+  provides=("${MINGW_PACKAGE_PREFIX}-omp")
 
   # Licensing information
 
@@ -296,7 +291,7 @@ package_gcc-libs() {
   # We explain the licensing in this generated README file
   mkdir -p "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-libs"
   cat << ENDFILE > "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-libs/README"
-The libgcc, libssp, libstdc++, libgomp and libatomic libraries are covered by
+The libgcc, libstdc++, libgomp and libatomic libraries are covered by
 GPL3+ with the GCC Runtime Library Exception. The libquadmath library is covered
 by LGPL2+. The package as a whole can be redistributed under GPL3+.
 ENDFILE
@@ -310,7 +305,7 @@ ENDFILE
 
   cd ${srcdir}${MINGW_PREFIX}
   # libitm* and libvtv* are disbled until fixed
-  cp bin/{libatomic*,libgcc*,libgomp*,libquadmath*,libssp*,libstdc*}.dll ${pkgdir}${MINGW_PREFIX}/bin/
+  cp bin/{libatomic*,libgcc*,libgomp*,libquadmath*,libstdc*}.dll ${pkgdir}${MINGW_PREFIX}/bin/
   if [ "$_enable_jit" == "yes" ]; then
     rm ${pkgdir}${MINGW_PREFIX}/bin/libgccjit-0.dll
   fi


### PR DESCRIPTION
There are no packages in MSYS2 that use it for 7 months, and we don't ship an import library for it since then as well, so remove it.

This also makes it possible to build gcc with stack protector enabled.