### PR TITLE
Update mingw-w64-arm-none-eabi-gcc to V13.2.0

### DIFF
--- a/mingw-w64-arm-none-eabi-gcc/PKGBUILD
+++ b/mingw-w64-arm-none-eabi-gcc/PKGBUILD
@@ -9,7 +9,7 @@ _enable_ada=no
 
 pkgbase=mingw-w64-${_target}-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_target}-${_realname}")
-pkgver=12.2.0
+pkgver=13.2.0
 pkgrel=1
 pkgdesc='GNU Tools for ARM Embedded Processors - GCC (mingw-w64)'
 arch=('any')
@@ -34,9 +34,9 @@ makedepends=(
     "${MINGW_PACKAGE_PREFIX}-mpfr"
     $([[ "$_enable_ada" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-gcc-ada")
 )
-options=('!emptydirs' '!strip')
+options=('!emptydirs')
 source=("https://ftp.gnu.org/gnu/gcc/gcc-${pkgver}/gcc-${pkgver}.tar.xz")
-sha256sums=('e549cf9cf3594a00e27b6589d4322d70e0720cdd213f39beb4181e06926230ff')
+sha256sums=('e275e76442a6067341a27f04c5c6b83d8613144004c0413528863dc6b5c743da')
 
 prepare() {
     cd ${srcdir}/gcc-${pkgver}


### PR DESCRIPTION
- Change versions
- Remove !strip option according to changes in th parent repo
- Adjusted checksum