### PR TITLE
libmariadbclient: update to 3.3.8

### DIFF
--- a/mingw-w64-libmariadbclient/001-mingw-build.patch
+++ b/mingw-w64-libmariadbclient/001-mingw-build.patch
@@ -1,7 +1,6 @@
-diff -Naur mariadb-connector-c-3.1.7-src-orig/cmake/install.cmake mariadb-connector-c-3.1.7-src/cmake/install.cmake
---- mariadb-connector-c-3.1.7-src-orig/cmake/install.cmake	2020-01-22 13:08:18.000000000 +0300
-+++ mariadb-connector-c-3.1.7-src/cmake/install.cmake	2020-04-21 15:43:58.718730500 +0300
-@@ -61,10 +61,10 @@
+--- a/cmake/install.cmake
++++ b/cmake/install.cmake
+@@ -62,11 +62,11 @@
  #
  
  SET(INSTALL_BINDIR_DEFAULT "bin")
@@ -10,26 +9,26 @@ diff -Naur mariadb-connector-c-3.1.7-src-orig/cmake/install.cmake mariadb-connec
  SET(INSTALL_PCDIR_DEFAULT "lib/pkgconfig")
  SET(INSTALL_INCLUDEDIR_DEFAULT "include/mariadb")
 -SET(INSTALL_DOCDIR_DEFAULT "docs")
+-SET(INSTALL_MANDIR_DEFAULT "man")
 +SET(INSTALL_DOCDIR_DEFAULT "share/docs/mariadb")
++SET(INSTALL_MANDIR_DEFAULT "share/man")
  IF(NOT IS_SUBPROJECT)
    SET(INSTALL_PLUGINDIR_DEFAULT "lib/mariadb/plugin")
  ELSE()
-diff -Naur mariadb-connector-c-3.1.7-src-orig/CMakeLists.txt mariadb-connector-c-3.1.7-src/CMakeLists.txt
---- mariadb-connector-c-3.1.7-src-orig/CMakeLists.txt	2020-01-22 13:08:18.000000000 +0300
-+++ mariadb-connector-c-3.1.7-src/CMakeLists.txt	2020-04-21 15:43:58.718730500 +0300
-@@ -392,7 +392,7 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -428,7 +428,7 @@
  INCLUDE(${CC_SOURCE_DIR}/plugins/CMakeLists.txt)
  ADD_SUBDIRECTORY(include)
  ADD_SUBDIRECTORY(libmariadb)
--IF(NOT WIN32)
-+IF(NOT MSVC)
+-IF((NOT WIN32) OR CYGWIN)
++IF((NOT MSVC) OR CYGWIN)
    ADD_SUBDIRECTORY(mariadb_config)
  ENDIF()
  
-diff -Naur mariadb-connector-c-3.1.7-src-orig/libmariadb/CMakeLists.txt mariadb-connector-c-3.1.7-src/libmariadb/CMakeLists.txt
---- mariadb-connector-c-3.1.7-src-orig/libmariadb/CMakeLists.txt	2020-01-22 13:08:18.000000000 +0300
-+++ mariadb-connector-c-3.1.7-src/libmariadb/CMakeLists.txt	2020-04-21 15:43:58.718730500 +0300
-@@ -451,6 +451,13 @@
+--- a/libmariadb/CMakeLists.txt
++++ b/libmariadb/CMakeLists.txt
+@@ -496,6 +496,13 @@
   ${CPACK_PACKAGE_VERSION_MAJOR}
   SOVERSION ${CPACK_PACKAGE_VERSION_MAJOR})
  
@@ -43,14 +42,14 @@ diff -Naur mariadb-connector-c-3.1.7-src-orig/libmariadb/CMakeLists.txt mariadb-
  IF(NOT WIN32)
    SET_TARGET_PROPERTIES(mariadbclient PROPERTIES OUTPUT_NAME "${LIBMARIADB_STATIC_NAME}")
  ENDIF()
-@@ -460,7 +467,9 @@
-           DESTINATION ${INSTALL_LIBDIR})
+@@ -513,7 +513,9 @@
+ IF(WIN32)
  INSTALL(TARGETS libmariadb
-           COMPONENT SharedLibraries
+         COMPONENT SharedLibraries
 -        DESTINATION ${INSTALL_LIBDIR})
 +        RUNTIME DESTINATION ${INSTALL_BINDIR}
 +        LIBRARY DESTINATION ${INSTALL_LIBDIR}
 +        ARCHIVE DESTINATION ${INSTALL_LIBDIR})
