### PR TITLE
swi-prolog: update to 9.2.4

### DIFF
--- a/mingw-w64-swi-prolog/PKGBUILD
+++ b/mingw-w64-swi-prolog/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=swi-prolog
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=9.2.3
+pkgver=9.2.4
 pkgrel=1
 pkgdesc="Prolog environment (mingw-w64)"
 arch=(any)
@@ -31,7 +31,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-pkgconf")
 source=("https://www.swi-prolog.org/download/stable/src/swipl-${pkgver}.tar.gz")
 
-sha256sums=('28329039526a93c10a160be5c7d90ca4fb7d1514e4a009a0852c6d237292e724')
+sha256sums=('d53cc13380b60ec4edeea0caead26af4d0e6bd877f458cf4fc6d6f90bd6e987c')
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"

--- a/mingw-w64-swi-prolog/PKGBUILD
+++ b/mingw-w64-swi-prolog/PKGBUILD
@@ -53,6 +53,7 @@ build() {
     -DSWIPL_PACKAGES_JAVA=OFF \
     -DSWIPL_PACKAGES_X=OFF \
     -DINSTALL_DOCUMENTATION=OFF \
+    -DINSTALL_TESTS=ON \
     -DSWIPL_{SHARED,STATIC}_LIB=ON \
     ../swipl-${pkgver}
 


### PR DESCRIPTION
now includes the test suite, run with ?- test_installation.