### PR TITLE
keepassxc: fix license syntax and add repository url

### DIFF
--- a/mingw-w64-keepassxc/PKGBUILD
+++ b/mingw-w64-keepassxc/PKGBUILD
@@ -9,7 +9,7 @@ pkgdesc="A modern, secure, and open-source password manager that stores and mana
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://keepassxc.org/'
-license=('spdx:GPL-2.0, spdx:GPL-3.0')
+license=('spdx:GPL-2.0 OR GPL-3.0')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cc"

--- a/mingw-w64-keepassxc/PKGBUILD
+++ b/mingw-w64-keepassxc/PKGBUILD
@@ -9,6 +9,7 @@ pkgdesc="A modern, secure, and open-source password manager that stores and mana
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url='https://keepassxc.org/'
+msys2_repository_url='https://github.com/keepassxreboot/keepassxc'
 license=('spdx:GPL-2.0 OR GPL-3.0')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"


### PR DESCRIPTION
Incorrect syntax caused it to display as:

![1](https://github.com/msys2/MINGW-packages/assets/50107074/f2865e64-5aa8-4e84-97ea-c64146db2b55)

Also added repository url.