### PR TITLE
qt5-static: enable vulkan

### DIFF
--- a/mingw-w64-qt5-static/0003-enable-avx-support.patch
+++ b/mingw-w64-qt5-static/0003-enable-avx-support.patch
@@ -1,0 +1,12 @@
+--- a/qtbase/config.tests/x86_simd/main.cpp
++++ b/qtbase/config.tests/x86_simd/main.cpp
+@@ -161,9 +161,6 @@
+ #endif
+ 
+ #if T(AVX)
+-#  if defined(__WIN64__) && defined(__GNUC__) && !defined(__clang__)
+-#    error "AVX support is broken in 64-bit MinGW - https://gcc.gnu.org/bugzilla/show_bug.cgi?id=49001"
+-#  endif
+ attribute_target("avx") void test_avx()
+ {
+     __m256d a = _mm256_setzero_pd();

--- a/mingw-w64-qt5-static/PKGBUILD
+++ b/mingw-w64-qt5-static/PKGBUILD
@@ -12,13 +12,14 @@ _realname=qt5-static
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.15.9
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 pkgdesc="A cross-platform application and UI framework (mingw-w64-static)"
 url='https://www.qt.io/'
 license=('GPL3' 'LGPL' 'FDL' 'custom')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-vulkan"
          "${MINGW_PACKAGE_PREFIX}-z3")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-clang"
@@ -30,10 +31,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-dbus"
              "${MINGW_PACKAGE_PREFIX}-openssl"
+             "${MINGW_PACKAGE_PREFIX}-vulkan-headers"
              "m4"
              "perl")
 groups=("${MINGW_PACKAGE_PREFIX}-qt-static" "${MINGW_PACKAGE_PREFIX}-qt5-static")
-options=('!strip')
 _pkgfile="qt-everywhere-opensource-src-${pkgver}"
 _pkgfqn="qt-everywhere-src-${pkgver}"
 noextract=(${_pkgfile}.tar.xz)
