### PR TITLE
onefetch: update to 2.19.0

### DIFF
--- a/mingw-w64-onefetch/PKGBUILD
+++ b/mingw-w64-onefetch/PKGBUILD
@@ -1,23 +1,25 @@
 _realname=onefetch
 pkgbase=mingw-w64-$_realname
 pkgname=$MINGW_PACKAGE_PREFIX-$_realname
-pkgver=2.18.1
-pkgrel=3
+pkgver=2.19.0
+pkgrel=1
 pkgdesc="Git repository summary on your terminal (mingw-w64)"
 url="https://github.com/o2sh/onefetch"
-license=('MIT')
+license=('spdx:MIT')
+msys2_references=(
+  'archlinux: onefetch'
+)
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 depends=("$MINGW_PACKAGE_PREFIX-libgit2")
 makedepends=("$MINGW_PACKAGE_PREFIX-rust"
              "$MINGW_PACKAGE_PREFIX-cmake")
 source=("$_realname-$pkgver.tar.gz::$url/archive/$pkgver.tar.gz")
-sha256sums=('7b0f03e9d2383ac32283cfb9ec09d10c8789a298969c8b7d45fa0168bd909140')
+sha256sums=('e6aa7504730de86f307d6c3671875b11a447a4088daf74df280c8f644dea4819')
 
 prepare() {
   cd "$_realname-$pkgver"
-  # update windows-targets to fix windows-gnullvm dependency specification
-  cargo update -p windows-targets@0.48.0 --precise 0.48.1
+
   cargo fetch --locked
   mkdir -p completions
 }
@@ -34,6 +36,8 @@ build() {
 
 check() {
   cd "$_realname-$pkgver"
+
+  WINAPI_NO_BUNDLED_LIBRARIES=1 \
   cargo test --frozen --all-features
 }
 


### PR DESCRIPTION
removed windows-targets workaround - updated upstream

added `WINAPI_NO_BUNDLED_LIBRARIES` in `check()` so it's not recompiled while testing