### PR TITLE
Fix libraw.pc

### DIFF
--- a/mingw-w64-libraw/PKGBUILD
+++ b/mingw-w64-libraw/PKGBUILD
@@ -8,7 +8,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.21.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Library for reading RAW files obtained from digital photo cameras (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -31,7 +31,7 @@ sha256sums=('630a6bcf5e65d1b1b40cdb8608bdb922316759bfb981c65091fec8682d1543cd'
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   patch -p1 -i "${srcdir}/LibRaw_obsolete-macros.patch"
-
+  sed -i 's/-lstdc++//g' *.pc.in
   autoreconf -ifv
 }
 


### PR DESCRIPTION
The `libraw.pc` file hardcodes `-lstdc++` which is but unnecessary and breaks building dependents on clang.

```
lld: error: unable to find library -lstdc++
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

Example: https://github.com/r-windows/libs/actions/runs/6283365115/job/17063752821