### PR TITLE
python-build: remove colorama from dependencies

### DIFF
--- a/mingw-w64-python-build/0001-optional-colorama.patch
+++ b/mingw-w64-python-build/0001-optional-colorama.patch
@@ -1,0 +1,11 @@
+--- build-1.0.3/pyproject.toml.orig	2023-09-07 09:20:37.753890800 +0200
++++ build-1.0.3/pyproject.toml	2023-09-07 09:21:02.542739800 +0200
+@@ -34,8 +34,6 @@
+ dependencies = [
+   "packaging >= 19.0",
+   "pyproject_hooks",
+-  # not actually a runtime dependency, only supplied as there is not "recommended dependency" support
+-  'colorama; os_name == "nt"',
+   'importlib-metadata >= 4.6; python_version < "3.10"',  # Not required for 3.8+, but fixes a stdlib bug
+   'tomli >= 1.1.0; python_version < "3.11"',
+ ]

--- a/mingw-w64-python-build/PKGBUILD
+++ b/mingw-w64-python-build/PKGBUILD
@@ -4,7 +4,7 @@ _realname=build
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=1.0.3
-pkgrel=1
+pkgrel=2
 pkgdesc="A simple, correct Python build frontend (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -22,12 +22,16 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-installer"
 )
 options=('!strip')
-source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('538aab1b64f9828977f84bc63ae570b060a8ed1be419e7870b8b4fc5e6ea553b')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
+        "0001-optional-colorama.patch")
+sha256sums=('538aab1b64f9828977f84bc63ae570b060a8ed1be419e7870b8b4fc5e6ea553b'
+            'c122e055e4c963629a6f5f5ebe894d15d32c92dcdd2b97e72598d860e5846c47')
 
 prepare() {
   cp -r "${_realname}-${pkgver}" "python-build-${CARCH}"
   cd "python-build-${CARCH}"
+
+  patch -Np1 -i "${srcdir}/0001-optional-colorama.patch"
 }
 
 build() {


### PR DESCRIPTION
it's optional in our case, since it would break bootstrapping otherwise.