### PR TITLE
libiff: Fix building shared library

### DIFF
--- a/mingw-w64-libiff/0001-libiff-fix-shared-library.patch
+++ b/mingw-w64-libiff/0001-libiff-fix-shared-library.patch
@@ -1,0 +1,14 @@
+--- a/src/libiff/Makefile.am
++++ b/src/libiff/Makefile.am
+@@ -1,3 +1,4 @@
+ lib_LTLIBRARIES = libiff.la
+ pkginclude_HEADERS = io.h id.h extension.h chunk.h group.h cat.h form.h list.h prop.h rawchunk.h util.h error.h iff.h ifftypes.h
+ libiff_la_SOURCES = io.c id.c extension.c chunk.c group.c cat.c form.c list.c prop.c rawchunk.c util.c error.c iff.c
++libiff_la_LDFLAGS = -no-undefined -export-symbols libiff.def
+--- a/src/libiff/libiff.def
++++ b/src/libiff/libiff.def
+@@ -1,4 +1,3 @@
+-LIBRARY    libiff
+ EXPORTS
+ 	IFF_readFd                @1
+ 	IFF_read                  @2

--- a/mingw-w64-libiff/PKGBUILD
+++ b/mingw-w64-libiff/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libiff
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.1.r60.g0290be4
-pkgrel=1
+pkgrel=2
 pkgdesc="Portable, extensible parser for the Interchange File Format (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -16,8 +16,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              'help2man'
              'git')
 _appcommit='0290be4ed3df0c1b8e8f5c24012cc75ba8870570'
-source=("${_realname}"::"git+https://github.com/svanderburg/libiff.git#commit=$_appcommit")
-sha256sums=('SKIP')
+source=("${_realname}"::"git+https://github.com/svanderburg/libiff.git#commit=$_appcommit"
+        0001-libiff-fix-shared-library.patch)
+sha256sums=('SKIP'
+            'be986e175cbf9e0f2aba6c1a73d6372e172eee95a9d3157ec4c1e60824af8670')
 
 pkgver() {
   cd "${srcdir}/${_realname}"
@@ -26,6 +28,7 @@ pkgver() {
 
 prepare() {
   cd "${srcdir}"/${_realname}
+  git apply "${srcdir}/0001-libiff-fix-shared-library.patch"
 
   ./bootstrap
 }

--- a/mingw-w64-libilbm/0001-libilbm-fix-shared-library.patch
+++ b/mingw-w64-libilbm/0001-libilbm-fix-shared-library.patch
@@ -1,0 +1,14 @@
+--- a/src/libilbm/Makefile.am
++++ b/src/libilbm/Makefile.am
+@@ -4,3 +4,4 @@ pkginclude_HEADERS = bitmapheader.h colormap.h colorrange.h cycleinfo.h destmerg
+ libilbm_la_SOURCES = bitmapheader.c colormap.c colorrange.c cycleinfo.c destmerge.c dpiheader.c grab.c sprite.c viewport.c byterun.c ilbm.c interleave.c ilbmimage.c drange.c cmykmap.c colornames.c
+ libilbm_la_CFLAGS = $(LIBIFF_CFLAGS)
+ libilbm_la_LIBADD = $(LIBIFF_LIBS)
++libilbm_la_LDFLAGS = -no-undefined -export-symbols libilbm.def
+--- a/src/libilbm/libilbm.def
++++ b/src/libilbm/libilbm.def
+@@ -1,4 +1,3 @@
+-LIBRARY libilbm
+ EXPORTS
+ 	ILBM_createBitMapHeader           @1
+ 	ILBM_readBitMapHeader             @2

--- a/mingw-w64-libilbm/PKGBUILD
+++ b/mingw-w64-libilbm/PKGBUILD
@@ -4,21 +4,22 @@ _realname=libilbm
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.1.r68.g170c269
-pkgrel=1
+pkgrel=2
 pkgdesc="Parser library for the ILBM: IFF Interleaved BitMap format (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://github.com/svanderburg/libilbm"
 license=('spdx:MIT')
-depends=()
+depends=("${MINGW_PACKAGE_PREFIX}-libiff")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools"
-             "${MINGW_PACKAGE_PREFIX}-libiff"
              'help2man'
              'git')
 _appcommit='170c269bce23423f1163545ed9344482b2cf4487'
-source=("${_realname}"::"git+https://github.com/svanderburg/libilbm.git#commit=$_appcommit")
-sha256sums=('SKIP')
+source=("${_realname}"::"git+https://github.com/svanderburg/libilbm.git#commit=$_appcommit"
+        0001-libilbm-fix-shared-library.patch)
+sha256sums=('SKIP'
+            'f5cf5b89fa9afab573ede7a542046f93b87309811b13f51d5b9c095b953ea7bf')
 
 pkgver() {
   cd "${srcdir}/${_realname}"
@@ -27,6 +28,7 @@ pkgver() {
 
 prepare() {
   cd "${srcdir}"/${_realname}
+  git apply "${srcdir}/0001-libilbm-fix-shared-library.patch"
 
   ./bootstrap
 }


### PR DESCRIPTION
* Add -no-undefined option to build shared library.
* Add -export-symbols options with libiff.def file to export proper APIs.
* Remove LIBRARY name in libiff.def to use proper name in import library.