### PR TITLE
llvm: update to 17.0.1 - Part2

### DIFF
--- a/mingw-w64-flang/0004-avoid-dependency-on-libcxx.patch
+++ b/mingw-w64-flang/0004-avoid-dependency-on-libcxx.patch
@@ -1,0 +1,18 @@
+--- "a/runtime/io-api.cpp"
++++ "b/runtime/io-api.cpp"
+@@ -1515,3 +1515,15 @@ enum Iostat IONAME(CheckUnitNumberInRange128)(common::int128_t unit,
+ #endif
+ 
+ } // namespace Fortran::runtime::io
++
++// Provide own definition for `std::__libcpp_verbose_abort` to avoid dependency
++// on the version provided by libc++.
++
++void std::__libcpp_verbose_abort(char const* format, ...) {
++  va_list list;
++  va_start(list, format);
++  std::vfprintf(stderr, format, list);
++  va_end(list);
++
++  std::abort();
++}

--- a/mingw-w64-flang/0006-Rename-flang-new-flang-experimental-exec-to-flang.patch
+++ b/mingw-w64-flang/0006-Rename-flang-new-flang-experimental-exec-to-flang.patch
@@ -2,7 +2,7 @@ Index: flang/lib/Frontend/CompilerInvocation.cpp
 ===================================================================
 --- flang/lib/Frontend/CompilerInvocation.cpp
 +++ flang/lib/Frontend/CompilerInvocation.cpp
-@@ -59,8 +59,8 @@
+@@ -63,8 +63,8 @@
  static bool parseShowColorsArgs(const llvm::opt::ArgList &args,
                                  bool defaultColor = true) {
    // Color diagnostics default to auto ("on" if terminal supports) in the
@@ -13,7 +13,7 @@ Index: flang/lib/Frontend/CompilerInvocation.cpp
    // Support both clang's -f[no-]color-diagnostics and gcc's
    // -f[no-]diagnostics-colors[=never|always|auto].
    enum {
-@@ -636,7 +636,7 @@
+@@ -682,7 +682,7 @@
      }
    }
  
@@ -26,7 +26,7 @@ Index: flang/lib/Frontend/FrontendActions.cpp
 ===================================================================
 --- flang/lib/Frontend/FrontendActions.cpp
 +++ flang/lib/Frontend/FrontendActions.cpp
