### PR TITLE
python-maturin: Update to 1.2.3

### DIFF
--- a/mingw-w64-python-maturin/PKGBUILD
+++ b/mingw-w64-python-maturin/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=maturin
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
-pkgver=1.1.0
-pkgrel=4
+pkgver=1.2.3
+pkgrel=1
 pkgdesc='Build and publish crates with pyo3, rust-cpython and cffi bindings as well as rust binaries as python packages (mingw-w64)'
 url='https://github.com/pyo3/maturin'
 arch=('any')
@@ -20,39 +20,20 @@ makedepends=(
 options=(!strip)
 source=("https://pypi.io/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz"
         "001-fix-default-target-on-mingw-32bit.patch")
-sha256sums=('4650aeaa8debd004b55aae7afb75248cbd4d61cd7da2dcf4ead8b22b58cecae0'
+sha256sums=('ef3f42af453d64f233b99543c3001bee645019a9c2022c7972210a9cacb5301f'
             '5d363f2540f84651439f47782c9d60ababde58f7187b09945040f3795745bf45')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
   patch -Np1 -i "${srcdir}/001-fix-default-target-on-mingw-32bit.patch"
-
-  cargo vendor \
-    --locked \
-    --versioned-dirs
-
-  mkdir -p .cargo
-  cat >> .cargo/config.toml <<END
-
-[source.crates-io]
-replace-with = "vendored-sources"
-
-[source.vendored-sources]
-directory = "vendor"
-END
-
-
-  sed -i -e 's/"cfg(all(target_arch = \\"\([^\\]\+\)\\", target_env = \\"gnu\\", target_abi = \\"llvm\\", not(windows_raw_dylib)))"/"\1-pc-windows-gnullvm"/g' \
-    "vendor/windows-targets-0.48.0/Cargo.toml"
-  sed -i -e 's/\("Cargo.toml":\)"[^"]\+"/\1"'"$(sha256sum "vendor/windows-targets-0.48.0/Cargo.toml" | cut -d' ' -f1)"'"/' \
-    "vendor/windows-targets-0.48.0/.cargo-checksum.json"
-
 }
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
 
+  # this is the default feature set in Cargo.toml
+  export MATURIN_SETUP_ARGS="--features full,rustls"
   ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
 }
 


### PR DESCRIPTION
Remove clangarm64 workaround, should no longer be needed since windows-targets is new enough now.

Also enables the default feature set, so commands like "new" and "init" are now available, as if built with cargo.