### PR TITLE
glib2: copy documetation comment from gcontenttype to gcontenttype-win32

### DIFF
--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -10,7 +10,7 @@ _realname=glib2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.80.2
-pkgrel=2
+pkgrel=3
 url="https://gitlab.gnome.org/GNOME/glib"
 msys2_references=(
   "cpe: cpe:/a:gnome:glib"
@@ -34,6 +34,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python-docutils")
 source=("https://download.gnome.org/sources/glib/${pkgver%.*}/glib-${pkgver}.tar.xz"
+        https://gitlab.gnome.org/GNOME/glib/-/commit/7e69f88480a4bf8d9653efd0310c4c25390a0c8b.patch
         0001-Update-g_fopen-g_open-and-g_creat-to-open-with-FILE_.patch
         0002-disable_glib_compile_schemas_warning.patch
         0004-disable-explicit-ms-bitfields.patch
@@ -42,6 +43,7 @@ source=("https://download.gnome.org/sources/glib/${pkgver%.*}/glib-${pkgver}.tar
         pyscript2exe.py)
 noextract=("glib-${pkgver}.tar.xz")
 sha256sums=('b9cfb6f7a5bd5b31238fd5d56df226b2dda5ea37611475bf89f6a0f9400fe8bd'
+            '4902e5748c6954ed38f690f27954db96709e705ff83bbdb4ebf7392a21f65824'
             '51d02360a1ee978fd45e77b84bca9cfbcf080d91986b5c0efe0732779c6a54ec'
             '396c25cfd740ffbb72209133c7b9453173167577265a4bb14502678de8d5a8f9'
             '48e94a9e61f8db9a2dc66556f12c725efe5e247a9ddc5b491f8cb8310a387293'
@@ -62,9 +64,11 @@ prepare() {
   tar -xf "glib-${pkgver}.tar.xz" || true
   cd "${srcdir}/glib-${pkgver}"
 
-  apply_patch_with_msg 0001-Update-g_fopen-g_open-and-g_creat-to-open-with-FILE_.patch
-  apply_patch_with_msg 0002-disable_glib_compile_schemas_warning.patch
-  apply_patch_with_msg 0004-disable-explicit-ms-bitfields.patch
+  apply_patch_with_msg \
+    7e69f88480a4bf8d9653efd0310c4c25390a0c8b.patch \
+    0001-Update-g_fopen-g_open-and-g_creat-to-open-with-FILE_.patch \
+    0002-disable_glib_compile_schemas_warning.patch \
+    0004-disable-explicit-ms-bitfields.patch
 }
 
 build() {


### PR DESCRIPTION
Fixes #21044
