### PR TITLE
new package: libipt

### DIFF
--- a/mingw-w64-libipt/001-fix-import-lib-naming.patch
+++ b/mingw-w64-libipt/001-fix-import-lib-naming.patch
@@ -1,0 +1,10 @@
+--- libipt/libipt/CMakeLists.txt.orig	2023-06-15 07:31:30.894623900 +0200
++++ libipt/libipt/CMakeLists.txt	2023-06-15 07:33:43.220525200 +0200
+@@ -99,6 +99,7 @@
+ 
+ set_target_properties(libipt PROPERTIES
+   PREFIX ""
++  IMPORT_PREFIX ""
+   PUBLIC_HEADER ${CMAKE_CURRENT_BINARY_DIR}/include/intel-pt.h
+   VERSION   ${PT_VERSION}
+   SOVERSION ${PT_VERSION_MAJOR}

--- a/mingw-w64-libipt/PKGBUILD
+++ b/mingw-w64-libipt/PKGBUILD
@@ -1,0 +1,88 @@
+# Maintainer: Bet4 <0xbet4@gmail.com>
+
+_realname=libipt
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgbase=mingw-w64-${_realname}
+pkgver=2.0+164.r903.20230324.7a863ba
+pkgrel=1
+pkgdesc='Intel(R) Processor Trace decoder library (mingw-w64)'
+arch=(
+  'i686'
+  'x86_64'
+)
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+url='https://github.com/intel/libipt'
+license=('BSD')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+           #  'pandoc' # Only required for building the manpage, we likely don't want that
+             "${MINGW_PACKAGE_PREFIX}-cc"
+             'git')
+_commit='7a863ba'
+source=("${_realname}"::"git+${url}#commit=${_commit}")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "${srcdir}/${_realname}"
+
+  _ver="$(git describe --tags | sed -E -e 's|^[vV]||' -e 's|\-g[0-9a-f]*$||' | tr '-' '+')"
+  _rev="$(git rev-list --count HEAD)"
+  _date="$(git log -1 --date=format:"%Y%m%d" --format="%ad")"
+  _hash="$(git rev-parse --short HEAD)"
+
+  if [ -z "${_ver}" ]; then
+    error "Could not determine version."
+    return 1
+  else
+    printf '%s' "${_ver}.r${_rev}.${_date}.${_hash}"
+  fi
+}
+
+prepare() {
+  cd "${srcdir}/${_realname}"
+}
+
+build() {
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
+
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    "${MINGW_PREFIX}"/bin/cmake.exe \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      "${extra_config[@]}" \
+      -DBUILD_SHARED_LIBS=ON \
+      -DDEVBUILD=OFF \
+      -DFEATURE_THREADS=ON \
+      -DFEATURE_ELF=ON \
+      -DMAN=OFF \
+      -DPTDUMP=ON \
+      -DPTSEG=ON \
+      -DPTTC=ON \
+      -DPTUNIT=ON \
+      -DPTXED=OFF \
+      -DSIDEBAND=ON \
+      ../${_realname}
+
+  "${MINGW_PREFIX}"/bin/cmake.exe --build .
+}
+
+check() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  "${MINGW_PREFIX}"/bin/cmake.exe --build . --target test
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
+
+  install -Dm644 "${srcdir}/${_realname}/README"  "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}/README"
+  install -Dm644 "${srcdir}/${_realname}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}

--- a/mingw-w64-libipt/PKGBUILD
+++ b/mingw-w64-libipt/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libipt
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgbase=mingw-w64-${_realname}
-pkgver=2.0+164.r903.20230324.7a863ba
+pkgver=2.0.6.r164.g7a863ba
 pkgrel=1
 pkgdesc='Intel(R) Processor Trace decoder library (mingw-w64)'
 arch=(
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
            #  'pandoc' # Only required for building the manpage, we likely don't want that
              "${MINGW_PACKAGE_PREFIX}-cc"
              'git')
-_commit='7a863ba'
+_commit='fa32af7a3aaa88b11e19ba8259fcd6eb4a2e768a'
 source=("${_realname}"::"git+${url}#commit=${_commit}")
 sha256sums=('SKIP')
 

