### PR TITLE
gtk4: default to the old "gl" renderer to work around crashes

### DIFF
--- a/mingw-w64-gtk4/0002-default-to-gl-instead-of-ngl.patch
+++ b/mingw-w64-gtk4/0002-default-to-gl-instead-of-ngl.patch
@@ -1,0 +1,11 @@
+--- gtk-4.14.1/gsk/gskrenderer.c.orig	2024-03-30 08:50:20.348266200 +0100
++++ gtk-4.14.1/gsk/gskrenderer.c	2024-03-30 08:51:03.543418300 +0100
+@@ -653,7 +653,7 @@
+   if (gl_software_rendering (surface))
+     return G_TYPE_INVALID;
+ 
+-  return gsk_ngl_renderer_get_type ();
++  return GSK_TYPE_GL_RENDERER;
+ }
+ 
+ #ifdef GDK_RENDERING_VULKAN

--- a/mingw-w64-gtk4/PKGBUILD
+++ b/mingw-w64-gtk4/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-media-gstreamer")
 pkgver=4.14.1
-pkgrel=1
+pkgrel=2
 pkgdesc="GObject-based multi-platform GUI toolkit (v4) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -37,10 +37,12 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-shared-mime-info")
 source=("https://download.gnome.org/sources/gtk/${pkgver:0:4}/gtk-${pkgver}.tar.xz"
         "https://gitlab.gnome.org/GNOME/gtk/-/commit/b569470b87d143d30c2388046c9a6450696f19b8.patch"
-        "0001-ngl-icon-drawing-fix.patch")
+        "0001-ngl-icon-drawing-fix.patch"
+        "0002-default-to-gl-instead-of-ngl.patch")
 sha256sums=('fcefb3f132f8cc4711a9efa5b353c9ae9bb5eeff0246fa74dbc2f2f839b9e308'
             '50e6ac71f2081f80d334a5be5c8c49b9c1c3fab001c1f4ca0f2556d7f2ec92ed'
-            '1532566146f18e768901e2ddb2cd69c3fe4f2c2efafe72a62c1ee6155feb982b')
+            '1532566146f18e768901e2ddb2cd69c3fe4f2c2efafe72a62c1ee6155feb982b'
+            'a83ccaa9c9d16ab477d5884b6e372e9af66198cec7b6c067d397d7ba859a12c6')
 
 prepare() {
   cd gtk-${pkgver}
@@ -50,6 +52,9 @@ prepare() {
 
   # https://gitlab.gnome.org/GNOME/gtk/-/issues/6564#note_2059394
   patch -Np1 -i ../0001-ngl-icon-drawing-fix.patch
+
+  # https://gitlab.gnome.org/GNOME/pango/-/issues/789
+  patch -Np1 -i ../0002-default-to-gl-instead-of-ngl.patch
 }
 
 build() {


### PR DESCRIPTION
Upstream report: https://gitlab.gnome.org/GNOME/pango/-/issues/789

This switches the default from ngl to gl. The crashes can still be reproduced via:

GSK_RENDERER=ngl adwaita-1-demo.exe