### PR TITLE
curl: enable http3

### DIFF
--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -3,10 +3,11 @@
 _realname=curl
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
-         "${MINGW_PACKAGE_PREFIX}-${_realname}-gnutls"
-         "${MINGW_PACKAGE_PREFIX}-${_realname}-winssl")
+         $([[ ${CARCH} == i686 ]] || echo \
+           "${MINGW_PACKAGE_PREFIX}-${_realname}-gnutls" \
+           "${MINGW_PACKAGE_PREFIX}-${_realname}-winssl"))
 pkgver=8.8.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Command line tool and library for transferring data with URLs (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -24,14 +25,15 @@ license=("spdx:MIT")
 _cert_depends=("${MINGW_PACKAGE_PREFIX}-ca-certificates"
                "${MINGW_PACKAGE_PREFIX}-libssh2")
 _openssl_depends=("${MINGW_PACKAGE_PREFIX}-openssl"
-                  "${MINGW_PACKAGE_PREFIX}-nghttp2")
+                  "${MINGW_PACKAGE_PREFIX}-nghttp2"
+                  $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-nghttp3"))
 _gnutls_depends=("${MINGW_PACKAGE_PREFIX}-rtmpdump"
                  "${MINGW_PACKAGE_PREFIX}-gnutls")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools"
              "${_cert_depends[@]}"
              "${_openssl_depends[@]}"
-             "${_gnutls_depends[@]}")
+             $([[ ${CARCH} == i686 ]] || echo "${_gnutls_depends[@]}"))
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-c-ares"
          "${MINGW_PACKAGE_PREFIX}-brotli"
@@ -81,10 +83,12 @@ prepare() {
 
 do_build() {
   _variant=$1
+
   _destdir="${srcdir}/build-${MSYSTEM}"
   if [ "${_variant}" != "-openssl" ]; then
     _destdir="${_destdir}${_variant}"
   fi
+
   local -a extra_config
   if check_option "debug" "y"; then
     extra_config+=( --enable-debug )
@@ -109,19 +113,18 @@ do_build() {
   elif [ "${_variant}" = "-openssl" ]; then
     _variant_config+=("--with-default-ssl-backend=openssl")
     _variant_config+=("--with-openssl")
-    _variant_config+=("--with-schannel")
     _variant_config+=("--with-ca-bundle=${MINGW_PREFIX}/etc/ssl/certs/ca-bundle.crt")
     _variant_config+=("--with-nghttp2=${MINGW_PREFIX}")
     _variant_config+=("--without-librtmp")
+    if [[ ${CARCH} != i686 ]]; then
+      _variant_config+=("--with-openssl-quic" "--with-nghttp3=${MINGW_PREFIX}")
+    fi
   fi
 
-  msg2 "Building static library"
+  msg2 "Building static library for curl${_variant}"
   mkdir -p "${_destdir}-static" && cd "${_destdir}-static"
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
-    --build=${MINGW_CHOST} \
-    --host=${MINGW_CHOST} \
-    --target=${MINGW_CHOST} \
     --disable-pthreads \
     --without-random \
     --enable-static \
@@ -135,18 +138,15 @@ do_build() {
     --with-zstd \
     "${_variant_config[@]}" \
     "${extra_config[@]}"
-# there's a bug with zsh completion generation script and Windows.
-# curl has to be specified with the file extension.
+  # there's a bug with zsh completion generation script and Windows.
+  # curl has to be specified with the file extension.
   sed -i "s|\/curl > \$\@|\/curl\$\{EXEEXT\} > \$\@|" scripts/Makefile
   make
 
-  msg2 "Building shared library"
+  msg2 "Building shared library for curl${_variant}"
   mkdir -p "${_destdir}-shared" && cd "${_destdir}-shared"
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
-    --build=${MINGW_CHOST} \
-    --host=${MINGW_CHOST} \
-    --target=${MINGW_CHOST} \
     --disable-pthreads \
     --without-random \
     --disable-static \
@@ -160,16 +160,18 @@ do_build() {
     --with-zstd \
     "${_variant_config[@]}" \
     "${extra_config[@]}"
-# there's a bug with zsh completion generation script and Windows.
-# curl has to be specified with the file extension.
+  # there's a bug with zsh completion generation script and Windows.
+  # curl has to be specified with the file extension.
   sed -i "s|\/curl > \$\@|\/curl\$\{EXEEXT\} > \$\@|" scripts/Makefile
   make
 }
 
 build() {
   do_build -openssl
-  do_build -winssl
-  do_build -gnutls
+  if [[ ${CARCH} != i686 ]]; then
+    do_build -winssl
+    do_build -gnutls
+  fi
 }
 
 do_package() {


### PR DESCRIPTION
Enabling nghttp3 requires enabling openssl-quic or ngtcp2. I have enabled openssl-quic following Arch.
openssl-quci requires to use a single ssl backend which requires to disable `schannel` with openssl backend.