### PR TITLE
openblas: update to 0.3.24

### DIFF
--- a/mingw-w64-openblas/002-lgfortran-requires-lquadmath.patch
+++ b/mingw-w64-openblas/002-lgfortran-requires-lquadmath.patch
@@ -1,11 +1,11 @@
 --- a/cmake/fc.cmake
 +++ b/cmake/fc.cmake
-@@ -51,7 +51,7 @@
-   set(FCOMMON_OPT "${FCOMMON_OPT} -fno-optimize-sibling-calls")
-   #Don't include -lgfortran, when NO_LAPACK=1 or lsbcc
-   if (NOT NO_LAPACK)
--    set(EXTRALIB "${EXTRALIB} -lgfortran")
-+    set(EXTRALIB "${EXTRALIB} -lgfortran -lquadmath")
+@@ -48,7 +48,7 @@
+     set(FCOMMON_OPT "${FCOMMON_OPT} -fno-optimize-sibling-calls")
+     if (NOT NO_LAPACK)
+       # Don't include -lgfortran, when NO_LAPACK=1 or lsbcc
+-      set(EXTRALIB "${EXTRALIB} -lgfortran")
++      set(EXTRALIB "${EXTRALIB} -lgfortran -lquadmath")
+     endif ()
    endif ()
    if (NO_BINARY_MODE)
-     if (MIPS64)

--- a/mingw-w64-openblas/PKGBUILD
+++ b/mingw-w64-openblas/PKGBUILD
@@ -5,7 +5,7 @@ _realname=OpenBLAS
 pkgbase=mingw-w64-openblas
 pkgname=("${MINGW_PACKAGE_PREFIX}-openblas"
          $([[ "${CARCH}" == "i686" ]] || echo "${MINGW_PACKAGE_PREFIX}-openblas64"))
-pkgver=0.3.23
+pkgver=0.3.24
 pkgrel=1
 pkgdesc="An optimized BLAS library based on GotoBLAS2 1.13 BSD, providing optimized blas, lapack, and cblas (mingw-w64)"
 arch=('any')
@@ -30,8 +30,8 @@ source=(https://github.com/xianyi/OpenBLAS/releases/download/v${pkgver}/${_realn
         002-lgfortran-requires-lquadmath.patch
         004-aarch64-detection.patch
         005-fix-pkgconfig-files.patch)
-sha256sums=('5d9491d07168a5d00116cdc068a40022c3455bf9293c7cb86a65b1054d7e5114'
-            '465057bcaaaec93d671681f0c5e79b8634bf5c9aca4f495338780ada2dffd49c'
+sha256sums=('ceadc5065da97bd92404cac7254da66cc6eb192679cf1002098688978d4d5132'
+            'c147ec053bdf0387d499372472365aa829db0d8200b6828b0ebce5209e8603fd'
             '70ce007ff4f6c2a127f9835ce9cd85081707cf3bcccddcfaa06817b06f69c941'
             'bb36b75624fe9768d3d16e9d824e79d4dea5b0f0056601ca4ce37bc93e46f4b5')
 
@@ -56,25 +56,25 @@ prepare() {
 _build_openblas() {
   _idx_opt=$1
 
-  declare _build_type
+  declare -a _extra_config
   if check_option "debug" "n"; then
-    _build_type="Release"
+    _extra_config+=("-DCMAKE_BUILD_TYPE=Release")
   else
-    _build_type="Debug"
+    _extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
-  declare _c_lapack_opt
   if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
-    _c_lapack_opt="-DC_LAPACK=ON"
+    _extra_config+=("-DC_LAPACK=ON")
   fi
 
-  declare target=CORE2
-  declare dynamic_arch="-DDYNAMIC_ARCH=ON"
-  if [[ ${MINGW_PACKAGE_PREFIX} == *-aarch64 ]]; then
-    target=CORTEXA53
+  if [[ ${CARCH} == aarch64 ]]; then
+    _extra_config+=("-DTARGET=CORTEXA53")
     # clang wasn't able to compile all the kernels inside the arm64 folder,
     # so disable for now
-    dynamic_arch="-DDYNAMIC_ARCH=OFF"
+    _extra_config+=("-DDYNAMIC_ARCH=OFF")
+  else
+    _extra_config+=("-DTARGET=CORE2")
+    _extra_config+=("-DDYNAMIC_ARCH=ON")
   fi
 
   unset CFLAGS
@@ -92,12 +92,10 @@ _build_openblas() {
     -DCMAKE_BUILD_TYPE=${_build_type} \
     -DBUILD_SHARED_LIBS=ON \
     -DBUILD_STATIC_LIBS=ON \
-    ${dynamic_arch} \
     -DUSE_THREAD=ON \
     -DNUM_THREADS=64 \
     -DUSE_OPENMP=ON \
-    -DTARGET=${target} \
-    ${_c_lapack_opt} \
+    "${_extra_config[@]}" \
     ${_idx_opt} \
     ../${_realname}-${pkgver}
 
@@ -105,14 +103,12 @@ _build_openblas() {
 }
 
 build() {
-  [[ -d "${srcdir}/build-${MSYSTEM}-32" ]] && rm -rf "${srcdir}/build-${MSYSTEM}-32"
   mkdir -p "${srcdir}/build-${MSYSTEM}-32" && cd "${srcdir}/build-${MSYSTEM}-32"
 
   msg2 "Build OpenBLAS with 32-bit indexing"
   _build_openblas ""
 
   if [ "${CARCH}" != "i686" ]; then
-    [[ -d "${srcdir}/build-${MSYSTEM}-64" ]] && rm -rf "${srcdir}/build-${MSYSTEM}-64"
     mkdir -p "${srcdir}/build-${MSYSTEM}-64" && cd "${srcdir}/build-${MSYSTEM}-64"
 
     msg2 "Build OpenBLAS with 64-bit indexing"


### PR DESCRIPTION
0.3.24 now supports Flang, but unfortunately Flang doesn't fully support OpenMP.
So We either build LAPACK with Flang and disable OpenMP or leave as It is (Build C_LAPACK)