### PR TITLE
nanodbc: build without -Werror

### DIFF
--- a/mingw-w64-nanodbc/0001-disable-werror.patch
+++ b/mingw-w64-nanodbc/0001-disable-werror.patch
@@ -1,0 +1,11 @@
+--- nanodbc-2.14.0/CMakeLists.txt.orig	2022-03-23 20:40:26.000000000 +0100
++++ nanodbc-2.14.0/CMakeLists.txt	2023-05-11 19:40:17.491955300 +0200
+@@ -35,7 +35,7 @@
+ message(STATUS "nanodbc compile: C++${CMAKE_CXX_STANDARD}")
+ 
+ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_COMPILER_IS_GNUCXX)
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wnarrowing -Werror")
++  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wnarrowing")
+   include(CheckCXXCompilerFlag)
+ 
+   if (NANODBC_ENABLE_COVERAGE)

--- a/mingw-w64-nanodbc/PKGBUILD
+++ b/mingw-w64-nanodbc/PKGBUILD
@@ -4,21 +4,25 @@ _realname=nanodbc
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.14.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A small C++ wrapper for the native C ODBC API (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
 url="https://nanodbc.io/"
-license=('MIT')
+license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
-source=("${_realname}-${pkgver}.tar.gz"::https://github.com/nanodbc/nanodbc/archive/v${pkgver}.tar.gz)
-sha256sums=('56228372042b689beccd96b0ac3476643ea85b3f57b3f23fb11ca4314e68b9a5')
+source=("${_realname}-${pkgver}.tar.gz"::https://github.com/nanodbc/nanodbc/archive/v${pkgver}.tar.gz
+        "0001-disable-werror.patch")
+sha256sums=('56228372042b689beccd96b0ac3476643ea85b3f57b3f23fb11ca4314e68b9a5'
+            '84a809a25e252229cad5ed1d4eee6a0a24c2c8405bdc69b60a518e4f184d7824')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
+
+  patch -Np1 -i "${srcdir}"/0001-disable-werror.patch
 }
 
 build() {


### PR DESCRIPTION
because failing to build because of deprecations is never a good idea