### PR TITLE
suitesparse: update to 7.3.1

### DIFF
--- a/mingw-w64-suitesparse/PKGBUILD
+++ b/mingw-w64-suitesparse/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=suitesparse
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-suitesparse")
-pkgver=7.3.0
+pkgver=7.3.1
 pkgrel=1
 pkgdesc='A suite of sparse matrix algorithms (mingw-w64)'
 url="https://faculty.cse.tamu.edu/davis/suitesparse.html"
@@ -19,8 +19,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/v${pkgver}.tar.gz")
-sha256sums=('ea290a04bd0c3dbbefe9a869a42644fc1bb61f9451040d8d88896a9df13ee620')
-noextract=(${_realname}-${pkgver}.tar.gz)
+sha256sums=('b512484396a80750acf3082adc1807ba0aabb103c2e09be5691f46f14d0a9718')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -32,8 +31,6 @@ apply_patch_with_msg() {
 
 prepare() {
   cd ${srcdir}
-  rm -rf SuiteSparse-${pkgver}
-  tar -xzf ${_realname}-${pkgver}.tar.gz || true
 }
 
 build() {
@@ -49,7 +46,7 @@ build() {
   fi
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-    make CMAKE_OPTIONS="-DCMAKE_INSTALL_PREFIX=\"${MINGW_PREFIX}\" ${_extra_config[@]} -DBLA_VENDOR=OpenBLAS"
+    make CMAKE_OPTIONS="-DCMAKE_INSTALL_PREFIX=\"${MINGW_PREFIX}\" ${_extra_config[@]} -DBLA_VENDOR=OpenBLAS -DCOMPACT=ON"
 }
 
 package() {


### PR DESCRIPTION
Also skip building factory kernels for GraphBLAS and rely on the JIT compiler instead as proposed by upstream.