### PR TITLE
notepad++: Update to 8.6.7

### DIFF
--- a/mingw-w64-notepad++/PKGBUILD
+++ b/mingw-w64-notepad++/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=notepad++
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=8.6.6
+pkgver=8.6.7
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -24,7 +24,7 @@ source=(
 )
 validpgpkeys=('14BCE4362749B2B51F8C71226C429F1D8D84F46E')
 sha256sums=(
-  'b3f6638c87a1188f34861ef5edfef12aeb63a45e7366953f933ea693418b983d'
+  'f062e0eca6a2ff754d3769d9c2d8c3d8ab710eecbab575ebe7f243358f1320f6'
   'bbb81ac3893a3701cdf6a193666d063b223bffcae4f78bf6e09ad81099ece508'
   'f4468e0fa0e476fc77282cb0b3cff845ed8bce91a816a7c04e8d272abf5c5b1c'
   '2643cce3dbd5fcb65481be4afe7bf6fdea084cde134e04b38dd07239e1f09d59'


### PR DESCRIPTION
Release note:
https://notepad-plus-plus.org/news/v867-released/