### PR TITLE
lcms2: Enable Fast Float plugin to be built

### DIFF
--- a/mingw-w64-lcms2/PKGBUILD
+++ b/mingw-w64-lcms2/PKGBUILD
@@ -46,7 +46,7 @@ build() {
       --auto-features=enabled \
       --buildtype=plain \
       -Ddefault_library=both \
-      ../${_realname}-${pkgver}
+      ../${_realname}-${pkgver} \
       -Dfastfloat=true
 
   meson compile

--- a/mingw-w64-lcms2/PKGBUILD
+++ b/mingw-w64-lcms2/PKGBUILD
@@ -47,6 +47,7 @@ build() {
       --buildtype=plain \
       -Ddefault_library=both \
       ../${_realname}-${pkgver}
+      -Dfastfloat=true
 
   meson compile
 }

--- a/mingw-w64-lcms2/PKGBUILD
+++ b/mingw-w64-lcms2/PKGBUILD
@@ -5,7 +5,7 @@ _realname=lcms2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.15
-pkgrel=2
+pkgrel=3
 pkgdesc="Small-footprint color management engine, version 2 (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -46,8 +46,8 @@ build() {
       --auto-features=enabled \
       --buildtype=plain \
       -Ddefault_library=both \
-      ../${_realname}-${pkgver} \
-      -Dfastfloat=true
+      -Dfastfloat=true \
+      ../${_realname}-${pkgver}
 
   meson compile
 }


### PR DESCRIPTION
There was a request for GIMP to add an option for LittleCMS optimization (https://gitlab.gnome.org/GNOME/gimp/-/issues/9536). This requires the lcms2 Fast Float plug-in to be built with lcms2. [A comment by lillolollo](https://gitlab.gnome.org/GNOME/gimp/-/issues/9536#note_1760997) indicated this can be done by adding the -Dfastfloat=true flag to PKGBUILD.

I have tested this locally and confirmed it still builds lcms2, now with the Fast Float plug-in as well. If anything else is needed, please let me know!