### PR TITLE
remove czkawka_gui for CLANG* enironments

### DIFF
--- a/mingw-w64-czkawka/PKGBUILD
+++ b/mingw-w64-czkawka/PKGBUILD
@@ -3,7 +3,8 @@
 _realname=czkawka
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-cli"
-         "${MINGW_PACKAGE_PREFIX}-${_realname}-gui")
+         # https://github.com/qarmin/czkawka/issues/1148
+         $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-${_realname}-gui"))
 pkgver=6.1.0
 pkgrel=1
 pkgdesc="Multi functional app to find duplicates, empty folders, similar images etc (mingw-w64)"


### PR DESCRIPTION
see https://github.com/qarmin/czkawka/issues/1148
czkawka_gui binary throws SIGSEGV at startup. anyone interested feel free to help