### PR TITLE
starship: update to 1.16.0

### DIFF
--- a/mingw-w64-starship/PKGBUILD
+++ b/mingw-w64-starship/PKGBUILD
@@ -23,8 +23,6 @@ noextract=("${_realname}-${pkgver}.tar.gz")
 prepare() {
   tar -xzf "${srcdir}"/${_realname}-${pkgver}.tar.gz -C ${srcdir} || true
   cd "${srcdir}/${_realname}-${pkgver}"
-  # update windows-targets to fix windows-gnullvm dependency specification
-  "${MINGW_PREFIX}/bin/cargo.exe" update -p windows-targets@0.48.0 --precise 0.48.1
   "${MINGW_PREFIX}/bin/cargo.exe" fetch --locked
 }
 

--- a/mingw-w64-starship/PKGBUILD
+++ b/mingw-w64-starship/PKGBUILD
@@ -7,7 +7,9 @@ pkgver=1.15.0
 pkgrel=1
 pkgdesc="The cross-shell prompt for astronauts (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
+# i686 is disabled, see
+# https://github.com/msys2/MINGW-packages/pull/17831#issuecomment-1648392525
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://starship.rs"
 license=('spdx:ISC')
 depends=("${MINGW_PACKAGE_PREFIX}-libgit2")

--- a/mingw-w64-starship/PKGBUILD
+++ b/mingw-w64-starship/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=starship
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.11.0
-pkgrel=2
+pkgver=1.15.0
+pkgrel=1
 pkgdesc="The cross-shell prompt for astronauts (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
@@ -15,7 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-cmake")
 options=('staticlibs' 'strip')
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/starship/starship/archive/refs/tags/v${pkgver}.tar.gz")
-sha256sums=('7b408ef8a2ab47d7a7d0e120889bf12c8f2a965796f8a027d8b2176287fdec6b')
+sha256sums=('e525476cf93d3a06332abf9e02415d4789fac6f28e4b7d98db7d83da08231828')
 noextract=("${_realname}-${pkgver}.tar.gz")
 
 prepare() {
@@ -27,11 +27,11 @@ prepare() {
 }
 
 build() {
-  export WINAPI_NO_BUNDLED_LIBRARIES=1
-  ${MINGW_PREFIX}/bin/cargo build \
-  --release \
-  --frozen \
-  --manifest-path build-${MSYSTEM}/Cargo.toml
+  WINAPI_NO_BUNDLED_LIBRARIES=1 \
+    ${MINGW_PREFIX}/bin/cargo build \
+    --release \
+    --frozen \
+    --manifest-path build-${MSYSTEM}/Cargo.toml
 }
 
 package() {

--- a/mingw-w64-starship/PKGBUILD
+++ b/mingw-w64-starship/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=starship
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.15.0
+pkgver=1.16.0
 pkgrel=1
 pkgdesc="The cross-shell prompt for astronauts (mingw-w64)"
 arch=('any')
@@ -17,7 +17,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-cmake")
 options=('staticlibs' 'strip')
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/starship/starship/archive/refs/tags/v${pkgver}.tar.gz")
-sha256sums=('e525476cf93d3a06332abf9e02415d4789fac6f28e4b7d98db7d83da08231828')
+sha256sums=('133888e190ce1563927e16ee693da3026d2e668d975ac373f853e030743775c5')
 noextract=("${_realname}-${pkgver}.tar.gz")
 
 prepare() {

--- a/mingw-w64-starship/PKGBUILD
+++ b/mingw-w64-starship/PKGBUILD
@@ -22,18 +22,19 @@ noextract=("${_realname}-${pkgver}.tar.gz")
 
 prepare() {
   tar -xzf "${srcdir}"/${_realname}-${pkgver}.tar.gz -C ${srcdir} || true
-  cp -r ${_realname}-${pkgver} build-${MSYSTEM}
-  ${MINGW_PREFIX}/bin/cargo fetch \
-  --locked \
-  --manifest-path build-${MSYSTEM}/Cargo.toml
+  cd "${srcdir}/${_realname}-${pkgver}"
+  # update windows-targets to fix windows-gnullvm dependency specification
+  "${MINGW_PREFIX}/bin/cargo.exe" update -p windows-targets@0.48.0 --precise 0.48.1
+  "${MINGW_PREFIX}/bin/cargo.exe" fetch --locked
 }
 
 build() {
+  cp -r ${_realname}-${pkgver} build-${MSYSTEM}
+  cd "${srcdir}/build-${MSYSTEM}"
   WINAPI_NO_BUNDLED_LIBRARIES=1 \
     ${MINGW_PREFIX}/bin/cargo build \
     --release \
-    --frozen \
-    --manifest-path build-${MSYSTEM}/Cargo.toml
+    --frozen
 }
 
 package() {
@@ -41,8 +42,8 @@ package() {
   --frozen \
   --offline \
   --no-track \
-  --path build-${MSYSTEM} \
-  --root ${pkgdir}${MINGW_PREFIX}
+  --path "build-${MSYSTEM}" \
+  --root "${pkgdir}${MINGW_PREFIX}"
 
   install -Dm 644 build-${MSYSTEM}/LICENSE -t "${pkgdir}${MINGW_PREFIX}"/share/licenses/starship/
   install -dm 755 "${pkgdir}${MINGW_PREFIX}"/share/{bash-completion/completions,fish/vendor_completions.d,zsh/site-functions}/


### PR DESCRIPTION
don't know why, but it fails on i686. should we disable it?

upd.: i686 is disabled, but it will be fixed soon. see further conversation for details 