### PR TITLE
python-tldr: new package

### DIFF
--- a/mingw-w64-python-shtab/PKGBUILD
+++ b/mingw-w64-python-shtab/PKGBUILD
@@ -1,0 +1,65 @@
+# Maintainer: Maksim Bondarenkov <maksapple2306@gmail.com>
+
+_realname=shtab
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=1.6.4
+pkgrel=1
+pkgdesc="Automagic shell tab completion for Python CLI applications (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+msys2_references=(
+  'pypi: shtab'
+)
+url='https://github.com/iterative/shtab'
+license=('spdx:Apache-2.0')
+depends=("${MINGW_PACKAGE_PREFIX}-python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build" 
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-wheel"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest"
+              "${MINGW_PACKAGE_PREFIX}-python-pytest-cov"
+              "${MINGW_PACKAGE_PREFIX}-python-pytest-timeout")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('aba9e049bed54ffdb650cb2e02657282d8c0148024b0f500277052df124d47de')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}
+}
+
+build() {
+  msg "Python build for ${MSYSTEM}"
+  cd "${srcdir}"
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+check() {
+  msg "Python test for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
+
+  ${MINGW_PREFIX}/bin/python -m pytest
+}
+
+package() {
+  msg "Python install for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  # Generate shell completions
+  for _shell in bash zsh; do
+    python -m shtab --print-own-completion "${_shell}" > "${_shell}.completion"
+  done
+
+  install -Dm644 bash.completion "${pkgdir}${MINGW_PREFIX}/share/bash-completion/completions/shtab"
+  install -Dm644 zsh.completion "${pkgdir}${MINGW_PREFIX}/share/zsh/site-functions/_shtab"
+  install -Dm644 LICENCE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENCE"
+}

--- a/mingw-w64-python-sphinx-argparse/PKGBUILD
+++ b/mingw-w64-python-sphinx-argparse/PKGBUILD
@@ -1,0 +1,52 @@
+# Maintainer: Maksim Bondarenkov <maksapple2306@gmail.com>
+
+_realname=sphinx-argparse
+_pypi_name=sphinx_argparse
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=0.4.0
+pkgrel=1
+pkgdesc="Sphinx extension that automatically documents argparse commands and options (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+msys2_references=(
+    'pypi: sphinx_argparse'
+)
+url='https://github.com/ashb/sphinx-argparse'
+license=('spdx:MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-python-sphinx")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-wheel"
+             "${MINGW_PACKAGE_PREFIX}-python-poetry-core")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
+optdepends=("${MINGW_PACKAGE_PREFIX}-python-commonmark: markdown support")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_pypi_name}-${pkgver}.tar.gz")
+sha256sums=('e0f34184eb56f12face774fbc87b880abdb9017a0998d1ec559b267e9697e449')
+
+build() {
+  msg "Python build for ${MSYSTEM}"
+  cd "${srcdir}"
+  cp -r "${_pypi_name}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+check() {
+  msg "Python test for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
+
+  ${MINGW_PREFIX}/bin/python -m pytest
+}
+
+package() {
+  msg "Python install for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}

--- a/mingw-w64-python-tldr/PKGBUILD
+++ b/mingw-w64-python-tldr/PKGBUILD
@@ -1,0 +1,62 @@
+# Maintainer: Maksim Bondarenkov <maksapple2306@gmail.com>
+
+_realname=tldr
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=3.2.0
+pkgrel=1
+pkgdesc="Command line client for tldr, a collection of simplified and community-driven man pages (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+msys2_references=(
+  'archlinux: tldr'
+  'pypi: tldr'
+)
+url='https://github.com/tldr-pages/tldr-python-client'
+license=('spdx:MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-python-colorama"
+         "${MINGW_PACKAGE_PREFIX}-python-shtab"
+         "${MINGW_PACKAGE_PREFIX}-python-termcolor")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-wheel"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python-sphinx-argparse")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
+options=('!strip')
+source=("${_realname}-${pkgver}.tar.gz::${url}/archive/refs/tags/${pkgver}.tar.gz")
+sha256sums=('9e8f89411f297c2591bccdc3b1515f6b41662ce3a1514c072282d6f7979fc0dc')
+
+build() {
+  msg "Python build for ${MSYSTEM}"
+  cd "${srcdir}"
+  cp -r "tldr-python-client-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  # man page
+  make -C docs
+  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+check() {
+  msg "Python test for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
+
+  ${MINGW_PREFIX}/bin/python -m pytest
+}
+
+package() {
+  msg "Python install for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE.md "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE.md"
+
+  # Generate shell completions
+  install -dm755 "${pkgdir}${MINGW_PREFIX}/share/bash-completion/completions/"
+  install -dm755 "${pkgdir}${MINGW_PREFIX}/share/zsh/site-functions/"
+  python -m tldr --print-completion bash > "${pkgdir}${MINGW_PREFIX}/share/bash-completion/completions/tldr"
+  python -m tldr --print-completion zsh > "${pkgdir}${MINGW_PREFIX}/share/zsh/site-functions/_tldr"
+}


### PR DESCRIPTION
also adds python-shtab and python-shpinx-argparse as dependencies.

~~currently I receive an error while building tldr. I have no idea what's wrong~~ fixed