### PR TITLE
ffmpeg: Update to 6.1

### DIFF
--- a/mingw-w64-ffmpeg/0009-wrong-null-type.patch
+++ b/mingw-w64-ffmpeg/0009-wrong-null-type.patch
@@ -1,0 +1,66 @@
+diff -Nur ffmpeg-6.1-orig/libavcodec/vulkan_av1.c ffmpeg-6.1/libavcodec/vulkan_av1.c
+--- ffmpeg-6.1-orig/libavcodec/vulkan_av1.c	2023-11-11 01:25:17.000000000 +0100
++++ ffmpeg-6.1/libavcodec/vulkan_av1.c	2023-11-11 10:45:06.826832600 +0100
+@@ -180,7 +180,7 @@
+         .sType = VK_STRUCTURE_TYPE_VIDEO_SESSION_PARAMETERS_CREATE_INFO_KHR,
+         .pNext = &av1_params,
+         .videoSession = ctx->common.session,
+-        .videoSessionParametersTemplate = NULL,
++        .videoSessionParametersTemplate = VK_NULL_HANDLE,
+     };
+ 
+     err = ff_vk_decode_create_params(buf, avctx, ctx, &session_params_create);
+diff -Nur ffmpeg-6.1-orig/libavcodec/vulkan_decode.c ffmpeg-6.1/libavcodec/vulkan_decode.c
+--- ffmpeg-6.1-orig/libavcodec/vulkan_decode.c	2023-11-11 01:25:17.000000000 +0100
++++ ffmpeg-6.1/libavcodec/vulkan_decode.c	2023-11-11 10:47:06.921322700 +0100
+@@ -187,10 +187,10 @@
+     if (vkpic->img_view_ref)
+         return 0;
+ 
+-    vkpic->dpb_frame     = NULL;
+-    vkpic->img_view_ref  = NULL;
+-    vkpic->img_view_out  = NULL;
+-    vkpic->img_view_dest = NULL;
++    vkpic->dpb_frame     = VK_NULL_HANDLE;
++    vkpic->img_view_ref  = VK_NULL_HANDLE;
++    vkpic->img_view_out  = VK_NULL_HANDLE;
++    vkpic->img_view_dest = VK_NULL_HANDLE;
+ 
+     vkpic->destroy_image_view = vk->DestroyImageView;
+     vkpic->wait_semaphores = vk->WaitSemaphores;
+diff -Nur ffmpeg-6.1-orig/libavcodec/vulkan_h264.c ffmpeg-6.1/libavcodec/vulkan_h264.c
+--- ffmpeg-6.1-orig/libavcodec/vulkan_h264.c	2023-11-11 01:25:17.000000000 +0100
++++ ffmpeg-6.1/libavcodec/vulkan_h264.c	2023-11-11 10:45:57.371334900 +0100
+@@ -315,7 +315,7 @@
+         .sType = VK_STRUCTURE_TYPE_VIDEO_SESSION_PARAMETERS_CREATE_INFO_KHR,
+         .pNext = &h264_params,
+         .videoSession = ctx->common.session,
+-        .videoSessionParametersTemplate = NULL,
++        .videoSessionParametersTemplate = VK_NULL_HANDLE,
+     };
+ 
+     /* SPS list */
+diff -Nur ffmpeg-6.1-orig/libavcodec/vulkan_hevc.c ffmpeg-6.1/libavcodec/vulkan_hevc.c
+--- ffmpeg-6.1-orig/libavcodec/vulkan_hevc.c	2023-11-11 01:25:17.000000000 +0100
++++ ffmpeg-6.1/libavcodec/vulkan_hevc.c	2023-11-11 10:46:24.663058100 +0100
+@@ -653,7 +653,7 @@
+         .sType = VK_STRUCTURE_TYPE_VIDEO_SESSION_PARAMETERS_CREATE_INFO_KHR,
+         .pNext = &h265_params,
+         .videoSession = ctx->common.session,
+-        .videoSessionParametersTemplate = NULL,
++        .videoSessionParametersTemplate = VK_NULL_HANDLE,
+     };
+ 
+     HEVCHeaderSet *hdr;
+diff -Nur ffmpeg-6.1-orig/libavcodec/vulkan_video.c ffmpeg-6.1/libavcodec/vulkan_video.c
+--- ffmpeg-6.1-orig/libavcodec/vulkan_video.c	2023-11-11 01:25:17.000000000 +0100
++++ ffmpeg-6.1/libavcodec/vulkan_video.c	2023-11-11 10:47:38.629188400 +0100
+@@ -287,7 +287,7 @@
+     if (common->session) {
+         vk->DestroyVideoSessionKHR(s->hwctx->act_dev, common->session,
+                                    s->hwctx->alloc);
+-        common->session = NULL;
++        common->session = VK_NULL_HANDLE;
+     }
+ 
+     if (common->nb_mem && common->mem)

