### PR TITLE
nodejs: Fix executing error

### DIFF
--- a/mingw-w64-nodejs/0001-Skip-check-OS-version.patch
+++ b/mingw-w64-nodejs/0001-Skip-check-OS-version.patch
@@ -1,0 +1,25 @@
+--- a/src/node_main.cc
++++ b/src/node_main.cc
+@@ -32,22 +32,6 @@
+ #define SKIP_CHECK_VALUE "1"
+ 
+ int wmain(int argc, wchar_t* wargv[]) {
+-  // Windows Server 2012 (not R2) is supported until 10/10/2023, so we allow it
+-  // to run in the experimental support tier.
+-  char buf[SKIP_CHECK_SIZE + 1];
+-  if (!IsWindows8Point1OrGreater() &&
+-      !(IsWindowsServer() && IsWindows8OrGreater()) &&
+-      (GetEnvironmentVariableA(SKIP_CHECK_VAR, buf, sizeof(buf)) !=
+-       SKIP_CHECK_SIZE ||
+-       strncmp(buf, SKIP_CHECK_VALUE, SKIP_CHECK_SIZE + 1) != 0)) {
+-    fprintf(stderr, "Node.js is only supported on Windows 8.1, Windows "
+-                    "Server 2012 R2, or higher.\n"
+-                    "Setting the " SKIP_CHECK_VAR " environment variable "
+-                    "to 1 skips this\ncheck, but Node.js might not execute "
+-                    "correctly. Any issues encountered on\nunsupported "
+-                    "platforms will not be fixed.");
+-    exit(ERROR_EXE_MACHINE_TYPE_MISMATCH);
+-  }
+ 
+   // Convert argv to UTF8
+   char** argv = new char*[argc + 1];

--- a/mingw-w64-nodejs/0006-Define-_WIN32_WINNT-in-node.gypi.patch
+++ b/mingw-w64-nodejs/0006-Define-_WIN32_WINNT-in-node.gypi.patch
@@ -15,7 +15,7 @@ index 3990c59e..2705cefe 100644
          'NODE_PLATFORM="win"',
        ],
        'defines': [
-+        '_WIN32_WINNT=0x0602',
++        '_WIN32_WINNT=0x0603',
          'FD_SETSIZE=1024',
          # we need to use node's preferred "win32" rather than gyp's preferred "win"
          'NODE_PLATFORM="win32"',

--- a/mingw-w64-nodejs/PKGBUILD
+++ b/mingw-w64-nodejs/PKGBUILD
@@ -9,7 +9,7 @@ _realname=nodejs
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=18.15.0
-pkgrel=1
+pkgrel=2
 pkgdesc="An open-source, cross-platform JavaScript runtime environment (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -27,6 +27,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-c-ares"
          "winpty")
 options=('!emptydirs' '!strip' '!buildflags')
 source=("https://nodejs.org/dist/v${pkgver}/node-v${pkgver}.tar.xz"
+        '0001-Skip-check-OS-version.patch'
         '0002-Fix-system-icu-build.patch'
         '0004-Define-localtime_s-for-MinGW.patch'
         '0005-Remove-.lib-suffix-on-linked-libraries.patch'
@@ -59,6 +60,7 @@ source=("https://nodejs.org/dist/v${pkgver}/node-v${pkgver}.tar.xz"
 prepare() {
   cd "${srcdir}/node-v${pkgver}"
 
+  patch -Np1 -i "${srcdir}/0001-Skip-check-OS-version.patch"
   patch -Np1 -i "${srcdir}/0002-Fix-system-icu-build.patch"
   patch -Np1 -i "${srcdir}/0004-Define-localtime_s-for-MinGW.patch"
   patch -Np1 -i "${srcdir}/0005-Remove-.lib-suffix-on-linked-libraries.patch"
@@ -154,10 +156,11 @@ package() {
 }
 
 sha256sums=('8e44d65018ff973284195c23186469a0ea4082e97ec4200e5f5706d5584daa37'
+            '0325fc0b6f9c9fa366651047e79f164ba25665d3a23efdd207430163dc50d6a6'
             '61023beecb4e1476c2bb177262a0c7f0847f50a1a09365b290df9e822ca8d881'
             'cba59c2a92d75e01f8417da130269d34b1db13995b647a00a03de47ff2ccfe1c'
             'be2a9d695741e70ab2c8ab07fc0ccba5fe24f392cc1fb3658f91d54bb58c1ba3'
-            '5797d5679b5515e55bc23d6d020eabffc588b3aa640350bb3b729dd5a23eb69b'
+            '8a63968d9334d12a5b5ee30f81a1c6bad3bad88440da638752981a48aa608134'
             'ba7a4117f2224569766a7aba7dde1e4601e06ad1f1fc47916805e554f4d87385'
             '1cb8d957d299532499b72559dd78a71fe9ec5b1def789d85969b315db5e6b68f'
             '3a7d3a666fb894ab17c932bc5af2b88a71688f1eaac2ceaa1fcd281000bb69cb'


### PR DESCRIPTION
node fails with error:
```
Node.js is only supported on Windows 8.1, Windows Server 2012 R2, or higher.
Setting the NODE_SKIP_PLATFORM_CHECK environment variable to 1 skips this
check, but Node.js might not execute correctly. Any issues encountered on
unsupported platforms will not be fixed
```
Fix it by setting _WIN32_WINNT to Windows 8.1