### PR TITLE
qt5-static: updates

### DIFF
--- a/mingw-w64-qt5-static/0009-add-missing-metatypes-configs.patch
+++ b/mingw-w64-qt5-static/0009-add-missing-metatypes-configs.patch
@@ -1,0 +1,28 @@
+--- a/qtbase/src/network/network.pro
++++ b/qtbase/src/network/network.pro
+@@ -1,5 +1,6 @@
+ TARGET   = QtNetwork
+ QT = core-private
++CONFIG += metatypes install_metatypes
+ 
+ DEFINES += QT_NO_USING_NAMESPACE QT_NO_FOREACH
+ #DEFINES += QLOCALSERVER_DEBUG QLOCALSOCKET_DEBUG
+--- a/qtbase/src/sql/sql.pro
++++ b/qtbase/src/sql/sql.pro
+@@ -1,5 +1,6 @@
+ TARGET	   = QtSql
+ QT         = core-private
++CONFIG += metatypes install_metatypes
+ 
+ DEFINES += QT_NO_USING_NAMESPACE
+ msvc:equals(QT_ARCH, i386): QMAKE_LFLAGS += /BASE:0x62000000
+--- a/qtbase/src/testlib/testlib.pro
++++ b/qtbase/src/testlib/testlib.pro
+@@ -1,6 +1,6 @@
+ TARGET = QtTest
+ QT = core-private
+-CONFIG += exceptions
++CONFIG += exceptions metatypes install_metatypes
+ 
+ MODULE_CONFIG = console testlib_defines
+ 

--- a/mingw-w64-qt5-static/0010-qmltyperegistrar-search-in-correct-directory.patch
+++ b/mingw-w64-qt5-static/0010-qmltyperegistrar-search-in-correct-directory.patch
@@ -1,0 +1,17 @@
+--- a/qtdeclarative/src/qmltyperegistrar/qmltypes.prf
++++ b/qtdeclarative/src/qmltyperegistrar/qmltypes.prf
+@@ -47,12 +47,12 @@
+     android:ABI = _$${ANDROID_TARGET_ARCH}
+     METATYPES_FILENAME = $$lower($$eval(QT.$${dep}.module))$${ABI}_metatypes.json
+     INSTALLED_METATYPES = $$[QT_INSTALL_LIBS]/metatypes/$$METATYPES_FILENAME
+-    isEmpty(MODULE_BASE_OUTDIR) {
++    exists($$INSTALLED_METATYPES) {
+         QML_FOREIGN_METATYPES += $$INSTALLED_METATYPES
+     } else {
+         MODULE_BASE_METATYPES = $$MODULE_BASE_OUTDIR/lib/metatypes/$$METATYPES_FILENAME
+         exists($$MODULE_BASE_METATYPES): QML_FOREIGN_METATYPES += $$MODULE_BASE_METATYPES
+-        else: QML_FOREIGN_METATYPES += $$INSTALLED_METATYPES
++        else: QML_FOREIGN_METATYPES += $$MODULE_BASE_OUTDIR/../qtbase/lib/metatypes/$$METATYPES_FILENAME
+     }
+ }
+ 

