### PR TITLE
directxmath: fix pkg-config includedir

### DIFF
--- a/mingw-w64-directxmath/0001-fix-pc-includedir.patch
+++ b/mingw-w64-directxmath/0001-fix-pc-includedir.patch
@@ -1,0 +1,11 @@
+--- directxmath-feb2024/CMakeLists.txt.orig	2024-03-05 09:17:57.065793700 +0100
++++ directxmath-feb2024/CMakeLists.txt	2024-03-05 09:18:04.347600700 +0100
+@@ -71,7 +71,7 @@
+ # Create pkg-config file
+ include(build/JoinPaths.cmake)
+ # from: https://github.com/jtojnar/cmake-snips#concatenating-paths-when-building-pkg-config-files
+-join_paths(DIRECTXMATH_INCLUDEDIR_FOR_PKG_CONFIG "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
++join_paths(DIRECTXMATH_INCLUDEDIR_FOR_PKG_CONFIG "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}" "directxmath")
+ join_paths(DIRECTXMATH_LIBDIR_FOR_PKG_CONFIG "\${prefix}"     "${CMAKE_INSTALL_LIBDIR}")
+ 
+ configure_file(

--- a/mingw-w64-directxmath/PKGBUILD
+++ b/mingw-w64-directxmath/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 # Version from CMakeLists.txt
 pkgver=3.1.9
 _tag=feb2024
-pkgrel=1
+pkgrel=2
 pkgdesc="DirectXMath is an all inline SIMD C++ linear algebra library for use in games and graphics apps (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -18,8 +18,17 @@ license=('spdx:MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cc")
-source=("${_realname}-${_tag}.tar.gz"::"https://github.com/microsoft/DirectXMath/archive/refs/tags/${_tag}.tar.gz")
-sha256sums=('f78bb400dcbedd987f2876b2fb6fe12199d795cd6a912f965ef3a2141c78303d')
+source=("${_realname}-${_tag}.tar.gz"::"https://github.com/microsoft/DirectXMath/archive/refs/tags/${_tag}.tar.gz"
+        "0001-fix-pc-includedir.patch")
+sha256sums=('f78bb400dcbedd987f2876b2fb6fe12199d795cd6a912f965ef3a2141c78303d'
+            'e67b001b4c3de8085d413c1ee82c7e02a5f159a915314decd2f989cd273bd507')
+
+prepare() {
+  cd "${_realname}-${_tag}"
+
+  # https://github.com/microsoft/DirectXMath/pull/174#issuecomment-1978176271
+  patch -Np1 -i "${srcdir}/0001-fix-pc-includedir.patch"
+}
 
 build() {
   cd "${srcdir}/${_realname}-${_tag}"


### PR DESCRIPTION
it was missing the directxmath subdir