### PR TITLE
mesa: enable h264dec,h264enc,h265dec,h265enc,vc1dec video-codecs

### DIFF
--- a/mingw-w64-mesa/0002-meson-vaon12-fix-driver-file-name-for-mingw-build.patch
+++ b/mingw-w64-mesa/0002-meson-vaon12-fix-driver-file-name-for-mingw-build.patch
@@ -1,0 +1,29 @@
+From 922b6040eb447db5db95bee8e8283829bfa64e7d Mon Sep 17 00:00:00 2001
+From: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>
+Date: Fri, 12 May 2023 09:22:36 -0700
+Subject: [PATCH 2/2] meson/vaon12: fix driver file name for mingw build
+
+This fixes vaon12 driver file name to be consistent with libva
+expectation - vaon12_drv_video.dll - without lib prefix.
+
+Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/22995>
+---
+ src/gallium/targets/va/meson.build | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/gallium/targets/va/meson.build b/src/gallium/targets/va/meson.build
+index b4cfbfb70e8..c6c50bccb19 100644
+--- a/src/gallium/targets/va/meson.build
++++ b/src/gallium/targets/va/meson.build
+@@ -73,6 +73,7 @@ if host_machine.system() == 'windows'
+     link_depends : va_link_depends,
+     install : true,
+     name_suffix : 'dll',
++    name_prefix : '',  # otherwise mingw will create libvaon12_drv_video.dll
+   )
+ else
+   libva_gallium = shared_library(
+-- 
+2.41.0
+

--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -4,7 +4,7 @@ _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=23.1.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Open-source implementation of the OpenGL, Vulkan and OpenCL specifications (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -36,12 +36,14 @@ license=('spdx:MIT')
 source=(https://mesa.freedesktop.org/archive/${_realname}-${pkgver}.tar.xz{,.sig}
         llvmwrapgen.sh
         do-not-install-standard-headers.patch
-        0001-Add-checks-for-NULL-dxil_validator.patch)
+        0001-Add-checks-for-NULL-dxil_validator.patch
+        0002-meson-vaon12-fix-driver-file-name-for-mingw-build.patch)
 sha256sums=('a2679031ed5b73b29c4f042ac64d96f83b0cfe4858617de32e2efc196c653a40'
             'SKIP'
             '69f21522f20c10f5699dfe3e128aa88d4fedde816f6e8df1506d7470c44bf3da'
             'ac10033dd72e6ab705a8bdd5e2a47542a557d0cfc4c23fd0f319f682ec9308b8'
-            '439bb27fc8201a6854f52550af7cffca1cecab05a5a89e335ac15f1dfce08832')
+            '439bb27fc8201a6854f52550af7cffca1cecab05a5a89e335ac15f1dfce08832'
+            '89b2dcef98cd5e9c5f39f79459cae6fd568577ebb380dffcc0c4e70cf8f9a82f')
 validpgpkeys=('8703B6700E7EE06D7A39B8D6EDAE37B02CEB490D') # Emil Velikov <emil.l.velikov@gmail.com>
 validpgpkeys+=('946D09B5E4C9845E63075FF1D961C596A7203456') # Andres Gomez <tanty@igalia.com>
 validpgpkeys+=('E3E8F480C52ADD73B278EE78E1ECBE07D7D70895') # Juan Antonio Suárez Romero (Igalia, S.L.) <jasuarez@igalia.com>"
@@ -100,7 +102,8 @@ prepare() {
 # Do not install standard API headers
   apply_patch_with_msg \
     do-not-install-standard-headers.patch \
-    0001-Add-checks-for-NULL-dxil_validator.patch
+    0001-Add-checks-for-NULL-dxil_validator.patch \
+    0002-meson-vaon12-fix-driver-file-name-for-mingw-build.patch
 
 # Generate binary wrap for LLVM if llvm-config tool is busted
   if ! [ "$(${MINGW_PREFIX}/bin/llvm-config --has-rtti 2>&1)" = YES ] && ! [ "$(${MINGW_PREFIX}/bin/llvm-config --has-rtti 2>&1)" = NO ]; then
@@ -124,6 +127,7 @@ build() {
   -Dbuild-tests=false
   -Dgallium-drivers=swrast,zink,d3d12
   -Dgallium-va=enabled
+  -Dvideo-codecs=h264dec,h264enc,h265dec,h265enc,vc1dec
   -Dmicrosoft-clc=enabled
   -Dstatic-libclc=all
   -Dcpp_rtti=true


### PR DESCRIPTION
Mesa requires explicit flags to enable named video codecs. With these enabled, user should see output similar to this on vainfo (actual list depends on HW capabilities, below is from Intel Alderlake):
```
  $ LIBVA_DRIVERS_PATH=/mingw64/bin/ vainfo
  Trying display: win32
  libva info: VA-API version 1.18.0
  libva info: Trying to open C:/msys64/mingw64/bin/\vaon12_drv_video.dll
  libva info: Found init function __vaDriverInit_1_18
  libva info: va_openDriver() returns 0
  C:\msys64\mingw64\bin\vainfo.exe: VA-API version: 1.18 (libva 2.18.2)
  C:\msys64\mingw64\bin\vainfo.exe: Driver version: Mesa Gallium driver 23.1.1 for D3D12 (Intel(R) Iris(R) Xe Graphics)
  C:\msys64\mingw64\bin\vainfo.exe: Supported profile and entrypoints
        VAProfileH264ConstrainedBaseline: VAEntrypointVLD
        VAProfileH264ConstrainedBaseline: VAEntrypointEncSlice
        VAProfileH264Main               : VAEntrypointVLD
        VAProfileH264Main               : VAEntrypointEncSlice
        VAProfileH264High               : VAEntrypointVLD
        VAProfileH264High               : VAEntrypointEncSlice
        VAProfileHEVCMain               : VAEntrypointVLD
        VAProfileHEVCMain10             : VAEntrypointVLD
        VAProfileVP9Profile0            : VAEntrypointVLD
        VAProfileVP9Profile2            : VAEntrypointVLD
        VAProfileAV1Profile0            : VAEntrypointVLD
        VAProfileNone                   : VAEntrypointVideoProc
```
This commit also applies a patch from upstream mesa to align vaon12 driver name with libva default expectation. This eliminates a need to explicitly set LIBVA_DRIVER_NAME environment variable.

Upstream: https://gitlab.freedesktop.org/mesa/mesa/-/commit/8fc5dd935f4925897cd0bebd117699628f57a645