### PR TITLE
jj: link to AUR's jujutsu

### DIFF
--- a/mingw-w64-jj/PKGBUILD
+++ b/mingw-w64-jj/PKGBUILD
@@ -9,6 +9,9 @@ pkgrel=1
 pkgdesc='Jujutsu (an experimental VCS) (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
+msys2_references=(
+  'aur: jujutsu'
+)
 url="https://github.com/martinvonz/jj"
 license=('spdx:Apache-2.0')
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust" "git")


### PR DESCRIPTION
fixes #17553 

maybe will update package while at it (if needed) but later

just for interest, do we need to switch to versioned tag?