### PR TITLE
typst: remove windows-targets workaround

### DIFF
--- a/mingw-w64-typst/PKGBUILD
+++ b/mingw-w64-typst/PKGBUILD
@@ -4,7 +4,7 @@ _realname=typst
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.8.0
-pkgrel=1
+pkgrel=2
 pkgdesc='A markup-based typesetting system for the sciences (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -17,25 +17,7 @@ sha256sums=('4b7886e312171b66fb33b7ad49c4df76748231d0047fb96b407c926070a5d9f9')
 prepare() {
   cd ${_realname}-${pkgver}
 
-  cargo vendor \
-    --locked \
-    --versioned-dirs
-
-  mkdir -p .cargo
-  cat >> .cargo/config.toml <<END
-
-[source.crates-io]
-replace-with = "vendored-sources"
-
-[source.vendored-sources]
-directory = "vendor"
-END
-
-
-  sed -i -e 's/"cfg(all(target_arch = \\"\([^\\]\+\)\\", target_env = \\"gnu\\", target_abi = \\"llvm\\", not(windows_raw_dylib)))"/"\1-pc-windows-gnullvm"/g' \
-    "vendor/windows-targets-0.48.5/Cargo.toml"
-  sed -i -e 's/\("Cargo.toml":\)"[^"]\+"/\1"'"$(sha256sum "vendor/windows-targets-0.48.5/Cargo.toml" | cut -d' ' -f1)"'"/' \
-    "vendor/windows-targets-0.48.5/.cargo-checksum.json"
+  ${MINGW_PREFIX}/bin/cargo fetch --locked
 }
 
 build() {


### PR DESCRIPTION
should no longer be needed for newer windows-targets