### PR TITLE
podman: Update to 5.0.1

### DIFF
--- a/mingw-w64-podman/0001-etc-prefix.patch
+++ b/mingw-w64-podman/0001-etc-prefix.patch
@@ -1,0 +1,11 @@
+--- podman-5.0.1/Makefile.orig	2024-04-01 14:28:31.000000000 +0200
++++ podman-5.0.1/Makefile	2024-04-16 08:31:07.202655400 +0200
+@@ -39,7 +39,7 @@
+ LIBEXECPODMAN ?= ${LIBEXECDIR}/podman
+ MANDIR ?= ${PREFIX}/share/man
+ SHAREDIR_CONTAINERS ?= ${PREFIX}/share/containers
+-ETCDIR ?= /etc
++ETCDIR ?= ${PREFIX}/etc
+ LIBDIR ?= ${PREFIX}/lib
+ TMPFILESDIR ?= ${LIBDIR}/tmpfiles.d
+ USERTMPFILESDIR ?= ${PREFIX}/share/user-tmpfiles.d

--- a/mingw-w64-podman/PKGBUILD
+++ b/mingw-w64-podman/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=podman
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=4.9.3
+pkgver=5.0.1
 pkgrel=1
 pkgdesc='Tool for running OCI-based containers in pods (mingw-w64)'
 arch=('any')
@@ -22,15 +22,22 @@ makedepends=(
 options=('!strip')
 _GV_VERSION="0.7.3"  # See GV_VERSION in Makefile
 source=("https://github.com/containers/podman/archive/v$pkgver/${_realname}-${pkgver}.tar.gz"
-        "https://github.com/containers/gvisor-tap-vsock/archive/v${_GV_VERSION}/gvisor-tap-vsock-${_GV_VERSION}.tar.gz")
-sha256sums=('37afc5bba2738c68dc24400893b99226c658cc9a2b22309f4d7abe7225d8c437'
-            '851ed29b92e15094d8eba91492b6d7bab74aff4538dae0c973eb7d8ff48afd8a')
+        "https://github.com/containers/gvisor-tap-vsock/archive/v${_GV_VERSION}/gvisor-tap-vsock-${_GV_VERSION}.tar.gz"
+        "0001-etc-prefix.patch")
+sha256sums=('ee6253866e949431c3f2c0e87582c864b8dd1c96773fc93d6c73dfaff9630ee2'
+            '851ed29b92e15094d8eba91492b6d7bab74aff4538dae0c973eb7d8ff48afd8a'
+            '2a1a5c9d126634e871853cfa0e17af8f1597a6ed9c709f59c4a19e1bbb76c68d')
 noextract=("${_realname}-${pkgver}.tar.gz")
 
 prepare() {
     echo "Extracting ${_realname}-${pkgver}.tar.gz ..."
     tar -xzf ${_realname}-${pkgver}.tar.gz | true
     rm -rf build-${MSYSTEM}
+
+    cd "${_realname}-${pkgver}"
+    patch -Np1 -i "${srcdir}/0001-etc-prefix.patch"
+    cd "${srcdir}"
+
     cp -r ${_realname}-${pkgver} build-${MSYSTEM}
 
     cp -r "gvisor-tap-vsock-${_GV_VERSION}" "build-proxy-${MSYSTEM}"


### PR DESCRIPTION
This is not compatible with podman 4, so all machines need to be reset:

With 4.9 (downgrade if needed):

podman machine stop
podman machine rm

With 5.0:

podman machine init
podman machine start

Also see https://blog.podman.io/2024/03/migration-of-podman-4-to-podman-5-machines/