### PR TITLE
qtwebkit: restore mingw32; fix build with libxml2 2.12.0

### DIFF
--- a/mingw-w64-qtwebkit/PKGBUILD
+++ b/mingw-w64-qtwebkit/PKGBUILD
@@ -5,10 +5,10 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _pkgver=5.212.0-alpha4
 pkgver=${_pkgver//-/}
-pkgrel=17
+pkgrel=18
 pkgdesc="Webkit module for Qt5 (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 url="https://github.com/qtwebkit/qtwebkit/wiki"
 msys2_references=(
   'archlinux: qt5-webkit'
@@ -52,7 +52,8 @@ source=(https://github.com/annulen/webkit/releases/download/qtwebkit-${_pkgver}/
         0601-missing-include.patch
         d92b11fea65364fefa700249bd3340e0cd4c5b31.patch
         6e18844035d9c5e25d770ed817b858c2423d894b.patch
-        4e1f209f21c3958e5a8d3a0646dccf9e429ca7e4.patch)
+        4e1f209f21c3958e5a8d3a0646dccf9e429ca7e4.patch
+        https://github.com/movableink/webkit/commit/df49bfc4c93001970c9b9266903ee7e8804fb576.patch)
 sha256sums=('9ca126da9273664dd23a3ccd0c9bebceb7bb534bddd743db31caf6a5a6d4a9e6'
             'ed80d9a31cb1f9565841e3e206d76810881b7fce30210022270bd19694a9c906'
             'b9e39597d140f3fc40d07ae0f0eea0cbabd7b16d8e430d26445ae3063b8ad055'
@@ -71,7 +72,8 @@ sha256sums=('9ca126da9273664dd23a3ccd0c9bebceb7bb534bddd743db31caf6a5a6d4a9e6'
             '83e9ffd3e74f6b533d5a3f5929e7918d31da690c66407cd1119f50d178fa94a0'
             'cc5a2b762426e9cda5a3ae056bba266b5f775ee75c0590913839c255d5f10db0'
             '49d4b19885806f82bff65b09e575488de176e63d91fad4545fda520aec96af82'
-            '8e5f2d183c05d740d5eb1c3a191796bfb43743a462c5a0341f8171202f048af7')
+            '8e5f2d183c05d740d5eb1c3a191796bfb43743a462c5a0341f8171202f048af7'
+            '82716a6d9a491501c6ecc66598adce37278498d9fab1c9610354ebf83d765ad9')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -112,6 +114,10 @@ prepare() {
     d92b11fea65364fefa700249bd3340e0cd4c5b31.patch \
     6e18844035d9c5e25d770ed817b858c2423d894b.patch \
     4e1f209f21c3958e5a8d3a0646dccf9e429ca7e4.patch
+
+  # Fix build with libxml2 2.12.0
+  apply_patch_with_msg \
+    df49bfc4c93001970c9b9266903ee7e8804fb576.patch
 
   # MSYS2 gperf cannot handle \r\n.
   find . -name "*.gperf" -exec dos2unix "{}" \;


### PR DESCRIPTION
See https://github.com/msys2/MINGW-packages/issues/20090#issuecomment-1950335792