### PR TITLE
gcc: refactor installation and add gcc-lto-dump package

### DIFF
--- a/mingw-w64-gcc/2f7e7bfa3c6327793cdcdcb5c770b93cecd49bd0.patch
+++ b/mingw-w64-gcc/2f7e7bfa3c6327793cdcdcb5c770b93cecd49bd0.patch
@@ -1,0 +1,89 @@
+From 2f7e7bfa3c6327793cdcdcb5c770b93cecd49bd0 Mon Sep 17 00:00:00 2001
+From: Mark Harmstone <mark@harmstone.com>
+Date: Tue, 18 Apr 2023 13:55:35 -0600
+Subject: [PATCH] Add -gcodeview option
+
+gcc/
+	* common.opt (gcodeview): Add new option.
+	* gcc.cc (driver_handle_option); Handle OPT_gcodeview.
+	* opts.cc (command_handle_option): Similarly.
+	* doc/invoke.texi: Add documentation for -gcodeview.
+---
+ gcc/common.opt      | 4 ++++
+ gcc/doc/invoke.texi | 7 +++++++
+ gcc/gcc.cc          | 4 ++++
+ gcc/opts.cc         | 3 +++
+ 4 files changed, 18 insertions(+)
+
+diff --git a/gcc/common.opt b/gcc/common.opt
+index 862c474d3c8f..a28ca13385a2 100644
+--- a/gcc/common.opt
++++ b/gcc/common.opt
+@@ -3318,6 +3318,10 @@ gas-locview-support
+ Common Driver Var(dwarf2out_as_locview_support)
+ Assume assembler support for view in (DWARF2+) .loc directives.
+ 
++gcodeview
++Common Driver JoinedOrMissing
++Generate debug information in CodeView format.
++
+ gcoff
+ Common Driver WarnRemoved
+ Does nothing.  Preserved for backward compatibility.
+diff --git a/gcc/doc/invoke.texi b/gcc/doc/invoke.texi
+index a38547f53e53..aae6bc729dbd 100644
+--- a/gcc/doc/invoke.texi
++++ b/gcc/doc/invoke.texi
+@@ -509,6 +509,7 @@ Objective-C and Objective-C++ Dialects}.
+ -gstrict-dwarf  -gno-strict-dwarf
+ -gas-loc-support  -gno-as-loc-support
+ -gas-locview-support  -gno-as-locview-support
++-gcodeview @gol
+ -gcolumn-info  -gno-column-info  -gdwarf32  -gdwarf64
+ -gstatement-frontiers  -gno-statement-frontiers
+ -gvariable-location-views  -gno-variable-location-views
+@@ -11328,6 +11329,12 @@ at file-scope or global-scope only.
+ Produce debugging information in Alpha/VMS debug format (if that is
+ supported).  This is the format used by DEBUG on Alpha/VMS systems.
+ 
++@item -gcodeview
++@opindex gcodeview
++Produce debugging information in CodeView debug format (if that is
++supported).  This is the format used by Microsoft Visual C++ on
++Windows.
++
+ @item -g@var{level}
+ @itemx -ggdb@var{level}
+ @itemx -gvms@var{level}
+diff --git a/gcc/gcc.cc b/gcc/gcc.cc
+index 16bb07f2cdc5..39a44fa486da 100644
+--- a/gcc/gcc.cc
++++ b/gcc/gcc.cc
+@@ -4572,6 +4572,10 @@ driver_handle_option (struct gcc_options *opts,
+       do_save = false;
+       break;
+ 
++    case OPT_gcodeview:
++      add_infile ("--pdb=", "*");
++      break;
++
+     default:
+       /* Various driver options need no special processing at this
+ 	 point, having been handled in a prescan above or being
+diff --git a/gcc/opts.cc b/gcc/opts.cc
+index fb2e5388ab19..86b94d62b588 100644
+--- a/gcc/opts.cc
++++ b/gcc/opts.cc
+@@ -3134,6 +3134,9 @@ common_handle_option (struct gcc_options *opts,
+                        loc);
+       break;
+ 
++    case OPT_gcodeview:
++      break;
++
+     case OPT_gbtf:
+       set_debug_level (BTF_DEBUG, false, arg, opts, opts_set, loc);
+       /* set the debug level to level 2, but if already at level 3,
+-- 
+2.39.3
+

--- a/mingw-w64-gcc/3eeb4801d6f45f6250fc77a6d3ab4e0115f8cfdd.patch
+++ b/mingw-w64-gcc/3eeb4801d6f45f6250fc77a6d3ab4e0115f8cfdd.patch
@@ -1,0 +1,30 @@
+From 3eeb4801d6f45f6250fc77a6d3ab4e0115f8cfdd Mon Sep 17 00:00:00 2001
+From: Jason Merrill <jason@redhat.com>
+Date: Tue, 18 Apr 2023 16:28:24 -0400
+Subject: [PATCH] doc: remove stray @gol
+
+@gol was removed in r13-6778, new doc additions can't use it.
+
+gcc/ChangeLog:
+
+	* doc/invoke.texi: Remove stray @gol.
+---
+ gcc/doc/invoke.texi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gcc/doc/invoke.texi b/gcc/doc/invoke.texi
+index aae6bc729dbd..57fb170ca4cc 100644
+--- a/gcc/doc/invoke.texi
++++ b/gcc/doc/invoke.texi
+@@ -509,7 +509,7 @@ Objective-C and Objective-C++ Dialects}.
+ -gstrict-dwarf  -gno-strict-dwarf
+ -gas-loc-support  -gno-as-loc-support
+ -gas-locview-support  -gno-as-locview-support
+--gcodeview @gol
++-gcodeview
+ -gcolumn-info  -gno-column-info  -gdwarf32  -gdwarf64
+ -gstatement-frontiers  -gno-statement-frontiers
+ -gvariable-location-views  -gno-variable-location-views
+-- 
+2.39.3
+

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -9,13 +9,16 @@ _enable_ada=yes
 _enable_objc=yes
 _enable_rust=no
 _enable_jit=yes
+
 _threads="posix"
+
 _realname=gcc
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-libs"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-libgfortran"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-fortran"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-lto-dump"
          $([[ "$_enable_ada" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-ada")
          $([[ "$_enable_objc" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-objc")
          $([[ "$_enable_rust" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-rust")
@@ -26,7 +29,8 @@ pkgver=13.2.0
 #_majorver=${pkgver:0:1}
 #_sourcedir=${_realname}-${_majorver}-${_snapshot}
 _sourcedir=${_realname}-${pkgver}
-pkgrel=3
+_libdir=lib/gcc/${CHOST}/${pkgver%%+*}
+pkgrel=4
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -69,9 +73,9 @@ source=("https://ftp.gnu.org/gnu/gcc/${_realname}-${pkgver%%+*}/${_realname}-${p
         0300-override-builtin-printf-format.patch
         2000-enable-rust.patch
         2001-fix-building-rust-on-mingw-w64.patch
-        "2f7e7bfa3c6327793cdcdcb5c770b93cecd49bd0.patch::https://gcc.gnu.org/git/?p=gcc.git;a=patch;h=2f7e7bfa3c6327793cdcdcb5c770b93cecd49bd0"
-        "3eeb4801d6f45f6250fc77a6d3ab4e0115f8cfdd.patch::https://gcc.gnu.org/git/?p=gcc.git;a=patch;h=3eeb4801d6f45f6250fc77a6d3ab4e0115f8cfdd"
-        777aa930b106fea2dd6ed9fe22b42a2717f1472d.patch)
+        "2f7e7bfa3c6327793cdcdcb5c770b93cecd49bd0.patch"
+        "3eeb4801d6f45f6250fc77a6d3ab4e0115f8cfdd.patch"
+        "777aa930b106fea2dd6ed9fe22b42a2717f1472d.patch")
 sha256sums=('e275e76442a6067341a27f04c5c6b83d8613144004c0413528863dc6b5c743da'
             'SKIP'
             'bce81824fc89e5e62cca350de4c17a27e27a18a1a1ad5ca3492aec1fc5af3234'
@@ -91,8 +95,8 @@ sha256sums=('e275e76442a6067341a27f04c5c6b83d8613144004c0413528863dc6b5c743da'
             'f73c8d1701762fed7d8102d17d8e4416a4cc5e600e297a89c2e1fe09cd743a1c'
             '693a91a863a706b3526af01c9de5ce8295c59ef0f56f009bcfbf79a93cba2728'
             'e78d51c908cd4e5c905c62e8350db1c609479bb95333c67f706b56974226fd94'
-            '585968957f4519aa7219de4804e96debe7592df047e497b99ea0ae073e6f57d3'
-            '73b923129e6c5b819ac994ce64b75520918992c65d00e0d97f8ca43cd6784e56'
+            '74c4693850f6c96992d43414f88e9f16ab1a5d1458f5e4dc76ac3ce435a80eef'
+            '8dc297c658911ead58cd06407b853bbe82c2c3da1ad24cbcc7b01f3c7b5f666b'
             'b0a98a41fea4a68f15d35b44495a487183a4d85ea9cb70cd4a645b4ed6583122')
 validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.org
               86CFFCA918CF3AF47147588051E8B148A9999C34  # evangelos@foutrelis.com
@@ -143,7 +147,7 @@ prepare() {
 
   # workaround for AVX misalignment issue for pass-by-value arguments
   #   cf. https://github.com/msys2/MSYS2-packages/issues/1209
-  #   cf. https://sourceforge.net/p/mingw-w64/discussion/723797/thread/bc936130/ 
+  #   cf. https://sourceforge.net/p/mingw-w64/discussion/723797/thread/bc936130/
   #  Issue is longstanding upstream at https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54412
   #  Potential alternative: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=939559
   # https://github.com/msys2/MINGW-packages/pull/8317#issuecomment-824548411
@@ -164,6 +168,8 @@ prepare() {
 
   # backport: https://github.com/msys2/MINGW-packages/issues/17599
   # https://inbox.sourceware.org/gcc-patches/a22433f5-b4d2-19b7-86a2-31e2ee45fb61@martin.st/T/
+  # https://gcc.gnu.org/git/?p=gcc.git;a=patch;h=2f7e7bfa3c6327793cdcdcb5c770b93cecd49bd0
+  # https://gcc.gnu.org/git/?p=gcc.git;a=patch;h=3eeb4801d6f45f6250fc77a6d3ab4e0115f8cfdd
   apply_patch_with_msg \
     2f7e7bfa3c6327793cdcdcb5c770b93cecd49bd0.patch \
     3eeb4801d6f45f6250fc77a6d3ab4e0115f8cfdd.patch
@@ -183,7 +189,7 @@ prepare() {
 }
 
 build() {
-  mkdir -p ${srcdir}/build-${MSYSTEM} && cd ${srcdir}/build-${MSYSTEM}
+  mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
 
   declare -a extra_config
   if check_option "debug" "n"; then
@@ -288,13 +294,6 @@ build() {
   # https://gcc.gnu.org/onlinedocs/gccint/Makefile.html
   make -O STAGE1_CFLAGS="-O2" \
           profiledbootstrap
-
-  rm -rf ${srcdir}${MINGW_PREFIX}
-
-  make DESTDIR=${srcdir} install
-  if [ "$_enable_ada" == "yes" ]; then
-    mv ${srcdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/adalib/*.dll ${srcdir}${MINGW_PREFIX}/bin/
-  fi
 }
 
 package_gcc-libs() {
@@ -310,27 +309,33 @@ package_gcc-libs() {
   # be redistributed under GPL-3.0-or-later.
   license=('spdx:GPL-3.0-or-later WITH GCC-exception-3.1 AND LGPL-2.1-or-later')
 
+  cd "${srcdir}"/build-${MSYSTEM}
+
+  make -C $CHOST/libgcc DESTDIR="${pkgdir}" install-shared
+  install -dm755 "${pkgdir}"${MINGW_PREFIX}/bin
+  mv "${pkgdir}"/libgcc_*.dll "${pkgdir}"${MINGW_PREFIX}/bin/
+
+  # libitm* and libvtv* are disbled until fixed
+  for lib in libatomic libgomp libquadmath libstdc++-v3/src; do
+    make -C $CHOST/$lib DESTDIR="${pkgdir}" install-toolexeclibLTLIBRARIES
+  done
+
+  rm -r "${pkgdir}"${MINGW_PREFIX}/lib
+
+  make -C $CHOST/libstdc++-v3/po DESTDIR="${pkgdir}" install
+
   # We explain the licensing in this generated README file
-  mkdir -p "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-libs"
-  cat << ENDFILE > "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-libs/README"
+  mkdir -p "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}-libs
+  cat << ENDFILE > "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}-libs/README
 The libgcc, libstdc++, libgomp and libatomic libraries are covered by
 GPL-3.0-or-later with GCC-exception-3.1. The libquadmath library is covered
 by LGPL-2.1-or-later. The package as a whole can be redistributed under GPL-3.0-or-later.
 ENDFILE
 
   # License files
-  install -Dm644 "${srcdir}/${_sourcedir}/COPYING3"        "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-libs/COPYING3"
-  install -Dm644 "${srcdir}/${_sourcedir}/COPYING.LIB"     "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-libs/COPYING.LIB"
-  install -Dm644 "${srcdir}/${_sourcedir}/COPYING.RUNTIME" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-libs/COPYING.RUNTIME"
-
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/bin
-
-  cd ${srcdir}${MINGW_PREFIX}
-  # libitm* and libvtv* are disbled until fixed
-  cp bin/{libatomic*,libgcc*,libgomp*,libquadmath*,libstdc*}.dll ${pkgdir}${MINGW_PREFIX}/bin/
-  if [ "$_enable_jit" == "yes" ]; then
-    rm ${pkgdir}${MINGW_PREFIX}/bin/libgccjit-0.dll
-  fi
+  install -Dm644 "${srcdir}"/${_sourcedir}/COPYING3        "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}-libs/COPYING3
+  install -Dm644 "${srcdir}"/${_sourcedir}/COPYING.LIB     "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}-libs/COPYING.LIB
+  install -Dm644 "${srcdir}"/${_sourcedir}/COPYING.RUNTIME "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}-libs/COPYING.RUNTIME
 }
 
 package_gcc() {
@@ -352,93 +357,72 @@ package_gcc() {
             "${MINGW_PACKAGE_PREFIX}-cc")
   conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-base")
 
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/{bin,include,lib,share}
+  cd "${srcdir}"/build-${MSYSTEM}
 
-  cd ${srcdir}${MINGW_PREFIX}
-  cp bin/cpp.exe                                        ${pkgdir}${MINGW_PREFIX}/bin/
-  cp bin/gcc.exe                                        ${pkgdir}${MINGW_PREFIX}/bin/
-  cp bin/gcc.exe                                        ${pkgdir}${MINGW_PREFIX}/bin/cc.exe
-  cp bin/gcc-ar.exe                                     ${pkgdir}${MINGW_PREFIX}/bin/
-  cp bin/gcc-nm.exe                                     ${pkgdir}${MINGW_PREFIX}/bin/
-  cp bin/gcc-ranlib.exe                                 ${pkgdir}${MINGW_PREFIX}/bin/
-  cp bin/gcov.exe                                       ${pkgdir}${MINGW_PREFIX}/bin/
-  cp bin/gcov-tool.exe                                  ${pkgdir}${MINGW_PREFIX}/bin/
-  cp bin/c++.exe                                        ${pkgdir}${MINGW_PREFIX}/bin/
-  cp bin/g++.exe                                        ${pkgdir}${MINGW_PREFIX}/bin/
-  cp bin/${MINGW_CHOST}-c++.exe                         ${pkgdir}${MINGW_PREFIX}/bin/
-  cp bin/${MINGW_CHOST}-g++.exe                         ${pkgdir}${MINGW_PREFIX}/bin/
-  cp bin/${MINGW_CHOST}-gcc-${pkgver%%+*}.exe           ${pkgdir}${MINGW_PREFIX}/bin/
-  cp bin/${MINGW_CHOST}-gcc.exe                         ${pkgdir}${MINGW_PREFIX}/bin/
-  cp bin/${MINGW_CHOST}-gcc.exe                         ${pkgdir}${MINGW_PREFIX}/bin/${MINGW_CHOST}-cc.exe
-  cp bin/${MINGW_CHOST}-gcc-ar.exe                      ${pkgdir}${MINGW_PREFIX}/bin/
-  cp bin/${MINGW_CHOST}-gcc-nm.exe                      ${pkgdir}${MINGW_PREFIX}/bin/
-  cp bin/${MINGW_CHOST}-gcc-ranlib.exe                  ${pkgdir}${MINGW_PREFIX}/bin/
+  make -C gcc DESTDIR="${pkgdir}" install-driver install-cpp install-gcc-ar \
+    c++.install-common install-headers install-plugin install-lto-wrapper
 
-  #cp bin/{libgcc*,libgomp*,libquadmath*,libstdc*}.dll ${pkgdir}${MINGW_PREFIX}/bin/
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/include
-  cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/include/*.h        ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/include/
-  cp -r lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/include-fixed   ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
-  cp -r lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/install-tools   ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
-  #cp -r lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/plugin          ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
-  cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/cc1.exe            ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
-  cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/collect2.exe       ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
-  cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/crt*.o             ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
-  cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/liblto*            ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
-  cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/libgcov*           ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
-  cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/lto*.exe           ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
-  cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/cc1plus.exe        ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
-  cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/g++-mapper-server.exe ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
+  make -C c++tools DESTDIR="${pkgdir}" install
 
-  cp lib/libatomic*                                      ${pkgdir}${MINGW_PREFIX}/lib/
-  cp lib/libgcc_*                                         ${pkgdir}${MINGW_PREFIX}/lib/
-  cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/libgcc*            ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
+  install -m755 -t "${pkgdir}"${MINGW_PREFIX}/bin/ gcc/gcov{,-tool}.exe
+  install -m755 -t "${pkgdir}"${MINGW_PREFIX}/${_libdir}/ \
+    gcc/{cc1,cc1plus,collect2,lto1}.exe
 
-  cp lib/libgomp*                                        ${pkgdir}${MINGW_PREFIX}/lib/
-  # cp lib/libitm*                                         ${pkgdir}${MINGW_PREFIX}/lib/
-  cp lib/libquadmath*                                    ${pkgdir}${MINGW_PREFIX}/lib/
-  # cp lib/libvtv*                                         ${pkgdir}${MINGW_PREFIX}/lib/
-  cp lib/libstdc++*                                      ${pkgdir}${MINGW_PREFIX}/lib/
-  cp lib/libsupc++*                                      ${pkgdir}${MINGW_PREFIX}/lib/
+  make -C $CHOST/libgcc DESTDIR="${pkgdir}" install
+  rm "${pkgdir}"/libgcc_*.dll
 
-  #mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/lib
-  #cp ${srcdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/lib/libgcc_s.a ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
-  #cp lib/gcc/${MINGW_CHOST}/lib/libgcc_s.a                ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/lib/
+  make -C $CHOST/libstdc++-v3/src DESTDIR="${pkgdir}" install
+  make -C $CHOST/libstdc++-v3/include DESTDIR="${pkgdir}" install
+  make -C $CHOST/libstdc++-v3/libsupc++ DESTDIR="${pkgdir}" install
+  make -C $CHOST/libstdc++-v3/python DESTDIR="${pkgdir}" install
+  make DESTDIR="${pkgdir}" install-libcc1
+  rm "${pkgdir}"${MINGW_PREFIX}/bin/libstdc++*.dll
 
-  #cp -r lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/include/c++      ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/include/
-  cp -r include/c++                                       ${pkgdir}${MINGW_PREFIX}/include/
-  #cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/libstdc++*         ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
-  #cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/libsupc++*         ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
+  for lib in libatomic libgomp libquadmath; do
+    make -C $CHOST/$lib DESTDIR="${pkgdir}" install
+    rm "${pkgdir}"${MINGW_PREFIX}/bin/${lib}*.dll
+  done
 
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/share/{doc,info,locale,man}
-  #cp -r share/doc/gcc-${pkgver%%+*} ${pkgdir}${MINGW_PREFIX}/share/doc/
-  cp share/info/cpp.info*                                ${pkgdir}${MINGW_PREFIX}/share/info/
-  cp share/info/cppinternals.info*                       ${pkgdir}${MINGW_PREFIX}/share/info/
-  cp share/info/gcc.info*                                ${pkgdir}${MINGW_PREFIX}/share/info/
-  cp share/info/gccinstall.info*                         ${pkgdir}${MINGW_PREFIX}/share/info/
-  cp share/info/gccint.info*                             ${pkgdir}${MINGW_PREFIX}/share/info/
-  # cp share/info/libitm.info*                             ${pkgdir}${MINGW_PREFIX}/share/info/
-  cp share/info/libgomp.info*                            ${pkgdir}${MINGW_PREFIX}/share/info/
-  cp share/info/libquadmath.info*                        ${pkgdir}${MINGW_PREFIX}/share/info/
+  rm -r "${pkgdir}"${MINGW_PREFIX}/${_libdir}/finclude
 
-  #cp share/locale/* ${pkgdir}${MINGW_PREFIX}/share/locale/
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/share/gcc-${pkgver%%+*}/python
-  cp -r share/gcc-${pkgver%%+*}/python/libstdcxx             ${pkgdir}${MINGW_PREFIX}/share/gcc-${pkgver%%+*}/python/
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/share/man/man1
-  cp share/man/man1/cpp.1*                               ${pkgdir}${MINGW_PREFIX}/share/man/man1/
-  cp share/man/man1/gcc.1*                               ${pkgdir}${MINGW_PREFIX}/share/man/man1/
-  cp share/man/man1/gcov.1*                              ${pkgdir}${MINGW_PREFIX}/share/man/man1/
-  cp share/man/man7/fsf-funding.7*                       ${pkgdir}${MINGW_PREFIX}/share/man/man1/
-  cp share/man/man7/gfdl.7*                              ${pkgdir}${MINGW_PREFIX}/share/man/man1/
-  cp share/man/man7/gpl.7*                               ${pkgdir}${MINGW_PREFIX}/share/man/man1/
-  cp share/man/man1/g++.1*                               ${pkgdir}${MINGW_PREFIX}/share/man/man1/
+  # install -d "${pkgdir}"${MINGW_PREFIX}/share/gdb/auto-load/usr/lib
+  # mv "${pkgdir}"${MINGW_PREFIX}/lib/libstdc++.dll.a-gdb.py \
+  #   "${pkgdir}"${MINGW_PREFIX}/share/gdb/auto-load/usr/lib/
 
-  # install plugins for binutils
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/bfd-plugins
-  cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/*plugin*.dll       ${pkgdir}${MINGW_PREFIX}/lib/bfd-plugins/
+  make DESTDIR="${pkgdir}" install-fixincludes
+  make -C gcc DESTDIR="${pkgdir}" install-mkheaders
+
+  make -C lto-plugin DESTDIR="${pkgdir}" install
+  install -dm755 "${pkgdir}"${MINGW_PREFIX}/lib/bfd-plugins/
+  cp "${pkgdir}"${MINGW_PREFIX}/${_libdir}/liblto_plugin.dll "${pkgdir}"${MINGW_PREFIX}/lib/bfd-plugins/
+
+  make -C $CHOST/libgomp DESTDIR="${pkgdir}" install-nodist_{libsubinclude,toolexeclib}HEADERS
+  make -C $CHOST/libquadmath DESTDIR="${pkgdir}" install-nodist_libsubincludeHEADERS
+
+  make -C gcc DESTDIR="${pkgdir}" install-man install-info
+  rm "${pkgdir}"${MINGW_PREFIX}/share/man/man1/{gfortran,lto-dump}.1
+  rm "${pkgdir}"${MINGW_PREFIX}/share/info/gfortran.info
+  if [ "$_enable_ada" == "yes" ]; then
+    rm "${pkgdir}"${MINGW_PREFIX}/share/info/{gnat-style,gnat_rm,gnat_ugn}.info
+  fi
+  if [ "$_enable_jit" == "yes" ]; then
+    rm "${pkgdir}"${MINGW_PREFIX}/share/info/libgccjit.info
+  fi
+
+  make -C libcpp DESTDIR="${pkgdir}" install
+  make -C gcc DESTDIR="${pkgdir}" install-po
+
+  # make -C $CHOST/libstdc++-v3/doc DESTDIR="${pkgdir}" doc-install-man
+
+  cp "${pkgdir}"${MINGW_PREFIX}/bin/gcc.exe "${pkgdir}"${MINGW_PREFIX}/bin/cc.exe
+  cp "${pkgdir}"${MINGW_PREFIX}/bin/gcc.exe "${pkgdir}"${MINGW_PREFIX}/bin/${CHOST}-cc.exe
 
   # install "custom" system gdbinit
-  install -D -m644 ${srcdir}/gdbinit ${pkgdir}${MINGW_PREFIX}/etc/gdbinit
-  sed -i 's|%GCC_NAME%|gcc-'${pkgver%%+*}'|g' ${pkgdir}${MINGW_PREFIX}/etc/gdbinit
+  install -D -m644 "${srcdir}"/gdbinit "${pkgdir}"${MINGW_PREFIX}/etc/gdbinit
+  sed -i 's|%GCC_NAME%|gcc-'${pkgver%%+*}'|g' "${pkgdir}"${MINGW_PREFIX}/etc/gdbinit
+
+  # byte-compile python libraries
+  # ${MINGW_PREFIX}/bin/python -m compileall -o 0 -o 1 "${pkgdir}"${MINGW_PREFIX}/share/gcc-${pkgver%%+*}/
 }
 
 package_gcc-libgfortran() {
@@ -446,9 +430,11 @@ package_gcc-libgfortran() {
   depends=("${MINGW_PACKAGE_PREFIX}-${_realname}-libs=${pkgver}-${pkgrel}")
   provides=("${MINGW_PACKAGE_PREFIX}-fc-libs")
 
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/bin
-  cd ${srcdir}${MINGW_PREFIX}
-  cp bin/libgfortran*.dll                                ${pkgdir}${MINGW_PREFIX}/bin/
+  cd "${srcdir}"/build-${MSYSTEM}
+  make -C $CHOST/libgfortran DESTDIR="${pkgdir}" install-toolexeclibLTLIBRARIES
+  rm -r "${pkgdir}"${MINGW_PREFIX}/lib
+
+  install -Dm644 "${srcdir}"/${_sourcedir}/COPYING.RUNTIME "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}-libgfortran/COPYING.RUNTIME
 }
 
 package_gcc-fortran() {
@@ -457,89 +443,68 @@ package_gcc-fortran() {
            "${MINGW_PACKAGE_PREFIX}-${_realname}-libgfortran=${pkgver}-${pkgrel}")
   provides=("${MINGW_PACKAGE_PREFIX}-fc")
 
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/{bin,lib,share}
+  cd "${srcdir}"/build-${MSYSTEM}
 
-  cd ${srcdir}${MINGW_PREFIX}
-  cp bin/gfortran.exe ${pkgdir}${MINGW_PREFIX}/bin/
-  cp bin/${MINGW_CHOST}-gfortran.exe ${pkgdir}${MINGW_PREFIX}/bin/
-
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}
-  cp -r lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/finclude       ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
-  cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/f951.exe          ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
-  cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/libcaf_single.a   ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
-  cp lib/libgfortran*                                   ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/share/man/man1
-  cp share/man/man1/gfortran.1*                         ${pkgdir}${MINGW_PREFIX}/share/man/man1/
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/share/info
-  cp share/info/gfortran.info*                          ${pkgdir}${MINGW_PREFIX}/share/info/
+  make -C $CHOST/libgfortran DESTDIR="${pkgdir}" install
+  rm "${pkgdir}"${MINGW_PREFIX}/bin/libgfortran*.dll
+  make -C $CHOST/libgomp DESTDIR="${pkgdir}" install-nodist_fincludeHEADERS
+  make -C gcc DESTDIR="${pkgdir}" fortran.install-{common,man,info}
+  install -Dm755 gcc/f951.exe "${pkgdir}"${MINGW_PREFIX}/${_libdir}/f951.exe
 }
 
 package_gcc-ada() {
   pkgdesc="GNU Compiler Collection (Ada) for MinGW-w64"
   depends=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}-${pkgrel}")
 
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/{bin,lib,share}
+  cd "${srcdir}"/build-${MSYSTEM}
 
-  cd ${srcdir}${MINGW_PREFIX}
-  cp bin/gnat*.exe ${pkgdir}${MINGW_PREFIX}/bin/
-
-  cp bin/{libgnarl*,libgnat*}.dll                       ${pkgdir}${MINGW_PREFIX}/bin/
-
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}
-  cp -r lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/adainclude     ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
-  cp -r lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/adalib         ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
-  cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/gnat1.exe         ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
-
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/share/info
-  cp share/info/gnat-style.info*                        ${pkgdir}${MINGW_PREFIX}/share/info/
-  cp share/info/gnat_rm.info*                           ${pkgdir}${MINGW_PREFIX}/share/info/
-  cp share/info/gnat_ugn.info*                          ${pkgdir}${MINGW_PREFIX}/share/info/
+  make -C gcc DESTDIR="${pkgdir}" ada.install-{common,info} install-gnatlib
+  mv "${pkgdir}"${MINGW_PREFIX}/${_libdir}/adalib/*.dll "${pkgdir}"${MINGW_PREFIX}/bin/
+  install -m755 gcc/gnat1.exe "${pkgdir}"${MINGW_PREFIX}/${_libdir}
 }
 
 package_gcc-objc() {
   pkgdesc="GNU Compiler Collection (ObjC,Obj-C++) for MinGW-w64"
   depends=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}-${pkgrel}")
 
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/{bin,lib}
+  cd "${srcdir}"/build-${MSYSTEM}
 
-  cd ${srcdir}${MINGW_PREFIX}
-  cp bin/libobjc*.dll ${pkgdir}${MINGW_PREFIX}/bin/
+  make -C $CHOST/libobjc DESTDIR="${pkgdir}" install-libs
+  make -C $CHOST/libobjc DESTDIR="${pkgdir}" install-headers
+  install -dm755 "${pkgdir}"${MINGW_PREFIX}/${_libdir}
+  install -m755 gcc/cc1obj{,plus}.exe "${pkgdir}"${MINGW_PREFIX}/${_libdir}/
 
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/include
-  cp -r lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/include/objc    ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/include/
-  cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/cc1obj.exe         ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
-  cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/cc1objplus.exe     ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
-  cp lib/libobjc.*                                       ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
+  install -Dm644 "${srcdir}/${_sourcedir}/COPYING.RUNTIME" "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}-objc/COPYING.RUNTIME
 }
 
 package_gcc-rust() {
   pkgdesc="GNU Compiler Collection (Rust) for MinGW-w64"
   depends=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}-${pkgrel}")
 
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/{bin,lib}
+  cd "${srcdir}"/build-${MSYSTEM}
 
-  cd ${srcdir}${MINGW_PREFIX}
-  cp bin/gccrs.exe ${pkgdir}${MINGW_PREFIX}/bin/
-  cp bin/${MINGW_CHOST}-gccrs.exe ${pkgdir}${MINGW_PREFIX}/bin/
+  make -C gcc DESTDIR="${pkgdir}" rust.install-{common,man,info}
 
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}
-  cp lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/rust1.exe          ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver%%+*}/
+  install -Dm755 gcc/gccrs.exe "${pkgdir}"${MINGW_PREFIX}/bin/gccrs.exe
+  install -Dm755 gcc/rust1.exe "${pkgdir}"${MINGW_PREFIX}/${_libdir}/rust1.exe
+}
+
+package_gcc-lto-dump() {
+  pkgdesc="Dump link time optimization object files (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}=$pkgver-$pkgrel")
+
+  cd "${srcdir}"/build-${MSYSTEM}
+
+  make -C gcc DESTDIR="${pkgdir}" lto.install-{common,man,info}
 }
 
 package_libgccjit() {
   pkgdesc="GNU Compiler Collection (libgccjit) for MinGW-w64"
   depends=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}-${pkgrel}")
 
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/{bin,lib,include}
+  cd "${srcdir}"/build-${MSYSTEM}
 
-  cd ${srcdir}${MINGW_PREFIX}
-
-  cp bin/libgccjit-0.dll                                      ${pkgdir}${MINGW_PREFIX}/bin/
-  cp include/libgccjit.h                                      ${pkgdir}${MINGW_PREFIX}/include/
-  cp include/libgccjit++.h                                    ${pkgdir}${MINGW_PREFIX}/include/
-  cp lib/libgccjit.dll.a                                      ${pkgdir}${MINGW_PREFIX}/lib/
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/share/info
-  cp share/info/libgccjit.info                                ${pkgdir}${MINGW_PREFIX}/share/info/
+  make -C gcc DESTDIR="${pkgdir}" jit.install-common jit.install-info
 }
 
 # template start; name=mingw-w64-splitpkg-wrappers; version=1.0;


### PR DESCRIPTION
ArchLinux named just lto-dump, should we follow them or name gcc-lto-dump?