### PR TITLE
Init mingw-w64-ossia-score package

### DIFF
--- a/mingw-w64-ossia-score/PKGBUILD
+++ b/mingw-w64-ossia-score/PKGBUILD
@@ -51,7 +51,7 @@ build() {
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake -Wno-dev -GNinja \
-    -S "${srcdir}" \
+    -S "${srcdir}/${_realname}-${pkgver}" \
     -B "build-${MSYSTEM}" \
     -DCMAKE_UNITY_BUILD=1 \
     -DSCORE_PCH=0 \

--- a/mingw-w64-ossia-score/PKGBUILD
+++ b/mingw-w64-ossia-score/PKGBUILD
@@ -78,5 +78,5 @@ package() {
 
   rm -rf "${pkgdir}${MINGW_PREFIX}/usr/share/faust"
 
-  install -D -m644 "${srcdir}/LICENSE.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/ossia-score/LICENSE"
+  install -D -m644 "${srcdir}/${_realname}-${pkgver}/LICENSE.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/ossia-score/LICENSE"
 }

--- a/mingw-w64-ossia-score/PKGBUILD
+++ b/mingw-w64-ossia-score/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=ossia-score
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=3.1.11
+pkgver=3.1.12
 pkgrel=1
 pkgdesc="ossia score, an interactive sequencer for the intermedia arts"
 arch=('any')
@@ -32,7 +32,7 @@ makedepends=(
   "git"
 )
 source=("https://github.com/ossia/score/releases/download/v${pkgver}/ossia.score-${pkgver}-src.tar.xz")
-sha512sums=('8927a965fddfe53031744913b4ac4819d93e1fb09a94e74cd0fbf6e4e3953b126e4bccab415f497243990f741837ebb5d2d106ed99de87b0079ca3b80b338251')
+sha512sums=('c3eba3e1bb3913b099433c2c558bdb8bafa935b985abb1383764b2797ec2acebb6f695dec9cffac671abe2be1f205296771270cfee5ecb32e3427515936adc54')
 noextract=(ossia.score-${pkgver}-src.tar.xz)
 
 prepare() {

--- a/mingw-w64-ossia-score/PKGBUILD
+++ b/mingw-w64-ossia-score/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=ossia-score
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=3.1.12
+pkgver=3.1.13
 pkgrel=1
 pkgdesc="ossia score, an interactive sequencer for the intermedia arts"
 arch=('any')

--- a/mingw-w64-ossia-score/PKGBUILD
+++ b/mingw-w64-ossia-score/PKGBUILD
@@ -1,0 +1,82 @@
+# Maintainer: Jean-Michaël Celerier <jeanmichael.celerier@gmail.com>
+
+_realname=ossia-score
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=3.1.11
+pkgrel=1
+pkgdesc="ossia score, an interactive sequencer for the intermedia arts"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url="https://ossia.io"
+license=('spdx:GPL-3.0-or-later')
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-qt6-base"
+  "${MINGW_PACKAGE_PREFIX}-qt6-declarative"
+  "${MINGW_PACKAGE_PREFIX}-qt6-websockets"
+  "${MINGW_PACKAGE_PREFIX}-qt6-serialport"
+  "${MINGW_PACKAGE_PREFIX}-qt6-shadertools"
+  "${MINGW_PACKAGE_PREFIX}-qt6-5compat"
+  "${MINGW_PACKAGE_PREFIX}-qt6-scxml"
+  "${MINGW_PACKAGE_PREFIX}-qt6-tools"
+  "${MINGW_PACKAGE_PREFIX}-portaudio"
+  "${MINGW_PACKAGE_PREFIX}-fftw"
+  "${MINGW_PACKAGE_PREFIX}-ffmpeg"
+  "${MINGW_PACKAGE_PREFIX}-SDL2"
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+  "${MINGW_PACKAGE_PREFIX}-ninja"
+  "${MINGW_PACKAGE_PREFIX}-gcc"
+  "${MINGW_PACKAGE_PREFIX}-boost"
+  "git"
+)
+source=("https://github.com/ossia/score/releases/download/v${pkgver}/ossia.score-${pkgver}-src.tar.xz")
+sha512sums=('8927a965fddfe53031744913b4ac4819d93e1fb09a94e74cd0fbf6e4e3953b126e4bccab415f497243990f741837ebb5d2d106ed99de87b0079ca3b80b338251')
+noextract=(ossia.score-${pkgver}-src.tar.xz)
+
+prepare() {
+  [[ -d ${srcdir}/${_realname}-${pkgver} ]] && rm -rf ${srcdir}/${_realname}-${pkgver}
+  MSYS=winsymlinks:native \
+  tar -xJf ${srcdir}/ossia.score-${pkgver}-src.tar.xz -C ${srcdir} || true
+}
+
+build() {
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake -Wno-dev -GNinja \
+    -S "${srcdir}" \
+    -B "build-${MSYSTEM}" \
+    -DCMAKE_UNITY_BUILD=1 \
+    -DSCORE_PCH=0 \
+    -DSCORE_STATIC_PLUGINS=1 \
+    -DSCORE_FHS_BUILD=1 \
+    -DSCORE_DEPLOYMENT_BUILD=1 \
+    -DSCORE_DISABLED_PLUGINS="score-plugin-vst3;score-plugin-jit;score-plugin-faust" \
+    -DCMAKE_CXX_FLAGS="-Wa,-mbig-obj" \
+    -DCMAKE_C_USE_RESPONSE_FILE_FOR_OBJECTS=1 \
+    -DCMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS=1 \
+    -DCMAKE_NINJA_FORCE_RESPONSE_FILE=1 \
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+    "${extra_config[@]}"
+
+  cmake --build "build-${MSYSTEM}"
+}
+
+
+package() {
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}/bin/cmake.exe" \
+    -DCMAKE_INSTALL_DO_STRIP=1 \
+    -DCOMPONENT=OssiaScore \
+    -P "build-${MSYSTEM}/cmake_install.cmake"
+
+  rm -rf "${pkgdir}${MINGW_PREFIX}/usr/share/faust"
+
+  install -D -m644 "${srcdir}/LICENSE.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/ossia-score/LICENSE"
+}

