### PR TITLE
vapoursynth: update to 62

### DIFF
--- a/mingw-w64-vapoursynth/PKGBUILD
+++ b/mingw-w64-vapoursynth/PKGBUILD
@@ -3,26 +3,26 @@
 _realname=vapoursynth
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=61
-pkgrel=2
+pkgver=62
+pkgrel=1
 pkgdesc="A video processing framework with simplicity in mind (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://www.vapoursynth.com/"
-license=('LGPL')
+license=('spdx:LGPL-2.1-or-later')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
-         "${MINGW_PACKAGE_PREFIX}-cython"
          "${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-zimg")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cython"
              "${MINGW_PACKAGE_PREFIX}-autotools"
-             "${MINGW_PACKAGE_PREFIX}-python-sphinx")
-options=(!strip staticlibs)
+             "${MINGW_PACKAGE_PREFIX}-python-sphinx"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 source=("vapoursynth-${pkgver}.tar.gz::https://github.com/vapoursynth/vapoursynth/archive/R${pkgver}.tar.gz"
         "0001-wrong-arguments-to-Mem32-constructor.patch"
         "0002-prevent-portable-python.patch"
         "0003-no-registry-setup-py.patch")
-sha256sums=('a5d4feeb056679dd1204153250d7c1d38e5a639e995d3c4e3a8e2e8fe1425b75'
+sha256sums=('6f3eb7e2e32a0572b363e08d16092418e99bd9c8f06661645a0995f1f736d438'
             '085331d7c81da760b66864ec34647094384514689e7ea9895e7bd34ed9ce9831'
             'bc75208eb672446a23535455040d0f5a7e49e19e8276773dd9bc30ee87da2e27'
             '7b902630104322c9e78cc937cc050a85888bf40e184c6b0cd34d1872aff3674e')
@@ -40,7 +40,6 @@ prepare() {
 }
 
 build() {
-  [[ -d "${srcdir}"/build-${MSYSTEM} ]] && rm -rf "${srcdir}"/build-${MSYSTEM}
   mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
 
   ../${_realname}-R${pkgver}/configure \
@@ -69,7 +68,7 @@ package() {
   rm -f ${pkgdir}${MINGW_PREFIX}/lib/vapoursynth/*.dll.a
   rm -f ${pkgdir}${MINGW_PREFIX}/lib/python${_py3ver}/site-packages/*.dll.a
 
-  export CFLAGS="-L$(cygpath -wm $pkgdir)/${MINGW_PREFIX}/lib $CFLAGS"
+  export LDFLAGS="-L$(cygpath -wm $pkgdir)/${MINGW_PREFIX}/lib $LDFLAGS"
   cd "${srcdir}/${_realname}-R${pkgver}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \


### PR DESCRIPTION
Changes:
  * Add python-setuptools in makedepends for setup.py.
  * Move cython to makedepends.
  * Use LDFLAGS for linker option.