### PR TITLE
gtk3: Import proposed patch to support high-DPI displays

### DIFF
--- a/mingw-w64-gtk3/0006-gdkdisplay-fix-hi-dpi-awareness.patch
+++ b/mingw-w64-gtk3/0006-gdkdisplay-fix-hi-dpi-awareness.patch
@@ -1,0 +1,51 @@
+From feb4f26b5c643382241aa995034fb36b02a21a4d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=D0=A0=D1=83=D1=81=D0=BB=D0=B0=D0=BD=20=D0=98=D0=B6=D0=B1?=
+ =?UTF-8?q?=D1=83=D0=BB=D0=B0=D1=82=D0=BE=D0=B2?= <lrn1986@gmail.com>
+Date: Mon, 8 Mar 2021 14:10:56 +0000
+Subject: [PATCH] GDK W32: Use PROCESS_PER_MONITOR_DPI_AWARE
+
+According to Microsoft documentation, PROCESS_SYSTEM_DPI_AWARE, just as
+PROCESS_DPI_UNAWARE, allows Windows to scale GTK windows and do all kinds
+of stuff. To ensure this doesn't happen, we need to use PROCESS_PER_MONITOR_DPI_AWARE,
+even if GTK does not really handle DPI changes dynamically via the  WM_DPICHANGED
+message.
+
+This completely prevents Windows from scaling GTK windows when they are moved
+between screens with different scaling set up.
+---
+ gdk/win32/gdkdisplay-win32.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/gdk/win32/gdkdisplay-win32.c b/gdk/win32/gdkdisplay-win32.c
+index c2b572b4026..0fa92a71436 100644
+--- a/gdk/win32/gdkdisplay-win32.c
++++ b/gdk/win32/gdkdisplay-win32.c
+@@ -916,10 +916,10 @@ _gdk_win32_enable_hidpi (GdkWin32Display *display)
+           /* then make the GDK-using app DPI-aware */
+           if (display->shcore_funcs.setDpiAwareFunc != NULL)
+             {
+-              switch (display->shcore_funcs.setDpiAwareFunc (PROCESS_SYSTEM_DPI_AWARE))
++              switch (display->shcore_funcs.setDpiAwareFunc (PROCESS_PER_MONITOR_DPI_AWARE))
+                 {
+                   case S_OK:
+-                    display->dpi_aware_type = PROCESS_SYSTEM_DPI_AWARE;
++                    display->dpi_aware_type = PROCESS_PER_MONITOR_DPI_AWARE;
+                     status = DPI_STATUS_SUCCESS;
+                     break;
+                   case E_ACCESSDENIED:
+@@ -1000,10 +1000,10 @@ _gdk_win32_enable_hidpi (GdkWin32Display *display)
+               /* This most probably means DPI awareness is set through
+                  the manifest, or a DPI compatibility setting is used. */
+               display->dpi_aware_type = display->user32_dpi_funcs.isDpiAwareFunc () ?
+-                                        PROCESS_SYSTEM_DPI_AWARE :
++                                        PROCESS_PER_MONITOR_DPI_AWARE :
+                                         PROCESS_DPI_UNAWARE;
+ 
+-              if (display->dpi_aware_type == PROCESS_SYSTEM_DPI_AWARE)
++              if (display->dpi_aware_type != PROCESS_DPI_UNAWARE)
+                 status = DPI_STATUS_SUCCESS;
+               else
+                 status = DPI_STATUS_DISABLED;
+-- 
+GitLab
+

--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -34,6 +34,7 @@ source=("git+https://gitlab.gnome.org/GNOME/gtk.git#commit=$_commit"
         "0003-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch"
         "0004-Disable-low-level-keyboard-hook.patch"
         "0005-meson-fix-linker-flags-pkgconfig.patch"
+        "0006-gdkdisplay-fix-hi-dpi-awareness.patch"
         "gtk-query-immodules-3.0.hook.in"
         "gtk-update-icon-cache.hook.in"
         "gtk-update-icon-cache.script.in")
@@ -41,6 +42,7 @@ sha256sums=('SKIP'
             'b84a7f38f0af80680bee143d431f2a7bae53899efb337de0f67a1b4d9b59fa02'
             'e553083298495f9581ae1454b1046a22b83e81862311b30de984057eec859708'
             'f006498eaf5e93a927f1ee966512f7f059e66d3f47433eedab5c0f08692bdfac'
+            '83eb229807e2d3d3437027498802f3864bb65144d6f0b31cd3f4b9b2f7382e11'
             'adbe57eb726d882bba7a031ab8fb1788e7cd03cbf713823fd0f99d3cb380b97c'
             '56a566739c4f153f3c924b2bfe5ec7aaca469e15c023810cd7c5f57036d1a258'
             'ad431cedaa2c4a20db35c753c89b85b45c67872004255762094277d27eb7c18a')
@@ -72,6 +74,10 @@ prepare() {
   # https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/5458
   apply_patch_with_msg \
     0005-meson-fix-linker-flags-pkgconfig.patch
+
+  # https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/3275
+  apply_patch_with_msg \
+    0006-gdkdisplay-fix-hi-dpi-awareness.patch
 
 }
 


### PR DESCRIPTION
Patch is taken from:
https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/3275

Changes allow gtk to scale its windows itself instead of having Windows do the scaling. In short  this fixes bluriness issues on high-DPI screens,which I’ve encountered when distributing gtk3 software on Windows, see Cimbali/pympress#302.