### PR TITLE
emacs: turn off optimizations, re-enable native-compilation

### DIFF
--- a/mingw-w64-emacs/002-clang-fixes.patch
+++ b/mingw-w64-emacs/002-clang-fixes.patch
@@ -1,26 +1,4 @@
 diff -aur emacs-28.2-orig/configure.ac emacs-28.2/configure.ac
---- emacs-28.2-orig/configure.ac	2022-09-07 06:24:51.000000000 +0800
-+++ emacs-28.2/configure.ac	2022-10-09 20:40:07.436552500 +0800
-@@ -147,7 +147,7 @@
-       fi
-       cc_target=`$cc -v 2>&1 | sed -n 's/Target: //p'`
-       case "$cc_target" in
--          *-*) host=$cc_target
-+          *-*) host=$target_alias
- 	      ;;
-           "") AC_MSG_ERROR([Impossible to obtain $cc compiler target.
- Please explicitly provide --host.])
-@@ -5765,8 +5765,8 @@
-   mingw32)
-    ## Is it any better under MinGW64 to relocate emacs into higher addresses?
-    case "$canonical" in
--     x86_64-*-*) LD_SWITCH_SYSTEM_TEMACS="-Wl,-stack,0x00800000 -Wl,-heap,0x00100000 -Wl,-image-base,0x400000000 -Wl,-entry,__start -Wl,-Map,./temacs.map" ;;
--     *) LD_SWITCH_SYSTEM_TEMACS="-Wl,-stack,0x00800000 -Wl,-heap,0x00100000 -Wl,-image-base,0x01000000 -Wl,-entry,__start -Wl,-Map,./temacs.map" ;;
-+     x86_64-*-*) LD_SWITCH_SYSTEM_TEMACS="-Wl,-stack,0x00800000 -Wl,-image-base,0x400000000 -Wl,-entry,__start -Wl,-Map,./temacs.map" ;;
-+     *) LD_SWITCH_SYSTEM_TEMACS="-Wl,-stack,0x00800000 -Wl,-image-base,0x01000000 -Wl,-entry,__start -Wl,-Map,./temacs.map" ;;
-    esac
-    ## If they want unexec, disable Windows ASLR for the Emacs binary
-    if test "$with_dumping" = "unexec"; then
 --- a/nt/mingw-cfg.site
 +++ b/nt/mingw-cfg.site
 @@ -29,6 +29,10 @@

--- a/mingw-w64-emacs/PKGBUILD
+++ b/mingw-w64-emacs/PKGBUILD
@@ -43,7 +43,7 @@ source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.xz"{,.s
 sha256sums=('ee21182233ef3232dc97b486af2d86e14042dbb65bbc535df562c3a858232488'
             'SKIP'
             'e1347064ec30094e21679764f784fa7557738946485359041473e6e9d7f3c3dc'
-            '6f3a3260d8fd6c1fbeafd0611f604c46799005dc776af076bff1fd4d8a3b6304')
+            'fc6551c6c556b7a3568b94316047aad416c8da8bbcad3aacc8dcf3fd2f071bfa')
 validpgpkeys=('28D3BED851FDF3AB57FEF93C233587A47C207910'
 	      '17E90D521672C04631B1183EE78DAE0F3115E06B'
 	      'E6C9029C363AD41D787A8EBB91C1262F01EB8D39'
@@ -69,8 +69,8 @@ build() {
 
   # Required for nanosleep with clang
   export LDFLAGS="${LDFLAGS} -lpthread"
-  # -Og, -O1 and -O2 all break the build.
-  CFLAGS+=" -O0"
+  # -D_FORTIFY_SOURCE breaks build
+  CFLAGS=${CFLAGS//"-Wp,-D_FORTIFY_SOURCE=2"}
 
   ../${_realname}-${pkgver}/configure \
     --prefix="${MINGW_PREFIX}" \

--- a/mingw-w64-emacs/PKGBUILD
+++ b/mingw-w64-emacs/PKGBUILD
@@ -6,7 +6,7 @@ _realname=emacs
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=28.2
-pkgrel=4
+pkgrel=5
 pkgdesc="The extensible, customizable, self-documenting, real-time display editor (mingw-w64)"
 url="https://www.gnu.org/software/${_realname}/"
 license=('spdx:GPL-3.0')
@@ -69,6 +69,8 @@ build() {
 
   # Required for nanosleep with clang
   export LDFLAGS="${LDFLAGS} -lpthread"
+  # -Og, -O1 and -O2 all break the build.
+  CFLAGS+=" -O0"
 
   ../${_realname}-${pkgver}/configure \
     --prefix="${MINGW_PREFIX}" \
@@ -76,9 +78,8 @@ build() {
     --build="${MINGW_CHOST}" \
     --with-modules \
     --without-dbus \
-    --without-compress-install
-    # disable jit due to gcc 13 taking more time to compile
-    # $_extra_cfg
+    --without-compress-install \
+    $_extra_cfg
 
   # --without-compress-install is needed because we don't have gzip in
   # the mingw binaries and it is also required by native compilation.


### PR DESCRIPTION
Using the `-O0` optimization level seems to address the issues that plague the previous two emacs releases. I tried `-Og` and `-O1`, but with those I was still getting problems.

Performance is not great, but still usable. As a quick test, I ran `vhdl-beautify-buffer` on a large VHDL file (one of the heavier emacs commands I know). A file which previously took 3.97 seconds to beautify now takes 23.91 seconds.

This might address issues #16413 #16375 and #16190, did not fully look into each of them though.

