### PR TITLE
SFCGAL: Update to 1.5.0

### DIFF
--- a/mingw-w64-python-pysfcgal/PKGBUILD
+++ b/mingw-w64-python-pysfcgal/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=pysfcgal
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
-pkgver=1.4.1
-pkgrel=3
+pkgver=1.5.0
+pkgrel=1
 pkgdesc='Python SFCGAL binding (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
@@ -12,7 +12,7 @@ msys2_references=(
   'pypi: PySFCGAL'
 )
 license=('spdx:MIT')
-url='https://gitlab.com/Oslandia/pysfcgal'
+url='https://gitlab.com/SFCGAL/pysfcgal'
 depends=(
     ${MINGW_PACKAGE_PREFIX}-python
     ${MINGW_PACKAGE_PREFIX}-sfcgal
@@ -22,8 +22,8 @@ makedepends=(${MINGW_PACKAGE_PREFIX}-python-setuptools
     ${MINGW_PACKAGE_PREFIX}-python-wheel
     ${MINGW_PACKAGE_PREFIX}-python-cffi
     ${MINGW_PACKAGE_PREFIX}-cc)
-source=(https://gitlab.com/Oslandia/pysfcgal/-/archive/v${pkgver}/pysfcgal-v${pkgver}.tar.gz)
-sha256sums=('a519cdb3a89dea11f92bee91f284cecd56dc88e4b0eda4f37d1c7268c0289980')
+source=(https://gitlab.com/SFCGAL/pysfcgal/-/archive/v${pkgver}/pysfcgal-v${pkgver}.tar.gz)
+sha256sums=('0ab7468f15a51aab4ddf103205493279edacf876bc30c6406ec2da9cf6aacb27')
 
 prepare() {
   rm -rf python-build-${MSYSTEM} | true

--- a/mingw-w64-sfcgal/PKGBUILD
+++ b/mingw-w64-sfcgal/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=sfcgal
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.4.1
-pkgrel=2
+pkgver=1.5.0
+pkgrel=1
 pkgdesc="Wrapper around CGAL that intents to implement 2D and 3D operations on OGC standards models (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -20,8 +20,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-gmp"
          "${MINGW_PACKAGE_PREFIX}-mpfr"
          "${MINGW_PACKAGE_PREFIX}-cgal")
-source=(https://gitlab.com/Oslandia/SFCGAL/-/archive/v${pkgver}/SFCGAL-v${pkgver}.tar.gz)
-sha256sums=('1800c8a26241588f11cddcf433049e9b9aea902e923414d2ecef33a3295626c3')
+source=(https://gitlab.com/SFCGAL/SFCGAL/-/archive/v${pkgver}/SFCGAL-v${pkgver}.tar.gz)
+sha256sums=('84f4d7cfb13e871d7472309722f6fb88982b3e4e2bb4b320df90b24f43c66f82')
 
 build() {
   [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}


### PR DESCRIPTION
Update to 1.5.0
Use new gitlab url

Changes: 
```

https://gitlab.com/sfcgal/SFCGAL/-/releases/v1.5.0

SFCGAL 1.5.0 (2023-10-30):
* Add visibility algorithms (Loïc Bartoletti)
* Straight Skeleton: Add a version with extrusion
* WKT: Fix triangle code (Loïc Bartoletti)
* Allow to disable GMPXX (Loïc Bartoletti, Fixes #249 and #252)
* Add polygon partition (Raphaël Delhome, Loïc Bartoletti)
* Minor typo correction (Regina Obe, #280)
* Remove CGAL unit test (Fix #257, Loïc Bartoletti)
* [C API] Add sfcgal_point_create_from_xyzm and sfcgal_point_create_from_xym functions (Loïc Bartoletti #274)
* Update CI and add FreeBSD, macOs CI (Loïc Bartoletti)
* Minors fixes (Loïc Bartoletti #269 and #270)
* Remove useless garden tests (Loïc Bartoletti)
* Fix SPDX-License-Identifier (Loïc Bartoletti reported by Bas Couwenberg #250)
NOTE: This is the first release on GitLab/SFCGAL space.
SFCGAL has now a dedicated space outside Oslandia one: https://gitlab.com/SFCGAL/.
```