### PR TITLE
add krokiet as separate package for czkawka

### DIFF
--- a/mingw-w64-czkawka/PKGBUILD
+++ b/mingw-w64-czkawka/PKGBUILD
@@ -3,14 +3,14 @@
 _realname=czkawka
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-cli"
-         "${MINGW_PACKAGE_PREFIX}-${_realname}-gui")
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-gui"
+         "${MINGW_PACKAGE_PREFIX}-krokiet")
 pkgver=7.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Multi functional app to find duplicates, empty folders, similar images etc (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://github.com/qarmin/czkawka'
-license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-gdk-pixbuf2"
          "${MINGW_PACKAGE_PREFIX}-glib2"
@@ -22,48 +22,58 @@ sha256sums=('ce7d072056dedc4f2ca4d3647dc786ba071d4f3c58e79415da18d7dafd62e87b')
 noextract=("${_realname}-${pkgver}.tar.gz")
 
 prepare() {
-  cd "${srcdir}"
   tar -xzf "${_realname}-${pkgver}.tar.gz" || true
   cd "${_realname}-${pkgver}"
 
-  local _target="${CARCH}-pc-windows-gnu"
-  if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
-    _target="${CARCH}-pc-windows-gnullvm"
-  fi
-
-  cargo fetch --locked --target "${_target}"
+  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
 }
 
 build() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
-  export PKG_CONFIG_PATH="${MINGW_PREFIX}/lib/pkgconfig"
-  cargo build --bin czkawka_cli --release --features "heif libraw"
-  cargo build --bin czkawka_gui --release --features "heif libraw"
+  cargo build --bin czkawka_cli --release --frozen --features "heif libraw"
+  cargo build --bin czkawka_gui --release --frozen --features "heif libraw"
+  cargo build --bin krokiet --release --frozen --features "heif libraw"
 }
 
 check() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
-  cargo test --bin czkawka_cli --release --features "heif libraw"
-  cargo test --bin czkawka_gui --release --features "heif libraw"
+  cargo test --bin czkawka_cli --release --frozen --features "heif libraw"
+  cargo test --bin czkawka_gui --release --frozen --features "heif libraw"
+  cargo test --bin krokiet --release --frozen --features "heif libraw"
 }
 
 package_czkawka-cli() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
   depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-libheif")
+  license=('spdx:MIT')
   pkgdesc+=" (CLI)"
 
+  install -Dm644 czkawka_cli/LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}_cli/LICENSE"
   install -Dm755 target/release/czkawka_cli.exe "${pkgdir}${MINGW_PREFIX}/bin/czkawka_cli.exe"
 }
 
 package_czkawka-gui() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
+  license=('spdx:MIT AND CC-BY-4.0')
   pkgdesc+=" (Desktop App)"
 
+  install -Dm644 czkawka_gui/LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}_gui/LICENSE"
   install -Dm755 target/release/czkawka_gui.exe "${pkgdir}${MINGW_PREFIX}/bin/czkawka_gui.exe"
+}
+
+package_krokiet() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-libheif")
+  license=('spdx:MIT AND GPL-3.0-or-later')
+  pkgdesc="New Czkawka frontend written in Slint (mingw-w64)"
+
+  install -Dm644 krokiet/LICENSE{,_MIT_CODE} -t "${pkgdir}${MINGW_PREFIX}/share/licenses/krokiet/"
+  install -Dm755 target/release/krokiet.exe "${pkgdir}${MINGW_PREFIX}/bin/krokiet.exe"
 }
 
 # template start; name=mingw-w64-splitpkg-wrappers; version=1.0;


### PR DESCRIPTION
upstream recommends to use it instead of czkawka_gui as krokiet has more reliable GUI backend
starting from this PR I'll use this `"$(rustc -vV | sed -n 's/host: //p')"` to fetch target triple