### PR TITLE
new package: mingw-w64-ardour

### DIFF
--- a/mingw-w64-ardour/0001-mingw-link-fixes.patch
+++ b/mingw-w64-ardour/0001-mingw-link-fixes.patch
@@ -1,0 +1,44 @@
+Link fixes for mingw build.
+
+1. fftw3f_threads is available in the MSYS2 fftw package, so allow it
+   on mingw — fftwf_make_planner_thread_safe is otherwise unresolved.
+
+2. libs/ardour/lv2_plugin.cc directly calls serd_env_* / sratom_set_env,
+   but lilv-0.pc only exposes the public lilv-0 lib for shared linking.
+   Add SERD/SRATOM to libardour's uselib when LILV is enabled so the
+   dll can link them itself.
+
+--- a/gtk2_ardour/wscript
++++ b/gtk2_ardour/wscript
+@@ -687,7 +687,7 @@ def build(bld):
+         obj.source += [ 'lv2_plugin_ui.cc' ]
+         obj.use += [ 'SUIL' ]
+
+-    if bld.is_defined('HAVE_FFTW35F') and bld.env['build_target'] != 'mingw' and bld.env['build_target'] != 'msvc':
++    if bld.is_defined('HAVE_FFTW35F') and bld.env['build_target'] != 'msvc':
+         bld.env['LIB_FFTW3F'] += ['fftw3f_threads']
+
+     if bld.is_defined('NEED_INTL'):
+--- a/libs/audiographer/wscript
++++ b/libs/audiographer/wscript
+@@ -40,7 +40,7 @@
+                                    and bld.is_defined('HAVE_GLIBMM')
+                                    and bld.is_defined('HAVE_GTHREAD'))
+
+-    if bld.is_defined('HAVE_FFTW35F') and bld.env['build_target'] != 'mingw' and bld.env['build_target'] != 'msvc':
++    if bld.is_defined('HAVE_FFTW35F') and bld.env['build_target'] != 'msvc':
+         bld.env['LIB_FFTW3F'] += ['fftw3f_threads']
+
+     audiographer_sources = [
+--- a/libs/ardour/wscript
++++ b/libs/ardour/wscript
+@@ -437,6 +437,9 @@ def build(bld):
+     if bld.is_defined('HAVE_LILV') :
+         obj.source += ['lv2_plugin.cc', 'lv2_evbuf.cc', 'uri_map.cc']
+         obj.uselib += ['LILV']
++        # lv2_plugin.cc calls serd_env_* / sratom_set_env directly; lilv-0.pc
++        # only exposes -llilv-0 for shared builds, so link these explicitly.
++        obj.uselib += ['SERD', 'SRATOM']
+         if bld.is_defined('HAVE_SUIL'):
+             obj.use += [ 'libsuil' ]
+

--- a/mingw-w64-ardour/0002-strip-srcdir-from-buildinfo.patch
+++ b/mingw-w64-ardour/0002-strip-srcdir-from-buildinfo.patch
@@ -1,0 +1,28 @@
+Strip absolute source-root path from embedded build-info.
+
+tools/autowaf.py prepends `-I<abspath-of-srcdir>` to CFLAGS/CXXFLAGS,
+and wscript then dumps the full flag list into libs/ardour/config_text.cc
+(the runtime `ardour_config_info` string compiled into libardour). That
+leaks the build-host srcdir into the shipped DLL, which makepkg's QA
+check flags as a $srcdir reference.
+
+Filter the abs-path -I entries out before writing the buildinfo string.
+The compile-time -I flag is left intact; only the embedded build-info
+report is sanitized.
+
+--- a/wscript
++++ b/wscript
+@@ -1567,8 +1567,11 @@
+     write_config_text('Mac ppc Architecture',  opts.ppc)
+     write_config_text('Mac arm64 Architecture',  opts.arm64)
+     config_text.write("\\n\\\n")
+-    write_config_text('C compiler flags',      conf.env['CFLAGS'])
+-    write_config_text('C++ compiler flags',    conf.env['CXXFLAGS'])
++    _abs_src = os.path.abspath('.')
++    def _strip_srcdir(flags):
++        return [f for f in flags if f != '-I' + _abs_src]
++    write_config_text('C compiler flags',      _strip_srcdir(conf.env['CFLAGS']))
++    write_config_text('C++ compiler flags',    _strip_srcdir(conf.env['CXXFLAGS']))
+     write_config_text('Linker flags',          conf.env['LINKFLAGS'])
+
+     config_text.write ('";\n}\n')

--- a/mingw-w64-ardour/PKGBUILD
+++ b/mingw-w64-ardour/PKGBUILD
@@ -1,0 +1,135 @@
+# Contributor: Kreijstal <rainb@tfwno.gf>
+
+_realname=ardour
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=9.2
+_commit=ad35364cd9de4f438409bb4dbbfc7a8b20bab3b6
+pkgrel=1
+pkgdesc="Professional-grade digital audio workstation (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64')
+url="https://ardour.org/"
+msys2_repository_url="https://github.com/Ardour/ardour"
+msys2_references=(
+  'archlinux: ardour'
+)
+license=(
+  'spdx:CC0-1.0'
+  'spdx:GPL-2.0-or-later'
+  'spdx:GPL-3.0-or-later'
+  'spdx:MIT'
+)
+groups=("${MINGW_PACKAGE_PREFIX}-pro-audio")
+depends=("${MINGW_PACKAGE_PREFIX}-cairo"
+         "${MINGW_PACKAGE_PREFIX}-cc-libs"
+         "${MINGW_PACKAGE_PREFIX}-hicolor-icon-theme"
+         "${MINGW_PACKAGE_PREFIX}-libsigc++"
+         "${MINGW_PACKAGE_PREFIX}-taglib")
+makedepends=("${MINGW_PACKAGE_PREFIX}-aubio"
+             "${MINGW_PACKAGE_PREFIX}-boost"
+             "${MINGW_PACKAGE_PREFIX}-cairomm"
+             "${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cppunit"
+             "${MINGW_PACKAGE_PREFIX}-curl"
+             "${MINGW_PACKAGE_PREFIX}-dbus"
+             "${MINGW_PACKAGE_PREFIX}-doxygen"
+             "${MINGW_PACKAGE_PREFIX}-drmingw"
+             "${MINGW_PACKAGE_PREFIX}-fftw"
+             "${MINGW_PACKAGE_PREFIX}-flac"
+             "${MINGW_PACKAGE_PREFIX}-fluidsynth"
+             "${MINGW_PACKAGE_PREFIX}-fontconfig"
+             "${MINGW_PACKAGE_PREFIX}-freetype"
+             "${MINGW_PACKAGE_PREFIX}-glib2"
+             "${MINGW_PACKAGE_PREFIX}-glibmm"
+             "${MINGW_PACKAGE_PREFIX}-graphviz"
+             "${MINGW_PACKAGE_PREFIX}-hidapi"
+             "${MINGW_PACKAGE_PREFIX}-itstool"
+             "${MINGW_PACKAGE_PREFIX}-jack2"
+             "${MINGW_PACKAGE_PREFIX}-libarchive"
+             "${MINGW_PACKAGE_PREFIX}-liblo"
+             "${MINGW_PACKAGE_PREFIX}-libogg"
+             "${MINGW_PACKAGE_PREFIX}-libpng"
+             "${MINGW_PACKAGE_PREFIX}-libsamplerate"
+             "${MINGW_PACKAGE_PREFIX}-libsndfile"
+             "${MINGW_PACKAGE_PREFIX}-libusb"
+             "${MINGW_PACKAGE_PREFIX}-libwebsockets"
+             "${MINGW_PACKAGE_PREFIX}-libxml2"
+             "${MINGW_PACKAGE_PREFIX}-lilv"
+             "${MINGW_PACKAGE_PREFIX}-lv2"
+             "${MINGW_PACKAGE_PREFIX}-pango"
+             "${MINGW_PACKAGE_PREFIX}-pangomm"
+             "${MINGW_PACKAGE_PREFIX}-pkgconf"
+             "${MINGW_PACKAGE_PREFIX}-readline"
+             "${MINGW_PACKAGE_PREFIX}-rubberband"
+             "${MINGW_PACKAGE_PREFIX}-serd"
+             "${MINGW_PACKAGE_PREFIX}-sord"
+             "${MINGW_PACKAGE_PREFIX}-sratom"
+             "${MINGW_PACKAGE_PREFIX}-vamp-plugin-sdk"
+             "git"
+             "python"
+             "unzip")
+optdepends=("${MINGW_PACKAGE_PREFIX}-harvid: video timeline and MP3 export"
+            "${MINGW_PACKAGE_PREFIX}-new-session-manager: session management"
+            "${MINGW_PACKAGE_PREFIX}-xjadeo: video monitoring")
+provides=('ladspa-host'
+          'lv2-host'
+          'vamp-host'
+          'vst-host'
+          'vst3-host')
+source=("${_realname}::git+https://github.com/Ardour/ardour.git#tag=${_commit}"
+        "${_realname}-midi-${pkgver}.zip::http://stuff.ardour.org/loops/ArdourBundledMedia.zip"
+        '0001-mingw-link-fixes.patch'
+        '0002-strip-srcdir-from-buildinfo.patch')
+noextract=("${_realname}-midi-${pkgver}.zip")
+sha256sums=('SKIP'
+            'a00de00671cdc329b2ca35c2a5c4150af3d6588147f9dca2e3dea752aa2e234c'
+            '1ee8fb3146e16a0e7ff9bd69a042eb14b4e4ef23ca40eb67f96faa17b8f66866'
+            '09660e9a8649cb406fd85072c74efecaccd948f5b03a623d32fb04947e2ee0eb')
+
+prepare() {
+  cd "${srcdir}/${_realname}"
+  patch -Np1 -i "${srcdir}/0001-mingw-link-fixes.patch"
+  patch -Np1 -i "${srcdir}/0002-strip-srcdir-from-buildinfo.patch"
+  # FS#54389
+  sed -e '8iexport GTK2_RC_FILES=/dev/null' -i gtk2_ardour/ardour.sh.in
+}
+
+build() {
+  local _waf_configure_options=(
+    --prefix="${MINGW_PREFIX}"
+    --check-c-compiler="${CC}"
+    --check-cxx-compiler="${CXX}"
+    --dist-target=mingw
+    --configdir=/etc
+    --cxx17
+    --freedesktop
+    --no-phone-home
+    --optimize
+    --ptformat
+    --with-backends="portaudio,dummy,jack"
+    --out="${srcdir}/build-${MSYSTEM}"
+  )
+
+  # waf treats CC/CXX env vars as absolute paths, bypassing PATH lookup.
+  unset CC CXX
+  export WAF_NO_PREFORK=1
+  export CFLAGS+=" -Wno-deprecated-declarations"
+  export CXXFLAGS+=" -Wno-deprecated-declarations"
+  export LINKFLAGS="${LDFLAGS}"
+
+  cd "${srcdir}/${_realname}"
+  /usr/bin/python waf configure "${_waf_configure_options[@]}"
+  /usr/bin/python waf build
+}
+
+package() {
+  cd "${srcdir}/${_realname}"
+  /usr/bin/python waf i18n --destdir="${pkgdir}"
+  /usr/bin/python waf install --destdir="${pkgdir}" --libdir="${MINGW_PREFIX}/lib" --prefix="${MINGW_PREFIX}"
+  install -vDm 644 "${_realname}.1" -t "${pkgdir}${MINGW_PREFIX}/share/man/man1/"
+
+  # Upstream ships MIDI loops as a separate zip with no flexible naming.
+  unzip "${srcdir}/${_realname}-midi-${pkgver}.zip" \
+    -d "${pkgdir}${MINGW_PREFIX}/share/${_realname}${pkgver/.*/}/media/"
+}


### PR DESCRIPTION
First things first, so this pkgbuild is based from arch and biswa96 patches, I managed to build it. And it runs, but I have trouble with the license path.  but hey it works?
![image](https://github.com/kreijstal-contributions/MINGW-packages/assets/2415206/5ac0a009-cba9-4f5c-a5cf-6a6b32fbbe81)

Cannot build on clang because there is no jack2 dependency in clang afaik.  There is a bug in waf when it detects CC or CXX as env variables it attempts to get it as a file, it does not check the path for these, it treats it as absolute values. I am not a musician, so no idea if it is functional.

There might be some path conversion bugs. 