### PR TITLE
icu: backport build fix (remove need for -fext-numeric-literals)

### DIFF
--- a/mingw-w64-icu/PKGBUILD
+++ b/mingw-w64-icu/PKGBUILD
@@ -6,7 +6,7 @@ _realname=icu
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=75.1
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 pkgdesc="International Components for Unicode library (mingw-w64)"
@@ -26,7 +26,8 @@ source=(https://github.com/unicode-org/icu/releases/download/release-${pkgver//.
         0015-debug.mingw.patch
         0016-icu-pkgconfig.patch
         0021-mingw-static-libraries-without-s.patch
-        0023-fix-twice-include-platform_make_fragment.patch)
+        0023-fix-twice-include-platform_make_fragment.patch
+        https://github.com/unicode-org/icu/commit/564c92d666354a8ed0f99cba0f239eba790bd148.patch)
 sha256sums=('cb968df3e4d2e87e8b11c49a5d01c787bd13b9545280fc6642f826527618caef'
             '4f4787caeccf70607cf0cbde0c005f05f5c6de1543265a927839122405b4054f'
             'e7ecdafe85e18a4a4b5f29bbfde38776521a848e5b65089a2379b90e59f1592d'
@@ -34,7 +35,8 @@ sha256sums=('cb968df3e4d2e87e8b11c49a5d01c787bd13b9545280fc6642f826527618caef'
             '0181f9ff8b7dd0a423869d8772da0a4feea64188347eb0dee7eb059aea92131c'
             '87ebe8962f8c387714f2a697a664a0c49aed2331b988548069d0c211abc36e05'
             'd8612f40b1731d9a94290afcf80c896184a2f15b8ae8f23b3643c64f6cabfa2f'
-            '12aa647cff22a721bdbceb4e77f5e66c6616e0e050dca8172acfd3365553fff4')
+            '12aa647cff22a721bdbceb4e77f5e66c6616e0e050dca8172acfd3365553fff4'
+            'e071322219b1f09175805e2adfea46a27e738950b2eb5d2e50b016af14406e2c')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -58,6 +60,8 @@ prepare() {
     0021-mingw-static-libraries-without-s.patch \
     0023-fix-twice-include-platform_make_fragment.patch
 
+  patch -Np2 -i "${srcdir}/564c92d666354a8ed0f99cba0f239eba790bd148.patch"
+
   cd source
   autoreconf -vfi
 }
@@ -70,10 +74,6 @@ build() {
     _extra_config+=("--enable-release")
   else
     _extra_config+=("--enable-debug")
-  fi
-
-  if [[ ${CC} == gcc ]]; then
-    CXXFLAGS+=" -fext-numeric-literals"
   fi
 
   ../icu/source/configure \


### PR DESCRIPTION
icu is built without gnu extensions but in various places undefs `__STRICT_ANSI__` which enables code in the libstdc++ that depends on gnu extensions.

We worked around this by enabling the specific extensions this required but this upstream patch is better, to not touch `__STRICT_ANSI__` in the first place:

https://github.com/unicode-org/icu/pull/3003