### PR TITLE
emacs: Update to 29.1

### DIFF
--- a/mingw-w64-emacs/PKGBUILD
+++ b/mingw-w64-emacs/PKGBUILD
@@ -2,11 +2,12 @@
 # Maintainer: Oscar Fuentes <ofv@wanadoo.es>
 
 _enable_jit=$([[ "${MINGW_PREFIX}" =~ /clang.* ]] || echo yes)
+_sanity_check=$([[ "${MINGW_PREFIX}" =~ /clang.* ]] || [[ "${MINGW_PREFIX}" =~ /ucrt.* ]] || echo yes)
 _realname=emacs
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=28.2
-pkgrel=6
+pkgver=29.1
+pkgrel=1
 pkgdesc="The extensible, customizable, self-documenting, real-time display editor (mingw-w64)"
 url="https://www.gnu.org/software/${_realname}/"
 license=('spdx:GPL-3.0')
@@ -40,7 +41,7 @@ source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.xz"{,.s
         "001-ucrt.patch"
         "002-clang-fixes.patch")
 # source=("https://alpha.gnu.org/gnu/${_realname}/pretest/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('ee21182233ef3232dc97b486af2d86e14042dbb65bbc535df562c3a858232488'
+sha256sums=('d2f881a5cc231e2f5a03e86f4584b0438f83edd7598a09d24a21bd8d003e2e01'
             'SKIP'
             'e1347064ec30094e21679764f784fa7557738946485359041473e6e9d7f3c3dc'
             '6f3a3260d8fd6c1fbeafd0611f604c46799005dc776af076bff1fd4d8a3b6304')
@@ -86,7 +87,12 @@ build() {
   # --without-compress-install is needed because we don't have gzip in
   # the mingw binaries and it is also required by native compilation.
 
-  make
+  # 001-ucrt.patch breaks stdout, causing make sanity-check to fail
+  if [[ "$_sanity_check" == "yes" ]] ; then
+    make
+  else
+    make actual-all
+  fi
 }
 
 package() {


### PR DESCRIPTION
`001-ucrt.patch` and `002-clang-fixes.patch` still work even though the line numbers don't match anymore. But I guess it's better to leave them as is to avoid introducing gratuitous changes?

As for the modification to the `build()` function, the emacs-29.1 update has added a `make sanity-check` target that invokes `emacs --batch --eval '(progn (defun f (n) (if (= 0 n) 1 (* n (f (- n 1))))) (princ (f 10)))'` after compilation. In the MinGW builds this returns `3628800`, but on the UCRT builds (including Clang) it returns nothing, which is why the check fails. 

I've modified the recipe so that it skips the sanity check for these versions: I believe the `001-ucrt.patch` is what causes this behaviour change (that or writing to `stdout` is fundamentally broken in the UCRT emacs build). Invoking the sanity check on the emacs-28.2 UCRT build doesn't return anything either, so at the very least this does not introduce a new issue.

Side note: Issues #17550 and #17343 are still present with the new Emacs/GCC versions, I've checked.