### PR TITLE
mingw-w64-efxc2 - update to latest release.

### DIFF
--- a/mingw-w64-efxc2/PKGBUILD
+++ b/mingw-w64-efxc2/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=efxc2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.0.8.155
+pkgver=0.0.9.170
 pkgrel=1
 pkgdesc="Enhanced version of fxc2 (mingw-w64)"
 arch=('any')
@@ -15,7 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-cc")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/JPeterMugaas/efxc2/archive/refs/tags/${pkgver}.tar.gz")
-sha256sums=('59931bbe427094d0ec528b10b3dcbb67efe3c055ff0d3c9587bf74d919875a9f')
+sha256sums=('a9d7893a0213068556a746dde31f945e3f79eddfa331347402b03ab02b48927d')
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"


### PR DESCRIPTION
Include Dir support.