### PR TITLE
Add runtime package for OpenSSL v1.1

### DIFF
--- a/mingw-w64-openssl-1.1/0001-shlib_wrap.sh-accommodate-for-MINGW-builds-being-tes.patch
+++ b/mingw-w64-openssl-1.1/0001-shlib_wrap.sh-accommodate-for-MINGW-builds-being-tes.patch
@@ -1,0 +1,44 @@
+From 57c86922b6e617573a896ed1202eccc6ba490ae5 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Sat, 12 Oct 2019 22:00:32 +0200
+Subject: [PATCH] shlib_wrap.sh: accommodate for MINGW builds being tested
+ using MSYS
+
+The old dichotomy between MSYS and MINGW rears its ugly head. Just
+because MSYS emulates Unix-y paths (i.e. paths that start with a
+forward-slash) to be relative to the root directory of MSYS2.
+
+And an additional pain is that the colon (which is used on Windows to
+separate the drive letter from the remainder of an absolute path) is
+mistaken in MSYS scripts/programs for a path delimiter, e.g. of the
+environment variable `PATH`.
+
+Let's make sure that when we run the tests through `shlib_wrap.sh`, we
+re-mangle Windows paths to pseudo Unix paths so that e.g. `zlib1.dll`
+can be found when (MINGW) `openssl.exe` tries to load a shared library
+and looks through the `PATH` to do so, using `;` as path delimiters (as
+is common on Windows).
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ util/shlib_wrap.sh.in | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/util/shlib_wrap.sh.in b/util/shlib_wrap.sh.in
+index eac70ed..d45c3c2 100755
+--- a/util/shlib_wrap.sh.in
++++ b/util/shlib_wrap.sh.in
+@@ -96,7 +96,9 @@ SunOS|IRIX*)
+ 	eval $rld_var=\"${THERE}'${'$rld_var':+:$'$rld_var'}'\"; export $rld_var
+ 	unset rld_var
+ 	;;
+-*)	LD_LIBRARY_PATH="${THERE}:$LD_LIBRARY_PATH"	# Linux, ELF HP-UX
++*)
++	case "$SYSNAME" in MINGW*) THERE="$(cygpath -au "$THERE")";; esac
++	LD_LIBRARY_PATH="${THERE}:$LD_LIBRARY_PATH"	# Linux, ELF HP-UX
+ 	DYLD_LIBRARY_PATH="${THERE}:$DYLD_LIBRARY_PATH"	# MacOS X
+ 	SHLIB_PATH="${THERE}:$SHLIB_PATH"		# legacy HP-UX
+ 	LIBPATH="${THERE}:$LIBPATH"			# AIX, OS/2
+-- 
+2.23.0.windows.1
+

