### PR TITLE
mpc,mpfr: enable static libs

### DIFF
--- a/mingw-w64-mpc/PKGBUILD
+++ b/mingw-w64-mpc/PKGBUILD
@@ -4,7 +4,7 @@ _realname=mpc
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.3.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Multiple precision complex arithmetic library (mingw-w64)"
 url='http://www.multiprecision.org'
 license=('LGPL')
@@ -27,7 +27,7 @@ build() {
   ../${_realname}-${pkgver}/configure \
      --build=${MINGW_CHOST} \
     --prefix=${MINGW_PREFIX} \
-    --disable-static \
+    --enable-static \
     --enable-shared \
     --with-gmp=${MINGW_PREFIX} \
     --with-mpfr=${MINGW_PREFIX}

--- a/mingw-w64-mpfr/PKGBUILD
+++ b/mingw-w64-mpfr/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 _pkgver=4.2.1
 pkgver=${_pkgver}
 # pkgver=${_pkgver}.p1
-pkgrel=1
+pkgrel=2
 pkgdesc="Multiple-precision floating-point library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -36,7 +36,7 @@ build() {
   ../${_realname}-${_pkgver}/configure \
     --build=${MINGW_CHOST} \
     --prefix=${MINGW_PREFIX} \
-    --disable-static \
+    --enable-static \
     --enable-shared \
     --with-gmp=${MINGW_PREFIX}
 


### PR DESCRIPTION
I am building a static gcc toolchain, but these static libraries are missing. Is there any reason they are disabled? I think there is no harm in adding them, they seem to be included already for libgmp (which is part of this family of libs).