### PR TITLE
add patch: ld: fix 32-bit mingw DLL symbol export bug

### DIFF
--- a/mingw-w64-binutils/PKGBUILD
+++ b/mingw-w64-binutils/PKGBUILD
@@ -32,6 +32,7 @@ source=(https://ftp.gnu.org/gnu/binutils/${_realname}-${pkgver}.tar.bz2{,.sig}
         reproducible-import-libraries.patch
         libiberty-unlink-handle-windows-nul.patch
         3001-hack-libiberty-link-order.patch
+        "f530d5f1bab6eb5adc65f422ef811fb278a21a4b.patch::https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff_plain;h=d544a1dca23469d212e7e9edc754487352c5f042;hp=f530d5f1bab6eb5adc65f422ef811fb278a21a4b"
 )
 sha256sums=('aa54850ebda5064c72cd4ec2d9b056c294252991486350d9a97ab2a6dfdfaf12'
             'SKIP'
@@ -42,7 +43,8 @@ sha256sums=('aa54850ebda5064c72cd4ec2d9b056c294252991486350d9a97ab2a6dfdfaf12'
             'd584f1cd9e94cba0e9b27625c4acc8ad5242cd625c9b44839d42fc116072568c'
             'a094660ec95996c00b598429843b7869037732146442af567ada9f539bd40480'
             '7ccbd418695733c50966068fa9755a6abb156f53af23701d2bc097c63e9e0030'
-            '604628156c08f3e361de60329af250fab6839e23e61e289f8369a7e18a04e277')
+            '604628156c08f3e361de60329af250fab6839e23e61e289f8369a7e18a04e277'
+            '6a4766aadee4ec68d6b4c82e2693710d1557de0be7df4fc4167aa2c4a1826dd1')
 validpgpkeys=('EAF1C276A747E9ED86210CBAC3126D3B4AE55E93'
               '3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F')
 
@@ -89,6 +91,10 @@ prepare() {
   # search paths, so imho if things link against the system lib or the just
   # built one is just luck, and I don't know how that is supposed to work.
   patch -p1 -i "${srcdir}/3001-hack-libiberty-link-order.patch"
+
+  # ld: fix 32-bit mingw DLL symbol export bug
+  # https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff;h=d544a1dca23469d212e7e9edc754487352c5f042;hp=f530d5f1bab6eb5adc65f422ef811fb278a21a4b
+  apply_patch_with_msg f530d5f1bab6eb5adc65f422ef811fb278a21a4b.patch
 }
 
 build() {


### PR DESCRIPTION
I added my patch: https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff;h=d544a1dca23469d212e7e9edc754487352c5f042;hp=f530d5f1bab6eb5adc65f422ef811fb278a21a4b