### PR TITLE
gcc: revert recent changes

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -24,7 +24,7 @@ pkgver=13.1.0
 #_majorver=${pkgver:0:1}
 #_sourcedir=${_realname}-${_majorver}-${_snapshot}
 _sourcedir=${_realname}-${pkgver}
-pkgrel=4
+pkgrel=5
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -262,10 +262,9 @@ build() {
 
   # https://gcc.gnu.org/onlinedocs/gccint/Makefile.html
   # https://bugs.archlinux.org/task/71777
+  # XXX: Removed all CFLAGS/LDFLAGS passing again due to
+  # https://github.com/msys2/MINGW-packages/pull/16968#issuecomment-1539038359
   make -O STAGE1_CFLAGS="-O2" \
-          BOOT_CFLAGS="$CFLAGS" \
-          BOOT_LDFLAGS="$LDFLAGS" \
-          LDFLAGS_FOR_TARGET="$LDFLAGS" \
           all
 
   rm -rf ${srcdir}${MINGW_PREFIX}


### PR DESCRIPTION
See https://github.com/msys2/MINGW-packages/pull/16968#issuecomment-1539038359

This partially reverts https://github.com/lazka/MINGW-packages/commit/518e217a129eeeb92e5090f1bb14deaf0ed70edf

It's unclear which parts of LDFLAGS/CFLAGS are breaking gcc, needs
investigating. -fstack-protector-strong could be one cause.