### PR TITLE
lua: Fix incorrect module search path

### DIFF
--- a/mingw-w64-lua/0003-Fix-LUA_-DIR-for-MSYS2-FHS-layout.patch
+++ b/mingw-w64-lua/0003-Fix-LUA_-DIR-for-MSYS2-FHS-layout.patch
@@ -11,33 +11,31 @@ diff --git a/src/luaconf.h b/src/luaconf.h
 index d9cf18c..c4b04c3 100644
 --- a/src/luaconf.h
 +++ b/src/luaconf.h
-@@ -185,14 +185,14 @@
- ** non-conventional directories.
- */
- 
--#define LUA_VDIR	LUA_VERSION_MAJOR "." LUA_VERSION_MINOR
- #if defined(_WIN32)	/* { */
- /*
+@@ -196,22 +196,19 @@
  ** In Windows, any exclamation mark ('!') in the path is replaced by the
  ** path of the directory of the executable file of the current process.
  */
 -#define LUA_LDIR	"!\\lua\\"
 -#define LUA_CDIR	"!\\"
-+#define LUA_VDIR	LUA_VERSION_MAJOR "." LUA_VERSION_MINOR "\\"
-+#define LUA_LDIR	"!\\..\\share\\lua\\" LUA_VDIR
-+#define LUA_CDIR	"!\\..\\lib\\lua\\" LUA_VDIR
- #define LUA_SHRDIR	"!\\..\\share\\lua\\" LUA_VDIR "\\"
+-#define LUA_SHRDIR	"!\\..\\share\\lua\\" LUA_VDIR "\\"
++#define LUA_LDIR	"!\\..\\share\\lua\\" LUA_VDIR "\\"
++#define LUA_CDIR	"!\\..\\lib\\lua\\" LUA_VDIR "\\"
  
  #if !defined(LUA_PATH_DEFAULT)
-@@ -211,7 +211,7 @@
+ #define LUA_PATH_DEFAULT  \
+ 		LUA_LDIR"?.lua;"  LUA_LDIR"?\\init.lua;" \
+ 		LUA_CDIR"?.lua;"  LUA_CDIR"?\\init.lua;" \
+-		LUA_SHRDIR"?.lua;" LUA_SHRDIR"?\\init.lua;" \
+ 		".\\?.lua;" ".\\?\\init.lua"
  #endif
  
- #else			/* }{ */
--
-+#define LUA_VDIR	LUA_VERSION_MAJOR "." LUA_VERSION_MINOR
- #define LUA_ROOT	"/usr/local/"
- #define LUA_LDIR	LUA_ROOT "share/lua/" LUA_VDIR "/"
- #define LUA_CDIR	LUA_ROOT "lib/lua/" LUA_VDIR "/"
+ #if !defined(LUA_CPATH_DEFAULT)
+ #define LUA_CPATH_DEFAULT \
+ 		LUA_CDIR"?.dll;" \
+-		LUA_CDIR"..\\lib\\lua\\" LUA_VDIR "\\?.dll;" \
+ 		LUA_CDIR"loadall.dll;" ".\\?.dll"
+ #endif
+ 
 -- 
 2.30.0.windows.2
 

--- a/mingw-w64-lua/PKGBUILD
+++ b/mingw-w64-lua/PKGBUILD
@@ -7,7 +7,7 @@ _realname=lua
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.4.4
-pkgrel=1
+pkgrel=2
 pkgdesc="A powerful light-weight programming language designed for extending applications. (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -26,7 +26,7 @@ sha256sums=('164c7849653b80ae67bec4b7473b884bf5cc8d2dca05653475ec2ed27b9ebf61'
             'ca9252633e782b8f85d6a94ea4f6babd4fe30bd759085b373160b1878e36ff78'
             '9b3c36d1b4001b12306419cf93fa3f0309957865a8d589577838d35d747fb07c'
             'f5b754096ba8117e9e7dedb2e4ecf7b57ab2747e284c14cd51b2cb3353bee3e0'
-            'bae70ef5c4a470527da6696351c9fb90284c6e5739fd2d12d408e5a135a3f1dd'
+            '0d7716c212b94c33ee9b96850213c4920f03b4278a03bf43020d435ae2742936'
             '046de390e803121bca31c9e63e0738cce228cec788cd88d5adcbc727f0f429f9'
             '142fb08b41a807b192b4b2c166696a1830a1c97967e5099ad0e579bf500e1da4')
 


### PR DESCRIPTION
Fixes https://github.com/msys2/MINGW-packages/issues/16638


    This removes paths which are duplicate and with double slashes.
    Also the module search path is now same as in Linux environment.
    The paths can be retrieved using these two lua code

    print("package.path: "..package.path)
    print("package.cpath: "..package.cpath)

    The removed paths as like this

    * package path:
        C:\msys64\ucrt64\bin\..\share\lua\5.4\\?.lua;
        C:\msys64\ucrt64\bin\..\share\lua\5.4\\?\init.lua;

    * package cpath:
        C:\msys64\ucrt64\bin\..\lib\lua\5.4\..\lib\lua\5.4\\?.dll

