### PR TITLE
add libipt to GDB

### DIFF
--- a/mingw-w64-gdb/PKGBUILD
+++ b/mingw-w64-gdb/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-multiarch")
 pkgver=13.2
-pkgrel=2
+pkgrel=3
 pkgdesc="GNU Debugger (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -16,6 +16,7 @@ groups=($( [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_P
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-mpc"
          "${MINGW_PACKAGE_PREFIX}-mpfr"
+         "${MINGW_PACKAGE_PREFIX}-libipt"
          "${MINGW_PACKAGE_PREFIX}-ncurses"
          "${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-readline"
@@ -108,6 +109,8 @@ do_build() {
     --disable-win32-registry \
     --disable-rpath \
     --disable-sim \
+    --with-libipt \
+    --with-libipt-type=shared \
     --with-curses \
     --with-system-gdbinit=${MINGW_PREFIX}/etc/gdbinit \
     --with-system-readline \


### PR DESCRIPTION
note: if linking does not work configure will not abort so needs a manual verification - which I've did:

* earlier the result of `record btrace pt` was
> Intel Processor Trace support was disabled at compile time.
* now, on both an an AMD box an modern I7, the result is
> You can't do that when your target is `native'

Not sure how to go on from that... so asked on the libipt repo https://github.com/intel/libipt/issues/100.