### PR TITLE
templates: Pass build directory as command line option of build system

### DIFF
--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-git.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-git.sh
@@ -36,8 +36,6 @@ prepare() {
 }
 
 build() {
-  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
-
   declare -a extra_config
   if check_option "debug" "n"; then
     extra_config+=("-DCMAKE_BUILD_TYPE=Release")
@@ -51,21 +49,18 @@ build() {
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       "${extra_config[@]}" \
       -DBUILD_{SHARED,STATIC}_LIBS=ON \
-      ../${_realname}
+      -S "${_realname}" \
+      -B "build-${MSYSTEM}"
 
-  "${MINGW_PREFIX}"/bin/cmake.exe --build .
+  "${MINGW_PREFIX}"/bin/cmake.exe --build "build-${MSYSTEM}"
 }
 
 check() {
-  cd "${srcdir}/build-${MSYSTEM}"
-
-  "${MINGW_PREFIX}"/bin/cmake.exe --build . --target test
+  "${MINGW_PREFIX}"/bin/cmake.exe --build "build-${MSYSTEM}" --target test
 }
 
 package() {
-  cd "${srcdir}/build-${MSYSTEM}"
-
-  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install "build-${MSYSTEM}"
 
   install -Dm644 "${srcdir}/${_realname}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-tarball.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-tarball.sh
@@ -28,9 +28,6 @@ prepare() {
 }
 
 build() {
-  cd "${srcdir}/${_realname}-${pkgver}"
-  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
-
   declare -a extra_config
   if check_option "debug" "n"; then
     extra_config+=("-DCMAKE_BUILD_TYPE=Release")
@@ -44,21 +41,18 @@ build() {
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       "${extra_config[@]}" \
       -DBUILD_{SHARED,STATIC}_LIBS=ON \
-      ../${_realname}-${pkgver}
+      -S "${_realname}-${pkgver}" \
+      -B "build-${MSYSTEM}"
 
-  "${MINGW_PREFIX}"/bin/cmake.exe --build .
+  "${MINGW_PREFIX}"/bin/cmake.exe --build "build-${MSYSTEM}"
 }
 
 check() {
-  cd "${srcdir}/build-${MSYSTEM}"
-
-  "${MINGW_PREFIX}"/bin/cmake.exe --build . --target test
+  "${MINGW_PREFIX}"/bin/cmake.exe --build "build-${MSYSTEM}" --target test
 }
 
 package() {
-  cd "${srcdir}/build-${MSYSTEM}"
-
-  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install "build-${MSYSTEM}"
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.meson-tarball.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.meson-tarball.sh
@@ -29,29 +29,24 @@ prepare() {
 }
 
 build() {
-  mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
-
   MSYS2_ARG_CONV_EXCL="--prefix=" \
     meson setup \
       --prefix="${MINGW_PREFIX}" \
       --wrap-mode=nodownload \
       --auto-features=enabled \
       --buildtype=plain \
-      ../${_realname}-${pkgver}
+      "build-${MSYSTEM}" \
+      "${_realname}-${pkgver}"
 
-  meson compile
+  meson compile -C "build-${MSYSTEM}"
 }
 
 check() {
-  cd "${srcdir}/build-${MSYSTEM}"
-
-  meson test
+  meson test -C "build-${MSYSTEM}"
 }
 
 package() {
-  cd "${srcdir}/build-${MSYSTEM}"
-
-  DESTDIR="${pkgdir}" meson install
+  meson install -C "build-${MSYSTEM}" --destdir "${pkgdir}"
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }


### PR DESCRIPTION
This helps to rule out all the cd commands and jumping between various directories.