### PR TITLE
enchant: Update to 2.6.7

### DIFF
--- a/mingw-w64-enchant/PKGBUILD
+++ b/mingw-w64-enchant/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=enchant
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.6.6
+pkgver=2.6.7
 pkgrel=1
 pkgdesc="Enchanting Spell Checking Library (mingw-w64)"
 arch=('any')
@@ -28,7 +28,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 checkdepends=("${MINGW_PACKAGE_PREFIX}-unittest-cpp")
 source=("https://github.com/AbiWord/enchant/releases/download/v${pkgver}/enchant-${pkgver}.tar.gz"
         001_fix_relocation.patch)
-sha256sums=('ce9b40e22b3ee5e91ca35403487af03896f4deb1134efcf0b1b3ef9764d28295'
+sha256sums=('a1c2e5b59acca000bbfb24810af4a1165733d407f2154786588e076c8cd57bfc'
             '2eaee551887a4dcd9b47fa3fc31db8955c51b323b89b9a6a4f096b7dca135942')
 
 prepare() {


### PR DESCRIPTION
A hotfix [release](https://github.com/AbiWord/enchant/releases/tag/v2.6.7):

> This release fixes a bug introduced in 2.6.6 that would cause Enchant to crash when used with Hunspell. Apologies!