### PR TITLE
[new package] Initial libminpack insertion.

### DIFF
--- a/mingw-w64-libminpack/0001-pkgconfig-input-to-cmake.patch
+++ b/mingw-w64-libminpack/0001-pkgconfig-input-to-cmake.patch
@@ -1,0 +1,18 @@
+diff -Naur a/cmake-minpack.pc.in b/cmake-minpack.pc.in
+--- a/cmake-minpack.pc.in	1969-12-31 21:00:00.000000000 -0300
++++ b/cmake-minpack.pc.in	2024-04-16 10:28:03.184627358 -0300
+@@ -0,0 +1,13 @@
++prefix=@CMAKE_INSTALL_PREFIX@
++exec_prefix=@CMAKE_INSTALL_PREFIX@
++lib_name=@minpack_library_name@
++libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
++includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
++version=@PROJECT_VERSION@
++
++Name: @minpack_library_name@
++Description: A software for solving nonlinear equations and nonlinear least squares problems.
++Version: ${version}
++Requires:
++Libs: -L${libdir} -l${lib_name}
++Cflags: -I${includedir}
+\ No newline at end of file

--- a/mingw-w64-libminpack/0002-minpack-c-cpp-header.patch
+++ b/mingw-w64-libminpack/0002-minpack-c-cpp-header.patch
@@ -1,0 +1,117 @@
+diff -Naur a/minpack.h b/minpack.h
+--- a/minpack.h	1969-12-31 21:00:00.000000000 -0300
++++ b/minpack.h	2024-04-16 10:24:21.429666175 -0300
+@@ -0,0 +1,113 @@
++/* Declarations for minpack */
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++/* find a zero of a system of N nonlinear functions in N variables by
++   a modification of the Powell hybrid method (Jacobian calculated by
++   a forward-difference approximation) */
++void hybrd1_ ( void (*fcn)(int *n, double *x, double *fvec, int *iflag ), 
++	       int *n, double *x, double *fvec, double *tol, int *info,
++	       double *wa, int *lwa );
++
++/* find a zero of a system of N nonlinear functions in N variables by
++   a modification of the Powell hybrid method (Jacobian calculated by
++   a forward-difference approximation, more general). */
++void hybrd_ ( void (*fcn)(int *n, double *x, double *fvec, int *iflag ), 
++	      int *n, double *x, double *fvec, double *xtol, int *maxfev,
++	      int *ml, int *mu, double *epsfcn, double *diag, int *mode,
++	      double *factor, int *nprint, int *info, int *nfev,
++	      double *fjac, int *ldfjac, double *r, int *lr, double *qtf,
++	      double *wa1, double *wa2, double *wa3, double *wa4);
++  
++/* find a zero of a system of N nonlinear functions in N variables by
++   a modification of the Powell hybrid method (user-supplied Jacobian) */
++void hybrj1_ ( void (*fcn)(int *n, double *x, double *fvec, double *fjec,
++			   int *ldfjac, int *iflag ), int *n, double *x,
++	       double *fvec, double *fjec, int *ldfjac, double *tol,
++	       int *info, double *wa, int *lwa );
++          
++/* find a zero of a system of N nonlinear functions in N variables by
++   a modification of the Powell hybrid method (user-supplied Jacobian,
++   more general) */
++void hybrj_ ( void (*fcn)(int *n, double *x, double *fvec, double *fjec,
++			  int *ldfjac, int *iflag ), int *n, double *x,
++	      double *fvec, double *fjec, int *ldfjac, double *xtol,
++	      int *maxfev, double *diag, int *mode, double *factor,
++	      int *nprint, int *info, int *nfev, int *njev, double *r,
++	      int *lr, double *qtf, double *wa1, double *wa2,
++	      double *wa3, double *wa4 );
++
++/* minimize the sum of the squares of nonlinear functions in N
++   variables by a modification of the Levenberg-Marquardt algorithm
++   (Jacobian calculated by a forward-difference approximation) */
++void lmdif1_ ( void (*fcn)(int *m, int *n, double *x, double *fvec,
++			   int *iflag ),
++	       int *m, int *n, double *x, double *fvec, double *tol,
++	       int *info, int *iwa, double *wa, int *lwa );
++
++/* minimize the sum of the squares of nonlinear functions in N
++   variables by a modification of the Levenberg-Marquardt algorithm
++   (Jacobian calculated by a forward-difference approximation, more
++   general) */
++void lmdif_ ( void (*fcn)(int *m, int *n, double *x, double *fvec,
++			  int *iflag ),
++	      int *m, int *n, double *x, double *fvec, double *ftol,
++	      double *xtol, double *gtol, int *maxfev, double *epsfcn,
++	      double *diag, int *mode, double *factor, int *nprint,
++	      int *info, int *nfev, double *fjac, int *ldfjac, int *ipvt,
++	      double *qtf, double *wa1, double *wa2, double *wa3,
++	      double *wa4 );
++
++/* minimize the sum of the squares of nonlinear functions in N
++   variables by a modification of the Levenberg-Marquardt algorithm
++   (user-supplied Jacobian) */
++void lmder1_ ( void (*fcn)(int *m, int *n, double *x, double *fvec,
++			   double *fjec, int *ldfjac, int *iflag ),
++	       int *m, int *n, double *x, double *fvec, double *fjec,
++	       int *ldfjac, double *tol, int *info, int *ipvt,
++	       double *wa, int *lwa );
++
++/* minimize the sum of the squares of nonlinear functions in N
++   variables by a modification of the Levenberg-Marquardt algorithm
++   (user-supplied Jacobian, more general) */
++void lmder_ ( void (*fcn)(int *m, int *n, double *x, double *fvec,
++			  double *fjec, int *ldfjac, int *iflag ),
++	      int *m, int *n, double *x, double *fvec, double *fjec,
++	      int *ldfjac, double *ftol, double *xtol, double *gtol,
++	      int *maxfev, double *diag, int *mode, double *factor,
++	      int *nprint, int *info, int *nfev, int *njev, int *ipvt,
++	      double *qtf, double *wa1, double *wa2, double *wa3,
++	      double *wa4 );
++
++/* minimize the sum of the squares of nonlinear functions in N
++   variables by a modification of the Levenberg-Marquardt algorithm
++   (user-supplied Jacobian, minimal storage) */
++void lmstr1_ ( void (*fcn)(int *m, int *n, double *x, double *fvec,
++			   double *fjrow, int *iflag ), int *m, int *n,
++	       double *x, double *fvec, double *fjac, int *ldfjac,
++	       double *tol, int *info, int *ipvt, double *wa, int *lwa );
++
++/* minimize the sum of the squares of nonlinear functions in N
++   variables by a modification of the Levenberg-Marquardt algorithm
++   (user-supplied Jacobian, minimal storage, more general) */
++void lmstr_ ( void (*fcn)(int *m, int *n, double *x, double *fvec,
++			  double *fjrow, int *iflag ), int *m,
++	      int *n, double *x, double *fvec, double *fjac,
++	      int *ldfjac, double *ftol, double *xtol, double *gtol,
++	      int *maxfev, double *diag, int *mode, double *factor,
++	      int *nprint, int *info, int *nfev, int *njev, int *ipvt,
++	      double *qtf, double *wa1, double *wa2, double *wa3,
++	      double *wa4 );
++ 
++void chkder_ ( int *m, int *n, double *x, double *fvec, double *fjec,
++	       int *ldfjac, double *xp, double *fvecp, int *mode,
++	       double *err  );
++
++double dpmpar_ ( int *i );
++
++double enorm_ ( int *n, double *x );
++
++#ifdef __cplusplus
++}
++#endif

