### PR TITLE
gcc: apply proposed upstream patch for seh_cfa_offset ICE regression

### DIFF
--- a/mingw-w64-gcc/3001-fix-ice.patch
+++ b/mingw-w64-gcc/3001-fix-ice.patch
@@ -1,0 +1,13 @@
+diff --git a/gcc/fold-mem-offsets.cc b/gcc/fold-mem-offsets.cc
+index 2e15b05529e..84b9623058b 100644
+--- a/gcc/fold-mem-offsets.cc
++++ b/gcc/fold-mem-offsets.cc
+@@ -491,7 +491,7 @@ fold_offsets (rtx_insn *insn, rtx reg, bool analyze, bitmap foldable_insns)
+ {
+   rtx_insn *def = get_single_def_in_bb (insn, reg);
+ 
+-  if (!def || GET_CODE (PATTERN (def)) != SET)
++  if (!def || RTX_FRAME_RELATED_P (def) || GET_CODE (PATTERN (def)) != SET)
+     return 0;
+ 
+   rtx dest = SET_DEST (PATTERN (def));

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -48,7 +48,7 @@ else
   _sourcedir=${_realname}-${_version}-${_snapshot}
   _url=https://gcc.gnu.org/pub/gcc/snapshots/${_version}-${_snapshot}
 fi
-pkgrel=2
+pkgrel=3
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -90,7 +90,8 @@ source=(${_url}/${_sourcedir}.tar.xz{,.sig}
         0021-PR14940-Allow-a-PCH-to-be-mapped-to-a-different-addr.patch
         0140-gcc-diagnostic-color.patch
         0200-add-m-no-align-vector-insn-option-for-i386.patch
-        2001-fix-building-rust-on-mingw-w64.patch)
+        2001-fix-building-rust-on-mingw-w64.patch
+        3001-fix-ice.patch)
 sha256sums=('e283c654987afe3de9d8080bc0bd79534b5ca0d681a73a11ff2b5d3767426840'
             'SKIP'
             'bce81824fc89e5e62cca350de4c17a27e27a18a1a1ad5ca3492aec1fc5af3234'
@@ -106,7 +107,8 @@ sha256sums=('e283c654987afe3de9d8080bc0bd79534b5ca0d681a73a11ff2b5d3767426840'
             '6c272078340a27b3f147e497115b0a6e9fc0da720a2602f12b086524522caa59'
             'e0a5b470f49a29f20215cc9f9d04c1cb9969dff6f0e546542799d3a693ef1c84'
             'c34f9e71b5a092be1987ad4c65891742c74c9eb8ef6560100e751cd31375f579'
-            'ddc1538c2b9132bce5b3b2cad2a382762d58b46b31d2ae291f6e4d963b88dfd4')
+            'ddc1538c2b9132bce5b3b2cad2a382762d58b46b31d2ae291f6e4d963b88dfd4'
+            '38a5dff6ebfffce24763fca4221554ab5a2a6416a14594c4b87e08c94b63e273')
 validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.org
               86CFFCA918CF3AF47147588051E8B148A9999C34  # evangelos@foutrelis.com
               13975A70E63C361C73AE69EF6EEB81F8981C74C7  # richard.guenther@gmail.com
@@ -165,6 +167,10 @@ prepare() {
 
   apply_patch_with_msg \
     2001-fix-building-rust-on-mingw-w64.patch
+
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115038
+  apply_patch_with_msg \
+    3001-fix-ice.patch
 
   # do not expect ${prefix}/mingw symlink - this should be superceded by
   # 0005-Windows-Don-t-ignore-native-system-header-dir.patch .. but isn't!


### PR DESCRIPTION
Patch taken from https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115038#c4

Fixes #20879
Fixes #20864
Fixes #20861