### PR TITLE
lua lua51 lua53 luajit: fix broken mintty patch and remove winpty wrappers and dependencies

### DIFF
--- a/mingw-w64-lua/0001-When-running-lua-on-mintty-or-other.patch
+++ b/mingw-w64-lua/0001-When-running-lua-on-mintty-or-other.patch
@@ -1,42 +1,45 @@
-From d40bacb83809e3c02ae915774efdd89478ba3102 Mon Sep 17 00:00:00 2001
-From: Ray Donnelly <mingw.android@gmail.com>
-Date: Mon, 15 Feb 2021 16:22:30 +0100
-Subject: [PATCH 1/3] When running Win32 version of luac on mintty or other
- Cygwin/MSYS terminal emulators, Ag cannot detect Cygwin/MSYS pty and it
- causes some problems.
-
-E.g.
-https://github.com/ggreer/the_silver_searcher/issues/535#issuecomment-70944218
-https://github.com/Alexpux/MSYS2-packages/pull/491
-
-Import a check routine from https://github.com/k-takata/ptycheck .
-
-Copied from a similar patch patch for ag
-
-Credit to: "K.Takata" <kentkt@csc.jp>
----
- src/Makefile   |   2 +-
- src/iscygpty.c | 185 +++++++++++++++++++++++++++++++++++++++++++++++++
- src/iscygpty.h |  41 +++++++++++
- src/lua.c      |   5 ++
- 4 files changed, 232 insertions(+), 1 deletion(-)
- create mode 100644 src/iscygpty.c
- create mode 100644 src/iscygpty.h
-
 diff --git a/src/Makefile b/src/Makefile
-index a99735a..b495b55 100644
+index b771196..15f1a72 100644
 --- a/src/Makefile
 +++ b/src/Makefile
-@@ -33,7 +33,7 @@ CMCFLAGS=
- PLATS= guess aix bsd c89 freebsd generic ios linux linux-readline macosx mingw posix solaris
+@@ -43,7 +43,7 @@ LUA_O=	lua.o
+ LUAC_T=	luac
+ LUAC_O=	luac.o
  
- LUA_A=	liblua.a
--CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o ltm.o lundump.o lvm.o lzio.o
-+CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o ltm.o lundump.o lvm.o lzio.o iscygpty.o
- LIB_O=	lauxlib.o lbaselib.o lcorolib.o ldblib.o liolib.o lmathlib.o loadlib.o loslib.o lstrlib.o ltablib.o lutf8lib.o linit.o
- BASE_O= $(CORE_O) $(LIB_O) $(MYOBJS)
+-ALL_O= $(BASE_O) $(LUA_O) $(LUAC_O)
++ALL_O= $(BASE_O) $(LUA_O) $(LUAC_O) iscygpty.o
+ ALL_T= $(LUA_A) $(LUA_T) $(LUAC_T)
+ ALL_A= $(LUA_A)
  
-diff --git a/src/iscygpty.c b/src/iscygpty.c
+@@ -60,8 +60,8 @@ $(LUA_A): $(BASE_O)
+ 	$(AR) $@ $(BASE_O)
+ 	$(RANLIB) $@
+ 
+-$(LUA_T): $(LUA_O) $(LUA_A)
+-	$(CC) -o $@ $(LDFLAGS) $(LUA_O) $(LUA_A) $(LIBS)
++$(LUA_T): $(LUA_O) iscygpty.o $(LUA_A)
++	$(CC) -o $@ $(LDFLAGS) $(LUA_O) iscygpty.o $(LUA_A) $(LIBS)
+ 
+ $(LUAC_T): $(LUAC_O) $(LUA_A)
+ 	$(CC) -o $@ $(LDFLAGS) $(LUAC_O) $(LUA_A) $(LIBS)
+@@ -158,6 +158,7 @@ lcode.o:
+ 
+ # DO NOT DELETE
+ 
++iscygpty.o: iscygpty.c iscygpty.h
+ lapi.o: lapi.c lprefix.h lua.h luaconf.h lapi.h llimits.h lstate.h \
+  lobject.h ltm.h lzio.h lmem.h ldebug.h ldo.h lfunc.h lgc.h lstring.h \
+  ltable.h lundump.h lvm.h
+@@ -209,7 +210,7 @@ ltable.o: ltable.c lprefix.h lua.h luaconf.h ldebug.h lstate.h lobject.h \
+ ltablib.o: ltablib.c lprefix.h lua.h luaconf.h lauxlib.h lualib.h
+ ltm.o: ltm.c lprefix.h lua.h luaconf.h ldebug.h lstate.h lobject.h \
+  llimits.h ltm.h lzio.h lmem.h ldo.h lgc.h lstring.h ltable.h lvm.h
+-lua.o: lua.c lprefix.h lua.h luaconf.h lauxlib.h lualib.h
++lua.o: lua.c lprefix.h lua.h luaconf.h lauxlib.h lualib.h iscygpty.h
+ luac.o: luac.c lprefix.h lua.h luaconf.h lauxlib.h ldebug.h lstate.h \
+  lobject.h llimits.h ltm.h lzio.h lmem.h lopcodes.h lopnames.h lundump.h
+ lundump.o: lundump.c lprefix.h lua.h luaconf.h ldebug.h lstate.h \
+diff --git b/src/iscygpty.c b/src/iscygpty.c
 new file mode 100644
 index 0000000..722f88f
 --- /dev/null
@@ -227,7 +230,7 @@ index 0000000..722f88f
 +#endif /* _WIN32 */
 +
 +/* vim: set ts=4 sw=4: */
-diff --git a/src/iscygpty.h b/src/iscygpty.h
+diff --git b/src/iscygpty.h b/src/iscygpty.h
 new file mode 100644
 index 0000000..82fd0af
 --- /dev/null
@@ -275,7 +278,7 @@ index 0000000..82fd0af
 +
 +#endif /* _ISCYGPTY_H */
 diff --git a/src/lua.c b/src/lua.c
-index b5b884b..3eb2c33 100644
+index 0ff8845..3f2b9b1 100644
 --- a/src/lua.c
 +++ b/src/lua.c
 @@ -20,6 +20,7 @@
@@ -286,18 +289,20 @@ index b5b884b..3eb2c33 100644
  
  #if !defined(LUA_PROGNAME)
  #define LUA_PROGNAME		"lua"
