### PR TITLE
Add libaribcaption 1.1.1

### DIFF
--- a/mingw-w64-libaribcaption/PKGBUILD
+++ b/mingw-w64-libaribcaption/PKGBUILD
@@ -1,0 +1,53 @@
+
+# Maintainer: Christoph Reiter <reiter.christoph@gmail.com>
+
+_realname=libaribcaption
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.1.1
+pkgrel=1
+pkgdesc="Portable ARIB STD-B24 Caption Decoder/Renderer (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm6')
+url='https://github.com/xqq/libaribcaption'
+license=('spdx:MIT')
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-gcc-libs"
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+  "${MINGW_PACKAGE_PREFIX}-ninja"
+  "${MINGW_PACKAGE_PREFIX}-cc"
+)
+source=("https://github.com/xqq/libaribcaption/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('278d03a0a662d00a46178afc64f32535ede2d78c603842b6fd1c55fa9cd44683')
+
+build() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
+
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    "${MINGW_PREFIX}"/bin/cmake.exe \
+      -GNinja \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      "${extra_config[@]}" \
+      -DBUILD_SHARED_LIBS=ON \
+      ../${_realname}-${pkgver}
+
+  "${MINGW_PREFIX}"/bin/cmake.exe --build .
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
This seems to be a replacement for aribb24, at least ffmpeg can use it instead of aribb24, and it is maintained.