### PR TITLE
libplacebo: remove xxhash dependency from .pc file

### DIFF
--- a/mingw-w64-libplacebo/PKGBUILD
+++ b/mingw-w64-libplacebo/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libplacebo
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=6.338.1
-pkgrel=3
+pkgrel=4
 pkgdesc="Reusable library for GPU-accelerated video/image rendering primitives (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -25,9 +25,17 @@ makedepends=("git"
              "${MINGW_PACKAGE_PREFIX}-vulkan-headers")
 license=('LGPL2.1')
 source=(${url}/-/archive/v${pkgver}/${_realname}-v${pkgver}.tar.gz
-        "0001-add-cflags-private.patch")
+        "0001-add-cflags-private.patch"
+        "https://code.videolan.org/videolan/libplacebo/-/merge_requests/628.patch")
 sha256sums=('f748bf9385f4c228e1379d7d1bed13581176bfdc54eb99f4abe22e649f8dc93f'
-            'bda9bed8b8fff7e69fe750b6f2caafde67f63343d05698a81fb1f7b27ac4cca3')
+            'bda9bed8b8fff7e69fe750b6f2caafde67f63343d05698a81fb1f7b27ac4cca3'
+            'f675881f51301873b9adf39aa2da48369a37bbcf644b279ec0697fd9dd69170a')
+
+prepare() {
+  cd "${_realname}-v${pkgver}"
+
+  patch -p1 -i "${srcdir}"/628.patch
+}
 
 build() {
   [[ -d "${srcdir}"/build-shared-${MSYSTEM} ]] && rm -rf "${srcdir}"/build-shared-${MSYSTEM}


### PR DESCRIPTION
it's a build time only dependency, see
https://github.com/msys2/MINGW-packages/pull/19180#issuecomment-1833353609