-@@ -402,7 +403,11 @@ static int handle_luainit (lua_State *L) {
+@@ -402,14 +403,14 @@ static int handle_luainit (lua_State *L) {
  #if defined(LUA_USE_POSIX)	/* { */
  
  #include <unistd.h>
-+#ifdef _WIN32
-+#define lua_stdin_is_tty()	iscygpty(0)
-+#else
- #define lua_stdin_is_tty()	isatty(0)
-+#endif
+-#define lua_stdin_is_tty()	isatty(0)
++#define lua_stdin_is_tty()	isatty(0) || is_cygpty(0)
  
  #elif defined(LUA_USE_WINDOWS)	/* }{ */
  
--- 
-2.30.0.windows.2
-
+ #include <io.h>
+ #include <windows.h>
+ 
+-#define lua_stdin_is_tty()	_isatty(_fileno(stdin))
++#define lua_stdin_is_tty()	_isatty(_fileno(stdin)) || is_cygpty(_fileno(stdin))
+ 
+ #else				/* }{ */
+ 

--- a/mingw-w64-lua/PKGBUILD
+++ b/mingw-w64-lua/PKGBUILD
@@ -7,7 +7,7 @@ _realname=lua
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.4.6
-pkgrel=1
+pkgrel=2
 pkgdesc="A powerful light-weight programming language designed for extending applications. (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -16,24 +16,24 @@ license=('spdx:MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
 source=("${url}/ftp/lua-${pkgver}.tar.gz"
         'lua.pc'
-        '0001-When-running-Win32-version-of-luac-on-mintty-or-othe.patch'
+        '0001-When-running-lua-on-mintty-or-other.patch'
         '0002-Add-Wl-out-implib-liblua.dll.a-to-AR.patch'
         '0003-Fix-LUA_-DIR-for-MSYS2-FHS-layout.patch'
         'link-implib.patch'
         'LICENSE')
 sha256sums=('7d5ea1b9cb6aa0b59ca3dde1c6adcb57ef83a1ba8e5432c0ecd06bf439b3ad88'
             'ca9252633e782b8f85d6a94ea4f6babd4fe30bd759085b373160b1878e36ff78'
-            'd4ada0484dc0e812903269f5cc0e8c13a994d7f640257d17fc26abc60161ad30'
+            '37246417ce7b1d062cb52012c087793c961527e5b6da5318cf573244a477f528'
             '5f0c29865f9645a61ca62b1860f26ffac8b3458bd5e7b7a9c92daae0927a1914'
             '2294a245794fac0ec6a6bae990ca2cb7c77b8426026192b5446480abd2a2fd21'
-            'c325c516628207bf226e4e8bac5d3dcafca523d29fcd46327f49419416f46925'
+            '0e9f1fab745c8d6cd1fe37a32c8bd6cca665692aac5c130237e648abef86f632'
             '142fb08b41a807b192b4b2c166696a1830a1c97967e5099ad0e579bf500e1da4')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   cp "${srcdir}/lua.pc" .
   rm -f src/iscygpty.{c,h} || true
-  patch -p1 -i "${srcdir}/0001-When-running-Win32-version-of-luac-on-mintty-or-othe.patch"
+  patch -p1 -i "${srcdir}/0001-When-running-lua-on-mintty-or-other.patch"
   patch -p1 -i "${srcdir}/0002-Add-Wl-out-implib-liblua.dll.a-to-AR.patch"
   patch -p1 -i "${srcdir}/0003-Fix-LUA_-DIR-for-MSYS2-FHS-layout.patch"
   patch -p1 -i "${srcdir}/link-implib.patch"
@@ -52,18 +52,6 @@ build() {
     STRIP="strip" \
     CC="${CC}" \
     mingw
-
-  # Check we do not encounter:
-  # "stdin is not a tty"
-  set -x
-  echo "print(\"Hello World\")" > hello-world.lua
-  ./src/luac.exe - < hello-world.lua
-  if [[ ! -f luac.out ]]; then
-    echo "ERROR :: luac.exe stdin read failed to create luac.out"
-    return 1
-  fi
-  rm hello-world.lua
-  rm luac.out
 }
 
 package() {

--- a/mingw-w64-lua/link-implib.patch
+++ b/mingw-w64-lua/link-implib.patch
@@ -1,19 +1,21 @@
---- lua-5.4.2/src/Makefile.orig	2021-03-14 15:42:23.960106400 -0700
-+++ lua-5.4.2/src/Makefile	2021-03-14 15:45:16.163223400 -0700
-@@ -33,6 +33,7 @@
+diff --git a/src/Makefile b/src/Makefile
+index 5a1ab3c..f2b778b 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -33,6 +33,7 @@ CMCFLAGS=
  PLATS= guess aix bsd c89 freebsd generic ios linux linux-readline macosx mingw posix solaris
  
  LUA_A=	liblua.a
 +LUA_LA=	liblua.a
- CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o ltm.o lundump.o lvm.o lzio.o iscygpty.o
+ CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o ltm.o lundump.o lvm.o lzio.o
  LIB_O=	lauxlib.o lbaselib.o lcorolib.o ldblib.o liolib.o lmathlib.o loadlib.o loslib.o lstrlib.o ltablib.o lutf8lib.o linit.o
  BASE_O= $(CORE_O) $(LIB_O) $(MYOBJS)
-@@ -61,10 +62,10 @@
+@@ -61,10 +62,10 @@ $(LUA_A): $(BASE_O)
  	$(RANLIB) $@
  
- $(LUA_T): $(LUA_O) $(LUA_A)
--	$(CC) -o $@ $(LDFLAGS) $(LUA_O) $(LUA_A) $(LIBS)
-+	$(CC) -o $@ $(LDFLAGS) $(LUA_O) $(LUA_LA) $(LIBS)
+ $(LUA_T): $(LUA_O) iscygpty.o $(LUA_A)
+-	$(CC) -o $@ $(LDFLAGS) $(LUA_O) iscygpty.o $(LUA_A) $(LIBS)
++	$(CC) -o $@ $(LDFLAGS) $(LUA_O) iscygpty.o $(LUA_LA) $(LIBS)
  
  $(LUAC_T): $(LUAC_O) $(LUA_A)
 -	$(CC) -o $@ $(LDFLAGS) $(LUAC_O) $(LUA_A) $(LIBS)
@@ -21,7 +23,7 @@
  
  test:
  	./$(LUA_T) -v
-@@ -132,7 +133,7 @@
+@@ -132,7 +133,7 @@ Darwin macos macosx:
  	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_MACOSX -DLUA_USE_READLINE" SYSLIBS="-lreadline"
  
  mingw:

--- a/mingw-w64-lua51/0001-When-running-lua-on-mintty-or-other.patch
+++ b/mingw-w64-lua51/0001-When-running-lua-on-mintty-or-other.patch
@@ -1,42 +1,45 @@
-From d40bacb83809e3c02ae915774efdd89478ba3102 Mon Sep 17 00:00:00 2001
-From: Ray Donnelly <mingw.android@gmail.com>
-Date: Mon, 15 Feb 2021 16:22:30 +0100
-Subject: [PATCH 1/3] When running Win32 version of luac on mintty or other
- Cygwin/MSYS terminal emulators, Ag cannot detect Cygwin/MSYS pty and it
- causes some problems.
-
-E.g.
-https://github.com/ggreer/the_silver_searcher/issues/535#issuecomment-70944218
-https://github.com/Alexpux/MSYS2-packages/pull/491
-
-Import a check routine from https://github.com/k-takata/ptycheck .
-
-Copied from a similar patch patch for ag
-
-Credit to: "K.Takata" <kentkt@csc.jp>
----
- src/Makefile   |   2 +-
- src/iscygpty.c | 185 +++++++++++++++++++++++++++++++++++++++++++++++++
- src/iscygpty.h |  41 +++++++++++
- src/lua.c      |   5 ++
- 4 files changed, 232 insertions(+), 1 deletion(-)
- create mode 100644 src/iscygpty.c
- create mode 100644 src/iscygpty.h
-
 diff --git a/src/Makefile b/src/Makefile
-index a99735a..b495b55 100644
+index 7a33916..ed874d8 100644
 --- a/src/Makefile
 +++ b/src/Makefile
-@@ -25,7 +25,7 @@
- LUA_A=	liblua5.1.a
- CORE_O=	lapi.o lcode.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o lmem.o \
- 	lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o ltm.o  \
--	lundump.o lvm.o lzio.o
-+	lundump.o lvm.o lzio.o iscygpty.o
- LIB_O=	lauxlib.o lbaselib.o ldblib.o liolib.o lmathlib.o loslib.o ltablib.o \
- 	lstrlib.o loadlib.o linit.o
+@@ -35,7 +35,7 @@ LUA_O=	lua.o
+ LUAC_T=	luac5.1
+ LUAC_O=	luac.o print.o
  
-diff --git a/src/iscygpty.c b/src/iscygpty.c
+-ALL_O= $(CORE_O) $(LIB_O) $(LUA_O) $(LUAC_O)
++ALL_O= $(CORE_O) $(LIB_O) $(LUA_O) $(LUAC_O) iscygpty.o
+ ALL_T= $(LUA_A) $(LUA_T) $(LUAC_T)
+ ALL_A= $(LUA_A)
+ 
+@@ -51,8 +51,8 @@ $(LUA_A): $(CORE_O) $(LIB_O)
+ 	$(AR) $@ $(CORE_O) $(LIB_O)	# DLL needs all object files
+ 	$(RANLIB) $@
+ 
+-$(LUA_T): $(LUA_O) $(LUA_A)
+-	$(CC) -o $@ $(MYLDFLAGS) $(LUA_O) $(LUA_A) $(LIBS)
++$(LUA_T): $(LUA_O) iscygpty.o $(LUA_A)
++	$(CC) -o $@ $(MYLDFLAGS) $(LUA_O) iscygpty.o $(LUA_A) $(LIBS)
+ 
+ $(LUAC_T): $(LUAC_O) $(LUA_A)
+ 	$(CC) -o $@ $(MYLDFLAGS) $(LUAC_O) $(LUA_A) $(LIBS)
+@@ -120,6 +120,7 @@ solaris:
+ 
+ # DO NOT DELETE
+ 
++iscygpty.o: iscygpty.c iscygpty.h
+ lapi.o: lapi.c lua.h luaconf.h lapi.h lobject.h llimits.h ldebug.h \
+   lstate.h ltm.h lzio.h lmem.h ldo.h lfunc.h lgc.h lstring.h ltable.h \
+   lundump.h lvm.h
+@@ -166,7 +167,7 @@ ltable.o: ltable.c lua.h luaconf.h ldebug.h lstate.h lobject.h llimits.h \
+ ltablib.o: ltablib.c lua.h luaconf.h lauxlib.h lualib.h
+ ltm.o: ltm.c lua.h luaconf.h lobject.h llimits.h lstate.h ltm.h lzio.h \
+   lmem.h lstring.h lgc.h ltable.h
+-lua.o: lua.c lua.h luaconf.h lauxlib.h lualib.h
++lua.o: lua.c lua.h luaconf.h lauxlib.h lualib.h iscygpty.h
+ luac.o: luac.c lua.h luaconf.h lauxlib.h ldo.h lobject.h llimits.h \
+   lstate.h ltm.h lzio.h lmem.h lfunc.h lopcodes.h lstring.h lgc.h \
+   lundump.h
+diff --git b/src/iscygpty.c b/src/iscygpty.c
 new file mode 100644
 index 0000000..722f88f
 --- /dev/null
@@ -227,7 +230,7 @@ index 0000000..722f88f
 +#endif /* _WIN32 */
 +
 +/* vim: set ts=4 sw=4: */
-diff --git a/src/iscygpty.h b/src/iscygpty.h
+diff --git b/src/iscygpty.h b/src/iscygpty.h
 new file mode 100644
 index 0000000..82fd0af
 --- /dev/null
@@ -275,21 +278,22 @@ index 0000000..82fd0af
 +
 +#endif /* _ISCYGPTY_H */
 diff --git a/src/luaconf.h b/src/luaconf.h
+index e2cb261..5b0c72b 100644
 --- a/src/luaconf.h
 +++ b/src/luaconf.h
-@@ -226,7 +226,12 @@
+@@ -226,11 +226,13 @@
  */
  #if defined(LUA_USE_ISATTY)
  #include <unistd.h>
-+#ifdef _WIN32
+-#define lua_stdin_is_tty()	isatty(0)
 +#include "iscygpty.h"
-+#define lua_stdin_is_tty()	iscygpty(0)
-+#else
- #define lua_stdin_is_tty()	isatty(0)
-+#endif
++#define lua_stdin_is_tty()	isatty(0) || is_cygpty(0)
  #elif defined(LUA_WIN)
  #include <io.h>
  #include <stdio.h>
-
--- 
-2.30.0.windows.2
+-#define lua_stdin_is_tty()	_isatty(_fileno(stdin))
++#include "iscygpty.h"
++#define lua_stdin_is_tty()	_isatty(_fileno(stdin)) || is_cygpty(_fileno(stdin))
+ #else
+ #define lua_stdin_is_tty()	1  /* assume stdin is a tty */
+ #endif

--- a/mingw-w64-lua51/PKGBUILD
+++ b/mingw-w64-lua51/PKGBUILD
@@ -6,25 +6,24 @@ _realname=lua51
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.1.5
-pkgrel=5
+pkgrel=6
 pkgdesc="A powerful light-weight programming language designed for extending applications. Version 5.1.x (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://www.lua.org/"
 license=('MIT')
-depends=('winpty')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
 options=('staticlibs' 'strip' 'emptydirs')
 source=("${url}/ftp/lua-${pkgver}.tar.gz"
-        '0001-When-running-Win32-version-of-luac-on-mintty-or-othe.patch'
+        '0001-When-running-lua-on-mintty-or-other.patch'
         '0002-Add-Wl-out-implib-liblua.dll.a-to-AR.patch'
         '0003-Fix-LUA_-DIR-for-MSYS2-FHS-layout.patch'
         'link-implib.patch')
 sha256sums=('2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333'
-            '6254b73bb5fb825ce7f65d2de88209722925ac8633efd88d8804a3c59a66a159'
+            'c4ec5b93ee9d0025db9c68a1f795e1065d46ba429d1c1abb521d2629140281a4'
             'd7b455d7b5caed9f3870d0bcc726c724e8b1d8e3f0cae8578bb2148939ffe0a2'
             '799f9d7d033dc401fad86e1c0accc7d2ce187b9caacb9f565468c30a5d22dd38'
-            'bb3568292d5cc91e923274a434a974379e9a8f8fcee222439aebdd1fa92776bb')
+            '0dbc3265b6c5270e213fdf3a37beb810bbbf077a8fefc8c886f34a616e9ebd8f')
 
 prepare() {
   cd "${srcdir}/lua-${pkgver}"
@@ -36,7 +35,7 @@ prepare() {
     -e 's/luac.exe/luac5.1.exe/' \
     -i src/Makefile
   rm -f src/iscygpty.{c,h} || true
-  patch -p1 -i "${srcdir}/0001-When-running-Win32-version-of-luac-on-mintty-or-othe.patch"
+  patch -p1 -i "${srcdir}/0001-When-running-lua-on-mintty-or-other.patch"
   patch -p1 -i "${srcdir}/0002-Add-Wl-out-implib-liblua.dll.a-to-AR.patch"
   patch -p1 -i "${srcdir}/0003-Fix-LUA_-DIR-for-MSYS2-FHS-layout.patch"
   patch -p1 -i "${srcdir}/link-implib.patch"
@@ -57,18 +56,6 @@ build() {
     STRIP="strip" \
     CC="${CC}" \
     mingw
-
-  # Check we do not encounter:
-  # "stdin is not a tty"
-  set -x
-  echo "print(\"Hello World\")" > hello-world.lua
-  ./src/luac5.1.exe - < hello-world.lua
-  if [[ ! -f luac.out ]]; then
-    echo "ERROR :: luac5.1.exe stdin read failed to create luac.out"
-    return 1
-  fi
-  rm hello-world.lua
-  rm luac.out
 }
 
 package() {

--- a/mingw-w64-lua51/link-implib.patch
+++ b/mingw-w64-lua51/link-implib.patch
@@ -1,19 +1,21 @@
---- lua-5.4.2/src/Makefile.orig	2021-03-14 15:42:23.960106400 -0700
-+++ lua-5.4.2/src/Makefile	2021-03-14 15:45:16.163223400 -0700
-@@ -23,6 +23,7 @@
+diff --git a/src/Makefile b/src/Makefile
+index 23670a4..47d2fe7 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -23,6 +23,7 @@ MYLIBS=
  PLATS= aix ansi bsd freebsd generic linux macosx mingw posix solaris
  
  LUA_A=	liblua5.1.a
 +LUA_LA=	liblua5.1.a
  CORE_O=	lapi.o lcode.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o lmem.o \
  	lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o ltm.o  \
- 	lundump.o lvm.o lzio.o iscygpty.o
-@@ -52,10 +53,10 @@
+ 	lundump.o lvm.o lzio.o
+@@ -52,10 +53,10 @@ $(LUA_A): $(CORE_O) $(LIB_O)
  	$(RANLIB) $@
  
- $(LUA_T): $(LUA_O) $(LUA_A)
--	$(CC) -o $@ $(MYLDFLAGS) $(LUA_O) $(LUA_A) $(LIBS)
-+	$(CC) -o $@ $(MYLDFLAGS) $(LUA_O) $(LUA_LA) $(LIBS)
+ $(LUA_T): $(LUA_O) iscygpty.o $(LUA_A)
+-	$(CC) -o $@ $(MYLDFLAGS) $(LUA_O) iscygpty.o $(LUA_A) $(LIBS)
++	$(CC) -o $@ $(MYLDFLAGS) $(LUA_O) iscygpty.o $(LUA_LA) $(LIBS)
  
  $(LUAC_T): $(LUAC_O) $(LUA_A)
 -	$(CC) -o $@ $(MYLDFLAGS) $(LUAC_O) $(LUA_A) $(LIBS)
@@ -21,7 +23,7 @@
  
  clean:
  	$(RM) $(ALL_T) $(ALL_O)
-@@ -104,7 +105,7 @@
+@@ -104,7 +105,7 @@ macosx:
  #	$(MAKE) all MYCFLAGS=-DLUA_USE_MACOSX
  
  mingw:

--- a/mingw-w64-lua53/PKGBUILD
+++ b/mingw-w64-lua53/PKGBUILD
@@ -7,24 +7,25 @@ _realname=lua53
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.3.6
-pkgrel=3
+pkgrel=4
 pkgdesc="A powerful light-weight programming language designed for extending applications. Version 5.3.x (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
 url="https://www.lua.org/"
 license=('MIT')
-depends=('winpty')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
 options=('staticlibs' 'strip' 'emptydirs')
 source=("${url}/ftp/lua-${pkgver}.tar.gz"
         'lua.pc'
+        'cygpty.patch'
         'searchpath.patch'
         'implib.patch'
         'LICENSE')
 sha256sums=('fc5fd69bb8736323f026672b1b7235da613d7177e72558893a0bdcd320466d60'
             'ca9252633e782b8f85d6a94ea4f6babd4fe30bd759085b373160b1878e36ff78'
+            '98d2ea184c151236747003f2d2afd0da71d1875d2868e3ac7358b5cf4925cd2b'
             '40e1d39f289d65e1b689b741689ab6a83bcfb4264f8b2d0d550f96ab3072bb24'
-            '744cb6bf6fb96ef65ee103d917eac679c983b6c02b7e643ba5b985d41b86aa87'
+            '86daf43473959330706c7992fda2a7d67c849b3591eca8ca2f527d61328a9c75'
             '142fb08b41a807b192b4b2c166696a1830a1c97967e5099ad0e579bf500e1da4')
 
 prepare() {
@@ -36,7 +37,9 @@ prepare() {
     -e 's/luac.exe/luac5.3.exe/' \
     -e 's/luac.exe/luac5.3.exe/' \
     -i src/Makefile
-  patch -p0 -i "${srcdir}/implib.patch"
+  rm -f src/iscygpty.{c,h} || true
+  patch -p1 -i "${srcdir}/cygpty.patch"
+  patch -p1 -i "${srcdir}/implib.patch"
   patch -p1 -i "${srcdir}/searchpath.patch"
 }
 
@@ -50,7 +53,7 @@ build() {
     -e "s|/usr|${MINGW_PREFIX}|g" \
     -i lua.pc
 
-  make -j1 \
+  make \
     AR="ar rcu" \
     RANLIB="ranlib" \
     STRIP="strip" \
@@ -67,21 +70,6 @@ package() {
     INSTALL_INC="${pkgdir}${MINGW_PREFIX}"/include/lua5.3 \
     INSTALL_MAN="${pkgdir}${MINGW_PREFIX}"/share/man/man1 \
     install
-
-  # Use winpty to wrap the exe when executed from bash. Please don't move this into a patch as hopefully one day we won't need this hack.
-  local _exename="lua5.3"
-  local _execname="luac5.3"
-  #handle lua.exe and make lua script and symlink equivilant
-  mv "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}.exe "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}_exe
-  echo "#!/usr/bin/env bash" > "${pkgdir}${MINGW_PREFIX}/bin/${_exename}"
-  echo '/usr/bin/winpty "$( dirname ${BASH_SOURCE[0]} )/'${_exename}'.exe" "$@"' >> "${pkgdir}${MINGW_PREFIX}/bin/${_exename}"
-  mv "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}_exe "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}.exe
-
-  #handle luac.exe and make luac script and symlink equivilant
-  mv "${pkgdir}"${MINGW_PREFIX}/bin/${_execname}.exe "${pkgdir}"${MINGW_PREFIX}/bin/${_execname}_exe
-  echo "#!/usr/bin/env bash" > "${pkgdir}${MINGW_PREFIX}/bin/${_execname}"
-  echo '/usr/bin/winpty "$( dirname ${BASH_SOURCE[0]} )/'${_execname}'.exe" "$@"' >> "${pkgdir}${MINGW_PREFIX}/bin/${_execname}"
-  mv "${pkgdir}"${MINGW_PREFIX}/bin/${_execname}_exe "${pkgdir}"${MINGW_PREFIX}/bin/${_execname}.exe
 
   install -Dm644 lua.pc "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/lua5.3.pc
 

--- a/mingw-w64-lua53/cygpty.patch
+++ b/mingw-w64-lua53/cygpty.patch
@@ -1,0 +1,308 @@
+diff --git a/src/Makefile b/src/Makefile
+index 25533d0..87449a6 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -42,7 +42,7 @@ LUA_O=	lua.o
+ LUAC_T=	luac5.3
+ LUAC_O=	luac.o
+ 
+-ALL_O= $(BASE_O) $(LUA_O) $(LUAC_O)
++ALL_O= $(BASE_O) $(LUA_O) $(LUAC_O) iscygpty.o
+ ALL_T= $(LUA_A) $(LUA_T) $(LUAC_T)
+ ALL_A= $(LUA_A)
+ 
+@@ -59,8 +59,8 @@ $(LUA_A): $(BASE_O)
+ 	$(AR) $@ $(BASE_O)
+ 	$(RANLIB) $@
+ 
+-$(LUA_T): $(LUA_O) $(LUA_A)
+-	$(CC) -o $@ $(LDFLAGS) $(LUA_O) $(LUA_A) $(LIBS)
++$(LUA_T): $(LUA_O) iscygpty.o $(LUA_A)
++	$(CC) -o $@ $(LDFLAGS) $(LUA_O) iscygpty.o $(LUA_A) $(LIBS)
+ 
+ $(LUAC_T): $(LUAC_O) $(LUA_A)
+ 	$(CC) -o $@ $(LDFLAGS) $(LUAC_O) $(LUA_A) $(LIBS)
+@@ -129,6 +129,7 @@ solaris:
+ 
+ # DO NOT DELETE
+ 
++iscygpty.o: iscygpty.c iscygpty.h
+ lapi.o: lapi.c lprefix.h lua.h luaconf.h lapi.h llimits.h lstate.h \
+  lobject.h ltm.h lzio.h lmem.h ldebug.h ldo.h lfunc.h lgc.h lstring.h \
+  ltable.h lundump.h lvm.h
+@@ -181,7 +182,7 @@ ltable.o: ltable.c lprefix.h lua.h luaconf.h ldebug.h lstate.h lobject.h \
+ ltablib.o: ltablib.c lprefix.h lua.h luaconf.h lauxlib.h lualib.h
+ ltm.o: ltm.c lprefix.h lua.h luaconf.h ldebug.h lstate.h lobject.h \
+  llimits.h ltm.h lzio.h lmem.h ldo.h lstring.h lgc.h ltable.h lvm.h
+-lua.o: lua.c lprefix.h lua.h luaconf.h lauxlib.h lualib.h
++lua.o: lua.c lprefix.h lua.h luaconf.h lauxlib.h lualib.h iscygpty.h
+ luac.o: luac.c lprefix.h lua.h luaconf.h lauxlib.h lobject.h llimits.h \
+  lstate.h ltm.h lzio.h lmem.h lundump.h ldebug.h lopcodes.h
+ lundump.o: lundump.c lprefix.h lua.h luaconf.h ldebug.h lstate.h \
+diff --git b/src/iscygpty.c b/src/iscygpty.c
+new file mode 100644
+index 0000000..722f88f
+--- /dev/null
++++ b/src/iscygpty.c
+@@ -0,0 +1,185 @@
++/*
++ * iscygpty.c -- part of ptycheck
++ * https://github.com/k-takata/ptycheck
++ *
++ * Copyright (c) 2015-2017 K.Takata
++ *
++ * You can redistribute it and/or modify it under the terms of either
++ * the MIT license (as described below) or the Vim license.
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining
++ * a copy of this software and associated documentation files (the
++ * "Software"), to deal in the Software without restriction, including
++ * without limitation the rights to use, copy, modify, merge, publish,
++ * distribute, sublicense, and/or sell copies of the Software, and to
++ * permit persons to whom the Software is furnished to do so, subject to
++ * the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be
++ * included in all copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
++ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
++ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++#ifdef _WIN32
++
++#include <ctype.h>
++#include <io.h>
++#include <wchar.h>
++#include <windows.h>
++
++#ifdef USE_FILEEXTD
++/* VC 7.1 or earlier doesn't support SAL. */
++# if !defined(_MSC_VER) || (_MSC_VER < 1400)
++#  define __out
++#  define __in
++#  define __in_opt
++# endif
++/* Win32 FileID API Library:
++ * http://www.microsoft.com/en-us/download/details.aspx?id=22599
++ * Needed for WinXP. */
++# include <fileextd.h>
++#else /* USE_FILEEXTD */
++/* VC 8 or earlier. */
++# if defined(_MSC_VER) && (_MSC_VER < 1500)
++#  ifdef ENABLE_STUB_IMPL
++#   define STUB_IMPL
++#  else
++#   error "Win32 FileID API Library is required for VC2005 or earlier."
++#  endif
++# endif
++#endif /* USE_FILEEXTD */
++
++
++#include "iscygpty.h"
++
++//#define USE_DYNFILEID
++#ifdef USE_DYNFILEID
++typedef BOOL (WINAPI *pfnGetFileInformationByHandleEx)(
++		HANDLE                    hFile,
++		FILE_INFO_BY_HANDLE_CLASS FileInformationClass,
++		LPVOID                    lpFileInformation,
++		DWORD                     dwBufferSize
++);
++static pfnGetFileInformationByHandleEx pGetFileInformationByHandleEx = NULL;
++
++# ifndef USE_FILEEXTD
++static BOOL WINAPI stub_GetFileInformationByHandleEx(
++		HANDLE                    hFile,
++		FILE_INFO_BY_HANDLE_CLASS FileInformationClass,
++		LPVOID                    lpFileInformation,
++		DWORD                     dwBufferSize
++		)
++{
++	return FALSE;
++}
++# endif
++
++static void setup_fileid_api(void)
++{
++	if (pGetFileInformationByHandleEx != NULL) {
++		return;
++	}
++	pGetFileInformationByHandleEx = (pfnGetFileInformationByHandleEx)
++		GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")),
++				"GetFileInformationByHandleEx");
++	if (pGetFileInformationByHandleEx == NULL) {
++# ifdef USE_FILEEXTD
++		pGetFileInformationByHandleEx = GetFileInformationByHandleEx;
++# else
++		pGetFileInformationByHandleEx = stub_GetFileInformationByHandleEx;
++# endif
++	}
++}
++#else
++# define pGetFileInformationByHandleEx	GetFileInformationByHandleEx
++# define setup_fileid_api()
++#endif
++
++
++#define is_wprefix(s, prefix) \
++	(wcsncmp((s), (prefix), sizeof(prefix) / sizeof(WCHAR) - 1) == 0)
++
++/* Check if the fd is a cygwin/msys's pty. */
++int is_cygpty(int fd)
++{
++#ifdef STUB_IMPL
++	return 0;
++#else
++	HANDLE h;
++	int size = sizeof(FILE_NAME_INFO) + sizeof(WCHAR) * (MAX_PATH - 1);
++	FILE_NAME_INFO *nameinfo;
++	WCHAR *p = NULL;
++
++	setup_fileid_api();
++
++	h = (HANDLE) _get_osfhandle(fd);
++	if (h == INVALID_HANDLE_VALUE) {
++		return 0;
++	}
++	/* Cygwin/msys's pty is a pipe. */
++	if (GetFileType(h) != FILE_TYPE_PIPE) {
++		return 0;
++	}
++	nameinfo = malloc(size + sizeof(WCHAR));
++	if (nameinfo == NULL) {
++		return 0;
++	}
++	/* Check the name of the pipe:
++	 * '\{cygwin,msys}-XXXXXXXXXXXXXXXX-ptyN-{from,to}-master' */
++	if (pGetFileInformationByHandleEx(h, FileNameInfo, nameinfo, size)) {
++		nameinfo->FileName[nameinfo->FileNameLength / sizeof(WCHAR)] = L'\0';
++		p = nameinfo->FileName;
++		if (is_wprefix(p, L"\\cygwin-")) {		/* Cygwin */
++			p += 8;
++		} else if (is_wprefix(p, L"\\msys-")) {	/* MSYS and MSYS2 */
++			p += 6;
++		} else {
++			p = NULL;
++		}
++		if (p != NULL) {
++			while (*p && isxdigit(*p))	/* Skip 16-digit hexadecimal. */
++				++p;
++			if (is_wprefix(p, L"-pty")) {
++				p += 4;
++			} else {
++				p = NULL;
++			}
++		}
++		if (p != NULL) {
++			while (*p && isdigit(*p))	/* Skip pty number. */
++				++p;
++			if (is_wprefix(p, L"-from-master")) {
++				//p += 12;
++			} else if (is_wprefix(p, L"-to-master")) {
++				//p += 10;
++			} else {
++				p = NULL;
++			}
++		}
++	}
++	free(nameinfo);
++	return (p != NULL);
++#endif /* STUB_IMPL */
++}
++
++/* Check if at least one cygwin/msys pty is used. */
++int is_cygpty_used(void)
++{
++	int fd, ret = 0;
++
++	for (fd = 0; fd < 3; fd++) {
++		ret |= is_cygpty(fd);
++	}
++	return ret;
++}
++
++#endif /* _WIN32 */
++
++/* vim: set ts=4 sw=4: */
+diff --git b/src/iscygpty.h b/src/iscygpty.h
+new file mode 100644
+index 0000000..82fd0af
+--- /dev/null
++++ b/src/iscygpty.h
+@@ -0,0 +1,41 @@
++/*
++ * iscygpty.h -- part of ptycheck
++ * https://github.com/k-takata/ptycheck
++ *
++ * Copyright (c) 2015-2017 K.Takata
++ *
++ * You can redistribute it and/or modify it under the terms of either
++ * the MIT license (as described below) or the Vim license.
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining
++ * a copy of this software and associated documentation files (the
++ * "Software"), to deal in the Software without restriction, including
++ * without limitation the rights to use, copy, modify, merge, publish,
++ * distribute, sublicense, and/or sell copies of the Software, and to
++ * permit persons to whom the Software is furnished to do so, subject to
++ * the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be
++ * included in all copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
++ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
++ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++#ifndef _ISCYGPTY_H
++#define _ISCYGPTY_H
++
++#ifdef _WIN32
++int is_cygpty(int fd);
++int is_cygpty_used(void);
++#else
++#define is_cygpty(fd)		0
++#define is_cygpty_used()	0
++#endif
++
++#endif /* _ISCYGPTY_H */
+diff --git a/src/lua.c b/src/lua.c
+index ca5b298..7d4f633 100644
+--- a/src/lua.c
++++ b/src/lua.c
+@@ -19,6 +19,7 @@
+ #include "lauxlib.h"
+ #include "lualib.h"
+ 
++#include "iscygpty.h"
+ 
+ 
+ #if !defined(LUA_PROMPT)
+@@ -50,14 +51,14 @@
+ #if defined(LUA_USE_POSIX)	/* { */
+ 
+ #include <unistd.h>
+-#define lua_stdin_is_tty()	isatty(0)
++#define lua_stdin_is_tty()	isatty(0) || is_cygpty(0)
+ 
+ #elif defined(LUA_USE_WINDOWS)	/* }{ */
+ 
+ #include <io.h>
+ #include <windows.h>
+ 
+-#define lua_stdin_is_tty()	_isatty(_fileno(stdin))
++#define lua_stdin_is_tty()	_isatty(_fileno(stdin)) || is_cygpty(_fileno(stdin))
+ 
+ #else				/* }{ */
+ 

--- a/mingw-w64-lua53/implib.patch
+++ b/mingw-w64-lua53/implib.patch
@@ -1,11 +1,36 @@
---- src/Makefile.orig	2023-02-15 08:58:22.205723900 +0100
-+++ src/Makefile	2023-02-15 09:01:51.544746000 +0100
-@@ -114,7 +114,7 @@
+diff --git a/src/Makefile b/src/Makefile
+index 87449a6..9a78736 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -29,6 +29,7 @@ MYOBJS=
+ PLATS= aix bsd c89 freebsd generic linux macosx mingw posix solaris
+ 
+ LUA_A=	liblua5.3.a
++LUA_LA=	liblua5.3.a
+ CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o \
+ 	lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o \
+ 	ltm.o lundump.o lvm.o lzio.o
+@@ -60,10 +61,10 @@ $(LUA_A): $(BASE_O)
+ 	$(RANLIB) $@
+ 
+ $(LUA_T): $(LUA_O) iscygpty.o $(LUA_A)
+-	$(CC) -o $@ $(LDFLAGS) $(LUA_O) iscygpty.o $(LUA_A) $(LIBS)
++	$(CC) -o $@ $(LDFLAGS) $(LUA_O) iscygpty.o $(LUA_LA) $(LIBS)
+ 
+ $(LUAC_T): $(LUAC_O) $(LUA_A)
+-	$(CC) -o $@ $(LDFLAGS) $(LUAC_O) $(LUA_A) $(LIBS)
++	$(CC) -o $@ $(LDFLAGS) $(LUAC_O) $(LUA_LA) $(LIBS)
+ 
+ clean:
+ 	$(RM) $(ALL_T) $(ALL_O)
+@@ -113,8 +114,8 @@ macosx:
+ 	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_MACOSX" SYSLIBS="-lreadline"
  
  mingw:
- 	$(MAKE) "LUA_A=lua53.dll" "LUA_T=lua5.3.exe" \
+-	$(MAKE) "LUA_A=lua53.dll" "LUA_T=lua5.3.exe" \
 -	"AR=$(CC) -shared -o" "RANLIB=strip --strip-unneeded" \
++	$(MAKE) "LUA_A=lua53.dll" "LUA_LA=liblua5.3.dll.a" "LUA_T=lua5.3.exe" \
 +	"AR=$(CC) -shared -Wl,--out-implib=liblua5.3.dll.a -o" "RANLIB=strip --strip-unneeded" \
  	"SYSCFLAGS=-DLUA_BUILD_AS_DLL" "SYSLIBS=" "SYSLDFLAGS=-s" lua5.3.exe
- 	$(MAKE) "LUAC_T=luac5.3.exe" luac.exe
+ 	$(MAKE) "LUAC_T=luac5.3.exe" luac5.3.exe
  

--- a/mingw-w64-luajit/001-mintty-cygpty-isatty.patch
+++ b/mingw-w64-luajit/001-mintty-cygpty-isatty.patch
@@ -1,0 +1,306 @@
+diff --git a/src/Makefile b/src/Makefile
+index 30d64be..bfa2231 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -624,6 +624,7 @@ depend:
+ 	@$(HOST_CC) $(HOST_ACFLAGS) -MM *.c host/*.c | \
+ 	  sed -e "s| [^ ]*/dasm_\S*\.h||g" \
+ 	      -e "s|^\([^l ]\)|host/\1|" \
++	      -e "s|host/iscygpty|iscygpty|" \
+ 	      -e "s| lj_target_\S*\.h| lj_target_*.h|g" \
+ 	      -e "s| lj_emit_\S*\.h| lj_emit_*.h|g" \
+ 	      -e "s| lj_asm_\S*\.h| lj_asm_*.h|g" >Makefile.dep
+@@ -717,9 +718,9 @@ $(LUAJIT_SO): $(LJVMCORE_O)
+ 	$(Q)$(TARGET_LD) $(TARGET_ASHLDFLAGS) -o $@ $(LJVMCORE_DYNO) $(TARGET_ALIBS)
+ 	$(Q)$(TARGET_STRIP) $@
+ 
+-$(LUAJIT_T): $(TARGET_O) $(LUAJIT_O) $(TARGET_DEP)
++$(LUAJIT_T): $(TARGET_O) $(LUAJIT_O) iscygpty.o $(TARGET_DEP)
+ 	$(E) "LINK      $@"
+-	$(Q)$(TARGET_LD) $(TARGET_ALDFLAGS) -o $@ $(LUAJIT_O) $(TARGET_O) $(TARGET_ALIBS)
++	$(Q)$(TARGET_LD) $(TARGET_ALDFLAGS) -o $@ $(LUAJIT_O) iscygpty.o $(TARGET_O) $(TARGET_ALIBS)
+ 	$(Q)$(TARGET_STRIP) $@
+ 	$(E) "OK        Successfully built LuaJIT"
+ 
+diff --git a/src/Makefile.dep b/src/Makefile.dep
+index 400ef8b..4734a23 100644
+--- a/src/Makefile.dep
++++ b/src/Makefile.dep
+@@ -1,3 +1,4 @@
++iscygpty.o: iscygpty.c iscygpty.h
+ lib_aux.o: lib_aux.c lua.h luaconf.h lauxlib.h lj_obj.h lj_def.h \
+  lj_arch.h lj_err.h lj_errmsg.h lj_state.h lj_trace.h lj_jit.h lj_ir.h \
+  lj_dispatch.h lj_bc.h lj_traceerr.h lj_lib.h lj_vmevent.h
+@@ -241,7 +242,8 @@ ljamalg.o: ljamalg.c lua.h luaconf.h lauxlib.h lj_assert.c lj_obj.h \
+  lib_aux.c lib_base.c lj_libdef.h lib_math.c lib_string.c lib_table.c \
+  lib_io.c lib_os.c lib_package.c lib_debug.c lib_bit.c lib_jit.c \
+  lib_ffi.c lib_buffer.c lib_init.c
+-luajit.o: luajit.c lua.h luaconf.h lauxlib.h lualib.h luajit.h lj_arch.h
++luajit.o: luajit.c lua.h luaconf.h lauxlib.h lualib.h luajit.h lj_arch.h \
++ iscygpty.h
+ host/buildvm.o: host/buildvm.c host/buildvm.h lj_def.h lua.h luaconf.h \
+  lj_arch.h lj_obj.h lj_def.h lj_arch.h lj_gc.h lj_obj.h lj_bc.h lj_ir.h \
+  lj_ircall.h lj_ir.h lj_jit.h lj_frame.h lj_bc.h lj_dispatch.h lj_ctype.h \
+diff --git b/src/iscygpty.c b/src/iscygpty.c
+new file mode 100644
+index 0000000..722f88f
+--- /dev/null
++++ b/src/iscygpty.c
+@@ -0,0 +1,185 @@
++/*
++ * iscygpty.c -- part of ptycheck
++ * https://github.com/k-takata/ptycheck
++ *
++ * Copyright (c) 2015-2017 K.Takata
++ *
++ * You can redistribute it and/or modify it under the terms of either
++ * the MIT license (as described below) or the Vim license.
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining
++ * a copy of this software and associated documentation files (the
++ * "Software"), to deal in the Software without restriction, including
++ * without limitation the rights to use, copy, modify, merge, publish,
++ * distribute, sublicense, and/or sell copies of the Software, and to
++ * permit persons to whom the Software is furnished to do so, subject to
++ * the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be
++ * included in all copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
++ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
++ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++#ifdef _WIN32
++
++#include <ctype.h>
++#include <io.h>
++#include <wchar.h>
++#include <windows.h>
++
++#ifdef USE_FILEEXTD
++/* VC 7.1 or earlier doesn't support SAL. */
++# if !defined(_MSC_VER) || (_MSC_VER < 1400)
++#  define __out
++#  define __in
++#  define __in_opt
++# endif
++/* Win32 FileID API Library:
++ * http://www.microsoft.com/en-us/download/details.aspx?id=22599
++ * Needed for WinXP. */
++# include <fileextd.h>
++#else /* USE_FILEEXTD */
++/* VC 8 or earlier. */
++# if defined(_MSC_VER) && (_MSC_VER < 1500)
++#  ifdef ENABLE_STUB_IMPL
++#   define STUB_IMPL
++#  else
++#   error "Win32 FileID API Library is required for VC2005 or earlier."
++#  endif
++# endif
++#endif /* USE_FILEEXTD */
++
++
++#include "iscygpty.h"
++
++//#define USE_DYNFILEID
++#ifdef USE_DYNFILEID
++typedef BOOL (WINAPI *pfnGetFileInformationByHandleEx)(
++		HANDLE                    hFile,
++		FILE_INFO_BY_HANDLE_CLASS FileInformationClass,
++		LPVOID                    lpFileInformation,
++		DWORD                     dwBufferSize
++);
++static pfnGetFileInformationByHandleEx pGetFileInformationByHandleEx = NULL;
++
++# ifndef USE_FILEEXTD
++static BOOL WINAPI stub_GetFileInformationByHandleEx(
++		HANDLE                    hFile,
++		FILE_INFO_BY_HANDLE_CLASS FileInformationClass,
++		LPVOID                    lpFileInformation,
++		DWORD                     dwBufferSize
++		)
++{
++	return FALSE;
++}
++# endif
++
++static void setup_fileid_api(void)
++{
++	if (pGetFileInformationByHandleEx != NULL) {
++		return;
++	}
++	pGetFileInformationByHandleEx = (pfnGetFileInformationByHandleEx)
++		GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")),
++				"GetFileInformationByHandleEx");
++	if (pGetFileInformationByHandleEx == NULL) {
++# ifdef USE_FILEEXTD
++		pGetFileInformationByHandleEx = GetFileInformationByHandleEx;
++# else
++		pGetFileInformationByHandleEx = stub_GetFileInformationByHandleEx;
++# endif
++	}
++}
++#else
++# define pGetFileInformationByHandleEx	GetFileInformationByHandleEx
++# define setup_fileid_api()
++#endif
++
++
++#define is_wprefix(s, prefix) \
++	(wcsncmp((s), (prefix), sizeof(prefix) / sizeof(WCHAR) - 1) == 0)
++
++/* Check if the fd is a cygwin/msys's pty. */
++int is_cygpty(int fd)
++{
++#ifdef STUB_IMPL
++	return 0;
++#else
++	HANDLE h;
++	int size = sizeof(FILE_NAME_INFO) + sizeof(WCHAR) * (MAX_PATH - 1);
++	FILE_NAME_INFO *nameinfo;
++	WCHAR *p = NULL;
++
++	setup_fileid_api();
++
++	h = (HANDLE) _get_osfhandle(fd);
++	if (h == INVALID_HANDLE_VALUE) {
++		return 0;
++	}
++	/* Cygwin/msys's pty is a pipe. */
++	if (GetFileType(h) != FILE_TYPE_PIPE) {
++		return 0;
++	}
++	nameinfo = malloc(size + sizeof(WCHAR));
++	if (nameinfo == NULL) {
++		return 0;
++	}
++	/* Check the name of the pipe:
++	 * '\{cygwin,msys}-XXXXXXXXXXXXXXXX-ptyN-{from,to}-master' */
++	if (pGetFileInformationByHandleEx(h, FileNameInfo, nameinfo, size)) {
++		nameinfo->FileName[nameinfo->FileNameLength / sizeof(WCHAR)] = L'\0';
++		p = nameinfo->FileName;
++		if (is_wprefix(p, L"\\cygwin-")) {		/* Cygwin */
++			p += 8;
++		} else if (is_wprefix(p, L"\\msys-")) {	/* MSYS and MSYS2 */
++			p += 6;
++		} else {
++			p = NULL;
++		}
++		if (p != NULL) {
++			while (*p && isxdigit(*p))	/* Skip 16-digit hexadecimal. */
++				++p;
++			if (is_wprefix(p, L"-pty")) {
++				p += 4;
++			} else {
++				p = NULL;
++			}
++		}
++		if (p != NULL) {
++			while (*p && isdigit(*p))	/* Skip pty number. */
++				++p;
++			if (is_wprefix(p, L"-from-master")) {
++				//p += 12;
++			} else if (is_wprefix(p, L"-to-master")) {
++				//p += 10;
++			} else {
++				p = NULL;
++			}
++		}
++	}
++	free(nameinfo);
++	return (p != NULL);
++#endif /* STUB_IMPL */
++}
++
++/* Check if at least one cygwin/msys pty is used. */
++int is_cygpty_used(void)
++{
++	int fd, ret = 0;
++
++	for (fd = 0; fd < 3; fd++) {
++		ret |= is_cygpty(fd);
++	}
++	return ret;
++}
++
++#endif /* _WIN32 */
++
++/* vim: set ts=4 sw=4: */
+diff --git b/src/iscygpty.h b/src/iscygpty.h
+new file mode 100644
+index 0000000..82fd0af
+--- /dev/null
++++ b/src/iscygpty.h
+@@ -0,0 +1,41 @@
++/*
++ * iscygpty.h -- part of ptycheck
++ * https://github.com/k-takata/ptycheck
++ *
++ * Copyright (c) 2015-2017 K.Takata
++ *
++ * You can redistribute it and/or modify it under the terms of either
++ * the MIT license (as described below) or the Vim license.
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining
++ * a copy of this software and associated documentation files (the
++ * "Software"), to deal in the Software without restriction, including
++ * without limitation the rights to use, copy, modify, merge, publish,
++ * distribute, sublicense, and/or sell copies of the Software, and to
++ * permit persons to whom the Software is furnished to do so, subject to
++ * the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be
++ * included in all copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
++ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
++ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++#ifndef _ISCYGPTY_H
++#define _ISCYGPTY_H
++
++#ifdef _WIN32
++int is_cygpty(int fd);
++int is_cygpty_used(void);
++#else
++#define is_cygpty(fd)		0
++#define is_cygpty_used()	0
++#endif
++
++#endif /* _ISCYGPTY_H */
+diff --git a/src/luajit.c b/src/luajit.c
+index 6dd6402..b11b14f 100644
+--- a/src/luajit.c
++++ b/src/luajit.c
+@@ -19,15 +19,17 @@
+ 
+ #include "lj_arch.h"
+ 
++#include "iscygpty.h"
++
+ #if LJ_TARGET_POSIX
+ #include <unistd.h>
+-#define lua_stdin_is_tty()	isatty(0)
++#define lua_stdin_is_tty()	isatty(0) || is_cygpty(0)
+ #elif LJ_TARGET_WINDOWS
+ #include <io.h>
+ #ifdef __BORLANDC__
+-#define lua_stdin_is_tty()	isatty(_fileno(stdin))
++#define lua_stdin_is_tty()	isatty(_fileno(stdin)) || is_cygpty(_fileno(stdin))
+ #else
+-#define lua_stdin_is_tty()	_isatty(_fileno(stdin))
++#define lua_stdin_is_tty()	_isatty(_fileno(stdin)) || is_cygpty(_fileno(stdin))
+ #endif
+ #else
+ #define lua_stdin_is_tty()	1

--- a/mingw-w64-luajit/PKGBUILD
+++ b/mingw-w64-luajit/PKGBUILD
@@ -7,13 +7,12 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 # https://github.com/LuaJIT/LuaJIT/issues/665#issuecomment-784452583
 _commit="51fb2f2c3af778f03258fccee9092401ee4a0215"
 pkgver=2.1.0.beta3.r481.g51fb2f2c
-pkgrel=2
+pkgrel=3
 pkgdesc="Just-in-time compiler and drop-in replacement for Lua 5.1 (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://luajit.org/"
 license=('spdx:MIT')
-depends=('winpty')
 conflicts=("${MINGW_PACKAGE_PREFIX}-lua51"
            "${MINGW_PACKAGE_PREFIX}-luajit-git")
 provides=("${MINGW_PACKAGE_PREFIX}-lua51"
@@ -22,10 +21,12 @@ replaces=("${MINGW_PACKAGE_PREFIX}-lua51"
           "${MINGW_PACKAGE_PREFIX}-luajit-git")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc" "git")
 source=("${_realname}"::"git+https://luajit.org/git/luajit.git#commit=${_commit}"
+        001-mintty-cygpty-isatty.patch
         002-fix-pkg-config-file.patch
         003-lua51-modules-paths.patch
         004-fix-default-cc.patch)
 sha256sums=('SKIP'
+            '0cadf1b6c67c910c81ccb7a6152148dccfb0f1c6b50cdb09a5707cd45e7cbe85'
             '4df486e82b0bbeead01dcf6001e90c51477a3a8ac18611d60d7067f2c7013428'
             'b8c9c9c6e16f8c772f760a9e2f39c048ca00dea01c7b7699f1dbe90e93f2c26c'
             '444df1c8ab9c8c348c7c81a7a6bf15d7e02410f4edc38894a65a4bb7ee9a8d68')
@@ -37,6 +38,8 @@ pkgver() {
 
 prepare() {
   cd "${_realname}"
+  rm -f src/iscygpty.{c,h} || true
+  git apply ${srcdir}/001-mintty-cygpty-isatty.patch
   git apply ${srcdir}/002-fix-pkg-config-file.patch
   git apply ${srcdir}/003-lua51-modules-paths.patch
   git apply ${srcdir}/004-fix-default-cc.patch
@@ -62,9 +65,6 @@ build() {
 package() {
   cd "${_realname}"
   make DESTDIR=${pkgdir} install
-
-  echo "#!/usr/bin/env bash" > "${pkgdir}${MINGW_PREFIX}/bin/${_realname}"
-  echo '/usr/bin/winpty "$( dirname ${BASH_SOURCE[0]} )/'${_realname}'.exe" "$@"' >> "${pkgdir}${MINGW_PREFIX}/bin/${_realname}"
 
   install -v -Dm644 "${srcdir}/${_realname}/src/lua51.dll" "${pkgdir}${MINGW_PREFIX}/bin/lua51.dll" || exit 1
   install -v -Dm644 "${srcdir}/${_realname}/src/luajit.exe" "${pkgdir}${MINGW_PREFIX}/bin/luajit.exe" || exit 1


### PR DESCRIPTION
Fixes https://github.com/msys2/MINGW-packages/issues/17472

All the changed patch files have been recreated with `git diff`. None of them are handwritten anymore. This ensures that `patch` and `git apply` always properly works.