### PR TITLE
mingw-w64-gnustep-base: add patches to fix config check failure for thread-safe +initialize

### DIFF
--- a/mingw-w64-gnustep-base/PKGBUILD
+++ b/mingw-w64-gnustep-base/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gnustep-base
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.29.0
-pkgrel=2
+pkgrel=3
 pkgdesc="GNUstep Base library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64')
@@ -32,11 +32,18 @@ source=("https://github.com/gnustep/libs-base/releases/download/base-${pkgver//.
         "https://github.com/gnustep/libs-base/commit/2039840e0e1f013f2d73deb6e083b88987cfa6af.patch"
         # MinGW: Add dllimport/dllexport attributes when compiling with clang
         # https://github.com/gnustep/libs-base/pull/363, merged
-        "https://github.com/gnustep/libs-base/commit/9041539ea25274cf92b7a3489ed5b03762d4af3f.patch")
+        "https://github.com/gnustep/libs-base/commit/9041539ea25274cf92b7a3489ed5b03762d4af3f.patch"
+        # Fix incompatible function pointer types in config check
+        # https://github.com/gnustep/libs-base/pull/303, merged
+        'https://github.com/gnustep/libs-base/commit/fe863c981d61e50e3ea9cbe7f2b23135c1f2faf1.patch'
+        # Fix undeclared function in config check
+        'https://github.com/gnustep/libs-base/commit/87fc1f5e2e4094f49b330bece89ba8aa4436c684.patch')
 sha256sums=('fa58eda665c3e0b9c420dc32bb3d51247a407c944d82e5eed1afe8a2b943ef37'
             'a7a3bad7bda7e63599677294f0ee0b2273b680168b6fd9b4b4c5618ba8a184d5'
             '2a325471df00494a2ff7b87a954e7ecee2e45c31296636326880a78078fa249f'
-            'ceb7cfc82ff3801e82e12b791f18c04c42ba3ab9ee0cc79ee453c157bf89d8d0')
+            'ceb7cfc82ff3801e82e12b791f18c04c42ba3ab9ee0cc79ee453c157bf89d8d0'
+            '0026c621970d40f80eb007159ed07ec471cca2d06ca31c245912ac6ca0a95656'
+            '5673a594ddcd5010d099d8878ec20f3895914e96a00fe00bbf8101a507f323c3')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -44,6 +51,8 @@ prepare() {
   patch -p1 -i ${srcdir}/37913d006d96a6bdcb963f4ca4889888dcce6094.patch
   patch -p1 -i ${srcdir}/2039840e0e1f013f2d73deb6e083b88987cfa6af.patch
   patch -p1 -i ${srcdir}/9041539ea25274cf92b7a3489ed5b03762d4af3f.patch
+  patch -p1 -i ${srcdir}/fe863c981d61e50e3ea9cbe7f2b23135c1f2faf1.patch
+  patch -p1 -i ${srcdir}/87fc1f5e2e4094f49b330bece89ba8aa4436c684.patch
 }
 
 build() {


### PR DESCRIPTION
Adds the following patches from the main branch of [gnustep/libs-base](https://github.com/gnustep/libs-base) to allow the config check [gnustep/libs-base/config/config.initialize.m](https://github.com/gnustep/libs-base/blob/master/config/config.initialize.m) to build and pass during the gnustep-base package build:

* https://github.com/gnustep/libs-base/commit/fe863c981d61e50e3ea9cbe7f2b23135c1f2faf1
* https://github.com/gnustep/libs-base/commit/87fc1f5e2e4094f49b330bece89ba8aa4436c684

The practical effect is the build process will detect that it is building against a runtime with thread-safe +initialize, and builds linking against gnustep-base in the msys2 environment will no longer print this warning message when they become multi-threaded:
```
WARNING your program is becoming multi-threaded, but you are using an ObjectiveC runtime library which does not have a thread-safe implementation of the +initialize method. Please see README.initialize for more information.
```
