### PR TITLE
python-xlsxwriter: fix undefined version in provides

### DIFF
--- a/mingw-w64-python-xlsxwriter/PKGBUILD
+++ b/mingw-w64-python-xlsxwriter/PKGBUILD
@@ -4,11 +4,8 @@ _pyname=XlsxWriter
 _realname=xlsxwriter
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}=${pkgver}")
-conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=3.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A Python module for creating Excel XLSL files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -24,6 +21,9 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python-wheel")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
+provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}=${pkgver}")
+conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 source=("https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${pkgver}.tar.gz")
 sha256sums=('9977d0c661a72866a61f9f7a809e25ebbb0fb7036baa3b9fe74afcfca6b3cb8c')
 


### PR DESCRIPTION
Move it after pkgver is defined to fix it.

The empty version results in pacman failing to install the package since pacman 6.1

Fixes #21045