### PR TITLE
Add CAIRO_WIN32_STATIC_BUILD for the static builds depending on cairo

### DIFF
--- a/mingw-w64-harfbuzz/PKGBUILD
+++ b/mingw-w64-harfbuzz/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
 pkgver=8.2.1
-pkgrel=1
+pkgrel=2
 pkgdesc="OpenType text shaping engine (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -39,6 +39,7 @@ build() {
     -DGMODULE_STATIC_COMPILATION
     -DGOBJECT_STATIC_COMPILATION
     -DGRAPHITE2_STATIC
+    -DCAIRO_WIN32_STATIC_BUILD
   )
 
   CFLAGS+=" ${_static_flags[@]}" \

--- a/mingw-w64-pango/PKGBUILD
+++ b/mingw-w64-pango/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
 pkgver=1.50.14
-pkgrel=3
+pkgrel=4
 pkgdesc="A library for layout and rendering of text (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -52,6 +52,7 @@ build() {
     -DGLIB_STATIC_COMPILATION
     -DGMODULE_STATIC_COMPILATION
     -DGOBJECT_STATIC_COMPILATION
+    -DCAIRO_WIN32_STATIC_BUILD
   )
 
   [[ -d build-${MSYSTEM} ]] && rm -rf build-${MSYSTEM}


### PR DESCRIPTION
cairo 1.18.0 requires it now