### PR TITLE
Python: use `-shared` instead if `-mdll`

### DIFF
--- a/mingw-w64-arrow/PKGBUILD
+++ b/mingw-w64-arrow/PKGBUILD
@@ -4,7 +4,7 @@ _realname=arrow
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=13.0.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Apache Arrow is a cross-language development platform for in-memory data (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -38,6 +38,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-clang"
              "${MINGW_PACKAGE_PREFIX}-gtk-doc"
              "${MINGW_PACKAGE_PREFIX}-rapidjson"
+             "${MINGW_PACKAGE_PREFIX}-python"
              "${MINGW_PACKAGE_PREFIX}-xsimd")
 source=("apache-arrow-${pkgver}.tar.gz"::"https://www.apache.org/dyn/closer.lua?action=download&filename=arrow/arrow-${pkgver}/apache-arrow-${pkgver}.tar.gz"
         "apache-arrow-${pkgver}.tar.gz.asc"::"https://www.apache.org/dyn/closer.lua?action=download&filename=arrow/arrow-${pkgver}/apache-arrow-${pkgver}.tar.gz.asc")
@@ -101,8 +102,6 @@ build() {
 
   ${MINGW_PREFIX}/bin/cmake --build .
 
-  if [[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]]; then
-
   mkdir -p "${srcdir}"/build-${MSYSTEM}-c-glib && cd "${srcdir}"/build-${MSYSTEM}-c-glib
 
   declare -a _meson_extra_config
@@ -125,17 +124,13 @@ build() {
 
   PATH="${srcdir}"/build-${MSYSTEM}-cpp/${_cmake_build_type}:$PATH \
     ${MINGW_PREFIX}/bin/meson compile
-  
-  fi
 }
 
 package() {
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install build-${MSYSTEM}-cpp
 
-  if [[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]]; then
   PATH="${srcdir}"/build-${MSYSTEM}-c-glib/arrow-glib:"${srcdir}"/build-${MSYSTEM}-cpp/${_cmake_build_type}:$PATH \
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/meson install -C build-${MSYSTEM}-c-glib
-  fi
 
   # Remove full path reference
   local _PREFIX_WIN="$(cygpath -wm ${MINGW_PREFIX})"

--- a/mingw-w64-python/0148-Use-shared-instead-of-mdll.patch
+++ b/mingw-w64-python/0148-Use-shared-instead-of-mdll.patch
@@ -1,0 +1,35 @@
+From f761ea235f7577c8143c7d4db2e0f991346fc751 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=D9=85=D9=87=D8=AF=D9=8A=20=D8=B4=D9=8A=D9=86=D9=88=D9=86?=
+ =?UTF-8?q?=20=28Mehdi=20Chinoune=29?= <mehdi.chinoune@hotmail.com>
+Date: Wed, 27 Sep 2023 21:45:13 +0100
+Subject: [PATCH 148/148] Use `-shared` instead of `-mdll`
+
+---
+ Lib/distutils/cygwinccompiler.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Lib/distutils/cygwinccompiler.py b/Lib/distutils/cygwinccompiler.py
+index d8c8428ac0..860b48c498 100644
+--- a/Lib/distutils/cygwinccompiler.py
++++ b/Lib/distutils/cygwinccompiler.py
+@@ -125,7 +125,7 @@ def __init__(self, verbose=0, dry_run=0, force=0):
+         shared_option = "-shared"
+ 
+         self.set_executables(compiler='%s -mcygwin -O -Wall' % self.cc,
+-                             compiler_so='%s -mcygwin -mdll -O -Wall' % self.cc,
++                             compiler_so='%s -mcygwin -shared -O -Wall' % self.cc,
+                              compiler_cxx='%s -mcygwin -O -Wall' % self.cxx,
+                              linker_exe='%s -mcygwin' % self.cc,
+                              linker_so=('%s -mcygwin %s' %
+@@ -287,7 +287,7 @@ def __init__(self, verbose=0, dry_run=0, force=0):
+                 'Cygwin gcc cannot be used with --compiler=mingw32')
+ 
+         self.set_executables(compiler='%s -O2 -Wall' % self.cc,
+-                             compiler_so='%s -mdll -O2 -Wall' % self.cc,
++                             compiler_so='%s -shared -O2 -Wall' % self.cc,
+                              compiler_cxx='%s -O2 -Wall' % self.cxx,
+                              linker_exe='%s' % self.cc,
+                              linker_so='%s %s'
+-- 
+2.42.0.windows.1
+

--- a/mingw-w64-python/PKGBUILD
+++ b/mingw-w64-python/PKGBUILD
@@ -22,11 +22,11 @@ else
   pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}${_pybasever}")
 fi
 pkgver=${_pybasever}.5
-pkgrel=2
+pkgrel=3
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
-license=('PSF')
+license=('spdx:PSF-2.0')
 url="https://www.python.org/"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-expat"
@@ -46,7 +46,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-autotools"
   "autoconf-archive"
 )
-options=('makeflags') # 'debug' '!strip')
+#options=('debug' '!strip')
 source=("https://www.python.org/ftp/python/${pkgver%rc?}/Python-${pkgver}.tar.xz"
         0001-sysconfig-make-_sysconfigdata.py-relocatable.patch
         0002-build-add-with-nt-threads-and-make-it-default-on-min.patch
@@ -194,7 +194,8 @@ source=("https://www.python.org/ftp/python/${pkgver%rc?}/Python-${pkgver}.tar.xz
         0144-setup.py-don-t-prepend-the-system-library-directorie.patch
         0145-tests-skip-a-broken-test.patch
         0146-Port-GetPythonImport-to-mingw.patch
-        0147-LoadLibraryExW-make-sure-to-only-use-backslashes-for.patch)
+        0147-LoadLibraryExW-make-sure-to-only-use-backslashes-for.patch
+        0148-Use-shared-instead-of-mdll.patch)
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -354,7 +355,8 @@ prepare() {
   0144-setup.py-don-t-prepend-the-system-library-directorie.patch \
   0145-tests-skip-a-broken-test.patch \
   0146-Port-GetPythonImport-to-mingw.patch \
-  0147-LoadLibraryExW-make-sure-to-only-use-backslashes-for.patch
+  0147-LoadLibraryExW-make-sure-to-only-use-backslashes-for.patch \
+  0148-Use-shared-instead-of-mdll.patch
  
   autoreconf -vfi
 }
@@ -602,4 +604,5 @@ sha256sums=('85cd12e9cf1d6d5a45f17f7afe1cebe7ee628d3282281c492e86adf636defa3f'
             '6e0d29ee44c5d5ab8605a980c7cee246acf5ccce638e6a7cee4c4e7a8ec865cd'
             '3b6bf12600203d45ff9b0ecde0bb9959c4fde923c9609e4c1e18b6d7877e3f1b'
             'd9a54181024f0b538d8903bdf772a0dd754811aab339e6f553c47e1198ab04cc'
-            '71fd408d8bb8ca40584f287adea583032d1b7150f011abe2165c44d468428f0f')
+            '71fd408d8bb8ca40584f287adea583032d1b7150f011abe2165c44d468428f0f'
+            '552c9d8d38c399424d3215fd4e69ab4a78752daad3a6b3ce4af313ae6f677462')


### PR DESCRIPTION
Confirm it by reenabling glib for arrow on clang environments where It was failing because if this bug.