### PR TITLE
emacs: depend on texinfo for proper info directory update upon install

### DIFF
--- a/mingw-w64-emacs/PKGBUILD
+++ b/mingw-w64-emacs/PKGBUILD
@@ -8,7 +8,7 @@ _realname=emacs
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=29.3
-pkgrel=2
+pkgrel=3
 pkgdesc="The extensible, customizable, self-documenting, real-time display editor (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -20,6 +20,7 @@ msys2_references=(
 license=('spdx:GPL-3.0-or-later')
 depends=("${MINGW_PACKAGE_PREFIX}-ctags"
          $([[ "$_enable_jit" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-libgccjit")
+         "${MINGW_PACKAGE_PREFIX}-texinfo" # solves https://github.com/msys2/MINGW-packages/issues/631
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-xpm-nox"
          "${MINGW_PACKAGE_PREFIX}-freetype"
@@ -83,6 +84,9 @@ build() {
   CFLAGS=${CFLAGS//"-Wp,-D_FORTIFY_SOURCE=2"}
   # -foptimize-sibling-calls breaks native compilation (GCC 13.1)
   CFLAGS+=" -fno-optimize-sibling-calls"
+  # configure script can not deal with the warnings that were turned
+  # into errors in GCC 14
+  CFLAGS+=" -Wno-error=implicit-function-declaration"
 
   ../${_realname}-${pkgver}/configure \
     --prefix="${MINGW_PREFIX}" \


### PR DESCRIPTION
This completes the fix for issue #631