### PR TITLE
python-rtree: fix loading spatialindex dll

### DIFF
--- a/mingw-w64-python-rtree/0001-fix-mingw-finder.patch
+++ b/mingw-w64-python-rtree/0001-fix-mingw-finder.patch
@@ -1,24 +1,14 @@
 --- a/rtree/finder.py
 +++ b/rtree/finder.py
-@@ -8,6 +8,7 @@
- import os
- import platform
- import sys
-+import sysconfig
- from ctypes.util import find_library
- 
- # the current working directory of this file
-@@ -29,6 +29,13 @@
-     :returns: Loaded shared library
-     """
-     if os.name == "nt":
-+        if sysconfig.get_platform().startswith("mingw"):
-+            lib_name = 'libspatialindex_c'
-+            path = find_library(lib_name)
-+            if path is None:
-+                raise OSError("could not find or load {}".format(lib_name))
-+            return ctypes.cdll.LoadLibrary(path)
-+
-         # check the platform architecture
-         if "64" in platform.architecture()[0]:
+@@ -33,7 +33,10 @@
              arch = "64"
+         else:
+             arch = "32"
+-        lib_name = f"spatialindex_c-{arch}.dll"
++        if "MSC" in sys.version:
++            lib_name = f"spatialindex_c-{arch}.dll"
++        else:
++            lib_name = "libspatialindex.dll"
+ 
+         # add search paths for conda installs
+         if (_sys_prefix / "conda-meta").exists() or "conda" in sys.version:

--- a/mingw-w64-python-rtree/PKGBUILD
+++ b/mingw-w64-python-rtree/PKGBUILD
@@ -4,7 +4,7 @@ _realname=rtree
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=1.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Rtree: spatial index for Python GIS (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -22,10 +22,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
 source=("https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${pkgver}.tar.gz"
         "0001-fix-mingw-finder.patch")
 sha256sums=('f5145f7852bf7f95c126fb16bf1a4c2ca9300ae151b07f8a0f7083ea47912675'
-            'd17957916b7811f6a58f63226deda4e4fbfdea6c7b41c73205f8de3d923bde2a')
+            'ea93e3bebacd88d36b47b843057a137f5c6d7abced8e44cbf298e2a716bdc9c5')
 
 prepare() {
-  cd "${srcdir}/${_pyname}-${pkgver}"
+  cd "${_pyname}-${pkgver}"
 
   patch -Np1 -i "${srcdir}"/0001-fix-mingw-finder.patch
 
@@ -35,12 +35,14 @@ prepare() {
 }
 
 build() {
-  cd "${srcdir}/python-build-${MSYSTEM}"
+  cd "python-build-${MSYSTEM}"
+
   ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 package() {
-  cd "${srcdir}/python-build-${MSYSTEM}"
+  cd "python-build-${MSYSTEM}"
+
   MSYS2_ARG_CONV_EXCL="--prefix=" \
     ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
     --destdir="${pkgdir}" dist/*.whl


### PR DESCRIPTION
Fixes #20143 