--- a/mingw-w64-libminpack/0003-cmake-build-script.patch
+++ b/mingw-w64-libminpack/0003-cmake-build-script.patch
@@ -1,0 +1,121 @@
+diff -Naur a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	1969-12-31 21:00:00.000000000 -0300
++++ b/CMakeLists.txt	2024-04-16 12:10:12.082969997 -0300
+@@ -0,0 +1,116 @@
++cmake_minimum_required(VERSION 3.13)
++
++# The default build type must be set
++# right after cmake_minimum_required
++# to take effect
++if (NOT DEFINED CMAKE_BUILD_TYPE)
++    set(CMAKE_BUILD_TYPE "Release")
++endif()
++
++# set the package version
++if (NOT DEFINED MINPACK_VERSION)
++    SET(MINPACK_VERSION "1.0.0")
++endif()
++
++project(minpack
++    VERSION ${MINPACK_VERSION}
++    LANGUAGES Fortran
++)
++
++# Build shared libraries by default
++if (NOT DEFINED BUILD_SHARED_LIBS)
++    set(BUILD_SHARED_LIBS ON)
++endif()
++
++# Also build static libraries by default
++if (NOT DEFINED BUILD_STATIC_LIBS)
++    set(BUILD_STATIC_LIBS ON)
++endif()
++
++# assert that at least one kind
++# of library was requested to build
++if (NOT (BUILD_SHARED_LIBS OR BUILD_STATIC_LIBS))
++    message(FATAL_ERROR "You must configure cmake to build either the shared or static library by setting -DBUILD_SHARED_LIBS=ON or -DBUILD_STATIC_LIBS=ON, respectively.")
++endif()
++
++# Fortran source files for minpack
++set(minpack_source_files
++    "chkder.f"
++    "dogleg.f"
++    "dpmpar.f"
++    "enorm.f"
++    "fdjac1.f"
++    "fdjac2.f"
++    "hybrd1.f"
++    "hybrd.f"
++    "hybrj1.f"
++    "hybrj.f"
++    "lmder1.f"
++    "lmder.f"
++    "lmdif1.f"
++    "lmdif.f"
++    "lmpar.f"
++    "lmstr1.f"
++    "lmstr.f"
++    "qform.f"
++    "qrfac.f"
++    "qrsolv.f"
++    "r1mpyq.f"
++    "r1updt.f"
++    "rwupdt.f"
++)
++
++# library name
++set(minpack_library_name "minpack")
++
++# minpack header file
++set(minpack_header "minpack.h")
++
++# minpack pkg-config input file to be transformed
++set(minpack_pkg_config_in "cmake-${minpack_library_name}.pc.in")
++
++# minpack pkg-config destination file
++set(minpack_pkg_config "${CMAKE_CURRENT_BINARY_DIR}/${minpack_library_name}.pc")
++
++# use GNU directories convention
++include(GNUInstallDirs)
++
++# Build the shared library
++if (BUILD_SHARED_LIBS)
++    add_library(minpack_shared SHARED "")
++    target_sources(minpack_shared PRIVATE ${minpack_source_files})
++    target_compile_definitions(minpack_shared PRIVATE DLL_EXPORT)
++
++    set_target_properties(minpack_shared
++        PROPERTIES
++        POSITION_INDEPENDENT_CODE ON
++        OUTPUT_NAME ${minpack_library_name}
++    )
++
++    install(TARGETS minpack_shared
++        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++    )
++endif()
++
++# Build the static library
++if (BUILD_STATIC_LIBS)
++    add_library(minpack_static STATIC "")
++    target_sources(minpack_static PRIVATE ${minpack_source_files})
++
++    set_target_properties(minpack_static
++        PROPERTIES
++        OUTPUT_NAME ${minpack_library_name}
++    )
++
++    install(TARGETS minpack_static
++        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++    )
++endif()
++
++configure_file(${minpack_pkg_config_in} ${minpack_pkg_config} @ONLY)
++install(FILES ${minpack_pkg_config} DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
++install(FILES ${minpack_header} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+\ No newline at end of file

--- a/mingw-w64-libminpack/PKGBUILD
+++ b/mingw-w64-libminpack/PKGBUILD
@@ -3,80 +3,125 @@
 _realname=libminpack
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=19961126+dfsg1.5
-_pkgver=19961126+dfsg1-5
+pkgver="1.0.0"
 pkgrel=1
 pkgdesc="A software for solving nonlinear equations and nonlinear least squares problems (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
-url='https://salsa.debian.org/science-team/minpack'
-license=('LicenseRef-BSD-4-Clause-Modified')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://www.netlib.org/minpack'
+license=('spdx:BSD-4-Clause-Modified')
 
-_fortran_compiler_pkg=""
-_fortran_compiler=""
-depends=()
-_LDFLAGS=""
+_fortran_compiler_pkg=$([[ $MSYSTEM = CLANG* ]] && echo "flang" || echo "gcc-fortran")
+_fortran_compiler=$([[ $MSYSTEM = CLANG* ]] && echo "flang" || echo "gfortran")
 
-if [[ ${MSYSTEM} = CLANG* ]] || [[ ${MSYSTEM} = MSYS ]];
-then
-  _fortran_compiler_pkg="flang"
-  _fortran_compiler="flang"
+depends=($([[ $_fortran_compiler = "gfortran" ]] &&
+        echo "${MINGW_PACKAGE_PREFIX}-gcc-libs" \
+        "${MINGW_PACKAGE_PREFIX}-libwinpthread-git" \
+        "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran"))
 
-  # -pipe on LDFLAGS defined at /etc/makepkg_mingw.conf
-  # causes flang compiler to fail on configure.
-  # So, we erase -pipe from LDFLAGS here
-  _LDFLAGS=$(echo "${LDFLAGS}" | sed -En "s/\-pipe//p")
-else
-  _fortran_compiler_pkg="gcc-fortran"
-  _fortran_compiler="gfortran"
-  depends+=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
-            "${MINGW_PACKAGE_PREFIX}-libwinpthread-git"
-            "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran")
-  _LDFLAGS="${LDFLAGS}"
-fi
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-${_fortran_compiler_pkg}")
 
-makedepends=("${MINGW_PACKAGE_PREFIX}-${_fortran_compiler_pkg}")
+source=("${url}/disclaimer"
+        "${url}/chkder.f"
+        "${url}/dogleg.f"
+        "${url}/dpmpar.f"
+        "${url}/enorm.f"
+        "${url}/fdjac1.f"
+        "${url}/fdjac2.f"
+        "${url}/hybrd1.f"
+        "${url}/hybrd.f"
+        "${url}/hybrj1.f"
+        "${url}/hybrj.f"
+        "${url}/lmder1.f"
+        "${url}/lmder.f"
+        "${url}/lmdif1.f"
+        "${url}/lmdif.f"
+        "${url}/lmpar.f"
+        "${url}/lmstr1.f"
+        "${url}/lmstr.f"
+        "${url}/qform.f"
+        "${url}/qrfac.f"
+        "${url}/qrsolv.f"
+        "${url}/r1mpyq.f"
+        "${url}/r1updt.f"
+        "${url}/rwupdt.f"
+        "0001-pkgconfig-input-to-cmake.patch"
+        "0002-minpack-c-cpp-header.patch"
+        "0003-cmake-build-script.patch")
 
-source=("${url}/-/archive/debian/${_pkgver}/minpack-debian-${_pkgver}.tar.gz")
+sha256sums=("f5b330efdad110cdd84d585ec61220b0650461fa599e36b13e1726c9346dcfb9" # disclaimer
+            "6a71d2df5e75a800b42386d1096d4a55c32cdcd1e930a8957bed845dc77e5ef1"
+            "5d29950bfbfa6415b4e07ce536b0388edd3ceb4d6b260b23eb11d9c3b6f135ba"
+            "5c56b40119ddb0d00f60730a2f6ad8ceaac70422172b51af8dbde3944b324e7e"
+            "c8ec66eeb809e5a1a8c896037597c73bd8966511a3b028fcc1f8be0e47310dd7"
+            "b87bc037c7b1f728d1ec6417bc228a7cdb7a37c85627e8730f6c40267ef53009"
+            "30ca8685efeab6f47bb40fb7c6f20f84d8467f39308bf10a54c9dac41c061391"
+            "427ee1ab96f8583ccb661e76173758b8a98ae06af710bdce1acf8022ed27ac7b"
+            "dae9685deaf24a3625ab65fc25c896cf0416aee1e09c93be17204273a381f521"
+            "8cdb1da05e2bc9c2356c966136bef0f452f8d8a74ff0ff8d44988ef9a46da5c6"
+            "f1f5994dba9b9e2a392bbc08ae1b1b74075dd0f8f6339531011fdedeb4654f96"
+            "bd9bec43c803c20ab523410cd55476833bec63c96b10088c0d87c2a7c1df6ec4"
+            "bcb863d4e71751e9c2e8bc163f3606823b206d4ded525645704238694d4b2cca"
+            "bc6fac1d9b45d0331587705b47c0bc403b485883bcd8c9af9b1a2a858f57c1f7"
+            "5e59e7d18e53bb588411f411d108851f8b3e24221c5983afe718dbf897874856"
+            "01495a05ec1c0ba4ec3ace1f8f5e0db0eb5a2b8cc38991213792083005d73b3a"
+            "1371ac7d94b943a647bc81bdf2df5826114c744a016a6ce78fe559c4205f1e61"
+            "d2a59ac39a1d5c1dc6ff69a3dcc317509df89ef7775ce53f30ca44e184e03503"
+            "2663c845eaefcbd398f13525f33e090b8dfe005fa4b4a3157caa8c06599f1bc5"
+            "8183b99d4550d2f20b1ffc7456d0afa756e9d0ac3d8976148628416632b3aa42"
+            "768eb92e2d4d257f81202b8de83d30e390ca92a0763e96b59175aee02bf45e7f"
+            "a8e8e5038e60823c273898b8c723f423bb9abbb5da377a73c33bce8f152b5b12"
+            "33924ea50382e1c74b7f8b0662bea19c7f6772468b5d07e3250384c7c18d1666"
+            "d5a5c0a934368be75905c0620898d6061970f4553f4045f8f19be25e492043c3" # rwupdt.f
+            "c9a6f6161c9aee0997e1e42a09111c106aaa6b05e0cdbe4b55c56aa0ad46bb0e"
+            "b062e25cc9d9d874fe8a5f6f27a912c7b9f927840bffecb6d7290bf47a80221b"
+            "033049e5833d7b133d59c7c52bbe4ed5c7d377264e241148ee944b188ce85ade")
 
-sha256sums=('a0be0155e812753871097b2032e62c9cc96abe5e8c906b932a9f18f862998063')
+prepare() {
+  mkdir -p "${srcdir}" && cd "${srcdir}"
+  patch -Np1 -i "${srcdir}"/0001-pkgconfig-input-to-cmake.patch
+  patch -Np1 -i "${srcdir}"/0002-minpack-c-cpp-header.patch
+  patch -Np1 -i "${srcdir}"/0003-cmake-build-script.patch
+}
 
 build() {
-  cd "${srcdir}/minpack-debian-${_pkgver}"
-  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
-  
-  "${srcdir}/minpack-debian-${_pkgver}"/configure \
-    F77="${_fortran_compiler}" \
-    LDFLAGS="${_LDFLAGS}" \
-    --prefix="${MINGW_PREFIX}" \
-    --build="${MINGW_CHOST}" \
-    --host="${MINGW_CHOST}" \
-    --target="${MINGW_CHOST}" \
-    --enable-static \
-    --enable-shared
-  
-  # Building a shared library while allowing undefined symbols is not allowed.
-  # Thus, we work around the problem following
-  # the advice contained at https://stackoverflow.com/a/62232265
-  sed -i.bak -e "s/\(allow_undefined=\)yes/\1no/" libtool
-  
-  if [ "${_fortran_compiler}" = "flang" ]
+  _LDFLAGS=""
+
+  if [[ $_fortran_compiler = "flang" ]];
   then
-    # The part '-Xlinker --out-implib -Xlinker \$lib' on libtool
-    # does not allow the link phase to run properly
-    # on flang. Then we replace it with '-Wl,--out-implib=\$lib'
-    # to pass arguments properly to the linker.
-    sed -i.bak2 -e "s/\-Xlinker \-\-out\-implib \-Xlinker \\\\\$lib/\-Wl,\-\-out\-implib\=\\\\\$lib/" libtool
+    # -pipe on LDFLAGS defined at /etc/makepkg_mingw.conf
+    # causes flang compiler to fail on configure.
+    # So, we erase -pipe from LDFLAGS here
+    _LDFLAGS=$(echo "${LDFLAGS}" | sed -En "s/\-pipe//p")
+  else
+    _LDFLAGS="${LDFLAGS}"
   fi
 
-  make
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
 
+  FC="${MINGW_PREFIX}/bin/${_fortran_compiler}" \
+  LDFLAGS="${_LDFLAGS}" \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  "${MINGW_PREFIX}"/bin/cmake.exe \
+    -G Ninja \
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+    "${extra_config[@]}" \
+    -DBUILD_{SHARED,STATIC}_LIBS=ON \
+    -S "${srcdir}" \
+    -B "${srcdir}/build-${MSYSTEM}"
+
+  "${MINGW_PREFIX}"/bin/cmake.exe --build "${srcdir}/build-${MSYSTEM}"
 }
 
 package() {
-  cd "${srcdir}/build-${MSYSTEM}"
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install "${srcdir}/build-${MSYSTEM}"
 
-  make install DESTDIR="${pkgdir}"
-
-  install -Dm644 "${srcdir}/minpack-debian-${_pkgver}/debian/copyright" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  install -Dm644 "${srcdir}/disclaimer" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-libminpack/PKGBUILD
+++ b/mingw-w64-libminpack/PKGBUILD
@@ -114,6 +114,7 @@ build() {
     -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
     "${extra_config[@]}" \
     -DBUILD_{SHARED,STATIC}_LIBS=ON \
+    -DMINPACK_VERSION="${pkgver}" \
     -S "${srcdir}" \
     -B "${srcdir}/build-${MSYSTEM}"
 

--- a/mingw-w64-libminpack/PKGBUILD
+++ b/mingw-w64-libminpack/PKGBUILD
@@ -3,26 +3,16 @@
 _realname=libminpack
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver="1.0.0"
+pkgver=1.0.0
 pkgrel=1
 pkgdesc="A software for solving nonlinear equations and nonlinear least squares problems (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://www.netlib.org/minpack'
 license=('spdx:BSD-4-Clause-Modified')
-
-_fortran_compiler_pkg=$([[ $MSYSTEM = CLANG* ]] && echo "flang" || echo "gcc-fortran")
-_fortran_compiler=$([[ $MSYSTEM = CLANG* ]] && echo "flang" || echo "gfortran")
-
-depends=($([[ $_fortran_compiler = "gfortran" ]] &&
-        echo "${MINGW_PACKAGE_PREFIX}-gcc-libs" \
-        "${MINGW_PACKAGE_PREFIX}-libwinpthread-git" \
-        "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran"))
-
-makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-ninja"
-             "${MINGW_PACKAGE_PREFIX}-${_fortran_compiler_pkg}")
-
+makedepends=("${MINGW_PACKAGE_PREFIX}-fc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
 source=("${url}/disclaimer"
         "${url}/chkder.f"
         "${url}/dogleg.f"
@@ -50,8 +40,7 @@ source=("${url}/disclaimer"
         "0001-pkgconfig-input-to-cmake.patch"
         "0002-minpack-c-cpp-header.patch"
         "0003-cmake-build-script.patch")
-
-sha256sums=("f5b330efdad110cdd84d585ec61220b0650461fa599e36b13e1726c9346dcfb9" # disclaimer
+sha256sums=("f5b330efdad110cdd84d585ec61220b0650461fa599e36b13e1726c9346dcfb9"
             "6a71d2df5e75a800b42386d1096d4a55c32cdcd1e930a8957bed845dc77e5ef1"
             "5d29950bfbfa6415b4e07ce536b0388edd3ceb4d6b260b23eb11d9c3b6f135ba"
             "5c56b40119ddb0d00f60730a2f6ad8ceaac70422172b51af8dbde3944b324e7e"
@@ -74,7 +63,7 @@ sha256sums=("f5b330efdad110cdd84d585ec61220b0650461fa599e36b13e1726c9346dcfb9" #
             "768eb92e2d4d257f81202b8de83d30e390ca92a0763e96b59175aee02bf45e7f"
             "a8e8e5038e60823c273898b8c723f423bb9abbb5da377a73c33bce8f152b5b12"
             "33924ea50382e1c74b7f8b0662bea19c7f6772468b5d07e3250384c7c18d1666"
-            "d5a5c0a934368be75905c0620898d6061970f4553f4045f8f19be25e492043c3" # rwupdt.f
+            "d5a5c0a934368be75905c0620898d6061970f4553f4045f8f19be25e492043c3"
             "c9a6f6161c9aee0997e1e42a09111c106aaa6b05e0cdbe4b55c56aa0ad46bb0e"
             "b062e25cc9d9d874fe8a5f6f27a912c7b9f927840bffecb6d7290bf47a80221b"
             "033049e5833d7b133d59c7c52bbe4ed5c7d377264e241148ee944b188ce85ade")
@@ -87,18 +76,6 @@ prepare() {
 }
 
 build() {
-  _LDFLAGS=""
-
-  if [[ $_fortran_compiler = "flang" ]];
-  then
-    # -pipe on LDFLAGS defined at /etc/makepkg_mingw.conf
-    # causes flang compiler to fail on configure.
-    # So, we erase -pipe from LDFLAGS here
-    _LDFLAGS=$(echo "${LDFLAGS}" | sed -En "s/\-pipe//p")
-  else
-    _LDFLAGS="${LDFLAGS}"
-  fi
-
   declare -a extra_config
   if check_option "debug" "n"; then
     extra_config+=("-DCMAKE_BUILD_TYPE=Release")
@@ -106,8 +83,6 @@ build() {
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
-  FC="${MINGW_PREFIX}/bin/${_fortran_compiler}" \
-  LDFLAGS="${_LDFLAGS}" \
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   "${MINGW_PREFIX}"/bin/cmake.exe \
     -G Ninja \
@@ -115,14 +90,14 @@ build() {
     "${extra_config[@]}" \
     -DBUILD_{SHARED,STATIC}_LIBS=ON \
     -DMINPACK_VERSION="${pkgver}" \
-    -S "${srcdir}" \
-    -B "${srcdir}/build-${MSYSTEM}"
+    -S . \
+    -B build-${MSYSTEM}
 
-  "${MINGW_PREFIX}"/bin/cmake.exe --build "${srcdir}/build-${MSYSTEM}"
+  "${MINGW_PREFIX}"/bin/cmake.exe --build build-${MSYSTEM}
 }
 
 package() {
-  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install "${srcdir}/build-${MSYSTEM}"
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install build-${MSYSTEM}
 
   install -Dm644 "${srcdir}/disclaimer" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-libminpack/PKGBUILD
+++ b/mingw-w64-libminpack/PKGBUILD
@@ -1,0 +1,82 @@
+# Maintainer: luau-project <luau.project@gmail.com>
+
+_realname=libminpack
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=19961126+dfsg1.5
+_pkgver=19961126+dfsg1-5
+pkgrel=1
+pkgdesc="A software for solving nonlinear equations and nonlinear least squares problems (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://salsa.debian.org/science-team/minpack'
+license=('LicenseRef-BSD-4-Clause-Modified')
+
+_fortran_compiler_pkg=""
+_fortran_compiler=""
+depends=()
+_LDFLAGS=""
+
+if [[ ${MSYSTEM} = CLANG* ]] || [[ ${MSYSTEM} = MSYS ]];
+then
+  _fortran_compiler_pkg="flang"
+  _fortran_compiler="flang"
+
+  # -pipe on LDFLAGS defined at /etc/makepkg_mingw.conf
+  # causes flang compiler to fail on configure.
+  # So, we erase -pipe from LDFLAGS here
+  _LDFLAGS=$(echo "${LDFLAGS}" | sed -En "s/\-pipe//p")
+else
+  _fortran_compiler_pkg="gcc-fortran"
+  _fortran_compiler="gfortran"
+  depends+=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+            "${MINGW_PACKAGE_PREFIX}-libwinpthread-git"
+            "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran")
+  _LDFLAGS="${LDFLAGS}"
+fi
+
+makedepends=("${MINGW_PACKAGE_PREFIX}-${_fortran_compiler_pkg}")
+
+source=("${url}/-/archive/debian/${_pkgver}/minpack-debian-${_pkgver}.tar.gz")
+
+sha256sums=('a0be0155e812753871097b2032e62c9cc96abe5e8c906b932a9f18f862998063')
+
+build() {
+  cd "${srcdir}/minpack-debian-${_pkgver}"
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
+  
+  "${srcdir}/minpack-debian-${_pkgver}"/configure \
+    F77="${_fortran_compiler}" \
+    LDFLAGS="${_LDFLAGS}" \
+    --prefix="${MINGW_PREFIX}" \
+    --build="${MINGW_CHOST}" \
+    --host="${MINGW_CHOST}" \
+    --target="${MINGW_CHOST}" \
+    --enable-static \
+    --enable-shared
+  
+  # Building a shared library while allowing undefined symbols is not allowed.
+  # Thus, we work around the problem following
+  # the advice contained at https://stackoverflow.com/a/62232265
+  sed -i.bak -e "s/\(allow_undefined=\)yes/\1no/" libtool
+  
+  if [ "${_fortran_compiler}" = "flang" ]
+  then
+    # The part '-Xlinker --out-implib -Xlinker \$lib' on libtool
+    # does not allow the link phase to run properly
+    # on flang. Then we replace it with '-Wl,--out-implib=\$lib'
+    # to pass arguments properly to the linker.
+    sed -i.bak2 -e "s/\-Xlinker \-\-out\-implib \-Xlinker \\\\\$lib/\-Wl,\-\-out\-implib\=\\\\\$lib/" libtool
+  fi
+
+  make
+
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  make install DESTDIR="${pkgdir}"
+
+  install -Dm644 "${srcdir}/minpack-debian-${_pkgver}/debian/copyright" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
## Description

MINPACK [[1]](https://www.netlib.org/minpack/) [[2]](https://salsa.debian.org/science-team/minpack/-/tree/master?ref_type=heads) [[3]](https://aur.archlinux.org/packages/libminpack) is a battle-tested software written in Fortran 77 for solving a system of nonlinear equations and nonlinear least squares problems. It is widely used in science, and currently employed on SciPy optimization [[4]](https://github.com/scipy/scipy/tree/main/scipy/optimize/minpack).

## Build

For mingw32, mingw64 and ucrt64, the build script uses gfortran to perform the build. On clang64 and clangarm64, it uses LLVM flang to build.

## Tests

I have tested minpack binaries on all mingw archs on my Windows 11 virtual machine even out of msys2 tree, exception goes to clangarm64. Since the toolset is the same used by clang64, I am confident it is going to work on clangarm64 too.