### PR TITLE
gtk3: Update to 3.24.39

### DIFF
--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -3,16 +3,14 @@
 _realname=gtk3
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-gtk-update-icon-cache")
-pkgver=3.24.38.r43.g0f717ca
+pkgver=3.24.39
 pkgrel=1
-_commit=0f717ca4239175334ff54c72b0f0d1953d9f95b5
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://www.gtk.org/"
 license=("spdx:LGPL-2.1-or-later")
-makedepends=("git"
-             "${MINGW_PACKAGE_PREFIX}-cc"
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-gtk-doc"
              "${MINGW_PACKAGE_PREFIX}-meson"
@@ -30,14 +28,14 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-pango"
          "${MINGW_PACKAGE_PREFIX}-shared-mime-info")
 options=('strip' '!debug' 'staticlibs')
-source=("git+https://gitlab.gnome.org/GNOME/gtk.git#commit=$_commit"
+source=("https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}.tar.xz"
         "0003-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch"
         "0004-Disable-low-level-keyboard-hook.patch"
         "0005-meson-fix-linker-flags-pkgconfig.patch"
         "gtk-query-immodules-3.0.hook.in"
         "gtk-update-icon-cache.hook.in"
         "gtk-update-icon-cache.script.in")
-sha256sums=('SKIP'
+sha256sums=('1cac3e566b9b2f3653a458c08c2dcdfdca9f908037ac03c9d8564b4295778d79'
             'b84a7f38f0af80680bee143d431f2a7bae53899efb337de0f67a1b4d9b59fa02'
             'e553083298495f9581ae1454b1046a22b83e81862311b30de984057eec859708'
             'f006498eaf5e93a927f1ee966512f7f059e66d3f47433eedab5c0f08692bdfac'
@@ -54,13 +52,8 @@ apply_patch_with_msg() {
   done
 }
 
-pkgver() {
-  cd "${srcdir}/gtk"
-  git describe --long --abbrev=7 | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
-}
-
 prepare() {
-  cd "${srcdir}/gtk"
+  cd "${srcdir}/gtk+-${pkgver}"
 
   # https://gitlab.gnome.org/GNOME/gtk/issues/760
   apply_patch_with_msg \
@@ -72,7 +65,6 @@ prepare() {
   # https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/5458
   apply_patch_with_msg \
     0005-meson-fix-linker-flags-pkgconfig.patch
-
 }
 
 build() {
@@ -98,7 +90,7 @@ build() {
     "${extra_config[@]}" \
     -Dbroadway_backend=true \
     -Dman=true \
-    "../gtk"
+    "../gtk+-${pkgver}"
 
   meson compile
 }
@@ -124,7 +116,7 @@ package_gtk3() {
   mv ${pkgdir}${MINGW_PREFIX}/bin/gtk-update-icon-cache "$srcdir"
   mv ${pkgdir}${MINGW_PREFIX}/share/man/man1/gtk-update-icon-cache.1 "$srcdir"
 
-  install -Dm644 "${srcdir}/gtk/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+  install -Dm644 "${srcdir}/gtk+-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }
 
 package_gtk-update-icon-cache() {


### PR DESCRIPTION
move back to use the tarball, since there haven't been many updates recently, and cloning is slow and results in huge source packages.