### PR TITLE
harfbuzz: update to 9.0.0

### DIFF
--- a/mingw-w64-harfbuzz/001-fix-build-with-chafa.patch
+++ b/mingw-w64-harfbuzz/001-fix-build-with-chafa.patch
@@ -1,0 +1,13 @@
+--- a/util/hb-info.cc
++++ b/util/hb-info.cc
+@@ -35,6 +35,10 @@
+ # include <chafa.h>
+ #endif
+ 
++#ifdef environ
++#undef environ
++#endif
++
+ const unsigned DEFAULT_FONT_SIZE = FONT_SIZE_UPEM;
+ const unsigned SUBPIXEL_BITS = 0;
+ 

--- a/mingw-w64-harfbuzz/PKGBUILD
+++ b/mingw-w64-harfbuzz/PKGBUILD
@@ -4,14 +4,18 @@
 _realname=harfbuzz
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-cairo"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-icu"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-utils"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
-pkgver=8.5.0
-pkgrel=2
-pkgdesc="OpenType text shaping engine (mingw-w64)"
+pkgver=9.0.0
+pkgrel=1
+pkgdesc="OpenType text shaping engine"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://github.com/harfbuzz/harfbuzz"
 msys2_references=(
+  "archlinux: harfbuzz"
   "cpe: cpe:/a:harfbuzz_project:harfbuzz"
 )
 license=('spdx:MIT')
@@ -23,17 +27,28 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
              "${MINGW_PACKAGE_PREFIX}-icu"
              "${MINGW_PACKAGE_PREFIX}-cairo"
+             $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-chafa")
              "${MINGW_PACKAGE_PREFIX}-ragel")
 depends=("${MINGW_PACKAGE_PREFIX}-freetype"
          "${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-gettext-runtime"
          "${MINGW_PACKAGE_PREFIX}-glib2"
          "${MINGW_PACKAGE_PREFIX}-graphite2")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-fonttools"
               "${MINGW_PACKAGE_PREFIX}-python-setuptools")
