### PR TITLE
librsvg: remove clangarm64 workaround

### DIFF
--- a/mingw-w64-librsvg/PKGBUILD
+++ b/mingw-w64-librsvg/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
 pkgver=2.56.2
-pkgrel=1
+pkgrel=2
 pkgdesc="SVG rendering library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -34,25 +34,7 @@ prepare() {
 
   patch -p1 -i "${srcdir}/0001-configure-set-pass-prefix-to-pkg-config-when-retriev.patch"
 
-  cargo vendor \
-    --locked \
-    --versioned-dirs
-
-  mkdir -p .cargo
-  cat >> .cargo/config.toml <<END
-
-[source.crates-io]
-replace-with = "vendored-sources"
-
-[source.vendored-sources]
-directory = "vendor"
-END
-
-
-  sed -i -e 's/"cfg(all(target_arch = \\"\([^\\]\+\)\\", target_env = \\"gnu\\", target_abi = \\"llvm\\", not(windows_raw_dylib)))"/"\1-pc-windows-gnullvm"/g' \
-    "vendor/windows-targets-0.48.1/Cargo.toml"
-  sed -i -e 's/\("Cargo.toml":\)"[^"]\+"/\1"'"$(sha256sum "vendor/windows-targets-0.48.1/Cargo.toml" | cut -d' ' -f1)"'"/' \
-    "vendor/windows-targets-0.48.1/.cargo-checksum.json"
+  cargo fetch --locked
 
   autoreconf -fiv
 }


### PR DESCRIPTION
No longer needed with windows-targets 0.48.1
see https://github.com/msys2/MINGW-packages/pull/17671#discussion_r1248543246