### PR TITLE
cmake: adapt to _split_longopt rename in bash-completion

### DIFF
--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -14,7 +14,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.29.5
 _rc=""
 _pkgver=${pkgver}${_rc}
-pkgrel=1
+pkgrel=2
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -50,12 +50,14 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-rhash"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 source=("https://github.com/Kitware/CMake/releases/download/v${_pkgver}/${_realname}-${_pkgver}.tar.gz"
+        "https://gitlab.kitware.com/cmake/cmake/-/merge_requests/9564.diff"
         "0001-Disable-response-files-for-MSYS-Generator.patch"
         "0002-Do-not-install-Qt-bundle-in-cmake-gui.patch"
         "0003-fix-find-python-on-mingw-aarch64.patch"
         "0004-Output-line-numbers-in-callstacks.patch"
         "0005-Default-to-ninja-generator.patch")
 sha256sums=('dd63da7d763c0db455ca232f2c443f5234fe0b11f8bd6958a81d29cc987dfd6e'
+            '989a4ef3a9e62bc80962315d44d009a643abd78eedb6dd82b95716097d4031c2'
             '25793edcbac05bb6d17fa9947b52ace4a6b5ccccf7758e22ae9ae022ed089061'
             'f6cf6a6f2729db2b9427679acd09520af2cd79fc26900b19a49cead05a55cd1a'
             '557b5cbc05d4d50b3a67a7892391fcaa5cd95c492cdb4338d86305d1f4a3b88a'
@@ -84,6 +86,7 @@ del_file_exists() {
 prepare() {
   cd ${_realname}-${_pkgver}
   apply_patch_with_msg \
+    9564.diff \
     0001-Disable-response-files-for-MSYS-Generator.patch \
     0002-Do-not-install-Qt-bundle-in-cmake-gui.patch \
     0003-fix-find-python-on-mingw-aarch64.patch \


### PR DESCRIPTION
This fixes the following error with bash completion.
-bash: _split_longopt: command not found