### PR TITLE
mcfgthread: Update to 1.6

### DIFF
--- a/mingw-w64-mcfgthread/PKGBUILD
+++ b/mingw-w64-mcfgthread/PKGBUILD
@@ -4,14 +4,14 @@ _realname=mcfgthread
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}"-libs)
-pkgver=1.5.2
+pkgver=1.6.1
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
 url="https://github.com/lhmouse/mcfgthread"
 license=('spdx:LGPL-3.0-or-later' 'custom')
 options=('staticlibs' 'strip' '!buildflags')
-_commit='86512e1303f204848e7acc15c9a00cccc2a79dfe'
+_commit='40263a6e2095ccba83071454191e09f14e9ee232'
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cc"
   "${MINGW_PACKAGE_PREFIX}-autotools"


### PR DESCRIPTION
This major release contains the following changes since v1.5-ga.2:

1. A compatibility manifest has been added to the DLL, declaring compatibility with Windows 7+.
2. The size of a TLS table is now decreased correctly during rehashing if deleted keys are detected. Previously it caused the table size to grow if the process kept allocating and deallocating TLS keys.

**Full Changelog**: https://github.com/lhmouse/mcfgthread/compare/v1.5-ga.2..v1.6-ga.1
