### PR TITLE
python-tomli cleanup

### DIFF
--- a/mingw-w64-gi-docgen/PKGBUILD
+++ b/mingw-w64-gi-docgen/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gi-docgen
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2023.1
-pkgrel=3
+pkgrel=4
 pkgdesc='Documentation tool for GObject-based libraries (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -16,7 +16,6 @@ depends=(
   "${MINGW_PACKAGE_PREFIX}-python-markdown"
   "${MINGW_PACKAGE_PREFIX}-python-markupsafe"
   "${MINGW_PACKAGE_PREFIX}-python-pygments"
-  "${MINGW_PACKAGE_PREFIX}-python-tomli" # Python<3.11
   "${MINGW_PACKAGE_PREFIX}-python-typogrify"
 )
 makedepends=(

--- a/mingw-w64-meson-python/PKGBUILD
+++ b/mingw-w64-meson-python/PKGBUILD
@@ -4,7 +4,7 @@ _realname=meson-python
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.13.2
-pkgrel=2
+pkgrel=3
 pkgdesc="Meson PEP 517 Python build backend (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -12,8 +12,7 @@ url='https://github.com/mesonbuild/meson-python'
 license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-meson"
          "${MINGW_PACKAGE_PREFIX}-python"
-         "${MINGW_PACKAGE_PREFIX}-python-pyproject-metadata"
-         "${MINGW_PACKAGE_PREFIX}-python-tomli") # Python < 3.11
+         "${MINGW_PACKAGE_PREFIX}-python-pyproject-metadata")
 makedepends=()
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")

--- a/mingw-w64-mypy/PKGBUILD
+++ b/mingw-w64-mypy/PKGBUILD
@@ -4,7 +4,7 @@ _realname=mypy
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.4.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Optional static typing for Python 2 and 3 (PEP484) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
@@ -12,7 +12,6 @@ url="http://www.mypy-lang.org/"
 license=('spdx:MIT')
 depends=(
   "${MINGW_PACKAGE_PREFIX}-python-mypy_extensions"
-  "${MINGW_PACKAGE_PREFIX}-python-tomli"
   "${MINGW_PACKAGE_PREFIX}-python-typing_extensions"
 )
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"

--- a/mingw-w64-python-autopep8/PKGBUILD
+++ b/mingw-w64-python-autopep8/PKGBUILD
@@ -4,7 +4,7 @@ _realname=autopep8
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
 pkgver=2.0.2
-pkgrel=2
+pkgrel=3
 pkgdesc='A tool that automatically formats Python code to conform to the PEP 8 style guide (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
@@ -12,8 +12,7 @@ license=('MIT')
 url='https://github.com/hhatto/autopep8'
 depends=(
     ${MINGW_PACKAGE_PREFIX}-python
-    ${MINGW_PACKAGE_PREFIX}-python-pycodestyle
-    ${MINGW_PACKAGE_PREFIX}-python-tomli)
+    ${MINGW_PACKAGE_PREFIX}-python-pycodestyle)
 makedepends=(${MINGW_PACKAGE_PREFIX}-python-setuptools unzip)
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('f9849cdd62108cb739dbcdbfb7fdcc9a30d1b63c4cc3e1c1f893b5360941b61c')

--- a/mingw-w64-python-black/PKGBUILD
+++ b/mingw-w64-python-black/PKGBUILD
@@ -4,7 +4,7 @@ _realname=black
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=23.7.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Uncompromising Python code formatter (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -14,8 +14,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-python-click"
          "${MINGW_PACKAGE_PREFIX}-python-mypy_extensions"
          "${MINGW_PACKAGE_PREFIX}-python-packaging"
          "${MINGW_PACKAGE_PREFIX}-python-pathspec"
-         "${MINGW_PACKAGE_PREFIX}-python-platformdirs"
-         "${MINGW_PACKAGE_PREFIX}-python-tomli") # tomli: to be removed with python 3.11
+         "${MINGW_PACKAGE_PREFIX}-python-platformdirs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
              "${MINGW_PACKAGE_PREFIX}-python-hatchling"

