### PR TITLE
qt6-svg: apply a security patch

### DIFF
--- a/mingw-w64-qt6-svg/PKGBUILD
+++ b/mingw-w64-qt6-svg/PKGBUILD
@@ -6,11 +6,11 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
 _qtver=6.6.0
 pkgver=${_qtver/-/}
-pkgrel=1
+pkgrel=2
 arch=(any)
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://www.qt.io'
-license=(spdx:LGPL-3.0-only WITH spdx:Qt-GPL-exception-1.0 AND spdx:BSD-3-Clause AND spdx:GFDL-1.3-no-invariants-only AND spdx:GPL-2.0-only AND spdx:GPL-3.0-only)
+license=(spdx:LGPL-3.0-only WITH Qt-GPL-exception-1.0 AND BSD-3-Clause AND GFDL-1.3-no-invariants-only AND GPL-2.0-only AND GPL-3.0-only)
 pkgdesc='Classes for displaying the contents of SVG files (mingw-w64)'
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
@@ -18,8 +18,15 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-qt6-base"
              "rsync")
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
-source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('33da25fef51102f564624a7ea3e57cb4a0a31b7b44783d1af5749ac36d3c72de')
+source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz"
+        "https://download.qt.io/official_releases/qt/6.6/CVE-2023-45872-qtsvg-6.6.0.diff")
+sha256sums=('33da25fef51102f564624a7ea3e57cb4a0a31b7b44783d1af5749ac36d3c72de'
+            '303983f67932c49a02fa89c70fa54bcc97a5e002febc1fc8b5786106e0e5b086')
+
+prepare() {
+  cd ${_pkgfn}
+  patch -p1 -i ${srcdir}/CVE-2023-45872-qtsvg-6.6.0.diff
+}
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}


### PR DESCRIPTION
see: https://www.qt.io/blog/security-advisory-loading-invalid-qml-image-source-impacts-qt