### PR TITLE
libvips: update to 8.15.0

### DIFF
--- a/mingw-w64-libvips/PKGBUILD
+++ b/mingw-w64-libvips/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libvips
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=8.14.5
+pkgver=8.15.0
 pkgrel=1
 pkgdesc="A fast image processing library with low memory needs (mingw-w64)"
 arch=('any')
@@ -33,9 +33,10 @@ depends=("${MINGW_PACKAGE_PREFIX}-cairo"
          "${MINGW_PACKAGE_PREFIX}-fftw"
          "${MINGW_PACKAGE_PREFIX}-glib2"
          "${MINGW_PACKAGE_PREFIX}-gobject-introspection-runtime"
+         "${MINGW_PACKAGE_PREFIX}-highway"
          "${MINGW_PACKAGE_PREFIX}-lcms2"
+         "${MINGW_PACKAGE_PREFIX}-libarchive"
          "${MINGW_PACKAGE_PREFIX}-libexif"
-         "${MINGW_PACKAGE_PREFIX}-libgsf"
          "${MINGW_PACKAGE_PREFIX}-libimagequant"
          "${MINGW_PACKAGE_PREFIX}-libpng"
          "${MINGW_PACKAGE_PREFIX}-librsvg"
@@ -44,10 +45,9 @@ depends=("${MINGW_PACKAGE_PREFIX}-cairo"
          "${MINGW_PACKAGE_PREFIX}-matio"
          "${MINGW_PACKAGE_PREFIX}-openexr"
          "${MINGW_PACKAGE_PREFIX}-openjpeg2"
-         "${MINGW_PACKAGE_PREFIX}-orc"
          "${MINGW_PACKAGE_PREFIX}-pango")
 source=("https://github.com/libvips/libvips/releases/download/v${pkgver}/vips-${pkgver}.tar.xz")
-sha256sums=('90374e9f6fbd5657b5faf306cacda20658d6144d385316b59b865bc1a487b68d')
+sha256sums=('d33f81c6ab4bd1faeedc36dc32f880b19e9d5ff69b502e59d175332dfb8f63f1')
 
 prepare() {
   cd "${srcdir}/vips-${pkgver}"
@@ -75,4 +75,7 @@ package() {
   cd "${srcdir}/build-${MSYSTEM}"
 
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/meson.exe install
+  
+  shopt -s globstar
+  rm ${pkgdir}${MINGW_PREFIX}/**/vips-modules-*/*.dll.a
 }


### PR DESCRIPTION
Hm, [the `.dll.a` import stubs are again being created although `shared_module()` is used](https://github.com/mesonbuild/meson/issues/12372), so this [might not be limited to meson-python](https://github.com/msys2/MINGW-packages/pull/18706#issuecomment-1747098489)...

P.S. Also seems to be the case w/ babl, gimp, and gdk-pixbuf among others.