### PR TITLE
ffmpeg: backport patch to fix the build with binutils 2.41

### DIFF
--- a/mingw-w64-ffmpeg/PKGBUILD
+++ b/mingw-w64-ffmpeg/PKGBUILD
@@ -7,7 +7,7 @@ _realname=ffmpeg
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=6.0
-pkgrel=6
+pkgrel=7
 pkgdesc="Complete solution to record, convert and stream audio and video (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -70,7 +70,8 @@ source=(https://ffmpeg.org/releases/${_realname}-${pkgver}.tar.xz{,.asc}
         "0005-Win32-Add-path-relocation-to-frei0r-plugins-search.patch"
         "0002-gcc-12.patch"
         "0001-lavu-vulkan-fix-handle-type-for-32-bit-targets.patch"
-        https://github.com/FFmpeg/FFmpeg/commit/f9620d74cd49c35223304ba41e28be6144e45783.patch)
+        https://github.com/FFmpeg/FFmpeg/commit/f9620d74cd49c35223304ba41e28be6144e45783.patch
+        https://github.com/FFmpeg/FFmpeg/commit/effadce6c756247ea8bae32dc13bb3e6f464f0eb.patch)
 validpgpkeys=('FCF986EA15E6E293A5644F10B4322F04D67658D8')
 sha256sums=('57be87c22d9b49c112b6d24bc67d42508660e6b718b3db89c44e47e289137082'
             'SKIP'
@@ -79,7 +80,8 @@ sha256sums=('57be87c22d9b49c112b6d24bc67d42508660e6b718b3db89c44e47e289137082'
             '58f91fde8be7fa093b13275c37b0276de08537449749599e5a50f4f9c8b20926'
             '84b9fcaa188eef15201a105a44c53d647e4fb800a5032336e0948d6bed2cbc1b'
             'bbc7e7b91886a8ac037d8e70692186ee4b48c37b4f1d82b81af8a54463b24803'
-            '146d397029d8980224c0e805646bc02707b54029fff8a3e62c1565672091aabc')
+            '146d397029d8980224c0e805646bc02707b54029fff8a3e62c1565672091aabc'
+            '206f4d8437b21f6197ffc444c86d0504892a5c2137cb227b4af1c1e8bf2c426c')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -108,6 +110,9 @@ prepare() {
   apply_patch_with_msg 0001-lavu-vulkan-fix-handle-type-for-32-bit-targets.patch
 
   apply_patch_with_msg f9620d74cd49c35223304ba41e28be6144e45783.patch
+
+  # https://github.com/msys2/MINGW-packages/issues/17946
+  apply_patch_with_msg effadce6c756247ea8bae32dc13bb3e6f464f0eb.patch
 }
 
 build() {


### PR DESCRIPTION
Fixes #17946