### PR TITLE
octave: update to 9.1.0

### DIFF
--- a/mingw-w64-octave/0003-no-community-support.patch
+++ b/mingw-w64-octave/0003-no-community-support.patch
@@ -1,21 +1,12 @@
-# HG changeset patch
-# User Markus Mützel <markus.muetzel@gmx.de>
-# Date 1680279978 -7200
-#      Fri Mar 31 18:26:18 2023 +0200
-# Node ID aaffb33108d308b386fe54c0e2b05619d88f13c6
-# Parent  89850bb5eb31f776d527aa14295100be61a1e7b4
-Add note about no community support for CLANG*64 versions.
-
-diff -r 89850bb5eb31 -r aaffb33108d3 liboctave/version.cc
 --- a/liboctave/version.cc	Fri Mar 31 18:07:24 2023 +0200
 +++ b/liboctave/version.cc	Fri Mar 31 18:26:18 2023 +0200
-@@ -73,7 +73,8 @@
-   // --version, the version number should follow the last space on the
-   // line.
+@@ -76,7 +76,8 @@
  
--  return "GNU Octave, version " OCTAVE_VERSION "\n" OCTAVE_COPYRIGHT;
-+  return "GNU Octave, version " OCTAVE_VERSION "\n" OCTAVE_COPYRIGHT
-+         "\n\nThis version is not supported by the Octave community.\n";
+   return "GNU Octave, version " OCTAVE_VERSION
+          + br
+-         + OCTAVE_COPYRIGHT;
++         + OCTAVE_COPYRIGHT
++         +"\n\nThis version is not supported by the Octave community.\n";
  }
  
  std::string

--- a/mingw-w64-octave/PKGBUILD
+++ b/mingw-w64-octave/PKGBUILD
@@ -1,64 +1,76 @@
 _realname=octave
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-pkgver=8.4.0
-pkgrel=5
+pkgver=9.1.0
+pkgrel=1
 pkgdesc="GNU Octave: Interactive programming environment for numerical computations (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://www.octave.org"
 msys2_repository_url="https://github.com/gnu-octave/octave"
 msys2_references=(
   'archlinux: octave'
 )
 license=('spdx:GPL-3.0-or-later')
-arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran")
+         "${MINGW_PACKAGE_PREFIX}-fontconfig"
+         "${MINGW_PACKAGE_PREFIX}-freetype"
+         "${MINGW_PACKAGE_PREFIX}-libiconv"
+         "${MINGW_PACKAGE_PREFIX}-libwinpthread-git"
+         "${MINGW_PACKAGE_PREFIX}-omp"
          "${MINGW_PACKAGE_PREFIX}-openblas"
-         "${MINGW_PACKAGE_PREFIX}-arpack"
-         "${MINGW_PACKAGE_PREFIX}-curl"
-         "${MINGW_PACKAGE_PREFIX}-fftw"
-         "${MINGW_PACKAGE_PREFIX}-ghostscript"
-         "${MINGW_PACKAGE_PREFIX}-gl2ps"
-         $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || echo "${MINGW_PACKAGE_PREFIX}-glpk")
-         "${MINGW_PACKAGE_PREFIX}-graphicsmagick"
-         "${MINGW_PACKAGE_PREFIX}-hdf5"
-         "${MINGW_PACKAGE_PREFIX}-libsndfile"
          "${MINGW_PACKAGE_PREFIX}-pcre2"
-         "${MINGW_PACKAGE_PREFIX}-qhull"
-         "${MINGW_PACKAGE_PREFIX}-suitesparse"
-         "${MINGW_PACKAGE_PREFIX}-sundials"
-         "${MINGW_PACKAGE_PREFIX}-qrupdate"
-         "${MINGW_PACKAGE_PREFIX}-qscintilla-qt5"
-         "${MINGW_PACKAGE_PREFIX}-qt5-tools")
+         "${MINGW_PACKAGE_PREFIX}-readline"
+         "${MINGW_PACKAGE_PREFIX}-zlib"
+         $([[ ${CARCH} == i686 ]] && echo \
+           "${MINGW_PACKAGE_PREFIX}-qt5-tools" || echo \
+           "${MINGW_PACKAGE_PREFIX}-arpack" \
+           "${MINGW_PACKAGE_PREFIX}-curl" \
+           "${MINGW_PACKAGE_PREFIX}-fftw" \
+           "${MINGW_PACKAGE_PREFIX}-ghostscript" \
+           "${MINGW_PACKAGE_PREFIX}-gl2ps" \
+           "${MINGW_PACKAGE_PREFIX}-glpk" \
+           "${MINGW_PACKAGE_PREFIX}-graphicsmagick" \
+           "${MINGW_PACKAGE_PREFIX}-hdf5" \
+           "${MINGW_PACKAGE_PREFIX}-libsndfile" \
+           "${MINGW_PACKAGE_PREFIX}-qhull" \
+           "${MINGW_PACKAGE_PREFIX}-qrupdate" \
+           "${MINGW_PACKAGE_PREFIX}-qscintilla-qt6" \
+           "${MINGW_PACKAGE_PREFIX}-qt6-tools" \
+           "${MINGW_PACKAGE_PREFIX}-suitesparse" \
+           "${MINGW_PACKAGE_PREFIX}-sundials")
+        )
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-fc"
-             $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || echo "${MINGW_PACKAGE_PREFIX}-gnuplot")
              "${MINGW_PACKAGE_PREFIX}-gperf"
