### PR TITLE
cargo-c: update to 0.10.1

### DIFF
--- a/mingw-w64-cargo-c/001-add-lib-prefix-on-windows-gnu.patch
+++ b/mingw-w64-cargo-c/001-add-lib-prefix-on-windows-gnu.patch
@@ -1,6 +1,6 @@
 --- a/src/build.rs
 +++ b/src/build.rs
-@@ -233,7 +233,7 @@
+@@ -230,7 +230,7 @@ fn build_implib_file(
              dlltool_command.arg("-D").arg(format!("{name}.dll"));
              dlltool_command
                  .arg("-l")
@@ -11,7 +11,7 @@
                  .arg(targetdir.join(format!("{name}.def")));
 --- a/src/build_targets.rs
 +++ b/src/build_targets.rs
-@@ -103,7 +103,7 @@
+@@ -111,7 +111,7 @@ impl BuildTargets {
                  let impl_lib = if env == "msvc" {
                      targetdir.join(format!("{lib_name}.dll.lib"))
                  } else {
@@ -19,4 +19,4 @@
 +                    targetdir.join(format!("lib{lib_name}.dll.a"))
                  };
                  let def = targetdir.join(format!("{lib_name}.def"));
-                 (shared_lib, static_lib, Some(impl_lib), Some(def))
+                 let pdb = if env == "msvc" {

--- a/mingw-w64-cargo-c/PKGBUILD
+++ b/mingw-w64-cargo-c/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=cargo-c
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.10.0
+pkgver=0.10.1
 pkgrel=1
 pkgdesc='A cargo subcommand to build and install C-ABI compatibile dynamic and static libraries (mingw-w64)'
 arch=('any')
@@ -15,17 +15,18 @@ msys2_references=(
 )
 license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-sqlite3"
-         "${MINGW_PACKAGE_PREFIX}-libssh2"
-         "${MINGW_PACKAGE_PREFIX}-libgit2")
+         "${MINGW_PACKAGE_PREFIX}-libssh2")
+         #"${MINGW_PACKAGE_PREFIX}-libgit2") uncomment after `git2` will be updated
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-openssl")
+options=('!strip')
 source=("https://github.com/lu-zero/cargo-c/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
         "${_realname}-${pkgver}.Cargo.lock"::"https://github.com/lu-zero/cargo-c/releases/download/v${pkgver}/Cargo.lock"
         001-add-lib-prefix-on-windows-gnu.patch)
-sha256sums=('85230801f57c1f2b85d99fae3fc43f93080ecc0e3763a6af178fc5e6c218004b'
-            'ba3fee6cbeba8c4ea8d0ca56bc72bc616eb7f2a9e705017c8e612f16f472cc30'
-            'b749ffdb37eb6016dca37c41c2d644156bbd4a7d8ffaa7bc18c7813f7af646c0')
+sha256sums=('0f08ef800bd2c46968356d9445ee780085fcbb500a2e8ac3447f2e4a9981e939'
+            '9e9a363ba6e00e6b0cfb6164af76311c2650a59bc4550e1aebcbecb134161766'
+            '6953c5161a4b03a5c4919e31178011f6d9eb93548055c521348a067397cb9290')
 
 prepare() {
     cp "${srcdir}/${_realname}-${pkgver}.Cargo.lock" "${_realname}-${pkgver}/Cargo.lock"
@@ -33,11 +34,12 @@ prepare() {
 
     patch -p1 -i "${srcdir}"/001-add-lib-prefix-on-windows-gnu.patch
 
+    # cargo update -p git2 --precise 0.19.0
     cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
 }
 
 _env() {
-    export LIBGIT2_NO_VENDOR=1
+    # export LIBGIT2_NO_VENDOR=1
     export OPENSSL_NO_VENDOR=1
     export LIBSSH2_SYS_USE_PKG_CONFIG=1
     export LIBSQLITE3_SYS_USE_PKG_CONFIG=1
@@ -47,14 +49,14 @@ build() {
     cd "${srcdir}/${_realname}-${pkgver}"
 
     _env
-    cargo build --release --frozen
+    cargo build --frozen --profile release-strip
 }
 
 check() {
     cd "${srcdir}/${_realname}-${pkgver}"
 
     _env
-    cargo test --release --frozen
+    cargo test --frozen --profile release-strip
 }
 
 package() {
@@ -66,7 +68,8 @@ package() {
     --offline \
     --no-track \
     --path . \
-    --root "${pkgdir}${MINGW_PREFIX}"
+    --root "${pkgdir}${MINGW_PREFIX}" \
+    --profile release-strip
 
     install -Dm644 "LICENSE" -t "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
 }


### PR DESCRIPTION
cargo-c can't use libgit2>=1.8.1 at the moment, let it use vendored library; switch to release-strip profile