### PR TITLE
nanovg: rebuild

### DIFF
--- a/mingw-w64-nanovg/PKGBUILD
+++ b/mingw-w64-nanovg/PKGBUILD
@@ -6,13 +6,13 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 pkgver=r398.c35e80c
-pkgrel=1
+pkgrel=2
 pkgdesc="Small antialiased vector graphics rendering library for OpenGL (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
 url="https://github.com/memononen/nanovg"
 license=('spdx:Zlib')
-makedepends=("git" "${MINGW_PACKAGE_PREFIX}-premake")
+makedepends=("git" "${MINGW_PACKAGE_PREFIX}-premake4" "${MINGW_PACKAGE_PREFIX}-cc")
 _commit="c35e80c3fed7445b4e2973fccccc89afd97834cf"
 source=("${_realname}"::"git+https://github.com/memononen/nanovg.git#commit=${_commit}")
 sha256sums=('SKIP')
@@ -39,7 +39,7 @@ build() {
   rm -rf "${MINGW_CHOST}" || true
   cp -rf "${srcdir}/${_realname}" "${srcdir}/${MINGW_CHOST}"
   cd "${srcdir}/${MINGW_CHOST}"
-  premake4 gmake --os=windows cc=gcc
+  premake4 gmake --os=windows cc=cc
   cd build
   make config=${_ctype} nanovg
 }

--- a/mingw-w64-premake4/PKGBUILD
+++ b/mingw-w64-premake4/PKGBUILD
@@ -1,0 +1,26 @@
+# Maintainer: Martell Malone <martellmalone@gmail.com>
+
+_realname=premake
+pkgbase=mingw-w64-${_realname}4
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}4")
+pkgver=4.3
+pkgrel=1
+pkgdesc="A build configuration tool. Describe your build using Lua and generate \
+the project files for your specific toolset (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+url="https://premake.sourceforge.io/"
+license=('GPL')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
+source=("https://downloads.sourceforge.net/sourceforge/premake/premake-${pkgver}-src.zip")
+sha256sums=('36536490f8928d8ecde135da80cd8b751ea5bebe50cabba5c0de49cd41cb2780')
+
+build() {
+  cd "${srcdir}/${_realname}-${pkgver}/build/gmake.windows"
+  CC=${MINGW_PREFIX}/bin/cc make
+}
+
+package() {
+  cd ${srcdir}/${_realname}-${pkgver}
+  install -Dm755 bin/release/premake4 ${pkgdir}${MINGW_PREFIX}/bin/premake4
+}


### PR DESCRIPTION
requires premake4, so bring it back