### PR TITLE
kdenlive: Add kcolorscheme and remove kdbusaddons dependency

### DIFF
--- a/mingw-w64-kdenlive/PKGBUILD
+++ b/mingw-w64-kdenlive/PKGBUILD
@@ -3,10 +3,14 @@ _realname=kdenlive
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=24.05.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A non-linear video editor for Linux using the MLT video framework (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
+msys2_references=(
+  'archlinux: kdenlive'
+)
+msys2_repository_url='https://invent.kde.org/multimedia/kdenlive/'
 url="https://kdenlive.org/"
 license=("spdx:GPL-3.0-only")
 makedepends=(
@@ -21,12 +25,12 @@ depends=(
   "${MINGW_PACKAGE_PREFIX}-karchive"
   "${MINGW_PACKAGE_PREFIX}-kbookmarks"
   "${MINGW_PACKAGE_PREFIX}-kcodecs"
+  "${MINGW_PACKAGE_PREFIX}-kcolorscheme"
   "${MINGW_PACKAGE_PREFIX}-kcompletion"
   "${MINGW_PACKAGE_PREFIX}-kconfig"
   "${MINGW_PACKAGE_PREFIX}-kconfigwidgets"
   "${MINGW_PACKAGE_PREFIX}-kcoreaddons"
   "${MINGW_PACKAGE_PREFIX}-kcrash"
-  "${MINGW_PACKAGE_PREFIX}-kdbusaddons"
   "${MINGW_PACKAGE_PREFIX}-kfilemetadata"
   "${MINGW_PACKAGE_PREFIX}-kguiaddons"
   "${MINGW_PACKAGE_PREFIX}-ki18n"


### PR DESCRIPTION
dbus is already disabled with -DNODBUS=ON option and not required in Windows.