### PR TITLE
mingw-w64-mpv-git

### DIFF
--- a/mingw-w64-mpv-git/PKGBUILD
+++ b/mingw-w64-mpv-git/PKGBUILD
@@ -1,0 +1,92 @@
+# Maintainer: Vincent Grande <shoober420@gmail.com>
+# Contributor: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: James Ross-Gowan <rossymiles@gmail.com>
+
+_realname=mpv
+pkgbase="mingw-w64-${_realname}"
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.37.0_114_g17be6e1990
+pkgrel=1
+pkgdesc="Video player based on MPlayer/mplayer2 (mingw-w64)"
+url="https://mpv.io/"
+msys2_repository_url="https://github.com/mpv-player/mpv"
+msys2_references=(
+  "cpe: cpe:/a:mpv:mpv"
+)
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64')
+license=('spx:GPL-2.0-only' 'spx:LGPL-2.1-only')
+depends=("${MINGW_PACKAGE_PREFIX}-ffmpeg"
+         "${MINGW_PACKAGE_PREFIX}-lcms2"
+         "${MINGW_PACKAGE_PREFIX}-libarchive"
+         "${MINGW_PACKAGE_PREFIX}-libass"
+         "${MINGW_PACKAGE_PREFIX}-libbluray"
+         "${MINGW_PACKAGE_PREFIX}-libcaca"
+         "${MINGW_PACKAGE_PREFIX}-libcdio"
+         "${MINGW_PACKAGE_PREFIX}-libcdio-paranoia"
+         "${MINGW_PACKAGE_PREFIX}-libdvdnav"
+         "${MINGW_PACKAGE_PREFIX}-libdvdread"
+         "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
+         "${MINGW_PACKAGE_PREFIX}-libplacebo"
+         "${MINGW_PACKAGE_PREFIX}-lua51"
+         "${MINGW_PACKAGE_PREFIX}-mujs"
+         "${MINGW_PACKAGE_PREFIX}-rubberband"
+         "${MINGW_PACKAGE_PREFIX}-shaderc"
+         "${MINGW_PACKAGE_PREFIX}-spirv-cross"
+         "${MINGW_PACKAGE_PREFIX}-uchardet"
+         "${MINGW_PACKAGE_PREFIX}-vapoursynth"
+         "${MINGW_PACKAGE_PREFIX}-vulkan"
+         "winpty"
+         "git")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-meson"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-pkgconf"
+             "${MINGW_PACKAGE_PREFIX}-python-docutils"
+             "${MINGW_PACKAGE_PREFIX}-python-rst2pdf"
+             "${MINGW_PACKAGE_PREFIX}-vulkan-headers")
+optdepends=("${MINGW_PACKAGE_PREFIX}-yt-dlp: for video-sharing websites playback")
+source=('git+https://github.com/mpv-player/mpv')
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "${srcdir}/${_realname}"
+  git describe --always --tags --dirty | sed -e 's/^v//' -e 's/-/_/g'
+}
+
+prepare() {
+  cd "${srcdir}/${_realname}"
+}
+
+build() {
+  mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    meson setup \
+      --prefix="${MINGW_PREFIX}" \
+      --wrap-mode=nodownload \
+      --buildtype=plain \
+      -Dlibmpv=true \
+      -Djavascript=enabled \
+      ../${_realname}
+
+  meson compile
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  DESTDIR="${pkgdir}" meson install
+
+  # Move encoding-profiles.conf to share/doc alongside the example .conf files.
+  # mpv doesn't search /etc for configuration on MinGW.
+  mv "${pkgdir}${MINGW_PREFIX}/etc/mpv/"*.conf "${pkgdir}${MINGW_PREFIX}/share/doc/mpv/"
+
+  # mpv needs winpty for key bindings to work on the terminal
+  mv "${pkgdir}${MINGW_PREFIX}/bin/mpv.exe" "${pkgdir}${MINGW_PREFIX}/bin/mpv_exe"
+  _exename=mpv
+  echo '#!/usr/bin/env bash' > "${pkgdir}${MINGW_PREFIX}/bin/${_exename}"
+  echo 'export _started_from_console=yes' >> "${pkgdir}${MINGW_PREFIX}/bin/${_exename}"
+  echo '/usr/bin/winpty "$( dirname ${BASH_SOURCE[0]} )/'${_exename}'.exe" "$@"' >> "${pkgdir}${MINGW_PREFIX}/bin/${_exename}"
+  mv "${pkgdir}${MINGW_PREFIX}/bin/mpv_exe" "${pkgdir}${MINGW_PREFIX}/bin/mpv.exe"
+}


### PR DESCRIPTION
Git version of the mingw-w64-mpv package.

Can be added to mpv.io download page below stable PKGBUILD.
https://mpv.io/installation/