### PR TITLE
Restore bsddb3, fix clang build and bump package release

### DIFF
--- a/mingw-w64-python-bsddb3/PKGBUILD
+++ b/mingw-w64-python-bsddb3/PKGBUILD
@@ -1,0 +1,58 @@
+# Contributor: Josip <bpisoj@gmail.com>
+
+_realname=bsddb3
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=6.2.9
+pkgrel=5
+pkgdesc="Python bindings for Oracle Berkeley DB (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+license=('BSD')
+url="https://www.jcea.es/programacion/pybsddb.htm"
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-db")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools" "${MINGW_PACKAGE_PREFIX}-cc")
+options=('staticlibs' 'strip' '!debug')
+source=("https://pypi.python.org/packages/source/b/bsddb3/${_realname}-${pkgver}.tar.gz"
+        db-6.0-support.patch
+        unsupported-runtime-dirs.patch)
+sha256sums=('70d05ec8dc568f42e70fc919a442e0daadc2a905a1cfb7ca77f549d49d6e7801'
+            'b96b05360f9a86af62e4c644be0fffc368f755d89ce14e23a93a75442c570cd6'
+            '1f686654150ff23c485c34a63d664d537e4ac47316e1f0ef74a9644e27d77442')
+
+prepare() {
+  plain "Patching setup files ..."
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -p1 -i ${srcdir}/db-6.0-support.patch
+  patch -p1 -i ${srcdir}/unsupported-runtime-dirs.patch
+
+  sed -i -e "s|if os.name == 'posix':|if os.name == 'nt':|g" setup{2,3}.py
+  sed -i -e "s|elif os.name == 'nt':|elif os.name == 'FOO':|g" setup{2,3}.py
+
+  cd "${srcdir}"
+  rm -rf "python-build-${CARCH}" | true
+  cp -r "${_realname}-${pkgver}" "python-build-${CARCH}"
+}
+
+build() {
+  cd "${srcdir}/python-build-${CARCH}"
+
+  CFLAGS+=" -DUNICODE -D_UNICODE"
+
+  export YES_I_HAVE_THE_RIGHT_TO_USE_THIS_BERKELEY_DB_VERSION=YES
+  export BERKELEYDB_DIR="${MINGW_PREFIX}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=;--install-purelib=;--install-data=" \
+  ${MINGW_PREFIX}/bin/python setup.py build
+}
+
+package() {
+  cd "${srcdir}/python-build-${CARCH}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=;--install-purelib=;--install-data=" \
+  ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX#\/} --root="${pkgdir}" --optimize=1 --skip-build
+}

--- a/mingw-w64-python-bsddb3/PKGBUILD
+++ b/mingw-w64-python-bsddb3/PKGBUILD
@@ -7,7 +7,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=6.2.9
-pkgrel=5
+pkgrel=6
 pkgdesc="Python bindings for Oracle Berkeley DB (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -42,6 +42,10 @@ build() {
   cd "${srcdir}/python-build-${CARCH}"
 
   CFLAGS+=" -DUNICODE -D_UNICODE"
+
+  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
+    CFLAGS+=" -Wno-incompatible-function-pointer-types"
+  fi
 
   export YES_I_HAVE_THE_RIGHT_TO_USE_THIS_BERKELEY_DB_VERSION=YES
   export BERKELEYDB_DIR="${MINGW_PREFIX}"

--- a/mingw-w64-python-bsddb3/db-6.0-support.patch
+++ b/mingw-w64-python-bsddb3/db-6.0-support.patch
@@ -1,0 +1,24 @@
+diff -Naur bsddb3-6.2.6-orig/setup2.py bsddb3-6.2.6/setup2.py
+--- bsddb3-6.2.6-orig/setup2.py	2019-07-09 15:17:59.018630700 +0300
++++ bsddb3-6.2.6/setup2.py	2019-07-10 08:26:06.217425400 +0300
+@@ -152,7 +152,7 @@
+         lflags_arg = LFLAGS + LIBS
+ 
+     # Supported Berkeley DB versions, in order of preference.
+-    db_ver_list = ((6, 2), (6, 1),
++    db_ver_list = ((6, 2), (6, 1), (6, 0),
+             (5, 3), (5, 1),
+             (4, 8), (4, 7))
+     db_ver = None
+diff -Naur bsddb3-6.2.6-orig/setup3.py bsddb3-6.2.6/setup3.py
+--- bsddb3-6.2.6-orig/setup3.py	2019-07-09 15:17:59.018630700 +0300
++++ bsddb3-6.2.6/setup3.py	2019-07-10 08:25:58.526611900 +0300
+@@ -152,7 +152,7 @@
+         lflags_arg = LFLAGS + LIBS
+ 
+     # Supported Berkeley DB versions, in order of preference.
+-    db_ver_list = ((6, 2), (6, 1),
++    db_ver_list = ((6, 2), (6, 1), (6, 0),
+             (5, 3), (5, 1),
+             (4, 8), (4, 7))
+     db_ver = None

--- a/mingw-w64-python-bsddb3/unsupported-runtime-dirs.patch
+++ b/mingw-w64-python-bsddb3/unsupported-runtime-dirs.patch
@@ -1,0 +1,10 @@
+--- bsddb3-6.2.9/setup3.py.orig	2022-06-12 09:37:28.978102500 +0200
++++ bsddb3-6.2.9/setup3.py	2022-06-12 10:00:04.408752300 +0200
+@@ -539,7 +539,6 @@
+                                depends = ['Modules/bsddb.h'],
+                                include_dirs = [ incdir ],
+                                library_dirs = [ libdir ],
+-                               runtime_library_dirs = [ libdir ],
+                                libraries = libname,
+                                extra_link_args = lflags_arg,
+                                )],


### PR DESCRIPTION
Restore bsddb3 6.2.29 which was recently removed with #17874 due to build failures with clang, and also work around the clang build error.

Clang generates a compiler error against code which gcc treats as a warning. This change disables that error (only for clang) so the build can succeed. The code in question needs to be fixed (has been raised with the project), but this fix allows the build to succeed so downstream consumers (e.g. Gramps) can use the package.

Bumped up the package release. Built mingw64 gcc, clang and ucrt builds locally with success.

FYI @mmuetzel @Biswa96 