### PR TITLE
libgsf: rebuild

### DIFF
--- a/mingw-w64-libgsf/PKGBUILD
+++ b/mingw-w64-libgsf/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libgsf
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.14.50
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
 pkgdesc="An extensible I/O abstraction library for dealing with structured file formats (mingw-w64)"
@@ -18,17 +18,20 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-vala"
              "${MINGW_PACKAGE_PREFIX}-gtk-doc"
              "${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-cc")
-options=('strip' 'staticlibs')
-license=('GPL' 'LGPL')
+license=('spdx:LGPL-2.1-only')
 url="https://gitlab.gnome.org/GNOME/libgsf.git"
 source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz
-        002-get-unix-path-for-git.patch)
+        002-get-unix-path-for-git.patch
+        https://gitlab.gnome.org/GNOME/libgsf/-/commit/167d7f96c81683392933ddb8c427e5d7c8ce284d.patch)
 sha256sums=('6e6c20d0778339069d583c0d63759d297e817ea10d0d897ebbe965f16e2e8e52'
-            'f08db8333d2b4a369737a77969b5896d408a4d9992fab6f1c9c44ddeae25c516')
+            'f08db8333d2b4a369737a77969b5896d408a4d9992fab6f1c9c44ddeae25c516'
+            '1db394176d0f6a98c2ad32a9cdaf05a183ae07c972f60153ff5160cb88ee2660')
 
 prepare() {
   cd ${_realname}-${pkgver}
   patch -b -V simple -p1 -i ${srcdir}/002-get-unix-path-for-git.patch
+  patch -p1 -i "${srcdir}/167d7f96c81683392933ddb8c427e5d7c8ce284d.patch"
+
   autoreconf -fiv
 }
 
@@ -46,7 +49,7 @@ build() {
     --prefix=${MINGW_PREFIX} \
     --libexecdir=${MINGW_PREFIX}/lib \
     --enable-introspection \
-    --enable-gtk-doc
+    --disable-gtk-doc
 
   make
 }


### PR DESCRIPTION
* backport clang v16 fix for finding bzip2
* disable gtk-doc, broken somehow
* general cleanup