### PR TITLE
qt6-base: fix inclusion of OpenGL header after Qt6 header

### DIFF
--- a/mingw-w64-qt6-base/005-qt-6.7.0-opengl-header.patch
+++ b/mingw-w64-qt6-base/005-qt-6.7.0-opengl-header.patch
@@ -1,0 +1,45 @@
+Avoid issue for projects that include <GL/glu.h> after <QOpenGLContext>
+on Windows.
+
+diff -urN qtbase-everywhere-src-6.7.0/src/gui/opengl/qopengl.h.orig qtbase-everywhere-src-6.7.0/src/gui/opengl/qopengl.h
++++ qtbase-everywhere-src-6.7.0/src/gui/opengl/qopengl.h	2024-04-22 19:00:32.146776300 +0200
+@@ -11,15 +11,21 @@
+ // On Windows we need to ensure that APIENTRY and WINGDIAPI are defined before
+ // we can include gl.h. But we do not want to include <windows.h> in this public
+ // Qt header, as it pollutes the global namespace with macros.
++// We also need to make sure that CALLBACK and GLAPI are defined (and all of
++// these keep being defined) in case <GL/glu.h> is included after this header.
+ #if defined(Q_OS_WIN)
+ # ifndef APIENTRY
+ #  define APIENTRY __stdcall
+-#  define Q_UNDEF_APIENTRY
+ # endif // APIENTRY
+ # ifndef WINGDIAPI
+ #  define WINGDIAPI __declspec(dllimport)
+-#  define Q_UNDEF_WINGDIAPI
+ # endif // WINGDIAPI
++# ifndef CALLBACK
++#  define CALLBACK APIENTRY
++# endif // CALLBACK
++# ifndef GLAPI
++#  define GLAPI extern
++# endif // GLAPI
+ # define QT_APIENTRY __stdcall
+ #endif
+ 
+@@ -281,15 +287,6 @@
+ 
+ QT_END_NAMESPACE
+ 
+-#ifdef Q_UNDEF_WINGDIAPI
+-# undef WINGDIAPI
+-# undef Q_UNDEF_WINGDIAPI
+-#endif
+-#ifdef Q_UNDEF_APIENTRY
+-# undef APIENTRY
+-# undef Q_UNDEF_APIENTRY
+-#endif
+-
+ #endif // QT_NO_OPENGL
+ 
+ #endif // QOPENGL_H

--- a/mingw-w64-qt6-base/PKGBUILD
+++ b/mingw-w64-qt6-base/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
 _qtver=6.7.0
 pkgver=${_qtver/-/}
-pkgrel=1
+pkgrel=2
 pkgdesc="A cross-platform application and UI framework (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -49,6 +49,7 @@ source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/subm
         002-fix-qtdocs-helpers-cmake.patch
         003-adjust-qmake-conf-mingw.patch
         004-qt-6.2.0-win32-g-Add-QMAKE_EXTENSION_IMPORTLIB-defaulting-to-.patch
+        005-qt-6.7.0-opengl-header.patch
         006-qt-6.2.0-dont-add-resource-files-to-qmake-libs.patch
         007-Fix-crashes-in-rasterization-code-using-setjmp.patch
         009-qfileinfo-undefine-mingw-stat.patch
@@ -60,6 +61,7 @@ sha256sums=('11b2e29e2e52fb0e3b453ea13bbe51a10fdff36e1c192d8868c5a40233b8b254'
             '3848318bccdfa21a139ccdb70f8226358c4a7ed3943231494aab3df83025d7c7'
             '68156b8b7717a0ce19c4b991942469171bfa048cd5c90765115a546e65669a1d'
             'ed5b61bcb367bbda459bec903d796ea45604278f577a988d602ade07ec6bf363'
+            'a2afc74d181864409dc96eca368b647c0f79e25751db88e3263f2d1101edf8e4'
             '4085a10b290b8e3d930de535cbad2ba3e643432cba433aa2b28fe664f86d38a3'
             '3a256533401a48aff7e3c4b02118d62a0cccc2b3566c6e550e7b467aca3e496f'
             'f4261d43a142a24e5fa3b23e25813754839db84078cc8c6dc611139bf531e64a'
@@ -91,6 +93,7 @@ prepare() {
     002-fix-qtdocs-helpers-cmake.patch \
     003-adjust-qmake-conf-mingw.patch \
     004-qt-6.2.0-win32-g-Add-QMAKE_EXTENSION_IMPORTLIB-defaulting-to-.patch \
+    005-qt-6.7.0-opengl-header.patch \
     006-qt-6.2.0-dont-add-resource-files-to-qmake-libs.patch \
     007-Fix-crashes-in-rasterization-code-using-setjmp.patch \
     009-qfileinfo-undefine-mingw-stat.patch \


### PR DESCRIPTION
The Qt6 header `qopengl.h` includes `<GL/gl.h>` while trying to avoid the inclusion of `windows.h`. It does that by defining two preprocessor macros that would normally be defined by including `windows.h` in `<GL/gl.h>`. If these macros are defined, `<GL/gl.h>` does not include `windows.h`. At the end of `qopengl.h`, these preprocessor macros are undefined.

If a project tries to include `<GL/glu.h>` after (indirectly) including `qopengl.h`, the following happens:
* `<GL/glu.h>` includes `<GL/gl.h>` and expects that the necessary preprocessor macros are getting defined by including that header.
*  `<GL/gl.h>` was already included before (in `qopengl.h`) and the inclusion guards lead to `#include <GL/gl.h>` being a no-op at that point.
*  The necessary preprocessor macros are undefined which leads to compilation errors.

This PR adds a patch that
* adds definitions for two more preprocessor macros in `qopengl.h`  that are needed when including `<GL/glu.h>` in user code and
* no longer undefines these (four) preprocessor macros at the end of `qopengl.h`.
