### PR TITLE
vtk: fix exported target for `vtkm::openmp` pointing to nonexistent files

### DIFF
--- a/mingw-w64-vtk/008-fix-vtkm_openmp-exported-target.patch
+++ b/mingw-w64-vtk/008-fix-vtkm_openmp-exported-target.patch
@@ -1,0 +1,46 @@
+--- a/ThirdParty/vtkm/vtkvtkm/vtk-m/CMake/VTKmConfig.cmake.in
++++ b/ThirdParty/vtkm/vtkvtkm/vtk-m/CMake/VTKmConfig.cmake.in
+@@ -105,6 +105,14 @@ if (VTKm_ENABLE_TBB)
+   endif()
+ endif()
+
++if (VTKm_ENABLE_OPENMP)
++  find_dependency(OpenMP)
++  if (NOT OpenMP_FOUND)
++    set(VTKm_FOUND 0)
++    list(APPEND VTKm_NOT_FOUND_REASON "OpenMP not found: ${OpenMP_NOT_FOUND_MESSAGE}")
++  endif()
++endif()
++
+ # Load the library exports, but only if not compiling VTK-m itself
+ set_and_check(VTKm_CONFIG_DIR "@PACKAGE_VTKm_INSTALL_CONFIG_DIR@")
+ set(VTKM_FROM_INSTALL_DIR FALSE)
+--- a/ThirdParty/vtkm/vtkvtkm/vtk-m/CMake/VTKmDeviceAdapters.cmake
++++ b/ThirdParty/vtkm/vtkvtkm/vtk-m/CMake/VTKmDeviceAdapters.cmake
+@@ -58,21 +58,13 @@ if(VTKm_ENABLE_OPENMP AND NOT (TARGET vtkm_openmp OR TARGET vtkm::openmp))
+   find_package(OpenMP 4.0 REQUIRED COMPONENTS CXX QUIET)
+
+   add_library(vtkm_openmp INTERFACE)
+-  set_target_properties(vtkm_openmp PROPERTIES EXPORT_NAME openmp)
+-  if(OpenMP_CXX_FLAGS)
+-    set_property(TARGET vtkm_openmp
+-      APPEND PROPERTY INTERFACE_COMPILE_OPTIONS $<$<COMPILE_LANGUAGE:CXX>:${OpenMP_CXX_FLAGS}>)
+-
+-    if(VTKm_ENABLE_CUDA)
+-      string(REPLACE ";" "," openmp_cuda_flags "-Xcompiler=${OpenMP_CXX_FLAGS}")
+-      set_property(TARGET vtkm_openmp
+-        APPEND PROPERTY INTERFACE_COMPILE_OPTIONS $<$<COMPILE_LANGUAGE:CUDA>:${openmp_cuda_flags}>)
+-    endif()
+-  endif()
+-  if(OpenMP_CXX_LIBRARIES)
+-    set_target_properties(vtkm_openmp PROPERTIES
+-      INTERFACE_LINK_LIBRARIES "${OpenMP_CXX_LIBRARIES}")
++  target_link_libraries(vtkm_openmp INTERFACE OpenMP::OpenMP_CXX)
++  target_compile_options(vtkm_openmp INTERFACE $<$<COMPILE_LANGUAGE:CXX>:${OpenMP_CXX_FLAGS}>)
++  if(VTKm_ENABLE_CUDA)
++    string(REPLACE ";" "," openmp_cuda_flags "-Xcompiler=${OpenMP_CXX_FLAGS}")
++    target_compile_options(vtkm_openmp INTERFACE $<$<COMPILE_LANGUAGE:CUDA>:${openmp_cuda_flags}>)
+   endif()
++  set_target_properties(vtkm_openmp PROPERTIES EXPORT_NAME openmp)
+   install(TARGETS vtkm_openmp EXPORT ${VTKm_EXPORT_NAME})
+ endif()

--- a/mingw-w64-vtk/PKGBUILD
+++ b/mingw-w64-vtk/PKGBUILD
@@ -5,7 +5,7 @@ _realname=vtk
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=9.3.0
-pkgrel=7
+pkgrel=8
 pkgdesc="A software system for 3D computer graphics, image processing and visualization (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -105,12 +105,14 @@ source=(https://www.vtk.org/files/release/${pkgver%.*}/VTK-${pkgver}.tar.gz
         "001-no-exact-version-for-fast_float.patch"
         "002-Fix-build-with-gcc-13.patch"
         "003-always-link-with-pdalcpp.patch::https://gitlab.kitware.com/vtk/vtk/-/commit/ccee5db7.patch"
-        "007-dll-export-some-functions.patch")
+        "007-dll-export-some-functions.patch"
+        "008-Fix-vtkm_openmp-exported-target.patch")
 sha256sums=('fdc7b9295225b34e4fdddc49cd06e66e94260cb00efee456e0f66568c9681be9'
             '411b0521fcd2864acae0af20ba6334f69f7c605c9e31996529f64aa749d61065'
             '20733e97ccf9b0a8e615c75936ce5e4c1db0ac00e9cac30bc359d5912da38990'
             '5b734e933a91e316ec9b95f5f526e35d096cb3db2ba4868f8a7c432ec0c3d530'
-            'a9b9292be90c259f0aa058e3f4a7a08b6218f20e6cb2a71e214acda2d2302a50')
+            'a9b9292be90c259f0aa058e3f4a7a08b6218f20e6cb2a71e214acda2d2302a50'
+            '988ef1d43dadf1da157fc69398f545c6d2e82d2dabd7cb830e9fba9ebaba34ac')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -127,7 +129,8 @@ prepare() {
   apply_patch_with_msg \
     001-no-exact-version-for-fast_float.patch \
     002-Fix-build-with-gcc-13.patch \
-    003-always-link-with-pdalcpp.patch
+    003-always-link-with-pdalcpp.patch \
+    008-Fix-vtkm_openmp-exported-target.patch
 
   # Succeed with Clang but failed with GCC!
   if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then


### PR DESCRIPTION
I've recently submitted a fix to VTK-m to ensure that exported targets for OpenMP do not point to nonexistent files in the MSYS2 vtk package. These files seem to come from the CI environment used to generate the packages and are mentionned in `/mingw64/lib/cmake/vtk/vtkm/VTKmTargets.cmake`:
```cmake
# Create imported target vtkm::openmp
add_library(vtkm::openmp INTERFACE IMPORTED)

set_target_properties(vtkm::openmp PROPERTIES
  INTERFACE_COMPILE_OPTIONS "\$<\$<COMPILE_LANGUAGE:CXX>:-fopenmp>"
  INTERFACE_LINK_LIBRARIES "D:/a/msys64/mingw64/lib/libgomp.dll.a;D:/a/msys64/mingw64/lib/libmingwthrd.a;D:/a/msys64/mingw64/lib/libmingwthrd.a"
)
```
We have had build failures for our project due to these hard-coded paths. I've built a new package with the proposed changes and the appropriate target `OpenMP::OpenMP_CXX` is now used instead of the paths to the libraries.

I'm submitting this PR to solve the issue in MSYS2 until a new version of VTK is published.

For more context:
- Issue: https://gitlab.kitware.com/vtk/vtk-m/-/issues/812
- MR: https://gitlab.kitware.com/vtk/vtk-m/-/merge_requests/3212