### PR TITLE
[new package] Exempi 2.6.5 w/ meson build

### DIFF
--- a/mingw-w64-exempi/001-win32-mingw.patch
+++ b/mingw-w64-exempi/001-win32-mingw.patch
@@ -1,0 +1,24 @@
+diff -bur exempi-orig/public/include/XMPCommon/XMPCommonDefines.h exempi/public/include/XMPCommon/XMPCommonDefines.h
+--- exempi-orig/public/include/XMPCommon/XMPCommonDefines.h	2024-06-15 11:07:50.176832300 -0600
++++ exempi/public/include/XMPCommon/XMPCommonDefines.h	2024-06-15 11:08:41.376698000 -0600
+@@ -87,7 +87,7 @@
+ 	// =========================
+ 	#if XMP_WinBuild
+ 		#define SUPPORT_SHARED_POINTERS_WITH_ALLOCATORS 1
+-		#if _MSC_VER <= 1600
++		#if _MSC_VER <= 1600 && !defined(__MINGW64__)
+ 			#define SUPPORT_STD_ATOMIC_IMPLEMENTATION 0
+ 			#define SUPPORT_SHARED_POINTERS_IN_TR1 1
+ 			#define SUPPORT_SHARED_POINTERS_IN_STD 0
+diff -bur exempi-orig/source/SuppressSAL.h exempi/source/SuppressSAL.h
+--- exempi-orig/source/SuppressSAL.h	2024-06-15 11:07:50.211863200 -0600
++++ exempi/source/SuppressSAL.h	2024-06-15 11:09:25.144530500 -0600
+@@ -17,7 +17,7 @@
+ #ifndef _H_SuppressSAL
+ #define _H_SuppressSAL
+ 
+-#if !defined(_WIN32) && !defined(_WIN64) /* The following definition is applicable only for non-windows platform */
++#if defined(__MINGW64__) || (!defined(_WIN32) && !defined(_WIN64)) /* The following definition is applicable only for non-msvc platform */
+ 
+ #define _In_
+ #define _In_opt_

--- a/mingw-w64-exempi/002-win32-host.patch
+++ b/mingw-w64-exempi/002-win32-host.patch
@@ -1,0 +1,35 @@
+diff -bur exempi-orig/meson.build exempi/meson.build
+--- exempi-orig/meson.build	2024-06-15 11:12:38.266441700 -0600
++++ exempi/meson.build	2024-06-15 11:15:11.287444500 -0600
+@@ -96,6 +96,7 @@
+   add_project_arguments('-DMAC_ENV=1', language: 'cpp')
+ elif host_machine.system() == 'windows'
+   add_project_arguments('-DWIN_ENV=1', language: 'cpp')
++  add_project_arguments('-DUNICODE', language: 'cpp')
+ else
+   add_project_arguments('-DUNIX_ENV=1', language: 'cpp')
+ endif
+diff -bur exempi-orig/public/include/XMP_Const.h exempi/public/include/XMP_Const.h
+--- exempi-orig/public/include/XMP_Const.h	2024-06-15 11:12:38.229917500 -0600
++++ exempi/public/include/XMP_Const.h	2024-06-15 11:13:55.359812000 -0600
+@@ -16,7 +16,7 @@
+ 	#include <string.h>
+ 	#include <stdlib.h>
+ 
+-#if XMP_MacBuild | XMP_iOSBuild	// ! No stdint.h on Windows and some UNIXes.
++#if XMP_MacBuild | XMP_iOSBuild | XMP_WinBuild	// ! No stdint.h on some UNIXes.
+     #include <stdint.h>
+ #endif
+ //Android has both inttypes and stdint. But inttypes includes stdint plus other functions
+diff -bur exempi-orig/source/meson.build exempi/source/meson.build
+--- exempi-orig/source/meson.build	2024-06-15 11:12:38.257933100 -0600
++++ exempi/source/meson.build	2024-06-15 11:14:15.807394800 -0600
+@@ -12,7 +12,7 @@
+   'XMP_LibUtils.hpp',
+   'XMP_LibUtils.cpp',
+   'XIO.cpp',
+-  'Host_IO-POSIX.cpp',
++  'Host_IO-Win.cpp',
+   'XMP_ProgressTracker.hpp',
+   'XMP_ProgressTracker.cpp',
+   'PerfUtils.hpp',

