### PR TITLE
Groonga: Update to 14.0.4

### DIFF
--- a/mingw-w64-groonga/PKGBUILD
+++ b/mingw-w64-groonga/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=groonga
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=14.0.3
+pkgver=14.0.4
 pkgrel=1
 pkgdesc="An opensource fulltext search engine (mingw-w64)"
 arch=('any')
@@ -28,7 +28,7 @@ makedepends=("git"
              "${MINGW_PACKAGE_PREFIX}-rapidjson"
              "${MINGW_PACKAGE_PREFIX}-ruby"
              "${MINGW_PACKAGE_PREFIX}-xsimd")
-sha256sums=('096a71ce09bd539da440f7157792d7fac9394f4533afadc939923ed1e6d3c3e6'
+sha256sums=('f29a6e88401cdb90437164a22f6f1e8467dd6ab9c1738be71933be9cb97a46c6'
             'SKIP')
 validpgpkeys=('2701F317CFCCCB975CADE9C2624CF77434839225') # Groonga Key <packages@groonga.org>
 


### PR DESCRIPTION
Groonga version14.0.4 has just released [here](https://github.com/groonga/groonga/releases/tag/v14.0.4).