### PR TITLE
ossia-score: update to 3.2.1

### DIFF
--- a/mingw-w64-ossia-score/PKGBUILD
+++ b/mingw-w64-ossia-score/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=ossia-score
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=3.2.0
+pkgver=3.2.1
 pkgrel=1
 pkgdesc="ossia score, an interactive sequencer for the intermedia arts"
 arch=('any')
@@ -39,7 +39,7 @@ makedepends=(
   "git"
 )
 source=("https://github.com/ossia/score/releases/download/v${pkgver}/ossia.score-${pkgver}-src.tar.xz")
-sha512sums=('55119fa2016834b5ebd1d581815162446773b926ee4391ad860a144b875f62f556c2f40b176fd2bffa6276c23b08e5a4b9ecd1ba78e687e363435b56abbad56a')
+sha512sums=('89a3b478a14d58a2e378326bb1727d85074fe3ed5a8fc3f796e300fc237004b1ea77ed10cac5fb37ffced07bc1a9d7a759e268a74e7c322e2e147e16b0182bc5')
 noextract=(ossia.score-${pkgver}-src.tar.xz)
 
 prepare() {


### PR DESCRIPTION
full changelog: https://github.com/ossia/score/compare/v3.2.0...v3.2.1. looks like there is no other changes required
@jcelerier