### PR TITLE
rust: rebuild 1.69.0 to work around clang issue with 1.70.0

### DIFF
--- a/mingw-w64-rust/0007-clang-subsystem.patch
+++ b/mingw-w64-rust/0007-clang-subsystem.patch
@@ -157,3 +157,15 @@ diff -urN rustc-1.65.0-src.orig/src/bootstrap/bootstrap.py rustc-1.65.0-src/src/
      def _download_component_helper(
          self, filename, pattern, tarball_suffix,
      ):
+diff -urN rustc-1.69.0-src/compiler/rustc_codegen_llvm/src/common.rs.orig rustc-1.69.0-src/compiler/rustc_codegen_llvm/src/common.rs
+--- rustc-1.69.0-src/compiler/rustc_codegen_llvm/src/common.rs.orig     2023-06-03 18:04:48.695354700 +0200
++++ rustc-1.69.0-src/compiler/rustc_codegen_llvm/src/common.rs  2023-06-03 18:04:55.208081500 +0200
+@@ -379,7 +379,7 @@
+ }
+
+ pub(crate) fn is_mingw_gnu_toolchain(target: &Target) -> bool {
+-    target.vendor == "pc" && target.os == "windows" && target.env == "gnu" && target.abi.is_empty()
++    false && target.vendor == "pc" && target.os == "windows" && target.env == "gnu" && target.abi.is_empty()
+ }
+
+ pub(crate) fn i686_decorated_name(

--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -5,14 +5,14 @@
 
 _realname=rust
 _bootstrapping=yes
-if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
+if [[ $MINGW_PACKAGE_PREFIX == *-w64-i686 || $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
   _bootstrapping=no
 fi
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-rust-docs")
 pkgver=1.69.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
@@ -46,7 +46,7 @@ sha256sums=('fb05971867ad6ccabbd3720279f5a94b99f61024923187b56bb5c455fa3cf60f'
             '7cb1773c288ffb1c1e751edc49b1890c84bf9c362742bc5225d19d474edb73a0'
             '36c531c73a2c12b3e66aa22526a404c3f770f1ab7e0e76c55af6fcc1a17e46fe'
             'c4e5ffeef84296d39c3e3e8f807fc8b33ce786b1e4edb21eef26b053586aca27'
-            '4af633d35e034fc2ea080b3df0f1c66c5cb31ec590c3e59dd7dddfe21faa2764'
+            '3388c413fffeeaa84f775a176b1653b360ffba7b0c0a6f5baa0c3a95aec8827a'
             'a214cd8394ab7416fd170c7fa05daf701a5357d38e4e54149370e6efff208e50'
             'e72ee077cd62bfc24c592a12ca27242d24ee14237d414c7e8fc4004bf8b031b8'
             'fc14094d0a0fde559be647fd9063260592378ac38d88a640b24ee85a1400be0c')


### PR DESCRIPTION
see https://github.com/msys2/MINGW-packages/pull/17406