### PR TITLE
gdk-pixbuf2: Add missing gdiplus dependency for static library

### DIFF
--- a/mingw-w64-gdk-pixbuf2/PKGBUILD
+++ b/mingw-w64-gdk-pixbuf2/PKGBUILD
@@ -7,7 +7,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
 pkgver=2.42.10
-pkgrel=3
+pkgrel=4
 pkgdesc="An image loading library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -34,7 +34,7 @@ noextract=("gdk-pixbuf-${pkgver}.tar.xz")
 sha256sums=('ee9b6c75d13ba096907a2e3c6b27b61bcd17f5c7ebeab5a5b439d2f2e39fe44b'
             '21bd9b2ba1447267c84f1b445cbcf50c62299254856c1c227cc7ba4babc9f27e'
             '9c4aadcc9ac9dc09c1d9ad94e395078f3d69623db3d7be66bacdb26b919e6540'
-            '3d3350dbb437a675e1bdfbc45ad7701634516cd95508411dfb33005b28c01044'
+            'c7a0e09fd611a6de0ed91348ba6776ad5c2c4fee4d834c61628318a374bc9318'
             '6277c30e763c7889a3446e2ce8c7b8dbe7212678497b2905582de8159831e3fb')
 
 prepare() {

--- a/mingw-w64-gdk-pixbuf2/fix-missing-meson-dep.patch
+++ b/mingw-w64-gdk-pixbuf2/fix-missing-meson-dep.patch
@@ -1,6 +1,6 @@
 --- gdk-pixbuf-2.38.0/gdk-pixbuf/meson.build.orig	2018-10-28 11:18:07.521967800 +0100
 +++ gdk-pixbuf-2.38.0/gdk-pixbuf/meson.build	2018-10-28 11:18:22.153804700 +0100
-@@ -135,7 +135,7 @@
+@@ -170,7 +170,7 @@
  
  # List of formats supported by the native Windows components-based loader(s)
  windows_native_loader_formats = [ 'bmp', 'emf', 'gif', 'ico', 'jpeg', 'tiff', 'wmf' ]
@@ -9,3 +9,11 @@
  
  # Build the loaders using native Windows components as static modules, if requested
  if native_windows_loaders
+@@ -214,6 +214,7 @@
+                     dependencies: [
+                       gdk_pixbuf_deps,
+                       included_loaders_deps,
++                      cc.find_library('gdiplus'),
+                     ],
+                     install: true)
+ 


### PR DESCRIPTION
Fixes https://github.com/msys2/MINGW-packages/pull/17829