### PR TITLE
[new package] makelink 1.0

### DIFF
--- a/mingw-w64-makelink/PKGBUILD
+++ b/mingw-w64-makelink/PKGBUILD
@@ -1,0 +1,33 @@
+# Maintainer: moskensoap <141073988+moskensoap@users.noreply.github.com>
+
+_realname=makelink
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.0
+pkgrel=1
+pkgdesc="Creat make.exe linking to mingw32-make.exe (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64')
+url="https://github.com/moskensoap/makelink"
+
+license=('MIT')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-make")
+depends=("${MINGW_PACKAGE_PREFIX}-make")
+source=("https://github.com/moskensoap/makelink/releases/download/${pkgver}/makelink-${pkgver}.tar.gz")
+sha256sums=('d012b80e1c31d7c5e5ee0fd03f2ce294aabf6abe700424e86df49ec7bcdf2b7e')
+
+
+build() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
+  cp -r "${srcdir}/${_realname}-${pkgver}"/* ./
+  mingw32-make
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  install -D -m755 "${srcdir}/build-${MSYSTEM}/make.exe" "${pkgdir}${MINGW_PREFIX}/bin/make.exe"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}

--- a/mingw-w64-makelink/PKGBUILD
+++ b/mingw-w64-makelink/PKGBUILD
@@ -7,7 +7,7 @@ pkgver=1.0
 pkgrel=1
 pkgdesc="Creat make.exe linking to mingw32-make.exe (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://github.com/moskensoap/makelink"
 
 license=('MIT')

--- a/mingw-w64-makelink/PKGBUILD
+++ b/mingw-w64-makelink/PKGBUILD
@@ -15,7 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-make")
 depends=("${MINGW_PACKAGE_PREFIX}-make")
 source=("https://github.com/moskensoap/makelink/releases/download/${pkgver}/makelink-${pkgver}.tar.gz")
-sha256sums=('d012b80e1c31d7c5e5ee0fd03f2ce294aabf6abe700424e86df49ec7bcdf2b7e')
+sha256sums=('e64d5245a01895ed950aa6aeed24c7150ff8f2a805fa2eadc512f1cf92dd2c6a')
 
 
 build() {


### PR DESCRIPTION
# Motivation
In the MSYS2 environment, users often copy and rename `mingw32-make.exe` to `make.exe` to maintain a Linux-like `make` command behavior on Windows. However, this approach has several drawbacks:

1. The renamed `make.exe` cannot be managed by `pacman`, the package manager for MSYS2.
2. Setting aliases or creating alias scripts like `make.cmd` works in shells but is not recognized by tools such as VS Code's Make extension, which requires an actual `make.exe`.

# Solution
To address these issues and maintain the familiar Linux workflow, a good idea is to compile a new `make.exe` that simply forwards all command-line arguments to `mingw32-make.exe` and executes it.

## Comparison with (msys)make.exe

- `(msys)make.exe` outputs Unix-like directory structures, while `mingw32-make.exe` (and the new `make.exe`) outputs Windows local directory structures.
- `(msys)make.exe` can execute Unix-style shell scripts directly, whereas `mingw32-make.exe` might require Windows batch scripts or MinGW-specific tools.

## Potential conflicts

MSYS2 isolates `make.exe` instances in different sub-environments using PATH's priority, preventing conflicts.

# Website
https://github.com/moskensoap/makelink