### PR TITLE
sccache: update to 0.7.6

### DIFF
--- a/mingw-w64-sccache/PKGBUILD
+++ b/mingw-w64-sccache/PKGBUILD
@@ -3,11 +3,11 @@
 _realname=sccache
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.7.5
+pkgver=0.7.6
 pkgrel=1
 pkgdesc='Shared compilation cache (mingw-w64)'
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://github.com/mozilla/sccache"
 msys2_references=(
   'archlinux: sccache'
@@ -16,7 +16,7 @@ license=('spdx:Apache-2.0')
 depends=("${MINGW_PACKAGE_PREFIX}-openssl" "${MINGW_PACKAGE_PREFIX}-zlib")
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
 source=("https://github.com/mozilla/sccache/archive/v$pkgver/${_realname}-${pkgver}.tar.gz")
-sha256sums=('19034b64ff223f852256869b3e3fa901059ee90de2e4085bf2bfb5690b430325')
+sha256sums=('c6ff8750516fe982c9e9c20fb80d27c41481a22bf9a5a2346cff05724110bd42')
 
 prepare() {
   cp -r ${_realname}-${pkgver} build-${MSYSTEM}


### PR DESCRIPTION
upstream finally updated ring dependency! enabling clangarm64