### PR TITLE
emacs: enable tree-sitter

### DIFF
--- a/mingw-w64-emacs/PKGBUILD
+++ b/mingw-w64-emacs/PKGBUILD
@@ -7,7 +7,7 @@ _realname=emacs
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=29.1
-pkgrel=1
+pkgrel=2
 pkgdesc="The extensible, customizable, self-documenting, real-time display editor (mingw-w64)"
 url="https://www.gnu.org/software/${_realname}/"
 license=('spdx:GPL-3.0')
@@ -21,6 +21,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-universal-ctags"
          "${MINGW_PACKAGE_PREFIX}-harfbuzz"
          "${MINGW_PACKAGE_PREFIX}-jansson"
          "${MINGW_PACKAGE_PREFIX}-gnutls"
+         "${MINGW_PACKAGE_PREFIX}-tree-sitter"
          "${MINGW_PACKAGE_PREFIX}-libwinpthread")
 optdepends=("${MINGW_PACKAGE_PREFIX}-giflib"
             "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
@@ -82,6 +83,7 @@ build() {
     --with-modules \
     --without-dbus \
     --without-compress-install \
+    --with-tree-sitter \
     $_extra_cfg
 
   # --without-compress-install is needed because we don't have gzip in


### PR DESCRIPTION
I don't know what this is, but someone requested it. Arch also enabled it:
https://gitlab.archlinux.org/archlinux/packaging/packages/emacs/-/commit/3c17a6ba310d252f15eabd