### PR TITLE
emacs: Remove _FORTIFY_SOURCE from build options

### DIFF
--- a/mingw-w64-emacs/PKGBUILD
+++ b/mingw-w64-emacs/PKGBUILD
@@ -6,7 +6,7 @@ _realname=emacs
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=28.2
-pkgrel=4
+pkgrel=5
 pkgdesc="The extensible, customizable, self-documenting, real-time display editor (mingw-w64)"
 url="https://www.gnu.org/software/${_realname}/"
 license=('spdx:GPL-3.0')
@@ -69,6 +69,8 @@ build() {
 
   # Required for nanosleep with clang
   export LDFLAGS="${LDFLAGS} -lpthread"
+  # -D_FORTIFY_SOURCE breaks build
+  CFLAGS=${CFLAGS//"-Wp,-D_FORTIFY_SOURCE=2"}
 
   ../${_realname}-${pkgver}/configure \
     --prefix="${MINGW_PREFIX}" \


### PR DESCRIPTION
Redo of #17319. `_FORTIFY_SOURCE` breaks the emacs builds. 

Resolves #16413 #16375 and #16190.