### PR TITLE
calceph: new package

### DIFF
--- a/mingw-w64-calceph/PKGBUILD
+++ b/mingw-w64-calceph/PKGBUILD
@@ -1,0 +1,53 @@
+_realname=calceph
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=3.5.3
+pkgrel=1
+pkgdesc='The CALCEPH Library is designed to access the binary planetary ephemeris files, such INPOPxx and JPL DExxx ephemeris files (mingw-w64)'
+url='https://www.imcce.fr/inpop/calceph'
+license=('CeCILL-C' 'CeCILL-B' 'CeCILL')
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran")
+)
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-cc"
+             $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-gcc-fortran")
+             "${MINGW_PACKAGE_PREFIX}-make"
+)
+options=('!strip' '!buildflags' )
+source=("https://www.imcce.fr/content/medias/recherche/equipes/asd/calceph/${_realname}-${pkgver}.tar.gz")
+sha256sums=('9dd2ebdec1d1f5bd6f01961d111dbf0a4b24d0c0545572f00c1d236800a25789')
+
+build() {
+  [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
+ 
+  declare -a _extra_config
+  [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]  && _extra_config+=("--enable-fortran=no")
+
+  ../${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target="${MINGW_CHOST}" \
+    FCFLAGS=-J../src ax_cv_f90_modext=mod      \
+    ${_extra_config[@]} \
+    --enable-static \
+    --enable-shared
+    make
+}
+
+check() {
+    cd "${srcdir}/build-${MSYSTEM}"
+    make check
+}
+
+package() {
+   cd "${srcdir}/build-${MSYSTEM}"
+    DESTDIR="${pkgdir}" make install 
+    install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING_CECILL_B.LIB" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING_CECILL_B.LIB"
+    install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING_CECILL_C.LIB" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING_CECILL_C.LIB"
+    install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING_CECILL_V2.1.LIB" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING_CECILL_V2.1.LIB"
+}

--- a/mingw-w64-calceph/PKGBUILD
+++ b/mingw-w64-calceph/PKGBUILD
@@ -14,9 +14,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-cc"
              $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-gcc-fortran")
-             "${MINGW_PACKAGE_PREFIX}-make"
 )
-options=('!strip' '!buildflags' )
 source=("https://www.imcce.fr/content/medias/recherche/equipes/asd/calceph/${_realname}-${pkgver}.tar.gz")
 sha256sums=('9dd2ebdec1d1f5bd6f01961d111dbf0a4b24d0c0545572f00c1d236800a25789')
 


### PR DESCRIPTION
The CALCEPH Library is designed to access the binary planetary ephemeris files