### PR TITLE
libdispatch: update to 5.10

### DIFF
--- a/mingw-w64-libdispatch/001-link-libBlocksRuntime.patch
+++ b/mingw-w64-libdispatch/001-link-libBlocksRuntime.patch
@@ -1,0 +1,10 @@
+diff --git a/src/BlocksRuntime/BlocksRuntime.def b/src/BlocksRuntime/BlocksRuntime.def
+index a3b1aab..3e1f033 100644
+--- a/src/BlocksRuntime/BlocksRuntime.def
++++ b/src/BlocksRuntime/BlocksRuntime.def
+@@ -1,4 +1,4 @@
+-LIBRARY BlocksRuntime
++LIBRARY libBlocksRuntime
+ EXPORTS
+   _NSConcreteGlobalBlock CONSTANT
+   _NSConcreteStackBlock CONSTANT

--- a/mingw-w64-libdispatch/PKGBUILD
+++ b/mingw-w64-libdispatch/PKGBUILD
@@ -4,25 +4,30 @@ _realname=libdispatch
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-libblocksruntime-swift")
-pkgver=5.9.2
+pkgver=5.10
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
-url="https://github.com/apple/swift-corelibs-libdispatch/"
+url="https://apple.github.io/swift-corelibs-libdispatch/"
+msys2_repository_url="https://github.com/apple/swift-corelibs-libdispatch/"
 license=('spdx:Apache-2.0')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-clang"
              "${MINGW_PACKAGE_PREFIX}-lld")
-source=("https://github.com/apple/swift-corelibs-libdispatch/archive/refs/tags/swift-${pkgver}-RELEASE.tar.gz"
+source=("https://github.com/apple/swift-corelibs-libdispatch/archive/swift-${pkgver}-RELEASE.tar.gz"
         # Support compiling on MinGW
-        "https://github.com/apple/swift-corelibs-libdispatch/commit/5460cefb493c88f577b8504de5c9718759e04a1b.patch")
-sha256sums=('b1f3e46ed248df6a3456d20bc23b2d8a12b740a40185d81b668b1d31735cadf2'
-            '8f6da4c8029bfa661a92a3d129625720162faad1ceaa1b37e66fbc545860b569')
+        "https://github.com/apple/swift-corelibs-libdispatch/commit/5460cefb493c88f577b8504de5c9718759e04a1b.patch"
+        "001-link-libBlocksRuntime.patch")
+sha256sums=('16e088cf12654d22658879710b9694a6fad1c94d5e5d0c597741b71fbcb3e034'
+            '8f6da4c8029bfa661a92a3d129625720162faad1ceaa1b37e66fbc545860b569'
+            '2b249f8478f9e63c6beb90d679d07102d0903d3ddfd28a265310d6a015b7d802')
 
 prepare() {
   cd ${srcdir}/swift-corelibs-${_realname}-swift-${pkgver}-RELEASE/
 
-  patch -p1 -i ${srcdir}/5460cefb493c88f577b8504de5c9718759e04a1b.patch
+  patch -Np1 -i ${srcdir}/001-link-libBlocksRuntime.patch
+  patch -Np1 -i ${srcdir}/5460cefb493c88f577b8504de5c9718759e04a1b.patch
 }
 
 build() {
@@ -35,6 +40,9 @@ build() {
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
+  export CXXFLAGS+=" -Wno-macro-redefined"
+  export CFLAGS+=" -Wno-macro-redefined"
+
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     LDFLAGS+=" -fuse-ld=lld" \
     "${MINGW_PREFIX}"/bin/cmake.exe \
@@ -42,7 +50,6 @@ build() {
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       -DCMAKE_C_COMPILER="clang" \
       -DCMAKE_CXX_COMPILER="clang++" \
-      -DCMAKE_DLL_NAME_WITH_SOVERSION=ON \
       "${extra_config[@]}" \
       ../swift-corelibs-${_realname}-swift-${pkgver}-RELEASE
 
@@ -50,32 +57,31 @@ build() {
 }
 
 package_libdispatch() {
-  pkgdesc="The libdispatch Project, (a.k.a. Grand Central Dispatch), for concurrency on multicore hardware. (mingw-w64)"
-  depends=("${MINGW_PACKAGE_PREFIX}-libblocksruntime-swift")
+  pkgdesc="The libdispatch Project, (a.k.a. Grand Central Dispatch), for concurrency on multicore hardware (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-libblocksruntime-swift"
+           "${MINGW_PACKAGE_PREFIX}-libwinpthread"
+           $([[ $MINGW_PACKAGE_PREFIX == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-gcc-libs"))
   cd "${srcdir}/build-${MSYSTEM}"
 
   DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
-  rm "${pkgdir}${MINGW_PREFIX}/bin/libBlocksRuntime.dll"
-  rm "${pkgdir}${MINGW_PREFIX}/lib/libBlocksRuntime.dll.a"
-  rm "${pkgdir}${MINGW_PREFIX}/include/Block.h"
+
+  mkdir -p dest${MINGW_PREFIX}/{bin,lib,include}
+  mv "${pkgdir}${MINGW_PREFIX}/bin/libBlocksRuntime.dll" "dest${MINGW_PREFIX}/bin/libBlocksRuntime.dll"
+  mv "${pkgdir}${MINGW_PREFIX}/lib/libBlocksRuntime.dll.a" "dest${MINGW_PREFIX}/lib/libBlocksRuntime.dll.a"
+  mv "${pkgdir}${MINGW_PREFIX}/include/Block.h" "dest${MINGW_PREFIX}/include/Block.h"
 
   install -Dm644 "${srcdir}/swift-corelibs-${_realname}-swift-${pkgver}-RELEASE/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }
 
 package_libblocksruntime-swift() {
-  pkgdesc="Blocks runtime library for Objective C (mingw-w64). (mingw-w64)"
+  pkgdesc="Blocks runtime library for Objective C (mingw-w64)"
   conflicts=("${MINGW_PACKAGE_PREFIX}-libblocksruntime")
   replaces=("${MINGW_PACKAGE_PREFIX}-libblocksruntime")
   provides=("${MINGW_PACKAGE_PREFIX}-libblocksruntime")
 
   cd "${srcdir}/build-${MSYSTEM}"
 
-  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
-  rm "${pkgdir}${MINGW_PREFIX}/bin/libdispatch.dll"
-  rm "${pkgdir}${MINGW_PREFIX}/lib/libdispatch.dll.a"
-  rm -rf "${pkgdir}${MINGW_PREFIX}/include/dispatch/"
-  rm -rf "${pkgdir}${MINGW_PREFIX}/include/os/"
-  rm -rf "${pkgdir}${MINGW_PREFIX}/share/man/"
+  mv dest/* "${pkgdir}"
 
   install -Dm644 "${srcdir}/swift-corelibs-${_realname}-swift-${pkgver}-RELEASE/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/libblocksruntime-swift/LICENSE"
 }


### PR DESCRIPTION
patch **is not** included in the new release https://github.com/apple/swift-corelibs-libdispatch/compare/swift-5.9.2-RELEASE...swift-5.10-RELEASE