### PR TITLE
emacs-pdf-tools-server: update to 1.1.0

### DIFF
--- a/mingw-w64-emacs-pdf-tools-server/PKGBUILD
+++ b/mingw-w64-emacs-pdf-tools-server/PKGBUILD
@@ -3,12 +3,13 @@
 _realname=emacs-pdf-tools-server
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.0.0
+# Issues may arise if not used with the same release of the pdf-tools emacs package
+pkgver=1.1.0
 pkgrel=1
 pkgdesc="Emacs support library for PDF files"
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/vedang/pdf-tools/archive/refs/tags/v${pkgver}.tar.gz")
 noextract=(${_realname}-${pkgver}.tar.gz)
-sha256sums=("b2b3bca06f838c2bc7219e1c1b50acae2b19ebd5af30980cb34211e6a69399cf")
+sha256sums=("bb5badef03e27411e62290d71c9e4657952230b6bd557c8523699d42c30a3866")
 mingw_arch=('mingw64' 'mingw32' 'ucrt64' 'clang64' 'clang32')
 arch=("any")
 url="https://github.com/vedang/pdf-tools"
@@ -40,6 +41,9 @@ prepare() {
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
+  # For vasprintf
+  CFLAGS+=' -D_GNU_SOURCE'
+  
   CXXFLAGS=-std=c++17 ../"${_realname}-${pkgver}"/server/configure \
     --prefix="${MINGW_PREFIX}" \
     --build="${MINGW_CHOST}" \


### PR DESCRIPTION
Two points of note:

- I did not find a way to verify the checksum, as it is not included in the [release](https://github.com/vedang/pdf-tools/releases/tag/v1.1.0) and there doesn't seem to be a way to [view it on Github](https://github.com/orgs/community/discussions/23512). I determined it from my locally downloaded copy. If this causes security concerns, please indicate how I should determine the checksum.
- The binary should be used together with v1.1.0 of the Emacs package as available via [NonGNU ELPA](https://elpa.nongnu.org/nongnu/pdf-tools.html) or [MELPA Stable](https://stable.melpa.org/#/pdf-tools) (the latter of which seems to still be stuck on v1.0.0 though). Discrepancies between the lisp package and the binary can otherwise [cause issues](https://github.com/vedang/pdf-tools/commit/a9c9a12c3ecf2005fa641059368ac8284f507620). I've included this information as a comment in relation to the package version since I didn't find a better place to document this.