### PR TITLE
libpaper: fix relocation

### DIFF
--- a/mingw-w64-libpaper/0001-fix-relocation.patch
+++ b/mingw-w64-libpaper/0001-fix-relocation.patch
@@ -1,0 +1,9 @@
+--- libpaper-2.1.0/prefix.am.orig	2023-07-15 11:55:24.774074000 +0200
++++ libpaper-2.1.0/prefix.am	2023-07-15 11:55:34.735682600 +0200
+@@ -1,5 +1,5 @@
+ if OS_WIN32
+-REAL_INSTALLPREFIX=`cygpath -m @prefix@`
++REAL_INSTALLPREFIX=@prefix@
+ else
+ REAL_INSTALLPREFIX=@prefix@
+ endif

--- a/mingw-w64-libpaper/PKGBUILD
+++ b/mingw-w64-libpaper/PKGBUILD
@@ -53,8 +53,4 @@ check() {
 package() {
   cd "${srcdir}"/build-${CARCH}
   make install DESTDIR="${pkgdir}"
-
-  # add systemwide default papersize read by many office applications
-  install -dm 755 ${pkgdir}${MINGW_PREFIX}/etc
-  echo '# Simply write the paper name. See papersize(5) for possible values' > ${pkgdir}${MINGW_PREFIX}/etc/papersize
 }

--- a/mingw-w64-libpaper/PKGBUILD
+++ b/mingw-w64-libpaper/PKGBUILD
@@ -4,18 +4,22 @@ _realname=libpaper
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="library for handling paper characteristics (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url='https://github.com/rrthomas/libpaper'
 license=('spdx:LGPL-2.1-or-later AND GPL-3.0-or-later')
 makedepends=('gettext' "${MINGW_PACKAGE_PREFIX}-autotools" "${MINGW_PACKAGE_PREFIX}-cc" "help2man")
-source=("https://github.com/rrthomas/libpaper/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('474e9575e1235a0d8e3661f072de0193bab6ea1023363772f698a2cc39d640cf')
+source=("https://github.com/rrthomas/libpaper/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz"
+        "0001-fix-relocation.patch")
+sha256sums=('474e9575e1235a0d8e3661f072de0193bab6ea1023363772f698a2cc39d640cf'
+            '591f90fbf97d1f848765ddf8a73908c3e4bf84eb0c2cda13bc00822180609bae')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
+
+  patch -Np1 -i "${srcdir}/0001-fix-relocation.patch"
 
   autoreconf -fiv
 }
@@ -24,6 +28,9 @@ build() {
   cd "${srcdir}"/${_realname}-${pkgver}
   [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
   mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+
+  export MSYS2_ARG_CONV_EXCL="-DREAL_INSTALLPREFIX;-DINSTALLDIR"
+
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \


### PR DESCRIPTION
gnulib assumes the path format matches what we pass to configure, so make sure we only pass unix paths to the gnulib relocation functions.