### PR TITLE
spirv-tools: update to 1.3.2.250.0

### DIFF
--- a/mingw-w64-spirv-tools/PKGBUILD
+++ b/mingw-w64-spirv-tools/PKGBUILD
@@ -4,7 +4,8 @@
 _realname=spirv-tools
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2023.2
+epoch=1
+pkgver=1.3.250.0
 pkgrel=1
 pkgdesc="API and commands for processing SPIR-V modules (mingw-w64)"
 arch=('any')
@@ -18,13 +19,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-python"
              "${MINGW_PACKAGE_PREFIX}-spirv-headers")
-source=("${_realname}-${pkgver}.tar.gz::https://github.com/KhronosGroup/SPIRV-Tools/archive/v${pkgver}.tar.gz"
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/KhronosGroup/SPIRV-Tools/archive/sdk-${pkgver}.tar.gz"
         002-Do-not-statically-link-to-the-C-runtime-with-mingw.patch)
-sha512sums=('988f5e31508e3f19c1dd9d9a013c8e9ff89eba86207a769d7d804f9ee0201c794f412a874c860167b2c040b2c5e1fb1c835ae3684c70feaac86e47f90c1a5010'
-            'fff1df5dd4b216a1a384b8c61644c1478db61a38e1892095f38d86894a9610f7446a94fa9aea7e638767ab3c56b5eaa9ddd6f172158c096cfbc52f31c1cd932a')
+sha256sums=('1c1d428537031ff0a753a6ebcc473e9c2b39bda351b556f5378cab1c0cf9c278'
+            '13713ff2ca9b3a8e2311fa33f163a314a0597d43185d4aee3ad66b4b6e648a5b')
 
 prepare() {
-  cd SPIRV-Tools-${pkgver}
+  cd SPIRV-Tools-sdk-${pkgver}
   patch -p1 -i ${srcdir}/002-Do-not-statically-link-to-the-C-runtime-with-mingw.patch
 }
 
@@ -50,7 +51,7 @@ build() {
       -DSPIRV_SKIP_EXECUTABLES=ON \
       -DSPIRV_SKIP_TESTS=ON \
       -DSPIRV-Headers_SOURCE_DIR=${MINGW_PREFIX} \
-      ../SPIRV-Tools-${pkgver}
+      ../SPIRV-Tools-sdk-${pkgver}
 
   ${MINGW_PREFIX}/bin/cmake.exe --build ./
 
@@ -67,7 +68,7 @@ build() {
       -DSPIRV_TOOLS_BUILD_STATIC=OFF \
       -DSPIRV_SKIP_TESTS=ON \
       -DSPIRV-Headers_SOURCE_DIR=${MINGW_PREFIX} \
-      ../SPIRV-Tools-${pkgver}
+      ../SPIRV-Tools-sdk-${pkgver}
 
   ${MINGW_PREFIX}/bin/cmake.exe --build ./
 }
@@ -80,7 +81,7 @@ package() {
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install ./
 
   install -dm755 "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
-  install -m644 ${srcdir}/SPIRV-Tools-${pkgver}/LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/"
+  install -m644 ${srcdir}/SPIRV-Tools-sdk-${pkgver}/LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/"
 
   local _WIN_PREFIX=$(cygpath -am ${MINGW_PREFIX})
   for _f in "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/*.pc; do


### PR DESCRIPTION
Fellow/match spirv-headers, spirv-cross versioning.
1.3.x are tagged more frequently that 202x ones.