### PR TITLE
podman: Update to 4.9.2

### DIFF
--- a/mingw-w64-podman/PKGBUILD
+++ b/mingw-w64-podman/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=podman
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=4.8.3
+pkgver=4.9.2
 pkgrel=1
 pkgdesc='Tool for running OCI-based containers in pods (mingw-w64)'
 arch=('any')
@@ -17,8 +17,11 @@ makedepends=(
     "${MINGW_PACKAGE_PREFIX}-python"
     "git"
 )
-source=("https://github.com/containers/podman/archive/v$pkgver/${_realname}-${pkgver}.tar.gz")
-sha256sums=('3a99b6c82644fa52929cf4143943c63d6784c84094892bc0e14197fa38a1c7fa')
+_GV_VERSION="0.7.2"  # See GV_VERSION in Makefile
+source=("https://github.com/containers/podman/archive/v$pkgver/${_realname}-${pkgver}.tar.gz"
+        "https://github.com/containers/gvisor-tap-vsock/archive/refs/tags/v${_GV_VERSION}.tar.gz")
+sha256sums=('5696e2ec07020a5a147444abd0cd6f8563412190212e1f12e6c1e110da0cc6d2'
+            '2163287ba1df33d9aba905888f271dc997d04fd3027f1c1f0c354d6045e07425')
 noextract=("${_realname}-${pkgver}.tar.gz")
 
 prepare() {
@@ -26,11 +29,11 @@ prepare() {
     tar -xzf ${_realname}-${pkgver}.tar.gz | true
     rm -rf build-${MSYSTEM}
     cp -r ${_realname}-${pkgver} build-${MSYSTEM}
+
+    cp -r "gvisor-tap-vsock-${_GV_VERSION}" "build-proxy-${MSYSTEM}"
 }
 
 build() {
-    cd "build-${MSYSTEM}"
-
     export GOOS=windows
     export GOROOT=${MINGW_PREFIX}/lib/go
     export CGO_CPPFLAGS="${CPPFLAGS}"
@@ -45,18 +48,22 @@ build() {
         ;;
     esac
 
+    cd  "${srcdir}/build-proxy-${MSYSTEM}"
+    make win-gvproxy win-sshproxy
+
+    cd "${srcdir}/build-${MSYSTEM}"
     # parallel make breaks markdown processing
     make -j1 podman-remote
     make -j1 docker-docs
-    make -j1 win-gvproxy
 }
 
 package() {
     cd "build-${MSYSTEM}"
 
+    # copy the proxy binaries where install.remote expects them
+    cp "${srcdir}/build-proxy-${MSYSTEM}/bin/"* "./bin/windows"
+
     make install.remote install.docker-full install.man install.completions DESTDIR="$pkgdir" PREFIX=${MINGW_PREFIX}
     rm -Rf "${pkgdir}${MINGW_PREFIX}/lib"
     sed -i "s|/usr/bin/||g" "${pkgdir}${MINGW_PREFIX}/bin/docker"
-
-    cp bin/windows/win-sshproxy.exe "${pkgdir}${MINGW_PREFIX}/bin"
 }


### PR DESCRIPTION
podman down downloads pre-built binaries for gvproxy.exe and win-sshproxy.exe, so download their source and build them manually, and put them in the expected location instead.