### PR TITLE
vala-language-server: add meson to optdepends

### DIFF
--- a/mingw-w64-vala-language-server/PKGBUILD
+++ b/mingw-w64-vala-language-server/PKGBUILD
@@ -4,7 +4,7 @@ _realname=vala-language-server
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.48.7
-pkgrel=1
+pkgrel=2
 pkgdesc="Vala Language Server for the Vala programming language (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
@@ -19,6 +19,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-jsonrpc-glib"
          "${MINGW_PACKAGE_PREFIX}-json-glib"
          "${MINGW_PACKAGE_PREFIX}-libgee"
          "${MINGW_PACKAGE_PREFIX}-vala")
+optdepends=("${MINGW_PACKAGE_PREFIX}-meson: to support meson projects")
 source=("https://github.com/vala-lang/vala-language-server/archive/refs/tags/${pkgver}.tar.gz")
 sha256sums=('6e848334accd27566843d56db15bedcf7529dc68e416d23d3b4e9fc522019c68')
 


### PR DESCRIPTION
Add `meson` to optdepends to support meson projects, which is widely used in the vala.