--- a/mingw-w64-python-build/PKGBUILD
+++ b/mingw-w64-python-build/PKGBUILD
@@ -4,7 +4,7 @@ _realname=build
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=0.10.0
-pkgrel=4
+pkgrel=5
 pkgdesc="A simple, correct Python build frontend (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -13,7 +13,6 @@ license=('spdx:MIT')
 depends=(
   "${MINGW_PACKAGE_PREFIX}-python-packaging"
   "${MINGW_PACKAGE_PREFIX}-python-pyproject-hooks"
-  "${MINGW_PACKAGE_PREFIX}-python-tomli"
 )
 optdepends=(
   "${MINGW_PACKAGE_PREFIX}-python-colorama"

--- a/mingw-w64-python-flit-scm/PKGBUILD
+++ b/mingw-w64-python-flit-scm/PKGBUILD
@@ -4,7 +4,7 @@ _realname=flit-scm
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=1.7.0
-pkgrel=2
+pkgrel=3
 pkgdesc="A PEP 518 build backend that uses setuptools_scm to generate a version file from your version control system, then flit to build the package. (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -12,8 +12,7 @@ url='https://gitlab.com/WillDaSilva/flit_scm'
 license=('MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-flit-core"
-         "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm"
-         "${MINGW_PACKAGE_PREFIX}-python-tomli")
+         "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build" "${MINGW_PACKAGE_PREFIX}-python-installer")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")

--- a/mingw-w64-python-flit/PKGBUILD
+++ b/mingw-w64-python-flit/PKGBUILD
@@ -4,7 +4,7 @@ _realname=flit
 pkgbase=mingw-w64-python-${_realname}
 pkgname=(${MINGW_PACKAGE_PREFIX}-python-$_realname)
 pkgver=3.9.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Simplified packaging of Python modules (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -15,7 +15,6 @@ depends=(
   "${MINGW_PACKAGE_PREFIX}-python"
   "${MINGW_PACKAGE_PREFIX}-python-flit-core"
   "${MINGW_PACKAGE_PREFIX}-python-requests"
-  "${MINGW_PACKAGE_PREFIX}-python-tomli"
   "${MINGW_PACKAGE_PREFIX}-python-tomli-w"
   "${MINGW_PACKAGE_PREFIX}-python-docutils"
 )

--- a/mingw-w64-python-hatch-fancy-pypi-readme/PKGBUILD
+++ b/mingw-w64-python-hatch-fancy-pypi-readme/PKGBUILD
@@ -4,15 +4,14 @@ _realname=hatch-fancy-pypi-readme
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=23.1.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Fancy PyPI READMEs with Hatch (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url='https://github.com/hynek/hatch-fancy-pypi-readme'
 license=('MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-python"
-         "${MINGW_PACKAGE_PREFIX}-python-hatchling"
-         "${MINGW_PACKAGE_PREFIX}-python-tomli") # with python<3.11
+         "${MINGW_PACKAGE_PREFIX}-python-hatchling")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build" "${MINGW_PACKAGE_PREFIX}-python-installer")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
 options=(!strip)

--- a/mingw-w64-python-hatchling/PKGBUILD
+++ b/mingw-w64-python-hatchling/PKGBUILD
@@ -4,7 +4,7 @@ _realname=hatchling
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=1.18.0
-pkgrel=2
+pkgrel=3
 pkgdesc='A modern project, package, and virtual env manager (backend) (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -15,7 +15,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-packaging"
          "${MINGW_PACKAGE_PREFIX}-python-pathspec"
          "${MINGW_PACKAGE_PREFIX}-python-pluggy"
-         "${MINGW_PACKAGE_PREFIX}-python-tomli"
          "${MINGW_PACKAGE_PREFIX}-python-trove-classifiers")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"

