### PR TITLE
faad2: Update to 2.11.1

### DIFF
--- a/mingw-w64-faad2/PKGBUILD
+++ b/mingw-w64-faad2/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=faad2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.11.0
+pkgver=2.11.1
 pkgrel=1
 pkgdesc="ISO AAC audio decoder (mingw-w64)"
 arch=('any')
@@ -15,7 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/knik0/${_realname}/archive/${pkgver}.tar.gz")
-sha256sums=('720c1dc404439e0a9117aa144dc7ead56f1658adf4badbb39f959d6ad8eed489')
+sha256sums=('72dbc0494de9ee38d240f670eccf2b10ef715fd0508c305532ca3def3225bb06')
 
 build() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -59,6 +59,4 @@ package() {
 
   cd "${srcdir}/build-${MSYSTEM}-shared"
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install .
-
-  install -Dm644  "${srcdir}/${_realname}-${pkgver}/frontend/faad.man" "${pkgdir}${MINGW_PREFIX}/share/man/man1/faad.1"
 }


### PR DESCRIPTION
the missing man page has been fixed upstream, so remove that workaround