### PR TITLE
ruff: split into bin and python lib packages 

### DIFF
--- a/mingw-w64-ruff/PKGBUILD
+++ b/mingw-w64-ruff/PKGBUILD
@@ -2,24 +2,22 @@
 
 _realname=ruff
 pkgbase=mingw-w64-${_realname}
-pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
+         "${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=0.1.11
-pkgrel=1
-pkgdesc="An extremely fast Python linter, written in Rust"
+pkgrel=2
+pkgdesc="An extremely fast Python linter, written in Rust (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
 url='https://github.com/astral-sh/ruff'
 license=('spdx:MIT')
-depends=(
-  "${MINGW_PACKAGE_PREFIX}-python"
-)
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-rust"
   "${MINGW_PACKAGE_PREFIX}-python-maturin"
   "${MINGW_PACKAGE_PREFIX}-python-installer"
 )
 options=('!strip')
-source=("$url/archive//v${pkgver}/${_realname}-${pkgver}.tar.gz"
+source=("$url/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
         "001-fix-building-with-gcc.patch")
 sha256sums=('47cf8357c7036829ea859184cce125cd256b9f74afc2f5288c697facbb6f6677'
             'a266b1594ab3280525d7bce5adb91026c1e183696a4586255d4a0fcd008d41c2')
@@ -46,16 +44,43 @@ build() {
 check() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
+  export WINAPI_NO_BUNDLED_LIBRARIES=1
   cargo test --release --frozen --all-features
 }
 
-package() {
+package_ruff() {
   cd "${srcdir}/${_realname}-${pkgver}"
+
+  install -Dm755 ./target/release/ruff "${pkgdir}${MINGW_PREFIX}/bin/ruff"
+  install -Dm644 LICENSE -t "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/"
+
+  local _complete="./target/release/ruff --generate-shell-completion"
+  $_complete bash | install -Dm644 /dev/stdin "${pkgdir}${MINGW_PREFIX}/share/bash-completion/completions/ruff.bash"
+  $_complete fish | install -Dm644 /dev/stdin "${pkgdir}${MINGW_PREFIX}/share/fish/vendor_completions.d/ruff.fish"
+  $_complete zsh  | install -Dm644 /dev/stdin "${pkgdir}${MINGW_PREFIX}/share/zsh/site-functions/_ruff"
+}
+
+package_python-ruff() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  pkgdesc+=" (Python module)"
+  depends=("${MINGW_PACKAGE_PREFIX}-python" "${MINGW_PACKAGE_PREFIX}-ruff")
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
     ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
     --destdir="${pkgdir}" target/wheels/*.whl
 
-  install -vDm 644 LICENSE -t "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/"
-  install -vDm 644 README.md -t "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}/"
+  # split ruff binary
+  rm -rf "${pkgdir}${MINGW_PREFIX}/bin/"
 }
+
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
+
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;


### PR DESCRIPTION
like in Arch. ruff itself doesn't depend on python module