### PR TITLE
[new-package] orcus 0.19.2

### DIFF
--- a/mingw-w64-orcus/001-fix-build-on-mingw.patch
+++ b/mingw-w64-orcus/001-fix-build-on-mingw.patch
@@ -1,0 +1,92 @@
+--- a/include/orcus/env.hpp
++++ b/include/orcus/env.hpp
+@@ -11,10 +11,7 @@
+ // orcus
+ 
+ #if defined _WIN32 || defined __CYGWIN__
+-  #if defined __MINGW32__
+-    #define ORCUS_DLLPUBLIC
+-    #define ORCUS_DLLLOCAL
+-  #elif defined __ORCUS_BUILDING_DLL
++  #if defined __ORCUS_BUILDING_DLL
+     #ifdef __GNUC__
+       #define ORCUS_DLLPUBLIC __attribute__ ((dllexport))
+     #else
+@@ -43,10 +40,7 @@
+ // orcus-parser
+ 
+ #if defined _WIN32 || defined __CYGWIN__
+-  #if defined __MINGW32__
+-    #define ORCUS_PSR_DLLPUBLIC
+-    #define ORCUS_PSR_DLLLOCAL
+-  #elif defined __ORCUS_PSR_BUILDING_DLL
++  #if defined __ORCUS_PSR_BUILDING_DLL
+     #ifdef __GNUC__
+       #define ORCUS_PSR_DLLPUBLIC __attribute__ ((dllexport))
+     #else
+@@ -75,10 +69,7 @@
+ // orcus-spreadsheet-model
+ 
+ #if defined _WIN32 || defined __CYGWIN__
+-  #if defined __MINGW32__
+-    #define ORCUS_SPM_DLLPUBLIC
+-    #define ORCUS_SPM_DLLLOCAL
+-  #elif defined __ORCUS_SPM_BUILDING_DLL
++  #if defined __ORCUS_SPM_BUILDING_DLL
+     #ifdef __GNUC__
+       #define ORCUS_SPM_DLLPUBLIC __attribute__ ((dllexport))
+     #else
+@@ -107,10 +98,7 @@
+ // orcus-mso
+ 
+ #if defined _WIN32 || defined __CYGWIN__
+-  #if defined __MINGW32__
+-    #define ORCUS_MSO_DLLPUBLIC
+-    #define ORCUS_MSO_DLLLOCAL
+-  #elif defined __ORCUS_MSO_BUILDING_DLL
++  #if defined __ORCUS_MSO_BUILDING_DLL
+     #ifdef __GNUC__
+       #define ORCUS_MSO_DLLPUBLIC __attribute__ ((dllexport))
+     #else
+--- a/src/python/Makefile.am
++++ b/src/python/Makefile.am
+@@ -29,7 +29,7 @@
+ 	gnumeric.hpp \
+ 	gnumeric.cpp
+ 
+-_orcus_la_LDFLAGS = -module -avoid-version -export-symbols-regex PyInit__orcus
++_orcus_la_LDFLAGS = -no-undefined -module -avoid-version -export-symbols-regex PyInit__orcus
+ _orcus_la_LIBADD = \
+ 	../liborcus/liborcus-@ORCUS_API_VERSION@.la \
+ 	../parser/liborcus-parser-@ORCUS_API_VERSION@.la \
+@@ -64,7 +64,7 @@
+ _orcus_json_la_SOURCES = \
+ 	json.cpp
+ 
+-_orcus_json_la_LDFLAGS = -module -avoid-version -export-symbols-regex PyInit__orcus_json
++_orcus_json_la_LDFLAGS = -no-undefined -module -avoid-version -export-symbols-regex PyInit__orcus_json
+ _orcus_json_la_LIBADD = \
+ 	../liborcus/liborcus-@ORCUS_API_VERSION@.la \
+ 	../parser/liborcus-parser-@ORCUS_API_VERSION@.la \
+--- a/src/python/json.cpp
++++ b/src/python/json.cpp
+@@ -279,7 +279,7 @@
+ 
+ extern "C" {
+ 
+-ORCUS_DLLPUBLIC PyObject* PyInit__orcus_json()
++PyObject* PyInit__orcus_json()
+ {
+     PyObject* m = PyModule_Create(&orcus::python::moduledef);
+     return m;
+--- a/src/python/python.cpp
++++ b/src/python/python.cpp
+@@ -146,7 +146,7 @@
+ 
+ extern "C" {
+ 
+-ORCUS_DLLPUBLIC PyObject* PyInit__orcus()
++PyObject* PyInit__orcus()
+ {
+     PyObject* m = PyModule_Create(&orcus::python::moduledef);
+     if (!orcus::python::populate_module_attributes(m))

--- a/mingw-w64-orcus/002-workaround-for-gcc.patch
+++ b/mingw-w64-orcus/002-workaround-for-gcc.patch
@@ -1,0 +1,12 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -47,7 +47,8 @@
+ # ===================================
+ # Check for filesystem implementation
+ # ===================================
+-AC_CHECK_HEADER([filesystem], [have_filesystem=yes], [have_filesystem=no], [])
++#AC_CHECK_HEADER([filesystem], [have_filesystem=yes], [have_filesystem=no], [])
++have_filesystem=no
+ 
+ AC_CHECK_HEADER([experimental/filesystem], [have_experimental_filesystem=yes], [have_experimental_filesystem=no], [])
+ 

--- a/mingw-w64-orcus/PKGBUILD
+++ b/mingw-w64-orcus/PKGBUILD
@@ -1,0 +1,90 @@
+# Contributor: Mehdi Chinoune <mehdi.chinoune@hotmail.com>
+
+_realname=orcus
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=0.19.2
+pkgrel=1
+pkgdesc="Standalone file import filter library for spreadsheet documents (ODS, XLSX and CSV). (mingw-w64)"
+arch=('any')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
+url='https://gitlab.com/orcus/orcus'
+msys2_references=(
+  'archlinux: liborcus'
+)
+license=('spdx:MPL-2.0')
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-boost"
+         "${MINGW_PACKAGE_PREFIX}-ixion"
+         "${MINGW_PACKAGE_PREFIX}-zlib")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-mdds"
+             "${MINGW_PACKAGE_PREFIX}-python")
+optdepends=("${MINGW_PACKAGE_PREFIX}-python: Python bindings")
+source=("https://gitlab.com/orcus/orcus/-/archive/${pkgver}/${_realname}-${pkgver}.tar.bz2"
+        "001-fix-build-on-mingw.patch"
+        "002-workaround-for-gcc.patch")
+sha256sums=('d5e443bc5dbfd2271eee792bbd7048bc3675da41007b0c410e9c8dca56433638'
+            '1b86bbb84e69f5ea0d5de766537acc5108f299b2a3cfa1732341c9bd2eb32d41'
+            'd2b76a347e6f8bfd09ef104aa1abd7add59b5ec108df65db7a562f248311d30c')
+
+prepare() {
+  cd ${_realname}-${pkgver}
+  patch -p1 -i "${srcdir}"/001-fix-build-on-mingw.patch
+
+  if [[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]]; then
+    patch -p1 -i "${srcdir}"/002-workaround-for-gcc.patch
+  fi
+
+  autoreconf -fiv
+}
+
+build() {
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
+
+  export lt_cv_deplibs_check_method='pass_all'
+
+  declare -a _extra_config
+  if [[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]]; then
+    _extra_config+=("--disable-spreadsheet-model" "--disable-python")
+  fi
+
+  ../${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --with-cpu-features \
+    --without-benchmark \
+    "${_extra_config[@]}"
+
+  make
+}
+
+check() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  make check || true
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  DESTDIR="${pkgdir}" make install
+
+  MSYS2_ARG_CONV_EXCL="-p" python -m compileall \
+    -o 0 -o 1 -q -s"${pkgdir}" -p"/" "${pkgdir}${MINGW_PREFIX}/lib/python"*
+
+  PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+    -exec sed -i -e "s|${PREFIX_WIN}|\$\{prefix\}|g" {} \;
+
+  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
+    # Use *.pyd extension for python modules
+    for _dll in "${pkgdir}${MINGW_PREFIX}"/lib/python3.11/site-packages/*.dll; do
+      mv ${_dll} ${_dll/.dll/.pyd}
+    done
+    # remove unused import libraries
+    rm -f "${pkgdir}${MINGW_PREFIX}"/lib/python3.11/site-packages/*.dll.a
+  fi
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
It looks like stdc++/filesystem is broken with GCC. 
- It fails to build when using std::filesystem
- It fails to link when force std::experimental::filesystem
- It fails to build also when trying to force boost::filesystem

In clang environments both std and boost filesystem build and link (didn't try std::experimental)

The library builds on ArchLinux and there is no reported issue about it, so It looks like a MINGW specific issue.