### PR TITLE
pango: backport a Windows double free fix

### DIFF
--- a/mingw-w64-pango/PKGBUILD
+++ b/mingw-w64-pango/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
 pkgver=1.52.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A library for layout and rendering of text (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -33,10 +33,12 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 options=('staticlibs' 'strip' 'emptydirs')
 source=("https://download.gnome.org/sources/pango/${pkgver:0:4}/${_realname}-${pkgver}.tar.xz"
         "https://gitlab.gnome.org/GNOME/pango/-/merge_requests/720.patch"
-        "0001-disable-dwrite.patch")
+        "0001-disable-dwrite.patch"
+        "https://gitlab.gnome.org/GNOME/pango/-/commit/1f158f7fe8b1535c4be3d8a2f0eff54f40e588b7.patch")
 sha256sums=('58728a0a2d86f60761208df9493033d18ecb2497abac80ee1a274ad0c6e55f0f'
             'ccaa073482a2fee193ac38de548fa3cef6aba10090f96b358c725beff7539e32'
-            '18f14c39d441ec8d015209a6d1daf15fd17e7504b958f808b33477e1d54d5c97')
+            '18f14c39d441ec8d015209a6d1daf15fd17e7504b958f808b33477e1d54d5c97'
+            'cfd98767cf29be4fe604611edea4e709394f4bbf5cd184f08518cafeb2080aa7')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -46,6 +48,9 @@ prepare() {
 
   # https://gitlab.gnome.org/GNOME/pango/-/issues/767
   patch -Np1 -i "${srcdir}/0001-disable-dwrite.patch"
+
+  # https://gitlab.gnome.org/GNOME/pango/-/merge_requests/726
+  patch -Np1 -i "${srcdir}/1f158f7fe8b1535c4be3d8a2f0eff54f40e588b7.patch"
 }
 
 build() {


### PR DESCRIPTION
See https://gitlab.gnome.org/GNOME/pango/-/merge_requests/726

Since I see crashes in gtk4. This doesn't help in my case, but let's backport it anyway.