### PR TITLE
libraw: Remove hardcoded stdc++ in pkgconfig file

### DIFF
--- a/mingw-w64-libraw/0001-libraw-pkgconfig-remove-stdcxx.patch
+++ b/mingw-w64-libraw/0001-libraw-pkgconfig-remove-stdcxx.patch
@@ -1,0 +1,20 @@
+--- a/libraw.pc.in
++++ b/libraw.pc.in
+@@ -7,6 +7,6 @@
+ Description: Raw image decoder library (non-thread-safe)
+ Requires: @PACKAGE_REQUIRES@
+ Version: @PACKAGE_VERSION@
+-Libs: -L${libdir} -lraw -lstdc++@PC_OPENMP@
++Libs: -L${libdir} -lraw @PC_OPENMP@
+ Libs.private: @PACKAGE_LIBS_PRIVATE@
+ Cflags: -I${includedir}/libraw -I${includedir}
+--- a/libraw_r.pc.in
++++ b/libraw_r.pc.in
+@@ -7,6 +7,6 @@
+ Description: Raw image decoder library (thread-safe)
+ Requires: @PACKAGE_REQUIRES@
+ Version: @PACKAGE_VERSION@
+-Libs: -L${libdir} -lraw_r -lstdc++@PC_OPENMP@
++Libs: -L${libdir} -lraw_r @PC_OPENMP@
+ Libs.private: @PACKAGE_LIBS_PRIVATE@
+ Cflags: -I${includedir}/libraw -I${includedir}

--- a/mingw-w64-libraw/PKGBUILD
+++ b/mingw-w64-libraw/PKGBUILD
@@ -8,7 +8,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.21.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Library for reading RAW files obtained from digital photo cameras (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -24,12 +24,15 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-omp")
 options=('staticlibs' 'strip')
 source=("https://www.libraw.org/data/${_realname}-${pkgver}.tar.gz"
+        "0001-libraw-pkgconfig-remove-stdcxx.patch"
         "LibRaw_obsolete-macros.patch")
 sha256sums=('630a6bcf5e65d1b1b40cdb8608bdb922316759bfb981c65091fec8682d1543cd'
+            '3b4c6aece23e020bf50a8bf349a25186273a601286fa2bb1f0a7269083277c13'
             '4a31c0ee066f43915beff6f7959b6b2cd246d390720df379bfc047d4cedb6a8f')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
+  patch -p1 -i "${srcdir}/0001-libraw-pkgconfig-remove-stdcxx.patch"
   patch -p1 -i "${srcdir}/LibRaw_obsolete-macros.patch"
 
   autoreconf -ifv


### PR DESCRIPTION
libstdc++ is not available in clang environments.