### PR TITLE
librsvg: fix static build

### DIFF
--- a/mingw-w64-librsvg/PKGBUILD
+++ b/mingw-w64-librsvg/PKGBUILD
@@ -25,16 +25,29 @@ depends=("${MINGW_PACKAGE_PREFIX}-gdk-pixbuf2"
 optdepends=("${MINGW_PACKAGE_PREFIX}-gtk3: for rsvg-view-3")
 options=('staticlibs' 'strip')
 source=("https://download.gnome.org/sources/librsvg/${pkgver%.*}/${_realname}-${pkgver}.tar.xz"
-        "0001-configure-set-pass-prefix-to-pkg-config-when-retriev.patch")
+        "0001-configure-set-pass-prefix-to-pkg-config-when-retriev.patch"
+        "glib-0.18.1.tar.gz::https://crates.io/api/v1/crates/glib/0.18.1/download"
+        "glib-rs.patch")
 sha256sums=('335fe2e0c2cbf1b7bf0668651224a23e135451f0b1793cd813649be2bffa74e8'
-            '189eec6486c9ef6cf1071af9750405bc41e16ae3a55ad663435e574369fec915')
+            '189eec6486c9ef6cf1071af9750405bc41e16ae3a55ad663435e574369fec915'
+            '331156127e8166dd815cf8d2db3a5beb492610c716c03ee6db4f2d07092af0a7'
+            'e0f5accba0ff47d9cdf79f506ea76ea0b373edaf6845a23180a00c15e0a8691d')
 msys2_repository_url="https://gitlab.gnome.org/GNOME/librsvg"
 
 prepare() {
-  cd "${srcdir}/${_realname}-${pkgver}"
+  # Patch bug in glib rust bindings
+  # See: https://github.com/gtk-rs/gtk-rs-core/pull/1199
+  # Version of glib-rs should match what is in librsvg Cargo.lock
+  cd "${srcdir}/glib-0.18.1"
+  patch -p1 -i "${srcdir}/glib-rs.patch"
 
+  cd "${srcdir}/${_realname}-${pkgver}"
   patch -p1 -i "${srcdir}/0001-configure-set-pass-prefix-to-pkg-config-when-retriev.patch"
 
+  echo "" >> Cargo.toml
+  echo "[patch.crates-io]" >> Cargo.toml
+  echo "glib = { path = '../glib-0.18.1' }" >> Cargo.toml
+  cargo update --package glib
   cargo fetch --locked
 
   autoreconf -fiv

--- a/mingw-w64-librsvg/PKGBUILD
+++ b/mingw-w64-librsvg/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
 pkgver=2.57.0
-pkgrel=1
+pkgrel=2
 pkgdesc="SVG rendering library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')

--- a/mingw-w64-librsvg/glib-rs.patch
+++ b/mingw-w64-librsvg/glib-rs.patch
@@ -1,0 +1,11 @@
+diff -aurp glib-0.18.1-orig/src/param_spec.rs glib-0.18.1/src/param_spec.rs
+--- glib-0.18.1-orig/src/param_spec.rs	2023-10-05 22:28:59.000000000 +0200
++++ glib-0.18.1/src/param_spec.rs	2023-10-05 22:33:15.000000000 +0200
+@@ -296,7 +296,6 @@ pub unsafe trait ParamSpecType:
+ {
+ }
+ 
+-#[link(name = "gobject-2.0")]
+ extern "C" {
+     pub static g_param_spec_types: *const ffi::GType;
+ }


### PR DESCRIPTION
This fixes #18574. Basically this reverts https://github.com/gtk-rs/gtk-rs-core/commit/d14883cbb9f56a5b63af0ab6a600a76d5c6a49c2 which fixed some problem with dynamic linking on MSVC.

Also a bit of an experiment in packaging a patch for a rust dependency, which is perhaps something we may need to start doing more often. I tried to do it as clearly as possible. It works, but completely understand if you feel it is still too messy.

See upstream discussions: 
 - https://github.com/gtk-rs/gtk-rs-core/pull/1199
 - https://github.com/gtk-rs/gir/pull/1475
 - https://gitlab.gnome.org/GNOME/librsvg/-/issues/896
