### PR TITLE
curl: enable unity builds

### DIFF
--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
            "${MINGW_PACKAGE_PREFIX}-${_realname}-gnutls" \
            "${MINGW_PACKAGE_PREFIX}-${_realname}-winssl"))
 pkgver=8.8.0
-pkgrel=4
+pkgrel=5
 pkgdesc="Command line tool and library for transferring data with URLs (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -132,6 +132,7 @@ do_build() {
       -GNinja \
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       -DCMAKE_FIND_STATIC_LIBRARIES=ON \
+      -DCMAKE_UNITY_BUILD=ON \
       "${_extra_config[@]}" \
       "${_variant_config[@]}" \
       -DPICKY_COMPILER=OFF \
@@ -154,6 +155,7 @@ do_build() {
       -GNinja \
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       -DCMAKE_DLL_NAME_WITH_SOVERSION=ON \
+      -DCMAKE_UNITY_BUILD=ON \
       "${_extra_config[@]}" \
       "${_variant_config[@]}" \
       -DPICKY_COMPILER=OFF \


### PR DESCRIPTION
It's supported and tested upstream, so why not.
See https://github.com/msys2/MINGW-packages/pull/21013#issuecomment-2138006836