### PR TITLE
emacs: Enable ahead of time native compilation

### DIFF
--- a/mingw-w64-emacs/PKGBUILD
+++ b/mingw-w64-emacs/PKGBUILD
@@ -8,7 +8,7 @@ _realname=emacs
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=29.2
-pkgrel=1
+pkgrel=2
 pkgdesc="The extensible, customizable, self-documenting, real-time display editor (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -66,7 +66,7 @@ build() {
 
   _extra_cfg=""
   if [[ "$_enable_jit" == "yes" ]] ; then
-      _extra_cfg="$_extra_cfg --with-native-compilation"
+      _extra_cfg="$_extra_cfg --with-native-compilation=aot"
   fi
 
   # Required for nanosleep with clang


### PR DESCRIPTION
There was some talk on enabling it in https://github.com/msys2/MINGW-packages/pull/19810 with the concern that compilation might take too long. Turns out, it doesn't, the CI finished in a bit more than 30 minutes, compared to around 15 minutes without AOT. That's quite reasonable (Github [recently bumping their hosted runners to 4 CPU cores](https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/) certainly helps), thus I think AOT should be enabled to save a lot of compilation for users.

