### PR TITLE
python: fix shebang of scripts like idle3

### DIFF
--- a/mingw-w64-python/PKGBUILD
+++ b/mingw-w64-python/PKGBUILD
@@ -22,7 +22,7 @@ else
   pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}${_pybasever}")
 fi
 pkgver=${_pybasever}.4
-pkgrel=3
+pkgrel=4
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -414,8 +414,7 @@ package() {
 
   # fixup shebangs
   for fscripts in 2to3 2to3-${_pybasever} idle3 idle${_pybasever} pydoc3 pydoc${_pybasever}; do
-    sed -i "s|$(cygpath -w ${MINGW_PREFIX} | sed 's|\\|\\\\|g')/bin/python${_pybasever}.exe|/usr/bin/env python${_pybasever}.exe|g" \
-      "${pkgdir}${MINGW_PREFIX}"/bin/${fscripts}
+    sed -e '1 { s|^#!.*$|#!/usr/bin/env python'"${_pybasever}"'.exe| }' -i "${pkgdir}${MINGW_PREFIX}"/bin/${fscripts}
   done
 
   # default aliases for all scripts/binaries


### PR DESCRIPTION
due to some PATHSEP fixes the original shebang now uses forward slashes and the sed no longer had any effect.

Instead of fixing the cygpath call just replace the shebang without matching, so this doesn't happen again.

Fixes #17929