### PR TITLE
[new-package] lua-cjson

### DIFF
--- a/mingw-w64-lua-cjson/PKGBUILD
+++ b/mingw-w64-lua-cjson/PKGBUILD
@@ -1,0 +1,164 @@
+# Maintainer: luau-project <luau.project@gmail.com>
+
+_pkgsuffix=cjson
+_realname=lua-${_pkgsuffix}
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-lua-${_pkgsuffix}"
+         "${MINGW_PACKAGE_PREFIX}-lua51-${_pkgsuffix}"
+         "${MINGW_PACKAGE_PREFIX}-lua53-${_pkgsuffix}")
+pkgver=2.1.0.9
+pkgrel=1
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/openresty/lua-cjson'
+license=('spdx:MIT')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-lua"
+             "${MINGW_PACKAGE_PREFIX}-lua51"
+             "${MINGW_PACKAGE_PREFIX}-lua53"
+             "${MINGW_PACKAGE_PREFIX}-pkgconf")
+source=("${url}/archive/refs/tags/${pkgver}.tar.gz")
+sha256sums=('9e1fd46eced543b149f2b08703b0c0165619524f92d350a453e8c11e4fd089b0')
+
+prepare() {
+  # current Lua
+  _lua_ver=$(pkgconf --variable=V lua)
+  _lua_ver_short=$(echo $_lua_ver | sed -En "s/\.//p")
+
+  _options=("LUA_VERSION=${_lua_ver}"
+            "PREFIX=${MINGW_PREFIX}"
+            "TARGET=cjson.dll"
+            "CJSON_CFLAGS=-DDISABLE_INVALID_NUMBERS"
+            "CJSON_LDFLAGS=-shared ${MINGW_PREFIX}/bin/lua${_lua_ver_short}.dll"
+            "LUA_BIN_SUFFIX=.lua")
+
+  # Lua 5.1
+  _lua_ver51=$(pkgconf --variable=V lua5.1)
+  _lua_ver_short51=$(echo $_lua_ver51 | sed -En "s/\.//p")
+
+  _options51=("LUA_VERSION=${_lua_ver51}"
+             "PREFIX=${MINGW_PREFIX}"
+             "TARGET=cjson.dll"
+             "LUA_INCLUDE_DIR=${MINGW_PREFIX}/include/lua${_lua_ver51}"
+             "CJSON_CFLAGS=-DDISABLE_INVALID_NUMBERS"
+             "CJSON_LDFLAGS=-shared ${MINGW_PREFIX}/bin/lua${_lua_ver_short51}.dll"
+             "LUA_BIN_SUFFIX=.lua")
+
+  cp -r "${srcdir}/${_realname}-${pkgver}" "${srcdir}/${_realname}-${pkgver}-51"
+
+  sed -e "s/json2lua\.lua/json2lua${_lua_ver_short51}.lua/" \
+      -e "s/\#\!\/usr\/bin\/env lua/\#\!\/usr\/bin\/env lua${_lua_ver51}/" \
+      -i "${srcdir}/${_realname}-${pkgver}-51"/lua/json2lua.lua
+
+  sed -e "s/lua2json\.lua/lua2json${_lua_ver_short51}.lua/" \
+      -e "s/\#\!\/usr\/bin\/env lua/\#\!\/usr\/bin\/env lua${_lua_ver51}/" \
+      -i "${srcdir}/${_realname}-${pkgver}-51"/lua/lua2json.lua
+
+  sed -e "s/json2lua\$(LUA_BIN_SUFFIX)/json2lua${_lua_ver_short51}\$(LUA_BIN_SUFFIX)/" \
+      -e "s/lua2json\$(LUA_BIN_SUFFIX)/lua2json${_lua_ver_short51}\$(LUA_BIN_SUFFIX)/" \
+      -i "${srcdir}/${_realname}-${pkgver}-51"/Makefile
+
+  for entry in "${srcdir}/${_realname}-${pkgver}-51"/tests/*.lua;
+  do
+    sed -e "s/\#\!\/usr\/bin\/env lua/\#\!\/usr\/bin\/env lua${_lua_ver51}/" \
+        -i $entry;
+  done
+
+  # Lua 5.3
+  _lua_ver53=$(pkgconf --variable=V lua5.3)
+  _lua_ver_short53=$(echo $_lua_ver53 | sed -En "s/\.//p")
+
+  _options53=("LUA_VERSION=${_lua_ver53}"
+             "PREFIX=${MINGW_PREFIX}"
+             "TARGET=cjson.dll"
+             "LUA_INCLUDE_DIR=${MINGW_PREFIX}/include/lua${_lua_ver53}"
+             "CJSON_CFLAGS=-DDISABLE_INVALID_NUMBERS"
+             "CJSON_LDFLAGS=-shared ${MINGW_PREFIX}/bin/lua${_lua_ver_short53}.dll"
+             "LUA_BIN_SUFFIX=.lua")
+
+  cp -r "${srcdir}/${_realname}-${pkgver}" "${srcdir}/${_realname}-${pkgver}-53"
+
+  sed -e "s/json2lua\.lua/json2lua${_lua_ver_short53}.lua/" \
+      -e "s/\#\!\/usr\/bin\/env lua/\#\!\/usr\/bin\/env lua${_lua_ver53}/" \
+      -i "${srcdir}/${_realname}-${pkgver}-53"/lua/json2lua.lua
+
+  sed -e "s/lua2json\.lua/lua2json${_lua_ver_short53}.lua/" \
+      -e "s/\#\!\/usr\/bin\/env lua/\#\!\/usr\/bin\/env lua${_lua_ver53}/" \
+      -i "${srcdir}/${_realname}-${pkgver}-53"/lua/lua2json.lua
+
+  sed -e "s/json2lua\$(LUA_BIN_SUFFIX)/json2lua${_lua_ver_short53}\$(LUA_BIN_SUFFIX)/" \
+      -e "s/lua2json\$(LUA_BIN_SUFFIX)/lua2json${_lua_ver_short53}\$(LUA_BIN_SUFFIX)/" \
+      -i "${srcdir}/${_realname}-${pkgver}-53"/Makefile
+
+  for entry in "${srcdir}/${_realname}-${pkgver}-53"/tests/*.lua;
+  do
+    sed -e "s/\#\!\/usr\/bin\/env lua/\#\!\/usr\/bin\/env lua${_lua_ver53}/" \
+        -i $entry;
+  done
+}
+
+build() {
+  # current Lua
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  make \
+    "${_options[@]}" \
+    all
+
+  # Lua 5.1
+  cd "${srcdir}/${_realname}-${pkgver}-51"
+
+  make \
+    "${_options51[@]}" \
+    all
+  
+  # Lua 5.3
+  cd "${srcdir}/${_realname}-${pkgver}-53"
+
+  make \
+    "${_options53[@]}" \
+    all
+}
+
+package_lua-cjson() {
+  depends=("${MINGW_PACKAGE_PREFIX}-lua")
+  pkgdesc="Lua CJSON is a fast JSON encoding/parsing module for Lua (mingw-w64)"
+
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  make \
+    DESTDIR="${pkgdir}" \
+    "${_options[@]}" \
+    install install-extra
+}
+
+package_lua51-cjson() {
+  depends=("${MINGW_PACKAGE_PREFIX}-lua51")
+  pkgdesc="Lua CJSON is a fast JSON encoding/parsing module for Lua ${_lua_ver51} (mingw-w64)"
+
+  cd "${srcdir}/${_realname}-${pkgver}-51"
+
+  make \
+    DESTDIR="${pkgdir}" \
+    "${_options51[@]}" \
+    install install-extra
+}
+
+package_lua53-cjson() {
+  depends=("${MINGW_PACKAGE_PREFIX}-lua53")
+  pkgdesc="Lua CJSON is a fast JSON encoding/parsing module for Lua ${_lua_ver53} (mingw-w64)"
+
+  cd "${srcdir}/${_realname}-${pkgver}-53"
+
+  make \
+    DESTDIR="${pkgdir}" \
+    "${_options53[@]}" \
+    install install-extra
+}
+
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done


### PR DESCRIPTION
## Description

[Lua CJSON](https://github.com/openresty/lua-cjson) is a fast JSON encoding/parsing module for Lua (5.1+). Nowadays, **lua-cjson** is the most downloaded (+19M) Lua package on [LuaRocks](https://luarocks.org/) (the main package manager for Lua).

In the PKGBUILD script provided here, it is building lua-cjson for every mingw_arch, and every Lua version available here (current 5.4, 5.3 and 5.1).

## Packages names

* Current Lua (5.4): mingw-w64-*-lua-cjson
* Lua 5.1: mingw-w64-*-lua51-cjson
* Lua 5.3: mingw-w64-*-lua53-cjson

> [!NOTE]
> 
> If needed, I can place all these ```sed``` lines inside the ```prepare()``` function into patch files to make things more readable.