### PR TITLE
python-qtconsole: Add qt5-svg to depends

### DIFF
--- a/mingw-w64-python-qtconsole/PKGBUILD
+++ b/mingw-w64-python-qtconsole/PKGBUILD
@@ -7,7 +7,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=5.4.4
-pkgrel=1
+pkgrel=2
 pkgdesc="A rich Qt-based console for working with Jupyter kernels, supporting rich media output, session export, and more (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
@@ -23,7 +23,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-jupyter_core"
          "${MINGW_PACKAGE_PREFIX}-python-pygments"
          "${MINGW_PACKAGE_PREFIX}-python-pyqt5"
-         "${MINGW_PACKAGE_PREFIX}-python-qtpy")
+         "${MINGW_PACKAGE_PREFIX}-python-qtpy"
+         "${MINGW_PACKAGE_PREFIX}-qt5-svg")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"


### PR DESCRIPTION
Without this dependency the `jupyter-qtconsole` can't be launched.