### PR TITLE
mingw-w64-opencv: rebuild with cxx_std=17

### DIFF
--- a/mingw-w64-opencv/PKGBUILD
+++ b/mingw-w64-opencv/PKGBUILD
@@ -7,7 +7,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=4.9.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Open Source Computer Vision Library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -181,6 +181,7 @@ build() {
     -DPROTOBUF_UPDATE_FILES=ON \
     -Dprotobuf_MODULE_COMPATIBLE=ON \
     -DENABLE_PRECOMPILED_HEADERS=OFF \
+    -DCMAKE_CXX_STANDARD=17 \
     "${_extra_config[@]}" \
     ../${_realname}-${pkgver}
 


### PR DESCRIPTION
Set C++ standard to 17 to fix broken protobuf support.

Thank's to @Biswa96 who came with the link
https://github.com/opencv/opencv/blob/4.9.0/cmake/OpenCVFindProtobuf.cmake#L84

Closes #19677
