### PR TITLE
i2pd: update to 2.50.1

### DIFF
--- a/mingw-w64-i2pd/PKGBUILD
+++ b/mingw-w64-i2pd/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=i2pd
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-pkgver=2.49.0
+pkgver=2.50.1
 pkgrel=1
 pkgdesc='A full-featured C++ implementation of the I2P router (mingw-w64)'
 url='https://i2pd.website/'
@@ -20,7 +20,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/PurpleI2P/i2pd/archive/${pkgver}.tar.gz")
-sha256sums=('d8e07f78cc9f1ba65e8460db27c649dd0cfdd3ba334725f8d6f9ee815cb40e68')
+sha256sums=('74c8fcffbadd10a5c3fd8a7a7a8557145fe95087898f5663123a707a1c72896d')
 noextract=("${_realname}-${pkgver}.tar.gz") # symlinks
 
 prepare() {


### PR DESCRIPTION
We created minor release with OpenSSL 3.2.0 support fix, so now it can be updated.