### PR TITLE
exiv2: Update to 0.28.0

### DIFF
--- a/mingw-w64-exiv2/PKGBUILD
+++ b/mingw-w64-exiv2/PKGBUILD
@@ -5,7 +5,7 @@
 _realname=exiv2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.27.7
+pkgver=0.28.0
 pkgrel=1
 pkgdesc="Exif/IPTC/Xmp C++ metadata library and tools (mingw-w64)"
 arch=('any')
@@ -20,10 +20,11 @@ depends=("${MINGW_PACKAGE_PREFIX}-curl"
          "${MINGW_PACKAGE_PREFIX}-gettext"
          "${MINGW_PACKAGE_PREFIX}-libiconv"
          "${MINGW_PACKAGE_PREFIX}-zlib"
+         "${MINGW_PACKAGE_PREFIX}-libinih"
          "${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libwinpthread-git")
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/Exiv2/${_realname}/archive/v${pkgver}.tar.gz")
-sha256sums=('551b1266e3aabd321f6d555dccd776128ee449d5039feafee927a1f33f7a9753')
+sha256sums=('04c0675caf4338bb96cd09982f1246d588bcbfe8648c0f5a30b56c7c496f1a0b')
 
 build() {
   #shared
@@ -45,7 +46,6 @@ build() {
       -DBUILD_SHARED_LIBS=ON \
       -DEXIV2_ENABLE_VIDEO=ON \
       -DEXIV2_ENABLE_NLS=ON \
-      -DEXIV2_ENABLE_WIN_UNICODE=ON \
       -DEXIV2_BUILD_SAMPLES=OFF \
       -DEXIV2_ENABLE_WEBREADY=ON \
       -DEXIV2_ENABLE_CURL=ON \
@@ -75,7 +75,6 @@ build() {
       -DBUILD_SHARED_LIBS=OFF \
       -DEXIV2_ENABLE_VIDEO=ON \
       -DEXIV2_ENABLE_NLS=ON \
-      -DEXIV2_ENABLE_WIN_UNICODE=ON \
       -DEXIV2_BUILD_SAMPLES=OFF \
       -DEXIV2_ENABLE_WEBREADY=ON \
       -DEXIV2_ENABLE_CURL=ON \


### PR DESCRIPTION
new libinih dependency

EXIV2_ENABLE_WIN_UNICODE was removed in https://github.com/Exiv2/exiv2/pull/2090