### PR TITLE
cjose: Update to 0.6.2.2

### DIFF
--- a/mingw-w64-cjose/001-cjose-0.6.1-fix-mingw-build.patch
+++ b/mingw-w64-cjose/001-cjose-0.6.1-fix-mingw-build.patch
@@ -11,30 +11,12 @@ index 799f2731016b9d288d1e85c5ef4b6796792d4e40..8851e0ebf96f381798767eb23aecd628
  AC_CONFIG_MACRO_DIR([m4])
  
  ### Basic program checks
-diff --git a/src/concatkdf.c b/src/concatkdf.c
-index 65c49766c6db6f151ee2788a1600475ca83ddf0d..1f76566bd0af8f80d814f82fb943a5eb7e1bbac8 100644
---- a/src/concatkdf.c
-+++ b/src/concatkdf.c
-@@ -7,7 +7,11 @@
- 
- #include "include/concatkdf_int.h"
- 
-+#ifdef _WIN32
-+#include <Winsock2.h>
-+#else
- #include <arpa/inet.h>
-+#endif
- #include <openssl/evp.h>
- #include <string.h>
- #include <cjose/base64.h>
-diff --git a/src/Makefile.am b/src/Makefile.am
-index a855d3b3f7e49231ffb1d1794aeaf57ddf301207..2d19ff68257bdb37fc443f67c70ddd592f35e7d7 100644
---- a/src/Makefile.am
-+++ b/src/Makefile.am
-@@ -2,7 +2,7 @@ AM_CFLAGS =-std=gnu99 --pedantic -Wall -Werror -g -O2 -I$(top_builddir)/include
+--- cjose-0.6.2.2/src/Makefile.am.orig	2024-01-17 09:07:57.893895400 +0100
++++ cjose-0.6.2.2/src/Makefile.am	2024-01-17 09:09:05.212359300 +0100
+@@ -2,7 +2,7 @@
  
  lib_LTLIBRARIES=libcjose.la
- libcjose_la_CPPFLAGS= -I$(topdir)/include
+ libcjose_la_CPPFLAGS= -I$(top_srcdir)/include
 -libcjose_la_LDFLAGS= -lm
 +libcjose_la_LDFLAGS= -lm -lws2_32 -no-undefined
  libcjose_la_SOURCES=version.c \

--- a/mingw-w64-cjose/PKGBUILD
+++ b/mingw-w64-cjose/PKGBUILD
@@ -3,22 +3,22 @@
 _realname=cjose
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.6.1
-pkgrel=2
+pkgver=0.6.2.2
+pkgrel=1
 pkgdesc="C library implementing the Javascript Object Signing and Encryption (JOSE) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
-url="https://github.com/cisco/cjose"
-license=('MIT')
+url="https://github.com/OpenIDC/cjose"
+license=('spdx:MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-check")
 depends=("${MINGW_PACKAGE_PREFIX}-jansson"
          "${MINGW_PACKAGE_PREFIX}-openssl")
-source=("${_realname}-${pkgver}.tar.gz::https://github.com/cisco/cjose/archive/${pkgver}.tar.gz"
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/OpenIDC/cjose/releases/download/v${pkgver}/cjose-${pkgver}.tar.gz"
         "001-cjose-0.6.1-fix-mingw-build.patch")
-sha256sums=('208eaa0fa616b44a71d8aa155c40b14c7c9d0fa2bb91d1408824520d2fc1b4dd'
-            'beddabd564eb057f6a99c898e27ad048d245ac7fc9f3e43ff0f4fa53d470d100')
+sha256sums=('2de8652b23ee3e15398176e8b2aaa513aa89635368f2748fbc304f8aefe910a4'
+            'd43f20f5a2bd23ede21823fd1e5115f2247f8dcfaddd7092f8f0204d411db335')
 noextract=("${_realname}-${pkgver}.tar.gz")
 
 prepare() {


### PR DESCRIPTION
Move to new upstream as other distros (Fedora, Gentoo, ...)

Simple patch refresh otherwise, one hunk was fixed upstream.