### PR TITLE
emacs: Re-enable native-compilation, disable -foptimize-sibling-calls

### DIFF
--- a/mingw-w64-emacs/PKGBUILD
+++ b/mingw-w64-emacs/PKGBUILD
@@ -6,7 +6,7 @@ _realname=emacs
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=28.2
-pkgrel=5
+pkgrel=6
 pkgdesc="The extensible, customizable, self-documenting, real-time display editor (mingw-w64)"
 url="https://www.gnu.org/software/${_realname}/"
 license=('spdx:GPL-3.0')
@@ -71,6 +71,8 @@ build() {
   export LDFLAGS="${LDFLAGS} -lpthread"
   # -D_FORTIFY_SOURCE breaks build
   CFLAGS=${CFLAGS//"-Wp,-D_FORTIFY_SOURCE=2"}
+  # -foptimize-sibling-calls breaks native compilation (GCC 13.1)
+  CFLAGS+=" -fno-optimize-sibling-calls"
 
   ../${_realname}-${pkgver}/configure \
     --prefix="${MINGW_PREFIX}" \
@@ -78,9 +80,8 @@ build() {
     --build="${MINGW_CHOST}" \
     --with-modules \
     --without-dbus \
-    --without-compress-install
-    # disable jit due to gcc 13 taking more time to compile
-    # $_extra_cfg
+    --without-compress-install \
+    $_extra_cfg
 
   # --without-compress-install is needed because we don't have gzip in
   # the mingw binaries and it is also required by native compilation.


### PR DESCRIPTION
For now this is a draft to test whether the build succeeds, I lack the knowledge to set up the CI.

I might have found the optimization that breaks the native-compilation build, `-foptimize-sibling-calls`. See also https://debbugs.gnu.org/cgi/bugreport.cgi?bug=63365.