### PR TITLE
curl: exclude pathtools.c from unity mode

### DIFF
--- a/mingw-w64-curl/0001-Make-cURL-relocatable.patch
+++ b/mingw-w64-curl/0001-Make-cURL-relocatable.patch
@@ -8,6 +8,16 @@
  
  configure_file(curl_config.h.cmake
    ${CMAKE_CURRENT_BINARY_DIR}/curl_config.h)
+@@ -59,6 +60,8 @@
+   target_link_libraries(curlu PRIVATE ${CURL_LIBS})
+ endif()
+ 
++set_source_files_properties(pathtools.c PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
++
+ if(ENABLE_CURLDEBUG)
+   # We must compile these sources separately to avoid memdebug.h redefinitions
+   # applying to them.
+
 --- a/lib/curl_config.h.cmake
 +++ b/lib/curl_config.h.cmake
 @@ -35,6 +35,9 @@

--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
            "${MINGW_PACKAGE_PREFIX}-${_realname}-gnutls" \
            "${MINGW_PACKAGE_PREFIX}-${_realname}-winssl"))
 pkgver=8.8.0
-pkgrel=9
+pkgrel=10
 pkgdesc="Command line tool and library for transferring data with URLs (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -52,7 +52,7 @@ sha256sums=('0f58bb95fc330c8a46eeb3df5701b0d90c9d9bfcc42bd1cd08791d12551d4400'
             'SKIP'
             'ebf471173f5ee9c4416c10a78760cea8afaf1a4a6e653977321e8547ce7bf3c0'
             '1585ef1b61cf53a2ca27049c11d49e0834683dfda798f03547761375df482a90'
-            'adfa29d6f427fc6154c90e6ce297879ef88dc1831a7a04497d803acf3de93eea'
+            '67cafabd99ad1e636e042d052409afdfb52de4e3893b47413ad366e486c1c0a7'
             'f411ae7662fc67ff52bdc7d42a92e255e52154bb7d06251694802ba8d709319d'
             '78a74e955ed1d0dfe9915891139cfe4feefc6c0d80fc38cf4da8697cf0d603d3')
 validpgpkeys=('27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2')  # Daniel Stenberg


### PR DESCRIPTION
`pathtools.c` contains code that is also present in other static
MSYS2/mingw-w64-built libraries. To allow the linker to de-duplicate
this common object and avoid "multiple definition" linker errors, the
object must be kept separate from the rest of the library, that is
compiled into a single, "unity" object after
ee2184d939d4a99ab017b0f61222b0555d6b1467 #21021.

Ref: #21028
