### PR TITLE
blender: add missing header

### DIFF
--- a/mingw-w64-blender/0040-missing-header.patch
+++ b/mingw-w64-blender/0040-missing-header.patch
@@ -1,0 +1,11 @@
+--- blender-3.5.0/extern/glog/src/symbolize.h.orig	2023-02-15 23:58:23.000000000 +0100
++++ blender-3.5.0/extern/glog/src/symbolize.h	2023-07-27 19:44:32.093543000 +0200
+@@ -60,6 +60,8 @@
+ 
+ #ifdef HAVE_SYMBOLIZE
+ 
++#include <cstdint>
++
+ #if defined(__ELF__)  // defined by gcc
+ #if defined(__OpenBSD__)
+ #include <sys/exec_elf.h>

--- a/mingw-w64-blender/PKGBUILD
+++ b/mingw-w64-blender/PKGBUILD
@@ -12,11 +12,11 @@ _realname=blender
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.5.0
-pkgrel=2
+pkgrel=3
 pkgdesc="A fully integrated 3D graphics creation suite (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
-license=('GPL')
+license=('spdx:GPL-2.0-or-later')
 # buid conflict with "${MINGW_PACKAGE_PREFIX}-glog"
 url="https://www.blender.org"
 depends=("${MINGW_PACKAGE_PREFIX}-alembic"
@@ -101,7 +101,8 @@ source=(https://download.blender.org/source/${_realname}-${pkgver}.tar.xz
         0034-Fix-ARM64-Build.patch
         0035-Enable-SSE2NEON-on-Windows-ARM.patch
         0038-Fix-ARM64-Intrin.patch
-        0039-no-WRL-on-mingw-w64.patch)
+        0039-no-WRL-on-mingw-w64.patch
+        0040-missing-header.patch)
 sha256sums=('42862e86d9cf6904991f0a8cbe62c802505be9257b19cf043ec088dccee714e3'
             '447198b809e407c709018e243eeebb5cd1524ae42fb25773d9a457388a7be57e'
             'e08141d29b99d4abc27937bda8aa3a8ee6acea6d6ec5c54978d4ac924b3afeeb'
@@ -130,7 +131,8 @@ sha256sums=('42862e86d9cf6904991f0a8cbe62c802505be9257b19cf043ec088dccee714e3'
             'a48e49b9e6034ccd3b448bc44f4f30a4d64682e8820f68d470069c9cbcf8b6c7'
             '439c4d0978e3690f42a2c7b84a9fa91ed9b27979f244d4e8edd1461fe20d7011'
             'c24cbf39c116d86927123b98ec5cffb23a63a76e3b339640fe0934cf61db3706'
-            '6fb10ad52295b2232576642a21af48d34d95ca789c7f66fc33578812ce5f5eeb')
+            '6fb10ad52295b2232576642a21af48d34d95ca789c7f66fc33578812ce5f5eeb'
+            '91e0347aaca5e867d5c743c402fa24e60f2b68272b91ffdaef5e7e45ece11ea4')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -174,7 +176,8 @@ prepare() {
     0034-Fix-ARM64-Build.patch \
     0035-Enable-SSE2NEON-on-Windows-ARM.patch \
     0038-Fix-ARM64-Intrin.patch \
-    0039-no-WRL-on-mingw-w64.patch
+    0039-no-WRL-on-mingw-w64.patch \
+    0040-missing-header.patch
 }
 
 build() {
@@ -257,4 +260,9 @@ package() {
     ${pkgdir}${MINGW_PREFIX}/share/blender/${pkgver%.*}/scripts/startup \
     ${pkgdir}${MINGW_PREFIX}/share/blender/${pkgver%.*}/scripts/modules \
     ${pkgdir}${MINGW_PREFIX}/share/blender/${pkgver%.*}/scripts/addons
+
+  install -d "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/"
+  for file in "${srcdir}/${_realname}-${pkgver}/doc/license/"*; do
+    install -Dm644 "${file}" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/"
+  done
 }


### PR DESCRIPTION
Trying to build blender in MINGW64 fails with errors like the following:
```
FAILED: extern/glog/CMakeFiles/extern_glog.dir/src/signalhandler.cc.obj
C:\msys64\mingw64\bin\g++.exe -DFREE_WINDOWS -DGFLAGS_DLL_DECL="" -DGFLAGS_DLL_DECLARE_FLAG="" -DGFLAGS_DLL_DEFINE_FLAG="" -DGOOGLE_GLOG_DLL_DECL="" -DNDEBUG -DWIN32 -DWITH_ASSERT_ABORT -DWITH_OPENGL -D_WIN32_WINNT=0x603 -D__LITTLE_ENDIAN__ -D__MMX__ -D__SSE2__ -D__SSE__ -ID:/repo/MSYS2/MINGW-packages/mingw-w64-blender/src/blender-3.5.0/extern/glog/src -ID:/repo/MSYS2/MINGW-packages/mingw-w64-blender/src/blender-3.5.0/extern/gflags/src -ID:/repo/MSYS2/MINGW-packages/mingw-w64-blender/src/blender-3.5.0/extern/glog/src/windows -march=nocona -msahf -mtune=generic -O2 -pipe -w -fopenmp -msse -pipe -fPIC -funsigned-char -fno-strict-aliasing -ffp-contract=off -msse2 -fmacro-prefix-map="D:/repo/MSYS2/MINGW-packages/mingw-w64-blender/src/blender-3.5.0\"="" -fmacro-prefix-map="D:/repo/MSYS2/MINGW-packages/mingw-w64-blender/src/build-MINGW64\"=""   -Wno-maybe-uninitialized -O2 -DNDEBUG -std=c++17 -MD -MT extern/glog/CMakeFiles/extern_glog.dir/src/signalhandler.cc.obj -MF extern\glog\CMakeFiles\extern_glog.dir\src\signalhandler.cc.obj.d -o extern/glog/CMakeFiles/extern_glog.dir/src/signalhandler.cc.obj -c D:/repo/MSYS2/MINGW-packages/mingw-w64-blender/src/blender-3.5.0/extern/glog/src/signalhandler.cc
In file included from D:/repo/MSYS2/MINGW-packages/mingw-w64-blender/src/blender-3.5.0/extern/glog/src/signalhandler.cc:36:
D:/repo/MSYS2/MINGW-packages/mingw-w64-blender/src/blender-3.5.0/extern/glog/src/symbolize.h:123:34: error: 'uint64_t' has not been declared
  123 |                                  uint64_t relocation);
      |                                  ^~~~~~~~
D:/repo/MSYS2/MINGW-packages/mingw-w64-blender/src/blender-3.5.0/extern/glog/src/symbolize.h:136:15: error: typedef 'google::SymbolizeOpenObjectFileCallback' is initialized (use 'decltype' instead)
  136 | typedef int (*SymbolizeOpenObjectFileCallback)(uint64_t pc,
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
D:/repo/MSYS2/MINGW-packages/mingw-w64-blender/src/blender-3.5.0/extern/glog/src/symbolize.h:136:48: error: 'uint64_t' was not declared in this scope
  136 | typedef int (*SymbolizeOpenObjectFileCallback)(uint64_t pc,
      |                                                ^~~~~~~~
D:/repo/MSYS2/MINGW-packages/mingw-w64-blender/src/blender-3.5.0/extern/glog/src/symbolize.h:59:1: note: 'uint64_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   58 | #include "config.h"
  +++ |+#include <cstdint>
   59 | #include "glog/logging.h"
```

Add the missing header.
