### PR TITLE
qt6-base: Fix zombie processes due to qt dbus

### DIFF
--- a/mingw-w64-qt6-base/013-qt-5.7.0-qdbus-manager-quit.patch
+++ b/mingw-w64-qt6-base/013-qt-5.7.0-qdbus-manager-quit.patch
@@ -1,0 +1,13 @@
+--- a/src/dbus/qdbusconnection.cpp
++++ b/src/dbus/qdbusconnection.cpp
+@@ -96,6 +96,10 @@
+             this, &QDBusConnectionManager::createServer, Qt::BlockingQueuedConnection);
+     moveToThread(this);         // ugly, don't do this in other projects
+ 
++    qAddPostRoutine([]() {
++        QMetaObject::invokeMethod(QDBusConnectionManager::instance(), "quit");
++    });
++
+ #ifdef Q_OS_WIN
+     // prevent the library from being unloaded on Windows. See comments in the function.
+     preventDllUnload();

--- a/mingw-w64-qt6-base/PKGBUILD
+++ b/mingw-w64-qt6-base/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
 _qtver=6.6.2
 pkgver=${_qtver/-/}
-pkgrel=1
+pkgrel=2
 pkgdesc="A cross-platform application and UI framework (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -52,7 +52,8 @@ source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/subm
         009-qfileinfo-undefine-mingw-stat.patch
         010-export-some-constexpr-variables.patch
         011-qt6-windeployqt-fixes.patch
-        012-fix-unicode-definitions-in-cmake-interface.patch)
+        012-fix-unicode-definitions-in-cmake-interface.patch
+        013-qt-5.7.0-qdbus-manager-quit.patch)
 sha256sums=('b89b426b9852a17d3e96230ab0871346574d635c7914480a2a27f98ff942677b'
             '94b99116136156af6a97bdd080434287a06eb16dd64d335aee94d75340a8b299'
             '3848318bccdfa21a139ccdb70f8226358c4a7ed3943231494aab3df83025d7c7'
@@ -63,7 +64,8 @@ sha256sums=('b89b426b9852a17d3e96230ab0871346574d635c7914480a2a27f98ff942677b'
             'f4261d43a142a24e5fa3b23e25813754839db84078cc8c6dc611139bf531e64a'
             '23656a7839d7dcb763d022722d723493c847914b0639bab861ddb05d823af5b7'
             '7f1a0a14f423741956253690d16d635055a8e887fe39f7f0160d40c5c63ae1b1'
-            'b217dad1b9ebf212f4d0d5c88140c26c491373e66d3ae88cb98deb5d688e59b0')
+            'b217dad1b9ebf212f4d0d5c88140c26c491373e66d3ae88cb98deb5d688e59b0'
+            'f7e88a1515745ae82ee7d9f39cc3c4f48520f1d88d7f47bc8f27cc2a2bc47f53')
 
 # Use the right mkspecs file
 if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
@@ -92,7 +94,8 @@ prepare() {
     006-qt-6.2.0-dont-add-resource-files-to-qmake-libs.patch \
     007-Fix-crashes-in-rasterization-code-using-setjmp.patch \
     009-qfileinfo-undefine-mingw-stat.patch \
-    011-qt6-windeployqt-fixes.patch
+    011-qt6-windeployqt-fixes.patch \
+    013-qt-5.7.0-qdbus-manager-quit.patch
 
   # For: https://github.com/msys2/MINGW-packages/issues/15801
   # See: https://bugreports.qt.io/browse/QTBUG-103019


### PR DESCRIPTION
Similar as f6eacbcdd74cc836294e8e7337c5d3cf772a3117

Fixes #13198 (but with qt6)
