### PR TITLE
lcms2: update licensing info

### DIFF
--- a/mingw-w64-lcms2/PKGBUILD
+++ b/mingw-w64-lcms2/PKGBUILD
@@ -5,12 +5,12 @@ _realname=lcms2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.15
-pkgrel=3
+pkgrel=4
 pkgdesc="Small-footprint color management engine, version 2 (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://www.littlecms.com/"
-license=("spdx:MIT")
+license=('spdx:MIT' 'spdx:GPL-3.0-or-later')
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cc"
   "${MINGW_PACKAGE_PREFIX}-meson"
@@ -58,4 +58,5 @@ package() {
   DESTDIR="${pkgdir}" meson install
 
   install -Dm644 "${srcdir}"/${_realname}-${pkgver}/COPYING "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/COPYING
+  install -Dm644 "${srcdir}"/${_realname}-${pkgver}/plugins/fast_float/COPYING.GPL3 "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/COPYING-fast_float
 }


### PR DESCRIPTION
Following up from https://github.com/msys2/MINGW-packages/pull/17655 @Biswa96 @cmyk-student 

Let's provide all the licensing information at the very least.

I can't verify/confirm if linking w/ `lcms2_fast_float` but not using any of its symbols is sufficient to avoid actual linkage. Perhaps it relies on `strip` being run on the object, don't know if that would always be the case...