### PR TITLE
sqlite3: update to 3.43.0

### DIFF
--- a/mingw-w64-sqlite3/0001-sqlite-pcachetrace-include-sqlite3.patch
+++ b/mingw-w64-sqlite3/0001-sqlite-pcachetrace-include-sqlite3.patch
@@ -1,0 +1,10 @@
+--- a/ext/misc/pcachetrace.c
++++ b/ext/misc/pcachetrace.c
+@@ -24,6 +24,7 @@
+ #include <assert.h>
+ #include <string.h>
+ #include <stdio.h>
++#include "sqlite3.h"
+ 
+ /* The original page cache routines */
+ static sqlite3_pcache_methods2 pcacheBase;

--- a/mingw-w64-sqlite3/PKGBUILD
+++ b/mingw-w64-sqlite3/PKGBUILD
@@ -7,9 +7,9 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-sqlite-docs")
 _sqlite_year=2023
-_amalgamationver=3420000
+_amalgamationver=3430000
 _docver=${_amalgamationver}
-pkgver=3.42.0
+pkgver=3.43.0
 pkgrel=1
 pkgdesc="A C library that implements an SQL database engine (mingw-w64)"
 arch=('any')
@@ -23,17 +23,24 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc" "${MINGW_PACKAGE_PREFIX}-autotools")
 source=(https://www.sqlite.org/${_sqlite_year}/sqlite-src-${_amalgamationver}.zip
         https://www.sqlite.org/${_sqlite_year}/sqlite-doc-${_docver}.zip
+        0001-sqlite-pcachetrace-include-sqlite3.patch
         Makefile.ext.in
         README.md.in
         LICENSE)
-sha256sums=('38ca56a317be37fb00bd92bc280d9b9209bd4008b297d483c41ec1f6079bfb6d'
-            'd62fd5f0fcfd15b2c26171e89f762268e2863df3c09696e76cf1482e34db8262'
+sha256sums=('976c31a5a49957a7a8b11ab0407af06b1923d01b76413c9cf1c9f7fc61a3501c'
+            'e88f98c5651f996e989ef3b7122ed29b01bd2a0100b0aa72dd96013248442291'
+            '6518119034ceb2820d058afcb099d11f636271f55a41ffae22855af66a369166'
             '4a8a87289253529cf04c916e5743c8727a5506b5185bc9bd4070b42037e8ae20'
             '5ca42f1f92abfb61bacc9ff60f5836cc56e2ce2af52264f918cb06c3d566d562'
             '0b76663a90e034f3d7f2af5bfada4cedec5ebc275361899eccc5c18e6f01ff1f')
 options=('staticlibs' '!buildflags')
 
 sqlite_tools="sqlite3_analyzer.exe dbhash.exe sqldiff.exe"
+
+prepare() {
+  cd "sqlite-src-${_amalgamationver}"
+  patch -p1 -i "${srcdir}/0001-sqlite-pcachetrace-include-sqlite3.patch"
+}
 
 build() {
   test -d ${srcdir}/build-${MSYSTEM} && rm -rf ${srcdir}/build-${MSYSTEM}

--- a/mingw-w64-sqlite3/PKGBUILD
+++ b/mingw-w64-sqlite3/PKGBUILD
@@ -35,7 +35,8 @@ sha256sums=('976c31a5a49957a7a8b11ab0407af06b1923d01b76413c9cf1c9f7fc61a3501c'
             '0b76663a90e034f3d7f2af5bfada4cedec5ebc275361899eccc5c18e6f01ff1f')
 options=('staticlibs' '!buildflags')
 
-sqlite_tools="sqlite3_analyzer.exe dbhash.exe sqldiff.exe"
+# From Debian sqlite3-tools
+_sqlite_tools="showdb.exe showjournal.exe showstat4.exe showwal.exe sqlite3_analyzer.exe dbhash.exe sqldiff.exe"
 
 prepare() {
   cd "sqlite-src-${_amalgamationver}"
@@ -77,7 +78,7 @@ build() {
   make
 
   # build additional tools
-  make $sqlite_tools
+  make ${_sqlite_tools}
 
   # build extensions
   ./config.status --file=ext/misc/Makefile:../Makefile.ext.in
@@ -99,8 +100,8 @@ package_sqlite3() {
   cd ${srcdir}/build-${MSYSTEM}
   make DESTDIR="${pkgdir}" install
 
-  for t in $sqlite_tools; do
-    install -Dm755 .libs/$t "${pkgdir}${MINGW_PREFIX}/bin/$t"
+  for tools in ${_sqlite_tools}; do
+    install -Dm755 .libs/$tools "${pkgdir}${MINGW_PREFIX}/bin/$tools"
   done
   mv ${pkgdir}${MINGW_PREFIX}/lib/bin/*.* ${pkgdir}${MINGW_PREFIX}/lib/sqlite${pkgver}/
   rm -rf ${pkgdir}${MINGW_PREFIX}/lib/bin


### PR DESCRIPTION

    The new patch file fixes the following compiler error.

    ../../../sqlite-src-3430000/ext/misc/pcachetrace.c:29:8: error: unknown type name 'sqlite3_pcache_methods2'
       29 | static sqlite3_pcache_methods2 pcacheBase;
          |        ^~~~~~~~~~~~~~~~~~~~~~~

