### PR TITLE
lsd: update to 1.0.0

### DIFF
--- a/mingw-w64-lsd/PKGBUILD
+++ b/mingw-w64-lsd/PKGBUILD
@@ -5,20 +5,20 @@
 _realname=lsd
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.23.1
-pkgrel=2
+pkgver=1.0.0
+pkgrel=1
 pkgdesc="The next gen ls command (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
-url="https://github.com/Peltoche/lsd"
-license=("MIT")
+url="https://github.com/lsd-rs/lsd"
+license=("spdx:Apache-2.0")
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
 #depends=()
-#optdepends=('powerline-fonts: powerline symbols for terminals'
-#            'nerd-fonts-complete: popular collections such as Font Awesome & fonts such as Hack')
-source=("${_realname}-${pkgver}.tar.gz::https://github.com/Peltoche/lsd/archive/refs/tags/${pkgver}.tar.gz"
+optdepends=("${MINGW_PACKAGE_PREFIX}-ttf-font-nerd: popular collections such as Font Awesome & fonts such as Hack")
+           #'powerline-fonts: powerline symbols for terminals')
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/lsd-rs/lsd/archive/refs/tags/v${pkgver}.tar.gz"
         "old-windows-aarch64.patch")
-sha256sums=('9698919689178cc095f39dcb6a8a41ce32d5a1283e6fe62755e9a861232c307d'
+sha256sums=('ab34e9c85bc77cfa42b43bfb54414200433a37419f3b1947d0e8cfbb4b7a6325'
             'd5af6a44b5309465faa8485e74062dfc30705acd08d8f5a9bc02431f6894edd2')
 
 prepare() {
@@ -44,8 +44,8 @@ build() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
   export SHELL_COMPLETIONS_DIR="$PWD/completions"
-  export WINAPI_NO_BUNDLED_LIBRARIES=1
-  cargo build --release --frozen
+  WINAPI_NO_BUNDLED_LIBRARIES=1 \
+    cargo build --release --frozen
 }
 
 check() {
@@ -72,7 +72,7 @@ package() {
     --path . \
     --root "${pkgdir}${MINGW_PREFIX}"
 
-  install -Dm644 LICENSE "$pkgdir${MINGW_PREFIX}/share/licenses/$pkgname/LICENSE"
+  install -Dm644 LICENSE "$pkgdir${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
   install -Dm644 completions/_lsd "$pkgdir${MINGW_PREFIX}/share/zsh/site-functions/_lsd"
   install -Dm644 completions/lsd.bash "$pkgdir${MINGW_PREFIX}/share/bash-completion/completions/lsd"
   install -Dm644 completions/lsd.fish "$pkgdir${MINGW_PREFIX}/share/fish/vendor_completions.d/lsd.fish"


### PR DESCRIPTION
notable changes:
- changed upstream URL
- nerd-fonts are now in repo, uncomment optdepends
- install license in correct directory