### PR TITLE
gimp3: Update to 2.99.18

### DIFF
--- a/mingw-w64-gimp3/0003-dont-install-external-files.patch
+++ b/mingw-w64-gimp3/0003-dont-install-external-files.patch
@@ -1,0 +1,11 @@
+--- gimp-2.99.18/data/meson.build.orig	2024-02-20 07:52:22.874149700 +0100
++++ gimp-2.99.18/data/meson.build	2024-02-20 07:52:26.173111900 +0100
+@@ -28,7 +28,7 @@
+ )
+ 
+ # Fix iso-codes warning (Local-Native only)
+-if platform_windows and not meson.is_cross_build()
++if platform_windows and not meson.is_cross_build() and false
+    install_data(
+      join_paths(isocodes_location, 'iso_639.xml'),
+      install_dir: join_paths(get_option('datadir'), 'xml/iso-codes')

--- a/mingw-w64-gimp3/PKGBUILD
+++ b/mingw-w64-gimp3/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=gimp3
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.99.16
-pkgrel=10
+pkgver=2.99.18
+pkgrel=1
 pkgdesc="GNU Image Manipulation Program (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -20,8 +20,10 @@ depends=("${MINGW_PACKAGE_PREFIX}-aalib"
          "${MINGW_PACKAGE_PREFIX}-babl"
          "${MINGW_PACKAGE_PREFIX}-brotli"
          "${MINGW_PACKAGE_PREFIX}-cairo"
+         "${MINGW_PACKAGE_PREFIX}-cfitsio"
          "${MINGW_PACKAGE_PREFIX}-drmingw"
          "${MINGW_PACKAGE_PREFIX}-gegl"
+         "${MINGW_PACKAGE_PREFIX}-gettext-runtime"
          "${MINGW_PACKAGE_PREFIX}-gexiv2"
          "${MINGW_PACKAGE_PREFIX}-ghostscript"
          "${MINGW_PACKAGE_PREFIX}-gi-docgen"
@@ -38,7 +40,9 @@ depends=("${MINGW_PACKAGE_PREFIX}-aalib"
          "${MINGW_PACKAGE_PREFIX}-lensfun"
          "${MINGW_PACKAGE_PREFIX}-libarchive"
          "${MINGW_PACKAGE_PREFIX}-libheif"
+         "${MINGW_PACKAGE_PREFIX}-libiff"
          "${MINGW_PACKAGE_PREFIX}-libjxl"
+         "${MINGW_PACKAGE_PREFIX}-libilbm"
          "${MINGW_PACKAGE_PREFIX}-libmng"
          "${MINGW_PACKAGE_PREFIX}-libmypaint"
          "${MINGW_PACKAGE_PREFIX}-libspiro"
@@ -59,18 +63,17 @@ depends=("${MINGW_PACKAGE_PREFIX}-aalib"
          "${MINGW_PACKAGE_PREFIX}-xpm-nox")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-meson"
+             "${MINGW_PACKAGE_PREFIX}-gettext-tools"
              "${MINGW_PACKAGE_PREFIX}-qoi")
 source=("https://download.gimp.org/pub/gimp/v2.99/gimp-${pkgver}.tar.xz"
         0001-clang-rc-files-fix.patch
         0002-skip-test-env.patch
-        luajit.interp
-        gimp-script-fu-interpreter.interp
+        0003-dont-install-external-files.patch
         )
-sha256sums=('6b4496edee447339f923276755247eadb64ec40d8aec241d06b62d1a6eb6508d'
+sha256sums=('8c1bb7a94ac0d4d0cde4d701d8b356387c2ecd87abbd35bbf7d222d40f6ddb6e'
             '54b3abc136b78fd2ae9b7d2acd202fb91bf3b6c248b131f1629ca50ef2493fbe'
             '511a2a969d1ff3254b4f2453cdfbc3a86a60e2379adf9f6ed5735454a45ef6ee'
-            'ee8fd9e26675c7c2e477f280f3aad20cfa66d0a2da0cbceb7b2448f4bb8f8d37'
-            '49d7ac87f2f437e89bb43e9be749c206d4c51bd9245133ffb1071aad4592ffb0')
+            'd0181cc5e68ade9f42869c0f147deec7da15cc9c0a7d9b78862ef02fce081688')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -84,14 +87,13 @@ prepare() {
   cd "${srcdir}/gimp-${pkgver}"
   apply_patch_with_msg \
     0001-clang-rc-files-fix.patch \
-    0002-skip-test-env.patch
+    0002-skip-test-env.patch \
+    0003-dont-install-external-files.patch
 }
 
 build() {
   mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
 
-  CFLAGS+=" -Wno-error=int-conversion -Wno-incompatible-function-pointer-types" \
-  CXXFLAGS+=" -Wno-error=int-conversion -Wno-incompatible-function-pointer-types" \
   MSYS2_ARG_CONV_EXCL="--prefix=" \
   ${MINGW_PREFIX}/bin/meson.exe setup \
     --buildtype=plain \
@@ -110,6 +112,7 @@ build() {
     -Dlinux-input=disabled \
     -Dxcursor=disabled \
     -Dwin32-debug-console=true \
+    -Denable-default-bin=disabled \
     ../gimp-${pkgver}
 
   ${MINGW_PREFIX}/bin/meson.exe compile
@@ -123,11 +126,12 @@ package() {
   sed -e "s|\=.*|\=python3w.exe|g" -i "${pkgdir}${MINGW_PREFIX}"/lib/gimp/2.99/interpreters/pygimp.interp
   sed -e "s|::python3|::python3w.exe|g" -i "${pkgdir}${MINGW_PREFIX}"/lib/gimp/2.99/interpreters/pygimp.interp
 
-  # Create the scm scripts interpreter path (Only created by the installer in Windows)
-  install -Dm644 "${srcdir}"/gimp-script-fu-interpreter.interp "${pkgdir}${MINGW_PREFIX}"/lib/gimp/2.99/interpreters/gimp-script-fu-interpreter.interp
-
-  # Create the Lua scripts interpreter path (Only created by the installer in Windows)
-  install -Dm644 "${srcdir}"/luajit.interp "${pkgdir}${MINGW_PREFIX}"/lib/gimp/2.99/interpreters/lua.interp
+  # enable-default-bin uses symlinks, so disable it and copy manually instead
+  for _prog in "${pkgdir}${MINGW_PREFIX}/bin/"*-2.99.exe; do
+    _baseprog=$(basename "$_prog")
+    install -Dm755 "${_prog}" \
+      "${pkgdir}${MINGW_PREFIX}/bin/${_baseprog//-2.99/}"
+  done
 
   rm -f "${pkgdir}${MINGW_PREFIX}/lib/gimp/2.99/modules/*.dll.a"
 

--- a/mingw-w64-gimp3/gimp-script-fu-interpreter.interp
+++ b/mingw-w64-gimp3/gimp-script-fu-interpreter.interp
@@ -1,4 +1,0 @@
-gimp-script-fu-interpreter=gimp-script-fu-interpreter-3.0.exe
-gimp-script-fu-interpreter-3.0=gimp-script-fu-interpreter-3.0.exe
-/usr/bin/gimp-script-fu-interpreter=gimp-script-fu-interpreter-3.0.exe
-:ScriptFu:E::scm::gimp-script-fu-interpreter-3.0.exe:

--- a/mingw-w64-gimp3/luajit.interp
+++ b/mingw-w64-gimp3/luajit.interp
@@ -1,5 +1,0 @@
-lua=luajit.exe
-luajit=luajit.exe
-/usr/bin/luajit=luajit.exe
-/usr/bin/lua=luajit.exe
-:Lua:E::lua::luajit.exe:


### PR DESCRIPTION
* remove .interp files, seem to be installed by default now
* add new deps
* fix gimp installing system files again for some reason
* Remove compiler flags for ignoring errors, seems to be fixed now
* Disable enable-default-bin, to avoid symlinks