### PR TITLE
[New Package]: libilbm

### DIFF
--- a/mingw-w64-libilbm/PKGBUILD
+++ b/mingw-w64-libilbm/PKGBUILD
@@ -3,14 +3,13 @@
 _realname=libilbm
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.1
-_realver=0.1
+pkgver=0.1.r68.g170c269
 pkgrel=1
 pkgdesc="Parser library for the ILBM: IFF Interleaved BitMap format (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://github.com/svanderburg/libilbm"
-license=('MIT')
+license=('spdx:MIT')
 depends=()
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools"
@@ -23,7 +22,7 @@ sha256sums=('SKIP')
 
 pkgver() {
   cd "${srcdir}/${_realname}"
-  echo "$(cat version)"
+  printf "0.1.r%s.g%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
 }
 
 prepare() {

--- a/mingw-w64-libilbm/PKGBUILD
+++ b/mingw-w64-libilbm/PKGBUILD
@@ -1,0 +1,53 @@
+# Maintainer: Alx Sa <cmyk.student@gmail.com>
+
+_realname=libilbm
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.1
+_realver=0.1
+pkgrel=1
+pkgdesc="Parser library for the ILBM: IFF Interleaved BitMap format (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+url="https://github.com/svanderburg/libilbm"
+license=('MIT')
+depends=()
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-libiff"
+             'help2man'
+             'git')
+_appcommit='170c269bce23423f1163545ed9344482b2cf4487'
+source=("${_realname}"::"git+https://github.com/svanderburg/libilbm.git#commit=$_appcommit")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "${srcdir}/${_realname}"
+  echo "$(cat version)"
+}
+
+prepare() {
+  cd "${srcdir}"/${_realname}
+
+  ./bootstrap
+}
+
+build() {
+  cd "${srcdir}"/${_realname}
+
+  ./configure \
+    --prefix="${MINGW_PREFIX}" \
+    --build="${MINGW_CHOST}" \
+    --host="${MINGW_CHOST}" \
+    --target="${MINGW_CHOST}" \
+    --enable-static \
+    --enable-shared
+
+  make -j 1
+}
+
+package() {
+  cd "${srcdir}"/${_realname}
+  make DESTDIR="${pkgdir}" install
+  install -Dm644 "${srcdir}/${_realname}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}


### PR DESCRIPTION
This follows up #17329 to finish adding support for GIMP's new [AMIGA IFF image plug-in](https://gitlab.gnome.org/GNOME/gimp/-/merge_requests/897). 

This patch proposes adding the libilbm package to the MSYS2 repository, which is required to build the GIMP IFF plug-in on Windows now that libiff has been accepted.
As the libiff and libilbm repositories are structured the same, the PKGBUILD file is nearly identical to what @Biswa96 assisted me with for libiff (thanks again!)

I tested and was able to build the package with this locally - hopefully there are no new issues!