### PR TITLE
pycryptodome: fix arm64 build

### DIFF
--- a/mingw-w64-python-pycryptodome/PKGBUILD
+++ b/mingw-w64-python-pycryptodome/PKGBUILD
@@ -4,7 +4,7 @@ _realname=pycryptodome
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=3.18.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Collection of cryptographic algorithms and protocols, implemented for use from Python (mingw-w64)"
 url="https://www.pycryptodome.org/"
 license=('spdx:BSD-2-Clause')
@@ -14,13 +14,16 @@ depends=("${MINGW_PACKAGE_PREFIX}-gmp"
          "${MINGW_PACKAGE_PREFIX}-python")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-cc")
-source=("${_realname}-${pkgver}.tar.gz::https://github.com/Legrandin/pycryptodome/archive/v${pkgver}.tar.gz")
-sha256sums=('60f58349c3d62a99bb87665b2a16afda87dc2d537a14aa45aaad1a3748b781ba')
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/Legrandin/pycryptodome/archive/v${pkgver}.tar.gz"
+        "check-for-__cpuidex-in-intrin-h.patch::https://github.com/Legrandin/pycryptodome/pull/757.patch")
+sha256sums=('60f58349c3d62a99bb87665b2a16afda87dc2d537a14aa45aaad1a3748b781ba'
+            '59feec98aee2aefc0d5d187861328ad08515b2cb3a64180c33d295c3cf6db367')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
   export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}
+  patch -Nbp1 -i "${srcdir}/check-for-__cpuidex-in-intrin-h.patch"
 }
 
 build() {


### PR DESCRIPTION
See also Legrandin/pycryptodome#757.  This may also be due to a bug in mingw-w64, that `__cpuid` prototype is present on ARM.