### PR TITLE
emacs-pdf-tools-server: update to 1.1.0

### DIFF
--- a/mingw-w64-emacs-pdf-tools-server/PKGBUILD
+++ b/mingw-w64-emacs-pdf-tools-server/PKGBUILD
@@ -3,12 +3,12 @@
 _realname=emacs-pdf-tools-server
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.0.0
+pkgver=1.1.0
 pkgrel=1
 pkgdesc="Emacs support library for PDF files"
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/vedang/pdf-tools/archive/refs/tags/v${pkgver}.tar.gz")
 noextract=(${_realname}-${pkgver}.tar.gz)
-sha256sums=("b2b3bca06f838c2bc7219e1c1b50acae2b19ebd5af30980cb34211e6a69399cf")
+sha256sums=("bb5badef03e27411e62290d71c9e4657952230b6bd557c8523699d42c30a3866")
 mingw_arch=('mingw64' 'mingw32' 'ucrt64' 'clang64' 'clang32')
 arch=("any")
 url="https://github.com/vedang/pdf-tools"


### PR DESCRIPTION
CLANG builds fail, investigating.