### PR TITLE
clucene: Backport some patches from Arch and Gentoo

### DIFF
--- a/mingw-w64-clucene/003-fix-pkgconfig-file.patch
+++ b/mingw-w64-clucene/003-fix-pkgconfig-file.patch
@@ -5,7 +5,6 @@
  Description: CLucene - a C++ search engine, ported from the popular Apache Lucene
  Version: @CLUCENE_VERSION_MAJOR@.@CLUCENE_VERSION_MINOR@.@CLUCENE_VERSION_REVISION@.@CLUCENE_VERSION_PATCH@
 -Libs: -L${prefix}/@LIB_DESTINATION@/ -lclucene-core
--Cflags: -I${prefix}/include -I${prefix}/include/CLucene/ext
 +Libs: -L${prefix}/@LIB_DESTINATION@/ -lclucene-core -lclucene-shared
-+Cflags: -I${prefix}/include -I${prefix}/include/CLucene/ext
+ Cflags: -I${prefix}/include -I${prefix}/include/CLucene/ext
  ~

--- a/mingw-w64-clucene/004-fix-narrowing-conversions.patch
+++ b/mingw-w64-clucene/004-fix-narrowing-conversions.patch
@@ -1,0 +1,36 @@
+--- a/src/core/CLucene/queryParser/QueryParser.cpp
++++ b/src/core/CLucene/queryParser/QueryParser.cpp
+@@ -79,7 +79,7 @@
+     _T("<RANGEEX_GOOP>")
+ };
+ 
+-const int32_t QueryParser::jj_la1_0[] = {0x180,0x180,0xe00,0xe00,0x1f69f80,0x48000,0x10000,0x1f69000,0x1348000,0x80000,0x80000,0x10000,0x18000000,0x2000000,0x18000000,0x10000,0x80000000,0x20000000,0x80000000,0x10000,0x80000,0x10000,0x1f68000};
++const int32_t QueryParser::jj_la1_0[] = {0x180,0x180,0xe00,0xe00,0x1f69f80,0x48000,0x10000,0x1f69000,0x1348000,0x80000,0x80000,0x10000,0x18000000,0x2000000,0x18000000,0x10000,int32_t(0x80000000),0x20000000,int32_t(0x80000000),0x10000,0x80000,0x10000,0x1f68000};
+ const int32_t QueryParser::jj_la1_1[] = {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1,0x0,0x1,0x0,0x0,0x0,0x0};
+ 
+ struct QueryParser::JJCalls {
+--- a/src/core/CLucene/queryParser/QueryParserTokenManager.cpp
++++ b/src/core/CLucene/queryParser/QueryParserTokenManager.cpp
+@@ -15,9 +15,9 @@
+ 
+ CL_NS_DEF(queryParser)
+ 
+-const int64_t QueryParserTokenManager::jjbitVec2[]={0x0L, 0x0L, _ILONGLONG(0xffffffffffffffff), _ILONGLONG(0xffffffffffffffff)};
++const int64_t QueryParserTokenManager::jjbitVec2[]={0x0L, 0x0L, int64_t(_ILONGLONG(0xffffffffffffffff)), int64_t(_ILONGLONG(0xffffffffffffffff))};
+ const int64_t QueryParserTokenManager::jjbitVec0[] = {
+-	_ILONGLONG(0xfffffffffffffffe), _ILONGLONG(0xffffffffffffffff), _ILONGLONG(0xffffffffffffffff), _ILONGLONG(0xffffffffffffffff)
++	int64_t(_ILONGLONG(0xfffffffffffffffe)), int64_t(_ILONGLONG(0xffffffffffffffff)), int64_t(_ILONGLONG(0xffffffffffffffff)), int64_t(_ILONGLONG(0xffffffffffffffff))
+ };
+ const int32_t QueryParserTokenManager::jjnextStates[]={
+ 		15, 17, 18, 29, 32, 23, 33, 30, 20, 21, 32, 23, 33, 31, 34, 27,
+--- a/src/core/CLucene/queryParser/legacy/Lexer.cpp
++++ b/src/core/CLucene/queryParser/legacy/Lexer.cpp
+@@ -117,7 +117,7 @@ bool Lexer::GetNextToken(QueryToken* tok
+       if( _istspace(ch)!=0 ) {
+          continue;
+       }
+-      TCHAR buf[2] = {ch,'\0'};
++      TCHAR buf[2] = {TCHAR(ch),'\0'};
+       switch(ch) {
+          case '+':
+             token->set(buf, QueryToken::PLUS);

--- a/mingw-w64-clucene/005-Replace-std-binary_function-with-typedefs.patch
+++ b/mingw-w64-clucene/005-Replace-std-binary_function-with-typedefs.patch
@@ -1,0 +1,199 @@
+Replace std::binary_function with typedefs (deprecated in c++11 and removed in c++17).
+Bug: https://bugs.gentoo.org/869170
+--- a/src/core/CLucene/index/_Term.h
++++ b/src/core/CLucene/index/_Term.h
+@@ -13,9 +13,12 @@
+ CL_NS_DEF(index)
+ 
+ 
+-class Term_Equals:public CL_NS_STD(binary_function)<const Term*,const Term*,bool>
++class Term_Equals
+ {
+ public:
++	typedef const Term* first_argument_type;
++	typedef const Term* second_argument_type;
++	typedef bool result_type;
+ 	bool operator()( const Term* val1, const Term* val2 ) const{
+ 		return val1->equals(val2);
+ 	}
+--- a/src/core/CLucene/search/BooleanQuery.cpp
++++ b/src/core/CLucene/search/BooleanQuery.cpp
+@@ -25,9 +25,12 @@ CL_NS_USE(index)
+ CL_NS_USE(util)
+ CL_NS_DEF(search)
+ 
+-	class BooleanClause_Compare:public CL_NS_STD(binary_function)<const BooleanClause*,const BooleanClause*,bool>
++	class BooleanClause_Compare
+ 	{
+ 	public:
++		typedef const BooleanClause* first_argument_type;
++		typedef const BooleanClause* second_argument_type;
++		typedef bool result_type;
+ 		bool operator()( const BooleanClause* val1, const BooleanClause* val2 ) const {
+ 			return val1->equals(val2);
+ 		}
+--- a/src/core/CLucene/search/MultiPhraseQuery.cpp
++++ b/src/core/CLucene/search/MultiPhraseQuery.cpp
+@@ -377,9 +377,12 @@ TCHAR* MultiPhraseQuery::toString(const TCHAR* f) const {
+ 	return buffer.giveBuffer();
+ }
+ 
+-class TermArray_Equals:public CL_NS_STD(binary_function)<const Term**,const Term**,bool>
++class TermArray_Equals
+ {
+ public:
++	typedef const Term** first_argument_type;
++	typedef const Term** second_argument_type;
++	typedef bool result_type;
+ 	bool operator()( CL_NS(util)::ArrayBase<CL_NS(index)::Term*>* val1, CL_NS(util)::ArrayBase<CL_NS(index)::Term*>* val2 ) const{
+     if ( val1->length != val2->length )
+       return false;
+--- a/src/core/CLucene/util/Equators.h
++++ b/src/core/CLucene/util/Equators.h
+@@ -22,21 +22,30 @@ CL_NS_DEF(util)
+ /** @internal */
+ class CLUCENE_INLINE_EXPORT Equals{
+ public:
+-	class CLUCENE_INLINE_EXPORT Int32:public CL_NS_STD(binary_function)<const int32_t*,const int32_t*,bool>
++	class CLUCENE_INLINE_EXPORT Int32
+ 	{
+ 	public:
++		typedef const int32_t* first_argument_type;
++		typedef const int32_t* second_argument_type;
++		typedef bool result_type;
+ 		bool operator()( const int32_t val1, const int32_t val2 ) const;
+ 	};
+ 	
+-	class CLUCENE_INLINE_EXPORT Char:public CL_NS_STD(binary_function)<const char*,const char*,bool>
++	class CLUCENE_INLINE_EXPORT Char
+ 	{
+ 	public:
++		typedef const char* first_argument_type;
++		typedef const char* second_argument_type;
++		typedef bool result_type;
+ 		bool operator()( const char* val1, const char* val2 ) const;
+ 	};
+ #ifdef _UCS2
+-	class CLUCENE_INLINE_EXPORT WChar: public CL_NS_STD(binary_function)<const wchar_t*,const wchar_t*,bool>
++	class CLUCENE_INLINE_EXPORT WChar
+ 	{
+ 	public:
++		typedef const wchar_t* first_argument_type;
++		typedef const wchar_t* second_argument_type;
++		typedef bool result_type;
+ 		bool operator()( const wchar_t* val1, const wchar_t* val2 ) const;
+ 	};
+ 	class CLUCENE_INLINE_EXPORT TChar: public WChar{
+@@ -48,9 +57,12 @@ public:
+ 
+ 
+     template<typename _cl>
+-	class CLUCENE_INLINE_EXPORT Void:public CL_NS_STD(binary_function)<const void*,const void*,bool>
++	class CLUCENE_INLINE_EXPORT Void
+ 	{
+ 	public:
++		typedef const void* first_argument_type;
++		typedef const void* second_argument_type;
++		typedef bool result_type;
+ 		bool operator()( _cl* val1, _cl* val2 ) const{
+ 			return val1==val2;
+ 		}
+--- a/src/core/CLucene/util/_Arrays.h
++++ b/src/core/CLucene/util/_Arrays.h
+@@ -124,12 +124,14 @@ CL_NS_DEF(util)
+ 	
+ 	template <typename _kt, typename _comparator, 
+ 		typename class1, typename class2>
+-	class CLListEquals:
+-		public CL_NS_STD(binary_function)<class1*,class2*,bool>
++	class CLListEquals
+ 	{
+ 	typedef typename class1::const_iterator _itr1;
+ 	typedef typename class2::const_iterator _itr2;
+ 	public:
++		typedef class1* first_argument_type;
++		typedef class2* second_argument_type;
++		typedef bool result_type;
+ 		CLListEquals(){
+ 		}
+ 		bool equals( class1* val1, class2* val2 ) const{
+--- a/src/test/index/TestTermVectorsReader.cpp
++++ b/src/test/index/TestTermVectorsReader.cpp
+@@ -93,17 +93,21 @@ CL_NS_USE(util);
+     }
+   };
+ 
+-  struct MyTCharCompare :
+-    public std::binary_function<const TCHAR*, const TCHAR*, bool>
++  struct MyTCharCompare
+   {
++    typedef const TCHAR* first_argument_type;
++    typedef const TCHAR* second_argument_type;
++    typedef bool result_type;
+     bool operator () (const TCHAR* v1, const TCHAR* v2) const {
+       return _tcscmp(v1, v2) < 0;
+     }
+   };
+ 
+-  struct TestTokenCompare : 
+-    public std::binary_function<const TestToken*, const TestToken*, bool>
++  struct TestTokenCompare
+   {
++    typedef const TestToken* first_argument_type;
++    typedef const TestToken* second_argument_type;
++    typedef bool result_type;
+     bool operator () (const TestToken* t1, const TestToken* t2) const {
+       return t1->pos < t2->pos;
+     }
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -45,6 +45,14 @@ ELSE(NOT CMAKE_BUILD_TYPE)
+     MESSAGE( "Compiling as ${CMAKE_BUILD_TYPE}" )
+ ENDIF(NOT CMAKE_BUILD_TYPE)
+ 
++IF(CMAKE_C_COMPILER_ID MATCHES "Clang")
++  SET(CMAKE_COMPILER_IS_CLANG 1)
++ENDIF(CMAKE_C_COMPILER_ID MATCHES "Clang")
++
++IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
++  SET(CMAKE_COMPILER_IS_CLANGXX 1)
++ENDIF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
++
+ OPTION(ENABLE_DEBUG
+   "enable debug support"
+   OFF)
+@@ -62,14 +70,14 @@ OPTION(ENABLE_ASCII_MODE
+   OFF)
+   
+ SET(ENABLE_ANSI_MODE OFF)
+-IF(CMAKE_COMPILER_IS_GNUCXX)
++IF(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANGXX)
+   SET(ENABLE_ANSI_MODE ON)
+   
+   #exceptions:
+   IF(MINGW OR CYGWIN)
+     SET(ENABLE_ANSI_MODE OFF)
+   ENDIF(MINGW OR CYGWIN)
+-ENDIF(CMAKE_COMPILER_IS_GNUCXX)
++ENDIF(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANGXX)
+ 
+ OPTION(ENABLE_ANSI_MODE
+   "compile with -ansi flag"
+@@ -109,7 +117,7 @@ OPTION(ENABLE_COMPILE_TESTS
+ 
+ #check flags...
+ INCLUDE (TestCXXAcceptsFlag)
+-IF ( CMAKE_COMPILER_IS_GNUCC )
++IF ( CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG )
+     CHECK_CXX_ACCEPTS_FLAG(-pg GccFlagPg)
+     IF ( GccFlagPg )
+         OPTION(ENABLE_GPROF
+@@ -131,7 +139,7 @@ IF ( CMAKE_COMPILER_IS_GNUCC )
+    IF( ENABLE_ANSI_MODE )
+     SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ansi")
+    ENDIF ( ENABLE_ANSI_MODE )
+-ENDIF(CMAKE_COMPILER_IS_GNUCC) 
++ENDIF(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG) 
+ 
+ 
+ #Single output directory for building all executables and libraries.

--- a/mingw-w64-clucene/PKGBUILD
+++ b/mingw-w64-clucene/PKGBUILD
@@ -4,7 +4,7 @@ _realname=clucene
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.3.3.4
-pkgrel=4
+pkgrel=5
 pkgdesc="CLucene - a C++ search engine (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -21,12 +21,16 @@ source=("https://downloads.sourceforge.net/project/${_realname}/${_realname}-cor
         clucene-core-2.3.3.4.patch
         002-install-contribs-lib.patch
         003-fix-pkgconfig-file.patch
+        004-fix-narrowing-conversions.patch
+        005-Replace-std-binary_function-with-typedefs.patch
         010-pthread.patch
         020-gcc.patch)
 sha256sums=('ddfdc433dd8ad31b5c5819cc4404a8d2127472a3b720d3e744e8c51d79732eab'
             'a3b0bb664231ed5e66384dd606422d7f6d9f0e6181f295056acfbe0b0d4d7c9c'
             'd3dbb355d00445455fb91c74dacdea380048d3fc2f71b13c5be656ada0f627db'
-            'fedfadf790417bf133e313a30c817b3359856981ac21b3fae5f7dc34fe1a7fd8'
+            'd4e4082dba978f3267d40820b75889606b41a5f639f148bc75067b3d04ee4d14'
+            '7828895a3da58ef4e6d2f6480af01ab53579f4fc9984043e3708b8c16431bd0c'
+            '6594312b42a9bf9b5130ec22075da006fa1024cbabcacf919cc86e672e1f476c'
             '81f96824bf2ff0dc35288be6fa891df66841110fcd26f59c77025a96b831b637'
             '821471b0bc4e36571eea1d4d637e1c7881aae4ab18a78fed8be29771e38b58b0')
 
@@ -44,6 +48,8 @@ prepare() {
     clucene-core-2.3.3.4.patch \
     002-install-contribs-lib.patch \
     003-fix-pkgconfig-file.patch \
+    004-fix-narrowing-conversions.patch \
+    005-Replace-std-binary_function-with-typedefs.patch \
     010-pthread.patch \
     020-gcc.patch
 }
@@ -58,13 +64,12 @@ build() {
     _extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
-  CXXFLAGS+=" -Wno-narrowing -Wno-deprecated-declarations" \
+  CXXFLAGS+=" -Wno-deprecated-declarations" \
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe -Wno-dev \
     -G"Ninja" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DBUILD_STATIC_LIBRARIES=ON \
-    -DCMAKE_CXX_STANDARD=14 \
     -DCMAKE_DLL_NAME_WITH_SOVERSION=ON \
     -DBUILD_CONTRIBS_LIB=ON \
     "${_extra_config[@]}" \


### PR DESCRIPTION
https://gitlab.archlinux.org/archlinux/packaging/packages/clucene/-/blob/caf24cd2/clucene-narrowing-conversions.patch https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-cpp/clucene/files/clucene-2.3.3.4-fix-binary-function.patch?id=1ba9c12d