### PR TITLE
binutils: backport patch "optimize handle_COMDAT"

### DIFF
--- a/mingw-w64-binutils/PKGBUILD
+++ b/mingw-w64-binutils/PKGBUILD
@@ -6,7 +6,7 @@ _realname=binutils
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.41
-pkgrel=1
+pkgrel=2
 pkgdesc="A set of programs to assemble and manipulate binary and object files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -25,6 +25,11 @@ source=(https://ftp.gnu.org/gnu/binutils/${_realname}-${pkgver}.tar.bz2{,.sig}
         reproducible-import-libraries.patch
         specify-timestamp.patch
         libiberty-unlink-handle-windows-nul.patch
+        "6aadf8a04d162feb2afe3c41f5b36534d661d447.patch::https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff_plain;h=6aadf8a04d162feb2afe3c41f5b36534d661d447"
+        "398f1ddf5e89e066aeee242ea854dcbaa8eb9539.patch::https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff_plain;h=398f1ddf5e89e066aeee242ea854dcbaa8eb9539"
+        "26d0081b52dc482c59abba23ca495304e698ce4b.patch::https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff_plain;h=26d0081b52dc482c59abba23ca495304e698ce4b"
+        "8606b47e94078e77a53f3cd714272c853d2add22.patch::https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff_plain;h=8606b47e94078e77a53f3cd714272c853d2add22"
+        "54d57acf610e5db2e70afa234fd4018207606774.patch::https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff_plain;h=54d57acf610e5db2e70afa234fd4018207606774"
 )
 sha256sums=('a4c4bec052f7b8370024e60389e194377f3f48b56618418ea51067f67aaab30b'
             'SKIP'
@@ -35,7 +40,12 @@ sha256sums=('a4c4bec052f7b8370024e60389e194377f3f48b56618418ea51067f67aaab30b'
             'd584f1cd9e94cba0e9b27625c4acc8ad5242cd625c9b44839d42fc116072568c'
             'a094660ec95996c00b598429843b7869037732146442af567ada9f539bd40480'
             '27696da8ecfff307537a461b205fad44d6abc1fa648fbf839e72a1d3ea71c40a'
-            '7ccbd418695733c50966068fa9755a6abb156f53af23701d2bc097c63e9e0030')
+            '7ccbd418695733c50966068fa9755a6abb156f53af23701d2bc097c63e9e0030'
+            '6da34bb31674dd06b6224cec7d3cda45f689fdfe8cdb8a4fc5e7f93694abf124'
+            'e524ca344af401d9ea513931dae70daf62014e1efcd706a681bdb9dd0deffaa9'
+            '8388ea27dc4d0d477fb1a6cbe96f4697c81a714c7b8a6923bd8df29d4aef0321'
+            '0c300b88823d0a8ee23b570f1f7f4d32a08530910175117ea60d559b1e412b3e'
+            '70f639d4c66a261ff94a9c6bc4669efcefe669cdf6a45edce83c158e7d4fa306')
 validpgpkeys=('EAF1C276A747E9ED86210CBAC3126D3B4AE55E93'
               '3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F')
 
@@ -76,6 +86,13 @@ prepare() {
   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108276
   # https://gcc.gnu.org/pipermail/gcc-patches/2023-January/609487.html
   patch -p1 -i "${srcdir}/libiberty-unlink-handle-windows-nul.patch"
+
+  apply_patch_with_msg \
+    6aadf8a04d162feb2afe3c41f5b36534d661d447.patch \
+    398f1ddf5e89e066aeee242ea854dcbaa8eb9539.patch \
+    26d0081b52dc482c59abba23ca495304e698ce4b.patch \
+    8606b47e94078e77a53f3cd714272c853d2add22.patch \
+    54d57acf610e5db2e70afa234fd4018207606774.patch
 }
 
 build() {


### PR DESCRIPTION
Makes `ld` faster. Should fix #7660.