### PR TITLE
libgda: clean up makedeps

### DIFF
--- a/mingw-w64-libgda/PKGBUILD
+++ b/mingw-w64-libgda/PKGBUILD
@@ -4,11 +4,11 @@ _realname=libgda
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.2.9
-pkgrel=4
+pkgrel=5
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
 pkgdesc="Data abstraction library based on GLib (mingw-w64)"
-license=("LGPL2")
+license=("spdx:LGPL-2.0-or-later AND GPL-2.0-or-later")
 url="https://www.gnome-db.org/"
 depends=("${MINGW_PACKAGE_PREFIX}-gtk3"
          "${MINGW_PACKAGE_PREFIX}-gtksourceview3"
@@ -29,8 +29,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-postgresql"
              "${MINGW_PACKAGE_PREFIX}-libmariadbclient"
              "${MINGW_PACKAGE_PREFIX}-openldap"
-             "gnome-doc-utils"
-             "gtk-doc"
+             "${MINGW_PACKAGE_PREFIX}-gtk-doc"
              "intltool")
 source=(https://download.gnome.org/sources/${_realname}/${pkgver:0:3}/${_realname}-${pkgver}.tar.xz
         001-lemon.patch


### PR DESCRIPTION
* gnome-doc-utils doesn't seem to be used any more
* move to mingw version of gtk-doc