### PR TITLE
suitesparse: Fix relocation issue with GraphBLAS JIT compiler

### DIFF
--- a/mingw-w64-suitesparse/PKGBUILD
+++ b/mingw-w64-suitesparse/PKGBUILD
@@ -4,7 +4,7 @@ _realname=suitesparse
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-suitesparse")
 pkgver=7.3.1
-pkgrel=1
+pkgrel=2
 pkgdesc='A suite of sparse matrix algorithms (mingw-w64)'
 url="https://faculty.cse.tamu.edu/davis/suitesparse.html"
 license=('spdx:LGPL-3.0-or-later AND BSD-3-Clause AND LGPL-2.1-or-later AND GPL-2.0-or-later AND LGPL-2.0-or-later AND Apache-2.0 AND GPL-3.0-or-later')
@@ -18,8 +18,10 @@ depends=("${MINGW_PACKAGE_PREFIX}-openblas"
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
-source=(${_realname}-${pkgver}.tar.gz::"https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/v${pkgver}.tar.gz")
-sha256sums=('b512484396a80750acf3082adc1807ba0aabb103c2e09be5691f46f14d0a9718')
+source=(${_realname}-${pkgver}.tar.gz::"https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/v${pkgver}.tar.gz"
+        0001-relocate-jit-compiler.patch::https://github.com/DrTimothyAldenDavis/SuiteSparse/commit/c697550beb30046c5078c318f2d7e58751b5b2fd.patch)
+sha256sums=('b512484396a80750acf3082adc1807ba0aabb103c2e09be5691f46f14d0a9718'
+            'df1e5a59d8eb6cd56dbd6f590c743c39f8afbc7aea721c9db84c6bc683b65d97')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -30,7 +32,10 @@ apply_patch_with_msg() {
 }
 
 prepare() {
-  cd ${srcdir}
+  cd ${srcdir}/${_realname}-${pkgver}
+
+  apply_patch_with_msg \
+    0001-relocate-jit-compiler.patch
 }
 
 build() {


### PR DESCRIPTION
There is a relocation issue when it comes to the path to the compiler that is used for the JIT compilation in GraphBLAS. (Sorry, I didn't notice before. I accidentally tested with a locally compiled library without realizing.)

This should be fixed by cherry-picking the upstreamed change.
