### PR TITLE
pygments: disable docs temporarily during rebuilds

### DIFF
--- a/mingw-w64-python-pygments/PKGBUILD
+++ b/mingw-w64-python-pygments/PKGBUILD
@@ -9,7 +9,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=2.15.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Python syntax highlighter (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -37,7 +37,7 @@ prepare() {
 build () {
   cd "${srcdir}/python-build-${MSYSTEM}"
   ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
-  make -C doc html
+  #make -C doc html
 }
 
 check() {
@@ -55,7 +55,7 @@ package() {
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
 
-  mkdir -p "$pkgdir${MINGW_PREFIX}/share/doc"
-  cp -rT doc/_build/html "$pkgdir${MINGW_PREFIX}/share/doc/${_realname}"
-  install -Dm644 doc/pygmentize.1 -t "$pkgdir${MINGW_PREFIX}/share/man/man1"
+  #mkdir -p "$pkgdir${MINGW_PREFIX}/share/doc"
+  #cp -rT doc/_build/html "$pkgdir${MINGW_PREFIX}/share/doc/${_realname}"
+  #install -Dm644 doc/pygmentize.1 -t "$pkgdir${MINGW_PREFIX}/share/man/man1"
 }


### PR DESCRIPTION
This should be reverted once jinja is built