### PR TITLE
gcc: Pass `--disable-libstdcxx-time` when building a non-posix thread model

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -26,7 +26,7 @@ pkgver=13.2.0
 #_majorver=${pkgver:0:1}
 #_sourcedir=${_realname}-${_majorver}-${_snapshot}
 _sourcedir=${_realname}-${pkgver}
-pkgrel=2
+pkgrel=3
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -91,8 +91,8 @@ sha256sums=('e275e76442a6067341a27f04c5c6b83d8613144004c0413528863dc6b5c743da'
             'f73c8d1701762fed7d8102d17d8e4416a4cc5e600e297a89c2e1fe09cd743a1c'
             '693a91a863a706b3526af01c9de5ce8295c59ef0f56f009bcfbf79a93cba2728'
             'e78d51c908cd4e5c905c62e8350db1c609479bb95333c67f706b56974226fd94'
-            '74c4693850f6c96992d43414f88e9f16ab1a5d1458f5e4dc76ac3ce435a80eef'
-            '8dc297c658911ead58cd06407b853bbe82c2c3da1ad24cbcc7b01f3c7b5f666b'
+            '585968957f4519aa7219de4804e96debe7592df047e497b99ea0ae073e6f57d3'
+            '73b923129e6c5b819ac994ce64b75520918992c65d00e0d97f8ca43cd6784e56'
             'b0a98a41fea4a68f15d35b44495a487183a4d85ea9cb70cd4a645b4ed6583122')
 validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.org
               86CFFCA918CF3AF47147588051E8B148A9999C34  # evangelos@foutrelis.com
@@ -190,6 +190,10 @@ build() {
     extra_config+=("--disable-libstdcxx-debug")
   else
     extra_config+=("--enable-libstdcxx-debug")
+  fi
+
+  if [ "$_threads" != "posix" ]; then
+    extra_config+=("--disable-libstdcxx-time")
   fi
 
   case "${CARCH}" in


### PR DESCRIPTION
When building libstdc++, by default (`--enable-libstdcxx-time=auto` [seen in source code](https://github.com/gcc-mirror/gcc/blob/fd35d72a3dcd5ba14d81a1890236acd0145497e1/libstdc%2B%2B-v3/acinclude.m4#L1748)) the configure script attempts to detect existence of `nanosleep()`. As long as winpthreads is installed, the test succeeds and `#define _GLIBCXX_USE_NANOSLEEP 1` in 'c++config.h' is emitted, and libstdc++ will have a dependency on winpthreads. This is undesired when building GCC with a non-posix thread model, namely, `win32`, `mcf` or `single`.

We only build `posix` thread model, so this has no effect on the MSYS2 gcc.
