### PR TITLE
notepad++: update to 8.6.1

### DIFF
--- a/mingw-w64-notepad++/PKGBUILD
+++ b/mingw-w64-notepad++/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=notepad++
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=8.6
+pkgver=8.6.1
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -21,14 +21,24 @@ source=(
   notepad++
   msys2.readme.txt
   msys2.create.portable.sh
+  Parameters.h.patch
 )
 validpgpkeys=('14BCE4362749B2B51F8C71226C429F1D8D84F46E')
 sha256sums=(
-  'b7ebc95000a7da2d60858abf68db0291d9c7732d80053a623329f21620668724'
+  'a8fd564b08dc49058d4edf92699a24b1e3017f97900a074e8e582109ac7d8b41'
   'c944d0a1897b2fe20ef4a6a21257189686dcce8d95096f4129a7a65dd8cb19c5'
   'f4468e0fa0e476fc77282cb0b3cff845ed8bce91a816a7c04e8d272abf5c5b1c'
   'c6bc527d7330c61c3c99569dce9330ff89078269d5b1e0977d4ab10ed0978ceb'
+  '985e957f5d2d5fdcfce801502c3ea3ab01de4f141776f5b8610e72caad1ca5f1'
 )
+
+prepare() {
+  cd "${srcdir}/notepad-plus-plus-${pkgver}"
+  if [ "$MSYSTEM" == "CLANG64" ]
+  then
+    patch -p1 < ../Parameters.h.patch
+  fi
+}
 
 build() {
   mkdir -p "${srcdir}"/build-${MSYSTEM}

--- a/mingw-w64-notepad++/Parameters.h.patch
+++ b/mingw-w64-notepad++/Parameters.h.patch
@@ -1,0 +1,12 @@
+diff -Naur a/PowerEditor/src/Parameters.h b/PowerEditor/src/Parameters.h
+--- a/PowerEditor/src/Parameters.h	2024-01-05 17:26:31.000000000 +0100
++++ b/PowerEditor/src/Parameters.h	2024-01-06 18:51:24.132449700 +0100
+@@ -587,7 +587,7 @@
+ 	LangMenuItem(LangType lt, int cmdID = 0, const std::wstring& langName = TEXT("")):
+ 	_langType(lt), _cmdID(cmdID), _langName(langName){};
+ 
+-	bool operator<(const LangMenuItem& rhs)
++	bool operator<(const LangMenuItem& rhs) const
+ 	{
+ 		std::wstring lhs_lang(this->_langName.length(), ' '), rhs_lang(rhs._langName.length(), ' ');
+ 		std::transform(this->_langName.begin(), this->_langName.end(), lhs_lang.begin(), towlower);


### PR DESCRIPTION
I've added the patch to get rid of clang64 compilation issues, will create a PR for upstream later:

```
VERBOSE=1 mingw32-make -f ../notepad-plus-plus-8.6.1/PowerEditor/gcc/makefile
...
+ compiling C:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
g++ -include C:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/gcc/gcc-fixes.h -std=c++20 -O3 -Wno-alloc-size-larger-than -Wconversion -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/../scintilla/include -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/../lexilla/include -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/. -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/DarkMode -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/MISC -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/MISC/Common -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/MISC/Exception -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/MISC/PluginsManager -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/MISC/Process -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/MISC/RegExt -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/MISC/crc16 -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/MISC/md5 -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/MISC/sha1 -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/MISC/sha2 -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/MISC/sha512 -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/ScintillaComponent -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/TinyXml -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/TinyXml/tinyXmlA -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/AboutDlg -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/AnsiCharPanel -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/ClipboardHistory -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/ColourPicker -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/ContextMenu -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/DockingWnd -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/DocumentMap -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/FileBrowser -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/FindCharsInRange -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/FunctionList -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/Grid -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/ImageListSet -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/OpenSaveFileDialog -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/PluginsAdmin -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/Preference -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/ProjectPanel -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/ReadDirectoryChanges -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/SplitterContainer -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/StaticDialog -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/StaticDialog/RunDlg -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/StatusBar -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/TabBar -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/TaskList -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/ToolBar -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/ToolTip -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/TrayIcon -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/TreeView -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/VerticalFileSwitcher -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/WindowsDlg -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/shortcut -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/json -IC:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/uchardet -DUNICODE -D_UNICODE -DOEMRESOURCE -DNOMINMAX -D_WIN32_WINNT=_WIN32_WINNT_VISTA -DTIXML_USE_STL -DTIXMLA_USE_STL -DNDEBUG -MMD -c -o bin.x86_64.build/WinControls/Preference/preferenceDlg.o C:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
...
In file included from C:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp:18:
In file included from C:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/Preference/preferenceDlg.h:20:
In file included from C:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/TabBar/ControlsTab.h:22:
In file included from C:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/MISC/Common/Common.h:17:
In file included from C:/msys64/clang64/include/c++/v1/vector:304:
In file included from C:/msys64/clang64/include/c++/v1/__algorithm/copy.h:12:
In file included from C:/msys64/clang64/include/c++/v1/__algorithm/copy_move_common.h:18:
In file included from C:/msys64/clang64/include/c++/v1/__string/constexpr_c_functions.h:25:
In file included from C:/msys64/clang64/include/c++/v1/__utility/is_pointer_in_range.h:12:
C:/msys64/clang64/include/c++/v1/__algorithm/comp.h:41:18: error: invalid operands to binary expression ('const LangMenuItem' and 'const LangMenuItem')
   41 |     return __lhs < __rhs;
      |            ~~~~~ ^ ~~~~~
C:/msys64/clang64/include/c++/v1/__algorithm/sift_down.h:47:34: note: in instantiation of function template specialization 'std::__less<>::operator()<LangMenuItem, LangMenuItem>' requested here
   47 |     if ((__child + 1) < __len && __comp(*__child_i, *(__child_i + difference_type(1)))) {
      |                                  ^
C:/msys64/clang64/include/c++/v1/__algorithm/make_heap.h:39:14: note: in instantiation of function template specialization 'std::__sift_down<std::_ClassicAlgPolicy, std::__less<void, void> &, LangMenuItem *>' requested here
   39 |         std::__sift_down<_AlgPolicy>(__first, __comp_ref, __n, __first + __start);
      |              ^
C:/msys64/clang64/include/c++/v1/__algorithm/partial_sort.h:39:8: note: in instantiation of function template specialization 'std::__make_heap<std::_ClassicAlgPolicy, std::__less<void, void> &, LangMenuItem *>' requested here
   39 |   std::__make_heap<_AlgPolicy>(__first, __middle, __comp);
      |        ^
C:/msys64/clang64/include/c++/v1/__algorithm/partial_sort.h:66:12: note: in instantiation of function template specialization 'std::__partial_sort_impl<std::_ClassicAlgPolicy, std::__less<void, void> &, LangMenuItem *, LangMenuItem *>' requested here
   66 |       std::__partial_sort_impl<_AlgPolicy>(__first, __middle, __last, static_cast<__comp_ref_type<_Compare> >(__comp));
      |            ^
C:/msys64/clang64/include/c++/v1/__algorithm/sort.h:943:10: note: in instantiation of function template specialization 'std::__partial_sort<std::_ClassicAlgPolicy, std::__less<void, void>, LangMenuItem *, LangMenuItem *>' requested here
  943 |     std::__partial_sort<_AlgPolicy>(
      |          ^
C:/msys64/clang64/include/c++/v1/__algorithm/sort.h:954:8: note: in instantiation of function template specialization 'std::__sort_impl<std::_ClassicAlgPolicy, std::__wrap_iter<LangMenuItem *>, std::__less<void, void>>' requested here
  954 |   std::__sort_impl<_ClassicAlgPolicy>(std::move(__first), std::move(__last), __comp);
      |        ^
C:/msys64/clang64/include/c++/v1/__algorithm/sort.h:960:8: note: in instantiation of function template specialization 'std::sort<std::__wrap_iter<LangMenuItem *>, std::__less<void, void>>' requested here
  960 |   std::sort(__first, __last, __less<>());
      |        ^
C:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp:2870:9: note: in instantiation of function template specialization 'std::sort<std::__wrap_iter<LangMenuItem *>>' requested here
 2870 |                         std::sort(_langList.begin(), _langList.end());
      |                              ^
C:/msys64/clang64/include/c++/v1/__utility/pair.h:623:1: note: candidate template ignored: could not match 'const pair<_T1, _T2>' against 'const LangMenuItem'
  623 | operator<=>(const pair<_T1,_T2>& __x, const pair<_U1,_U2>& __y)
      | ^
C:/msys64/clang64/include/c++/v1/__utility/pair.h:623:1: note: candidate template ignored: could not match 'const pair<_T1, _T2>' against 'const LangMenuItem'
C:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/src/./Parameters.h:590:7: note: candidate function not viable: 'this' argument has type 'const LangMenuItem', but method is not marked const
  590 |         bool operator<(const LangMenuItem& rhs)
      |              ^
...
mingw32-make: *** [C:/MINGW-packages/mingw-w64-notepad++/src/notepad-plus-plus-8.6.1/PowerEditor/gcc/makefile:208: all] Error 2
```