### PR TITLE
nerd-fonts: update to 3.2.1

### DIFF
--- a/mingw-w64-nerd-fonts/PKGBUILD
+++ b/mingw-w64-nerd-fonts/PKGBUILD
@@ -69,7 +69,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-otf-aurulent-nerd"
          "${MINGW_PACKAGE_PREFIX}-ttf-victor-mono-nerd"
          "${MINGW_PACKAGE_PREFIX}-ttf-zed-mono-nerd")
 pkgdesc="Iconic font aggregator, collection, and patcher (mingw-w64)"
-pkgver=3.2.0
+pkgver=3.2.1
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -149,72 +149,72 @@ source=("0xproto-${pkgver}.tar.xz::${_urlbase}/0xProto.tar.xz"
         "ubuntusans-${pkgver}.tar.xz::${_urlbase}/UbuntuSans.tar.xz"
         "victormono-${pkgver}.tar.xz::${_urlbase}/VictorMono.tar.xz"
         "zedmono-${pkgver}.tar.xz::${_urlbase}/ZedMono.tar.xz")
-sha256sums=('d6db9025a1f09c51de9b2214a637fe9419311f4885ad9428340c819308bdf96e'
-            '3a73e484780e9983e65e51a4d50330896713163fd1d8dee162b93c1eeb4ec2c3'
-            'c2e47c89dfdf007884528e4a3929a62b3b86b91c4897c19e05e24c6d6efcf9cf'
-            '9f73054917c0241f9f9bca4f5614af05dfd460badf6a3a47262b58bfe61764c9'
-            'ce41bcc35906fa795ce7b8ea71c6f07fb6994a65e575e3211983ae103634a93e'
-            'af213cfa4a770ff032223cf2bb92fee34c7267ac787c6b7b29b59d35dbf84760'
-            'b655fd38f55e9fb61e028e1c6a11b5ce2e94c40c474f1f0d96d9c0c35ea46e69'
-            '3c1a8e4028b4db7807d66fec86e80b21a95d8d17e2dc6ec9299659c8c1b3d826'
-            '6647b8c978028ab9e133260754b2d5a7f9472feb1f58dd0a45b38c683055a05a'
-            'b9f5fdcfaedb27baa0c8aa1fdbfdf312751f71b14d95c34e3633b58ec6ebd7b3'
-            '8b228d76e13d984f9349f6bec9de36f8e831b345693870245f5e6bee42ce270c'
-            'a511f7e86f498f4afb80748d6121c5c45eac3e328139c52184eacbd1ac881c49'
-            '6c9d31a3108bf2385cd7d7f76883d8aca247fd4dd14651f20fbf595495f23b9d'
-            '744510c90ddefe423679558fb18ad8714a53d5579155d0397f7a3db988de291f'
-            'cca47cfedfd3c548e1bfdb265384adef93aed552e1b7801772fe013e06e9e54b'
-            '2d9277c41bce302c074d4898111836b19746772d29fdd7dc01705e48581c3b87'
-            '7e4a03e397b40ff9e3d0d5e6374d3908dee59a584f6dc7fa76d8fd949d253e37'
-            'db1216e2631e1aafbc7e4a206a331608965d6cc9474fc6bd4dfb931dfe9278fc'
-            '3998961c8d382b3c14078ccf49b7c70d0b62ee81ffdf0a1eaceffc5a3697a30d'
-            '3721de207bac38f05797f21cfd6e672a268b3fd8419a47f789fafa11f85f084a'
-            '02b9f7fda56efcfba2fd5ccf3d81455af52b3a405648ece7f0e1c58aac7109bc'
-            '2e5fcc890e64d48d3afd9b1e16d03f7c945941073c6c6a724298f29135bc93fd'
-            'bdeae85787344c8ac1f3fde13ea16bcff201ce656d76f5b0de77f2952db6d4f3'
-            '01d399eb32242b4689d1523ab634d0ff7b19200f117e72a5d97abf8ddbbdc787'
-            '0d148a396f377262d59719e3d5da3ef58e448fe6f96001a85e365bef4ba772bf'
-            '279c47fc2b4efdf7fb76852db5a9d1664df1b461515dc6052350ce4271a6760b'
-            'b89528815c5faa2f27f8fd5aa14d0e1460d1e8e8730e301552578baae973102a'
-            'bd3ec9b863603438ddaad8853e3c94cc94bd9469f9c1b85de7b8f433698edc3b'
-            '4e5d74a8f0fd0081e012fed0b97500bd254ae2a884de43f7bfa70b43d79c6518'
-            'ff96f08889b57513b5e08013b39793d7690983f828ad2c590a373b9a082a428a'
-            '8e861655539d558a0721c2b5a9543d20b438b1ba028933bd11724b73c96762b3'
-            '1aabe42b6e72b9f5e7ae5ac41afedb703180ba9bb680540945342935f5327990'
-            '64fc2b773674f3b50c22cd119909f124f7c6007082365ba2da0d4053f71b8c74'
-            '8620a0b58be4f426013cfb409ba668ab013b14536443e742263b3a86ce4247cb'
-            'a90454ca119abc228ac6ff5f37a4b9468f0a80b8236e272aa80f64e5dc71e45e'
-            '588da479e028e5aaa3438761b6187c7eeb2161cc197220ff65c5fc5d9ff8619a'
-            '97be9ff8e9aebbe3a85e22a9ad08fa3e2361404531f78ee12ea6ea33ec9ead87'
-            'aca644a2b8cb3345e1e4e702df674df245c0a8ee3e3a29d4116c9492ef421cf8'
-            '8aa63c46a5dbb7a075ba579bb2189d3d7e42f3027797df85b14727aaeb71a29d'
-            'b945441065c2cc86ea5290c2523d1dd87e27adee93bc32184d2523b852251244'
-            'd8854ae585b35e1f639ef6ecc50cb6bf789e70b9bf7e9726b525069e63b01ee8'
-            '86e2800414f85b01df0a1b11ad339ae851253afe815a6a1a744d1a9eadf9a079'
-            '73abcdc12015143eaf24ed5097ae357aa552c8cb90c3500e551ae1315cdc97ca'
-            '0b49634ee2b0aa3764f223064797d8a3fdc03760d1fb668a0f563bc24320b93c'
-            'e22c15c18e7f48bbe3f137539662eff384898d33879e1589b3d30c4a255123b2'
-            '33b0e22e29f101a73f2d3968008450faef0f0bbbb581a8c4d96027b7b6a93d57'
-            '221860e985ea2a7f799a76c4be8dabdee242e85bd5e6c1e89ae86674fad44b3e'
-            'e02961e17dbeb37f48b5af102eab6c9cc5083e90d3da503f78cd3385b64af423'
-            '459dfe40e05e6428f81a4a11d956e4c59243b8c3dd018956760f59c9acd324fe'
-            'ced545faeb348c73a924e09078eb26a87e0bfd7219b3dd4af9c7579d5d221505'
-            '92b235828cc5ad1b234f45fbbb767baeda6647d8c6b1c6535206b9b1c32ed28c'
-            '05fe04c852925419be8958e4fc1907ba69f1d575a41239b46aeaf8c11cf52733'
-            '8e271ba485c07706e772693586ea300dc124ecf6d0a589ad37b1388642c8757d'
-            '01b59814b15a08d9cc858b19530c8295846ab517661351562849b6c05606dbd7'
-            '6df852dfcc2bb95e8653cf30463d29ebfaa653dc2650a9f7c667ecbc8416090a'
-            '1151b15db67316613320249633f5711caf094e43f5b3ac38b1f624c2d2fe6f48'
-            'c48283f68fa15c731cda9142e3991ba86efa30d0ecf938d25c678271453c9b1f'
-            '78a1aef2ea83ece21d97f948c9f4ee2ce9ba8ea9be3fdf531be7a0d0560dd9fe'
-            '7c33439ae54dcdfa89715d7f82797a4b76b9151ec807e158e7dca7bca2bef58c'
-            'fa96d505c5d67a85b1a02fc2a3fabe290783434ede477522a80ae6244281b13b'
-            'b0569548a5a7aa93e959558ec7a187316bf8131367ad8fe13a4f73d49905f42c'
-            '7ad81f36a9f472f97bfbffbc8513053bdc0e931ef1b59fb4e95df0a99b3037e1'
-            '3ce716484ea6ae666013404e9fecf1d7a29c20e9ddadf7c776eafb28cd22fbe3'
-            '121a781422ec395b2fff516b89535be7e1e496bde70d3e1253d680f9ecfed7aa'
-            'cf0451de630a535f473462b5ad9b42973e103b252d527379f00c2cdb1de7cadb'
-            'aeac50f6973e269bdd05b01680ca496665fa27ecc69914bde254307b3d11d61b')
+sha256sums=('cf165059645c02212fbdb5a27858056772d12a762468a0971c5bed3de88d0427'
+            '6168e416a4331e8d59d5436d9a3c8170f98ee044e2fe662cbf1d7bea612f927d'
+            'c307d029f638a411834972569317a04b9d75e968a53b12e41c787db064a6bef7'
+            '1e4b7f7c8528c9d43760eacdb5d423ad272f028cad5958e594a30486dce409d3'
+            '20f3bc015e46e4fe9f57cfe495eaa167b796e047df4f98676fe16649aba4ffb8'
+            'd71be5a39c772a58d2592e490784298753573ee47836633ade381f1eeee39c72'
+            '432c4a9080038554a94a46f435cb1aca3d58e23deb445e5c39d2c740a9edac84'
+            '5328418c755f076363e46960f311c734c0939167ab02eb718a8fb7bcc1bbd2e8'
+            '5af79aaebec3aa474c801e48aa2cb901cf1e9c03cbb3b6c189fed439e867e6e9'
+            '9672540e8707d221fe48fa5da49aec5a605b2d38a85c9fed959eb76990b33367'
+            '45d29f5be8add78ae271550d542387f4c98bbbe62e395a3646bc67f66f9d3c5c'
+            'dc0835a985f19491526fb5773ad7d9646bbdb962cda5076615b686427fb565dc'
+            '173f5a8fe5bb0a4e7db61ac9a77e97c7b5071b9b2a9f8dbaf8432311518a5f4a'
+            'b8f14c715bdcce4afafd9c4e57acba5b9d5c1c3357f054a505716187ae1e98b1'
+            'c01665970a43c13b27ea1fb9c85055d9c2369b3f9f2d1b37c08ffeaad7830cb0'
+            '6e7dd3ebdb82ee4a5b358801c082553692431e246c996dcbb3a737a28c78e4db'
+            'b94bde4d2e9ceb1f2c19b2846c1a9892797e4e15e9594303eb7088534244a18b'
+            'd3910065466618646baf9a621d385f8122c310e29d449462e5bd25bd300e0dd7'
+            'd1ca4f8bae74e089775a9ba6b2015ee79e03ec0970e76499f56131499524efa4'
+            '2d6db874195ac7ec4d9b396a9612e1e342b060d8aef0304b0b99c49c3b9a351d'
+            'def4b29f7aa0620a7fa12edb28197a2697680b5e21636fa3dcc602e08ae13bc4'
+            'c0224b12e3da90550bb1c42a9149346326ebbc9f41cf83a5e6c8944e57772bc5'
+            '0f247f19afece755de1a1b7b2eae38d48023ce4436323ab51f571d38314c6c73'
+            '44a4ce529f51dc5f067a10b851acd06a1dc7ea7d6af5ba8a420e057232c8d948'
+            '7ab613fac9d5931bd32d8e5a438ae0cb17536317e171f28ee5ddb8a171941041'
+            '89b9023f3f6d5e4b8040022ff29b36faee440cf49015fda163215c922569b5f3'
+            '4fb0ff16a5e587e65f59e55d08283729de700f0c0bf682ec1bef18ab51264ada'
+            'f6b8a6cfb0d06bd25e7653c2ac18a562f53f6143eb131195a5fca4dde30d6aa8'
+            '23552caf1b6075858756de2e8f3a3fbb9799b478882f3f7afeefa8ca7f4601ae'
+            '85b0b39b30a9ddd89462b0a7a732b461de04f667dc01a5e987bf0c2accbb576f'
+            '97e2774a01a151fc2f711f018831d24777472daf0f2822230ce20a7ac227a041'
+            '2c9f5a1117e1b5a640287081680837e7b870c94868627766483011ff0b80c3f7'
+            '69e0a42a6e8072b2a084f09a5056e857e9b620afd57d7d07c8d1da2cf4809b41'
+            '7a96f8cc30e57a426ffce3b844deb10d6325181b28df9b76735308f2d787dc2d'
+            'a016b61e49c395c5b1e5bd2c919ae668724a33f2ef14da3becf932da401a080d'
+            '1be123fa355a9acee79d19891c02499792f6a4e12ffa8973c6b1cb738465f337'
+            'b5d5e7b26c76f1cfe97a697716fdd682b18faf9f73883915c2b0c2d9fcc48cf5'
+            '3132ff085ce404a3c065054638f3dc68de27d07a5cc5379b90b2a248877971eb'
+            '6cf8822bc1ca18e34b06578c7499f380c019e6ffc883eed26df5f498dfcc4006'
+            '2282cb16651a377d5b084486a268189fdafd9067775f1f24ffaf5a36a2459501'
+            '9d0ad55cbd83967ca93e940f4951d41b23a44c892d9a4788af460d71f8bb81a4'
+            'a2720d1fbf7ebb51b6a0ab191de41d96c7594d61f02c582db2249ea30c1ce263'
+            '62484ea8f66ae3b75610b89c5d3258f8610844fec6d8402239c27a5042dccc7d'
+            '1abdaf5542b75a51d75de6373148a8e401b28eda88e6c90f243fb6114fd659ea'
+            'e5d2e8180d5df1fe473b598edac5f67ce38b1d906248936eb386dd332a338346'
+            'eb035bfb09043db2278dd6f95ca956a7cc42a3e6cc30910295c51555b2e8ff81'
+            'c7a5ff556ff4aad5381e8a57e0d17d79c591e1267f0a9c271b09306ac4581aba'
+            'eb3697dd13c5e50951023c0768538a2f70e1e4f22d94800a45779a6d1b49f7a3'
+            '5c60700788b093e0bfb30b2f59b52397f3fdc2cdf2b6fb9307a58b61e7ddfe74'
+            '4be621219ff5508c4176487b4fdc8cd0f6d8d8fceeb935f83df11a49dca3096f'
+            '96d43a8c53173b992537a1d34ae984f65a8999b7c8991a02c17d4b77497581fa'
+            'fcb796892b105c98ad05a29f184f09a02038970ff6a95f8cda082cd1b1b08cde'
+            'fe3bd035d43b943de17e6e0da1dfb0bd1dcc1b319e10c5e5925ab70436d48385'
+            '1a58c57b63f380441ea07d44780680844afe12dd299651b87db59f9f311702d1'
+            'e5f7db6999bf6dd6501d8933575caab49827486ce774c6c35a6e411da8c6cfba'
+            '3ccfd4d8d625c708e593e46ea0404536984f69f11c7a08b5a59eb9bbc9dfde3c'
+            'dbcfa99f4d41f05e4b59eb2197873515c035eff1a68800bf0f43db471ef7ba57'
+            '56a43a2729035f7fec17b68823a7db9ea06fcf9ec8d0b5e70d73ab79488a1b21'
+            'b6b9d7c604cc55d2c6859ad098371dfbfe540eb2d5aab4faad21f81149659338'
+            '658cc9506acf89b5f5dfc6b55eb9899b782dcf8d89f3d11c9abb2c4d52617f12'
+            '21b43c2314614733f5e9b4b4f3117edc3986d2b0f2a33409b111cc38360e8391'
+            '6a254d48c837974e7c43fb92124e8e057c1d4b31c9ebe635f5c562233a24f3ad'
+            '2b678521c5c8a963ba2c8f7846e21df4323838c64d70d59cb1ff38124d7f7396'
+            '3ef8c7ca298d5528cf4296298ab67d7c5c2ba00030735db4851cea8f52d8444a'
+            'aa1b09dca861a306cd24c2c47fded88b63ae833ff0e815dad3642465583e300f'
+            '2df9c9e54e5a2bc19c2ffd1df7ee283e02ba2e9a5fda1067b4884375ae4b0b7a')
 noextract=("${source[@]%%::*}")
 
 prepare() {
@@ -236,7 +236,7 @@ prepare() {
 
 package_ttf-0xproto-nerd() {
   pkgdesc="Patched font 0xProto from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN')
 
   install -Dm644 0xproto/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 0xproto/LICENSE -t "${pkgdir}${MINGW_PREFIX}/share/licenses/ttf-0xproto-nerd/"
@@ -244,7 +244,7 @@ package_ttf-0xproto-nerd() {
 
 package_ttf-3270-nerd() {
   pkgdesc="Patched font IBM 3270 from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1 AND BSD-3-Clause')
+  license=('spdx:BSD-3-Clause')
 
   install -Dm644 3270/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 3270/LICENSE.txt -t "${pkgdir}${MINGW_PREFIX}/share/licenses/ttf-3270-nerd/"
@@ -260,7 +260,7 @@ package_ttf-agave-nerd() {
 
 package_ttf-anonymouspro-nerd() {
   pkgdesc="Patched font Anonymous Pro (Anonymice) from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-RFN')
 
   install -Dm644 anonymouspro/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 anonymouspro/OFL.txt -t \
@@ -277,7 +277,7 @@ package_ttf-arimo-nerd() {
 
 package_otf-aurulent-nerd() {
   pkgdesc="Patched font Aurulent Sans Mono from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN')
 
   install -Dm644 aurulent/*.otf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/OTF"
   install -Dm644 aurulent/"SIL Open Font License.txt" -t \
@@ -304,7 +304,7 @@ package_ttf-bitstream-vera-mono-nerd() {
 
 package_ttf-cascadia-code-nerd() {
   pkgdesc="Patched font Cascadia Code (Caskaydia) from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-RFN')
 
   install -Dm644 cascadiacode/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 cascadiacode/LICENSE -t \
@@ -313,7 +313,7 @@ package_ttf-cascadia-code-nerd() {
 
 package_ttf-cascadia-mono-nerd() {
   pkgdesc="Patched font Cascadia Mono (Caskaydia) from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-RFN')
 
   install -Dm644 cascadiamono/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 cascadiamono/LICENSE -t \
@@ -322,7 +322,7 @@ package_ttf-cascadia-mono-nerd() {
 
 package_otf-codenewroman-nerd() {
   pkgdesc="Patched font Code New Roman from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN')
 
   install -Dm644 codenewroman/*.otf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/OTF"
   install -Dm644 codenewroman/license.txt -t \
@@ -340,7 +340,7 @@ package_otf-comicshanns-nerd() {
 
 package_otf-commit-mono-nerd() {
   pkgdesc="Patched font Commit Mono from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN')
 
   install -Dm644 commitmono/*.otf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/OTF"
   install -Dm644 commitmono/LICENSE -t \
@@ -357,7 +357,7 @@ package_ttf-cousine-nerd() {
 
 package_ttf-d2coding-nerd() {
   pkgdesc="Patched font D2Coding from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN')
 
   install -Dm644 d2coding/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 d2coding/LICENSE -t "${pkgdir}${MINGW_PREFIX}/share/licenses/ttf-d2coding-nerd/"
@@ -365,7 +365,7 @@ package_ttf-d2coding-nerd() {
 
 package_ttf-daddytime-mono-nerd() {
   pkgdesc="Patched font Daddy Time Mono from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN')
 
   install -Dm644 daddytimemono/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 daddytimemono/LICENSE.md -t \
@@ -390,7 +390,7 @@ package_otf-droid-nerd() {
 
 package_ttf-envy-code-r-nerd() {
   pkgdesc="Patched font Envy Code R from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-RFN')
 
   install -Dm644 envycoder/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 envycoder/LICENCE.md -t \
@@ -399,7 +399,7 @@ package_ttf-envy-code-r-nerd() {
 
 package_ttf-fantasque-nerd() {
   pkgdesc="Patched font Fantasque Sans Mono from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN')
 
   install -Dm644 fantasque/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 fantasque/OFL.txt -t "${pkgdir}${MINGW_PREFIX}/share/licenses/ttf-fantasque-nerd/"
@@ -407,7 +407,7 @@ package_ttf-fantasque-nerd() {
 
 package_ttf-firacode-nerd() {
   pkgdesc="Patched font Fira (Fura) Code from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN')
 
   install -Dm644 fira/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 fira/LICENSE -t "${pkgdir}${MINGW_PREFIX}/share/licenses/ttf-firacode-nerd/"
@@ -415,7 +415,7 @@ package_ttf-firacode-nerd() {
 
 package_otf-firamono-nerd() {
   pkgdesc="Patched font Fira (Fura) Mono from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN')
 
   install -Dm644 firamono/*.otf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/OTF"
   install -Dm644 firamono/LICENSE -t "${pkgdir}${MINGW_PREFIX}/share/licenses/otf-firamono-nerd/"
@@ -423,7 +423,7 @@ package_otf-firamono-nerd() {
 
 package_otf-geist-mono-nerd() {
   pkgdesc="Patched font Geist Mono from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN')
 
   install -Dm644 geistmono/*.otf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/OTF"
   install -Dm644 geistmono/LICENSE -t \
@@ -432,7 +432,7 @@ package_otf-geist-mono-nerd() {
 
 package_ttf-go-nerd() {
   pkgdesc="Patched font Go Mono from nerd fonts library (mingw-w64)"
-  license=('spdx:BSD-3-Clause')
+  license=('spdx:BSD-3-Clause-Clear')
 
   install -Dm644 go/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 go/LICENSE.txt -t "${pkgdir}${MINGW_PREFIX}/share/licenses/ttf-go-nerd/"
@@ -448,7 +448,7 @@ package_ttf-gohu-nerd() {
 
 package_ttf-hack-nerd() {
   pkgdesc="Patched font Hack from nerd fonts library (mingw-w64)"
-  license=('spdx:MIT AND Bitstream-Vera')
+  license=('spdx:Bitstream-Vera AND MIT')
 
   install -Dm644 hack/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 hack/LICENSE.md -t "${pkgdir}${MINGW_PREFIX}/share/licenses/ttf-hack-nerd/"
@@ -456,7 +456,7 @@ package_ttf-hack-nerd() {
 
 package_otf-hasklig-nerd() {
   pkgdesc="Patched font Hasklig (Hasklug) from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-RFN')
 
   install -Dm644 hasklig/*.otf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/OTF"
   install -Dm644 hasklig/LICENSE.md -t "${pkgdir}${MINGW_PREFIX}/share/licenses/otf-hasklig-nerd/"
@@ -473,7 +473,7 @@ package_ttf-heavydata-nerd() {
 
 package_otf-hermit-nerd() {
   pkgdesc="Patched font Hermit from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-RFN')
 
   install -Dm644 hermit/*.otf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/OTF"
   install -Dm644 hermit/LICENSE -t "${pkgdir}${MINGW_PREFIX}/share/licenses/otf-hermit-nerd/"
@@ -481,7 +481,7 @@ package_otf-hermit-nerd() {
 
 package_ttf-iawriter-nerd() {
   pkgdesc="Patched font iA Writer (iM Writing) from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-RFN')
 
   install -Dm644 iawriter/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 iawriter/LICENSE.md -t "${pkgdir}${MINGW_PREFIX}/share/licenses/ttf-iawriter-nerd/"
@@ -489,7 +489,7 @@ package_ttf-iawriter-nerd() {
 
 package_ttf-ibmplex-mono-nerd() {
   pkgdesc="Patched font IBM Plex Mono (Blex) from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-RFN')
 
   install -Dm644 ibmplexmono/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 ibmplexmono/LICENSE.txt -t "${pkgdir}${MINGW_PREFIX}/share/licenses/ttf-ibmplex-mono-nerd/"
@@ -497,7 +497,7 @@ package_ttf-ibmplex-mono-nerd() {
 
 package_ttf-inconsolata-nerd() {
   pkgdesc="Patched font Inconsolata from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN')
 
   install -Dm644 inconsolata/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 inconsolata/OFL.txt -t \
@@ -506,7 +506,7 @@ package_ttf-inconsolata-nerd() {
 
 package_ttf-inconsolata-go-nerd() {
   pkgdesc="Patched font Inconsolata Go from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN')
 
   install -Dm644 inconsolatago/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 inconsolatago/OFL.txt -t \
@@ -515,7 +515,7 @@ package_ttf-inconsolata-go-nerd() {
 
 package_ttf-inconsolata-lgc-nerd() {
   pkgdesc="Patched font Inconsolata LGC from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN')
 
   install -Dm644 inconsolatalgc/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 inconsolatalgc/LICENSE \
@@ -524,7 +524,7 @@ package_ttf-inconsolata-lgc-nerd() {
 
 package_ttf-intelone-mono-nerd() {
   pkgdesc="Patched font IntelOne Mono (Intone Mono) from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-RFN')
 
   install -Dm644 intelone/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 intelone/LICENSE.txt \
@@ -533,7 +533,7 @@ package_ttf-intelone-mono-nerd() {
 
 package_ttf-iosevka-nerd() {
   pkgdesc="Patched font Iosevka from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN')
 
   install -Dm644 iosevka/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 iosevka/LICENSE.md -t "${pkgdir}${MINGW_PREFIX}/share/licenses/ttf-iosevka-nerd/"
@@ -541,7 +541,7 @@ package_ttf-iosevka-nerd() {
 
 package_ttf-iosevkaterm-nerd() {
   pkgdesc="Patched font Iosevka Term from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN')
 
   install -Dm644 iosevkaterm/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF/"
   install -Dm644 iosevkaterm/LICENSE.md -t \
@@ -550,7 +550,7 @@ package_ttf-iosevkaterm-nerd() {
 
 package_ttf-iosevkaterm-slab-nerd() {
   pkgdesc="Patched font Iosevka Term Slab from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN')
 
   install -Dm644 iosevkatermslab/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF/"
   install -Dm644 iosevkatermslab/LICENSE.md -t \
@@ -559,7 +559,7 @@ package_ttf-iosevkaterm-slab-nerd() {
 
 package_ttf-jetbrains-mono-nerd() {
   pkgdesc="Patched font JetBrains Mono from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN')
 
   install -Dm644 jetbrainsmono/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 jetbrainsmono/OFL.txt -t \
@@ -568,7 +568,7 @@ package_ttf-jetbrains-mono-nerd() {
 
 package_ttf-lekton-nerd() {
   pkgdesc="Patched font Lekton from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN')
 
   install -Dm644 lekton/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 lekton/"SIL Open Font License.txt" -t \
@@ -577,7 +577,7 @@ package_ttf-lekton-nerd() {
 
 package_ttf-liberation-mono-nerd() {
   pkgdesc="Patched font Liberation Mono from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-RFN')
 
   install -Dm644 liberationmono/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 liberationmono/LICENSE -t \
@@ -586,7 +586,7 @@ package_ttf-liberation-mono-nerd() {
 
 package_ttf-lilex-nerd() {
   pkgdesc="Patched font Lilex from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN')
 
   install -Dm644 lilex/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 lilex/LICENSE.txt -t "${pkgdir}${MINGW_PREFIX}/share/licenses/ttf-lilex-nerd/"
@@ -594,7 +594,7 @@ package_ttf-lilex-nerd() {
 
 package_ttf-martian-mono-nerd() {
   pkgdesc="Patched font Martian Mono from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN')
 
   install -Dm644 martianmono/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 martianmono/LICENSE -t \
@@ -611,7 +611,7 @@ package_ttf-meslo-nerd() {
 
 package_otf-monaspace-nerd() {
   pkgdesc="Patched font Monaspace from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-RFN')
 
   install -Dm644 monaspace/*.otf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/OTF"
   install -Dm644 monaspace/LICENSE -t "${pkgdir}${MINGW_PREFIX}/share/licenses/otf-monaspace-nerd/"
@@ -627,7 +627,7 @@ package_ttf-monofur-nerd() {
 
 package_ttf-monoid-nerd() {
   pkgdesc="Patched font Monoid from nerd fonts library (mingw-w64)"
-  license=('spdx:MIT AND OFL-1.1')
+  license=('spdx:MIT OR OFL-1.1-no-RFN')
 
   install -Dm644 monoid/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 monoid/LICENSE -t "${pkgdir}${MINGW_PREFIX}/share/licenses/ttf-monoid-nerd/"
@@ -635,7 +635,7 @@ package_ttf-monoid-nerd() {
 
 package_ttf-mononoki-nerd() {
   pkgdesc="Patched font Mononoki from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-RFN')
 
   install -Dm644 mononoki/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 mononoki/LICENSE.txt -t \
@@ -644,7 +644,7 @@ package_ttf-mononoki-nerd() {
 
 package_ttf-mplus-nerd() {
   pkgdesc="Patched font MPlus from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN')
 
   install -Dm644 mplus/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 mplus/OFL.txt -t "${pkgdir}${MINGW_PREFIX}/share/licenses/ttf-mplus-nerd/"
@@ -652,7 +652,7 @@ package_ttf-mplus-nerd() {
 
 package_ttf-noto-nerd() {
   pkgdesc="Patched font Noto from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN')
 
   install -Dm644 noto/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 noto/LICENSE_OFL.txt -t "${pkgdir}${MINGW_PREFIX}/share/licenses/ttf-noto-nerd/"
@@ -669,7 +669,7 @@ package_otf-opendyslexic-nerd() {
 
 package_otf-overpass-nerd() {
   pkgdesc="Patched font Overpass from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN OR LGPL-2.1-only')
 
   install -Dm644 overpass/*.otf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/OTF"
   install -Dm644 overpass/LICENSE.md -t \
@@ -695,7 +695,7 @@ package_ttf-proggyclean-nerd() {
 
 package_ttf-recursive-mono-nerd() {
   pkgdesc="Patched font Recursive Mono from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN')
 
   install -Dm644 recursive/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 recursive/LICENSE.txt -t \
@@ -713,7 +713,7 @@ package_ttf-roboto-mono-nerd() {
 
 package_ttf-sharetech-mono-nerd() {
   pkgdesc="Patched font Share Tech Mono (Shure Tech Mono) from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-RFN')
 
   install -Dm644 sharetechmono/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 sharetechmono/OFL.txt -t \
@@ -722,7 +722,7 @@ package_ttf-sharetech-mono-nerd() {
 
 package_ttf-sourcecodepro-nerd() {
   pkgdesc="Patched font Source Code Pro from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-RFN')
 
   install -Dm644 sourcecodepro/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 sourcecodepro/LICENSE.txt -t \
@@ -731,7 +731,7 @@ package_ttf-sourcecodepro-nerd() {
 
 package_ttf-space-mono-nerd() {
   pkgdesc="Patched font Space Mono from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN')
 
   install -Dm644 spacemono/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 spacemono/OFL.txt -t "${pkgdir}${MINGW_PREFIX}/share/licenses/ttf-space-mono-nerd/"
@@ -739,7 +739,7 @@ package_ttf-space-mono-nerd() {
 
 package_ttf-terminus-nerd() {
   pkgdesc="Patched font Terminus (Terminess) from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-RFN')
 
   install -Dm644 terminus/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 terminus/LICENSE.txt -t \
@@ -784,7 +784,7 @@ package_ttf-ubuntu-sans-nerd() {
 
 package_ttf-victor-mono-nerd() {
   pkgdesc="Patched font Victor Mono from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN')
 
   install -Dm644 victormono/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 victormono/LICENSE.txt -t \
@@ -793,7 +793,7 @@ package_ttf-victor-mono-nerd() {
 
 package_ttf-zed-mono-nerd() {
   pkgdesc="Patched font Zed Mono from nerd fonts library (mingw-w64)"
-  license=('spdx:OFL-1.1')
+  license=('spdx:OFL-1.1-no-RFN')
 
   install -Dm644 zedmono/*.ttf -t "${pkgdir}${MINGW_PREFIX}/share/fonts/TTF"
   install -Dm644 zedmono/LICENSE.md -t \


### PR DESCRIPTION
license refresh, source: https://github.com/ryanoasis/nerd-fonts/blob/master/bin/scripts/lib/fonts.json