### PR TITLE
scotch: Build without PT-Scotch in aarch64 (due to missing MPI)

### DIFF
--- a/mingw-w64-scotch/PKGBUILD
+++ b/mingw-w64-scotch/PKGBUILD
@@ -6,12 +6,12 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-int64")
 pkgdesc='Graph partitioning and sparse matrix ordering package (mingw-w64)'
 pkgver=7.0.4
-pkgrel=1
+pkgrel=2
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libsystre"
-         "${MINGW_PACKAGE_PREFIX}-msmpi")
+         $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || echo "${MINGW_PACKAGE_PREFIX}-msmpi"))
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
 options=('!strip' 'staticlibs')
 license=('spdx:CECILL-C')
@@ -44,15 +44,24 @@ _build_scotch() {
 
   cp -p "${srcdir}/${_idx_makefile_inc}" "${srcdir}/${_realname}-v${pkgver}/src/Makefile.inc"
   cd "${srcdir}/${_realname}-v${pkgver}/src"
-  make scotch ptscotch esmumps ptesmumps
+
+  if [[ ${CARCH} != aarch64 ]]; then
+    make scotch ptscotch esmumps ptesmumps
+  else
+    # No MPI so no PT-Scotch
+    make scotch esmumps 
+  fi
 
   cd ../lib
   ${CC} -shared -o lib${_realname}.dll -Wl,--enable-auto-import -Wl,--export-all-symbols,-no-undefined \
     -Wl,--out-implib,lib${_realname}.dll.a -Wl,--whole-archive lib${_realname}.a lib${_realname}err.a -Wl,--no-whole-archive \
     -pthread
-  mpicc -shared -o libpt${_realname}.dll -Wl,--enable-auto-import -Wl,--export-all-symbols,-no-undefined \
-    -Wl,--out-implib,libpt${_realname}.dll.a -Wl,--whole-archive libpt${_realname}.a libpt${_realname}err.a -Wl,--no-whole-archive \
-    -L. -l${_realname} -pthread
+
+  if [[ ${CARCH} != aarch64 ]]; then
+    mpicc -shared -o libpt${_realname}.dll -Wl,--enable-auto-import -Wl,--export-all-symbols,-no-undefined \
+      -Wl,--out-implib,libpt${_realname}.dll.a -Wl,--whole-archive libpt${_realname}.a libpt${_realname}err.a -Wl,--no-whole-archive \
+      -L. -l${_realname} -pthread
+  fi
 
   cd "${srcdir}/${_realname}-v${pkgver}"
   mv include include${_idx_suffix}
@@ -60,7 +69,9 @@ _build_scotch() {
   mv bin bin${_idx_suffix}
   cd include${_idx_suffix}
   mv metis.h scotchmetis.h
-  mv parmetis.h ptscotchparmetis.h
+  if [[ ${CARCH} != aarch64 ]]; then
+    mv parmetis.h ptscotchparmetis.h
+  fi
 }
 
 build()
@@ -91,20 +102,23 @@ _package_scotch() {
 	Libs.private: -lscotcherr
 	Libs: -L\${libdir} -lscotch
   " | sed '/^\s*$/d;s/^\s*//' > "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/scotch.pc"
-  echo "
-	prefix=${MINGW_PREFIX}
-	libdir=\${prefix}/lib
-	includedir=\${prefix}/include
-	Name: ptscotch
-	URL: ${url}
-	Version: ${pkgver}
-	Description: Parallel graph partitioning and sparse matrix ordering package
-	Requires: scotch
-	Requires.private: msmpi
-	Cflags: -I\${includedir}
-	Libs.private: -lptscotcherr
-	Libs: -L\${libdir} -lptscotch
-  " | sed '/^\s*$/d;s/^\s*//' > "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/ptscotch.pc"
+
+  if [[ ${CARCH} != aarch64 ]]; then
+    echo "
+    prefix=${MINGW_PREFIX}
+    libdir=\${prefix}/lib
+    includedir=\${prefix}/include
+    Name: ptscotch
+    URL: ${url}
+    Version: ${pkgver}
+    Description: Parallel graph partitioning and sparse matrix ordering package
+    Requires: scotch
+    Requires.private: msmpi
+    Cflags: -I\${includedir}
+    Libs.private: -lptscotcherr
+    Libs: -L\${libdir} -lptscotch
+    " | sed '/^\s*$/d;s/^\s*//' > "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/ptscotch.pc"
+  fi  
   (
     cd include${_idx_suffix}
     install -m644 *.h "${pkgdir}${MINGW_PREFIX}/include"


### PR DESCRIPTION
Is this acceptable?  It's better than just not having the package at all :)