### PR TITLE
xz: Switch from upstream tarball to git tarball

### DIFF
--- a/mingw-w64-xz/PKGBUILD
+++ b/mingw-w64-xz/PKGBUILD
@@ -5,7 +5,7 @@ _realname=xz
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.6.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Library and command line tools for XZ and LZMA compressed files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -21,12 +21,22 @@ license=('spdx:0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later')
 depends=("${MINGW_PACKAGE_PREFIX}-gettext-runtime")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools"
-             "${MINGW_PACKAGE_PREFIX}-gettext-tools")
-source=("https://github.com/tukaani-project/xz/releases/download/v${pkgver}/xz-${pkgver}.tar.xz"{,.sig})
-sha256sums=('f334777310ca3ae9ba07206d78ed286a655aa3f44eec27854f740c26b2cd2ed0'
-            'SKIP')
-validpgpkeys=('3690C240CE51B4670D30AD1C38EE757D69184620' # Lasse Collin <lasse.collin@tukaani.org>
-              '22D465F2B4C173803B20C6DE59FCF207FEA7F445') # Jia Tan <jiat0218@gmail.com>
+             "${MINGW_PACKAGE_PREFIX}-gettext-tools"
+             "${MINGW_PACKAGE_PREFIX}-doxygen"
+             "po4a")
+# WARNING: don't use the upstream tarball until this is resolved:
+# https://github.com/tukaani-project/xz/issues/92
+# https://nvd.nist.gov/vuln/detail/CVE-2024-3094
+source=("https://github.com/tukaani-project/xz/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('237284fae40e5f8e9908f0a977e7d0b9a5c7c1c10a41b8e6ed0fb40e930467c8')
+validpgpkeys=('3690C240CE51B4670D30AD1C38EE757D69184620') # Lasse Collin <lasse.collin@tukaani.org>
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+
+  ./autogen.sh
+}
+
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"


### PR DESCRIPTION
That doesn't contain a configure, so run autogen.
Also needs extra build depends for things already included
in the tarball.

And remove the signing key from the bad actor.