### PR TITLE
libwebp: backport security fix

### DIFF
--- a/mingw-w64-libwebp/PKGBUILD
+++ b/mingw-w64-libwebp/PKGBUILD
@@ -5,7 +5,7 @@ _realname=libwebp
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.3.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A library to encode and decode images in WebP format (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -20,15 +20,19 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 provides=("${MINGW_PACKAGE_PREFIX}-libsharpyuv")
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/webmproject/libwebp/archive/v${pkgver}.tar.gz
-        0001-mingw-cmake-output.patch)
+        0001-mingw-cmake-output.patch
+        https://hg.mozilla.org/releases/mozilla-release/raw-rev/e245ca2125a6eb1e2d08cc9e5824f15e1e67a566)
 sha256sums=('1c45f135a20c629c31cebcba62e2b399bae5d6e79851aa82ec6686acedcf6f65'
-            '30ed42b782af427f57049abada30ce6d4d62318ee13014585cb352b570c68e3d')
+            '30ed42b782af427f57049abada30ce6d4d62318ee13014585cb352b570c68e3d'
+            'f5f69bcc54a1bb18e2df22f7fa94af7569f7d5150d9a18738ea43a999b552f06')
 validpgpkeys=('6B0E6B70976DE303EDF2F601F9C3D6BDB8232B5D')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
   patch -Np1 -i "${srcdir}"/0001-mingw-cmake-output.patch
+  # https://hg.mozilla.org/releases/mozilla-release/rev/e245ca2125a6eb1e2d08cc9e5824f15e1e67a566
+  patch -Np3 -i "${srcdir}"/e245ca2125a6eb1e2d08cc9e5824f15e1e67a566
 }
 
 build() {


### PR DESCRIPTION
since the upstream commit doesn't apply cleanly, take the backported one from mozilla for now