### PR TITLE
PDCurses: update to PDCursesMod 4.3.7 + enabled vt port

### DIFF
--- a/mingw-w64-pdcurses/PKGBUILD
+++ b/mingw-w64-pdcurses/PKGBUILD
@@ -8,11 +8,11 @@ provides=("${MINGW_PACKAGE_PREFIX}-curses")
 # No replace or conflict as the installed names are different
 #replaces=("${MINGW_PACKAGE_PREFIX}-ncurses" "${MINGW_PACKAGE_PREFIX}-termcap")
 #conflicts=("${MINGW_PACKAGE_PREFIX}-ncurses" "${MINGW_PACKAGE_PREFIX}-termcap")
-pkgver=4.3.6
+pkgver=4.3.7
 pkgrel=1
 pkgdesc="Curses library on the Win32 API (mingw-w64)"
 # ports that are available with this package
-_pdcports="wincon wingui"  # vt is relevant especially for Windows Terminal - look at this later
+_pdcports="wincon wingui vt"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://www.projectpluto.com/win32a.htm"
@@ -21,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 options=('staticlibs' 'strip')
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/Bill-Gray/PDCursesMod/archive/v${pkgver}.tar.gz")
-sha256sums=('daba062ac9c0e2cd24f09b8e8a13cccec18ec8e63807119468939fc7a58e5627')
+sha256sums=('cc652f20f932ad2dd6060b0c31297fd46c633d1ac5368f2cec8af7224fe16315')
 
 #prepare() {
 #  cd PDCursesMod-${pkgver}


### PR DESCRIPTION
https://github.com/Bill-Gray/PDCursesMod/releases/tag/v4.3.7