-optdepends=("${MINGW_PACKAGE_PREFIX}-icu: harfbuzz-icu support"
-            "${MINGW_PACKAGE_PREFIX}-cairo: hb-view program")
-source=("https://github.com/harfbuzz/harfbuzz/releases/download/${pkgver}/harfbuzz-${pkgver}.tar.xz")
-sha256sums=('77e4f7f98f3d86bf8788b53e6832fb96279956e1c3961988ea3d4b7ca41ddc27')
+source=("https://github.com/harfbuzz/harfbuzz/releases/download/${pkgver}/harfbuzz-${pkgver}.tar.xz"
+        "001-fix-build-with-chafa.patch")
+sha256sums=('a41b272ceeb920c57263ec851604542d9ec85ee3030506d94662067c7b6ab89e'
+            '26b37a1ca9872973905ecb96bcbe3f054472252320956faa74428206900d360e')
+noextract=("harfbuzz-${pkgver}.tar.xz")
+
+prepare() {
+  echo "Extracting harfbuzz-${pkgver}.tar.xz..."
+  tar -xJf harfbuzz-${pkgver}.tar.xz || true
+
+  cd ${_realname}-${pkgver}
+  patch -p1 -i "${srcdir}"/001-fix-build-with-chafa.patch
+}
 
 build() {
   local -a _static_flags=(
@@ -44,6 +59,13 @@ build() {
     -DGRAPHITE2_STATIC
     -DCAIRO_WIN32_STATIC_BUILD
   )
+
+  declare -a _extra_config
+  if [[ ${CARCH} != i686 ]]; then
+    _extra_config+=("-Dchafa=enabled")
+  else
+    _extra_config+=("-Dchafa=disabled")
+  fi
 
   CFLAGS+=" ${_static_flags[@]}" \
   CXXFLAGS+=" ${_static_flags[@]}" \
@@ -60,10 +82,10 @@ build() {
     -Dcpp_std=c++17 \
     -Dgdi=enabled \
     -Dgraphite=enabled \
-    -Dchafa=disabled \
     -Ddirectwrite=enabled \
     -Dtests=disabled \
     -Ddocs=disabled \
+    "${_extra_config[@]}" \
     "build-${MSYSTEM}-static" \
     "${_realname}-${pkgver}"
 
@@ -82,9 +104,9 @@ build() {
     -Dcpp_std=c++17 \
     -Dgdi=enabled \
     -Dgraphite=enabled \
-    -Dchafa=disabled \
     -Ddirectwrite=enabled \
     -Dtests=disabled \
+    "${_extra_config[@]}" \
     "build-${MSYSTEM}-shared" \
     "${_realname}-${pkgver}"
 
@@ -99,22 +121,70 @@ check(){
 }
 
 package_harfbuzz() {
+  pkgdesc+=" (mingw-w64)"
+
   ${MINGW_PREFIX}/bin/meson install -C "build-${MSYSTEM}-static" --destdir "${pkgdir}"
 
   ${MINGW_PREFIX}/bin/meson install -C "build-${MSYSTEM}-shared" --destdir "${pkgdir}"
 
-  mkdir -p dest${MINGW_PREFIX}/share
-  mv "${pkgdir}${MINGW_PREFIX}"/share/gtk-doc dest${MINGW_PREFIX}/share/gtk-doc
+  mkdir -p dest-docs${MINGW_PREFIX}/share
+  mv "${pkgdir}"${MINGW_PREFIX}/share/gtk-doc dest-docs${MINGW_PREFIX}/share/gtk-doc
 
-  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+  mkdir -p dest-utils${MINGW_PREFIX}/bin
+  mv "${pkgdir}"${MINGW_PREFIX}/bin/*.exe dest-utils${MINGW_PREFIX}/bin/
+
+  mkdir -p dest-cairo${MINGW_PREFIX}/bin
+  mkdir -p dest-cairo${MINGW_PREFIX}/include/harfbuzz/
+  mkdir -p dest-cairo${MINGW_PREFIX}/lib/pkgconfig
+  mv "${pkgdir}"${MINGW_PREFIX}/bin/libharfbuzz-cairo*.dll dest-cairo${MINGW_PREFIX}/bin/
+  mv "${pkgdir}"${MINGW_PREFIX}/include/harfbuzz/hb-cairo.h dest-cairo${MINGW_PREFIX}/include/harfbuzz/
+  mv "${pkgdir}"${MINGW_PREFIX}/lib/libharfbuzz-cairo*.a dest-cairo${MINGW_PREFIX}/lib/
+  mv "${pkgdir}"${MINGW_PREFIX}/lib/pkgconfig/harfbuzz-cairo.pc dest-cairo${MINGW_PREFIX}/lib/pkgconfig/
+
+  mkdir -p dest-icu${MINGW_PREFIX}/bin
+  mkdir -p dest-icu${MINGW_PREFIX}/include/harfbuzz/
+  mkdir -p dest-icu${MINGW_PREFIX}/lib/pkgconfig
+  mv "${pkgdir}"${MINGW_PREFIX}/bin/libharfbuzz-icu*.dll dest-icu${MINGW_PREFIX}/bin/
+  mv "${pkgdir}"${MINGW_PREFIX}/include/harfbuzz/hb-icu.h dest-icu${MINGW_PREFIX}/include/harfbuzz/
+  mv "${pkgdir}"${MINGW_PREFIX}/lib/libharfbuzz-icu*.a dest-icu${MINGW_PREFIX}/lib/
+  mv "${pkgdir}"${MINGW_PREFIX}/lib/pkgconfig/harfbuzz-icu.pc dest-icu${MINGW_PREFIX}/lib/pkgconfig/
+
+  install -Dm644 "${srcdir}"/${_realname}-${pkgver}/COPYING \
+    "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/COPYING
+}
+
+package_harfbuzz-cairo() {
+  pkgdesc+=" - Cairo integration (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-harfbuzz"
+           "${MINGW_PACKAGE_PREFIX}-cairo")
+
+  mv dest-cairo/* "${pkgdir}"
+}
+
+package_harfbuzz-icu() {
+  pkgdesc+=" - ICU integration (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-harfbuzz"
+           "${MINGW_PACKAGE_PREFIX}-icu")
+
+  mv dest-icu/* "${pkgdir}"
+}
+
+package_harfbuzz-utils() {
+  pkgdesc+=" - Utilities (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-harfbuzz"
+           "${MINGW_PACKAGE_PREFIX}-harfbuzz-cairo"
+           "${MINGW_PACKAGE_PREFIX}-cairo"
+           $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-chafa"))
+
+  mv dest-utils/* "${pkgdir}"
 }
 
 package_harfbuzz-docs() {
-  pkgdesc+=" (documentation)"
+  pkgdesc+=" - Documentation (mingw-w64)"
   depends=()
   optdepends=()
 
-  mv dest/* "${pkgdir}"
+  mv dest-docs/* "${pkgdir}"
 }
 
 # template start; name=mingw-w64-splitpkg-wrappers; version=1.0;


### PR DESCRIPTION
- Split package the same as Arch  (utils, icu and cairo)
- Enable chafa support (on non i686)