### PR TITLE
harfbuzz: Fix glib2 linking in static library

### DIFF
--- a/mingw-w64-harfbuzz/PKGBUILD
+++ b/mingw-w64-harfbuzz/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
 pkgver=8.0.1
-pkgrel=1
+pkgrel=2
 pkgdesc="OpenType text shaping engine (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -33,16 +33,16 @@ source=("https://github.com/harfbuzz/harfbuzz/releases/download/${pkgver}/harfbu
 sha256sums=('c1ce780acd385569f25b9a29603d1d5bc71e6940e55bfdd4f7266fad50e42620')
 
 build() {
-  # Build static and shared libs separately due to necessity of defining DGRAPHITE2_STATIC
-  # manually when building static version
-  export _static_dir="${srcdir}/build-${MSYSTEM}-static"
-  export _shared_dir="${srcdir}/build-${MSYSTEM}-shared"
+  local -a _static_flags=(
+    -DGIO_STATIC_COMPILATION
+    -DGLIB_STATIC_COMPILATION
+    -DGMODULE_STATIC_COMPILATION
+    -DGOBJECT_STATIC_COMPILATION
+    -DGRAPHITE2_STATIC
+  )
 
-  mkdir -p "${_static_dir}" && cd "${_static_dir}"
-
-  # static build
-  CFLAGS="${CFLAGS} -DGRAPHITE2_STATIC" \
-  CXXFLAGS="${CXXFLAGS} -DGRAPHITE2_STATIC" \
+  CFLAGS+=" ${_static_flags[@]}" \
+  CXXFLAGS+=" ${_static_flags[@]}" \
   MSYS2_ARG_CONV_EXCL="--prefix=" \
   ${MINGW_PREFIX}/bin/meson setup \
     --prefix="${MINGW_PREFIX}" \
@@ -59,12 +59,10 @@ build() {
     -Ddirectwrite=enabled \
     -Dtests=disabled \
     -Ddocs=disabled \
-    ../${_realname}-${pkgver}
+    "build-${MSYSTEM}-static" \
+    "${_realname}-${pkgver}"
 
-  ${MINGW_PREFIX}/bin/meson compile
-
-  # shared build
-  mkdir -p "${_shared_dir}" && cd "${_shared_dir}"
+  ${MINGW_PREFIX}/bin/meson compile -C "build-${MSYSTEM}-static"
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
   ${MINGW_PREFIX}/bin/meson setup \
@@ -81,9 +79,10 @@ build() {
     -Dchafa=disabled \
     -Ddirectwrite=enabled \
     -Dtests=disabled \
-    ../${_realname}-${pkgver}
+    "build-${MSYSTEM}-shared" \
+    "${_realname}-${pkgver}"
 
-  ${MINGW_PREFIX}/bin/meson compile
+  ${MINGW_PREFIX}/bin/meson compile -C "build-${MSYSTEM}-shared"
 }
 
 check(){
@@ -94,9 +93,9 @@ check(){
 }
 
 package_harfbuzz() {
-  ${MINGW_PREFIX}/bin/meson install -C "${srcdir}/build-${MSYSTEM}-static" --destdir "${pkgdir}"
+  ${MINGW_PREFIX}/bin/meson install -C "build-${MSYSTEM}-static" --destdir "${pkgdir}"
 
-  ${MINGW_PREFIX}/bin/meson install -C "${srcdir}/build-${MSYSTEM}-shared" --destdir "${pkgdir}"
+  ${MINGW_PREFIX}/bin/meson install -C "build-${MSYSTEM}-shared" --destdir "${pkgdir}"
 
   mkdir -p dest${MINGW_PREFIX}/share
   mv "${pkgdir}${MINGW_PREFIX}"/share/gtk-doc dest${MINGW_PREFIX}/share/gtk-doc


### PR DESCRIPTION
This defines some glib2 macro to remove dllimport attribute in libharfbuzz.a and libharfbuzz-gobject.a files. This removes the following symbols from libharfbuzz-gobject.a:

```
__imp_g_boxed_type_register_static
__imp_g_enum_register_static
__imp_g_flags_register_static
__imp_g_intern_static_string
__imp_g_once_init_enter
__imp_g_once_init_leave
```
