### PR TITLE
qt6-static: re-introduce qtcharts.

### DIFF
--- a/mingw-w64-qt6-static/PKGBUILD
+++ b/mingw-w64-qt6-static/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}-static
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-static")
 _qtver=6.6.0
 pkgver=${_qtver/-/}
-pkgrel=1
+pkgrel=2
 arch=(any)
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 msys2_references=(
@@ -196,7 +196,7 @@ build() {
     -DFEATURE_wmf=ON \
     -DQT_BUILD_TESTS=OFF \
     -DQT_BUILD_EXAMPLES=OFF \
-    -DQT_BUILD_SUBMODULES="qtbase;qtlanguageserver;qtshadertools;qtdeclarative;qt5compat;qtactiveqt;qtimageformats;qtsvg;qttools;qttranslations" \
+    -DQT_BUILD_SUBMODULES="qtbase;qtlanguageserver;qtshadertools;qtdeclarative;qt5compat;qtactiveqt;qtimageformats;qtsvg;qttools;qttranslations;qtcharts" \
     -DOPENSSL_DEPENDENCIES="-lws2_32;-lgdi32;-lcrypt32" \
     -DLIBPNG_DEPENDENCIES="-lz" \
     -DGLIB2_DEPENDENCIES="-lintl;-lws2_32;-lole32;-lwinmm;-lshlwapi;-lm" \


### PR DESCRIPTION
Fixes #18952 