### PR TITLE
rust: add split package for source code

### DIFF
--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -17,9 +17,10 @@ embed_manifest_url=https://gitlab.com/careyevans/embed-manifest/-/archive/v${emb
 _realname=rust
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
-         $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-rust-docs"))
+         $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-rust-docs")
+         "${MINGW_PACKAGE_PREFIX}-rust-src")
 pkgver=1.78.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
@@ -241,6 +242,7 @@ package_rust() {
            "${MINGW_PACKAGE_PREFIX}-curl"
            "${MINGW_PACKAGE_PREFIX}-libxml2"
            "${MINGW_PACKAGE_PREFIX}-libssh2")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-rust-src: Required for rust-analyzer component")
 
   cd "${srcdir}/${MSYSTEM}"
 
@@ -256,6 +258,8 @@ package_rust() {
   mv "${pkgdir}${MINGW_PREFIX}/etc/bash_completion.d/cargo" \
      "${pkgdir}${MINGW_PREFIX}/share/bash-completion/completions/cargo"
 
+  install -d "${srcdir}/${MSYSTEM}/dest-src${MINGW_PREFIX}/lib/rustlib/src"
+  mv src/* "${srcdir}/${MSYSTEM}/dest-src${MINGW_PREFIX}/lib/rustlib/src"
 }
 
 package_rust-docs() {
@@ -268,6 +272,13 @@ package_rust-docs() {
 
   install -d "$pkgdir"/${MINGW_PREFIX}/share/
   cp -a dest-doc "$pkgdir"/${MINGW_PREFIX}/share/doc
+}
+
+package_rust-src() {
+  pkgdesc='Source code for the Rust standard library (mingw-w64)'
+
+  cd "${srcdir}/${MSYSTEM}"
+  cp -a dest-src/* ${pkgdir}
 }
 
 # template start; name=mingw-w64-splitpkg-wrappers; version=1.0;


### PR DESCRIPTION
it's not required for a compiler, but for rust-analyzer. the same thing is already implemented in arch