### PR TITLE
libpng: Update to 1.6.43

### DIFF
--- a/mingw-w64-libpng/PKGBUILD
+++ b/mingw-w64-libpng/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libpng
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.6.42
+pkgver=1.6.43
 _apngver=1.6.40
 pkgrel=1
 arch=('any')
@@ -16,17 +16,23 @@ license=('custom')
 url="http://www.libpng.org/pub/png/libpng.html"
 msys2_repository_url='https://github.com/pnggroup/libpng'
 options=('strip' '!libtool' 'staticlibs')
+# apng: https://github.com/mozilla/gecko-dev/commits/master/media/libpng/apng.patch
 source=("https://downloads.sourceforge.net/sourceforge/libpng/${_realname}-${pkgver}.tar.xz"
-        "https://downloads.sourceforge.net/project/libpng-apng/libpng16/${_apngver}/${_realname}-${_apngver}-apng.patch.gz")
-sha256sums=('c919dbc11f4c03b05aba3f8884d8eb7adfe3572ad228af972bb60057bdb48450'
-            '0a3ca46482938d8d6c722662bed2c7ee0c65a1b5624444b3ced21ad8d356db2f')
+        "https://raw.githubusercontent.com/mozilla/gecko-dev/ee4f298265cc851314bf431fb0efccba6af15f74/media/libpng/apng.patch")
+sha256sums=('6a5ca0652392a2d7c9db2ae5b40210843c0bbc081cbd410825ab00cc59f14a6c'
+            '2a65fa19b126e85ad14ef1d1d9fc5079193e92af6b8db4454e3a875da5fdb79d')
 validpgpkeys=('8048643BA2C840F4F92A195FF54984BFA16C640F')  # Glenn Randers-Pehrson (mozilla) <glennrp+bmo@gmail.com>
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
   # Add animated PNG (apng) support
-  patch -p1 -i "${srcdir}/${_realname}-${_apngver}-apng.patch"
+  # Some context as to why this is here: https://bugs.gentoo.org/824018
+  # Arch dropped it some time ago:
+  # https://gitlab.archlinux.org/archlinux/packaging/packages/libpng/-/commit/bc95b152de9709a21c2938d5a
+  # Maybe we should too?
+  patch -p1 -i "${srcdir}/apng.patch"
+
   # autoreconf to get updated libtool files with clang support
   autoreconf -fiv
 }


### PR DESCRIPTION
switch to mozilla for the apng patch, since the patch set on sourceforge is lagging behind and no longer applies.