### PR TITLE
python2: fix unknown gnu_printf format attribute for clang

### DIFF
--- a/mingw-w64-python2/0100-MINGW-BASE-use-NT-thread-model.patch
+++ b/mingw-w64-python2/0100-MINGW-BASE-use-NT-thread-model.patch
@@ -21,7 +21,7 @@ diff -Naur Python-2.7.9-orig/configure.ac Python-2.7.9/configure.ac
 +AC_MSG_CHECKING([for NT threads])
 +AC_CACHE_VAL([ac_cv_ntthread],[
 +  AC_LINK_IFELSE([
-+    AC_LANG_PROGRAM([[]],[[_beginthread(0, 0, 0);]])
++    AC_LANG_PROGRAM([[#include <process.h>]],[[_beginthread(0, 0, 0);]])
 +  ],
 +  [ac_cv_ntthread=yes],
 +  [ac_cv_ntthread=no])

--- a/mingw-w64-python2/1030-use-gnu_printf-in-format.patch
+++ b/mingw-w64-python2/1030-use-gnu_printf-in-format.patch
@@ -1,69 +1,80 @@
-diff -Naur Python-2.7.9-orig/Include/pgenheaders.h Python-2.7.9/Include/pgenheaders.h
---- Python-2.7.9-orig/Include/pgenheaders.h	2014-12-10 18:59:32.000000000 +0300
-+++ Python-2.7.9/Include/pgenheaders.h	2014-12-11 13:51:30.074600000 +0300
+--- Python-2.7.18/Include/pgenheaders.h.orig	2020-04-19 23:13:39.000000000 +0200
++++ Python-2.7.18/Include/pgenheaders.h	2023-07-01 19:55:50.342406900 +0200
 @@ -10,9 +10,9 @@
  #include "Python.h"
  
  PyAPI_FUNC(void) PySys_WriteStdout(const char *format, ...)
 -			Py_GCC_ATTRIBUTE((format(printf, 1, 2)));
-+			Py_GCC_ATTRIBUTE((format(gnu_printf, 1, 2)));
++			_Py_PRINTF(1, 2);
  PyAPI_FUNC(void) PySys_WriteStderr(const char *format, ...)
 -			Py_GCC_ATTRIBUTE((format(printf, 1, 2)));
-+			Py_GCC_ATTRIBUTE((format(gnu_printf, 1, 2)));
++			_Py_PRINTF(1, 2);
  
  #define addarc _Py_addarc
  #define addbit _Py_addbit
-diff -Naur Python-2.7.9-orig/Include/pyerrors.h Python-2.7.9/Include/pyerrors.h
---- Python-2.7.9-orig/Include/pyerrors.h	2014-12-10 18:59:32.000000000 +0300
-+++ Python-2.7.9/Include/pyerrors.h	2014-12-11 13:51:30.074600000 +0300
-@@ -193,7 +193,7 @@
+--- Python-2.7.18/Include/pyerrors.h.orig	2020-04-19 23:13:39.000000000 +0200
++++ Python-2.7.18/Include/pyerrors.h	2023-07-01 19:56:22.135734100 +0200
+@@ -194,7 +194,7 @@
  #endif /* MS_WINDOWS */
  
  PyAPI_FUNC(PyObject *) PyErr_Format(PyObject *, const char *, ...)
 -                        Py_GCC_ATTRIBUTE((format(printf, 2, 3)));
-+                        Py_GCC_ATTRIBUTE((format(gnu_printf, 2, 3)));
++                        _Py_PRINTF(2, 3);
  
  #ifdef MS_WINDOWS
  PyAPI_FUNC(PyObject *) PyErr_SetFromWindowsErrWithFilenameObject(
-@@ -318,9 +318,9 @@
+@@ -319,9 +319,9 @@
  
  #include <stdarg.h>
  PyAPI_FUNC(int) PyOS_snprintf(char *str, size_t size, const char  *format, ...)
 -                        Py_GCC_ATTRIBUTE((format(printf, 3, 4)));
-+                        Py_GCC_ATTRIBUTE((format(gnu_printf, 3, 4)));
++                        _Py_PRINTF(3, 4);
  PyAPI_FUNC(int) PyOS_vsnprintf(char *str, size_t size, const char  *format, va_list va)
 -                        Py_GCC_ATTRIBUTE((format(printf, 3, 0)));
-+                        Py_GCC_ATTRIBUTE((format(gnu_printf, 3, 0)));
++                        _Py_PRINTF(3, 0);
  
  #ifdef __cplusplus
  }
-diff -Naur Python-2.7.9-orig/Include/stringobject.h Python-2.7.9/Include/stringobject.h
---- Python-2.7.9-orig/Include/stringobject.h	2014-12-10 18:59:32.000000000 +0300
-+++ Python-2.7.9/Include/stringobject.h	2014-12-11 13:51:30.090200000 +0300
+--- Python-2.7.18/Include/stringobject.h.orig	2020-04-19 23:13:39.000000000 +0200
++++ Python-2.7.18/Include/stringobject.h	2023-07-01 19:56:34.308925100 +0200
 @@ -62,9 +62,9 @@
  PyAPI_FUNC(PyObject *) PyString_FromStringAndSize(const char *, Py_ssize_t);
  PyAPI_FUNC(PyObject *) PyString_FromString(const char *);
  PyAPI_FUNC(PyObject *) PyString_FromFormatV(const char*, va_list)
 -				Py_GCC_ATTRIBUTE((format(printf, 1, 0)));
-+				Py_GCC_ATTRIBUTE((format(gnu_printf, 1, 0)));
++				_Py_PRINTF(1, 0);
  PyAPI_FUNC(PyObject *) PyString_FromFormat(const char*, ...)
 -				Py_GCC_ATTRIBUTE((format(printf, 1, 2)));
-+				Py_GCC_ATTRIBUTE((format(gnu_printf, 1, 2)));
++				_Py_PRINTF(1, 2);
  PyAPI_FUNC(Py_ssize_t) PyString_Size(PyObject *);
  PyAPI_FUNC(char *) PyString_AsString(PyObject *);
  PyAPI_FUNC(PyObject *) PyString_Repr(PyObject *, int);
-diff -Naur Python-2.7.9-orig/Include/sysmodule.h Python-2.7.9/Include/sysmodule.h
---- Python-2.7.9-orig/Include/sysmodule.h	2014-12-10 18:59:32.000000000 +0300
-+++ Python-2.7.9/Include/sysmodule.h	2014-12-11 13:51:30.090200000 +0300
+--- Python-2.7.18/Include/sysmodule.h.orig	2020-04-19 23:13:39.000000000 +0200
++++ Python-2.7.18/Include/sysmodule.h	2023-07-01 19:56:45.175041900 +0200
 @@ -15,9 +15,9 @@
  PyAPI_FUNC(void) PySys_SetPath(char *);
  
  PyAPI_FUNC(void) PySys_WriteStdout(const char *format, ...)
 -			Py_GCC_ATTRIBUTE((format(printf, 1, 2)));
-+			Py_GCC_ATTRIBUTE((format(gnu_printf, 1, 2)));
++			_Py_PRINTF(1, 2);
  PyAPI_FUNC(void) PySys_WriteStderr(const char *format, ...)
 -			Py_GCC_ATTRIBUTE((format(printf, 1, 2)));
-+			Py_GCC_ATTRIBUTE((format(gnu_printf, 1, 2)));
++			_Py_PRINTF(1, 2);
  
  PyAPI_FUNC(void) PySys_ResetWarnOptions(void);
  PyAPI_FUNC(void) PySys_AddWarnOption(char *);
+--- Python-2.7.18/Include/pyport.h.orig	2023-07-01 19:50:28.099134800 +0200
++++ Python-2.7.18/Include/pyport.h	2023-07-01 19:54:47.961648000 +0200
+@@ -671,6 +675,12 @@
+ extern char * _getpty(int *, int, mode_t, int);
+ #endif
+ 
++#if defined(__GNUC__) && ((__GNUC__ == 4 && __GNUC_MINOR__>= 4) || __GNUC__ > 4)
++#  define _Py_PRINTF(X,Y) Py_GCC_ATTRIBUTE((format(gnu_printf,X,Y)))
++#else
++#  define _Py_PRINTF(X,Y) Py_GCC_ATTRIBUTE((format(printf,X,Y))) 
++#endif
++
+ /* On QNX 6, struct termio must be declared by including sys/termio.h
+    if TCGETA, TCSETA, TCSETAW, or TCSETAF are used.  sys/termio.h must
+    be included before termios.h or it will generate an error. */

--- a/mingw-w64-python2/PKGBUILD
+++ b/mingw-w64-python2/PKGBUILD
@@ -6,7 +6,7 @@ _realname=python2
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.7.18
-pkgrel=7
+pkgrel=8
 _pybasever=${pkgver%.*}
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
@@ -336,6 +336,9 @@ build() {
     extra_config+=("--with-pydebug")
   fi
 
+  # for clang v16
+  CFLAGS+=" -Wno-incompatible-function-pointer-types"
+
   local LIBFFI_INC=`${MINGW_PREFIX}/bin/pkg-config libffi --cflags-only-I | sed "s|\-I||g"`
   export LIBFFI_INCLUDEDIR=$(cygpath -wm ${LIBFFI_INC})
 
@@ -437,7 +440,7 @@ package() {
 sha256sums=('b62c0e7937551d0cc02b8fd5cb0f544f9405bafc9a54d3808ed4594812edef43'
             '31e9c1b8842077967708955e5f0023bda46d77a838285c7f80ef9775fa92aa14'
             'ba7896f990ae941411eea25dc1afc5364bc6ba8faa940543d30a984b8ea0bb2a'
-            '2385c56258951e8bce7cbd074b9887a949d84db4fddded0224fd5eb4df479319'
+            '543761b6b4b5e5d7345b298e615963cdfcc62b64616b3adc275ffc564c52ec9b'
             'c26142f87f8326e72620e531e18f0b89aca0f6f8a6985023db91b27a5be0a3e6'
             '91988723f9022def0c008a6245312a9f178439e03324f225a5c517755b788532'
             'f43ddf417d92585a4c4f2034d9724b9873d898b3db398276fcacbdd2eb1545c9'
@@ -515,7 +518,7 @@ sha256sums=('b62c0e7937551d0cc02b8fd5cb0f544f9405bafc9a54d3808ed4594812edef43'
             '3bb4f399795f75767cb5e4684d0e1cd0e70b82f09e2234730f5b3be23ea30d97'
             'd17ee858f2182b0e189a8f894909a1214b24bb914fb0b6c98f15fcba33e41561'
             'abda2d8486b2ef9ef9c85fcfa0d2fa17afe83c3a23dc6f1e3340042f75083330'
-            '073a2882d383d87d37e9fc1b3e57b8d94898784df8d9b144a07767b2f3497e23'
+            '7886bd86e5953ba842fa58a54418c5bd555fccd903fab9c10c879af094408879'
             'f1cfeb815277166384632bd9730fe89f64dc5da7ee09c13a0b3515da08b08847'
             'be5379525508e0bc0c374f20a669c38c93986e24a07696d2a83a9552cc085b8d'
             '3f678e1c2d5280e7e712d35383557c31e069833b412242a18c8f395b4b68cc67'


### PR DESCRIPTION
this backports https://github.com/msys2/MINGW-packages/blob/d8414ad1842901eacfdb580acc3c25c118ca82f9/mingw-w64-python/0050-use-gnu_printf-in-format.patch from our Python 3 package, to use printf instead of gnu_printf which clang doesn't support.

as pointed out here: https://github.com/mesonbuild/meson/pull/11530#issuecomment-1532351609