### PR TITLE
ffmpeg: rebuild and backport a build fix; enable svt-av1 for clangarm64

### DIFF
--- a/mingw-w64-ffmpeg/PKGBUILD
+++ b/mingw-w64-ffmpeg/PKGBUILD
@@ -7,7 +7,7 @@ _realname=ffmpeg
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=6.0
-pkgrel=4
+pkgrel=5
 pkgdesc="Complete solution to record, convert and stream audio and video (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -49,7 +49,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-aom"
          "${MINGW_PACKAGE_PREFIX}-SDL2"
          "${MINGW_PACKAGE_PREFIX}-speex"
          "${MINGW_PACKAGE_PREFIX}-srt"
-         $([[ "${CARCH}" != "x86_64" ]] || echo "${MINGW_PACKAGE_PREFIX}-svt-av1")
+          $([[ "${CARCH}" == "i686" ]] || echo "${MINGW_PACKAGE_PREFIX}-svt-av1")
          "${MINGW_PACKAGE_PREFIX}-vid.stab"
          "${MINGW_PACKAGE_PREFIX}-vulkan"
          "${MINGW_PACKAGE_PREFIX}-libx264"
@@ -167,7 +167,7 @@ build() {
     --enable-librav1e
   )
 
-  if [[ "${CARCH}" == "x86_64" ]]; then
+  if [[ "${CARCH}" != "i686" ]]; then
     common_config+=(
        --enable-libsvtav1
     )

--- a/mingw-w64-ffmpeg/PKGBUILD
+++ b/mingw-w64-ffmpeg/PKGBUILD
@@ -7,7 +7,7 @@ _realname=ffmpeg
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=6.0
-pkgrel=3
+pkgrel=4
 pkgdesc="Complete solution to record, convert and stream audio and video (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -69,7 +69,8 @@ source=(https://ffmpeg.org/releases/${_realname}-${pkgver}.tar.xz{,.asc}
         "pathtools.h"
         "0005-Win32-Add-path-relocation-to-frei0r-plugins-search.patch"
         "0002-gcc-12.patch"
-        "0001-lavu-vulkan-fix-handle-type-for-32-bit-targets.patch")
+        "0001-lavu-vulkan-fix-handle-type-for-32-bit-targets.patch"
+        https://github.com/FFmpeg/FFmpeg/commit/f9620d74cd49c35223304ba41e28be6144e45783.patch)
 validpgpkeys=('FCF986EA15E6E293A5644F10B4322F04D67658D8')
 sha256sums=('57be87c22d9b49c112b6d24bc67d42508660e6b718b3db89c44e47e289137082'
             'SKIP'
@@ -77,7 +78,8 @@ sha256sums=('57be87c22d9b49c112b6d24bc67d42508660e6b718b3db89c44e47e289137082'
             '965d3921ec4fdeec94a2718bc2c85ce5e1a00ea0e499330a554074a7ae15dfc6'
             '58f91fde8be7fa093b13275c37b0276de08537449749599e5a50f4f9c8b20926'
             '84b9fcaa188eef15201a105a44c53d647e4fb800a5032336e0948d6bed2cbc1b'
-            'bbc7e7b91886a8ac037d8e70692186ee4b48c37b4f1d82b81af8a54463b24803')
+            'bbc7e7b91886a8ac037d8e70692186ee4b48c37b4f1d82b81af8a54463b24803'
+            '146d397029d8980224c0e805646bc02707b54029fff8a3e62c1565672091aabc')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -104,6 +106,8 @@ prepare() {
   # https://trac.ffmpeg.org/ticket/9983
   # https://ffmpeg.org/pipermail/ffmpeg-devel/2023-March/307142.html
   apply_patch_with_msg 0001-lavu-vulkan-fix-handle-type-for-32-bit-targets.patch
+
+  apply_patch_with_msg f9620d74cd49c35223304ba41e28be6144e45783.patch
 }
 
 build() {

--- a/mingw-w64-ffmpeg4.4/PKGBUILD
+++ b/mingw-w64-ffmpeg4.4/PKGBUILD
@@ -7,7 +7,7 @@ _realname=ffmpeg
 pkgbase="mingw-w64-${_realname}4.4"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}4.4"
 pkgver=4.4.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Complete solution to record, convert and stream audio and video (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -47,7 +47,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-aom"
          "${MINGW_PACKAGE_PREFIX}-SDL2"
          "${MINGW_PACKAGE_PREFIX}-speex"
          "${MINGW_PACKAGE_PREFIX}-srt"
-         $([[ "${CARCH}" != "x86_64" ]] || echo "${MINGW_PACKAGE_PREFIX}-svt-av1")
+         $([[ "${CARCH}" == "i686" ]] || echo "${MINGW_PACKAGE_PREFIX}-svt-av1")
          "${MINGW_PACKAGE_PREFIX}-vid.stab"
          "${MINGW_PACKAGE_PREFIX}-vulkan"
          "${MINGW_PACKAGE_PREFIX}-libx264"
@@ -159,7 +159,7 @@ build() {
     --enable-librav1e
   )
 
-  if [[ "${CARCH}" == "x86_64" ]]; then
+  if [[ "${CARCH}" != "i686" ]]; then
     common_config+=(
        --enable-libsvtav1
     )


### PR DESCRIPTION
Fixes:
error: incompatible function pointer types initializing 'PFN_vkDebugUtilsMessengerCallbackEXT'

for clang32 since clang v16