### PR TITLE
mesa: Update to 23.3.1

### DIFF
--- a/mingw-w64-mesa/0001-mesa-dzn-cast-void-pointer.patch
+++ b/mingw-w64-mesa/0001-mesa-dzn-cast-void-pointer.patch
@@ -1,0 +1,20 @@
+--- a/src/microsoft/vulkan/dzn_device.c
++++ b/src/microsoft/vulkan/dzn_device.c
+@@ -2806,7 +2806,7 @@
+       if (!device->dev13)
+          goto cleanup;
+ 
+-      if (FAILED(ID3D12Device13_OpenExistingHeapFromAddress1(device->dev13, host_pointer, heap_desc.SizeInBytes, &IID_ID3D12Heap, &mem->heap)))
++      if (FAILED(ID3D12Device13_OpenExistingHeapFromAddress1(device->dev13, host_pointer, heap_desc.SizeInBytes, &IID_ID3D12Heap, (void **)&mem->heap)))
+          goto cleanup;
+ 
+       D3D12_HEAP_DESC desc = dzn_ID3D12Heap_GetDesc(mem->heap);
+@@ -3920,7 +3920,7 @@
+       return VK_ERROR_FEATURE_NOT_PRESENT;
+ 
+    ID3D12Heap *heap;
+-   if (FAILED(ID3D12Device13_OpenExistingHeapFromAddress1(device->dev13, pHostPointer, 1, &IID_ID3D12Heap, &heap)))
++   if (FAILED(ID3D12Device13_OpenExistingHeapFromAddress1(device->dev13, pHostPointer, 1, &IID_ID3D12Heap, (void **)&heap)))
+       return VK_ERROR_INVALID_EXTERNAL_HANDLE;
+ 
+    struct dzn_physical_device *pdev = container_of(device->vk.physical, struct dzn_physical_device, vk);

--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -37,12 +37,14 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-opengl-man-pages: for the OpenGL API man pa
 source=(https://mesa.freedesktop.org/archive/${_realname}-${pkgver}.tar.xz{,.sig}
         llvmwrapgen.sh
         do-not-install-standard-headers.patch
+        0001-mesa-dzn-cast-void-pointer.patch
         0003-addrlib-workaround-old-cpu-target.patch
         0005-gallium-fix-build-with-llvm-17.patch)
 sha256sums=('6e48126d70fdb3f20ffeb246ca0c2e41ffdc835f0663a03d4526b8bf5db41de6'
             'SKIP'
             '69f21522f20c10f5699dfe3e128aa88d4fedde816f6e8df1506d7470c44bf3da'
             'ac10033dd72e6ab705a8bdd5e2a47542a557d0cfc4c23fd0f319f682ec9308b8'
+            '4fb5ed3ade90d83be1d9a76c6875a5b81abc0704eabcd017f4c22402543a8e1d'
             '4e511b1ab380d0e7d1f152f89c82665e5ef7de96f26de1b5597aa1db85cfc5a4'
             '0060d3629041597fd40c86d9ebee46c1729b7fc13ba29f89a1bf0db0823b21b4')
 validpgpkeys=('8703B6700E7EE06D7A39B8D6EDAE37B02CEB490D') # Emil Velikov <emil.l.velikov@gmail.com>
@@ -81,6 +83,7 @@ prepare() {
 # Do not install standard API headers
   apply_patch_with_msg \
     do-not-install-standard-headers.patch \
+    0001-mesa-dzn-cast-void-pointer.patch \
     0003-addrlib-workaround-old-cpu-target.patch
   # https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/23827
   apply_patch_with_msg \

--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=23.3.0
+pkgver=23.3.1
 pkgrel=1
 pkgdesc="Open-source implementation of the OpenGL, Vulkan and OpenCL specifications (mingw-w64)"
 url="https://www.mesa3d.org/"
@@ -39,7 +39,7 @@ source=(https://mesa.freedesktop.org/archive/${_realname}-${pkgver}.tar.xz{,.sig
         do-not-install-standard-headers.patch
         0003-addrlib-workaround-old-cpu-target.patch
         0005-gallium-fix-build-with-llvm-17.patch)
-sha256sums=('50f729dd60ed6335b989095baad81ef5edf7cfdd4b4b48b9b955917cb07d69c5'
+sha256sums=('6e48126d70fdb3f20ffeb246ca0c2e41ffdc835f0663a03d4526b8bf5db41de6'
             'SKIP'
             '69f21522f20c10f5699dfe3e128aa88d4fedde816f6e8df1506d7470c44bf3da'
             'ac10033dd72e6ab705a8bdd5e2a47542a557d0cfc4c23fd0f319f682ec9308b8'


### PR DESCRIPTION
dzn started failing to build for unknown reasons. Trying to build 23.3,0 also fails in dzn so ir's a bug in a dependency. Maybe we need to update Directx-headers to the untagged v1.611.1.  