### PR TITLE
rapidjson: fix build error with GCC 14

### DIFF
--- a/mingw-w64-rapidjson/PKGBUILD
+++ b/mingw-w64-rapidjson/PKGBUILD
@@ -4,7 +4,7 @@ _realname=rapidjson
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.1.0
-pkgrel=7
+pkgrel=8
 pkgdesc='A fast JSON parser/generator for C++ with both SAX/DOM style API (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -25,7 +25,8 @@ source=("${_realname}-${pkgver}.tar.gz::https://github.com/Tencent/rapidjson/arc
         '0005-PrettyWriter.patch'
         '0006-aarch64.patch'
         '0007-fix-pkgconfig-file.patch'
-        '0008-cmake-relocate-dirs.patch')
+        '0008-cmake-relocate-dirs.patch'
+        "0009-remove-non-compiling-assignment-operator.patch::https://patch-diff.githubusercontent.com/raw/Tencent/rapidjson/pull/719.patch")
 sha256sums=('bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e'
             '5a838fe611b367f8939231aae1f604f83fd97108d3b2ac66def00ff1205afcf2'
             '8160d2ef142055cecb520b23cf11e90e0a6e92719427fa33755800cc748cf8be'
@@ -34,29 +35,43 @@ sha256sums=('bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e'
             'e3efdb8263bafb3fc3af7558c7f57f9d8a3d2ab231f05c693cc615d7784cd320'
             'a2bd02572ffd4eb39d2248b3e818072d07948a65cb440f90d2fd5688e370570b'
             '3c186ea46d4ab1b67f4cd577799a059b6312dd43bf7b28e0b86c0a1bedac5cf8'
-            '3e5bc65df66e77e183c8046e3133132606c969754930a999f318f5ca5c6bd190')
+            '3e5bc65df66e77e183c8046e3133132606c969754930a999f318f5ca5c6bd190'
+            '8abc5c5ef033801ea99a9f289126e473ccf4ebdb9ab33fa8157f957fdeb03a2f')
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Np1 -i "${srcdir}/$_patch"
+  done
+}
 
 prepare() {
   cd "${_realname}-${pkgver}"
-  patch -p1 -i "${srcdir}/0001-Use-relative-paths-for-doxygen-outputs.patch"
-  patch -p1 -i "${srcdir}/0002-Add-CMake-check-for-MinGW.patch"
-  patch -p1 -i "${srcdir}/0003-Exclude-CMakeLists.txt-from-install-targets.patch"
-  patch -p1 -i "${srcdir}/0004-CMake-Install-compiled-example-executables.patch"
+  apply_patch_with_msg \
+    0001-Use-relative-paths-for-doxygen-outputs.patch \
+    0002-Add-CMake-check-for-MinGW.patch \
+    0003-Exclude-CMakeLists.txt-from-install-targets.patch \
+    0004-CMake-Install-compiled-example-executables.patch
 
   # Cherrypick changes from upstream:
   # https://github.com/Tencent/rapidjson/commit/1a803826f1197b5e30703afe4b9c0e7dd48074f5
   # https://github.com/Tencent/rapidjson/commit/d88be8ef1649eca4602348d1aab5c16c36f83d4f
-  patch -p1 -i "${srcdir}/0005-PrettyWriter.patch"
+  apply_patch_with_msg \
+    0005-PrettyWriter.patch
 
   if [[ ${MSYSTEM_CARCH} == aarch64 ]]; then
-    patch -p1 -i "${srcdir}/0006-aarch64.patch"
+    apply_patch_with_msg 0006-aarch64.patch
   fi
 
-  patch -p1 -i "${srcdir}/0007-fix-pkgconfig-file.patch"
+  apply_patch_with_msg \
+    0007-fix-pkgconfig-file.patch
 
   # With uppercase RAPIDJSON_ variables, using
   # https://github.com/Tencent/rapidjson/commit/0bc856a747ce6b56107c29c80e5f86eb0fee151e
-  patch -p1 -i "${srcdir}/0008-cmake-relocate-dirs.patch"
+  apply_patch_with_msg \
+    0008-cmake-relocate-dirs.patch \
+    0009-remove-non-compiling-assignment-operator.patch
 
   find -name CMakeLists.txt | xargs sed -e 's|-Werror||' -i # Don't use -Werror
 }


### PR DESCRIPTION
Cherry-pick upstream patch to avoid build error with GCC 14. 

Fixes #20858.