--- a/mingw-w64-qt5-static/0012-mingw-add-extra-flags.patch
+++ b/mingw-w64-qt5-static/0012-mingw-add-extra-flags.patch
@@ -1,0 +1,47 @@
+--- a/qtbase/mkspecs/common/g++-win32.conf
++++ b/qtbase/mkspecs/common/g++-win32.conf
+@@ -45,7 +45,7 @@
+ QMAKE_LFLAGS_CONSOLE    = -Wl,-subsystem,console
+ QMAKE_LFLAGS_WINDOWS    = -Wl,-subsystem,windows
+ QMAKE_LFLAGS_DLL        = -shared
+-QMAKE_LFLAGS_STATIC_LIB = -static
++QMAKE_LFLAGS_STATIC_LIB = -static -static-libgcc -static-libstdc++
+ QMAKE_LFLAGS_GCSECTIONS = -Wl,--gc-sections
+ equals(QMAKE_HOST.os, Windows) {
+     QMAKE_LINK_OBJECT_MAX = 10
+--- a/qtbase/mkspecs/win32-g++/qmake.conf
++++ b/qtbase/mkspecs/win32-g++/qmake.conf
+@@ -13,12 +13,12 @@
+ # modifications to g++-win32.conf
+ 
+ QMAKE_CC                = $${CROSS_COMPILE}gcc
+-QMAKE_CFLAGS           += -fno-keep-inline-dllexport
+-QMAKE_CFLAGS_WARN_ON   += -Wextra
++QMAKE_CFLAGS           +=
++QMAKE_CFLAGS_WARN_ON   += -Wextra -Wno-deprecated-declarations -Wno-implicit-fallthrough -Wno-unused-parameter
+ 
+ QMAKE_CXX               = $${CROSS_COMPILE}g++
+-QMAKE_CXXFLAGS         += -fno-keep-inline-dllexport
+-QMAKE_CXXFLAGS_WARN_ON  = $$QMAKE_CFLAGS_WARN_ON
++QMAKE_CXXFLAGS         += -Wa,-mbig-obj
++QMAKE_CXXFLAGS_WARN_ON  = $$QMAKE_CFLAGS_WARN_ON -Wno-class-memaccess
+ 
+ QMAKE_LINK              = $${CROSS_COMPILE}g++
+ QMAKE_LINK_C            = $${CROSS_COMPILE}gcc
+--- a/qtbase/mkspecs/win32-clang-g++/qmake.conf
++++ b/qtbase/mkspecs/win32-clang-g++/qmake.conf
+@@ -15,11 +15,11 @@
+ 
+ QMAKE_CC                = $${CROSS_COMPILE}clang
+ QMAKE_CFLAGS           +=
+-QMAKE_CFLAGS_WARN_ON   += -Wextra -Wno-ignored-attributes
++QMAKE_CFLAGS_WARN_ON   += -Wextra -Wno-ignored-attributes -Wno-deprecated-declarations -Wno-missing-exception-spec -Wno-unused-but-set-variable
+ 
+ QMAKE_CXX               = $${CROSS_COMPILE}clang++
+-QMAKE_CXXFLAGS         +=
+-QMAKE_CXXFLAGS_WARN_ON  = $$QMAKE_CFLAGS_WARN_ON
++QMAKE_CXXFLAGS         += -Wa,-mbig-obj
++QMAKE_CXXFLAGS_WARN_ON  = $$QMAKE_CFLAGS_WARN_ON -Wno-deprecated-copy
+ 
+ QMAKE_LINK              = $${CROSS_COMPILE}clang++
+ QMAKE_LINK_C            = $${CROSS_COMPILE}clang

--- a/mingw-w64-qt5-static/0013-qtbase-use-system-libs.patch
+++ b/mingw-w64-qt5-static/0013-qtbase-use-system-libs.patch
@@ -1,0 +1,111 @@
+--- a/qtbase/configure.json
++++ b/qtbase/configure.json
+@@ -168,7 +168,8 @@
+             "sources": [
+                 { "libs": "-lzdll", "condition": "config.msvc" },
+                 { "libs": "-lzlib", "condition": "config.msvc" },
+-                { "libs": "-lz", "condition": "!config.msvc" },
++                { "libs": "-lz", "condition": "!config.msvc && features.shared" },
++                { "libs": "-l:libz.a", "condition": "!features.shared" },
+                 { "libs": "-s USE_ZLIB=1", "condition": "config.wasm" }
+             ]
+         },
+@@ -183,7 +184,8 @@
+                 ]
+             },
+             "sources": [
+-                { "type": "pkgConfig", "args": "libzstd >= 1.3" },
++                { "type": "pkgConfig", "args": "libzstd >= 1.3", "condition": "features.shared" },
++                { "libs": "-l:libzstd.a", "condition": "!features.shared" },
+                 "-lzstd"
+             ]
+         },
+--- a/qtbase/src/corelib/configure.json
++++ b/qtbase/src/corelib/configure.json
+@@ -111,9 +111,10 @@
+                         "debug": "-lsicuind -lsicuucd -lsicudtd",
+                         "release": "-lsicuin -lsicuuc -lsicudt"
+                     },
+-                    "condition": "config.win32 && !features.shared"
++                    "condition": "config.msvc && !features.shared"
+                 },
+                 { "libs": "-licuin -licuuc -licudt", "condition": "config.win32 && features.shared" },
++                { "libs": "-licuin -licuuc -licudt -lpthread", "condition": "config.win32 && !features.shared" },
+                 { "libs": "-licui18n -licuuc -licudata", "condition": "!config.win32" }
+             ],
+             "use": [
+@@ -193,7 +194,7 @@
+             },
+             "headers": "pcre2.h",
+             "sources": [
+-                { "type": "pkgConfig", "args": "libpcre2-16" },
++                { "type": "pkgConfig", "args": "libpcre2-16", "condition": "features.shared" },
+                 "-lpcre2-16"
+             ]
+         },
+--- a/qtbase/src/gui/configure.json
++++ b/qtbase/src/gui/configure.json
+@@ -238,7 +238,8 @@
+             },
+             "headers": "ft2build.h",
+             "sources": [
+-                { "type": "pkgConfig", "args": "freetype2" },
++                { "type": "pkgConfig", "args": "freetype2", "condition": "features.shared" },
++                { "type": "freetype", "libs": "-lfreetype -lbz2", "condition": "!features.shared" },
+                 { "type": "freetype", "libs": "-lfreetype", "condition": "!config.wasm" },
+                 { "libs": "-s USE_FREETYPE=1", "condition": "config.wasm" },
+                 { "libs": "-lfreetype" }
+@@ -303,6 +304,7 @@
+             },
+             "headers": "harfbuzz/hb.h",
+             "sources": [
++                { "type": "pkgConfig", "args": "--static --libs harfbuzz", "condition": "!features.shared" },
+                 "-lharfbuzz"
+             ]
+         },
+@@ -373,7 +375,7 @@
+             },
+             "headers": "jpeglib.h",
+             "sources": [
+-                { "type": "pkgConfig", "args": "libjpeg" },
++                { "type": "pkgConfig", "args": "libjpeg", "condition": "features.shared" },
+                 { "libs": "-llibjpeg", "condition": "config.msvc" },
+                 "-ljpeg"
+             ]
+@@ -396,10 +398,10 @@
+             },
+             "headers": "png.h",
+             "sources": [
+-                { "type": "pkgConfig", "args": "libpng" },
++                { "type": "pkgConfig", "args": "libpng", "condition": "features.shared" },
+                 { "libs": "-llibpng16", "condition": "config.msvc" },
+                 { "libs": "-llibpng", "condition": "config.msvc" },
+-                { "libs": "-lpng16", "condition": "!config.msvc" },
++                { "libs": "-lpng16 -lz", "condition": "!config.msvc" },
+                 { "libs": "-lpng", "condition": "!config.msvc" },
+                 { "libs": "-s USE_LIBPNG=1", "condition": "config.wasm" }
+             ],
+--- a/qtbase/src/network/configure.json
++++ b/qtbase/src/network/configure.json
+@@ -85,6 +85,9 @@
+             },
+             "sources": [
+                 { "type": "openssl" },
++                { "type": "pkgConfig", "args": "--static --libs libssl",
++                    "condition": "config.win32 && !features.shared"
++                },
+                 {
+                     "libs": "-lssleay32 -llibeay32 -lUser32 -lWs2_32 -lAdvapi32 -lGdi32",
+                     "condition": "config.win32"
+--- a/qtbase/src/plugins/sqldrivers/configure.json
++++ b/qtbase/src/plugins/sqldrivers/configure.json
+@@ -148,7 +150,8 @@
+             },
+             "headers": "sqlite3.h",
+             "sources": [
+-                { "type": "pkgConfig", "args": "sqlite3" },
++                { "type": "pkgConfig", "args": "sqlite3", "condition": "features.shared" },
++                { "type": "pkgConfig", "args": "--static --libs sqlite3", "condition": "!features.shared" },
+                 "-lsqlite3"
+             ],
+             "use": [

--- a/mingw-w64-qt5-static/0014-qtimageformats-use-system-libs.patch
+++ b/mingw-w64-qt5-static/0014-qtimageformats-use-system-libs.patch
@@ -1,0 +1,26 @@
+--- a/qtimageformats/src/imageformats/configure.json
++++ b/qtimageformats/src/imageformats/configure.json
+@@ -84,8 +84,9 @@
+                 ]
+             },
+             "sources": [
+-                { "type": "pkgConfig", "args": "libtiff-4" },
+-                { "libs": "-ltiff" }
++                { "type": "pkgConfig", "args": "libtiff-4", "condition": "features.shared" },
++                { "type": "pkgConfig", "args": "--static --libs libtiff-4", "condition": "!features.shared" },
++                { "libs": "-ltiff", "condition": "features.shared" }
+             ]
+         },
+         "webp": {
+@@ -115,8 +116,9 @@
+                 ]
+             },
+             "sources": [
+-                { "type": "pkgConfig", "args": "libwebp libwebpmux libwebpdemux" },
+-                { "libs": "-lwebp -lwebpdemux -lwebpmux" }
++                { "type": "pkgConfig", "args": "libwebp libwebpmux libwebpdemux", "condition": "features.shared" },
++                { "libs": "-lwebp -lwebpdemux -lwebpmux", "condition": "features.shared" },
++                { "libs": "-lwebpdemux -lwebpmux -lwebp -lsharpyuv", "condition": "!features.shared" }
+             ]
+         }
+     },

