### PR TITLE
readline: Update to 8.2.007

### DIFF
--- a/mingw-w64-readline/0003-fd_set.patch
+++ b/mingw-w64-readline/0003-fd_set.patch
@@ -1,20 +1,6 @@
 Guard functions that use types that aren't available on all platforms with
 pre-processor conditions.
 
-diff -urN readline-8.2/input.c.orig readline-8.2/input.c
---- readline-8.2/input.c.orig	2022-11-12 17:54:14.800371248 +0100
-+++ readline-8.2/input.c	2022-11-12 17:58:13.327167979 +0100
-@@ -151,7 +151,9 @@
- 
- int _rl_timeout_init (void);
- int _rl_timeout_sigalrm_handler (void);
-+#if defined (HAVE_PSELECT) || defined (HAVE_SELECT)
- int _rl_timeout_select (int, fd_set *, fd_set *, fd_set *, const struct timeval *, const sigset_t *);
-+#endif
- 
- static void _rl_timeout_handle (void);
- #if defined (RL_TIMEOUT_USE_SIGALRM)
-
 diff -urN readline-8.2/rlprivate.h.orig readline-8.2/rlprivate.h
 --- readline-8.2/rlprivate.h.orig	2022-08-12 00:35:16.000000000 +0200
 +++ readline-8.2/rlprivate.h	2022-11-12 17:43:54.266291863 +0100

--- a/mingw-w64-readline/PKGBUILD
+++ b/mingw-w64-readline/PKGBUILD
@@ -4,9 +4,9 @@ _realname=readline
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _basever=8.2
-_patchlevel=001
+_patchlevel=007
 pkgver=${_basever}.${_patchlevel}
-pkgrel=6
+pkgrel=1
 pkgdesc="MinGW port of readline for editing typed command lines (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -35,9 +35,21 @@ sha256sums=('3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35'
             'SKIP'
             '2b30dcb0804abb6e7e4f44cd119bddef94c1b1d7ebff43dda401e710eda2fd0f'
             '52ae0da2769afe2853e3ffad8ae2e22eb8a72ce3ee8f2fc9084cb4dc554b2813'
-            '6c90a984519f6e5a201c3b107ec5a7319db2a4f7b30f48dd43c0964894fbf3a6'
+            '6329d02c9e151951136a31cce036f952f95f80a63d60694539839b9c706857e9'
             '72ed438ae142ba9d5498652dfdf4fb517265bcf9a67199b7c5b35cc24fa25b9e'
             'bbf97f1ec40a929edab5aa81998c1e2ef435436c597754916e6a5868f273aff7'
+            'SKIP'
+            'e06503822c62f7bc0d9f387d4c78c09e0ce56e53872011363c74786c7cd4c053'
+            'SKIP'
+            '24f587ba46b46ed2b1868ccaf9947504feba154bb8faabd4adaea63ef7e6acb0'
+            'SKIP'
+            '79572eeaeb82afdc6869d7ad4cba9d4f519b1218070e17fa90bbecd49bd525ac'
+            'SKIP'
+            '622ba387dae5c185afb4b9b20634804e5f6c1c6e5e87ebee7c35a8f065114c99'
+            'SKIP'
+            'c7b45ff8c0d24d81482e6e0677e81563d13c74241f7b86c4de00d239bc81f5a1'
+            'SKIP'
+            '5911a5b980d7900aabdbee483f86dab7056851e6400efb002776a0a4a1bab6f6'
             'SKIP')
 
 apply_patch_with_msg() {
@@ -72,6 +84,10 @@ build() {
   [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}
   mkdir -p ${srcdir}/build-${MSYSTEM} && cd ${srcdir}/build-${MSYSTEM}
   export CFLAGS="$CFLAGS -DNEED_EXTERN_PC=1" # Use extern PC variable from libtermcap
+
+  # XXX: make mingw-w64 provide a dummy alarm() function
+  CFLAGS+=" -D__USE_MINGW_ALARM -D_POSIX"
+
   ../${_realname}-${_basever}/configure \
     --prefix=${MINGW_PREFIX} \
     --host=${MINGW_CHOST} \


### PR DESCRIPTION
0003-fd_set.patch: remove hunk which is included in readline82-004

https://ftp.gnu.org/gnu/readline/readline-8.2-patches/readline82-004

XXX: make mingw-w64 provide a dummy alarm(), this just worked because
old clang wasn't that strict.