### PR TITLE
PyOpenGL-accelerate 3.1.7

### DIFF
--- a/mingw-w64-python-pyopengl-accelerate/PKGBUILD
+++ b/mingw-w64-python-pyopengl-accelerate/PKGBUILD
@@ -1,10 +1,10 @@
 # Contributor: Mehdi Chinoune <mehdi.chinoune@hotmail.com>
 
 _realname=pyopengl-accelerate
+_pyname=PyOpenGL-accelerate
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=3.1.6
-_commit=227f9c66976d9f5dadf62b9a97e6beaec84831ca # McFletch does not release bundles on GitHub, therefore we use commit hashes to get specific versions
+pkgver=3.1.7
 pkgrel=1
 pkgdesc="Acceleration code for PyOpenGL (mingw-w64)"
 arch=('any')
@@ -15,12 +15,17 @@ depends=("${MINGW_PACKAGE_PREFIX}-python-pyopengl")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-cython"
              "${MINGW_PACKAGE_PREFIX}-cc")
-source=("https://github.com/mcfletch/pyopengl/archive/${_commit}.tar.gz")
-sha256sums=('6b556e5aa2fd6517809e1559593038c99d3318d21155be4de3d18acfef093d40')
+source=("https://files.pythonhosted.org/packages/93/09/d08b3d07dbd88258276496a47273778f330f5ccf8390cb21b16b29d660de/${_pyname}-${pkgver}.tar.gz")
+sha256sums=('2b123621273a939f7fd2ec227541e399f9b5d4e815d69ae0bdb1b6c70a293680')
+
+prepare() {
+  cd "${srcdir}"
+  rm -fr python-build-${MSYSTEM} | true
+  cp -r "${_pyname}-${pkgver}" "python-build-${MSYSTEM}"
+}
 
 build() {
-  cp -r "pyopengl-${_commit}/accelerate" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
-
+  cd "${srcdir}/python-build-${MSYSTEM}"
   "${MINGW_PREFIX}"/bin/python setup.py build
 }
 

--- a/mingw-w64-python-pyopengl-accelerate/PKGBUILD
+++ b/mingw-w64-python-pyopengl-accelerate/PKGBUILD
@@ -15,7 +15,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-python-pyopengl")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-cython"
              "${MINGW_PACKAGE_PREFIX}-cc")
-source=("https://files.pythonhosted.org/packages/93/09/d08b3d07dbd88258276496a47273778f330f5ccf8390cb21b16b29d660de/${_pyname}-${pkgver}.tar.gz")
+source=("https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${pkgver}.tar.gz")
 sha256sums=('2b123621273a939f7fd2ec227541e399f9b5d4e815d69ae0bdb1b6c70a293680')
 
 prepare() {


### PR DESCRIPTION
`PyOpenGL` was updated to 3.1.7 in cd65d1a7efabec69153fc511542a8cdf5f87ce5e but this package was left behind at 3.1.6
The two packages should always be updated in tandem - perhaps a note should be added in `PyOpenGL`?

This PR also switches to using releases from pypi, as those exist, unlike the repository on github.