### PR TITLE
gcc: Fix exception handling on mingw32

### DIFF
--- a/mingw-w64-gcc/0022-fix-radix-sort-on-32bit-platforms.patch
+++ b/mingw-w64-gcc/0022-fix-radix-sort-on-32bit-platforms.patch
@@ -1,0 +1,55 @@
+From c7c22c10118d9f738ce60c97675def01c5e2d33d Mon Sep 17 00:00:00 2001
+From: Thomas Neumann <tneumann@users.sourceforge.net>
+Date: Wed, 10 May 2023 12:33:49 +0200
+Subject: [PATCH] fix radix sort on 32bit platforms [PR109670]
+
+The radix sort uses two buffers, a1 for input and a2 for output.
+After every digit the role of the two buffers is swapped.
+When terminating the sort early the code made sure the output
+was in a2.  However, when we run out of bits, as can happen on
+32bit platforms, the sorted result was in a1, was we had just
+swapped a1 and a2.
+This patch fixes the problem by unconditionally having a1 as
+output after every loop iteration.
+
+This bug manifested itself only on 32bit platforms and even then
+only in some circumstances, as it needs frames where a swap
+is required due to differences in the top-most byte, which is
+affected by ASLR. The new logic was validated by exhaustive
+search over 32bit input values.
+
+libgcc/ChangeLog:
+        * unwind-dw2-fde.c: Fix radix sort buffer management.
+---
+ libgcc/unwind-dw2-fde.c | 8 +++-----
+ 1 file changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/libgcc/unwind-dw2-fde.c b/libgcc/unwind-dw2-fde.c
+index 7b74c391ced..31a3834156b 100644
+--- a/libgcc/unwind-dw2-fde.c
++++ b/libgcc/unwind-dw2-fde.c
+@@ -624,8 +624,6 @@ fde_radixsort (struct object *ob, fde_extractor_t fde_extractor,
+       // Stop if we are already sorted.
+       if (!violations)
+ 	{
+-	  // The sorted data is in a1 now.
+-	  a2 = a1;
+ 	  break;
+ 	}
+ 
+@@ -660,9 +658,9 @@ fde_radixsort (struct object *ob, fde_extractor_t fde_extractor,
+ #undef FANOUT
+ #undef FANOUTBITS
+ 
+-  // The data is in a2 now, move in place if needed.
+-  if (a2 != v1->array)
+-    memcpy (v1->array, a2, sizeof (const fde *) * n);
++  // The data is in a1 now, move in place if needed.
++  if (a1 != v1->array)
++    memcpy (v1->array, a1, sizeof (const fde *) * n);
+ }
+ 
+ static inline void
+-- 
+2.39.2
+

--- a/mingw-w64-gcc/2000-enable-rust.patch
+++ b/mingw-w64-gcc/2000-enable-rust.patch
@@ -1,0 +1,42 @@
+--- a/configure
++++ b/configure
+@@ -8909,18 +8909,6 @@
+             ;;
+         esac
+ 
+-        # Disable Rust for GCC 13 release.
+-        case ${add_this_lang}:${language} in
+-          yes:rust)
+-            # Specifically requested language; tell them.
+-            as_fn_error $? "Rust is not supported in GCC 13 release" "$LINENO" 5
+-           ;;
+-          *:rust)
+-            # Silently disable.
+-            add_this_lang=unsupported
+-            ;;
+-        esac
+-
+         # Disable jit if -enable-host-shared not specified
+         # but not if building for Mingw. All code in Windows
+         # is position independent code (PIC).
+--- a/configure.ac
++++ b/configure.ac
+@@ -2150,18 +2150,6 @@ if test -d ${srcdir}/gcc; then
+             ;;
+         esac
+ 
+-        # Disable Rust for GCC 13 release.
+-        case ${add_this_lang}:${language} in
+-          yes:rust)
+-            # Specifically requested language; tell them.
+-            AC_MSG_ERROR([Rust is not supported in GCC 13 release])
+-           ;;
+-          *:rust)
+-            # Silently disable.
+-            add_this_lang=unsupported
+-            ;;
+-        esac
+-
+         # Disable jit if -enable-host-shared not specified
+         # but not if building for Mingw. All code in Windows
+         # is position independent code (PIC).

