### PR TITLE
winfile: Fix building with Clang after Clang 17 and enable aarch64 builds

### DIFF
--- a/mingw-w64-winfile/001-cpp-17.patch
+++ b/mingw-w64-winfile/001-cpp-17.patch
@@ -1,0 +1,12 @@
+diff -bur winfile-10.2.0.0-orig/GNUmakefile winfile-10.2.0.0/GNUmakefile
+--- winfile-10.2.0.0-orig/GNUmakefile	2024-02-28 21:41:35.165193000 -0700
++++ winfile-10.2.0.0/GNUmakefile	2024-02-28 21:41:47.948770100 -0700
+@@ -34,7 +34,7 @@
+ 
+ OBJS = $(subst .c,.o,$(SRCS)) src/wfgoto.o src/res.o
+ 
+-CFLAGS = -DUNICODE -DFASTMOVE -DSTRSAFE_NO_DEPRECATE -DWINVER=0x0600
++CFLAGS = -Wno-register -Wno-implicit-int -Wno-incompatible-function-pointer-types -DUNICODE -DFASTMOVE -DSTRSAFE_NO_DEPRECATE -DWINVER=0x0600
+ LDLIBS = -mwindows -lgdi32 -lcomctl32 -lole32 -lshlwapi -loleaut32 -lversion
+ TARGET = winfile
+ ifeq ($(OS),Windows_NT)

--- a/mingw-w64-winfile/PKGBUILD
+++ b/mingw-w64-winfile/PKGBUILD
@@ -4,17 +4,34 @@ _realname=winfile
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=10.2.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Original Windows File Manager (winfile) with enhancements (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://github.com/microsoft/winfile"
 license=('MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
 options=(!strip staticlibs !buildflags)
-source=("${_realname}-${pkgver}.tar.gz::${url}/archive/v${pkgver}.tar.gz")
-sha256sums=('441ec49ca6ad3af6abb3169a5f95e84ce00d3e3a9dedaf33f1088f4e4ac32524')
+source=("${_realname}-${pkgver}.tar.gz::${url}/archive/v${pkgver}.tar.gz"
+        "001-cpp-17.patch")
+sha256sums=('441ec49ca6ad3af6abb3169a5f95e84ce00d3e3a9dedaf33f1088f4e4ac32524'
+            '98e2043523fc2e989e3483fb3f72fec107dfb579251b1519b92fcbc9a428848e')
+
+_apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying ${_patch}"
+    patch -p1 -i "${srcdir}/${_patch}"
+  done
+}
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  _apply_patch_with_msg \
+    001-cpp-17.patch
+}
 
 build() {
   [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"


### PR DESCRIPTION
Windows 3.11 ARM64

![image](https://github.com/msys2/MINGW-packages/assets/1100440/a2fea833-b9a4-4b68-8328-49c80af44d38)
