### PR TITLE
[new-package] python-versioneer 0.29

### DIFF
--- a/mingw-w64-python-versioneer/001-fix-build.patch
+++ b/mingw-w64-python-versioneer/001-fix-build.patch
@@ -1,0 +1,11 @@
+--- a/setup.py
++++ b/setup.py
+@@ -125,7 +125,7 @@
+         s = Path("src/installer.py").read_text()
+         s = ver(s.replace("@VERSIONEER-INSTALLER@", v_b64))
+         with tempfile.TemporaryDirectory() as tempdir:
+-            installer = Path(tempdir) / "versioneer.py"
++            installer = Path(os.getcwd()) / "versioneer.py"
+             installer.write_text(s)
+ 
+             self.package_dir.update({'': os.path.relpath(installer.parent)})

--- a/mingw-w64-python-versioneer/PKGBUILD
+++ b/mingw-w64-python-versioneer/PKGBUILD
@@ -1,0 +1,46 @@
+# Contributor: Mehdi Chinoune <mehdi.chinoune@hotmail.com>
+
+_realname=versioneer
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=0.29
+pkgrel=1
+pkgdesc="Easy VCS-based management of project version strings (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/python-versioneer/python-versioneer'
+msys2_references=(
+  'pypi: versioneer'
+)
+license=('spdx:Unlicense')
+depends=("${MINGW_PACKAGE_PREFIX}-python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python-wheel")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
+        "001-fix-build.patch")
+sha256sums=('5ab283b9857211d61b53318b7c792cf68e798e765ee17c27ade9f6c924235731'
+            '04c0afd639faba3fa1d03528be738013e5e19796502ed42ee599dbf748da3d18')
+
+prepare() {
+  cd ${_realname}-${pkgver}
+  patch -p1 -i "${srcdir}"/001-fix-build.patch
+}
+
+build() {
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "${srcdir}/python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}


### PR DESCRIPTION
This package is required for the latest constantly and pandas python packages.
But It fails to build because the prefix disk `D:\` is different that source disk `C:\`.