### PR TITLE
Fortran-stdlib: v0.6.0

### DIFF
--- a/mingw-w64-fortran-stdlib/001-using-openblas.patch
+++ b/mingw-w64-fortran-stdlib/001-using-openblas.patch
@@ -1,0 +1,36 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b10e1f7..0029d06 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -42,6 +42,17 @@ if(NOT DEFINED CMAKE_MAXIMUM_RANK)
+   set(CMAKE_MAXIMUM_RANK 4 CACHE STRING "Maximum array rank for generated procedures")
+ endif()
+
++find_package(PkgConfig)
++pkg_check_modules(OPENBLAS openblas)
++if(OPENBLAS_FOUND)
++  add_compile_definitions(STDLIB_EXTERNAL_BLAS STDLIB_EXTERNAL_LAPACK)
++  include_directories(${OPENBLAS_INCLUDE_DIRS})
++  link_directories(${OPENBLAS_LIBRARY_DIRS})
++  message(STATUS "Using OpenBLAS")
++else()
++  message(STATUS "Using intrinsic reference BLAS")
++endif()
++
+ # --- find preprocessor
+ find_program(FYPP fypp)
+ if(NOT FYPP)
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index a031ab8..5b02669 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -114,6 +114,9 @@ set(SRC
+ )
+
+ add_library(${PROJECT_NAME} ${SRC})
++if(OPENBLAS_FOUND)
++  target_link_libraries(${PROJECT_NAME} ${OPENBLAS_LIBRARIES})
++endif()
+
+ set_target_properties(
+   ${PROJECT_NAME}

--- a/mingw-w64-fortran-stdlib/001-using-openblas.patch
+++ b/mingw-w64-fortran-stdlib/001-using-openblas.patch
@@ -1,35 +1,32 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b10e1f7..0029d06 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -42,6 +42,17 @@ if(NOT DEFINED CMAKE_MAXIMUM_RANK)
+@@ -42,6 +42,15 @@
    set(CMAKE_MAXIMUM_RANK 4 CACHE STRING "Maximum array rank for generated procedures")
  endif()
 
-+find_package(PkgConfig)
-+pkg_check_modules(OPENBLAS openblas)
-+if(OPENBLAS_FOUND)
-+  add_compile_definitions(STDLIB_EXTERNAL_BLAS STDLIB_EXTERNAL_LAPACK)
-+  include_directories(${OPENBLAS_INCLUDE_DIRS})
-+  link_directories(${OPENBLAS_LIBRARY_DIRS})
-+  message(STATUS "Using OpenBLAS")
-+else()
-+  message(STATUS "Using intrinsic reference BLAS")
++find_package(BLAS)
++if(BLAS_FOUND)
++  add_compile_definitions(STDLIB_EXTERNAL_BLAS)
++endif()
++find_package(LAPACK)
++if(LAPACK_FOUND)
++  add_compile_definitions(STDLIB_EXTERNAL_LAPACK)
 +endif()
 +
  # --- find preprocessor
  find_program(FYPP fypp)
  if(NOT FYPP)
-diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index a031ab8..5b02669 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -114,6 +114,9 @@ set(SRC
+@@ -114,6 +114,12 @@
  )
 
  add_library(${PROJECT_NAME} ${SRC})
-+if(OPENBLAS_FOUND)
-+  target_link_libraries(${PROJECT_NAME} ${OPENBLAS_LIBRARIES})
++if(BLAS_FOUND)
++  target_link_libraries(${PROJECT_NAME} BLAS::BLAS)
++endif()
++if(LAPACK_FOUND)
++  target_link_libraries(${PROJECT_NAME} LAPACK::LAPACK)
 +endif()
 
  set_target_properties(

--- a/mingw-w64-fortran-stdlib/PKGBUILD
+++ b/mingw-w64-fortran-stdlib/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=fortran-stdlib
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.6.0
+pkgver=0.6.1
 pkgrel=1
 pkgdesc="Fortran Standard Library (mingw-w64)"
 arch=('any')
@@ -22,10 +22,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-fc"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-python-fypp"
              "${MINGW_PACKAGE_PREFIX}-openblas")
-source=("https://github.com/fortran-lang/stdlib/archive/refs/tags/v${pkgver}/${_realname}-${pkgver}.tar.gz"
+source=("https://github.com/fortran-lang/stdlib/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
 	      "001-using-openblas.patch")
-sha256sums=('2977be7057313db88f4993a91305b2791a8529b67c6fc963d6be42d08851b53a'
-            '0e5990e04231013661cd7f6dcdca9cf8a3c6c6006542bb20ea2b92b835284519')
+sha256sums=('b46964e19e6b47ad5e63ac8a3706c4fa33504339000ca0cd0475a0cc06b0b7bd'
+            '1ec6c36684c2c37bcb3adb0d8c13f1182377365643e575e399e7076d6a79e59d')
 
 prepare() {
   cd "${srcdir}/stdlib-${pkgver}"

--- a/mingw-w64-fortran-stdlib/PKGBUILD
+++ b/mingw-w64-fortran-stdlib/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=fortran-stdlib
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.3.0
+pkgver=0.6.0
 pkgrel=1
 pkgdesc="Fortran Standard Library (mingw-w64)"
 arch=('any')
@@ -15,13 +15,22 @@ url="https://github.com/fortran-lang/stdlib"
 license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libwinpthread"
-         $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran"))
+         $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran")
+         "${MINGW_PACKAGE_PREFIX}-openblas")
 makedepends=("${MINGW_PACKAGE_PREFIX}-fc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
-             "${MINGW_PACKAGE_PREFIX}-python-fypp")
-source=("https://github.com/fortran-lang/stdlib/archive/refs/tags/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('ca8ac7258d546045d317ed865c864a31141f6be5676b9332000b22bf975bdebf')
+             "${MINGW_PACKAGE_PREFIX}-python-fypp"
+             "${MINGW_PACKAGE_PREFIX}-openblas")
+source=("https://github.com/fortran-lang/stdlib/archive/refs/tags/v${pkgver}/${_realname}-${pkgver}.tar.gz"
+	      "001-using-openblas.patch")
+sha256sums=('2977be7057313db88f4993a91305b2791a8529b67c6fc963d6be42d08851b53a'
+            '0e5990e04231013661cd7f6dcdca9cf8a3c6c6006542bb20ea2b92b835284519')
+
+prepare() {
+  cd "${srcdir}/stdlib-${pkgver}"
+  patch -p1 -i ${srcdir}/001-using-openblas.patch
+}
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}


### PR DESCRIPTION
### Description

`Fortran-stdlib` comes with modern Reference-BLAS built into v0.6.0, and also provides macro definitions to use external BLAS and LAPACK.
This PR upgrades `Fortran-stdlib` to v0.6.0 and links to OpenBLAS for optimized performance by adding a CMake patch.