- 
- 
- IF(MSVC)
+ ELSE()
+ # in cmake 3.12+ we can use
+ #INSTALL(TARGETS libmariadb LIBRARY DESTINATION ${INSTALL_LIBDIR}

--- a/mingw-w64-libmariadbclient/004-fix-build-remote-io.patch
+++ b/mingw-w64-libmariadbclient/004-fix-build-remote-io.patch
@@ -1,0 +1,11 @@
+--- a/plugins/io/CMakeLists.txt
++++ b/plugins/io/CMakeLists.txt
+@@ -11,5 +11,8 @@
+                   SOURCES ${CC_SOURCE_DIR}/plugins/io/remote_io.c
+                   INCLUDES ${CURL_INCLUDE_DIR}
+                   LIBRARIES ${CURL_LIBRARIES})
++    if(MINGW)
++      target_link_libraries(remote_io ws2_32)
++    endif()
+   ENDIF()
+ ENDIF()

--- a/mingw-w64-libmariadbclient/PKGBUILD
+++ b/mingw-w64-libmariadbclient/PKGBUILD
@@ -3,47 +3,56 @@
 _realname=libmariadbclient
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.1.13
+pkgver=3.3.8
 pkgrel=1
 pkgdesc="MariaDB client libraries (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
-msys2_references=(
-  'archlinux: mariadb-libs'
-)
 url="https://mariadb.org/"
