### PR TITLE
emacs: Fix compiling with clang due to sys/wait.h

### DIFF
--- a/mingw-w64-emacs/002-clang-fixes.patch
+++ b/mingw-w64-emacs/002-clang-fixes.patch
@@ -21,3 +21,16 @@ diff -aur emacs-28.2-orig/configure.ac emacs-28.2/configure.ac
     esac
     ## If they want unexec, disable Windows ASLR for the Emacs binary
     if test "$with_dumping" = "unexec"; then
+--- a/nt/mingw-cfg.site
++++ b/nt/mingw-cfg.site
+@@ -29,6 +29,10 @@
+ # are necessary to steer the test in the direction you need, by
+ # judiciously setting variables that control the test results.
+ 
++# We want to use sys/wait.h from nt/inc
++# https://lists.gnu.org/archive/html/help-gnu-emacs/2023-05/msg00107.html
++ac_cv_header_sys_wait_h=yes
++
+ # We want to use getopt.h from gnulib
+ ac_cv_header_getopt_h=no
+ 

--- a/mingw-w64-emacs/PKGBUILD
+++ b/mingw-w64-emacs/PKGBUILD
@@ -76,8 +76,9 @@ build() {
     --build="${MINGW_CHOST}" \
     --with-modules \
     --without-dbus \
-    --without-compress-install \
-    $_extra_cfg
+    --without-compress-install
+    # disable jit due to gcc 13 taking more time to compile
+    # $_extra_cfg
 
   # --without-compress-install is needed because we don't have gzip in
   # the mingw binaries and it is also required by native compilation.

--- a/mingw-w64-emacs/PKGBUILD
+++ b/mingw-w64-emacs/PKGBUILD
@@ -6,7 +6,7 @@ _realname=emacs
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=28.2
-pkgrel=3
+pkgrel=4
 pkgdesc="The extensible, customizable, self-documenting, real-time display editor (mingw-w64)"
 url="https://www.gnu.org/software/${_realname}/"
 license=('spdx:GPL-3.0')
@@ -43,7 +43,7 @@ source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.xz"{,.s
 sha256sums=('ee21182233ef3232dc97b486af2d86e14042dbb65bbc535df562c3a858232488'
             'SKIP'
             'e1347064ec30094e21679764f784fa7557738946485359041473e6e9d7f3c3dc'
-            '0543a3082262077edb89f2ee1af2531025888be7d15c8255d6c67fb732711781')
+            '6f3a3260d8fd6c1fbeafd0611f604c46799005dc776af076bff1fd4d8a3b6304')
 validpgpkeys=('28D3BED851FDF3AB57FEF93C233587A47C207910'
 	      '17E90D521672C04631B1183EE78DAE0F3115E06B'
 	      'E6C9029C363AD41D787A8EBB91C1262F01EB8D39'
@@ -66,6 +66,10 @@ build() {
   if [[ "$_enable_jit" == "yes" ]] ; then
       _extra_cfg="$_extra_cfg --with-native-compilation"
   fi
+
+  # Required for nanosleep with clang
+  export LDFLAGS="${LDFLAGS} -lpthread"
+
   ../${_realname}-${pkgver}/configure \
     --prefix="${MINGW_PREFIX}" \
     --host="${MINGW_CHOST}" \


### PR DESCRIPTION
Fixes https://github.com/msys2/MINGW-packages/issues/17117


    Compiling with clang failed due to wait(2) function is not declared in
    emcas sys/wait.h file. The following error is shown in config.log file

    conftest.c:70:3: error: call to undeclared function 'wait'; ISO C99 and
    later do not support implicit function declarations [-Wimplicit-function-declaration]

    This adds the suggestion from https://lists.gnu.org/archive/html/help-gnu-emacs/2023-05/msg00107.html

