### PR TITLE
cargo-generate: redesign the recipe

### DIFF
--- a/mingw-w64-cargo-generate/PKGBUILD
+++ b/mingw-w64-cargo-generate/PKGBUILD
@@ -4,7 +4,7 @@ _realname=cargo-generate
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.19.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Use pre-existing git repositories as templates (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -13,44 +13,37 @@ msys2_references=(
   'archlinux: cargo-generate'
 )
 license=('spdx:MIT OR Apache-2.0')
+depends=("${MINGW_PACKAGE_PREFIX}-libgit2" "${MINGW_PACKAGE_PREFIX}-libssh2")
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
-             "${MINGW_PACKAGE_PREFIX}-mdbook")
-source=("$url/archive/v$pkgver/$_realname-$pkgver.tar.gz")
+             "${MINGW_PACKAGE_PREFIX}-mdbook"
+             "${MINGW_PACKAGE_PREFIX}-pkgconf"
+             "${MINGW_PACKAGE_PREFIX}-openssl")
+source=("${url}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('520e7a98bf82f368e911c14e774f8ef16a4c8ffd785d492c9d518ee563dc3864')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
-  cargo vendor \
-    --locked \
-    --versioned-dirs
-
-  mkdir -p .cargo
-  cat >> .cargo/config.toml <<END
-
-[source.crates-io]
-replace-with = "vendored-sources"
-
-[source.vendored-sources]
-directory = "vendor"
-END
-
+  export LIBSSH2_SYS_USE_PKG_CONFIG=1
+  export LIBGIT2_NO_VENDOR=1
+  export LIBZ_SYS_STATIC=0
+  export OPENSSL_NO_VENDOR=1
+  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
 }
 
 build() {
-  cp -r "${_realname}-${pkgver}" "build-${MSYSTEM}"
-  cd "build-${MSYSTEM}"
+  cd "${srcdir}/${_realname}-${pkgver}"
 
   "${MINGW_PREFIX}/bin/cargo.exe" build \
     --release \
-    --locked
+    --frozen
 
   cd guide
   "${MINGW_PREFIX}/bin/mdbook.exe" build
 }
 
 check() {
-  cd "${srcdir}/build-${MSYSTEM}"
+  cd "${srcdir}/${_realname}-${pkgver}"
 
   "${MINGW_PREFIX}/bin/cargo.exe" test \
     --release \
@@ -58,7 +51,7 @@ check() {
 }
 
 package() {
-  cd "${srcdir}/build-${MSYSTEM}"
+  cd "${srcdir}/${_realname}-${pkgver}"
 
   install -Dm755 "target/release/${_realname}.exe" "${pkgdir}${MINGW_PREFIX}/bin/${_realname}.exe"
   install -d "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"


### PR DESCRIPTION
- disable vendoring (both cargo vendor and `-sys` crates), use shared libs where possible