### PR TITLE
gitg: remove dependency on libsoup

### DIFF
--- a/mingw-w64-gitg/PKGBUILD
+++ b/mingw-w64-gitg/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gitg
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=41
-pkgrel=5
+pkgrel=6
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
 pkgdesc="git repository viewer for GTK+/GNOME (mingw-w64)"
@@ -16,7 +16,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme"
          "${MINGW_PACKAGE_PREFIX}-python3-gobject"
          "${MINGW_PACKAGE_PREFIX}-gsettings-desktop-schemas"
          "${MINGW_PACKAGE_PREFIX}-gtk-update-icon-cache"
-         "${MINGW_PACKAGE_PREFIX}-libsoup"
          "${MINGW_PACKAGE_PREFIX}-libsecret"
          "${MINGW_PACKAGE_PREFIX}-gspell"
          "${MINGW_PACKAGE_PREFIX}-libgit2-glib"


### PR DESCRIPTION
it no longer depends on it since v41