### PR TITLE
python-jupyterlab/notebook: update to 4.1.1/7.1.0

### DIFF
--- a/mingw-w64-python-jupyter_notebook/PKGBUILD
+++ b/mingw-w64-python-jupyter_notebook/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=notebook
 pkgbase=mingw-w64-python-jupyter_${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-jupyter_${_realname}
-pkgver=7.0.8
+pkgver=7.1.0
 pkgrel=1
 pkgdesc='Jupyter Interactive Notebook (mingw-w64)'
 arch=('any')
@@ -24,7 +24,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer")
 options=('!strip')
 source=(https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz)
-sha256sums=('3957ecd956056b0014677afc76d3bb44c2d2f29649f87b24d13606ff1d18938f')
+sha256sums=('99caf01ff166b1cc86355c9b37c1ba9bf566c1d7fc4ab57bb6f8f24e36c4260e')
 
 prepare() {
   rm -rf python-build-${MSYSTEM} | true

--- a/mingw-w64-python-jupyterlab/PKGBUILD
+++ b/mingw-w64-python-jupyterlab/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=jupyterlab
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
-pkgver=4.0.11
+pkgver=4.1.1
 pkgrel=1
 pkgdesc='JupyterLab computational environment (mingw-w64)'
 arch=('any')
@@ -24,6 +24,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-jupyter_server"
          "${MINGW_PACKAGE_PREFIX}-python-jupyter_notebook_shim"
          "${MINGW_PACKAGE_PREFIX}-python-jupyterlab-server"
+         "${MINGW_PACKAGE_PREFIX}-python-httpx"
          "${MINGW_PACKAGE_PREFIX}-python-packaging"
          "${MINGW_PACKAGE_PREFIX}-python-traitlets"
          "${MINGW_PACKAGE_PREFIX}-python-tornado"
@@ -33,7 +34,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer")
 options=('!strip')
 source=(https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz)
-sha256sums=('d1aec24712566bc25a36229788242778e498ca4088028e2f9aa156b8b7fdc8fc')
+sha256sums=('8acc9f561729d8f32c14c294c397917cddfeeb13a5d46f811979b71b4911a9fd')
 
 prepare() {
   rm -rf python-build-${MSYSTEM} | true


### PR DESCRIPTION
Looks like we should wait for the next release of the `notebook`...