### PR TITLE
vulkan-utility-libraries: fix file conflicts with vulkan-validation-layers

### DIFF
--- a/mingw-w64-vulkan-utility-libraries/PKGBUILD
+++ b/mingw-w64-vulkan-utility-libraries/PKGBUILD
@@ -4,7 +4,7 @@ _realname=Vulkan-Utility-Libraries
 pkgbase=mingw-w64-vulkan-utility-libraries
 pkgname=("${MINGW_PACKAGE_PREFIX}-vulkan-utility-libraries")
 pkgver=1.3.264
-pkgrel=1
+pkgrel=2
 pkgdesc='Libraries for Vulkan developers (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -16,7 +16,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/KhronosGroup/${_realname}/archive/v${pkgver}.tar.gz")
-sha256sums=('080293761cf0278a257646f2a27c3d952090a0ac8d6156156c0558fe3a6ecdee')
+sha256sums=('a6592b1d0eefe7331bc72153770d88e88b51dd1c16fbcd990098389941ed986c')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -57,5 +57,9 @@ package() {
   cd ${srcdir}/build-${MSYSTEM}
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install .
 
-  install -Dm644 ${srcdir}/${_realname}-${pkgver}/LICENSE.md ${pkgdir}${MINGW_PREFIX}/share/licenses/vulkan-validation-layers/LICENSE
+  # FIXME: Once we update Vulkan-ValidationLayers we can remove this since the header
+  # got removed there: https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6385
+  rm "${pkgdir}${MINGW_PREFIX}/include/vulkan/vk_enum_string_helper.h"
+
+  install -Dm644 ${srcdir}/${_realname}-${pkgver}/LICENSE.md ${pkgdir}${MINGW_PREFIX}/share/licenses/vulkan-utility-libraries/LICENSE
 }

--- a/mingw-w64-vulkan-utility-libraries/PKGBUILD
+++ b/mingw-w64-vulkan-utility-libraries/PKGBUILD
@@ -16,7 +16,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/KhronosGroup/${_realname}/archive/v${pkgver}.tar.gz")
-sha256sums=('a6592b1d0eefe7331bc72153770d88e88b51dd1c16fbcd990098389941ed986c')
+sha256sums=('080293761cf0278a257646f2a27c3d952090a0ac8d6156156c0558fe3a6ecdee')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {


### PR DESCRIPTION
* there was a copy/paste error in the license path
* Remove vk_enum_string_helper.h for now, should be fixed in the next vulkan sdk version

Fixes #18582