### PR TITLE
hdf5: Use Requires.private in pkgconfig file

### DIFF
--- a/mingw-w64-hdf5/0001-hdf5-pkgconfig-use-requires-private.patch
+++ b/mingw-w64-hdf5/0001-hdf5-pkgconfig-use-requires-private.patch
@@ -1,0 +1,26 @@
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -1344,17 +1345,19 @@
+   set (PKGCONFIG_LIBNAME "${PKGCONFIG_LIBNAME}${CMAKE_DEBUG_POSTFIX}")
+ endif ()
+ 
+-foreach (libs ${LINK_LIBS})
+-  set (_PKG_CONFIG_LIBS_PRIVATE "${_PKG_CONFIG_LIBS_PRIVATE} -l${libs}")
+-endforeach ()
+-
+ # The settings for the compression libs depends on if they have pkconfig support
+ # Assuming they don't
+ foreach (libs ${LINK_COMP_LIBS})
+ #  set (_PKG_CONFIG_REQUIRES_PRIVATE "${_PKG_CONFIG_REQUIRES_PRIVATE} -l${libs}")
++  get_filename_component(libs ${libs} NAME_WE)
++  string(REPLACE "lib" "" libs ${libs})
+   set (_PKG_CONFIG_LIBS_PRIVATE "${_PKG_CONFIG_LIBS_PRIVATE} -l${libs}")
+ endforeach ()
+ 
++if (${CURL_FOUND} AND ${OPENSSL_FOUND})
++  set (_PKG_CONFIG_REQUIRES_PRIVATE "${_PKG_CONFIG_REQUIRES_PRIVATE} libcrypto libssl libcurl")
++endif()
++
+ if (BUILD_STATIC_LIBS)
+   set (_PKG_CONFIG_LIBS "${_PKG_CONFIG_LIBS} -l${PKGCONFIG_LIBNAME}")
+ endif ()

--- a/mingw-w64-hdf5/PKGBUILD
+++ b/mingw-w64-hdf5/PKGBUILD
@@ -7,7 +7,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _ver=1.14.2
 patch=
 pkgver=${_ver}${patch//-/.}
-pkgrel=2
+pkgrel=3
 pkgdesc="General purpose library and file format for storing scientific data (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -28,11 +28,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 source=("https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${_ver%.*}/hdf5-${_ver}/src/hdf5-${_ver}${patch}.tar.bz2"
         "hdf5-proper-library-names-mingw.patch"
         "hdf5-fix-static-lib.patch"
-        "hdf5-fix-fortran-module-directory-leak.patch")
+        "hdf5-fix-fortran-module-directory-leak.patch"
+        "0001-hdf5-pkgconfig-use-requires-private.patch")
 sha256sums=('ea3c5e257ef322af5e77fc1e52ead3ad6bf3bb4ac06480dd17ee3900d7a24cfb'
             'e236f5805152b25065c206922d7ec1bab05b233adac51bbd0fb1e546326162f6'
             '9d172a7f6b8f54fdbf840e032708acade4ab88c81262b45bfa85d203810962a9'
-            '02b5d7335a9db628ed03b29c62d8f0e5f5618fa39de8e453aa02b530d28317a8')
+            '02b5d7335a9db628ed03b29c62d8f0e5f5618fa39de8e453aa02b530d28317a8'
+            '49ad101c839055cab22d3a557a12163b750b5fc9edcef4e84b957c3c5adef19f')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -46,10 +48,12 @@ apply_patch_with_msg() {
 prepare() {
   cd "${srcdir}/${_realname}-${_ver}${patch}"
 
+  # 0001: curl and openssl in Requires.private, zlib, libaec in Libs.private
   apply_patch_with_msg \
     hdf5-proper-library-names-mingw.patch \
     hdf5-fix-static-lib.patch \
-    hdf5-fix-fortran-module-directory-leak.patch
+    hdf5-fix-fortran-module-directory-leak.patch \
+    0001-hdf5-pkgconfig-use-requires-private.patch
 }
 
 build() {


### PR DESCRIPTION

    This adds openssl and curl in Requires.private field in hdf5.pc file.
    Otherwise, those libraries were added in Libs.private with full path.
    It caused linking errors like following.

    ld.exe: cannot find -lC:/msys64/mingw64/lib/libcurl.dll.a: Invalid argument
    ld.exe: cannot find -lC:/msys64/mingw64/lib/libssl.dll.a: Invalid argument
    ld.exe: cannot find -lC:/msys64/mingw64/lib/libcrypto.dll.a: Invalid argument
    ld.exe: cannot find -lC:/msys64/mingw64/lib/libz.dll.a: Invalid argument
    ld.exe: cannot find -lC:/msys64/mingw64/lib/libsz.dll.a: Invalid argument

    The remaining zlib and libaec are kept in Libs.private with the library
    path stripped. Those compression libraries are in LINK_COMP_LIBS in
    cmake file and that helps to separate them from curl and openssl.


Fixes https://github.com/msys2/MINGW-packages/issues/18554