### PR TITLE
binutils: backport patch for x86 import libs

### DIFF
--- a/mingw-w64-binutils/PKGBUILD
+++ b/mingw-w64-binutils/PKGBUILD
@@ -6,7 +6,7 @@ _realname=binutils
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.40
-pkgrel=2
+pkgrel=3
 pkgdesc="A set of programs to assemble and manipulate binary and object files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -27,6 +27,7 @@ source=(https://ftp.gnu.org/gnu/binutils/${_realname}-${pkgver}.tar.bz2{,.sig}
         libiberty-unlink-handle-windows-nul.patch
         bfd-real-fopen-handle-windows-nul.patch
         3001-try-fix-compare_section-abort.patch
+        decorated-symbols-in-import-libs.patch
 )
 sha256sums=('f8298eb153a4b37d112e945aa5cb2850040bcf26a3ea65b5a715c83afe05e48a'
             'SKIP'
@@ -39,7 +40,8 @@ sha256sums=('f8298eb153a4b37d112e945aa5cb2850040bcf26a3ea65b5a715c83afe05e48a'
             '27696da8ecfff307537a461b205fad44d6abc1fa648fbf839e72a1d3ea71c40a'
             '7ccbd418695733c50966068fa9755a6abb156f53af23701d2bc097c63e9e0030'
             'dda1cf0c1825283a8b3708d1a4087dd650f4fbc3f8aa571e211cfe3e1458c8f8'
-            'ddfa01ed6ce1c0608bbcd462ced8383b5f9f686c2b49fb510a41637fff2ca019')
+            'ddfa01ed6ce1c0608bbcd462ced8383b5f9f686c2b49fb510a41637fff2ca019'
+            '6313b7b32840db54bc20cfee7d2537e3e414b657e42e7bae1db1f61d3b63d599')
 validpgpkeys=('EAF1C276A747E9ED86210CBAC3126D3B4AE55E93'
               '3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F')
 
