### PR TITLE
zed: update to 0.140.5

### DIFF
--- a/mingw-w64-zed/PKGBUILD
+++ b/mingw-w64-zed/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=zed
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.139.3
-pkgrel=2
+pkgver=0.140.5
+pkgrel=1
 pkgdesc="A high-performance, multiplayer code editor (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64')
@@ -26,13 +26,16 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-fontconfig"
              "${MINGW_PACKAGE_PREFIX}-openssl"
              "${MINGW_PACKAGE_PREFIX}-sqlite3")
+optdepends=("${MINGW_PACKAGE_PREFIX}-ollama: provides LLMs for assistance panel"
+            "${MINGW_PACKAGE_PREFIX}-clang: for a better C/C++ language support"
+            "${MINGW_PACKAGE_PREFIX}-rust: for a rust-analyzer (requires ${MINGW_PACKAGE_PREFIX}-rust-src)")
 source=("https://github.com/zed-industries/zed/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
         "zstd-sys.tar.gz::https://crates.io/api/v1/crates/zstd-sys/2.0.10+zstd.1.5.6/download"
         "curl-sys.tar.gz::https://crates.io/api/v1/crates/curl-sys/0.4.67+curl-8.3.0/download"
         "zed-download-pc-windows-gnu-assets.patch"
         "curl-sys-use-pkgconfig.patch"
         "zstd-sys-remove-statik.patch")
-sha256sums=('cd15f80c95ec4c33cbe821ff70e64c3922d1187fa13ac894a8049b615cad2e4f'
+sha256sums=('a634d8a29738446d76b299ea9a662beade7b7933f43deccb432e9f52cfa2b68b'
             'c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa'
             '3cc35d066510b197a0f72de863736641539957628c8a42e70e27c66849e77c34'
             '94ca0bc7ae6f73bc4cdb9dd02af2946541b2bee7c71f279a4eeef1f987e76fe4'
@@ -70,8 +73,7 @@ build() {
   export LIBSQLITE3_SYS_USE_PKG_CONFIG=1
   export ZED_UPDATE_EXPLANATION='Updates are handled by pacman'
   if [[ $MINGW_PACKAGE_PREFIX != *-clang-* ]]; then
-    export CFLAGS+=" -Wno-incompatible-pointer-types" 
-    export CXXFLAGS+=" -Wno-incompatible-pointer-types"
+    export CFLAGS+=" -Wno-incompatible-pointer-types"
     export RUSTFLAGS="-Clink-arg=-fuse-ld=lld"
   fi
 
@@ -85,6 +87,6 @@ check() {
 }
 
 package() {
-  install -Dm755 "${_realname}-${pkgver}/target/release/Zed" "${pkgdir}${MINGW_PREFIX}/bin/zed"
+  install -Dm755 "${_realname}-${pkgver}/target/release/zed" "${pkgdir}${MINGW_PREFIX}/bin/zed"
   install -Dm644 "${_realname}-${pkgver}"/LICENSE-{AGPL,APACHE,GPL} -t "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/"
 }


### PR DESCRIPTION
~[test] use mold as linker~ `mold: fatal: unknown -m argument: i386pep`