### PR TITLE
wxwidgets3.2: Update to 3.2.4 and

### DIFF
--- a/mingw-w64-wxwidgets3.2/PKGBUILD
+++ b/mingw-w64-wxwidgets3.2/PKGBUILD
@@ -13,7 +13,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-common"
          "${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-gtk3-libs"
          "${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-msw"
          "${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-gtk3")
-pkgver=${_wx_basever}.3
+pkgver=${_wx_basever}.4
 pkgrel=1
 pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX (mingw-w64)"
 arch=('any')
@@ -43,7 +43,7 @@ source=(
   # the wxTeam rejected this patch
   005-wxWidgets-3.1.3-Remove-WX_LIBS_STATIC-from-m4.patch
 )
-sha256sums=('c170ab67c7e167387162276aea84e055ee58424486404bba692c401730d1a67a'
+sha256sums=('0640e1ab716db5af2ecb7389dbef6138d7679261fbff730d23845ba838ca133e'
             '2b3b183a6a76ad539abc49a41033aa923c13b395c0e55189ba962068781c7135'
             '4a4828f0c9cdc638cffde6a30b5dfb14283719acc9e89e19de8ec2d5a80a5aec')
 prepare() {
@@ -327,6 +327,14 @@ package_wxwidgets3.2-msw() {
   if [[ ${MINGW_CHOST} == aarch64-* ]]; then
     sed -s "s|\"-mthreads\"|\"\"|g" -i "${pkgdir}${MINGW_PREFIX}/bin/wx-config"
     sed -s "s|\"-mthreads\"|\"\"|g" -i "${pkgdir}${MINGW_PREFIX}/bin/wx-config-static"
+  fi
+
+  # CLANG gives warnings and in some cases errors on "-mwindows" option while building wxPython
+  if [[ ${MSYSTEM} == CLANG* ]]; then
+    sed -s "s| -mwindows||g" -i "${pkgdir}${MINGW_PREFIX}/bin/wx-config"
+    sed -s "s| -mwindows||g" -i "${pkgdir}${MINGW_PREFIX}/bin/wx-config-static"
+    sed -s "s| -mwindows||g" -i "${pkgdir}${MINGW_PREFIX}/lib/wx/config/msw-unicode-${_wx_basever}"
+    sed -s "s| -mwindows||g" -i "${pkgdir}${MINGW_PREFIX}/lib/wx/config/msw-unicode-static-${_wx_basever}"
   fi
 
   # create wx-config copy with version file suffix


### PR DESCRIPTION
add hack to fix wxPython CLANG builds.