### PR TITLE
python-setuptools: add support for py_limited_api

### DIFF
--- a/mingw-w64-python-setuptools/0010-support-py_limited_api.patch
+++ b/mingw-w64-python-setuptools/0010-support-py_limited_api.patch
@@ -1,0 +1,21 @@
+--- setuptools-68.0.0/setuptools/command/build_ext.py.orig	2023-06-19 17:52:37.000000000 +0200
++++ setuptools-68.0.0/setuptools/command/build_ext.py	2023-08-21 18:39:55.475275100 +0200
+@@ -340,6 +340,18 @@
+         if os.path.exists(stub_file) and not self.dry_run:
+             os.unlink(stub_file)
+ 
++    def get_libraries(self, ext):
++        libraries =  _build_ext.get_libraries(self, ext)
++        if getattr(ext, 'py_limited_api') and self.plat_name.startswith('mingw'):
++            # XXX Since gcc/clang don't support linking specific libraries via
++            # pragma like CPython does with MSVC (see PC/pyconfig.h in cpython),
++            # and because py_limited_api is a setuptools feature and not a
++            # distutils one, this is the only place where we can check and force
++            # it to link against python3 instead of python3.x
++            versioned = 'python' + get_config_var('LDVERSION')
++            return ['python3' if l == versioned else l for l in libraries]
++        return libraries
++
+ 
+ if use_stubs or os.name == 'nt':
+     # Build shared libraries

--- a/mingw-w64-python-setuptools/PKGBUILD
+++ b/mingw-w64-python-setuptools/PKGBUILD
@@ -9,7 +9,7 @@ conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
            "${MINGW_PACKAGE_PREFIX}-python2-setuptools<42.0.2")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=68.0.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Easily download, build, install, upgrade, and uninstall Python packages (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -49,7 +49,8 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
         '0006-fix-tests-path.patch'
         '0007-windows-arm64.patch'
         '0008-default-stdlib-distutils.patch'
-        '0009-launcher-revert-symlink-resolve.patch')
+        '0009-launcher-revert-symlink-resolve.patch'
+        '0010-support-py_limited_api.patch')
 sha256sums=('baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235'
             '7b196884ac0151801f9638dabbf9a789fa9070a3b07a4c9e625c5523e8d47387'
             'fa54581e3dddb9f4edd332dedbc101f48939a9ca5878e13cf9cf9b3408bc8c22'
@@ -58,7 +59,8 @@ sha256sums=('baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235'
             'dbdd96a7ead797b2db9f02dfe19ce853d3775337ccf8fd836377fe3c2a9d1c24'
             'cb897bc7292a733167fa48b5ca18323d76d3374683a7f5e9986c9df63f5332cc'
             'db9a6e2c18d4adfd7c88d17d28268d57afba8845556c1cf1e5c92f513bf36847'
-            '391d682a8b8832d7e4be3ac0c3327cfe3c8e520f16e25b43d4441df8036bf147')
+            '391d682a8b8832d7e4be3ac0c3327cfe3c8e520f16e25b43d4441df8036bf147'
+            'ccb276f9d2d26587d29ecfd4d47a3d4e96fb58738cfaf3a600a8b942c79fc439')
 
 prepare() {
   cd "${srcdir}/setuptools-${pkgver}"
@@ -77,6 +79,9 @@ prepare() {
   # and our Python can't deal with that for some reason
   # (from what I see the launcher code itself deals with it fine)
   patch -R -p1 -i ${srcdir}/0009-launcher-revert-symlink-resolve.patch
+
+  # https://github.com/msys2-contrib/cpython-mingw/issues/149
+  patch -p1 -i ${srcdir}/0010-support-py_limited_api.patch
 
   cd "${srcdir}"
   rm -rf python-build-${MSYSTEM} | true


### PR DESCRIPTION
This makes distutils link against python3 instead of python3.x when py_limited_api is set on the extension. With MSVC this is solved via pragma, which doesn't have an alternative with our toolchains.

This depends on libpython3.dll being installed, so https://github.com/msys2-contrib/cpython-mingw/pull/148