### PR TITLE
luajit: disable unwind on 32-bit builds

### DIFF
--- a/mingw-w64-luajit/PKGBUILD
+++ b/mingw-w64-luajit/PKGBUILD
@@ -7,7 +7,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 # https://github.com/LuaJIT/LuaJIT/issues/665#issuecomment-784452583
 _commit="51fb2f2c3af778f03258fccee9092401ee4a0215"
 pkgver=2.1.0.beta3.r481.g51fb2f2c
-pkgrel=1
+pkgrel=2
 pkgdesc="Just-in-time compiler and drop-in replacement for Lua 5.1 (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -46,11 +46,17 @@ prepare() {
 build() {
   cd "${_realname}"
 
+  XCFLAGS=-DLUAJIT_ENABLE_GC64
+  if [[ "$MSYSTEM" == "MINGW32" || "$MSYSTEM" == "CLANG32" ]]; then
+    # https://github.com/msys2/MINGW-packages/issues/17042
+    XCFLAGS+=" -DLUAJIT_NO_UNWIND"
+  fi
+
   msg "Build static version"
-  make amalg BUILDMODE=static XCFLAGS=-DLUAJIT_ENABLE_GC64
+  make amalg BUILDMODE=static XCFLAGS="${XCFLAGS}"
 
   msg "Build dynamic version"
-  make XCFLAGS=-DLUAJIT_ENABLE_GC64
+  make XCFLAGS="${XCFLAGS}"
 }
 
 package() {


### PR DESCRIPTION
This fixes crashes on 32-bit build. MSYS explicitly disables SEH for 32-bit builds which breaks the unwinding code in luajit.

Fixes: #17042