### PR TITLE
cmake: add an option to find static libraries

### DIFF
--- a/mingw-w64-cmake/0007-add-option-to-find-static-libraries.patch
+++ b/mingw-w64-cmake/0007-add-option-to-find-static-libraries.patch
@@ -1,0 +1,15 @@
+--- a/Modules/Platform/Windows-GNU.cmake
++++ b/Modules/Platform/Windows-GNU.cmake
+@@ -43,7 +43,11 @@
+ set(CMAKE_EXTRA_LINK_EXTENSIONS ".lib") # MinGW can also link to a MS .lib
+ 
+ set(CMAKE_FIND_LIBRARY_PREFIXES "lib" "")
+-set(CMAKE_FIND_LIBRARY_SUFFIXES ".dll.a" ".a" ".lib")
++if(NOT CMAKE_FIND_STATIC_LIBRARIES)
++  set(CMAKE_FIND_LIBRARY_SUFFIXES "${CMAKE_IMPORT_LIBRARY_SUFFIX}" "${CMAKE_STATIC_LIBRARY_SUFFIX}" "${CMAKE_EXTRA_LINK_EXTENSIONS}")
++else()
++  set(CMAKE_FIND_LIBRARY_SUFFIXES "${CMAKE_STATIC_LIBRARY_SUFFIX}" "${CMAKE_IMPORT_LIBRARY_SUFFIX}" "${CMAKE_EXTRA_LINK_EXTENSIONS}")
++endif()
+ set(CMAKE_C_STANDARD_LIBRARIES_INIT "-lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32")
+ set(CMAKE_CXX_STANDARD_LIBRARIES_INIT "${CMAKE_C_STANDARD_LIBRARIES_INIT}")
+ 

--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -14,7 +14,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.29.3
 _rc=""
 _pkgver=${pkgver}${_rc}
-pkgrel=3
+pkgrel=4
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -55,14 +55,16 @@ source=("https://github.com/Kitware/CMake/releases/download/v${_pkgver}/${_realn
         "0003-fix-find-python-on-mingw-aarch64.patch"
         "0004-Output-line-numbers-in-callstacks.patch"
         "0005-Default-to-ninja-generator.patch"
-        "0006-fix-c++-module-mapper-line-endings-for-mingw-w64-gcc.patch::https://gitlab.kitware.com/cmake/cmake/-/commit/9e2f31ec.patch")
+        "0006-fix-c++-module-mapper-line-endings-for-mingw-w64-gcc.patch::https://gitlab.kitware.com/cmake/cmake/-/commit/9e2f31ec.patch"
+        "0007-add-option-to-find-static-libraries.patch")
 sha256sums=('252aee1448d49caa04954fd5e27d189dd51570557313e7b281636716a238bccb'
             '25793edcbac05bb6d17fa9947b52ace4a6b5ccccf7758e22ae9ae022ed089061'
             'f6cf6a6f2729db2b9427679acd09520af2cd79fc26900b19a49cead05a55cd1a'
             '557b5cbc05d4d50b3a67a7892391fcaa5cd95c492cdb4338d86305d1f4a3b88a'
             '15fdf3fb1a0f1c153c8cfbdd2b5c64035b7a04de618bfe61d7d74ced0d6a5c4b'
             '426818278090704d2a12f62ef3dfd94c47b11fa2784bb842989b7f6a09ee7aa2'
-            'c83506e8a4e76a28ccf99aad85a340beb2090b428a3f9714d772125fe37a591e')
+            'c83506e8a4e76a28ccf99aad85a340beb2090b428a3f9714d772125fe37a591e'
+            'b7e06930ae8576776a9b9734d10b776a052a335b69c82eda90548ecf243c6407')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -90,7 +92,8 @@ prepare() {
     0002-Do-not-install-Qt-bundle-in-cmake-gui.patch \
     0003-fix-find-python-on-mingw-aarch64.patch \
     0004-Output-line-numbers-in-callstacks.patch \
-    0006-fix-c++-module-mapper-line-endings-for-mingw-w64-gcc.patch
+    0006-fix-c++-module-mapper-line-endings-for-mingw-w64-gcc.patch \
+    0007-add-option-to-find-static-libraries.patch
 
   # We want cmake to default to something useful and not MSVC
   apply_patch_with_msg \


### PR DESCRIPTION
The user has to pass `-DCMAKE_FIND_STATIC_LIBRARIES=ON` to find static libraries instead of shared ones.