### PR TITLE
starship: update to 1.19.0

### DIFF
--- a/mingw-w64-starship/PKGBUILD
+++ b/mingw-w64-starship/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=starship
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.18.2
+pkgver=1.19.0
 pkgrel=1
 pkgdesc="The cross-shell prompt for astronauts (mingw-w64)"
 arch=('any')
@@ -16,13 +16,11 @@ msys2_references=(
 )
 license=('spdx:ISC')
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
-             "${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-pkgconf"
-             "${MINGW_PACKAGE_PREFIX}-zlib")
+             "${MINGW_PACKAGE_PREFIX}-cmake")
 optdepends=("${MINGW_PACKAGE_PREFIX}-ttf-font-nerd: Nerd Font Symbols preset")
 options=('!strip' '!lto') # done at build stage
 source=("https://github.com/starship/starship/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('505100002efe93dbff702edd82f814cadc340335487993e76dd6777dba461a7a')
+sha256sums=('cf789791b5c11d6d7a00628590696627bb8f980e3d7c7a0200026787b08aba37')
 noextract=("${_realname}-${pkgver}.tar.gz")
 
 prepare() {
@@ -32,15 +30,10 @@ prepare() {
   cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
 }
 
-_env() {
-  export LIBZ_SYS_STATIC=0
-  export WINAPI_NO_BUNDLED_LIBRARIES=1
-}
-
 build() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
-  _env
+  export WINAPI_NO_BUNDLED_LIBRARIES=1
   ${MINGW_PREFIX}/bin/cargo build \
     --release \
     --frozen
@@ -49,7 +42,7 @@ build() {
 package() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
-  _env
+  export WINAPI_NO_BUNDLED_LIBRARIES=1
   ${MINGW_PREFIX}/bin/cargo install \
     --frozen \
     --offline \


### PR DESCRIPTION
zlib can't be linked statically nor dynamically as starship also uses `libz-ng-sys`: https://github.com/rust-lang/libz-sys/blob/main/build.rs#L16