-@@ -108,7 +108,7 @@
+@@ -206,7 +206,7 @@
      llvm::SMDiagnostic err;
      llvmModule = llvm::parseIRFile(getCurrentInput().getFile(), err, *llvmCtx);
      if (!llvmModule || llvm::verifyModule(*llvmModule, &llvm::errs())) {
@@ -39,7 +39,7 @@ Index: flang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
 ===================================================================
 --- flang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
 +++ flang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
-@@ -102,8 +102,7 @@
+@@ -104,8 +104,7 @@
    // Honor -help.
    if (flang->getFrontendOpts().showHelp) {
      clang::driver::getDriverOptTable().printHelp(
@@ -52,7 +52,7 @@ Index: flang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
 ===================================================================
 --- flang/tools/f18/CMakeLists.txt
 +++ flang/tools/f18/CMakeLists.txt
-@@ -20,7 +20,7 @@
+@@ -22,7 +22,7 @@
  )
  
  # Create module files directly from the top-level module source directory.
@@ -61,12 +61,12 @@ Index: flang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
  # cross compiled, and thus can't be executed on the build system and thus
  # can't be used for generating module files.
  if (NOT CMAKE_CROSSCOMPILING)
-@@ -42,9 +42,9 @@
-     endif()
+@@ -53,9 +53,9 @@
+ 
      add_custom_command(OUTPUT ${base}.mod
        COMMAND ${CMAKE_COMMAND} -E make_directory ${FLANG_INTRINSIC_MODULES_DIR}
--      COMMAND flang-new -fc1 -cpp -fsyntax-only -module-dir ${FLANG_INTRINSIC_MODULES_DIR}
-+      COMMAND flang -fc1 -cpp -fsyntax-only -module-dir ${FLANG_INTRINSIC_MODULES_DIR}
+-      COMMAND flang-new -cpp -fsyntax-only ${opts} -module-dir ${FLANG_INTRINSIC_MODULES_DIR}
++      COMMAND flang -cpp -fsyntax-only ${opts} -module-dir ${FLANG_INTRINSIC_MODULES_DIR}
          ${FLANG_SOURCE_DIR}/module/${filename}.f90
 -      DEPENDS flang-new ${FLANG_SOURCE_DIR}/module/${filename}.f90 ${depends}
 +      DEPENDS flang ${FLANG_SOURCE_DIR}/module/${filename}.f90 ${depends}
@@ -185,7 +185,7 @@ Index: flang/tools/flang-driver/driver.cpp
 ===================================================================
 --- flang/tools/flang-driver/driver.cpp
 +++ flang/tools/flang-driver/driver.cpp
-@@ -88,14 +88,15 @@
+@@ -90,14 +90,15 @@
    llvm::InitLLVM x(argc, argv);
    llvm::SmallVector<const char *, 256> args(argv, argv + argc);
  
@@ -203,7 +203,7 @@ Index: flang/tools/flang-driver/driver.cpp
    auto firstArg = std::find_if(args.begin() + 1, args.end(),
                                 [](const char *a) { return a != nullptr; });
    if (firstArg != args.end()) {
-@@ -104,7 +105,7 @@
+@@ -107,7 +107,7 @@
                     << "Valid tools include '-fc1'.\n";
        return 1;
      }

--- a/mingw-w64-flang/PKGBUILD
+++ b/mingw-w64-flang/PKGBUILD
@@ -1,17 +1,20 @@
+# Contributor: Mehdi Chinoune <mehdi.chinoune@hotmail.com>
+
 _compiler=clang
+
 _realname=flang
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_version=16.0.5
+_version=17.0.1
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
 pkgrel=1
 pkgdesc="Fortran frontend for LLVM (mingw-w64)"
-arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://flang.llvm.org/"
-license=("spdx:Apache-2.0 WITH LLVM-exception")
+license=("spdx:Apache-2.0 AND spdx:LLVM-exception")
+arch=('any')
+mingw_arch=('clang64' 'clangarm64')
 provides=($([[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-fc"))
 depends=("${MINGW_PACKAGE_PREFIX}-clang"
          "${MINGW_PACKAGE_PREFIX}-llvm"
@@ -35,19 +38,19 @@ source=("${_url}/${_pkgfn}.tar.xz"{,.sig}
         "0001-cast-cxx11-narrowing.patch"
         "0002-cmake-22162.patch"
         "0003-do-not-link-to-llvm-dylib.patch"
-        "0004-do-not-use-clock_gettime-on-mingw.patch"::"https://github.com/llvm/llvm-project/commit/329964769972ef3c8a68f2dfea30e66beb4ae3e2.patch"
+        "0004-Avoid-dependency-on-libcxx.patch"
         "0005-Fix-c_long_double-value-on-mingw-aarch64.patch"
         "0006-Rename-flang-new-flang-experimental-exec-to-flang.patch")
-sha256sums=('1989097966d843753c5c094142c19b7cdbc3f94c465241c8a63398970755244a'
+sha256sums=('3575d8d8c7e03d6c7714deb119a5bd78bc1bc2d383e1f8042e4a694074ec140e'
             'SKIP'
-            '9400d49acd53a4b8f310de60554a891436db5a19f6f227f99f0de13e4afaaaff'
+            '46e745d9bdcd2e18719a47b080e65fd476e1f6c4bbaa5947e4dee057458b78bc'
             'SKIP'
             'ba08064d737a2aa173125e88c3900dce804220fb0562596b03130177c2139312'
             '77fb0612217b6af7a122f586a9d0d334cd48bb201509bf72e8f8e6244616e895'
             '8d70b33d20d74801aeee82173944fed3b33ae185031537e1b50a640238f7a988'
-            'b724ce543a67194841716fb4078fdaab55b2346adaa6cfa064808bbf703841b4'
+            '1cafbdbc3384fecb856be68f883d07f473717b687e129339c8eac827c5d87604'
             'a1811227e2a26c2786b0c8577528580e679111f6c0889afea57d08333e2d5e4f'
-            '5f8dffa8dadaa55f36f1330222b11e03673ea3a30099acf0537410a34728407a')
+            '645c3c5b55f03c7ce87a4927d4b6045283aef7926c029f1b2ca135a14389a9c3')
 validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Google.
               '474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard
               'D574BD5D1D0E98895E3BF90044F2485E45D59042') # Tobias Hieta
@@ -69,12 +72,12 @@ prepare() {
     "0002-cmake-22162.patch" \
     "0003-do-not-link-to-llvm-dylib.patch" \
     "0005-Fix-c_long_double-value-on-mingw-aarch64.patch"
-  # https://reviews.llvm.org/D149051
-  msg2 "Applying 0004-do-not-use-clock_gettime-on-mingw.patch"
-  patch -Nbp2 -i "${srcdir}/0004-do-not-use-clock_gettime-on-mingw.patch"
   # https://reviews.llvm.org/D143592
   apply_patch_with_msg \
     "0006-Rename-flang-new-flang-experimental-exec-to-flang.patch"
+  # https://reviews.llvm.org/D158957
+  apply_patch_with_msg \
+    "0004-Avoid-dependency-on-libcxx.patch"
 }
 
 build() {

--- a/mingw-w64-mlir/PKGBUILD
+++ b/mingw-w64-mlir/PKGBUILD
@@ -1,30 +1,37 @@
 # Contributor: Mehdi Chinoune <mehdi.chinoune@hotmail.com>
 
+_compiler=clang
+
 _realname=mlir
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_version=16.0.5
+_version=17.0.1
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
 pkgrel=1
 pkgdesc="Multi-Level IR Compiler Framework for LLVM (mingw-w64)"
 url="https://mlir.llvm.org/"
+license=("spdx:Apache-2.0 AND spdx:LLVM-exception")
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
-license=("custom:Apache 2.0 with LLVM Exception")
 depends=("${MINGW_PACKAGE_PREFIX}-llvm")
 makedepends=("${MINGW_PACKAGE_PREFIX}-clang"
+             "${MINGW_PACKAGE_PREFIX}-lld"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
+            #"${MINGW_PACKAGE_PREFIX}-python"
+            #"${MINGW_PACKAGE_PREFIX}-python-numpy"
+            #"${MINGW_PACKAGE_PREFIX}-pybind11")
+# optdepends=("${MINGW_PACKAGE_PREFIX}-python: Python bindings")
 _pkgfn=${_realname}-${pkgver}.src
 _url=https://github.com/llvm/llvm-project/releases/download/${_tag}
 source=("${_url}/${_pkgfn}.tar.xz"{,.sig}
         "${_url}/cmake-${pkgver}.src.tar.xz"{,.sig}
         0001-do-not-link-to-llvm-dylib.patch)
-sha256sums=('cc95a7afef6765fd9f823d3fd40191d67f361a06ed4cfad64ba819f2dff4c2a9'
+sha256sums=('a238c1229e42de66a6bcc6b27044e296db5fc38b384a74ec412bfb4e6e329d7b'
             'SKIP'
-            '9400d49acd53a4b8f310de60554a891436db5a19f6f227f99f0de13e4afaaaff'
+            '46e745d9bdcd2e18719a47b080e65fd476e1f6c4bbaa5947e4dee057458b78bc'
             'SKIP'
             '5012547c4b7bde0d372f4d45bfc8ad93a9baee62e04e161460aa2a4ec2cc8c32')
 validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Google.
@@ -42,24 +49,30 @@ prepare() {
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
 
-  if check_option "debug" "y"; then
-    _build_type="Debug"
+  declare -a _extra_config
+  if check_option "debug" "n"; then
+    _extra_config+=("-DCMAKE_BUILD_TYPE=Release")
   else
-    _build_type="Release"
+    _extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
-  CC=${MINGW_PREFIX}/bin/clang \
-  CXX=${MINGW_PREFIX}/bin/clang++ \
+  if [ "${_compiler}" == "clang" ]; then
+    export CC='clang'
+    export CXX='clang++'
+    _extra_config+=(-DLLVM_ENABLE_LLD=ON)
+  fi
+
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake \
     -GNinja \
-    -DCMAKE_BUILD_TYPE=${_build_type} \
+    "${_extra_config[@]}" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DCMAKE_SYSTEM_IGNORE_PATH=/usr/lib \
     -DLLVM_HOST_TRIPLE="${CARCH}-w64-windows-gnu" \
     -DPython3_EXECUTABLE=${MINGW_PREFIX}/bin/python.exe \
     -DLLVM_LINK_LLVM_DYLIB=ON \
     -DLLVM_BUILD_LLVM_DYLIB=ON \
+    -DMLIR_BUILD_MLIR_C_DYLIB=ON \
     -DMLIR_LINK_MLIR_DYLIB=ON \
     -DLLVM_BUILD_TOOLS=ON \
     -DLLVM_BUILD_UTILS=ON \
@@ -67,6 +80,7 @@ build() {
     -DMLIR_INCLUDE_TESTS=OFF \
     -DCMAKE_C_VISIBILITY_PRESET=hidden \
     -DCMAKE_CXX_VISIBILITY_PRESET=hidden \
+    -DMLIR_ENABLE_BINDINGS_PYTHON=OFF \
     -Wno-dev \
     ../$_pkgfn
 

--- a/mingw-w64-openmp/PKGBUILD
+++ b/mingw-w64-openmp/PKGBUILD
@@ -7,16 +7,16 @@ fi
 _realname=openmp
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_version=16.0.5
+_version=17.0.1
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
 pkgrel=1
 pkgdesc="LLVM OpenMP Library (mingw-w64)"
 url="https://openmp.llvm.org/"
+license=("spdx:Apache-2.0 AND spdx:LLVM-exception")
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
-license=("custom:Apache 2.0 with LLVM Exception")
 groups=($( (( _clangprefix )) && echo "${MINGW_PACKAGE_PREFIX}-toolchain"))
 provides=($( (( _clangprefix )) && echo "${MINGW_PACKAGE_PREFIX}-omp"))
 depends=($( (( _clangprefix )) || echo "${MINGW_PACKAGE_PREFIX}-gcc-libs"))
@@ -31,9 +31,9 @@ source=($_url/$_pkgfn.tar.xz{,.sig}
         ${_url}/cmake-${pkgver}.src.tar.xz{,.sig}
         "001-cast-to-make-gcc-happy.patch"
         "002-hacks-for-static-linking.patch")
-sha256sums=('bc15dc5b3c77f4c441f3a0c386befaa6a2f911e090740c062d2ebcabf52f4c52'
+sha256sums=('d4a25c04d1bc035990a85f172bfe29a38f21ff87448f7fbae165fa780cb95717'
             'SKIP'
-            '9400d49acd53a4b8f310de60554a891436db5a19f6f227f99f0de13e4afaaaff'
+            '46e745d9bdcd2e18719a47b080e65fd476e1f6c4bbaa5947e4dee057458b78bc'
             'SKIP'
             '11352ffbe7559a7170f2abd52b3552c877fbcf8fc82cff77b421e8b130a4dd66'
             '7238f009264bc1b162b73ca3a2a0b224b65ec3ed384304f3e5464032c4c026f4')


### PR DESCRIPTION
flang fails to build on GNU environments even we force clang+lld.
```
  [268/359] Linking CXX executable bin\tco.exe
  FAILED: bin/tco.exe 
  cmd.exe /C "cd . && D:\M\msys64\mingw64\bin\clang++.exe -march=nocona -msahf -mtune=generic -O2 -pipe -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wc++98-compat-extra-semi -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -ffunction-sections -fdata-sections -Wno-deprecated-copy -Wno-string-conversion -Wno-ctad-maybe-unsupported -Wno-unused-command-line-argument -Wstring-conversion           -Wcovered-switch-default -Wno-nested-anon-types -O3 -DNDEBUG -pipe -fuse-ld=lld -Wl,--stack,16777216    -Wl,--gc-sections @CMakeFiles\tco.rsp -o bin\tco.exe -Wl,--out-implib,lib\libtco.dll.a -Wl,--major-image-version,0,--minor-image-version,0  && cd ."
  ld.lld: error: libMLIRLLVMDialect.a(LLVMDialect.cpp.obj): .rdata should not refer to special section 0
  
  clang++: error: linker command failed with exit code 1 (use -v to see invocation)
  
  [269/359] Linking CXX executable bin\bbc.exe
  FAILED: bin/bbc.exe 
  cmd.exe /C "cd . && D:\M\msys64\mingw64\bin\clang++.exe -march=nocona -msahf -mtune=generic -O2 -pipe -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wc++98-compat-extra-semi -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -ffunction-sections -fdata-sections -Wno-deprecated-copy -Wno-string-conversion -Wno-ctad-maybe-unsupported -Wno-unused-command-line-argument -Wstring-conversion           -Wcovered-switch-default -Wno-nested-anon-types -O3 -DNDEBUG -pipe -fuse-ld=lld -Wl,--stack,16777216    -Wl,--gc-sections @CMakeFiles\bbc.rsp -o bin\bbc.exe -Wl,--out-implib,lib\libbbc.dll.a -Wl,--major-image-version,0,--minor-image-version,0  && cd ."
  ld.lld: error: libMLIRLLVMDialect.a(LLVMDialect.cpp.obj): .rdata should not refer to special section 0
  
  clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```