### PR TITLE
libgridxc: No MPI on aarch64

### DIFF
--- a/mingw-w64-libgridxc/PKGBUILD
+++ b/mingw-w64-libgridxc/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libgridxc
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.1.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Library for XC computation on grids. (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -19,7 +19,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 makedepends=("${MINGW_PACKAGE_PREFIX}-fc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
-             "${MINGW_PACKAGE_PREFIX}-msmpi")
+             $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || echo "${MINGW_PACKAGE_PREFIX}-msmpi"))
 source=("https://gitlab.com/siesta-project/libraries/libgridxc/-/archive/${pkgver}/${_realname}-${pkgver}.tar.bz2"
         "001-fix-install-dll.patch"
         "002-fix-pkgconf-file.patch")
@@ -56,7 +56,7 @@ build() {
       -DBUILD_SHARED_LIBS=ON \
       -DCMAKE_DLL_NAME_WITH_SOVERSION=ON \
       -DLIBGRIDXC_WITH_LIBXC=ON \
-      -DLIBGRIDXC_WITH_MPI=ON \
+      $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-aarch64* ]] || echo "-DLIBGRIDXC_WITH_MPI=ON") \
       -DLIBGRIDXC_TESTS=OFF \
       -DFortran_FLAGS_RELEASE="-O3" \
       -S "${_realname}-${pkgver}" \


### PR DESCRIPTION
Fixes:
![image](https://github.com/msys2/MINGW-packages/assets/1100440/94020569-3b4f-4237-957e-43178642d9f2)
