### PR TITLE
Revert "imagemagick: Use native Windows thread APIs"

### DIFF
--- a/mingw-w64-imagemagick/PKGBUILD
+++ b/mingw-w64-imagemagick/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
 _basever=7.1.1
 _rc=-33
 pkgver=${_basever}${_rc//-/.} # pkgver doesn't have "," "/", "-" and space.
-pkgrel=1
+pkgrel=2
 pkgdesc="An image viewing/manipulation program (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -51,6 +51,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-bzip2"
          "${MINGW_PACKAGE_PREFIX}-libtiff"
          "${MINGW_PACKAGE_PREFIX}-libltdl"
          "${MINGW_PACKAGE_PREFIX}-libwebp"
+         "${MINGW_PACKAGE_PREFIX}-libwinpthread"
          "${MINGW_PACKAGE_PREFIX}-libwmf"
          "${MINGW_PACKAGE_PREFIX}-libxml2"
          "${MINGW_PACKAGE_PREFIX}-omp"
@@ -116,7 +117,6 @@ build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
 
   # --with-lcms2, --with-opencl, --without-ltdl
-  # --without-threads: prefer native Windows thread APIs
   ../ImageMagick-${_basever}${_rc}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
@@ -142,7 +142,6 @@ build() {
     --without-autotrace \
     --without-dps \
     --without-fpx \
-    --without-threads \
     --with-jbig \
     --without-perl \
     --without-x \


### PR DESCRIPTION

    This reverts commit 0dff9a633d6dd0cb9f117fce7c9bde311e9a39c7
    
    This was disabled due to compiler error with clang which was fixed in upstream.
    https://github.com/ImageMagick/ImageMagick/commit/2fbf9383c574d08327f7e41db50d613003857604
    https://github.com/ImageMagick/ImageMagick/commit/d32677a65e630fa4a36bd1994498234ca280cae2

Fixes #20983
