### PR TITLE
libavif: Add private dependencies in pkgconfig file

### DIFF
--- a/mingw-w64-libavif/0001-libavif-pkgconfig-add-private-deps.patch
+++ b/mingw-w64-libavif/0001-libavif-pkgconfig-add-private-deps.patch
@@ -1,0 +1,74 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 01bb619..9d46ddd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -66,6 +66,9 @@ option(AVIF_LOCAL_AVM "Build the AVM (AV2) codec by providing your own copy of t
+        OFF
+ )
+ 
++set(AVIF_PKG_CONFIG_EXTRA_LIBS_PRIVATE "")
++set(AVIF_PKG_CONFIG_EXTRA_REQUIRES_PRIVATE "")
++
+ if(AVIF_LOCAL_LIBGAV1)
+     enable_language(CXX)
+ endif()
+@@ -181,6 +184,7 @@ if(libyuv_FOUND)
+     set(AVIF_PLATFORM_DEFINITIONS ${AVIF_PLATFORM_DEFINITIONS} -DAVIF_LIBYUV_ENABLED=1)
+     set(AVIF_PLATFORM_INCLUDES ${AVIF_PLATFORM_INCLUDES} ${LIBYUV_INCLUDE_DIR})
+     set(AVIF_PLATFORM_LIBRARIES ${AVIF_PLATFORM_LIBRARIES} ${LIBYUV_LIBRARY})
++    set(AVIF_PKG_CONFIG_EXTRA_LIBS_PRIVATE "${AVIF_PKG_CONFIG_EXTRA_LIBS_PRIVATE} -lyuv")
+ endif(libyuv_FOUND)
+ option(AVIF_LOCAL_LIBSHARPYUV "Build libsharpyuv by providing your own copy inside the ext subdir." OFF)
+ if(AVIF_LOCAL_LIBSHARPYUV)
+@@ -204,6 +208,7 @@ if(libsharpyuv_FOUND)
+     set(AVIF_PLATFORM_DEFINITIONS ${AVIF_PLATFORM_DEFINITIONS} -DAVIF_LIBSHARPYUV_ENABLED=1)
+     set(AVIF_PLATFORM_INCLUDES ${AVIF_PLATFORM_INCLUDES} ${LIBSHARPYUV_INCLUDE_DIR})
+     set(AVIF_PLATFORM_LIBRARIES ${AVIF_PLATFORM_LIBRARIES} ${LIBSHARPYUV_LIBRARY})
++    set(AVIF_PKG_CONFIG_EXTRA_REQUIRES_PRIVATE "${AVIF_PKG_CONFIG_EXTRA_REQUIRES_PRIVATE} libsharpyuv")
+ else(libsharpyuv_FOUND)
+     message(STATUS "libavif: libsharpyuv not found")
+ endif(libsharpyuv_FOUND)
+@@ -334,6 +339,7 @@ if(AVIF_CODEC_DAV1D)
+             set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES} ${DAV1D_INCLUDE_DIR})
+         endif()
+         set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${DAV1D_LIBRARY})
++        set(AVIF_PKG_CONFIG_EXTRA_REQUIRES_PRIVATE "${AVIF_PKG_CONFIG_EXTRA_REQUIRES_PRIVATE} dav1d")
+     endif()
+ 
+     if(UNIX AND NOT APPLE)
+@@ -393,6 +399,7 @@ if(AVIF_CODEC_RAV1E)
+             set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES} ${RAV1E_INCLUDE_DIR})
+         endif()
+         set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${RAV1E_LIBRARIES})
++        set(AVIF_PKG_CONFIG_EXTRA_REQUIRES_PRIVATE "${AVIF_PKG_CONFIG_EXTRA_REQUIRES_PRIVATE} rav1e")
+     endif()
+ 
+     # Unfortunately, rav1e requires a few more libraries
+@@ -426,6 +433,7 @@ if(AVIF_CODEC_SVT)
+             set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES} ${SVT_INCLUDE_DIR})
+         endif()
+         set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${SVT_LIBRARY})
++        set(AVIF_PKG_CONFIG_EXTRA_REQUIRES_PRIVATE "${AVIF_PKG_CONFIG_EXTRA_REQUIRES_PRIVATE} SvtAv1Enc")
+     endif()
+ 
+     message(STATUS "libavif: Codec enabled: svt (encode)")
+@@ -464,6 +472,7 @@ if(AVIF_CODEC_AOM)
+             set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES} ${AOM_INCLUDE_DIR})
+         endif()
+         set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${AOM_LIBRARIES})
++        set(AVIF_PKG_CONFIG_EXTRA_REQUIRES_PRIVATE "${AVIF_PKG_CONFIG_EXTRA_REQUIRES_PRIVATE} aom")
+     endif()
+ 
+     message(STATUS "libavif: Codec enabled: aom (${AVIF_CODEC_AOM_ENCODE_DECODE_CONFIG})")
+diff --git a/libavif.pc.cmake b/libavif.pc.cmake
+index c091443..1341c2b 100644
+--- a/libavif.pc.cmake
++++ b/libavif.pc.cmake
+@@ -7,4 +7,7 @@ Name: @PROJECT_NAME@
+ Description: Library for encoding and decoding .avif files
+ Version: @PROJECT_VERSION@
+ Libs: -L${libdir} -lavif
++Libs.private:@AVIF_PKG_CONFIG_EXTRA_LIBS_PRIVATE@
+ Cflags: -I${includedir}@AVIF_PKG_CONFIG_EXTRA_CFLAGS@
++Cflags.private: -UAVIF_DLL
++Requires.private:@AVIF_PKG_CONFIG_EXTRA_REQUIRES_PRIVATE@

--- a/mingw-w64-libavif/PKGBUILD
+++ b/mingw-w64-libavif/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libavif
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.0.3
-pkgrel=2
+pkgrel=3
 pkgdesc="Library for encoding and decoding .avif files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -26,8 +26,17 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-cc")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-gtest")
-source=("${_realname}-${pkgver}.tar.gz::https://github.com/AOMediaCodec/libavif/archive/v${pkgver}.tar.gz")
-sha512sums=('b713f35fd3e54e105e16f46012becdada86f522b4ed8ab7097a93fd437524b4f2c997c42d6f06828f93b53253b1d90302417afdb0bd8e09d176f64f19c7a0faa')
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/AOMediaCodec/libavif/archive/v${pkgver}.tar.gz"
+        0001-libavif-pkgconfig-add-private-deps.patch)
+sha512sums=('b713f35fd3e54e105e16f46012becdada86f522b4ed8ab7097a93fd437524b4f2c997c42d6f06828f93b53253b1d90302417afdb0bd8e09d176f64f19c7a0faa'
+            '16c6d24c428527bad9b568052e5c5cca5387bfdbee3ecd86fe78c305e72af7207e3546ee8bfdf873acdd21db4fce599bb59c2fbf83e61c8fcf8e9fe9631fb960')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+
+  # backported from upstream
+  patch -p1 -i "${srcdir}/0001-libavif-pkgconfig-add-private-deps.patch"
+}
 
 build() {
   declare -a extra_config


### PR DESCRIPTION
This fixes static linking with sdl2_image library.

Fixes #19538