### PR TITLE
cairo: Fix glib2 linking in static library

### DIFF
--- a/mingw-w64-cairo/PKGBUILD
+++ b/mingw-w64-cairo/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _commit='b43e7c6f3cf7855e16170a06d3a9c7234c60ca94'
 pkgver=1.17.8
-pkgrel=2
+pkgrel=3
 pkgdesc="Cairo vector graphics library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -65,6 +65,13 @@ prepare() {
 }
 
 build() {
+  local -a _static_flags=(
+    -DGIO_STATIC_COMPILATION
+    -DGLIB_STATIC_COMPILATION
+    -DGMODULE_STATIC_COMPILATION
+    -DGOBJECT_STATIC_COMPILATION
+  )
+
   local -a _meson_options
   _meson_options=(
     --prefix=${MINGW_PREFIX}
@@ -81,6 +88,8 @@ build() {
   )
 
   # Enables CAIRO_WIN32_STATIC_BUILD, keeps DllMain far away (#17643)
+  CFLAGS+=" ${_static_flags[@]}" \
+  CXXFLAGS+=" ${_static_flags[@]}" \
   MSYS2_ARG_CONV_EXCL="--prefix=" \
   ${MINGW_PREFIX}/bin/meson setup \
     "${_meson_options[@]}" \
@@ -88,7 +97,7 @@ build() {
     "${_realname}-${pkgver}" \
     "build-${MSYSTEM}-static"
 
-  meson compile -C build-${MSYSTEM}-static
+  meson compile -C "build-${MSYSTEM}-static"
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
   ${MINGW_PREFIX}/bin/meson setup \


### PR DESCRIPTION
This defines some glib2 macro to remove dllimport attribute in libcairo-gobject.a static library. This removes the following symbols from libcairo-gobject.a:

```
__imp_g_boxed_type_register_static
__imp_g_enum_register_static
__imp_g_free
__imp_g_intern_static_string
__imp_g_memdup2
__imp_g_once_init_enter
__imp_g_once_init_leave
```

Fixes https://github.com/msys2/MINGW-packages/issues/17651