### PR TITLE
gcc: backport codeview support

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -26,7 +26,7 @@ pkgver=13.1.0
 #_majorver=${pkgver:0:1}
 #_sourcedir=${_realname}-${_majorver}-${_snapshot}
 _sourcedir=${_realname}-${pkgver}
-pkgrel=6
+pkgrel=7
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -69,7 +69,9 @@ source=("https://ftp.gnu.org/gnu/gcc/${_realname}-${pkgver%%+*}/${_realname}-${p
         0200-add-m-no-align-vector-insn-option-for-i386.patch
         0300-override-builtin-printf-format.patch
         2000-enable-rust.patch
-        2001-fix-building-rust-on-mingw-w64.patch)
+        2001-fix-building-rust-on-mingw-w64.patch
+        "2f7e7bfa3c6327793cdcdcb5c770b93cecd49bd0.patch::https://gcc.gnu.org/git/?p=gcc.git;a=patch;h=2f7e7bfa3c6327793cdcdcb5c770b93cecd49bd0"
+        "3eeb4801d6f45f6250fc77a6d3ab4e0115f8cfdd.patch::https://gcc.gnu.org/git/?p=gcc.git;a=patch;h=3eeb4801d6f45f6250fc77a6d3ab4e0115f8cfdd")
 sha256sums=('61d684f0aa5e76ac6585ad8898a2427aade8979ed5e7f85492286c4dfc13ee86'
             'SKIP'
             'bce81824fc89e5e62cca350de4c17a27e27a18a1a1ad5ca3492aec1fc5af3234'
@@ -89,7 +91,9 @@ sha256sums=('61d684f0aa5e76ac6585ad8898a2427aade8979ed5e7f85492286c4dfc13ee86'
             'c34f9e71b5a092be1987ad4c65891742c74c9eb8ef6560100e751cd31375f579'
             'f73c8d1701762fed7d8102d17d8e4416a4cc5e600e297a89c2e1fe09cd743a1c'
             '693a91a863a706b3526af01c9de5ce8295c59ef0f56f009bcfbf79a93cba2728'
-            'e78d51c908cd4e5c905c62e8350db1c609479bb95333c67f706b56974226fd94')
+            'e78d51c908cd4e5c905c62e8350db1c609479bb95333c67f706b56974226fd94'
+            '585968957f4519aa7219de4804e96debe7592df047e497b99ea0ae073e6f57d3'
+            '73b923129e6c5b819ac994ce64b75520918992c65d00e0d97f8ca43cd6784e56')
 validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.org
               86CFFCA918CF3AF47147588051E8B148A9999C34  # evangelos@foutrelis.com
               13975A70E63C361C73AE69EF6EEB81F8981C74C7  # richard.guenther@gmail.com
@@ -161,6 +165,12 @@ prepare() {
   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109670#c12
   apply_patch_with_msg \
     0022-fix-radix-sort-on-32bit-platforms.patch
+
+  # backport: https://github.com/msys2/MINGW-packages/issues/17599
+  # https://inbox.sourceware.org/gcc-patches/a22433f5-b4d2-19b7-86a2-31e2ee45fb61@martin.st/T/
+  apply_patch_with_msg \
+    2f7e7bfa3c6327793cdcdcb5c770b93cecd49bd0.patch \
+    3eeb4801d6f45f6250fc77a6d3ab4e0115f8cfdd.patch
 
   # do not expect ${prefix}/mingw symlink - this should be superceded by
   # 0005-Windows-Don-t-ignore-native-system-header-dir.patch .. but isn't!


### PR DESCRIPTION
Fixes https://github.com/msys2/MINGW-packages/issues/17599