### PR TITLE
flatbuffers: update to 23.5.9

### DIFF
--- a/mingw-w64-flatbuffers/PKGBUILD
+++ b/mingw-w64-flatbuffers/PKGBUILD
@@ -4,7 +4,7 @@ _realname=flatbuffers
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=23.3.3
+pkgver=23.5.9
 pkgrel=1
 pkgdesc='Memory Efficient Serialization Library (mingw-w64)'
 arch=('any')
@@ -19,7 +19,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 depends=("${MINGW_PACKAGE_PREFIX}-libsystre")
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/google/${_realname}/archive/v${pkgver}.tar.gz"
         0001-cmake-fix-install.patch)
-sha256sums=('8aff985da30aaab37edf8e5b02fda33ed4cbdd962699a8e2af98fdef306f4e4d'
+sha256sums=('fa0036f4a2d082f7034fd90a53a02ce0e121548b39c07c8d2a77a821da02fb01'
             '3a7900943c5a95a0350052ed29a982c65bc821ca50f0f56a7b9482e6361a10f0')
 noextract=(${_realname}-${pkgver}.tar.gz)
 
@@ -47,6 +47,7 @@ build() {
     -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
     "${_extra_config[@]}" \
     -DFLATBUFFERS_BUILD_SHAREDLIB=ON \
+    -DFLATBUFFERS_BUILD_TESTS=OFF \
     ../${_realname}-${pkgver}
 
   ${MINGW_PREFIX}/bin/cmake.exe --build ./


### PR DESCRIPTION
GCC crashes without any error message.