### PR TITLE
Capstone: workaround on #20581

### DIFF
--- a/mingw-w64-capstone/PKGBUILD
+++ b/mingw-w64-capstone/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-capstone"
          "${MINGW_PACKAGE_PREFIX}-python-capstone")
 pkgver=5.0.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Lightweight multi-platform, multi-architecture disassembly framework (mingw-w64)'
 url='https://www.capstone-engine.org/index.html'
 arch=('any')
@@ -20,13 +20,16 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python-wheel")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/capstone-engine/capstone/archive/refs/tags/${pkgver}.tar.gz"
-        "mingw_python.patch")
+        "mingw_python.patch"
+        "fix_pkgconf_version_on_cmake.patch")
 sha256sums=('2b9c66915923fdc42e0e32e2a9d7d83d3534a45bb235e163a70047951890c01a'
-            '1b3fad23218c15ea232c0698b45095325d17401c9902268395b452ba3733ae0d')
+            '1b3fad23218c15ea232c0698b45095325d17401c9902268395b452ba3733ae0d'
+            'f712940d351a30b80bf70578ac4d90e82e0a626b98c0913ddcf125201f594266')
 
 prepare() {
   cd ${_realname}-${pkgver}
   patch -p1 -i "${srcdir}/mingw_python.patch"
+  patch -p1 -i "${srcdir}/fix_pkgconf_version_on_cmake.patch"
 }
 
 build() {

--- a/mingw-w64-capstone/PKGBUILD
+++ b/mingw-w64-capstone/PKGBUILD
@@ -24,7 +24,7 @@ source=("${_realname}-${pkgver}.tar.gz::https://github.com/capstone-engine/capst
         "fix_pkgconf_version_on_cmake.patch")
 sha256sums=('2b9c66915923fdc42e0e32e2a9d7d83d3534a45bb235e163a70047951890c01a'
             '1b3fad23218c15ea232c0698b45095325d17401c9902268395b452ba3733ae0d'
-            'f712940d351a30b80bf70578ac4d90e82e0a626b98c0913ddcf125201f594266')
+            'e28d9d4ab763cf4bbb16639afa9e8a3d227731b5d0cb1dd5756d3c2ad00076a6')
 
 prepare() {
   cd ${_realname}-${pkgver}

--- a/mingw-w64-capstone/fix_pkgconf_version_on_cmake.patch
+++ b/mingw-w64-capstone/fix_pkgconf_version_on_cmake.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -22,7 +22,7 @@ cmake_policy(SET CMP0042 NEW)
+ cmake_policy(SET CMP0091 NEW)
+ 
+ project(capstone
+-    VERSION 5.0
++    VERSION 5.0.1
+ )
+ 
+ if (MSVC)


### PR DESCRIPTION
## Context:
Capstone issue: https://github.com/capstone-engine/capstone/issues/2310
Fixes #20581

I recommend having a look at the Capstone issue first.

Fixes the pkgconfig bogus version, using a workaround until upstream fixes the root issue.