### PR TITLE
[new package] cminpack

### DIFF
--- a/mingw-w64-cminpack/PKGBUILD
+++ b/mingw-w64-cminpack/PKGBUILD
@@ -1,0 +1,82 @@
+# Maintainer: luau-project <luau.project@gmail.com>
+
+_realname=cminpack
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.3.9
+pkgrel=1
+pkgdesc="A C/C++ rewrite of the MINPACK software for solving nonlinear equations and nonlinear least squares problems (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='http://devernay.free.fr/hacks/cminpack'
+license=('spdx:Minpack')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
+source=("https://github.com/devernay/cminpack/archive/v1.3.9.tar.gz")
+sha256sums=("aa37bac5b5caaa4f5805ea5c4240e3834c993672f6dab0b17190ee645e251c9f")
+
+prepare() {
+  # on Windows, EOL must be CRLF (\r\n)
+  # for reference test files,
+  # but the tarball is packed with LF (\n).
+  # So, we replace LF with CRLF.
+  for ref in ./${_realname}-${pkgver}/examples/ref/*.ref;
+  do
+    mv $ref $ref.bak;
+    unix2dos -n $ref.bak $ref;
+  done
+}
+
+build() {
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  # Configure the static version
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  "${MINGW_PREFIX}"/bin/cmake.exe \
+    -G Ninja \
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+    "${extra_config[@]}" \
+    -DUSE_BLAS=OFF \
+    -DBUILD_SHARED_LIBS=OFF \
+    -S "${_realname}-${pkgver}" \
+    -B build-${MSYSTEM}-static
+
+  "${MINGW_PREFIX}"/bin/cmake.exe --build build-${MSYSTEM}-static
+
+  # Configure the shared version
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  "${MINGW_PREFIX}"/bin/cmake.exe \
+    -G Ninja \
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+    "${extra_config[@]}" \
+    -DUSE_BLAS=OFF \
+    -DBUILD_SHARED_LIBS=ON \
+    -S "${_realname}-${pkgver}" \
+    -B build-${MSYSTEM}-shared
+
+  "${MINGW_PREFIX}"/bin/cmake.exe --build build-${MSYSTEM}-shared
+}
+
+check() {
+  # test the static version
+  "${MINGW_PREFIX}"/bin/cmake.exe --build build-${MSYSTEM}-static --target test
+
+  # test the shared version
+  "${MINGW_PREFIX}"/bin/cmake.exe --build build-${MSYSTEM}-shared --target test
+}
+
+package() {
+  # install the static version
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install build-${MSYSTEM}-static
+
+  # install the shared version
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install build-${MSYSTEM}-shared
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/CopyrightMINPACK.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}

--- a/mingw-w64-cminpack/PKGBUILD
+++ b/mingw-w64-cminpack/PKGBUILD
@@ -13,21 +13,6 @@ license=('spdx:Minpack')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
-<<<<<<< HEAD
-source=("https://github.com/devernay/cminpack/archive/v1.3.9.tar.gz")
-sha256sums=("aa37bac5b5caaa4f5805ea5c4240e3834c993672f6dab0b17190ee645e251c9f")
-
-prepare() {
-  # on Windows, EOL must be CRLF (\r\n)
-  # for reference test files,
-  # but the tarball is packed with LF (\n).
-  # So, we replace LF with CRLF.
-  for ref in ./${_realname}-${pkgver}/examples/ref/*.ref;
-  do
-    mv $ref $ref.bak;
-    unix2dos -n $ref.bak $ref;
-  done
-=======
 source=("https://github.com/devernay/cminpack/archive/v1.3.9.tar.gz"
         "001-fix-cmake-eol-for-tests.patch"
         "002-fix-pkg-config.patch")
@@ -40,7 +25,6 @@ prepare() {
 
   patch -Np1 -i "${srcdir}"/001-fix-cmake-eol-for-tests.patch
   patch -Np1 -i "${srcdir}"/002-fix-pkg-config.patch
->>>>>>> cminpack-update
 }
 
 build() {
@@ -51,33 +35,13 @@ build() {
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
-<<<<<<< HEAD
-  # Configure the static version
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   "${MINGW_PREFIX}"/bin/cmake.exe \
     -G Ninja \
     -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
     "${extra_config[@]}" \
     -DUSE_BLAS=OFF \
-    -DBUILD_SHARED_LIBS=OFF \
-    -S "${_realname}-${pkgver}" \
-    -B build-${MSYSTEM}-static
-
-  "${MINGW_PREFIX}"/bin/cmake.exe --build build-${MSYSTEM}-static
-
-  # Configure the shared version
-=======
->>>>>>> cminpack-update
-  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-  "${MINGW_PREFIX}"/bin/cmake.exe \
-    -G Ninja \
-    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
-    "${extra_config[@]}" \
-    -DUSE_BLAS=OFF \
-<<<<<<< HEAD
-=======
     -DCMINPACK_PRECISION=d \
->>>>>>> cminpack-update
     -DBUILD_SHARED_LIBS=ON \
     -S "${_realname}-${pkgver}" \
     -B build-${MSYSTEM}-shared
@@ -86,24 +50,10 @@ build() {
 }
 
 check() {
-<<<<<<< HEAD
-  # test the static version
-  "${MINGW_PREFIX}"/bin/cmake.exe --build build-${MSYSTEM}-static --target test
-
-  # test the shared version
-=======
->>>>>>> cminpack-update
   "${MINGW_PREFIX}"/bin/cmake.exe --build build-${MSYSTEM}-shared --target test
 }
 
 package() {
-<<<<<<< HEAD
-  # install the static version
-  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install build-${MSYSTEM}-static
-
-  # install the shared version
-=======
->>>>>>> cminpack-update
   DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install build-${MSYSTEM}-shared
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/CopyrightMINPACK.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"

--- a/mingw-w64-xz/PKGBUILD
+++ b/mingw-w64-xz/PKGBUILD
@@ -5,7 +5,7 @@ _realname=xz
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.6.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Library and command line tools for XZ and LZMA compressed files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -42,7 +42,8 @@ build() {
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --disable-rpath \
-    --disable-lzma-links
+    --disable-lzma-links \
+    --enable-doxygen
 
   make
 }


### PR DESCRIPTION
## Description

According to the description given by the author Frédéric Devernay on [https://github.com/devernay/cminpack](https://github.com/devernay/cminpack), **cminpack** is a C/C++ rewrite of the MINPACK software (originally in FORTRAN) for solving nonlinear equations and nonlinear least squares problems.

## Positive points

* cminpack is a mature library, which has been around for almost 20 years;
* reentrant code;
* API is more user friendly than that one found in the original Fortran minpack;
* Eigen (a scientific library) mentions to have used cminpack in their implementation of nonlinear optimization [https://eigen.tuxfamily.org/dox/unsupported/index.html](https://eigen.tuxfamily.org/dox/unsupported/index.html), [https://gitlab.com/libeigen/eigen/-/blob/master/unsupported/Eigen/NonLinearOptimization?ref_type=heads#L45](https://gitlab.com/libeigen/eigen/-/blob/master/unsupported/Eigen/NonLinearOptimization?ref_type=heads#L45);
* Available on a large number of repositories (Debian, Ubuntu, Fedora, Arch) for almost a decade [https://repology.org/project/cminpack/versions](https://repology.org/project/cminpack/versions).

## Website

[http://devernay.free.fr/hacks/cminpack/](http://devernay.free.fr/hacks/cminpack/)