### PR TITLE
python-llvmlite: remove cython from makedepends

### DIFF
--- a/mingw-w64-python-llvmlite/PKGBUILD
+++ b/mingw-w64-python-llvmlite/PKGBUILD
@@ -7,7 +7,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=0.41.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Lightweight LLVM python binding for writing JIT compilers (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -22,7 +22,6 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python-wheel"
-             "${MINGW_PACKAGE_PREFIX}-cython0"
              "${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"


### PR DESCRIPTION
this shouldn't be required