### PR TITLE
SFCGAL: Update to 1.5.1

### DIFF
--- a/mingw-w64-python-pysfcgal/PKGBUILD
+++ b/mingw-w64-python-pysfcgal/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=pysfcgal
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
-pkgver=1.5.0
+pkgver=1.5.1
 pkgrel=1
 pkgdesc='Python SFCGAL binding (mingw-w64)'
 arch=('any')
@@ -23,7 +23,7 @@ makedepends=(${MINGW_PACKAGE_PREFIX}-python-setuptools
     ${MINGW_PACKAGE_PREFIX}-python-cffi
     ${MINGW_PACKAGE_PREFIX}-cc)
 source=(https://gitlab.com/SFCGAL/pysfcgal/-/archive/v${pkgver}/pysfcgal-v${pkgver}.tar.gz)
-sha256sums=('0ab7468f15a51aab4ddf103205493279edacf876bc30c6406ec2da9cf6aacb27')
+sha256sums=('1207d4dad15eb7d18e5fcd1ffa33d8f7968505c26ec1ddbb520ecd6f0a487315')
 
 prepare() {
   rm -rf python-build-${MSYSTEM} | true

--- a/mingw-w64-sfcgal/PKGBUILD
+++ b/mingw-w64-sfcgal/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=sfcgal
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.5.0
+pkgver=1.5.1
 pkgrel=1
 pkgdesc="Wrapper around CGAL that intents to implement 2D and 3D operations on OGC standards models (mingw-w64)"
 arch=('any')
@@ -21,7 +21,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-mpfr"
          "${MINGW_PACKAGE_PREFIX}-cgal")
 source=(https://gitlab.com/SFCGAL/SFCGAL/-/archive/v${pkgver}/SFCGAL-v${pkgver}.tar.gz)
-sha256sums=('84f4d7cfb13e871d7472309722f6fb88982b3e4e2bb4b320df90b24f43c66f82')
+sha256sums=('ea5d1662fada7de715ad564dc810c3059024ed81ae393f5352489f706fdfa3b1')
 
 build() {
   [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}


### PR DESCRIPTION
Update to 1.5.1

Changes:
```
1.5.1 (2023-12-21):
    * Rewrite and fix visibility algorithm (Loïc Bartoletti)
    * Apply clang-tidy fixes (Loïc Bartoletti)
    * Add vcpkg CI and temporarily disable alpha-shapes for MSVC (Loïc Bartoletti)
```