### PR TITLE
[new package] lfortran 0.30.0

### DIFF
--- a/mingw-w64-lfortran/001-win-install.patch
+++ b/mingw-w64-lfortran/001-win-install.patch
@@ -1,0 +1,31 @@
+diff --git "a/./src/libasr/runtime/lfortran_intrinsics.c" "b/./src/libasr/runtime/lfortran_intrinsics.c"
+index ea6e588..c80bc8c 100644
+--- "a/./src/libasr/runtime/lfortran_intrinsics.c"
++++ "b/./src/libasr/runtime/lfortran_intrinsics.c"
+@@ -1849,7 +1849,7 @@ LFORTRAN_API void _lfortran_cpu_time(double *t) {
+ 
+ LFORTRAN_API void _lfortran_i32sys_clock(
+         int32_t *count, int32_t *rate, int32_t *max) {
+-#if defined(_MSC_VER)
++#if defined(_MSC_VER) || defined(__WIN32__)
+         *count = - INT_MAX;
+         *rate = 0;
+         *max = 0;
+@@ -1869,7 +1869,7 @@ LFORTRAN_API void _lfortran_i32sys_clock(
+ 
+ LFORTRAN_API void _lfortran_i64sys_clock(
+         uint64_t *count, int64_t *rate, int64_t *max) {
+-#if defined(_MSC_VER)
++#if defined(_MSC_VER) || defined(__WIN32__)
+         *count = - INT_MAX;
+         *rate = 0;
+         *max = 0;
+@@ -1898,7 +1898,7 @@ LFORTRAN_API double _lfortran_time()
+     uli.LowPart = ft.dwLowDateTime;
+     uli.HighPart = ft.dwHighDateTime;
+     return (double)uli.QuadPart / 10000000.0 - 11644473600.0;
+-#elif defined(__APPLE__) && !defined(__aarch64__)
++#elif defined(__APPLE__) && !defined(__aarch64__) || defined(__WIN32__)
+     return 0.0;
+ #else
+     struct timespec ts;

--- a/mingw-w64-lfortran/001-win-install.patch
+++ b/mingw-w64-lfortran/001-win-install.patch
@@ -7,7 +7,7 @@ index ea6e588..c80bc8c 100644
  LFORTRAN_API void _lfortran_i32sys_clock(
          int32_t *count, int32_t *rate, int32_t *max) {
 -#if defined(_MSC_VER)
-+#if defined(_MSC_VER) || defined(_WIN32)
++#if defined(_WIN32)
          *count = - INT_MAX;
          *rate = 0;
          *max = 0;
@@ -16,7 +16,7 @@ index ea6e588..c80bc8c 100644
  LFORTRAN_API void _lfortran_i64sys_clock(
          uint64_t *count, int64_t *rate, int64_t *max) {
 -#if defined(_MSC_VER)
-+#if defined(_MSC_VER) || defined(_WIN32)
++#if defined(_WIN32)
          *count = - INT_MAX;
          *rate = 0;
          *max = 0;

--- a/mingw-w64-lfortran/001-win-install.patch
+++ b/mingw-w64-lfortran/001-win-install.patch
@@ -7,7 +7,7 @@ index ea6e588..c80bc8c 100644
  LFORTRAN_API void _lfortran_i32sys_clock(
          int32_t *count, int32_t *rate, int32_t *max) {
 -#if defined(_MSC_VER)
-+#if defined(_MSC_VER) || defined(__WIN32__)
++#if defined(_MSC_VER) || defined(_WIN32)
          *count = - INT_MAX;
          *rate = 0;
          *max = 0;
@@ -16,7 +16,7 @@ index ea6e588..c80bc8c 100644
  LFORTRAN_API void _lfortran_i64sys_clock(
          uint64_t *count, int64_t *rate, int64_t *max) {
 -#if defined(_MSC_VER)
-+#if defined(_MSC_VER) || defined(__WIN32__)
++#if defined(_MSC_VER) || defined(_WIN32)
          *count = - INT_MAX;
          *rate = 0;
          *max = 0;
@@ -25,7 +25,7 @@ index ea6e588..c80bc8c 100644
      uli.HighPart = ft.dwHighDateTime;
      return (double)uli.QuadPart / 10000000.0 - 11644473600.0;
 -#elif defined(__APPLE__) && !defined(__aarch64__)
-+#elif defined(__APPLE__) && !defined(__aarch64__) || defined(__WIN32__)
++#elif defined(__APPLE__) && !defined(__aarch64__) || defined(_WIN32)
      return 0.0;
  #else
      struct timespec ts;

--- a/mingw-w64-lfortran/PKGBUILD
+++ b/mingw-w64-lfortran/PKGBUILD
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 source=("${url}/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz"
         001-win-install.patch)
 sha256sums=('aafdfbfe81d69ceb3650ae1cf9bcd8a1f1532d895bf88f3071fe9610859bcd6f'
-            'a6abdf74d0f0ed242e0be71e3fdb0fb32741b0d2e689c1a5dbbccc7a4babae63')
+            'a61475b45ba94b8b98dcd05f429735cd15c32e630ad4c970aec5d7fb9032ea60')
 
 prepare() {
     cd "${srcdir}/${_realname}-${pkgver}"

--- a/mingw-w64-lfortran/PKGBUILD
+++ b/mingw-w64-lfortran/PKGBUILD
@@ -1,0 +1,56 @@
+# Maintainer: ZUO Zhihua <zuo.zhihua@qq.com>
+
+_realname=lfortran
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.30.0
+pkgrel=1
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+pkgdesc="Modern open-source (BSD licensed) interactive Fortran compiler built on top of LLVM (mingw-w64)"
+url="https://github.com/lfortran/lfortran"
+license=('spdx:BSD-3')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-llvm-15"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
+source=(${_realname}-${pkgver}.tar.gz::"${url}/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz"
+        001-win-install.patch)
+sha256sums=('aafdfbfe81d69ceb3650ae1cf9bcd8a1f1532d895bf88f3071fe9610859bcd6f'
+            '165d5f8653f30009949087047750e4774b20bb4aa288756a3045054dda76e357')
+
+prepare() {
+    cd "${srcdir}/${_realname}-${pkgver}"
+    patch -p1 -i ${srcdir}/001-win-install.patch
+}
+
+build() {
+    cd "${srcdir}/${_realname}-${pkgver}"
+    mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
+
+    export LLVM_DIR="${MINGW_PREFIX}/opt/llvm-15/lib/cmake/llvm"
+    MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+        "${MINGW_PREFIX}"/bin/cmake.exe \
+            -GNinja \
+            -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DWITH_LLVM=yes \
+            -DWITH_STACKTRACE=no \
+            ../${_realname}-${pkgver}
+
+    "${MINGW_PREFIX}"/bin/cmake.exe --build .
+}
+
+check() {
+    cd "${srcdir}/build-${MSYSTEM}"
+
+    "${MINGW_PREFIX}"/bin/cmake.exe --build . --target test
+}
+
+package() {
+    cd "${srcdir}/build-${MSYSTEM}"
+
+    DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
+
+    install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}

--- a/mingw-w64-lfortran/PKGBUILD
+++ b/mingw-w64-lfortran/PKGBUILD
@@ -9,15 +9,16 @@ arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 pkgdesc="Modern open-source (BSD licensed) interactive Fortran compiler built on top of LLVM (mingw-w64)"
 url="https://github.com/lfortran/lfortran"
-license=('spdx:BSD-3')
+license=('spdx:BSD-3-Clause')
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-llvm-15"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
-source=(${_realname}-${pkgver}.tar.gz::"${url}/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz"
+source=("${url}/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz"
         001-win-install.patch)
 sha256sums=('aafdfbfe81d69ceb3650ae1cf9bcd8a1f1532d895bf88f3071fe9610859bcd6f'
-            '165d5f8653f30009949087047750e4774b20bb4aa288756a3045054dda76e357')
+            'a6abdf74d0f0ed242e0be71e3fdb0fb32741b0d2e689c1a5dbbccc7a4babae63')
 
 prepare() {
     cd "${srcdir}/${_realname}-${pkgver}"
@@ -25,7 +26,6 @@ prepare() {
 }
 
 build() {
-    cd "${srcdir}/${_realname}-${pkgver}"
     mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
     export LLVM_DIR="${MINGW_PREFIX}/opt/llvm-15/lib/cmake/llvm"


### PR DESCRIPTION
LFortran: Modern open-source (BSD licensed) interactive Fortran compiler built on top of LLVM.
LFortran is similar to Julia and can dynamically execute or statically compile Fortran code.

Add a patch (`001-win-install.patch`) to build LFortran in the MINGW64 environment, which will be subsequently committed to the [LFortran repository](https://github.com/lfortran/lfortran).