### PR TITLE
fastapi reverts

### DIFF
--- a/mingw-w64-python-anyio/PKGBUILD
+++ b/mingw-w64-python-anyio/PKGBUILD
@@ -5,6 +5,7 @@ pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
 pkgver=3.7.0
 pkgrel=2
+epoch=1
 pkgdesc='High level compatibility layer for multiple asynchronous event loop implementations (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')

--- a/mingw-w64-python-anyio/PKGBUILD
+++ b/mingw-w64-python-anyio/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=anyio
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
-pkgver=3.7.0
-pkgrel=2
+pkgver=3.7.1
+pkgrel=3
 epoch=1
 pkgdesc='High level compatibility layer for multiple asynchronous event loop implementations (mingw-w64)'
 arch=('any')
@@ -23,7 +23,7 @@ makedepends=(
     ${MINGW_PACKAGE_PREFIX}-python-setuptools-scm
     ${MINGW_PACKAGE_PREFIX}-python-wheel)
 source=(https://github.com/agronholm/${_realname}/archive/${pkgver}.tar.gz)
-sha256sums=('2f8c7bede49fa8344a96feee63de52fb9b02881dc3137cd4b5cc770d5cc4b436')
+sha256sums=('aa8ed0d799e61b61f7888e13668d36b467e3368129e8efa92bbf62a9cf063f84')
 
 prepare() {
   rm -rf python-build-${MSYSTEM} | true

--- a/mingw-w64-python-anyio/PKGBUILD
+++ b/mingw-w64-python-anyio/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=anyio
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
-pkgver=4.0.0
-pkgrel=1
+pkgver=3.7.0
+pkgrel=2
 pkgdesc='High level compatibility layer for multiple asynchronous event loop implementations (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -22,7 +22,7 @@ makedepends=(
     ${MINGW_PACKAGE_PREFIX}-python-setuptools-scm
     ${MINGW_PACKAGE_PREFIX}-python-wheel)
 source=(https://github.com/agronholm/${_realname}/archive/${pkgver}.tar.gz)
-sha256sums=('518a6f319b174b5b7de126ae983035d2205df4ef0f39eb23ac4139cbb1bf3c49')
+sha256sums=('2f8c7bede49fa8344a96feee63de52fb9b02881dc3137cd4b5cc770d5cc4b436')
 
 prepare() {
   rm -rf python-build-${MSYSTEM} | true

--- a/mingw-w64-python-starlette/PKGBUILD
+++ b/mingw-w64-python-starlette/PKGBUILD
@@ -3,6 +3,7 @@
 _realname=starlette
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+epoch=1
 pkgver=0.27.0
 pkgrel=2
 pkgdesc="The little ASGI framework that shines (mingw-w64)"

--- a/mingw-w64-python-starlette/PKGBUILD
+++ b/mingw-w64-python-starlette/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=starlette
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=0.31.1
-pkgrel=1
+pkgver=0.27.0
+pkgrel=2
 pkgdesc="The little ASGI framework that shines (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
@@ -14,12 +14,11 @@ depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-anyio")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
-             "${MINGW_PACKAGE_PREFIX}-python-hatchling"
-             "${MINGW_PACKAGE_PREFIX}-python-wheel")
+             "${MINGW_PACKAGE_PREFIX}-python-hatchling")
 optdepends=("${MINGW_PACKAGE_PREFIX}-python-itsdangerous: for session middleware support"
             "${MINGW_PACKAGE_PREFIX}-python-jinja: for jinja templates")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('a4dc2a3448fb059000868d7eb774dd71229261b6d49b6851e7849bec69c0a011')
+sha256sums=('6a6b0d042acb8d469a01eba54e9cda6cbd24ac602c4cd016723117d6a7e73b75')
 
 prepare() {
   rm -rf python-build-${MSYSTEM} | true


### PR DESCRIPTION
it's not compatible with newer anyio and starlette

see https://github.com/msys2/MINGW-packages/commit/41fd5f246e4a4a2fccdd61b0490d4b31c6f5dfd9#commitcomment-127546512