### PR TITLE
llama.cpp: Update to r1967.256d1bb0

### DIFF
--- a/mingw-w64-llama.cpp/PKGBUILD
+++ b/mingw-w64-llama.cpp/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=llama.cpp
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=r1691.7082d24c
+pkgver=r1967.256d1bb0
 pkgrel=1
 pkgdesc="Port of Facebook's LLaMA model in C/C++ (mingw-w64)"
 arch=('any')
@@ -18,7 +18,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cc"
   'git'
 )
-_commit='7082d24cec35e9ce9147535a2224dfc67ee0a78c'
+_commit='256d1bb0ddce6a0a21f5a7503019bdd5c1933cba'
 source=("${_realname}"::"git+https://github.com/ggerganov/llama.cpp.git#commit=${_commit}")
 sha256sums=('SKIP')
 
@@ -50,6 +50,9 @@ build() {
       -DBUILD_SHARED_LIBS=ON \
       -DLLAMA_BLAS=ON \
       -DLLAMA_BLAS_VENDOR=OpenBLAS \
+      -DLLAMA_WIN_VER="0x603" \
+      -DLLAMA_NATIVE=OFF \
+      -DLLAMA_CCACHE=OFF \
       ../${_realname}
 
   "${MINGW_PREFIX}"/bin/cmake.exe --build .


### PR DESCRIPTION
* bump LLAMA_WIN_VER to fix the build (it uses newer APIs that reuqire it)
* disable LLAMA_NATIVE so our CFLAGS are used
* disable ccache since that breaks the build somehow (ccache errors out)