### PR TITLE
python-greenlet: Remove deprecated register keyword for clang32

### DIFF
--- a/mingw-w64-python-greenlet/PKGBUILD
+++ b/mingw-w64-python-greenlet/PKGBUILD
@@ -7,35 +7,39 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=2.0.2
-pkgrel=2
+pkgrel=3
 pkgdesc="Lightweight in-process concurrent programming (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://pypi.python.org/pypi/greenlet"
-license=('MIT')
+license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-python")
-makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools"
-             "${MINGW_PACKAGE_PREFIX}-cc")
-options=('staticlibs' 'strip' '!debug')
-source=("${_realname}-${pkgver}.tar.gz::https://files.pythonhosted.org/packages/source/g/greenlet/${_realname}-${pkgver}.tar.gz")
-sha256sums=('e7c8dc13af7db097bed64a051d2dd49e9f0af495c26995c00a9ee842690d34c0')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python-wheel")
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
+        "0001-remove-register-keyword.patch::https://github.com/python-greenlet/greenlet/commit/414319112db6d330ecc9f580bae1e896208693bd.patch")
+sha256sums=('e7c8dc13af7db097bed64a051d2dd49e9f0af495c26995c00a9ee842690d34c0'
+            '0f1d3c2c676c64947582a944076afeb70bb30d24bf0154f6d3cfce021a8a790c')
 
 prepare() {
-  rm -rf "python-build-${MSYSTEM}" | true
-  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -p1 -i "${srcdir}/0001-remove-register-keyword.patch"
 }
 
 build() {
-  cd "${srcdir}/python-build-${MSYSTEM}"
-  ${MINGW_PREFIX}/bin/python setup.py build
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 package() {
   cd "${srcdir}/python-build-${MSYSTEM}"
 
-  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
-    --root="${pkgdir}" --optimize=1 --skip-build
-  
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
   install -Dm0644 LICENSE.PSF "${pkgdir}"${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE.PSF
 }


### PR DESCRIPTION

    This fixes the following error with clang32
    src/greenlet/platform/switch_x86_unix.h:54:5: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]

