### PR TITLE
cargo-c: Update to 0.9.21

### DIFF
--- a/mingw-w64-cargo-c/PKGBUILD
+++ b/mingw-w64-cargo-c/PKGBUILD
@@ -28,24 +28,8 @@ prepare() {
 
     patch -p1 -i "${srcdir}"/001-add-lib-prefix-on-windows-gnu.patch
 
-    cargo vendor \
-        --locked \
-        --versioned-dirs
-
-    mkdir -p .cargo
-    cat >> .cargo/config.toml <<END
-[source.crates-io]
-replace-with = "vendored-sources"
-
-[source.vendored-sources]
-directory = "vendor"
-END
-
-
-    sed -i -e 's/"cfg(all(target_arch = \\"\([^\\]\+\)\\", target_env = \\"gnu\\", target_abi = \\"llvm\\", not(windows_raw_dylib)))"/"\1-pc-windows-gnullvm"/g' \
-        "vendor/windows-targets-0.48.0/Cargo.toml"
-    sed -i -e 's/\("Cargo.toml":\)"[^"]\+"/\1"'"$(sha256sum "vendor/windows-targets-0.48.0/Cargo.toml" | cut -d' ' -f1)"'"/' \
-        "vendor/windows-targets-0.48.0/.cargo-checksum.json"
+    cargo fetch \
+        --locked
 }
 
 build() {

--- a/mingw-w64-cargo-c/PKGBUILD
+++ b/mingw-w64-cargo-c/PKGBUILD
@@ -3,13 +3,13 @@
 _realname=cargo-c
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.9.19
+pkgver=0.9.21
 pkgrel=1
 pkgdesc='A cargo subcommand to build and install C-ABI compatibile dynamic and static libraries (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang32' 'clang64' 'clangarm64')
 url='https://github.com/lu-zero/cargo-c/'
-license=('MIT')
+license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-curl"
          "${MINGW_PACKAGE_PREFIX}-openssl"
          "${MINGW_PACKAGE_PREFIX}-libgit2"
@@ -18,8 +18,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/lu-zero/cargo-c/archive/v${pkgver}.tar.gz"
         "${_realname}-${pkgver}.Cargo.lock"::"https://github.com/lu-zero/cargo-c/releases/download/v${pkgver}/Cargo.lock"
         001-add-lib-prefix-on-windows-gnu.patch)
-sha256sums=('c2633ff22e52da9985394f30c8ef5e9abbac4d14c9b79e3690c8e95cf500ab97'
-            '7dc8d68efcda151e0b284654c9ca0a17af4cc8bbf4db88342297b016361ef0d3'
+sha256sums=('fbc199ca7da0514d18200a19630a9bbce6f4d5871c9c3ca5f0b6bca42ee99095'
+            '30e60a7853ee4c6cc32239bc67fe55f8834d19cf70d49a4d35cece2c1d6931f3'
             'b749ffdb37eb6016dca37c41c2d644156bbd4a7d8ffaa7bc18c7813f7af646c0')
 
 prepare() {


### PR DESCRIPTION
windows-targets has been updated to 0.48.1, so remove the workaround for arm64