### PR TITLE
gpgme: update to 1.20.0

### DIFF
--- a/mingw-w64-gpgme/0004-gpgme-find-gnupg.patch
+++ b/mingw-w64-gpgme/0004-gpgme-find-gnupg.patch
@@ -19,7 +19,7 @@ diff -urN a/configure.ac b/configure.ac
 diff -urN a/src/w32-util.c b/src/w32-util.c
 --- a/src/w32-util.c	2015-08-04 22:35:23.525700800 +0100
 +++ b/src/w32-util.c	2015-08-04 22:35:24.087301800 +0100
-@@ -555,6 +555,7 @@
+@@ -587,6 +587,7 @@
        gpg = find_program_in_dir (inst_dir, name);
      }
  
@@ -27,7 +27,7 @@ diff -urN a/src/w32-util.c b/src/w32-util.c
    /* 2. Try to find gpg.exe using that ancient registry key.  */
    if (!gpg)
      {
-@@ -576,6 +577,7 @@
+@@ -608,6 +609,7 @@
        name = default_gpg_name? default_gpg_name : "GNU\\GnuPG\\gpg.exe";
        gpg = find_program_at_standard_place (name);
      }
@@ -35,7 +35,7 @@ diff -urN a/src/w32-util.c b/src/w32-util.c
  
    /* 4. Print a debug message if not found.  */
    if (!gpg)
-@@ -603,6 +605,7 @@
+@@ -703,6 +705,7 @@
        gpgconf = find_program_in_dir (inst_dir, name);
      }
  
@@ -43,11 +43,11 @@ diff -urN a/src/w32-util.c b/src/w32-util.c
    /* 2. Try to find gpgconf.exe from GnuPG >= 2.1 below CSIDL_PROGRAM_FILES. */
    if (!gpgconf)
      {
-@@ -638,6 +641,7 @@
-           free (dir);
-         }
+@@ -740,6 +743,7 @@
+     {
+       gpgconf = find_program_at_standard_place ("GNU\\GnuPG\\gpgconf.exe");
      }
 +#endif
  
-   /* 4. Try to find gpgconf.exe from Gpg4win below CSIDL_PROGRAM_FILES.  */
-   if (!gpgconf)
+   /* 5. Try to find gpgconf.exe relative to us as Gpg4win installs it.  */
+   if (!gpgconf && inst_dir)

--- a/mingw-w64-gpgme/0005-invoke-scripts-via-sh.patch
+++ b/mingw-w64-gpgme/0005-invoke-scripts-via-sh.patch
@@ -1,24 +1,6 @@
 --- gpgme-1.13.0.orig/lang/python/setup.py.in	2019-04-07 20:10:01.767088400 -0400
 +++ gpgme-1.13.0/lang/python/setup.py.in	2019-04-07 20:18:35.986816000 -0400
-@@ -61,7 +61,7 @@
-     devnull = open(os.devnull, 'w')
- 
- try:
--    subprocess.check_call(gpgme_config + ['--version'], stdout=devnull)
-+    subprocess.check_call(['sh'] + ['-c'] + [' '.join(gpgme_config + ['--version'])], stdout=devnull)
- except:
-     sys.exit('Could not find gpgme-config.  ' +
-              'Please install the libgpgme development package.')
-@@ -69,7 +69,7 @@
- 
- def getconfig(what, config=gpgme_config):
-     confdata = subprocess.Popen(
--        config + ['--%s' % what], stdout=subprocess.PIPE).communicate()[0]
-+        ['sh'] + ['-c'] + [' '.join(config + ['--%s' % what])], stdout=subprocess.PIPE).communicate()[0]
-     return [x for x in confdata.decode('utf-8').split() if x != '']
- 
- 
-@@ -104,7 +104,7 @@
+@@ -91,7 +91,7 @@
  
  # Adjust include and library locations in case of win32
  uname_s = os.popen('uname -s').read()
