### PR TITLE
czkawka: update to 7.0.0

### DIFF
--- a/mingw-w64-czkawka/PKGBUILD
+++ b/mingw-w64-czkawka/PKGBUILD
@@ -3,25 +3,22 @@
 _realname=czkawka
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-cli"
-         # https://github.com/qarmin/czkawka/issues/1148
-         $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-${_realname}-gui"))
-pkgver=6.1.0
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-gui")
+pkgver=7.0.0
 pkgrel=1
 pkgdesc="Multi functional app to find duplicates, empty folders, similar images etc (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://github.com/qarmin/czkawka'
 license=('spdx:MIT')
-depends=("${MINGW_PACKAGE_PREFIX}-bzip2"
-         "${MINGW_PACKAGE_PREFIX}-cairo"
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-gdk-pixbuf2"
+         "${MINGW_PACKAGE_PREFIX}-glib2"
          "${MINGW_PACKAGE_PREFIX}-gtk4"
-         "${MINGW_PACKAGE_PREFIX}-hicolor-icon-theme"
-         "${MINGW_PACKAGE_PREFIX}-libheif"
-         "${MINGW_PACKAGE_PREFIX}-pango")
+         "${MINGW_PACKAGE_PREFIX}-libheif")
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust" "${MINGW_PACKAGE_PREFIX}-pkgconf")
-source=("https://github.com/qarmin/czkawka/archive/refs/tags/${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('63e64c717a93b3d5210d6a4718833fdbf3ad7b28c9b74a243d9de3ab1ee6ad5a')
+source=("https://github.com/qarmin/czkawka/archive/${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('ce7d072056dedc4f2ca4d3647dc786ba071d4f3c58e79415da18d7dafd62e87b')
 noextract=("${_realname}-${pkgver}.tar.gz")
 
 prepare() {
@@ -41,25 +38,24 @@ build() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
   export PKG_CONFIG_PATH="${MINGW_PREFIX}/lib/pkgconfig"
-  cargo build --bin czkawka_cli --release --features heif
-  cargo build --bin czkawka_gui --release --features heif
+  cargo build --bin czkawka_cli --release --features "heif libraw"
+  cargo build --bin czkawka_gui --release --features "heif libraw"
 }
 
 check() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
-  cargo test --bin czkawka_cli --release --features heif
-  cargo test --bin czkawka_gui --release --features heif
+  cargo test --bin czkawka_cli --release --features "heif libraw"
+  cargo test --bin czkawka_gui --release --features "heif libraw"
 }
 
 package_czkawka-cli() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
-  depends=("${MINGW_PACKAGE_PREFIX}-bzip2" "${MINGW_PACKAGE_PREFIX}-libheif")
+  depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-libheif")
   pkgdesc+=" (CLI)"
 
   install -Dm755 target/release/czkawka_cli.exe "${pkgdir}${MINGW_PREFIX}/bin/czkawka_cli.exe"
-  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/czkawka-cli/LICENSE"
 }
 
 package_czkawka-gui() {
@@ -68,7 +64,6 @@ package_czkawka-gui() {
   pkgdesc+=" (Desktop App)"
 
   install -Dm755 target/release/czkawka_gui.exe "${pkgdir}${MINGW_PREFIX}/bin/czkawka_gui.exe"
-  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/czkawka-gui/LICENSE"
 }
 
 # template start; name=mingw-w64-splitpkg-wrappers; version=1.0;


### PR DESCRIPTION
- czkawka_gui works on CLANG*
- new feature `libraw`
- dependencies cleanup (but anyway they are installed with gtk4)