### PR TITLE
gettext: build static and shared libraries separately

### DIFF
--- a/mingw-w64-gettext/PKGBUILD
+++ b/mingw-w64-gettext/PKGBUILD
@@ -5,7 +5,7 @@ _realname=gettext
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.22.4
-pkgrel=2
+pkgrel=3
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://www.gnu.org/software/gettext/"
@@ -63,24 +63,22 @@ prepare() {
     0022-libasprintf.patch \
     0023-gnulib.patch
 
-  autoreconf -fiv
+  libtoolize --automake --copy --force
+  WANT_AUTOMAKE=latest ./autogen.sh --skip-gnulib
 }
 
-build() {
-  mkdir -p ${srcdir}/build-${MSYSTEM} && cd ${srcdir}/build-${MSYSTEM}
-
-  export MSYS2_ARG_CONV_EXCL="-DLOCALEDIR=;-DLIBDIR=;-DLOCALE_ALIAS_PATH="
+_build() {
+  _config_opt=$1
 
   # gl_cv_func_mkdir_trailing_dot_works=yes was added to avoid having two
   # incompatible declarations of mkdir in the same compilation unit.
-  lt_cv_deplibs_check_method='pass_all' \
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
     --disable-java \
     --disable-native-java \
     --disable-csharp \
-    --enable-static \
+    ${_config_opt} \
     --enable-threads=win32 \
     --enable-relocatable \
     --without-emacs \
@@ -93,6 +91,7 @@ build() {
     --with-included-glib \
     --with-libncurses-prefix=${MINGW_PREFIX} \
     --disable-silent-rules \
+    lt_cv_deplibs_check_method='pass_all' \
     gl_cv_func_mkdir_trailing_dot_works=yes
 
   # to make relocate() in gnulib-lib work
@@ -101,8 +100,21 @@ build() {
   make
 }
 
+build() {
+
+  export MSYS2_ARG_CONV_EXCL="-DLOCALEDIR=;-DLIBDIR=;-DLOCALE_ALIAS_PATH="
+
+  msg2 "Build static libraries"
+  mkdir -p ${srcdir}/build-${MSYSTEM}-static && cd ${srcdir}/build-${MSYSTEM}-static
+  _build "--enable-static --disable-shared"
+
+  msg2 "Build shared libraries"
+  mkdir -p ${srcdir}/build-${MSYSTEM}-shared && cd ${srcdir}/build-${MSYSTEM}-shared
+  _build "--enable-shared --disable-static"
+}
+
 check () {
-  cd ${srcdir}/build-${MSYSTEM}
+  cd ${srcdir}/build-${MSYSTEM}-static
 
   # ensure that the Windows-specific `%I64*` format family is recognized correctly
   cat >test-I64d.c <<EOF
@@ -125,7 +137,10 @@ EOF
 }
 
 package() {
-  cd ${srcdir}/build-${MSYSTEM}
+  cd ${srcdir}/build-${MSYSTEM}-static
+  make DESTDIR="${pkgdir}" install
+
+  cd ${srcdir}/build-${MSYSTEM}-shared
   make DESTDIR="${pkgdir}" install
 
   # Licenses


### PR DESCRIPTION
In recent versions of `gettext`, `relocatable.o` is no longer linked into `libintl.a` directly, but indirectly via the (convenience) library `libgnu.a`.
While two versions of `relocatable.o` are still built (one that exports `DllMain` and one that doesn't), only one of those object files (the one that exports `DllMain`) is linked into the convenience library `libgnu.a`. That means that the *static* library `libintl.a` (that links all objects from that convenience library) now also exports `DllMain`.

Prevent that from happening by building static and shared libraries in separate steps.

This should be fixing the issue described in #19086.
