### PR TITLE
cargo-generate: add aarch64 workaround for windows-targets 0.48.0

### DIFF
--- a/mingw-w64-cargo-generate/PKGBUILD
+++ b/mingw-w64-cargo-generate/PKGBUILD
@@ -4,10 +4,10 @@ _realname=cargo-generate
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.18.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Use pre-existing git repositories as templates (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://github.com/cargo-generate/cargo-generate"
 license=('MIT' 'Apache')
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
@@ -17,17 +17,35 @@ source=("$_realname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
 sha256sums=('72abac76c88e63080fef118e6bd70e1fd27c6c4446515de3c02fca3dccfb44dc')
 
 prepare() {
-  cd "${srcdir}"
-  rm -rf "build-${MSYSTEM}" | true
-  cp -r "${_realname}-${pkgver}" "build-${MSYSTEM}"
-  cd "${srcdir}/build-${MSYSTEM}"
+  cd "${srcdir}/${_realname}-${pkgver}"
 
-  "${MINGW_PREFIX}/bin/cargo.exe" fetch
+  cargo vendor \
+    --locked \
+    --versioned-dirs
+
+  mkdir -p .cargo
+  cat >> .cargo/config.toml <<END
+
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "vendor"
+END
+
+
+  sed -i -e 's/"cfg(all(target_arch = \\"\([^\\]\+\)\\", target_env = \\"gnu\\", target_abi = \\"llvm\\", not(windows_raw_dylib)))"/"\1-pc-windows-gnullvm"/g' \
+    "vendor/windows-targets-0.48.0/Cargo.toml"
+  sed -i -e 's/\("Cargo.toml":\)"[^"]\+"/\1"'"$(sha256sum "vendor/windows-targets-0.48.0/Cargo.toml" | cut -d' ' -f1)"'"/' \
+    "vendor/windows-targets-0.48.0/.cargo-checksum.json"
 }
 
 build() {
+  cd "${srcdir}"
+  rm -rf "build-${MSYSTEM}" | true
+  cp -r "${_realname}-${pkgver}" "build-${MSYSTEM}"
   msg "Cargo build for ${MSYSTEM}"
-  cd "${srcdir}/build-${MSYSTEM}"
+  cd "build-${MSYSTEM}"
 
   "${MINGW_PREFIX}/bin/cargo.exe" build \
     --release \


### PR DESCRIPTION
Added an extra newline to the `.cargo/config.toml` addition because I encountered a project that already had such a file that didn't end with a newline.