### PR TITLE
python-maturin: update to 1.3.2

### DIFF
--- a/mingw-w64-python-maturin/PKGBUILD
+++ b/mingw-w64-python-maturin/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=maturin
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
-pkgver=1.3.1
+pkgver=1.3.2
 pkgrel=1
 pkgdesc='Build and publish crates with pyo3, rust-cpython and cffi bindings as well as rust binaries as python packages (mingw-w64)'
 url='https://github.com/pyo3/maturin'
@@ -23,7 +23,7 @@ makedepends=(
 options=(!strip)
 source=("https://pypi.io/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz"
         "001-fix-default-target-on-mingw-32bit.patch")
-sha256sums=('efa194e99ae5fff185263d8244acacb12ae256ea73aba62c9446f6075ffc7ac1'
+sha256sums=('952d458b3dea01e9670582ac2dff3c522a34e491f08ed6376b270655a68c24af'
             '5d363f2540f84651439f47782c9d60ababde58f7187b09945040f3795745bf45')
 
 prepare() {
@@ -35,13 +35,7 @@ prepare() {
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
 
-  # the features pull in "ring" which is not available on arm64
-  # https://github.com/msys2/MINGW-packages/pull/18245#issuecomment-1690765429
-  if [[ ${MSYSTEM} != CLANGARM64 ]]; then
-    # this is the default feature set in Cargo.toml
-    export MATURIN_SETUP_ARGS="--features full,rustls"
-  fi
-
+  export MATURIN_SETUP_ARGS="--features full,rustls"
   ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
 }
 


### PR DESCRIPTION
ring dependency is updated in this release, enabling its features for aarch64