### PR TITLE
opensubdiv: split docs into separate package

### DIFF
--- a/mingw-w64-opensubdiv/PKGBUILD
+++ b/mingw-w64-opensubdiv/PKGBUILD
@@ -2,9 +2,10 @@
 
 _realname=opensubdiv
 pkgbase=mingw-w64-${_realname}
-pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
 pkgver=3.5.1
-pkgrel=1
+pkgrel=2
 pkgdesc="An Open-Source subdivision surface library (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -70,7 +71,34 @@ build() {
   ${MINGW_PREFIX}/bin/cmake.exe --build ./
 }
 
-package() {
-  cd "${srcdir}/build-${MSYSTEM}"
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install .
+package_opensubdiv() {
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install "${srcdir}/build-${MSYSTEM}"
+
+  # remove path reference in cmake
+  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+  for _f in "${pkgdir}${MINGW_PREFIX}"/lib/cmake/OpenSubdiv/*.cmake; do
+    sed -e "s|${PREFIX_WIN}|\$\{_IMPORT_PREFIX\}|g" -i ${_f}
+  done
+
+  # split docs
+  mkdir -p dest${MINGW_PREFIX}/share
+  mv "${pkgdir}${MINGW_PREFIX}"/share/doc dest${MINGW_PREFIX}/share/doc
 }
+
+package_opensubdiv-docs() {
+  pkgdesc+=" (documentation)"
+  depends=()
+
+  mv dest/* "${pkgdir}"
+}
+
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
+
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;


### PR DESCRIPTION
* This halves the size of the package.
* Also remove full path reference in cmake files.