### PR TITLE
cmake: fix openmp v5.1 support

### DIFF
--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -12,7 +12,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
            "${MINGW_PACKAGE_PREFIX}-${_realname}-gui" \
            "${MINGW_PACKAGE_PREFIX}-${_realname}-docs"))
 pkgver=3.27.7
-pkgrel=2
+pkgrel=3
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -50,13 +50,15 @@ source=("https://github.com/Kitware/CMake/releases/download/v${pkgver}/${_realna
         "0002-Do-not-install-Qt-bundle-in-cmake-gui.patch"
         "0003-Fix-FindGLEW-on-MINGW.patch::https://gitlab.kitware.com/cmake/cmake/-/commit/a37a04b5.patch"
         "0004-Output-line-numbers-in-callstacks.patch"
-        "0005-Default-to-ninja-generator.patch")
+        "0005-Default-to-ninja-generator.patch"
+        "https://gitlab.kitware.com/cmake/cmake/-/merge_requests/8965.patch")
 sha256sums=('08f71a106036bf051f692760ef9558c0577c42ac39e96ba097e7662bd4158d8e'
             '25793edcbac05bb6d17fa9947b52ace4a6b5ccccf7758e22ae9ae022ed089061'
             'f6cf6a6f2729db2b9427679acd09520af2cd79fc26900b19a49cead05a55cd1a'
             'e0688d5488b2dc6e10b4e0ff2f1303fe27f42a13fa2f4bc23799eff8b0f163bd'
             '15fdf3fb1a0f1c153c8cfbdd2b5c64035b7a04de618bfe61d7d74ced0d6a5c4b'
-            '426818278090704d2a12f62ef3dfd94c47b11fa2784bb842989b7f6a09ee7aa2')
+            '426818278090704d2a12f62ef3dfd94c47b11fa2784bb842989b7f6a09ee7aa2'
+            'eb7c10a79d87d95b79fb0ccfad7b1268aa8f8b70119a297d012f527518a1699c')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -84,6 +86,9 @@ prepare() {
     0002-Do-not-install-Qt-bundle-in-cmake-gui.patch \
     0003-Fix-FindGLEW-on-MINGW.patch \
     0004-Output-line-numbers-in-callstacks.patch
+
+  # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/8965
+  apply_patch_with_msg 8965.patch
 
   # We want cmake to default to something useful and not MSVC
   apply_patch_with_msg \


### PR DESCRIPTION
this makes FindOpenMP() set the openmp version again for clang environments.