### PR TITLE
Add ARM and RISCV as targets to LLVM-14

### DIFF
--- a/mingw-w64-llvm-14/PKGBUILD
+++ b/mingw-w64-llvm-14/PKGBUILD
@@ -15,7 +15,7 @@ pkgbase=mingw-w64-${_realname}-14
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-14"
          "${MINGW_PACKAGE_PREFIX}-clang-14")
 pkgver=14.0.6
-pkgrel=1
+pkgrel=2
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -142,7 +142,7 @@ build() {
 
   local _projects="clang"
 
-  platform_config+=(-DLLVM_TARGETS_TO_BUILD="AArch64;X86")
+  platform_config+=(-DLLVM_TARGETS_TO_BUILD="AArch64;ARM;RISCV;X86")
 
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
 


### PR DESCRIPTION
Needed for building https://github.com/m-labs/artiq and https://git.m-labs.hk/M-Labs/artiq-zynq firmware, which targets RISCV32 and ARM32 respectively.