--- a/mingw-w64-ossia-score/PKGBUILD
+++ b/mingw-w64-ossia-score/PKGBUILD
@@ -27,7 +27,7 @@ depends=(
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cmake"
   "${MINGW_PACKAGE_PREFIX}-ninja"
-  "${MINGW_PACKAGE_PREFIX}-gcc"
+  "${MINGW_PACKAGE_PREFIX}-cc"
   "${MINGW_PACKAGE_PREFIX}-boost"
   "git"
 )

--- a/mingw-w64-ossia-score/PKGBUILD
+++ b/mingw-w64-ossia-score/PKGBUILD
@@ -32,7 +32,7 @@ makedepends=(
   "git"
 )
 source=("https://github.com/ossia/score/releases/download/v${pkgver}/ossia.score-${pkgver}-src.tar.xz")
-sha512sums=('c3eba3e1bb3913b099433c2c558bdb8bafa935b985abb1383764b2797ec2acebb6f695dec9cffac671abe2be1f205296771270cfee5ecb32e3427515936adc54')
+sha512sums=('14b25c34fe4a37c2347cd1aea517cb548eb5091066d01b6e3e955d66dc5ba59929cce2b04e9ccad3c159498d95f30cb68889193a4a86ec8705291d8603dda259')
 noextract=(ossia.score-${pkgver}-src.tar.xz)
 
 prepare() {


### PR DESCRIPTION
ossia score ([ossia.io](https://ossia.io/)) is a software for creating live audio, video, light & multimedia shows and art installations.
Note: the last current stable release needs some patches for building. Next version will work directly, I'll update the PR asap.