### PR TITLE
gdal: Add `xsimd` to makedepends.

### DIFF
--- a/mingw-w64-gdal/PKGBUILD
+++ b/mingw-w64-gdal/PKGBUILD
@@ -9,7 +9,7 @@ pkgbase=mingw-w64-${_realname,,}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=3.7.0
-pkgrel=3
+pkgrel=4
 pkgdesc="A translator library for raster geospatial data formats (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -20,7 +20,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-python-numpy"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"
-             "${MINGW_PACKAGE_PREFIX}-swig")
+             "${MINGW_PACKAGE_PREFIX}-swig"
+             "${MINGW_PACKAGE_PREFIX}-xsimd")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-armadillo"
          "${MINGW_PACKAGE_PREFIX}-arrow"


### PR DESCRIPTION
`xsimd` is a transient dependency of `arrow`. Without it installed, including `arrow`'s CMake module fails to import the target and leaves some variables in a bad state (e.g., `CMAKE_MODULE_PATH`).
