### PR TITLE
opus: Enable detection of NEON and other aarch64 features

### DIFF
--- a/mingw-w64-opus/001-aarch64-features.patch
+++ b/mingw-w64-opus/001-aarch64-features.patch
@@ -5,7 +5,7 @@ diff -bur opus-1.5.1-orig/celt/arm/armcpu.c opus-1.5.1/celt/arm/armcpu.c
    return flags;
  }
  
-+#elif defined(__MINGW64__)
++#elif !defined(_MSC_VER) && defined(_WIN32)
 +# define WIN32_LEAN_AND_MEAN
 +# define WIN32_EXTRA_LEAN
 +# include <windows.h>

--- a/mingw-w64-opus/001-aarch64-features.patch
+++ b/mingw-w64-opus/001-aarch64-features.patch
@@ -1,0 +1,35 @@
+diff -bur opus-1.5.1-orig/celt/arm/armcpu.c opus-1.5.1/celt/arm/armcpu.c
+--- opus-1.5.1-orig/celt/arm/armcpu.c	2024-03-09 21:13:23.646469400 -0700
++++ opus-1.5.1/celt/arm/armcpu.c	2024-03-09 22:51:55.794039700 -0700
+@@ -191,6 +191,31 @@
+   return flags;
+ }
+ 
++#elif defined(__MINGW64__)
++# define WIN32_LEAN_AND_MEAN
++# define WIN32_EXTRA_LEAN
++# include <windows.h>
++
++static OPUS_INLINE opus_uint32 opus_cpu_capabilities(void){
++  opus_uint32 flags;
++  flags=0;
++
++# if defined(OPUS_ARM_MAY_HAVE_EDSP) || defined(OPUS_ARM_MAY_HAVE_MEDIA) \
++ || defined(OPUS_ARM_MAY_HAVE_NEON) || defined(OPUS_ARM_MAY_HAVE_NEON_INTR)
++
++    flags |= OPUS_CPU_ARM_EDSP_FLAG | OPUS_CPU_ARM_MEDIA_FLAG | OPUS_CPU_ARM_NEON_FLAG;
++
++#  if defined(OPUS_ARM_MAY_HAVE_DOTPROD)
++  
++  if (IsProcessorFeaturePresent(PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE))
++  {
++    flags |= OPUS_CPU_ARM_DOTPROD_FLAG;
++  }
++#  endif
++# endif
++  return flags;
++}
++
+ #else
+ /* The feature registers which can tell us what the processor supports are
+  * accessible in priveleged modes only, so we can't have a general user-space

--- a/mingw-w64-opus/PKGBUILD
+++ b/mingw-w64-opus/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
 pkgver=1.5.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Codec designed for interactive speech and audio transmission over the Internet (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -18,21 +18,28 @@ makedepends=(
     "${MINGW_PACKAGE_PREFIX}-meson"
     "${MINGW_PACKAGE_PREFIX}-ninja"
 )
-source=("https://downloads.xiph.org/releases/opus/opus-${pkgver}.tar.gz")
-sha256sums=('b84610959b8d417b611aa12a22565e0a3732097c6389d19098d844543e340f85')
+source=("https://downloads.xiph.org/releases/opus/opus-${pkgver}.tar.gz"
+        001-aarch64-features.patch)
+sha256sums=('b84610959b8d417b611aa12a22565e0a3732097c6389d19098d844543e340f85'
+            'cdd19c89fdc7145ef5aae493df17685d381ea046f5d28179d4016cd7debb592c')
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying ${_patch}"
+    patch -Nbp1 -i "${srcdir}/${_patch}"
+  done
+}
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
+
+  apply_patch_with_msg \
+    001-aarch64-features.patch
 }
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
-
-  declare -a extra_config
-  if [[ "${CARCH}" == "aarch64" ]]; then
-    # not implemented and fails to build
-    extra_config+=("-Drtcd=disabled")
-  fi
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
     ${MINGW_PREFIX}/bin/meson.exe setup \
@@ -43,7 +50,6 @@ build() {
       --default-library=both \
       -Dasm=disabled \
       -Dcustom-modes=true \
-      "${extra_config[@]}" \
       ../${_realname}-${pkgver}
 
   ${MINGW_PREFIX}/bin/meson.exe compile

--- a/mingw-w64-opus/PKGBUILD
+++ b/mingw-w64-opus/PKGBUILD
@@ -21,7 +21,7 @@ makedepends=(
 source=("https://downloads.xiph.org/releases/opus/opus-${pkgver}.tar.gz"
         001-aarch64-features.patch)
 sha256sums=('b84610959b8d417b611aa12a22565e0a3732097c6389d19098d844543e340f85'
-            'cdd19c89fdc7145ef5aae493df17685d381ea046f5d28179d4016cd7debb592c')
+            '5fb0f28264492d6512acb6eec7b5e147c922751f6df30d1317114048eca01516')
 
 apply_patch_with_msg() {
   for _patch in "$@"


### PR DESCRIPTION
```
ninja: Entering directory `C:/M_P/mingw-w64-opus/src/build-CLANGARM64'
ninja: no work to do.
 1/15 test_unit_types              OK               0.12s
 2/15 test_unit_mathops            OK               0.11s
 3/15 test_unit_laplace            OK               0.08s
 4/15 test_unit_dft                OK               0.06s
 5/15 test_unit_rotation           OK               0.05s
 6/15 test_unit_mdct               OK               0.20s
 7/15 test_opus_padding            OK               0.09s
 8/15 test_opus_projection         OK               0.06s
 9/15 test_unit_cwrs32             OK               1.00s
10/15 test_unit_cwrs32             OK               1.08s
11/15 test_unit_entropy            OK               2.17s
12/15 test_opus_api                OK               4.07s
13/15 test_opus_extensions         OK              18.23s
14/15 test_opus_decode             OK              26.36s
15/15 test_opus_encode             OK              54.61s

Ok:                 15
Expected Fail:      0
Fail:               0
Unexpected Pass:    0
Skipped:            0
Timeout:            0
```