### PR TITLE
python-ruamel.yaml.clib: rebuild; fix build with gcc 14

### DIFF
--- a/mingw-w64-python-ruamel.yaml.clib/PKGBUILD
+++ b/mingw-w64-python-ruamel.yaml.clib/PKGBUILD
@@ -4,7 +4,7 @@ _realname=ruamel.yaml.clib
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=0.2.8
-pkgrel=1
+pkgrel=2
 pkgdesc='C version of reader, parser and emitter for ruamel.yaml derived from libyaml (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -14,8 +14,13 @@ msys2_references=(
 url="https://sourceforge.net/projects/ruamel-yaml-clib/"
 license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-python")
-makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools"
-             "${MINGW_PACKAGE_PREFIX}-cc")
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+  "${MINGW_PACKAGE_PREFIX}-python-wheel"
+  "${MINGW_PACKAGE_PREFIX}-python-build"
+  "${MINGW_PACKAGE_PREFIX}-python-installer"
+  "${MINGW_PACKAGE_PREFIX}-cc"
+)
 source=("https://files.pythonhosted.org/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('beb2e0404003de9a4cab9753a8805a8fe9320ee6673136ed7f04255fe60bb512')
 
@@ -28,16 +33,22 @@ build() {
   msg "Python build for ${MSYSTEM}"
   cd "${srcdir}/python-build-${MSYSTEM}"
 
+  # Workaround for GCC 14, see https://sourceforge.net/p/ruamel-yaml-clib/tickets/22/
+  CFLAGS+=" -Wno-error=incompatible-pointer-types"
+
   # clang build workaround
   # TODO: maybe cython regen would help too? but cython sources are not included in the tarball
   CFLAGS+=" -Wno-incompatible-function-pointer-types"
-  ${MINGW_PREFIX}/bin/python setup.py build
+
+  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 package() {
   cd "${srcdir}/python-build-${MSYSTEM}"
-  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  RUAMEL_NO_PIP_INSTALL_CHECK=1 ${MINGW_PREFIX}/bin/python setup.py install \
-    --prefix=${MINGW_PREFIX} --root="${pkgdir}" --optimize=1 --skip-build
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
 }


### PR DESCRIPTION
and port to build/installer