### PR TITLE
zydis: remove -Wno-int-conversion

### DIFF
--- a/mingw-w64-zydis/PKGBUILD
+++ b/mingw-w64-zydis/PKGBUILD
@@ -35,8 +35,6 @@ build() {
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
-  export CFLAGS+=" -Wno-int-conversion"
-
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     "${MINGW_PREFIX}"/bin/cmake.exe \
       -GNinja \


### PR DESCRIPTION
looks like it was triggered with zycore-c<=1.4.1