### PR TITLE
bat: redesign recipe

### DIFF
--- a/mingw-w64-bat/PKGBUILD
+++ b/mingw-w64-bat/PKGBUILD
@@ -4,7 +4,7 @@ _realname=bat
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.24.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Cat clone with syntax highlighting and git integration (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -16,52 +16,49 @@ license=('spdx:MIT OR Apache-2.0')
 depends=(
   "${MINGW_PACKAGE_PREFIX}-libgit2"
   "${MINGW_PACKAGE_PREFIX}-oniguruma"
-  "${MINGW_PACKAGE_PREFIX}-gcc-libs"
+  "${MINGW_PACKAGE_PREFIX}-zlib"
 )
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-rust"
+  "${MINGW_PACKAGE_PREFIX}-pkgconf"
+  'git'
 )
+options=('!strip' '!lto')
 source=("https://github.com/sharkdp/bat/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('907554a9eff239f256ee8fe05a922aad84febe4fe10a499def72a4557e9eedfb')
 
 prepare() {
-  cp -r ${_realname}-${pkgver} build-${MSYSTEM}
+  cd "${srcdir}/${_realname}-${pkgver}"
 
   # update windows-targets to fix windows-gnullvm dependency specification
-  cargo update -p windows-targets@0.48.0 --precise 0.48.1 \
-    --manifest-path build-${MSYSTEM}/Cargo.toml
+  cargo update -p windows-targets@0.48.0 --precise 0.48.1
 
   local _target="${CARCH}-pc-windows-gnu"
   if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
     _target="${CARCH}-pc-windows-gnullvm"
   fi
-
-  cargo fetch \
-    --locked \
-    --manifest-path build-${MSYSTEM}/Cargo.toml \
-    --target "${_target}"
+  cargo fetch --locked --target "${_target}"
 }
 
 build() {
-  ${MINGW_PREFIX}/bin/cargo build \
-  --release \
-  --frozen \
-  --manifest-path build-${MSYSTEM}/Cargo.toml
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  GIT_DIR=/dev/null \
+  RUSTONIG_DYNAMIC_LIBONIG=1 \
+  LIBGIT2_NO_VENDOR=1 \
+  LIBZ_SYS_STATIC=0 \
+    cargo build --release --frozen
 }
 
 package() {
-  ${MINGW_PREFIX}/bin/cargo install \
-  --frozen \
-  --offline \
-  --no-track \
-  --path build-${MSYSTEM} \
-  --root ${pkgdir}${MINGW_PREFIX}
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  install -Dm755 target/release/bat "${pkgdir}${MINGW_PREFIX}/bin/bat"
 
   # Package licenses
-  install -Dm644 build-${MSYSTEM}/LICENSE-{APACHE,MIT} -t \
-    "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname}
+  install -Dm644 LICENSE-{APACHE,MIT} -t "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
 
-  cd build-${MSYSTEM}/target/release/build
+  cd target/release/build
 
   # Package the man page
   find . -name bat.1 -type f -exec install -Dm644 {} \


### PR DESCRIPTION
- make it to match template
- add changes for dynamic linking
- set `GIT_DIR=/dev/null` to resolve

<details>

```
Failed to add dependency on the git state: failed to canonicalize ~/MINGW-packages/.git\logs/HEAD: Системе не удается найти указанный путь. (os error 3). Git state changes might not trigger a rebuild.
Failed to add dependency on the git state: failed to canonicalize ~/MINGW-packages/.git\index: Системе не удается найти указанный путь. (os error 3). Git state changes might not trigger a rebuild.
Failed to add dependency on the git state: failed to canonicalize ~/MINGW-packages/.git\logs/HEAD: Системе не удается найти указанный путь. (os error 3). Git state changes might not trigger a rebuild.
Failed to add dependency on the git state: failed to canonicalize ~/MINGW-packages/.git\index: Системе не удается найти указанный путь. (os error 3). Git state changes might not trigger a rebuild.
```

</details>

- removed cargo install as it's always recompiled (I didn't find a solution for it)