### PR TITLE
Exiv2 0.28

### DIFF
--- a/mingw-w64-exiv2/PKGBUILD
+++ b/mingw-w64-exiv2/PKGBUILD
@@ -5,7 +5,7 @@
 _realname=exiv2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.27.7
+pkgver=0.28.0
 pkgrel=1
 pkgdesc="Exif/IPTC/Xmp C++ metadata library and tools (mingw-w64)"
 arch=('any')
@@ -14,16 +14,19 @@ url='https://exiv2.org/'
 license=('spdx:GPL-2.0-or-later')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-ninja")
-depends=("${MINGW_PACKAGE_PREFIX}-curl"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-python")
+depends=("${MINGW_PACKAGE_PREFIX}-brotli"
+         "${MINGW_PACKAGE_PREFIX}-curl"
          "${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-gettext"
          "${MINGW_PACKAGE_PREFIX}-libiconv"
+         "${MINGW_PACKAGE_PREFIX}-libinih"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libwinpthread-git")
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/Exiv2/${_realname}/archive/v${pkgver}.tar.gz")
-sha256sums=('551b1266e3aabd321f6d555dccd776128ee449d5039feafee927a1f33f7a9753')
+sha256sums=('04c0675caf4338bb96cd09982f1246d588bcbfe8648c0f5a30b56c7c496f1a0b')
 
 build() {
   #shared
@@ -43,13 +46,13 @@ build() {
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
       "${extra_config[@]}" \
       -DBUILD_SHARED_LIBS=ON \
+      -DCONAN_AUTO_INSTALL=OFF \
       -DEXIV2_ENABLE_VIDEO=ON \
       -DEXIV2_ENABLE_NLS=ON \
-      -DEXIV2_ENABLE_WIN_UNICODE=ON \
       -DEXIV2_BUILD_SAMPLES=OFF \
       -DEXIV2_ENABLE_WEBREADY=ON \
       -DEXIV2_ENABLE_CURL=ON \
-      -DEXIV2_ENABLE_BMFF=ON \
+      -DPython3_EXECUTABLE=${MINGW_PREFIX}/bin/python.exe \
       ../${_realname}-${pkgver}
 
   ${MINGW_PREFIX}/bin/cmake --build .
@@ -73,13 +76,13 @@ build() {
       -DCMAKE_CXX_FLAGS="-DCURL_STATICLIB" \
       -DCMAKE_C_FLAGS="-DCURL_STATICLIB" \
       -DBUILD_SHARED_LIBS=OFF \
+      -DCONAN_AUTO_INSTALL=OFF \
       -DEXIV2_ENABLE_VIDEO=ON \
       -DEXIV2_ENABLE_NLS=ON \
-      -DEXIV2_ENABLE_WIN_UNICODE=ON \
       -DEXIV2_BUILD_SAMPLES=OFF \
       -DEXIV2_ENABLE_WEBREADY=ON \
       -DEXIV2_ENABLE_CURL=ON \
-      -DEXIV2_ENABLE_BMFF=ON \
+      -DPython3_EXECUTABLE=${MINGW_PREFIX}/bin/python.exe \
       ../${_realname}-${pkgver}
 
   ${MINGW_PREFIX}/bin/cmake --build .

--- a/mingw-w64-gexiv2/PKGBUILD
+++ b/mingw-w64-gexiv2/PKGBUILD
@@ -2,57 +2,63 @@
 
 _realname=gexiv2
 pkgbase=mingw-w64-${_realname}
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.14.1
-pkgrel=1
+pkgrel=2
+pkgdesc="GObject-based wrapper around the Exiv2 library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
-pkgdesc="GObject-based wrapper around the Exiv2 library (mingw-w64)"
+url='https://wiki.gnome.org/Projects/gexiv2'
+license=('spdx:GPL-2.0-or-later')
 depends=("${MINGW_PACKAGE_PREFIX}-glib2"
          "${MINGW_PACKAGE_PREFIX}-exiv2")
 makedepends=("${MINGW_PACKAGE_PREFIX}-meson"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-vala"
              "${MINGW_PACKAGE_PREFIX}-python-gobject"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
              "${MINGW_PACKAGE_PREFIX}-gtk-doc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-cc")
-options=('strip' 'staticlibs')
-license=("LGPL 2.1")
-url="https://wiki.gnome.org/Projects/gexiv2"
-source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz)
-sha256sums=('ec3ee3ec3860b9c78958a55da89cf76ae2305848e12f41945b7b52124d8f6cf9')
+source=("https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz"
+        "https://gitlab.gnome.org/GNOME/gexiv2/-/commit/06adc8fb.patch"
+        "https://gitlab.gnome.org/GNOME/gexiv2/-/merge_requests/78.patch")
+sha256sums=('ec3ee3ec3860b9c78958a55da89cf76ae2305848e12f41945b7b52124d8f6cf9'
+            '10ffd40036948bb3baf6107011d0e0a0062a44f6b3d882935296afd8a1f4d852'
+            '83338b9bbd54c8ffc69688ae8929313a38774053cb68d9b3edf0334d34affc23')
 
 prepare() {
-  cd ${_realname}-${pkgver}
+  cd "${srcdir}"/${_realname}-${pkgver}
 
+  patch -Np1 -i "${srcdir}"/06adc8fb.patch
+  patch -Np1 -i "${srcdir}"/78.patch
 }
 
 build() {
-  [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}
-  mkdir -p build-${MINGW_CHOST}
-  cd build-${MINGW_CHOST}
+  mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
 
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    meson setup \
+      --prefix="${MINGW_PREFIX}" \
+      --wrap-mode=nodownload \
+      --auto-features=enabled \
+      --buildtype=plain \
+      -Dgtk_doc=true \
+      ../${_realname}-${pkgver}
 
-  MSYS2_ARG_CONV_EXCL="--prefix=;-Dpython3_girdir=" \
-  ${MINGW_PREFIX}/bin/meson.exe \
-    --prefix="${MINGW_PREFIX}" \
-    --buildtype plain \
-    -Dcpp_std=c++11 \
-    -Dgtk_doc=true \
-    ../${_realname}-${pkgver}
-
-  ${MINGW_PREFIX}/bin/meson.exe compile
+  meson compile
 }
 
 check() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
-  ${MINGW_PREFIX}/bin/meson.exe test || true
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  meson test || true
 }
 
 package() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/meson.exe install
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  DESTDIR="${pkgdir}" meson install
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-pdf2djvu/PKGBUILD
+++ b/mingw-w64-pdf2djvu/PKGBUILD
@@ -2,14 +2,14 @@
 
 _realname=pdf2djvu
 pkgbase=mingw-w64-${_realname}
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.9.19
-pkgrel=3
+pkgrel=4
 pkgdesc="Creates DjVu files from PDF files (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://jwilk.net/software/pdf2djvu"
-license=('GPL2')
+license=('spdx:GPL-2.0-only')
 depends=("${MINGW_PACKAGE_PREFIX}-poppler"
          "${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-djvulibre"
@@ -31,11 +31,10 @@ validpgpkeys=('CDB5A1243ACDB63009AD07212D4EB3A6015475F5') # Jakub Wilk <jwilk@jw
 noextract=(pdf2djvu-${pkgver}.tar.xz)
 
 prepare() {
-  [[ -d ${_realname}-${pkgver} ]] && rm -rf ${_realname}-${pkgver}
   tar -xf pdf2djvu-${pkgver}.tar.xz || true
   cp ${srcdir}/${_realname}-${pkgver}/tests/test-antialias-off.tex \
      ${srcdir}/${_realname}-${pkgver}/tests/test-antialias-on.tex
-  cd ${srcdir}/${_realname}-${pkgver}
+  cd "${srcdir}/${_realname}-${pkgver}"
 
   patch -p1 -i "${srcdir}/001-cxx17-for-poppler.patch"
 
@@ -43,24 +42,21 @@ prepare() {
 }
 
 build() {
-  [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}
-  cp -rf ${_realname}-${pkgver} build-${MSYSTEM} && cd ${srcdir}/build-${MSYSTEM}
+  cp -rf "${srcdir}/${_realname}-${pkgver}" "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
-  # exiv2 depends on std::auto_ptr which got removed.
-  # should be fixed in exiv2 0.28
-  CXXFLAGS+=" -D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR=1" \
   ./configure \
-      --prefix=${MINGW_PREFIX} \
-      --build=${MINGW_CHOST} \
-      --host=${MINGW_CHOST} \
-      --target=${MINGW_CHOST} \
-      --with-libiconv-prefix=${MINGW_PREFIX}
+    --prefix="${MINGW_PREFIX}" \
+    --build="${MINGW_CHOST}" \
+    --host="${MINGW_CHOST}" \
+    --with-libiconv-prefix="${MINGW_PREFIX}"
+
   make
 }
 
 package() {
   cd "${srcdir}/build-${MSYSTEM}"
-  make DESTDIR=${pkgdir} install
 
-  install -Dm644 ${srcdir}/${_realname}-${pkgver}/doc/COPYING ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING
+  make install DESTDIR="${pkgdir}"
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/doc/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-qgis/PKGBUILD
+++ b/mingw-w64-qgis/PKGBUILD
@@ -3,7 +3,7 @@ _realname=qgis
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.32.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Geographic Information System (GIS) that supports vector, raster & database formats (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -50,13 +50,15 @@ source=("https://qgis.org/downloads/${_realname}-$pkgver.tar.bz2"
         "002-fix-settingstree-init-order-clang.patch"
         "003-fix-pyrcc-command.patch"
         "004-fix-customwidgets-install.patch"
-        "005-fix-build-with-protobuf-23.patch")
+        "005-fix-build-with-protobuf-23.patch"
+        "https://patch-diff.githubusercontent.com/raw/qgis/QGIS/pull/53762.patch")
 sha256sums=('dfc90a6103a3c6020d005dbb68c81caf9a4c11fca4be53bfe070226813f87a9a'
             '8a1c67b3bed1545813044f842cc0f6ff1076849e27379db6f64092014936b4c5'
             'e880eef26fa06d8fae291346f87735e140145c2d65558fce69e480e303c629e2'
             'c0f599996d90da55d1370f7144d545352d0075ca7876d4ade52c520b237ce318'
             '216dc67ef707f2e918afb7d190c9ea75c11065dea0d23d11b94cab5d8463bac3'
-            'ac6c96e88346c1cec739b1e628afb02aef1895c0d09213269bad75b1a8cee617')
+            'ac6c96e88346c1cec739b1e628afb02aef1895c0d09213269bad75b1a8cee617'
+            '9b8937a09854c927722cadd7b7e5be144ab6e419b0f696fe98cbd55fb965e0c5')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
@@ -67,6 +69,7 @@ prepare() {
   patch -p1 -i "${srcdir}"/003-fix-pyrcc-command.patch
   patch -p1 -i "${srcdir}"/004-fix-customwidgets-install.patch
   patch -p1 -i "${srcdir}"/005-fix-build-with-protobuf-23.patch
+  patch -p1 -i "${srcdir}"/53762.patch
 }
 
 build() {
@@ -113,5 +116,8 @@ build() {
 
 package() {
   cd "${srcdir}/build-${MSYSTEM}"
+
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }


### PR DESCRIPTION
This is just a dry run for now.

There are a few more dependencies to patch (or wait for upstream releases) and rebuild:

- krita ([some unreleased patches seem to be in master](https://invent.kde.org/search?search=exiv2&nav_source=navbar&project_id=206&group_id=1566&scope=merge_requests), not tested here yet)
- qgis ([unreleased patch is in master](https://github.com/qgis/QGIS/pull/53762), tested ok here w/ exception of MINGW64 build timing out)

Also, I _think_ [exiv2 0.28 won't work properly on MINGW32 and MINGW64 any longer](https://github.com/Exiv2/exiv2/issues/2637), so I presume a strategy is needed there?