### PR TITLE
ruby: fix the build with recent llvm windres

### DIFF
--- a/mingw-w64-ruby/81a1fca366d9f5b49836e42acdb19f3ff0c8173c.patch
+++ b/mingw-w64-ruby/81a1fca366d9f5b49836e42acdb19f3ff0c8173c.patch
@@ -1,0 +1,60 @@
+From 81a1fca366d9f5b49836e42acdb19f3ff0c8173c Mon Sep 17 00:00:00 2001
+From: Pierrick Bouvier <pierrick.bouvier@linaro.org>
+Date: Tue, 21 Nov 2023 16:13:21 +0400
+Subject: [PATCH] [win32] detect llvm-windres (used for windows-arm64)
+
+When adding preprocessor option for llvm-windres (using clang as
+parameter), it fails. Thus, do not add this.
+
+It's needed to be able to compile windows-arm64 version, because MSYS2
+toolchain is LLVM based (instead of GCC/binutils).
+---
+ configure.ac          |  4 ++++
+ cygwin/GNUmakefile.in | 11 ++++++++---
+ 2 files changed, 12 insertions(+), 3 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 805cbaae18ee2..588fdec3827a6 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -512,6 +512,9 @@ AS_CASE(["$target_os"],
+ ],
+ [hiuxmpp*], [AC_DEFINE(__HIUX_MPP__)])    # by TOYODA Eizi <toyoda@npd.kishou.go.jp>
+ 
++USE_LLVM_WINDRES=no
++windres_version=`windres --version | grep LLVM`
++test -z "$windres_version" || USE_LLVM_WINDRES=yes
+ 
+ AC_PROG_LN_S
+ AC_PROG_MAKE_SET
+@@ -4245,6 +4248,7 @@ AC_SUBST(MINIOBJS)
+ AC_SUBST(THREAD_MODEL)
+ AC_SUBST(COROUTINE_TYPE, ${coroutine_type})
+ AC_SUBST(PLATFORM_DIR)
++AC_SUBST(USE_LLVM_WINDRES)
+ 
+ firstmf=`echo $FIRSTMAKEFILE | sed 's/:.*//'`
+ firsttmpl=`echo $FIRSTMAKEFILE | sed 's/.*://'`
+diff --git a/cygwin/GNUmakefile.in b/cygwin/GNUmakefile.in
+index 09298590304b5..192a8cc7112b3 100644
+--- a/cygwin/GNUmakefile.in
++++ b/cygwin/GNUmakefile.in
+@@ -3,9 +3,14 @@ gnumake = yes
+ include Makefile
+ 
+ ENABLE_SHARED=@ENABLE_SHARED@
+ DLLWRAP = @DLLWRAP@ --target=@target_os@ --driver-name="$(CC)"
+-windres-cpp := $(CPP) -xc
+-windres-cpp := --preprocessor=$(firstword $(windres-cpp)) \
+-	$(addprefix --preprocessor-arg=,$(wordlist 2,$(words $(windres-cpp)),$(windres-cpp)))
++ifeq (@USE_LLVM_WINDRES@,yes) # USE_LLVM_WINDRES
++	# llvm-windres fails when preprocessor options are added
++	windres-cpp :=
++else
++	windres-cpp := $(CPP) -xc
++	windres-cpp := --preprocessor=$(firstword $(windres-cpp)) \
++		$(addprefix --preprocessor-arg=,$(wordlist 2,$(words $(windres-cpp)),$(windres-cpp)))
++endif
+ WINDRES = @WINDRES@ $(windres-cpp) -DRC_INVOKED
+ STRIP = @STRIP@
+ 

--- a/mingw-w64-ruby/PKGBUILD
+++ b/mingw-w64-ruby/PKGBUILD
@@ -10,7 +10,7 @@ _realname=ruby
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.1.3
-pkgrel=2
+pkgrel=3
 pkgdesc="An object-oriented language for quick and easy programming (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -32,7 +32,8 @@ source=("https://cache.ruby-lang.org/pub/ruby/${pkgver%.*}/${_realname}-${pkgver
         0003-fix-check-types.patch
         0007-nm-use-full-options.patch
         0008-ucrt-32-win11-insns.patch
-        0009-windows-arm64.patch)
+        0009-windows-arm64.patch
+        81a1fca366d9f5b49836e42acdb19f3ff0c8173c.patch)
 ## Populated by the updpkgprovs script
 provides=(
     "${MINGW_PACKAGE_PREFIX}-ruby-debug=1.6.3"
@@ -127,7 +128,8 @@ sha256sums=('5ea498a35f4cd15875200a52dde42b6eb179e1264e17d78732c3a57cd1c6ab9e'
             'e5d665cabac8b7fbb0dda9a556c2350190801aa07b3cb90a0d50097ab99272a0'
             'b250c66bc8b372fb4c53902a6d56c01ad057416e3e368a5c5434d9a4ebdc3819'
             'c9f816baf5b2803e017924c7eeef6a478beb76247d6d4b39a2424c8d34687b2b'
-            'f3a61f6d600bb962f23e4ff1c0857120630541d8fcb542957dc0848b00a39690')
+            'f3a61f6d600bb962f23e4ff1c0857120630541d8fcb542957dc0848b00a39690'
+            'b910a224d641e48f2c6ef2e7bee7d5d31f7fbda15070fb1ee8460e25590c4085')
 noextract=(${_realname}-${pkgver}.tar.gz)
 
 apply_patch_with_msg() {
@@ -159,6 +161,12 @@ prepare() {
       0007-nm-use-full-options.patch \
       0008-ucrt-32-win11-insns.patch \
       0009-windows-arm64.patch
+
+  # https://github.com/ruby/ruby/pull/8995 (slightly adjusted to apply cleanly)
+  # This fails with llvm-windres (but works with binutils windres):
+  # windres.exe --preprocessor=clang --preprocessor-arg=-E --preprocessor-arg=-xc a.rc -o a.o
+  apply_patch_with_msg \
+    81a1fca366d9f5b49836e42acdb19f3ff0c8173c.patch
 
   autoreconf -fi
 }


### PR DESCRIPTION
This fails now:

windres.exe --preprocessor=clang --preprocessor-arg=-E --preprocessor-arg=-xc a.rc -o a.o

We should probably report it to upstream to see what they say. This patch just removes the --preprocessor args, since the windres defaults are equivalent anyway.