### PR TITLE
openssl: Update to 3.1.2

### DIFF
--- a/mingw-w64-openssl/PKGBUILD
+++ b/mingw-w64-openssl/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=openssl
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=3.1.1
+pkgver=3.1.2
 pkgrel=1
 pkgdesc="The Open Source toolkit for Secure Sockets Layer and Transport Layer Security (mingw-w64)"
 arch=('any')
@@ -19,7 +19,7 @@ source=("https://www.openssl.org/source/openssl-${pkgver}.tar.gz"{,.asc}
         '002-relocation.patch'
         'pathtools.c'
         'pathtools.h')
-sha256sums=('b3aa61334233b852b63ddb048df181177c2c659eb9d4376008118f9c08d07674'
+sha256sums=('a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539'
             'SKIP'
             '21b96771b401442570e885c2d5689a359a91e86dcbf5511db3667202b6c1fa8a'
             '5628dd39ab0d3ce4afbb5207bab5d22766abc86a8875b48b6d4d3efd68550e68'
@@ -32,6 +32,7 @@ validpgpkeys=(
   '7953AC1FBC3DC8B3B292393ED5E9E43F7DF9EE8C' # Richard Levitte <richard@levitte.org>
   'A21FAB74B0088AA361152586B8EF1A6BA9DA2D5C' # Tomáš Mráz <tm@t8m.info>
   'B7C1C14360F353A36862E4D5231C84CDDCC69C45' # Paul Dale <pauli@openssl.org>
+  'EFC0A467D613CB83C7ED6D30D894E2CE8B3D79F5' # OpenSSL security team <openssl-security@openssl.org>
 )
 
 # Helper macros to help make tasks easier #
@@ -80,7 +81,7 @@ build() {
   esac
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-  ../"${_realname}-${pkgver}"/Configure \
+  /usr/bin/perl ../"${_realname}-${pkgver}"/Configure \
     --prefix="${MINGW_PREFIX}" \
     --libdir=lib \
     --openssldir=etc/ssl \


### PR DESCRIPTION
also fix the build in case mingw perl is installed by forcing the msys one