### PR TITLE
glpk: Do not use embedded zlib nor embedded suitesparse

### DIFF
--- a/mingw-w64-glpk/0003-no-embedded-zlib.patch
+++ b/mingw-w64-glpk/0003-no-embedded-zlib.patch
@@ -1,0 +1,52 @@
+Description: Do not use embedded copy of zlib
+Author: Sébastien Villemot <sebastien@debian.org>
+Forwarded: not-needed
+Last-Update: 2013-06-25
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -18,8 +18,7 @@ libglpk_la_CPPFLAGS = \
+ -I$(srcdir)/mpl \
+ -I$(srcdir)/npp \
+ -I$(srcdir)/proxy \
+--I$(srcdir)/simplex \
+--I$(srcdir)/zlib
++-I$(srcdir)/simplex
+ 
+ libglpk_la_LDFLAGS = \
+ -version-info 43:1:3 \
+@@ -202,21 +201,6 @@ simplex/spxprim.c \
+ simplex/spxprob.c \
+ simplex/spychuzc.c \
+ simplex/spychuzr.c \
+-simplex/spydual.c \
+-zlib/adler32.c \
+-zlib/compress.c \
+-zlib/crc32.c \
+-zlib/deflate.c \
+-zlib/gzclose.c \
+-zlib/gzlib.c \
+-zlib/gzread.c \
+-zlib/gzwrite.c \
+-zlib/inffast.c \
+-zlib/inflate.c \
+-zlib/inftrees.c \
+-zlib/trees.c \
+-zlib/uncompr.c \
+-zlib/zio.c \
+-zlib/zutil.c
++simplex/spydual.c
+ 
+ ## eof ##
+--- a/configure.ac
++++ b/configure.ac
+@@ -190,6 +190,8 @@ case "${host}" in
+ esac
+ AC_SUBST([NOUNDEFINED])
+ 
++AC_CHECK_LIB([z], [gzopen])
++
+ AC_CONFIG_FILES(
+    [src/Makefile examples/Makefile Makefile])
+ AC_OUTPUT

--- a/mingw-w64-glpk/0004-no-embedded-suitesparse.patch
+++ b/mingw-w64-glpk/0004-no-embedded-suitesparse.patch
@@ -1,0 +1,61 @@
+Description: Do not use embedded copy of AMD and COLAMD libraries from suitesparse
+Author: Sébastien Villemot <sebastien@debian.org>
+Forwarded: not-needed
+Last-Update: 2013-06-25
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/configure.ac
++++ b/configure.ac
+@@ -192,6 +192,12 @@ AC_SUBST([NOUNDEFINED])
+ 
+ AC_CHECK_LIB([z], [gzopen])
+ 
++AC_CHECK_LIB([amd], [amd_1])
++AC_CHECK_LIB([colamd], [colamd])
++
++CPPFLAGS="$CPPFLAGS $(pkg-config --cflags AMD)"
++AC_CHECK_HEADER([amd.h])
++
+ AC_CONFIG_FILES(
+    [src/Makefile examples/Makefile Makefile])
+ AC_OUTPUT
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -6,10 +6,8 @@ lib_LTLIBRARIES = libglpk.la
+ 
+ libglpk_la_CPPFLAGS = \
+ -I$(srcdir) \
+--I$(srcdir)/amd \
+ -I$(srcdir)/api \
+ -I$(srcdir)/bflib \
+--I$(srcdir)/colamd \
+ -I$(srcdir)/draft \
+ -I$(srcdir)/env \
+ -I$(srcdir)/intopt \
+@@ -26,18 +24,6 @@ libglpk_la_LDFLAGS = \
+ ${NOUNDEFINED}
+ 
+ libglpk_la_SOURCES = \
+-amd/amd_1.c \
+-amd/amd_2.c \
+-amd/amd_aat.c \
+-amd/amd_control.c \
+-amd/amd_defaults.c \
+-amd/amd_dump.c \
+-amd/amd_info.c \
+-amd/amd_order.c \
+-amd/amd_post_tree.c \
+-amd/amd_postorder.c \
+-amd/amd_preprocess.c \
+-amd/amd_valid.c \
+ api/advbas.c \
+ api/asnhall.c \
+ api/asnlp.c \
+@@ -103,7 +89,6 @@ bflib/scf.c \
+ bflib/scfint.c \
+ bflib/sgf.c \
+ bflib/sva.c \
+-colamd/colamd.c \
+ draft/bfd.c \
+ draft/bfx.c \
+ draft/glpapi06.c \

--- a/mingw-w64-glpk/PKGBUILD
+++ b/mingw-w64-glpk/PKGBUILD
@@ -4,29 +4,49 @@ _realname=glpk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.0
-pkgrel=1
+pkgrel=2
 pkgdesc="GNU Linear Programming Kit: solve LP, MIP and other problems (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
 url="https://www.gnu.org/software/glpk/glpk.html"
 license=('spdx:GPL-3.0-or-later')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
-         "${MINGW_PACKAGE_PREFIX}-gmp")
+         "${MINGW_PACKAGE_PREFIX}-gmp"
+         "${MINGW_PACKAGE_PREFIX}-suitesparse"
+         "${MINGW_PACKAGE_PREFIX}-zlib")
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-cc")
 options=('staticlibs' 'strip')
 source=("https://ftp.gnu.org/gnu/glpk/glpk-${pkgver}.tar.gz"
         'timeval-64bit.patch'
-        'fix-platform-check.patch')
+        'fix-platform-check.patch'
+        '0003-no-embedded-zlib.patch'
+        '0004-no-embedded-suitesparse.patch')
 sha256sums=('4a1013eebb50f728fc601bdd833b0b2870333c3b3e5a816eeba921d95bec6f15'
             '2d09d58139fd85d695f5b2933ec750adf0b438a1e9a53dee1b264b80dd2e0f6a'
-            '9a866c1e14f7a200a46b83c78b9f2d207167633e6ef0c51341008f07ee677d8a')
+            '9a866c1e14f7a200a46b83c78b9f2d207167633e6ef0c51341008f07ee677d8a'
+            '54acbe1f9f0561adcc1d0052b1175918004b7168352d126e23da499df564a42c'
+            '71c040ab77e64756ac29203714d2b94f994354cedefe5f5111f07fab6ff5e626')
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Np1 -i "${srcdir}/$_patch"
+  done
+}
 
 prepare () {
   cd "${srcdir}/glpk-${pkgver}"
-  patch -p1 -i "${srcdir}/timeval-64bit.patch"
-  patch -Np1 -i "${srcdir}/fix-platform-check.patch"
+
+  apply_patch_with_msg \
+    timeval-64bit.patch \
+    fix-platform-check.patch \
+    0003-no-embedded-zlib.patch \
+    0004-no-embedded-suitesparse.patch
+
   sed -i "s|-version-info|-no-undefined -version-info|g" src/Makefile.am
+
   autoreconf -vfi
 }
 


### PR DESCRIPTION
GLPK is a very stable library that gets updated only rarely. That means that the embedded zlib and SuiteSparse sources are pretty old by now.

Adopt patches from Debian to use the (more up-to-date) libraries instead:
https://salsa.debian.org/science-team/glpk/-/tree/6aef0457486b0bb014b755ac5c8408c8c697afd4/debian/patches