### PR TITLE
Update GTK3

### DIFF
--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -3,9 +3,9 @@
 _realname=gtk3
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-gtk-update-icon-cache")
-pkgver=3.24.38.r0.g3e6fd55
+pkgver=3.24.38.r0.0f717ca4
 pkgrel=1
-_commit=3e6fd55ee00d4209ce2f2af292829e4d6f674adc
+_commit=0f717ca4239175334ff54c72b0f0d1953d9f95b5
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -36,16 +36,14 @@ source=("git+https://gitlab.gnome.org/GNOME/gtk.git#commit=$_commit"
         "0005-meson-fix-linker-flags-pkgconfig.patch"
         "gtk-query-immodules-3.0.hook.in"
         "gtk-update-icon-cache.hook.in"
-        "gtk-update-icon-cache.script.in"
-        "https://github.com/GNOME/gtk/commit/43f37894b02e74d87c0474d20ea74e7997d0b872.patch")
+        "gtk-update-icon-cache.script.in")
 sha256sums=('SKIP'
             'b84a7f38f0af80680bee143d431f2a7bae53899efb337de0f67a1b4d9b59fa02'
             'e553083298495f9581ae1454b1046a22b83e81862311b30de984057eec859708'
             'f006498eaf5e93a927f1ee966512f7f059e66d3f47433eedab5c0f08692bdfac'
             'adbe57eb726d882bba7a031ab8fb1788e7cd03cbf713823fd0f99d3cb380b97c'
             '56a566739c4f153f3c924b2bfe5ec7aaca469e15c023810cd7c5f57036d1a258'
-            'ad431cedaa2c4a20db35c753c89b85b45c67872004255762094277d27eb7c18a'
-            '27dfab39e97fdde99f4a1c7a96553977e76a575c6647bd2b1bed35b71d8ba3d6')
+            'ad431cedaa2c4a20db35c753c89b85b45c67872004255762094277d27eb7c18a')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -75,9 +73,6 @@ prepare() {
   apply_patch_with_msg \
     0005-meson-fix-linker-flags-pkgconfig.patch
 
-  # https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/6004
-  apply_patch_with_msg \
-    43f37894b02e74d87c0474d20ea74e7997d0b872.patch
 }
 
 build() {

--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gtk3
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-gtk-update-icon-cache")
-pkgver=3.24.38.r0.0f717ca4
+pkgver=3.24.38.r43.g0f717ca
 pkgrel=1
 _commit=0f717ca4239175334ff54c72b0f0d1953d9f95b5
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"


### PR DESCRIPTION
A bug that affect all the popup windows is fixed https://gitlab.gnome.org/GNOME/gtk/-/issues/5974 Since gimp is releasing a new version this avoid crash in multiple tools