### PR TITLE
gpgme: update to 1.22.0

### DIFF
--- a/mingw-w64-gpgme/PKGBUILD
+++ b/mingw-w64-gpgme/PKGBUILD
@@ -7,8 +7,8 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-qgpgme-qt5"
          "${MINGW_PACKAGE_PREFIX}-python-gpgme")
-pkgver=1.21.0
-pkgrel=2
+pkgver=1.22.0
+pkgrel=1
 pkgdesc="A C wrapper library for GnuPG (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -44,7 +44,7 @@ validpgpkeys=('5B80C5754298F0CB55D8ED6ABCEF7E294B092E28'
               '6DAA6E64A76D2840571B4902528897B826403ADA'
               'AC8E115BF73E2D8D47FA9908E98E9B2D19C6C8BD'
               '02F38DFF731FF97CB039A1DA549E695E905BA208')
-sha256sums=('416e174e165734d84806253f8c96bda2993fd07f258c3aad5f053a6efd463e88'
+sha256sums=('9551e37081ad3bde81018a0d24f245c3f8206990549598fb31a97a68380a7b71'
             'SKIP'
             'c8e4b6a64f71ceb8a84f177829ce7e96f983881ffe8e7e952de3b255a8e20143'
             '75f77086c96fb4bcb9edad01bf64bbf11a7ec435f751b901f3fb180b410fa236'
@@ -52,7 +52,7 @@ sha256sums=('416e174e165734d84806253f8c96bda2993fd07f258c3aad5f053a6efd463e88'
             '1fa234be3412c7664110900de2074b36c88d39c79bbc6ec7870fd6b76f7cb5e4'
             'ace3d5166372e0422a625f76a2890d70f2916d9239ade74e58bd23077e9c1c6b'
             '5e8e7e773a09ed1e1724c9d7216eaaecce52af49152513366026a2fa3245d762'
-            '0d5a1eac9246665a3828873ec5cc3bba2b352cffc1781dbe4ba19efc88be0d66'
+            '81f412ffdeeb2a0757248b517fbda9caae9913b1552c88abb8347faa4d1efea2'
             '645f019ff078b26e6badbc238a440a4430ada2e48d8f6eda715a76546e2a5848'
             'd09070c005b72e8aed14a848553f7c7289353ff7f32e62c9013a729ba46d7117')
 
@@ -89,6 +89,8 @@ build() {
   export CFLAGS="${CFLAGS} -Wno-int-conversion -Wno-incompatible-function-pointer-types"
 
   # mingw doxygen can't wrok with UNIX paths in doxyfile
+  # --with-libtool-modification=never : Otherwise DLL name changes
+  # see cmake files for the expected DLL names
   DOXYGEN=/usr/bin/doxygen \
   PYTHON=${MINGW_PREFIX}/bin/python3 \
   ./configure \
@@ -103,7 +105,8 @@ build() {
     --disable-gpgsm-test \
     --disable-gpgconf-test \
     --disable-gpg-test \
-    --enable-w32-glib
+    --enable-w32-glib \
+    --with-libtool-modification=never
 
   make
 

--- a/mingw-w64-gpgme/relocatable-cmake.patch
+++ b/mingw-w64-gpgme/relocatable-cmake.patch
@@ -40,7 +40,7 @@ diff --git a/lang/qt/src/QGpgmeConfig-w32.cmake.in.in b/lang/qt/src/QGpgmeConfig
 index b8978053..8f7a2d43 100644
 --- a/lang/qt/src/QGpgmeConfig-w32.cmake.in.in
 +++ b/lang/qt/src/QGpgmeConfig-w32.cmake.in.in
-@@ -58,18 +58,28 @@ unset(_targetsDefined)
+@@ -58,14 +58,22 @@
  unset(_targetsNotDefined)
  unset(_expectedTargets)
  
@@ -61,15 +61,17 @@ index b8978053..8f7a2d43 100644
 +  IMPORTED_IMPLIB_RELEASE "${_IMPORT_PREFIX}/lib/libqgpgme.dll.a"
 +  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include/qgpgme;${_IMPORT_PREFIX}/include"
    INTERFACE_LINK_LIBRARIES "Gpgmepp;Qt5::Core"
--  IMPORTED_LOCATION "@resolved_libdir@/libqgpgme-7.dll"
+-  IMPORTED_LOCATION "@resolved_bindir@/libqgpgme-15.dll"
 +  IMPORTED_LOCATION "${_IMPORT_PREFIX}/bin/libqgpgme-15.dll"
  )
+ get_target_property(_libpath QGpgme IMPORTED_IMPLIB_RELEASE)
+ get_target_property(_dllpath QGpgme IMPORTED_LOCATION)
+@@ -73,6 +81,8 @@
+ list(APPEND _IMPORT_CHECK_TARGETS QGpgme )
+ list(APPEND _IMPORT_CHECK_FILES_FOR_QGpgme "${_libpath}" "${_dllpath}" )
  
- list(APPEND _IMPORT_CHECK_TARGETS QGgpme )
--list(APPEND _IMPORT_CHECK_FILES_FOR_Qgpgme "@resolved_libdir@/libqgpgme.dll.a" "@resolved_bindir@/libqgpgme-7.dll" )
-+list(APPEND _IMPORT_CHECK_FILES_FOR_Qgpgme "${_IMPORT_PREFIX}/lib/libqgpgme.dll.a" "${_IMPORT_PREFIX}/bin/libqgpgme-15.dll" )
-+
 +set(_IMPORT_PREFIX)
- 
++
  if(CMAKE_VERSION VERSION_LESS 2.8.12)
    message(FATAL_ERROR "This file relies on consumers using CMake 2.8.12 or greater.")
+ endif()


### PR DESCRIPTION

    Changes:

    * Remove hunks in relocatable-cmake.patch file which were fixed in upstream.
      DLL name and path was fixed in this (libqgpgme-7.dll to libqgpgme-15.dll)
      https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpgme.git;a=commit;h=be0e653ce3039b1a81d23bed9dc99c0e60a7995a
    * Disble modifying libtool file in build directory. Otherwise, it changes
      the DLL name. That libtool logic was added in this commit
      https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpgme.git;a=commit;h=e622e36f1f32641c66b28a0de95c75ae35f6ca05
      But the cmake files expect previous DLL names.

