### PR TITLE
freeimage: Avoid build error with modern compilers

### DIFF
--- a/mingw-w64-freeimage/PKGBUILD
+++ b/mingw-w64-freeimage/PKGBUILD
@@ -7,12 +7,12 @@ provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=3.18.0
-pkgrel=11
+pkgrel=12
 libver=3
 pkgdesc="Library project for developers who would like to support popular graphics image formats (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
-license=('GPL' 'custom:FIPL')
+license=('spdx:FreeImage OR GPL-2.0-or-later')
 url="https://freeimage.sourceforge.io/"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-jxrlib"
@@ -31,8 +31,8 @@ options=('strip' 'staticlibs' '!buildflags')
 source=("https://downloads.sourceforge.net/sourceforge/freeimage/${_realname}${pkgver//./}.zip"
         'FreeImage-3.18.0_mingw-makefiles.patch'
         'FreeImage-3.18.0_unbundle.patch'
-        'freeimage-libraw-0.20.patch'
-        'freeimage-libraw-0.21.patch'
+        'freeimage-libraw-0.20.patch' # taken from Arch
+        'freeimage-libraw-0.21.patch' # taken from Arch
         'freeimage-libtiff-4.4.0.patch')
 sha256sums=('f41379682f9ada94ea7b34fe86bf9ee00935a3147be41b6569c9605a53e438fd'
             'ccb04cd703530d73b123f84310287a0318e13786a7320b7e81a33f2dccb445ca'
@@ -41,18 +41,26 @@ sha256sums=('f41379682f9ada94ea7b34fe86bf9ee00935a3147be41b6569c9605a53e438fd'
             'cacb6ae3a2cebf8208d34ea01423a5309ee88ff649afbbb371e49cfeb57d8331'
             '1f743835f4b06bf14a8ce01b7125e5eed886939dca3853814c5ca46d500d275a')
 
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Np1 -i "${srcdir}/$_patch"
+  done
+}
+
 prepare() {
   cd ${srcdir}/${_realname}
 
-  patch -p1 -i ${srcdir}/FreeImage-3.18.0_mingw-makefiles.patch
-  patch -p1 -i ${srcdir}/FreeImage-3.18.0_unbundle.patch
-
-  # taken from Arch
-  patch -p1 -i ${srcdir}/freeimage-libraw-0.20.patch
-  patch -p1 -i ${srcdir}/freeimage-libraw-0.21.patch
+  apply_patch_with_msg \
+    FreeImage-3.18.0_mingw-makefiles.patch \
+    FreeImage-3.18.0_unbundle.patch \
+    freeimage-libraw-0.20.patch \
+    freeimage-libraw-0.21.patch
 
   # taken from https://sourceforge.net/p/freeimage/discussion/36109/thread/2018fdc6e7/
-  patch -p2 -i ${srcdir}/freeimage-libtiff-4.4.0.patch
+  msg2 "Applying freeimage-libtiff-4.4.0.patch"
+  patch -Np2 -i "${srcdir}/freeimage-libtiff-4.4.0.patch"
 
   # remove all included libs to make sure these don't get used during compile
   rm -r Source/Lib* Source/ZLib Source/OpenEXR
@@ -84,10 +92,14 @@ build() {
   msg "Building freeimage..."
   cd "${srcdir}/build-${MSYSTEM}"
   make \
+    CC="${CC} -std=gnu11" \
+    CXX="${CXX} -std=gnu++11" \
     MINGW_TARGET=${MINGW_CHOST} -f Makefile.gnu
 
   msg "Building freeimageplus..."
   make \
+    CC="${CC} -std=gnu11" \
+    CXX="${CXX} -std=gnu++11" \
     MINGW_TARGET=${MINGW_CHOST} -f Makefile.fip
 }
 


### PR DESCRIPTION
The sources of FreeImage are old and no longer comply to modern standards.
Fix the standard to C11 and C++11 respectively (with GNU extensions) to get it to compile with modern compilers which default to newer standards.
