### PR TITLE
JKQtplotter : a new package

### DIFF
--- a/mingw-w64-JKQtplotter/PKGBUILD
+++ b/mingw-w64-JKQtplotter/PKGBUILD
@@ -1,0 +1,53 @@
+_fname=JKQtplotter
+_realname=${_fname}
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=4.0.3
+pkgrel=2
+arch=('any')
+mingw_arch=('mingw64')
+pkgdesc="C++ Functional Terminal User Interface library. (mingw-w64)"
+url="https://github.com/jkriege2/JKQtPlotter"
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+"${MINGW_PACKAGE_PREFIX}-qt6-base"
+"${MINGW_PACKAGE_PREFIX}-qt6-svg"
+"${MINGW_PACKAGE_PREFIX}-qt6-scxml")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake")
+options=('strip')
+license=('MIT')
+source=(${_realname}-${pkgver}.tar.gz::"https://github.com/jkriege2/JKQtPlotter/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('584105453a2294ad83d61d367856798fe5cf7635d29c09802bd9f1b3dcd27724')
+
+build() {
+  cd "${srcdir}/${_fname}-${pkgver}"
+  local _build="build_${CARCH}"
+  local _fc="${MINGW_PREFIX}/bin/JKQtplotter"
+
+  FC="${_fc}" \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DCMAKE_BUILD_TYPE=Release \
+-DJKQtPlotter_BUILD_EXAMPLES=0 \
+    -B"${_build}"
+  cmake --build "${_build}"
+}
+
+package() {
+  cd "${srcdir}/${_fname}-${pkgver}/build_${CARCH}"
+
+  DESTDIR="${pkgdir}" \
+  cmake --install .
+  
+  cd "${pkgdir}/mingw64/lib/cmake"
+  sed -i "s/{_IMPORT_PREFIX}\//{_IMPORT_PREFIX}\/..\//g" `grep _IMPORT_PREFIX -rl ./`
+  mkdir "JKQTCommonSharedLib"
+  mv JKQTCommonSharedLib*.cmake JKQTCommonSharedLib
+  mkdir "JKQTFastPlotterSharedLib"
+  mv JKQTFastPlotterSharedLib*.cmake JKQTFastPlotterSharedLib
+  mkdir "JKQTMathTextSharedLib"
+  mv JKQTMathTextSharedLib*.cmake JKQTMathTextSharedLib
+  mkdir "JKQTPlotterSharedLib"
+  mv JKQTPlotterSharedLib*.cmake JKQTPlotterSharedLib
+	
+}

--- a/mingw-w64-JKQtplotter/PKGBUILD
+++ b/mingw-w64-JKQtplotter/PKGBUILD
@@ -44,7 +44,7 @@ package() {
   cmake --install .
   
   cd "${pkgdir}/mingw64/lib/cmake"
-  sed -i "s/{_IMPORT_PREFIX}\//{_IMPORT_PREFIX}\/..\//g" `grep _IMPORT_PREFIX -rl ./`
+  sed -i "s/{_IMPORT_PREFIX}\//{_IMPORT_PREFIX}\/..\//g" `grep _IMPORT_PREFIX -rl .\`
   mkdir "JKQTCommonSharedLib"
   mv JKQTCommonSharedLib*.cmake JKQTCommonSharedLib
   mkdir "JKQTFastPlotterSharedLib"

--- a/mingw-w64-JKQtplotter/PKGBUILD
+++ b/mingw-w64-JKQtplotter/PKGBUILD
@@ -5,7 +5,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.0.3
 pkgrel=2
 arch=('any')
-mingw_arch=('mingw64')
+mingw_arch=('mingw64' 'ucrt64' )
 pkgdesc="C++ Functional Terminal User Interface library. (mingw-w64)"
 url="https://github.com/jkriege2/JKQtPlotter"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
@@ -23,6 +23,7 @@ source=(${_realname}-${pkgver}.tar.gz::"https://github.com/jkriege2/JKQtPlotter/
 sha256sums=('584105453a2294ad83d61d367856798fe5cf7635d29c09802bd9f1b3dcd27724')
 
 build() {
+  msg "JKQtplotter build for ${MINGW_ARCH}"
   cd "${srcdir}/${_fname}-${pkgver}"
   local _build="build_${CARCH}"
   local _fc="${MINGW_PREFIX}/bin/JKQtplotter"
@@ -43,8 +44,8 @@ package() {
   DESTDIR="${pkgdir}" \
   cmake --install .
   
-  cd "${pkgdir}/mingw64/lib/cmake"
-  sed -i "s/{_IMPORT_PREFIX}\//{_IMPORT_PREFIX}\/..\//g" `grep _IMPORT_PREFIX -rl .\`
+  cd "${pkgdir}/${MINGW_ARCH}/lib/cmake"
+  find . -name '*.cmake' -print0 | xargs -0 sed -i "s/{_IMPORT_PREFIX}\//{_IMPORT_PREFIX}\/..\//g"
   mkdir "JKQTCommonSharedLib"
   mv JKQTCommonSharedLib*.cmake JKQTCommonSharedLib
   mkdir "JKQTFastPlotterSharedLib"

--- a/mingw-w64-JKQtplotter/PKGBUILD
+++ b/mingw-w64-JKQtplotter/PKGBUILD
@@ -9,10 +9,14 @@ mingw_arch=('mingw64')
 pkgdesc="C++ Functional Terminal User Interface library. (mingw-w64)"
 url="https://github.com/jkriege2/JKQtPlotter"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+"${MINGW_PACKAGE_PREFIX}-cc"
 "${MINGW_PACKAGE_PREFIX}-qt6-base"
 "${MINGW_PACKAGE_PREFIX}-qt6-svg"
 "${MINGW_PACKAGE_PREFIX}-qt6-scxml")
-makedepends=("${MINGW_PACKAGE_PREFIX}-cmake")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+"${MINGW_PACKAGE_PREFIX}-cc"
+"${MINGW_PACKAGE_PREFIX}-sed"
+"${MINGW_PACKAGE_PREFIX}-grep")
 options=('strip')
 license=('MIT')
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/jkriege2/JKQtPlotter/archive/refs/tags/v${pkgver}.tar.gz")


### PR DESCRIPTION
Unfortunately,this project cannot be compiled under mingw32 because it doesn't have the required dependencies.