### PR TITLE
unordered_dense: new package

### DIFF
--- a/mingw-w64-unordered-dense/PKGBUILD
+++ b/mingw-w64-unordered-dense/PKGBUILD
@@ -1,0 +1,39 @@
+# Maintainer: Christoph Reiter <reiter.christoph@gmail.com>
+# Contributor: Philippe Renon <philippe_renon@yahoo.fr>
+
+_realname=unordered_dense
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=4.4.0
+pkgrel=1
+pkgdesc='A fast & densely stored hashmap and hashset (mingw-w64)'
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+url='https://github.com/martinus/unordered_dense'
+license=('spdx:MIT')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
+source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/martinus/${_realname}/archive/refs/tags/v${pkgver}.tar.gz")
+sha512sums=('82724dd3651f520a240b131fa7cac209d844b9f3a54ea36c8cbb125cb42fdbf5f38d96935f2999e5bf04c447b2b9fde4ebc740decfd7d3d4b7d45177d4f26b58')
+
+build() {
+  [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}
+  mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G "Ninja" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    ../${_realname}-${pkgver}
+
+  ${MINGW_PREFIX}/bin/cmake.exe --build ./
+}
+
+package() {
+  cd ${srcdir}/build-${MSYSTEM}
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install ./
+
+  install -Dm644 ${srcdir}/${_realname}-${pkgver}/README.md ${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}/README.md
+  install -Dm644 ${srcdir}/${_realname}-${pkgver}/LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+}


### PR DESCRIPTION
The Vulkan Validation Layers is about to switch from using [robin_hood_hashing](https://github.com/martinus/robin-hood-hashing) to [unordered_dense](https://github.com/martinus/unordered_dense).
