### PR TITLE
luajit: Fix module search path

### DIFF
--- a/mingw-w64-luajit/003-lua51-modules-paths.patch
+++ b/mingw-w64-luajit/003-lua51-modules-paths.patch
@@ -1,7 +1,7 @@
 diff -bur LuaJIT-2.1.0-beta3-orig/src/luaconf.h LuaJIT-2.1.0-beta3/src/luaconf.h
 --- LuaJIT-2.1.0-beta3-orig/src/luaconf.h	2023-01-26 22:15:03.558193500 -0700
 +++ LuaJIT-2.1.0-beta3/src/luaconf.h	2023-01-26 22:15:17.283052500 -0700
-@@ -18,12 +18,20 @@
+@@ -18,10 +18,17 @@
  ** In Windows, any exclamation mark ('!') in the path is replaced by the
  ** path of the directory of the executable file of the current process.
  */
@@ -12,17 +12,13 @@ diff -bur LuaJIT-2.1.0-beta3-orig/src/luaconf.h LuaJIT-2.1.0-beta3/src/luaconf.h
 +#define LUA_LDIR	"!\\..\\share\\lua\\5.1\\"
 +#define LUA_CDIR	"!\\..\\lib\\lua\\5.1\\"
 +
-+#define LUAJIT_LDIR	"!\\lua\\"
-+#define LUAJIT_CDIR	"!\\"
++#define LUAJIT_LDIR	"!\\..\\share\\luajit-2.1.0-beta3\\"
++
  #define LUA_PATH_DEFAULT \
 -  ".\\?.lua;" LUA_LDIR"?.lua;" LUA_LDIR"?\\init.lua;"
 +  ".\\?.lua;" LUAJIT_LDIR"?.lua;" LUAJIT_LDIR"?\\init.lua;" \
 +              LUA_LDIR"?.lua;"  LUA_LDIR"?\\init.lua;" \
 +              LUA_CDIR"?.lua;"  LUA_CDIR"?\\init.lua"
  #define LUA_CPATH_DEFAULT \
--  ".\\?.dll;" LUA_CDIR"?.dll;" LUA_CDIR"loadall.dll"
-+  ".\\?.dll;" LUAJIT_CDIR"?.dll;" LUA_CDIR"?.dll;" LUAJIT_CDIR"loadall.dll"
-+
+   ".\\?.dll;" LUA_CDIR"?.dll;" LUA_CDIR"loadall.dll"
  #else
- /*
- ** Note to distribution maintainers: do NOT patch the following lines!

--- a/mingw-w64-luajit/PKGBUILD
+++ b/mingw-w64-luajit/PKGBUILD
@@ -5,8 +5,8 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 # LuaJIT has abandoned versioned releases and now advises using git HEAD
 # https://github.com/LuaJIT/LuaJIT/issues/665#issuecomment-784452583
-_commit="1c279127050e86e99970100e9c42e0f09cd54ab7"
-pkgver=2.1.0.beta3.r475.g1c279127
+_commit="224129a8e64bfa219d35cd03055bf03952f167f6"
+pkgver=2.1.0.beta3.r476.g224129a8
 pkgrel=1
 pkgdesc="Just-in-time compiler and drop-in replacement for Lua 5.1 (mingw-w64)"
 arch=('any')
@@ -27,7 +27,7 @@ source=("${_realname}"::"git+https://luajit.org/git/luajit.git#commit=${_commit}
         004-fix-default-cc.patch)
 sha256sums=('SKIP'
             '4df486e82b0bbeead01dcf6001e90c51477a3a8ac18611d60d7067f2c7013428'
-            '184a8da3ebc4a35585285cdbc300ef8e24c2ef41e0ec6d00f0e3607f33765c27'
+            'b8c9c9c6e16f8c772f760a9e2f39c048ca00dea01c7b7699f1dbe90e93f2c26c'
             '444df1c8ab9c8c348c7c81a7a6bf15d7e02410f4edc38894a65a4bb7ee9a8d68')
 
 pkgver() {


### PR DESCRIPTION
Fixes https://github.com/msys2/MINGW-packages/issues/16618


    This matches the module search path with luajit in Linux environment.
    The paths can be retrieved using these two lua code

    print("package.path: "..package.path)
    print("package.cpath: "..package.cpath)

    The paths were replaced like this

    * package path:
      - Removed:
        C:\msys64\ucrt64\bin\lua\?.lua;
        C:\msys64\ucrt64\bin\lua\?\init.lua;
      - Added:
        C:\msys64\ucrt64\bin\..\share\luajit-2.1.0-beta3\?.lua;
        C:\msys64\ucrt64\bin\..\share\luajit-2.1.0-beta3\?\init.lua;

    * package cpath:
      - Removed:
        C:\msys64\ucrt64\bin\?.dll;
        C:\msys64\ucrt64\bin\loadall.dll
      - Added:
        C:\msys64\ucrt64\bin\..\lib\lua\5.1\loadall.dll

