### PR TITLE
ffmpeg4.4: backport patch to fix the build with binutils 2.41

### DIFF
--- a/mingw-w64-ffmpeg4.4/PKGBUILD
+++ b/mingw-w64-ffmpeg4.4/PKGBUILD
@@ -7,7 +7,7 @@ _realname=ffmpeg
 pkgbase="mingw-w64-${_realname}4.4"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}4.4"
 pkgver=4.4.4
-pkgrel=3
+pkgrel=4
 pkgdesc="Complete solution to record, convert and stream audio and video (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -70,7 +70,8 @@ source=(https://ffmpeg.org/releases/${_realname}-${pkgver}.tar.xz{,.asc}
         "0002-gcc-12.patch"
         "0003-fix-clang32-build.patch"
         https://github.com/FFmpeg/FFmpeg/commit/c3c8f97a9804b4234e97f13b0057ffc2c9af27c0.patch
-        https://github.com/FFmpeg/FFmpeg/commit/f9620d74cd49c35223304ba41e28be6144e45783.patch)
+        https://github.com/FFmpeg/FFmpeg/commit/f9620d74cd49c35223304ba41e28be6144e45783.patch
+        https://github.com/FFmpeg/FFmpeg/commit/effadce6c756247ea8bae32dc13bb3e6f464f0eb.patch)
 validpgpkeys=('FCF986EA15E6E293A5644F10B4322F04D67658D8')
 sha256sums=('e80b380d595c809060f66f96a5d849511ef4a76a26b76eacf5778b94c3570309'
             'SKIP'
@@ -79,7 +80,8 @@ sha256sums=('e80b380d595c809060f66f96a5d849511ef4a76a26b76eacf5778b94c3570309'
             '84b9fcaa188eef15201a105a44c53d647e4fb800a5032336e0948d6bed2cbc1b'
             '06481611d3449e2cc4f4759d2e0ad5b1ce2c4f313d0b63d4cb0a51d9fe02a424'
             '3ece733e96c9454209a42f706251e3d68e2ba1f2ef12afb559d4c48db145141f'
-            '146d397029d8980224c0e805646bc02707b54029fff8a3e62c1565672091aabc')
+            '146d397029d8980224c0e805646bc02707b54029fff8a3e62c1565672091aabc'
+            '206f4d8437b21f6197ffc444c86d0504892a5c2137cb227b4af1c1e8bf2c426c')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -100,6 +102,9 @@ prepare() {
     0003-fix-clang32-build.patch \
     c3c8f97a9804b4234e97f13b0057ffc2c9af27c0.patch \
     f9620d74cd49c35223304ba41e28be6144e45783.patch
+
+  # https://github.com/msys2/MINGW-packages/issues/17946
+  apply_patch_with_msg effadce6c756247ea8bae32dc13bb3e6f464f0eb.patch
 }
 
 build() {


### PR DESCRIPTION
See #17946