### PR TITLE
 openexr: Fix exporting TypedAttribute::value for GIMP

### DIFF
--- a/mingw-w64-openexr/0007-export-TypedAttribute-value.patch
+++ b/mingw-w64-openexr/0007-export-TypedAttribute-value.patch
@@ -1,0 +1,20 @@
+--- a/src/lib/OpenEXR/ImfAttribute.h
++++ b/src/lib/OpenEXR/ImfAttribute.h
+@@ -241,7 +241,7 @@
+ }
+ 
+ template <class T>
+-inline T &
++T &
+ TypedAttribute<T>::value ()
+ {
+     return _value;
+@@ -249,7 +249,7 @@
+ 
+ 
+ template <class T>
+-inline const T &
++const T &
+ TypedAttribute<T>::value () const
+ {
+     return _value;

--- a/mingw-w64-openexr/PKGBUILD
+++ b/mingw-w64-openexr/PKGBUILD
@@ -4,12 +4,12 @@ _realname=openexr
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=3.1.9
-pkgrel=1
+pkgrel=2
 pkgdesc='A high dynamic-range image file format library (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://www.openexr.com/"
-license=('BSD')
+license=('spdx:BSD-3-Clause')
 depends=("${MINGW_PACKAGE_PREFIX}-imath"
          "${MINGW_PACKAGE_PREFIX}-libwinpthread-git"
          "${MINGW_PACKAGE_PREFIX}-zlib")
@@ -25,9 +25,11 @@ replaces=(
   "${MINGW_PACKAGE_PREFIX}-pyilmbase"
 )
 source=("https://github.com/openexr/openexr/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
-        0006-cmake-soversion.patch)
+        0006-cmake-soversion.patch
+        0007-export-TypedAttribute-value.patch)
 sha256sums=('103e902d3902800ab07b5f3a298be7afd2755312737b2cdbfa01326ff99dac07'
-            'e65852ac2e5545472ad90830c97e964aa2c71e1795979a8b9867155d578d45ed')
+            'e65852ac2e5545472ad90830c97e964aa2c71e1795979a8b9867155d578d45ed'
+            'a217595fe918955905e92b2f3d3823b90c5d5e4b136ae8db3e1ded4467de49e1')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -42,7 +44,8 @@ prepare(){
   cd "${srcdir}/${_realname}-${pkgver}"
 
   apply_patch_with_msg \
-    0006-cmake-soversion.patch
+    0006-cmake-soversion.patch \
+    0007-export-TypedAttribute-value.patch
 }
 
 build() {


### PR DESCRIPTION
This removes inline specifier to export TypedAttribute::value which was already declared with dllexport attribute.

Fixes https://github.com/msys2/MINGW-packages/issues/17757