### PR TITLE
akira: Enable clang64 and clangarm64 builds

### DIFF
--- a/mingw-w64-akira/PKGBUILD
+++ b/mingw-w64-akira/PKGBUILD
@@ -4,9 +4,9 @@ _realname=akira
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.0.16
-pkgrel=1
+pkgrel=2
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 pkgdesc="Akira is a native Linux Design application built in Vala and GTK. (mingw-w64)"
 depends=( "${MINGW_PACKAGE_PREFIX}-granite"
           "${MINGW_PACKAGE_PREFIX}-elementary-icon-theme"
@@ -42,6 +42,7 @@ build() {
     --prefix="${MINGW_PREFIX}" \
     --buildtype plain \
     -Dwerror=false \
+    -Dc_args=-Wno-incompatible-function-pointer-types \
     ../${_realname}-${pkgver}
 
   meson compile


### PR DESCRIPTION
![image](https://github.com/msys2/MINGW-packages/assets/1100440/2976f4bd-586e-48f4-a6c1-d999406f93bc)
