### PR TITLE
libgcrypt: Update to 1.10.3

### DIFF
--- a/mingw-w64-libgcrypt/PKGBUILD
+++ b/mingw-w64-libgcrypt/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=libgcrypt
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.10.2
+pkgver=1.10.3
 pkgrel=1
 pkgdesc="General purpose cryptographic library based on the code from GnuPG (mingw-w64)"
 arch=('any')
@@ -20,11 +20,11 @@ source=("https://gnupg.org/ftp/gcrypt/libgcrypt/${_realname}-${pkgver}.tar.bz2"{
         'libgcrypt-use-correct-def-file.patch'
         'Smarter-fig2dev-detection.all.patch')
 # https://gnupg.org/signature_key.html
-validpgpkeys=('D8692123C4065DEA5E0F3AB5249B39D24F25E3B6'
-              '031EC2536E580D8EA286A9F22071B08A33BD3F06'
-              '5B80C5754298F0CB55D8ED6ABCEF7E294B092E28'
-              '6DAA6E64A76D2840571B4902528897B826403ADA')
-sha256sums=('3b9c02a004b68c256add99701de00b383accccf37177e0d6c58289664cce0c03'
+validpgpkeys=('5B80C5754298F0CB55D8ED6ABCEF7E294B092E28'  # Andre Heinecke (Release Signing Key)
+              '6DAA6E64A76D2840571B4902528897B826403ADA'  # Werner Koch (dist signing 2020)
+              'AC8E115BF73E2D8D47FA9908E98E9B2D19C6C8BD'  # Niibe Yutaka (GnuPG Release Key)
+              '02F38DFF731FF97CB039A1DA549E695E905BA208') # GnuPG.com (Release Signing Key 2021)
+sha256sums=('8b0870897ac5ac67ded568dcfadf45969cfa8a6beb0fd60af2a9eadc2a3272aa'
             'SKIP'
             '55cf915badebb4b3cfa671eea725aebb77be791aa39a19caef090ded4f38d8eb'
             'd6855fc9b7a3a7fa440be1d9ae3477f8c08524d1aab1a8c7bb26d62b55382f72')


### PR DESCRIPTION
and refresh the active signing key list based on
https://gnupg.org/signature_key.html