--- a/mingw-w64-python-jupyter_notebook_shim/PKGBUILD
+++ b/mingw-w64-python-jupyter_notebook_shim/PKGBUILD
@@ -4,7 +4,7 @@ _realname=notebook_shim
 pkgbase=mingw-w64-python-jupyter_${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-jupyter_${_realname}
 pkgver=0.2.3
-pkgrel=2
+pkgrel=3
 pkgdesc='A shim layer for notebook traits and config (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -12,8 +12,7 @@ url='https://jupyter.org/'
 license=('spdx:BSD-3-Clause')
 depends=(
     ${MINGW_PACKAGE_PREFIX}-python
-    ${MINGW_PACKAGE_PREFIX}-python-jupyter_server
-    ${MINGW_PACKAGE_PREFIX}-python-tomli)
+    ${MINGW_PACKAGE_PREFIX}-python-jupyter_server)
 makedepends=(
     ${MINGW_PACKAGE_PREFIX}-python-build
     ${MINGW_PACKAGE_PREFIX}-python-hatchling

--- a/mingw-w64-python-lsp-black/PKGBUILD
+++ b/mingw-w64-python-lsp-black/PKGBUILD
@@ -5,7 +5,7 @@ _realname=lsp-black
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
 pkgver=1.3.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Black plugin for the Python LSP Server (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
@@ -14,8 +14,7 @@ url='https://github.com/python-lsp/python-lsp-black'
 depends=(
     "${MINGW_PACKAGE_PREFIX}-python"
     "${MINGW_PACKAGE_PREFIX}-python-black"
-    "${MINGW_PACKAGE_PREFIX}-python-lsp-server"
-    "${MINGW_PACKAGE_PREFIX}-python-tomli")
+    "${MINGW_PACKAGE_PREFIX}-python-lsp-server")
 makedepends=(
     "${MINGW_PACKAGE_PREFIX}-python-build"
     "${MINGW_PACKAGE_PREFIX}-python-installer"

--- a/mingw-w64-python-maturin/PKGBUILD
+++ b/mingw-w64-python-maturin/PKGBUILD
@@ -4,15 +4,14 @@ _realname=maturin
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
 pkgver=1.1.0
-pkgrel=3
+pkgrel=4
 pkgdesc='Build and publish crates with pyo3, rust-cpython and cffi bindings as well as rust binaries as python packages (mingw-w64)'
 url='https://github.com/pyo3/maturin'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 license=('spdx:MIT OR Apache-2.0')
 depends=(
-    "${MINGW_PACKAGE_PREFIX}-python"
-    "${MINGW_PACKAGE_PREFIX}-python-tomli")
+    "${MINGW_PACKAGE_PREFIX}-python")
 makedepends=(
     "${MINGW_PACKAGE_PREFIX}-python-build"
     "${MINGW_PACKAGE_PREFIX}-python-installer"

--- a/mingw-w64-python-nvchecker/PKGBUILD
+++ b/mingw-w64-python-nvchecker/PKGBUILD
@@ -4,14 +4,13 @@ _realname=nvchecker
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=2.12
-pkgrel=2
+pkgrel=3
 pkgdesc="New version checker for software releases (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'mingw32' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
 url="https://github.com/lilydjwg/nvchecker"
 license=('MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-python"
-         "${MINGW_PACKAGE_PREFIX}-python-tomli"
          "${MINGW_PACKAGE_PREFIX}-python-structlog"
          "${MINGW_PACKAGE_PREFIX}-python-platformdirs"
          "${MINGW_PACKAGE_PREFIX}-python-tornado"

--- a/mingw-w64-python-pdm-backend/PKGBUILD
+++ b/mingw-w64-python-pdm-backend/PKGBUILD
@@ -4,7 +4,7 @@ _realname=pdm-backend
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=2.1.4
-pkgrel=2
+pkgrel=3
 pkgdesc="The build backend used by PDM that supports latest packaging standards (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -13,7 +13,6 @@ license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-packaging"
          "${MINGW_PACKAGE_PREFIX}-python-pyproject-metadata"
-         "${MINGW_PACKAGE_PREFIX}-python-tomli"
          "${MINGW_PACKAGE_PREFIX}-python-tomli-w")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer")

--- a/mingw-w64-python-pip-tools/PKGBUILD
+++ b/mingw-w64-python-pip-tools/PKGBUILD
@@ -4,7 +4,7 @@ _realname=pip-tools
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=7.1.0
-pkgrel=2
+pkgrel=3
 pkgdesc='A set of tools to keep your pinned Python dependencies fresh. (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
@@ -13,7 +13,6 @@ license=('spdx:BSD-3-Clause')
 depends=("${MINGW_PACKAGE_PREFIX}-python-build"
          "${MINGW_PACKAGE_PREFIX}-python-click"
          "${MINGW_PACKAGE_PREFIX}-python-pip"
-         "${MINGW_PACKAGE_PREFIX}-python-tomli"
          "${MINGW_PACKAGE_PREFIX}-python-setuptools"
          "${MINGW_PACKAGE_PREFIX}-python-wheel")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-installer"

--- a/mingw-w64-python-poetry/PKGBUILD
+++ b/mingw-w64-python-poetry/PKGBUILD
@@ -4,7 +4,7 @@ _realname=poetry
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=1.5.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Python dependency management and packaging made easy (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -34,7 +34,6 @@ depends=(
   "${MINGW_PACKAGE_PREFIX}-python-requests"
   "${MINGW_PACKAGE_PREFIX}-python-requests-toolbelt"
   "${MINGW_PACKAGE_PREFIX}-python-shellingham"
-  "${MINGW_PACKAGE_PREFIX}-python-tomli"
   "${MINGW_PACKAGE_PREFIX}-python-tomlkit"
   "${MINGW_PACKAGE_PREFIX}-python-trove-classifiers"
   "${MINGW_PACKAGE_PREFIX}-python-virtualenv"

--- a/mingw-w64-python-pydocstyle/PKGBUILD
+++ b/mingw-w64-python-pydocstyle/PKGBUILD
@@ -4,7 +4,7 @@ _realname=pydocstyle
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
 pkgver=6.3.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Python docstring style checker (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
@@ -12,8 +12,7 @@ license=('MIT')
 url='https://github.com/PyCQA/pydocstyle'
 depends=(
     ${MINGW_PACKAGE_PREFIX}-python
-    ${MINGW_PACKAGE_PREFIX}-python-snowballstemmer
-    ${MINGW_PACKAGE_PREFIX}-python-tomli) # Python<3.11
+    ${MINGW_PACKAGE_PREFIX}-python-snowballstemmer)
 makedepends=(${MINGW_PACKAGE_PREFIX}-python-build
              ${MINGW_PACKAGE_PREFIX}-python-installer
              ${MINGW_PACKAGE_PREFIX}-python-poetry-core)

--- a/mingw-w64-python-pylint/PKGBUILD
+++ b/mingw-w64-python-pylint/PKGBUILD
@@ -7,7 +7,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=2.17.4
-pkgrel=2
+pkgrel=3
 pkgdesc="Analyzes Python code looking for bugs and signs of poor quality (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -20,7 +20,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-isort"
          "${MINGW_PACKAGE_PREFIX}-python-mccabe"
          "${MINGW_PACKAGE_PREFIX}-python-platformdirs"
-         "${MINGW_PACKAGE_PREFIX}-python-tomli" # for python <3.11
          "${MINGW_PACKAGE_PREFIX}-python-tomlkit")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"

--- a/mingw-w64-python-pyproject-api/PKGBUILD
+++ b/mingw-w64-python-pyproject-api/PKGBUILD
@@ -4,15 +4,14 @@ _realname=pyproject-api
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=1.5.2
-pkgrel=2
+pkgrel=3
 pkgdesc="API to interact with the python pyproject.toml based projects (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url='https://github.com/tox-dev/pyproject-api'
 license=('MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-python"
-         "${MINGW_PACKAGE_PREFIX}-python-packaging"
-         "${MINGW_PACKAGE_PREFIX}-python-tomli") # Python<3.11
+         "${MINGW_PACKAGE_PREFIX}-python-packaging")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
              "${MINGW_PACKAGE_PREFIX}-python-hatchling"

--- a/mingw-w64-python-pyproject-hooks/PKGBUILD
+++ b/mingw-w64-python-pyproject-hooks/PKGBUILD
@@ -5,7 +5,7 @@ _realname=pyproject-hooks
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=1.0.0
-pkgrel=2
+pkgrel=3
 pkgdesc="A low-level library for calling build-backends in pyproject.toml-based project (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -13,7 +13,6 @@ url='https://github.com/pypa/pyproject-hooks'
 license=('spdx:MIT')
 depends=(
   "${MINGW_PACKAGE_PREFIX}-python"
-  "${MINGW_PACKAGE_PREFIX}-python-tomli"
 )
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-flit-core"

--- a/mingw-w64-python-pytest/PKGBUILD
+++ b/mingw-w64-python-pytest/PKGBUILD
@@ -7,7 +7,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=7.4.0
-pkgrel=2
+pkgrel=3
 pkgdesc='simple powerful testing with Python (mingw-w64)'
 url='https://pytest.org/'
 license=('MIT')
@@ -15,13 +15,9 @@ arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 depends=("${MINGW_PACKAGE_PREFIX}-python-attrs"
          "${MINGW_PACKAGE_PREFIX}-python-colorama"
-         # excpetiongroup to be removed with python 3.11
-         "${MINGW_PACKAGE_PREFIX}-python-exceptiongroup"
          "${MINGW_PACKAGE_PREFIX}-python-iniconfig"
          "${MINGW_PACKAGE_PREFIX}-python-packaging"
-         "${MINGW_PACKAGE_PREFIX}-python-pluggy"
-         # tomli to be removed with python 3.11
-         "${MINGW_PACKAGE_PREFIX}-python-tomli")
+         "${MINGW_PACKAGE_PREFIX}-python-pluggy")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"

--- a/mingw-w64-python-pytoolconfig/PKGBUILD
+++ b/mingw-w64-python-pytoolconfig/PKGBUILD
@@ -4,14 +4,13 @@ _realname=pytoolconfig
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=1.2.5
-pkgrel=2
+pkgrel=3
 pkgdesc="Python tool configuration (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url='https://github.com/bageljrkhanofemus/pytoolconfig'
 license=('spdx:LGPL-3.0-or-later')
 depends=("${MINGW_PACKAGE_PREFIX}-python"
-         "${MINGW_PACKAGE_PREFIX}-python-tomli"
          "${MINGW_PACKAGE_PREFIX}-python-packaging")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"

--- a/mingw-w64-python-scikit-build/PKGBUILD
+++ b/mingw-w64-python-scikit-build/PKGBUILD
@@ -4,7 +4,7 @@ _realname=scikit-build
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=0.17.6
-pkgrel=2
+pkgrel=3
 pkgdesc="Improved build system generator for Python C/C++/Fortran/Cython extensions (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -15,7 +15,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-packaging"
          "${MINGW_PACKAGE_PREFIX}-python-setuptools"
          "${MINGW_PACKAGE_PREFIX}-python-wheel"
-         "${MINGW_PACKAGE_PREFIX}-python-tomli"
          "${MINGW_PACKAGE_PREFIX}-cmake")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"

