### PR TITLE
soapyrtlsdr: Add version 0.3.3

### DIFF
--- a/mingw-w64-soapyrtlsdr/PKGBUILD
+++ b/mingw-w64-soapyrtlsdr/PKGBUILD
@@ -1,0 +1,47 @@
+_realname=soapyrtlsdr
+_pkgname=SoapyRTLSDR
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.3.3
+_gitver=soapy-rtl-sdr-$pkgver
+pkgrel=1
+pkgdesc='Soapy SDR plugin for RTL-SDR devices (mingw-w64)'
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+url='https://github.com/pothosware/SoapyRTLSDR'
+license=('MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-soapysdr"
+         "${MINGW_PACKAGE_PREFIX}-rtl-sdr")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+source=("$pkgname-$pkgver.tar.gz::$url/archive/$_gitver.tar.gz")
+sha512sums=('a43511c8644a8dbec8e0b7d8f114c4955ba9407727680680cef446a12a9ee27bfe892cab49aa77ce82d52e4272075f4e6f2ee38350675f5508601ff24ff82081')
+
+build() {
+  cd "${srcdir}"/$_pkgname-$_gitver
+
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
+
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    "${MINGW_PREFIX}"/bin/cmake.exe \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      "${extra_config[@]}" \
+      -GNinja \
+      ../$_pkgname-$_gitver
+
+  "${MINGW_PREFIX}"/bin/cmake.exe --build .
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
+}


### PR DESCRIPTION
Yep! MinGW now has a bunch of radio and signal processing libs to tinker with!

This may not be able to compile as it depends on a just merged package (`rtl-sdr`). See https://github.com/msys2/MINGW-packages/pull/17459

If build fails, I will relaunch whenever the package pops up at https://packages.msys2.org/base/mingw-w64-rtl-sdr. Another interesting link https://packages.msys2.org/queue.

Thanks!