### PR TITLE
wxwidgets3.2: Fix CLANG scripts causing wxPython build error

### DIFF
--- a/mingw-w64-wxwidgets3.2/PKGBUILD
+++ b/mingw-w64-wxwidgets3.2/PKGBUILD
@@ -14,7 +14,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-common"
          "${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-msw"
          "${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-gtk3")
 pkgver=${_wx_basever}.3
-pkgrel=1
+pkgrel=2
 pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -327,6 +327,14 @@ package_wxwidgets3.2-msw() {
   if [[ ${MINGW_CHOST} == aarch64-* ]]; then
     sed -s "s|\"-mthreads\"|\"\"|g" -i "${pkgdir}${MINGW_PREFIX}/bin/wx-config"
     sed -s "s|\"-mthreads\"|\"\"|g" -i "${pkgdir}${MINGW_PREFIX}/bin/wx-config-static"
+  fi
+
+  # CLANG gives warnings and in some cases errors on "-mwindows" option while building wxPython
+  if [[ ${MSYSTEM} == CLANG* ]]; then
+    sed -s "s| -mwindows||g" -i "${pkgdir}${MINGW_PREFIX}/bin/wx-config"
+    sed -s "s| -mwindows||g" -i "${pkgdir}${MINGW_PREFIX}/bin/wx-config-static"
+    sed -s "s| -mwindows||g" -i "${pkgdir}${MINGW_PREFIX}/lib/wx/config/msw-unicode-${_wx_basever}"
+    sed -s "s| -mwindows||g" -i "${pkgdir}${MINGW_PREFIX}/lib/wx/config/msw-unicode-static-${_wx_basever}"
   fi
 
   # create wx-config copy with version file suffix


### PR DESCRIPTION
wxPython building errors out from use of "-mwindows"; this change removes "-mwindows" in CLANG64/32 packages.