### PR TITLE
ruff: update to 0.1.14

### DIFF
--- a/mingw-w64-ruff/PKGBUILD
+++ b/mingw-w64-ruff/PKGBUILD
@@ -4,7 +4,7 @@ _realname=ruff
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=0.1.13
+pkgver=0.1.14
 pkgrel=1
 pkgdesc="An extremely fast Python linter, written in Rust (mingw-w64)"
 arch=('any')
@@ -19,7 +19,7 @@ makedepends=(
 options=('!strip')
 source=("$url/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
         "001-fix-building-with-gcc.patch")
-sha256sums=('36a32001c821b844d19fc3d95d6d9265b9ef03b08c5e0950dfa94191454b5a93'
+sha256sums=('7b186090cab2dfd602dc36f8abfb68b8421fb1e959fbc023e001eed2e5ea8cdd'
             'a266b1594ab3280525d7bce5adb91026c1e183696a4586255d4a0fcd008d41c2')
 noextract=("${_realname}-${pkgver}.tar.gz")
 
@@ -30,6 +30,9 @@ prepare() {
   if [[ ${MINGW_PACKAGE_PREFIX} != *clang-* ]]; then
     patch -p1 -i "${srcdir}"/001-fix-building-with-gcc.patch
   fi
+
+  # otherwise cargo installs msvc toolchain from rustup
+  rm -f rust-toolchain.toml
 
   cargo fetch --locked
 }


### PR DESCRIPTION
I tried to apply workaround for fetching less deps, but maturin anyway downloads some more for other targets