### PR TITLE
cargo-local-registry: update windows-targets crate

### DIFF
--- a/mingw-w64-cargo-local-registry/PKGBUILD
+++ b/mingw-w64-cargo-local-registry/PKGBUILD
@@ -4,7 +4,7 @@ _realname=cargo-local-registry
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.2.6
-pkgrel=1
+pkgrel=2
 pkgdesc="A cargo subcommand to manage local registries (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
@@ -16,17 +16,18 @@ source=("$_realname-$pkgver.tar.gz::$url/archive/$pkgver.tar.gz")
 sha256sums=('b42e4904e4db100c27d81cf94a034438b20ae6dbb34d0fee39012f2d548680ca')
 
 prepare() {
-  cd "${srcdir}"
-  rm -rf "build-${MSYSTEM}" | true
-  cp -r "${_realname}-${pkgver}" "build-${MSYSTEM}"
-  cd "${srcdir}/build-${MSYSTEM}"
+  cd "${srcdir}/${_realname}-${pkgver}"
 
-  "${MINGW_PREFIX}/bin/cargo.exe" fetch
+  # update windows-targets to fix windows-gnullvm dependency specification
+  "${MINGW_PREFIX}/bin/cargo.exe" update -p windows-targets@0.48.0 --precise 0.48.1
+  "${MINGW_PREFIX}/bin/cargo.exe" fetch --locked
 }
 
 build() {
   msg "Cargo build for ${MSYSTEM}"
-  cd "${srcdir}/build-${MSYSTEM}"
+  cd "${srcdir}"
+  cp -r "${_realname}-${pkgver}" "build-${MSYSTEM}"
+  cd "build-${MSYSTEM}"
 
   "${MINGW_PREFIX}/bin/cargo.exe" build \
     --release \


### PR DESCRIPTION
for windows-gnullvm fix.  Less hacky than the previous sed approach used
in other packages before 0.48.1 was published.