### PR TITLE
readline: Make event hook patch not break Unix build

### DIFF
--- a/mingw-w64-readline/0002-event-hook.patch
+++ b/mingw-w64-readline/0002-event-hook.patch
@@ -15,12 +15,16 @@
  #define any_typein (push_index != pop_index)
  
  int
-@@ -187,7 +195,7 @@
+@@ -187,7 +195,11 @@
  int
  _rl_pushed_input_available (void)
  {
 -  return (push_index != pop_index);
-+  return ((push_index != pop_index) || _win32_bufidx > 0);
++  return (push_index != pop_index)
++#if defined (__MINGW32__)
++    || _win32_bufidx > 0
++#endif
++    ;
  }
  
  /* Return the amount of space available in the buffer for stuffing

--- a/mingw-w64-readline/PKGBUILD
+++ b/mingw-w64-readline/PKGBUILD
@@ -6,7 +6,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _basever=8.2
 _patchlevel=007
 pkgver=${_basever}.${_patchlevel}
-pkgrel=1
+pkgrel=2
 pkgdesc="MinGW port of readline for editing typed command lines (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -34,7 +34,7 @@ validpgpkeys=('7C0135FB088AAF6C66C650B9BB5869F064EA74AB')
 sha256sums=('3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35'
             'SKIP'
             '2b30dcb0804abb6e7e4f44cd119bddef94c1b1d7ebff43dda401e710eda2fd0f'
-            '52ae0da2769afe2853e3ffad8ae2e22eb8a72ce3ee8f2fc9084cb4dc554b2813'
+            '5a5ab63e87a025af39b3e5101b171d16bd5d227f350f036a32193496d12bcbe2'
             '6329d02c9e151951136a31cce036f952f95f80a63d60694539839b9c706857e9'
             '72ed438ae142ba9d5498652dfdf4fb517265bcf9a67199b7c5b35cc24fa25b9e'
             'bbf97f1ec40a929edab5aa81998c1e2ef435436c597754916e6a5868f273aff7'


### PR DESCRIPTION
This means we can apply all four patches unconditionally / they are more suitable for upstreaming.