### PR TITLE
rust: rebuild for LLVM 18

### DIFF
--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -13,7 +13,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-rust-docs"))
 pkgver=1.76.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
@@ -41,7 +41,9 @@ source=("https://static.rust-lang.org/dist/${_realname}c-${pkgver}-src.tar.gz"{,
         "0005-win32-config.patch"
         "0007-clang-subsystem.patch"
         "0008-disable-self-contained.patch"
-        "0011-disable-uac-for-installer.patch")
+        "0011-disable-uac-for-installer.patch"
+        # remove after rust >= 1.78.0
+        "0012-update-to-llvm-18.patch::https://github.com/rust-lang/rust/pull/120055.patch")
 noextract=(${_realname}c-${pkgver}-src.tar.gz)
 sha256sums=('9e5cff033a7f0d2266818982ad90e4d3e4ef8f8ee1715776c6e25073a136c021'
             'SKIP'
@@ -49,7 +51,8 @@ sha256sums=('9e5cff033a7f0d2266818982ad90e4d3e4ef8f8ee1715776c6e25073a136c021'
             '7d1c4e49524b835a8eadc961b39f5594b12a522a1e24368999be2c7e85399e4e'
             '1f668f4aed56060ec74fd53a39da1fbaef69b84de510d955baf349db672a8d15'
             '7a3b5722ff576b0661f36796f088dee4ce318b5dbc3fdcd65b48972de68a0edf'
-            'e7c13f738c670f3d5ce1742eff71e15bb6675ebe86a58dee44d6a58541bdd5a8')
+            'e7c13f738c670f3d5ce1742eff71e15bb6675ebe86a58dee44d6a58541bdd5a8'
+            '2a7378c7c2c1298f84d69f2f7040ac59ac619c89cadd57c478624b199b499ee7')
 validpgpkeys=('108F66205EAEB0AAA8DD5E1C85AB96E6FA1BE5FE'  # Rust Language (Tag and Release Signing Key) <rust-key@rust-lang.org>
               '474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard <tstellar@redhat.com>
               'B6C8F98282B944E3B0D5C2530FC3042E345AD05D') # Hans Wennborg <hans@chromium.org>
@@ -95,6 +98,10 @@ prepare() {
     apply_patch_with_msg \
       0011-disable-uac-for-installer.patch
   fi
+
+  # https://github.com/rust-lang/rust/pull/120055
+  apply_patch_with_msg \
+    0012-update-to-llvm-18.patch
 }
 
 build() {


### PR DESCRIPTION
LLVM 18 support will be added only at rust 1.78.0, so applying upstream changes now