### PR TITLE
gdal: enable libjxl and openexr

### DIFF
--- a/mingw-w64-gdal/PKGBUILD
+++ b/mingw-w64-gdal/PKGBUILD
@@ -9,7 +9,7 @@ pkgbase=mingw-w64-${_realname,,}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=3.8.3
-pkgrel=1
+pkgrel=2
 pkgdesc="A translator library for raster geospatial data formats (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -48,6 +48,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libheif"
          "${MINGW_PACKAGE_PREFIX}-libiconv"
          "${MINGW_PACKAGE_PREFIX}-libjpeg"
+         "${MINGW_PACKAGE_PREFIX}-libjxl"
          "${MINGW_PACKAGE_PREFIX}-libkml"
          "${MINGW_PACKAGE_PREFIX}-libpng"
          "${MINGW_PACKAGE_PREFIX}-libmariadbclient"
@@ -57,6 +58,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libxml2"
          "${MINGW_PACKAGE_PREFIX}-lz4"
          "${MINGW_PACKAGE_PREFIX}-netcdf"
+         "${MINGW_PACKAGE_PREFIX}-openexr"
          "${MINGW_PACKAGE_PREFIX}-openjpeg2"
          "${MINGW_PACKAGE_PREFIX}-openssl"
          "${MINGW_PACKAGE_PREFIX}-pcre2"


### PR DESCRIPTION
Skipped podofo for now because of licensing - could be done as optional and dynamic only I guess if there is a request for it...