### PR TITLE
onefetch: update windows-targets for gnullvm support

### DIFF
--- a/mingw-w64-onefetch/PKGBUILD
+++ b/mingw-w64-onefetch/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=onefetch
 pkgbase=mingw-w64-$_realname
 pkgname=$MINGW_PACKAGE_PREFIX-$_realname
-pkgver=2.17.0
+pkgver=2.18.1
 pkgrel=1
 pkgdesc="Git repository summary on your terminal (mingw-w64)"
 url="https://github.com/o2sh/onefetch"
@@ -12,7 +12,7 @@ depends=("$MINGW_PACKAGE_PREFIX-libgit2")
 makedepends=("$MINGW_PACKAGE_PREFIX-rust"
              "$MINGW_PACKAGE_PREFIX-cmake")
 source=("$_realname-$pkgver.tar.gz::$url/archive/$pkgver.tar.gz")
-sha256sums=('fdaa0df2d7c9c75fdcb6421d03647ee64dfc9da839bcd90d6c5d34595d35e0db')
+sha256sums=('7b0f03e9d2383ac32283cfb9ec09d10c8789a298969c8b7d45fa0168bd909140')
 
 prepare() {
   cd "$_realname-$pkgver"

--- a/mingw-w64-onefetch/PKGBUILD
+++ b/mingw-w64-onefetch/PKGBUILD
@@ -2,7 +2,7 @@ _realname=onefetch
 pkgbase=mingw-w64-$_realname
 pkgname=$MINGW_PACKAGE_PREFIX-$_realname
 pkgver=2.18.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Git repository summary on your terminal (mingw-w64)"
 url="https://github.com/o2sh/onefetch"
 license=('MIT')
@@ -16,6 +16,8 @@ sha256sums=('7b0f03e9d2383ac32283cfb9ec09d10c8789a298969c8b7d45fa0168bd909140')
 
 prepare() {
   cd "$_realname-$pkgver"
+  # update windows-targets to fix windows-gnullvm dependency specification
+  cargo update -p windows-targets@0.48.0 --precise 0.48.1
   cargo fetch --locked
   mkdir -p completions
 }


### PR DESCRIPTION
Fixes https://github.com/msys2/MINGW-packages/pull/18083#issuecomment-1676330759
See https://github.com/o2sh/onefetch/issues/1143

Successful CLANGARM64 CI run: https://github.com/msys2-arm/MINGW-packages/actions/runs/5858975316/job/15884039932