### PR TITLE
meson: add optdepends on sccache and ccache

### DIFF
--- a/mingw-w64-meson/PKGBUILD
+++ b/mingw-w64-meson/PKGBUILD
@@ -4,7 +4,7 @@ _realname=meson
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.4.0
-pkgrel=2
+pkgrel=3
 pkgdesc="High-productivity build system (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -24,6 +24,8 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-setuptools"
   "${MINGW_PACKAGE_PREFIX}-python-wheel"
 )
+optdepends=("${MINGW_PACKAGE_PREFIX}-ccache: for a faster compilation"
+            "${MINGW_PACKAGE_PREFIX}-sccache: for a faster compilation (preferred over ccache)")
 options=('!strip')
 source=("https://github.com/mesonbuild/${_realname}/releases/download/${pkgver}/${_realname}-${pkgver}.tar.gz"
         'color-term.patch'


### PR DESCRIPTION
see https://mesonbuild.com/Feature-autodetection.html#ccache and https://mesonbuild.com/Release-notes-for-0-61-0.html#added-support-for-sccache