### PR TITLE
gmp: add macro to let applications link static

### DIFF
--- a/mingw-w64-gmp/PKGBUILD
+++ b/mingw-w64-gmp/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gmp
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=6.3.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A free library for arbitrary precision arithmetic (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -12,10 +12,12 @@ url="https://gmplib.org/"
 license=('LGPL3' 'GPL')
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools" "${MINGW_PACKAGE_PREFIX}-cc")
 source=(https://ftp.gnu.org/gnu/gmp/${_realname}-${pkgver}.tar.xz{,.sig}
-        do-not-use-dllimport.diff)
+        do-not-use-dllimport.diff
+        gmp-staticlib.diff)
 sha256sums=('a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898'
             'SKIP'
-            '385ab704f82c47f3aecc9141f43c96e7b8de2bf0e654dc457ce0f1a039db2c68')
+            '385ab704f82c47f3aecc9141f43c96e7b8de2bf0e654dc457ce0f1a039db2c68'
+            '7c3cde2634baa2cb1c31404bbfed2d8d7ba33556971ac842a08f2e87667849ab')
 validpgpkeys=('343C2FF0FBEE5EC2EDBEF399F3599FF828C67298') # Niels Möller <nisse@lysator.liu.se>"
 
 prepare() {
@@ -24,6 +26,7 @@ prepare() {
   mkdir ../stash
   cp config.{guess,sub} ../stash
   patch -p2 -i ${srcdir}/do-not-use-dllimport.diff
+  patch -p1 -i ${srcdir}/gmp-staticlib.diff
   autoreconf -fiv
   cp -f ../stash/config.{guess,sub} .
 }

--- a/mingw-w64-gmp/gmp-staticlib.diff
+++ b/mingw-w64-gmp/gmp-staticlib.diff
@@ -1,0 +1,25 @@
+diff -aurp gmp-6.3.0-orig/gmp-h.in gmp-6.3.0/gmp-h.in
+--- gmp-6.3.0-orig/gmp-h.in	2023-09-13 19:30:34.000000000 +0200
++++ gmp-6.3.0/gmp-h.in	2023-09-13 19:32:29.000000000 +0200
+@@ -59,8 +59,12 @@ see https://www.gnu.org/licenses/.  */
+ /* Instantiated by configure. */
+ #if ! defined (__GMP_WITHIN_CONFIGURE)
+ @DEFN_LONG_LONG_LIMB@
++#ifdef GMP_STATICLIB
++#define __GMP_LIBGMP_DLL  0
++#else
+ #define __GMP_LIBGMP_DLL  @LIBGMP_DLL@
+ #endif
++#endif
+ 
+ 
+ /* __GMP_DECLSPEC supports Windows DLL versions of libgmp, and is empty in
+diff -aurp gmp-6.3.0-orig/gmp.pc.in gmp-6.3.0/gmp.pc.in
+--- gmp-6.3.0-orig/gmp.pc.in	2023-09-13 19:30:34.000000000 +0200
++++ gmp-6.3.0/gmp.pc.in	2023-09-14 00:10:14.000000000 +0200
+@@ -8,4 +8,5 @@ Description: GNU Multiple Precision Arit
+ URL: https://gmplib.org
+ Version: @PACKAGE_VERSION@
+ Cflags: -I${includedir}
++Cflags.private: -DGMP_STATICLIB
+ Libs: -L${libdir} -lgmp


### PR DESCRIPTION
See discussion in https://github.com/msys2/MINGW-packages/pull/18470#issuecomment-1718052861

This introduces a macro `GMP_STATICLIB` that will allow applications to build against the static `libgmp.a` library, analogous to `LIBXML_STATIC` or `CURL_STATICLIB` or `NGHTTP2_STATICLIB` and so on.