### PR TITLE
neovim-qt: Enable aarch64 builds

### DIFF
--- a/mingw-w64-neovim-qt/PKGBUILD
+++ b/mingw-w64-neovim-qt/PKGBUILD
@@ -7,7 +7,7 @@ pkgver=0.2.18
 pkgrel=1
 pkgdesc="Neovim client library and GUI, in Qt5. (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 msys2_references=(
   'archlinux: neovim-qt'
 )


### PR DESCRIPTION
![image](https://github.com/msys2/MINGW-packages/assets/1100440/c6163e3e-03cc-4e64-8490-719fbf5afc21)
