### PR TITLE
spice: update to 0.15.2

### DIFF
--- a/mingw-w64-spice/PKGBUILD
+++ b/mingw-w64-spice/PKGBUILD
@@ -1,18 +1,21 @@
+# Maintainer: Biswapriyo Nath <nathbappai@gmail.com>
+
 _realname=spice
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.15.1
-pkgrel=2
+pkgver=0.15.2
+pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 pkgdesc="SPICE: Simple Protocol for Independent Computing Environments (mingw-w64)"
-license=("LGPLv2.1")
+license=('spdx:LGPL-2.1-or-later')
 url="https://www.spice-space.org/"
 depends=(
              "${MINGW_PACKAGE_PREFIX}-glib2"
              "${MINGW_PACKAGE_PREFIX}-gstreamer"
              "${MINGW_PACKAGE_PREFIX}-gst-plugins-base"
              "${MINGW_PACKAGE_PREFIX}-gst-plugins-good"
+             "${MINGW_PACKAGE_PREFIX}-libcacard"
              "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
              "${MINGW_PACKAGE_PREFIX}-libwinpthread-git"
              "${MINGW_PACKAGE_PREFIX}-lz4"
@@ -32,13 +35,17 @@ makedepends=(
              "autoconf-archive"
              "${MINGW_PACKAGE_PREFIX}-asciidoc"
 )
-source=(https://www.spice-space.org/download/releases/spice-server/${_realname}-${pkgver}.tar.bz2{,.sig})
+source=(https://www.spice-space.org/download/releases/spice-server/${_realname}-${pkgver}.tar.bz2{,.sig}
+        0001-fix-compiling-with-libcacard.patch::https://gitlab.freedesktop.org/spice/spice/-/commit/3dfd5243c7d8146ff25de4cd76657641118821be.patch)
 validpgpkeys=('206D3B352F566F3B0E6572E997D9123DE37A484F')
-sha256sums=('ada9af67ab321916bd7eb59e3d619a4a7796c08a28c732edfc7f02fc80b1a37a'
-            'SKIP')
+sha256sums=('6d9eb6117f03917471c4bc10004abecff48a79fb85eb85a1c45f023377015b81'
+            'SKIP'
+            '9ebd4f572dc2316e47b63b1c8802c69297922ce9ca14603959208afa74065be3')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
+  patch -p1 -i "${srcdir}"/0001-fix-compiling-with-libcacard.patch
+
   # Fix test to recognize CRLF lineending
   find . -name test-logging.c -exec \
     sed -i "s/\\\\n/\\\\r\\\\n/g" {} \;
@@ -53,14 +60,12 @@ build() {
   # --enable-extra-checks:  adds (failing) test test-video-encoders
   # --enable-manual=no:     because manual is already provided in tarball
   # --with-sasl=no:         because compilation fails
-  # --enable-lz4=${lz4}:    because linking fails on i686
-  [ "i686" == "${CARCH}" ] && lz4=no || lz4=yes
+
   CFLAGS="-g -O2" \
   CXXFLAGS="-g -O2 -fno-exceptions -fno-check-new" \
   LDFLAGS="-g -lpthread" \
   "${srcdir}"/${_realname}-${pkgver}/configure \
     --prefix="${MINGW_PREFIX}" \
-    --enable-lz4=${lz4} \
     --enable-gstreamer=1.0 \
     --enable-manual=no \
     --with-sasl=no


### PR DESCRIPTION
* Enable lz4 for all architectures.
* Add libcacard dependency.