### PR TITLE
czmq: add package

### DIFF
--- a/mingw-w64-czmq/PKGBUILD
+++ b/mingw-w64-czmq/PKGBUILD
@@ -1,0 +1,60 @@
+# Obtained from the PKGBUILD of mingw-w64-zeromq
+
+_realname=czmq
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=4.2.1
+pkgrel=3
+pkgdesc="High-level C binding for ØMQ"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+url="https://www.zeromq.org/"
+msys2_repository_url="https://github.com/zeromq/czmq/"
+msys2_references=(
+  "cpe: cpe:/a:zeromq:czmq"
+)
+license=("spdx:MPL-2.0")
+depends=("${MINGW_PACKAGE_PREFIX}-zeromq")
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-autotools")
+source=("https://github.com/zeromq/czmq/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('5d720a204c2a58645d6f7643af15d563a712dad98c9d32c1ed913377daa6ac39')
+
+prepare() {
+  cd ${_realname}-${pkgver}
+
+  autoreconf -fi
+}
+
+build() {
+  # Configuring and building into a separate build directory, like it is done for the `mingw-w64-zeromq`
+  # package, makes the build fail with errors about missing `#include <linux/wireless.h>`, even if the
+  # `./configure` output says "checking for linux/wireless.h... no". I'm not sure about the reason for this,
+  # but configuring and building in the source directory (as by czmq README.md instructions) works, so we
+  # do this instead.
+
+  cd ${_realname}-${pkgver}
+
+  # Those are required for the build to work, otherwise linking errors are thrown.
+  LDFLAGS="-lws2_32 -liphlpapi -lrpcrt4"
+
+  ./configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --enable-shared \
+    --enable-static \
+    --disable-Werror
+
+  make
+}
+
+package() {
+  cd ${_realname}-${pkgver}
+  make DESTDIR="${pkgdir}" install
+
+  # Fix .pc file
+  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
+  sed -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/libczmq.pc"
+}


### PR DESCRIPTION
Add a package for the [CZMQ](https://github.com/zeromq/czmq) higher level library (that depends on `libzmq` which is already provided by the `mingw-w64-zeromq` package). I obtained the `PKGBUILD` is obtained starting from the `mingw-w64-zeromq` one.