### PR TITLE
qt5-connectivity: Fix building in 32 bit environment

### DIFF
--- a/mingw-w64-qt5-connectivity/0001-qtconnectivity-add-callback-attribute.patch
+++ b/mingw-w64-qt5-connectivity/0001-qtconnectivity-add-callback-attribute.patch
@@ -1,0 +1,16 @@
+--- a/src/bluetooth/qbluetoothservicediscoveryagent_win.cpp
++++ b/src/bluetooth/qbluetoothservicediscoveryagent_win.cpp
+@@ -206,12 +206,7 @@
+     return sequence;
+ }
+
+-#if defined(Q_CC_MINGW)
+-# define SDP_CALLBACK
+-#else
+-# define SDP_CALLBACK QT_WIN_CALLBACK
+-#endif
+-static BOOL SDP_CALLBACK bluetoothSdpCallback(ULONG attributeId, LPBYTE valueStream, ULONG streamSize, LPVOID param)
++static BOOL QT_WIN_CALLBACK bluetoothSdpCallback(ULONG attributeId, LPBYTE valueStream, ULONG streamSize, LPVOID param)
+ {
+     QBluetoothServiceInfo *result = static_cast<QBluetoothServiceInfo*>(param);
+ 

--- a/mingw-w64-qt5-connectivity/PKGBUILD
+++ b/mingw-w64-qt5-connectivity/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
 _qtver=5.15.10
 pkgver=${_qtver}+kde+r4
-pkgrel=1
+pkgrel=2
 _commit=eeaf42bccd49e8161fbae82d110026d25a5a9a7f
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -19,12 +19,19 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "rsync")
 options=('!strip')
 _pkgfn="${_realname/5-/}"
-source=(git+https://invent.kde.org/qt/qt/$_pkgfn#commit=$_commit)
-sha256sums=('SKIP')
+source=(git+https://invent.kde.org/qt/qt/$_pkgfn#commit=$_commit
+        0001-qtconnectivity-add-callback-attribute.patch)
+sha256sums=('SKIP'
+            'a2eeaec6d1f05519f754b7baed7d08c24221b24ae282ff711c35a84fab68ff6c')
 
 pkgver() {
   cd $_pkgfn
   echo "${_qtver}+kde+r"`git rev-list --count v${_qtver}-lts-lgpl..$_commit`
+}
+
+prepare() {
+  cd $_pkgfn
+  git apply "${srcdir}/0001-qtconnectivity-add-callback-attribute.patch"
 }
 
 build() {


### PR DESCRIPTION

    Once upon a time, the PFN_BLUETOOTH_ENUM_ATTRIBUTES_CALLBACK was defined
    in mingw-w64 incorrectly. It was fixed in this commit[1].

    But, Qt5 worked around that issue. Now that workaround is not valid.
    This change removes that workaround.

    [1]: https://github.com/mingw-w64/mingw-w64/commit/427ab730f00c2dc45508f0e27af7f7a67cf9f3ab