@@ -87,6 +89,11 @@ prepare() {
   # https://sourceware.org/bugzilla/show_bug.cgi?id=30079#c2
   # XXX: Update to upstream fix once there is one
   patch -p1 -i "${srcdir}/3001-try-fix-compare_section-abort.patch"
+
+  if [ "${CARCH}" = "i686" ]; then
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=30421
+    apply_patch_with_msg decorated-symbols-in-import-libs.patch
+  fi
 }
 
 build() {

--- a/mingw-w64-binutils/decorated-symbols-in-import-libs.patch
+++ b/mingw-w64-binutils/decorated-symbols-in-import-libs.patch
@@ -1,0 +1,308 @@
+From 61213b777f28d706aeeefdbc577dffa5b83d0e35 Mon Sep 17 00:00:00 2001
+From: Luca Bacci <luca.bacci@outlook.com>
+Date: Mon, 15 May 2023 10:48:45 +0200
+Subject: [PATCH] Decorated symbols in import libs (BUG 30421)
+
+Signed-off-by: Luca Bacci <luca.bacci@outlook.com>
+---
+ bfd/cofflink.c      | 34 +++++++++++++++++++++++++++++++++-
+ bfd/libcoff-in.h    | 11 +++++++++++
+ bfd/libcoff.h       | 11 +++++++++++
+ ld/emultempl/pe.em  | 29 ++++++++++++++++++++++++++++-
+ ld/emultempl/pep.em | 25 +++++++++++++++++++++++++
+ ld/pe-dll.c         | 39 ++++++++++++++++++++++++++++++++-------
+ 6 files changed, 140 insertions(+), 9 deletions(-)
+
+diff --git a/bfd/cofflink.c b/bfd/cofflink.c
+index 9baec2fc712..24c4a2b0ad7 100644
+--- a/bfd/cofflink.c
++++ b/bfd/cofflink.c
+@@ -89,6 +89,34 @@ _bfd_coff_link_hash_newfunc (struct bfd_hash_entry *entry,
+   return (struct bfd_hash_entry *) ret;
+ }
+ 
++struct bfd_hash_entry *
++_decoration_hash_newfunc (struct bfd_hash_entry *entry,
++			  struct bfd_hash_table *table,
++			  const char *string)
++{
++  struct decoration_hash_entry *ret = (struct decoration_hash_entry *) entry;
++
++  /* Allocate the structure if it has not already been allocated by a
++     subclass.  */
++  if (ret == NULL)
++    {
++      ret = (struct decoration_hash_entry *)
++	    bfd_hash_allocate (table, sizeof (struct decoration_hash_entry));
++      if (ret == NULL)
++	return NULL;
++    }
++
++  /* Call the allocation method of the superclass.  */
++  ret = (struct decoration_hash_entry *)
++	_bfd_link_hash_newfunc ((struct bfd_hash_entry *) ret, table, string);
++  if (ret != NULL)
++    {
++      ret->decorated_link = NULL;
++    }
++
++  return (struct bfd_hash_entry *) ret;
++}
++
+ /* Initialize a COFF linker hash table.  */
+ 
+ bool
+@@ -100,7 +128,11 @@ _bfd_coff_link_hash_table_init (struct coff_link_hash_table *table,
+ 				unsigned int entsize)
+ {
+   memset (&table->stab_info, 0, sizeof (table->stab_info));
+-  return _bfd_link_hash_table_init (&table->root, abfd, newfunc, entsize);
++
++  return bfd_hash_table_init (&table->decoration_hash,
++			      _decoration_hash_newfunc,
++			      sizeof (struct decoration_hash_entry))
++	 &&_bfd_link_hash_table_init (&table->root, abfd, newfunc, entsize);
+ }
+ 
+ /* Create a COFF linker hash table.  */
+diff --git a/bfd/libcoff-in.h b/bfd/libcoff-in.h
+index d0839c76e96..af59486c925 100644
+--- a/bfd/libcoff-in.h
++++ b/bfd/libcoff-in.h
+@@ -282,6 +282,9 @@ struct coff_link_hash_table
+   struct bfd_link_hash_table root;
+   /* A pointer to information used to link stabs in sections.  */
+   struct stab_info stab_info;
++  /* Hash table that maps undecorated names to their respective
++   * decorated coff_link_hash_entry as found in fixup_stdcalls  */
++  struct bfd_hash_table decoration_hash;
+ };
+ 
+ struct coff_reloc_cookie
+@@ -313,6 +316,12 @@ struct coff_reloc_cookie
+ 
+ #define coff_hash_table(p) ((struct coff_link_hash_table *) ((p)->hash))
+ 
++struct decoration_hash_entry
++{
++  struct bfd_hash_entry root;
++  struct bfd_link_hash_entry *decorated_link;
++};
++
+ /* Functions in coffgen.c.  */
+ extern bfd_cleanup coff_object_p
+   (bfd *);
+@@ -560,6 +569,8 @@ struct coff_section_alignment_entry
+   unsigned int alignment_power;
+ };
+ 
++extern struct bfd_hash_entry *_decoration_hash_newfunc
++  (struct bfd_hash_entry *, struct bfd_hash_table *, const char *);
+ extern struct bfd_hash_entry *_bfd_coff_link_hash_newfunc
+   (struct bfd_hash_entry *, struct bfd_hash_table *, const char *);
+ extern bool _bfd_coff_link_hash_table_init
+diff --git a/bfd/libcoff.h b/bfd/libcoff.h
+index 235d5c3c843..9084832da97 100644
+--- a/bfd/libcoff.h
++++ b/bfd/libcoff.h
+@@ -286,6 +286,9 @@ struct coff_link_hash_table
+   struct bfd_link_hash_table root;
+   /* A pointer to information used to link stabs in sections.  */
+   struct stab_info stab_info;
++  /* Hash table that maps undecorated names to their respective
++   * decorated coff_link_hash_entry as found in fixup_stdcalls  */
++  struct bfd_hash_table decoration_hash;
+ };
+ 
+ struct coff_reloc_cookie
+@@ -317,6 +320,12 @@ struct coff_reloc_cookie
+ 
+ #define coff_hash_table(p) ((struct coff_link_hash_table *) ((p)->hash))
+ 
++struct decoration_hash_entry
++{
++  struct bfd_hash_entry root;
++  struct bfd_link_hash_entry *decorated_link;
++};
++
+ /* Functions in coffgen.c.  */
+ extern bfd_cleanup coff_object_p
+   (bfd *);
+@@ -564,6 +573,8 @@ struct coff_section_alignment_entry
+   unsigned int alignment_power;
+ };
+ 
++extern struct bfd_hash_entry *_decoration_hash_newfunc
++  (struct bfd_hash_entry *, struct bfd_hash_table *, const char *);
+ extern struct bfd_hash_entry *_bfd_coff_link_hash_newfunc
+   (struct bfd_hash_entry *, struct bfd_hash_table *, const char *);
+ extern bool _bfd_coff_link_hash_table_init
+diff --git a/ld/emultempl/pe.em b/ld/emultempl/pe.em
+index 38cb61138bd..7d956bf555c 100644
+--- a/ld/emultempl/pe.em
++++ b/ld/emultempl/pe.em
+@@ -1188,6 +1188,30 @@ change_undef (struct bfd_link_hash_entry * undef,
+   lang_add_gc_name (sym->root.string);
+ }
+ 
++static void
++set_decoration (const char *undecorated_name,
++		struct bfd_link_hash_entry * decoration)
++{
++  static bool  gave_warning_message = false;
++  struct decoration_hash_entry *entry;
++
++  if (is_underscoring () && undecorated_name[0] == '_')
++    undecorated_name++;
++
++  entry = (struct decoration_hash_entry *)
++	  bfd_hash_lookup (&(coff_hash_table (&link_info)->decoration_hash),
++			   undecorated_name, true /* create */, false /* copy */);
++
++  if (entry->decorated_link != NULL && !gave_warning_message)
++    {
++      einfo (_("%P: warning: overwriting decorated name %s with %s\n"),
++	     entry->decorated_link->root.string, undecorated_name);
++      gave_warning_message = true;
++    }
++
++  entry->decorated_link = decoration;
++}
++
+ static void
+ pe_fixup_stdcalls (void)
+ {
+@@ -1231,7 +1255,10 @@ pe_fixup_stdcalls (void)
+ 	    bfd_link_hash_traverse (link_info.hash, pe_undef_cdecl_match,
+ 				    (char *) name);
+ 	    if (pe_undef_found_sym)
+-	      change_undef (undef, pe_undef_found_sym);
++	      {
++		change_undef (undef, pe_undef_found_sym);
++		set_decoration (undef->root.string, pe_undef_found_sym);
++	      }
+ 	  }
+       }
+ }
+diff --git a/ld/emultempl/pep.em b/ld/emultempl/pep.em
+index 32883b27706..99e71951b8a 100644
+--- a/ld/emultempl/pep.em
++++ b/ld/emultempl/pep.em
+@@ -1119,6 +1119,30 @@ pep_undef_cdecl_match (struct bfd_link_hash_entry *h, void *inf)
+   return true;
+ }
+ 
++static void
++set_decoration (const char *undecorated_name,
++		struct bfd_link_hash_entry * decoration)
++{
++  static bool  gave_warning_message = false;
++  struct decoration_hash_entry *entry;
++
++  if (is_underscoring () && undecorated_name[0] == '_')
++    undecorated_name++;
++
++  entry = (struct decoration_hash_entry *)
++	  bfd_hash_lookup (&(coff_hash_table (&link_info)->decoration_hash),
++			   undecorated_name, true /* create */, false /* copy */);
++
++  if (entry->decorated_link != NULL && !gave_warning_message)
++    {
++      einfo (_("%P: warning: overwriting decorated name %s with %s\n"),
++	     entry->decorated_link->root.string, undecorated_name);
++      gave_warning_message = true;
++    }
++
++  entry->decorated_link = decoration;
++}
++
+ static void
+ pep_fixup_stdcalls (void)
+ {
+@@ -1180,6 +1204,7 @@ pep_fixup_stdcalls (void)
+ 		undef->type = bfd_link_hash_defined;
+ 		undef->u.def.value = sym->u.def.value;
+ 		undef->u.def.section = sym->u.def.section;
++		set_decoration (undef->root.string, sym);
+ 
+ 		if (pep_enable_stdcall_fixup == -1)
+ 		  {
+diff --git a/ld/pe-dll.c b/ld/pe-dll.c
+index 8d74dba6af0..e45ae104265 100644
+--- a/ld/pe-dll.c
++++ b/ld/pe-dll.c
+@@ -2321,6 +2321,31 @@ make_one (def_file_export *exp, bfd *parent, bool include_jmp_stub)
+   bfd *abfd;
+   const unsigned char *jmp_bytes = NULL;
+   int jmp_byte_count = 0;
++  const char *internal_name = exp->internal_name;
++
++  if (!exp->flag_noname)
++    {
++      /* Check for a decorated symbol name */
++      struct decoration_hash_entry *entry;
++
++      entry = (struct decoration_hash_entry *)
++	      bfd_hash_lookup (&(coff_hash_table (&link_info)->decoration_hash),
++			       internal_name, false, false);
++      if (entry)
++	{
++	  if (entry->decorated_link)
++	    {
++	      internal_name = entry->decorated_link->root.string;
++
++	      if (pe_details->underscored && internal_name[0] == '_')
++		internal_name++;
++	    }
++	  else
++	    {
++	      einfo (_("%P: error: NULL decorated name for %s\n"), internal_name);
++	    }
++	}
++    }
+ 
+   /* Include the jump stub section only if it is needed. A jump
+      stub is needed if the symbol being imported <sym> is a function
+@@ -2382,13 +2407,13 @@ make_one (def_file_export *exp, bfd *parent, bool include_jmp_stub)
+   id4 = quick_section (abfd, ".idata$4", SEC_HAS_CONTENTS, 2);
+   id6 = quick_section (abfd, ".idata$6", SEC_HAS_CONTENTS, 2);
+ 
+-  if  (*exp->internal_name == '@')
++  if  (*internal_name == '@')
+     {
+       quick_symbol (abfd, U ("_head_"), dll_symname, "", UNDSEC,
+ 		    BSF_GLOBAL, 0);
+       if (include_jmp_stub)
+-	quick_symbol (abfd, "", exp->internal_name, "", tx, BSF_GLOBAL, 0);
+-      quick_symbol (abfd, "__imp_", exp->internal_name, "", id5,
++	quick_symbol (abfd, "", internal_name, "", tx, BSF_GLOBAL, 0);
++      quick_symbol (abfd, "__imp_", internal_name, "", id5,
+ 		    BSF_GLOBAL, 0);
+       /* Fastcall applies only to functions,
+ 	 so no need for auto-import symbol.  */
+@@ -2398,18 +2423,18 @@ make_one (def_file_export *exp, bfd *parent, bool include_jmp_stub)
+       quick_symbol (abfd, U ("_head_"), dll_symname, "", UNDSEC,
+ 		    BSF_GLOBAL, 0);
+       if (include_jmp_stub)
+-	quick_symbol (abfd, U (""), exp->internal_name, "", tx,
++	quick_symbol (abfd, U (""), internal_name, "", tx,
+ 		      BSF_GLOBAL, 0);
+-      quick_symbol (abfd, "__imp_", U (""), exp->internal_name, id5,
++      quick_symbol (abfd, "__imp_", U (""), internal_name, id5,
+ 		    BSF_GLOBAL, 0);
+       /* Symbol to reference ord/name of imported
+ 	 data symbol, used to implement auto-import.  */
+       if (exp->flag_data)
+-	quick_symbol (abfd, "__nm_", U (""), exp->internal_name, id6,
++	quick_symbol (abfd, "__nm_", U (""), internal_name, id6,
+ 		      BSF_GLOBAL,0);
+     }
+   if (pe_dll_compat_implib)
+-    quick_symbol (abfd, "___imp_", exp->internal_name, "", id5,
++    quick_symbol (abfd, "___imp_", internal_name, "", id5,
+ 		  BSF_GLOBAL, 0);
+ 
+   if (include_jmp_stub)
+-- 
+2.40.1
+


### PR DESCRIPTION
Fixes an issue in ld where import libraries are generated with undecorated symbols. See https://sourceware.org/bugzilla/show_bug.cgi?id=30421