### PR TITLE
evince: Set subsystem to 'windows'

### DIFF
--- a/mingw-w64-evince/0010-no-console.patch
+++ b/mingw-w64-evince/0010-no-console.patch
@@ -1,0 +1,11 @@
+diff -bur evince-orig/shell/meson.build evince-46.3/shell/meson.build
+--- evince-orig/shell/meson.build	2024-06-29 19:17:37.549043300 -0600
++++ evince-46.3/shell/meson.build	2024-06-29 19:18:02.149608400 -0600
+@@ -93,6 +93,7 @@
+   dependencies: evince_deps,
+   c_args: evince_cflags,
+   install: true,
++  win_subsystem: 'windows'
+ )
+ 
+ if enable_dbus

--- a/mingw-w64-evince/PKGBUILD
+++ b/mingw-w64-evince/PKGBUILD
@@ -4,7 +4,7 @@ _realname=evince
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=46.3
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 pkgdesc="Document (PostScript, PDF) viewer (mingw-w64)"
@@ -45,12 +45,14 @@ source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname
         0003-mingw-dont-have-fcntl.patch
         0008-disable-pdf-document-load-fd.patch
         0009-evince-pe-icon.patch::https://gitlab.gnome.org/GNOME/evince/-/merge_requests/701.diff
-        evince.ico::https://gitlab.gnome.org/GNOME/evince/-/raw/24967ecf7f658bb69e512d6e09287c1ccc02c11c/shell/evince.ico?inline=false)
+        evince.ico::https://gitlab.gnome.org/GNOME/evince/-/raw/24967ecf7f658bb69e512d6e09287c1ccc02c11c/shell/evince.ico?inline=false
+        0010-no-console.patch)
 sha256sums=('bc0d1d41b9d7ffc762e99d2abfafacbf745182f0b31d86db5eec8c67f5f3006b'
             '5c011fb1dec0564dcea06d145a2cc3572641dcd021477eb1172ecddd9cacbffd'
             'f9e2010366f9185e1f6a18b9ac7207c792d970fd1636b3f3bd329f58259cf89e'
             '6b5a22b5b7ad8bd964c579ccd31a4776eecf0d33b3f10ffacb64774dfb70ff10'
-            '0b7493eef41f0907cb523d9165c7a67a13f05c7ee9fb5cce42f7ff3342bc4e4e')
+            '0b7493eef41f0907cb523d9165c7a67a13f05c7ee9fb5cce42f7ff3342bc4e4e'
+            'db40297acd4a5eaf7cc94464737020a22c2f9a952683f55adfc24a392de1af24')
 noextract=(${_realname}-${pkgver}.tar.xz)
 
 apply_patch_with_msg() {
@@ -68,7 +70,8 @@ prepare() {
   apply_patch_with_msg \
     0003-mingw-dont-have-fcntl.patch \
     0008-disable-pdf-document-load-fd.patch \
-    0009-evince-pe-icon.patch
+    0009-evince-pe-icon.patch \
+    0010-no-console.patch
 
   cp "${srcdir}/evince.ico" "shell/evince.ico"
 }


### PR DESCRIPTION
Fixes #19723 and #20519