### PR TITLE
gettext: revert upstream adding a printf format attribute

### DIFF
--- a/mingw-w64-gettext/0024-disable-gnu-format.patch
+++ b/mingw-w64-gettext/0024-disable-gnu-format.patch
@@ -1,0 +1,16 @@
+--- gettext-0.22.5/gettext-runtime/intl/libgnuintl.in.h.orig	2024-02-21 17:32:21.000000000 +0100
++++ gettext-0.22.5/gettext-runtime/intl/libgnuintl.in.h	2024-02-23 07:22:27.934079300 +0100
+@@ -134,6 +134,13 @@
+ # define _INTL_ATTRIBUTE_FORMAT(spec)
+ #endif
+ 
++/* gettext printf functions allow ms specific format specifiers like %I64u
++   which error out with __gnu_printf__, so revert this for now on Windows */
++#ifdef __MINGW32__
++#undef _INTL_ATTRIBUTE_FORMAT
++#define _INTL_ATTRIBUTE_FORMAT(spec)
++#endif
++
+ /* _INTL_ATTRIBUTE_SPEC_PRINTF_STANDARD
+    An __attribute__ __format__ specifier for a function that takes a format
+    string and arguments, where the format string directives are the ones

--- a/mingw-w64-gettext/PKGBUILD
+++ b/mingw-w64-gettext/PKGBUILD
@@ -5,7 +5,7 @@ _realname=gettext
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-runtime" "${MINGW_PACKAGE_PREFIX}-${_realname}-tools")
 pkgver=0.22.5
-pkgrel=1
+pkgrel=2
 pkgdesc="GNU internationalization library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -23,7 +23,8 @@ source=(https://ftp.gnu.org/pub/gnu/${_realname}/${_realname}-${pkgver}.tar.gz{,
         gettext-0.22-disable-libtextstyle.patch
         0021-replace-fsync.patch
         0022-libasprintf.patch
-        0023-gnulib.patch)
+        0023-gnulib.patch
+        0024-disable-gnu-format.patch)
 sha256sums=('ec1705b1e969b83a9f073144ec806151db88127f5e40fe5a94cb6c8fa48996a0'
             'SKIP'
             'cbc2f533012d646521afa20f8b256917fce040741ff42cf53fb6dd7123a6670a'
@@ -31,7 +32,8 @@ sha256sums=('ec1705b1e969b83a9f073144ec806151db88127f5e40fe5a94cb6c8fa48996a0'
             'a28a27192f336f0b0908bdbf840d3b19d7b587c4ac52cad635cb43e95eb3c78d'
             '380dbddee2f9e2feee4c1435e8a942b5d11d0125e60c3350ebb10c19b19011aa'
             'c354f6a7021069c99b90f1c6d6f6a4ccf40a01e9f6742b866df2b5a7286cb868'
-            '4f34906eeb535c74fa3f2936729b59c36d05d503a274e2b850fc770263c60b46')
+            '4f34906eeb535c74fa3f2936729b59c36d05d503a274e2b850fc770263c60b46'
+            'ce7ccf6dd3a492cab322253cd67310899b546eccc25821c25cbc047a1a984633')
 validpgpkeys=('462225C3B46F34879FC8496CD605848ED7E69871'  # Daiki Ueno
               '9001B85AF9E1B83DF1BDA942F5BE8B267C6A406D') # Bruno Haible
 
@@ -59,6 +61,11 @@ prepare() {
     0021-replace-fsync.patch \
     0022-libasprintf.patch \
     0023-gnulib.patch
+
+  # https://github.com/msys2/MINGW-packages/pull/19047#issuecomment-1960769618
+  # https://git.savannah.gnu.org/gitweb/?p=gettext.git;a=commitdiff;h=eef429bbccbff2bca08bafc2ff76f7ec2be93d2a
+  apply_patch_with_msg \
+    0024-disable-gnu-format.patch
 
   libtoolize --automake --copy --force
   WANT_AUTOMAKE=latest ./autogen.sh --skip-gnulib


### PR DESCRIPTION
It doesn't match what the gettext functions allow, so revert to avoid build warnings for things like %I64u