### PR TITLE
mingw-w64-efxc2 - update to latest version.

### DIFF
--- a/mingw-w64-efxc2/PKGBUILD
+++ b/mingw-w64-efxc2/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=efxc2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.0.7.124
+pkgver=0.0.8.155
 pkgrel=1
 pkgdesc="Enhanced version of fxc2 (mingw-w64)"
 arch=('any')
@@ -15,7 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-cc")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/JPeterMugaas/efxc2/archive/refs/tags/${pkgver}.tar.gz")
-sha256sums=('ac5ff386ea5c7a7b2303c96c59f608eba3e8a0af4f9bd7fcae8c8d0c7e9d7970')
+sha256sums=('59931bbe427094d0ec528b10b3dcbb67efe3c055ff0d3c9587bf74d919875a9f')
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"


### PR DESCRIPTION
This features conversion to C++ Standard 20.