### PR TITLE
mingw-w64-directx-headers - remove workaround for .pc file generation…

### DIFF
--- a/mingw-w64-directx-headers/DirectX-Headers.pc.in
+++ b/mingw-w64-directx-headers/DirectX-Headers.pc.in
@@ -1,9 +1,0 @@
-prefix=MINGW_PREFIX
-includedir=${prefix}/include
-libdir=${prefix}/lib
-
-Name: DirectX-Headers
-Description: Headers for using D3D12
-Version: VERSION
-Libs: -L${libdir} -lDirectX-Headers -lDirectX-Guids
-Cflags: -I${includedir}

--- a/mingw-w64-directx-headers/PKGBUILD
+++ b/mingw-w64-directx-headers/PKGBUILD
@@ -8,7 +8,7 @@ _realname=directx-headers
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.611.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Official DirectX headers available under an open source license (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -20,10 +20,8 @@ license=('spdx:MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cc")
-source=("${_realname}-${pkgver}.tar.gz::https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v${pkgver}.tar.gz"
-       DirectX-Headers.pc.in)
-sha256sums=('edb8b52b1379f841df5d0d5e11dde08e0c3912508179fb3711f163382e88865c'
-            'ee973cd0715cc2264543e404d2a6bf885be823a34e4eb371a27901d7dae01c08')
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('edb8b52b1379f841df5d0d5e11dde08e0c3912508179fb3711f163382e88865c')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
@@ -50,12 +48,6 @@ build() {
       ../${_realname}-${pkgver}
 
   "${MINGW_PREFIX}"/bin/cmake.exe --build .
-  
-# Generate DirectX-Headers.pc manually for software that doesn't use
-# CMake for builds such as mesa.
-  sed ${srcdir}/DirectX-Headers.pc.in \
-    -e "s|VERSION|$pkgver|g" \
-    -e "s|MINGW_PREFIX|${MINGW_PREFIX}|g" > DirectX-Headers.pc
 }
 
 package() {


### PR DESCRIPTION
….  CMake now does that in the build system.