### PR TITLE
Add vexcl package

### DIFF
--- a/mingw-w64-amgcl/PKGBUILD
+++ b/mingw-w64-amgcl/PKGBUILD
@@ -4,7 +4,7 @@ _realname=amgcl
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.4.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Header-only C++ library for solving large sparse linear systems with algebraic multigrid (AMG) method. (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -17,8 +17,15 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python"
              "${MINGW_PACKAGE_PREFIX}-eigen3"
              $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-fc")
-             "${MINGW_PACKAGE_PREFIX}-scotch")
+             "${MINGW_PACKAGE_PREFIX}-opencl-headers"
+             "${MINGW_PACKAGE_PREFIX}-opencl-clhpp"
+             "${MINGW_PACKAGE_PREFIX}-vexcl")
 depends=("${MINGW_PACKAGE_PREFIX}-boost")
+optdepends=("${MINGW_PACKAGE_PREFIX}-eigen3"
+            "${MINGW_PACKAGE_PREFIX}-vexcl"
+            "${MINGW_PACKAGE_PREFIX}-opencl-headers"
+            "${MINGW_PACKAGE_PREFIX}-opencl-clhpp"
+            "${MINGW_PACKAGE_PREFIX}-opencl-icd")
 source=("https://github.com/ddemidov/amgcl/archive/${pkgver}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('02fd5418e14d669422f65fc739ce72bf9516ced2d8942574d4b8caa05dda9d8c')
 
@@ -57,11 +64,6 @@ package() {
   cd "${srcdir}/build-${MSYSTEM}"
 
   DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
-
-  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
-  for _f in "${pkgdir}${MINGW_PREFIX}"/share/amgcl/cmake/*.cmake; do
-    sed -e "s|${PREFIX_WIN}|\$\{_IMPORT_PREFIX\}|g" -i ${_f}
-  done
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE.md" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-vexcl/0001-fix-missing-memory-header.patch
+++ b/mingw-w64-vexcl/0001-fix-missing-memory-header.patch
@@ -1,0 +1,11 @@
+diff -Naur vexcl-1.4.3.orig/vexcl/backend/jit/device_vector.hpp vexcl-1.4.3/vexcl/backend/jit/device_vector.hpp
+--- vexcl-1.4.3.orig/vexcl/backend/jit/device_vector.hpp	2024-01-02 21:10:16.234751400 +0100
++++ vexcl-1.4.3/vexcl/backend/jit/device_vector.hpp	2024-01-02 21:12:03.261317800 +0100
+@@ -32,6 +32,7 @@
+  */
+ 
+ #include <vector>
++#include <memory>
+ 
+ namespace vex {
+ namespace backend {

--- a/mingw-w64-vexcl/PKGBUILD
+++ b/mingw-w64-vexcl/PKGBUILD
@@ -1,0 +1,61 @@
+# Maintainer: ImperatorS79 <fevrier.simon@gmail.com>
+
+_realname=vexcl
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.4.3
+pkgrel=1
+pkgdesc="Vector expression template library for OpenCL/CUDA. (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64')
+url='http://vexcl.readthedocs.io/'
+msys2_repository_url="https://github.com/ddemidov/vexcl"
+license=('spdx:MIT')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-opencl-headers"
+             "${MINGW_PACKAGE_PREFIX}-opencl-clhpp")
+depends=("${MINGW_PACKAGE_PREFIX}-boost")
+optdepends=("${MINGW_PACKAGE_PREFIX}-opencl-headers"
+            "${MINGW_PACKAGE_PREFIX}-opencl-clhpp"
+            "${MINGW_PACKAGE_PREFIX}-opencl-icd")
+source=("https://github.com/ddemidov/vexcl/archive/${pkgver}/${_realname}-${pkgver}.tar.gz"
+        "0001-fix-missing-memory-header.patch")
+sha256sums=('c9f2a429dc4454e69332cc8b7fbaa5adcd831bce1267fcc1f19e1c110d82deb8'
+            '218de270bc64623856b41ac8276eabbbe7454633676150a9fa066003902b18f9')
+            
+prepare() {
+  cd "${srcdir}"/${_realname}-${pkgver}
+
+  patch -Np1 -i "${srcdir}"/0001-fix-missing-memory-header.patch
+}
+
+build() {
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    "${MINGW_PREFIX}"/bin/cmake.exe \
+      -GNinja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      -DVEXCL_BUILD_TESTS=ON \
+      -DVEXCL_BUILD_EXAMPLES=ON \
+      ../${_realname}-${pkgver}
+
+  "${MINGW_PREFIX}"/bin/cmake.exe --build . -j 1
+}
+
+check() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  "${MINGW_PREFIX}"/bin/cmake.exe --build . --target test
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE.md" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
I have two problems with vexcl and amgcl packages:
    1) In both packages after the build, I got a warning message saying that there is reference to "cygpath -w /" inside the files of the package (.cmake files notably).
    2) In the .cmake files of vexcl package, `_IMPORT_PREFIX` is defined to "",  and this prevents the amgcl package to correctly detect vexcl, as the path `${_IMPORT_PREFIX}/include` becomes `/include` and the latter does not exists.
    
I can easily change `_IMPORT_PREFIX` to `MINGW_PREFIX` and the last error disappear and the packages build, but I guess this is not a good way of doing things. I do not know where the first problem originate from.