### PR TITLE
groonga: update to 14.0.3

### DIFF
--- a/mingw-w64-groonga/PKGBUILD
+++ b/mingw-w64-groonga/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=groonga
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=14.0.2
-pkgrel=2
+pkgver=14.0.3
+pkgrel=1
 pkgdesc="An opensource fulltext search engine (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -28,7 +28,7 @@ makedepends=("git"
              "${MINGW_PACKAGE_PREFIX}-rapidjson"
              "${MINGW_PACKAGE_PREFIX}-ruby"
              "${MINGW_PACKAGE_PREFIX}-xsimd")
-sha256sums=('a3d0ba94f38f91bd8a09b1780aa2f22ad5c77ce741de3008bf93fa4a34c90097'
+sha256sums=('096a71ce09bd539da440f7157792d7fac9394f4533afadc939923ed1e6d3c3e6'
             'SKIP')
 validpgpkeys=('2701F317CFCCCB975CADE9C2624CF77434839225') # Groonga Key <packages@groonga.org>
 


### PR DESCRIPTION
Groonga version14.0.3 has just released [here](https://github.com/groonga/groonga/releases/tag/v14.0.3).