### PR TITLE
miniupnpc: update to 2.2.5

### DIFF
--- a/mingw-w64-miniupnpc/PKGBUILD
+++ b/mingw-w64-miniupnpc/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=miniupnpc
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-pkgver=2.2.4
+pkgver=2.2.5
 pkgrel=1
 pkgdesc="A small UPnP client library/tool to access Internet Gateway Devices (mingw-w64)"
 arch=('any')
@@ -19,7 +19,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 optdepends=("${MINGW_PACKAGE_PREFIX}-python: Python bindings")
 source=(https://miniupnp.tuxfamily.org/files/${_realname}-${pkgver}.tar.gz{,.sig}
         002-python-module-build.patch)
-sha256sums=('481a5e4aede64e9ef29895b218836c3608d973e77a35b4f228ab1f3629412c4b'
+sha256sums=('38acd5f4602f7cf8bcdc1ec30b2d58db2e9912e5d9f5350dd99b06bfdffb517c'
             'SKIP'
             '79857b7808ece306cfae0bfb6c072a0022aaba1d8624273d51ed4e4fc741509c')
 validpgpkeys=('751E9FF6944A3B36A5432216DB511043A31ACAAF') # miniupnp <miniupnp@free.fr>
@@ -55,8 +55,6 @@ package() {
   cd build-${MSYSTEM}
   DESTDIR=${pkgdir} ${MINGW_PREFIX}/bin/cmake --install .
 
-  install -Dm644 ${srcdir}/${_realname}-${pkgver}/man3/miniupnpc.3 \
-    "${pkgdir}${MINGW_PREFIX}/share/man/man3/miniupnpc.3"
   install -Dm644 ${srcdir}/${_realname}-${pkgver}/LICENSE \
     "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 


### PR DESCRIPTION
man files are now correctly installed with cmake (https://github.com/miniupnp/miniupnp/commit/12f7201abe2e3b7d88aef0b098502bce956a4628)