### PR TITLE
openpgl: work around missing _mm_malloc() on arm64

### DIFF
--- a/mingw-w64-openpgl/004-arm64-no-mm-malloc.patch
+++ b/mingw-w64-openpgl/004-arm64-no-mm-malloc.patch
@@ -1,0 +1,16 @@
+--- openpgl-0.6.0/third-party/embreeSrc/common/sys/alloc.cpp.orig	2024-02-10 20:52:01.336701200 +0100
++++ openpgl-0.6.0/third-party/embreeSrc/common/sys/alloc.cpp	2024-02-10 20:54:13.463546000 +0100
+@@ -4,6 +4,13 @@
+ #include "alloc.h"
+ #include "intrinsics.h"
+ 
++#ifdef _WIN32
++#define WIN32_LEAN_AND_MEAN
++#include <windows.h>
++
++#define _mm_malloc(size, alignment) _aligned_malloc(size, alignment)
++#define _mm_free(ptr) _aligned_free(ptr)
++#endif
+ 
+ ////////////////////////////////////////////////////////////////////////////////
+ /// All Platforms

--- a/mingw-w64-openpgl/PKGBUILD
+++ b/mingw-w64-openpgl/PKGBUILD
@@ -4,7 +4,7 @@ _realname=openpgl
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.6.0
-pkgrel=3
+pkgrel=4
 pkgdesc="Intel(R) Open Path Guiding Library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -22,17 +22,20 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 source=("https://github.com/OpenPathGuidingLibrary/openpgl/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
         001-add-compile-flags.patch
         002-Fix-finding-TBB.patch
-        003-Fix-building-on-mingw-w64-aarch64.patch)
+        003-Fix-building-on-mingw-w64-aarch64.patch
+        004-arm64-no-mm-malloc.patch)
 sha256sums=('4192a4096ee3e3d31878cd013f8de23418c8037c576537551f946c4811931c5e'
             '27f9b0767f1356224783b87f888e4a91d6e64774f733cab68d813d227fb675c6'
             '6703e4dd3f06dfd2d9f28a9d7cb727c9476d231f662fd676883d42a61873aa0f'
-            '7b58f6a79e5bfd7b8f679135457c264c66d434d0614b0e937eebe69786c2ff93')
+            '7b58f6a79e5bfd7b8f679135457c264c66d434d0614b0e937eebe69786c2ff93'
+            'f30084ff5c50a655237cd729838563a8e7348a8ef0bd0fa588b6777f07b84286')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
   patch -p1 -i "${srcdir}"/001-add-compile-flags.patch
   patch -p1 -i "${srcdir}"/002-Fix-finding-TBB.patch
   patch -p1 -i "${srcdir}"/003-Fix-building-on-mingw-w64-aarch64.patch
+  patch -p1 -i "${srcdir}"/004-arm64-no-mm-malloc.patch
 }
 
 build() {


### PR DESCRIPTION
same as with https://github.com/msys2/MINGW-packages/blob/1b4f088e43b9f317233de9717ba69468a856c7aa/mingw-w64-embree/002-arm64-no-mm-malloc.patch