### PR TITLE
mesa: apply patch to avoid crash on missing dxil.dll

### DIFF
--- a/mingw-w64-mesa/0001-Add-checks-for-NULL-dxil_validator.patch
+++ b/mingw-w64-mesa/0001-Add-checks-for-NULL-dxil_validator.patch
@@ -1,0 +1,86 @@
+From 3136fe409a0ca0f9609604e3d908ad73ddcd8b1d Mon Sep 17 00:00:00 2001
+From: Luca Bacci <luca.bacci@outlook.com>
+Date: Mon, 27 Mar 2023 17:53:11 +0200
+Subject: [PATCH] Add checks for NULL dxil_validator
+
+Fixes https://gitlab.freedesktop.org/mesa/mesa/-/issues/8718
+
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/22141>
+---
+ src/gallium/drivers/d3d12/d3d12_context.cpp |  3 +--
+ src/microsoft/compiler/dxil_validator.cpp   | 11 ++++++++++-
+ src/microsoft/vulkan/dzn_device.c           |  3 +--
+ 3 files changed, 12 insertions(+), 5 deletions(-)
+
+diff --git a/src/gallium/drivers/d3d12/d3d12_context.cpp b/src/gallium/drivers/d3d12/d3d12_context.cpp
+index 871c98ff56f..ed4f2bafb31 100644
+--- a/src/gallium/drivers/d3d12/d3d12_context.cpp
++++ b/src/gallium/drivers/d3d12/d3d12_context.cpp
+@@ -75,8 +75,7 @@ d3d12_context_destroy(struct pipe_context *pctx)
+    mtx_unlock(&screen->submit_mutex);
+ 
+ #ifdef _WIN32
+-   if (ctx->dxil_validator)
+-      dxil_destroy_validator(ctx->dxil_validator);
++   dxil_destroy_validator(ctx->dxil_validator);
+ #endif
+ 
+ #ifndef _GAMING_XBOX
+diff --git a/src/microsoft/compiler/dxil_validator.cpp b/src/microsoft/compiler/dxil_validator.cpp
+index 4b68957a7da..c19b395aae1 100644
+--- a/src/microsoft/compiler/dxil_validator.cpp
++++ b/src/microsoft/compiler/dxil_validator.cpp
+@@ -237,6 +237,9 @@ fail:
+ void
+ dxil_destroy_validator(struct dxil_validator *val)
+ {
++   if (!val)
++      return;
++
+    /* if we have a validator, we have these */
+    val->dxc_validator->Release();
+    FreeLibrary(val->dxil_mod);
+@@ -299,6 +302,9 @@ public:
+ bool
+ dxil_validate_module(struct dxil_validator *val, void *data, size_t size, char **error)
+ {
++   if (!val)
++      return false;
++
+    ShaderBlob source(data, size);
+ 
+    ComPtr<IDxcOperationResult> result;
+@@ -337,6 +343,9 @@ dxil_validate_module(struct dxil_validator *val, void *data, size_t size, char *
+ char *
+ dxil_disasm_module(struct dxil_validator *val, void *data, size_t size)
+ {
++   if (!val)
++      return NULL;
++
+    if (!val->dxc_compiler || !val->dxc_library) {
+       fprintf(stderr, "DXIL: disassembly requires IDxcLibrary and "
+               "IDxcCompiler from dxcompiler.dll\n");
+@@ -364,5 +373,5 @@ dxil_disasm_module(struct dxil_validator *val, void *data, size_t size)
+ enum dxil_validator_version
+ dxil_get_validator_version(struct dxil_validator *val)
+ {
+-   return val->version;
++   return val ? val->version : NO_DXIL_VALIDATION;
+ }
+diff --git a/src/microsoft/vulkan/dzn_device.c b/src/microsoft/vulkan/dzn_device.c
+index f0f30dd2f32..6c485d783d8 100644
+--- a/src/microsoft/vulkan/dzn_device.c
++++ b/src/microsoft/vulkan/dzn_device.c
+@@ -202,8 +202,7 @@ dzn_instance_destroy(struct dzn_instance *instance, const VkAllocationCallbacks
+    vk_instance_finish(&instance->vk);
+ 
+ #ifdef _WIN32
+-   if (instance->dxil_validator)
+-      dxil_destroy_validator(instance->dxil_validator);
++   dxil_destroy_validator(instance->dxil_validator);
+ #endif
+ 
+    if (instance->factory)
+-- 
+2.41.0
+

--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -4,7 +4,7 @@ _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=23.1.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Open-source implementation of the OpenGL, Vulkan and OpenCL specifications (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -35,11 +35,13 @@ url="https://www.mesa3d.org/"
 license=('spdx:MIT')
 source=(https://mesa.freedesktop.org/archive/${_realname}-${pkgver}.tar.xz{,.sig}
         llvmwrapgen.sh
-        do-not-install-standard-headers.patch)
+        do-not-install-standard-headers.patch
+        0001-Add-checks-for-NULL-dxil_validator.patch)
 sha256sums=('a2679031ed5b73b29c4f042ac64d96f83b0cfe4858617de32e2efc196c653a40'
             'SKIP'
             '69f21522f20c10f5699dfe3e128aa88d4fedde816f6e8df1506d7470c44bf3da'
-            'ac10033dd72e6ab705a8bdd5e2a47542a557d0cfc4c23fd0f319f682ec9308b8')
+            'ac10033dd72e6ab705a8bdd5e2a47542a557d0cfc4c23fd0f319f682ec9308b8'
+            '439bb27fc8201a6854f52550af7cffca1cecab05a5a89e335ac15f1dfce08832')
 validpgpkeys=('8703B6700E7EE06D7A39B8D6EDAE37B02CEB490D') # Emil Velikov <emil.l.velikov@gmail.com>
 validpgpkeys+=('946D09B5E4C9845E63075FF1D961C596A7203456') # Andres Gomez <tanty@igalia.com>
 validpgpkeys+=('E3E8F480C52ADD73B278EE78E1ECBE07D7D70895') # Juan Antonio Suárez Romero (Igalia, S.L.) <jasuarez@igalia.com>"
@@ -97,7 +99,8 @@ prepare() {
 
 # Do not install standard API headers
   apply_patch_with_msg \
-    do-not-install-standard-headers.patch
+    do-not-install-standard-headers.patch \
+    0001-Add-checks-for-NULL-dxil_validator.patch
 
 # Generate binary wrap for LLVM if llvm-config tool is busted
   if ! [ "$(${MINGW_PREFIX}/bin/llvm-config --has-rtti 2>&1)" = YES ] && ! [ "$(${MINGW_PREFIX}/bin/llvm-config --has-rtti 2>&1)" = NO ]; then


### PR DESCRIPTION
As of now we miss dxil.dll within msys2 installation. This is being addressed by https://github.com/msys2/MINGW-packages/pull/16643, but creating a package for dxil will take some time due to resolving redistribution concerns.

In a meanwhile this commit applies patch from mesa main branch to avoid a crash on missing dxil.dll. This allows some workflows to actually work, for example, vaon12 media workflows which don't require shader operations.

Issue: https://gitlab.freedesktop.org/mesa/mesa/-/issues/8718
Upstream: https://gitlab.freedesktop.org/mesa/mesa/-/commit/098342ce53f692b719dd3aeb876737ad886c37f0