--- a/mingw-w64-qt5-static/0035-qt-5.3.2-dont-add-resource-files-to-qmake-libs.patch
+++ b/mingw-w64-qt5-static/0035-qt-5.3.2-dont-add-resource-files-to-qmake-libs.patch
@@ -1,12 +1,14 @@
 diff -Naur qt-everywhere-src-5.12.4-orig/qtbase/qmake/generators/win32/mingw_make.cpp qt-everywhere-src-5.12.4/qtbase/qmake/generators/win32/mingw_make.cpp
 --- qt-everywhere-src-5.12.4-orig/qtbase/qmake/generators/win32/mingw_make.cpp	2019-06-12 23:59:14.000000000 +0300
 +++ qt-everywhere-src-5.12.4/qtbase/qmake/generators/win32/mingw_make.cpp	2019-06-15 15:34:10.657701800 +0300
-@@ -209,7 +209,7 @@
+@@ -147,7 +147,9 @@
  
      processVars();
  
 -    project->values("LIBS") += project->values("RES_FILE");
-+    project->values("OBJECTS") += project->values("RES_FILE");
++    if (project->isActiveConfig("shared") || project->first("TEMPLATE") == "app") {
++        project->values("LIBS") += project->values("RES_FILE");
++    }
  
      if (project->isActiveConfig("dll")) {
          QString destDir = "";

--- a/mingw-w64-qt5-static/0401-disable-warning-of-non-existent-files.patch
+++ b/mingw-w64-qt5-static/0401-disable-warning-of-non-existent-files.patch
@@ -1,0 +1,28 @@
+--- a/qtbase/qmake/generators/makefile.cpp
++++ b/qtbase/qmake/generators/makefile.cpp
+@@ -323,8 +323,10 @@
+                                   vpath.join(QString("::")).toLatin1().constData());
+                         if(flags & VPATH_RemoveMissingFiles)
+                             remove_file = true;
+-                        else if(flags & VPATH_WarnMissingFiles)
+-                            warn_msg(WarnLogic, "Failure to find: %s", val.toLatin1().constData());
++                        else if(flags & VPATH_WarnMissingFiles) {
++                            if(!project->isActiveConfig("static"))
++                                warn_msg(WarnLogic, "Failure to find: %s", val.toLatin1().constData());
++                        }
+                     } else {
+                         l.removeAt(val_it);
+                         QString a;
+@@ -341,8 +343,10 @@
+                               regex.toLatin1().constData(), real_dir.toLatin1().constData());
+                     if(flags & VPATH_RemoveMissingFiles)
+                         remove_file = true;
+-                    else if(flags & VPATH_WarnMissingFiles)
+-                        warn_msg(WarnLogic, "Failure to find: %s", val.toLatin1().constData());
++                    else if(flags & VPATH_WarnMissingFiles) {
++                        if(!project->isActiveConfig("static"))
++                            warn_msg(WarnLogic, "Failure to find: %s", val.toLatin1().constData());
++                    }
+                 }
+             }
+         }

