### PR TITLE
mkvtoolnix: update to 78.0

### DIFF
--- a/mingw-w64-mkvtoolnix/PKGBUILD
+++ b/mingw-w64-mkvtoolnix/PKGBUILD
@@ -4,14 +4,15 @@ _realname=mkvtoolnix
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-cli"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-gui")
-pkgver=73.0.0
+pkgver=78.0
 pkgrel=1
 pkgdesc="Set of tools to create, edit and inspect Matroska files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
 url='https://mkvtoolnix.download/'
 license=('GPLv2')
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+depends=("${MINGW_PACKAGE_PREFIX}-boost"
+         "${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-gmp"
          "${MINGW_PACKAGE_PREFIX}-libebml"
          "${MINGW_PACKAGE_PREFIX}-libmatroska"
@@ -20,7 +21,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 makedepends=("po4a"
              "zsh"
              "${MINGW_PACKAGE_PREFIX}-autotools"
-             "${MINGW_PACKAGE_PREFIX}-boost"
              "${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmark"
              "${MINGW_PACKAGE_PREFIX}-docbook-xsl"
@@ -32,7 +32,7 @@ makedepends=("po4a"
              "${MINGW_PACKAGE_PREFIX}-ruby"
              "${MINGW_PACKAGE_PREFIX}-zlib")
 source=(https://mkvtoolnix.download/sources/mkvtoolnix-${pkgver}.tar.xz{,.sig})
-sha256sums=('f31a129723571b46a974bc5d57d73733c1245ee429afd6ddaf274038e94e2280'
+sha256sums=('6a50fce8c66c55410e0df2a6952f0bab7a3c92914db7feb285b9f1bb03fcd0d3'
             'SKIP')
 validpgpkeys=('D9199745B0545F2E8197062B0F92290A445B9007') # Moritz Bunkus <moritz@bunkus.org>
 noextract=(mkvtoolnix-${pkgver}.tar.xz)
@@ -54,6 +54,8 @@ build() {
     --build="${MINGW_CHOST}" \
     --host="${MINGW_CHOST}" \
     --target="${MINGW_CHOST}" \
+    --with-boost-system=boost_system-mt \
+    --with-boost-filesystem=boost_filesystem-mt \
     --enable-qt6=yes \
     --enable-qt5=no \
     --disable-update-check


### PR DESCRIPTION
`boost` is now required as of 74.0.0: https://www.bunkus.org/blog/2023/02/mkvtoolnix-v74-released/