--- a/mingw-w64-libipt/PKGBUILD
+++ b/mingw-w64-libipt/PKGBUILD
@@ -1,26 +1,22 @@
-# Maintainer: Bet4 <0xbet4@gmail.com>
-
 _realname=libipt
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgbase=mingw-w64-${_realname}
-pkgver=2.0.6.r164.g7a863ba
+pkgbase="mingw-w64-${_realname}"
+pkgver=2.0.5+18.r812.20230324.fa32af7
 pkgrel=1
 pkgdesc='Intel(R) Processor Trace decoder library (mingw-w64)'
-arch=(
-  'i686'
-  'x86_64'
-)
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://github.com/intel/libipt'
-license=('BSD')
+license=('spdx:BSD-3-Clause')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
            #  'pandoc' # Only required for building the manpage, we likely don't want that
              "${MINGW_PACKAGE_PREFIX}-cc"
              'git')
 _commit='fa32af7a3aaa88b11e19ba8259fcd6eb4a2e768a'
-source=("${_realname}"::"git+${url}#commit=${_commit}")
-sha256sums=('SKIP')
+source=("${_realname}"::"git+${url}#commit=${_commit}"
+        "001-fix-import-lib-naming.patch")
+sha256sums=('SKIP'
+            '4e2a72080256239bf38abc1b9bbbd80bb9b9b4e584e914d57f8f93bcec15a26d')
 
 pkgver() {
   cd "${srcdir}/${_realname}"
@@ -40,6 +36,9 @@ pkgver() {
 
 prepare() {
   cd "${srcdir}/${_realname}"
+
+  # https://github.com/intel/libipt/issues/99
+  patch -Np1 -i "${srcdir}/001-fix-import-lib-naming.patch"
 }
 
 build() {
@@ -62,7 +61,6 @@ build() {
       -DFEATURE_ELF=ON \
       -DMAN=OFF \
       -DPTDUMP=ON \
-      -DPTSEG=ON \
       -DPTTC=ON \
       -DPTUNIT=ON \
       -DPTXED=OFF \
@@ -82,8 +80,6 @@ package() {
   cd "${srcdir}/build-${MSYSTEM}"
 
   DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
-  # work around bad install name
-  mv "${pkgdir}${MINGW_PREFIX}/lib/liblibipt.dll.a" "${pkgdir}${MINGW_PREFIX}/lib/libipt.dll.a"
 
   install -Dm644 "${srcdir}/${_realname}/README"  "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}/README"
   install -Dm644 "${srcdir}/${_realname}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"

--- a/mingw-w64-libipt/PKGBUILD
+++ b/mingw-w64-libipt/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=libipt
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgbase="mingw-w64-${_realname}"
-pkgver=2.0.5+18.r812.20230324.fa32af7
+pkgver=2.0.5.r18.gfa32af7
 pkgrel=1
 pkgdesc='Intel(R) Processor Trace decoder library (mingw-w64)'
 arch=('any')
@@ -21,17 +21,7 @@ sha256sums=('SKIP'
 pkgver() {
   cd "${srcdir}/${_realname}"
 
-  _ver="$(git describe --tags | sed -E -e 's|^[vV]||' -e 's|\-g[0-9a-f]*$||' | tr '-' '+')"
-  _rev="$(git rev-list --count HEAD)"
-  _date="$(git log -1 --date=format:"%Y%m%d" --format="%ad")"
-  _hash="$(git rev-parse --short HEAD)"
-
-  if [ -z "${_ver}" ]; then
-    error "Could not determine version."
-    return 1
-  else
-    printf '%s' "${_ver}.r${_rev}.${_date}.${_hash}"
-  fi
+  git describe --long --tags --abbrev=7 | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
 prepare() {

--- a/mingw-w64-libipt/PKGBUILD
+++ b/mingw-w64-libipt/PKGBUILD
@@ -82,6 +82,8 @@ package() {
   cd "${srcdir}/build-${MSYSTEM}"
 
   DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
+  # work around bad install name
+  mv "${pkgdir}${MINGW_PREFIX}/lib/liblibipt.dll.a" "${pkgdir}${MINGW_PREFIX}/lib/libipt.dll.a"
 
   install -Dm644 "${srcdir}/${_realname}/README"  "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}/README"
   install -Dm644 "${srcdir}/${_realname}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"


### PR DESCRIPTION
Adding Intel(R) Processor Trace (Intel PT) Decoder Library; the intended use is adding that to GDB as a follow-up.