### PR TITLE
Revert "vulkan-headers: update to 1.3.261"

### DIFF
--- a/mingw-w64-vulkan-headers/PKGBUILD
+++ b/mingw-w64-vulkan-headers/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=Vulkan-Headers
 pkgbase=mingw-w64-vulkan-headers
 pkgname=("${MINGW_PACKAGE_PREFIX}-vulkan-headers")
-pkgver=1.3.261
+pkgver=1.3.256
 pkgrel=1
 pkgdesc='Vulkan header files (mingw-w64)'
 arch=('any')
@@ -17,7 +17,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/KhronosGroup/${_realname}/archive/v${pkgver}.tar.gz")
-sha256sums=('0c67b2b76a7d6534c0f98085dbbcd4a1ac945b15b269bc81ee7dbe6cf28d53bb')
+sha256sums=('fcd3021d5f504941aa285836125fc61e6b0636bb61da6f33d9ae9299786f729b')
 
 build() {
   mkdir -p ${srcdir}/build-${MSYSTEM} && cd ${srcdir}/build-${MSYSTEM}
@@ -47,5 +47,5 @@ package() {
   cd ${srcdir}/build-${MSYSTEM}
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install .
 
-  install -Dm644 ${srcdir}/${_realname}-${pkgver}/LICENSE.md ${pkgdir}${MINGW_PREFIX}/share/licenses/vulkan-headers/LICENSE
+  install -Dm644 ${srcdir}/${_realname}-${pkgver}/LICENSE.TXT ${pkgdir}${MINGW_PREFIX}/share/licenses/vulkan-headers/LICENSE
 }

--- a/mingw-w64-vulkan-headers/PKGBUILD
+++ b/mingw-w64-vulkan-headers/PKGBUILD
@@ -6,6 +6,7 @@ pkgbase=mingw-w64-vulkan-headers
 pkgname=("${MINGW_PACKAGE_PREFIX}-vulkan-headers")
 pkgver=1.3.256
 pkgrel=1
+epoch=1
 pkgdesc='Vulkan header files (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')

--- a/mingw-w64-vulkan-loader/PKGBUILD
+++ b/mingw-w64-vulkan-loader/PKGBUILD
@@ -8,6 +8,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-vulkan")
 replaces=("${MINGW_PACKAGE_PREFIX}-vulkan")
 pkgver=1.3.256
 pkgrel=1
+epoch=1
 pkgdesc='Vulkan Installable Client Driver (ICD) Loader (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')

--- a/mingw-w64-vulkan-loader/PKGBUILD
+++ b/mingw-w64-vulkan-loader/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-vulkan-loader
 pkgname=("${MINGW_PACKAGE_PREFIX}-vulkan-loader")
 provides=("${MINGW_PACKAGE_PREFIX}-vulkan")
 replaces=("${MINGW_PACKAGE_PREFIX}-vulkan")
-pkgver=1.3.261
+pkgver=1.3.256
 pkgrel=1
 pkgdesc='Vulkan Installable Client Driver (ICD) Loader (mingw-w64)'
 arch=('any')
@@ -21,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python")
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/KhronosGroup/${_realname}/archive/v${pkgver}.tar.gz"
         0001-disable-masm.patch)
-sha256sums=('85d13004c81b032baf7cc4c2de0b2cb57072a86855d7ca7fc9a813621da275ba'
+sha256sums=('71fc0b7ec947eb2d9403238930ba7e53622fa0787aed0ea5f5dc21eec2818eae'
             '4614c7c3c5f5cc10d9aa92cc2f85699b07fca0ecfbc2e6893f433e1f3d118321')
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {


### PR DESCRIPTION
VVL 1.3.255 cannot be build with vulkan-headers 1.3.261. VVL 1.3.261 cannot be build with SPIR-V Tools 1.3.250.0 which is currently latest release. So revert header and loader update to bring back the compatibility.

Those 4 packages have to be updated together, because they have dependencies between each other and not all of them have the same release cycle.
SPIR-V Tools
glsllang
VVL
vulkan-headers