### PR TITLE
sccache: update to 0.7.4

### DIFF
--- a/mingw-w64-sccache/PKGBUILD
+++ b/mingw-w64-sccache/PKGBUILD
@@ -3,11 +3,11 @@
 _realname=sccache
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.6.0
+pkgver=0.7.4
 pkgrel=1
 pkgdesc='Shared compilation cache (mingw-w64)'
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 msys2_references=(
   'archlinux: sccache'
 )
@@ -16,7 +16,7 @@ license=('spdx:Apache-2.0')
 depends=("${MINGW_PACKAGE_PREFIX}-openssl" "${MINGW_PACKAGE_PREFIX}-zlib")
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
 source=("https://github.com/mozilla/sccache/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('ffa687a872f590ba0bfeacb54ef16f25f78426207614681f85b183fabe515400')
+sha256sums=('32301f125d5b1d73830b163fd15fe9b5c22cf4a4a6b835d893dec563aba5b4fc')
 
 prepare() {
   cp -r ${_realname}-${pkgver} build-${MSYSTEM}
@@ -26,32 +26,31 @@ prepare() {
 }
 
 build() {
-  export WINAPI_NO_BUNDLED_LIBRARIES=1
+  WINAPI_NO_BUNDLED_LIBRARIES=1 \
   ${MINGW_PREFIX}/bin/cargo build \
 	--release \
 	--frozen \
 	--manifest-path build-${MSYSTEM}/Cargo.toml \
-	--features all \
 	--features native-zlib
 }
 
 check() {
+  WINAPI_NO_BUNDLED_LIBRARIES=1 \
   ${MINGW_PREFIX}/bin/cargo test \
 	--release \
 	--frozen \
 	--manifest-path build-${MSYSTEM}/Cargo.toml \
-	--features all \
 	--features native-zlib
 }
 
 package() {
+  WINAPI_NO_BUNDLED_LIBRARIES=1 \
   ${MINGW_PREFIX}/bin/cargo install \
 	--frozen \
 	--offline \
 	--no-track \
 	--path build-${MSYSTEM} \
 	--root ${pkgdir}${MINGW_PREFIX} \
-	--features all \
 	--features native-zlib
 
   install -Dm644 ${_realname}-${pkgver}/LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"


### PR DESCRIPTION
- `--features all` is enabled by default, removing
- `WINAPI_NO_BUNDLED_LIBRARIES` needs to be set all the time, otherwise it's recompiled
- give another try for aarch64