### PR TITLE
gegl: remove exiv2 as direct dep

### DIFF
--- a/mingw-w64-gegl/PKGBUILD
+++ b/mingw-w64-gegl/PKGBUILD
@@ -5,7 +5,7 @@ _realname=gegl
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.4.44
-pkgrel=1
+pkgrel=2
 pkgdesc="Generic Graphics Library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -21,7 +21,6 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-asciidoc"
              "${MINGW_PACKAGE_PREFIX}-meson")
 depends=("${MINGW_PACKAGE_PREFIX}-babl"
          "${MINGW_PACKAGE_PREFIX}-cairo"
-         "${MINGW_PACKAGE_PREFIX}-exiv2"
          "${MINGW_PACKAGE_PREFIX}-ffmpeg"
          "${MINGW_PACKAGE_PREFIX}-gexiv2"
          "${MINGW_PACKAGE_PREFIX}-gcc-libs"
@@ -46,13 +45,17 @@ depends=("${MINGW_PACKAGE_PREFIX}-babl"
          "${MINGW_PACKAGE_PREFIX}-SDL2"
          "${MINGW_PACKAGE_PREFIX}-suitesparse")
 noextract=("${_realname}-${pkgver}.tar.xz")
-source=(https://download.gimp.org/pub/gegl/${pkgver%.*}/${_realname}-${pkgver}.tar.xz)
-sha256sums=('0a4cdb41635e406a0849cd0d3f03caf7d97cab8aa13d28707d532d0089d56126')
+source=(https://download.gimp.org/pub/gegl/${pkgver%.*}/${_realname}-${pkgver}.tar.xz
+        https://gitlab.gnome.org/GNOME/gegl/-/commit/cc4c9d3078d6a04b00e637a5bcca2f425cf3c528.diff)
+sha256sums=('0a4cdb41635e406a0849cd0d3f03caf7d97cab8aa13d28707d532d0089d56126'
+            'ae0bcd5bedc8385a5820505a5043ea36b2c06abdf1e238494fb6813a8c34e885')
 
 prepare() {
   tar -xf "${_realname}-${pkgver}.tar.xz" || true
   tar -xf "${_realname}-${pkgver}.tar.xz" || true
   cd "${_realname}-${pkgver}"
+  # https://gitlab.gnome.org/GNOME/gegl/-/issues/325
+  patch -Np1 -i "${srcdir}"/cc4c9d3078d6a04b00e637a5bcca2f425cf3c528.diff
 }
 
 build() {


### PR DESCRIPTION
Depending on `gexiv2` is sufficient.