### PR TITLE
swig: Update to 4.2.1

### DIFF
--- a/mingw-w64-swig/PKGBUILD
+++ b/mingw-w64-swig/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=swig
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.2.0
+pkgver=4.2.1
 pkgrel=1
 pkgdesc="Generate scripting interfaces to C/C++ code (mingw-w64)"
 arch=('any')
@@ -23,7 +23,7 @@ source=(https://downloads.sourceforge.net/${_realname}/${_realname}-${pkgver}.ta
         pathtools.h
         001-relocate.patch
         002-fix-python-find.patch)
-sha256sums=('261ca2d7589e260762817b912c075831572b72ff2717942f75b3e51244829c97'
+sha256sums=('fa045354e2d048b2cddc69579e4256245d4676894858fcf0bab2290ecf59b7d8'
             'ebf471173f5ee9c4416c10a78760cea8afaf1a4a6e653977321e8547ce7bf3c0'
             '1585ef1b61cf53a2ca27049c11d49e0834683dfda798f03547761375df482a90'
             'a27041d7b13a17547f8a534d80c370a9e689f8f2784d150fc755cbb91382dac4'


### PR DESCRIPTION
Since swig-4.2.0 has a bug, that [breaks FXRuby](https://github.com/larskanis/fxruby/actions/runs/8629979642/job/23655281538#step:6:55) CI runs.