### PR TITLE
transmission: Enable aarch64 builds

### DIFF
--- a/mingw-w64-transmission/PKGBUILD
+++ b/mingw-w64-transmission/PKGBUILD
@@ -8,7 +8,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-cli"
 pkgver=4.0.5
 pkgrel=1
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 msys2_references=(
   'archlinux: transmission-gtk'
 )

--- a/mingw-w64-transmission/PKGBUILD
+++ b/mingw-w64-transmission/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-cli"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-gtk"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-qt")
 pkgver=4.0.5
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 msys2_references=(
@@ -32,7 +32,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-qt5-base"
              "${MINGW_PACKAGE_PREFIX}-qt5-svg"
              "${MINGW_PACKAGE_PREFIX}-qt5-tools"
-             "${MINGW_PACKAGE_PREFIX}-qt5-winextras")
+             "${MINGW_PACKAGE_PREFIX}-qt5-winextras"
+             "${MINGW_PACKAGE_PREFIX}-gettext-tools")
 source=("https://github.com/transmission/transmission/releases/download/${pkgver}/transmission-${pkgver}.tar.xz")
 sha256sums=('fd68ff114a479200043c30c7e69dba4c1932f7af36ca4c5b5d2edcb5866e6357')
 noextract=("transmission-${pkgver}.tar.xz")


### PR DESCRIPTION
![image](https://github.com/msys2/MINGW-packages/assets/1100440/f5f1213b-c8a4-4f10-b31d-37eeabf0f8a8)
