### PR TITLE
python-pytest: update to 8.1.2 and update plugins

### DIFF
--- a/mingw-w64-python-pytest-asyncio/PKGBUILD
+++ b/mingw-w64-python-pytest-asyncio/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=pytest-asyncio
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=0.23.5
+pkgver=0.23.6
 pkgrel=1
 pkgdesc='Pytest support for asyncio (mingw-w64)'
 arch=('any')
@@ -24,7 +24,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-flaky"
               "${MINGW_PACKAGE_PREFIX}-python-hypothesis")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('3a048872a9c4ba14c3e90cc1aa20cbc2def7d01c7c8db3777ec281ba9c057675')
+sha256sums=('ffe523a89c1c222598c76856e76852b787504ddb72dd5d9b6617ffa8aa2cde5f')
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-python-pytest-cov/PKGBUILD
+++ b/mingw-w64-python-pytest-cov/PKGBUILD
@@ -6,8 +6,8 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=4.1.0
-pkgrel=2
+pkgver=5.0.0
+pkgrel=1
 pkgdesc="py.test plugin for coverage reporting with support for both centralised and distributed testing, including subprocesses and multiprocessing (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -29,7 +29,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python-virtualenv"
 #              "${MINGW_PACKAGE_PREFIX}-python-fields"
 )
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6')
+sha256sums=('5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857')
 
 prepare() {
   cd "${srcdir}"

--- a/mingw-w64-python-pytest-enabler/PKGBUILD
+++ b/mingw-w64-python-pytest-enabler/PKGBUILD
@@ -4,7 +4,7 @@ _pyname=pytest-enabler
 _realname=pytest-enabler
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=3.0.0
+pkgver=3.1.1
 pkgrel=1
 pkgdesc='Enable installed pytest plugins (mingw-w64)'
 arch=('any')
@@ -27,7 +27,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm"
 )
 source=("https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${pkgver}.tar.gz")
-sha256sums=('62376d2fdae65ee967849fa3586f8ce68506988e94c64030c8ff2b038d6422c5')
+sha256sums=('9ea1157e716801f9ba3f1c3db4474ec2114a0b8e77b909c1eb0f7a630a325483')
 
 prepare() {
   cd "$srcdir"

--- a/mingw-w64-python-pytest-isort/PKGBUILD
+++ b/mingw-w64-python-pytest-isort/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=pytest-isort
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=3.1.0
-pkgrel=2
+pkgver=4.0.0
+pkgrel=1
 pkgdesc='pytest plugin to perform isort checks (import ordering) (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -20,7 +20,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
              "${MINGW_PACKAGE_PREFIX}-python-poetry-core")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('067801dc5e54a474330d074d521c815948ff6d5cf0ed3b9d057b78216851186c')
+sha256sums=('00e99642e282b00b849cf9b49d9102a02ab8c4ec549ace57d7868b723713aaa9')
 
 build() {
   cd "${srcdir}"

--- a/mingw-w64-python-pytest-mock/PKGBUILD
+++ b/mingw-w64-python-pytest-mock/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=pytest-mock
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=3.12.0
+pkgver=3.14.0
 pkgrel=1
 pkgdesc='Thin-wrapper around the mock package for easier use with py.test (mingw-w64)'
 arch=('any')
@@ -23,7 +23,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-wheel")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest-asyncio")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('31a40f038c22cad32287bb43932054451ff5583ff094bca6f675df2f8bc1a6e9')
+sha256sums=('2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0')
 
 prepare() {
   export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver

--- a/mingw-w64-python-pytest-timeout/PKGBUILD
+++ b/mingw-w64-python-pytest-timeout/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=pytest-timeout
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=2.3.0
+pkgver=2.3.1
 pkgrel=1
 pkgdesc='py.test plugin to abort hanging tests (mingw-w64)'
 arch=('any')
@@ -19,8 +19,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python-wheel")
-source=("https://github.com/pytest-dev/pytest-timeout/archive/$pkgver/${_realname}-$pkgver.tar.gz")
-sha512sums=('be2f706bac5375f48c9fd92d420cccb118b0ea2aa9bbc6eb7bffef4af624d682de99b52dd106c1cbb8b5ecffcbf25ff4ab3c8e121e92d7f429e8784ed79b5aa0')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('12397729125c6ecbdaca01035b9e5239d4db97352320af155b3f5de1ba5165d9')
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-python-pytest/PKGBUILD
+++ b/mingw-w64-python-pytest/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=8.0.1
+pkgver=8.1.2
 pkgrel=1
 pkgdesc='simple powerful testing with Python (mingw-w64)'
 license=('spdx:MIT')
@@ -37,7 +37,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python-argcomplete"
               "${MINGW_PACKAGE_PREFIX}-python-requests")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('267f6563751877d772019b13aacbe4e860d73fe8f651f28112e9ac37de7513ae')
+sha256sums=('f3c45d1d5eed96b01a2aea70dee6a4a366d51d38f9957768083e4fecfc77f3ef')
 
 prepare() {
   sed -i 's/assert numentries == 0/assert numentries == 26/' ${_realname}-${pkgver}/testing/python/collect.py


### PR DESCRIPTION
Also update:
mingw-w64-python-pytest-asyncio 0.23.6
mingw-w64-python-pytest-cov 5.0.0
mingw-w64-python-pytest-enabler 3.1.1
mingw-w64-python-pytest-isort  4.0.0
mingw-w64-python-pytest-mock 3.14.0
mingw-w64-python-pytest-timeout 2.3.1