--- a/mingw-w64-qt5-static/0402-deprecated-ucrt-functions.patch
+++ b/mingw-w64-qt5-static/0402-deprecated-ucrt-functions.patch
@@ -1,0 +1,20 @@
+--- a/qtbase/src/corelib/time/qdatetime.cpp
++++ b/qtbase/src/corelib/time/qdatetime.cpp
+@@ -2728,7 +2728,7 @@
+ #elif defined(Q_OS_INTEGRITY) || defined(Q_OS_RTEMS)
+         return 0;
+ #else
+-        return timezone;
++        return _timezone;
+ #endif // Q_OS_WIN
+ }
+ 
+@@ -2743,7 +2743,7 @@
+         return QString();
+     return QString::fromLocal8Bit(name);
+ #else
+-    return QString::fromLocal8Bit(tzname[isDst]);
++    return QString::fromLocal8Bit(_tzname[isDst]);
+ #endif // Q_OS_WIN
+ }
+ 

--- a/mingw-w64-qt5-static/0403-qtactiveqt-tools-avoid-race-condition.patch
+++ b/mingw-w64-qt5-static/0403-qtactiveqt-tools-avoid-race-condition.patch
@@ -1,0 +1,17 @@
+--- a/qtactiveqt/tools/dumpcpp/dumpcpp.pro
++++ b/qtactiveqt/tools/dumpcpp/dumpcpp.pro
+@@ -1,5 +1,6 @@
+ QT += axcontainer widgets core-private
+ DEFINES += QT_NO_CAST_TO_ASCII QT_ASCII_CAST_WARNINGS
++static: CONFIG -= import_plugins
+ 
+ SOURCES = main.cpp
+ 
+--- a/qtactiveqt/tools/dumpdoc/dumpdoc.pro
++++ b/qtactiveqt/tools/dumpdoc/dumpdoc.pro
+@@ -1,4 +1,5 @@
+ QT += axcontainer widgets
++static: CONFIG -= import_plugins
+ 
+ SOURCES += main.cpp
+ 

--- a/mingw-w64-qt5-static/0411-javascriptcore-disable-deprecated-warnings.patch
+++ b/mingw-w64-qt5-static/0411-javascriptcore-disable-deprecated-warnings.patch
@@ -1,0 +1,12 @@
+--- a/qtscript/src/3rdparty/javascriptcore/WebKit.pri
++++ b/qtscript/src/3rdparty/javascriptcore/WebKit.pri
+@@ -60,6 +60,9 @@
+ CONFIG -= warn_on
+ *-g++*:QMAKE_CXXFLAGS += -Wall -Wreturn-type -Wcast-align -Wchar-subscripts -Wformat-security -Wreturn-type -Wno-unused-parameter -Wno-sign-compare -Wno-switch -Wno-switch-enum -Wundef -Wmissing-noreturn -Winit-self
+ 
++win32-clang-g++:QMAKE_CXXFLAGS += -Wno-deprecated-builtins -Wno-deprecated-declarations
++win32-g++:QMAKE_CXXFLAGS += -Wno-class-memaccess -Wno-deprecated-declarations
++
+ # Enable GNU compiler extensions to the ARM compiler for all Qt ports using RVCT
+ *-armcc {
+     RVCT_COMMON_CFLAGS = --gnu --diag_suppress 68,111,177,368,830,1293

--- a/mingw-w64-qt5-static/0412-jitstubs-underscore-symbol-name-for-x86.patch
+++ b/mingw-w64-qt5-static/0412-jitstubs-underscore-symbol-name-for-x86.patch
@@ -1,0 +1,11 @@
+--- a/qtscript/src/3rdparty/javascriptcore/JavaScriptCore/jit/JITStubs.cpp
++++ b/qtscript/src/3rdparty/javascriptcore/JavaScriptCore/jit/JITStubs.cpp
+@@ -68,7 +68,7 @@
+ 
+ namespace JSC {
+ 
+-#if OS(DARWIN) || OS(WINDOWS)
++#if OS(DARWIN) || (OS(WINDOWS) && CPU(X86))
+ #define SYMBOL_STRING(name) "_" #name
+ #else
+ #define SYMBOL_STRING(name) #name

--- a/mingw-w64-qt5-static/PKGBUILD
+++ b/mingw-w64-qt5-static/PKGBUILD
@@ -1,41 +1,33 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 # Maintainer: Ray Donnelly <mingw.android@gmail.com>
-
-# Use the right mkspecs file
-if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
-  _platform=win32-clang-g++
-else
-  _platform=win32-g++
-fi
+# Contributor: Raed Rizqie <raed.rizqie@gmail.com>
 
 _realname=qt5-static
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.15.13
-pkgrel=1
+pkgrel=2
 pkgdesc="A cross-platform application and UI framework (static) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url='https://www.qt.io/'
 msys2_references=(
   'archlinux: qt5-base'
-  "cpe: cpe:/a:qt:qt"
+  'aur: mingw-w64-qt5-base-static'
 )
+msys2_repository_url='https://github.com/qt/qt5'
 license=('spdx:GPL-2.0-only WITH Qt-GPL-exception-1.0 AND GPL-3.0-or-later AND LGPL-2.1-or-later AND LGPL-3.0-only AND GFDL-1.3-or-later')
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
-         "${MINGW_PACKAGE_PREFIX}-vulkan"
-         "${MINGW_PACKAGE_PREFIX}-z3")
+depends=("${MINGW_PACKAGE_PREFIX}-vulkan-loader")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-clang"
-             "${MINGW_PACKAGE_PREFIX}-clang-tools-extra"
              "${MINGW_PACKAGE_PREFIX}-fxc2"
+             "${MINGW_PACKAGE_PREFIX}-gperf"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-python"
-             "${MINGW_PACKAGE_PREFIX}-make"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-dbus"
              "${MINGW_PACKAGE_PREFIX}-openssl"
-             "${MINGW_PACKAGE_PREFIX}-vulkan-headers")
+             "${MINGW_PACKAGE_PREFIX}-zlib"
+             "${MINGW_PACKAGE_PREFIX}-zstd")
 _pkgfile="qt-everywhere-opensource-src-${pkgver}"
 _pkgfqn="qt-everywhere-src-${pkgver}"
 noextract=(${_pkgfile}.tar.xz)
