### PR TITLE
gettext: split into gettext-runtime and gettext-tools

### DIFF
--- a/mingw-w64-gettext/PKGBUILD
+++ b/mingw-w64-gettext/PKGBUILD
@@ -3,19 +3,17 @@
 
 _realname=gettext
 pkgbase=mingw-w64-${_realname}
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-runtime" "${MINGW_PACKAGE_PREFIX}-${_realname}-tools")
 pkgver=0.22.4
-pkgrel=3
+pkgrel=4
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://www.gnu.org/software/gettext/"
 pkgdesc="GNU internationalization library (mingw-w64)"
 # GPL3 for the package as a whole and LGPL for some parts, see the license files
 license=('spdx:GPL-3.0-or-later AND LGPL-2.1-or-later')
-depends=("${MINGW_PACKAGE_PREFIX}-expat"
-         "${MINGW_PACKAGE_PREFIX}-gcc-libs"
-         "${MINGW_PACKAGE_PREFIX}-libiconv"
-        )
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-libiconv")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-ncurses"
@@ -136,28 +134,67 @@ EOF
   ./test-I64d.exe || return 1
 }
 
-package() {
-  cd ${srcdir}/build-${MSYSTEM}-static
+package_gettext-runtime() {
+  pkgdesc="GNU internationalization runtime library (mingw-w64)"
+  depends=(
+    "${MINGW_PACKAGE_PREFIX}-gcc-libs"
+    "${MINGW_PACKAGE_PREFIX}-libiconv"
+  )
+  conflicts=("${MINGW_PACKAGE_PREFIX}-gettext<=0.22.4-3")
+
+  cd ${srcdir}/build-${MSYSTEM}-static/gettext-runtime
   make DESTDIR="${pkgdir}" install
 
-  cd ${srcdir}/build-${MSYSTEM}-shared
+  cd ${srcdir}/build-${MSYSTEM}-shared/gettext-runtime
   make DESTDIR="${pkgdir}" install
 
   # Licenses
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/gettext-runtime/COPYING" \
+    "${pkgdir}${MINGW_PREFIX}/share/licenses/gettext-runtime/COPYING"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/gettext-runtime/intl/COPYING.LIB" \
+    "${pkgdir}${MINGW_PREFIX}/share/licenses/gettext-runtime/intl/COPYING.LIB"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/gettext-runtime/libasprintf/COPYING" \
+    "${pkgdir}${MINGW_PREFIX}/share/licenses/gettext-runtime/libasprintf/COPYING"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/gettext-runtime/libasprintf/COPYING.LIB" \
+    "${pkgdir}${MINGW_PREFIX}/share/licenses/gettext-runtime/libasprintf/COPYING.LIB"
+}
+
+package_gettext-tools() {
+  pkgdesc="GNU internationalization tools (mingw-w64)"
+  depends=(
+    "${MINGW_PACKAGE_PREFIX}-gettext-runtime"
+    "${MINGW_PACKAGE_PREFIX}-gcc-libs"
+    "${MINGW_PACKAGE_PREFIX}-libiconv"
+  )
+  provides=("${MINGW_PACKAGE_PREFIX}-gettext=${pkgver}-${pkgrel}")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-gettext<=0.22.4-3")
+
+  cd ${srcdir}/build-${MSYSTEM}-static/gettext-tools
+  make DESTDIR="${pkgdir}" install
+
+  cd ${srcdir}/build-${MSYSTEM}-shared/gettext-tools
+  make DESTDIR="${pkgdir}" install
+
+  # Licenses
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/gettext-tools/COPYING" \
+    "${pkgdir}${MINGW_PREFIX}/share/licenses/gettext-tools/COPYING"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/gettext-tools/gnulib-lib/libxml/COPYING" \
+    "${pkgdir}${MINGW_PREFIX}/share/licenses/gettext-tools/gnulib-lib/libxml/COPYING"
+
+  # Not sure where to put them, so put them in the gettext-tools package
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" \
     "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
-  install -Dm644 "${srcdir}/${_realname}-${pkgver}/gettext-runtime/COPYING" \
-    "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/gettext-runtime/COPYING"
-  install -Dm644 "${srcdir}/${_realname}-${pkgver}/gettext-runtime/intl/COPYING.LIB" \
-    "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/gettext-runtime/intl/COPYING.LIB"
-  install -Dm644 "${srcdir}/${_realname}-${pkgver}/gettext-runtime/libasprintf/COPYING" \
-    "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/gettext-runtime/libasprintf/COPYING"
-  install -Dm644 "${srcdir}/${_realname}-${pkgver}/gettext-runtime/libasprintf/COPYING.LIB" \
-    "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/gettext-runtime/libasprintf/COPYING.LIB"
-  install -Dm644 "${srcdir}/${_realname}-${pkgver}/gettext-tools/COPYING" \
-    "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/gettext-tools/COPYING"
-  install -Dm644 "${srcdir}/${_realname}-${pkgver}/gettext-tools/gnulib-lib/libxml/COPYING" \
-    "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/gettext-tools/gnulib-lib/libxml/COPYING"
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/gnulib-local/lib/libxml/COPYING" \
     "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/gnulib-local/lib/libxml/COPYING"
 }
+
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
+
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;


### PR DESCRIPTION
90% is tools which is not needed at runtime, and since it's easy to split this way just split the two sub projects into two packages.

Other packages can switch to add gettext-tools to makedepends and just gettext-runtime to depends.

Also removes expat dependency, turns out it doesn't need it since 0.19.7