### PR TITLE
graphicsmagick: Fix writing TIFF images with transparency

### DIFF
--- a/mingw-w64-graphicsmagick/002-tiff-transparency.patch
+++ b/mingw-w64-graphicsmagick/002-tiff-transparency.patch
@@ -1,0 +1,19 @@
+# HG changeset patch
+# User Markus Mützel <markus.muetzel@gmx.de>
+# Date 1692044411 -7200
+#      Mon Aug 14 22:20:11 2023 +0200
+# Node ID 292e7cc8803b116f646ee4cf10b2d9283283d8b7
+# Parent  53cbd2ee5481c93194aead28dcb4ba577ef53b64
+WriteTIFFImage: Create valid TIFF images with transparency.
+
+diff -r 53cbd2ee5481 -r 292e7cc8803b coders/tiff.c
+--- a/coders/tiff.c	Sat Aug 12 10:19:43 2023 -0500
++++ b/coders/tiff.c	Mon Aug 14 22:20:11 2023 +0200
+@@ -5143,6 +5143,7 @@
+           /*
+             Image has a matte channel.  Mark it correctly.
+           */
++          alpha_type=UnassociatedAlpha;
+           uint16
+             extra_samples,
+             sample_info[1];

--- a/mingw-w64-graphicsmagick/PKGBUILD
+++ b/mingw-w64-graphicsmagick/PKGBUILD
@@ -4,12 +4,12 @@ _realname=graphicsmagick
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.3.41
-pkgrel=1
+pkgrel=2
 pkgdesc="An image viewing/manipulation program (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="http://www.graphicsmagick.org/"
-license=("custom")
+license=("spdx:MIT")
 makedepends=("${MINGW_PACKAGE_PREFIX}-ghostscript"
              "${MINGW_PACKAGE_PREFIX}-libheif"
              "${MINGW_PACKAGE_PREFIX}-libjxl"
@@ -44,11 +44,13 @@ options=('staticlibs' 'strip' 'libtool')
 source=(https://sourceforge.net/projects/graphicsmagick/files/${_realname}/${pkgver}/GraphicsMagick-${pkgver}.tar.xz
         pathtools.c
         pathtools.h
-        001-relocate.patch)
+        001-relocate.patch
+        002-tiff-transparency.patch)
 sha256sums=('b741b11ba86162db4d4ec1b354989a773f73c40722d1148239f6c69c9f04a6aa'
             '08209cbf1633fa92eae7e5d28f95f8df9d6184cc20fa878c99aec4709bb257fd'
             '965d3921ec4fdeec94a2718bc2c85ce5e1a00ea0e499330a554074a7ae15dfc6'
-            '73ce65aad39e54b786c332a9aac42d39353af02cf32e3fbfe4e607644cc0a254')
+            '73ce65aad39e54b786c332a9aac42d39353af02cf32e3fbfe4e607644cc0a254'
+            'e040ba17c50391d03322e9f47ca5876385e8f1a984ec96856276a97f2794be16')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -71,7 +73,8 @@ prepare() {
   cp -fHv "${srcdir}"/pathtools.[ch] magick/
 
   apply_patch_with_msg \
-    001-relocate.patch
+    001-relocate.patch \
+    002-tiff-transparency.patch
 
   autoreconf -fiv
 }

--- a/mingw-w64-graphicsmagick/PKGBUILD
+++ b/mingw-w64-graphicsmagick/PKGBUILD
@@ -73,7 +73,10 @@ prepare() {
   cp -fHv "${srcdir}"/pathtools.[ch] magick/
 
   apply_patch_with_msg \
-    001-relocate.patch \
+    001-relocate.patch
+
+  # https://sourceforge.net/p/graphicsmagick/bugs/718/
+  apply_patch_with_msg \
     002-tiff-transparency.patch
 
   autoreconf -fiv


### PR DESCRIPTION
The latest version of GraphicsMagick is stricter when it comes to reading TIFF images with transparency. It is now a requirement that `TIFFTAG_EXTRASAMPLES` is defined in the image file for the alpha channel:
http://hg.code.sf.net/p/graphicsmagick/code/rev/5c6fd2a5e177

Afaict, that is conform to the standard:
https://www.awaresystems.be/imaging/tiff/tifftags/extrasamples.html

However, the TIFF files with transparency that are created by GraphicsMagick itself don't write that tag (with default parameters).

Add a patch that writes the necessary tag for TIFF images with transparency with default parameters.

With this patch, Octave's test for `imwrite` passes again.

It is still a pity that GraphicsMagick now refuses to read files completely that it wrote itself in previous versions. As it stands, the alpha channel is lost.
