### PR TITLE
python-lazy-loader: new package, update scikit-image

### DIFF
--- a/mingw-w64-python-lazy-loader/PKGBUILD
+++ b/mingw-w64-python-lazy-loader/PKGBUILD
@@ -1,0 +1,56 @@
+# Maintainer: Miloš Komarčević <miloskomarcevic@aim.com>
+
+_pyname=lazy_loader
+_realname=lazy-loader
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=0.3
+pkgrel=1
+pkgdesc="Populate library namespace without incurring immediate import costs (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+msys2_references=(
+  'pypi: lazy_loader'
+)
+url='https://github.com/scientific-python/lazy_loader'
+license=('spdx:BSD-3-Clause')
+depends=("${MINGW_PACKAGE_PREFIX}-python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-flit-core"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-wheel")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest"
+              "${MINGW_PACKAGE_PREFIX}-python-pytest-cov")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${pkgver}.tar.gz")
+sha256sums=('3b68898e34f5b2a29daaaac172c6555512d0f32074f147e2254e4a6d9d838f37')
+
+build() {
+  msg "Python build for ${MSYSTEM}"
+  cd "${srcdir}"
+  cp -r "${_pyname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+check() {
+  msg "Python test for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
+
+  ${MINGW_PREFIX}/bin/python -m pytest
+}
+
+package() {
+  msg "Python install for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE.md "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+  install -Dm644 README.md "${pkgdir}${MINGW_PREFIX}/share/doc/python-${_realname}/README.md"
+  
+  local _pyver=$(${MINGW_PREFIX}/bin/python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+  rm -rfv "${pkgdir}${MINGW_PREFIX}/lib/python${_pyver}/site-packages/${_pyname}/tests"
+}

--- a/mingw-w64-python-scikit-image/PKGBUILD
+++ b/mingw-w64-python-scikit-image/PKGBUILD
@@ -1,10 +1,12 @@
 # Maintainer: Sarah Ottinger <schalaalexiazeal@gmail.com>
+# Contributor: Miloš Komarčević <miloskomarcevic@aim.com>
 
+_pyname=scikit_image
 _realname=scikit-image
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=0.19.3
-pkgrel=2
+pkgver=0.22.0
+pkgrel=1
 pkgdesc='Image processing routines for SciPy (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -12,60 +14,59 @@ msys2_references=(
   'pypi: scikit-image'
 )
 url="https://scikit-image.org/"
-license=('BSD')
-depends=("${MINGW_PACKAGE_PREFIX}-python-matplotlib>3.0.0"
-"${MINGW_PACKAGE_PREFIX}-python-scipy>=1.0.1"
-"${MINGW_PACKAGE_PREFIX}-python-pywavelets>=1.1.1"
-"${MINGW_PACKAGE_PREFIX}-python-numpy>1.18.0"
-"${MINGW_PACKAGE_PREFIX}-python-networkx>=2.0"
-"${MINGW_PACKAGE_PREFIX}-python-imageio>=2.3.0"
-"${MINGW_PACKAGE_PREFIX}-python-tifffile>=2019.7.26"
-"${MINGW_PACKAGE_PREFIX}-python-pillow>7.1.1")
+license=('spdx:BSD-3-Clause AND BSD-2-Clause AND MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-python-matplotlib>=3.5"
+  "${MINGW_PACKAGE_PREFIX}-python-scipy>=1.8"
+  "${MINGW_PACKAGE_PREFIX}-python-pywavelets>=1.1.1"
+  "${MINGW_PACKAGE_PREFIX}-python-numpy>1.22"
+  "${MINGW_PACKAGE_PREFIX}-python-networkx>=2.8"
+  "${MINGW_PACKAGE_PREFIX}-python-imageio>=2.27"
+  "${MINGW_PACKAGE_PREFIX}-python-tifffile>=2022.8.12"
+  "${MINGW_PACKAGE_PREFIX}-python-pillow>=9.0.1"
+  "${MINGW_PACKAGE_PREFIX}-python-lazy-loader>=0.3")
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+  "${MINGW_PACKAGE_PREFIX}-python-wheel"
+  "${MINGW_PACKAGE_PREFIX}-python-build"
+  "${MINGW_PACKAGE_PREFIX}-python-installer"
   "${MINGW_PACKAGE_PREFIX}-python-pythran"
   "${MINGW_PACKAGE_PREFIX}-cython"
