### PR TITLE
embree: fix build error with clangarm64 due to missing _mm_malloc

### DIFF
--- a/mingw-w64-embree/002-arm64-no-mm-malloc.patch
+++ b/mingw-w64-embree/002-arm64-no-mm-malloc.patch
@@ -1,0 +1,19 @@
+--- embree-4.2.0/common/sys/alloc.cpp.orig	2023-07-04 11:17:39.000000000 +0200
++++ embree-4.2.0/common/sys/alloc.cpp	2023-08-05 10:41:18.866068400 +0200
+@@ -56,7 +56,15 @@
+   }
+ 
+ #endif
+-  
++
++#ifdef _WIN32
++#define WIN32_LEAN_AND_MEAN
++#include <windows.h>
++
++#define _mm_malloc(size, alignment) _aligned_malloc(size, alignment)
++#define _mm_free(ptr) _aligned_free(ptr)
++#endif
++
+   void* alignedMalloc(size_t size, size_t align)
+   {
+     if (size == 0)

--- a/mingw-w64-embree/PKGBUILD
+++ b/mingw-w64-embree/PKGBUILD
@@ -4,7 +4,7 @@ _realname=embree
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc="High Performance Ray Tracing Kernels Intel Corporation (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -16,12 +16,17 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/embree/embree/archive/v${pkgver}.tar.gz
-        001-build-fixes.patch)
+        001-build-fixes.patch
+        002-arm64-no-mm-malloc.patch)
 sha256sums=('b0479ce688045d17aa63ce6223c84b1cdb5edbf00d7eda71c06b7e64e21f53a0'
-            '3e5f251a93a6d8241a200fb311cf069643bcb3375a057216bca062df6e12e61b')
+            '3e5f251a93a6d8241a200fb311cf069643bcb3375a057216bca062df6e12e61b'
+            '8299d40d4ec23ecf034d485e12b56cdba2f4bd626305b978109ebfe1df618302')
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/001-build-fixes.patch
+
+  # no _mm_malloc with clangarm64, so just use _aligned_malloc everywhere
+  patch -p1 -i ${srcdir}/002-arm64-no-mm-malloc.patch
 }
 
 build() {


### PR DESCRIPTION
It was removed in https://github.com/mingw-w64/mingw-w64/commit/6affcc5d15b9caabb5891a Let's just used the default Windows API for this in all cases.