### PR TITLE
[New package] ollama

### DIFF
--- a/mingw-w64-llama.cpp/PKGBUILD
+++ b/mingw-w64-llama.cpp/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=llama.cpp
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=r1967.256d1bb0
+pkgver=r2355.e04e04f8f
 pkgrel=1
 pkgdesc="Port of Facebook's LLaMA model in C/C++ (mingw-w64)"
 arch=('any')
@@ -18,7 +18,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cc"
   'git'
 )
-_commit='256d1bb0ddce6a0a21f5a7503019bdd5c1933cba'
+_commit='e04e04f8fad549bb0b3ec1c91f0413aeb08baf29'
 source=("${_realname}"::"git+https://github.com/ggerganov/llama.cpp.git#commit=${_commit}")
 sha256sums=('SKIP')
 

--- a/mingw-w64-ollama/0001-Hijack-the-build-for-msys2-P.patch
+++ b/mingw-w64-ollama/0001-Hijack-the-build-for-msys2-P.patch
@@ -1,0 +1,92 @@
+From c16eebd58d1c017c7c63e6e4986a748bed70052d Mon Sep 17 00:00:00 2001
+From: Kreijstal <rainb@tfwno.gf>
+Date: Thu, 7 Mar 2024 03:22:25 +0100
+Subject: [PATCH] Hijack the build for msys2 :P
+
+---
+ llm/ext_server/CMakeLists.txt |  4 ++--
+ llm/generate/gen_windows.ps1  | 35 ++++++++++++++++++++++++++++-------
+ 2 files changed, 30 insertions(+), 9 deletions(-)
+
+diff --git a/llm/ext_server/CMakeLists.txt b/llm/ext_server/CMakeLists.txt
+index dd1831f..9175a1b 100644
+--- a/llm/ext_server/CMakeLists.txt
++++ b/llm/ext_server/CMakeLists.txt
+@@ -12,7 +12,7 @@ target_include_directories(${TARGET} PRIVATE ../..)
+ target_include_directories(${TARGET} PRIVATE ../../..)
+ target_compile_features(${TARGET} PRIVATE cxx_std_11)
+ target_compile_definitions(${TARGET} PUBLIC LLAMA_SERVER_LIBRARY=1)
+-target_link_libraries(${TARGET} PRIVATE ggml llava common )
++target_link_libraries(${TARGET} PRIVATE ggml llava common wsock32 ws2_32 )
+ set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+ target_compile_definitions(${TARGET} PRIVATE SERVER_VERBOSE=$<BOOL:${LLAMA_SERVER_VERBOSE}>)
+ install(TARGETS ext_server LIBRARY)
+@@ -22,4 +22,4 @@ if (CUDAToolkit_FOUND)
+     if (WIN32)
+         target_link_libraries(${TARGET} PRIVATE nvml)
+     endif()
+-endif()
+\ No newline at end of file
++endif()
+diff --git a/llm/generate/gen_windows.ps1 b/llm/generate/gen_windows.ps1
+index e031342..1f1c2d1 100644
+--- a/llm/generate/gen_windows.ps1
++++ b/llm/generate/gen_windows.ps1
+@@ -5,7 +5,7 @@ $ErrorActionPreference = "Stop"
+ function init_vars {
+     $script:SRC_DIR = $(resolve-path "..\..\")
+     $script:llamacppDir = "../llama.cpp"
+-    $script:cmakeDefs = @("-DBUILD_SHARED_LIBS=on", "-DLLAMA_NATIVE=off",  "-A", "x64")
++    $script:cmakeDefs = @("-DBUILD_SHARED_LIBS=on", "-DLLAMA_NATIVE=off")
+     $script:cmakeTargets = @("ext_server")
+     $script:ARCH = "amd64" # arm not yet supported.
+     if ($env:CGO_CFLAGS -contains "-g") {
+@@ -90,18 +90,39 @@ function build {
+     & cmake --build $script:buildDir --config $script:config ($script:cmakeTargets | ForEach-Object { "--target", $_ })
+     if ($LASTEXITCODE -ne 0) { exit($LASTEXITCODE)}
+ }
+-
+ function install {
++    Write-Host "Installing ${script:buildDir}"
+     rm -ea 0 -recurse -force -path "${script:buildDir}/lib"
+     md "${script:buildDir}/lib" -ea 0 > $null
+-    cp "${script:buildDir}/bin/${script:config}/ext_server.dll" "${script:buildDir}/lib"
+-    cp "${script:buildDir}/bin/${script:config}/llama.dll" "${script:buildDir}/lib"
+-    # Display the dll dependencies in the build log
+-    if ($script:DUMPBIN -ne $null) {
+-        & "$script:DUMPBIN" /dependents "${script:buildDir}/bin/${script:config}/ext_server.dll" | select-string ".dll"
++
++    $extServerDllPath = "${script:buildDir}/bin/${script:config}/ext_server.dll"
++    $extServerDllPathWithoutConfig = "${script:buildDir}/bin/libext_server.dll"
++
++    if (Test-Path $extServerDllPath) {
++        cp $extServerDllPath "${script:buildDir}/lib"
++        cp "${script:buildDir}/bin/${script:config}/llama.dll" "${script:buildDir}/lib"
++
++        # Display the dll dependencies in the build log
++        if ($script:DUMPBIN -ne $null) {
++            & "$script:DUMPBIN" /dependents $extServerDllPath | Select-String ".dll"
++        }
++    }
++    elseif (Test-Path $extServerDllPathWithoutConfig) {
++        cp $extServerDllPathWithoutConfig "${script:buildDir}/lib"
++        cp "${script:buildDir}/bin/libllama.dll" "${script:buildDir}/lib"
++
++        # Display the dll dependencies in the build log
++        if ($script:DUMPBIN -ne $null) {
++            & "$script:DUMPBIN" /dependents $extServerDllPathWithoutConfig | Select-String ".dll"
++        }
++    }
++    else {
++        Write-Host "ext_server.dll not found in ${script:buildDir}/bin/${script:config} or ${script:buildDir}/bin"
++        Write-Error "Installation failed."
+     }
+ }
+ 
++
+ function sign {
+     if ("${env:KEY_CONTAINER}") {
+         write-host "Signing ${script:buildDir}/lib/*.dll"
+-- 
+2.43.2
+

--- a/mingw-w64-ollama/PKGBUILD
+++ b/mingw-w64-ollama/PKGBUILD
@@ -1,0 +1,55 @@
+_realname=ollama
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgdesc='Create, run and share large language models (LLMs) (mingw-w64)'
+pkgver=0.1.28
+pkgrel=1
+arch=(any)
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm')
+url='https://github.com/jmorganca/ollama'
+license=(MIT)
+_ollamacommit=3b4bab3dc55c615a14b1ae74ea64815d3891b5b0 # tag: v0.1.28
+# The llama.cpp git submodule commit hash can be found here:
+# https://github.com/jmorganca/ollama/tree/v0.1.28/llm
+# The llama repository is not relevant for msys2 because it is hardcoded in the powershell build script
+#_llama_cpp_commit=87c91c07663b707e831c59ec373b5e665ff9d64a 
+makedepends=(${MINGW_PACKAGE_PREFIX}-cmake git ${MINGW_PACKAGE_PREFIX}-go ${MINGW_PACKAGE_PREFIX}-gcc)
+source=(git+$url#commit=$_ollamacommit
+        0001-Hijack-the-build-for-msys2-P.patch
+)
+b2sums=('SKIP'
+        '0cdb1b996e4b11968a1a3694d72a22f4b479ea428badc6a349ed7779c90addbd9a13714cc6d2fe442d63c34a8ae6a45e05d59673a5edc8fdc227fb607dad514c')
+
+prepare() {
+  #rm -rf llm/llama.cpp
+  patch -Np1 -d $_realname -i ../0001*.patch
+  cd $_realname
+  # Copy git submodule files instead of symlinking because the build process is sensitive to symlinks
+#  cp -r "$srcdir/llama.cpp" llm/llama.cpp
+
+}
+
+build() {
+  cd $_realname
+  export CGO_CFLAGS="$CFLAGS" CGO_CPPFLAGS="$CPPFLAGS" CGO_CXXFLAGS="$CXXFLAGS" CGO_LDFLAGS="$LDFLAGS"
+  export GOPROXY=direct 
+  export GOROOT=${MINGW_PREFIX}/lib/go
+  export GOPATH=${MINGW_PREFIX}/
+  go generate ./...
+  go build -buildmode=pie -trimpath -mod=readonly -modcacherw -ldflags=-linkmode=external \
+    -ldflags=-buildid='' -ldflags="-X=github.com/jmorganca/ollama/version.Version=$pkgver" -o "${srcdir}/build-${MSYSTEM}/"
+
+}
+
+
+check() {
+  cd $_realname
+  ./ollama --version >/dev/null
+  go test .
+}
+
+package() {
+ cd $srcdir/build-$MSYSTEM
+ mkdir -p ${pkgdir}${MINGW_PREFIX}/bin
+ install ollama.exe -t"${pkgdir}${MINGW_PREFIX}/bin/"
+}


### PR DESCRIPTION
ollama supports windows now! 
ollama is a LLM manager, makes it easy to run LLM models, like mixtral, or deepseek, (there is already a llama.cpp package, but with ollama you can serve frontend of many llms)

The build uses powershell because upstream uses powershell for windows even though there are bash files for linux only, they are very biased towards MSVC.
It is possible there are upstream changes that can be done. maybe use bash instead of powershell for msys2, I just patched some powershell parts that were biased towards MSVC.