### PR TITLE
gdk-pixbuf2: Build static library separately

### DIFF
--- a/mingw-w64-gdk-pixbuf2/PKGBUILD
+++ b/mingw-w64-gdk-pixbuf2/PKGBUILD
@@ -7,25 +7,23 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
 pkgver=2.42.10
-pkgrel=2
+pkgrel=3
 pkgdesc="An image loading library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://gitlab.gnome.org/GNOME/gdk-pixbuf"
 license=('spdx:LGPL-2.1-or-later')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
              "${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-gi-docgen"
-             "${MINGW_PACKAGE_PREFIX}-python-docutils"
-             "tar")
+             "${MINGW_PACKAGE_PREFIX}-python-docutils")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-glib2>=2.37.2"
          "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
          "${MINGW_PACKAGE_PREFIX}-libpng"
          "${MINGW_PACKAGE_PREFIX}-libtiff")
-options=('emptydirs')
 install=${_realname}-${MSYSTEM}.install
 source=("https://download.gnome.org/sources/gdk-pixbuf/${pkgver%.*}/gdk-pixbuf-${pkgver}.tar.xz"
         0003-fix-dllmain.patch
@@ -55,27 +53,53 @@ prepare() {
 }
 
 build() {
-  mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
+  local -a _static_flags=(
+    -DGIO_STATIC_COMPILATION
+    -DGLIB_STATIC_COMPILATION
+    -DGMODULE_STATIC_COMPILATION
+    -DGOBJECT_STATIC_COMPILATION
+  )
+
+  local -a _meson_options=(
+    --prefix=${MINGW_PREFIX}
+    --wrap-mode=nodownload
+    --auto-features=enabled
+    --buildtype=plain
+    -Dinstalled_tests=false
+    -Drelocatable=true
+    -Dnative_windows_loaders=true
+    -Dbuiltin_loaders=windows
+  )
+
+  # Does not enable DLL_EXPORT, keeps DllMain far away (#17643)
+  # gir disabled. ERROR: can't resolve libraries to shared libraries
+  CFLAGS+=" ${_static_flags[@]}" \
+  CXXFLAGS+=" ${_static_flags[@]}" \
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+  ${MINGW_PREFIX}/bin/meson setup \
+    "${_meson_options[@]}" \
+    --default-library=static \
+    -Dgtk_doc=false \
+    -Dintrospection=disabled \
+    "gdk-pixbuf-${pkgver}" \
+    "build-${MSYSTEM}-static"
+
+  ${MINGW_PREFIX}/bin/meson compile -C "build-${MSYSTEM}-static"
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-  ${MINGW_PREFIX}/bin/meson \
-    --prefix=${MINGW_PREFIX} \
-    --wrap-mode=nodownload \
-    --default-library=both \
-    --auto-features=enabled \
-    --buildtype=plain \
-    -Dinstalled_tests=false \
-    -Drelocatable=true \
+  ${MINGW_PREFIX}/bin/meson setup \
+    "${_meson_options[@]}" \
+    --default-library=shared \
     -Dgtk_doc=true \
-    -Dnative_windows_loaders=true \
-    -Dbuiltin_loaders=windows \
-    "../gdk-pixbuf-${pkgver}"
+    "gdk-pixbuf-${pkgver}" \
+    "build-${MSYSTEM}-shared"
 
-  ${MINGW_PREFIX}/bin/meson compile
+  ${MINGW_PREFIX}/bin/meson compile -C "build-${MSYSTEM}-shared"
 }
 
 package_gdk-pixbuf2() {
-  ${MINGW_PREFIX}/bin/meson install -C "${srcdir}/build-${MSYSTEM}" --destdir "${pkgdir}"
+  ${MINGW_PREFIX}/bin/meson install -C "${srcdir}/build-${MSYSTEM}-static" --destdir "${pkgdir}"
+  ${MINGW_PREFIX}/bin/meson install -C "${srcdir}/build-${MSYSTEM}-shared" --destdir "${pkgdir}"
 
   for hook in gdk-pixbuf-query-loaders; do
     local hook_path="${srcdir}/${MINGW_PACKAGE_PREFIX}-${hook}.hook";


### PR DESCRIPTION
* Removes DllMain symbol in static library.
* Remove glib2 symbols with __imp decoration i.e. without dllimport attribute.

Fixes https://github.com/msys2/MINGW-packages/issues/17643