### PR TITLE
libobjc2: Add clang64 support

### DIFF
--- a/mingw-w64-gnustep-base/PKGBUILD
+++ b/mingw-w64-gnustep-base/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gnustep-base
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.29.0
-pkgrel=1
+pkgrel=2
 pkgdesc="GNUstep Base library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64')
@@ -50,7 +50,15 @@ build() {
   rsync --recursive --times --links "${srcdir}/${_realname}-${pkgver}"/* "${srcdir}/build-${MSYSTEM}"
   cd "${srcdir}/build-${MSYSTEM}"
 
-  LDFLAGS="-fuse-ld=lld -lstdc++ -lgcc_s" \
+  case ${MSYSTEM} in
+    MINGW*|UCRT*)
+      export LDFLAGS="-fuse-ld=lld -lstdc++ -lgcc_s"
+      ;;
+    CLANG*)
+      export LDFLAGS="-lc++"
+      ;;
+  esac
+
   CC="$MINGW_PREFIX/bin/clang" \
   CXX="$MINGW_PREFIX/bin/clang++" \
   ./configure \

--- a/mingw-w64-gnustep-gui/PKGBUILD
+++ b/mingw-w64-gnustep-gui/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gnustep-gui
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.30.0
-pkgrel=1
+pkgrel=2
 pkgdesc="GNUstep GUI Library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64')
@@ -39,7 +39,15 @@ build() {
   rsync --recursive --times --links "${srcdir}/${_realname}-${pkgver}"/* "${srcdir}/build-${MSYSTEM}"
   cd "${srcdir}/build-${MSYSTEM}"
 
-  LDFLAGS="-fuse-ld=lld -lstdc++ -lgcc_s" \
+  case ${MSYSTEM} in
+    MINGW*|UCRT*)
+      export LDFLAGS="-fuse-ld=lld -lstdc++ -lgcc_s"
+      ;;
+    CLANG*)
+      export LDFLAGS="-lc++"
+      ;;
+  esac
+
   CC="$MINGW_PREFIX/bin/clang" \
   CXX="$MINGW_PREFIX/bin/clang++" \
   ./configure \

--- a/mingw-w64-gnustep-make/PKGBUILD
+++ b/mingw-w64-gnustep-make/PKGBUILD
@@ -4,10 +4,10 @@ _realname=gnustep-make
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.9.1
-pkgrel=1
+pkgrel=2
 pkgdesc="GNUstep build system (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64')
 url='https://gnustep.github.org/'
 license=('spdx:GPL-3.0-or-later')
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
@@ -25,7 +25,15 @@ build() {
   cd "${srcdir}/${_realname}-${pkgver}"
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
-  LDFLAGS="-fuse-ld=lld -lstdc++ -lgcc_s" \
+  case ${MSYSTEM} in
+    MINGW*|UCRT*)
+      export LDFLAGS="-fuse-ld=lld -lstdc++ -lgcc_s"
+      ;;
+    CLANG*)
+      export LDFLAGS="-lc++"
+      ;;
+  esac
+
   CC="$MINGW_PREFIX/bin/clang" \
   CXX="$MINGW_PREFIX/bin/clang++" \
   ../"${_realname}-${pkgver}"/configure \

--- a/mingw-w64-libobjc2/PKGBUILD
+++ b/mingw-w64-libobjc2/PKGBUILD
@@ -28,16 +28,20 @@ source=("https://github.com/gnustep/${_realname}/archive/refs/tags/v${pkgver}.zi
         # Install runtime files in CMAKE_INSTALL_BINDIR when GNUstep is not installed
         "https://github.com/gnustep/libobjc2/commit/639c676bb8033422539e19a2e2888bdbd06507e5.patch"
         # Support building on msys/clang64
-        "https://github.com/gnustep/libobjc2/commit/1ff5e1298dd76aa370d5a12b690857f9a47b4b56.patch")
+        "https://github.com/gnustep/libobjc2/commit/1ff5e1298dd76aa370d5a12b690857f9a47b4b56.patch"
+        # MinGW: Update library prefix/suffix
+        "https://github.com/gnustep/libobjc2/commit/d3e81f7435dd25a3fa8caeb9dad15216ff4d1a38.patch")
 sha256sums=('3f72ea4955e3e4671d64c64c339f4947b6112b1b2dd02377c5c982057bbeda04'
             'aaa23146b3c2ec442b5dbf20606020bddd15230041ad738ef3a06e92d13605c3'
-            'fba7d33aa03ee7383b559c5b845063acd16b45396520250849f22559577adcc9')
+            'fba7d33aa03ee7383b559c5b845063acd16b45396520250849f22559577adcc9'
+            'bc6c6ab3fa79aa2242bf8b3480d03329551c73afe7e155f92fff758143bb0fe2')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
 
   patch -p1 -i ${srcdir}/639c676bb8033422539e19a2e2888bdbd06507e5.patch
   patch -p1 -i ${srcdir}/1ff5e1298dd76aa370d5a12b690857f9a47b4b56.patch
+  patch -p1 -i ${srcdir}/d3e81f7435dd25a3fa8caeb9dad15216ff4d1a38.patch
 }
 
 build() {

--- a/mingw-w64-libobjc2/PKGBUILD
+++ b/mingw-w64-libobjc2/PKGBUILD
@@ -10,16 +10,7 @@ arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
 url="https://github.com/gnustep/libobjc2"
 license=('spdx:MIT')
-# libobjc2 depends on the C++ runtime, which is libc++ on clang64 and libstdc++ on mingw64/ucrt64
-if [[ ${MSYSTEM} == CLANG* ]]; then
-  depends=(
-    "${MINGW_PACKAGE_PREFIX}-libc++"
-  )
-else
-  depends=(
-    "${MINGW_PACKAGE_PREFIX}-gcc-libs"
-  )
-fi
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-clang"
              "${MINGW_PACKAGE_PREFIX}-lld"

--- a/mingw-w64-libobjc2/PKGBUILD
+++ b/mingw-w64-libobjc2/PKGBUILD
@@ -20,19 +20,19 @@ source=("https://github.com/gnustep/${_realname}/archive/v${pkgver}/${_realname}
         "https://github.com/gnustep/libobjc2/commit/639c676bb8033422539e19a2e2888bdbd06507e5.patch"
         # Support building on msys/clang64
         "https://github.com/gnustep/libobjc2/commit/1ff5e1298dd76aa370d5a12b690857f9a47b4b56.patch"
-        # MinGW: Update library prefix/suffix
-        "https://github.com/gnustep/libobjc2/commit/d3e81f7435dd25a3fa8caeb9dad15216ff4d1a38.patch")
+        # MinGW: Remove manual setting of library prefix/suffix
+        "https://github.com/gnustep/libobjc2/commit/f983cdbf683925d942dd1d86edcfe4316bf9ed6c.patch")
 sha256sums=('c4c5cede579949249f16736c9b1f85c58c44addb013f59970dcb566d9069152a'
             'aaa23146b3c2ec442b5dbf20606020bddd15230041ad738ef3a06e92d13605c3'
             'fba7d33aa03ee7383b559c5b845063acd16b45396520250849f22559577adcc9'
-            'bc6c6ab3fa79aa2242bf8b3480d03329551c73afe7e155f92fff758143bb0fe2')
+            'd955fcee075af724a97d63f1b325e97ab6c3d018ac38f0597ef3e8c57b0820e2')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
 
   patch -p1 -i ${srcdir}/639c676bb8033422539e19a2e2888bdbd06507e5.patch
   patch -p1 -i ${srcdir}/1ff5e1298dd76aa370d5a12b690857f9a47b4b56.patch
-  patch -p1 -i ${srcdir}/d3e81f7435dd25a3fa8caeb9dad15216ff4d1a38.patch
+  patch -p1 -i ${srcdir}/f983cdbf683925d942dd1d86edcfe4316bf9ed6c.patch
 }
 
 build() {

--- a/mingw-w64-libobjc2/PKGBUILD
+++ b/mingw-w64-libobjc2/PKGBUILD
@@ -7,23 +7,37 @@ pkgver=2.2
 pkgrel=1
 pkgdesc="Objective-C runtime library intended for use with Clang. (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64')
 url="https://github.com/gnustep/libobjc2"
 license=('spdx:MIT')
+# libobjc2 depends on the C++ runtime, which is libc++ on clang64 and libstdc++ on mingw64/ucrt64
+if [[ ${MSYSTEM} == CLANG* ]]; then
+  depends=(
+    "${MINGW_PACKAGE_PREFIX}-libc++"
+  )
+else
+  depends=(
+    "${MINGW_PACKAGE_PREFIX}-gcc-libs"
+  )
+fi
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-clang"
              "${MINGW_PACKAGE_PREFIX}-lld"
              'git')
 source=("https://github.com/gnustep/${_realname}/archive/refs/tags/v${pkgver}.zip"
         # Install runtime files in CMAKE_INSTALL_BINDIR when GNUstep is not installed
-        "https://github.com/gnustep/libobjc2/commit/639c676bb8033422539e19a2e2888bdbd06507e5.patch")
+        "https://github.com/gnustep/libobjc2/commit/639c676bb8033422539e19a2e2888bdbd06507e5.patch"
+        # Support building on msys/clang64
+        "https://github.com/gnustep/libobjc2/commit/1ff5e1298dd76aa370d5a12b690857f9a47b4b56.patch")
 sha256sums=('3f72ea4955e3e4671d64c64c339f4947b6112b1b2dd02377c5c982057bbeda04'
-            'aaa23146b3c2ec442b5dbf20606020bddd15230041ad738ef3a06e92d13605c3')
+            'aaa23146b3c2ec442b5dbf20606020bddd15230041ad738ef3a06e92d13605c3'
+            'fba7d33aa03ee7383b559c5b845063acd16b45396520250849f22559577adcc9')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
 
   patch -p1 -i ${srcdir}/639c676bb8033422539e19a2e2888bdbd06507e5.patch
+  patch -p1 -i ${srcdir}/1ff5e1298dd76aa370d5a12b690857f9a47b4b56.patch
 }
 
 build() {
@@ -36,7 +50,14 @@ build() {
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
-  export LDFLAGS="-fuse-ld=lld -lstdc++ -lgcc_s"
+  case ${MSYSTEM} in
+    MINGW*|UCRT*)
+      export LDFLAGS="-fuse-ld=lld -lstdc++ -lgcc_s"
+      ;;
+    CLANG*)
+      export LDFLAGS="-lc++"
+      ;;
+  esac
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     "${MINGW_PREFIX}"/bin/cmake.exe \
@@ -54,7 +75,13 @@ build() {
 check() {
   cd "${srcdir}/build-${MSYSTEM}"
 
-  "${MINGW_PREFIX}"/bin/cmake.exe --build . --target test
+  declare -a extra_flags
+
+  if [[ ${MSYSTEM} == CLANG* ]]; then
+    extra_flags="-E UnexpectedException*"
+  fi
+
+  "${MINGW_PREFIX}"/bin/ctest.exe $extra_flags
 }
 
 package() {
@@ -62,6 +89,5 @@ package() {
 
   DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
 
-  mv ${pkgdir}${MINGW_PREFIX}/lib/objc.lib ${pkgdir}${MINGW_PREFIX}/lib/objc.dll.a
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-libobjc2/PKGBUILD
+++ b/mingw-w64-libobjc2/PKGBUILD
@@ -15,14 +15,14 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-clang"
              "${MINGW_PACKAGE_PREFIX}-lld"
              'git')
-source=("https://github.com/gnustep/${_realname}/archive/refs/tags/v${pkgver}.zip"
+source=("https://github.com/gnustep/${_realname}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
         # Install runtime files in CMAKE_INSTALL_BINDIR when GNUstep is not installed
         "https://github.com/gnustep/libobjc2/commit/639c676bb8033422539e19a2e2888bdbd06507e5.patch"
         # Support building on msys/clang64
         "https://github.com/gnustep/libobjc2/commit/1ff5e1298dd76aa370d5a12b690857f9a47b4b56.patch"
         # MinGW: Update library prefix/suffix
         "https://github.com/gnustep/libobjc2/commit/d3e81f7435dd25a3fa8caeb9dad15216ff4d1a38.patch")
-sha256sums=('3f72ea4955e3e4671d64c64c339f4947b6112b1b2dd02377c5c982057bbeda04'
+sha256sums=('c4c5cede579949249f16736c9b1f85c58c44addb013f59970dcb566d9069152a'
             'aaa23146b3c2ec442b5dbf20606020bddd15230041ad738ef3a06e92d13605c3'
             'fba7d33aa03ee7383b559c5b845063acd16b45396520250849f22559577adcc9'
             'bc6c6ab3fa79aa2242bf8b3480d03329551c73afe7e155f92fff758143bb0fe2')
@@ -60,7 +60,8 @@ build() {
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       -DCMAKE_C_COMPILER="clang" \
       -DCMAKE_CXX_COMPILER="clang++" \
-      -DTESTS=ON \
+      -DCMAKE_DLL_NAME_WITH_SOVERSION=ON \
+      -DTESTS=OFF \
       "${extra_config[@]}" \
       ../${_realname}-${pkgver}
 
@@ -69,9 +70,10 @@ build() {
 
 check() {
   cd "${srcdir}/build-${MSYSTEM}"
+  "${MINGW_PREFIX}"/bin/cmake -DTESTS=ON ../${_realname}-${pkgver}
+  "${MINGW_PREFIX}"/bin/cmake --build .
 
   declare -a extra_flags
-
   if [[ ${MSYSTEM} == CLANG* ]]; then
     extra_flags="-E UnexpectedException*"
   fi

--- a/mingw-w64-libpreferencepanes/PKGBUILD
+++ b/mingw-w64-libpreferencepanes/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 # Using same naming convention as Ubuntu: https://packages.ubuntu.com/noble/libpreferencepanes1
 pkgname=("${MINGW_PACKAGE_PREFIX}-libpreferencepanes")
 pkgver=1.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc="GNUstep preferences library - runtime library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64')


### PR DESCRIPTION
Upstream libobjc2 now has clang64 support (via https://github.com/gnustep/libobjc2/pull/276).

Cherry-pick that commit and add clang64 to the build matrix for libobjc2.  This cherry-picked commit also fixes the ".dll.a" suffix for library objects, so we no longer need to manually rename that file.