### PR TITLE
rust: rebuild

### DIFF
--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -13,7 +13,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-rust-docs"))
 pkgver=1.76.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')


### PR DESCRIPTION
Building the latest Rust on CLANG32 fails. See https://github.com/msys2/MINGW-packages/pull/20397.

I wan't to confirm that it could be related to the toolchain by rebuilding the currrent version.