@@ -49,7 +41,12 @@ source=(https://download.qt.io/official_releases/qt/${pkgver%.*}/${pkgver}/singl
         0006-qt-5.3.0-win_flex-replace.patch
         0007-qt-5.3.0-win32-g-Enable-static-builds.patch
         0008-qt-5.3.0-win32-g-Add-QMAKE_EXTENSION_IMPORTLIB-defaulting-to-.patch
+        0009-add-missing-metatypes-configs.patch
+        0010-qmltyperegistrar-search-in-correct-directory.patch
         0011-qt-5.8.0-mingw-dbus-and-pkg-config.patch
+        0012-mingw-add-extra-flags.patch
+        0013-qtbase-use-system-libs.patch
+        0014-qtimageformats-use-system-libs.patch
         0016-qt-5.8.0-win32-g++-use-qpa-genericunixfontdatabase.patch
         0017-qt-5.3.0-fix-examples-building.patch
         0024-qt-5.3.0-icu-add-U_LIB_SUFFIX_C_NAME.patch
@@ -76,7 +73,12 @@ source=(https://download.qt.io/official_releases/qt/${pkgver%.*}/${pkgver}/singl
         0300-qt-5.8.0-cast-errors.patch
         0302-ugly-hack-disable-qdoc-build.patch
         0304-qtdeclarative-disable-dx12.patch
-        0310-fix-assimp-not-found.patch)
+        0310-fix-assimp-not-found.patch
+        0401-disable-warning-of-non-existent-files.patch
+        0402-deprecated-ucrt-functions.patch
+        0403-qtactiveqt-tools-avoid-race-condition.patch
+        0411-javascriptcore-disable-deprecated-warnings.patch
+        0412-jitstubs-underscore-symbol-name-for-x86.patch)
 sha256sums=('9550ec8fc758d3d8d9090e261329700ddcd712e2dda97e5fcfeabfac22bea2ca'
             '884b32f0e2e1bb110330a921b69443379a7be98c42f13754f9c5f56c040ba3b7'
             '617e6fa85a92353d0073425d37cd5d90d92cb7f906d66dd2d0df576122d091a4'
@@ -87,7 +89,12 @@ sha256sums=('9550ec8fc758d3d8d9090e261329700ddcd712e2dda97e5fcfeabfac22bea2ca'
             '18fd2fa42215ac47b3b314261ab98cbe65f8231429e4f29a152288a3ca93daf1'
             '4e154fbc9059a096c351d019da6b18c907b1d8b06e028f48c7365f62bcd0edc9'
             'e2ec5e67bdcfd162a82c49181a2d480f4b193acdfa6b0e22f4a8448286162630'
+            '37e1d7f222718d6551442ab3fb2d979089dfd7b19690709318e4e1edc44444cd'
+            'b5066718a1a393bda5e928434e8f987c3353ed8be2b0e103eb5fa6832a5e395a'
             '465d3897c4494695b66ac121944b3bd370db91bfea71dd2c9170dbf268cc99ea'
+            'ec64b9971fabbf24047c3ccc33b64645a473165863376271789663f2de1c2a7b'
+            'b4135a287752a983183b966785c04c46c018055d43b8a84ef9f6e72c3406a766'
+            '91d65c71a1c809b23dc651981eee64a8d1fe9c8738f4c4756e5dca87e1c3ad4a'
             'b31929c78f9906756a5e1bdf9a796541865c474aaa1b3eefea1a3f1d7c8d94ca'
             'd8a476be7e55e8bb9362868073dc9e7937431e68b9578c0a0ed103cf1ebc8c01'
             'd7c228df3cc680793a6c858e1fac01092c0877071c075804b7e93f6b3a481eae'
@@ -95,7 +102,7 @@ sha256sums=('9550ec8fc758d3d8d9090e261329700ddcd712e2dda97e5fcfeabfac22bea2ca'
             'f80ce415f25f0aa4ead2efe369b41efe35d9848d4d36d8dbf3831e48dbd6e506'
             '19566c38bd50581acaa6a9f46f0e25c41fdfc8b0b42269126e4d3a9b83e2f224'
             'ddaa067d144f5788ab7a3ed0dfc426d702c13de9c35f04eaaf38d642be4934d4'
-            '8beeb610df3aff14bae43c56e5781cda3d49f1ad23c6e3fc2aa2405ce002de46'
+            'bfb9ff161442683c88e137ca4ac4f9aabe44742d8204be565ccdaac6c59fcc0d'
             'f008164ef2a224b8c52736bab53f1aeec72d610928f03cce57f632824dfdd615'
             'a09ba083957a2b9020b5e17e57db98c3f41390db26d85b310798597fc2a4d34f'
             '42724bd154ed98c612d19a7daee2b5028270ef6dbfe7f35d5f97c8d0605f9fe6'
@@ -114,7 +121,12 @@ sha256sums=('9550ec8fc758d3d8d9090e261329700ddcd712e2dda97e5fcfeabfac22bea2ca'
             '9ea7aeb486023f3aebf1af44603ebd9266009aaeaf91e52c37c8c5154ea3900c'
             '7e57ce20b6707bc3b4a727da3287cadda13a74317d86515358b2535bc15244c7'
             '052c7035ad9a4fc0321975ba7658fb755bbc0841c7e1d9e88bb0a15e6a90b770'
-            '157b97b3e3031d93d93e45368a1c54ebfbf9578116f75f5126e977e5dd518191')
+            '157b97b3e3031d93d93e45368a1c54ebfbf9578116f75f5126e977e5dd518191'
+            '1d25b493ebe8bdb6e332db0c3b149626cf4ed5b51f67fe45fafd9b28c87088e8'
+            '3dc92472a3f7ac0927546ae6f8ac3dc3b88158fa523917ecaac5aaae95cbe25e'
+            '1e90e103bd96f07452d648286a3289306dbd5e101123798206410fb78283fff8'
+            '614b027c94784fcfd7979cea3326b75d8415da2dbd0ab7d5181ad04c21341644'
+            '62616c2b8aa19afbcb1bd6d05427ddfc87fa3bc6ed0bc1a688f80d8e95742bca')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -131,10 +143,7 @@ prepare() {
   tar -xJf ${srcdir}/${_pkgfile}.tar.xz -C ${srcdir} --exclude=${_pkgfqn}/{qtandroidextras,qtmacextras,qtwayland,qtwebengine,qtx11extras} || true
 
   cd ${srcdir}/${_pkgfqn}
-
-  # MSYS2 gperf cannot handle \r\n.
-  msg2 "Converting line endings of .gperf files..."
-  find . -name "*.gperf" -exec dos2unix "{}" \;
+  touch qtbase/.gitignore
 
   apply_patch_with_msg \
     0000-adjust-qmake-conf-mingw.patch \
@@ -146,7 +155,12 @@ prepare() {
     0006-qt-5.3.0-win_flex-replace.patch \
     0007-qt-5.3.0-win32-g-Enable-static-builds.patch \
     0008-qt-5.3.0-win32-g-Add-QMAKE_EXTENSION_IMPORTLIB-defaulting-to-.patch \
+    0009-add-missing-metatypes-configs.patch \
+    0010-qmltyperegistrar-search-in-correct-directory.patch \
     0011-qt-5.8.0-mingw-dbus-and-pkg-config.patch \
+    0012-mingw-add-extra-flags.patch \
+    0013-qtbase-use-system-libs.patch \
+    0014-qtimageformats-use-system-libs.patch \
     0016-qt-5.8.0-win32-g++-use-qpa-genericunixfontdatabase.patch \
     0017-qt-5.3.0-fix-examples-building.patch \
     0025-qt-5.8.0-force-using-make-on-msys.patch
@@ -178,50 +192,29 @@ prepare() {
     0100-fix-relocatable-prefix-staticbuild-v2.patch \
     0125-qt5-windeployqt-fixes.patch \
     0300-qt-5.8.0-cast-errors.patch \
+    0302-ugly-hack-disable-qdoc-build.patch \
     0304-qtdeclarative-disable-dx12.patch \
     0310-fix-assimp-not-found.patch
 
-  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
-    sed -i "s| -mthreads||g" qtbase/mkspecs/common/g++-win32.conf
-  fi
-
-  local _ARCH_TUNE=
-  if [[ ${CARCH} == x86_64 ]]; then
-    _ARCH_TUNE="-march=nocona -msahf -mtune=generic"
-  elif [[ ${CARCH} == i686 ]]; then
-    _ARCH_TUNE="-march=pentium4 -mtune=generic"
-  fi
-
-  BIGOBJ_FLAGS="-Wa,-mbig-obj"
-
-  # Append these ones ..
-  sed -i "s|^QMAKE_CFLAGS .*= \(.*\)$|QMAKE_CFLAGS            = \1 ${_ARCH_TUNE} ${BIGOBJ_FLAGS}|g" qtbase/mkspecs/${_platform}/qmake.conf
-  sed -i "s|^QMAKE_CXXFLAGS .*= \(.*\)$|QMAKE_CXXFLAGS            = \1 ${_ARCH_TUNE} ${BIGOBJ_FLAGS}|g" qtbase/mkspecs/${_platform}/qmake.conf
-
-  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
-    sed -i "s| -mthreads||g" qtbase/mkspecs/common/g++-win32.conf
-  fi
-  # But overwrite this one.
-  #sed -i "s|^QMAKE_LFLAGS_RELEASE .*= \(.*\)$|QMAKE_LFLAGS_RELEASE    = ${QMAKE_LFLAGS_RELEASE}|g" qtbase/mkspecs/common/g++-win32.conf
+  apply_patch_with_msg \
+    0401-disable-warning-of-non-existent-files.patch \
+    0402-deprecated-ucrt-functions.patch \
+    0403-qtactiveqt-tools-avoid-race-condition.patch \
+    0411-javascriptcore-disable-deprecated-warnings.patch \
+    0412-jitstubs-underscore-symbol-name-for-x86.patch
 
   # To keep the build folder name quite small (PATH_MAX limit)
-  # the source folder (long) is renamed to $MSYSTEM (MINGW32 or MINGW64)
+  # the source folder (long) is renamed to 'qt5'
   cd ${srcdir}
-  [[ -d ${MSYSTEM} ]] && rm -rf ${MSYSTEM}
-  sleep 5
-  mv ${_pkgfqn} ${MSYSTEM}
+  mv ${_pkgfqn} qt5
 }
 
 build() {
+  mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
+
   local _buildpkgdir=${pkgdirbase}/${pkgname}/${MINGW_PREFIX}/${_realname}
   mkdir -p ${_buildpkgdir}
   local QTDIR_WIN=$(cygpath -am ${_buildpkgdir})
-
-  cd ${MSYSTEM}
-  touch qtbase/.gitignore
-
-  # https://github.com/msys2/MSYS2-packages/issues/2282
-  export MSYS2_ARG_CONV_EXCL='--foreign-types='
 
   # Qt manages the compiler flags for release / debug configs separately, so having our own values (-O2) is harmful here ..
   unset CFLAGS
@@ -232,17 +225,18 @@ build() {
   unset QMAKEPATH
   unset QMAKEFEATURES
 
-  export PATH="${srcdir}/${MSYSTEM}/qtbase/bin:${srcdir}/${MSYSTEM}/qtbase/lib:${PATH}"
-  export LLVM_INSTALL_DIR=${MINGW_PREFIX}
+  export PATH="${srcdir}/build-${MSYSTEM}/qtbase/bin:${srcdir}/build-${MSYSTEM}/qtbase/lib:${PATH}"
   export VULKAN_SDK=${MINGW_PREFIX}
-
-  export QDOC_USE_STATIC_LIBCLANG=1
-  #export FORCE_MINGW_QDOC_BUILD=1
-  # Hack to disable building qdoc
-  patch -p1 -i ${srcdir}/0302-ugly-hack-disable-qdoc-build.patch
   export QDOC_SKIP_BUILD=1
 
-  ./configure \
+  # Use the right mkspecs file
+  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
+    _platform=win32-clang-g++
+  else
+    _platform=win32-g++
+  fi
+
+  ../qt5/configure \
     -prefix ${QTDIR_WIN} \
     -datadir ${QTDIR_WIN}/share/qt5 \
     -archdatadir ${QTDIR_WIN}/share/qt5 \
@@ -255,17 +249,11 @@ build() {
     -feature-relocatable \
     -static \
     -static-runtime \
-    -DJAS_DLL=0 \
+    -silent \
+    -dbus-linked \
     -opengl desktop \
-    -schannel \
-    -no-fontconfig \
-    -no-glib \
-    -no-gstreamer \
-    -no-iconv \
-    -no-icu \
-    -no-jasper \
-    -no-mng \
-    -no-wmf \
+    -openssl-linked \
+    -sql-sqlite \
     -qt-assimp \
     -qt-doubleconversion \
     -qt-freetype \
@@ -273,42 +261,45 @@ build() {
     -qt-libjpeg \
     -qt-libpng \
     -qt-pcre \
+    -qt-sqlite \
     -qt-tiff \
     -qt-webp \
-    -dbus-linked \
+    -no-fontconfig \
+    -no-glib \
+    -no-gstreamer \
+    -no-iconv \
+    -no-icu \
+    -no-jasper \
+    -no-mng \
     -no-sql-ibase \
     -no-sql-mysql \
     -no-sql-odbc \
     -no-sql-psql \
     -no-sql-sqlite2 \
-    -sql-sqlite \
-    -qt-sqlite
+    -no-wmf
 
-  make || make
+  make
 }
 
 check() {
-  cd ${MSYSTEM}
+  cd build-${MSYSTEM}
   make check -j1 -k
 }
 
 package() {
-  cd ${MSYSTEM}
+  cd build-${MSYSTEM}
 
   make install
 
   install -d "${pkgdir}${MINGW_PREFIX}/${_realname}"/share/licenses/qt5
-  install -Dm644 LICENSE* -t "${pkgdir}${MINGW_PREFIX}/${_realname}"/share/licenses/qt5
-
-  # Remove dlls from lib/
-  rm -f "${pkgdir}${MINGW_PREFIX}/${_realname}/lib"/*.dll
+  install -Dm644 ${srcdir}/qt5/LICENSE* -t "${pkgdir}${MINGW_PREFIX}/${_realname}"/share/licenses/qt5
 
   # Remove *.orig files
   find "${pkgdir}${MINGW_PREFIX}/${_realname}" -type f -name "*.orig" -exec rm -f {} \;
 
   # Workaround for installing empty .pc files
   plain "---> Fix pkgconfig files..."
-  local _pc_files=( $(find ${srcdir}/${MSYSTEM} -type f -name Qt5*.pc) )
+  local _pc_files=( $(find ${srcdir}/build-${MSYSTEM} -type f -name Qt5*.pc) )
   cp -f ${_pc_files[@]} ${pkgdir}${MINGW_PREFIX}/${_realname}/lib/pkgconfig/
 
   # Fix paths in qconfig.pri and qmodule.pri:
@@ -317,21 +308,22 @@ package() {
   local PKGDIR_QT_PREFIX_WIN=$(cygpath -m ${pkgdir}${MINGW_PREFIX}/${_realname})
   local FAKE_PREFIX_FOR_REPLACE="@@QT_REAL_PREFIX/dir@@"
   local MINGW_PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  local BUILDDIR_PREFIX=$(cygpath -m ${srcdir}/build-${MSYSTEM})
 
   find "${pkgdir}${MINGW_PREFIX}/${_realname}/share/qt5" -type f \( -name '*.pri' -o -name '*.prl' \) \
-      -exec sed -i -e "s|${QT_PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+    -exec sed -i -e "s|${QT_PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
 
   find "${pkgdir}${MINGW_PREFIX}/${_realname}/lib" -type f \( -name '*.pri' -o -name '*.prl' \) \
-      -exec sed -i -e "s|${QT_PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+    -exec sed -i -e "s|${QT_PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
 
   find "${pkgdir}${MINGW_PREFIX}/${_realname}/lib" -type f -name '*.cmake' \
-      -exec sed -i -e "s|${QT_PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
+    -exec sed -i -e "s|${QT_PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}|g" {} \;
 
   find "${pkgdir}${MINGW_PREFIX}/${_realname}/lib/pkgconfig" -type f -name '*.pc' \
-      -exec sed -i -e "s|${QT_PREFIX_WIN}|${MINGW_PREFIX}/${_realname}|g" {} \;
+    -exec sed -i -e "s|${QT_PREFIX_WIN}|${MINGW_PREFIX}/${_realname}|g" {} \;
 
   find "${pkgdir}${MINGW_PREFIX}/${_realname}/lib/pkgconfig" -type f -name '*.pc' \
-      -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}/${_realname}|g" {} \;
+    -exec sed -i -e "s|${PKGDIR_QT_PREFIX_WIN}|${MINGW_PREFIX}/${_realname}|g" {} \;
 
   find "${pkgdir}${MINGW_PREFIX}/${_realname}/lib" -type f -name '*.cmake' \
     -exec sed -i -e "s|${MINGW_PREFIX_WIN}|${FAKE_PREFIX_FOR_REPLACE}/..|g" {} \;
@@ -344,4 +336,38 @@ package() {
 
   find "${pkgdir}${MINGW_PREFIX}/${_realname}/lib/pkgconfig" -type f -name '*.pc' \
     -exec sed -i -e "s|${MINGW_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/${_realname}/lib/pkgconfig" -type f -name '*.pc' \
+    -exec sed -i -e "s|${BUILDDIR_PREFIX}/qtbase/lib/lib|-l|g" -e "s|.a | |g" \
+                 -e "s|${BUILDDIR_PREFIX}/qt3d/lib/lib|-l|g" \
+                 -e "s|${BUILDDIR_PREFIX}/qtactiveqt/lib/lib|-l|g" \
+                 -e "s|${BUILDDIR_PREFIX}/qtdeclarative/lib/lib|-l|g" \
+                 -e "s|${BUILDDIR_PREFIX}/qtlocation/lib/lib|-l|g" \
+                 -e "s|${BUILDDIR_PREFIX}/qtmultimedia/lib/lib|-l|g" \
+                 -e "s|${BUILDDIR_PREFIX}/qttools/lib/lib|-l|g" \
+                 -e "s|${BUILDDIR_PREFIX}/qtquick3d/lib/lib|-l|g" \
+                 -e "s|${BUILDDIR_PREFIX}/qtquickcontrols2/lib/lib|-l|g" \
+                 -e "s|${BUILDDIR_PREFIX}/qtscript/lib/lib|-l|g" \
+                 -e "s|${BUILDDIR_PREFIX}/qtserialport/lib/lib|-l|g" \
+                 -e "s|${BUILDDIR_PREFIX}/qtgamepad/lib/lib|-l|g" \
+                 -e "s|-L${BUILDDIR_PREFIX}/qtlocation/lib ||g" \
+                 -e "s|.a | |g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/${_realname}/share/qt5" -type f -name '*.prl' \
+    -exec sed -i -e "s|\$\$\[QT_INSTALL_LIBS\]/lib|-l|g" \
+                 -e "s|-L\$\$\[QT_INSTALL_LIBS\]/lib ||g" \
+                 -e "s|-L\$\$\[QT_INSTALL_LIBS\]/lib;||g" \
+                 -e "s|-L\$\$\[QT_INSTALL_LIBS\] ||g" \
+                 -e "s|-L\$\$\[QT_INSTALL_LIBS\];||g" \
+                 -e "s|.a | |g" -e "s|.a;|;|g" \
+                 -e "s|lqt_clipper.a|lqt_clipper|g" {} \;
+
+  find "${pkgdir}${MINGW_PREFIX}/${_realname}/lib" -type f -name '*.prl' \
+    -exec sed -i -e "s|\$\$\[QT_INSTALL_LIBS\]/lib|-l|g" \
+                 -e "s|-L\$\$\[QT_INSTALL_LIBS\]/lib ||g" \
+                 -e "s|-L\$\$\[QT_INSTALL_LIBS\]/lib;||g" \
+                 -e "s|-L\$\$\[QT_INSTALL_LIBS\] ||g" \
+                 -e "s|-L\$\$\[QT_INSTALL_LIBS\];||g" \
+                 -e "s|.a | |g" -e "s|.a;|;|g" \
+                 -e "s|lqt_clipper.a|lqt_clipper|g" {} \;
 }


### PR DESCRIPTION

- simplified PKGBUILD recipe
- build in silent mode
- make sure we link with static zlib and zstd
- fix qmltyperegistrar 'Cannot open foreign types file' error
- fix race condition when building qtactiveqt tools
- fix *.pc & *.prl files further by removing full path to libs