### PR TITLE
octave: update to 9.1.0

### DIFF
--- a/mingw-w64-octave/0003-no-community-support.patch
+++ b/mingw-w64-octave/0003-no-community-support.patch
@@ -7,14 +7,14 @@
 Add note about no community support for CLANG*64 versions.
 
 diff -r 89850bb5eb31 -r aaffb33108d3 liboctave/version.cc
---- a/liboctave/version.cc	Fri Mar 31 18:07:24 2023 +0200
-+++ b/liboctave/version.cc	Fri Mar 31 18:26:18 2023 +0200
-@@ -73,7 +73,8 @@
-   // --version, the version number should follow the last space on the
-   // line.
+--- octave-9.1.0/liboctave/version.cc.orig	2024-03-15 18:57:08.844733200 +0100
++++ octave-9.1.0/liboctave/version.cc	2024-03-15 18:59:07.632471500 +0100
+@@ -76,7 +76,8 @@
  
--  return "GNU Octave, version " OCTAVE_VERSION "\n" OCTAVE_COPYRIGHT;
-+  return "GNU Octave, version " OCTAVE_VERSION "\n" OCTAVE_COPYRIGHT
+   return "GNU Octave, version " OCTAVE_VERSION
+          + br
+-         + OCTAVE_COPYRIGHT;
++         + OCTAVE_COPYRIGHT
 +         "\n\nThis version is not supported by the Octave community.\n";
  }
  

--- a/mingw-w64-octave/PKGBUILD
+++ b/mingw-w64-octave/PKGBUILD
@@ -1,8 +1,8 @@
 _realname=octave
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-pkgver=8.4.0
-pkgrel=5
+pkgver=9.1.0
+pkgrel=1
 pkgdesc="GNU Octave: Interactive programming environment for numerical computations (mingw-w64)"
 url="https://www.octave.org"
 msys2_repository_url="https://github.com/gnu-octave/octave"
@@ -14,27 +14,27 @@ arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran")
-         "${MINGW_PACKAGE_PREFIX}-openblas"
          "${MINGW_PACKAGE_PREFIX}-arpack"
          "${MINGW_PACKAGE_PREFIX}-curl"
          "${MINGW_PACKAGE_PREFIX}-fftw"
          "${MINGW_PACKAGE_PREFIX}-ghostscript"
          "${MINGW_PACKAGE_PREFIX}-gl2ps"
-         $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || echo "${MINGW_PACKAGE_PREFIX}-glpk")
+         "${MINGW_PACKAGE_PREFIX}-glpk"
          "${MINGW_PACKAGE_PREFIX}-graphicsmagick"
          "${MINGW_PACKAGE_PREFIX}-hdf5"
          "${MINGW_PACKAGE_PREFIX}-libsndfile"
+         "${MINGW_PACKAGE_PREFIX}-openblas"
          "${MINGW_PACKAGE_PREFIX}-pcre2"
          "${MINGW_PACKAGE_PREFIX}-qhull"
-         "${MINGW_PACKAGE_PREFIX}-suitesparse"
-         "${MINGW_PACKAGE_PREFIX}-sundials"
          "${MINGW_PACKAGE_PREFIX}-qrupdate"
-         "${MINGW_PACKAGE_PREFIX}-qscintilla-qt5"
-         "${MINGW_PACKAGE_PREFIX}-qt5-tools")
+         $([[ ${CARCH} == i686 ]] && echo "${MINGW_PACKAGE_PREFIX}-qscintilla-qt5" || echo "${MINGW_PACKAGE_PREFIX}-qscintilla-qt6")
+         $([[ ${CARCH} == i686 ]] && echo "${MINGW_PACKAGE_PREFIX}-qt5-tools" || echo "${MINGW_PACKAGE_PREFIX}-qt6-tools")
+         "${MINGW_PACKAGE_PREFIX}-suitesparse"
+         "${MINGW_PACKAGE_PREFIX}-sundials")
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-fc"
-             $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || echo "${MINGW_PACKAGE_PREFIX}-gnuplot")
+             "${MINGW_PACKAGE_PREFIX}-gnuplot"
              "${MINGW_PACKAGE_PREFIX}-gperf"
              "${MINGW_PACKAGE_PREFIX}-fltk"
              "${MINGW_PACKAGE_PREFIX}-portaudio"
@@ -49,16 +49,16 @@ optdepends=('texinfo: for help-support in Octave'
             "${MINGW_PACKAGE_PREFIX}-gnuplot: alternative plotting"
             "${MINGW_PACKAGE_PREFIX}-portaudio: audio support")
 source=(https://ftp.gnu.org/gnu/octave/octave-$pkgver.tar.xz{,.sig}
-        "0001-no-namespace-in-extern-C.patch::https://hg.savannah.gnu.org/hgweb/octave/raw-rev/123c5d78fc9d"
+        "0001-correct-LIBS.patch::https://hg.savannah.gnu.org/hgweb/octave/raw-rev/557fbfea93ab"
         "0002-mk-doc-cache-path.patch"
         "0003-no-community-support.patch"
         "0005-makeinfo-perl.patch")
 validpgpkeys=('DBD9C84E39FE1AAE99F04446B05F05B75D36644B')  # John W. Eaton
