### PR TITLE
mingw-w64-pidgin: Updated to 2.14.12

### DIFF
--- a/mingw-w64-pidgin/PKGBUILD
+++ b/mingw-w64-pidgin/PKGBUILD
@@ -4,8 +4,8 @@
 _realname='pidgin'
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.14.10
-pkgrel=2
+pkgver=2.14.12
+pkgrel=1
 pkgdesc='Multi-protocol instant messaging client (mingw-w64)'
 url='https://pidgin.im'
 license=(GPL2 partial:'GPL2+') # GPL2+, but Novell and SILC are GPL2-only
@@ -15,7 +15,7 @@ source=("https://downloads.sourceforge.net/${_realname}/${_realname}-${pkgver}.t
         001-autotools-and-fhs.patch
         002-build-fixes.patch
         003-build-fixes.patch)
-sha256sums=('454b1b928bc6bcbb183353af30fbfde5595f2245a3423a1a46e6c97a2df22810'
+sha256sums=('2b05246be208605edbb93ae9edc079583d449e2a9710db6d348d17f59020a4b7'
             'SKIP'
             '5852d78f97e344226e598f2342b7a1b276f25eec71903bacdc9f68849804df85'
             'bdc8fc0e707206ec340711c25c7ef5be453be1cff93b1678908ebe71907600d7'


### PR DESCRIPTION
Changelog from upstream: Remove a string from the Romanian translation that’s breaking iconv on Windows.