### PR TITLE
jj: switch to cargo install

### DIFF
--- a/mingw-w64-jj/PKGBUILD
+++ b/mingw-w64-jj/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
 pkgver=0.9.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Jujutsu (an experimental VCS) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
@@ -49,7 +49,16 @@ check() {
 package_jj() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
-  install -Dm755 "target/release/${_realname}.exe" "${pkgdir}${MINGW_PREFIX}/bin/${_realname}.exe"
+  ${MINGW_PREFIX}/bin/cargo install \
+    --frozen \
+    --offline \
+    --no-track \
+    --path cli \
+    --root "${pkgdir}${MINGW_PREFIX}" \
+    --all-features
+  
+  # used for internal testing
+  rm ${pkgdir}${MINGW_PREFIX}/bin/fake*
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
   install -Dm644 jj.bash "${pkgdir}${MINGW_PREFIX}/share/bash-completion/completions/jj"


### PR DESCRIPTION
~~this provides 2 extra binaries: `fake-editor` and
`fake-diff-editor`~~ now not, see further conversation