### PR TITLE
libobjc2: conflicts with the GCC Objective C runtime

### DIFF
--- a/mingw-w64-libobjc2/PKGBUILD
+++ b/mingw-w64-libobjc2/PKGBUILD
@@ -3,7 +3,9 @@
 _realname=libobjc2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-conflicts=("${MINGW_PACKAGE_PREFIX}-gcc-objc")
+if [[ ${MSYSTEM} != CLANG* ]]; then
+  conflicts=("${MINGW_PACKAGE_PREFIX}-gcc-objc")
+fi
 pkgver=2.2
 pkgrel=3
 pkgdesc="Objective-C runtime library intended for use with Clang. (mingw-w64)"

--- a/mingw-w64-libobjc2/PKGBUILD
+++ b/mingw-w64-libobjc2/PKGBUILD
@@ -3,8 +3,9 @@
 _realname=libobjc2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+conflicts=("${MINGW_PACKAGE_PREFIX}-gcc-objc")
 pkgver=2.2
-pkgrel=2
+pkgrel=3
 pkgdesc="Objective-C runtime library intended for use with Clang. (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')


### PR DESCRIPTION
Both libobjc2 and gcc-objc provide an Objective C runtime, so these packages conflict with each other.