### PR TITLE
openh264: port to meson, fix import library

### DIFF
--- a/mingw-w64-gst-plugins-bad/PKGBUILD
+++ b/mingw-w64-gst-plugins-bad/PKGBUILD
@@ -8,7 +8,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-gst-plugins-bad-libs"
          "${MINGW_PACKAGE_PREFIX}-gst-plugins-bad"
          $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-gst-plugin-opencv"))
 pkgver=1.22.9
-pkgrel=1
+pkgrel=2
 pkgdesc="GStreamer Multimedia Framework Bad Plugins (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')

--- a/mingw-w64-openh264/0001-openh264-install-executables.patch
+++ b/mingw-w64-openh264/0001-openh264-install-executables.patch
@@ -1,0 +1,19 @@
+--- a/codec/console/dec/meson.build
++++ b/codec/console/dec/meson.build
+@@ -11,5 +11,6 @@
+ 
+ decexe = executable('h264dec', cpp_sources,
+   include_directories: decinc,
++  install: true,
+   link_with: [libdecoder, libcommon, libconsole_common],
+   dependencies: deps)
+--- a/codec/console/enc/meson.build
++++ b/codec/console/enc/meson.build
+@@ -4,6 +4,6 @@
+ 
+ encexe = executable('h264enc', cpp_sources,
+   include_directories: [inc, console_common_inc, processing_inc, encoder_inc],
+-
++  install: true,
+   link_with: [libencoder, libcommon, libprocessing, libconsole_common],
+   dependencies: [deps])

--- a/mingw-w64-openh264/PKGBUILD
+++ b/mingw-w64-openh264/PKGBUILD
@@ -5,40 +5,63 @@ _arch="i686"
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.4.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Library for encoding/decoding H264/AVC video streams (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://www.openh264.org/"
 msys2_repository_url="https://github.com/cisco/openh264"
-license=("BSD")
-makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
-             $([[ ${MSYSTEM_CARCH} == aarch64 ]] || echo "${MINGW_PACKAGE_PREFIX}-nasm")
-             "${MINGW_PACKAGE_PREFIX}-pkgconf")
+license=('spdx:BSD-2-Clause')
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+   $([[ ${MSYSTEM_CARCH} == aarch64 ]] || echo "${MINGW_PACKAGE_PREFIX}-nasm")
+  "${MINGW_PACKAGE_PREFIX}-meson"
+  "${MINGW_PACKAGE_PREFIX}-ninja"
+  "${MINGW_PACKAGE_PREFIX}-pkgconf"
+)
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
-options=('strip' 'staticlibs')
-source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/cisco/openh264/archive/v${pkgver}.tar.gz")
-sha256sums=('8ffbe944e74043d0d3fb53d4a2a14c94de71f58dbea6a06d0dc92369542958ea')
+source=(
+  "${_realname}-${pkgver}.tar.gz"::"https://github.com/cisco/openh264/archive/v${pkgver}.tar.gz"
+  "0001-openh264-install-executables.patch"
+)
+sha256sums=('8ffbe944e74043d0d3fb53d4a2a14c94de71f58dbea6a06d0dc92369542958ea'
+            '0b1246577b257560b6fae782dd93eabeedcb8d9c87c20d6d7732b79ba14c38d6')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+  patch -p1 -i "${srcdir}/0001-openh264-install-executables.patch"
+}
 
 build() {
-  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
-  cp -rf "$srcdir/${_realname}-${pkgver}" "${srcdir}/build-${MINGW_CHOST}"
-  cd "${srcdir}/build-${MINGW_CHOST}"
-  if [[ "${MINGW_CHOST}" == "i686-w64-mingw32" ]]; then
-    _arch="i686"
-  elif [[ "${MINGW_CHOST}" == "aarch64-w64-mingw32" ]]; then
-    _arch="arm64"
-  else
-    _arch="x86_64"
-  fi
-  make ARCH=${_arch} AR=ar OS=mingw_nt
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    ${MINGW_PREFIX}/bin/meson.exe setup \
+      --prefix="${MINGW_PREFIX}" \
+      --default-library=static \
+      --wrap-mode=nodownload \
+      --auto-features=enabled \
+      --buildtype=plain \
+      -Dtests=disabled \
+      build-${MSYSTEM}-static \
+      ${_realname}-${pkgver}
+
+  ${MINGW_PREFIX}/bin/meson.exe compile -C build-${MSYSTEM}-static
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    ${MINGW_PREFIX}/bin/meson.exe setup \
+      --prefix="${MINGW_PREFIX}" \
+      --default-library=shared \
+      --wrap-mode=nodownload \
+      --auto-features=enabled \
+      --buildtype=plain \
+      -Dtests=disabled \
+      build-${MSYSTEM}-shared \
+      ${_realname}-${pkgver}
+
+  ${MINGW_PREFIX}/bin/meson.exe compile -C build-${MSYSTEM}-shared
 }
 
 package() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
-  make ARCH=${_arch} DESTDIR="${pkgdir}" PREFIX=${MINGW_PREFIX} install
-  install -Dm755 h264dec.exe "${pkgdir}${MINGW_PREFIX}"/bin/h264dec.exe
-  install -Dm755 h264enc.exe "${pkgdir}${MINGW_PREFIX}"/bin/h264enc.exe
-
-  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  ${MINGW_PREFIX}/bin/meson.exe install -C build-${MSYSTEM}-static --destdir "${pkgdir}"
+  ${MINGW_PREFIX}/bin/meson.exe install -C build-${MSYSTEM}-shared --destdir "${pkgdir}"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
Previously, all symbols were exported from import library. The meson build system now uses proper DEF to export symbols.

This issue was reported by @1480c1 ❤️ 