@@ -41,6 +42,7 @@ source=(https://download.qt.io/official_releases/qt/${pkgver%.*}/${pkgver}/singl
         0000-adjust-qmake-conf-mingw.patch
         0001-qt-5.8.0-fix-sql-libraries-mingw.patch
         0002-qt-5.8.0-configure-gcc-before-clang.patch
+        0003-enable-avx-support.patch
         0004-fix-linking-again-different-static-libs.patch
         0006-qt-5.3.0-win_flex-replace.patch
         0007-qt-5.3.0-win32-g-Enable-static-builds.patch
@@ -96,6 +98,7 @@ prepare() {
     0000-adjust-qmake-conf-mingw.patch \
     0001-qt-5.8.0-fix-sql-libraries-mingw.patch \
     0002-qt-5.8.0-configure-gcc-before-clang.patch \
+    0003-enable-avx-support.patch \
     0004-fix-linking-again-different-static-libs.patch \
     0006-qt-5.3.0-win_flex-replace.patch \
     0007-qt-5.3.0-win32-g-Enable-static-builds.patch \
@@ -135,6 +138,10 @@ prepare() {
     0304-qtdeclarative-disable-dx12.patch \
     0310-fix-assimp-not-found.patch
 
+  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
+    sed -i "s| -mthreads||g" qtbase/mkspecs/common/g++-win32.conf
+  fi
+
   local _ARCH_TUNE=
   case ${MINGW_CHOST} in
     i686*)
@@ -166,34 +173,8 @@ build() {
   mkdir -p ${_buildpkgdir}
   local QTDIR_WIN=$(cygpath -am ${_buildpkgdir})
 
-  local _freetype2_pkgconf=""
-  local _libxml2_pkgconf=""
-
-  _extra_incpaths+=("-I")
-  _extra_incpaths+=("${MINGW_PREFIX}/include/mariadb")
-
-  local -a _extra_libpaths=()
-  local -a _extra_libs=()
-
   cd ${MSYSTEM}
   touch qtbase/.gitignore
-
-  # Set other config stuff that's configure-script-type dependent.
-  local -a _extra_config
-
-  _extra_config+=("-no-glib")
-
-  # static can't use anything but -qt-sql-sqlite both for size
-  # reasons and because shared libraries get auto-detected and
-  # built as plugins.
-  local -a _sql_config
-  _sql_config+=("-no-sql-ibase")
-  _sql_config+=("-no-sql-mysql")
-  _sql_config+=("-no-sql-odbc")
-  _sql_config+=("-no-sql-psql")
-  _sql_config+=("-no-sql-sqlite2")
-  _sql_config+=("-sql-sqlite")
-  _sql_config+=("-qt-sqlite")
 
   # https://github.com/msys2/MSYS2-packages/issues/2282
   export MSYS2_ARG_CONV_EXCL='--foreign-types='
@@ -212,35 +193,51 @@ build() {
 
   export PATH="${srcdir}/${MSYSTEM}/qtbase/bin:${srcdir}/${MSYSTEM}/qtbase/lib:${PATH}"
   export LLVM_INSTALL_DIR=${MINGW_PREFIX}
-  #export FORCE_MINGW_QDOC_BUILD=1
   export VULKAN_SDK=${MINGW_PREFIX}
 
   export QDOC_USE_STATIC_LIBCLANG=1
+  #export FORCE_MINGW_QDOC_BUILD=1
   # Hack to disable building qdoc
   patch -p1 -i ${srcdir}/0302-ugly-hack-disable-qdoc-build.patch
   export QDOC_SKIP_BUILD=1
 
   configure_opts+=("-static")
   configure_opts+=("-static-runtime")
-  configure_opts+=("-no-jasper")
-  configure_opts+=("-no-mng")
   configure_opts+=("-D" "JAS_DLL=0")
-  configure_opts+=("-dbus-linked")
   configure_opts+=("-schannel")
 
   configure_opts+=("-no-fontconfig")
+  configure_opts+=("-no-glib")
+  configure_opts+=("-no-gstreamer")
+  configure_opts+=("-no-iconv")
+  configure_opts+=("-no-icu")
+  configure_opts+=("-no-jasper")
+  configure_opts+=("-no-mng")
+  configure_opts+=("-no-wmf")
+  configure_opts+=("-qt-assimp")
+  configure_opts+=("-qt-doubleconversion")
   configure_opts+=("-qt-freetype")
   configure_opts+=("-qt-harfbuzz")
   configure_opts+=("-qt-libjpeg")
   configure_opts+=("-qt-libpng")
+  configure_opts+=("-qt-pcre")
   configure_opts+=("-qt-tiff")
   configure_opts+=("-qt-webp")
-  configure_opts+=("-qt-pcre")
-  configure_opts+=("-no-icu")
-  configure_opts+=("-qt-assimp")
-  configure_opts+=("-qt-doubleconversion")
+  configure_opts+=("-dbus-linked")
   configure_opts+=("-nomake" "examples")
   configure_opts+=("-nomake" "tests")
+
+  # static can't use anything but -qt-sql-sqlite both for size
+  # reasons and because shared libraries get auto-detected and
+  # built as plugins.
+  local -a _sql_config
+  _sql_config+=("-no-sql-ibase")
+  _sql_config+=("-no-sql-mysql")
+  _sql_config+=("-no-sql-odbc")
+  _sql_config+=("-no-sql-psql")
+  _sql_config+=("-no-sql-sqlite2")
+  _sql_config+=("-sql-sqlite")
+  _sql_config+=("-qt-sqlite")
 
   ./configure \
     -prefix ${QTDIR_WIN} \
@@ -250,17 +247,10 @@ build() {
     -opensource \
     -confirm-license \
     -platform ${_platform} \
-    -debug-and-release \
-    "${_extra_incpaths[@]}" \
-    "${_extra_libpaths[@]}" \
-    "${_extra_libs[@]}" \
-    -no-iconv \
-    -no-gstreamer \
-    -no-wmf \
+    -release \
     -feature-relocatable \
-    "${_extra_config[@]}" \
-    "${_sql_config[@]}" \
-    "${configure_opts[@]}"
+    "${configure_opts[@]}" \
+    "${_sql_config[@]}"
 
   # I'm keeping this around while qt5-static cmake problems persist (hopefully not long!)
   # qtbase/mkspecs/modules-inst/qt_lib_core.pri
@@ -354,6 +344,7 @@ sha256sums=('26d5f36134db03abe4a6db794c7570d729c92a3fc1b0bf9b1c8f86d0573cd02f'
             '884b32f0e2e1bb110330a921b69443379a7be98c42f13754f9c5f56c040ba3b7'
             '617e6fa85a92353d0073425d37cd5d90d92cb7f906d66dd2d0df576122d091a4'
             '27ce2161b5dbea2fcce6b15948ab722a71036d056420854f6554969f683583bb'
+            '15c9fdf4d54628e64a9b7e456a5308aecf0f1c8e33a5aff0ab0bcac0300a9568'
             'e04033364f5ad77906b4100c34572df57bd793a55bc33b7d8a753a2cc60af259'
             '18fd2fa42215ac47b3b314261ab98cbe65f8231429e4f29a152288a3ca93daf1'
             '4e154fbc9059a096c351d019da6b18c907b1d8b06e028f48c7365f62bcd0edc9'


### PR DESCRIPTION
Reduce buildtime by using release build mode instead of release-and-debug which builds release and debug libraries separately hence the long buildtime. We did the same with qt6-static.