### PR TITLE
python-pip: Use python-build to build

### DIFF
--- a/mingw-w64-python-pip/PKGBUILD
+++ b/mingw-w64-python-pip/PKGBUILD
@@ -8,7 +8,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=23.2.1
-pkgrel=1
+pkgrel=2
 pkgdesc="The PyPA recommended tool for installing Python packages. (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -17,12 +17,10 @@ url="https://pip.pypa.io/"
 depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-setuptools"
          "${MINGW_PACKAGE_PREFIX}-python-distlib")
-# checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest"
-#               "${MINGW_PACKAGE_PREFIX}-python-scripttest"
-#               "${MINGW_PACKAGE_PREFIX}-python-csv23"
-#               "${MINGW_PACKAGE_PREFIX}-python-cryptography"
-#               "${MINGW_PACKAGE_PREFIX}-python-werkzeug"
-#               "${MINGW_PACKAGE_PREFIX}-python-virtualenv")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-wheel")
+options=('!strip')
 source=(
   "${_realname}-${pkgver}.tar.gz::https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
   "0001-use-system-distlib.patch"
@@ -31,33 +29,22 @@ sha256sums=('fb0bd5435b3200c602b5bf61d2d43c2f13c02e29c1707567ae7fbc514eb9faf2'
             'c7f98690afa60e59324f1ce52e72bd7809cbfaba4e29a2d933f08c1a025f8246')
 
 prepare() {
-  rm -rf python-build-${CARCH}| true
-  cp -r "${_realname}-${pkgver}" "python-build-${CARCH}"
-  rm -rf "python-build-${CARCH}"/src/pip/_vendor/distlib
-  cd "${srcdir}/python-build-${CARCH}"
+  cd "${_realname}-${pkgver}"
+  rm -r src/pip/_vendor/distlib
   patch -p1 -i ${srcdir}/0001-use-system-distlib.patch
 }
 
 build() {
-  msg "Python build for ${CARCH}" 
-  cd "${srcdir}/python-build-${CARCH}"
-  ${MINGW_PREFIX}/bin/python setup.py build
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
 }
-# check() {
-#   msg "Python test for ${CARCH}"
-#   cd "${srcdir}/python-build-${CARCH}"
-#   ${MINGW_PREFIX}/bin/pytest tests
-# }
+
 package() {
-  cd "${srcdir}/python-build-${CARCH}"
-  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-    ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX#\/} --root="${pkgdir}" --optimize=1 --skip-build -v
+  cd "${srcdir}/python-build-${MSYSTEM}"
 
-  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
-  # fix python command in files
-  for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
-    sed -i 's/\#\!.*//' $_f
-  done
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
 
-  install -D -m644 LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+  install -Dm644 LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE.txt"
 }


### PR DESCRIPTION

    This fixes the following error with pip install command.

    //python.exe: can't open file '\\\\pip-script.py': [Errno 2] No such file or directory

