### PR TITLE
gdk-pixbuf: update to 2.42.11

### DIFF
--- a/mingw-w64-gdk-pixbuf2/0004-build-all-loaders-plus-gdi.patch
+++ b/mingw-w64-gdk-pixbuf2/0004-build-all-loaders-plus-gdi.patch
@@ -25,22 +25,21 @@
    },
    'bmp': {
      'sources': [ 'io-bmp.c' ],
--    'enabled': not native_windows_loaders,
+-    'enabled': enabled_loaders.contains('bmp') and not native_windows_loaders,
 +    'enabled': true,
    },
    'gif': {
      'sources': [ 'io-gif.c', 'io-gif-animation.c', 'lzw.c' ],
--    'enabled': not native_windows_loaders,
+-    'enabled': enabled_loaders.contains('gif') and not native_windows_loaders,
 +    'enabled': true,
    },
    'ico': {
      'sources': [ 'io-ico.c' ],
--    'enabled': not native_windows_loaders,
+-    'enabled': enabled_loaders.contains('ico') and not native_windows_loaders,
 +    'enabled': true,
    },
    'ani': {
      'sources': [ 'io-ani.c', 'io-ani-animation.c' ],
-
 --- gdk-pixbuf-2.36.11/gdk-pixbuf/gdk-pixbuf-io.c.orig	2018-02-01 18:02:27.955913000 +0100
 +++ gdk-pixbuf-2.36.11/gdk-pixbuf/gdk-pixbuf-io.c	2018-02-01 18:11:35.652239400 +0100
 @@ -457,17 +457,17 @@

--- a/mingw-w64-gdk-pixbuf2/PKGBUILD
+++ b/mingw-w64-gdk-pixbuf2/PKGBUILD
@@ -6,8 +6,8 @@ _realname=gdk-pixbuf2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
-pkgver=2.42.10
-pkgrel=4
+pkgver=2.42.11
+pkgrel=1
 pkgdesc="An image loading library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -24,36 +24,47 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-gi-docgen"
              "${MINGW_PACKAGE_PREFIX}-python-docutils")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
-         "${MINGW_PACKAGE_PREFIX}-glib2>=2.37.2"
+         "${MINGW_PACKAGE_PREFIX}-glib2"
          "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
          "${MINGW_PACKAGE_PREFIX}-libpng"
          "${MINGW_PACKAGE_PREFIX}-libtiff")
 install=${_realname}-${MSYSTEM}.install
 source=("https://download.gnome.org/sources/gdk-pixbuf/${pkgver%.*}/gdk-pixbuf-${pkgver}.tar.xz"
+        https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/commit/238893d8cd6f9c2616a05ab521a29651a17a38c2.patch
         0003-fix-dllmain.patch
         0004-build-all-loaders-plus-gdi.patch
         fix-missing-meson-dep.patch
         gdk-pixbuf-query-loaders.hook.in)
 noextract=("gdk-pixbuf-${pkgver}.tar.xz")
-sha256sums=('ee9b6c75d13ba096907a2e3c6b27b61bcd17f5c7ebeab5a5b439d2f2e39fe44b'
+sha256sums=('49dcb402388708647e8c321d56b6fb30f21e51e515d0c5a942268d23052a2f00'
+            '32ca479a00edcb213b5e867aefafd1543d28a2d3fe3f4c8c81377f98f6887408'
             '21bd9b2ba1447267c84f1b445cbcf50c62299254856c1c227cc7ba4babc9f27e'
-            '9c4aadcc9ac9dc09c1d9ad94e395078f3d69623db3d7be66bacdb26b919e6540'
+            'edc53917fc286f1eaca1cf5a4411feb6253543d8373a7d661a5dd354c31db015'
             'c7a0e09fd611a6de0ed91348ba6776ad5c2c4fee4d834c61628318a374bc9318'
             '6277c30e763c7889a3446e2ce8c7b8dbe7212678497b2905582de8159831e3fb')
+
+_apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying ${_patch}"
+    patch -p1 -i "${srcdir}/${_patch}"
+  done
+}
 
 prepare() {
   cd ${srcdir}/
   tar --exclude tests/test-images/reftests/tga -xf "gdk-pixbuf-${pkgver}.tar.xz"
   cd ${srcdir}/gdk-pixbuf-${pkgver}
 
-  msg2 "0003-fix-dllmain.patch"
-  patch -p1 -i "${srcdir}"/0003-fix-dllmain.patch
-  patch -p1 -i "${srcdir}"/fix-missing-meson-dep.patch
+  _apply_patch_with_msg \
+    238893d8cd6f9c2616a05ab521a29651a17a38c2.patch \
+    0003-fix-dllmain.patch \
+    fix-missing-meson-dep.patch
 
   # build all loaders + all gdi loaders static and just don't register
   # the gdi loaders we don't need so the external ones get used
   # (everything except wmf/emf atm)
-  patch -p1 -i "${srcdir}"/0004-build-all-loaders-plus-gdi.patch
+  _apply_patch_with_msg 0004-build-all-loaders-plus-gdi.patch
 }
 
 build() {
@@ -73,6 +84,7 @@ build() {
     -Drelocatable=true
     -Dnative_windows_loaders=true
     -Dbuiltin_loaders=windows
+    -Dothers=enabled
   )
 
   # Does not enable DLL_EXPORT, keeps DllMain far away (#17643)


### PR DESCRIPTION

    * Enable building less supported image formats which was disabled in this version.
      See https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/commit/e052a112075a19fb75f1f2ff3de4c82923de13f2
    * Import a fix for meson.build file.
      See https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/commit/238893d8cd6f9c2616a05ab521a29651a17a38c2
