### PR TITLE
curl: Fix Requires.private field pkgconfig file

### DIFF
--- a/mingw-w64-curl/0004-more-static-fixes.patch
+++ b/mingw-w64-curl/0004-more-static-fixes.patch
@@ -1,10 +1,46 @@
+--- a/CMake/FindBrotli.cmake
++++ b/CMake/FindBrotli.cmake
+@@ -41,3 +41,4 @@
+ 
+ set(BROTLI_INCLUDE_DIRS ${BROTLI_INCLUDE_DIR})
+ set(BROTLI_LIBRARIES ${BROTLICOMMON_LIBRARY} ${BROTLIDEC_LIBRARY})
++set(LIBCURL_REQUIRES_PRIVATE "libbrotlidec ${LIBCURL_REQUIRES_PRIVATE}")
+--- a/CMake/FindNGHTTP2.cmake
++++ b/CMake/FindNGHTTP2.cmake
+@@ -37,5 +37,6 @@
+ 
+ set(NGHTTP2_INCLUDE_DIRS ${NGHTTP2_INCLUDE_DIR})
+ set(NGHTTP2_LIBRARIES ${NGHTTP2_LIBRARY})
++set(LIBCURL_REQUIRES_PRIVATE "libnghttp2 ${LIBCURL_REQUIRES_PRIVATE}")
+ 
+ mark_as_advanced(NGHTTP2_INCLUDE_DIRS NGHTTP2_LIBRARIES)
+--- a/CMake/FindNGHTTP3.cmake
++++ b/CMake/FindNGHTTP3.cmake
+@@ -73,6 +73,7 @@
+ if(NGHTTP3_FOUND)
+   set(NGHTTP3_LIBRARIES    ${NGHTTP3_LIBRARY})
+   set(NGHTTP3_INCLUDE_DIRS ${NGHTTP3_INCLUDE_DIR})
++  set(LIBCURL_REQUIRES_PRIVATE "libnghttp3 ${LIBCURL_REQUIRES_PRIVATE}")
+ endif()
+ 
+ mark_as_advanced(NGHTTP3_INCLUDE_DIRS NGHTTP3_LIBRARIES)
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -886,6 +886,7 @@
+   check_library_exists("idn2" "idn2_lookup_ul" "" HAVE_LIBIDN2)
+   if(HAVE_LIBIDN2)
+     set(CURL_LIBS "idn2;${CURL_LIBS}")
++    set(LIBCURL_REQUIRES_PRIVATE "libidn2 ${LIBCURL_REQUIRES_PRIVATE}")
+     check_include_file_concat("idn2.h" HAVE_IDN2_H)
+   endif()
+ else()
 --- a/libcurl.pc.in
 +++ b/libcurl.pc.in
 @@ -36,6 +36,8 @@
  URL: https://curl.se/
  Description: Library to transfer files with ftp, http, etc.
  Version: @CURLVERSION@
-+Requires.private: libidn2 libbrotlidec libnghttp2 libnghttp3
++Requires.private: @LIBCURL_REQUIRES_PRIVATE@
  Libs: -L${libdir} -lcurl @LIBCURL_NO_SHARED@
  Libs.private: @LIBCURL_LIBS@
  Cflags: -I${includedir} @CPPFLAG_CURL_STATICLIB@

--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
            "${MINGW_PACKAGE_PREFIX}-${_realname}-gnutls" \
            "${MINGW_PACKAGE_PREFIX}-${_realname}-winssl"))
 pkgver=8.8.0
-pkgrel=8
+pkgrel=9
 pkgdesc="Command line tool and library for transferring data with URLs (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -54,7 +54,7 @@ sha256sums=('0f58bb95fc330c8a46eeb3df5701b0d90c9d9bfcc42bd1cd08791d12551d4400'
             '1585ef1b61cf53a2ca27049c11d49e0834683dfda798f03547761375df482a90'
             'adfa29d6f427fc6154c90e6ce297879ef88dc1831a7a04497d803acf3de93eea'
             'f411ae7662fc67ff52bdc7d42a92e255e52154bb7d06251694802ba8d709319d'
-            '9f7394beffb48e36e282fab03762a7c1853fcb245f94c79f7a93607c1b243515')
+            '78a74e955ed1d0dfe9915891139cfe4feefc6c0d80fc38cf4da8697cf0d603d3')
 validpgpkeys=('27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2')  # Daniel Stenberg
 
 apply_patch_with_msg() {


### PR DESCRIPTION
This adds the reference in Requires.private when the dependencies are found. Hence, this fixes pkgconfig file in gnutls and winssl versions.