### PR TITLE
vala: update to v0.56.16

### DIFF
--- a/mingw-w64-vala/PKGBUILD
+++ b/mingw-w64-vala/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=vala
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.56.15
+pkgver=0.56.16
 pkgrel=1
 pkgdesc="Compiler for the GObject type system (mingw-w64)"
 arch=('any')
@@ -20,7 +20,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-glib2"
          "${MINGW_PACKAGE_PREFIX}-graphviz")
 source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz
         0001-relocate-plugin-path.patch)
-sha256sums=('535b6452ed310fd5fb5c7dd6794b6213dac3b48e645e5bff3173741ec2cb3f2b'
+sha256sums=('05487b5600f5d2f09e66a753cccd8f39c1bff9f148aea1b7774d505b9c8bca9b'
             '266756afe0fa2871800e2d4cbf5db5c9e9e68abd52f7f694f077c7e425bc2772')
 msys2_repository_url="https://gitlab.gnome.org/GNOME/vala"
 
@@ -37,7 +37,6 @@ build() {
   [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
-  CFLAGS+=" -Wno-incompatible-pointer-types" \
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \


### PR DESCRIPTION
Remove CFLAG `-Wno-incompatible-pointer-types` since upstream fixed it.

See also: https://gitlab.gnome.org/GNOME/vala/-/commit/23ec71b1a5c4cead3d1bdac82e184d0a63fa7b79