### PR TITLE
wireshark: Update to 4.2.0

### DIFF
--- a/mingw-w64-wireshark/PKGBUILD
+++ b/mingw-w64-wireshark/PKGBUILD
@@ -1,10 +1,9 @@
 # Maintainer: Wireshark Core Team <wireshark-dev@wireshark.org>
 
 _realname=wireshark
-_commit=1c32e4b2521c30f3c2d778d0a489933f7f7bcda1
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=4.2.0rc0.r13.g1c32e4b252
+pkgver=4.2.0
 pkgrel=1
 pkgdesc="Network traffic and protocol analyzer/sniffer (mingw-w64)"
 arch=('any')
@@ -27,6 +26,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-bcg729"
          "${MINGW_PACKAGE_PREFIX}-lz4"
          "${MINGW_PACKAGE_PREFIX}-minizip"
          "${MINGW_PACKAGE_PREFIX}-nghttp2"
+         "${MINGW_PACKAGE_PREFIX}-nghttp3"
          "${MINGW_PACKAGE_PREFIX}-opencore-amr"
          "${MINGW_PACKAGE_PREFIX}-opus"
          "${MINGW_PACKAGE_PREFIX}-pcre2"
@@ -43,18 +43,11 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python"
-             "${MINGW_PACKAGE_PREFIX}-qt6-tools"
-             'git')
+             "${MINGW_PACKAGE_PREFIX}-qt6-tools")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest"
               "${MINGW_PACKAGE_PREFIX}-python-pytest-xdist")
-source=("${_realname}"::"git+https://gitlab.com/wireshark/wireshark.git#commit=${_commit}")
-sha256sums=('SKIP')
-
-pkgver() {
-  cd "${_realname}"
-
-  git describe --long "${_commit}" | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g;s/^v//g'
-}
+source=("https://www.wireshark.org/download/src/${_realname}-${pkgver}.tar.xz")
+sha256sums=('0e428492f4c3625d61a7ccff008dc0e429d16ab8caccad4403157ea92b48a75b')
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
@@ -83,7 +76,7 @@ build() {
       -GNinja \
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       "${extra_config[@]}" \
-      ../${_realname}
+      ../${_realname}-${pkgver}
 
   "${MINGW_PREFIX}"/bin/cmake.exe --build .
 }
@@ -101,5 +94,5 @@ package() {
   DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
   DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install . --component Development
 
-  install -Dm644 "${srcdir}/${_realname}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }


### PR DESCRIPTION
Switch-over the package to build from a tarball.

Also add new dependency nghttp3.