### PR TITLE
glib2: Update to 2.78.1

### DIFF
--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -6,8 +6,8 @@
 _realname=glib2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.78.0
-pkgrel=3
+pkgver=2.78.1
+pkgrel=1
 url="https://gitlab.gnome.org/GNOME/glib"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -31,17 +31,15 @@ source=("https://download.gnome.org/sources/glib/${pkgver%.*}/glib-${pkgver}.tar
         glib-compile-schemas.hook.in
         gio-querymodules.hook.in
         pyscript2exe.py
-        https://gitlab.gnome.org/GNOME/glib/-/commit/82c764ce2e42f0d1032627dabcbd742d5f2bd8fa.patch
         0001-Add-support-for-TLS-callbacks-on-Windows.patch)
 noextract=("glib-${pkgver}.tar.xz")
-sha256sums=('44eaab8b720877ce303c5540b657b126f12dc94972d9880b52959f43fb537b30'
+sha256sums=('915bc3d0f8507d650ead3832e2f8fb670fce59aac4d7754a7dab6f1e6fed78b2'
             '51d02360a1ee978fd45e77b84bca9cfbcf080d91986b5c0efe0732779c6a54ec'
             '396c25cfd740ffbb72209133c7b9453173167577265a4bb14502678de8d5a8f9'
             '48e94a9e61f8db9a2dc66556f12c725efe5e247a9ddc5b491f8cb8310a387293'
             '0c3d54636407e0e13429b73959cace626253cd772e1d4870de0fb92b0b99545a'
             'f18d27d98709dba8c5f9756672baaf0158fb4353c9edbdc2e80021f88ff34ced'
             'e57174517b08cf8f9fb4f43a381d342d23d2db3cad661107f35ca21c39b5734d'
-            '34a145f7db89549b397af9c34543f2fb15a83696e015fd45610e4262d4fdc65d'
             '59bc474d527ae5930b0f652d32acb1c55f17c492464a8175923d340ec707b311')
 
 apply_patch_with_msg() {
@@ -60,9 +58,6 @@ prepare() {
   apply_patch_with_msg 0001-Update-g_fopen-g_open-and-g_creat-to-open-with-FILE_.patch
   apply_patch_with_msg 0002-disable_glib_compile_schemas_warning.patch
   apply_patch_with_msg 0004-disable-explicit-ms-bitfields.patch
-
-  # https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3575
-  apply_patch_with_msg 82c764ce2e42f0d1032627dabcbd742d5f2bd8fa.patch
 
   # https://github.com/msys2/MINGW-packages/issues/18207
   # https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3560


### PR DESCRIPTION
patch is included in this new release