### PR TITLE
arpack: Rebuild with updated Flang for issue with complex numbers

### DIFF
--- a/mingw-w64-arpack/PKGBUILD
+++ b/mingw-w64-arpack/PKGBUILD
@@ -9,7 +9,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          $([[ "${CARCH}" == "i686" ]] || echo "${MINGW_PACKAGE_PREFIX}-${_realname}64"))
 pkgver=3.9.0
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 pkgdesc="Fortran77 subroutines designed to solve large scale eigenvalue problems (mingw-w64)"


### PR DESCRIPTION
The last time ARPACK was built for CLANG64, Flang was still broken for complex values on Windows.

Rebuild now that lowering of complex values with Flang is fixed.

See also here for a downstream issue:
https://octave.discourse.group/t/compilation-with-flang-on-windows/4734/6