### PR TITLE
zeromq: Fix aarch64 build

### DIFF
--- a/mingw-w64-zeromq/PKGBUILD
+++ b/mingw-w64-zeromq/PKGBUILD
@@ -4,7 +4,7 @@ _realname=zeromq
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.3.5
-pkgrel=1
+pkgrel=2
 pkgdesc="Fast messaging system built on sockets, C and C++ bindings. aka 0MQ, ZMQ (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -16,11 +16,17 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cc"
   "${MINGW_PACKAGE_PREFIX}-autotools")
 optdepends=("${MINGW_PACKAGE_PREFIX}-cppzmq: C++ binding for libzmq")
-source=("https://github.com/zeromq/libzmq/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('6653ef5910f17954861fe72332e68b03ca6e4d9c7160eb3a8de5a5a913bfab43')
+source=("https://github.com/zeromq/libzmq/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz"
+        https://github.com/zeromq/libzmq/commit/a02cbd0646175a44edb1d636911eb8dae12ec13f.patch)
+sha256sums=('6653ef5910f17954861fe72332e68b03ca6e4d9c7160eb3a8de5a5a913bfab43'
+            '6c5c612b06f4209754991bd51ca42efbfbc4c9db5b86080b0ce3bc179d2e7d3b')
 
 prepare() {
   cd ${_realname}-${pkgver}
+
+  # aarch64 error: use of undeclared identifier 'nsecs_per_usec'
+  patch -R -p1 -i "${srcdir}/a02cbd0646175a44edb1d636911eb8dae12ec13f.patch"
+
   autoreconf -fi
 }
 


### PR DESCRIPTION

    This fixes the following compiler error in aarch64 build.

    ../zeromq-4.3.5/src/clock.cpp:251:48: error: use of undeclared identifier 'nsecs_per_usec'; did you mean 'usecs_per_sec'?
      251 |     return static_cast<uint64_t> (ts.tv_sec) * nsecs_per_usec * usecs_per_sec
          |                                                ^~~~~~~~~~~~~~
          |                                                usecs_per_sec
    ../zeromq-4.3.5/src/clock.cpp:106:16: note: 'usecs_per_sec' declared here
      106 | const uint64_t usecs_per_sec = 1000000;
          |                ^

