### PR TITLE
libxml++: Enable aarch64 builds

### DIFF
--- a/mingw-w64-libxml++/PKGBUILD
+++ b/mingw-w64-libxml++/PKGBUILD
@@ -16,6 +16,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-doxygen"
              "${MINGW_PACKAGE_PREFIX}-graphviz"
+             "${MINGW_PACKAGE_PREFIX}-libxslt"
+             "${MINGW_PACKAGE_PREFIX}-docbook-xsl"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
 options=('strip' 'staticlibs')
 license=('LGPL')

--- a/mingw-w64-libxml++/PKGBUILD
+++ b/mingw-w64-libxml++/PKGBUILD
@@ -6,7 +6,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.2.2
 pkgrel=4
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 pkgdesc="C++ wrapper for the libxml2 XML parser library (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libxml2"


### PR DESCRIPTION
```
# meson test
ninja: Entering directory `C:/Dev/Github/MINGW-packages/mingw-w64-libxml++/src/build-aarch64-w64-mingw32'
ninja: no work to do.
 1/19 dom_build_example                                       OK              0.09s
 2/19 dom_parse_entities_example                              OK              0.09s
 3/19 dom_parser_example                                      OK              0.07s
 4/19 dom_parser_raw_example                                  OK              0.06s
 5/19 dom_read_write_example                                  OK              0.05s
 6/19 dom_update_namespace_example                            OK              0.04s
 7/19 dom_xinclude_example                                    OK              0.13s
 8/19 dom_xpath_example                                       OK              0.11s
 9/19 dtdvalidation_example                                   OK              0.09s
10/19 import_node_example                                     OK              0.09s
11/19 sax_exception_example                                   OK              0.08s
12/19 sax_parser_example                                      OK              0.06s
13/19 sax_parser_build_dom_example                            OK              0.10s
14/19 sax_parser_entities_example                             OK              0.10s
15/19 textreader_example                                      OK              0.07s
16/19 schemavalidation_example                                OK              0.07s
17/19 saxparser_chunk_parsing_inconsistent_state_test         OK              0.06s
18/19 saxparser_parse_double_free_test                        OK              0.04s
19/19 saxparser_parse_stream_inconsistent_state_test          OK              0.04s

Ok:                 19
Expected Fail:      0
Fail:               0
Unexpected Pass:    0
Skipped:            0
Timeout:            0
```