### PR TITLE
numba: fix exe launcher

### DIFF
--- a/mingw-w64-python-numba/PKGBUILD
+++ b/mingw-w64-python-numba/PKGBUILD
@@ -4,7 +4,7 @@ _realname=numba
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=0.58.1
-pkgrel=1
+pkgrel=2
 pkgdesc='NumPy aware dynamic Python compiler using LLVM (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -12,6 +12,7 @@ msys2_references=(
   'pypi: numba'
 )
 url="https://numba.pydata.org/"
+msys2_repository_url="https://github.com/numba/numba"
 license=('spdx:BSD-2-Clause')
 depends=(
   "${MINGW_PACKAGE_PREFIX}-python"
@@ -23,10 +24,9 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python-wheel"
-             "${MINGW_PACKAGE_PREFIX}-cython0"
              "${MINGW_PACKAGE_PREFIX}-cc")
 optdepends=("${MINGW_PACKAGE_PREFIX}-python-scipy")
-options=('!emptydirs')
+options=('!emptydirs' '!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('487ded0633efccd9ca3a46364b40006dbdaca0f95e99b8b83e778d1195ebcbaa')
 
@@ -47,9 +47,6 @@ package() {
   MSYS2_ARG_CONV_EXCL="--prefix=" \
     ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
     --destdir="${pkgdir}" dist/*.whl
-
-  local _PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
-  sed -s "s|${_PREFIX_WIN}/bin/||g" -i "${pkgdir}${MINGW_PREFIX}/bin/numba"
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
 }


### PR DESCRIPTION
* don't strip
* don't call sed on the binary launcher

remove cython dep while at it, likely not needed