### PR TITLE
emacs: Enable aarch64 builds

### DIFF
--- a/mingw-w64-emacs/003-aarch64-fixes.patch
+++ b/mingw-w64-emacs/003-aarch64-fixes.patch
@@ -1,0 +1,103 @@
+diff -bur emacs-29.2-orig/configure.ac emacs-29.2/configure.ac
+--- emacs-29.2-orig/configure.ac	2024-02-29 01:02:11.875373100 -0700
++++ emacs-29.2/configure.ac	2024-02-29 01:02:44.859394600 -0700
+@@ -825,7 +825,7 @@
+   ;;
+ 
+   # MinGW64
+-  x86_64-*-* )
++  x86_64-*-* | aarch64-*-*)
+     case "${canonical}" in
+       *-mingw* )
+ 		opsys=mingw32
+@@ -1619,6 +1619,7 @@
+ if test "$opsys" = "mingw32"; then
+   case "$canonical" in
+     x86_64-*-mingw*) C_SWITCH_SYSTEM="-mtune=generic" ;;
++    aarch64-*-mingw*) C_SWITCH_SYSTEM="-mtune=cortex-a53" ;;
+     *) C_SWITCH_SYSTEM="-mtune=pentium4" ;;
+   esac
+ fi
+diff -bur emacs-29.2-orig/nt/inc/ms-w32.h emacs-29.2/nt/inc/ms-w32.h
+--- emacs-29.2-orig/nt/inc/ms-w32.h	2024-02-29 01:02:16.696003700 -0700
++++ emacs-29.2/nt/inc/ms-w32.h	2024-02-29 01:02:59.299874200 -0700
+@@ -229,7 +229,7 @@
+ /* The following is needed for recovery from C stack overflows.  */
+ #include <setjmp.h>
+ typedef jmp_buf sigjmp_buf;
+-#ifdef MINGW_W64
++#if defined(MINGW_W64) && !defined(_M_ARM64)
+ /* Evidently, MinGW64's longjmp crashes when invoked from an exception
+    handler, see https://sourceforge.net/p/mingw-w64/mailman/message/32421953/.
+    This seems to be an unsolved problem in the MinGW64 runtime.  So we
+diff -bur emacs-29.2-orig/src/w32fns.c emacs-29.2/src/w32fns.c
+--- emacs-29.2-orig/src/w32fns.c	2024-02-29 01:28:43.054838500 -0700
++++ emacs-29.2/src/w32fns.c	2024-02-29 01:28:49.745934200 -0700
+@@ -11037,8 +11037,12 @@
+   if (gc_in_progress)
+     terminate_due_to_signal (SIGSEGV, 40);
+ #ifdef _WIN64
++#ifdef _M_ARM64
++  longjmp(return_to_command_loop, 1);
++#else
+   /* See ms-w32.h: MinGW64's longjmp crashes if invoked in this context.  */
+   __builtin_longjmp (return_to_command_loop, 1);
++#endif  
+ #else
+   sys_longjmp (return_to_command_loop, 1);
+ #endif
+@@ -11065,7 +11069,11 @@
+     {
+       /* Call stack_overflow_handler ().  */
+ #ifdef _WIN64
++#ifdef _M_ARM64
++      exception_data->ContextRecord->Pc = (DWORD_PTR) &stack_overflow_handler;
++#else
+       exception_data->ContextRecord->Rip = (DWORD_PTR) &stack_overflow_handler;
++#endif      
+ #else
+       exception_data->ContextRecord->Eip = (DWORD_PTR) &stack_overflow_handler;
+ #endif
+diff -bur emacs-29.2-orig/configure.ac emacs-29.2/configure.ac
+--- emacs-29.2-orig/configure.ac	2024-02-29 01:38:36.186527500 -0700
++++ emacs-29.2/configure.ac	2024-02-29 01:38:43.064754200 -0700
+@@ -2291,6 +2291,7 @@
+   EMACSRES="emacs.res"
+   case "$canonical" in
+     x86_64-*-*) EMACS_MANIFEST="emacs-x64.manifest" ;;
++    aarch64-*-*) EMACS_MANIFEST="emacs-ARM64.manifest" ;;
+     *) EMACS_MANIFEST="emacs-x86.manifest" ;;
+   esac
+   dnl Construct something of the form "24,4,0,0" with 4 components.
+diff -bur emacs-29.2-orig/nt/emacs.rc.in emacs-29.2/nt/emacs.rc.in
+--- emacs-29.2-orig/nt/emacs.rc.in	2024-02-29 01:56:45.198564800 -0700
++++ emacs-29.2/nt/emacs.rc.in	2024-02-29 01:58:17.868439500 -0700
+@@ -1,6 +1,8 @@
+ Emacs ICON   icons/emacs.ico
+ 32649 CURSOR icons/hand.cur
+-#if defined (WIN64) || defined (__x86_64__)
++#ifdef __aarch64__
++1 24 "emacs-ARM64.manifest"
++#elif defined (WIN64) || defined (__x86_64__)
+ 1 24 "emacs-x64.manifest"
+ #else
+ 1 24 "emacs-x86.manifest"
+diff -bur emacs-29.2-orig/configure.ac emacs-29.2/configure.ac
+--- emacs-29.2-orig/configure.ac	2024-02-29 02:34:43.722695200 -0700
++++ emacs-29.2/configure.ac	2024-02-29 02:37:30.573110900 -0700
+@@ -6510,13 +6510,13 @@
+   mingw32)
+    ## Is it any better under MinGW64 to relocate emacs into higher addresses?
+    case "$canonical" in
+-     x86_64-*-*) LD_SWITCH_SYSTEM_TEMACS="-Wl,-stack,0x00800000 -Wl,-heap,0x00100000 -Wl,-image-base,0x400000000 -Wl,-entry,__start -Wl,-Map,./temacs.map" ;;
++     x86_64-*-* | aarch64-*-*) LD_SWITCH_SYSTEM_TEMACS="-Wl,-stack,0x00800000 -Wl,-heap,0x00100000 -Wl,-image-base,0x400000000 -Wl,-entry,__start -Wl,-Map,./temacs.map" ;;
+      *) LD_SWITCH_SYSTEM_TEMACS="-Wl,-stack,0x00800000 -Wl,-heap,0x00100000 -Wl,-image-base,0x01000000 -Wl,-entry,__start -Wl,-Map,./temacs.map" ;;
+    esac
+    ## If they want unexec, disable Windows ASLR for the Emacs binary
+    if test "$with_dumping" = "unexec"; then
+       case "$canonical" in
+-        x86_64-*-*) LD_SWITCH_SYSTEM_TEMACS="$LD_SWITCH_SYSTEM_TEMACS -Wl,-disable-dynamicbase -Wl,-disable-high-entropy-va -Wl,-default-image-base-low" ;;
++        x86_64-*-* | aarch64-*-*) LD_SWITCH_SYSTEM_TEMACS="$LD_SWITCH_SYSTEM_TEMACS -Wl,-disable-dynamicbase -Wl,-disable-high-entropy-va -Wl,-default-image-base-low" ;;
+         *) LD_SWITCH_SYSTEM_TEMACS="$LD_SWITCH_SYSTEM_TEMACS -Wl,-disable-dynamicbase" ;;
+       esac
+    fi

