### PR TITLE
openal: Add Cflags.private in pkgconfig file

### DIFF
--- a/mingw-w64-openal/0004-pkgconfig-add-Cflags-private.patch
+++ b/mingw-w64-openal/0004-pkgconfig-add-Cflags-private.patch
@@ -1,0 +1,7 @@
+--- a/openal.pc.in
++++ b/openal.pc.in
+@@ -10,3 +10,4 @@
+ Libs: -L${libdir} -l@LIBNAME@ @PKG_CONFIG_LIBS@
+ Libs.private:@PKG_CONFIG_PRIVATE_LIBS@
+ Cflags: -I${includedir} -I${includedir}/AL @PKG_CONFIG_CFLAGS@
++Cflags.private: -DAL_LIBTYPE_STATIC

--- a/mingw-w64-openal/PKGBUILD
+++ b/mingw-w64-openal/PKGBUILD
@@ -4,7 +4,7 @@ _realname=openal
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.23.1
-pkgrel=1
+pkgrel=2
 pkgdesc="OpenAL audio library for use with opengl (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -20,11 +20,13 @@ source=(https://github.com/kcat/openal-soft/archive/${pkgver}.tar.gz
         0001-versioned-w32-dll.mingw.patch
         0002-w32ize-portaudio-loading.mingw.patch
         0003-openal-not-32.mingw.patch
+        0004-pkgconfig-add-Cflags-private.patch
         0005-mingw-dont-check-libm.patch)
 sha256sums=('dfddf3a1f61059853c625b7bb03de8433b455f2f79f89548cbcbd5edca3d4a4a'
             'c3e56b5594ada0b95588373bd8ca062677805beae393c6551301518ab24a0cd3'
             'f0bde7d3a8087530ab1bb2f48e59eec6f4cf60d59c5afe3a0c28c95e6b138751'
             '33dccfc603a48d265341e60bc801976d077e546ab5c91a93e8426eac01bb7ad4'
+            'fb62d0ee19f79dc8990686c4341e1bdbc5fe91418f8deb7267b9fb3887a18e83'
             'c2528ecc034ea993cb63893b3f2ce5ceeac8d63295decf6864f58cd646c74299')
 
 # Helper macros to help make tasks easier #
@@ -42,6 +44,7 @@ prepare() {
     0001-versioned-w32-dll.mingw.patch \
     0002-w32ize-portaudio-loading.mingw.patch \
     0003-openal-not-32.mingw.patch \
+    0004-pkgconfig-add-Cflags-private.patch \
     0005-mingw-dont-check-libm.patch
 }
 


### PR DESCRIPTION
This defines AL_LIBTYPE_STATIC macro while static linking. Previously, that macro was only defined in pkgconfig file of static openal build.