### PR TITLE
[new-package] java-openjdk 23.u9

### DIFF
--- a/mingw-w64-java-openjdk/PKGBUILD
+++ b/mingw-w64-java-openjdk/PKGBUILD
@@ -1,0 +1,112 @@
+# Contributor: Mehdi Chinoune <mehdi.chinoune@hotmail.com>
+
+_bootstrap=1
+
+_realname=java-openjdk
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-java-openjdk")
+_majorver=23
+_minorver=
+_securityver=
+_updatever=9
+#pkgver=${_majorver}.${_minorver}.${_securityver}.u${_updatever}
+pkgver=${_majorver}.u${_updatever}
+#_git_tag=jdk-${_majorver}.${_minorver}.${_securityver}+${_updatever}
+_git_tag=jdk-${_majorver}+${_updatever}
+pkgrel=1
+pkgdesc="OpenJDK Java (mingw-w64)"
+arch=('any')
+mingw_arch=('ucrt64')
+url='https://www.openjdk.org/'
+msys2_repository_url="https://github.com/openjdk/jdk"
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-freetype"
+         "${MINGW_PACKAGE_PREFIX}-giflib"
+         "${MINGW_PACKAGE_PREFIX}-lcms2"
+         "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
+         "${MINGW_PACKAGE_PREFIX}-libpng"
+         "${MINGW_PACKAGE_PREFIX}-zlib")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-autotools"
+             $( (( _bootstrap )) || echo "${MINGW_PACKAGE_PREFIX}-java-openjdk")
+             "zip"
+             "unzip")
+source=("https://github.com/openjdk/jdk/archive/${_git_tag}.tar.gz"
+        
+        "0001-support-mingw.patch::https://github.com/TheShermanTanker/jdk/commit/cca62c410.patch")
+sha256sums=('5e57b80199e389484f890aa4675d57696d92d1136a9651fe0920652eb698b1d6'
+            
+            '93b8a78d82faedd314b53efb9b911106ae62d66def674b21645f3c930c1b980b')
+
+if (( _bootstrap )); then
+  source+=("https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_windows-x64_bin.zip")
+  sha256sums+=('b6c17e747ae78cdd6de4d7532b3164b277daee97c007d3eaa2b39cca99882664')
+fi
+
+prepare() {
+  cd "${srcdir}/jdk-${_git_tag/+/-}"
+
+  patch -p1 -i "${srcdir}/0001-support-mingw.patch"
+}
+
+build() {
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
+
+  declare -a _extra_config
+  if check_option "debug" "n"; then
+    _extra_config+=("--with-native-debug-symbols=none")
+  fi
+
+  if (( _bootstrap )); then
+    _extra_config+=("--with-boot-jdk=../jdk-21.0.2")
+  fi
+
+  export _CFLAGS=${CFLAGS} _CXXFLAGS=${CXXFLAGS} _LDFLAGS=${LDFLAGS}
+  unset CFLAGS CXXFLAGS LDFLAGS
+
+  ../"jdk-${_git_tag/+/-}"/configure \
+    --prefix="${MINGW_PREFIX}" \
+    --with-toolchain-type=gcc \
+    --with-version-build="${_updatever}" \
+    --with-version-pre="" \
+    --with-version-opt="" \
+    --with-vendor-name='MSYS2' \
+    --with-vendor-url='https://github.com/msys2/MINGW-packages/${pkgbase}' \
+    --with-vendor-bug-url='https://github.com/msys2/MINGW-packages/issues' \
+    --with-vendor-vm-bug-url='https://github.com/msys2/MINGW-packages/issues' \
+    --enable-linktime-gc \
+    --with-extra-cflags="${_CFLAGS}" \
+    --with-extra-cxxflags="${_CXXFLAGS}" \
+    --with-extra-ldflags="${_LDFLAGS}" \
+    --disable-warnings-as-errors \
+    --with-stdc++lib=dynamic \
+    --with-libjpeg=system \
+    --with-giflib=system \
+    --with-libpng=system \
+    --with-lcms=system \
+    --with-zlib=system \
+    --with-harfbuzz=system \
+    --with-num-cores=${MAKEFLAGS/-j} \
+    "${_extra_config[@]}"
+
+  MAKEFLAGS="" \
+  make images
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  cp -r images/jdk "${pkgdir}"${MINGW_PREFIX}
+
+  cp "${pkgdir}"${MINGW_PREFIX}/bin/server/jvm.dll "${pkgdir}"${MINGW_PREFIX}/bin/
+
+  install -dm 755 "${pkgdir}"${MINGW_PREFIX}/share/${_realname}
+  mv "${pkgdir}"${MINGW_PREFIX}/release "${pkgdir}"${MINGW_PREFIX}/share/${_realname}/
+  mv "${pkgdir}"${MINGW_PREFIX}/demo "${pkgdir}"${MINGW_PREFIX}/share/${_realname}/
+
+  install -dm 755 "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/
+  mv "${pkgdir}"${MINGW_PREFIX}/legal "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/
+
+  install -Dm644 "${srcdir}/jdk-${_git_tag/+/-}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
Unfortunately, It fails to build.
Doesn't accept clang even after I tried to use /clang64/bin/gcc.exe

@TheShermanTanker 