### PR TITLE
glib2: backport two fixes for non-ascii command line parsing

### DIFF
--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -7,7 +7,7 @@ _realname=glib2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.76.3
-pkgrel=1
+pkgrel=2
 url="https://gitlab.gnome.org/GNOME/glib"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -30,7 +30,9 @@ source=("https://download.gnome.org/sources/glib/${pkgver%.*}/glib-${pkgver}.tar
         0004-disable-explicit-ms-bitfields.patch
         glib-compile-schemas.hook.in
         gio-querymodules.hook.in
-        pyscript2exe.py)
+        pyscript2exe.py
+        https://gitlab.gnome.org/GNOME/glib/-/commit/6c6a844a508f6df1966aa849e8a1cd07625f83f5.patch
+        https://gitlab.gnome.org/GNOME/glib/-/commit/7e41ac18da126981ff1811c051e198cb4cb13423.patch)
 noextract=("glib-${pkgver}.tar.xz")
 sha256sums=('c0be444e403d7c3184d1f394f89f0b644710b5e9331b54fa4e8b5037813ad32a'
             '51d02360a1ee978fd45e77b84bca9cfbcf080d91986b5c0efe0732779c6a54ec'
@@ -38,7 +40,9 @@ sha256sums=('c0be444e403d7c3184d1f394f89f0b644710b5e9331b54fa4e8b5037813ad32a'
             '3d2585f460f797c67f9e5149d3b3d52ff2481c48fd7cb791a03f5f0e68304d39'
             '0c3d54636407e0e13429b73959cace626253cd772e1d4870de0fb92b0b99545a'
             'f18d27d98709dba8c5f9756672baaf0158fb4353c9edbdc2e80021f88ff34ced'
-            'e57174517b08cf8f9fb4f43a381d342d23d2db3cad661107f35ca21c39b5734d')
+            'e57174517b08cf8f9fb4f43a381d342d23d2db3cad661107f35ca21c39b5734d'
+            '3002e59bfc4c6d67627da4360ed85ce9277fc23be8a9f407fd07d09746695248'
+            'a1c1fd44929427d0c447042f08df921190d1b81db38a5e22a1709e6209e95a33')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -56,6 +60,12 @@ prepare() {
   apply_patch_with_msg 0001-Update-g_fopen-g_open-and-g_creat-to-open-with-FILE_.patch
   apply_patch_with_msg 0002-disable_glib_compile_schemas_warning.patch
   apply_patch_with_msg 0004-disable-explicit-ms-bitfields.patch
+
+  # https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3447
+  # Will be part of 2.76.4
+  apply_patch_with_msg \
+    6c6a844a508f6df1966aa849e8a1cd07625f83f5.patch \
+    7e41ac18da126981ff1811c051e198cb4cb13423.patch
 }
 
 build() {


### PR DESCRIPTION
This fixes #17116