### PR TITLE
libcgosling: initial package [do not merge]

### DIFF
--- a/mingw-w64-libcgosling/PKGBUILD
+++ b/mingw-w64-libcgosling/PKGBUILD
@@ -1,0 +1,41 @@
+# Maintainer: Richard Pospesel <richard@blueprintforfreespeech.net>
+
+_realname=libcgosling
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.2.2
+pkgrel=1
+pkgdesc="C bindings for Gosling crate"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+url=https://github.com/blueprint-freespeech/gosling
+license=('BSD-3-Clause')
+source=("git+https://github.com/blueprint-freespeech/gosling?signed#tag=cgosling-v${pkgver}")
+sha256sums=('SKIP')
+validpgpkeys=(
+    'BE7C914CC922CED9D93D23B7DE47360363F34B2C' # Richard Pospesel <richard@blueprintforfreespeech.net>
+)
+makedepends=(
+    "make"
+    "${MINGW_PACKAGE_PREFIX}-cmake"
+    "${MINGW_PACKAGE_PREFIX}-rust"
+    "${MINGW_PACKAGE_PREFIX}-clang"
+)
+optdepends=("${MINGW_PACKAGE_PREFIX}-tor")
+
+build() {
+  ${MINGW_PREFIX}/bin/cmake \
+    -G "Unix Makefiles" \
+    -S "${srcdir}/gosling" \
+    -B "${srcdir}/build-${MSYSTEM}" \
+    -DCMAKE_C_COMPILER="clang" \
+    -DCMAKE_CXX_COMPILER="clang++" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DCMAKE_BUILD_TYPE=Release \
+
+  ${MINGW_PREFIX}/bin/cmake --build "${srcdir}/build-${MSYSTEM}"
+}
+
+package() {
+  ${MINGW_PREFIX}/bin/cmake --install "${srcdir}/build-${MSYSTEM}"
+}


### PR DESCRIPTION
Hello! I just got this working with clang64 and wanted to verify the rest of the valid targets work in CI.

Verified locally using makepkg, but I'm a bit confused as to why I seem to need to explicitly set the cmake CC and CXX variables (clang and clang++) when other CMake-based PKGBUILD recipes don't seem to need to do this as a rule (though some do of course).

Anyway, I've tried my best to follow what other package recipes are already doing, but happy to make changes to be more idiomatic or correct.

Thanks!