### PR TITLE
mpv,mujs,vapoursynth: Enable aarch64 builds

### DIFF
--- a/mingw-w64-mpv/PKGBUILD
+++ b/mingw-w64-mpv/PKGBUILD
@@ -5,7 +5,7 @@ _realname=mpv
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.38.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Video player based on MPlayer/mplayer2 (mingw-w64)"
 url="https://mpv.io/"
 msys2_repository_url="https://github.com/mpv-player/mpv"
@@ -13,8 +13,8 @@ msys2_references=(
   "cpe: cpe:/a:mpv:mpv"
 )
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64')
-license=('spx:GPL-2.0-only' 'spx:LGPL-2.1-only')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+license=('spdx:GPL-2.0-or-later')
 depends=("${MINGW_PACKAGE_PREFIX}-ffmpeg"
          "${MINGW_PACKAGE_PREFIX}-lcms2"
          "${MINGW_PACKAGE_PREFIX}-libarchive"
@@ -61,6 +61,7 @@ build() {
       --buildtype=plain \
       -Dlibmpv=true \
       -Djavascript=enabled \
+      $([[ ${CARCH} == aarch64 ]] && echo "-Dgl=disabled") \
       ../${_realname}-${pkgver}
 
   meson compile

--- a/mingw-w64-mujs/PKGBUILD
+++ b/mingw-w64-mujs/PKGBUILD
@@ -6,7 +6,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.3.5
 pkgrel=1
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 msys2_references=(
   'archlinux: mujs'
 )

--- a/mingw-w64-vapoursynth/PKGBUILD
+++ b/mingw-w64-vapoursynth/PKGBUILD
@@ -7,7 +7,7 @@ pkgver=65
 pkgrel=1
 pkgdesc="A video processing framework with simplicity in mind (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 msys2_references=(
   'archlinux: vapoursynth'
 )


### PR DESCRIPTION
![image](https://github.com/msys2/MINGW-packages/assets/1100440/ca6b37a6-e588-4b99-ac06-0ff3d94d03c4)
