### PR TITLE
vapoursynth: Re-enable clang32 due to OOM issue

### DIFF
--- a/mingw-w64-mpv/PKGBUILD
+++ b/mingw-w64-mpv/PKGBUILD
@@ -5,7 +5,7 @@ _realname=mpv
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.36.0
-pkgrel=3
+pkgrel=2
 pkgdesc="Video player based on MPlayer/mplayer2 (mingw-w64)"
 url="https://mpv.io/"
 arch=('any')
@@ -29,7 +29,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-ffmpeg"
          "${MINGW_PACKAGE_PREFIX}-shaderc"
          "${MINGW_PACKAGE_PREFIX}-spirv-cross"
          "${MINGW_PACKAGE_PREFIX}-uchardet"
-         $([[ ${MSYSTEM} == CLANG32 ]] || echo "${MINGW_PACKAGE_PREFIX}-vapoursynth")
+         "${MINGW_PACKAGE_PREFIX}-vapoursynth"
          "${MINGW_PACKAGE_PREFIX}-vulkan"
          "winpty")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"

--- a/mingw-w64-vapoursynth/PKGBUILD
+++ b/mingw-w64-vapoursynth/PKGBUILD
@@ -7,7 +7,7 @@ pkgver=65
 pkgrel=1
 pkgdesc="A video processing framework with simplicity in mind (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64') # clang32 OOM
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 msys2_references=(
   'archlinux: vapoursynth'
 )
@@ -86,6 +86,10 @@ package() {
 
   export LDFLAGS="-L$(cygpath -wm $pkgdir)/${MINGW_PREFIX}/lib $LDFLAGS"
   cd "${srcdir}/${_realname}-R${pkgver}"
+
+  # avoid clang32 OOMing by reducing memory usage
+  [[ ${MSYSTEM} == CLANG32 ]] && CFLAGS+=" -g0"
+
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
     --root="${pkgdir}" --optimize=1


### PR DESCRIPTION
This reverts commit b8c3ea257b1ac2bff9126a67db2de41456802b52.