### PR TITLE
libslirp: Update to 4.8.0

### DIFF
--- a/mingw-w64-libslirp/PKGBUILD
+++ b/mingw-w64-libslirp/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=libslirp
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.7.0
-pkgrel=2
+pkgver=4.8.0
+pkgrel=1
 pkgdesc="General purpose TCP-IP emulator (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'mingw32' 'ucrt64' 'clang64' 'clangarm64')
@@ -18,14 +18,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-pkgconf")
-source=("https://gitlab.freedesktop.org/slirp/${_realname}/-/archive/v${pkgver}/${_realname}-v${pkgver}.tar.bz2"
-        "https://gitlab.freedesktop.org/slirp/libslirp/-/commit/84b276c5abb13f4770b046b0efca2cb574ef6d02.patch")
-sha256sums=('358ce8b6ea59ec9deac937cc754f0115b992839e7b0cddf30ffb8f77dc21da82'
-            '26284c63318a9916db77c658d586cadb067e86be4dbe2379491487ee14f47e23')
+source=("https://gitlab.freedesktop.org/slirp/${_realname}/-/archive/v${pkgver}/${_realname}-v${pkgver}.tar.bz2")
+noextract=("${_realname}-v${pkgver}.tar.bz2")
+sha256sums=('1c2e3d30e41a055ed41f9d0b3234d0d143bc28f5ad84bb101413f830844df757')
 
 prepare() {
+  bsdtar -xf "${_realname}-v${pkgver}.tar.bz2" 2>/dev/null || bsdtar -xf "${_realname}-v${pkgver}.tar.bz2"
   cd "${_realname}-v${pkgver}"
-  patch -p1 -i "${srcdir}/84b276c5abb13f4770b046b0efca2cb574ef6d02.patch"
 }
 
 build() {


### PR DESCRIPTION
* Drop patch included in the new release
* Now contains symlinks, so do the double extract trick