### PR TITLE
[libminpack] Fix depends on PKGBUILD

### DIFF
--- a/mingw-w64-libminpack/PKGBUILD
+++ b/mingw-w64-libminpack/PKGBUILD
@@ -10,6 +10,7 @@ arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://www.netlib.org/minpack'
 license=('spdx:BSD-4-Clause-Modified')
+depends=($([[ ${MSYSTEM} != CLANG* ]] && echo "${MINGW_PACKAGE_PREFIX}-fc-libs"))
 makedepends=("${MINGW_PACKAGE_PREFIX}-fc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")


### PR DESCRIPTION
## Description

Recently, I authored the PKGBUILD script for ```mingw-w64-libminpack```, and it was added to the repository ([#20643](https://github.com/msys2/MINGW-packages/pull/20643)) with valuable contributions from @MehdiChinoune. I am still learning the way how MSYS2 works, but it seems -- in my possibly mistaken view -- that ```depends``` field on PKGBUILD has the purpose to not break dependencies in the package tree.

On environments (```mingw64``` and ```ucrt64```) such that libminpack is built by gfortran, the programs dynamically linked to libminpack depend on a few runtime DLLs:
* **libgcc_s_seh-1.dll**
* **libgfortran-5.dll**
* **libminpack.dll** (library built from [MINGW-packages repository](https://github.com/msys2/MINGW-packages))
* **libquadmath-0.dll**
* **libwinpthread-1.dll**

> [!TIP]
> 
> In my brief investigation, on ```mingw64``` and ```ucrt64``` environments, I found that the dependency tree of ```${MINGW_PACKAGE_PREFIX}-fc-libs``` contains all the required runtime DLLs listed above.

> [!NOTE]
> 
> On ```clang64``` and ```clangarm64``` environments, there is no need to change anything because the app runs fine without any DLLs.

## TLDR;

In my view, for the environments ```mingw64``` and ```ucrt64```, a solution to handle dependencies properly would be to include the following command in the beginning of the PKGBUILD script.

```bash
depends=($([[ ${MSYSTEM} != CLANG* ]] && echo "${MINGW_PACKAGE_PREFIX}-fc-libs"))
```

In the following, I am going to show that an app dynamically linked to libminpack built on UCRT64 environment
asks for missing DLLs at runtime. First, I do an in-tree run of the app showing that everything works fine.
Later, I try to startup the same app out-of-MSYS2-tree and the system requires those DLLs to run the app. Thus,
this demonstrates the lack of proper dependencies, because at the moment PKGBUILD does not list any dependency for ```mingw64``` and ```ucrt64``` environments.

## Summary of the detailed explanation
* In-tree UCRT64 test
* Out-of-tree UCRT64 test

## In-tree UCRT64 test

1. Open a shell for ```ucrt64``` environemnt, then execute each command below

    ```bash
    # go to temp
    cd /tmp

    # create a clean folder to run tests
    rm -rf libminpack-chkder-test && \
    mkdir -p libminpack-chkder-test && \
    cd libminpack-chkder-test

    # clone MINGW-packages repo to build libminpack
    git clone https://github.com/msys2/MINGW-packages.git

    # change to libminpack dir
    cd MINGW-packages/mingw-w64-libminpack

    # build package (internet connection required)
    makepkg-mingw --cleanbuild --syncdeps --force --noconfirm

    # delete possible file there
    rm -f chkder-test.f

    # download test file from official minpack
    wget https://www.netlib.org/minpack/ex/file20 -O chkder-test.f

    # download data for that test
    wget https://www.netlib.org/minpack/ex/file23 -O chkder-test.dat

    # build the test program
    gfortran.exe -o chkder-test chkder-test.f \
    -L"pkg/mingw-w64-ucrt-x86_64-libminpack/ucrt64/lib" \
    -lminpack

    # pass the location of libminpack.dll in front of PATH
    # to run the compiled test program
    PATH=pkg/mingw-w64-ucrt-x86_64-libminpack/ucrt64/bin:$PATH \
    ./chkder-test.exe < chkder-test.dat
    ```
2. The expected result is that the test program ran normally;
3. Yet in the shell above, copy the generated test binary and data to a location out-of-MSYS2-tree (I am supposing that ```%USERPROFILE%\Downloads``` is out of tree).

    ```bash
    # create a clean folder to run the test out-of-tree
    rm -rf "$(cygpath.exe $USERPROFILE)"/Downloads/libminpack-chkder-test && \
    mkdir -p "$(cygpath.exe $USERPROFILE)"/Downloads/libminpack-chkder-test

    # copy the test program
    cp chkder-test.exe "$(cygpath.exe $USERPROFILE)"/Downloads/libminpack-chkder-test

    # copy the test data
    cp chkder-test.dat "$(cygpath.exe $USERPROFILE)"/Downloads/libminpack-chkder-test

    # sanity-check that the test program and test data were copied
    ls "$(cygpath.exe $USERPROFILE)"/Downloads/libminpack-chkder-test
    ```

4. Leave that shell opened to ease out-of-tree tests below.

## Out-of-tree UCRT64 test

> [!IMPORTANT]
> 
> Check that ```C:\msys64\ucrt64\bin``` is **NOT** on your PATH system environment variable.

1. Open a vanilla cmd prompt and execute the test

    ```cmd
    REM change to directory created previously
    cd %USERPROFILE%\Downloads\libminpack-chkder-test

    REM execute the program without any DLLs in the folder
    chkder-test.exe < chkder-test.dat
    ```

2. Expected result (system asking for libgfortran-5.dll) 
![Screenshot from 2024-04-17 14-16-13](https://github.com/msys2/MINGW-packages/assets/18295115/9ed33204-5f8a-4ae3-9b84-a7d97eed5851)

4. In the ```ucrt64``` shell opened, copy libgfortran-5.dll to the out-of-tree directory
    
    ```bash
    # copy libgfortran-5.dll
    cp ${MINGW_PREFIX}/bin/libgfortran-5.dll "$(cygpath.exe $USERPROFILE)"/Downloads/libminpack-chkder-test

    # sanity-check that it is there
    ls "$(cygpath.exe $USERPROFILE)"/Downloads/libminpack-chkder-test
    ```
5. At cmd, rerun the test

    ```cmd
    chkder-test.exe < chkder-test.dat
    ```
6. Expected result (system asking for libgcc_s_seh-1.dll) 
![Screenshot from 2024-04-17 14-20-39](https://github.com/msys2/MINGW-packages/assets/18295115/101179a8-ef10-4978-a214-497c6b9743e4)

7. On ```ucrt64``` shell, copy libgcc_s_seh-1.dll to out-of-tree dir
    
    ```bash
    # copy libgcc_s_seh-1.dll
    cp ${MINGW_PREFIX}/bin/libgcc_s_seh-1.dll "$(cygpath.exe $USERPROFILE)"/Downloads/libminpack-chkder-test

    # sanity-check that it is there
    ls "$(cygpath.exe $USERPROFILE)"/Downloads/libminpack-chkder-test
    ```
8. At cmd, rerun the test

    ```cmd
    chkder-test.exe < chkder-test.dat
    ```
9. Expected result (system asking for libminpack.dll) 
![Screenshot from 2024-04-17 14-19-55](https://github.com/msys2/MINGW-packages/assets/18295115/356700b4-665c-434b-b45f-6960d44af2cf)

10. On ```ucrt64``` shell, copy libminpack.dll to out-of-tree dir
    
    ```bash
    # copy libminpack.dll
    cp pkg/mingw-w64-ucrt-x86_64-libminpack/ucrt64/bin/libminpack.dll "$(cygpath.exe $USERPROFILE)"/Downloads/libminpack-chkder-test

    # sanity-check that it is there
    ls "$(cygpath.exe $USERPROFILE)"/Downloads/libminpack-chkder-test
    ```
11. At cmd, rerun the test

    ```cmd
    chkder-test.exe < chkder-test.dat
    ```
12. Expected result (system asking for libwinpthread-1.dll) 
![Screenshot from 2024-04-17 17-17-41](https://github.com/msys2/MINGW-packages/assets/18295115/df60af3e-2c1c-4fca-a306-434007f38c64)

13. On ```ucrt64``` shell, copy libwinpthread-1.dll to out-of-tree dir
    
    ```bash
    # copy libwinpthread-1.dll
    cp ${MINGW_PREFIX}/bin/libwinpthread-1.dll "$(cygpath.exe $USERPROFILE)"/Downloads/libminpack-chkder-test

    # sanity-check that it is there
    ls "$(cygpath.exe $USERPROFILE)"/Downloads/libminpack-chkder-test
    ```
14. At cmd, rerun the test

    ```cmd
    chkder-test.exe < chkder-test.dat
    ```
15. Expected result (system asking for libquadmath-0.dll) 
![Screenshot from 2024-04-17 14-25-20](https://github.com/msys2/MINGW-packages/assets/18295115/17c110e5-c325-4f0f-aaa8-202759f349fb)

16. On ```ucrt64``` shell, copy libquadmath-0.dll to out-of-tree dir
    
    ```bash
    # copy libquadmath-0.dll
    cp ${MINGW_PREFIX}/bin/libquadmath-0.dll "$(cygpath.exe $USERPROFILE)"/Downloads/libminpack-chkder-test

    # sanity-check that it is there
    ls "$(cygpath.exe $USERPROFILE)"/Downloads/libminpack-chkder-test
    ```
17. At cmd, rerun the test

    ```cmd
    chkder-test.exe < chkder-test.dat
    ```
18. Finally, since all the required DLLs are on the app folder, the app runs fine.
