### PR TITLE
zxing-cpp: update to 2.2.1

### DIFF
--- a/mingw-w64-zxing-cpp/PKGBUILD
+++ b/mingw-w64-zxing-cpp/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=zxing-cpp
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.2.0
+pkgver=2.2.1
 pkgrel=1
 pkgdesc='A multi-format linear/matrix barcode image processing library implemented in C++ (mingw-w64)'
 arch=('any')
@@ -17,7 +17,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "unzip")
 source=(https://github.com/zxing-cpp/zxing-cpp/archive/v${pkgver}/${_realname}-${pkgver}.zip)
 noextract=("${_realname}-${pkgver}.zip")
-sha256sums=('0e088094712284a7f41bb7fef97ec2e80b92a71372dff1a658923ea4ccfb0f34')
+sha256sums=('71d9288f0637d321ee6823d8c27e684e9a00d4ffb92f18aff95fb5342cb6521d')
 
 prepare() {
   unzip -q "${_realname}-${pkgver}.zip"


### PR DESCRIPTION
This is a fix for a c++ ABI breakage of the 2.2.0 release. Only of relevance if people want to run an executable that was compiled with dynamically linking against version 2.1.0 and is still supposed to run with a new dll (of version 2.2.1).