### PR TITLE
lua53: Fix incorrect module search path

### DIFF
--- a/mingw-w64-lua53/PKGBUILD
+++ b/mingw-w64-lua53/PKGBUILD
@@ -7,7 +7,7 @@ _realname=lua53
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.3.6
-pkgrel=1
+pkgrel=2
 pkgdesc="A powerful light-weight programming language designed for extending applications. Version 5.3.x (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
@@ -23,7 +23,7 @@ source=("${url}/ftp/lua-${pkgver}.tar.gz"
         'LICENSE')
 sha256sums=('fc5fd69bb8736323f026672b1b7235da613d7177e72558893a0bdcd320466d60'
             'ca9252633e782b8f85d6a94ea4f6babd4fe30bd759085b373160b1878e36ff78'
-            '3a915911ae680ac3670d6bf96973799baaa7d9c58e6003878eb4369983acc0db'
+            '40e1d39f289d65e1b689b741689ab6a83bcfb4264f8b2d0d550f96ab3072bb24'
             '744cb6bf6fb96ef65ee103d917eac679c983b6c02b7e643ba5b985d41b86aa87'
             '142fb08b41a807b192b4b2c166696a1830a1c97967e5099ad0e579bf500e1da4')
 

--- a/mingw-w64-lua53/searchpath.patch
+++ b/mingw-w64-lua53/searchpath.patch
@@ -1,14 +1,22 @@
 --- lua-5.3.3/src/luaconf.h.orig	2016-05-01 16:06:09.000000000 -0400
 +++ lua-5.3.3/src/luaconf.h	2016-10-06 08:03:00.436714600 -0400
-@@ -173,8 +173,9 @@
+@@ -185,17 +185,14 @@
  ** In Windows, any exclamation mark ('!') in the path is replaced by the
  ** path of the directory of the executable file of the current process.
  */
 -#define LUA_LDIR	"!\\lua\\"
 -#define LUA_CDIR	"!\\"
-+#define LUA_VDIR	LUA_VERSION_MAJOR "." LUA_VERSION_MINOR "\\"
-+#define LUA_LDIR	"!\\..\\share\\lua\\" LUA_VDIR
-+#define LUA_CDIR	"!\\..\\lib\\lua\\" LUA_VDIR
- #define LUA_SHRDIR	"!\\..\\share\\lua\\" LUA_VDIR "\\"
+-#define LUA_SHRDIR	"!\\..\\share\\lua\\" LUA_VDIR "\\"
++#define LUA_LDIR	"!\\..\\share\\lua\\" LUA_VDIR "\\"
++#define LUA_CDIR	"!\\..\\lib\\lua\\" LUA_VDIR "\\"
  #define LUA_PATH_DEFAULT  \
  		LUA_LDIR"?.lua;"  LUA_LDIR"?\\init.lua;" \
+ 		LUA_CDIR"?.lua;"  LUA_CDIR"?\\init.lua;" \
+-		LUA_SHRDIR"?.lua;" LUA_SHRDIR"?\\init.lua;" \
+ 		".\\?.lua;" ".\\?\\init.lua"
+ #define LUA_CPATH_DEFAULT \
+ 		LUA_CDIR"?.dll;" \
+-		LUA_CDIR"..\\lib\\lua\\" LUA_VDIR "\\?.dll;" \
+ 		LUA_CDIR"loadall.dll;" ".\\?.dll"
+ 
+ #else			/* }{ */


### PR DESCRIPTION
Fixes https://github.com/msys2/MINGW-packages/issues/16638

    This removes paths which are duplicate and with double slashes.
    Also the module search path is now same as in Linux environment.
    The paths can be retrieved using these two lua code

    print("package.path: "..package.path)
    print("package.cpath: "..package.cpath)

    The removed paths as like this

    * package path:
        C:\msys64\ucrt64\bin\..\share\lua\5.3\\?.lua;
        C:\msys64\ucrt64\bin\..\share\lua\5.3\\?\init.lua;

    * package cpath:
        C:\msys64\ucrt64\bin\..\lib\lua\5.3\..\lib\lua\5.3\\?.dll

