### PR TITLE
libBlocksRuntime: Mark public symbols with dllexport

### DIFF
--- a/mingw-w64-libblocksruntime/0002-libblocksruntime-0.4.1-export-symbols.patch
+++ b/mingw-w64-libblocksruntime/0002-libblocksruntime-0.4.1-export-symbols.patch
@@ -1,0 +1,87 @@
+diff --git libblocksruntime-0.4.1/Block.h libblocksruntime-0.4.1/Block.h
+index 55cdd01..fb8671b 100644
+--- libblocksruntime-0.4.1/Block.h
++++ libblocksruntime-0.4.1/Block.h
+@@ -33,6 +33,12 @@
+ #   endif
+ #endif
+ 
++#if defined _WIN32 || defined __CYGWIN__
++#   define BLOCK_PUBLIC __attribute__((dllimport))
++#else
++#	define BLOCK_PUBLIC
++#endif
++
+ #if defined(__cplusplus)
+ extern "C" {
+ #endif
+@@ -41,10 +47,10 @@ extern "C" {
+  * This must be paired with Block_release to recover memory, even when running
+  * under Objective-C Garbage Collection.
+  */
+-BLOCK_EXPORT void *_Block_copy(const void *aBlock);
++BLOCK_PUBLIC BLOCK_EXPORT void *_Block_copy(const void *aBlock);
+ 
+ /* Lose the reference, and if heap based and last reference, recover the memory. */
+-BLOCK_EXPORT void _Block_release(const void *aBlock);
++BLOCK_PUBLIC BLOCK_EXPORT void _Block_release(const void *aBlock);
+ 
+ #if defined(__cplusplus)
+ }
+diff --git libblocksruntime-0.4.1/Block_private.h libblocksruntime-0.4.1/Block_private.h
+index 8ae8218..32a5c0e 100644
+--- libblocksruntime-0.4.1/Block_private.h
++++ libblocksruntime-0.4.1/Block_private.h
+@@ -33,6 +33,14 @@
+ #   endif
+ #endif
+ 
++#if defined _WIN32 || defined __CYGWIN__
++#   define BLOCK_PUBLIC __attribute__((dllexport))
++#   define BLOCK_WEAK
++#else
++#	define BLOCK_PUBLIC
++#   define BLOCK_WEAK __attribute__((weak))
++#endif
++
+ #ifndef _MSC_VER
+ #include <stdbool.h>
+ #else
+diff --git libblocksruntime-0.4.1/runtime.c libblocksruntime-0.4.1/runtime.c
+index c4432bb..a8edffe 100644
+--- libblocksruntime-0.4.1/runtime.c
++++ libblocksruntime-0.4.1/runtime.c
+@@ -300,13 +300,13 @@ static void _Block_byref_release(const void *arg) {
+ #pragma mark SPI/API
+ #endif /* if 0 */
+ 
+-void * __attribute__((weak)) _Block_copy(const void *arg) {
++BLOCK_PUBLIC void * BLOCK_WEAK _Block_copy(const void *arg) {
+     return _Block_copy_internal(arg, WANTS_ONE);
+ }
+ 
+ 
+ // API entry point to release a copied Block
+-void __attribute__((weak)) _Block_release(void *arg) {
++BLOCK_PUBLIC void BLOCK_WEAK _Block_release(void *arg) {
+     struct Block_layout *aBlock = (struct Block_layout *)arg;
+     int32_t newCount;
+     if (!aBlock) return;
+@@ -391,7 +391,7 @@ The implementation of the two routines would be improved by switch statements en
+  * When Blocks or Block_byrefs hold objects then their copy routine helpers use this entry point
+  * to do the assignment.
+  */
+-void  __attribute__((weak)) _Block_object_assign(void *destAddr, const void *object, const int flags) {
++BLOCK_PUBLIC void BLOCK_WEAK _Block_object_assign(void *destAddr, const void *object, const int flags) {
+     //printf("_Block_object_assign(*%p, %p, %x)\n", destAddr, object, flags);
+     if ((flags & BLOCK_BYREF_CALLER) == BLOCK_BYREF_CALLER) {
+         if ((flags & BLOCK_FIELD_IS_WEAK) == BLOCK_FIELD_IS_WEAK) {
+@@ -424,7 +424,7 @@ void  __attribute__((weak)) _Block_object_assign(void *destAddr, const void *obj
+ // When Blocks or Block_byrefs hold objects their destroy helper routines call this entry point
+ // to help dispose of the contents
+ // Used initially only for __attribute__((NSObject)) marked pointers.
+-void __attribute__((weak)) _Block_object_dispose(const void *object, const int flags) {
++BLOCK_PUBLIC void BLOCK_WEAK _Block_object_dispose(const void *object, const int flags) {
+     //printf("_Block_object_dispose(%p, %x)\n", object, flags);
+     if (flags & BLOCK_FIELD_IS_BYREF)  {
+         // get rid of the __block data structure held in a Block

--- a/mingw-w64-libblocksruntime/PKGBUILD
+++ b/mingw-w64-libblocksruntime/PKGBUILD
@@ -38,7 +38,7 @@ build() {
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \
-    --enable-static \
+    --disable-static \
     --enable-shared
 
   make

--- a/mingw-w64-libblocksruntime/PKGBUILD
+++ b/mingw-w64-libblocksruntime/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libblocksruntime
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.4.1
-pkgrel=2
+pkgrel=3
 pkgdesc='compiler-rt Blocks runtime library for Clang (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
@@ -16,13 +16,16 @@ msys2_references=(
 depends=("${MINGW_PACKAGE_PREFIX}-clang")
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools" "${MINGW_PACKAGE_PREFIX}-cc")
 source=("https://deb.debian.org/debian/pool/main/libb/${_realname}/${_realname}_${pkgver}.orig.tar.gz"
-        "0001-libblocksruntime-0.4.1-fix-shared-installation.patch")
+        "0001-libblocksruntime-0.4.1-fix-shared-installation.patch"
+        "0002-libblocksruntime-0.4.1-export-symbols.patch")
 sha256sums=('7807e18d7d6cabd90f77c8b8a8ebd472516fa4ed6a02df82e0c33b1c5e112abc'
-            '73cd40b3d8da2adf03ba85ba9a615d19512289bfc71dafb1f6240bb61540b24d')
+            '73cd40b3d8da2adf03ba85ba9a615d19512289bfc71dafb1f6240bb61540b24d'
+            '7340bf00fcb855a7906e037b2e607fd100d423838f36ffce4ed50524db8bf733')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
   patch -Np1 -i "${srcdir}/0001-libblocksruntime-0.4.1-fix-shared-installation.patch"
+  patch -Np1 -i "${srcdir}/0002-libblocksruntime-0.4.1-export-symbols.patch"
   autoreconf -fiv
 }
 


### PR DESCRIPTION
Functions which are marked with `BLOCK_EXPORT`  are supposed to be externally visible, but miss the `__attribute__((dllexport))` attribute.  As a result, they are not exported from a .dll when compiled with clang.

Additionally, methods marked with `__attribute__((dllexport))`  cannot have the `__attribute__((weak))` attribute applied to them, so make that conditional on being compiled for non-Windows platforms.

Together with #19767, this helps compiling Objective C code on MinGW using the clang compiler.