### PR TITLE
feat: add serust

### DIFF
--- a/mingw-w64-serust/PKGBUILD
+++ b/mingw-w64-serust/PKGBUILD
@@ -16,10 +16,7 @@ sha256sums=('95e99134925e4ce4c7cccb0d0f7577327ed506b830bd1f220ff534162c78d812')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
-
-  cargo vendor \
-    --locked \
-    --versioned-dirs
+  cargo fetch --locked
 }
 
 build() {

--- a/mingw-w64-serust/PKGBUILD
+++ b/mingw-w64-serust/PKGBUILD
@@ -1,4 +1,4 @@
-# Maintainer: thewh1teagle
+# Maintainer: thewh1teagle <61390950+thewh1teagle@users.noreply.github.com>
 
 _realname=serust
 pkgbase=mingw-w64-${_realname}
@@ -7,7 +7,7 @@ pkgver=0.0.1
 pkgrel=1
 pkgdesc="Serial monitor in Rust"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://github.com/thewh1teagle/serust"
 license=('MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
@@ -36,4 +36,3 @@ package() {
   install -Dm755 "target/release/${_realname}.exe" "${pkgdir}${MINGW_PREFIX}/bin/${_realname}.exe"
   install -Dm644 "LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }
-

--- a/mingw-w64-serust/PKGBUILD
+++ b/mingw-w64-serust/PKGBUILD
@@ -1,0 +1,42 @@
+# Maintainer: thewh1teagle
+
+_realname=serust
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.0.1
+pkgrel=1
+pkgdesc="Serial monitor in Rust"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+url="https://github.com/thewh1teagle/serust"
+license=('MIT')
+makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
+source=("$_realname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
+sha256sums=('95e99134925e4ce4c7cccb0d0f7577327ed506b830bd1f220ff534162c78d812')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  cargo vendor \
+    --locked \
+    --versioned-dirs
+}
+
+build() {
+  rm -rf "build-${MSYSTEM}" | true
+  cp -r "${_realname}-${pkgver}" "build-${MSYSTEM}"
+  msg "Cargo build for ${MSYSTEM}"
+  cd "build-${MSYSTEM}"
+
+  "${MINGW_PREFIX}/bin/cargo.exe" build \
+    --release \
+    --locked
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  install -Dm755 "target/release/${_realname}.exe" "${pkgdir}${MINGW_PREFIX}/bin/${_realname}.exe"
+  install -Dm644 "LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}
+


### PR DESCRIPTION
Add `serust` 
Serial monitor CLI tool
used for debug microcontrollers over USB with serial connection,
or with arduino / raspberry pi, etc...
from https://github.com/thewh1teagle/serust