### PR TITLE
hunspell: some relocation cleanups

### DIFF
--- a/mingw-w64-hunspell/01-relocate.patch
+++ b/mingw-w64-hunspell/01-relocate.patch
@@ -14,10 +14,8 @@ index 4c29f1a..cc25476 100644
  nodist_hunspell_SOURCES= ../../config.h
  hunspell_LDADD = @LIBINTL@ @LIBICONV@ ../parsers/libparsers.a \
  	../hunspell/libhunspell-1.7.la @CURSESLIB@ @READLINELIB@
-diff --git a/src/tools/hunspell.cxx b/src/tools/hunspell.cxx
-index 399df86..0599794 100644
---- a/src/tools/hunspell.cxx
-+++ b/src/tools/hunspell.cxx
+--- hunspell-1.7.2/src/tools/hunspell.cxx.orig	2022-12-29 21:10:49.000000000 +0100
++++ hunspell-1.7.2/src/tools/hunspell.cxx	2023-07-20 07:59:29.376921500 +0200
 @@ -51,6 +51,7 @@
  #include "../hunspell/hunspell.hxx"
  #include "../hunspell/csutil.hxx"
@@ -60,14 +58,16 @@ index 399df86..0599794 100644
  #define PATHSEP ";"
  
  #ifdef __MINGW32__
-@@ -2042,11 +2064,20 @@ int main(int argc, char** argv) {
+@@ -2054,11 +2071,24 @@
    {
      std::string path_std_str = ".";
      path_std_str.append(PATHSEP); // <- check path in local directory
 +#ifndef __MINGW32__
      path_std_str.append(PATHSEP); // <- check path in root directory
 +#else
-+    path_std_str.append(single_path_relocation(BINDIR, BINDIR)).append(PATHSEP);
++    char* reloc_path = single_path_relocation(BINDIR, BINDIR);
++    path_std_str.append(reloc_path).append(PATHSEP);
++    free(reloc_path);
 +#endif    
      if (getenv("DICPATH")) {
        path_std_str.append(getenv("DICPATH")).append(PATHSEP);
@@ -75,25 +75,29 @@ index 399df86..0599794 100644
 +#ifndef __MINGW32__
      path_std_str.append(LIBDIR).append(PATHSEP);
 +#else
-+  path_std_str.append(pathlist_relocation(BINDIR, LIBDIR)).append(PATHSEP);
++  char* reloc_pathlist = get_relocated_path_list(BINDIR, LIBDIR);
++  path_std_str.append(reloc_pathlist).append(PATHSEP);
++  free(reloc_pathlist);
 +#endif
 +
      if (HOME) {
        const char * userooodir[] = USEROOODIR;
        for(size_t i = 0; i < sizeof(userooodir)/sizeof(userooodir[0]); ++i) {
-@@ -2056,7 +2087,11 @@ int main(int argc, char** argv) {
+@@ -2068,7 +2098,13 @@
  #endif
          path_std_str.append(userooodir[i]).append(PATHSEP);
        }
 +#ifndef __MINGW32__
        path_std_str.append(OOODIR);
 +#else
-+      path_std_str.append(single_path_relocation(BINDIR, OOODIR)).append(PATHSEP);
++      char* reloc_path = single_path_relocation(BINDIR, OOODIR);
++      path_std_str.append(reloc_path).append(PATHSEP);
++      free(reloc_path);
 +#endif 
      }
      path = mystrdup(path_std_str.c_str());
    }
-@@ -2152,6 +2187,7 @@ int main(int argc, char** argv) {
+@@ -2168,6 +2204,7 @@
    }
  
    if (arg_files == -1) {

--- a/mingw-w64-hunspell/PKGBUILD
+++ b/mingw-w64-hunspell/PKGBUILD
@@ -9,7 +9,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 # Please rebuild enchant when updating this if needed, otherwise it may
 # silently break spell checking in applications
 pkgver=1.7.2
-pkgrel=2
+pkgrel=3
 pkgdesc="Spell checker and morphological analyzer library and program (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -33,7 +33,7 @@ noextract=("${_realname}-${pkgver}.tar.gz")
 sha256sums=('69fa312d3586c988789266eaf7ffc9861d9f6396c31fc930a014d551b59bbd6e'
             '08209cbf1633fa92eae7e5d28f95f8df9d6184cc20fa878c99aec4709bb257fd'
             '965d3921ec4fdeec94a2718bc2c85ce5e1a00ea0e499330a554074a7ae15dfc6'
-            'b83cf450151da0f5dd07184eafde0b7d86ebc5affc799f44755c205aa30ae207'
+            '628ac7f44ae0e093f229e88316cc8fbfb027cdcbe2bc5cc28d75bc3c57413f7a'
             '260432a8f01525e83124c79e375cc9f0692b1a6c97773add4c69b8efe081cf1d')
 
 prepare() {


### PR DESCRIPTION
properly free the result of single_path_relocation() and replace pathlist_relocation() with get_relocated_path_list() which returns a heap allocated string instead.