### PR TITLE
hyperfine, watchexec: update windows-targets for gnullvm support

### DIFF
--- a/mingw-w64-hyperfine/PKGBUILD
+++ b/mingw-w64-hyperfine/PKGBUILD
@@ -4,7 +4,7 @@ _realname=hyperfine
 pkgbase=mingw-w64-$_realname
 pkgname=$MINGW_PACKAGE_PREFIX-$_realname
 pkgver=1.17.0
-pkgrel=1
+pkgrel=2
 pkgdesc='A command-line benchmarking tool (mingw-w64)'
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -17,6 +17,8 @@ sha256sums=('3dcd86c12e96ab5808d5c9f3cec0fcc04192a87833ff009063c4a491d5487b58')
 prepare() {
   cd "${_realname}-${pkgver}"
 
+  # update windows-targets to fix windows-gnullvm dependency specification
+  cargo update -p windows-targets@0.48.0 --precise 0.48.1
   cargo fetch --locked
 }
 

--- a/mingw-w64-watchexec/PKGBUILD
+++ b/mingw-w64-watchexec/PKGBUILD
@@ -2,7 +2,7 @@ _realname=watchexec
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.22.3
-pkgrel=1
+pkgrel=2
 url="https://watchexec.github.io/"
 pkgdesc="Executes commands in response to file modifications (mingw-w64)"
 license=('spdx:Apache-2.0')
@@ -15,6 +15,8 @@ sha256sums=('698ed1dc178279594542f325b23f321c888c9c12c1960fe11c0ca48ba6edad76')
 prepare() {
   cd "${_realname}-${pkgver}"
 
+  # update windows-targets to fix windows-gnullvm dependency specification
+  cargo update -p windows-targets@0.48.0 --precise 0.48.1
   cargo fetch --locked
 }
 


### PR DESCRIPTION
Successful CLANGARM64 CI run: https://github.com/msys2-arm/MINGW-packages/actions/runs/5843684183/job/15846050647