### PR TITLE
ripgrep: improve package build

### DIFF
--- a/mingw-w64-ripgrep/PKGBUILD
+++ b/mingw-w64-ripgrep/PKGBUILD
@@ -4,18 +4,19 @@ _realname=ripgrep
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=14.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc='line-oriented search tool that recursively searches your current directory for a regex pattern (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://github.com/BurntSushi/ripgrep'
 msys2_references=(
-    'archlinux: ripgrep'
+  'archlinux: ripgrep'
 )
 license=('spdx:MIT OR Unlicense')
 depends=("${MINGW_PACKAGE_PREFIX}-pcre2")
-makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
-source=("${url}/archive/refs/tags/${pkgver}/${_realname}-${pkgver}.tar.gz")
+makedepends=("${MINGW_PACKAGE_PREFIX}-rust" "${MINGW_PACKAGE_PREFIX}-pkgconf")
+options=('!strip' '!lto')
+source=("${url}/archive/${pkgver}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('33c6169596a6bbfdc81415910008f26e0809422fda2d849562637996553b2ab6')
 noextract=("${_realname}-${pkgver}.tar.gz")
 
@@ -30,13 +31,13 @@ prepare() {
 build() {
   cd "${_realname}-${pkgver}"
 
-  cargo build --release --locked --features 'pcre2'
+  cargo build --locked --features 'pcre2' --profile release-lto
 }
 
 check() {
   cd "${_realname}-${pkgver}"
 
-  cargo test --release --locked --features 'pcre2'
+  cargo test --locked --features 'pcre2' --profile release-lto
 }
 
 package() {
@@ -47,20 +48,15 @@ package() {
     --offline \
     --no-track \
     --features 'pcre2' \
+    --profile release-lto \
     --path . \
     --root "${pkgdir}${MINGW_PREFIX}"
 
-  mkdir -p "${pkgdir}${MINGW_PREFIX}/share/zsh/site-functions"
-  target/release/rg --generate complete-zsh > "${pkgdir}${MINGW_PREFIX}/share/zsh/site-functions/_rg"
-
-  mkdir -p "${pkgdir}${MINGW_PREFIX}/share/bash-completion/completions"
-  target/release/rg --generate complete-bash > "${pkgdir}${MINGW_PREFIX}/share/bash-completion/completions/rg"
-
-  mkdir -p "${pkgdir}${MINGW_PREFIX}/share/fish/vendor_completions.d"
-  target/release/rg --generate complete-fish > "${pkgdir}${MINGW_PREFIX}/share/fish/vendor_completions.d/rg.fish"
-
-  mkdir -p "${pkgdir}${MINGW_PREFIX}/share/man/man1"
-  target/release/rg --generate man >  "${pkgdir}${MINGW_PREFIX}/share/man/man1/rg.1"
+  local _complete="./target/release-lto/rg --generate"
+  $_complete complete-zsh | install -Dm644 /dev/stdin "${pkgdir}${MINGW_PREFIX}/share/zsh/site-functions/_rg"
+  $_complete complete-bash | install -Dm644 /dev/stdin "${pkgdir}${MINGW_PREFIX}/share/bash-completion/completions/rg"
+  $_complete complete-fish | install -Dm644 /dev/stdin "${pkgdir}${MINGW_PREFIX}/share/fish/vendor_completions.d/rg.fish"
+  $_complete man | install -Dm644 /dev/stdin "${pkgdir}${MINGW_PREFIX}/share/man/man1/rg.1"
 
   install -Dm644 COPYING LICENSE-MIT UNLICENSE -t "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/"
 }


### PR DESCRIPTION
a random investigation:
- `release-lto` profile enables strip and lto. see https://github.com/BurntSushi/ripgrep/blob/master/Cargo.toml#L74-L87
- `pkgconf` must be at makedepends, otherwise `pcre2` is recompiled from source and linked *staticly* (ntldd now shows a pcre2 dll). see https://github.com/BurntSushi/ripgrep?tab=readme-ov-file#building
- install completions in a new way