@@ -27,15 +9,6 @@
      mnts = [
          x.split()[0:3:2] for x in os.popen('mount').read().split('\n') if x
      ]
-@@ -184,7 +184,7 @@
- 
-         try:
-             subprocess.check_call(
--                gpg_error_config + ['--version'], stdout=devnull)
-+                ['sh'] + ['-c'] + [' '.join(gpg_error_config + ['--version'])], stdout=devnull)
-         except:
-             sys.exit('Could not find gpg-error-config.  ' +
-                      'Please install the libgpg-error development package.')
 --- gpgme-1.10.0/lang/python/helpers.h.orig	2017-12-14 11:28:11.673618100 +0300
 +++ gpgme-1.10.0/lang/python/helpers.h	2017-12-14 11:28:19.112231900 +0300
 @@ -25,7 +25,7 @@

--- a/mingw-w64-gpgme/0008-no-py2.patch
+++ b/mingw-w64-gpgme/0008-no-py2.patch
@@ -1,11 +1,11 @@
 --- gpgme-1.14.0/configure.ac.orig	2020-09-05 15:02:43.720753300 +0200
 +++ gpgme-1.14.0/configure.ac	2020-09-05 15:03:38.558261200 +0200
-@@ -443,7 +443,7 @@
+@@ -521,7 +521,7 @@
  	if test "$found_py" = "1" -o "$found_py3" = "1"; then
  	  # Reset everything, so that we can look for another Python.
            m4_foreach([mym4pythonver],
--                     [[2.7],[3.4],[3.5],[3.6],[3.7],[3.8],[3.9],[all]],
-+                     [[3.4],[3.5],[3.6],[3.7],[3.8],[3.9],[all]],
+-                     [[2.7],[3.4],[3.5],[3.6],[3.7],[3.8],[3.9],[3.10],
++                     [[3.4],[3.5],[3.6],[3.7],[3.8],[3.9],[3.10],
+                       [3.11],[3.12],[all]],
             [unset PYTHON
  	    unset PYTHON_VERSION
- 	    unset PYTHON_CPPFLAGS

--- a/mingw-w64-gpgme/0009-fix-broken-version.patch
+++ b/mingw-w64-gpgme/0009-fix-broken-version.patch
@@ -1,6 +1,6 @@
 --- a/autogen.sh
 +++ b/autogen.sh
-@@ -265,8 +265,8 @@
+@@ -268,8 +268,8 @@
        rvd=$((0x$(echo ${rev} | dd bs=1 count=4 2>/dev/null)))
      else
        ingit=no

--- a/mingw-w64-gpgme/0010-m4-check-python-exit-code.patch
+++ b/mingw-w64-gpgme/0010-m4-check-python-exit-code.patch
@@ -1,0 +1,11 @@
+--- a/m4/ax_python_devel.m4
++++ b/m4/ax_python_devel.m4
+@@ -137,7 +137,7 @@
+ 	#
+ 	AC_MSG_CHECKING([for the distutils Python package])
+ 	ac_distutils_result=`$PYTHON -c "import distutils" 2>&1`
+-	if test -z "$ac_distutils_result"; then
++	if test $? -eq 0; then
+ 		AC_MSG_RESULT([yes])
+ 	else
+ 		AC_MSG_RESULT([no])

--- a/mingw-w64-gpgme/0011-makefile-am-disable-tests.patch
+++ b/mingw-w64-gpgme/0011-makefile-am-disable-tests.patch
@@ -1,0 +1,11 @@
+--- a/lang/python/Makefile.am
++++ b/lang/python/Makefile.am
+@@ -23,7 +23,7 @@
+ 	gpgme.i \
+ 	helpers.c helpers.h private.h
+ 
+-SUBDIRS = . tests examples doc src
++SUBDIRS = . examples doc src
+ 
+ .PHONY: prepare
+ prepare: copystamp

--- a/mingw-w64-gpgme/PKGBUILD
+++ b/mingw-w64-gpgme/PKGBUILD
@@ -91,8 +91,10 @@ build() {
   cp -r "${srcdir}"/${_realname}-${pkgver} "${srcdir}"/build-${MSYSTEM}
   cd "${srcdir}"/build-${MSYSTEM}
 
+  # for clang
+  export CFLAGS="${CFLAGS} -Wno-int-conversion -Wno-incompatible-function-pointer-types"
+
   # mingw doxygen can't wrok with UNIX paths in doxyfile
-  CFLAGS+=" -Wno-int-conversion -Wno-incompatible-function-pointer-types" \
   DOXYGEN=/usr/bin/doxygen \
   PYTHON=${MINGW_PREFIX}/bin/python3 \
   ./configure \

--- a/mingw-w64-gpgme/PKGBUILD
+++ b/mingw-w64-gpgme/PKGBUILD
@@ -6,7 +6,7 @@ _realname=gpgme
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-qgpgme-qt5")
-pkgver=1.18.0
+pkgver=1.20.0
 pkgrel=1
 pkgdesc="A C wrapper library for GnuPG (mingw-w64)"
 arch=('any')
@@ -20,7 +20,9 @@ depends=("${MINGW_PACKAGE_PREFIX}-glib2"
          "${MINGW_PACKAGE_PREFIX}-npth")
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-python"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-qt5-base"
+             "${MINGW_PACKAGE_PREFIX}-swig"
              "${MINGW_PACKAGE_PREFIX}-cc"
              "doxygen")
 source=("https://www.gnupg.org/ftp/gcrypt/${_realname}/${_realname}-${pkgver}.tar.bz2"{,.sig}
@@ -30,6 +32,8 @@ source=("https://www.gnupg.org/ftp/gcrypt/${_realname}/${_realname}-${pkgver}.ta
         0007-mkdefsinc-use-CPPFLAGS.patch
         0008-no-py2.patch
         0009-fix-broken-version.patch
+        0010-m4-check-python-exit-code.patch
+        0011-makefile-am-disable-tests.patch
         relocatable-cmake.patch
         gpgmepp-portable-types.patch
         gpgme-fix-cpp-tests.patch)
@@ -38,16 +42,18 @@ validpgpkeys=('5B80C5754298F0CB55D8ED6ABCEF7E294B092E28'
               '6DAA6E64A76D2840571B4902528897B826403ADA'
               'AC8E115BF73E2D8D47FA9908E98E9B2D19C6C8BD'
               '02F38DFF731FF97CB039A1DA549E695E905BA208')
-sha256sums=('361d4eae47ce925dba0ea569af40e7b52c645c4ae2e65e5621bf1b6cdd8b0e9e'
+sha256sums=('25a5785a5da356689001440926b94e967d02e13c49eb7743e35ef0cf22e42750'
             'SKIP'
-            '0a3d02312dbad81bb834615359106afe55ee32e2d1762ab597cf160d5fe07147'
-            '2389cc237bf860b961bf3519377e83f7678e657dcf28c33510cd155f80516d42'
+            'c8e4b6a64f71ceb8a84f177829ce7e96f983881ffe8e7e952de3b255a8e20143'
+            '42f9caf749b6b8cd304431550ccf125d3a5daf9e36ba8319405a3d517b4fbc03'
             'b56fe3e3da872ca84d08b4aa426e6f71b3227e2a253bc45bf6023abf1288ecc9'
             'f022993b4ae8f69f8248a6e22a0b6f0d0f43a074cdbcdbe2efb479e48064f988'
-            'e807c2bf042ed9a603bb7fda8e7d2b73c4443c4ba9b33e21b3979d10ffdad48e'
-            '020ff5ed7906a16cdc092ef5c2a2a2c373fb1bce342c1690b9f04b020d1a5b20'
+            '1fa234be3412c7664110900de2074b36c88d39c79bbc6ec7870fd6b76f7cb5e4'
+            'ace3d5166372e0422a625f76a2890d70f2916d9239ade74e58bd23077e9c1c6b'
+            '5e8e7e773a09ed1e1724c9d7216eaaecce52af49152513366026a2fa3245d762'
+            '5feaf82d651d875f1af79287d22aa24027a07d866f33295ddd2fbf0ce856f187'
             '32465eb5f99015d06a0b89c30c69a7c4208ab32c287275b729cf9bec08c4474c'
-            'e161d4012b137f5252b7d64b5fe108144bb1725bde5a389a968cfcae28fc2321'
+            'a5aa665a36eb3c073a58e1468e50831059481007de78e25b01b0afbef8750df3'
             'd09070c005b72e8aed14a848553f7c7289353ff7f32e62c9013a729ba46d7117')
 
 _apply_patch_with_msg() {
@@ -68,6 +74,8 @@ prepare() {
     0007-mkdefsinc-use-CPPFLAGS.patch \
     0008-no-py2.patch \
     0009-fix-broken-version.patch \
+    0010-m4-check-python-exit-code.patch \
+    0011-makefile-am-disable-tests.patch \
     relocatable-cmake.patch \
     gpgmepp-portable-types.patch \
     gpgme-fix-cpp-tests.patch

--- a/mingw-w64-gpgme/PKGBUILD
+++ b/mingw-w64-gpgme/PKGBUILD
@@ -5,7 +5,8 @@
 _realname=gpgme
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
-         "${MINGW_PACKAGE_PREFIX}-qgpgme-qt5")
+         "${MINGW_PACKAGE_PREFIX}-qgpgme-qt5"
+         "${MINGW_PACKAGE_PREFIX}-python-gpgme")
 pkgver=1.20.0
 pkgrel=1
 pkgdesc="A C wrapper library for GnuPG (mingw-w64)"
@@ -20,7 +21,10 @@ depends=("${MINGW_PACKAGE_PREFIX}-glib2"
          "${MINGW_PACKAGE_PREFIX}-npth")
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-python"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python-wheel"
              "${MINGW_PACKAGE_PREFIX}-qt5-base"
              "${MINGW_PACKAGE_PREFIX}-swig"
              "${MINGW_PACKAGE_PREFIX}-cc"
@@ -84,13 +88,14 @@ prepare() {
 }
 
 build() {
-  mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
+  cp -r "${srcdir}"/${_realname}-${pkgver} "${srcdir}"/build-${MSYSTEM}
+  cd "${srcdir}"/build-${MSYSTEM}
 
   # mingw doxygen can't wrok with UNIX paths in doxyfile
   CFLAGS+=" -Wno-int-conversion -Wno-incompatible-function-pointer-types" \
   DOXYGEN=/usr/bin/doxygen \
   PYTHON=${MINGW_PREFIX}/bin/python3 \
-  ../${_realname}-${pkgver}/configure \
+  ./configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
@@ -105,6 +110,14 @@ build() {
     --enable-w32-glib
 
   make
+
+  (
+    # use a PEP517 workflow to get a reproducible Python package
+    # NOTE: top_builddir is required so that the build takes place against local gpgme, not system gpgme
+    cd lang/python/
+    top_builddir="${srcdir}"/build-${MSYSTEM} \
+    ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
+  )
 }
 
 check() {
@@ -125,6 +138,7 @@ package_gpgme() {
   # split qgpgme
   rm -r "${pkgdir}${MINGW_PREFIX}"/bin/libqgpgme*
   rm -r "${pkgdir}${MINGW_PREFIX}"/lib/{cmake/QGpgme/,libqgpgme.*}
+  rm -r "${pkgdir}${MINGW_PREFIX}"/lib/python*
 }
 
 package_qgpgme-qt5() {
@@ -135,6 +149,18 @@ package_qgpgme-qt5() {
   cd "${srcdir}"/build-${MSYSTEM}/lang/qt
   make DESTDIR="${pkgdir}" install
   rm -r "${pkgdir}${MINGW_PREFIX}"/include
+}
+
+package_python-gpgme() {
+  pkgdesc="Python bindings for GPGme (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-gpgme"
+           "${MINGW_PACKAGE_PREFIX}-python")
+
+  cd "${srcdir}"/build-${MSYSTEM}/lang/python
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
 }
 
 # template start; name=mingw-w64-splitpkg-wrappers; version=1.0;

--- a/mingw-w64-gpgme/gpgmepp-portable-types.patch
+++ b/mingw-w64-gpgme/gpgmepp-portable-types.patch
@@ -2,7 +2,7 @@ diff --git a/configure.ac b/configure.ac
 index 1813cc57..1d9ceb4b 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -924,7 +924,8 @@ AC_CONFIG_FILES(Makefile src/Makefile
+@@ -1041,7 +1041,8 @@ AC_CONFIG_FILES(Makefile src/Makefile
                  src/versioninfo.rc
                  src/gpgme.pc
                  src/gpgme-glib.pc
@@ -53,8 +53,8 @@ diff --git a/lang/cpp/src/data.cpp b/lang/cpp/src/data.cpp
 index 2782aa79..1da0df52 100644
 --- a/lang/cpp/src/data.cpp
 +++ b/lang/cpp/src/data.cpp
-@@ -217,17 +217,17 @@ GpgME::Error GpgME::Data::setFileName(const char *name)
-     return Error(gpgme_data_set_file_name(d->data, name));
+@@ -222,17 +222,17 @@ GpgME::Error GpgME::Data::setFileName(const std::string &name)
+     return Error(gpgme_data_set_file_name(d->data, name.c_str()));
  }
  
 -ssize_t GpgME::Data::read(void *buffer, size_t length)
@@ -96,9 +96,9 @@ index df8607e7..1c909ef8 100644
  namespace GpgME
  {
  
-@@ -106,9 +108,9 @@ public:
-     char *fileName() const;
+@@ -108,9 +110,9 @@
      Error setFileName(const char *name);
+     Error setFileName(const std::string &name);
  
 -    ssize_t read(void *buffer, size_t length);
 -    ssize_t write(const void *buffer, size_t length);
@@ -113,25 +113,43 @@ diff --git a/lang/qt/src/Makefile.am b/lang/qt/src/Makefile.am
 index 32251424..60f18b10 100644
 --- a/lang/qt/src/Makefile.am
 +++ b/lang/qt/src/Makefile.am
-@@ -260,7 +260,7 @@ nodist_qgpgmeinclude_HEADERS = qgpgme_version.h
+@@ -307,7 +307,7 @@ camelcaseinclude_HEADERS = $(camelcase_headers)
+ nodist_qgpgmeinclude_HEADERS = qgpgme_version.h
  
- libqgpgme_la_SOURCES = $(qgpgme_sources) $(qgpgme_headers) $(private_qgpgme_headers)
- 
+ if WANT_QT5
 -AM_CPPFLAGS = -I$(top_srcdir)/lang/cpp/src -I$(top_builddir)/src \
 +AM_CPPFLAGS = -I$(top_srcdir)/lang/cpp/src -I$(top_builddir)/lang/cpp/src -I$(top_builddir)/src \
-               @GPGME_QT_CFLAGS@ @GPG_ERROR_CFLAGS@ @LIBASSUAN_CFLAGS@ \
+               @GPGME_QT5_CFLAGS@ @GPG_ERROR_CFLAGS@ @LIBASSUAN_CFLAGS@ \
+               -DBUILDING_QGPGME -Wsuggest-override \
+               -Wzero-as-null-pointer-constant
+@@ -320,7 +320,7 @@ libqgpgme_la_LDFLAGS = -no-undefined -version-info \
+                        @LIBQGPGME_LT_CURRENT@:@LIBQGPGME_LT_REVISION@:@LIBQGPGME_LT_AGE@
+ endif
+ if WANT_QT6
+-AM_CPPFLAGS = -I$(top_srcdir)/lang/cpp/src -I$(top_builddir)/src \
++AM_CPPFLAGS = -I$(top_srcdir)/lang/cpp/src -I$(top_builddir)/lang/cpp/src -I$(top_builddir)/src \
+               @GPGME_QT6_CFLAGS@ @GPG_ERROR_CFLAGS@ @LIBASSUAN_CFLAGS@ \
                -DBUILDING_QGPGME -Wsuggest-override \
                -Wzero-as-null-pointer-constant
 diff --git a/lang/qt/tests/Makefile.am b/lang/qt/tests/Makefile.am
 index bfe77ad5..7856a4f6 100644
 --- a/lang/qt/tests/Makefile.am
 +++ b/lang/qt/tests/Makefile.am
-@@ -48,7 +48,7 @@ LDADD = ../../cpp/src/libgpgmepp.la ../src/libqgpgme.la \
-         ../../../src/libgpgme.la @GPGME_QT_LIBS@ @GPG_ERROR_LIBS@ \
-         @GPGME_QTTEST_LIBS@ @LDADD_FOR_TESTS_KLUDGE@ -lstdc++
+@@ -51,7 +51,7 @@ LDADD = ../../cpp/src/libgpgmepp.la ../src/libqgpgme.la \
+         ../../../src/libgpgme.la @GPGME_QT5_LIBS@ @GPG_ERROR_LIBS@ \
+         @GPGME_QT5TEST_LIBS@ @LDADD_FOR_TESTS_KLUDGE@ -lstdc++
  
 -AM_CPPFLAGS = -I$(top_srcdir)/lang/cpp/src -I$(top_builddir)/src \
 +AM_CPPFLAGS = -I$(top_srcdir)/lang/cpp/src -I$(top_builddir)/lang/cpp/src -I$(top_builddir)/src \
-               @GPG_ERROR_CFLAGS@ @GPGME_QT_CFLAGS@ @GPG_ERROR_CFLAGS@ \
-               @LIBASSUAN_CFLAGS@ @GPGME_QTTEST_CFLAGS@ -DBUILDING_QGPGME \
+               @GPG_ERROR_CFLAGS@ @GPGME_QT5_CFLAGS@ @GPG_ERROR_CFLAGS@ \
+               @LIBASSUAN_CFLAGS@ @GPGME_QT5TEST_CFLAGS@ -DBUILDING_QGPGME \
+               -I$(top_srcdir)/lang/qt/src \
+@@ -62,7 +62,7 @@ LDADD = ../../cpp/src/libgpgmepp.la ../src/libqgpgmeqt6.la \
+         ../../../src/libgpgme.la @GPGME_QT6_LIBS@ @GPG_ERROR_LIBS@ \
+         @GPGME_QT6TEST_LIBS@ @LDADD_FOR_TESTS_KLUDGE@ -lstdc++
+ 
+-AM_CPPFLAGS = -I$(top_srcdir)/lang/cpp/src -I$(top_builddir)/src \
++AM_CPPFLAGS = -I$(top_srcdir)/lang/cpp/src -I$(top_builddir)/lang/cpp/src -I$(top_builddir)/src \
+               @GPG_ERROR_CFLAGS@ @GPGME_QT6_CFLAGS@ @GPG_ERROR_CFLAGS@ \
+               @LIBASSUAN_CFLAGS@ @GPGME_QT6TEST_CFLAGS@ -DBUILDING_QGPGME \
                -I$(top_srcdir)/lang/qt/src \


### PR DESCRIPTION
* Remove hunks which replace gpgme-config with shell, fixed in https://dev.gnupg.org/rMae9258fbf3b9d434495ef11fc184a91fe7c4ca57
* Check exit code for python disutils due to deprecation message.
* Disable python test due to this [Makefile:645: pubring-stamp] Error 2