### PR TITLE
pcre2: Fix static library

### DIFF
--- a/mingw-w64-pcre2/PKGBUILD
+++ b/mingw-w64-pcre2/PKGBUILD
@@ -4,7 +4,7 @@ _realname=pcre2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=10.43
-pkgrel=1
+pkgrel=2
 pkgdesc="A library that implements Perl 5-style regular expressions (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -19,33 +19,59 @@ depends=("${MINGW_PACKAGE_PREFIX}-bzip2"
 source=(https://github.com/PhilipHazel/pcre2/releases/download/${_realname}-${pkgver}/${_realname}-${pkgver}.tar.bz2{,.sig})
 sha256sums=('e2a53984ff0b07dfdb5ae4486bbb9b21cca8e7df2434096cc9bf1b728c350bcb'
             'SKIP')
-validpgpkeys=('45F68D54BBE23FB3039B46E59766E084FB0F43D8')
+validpgpkeys=('45F68D54BBE23FB3039B46E59766E084FB0F43D8') # Philip Hazel <Philip.Hazel@gmail.com>
 
 build() {
-  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
+  local -a _common_config=(
+    --enable-pcre2-8
+    --enable-pcre2-16
+    --enable-pcre2-32
+    --enable-pcre2grep-libz
+    --enable-pcre2grep-libbz2
+    --enable-pcre2test-libedit
+  )
+
+  mkdir -p "${srcdir}/build-${MSYSTEM}-static" && cd "${srcdir}/build-${MSYSTEM}-static"
+
+  CPPFLAGS+=" -DPCRE2_STATIC" \
+  "${srcdir}"/${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --enable-static \
+    --disable-shared \
+    "${_common_config[@]}"
+
+  make
+
+  mkdir -p "${srcdir}/build-${MSYSTEM}-shared" && cd "${srcdir}/build-${MSYSTEM}-shared"
 
   "${srcdir}"/${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \
-    --enable-pcre2-8 \
-    --enable-pcre2-16 \
-    --enable-pcre2-32 \
-    --enable-pcre2grep-libz \
-    --enable-pcre2grep-libbz2 \
-    --enable-pcre2test-libedit
+    --enable-shared \
+    --disable-static \
+    "${_common_config[@]}"
 
   make
 }
 
 check() {
-  cd "${srcdir}/build-${MSYSTEM}"
+  cd "${srcdir}/build-${MSYSTEM}-static"
+  make check || true
+
+  cd "${srcdir}/build-${MSYSTEM}-shared"
   make check || true
 }
 
 package() {
-  cd "${srcdir}/build-${MSYSTEM}"
+  cd "${srcdir}/build-${MSYSTEM}-static"
+  make DESTDIR="${pkgdir}" install
+
+  cd "${srcdir}/build-${MSYSTEM}-shared"
   make DESTDIR="${pkgdir}" install
 
   # License files


### PR DESCRIPTION
This removes pcre2-8 symbols with dllimport attributes in pcre2-posix.a library.

Fixes #20234