### PR TITLE
libjxl: update to 0.9.1

### DIFF
--- a/mingw-w64-libjxl/PKGBUILD
+++ b/mingw-w64-libjxl/PKGBUILD
@@ -4,11 +4,12 @@
 _realname=libjxl
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.8.2
-pkgrel=2
+pkgver=0.9.1
+pkgrel=1
 pkgdesc='JPEG XL image format reference implementation (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+msys2_repository_url='https://github.com/libjxl/libjxl'
 url="https://jpeg.org/jpegxl/"
 license=('spdx:BSD-3-Clause')
 depends=("${MINGW_PACKAGE_PREFIX}-brotli"
@@ -27,14 +28,12 @@ makedepends=("git"
              "${MINGW_PACKAGE_PREFIX}-asciidoc"
              "${MINGW_PACKAGE_PREFIX}-gdk-pixbuf2")
 optdepends=("${MINGW_PACKAGE_PREFIX}-gdk-pixbuf2: for gdk-pixbuf loader")
-source=("git+https://github.com/libjxl/libjxl.git#tag=v${pkgver}")
-sha256sums=('SKIP')
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/libjxl/libjxl/archive/v${pkgver}.tar.gz")
+sha256sums=('a0e72e9ece26878147069ad4888ac3382021d4bbee71c2e1b687d5bde7fd7e01')
+noextract=("${_realname}-${pkgver}.tar.gz")
 
 prepare() {
-  cd "${_realname}"
-
-  git submodule init
-  git submodule update third_party/skcms
+  tar -xzf "${_realname}-${pkgver}.tar.gz" || true
 }
 
 build() {
@@ -45,14 +44,39 @@ build() {
     _extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
-  [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
-  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
-
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-  ${MINGW_PREFIX}/bin/cmake.exe \
+  ${MINGW_PREFIX}/bin/cmake \
     -G"Ninja" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     "${_extra_config[@]}" \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DBUILD_TESTING=OFF \
+    -DJPEGXL_BUNDLE_LIBPNG=OFF \
+    -DJPEGXL_ENABLE_BENCHMARK=OFF \
+    -DJPEGXL_ENABLE_DOXYGEN=OFF \
+    -DJPEGXL_ENABLE_EXAMPLES=OFF \
+    -DJPEGXL_ENABLE_JNI=OFF \
+    -DJPEGXL_ENABLE_PLUGINS=OFF \
+    -DJPEGXL_ENABLE_SJPEG=OFF \
+    -DJPEGXL_ENABLE_SKCMS=OFF \
+    -DJPEGXL_ENABLE_TCMALLOC=OFF \
+    -DJPEGXL_ENABLE_TOOLS=OFF \
+    -DJPEGXL_FORCE_SYSTEM_BROTLI=ON \
+    -DJPEGXL_FORCE_SYSTEM_HWY=ON \
+    -DJPEGXL_FORCE_SYSTEM_LCMS2=ON \
+    -DJPEGXL_VERSION=${pkgver}-${pkgrel} \
+    -DJPEGXL_WARNINGS_AS_ERRORS=OFF \
+    -S ${_realname}-${pkgver} \
+    -B build-${MSYSTEM}-static
+
+  ${MINGW_PREFIX}/bin/cmake --build build-${MSYSTEM}-static
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake \
+    -G"Ninja" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    "${_extra_config[@]}" \
+    -DBUILD_SHARED_LIBS=ON \
     -DBUILD_TESTING=OFF \
     -DJPEGXL_BUNDLE_LIBPNG=OFF \
     -DJPEGXL_ENABLE_BENCHMARK=OFF \
@@ -68,10 +92,12 @@ build() {
     -DJPEGXL_FORCE_SYSTEM_BROTLI=ON \
     -DJPEGXL_FORCE_SYSTEM_HWY=ON \
     -DJPEGXL_FORCE_SYSTEM_LCMS2=ON \
+    -DJPEGXL_VERSION=${pkgver}-${pkgrel} \
     -DJPEGXL_WARNINGS_AS_ERRORS=OFF \
-    ../${_realname}
+    -S ${_realname}-${pkgver} \
+    -B build-${MSYSTEM}-shared
 
-  ${MINGW_PREFIX}/bin/cmake.exe --build ./
+  ${MINGW_PREFIX}/bin/cmake --build build-${MSYSTEM}-shared
 }
 
 check() {
@@ -80,8 +106,8 @@ check() {
 }
 
 package() {
-  cd "${srcdir}/build-${MSYSTEM}"
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install ./
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install build-${MSYSTEM}-static
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install build-${MSYSTEM}-shared
 
-  install -Dm644 "${srcdir}/${_realname}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
Dry run for now - there's quite a few dependencies to be checked and rebuilt as the API has changed.

darktable 4.6 was already proofed ahead for 0.9.x
gimp ?
gimp3 ?
graphicsmagick ?
imagemagick ?
kimageformats-qt5 ?
krita ?
libvips ?
python-imagecodecs ?
SDL2_image ?








