### PR TITLE
DONE: #17115 Fix glib-compile-schemas.

### DIFF
--- a/mingw-w64-glib2/0006-glib_compile_schemas_fix_utf8_cmd_line.patch
+++ b/mingw-w64-glib2/0006-glib_compile_schemas_fix_utf8_cmd_line.patch
@@ -1,0 +1,61 @@
+--- a/gio/glib-compile-schemas.c
++++ b/gio/glib-compile-schemas.c
+@@ -21,6 +21,7 @@
+ 
+ /* Prologue {{{1 */
+ #include "config.h"
++#include <glib.h>
+ 
+ #include <gstdio.h>
+ #include <gi18n.h>
+@@ -2169,6 +2170,7 @@
+   gboolean strict = FALSE;
+   gchar **schema_files = NULL;
+   gchar **override_files = NULL;
++  gchar **command_line = NULL;
+   GOptionContext *context = NULL;
+   gint retval;
+   GOptionEntry entries[] = {
+@@ -2210,12 +2212,22 @@
+        "and the cache file is called gschemas.compiled."));
+   g_option_context_add_main_entries (context, entries, GETTEXT_PACKAGE);
+ 
++#ifdef G_OS_WIN32
++  command_line = g_win32_get_command_line ();
++  if (!g_option_context_parse_strv(context, &command_line, &error))
++    {
++      fprintf (stderr, "%s\n", error->message);
++      retval = 1;
++      goto done;
++    }
++#else
+   if (!g_option_context_parse (context, &argc, &argv, &error))
+     {
+       fprintf (stderr, "%s\n", error->message);
+       retval = 1;
+       goto done;
+     }
++#endif
+ 
+   if (show_version_and_exit)
+     {
+@@ -2231,7 +2243,11 @@
+       goto done;
+     }
+ 
++#ifdef G_OS_WIN32
++  srcdir = command_line[1];
++#else
+   srcdir = argv[1];
++#endif
+ 
+   target = g_build_filename (targetdir ? targetdir : srcdir, "gschemas.compiled", NULL);
+ 
+@@ -2320,6 +2336,7 @@
+   g_free (target);
+   g_strfreev (schema_files);
+   g_strfreev (override_files);
++  g_strfreev (command_line);
+   g_option_context_free (context);
+ 
+ #ifdef G_OS_WIN32

--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -28,6 +28,7 @@ source=("https://download.gnome.org/sources/glib/${pkgver%.*}/glib-${pkgver}.tar
         0001-Update-g_fopen-g_open-and-g_creat-to-open-with-FILE_.patch
         0002-disable_glib_compile_schemas_warning.patch
         0004-disable-explicit-ms-bitfields.patch
+        0006-glib_compile_schemas_fix_utf8_cmd_line.patch
         glib-compile-schemas.hook.in
         gio-querymodules.hook.in
         pyscript2exe.py)
@@ -36,6 +37,7 @@ sha256sums=('24f3847857b1d8674cdb0389a36edec0f13c666cd3ce727ecd340eb9da8aca9e'
             '51d02360a1ee978fd45e77b84bca9cfbcf080d91986b5c0efe0732779c6a54ec'
             '396c25cfd740ffbb72209133c7b9453173167577265a4bb14502678de8d5a8f9'
             '3d2585f460f797c67f9e5149d3b3d52ff2481c48fd7cb791a03f5f0e68304d39'
+            '307a5a973d13dfd7b8aeac69c1ff93b27d9451deeefcdc7c597a4f296eefe692'
             '0c3d54636407e0e13429b73959cace626253cd772e1d4870de0fb92b0b99545a'
             'f18d27d98709dba8c5f9756672baaf0158fb4353c9edbdc2e80021f88ff34ced'
             'e57174517b08cf8f9fb4f43a381d342d23d2db3cad661107f35ca21c39b5734d')
@@ -56,6 +58,7 @@ prepare() {
   apply_patch_with_msg 0001-Update-g_fopen-g_open-and-g_creat-to-open-with-FILE_.patch
   apply_patch_with_msg 0002-disable_glib_compile_schemas_warning.patch
   apply_patch_with_msg 0004-disable-explicit-ms-bitfields.patch
+  apply_patch_with_msg 0006-glib_compile_schemas_fix_utf8_cmd_line.patch
 }
 
 build() {


### PR DESCRIPTION
Fixed: glib-compile-schemas failed when the source directory has non Latin symbols, under MNGW64 on MS Windows platform.

Root cause: using g_option_context_parse is incorrect under the MS Windows platform due the it expects system codepage instead of UTF-8.

Resolution: using g_option_context_parse_strv when G_OS_WIN32 is defined with g_win32_get_command_line.