--- a/mingw-w64-openssl-1.1/0001-tests-work-around-the-MSYS-vs-Windows-paths-problem.patch
+++ b/mingw-w64-openssl-1.1/0001-tests-work-around-the-MSYS-vs-Windows-paths-problem.patch
@@ -1,0 +1,39 @@
+From e8a86b273d7cef26961c12c1441c57d2f9046134 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Sat, 12 Oct 2019 20:09:06 +0200
+Subject: [PATCH] tests: work around the "MSYS vs Windows paths" problem
+
+The tests fail for the wrong reason: they cannot even access the files
+because their paths are given in MSYS format (because the test script is
+written in Perl and is executed by MSYS2's Perl interpreter), but
+`openssl.exe` is a MINGW program, so it needs Windows paths.
+
+There are probably more elegant ways to achieve the same, but I really
+only need to get the tests to run with the correct paths, and I cannot
+find anything on the web that suggests how to do this without forking
+and executing `cygpath.exe`. So I give up on a better way, for now.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ util/perl/OpenSSL/Test.pm | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/util/perl/OpenSSL/Test.pm b/util/perl/OpenSSL/Test.pm
+index 49fb88f..dccefd0 100644
+--- a/util/perl/OpenSSL/Test.pm
++++ b/util/perl/OpenSSL/Test.pm
+@@ -871,7 +871,11 @@ sub __env {
+     (my $recipe_datadir = basename($0)) =~ s/\.t$/_data/i;
+ 
+     $directories{SRCTOP}  = abs_path($ENV{SRCTOP} || $ENV{TOP});
++    $directories{SRCTOP}  = `cygpath -m $directories{SRCTOP}`;
++    $directories{SRCTOP} =~ s/\r?\n$//;
+     $directories{BLDTOP}  = abs_path($ENV{BLDTOP} || $ENV{TOP});
++    $directories{BLDTOP}  = `cygpath -m $directories{BLDTOP}`;
++    $directories{BLDTOP} =~ s/\r?\n$//;
+     $directories{BLDAPPS} = $ENV{BIN_D}  || __bldtop_dir("apps");
+     $directories{SRCAPPS} =                 __srctop_dir("apps");
+     $directories{BLDFUZZ} =                 __bldtop_dir("fuzz");
+-- 
+2.23.0.windows.1
+

--- a/mingw-w64-openssl-1.1/PKGBUILD
+++ b/mingw-w64-openssl-1.1/PKGBUILD
@@ -1,0 +1,197 @@
+# Maintainer: Alexey Pavlov <Alexpux@gmail.com>
+
+_realname=openssl
+pkgbase=mingw-w64-${_realname}-1.1
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-1.1"
+	"${MINGW_PACKAGE_PREFIX}-${_realname}-1.1-pdb")
+_ver=1.1.1t
+# use a pacman compatible version scheme
+pkgver=${_ver/[a-z]/.${_ver//[0-9.]/}}
+pkgrel=1
+arch=('any')
+pkgdesc="The Open Source toolkit for Secure Sockets Layer and Transport Layer Security (mingw-w64)"
+depends=("${MINGW_PACKAGE_PREFIX}-ca-certificates" "${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-zlib")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
+if [[ "$MSYSTEM" != CLANG* ]]; then
+  makedepends+=("${MINGW_PACKAGE_PREFIX}-cv2pdb")
+fi
+options=('!strip' '!buildflags' 'staticlibs')
+license=('BSD')
+url="https://www.openssl.org"
+noextract=(${_realname}-${_ver}.tar.gz)
+source=(https://www.openssl.org/source/${_realname}-${_ver}.tar.gz{,.asc}
+        'openssl-1.1.1-relocation.patch'
+        '0001-tests-work-around-the-MSYS-vs-Windows-paths-problem.patch'
+        '0001-shlib_wrap.sh-accommodate-for-MINGW-builds-being-tes.patch'
+        'openssl-1.1.1-mingw-arm.patch')
+sha256sums=('8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b'
+            'SKIP'
+            '1c6bf1b9cf0f183c96349b1820df52b1c5f2bc193060d4d31a6c45230a857f5c'
+            'f2871bff59d19fe60086116c0549b54814e8e0af7a9ce3b96bb21604466ad556'
+            '8d370171d3fc47db8603097c56c247b1ea7a1364109ac202064c70cf1629deef'
+            'd41fad88631e7b8d2a56662f2166ea97ecbc6369f2ad3eac415182bc9ac9f308')
+
+validpgpkeys=('8657ABB260F056B1E5190839D9C4D26D0E604491'
+              '7953AC1FBC3DC8B3B292393ED5E9E43F7DF9EE8C'
+              'DC7032662AF885E2F47F243F527466A21CA79E6D'
+              'A21FAB74B0088AA361152586B8EF1A6BA9DA2D5C')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
+prepare() {
+  # Clean up old sources so re-patching doesn't fail.
+  [[ -d ${srcdir}/${_realname}-${_ver} ]] && rm -rf ${srcdir}/${_realname}-${_ver}
+  tar -xzvf ${_realname}-${_ver}.tar.gz -C ${srcdir} || true
+  cd ${srcdir}/${_realname}-${_ver}
+
+# openssl-1.0.0a-ldflags.patch
+# openssl-1.0.2a-parallel-build.patch
+# openssl-1.0.1-x32.patch
+#  openssl-0.9.6-x509.patch
+  apply_patch_with_msg \
+     openssl-1.1.1-relocation.patch \
+     0001-tests-work-around-the-MSYS-vs-Windows-paths-problem.patch \
+     0001-shlib_wrap.sh-accommodate-for-MINGW-builds-being-tes.patch \
+     openssl-1.1.1-mingw-arm.patch
+}
+
+build() {
+  rm -rf ${srcdir}/build-${CARCH}
+ 
+  # No support for out-of-source builds
+  mkdir -p ${srcdir}/build-${CARCH}
+#  cp -a ${srcdir}/${_realname}-${_ver}/* ${srcdir}/build-${CARCH}
+
+  # Use mingw cflags instead of hardcoded ones
+  sed -i -e '/^"mingw"/ s/-fomit-frame-pointer -O3 -Wall/-O2 -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions --param=ssp-buffer-size=4/' \
+     ${srcdir}/${_realname}-${_ver}/Configure
+#     ${srcdir}/build-${CARCH}/Configure
+
+  case "${CARCH}" in
+    i?86)
+      _mingw=mingw
+      ;;
+    x86_64)
+      _mingw=mingw64
+      ;;
+    aarch64)
+      _mingw="mingwarm64 no-asm"
+      ;;
+  esac
+
+  export CC=${MINGW_PREFIX}/bin/cc.exe
+  export CXX=${MINGW_PREFIX}/bin/c++.exe
+  STRIP_OPTS=
+
+  if [[ "$MSYSTEM" == CLANG* ]]
+  then
+    export LDFLAGS="-Wl,-pdb=" # Ensures that Clang generates PDB files
+    STRIP=llvm-strip
+    STRIP_OPTS=--strip-debug
+  else
+    STRIP=cv2pdb
+  fi
+  cd "${srcdir}/build-${CARCH}"
+  export MSYS2_ARG_CONV_EXCL="--prefix="
+  ${srcdir}/${_realname}-${_ver}/Configure \
+    --prefix=${MINGW_PREFIX} \
+    --openssldir=ssl \
+    ${_mingw} \
+    shared \
+    zlib-dynamic \
+    enable-camellia \
+    enable-capieng \
+    enable-idea \
+    enable-mdc2 \
+    enable-rc5  \
+    enable-rfc3779 \
+    -D__MINGW_USE_VC2005_COMPAT \
+    -DOPENSSLBIN=\"\\\"${MINGW_PREFIX}/bin\\\"\"
+
+  sed -i -e 's/ -O3 /&-g /' \
+    -e 's/TOP=\.\.\//TOP="$(pwd)"\/..\//' \
+    Makefile
+
+  make ZLIB_INCLUDE=-I"${MINGW_PREFIX}"/include depend all
+
+  case "${pkgname[@]}" in
+  *-pdb|*-pdb\ *)
+    for file in apps/*.exe *.dll engines/*.dll
+    do
+      $STRIP $STRIP_OPTS "$file" || exit
+    done
+
+    # copy cv2pdb'ed versions of libeay32.dll and ssleay32.dll to apps/
+    cp -f *.dll *.pdb apps/;;
+  esac
+}
+
+check() {
+  cd "${srcdir}/build-${CARCH}"
+  make VERBOSE=1 test
+}
+
+_package() {
+  cd "${srcdir}/build-${CARCH}"
+
+  test pdb != "$1" || {
+    install -d -m 755 "${pkgdir}${MINGW_PREFIX}/bin"
+    install -d -m 755 "${pkgdir}${MINGW_PREFIX}/lib/engines"
+    install -m 755 *.pdb "${pkgdir}${MINGW_PREFIX}/bin"
+    install -m 755 engines/*.pdb "${pkgdir}${MINGW_PREFIX}/lib/engines"
+    return
+  }
+
+  mkdir -p "${pkgdir}${MINGW_PREFIX}"/bin
+  mkdir -p "${pkgdir}${MINGW_PREFIX}"/lib/engines-1_1
+  mkdir -p "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname}-1.1
+
+  make -j1 DESTDIR="${pkgdir}" install_engines
+  install -D -m644 "${srcdir}/${_realname}-${_ver}/LICENSE" \
+         "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname}-1.1/LICENSE
+
+  chmod -R 777 "${pkgdir}${MINGW_PREFIX}"/bin
+  chmod -R 777 "${pkgdir}${MINGW_PREFIX}"/lib
+  chmod -R 777 "${pkgdir}${MINGW_PREFIX}"/lib/engines-1_1
+}
+
+package_mingw-w64-i686-openssl-1.1() {
+  _package
+}
+
+package_mingw-w64-x86_64-openssl-1.1() {
+  _package
+}
+
+package_mingw-w64-clang-aarch64-openssl-1.1() {
+  _package
+}
+
+package_mingw-w64-i686-openssl-1.1-pdb() {
+  _package pdb
+}
+
+package_mingw-w64-x86_64-openssl-1.1-pdb() {
+  _package pdb
+}
+
+package_mingw-w64-clang-aarch64-openssl-1.1-pdb() {
+  _package pdb
+}

--- a/mingw-w64-openssl-1.1/openssl-0.9.6-x509.patch
+++ b/mingw-w64-openssl-1.1/openssl-0.9.6-x509.patch
@@ -1,0 +1,63 @@
+Do not treat duplicate certs as an error.
+
+--- openssl-0.9.6/crypto/x509/by_file.c	Wed Sep 27 15:09:05 2000
++++ openssl-0.9.6/crypto/x509/by_file.c	Wed Sep 27 14:21:20 2000
+@@ -152,9 +152,12 @@
+                 }
+             }
+             i = X509_STORE_add_cert(ctx->store_ctx, x);
+-            if (!i)
+-                goto err;
+-            count++;
++            /* ignore any problems with current certificate 
++                and continue with the next one */
++            if (i)
++                count++;
++            else
++                ERR_clear_error();
+             X509_free(x);
+             x = NULL;
+         }
+@@ -166,8 +169,8 @@
+             goto err;
+         }
+         i = X509_STORE_add_cert(ctx->store_ctx, x);
+-        if (!i)
+-            goto err;
++        if (!i)
++          ERR_clear_error();
+         ret = i;
+     } else {
+         X509err(X509_F_X509_LOAD_CERT_FILE, X509_R_BAD_X509_FILETYPE);
+--- openssl-0.9.6/crypto/store/store.h	2009-08-12 00:57:20.000000000 +0200
++++ openssl-0.9.6/crypto/store/store.h	2009-08-12 01:00:27.000000000 +0200
+@@ -77,6 +77,13 @@
+ extern "C" {
+ #endif
+ 
++#ifdef OPENSSL_SYS_WIN32
++/* Under Win32 these are defined in wincrypt.h */
++#undef X509_NAME
++#undef X509_CERT_PAIR
++#undef X509_EXTENSIONS
++#endif
++
+ /* Already defined in ossl_typ.h */
+ /* typedef struct store_st STORE; */
+ /* typedef struct store_method_st STORE_METHOD; */
+--- openssl-0.9.6/crypto/pem/pem.h	2009-08-12 01:14:59.000000000 +0200
++++ openssl-0.9.6/crypto/pem/pem.h	2009-08-12 01:15:01.000000000 +0200
+@@ -74,6 +74,13 @@
+ extern "C" {
+ #endif
+ 
++#ifdef OPENSSL_SYS_WIN32
++/* Under Win32 these are defined in wincrypt.h */
++#undef X509_NAME
++#undef X509_CERT_PAIR
++#undef X509_EXTENSIONS
++#endif
++
+ # define PEM_BUFSIZE             1024
+ 
+ # define PEM_OBJ_UNDEF           0

--- a/mingw-w64-openssl-1.1/openssl-1.0.0a-ldflags.patch
+++ b/mingw-w64-openssl-1.1/openssl-1.0.0a-ldflags.patch
@@ -1,0 +1,23 @@
+http://bugs.gentoo.org/327421
+
+--- a/Makefile.org
++++ b/Makefile.org
+@@ -216,6 +216,7 @@
+ 		MAKEDEPEND='$$$${TOP}/util/domd $$$${TOP} -MD $(MAKEDEPPROG)' \
+ 		DEPFLAG='-DOPENSSL_NO_DEPRECATED $(DEPFLAG)'	\
+ 		MAKEDEPPROG='$(MAKEDEPPROG)'			\
++		LDFLAGS='${LDFLAGS}'				\
+ 		SHARED_LDFLAGS='$(SHARED_LDFLAGS)'		\
+ 		KRB5_INCLUDES='$(KRB5_INCLUDES)' LIBKRB5='$(LIBKRB5)'	\
+ 		ZLIB_INCLUDE='$(ZLIB_INCLUDE)' LIBZLIB='$(LIBZLIB)'	\
+--- a/Makefile.shared
++++ b/Makefile.shared
+@@ -153,7 +153,7 @@
+ 	NOALLSYMSFLAGS='-Wl,--no-whole-archive'; \
+ 	SHAREDFLAGS="$(CFLAGS) $(SHARED_LDFLAGS) -shared -Wl,-Bsymbolic -Wl,-soname=$$SHLIB$$SHLIB_SOVER$$SHLIB_SUFFIX"
+ 
+-DO_GNU_APP=LDFLAGS="$(CFLAGS) -Wl,-rpath,$(LIBRPATH)"
++DO_GNU_APP=LDFLAGS="$(LDFLAGS) $(CFLAGS)"
+ 
+ #This is rather special.  It's a special target with which one can link
+ #applications without bothering with any features that have anything to

--- a/mingw-w64-openssl-1.1/openssl-1.0.1-x32.patch
+++ b/mingw-w64-openssl-1.1/openssl-1.0.1-x32.patch
@@ -1,0 +1,70 @@
+http://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/?id=51bfed2e26fc13a66e8b5710aa2ce1d7a04af721
+
+UpstreamStatus: Pending
+
+Received from H J Liu @ Intel
+Make the assembly syntax compatible with x32 gcc. Othewise x32 gcc throws errors.
+Signed-Off-By: Nitin A Kamble <nitin.a.kamble@intel.com> 2011/07/13
+
+ported the patch to the 1.0.0e version
+Signed-Off-By: Nitin A Kamble <nitin.a.kamble@intel.com> 2011/12/01
+Index: openssl-1.0.2a/Configure
+===================================================================
+--- openssl-1.0.2a.orig/Configure
++++ openssl-1.0.2a/Configure
+@@ -217,6 +217,7 @@ my %table=(
+ "debug-linux-generic32","gcc:-DBN_DEBUG -DREF_CHECK -DCONF_DEBUG -DCRYPTO_MDEBUG -g -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${no_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+ "debug-linux-generic64","gcc:-DBN_DEBUG -DREF_CHECK -DCONF_DEBUG -DCRYPTO_MDEBUG -DTERMIO -g -Wall::-D_REENTRANT::-ldl:SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${no_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+ "debug-linux-x86_64","gcc:-DBN_DEBUG -DREF_CHECK -DCONF_DEBUG -DCRYPTO_MDEBUG -m64 -DL_ENDIAN -g -Wall::-D_REENTRANT::-ldl:SIXTY_FOUR_BIT_LONG RC4_CHUNK DES_INT DES_UNROLL:${x86_64_asm}:elf:dlfcn:linux-shared:-fPIC:-m64:.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR):::64",
++"linux-x32",	"gcc:-DL_ENDIAN 	-DTERMIO -O2 -pipe -g -feliminate-unused-debug-types -Wall::-D_REENTRANT::-ldl:SIXTY_FOUR_BIT RC4_CHUNK DES_INT DES_UNROLL:${x86_64_asm}:elf:dlfcn:linux-shared:-fPIC:-mx32:.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+ "dist",		"cc:-O::(unknown)::::::",
+ 
+ # Basic configs that should work on any (32 and less bit) box
+Index: openssl-1.0.2a/crypto/bn/asm/x86_64-gcc.c
+===================================================================
+--- openssl-1.0.2a.orig/crypto/bn/asm/x86_64-gcc.c
++++ openssl-1.0.2a/crypto/bn/asm/x86_64-gcc.c
+@@ -212,9 +212,9 @@ BN_ULONG bn_add_words (BN_ULONG *rp, con
+     asm volatile ("       subq    %0,%0           \n" /* clear carry */
+                   "       jmp     1f              \n"
+                   ".p2align 4                     \n"
+-                  "1:     movq    (%4,%2,8),%0    \n"
+-                  "       adcq    (%5,%2,8),%0    \n"
+-                  "       movq    %0,(%3,%2,8)    \n"
++                  "1:     movq    (%q4,%2,8),%0   \n"
++                  "       adcq    (%q5,%2,8),%0   \n"
++                  "       movq    %0,(%q3,%2,8)   \n"
+                   "       lea     1(%2),%2        \n"
+                   "       loop    1b              \n"
+                   "       sbbq    %0,%0           \n":"=&r" (ret), "+c"(n),
+@@ -238,9 +238,9 @@ BN_ULONG bn_sub_words (BN_ULONG *rp, con
+     asm volatile ("       subq    %0,%0           \n" /* clear borrow */
+                   "       jmp     1f              \n"
+                   ".p2align 4                     \n"
+-                  "1:     movq    (%4,%2,8),%0    \n"
+-                  "       sbbq    (%5,%2,8),%0    \n"
+-                  "       movq    %0,(%3,%2,8)    \n"
++                  "1:     movq    (%q4,%2,8),%0   \n"
++                  "       sbbq    (%q5,%2,8),%0   \n"
++                  "       movq    %0,(%q3,%2,8)   \n"
+                   "       lea     1(%2),%2        \n"
+                   "       loop    1b              \n"
+                   "       sbbq    %0,%0           \n":"=&r" (ret), "+c"(n),
+Index: openssl-1.0.2a/crypto/bn/bn.h
+===================================================================
+--- openssl-1.0.2a.orig/crypto/bn/bn.h
++++ openssl-1.0.2a/crypto/bn/bn.h
+@@ -173,6 +173,13 @@ extern "C" {
+ #  endif
+ # endif
+ 
++/* Address type.  */
++#ifdef _WIN64
++#define BN_ADDR unsigned long long
++#else
++#define BN_ADDR unsigned long
++#endif
++
+ /*
+  * assuming long is 64bit - this is the DEC Alpha unsigned long long is only
+  * 64 bits :-(, don't define BN_LLONG for the DEC Alpha

--- a/mingw-w64-openssl-1.1/openssl-1.0.2-ipv6.patch
+++ b/mingw-w64-openssl-1.1/openssl-1.0.2-ipv6.patch
@@ -1,0 +1,611 @@
+http://rt.openssl.org/Ticket/Display.html?id=2051&user=guest&pass=guest
+
+--- openssl-1.0.2/apps/s_apps.h
++++ openssl-1.0.2/apps/s_apps.h
+@@ -154,7 +154,7 @@
+ int do_server(int port, int type, int *ret,
+               int (*cb) (char *hostname, int s, int stype,
+                          unsigned char *context), unsigned char *context,
+-              int naccept);
++              int naccept, int use_ipv4, int use_ipv6);
+ #ifdef HEADER_X509_H
+ int MS_CALLBACK verify_callback(int ok, X509_STORE_CTX *ctx);
+ #endif
+@@ -167,7 +167,8 @@
+ int ssl_print_curves(BIO *out, SSL *s, int noshared);
+ #endif
+ int ssl_print_tmp_key(BIO *out, SSL *s);
+-int init_client(int *sock, char *server, int port, int type);
++int init_client(int *sock, char *server, int port, int type,
++		int use_ipv4, int use_ipv6);
+ int should_retry(int i);
+ int extract_port(char *str, short *port_ptr);
+ int extract_host_port(char *str, char **host_ptr, unsigned char *ip,
+--- openssl-1.0.2/apps/s_client.c
++++ openssl-1.0.2/apps/s_client.c
+@@ -302,6 +302,10 @@
+ {
+     BIO_printf(bio_err, "usage: s_client args\n");
+     BIO_printf(bio_err, "\n");
++    BIO_printf(bio_err, " -4             - use IPv4 only\n");
++#if OPENSSL_USE_IPV6
++    BIO_printf(bio_err, " -6             - use IPv6 only\n");
++#endif
+     BIO_printf(bio_err, " -host host     - use -connect instead\n");
+     BIO_printf(bio_err, " -port port     - use -connect instead\n");
+     BIO_printf(bio_err,
+@@ -658,6 +662,7 @@
+     int sbuf_len, sbuf_off;
+     fd_set readfds, writefds;
+     short port = PORT;
++    int use_ipv4, use_ipv6;
+     int full_log = 1;
+     char *host = SSL_HOST_NAME;
+     char *cert_file = NULL, *key_file = NULL, *chain_file = NULL;
+@@ -709,7 +714,11 @@
+ #endif
+     char *sess_in = NULL;
+     char *sess_out = NULL;
+-    struct sockaddr peer;
++#if OPENSSL_USE_IPV6
++    struct sockaddr_storage peer;
++#else
++    struct sockaddr_in peer;
++#endif
+     int peerlen = sizeof(peer);
+     int fallback_scsv = 0;
+     int enable_timeouts = 0;
+@@ -737,6 +746,12 @@
+ 
+     meth = SSLv23_client_method();
+ 
++    use_ipv4 = 1;
++#if OPENSSL_USE_IPV6
++    use_ipv6 = 1;
++#else
++    use_ipv6 = 0;
++#endif
+     apps_startup();
+     c_Pause = 0;
+     c_quiet = 0;
+@@ -1096,6 +1111,16 @@
+             jpake_secret = *++argv;
+         }
+ #endif
++	else if (strcmp(*argv,"-4") == 0) {
++	    use_ipv4 = 1;
++	    use_ipv6 = 0;
++	}
++#if OPENSSL_USE_IPV6
++	else if (strcmp(*argv,"-6") == 0) {
++	    use_ipv4 = 0;
++	    use_ipv6 = 1;
++	}
++#endif
+ #ifndef OPENSSL_NO_SRTP
+         else if (strcmp(*argv, "-use_srtp") == 0) {
+             if (--argc < 1)
+@@ -1421,7 +1446,7 @@
+ 
+  re_start:
+ 
+-    if (init_client(&s, host, port, socket_type) == 0) {
++    if (init_client(&s, host, port, socket_type, use_ipv4, use_ipv6) == 0) {
+         BIO_printf(bio_err, "connect:errno=%d\n", get_last_socket_error());
+         SHUTDOWN(s);
+         goto end;
+@@ -1444,7 +1469,7 @@
+     if (socket_type == SOCK_DGRAM) {
+ 
+         sbio = BIO_new_dgram(s, BIO_NOCLOSE);
+-        if (getsockname(s, &peer, (void *)&peerlen) < 0) {
++        if (getsockname(s, (struct sockaddr *)&peer, (void *)&peerlen) < 0) {
+             BIO_printf(bio_err, "getsockname:errno=%d\n",
+                        get_last_socket_error());
+             SHUTDOWN(s);
+--- openssl-1.0.2/apps/s_server.c
++++ openssl-1.0.2/apps/s_server.c
+@@ -643,6 +643,10 @@
+     BIO_printf(bio_err,
+                " -alpn arg  - set the advertised protocols for the ALPN extension (comma-separated list)\n");
+ #endif
++    BIO_printf(bio_err, " -4            - use IPv4 only\n");
++#if OPENSSL_USE_IPV6
++    BIO_printf(bio_err, " -6            - use IPv6 only\n");
++#endif
+     BIO_printf(bio_err,
+                " -keymatexport label   - Export keying material using label\n");
+     BIO_printf(bio_err,
+@@ -1070,6 +1074,7 @@
+     int state = 0;
+     const SSL_METHOD *meth = NULL;
+     int socket_type = SOCK_STREAM;
++    int use_ipv4, use_ipv6;
+     ENGINE *e = NULL;
+     char *inrand = NULL;
+     int s_cert_format = FORMAT_PEM, s_key_format = FORMAT_PEM;
+@@ -1111,6 +1116,12 @@
+ 
+     meth = SSLv23_server_method();
+ 
++    use_ipv4 = 1;
++#if OPENSSL_USE_IPV6
++    use_ipv6 = 1;
++#else
++    use_ipv6 = 0;
++#endif
+     local_argc = argc;
+     local_argv = argv;
+ 
+@@ -1503,6 +1514,16 @@
+             jpake_secret = *(++argv);
+         }
+ #endif
++	else if (strcmp(*argv,"-4") == 0) {
++	    use_ipv4 = 1;
++	    use_ipv6 = 0;
++	}
++#if OPENSSL_USE_IPV6
++	else if (strcmp(*argv,"-6") == 0) {
++	    use_ipv4 = 0;
++	    use_ipv6 = 1;
++	}
++#endif
+ #ifndef OPENSSL_NO_SRTP
+         else if (strcmp(*argv, "-use_srtp") == 0) {
+             if (--argc < 1)
+@@ -2023,13 +2044,13 @@
+     (void)BIO_flush(bio_s_out);
+     if (rev)
+         do_server(port, socket_type, &accept_socket, rev_body, context,
+-                  naccept);
++                  naccept, use_ipv4, use_ipv6);
+     else if (www)
+         do_server(port, socket_type, &accept_socket, www_body, context,
+-                  naccept);
++                  naccept, use_ipv4, use_ipv6);
+     else
+         do_server(port, socket_type, &accept_socket, sv_body, context,
+-                  naccept);
++                  naccept, use_ipv4, use_ipv6);
+     print_stats(bio_s_out, ctx);
+     ret = 0;
+  end:
+--- openssl-1.0.2/apps/s_socket.c
++++ openssl-1.0.2/apps/s_socket.c
+@@ -101,16 +101,16 @@
+ #  include "netdb.h"
+ # endif
+ 
+-static struct hostent *GetHostByName(char *name);
++static struct hostent *GetHostByName(char *name, int domain);
+ # if defined(OPENSSL_SYS_WINDOWS) || (defined(OPENSSL_SYS_NETWARE) && !defined(NETWARE_BSDSOCK))
+ static void ssl_sock_cleanup(void);
+ # endif
+ static int ssl_sock_init(void);
+-static int init_client_ip(int *sock, unsigned char ip[4], int port, int type);
+-static int init_server(int *sock, int port, int type);
+-static int init_server_long(int *sock, int port, char *ip, int type);
++static int init_client_ip(int *sock, unsigned char *ip, int port, int type, int domain);
++static int init_server(int *sock, int port, int type, int use_ipv4, int use_ipv6);
++static int init_server_long(int *sock, int port, char *ip, int type, int use_ipv4, int use_ipv6);
+ static int do_accept(int acc_sock, int *sock, char **host);
+-static int host_ip(char *str, unsigned char ip[4]);
++static int host_ip(char *str, unsigned char *ip, int domain);
+ 
+ # ifdef OPENSSL_SYS_WIN16
+ #  define SOCKET_PROTOCOL 0     /* more microsoft stupidity */
+@@ -231,38 +231,68 @@
+     return (1);
+ }
+ 
+-int init_client(int *sock, char *host, int port, int type)
++int init_client(int *sock, char *host, int port, int type, int use_ipv4, int use_ipv6)
+ {
++# if OPENSSL_USE_IPV6
++    unsigned char ip[16];
++# else
+     unsigned char ip[4];
++# endif
+ 
+-    memset(ip, '\0', sizeof ip);
+-    if (!host_ip(host, &(ip[0])))
+-        return 0;
+-    return init_client_ip(sock, ip, port, type);
+-}
+-
+-static int init_client_ip(int *sock, unsigned char ip[4], int port, int type)
+-{
+-    unsigned long addr;
++    if (use_ipv4)
++	if (host_ip(host, ip, AF_INET))
++	    return(init_client_ip(sock, ip, port, type, AF_INET));
++# if OPENSSL_USE_IPV6
++    if (use_ipv6)
++	if (host_ip(host, ip, AF_INET6))
++	    return(init_client_ip(sock, ip, port, type, AF_INET6));
++# endif
++    return 0;
++}
++
++static int init_client_ip(int *sock, unsigned char ip[4], int port, int type, int domain)
++{
++# if OPENSSL_USE_IPV6
++    struct sockaddr_storage them;
++    struct sockaddr_in *them_in = (struct sockaddr_in *)&them;
++    struct sockaddr_in6 *them_in6 = (struct sockaddr_in6 *)&them;
++# else
+     struct sockaddr_in them;
++    struct sockaddr_in *them_in = &them;
++# endif
++    socklen_t addr_len;
+     int s, i;
+ 
+     if (!ssl_sock_init())
+         return (0);
+ 
+     memset((char *)&them, 0, sizeof(them));
+-    them.sin_family = AF_INET;
+-    them.sin_port = htons((unsigned short)port);
+-    addr = (unsigned long)
+-        ((unsigned long)ip[0] << 24L) |
+-        ((unsigned long)ip[1] << 16L) |
+-        ((unsigned long)ip[2] << 8L) | ((unsigned long)ip[3]);
+-    them.sin_addr.s_addr = htonl(addr);
++    if (domain == AF_INET) {
++	addr_len = (socklen_t)sizeof(struct sockaddr_in);
++	them_in->sin_family=AF_INET;
++	them_in->sin_port=htons((unsigned short)port);
++# ifndef BIT_FIELD_LIMITS
++	memcpy(&them_in->sin_addr.s_addr, ip, 4);
++# else
++	memcpy(&them_in->sin_addr, ip, 4);
++# endif
++    }
++    else
++# if OPENSSL_USE_IPV6
++    {
++	addr_len = (socklen_t)sizeof(struct sockaddr_in6);
++	them_in6->sin6_family=AF_INET6;
++	them_in6->sin6_port=htons((unsigned short)port);
++	memcpy(&(them_in6->sin6_addr), ip, sizeof(struct in6_addr));
++    }
++# else
++	return(0);
++# endif
+ 
+     if (type == SOCK_STREAM)
+-        s = socket(AF_INET, SOCK_STREAM, SOCKET_PROTOCOL);
++        s = socket(domain, SOCK_STREAM, SOCKET_PROTOCOL);
+     else                        /* ( type == SOCK_DGRAM) */
+-        s = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
++        s = socket(domain, SOCK_DGRAM, IPPROTO_UDP);
+ 
+     if (s == INVALID_SOCKET) {
+         perror("socket");
+@@ -280,7 +310,7 @@
+     }
+ # endif
+ 
+-    if (connect(s, (struct sockaddr *)&them, sizeof(them)) == -1) {
++    if (connect(s, (struct sockaddr *)&them, addr_len) == -1) {
+         closesocket(s);
+         perror("connect");
+         return (0);
+@@ -292,14 +322,14 @@
+ int do_server(int port, int type, int *ret,
+               int (*cb) (char *hostname, int s, int stype,
+                          unsigned char *context), unsigned char *context,
+-              int naccept)
++              int naccept, int use_ipv4, int use_ipv6)
+ {
+     int sock;
+     char *name = NULL;
+     int accept_socket = 0;
+     int i;
+ 
+-    if (!init_server(&accept_socket, port, type))
++    if (!init_server(&accept_socket, port, type, use_ipv4, use_ipv6))
+         return (0);
+ 
+     if (ret != NULL) {
+@@ -328,32 +358,41 @@
+     }
+ }
+ 
+-static int init_server_long(int *sock, int port, char *ip, int type)
++static int init_server_long(int *sock, int port, char *ip, int type, int use_ipv4, int use_ipv6)
+ {
+     int ret = 0;
++    int domain;
++# if OPENSSL_USE_IPV6
++    struct sockaddr_storage server;
++    struct sockaddr_in *server_in = (struct sockaddr_in *)&server;
++    struct sockaddr_in6 *server_in6 = (struct sockaddr_in6 *)&server;
++# else
+     struct sockaddr_in server;
++    struct sockaddr_in *server_in = &server;
++# endif
++    socklen_t addr_len;
+     int s = -1;
+ 
++    if (!use_ipv4 && !use_ipv6)
++	goto err;
++# if OPENSSL_USE_IPV6
++    /* we are fine here */
++# else
++    if (use_ipv6)
++	goto err;
++# endif
+     if (!ssl_sock_init())
+         return (0);
+ 
+-    memset((char *)&server, 0, sizeof(server));
+-    server.sin_family = AF_INET;
+-    server.sin_port = htons((unsigned short)port);
+-    if (ip == NULL)
+-        server.sin_addr.s_addr = INADDR_ANY;
+-    else
+-/* Added for T3E, address-of fails on bit field (beckman@acl.lanl.gov) */
+-# ifndef BIT_FIELD_LIMITS
+-        memcpy(&server.sin_addr.s_addr, ip, 4);
++#if OPENSSL_USE_IPV6
++    domain = use_ipv6 ? AF_INET6 : AF_INET;
+ # else
+-        memcpy(&server.sin_addr, ip, 4);
++    domain = AF_INET;
+ # endif
+-
+     if (type == SOCK_STREAM)
+-        s = socket(AF_INET, SOCK_STREAM, SOCKET_PROTOCOL);
+-    else                        /* type == SOCK_DGRAM */
+-        s = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
++	s=socket(domain, SOCK_STREAM, SOCKET_PROTOCOL);
++    else /* type == SOCK_DGRAM */
++	s=socket(domain, SOCK_DGRAM, IPPROTO_UDP);
+ 
+     if (s == INVALID_SOCKET)
+         goto err;
+@@ -363,7 +402,42 @@
+         setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (void *)&j, sizeof j);
+     }
+ # endif
+-    if (bind(s, (struct sockaddr *)&server, sizeof(server)) == -1) {
++# if OPENSSL_USE_IPV6
++    if ((use_ipv4 == 0) && (use_ipv6 == 1)) {
++	const int on = 1;
++
++	setsockopt(s, IPPROTO_IPV6, IPV6_V6ONLY,
++		    (const void *) &on, sizeof(int));
++    }
++# endif
++    if (domain == AF_INET) {
++	addr_len = (socklen_t)sizeof(struct sockaddr_in);
++	memset(server_in, 0, sizeof(struct sockaddr_in));
++	server_in->sin_family=AF_INET;
++	server_in->sin_port = htons((unsigned short)port);
++	if (ip == NULL)
++	    server_in->sin_addr.s_addr = htonl(INADDR_ANY);
++	else
++/* Added for T3E, address-of fails on bit field (beckman@acl.lanl.gov) */
++# ifndef BIT_FIELD_LIMITS
++	    memcpy(&server_in->sin_addr.s_addr, ip, 4);
++# else
++	    memcpy(&server_in->sin_addr, ip, 4);
++# endif
++    }
++# if OPENSSL_USE_IPV6
++    else {
++	addr_len = (socklen_t)sizeof(struct sockaddr_in6);
++	memset(server_in6, 0, sizeof(struct sockaddr_in6));
++	server_in6->sin6_family = AF_INET6;
++	server_in6->sin6_port = htons((unsigned short)port);
++	if (ip == NULL)
++	    server_in6->sin6_addr = in6addr_any;
++	else
++	    memcpy(&server_in6->sin6_addr, ip, sizeof(struct in6_addr));
++    }
++# endif
++    if (bind(s, (struct sockaddr *)&server, addr_len) == -1) {
+ # ifndef OPENSSL_SYS_WINDOWS
+         perror("bind");
+ # endif
+@@ -381,16 +455,23 @@
+     return (ret);
+ }
+ 
+-static int init_server(int *sock, int port, int type)
++static int init_server(int *sock, int port, int type, int use_ipv4, int use_ipv6)
+ {
+-    return (init_server_long(sock, port, NULL, type));
++    return (init_server_long(sock, port, NULL, type, use_ipv4, use_ipv6));
+ }
+ 
+ static int do_accept(int acc_sock, int *sock, char **host)
+ {
+     int ret;
+     struct hostent *h1, *h2;
+-    static struct sockaddr_in from;
++#if OPENSSL_USE_IPV6
++    struct sockaddr_storage from;
++    struct sockaddr_in *from_in = (struct sockaddr_in *)&from;
++    struct sockaddr_in6 *from_in6 = (struct sockaddr_in6 *)&from;
++#else
++    struct sockaddr_in from;
++    struct sockaddr_in *from_in = &from;
++#endif
+     int len;
+ /*      struct linger ling; */
+ 
+@@ -440,14 +521,25 @@
+ 
+     if (host == NULL)
+         goto end;
++# if OPENSSL_USE_IPV6
++    if (from.ss_family == AF_INET)
++# else
++    if (from.sin_family == AF_INET)
++# endif
+ # ifndef BIT_FIELD_LIMITS
+-    /* I should use WSAAsyncGetHostByName() under windows */
+-    h1 = gethostbyaddr((char *)&from.sin_addr.s_addr,
+-                       sizeof(from.sin_addr.s_addr), AF_INET);
++	/* I should use WSAAsyncGetHostByName() under windows */
++	h1 = gethostbyaddr((char *)&from_in->sin_addr.s_addr,
++                	    sizeof(from_in->sin_addr.s_addr), AF_INET);
+ # else
+-    h1 = gethostbyaddr((char *)&from.sin_addr,
+-                       sizeof(struct in_addr), AF_INET);
++	h1 = gethostbyaddr((char *)&from_in->sin_addr,
++            		    sizeof(struct in_addr), AF_INET);
++# endif
++# if OPENSSL_USE_IPV6
++    else
++	h1 = gethostbyaddr((char *)&from_in6->sin6_addr,
++			    sizeof(struct in6_addr), AF_INET6);
+ # endif
++	    
+     if (h1 == NULL) {
+         BIO_printf(bio_err, "bad gethostbyaddr\n");
+         *host = NULL;
+@@ -460,14 +552,22 @@
+         }
+         BUF_strlcpy(*host, h1->h_name, strlen(h1->h_name) + 1);
+ 
+-        h2 = GetHostByName(*host);
++# if OPENSSL_USE_IPV6
++	h2=GetHostByName(*host, from.ss_family);
++# else
++	h2=GetHostByName(*host, from.sin_family);
++# endif
+         if (h2 == NULL) {
+             BIO_printf(bio_err, "gethostbyname failure\n");
+             closesocket(ret);
+             return (0);
+         }
+-        if (h2->h_addrtype != AF_INET) {
+-            BIO_printf(bio_err, "gethostbyname addr is not AF_INET\n");
++# if OPENSSL_USE_IPV6
++	if (h2->h_addrtype != from.ss_family) {
++# else
++	if (h2->h_addrtype != from.sin_family) {
++# endif
++            BIO_printf(bio_err, "gethostbyname addr is not correct\n");
+             closesocket(ret);
+             return (0);
+         }
+@@ -483,14 +583,14 @@
+     char *h, *p;
+ 
+     h = str;
+-    p = strchr(str, ':');
++    p = strrchr(str, ':');
+     if (p == NULL) {
+         BIO_printf(bio_err, "no port defined\n");
+         return (0);
+     }
+     *(p++) = '\0';
+ 
+-    if ((ip != NULL) && !host_ip(str, ip))
++    if ((ip != NULL) && !host_ip(str, ip, AF_INET))
+         goto err;
+     if (host_ptr != NULL)
+         *host_ptr = h;
+@@ -502,44 +602,51 @@
+     return (0);
+ }
+ 
+-static int host_ip(char *str, unsigned char ip[4])
++static int host_ip(char *str, unsigned char *ip, int domain)
+ {
+     unsigned int in[4];
++    unsigned long l;
+     int i;
+ 
+-    if (sscanf(str, "%u.%u.%u.%u", &(in[0]), &(in[1]), &(in[2]), &(in[3])) ==
+-        4) {
++    if ((domain == AF_INET) && (sscanf(str, "%u.%u.%u.%u", &(in[0]), &(in[1]), &(in[2]), &(in[3])) == 4)) {
+         for (i = 0; i < 4; i++)
+             if (in[i] > 255) {
+                 BIO_printf(bio_err, "invalid IP address\n");
+                 goto err;
+             }
+-        ip[0] = in[0];
+-        ip[1] = in[1];
+-        ip[2] = in[2];
+-        ip[3] = in[3];
+-    } else {                    /* do a gethostbyname */
++	l=htonl((in[0]<<24L)|(in[1]<<16L)|(in[2]<<8L)|in[3]);
++	memcpy(ip, &l, 4);
++	return 1;
++    }
++# if OPENSSL_USE_IPV6
++    else if ((domain == AF_INET6) && (inet_pton(AF_INET6, str, ip) == 1))
++	return 1;
++# endif
++    else {                    /* do a gethostbyname */
+         struct hostent *he;
+ 
+         if (!ssl_sock_init())
+             return (0);
+ 
+-        he = GetHostByName(str);
++        he = GetHostByName(str, domain);
+         if (he == NULL) {
+             BIO_printf(bio_err, "gethostbyname failure\n");
+             goto err;
+         }
+         /* cast to short because of win16 winsock definition */
+-        if ((short)he->h_addrtype != AF_INET) {
+-            BIO_printf(bio_err, "gethostbyname addr is not AF_INET\n");
++        if ((short)he->h_addrtype != domain) {
++            BIO_printf(bio_err, "gethostbyname addr is not correct\n");
+             return (0);
+         }
+-        ip[0] = he->h_addr_list[0][0];
+-        ip[1] = he->h_addr_list[0][1];
+-        ip[2] = he->h_addr_list[0][2];
+-        ip[3] = he->h_addr_list[0][3];
++	if (domain == AF_INET)
++	    memset(ip, 0, 4);
++# if OPENSSL_USE_IPV6
++	else
++	    memset(ip, 0, 16);
++# endif
++	memcpy(ip, he->h_addr_list[0], he->h_length);
++	return 1;
+     }
+-    return (1);
+  err:
+     return (0);
+ }
+@@ -573,7 +680,7 @@
+ static unsigned long ghbn_hits = 0L;
+ static unsigned long ghbn_miss = 0L;
+ 
+-static struct hostent *GetHostByName(char *name)
++static struct hostent *GetHostByName(char *name, int domain)
+ {
+     struct hostent *ret;
+     int i, lowi = 0;
+@@ -585,13 +692,18 @@
+             lowi = i;
+         }
+         if (ghbn_cache[i].order > 0) {
+-            if (strncmp(name, ghbn_cache[i].name, 128) == 0)
++            if ((strncmp(name, ghbn_cache[i].name, 128) == 0) && (ghbn_cache[i].ent.h_addrtype == domain))
+                 break;
+         }
+     }
+     if (i == GHBN_NUM) {        /* no hit */
+         ghbn_miss++;
+-        ret = gethostbyname(name);
++        if (domain == AF_INET)
++    	    ret = gethostbyname(name);
++# if OPENSSL_USE_IPV6
++	else
++	    ret = gethostbyname2(name, AF_INET6);
++# endif
+         if (ret == NULL)
+             return (NULL);
+         /* else add to cache */

--- a/mingw-w64-openssl-1.1/openssl-1.0.2a-parallel-build.patch
+++ b/mingw-w64-openssl-1.1/openssl-1.0.2a-parallel-build.patch
@@ -1,0 +1,363 @@
+http://rt.openssl.org/Ticket/Display.html?id=2084&user=guest&pass=guest
+
+--- openssl-1.0.2a/crypto/Makefile
++++ openssl-1.0.2a/crypto/Makefile
+@@ -85,11 +85,11 @@
+ 	@if [ -z "$(THIS)" ]; then $(MAKE) -f $(TOP)/Makefile reflect THIS=$@; fi
+ 
+ subdirs:
+-	@target=all; $(RECURSIVE_MAKE)
++	+@target=all; $(RECURSIVE_MAKE)
+ 
+ files:
+ 	$(PERL) $(TOP)/util/files.pl "CPUID_OBJ=$(CPUID_OBJ)" Makefile >> $(TOP)/MINFO
+-	@target=files; $(RECURSIVE_MAKE)
++	+@target=files; $(RECURSIVE_MAKE)
+ 
+ links:
+ 	@$(PERL) $(TOP)/util/mklink.pl ../include/openssl $(EXHEADER)
+@@ -100,7 +100,7 @@
+ # lib: $(LIB): are splitted to avoid end-less loop
+ lib:	$(LIB)
+ 	@touch lib
+-$(LIB):	$(LIBOBJ)
++$(LIB):	$(LIBOBJ) | subdirs
+ 	$(AR) $(LIB) $(LIBOBJ)
+ 	test -z "$(FIPSLIBDIR)" || $(AR) $(LIB) $(FIPSLIBDIR)fipscanister.o
+ 	$(RANLIB) $(LIB) || echo Never mind.
+@@ -111,7 +111,7 @@
+ 	fi
+ 
+ libs:
+-	@target=lib; $(RECURSIVE_MAKE)
++	+@target=lib; $(RECURSIVE_MAKE)
+ 
+ install:
+ 	@[ -n "$(INSTALLTOP)" ] # should be set by top Makefile...
+@@ -120,7 +120,7 @@
+ 	(cp $$i $(INSTALL_PREFIX)$(INSTALLTOP)/include/openssl/$$i; \
+ 	chmod 644 $(INSTALL_PREFIX)$(INSTALLTOP)/include/openssl/$$i ); \
+ 	done;
+-	@target=install; $(RECURSIVE_MAKE)
++	+@target=install; $(RECURSIVE_MAKE)
+ 
+ lint:
+ 	@target=lint; $(RECURSIVE_MAKE)
+--- openssl-1.0.2a/crypto/objects/Makefile
++++ openssl-1.0.2a/crypto/objects/Makefile
+@@ -44,11 +44,11 @@
+ # objects.pl both reads and writes obj_mac.num
+ obj_mac.h: objects.pl objects.txt obj_mac.num
+ 	$(PERL) objects.pl objects.txt obj_mac.num obj_mac.h
+-	@sleep 1; touch obj_mac.h; sleep 1
+ 
+-obj_xref.h: objxref.pl obj_xref.txt obj_mac.num
++# This doesn't really need obj_mac.h, but since that rule reads & writes
++# obj_mac.num, we can't run in parallel with it.
++obj_xref.h: objxref.pl obj_xref.txt obj_mac.num obj_mac.h
+ 	$(PERL) objxref.pl obj_mac.num obj_xref.txt > obj_xref.h
+-	@sleep 1; touch obj_xref.h; sleep 1
+ 
+ files:
+ 	$(PERL) $(TOP)/util/files.pl Makefile >> $(TOP)/MINFO
+--- openssl-1.0.2a/engines/Makefile
++++ openssl-1.0.2a/engines/Makefile
+@@ -72,7 +72,7 @@
+ 
+ all:	lib subdirs
+ 
+-lib:	$(LIBOBJ)
++lib:	$(LIBOBJ) | subdirs
+ 	@if [ -n "$(SHARED_LIBS)" ]; then \
+ 		set -e; \
+ 		for l in $(LIBNAMES); do \
+@@ -89,7 +89,7 @@
+ 
+ subdirs:
+ 	echo $(EDIRS)
+-	@target=all; $(RECURSIVE_MAKE)
++	+@target=all; $(RECURSIVE_MAKE)
+ 
+ files:
+ 	$(PERL) $(TOP)/util/files.pl Makefile >> $(TOP)/MINFO
+@@ -128,7 +128,7 @@
+ 			  mv -f $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/engines/$$pfx$$l$$sfx.new $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/engines/$$pfx$$l$$sfx ); \
+ 		done; \
+ 	fi
+-	@target=install; $(RECURSIVE_MAKE)
++	+@target=install; $(RECURSIVE_MAKE)
+ 
+ tags:
+ 	ctags $(SRC)
+--- openssl-1.0.2a/Makefile.org
++++ openssl-1.0.2a/Makefile.org
+@@ -281,17 +281,17 @@
+ build_libssl: build_ssl libssl.pc
+ 
+ build_crypto:
+-	@dir=crypto; target=all; $(BUILD_ONE_CMD)
++	+@dir=crypto; target=all; $(BUILD_ONE_CMD)
+ build_ssl: build_crypto
+-	@dir=ssl; target=all; $(BUILD_ONE_CMD)
++	+@dir=ssl; target=all; $(BUILD_ONE_CMD)
+ build_engines: build_crypto
+-	@dir=engines; target=all; $(BUILD_ONE_CMD)
++	+@dir=engines; target=all; $(BUILD_ONE_CMD)
+ build_apps: build_libs
+-	@dir=apps; target=all; $(BUILD_ONE_CMD)
++	+@dir=apps; target=all; $(BUILD_ONE_CMD)
+ build_tests: build_libs
+-	@dir=test; target=all; $(BUILD_ONE_CMD)
++	+@dir=test; target=all; $(BUILD_ONE_CMD)
+ build_tools: build_libs
+-	@dir=tools; target=all; $(BUILD_ONE_CMD)
++	+@dir=tools; target=all; $(BUILD_ONE_CMD)
+ 
+ all_testapps: build_libs build_testapps
+ build_testapps:
+@@ -530,9 +530,9 @@
+ dist_pem_h:
+ 	(cd crypto/pem; $(MAKE) -e $(BUILDENV) pem.h; $(MAKE) clean)
+ 
+-install: all install_docs install_sw
++install: install_docs install_sw
+ 
+-install_sw:
++install_dirs:
+ 	@$(PERL) $(TOP)/util/mkdir-p.pl $(INSTALL_PREFIX)$(INSTALLTOP)/bin \
+ 		$(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR) \
+ 		$(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/engines \
+@@ -541,12 +541,19 @@
+ 		$(INSTALL_PREFIX)$(OPENSSLDIR)/misc \
+ 		$(INSTALL_PREFIX)$(OPENSSLDIR)/certs \
+ 		$(INSTALL_PREFIX)$(OPENSSLDIR)/private
++	@$(PERL) $(TOP)/util/mkdir-p.pl \
++		$(INSTALL_PREFIX)$(MANDIR)/man1 \
++		$(INSTALL_PREFIX)$(MANDIR)/man3 \
++		$(INSTALL_PREFIX)$(MANDIR)/man5 \
++		$(INSTALL_PREFIX)$(MANDIR)/man7
++
++install_sw: install_dirs
+ 	@set -e; headerlist="$(EXHEADER)"; for i in $$headerlist;\
+ 	do \
+ 	(cp $$i $(INSTALL_PREFIX)$(INSTALLTOP)/include/openssl/$$i; \
+ 	chmod 644 $(INSTALL_PREFIX)$(INSTALLTOP)/include/openssl/$$i ); \
+ 	done;
+-	@set -e; target=install; $(RECURSIVE_BUILD_CMD)
++	+@set -e; target=install; $(RECURSIVE_BUILD_CMD)
+ 	@set -e; liblist="$(LIBS)"; for i in $$liblist ;\
+ 	do \
+ 		if [ -f "$$i" ]; then \
+@@ -630,12 +640,7 @@
+ 		done; \
+ 	done
+ 
+-install_docs:
+-	@$(PERL) $(TOP)/util/mkdir-p.pl \
+-		$(INSTALL_PREFIX)$(MANDIR)/man1 \
+-		$(INSTALL_PREFIX)$(MANDIR)/man3 \
+-		$(INSTALL_PREFIX)$(MANDIR)/man5 \
+-		$(INSTALL_PREFIX)$(MANDIR)/man7
++install_docs: install_dirs
+ 	@pod2man="`cd ./util; ./pod2mantest $(PERL)`"; \
+ 	here="`pwd`"; \
+ 	filecase=; \
+--- openssl-1.0.2a/Makefile.shared
++++ openssl-1.0.2a/Makefile.shared
+@@ -105,6 +105,7 @@
+     SHAREDFLAGS="$${SHAREDFLAGS:-$(CFLAGS) $(SHARED_LDFLAGS)}"; \
+     LIBPATH=`for x in $$LIBDEPS; do echo $$x; done | sed -e 's/^ *-L//;t' -e d | uniq`; \
+     LIBPATH=`echo $$LIBPATH | sed -e 's/ /:/g'`; \
++    [ -e $$SHLIB$$SHLIB_SOVER$$SHLIB_SUFFIX ] && exit 0; \
+     LD_LIBRARY_PATH=$$LIBPATH:$$LD_LIBRARY_PATH \
+     $${SHAREDCMD} $${SHAREDFLAGS} \
+ 	-o $$SHLIB$$SHLIB_SOVER$$SHLIB_SUFFIX \
+@@ -122,6 +123,7 @@
+ 			done; \
+ 		fi; \
+ 		if [ -n "$$SHLIB_SOVER" ]; then \
++			[ -e "$$SHLIB$$SHLIB_SUFFIX" ] || \
+ 			( $(SET_X); rm -f $$SHLIB$$SHLIB_SUFFIX; \
+ 			  ln -s $$prev $$SHLIB$$SHLIB_SUFFIX ); \
+ 		fi; \
+--- openssl-1.0.2a/test/Makefile
++++ openssl-1.0.2a/test/Makefile
+@@ -134,7 +134,7 @@
+ tags:
+ 	ctags $(SRC)
+ 
+-tests:	exe apps $(TESTS)
++tests:	exe $(TESTS)
+ 
+ apps:
+ 	@(cd ..; $(MAKE) DIRS=apps all)
+@@ -408,121 +408,121 @@
+ 		link_app.$${shlib_target}
+ 
+ $(RSATEST)$(EXE_EXT): $(RSATEST).o $(DLIBCRYPTO)
+-	@target=$(RSATEST); $(BUILD_CMD)
++	+@target=$(RSATEST); $(BUILD_CMD)
+ 
+ $(BNTEST)$(EXE_EXT): $(BNTEST).o $(DLIBCRYPTO)
+-	@target=$(BNTEST); $(BUILD_CMD)
++	+@target=$(BNTEST); $(BUILD_CMD)
+ 
+ $(ECTEST)$(EXE_EXT): $(ECTEST).o $(DLIBCRYPTO)
+-	@target=$(ECTEST); $(BUILD_CMD)
++	+@target=$(ECTEST); $(BUILD_CMD)
+ 
+ $(EXPTEST)$(EXE_EXT): $(EXPTEST).o $(DLIBCRYPTO)
+-	@target=$(EXPTEST); $(BUILD_CMD)
++	+@target=$(EXPTEST); $(BUILD_CMD)
+ 
+ $(IDEATEST)$(EXE_EXT): $(IDEATEST).o $(DLIBCRYPTO)
+-	@target=$(IDEATEST); $(BUILD_CMD)
++	+@target=$(IDEATEST); $(BUILD_CMD)
+ 
+ $(MD2TEST)$(EXE_EXT): $(MD2TEST).o $(DLIBCRYPTO)
+-	@target=$(MD2TEST); $(BUILD_CMD)
++	+@target=$(MD2TEST); $(BUILD_CMD)
+ 
+ $(SHATEST)$(EXE_EXT): $(SHATEST).o $(DLIBCRYPTO)
+-	@target=$(SHATEST); $(BUILD_CMD)
++	+@target=$(SHATEST); $(BUILD_CMD)
+ 
+ $(SHA1TEST)$(EXE_EXT): $(SHA1TEST).o $(DLIBCRYPTO)
+-	@target=$(SHA1TEST); $(BUILD_CMD)
++	+@target=$(SHA1TEST); $(BUILD_CMD)
+ 
+ $(SHA256TEST)$(EXE_EXT): $(SHA256TEST).o $(DLIBCRYPTO)
+-	@target=$(SHA256TEST); $(BUILD_CMD)
++	+@target=$(SHA256TEST); $(BUILD_CMD)
+ 
+ $(SHA512TEST)$(EXE_EXT): $(SHA512TEST).o $(DLIBCRYPTO)
+-	@target=$(SHA512TEST); $(BUILD_CMD)
++	+@target=$(SHA512TEST); $(BUILD_CMD)
+ 
+ $(RMDTEST)$(EXE_EXT): $(RMDTEST).o $(DLIBCRYPTO)
+-	@target=$(RMDTEST); $(BUILD_CMD)
++	+@target=$(RMDTEST); $(BUILD_CMD)
+ 
+ $(MDC2TEST)$(EXE_EXT): $(MDC2TEST).o $(DLIBCRYPTO)
+-	@target=$(MDC2TEST); $(BUILD_CMD)
++	+@target=$(MDC2TEST); $(BUILD_CMD)
+ 
+ $(MD4TEST)$(EXE_EXT): $(MD4TEST).o $(DLIBCRYPTO)
+-	@target=$(MD4TEST); $(BUILD_CMD)
++	+@target=$(MD4TEST); $(BUILD_CMD)
+ 
+ $(MD5TEST)$(EXE_EXT): $(MD5TEST).o $(DLIBCRYPTO)
+-	@target=$(MD5TEST); $(BUILD_CMD)
++	+@target=$(MD5TEST); $(BUILD_CMD)
+ 
+ $(HMACTEST)$(EXE_EXT): $(HMACTEST).o $(DLIBCRYPTO)
+-	@target=$(HMACTEST); $(BUILD_CMD)
++	+@target=$(HMACTEST); $(BUILD_CMD)
+ 
+ $(WPTEST)$(EXE_EXT): $(WPTEST).o $(DLIBCRYPTO)
+-	@target=$(WPTEST); $(BUILD_CMD)
++	+@target=$(WPTEST); $(BUILD_CMD)
+ 
+ $(RC2TEST)$(EXE_EXT): $(RC2TEST).o $(DLIBCRYPTO)
+-	@target=$(RC2TEST); $(BUILD_CMD)
++	+@target=$(RC2TEST); $(BUILD_CMD)
+ 
+ $(BFTEST)$(EXE_EXT): $(BFTEST).o $(DLIBCRYPTO)
+-	@target=$(BFTEST); $(BUILD_CMD)
++	+@target=$(BFTEST); $(BUILD_CMD)
+ 
+ $(CASTTEST)$(EXE_EXT): $(CASTTEST).o $(DLIBCRYPTO)
+-	@target=$(CASTTEST); $(BUILD_CMD)
++	+@target=$(CASTTEST); $(BUILD_CMD)
+ 
+ $(RC4TEST)$(EXE_EXT): $(RC4TEST).o $(DLIBCRYPTO)
+-	@target=$(RC4TEST); $(BUILD_CMD)
++	+@target=$(RC4TEST); $(BUILD_CMD)
+ 
+ $(RC5TEST)$(EXE_EXT): $(RC5TEST).o $(DLIBCRYPTO)
+-	@target=$(RC5TEST); $(BUILD_CMD)
++	+@target=$(RC5TEST); $(BUILD_CMD)
+ 
+ $(DESTEST)$(EXE_EXT): $(DESTEST).o $(DLIBCRYPTO)
+-	@target=$(DESTEST); $(BUILD_CMD)
++	+@target=$(DESTEST); $(BUILD_CMD)
+ 
+ $(RANDTEST)$(EXE_EXT): $(RANDTEST).o $(DLIBCRYPTO)
+-	@target=$(RANDTEST); $(BUILD_CMD)
++	+@target=$(RANDTEST); $(BUILD_CMD)
+ 
+ $(DHTEST)$(EXE_EXT): $(DHTEST).o $(DLIBCRYPTO)
+-	@target=$(DHTEST); $(BUILD_CMD)
++	+@target=$(DHTEST); $(BUILD_CMD)
+ 
+ $(DSATEST)$(EXE_EXT): $(DSATEST).o $(DLIBCRYPTO)
+-	@target=$(DSATEST); $(BUILD_CMD)
++	+@target=$(DSATEST); $(BUILD_CMD)
+ 
+ $(METHTEST)$(EXE_EXT): $(METHTEST).o $(DLIBCRYPTO)
+-	@target=$(METHTEST); $(BUILD_CMD)
++	+@target=$(METHTEST); $(BUILD_CMD)
+ 
+ $(SSLTEST)$(EXE_EXT): $(SSLTEST).o $(DLIBSSL) $(DLIBCRYPTO)
+-	@target=$(SSLTEST); $(FIPS_BUILD_CMD)
++	+@target=$(SSLTEST); $(FIPS_BUILD_CMD)
+ 
+ $(ENGINETEST)$(EXE_EXT): $(ENGINETEST).o $(DLIBCRYPTO)
+-	@target=$(ENGINETEST); $(BUILD_CMD)
++	+@target=$(ENGINETEST); $(BUILD_CMD)
+ 
+ $(EVPTEST)$(EXE_EXT): $(EVPTEST).o $(DLIBCRYPTO)
+-	@target=$(EVPTEST); $(BUILD_CMD)
++	+@target=$(EVPTEST); $(BUILD_CMD)
+ 
+ $(EVPEXTRATEST)$(EXE_EXT): $(EVPEXTRATEST).o $(DLIBCRYPTO)
+-	@target=$(EVPEXTRATEST); $(BUILD_CMD)
++	+@target=$(EVPEXTRATEST); $(BUILD_CMD)
+ 
+ $(ECDSATEST)$(EXE_EXT): $(ECDSATEST).o $(DLIBCRYPTO)
+-	@target=$(ECDSATEST); $(BUILD_CMD)
++	+@target=$(ECDSATEST); $(BUILD_CMD)
+ 
+ $(ECDHTEST)$(EXE_EXT): $(ECDHTEST).o $(DLIBCRYPTO)
+-	@target=$(ECDHTEST); $(BUILD_CMD)
++	+@target=$(ECDHTEST); $(BUILD_CMD)
+ 
+ $(IGETEST)$(EXE_EXT): $(IGETEST).o $(DLIBCRYPTO)
+-	@target=$(IGETEST); $(BUILD_CMD)
++	+@target=$(IGETEST); $(BUILD_CMD)
+ 
+ $(JPAKETEST)$(EXE_EXT): $(JPAKETEST).o $(DLIBCRYPTO)
+-	@target=$(JPAKETEST); $(BUILD_CMD)
++	+@target=$(JPAKETEST); $(BUILD_CMD)
+ 
+ $(ASN1TEST)$(EXE_EXT): $(ASN1TEST).o $(DLIBCRYPTO)
+-	@target=$(ASN1TEST); $(BUILD_CMD)
++	+@target=$(ASN1TEST); $(BUILD_CMD)
+ 
+ $(SRPTEST)$(EXE_EXT): $(SRPTEST).o $(DLIBCRYPTO)
+-	@target=$(SRPTEST); $(BUILD_CMD)
++	+@target=$(SRPTEST); $(BUILD_CMD)
+ 
+ $(V3NAMETEST)$(EXE_EXT): $(V3NAMETEST).o $(DLIBCRYPTO)
+-	@target=$(V3NAMETEST); $(BUILD_CMD)
++	+@target=$(V3NAMETEST); $(BUILD_CMD)
+ 
+ $(HEARTBEATTEST)$(EXE_EXT): $(HEARTBEATTEST).o $(DLIBCRYPTO)
+-	@target=$(HEARTBEATTEST); $(BUILD_CMD_STATIC)
++	+@target=$(HEARTBEATTEST); $(BUILD_CMD_STATIC)
+ 
+ $(CONSTTIMETEST)$(EXE_EXT): $(CONSTTIMETEST).o
+-	@target=$(CONSTTIMETEST) $(BUILD_CMD)
++	+@target=$(CONSTTIMETEST) $(BUILD_CMD)
+ 
+ $(VERIFYEXTRATEST)$(EXE_EXT): $(VERIFYEXTRATEST).o
+ 	@target=$(VERIFYEXTRATEST) $(BUILD_CMD)
+@@ -538,7 +538,7 @@
+ #	fi
+ 
+ dummytest$(EXE_EXT): dummytest.o $(DLIBCRYPTO)
+-	@target=dummytest; $(BUILD_CMD)
++	+@target=dummytest; $(BUILD_CMD)
+ 
+ # DO NOT DELETE THIS LINE -- make depend depends on it.
+ 

--- a/mingw-w64-openssl-1.1/openssl-1.1.1-mingw-arm.patch
+++ b/mingw-w64-openssl-1.1/openssl-1.1.1-mingw-arm.patch
@@ -1,0 +1,57 @@
+--- openssl-1.1.1i/Configurations/10-main.conf.ORIG	2021-01-16 16:36:58.560632200 -0800
++++ openssl-1.1.1i/Configurations/10-main.conf	2021-01-16 16:40:28.966865000 -0800
+@@ -1433,7 +1433,53 @@
+         multilib         => "64",
+         apps_aux_src     => add("win32_init.c"),
+     },
+-
++    "mingwarm32" => {
++        inherit_from     => [ "BASE_unix", asm("armv4_asm")],
++        CC               => "gcc",
++        CFLAGS           => picker(default => "-Wall",
++                                   debug   => "-g -O0",
++                                   release => "-O3 -fomit-frame-pointer"),
++        cppflags         => combine("-DUNICODE -D_UNICODE -DWIN32_LEAN_AND_MEAN",
++                                    threads("-D_MT")),
++        lib_cppflags     => "-DL_ENDIAN",
++        sys_id           => "MINGWARM32",
++        ex_libs          => add("-lws2_32 -lgdi32 -lcrypt32"),
++        bn_ops           => "BN_LLONG EXPORT_VAR_AS_FN",
++        thread_scheme    => "winthreads",
++        perlasm_scheme   => "coff",
++        dso_scheme       => "win32",
++        shared_target    => "mingw-shared",
++        shared_cppflags  => add("_WINDLL"),
++        shared_ldflag    => "-static-libgcc",
++        shared_extension => ".dll",
++        multilib         => "",
++        apps_aux_src     => add("win32_init.c"),
++        # "WOW" stands for "Windows on Windows", and that word engages
++        # some installation path heuristics in unix-Makefile.tmpl...
++        build_scheme     => add("WOW", { separator => undef }),
++    },
++    "mingwarm64" => {
++        inherit_from     => [ "BASE_unix", asm("aarch64_asm")],
++        CC               => "gcc",
++        CFLAGS           => picker(default => "-Wall",
++                                   debug   => "-g -O0",
++                                   release => "-O3 -fomit-frame-pointer"),
++        cppflags         => combine("-DUNICODE -D_UNICODE -DWIN32_LEAN_AND_MEAN",
++                                    threads("-D_MT")),
++        lib_cppflags     => "-DL_ENDIAN",
++        sys_id           => "MINGWARM64",
++        ex_libs          => add("-lws2_32 -lgdi32 -lcrypt32"),
++        bn_ops           => "SIXTY_FOUR_BIT EXPORT_VAR_AS_FN",
++        thread_scheme    => "winthreads",
++        perlasm_scheme   => "coff",
++        dso_scheme       => "win32",
++        shared_target    => "mingw-shared",
++        shared_cppflags  => add("_WINDLL"),
++        shared_ldflag    => "-static-libgcc",
++        shared_extension => ".dll",
++        multilib         => "",
++        apps_aux_src     => add("win32_init.c"),
++    },
+ #### UEFI
+     "UEFI" => {
+         inherit_from     => [ "BASE_unix" ],

--- a/mingw-w64-openssl-1.1/openssl-1.1.1-parallel-build.patch
+++ b/mingw-w64-openssl-1.1/openssl-1.1.1-parallel-build.patch
@@ -1,0 +1,363 @@
+http://rt.openssl.org/Ticket/Display.html?id=2084&user=guest&pass=guest
+
+--- openssl-1.0.2a/crypto/Makefile
++++ openssl-1.0.2a/crypto/Makefile
+@@ -85,11 +85,11 @@
+ 	@if [ -z "$(THIS)" ]; then $(MAKE) -f $(TOP)/Makefile reflect THIS=$@; fi
+ 
+ subdirs:
+-	@target=all; $(RECURSIVE_MAKE)
++	+@target=all; $(RECURSIVE_MAKE)
+ 
+ files:
+ 	$(PERL) $(TOP)/util/files.pl "CPUID_OBJ=$(CPUID_OBJ)" Makefile >> $(TOP)/MINFO
+-	@target=files; $(RECURSIVE_MAKE)
++	+@target=files; $(RECURSIVE_MAKE)
+ 
+ links:
+ 	@$(PERL) $(TOP)/util/mklink.pl ../include/openssl $(EXHEADER)
+@@ -100,7 +100,7 @@
+ # lib: $(LIB): are splitted to avoid end-less loop
+ lib:	$(LIB)
+ 	@touch lib
+-$(LIB):	$(LIBOBJ)
++$(LIB):	$(LIBOBJ) | subdirs
+ 	$(AR) $(LIB) $(LIBOBJ)
+ 	test -z "$(FIPSLIBDIR)" || $(AR) $(LIB) $(FIPSLIBDIR)fipscanister.o
+ 	$(RANLIB) $(LIB) || echo Never mind.
+@@ -111,7 +111,7 @@
+ 	fi
+ 
+ libs:
+-	@target=lib; $(RECURSIVE_MAKE)
++	+@target=lib; $(RECURSIVE_MAKE)
+ 
+ install:
+ 	@[ -n "$(INSTALLTOP)" ] # should be set by top Makefile...
+@@ -120,7 +120,7 @@
+ 	(cp $$i $(INSTALL_PREFIX)$(INSTALLTOP)/include/openssl/$$i; \
+ 	chmod 644 $(INSTALL_PREFIX)$(INSTALLTOP)/include/openssl/$$i ); \
+ 	done;
+-	@target=install; $(RECURSIVE_MAKE)
++	+@target=install; $(RECURSIVE_MAKE)
+ 
+ lint:
+ 	@target=lint; $(RECURSIVE_MAKE)
+--- openssl-1.0.2a/crypto/objects/Makefile
++++ openssl-1.0.2a/crypto/objects/Makefile
+@@ -44,11 +44,11 @@
+ # objects.pl both reads and writes obj_mac.num
+ obj_mac.h: objects.pl objects.txt obj_mac.num
+ 	$(PERL) objects.pl objects.txt obj_mac.num obj_mac.h
+-	@sleep 1; touch obj_mac.h; sleep 1
+ 
+-obj_xref.h: objxref.pl obj_xref.txt obj_mac.num
++# This doesn't really need obj_mac.h, but since that rule reads & writes
++# obj_mac.num, we can't run in parallel with it.
++obj_xref.h: objxref.pl obj_xref.txt obj_mac.num obj_mac.h
+ 	$(PERL) objxref.pl obj_mac.num obj_xref.txt > obj_xref.h
+-	@sleep 1; touch obj_xref.h; sleep 1
+ 
+ files:
+ 	$(PERL) $(TOP)/util/files.pl Makefile >> $(TOP)/MINFO
+--- openssl-1.0.2a/engines/Makefile
++++ openssl-1.0.2a/engines/Makefile
+@@ -72,7 +72,7 @@
+ 
+ all:	lib subdirs
+ 
+-lib:	$(LIBOBJ)
++lib:	$(LIBOBJ) | subdirs
+ 	@if [ -n "$(SHARED_LIBS)" ]; then \
+ 		set -e; \
+ 		for l in $(LIBNAMES); do \
+@@ -89,7 +89,7 @@
+ 
+ subdirs:
+ 	echo $(EDIRS)
+-	@target=all; $(RECURSIVE_MAKE)
++	+@target=all; $(RECURSIVE_MAKE)
+ 
+ files:
+ 	$(PERL) $(TOP)/util/files.pl Makefile >> $(TOP)/MINFO
+@@ -128,7 +128,7 @@
+ 			  mv -f $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/engines/$$pfx$$l$$sfx.new $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/engines/$$pfx$$l$$sfx ); \
+ 		done; \
+ 	fi
+-	@target=install; $(RECURSIVE_MAKE)
++	+@target=install; $(RECURSIVE_MAKE)
+ 
+ tags:
+ 	ctags $(SRC)
+--- openssl-1.0.2a/Makefile.org
++++ openssl-1.0.2a/Makefile.org
+@@ -281,17 +281,17 @@
+ build_libssl: build_ssl libssl.pc
+ 
+ build_crypto:
+-	@dir=crypto; target=all; $(BUILD_ONE_CMD)
++	+@dir=crypto; target=all; $(BUILD_ONE_CMD)
+ build_ssl: build_crypto
+-	@dir=ssl; target=all; $(BUILD_ONE_CMD)
++	+@dir=ssl; target=all; $(BUILD_ONE_CMD)
+ build_engines: build_crypto
+-	@dir=engines; target=all; $(BUILD_ONE_CMD)
++	+@dir=engines; target=all; $(BUILD_ONE_CMD)
+ build_apps: build_libs
+-	@dir=apps; target=all; $(BUILD_ONE_CMD)
++	+@dir=apps; target=all; $(BUILD_ONE_CMD)
+ build_tests: build_libs
+-	@dir=test; target=all; $(BUILD_ONE_CMD)
++	+@dir=test; target=all; $(BUILD_ONE_CMD)
+ build_tools: build_libs
+-	@dir=tools; target=all; $(BUILD_ONE_CMD)
++	+@dir=tools; target=all; $(BUILD_ONE_CMD)
+ 
+ all_testapps: build_libs build_testapps
+ build_testapps:
+@@ -530,9 +530,9 @@
+ dist_pem_h:
+ 	(cd crypto/pem; $(MAKE) -e $(BUILDENV) pem.h; $(MAKE) clean)
+ 
+-install: all install_docs install_sw
++install: install_docs install_sw
+ 
+-install_sw:
++install_dirs:
+ 	@$(PERL) $(TOP)/util/mkdir-p.pl $(INSTALL_PREFIX)$(INSTALLTOP)/bin \
+ 		$(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR) \
+ 		$(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/engines \
+@@ -541,12 +541,19 @@
+ 		$(INSTALL_PREFIX)$(OPENSSLDIR)/misc \
+ 		$(INSTALL_PREFIX)$(OPENSSLDIR)/certs \
+ 		$(INSTALL_PREFIX)$(OPENSSLDIR)/private
++	@$(PERL) $(TOP)/util/mkdir-p.pl \
++		$(INSTALL_PREFIX)$(MANDIR)/man1 \
++		$(INSTALL_PREFIX)$(MANDIR)/man3 \
++		$(INSTALL_PREFIX)$(MANDIR)/man5 \
++		$(INSTALL_PREFIX)$(MANDIR)/man7
++
++install_sw: install_dirs
+ 	@set -e; headerlist="$(EXHEADER)"; for i in $$headerlist;\
+ 	do \
+ 	(cp $$i $(INSTALL_PREFIX)$(INSTALLTOP)/include/openssl/$$i; \
+ 	chmod 644 $(INSTALL_PREFIX)$(INSTALLTOP)/include/openssl/$$i ); \
+ 	done;
+-	@set -e; target=install; $(RECURSIVE_BUILD_CMD)
++	+@set -e; target=install; $(RECURSIVE_BUILD_CMD)
+ 	@set -e; liblist="$(LIBS)"; for i in $$liblist ;\
+ 	do \
+ 		if [ -f "$$i" ]; then \
+@@ -630,12 +640,7 @@
+ 		done; \
+ 	done
+ 
+-install_docs:
+-	@$(PERL) $(TOP)/util/mkdir-p.pl \
+-		$(INSTALL_PREFIX)$(MANDIR)/man1 \
+-		$(INSTALL_PREFIX)$(MANDIR)/man3 \
+-		$(INSTALL_PREFIX)$(MANDIR)/man5 \
+-		$(INSTALL_PREFIX)$(MANDIR)/man7
++install_docs: install_dirs
+ 	@pod2man="`cd ./util; ./pod2mantest $(PERL)`"; \
+ 	here="`pwd`"; \
+ 	filecase=; \
+--- openssl-1.0.2a/Makefile.shared
++++ openssl-1.0.2a/Makefile.shared
+@@ -105,6 +105,7 @@
+     SHAREDFLAGS="$${SHAREDFLAGS:-$(CFLAGS) $(SHARED_LDFLAGS)}"; \
+     LIBPATH=`for x in $$LIBDEPS; do echo $$x; done | sed -e 's/^ *-L//;t' -e d | uniq`; \
+     LIBPATH=`echo $$LIBPATH | sed -e 's/ /:/g'`; \
++    [ -e $$SHLIB$$SHLIB_SOVER$$SHLIB_SUFFIX ] && exit 0; \
+     LD_LIBRARY_PATH=$$LIBPATH:$$LD_LIBRARY_PATH \
+     $${SHAREDCMD} $${SHAREDFLAGS} \
+ 	-o $$SHLIB$$SHLIB_SOVER$$SHLIB_SUFFIX \
+@@ -122,6 +123,7 @@
+ 			done; \
+ 		fi; \
+ 		if [ -n "$$SHLIB_SOVER" ]; then \
++			[ -e "$$SHLIB$$SHLIB_SUFFIX" ] || \
+ 			( $(SET_X); rm -f $$SHLIB$$SHLIB_SUFFIX; \
+ 			  ln -s $$prev $$SHLIB$$SHLIB_SUFFIX ); \
+ 		fi; \
+--- openssl-1.0.2a/test/Makefile
++++ openssl-1.0.2a/test/Makefile
+@@ -134,7 +134,7 @@
+ tags:
+ 	ctags $(SRC)
+ 
+-tests:	exe apps $(TESTS)
++tests:	exe $(TESTS)
+ 
+ apps:
+ 	@(cd ..; $(MAKE) DIRS=apps all)
+@@ -408,121 +408,121 @@
+ 		link_app.$${shlib_target}
+ 
+ $(RSATEST)$(EXE_EXT): $(RSATEST).o $(DLIBCRYPTO)
+-	@target=$(RSATEST); $(BUILD_CMD)
++	+@target=$(RSATEST); $(BUILD_CMD)
+ 
+ $(BNTEST)$(EXE_EXT): $(BNTEST).o $(DLIBCRYPTO)
+-	@target=$(BNTEST); $(BUILD_CMD)
++	+@target=$(BNTEST); $(BUILD_CMD)
+ 
+ $(ECTEST)$(EXE_EXT): $(ECTEST).o $(DLIBCRYPTO)
+-	@target=$(ECTEST); $(BUILD_CMD)
++	+@target=$(ECTEST); $(BUILD_CMD)
+ 
+ $(EXPTEST)$(EXE_EXT): $(EXPTEST).o $(DLIBCRYPTO)
+-	@target=$(EXPTEST); $(BUILD_CMD)
++	+@target=$(EXPTEST); $(BUILD_CMD)
+ 
+ $(IDEATEST)$(EXE_EXT): $(IDEATEST).o $(DLIBCRYPTO)
+-	@target=$(IDEATEST); $(BUILD_CMD)
++	+@target=$(IDEATEST); $(BUILD_CMD)
+ 
+ $(MD2TEST)$(EXE_EXT): $(MD2TEST).o $(DLIBCRYPTO)
+-	@target=$(MD2TEST); $(BUILD_CMD)
++	+@target=$(MD2TEST); $(BUILD_CMD)
+ 
+ $(SHATEST)$(EXE_EXT): $(SHATEST).o $(DLIBCRYPTO)
+-	@target=$(SHATEST); $(BUILD_CMD)
++	+@target=$(SHATEST); $(BUILD_CMD)
+ 
+ $(SHA1TEST)$(EXE_EXT): $(SHA1TEST).o $(DLIBCRYPTO)
+-	@target=$(SHA1TEST); $(BUILD_CMD)
++	+@target=$(SHA1TEST); $(BUILD_CMD)
+ 
+ $(SHA256TEST)$(EXE_EXT): $(SHA256TEST).o $(DLIBCRYPTO)
+-	@target=$(SHA256TEST); $(BUILD_CMD)
++	+@target=$(SHA256TEST); $(BUILD_CMD)
+ 
+ $(SHA512TEST)$(EXE_EXT): $(SHA512TEST).o $(DLIBCRYPTO)
+-	@target=$(SHA512TEST); $(BUILD_CMD)
++	+@target=$(SHA512TEST); $(BUILD_CMD)
+ 
+ $(RMDTEST)$(EXE_EXT): $(RMDTEST).o $(DLIBCRYPTO)
+-	@target=$(RMDTEST); $(BUILD_CMD)
++	+@target=$(RMDTEST); $(BUILD_CMD)
+ 
+ $(MDC2TEST)$(EXE_EXT): $(MDC2TEST).o $(DLIBCRYPTO)
+-	@target=$(MDC2TEST); $(BUILD_CMD)
++	+@target=$(MDC2TEST); $(BUILD_CMD)
+ 
+ $(MD4TEST)$(EXE_EXT): $(MD4TEST).o $(DLIBCRYPTO)
+-	@target=$(MD4TEST); $(BUILD_CMD)
++	+@target=$(MD4TEST); $(BUILD_CMD)
+ 
+ $(MD5TEST)$(EXE_EXT): $(MD5TEST).o $(DLIBCRYPTO)
+-	@target=$(MD5TEST); $(BUILD_CMD)
++	+@target=$(MD5TEST); $(BUILD_CMD)
+ 
+ $(HMACTEST)$(EXE_EXT): $(HMACTEST).o $(DLIBCRYPTO)
+-	@target=$(HMACTEST); $(BUILD_CMD)
++	+@target=$(HMACTEST); $(BUILD_CMD)
+ 
+ $(WPTEST)$(EXE_EXT): $(WPTEST).o $(DLIBCRYPTO)
+-	@target=$(WPTEST); $(BUILD_CMD)
++	+@target=$(WPTEST); $(BUILD_CMD)
+ 
+ $(RC2TEST)$(EXE_EXT): $(RC2TEST).o $(DLIBCRYPTO)
+-	@target=$(RC2TEST); $(BUILD_CMD)
++	+@target=$(RC2TEST); $(BUILD_CMD)
+ 
+ $(BFTEST)$(EXE_EXT): $(BFTEST).o $(DLIBCRYPTO)
+-	@target=$(BFTEST); $(BUILD_CMD)
++	+@target=$(BFTEST); $(BUILD_CMD)
+ 
+ $(CASTTEST)$(EXE_EXT): $(CASTTEST).o $(DLIBCRYPTO)
+-	@target=$(CASTTEST); $(BUILD_CMD)
++	+@target=$(CASTTEST); $(BUILD_CMD)
+ 
+ $(RC4TEST)$(EXE_EXT): $(RC4TEST).o $(DLIBCRYPTO)
+-	@target=$(RC4TEST); $(BUILD_CMD)
++	+@target=$(RC4TEST); $(BUILD_CMD)
+ 
+ $(RC5TEST)$(EXE_EXT): $(RC5TEST).o $(DLIBCRYPTO)
+-	@target=$(RC5TEST); $(BUILD_CMD)
++	+@target=$(RC5TEST); $(BUILD_CMD)
+ 
+ $(DESTEST)$(EXE_EXT): $(DESTEST).o $(DLIBCRYPTO)
+-	@target=$(DESTEST); $(BUILD_CMD)
++	+@target=$(DESTEST); $(BUILD_CMD)
+ 
+ $(RANDTEST)$(EXE_EXT): $(RANDTEST).o $(DLIBCRYPTO)
+-	@target=$(RANDTEST); $(BUILD_CMD)
++	+@target=$(RANDTEST); $(BUILD_CMD)
+ 
+ $(DHTEST)$(EXE_EXT): $(DHTEST).o $(DLIBCRYPTO)
+-	@target=$(DHTEST); $(BUILD_CMD)
++	+@target=$(DHTEST); $(BUILD_CMD)
+ 
+ $(DSATEST)$(EXE_EXT): $(DSATEST).o $(DLIBCRYPTO)
+-	@target=$(DSATEST); $(BUILD_CMD)
++	+@target=$(DSATEST); $(BUILD_CMD)
+ 
+ $(METHTEST)$(EXE_EXT): $(METHTEST).o $(DLIBCRYPTO)
+-	@target=$(METHTEST); $(BUILD_CMD)
++	+@target=$(METHTEST); $(BUILD_CMD)
+ 
+ $(SSLTEST)$(EXE_EXT): $(SSLTEST).o $(DLIBSSL) $(DLIBCRYPTO)
+-	@target=$(SSLTEST); $(FIPS_BUILD_CMD)
++	+@target=$(SSLTEST); $(FIPS_BUILD_CMD)
+ 
+ $(ENGINETEST)$(EXE_EXT): $(ENGINETEST).o $(DLIBCRYPTO)
+-	@target=$(ENGINETEST); $(BUILD_CMD)
++	+@target=$(ENGINETEST); $(BUILD_CMD)
+ 
+ $(EVPTEST)$(EXE_EXT): $(EVPTEST).o $(DLIBCRYPTO)
+-	@target=$(EVPTEST); $(BUILD_CMD)
++	+@target=$(EVPTEST); $(BUILD_CMD)
+ 
+ $(EVPEXTRATEST)$(EXE_EXT): $(EVPEXTRATEST).o $(DLIBCRYPTO)
+-	@target=$(EVPEXTRATEST); $(BUILD_CMD)
++	+@target=$(EVPEXTRATEST); $(BUILD_CMD)
+ 
+ $(ECDSATEST)$(EXE_EXT): $(ECDSATEST).o $(DLIBCRYPTO)
+-	@target=$(ECDSATEST); $(BUILD_CMD)
++	+@target=$(ECDSATEST); $(BUILD_CMD)
+ 
+ $(ECDHTEST)$(EXE_EXT): $(ECDHTEST).o $(DLIBCRYPTO)
+-	@target=$(ECDHTEST); $(BUILD_CMD)
++	+@target=$(ECDHTEST); $(BUILD_CMD)
+ 
+ $(IGETEST)$(EXE_EXT): $(IGETEST).o $(DLIBCRYPTO)
+-	@target=$(IGETEST); $(BUILD_CMD)
++	+@target=$(IGETEST); $(BUILD_CMD)
+ 
+ $(JPAKETEST)$(EXE_EXT): $(JPAKETEST).o $(DLIBCRYPTO)
+-	@target=$(JPAKETEST); $(BUILD_CMD)
++	+@target=$(JPAKETEST); $(BUILD_CMD)
+ 
+ $(ASN1TEST)$(EXE_EXT): $(ASN1TEST).o $(DLIBCRYPTO)
+-	@target=$(ASN1TEST); $(BUILD_CMD)
++	+@target=$(ASN1TEST); $(BUILD_CMD)
+ 
+ $(SRPTEST)$(EXE_EXT): $(SRPTEST).o $(DLIBCRYPTO)
+-	@target=$(SRPTEST); $(BUILD_CMD)
++	+@target=$(SRPTEST); $(BUILD_CMD)
+ 
+ $(V3NAMETEST)$(EXE_EXT): $(V3NAMETEST).o $(DLIBCRYPTO)
+-	@target=$(V3NAMETEST); $(BUILD_CMD)
++	+@target=$(V3NAMETEST); $(BUILD_CMD)
+ 
+ $(HEARTBEATTEST)$(EXE_EXT): $(HEARTBEATTEST).o $(DLIBCRYPTO)
+-	@target=$(HEARTBEATTEST); $(BUILD_CMD_STATIC)
++	+@target=$(HEARTBEATTEST); $(BUILD_CMD_STATIC)
+ 
+ $(CONSTTIMETEST)$(EXE_EXT): $(CONSTTIMETEST).o
+-	@target=$(CONSTTIMETEST) $(BUILD_CMD)
++	+@target=$(CONSTTIMETEST) $(BUILD_CMD)
+ 
+ $(VERIFYEXTRATEST)$(EXE_EXT): $(VERIFYEXTRATEST).o
+ 	@target=$(VERIFYEXTRATEST) $(BUILD_CMD)
+@@ -538,7 +538,7 @@
+ #	fi
+ 
+ dummytest$(EXE_EXT): dummytest.o $(DLIBCRYPTO)
+-	@target=dummytest; $(BUILD_CMD)
++	+@target=dummytest; $(BUILD_CMD)
+ 
+ # DO NOT DELETE THIS LINE -- make depend depends on it.
+ 

--- a/mingw-w64-openssl-1.1/openssl-1.1.1-relocation.patch
+++ b/mingw-w64-openssl-1.1/openssl-1.1.1-relocation.patch
@@ -1,0 +1,670 @@
+diff --git a/crypto/build.info b/crypto/build.info
+index b515b7318e..f090ff458d 100644
+--- a/crypto/build.info
++++ b/crypto/build.info
+@@ -1,7 +1,7 @@
+ LIBS=../libcrypto
+ SOURCE[../libcrypto]=\
+         cryptlib.c mem.c mem_dbg.c cversion.c ex_data.c cpt_err.c \
+-        ebcdic.c uid.c o_time.c o_str.c o_dir.c o_fopen.c ctype.c \
++        ebcdic.c uid.c o_time.c o_str.c o_dir.c o_fopen.c pathtools.c ctype.c \
+         threads_pthread.c threads_win.c threads_none.c getenv.c \
+         o_init.c o_fips.c mem_sec.c init.c {- $target{cpuid_asm_src} -} \
+         {- $target{uplink_aux_src} -}
+diff --git a/crypto/engine/eng_list.c b/crypto/engine/eng_list.c
+index 4bc7ea173c..5f881fb2cb 100644
+--- a/crypto/engine/eng_list.c
++++ b/crypto/engine/eng_list.c
+@@ -9,6 +9,7 @@
+  */
+ 
+ #include "eng_local.h"
++#include "pathtools.h"
+ 
+ /*
+  * The linked-list of pointers to engine types. engine_list_head incorporates
+@@ -30,6 +31,20 @@ static ENGINE *engine_list_tail = NULL;
+  * cleanup.
+  */
+ 
++char * enginedir_relocation(const char *path)
++{
++  char exe_path[PATH_MAX];
++  get_executable_path (NULL, &exe_path[0], sizeof(exe_path)/sizeof(exe_path[0]));
++  if (strrchr (exe_path, '/') != NULL)
++  {
++     strrchr (exe_path, '/')[1] = '\0';
++  }
++  char * rel_to_datadir = get_relative_path (OPENSSLBIN, path);
++  strcat (exe_path, rel_to_datadir);
++  simplify_path (&exe_path[0]);
++  return malloc_copy_string(exe_path);
++}
++
+ static void engine_list_cleanup(void)
+ {
+     ENGINE *iterator = engine_list_head;
+@@ -318,8 +333,10 @@ ENGINE *ENGINE_by_id(const char *id)
+      * Prevent infinite recursion if we're looking for the dynamic engine.
+      */
+     if (strcmp(id, "dynamic")) {
+-        if ((load_dir = ossl_safe_getenv("OPENSSL_ENGINES")) == NULL)
+-            load_dir = ENGINESDIR;
++        if ((load_dir = ossl_safe_getenv("OPENSSL_ENGINES")) == NULL) {
++            const char * reloc_engines = enginedir_relocation(ENGINESDIR);
++            load_dir = reloc_engines;
++        }
+         iterator = ENGINE_by_id("dynamic");
+         if (!iterator || !ENGINE_ctrl_cmd_string(iterator, "ID", id, 0) ||
+             !ENGINE_ctrl_cmd_string(iterator, "DIR_LOAD", "2", 0) ||
+diff --git a/crypto/pathtools.c b/crypto/pathtools.c
+new file mode 100644
+index 0000000000..81ffa7e8a6
+--- /dev/null
++++ b/crypto/pathtools.c
+@@ -0,0 +1,499 @@
++/*
++      .Some useful path tools.
++        .ASCII only for now.
++   .Written by Ray Donnelly in 2014.
++   .Licensed under CC0 (and anything.
++  .else you need to license it under).
++      .No warranties whatsoever.
++  .email: <mingw.android@gmail.com>.
++ */
++
++#if defined(__APPLE__)
++#include <stdlib.h>
++#else
++#include <malloc.h>
++#endif
++#include <limits.h>
++#include <stdio.h>
++#include <string.h>
++#if defined(__linux__) || defined(__CYGWIN__) || defined(__MSYS__)
++#include <alloca.h>
++#endif
++#include <unistd.h>
++
++/* If you don't define this, then get_executable_path()
++   can only use argv[0] which will often not work well */
++#define IMPLEMENT_SYS_GET_EXECUTABLE_PATH
++
++#if defined(IMPLEMENT_SYS_GET_EXECUTABLE_PATH)
++#if defined(__linux__) || defined(__CYGWIN__) || defined(__MSYS__)
++/* Nothing needed, unistd.h is enough. */
++#elif defined(__APPLE__)
++#include <mach-o/dyld.h>
++#elif defined(_WIN32)
++#define WIN32_MEAN_AND_LEAN
++#include <windows.h>
++#include <psapi.h>
++#endif
++#endif /* defined(IMPLEMENT_SYS_GET_EXECUTABLE_PATH) */
++
++#include "pathtools.h"
++
++char *
++malloc_copy_string(char const * original)
++{
++  char * result = (char *) malloc (sizeof (char*) * strlen (original)+1);
++  if (result != NULL)
++  {
++    strcpy (result, original);
++  }
++  return result;
++}
++
++void
++sanitise_path(char * path)
++{
++  size_t path_size = strlen (path);
++
++  /* Replace any '\' with '/' */
++  char * path_p = path;
++  while ((path_p = strchr (path_p, '\\')) != NULL)
++  {
++    *path_p = '/';
++  }
++  /* Replace any '//' with '/' */
++  path_p = path;
++  while ((path_p = strstr (path_p, "//")) != NULL)
++  {
++    memmove (path_p, path_p + 1, path_size--);
++  }
++  return;
++}
++
++char *
++get_relative_path(char const * from_in, char const * to_in)
++{
++  size_t from_size = (from_in == NULL) ? 0 : strlen (from_in);
++  size_t to_size = (to_in == NULL) ? 0 : strlen (to_in);
++  size_t max_size = (from_size + to_size) * 2 + 4;
++  char * scratch_space = (char *) alloca (from_size + 1 + to_size + 1 + max_size + max_size);
++  char * from;
++  char * to;
++  char * common_part;
++  char * result;
++  size_t count;
++
++  /* No to, return "./" */
++  if (to_in == NULL)
++  {
++    return malloc_copy_string ("./");
++  }
++
++  /* If alloca failed or no from was given return a copy of to */
++  if (   from_in == NULL
++      || scratch_space == NULL )
++  {
++    return malloc_copy_string (to_in);
++  }
++
++  from = scratch_space;
++  strcpy (from, from_in);
++  to = from + from_size + 1;
++  strcpy (to, to_in);
++  common_part = to + to_size + 1;
++  result = common_part + max_size;
++  simplify_path (from);
++  simplify_path (to);
++
++  result[0] = '\0';
++
++  size_t match_size_dirsep = 0;  /* The match size up to the last /. Always wind back to this - 1 */
++  size_t match_size = 0;         /* The running (and final) match size. */
++  size_t largest_size = (from_size > to_size) ? from_size : to_size;
++  int to_final_is_slash = (to[to_size-1] == '/') ? 1 : 0;
++  char from_c;
++  char to_c;
++  for (match_size = 0; match_size < largest_size; ++match_size)
++  {
++    /* To simplify the logic, always pretend the strings end with '/' */
++    from_c = (match_size < from_size) ? from[match_size] : '/';
++    to_c =   (match_size <   to_size) ?   to[match_size] : '/';
++
++    if (from_c != to_c)
++    {
++      if (from_c != '\0' || to_c != '\0')
++      {
++        match_size = match_size_dirsep;
++      }
++      break;
++    }
++    else if (from_c == '/')
++    {
++      match_size_dirsep = match_size;
++    }
++  }
++  strncpy (common_part, from, match_size);
++  common_part[match_size] = '\0';
++  from += match_size;
++  to += match_size;
++  size_t ndotdots = 0;
++  char const* from_last = from + strlen(from) - 1;
++  while ((from = strchr (from, '/')) && from != from_last)
++  {
++    ++ndotdots;
++    ++from;
++  }
++  for (count = 0; count < ndotdots; ++count)
++  {
++    strcat(result, "../");
++  }
++  if (strlen(to) > 0)
++  {
++    strcat(result, to+1);
++  }
++  /* Make sure that if to ends with '/' result does the same, and
++     vice-versa. */
++  size_t size_result = strlen(result);
++  if ((to_final_is_slash == 1)
++      && (!size_result || result[size_result-1] != '/'))
++  {
++    strcat (result, "/");
++  }
++  else if (!to_final_is_slash
++           && size_result && result[size_result-1] == '/')
++  {
++    result[size_result-1] = '\0';
++  }
++
++  return malloc_copy_string (result);
++}
++
++void
++simplify_path(char * path)
++{
++  ssize_t n_toks = 1; /* in-case we need an empty initial token. */
++  ssize_t i, j;
++  size_t tok_size;
++  size_t in_size = strlen (path);
++  int it_ended_with_a_slash = (path[in_size - 1] == '/') ? 1 : 0;
++  char * result = path;
++  sanitise_path(result);
++  char * result_p = result;
++
++  do
++  {
++    ++n_toks;
++    ++result_p;
++  } while ((result_p = strchr (result_p, '/')) != NULL);
++
++  result_p = result;
++  char const ** toks = (char const **) alloca (sizeof (char const*) * n_toks);
++  n_toks = 0;
++  do
++  {
++    if (result_p > result)
++    {
++      *result_p++ = '\0';
++    }
++    else if (*result_p == '/')
++    {
++      /* A leading / creates an empty initial token. */
++      toks[n_toks++] = result_p;
++      *result_p++ = '\0';
++    }
++    toks[n_toks++] = result_p;
++  } while ((result_p = strchr (result_p, '/')) != NULL);
++
++  /* Remove all non-leading '.' and any '..' we can match
++     with an earlier forward path (i.e. neither '.' nor '..') */
++  for (i = 1; i < n_toks; ++i)
++  {
++    int removals[2] = { -1, -1 };
++    if ( strcmp (toks[i], "." ) == 0)
++    {
++      removals[0] = i;
++    }
++    else if ( strcmp (toks[i], ".." ) == 0)
++    {
++      /* Search backwards for a forward path to collapse.
++         If none are found then the .. also stays. */
++      for (j = i - 1; j > -1; --j)
++      {
++        if ( strcmp (toks[j], "." )
++          && strcmp (toks[j], ".." ) )
++        {
++          removals[0] = j;
++          removals[1] = i;
++          break;
++        }
++      }
++    }
++    for (j = 0; j < 2; ++j)
++    {
++      if (removals[j] >= 0) /* Can become -2 */
++      {
++        --n_toks;
++        memmove (&toks[removals[j]], &toks[removals[j]+1], (n_toks - removals[j])*sizeof (char*));
++        --i;
++        if (!j)
++        {
++          --removals[1];
++        }
++      }
++    }
++  }
++  result_p = result;
++  for (i = 0; i < n_toks; ++i)
++  {
++    tok_size = strlen(toks[i]);
++    memcpy (result_p, toks[i], tok_size);
++    result_p += tok_size;
++    if ((!i || tok_size) && ((i < n_toks - 1) || it_ended_with_a_slash == 1))
++    {
++      *result_p = '/';
++      ++result_p;
++    }
++  }
++  *result_p = '\0';
++}
++
++/* Returns actual_to by calculating the relative path from -> to and
++   applying that to actual_from. An assumption that actual_from is a
++   dir is made, and it may or may not end with a '/' */
++char const *
++get_relocated_path (char const * from, char const * to, char const * actual_from)
++{
++  char const * relative_from_to = get_relative_path (from, to);
++  char * actual_to = (char *) malloc (strlen(actual_from) + 2 + strlen(relative_from_to));
++  return actual_to;
++}
++
++int
++get_executable_path(char const * argv0, char * result, ssize_t max_size)
++{
++  char * system_result = (char *) alloca (max_size);
++  ssize_t system_result_size = -1;
++  ssize_t result_size = -1;
++
++  if (system_result != NULL)
++  {
++#if defined(IMPLEMENT_SYS_GET_EXECUTABLE_PATH)
++#if defined(__linux__) || defined(__CYGWIN__) || defined(__MSYS__)
++    system_result_size = readlink("/proc/self/exe", system_result, max_size);
++#elif defined(__APPLE__)
++    uint32_t bufsize = (uint32_t)max_size;
++    if (_NSGetExecutablePath(system_result, &bufsize) == 0)
++    {
++      system_result_size = (ssize_t)bufsize;
++    }
++#elif defined(_WIN32)
++    unsigned long bufsize = (unsigned long)max_size;
++    system_result_size = GetModuleFileNameA(NULL, system_result, bufsize);
++    if (system_result_size == 0 || system_result_size == (ssize_t)bufsize)
++    {
++      /* Error, possibly not enough space. */
++      system_result_size = -1;
++    }
++    else
++    {
++      /* Early conversion to unix slashes instead of more changes
++         everywhere else .. */
++      char * winslash;
++      system_result[system_result_size] = '\0';
++      while ((winslash = strchr (system_result, '\\')) != NULL)
++      {
++        *winslash = '/';
++      }
++    }
++#else
++#warning "Don't know how to get executable path on this system"
++#endif
++#endif /* defined(IMPLEMENT_SYS_GET_EXECUTABLE_PATH) */
++  }
++  /* Use argv0 as a default in-case of failure */
++  if (system_result_size != -1)
++  {
++    strncpy (result, system_result, system_result_size);
++    result[system_result_size] = '\0';
++  }
++  else
++  {
++    if (argv0 != NULL)
++    {
++      strncpy (result, argv0, max_size);
++      result[max_size-1] = '\0';
++    }
++    else
++    {
++      result[0] = '\0';
++    }
++  }
++  result_size = strlen (result);
++  return result_size;
++}
++
++char const *
++strip_n_prefix_folders(char const * path, size_t n)
++{
++  if (path == NULL)
++  {
++    return NULL;
++  }
++
++  if (path[0] != '/')
++  {
++    return path;
++  }
++
++  char const * last = path;
++  while (n-- && path != NULL)
++  {
++    last = path;
++    path = strchr (path + 1, '/');
++  }
++  return (path == NULL) ? last : path;
++}
++
++void
++strip_n_suffix_folders(char * path, size_t n)
++{
++  if (path == NULL)
++  {
++    return;
++  }
++  while (n--)
++  {
++    if (strrchr (path + 1, '/'))
++    {
++      *strrchr (path + 1, '/') = '\0';
++    }
++    else
++    {
++      return;
++    }
++  }
++  return;
++}
++
++size_t
++split_path_list(char const * path_list, char split_char, char *** arr)
++{
++  size_t path_count;
++  size_t path_list_size;
++  char const * path_list_p;
++
++  path_list_p = path_list;
++  if (path_list == NULL || path_list[0] == '\0')
++  {
++    return 0;
++  }
++  path_list_size = strlen (path_list);
++
++  path_count = 0;
++  do
++  {
++    ++path_count;
++    ++path_list_p;
++  }
++  while ((path_list_p = strchr (path_list_p, split_char)) != NULL);
++
++  /* allocate everything in one go. */
++  char * all_memory = (char *) malloc (sizeof (char *) * path_count + strlen(path_list) + 1);
++  if (all_memory == NULL)
++    return 0;
++  *arr = (char **)all_memory;
++  all_memory += sizeof (char *) * path_count;
++
++  path_count = 0;
++  path_list_p = path_list;
++  char const * next_path_list_p = 0;
++  do
++  {
++    next_path_list_p = strchr (path_list_p, split_char);
++    if (next_path_list_p != NULL)
++    {
++      ++next_path_list_p;
++    }
++    size_t this_size = (next_path_list_p != NULL)
++                       ? next_path_list_p - path_list_p - 1
++                       : &path_list[path_list_size] - path_list_p;
++    memcpy (all_memory, path_list_p, this_size);
++    all_memory[this_size] = '\0';
++    (*arr)[path_count++] = all_memory;
++    all_memory += this_size + 1;
++  } while ((path_list_p = next_path_list_p) != NULL);
++
++  return path_count;
++}
++
++char *
++get_relocated_path_list(char const * from, char const * to_path_list)
++{
++  char exe_path[MAX_PATH];
++  char * temp;
++  get_executable_path (NULL, &exe_path[0], sizeof (exe_path) / sizeof (exe_path[0]));
++  if ((temp = strrchr (exe_path, '/')) != NULL)
++  {
++    temp[1] = '\0';
++  }
++
++  char **arr = NULL;
++  /* Ask Alexey why he added this. Are we not 100% sure
++     that we're dealing with unix paths here? */
++  char split_char = ':';
++  if (strchr (to_path_list, ';'))
++  {
++    split_char = ';';
++  }
++  size_t count = split_path_list (to_path_list, split_char, &arr);
++  int result_size = 1 + (count - 1); /* count - 1 is for ; delim. */
++  size_t exe_path_size = strlen (exe_path);
++  size_t i;
++  /* Space required is:
++     count * (exe_path_size + strlen (rel_to_datadir))
++     rel_to_datadir upper bound is:
++     (count * strlen (from)) + (3 * num_slashes (from))
++     + strlen(arr[i]) + 1.
++     .. pathalogically num_slashes (from) is strlen (from)
++     (from = ////////) */
++  size_t space_required = (count * (exe_path_size + 4 * strlen (from))) + count - 1;
++  for (i = 0; i < count; ++i)
++  {
++    space_required += strlen (arr[i]);
++  }
++  char * scratch = (char *) alloca (space_required);
++  if (scratch == NULL)
++    return NULL;
++  for (i = 0; i < count; ++i)
++  {
++    char * rel_to_datadir = get_relative_path (from, arr[i]);
++    scratch[0] = '\0';
++    arr[i] = scratch;
++    strcat (scratch, exe_path);
++    strcat (scratch, rel_to_datadir);
++    simplify_path (arr[i]);
++    size_t arr_i_size = strlen (arr[i]);
++    result_size += arr_i_size;
++    scratch = arr[i] + arr_i_size + 1;
++  }
++  char * result = (char *) malloc (result_size);
++  if (result == NULL)
++  {
++    return NULL;
++  }
++  result[0] = '\0';
++  for (i = 0; i < count; ++i)
++  {
++    strcat (result, arr[i]);
++    if (i != count-1)
++    {
++#if defined(_WIN32)
++      strcat (result, ";");
++#else
++      strcat (result, ":");
++#endif
++    }
++  }
++  free ((void*)arr);
++  return result;
++}
+diff --git a/crypto/x509/x509_def.c b/crypto/x509/x509_def.c
+index bfa8d7d852..6fcc1b021a 100644
+--- a/crypto/x509/x509_def.c
++++ b/crypto/x509/x509_def.c
+@@ -9,27 +9,42 @@
+ 
+ #include <stdio.h>
+ #include "internal/cryptlib.h"
++#include "pathtools.h"
+ #include <openssl/crypto.h>
+ #include <openssl/x509.h>
+ 
++char * openssl_relocation(const char *path)
++{
++  char exe_path[PATH_MAX];
++  get_executable_path (NULL, &exe_path[0], sizeof(exe_path)/sizeof(exe_path[0]));
++  if (strrchr (exe_path, '/') != NULL)
++  {
++     strrchr (exe_path, '/')[1] = '\0';
++  }
++  char * rel_to_datadir = get_relative_path (OPENSSLBIN, path);
++  strcat (exe_path, rel_to_datadir);
++  simplify_path (&exe_path[0]);
++  return malloc_copy_string(exe_path);
++}
++
+ const char *X509_get_default_private_dir(void)
+ {
+-    return X509_PRIVATE_DIR;
++    return openssl_relocation(X509_PRIVATE_DIR);
+ }
+ 
+ const char *X509_get_default_cert_area(void)
+ {
+-    return X509_CERT_AREA;
++    return openssl_relocation(X509_CERT_AREA);
+ }
+ 
+ const char *X509_get_default_cert_dir(void)
+ {
+-    return X509_CERT_DIR;
++    return openssl_relocation(X509_CERT_DIR);
+ }
+ 
+ const char *X509_get_default_cert_file(void)
+ {
+-    return X509_CERT_FILE;
++    return openssl_relocation(X509_CERT_FILE);
+ }
+ 
+ const char *X509_get_default_cert_dir_env(void)
+diff --git a/pathtools.h b/pathtools.h
+new file mode 100644
+index 0000000000..a8a2928049
+--- /dev/null
++++ b/pathtools.h
+@@ -0,0 +1,49 @@
++/*
++      .Some useful path tools.
++        .ASCII only for now.
++   .Written by Ray Donnelly in 2014.
++   .Licensed under CC0 (and anything.
++  .else you need to license it under).
++      .No warranties whatsoever.
++  .email: <mingw.android@gmail.com>.
++ */
++
++#ifndef PATHTOOLS_H
++#define PATHTOOLS_H
++
++#include <unistd.h>
++#if defined(__APPLE__)
++#include <stdlib.h>
++#else
++#include <malloc.h>
++#endif
++#include <stdio.h>
++
++char * malloc_copy_string(char const * original);
++
++/* In-place replaces any '\' with '/' and any '//' with '/' */
++void sanitise_path(char * path);
++
++/* Uses a host OS specific function to determine the path of the executable,
++   if IMPLEMENT_SYS_GET_EXECUTABLE_PATH is defined, otherwise uses argv0. */
++int get_executable_path(char const * argv0, char * result, ssize_t max_size);
++
++/* Where possible, in-place removes occourances of '.' and 'path/..' */
++void simplify_path(char * path);
++
++/* Allocates (via malloc) and returns the path to get from from to to. */
++char * get_relative_path(char const * from, char const * to);
++
++size_t split_path_list(char const * path_list, char split_char, char *** arr);
++
++/* Advances path along by the amount that removes n prefix folders. */
++char const *
++strip_n_prefix_folders(char const * path, size_t n);
++
++/* NULL terminates path to remove n suffix folders. */
++void
++strip_n_suffix_folders(char * path, size_t n);
++
++char * get_relocated_path_list(char const * from, char const * to_path_list);
++
++#endif /* PATHTOOLS_H */


### PR DESCRIPTION
This allows me to have both OpenSSL v3 (full) and v1.1 (runtime) for programs not yet upgraded, such as Git. The recipe and patches are taken directly from git-for-windows/migw-packages. Naming follows Arch Linux: https://archlinux.org/packages/core/x86_64/openssl-1.1/

Issues:
- cv2pdb gets stuck for some reason (I have it installed)

Please comment.