### PR TITLE
gimp3: Update to 2.99.16

### DIFF
--- a/mingw-w64-gimp3/0004-clang-windres.patch
+++ b/mingw-w64-gimp3/0004-clang-windres.patch
@@ -123,22 +123,21 @@ diff -bur gimp-2.99.12-c/plug-ins/file-faxg3/meson.build gimp-2.99.12/plug-ins/f
      ],
      include_directories: [
        rootInclude, appInclude,
-diff -bur gimp-2.99.12-c/plug-ins/file-fits/meson.build gimp-2.99.12/plug-ins/file-fits/meson.build
---- gimp-2.99.12-c/plug-ins/file-fits/meson.build	2022-08-21 13:21:38.000000000 -0600
-+++ gimp-2.99.12/plug-ins/file-fits/meson.build	2022-08-26 11:05:18.334294700 -0600
+--- gimp-2.99.16/plug-ins/file-fits/meson.build.orig	2023-07-06 07:48:46.078752900 +0200
++++ gimp-2.99.16/plug-ins/file-fits/meson.build	2023-07-06 07:49:41.120861200 +0200
 @@ -9,9 +9,9 @@
-   plugin_sources += windows.compile_resources(
-     gimp_plugins_rc,
-     args: [
--      '--define', 'ORIGINALFILENAME_STR="@0@"'.format(plugin_name+'.exe'),
--      '--define', 'INTERNALNAME_STR="@0@"'    .format(plugin_name),
--      '--define', 'TOP_SRCDIR="@0@"'          .format(meson.project_source_root()),
-+      '--define', 'ORIGINALFILENAME_STR=@0@'.format(plugin_name+'.exe'),
-+      '--define', 'INTERNALNAME_STR=@0@'    .format(plugin_name),
-+      '--define', 'TOP_SRCDIR=@0@'          .format(meson.project_source_root()),
-     ],
-     include_directories: [
-       rootInclude, appInclude,
+     plugin_sources += windows.compile_resources(
+       gimp_plugins_rc,
+       args: [
+-        '--define', 'ORIGINALFILENAME_STR="@0@"'.format(plugin_name+'.exe'),
+-        '--define', 'INTERNALNAME_STR="@0@"'    .format(plugin_name),
+-        '--define', 'TOP_SRCDIR="@0@"'          .format(meson.project_source_root()),
++        '--define', 'ORIGINALFILENAME_STR=@0@'.format(plugin_name+'.exe'),
++        '--define', 'INTERNALNAME_STR=@0@'    .format(plugin_name),
++        '--define', 'TOP_SRCDIR=@0@'          .format(meson.project_source_root()),
+       ],
+       include_directories: [
+         rootInclude, appInclude,
 diff -bur gimp-2.99.12-c/plug-ins/file-fli/meson.build gimp-2.99.12/plug-ins/file-fli/meson.build
 --- gimp-2.99.12-c/plug-ins/file-fli/meson.build	2022-08-21 13:21:38.000000000 -0600
 +++ gimp-2.99.12/plug-ins/file-fli/meson.build	2022-08-26 11:05:18.336295400 -0600

--- a/mingw-w64-gimp3/PKGBUILD
+++ b/mingw-w64-gimp3/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=gimp3
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.99.14
-pkgrel=6
+pkgver=2.99.16
+pkgrel=1
 pkgdesc="GNU Image Manipulation Program (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang32' 'clang64' 'clangarm64')
@@ -41,7 +41,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-aalib"
          "${MINGW_PACKAGE_PREFIX}-libwebp"
          "${MINGW_PACKAGE_PREFIX}-libwmf"
          $([[ ${MSYSTEM_CARCH} == aarch64 ]] || echo "${MINGW_PACKAGE_PREFIX}-luajit")
-         $([[ ${MSYSTEM_CARCH} == aarch64 ]] && echo "${MINGW_PACKAGE_PREFIX}-lua51")
+         "${MINGW_PACKAGE_PREFIX}-lua51"
          "${MINGW_PACKAGE_PREFIX}-lua51-lgi"
          "${MINGW_PACKAGE_PREFIX}-maxflow"
          "${MINGW_PACKAGE_PREFIX}-mypaint-brushes"
@@ -56,21 +56,18 @@ depends=("${MINGW_PACKAGE_PREFIX}-aalib"
          "${MINGW_PACKAGE_PREFIX}-xpm-nox")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-meson")
-options=('strip' 'makeflags')
 source=("https://download.gimp.org/pub/gimp/v2.99/gimp-${pkgver}.tar.xz"
         0001-clang-rc-files-fix.patch
         0002-skip-test-env.patch
         0004-clang-windres.patch
-        https://gitlab.gnome.org/GNOME/gimp/-/commit/9b517fbf7d629fb940344719eddf9421f013569b.patch
         lua.interp
         luajit.interp
         gimp-script-fu-interpreter.interp
         )
-sha256sums=('313a205475d1ff03c5c4d9602f09f5c975ba6c1c79d8843e2396f9fe2abdf7a8'
+sha256sums=('6b4496edee447339f923276755247eadb64ec40d8aec241d06b62d1a6eb6508d'
             '54b3abc136b78fd2ae9b7d2acd202fb91bf3b6c248b131f1629ca50ef2493fbe'
             '511a2a969d1ff3254b4f2453cdfbc3a86a60e2379adf9f6ed5735454a45ef6ee'
-            'ca612aeec8ae33e1fdcc70262aa65feefc4c0e391a9fda600b44aebfdd5f8cf5'
-            'af745ee612a83f5f9744ea9c0efe83326996c2a817ca1dc1bf6d73018e2cf78a'
+            '739b15faebe85db54bc09b8556f8eaf3b59789cf26f65a7a17eb36314fb6ceb4'
             '1f3ddde21613be29e83c39ec3fa420073c522e746455997529ada707b7d33eed'
             'ee8fd9e26675c7c2e477f280f3aad20cfa66d0a2da0cbceb7b2448f4bb8f8d37'
             '49d7ac87f2f437e89bb43e9be749c206d4c51bd9245133ffb1071aad4592ffb0')
@@ -92,19 +89,16 @@ prepare() {
   # Workaround for https://github.com/llvm/llvm-project/issues/57334
   apply_patch_with_msg \
     0004-clang-windres.patch
-
-  # https://gitlab.gnome.org/GNOME/gimp/-/issues/9132
-  apply_patch_with_msg \
-    9b517fbf7d629fb940344719eddf9421f013569b.patch
 }
 
 build() {
   [[ -d "${srcdir}"/build-${MSYSTEM} ]] && rm -rf "${srcdir}"/build-${MSYSTEM}
   mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
 
-  CFLAGS+=" -Wno-error=int-conversion" CXXFLAGS+=" -Wno-error=int-conversion" \
+  CFLAGS+=" -Wno-error=int-conversion -Wno-incompatible-function-pointer-types" \
+  CXXFLAGS+=" -Wno-error=int-conversion -Wno-incompatible-function-pointer-types" \
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-  ${MINGW_PREFIX}/bin/meson.exe \
+  ${MINGW_PREFIX}/bin/meson.exe setup \
     --buildtype=plain \
     --auto-features=enabled \
     --prefix=${MINGW_PREFIX} \
@@ -117,7 +111,7 @@ build() {
     -Dgi-docgen=disabled \
     -Dgudev=disabled \
     -Dheadless-tests=disabled \
-    -Djavascript=false \
+    -Djavascript=disabled \
     -Dlinux-input=disabled \
     -Dxcursor=disabled \
     -Dwin32-debug-console=true \


### PR DESCRIPTION
fixes #17727

* refresh patch
* lua is available for arm64 now
* remove default options
* remove patch included in the release