### PR TITLE
Fix lxml crashing

### DIFF
--- a/mingw-w64-python-lxml/PKGBUILD
+++ b/mingw-w64-python-lxml/PKGBUILD
@@ -5,7 +5,7 @@ _realname=lxml
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=4.9.4
-pkgrel=1
+pkgrel=2
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}=${pkgver}"
           "${MINGW_PACKAGE_PREFIX}-python-${_realname}-docs")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
@@ -62,7 +62,7 @@ build() {
 
   CFLAGS+=" -Wno-incompatible-function-pointer-types" \
   ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation \
-    -C--with-cython -C--with-unicode-strings
+    -C--build-option=--with-cython -C--build-option=--with-unicode-strings
 }
 
 package() {


### PR DESCRIPTION
the build options forcing cython to run were no longer passed to setup.py which meant the cython patch preventing a crash was no longer included in the compiled C code, which re-surfaced crashes in the meson test suite for example.