### PR TITLE
xvidcore: Add lib prefix with static and import library name

### DIFF
--- a/mingw-w64-xvidcore/PKGBUILD
+++ b/mingw-w64-xvidcore/PKGBUILD
@@ -4,7 +4,7 @@ _realname=xvidcore
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.3.7
-pkgrel=3
+pkgrel=4
 pkgdesc="XviD is an open source MPEG-4 video codec (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -42,4 +42,8 @@ build() {
 package() {
   cd ${srcdir}/build-${MINGW_CHOST}/build/generic
   make DESTDIR="${pkgdir}" install
+
+  # add lib prefix with static and import library name (#18553)
+  mv "${pkgdir}${MINGW_PREFIX}"/lib/{,lib}xvidcore.dll.a
+  mv "${pkgdir}${MINGW_PREFIX}"/lib/{,lib}xvidcore.a
 }


### PR DESCRIPTION
    This fixes the following linker error with

    * gcc:

    ld.exe: cannot find -lxvidcore: No such file or directory
    ld.exe: note to link with lib/xvidcore.a use -l:xvidcore.a or rename it to libxvidcore.a

    * clang:

    lld: error: unable to find library -lxvidcore
    cc: error: linker command failed with exit code 1 (use -v to see invocation)

Fixes https://github.com/msys2/MINGW-packages/issues/18553
