### PR TITLE
libheif: backport fixes for zero box redux

### DIFF
--- a/mingw-w64-libheif/PKGBUILD
+++ b/mingw-w64-libheif/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libheif
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.17.1
-pkgrel=2
+pkgrel=3
 pkgdesc="HEIF image decoder/encoder library and tools (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -28,15 +28,21 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-x265"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 source=("https://github.com/strukturag/libheif/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz"
-        https://github.com/strukturag/libheif/commit/1918de7f0f5813d2c20b18e954c17a27ac28a5b3.patch)
+        https://github.com/strukturag/libheif/commit/1918de7f0f5813d2c20b18e954c17a27ac28a5b3.patch
+        https://github.com/strukturag/libheif/commit/fe8d6b2a9e9c058147c628379b11e890dad328b3.patch
+        https://github.com/strukturag/libheif/commit/316291a9d374da768c8b629d2f04ed18015a3608.patch)
 sha256sums=('97d74c58a346887c1bbf98dcf0322c13b728286153d0f1be2b350f7107e49dba'
-            '9238f41df47a937e2dcfa5cdf6bf0b17e069c15f2bdbdd2d4490bc7707b11ec0')
+            '9238f41df47a937e2dcfa5cdf6bf0b17e069c15f2bdbdd2d4490bc7707b11ec0'
+            '429bf8edd045f8edf5419290443cd2307451194ca88346cc2c562846f231421a'
+            '1b3d5fbbe35779b5c417812fa1959d7de2acff60c289eecbcaea90525b866383')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
 
   # https://github.com/strukturag/libheif/issues/1010
   patch -Np1 -i "${srcdir}"/1918de7f0f5813d2c20b18e954c17a27ac28a5b3.patch
+  patch -Np1 -i "${srcdir}"/fe8d6b2a9e9c058147c628379b11e890dad328b3.patch
+  patch -Np1 -i "${srcdir}"/316291a9d374da768c8b629d2f04ed18015a3608.patch
 }
 
 build() {


### PR DESCRIPTION
Turns out the initial single patch was insufficient.