### PR TITLE
mypaint: fix compatibility with Python 3.11

### DIFF
--- a/mingw-w64-mypaint/PKGBUILD
+++ b/mingw-w64-mypaint/PKGBUILD
@@ -26,16 +26,29 @@ depends=("${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme"
 makedepends=("${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-swig"
-             "${MINGW_PACKAGE_PREFIX}-cc")
+             "${MINGW_PACKAGE_PREFIX}-cc"
+             $([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-gcc-compat"))
 options=('strip' '!debug' 'staticlibs')
-license=("GPL2" 'spdx:ISC')
+license=('spdx:GPL-2.0-or-later' 'spdx:ISC')
 url="http://mypaint.org"
-source=(https://github.com/mypaint/mypaint/releases/download/v${pkgver}/mypaint-${pkgver}.tar.xz)
-sha256sums=('f3e437d7cdd5fd28ef6532e8ab6b4b05d842bcdd644f16a0162dad3d8e57bb16')
+source=(https://github.com/mypaint/mypaint/releases/download/v${pkgver}/mypaint-${pkgver}.tar.xz
+        "0001-universal-newline.patch"::https://github.com/mypaint/mypaint/commit/032a155b72f2b021f66a994050d83f07342d04af.patch)
+sha256sums=('f3e437d7cdd5fd28ef6532e8ab6b4b05d842bcdd644f16a0162dad3d8e57bb16'
+            'b893d4b94dea23f1c71e363893bba2439a824bec05575b1514d6821397fc3d53')
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying ${_patch}"
+    patch -Nbp1 -i "${srcdir}/${_patch}"
+  done
+}
 
 prepare() {
-    cd "${srcdir}/${_realname}-${pkgver}"
+  cd "${srcdir}/${_realname}-${pkgver}"
 
+  apply_patch_with_msg \
+    0001-universal-newline.patch
 }
 
 build() {


### PR DESCRIPTION
"U" as the mode for universal line endings has been deprecated for a while and has been removed in Python 3.11. Universal line endings are the default now.

The CLANG* environments are failing currently (because numpy hasn't been rebuilt yet).
But this should fix the build error at least with GCC.
