### PR TITLE
notepad++: Update to 8.6.6

### DIFF
--- a/mingw-w64-notepad++/PKGBUILD
+++ b/mingw-w64-notepad++/PKGBUILD
@@ -1,8 +1,8 @@
 _realname=notepad++
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=8.6.5
-pkgrel=2
+pkgver=8.6.6
+pkgrel=1
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
 pkgdesc="Notepad++ is a free (as in “free speech” and also as in “free beer”) source code editor and Notepad replacement that supports several languages."
@@ -24,8 +24,8 @@ source=(
 )
 validpgpkeys=('14BCE4362749B2B51F8C71226C429F1D8D84F46E')
 sha256sums=(
-  '53bba28cc5d71ff6efa58487ff80e0d526dc9251e277e9f1a9f869fb87c7f072'
-  'bd6a61834ae1a7c57e5628c2df9d1e71a9ab60c711188abe116c8b4e7bdeab2f'
+  'b3f6638c87a1188f34861ef5edfef12aeb63a45e7366953f933ea693418b983d'
+  'bbb81ac3893a3701cdf6a193666d063b223bffcae4f78bf6e09ad81099ece508'
   'f4468e0fa0e476fc77282cb0b3cff845ed8bce91a816a7c04e8d272abf5c5b1c'
   '2643cce3dbd5fcb65481be4afe7bf6fdea084cde134e04b38dd07239e1f09d59'
 )

--- a/mingw-w64-notepad++/notepad++
+++ b/mingw-w64-notepad++/notepad++
@@ -12,13 +12,11 @@
 # variables have to be unset.
 #
 # To set the localization, -L can be used, see notepad++ --help,
-# localization can only be set on start
 
 
-# determine npplocale (invalid arguments are ignored by notepad++),
-# relevant in correct priority would be LC_ALL LC_MESSAGES LANG, but
-# MSYS2 default only defines LC_CTYPE, which therefore is last resort
-for locale in $LC_ALL $LC_MESSAGES $LANG $LC_CTYPE
+# determine npplocale, if one of LC_ALL LC_MESSAGES LANG is set,
+# else respect notepad++'s language setting
+for locale in $LC_ALL $LC_MESSAGES $LANG
 do
 	if [[ $locale =~ ^([a-z]{2}) ]]
 	then


### PR DESCRIPTION
To respect notepad++ settings for locale, it's no longer overridden based on default MSYS2 environment variable LC_CTYPE when started with wrapper script.