### PR TITLE
minidump-stackwalk: update to 0.19.1

### DIFF
--- a/mingw-w64-minidump-stackwalk/PKGBUILD
+++ b/mingw-w64-minidump-stackwalk/PKGBUILD
@@ -4,18 +4,18 @@ _realname=minidump-stackwalk
 _projectname=rust-minidump
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.18.0
+pkgver=0.19.1
 pkgrel=1
 pkgdesc="Provides both machine-readable and human-readable digests of a minidump, with backtraces and symbolication (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url='https://github.com/rust-minidump/rust-minidump/tree/main/minidump-stackwalk'
 license=('spdx:MIT')
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-rust"
 )
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/rust-minidump/rust-minidump/archive/v${pkgver}.tar.gz")
-sha256sums=('278af5c1d9da078c96bbba867e7c38096bd48ba328876e15525e74418b5dd5a7')
+sha256sums=('bf8d8f69318ff5687c48bd51623bd434a3210ed16c708a02be797c1f3003fe3f')
 
 prepare() {
   cp -r "${_projectname}-${pkgver}" "build-${MSYSTEM}"


### PR DESCRIPTION
it seems that we can enable arm64 there