### PR TITLE
gst-plugins-good: depend on libsoup3

### DIFF
--- a/mingw-w64-gst-plugins-good/PKGBUILD
+++ b/mingw-w64-gst-plugins-good/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-gst-plugin-gtk")
 pkgver=1.22.5
-pkgrel=1
+pkgrel=2
 pkgdesc="GStreamer Multimedia Framework Base Plugins (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -30,7 +30,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-bzip2"
          "${MINGW_PACKAGE_PREFIX}-libjpeg"
          "${MINGW_PACKAGE_PREFIX}-libpng"
          "${MINGW_PACKAGE_PREFIX}-libshout"
-         "${MINGW_PACKAGE_PREFIX}-libsoup"
+         "${MINGW_PACKAGE_PREFIX}-libsoup3"
          "${MINGW_PACKAGE_PREFIX}-libvpx"
          "${MINGW_PACKAGE_PREFIX}-mpg123"
          "${MINGW_PACKAGE_PREFIX}-speex"


### PR DESCRIPTION
the soup element dlopens one of libsoup2 or 3 depending on what is already loaded, so this shouldn't make a difference for the build. But default to libsoup3 so the newer lib gets loaded if possible.