--- a/mingw-w64-ffmpeg/0015-guard-null-hw-frames-ctx.patch
+++ b/mingw-w64-ffmpeg/0015-guard-null-hw-frames-ctx.patch
@@ -1,0 +1,69 @@
+Guard against segfault running VLC decoding under msys2 [1]:
+
+Thread 33 received signal SIGSEGV, Segmentation fault.
+[Switching to Thread 37728.0xadd0]
+ff_hwaccel_frame_priv_alloc (avctx=0x6447b00, hwaccel_picture_private=0x65dfd00)
+    at libavcodec/decode.c:1848
+1848        frames_ctx = (AVHWFramesContext *)avctx->hw_frames_ctx->data;
+(gdb) bt
+    at libavcodec/decode.c:1848
+    at libavcodec/h264_slice.c:208
+    first_slice=1) at libavcodec/h264_slice.c:1599
+    at libavcodec/h264_slice.c:2130
+    at libavcodec/h264dec.c:652
+    got_frame=0x646e4b0, avpkt=0x64522c0) at libavcodec/h264dec.c:1048
+
+(gdb) p avctx
+$1 = (AVCodecContext *) 0x6447b00
+(gdb) p avctx->hw_frames_ctx
+$2 = (AVBufferRef *) 0x0
+
+v2: check for free_frame_priv (Hendrik)
+v3: return EINVAL (Christoph Reiter)
+
+See[1]: https://github.com/msys2/MINGW-packages/pull/19050
+Fixes: be07145109 ("avcodec: add AVHWAccel.free_frame_priv callback")
+CC: Lynne <dev at lynne.ee>
+CC: Christoph Reiter <reiter.christoph at gmail.com>
+Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin at intel.com>
+---
+ libavcodec/decode.c | 18 +++++++++++++-----
+ 1 file changed, 13 insertions(+), 5 deletions(-)
+
+diff --git a/libavcodec/decode.c b/libavcodec/decode.c
+index ad39021..50c3995 100644
+--- a/libavcodec/decode.c
++++ b/libavcodec/decode.c
+@@ -1838,17 +1838,25 @@ int ff_copy_palette(void *dst, const AVPacket *src, void *logctx)
+ int ff_hwaccel_frame_priv_alloc(AVCodecContext *avctx, void **hwaccel_picture_private)
+ {
+     const FFHWAccel *hwaccel = ffhwaccel(avctx->hwaccel);
+-    AVHWFramesContext *frames_ctx;
+ 
+     if (!hwaccel || !hwaccel->frame_priv_data_size)
+         return 0;
+ 
+     av_assert0(!*hwaccel_picture_private);
+ 
+-    frames_ctx = (AVHWFramesContext *)avctx->hw_frames_ctx->data;
+-    *hwaccel_picture_private = ff_refstruct_alloc_ext(hwaccel->frame_priv_data_size, 0,
+-                                                      frames_ctx->device_ctx,
+-                                                      hwaccel->free_frame_priv);
++    if (hwaccel->free_frame_priv) {
++        AVHWFramesContext *frames_ctx;
++
++        if (!avctx->hw_frames_ctx)
++            return AVERROR(EINVAL);
++
++        *hwaccel_picture_private = ff_refstruct_alloc_ext(hwaccel->frame_priv_data_size, 0,
++                                                          frames_ctx->device_ctx,
++                                                          hwaccel->free_frame_priv);
++    } else {
++        *hwaccel_picture_private = ff_refstruct_allocz(hwaccel->frame_priv_data_size);
++    }
++
+     if (!*hwaccel_picture_private)
+         return AVERROR(ENOMEM);
+ 
+-- 
+1.8.3.1

--- a/mingw-w64-ffmpeg/PKGBUILD
+++ b/mingw-w64-ffmpeg/PKGBUILD
@@ -69,14 +69,16 @@ source=(https://ffmpeg.org/releases/${_realname}-${pkgver}.tar.xz{,.asc}
         "pathtools.c"
         "pathtools.h"
         "0005-Win32-Add-path-relocation-to-frei0r-plugins-search.patch"
-        "0009-wrong-null-type.patch")
+        "0009-wrong-null-type.patch"
+        "0015-guard-null-hw-frames-ctx.patch")
 validpgpkeys=('FCF986EA15E6E293A5644F10B4322F04D67658D8')
 sha256sums=('488c76e57dd9b3bee901f71d5c95eaf1db4a5a31fe46a28654e837144207c270'
             'SKIP'
             'ebf471173f5ee9c4416c10a78760cea8afaf1a4a6e653977321e8547ce7bf3c0'
             '1585ef1b61cf53a2ca27049c11d49e0834683dfda798f03547761375df482a90'
             '8c74e9b5800dbb41c33a60114712726ec768ad6de8f147c2eb30656fd4c899cc'
-            'f76048e6e1944e15f646a52b75e75bc8906ca80f2a3124fba6a2050722750447')
+            'f76048e6e1944e15f646a52b75e75bc8906ca80f2a3124fba6a2050722750447'
+            'ddad247ff44287b5d0089b5b910b4ba0272404c71b2ffb127e3cf833e8b1cb74')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -100,6 +102,9 @@ prepare() {
     0005-Win32-Add-path-relocation-to-frei0r-plugins-search.patch
 
   apply_patch_with_msg 0009-wrong-null-type.patch
+
+  # https://github.com/msys2/MINGW-packages/pull/19050#issuecomment-1810884473
+  apply_patch_with_msg 0015-guard-null-hw-frames-ctx.patch
 }
 
 build() {

--- a/mingw-w64-ffmpeg/PKGBUILD
+++ b/mingw-w64-ffmpeg/PKGBUILD
@@ -6,7 +6,7 @@
 _realname=ffmpeg
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=6.0.1
+pkgver=6.1
 pkgrel=1
 pkgdesc="Complete solution to record, convert and stream audio and video (mingw-w64)"
 arch=('any')
@@ -29,17 +29,18 @@ depends=("${MINGW_PACKAGE_PREFIX}-aom"
          "${MINGW_PACKAGE_PREFIX}-libexif"
          "${MINGW_PACKAGE_PREFIX}-libgme"
          "${MINGW_PACKAGE_PREFIX}-libiconv"
-         $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || echo "${MINGW_PACKAGE_PREFIX}-libmfx")
          "${MINGW_PACKAGE_PREFIX}-libmodplug"
          "${MINGW_PACKAGE_PREFIX}-libssh"
          "${MINGW_PACKAGE_PREFIX}-libplacebo"
          "${MINGW_PACKAGE_PREFIX}-librsvg"
          "${MINGW_PACKAGE_PREFIX}-libsoxr"
          "${MINGW_PACKAGE_PREFIX}-libtheora"
+         "${MINGW_PACKAGE_PREFIX}-libva"
          "${MINGW_PACKAGE_PREFIX}-libvorbis"
          "${MINGW_PACKAGE_PREFIX}-libvpx"
          "${MINGW_PACKAGE_PREFIX}-libwebp"
          "${MINGW_PACKAGE_PREFIX}-libxml2"
+         "${MINGW_PACKAGE_PREFIX}-onevpl"
          "${MINGW_PACKAGE_PREFIX}-openal"
          "${MINGW_PACKAGE_PREFIX}-opencore-amr"
          "${MINGW_PACKAGE_PREFIX}-openjpeg2"
@@ -68,14 +69,14 @@ source=(https://ffmpeg.org/releases/${_realname}-${pkgver}.tar.xz{,.asc}
         "pathtools.c"
         "pathtools.h"
         "0005-Win32-Add-path-relocation-to-frei0r-plugins-search.patch"
-        "https://github.com/FFmpeg/FFmpeg/commit/182663a58a7a099e02e76da3b0f96d63e5c26a6d.patch")
+        "0009-wrong-null-type.patch")
 validpgpkeys=('FCF986EA15E6E293A5644F10B4322F04D67658D8')
