### PR TITLE
Add sdl12-compat

### DIFF
--- a/mingw-w64-sdl12-compat/0001-just-build-normal.patch
+++ b/mingw-w64-sdl12-compat/0001-just-build-normal.patch
@@ -1,0 +1,22 @@
+--- sdl12-compat-release-1.2.64/CMakeLists.txt.orig	2023-06-20 21:53:56.954574400 +0200
++++ sdl12-compat-release-1.2.64/CMakeLists.txt	2023-06-20 21:54:09.385339800 +0200
+@@ -116,7 +116,7 @@
+         OUTPUT_NAME "SDL")
+ endif()
+ 
+-if(MINGW)
++if(0)
+     set_target_properties(SDL PROPERTIES LINK_FLAGS "-nostdlib")
+     target_link_libraries(SDL PRIVATE "-static-libgcc -lgcc") # libgcc is needed for 32 bit (x86) builds
+ endif()
+--- sdl12-compat-release-1.2.64/src/SDL12_compat.c.orig	2023-06-20 22:09:55.923654700 +0200
++++ sdl12-compat-release-1.2.64/src/SDL12_compat.c	2023-06-20 22:10:06.963529000 +0200
+@@ -1528,7 +1528,7 @@
+ __declspec(selectany) int _fltused = 1;
+ #endif
+ #if defined(__MINGW32__)
+-#define _DllMainCRTStartup DllMainCRTStartup
++#define _DllMainCRTStartup DllMain
+ #endif
+ #if defined(__WATCOMC__)
+ #define _DllMainCRTStartup LibMain

--- a/mingw-w64-sdl12-compat/0002-sdl-config-win-paths.patch
+++ b/mingw-w64-sdl12-compat/0002-sdl-config-win-paths.patch
@@ -1,0 +1,11 @@
+--- sdl12-compat-release-1.2.64/sdl-config.in.orig	2023-06-20 22:16:09.769575500 +0200
++++ sdl12-compat-release-1.2.64/sdl-config.in	2023-06-20 22:16:23.995182600 +0200
+@@ -7,7 +7,7 @@
+ 
+ # Copied and modified from SDL2's sdl2-compat.
+ 
+-prefix=@CMAKE_INSTALL_PREFIX@
++prefix="$(cygpath -m "@CMAKE_INSTALL_PREFIX@")"
+ exec_prefix=${prefix}
+ exec_prefix_set=no
+ libdir=@CMAKE_INSTALL_FULL_LIBDIR@

--- a/mingw-w64-sdl12-compat/PKGBUILD
+++ b/mingw-w64-sdl12-compat/PKGBUILD
@@ -1,0 +1,70 @@
+# Maintainer: Christoph Reiter <reiter.christoph@gmail.com>
+
+_realname=sdl12-compat
+pkgbase="mingw-w64-${_realname}"
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.2.64
+pkgrel=1
+pkgdesc="SDL 1.2 runtime compatibility library using SDL 2.0"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+url="https://github.com/libsdl-org/sdl12-compat"
+license=('spdx:Zlib')
+conflicts=("${MINGW_PACKAGE_PREFIX}-SDL")
+provides=("${MINGW_PACKAGE_PREFIX}-SDL")
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-SDL2"
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+  "${MINGW_PACKAGE_PREFIX}-ninja"
+  "${MINGW_PACKAGE_PREFIX}-cc")
+source=("https://github.com/libsdl-org/sdl12-compat/archive/refs/tags/release-${pkgver}.tar.gz"
+        "0001-just-build-normal.patch"
+        "0002-sdl-config-win-paths.patch")
+sha256sums=('3e308e817c7f0c6383225485e9a67bf1119ad684b8cc519038671cc1b5d29861'
+            'b61ea4ca9e015d1b72b3b07eed3842c88f68e7766ae48c44a2b2e8e402e4d672'
+            '731f9475c171b034c10d57d2c13fb822cf46fba61b5fc938365c11ca70b2fba7')
+
+prepare() {
+  cd "${_realname}-release-${pkgver}"
+
+  patch -Np1 -i "${srcdir}/0001-just-build-normal.patch"
+  patch -Np1 -i "${srcdir}/0002-sdl-config-win-paths.patch"
+}
+
+build() {
+  cd "${_realname}-release-${pkgver}"
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
+
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    "${MINGW_PREFIX}"/bin/cmake.exe \
+      -GNinja \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      "${extra_config[@]}" \
+      -DBUILD_SHARED_LIBS=ON \
+      "../${_realname}-release-${pkgver}"
+
+  "${MINGW_PREFIX}"/bin/cmake.exe --build .
+}
+
+check() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  "${MINGW_PREFIX}"/bin/cmake.exe --build . --target test
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
+
+  install -Dm644 "${srcdir}/${_realname}-release-${pkgver}/LICENSE.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.txt"
+}


### PR DESCRIPTION
try to build it as a normal library without -nostdlib -static-libgcc stuff, which breaks for example stack protector. I might be missing something though.

Also no "replaces" for now, until we are sure it can replace sdl1