--- a/mingw-w64-emacs/PKGBUILD
+++ b/mingw-w64-emacs/PKGBUILD
@@ -8,10 +8,10 @@ _realname=emacs
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=29.2
-pkgrel=2
+pkgrel=3
 pkgdesc="The extensible, customizable, self-documenting, real-time display editor (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://www.gnu.org/software/${_realname}/"
 msys2_references=(
   'archlinux: emacs'
@@ -41,22 +41,29 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!zipman')
 source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.xz"{,.sig}
         "001-ucrt.patch"
-        "002-clang-fixes.patch")
+        "002-clang-fixes.patch"
+        "003-aarch64-fixes.patch"
+        "emacs-ARM64.manifest")
 # source=("https://alpha.gnu.org/gnu/${_realname}/pretest/${_realname}-${pkgver}.tar.xz"{,.sig})
 sha256sums=('7d3d2448988720bf4bf57ad77a5a08bf22df26160f90507a841ba986be2670dc'
             'SKIP'
             'e1347064ec30094e21679764f784fa7557738946485359041473e6e9d7f3c3dc'
-            'd8732584a8f3bfd0badbd16d15384b7098e25c5df48632beb02d35f6050c358b')
+            'd8732584a8f3bfd0badbd16d15384b7098e25c5df48632beb02d35f6050c358b'
+            'd128982d87af1e524ae809147613168153f0e5c1efb0ef633793df47b762c9e1'
+            'bfe64602dbeeec85799c1156ca4f3837fdac42a076e83a4221768db3417220e1')
 validpgpkeys=('28D3BED851FDF3AB57FEF93C233587A47C207910'
               '17E90D521672C04631B1183EE78DAE0F3115E06B'
               'E6C9029C363AD41D787A8EBB91C1262F01EB8D39'
               'CEA1DE21AB108493CC9C65742E82323B8F4353EE')
 
 prepare() {
+  cp "${srcdir}/emacs-ARM64.manifest" "${_realname}-${pkgver}/nt"
+
   cd "${_realname}-${pkgver}"
 
   patch -Np1 -i "${srcdir}/001-ucrt.patch"
   patch -Np1 -i "${srcdir}/002-clang-fixes.patch"
+  patch -Np1 -i "${srcdir}/003-aarch64-fixes.patch"
 
   ./autogen.sh
 }

--- a/mingw-w64-emacs/emacs-ARM64.manifest
+++ b/mingw-w64-emacs/emacs-ARM64.manifest
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls"
+                        version="6.0.0.0" processorArchitecture="ARM64"
+                        publicKeyToken="6595b64144ccf1df"
+                        language="*"/>
+    </dependentAssembly>
+  </dependency>
+  <assemblyIdentity version="1.0.0.0" processorArchitecture="ARM64"
+		    name="emacs" type="win32"/>
+  <description>GNU Emacs</description>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1"> 
+      <application> 
+        <!-- Windows Vista -->
+        <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+        <!-- Windows 7 -->
+        <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+        <!-- Windows 8 -->
+        <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+        <!-- Windows 8.1 -->
+        <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+        <!-- Windows 10 -->
+        <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      </application> 
+    </compatibility>
+  <asmv3:application>
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+      <dpiAware>true</dpiAware>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+</assembly>


### PR DESCRIPTION
![image](https://github.com/msys2/MINGW-packages/assets/1100440/fa0b9a14-d897-4f76-867d-45579b5c9a9b)

![image](https://github.com/msys2/MINGW-packages/assets/1100440/98245954-2c0b-457d-8bda-a60c03d014de)
