### PR TITLE
ogre3d: De-activate Python bindings for MINGW32

### DIFF
--- a/mingw-w64-ogre3d/PKGBUILD
+++ b/mingw-w64-ogre3d/PKGBUILD
@@ -5,12 +5,12 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=13.6.3
 _imgui_ver=1.87
-pkgrel=2
+pkgrel=3
 pkgdesc="A cross-platform 3D game engine (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://www.ogre3d.org/"
-license=("MIT")
+license=("spdx:MIT")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
@@ -86,6 +86,12 @@ build() {
     extra_config+=( -DCMAKE_BUILD_TYPE=Release )
   fi
 
+  if [[ "${MSYSTEM}" == "MINGW32" ]]; then
+    extra_config+=( -DOGRE_BUILD_COMPONENT_PYTHON=OFF )
+  else
+    extra_config+=( -DPYTHON_EXECUTABLE="${MINGW_PREFIX}/bin/python.exe" )
+  fi
+
   CXXFLAGS+=" -Wno-ignored-attributes -Wno-inconsistent-missing-override"
 
   rm -rf ${srcdir}/build-${MSYSTEM}
@@ -123,7 +129,6 @@ build() {
     -DOGRE_DOCS_PATH=share/doc/OGRE \
     -DOGRE_PLUGINS_PATH=lib/OGRE \
     -DOGRE_NODELESS_POSITIONING=ON \
-    -DPYTHON_EXECUTABLE="${MINGW_PREFIX}/bin/python.exe" \
     "${extra_config[@]}" \
     ../ogre-${pkgver}
 


### PR DESCRIPTION
`cc1plus` OOMs when trying to compile the Python bindings on MINGW32.

I also tried to switch to `-DCMAKE_BUILD_TYPE=None` and adding `-Os` and/or `-flarge-source-files`. But that doesn't make any difference.

Without the Python bindings, the rest still builds without issues for me on MINGW32. (I don't know if they are needed by any reverse dependencies though.)
