### PR TITLE
kicad: update to 8.0.2

### DIFF
--- a/mingw-w64-kicad-doc/PKGBUILD
+++ b/mingw-w64-kicad-doc/PKGBUILD
@@ -15,8 +15,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-ca"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-pl"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-ru"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-zh")
-pkgver=8.0.0
-_rcver=rc3
+pkgver=8.0.2
 pkgrel=1
 pkgdesc="Documentation for KiCad (mingw-w64)"
 arch=(any)
@@ -30,11 +29,21 @@ makedepends=()
 optdepends=("${MINGW_PACKAGE_PREFIX}-kicad-meta"
             "${MINGW_PACKAGE_PREFIX}-kicad")
 
-source=("https://kicad-downloads.s3.cern.ch/docs/kicad-doc-${pkgver}-${_rcver}.tar.gz")
-sha256sums=('accc555691321a20185c01f37af55d5ede8f46b5662762c47d53a0f496094e48')
+# Latest available doc tarball from previously used source is for 8.0.0-rc3:
+# https://kicad-downloads.s3.cern.ch/docs/kicad-doc-8.0.0-rc3.tar.gz
+# Use the more current build artifact from the release tag instead:
+# https://gitlab.com/kicad/services/kicad-doc/-/artifacts
+source=("${_realname}-${pkgver}.zip::https://gitlab.com/kicad/services/kicad-doc/-/jobs/6731879825/artifacts/download")
+sha256sums=('8b12ccd6eb09c3ebd76e193f71b0bda88649fe0cfbb7e217915407ef5faeb34a')
+
+prepare() {
+  cd ${srcdir}
+
+  tar -xzf ${srcdir}/archive/kicad-doc-unknown.tar.gz -C ${srcdir}
+}
 
 build_lang() {
-  cd "${srcdir}/kicad-doc-${pkgver}-${_rcver}/share/doc/kicad/help"
+  cd "${srcdir}/kicad-doc-unknown/share/doc/kicad/help"
   mkdir -p "${pkgdir}${MINGW_PREFIX}/share/doc/kicad/help/"
   cp -R ${langid} "${pkgdir}${MINGW_PREFIX}/share/doc/kicad/help/"
 }

--- a/mingw-w64-kicad-doc/PKGBUILD
+++ b/mingw-w64-kicad-doc/PKGBUILD
@@ -15,7 +15,8 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-ca"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-pl"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-ru"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-zh")
-pkgver=7.0.10
+pkgver=8.0.0
+_rcver=rc3
 pkgrel=1
 pkgdesc="Documentation for KiCad (mingw-w64)"
 arch=(any)
@@ -29,11 +30,11 @@ makedepends=()
 optdepends=("${MINGW_PACKAGE_PREFIX}-kicad-meta"
             "${MINGW_PACKAGE_PREFIX}-kicad")
 
-source=("https://kicad-downloads.s3.cern.ch/docs/kicad-doc-${pkgver}.tar.gz")
-sha256sums=('5f48e580e9e917e9442d7a3b2a500e921d1e6e5f80f77efdd1629dbe555ca77a')
+source=("https://kicad-downloads.s3.cern.ch/docs/kicad-doc-${pkgver}-${_rcver}.tar.gz")
+sha256sums=('accc555691321a20185c01f37af55d5ede8f46b5662762c47d53a0f496094e48')
 
 build_lang() {
-  cd "${srcdir}/kicad-doc-${pkgver}/share/doc/kicad/help"
+  cd "${srcdir}/kicad-doc-${pkgver}-${_rcver}/share/doc/kicad/help"
   mkdir -p "${pkgdir}${MINGW_PREFIX}/share/doc/kicad/help/"
   cp -R ${langid} "${pkgdir}${MINGW_PREFIX}/share/doc/kicad/help/"
 }

--- a/mingw-w64-kicad-library/PKGBUILD
+++ b/mingw-w64-kicad-library/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-footprints"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-templates"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-packages3D"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-meta")
-pkgver=7.0.10
+pkgver=8.0.2
 pkgrel=1
 pkgdesc="Support libraries for KiCad (mingw-w64)"
 arch=('any')
@@ -26,10 +26,10 @@ source=("https://gitlab.com/kicad/libraries/kicad-footprints/-/archive/${pkgver}
         "https://gitlab.com/kicad/libraries/kicad-symbols/-/archive/${pkgver}/kicad-symbols-${pkgver}.tar.bz2"
         "https://gitlab.com/kicad/libraries/kicad-templates/-/archive/${pkgver}/kicad-templates-${pkgver}.tar.bz2"
         "https://gitlab.com/kicad/libraries/kicad-packages3D/-/archive/${pkgver}/kicad-packages3D-${pkgver}.tar.bz2")
-sha256sums=('369771dd04e36c7bd4e24e82526db0a1972b0a4f721eb12f664c010ae99ec290'
-            '510c145d07fea3d57097783208f7befa2aff4e087dc2d684f623710b829585d5'
-            'b55381038863ebe627c4c2552c36ad7eeab0ae36861a2ce0aa56c9b334cad8fe'
-            '9ca3119afe9d3d99bd7ef540471a13092d423f6fda88e661388c0b6ced65c072')
+sha256sums=('ec957fcc7a59adaa7b30b541274b261ac7077918670ccd0382ece9fd11ba0bdf'
+            'c8b8e79d76b3bb3768e42c3f084489abb489a81b3e404efef518d69eada08831'
+            '6aeefadd69f9a24cc63dcd460266d721ddfad5faf2e4c9d0c47ecdbfcdeb4fbf'
+            '2bb1df0bbf054fa0c89206770322c30079f6b5f36ea70024be155deab9ca1d21')
 
 build() {
   declare -a _extra_config

--- a/mingw-w64-kicad/PKGBUILD
+++ b/mingw-w64-kicad/PKGBUILD
@@ -8,8 +8,8 @@ _realname=kicad
 _wx_basever=3.2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=8.0.0
-pkgrel=2
+pkgver=8.0.2
+pkgrel=1
 pkgdesc="Software for the creation of electronic schematic diagrams and printed circuit board artwork (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -69,7 +69,7 @@ source=(
   '005-clang-fmt-workaround.patch'
   '006-ki-6.0-rewrite-kiwin32_rc_for_clang.patch'
 )
-sha256sums=('aee1630aac44ab181cedd293a54c339f623361cb6d5b374c27ca5389f80a28b6'
+sha256sums=('7d26964384300a260b7975207a6ac28d393aeb270d1b837f9eadba95ab940465'
             '2924a86849c02aecd21cded0bd2069353fca33c3364f9b41f9bfdd80e19085cf'
             'd8d5f4bdd0aa6d8a907710c523f6f95840636cb2ef69e5275c6ed4966f134353'
             'f35a96c2393c21c266dbcd42616df64f9ee13b2423478bf6de029a3ad4e0ee8a'
@@ -87,9 +87,6 @@ apply_patch_with_msg() {
 
 prepare() {
   cd ${_realname}-${pkgver}
-  # https://gitlab.com/kicad/code/kicad/-/commit/aa3e2988
-  #apply_patch_with_msg \
-  #  001-Kicad-manager-build-the-PLUGIN_CONTENT_MANAGER-only-on-request.patch
 
   apply_patch_with_msg \
     002-ki-6.0-cmake-fixes-for-MINGW-CLANG.patch \


### PR DESCRIPTION
The newest doc tarball that I could find is for version 8.0.0-rc3.

Does someone know where newer doc tarballs could be found?
Should we remove the doc packages? Users could still find the online documentation.

