### PR TITLE
vlc: build without libplacebo

### DIFF
--- a/mingw-w64-vlc/PKGBUILD
+++ b/mingw-w64-vlc/PKGBUILD
@@ -8,7 +8,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 pkgver=3.0.20
-pkgrel=1
+pkgrel=2
 pkgdesc="A multi-platform MPEG, VCD/DVD, and DivX player (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -58,7 +58,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-a52dec"
          "${MINGW_PACKAGE_PREFIX}-libnfs"
          "${MINGW_PACKAGE_PREFIX}-libpng"
          "${MINGW_PACKAGE_PREFIX}-libnotify"
-         "${MINGW_PACKAGE_PREFIX}-libplacebo"
          "${MINGW_PACKAGE_PREFIX}-libproxy"
          "${MINGW_PACKAGE_PREFIX}-librsvg"
          "${MINGW_PACKAGE_PREFIX}-libsamplerate"
@@ -171,6 +170,7 @@ build() {
     --disable-telx \
     --enable-nls \
     --disable-lua \
+    --disable-libplacebo \
     --disable-gst-decode
 
   make


### PR DESCRIPTION
vlc 3 is not compatible with libplacebo v6 and blocks updating other packages. From a quick glance it only seems to affect the opengl video output, which isn't the default anyway, so hopefully shouldn't affect many users.

If this is a problem let us know.