### PR TITLE
python-pytest: update to 8.2.0 and dependencies

### DIFF
--- a/mingw-w64-python-coverage/PKGBUILD
+++ b/mingw-w64-python-coverage/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=7.4.2
+pkgver=7.5.1
 pkgrel=1
 pkgdesc="Code coverage measurement for Python (mingw-w64)"
 arch=('any')
@@ -24,7 +24,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-cc")
 options=(!strip)
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('1a5ee18e3a8d766075ce9314ed1cb695414bae67df6a4b0805f5137d93d6f1cb')
+sha256sums=('54de9ef3a9da981f7af93eafde4ede199e0846cd819eb27c88e2b712aae9708c')
 
 prepare() { 
   rm -rf python-build-${MSYSTEM} | true

--- a/mingw-w64-python-execnet/PKGBUILD
+++ b/mingw-w64-python-execnet/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=2.0.2
+pkgver=2.1.1
 pkgrel=1
 pkgdesc="Rapid multi-Python deployment (mingw-w64)"
 arch=('any')
@@ -22,7 +22,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-hatch-vcs"
              "${MINGW_PACKAGE_PREFIX}-python-installer")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha512sums=('9e2e7ff4e04f50b12a3dd47d3326a3ea229f64926e8598bdce6ea25bd57afb41e96249e1c9f7333927a38a2793f67cac77965c922980055ed758dee361bf2ce4')
+sha512sums=('486f906ad653d16cce7337d9085c36070fe3dd721a3723ca62ceb25862c3ff837120062df028d5aadec17f854c0d46204537e9d75d22079a677f08c50dd48d21')
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-python-pluggy/PKGBUILD
+++ b/mingw-w64-python-pluggy/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=pluggy
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=1.4.0
+pkgver=1.5.0
 pkgrel=1
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}=${pkgver}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
@@ -24,7 +24,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-wheel")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest-runner")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('8c85c2876142a764e5b7548e7d9a0e0ddb46f5185161049a79b7e974454223be')
+sha256sums=('2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1')
 
 prepare() {
   rm -rf python-build-${MSYSTEM} | true

--- a/mingw-w64-python-pytest/PKGBUILD
+++ b/mingw-w64-python-pytest/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=8.1.2
+pkgver=8.2.0
 pkgrel=1
 pkgdesc='simple powerful testing with Python (mingw-w64)'
 license=('spdx:MIT')
@@ -37,7 +37,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python-argcomplete"
               "${MINGW_PACKAGE_PREFIX}-python-requests")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('f3c45d1d5eed96b01a2aea70dee6a4a366d51d38f9957768083e4fecfc77f3ef')
+sha256sums=('d507d4482197eac0ba2bae2e9babf0672eb333017bcedaa5fb1a3d42c1174b3f')
 
 prepare() {
   sed -i 's/assert numentries == 0/assert numentries == 26/' ${_realname}-${pkgver}/testing/python/collect.py


### PR DESCRIPTION
Also updates:
python-pluggy 1.5.0
python-execnet 2.1.1
python-coverage 7.5.1 (dependency of python-pytest-cov already updated)
