### PR TITLE
pastix: update to 6.3.2

### DIFF
--- a/mingw-w64-pastix/PKGBUILD
+++ b/mingw-w64-pastix/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=pastix
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=6.3.1
-pkgrel=2
+pkgver=6.3.2
+pkgrel=1
 pkgdesc='High performance parallel solver for very large sparse linear systems based on direct methods (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -120,10 +120,6 @@ package() {
   #Shared Install
   cd "${srcdir}/build-${MINGW_CHOST}-shared"
   DESTDIR="${pkgdir}" cmake --install .
-
-  #From AUR: move examples into proper doc directory
-  mv "${pkgdir}${MINGW_PREFIX}"/examples/* "${pkgdir}${MINGW_PREFIX}"/share/doc/pastix/examples/
-  rm -rf "${pkgdir}${MINGW_PREFIX}"/examples/
 
   #License
   install -Dm644 ${srcdir}/${_realname}/LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE


### PR DESCRIPTION
In new version "cmake: Fix example installation path"