### PR TITLE
gst-plugins-rs: Update to 1.22.7

### DIFF
--- a/mingw-w64-gst-plugins-rs/PKGBUILD
+++ b/mingw-w64-gst-plugins-rs/PKGBUILD
@@ -5,9 +5,9 @@ pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgdesc='GStreamer plugins written in Rust (mingw-w64)' 
 url="https://gitlab.freedesktop.org/gstreamer/$_realname"
-pkgver=0.11.0
-_tag=$pkgver+fixup
-pkgrel=2
+pkgver=1.22.7
+_tag=gstreamer-$pkgver
+pkgrel=1
 license=('spdx:LGPL-3.0-or-later'
          'spdx:Apache-2.0'
          'spdx:MIT'
@@ -22,12 +22,13 @@ depends=(${MINGW_PACKAGE_PREFIX}-gtk4
 makedepends=(${MINGW_PACKAGE_PREFIX}-pkgconf
              ${MINGW_PACKAGE_PREFIX}-rust
              ${MINGW_PACKAGE_PREFIX}-cargo-c)
-source=("$url/-/archive/$_tag/$_realname-$_tag.tar.bz2")
-sha256sums=('7e9e1dbf2ad649926523b05a46bf5b26f4a8bf113d88723174842c2685f6dbcd')
+source=("$url/-/archive/$_tag/$_realname-gstreamer-$_tag.tar.bz2")
+sha256sums=('e819ae85963c39cf2e7d7d8681aa60cb2f40e56268880f1c33fbd70cfab7ea12')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
 arch=(any)
 
 prepare() {
+  mv "$_realname-$_tag-"* "$_realname-$_tag"
   cd $_realname-$_tag
   cargo fetch
 }

--- a/mingw-w64-gst-plugins-rs/PKGBUILD
+++ b/mingw-w64-gst-plugins-rs/PKGBUILD
@@ -17,7 +17,6 @@ depends=(${MINGW_PACKAGE_PREFIX}-gtk4
          ${MINGW_PACKAGE_PREFIX}-gstreamer
          ${MINGW_PACKAGE_PREFIX}-gst-plugins-base
          ${MINGW_PACKAGE_PREFIX}-gst-plugins-bad-libs
-         ${MINGW_PACKAGE_PREFIX}-dav1d
          ${MINGW_PACKAGE_PREFIX}-libwebp)
 makedepends=(${MINGW_PACKAGE_PREFIX}-pkgconf
              ${MINGW_PACKAGE_PREFIX}-rust
@@ -39,6 +38,7 @@ _cargo_opts=(--workspace
              --library-type=cdylib
              --prefix="${MINGW_PREFIX}"
              --exclude gst-plugin-csound
+             --exclude gst-plugin-dav1d  # not compatiple with dav1d 1.3.0 yet
              --exclude gst-plugin-aws)
 
 build() {


### PR DESCRIPTION
Move to the release tags using the general gstreamer version.

disable dav1d for now: Package 'dav1d' has version '1.3.0', required version is '<= 1.2.1'