--- a/mingw-w64-python-setuptools-scm/PKGBUILD
+++ b/mingw-w64-python-setuptools-scm/PKGBUILD
@@ -7,7 +7,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=7.1.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Handles managing your python package versions in scm metadata (mingw-w64)'
 url='https://github.com/pypa/setuptools_scm'
 license=('MIT')
@@ -15,7 +15,6 @@ arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 depends=("${MINGW_PACKAGE_PREFIX}-python-packaging"
          "${MINGW_PACKAGE_PREFIX}-python-setuptools"
-         "${MINGW_PACKAGE_PREFIX}-python-tomli"
          "${MINGW_PACKAGE_PREFIX}-python-typing_extensions")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
 sha256sums=('6c508345a771aad7d56ebff0e70628bf2b0ec7573762be9960214730de278f27')

--- a/mingw-w64-python-tox/PKGBUILD
+++ b/mingw-w64-python-tox/PKGBUILD
@@ -7,7 +7,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=4.6.3
-pkgrel=2
+pkgrel=3
 pkgdesc="Python virtualenv management and testing tool (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -25,7 +25,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-platformdirs"
          "${MINGW_PACKAGE_PREFIX}-python-pluggy"
          "${MINGW_PACKAGE_PREFIX}-python-pyproject-api"
