### PR TITLE
curl: port to simpler relocation API

### DIFF
--- a/mingw-w64-curl/0001-Make-cURL-relocatable.patch
+++ b/mingw-w64-curl/0001-Make-cURL-relocatable.patch
@@ -1,30 +1,3 @@
-From 5176fc67557291c1774c363640c72f80ad409563 Mon Sep 17 00:00:00 2001
-From: Ray Donnelly <mingw.android@gmail.com>
-Date: Wed, 22 Feb 2017 11:03:04 +0100
-Subject: [PATCH] Make cURL relocatable
-
-This adds the ability to specify CA_BUNDLE paths that are relative to
-the MSYS2 pseudo-root directory.
-
-To make it truly relocatable, we use the path to the *cURL library*
-instead of the path to the current .exe to determine the location of the
-pseudo-root directory (allowing the .exe file to live completely outside
-of the MSYS2 system, e.g. in $HOME/bin). This requires Win32 API
-available in Windows XP & 2003 and later, well within the Windows
-versions supported by Cygwin (and therefore MSYS2).
-
-We also need to be extra careful to extend that path logic to the
-ca-bundle.crt used to validate HTTPS *proxies*, not only HTTPS servers.
-
-Original-patch-by: Ray Donnelly <mingw.android@gmail.com>
-Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
----
- configure.ac         |   1 +
- lib/Makefile.inc     |   5 +-
- lib/curl_config.h.in |   3 +
- lib/url.c            |  26 ++-
- 6 files changed, 624 insertions(+), 3 deletions(-)
-
 diff --git a/configure.ac b/configure.ac
 index 798fa5f1e..2ed766c0d 100755
 --- a/configure.ac
@@ -71,11 +44,9 @@ index 0f2a80403..9bad51f8d 100644
  /* to disable cookies support */
  #undef CURL_DISABLE_COOKIES
  
-diff --git a/lib/url.c b/lib/url.c
-index 945d4e327..981e60d26 100644
---- a/lib/url.c
-+++ b/lib/url.c
-@@ -131,6 +131,9 @@
+--- curl-8.4.0/lib/url.c.orig	2023-10-09 08:21:51.000000000 +0200
++++ curl-8.4.0/lib/url.c	2023-11-05 12:26:12.030706100 +0100
+@@ -119,6 +119,9 @@
  #include "altsvc.h"
  #include "dynbuf.h"
  #include "headers.h"
@@ -85,49 +56,37 @@ index 945d4e327..981e60d26 100644
  
  /* The last 3 #include files should be in this order */
  #include "curl_printf.h"
-@@ -575,21 +575,54 @@
+@@ -572,21 +575,46 @@
     */
    if(Curl_ssl_backend() != CURLSSLBACKEND_SCHANNEL) {
  #if defined(CURL_CA_BUNDLE)
 +#if defined(__MINGW32__)
-+    const size_t path_max = PATH_MAX;
-+    char relocated_bundle[path_max];
-+    get_dll_path(relocated_bundle, path_max);
-+    strip_n_suffix_folders(relocated_bundle, 1);
-+    strncat(relocated_bundle, "/", path_max);
-+    char *relative = get_relative_path(CURL_BINDIR, CURL_CA_BUNDLE);
-+    strncat(relocated_bundle, relative, path_max);
-+    free((void*)relative);
-+    simplify_path(relocated_bundle);
++    char *relocated_bundle = single_path_relocation_lib(CURL_BINDIR, CURL_CA_BUNDLE);
 +    result = Curl_setstropt(&set->str[STRING_SSL_CAFILE], relocated_bundle);
++    free(relocated_bundle);
 +#else
      result = Curl_setstropt(&set->str[STRING_SSL_CAFILE], CURL_CA_BUNDLE);
 +#endif /* defined(__MINGW32__) */
      if(result)
        return result;
  
--    result = Curl_setstropt(&set->str[STRING_SSL_CAFILE_PROXY],
--                            CURL_CA_BUNDLE);
 +#if defined(__MINGW32__)
-+    result = Curl_setstropt(&set->str[STRING_SSL_CAFILE_PROXY], relocated_bundle);
++    relocated_bundle = single_path_relocation_lib(CURL_BINDIR, CURL_CA_BUNDLE);
++    result = Curl_setstropt(&set->str[STRING_SSL_CAFILE_PROXY],
++                            relocated_bundle);
++    free(relocated_bundle);
 +#else
-+    result = Curl_setstropt(&set->str[STRING_SSL_CAFILE_PROXY], CURL_CA_BUNDLE);
+     result = Curl_setstropt(&set->str[STRING_SSL_CAFILE_PROXY],
+                             CURL_CA_BUNDLE);
 +#endif
      if(result)
        return result;
  #endif
  #if defined(CURL_CA_PATH)
 +#if defined(__MINGW32__)
-+    const size_t path_max = PATH_MAX;
-+    char relocated_ca_path[path_max];
-+    get_dll_path(relocated_ca_path, path_max);
-+    strip_n_suffix_folders(relocated_ca_path, 1);
-+    strncat(relocated_ca_path, "/", path_max);
-+    char *relative = get_relative_path(CURL_BINDIR, CURL_CA_PATH);
-+    strncat(relocated_ca_path, relative, path_max);
-+    free((void*)relative);
-+    simplify_path(relocated_ca_path);
++    char *relocated_ca_path = single_path_relocation_lib(CURL_BINDIR, CURL_CA_PATH);
 +    result = Curl_setstropt(&set->str[STRING_SSL_CAPATH], relocated_ca_path);
++    free(relocated_ca_path);
 +#else
      result = Curl_setstropt(&set->str[STRING_SSL_CAPATH], CURL_CA_PATH);
 +#endif /* defined(__MINGW32__) */
@@ -135,13 +94,12 @@ index 945d4e327..981e60d26 100644
        return result;
  
 +#if defined(__MINGW32__)
++    relocated_ca_path = single_path_relocation_lib(CURL_BINDIR, CURL_CA_PATH);
 +    result = Curl_setstropt(&set->str[STRING_SSL_CAPATH_PROXY], relocated_ca_path);
++    free(relocated_ca_path);
 +#else
      result = Curl_setstropt(&set->str[STRING_SSL_CAPATH_PROXY], CURL_CA_PATH);
 +#endif
      if(result)
        return result;
  #endif
--- 
-2.16.1.windows.4
-

--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-gnutls"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-winssl")
 pkgver=8.4.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Command line tool and library for transferring data with URLs (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -41,7 +41,7 @@ sha256sums=('16c62a9c4af0f703d28bda6d7bbf37ba47055ad3414d70dec63e2e6336f2a82d'
             'SKIP'
             'ebf471173f5ee9c4416c10a78760cea8afaf1a4a6e653977321e8547ce7bf3c0'
             '1585ef1b61cf53a2ca27049c11d49e0834683dfda798f03547761375df482a90'
-            'c4e6bfd5b58f944d75293128effbd22fe42ee0131b915d9230ceb3c004c0322d'
+            '42bfa4c589e87a04d68ae4675f8200570f414ef363067015b159af91f3a94232'
             '3ee9c75a3046f86f91290c143170179230c9adc6eabfbb79eb26f708a165b719'
             '7492d019036b5bec251bfbc3c0b40e5f16d3dd6b2515068835e087a6c21f19ad'
             '590eb65e90e756eaad993d52a101f29091ada2c742c5a607684e88fc5c560d54')


### PR DESCRIPTION
Use single_path_relocation_lib() everywhere which does the same as before.