### PR TITLE
[New Package]: libiff

### DIFF
--- a/mingw-w64-libiff/PKGBUILD
+++ b/mingw-w64-libiff/PKGBUILD
@@ -1,0 +1,47 @@
+# Maintainer: Alx Sa <cmyk.student@gmail.com>
+
+_realname=libiff
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.1
+_realver=0.1
+pkgrel=1
+pkgdesc="Portable, extensible parser for the Interchange File Format (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+url="https://github.com/svanderburg/libiff"
+license=('MIT')
+depends=()
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             'help2man'
+             'git')
+_appcommit='0290be4ed3df0c1b8e8f5c24012cc75ba8870570'
+source=("${_realname}"::"git+https://github.com/svanderburg/libiff.git#commit=$_appcommit")
+sha256sums=('SKIP')
+
+prepare() {
+  cd "${srcdir}"/${_realname}
+
+}
+
+build() {
+  cd "${srcdir}"/${_realname}
+
+  ./bootstrap
+
+  ./configure \
+    --prefix="${MINGW_PREFIX}" \
+    --build="${MINGW_CHOST}" \
+    --host="${MINGW_CHOST}" \
+    --target="${MINGW_CHOST}" \
+    --enable-static \
+    --enable-shared
+
+  make -j 1
+}
+
+package() {
+  cd "${srcdir}"/${_realname}
+  make DESTDIR="${pkgdir}" install
+  install -Dm644 "${srcdir}/${_realname}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}


### PR DESCRIPTION
GIMP has a [new plug-in](https://gitlab.gnome.org/GNOME/gimp/-/merge_requests/897) for importing Amiga IFF images. It depends on libilbm, which depends on libiff.

This patch proposes adding the libiff package to the MSYS2 repository as a first step to supporting the GIMP IFF plug-in on Windows.

I tested and was able to build the package with this locally. I used the recipes for [aalib](https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-aalib/PKGBUILD) and [fritzing](https://github.com/msys2/MINGW-packages/tree/0f9947e812605ad4c66c4725c62e76792cae0a7c/mingw-w64-fritzing) as references to implement this. Feedback appreciated!