### PR TITLE
ffmpeg4.4: disable nvenc

### DIFF
--- a/mingw-w64-ffmpeg4.4/PKGBUILD
+++ b/mingw-w64-ffmpeg4.4/PKGBUILD
@@ -7,7 +7,7 @@ _realname=ffmpeg
 pkgbase="mingw-w64-${_realname}4.4"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}4.4"
 pkgver=4.4.4
-pkgrel=10
+pkgrel=11
 pkgdesc="Complete solution to record, convert and stream audio and video (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -67,7 +67,6 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-vulkan-headers"
              $([[ ${CARCH} == aarch64 ]] || echo \
                "${MINGW_PACKAGE_PREFIX}-amf-headers" \
-               "${MINGW_PACKAGE_PREFIX}-ffnvcodec-headers" \
                "${MINGW_PACKAGE_PREFIX}-nasm"))
 source=(https://ffmpeg.org/releases/${_realname}-${pkgver}.tar.xz{,.asc}
         https://github.com/FFmpeg/FFmpeg/commit/c6fdbe26ef30fff817581e5ed6e078d96111248a.patch
@@ -127,6 +126,7 @@ build() {
     --disable-debug
     --disable-stripping
     --disable-doc
+    --disable-nvenc
     --enable-dxva2
     --enable-d3d11va
     --enable-fontconfig
@@ -182,7 +182,6 @@ build() {
     common_config+=(
         --enable-libmfx
         --enable-amf
-        --enable-nvenc
     )
   fi
 


### PR DESCRIPTION
It no longer builds and needs backports that no longer cleanly apply. While it's probably possibel to fix this there are not many 4.4 users left, so just disable that feature.