### PR TITLE
update cJSON to 1.7.16

### DIFF
--- a/mingw-w64-cjson/PKGBUILD
+++ b/mingw-w64-cjson/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=cjson
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.7.15
-pkgrel=2
+pkgver=1.7.16
+pkgrel=1
 pkgdesc="Ultralightweight JSON parser in ANSI C (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -15,7 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/DaveGamble/cJSON/archive/v${pkgver}.tar.gz")
-sha512sums=('0b32a758c597fcc90c8ed0af493c9bccd611b9d4f9a03e87de3f7337bb9a28990b810befd44bc321a0cb42cbcd0b026d45761f9bab7bd798f920b7b6975fb124')
+sha512sums=('24e6efb1067ecd2d87ea64eef5969fc425e8bcefd18f634cee6cc0b5b13614c97146495aaa125febd33a20d197408af720b596549db7537ec05d3e60bd87ea6a')
 
 build() {
   [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}


### PR DESCRIPTION
From the release notes:

## Features:

* Add an option for ENABLE_CJSON_VERSION_SO in CMakeLists.txt, see https://github.com/DaveGamble/cJSON/pull/534
* Add cmake_policy to CMakeLists.txt, see https://github.com/DaveGamble/cJSON/pull/613
* Add cJSON_SetBoolValue, see https://github.com/DaveGamble/cJSON/pull/639
* Add meson documentation, see https://github.com/DaveGamble/cJSON/pull/761

## Fixes:

* Fix memory leak in merge_patch, see https://github.com/DaveGamble/cJSON/pull/611
* Fix conflicting target names 'uninstall', see https://github.com/DaveGamble/cJSON/pull/617
* Bump cmake version to 3.0 and use new version syntax, see https://github.com/DaveGamble/cJSON/pull/587
* Print int without decimal places, see https://github.com/DaveGamble/cJSON/pull/630
* Fix 'cjson_utils-static' target not exist, see https://github.com/DaveGamble/cJSON/pull/625
* Add allocate check for replace_item_in_object, see https://github.com/DaveGamble/cJSON/pull/675
* Fix a null pointer crash in cJSON_ReplaceItemViaPointer, see https://github.com/DaveGamble/cJSON/pull/726