### PR TITLE
libtiff: Add missing tif_hash_set.h

### DIFF
--- a/mingw-w64-libtiff/0002-libtiff-install-headers.patch
+++ b/mingw-w64-libtiff/0002-libtiff-install-headers.patch
@@ -1,0 +1,15 @@
+--- a/libtiff/Makefile.am
++++ b/libtiff/Makefile.am
+@@ -37,8 +37,12 @@
+ 	tif_win32_versioninfo.rc
+ 
+ libtiffinclude_HEADERS = \
++	tif_config.h \
++	tif_dir.h \
++	tif_hash_set.h \
+ 	tiff.h \
+ 	tiffio.h \
++	tiffiop.h \
+ 	tiffvers.h
+ 
+ if HAVE_CXX

--- a/mingw-w64-libtiff/PKGBUILD
+++ b/mingw-w64-libtiff/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
 pkgver=4.5.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Library for manipulation of TIFF images (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -25,13 +25,16 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-python-sphinx")
 source=(https://download.osgeo.org/libtiff/tiff-${pkgver}.tar.gz
-        "0001-fix-test-newline.patch")
+        0001-fix-test-newline.patch
+        0002-libtiff-install-headers.patch)
 sha256sums=('d7f38b6788e4a8f5da7940c5ac9424f494d8a79eba53d555f4a507167dca5e2b'
-            'aacda67800bd9c4704761519876631c7309021d37594d72165361386547e9359')
+            'aacda67800bd9c4704761519876631c7309021d37594d72165361386547e9359'
+            '493742947c8667655b6b89f2d7d27e92e1438a490ed86f50811112394b432a12')
 
 prepare() {
   cd tiff-${pkgver}
   patch -p0 -i "${srcdir}/0001-fix-test-newline.patch"
+  patch -p1 -i "${srcdir}/0002-libtiff-install-headers.patch"
 
   # autoreconf to get updated libtool files for clang support
   autoreconf -fiv
@@ -89,9 +92,6 @@ check() {
 package_libtiff() {
   make DESTDIR="${pkgdir}" -C "${srcdir}/build-${MSYSTEM}-static" install
   make DESTDIR="${pkgdir}" -C "${srcdir}/build-${MSYSTEM}-shared" install
-
-  cp ${srcdir}/tiff-${pkgver}/libtiff/{tiffiop,tif_dir}.h "${pkgdir}${MINGW_PREFIX}/include/"
-  cp "${srcdir}/build-${MSYSTEM}-shared/libtiff/tif_config.h" "${pkgdir}${MINGW_PREFIX}/include/"
 
   # License
   # See https://fedoraproject.org/wiki/Licensing:MIT#Hylafax_Variant


### PR DESCRIPTION
Also move the extra headers install logic to separate patch file

Fixes https://github.com/msys2/MINGW-packages/issues/18226