### PR TITLE
python-lief: Fix exported API from python module

### DIFF
--- a/mingw-w64-python-lief/0001-fix-exported-API-pymodule.patch
+++ b/mingw-w64-python-lief/0001-fix-exported-API-pymodule.patch
@@ -1,0 +1,11 @@
+--- a/api/python/src/pyLIEF.cpp
++++ b/api/python/src/pyLIEF.cpp
+@@ -51,7 +51,7 @@
+ #include "platforms/pyPlatform.hpp"
+ 
+ 
+-PYBIND11_MODULE(_lief, LIEF_module) {
++PYBIND11_MODULE(lief, LIEF_module) {
+ 
+   LIEF_module.attr("__version__")   = py::str(LIEF_VERSION);
+   LIEF_module.attr("__tag__")       = py::str(LIEF_TAG);

--- a/mingw-w64-python-lief/PKGBUILD
+++ b/mingw-w64-python-lief/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
 pkgdesc="LIEF - Library to Instrument Executable Formats (mingw-w64)"
 pkgver=0.13.2
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://github.com/lief-project/LIEF/"
@@ -19,11 +19,14 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python-tomli")
 options=('staticlibs' '!strip' '!debug')
-source=(lief-${pkgver}.tar.gz::https://github.com/lief-project/LIEF/archive/refs/tags/${pkgver}.tar.gz)
-sha256sums=('c68ef94ee613c6557faccc135bdaba4322c2e044be2b806ceea1de763cc099cf')
+source=(lief-${pkgver}.tar.gz::https://github.com/lief-project/LIEF/archive/refs/tags/${pkgver}.tar.gz
+        0001-fix-exported-API-pymodule.patch)
+sha256sums=('c68ef94ee613c6557faccc135bdaba4322c2e044be2b806ceea1de763cc099cf'
+            '5d59f6a2e547f62ccbb00b469ab4316925576c562aee3be2a293beca6975c466')
 
 prepare() {
   cd "${srcdir}/LIEF-${pkgver}"
+  patch -p1 -i "${srcdir}/0001-fix-exported-API-pymodule.patch"
 
   (cd api/python && python setup.py egg_info)
 }


### PR DESCRIPTION
Fixes https://github.com/msys2/MINGW-packages/issues/17942