### PR TITLE
octave: update to 9.2.0

### DIFF
--- a/mingw-w64-octave/PKGBUILD
+++ b/mingw-w64-octave/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=octave
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-pkgver=9.1.0
-pkgrel=5
+pkgver=9.2.0
+pkgrel=1
 pkgdesc="GNU Octave: Interactive programming environment for numerical computations (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -33,7 +33,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-pcre2"
          "${MINGW_PACKAGE_PREFIX}-qhull"
          "${MINGW_PACKAGE_PREFIX}-qrupdate"
-         $(true && echo \
+         $([[ ${CARCH} == i686 ]] && echo \
            "${MINGW_PACKAGE_PREFIX}-qscintilla-qt5" \
            "${MINGW_PACKAGE_PREFIX}-qt5-base" \
            "${MINGW_PACKAGE_PREFIX}-qt5-tools" || echo \
@@ -62,17 +62,13 @@ optdepends=("unzip: for decompressing .zip archives"
             "${MINGW_PACKAGE_PREFIX}-gnuplot: alternative plotting"
             "${MINGW_PACKAGE_PREFIX}-portaudio: audio support")
 source=(https://ftp.gnu.org/gnu/octave/octave-$pkgver.tar.xz{,.sig}
-        "0001-correct-LIBS.patch::https://hg.savannah.gnu.org/hgweb/octave/raw-rev/557fbfea93ab"
         "0002-mk-doc-cache-path.patch"
-        "0003-no-community-support.patch"
-        "0004-gcc-14-incompatible-pointer-types.patch::https://hg.savannah.gnu.org/hgweb/octave/raw-rev/6d7e7a2faf4b")
+        "0003-no-community-support.patch")
 validpgpkeys=('DBD9C84E39FE1AAE99F04446B05F05B75D36644B')  # John W. Eaton
-sha256sums=('ed654b024aea56c44b26f131d31febc58b7cf6a82fad9f0b0bf6e3e9aa1a134b'
+sha256sums=('21417afb579105b035cac0bea09201522e384893ae90a781b8727efa32765807'
             'SKIP'
-            '71fb01e039c79781e52cf95506ad3126c9e911a5f20e796195ca84faa73e9b9c'
             'aa5bd559d9774abc0f0c930a606762d1e452cc90278d16d8ae83561c0cae3bf8'
-            'e53af21ad087e10a2906506589aab89ab8b43f4e3e4994b4c28e4d8ae83639ad'
-            'ac7ca459d708e8096b1950ee7fb5a322611985b318b242d0e8129b5977bd8871')
+            'e53af21ad087e10a2906506589aab89ab8b43f4e3e4994b4c28e4d8ae83639ad')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -86,9 +82,7 @@ prepare() {
   cd "${_realname}-${pkgver}"
 
   apply_patch_with_msg \
-    0001-correct-LIBS.patch \
-    0002-mk-doc-cache-path.patch \
-    0004-gcc-14-incompatible-pointer-types.patch
+    0002-mk-doc-cache-path.patch
 
   if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
     apply_patch_with_msg \
@@ -127,7 +121,6 @@ build() {
     --enable-shared \
     --disable-static \
     --enable-relocate-all \
-    --with-qt=5 \
     "${_extra_config[@]}" \
     octave_cv_fftw3_threads_lib="-lfftw3_omp" \
     octave_cv_fftw3f_threads_lib="-lfftw3f_omp" \


### PR DESCRIPTION
Build with Qt6 again on environments where it is available.

Drop cherry-picked patches that are part of the new release.