### PR TITLE
gitui: update to 0.25.0

### DIFF
--- a/mingw-w64-gitui/PKGBUILD
+++ b/mingw-w64-gitui/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gitui
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.24.3
+pkgver=0.25.0
 pkgrel=1
 pkgdesc='Blazing fast terminal-ui for git written in Rust (mingw-w64)'
 msys2_references=(
@@ -11,13 +11,15 @@ msys2_references=(
 )
 url='https://github.com/extrawurst/gitui'
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 license=('spdx:MIT')
-depends=("${MINGW_PACKAGE_PREFIX}-zlib")
+depends=("${MINGW_PACKAGE_PREFIX}-libgit2")
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
-             "${MINGW_PACKAGE_PREFIX}-python")
+             "${MINGW_PACKAGE_PREFIX}-python"
+             "${MINGW_PACKAGE_PREFIX}-pkgconf"
+             "${MINGW_PACKAGE_PREFIX}-openssl")
 source=("https://github.com/extrawurst/gitui/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('a5fc6b52a4db0037c3351b9743af49c8bb9ccff4dda5bdb064bab9e59f68fde2')
+sha256sums=('711fc5e72fe02e6bc37dc71ec33c2fdf43771e680140a2cc718b2ae5a9fc3174')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -32,21 +34,38 @@ prepare() {
 build() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
-  cargo build --frozen --release
+  OPENSSL_NO_VENDOR=1 \
+  GIT_DIR=/dev/null \
+  cargo build \
+    --frozen \
+    --release \
+    --no-default-features \
+    --features "ghemoji regex-fancy trace-libgit"
 }
 
 check() {
   cd "${srcdir}/${_realname}-${pkgver}"
-  cargo test --frozen --release
+
+  OPENSSL_NO_VENDOR=1 \
+  GIT_DIR=/dev/null \
+  cargo test \
+    --frozen \
+    --release \
+    --no-default-features \
+    --features "ghemoji regex-fancy trace-libgit"
 }
 
 package() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
+  OPENSSL_NO_VENDOR=1 \
+  GIT_DIR=/dev/null \
   cargo install \
     --frozen \
     --offline \
     --no-track \
+    --no-default-features \
+    --features "ghemoji regex-fancy trace-libgit" \
     --path . \
     --root "${pkgdir}${MINGW_PREFIX}"
 


### PR DESCRIPTION
- local build showed that libgit2 dynamic lib is used (zlib not)
- remove vendor-openssl feature which broke clangarm64 build