-sha256sums=('6f9ad73a3ee4291b6341d6c0f5e5c85d6e0310376e4991b959a6d340b3ffa8a8'
+sha256sums=('ed654b024aea56c44b26f131d31febc58b7cf6a82fad9f0b0bf6e3e9aa1a134b'
             'SKIP'
-            '82909b2b878aff25b276e73def14a14c2756ae3688275df154a425105e3abc33'
+            '71fb01e039c79781e52cf95506ad3126c9e911a5f20e796195ca84faa73e9b9c'
             'aa5bd559d9774abc0f0c930a606762d1e452cc90278d16d8ae83561c0cae3bf8'
-            '14f6afe84529982041e20653a8c146630f598493abbdf5e8d52f0bee80326a5b'
+            'e53af21ad087e10a2906506589aab89ab8b43f4e3e4994b4c28e4d8ae83639ad'
             '3f6756b39547d996955762b71ce6845a8ebfde6bad92a3a1a6d72fd43df5973d')
 
 apply_patch_with_msg() {
@@ -73,18 +73,16 @@ prepare() {
   cd "${_realname}-${pkgver}"
 
   apply_patch_with_msg \
+    0001-correct-LIBS.patch \
     0002-mk-doc-cache-path.patch \
     0005-makeinfo-perl.patch
 
   if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
     apply_patch_with_msg \
-      0001-no-namespace-in-extern-C.patch \
       0003-no-community-support.patch
-
-    # We need the patched libtool with Flang specific changes.
-    autoreconf -fiv
   fi
 
+  autoreconf -fiv
 }
 
 build() {
@@ -92,30 +90,20 @@ build() {
 
   declare -a _extra_config
   if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
-    _extra_config+=(# Clang seems to require a different set of dllexport
-                    # attributes than GCC.  For the time being, export all
-                    # symbols (including those from gnulib and other static
-                    # libraries linked into the Octave libraries).  Doing that
-                    # might cause issues in some cases.  But solving this
-                    # without breaking GCC support might be difficult.
-                    "--disable-lib-visibility-flags"
-                    # Libtool still needs some hints how to handle LLVM Flang:
-                    "--enable-fortran-calling-convention=gfortran"
+    # Libtool still needs some hints how to handle LLVM Flang:
+    _extra_config+=("--enable-fortran-calling-convention=gfortran"
                     "ac_cv_f77_compiler_gnu=yes"
                     "lt_cv_prog_gnu_ld=yes"
                     "F77=${MINGW_PREFIX}/bin/flang"
-                    # LLVM 16 seems to have switched defaults to C++17.
-                    # Apparently, some STL functions that are deprecated in that
-                    # version of the standard are used.  For the time being,
-                    # build with the C++14 feature set (and GNU extensions).
-                    "CXX=${MINGW_PREFIX}/bin/clang++ -std=gnu++14")
+                    "LDFLAGS=")
     # The headers from some dependent libraries (graphicsmagick++?) cause a
     # torrent of warnings about deprecated declarations.  Sometimes to the
     # point that the build crashes with garbled characters in the terminal
-    # output for some reason.  Just calling `make all -j2` again in the build
-    # tree lets the compilation finish successfully.
+    # output for some reason.  Same issue with dllimport attributes at
+    # inlined functions in Qt6 headers. Just calling `make all -j2` again in
+    # the build tree lets the compilation finish successfully.
     # Disable those warnings as a work-around.
-    CXXFLAGS+=" -Wno-deprecated-declarations"
+    CXXFLAGS+=" -Wno-deprecated-declarations -Wno-ignored-attributes"
   fi
 
   # The configure step sometimes hangs for MINGW32 for currently unknown reasons.
@@ -127,14 +115,10 @@ build() {
     --target=${MINGW_CHOST} \
     --build=${MINGW_CHOST} \
     --prefix=${MINGW_PREFIX} \
-    --libexecdir=${MINGW_PREFIX}/lib \
-    --sbindir=${MINGW_PREFIX}/bin \
     --enable-shared \
     --disable-static \
     --enable-relocate-all \
-    --enable-link-all-dependencies \
     "${_extra_config[@]}" \
-    gl_cv_have_weak=no \
     octave_cv_fftw3_threads_lib="-lfftw3_omp" \
     octave_cv_fftw3f_threads_lib="-lfftw3f_omp" \
     JAVA_HOME=""


### PR DESCRIPTION
Build with some packages that are available on CLANGARM64 now.
Build with Qt5 packages for MINGW32, build with Qt6 packages otherwise.
Suppress more warnings from Clang that seem to break the terminal somehow.
Drop some configure flags that are no longer needed.
Refresh a patch that no longer applied cleanly.
