### PR TITLE
[ossia-score] Update to 3.2.0, reinstate clang arm64

### DIFF
--- a/mingw-w64-ossia-score/PKGBUILD
+++ b/mingw-w64-ossia-score/PKGBUILD
@@ -57,7 +57,7 @@ build() {
   fi
 
   CXXFLAGS+=" -Wa,-mbig-obj"
-  if $CXX --version | grep clang; then
+  if [[ ${CC} == clang ]]; then
     CXXFLAGS+=" -fexperimental-library"
   fi
 

--- a/mingw-w64-ossia-score/PKGBUILD
+++ b/mingw-w64-ossia-score/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=ossia-score
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=3.1.14
+pkgver=3.2.0
 pkgrel=1
 pkgdesc="ossia score, an interactive sequencer for the intermedia arts"
 arch=('any')
@@ -38,7 +38,7 @@ makedepends=(
   "git"
 )
 source=("https://github.com/ossia/score/releases/download/v${pkgver}/ossia.score-${pkgver}-src.tar.xz")
-sha512sums=('2e8d27bf170c95d7dea835705a4d9d5da3180c095ae1ad189473e041b293fbc445c5201c19a003e0782bc60deb726c37f4f9fd97f319e0a6dd3deaf900381153')
+sha512sums=('55119fa2016834b5ebd1d581815162446773b926ee4391ad860a144b875f62f556c2f40b176fd2bffa6276c23b08e5a4b9ecd1ba78e687e363435b56abbad56a')
 noextract=(ossia.score-${pkgver}-src.tar.xz)
 
 prepare() {
@@ -55,6 +55,11 @@ build() {
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
+  CXX_ADDITIONAL_FLAGS=
+  if c++ --version | grep clang; then
+    CXX_ADDITIONAL_FLAGS=-fexperimental-library
+  fi
+
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake -Wno-dev -GNinja \
     -S "${srcdir}/${_realname}-${pkgver}" \
@@ -67,7 +72,7 @@ build() {
     -DSCORE_MSYS2_PACKAGE=1 \
     -DOSSIA_USE_SYSTEM_LIBRARIES=1 \
     -DSCORE_DISABLED_PLUGINS="score-plugin-vst3;score-plugin-jit;score-plugin-faust" \
-    -DCMAKE_CXX_FLAGS="-Wa,-mbig-obj -fexperimental-library" \
+    -DCMAKE_CXX_FLAGS="-Wa,-mbig-obj $CXX_ADDITIONAL_FLAGS" \
     -DCMAKE_C_USE_RESPONSE_FILE_FOR_OBJECTS=1 \
     -DCMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS=1 \
     -DCMAKE_NINJA_FORCE_RESPONSE_FILE=1 \

--- a/mingw-w64-ossia-score/PKGBUILD
+++ b/mingw-w64-ossia-score/PKGBUILD
@@ -3,11 +3,11 @@
 _realname=ossia-score
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=3.1.13
+pkgver=3.1.14
 pkgrel=1
 pkgdesc="ossia score, an interactive sequencer for the intermedia arts"
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://ossia.io"
 license=('spdx:GPL-3.0-or-later')
 depends=(
@@ -23,6 +23,12 @@ depends=(
   "${MINGW_PACKAGE_PREFIX}-fftw"
   "${MINGW_PACKAGE_PREFIX}-ffmpeg"
   "${MINGW_PACKAGE_PREFIX}-SDL2"
+  "${MINGW_PACKAGE_PREFIX}-rapidjson"
+  "${MINGW_PACKAGE_PREFIX}-fmt"
+  "${MINGW_PACKAGE_PREFIX}-spdlog"
+  "${MINGW_PACKAGE_PREFIX}-rubberband"
+  "${MINGW_PACKAGE_PREFIX}-re2"
+  "${MINGW_PACKAGE_PREFIX}-snappy"
 )
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cmake"
@@ -32,7 +38,7 @@ makedepends=(
   "git"
 )
 source=("https://github.com/ossia/score/releases/download/v${pkgver}/ossia.score-${pkgver}-src.tar.xz")
-sha512sums=('14b25c34fe4a37c2347cd1aea517cb548eb5091066d01b6e3e955d66dc5ba59929cce2b04e9ccad3c159498d95f30cb68889193a4a86ec8705291d8603dda259')
+sha512sums=('2e8d27bf170c95d7dea835705a4d9d5da3180c095ae1ad189473e041b293fbc445c5201c19a003e0782bc60deb726c37f4f9fd97f319e0a6dd3deaf900381153')
 noextract=(ossia.score-${pkgver}-src.tar.xz)
 
 prepare() {
@@ -58,8 +64,10 @@ build() {
     -DSCORE_STATIC_PLUGINS=1 \
     -DSCORE_FHS_BUILD=1 \
     -DSCORE_DEPLOYMENT_BUILD=1 \
+    -DSCORE_MSYS2_PACKAGE=1 \
+    -DOSSIA_USE_SYSTEM_LIBRARIES=1 \
     -DSCORE_DISABLED_PLUGINS="score-plugin-vst3;score-plugin-jit;score-plugin-faust" \
-    -DCMAKE_CXX_FLAGS="-Wa,-mbig-obj" \
+    -DCMAKE_CXX_FLAGS="-Wa,-mbig-obj -fexperimental-library" \
     -DCMAKE_C_USE_RESPONSE_FILE_FOR_OBJECTS=1 \
     -DCMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS=1 \
     -DCMAKE_NINJA_FORCE_RESPONSE_FILE=1 \

--- a/mingw-w64-ossia-score/PKGBUILD
+++ b/mingw-w64-ossia-score/PKGBUILD
@@ -23,6 +23,7 @@ depends=(
   "${MINGW_PACKAGE_PREFIX}-fftw"
   "${MINGW_PACKAGE_PREFIX}-ffmpeg"
   "${MINGW_PACKAGE_PREFIX}-SDL2"
+  "${MINGW_PACKAGE_PREFIX}-rapidfuzz-cpp"
   "${MINGW_PACKAGE_PREFIX}-rapidjson"
   "${MINGW_PACKAGE_PREFIX}-fmt"
   "${MINGW_PACKAGE_PREFIX}-spdlog"

--- a/mingw-w64-ossia-score/PKGBUILD
+++ b/mingw-w64-ossia-score/PKGBUILD
@@ -56,9 +56,9 @@ build() {
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
-  CXX_ADDITIONAL_FLAGS=
-  if c++ --version | grep clang; then
-    CXX_ADDITIONAL_FLAGS=-fexperimental-library
+  CXXFLAGS+=" -Wa,-mbig-obj"
+  if $CXX --version | grep clang; then
+    CXXFLAGS+=" -fexperimental-library"
   fi
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
@@ -73,7 +73,6 @@ build() {
     -DSCORE_MSYS2_PACKAGE=1 \
     -DOSSIA_USE_SYSTEM_LIBRARIES=1 \
     -DSCORE_DISABLED_PLUGINS="score-plugin-vst3;score-plugin-jit;score-plugin-faust" \
-    -DCMAKE_CXX_FLAGS="-Wa,-mbig-obj $CXX_ADDITIONAL_FLAGS" \
     -DCMAKE_C_USE_RESPONSE_FILE_FOR_OBJECTS=1 \
     -DCMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS=1 \
     -DCMAKE_NINJA_FORCE_RESPONSE_FILE=1 \


### PR DESCRIPTION
Also this uses more dependencies from the host environment as requested.