### PR TITLE
ccfits: new package

### DIFF
--- a/mingw-w64-ccfits/PKGBUILD
+++ b/mingw-w64-ccfits/PKGBUILD
@@ -1,0 +1,47 @@
+# Maintainer: Minato Feng <feng1m8@outlook.com>
+
+_realname=ccfits
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=2.6
+pkgrel=1
+pkgdesc="Object Oriented Interface to the CFITSIO Library"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
+url="https://heasarc.gsfc.nasa.gov/docs/software/fitsio/ccfits/"
+license=('custom')
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+depends=("${MINGW_PACKAGE_PREFIX}-cfitsio")
+source=(https://heasarc.gsfc.nasa.gov/docs/software/fitsio/${_realname}/CCfits-${pkgver}.tar.gz)
+sha256sums=('2bb439db67e537d0671166ad4d522290859e8e56c2f495c76faa97bc91b28612')
+
+prepare() {
+  cd "${srcdir}/CCfits-${pkgver}"
+
+  autoreconf -vfi -Iconfig/m4
+}
+
+build() {
+  cd "${srcdir}/CCfits-${pkgver}"
+
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
+
+  ../"CCfits-${pkgver}"/configure \
+    --prefix="${MINGW_PREFIX}" \
+    --build="${MINGW_CHOST}" \
+    --host="${MINGW_CHOST}" \
+    --target="${MINGW_CHOST}" \
+    --enable-static \
+    --enable-shared
+
+  make LDFLAGS="-no-undefined"
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  make install DESTDIR="${pkgdir}"
+
+  install -Dm644 "${srcdir}/CCfits-${pkgver}/License.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/License.txt"
+}


### PR DESCRIPTION
[CCfits](https://heasarc.gsfc.nasa.gov/fitsio/CCfits/) is an object oriented interface to the [cfitsio](https://heasarc.gsfc.nasa.gov/fitsio/fitsio.html) library.
CFITSIO is a library of C and Fortran subroutines for reading and writing data files in FITS (Flexible Image Transport System) data format.
CCfits project is packaged in [Arch Linux](https://archlinux.org/packages/extra/x86_64/ccfits/).