### PR TITLE
ffmpeg: rebuild for ffnvcodec-headers update

### DIFF
--- a/mingw-w64-ffmpeg/PKGBUILD
+++ b/mingw-w64-ffmpeg/PKGBUILD
@@ -7,7 +7,7 @@ _realname=ffmpeg
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=6.0
-pkgrel=8
+pkgrel=9
 pkgdesc="Complete solution to record, convert and stream audio and video (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -71,6 +71,8 @@ source=(https://ffmpeg.org/releases/${_realname}-${pkgver}.tar.xz{,.asc}
         "0002-gcc-12.patch"
         "0001-lavu-vulkan-fix-handle-type-for-32-bit-targets.patch"
         https://github.com/FFmpeg/FFmpeg/commit/f9620d74cd49c35223304ba41e28be6144e45783.patch
+        https://github.com/FFmpeg/FFmpeg/commit/03823ac0c6a38bd6ba972539e3203a592579792f.patch
+        https://github.com/FFmpeg/FFmpeg/commit/d2b46c1ef768bc31ba9180f6d469d5b8be677500.patch
         https://github.com/FFmpeg/FFmpeg/commit/effadce6c756247ea8bae32dc13bb3e6f464f0eb.patch)
 validpgpkeys=('FCF986EA15E6E293A5644F10B4322F04D67658D8')
 sha256sums=('57be87c22d9b49c112b6d24bc67d42508660e6b718b3db89c44e47e289137082'
@@ -81,6 +83,8 @@ sha256sums=('57be87c22d9b49c112b6d24bc67d42508660e6b718b3db89c44e47e289137082'
             '84b9fcaa188eef15201a105a44c53d647e4fb800a5032336e0948d6bed2cbc1b'
             'bbc7e7b91886a8ac037d8e70692186ee4b48c37b4f1d82b81af8a54463b24803'
             '17df7ec458c7c04f365b3a00328abb3a7cf7f9a7ba9cecf0e492be116d7e6277'
+            '2d90ce59ca85ef42e02b0e707080a6b1447783c035f48a7103d71c4d691a4dcf'
+            '24cbefad7b2ce3b813ef36a36b984e631c579d43b4107baf5d198fb9da23412b'
             '8fad5f253bcda7a17523dbfcbfcfd60b3db23783dcdb65998005cddc7c7776c3')
 
 # Helper macros to help make tasks easier #
@@ -109,7 +113,10 @@ prepare() {
   # https://ffmpeg.org/pipermail/ffmpeg-devel/2023-March/307142.html
   apply_patch_with_msg 0001-lavu-vulkan-fix-handle-type-for-32-bit-targets.patch
 
-  apply_patch_with_msg f9620d74cd49c35223304ba41e28be6144e45783.patch
+  apply_patch_with_msg \
+    f9620d74cd49c35223304ba41e28be6144e45783.patch \
+    03823ac0c6a38bd6ba972539e3203a592579792f.patch \
+    d2b46c1ef768bc31ba9180f6d469d5b8be677500.patch
 
   # https://github.com/msys2/MINGW-packages/issues/17946
   apply_patch_with_msg effadce6c756247ea8bae32dc13bb3e6f464f0eb.patch


### PR DESCRIPTION

    * This change fixes the following error with configure command.

    ERROR: nvenc requested but not found

    * The compiler error in config.log is as following.

    test.c: In function 'f':
    test.c:3:54: error: 'NV_ENC_PRESET_HQ_GUID' undeclared (first use in this function);
    did you mean 'NV_ENC_PRESET_P7_GUID'?
        3 | void f(void) { struct { const GUID guid; } s[] = { { NV_ENC_PRESET_HQ_GUID } }; }
          |                                                      ^~~~~~~~~~~~~~~~~~~~~
          |                                                      NV_ENC_PRESET_P7_GUID

