### PR TITLE
android-tools: Fix compiler error due to SetThreadDescription name collision

### DIFF
--- a/mingw-w64-android-tools/0004-fix-SetThreadDescription-name-collision.patch
+++ b/mingw-w64-android-tools/0004-fix-SetThreadDescription-name-collision.patch
@@ -1,0 +1,18 @@
+--- a/vendor/adb/sysdeps_win32.cpp
++++ b/vendor/adb/sysdeps_win32.cpp
+@@ -3089,13 +3089,13 @@
+ }
+ 
+ // The SetThreadDescription API was brought in version 1607 of Windows 10.
+-typedef HRESULT(WINAPI* SetThreadDescription)(HANDLE hThread, PCWSTR lpThreadDescription);
++typedef HRESULT(WINAPI* SetThreadDescriptionFunc)(HANDLE hThread, PCWSTR lpThreadDescription);
+ 
+ // Based on PlatformThread::SetName() from
+ // https://cs.chromium.org/chromium/src/base/threading/platform_thread_win.cc
+ int adb_thread_setname(const std::string& name) {
+     // The SetThreadDescription API works even if no debugger is attached.
+-    auto set_thread_description_func = reinterpret_cast<SetThreadDescription>(
++    auto set_thread_description_func = reinterpret_cast<SetThreadDescriptionFunc>(
+             ::GetProcAddress(::GetModuleHandleW(L"Kernel32.dll"), "SetThreadDescription"));
+     if (set_thread_description_func) {
+         std::wstring name_wide;

--- a/mingw-w64-android-tools/PKGBUILD
+++ b/mingw-w64-android-tools/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=34.0.4
 _tag=${pkgver}
-pkgrel=2
+pkgrel=3
 pkgdesc='Android platform tools (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -29,7 +29,8 @@ source=("https://github.com/nmeum/android-tools/releases/download/${_tag}/${_rea
         "AdbWinApi.def"
         "0001-android-tools-cmake.patch"
         "0002-android-tools-vendor.patch"
-        "0003-fix-building-with-gcc-mingw.patch")
+        "0003-fix-building-with-gcc-mingw.patch"
+        "0004-fix-SetThreadDescription-name-collision.patch")
 noextract=("${_realname}-${_tag}.tar.xz")
 sha256sums=('7a22ff9cea81ff4f38f560687858e8f8fb733624412597e3cc1ab0262f8da3a1'
             'd8856c8d3e4315393c4c47cffa491e973932d39efbe8bfdd2a0456d16b9c56cc'
@@ -37,7 +38,8 @@ sha256sums=('7a22ff9cea81ff4f38f560687858e8f8fb733624412597e3cc1ab0262f8da3a1'
             'e6fc31c148e120fc69be53e0464434c492ab0eaa0dbc8f18dd3c19eb2dd2577b'
             '7e394b2c0d86bec01c06995a07e7bcf90ff44fe93dc38f5b58c20d7d52d96a65'
             '3c66c9756272a63d4e5b8a13b2d55e6b42bf3f0a297739cf3ea78e8fd7a3881e'
-            '528e7a2dbf366832d6ae339e013de7c311efb7fa9139ce3478bc18fe29b0542d')
+            '528e7a2dbf366832d6ae339e013de7c311efb7fa9139ce3478bc18fe29b0542d'
+            '2fe4ceec9d73cea98a37ae7b6844a1c1abbb7bf14cb696f4e14b632fea33aa3c')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -58,7 +60,8 @@ prepare() {
   apply_patch_with_msg \
     0001-android-tools-cmake.patch \
     0002-android-tools-vendor.patch \
-    0003-fix-building-with-gcc-mingw.patch
+    0003-fix-building-with-gcc-mingw.patch \
+    0004-fix-SetThreadDescription-name-collision.patch
 }
 
 build() {


### PR DESCRIPTION
SetThreadDescription was added in https://github.com/mingw-w64/mingw-w64/commit/3a137bd87e commit.

Thanks to MehdiChinoune who found this issue.