### PR TITLE
ripgrep: update to 14.0.2

### DIFF
--- a/mingw-w64-ripgrep/PKGBUILD
+++ b/mingw-w64-ripgrep/PKGBUILD
@@ -3,47 +3,64 @@
 _realname=ripgrep
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=13.0.0
-pkgrel=2
+pkgver=14.0.2
+pkgrel=1
 pkgdesc='line-oriented search tool that recursively searches your current directory for a regex pattern (mingw-w64)'
-arch=(any)
-mingw_arch=(mingw32 mingw64 ucrt64 clang64 clangarm64)
-url=https://github.com/BurntSushi/$_realname
-license=(MIT custom:UNLICENSE)
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/BurntSushi/ripgrep'
+msys2_references=(
+    'archlinux: ripgrep'
+)
+license=('spdx:MIT OR Unlicense')
 depends=("${MINGW_PACKAGE_PREFIX}-pcre2")
-makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
-             "${MINGW_PACKAGE_PREFIX}-jq"
-             "${MINGW_PACKAGE_PREFIX}-asciidoctor"
-             git)
-source=("git+$url#tag=13.0.0")
-sha512sums=('SKIP')
+makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
+source=("${url}/archive/refs/tags/${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('2b9bd8a582d1fea70eb932e389e0895922b9a0147f65f9ad4b601b3f3a82a195')
+noextract=("${_realname}-${pkgver}.tar.gz")
 
 prepare() {
-  cd "${srcdir}/${_realname}"
+  cd "${srcdir}"
+  tar -xzf "${_realname}-${pkgver}.tar.gz" || true
 
+  cd "${srcdir}/${_realname}-${pkgver}"
   cargo fetch --locked
 }
 
 build() {
-    cd "${srcdir}/${_realname}" || return 1
+  cd "${_realname}-${pkgver}"
 
-    cargo build --release --frozen --features 'pcre2' --message-format=json-render-diagnostics | tee /dev/shm/a |
-    jq -r 'select(.out_dir) | select(.package_id | startswith("ripgrep ")) | .out_dir' > out_dir
+  cargo build --release --locked --features 'pcre2'
+}
+
+check() {
+  cd "${_realname}-${pkgver}"
+
+  cargo test --release --locked --features 'pcre2'
 }
 
 package() {
-  cd "${srcdir}/${_realname}" || return 1
+  cd "${srcdir}/${_realname}-${pkgver}"
 
   cargo install \
     --frozen \
     --offline \
     --no-track \
+    --features 'pcre2' \
     --path . \
     --root "${pkgdir}${MINGW_PREFIX}"
-  local OUT_DIR=$(<out_dir)
 
-  install -Dm644 "complete/_rg" "$pkgdir/$MINGW_PREFIX/share/zsh/site-functions/_rg"
-  install -Dm644 "$OUT_DIR"/rg.bash "$pkgdir/$MINGW_PREFIX/share/bash-completion/completions/rg"
-  install -Dm644 "$OUT_DIR"/rg.fish "$pkgdir/$MINGW_PREFIX/share/fish/vendor_completions.d/rg.fish"
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/share/zsh/site-functions"
+  target/release/rg --generate complete-zsh > "${pkgdir}${MINGW_PREFIX}/share/zsh/site-functions/_rg"
+
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/share/bash-completion/completions"
+  target/release/rg --generate complete-bash > "${pkgdir}${MINGW_PREFIX}/share/bash-completion/completions/rg"
+
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/share/fish/vendor_completions.d"
+  target/release/rg --generate complete-fish > "${pkgdir}${MINGW_PREFIX}/share/fish/vendor_completions.d/rg.fish"
+
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/share/man/man1"
+  target/release/rg --generate man >  "${pkgdir}${MINGW_PREFIX}/share/man/man1/rg.1"
+
   install -Dm644 COPYING LICENSE-MIT UNLICENSE -t "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/"
 }


### PR DESCRIPTION
~~- enabled clang32 (why wasn't it enabled?)~~ see https://github.com/msys2/MINGW-packages/pull/19221#issuecomment-1830400981
- cleanup
- fixed missing `--features 'pcre2'` in `cargo install`