### PR TITLE
svt-av1: update to 2.1.1

### DIFF
--- a/mingw-w64-svt-av1/PKGBUILD
+++ b/mingw-w64-svt-av1/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=SVT-AV1
 pkgbase=mingw-w64-svt-av1
 pkgname=("${MINGW_PACKAGE_PREFIX}-svt-av1")
-pkgver=2.1.0
+pkgver=2.1.1
 pkgrel=1
 pkgdesc="Scalable Video Technology AV1 encoder and decoder (mingw-w64)"
 arch=('any')
@@ -15,7 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-nasm"
              "${MINGW_PACKAGE_PREFIX}-cc")
 source=("${url}/-/archive/v${pkgver}/${_realname}-v${pkgver}.tar.gz")
-sha256sums=('72a076807544f3b269518ab11656f77358284da7782cece497781ab64ed4cb8a')
+sha256sums=('03b3cf985b52da294f241cbd2b0a8996a34f817fa75c4e8f9dc1bb6458d24de2')
 
 prepare() {
   cd "${srcdir}"/${_realname}-v${pkgver}


### PR DESCRIPTION
Note: decoder parts removed upstream, but doesn't seem anyone was linking to those.