### PR TITLE
dust: try to fix building on aarch64

### DIFF
--- a/mingw-w64-dust/PKGBUILD
+++ b/mingw-w64-dust/PKGBUILD
@@ -4,7 +4,7 @@ _realname=dust
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.8.6
-pkgrel=1
+pkgrel=2
 pkgdesc="A more intuitive version of du in rust (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -21,6 +21,7 @@ sha256sums=('feede818e814011207c5bfeaf06dd9fc95825c59ab70942aa9b9314791c5d6b6'
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
+  ${MINGW_PREFIX}/bin/cargo update -p windows-targets@0.48.0 --precise 0.48.1
   cargo vendor \
     --locked \
     --versioned-dirs


### PR DESCRIPTION
took workaround from other packages that use windows-0.48.0 crate