### PR TITLE
mypy: Update to 1.7.1

### DIFF
--- a/mingw-w64-mypy/PKGBUILD
+++ b/mingw-w64-mypy/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=mypy
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.7.0
+pkgver=1.7.1
 pkgrel=1
 pkgdesc="Optional static typing for Python 3 (PEP484) (mingw-w64)"
 arch=('any')
@@ -12,6 +12,7 @@ msys2_references=(
   'pypi: mypy'
 )
 url="https://www.mypy-lang.org/"
+msys2_repository_url="https://github.com/python/mypy"
 license=('spdx:MIT')
 depends=(
   "${MINGW_PACKAGE_PREFIX}-python-mypy_extensions"
@@ -24,7 +25,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-cc")
 options=(!strip)
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('1e280b5697202efa698372d2f39e9a6713a0395a756b1c6bd48995f8d72690dc')
+sha256sums=('fcb6d9afb1b6208b4c712af0dafdc650f518836065df0d4fb1d800f5d6773db2')
 
 export PYTHONHASHSEED=0
 
@@ -47,7 +48,4 @@ package() {
     --destdir="${pkgdir}" dist/*.whl
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
-
-  local _PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
-  sed -s "s|${_PREFIX_WIN}/bin/||g" -i "${pkgdir}${MINGW_PREFIX}/bin/mypyc"
 }


### PR DESCRIPTION
fix mypyc, which was corrupted by a left over sed call, assuming mypyc was still a python script from setuptools.