-         "${MINGW_PACKAGE_PREFIX}-python-tomli"
          "${MINGW_PACKAGE_PREFIX}-python-virtualenv"
          "${MINGW_PACKAGE_PREFIX}-python-filelock")
 options=('!strip')

--- a/mingw-w64-python-versioningit/PKGBUILD
+++ b/mingw-w64-python-versioningit/PKGBUILD
@@ -4,14 +4,13 @@ _realname=versioningit
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=2.2.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Versioning It with your Version In Git (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url='https://github.com/jwodder/versioningit'
 license=('spdx:MIT')
-depends=("${MINGW_PACKAGE_PREFIX}-python-packaging"
-         "${MINGW_PACKAGE_PREFIX}-python-tomli")
+depends=("${MINGW_PACKAGE_PREFIX}-python-packaging")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"

--- a/mingw-w64-sip/PKGBUILD
+++ b/mingw-w64-sip/PKGBUILD
@@ -8,14 +8,13 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-sip4")
 replaces=("${MINGW_PACKAGE_PREFIX}-sip5")
 pkgver=6.7.9
-pkgrel=2
+pkgrel=3
 pkgdesc="A tool that makes it easy to create Python bindings for C and C++ libraries (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 license=('custom:"sip"')
 url="https://riverbankcomputing.com/software/sip"
 depends=("${MINGW_PACKAGE_PREFIX}-python"
-         "${MINGW_PACKAGE_PREFIX}-python-tomli"
          "${MINGW_PACKAGE_PREFIX}-python-ply"
          "${MINGW_PACKAGE_PREFIX}-python-packaging"
          "${MINGW_PACKAGE_PREFIX}-python-setuptools")


### PR DESCRIPTION
In Python 3.11 tomli is also available in the stdlib and various packages use it if available instead of the tomli package.
Remove the tomli dependency for packages which don't require it with Python 3.11 anymore.