### PR TITLE
msitools: Make DATADIR and LIBDIR relative to runtime installation location

### DIFF
--- a/mingw-w64-msitools/002-use-paths-relative-to-the-installation-prefix.patch
+++ b/mingw-w64-msitools/002-use-paths-relative-to-the-installation-prefix.patch
@@ -1,0 +1,50 @@
+--- msitools-0.103/meson.build
++++ msitools-0.103/meson.build
+@@ -23,8 +23,8 @@ config.set_quoted('PACKAGE_VERSION', meson.project_version())
+ config.set_quoted('PACKAGE_STRING', '@0@ @1@'.format(meson.project_name(), meson.project_version()))
+ config.set_quoted('GETTEXT_PACKAGE', meson.project_name())
+ config.set_quoted('PACKAGE_BUGREPORT', 'https://gitlab.gnome.org/GNOME/msitools/issues')
+-config.set_quoted('LOCALEDIR', get_option('prefix') / get_option('localedir'))
+-config.set_quoted('DATADIR', get_option('prefix') / get_option('datadir'))
++config.set_quoted('LOCALEDIR', get_option('localedir'))
++config.set_quoted('DATADIR', get_option('datadir'))
+ 
+ config_h = configure_file(
+   output: 'config.h',
+--- msitools-0.103/tools/msiextract.vala
++++ msitools-0.103/tools/msiextract.vala
+@@ -152,7 +152,9 @@ public void extract (string filename) throws GLib.Error {
+ }
+ 
+ public int main (string[] args) {
+-    Intl.bindtextdomain (Config.GETTEXT_PACKAGE, Config.LOCALEDIR);
++    string? prefix = Win32.get_package_installation_directory_of_module(null);
++
++    Intl.bindtextdomain (Config.GETTEXT_PACKAGE, Path.build_filename (prefix, Config.LOCALEDIR));
+     Intl.bind_textdomain_codeset (Config.GETTEXT_PACKAGE, "UTF-8");
+     Intl.textdomain (Config.GETTEXT_PACKAGE);
+     GLib.Environment.set_application_name ("msiextract");
+--- msitools-0.103/tools/wixl/wixl.vala
++++ msitools-0.103/tools/wixl/wixl.vala
+@@ -47,7 +47,9 @@ namespace Wixl {
+     }
+ 
+     int main (string[] args) {
+-        Intl.bindtextdomain (Config.GETTEXT_PACKAGE, Config.LOCALEDIR);
++        string? prefix = Win32.get_package_installation_directory_of_module(null);
++
++        Intl.bindtextdomain (Config.GETTEXT_PACKAGE, Path.build_filename (prefix, Config.LOCALEDIR));
+         Intl.bind_textdomain_codeset (Config.GETTEXT_PACKAGE, "UTF-8");
+         Intl.textdomain (Config.GETTEXT_PACKAGE);
+         GLib.Environment.set_application_name ("wixl");
+@@ -57,8 +59,8 @@ namespace Wixl {
+         opt_context.set_help_enabled (true);
+         opt_context.add_main_entries (options, null);
+ 
+-        wxidir = Path.build_filename (Config.DATADIR, "wixl-" + Config.PACKAGE_VERSION, "include");
+-        extdir = Path.build_filename (Config.DATADIR, "wixl-" + Config.PACKAGE_VERSION, "ext");
++        wxidir = Path.build_filename (prefix, Config.DATADIR, "wixl-" + Config.PACKAGE_VERSION, "include");
++        extdir = Path.build_filename (prefix, Config.DATADIR, "wixl-" + Config.PACKAGE_VERSION, "ext");
+ 
+         try {
+             opt_context.parse (ref args);

--- a/mingw-w64-msitools/PKGBUILD
+++ b/mingw-w64-msitools/PKGBUILD
@@ -7,7 +7,7 @@ _realname=msitools
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.103
-pkgrel=1
+pkgrel=2
 pkgdesc="A set of programs to inspect and build Windows Installer (.MSI) files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -22,15 +22,19 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-vala")
 source=("https://download.gnome.org/sources/${_realname}/${pkgver}/${_realname}-${pkgver}.tar.xz"
-	"001-wixl-heat-rename-header.patch")
+	"001-wixl-heat-rename-header.patch"
+	"002-use-paths-relative-to-the-installation-prefix.patch")
 sha256sums=('d17622eebbf37fa4c09b59be0bc8db08b26be300a6731c74da1ebce262bce839'
-            'b3c0bc13bd0bdd6db7d6649b2000613616499d3768c6ae0d76e400890db3d0c5')
+            'b3c0bc13bd0bdd6db7d6649b2000613616499d3768c6ae0d76e400890db3d0c5'
+            'a743bd3f043bddf62aea8c06bcebe5de7bd08c4cc1050d433c863bce83267c4c')
 msys2_repository_url="https://gitlab.gnome.org/GNOME/msitools"
 
 prepare() {
   cd $srcdir/${_realname}-${pkgver}
 
-  patch -Np1 -i ${srcdir}/001-wixl-heat-rename-header.patch
+  for p in ${srcdir}/*.patch; do
+    patch -Np1 -i ${p}
+  done
 }
 
 build() {

--- a/mingw-w64-msitools/PKGBUILD
+++ b/mingw-w64-msitools/PKGBUILD
@@ -15,7 +15,9 @@ url='https://wiki.gnome.org/msitools'
 license=('spdx:LGPL-2.1-or-later')
 depends=("${MINGW_PACKAGE_PREFIX}-gcab"
          "${MINGW_PACKAGE_PREFIX}-libgsf")
-makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+makedepends=("bison"
+	     "patch"
+	     "${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
              "${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-ninja"
@@ -26,7 +28,7 @@ source=("https://download.gnome.org/sources/${_realname}/${pkgver}/${_realname}-
 	"002-use-paths-relative-to-the-installation-prefix.patch")
 sha256sums=('d17622eebbf37fa4c09b59be0bc8db08b26be300a6731c74da1ebce262bce839'
             'b3c0bc13bd0bdd6db7d6649b2000613616499d3768c6ae0d76e400890db3d0c5'
-            'a743bd3f043bddf62aea8c06bcebe5de7bd08c4cc1050d433c863bce83267c4c')
+            'edba2e321f9318b1b2ffb90d0bc518eaede6a7b4fd69a1ee250d3fbc0b270dbe')
 msys2_repository_url="https://gitlab.gnome.org/GNOME/msitools"
 
 prepare() {


### PR DESCRIPTION
This patch-set supersedes an earlier attempt: https://github.com/msys2/MINGW-packages/pull/18611