### PR TITLE
libavif: update to 1.0.1

### DIFF
--- a/mingw-w64-SDL2_image/PKGBUILD
+++ b/mingw-w64-SDL2_image/PKGBUILD
@@ -4,7 +4,7 @@ _realname=SDL2_image
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=2.6.3
-pkgrel=1
+pkgrel=2
 pkgdesc="A simple library to load images of various formats as SDL surfaces (Version 2) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -22,6 +22,12 @@ source=("https://github.com/libsdl-org/SDL_image/releases/download/release-${pkg
 sha256sums=('b448a8ca5b7927d9bd1577d393f4d6c59581f87ee525652a27e699941db37b7c'
             'SKIP')
 validpgpkeys=('1528635D8053A57F77D1E08630A59377A7763BE6') # Sam Lantinga <slouken@libsdl.org>
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  sed -i 's/LIBAVIF_MINIMUM_VERSION "0.9.1"/LIBAVIF_MINIMUM_VERSION "1.0.1"/' CMakeLists.txt
+}
 
 build() {
   local -a _common_config

--- a/mingw-w64-darktable/PKGBUILD
+++ b/mingw-w64-darktable/PKGBUILD
@@ -4,7 +4,7 @@ _realname=darktable
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=4.4.2
-pkgrel=2
+pkgrel=3
 pkgdesc="darktable is an open source photography workflow application and raw developer (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -58,6 +58,14 @@ source=("https://github.com/darktable-org/${_realname}/releases/download/release
 sha256sums=('c11d28434fdf2e9ce572b9b1f9bc4e64dcebf6148e25080b4c32eb51916cfa98'
             'SKIP')
 validpgpkeys=('F10F9686652B0E949FCD94C318DCA123F949BD3B') # Pascal Obry <pascal@obry.net>
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  # upstream change doesn't apply cleanly, this is the minimum needed
+  # see https://github.com/darktable-org/darktable/pull/15128
+  sed -i "s/libavif 0.8.2 /libavif /" src/CMakeLists.txt
+}
 
 build() {
   mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}

--- a/mingw-w64-kimageformats-qt5/PKGBUILD
+++ b/mingw-w64-kimageformats-qt5/PKGBUILD
@@ -5,7 +5,7 @@ _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kimageformats"
 pkgver=5.109.0
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 pkgdesc="Plugins to allow QImage to support extra file formats (mingw-w64)"
@@ -32,13 +32,17 @@ else
   depends+=("${MINGW_PACKAGE_PREFIX}-qt5-base")
 fi
 groups=("${MINGW_PACKAGE_PREFIX}-kf5")
-source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz"{,.sig})
+source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz"{,.sig}
+        "https://invent.kde.org/frameworks/kimageformats/-/commit/bcec942cc92e0968c724a2c1f92b4cd048bf8fa7.patch")
 sha256sums=('15533e1ba0fa187f0da0094b8ea135f38a9cebffd9118a12fcd23003eb591687'
-            'SKIP')
+            'SKIP'
+            '9a32f3aeb4aad73baa1fd0c17c50173521cccf888239a8ed742391f2f11b9214')
 validpgpkeys=('53E6B47B45CEA3E0D5B7457758D0EE648A48B3BB') # David Faure <faure@kde.org>
 
 prepare() {
   cd "${srcdir}"/${_basename}-${pkgver}
+
+  patch -Np1 -i "${srcdir}"/bcec942cc92e0968c724a2c1f92b4cd048bf8fa7.patch
 
   mkdir -p "${srcdir}"/build-${MSYSTEM}${_variant}
 }

--- a/mingw-w64-libavif/PKGBUILD
+++ b/mingw-w64-libavif/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=libavif
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.11.1
-pkgrel=5
+pkgver=1.0.1
+pkgrel=1
 pkgdesc="Library for encoding and decoding .avif files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -27,7 +27,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-cc")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-gtest")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/AOMediaCodec/libavif/archive/v${pkgver}.tar.gz")
-sha512sums=('4a9e2711fccddf35c477db6e2fa2f76c0648aafaa98b4e3f34df62c0fbd02ddcd57762f1f8149822da4f1bc3757ee75ec1d9ced5e56a54dbe9d0b43265aacd4c')
+sha512sums=('f7c35e40f9214314afeae69d5da6ab345e6dbd025e737a920ea4270452cdf7ff7010d7af5cc18d27e93b217114eb6b613cd349703d0e1bb7814dbeb84a9fd70f')
 
 build() {
   [[ -d "${srcdir}"/build-${MSYSTEM} ]] && rm -rf "${srcdir}"/build-${MSYSTEM}
@@ -44,6 +44,7 @@ build() {
   ${MINGW_PREFIX}/bin/cmake \
     -G Ninja \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DCMAKE_SHARED_LIBRARY_NAME_WITH_VERSION=ON \
     "${extra_config[@]}" \
     -DAVIF_BUILD_APPS=ON \
     -DAVIF_CODEC_AOM=ON \

--- a/mingw-w64-libgd/PKGBUILD
+++ b/mingw-w64-libgd/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libgd
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.3.2
-pkgrel=7
+pkgrel=8
 pkgdesc="GD is an open source code library for the dynamic creation of images by programmers (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -45,6 +45,7 @@ prepare() {
   patch -Nbp1 -i "${srcdir}/mingw-replace-posix_memalign.patch"
   patch -Nbp1 -i "${srcdir}/mingw-getline-link.patch"
 
+  sed -i "s/libavif 0.8.2 /libavif /" CMakeLists.txt
 }
 
 build() {

--- a/mingw-w64-python-imagecodecs/PKGBUILD
+++ b/mingw-w64-python-imagecodecs/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=imagecodecs
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=2023.8.12
+pkgver=2023.9.4
 pkgrel=1
 pkgdesc="Image transformation, compression, and decompression codecs (mingw-w64)"
 arch=('any')
@@ -40,17 +40,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
-        "0001-deflate.patch"
-        "https://patch-diff.githubusercontent.com/raw/cgohlke/imagecodecs/pull/83.patch")
-sha256sums=('5410ccd1e6f46289c10c076579d38f621b4aaa207d54d93aeb338c5fbcdea709'
-            '51e7f4d58ef17d230bf9755832902982b4c228c153d30c65749d2312c3bbf281'
-            'bee46218af3c8a760c73ec00ed3d23edf1ed702eb08c2ef702185070872e0b8a')
+        "0001-deflate.patch")
+sha256sums=('1f09a2f9df6f6e29abbe2a20a1e7f5990edd1bd2c02dcb0611c841ffc5b8b178'
+            '51e7f4d58ef17d230bf9755832902982b4c228c153d30c65749d2312c3bbf281')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   patch -p1 -i "${srcdir}"/0001-deflate.patch
-  # https://github.com/cgohlke/imagecodecs/pull/83
-  patch -p1 -i "${srcdir}"/83.patch
 }
 
 build() {


### PR DESCRIPTION
Deps need patching/update because of API change and/or `SameMajor` CMake version matching policy.