### PR TITLE
86Box: Enable clangarm64

### DIFF
--- a/mingw-w64-86box/PKGBUILD
+++ b/mingw-w64-86box/PKGBUILD
@@ -7,7 +7,7 @@ pkgver=4.0.1
 pkgrel=1
 pkgdesc="An emulator for classic IBM PC clones (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url='https://86box.net/'
 license=('spdx:GPL-2.0-or-later')
 depends=(
@@ -45,6 +45,11 @@ build() {
     extra_config+=("-DCMAKE_BUILD_TYPE=Release")
   else
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  if [[ ${MSYSTEM} == CLANGARM64 ]]; then
+    # Only the "new" dynarec supports ARM
+    extra_config+=("-DNEW_DYNAREC=ON")
   fi
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \


### PR DESCRIPTION
Haven't tested yet, but I ported 86Box over in upstream myself and built in on MSYS2 CLANGARM64 manually for many times, it should work.