-license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+msys2_repository_url="https://github.com/mariadb-corporation/mariadb-connector-c"
+msys2_references=(
+  'archlinux'
+)
+license=('spdx:LGPL-2.1-or-later')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
-             "${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-tools-git")
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
-         "${MINGW_PACKAGE_PREFIX}-curl"
-         #"${MINGW_PACKAGE_PREFIX}-openssl"
-         "${MINGW_PACKAGE_PREFIX}-zlib")
-#optdepends=("${MINGW_PACKAGE_PREFIX}-curl")
-options=('!strip' 'staticlibs')
+             $([[ ${CARCH} != i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-tools-git"))
+depends=("${MINGW_PACKAGE_PREFIX}-curl"
+         "${MINGW_PACKAGE_PREFIX}-zlib"
+         "${MINGW_PACKAGE_PREFIX}-zstd")
 source=(https://mirror.rackspace.com/mariadb/connector-c-${pkgver}/mariadb-connector-c-${pkgver}-src.tar.gz{,.asc}
         001-mingw-build.patch
         002-fix-prototype.patch
-        003-gcc-fix-use_VA_ARGS.patch)
-sha256sums=('0271a5edfd64b13bca5937267474e4747d832ec62e169fc2589d2ead63746875'
+        003-gcc-fix-use_VA_ARGS.patch
+        004-fix-build-remote-io.patch)
+sha256sums=('f9f076b4aa9fb22cc94b24f82c80f9ef063805ecd6533a2eb5d5060cf93833e8'
             'SKIP'
-            'a5ef33cae8a5a5b06c5b5686628bb8e9419f6bd2305343c63e952f4da1fa0fac'
+            '64ad2b8c85fb369c20c1941c896c2a7d5202a8b7259e9e31922c8d0bfcbfd198'
             '346695ce8f10c2c426f880240ef7bbe7b8d70c6e58b0cc30483735c2b2d53261'
-            'fc08055e5d63e310e2658b15f6e1f00b59f2aad2dec37560c01954fac6af4a6e')
-validpgpkeys=("199369E5404BD5FC7D2FE43BCBCB082A1BB943DB") #MariaDB Package Signing Key <package-signing-key@mariadb.org>
+            'fc08055e5d63e310e2658b15f6e1f00b59f2aad2dec37560c01954fac6af4a6e'
+            'dc3a0a5866cceb5996cc59af31af5b824e2146af7f64b1becf7fac3dfbf1e380')
+validpgpkeys=("177F4010FE56CA3336300305F1656F24C74CD1D8") #MariaDB Package Signing Key <package-signing-key@mariadb.org>
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
 
 prepare() {
   cd ${srcdir}/mariadb-connector-c-${pkgver}-src
-  patch -p1 -i ${srcdir}/001-mingw-build.patch
-  patch -p1 -i ${srcdir}/002-fix-prototype.patch
-  patch -p1 -i ${srcdir}/003-gcc-fix-use_VA_ARGS.patch
+  apply_patch_with_msg \
+    001-mingw-build.patch \
+    002-fix-prototype.patch \
+    003-gcc-fix-use_VA_ARGS.patch \
+    004-fix-build-remote-io.patch
 }
 
 build() {
-  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
-  mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
   declare -a _extra_config
   if check_option "debug" "n"; then
@@ -56,19 +65,21 @@ build() {
   ${MINGW_PREFIX}/bin/cmake.exe \
     -G "Ninja" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DINSTALL_LIBDIR=lib \
     "${_extra_config[@]}" \
     -DWITH_EXTERNAL_ZLIB=ON \
     -DWITH_MYSQLCOMPAT=OFF \
     -DWITH_SSL="SCHANNEL" \
-    -DCLIENT_PLUGIN_AUTH_GSSAPI_CLIENT=STATIC \
-    -DCLIENT_PLUGIN_DIALOG=STATIC \
-    -DCLIENT_PLUGIN_REMOTE_IO=OFF \
-    -DCLIENT_PLUGIN_PVIO_NPIPE=STATIC \
-    -DCLIENT_PLUGIN_PVIO_SHMEM=STATIC \
-    -DCLIENT_PLUGIN_CLIENT_ED25519=OFF \
-    -DCLIENT_PLUGIN_CACHING_SHA2_PASSWORD=STATIC \
-    -DCLIENT_PLUGIN_SHA256_PASSWORD=STATIC \
-    -DCLIENT_PLUGIN_MYSQL_CLEAR_PASSWORD=STATIC \
+    -DWITH_UNIT_TESTS=OFF \
+    -DCLIENT_PLUGIN_AUTH_GSSAPI_CLIENT=DYNAMIC \
+    -DCLIENT_PLUGIN_DIALOG=DYNAMIC \
+    -DCLIENT_PLUGIN_REMOTE_IO=DYNAMIC \
+    -DCLIENT_PLUGIN_PVIO_NPIPE=DYNAMIC \
+    -DCLIENT_PLUGIN_PVIO_SHMEM=DYNAMIC \
+    -DCLIENT_PLUGIN_CLIENT_ED25519=DYNAMIC \
+    -DCLIENT_PLUGIN_CACHING_SHA2_PASSWORD=DYNAMIC \
+    -DCLIENT_PLUGIN_SHA256_PASSWORD=DYNAMIC \
+    -DCLIENT_PLUGIN_MYSQL_CLEAR_PASSWORD=DYNAMIC \
     -DCLIENT_PLUGIN_MYSQL_OLD_PASSWORD=STATIC \
     ../mariadb-connector-c-${pkgver}-src
 
@@ -76,8 +87,8 @@ build() {
 }
 
 package() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
-  DESTDIR=${pkgdir} ${MINGW_PREFIX}/bin/cmake.exe --build ./ --target install
+  cd "${srcdir}/build-${MSYSTEM}"
+  DESTDIR=${pkgdir} ${MINGW_PREFIX}/bin/cmake.exe --install .
 
   ln -s "${pkgdir}${MINGW_PREFIX}"/include/mariadb "${pkgdir}${MINGW_PREFIX}"/include/mysql
 
@@ -91,10 +102,14 @@ package() {
   cp "${pkgdir}${MINGW_PREFIX}"/lib/{libmariadb,libmysqlclient_r}.dll.a
   cp "${pkgdir}${MINGW_PREFIX}"/lib/{libmariadbclient,libmysqlclient}.a
   cp "${pkgdir}${MINGW_PREFIX}"/lib/{libmariadbclient,libmysqlclient_r}.a
+  cp "${pkgdir}${MINGW_PREFIX}"/bin/{mariadb_config,mysql_config}.exe
+  cp "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/{libmariadb,mysqlclient}.pc
 
   local _PRE_WIN="$(cygpath -m ${MINGW_PREFIX})"
 
   for pcfile in  "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/*.pc; do
     sed -s "s|${_PRE_WIN}|${MINGW_PREFIX}|g" -i "${pcfile}"
   done
+
+  install -Dm644 "${srcdir}/mariadb-connector-c-${pkgver}-src/COPYING.LIB" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.LIB"
 }


### PR DESCRIPTION
Offer more discoverability as mysqlclient by providing mysql_config.exe and mysqlclient.pc files which used by many projects to detect and link against MySQL.