### PR TITLE
llvm-15: Make clang compiler functional by specifying SYSROOT

### DIFF
--- a/mingw-w64-llvm-15/PKGBUILD
+++ b/mingw-w64-llvm-15/PKGBUILD
@@ -13,20 +13,21 @@ fi
 _realname=llvm
 pkgbase=mingw-w64-${_realname}-15
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-15"
-         "${MINGW_PACKAGE_PREFIX}-clang-15")
+         "${MINGW_PACKAGE_PREFIX}-clang-15"
+         "${MINGW_PACKAGE_PREFIX}-compiler-rt-15")
 _version=15.0.7
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
-pkgrel=1
-pkgdesc="C language family frontend for LLVM (mingw-w64)"
+pkgrel=2
+pkgdesc="C language family frontend for LLVM 15 (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 msys2_references=(
-  'archlinux: llvm'
+  'archlinux: llvm15'
 )
 url="https://llvm.org/"
-license=("custom:Apache 2.0 with LLVM Exception")
+license=("spdx:Apache-2.0 WITH LLVM-exception")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-z3"
@@ -34,11 +35,11 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-python"
-             "git"
-             )
+             "git")
 _url=https://github.com/llvm/llvm-project/releases/download/${_tag}
 source=("${_url}/llvm-${pkgver}.src.tar.xz"{,.sig}
         "${_url}/clang-${pkgver}.src.tar.xz"{,.sig}
+        "${_url}/compiler-rt-${pkgver}.src.tar.xz"{,.sig}
         "${_url}/cmake-${pkgver}.src.tar.xz"{,.sig}
         "0001-Fix-GetHostTriple-for-mingw-w64-in-msys.patch"
         "0002-Revert-CMake-try-creating-symlink-first-on-windows.patch"
@@ -55,6 +56,8 @@ source=("${_url}/llvm-${pkgver}.src.tar.xz"{,.sig}
 sha256sums=('4ad8b2cc8003c86d0078d15d987d84e3a739f24aae9033865c027abae93ee7a4'
             'SKIP'
             'a6b673ef15377fb46062d164e8ddc4d05c348ff8968f015f7f4af03f51000067'
+            'SKIP'
+            '353832c66cce60931ea0413b3c071faad59eefa70d02c97daa8978b15e4b25b7'
             'SKIP'
             '8986f29b634fdaa9862eedda78513969fe9788301c9f2d938f4c10a3e7a3e7ea'
             'SKIP'
@@ -86,7 +89,7 @@ prepare() {
   tar -xJf ${srcdir}/clang-${pkgver}.src.tar.xz -C ${srcdir} || true
 
   # Rename Directories
-  for pkg in llvm clang cmake; do
+  for pkg in llvm clang compiler-rt cmake; do
     mv ${pkg}-$pkgver.src ${pkg}
   done
 
@@ -139,6 +142,7 @@ build() {
   fi
   common_cmake_args+=(-Wno-dev
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX}/opt/llvm-15
+    -DDEFAULT_SYSROOT="../../.."
     -DCMAKE_SYSTEM_IGNORE_PATH=/usr/lib
     -DLLVM_HOST_TRIPLE="${CARCH}-w64-windows-gnu"
     -DPython3_EXECUTABLE=${MINGW_PREFIX}/bin/python.exe)
@@ -152,18 +156,19 @@ build() {
     platform_config+=(-DCLANG_DEFAULT_RTLIB=compiler-rt
       -DCLANG_DEFAULT_UNWINDLIB=libunwind
       -DCLANG_DEFAULT_CXX_STDLIB=libc++
+      -DCOMPILER_RT_USE_BUILTINS_LIBRARY=ON
       -DLLVM_ENABLE_LIBCXX=ON
       -DCLANG_DEFAULT_LINKER=lld
       -DLLVM_ENABLE_LLD=ON)
   fi
 
-  local _projects="clang"
+  local _projects="clang;compiler-rt"
 
   platform_config+=(-DLLVM_TARGETS_TO_BUILD="AArch64;X86")
 
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
 
-  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DDEFAULT_SYSROOT=" \
   ${MINGW_PREFIX}/bin/cmake.exe \
     -GNinja \
     -DFFI_INCLUDE_DIR="${FFI_INCLUDE_DIR}" \
@@ -176,40 +181,53 @@ build() {
     -DLLVM_ENABLE_RTTI=ON \
     -DLLVM_INCLUDE_EXAMPLES=OFF \
     -DLLVM_INCLUDE_BENCHMARKS=OFF \
-    -DLLVM_INCLUDE_TESTS=ON \
+    -DLLVM_INCLUDE_TESTS=OFF \
     -DLLVM_INCLUDE_UTILS=ON \
     "${common_cmake_args[@]}" \
     "${platform_config[@]}" \
     ../llvm
 
   ${MINGW_PREFIX}/bin/cmake.exe --build .
+}
 
-  # Disable automatic installation of components that go into subpackages
-  # -i.orig to check what has been removed in-case it starts dropping more than it should
-  #
-  sed -i.orig '/clang\/cmake_install.cmake/d' tools/cmake_install.cmake
+package_compiler-rt-15() {
+  pkgdesc="Runtime libraries for Clang and LLVM 15 (mingw-w64)"
+  url="https://compiler-rt.llvm.org/"
+  depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install "${srcdir}/build-${MSYSTEM}/projects/compiler-rt"
+
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/opt/llvm-15/bin/"
+  find "${pkgdir}${MINGW_PREFIX}/opt/llvm-15/lib/clang/${_version}/lib/windows/" \
+    -name '*.dll' -exec mv '{}' "${pkgdir}${MINGW_PREFIX}/opt/llvm-15/bin/" \;
+  # remove bin dir we created if it is still empty
+  rmdir "${pkgdir}${MINGW_PREFIX}/opt/llvm-15/bin/" 2>/dev/null || true
 }
 
 package_clang-15() {
-  pkgdesc="C language family frontend for LLVM (mingw-w64)"
+  pkgdesc="C language family frontend for LLVM 15 (mingw-w64)"
   url="https://clang.llvm.org/"
   depends=("${MINGW_PACKAGE_PREFIX}-llvm-15"
+           "${MINGW_PACKAGE_PREFIX}-compiler-rt-15"
            $( ((_clangprefix)) && echo \
-             "${MINGW_PACKAGE_PREFIX}-compiler-rt" \
              "${MINGW_PACKAGE_PREFIX}-crt" \
              "${MINGW_PACKAGE_PREFIX}-headers" \
              "${MINGW_PACKAGE_PREFIX}-lld" \
              "${MINGW_PACKAGE_PREFIX}-winpthreads" \
              || echo "${MINGW_PACKAGE_PREFIX}-gcc"))
 
-  cmake --install "${srcdir}/build-${MSYSTEM}/tools/clang" --prefix "${pkgdir}${MINGW_PREFIX}/opt/llvm-15"
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install "${srcdir}/build-${MSYSTEM}/tools/clang"
 }
 
 package_llvm-15() {
-  pkgdesc="Low Level Virtual Machine (mingw-w64)"
+  pkgdesc="Low Level Virtual Machine - 15 (mingw-w64)"
   depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 
-  cd "${srcdir}"/llvm
+  # Disable automatic installation of components that go into subpackages
+  # -i.orig to check what has been removed in-case it starts dropping more than it should
+  #
+  sed -i.orig '/clang\/cmake_install.cmake/d' "${srcdir}/build-${MSYSTEM}"/tools/cmake_install.cmake
+  sed -i.orig '/compiler-rt\/cmake_install.cmake/d' "${srcdir}/build-${MSYSTEM}"/projects/cmake_install.cmake
 
   DESTDIR="${pkgdir}" cmake --install "${srcdir}/build-${MSYSTEM}"
 


### PR DESCRIPTION
Previously We could only link to its libraries. Now we could use the compilers to build.