### PR TITLE
gnustep-base: patch in some xml fixes from main branch of gnustep-base

### DIFF
--- a/mingw-w64-gnustep-base/PKGBUILD
+++ b/mingw-w64-gnustep-base/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gnustep-base
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.29.0
-pkgrel=6
+pkgrel=7
 pkgdesc="GNUstep Base library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64')
@@ -40,13 +40,17 @@ source=("https://github.com/gnustep/libs-base/releases/download/base-${pkgver//.
         # https://github.com/gnustep/libs-base/pull/303, merged
         'https://github.com/gnustep/libs-base/commit/fe863c981d61e50e3ea9cbe7f2b23135c1f2faf1.patch'
         # Fix undeclared function in config check
-        'https://github.com/gnustep/libs-base/commit/87fc1f5e2e4094f49b330bece89ba8aa4436c684.patch')
+        'https://github.com/gnustep/libs-base/commit/87fc1f5e2e4094f49b330bece89ba8aa4436c684.patch'
+        # Two small xml fixes
+        # https://github.com/gnustep/libs-base/pull/405, merged
+        'https://github.com/gnustep/libs-base/commit/0935f77d8f0a31ba24c9758bf6da3d84d750e7b0.patch')
 sha256sums=('fa58eda665c3e0b9c420dc32bb3d51247a407c944d82e5eed1afe8a2b943ef37'
             'a7a3bad7bda7e63599677294f0ee0b2273b680168b6fd9b4b4c5618ba8a184d5'
             '2a325471df00494a2ff7b87a954e7ecee2e45c31296636326880a78078fa249f'
             'ceb7cfc82ff3801e82e12b791f18c04c42ba3ab9ee0cc79ee453c157bf89d8d0'
             '0026c621970d40f80eb007159ed07ec471cca2d06ca31c245912ac6ca0a95656'
-            '5673a594ddcd5010d099d8878ec20f3895914e96a00fe00bbf8101a507f323c3')
+            '5673a594ddcd5010d099d8878ec20f3895914e96a00fe00bbf8101a507f323c3'
+            '600c9a319bf6e7ab81e62e0450d5aee9761d2f6ac08d60b8bf5047128f279292')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -56,6 +60,7 @@ prepare() {
   patch -p1 -i ${srcdir}/9041539ea25274cf92b7a3489ed5b03762d4af3f.patch
   patch -p1 -i ${srcdir}/fe863c981d61e50e3ea9cbe7f2b23135c1f2faf1.patch
   patch -p1 -i ${srcdir}/87fc1f5e2e4094f49b330bece89ba8aa4436c684.patch
+  patch -p1 -i ${srcdir}/0935f77d8f0a31ba24c9758bf6da3d84d750e7b0.patch
 }
 
 build() {


### PR DESCRIPTION
Adds patch for the merge commit from https://github.com/gnustep/libs-base/pull/405 to msys2 `gnustep-base` package

cc @qmfrederik 