### PR TITLE
clang: make llvm-libs conflict with llvm before the split

### DIFF
--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -27,7 +27,7 @@ _version=16.0.4
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
-pkgrel=1
+pkgrel=2
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -398,6 +398,7 @@ package_llvm-libs() {
            "${MINGW_PACKAGE_PREFIX}-zlib"
            "${MINGW_PACKAGE_PREFIX}-libxml2"
            "${MINGW_PACKAGE_PREFIX}-zstd")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-llvm<16.0.2-2")
 
   cp -r "${srcdir}/llvm-libs/${MINGW_PREFIX}" "${pkgdir}${MINGW_PREFIX}"
 


### PR DESCRIPTION
the split happened in 87c0fcc23c4171e4fa7c23, so with 16.0.2-2