### PR TITLE
qt6: update to 6.5.2

### DIFF
--- a/mingw-w64-qt6-3d/PKGBUILD
+++ b/mingw-w64-qt6-3d/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-3d
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -24,7 +24,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 options=('!strip')
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('7e54e1e810ba57b510002b899d9b63d611b287691731739665c1a1b26139689b')
+sha256sums=('21f064db21ad1bfc5547fd4e8cba09acc8c187de58d7eee206f6549ab9e2f910')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-5compat/PKGBUILD
+++ b/mingw-w64-qt6-5compat/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-5compat
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -22,7 +22,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('ae992b295fefabef2445beb3a8ec31c40fa0fb2c01603eaf2acfdb4a0054fb83')
+sha256sums=('b9abe42ee2055c27a8e7579c7816069e91aae1f9b10649bf572db8ba96fa91c4')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-activeqt/PKGBUILD
+++ b/mingw-w64-qt6-activeqt/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-activeqt
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -22,7 +22,7 @@ _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz"
         001-appending-qt6-to-remove-qt5-conflict.patch
         002-Handle-win64-in-dumpcpp-and-MetaObjectGenerator-read.patch)
-sha256sums=('cd4c9da7a1670962d9e5968f2672f5d4e4ac8aaf6598b032c49cd9bf613c317a'
+sha256sums=('5d0040ca776fe484fd19f09567bc5f2838faab409e38a15730855169215ff013'
             '66b9460aeb5dd1144a04448cc461811157b100cb765e84d6af24fd83476a4217'
             '93e1c08068e45372fb02e9a33e3366b5067817ea7de4bba4e91b6c165645cb41')
 

--- a/mingw-w64-qt6-base/004-qt-6.2.0-win32-g-Add-QMAKE_EXTENSION_IMPORTLIB-defaulting-to-.patch
+++ b/mingw-w64-qt6-base/004-qt-6.2.0-win32-g-Add-QMAKE_EXTENSION_IMPORTLIB-defaulting-to-.patch
@@ -28,12 +28,12 @@
      } else {
          CMAKE_WINMAIN_FILE_LOCATION_DEBUG = qtmain$${QT_LIBINFIX}$${debug_suffix}.lib
          CMAKE_WINMAIN_FILE_LOCATION_RELEASE = qtmain$${QT_LIBINFIX}.lib
---- qtbase-6.2.0/mkspecs/features/qt.prf.orig	2021-10-07 10:08:00.815247900 +0300
-+++ qtbase-6.2.0/mkspecs/features/qt.prf	2021-10-07 10:11:39.347590300 +0300
-@@ -220,9 +220,13 @@
-             } else {
+--- a/mkspecs/features/qt.prf
++++ b/mkspecs/features/qt.prf
+@@ -250,9 +250,13 @@ for(ever) {
                  lib_bases = $$MODULE_MODULE$$qtPlatformTargetSuffix()
                  darwin: lib_bases *= $$MODULE_MODULE
+                 add_lib_to_pretargetdeps = false
 -                win32|contains(MODULE_CONFIG, staticlib) {
 +                win32 {
                      lib_prefix = $$MODULE_LIBS/$$QMAKE_PREFIX_STATICLIB
@@ -44,8 +44,8 @@
 +                        lib_suffixes = $$QMAKE_EXTENSION_IMPORTLIB
 +                    }
                      lib_suffixes *= $$QMAKE_LIB_EXTENSIONS
-                     add_lib_to_pretargetdeps = true
-                 } else {
+                     !xcodebuild: \
+                         add_lib_to_pretargetdeps = true
 --- qtbase-6.2.0/qmake/generators/win32/winmakefile.cpp.orig	2021-10-07 10:14:13.043627000 +0300
 +++ qtbase-6.2.0/qmake/generators/win32/winmakefile.cpp	2021-10-07 10:16:00.750253600 +0300
 @@ -99,10 +99,16 @@

--- a/mingw-w64-qt6-base/PKGBUILD
+++ b/mingw-w64-qt6-base/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-base
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=2
 arch=(any)
@@ -49,21 +49,19 @@ source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/subm
         009-qfileinfo-undefine-mingw-stat.patch
         010-export-some-constexpr-variables.patch
         011-qt6-windeployqt-fixes.patch
-        012-fix-unicode-definitions-in-cmake-interface.patch
-        https://download.qt.io/official_releases/qt/6.5/CVE-2023-34410-qtbase-6.5.diff)
-sha256sums=('db56fa1f4303a1189fe33418d25d1924931c7aef237f89eea9de58e858eebfed'
+        012-fix-unicode-definitions-in-cmake-interface.patch)
+sha256sums=('3db4c729b4d80a9d8fda8dd77128406353baff4755ca619177eda4cddae71269'
             'ec22ac099ff85be804c7a740852bdc10d9a40f32eab58c5e49bc86dc28f2a7b9'
             '3848318bccdfa21a139ccdb70f8226358c4a7ed3943231494aab3df83025d7c7'
             '68156b8b7717a0ce19c4b991942469171bfa048cd5c90765115a546e65669a1d'
-            'e8867fa643823b149b2f1937a4854752aa86191148ae8cf4667e32ed5b97a36c'
+            '142ed248e8025360a8a6b93bece2a13bef9f032d42723f36df730a5e2d00bcdd'
             'b644586be741dabf66b79bcc2eed71727739f4b301e0ae7da35506b30605aeb5'
             '4085a10b290b8e3d930de535cbad2ba3e643432cba433aa2b28fe664f86d38a3'
             '3a256533401a48aff7e3c4b02118d62a0cccc2b3566c6e550e7b467aca3e496f'
             '97a00b185fe6a952eeb3b8b154996e0527fd78a75150e908cd6acd61676fd453'
             'e9dcf3275163b7dd73f613f2929b10551649c8df80677fafd873b5e31430b43a'
             '7f1a0a14f423741956253690d16d635055a8e887fe39f7f0160d40c5c63ae1b1'
-            'b217dad1b9ebf212f4d0d5c88140c26c491373e66d3ae88cb98deb5d688e59b0'
-            'b36f7606f7875dc40eae5dd672977686068bb0f60304320fb19fa54b8540b30b')
+            'b217dad1b9ebf212f4d0d5c88140c26c491373e66d3ae88cb98deb5d688e59b0')
 
 # Use the right mkspecs file
 if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
@@ -99,9 +97,6 @@ prepare() {
   # See: https://bugreports.qt.io/browse/QTBUG-103019
   apply_patch_with_msg \
     012-fix-unicode-definitions-in-cmake-interface.patch
-  # https://www.qt.io/blog/security-advisory-qt-network-2
-  apply_patch_with_msg \
-    CVE-2023-34410-qtbase-6.5.diff
 
   if [[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]]; then
     apply_patch_with_msg \

--- a/mingw-w64-qt6-charts/PKGBUILD
+++ b/mingw-w64-qt6-charts/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-charts
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -21,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('b15b500fc7e75b8881d5fe19bd13418213bc5f7834eadc9fb00edc084e92cf75')
+sha256sums=('775af7be019cca698b27e5acffbc2def8f7a5b8f06f5c6db2a7015d578a6ad2d')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-connectivity/PKGBUILD
+++ b/mingw-w64-qt6-connectivity/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-connectivity
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -20,7 +20,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('2fd74c9b78c4df2b9b2efe5e48fa6c9689f6c200ee4a90edd5bfedda3089827a')
+sha256sums=('db2e4922352d253cafbb8f21eeca58da269c19e0e6d614420af19a7cd35fdc99')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-datavis3d/PKGBUILD
+++ b/mingw-w64-qt6-datavis3d/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-datavis3d
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -21,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('52332abc3131c518fc73cd64e3562bc7ba45b4532fdc5f1249c983c7575da333')
+sha256sums=('68c13918dcbbc49d06fff561c3253176ce5654ebaaf6099fea76454bd8a51ce9')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-declarative/PKGBUILD
+++ b/mingw-w64-qt6-declarative/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-declarative
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -22,7 +22,7 @@ options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz"
         001-appending-qt6-to-remove-qt5-conflict.patch)
-sha256sums=('201148f9614a65d169a85cd0d0fbd414603498da6ff330c4e0835ecd962dce79'
+sha256sums=('f3a11fe54e9fac77c649e46e39f1cbe161e9efe89bad205115ba2861b1eb8719'
             'b08b7a9cd263eaa2f09ec1b7718d79c253b4e30f3a1f47df6c89fa2e85d7659d')
 
 # Helper macros to help make tasks easier #

--- a/mingw-w64-qt6-doc/PKGBUILD
+++ b/mingw-w64-qt6-doc/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=qt6-doc
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -34,7 +34,7 @@ _pkgfn="qt-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/$_qtver/single/$_pkgfn.tar.xz"
         001-fix-qtdocs-helpers-cmake.patch
         002-do-not-find-zstd-with-cmake-config.patch)
-sha256sums=('a2d88a6f8c3835dca52f3b7433149c3de606a96bbf024640c27657276cc7350a'
+sha256sums=('cde57be663d0f875759797298bdc37a936d517c39f2013e4e6ece5e12edeed12'
             '3848318bccdfa21a139ccdb70f8226358c4a7ed3943231494aab3df83025d7c7'
             '4508a70aebb573bd5b97b35e7926dcb08080aba8544e6a097f704bd8b814a279')
 

--- a/mingw-w64-qt6-grpc/PKGBUILD
+++ b/mingw-w64-qt6-grpc/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-grpc
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=2
 arch=(any)
@@ -24,7 +24,7 @@ _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz"
         "001-fix-build-with-grpc-1.53.patch"
         "002-fix-build-with-protobuf-23.patch")
-sha256sums=('9abe2d1a6946ec79144fd834d3afff85cd30f7ada991f8a1982f2c15d8a947e4'
+sha256sums=('7ab2969b07cde418cce87a8aa7904e218d235222ea927949f153dde3ade0d204'
             '6318facf1729903a53ba6c1785e5b89277001b5a51182a24c6e91db52766fa55'
             '353774a32444def3db3a8d6056820b758750b47579b683a2c42105191121c281')
 

--- a/mingw-w64-qt6-httpserver/PKGBUILD
+++ b/mingw-w64-qt6-httpserver/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-httpserver
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -20,7 +20,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('47de4f502c61e2875cc9b1d5906a332672c3cce832de10833db91e4bddcefc7c')
+sha256sums=('f8fa2b5d1278d05c8841fe14d3a81c91196a126219d491562f7c179b5202dcac')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-imageformats/PKGBUILD
+++ b/mingw-w64-qt6-imageformats/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-imageformats
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -24,7 +24,7 @@ options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz"
         001-disable-finding-webp-from-cmake-config-files.patch)
-sha256sums=('897f7fc299ad03580dee91920644dc43cb5d32e1b8c97e8b594fac9aa68c5db5'
+sha256sums=('aae0c08924c6a5e47f9d57e031673d611ffff7aab2bee2e1cc460471ecac6743'
             '90c0de75adb82acc9bae387706a63ceab8960e0584b4d69e47785e168a59d402')
 
 prepare() {

--- a/mingw-w64-qt6-languageserver/PKGBUILD
+++ b/mingw-w64-qt6-languageserver/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-languageserver
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -20,7 +20,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('99a6cc6aca124626a2085077dc7f4bb9dbb20da518df6b115056813149832bc9')
+sha256sums=('73b5ec0caa830708c016951a6e27f308f78e95d13810c56ef342317c398bd1a4')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-location/PKGBUILD
+++ b/mingw-w64-qt6-location/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-location
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -22,7 +22,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('b68a18fa97c49832fe401060cf324081ba17b8f73eee72b04a8650fa403612f4')
+sha256sums=('891d7d64c26617bf1993a6d8b3d206ec9ce5b0a5396146f691b11d895fd86dfb')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-lottie/PKGBUILD
+++ b/mingw-w64-qt6-lottie/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-lottie
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -20,7 +20,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('10b8f8107b75314703a4d0e0f60778c30c8f41a339622bc8166eec284ac26b81')
+sha256sums=('003adc5cf0d50b32d00a09d66ba6332db22191fb0999f51e032f02a21474e89b')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-multimedia/PKGBUILD
+++ b/mingw-w64-qt6-multimedia/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-ffmpeg"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-wmf")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=3
 arch=(any)
@@ -27,7 +27,7 @@ options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz"
         001-export-some-constexpr-variables.patch)
-sha256sums=('0b1fc560e1c8cdda1ddb13db832c3b595f7e4079118d4847d8de18d82464e1cc'
+sha256sums=('948f00aa679e92839a2a71bd07245a92cc849af486607417ee4c334b2b998975'
             'e1694338779eb499341618c62d11f832f2b7f1f90c8a20345932530a61203105')
 
 prepare() {

--- a/mingw-w64-qt6-networkauth/PKGBUILD
+++ b/mingw-w64-qt6-networkauth/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-networkauth
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -20,7 +20,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('a730b56a3e96fa70e3908209ba6cafe67e93c3dfe50541538f8b7d8503d971a3')
+sha256sums=('4ecc4b560ac24c29086550972d634a4e1a1a58936b6186a24dd131f8079c283c')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-positioning/PKGBUILD
+++ b/mingw-w64-qt6-positioning/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-positioning
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -21,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('053cf940e18880c53ec35022d495c75fdb3adf762dbb3b4a6e48341f7a0ea422')
+sha256sums=('70493f03748d1c5b1577e4c011c0af9bcaffcdc6c5e519362605b01f917614fa')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-quick3d/PKGBUILD
+++ b/mingw-w64-qt6-quick3d/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-quick3d
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -25,7 +25,7 @@ options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz"
         001-appending-qt6-to-remove-qt5-conflict.patch)
-sha256sums=('51b626a6d56b119d42c092265ee1a31ae04f4732c7e6e129c26dfb41dfb0cc1e'
+sha256sums=('75e0a35d9419e8b2ae98c950056b55f2377e4b559aafbe00a9c8d150c5db00da'
             '211bb1f042bf9c0ddedb15b0e3d62b94e3b247dc96294fd92f4d8035784f1c7d')
 
 # Helper macros to help make tasks easier #

--- a/mingw-w64-qt6-quick3dphysics/PKGBUILD
+++ b/mingw-w64-qt6-quick3dphysics/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-quick3dphysics
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -21,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('94ad887419d5141aa1507f9b71bd80f13bd134f75362c49f5aa7a3ce1b7613c8')
+sha256sums=('7500129836b12448036812cccc0313c695d849db9035d8588081ed7ac1463137')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-quickeffectmaker/PKGBUILD
+++ b/mingw-w64-qt6-quickeffectmaker/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-quickeffectmaker
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -22,7 +22,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('51bcec0744bb82bde70c48ca92f9fe2268cb74647125b52478355f5a93db90a2')
+sha256sums=('d547c727c27dbe05b7d8e4b35ff0858708d0543f26f23bbb8e184e23f1d76cbf')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-quicktimeline/PKGBUILD
+++ b/mingw-w64-qt6-quicktimeline/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-quicktimeline
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -20,7 +20,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('1079dba276c51b9bbc9bfd90014005eb94339a6ce18a4f3fb1b6f4724f4ad551')
+sha256sums=('c945ae905dc1542967c7f9bea826022235bc179c2ed59142c029336c03f015ba')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-remoteobjects/PKGBUILD
+++ b/mingw-w64-qt6-remoteobjects/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-remoteobjects
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -21,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('78cf47af58793756dd0633db08371646d8d28930d911e75aeeab385aecc7629b')
+sha256sums=('c0f41f1f79eff28303ecd68dc064a4d8f92b35f3ddc06d78909b142bc0d4494c')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-scxml/PKGBUILD
+++ b/mingw-w64-qt6-scxml/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-scxml
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -20,7 +20,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('1c3ea3c8bb52c30e06ff113b4deaeb30d664d592afba650f0c1910b30a002477')
+sha256sums=('a830f2ec750913a70f854e487b1b44d1ec3a48eb21253f414a1990f8cf4dbdcb')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {

--- a/mingw-w64-qt6-sensors/PKGBUILD
+++ b/mingw-w64-qt6-sensors/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-sensors
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -21,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('c95aca8371c2909255d908f4d78a0bfd975a83a73ed882eabc561d444864aba5')
+sha256sums=('4006bd7cfbb4302a887bda82b7fe3c31633626363a5e6ba9730bdb4fa8ab2aa6')
 
 build() {
   mkdir -p build-${MSYSTEM} &&cd build-${MSYSTEM}

--- a/mingw-w64-qt6-serialbus/PKGBUILD
+++ b/mingw-w64-qt6-serialbus/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-serialbus
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -21,7 +21,7 @@ options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz"
         "001-appending-qt6-to-remove-qt5-conflict.patch")
-sha256sums=('dbff967829bf0ac75ed54fb0da4893a7a160309989d9e2da349622a72c5e157f'
+sha256sums=('f0426307cdc185547ad6331a670187d180cce4c11254d6a26aa997fe03b7cdfe'
             '06d8b31a6022e43a5daeb71f083d8344e18c8234c6f7988bbc0a49f14bd2f539')
 
 # Helper macros to help make tasks easier #

--- a/mingw-w64-qt6-serialport/PKGBUILD
+++ b/mingw-w64-qt6-serialport/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-serialport
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -20,7 +20,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('c3554d0646d4e2b981a4b17f3d196317def7eabea42b81c97967e355bcb432a6')
+sha256sums=('063c54169aea6b303183b434637ad050e9f67d7f22bb3eff1ede1905eb2ccc9e')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-shadertools/PKGBUILD
+++ b/mingw-w64-qt6-shadertools/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-shadertools
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -22,7 +22,7 @@ options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz"
         "001-fix-build-with-gcc-13.patch::https://invent.kde.org/qt/qt/qtshadertools/-/commit/fcc470ea.patch")
-sha256sums=('e5806761835944ef91d5aee0679e0c8231bf7a981e064480e65c751ebdf65052'
+sha256sums=('ca3fb0db8576c59b9c38bb4b271cc6e10aebeb54e2121f429f4ee80671fc0a3d'
             'acfd1318429e2ef1b5ea4f217a2d9f736b9672bf7a2fedf020ba086de79ebb43')
 
 prepare() {

--- a/mingw-w64-qt6-speech/PKGBUILD
+++ b/mingw-w64-qt6-speech/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-speech
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -21,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('67120ba5f156962713b6fd5aeb109ed789f66d07e8bfbda4fa24d12d653457b6')
+sha256sums=('88ff9c2876f4a76632bfee7f58c3277aab9ff49e24d628e4a19f6b0e7a62d4b2')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-static/002-qt-6.2.0-win32-g-Add-QMAKE_EXTENSION_IMPORTLIB-defaulting-to-.patch
+++ b/mingw-w64-qt6-static/002-qt-6.2.0-win32-g-Add-QMAKE_EXTENSION_IMPORTLIB-defaulting-to-.patch
@@ -29,12 +29,12 @@ diff -Naur qt-everywhere-src-6.2.0-orig/qtbase/mkspecs/common/g++-win32.conf qt-
      } else {
          CMAKE_WINMAIN_FILE_LOCATION_DEBUG = qtmain$${QT_LIBINFIX}$${debug_suffix}.lib
          CMAKE_WINMAIN_FILE_LOCATION_RELEASE = qtmain$${QT_LIBINFIX}.lib
---- qt-everywhere-src-6.2.0/qtbase/mkspecs/features/qt.prf.orig	2021-10-07 10:08:00.815247900 +0300
-+++ qt-everywhere-src-6.2.0/qtbase/mkspecs/features/qt.prf	2021-10-07 10:11:39.347590300 +0300
-@@ -220,9 +220,13 @@
-             } else {
+--- a/qtbase/mkspecs/features/qt.prf
++++ b/qtbase/mkspecs/features/qt.prf
+@@ -250,9 +250,13 @@ for(ever) {
                  lib_bases = $$MODULE_MODULE$$qtPlatformTargetSuffix()
                  darwin: lib_bases *= $$MODULE_MODULE
+                 add_lib_to_pretargetdeps = false
 -                win32|contains(MODULE_CONFIG, staticlib) {
 +                win32 {
                      lib_prefix = $$MODULE_LIBS/$$QMAKE_PREFIX_STATICLIB
@@ -45,8 +45,8 @@ diff -Naur qt-everywhere-src-6.2.0-orig/qtbase/mkspecs/common/g++-win32.conf qt-
 +                        lib_suffixes = $$QMAKE_EXTENSION_IMPORTLIB
 +                    }
                      lib_suffixes *= $$QMAKE_LIB_EXTENSIONS
-                     add_lib_to_pretargetdeps = true
-                 } else {
+                     !xcodebuild: \
+                         add_lib_to_pretargetdeps = true
 --- qt-everywhere-src-6.2.0/qtbase/qmake/generators/win32/winmakefile.cpp.orig	2021-10-07 10:14:13.043627000 +0300
 +++ qt-everywhere-src-6.2.0/qtbase/qmake/generators/win32/winmakefile.cpp	2021-10-07 10:16:00.750253600 +0300
 @@ -99,10 +99,16 @@

--- a/mingw-w64-qt6-static/017-fix-build-with-grpc-1.53.patch
+++ b/mingw-w64-qt6-static/017-fix-build-with-grpc-1.53.patch
@@ -1,0 +1,45 @@
+From 0d0d14e5510127e9c5162e140a9ef6d004c2616a Mon Sep 17 00:00:00 2001
+From: Konrad Kujawa <konrad.kujawa@qt.io>
+Date: Thu, 22 Jun 2023 15:30:20 +0200
+Subject: Fix include of std::set
+
+With new version of gRPC, compiler complains about missing include of
+the std::set. Move include from .cpp to .h files.
+
+Pick-to: 6.6
+Change-Id: Ibfef277598cb9e620ab1b693a42564706302c9cc
+Reviewed-by: Alexey Edelev <alexey.edelev@qt.io>
+---
+ src/tools/qtgrpcgen/qgrpcgenerator.cpp         | 1 -
+ src/tools/qtgrpcgen/qgrpcgenerator.h           | 3 ++-
+ src/tools/qtprotobufgen/qprotobufgenerator.cpp | 4 ++--
+ src/tools/qtprotobufgen/qprotobufgenerator.h   | 2 ++
+ 4 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/src/tools/qtgrpcgen/qgrpcgenerator.cpp b/src/tools/qtgrpcgen/qgrpcgenerator.cpp
+index 3a750c5..520e2c5 100644
+--- a/src/tools/qtgrpcgen/qgrpcgenerator.cpp
++++ b/src/tools/qtgrpcgen/qgrpcgenerator.cpp
+@@ -10,7 +10,6 @@
+ #include "utils.h"
+ #include "options.h"
+ 
+-#include <set>
+ #include <google/protobuf/compiler/code_generator.h>
+ #include <google/protobuf/stubs/logging.h>
+ #include <google/protobuf/stubs/common.h>
+diff --git a/src/tools/qtgrpcgen/qgrpcgenerator.h b/src/tools/qtgrpcgen/qgrpcgenerator.h
+index ea40438..5f842f0 100644
+--- a/src/tools/qtgrpcgen/qgrpcgenerator.h
++++ b/src/tools/qtgrpcgen/qgrpcgenerator.h
+@@ -4,8 +4,9 @@
+ #ifndef QGRPCGENERATOR_H
+ #define QGRPCGENERATOR_H
+ 
+-#include <memory>
+ #include "generatorbase.h"
++#include <memory>
++#include <set>
+ 
+ namespace google::protobuf {
+ class FileDescriptor;

--- a/mingw-w64-qt6-static/018-fix-build-with-protobuf-23.patch
+++ b/mingw-w64-qt6-static/018-fix-build-with-protobuf-23.patch
@@ -1,0 +1,68 @@
+diff --git a/src/tools/qtgrpcgen/clientdeclarationprinter.cpp b/src/tools/qtgrpcgen/clientdeclarationprinter.cpp
+index 9bd57a1..eedb91f 100644
+--- a/src/tools/qtgrpcgen/clientdeclarationprinter.cpp
++++ b/src/tools/qtgrpcgen/clientdeclarationprinter.cpp
+@@ -8,7 +8,6 @@
+ #include <google/protobuf/io/printer.h>
+ #include <google/protobuf/io/zero_copy_stream.h>
+ #include <google/protobuf/stubs/common.h>
+-#include <google/protobuf/stubs/logging.h>
+ 
+ #include <string>
+ #include <unordered_set>
+diff --git a/src/tools/qtgrpcgen/qgrpcgenerator.cpp b/src/tools/qtgrpcgen/qgrpcgenerator.cpp
+index 4cab74d..1d5e04d 100644
+--- a/src/tools/qtgrpcgen/qgrpcgenerator.cpp
++++ b/src/tools/qtgrpcgen/qgrpcgenerator.cpp
+@@ -12,7 +12,7 @@
+ 
+ #include <set>
+ #include <google/protobuf/compiler/code_generator.h>
++#include <google/protobuf/descriptor_legacy.h>
+-#include <google/protobuf/stubs/logging.h>
+ #include <google/protobuf/stubs/common.h>
+ #include <google/protobuf/io/printer.h>
+ #include <google/protobuf/io/zero_copy_stream.h>
+@@ -35,7 +34,7 @@ bool QGrpcGenerator::Generate(const FileDescriptor *file,
+                               std::string *error) const
+ {
+     assert(file != nullptr && generatorContext != nullptr);
+-    if (file->syntax() != FileDescriptor::SYNTAX_PROTO3) {
++    if (FileDescriptorLegacy(file).syntax() != FileDescriptorLegacy::SYNTAX_PROTO3) {
+         *error = "Invalid proto used. qtgrpcgen only supports 'proto3' syntax";
+         return false;
+     }
+diff --git a/src/tools/qtprotobufgen/qprotobufgenerator.cpp b/src/tools/qtprotobufgen/qprotobufgenerator.cpp
+index 5a1ccc2..e0d8981 100644
+--- a/src/tools/qtprotobufgen/qprotobufgenerator.cpp
++++ b/src/tools/qtprotobufgen/qprotobufgenerator.cpp
+@@ -17,7 +17,7 @@
+ #include <array>
+ #include <numeric>
+ #include <set>
++#include <google/protobuf/descriptor_legacy.h>
+-#include <google/protobuf/stubs/logging.h>
+ #include <google/protobuf/stubs/common.h>
+ #include <google/protobuf/io/printer.h>
+ #include <google/protobuf/io/zero_copy_stream.h>
+@@ -41,7 +40,7 @@ bool QProtobufGenerator::Generate(const FileDescriptor *file,
+ {
+     assert(file != nullptr && generatorContext != nullptr);
+ 
+-    if (file->syntax() != FileDescriptor::SYNTAX_PROTO3) {
++    if (FileDescriptorLegacy(file).syntax() != FileDescriptorLegacy::SYNTAX_PROTO3) {
+         *error = "Invalid proto used. qtprotobufgen only supports 'proto3' syntax";
+         return false;
+     }
+diff --git a/src/tools/qtprotoccommon/generatorbase.cpp b/src/tools/qtprotoccommon/generatorbase.cpp
+index bc51206..1004c61 100644
+--- a/src/tools/qtprotoccommon/generatorbase.cpp
++++ b/src/tools/qtprotoccommon/generatorbase.cpp
+@@ -5,7 +5,6 @@
+ #include "generatorbase.h"
+ 
+ #include <google/protobuf/descriptor.h>
+-#include <google/protobuf/stubs/logging.h>
+ #include <google/protobuf/stubs/common.h>
+ #include <google/protobuf/io/printer.h>
+ #include <google/protobuf/io/zero_copy_stream.h>

--- a/mingw-w64-qt6-static/PKGBUILD
+++ b/mingw-w64-qt6-static/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=qt6
 pkgbase=mingw-w64-${_realname}-static
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-static")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -56,10 +56,12 @@ source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/sing
         012-Handle-win64-in-dumpcpp-and-MetaObjectGenerator-read.patch
         013-disable-finding-webp-from-cmake-config-files.patch
         015-qt6-windeployqt-fixes.patch
-        016-fix-building-shadertools-with-gcc-13.patch::https://invent.kde.org/qt/qt/qtshadertools/-/commit/fcc470ea.patch)
-sha256sums=('a2d88a6f8c3835dca52f3b7433149c3de606a96bbf024640c27657276cc7350a'
+        016-fix-building-shadertools-with-gcc-13.patch::https://invent.kde.org/qt/qt/qtshadertools/-/commit/fcc470ea.patch
+        017-fix-build-with-grpc-1.53.patch
+        018-fix-build-with-protobuf-23.patch)
+sha256sums=('cde57be663d0f875759797298bdc37a936d517c39f2013e4e6ece5e12edeed12'
             '26f3bcc3729520a5ba648a9ce92a9293c8fb1cf16d81af612587ce10d501dcb6'
-            '2cce9659a2ae04e28f25e425852a0be28b3ba8080075c697d6c0e9b7bbfb7e5c'
+            '48bcf7e4d5c6101d653d7bb0c1beae53ddc393d56a756cb3f246848ef0fabcc1'
             'af3f4c6491942ee6a7681eecef2d999897e38fcef7a5edcf3774589f137dac73'
             'fa73433aa123487562f365dd98735d44fb1effd38d13de4c0e33bd5f8e812396'
             '554e979085f5deabd9f83637168c79f4929781434164d42dd14a8335a61d3cfc'
@@ -72,7 +74,9 @@ sha256sums=('a2d88a6f8c3835dca52f3b7433149c3de606a96bbf024640c27657276cc7350a'
             '39d57493b0edc1317729b88dad6a07b86936072f0fbbd2aae7b01e2211ce29ed'
             'ce0023e8b72fe4b5840ca892bd5ad52120b6b484161bf2ffe0b6da9404625641'
             '605ad15bc71a7b2d5b1c7a197a44e6251a0098f702f5411bf3e82a4966528132'
-            'acfd1318429e2ef1b5ea4f217a2d9f736b9672bf7a2fedf020ba086de79ebb43')
+            'acfd1318429e2ef1b5ea4f217a2d9f736b9672bf7a2fedf020ba086de79ebb43'
+            '6318facf1729903a53ba6c1785e5b89277001b5a51182a24c6e91db52766fa55'
+            '353774a32444def3db3a8d6056820b758750b47579b683a2c42105191121c281')
 
 # Use the right mkspecs file
 if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
@@ -118,6 +122,11 @@ prepare() {
   cd qtshadertools
   apply_patch_with_msg \
     016-fix-building-shadertools-with-gcc-13.patch
+
+  cd ../qtgrpc
+  apply_patch_with_msg \
+    017-fix-build-with-grpc-1.53.patch \
+    018-fix-build-with-protobuf-23.patch
 
   cd ..
 

--- a/mingw-w64-qt6-svg/PKGBUILD
+++ b/mingw-w64-qt6-svg/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-svg
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -20,7 +20,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('d58d29491d44f0f59b684686a9898fec0e6c4fb7c09d9393b4e9c211fe9608ef')
+sha256sums=('48b4cc1093af2e0ab3bea30f60651bddd877a2335d16e7207879a2e9e81963a3')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-tools/PKGBUILD
+++ b/mingw-w64-qt6-tools/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-tools
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -24,7 +24,7 @@ options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz"
         001-appending-qt6-to-remove-qt5-conflict.patch)
-sha256sums=('5744df9e84b2a86f7f932ffc00341c7d7209e741fd1c0679a32b855fcceb2329'
+sha256sums=('551ffb22751d8fd4d88e9ebd55b9131f4ca55341ee497fdbbba4da8d10d94341'
             '23bd803881eed76d502973799eea456108f92ec8f7b706a0155298618bab40a0')
 
 # Helper macros to help make tasks easier #

--- a/mingw-w64-qt6-translations/PKGBUILD
+++ b/mingw-w64-qt6-translations/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=qt6-translations
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -20,7 +20,7 @@ options=('!strip')
 groups=("${MINGW_PACKAGE_PREFIX}-qt6")
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('527e2c34c2637ece49c0e1fb65b0c5e5dce0f9b3f3710381468fe4e36080d49b')
+sha256sums=('337c45637e757e754c2f0ea65c20de3e6e53a841dda1253db15baa622515beeb')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-virtualkeyboard/PKGBUILD
+++ b/mingw-w64-qt6-virtualkeyboard/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-virtualkeyboard
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -22,7 +22,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('89b243d6d0367502f2d6ae8828364a628986a8de189704e857fb0cdfee863cc1')
+sha256sums=('0570e0387e22a526b8ff735355ca8f09347501b71f7ae2166b60a81a40626269')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-webchannel/PKGBUILD
+++ b/mingw-w64-qt6-webchannel/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-webchannel
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -21,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('2b374367e737f7579e682603c2025712f72a5d6814d5983a20c5bffac210ec4a')
+sha256sums=('c188d9fa6e535b850b574fa9e47c6089555b8df1fe041dcb13aeeca336b78e63')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-websockets/PKGBUILD
+++ b/mingw-w64-qt6-websockets/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-websockets
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -20,7 +20,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('6b8f66b250a675117aae35b48dbfc589619be2810a759ad1712a9cd20561da19')
+sha256sums=('204bd7b0dffb54c934abc6cf0eb5e3016f11b3c9721a67b4875a6b21bb8b5c76')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-webview/PKGBUILD
+++ b/mingw-w64-qt6-webview/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-webview
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.5.1
+_qtver=6.5.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -20,7 +20,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('6bafb68ea87199e1f47d9e471546cad935d18990c139c488b1e1db344f8f3a64')
+sha256sums=('5902e072a874ba49f2046a2c4abc113775cb52e4eaa7c8758553cc8ffa0df631')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}


### PR DESCRIPTION
Bump from Qt6 6.5.1 to 6.5.2. The removed CVE patch was removed because it is now included in the 6.5.2 release.