--- a/mingw-w64-exempi/PKGBUILD
+++ b/mingw-w64-exempi/PKGBUILD
@@ -1,0 +1,78 @@
+
+_realname=exempi
+_commit=edeaff6131c5264b8c070c03f4fc6db7264b5b0f
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=2.6.5.r9.gedeaff6
+pkgrel=1
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+pkgdesc="Library to parse XMP metadata (mingw-w64)"
+url="https://libopenraw.freedesktop.org/exempi"
+msys2_repository_url="https://gitlab.freedesktop.org/libopenraw/exempi"
+msys2_references=(
+  "archlinux: exempi"
+  "cpe: cpe:2.3:a:exempi_project:exempi"
+)
+license=("spdx:BSD-3-Clause")
+depends=("${MINGW_PACKAGE_PREFIX}-expat"
+         "${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-winpthreads"
+         "${MINGW_PACKAGE_PREFIX}-zlib")
+makedepends=("git"
+             "${MINGW_PACKAGE_PREFIX}-boost"
+             "${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-meson"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
+source=("${_realname}"::"git+https://gitlab.freedesktop.org/libopenraw/$_realname.git#commit=$_commit"
+        001-win32-mingw.patch
+        002-win32-host.patch)
+sha256sums=('224e864924aa4a0076e7f4aed0efc275313235c4f2deeee214a15aabf9722603'
+            '6f59cf5eb300814e0a403606f2047b2f9b2863565d51e9237b9074b3f7d49b0e'
+            'a271d34042b6dff7c8cabbd9388da5364b67c4268f0a4024de528ccf413e55fb')
+
+pkgver() {
+  cd "${srcdir}/${_realname}"
+
+  git describe --long --abbrev=7 | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying ${_patch}"
+    patch -Nbp1 -i "${srcdir}/${_patch}"
+  done
+}
+
+prepare() {
+  cd ${_realname}
+
+  apply_patch_with_msg \
+    001-win32-mingw.patch \
+    002-win32-host.patch
+}
+
+build() {
+  mkdir -p build-${MSYSTEM}
+  cd build-${MSYSTEM}
+
+  LDFLAGS+=" -lpthread" \
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+   ${MINGW_PREFIX}/bin/meson setup \
+     --prefix=${MINGW_PREFIX} \
+     --wrap-mode=nodownload \
+     --auto-features=enabled \
+     --buildtype=plain \
+     "../${_realname}"
+
+  ${MINGW_PREFIX}/bin/ninja
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  DESTDIR="${pkgdir}" ninja install
+
+  install -Dm644 "${srcdir}/${_realname}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}


### PR DESCRIPTION
Meson building was added right after the 2.6.5 release, so git sources are the only way
I couldn't get it to build with autotools :(

```
$ ninja test
 1/14 testinit                  OK              0.18s
 2/14 testexempicore            OK              0.18s
 3/14 testwritenewprop          OK              0.17s
 4/14 testtiffleak              OK              0.15s
 5/14 testxmpfiles              OK              0.15s
 6/14 testxmpfileswrite         OK              0.14s
 7/14 testparse                 OK              0.13s
 8/14 testiterator              OK              0.12s
 9/14 testfdo18635              OK              0.11s
10/14 testfdo83313              OK              0.10s
11/14 testcpp                   OK              0.07s
12/14 testwebp                  OK              0.06s
13/14 testadobesdk              OK              0.04s
14/14 testxmpformat             OK              0.03s

Ok:                 14
Expected Fail:      0
Fail:               0
Unexpected Pass:    0
Skipped:            0
Timeout:            0

Full log written to X:/Github/MINGW-packages/mingw-w64-exempi/src/build-UCRT64/meson-logs/testlog.txt
```