### PR TITLE
pango: Fix glib2 linking in static library

### DIFF
--- a/mingw-w64-pango/PKGBUILD
+++ b/mingw-w64-pango/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
 pkgver=1.50.14
-pkgrel=2
+pkgrel=3
 pkgdesc="A library for layout and rendering of text (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -47,13 +47,19 @@ prepare() {
 }
 
 build() {
-  cd "${srcdir}"
+  local -a _static_flags=(
+    -DGIO_STATIC_COMPILATION
+    -DGLIB_STATIC_COMPILATION
+    -DGMODULE_STATIC_COMPILATION
+    -DGOBJECT_STATIC_COMPILATION
+  )
+
   [[ -d build-${MSYSTEM} ]] && rm -rf build-${MSYSTEM}
   mkdir -p build-${MSYSTEM}
   cd build-${MSYSTEM}
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-  ${MINGW_PREFIX}/bin/meson \
+  ${MINGW_PREFIX}/bin/meson setup \
     --prefix="${MINGW_PREFIX}" \
     --default-library shared \
     --buildtype plain \
@@ -70,8 +76,10 @@ build() {
   mkdir -p build-static-${MSYSTEM}
   cd build-static-${MSYSTEM}
 
+  CFLAGS+=" ${_static_flags[@]}" \
+  CXXFLAGS+=" ${_static_flags[@]}" \
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-  ${MINGW_PREFIX}/bin/meson \
+  ${MINGW_PREFIX}/bin/meson setup \
     --prefix="${MINGW_PREFIX}" \
     --default-library static \
     --buildtype plain \


### PR DESCRIPTION
This defines some glib2 macro to remove dllimport attribute in static library.

Fixes https://github.com/msys2/MINGW-packages/issues/17651