### PR TITLE
python-jellyfish: update to 1.0.3

### DIFF
--- a/mingw-w64-python-jellyfish/PKGBUILD
+++ b/mingw-w64-python-jellyfish/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=jellyfish
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
-pkgver=1.0.0
-pkgrel=3
+pkgver=1.0.3
+pkgrel=1
 pkgdesc='A python library for doing approximate and phonetic matching of strings (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -19,31 +19,12 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-maturin"
              "${MINGW_PACKAGE_PREFIX}-rust")
 source=("https://files.pythonhosted.org/packages/source/j/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('881aae3671999bb07ce50c27696f29ca7e842f3e123acc0db6525c9999881bd4')
+sha256sums=('ddb22b7155f208e088352283ee78cb4ef2d2067a76e148a8bb43d177f32b37d2')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
-  cargo vendor \
-    --locked \
-    --versioned-dirs
-
-  mkdir -p .cargo
-  cat >> .cargo/config.toml <<END
-
-[source.crates-io]
-replace-with = "vendored-sources"
-
-[source.vendored-sources]
-directory = "vendor"
-END
-
-
-  sed -i -e 's/"cfg(all(target_arch = \\"\([^\\]\+\)\\", target_env = \\"gnu\\", target_abi = \\"llvm\\", not(windows_raw_dylib)))"/"\1-pc-windows-gnullvm"/g' \
-    "vendor/windows-targets-0.48.0/Cargo.toml"
-  sed -i -e 's/\("Cargo.toml":\)"[^"]\+"/\1"'"$(sha256sum "vendor/windows-targets-0.48.0/Cargo.toml" | cut -d' ' -f1)"'"/' \
-    "vendor/windows-targets-0.48.0/.cargo-checksum.json"
-
+  cargo fetch --locked
 }
 
 build() {


### PR DESCRIPTION
removed windows-targets workaround