### PR TITLE
libaec: update to 1.1.2

### DIFF
--- a/mingw-w64-libaec/PKGBUILD
+++ b/mingw-w64-libaec/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=libaec
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.0.6
-pkgrel=2
+pkgver=1.1.2
+pkgrel=1
 pkgdesc="Adaptive Entropy Coding library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -16,10 +16,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
 provides=("${MINGW_PACKAGE_PREFIX}-szip")
 replaces=("${MINGW_PACKAGE_PREFIX}-szip")
 options=('staticlibs' 'strip')
-_md5=45b10e42123edd26ab7b3ad92bcf7be2
+_md5=3847727cd2e8c941f0d68f6822a73ed7
 source=("${url}/uploads/${_md5}/${_realname}-${pkgver}.tar.gz"
         "0005-cmake-fix-cmake-install.patch")
-sha256sums=('032961877231113bb094ef224085e6d66fd670f85a3e17f53d0f131abf24f2fd'
+sha256sums=('a5d03a242468014b92b1b196de397f1e9a7927782db1a0423ea01db78421e373'
             '9acc599a0f809b1f196c2ff0db6990901e812e659a594041e7540c4980b3fc91')
 
 prepare() {


### PR DESCRIPTION
Hm, not sure why the CLANG64 grokker thinks all the DLL symbols were removed?