### PR TITLE
update numba/llvmlite to 0.58.1/0.41.1

### DIFF
--- a/mingw-w64-python-llvmlite/PKGBUILD
+++ b/mingw-w64-python-llvmlite/PKGBUILD
@@ -6,11 +6,11 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=0.41.0
+pkgver=0.41.1
 pkgrel=1
 pkgdesc='Lightweight LLVM python binding for writing JIT compilers (mingw-w64)'
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 msys2_references=(
   'pypi: llvmlite'
 )
@@ -30,7 +30,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
         "multi-defs.patch"
         "path_fix.patch")
-sha256sums=('7d41db345d76d2dfa31871178ce0d8e9fd8aa015aa1b7d4dab84b5cb393901e0'
+sha256sums=('f19f767a018e6ec89608e1f6b13348fa2fcde657151137cb64e56d48598a92db'
             'b4610934ac8fd7e614d9ea920856ff6da2fbeb146028a664ada8543b8b33ec56'
             '813ecc48f18543f0d36b03c7596a1a6a26be31b9cfa44f1111ac232821844a79')
 

--- a/mingw-w64-python-numba/PKGBUILD
+++ b/mingw-w64-python-numba/PKGBUILD
@@ -3,11 +3,11 @@
 _realname=numba
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=0.58.0
+pkgver=0.58.1
 pkgrel=1
 pkgdesc='NumPy aware dynamic Python compiler using LLVM (mingw-w64)'
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 msys2_references=(
   'pypi: numba'
 )
@@ -28,7 +28,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
 optdepends=("${MINGW_PACKAGE_PREFIX}-python-scipy")
 options=('!emptydirs')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('e5d5a318dc65a101ef846d7fd93f3cf2f7942494019e8342e51238b360739125')
+sha256sums=('487ded0633efccd9ca3a46364b40006dbdaca0f95e99b8b83e778d1195ebcbaa')
 
 prepare() {
   cd "${srcdir}"


### PR DESCRIPTION
see: https://github.com/numba/llvmlite/issues/994
see: https://github.com/numba/numba/issues/9041

I will disable i686 in dependent packages later.