### PR TITLE
gcc: Build with PGO

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -26,12 +26,12 @@ pkgver=13.2.0
 #_majorver=${pkgver:0:1}
 #_sourcedir=${_realname}-${_majorver}-${_snapshot}
 _sourcedir=${_realname}-${pkgver}
-pkgrel=2
+pkgrel=3
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
 url="https://gcc.gnu.org"
-license=('GPL' 'LGPL' 'FDL' 'custom')
+license=('spdx:GPL-3.0-or-later')
 groups=("${MINGW_PACKAGE_PREFIX}-toolchain")
 makedepends=("${MINGW_PACKAGE_PREFIX}-${_realname}"
              $([[ "$_enable_ada" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-ada")
@@ -91,8 +91,8 @@ sha256sums=('e275e76442a6067341a27f04c5c6b83d8613144004c0413528863dc6b5c743da'
             'f73c8d1701762fed7d8102d17d8e4416a4cc5e600e297a89c2e1fe09cd743a1c'
             '693a91a863a706b3526af01c9de5ce8295c59ef0f56f009bcfbf79a93cba2728'
             'e78d51c908cd4e5c905c62e8350db1c609479bb95333c67f706b56974226fd94'
-            '74c4693850f6c96992d43414f88e9f16ab1a5d1458f5e4dc76ac3ce435a80eef'
-            '8dc297c658911ead58cd06407b853bbe82c2c3da1ad24cbcc7b01f3c7b5f666b'
+            '585968957f4519aa7219de4804e96debe7592df047e497b99ea0ae073e6f57d3'
+            '73b923129e6c5b819ac994ce64b75520918992c65d00e0d97f8ca43cd6784e56'
             'b0a98a41fea4a68f15d35b44495a487183a4d85ea9cb70cd4a645b4ed6583122')
 validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.org
               86CFFCA918CF3AF47147588051E8B148A9999C34  # evangelos@foutrelis.com
@@ -287,7 +287,7 @@ build() {
 
   # https://gcc.gnu.org/onlinedocs/gccint/Makefile.html
   make -O STAGE1_CFLAGS="-O2" \
-          all
+          profiledbootstrap
 
   rm -rf ${srcdir}${MINGW_PREFIX}
 
@@ -304,17 +304,18 @@ package_gcc-libs() {
 
   # Licensing information
 
-  # Part of the package is GCCRLE, part is LGPL2+, see README generation below.
-  # Since the packaged GCCRLE libraries are also GPL3+, and LGPL2+ is compatible
-  # with GPL3+, the whole package can be redistributed under GPL3+.
-  license=(GPL3+ partial:'GCCRLE' partial:'LGPL2+')
+  # Part of the package is GCCRLE, part is LGPL-2.1-or-later, see README generation below.
+  # Since the packaged GCCRLE libraries are also spdx:GPL-3.0-or-later,
+  # and LGPL-2.1-or-later is compatible with GPL-3.0-or-later, the whole package can
+  # be redistributed under GPL-3.0-or-later.
+  license=('spdx:GPL-3.0-or-later WITH GCC-exception-3.1 AND LGPL-2.1-or-later')
 
   # We explain the licensing in this generated README file
   mkdir -p "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-libs"
   cat << ENDFILE > "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-libs/README"
 The libgcc, libstdc++, libgomp and libatomic libraries are covered by
-GPL3+ with the GCC Runtime Library Exception. The libquadmath library is covered
-by LGPL2+. The package as a whole can be redistributed under GPL3+.
+GPL-3.0-or-later with GCC-exception-3.1. The libquadmath library is covered
+by LGPL-2.1-or-later. The package as a whole can be redistributed under GPL-3.0-or-later.
 ENDFILE
 
   # License files
@@ -443,6 +444,7 @@ package_gcc() {
 package_gcc-libgfortran() {
   pkgdesc="GNU Compiler Collection (libgfortran) for MinGW-w64"
   depends=("${MINGW_PACKAGE_PREFIX}-${_realname}-libs=${pkgver}-${pkgrel}")
+  provides=("${MINGW_PACKAGE_PREFIX}-fc-libs")
 
   mkdir -p ${pkgdir}${MINGW_PREFIX}/bin
   cd ${srcdir}${MINGW_PREFIX}


### PR DESCRIPTION
I have tested the artifacts on my local machine building a small project:

Without PGO: 188s 190s 189s average~=189s
With PGO: 176s 177s 179s average~=177.3
A speedup = (189-177.3)/189 ~= 6%

Wait for other members to test and comment