-sha256sums=('9b16b8731d78e596b4be0d720428ca42df642bb2d78342881ff7f5bc29fc9623'
+sha256sums=('488c76e57dd9b3bee901f71d5c95eaf1db4a5a31fe46a28654e837144207c270'
             'SKIP'
             'ebf471173f5ee9c4416c10a78760cea8afaf1a4a6e653977321e8547ce7bf3c0'
             '1585ef1b61cf53a2ca27049c11d49e0834683dfda798f03547761375df482a90'
             '8c74e9b5800dbb41c33a60114712726ec768ad6de8f147c2eb30656fd4c899cc'
-            '7ed3d72fccc70789c4ba01fa870a8d83e1321487d891ce54f04b9f87778603d0')
+            'f76048e6e1944e15f646a52b75e75bc8906ca80f2a3124fba6a2050722750447')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -96,8 +97,9 @@ prepare() {
   cp -fHv "${srcdir}"/pathtools.[ch] libavfilter/
 
   apply_patch_with_msg \
-    0005-Win32-Add-path-relocation-to-frei0r-plugins-search.patch \
-    182663a58a7a099e02e76da3b0f96d63e5c26a6d.patch
+    0005-Win32-Add-path-relocation-to-frei0r-plugins-search.patch
+
+  apply_patch_with_msg 0009-wrong-null-type.patch
 }
 
 build() {
@@ -155,6 +157,7 @@ build() {
     --enable-vulkan
     --enable-zlib
     --enable-librav1e
+    --enable-libvpl
   )
 
   if [[ "${CARCH}" != "i686" ]]; then
@@ -165,7 +168,6 @@ build() {
 
   if [[ "${MINGW_PACKAGE_PREFIX}" != *clang-aarch64* ]]; then
     common_config+=(
-        --enable-libmfx
         --enable-amf
         --enable-nvenc
     )


### PR DESCRIPTION
* Remove patch included in the release
* Add libva dependency, changelog mentions this should be supported now
* Replace libmfx with libvpl since, " libmfx is deprecated. Please run configure with --enable-libvpl to use libvpl instead."
* Add a patch to fix the clang32 build (the usual VK_NULL_HANDLE != NULL issue)