### PR TITLE
libva: add relocation support for the default drivers path

### DIFF
--- a/mingw-w64-libva/0001-libva-add-driver-path-relocation.patch
+++ b/mingw-w64-libva/0001-libva-add-driver-path-relocation.patch
@@ -1,0 +1,53 @@
+--- libva-2.20.0/va/va.c.orig	2023-09-14 10:04:13.000000000 +0200
++++ libva-2.20.0/va/va.c	2023-11-14 21:13:59.128325000 +0100
+@@ -370,6 +370,28 @@
+     return driver_path;
+ }
+ 
++#ifdef __MINGW32__
++static char *getDLLPath()
++{
++    HMODULE hModule;
++    if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, (LPCSTR)&getDLLPath, &hModule)) {
++        char *modulePath = (char *)malloc(MAX_PATH);
++        if (modulePath == NULL) {
++            return NULL;
++        }
++        if (GetModuleFileNameA(hModule, modulePath, MAX_PATH) > 0) {
++            char *lastBackslash = strrchr(modulePath, '\\');
++            if (lastBackslash) {
++                *lastBackslash = '\0';
++                return modulePath;
++            }
++        }
++        free(modulePath);
++    }
++    return NULL;
++}
++#endif
++
+ static VAStatus va_openDriver(VADisplay dpy, char *driver_name)
+ {
+     VADriverContextP ctx = CTX(dpy);
+@@ -381,10 +403,21 @@
+     if (geteuid() == getuid())
+         /* don't allow setuid apps to use LIBVA_DRIVERS_PATH */
+         search_path = secure_getenv("LIBVA_DRIVERS_PATH");
++#ifdef __MINGW32__
++    if (!search_path) {
++        search_path = getDLLPath();
++        if (!search_path) {
++            va_errorMessage(dpy, "Failed to detect drivers path\n");
++            return VA_STATUS_ERROR_OPERATION_FAILED;
++        }
++    } else
++        search_path = strdup((const char *)search_path);
++#else
+     if (!search_path)
+         search_path = VA_DRIVERS_PATH;
+ 
+     search_path = strdup((const char *)search_path);
++#endif
+     if (!search_path) {
+         va_errorMessage(dpy, "%s L%d Out of memory\n",
+                         __FUNCTION__, __LINE__);

--- a/mingw-w64-libva/PKGBUILD
+++ b/mingw-w64-libva/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libva
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.20.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Video Acceleration (VA) API (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -13,11 +13,15 @@ license=('spdx:MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cc")
-source=("${_realname}-${pkgver}.tar.gz::https://github.com/intel/libva/archive/refs/tags/${pkgver}.tar.gz")
-sha256sums=('117f8d658a5fc9ea406ca80a3eb4ae1d70b15a54807c9ed77199c812bed73b60')
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/intel/libva/archive/refs/tags/${pkgver}.tar.gz"
+        "0001-libva-add-driver-path-relocation.patch")
+sha256sums=('117f8d658a5fc9ea406ca80a3eb4ae1d70b15a54807c9ed77199c812bed73b60'
+            '1cc40ae0b25f462fa0cb4c4717ea7728e8ff0d83c13197035525ff76c0947ad3')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
+
+  patch -Np1 -i "${srcdir}/0001-libva-add-driver-path-relocation.patch"
 }
 
 build() {


### PR DESCRIPTION
needs mesa installed

```console
$ vainfo.exe
Trying display: win32
libva info: VA-API version 1.20.0
libva info: Trying to open C:\msys64\ucrt64\bin\vaon12_drv_video.dll
libva info: Found init function __vaDriverInit_1_20
libva info: va_openDriver() returns 0
C:\msys64\ucrt64\bin\vainfo.exe: VA-API version: 1.20 (libva 2.20.0)
C:\msys64\ucrt64\bin\vainfo.exe: Driver version: Mesa Gallium driver 23.2.1 for D3D12 (Radeon RX 590 Series)
C:\msys64\ucrt64\bin\vainfo.exe: Supported profile and entrypoints
      VAProfileH264ConstrainedBaseline: VAEntrypointVLD
      VAProfileH264Main               : VAEntrypointVLD
      VAProfileH264High               : VAEntrypointVLD
      VAProfileHEVCMain               : VAEntrypointVLD
      VAProfileHEVCMain10             : VAEntrypointVLD
      VAProfileNone                   : VAEntrypointVideoProc
```