### PR TITLE
CI: do a treeless clone in case we need the history

### DIFF
--- a/.github/workflows/generate-srcinfo.yml
+++ b/.github/workflows/generate-srcinfo.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
 
       - uses: actions/setup-python@v5
         id: setup-python

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           path: temp
           fetch-depth: 0
+          filter: tree:0
           persist-credentials: false
 
       # to match the autobuild environment

--- a/mingw-w64-glab/PKGBUILD
+++ b/mingw-w64-glab/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=glab
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.40.0
+pkgver=1.41.0
 pkgrel=1
 pkgdesc='Cli tool to help work seamlessly with GitLab from the command line (mingw-w64)'
 arch=('any')
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-go"
 optdepends=("git: To interact with repositories")
 options=('!strip')
 source=("https://gitlab.com/gitlab-org/cli/-/archive/v${pkgver}/cli-v${pkgver}.tar.gz")
-sha256sums=('0e426a4b0b1945fa16b504c2245a9a525e0b4a858565e482d934b481163d87b5')
+sha256sums=('3531455facae3a9695e2826277040157e8a337ee7eb7e212e054d7ffc61bc7db')
 
 build() {
     cd "cli-v${pkgver}"


### PR DESCRIPTION
For cases where we pass "fetch-depth: 0" to get the full history, enable a treeless clone, since we only care about old commits, and not much more.

This should speed up cloning in theory.