### PR TITLE
fetch less crates in preparation step, take 2

### DIFF
--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.cargo-tarball.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.cargo-tarball.sh
@@ -24,7 +24,12 @@ prepare() {
   patch -Np1 -i "${srcdir}"/0001-A-really-important-fix.patch
   patch -Np1 -i "${srcdir}"/0002-A-less-important-fix.patch
 
-  cargo fetch --locked
+  # if packaging fails at build, use `cargo fetch --locked` instead
+  local _target="${CARCH}-pc-windows-gnu"
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
+    _target="${CARCH}-pc-windows-gnullvm"
+  fi
+  cargo fetch --locked --target "${_target}"
 }
 
 build() {

--- a/mingw-w64-bat/PKGBUILD
+++ b/mingw-w64-bat/PKGBUILD
@@ -31,9 +31,15 @@ prepare() {
   cargo update -p windows-targets@0.48.0 --precise 0.48.1 \
     --manifest-path build-${MSYSTEM}/Cargo.toml
 
-  ${MINGW_PREFIX}/bin/cargo fetch \
-  --locked \
-  --manifest-path build-${MSYSTEM}/Cargo.toml
+  local _target="${CARCH}-pc-windows-gnu"
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
+    _target="${CARCH}-pc-windows-gnullvm"
+  fi
+
+  cargo fetch \
+    --locked \
+    --manifest-path build-${MSYSTEM}/Cargo.toml \
+    --target "${_target}"
 }
 
 build() {
@@ -52,10 +58,8 @@ package() {
   --root ${pkgdir}${MINGW_PREFIX}
 
   # Package licenses
-  install -Dm644 build-${MSYSTEM}/LICENSE-APACHE \
-    "${pkgdir}${MINGW_PREFIX}"/share/licenses/$pkgname/LICENSE-APACHE
-  install -Dm644 build-${MSYSTEM}/LICENSE-MIT \
-    "${pkgdir}${MINGW_PREFIX}"/share/licenses/$pkgname/LICENSE-MIT
+  install -Dm644 build-${MSYSTEM}/LICENSE-{APACHE,MIT} -t \
+    "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname}
 
   cd build-${MSYSTEM}/target/release/build
 
@@ -69,5 +73,4 @@ package() {
   # Package the fish completion
   find . -name bat.fish -type f -exec install -Dm644 {} \
     "${pkgdir}${MINGW_PREFIX}"/share/fish/vendor_completions.d/bat.fish \;
-
 }

--- a/mingw-w64-cargo-c/PKGBUILD
+++ b/mingw-w64-cargo-c/PKGBUILD
@@ -31,8 +31,11 @@ prepare() {
 
     patch -p1 -i "${srcdir}"/001-add-lib-prefix-on-windows-gnu.patch
 
-    cargo fetch \
-        --locked
+    local _target="${CARCH}-pc-windows-gnu"
+    if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
+        _target="${CARCH}-pc-windows-gnullvm"
+    fi
+    cargo fetch --locked --target "${_target}"
 }
 
 build() {

--- a/mingw-w64-cargo-create-tauri-app/PKGBUILD
+++ b/mingw-w64-cargo-create-tauri-app/PKGBUILD
@@ -18,18 +18,20 @@ sha256sums=('6dd4108d016820f69a3edfcbee8ef03cfb1c74ee754b688ade148bf046432d81')
 prepare() {
   cd "${srcdir}/${_basename}-${_basename}-v${pkgver}"
 
-  "${MINGW_PREFIX}/bin/cargo.exe" fetch --locked
+  local _target="${CARCH}-pc-windows-gnu"
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
+    _target="${CARCH}-pc-windows-gnullvm"
+  fi
+  "${MINGW_PREFIX}/bin/cargo.exe" fetch --locked --target "${_target}"
 }
 
 build() {
-  msg "Cargo build for ${MSYSTEM}"
-  cd "${srcdir}"
   cp -r "${_basename}-${_basename}-v${pkgver}" "build-${MSYSTEM}"
   cd "build-${MSYSTEM}"
 
   "${MINGW_PREFIX}/bin/cargo.exe" build \
     --release \
-    --locked
+    --frozen
 }
 
 check() {
@@ -37,7 +39,7 @@ check() {
 
   "${MINGW_PREFIX}/bin/cargo.exe" test \
     --release \
-    --locked
+    --frozen
 }
 
 package() {
@@ -48,4 +50,3 @@ package() {
   install -Dm644 "LICENSE_MIT" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE_MIT"
   install -Dm644 "LICENSE_APACHE-2.0" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE_APACHE-2.0"
 }
-

--- a/mingw-w64-cargo-generate/PKGBUILD
+++ b/mingw-w64-cargo-generate/PKGBUILD
@@ -9,6 +9,9 @@ pkgdesc="Use pre-existing git repositories as templates (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://github.com/cargo-generate/cargo-generate"
+msys2_references=(
+  'archlinux: cargo-generate'
+)
 license=('spdx:MIT OR Apache-2.0')
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-mdbook")
@@ -35,18 +38,14 @@ END
 }
 
 build() {
-  rm -rf "build-${MSYSTEM}" | true
   cp -r "${_realname}-${pkgver}" "build-${MSYSTEM}"
-  msg "Cargo build for ${MSYSTEM}"
   cd "build-${MSYSTEM}"
 
   "${MINGW_PREFIX}/bin/cargo.exe" build \
     --release \
     --locked
 
-  msg "Build documentation"
   cd guide
-
   "${MINGW_PREFIX}/bin/mdbook.exe" build
 }
 
@@ -67,4 +66,3 @@ package() {
   install -Dm644 "LICENSE-MIT" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE-MIT"
   install -Dm644 "LICENSE-APACHE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE-APACHE"
 }
-

--- a/mingw-w64-cargo-local-registry/PKGBUILD
+++ b/mingw-w64-cargo-local-registry/PKGBUILD
@@ -9,6 +9,9 @@ pkgdesc="A cargo subcommand to manage local registries (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://github.com/dhovart/cargo-local-registry"
+msys2_references=(
+  'aur: cargo-local-registry'
+)
 license=('spdx:MIT OR Apache-2.0')
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
 source=("$url/archive/$pkgver/$_realname-$pkgver.tar.gz")
@@ -19,7 +22,12 @@ prepare() {
 
   # update windows-targets to fix windows-gnullvm dependency specification
   "${MINGW_PREFIX}/bin/cargo.exe" update -p windows-targets@0.48.0 --precise 0.48.1
-  "${MINGW_PREFIX}/bin/cargo.exe" fetch --locked
+
+  local _target="${CARCH}-pc-windows-gnu"
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
+    _target="${CARCH}-pc-windows-gnullvm"
+  fi
+  "${MINGW_PREFIX}/bin/cargo.exe" fetch --locked --target "${_target}"
 }
 
 build() {
@@ -30,7 +38,7 @@ build() {
 
   "${MINGW_PREFIX}/bin/cargo.exe" build \
     --release \
-    --locked
+    --frozen
 }
 
 check() {
@@ -38,7 +46,7 @@ check() {
 
   "${MINGW_PREFIX}/bin/cargo.exe" test \
     --release \
-    --locked
+    --frozen
 }
 
 package() {
@@ -49,4 +57,3 @@ package() {
   install -Dm644 "LICENSE-MIT" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE-MIT"
   install -Dm644 "LICENSE-APACHE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE-APACHE"
 }
-

--- a/mingw-w64-cargo-tauri/PKGBUILD
+++ b/mingw-w64-cargo-tauri/PKGBUILD
@@ -10,6 +10,9 @@ pkgdesc="Command line interface for building Tauri apps (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://github.com/tauri-apps/tauri"
+msys2_references=(
+  'archlinux: cargo-tauri'
+)
 license=('spdx:MIT OR Apache-2.0')
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
 source=("${url}/archive/${_basename}-cli-v${pkgver}/${_basename}-${_basename}-cli-v${pkgver}.tar.gz")
@@ -24,18 +27,20 @@ prepare() {
 
   cd "${srcdir}/${_basename}-${_basename}-cli-v${pkgver}/tooling/cli"
 
-  "${MINGW_PREFIX}/bin/cargo.exe" fetch --locked
+  local _target="${CARCH}-pc-windows-gnu"
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
+    _target="${CARCH}-pc-windows-gnullvm"
+  fi
+  "${MINGW_PREFIX}/bin/cargo.exe" fetch --locked --target "${_target}"
 }
 
 build() {
-  msg "Cargo build for ${MSYSTEM}"
-  cd "${srcdir}"
   cp -r "${_basename}-${_basename}-cli-v${pkgver}" "build-${MSYSTEM}"
   cd "build-${MSYSTEM}/tooling/cli"
 
   "${MINGW_PREFIX}/bin/cargo.exe" build \
     --release \
-    --locked
+    --frozen
 }
 
 check() {
@@ -43,7 +48,7 @@ check() {
 
   "${MINGW_PREFIX}/bin/cargo.exe" test \
     --release \
-    --locked
+    --frozen
 }
 
 package() {
@@ -54,4 +59,3 @@ package() {
   install -Dm644 "LICENSE_MIT" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE_MIT"
   install -Dm644 "LICENSE_APACHE-2.0" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE_APACHE-2.0"
 }
-

--- a/mingw-w64-fd/PKGBUILD
+++ b/mingw-w64-fd/PKGBUILD
@@ -20,7 +20,11 @@ sha512sums=('e992db9170884c5c426d51ba06a0684b000c65df3fae392fe9ffb3555b94f1d0cfd
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  cargo fetch --locked
+  local _target="${CARCH}-pc-windows-gnu"
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
+    _target="${CARCH}-pc-windows-gnullvm"
+  fi
+  cargo fetch --locked --target "${_target}"
 }
 
 build() {
@@ -42,6 +46,5 @@ package() {
 
   make install DESTDIR="${pkgdir}" prefix="${MINGW_PREFIX}"
 
-  install -Dm644 LICENSE-APACHE "$pkgdir"$MINGW_PREFIX/share/licenses/fd/LICENSE-APACHE
-  install -Dm644 LICENSE-MIT "$pkgdir"$MINGW_PREFIX/share/licenses/fd/LICENSE-MIT
+  install -Dm644 LICENSE-{APACHE,MIT} -t "$pkgdir"$MINGW_PREFIX/share/licenses/fd/
 }

--- a/mingw-w64-hexyl/PKGBUILD
+++ b/mingw-w64-hexyl/PKGBUILD
@@ -20,14 +20,24 @@ source=(
 sha512sums=('770fe3db1fc10ba78cde00d727cf0494d0447e08e1e1f103bd206475c839d4d04c714b5257a3c42d2e489ce02e0b4b9b2701fb89ca9222830c87ccaa2fc8463c')
 b2sums=('1c2ccbb21c7aad1d2c1daca7ed99009ec2e2a02a96dd8a73d6ba11d00291f0e81afdd790d52219406ba4571408c68a5be714f5aeb36fc74c85d2868d4e0883d4')
 
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  local _target="${CARCH}-pc-windows-gnu"
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
+    _target="${CARCH}-pc-windows-gnullvm"
+  fi
+  cargo fetch --locked --target "${_target}"
+}
+
 build() {
   cd "${srcdir}/${_realname}-${pkgver}"
-  cargo build --release --locked
+  cargo build --release --frozen
 }
 
 check() {
   cd "${srcdir}/${_realname}-${pkgver}"
-  cargo test --release --locked
+  cargo test --release --frozen
 }
 
 package() {

--- a/mingw-w64-hyperfine/PKGBUILD
+++ b/mingw-w64-hyperfine/PKGBUILD
@@ -17,7 +17,11 @@ sha256sums=('fea7b92922117ed04b9c84bb9998026264346768804f66baa40743c5528bed6b')
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  cargo fetch --locked
+  local _target="${CARCH}-pc-windows-gnu"
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
+    _target="${CARCH}-pc-windows-gnullvm"
+  fi
+  cargo fetch --locked --target "${_target}"
 }
 
 build() {

--- a/mingw-w64-jj/PKGBUILD
+++ b/mingw-w64-jj/PKGBUILD
@@ -23,7 +23,11 @@ sha256sums=('f4e2be834cf9ea966ac58451298c8f1eed145c190fbca62b5b5a6bd145ac997e')
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
-  ${MINGW_PREFIX}/bin/cargo fetch --locked
+  local _target="${CARCH}-pc-windows-gnu"
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
+    _target="${CARCH}-pc-windows-gnullvm"
+  fi
+  ${MINGW_PREFIX}/bin/cargo fetch --locked --target "${_target}"
 }
 
 build() {
@@ -60,7 +64,7 @@ package_jj() {
     --path cli \
     --root "${pkgdir}${MINGW_PREFIX}" \
     --all-features
-  
+
   # used for internal testing
   rm ${pkgdir}${MINGW_PREFIX}/bin/fake*
 

--- a/mingw-w64-mdbook-pikchr/PKGBUILD
+++ b/mingw-w64-mdbook-pikchr/PKGBUILD
@@ -9,6 +9,9 @@ pkgdesc="A mdbook preprocessor to render pikchr code blocks as images in your bo
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://github.com/podsvirov/mdbook-pikchr"
+msys2_references=(
+  'aur: mdbook-pikchr'
+)
 license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-mdbook")
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
@@ -16,16 +19,17 @@ source=("${_realname}-${pkgver}.tar.gz::${url}/archive/v${pkgver}.tar.gz")
 sha256sums=('e3f1bcba19db94fa66ea12152e7082de0e1ad6171b1fd6638f2b65a9cfbb5b60')
 
 prepare() {
-  cd "${srcdir}"
-  rm -rf "build-${MSYSTEM}" | true
   cp -r "${_realname}-${pkgver}" "build-${MSYSTEM}"
   cd "${srcdir}/build-${MSYSTEM}"
 
   sed -e "s/https:\/\/raw.githubusercontent.com\/podsvirov\/mdbook-pikchr\/master\///" -i README.md
   sed -e "s/debug/release/" -i book.toml
 
-  "${MINGW_PREFIX}/bin/cargo.exe" fetch \
-    --locked
+  local _target="${CARCH}-pc-windows-gnu"
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
+    _target="${CARCH}-pc-windows-gnullvm"
+  fi
+  "${MINGW_PREFIX}/bin/cargo.exe" fetch --locked --target "${_target}"
 }
 
 build() {
@@ -34,7 +38,7 @@ build() {
 
   "${MINGW_PREFIX}/bin/cargo.exe" build \
     --release \
-    --locked
+    --frozen
 
   msg "Build documentation"
 
@@ -52,7 +56,7 @@ check() {
 
   "${MINGW_PREFIX}/bin/cargo.exe" test \
     --release \
-    --locked
+    --frozen
 }
 
 package() {

--- a/mingw-w64-mdbook/PKGBUILD
+++ b/mingw-w64-mdbook/PKGBUILD
@@ -10,6 +10,9 @@ pkgdesc="Create book from markdown files, like Gitbook but implemented in Rust (
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://github.com/rust-lang/mdBook"
+msys2_references=(
+  'archlinux: mdbook'
+)
 license=('spdx:MPL-2.0')
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
 optdepends=("${MINGW_PACKAGE_PREFIX}-mdbook-pikchr: To render pikchr code blocks as image")
@@ -19,7 +22,11 @@ sha256sums=('dd47214172ecf95e1b2cbcbebb8428d0b029e0de5dce74204b3c3a91f26223a1')
 prepare() {
   cd "${srcdir}/${_realName}-${pkgver}"
 
-  cargo fetch --locked
+  local _target="${CARCH}-pc-windows-gnu"
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
+    _target="${CARCH}-pc-windows-gnullvm"
+  fi
+  cargo fetch --locked --target "${_target}"
 }
 
 build() {
@@ -31,7 +38,7 @@ build() {
   WINAPI_NO_BUNDLED_LIBRARIES=1 \
   "${MINGW_PREFIX}/bin/cargo.exe" build \
     --release \
-    --locked
+    --frozen
 
   mkdir completions | true
   "./target/release/${_realname}.exe" completions bash > "completions/${_realname}.bash"
@@ -49,7 +56,7 @@ check() {
 
   "${MINGW_PREFIX}/bin/cargo.exe" test \
     --release \
-    --locked
+    --frozen
 }
 
 package() {
@@ -63,4 +70,3 @@ package() {
   cp -a "guide/book" "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}/html"
   install -Dm644 "LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }
-

--- a/mingw-w64-minidump-stackwalk/PKGBUILD
+++ b/mingw-w64-minidump-stackwalk/PKGBUILD
@@ -10,6 +10,9 @@ pkgdesc="Provides both machine-readable and human-readable digests of a minidump
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://github.com/rust-minidump/rust-minidump/tree/main/minidump-stackwalk'
+msys2_references=(
+  'aur: minidump-stackwalk'
+)
 license=('spdx:MIT')
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-rust"
@@ -21,8 +24,13 @@ prepare() {
   cp -r "${_projectname}-${pkgver}" "build-${MSYSTEM}"
   cd "build-${MSYSTEM}/minidump-stackwalk"
 
+  local _target="${CARCH}-pc-windows-gnu"
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
+    _target="${CARCH}-pc-windows-gnullvm"
+  fi
   cargo fetch \
     --locked \
+    --target "${_target}" \
     --manifest-path "../Cargo.toml"
 }
 

--- a/mingw-w64-onefetch/PKGBUILD
+++ b/mingw-w64-onefetch/PKGBUILD
@@ -20,14 +20,19 @@ sha256sums=('e6aa7504730de86f307d6c3671875b11a447a4088daf74df280c8f644dea4819')
 prepare() {
   cd "$_realname-$pkgver"
 
-  cargo fetch --locked
+  local _target="${CARCH}-pc-windows-gnu"
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
+    _target="${CARCH}-pc-windows-gnullvm"
+  fi
+  cargo fetch --locked --target "${_target}"
+
   mkdir -p completions
 }
 
 build() {
   cd "$_realname-$pkgver"
   WINAPI_NO_BUNDLED_LIBRARIES=1 \
-  cargo build --release --all-features
+  cargo build --release --all-features --frozen
   local _completion="target/release/onefetch --generate"
   $_completion bash > "completions/onefetch"
   $_completion fish > "completions/onefetch.fish"

--- a/mingw-w64-ripgrep/PKGBUILD
+++ b/mingw-w64-ripgrep/PKGBUILD
@@ -21,23 +21,26 @@ sha256sums=('33c6169596a6bbfdc81415910008f26e0809422fda2d849562637996553b2ab6')
 noextract=("${_realname}-${pkgver}.tar.gz")
 
 prepare() {
-  cd "${srcdir}"
   tar -xzf "${_realname}-${pkgver}.tar.gz" || true
-
   cd "${srcdir}/${_realname}-${pkgver}"
-  cargo fetch --locked
+
+  local _target="${CARCH}-pc-windows-gnu"
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
+    _target="${CARCH}-pc-windows-gnullvm"
+  fi
+  cargo fetch --locked --target "${_target}"
 }
 
 build() {
   cd "${_realname}-${pkgver}"
 
-  cargo build --locked --features 'pcre2' --profile release-lto
+  cargo build --frozen --features 'pcre2' --profile release-lto
 }
 
 check() {
   cd "${_realname}-${pkgver}"
 
-  cargo test --locked --features 'pcre2' --profile release-lto
+  cargo test --frozen --features 'pcre2' --profile release-lto
 }
 
 package() {

--- a/mingw-w64-sccache/PKGBUILD
+++ b/mingw-w64-sccache/PKGBUILD
@@ -20,38 +20,39 @@ sha256sums=('19034b64ff223f852256869b3e3fa901059ee90de2e4085bf2bfb5690b430325')
 
 prepare() {
   cp -r ${_realname}-${pkgver} build-${MSYSTEM}
-  ${MINGW_PREFIX}/bin/cargo fetch \
+
+  cargo fetch \
     --locked \
-	--manifest-path build-${MSYSTEM}/Cargo.toml
+    --manifest-path build-${MSYSTEM}/Cargo.toml
 }
 
 build() {
   WINAPI_NO_BUNDLED_LIBRARIES=1 \
   ${MINGW_PREFIX}/bin/cargo build \
-	--release \
-	--frozen \
-	--manifest-path build-${MSYSTEM}/Cargo.toml \
-	--features native-zlib
+    --release \
+    --frozen \
+    --manifest-path build-${MSYSTEM}/Cargo.toml \
+    --features native-zlib
 }
 
 check() {
   WINAPI_NO_BUNDLED_LIBRARIES=1 \
   ${MINGW_PREFIX}/bin/cargo test \
-	--release \
-	--frozen \
-	--manifest-path build-${MSYSTEM}/Cargo.toml \
-	--features native-zlib
+    --release \
+    --frozen \
+    --manifest-path build-${MSYSTEM}/Cargo.toml \
+    --features native-zlib
 }
 
 package() {
   WINAPI_NO_BUNDLED_LIBRARIES=1 \
   ${MINGW_PREFIX}/bin/cargo install \
-	--frozen \
-	--offline \
-	--no-track \
-	--path build-${MSYSTEM} \
-	--root ${pkgdir}${MINGW_PREFIX} \
-	--features native-zlib
+    --frozen \
+    --offline \
+    --no-track \
+    --path build-${MSYSTEM} \
+    --root ${pkgdir}${MINGW_PREFIX} \
+    --features native-zlib
 
   install -Dm644 ${_realname}-${pkgver}/LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-starship/PKGBUILD
+++ b/mingw-w64-starship/PKGBUILD
@@ -9,6 +9,10 @@ pkgdesc="The cross-shell prompt for astronauts (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://starship.rs"
+msys2_repository_url="https://github.com/starship/starship"
+msys2_references=(
+  'archlinux: starship'
+)
 license=('spdx:ISC')
 depends=("${MINGW_PACKAGE_PREFIX}-libgit2")
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
@@ -32,7 +36,11 @@ prepare() {
   # https://github.com/starship/starship/pull/5694
   patch -Np1 -i "${srcdir}/5694.patch"
 
-  cargo fetch --locked
+  local _target="${CARCH}-pc-windows-gnu"
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
+    _target="${CARCH}-pc-windows-gnullvm"
+  fi
+  cargo fetch --locked --target "${_target}"
 }
 
 build() {

--- a/mingw-w64-stork/PKGBUILD
+++ b/mingw-w64-stork/PKGBUILD
@@ -9,6 +9,9 @@ pkgdesc="Impossibly fast web search, made for static sites (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://github.com/jameslittle230/stork"
+msys2_references=(
+  'aur: stork'
+)
 license=('spdx:Apache-2.0')
 depends=(
   "${MINGW_PACKAGE_PREFIX}-gcc-libs"
@@ -21,13 +24,14 @@ source=("$url/archive/v$pkgver/$_realname-$pkgver.tar.gz")
 sha256sums=('cf7f5ed75815bf7e302fd76ec55ac89db2d06a682c5a07b1431d18105b3ada62')
 
 prepare() {
-  cd "${srcdir}"
-  rm -rf "build-${MSYSTEM}" | true
   cp -r "${_realname}-${pkgver}" "build-${MSYSTEM}"
   cd "${srcdir}/build-${MSYSTEM}"
 
-  ${MINGW_PREFIX}/bin/cargo fetch \
-    --locked
+  local _target="${CARCH}-pc-windows-gnu"
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
+    _target="${CARCH}-pc-windows-gnullvm"
+  fi
+  ${MINGW_PREFIX}/bin/cargo fetch --locked --target "${_target}"
 }
 
 build() {
@@ -35,7 +39,7 @@ build() {
 
   ${MINGW_PREFIX}/bin/cargo build \
     --release \
-    --locked
+    --frozen
 }
 
 check() {
@@ -43,7 +47,7 @@ check() {
 
   ${MINGW_PREFIX}/bin/cargo test \
     --release \
-    --locked
+    --frozen
 }
 
 package() {
@@ -53,4 +57,3 @@ package() {
 
   install -Dm644 license.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }
-

--- a/mingw-w64-tree-sitter/PKGBUILD
+++ b/mingw-w64-tree-sitter/PKGBUILD
@@ -10,32 +10,36 @@ arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://tree-sitter.github.io/"
 msys2_repository_url="https://github.com/tree-sitter/tree-sitter"
+msys2_references=(
+  'archlinux: tree-sitter'
+)
 license=('spdx:MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-rust"
-             "unzip")
-source=("https://github.com/tree-sitter/tree-sitter/archive/v${pkgver}/${_realname}-${pkgver}.zip"
+             "${MINGW_PACKAGE_PREFIX}-rust")
+source=("https://github.com/tree-sitter/tree-sitter/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
         001-mingw-build.patch)
-sha256sums=('5f04d75f2b2b9424131e4b769c1e64f7a82bfcf930c79a87c118d251d44ef6e2'
+sha256sums=('6181ede0b7470bfca37e293e7d5dc1d16469b9485d13f13a605baec4a8b1f791'
             '19d2a1608ca5c6138c228b97815c48ac95be2bec1265c207fdc0950a65b8ebad')
-noextract=("${_realname}-${pkgver}.zip")
+noextract=("${_realname}-${pkgver}.tar.gz")
 
 prepare() {
-  [[ -d ${_realname}-${pkgver} ]] && rm -rf ${_realname}-${pkgver}
-  unzip -q "${_realname}-${pkgver}.zip"
+  tar -xzf "${_realname}-${pkgver}.tar.gz" || true
   cd "${srcdir}/${_realname}-${pkgver}"
   patch -p1 -i ${srcdir}/001-mingw-build.patch
 
-  cargo fetch --locked
+  local _target="${CARCH}-pc-windows-gnu"
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
+    _target="${CARCH}-pc-windows-gnullvm"
+  fi
+  cargo fetch --locked --target "${_target}"
 }
 
 build() {
   cd "${srcdir}/${_realname}-${pkgver}"
-  make clean
   make
 
   cd "${srcdir}/${_realname}-${pkgver}"
-  cargo build --locked --offline --release
+  cargo build --frozen --release
 }
 
 check() {

--- a/mingw-w64-typst/PKGBUILD
+++ b/mingw-w64-typst/PKGBUILD
@@ -9,6 +9,10 @@ pkgdesc='A markup-based typesetting system for the sciences (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://typst.app/'
+msys2_repository_url='https://github.com/typst/typst/'
+msys2_references=(
+  'archlinux: typst'
+)
 license=('spdx:Apache-2.0')
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
 source=("https://github.com/typst/typst/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
@@ -17,7 +21,11 @@ sha256sums=('f1b7baba3c6f6f37dee6d05c9ab53d2ba5cd879a57b6e726dedf9bc51811e132')
 prepare() {
   cd ${_realname}-${pkgver}
 
-  ${MINGW_PREFIX}/bin/cargo fetch --locked
+  local _target="${CARCH}-pc-windows-gnu"
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
+    _target="${CARCH}-pc-windows-gnullvm"
+  fi
+  ${MINGW_PREFIX}/bin/cargo fetch --locked --target "${_target}"
 }
 
 build() {

--- a/mingw-w64-uutils-coreutils/PKGBUILD
+++ b/mingw-w64-uutils-coreutils/PKGBUILD
@@ -9,21 +9,33 @@ pkgdesc="Cross-platform Rust rewrite of the GNU coreutils (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64')
 url='https://github.com/uutils/coreutils'
+msys2_references=(
+  'archlinux: uutils-coreutils'
+)
 license=('spdx:MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
 source=("https://github.com/uutils/coreutils/archive/${pkgver}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('cb10a4790e80900345db9a4a929d36ab0d6bb0a81cd3427730300cbae5be9178')
 
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  local _target="${CARCH}-pc-windows-gnu"
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
+    _target="${CARCH}-pc-windows-gnullvm"
+  fi
+  cargo fetch --locked --target "${_target}"
+}
+
 build() {
-  [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}
-  cp -r "${srcdir}/${_realname}-${pkgver}" "${srcdir}/build${MSYSTEM}"
-  cd "${srcdir}/build${MSYSTEM}"
+  cp -r "${srcdir}/${_realname}-${pkgver}" "${srcdir}/build-${MSYSTEM}"
+  cd "${srcdir}/build-${MSYSTEM}"
 
   make PROFILE=release
 }
 
 package() {
-  cd "${srcdir}/build${MSYSTEM}"
+  cd "${srcdir}/build-${MSYSTEM}"
 
   make install DESTDIR="$pkgdir" PREFIX=${MINGW_PREFIX}
 

--- a/mingw-w64-vivid/PKGBUILD
+++ b/mingw-w64-vivid/PKGBUILD
@@ -9,6 +9,9 @@ pkgdesc='A themeable LS_COLORS generator with a rich filetype datebase (mingw-w6
 arch=(any)
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://github.com/sharkdp/vivid'
+msys2_references=(
+  'archlinux: vivid'
+)
 license=('spdx:MIT OR Apache-2.0')
 makedepends=($MINGW_PACKAGE_PREFIX-rust)
 source=("$url/archive/v$pkgver/${_realname}-${pkgver}.tar.gz")
@@ -17,12 +20,17 @@ b2sums=('6bae858a27d704ff73ded2560ae74f6821c97517c8e8e3f9058619cfdf11bd3bd626074
 
 prepare() {
   cd vivid-$pkgver
-  cargo fetch --locked
+
+  local _target="${CARCH}-pc-windows-gnu"
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
+    _target="${CARCH}-pc-windows-gnullvm"
+  fi
+  cargo fetch --locked --target "${_target}"
 }
 
 build() {
   cd vivid-$pkgver
-  cargo build --release --locked --offline
+  cargo build --release --frozen
 }
 
 package() {

--- a/mingw-w64-wasm-pack/PKGBUILD
+++ b/mingw-w64-wasm-pack/PKGBUILD
@@ -9,6 +9,9 @@ pkgdesc="Your favorite rust -> wasm workflow tool! (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
 url="https://github.com/rustwasm/wasm-pack"
+msys2_references=(
+  'archlinux: wasm-pack'
+)
 license=('spdx:MIT OR Apache-2.0')
 depends=(
   "${MINGW_PACKAGE_PREFIX}-bzip2"
@@ -23,24 +26,23 @@ source=("$url/archive/v$pkgver/$_realname-$pkgver.tar.gz")
 sha256sums=('afa164fec0b119e2c47e38aad9e83351cb414e8ca3c062de292ec8008a45ac09')
 
 prepare() {
-  cd "${srcdir}"
-  rm -rf "build-${MSYSTEM}" | true
   cp -r "${_realname}-${pkgver}" "build-${MSYSTEM}"
   cd "${srcdir}/build-${MSYSTEM}"
 
-  ${MINGW_PREFIX}/bin/cargo fetch \
-    --locked
+  local _target="${CARCH}-pc-windows-gnu"
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
+    _target="${CARCH}-pc-windows-gnullvm"
+  fi
+  ${MINGW_PREFIX}/bin/cargo fetch --locked --target "${_target}"
 }
 
 build() {
-  msg "Cargo build for ${MSYSTEM}"
   cd "${srcdir}/build-${MSYSTEM}"
 
   ${MINGW_PREFIX}/bin/cargo build \
     --release \
-    --locked
+    --frozen
 
-  msg "Build documentation"
   cd "${srcdir}/build-${MSYSTEM}/docs"
   ${MINGW_PREFIX}/bin/mdbook build
 }
@@ -50,7 +52,7 @@ check() {
 
   ${MINGW_PREFIX}/bin/cargo test \
     --release \
-    --locked
+    --frozen
 }
 
 package() {
@@ -64,4 +66,3 @@ package() {
   install -d "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/"
   cp -t "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/" LICENSE-{APACHE,MIT}
 }
-

--- a/mingw-w64-watchexec/PKGBUILD
+++ b/mingw-w64-watchexec/PKGBUILD
@@ -19,7 +19,11 @@ sha256sums=('9609163c14cd49ec651562838f38b88ed2d370e354af312ddc78c2be76c08d37')
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  cargo fetch --locked
+  local _target="${CARCH}-pc-windows-gnu"
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
+    _target="${CARCH}-pc-windows-gnullvm"
+  fi
+  cargo fetch --locked --target "${_target}"
 }
 
 build() {


### PR DESCRIPTION
retry of #18231

what's changed:
- for packages that don't makedepend on `cargo-c`, `maturin`, `python` I specified target for fetching deps
- changed `--locked` to `--frozen` to ensure that there are no extra https requests (which means that extra deps are needed)
- small cleanup for some recipes (that includes trailing whitespaces and extra newlines, which my vscode trim automaticly)

there is no need to rebuild these packages as this doesn't affect `build()` stage, only `prepare()`

I'm open for any feedback as this could be a breaking change :)

update: removed this for `sccache`: it tries to download a unix-specific dependency at build
update2: I changed indent from tab to spaces for sccache, so it should looks now normally