### PR TITLE
llvm 16.0.5 update (1/3)

### DIFF
--- a/mingw-w64-clang/0006-COFF-Remove-misleading-and-unclear-comments.-NFC.patch
+++ b/mingw-w64-clang/0006-COFF-Remove-misleading-and-unclear-comments.-NFC.patch
@@ -1,0 +1,30 @@
+From 9080f619461f3d68c8126dcde7c6f95dbae75347 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Storsj=C3=B6?= <martin@martin.st>
+Date: Wed, 7 Jun 2023 13:55:21 +0300
+Subject: [PATCH] [COFF] Remove misleading and unclear comments. NFC.
+
+It is not planned that GNU binutils would change this aspect of
+its behaviour wrt how symbol decoration is done.
+
+Differential Revision: https://reviews.llvm.org/D152359
+---
+ include/llvm/Object/COFFModuleDefinition.h | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/include/llvm/Object/COFFModuleDefinition.h b/include/llvm/Object/COFFModuleDefinition.h
+index 8e14dd614..c9d8f4289 100644
+--- a/include/llvm/Object/COFFModuleDefinition.h
++++ b/include/llvm/Object/COFFModuleDefinition.h
+@@ -39,9 +39,6 @@ struct COFFModuleDefinition {
+   uint32_t MinorOSVersion = 0;
+ };
+ 
+-// mingw and wine def files do not mangle _ for x86 which
+-// is a consequence of legacy binutils' dlltool functionality.
+-// This MingwDef flag should be removed once mingw stops this pratice.
+ Expected<COFFModuleDefinition>
+ parseCOFFModuleDefinition(MemoryBufferRef MB, COFF::MachineTypes Machine,
+                           bool MingwDef = false);
+-- 
+2.41.0.windows.1
+

