### PR TITLE
tor: update to 0.4.8.4

### DIFF
--- a/mingw-w64-tor/PKGBUILD
+++ b/mingw-w64-tor/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=tor
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.4.7.13
+pkgver=0.4.8.4
 pkgrel=1
 pkgdesc="Anonymizing overlay network (mingw-w64)"
 url="https://www.torproject.org/"
@@ -19,9 +19,16 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cc"
   "${MINGW_PACKAGE_PREFIX}-autotools"
   "${MINGW_PACKAGE_PREFIX}-ca-certificates")
-source=("https://dist.torproject.org/${_realname}-${pkgver}.tar.gz")
-sha256sums=('2079172cce034556f110048e26083ce9bea751f3154b0ad2809751815b11ea9d')
-#validpgpkeys=('2133BC600AB133E1D826D173FE43009C4607B1FB') # Nick Mathewson <nickm@alum.mit.edu>
+source=("https://dist.torproject.org/${_realname}-${pkgver}.tar.gz"{,.sha256sum{,.asc}})
+sha256sums=('09c1ce74a25fc3b48c81ff146cbd0dd538cbbb8fe4e2964fc2fb2b192f6a1d2b'
+            'f4127d40d6301b3e949d1e37105eaa18a230848a6d8b0593489a320792eb6c86'
+            'SKIP')
+# list of keys https://gitlab.torproject.org/tpo/core/tor/-/raw/main/README.md
+validpgpkeys=(
+  '514102454D0A87DB0767A1EBBE6A0531C18A9179' # Alexander Færøy <ahf@0x90.dk>
+  'B74417EDDF22AC9F9E90F49142E86A2A11F48D36' # David Goulet <dgoulet@ev0ke.net>
+  '2133BC600AB133E1D826D173FE43009C4607B1FB' # Nick Mathewson <nickm@alum.mit.edu>
+)
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"


### PR DESCRIPTION
Add pgp keys to validate source tarball