### PR TITLE
libdovi: fix missing `--all-features` option

### DIFF
--- a/mingw-w64-libdovi/PKGBUILD
+++ b/mingw-w64-libdovi/PKGBUILD
@@ -5,12 +5,15 @@ _sourcename=dovi_tool-${_realname}
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=3.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Library to read and write Dolby Vision metadata (C-API)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url='https://github.com/quietvoid/dovi_tool/tree/main/dolby_vision'
-license=('MIT')
+license=('spdx:MIT')
+msys2_references=(
+  'archlinux: libdovi'
+)
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-cargo-c")
 source=("https://github.com/quietvoid/dovi_tool/archive/refs/tags/libdovi-${pkgver}.tar.gz")
@@ -28,6 +31,7 @@ build() {
   cargo cbuild \
     --release \
     --frozen \
+    --all-features \
     --prefix="${MINGW_PREFIX}"
 }
 
@@ -47,6 +51,7 @@ package() {
     cargo cinstall \
         --release \
         --frozen \
+        --all-features \
         --prefix="${MINGW_PREFIX}" \
         --destdir="${pkgdir}"
 


### PR DESCRIPTION
and some metadata while at it