### PR TITLE
texinfo: Add package for info files

### DIFF
--- a/mingw-w64-texinfo/PKGBUILD
+++ b/mingw-w64-texinfo/PKGBUILD
@@ -1,0 +1,62 @@
+# Maintainer: Biswapriyo Nath <nathbappai@gmail.com>
+
+_realname=texinfo
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=7.1
+pkgrel=1
+pkgdesc="GNU documentation system for on-line information and printed output (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url="https://www.gnu.org/software/texinfo/"
+msys2_repository_url="https://git.savannah.gnu.org/cgit/texinfo.git"
+msys2_references=(
+  "anitya: 4958"
+  "cpe: cpe:/a:gnu:texinfo"
+)
+license=('spdx:GPL-3.0-or-later')
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-libiconv"
+  "${MINGW_PACKAGE_PREFIX}-gettext-runtime"
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-autotools"
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-gettext-tools"
+)
+source=("https://ftp.gnu.org/pub/gnu/${_realname}/${_realname}-${pkgver}.tar.xz"{,.sig}
+        "texinfo-install.hook.in"
+        "texinfo-remove.hook.in")
+sha256sums=('deeec9f19f159e046fdf8ad22231981806dac332cc372f1c763504ad82b30953'
+            'SKIP'
+            'd367fe9dfa09385408cd2e2240f95738258d727449cb3b29e685925210c2a1d9'
+            'ef6e404ee6a45f18957e413d2d83a7699a486bebfde28eb8d515a5f14736d948')
+validpgpkeys=('EAF669B31E31E1DECBD11513DDBC579DAB37FBA9') # Gavin Smith (Texinfo maintainer) <GavinSmith0123@gmail.com>
+
+build() {
+  mkdir -p "build-${MSYSTEM}" && cd "build-${MSYSTEM}"
+
+  ../"${_realname}-${pkgver}"/configure \
+    --prefix="${MINGW_PREFIX}" \
+    --build="${MINGW_CHOST}" \
+    --host="${MINGW_CHOST}" \
+    --target="${MINGW_CHOST}"
+
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  make install DESTDIR="${pkgdir}"
+
+  for hook in texinfo-install texinfo-remove; do
+    local hook_path="${srcdir}/${MINGW_PACKAGE_PREFIX}-${hook}.hook";
+    cp "${srcdir}/${hook}.hook.in" "${hook_path}"
+    sed -s "s|@MINGW_HOOK_TARGET_PREFIX@|${MINGW_PREFIX:1}|g" -i "${hook_path}"
+    sed -s "s|@MINGW_PREFIX@|${MINGW_PREFIX}|g" -i "${hook_path}"
+    install -Dt "$pkgdir/usr/share/libalpm/hooks" -m644 "${hook_path}"
+  done
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}

--- a/mingw-w64-texinfo/texinfo-install.hook.in
+++ b/mingw-w64-texinfo/texinfo-install.hook.in
@@ -1,0 +1,11 @@
+[Trigger]
+Type = Path
+Operation = Install
+Operation = Upgrade
+Target = @MINGW_HOOK_TARGET_PREFIX@/share/info/*
+
+[Action]
+Description = Updating the info directory file...
+When = PostTransaction
+Exec = /usr/bin/sh -c 'while read -r f; do @MINGW_PREFIX@/bin/install-info.exe "$f" @MINGW_PREFIX@/share/info/dir 2> /dev/null; done'
+NeedsTargets

--- a/mingw-w64-texinfo/texinfo-remove.hook.in
+++ b/mingw-w64-texinfo/texinfo-remove.hook.in
@@ -1,0 +1,10 @@
+[Trigger]
+Type = Path
+Operation = Remove
+Target = @MINGW_HOOK_TARGET_PREFIX@/share/info/*
+
+[Action]
+Description = Removing old entries from the info directory file...
+When = PreTransaction
+Exec = /usr/bin/sh -c 'while read -r f; do @MINGW_PREFIX@/bin/install-info.exe --delete "$f" @MINGW_PREFIX@/share/info/dir 2> /dev/null; done'
+NeedsTargets


### PR DESCRIPTION
Fixes #631

The hook files are copied from msys2/texinfo directory.
The sed command in package function is copied from mingw glib2 directory.