--- a/mingw-w64-clang/0007-llvm-dlltool-Clarify-parameters-simplify-ArgList-usa.patch
+++ b/mingw-w64-clang/0007-llvm-dlltool-Clarify-parameters-simplify-ArgList-usa.patch
@@ -1,0 +1,51 @@
+From 8deeaef0291f3d63900eb3c61dc46625fb24aafb Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Storsj=C3=B6?= <martin@martin.st>
+Date: Wed, 7 Jun 2023 14:13:55 +0300
+Subject: [PATCH] [llvm-dlltool] Clarify parameters, simplify ArgList usage.
+ NFC.
+
+Add comments about unclear bool arguments to functions, switch to
+hasArg instead of getLastArg for cases where we don't need to check
+the argument's value.
+
+Differential Revision: https://reviews.llvm.org/D152360
+---
+ lib/ToolDrivers/llvm-dlltool/DlltoolDriver.cpp | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/lib/ToolDrivers/llvm-dlltool/DlltoolDriver.cpp b/lib/ToolDrivers/llvm-dlltool/DlltoolDriver.cpp
+index fcda61dd1..a5dcf6c1c 100644
+--- a/lib/ToolDrivers/llvm-dlltool/DlltoolDriver.cpp
++++ b/lib/ToolDrivers/llvm-dlltool/DlltoolDriver.cpp
+@@ -166,7 +166,7 @@ int llvm::dlltoolDriverMain(llvm::ArrayRef<const char *> ArgsArr) {
+   }
+ 
+   Expected<COFFModuleDefinition> Def =
+-      parseCOFFModuleDefinition(*MB, Machine, true);
++      parseCOFFModuleDefinition(*MB, Machine, /*MingwDef=*/true);
+ 
+   if (!Def) {
+     llvm::errs() << "error parsing definition\n"
+@@ -197,7 +197,7 @@ int llvm::dlltoolDriverMain(llvm::ArrayRef<const char *> ArgsArr) {
+     }
+   }
+ 
+-  if (Machine == IMAGE_FILE_MACHINE_I386 && Args.getLastArg(OPT_k)) {
++  if (Machine == IMAGE_FILE_MACHINE_I386 && Args.hasArg(OPT_k)) {
+     for (COFFShortExport& E : Def->Exports) {
+       if (!E.AliasTarget.empty() || (!E.Name.empty() && E.Name[0] == '?'))
+         continue;
+@@ -214,8 +214,8 @@ int llvm::dlltoolDriverMain(llvm::ArrayRef<const char *> ArgsArr) {
+     }
+   }
+ 
+-  if (!Path.empty() &&
+-      writeImportLibrary(Def->OutputFile, Path, Def->Exports, Machine, true))
++  if (!Path.empty() && writeImportLibrary(Def->OutputFile, Path, Def->Exports,
++                                          Machine, /*MinGW=*/true))
+     return 1;
+   return 0;
+ }
+-- 
+2.41.0.windows.1
+

--- a/mingw-w64-clang/0008-llvm-dlltool-Ignore-the-temp-prefix-option.patch
+++ b/mingw-w64-clang/0008-llvm-dlltool-Ignore-the-temp-prefix-option.patch
@@ -1,0 +1,44 @@
+From 6540157fe389b3dc46e9a1306370acd79d40c183 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Storsj=C3=B6?= <martin@martin.st>
+Date: Wed, 7 Jun 2023 13:41:15 +0300
+Subject: [PATCH] [llvm-dlltool] Ignore the --temp-prefix option
+
+llvm-dlltool tolerates unknown options as long as they are plain
+flags, but if given the parameter value as a separate argument,
+e.g. "--temp-prefix foo", it fails to ignore it.
+
+Differential Revision: https://reviews.llvm.org/D152361
+---
+ lib/ToolDrivers/llvm-dlltool/Options.td  | 3 +++
+ test/tools/llvm-dlltool/ignored-opts.def | 8 ++++++++
+ 2 files changed, 11 insertions(+)
+ create mode 100644 llvm/test/tools/llvm-dlltool/ignored-opts.def
+
+diff --git a/lib/ToolDrivers/llvm-dlltool/Options.td b/lib/ToolDrivers/llvm-dlltool/Options.td
+index e78182ab8..6da5dc8f5 100644
+--- a/lib/ToolDrivers/llvm-dlltool/Options.td
++++ b/lib/ToolDrivers/llvm-dlltool/Options.td
+@@ -24,3 +24,6 @@ def S_alias: JoinedOrSeparate<["--"], "as">, Alias<S>;
+ 
+ def f: JoinedOrSeparate<["-"], "f">, HelpText<"Assembler Flags">;
+ def f_alias: JoinedOrSeparate<["--"], "as-flags">, Alias<f>;
++
++def t: JoinedOrSeparate<["-"], "t">, HelpText<"Prefix for temporary files (ignored)">;
++def t_alias: JoinedOrSeparate<["--"], "temp-prefix">, Alias<t>;
+diff --git a/test/tools/llvm-dlltool/ignored-opts.def b/test/tools/llvm-dlltool/ignored-opts.def
+new file mode 100644
+index 000000000..6cc05e376
+--- /dev/null
++++ b/test/tools/llvm-dlltool/ignored-opts.def
+@@ -0,0 +1,8 @@
++; RUN: llvm-dlltool -m i386 -d %s -l %t.a --temp-prefix foo
++; RUN: llvm-dlltool -m i386 -d %s -l %t.a --temp-prefix=foo
++; RUN: llvm-dlltool -m i386 -d %s -l %t.a -t foo
++; RUN: llvm-dlltool -m i386 -d %s -l %t.a -tfoo
++
++LIBRARY test.dll
++EXPORTS
++TestFunction
+-- 
+2.41.0.windows.1
+

--- a/mingw-w64-clang/0009-llvm-dlltool-Implement-the-no-leading-underscore-opt.patch
+++ b/mingw-w64-clang/0009-llvm-dlltool-Implement-the-no-leading-underscore-opt.patch
@@ -1,0 +1,148 @@
+From fb19fa2f3dfdd60d42c12ef28467d6f8f5149d6a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Storsj=C3=B6?= <martin@martin.st>
+Date: Wed, 7 Jun 2023 14:11:30 +0300
+Subject: [PATCH] [llvm-dlltool] Implement the --no-leading-underscore option
+
+This requires being able to opt out from adding the leading underscores
+in COFFModuleDefinition. Normally it is added automatically for I386
+type targets. We could either move the decision entirely to all
+callers, letting the caller check the machine type and decide whether
+underscores should be added, or keep the logic mostly as is, but allowing
+opting out from the behaviour on I386.
+
+I went with keeping the interface as is for now.
+
+Differential Revision: https://reviews.llvm.org/D152363
+---
+ include/llvm/Object/COFFModuleDefinition.h    |  2 +-
+ lib/Object/COFFModuleDefinition.cpp           | 17 +++++++++++------
+ .../llvm-dlltool/DlltoolDriver.cpp            |  5 +++--
+ lib/ToolDrivers/llvm-dlltool/Options.td       |  3 +++
+ .../llvm-dlltool/no-leading-underscore.def    | 19 +++++++++++++++++++
+ 5 files changed, 37 insertions(+), 9 deletions(-)
+ create mode 100644 llvm/test/tools/llvm-dlltool/no-leading-underscore.def
+
+diff --git a/include/llvm/Object/COFFModuleDefinition.h b/include/llvm/Object/COFFModuleDefinition.h
+index c9d8f4289..a4ed9978d 100644
+--- a/include/llvm/Object/COFFModuleDefinition.h
++++ b/include/llvm/Object/COFFModuleDefinition.h
+@@ -41,7 +41,7 @@ struct COFFModuleDefinition {
+ 
+ Expected<COFFModuleDefinition>
+ parseCOFFModuleDefinition(MemoryBufferRef MB, COFF::MachineTypes Machine,
+-                          bool MingwDef = false);
++                          bool MingwDef = false, bool AddUnderscores = true);
+ 
+ } // End namespace object.
+ } // End namespace llvm.
+diff --git a/lib/Object/COFFModuleDefinition.cpp b/lib/Object/COFFModuleDefinition.cpp
+index 0666970d5..a33949733 100644
+--- a/lib/Object/COFFModuleDefinition.cpp
++++ b/lib/Object/COFFModuleDefinition.cpp
+@@ -138,8 +138,11 @@ private:
+ 
+ class Parser {
+ public:
+-  explicit Parser(StringRef S, MachineTypes M, bool B)
+-      : Lex(S), Machine(M), MingwDef(B) {}
++  explicit Parser(StringRef S, MachineTypes M, bool B, bool AU)
++      : Lex(S), Machine(M), MingwDef(B), AddUnderscores(AU) {
++    if (Machine != IMAGE_FILE_MACHINE_I386)
++      AddUnderscores = false;
++  }
+ 
+   Expected<COFFModuleDefinition> parse() {
+     do {
+@@ -234,7 +237,7 @@ private:
+       unget();
+     }
+ 
+-    if (Machine == IMAGE_FILE_MACHINE_I386) {
++    if (AddUnderscores) {
+       if (!isDecorated(E.Name, MingwDef))
+         E.Name = (std::string("_").append(E.Name));
+       if (!E.ExtName.empty() && !isDecorated(E.ExtName, MingwDef))
+@@ -279,7 +282,7 @@ private:
+       if (Tok.K == EqualEqual) {
+         read();
+         E.AliasTarget = std::string(Tok.Value);
+-        if (Machine == IMAGE_FILE_MACHINE_I386 && !isDecorated(E.AliasTarget, MingwDef))
++        if (AddUnderscores && !isDecorated(E.AliasTarget, MingwDef))
+           E.AliasTarget = std::string("_").append(E.AliasTarget);
+         continue;
+       }
+@@ -349,12 +352,14 @@ private:
+   MachineTypes Machine;
+   COFFModuleDefinition Info;
+   bool MingwDef;
++  bool AddUnderscores;
+ };
+ 
+ Expected<COFFModuleDefinition> parseCOFFModuleDefinition(MemoryBufferRef MB,
+                                                          MachineTypes Machine,
+-                                                         bool MingwDef) {
+-  return Parser(MB.getBuffer(), Machine, MingwDef).parse();
++                                                         bool MingwDef,
++                                                         bool AddUnderscores) {
++  return Parser(MB.getBuffer(), Machine, MingwDef, AddUnderscores).parse();
+ }
+ 
+ } // namespace object
+diff --git a/lib/ToolDrivers/llvm-dlltool/DlltoolDriver.cpp b/lib/ToolDrivers/llvm-dlltool/DlltoolDriver.cpp
+index a5dcf6c1c..39bb8dd8e 100644
+--- a/lib/ToolDrivers/llvm-dlltool/DlltoolDriver.cpp
++++ b/lib/ToolDrivers/llvm-dlltool/DlltoolDriver.cpp
+@@ -165,8 +165,9 @@ int llvm::dlltoolDriverMain(llvm::ArrayRef<const char *> ArgsArr) {
+     return 1;
+   }
+ 
+-  Expected<COFFModuleDefinition> Def =
+-      parseCOFFModuleDefinition(*MB, Machine, /*MingwDef=*/true);
++  bool AddUnderscores = !Args.hasArg(OPT_no_leading_underscore);
++  Expected<COFFModuleDefinition> Def = parseCOFFModuleDefinition(
++      *MB, Machine, /*MingwDef=*/true, AddUnderscores);
+ 
+   if (!Def) {
+     llvm::errs() << "error parsing definition\n"
+diff --git a/lib/ToolDrivers/llvm-dlltool/Options.td b/lib/ToolDrivers/llvm-dlltool/Options.td
+index 6da5dc8f5..fee408fd0 100644
+--- a/lib/ToolDrivers/llvm-dlltool/Options.td
++++ b/lib/ToolDrivers/llvm-dlltool/Options.td
+@@ -15,6 +15,9 @@ def d_long : JoinedOrSeparate<["--"], "input-def">, Alias<d>;
+ def k: Flag<["-"], "k">, HelpText<"Kill @n Symbol from export">;
+ def k_alias: Flag<["--"], "kill-at">, Alias<k>;
+ 
++def no_leading_underscore: Flag<["--"], "no-leading-underscore">,
++    HelpText<"Don't add leading underscores on symbols">;
++
+ //==============================================================================
+ // The flags below do nothing. They are defined only for dlltool compatibility.
+ //==============================================================================
+diff --git a/test/tools/llvm-dlltool/no-leading-underscore.def b/test/tools/llvm-dlltool/no-leading-underscore.def
+new file mode 100644
+index 000000000..6b78e15d2
+--- /dev/null
++++ b/test/tools/llvm-dlltool/no-leading-underscore.def
+@@ -0,0 +1,19 @@
++; RUN: llvm-dlltool -k -m i386 --input-def %s --output-lib %t.a --no-leading-underscore --kill-at
++; RUN: llvm-readobj %t.a | FileCheck %s
++; RUN: llvm-nm %t.a | FileCheck %s -check-prefix=CHECK-NM
++
++LIBRARY test.dll
++EXPORTS
++func
++alias == func
++DecoratedFunction@4
++
++; CHECK:      Name type: name
++; CHECK-NEXT: Symbol: __imp_func
++; CHECK-NEXT: Symbol: func
++; CHECK:      Name type: undecorate
++; CHECK-NEXT: Symbol: __imp_DecoratedFunction@4
++; CHECK-NEXT: Symbol: DecoratedFunction@4
++
++; CHECK-NM: W alias
++; CHECK-NM: U func
+-- 
+2.41.0.windows.1
+

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -63,6 +63,10 @@ source=("${_url}/llvm-${pkgver}.src.tar.xz"{,.sig}
         "0003-add-pthread-as-system-lib-for-mingw.patch"
         "0004-enable-emutls-for-mingw.patch"
         "0005-Fix-Any-linker-error-with-multiple-compilers.patch"
+        "0006-COFF-Remove-misleading-and-unclear-comments.-NFC.patch"
+        "0007-llvm-dlltool-Clarify-parameters-simplify-ArgList-usa.patch"
+        "0008-llvm-dlltool-Ignore-the-temp-prefix-option.patch"
+        "0009-llvm-dlltool-Implement-the-no-leading-underscore-opt.patch"
         "0101-link-pthread-with-mingw.patch"
         "0102-Rename-flang-new-flang-experimental-exec-to-flang.patch"
         "0303-ignore-new-bfd-options.patch")
@@ -91,6 +95,10 @@ sha256sums=('701b764a182d8ea8fb017b6b5f7f5f1272a29f17c339b838f48de894ffdd4f91'
             '7f0c64cd87b61e894be632f180ae5291e1aa9f1d9d382608f659067eeeda7146'
             'ef2ae12a4d6ac7a52d38bb305818b26c830ae42d14468e4b1913157d998b2137'
             '294756995c1d528f9b5d4b64559edfee151ce0a06bd863a2cafce58a82ce53fd'
+            'b81c6ae4eaa5fba28b5827cf11bc12bd52bddc19018c23d4b193346291e01b73'
+            'de20db3d23020a6e734d87e168c1661a904a88aa32f68d5ef17984753e8eacc8'
+            'd0a1d4309bbe999e2af0ee37361714cb94bb6123145a6cacc2c1482e87ad8e4e'
+            '2f66a5073f17e8cad35aab8c545b34bb3a2263aa693e138b6af6724caeda6d70'
             '715cb8862753854b2d9256e0b70003e2d1f57083d83eaeaf5a095fc72b8a4e26'
             'd4b6d171f3fd878b7a21043824c0477235c7acb6a73115a337295724ff8b0d1c'
             'de631ab199a6fe83b3f695350bffaad067a2f95fc2ba9c8fe57dc85665d3653c')
@@ -131,6 +139,13 @@ prepare() {
     "0001-Fix-GetHostTriple-for-mingw-w64-in-msys.patch" \
     "0002-Revert-CMake-try-creating-symlink-first-on-windows.patch" \
     "0005-Fix-Any-linker-error-with-multiple-compilers.patch"
+
+  # upstream commits 9080f619461f 8deeaef0291f 6540157fe389 fb19fa2f3dfd
+  apply_patch_with_msg \
+    "0006-COFF-Remove-misleading-and-unclear-comments.-NFC.patch" \
+    "0007-llvm-dlltool-Clarify-parameters-simplify-ArgList-usa.patch" \
+    "0008-llvm-dlltool-Ignore-the-temp-prefix-option.patch" \
+    "0009-llvm-dlltool-Implement-the-no-leading-underscore-opt.patch"
 
   if (( ! _clangprefix )); then
     apply_patch_with_msg \

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -23,11 +23,11 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-lld"
          "${MINGW_PACKAGE_PREFIX}-llvm"
          "${MINGW_PACKAGE_PREFIX}-llvm-libs")
-_version=16.0.4
+_version=16.0.5
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
-pkgrel=2
+pkgrel=1
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -72,19 +72,19 @@ source=("${_url}/llvm-${pkgver}.src.tar.xz"{,.sig}
 #0201-0299 -> rt
 #0301-0399 -> lld
 #0401-0499 -> clang-tools-extra
-sha256sums=('28cdf0e409cba177436693e2749e0ab75cd9e83a3fac1a4d35ecd6b8e9aed882'
+sha256sums=('701b764a182d8ea8fb017b6b5f7f5f1272a29f17c339b838f48de894ffdd4f91'
             'SKIP'
-            '56f5797c20834769d4bf6c35b1677cebf31d27ad34d5c9b8d9f0237c1d11b51a'
+            'f4bb3456c415f01e929d96983b851c49d02b595bf4f99edbbfc55626437775a7'
             'SKIP'
-            '38bb941098d5f9227e4c66595920245642dec1c25e94aa80a59c36d7301ea606'
+            '63323e37dac6f7425c6defb1d7f06b830b024223c4a4106df3bbb16602b20f2f'
             'SKIP'
-            '5f9e7ceecb1d10cd6072b59ddde5bea2cb40cd6fbedea51bb10f43ee9a4059c1'
+            '2a5c212e7eb2de78b8c54d1f3d474bfc6330447c3a40944899f3607d0cc91995'
             'SKIP'
-            '83ca029906c887ece7094a484e8dc00ed6005d32b3192272af2cda239b587b53'
+            '0c593d1c23f626dc33caa8bf112868f77126e018b58dd1641f5ae6aa1c2a0ce3'
             'SKIP'
-            '1a366c5f7a7a0efa2f7ede960717f26f5332df28adc9b3c47516a859de2ccf7b'
+            '9400d49acd53a4b8f310de60554a891436db5a19f6f227f99f0de13e4afaaaff'
             'SKIP'
-            '760c72eb27ea0ccb21b1d9d25c2ae7b1fc47fd087a06be036d8ee1ad8e2fbcd7'
+            '0a4bbb8505e95570e529d6b3d5176e93beb3260f061de9001e320d57b59aed59'
             'SKIP'
             'eb03df53671df6627768141b3aaa76abe176a14e5e47911c97bec544387c4aff'
             '5754c357cfc17769e80d95b673d41b1e54616e2487e037d761a1ac8bb28a2849'

--- a/mingw-w64-clang/README-patches.md
+++ b/mingw-w64-clang/README-patches.md
@@ -15,6 +15,10 @@ Legend:
 - `"0003-add-pthread-as-system-lib-for-mingw.patch"` :grey_exclamation:
 - `"0004-enable-emutls-for-mingw.patch"` :grey_exclamation:
 - `"0005-Fix-Any-linker-error-with-multiple-compilers.patch"` :grey_question:
+- `"0006-COFF-Remove-misleading-and-unclear-comments.-NFC.patch"` :arrow_down_small: https://reviews.llvm.org/D152359
+- `"0007-llvm-dlltool-Clarify-parameters-simplify-ArgList-usa.patch"` :arrow_down_small: https://reviews.llvm.org/D152360
+- `"0008-llvm-dlltool-Ignore-the-temp-prefix-option.patch"` :arrow_down_small: https://reviews.llvm.org/D152361
+- `"0009-llvm-dlltool-Implement-the-no-leading-underscore-opt.patch"` :arrow_down_small: https://reviews.llvm.org/D152363
 - `"0101-link-pthread-with-mingw.patch"` :grey_exclamation:
-- `"0301-Add-exceptions-for-Flang-runtime-libraries-on-MinGW.patch"` :upstreamed:
+- `"0102-Rename-flang-new-flang-experimental-exec-to-flang.patch"` :grey_question: https://reviews.llvm.org/D143592
 - `"0303-ignore-new-bfd-options.patch"` :x:

--- a/mingw-w64-libc++/PKGBUILD
+++ b/mingw-w64-libc++/PKGBUILD
@@ -8,7 +8,7 @@ _realname=libc++
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-libunwind")
-_version=16.0.4
+_version=16.0.5
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
@@ -36,15 +36,15 @@ source=("${_url}/libcxx-${pkgver}.src.tar.xz"{,.sig}
         "${_url}/cmake-${pkgver}.src.tar.xz"{,.sig}
         "https://raw.githubusercontent.com/llvm/llvm-project/${_tag}/runtimes/CMakeLists.txt"
         "https://raw.githubusercontent.com/llvm/llvm-project/${_tag}/runtimes/Components.cmake.in")
-sha256sums=('d4e3e1c6432ba3a7ba626cb1406621961290885766638e63d39b048179ac98d7'
+sha256sums=('a2dfbdc932ed4d1e0001a0cbb8566d9d04549bd837e8f56485fc2a0bb4add335'
             'SKIP'
-            '61c22e1754c8efe09f66b23b7b5b94b70d91ca1fbfcefd5e080704b604cec816'
+            '54207748515f843adf8c1e3cbe628208ffe063cebd79429841aa0497a90f070b'
             'SKIP'
-            '5412af4d6bcdbca6444b7c001fa5b83e9910cac496b4005ee1f8744a46502ffc'
+            'e7f65970298a60e9608a9fc55ea9af5e9c8e1bc0dc0067f3e9f10eb3fe3e8986'
             'SKIP'
-            '28cdf0e409cba177436693e2749e0ab75cd9e83a3fac1a4d35ecd6b8e9aed882'
+            '701b764a182d8ea8fb017b6b5f7f5f1272a29f17c339b838f48de894ffdd4f91'
             'SKIP'
-            '1a366c5f7a7a0efa2f7ede960717f26f5332df28adc9b3c47516a859de2ccf7b'
+            '9400d49acd53a4b8f310de60554a891436db5a19f6f227f99f0de13e4afaaaff'
             'SKIP'
             '29b9498389058dc93075d99596b11c655a844d18fafabe9b42fcee5a95d895da'
             'bc0974b6555874d3c24295fe8b99b25aea8086158ee4ab87e9a8709191cc7824')


### PR DESCRIPTION
backport llvm-dlltool patches

These are necessary to be able to bootstrap rust on CLANG* environments
using the upstream *-pc-windows-gnu binaries.  They now call dlltool
with arguments that up to now were not supported by llvm-dlltool.

Also update README-patches.md