### PR TITLE
libdovi: Remove full path reference in pkgconfig file

### DIFF
--- a/mingw-w64-libdovi/PKGBUILD
+++ b/mingw-w64-libdovi/PKGBUILD
@@ -5,7 +5,7 @@ _sourcename=dovi_tool-${_realname}
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=3.2.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Library to read and write Dolby Vision metadata (C-API)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -54,6 +54,9 @@ package() {
         --all-features \
         --prefix="${MINGW_PREFIX}" \
         --destdir="${pkgdir}"
+
+  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+  sed -s "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/dovi.pc
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
Fixes #19822