### PR TITLE
python-jellyfish: add aarch64 workaround for windows-targets 0.48.0

### DIFF
--- a/mingw-w64-python-jellyfish/PKGBUILD
+++ b/mingw-w64-python-jellyfish/PKGBUILD
@@ -4,7 +4,7 @@ _realname=jellyfish
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
 pkgver=1.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc='A python library for doing approximate and phonetic matching of strings (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -19,13 +19,33 @@ source=("https://files.pythonhosted.org/packages/source/j/${_realname}/${_realna
 sha256sums=('881aae3671999bb07ce50c27696f29ca7e842f3e123acc0db6525c9999881bd4')
 
 prepare() {
-  cd "${srcdir}"
-  rm -rf "python-build-${MSYSTEM}" | true
-  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  cargo vendor \
+    --locked \
+    --versioned-dirs
+
+  mkdir -p .cargo
+  cat >> .cargo/config.toml <<END
+
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "vendor"
+END
+
+
+  sed -i -e 's/"cfg(all(target_arch = \\"\([^\\]\+\)\\", target_env = \\"gnu\\", target_abi = \\"llvm\\", not(windows_raw_dylib)))"/"\1-pc-windows-gnullvm"/g' \
+    "vendor/windows-targets-0.48.0/Cargo.toml"
+  sed -i -e 's/\("Cargo.toml":\)"[^"]\+"/\1"'"$(sha256sum "vendor/windows-targets-0.48.0/Cargo.toml" | cut -d' ' -f1)"'"/' \
+    "vendor/windows-targets-0.48.0/.cargo-checksum.json"
+
 }
 
 build() {
-  cd "${srcdir}/python-build-${MSYSTEM}"
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
   ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
 }
 


### PR DESCRIPTION
Successful ARM64 CI run: https://github.com/msys2-arm/MINGW-packages/actions/runs/5394138325/jobs/9794885039