### PR TITLE
1. directx-headers - make this its own package to facilitate reuse by…

### DIFF
--- a/mingw-w64-directx-headers/DirectX-Headers.pc.in
+++ b/mingw-w64-directx-headers/DirectX-Headers.pc.in
@@ -1,0 +1,9 @@
+prefix=MINGW_PREFIX
+includedir=${prefix}/include
+libdir=${prefix}/lib
+
+Name: DirectX-Headers
+Description: Headers for using D3D12
+Version: VERSION
+Libs: -L${libdir} -lDirectX-Headers -lDirectX-Guids
+Cflags: -I${includedir}

--- a/mingw-w64-directx-headers/PKGBUILD
+++ b/mingw-w64-directx-headers/PKGBUILD
@@ -22,7 +22,7 @@ source=("$url/archive/refs/tags/v$pkgver.tar.gz"
        DirectX-Headers.pc.in)
 sha256sums=('343b04a8206c4169a1feab99a7bd29ecb0c8f511988e9a007fea51768bda14fa'
             '899a018a4107855a74cc6cee783341c2347be22a5b704cc26ccca8c5f182d9ed'
-            'b6373e98fe5e5213784660908c605257656d2ae0a75449fbe68641355eae4d13')
+            'ee973cd0715cc2264543e404d2a6bf885be823a34e4eb371a27901d7dae01c08')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}

--- a/mingw-w64-directx-headers/PKGBUILD
+++ b/mingw-w64-directx-headers/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
 
-#This uses CMake instead of mesa because the CMake build
+#This uses CMake instead of meson because the CMake build
 #generate *.cmake that are used by other libraries that
 #depend upon CMake's findpackage ffunction.
 

--- a/mingw-w64-directx-headers/PKGBUILD
+++ b/mingw-w64-directx-headers/PKGBUILD
@@ -1,0 +1,68 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+#This uses CMake instead of mesa because the CMake build
+#generate *.cmake that are used by other libraries that
+#depend upon CMake's findpackage ffunction.
+
+_realname=directx-headers
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.610.0
+pkgrel=1
+pkgdesc="Official DirectX headers available under an open source license (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+url='https://github.com/microsoft/DirectX-Headers'
+license=('MIT')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+source=("$url/archive/refs/tags/v$pkgver.tar.gz"
+       fix-cmake.patch
+       DirectX-Headers.pc.in)
+sha256sums=('343b04a8206c4169a1feab99a7bd29ecb0c8f511988e9a007fea51768bda14fa'
+            '899a018a4107855a74cc6cee783341c2347be22a5b704cc26ccca8c5f182d9ed'
+            'b6373e98fe5e5213784660908c605257656d2ae0a75449fbe68641355eae4d13')
+
+prepare() {
+  cd "${srcdir}"/${_realname}-${pkgver}
+
+# fix RPCNDR version incompatibility
+  patch -Np1 -i "${srcdir}"/fix-cmake.patch
+}
+
+build() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
+
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    "${MINGW_PREFIX}"/bin/cmake.exe \
+      -GNinja \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      "${extra_config[@]}" \
+      -DDXHEADERS_BUILD_TEST=OFF -DDXHEADERS_BUILD_GOOGLE_TEST=OFF \
+      ../${_realname}-${pkgver}
+
+  "${MINGW_PREFIX}"/bin/cmake.exe --build .
+  
+# Generate DirectX-Headers.pc manually for software that doesn't use
+# CMake for builds such as mesa.
+  sed ${srcdir}/DirectX-Headers.pc.in \
+    -e "s|VERSION|$pkgver|g" \
+    -e "s|MINGW_PREFIX|${MINGW_PREFIX}|g" > DirectX-Headers.pc
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
+
+  install -Dm644 "DirectX-Headers.pc" "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/DirectX-Headers.pc"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}

--- a/mingw-w64-directx-headers/fix-cmake.patch
+++ b/mingw-w64-directx-headers/fix-cmake.patch
@@ -1,0 +1,11 @@
+--- DirectX-Headers-1.610.0/CMakeLists.txt.bak	2023-05-18 20:00:56.042623700 -0400
++++ DirectX-Headers-1.610.0/CMakeLists.txt	2023-05-19 04:08:46.329015800 -0400
+@@ -45,6 +45,8 @@ if (NOT WIN32)
+         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/wsl/stubs>"
+         "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/wsl/stubs>"
+     )
++elseif((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__REQUIRED_RPCNDR_H_VERSION__=475")
+ endif()
+ 
+ add_library(Microsoft::DirectX-Headers ALIAS DirectX-Headers)

--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -4,13 +4,15 @@ _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=23.0.3
-pkgrel=1
+pkgrel=2
 pkgdesc="Open-source implementation of the OpenGL, Vulkan and OpenCL specifications (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-directx-headers"
              "${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-polly"
              "${MINGW_PACKAGE_PREFIX}-python-mako"
              "${MINGW_PACKAGE_PREFIX}-libclc"
              "${MINGW_PACKAGE_PREFIX}-libelf"

--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -9,6 +9,7 @@ pkgdesc="Open-source implementation of the OpenGL, Vulkan and OpenCL specificati
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-directx-headers"
              "${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"


### PR DESCRIPTION
… any other libraries.  Includes .pc file and *.cmake support.  Current version.

2. add directx-headers and polly as build-time dependencies.