### PR TITLE
libpreferencepanes: new package

### DIFF
--- a/mingw-w64-libpreferencepanes/PKGBUILD
+++ b/mingw-w64-libpreferencepanes/PKGBUILD
@@ -1,0 +1,48 @@
+# Maintainer: Frederik Carlier <frederik.carlier@keysight.com>
+
+_realname=apps-systempreferences
+pkgbase=mingw-w64-${_realname}
+# Using same naming convention as Ubuntu: https://packages.ubuntu.com/noble/libpreferencepanes1
+pkgname=("${MINGW_PACKAGE_PREFIX}-libpreferencepanes")
+pkgver=1.2.0
+pkgrel=1
+pkgdesc="GNUstep preferences library - runtime library (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64')
+url='https://gnustep.github.org/'
+license=('spdx:LGPL-2.1-or-later')
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-clang"
+             "${MINGW_PACKAGE_PREFIX}-lld"
+             "${MINGW_PACKAGE_PREFIX}-gnustep-make"
+             rsync)
+depends=("${MINGW_PACKAGE_PREFIX}-gnustep-gui")
+source=("https://github.com/gnustep/${_realname}/archive/refs/tags/systempreferences-${pkgver//./_}.tar.gz")
+sha256sums=('274d4f77eb06410bbd7c6df58742c9485f63dedf6bbd86e2dd10be10ec249461')
+
+prepare() {
+  cd "${srcdir}/${_realname}-systempreferences-${pkgver//./_}"
+}
+
+build() {
+  rsync --recursive --times --links "${srcdir}/${_realname}-systempreferences-${pkgver//./_}"/* "${srcdir}/build-${MSYSTEM}"
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  CC="$MINGW_PREFIX/bin/clang" \
+  CXX="$MINGW_PREFIX/bin/clang++" \
+  make
+}
+
+check() {
+  cd "${srcdir}/build-${MSYSTEM}"
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  make install DESTDIR="${pkgdir}"
+  rm -rf ${pkgdir}/${MINGW_PREFIX}/lib/GNUstep/Bundles/
+  rm -rf ${pkgdir}/${MINGW_PREFIX}/lib/GNUstep/Applications/
+
+  install -Dm644 "${srcdir}/${_realname}-systempreferences-${pkgver//./_}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}

--- a/mingw-w64-libpreferencepanes/PKGBUILD
+++ b/mingw-w64-libpreferencepanes/PKGBUILD
@@ -20,10 +20,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-gnustep-gui")
 source=("https://github.com/gnustep/${_realname}/archive/refs/tags/systempreferences-${pkgver//./_}.tar.gz")
 sha256sums=('274d4f77eb06410bbd7c6df58742c9485f63dedf6bbd86e2dd10be10ec249461')
 
-prepare() {
-  cd "${srcdir}/${_realname}-systempreferences-${pkgver//./_}"
-}
-
 build() {
   rsync --recursive --times --links "${srcdir}/${_realname}-systempreferences-${pkgver//./_}"/* "${srcdir}/build-${MSYSTEM}"
   cd "${srcdir}/build-${MSYSTEM}"

--- a/mingw-w64-libpreferencepanes/PKGBUILD
+++ b/mingw-w64-libpreferencepanes/PKGBUILD
@@ -33,16 +33,12 @@ build() {
   make
 }
 
-check() {
-  cd "${srcdir}/build-${MSYSTEM}"
-}
-
 package() {
   cd "${srcdir}/build-${MSYSTEM}"
 
   make install DESTDIR="${pkgdir}"
-  rm -rf ${pkgdir}/${MINGW_PREFIX}/lib/GNUstep/Bundles/
-  rm -rf ${pkgdir}/${MINGW_PREFIX}/lib/GNUstep/Applications/
+  rm -rf ${pkgdir}${MINGW_PREFIX}/lib/GNUstep/Bundles/
+  rm -rf ${pkgdir}${MINGW_PREFIX}/lib/GNUstep/Applications/
 
   install -Dm644 "${srcdir}/${_realname}-systempreferences-${pkgver//./_}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }


### PR DESCRIPTION
Packages the https://github.com/gnustep/apps-systempreferences library.

This package contains the library component only; and excludes the actual system preferences application and the supporting bundles.

The libpreferencepanes names was chosen in analogy with how this library is packaged in Ubuntu: https://packages.ubuntu.com/noble/libpreferencepanes1