### PR TITLE
faudio: switch from SDL2 dep to PLATFORM_WIN32

### DIFF
--- a/mingw-w64-faudio/PKGBUILD
+++ b/mingw-w64-faudio/PKGBUILD
@@ -4,13 +4,12 @@ _realname=FAudio
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=24.01
-pkgrel=1
+pkgrel=2
 pkgdesc="Accuracy-focused XAudio reimplementation for open platforms (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://fna-xna.github.io/"
 license=('custom')
-depends=("${MINGW_PACKAGE_PREFIX}-SDL2")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cc")
@@ -19,6 +18,7 @@ sha256sums=('28839f2f962180e0f8e0d3cb10061758f3cab7ea7eb92a8ba62ae6d0077e9fb6')
 
 build() {
   declare -a extra_config
+  extra_config+=("-DPLATFORM_WIN32=TRUE")
   if check_option "debug" "n"; then
     extra_config+=("-DCMAKE_BUILD_TYPE=Release")
   else


### PR DESCRIPTION
Use the -DPLATFORM_WIN32=TRUE cmake parameter to activate the win32-specific code instead of using SDL2, remove the SDL2 dependency and increase the pkgrel.