### PR TITLE
watchexec: update to 1.24.1

### DIFF
--- a/mingw-w64-watchexec/PKGBUILD
+++ b/mingw-w64-watchexec/PKGBUILD
@@ -1,16 +1,20 @@
 _realname=watchexec
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.23.0
+pkgver=1.24.1
 pkgrel=1
+msys2_repository_url="https://github.com/watchexec/watchexec/"
 url="https://watchexec.github.io/"
 pkgdesc="Executes commands in response to file modifications (mingw-w64)"
 license=('spdx:Apache-2.0')
+msys2_references=(
+  'archlinux: watchexec'
+)
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
-source=("https://github.com/watchexec/watchexec/archive/v${pkgver}.tar.gz")
-sha256sums=('2a321962669979feef44ea7a6220819d5c916ca939eba41b033ea346a44caa90')
+source=("https://github.com/watchexec/watchexec/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('9afc736fd4c0f895c89b7d6b1bbbb831fdb255400f785dcd3a414f62a5db6bd5')
 
 prepare() {
   cd "${_realname}-${pkgver}"
@@ -21,13 +25,13 @@ prepare() {
 build() {
   cd "${_realname}-${pkgver}"
 
-  cargo build --release --frozen
+  cargo build --release --frozen -p watchexec-cli
 }
 
 check() {
   cd "${_realname}-${pkgver}"
 
-  cargo test --release --frozen
+  cargo test --release --frozen -p watchexec-cli
 }
 
 package() {
@@ -38,14 +42,13 @@ package() {
     --offline \
     --no-track \
     --path crates/cli \
-    --root "${pkgdir}${MINGW_PREFIX}" \
-    watchexec-cli
+    --root "${pkgdir}${MINGW_PREFIX}"
 
-  install -Dm644 completions/zsh "$pkgdir${MINGW_PREFIX}/share/zsh/site-functions/_watchexec"
-  install -Dm644 doc/watchexec.1 "$pkgdir${MINGW_PREFIX}/share/man/man1/watchexec.1"
-  install -Dm644 doc/watchexec.1.pdf "$pkgdir${MINGW_PREFIX}/share/doc/watchexec/watchexec.1.pdf"
-  install -Dm644 doc/watchexec.1.md "$pkgdir${MINGW_PREFIX}/share/doc/watchexec/watchexec.1.md"
-  install -Dm644 doc/logo.svg "$pkgdir${MINGW_PREFIX}/share/icons/hicolor/scalable/apps/watchexec.svg"
-  install -Dm644 LICENSE "$pkgdir${MINGW_PREFIX}/share/licenses/watchexec/LICENSE"
-  install -Dm644 README.md "${pkgdir}${MINGW_PREFIX}/share/doc/watchexec/README"
+  install -Dm644 completions/bash "${pkgdir}${MINGW_PREFIX}/share/bash-completion/completions/watchexec"
+  install -Dm644 completions/zsh "${pkgdir}${MINGW_PREFIX}/share/zsh/site-functions/_watchexec"
+  install -Dm644 completions/fish "${pkgdir}${MINGW_PREFIX}/share/fish/vendor_completions.d/watchexec.fish"
+  install -Dm644 doc/watchexec.1 "${pkgdir}${MINGW_PREFIX}/share/man/man1/watchexec.1"
+  install -Dm644 doc/watchexec.1.md "${pkgdir}${MINGW_PREFIX}/share/doc/watchexec/watchexec.1.md"
+  install -Dm644 doc/logo.svg "${pkgdir}${MINGW_PREFIX}/share/icons/hicolor/scalable/apps/watchexec.svg"
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/watchexec/LICENSE"
 }


### PR DESCRIPTION
- specified `-p watchexec-cli`, otherwise it's recompiled
- more competions
- some docs' cleanup