### PR TITLE
emscripten: don't use git for llvm and binaryen

### DIFF
--- a/mingw-w64-emscripten/PKGBUILD
+++ b/mingw-w64-emscripten/PKGBUILD
@@ -9,7 +9,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=3.1.39
 _binaryen_revision=8ec55f6ac81f4b0d67e3ab8ca14736ff3fbdc671
 _llvm_project_revision=c672c3fe05adbb590abc99da39143b55ad510538
-pkgrel=1
+pkgrel=2
 pkgdesc="Compile C and C++ into highly-optimizable JavaScript for the web (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64')
@@ -31,11 +31,18 @@ conflicts=("${MINGW_PACKAGE_PREFIX}-binaryen")
 provides=("${MINGW_PACKAGE_PREFIX}-binaryen")
 install="emscripten-${MSYSTEM}.install"
 source=("git+https://github.com/emscripten-core/emscripten#tag=$pkgver"
-        "git+https://github.com/llvm/llvm-project.git#commit=$_llvm_project_revision"
-        "git+https://github.com/WebAssembly/binaryen.git#commit=$_binaryen_revision")
+        "llvm-project.tar.gz::https://github.com/llvm/llvm-project/archive/$_llvm_project_revision.tar.gz"
+        "binaryen.tar.gz::https://github.com/WebAssembly/binaryen/archive/$_binaryen_revision.tar.gz")
 sha512sums=('SKIP'
             'SKIP'
             'SKIP')
+noextract=("llvm-project.tar.gz")
+
+prepare() {
+  tar -xf llvm-project.tar.gz 2> /dev/null || true
+  mv "llvm-project-$_llvm_project_revision" llvm-project
+  mv "binaryen-$_binaryen_revision" binaryen
+}
 
 build() {
   declare -a _extra_config


### PR DESCRIPTION
this brings the source package size down from 3.2GB to 0.5GB