### PR TITLE
Add separate python-jinja-docs

### DIFF
--- a/mingw-w64-python-jinja-docs/PKGBUILD
+++ b/mingw-w64-python-jinja-docs/PKGBUILD
@@ -1,0 +1,35 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+
+_pyname=jinja2
+_realname=jinja
+# this is a separate package to break the jinja2 <-> sphinx dependency cycle
+pkgbase=mingw-w64-python-${_realname}-docs
+pkgname="${MINGW_PACKAGE_PREFIX}-python-${_realname}-docs"
+pkgver=3.1.2
+pkgrel=6
+pkgdesc="A simple pythonic template language written in Python (mingw-w64) (documentation)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+license=('spdx:BSD-3-Clause')
+url="https://jinja.palletsprojects.com/"
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-pallets-sphinx-themes"
+             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-log-cabinet"
+             "${MINGW_PACKAGE_PREFIX}-python-sphinx-issues")
+source=(${_realname}-${pkgver}.tar.gz::https://github.com/pallets/jinja/archive/${pkgver}.tar.gz)
+sha256sums=('ecae76cd1a064d40eb46c5375f07953d747f4d65b68cd3fa5f02c91714b799fc')
+
+prepare() {
+  rm -rf python-build-${MSYSTEM} | true
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
+}
+
+build() {
+  msg "Build documentation"
+  cd "${srcdir}/python-build-${MSYSTEM}/docs"
+  make html
+}
+
+package() {
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/share/doc/python-${_realname}"
+  cp -a "${srcdir}/python-build-${MSYSTEM}/docs/_build/html" "${pkgdir}${MINGW_PREFIX}/share/doc/python-${_realname}/html"
+}

--- a/mingw-w64-python-jinja/PKGBUILD
+++ b/mingw-w64-python-jinja/PKGBUILD
@@ -4,7 +4,6 @@ _pyname=jinja2
 _realname=jinja
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-#         "${MINGW_PACKAGE_PREFIX}-python-${_realname}-docs")
 pkgver=3.1.2
 pkgrel=6
 pkgdesc="A simple pythonic template language written in Python (mingw-w64)"
@@ -13,10 +12,10 @@ mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 license=('spdx:BSD-3-Clause')
 url="https://jinja.palletsprojects.com/"
 depends=("${MINGW_PACKAGE_PREFIX}-python-markupsafe")
-makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools"
-             "${MINGW_PACKAGE_PREFIX}-python-pallets-sphinx-themes"
-             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-log-cabinet"
-             "${MINGW_PACKAGE_PREFIX}-python-sphinx-issues")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
+provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/pallets/jinja/archive/${pkgver}.tar.gz)
 sha256sums=('ecae76cd1a064d40eb46c5375f07953d747f4d65b68cd3fa5f02c91714b799fc')
 
@@ -29,39 +28,12 @@ build() {
   msg "Python build for ${MSYSTEM}"
   cd "${srcdir}/python-build-${MSYSTEM}"
   ${MINGW_PREFIX}/bin/python setup.py build
-
-  #msg "Build documentation"
-  #cd "${srcdir}/python-build-${MSYSTEM}/docs"
-  #make html
 }
 
-package_python-jinja() {
-  provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-  conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-  replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-
+package() {
   cd "${srcdir}/python-build-${MSYSTEM}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
     ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" -O1
 
   install -Dm644 LICENSE.rst "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE.rst"
 }
-
-package_python-jinja-docs() {
-  pkgdesc+=" (documentation)"
-  depends=()
-
-  mkdir -p "${pkgdir}${MINGW_PREFIX}/share/doc/python-${_realname}"
-  cp -a "${srcdir}/python-build-${MSYSTEM}/docs/_build/html" "${pkgdir}${MINGW_PREFIX}/share/doc/python-${_realname}/html"
-}
-
-# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
-# vim: set ft=bash :
-
-# generate wrappers
-for _name in "${pkgname[@]}"; do
-  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
-  _func="$(declare -f "${_short}")"
-  eval "${_func/#${_short}/package_${_name}}"
-done
-# template end;


### PR DESCRIPTION
due to jinja having many reverse dependencies and the dep cycle with sphinx we need some way to break the cycle. Split out the docs build into a separate PKGBUILD.