### PR TITLE
Update Vulkan Headers to 1.3.275

### DIFF
--- a/mingw-w64-vulkan-headers/PKGBUILD
+++ b/mingw-w64-vulkan-headers/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=Vulkan-Headers
 pkgbase=mingw-w64-vulkan-headers
 pkgname=("${MINGW_PACKAGE_PREFIX}-vulkan-headers")
-pkgver=1.3.268
+pkgver=1.3.275
 pkgrel=1
 pkgdesc='Vulkan header files (mingw-w64)'
 arch=('any')
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/KhronosGroup/${_realname}/archive/v${pkgver}.tar.gz")
-sha256sums=('d5c59d5fc3ab264006dfea1eb1a11f609ea5dfa8319a5aaca061007828012a78')
+sha256sums=('7161da645dbd33fd4ea61eec08e0d77389a640010acbf4afc00234f84df9b314')
 
 build() {
   mkdir -p ${srcdir}/build-${MSYSTEM} && cd ${srcdir}/build-${MSYSTEM}


### PR DESCRIPTION
Matches Vulkan SDK version 1.3.275 