### PR TITLE
jj: update to 0.12.0

### DIFF
--- a/mingw-w64-jj/PKGBUILD
+++ b/mingw-w64-jj/PKGBUILD
@@ -4,7 +4,7 @@ _realname=jj
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
-pkgver=0.11.0
+pkgver=0.12.0
 pkgrel=1
 pkgdesc="Jujutsu (an experimental VCS) (mingw-w64)"
 arch=('any')
@@ -12,12 +12,13 @@ mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
 msys2_references=(
   'aur: jujutsu'
 )
-msys2_documentation_url=https://martinvonz.github.io/jj/v0.11.0/
+msys2_documentation_url="https://martinvonz.github.io/jj/v${pkgver}"
 url="https://github.com/martinvonz/jj"
 license=('spdx:Apache-2.0')
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
+depends=("${MINGW_PACKAGE_PREFIX}-zlib")
 source=("${url}/archive/refs/tags/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('bac30443ca362b3854f1478866f86e2f640ae4993d7581867c129ff9006f0759')
+sha256sums=('da90259cd1003d9f87af277c8b20625f3b07c3fe785fb490fe17659f2082852f')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -29,6 +30,7 @@ build() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
   ${MINGW_PREFIX}/bin/cargo build \
+    -p jj-cli \
     --release \
     --frozen \
     --all-features
@@ -42,6 +44,7 @@ check() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
   ${MINGW_PREFIX}/bin/cargo test \
+    -p jj-cli \
     --release \
     --frozen \
     --all-features


### PR DESCRIPTION
added zlib dependency as needed by ntldd output
specified `-p jj-cli`, otherwise it's recompiled