### PR TITLE
highway: update to 1.0.5

### DIFF
--- a/mingw-w64-highway/PKGBUILD
+++ b/mingw-w64-highway/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=highway
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.0.4
+pkgver=1.0.5
 pkgrel=1
 pkgdesc="C++ library for SIMD (Single Instruction, Multiple Data) (mingw-w64)"
 arch=('any')
@@ -15,12 +15,11 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 #checkdepends=("${MINGW_PACKAGE_PREFIX}-gtest")
-source=("${_realname}-${pkgver}.tar.gz"::"${url}/archive/refs/tags/${pkgver}.tar.gz")
-sha256sums=('faccd343935c9e98afd1016e9d20e0b8b89d908508d1af958496f8c2d3004ac2')
-
-prepare() {
-  cd "${srcdir}"/${_realname}-${pkgver}
-}
+source=("${_realname}-${pkgver}.tar.gz"::"${url}/archive/refs/tags/${pkgver}.tar.gz"
+        "${_realname}-${pkgver}.tar.gz.asc"::"${url}/releases/download/${pkgver}/${_realname}-${pkgver}.tar.gz.asc")
+sha256sums=('99b7dad98b8fa088673b720151458fae698ae5df9154016e39de4afdc23bb927'
+            'SKIP')
+validpgpkeys=('F2517B366FF63639D8B84BE1747A7E9A27DB674F')
 
 build() {
   declare -a extra_config


### PR DESCRIPTION
The [releases are now signed](https://github.com/google/highway/releases/tag/1.0.5).