### PR TITLE
GNUstep: update packages to the latest releases

### DIFF
--- a/mingw-w64-gnustep-back/PKGBUILD
+++ b/mingw-w64-gnustep-back/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=gnustep-back
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.30.0
-pkgrel=3
+pkgver=0.31.0
+pkgrel=1
 pkgdesc="GNUstep GUI Backend (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64')
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
 depends=("${MINGW_PACKAGE_PREFIX}-gnustep-gui"
          "${MINGW_PACKAGE_PREFIX}-cairo")
 source=("https://github.com/gnustep/libs-back/releases/download/back-${pkgver//./_}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('60177d44beebd0216be4aa7eea6cf009cf9ff844bc35f0eacd622bf710372cff')
+sha256sums=('04ca1a2d0b46f79b4dfd47c17d7e06f41d079cc5e1dbb45c239f7c3dec95d2ee')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -27,6 +27,8 @@ prepare() {
 build() {
   rsync --recursive --times --links "${srcdir}/${_realname}-${pkgver}"/* "${srcdir}/build-${MSYSTEM}"
   cd "${srcdir}/build-${MSYSTEM}"
+
+  . ${MINGW_PREFIX}/share/GNUstep/Makefiles/GNUstep.sh
 
   LDFLAGS="-fuse-ld=lld -lstdc++ -lgcc_s" \
   CC="$MINGW_PREFIX/bin/clang" \

--- a/mingw-w64-gnustep-base/PKGBUILD
+++ b/mingw-w64-gnustep-base/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gnustep-base
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.29.0
+pkgver=1.30.0
 pkgrel=8
 pkgdesc="GNUstep Base library (mingw-w64)"
 arch=('any')
@@ -28,41 +28,16 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-zlib"
 )
 source=("https://github.com/gnustep/libs-base/releases/download/base-${pkgver//./_}/${_realname}-${pkgver}.tar.gz"
-        # Fix GSXML compatibility with libxml2 v2.11.0
-        # https://github.com/gnustep/libs-base/pull/295, merged
-        "https://github.com/gnustep/libs-base/commit/37913d006d96a6bdcb963f4ca4889888dcce6094.patch"
         # Use absolute paths in ./configure
         # https://github.com/gnustep/libs-base/pull/371, in review
-        "https://github.com/gnustep/libs-base/commit/2039840e0e1f013f2d73deb6e083b88987cfa6af.patch"
-        # MinGW: Add dllimport/dllexport attributes when compiling with clang
-        # https://github.com/gnustep/libs-base/pull/363, merged
-        "https://github.com/gnustep/libs-base/commit/9041539ea25274cf92b7a3489ed5b03762d4af3f.patch"
-        # Fix incompatible function pointer types in config check
-        # https://github.com/gnustep/libs-base/pull/303, merged
-        'https://github.com/gnustep/libs-base/commit/fe863c981d61e50e3ea9cbe7f2b23135c1f2faf1.patch'
-        # Fix undeclared function in config check
-        'https://github.com/gnustep/libs-base/commit/87fc1f5e2e4094f49b330bece89ba8aa4436c684.patch'
-        # Two small xml fixes
-        # https://github.com/gnustep/libs-base/pull/405, merged
-        'https://github.com/gnustep/libs-base/commit/0935f77d8f0a31ba24c9758bf6da3d84d750e7b0.patch')
-sha256sums=('fa58eda665c3e0b9c420dc32bb3d51247a407c944d82e5eed1afe8a2b943ef37'
-            'a7a3bad7bda7e63599677294f0ee0b2273b680168b6fd9b4b4c5618ba8a184d5'
-            '2a325471df00494a2ff7b87a954e7ecee2e45c31296636326880a78078fa249f'
-            'ceb7cfc82ff3801e82e12b791f18c04c42ba3ab9ee0cc79ee453c157bf89d8d0'
-            '0026c621970d40f80eb007159ed07ec471cca2d06ca31c245912ac6ca0a95656'
-            '5673a594ddcd5010d099d8878ec20f3895914e96a00fe00bbf8101a507f323c3'
-            '600c9a319bf6e7ab81e62e0450d5aee9761d2f6ac08d60b8bf5047128f279292')
+        "https://github.com/gnustep/libs-base/commit/2039840e0e1f013f2d73deb6e083b88987cfa6af.patch")
+sha256sums=('00b5bc4179045b581f9f9dc3751b800c07a5d204682e3e0eddd8b5e5dee51faa'
+            '2a325471df00494a2ff7b87a954e7ecee2e45c31296636326880a78078fa249f')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
-  patch -p1 -i ${srcdir}/37913d006d96a6bdcb963f4ca4889888dcce6094.patch
   patch -p1 -i ${srcdir}/2039840e0e1f013f2d73deb6e083b88987cfa6af.patch
-  patch -p1 -i ${srcdir}/9041539ea25274cf92b7a3489ed5b03762d4af3f.patch
-  patch -p1 -i ${srcdir}/fe863c981d61e50e3ea9cbe7f2b23135c1f2faf1.patch
-  patch -p1 -i ${srcdir}/87fc1f5e2e4094f49b330bece89ba8aa4436c684.patch
-  filterdiff -x '*/ChangeLog' ${srcdir}/0935f77d8f0a31ba24c9758bf6da3d84d750e7b0.patch > ${srcdir}/filtered0935f77d8f0a31ba24c9758bf6da3d84d750e7b0.patch
-  patch -p1 -i ${srcdir}/filtered0935f77d8f0a31ba24c9758bf6da3d84d750e7b0.patch
 }
 
 build() {

--- a/mingw-w64-gnustep-gui/PKGBUILD
+++ b/mingw-w64-gnustep-gui/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gnustep-gui
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.30.0
+pkgver=0.31.0
 pkgrel=6
 pkgdesc="GNUstep GUI Library (mingw-w64)"
 arch=('any')
@@ -22,22 +22,11 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
          "${MINGW_PACKAGE_PREFIX}-libpng"
          "${MINGW_PACKAGE_PREFIX}-libtiff")
-source=("https://github.com/gnustep/libs-gui/releases/download/gui-${pkgver//./_}/${_realname}-${pkgver}.tar.gz"
-        # GifQuantizeBuffer is considered private API in libgif 5.2 and later
-        # https://github.com/gnustep/libs-gui/pull/207, merged
-        "https://github.com/gnustep/libs-gui/commit/0c5e062e46e9801746ffbbfcaab2a3cbd6d253af.patch"
-        # Make PACKAGE_SCOPE @public on MinGW
-        # https://github.com/gnustep/libs-gui/pull/242/, in review
-        "https://github.com/gnustep/libs-gui/commit/0b88dbbe321ff00298296a83d24296151a1a9b04.patch")
-sha256sums=('469dcaa54ed05b2520a704c30c0761a75b3ade8428e2e64645fb7b38a15c3cc3'
-            '5a7087b6cbd9524e228943799d352f5dcf3f9a442a27aab9f16f0e2fc75cf710'
-            '164dd40e987f69b4effdd8b9b42a3ad2e0bf01c420c2a76bdf137f9351df92bd')
+source=("https://github.com/gnustep/libs-gui/releases/download/gui-${pkgver//./_}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('09740d819216e2d8a6706b214088f298eed76bf0d8fc0d6247514b5cb49f7fdb')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
-
-  patch -p1 -i ${srcdir}/0c5e062e46e9801746ffbbfcaab2a3cbd6d253af.patch
-  patch -p1 -i ${srcdir}/0b88dbbe321ff00298296a83d24296151a1a9b04.patch
 }
 
 build() {

--- a/mingw-w64-gnustep-make/PKGBUILD
+++ b/mingw-w64-gnustep-make/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=gnustep-make
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.9.1
-pkgrel=3
+pkgver=2.9.2
+pkgrel=1
 pkgdesc="GNUstep build system (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -15,7 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-lld"
              "${MINGW_PACKAGE_PREFIX}-libobjc2")
 source=("https://github.com/gnustep/tools-make/releases/download/make-${pkgver//./_}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('c3d6e70cf156b27e7d1ed2501c57df3f96e27488ce2f351b93e479c58c01eae7')
+sha256sums=('f540df9f0e1daeb3d23b08e14b204b2a46f1d0a4005cb171c95323413806e4e1')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"

--- a/mingw-w64-libpreferencepanes/PKGBUILD
+++ b/mingw-w64-libpreferencepanes/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 # Using same naming convention as Ubuntu: https://packages.ubuntu.com/noble/libpreferencepanes1
 pkgname=("${MINGW_PACKAGE_PREFIX}-libpreferencepanes")
 pkgver=1.2.0
-pkgrel=4
+pkgrel=5
 pkgdesc="GNUstep preferences library - runtime library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64')


### PR DESCRIPTION
- gnustep-make: 2.9.1 -> 2.9.2
- gnustep-base: 1.29.0 -> 1.30.0
- gnustep-gui: 0.30.0 -> 0.31.0
- gnustep-back: 0.30.0 -> 0.31.0