+  "${MINGW_PACKAGE_PREFIX}-meson-python"
+  "${MINGW_PACKAGE_PREFIX}-pkgconf"
   "${MINGW_PACKAGE_PREFIX}-cc")
-checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest>=5.2.0"
-"${MINGW_PACKAGE_PREFIX}-python-pytest-cov>=2.7.0"
-"${MINGW_PACKAGE_PREFIX}-python-pytest-flake8"
-"${MINGW_PACKAGE_PREFIX}-python-pytest-localserver"
-"${MINGW_PACKAGE_PREFIX}-python-pooch")
-optdepends=("${MINGW_PACKAGE_PREFIX}-python-pyqt5: for imshow(x, fancy=True) and skivi"
-"${MINGW_PACKAGE_PREFIX}-freeimage: for reading various types of image file formats"
-"${MINGW_PACKAGE_PREFIX}-python-pyamg: fast cg_mg mode of random walker segmentation")
-options=('!emptydirs')
-source=("https://files.pythonhosted.org/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('24b5367de1762da6ee126dd8f30cc4e7efda474e0d7d70685433f0e3aa2ec450')
-
-prepare() {
-  cd "$srcdir"
-  rm -rf python-build-${MSYSTEM} | true
-  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
-}
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest>=7.0"
+  "${MINGW_PACKAGE_PREFIX}-python-pytest-cov>=2.11.0"
+  "${MINGW_PACKAGE_PREFIX}-python-pytest-localserver"
+  "${MINGW_PACKAGE_PREFIX}-python-pooch")
+optdepends=("${MINGW_PACKAGE_PREFIX}-freeimage: for reading various types of image file formats"
+  "${MINGW_PACKAGE_PREFIX}-python-pyamg: fast cg_mg mode of random walker segmentation")
+options=('!strip' '!emptydirs')
+source=("https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${pkgver}.tar.gz")
+sha256sums=('018d734df1d2da2719087d15f679d19285fce97cd37695103deadfaef2873236')
 
 build() {
   msg "Python build for ${MSYSTEM}"
-  cd "${srcdir}/python-build-${MSYSTEM}"
-  ${MINGW_PREFIX}/bin/python setup.py build_ext --inplace
-  ${MINGW_PREFIX}/bin/python setup.py build
+  cd "${srcdir}"
+  cp -r "${_pyname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 check() {
+  msg "Python test for ${MSYSTEM}"
   cd "${srcdir}/python-build-${MSYSTEM}"
-  ${MINGW_PREFIX}/bin/pytest || warning "Tests failed"
+
+  ${MINGW_PREFIX}/bin/python -m pytest
 }
 
 package() {
+  msg "Python install for ${MSYSTEM}"
   cd "${srcdir}/python-build-${MSYSTEM}"
-  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
-    --root="${pkgdir}" --optimize=1 --skip-build
 
-  for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*-script.py; do
-    sed -e '1 { s/^#!.*$// }' -i ${_f}
-  done
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
 
-  install -Dm644 LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE.txt"
+  install -Dm644 LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
   install -Dm644 README.md "${pkgdir}${MINGW_PREFIX}/share/doc/python-${_realname}/README.md"
 }


### PR DESCRIPTION
Required for updating scikit-image and other "scientific Python" libraries: https://scientific-python.org/specs/

See also https://aur.archlinux.org/packages/python-lazy-loader