### PR TITLE
meson: depend on pkgconf

### DIFF
--- a/mingw-w64-meson/PKGBUILD
+++ b/mingw-w64-meson/PKGBUILD
@@ -4,7 +4,7 @@ _realname=meson
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.3.0
-pkgrel=1
+pkgrel=2
 pkgdesc="High-productivity build system (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -12,7 +12,8 @@ url="https://mesonbuild.com/"
 license=("spdx:Apache-2.0")
 options=('!strip')
 depends=("${MINGW_PACKAGE_PREFIX}-python"
-         "${MINGW_PACKAGE_PREFIX}-ninja")
+         "${MINGW_PACKAGE_PREFIX}-ninja"
+         "${MINGW_PACKAGE_PREFIX}-pkgconf")
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-setuptools"
   "${MINGW_PACKAGE_PREFIX}-python-wheel"


### PR DESCRIPTION
While pkgconf is strictly not required to build things, it usually is and might lead to confusing when missing, or worse, when the msys pkgconf is installed and results in hard to understand errors.