--- a/mingw-w64-gcc/2001-fix-building-rust-on-mingw-w64.patch
+++ b/mingw-w64-gcc/2001-fix-building-rust-on-mingw-w64.patch
@@ -1,0 +1,53 @@
+--- a/gcc/rust/backend/rust-compile-base.cc
++++ b/gcc/rust/backend/rust-compile-base.cc
+@@ -332,7 +332,7 @@
+ 
+       break;
+ 
+-    case Rust::ABI::WIN64:
++    case Rust::ABI::WIN_64:
+       abi_tree = get_identifier ("ms_abi");
+ 
+       break;
+--- a/gcc/rust/parse/rust-parse.cc
++++ b/gcc/rust/parse/rust-parse.cc
+@@ -87,7 +87,7 @@
+   // Source: rustc compiler
+   // (https://github.com/rust-lang/rust/blob/9863bf51a52b8e61bcad312f81b5193d53099f9f/compiler/rustc_expand/src/module.rs#L174)
+ #if defined(HAVE_DOS_BASED_FILE_SYSTEM)
+-  path.replace ('/', '\\');
++  std::replace (path.begin(), path.end(), '/', '\\');
+ #endif /* HAVE_DOS_BASED_FILE_SYSTEM */
+ 
+   return path;
+--- a/gcc/rust/util/rust-abi.cc
++++ b/gcc/rust/util/rust-abi.cc
+@@ -38,7 +38,7 @@
+   else if (abi.compare ("sysv64") == 0)
+     return Rust::ABI::SYSV64;
+   else if (abi.compare ("win64") == 0)
+-    return Rust::ABI::WIN64;
++    return Rust::ABI::WIN_64;
+ 
+   return Rust::ABI::UNKNOWN;
+ }
+@@ -62,7 +62,7 @@
+       return "fastcall";
+     case Rust::ABI::SYSV64:
+       return "sysv64";
+-    case Rust::ABI::WIN64:
++    case Rust::ABI::WIN_64:
+       return "win64";
+ 
+     case Rust::ABI::UNKNOWN:
+--- a/gcc/rust/util/rust-abi.h
++++ b/gcc/rust/util/rust-abi.h
+@@ -30,7 +30,7 @@
+   CDECL,
+   STDCALL,
+   FASTCALL,
+-  WIN64,
++  WIN_64,
+   SYSV64
+ };
+ 

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -26,7 +26,7 @@ pkgver=13.1.0
 #_majorver=${pkgver:0:1}
 #_sourcedir=${_realname}-${_majorver}-${_snapshot}
 _sourcedir=${_realname}-${pkgver}
