### PR TITLE
{libblocksruntime,delta}: cleanup wrong references

### DIFF
--- a/mingw-w64-delta/PKGBUILD
+++ b/mingw-w64-delta/PKGBUILD
@@ -10,6 +10,11 @@ arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://github.com/dandavison/delta"
 license=('spdx:MIT')
+msys2_references=(
+  'archlinux: git-delta'
+  'aur'
+  'cygwin'
+)
 depends=('git')
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
 source=("https://github.com/dandavison/delta/archive/refs/tags/$pkgver.tar.gz"

--- a/mingw-w64-libblocksruntime/PKGBUILD
+++ b/mingw-w64-libblocksruntime/PKGBUILD
@@ -10,6 +10,9 @@ arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
 url="https://compiler-rt.llvm.org"
 license=('spdx:NCSA' 'spdx:MIT')
+msys2_references=(
+  'archlinux'
+)
 depends=("${MINGW_PACKAGE_PREFIX}-clang")
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools" "${MINGW_PACKAGE_PREFIX}-cc")
 source=("https://deb.debian.org/debian/pool/main/libb/${_realname}/${_realname}_${pkgver}.orig.tar.gz"


### PR DESCRIPTION
~~wrote `git-delta-git` for AUR references so it properly links to it
(there is no other way to do it)~~

I decided it's better to just remove the reference 