### PR TITLE
mingw-w64-efxc2 - update to latest release.

### DIFF
--- a/mingw-w64-efxc2/PKGBUILD
+++ b/mingw-w64-efxc2/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=efxc2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.0.6.118
+pkgver=0.0.7.124
 pkgrel=1
 pkgdesc="Enhanced version of fxc2 (mingw-w64)"
 arch=('any')
@@ -15,7 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-cc")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/JPeterMugaas/efxc2/archive/refs/tags/${pkgver}.tar.gz")
-sha256sums=('52261c205328b231381ea8fe05d35442837d527f807b4af631a36884432d5080')
+sha256sums=('ac5ff386ea5c7a7b2303c96c59f608eba3e8a0af4f9bd7fcae8c8d0c7e9d7970')
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"


### PR DESCRIPTION
Release is primarily a fix for passing defines for the compiler.