### PR TITLE
mesa: Fix building AMD vulkan driver

### DIFF
--- a/mingw-w64-mesa/0003-addrlib-workaround-old-cpu-target.patch
+++ b/mingw-w64-mesa/0003-addrlib-workaround-old-cpu-target.patch
@@ -1,0 +1,18 @@
+--- a/src/amd/addrlib/src/core/addrcommon.h
++++ b/src/amd/addrlib/src/core/addrcommon.h
+@@ -356,12 +356,12 @@
+ {
+     ADDR_ASSERT(mask > 0);
+     unsigned long out = 0;
+-#if (defined(_WIN64) && defined(_M_X64)) || (defined(_WIN32) && defined(_M_IX64))
++#if defined(HAVE___BUILTIN_CTZ)
++    out = __builtin_ctz(mask);
++#elif (defined(_WIN64) && defined(_M_X64)) || (defined(_WIN32) && defined(_M_IX64))
+     out = ::_tzcnt_u32(mask);
+ #elif (defined(_WIN32) || defined(_WIN64))
+     ::_BitScanForward(&out, mask);
+-#elif defined(__GNUC__)
+-    out = __builtin_ctz(mask);
+ #else
+     while ((mask & 1) == 0)
+     {

--- a/mingw-w64-mesa/0004-radv-add-stdcall-attribute.patch
+++ b/mingw-w64-mesa/0004-radv-add-stdcall-attribute.patch
@@ -1,0 +1,121 @@
+diff --git a/src/amd/vulkan/radv_video.c b/src/amd/vulkan/radv_video.c
+index 32d5624..db27e88 100644
+--- a/src/amd/vulkan/radv_video.c
++++ b/src/amd/vulkan/radv_video.c
+@@ -193,7 +193,7 @@ static unsigned calc_ctx_size_h265_main10(struct radv_video_session *vid)
+    return cm_buffer_size + db_left_tile_ctx_size + db_left_tile_pxl_size;
+ }
+ 
+-VkResult
++VKAPI_ATTR VkResult VKAPI_CALL
+ radv_CreateVideoSessionKHR(VkDevice _device,
+                            const VkVideoSessionCreateInfoKHR *pCreateInfo,
+                            const VkAllocationCallbacks *pAllocator,
+@@ -245,7 +245,7 @@ radv_CreateVideoSessionKHR(VkDevice _device,
+    return VK_SUCCESS;
+ }
+ 
+-void
++VKAPI_ATTR void VKAPI_CALL
+ radv_DestroyVideoSessionKHR(VkDevice _device,
+                             VkVideoSessionKHR _session,
+                             const VkAllocationCallbacks *pAllocator)
+@@ -260,7 +260,7 @@ radv_DestroyVideoSessionKHR(VkDevice _device,
+ }
+ 
+ 
+-VkResult
++VKAPI_ATTR VkResult VKAPI_CALL
+ radv_CreateVideoSessionParametersKHR(VkDevice _device,
+                                      const VkVideoSessionParametersCreateInfoKHR *pCreateInfo,
+                                      const VkAllocationCallbacks *pAllocator,
+@@ -288,7 +288,7 @@ radv_CreateVideoSessionParametersKHR(VkDevice _device,
+    return VK_SUCCESS;
+ }
+ 
+-void
++VKAPI_ATTR void VKAPI_CALL
+ radv_DestroyVideoSessionParametersKHR(VkDevice _device,
+                                       VkVideoSessionParametersKHR _params,
+                                       const VkAllocationCallbacks *pAllocator)
+@@ -300,7 +300,7 @@ radv_DestroyVideoSessionParametersKHR(VkDevice _device,
+    vk_free2(&device->vk.alloc, pAllocator, params);
+ }
+ 
+-VkResult
++VKAPI_ATTR VkResult VKAPI_CALL
+ radv_GetPhysicalDeviceVideoCapabilitiesKHR(VkPhysicalDevice physicalDevice,
+                                            const VkVideoProfileInfoKHR *pVideoProfile,
+                                            VkVideoCapabilitiesKHR *pCapabilities)
+@@ -393,7 +393,7 @@ radv_GetPhysicalDeviceVideoCapabilitiesKHR(VkPhysicalDevice physicalDevice,
+    return VK_SUCCESS;
+ }
+ 
+-VkResult
++VKAPI_ATTR VkResult VKAPI_CALL
+ radv_GetPhysicalDeviceVideoFormatPropertiesKHR(VkPhysicalDevice physicalDevice,
+                                                const VkPhysicalDeviceVideoFormatInfoKHR *pVideoFormatInfo,
+                                                uint32_t *pVideoFormatPropertyCount,
+@@ -444,7 +444,7 @@ radv_GetPhysicalDeviceVideoFormatPropertiesKHR(VkPhysicalDevice physicalDevice,
+ #define RADV_BIND_SESSION_CTX 0
+ #define RADV_BIND_DECODER_CTX 1
+ 
+-VkResult
++VKAPI_ATTR VkResult VKAPI_CALL
+ radv_GetVideoSessionMemoryRequirementsKHR(VkDevice _device,
+                                           VkVideoSessionKHR videoSession,
+                                           uint32_t *pMemoryRequirementsCount,
+@@ -498,7 +498,7 @@ radv_GetVideoSessionMemoryRequirementsKHR(VkDevice _device,
+    return VK_SUCCESS;
+ }
+ 
+-VkResult
++VKAPI_ATTR VkResult VKAPI_CALL
+ radv_UpdateVideoSessionParametersKHR(VkDevice _device,
+                                      VkVideoSessionParametersKHR videoSessionParameters,
+                                      const VkVideoSessionParametersUpdateInfoKHR *pUpdateInfo)
+@@ -517,7 +517,7 @@ copy_bind(struct radv_vid_mem *dst,
+    dst->size = src->memorySize;
+ }
+ 
+-VkResult
++VKAPI_ATTR VkResult VKAPI_CALL
+ radv_BindVideoSessionMemoryKHR(VkDevice _device,
+                                VkVideoSessionKHR videoSession,
+                                uint32_t videoSessionBindMemoryCount,
+@@ -1493,7 +1493,7 @@ static void ruvd_dec_message_create(struct radv_video_session *vid,
+    msg->body.create.height_in_samples = vid->vk.max_coded.height;
+ }
+ 
+-void
++VKAPI_ATTR void VKAPI_CALL
+ radv_CmdBeginVideoCodingKHR(VkCommandBuffer commandBuffer,
+                             const VkVideoBeginCodingInfoKHR *pBeginInfo)
+ {
+@@ -1543,7 +1543,7 @@ radv_uvd_cmd_reset(struct radv_cmd_buffer *cmd_buffer)
+       radeon_emit(cmd_buffer->cs, 0x81ff);
+ }
+ 
+-void
++VKAPI_ATTR void VKAPI_CALL
+ radv_CmdControlVideoCodingKHR(VkCommandBuffer commandBuffer,
+                               const VkVideoCodingControlInfoKHR *pCodingControlInfo)
+ {
+@@ -1556,7 +1556,7 @@ radv_CmdControlVideoCodingKHR(VkCommandBuffer commandBuffer,
+    }
+ }
+ 
+-void
++VKAPI_ATTR void VKAPI_CALL
+ radv_CmdEndVideoCodingKHR(VkCommandBuffer commandBuffer,
+                           const VkVideoEndCodingInfoKHR *pEndCodingInfo)
+ {
+@@ -1686,7 +1686,7 @@ radv_vcn_decode_video(struct radv_cmd_buffer *cmd_buffer,
+    set_reg(cmd_buffer, cmd_buffer->device->physical_device->vid_dec_reg.cntl, 1);
+ }
+ 
+-void
++VKAPI_ATTR void VKAPI_CALL
+ radv_CmdDecodeVideoKHR(VkCommandBuffer commandBuffer,
+                        const VkVideoDecodeInfoKHR *frame_info)
+ {

--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -38,14 +38,16 @@ source=(https://mesa.freedesktop.org/archive/${_realname}-${pkgver}.tar.xz{,.sig
         do-not-install-standard-headers.patch
         0001-Add-checks-for-NULL-dxil_validator.patch
         0002-meson-vaon12-fix-driver-file-name-for-mingw-build.patch
-        0003-addrlib-workaround-old-cpu-target.patch)
+        0003-addrlib-workaround-old-cpu-target.patch
+        0004-radv-add-stdcall-attribute.patch)
 sha256sums=('7261a17fb94867e3dc5a90d8a1f100fa04b0cbbde51d25302c0872b5e9a10959'
             'SKIP'
             '69f21522f20c10f5699dfe3e128aa88d4fedde816f6e8df1506d7470c44bf3da'
             'ac10033dd72e6ab705a8bdd5e2a47542a557d0cfc4c23fd0f319f682ec9308b8'
             '439bb27fc8201a6854f52550af7cffca1cecab05a5a89e335ac15f1dfce08832'
             '89b2dcef98cd5e9c5f39f79459cae6fd568577ebb380dffcc0c4e70cf8f9a82f'
-            '4e511b1ab380d0e7d1f152f89c82665e5ef7de96f26de1b5597aa1db85cfc5a4')
+            '4e511b1ab380d0e7d1f152f89c82665e5ef7de96f26de1b5597aa1db85cfc5a4'
+            '77c31e7b63f6a01574be65d9a54f40e05cccd03eadae8ea3602ef5d17c4237a7')
 validpgpkeys=('8703B6700E7EE06D7A39B8D6EDAE37B02CEB490D') # Emil Velikov <emil.l.velikov@gmail.com>
 validpgpkeys+=('946D09B5E4C9845E63075FF1D961C596A7203456') # Andres Gomez <tanty@igalia.com>
 validpgpkeys+=('E3E8F480C52ADD73B278EE78E1ECBE07D7D70895') # Juan Antonio Suárez Romero (Igalia, S.L.) <jasuarez@igalia.com>"
@@ -106,7 +108,8 @@ prepare() {
     do-not-install-standard-headers.patch \
     0001-Add-checks-for-NULL-dxil_validator.patch \
     0002-meson-vaon12-fix-driver-file-name-for-mingw-build.patch \
-    0003-addrlib-workaround-old-cpu-target.patch
+    0003-addrlib-workaround-old-cpu-target.patch \
+    0004-radv-add-stdcall-attribute.patch
 
 # Generate binary wrap for LLVM if llvm-config tool is busted
   if ! [ "$(${MINGW_PREFIX}/bin/llvm-config --has-rtti 2>&1)" = YES ] && ! [ "$(${MINGW_PREFIX}/bin/llvm-config --has-rtti 2>&1)" = NO ]; then

--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -4,7 +4,7 @@ _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=23.1.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Open-source implementation of the OpenGL, Vulkan and OpenCL specifications (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -37,13 +37,15 @@ source=(https://mesa.freedesktop.org/archive/${_realname}-${pkgver}.tar.xz{,.sig
         llvmwrapgen.sh
         do-not-install-standard-headers.patch
         0001-Add-checks-for-NULL-dxil_validator.patch
-        0002-meson-vaon12-fix-driver-file-name-for-mingw-build.patch)
+        0002-meson-vaon12-fix-driver-file-name-for-mingw-build.patch
+        0003-addrlib-workaround-old-cpu-target.patch)
 sha256sums=('7261a17fb94867e3dc5a90d8a1f100fa04b0cbbde51d25302c0872b5e9a10959'
             'SKIP'
             '69f21522f20c10f5699dfe3e128aa88d4fedde816f6e8df1506d7470c44bf3da'
             'ac10033dd72e6ab705a8bdd5e2a47542a557d0cfc4c23fd0f319f682ec9308b8'
             '439bb27fc8201a6854f52550af7cffca1cecab05a5a89e335ac15f1dfce08832'
-            '89b2dcef98cd5e9c5f39f79459cae6fd568577ebb380dffcc0c4e70cf8f9a82f')
+            '89b2dcef98cd5e9c5f39f79459cae6fd568577ebb380dffcc0c4e70cf8f9a82f'
+            '4e511b1ab380d0e7d1f152f89c82665e5ef7de96f26de1b5597aa1db85cfc5a4')
 validpgpkeys=('8703B6700E7EE06D7A39B8D6EDAE37B02CEB490D') # Emil Velikov <emil.l.velikov@gmail.com>
 validpgpkeys+=('946D09B5E4C9845E63075FF1D961C596A7203456') # Andres Gomez <tanty@igalia.com>
 validpgpkeys+=('E3E8F480C52ADD73B278EE78E1ECBE07D7D70895') # Juan Antonio Suárez Romero (Igalia, S.L.) <jasuarez@igalia.com>"
@@ -103,7 +105,8 @@ prepare() {
   apply_patch_with_msg \
     do-not-install-standard-headers.patch \
     0001-Add-checks-for-NULL-dxil_validator.patch \
-    0002-meson-vaon12-fix-driver-file-name-for-mingw-build.patch
+    0002-meson-vaon12-fix-driver-file-name-for-mingw-build.patch \
+    0003-addrlib-workaround-old-cpu-target.patch
 
 # Generate binary wrap for LLVM if llvm-config tool is busted
   if ! [ "$(${MINGW_PREFIX}/bin/llvm-config --has-rtti 2>&1)" = YES ] && ! [ "$(${MINGW_PREFIX}/bin/llvm-config --has-rtti 2>&1)" = NO ]; then
@@ -134,11 +137,7 @@ build() {
   -Dmin-windows-version=7
   -Dgallium-opencl=icd
   -Dopencl-spirv=true
-  -Dvulkan-drivers=swrast,microsoft-experimental"
-
-  if [[ "${_mach}" == "clang-x86" ]]; then
-    buildconf="${buildconf},amd"
-  fi
+  -Dvulkan-drivers=swrast,amd,microsoft-experimental"
 
 # Fallback to binary wrap if llvm-config tool is busted
   if ! [ "$(${MINGW_PREFIX}/bin/llvm-config --has-rtti 2>&1)" = YES ] && ! [ "$(${MINGW_PREFIX}/bin/llvm-config --has-rtti 2>&1)" = NO ]; then


### PR DESCRIPTION
```
    _tzcnt_u32 requires Skylake or newer CPU[1]. So, it fails to build in
    msys2/mingw environment because the default target is older nocona.
    The attached patch allows to check __builtin_ctz first. This reverts
    the logic from 5bb1fc80fa2c91a6204d89c59b7288e941f94481 commit.

    This fixes the following compiler error

    bmiintrin.h: In function 'unsigned int Addr::BitScanForward(unsigned int)':
    bmiintrin.h:116:1: error: inlining failed in call to 'always_inline' 'unsigned int _tzcnt_u32(unsigned int)':
     target specific option mismatch
      116 | _tzcnt_u32 (unsigned int __X)
          | ^~~~~~~~~~
    ../../src/amd/addrlib/src/core/addrcommon.h:360:23: note: called from here
      360 |     out = ::_tzcnt_u32(mask);
          |           ~~~~~~~~~~~~^~~~~~

    [1]: https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_tzcnt_u32
```
