### PR TITLE
CI: Run package-grokker on both ucrt64 and clang64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,17 +158,26 @@ jobs:
   package-grokker:
     runs-on: ubuntu-latest
     needs: build
+    name: package-grokker-${{ matrix.msystem }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - msystem: UCRT64
+            repo: ucrt64
+          - msystem: CLANG64
+            repo: clang64
 
     steps:
       - uses: actions/download-artifact@v3
         id: artifacts
         continue-on-error: true
         with:
-          name: UCRT64-packages
+          name: ${{ matrix.msystem }}-packages
           path: artifacts
       - name: Grok packages
         uses: jeremyd2019/package-grokker/grok-artifacts@main
         if: steps.artifacts.outcome == 'success'
         with:
-          repo: ucrt64
+          repo: ${{ matrix.repo }}
           path: artifacts


### PR DESCRIPTION
Or should it run on all environments?