### PR TITLE
libva-utils: add package

### DIFF
--- a/mingw-w64-libva-utils/PKGBUILD
+++ b/mingw-w64-libva-utils/PKGBUILD
@@ -1,0 +1,45 @@
+# Maintainer: Dmitry Rogozhkin <dmitry.rogozhkin@intel.com>
+
+_realname=libva-utils
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=2.18.2
+pkgrel=1
+pkgdesc='Video Acceleration (VA) API utilies (mingw-w64)'
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+url='https://01.org/linuxmedia/vaapi'
+license=('spdx:MIT')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-directx-headers"
+             "${MINGW_PACKAGE_PREFIX}-meson"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config")
+depends=("${MINGW_PACKAGE_PREFIX}-libva")
+optdepends=("${MINGW_PACKAGE_PREFIX}-mesa: for the vaon12 Gallium driver")
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/intel/libva-utils/archive/refs/tags/${pkgver}.tar.gz")
+sha256sums=('c4c0555c96ca678f9ac47fbb56f0ae56ca39fd50fe3553bae5cb13117bfcb406')
+
+prepare() {
+  cd "${srcdir}"/${_realname}-${pkgver}
+}
+
+build() {
+  mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    ${MINGW_PREFIX}/bin/meson.exe setup \
+      --prefix="${MINGW_PREFIX}" \
+      --wrap-mode=nodownload \
+      --auto-features=enabled \
+      --buildtype=plain \
+      ../${_realname}-${pkgver}
+
+  ${MINGW_PREFIX}/bin/meson.exe compile
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/meson.exe install
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}


### PR DESCRIPTION
As of libva version 2.18.0 and mesa 23.1.1 it's required to set the following environment variables to be able to work with vaon12 driver:
```
  $ export | grep LIBVA
  declare -x LIBVA_DRIVERS_PATH="/mingw64/bin/"
  declare -x LIBVA_DRIVER_NAME="libvaon12"
```
This will be fixed in the next versions of libva and mesa - patches for that already landed in upstream versions of these components.

With above environment variables set user should see something like this (output depends on actual HW capabilities, below is a snapshot from Interl Alderlake running Windows 11):
```
  $ vainfo
  Trying display: win32
  libva info: VA-API version 1.18.0
  libva info: User environment variable requested driver 'libvaon12'
  libva info: Trying to open C:/msys64/mingw64/bin/\libvaon12_drv_video.dll
  libva info: Found init function __vaDriverInit_1_18
  libva info: va_openDriver() returns 0
  C:\msys64\mingw64\bin\vainfo.exe: VA-API version: 1.18 (libva 2.18.2)
  C:\msys64\mingw64\bin\vainfo.exe: Driver version: Mesa Gallium driver 23.1.1 for D3D12 (Intel(R) Iris(R) Xe Graphics)
  C:\msys64\mingw64\bin\vainfo.exe: Supported profile and entrypoints
        VAProfileVP9Profile0            : VAEntrypointVLD
        VAProfileVP9Profile2            : VAEntrypointVLD
        VAProfileAV1Profile0            : VAEntrypointVLD
        VAProfileNone                   : VAEntrypointVideoProc
```
To enable more features (h264 and h265 decoder/encoder and others) it's required to build mesa with corresponding capabilities. That's a subject for other patch in msys2 mesa build.