-pkgrel=5
+pkgrel=6
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -64,10 +64,10 @@ source=("https://ftp.gnu.org/gnu/gcc/${_realname}-${pkgver%%+*}/${_realname}-${p
         0014-gcc-9-branch-clone_function_name_1-Retain-any-stdcall-suffix.patch
         0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
         0021-PR14940-Allow-a-PCH-to-be-mapped-to-a-different-addr.patch
+        0022-fix-radix-sort-on-32bit-platforms.patch
         0140-gcc-diagnostic-color.patch
         0200-add-m-no-align-vector-insn-option-for-i386.patch
         0300-override-builtin-printf-format.patch
-        https://github.com/gcc-mirror/gcc/commit/1c118c9970600117700cc12284587e0238de6bbe.patch
         2000-enable-rust.patch
         2001-fix-building-rust-on-mingw-w64.patch)
 sha256sums=('61d684f0aa5e76ac6585ad8898a2427aade8979ed5e7f85492286c4dfc13ee86'
@@ -84,10 +84,10 @@ sha256sums=('61d684f0aa5e76ac6585ad8898a2427aade8979ed5e7f85492286c4dfc13ee86'
             'fd9bdecb2bbc4796bbc9f00b708dac42ef9e3464a06d6d27e5475cee117de5be'
             'ad1f7b5e7afaaec008b7cbd14feea13a10989fa91bda7003af72d457619bb199'
             '6c272078340a27b3f147e497115b0a6e9fc0da720a2602f12b086524522caa59'
+            '45950ed7a6a14436bde40e717eef07160671bfbbf41c2251f95a3f8c660bef6b'
             'e0a5b470f49a29f20215cc9f9d04c1cb9969dff6f0e546542799d3a693ef1c84'
             'c34f9e71b5a092be1987ad4c65891742c74c9eb8ef6560100e751cd31375f579'
             'f73c8d1701762fed7d8102d17d8e4416a4cc5e600e297a89c2e1fe09cd743a1c'
-            'aecce97a914cead59a1bbb90fba2f7645dfa5d8bb7dbf9eedb94cade2270a1c2'
             '693a91a863a706b3526af01c9de5ce8295c59ef0f56f009bcfbf79a93cba2728'
             'e78d51c908cd4e5c905c62e8350db1c609479bb95333c67f706b56974226fd94')
 validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.org
@@ -158,9 +158,9 @@ prepare() {
   apply_patch_with_msg \
     2001-fix-building-rust-on-mingw-w64.patch
 
-  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109670#c7
-  # https://github.com/gcc-mirror/gcc/commit/1c118c9970600117700cc12284587e0238de6bbe
-  patch -R -Nbp1 -i "${srcdir}/1c118c9970600117700cc12284587e0238de6bbe.patch"
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109670#c12
+  apply_patch_with_msg \
+    0022-fix-radix-sort-on-32bit-platforms.patch
 
   # do not expect ${prefix}/mingw symlink - this should be superceded by
   # 0005-Windows-Don-t-ignore-native-system-header-dir.patch .. but isn't!

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -7,6 +7,7 @@
 
 _enable_ada=yes
 _enable_objc=yes
+_enable_rust=no
 _enable_jit=yes
 _threads="posix"
 _realname=gcc
@@ -17,6 +18,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-fortran"
          $([[ "$_enable_ada" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-ada")
          $([[ "$_enable_objc" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-objc")
+         $([[ "$_enable_rust" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-rust")
          $([[ "$_enable_jit" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-libgccjit")
         )
 #_snapshot=20181214
@@ -65,7 +67,9 @@ source=("https://ftp.gnu.org/gnu/gcc/${_realname}-${pkgver%%+*}/${_realname}-${p
         0140-gcc-diagnostic-color.patch
         0200-add-m-no-align-vector-insn-option-for-i386.patch
         0300-override-builtin-printf-format.patch
-        https://github.com/gcc-mirror/gcc/commit/1c118c9970600117700cc12284587e0238de6bbe.patch)
+        https://github.com/gcc-mirror/gcc/commit/1c118c9970600117700cc12284587e0238de6bbe.patch
+        2000-enable-rust.patch
+        2001-fix-building-rust-on-mingw-w64.patch)
 sha256sums=('61d684f0aa5e76ac6585ad8898a2427aade8979ed5e7f85492286c4dfc13ee86'
             'SKIP'
             'bce81824fc89e5e62cca350de4c17a27e27a18a1a1ad5ca3492aec1fc5af3234'
@@ -83,7 +87,9 @@ sha256sums=('61d684f0aa5e76ac6585ad8898a2427aade8979ed5e7f85492286c4dfc13ee86'
             'e0a5b470f49a29f20215cc9f9d04c1cb9969dff6f0e546542799d3a693ef1c84'
             'c34f9e71b5a092be1987ad4c65891742c74c9eb8ef6560100e751cd31375f579'
             'f73c8d1701762fed7d8102d17d8e4416a4cc5e600e297a89c2e1fe09cd743a1c'
-            'aecce97a914cead59a1bbb90fba2f7645dfa5d8bb7dbf9eedb94cade2270a1c2')
+            'aecce97a914cead59a1bbb90fba2f7645dfa5d8bb7dbf9eedb94cade2270a1c2'
+            '693a91a863a706b3526af01c9de5ce8295c59ef0f56f009bcfbf79a93cba2728'
+            'e78d51c908cd4e5c905c62e8350db1c609479bb95333c67f706b56974226fd94')
 validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.org
               86CFFCA918CF3AF47147588051E8B148A9999C34  # evangelos@foutrelis.com
               13975A70E63C361C73AE69EF6EEB81F8981C74C7  # richard.guenther@gmail.com
@@ -145,6 +151,13 @@ prepare() {
   apply_patch_with_msg \
     0300-override-builtin-printf-format.patch
 
+  # https://salsa.debian.org/toolchain-team/gcc/-/blob/b953a3f9/debian/patches/rust-enabled.diff
+  apply_patch_with_msg \
+    2000-enable-rust.patch
+
+  apply_patch_with_msg \
+    2001-fix-building-rust-on-mingw-w64.patch
+
   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109670#c7
   # https://github.com/gcc-mirror/gcc/commit/1c118c9970600117700cc12284587e0238de6bbe
   patch -R -Nbp1 -i "${srcdir}/1c118c9970600117700cc12284587e0238de6bbe.patch"
@@ -160,7 +173,6 @@ prepare() {
 }
 
 build() {
-  [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}
   mkdir -p ${srcdir}/build-${MSYSTEM} && cd ${srcdir}/build-${MSYSTEM}
 
   declare -a extra_config
@@ -191,6 +203,9 @@ build() {
   fi
   if [ "$_enable_objc" == "yes" ]; then
     _languages+=",objc,obj-c++"
+  fi
+  if [ "$_enable_rust" == "yes" ]; then
+    _languages+=",rust"
   fi
   if [ "$_enable_jit" == "yes" ]; then
     _languages+=",jit"
@@ -439,8 +454,6 @@ package_gcc-fortran() {
   cp bin/gfortran.exe ${pkgdir}${MINGW_PREFIX}/bin/
   cp bin/${MINGW_CHOST}-gfortran.exe ${pkgdir}${MINGW_PREFIX}/bin/
 
-  #cp bin/libgfortran*.dll ${pkgdir}${MINGW_PREFIX}/bin/
-
   mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}
   cp -r lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/finclude       ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
   cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/f951.exe          ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
@@ -488,6 +501,20 @@ package_gcc-objc() {
   cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/cc1obj.exe         ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
   cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/cc1objplus.exe     ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
   cp lib/libobjc.*                                       ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
+}
+
+package_gcc-rust() {
+  pkgdesc="GNU Compiler Collection (Rust) for MinGW-w64"
+  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}-${pkgrel}")
+
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/{bin,lib}
+
+  cd ${srcdir}${MINGW_PREFIX}
+  cp bin/gccrs.exe ${pkgdir}${MINGW_PREFIX}/bin/
+  cp bin/${MINGW_CHOST}-gccrs.exe ${pkgdir}${MINGW_PREFIX}/bin/
+
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}
+  cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/rust1.exe          ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
 }
 
 package_libgccjit() {


### PR DESCRIPTION
- Backport patch from https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109670#c12
- Prepare for new gcc-rust package (disabled by default)