### PR TITLE
mingw-w64-efxc2 - update to latest release

### DIFF
--- a/mingw-w64-efxc2/PKGBUILD
+++ b/mingw-w64-efxc2/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=efxc2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.0.9.170
+pkgver=0.0.10.214
 pkgrel=1
 pkgdesc="Enhanced version of fxc2 (mingw-w64)"
 arch=('any')
@@ -15,7 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-cc")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/JPeterMugaas/efxc2/archive/refs/tags/${pkgver}.tar.gz")
-sha256sums=('a9d7893a0213068556a746dde31f945e3f79eddfa331347402b03ab02b48927d')
+sha256sums=('840a5410763d60180f353ddc88c8135e9054914899df47d144780d0e5ca7b4d5')
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
@@ -31,6 +31,7 @@ build() {
     "${MINGW_PREFIX}"/bin/cmake.exe \
       -GNinja \
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      -DEFXC2_BUILD_STATIC=OFF \
       "${extra_config[@]}" \
       ../${_realname}-${pkgver}
 


### PR DESCRIPTION
Features new parameter support for /P, /setprivate. More silent unless parameter is added.