### PR TITLE
zed: disable auto update

### DIFF
--- a/mingw-w64-zed/PKGBUILD
+++ b/mingw-w64-zed/PKGBUILD
@@ -70,6 +70,8 @@ build() {
   export LIBSQLITE3_SYS_USE_PKG_CONFIG=1
   export ZED_UPDATE_EXPLANATION='Updates are handled by pacman'
   if [[ $MINGW_PACKAGE_PREFIX != *-clang-* ]]; then
+    export CFLAGS+=" -Wno-incompatible-pointer-types" 
+    export CXXFLAGS+=" -Wno-incompatible-pointer-types"
     export RUSTFLAGS="-Clink-arg=-fuse-ld=lld"
   fi
 

--- a/mingw-w64-zed/PKGBUILD
+++ b/mingw-w64-zed/PKGBUILD
@@ -4,7 +4,7 @@ _realname=zed
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.139.3
-pkgrel=1
+pkgrel=2
 pkgdesc="A high-performance, multiplayer code editor (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64')
@@ -59,35 +59,26 @@ prepare() {
   cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
 }
 
-_env() {
+build() {
+  cd "${_realname}-${pkgver}"
+
   export OPENSSL_NO_VENDOR=1
   export LIBGIT2_NO_VENDOR=1
   export PKG_CONFIG_ALL_DYNAMIC=1
   export ZSTD_SYS_USE_PKG_CONFIG=1
   export WINAPI_NO_BUNDLED_LIBRARIES=1
   export LIBSQLITE3_SYS_USE_PKG_CONFIG=1
+  export ZED_UPDATE_EXPLANATION='Updates are handled by pacman'
   if [[ $MINGW_PACKAGE_PREFIX != *-clang-* ]]; then
     export RUSTFLAGS="-Clink-arg=-fuse-ld=lld"
-  fi
-}
-
-build() {
-  cd "${_realname}-${pkgver}"
-
-  _env
-  # remove a werror from gcc 14
-  if [[ $MINGW_PACKAGE_PREFIX != *-clang-* ]]; then
-    export CFLAGS+=" -Wno-incompatible-pointer-types"
-    export CXXFLAGS+=" -Wno-incompatible-pointer-types"
   fi
 
   cargo build --release --frozen -p zed
 }
 
 check() {
-  cd "${_realname}-${pkgver}-pre"
+  cd "${_realname}-${pkgver}"
 
-  _env
   cargo test --release --frozen -p zed
 }
 


### PR DESCRIPTION
- move _env into a build()
- ~at first try to remove workaround for gcc14~ didn't work
- add ZED_UPDATE_EXPLANATION (from Arch)