### PR TITLE
connect: port to single_path_relocation

### DIFF
--- a/mingw-w64-connect/0001-Make-it-relocatable.patch
+++ b/mingw-w64-connect/0001-Make-it-relocatable.patch
@@ -1,17 +1,3 @@
-From 8b761c5a76df828ba821514280346d3563d3e2f2 Mon Sep 17 00:00:00 2001
-From: Johannes Schindelin <johannes.schindelin@gmx.de>
-Date: Tue, 4 Apr 2023 20:45:00 +0200
-Subject: [PATCH] Make it relocatable
-
-This uses MSYS2's pathtools to make `connect` find the configuration
-file relative to the executable's location.
-
-Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
----
- Makefile  |  7 ++++++-
- connect.c | 19 +++++++++++++++++++
- 2 files changed, 25 insertions(+), 1 deletion(-)
-
 diff --git a/Makefile b/Makefile
 index fd7de37..eca7ea3 100644
 --- a/Makefile
@@ -33,11 +19,23 @@ index fd7de37..eca7ea3 100644
  
  ##
  
-diff --git a/connect.c b/connect.c
-index 3b59b1d..13d6a08 100644
---- a/connect.c
-+++ b/connect.c
-@@ -760,6 +760,8 @@ read_parameter_file_1(const char* name)
+--- ssh-connect-1.105/connect.c.orig	2016-03-23 09:33:39.000000000 +0100
++++ ssh-connect-1.105/connect.c	2023-11-05 23:54:04.171589700 +0100
+@@ -667,7 +667,13 @@
+ 
+ 
+ /** PARAMETER operation **/
++
++#if !defined(_WIN32)
+ #define PARAMETER_FILE "/etc/connectrc"
++#else
++#define PARAMETER_FILE (MINGW_PREFIX "/etc/connectrc")
++#endif
++
+ #define PARAMETER_DOTFILE ".connectrc"
+ typedef struct {
+     char* name;
+@@ -760,6 +766,8 @@
      }
  }
  
@@ -46,30 +44,19 @@ index 3b59b1d..13d6a08 100644
  void
  read_parameter_file(void)
  {
-@@ -768,7 +770,23 @@ read_parameter_file(void)
+@@ -768,7 +776,14 @@
      struct passwd *pw;
  #endif
  
 +#if !defined(_WIN32)
      read_parameter_file_1(PARAMETER_FILE);
 +#else
-+    char path[PATH_MAX], *rel, *slash;
-+    get_executable_path(progname, path, sizeof (path) / sizeof (path[0]));
-+#ifndef MINGW_PREFIX
-+#define MINGW_PREFIX ""
-+#endif
-+    rel = get_relative_path(MINGW_PREFIX "/bin/", PARAMETER_FILE);
-+    slash = strrchr(path, '/');
-+    if (slash)
-+        slash[1] = '\0';
-+    strcat (path, rel);
-+    simplify_path (path);
-+    read_parameter_file_1(path);
++    char *parameter_file = single_path_relocation(MINGW_PREFIX "/bin", PARAMETER_FILE);
++    read_parameter_file_1(parameter_file);
++    free(parameter_file);
 +#endif
 +
  #if !defined(_WIN32) || defined(cygwin)
      pw = getpwuid(getuid());
      if ( pw == NULL )
--- 
-2.40.0.windows.1
 

--- a/mingw-w64-connect/PKGBUILD
+++ b/mingw-w64-connect/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.105
 tag='e122d9bd28e1'
-pkgrel=4
+pkgrel=5
 pkgdesc="Make socket connection using SOCKS4/5 and HTTP tunnel (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -18,7 +18,7 @@ source=(${_realname}-${pkgver}.tar.gz::"${url}/archive/${pkgver}.tar.gz"
         "pathtools.c"
         "pathtools.h")
 sha256sums=('96c50fefe7ecf015cf64ba6cec9e421ffd3b18fef809f59961ef9229df528f3e'
-            '1e1c89159178349a75665fcb9dfb7639e477b9af32165a377dad54c55e8a59d3'
+            '9b1d2c5314e790379ba9e996e104c8bdef8719e743adb94aef50179d878d4a93'
             'ebf471173f5ee9c4416c10a78760cea8afaf1a4a6e653977321e8547ce7bf3c0'
             '1585ef1b61cf53a2ca27049c11d49e0834683dfda798f03547761375df482a90')
 


### PR DESCRIPTION
And also fix it, since PARAMETER_FILE didn't have the same prefix and made relocation fail.