-             "${MINGW_PACKAGE_PREFIX}-fltk"
-             "${MINGW_PACKAGE_PREFIX}-portaudio"
-             "${MINGW_PACKAGE_PREFIX}-rapidjson")
+             $([[ ${CARCH} == i686 ]] || echo \
+               "${MINGW_PACKAGE_PREFIX}-gnuplot" \
+               "${MINGW_PACKAGE_PREFIX}-fltk" \
+               "${MINGW_PACKAGE_PREFIX}-portaudio" \
+               "${MINGW_PACKAGE_PREFIX}-rapidjson")
+            )
 checkdepends=("unzip"
               "zip")
 optdepends=('texinfo: for help-support in Octave'
             "unzip: for decompressing .zip archives"
-            "zip: for compressing .zip archives"
-            "${MINGW_PACKAGE_PREFIX}-epstool: eps output with tight bounding box"
-            "${MINGW_PACKAGE_PREFIX}-fltk: alternative plotting and dialogs"
-            "${MINGW_PACKAGE_PREFIX}-gnuplot: alternative plotting"
-            "${MINGW_PACKAGE_PREFIX}-portaudio: audio support")
+            "zip: for compressing .zip archives")
+if [[ ${CARCH} != i686 ]]; then
+  optdepends+=("${MINGW_PACKAGE_PREFIX}-epstool: eps output with tight bounding box"
+               "${MINGW_PACKAGE_PREFIX}-fltk: alternative plotting and dialogs"
+               "${MINGW_PACKAGE_PREFIX}-gnuplot: alternative plotting"
+               "${MINGW_PACKAGE_PREFIX}-portaudio: audio support")
+fi
 source=(https://ftp.gnu.org/gnu/octave/octave-$pkgver.tar.xz{,.sig}
-        "0001-no-namespace-in-extern-C.patch::https://hg.savannah.gnu.org/hgweb/octave/raw-rev/123c5d78fc9d"
         "0002-mk-doc-cache-path.patch"
         "0003-no-community-support.patch"
         "0005-makeinfo-perl.patch")
 validpgpkeys=('DBD9C84E39FE1AAE99F04446B05F05B75D36644B')  # John W. Eaton
-sha256sums=('6f9ad73a3ee4291b6341d6c0f5e5c85d6e0310376e4991b959a6d340b3ffa8a8'
+sha256sums=('ed654b024aea56c44b26f131d31febc58b7cf6a82fad9f0b0bf6e3e9aa1a134b'
             'SKIP'
-            '82909b2b878aff25b276e73def14a14c2756ae3688275df154a425105e3abc33'
             'aa5bd559d9774abc0f0c930a606762d1e452cc90278d16d8ae83561c0cae3bf8'
-            '14f6afe84529982041e20653a8c146630f598493abbdf5e8d52f0bee80326a5b'
+            '313daf7bf0080e4d645a601dedc36208de466af51ffbc74afc21e8505544e45d'
             '3f6756b39547d996955762b71ce6845a8ebfde6bad92a3a1a6d72fd43df5973d')
 
 apply_patch_with_msg() {
@@ -78,7 +90,6 @@ prepare() {
 
   if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
     apply_patch_with_msg \
-      0001-no-namespace-in-extern-C.patch \
       0003-no-community-support.patch
 
     # We need the patched libtool with Flang specific changes.
@@ -103,19 +114,14 @@ build() {
                     "--enable-fortran-calling-convention=gfortran"
                     "ac_cv_f77_compiler_gnu=yes"
                     "lt_cv_prog_gnu_ld=yes"
-                    "F77=${MINGW_PREFIX}/bin/flang"
-                    # LLVM 16 seems to have switched defaults to C++17.
-                    # Apparently, some STL functions that are deprecated in that
-                    # version of the standard are used.  For the time being,
-                    # build with the C++14 feature set (and GNU extensions).
-                    "CXX=${MINGW_PREFIX}/bin/clang++ -std=gnu++14")
+                    "F77=${MINGW_PREFIX}/bin/flang")
     # The headers from some dependent libraries (graphicsmagick++?) cause a
     # torrent of warnings about deprecated declarations.  Sometimes to the
     # point that the build crashes with garbled characters in the terminal
     # output for some reason.  Just calling `make all -j2` again in the build
     # tree lets the compilation finish successfully.
     # Disable those warnings as a work-around.
-    CXXFLAGS+=" -Wno-deprecated-declarations"
+    CXXFLAGS+=" -Wno-deprecated-declarations -Wno-ignored-attributes"
   fi
 
   # The configure step sometimes hangs for MINGW32 for currently unknown reasons.
@@ -123,9 +129,6 @@ build() {
   # the build system in that case.
   timeout 30m \
   ../${_realname}-${pkgver}/configure \
-    --host=${MINGW_CHOST} \
-    --target=${MINGW_CHOST} \
-    --build=${MINGW_CHOST} \
     --prefix=${MINGW_PREFIX} \
     --libexecdir=${MINGW_PREFIX}/lib \
     --sbindir=${MINGW_PREFIX}/bin \
@@ -155,4 +158,6 @@ package() {
   for pcfile in "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/*.pc; do
     sed -s "s|${_PREFIX_WIN}|${MINGW_PREFIX}|g" -i "${pcfile}"
   done
+
+  install -D -m644 "${srcdir}"/${_realname}-${pkgver}/COPYING "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/COPYING
 }


### PR DESCRIPTION
- Build against Qt6 on non-i686 environments.
- Add all runtime dependencies to `depends()`.
- glpk and gnuplot are now available on clangarm64.
- Fix 0003-no-community-support.patch 
- Install COPYING file.
- remove `-std=gnu++14` c++ flag on clang environments as Qt6 requires c++17.
- Build it with minimal dependencies on MINGW32

@mmuetzel