### PR TITLE
mesa: Update to 24.0.9

### DIFF
--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=24.0.8
+pkgver=24.0.9
 pkgrel=1
 pkgdesc="Open-source implementation of the OpenGL, Vulkan and OpenCL specifications (mingw-w64)"
 url="https://www.mesa3d.org/"
@@ -39,7 +39,7 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-opengl-man-pages: for the OpenGL API man pa
 source=(https://mesa.freedesktop.org/archive/${_realname}-${pkgver}.tar.xz{,.sig}
         0000-addrlib-workaround-old-cpu-target.patch
         0001-fix-vulkan-json-manifest-generation.patch::https://gitlab.freedesktop.org/mesa/mesa/-/commit/fe520ecf.patch)
-sha256sums=('d1ed86a266d5b7b8c136ae587ef5618ed1a9837a43440f3713622bf0123bf5c1'
+sha256sums=('51aa686ca4060e38711a9e8f60c8f1efaa516baf411946ed7f2c265cd582ca4c'
             'SKIP'
             '4e511b1ab380d0e7d1f152f89c82665e5ef7de96f26de1b5597aa1db85cfc5a4'
             '9a2a16024c52df4857d79a65161993acdfe95ca6edaa9d892ade18d5ce676989')


### PR DESCRIPTION
See #20992 for reasons we stick to 24.0. Unfortunately things did not improve with 24.1.1.