### PR TITLE
spirv-cross: Update to 1.3.261.0

### DIFF
--- a/mingw-w64-spirv-cross/PKGBUILD
+++ b/mingw-w64-spirv-cross/PKGBUILD
@@ -4,8 +4,8 @@ _realname=spirv-cross
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 epoch=1
-pkgver=1.3.250.0
-pkgrel=2
+pkgver=1.3.261.0
+pkgrel=1
 pkgdesc="A tool and library for parsing and converting SPIR-V to other shader languages (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -16,12 +16,11 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-glslang"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-python"
-             "${MINGW_PACKAGE_PREFIX}-python-nose"
              "${MINGW_PACKAGE_PREFIX}-spirv-headers"
              "${MINGW_PACKAGE_PREFIX}-spirv-tools"
              "${MINGW_PACKAGE_PREFIX}-cc")
 source=(https://github.com/KhronosGroup/SPIRV-Cross/archive/refs/tags/sdk-${pkgver}.tar.gz)
-sha256sums=('dac4b3dabd3f166f0c2941cf72045331e2672591a06cdeaa72e550d403f3150c')
+sha256sums=('09f779bcac08613cb13d14fd17eb3fc2ea165bca7eefb84a7c9dee6fb29ba492')
 
 prepare() {
   cd "${srcdir}/SPIRV-Cross-sdk-${pkgver}"


### PR DESCRIPTION
and remove python-nose dep, I can't find anything referencing it