### PR TITLE
ffmpeg4.4: rebuild for ffnvcodec-headers update

### DIFF
--- a/mingw-w64-ffmpeg4.4/PKGBUILD
+++ b/mingw-w64-ffmpeg4.4/PKGBUILD
@@ -7,7 +7,7 @@ _realname=ffmpeg
 pkgbase="mingw-w64-${_realname}4.4"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}4.4"
 pkgver=4.4.4
-pkgrel=5
+pkgrel=6
 pkgdesc="Complete solution to record, convert and stream audio and video (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -71,6 +71,8 @@ source=(https://ffmpeg.org/releases/${_realname}-${pkgver}.tar.xz{,.asc}
         "0003-fix-clang32-build.patch"
         https://github.com/FFmpeg/FFmpeg/commit/c3c8f97a9804b4234e97f13b0057ffc2c9af27c0.patch
         https://github.com/FFmpeg/FFmpeg/commit/f9620d74cd49c35223304ba41e28be6144e45783.patch
+        https://github.com/FFmpeg/FFmpeg/commit/03823ac0c6a38bd6ba972539e3203a592579792f.patch
+        https://github.com/FFmpeg/FFmpeg/commit/d2b46c1ef768bc31ba9180f6d469d5b8be677500.patch
         https://github.com/FFmpeg/FFmpeg/commit/effadce6c756247ea8bae32dc13bb3e6f464f0eb.patch)
 validpgpkeys=('FCF986EA15E6E293A5644F10B4322F04D67658D8')
 sha256sums=('e80b380d595c809060f66f96a5d849511ef4a76a26b76eacf5778b94c3570309'
@@ -81,6 +83,8 @@ sha256sums=('e80b380d595c809060f66f96a5d849511ef4a76a26b76eacf5778b94c3570309'
             '06481611d3449e2cc4f4759d2e0ad5b1ce2c4f313d0b63d4cb0a51d9fe02a424'
             'a6935946bbb55065ce495a9ea88870d17239380448a69a3915848960ff4b81e2'
             '17df7ec458c7c04f365b3a00328abb3a7cf7f9a7ba9cecf0e492be116d7e6277'
+            '2d90ce59ca85ef42e02b0e707080a6b1447783c035f48a7103d71c4d691a4dcf'
+            '24cbefad7b2ce3b813ef36a36b984e631c579d43b4107baf5d198fb9da23412b'
             '8fad5f253bcda7a17523dbfcbfcfd60b3db23783dcdb65998005cddc7c7776c3')
 
 # Helper macros to help make tasks easier #
@@ -101,6 +105,8 @@ prepare() {
     0002-gcc-12.patch \
     0003-fix-clang32-build.patch \
     c3c8f97a9804b4234e97f13b0057ffc2c9af27c0.patch \
+    03823ac0c6a38bd6ba972539e3203a592579792f.patch \
+    d2b46c1ef768bc31ba9180f6d469d5b8be677500.patch \
     f9620d74cd49c35223304ba41e28be6144e45783.patch
 
   # https://github.com/msys2/MINGW-packages/issues/17946


### PR DESCRIPTION

    * This change fixes the following error with configure command.

    ERROR: nvenc requested but not found

    * The compiler error in config.log is as following.

    test.c: In function 'f':
    test.c:3:54: error: 'NV_ENC_PRESET_HQ_GUID' undeclared (first use in this function);
    did you mean 'NV_ENC_PRESET_P7_GUID'?
        3 | void f(void) { struct { const GUID guid; } s[] = { { NV_ENC_PRESET_HQ_GUID } }; }
          |                                                      ^~~~~~~~~~~~~~~~~~~~~
          |                                                      NV_ENC_PRESET_P7_GUID

