### PR TITLE
litehtml: update to 0.7

### DIFF
--- a/mingw-w64-litehtml/PKGBUILD
+++ b/mingw-w64-litehtml/PKGBUILD
@@ -3,22 +3,21 @@
 _realname=litehtml
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.6
+pkgver=0.7
 pkgrel=1
 pkgdesc="Fast and lightweight HTML/CSS rendering engine (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
 url='http://www.litehtml.com/'
-license=('BSD')
+license=('spdx:BSD-3-Clause')
 depends=("${MINGW_PACKAGE_PREFIX}-gumbo-parser")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
-source=("https://github.com/litehtml/litehtml/archive/v$pkgver/$pkgname-$pkgver.tar.gz")
-sha256sums=('d8ef26218d5dd7c622d9d42cbc233c0e26baf56d069df2dbe65cc5c0a6d38861')
+source=("https://github.com/litehtml/litehtml/archive/v$pkgver/$_realname-$pkgver.tar.gz")
+sha256sums=('4f561dfa616d7fefb732fe9f40d4da9f0ec3925456ea42346d8aa10e946ef7ba')
 
 build() {
-  cd "${srcdir}/${_realname}-${pkgver}"
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
   declare -a extra_config
@@ -33,7 +32,8 @@ build() {
       -GNinja \
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       "${extra_config[@]}" \
-      -DBUILD_{SHARED,STATIC}_LIBS=ON \
+      -DBUILD_SHARED_LIBS=ON \
+      -DCMAKE_SHARED_LIBRARY_NAME_WITH_VERSION=ON \
       -DEXTERNAL_GUMBO=ON \
       -DLITEHTML_UTF8=ON \
       -DBUILD_TESTING=OFF \


### PR DESCRIPTION
I still don't understand how did the previous packages were built!
The source download `url` contains the `$pkgname` (`==${MINGW_PACKAGE_PREFIX}-litehtml`)!