### PR TITLE
cogl: clean up makedepends and drop clang builds

### DIFF
--- a/mingw-w64-cogl/PKGBUILD
+++ b/mingw-w64-cogl/PKGBUILD
@@ -4,20 +4,24 @@ _realname=cogl
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.22.8
-pkgrel=2
+pkgrel=3
 pkgdesc="An object oriented GL/GLES Abstraction/Utility Layer (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64')
 url="https://blogs.gnome.org/clutter"
 license=('GPL2')
-makedepends=('intltool' 'itstool' 'gtk-doc' 'gnome-doc-utils' 'yelp-tools'
-             "${MINGW_PACKAGE_PREFIX}-autotools"
-             "${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-gobject-introspection")
 depends=("${MINGW_PACKAGE_PREFIX}-pango"
          "${MINGW_PACKAGE_PREFIX}-gdk-pixbuf2"
          "${MINGW_PACKAGE_PREFIX}-gstreamer"
          "${MINGW_PACKAGE_PREFIX}-gst-plugins-base")
+makedepends=(
+  "intltool"
+  "${MINGW_PACKAGE_PREFIX}-itstool"
+  "${MINGW_PACKAGE_PREFIX}-gtk-doc"
+  "${MINGW_PACKAGE_PREFIX}-yelp-tools"
+  "${MINGW_PACKAGE_PREFIX}-autotools"
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-gobject-introspection")
 options=(!libtool strip staticlibs)
 source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz
         "0002-windows-gl-headers.patch")
@@ -36,6 +40,8 @@ build() {
 
   mkdir doc
   cp -rf ../${_realname}-${pkgver}/doc/* doc/
+
+  CFLAGS+=" -Wno-error=maybe-uninitialized"
 
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \


### PR DESCRIPTION
It doesn't build with newer clang anymore.
Since it is unmaintained and has no users left, just drop it for clang.