### PR TITLE
mcfgthread: Update to v1.7.1

### DIFF
--- a/mingw-w64-mcfgthread/PKGBUILD
+++ b/mingw-w64-mcfgthread/PKGBUILD
@@ -4,17 +4,17 @@ _realname=mcfgthread
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}"-libs)
-pkgver=1.6.1
+pkgver=1.7.1
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
 url="https://github.com/lhmouse/mcfgthread"
 license=('spdx:LGPL-3.0-or-later' 'custom')
 options=('staticlibs' 'strip' '!buildflags')
-_commit='40263a6e2095ccba83071454191e09f14e9ee232'
+_commit='cf78d8a037a87373db9f2ca50c4f4fab7a60dae4'
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cc"
-  "${MINGW_PACKAGE_PREFIX}-autotools"
+  "${MINGW_PACKAGE_PREFIX}-meson"
   "${MINGW_PACKAGE_PREFIX}-crt"
   "${MINGW_PACKAGE_PREFIX}-headers"
   "git"
@@ -22,51 +22,26 @@ makedepends=(
 source=("git+https://github.com/lhmouse/mcfgthread.git#commit=${_commit}")
 sha256sums=('SKIP')
 
-prepare() {
-  cd "${srcdir}/${_realname}"
-
-  mkdir -p m4
-  autoreconf -ifv
-
-  pushd test_c++
-  mkdir -p m4
-  autoreconf -ifv
-  popd
-}
-
 build() {
   [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
   export CFLAGS+=' -Os -g'
+  MSYS2_ARG_CONV_EXCL="--prefix=" meson setup -Dbuildtype=plain  \
+    --prefix="${MINGW_PREFIX}" . ../${_realname}
 
-  ../${_realname}/configure \
-    --prefix=${MINGW_PREFIX} \
-    --build=${MINGW_CHOST} \
-    --host=${MINGW_CHOST} \
-    --disable-pch
-
-  make
+  # Build the DLL first, as Meson creates the DLL in the working directory,
+  # which might get picked up by cc1.exe when it is only half-baked.
+  ninja libmcfgthread-1.dll
+  meson compile
 
   rm -rf "${srcdir}${MINGW_PREFIX}"
-  make -j1 DESTDIR=${srcdir} install
+  DESTDIR="${srcdir}" meson install
 }
 
 check() {
   cd "${srcdir}/build-${MSYSTEM}"
-  make check
-
-  # Run c++ tests, which have to be configured separately after C
-  # libraries have been built.
-  mkdir -p test_c++
-  pushd test_c++
-
-  ../../${_realname}/test_c++/configure \
-    --build=${MINGW_CHOST} \
-    --host=${MINGW_CHOST}
-
-  make check
-  popd
+  meson test
 }
 
 package_mcfgthread() {
@@ -75,10 +50,8 @@ package_mcfgthread() {
 
   mkdir -p "${pkgdir}${MINGW_PREFIX}"
   cd "${srcdir}${MINGW_PREFIX}"
-  _files_cp="$(find bin -type f -and -not -name "*.dll")"
-  [[ -z "${_files_cp}" ]] || cp --parents -r ${_files_cp} --target-directory="${pkgdir}${MINGW_PREFIX}"
-  cp --parents -r include   --target-directory="${pkgdir}${MINGW_PREFIX}"
-  cp --parents -r lib       --target-directory="${pkgdir}${MINGW_PREFIX}"
+  cp --parents -r include -t "${pkgdir}${MINGW_PREFIX}"
+  cp --parents -r lib -t "${pkgdir}${MINGW_PREFIX}"
 }
 
 package_mcfgthread-libs() {
@@ -86,8 +59,7 @@ package_mcfgthread-libs() {
 
   mkdir -p "${pkgdir}${MINGW_PREFIX}"
   cd "${srcdir}${MINGW_PREFIX}"
-  _files_cp="$(find bin -type f -and -name "*.dll")"
-  [[ -z "${_files_cp}" ]] || cp --parents -r ${_files_cp} --target-directory="${pkgdir}${MINGW_PREFIX}"
+  cp --parents -r bin/libmcfgthread-1.dll -t "${pkgdir}${MINGW_PREFIX}"
 }
 
 # template start; name=mingw-w64-splitpkg-wrappers; version=1.0;


### PR DESCRIPTION
1. Migrate from autotools to meson.
2. Fix x87 `long double` test on ARM64EC (thanks to @Blackhex)
3. Make use of `GetSystemTimePreciseAsFileTime()` (win8) and `QueryInterruptTime()` (win10) when they are available.
4. Exclude system suspension from relative timeout intervals, like `CLOCK_MONOTONIC` on Linux.
5. Make headers usable with VC++. For C additional experimental options are required. See [devblog](https://devblogs.microsoft.com/cppblog/c11-atomics-in-visual-studio-2022-version-17-5-preview-2/).


