### PR TITLE
embree3: fix build error with clangarm64 due to missing _mm_malloc

### DIFF
--- a/mingw-w64-embree3/002-arm64-no-mm-malloc.patch
+++ b/mingw-w64-embree3/002-arm64-no-mm-malloc.patch
@@ -1,0 +1,19 @@
+--- embree-3.13.5/common/sys/alloc.cpp.orig	2023-08-05 12:22:20.363254500 +0200
++++ embree-3.13.5/common/sys/alloc.cpp	2023-08-05 12:22:53.386727300 +0200
+@@ -9,7 +9,15 @@
+ ////////////////////////////////////////////////////////////////////////////////
+ /// All Platforms
+ ////////////////////////////////////////////////////////////////////////////////
+-  
++
++#ifdef _WIN32
++#define WIN32_LEAN_AND_MEAN
++#include <windows.h>
++
++#define _mm_malloc(size, alignment) _aligned_malloc(size, alignment)
++#define _mm_free(ptr) _aligned_free(ptr)
++#endif
++
+ namespace embree
+ {
+   void* alignedMalloc(size_t size, size_t align) 

--- a/mingw-w64-embree3/PKGBUILD
+++ b/mingw-w64-embree3/PKGBUILD
@@ -4,7 +4,7 @@ _realname=embree3
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.13.5
-pkgrel=1
+pkgrel=2
 pkgdesc="High Performance Ray Tracing Kernels Intel Corporation (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -17,15 +17,19 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/embree/embree/archive/v${pkgver}.tar.gz
         001-build-fixes.patch
-        https://github.com/embree/embree/pull/412.patch)
+        https://github.com/embree/embree/pull/412.patch
+        002-arm64-no-mm-malloc.patch)
 sha256sums=('b8c22d275d9128741265537c559d0ea73074adbf2f2b66b0a766ca52c52d665b'
             '5ee91fb07f373b3a83f26f9f9fa3ab80661a9f0b7e1c3f4a23eb572f631fa37f'
-            '8bc0c0635ec0969eb60768fa9d0682096d96d17bf818eb995700f5f64601df14')
+            '8bc0c0635ec0969eb60768fa9d0682096d96d17bf818eb995700f5f64601df14'
+            'ef8f9f14ccb1c53eed144ae99d589ec8edd331bb5da8ca7e2d68a7cdc10822e0')
 prepare() {
   cd ${srcdir}/embree-${pkgver}
   patch -p1 -i ${srcdir}/001-build-fixes.patch
   # Windows ARM64 support
   patch -p1 -i ${srcdir}/412.patch
+  # no _mm_malloc with clangarm64, so just use _aligned_malloc everywhere
+  patch -p1 -i ${srcdir}/002-arm64-no-mm-malloc.patch
 
   mv kernels/embree.rc{,.orig}
   iconv -f UTF-16LE -t UTF-8 kernels/embree.rc.orig > kernels/embree.rc


### PR DESCRIPTION
It was removed in mingw-w64/mingw-w64@6affcc5d15b9caabb5891a Let's just used the default Windows API for this in all cases.