### PR TITLE
inkscape: Explicitly link as 'windows' subsystem

### DIFF
--- a/mingw-w64-inkscape/007-no-console-clang.patch
+++ b/mingw-w64-inkscape/007-no-console-clang.patch
@@ -1,0 +1,13 @@
+diff -bur inkscape-orig/src/CMakeLists.txt inkscape-1.3.2/src/CMakeLists.txt
+--- inkscape-orig/src/CMakeLists.txt	2024-06-29 19:45:16.228456500 -0600
++++ inkscape-1.3.2/src/CMakeLists.txt	2024-06-29 19:46:58.260824900 -0600
+@@ -376,6 +376,9 @@
+ add_executable(inkscape ${main_SRC})
+ add_executable(inkview ${view_SRC})
+ if(WIN32)
++  set_target_properties(inkscape PROPERTIES WIN32_EXECUTABLE TRUE)
++  set_target_properties(inkview PROPERTIES WIN32_EXECUTABLE TRUE)
++
+   # Make the same executables again, but this time as console application (GUI applications can't print to the console)
+   add_executable(inkscape_com ${main_SRC})
+   set_target_properties(inkscape_com

--- a/mingw-w64-inkscape/PKGBUILD
+++ b/mingw-w64-inkscape/PKGBUILD
@@ -6,7 +6,7 @@ _realname=inkscape
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.3.2
-pkgrel=6
+pkgrel=7
 pkgdesc="Vector graphics editor using the SVG file format (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -76,14 +76,16 @@ source=("https://media.inkscape.org/dl/resources/file/${_realname}-${pkgver}.tar
         003-include-missing-header.patch::https://gitlab.com/inkscape/inkscape/-/commit/694d8ae4.patch
         004-up-c++-to-c++20.patch::https://gitlab.com/inkscape/inkscape/-/commit/1798e9c1.patch
         005-fix-build-with-poppler-24.03.patch::https://gitlab.com/inkscape/inkscape/-/commit/f7e94457.patch
-        006-fix-build-with-poppler-24.05.patch::https://gitlab.com/inkscape/inkscape/-/commit/96ca7a6c.patch)
+        006-fix-build-with-poppler-24.05.patch::https://gitlab.com/inkscape/inkscape/-/commit/96ca7a6c.patch
+        007-no-console-clang.patch)
 sha256sums=('dbd1844dc443fe5e10d3e9a887144e5fb7223852fff191cfb5ef7adeab0e086b'
             '92387251c1740f1a57cde9e587cc673ef1600813617bd2c9db65598c324a24d4'
             '131b2e1190637df0554ef1ee8cf46440689584375c117d057ab47d5871c58128'
             'edc55ad0771b604c63737524fc5928a35334db04d6479e395801635d5f6dfc1f'
             '658f9d5c63af94e5e85d649e1fd9d45d6639916702154197dfa25afc1a515145'
             '8b85c64eb65d248c1b8cf5b670314dad67be63f3b6e8235e0473e73f53255bed'
-            'a83bb96779db1d3ed475d32e67c4ef1a5b56675c7cf323a04c5b28f938a0ac4e')
+            'a83bb96779db1d3ed475d32e67c4ef1a5b56675c7cf323a04c5b28f938a0ac4e'
+            'c49d38b7c1a66e4b40e1b75fb055b730eb863a67a74d899da6d4d6db6baedcec')
 noextract=("${_realname}-${pkgver}.tar.xz")
 
 apply_patch_with_msg() {
@@ -107,7 +109,8 @@ prepare() {
     003-include-missing-header.patch \
     004-up-c++-to-c++20.patch \
     005-fix-build-with-poppler-24.03.patch \
-    006-fix-build-with-poppler-24.05.patch
+    006-fix-build-with-poppler-24.05.patch \
+    007-no-console-clang.patch
 }
 
 build() {


### PR DESCRIPTION
Interesting case. MinGW builds are defaulting to windows subsystem (i.e. UCRT64), but CLANG64 and CLANGARM64 are not, so explicitly set the flag.