### PR TITLE
libobjc2: Update to 2.2.1

### DIFF
--- a/mingw-w64-libobjc2/PKGBUILD
+++ b/mingw-w64-libobjc2/PKGBUILD
@@ -6,8 +6,8 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 if [[ ${MSYSTEM} != CLANG* ]]; then
   conflicts=("${MINGW_PACKAGE_PREFIX}-gcc-objc")
 fi
-pkgver=2.2
-pkgrel=3
+pkgver=2.2.1
+pkgrel=1
 pkgdesc="Objective-C runtime library intended for use with Clang. (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -18,29 +18,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-clang"
              "${MINGW_PACKAGE_PREFIX}-lld"
              'git')
-source=("https://github.com/gnustep/${_realname}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
-        # Install runtime files in CMAKE_INSTALL_BINDIR when GNUstep is not installed
-        "https://github.com/gnustep/libobjc2/commit/639c676bb8033422539e19a2e2888bdbd06507e5.patch"
-        # Support building on msys/clang64
-        "https://github.com/gnustep/libobjc2/commit/1ff5e1298dd76aa370d5a12b690857f9a47b4b56.patch"
-        # MinGW: Remove manual setting of library prefix/suffix
-        "https://github.com/gnustep/libobjc2/commit/f983cdbf683925d942dd1d86edcfe4316bf9ed6c.patch"
-        # MinGW: Use _Unwind_RaiseException to throw exceptions
-        "https://github.com/gnustep/libobjc2/commit/38ebb38bcd5b4af43ddb87a5f34bc4b907795f82.patch")
-sha256sums=('c4c5cede579949249f16736c9b1f85c58c44addb013f59970dcb566d9069152a'
-            'aaa23146b3c2ec442b5dbf20606020bddd15230041ad738ef3a06e92d13605c3'
-            'fba7d33aa03ee7383b559c5b845063acd16b45396520250849f22559577adcc9'
-            'd955fcee075af724a97d63f1b325e97ab6c3d018ac38f0597ef3e8c57b0820e2'
-            '9bc16c12d0cf0f4e2aab4d7222aa6b4ffa6055ae30e40890d7e0e972db6dd532')
-
-prepare() {
-  cd ${srcdir}/${_realname}-${pkgver}
-
-  patch -p1 -i ${srcdir}/639c676bb8033422539e19a2e2888bdbd06507e5.patch
-  patch -p1 -i ${srcdir}/1ff5e1298dd76aa370d5a12b690857f9a47b4b56.patch
-  patch -p1 -i ${srcdir}/f983cdbf683925d942dd1d86edcfe4316bf9ed6c.patch
-  patch -p1 -i ${srcdir}/38ebb38bcd5b4af43ddb87a5f34bc4b907795f82.patch
-}
+source=("https://github.com/gnustep/${_realname}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('768ea8c5bd0999a29b5d15781125494f986456c1dc5c51d370fb31852cd31ea1')
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"


### PR DESCRIPTION
The [v2.2.1](https://github.com/gnustep/libobjc2/releases/tag/v2.2.1) release contains all patches which were required to get libobjc2 building on MSYS2, so we can now build from vanilla upstream.