### PR TITLE
uriparser: restore uriparser-config-*.cmake files

### DIFF
--- a/mingw-w64-uriparser/PKGBUILD
+++ b/mingw-w64-uriparser/PKGBUILD
@@ -7,12 +7,12 @@ pkgver=0.9.7
 pkgrel=1
 pkgdesc="RFC 3986 URI parsing and processing libary (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://uriparser.github.io/"
 license=('spdx:BSD-3-Clause')
-makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-ninja"
-             "${MINGW_PACKAGE_PREFIX}-cc")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-gtest")
 source=("https://github.com/${_realname}/${_realname}/releases/download/${_realname}-${pkgver}/${_realname}-${pkgver}.tar.xz")
 sha256sums=('1ddae35cb3cc2c36e8199829d46f1c7f8b222e74a723fdae67ec8561e1ac5a39')
@@ -26,7 +26,6 @@ build() {
   fi
 
   # Shared
-  [[ -d "${srcdir}/build-${MSYSTEM}-shared" ]] && rm -rf "${srcdir}/build-${MSYSTEM}-shared"
   mkdir -p "${srcdir}/build-${MSYSTEM}-shared" && cd "${srcdir}/build-${MSYSTEM}-shared"
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
@@ -34,7 +33,7 @@ build() {
       -G'Ninja' \
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
       -DCMAKE_INSTALL_LIBDIR=lib \
-      ${_extra_config[@]} \
+      "${_extra_config[@]}" \
       -DBUILD_SHARED_LIBS=ON \
       -DURIPARSER_BUILD_TESTS=OFF \
       -DURIPARSER_BUILD_DOCS=OFF \
@@ -43,7 +42,6 @@ build() {
   ${MINGW_PREFIX}/bin/cmake --build .
 
   # Static
-  [[ -d "${srcdir}/build-${MSYSTEM}-static" ]] && rm -rf "${srcdir}/build-${MSYSTEM}-static"
   mkdir -p "${srcdir}/build-${MSYSTEM}-static" && cd "${srcdir}/build-${MSYSTEM}-static"
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
@@ -51,8 +49,9 @@ build() {
       -G'Ninja' \
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
       -DCMAKE_INSTALL_LIBDIR=lib \
-      ${_extra_config[@]} \
+      "${_extra_config[@]}" \
       -DBUILD_SHARED_LIBS=OFF \
+      -DURIPARSER_BUILD_TOOLS=OFF \
       -DURIPARSER_BUILD_TESTS=OFF \
       -DURIPARSER_BUILD_DOCS=OFF \
       ../${_realname}-${pkgver}
@@ -68,12 +67,13 @@ check() {
 }
 
 package() {
-  # Static
-  cd "${srcdir}/build-${MSYSTEM}-static"
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
-
   # Shared
   cd "${srcdir}/build-${MSYSTEM}-shared"
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
 
+  # Static
+  cd "${srcdir}/build-${MSYSTEM}-static"
+  cp liburiparser.a "${pkgdir}"${MINGW_PREFIX}/lib/
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
For some reason, when shared build installed after static one those files got removed!