### PR TITLE
clang: backport binutils windres compat changes

### DIFF
--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -32,7 +32,7 @@ _version=17.0.6
 _rc=
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
-pkgrel=4
+pkgrel=5
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -69,7 +69,10 @@ source=("${_url}/llvm-${pkgver}.src.tar.xz"{,.sig}
         "0004-enable-emutls-for-mingw.patch"
         "0101-link-pthread-with-mingw.patch"
         "0102-Rename-flang-new-flang-experimental-exec-to-flang.patch"
-        "0303-ignore-new-bfd-options.patch")
+        "0303-ignore-new-bfd-options.patch"
+        https://github.com/llvm/llvm-project/commit/10b78cc8cea65e7e77d227af4027963f39402724.patch
+        https://github.com/llvm/llvm-project/commit/1709e8c656de69f6d823a3ae6773bf815e373909.patch
+        https://github.com/llvm/llvm-project/commit/9e3d915d8ebf86e24c9ff58766be8e7c6aa7b0c0.patch)
 # Some patch notes :)
 #0001-0099 -> llvm
 #0101-0199 -> clang
@@ -96,7 +99,10 @@ sha256sums=('b638167da139126ca11917b6880207cc6e8f9d1cbb1a48d87d017f697ef78188'
             '5f86e542dd1ec92b2fe06ee59061c3e23512df7bafabe82206f2b7d80b81836b'
             '715cb8862753854b2d9256e0b70003e2d1f57083d83eaeaf5a095fc72b8a4e26'
             '2770cadf8ccf6b31aece6aee8f76dceb71e6e9d01fdf3be74c3743480ce34899'
-            'de631ab199a6fe83b3f695350bffaad067a2f95fc2ba9c8fe57dc85665d3653c')
+            'de631ab199a6fe83b3f695350bffaad067a2f95fc2ba9c8fe57dc85665d3653c'
+            '88c4994341b4de2a23929e31a98031cb94b6d42575f9d8fd6e120f61ae0c5747'
+            '0f3dcb8b2d5f90f8ff2e77896d3b0ef6c87af8214e679917898e35dd678daef5'
+            'e745aa71c903445c86639507256a5ca775e69b569b58f2ff48d6047703cfc81a')
 validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Google.
               '474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard
               'D574BD5D1D0E98895E3BF90044F2485E45D59042') # Tobias Hieta
@@ -127,6 +133,13 @@ prepare() {
   for pkg in llvm clang clang-tools-extra compiler-rt lld cmake third-party; do
     mv ${pkg}-$pkgver.src ${pkg}
   done
+
+  # Backports for llvm-windres, for improved compat with binutils 3.26+
+  # https://github.com/msys2/MINGW-packages/pull/19157#issuecomment-1825285063
+  apply_patch_with_msg \
+    "10b78cc8cea65e7e77d227af4027963f39402724.patch" \
+    "1709e8c656de69f6d823a3ae6773bf815e373909.patch" \
+    "9e3d915d8ebf86e24c9ff58766be8e7c6aa7b0c0.patch"
 
   # Patch llvm
   cd "${srcdir}/llvm"


### PR DESCRIPTION
See https://github.com/msys2/MINGW-packages/pull/19157#issuecomment-1825285063