### PR TITLE
qemu: Update to 8.0.4

### DIFF
--- a/mingw-w64-qemu/PKGBUILD
+++ b/mingw-w64-qemu/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=(
   "${MINGW_PACKAGE_PREFIX}-qemu-guest-agent"
   "${MINGW_PACKAGE_PREFIX}-qemu-image-util"
 )
-_base_ver="8.0.3"
+_base_ver="8.0.4"
 # QEMU Versioning of RC-SourcePackage and RC-Version differs
 # e.g. qemu-6.1.0-rc0.tar.xz contains 6.0.90, qemu-6.1.0-rc1.tar.xz contains 6.0.91
 # Unset _rc_no to create Release-Build
@@ -100,7 +100,7 @@ source=(
   msys2.examples.tests.sh
 )
 sha256sums=(
-  'ecf4d32cbef9d397bfc8cc50e4d1e92a1b30253bf32e8ee73c7a8dcf9a232b09'
+  '81c817dda38af958be5bef1a6cf55b658bb2d3fb87c1e6a571de6b7b2c44516c'
   'SKIP'
   '51625fd83c0a63729942d3dfc6d48be3491a700fe0f7cb8e88935b46081c9016'
   'f2f9eeb31023d002f54637a9941ea0d8fae3c6f0a66c05c033857b305bd1470d'


### PR DESCRIPTION
The QEMU v8.0.4 stable release contains security fixes.

See https://lists.gnu.org/archive/html/qemu-devel/2023-08/msg02106.html