### PR TITLE
texlive: use debian patch for a more sensible zlib check

### DIFF
--- a/mingw-w64-texlive-bin/0005-untighten_version_check_zlib.patch
+++ b/mingw-w64-texlive-bin/0005-untighten_version_check_zlib.patch
@@ -1,0 +1,16 @@
+Description: Untighten version check of runtime linked zlib. Fix for #1056183.
+Forwarded: not-done, could be done
+Author: Hilmar Preuße <hille42@web.de>
+Last-Update: 20231119
+
+--- texlive-bin.orig/texk/web2c/luatexdir/luazlib/lzlib.c
++++ texlive-bin/texk/web2c/luatexdir/luazlib/lzlib.c
+@@ -546,7 +546,7 @@
+ 
+     /* make sure header and library version are consistent */
+     const char* version = zlibVersion();
+-    if (strncmp(version, ZLIB_VERSION, 4))
++    if (strncmp(version, ZLIB_VERSION, 2))
+     {
+         lua_pushfstring(L, "zlib library version does not match - header: %s, library: %s", ZLIB_VERSION, version);
+         lua_error(L);

--- a/mingw-w64-texlive-bin/PKGBUILD
+++ b/mingw-w64-texlive-bin/PKGBUILD
@@ -4,7 +4,7 @@ pkgbase=mingw-w64-texlive-bin
 pkgname=("${MINGW_PACKAGE_PREFIX}-texlive-bin" "${MINGW_PACKAGE_PREFIX}-libsynctex")
 pkgver=2023.20230523
 pkgdesc="TeX Live binaries (mingw-w64)"
-pkgrel=6
+pkgrel=7
 license=('GPL')
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -49,12 +49,14 @@ source=(
     "0001-Remove-DLUASOCKET_INET_PTON-from-Makefile.patch"
     "0002-fix-lauchers-mingw32.patch"
     "0003-runscript-always-quote-args.patch"
-    "0004-add-missing-includes-dvisvgm.patch")
+    "0004-add-missing-includes-dvisvgm.patch"
+    "0005-untighten_version_check_zlib.patch")
 sha256sums=('d3eca31c6a16a168f66471ce3837b7c950826967162eab04d58233f52462527e'
             '86ef2a99b2f0caed42777419837d9b539af1d1c8a101701e539e5467bb88662e'
             'decff8db61302c2a1760cfd4b42aaf0e25fcb7d2b9621cea3ec3f4c2557976a1'
             'c22ad079777082ebb7fe90e64d3f0d20b75756e50af776f2d4c1b9f9e692dba3'
-            '46d9572ae1e178377f9ab4c11696cb1fbff0999b9719c6e17b5dbbe790b267a3')
+            '46d9572ae1e178377f9ab4c11696cb1fbff0999b9719c6e17b5dbbe790b267a3'
+            'f805930ee0396aea3c6d189c078ad57d4c5c9212f6f3cb7f25e0c74b8151e0b1')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -70,6 +72,10 @@ prepare() {
     apply_patch_with_msg 0001-Remove-DLUASOCKET_INET_PTON-from-Makefile.patch
     apply_patch_with_msg 0003-runscript-always-quote-args.patch
     apply_patch_with_msg 0004-add-missing-includes-dvisvgm.patch
+
+    # https://github.com/msys2/MINGW-packages/issues/18251
+    # https://github.com/debian-tex/texlive-bin/blob/6dae83df50df3edc/debian/patches/untighten_version_check_zlib.diff
+    apply_patch_with_msg 0005-untighten_version_check_zlib.patch
 
     # from https://github.com/archlinux/svntogit-packages/blob/packages/texlive-bin/trunk/PKGBUILD#L21
     # bibtex-x needs kpathsea flags


### PR DESCRIPTION
See https://github.com/msys2/MINGW-packages/issues/18251#issuecomment-1923348362