### PR TITLE
Next attempt to build sundials for Windows on ARM

### DIFF
--- a/mingw-w64-octave/PKGBUILD
+++ b/mingw-w64-octave/PKGBUILD
@@ -23,7 +23,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-pcre2"
          "${MINGW_PACKAGE_PREFIX}-qhull"
          "${MINGW_PACKAGE_PREFIX}-suitesparse"
-         $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || echo "${MINGW_PACKAGE_PREFIX}-sundials")
+         "${MINGW_PACKAGE_PREFIX}-sundials"
          "${MINGW_PACKAGE_PREFIX}-qrupdate"
          "${MINGW_PACKAGE_PREFIX}-qscintilla-qt5"
          "${MINGW_PACKAGE_PREFIX}-qt5-tools")

--- a/mingw-w64-sundials/PKGBUILD
+++ b/mingw-w64-sundials/PKGBUILD
@@ -4,20 +4,19 @@ _realname=sundials
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=6.6.2
-pkgrel=1
+pkgrel=2
 pkgdesc="SUite of Nonlinear and DIfferential/ALgebraic equation Solvers (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://computing.llnl.gov/projects/sundials"
 license=('spdx:BSD-3-Clause')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
-         $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran")
-         "${MINGW_PACKAGE_PREFIX}-msmpi"
+         $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || echo "${MINGW_PACKAGE_PREFIX}-msmpi")
          "${MINGW_PACKAGE_PREFIX}-openblas"
          "${MINGW_PACKAGE_PREFIX}-omp"
-         "${MINGW_PACKAGE_PREFIX}-petsc"
+         $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || echo "${MINGW_PACKAGE_PREFIX}-petsc")
          "${MINGW_PACKAGE_PREFIX}-suitesparse"
-         "${MINGW_PACKAGE_PREFIX}-superlu_dist")
+         $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || echo "${MINGW_PACKAGE_PREFIX}-superlu_dist"))
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake")
 optdepends=("${MINGW_PACKAGE_PREFIX}-python: for running examples")
@@ -51,7 +50,7 @@ prepare() {
     0008-sundials-petsc-pkg-config-module.patch
 }
 
-petsc_arch=dmo
+_petsc_arch=dmo
 
 build() {
   [[ -d build-${MSYSTEM} ]] && rm -rf build-${MSYSTEM}
@@ -67,6 +66,28 @@ build() {
     export FFLAGS="-Qunused-arguments"
   fi
 
+  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]]; then
+    # There are currently no msmpi libraries for Windows on ARM.
+    # See: https://github.com/microsoft/Microsoft-MPI/issues/66
+    # Dont' build the features that require msmpi.
+    _extra_config+=("-DENABLE_MPI=OFF"
+                    "-DENABLE_PETSC=OFF"
+                    "-DENABLE_SUPERLUDIST=OFF")
+  else
+    _extra_config+=("-DBUILD_NVECTOR_MPIMANYVECTOR=ON"
+                    "-DBUILD_NVECTOR_MPIPLUSX=ON"
+                    "-DBUILD_NVECTOR_PARALLEL=ON"
+                    "-DENABLE_MPI=ON"
+                    "-DENABLE_PETSC=ON"
+                    "-DENABLE_SUPERLUDIST=ON"
+                    "-DPETSC_PKG_CONFIG_MODULE=petsc-${_petsc_arch}"
+                    "-DSUNDIALS_LOGGING_ENABLE_MPI=OFF"
+                    "-DSUPERLUDIST_INCLUDE_DIRS=${MINGW_PREFIX}/include/superlu_dist"
+                    "-DSUPERLUDIST_CONFIG_PATH=${MINGW_PREFIX}/include/superlu_dist/superlu_dist_config.h"
+                    "-DSUPERLUDIST_INDEX_SIZE=32"
+                    "-DSUPERLUDIST_OpenMP=ON")
+  fi
+
   I_MPI_ROOT="" \
   MSYS2_ARG_CONV_EXCL="CMAKE_INSTALL_PREFIX=;EXAMPLES_INSTALL_PATH=" \
   ${MINGW_PREFIX}/bin/cmake \
@@ -78,10 +99,7 @@ build() {
     -D BUILD_IDAS=ON \
     -D BUILD_KINSOL=ON \
     -D BUILD_NVECTOR_MANYVECTOR=ON \
-    -D BUILD_NVECTOR_MPIMANYVECTOR=ON \
-    -D BUILD_NVECTOR_MPIPLUSX=ON \
     -D BUILD_NVECTOR_OPENMP=ON \
-    -D BUILD_NVECTOR_PARALLEL=ON \
     -D BUILD_NVECTOR_PTHREADS=ON \
     -D BUILD_SHARED_LIBS=ON \
     -D BUILD_STATIC_LIBS=ON \
@@ -100,13 +118,10 @@ build() {
     -D ENABLE_KLU=ON \
     -D ENABLE_LAPACK=ON \
     -D ENABLE_MAGMA=OFF \
-    -D ENABLE_MPI=ON \
     -D ENABLE_OPENMP=ON \
     -D ENABLE_OPENMP_DEVICE=OFF \
-    -D ENABLE_PETSC=ON \
     -D ENABLE_PTHREAD=ON \
     -D ENABLE_RAJA=OFF \
-    -D ENABLE_SUPERLUDIST=ON \
     -D ENABLE_SUPERLUMT=OFF \
     -D ENABLE_SYCL=OFF \
     -D ENABLE_TRILINOS=OFF \
@@ -120,20 +135,13 @@ build() {
     -D LAPACK_LIBRARIES=${MINGW_PREFIX}/lib/libopenblas.dll.a \
     -D MPI_C_COMPILER=${MINGW_PREFIX}/bin/mpicc.exe \
     -D MPI_CXX_COMPILER=${MINGW_PREFIX}/bin/mpicxx.exe \
-    -D MPI_Fortran_COMPILER=${MINGW_PREFIX}/bin/mpifort.exe \
-    -D PETSC_PKG_CONFIG_MODULE=petsc-${petsc_arch} \
     -D SUITESPARSECONFIG_LIBRARY=${MINGW_PREFIX}/lib/libsuitesparseconfig.dll.a \
     -D SUNDIALS_BUILD_WITH_PROFILING=OFF \
     -D SUNDIALS_BUILD_WITH_MONITORING=ON \
     -D SUNDIALS_INDEX_SIZE=32 \
     -D SUNDIALS_PRECISION=DOUBLE \
-    -D SUNDIALS_LOGGING_ENABLE_MPI=OFF \
     -DSUNDIALS_F77_FUNC_CASE=LOWER \
     -DSUNDIALS_F77_FUNC_UNDERSCORES=ONE \
-    -D SUPERLUDIST_INCLUDE_DIRS=${MINGW_PREFIX}/include/superlu_dist \
-    -D SUPERLUDIST_CONFIG_PATH=${MINGW_PREFIX}/include/superlu_dist/superlu_dist_config.h \
-    -D SUPERLUDIST_INDEX_SIZE=32 \
-    -D SUPERLUDIST_OpenMP=ON \
     -B build-${MSYSTEM} \
     -S ${_realname}-${pkgver}
 


### PR DESCRIPTION
I *think* I got rid of all dependencies that require MSMPI. But I can't actually test on Windows on ARM (because I don't have access to it).
I just checked if that configuration would build for a MINGW64 environment. It does and all checks still pass.

There should be no functional difference for the already distributed binaries.