### PR TITLE
libvpl: Update to 2.11.0

### DIFF
--- a/mingw-w64-libvpl/PKGBUILD
+++ b/mingw-w64-libvpl/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libvpl
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.10.2
+pkgver=2.11.0
 pkgrel=1
 pkgdesc="Intel Video Processing Library (mingw-w64)"
 arch=('any')
@@ -22,7 +22,7 @@ source=("https://github.com/intel/libvpl/archive/v${pkgver}/${_realname}-${pkgve
         0001-fix-pkgconfig-file.patch
         0002-cmake-install-vars-sh.patch
         0003-cmake-fix-32bit-install.patch)
-sha256sums=('ad956ea7ecf14614325f59dfb44cc5ba08e2fcac373342d61c7db152ac651253'
+sha256sums=('3e322ba6b3593da03e1cfdb8062f9f1545f6d9b1de39e36876de5934b26737d2'
             'f23ca1ccbaa9c8e3fd4fd7320996e5be2753cfcdc6e2a25f6def08222a5691cd'
             'b9b1cdcb531ee0b6b1d7eef8bbfb1df8ca1ffe72d76961050dd912203edecc67'
             '21b2cc2f466f636940c8ef81f50dff177aff96d60dc4bc57f58c5c9f016502fe')
@@ -60,8 +60,6 @@ build() {
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       "${extra_config[@]}" \
       -DBUILD_SHARED_LIBS=OFF \
-      -DBUILD_TOOLS=OFF \
-      -DINSTALL_EXAMPLE_CODE=OFF \
       ../libvpl-${pkgver}
 
   "${MINGW_PREFIX}"/bin/cmake.exe --build .
@@ -74,8 +72,6 @@ build() {
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       "${extra_config[@]}" \
       -DBUILD_SHARED_LIBS=ON \
-      -DBUILD_TOOLS=OFF \
-      -DINSTALL_EXAMPLE_CODE=OFF \
       ../libvpl-${pkgver}
 
   "${MINGW_PREFIX}"/bin/cmake.exe --build .
@@ -87,6 +83,8 @@ package() {
 
   cd "${srcdir}/build-${MSYSTEM}-shared"
   DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
+
+  rm -r "${pkgdir}${MINGW_PREFIX}/share/vpl/examples"
 
   install -Dm644 "${srcdir}/libvpl-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
* 2.11 moved the tools to another project but we never built them
* 2.11 removed the option to not install examples, so manually delete them