### PR TITLE
glib2: add .exe extension in .pc file for wrappers we create

### DIFF
--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -7,7 +7,7 @@ _realname=glib2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.78.0
-pkgrel=1
+pkgrel=2
 url="https://gitlab.gnome.org/GNOME/glib"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -124,5 +124,10 @@ package() {
   for name in glib-mkenums glib-genmarshal gdbus-codegen gtester-report; do
     ${MINGW_PREFIX}/bin/python3 \
       "${srcdir}/pyscript2exe.py" "${pkgdir}${MINGW_PREFIX}/bin/${name}"
+
+        # https://github.com/mesonbuild/meson/issues/12271#issuecomment-1741381750
+        for pcfile in  "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/*.pc; do
+          sed -s "s|/${name}\$|/${name}.exe|g" -i "${pcfile}"
+        done
   done
 }


### PR DESCRIPTION
While the .pc file already contains absolute paths to .exe glib tools without .exe in the pc, a recent meson change in meson made it no longer find the tools.

Since we created those .exe we might as well adjust the path in the .pc files, so that any meson error is at least no longer MSYS2 specific.