### PR TITLE
texlive-bin: Rebuild with current runtime and compiler

### DIFF
--- a/mingw-w64-texlive-bin/0005-untighten_version_check_zlib.patch
+++ b/mingw-w64-texlive-bin/0005-untighten_version_check_zlib.patch
@@ -1,0 +1,16 @@
+Description: Untighten version check of runtime linked zlib. Fix for #1056183.
+Forwarded: not-done, could be done
+Author: Hilmar Preuße <hille42@web.de>
+Last-Update: 20231119
+
+--- texlive-bin.orig/texk/web2c/luatexdir/luazlib/lzlib.c
++++ texlive-bin/texk/web2c/luatexdir/luazlib/lzlib.c
+@@ -546,7 +546,7 @@
+ 
+     /* make sure header and library version are consistent */
+     const char* version = zlibVersion();
+-    if (strncmp(version, ZLIB_VERSION, 4))
++    if (strncmp(version, ZLIB_VERSION, 2))
+     {
+         lua_pushfstring(L, "zlib library version does not match - header: %s, library: %s", ZLIB_VERSION, version);
+         lua_error(L);

--- a/mingw-w64-texlive-bin/0006-workaround-pathconf.patch
+++ b/mingw-w64-texlive-bin/0006-workaround-pathconf.patch
@@ -1,0 +1,122 @@
+Work around issue https://github.com/msys2/msys2-runtime/issues/208 by
+converting from relative to absolute paths in the path lists using cygpath.
+
+diff -urN texlive-source/texk/web2c/Makefile.am.orig texlive-source/texk/web2c/Makefile.am
+--- texlive-source/texk/web2c/Makefile.am.orig	2023-05-02 17:26:43.000000000 +0200
++++ texlive-source/texk/web2c/Makefile.am	2024-07-01 17:56:04.403102900 +0200
+@@ -150,8 +150,8 @@
+ buildenv = TEXMFCNF=$(srcdir)/../kpathsea
+ 
+ # Calling tangle & Co.
+-tangle = $(tangle_silent)WEBINPUTS=.:$(srcdir) $(buildenv) $(TANGLE)
+-tangleboot = $(tangle_silent)WEBINPUTS=.:$(srcdir) $(buildenv) $(TANGLEBOOT)
++tangle = $(tangle_silent)WEBINPUTS=`cygpath -ua .`:`cygpath -ua $(srcdir)` $(buildenv) $(TANGLE)
++tangleboot = $(tangle_silent)WEBINPUTS=`cygpath -ua .`:`cygpath -ua $(srcdir)` $(buildenv) $(TANGLEBOOT)
+ tangle_silent = $(tangle_silent_@AM_V@)
+ tangle_silent_ = $(tangle_silent_@AM_DEFAULT_V@)
+ tangle_silent_0 = @echo "  TANGLE  " $@; $(SHELL) ./silent-sh $@ #
+@@ -163,7 +163,7 @@
+ ctangle_silent_0 = @echo "  CTANGLE " $@; $(SHELL) ./silent-sh $@ #
+ ctangle_silent_1 =
+ #
+-tie = $(tie_silent)WEBINPUTS=.:$(srcdir) $(buildenv) $(TIE)
++tie = $(tie_silent)WEBINPUTS=`cygpath -ua .`:`cygpath -ua $(srcdir)` $(buildenv) $(TIE)
+ tie_silent = $(tie_silent_@AM_V@)
+ tie_silent_ = $(tie_silent_@AM_DEFAULT_V@)
+ tie_silent_0 = @echo "  TIE     " $@; $(SHELL) ./silent-sh $@ #
+@@ -172,7 +172,7 @@
+ tie_m = $(tie) -m $@
+ 
+ # Calling tangle & Co. via tangle-sh (several output files)
+-texmf_tangle = WEBINPUTS=.:$(srcdir) AM_V_P=$(AM_V_P) $(SHELL) ./tangle-sh $@ $(TANGLE)
++texmf_tangle = WEBINPUTS=`cygpath -ua .`:`cygpath -ua $(srcdir)` AM_V_P=$(AM_V_P) $(SHELL) ./tangle-sh $@ $(TANGLE)
+ 
+ # For trip, trap, and other tests
+ DIFF = diff
+diff -urN texlive-source/texk/web2c/alephdir/am/aleph.am.orig texlive-source/texk/web2c/alephdir/am/aleph.am
+--- texlive-source/texk/web2c/alephdir/am/aleph.am.orig	2023-05-02 17:26:43.000000000 +0200
++++ texlive-source/texk/web2c/alephdir/am/aleph.am	2024-07-01 18:18:36.639902800 +0200
+@@ -12,7 +12,7 @@
+ endif ALEPH
+ EXTRA_PROGRAMS += aleph
+ 
+-al_tangle = WEBINPUTS=.:$(srcdir) AM_V_P=$(AM_V_P) $(SHELL) ./tangle-sh $@ $(OTANGLE)
++al_tangle = WEBINPUTS=`cygpath -ua .`:`cygpath -ua $(srcdir)` AM_V_P=$(AM_V_P) $(SHELL) ./tangle-sh $@ $(OTANGLE)
+ 
+ # With --enable-ipc, Aleph may need to link with -lsocket.
+ aleph_LDADD = $(LDADD) $(ipc_socketlibs)
+diff -urN texlive-source/texk/web2c/omegaware/am/omegaware.am.orig texlive-source/texk/web2c/omegaware/am/omegaware.am
+--- texlive-source/texk/web2c/omegaware/am/omegaware.am.orig	2023-05-02 17:26:43.000000000 +0200
++++ texlive-source/texk/web2c/omegaware/am/omegaware.am	2024-07-01 18:22:19.650570400 +0200
+@@ -17,7 +17,7 @@
+ 	$(omegaware_programs:=.p) $(omegaware_programs:=-web2c)
+ 
+ ow_tangle = WEBINPUTS=$(srcdir)/omegaware $(buildenv) $(TANGLE)
+-ow_otangle = WEBINPUTS=.:$(srcdir)/omegaware $(buildenv) $(OTANGLE)
++ow_otangle = WEBINPUTS=`cygpath -ua .`:`cygpath -ua $(srcdir)`/omegaware $(buildenv) $(OTANGLE)
+ 
+ nodist_odvicopy_SOURCES = odvicopy.c odvicopy.h
+ odvicopy.c odvicopy.h: odvicopy-web2c
+diff -urN texlive-source/texk/web2c/pdftexdir/am/pdftex.am.orig texlive-source/texk/web2c/pdftexdir/am/pdftex.am
+--- texlive-source/texk/web2c/pdftexdir/am/pdftex.am.orig	2023-05-02 17:26:43.000000000 +0200
++++ texlive-source/texk/web2c/pdftexdir/am/pdftex.am	2024-07-01 18:24:14.593833300 +0200
+@@ -24,7 +24,7 @@
+ # Force Automake to use CXXLD for linking
+ nodist_EXTRA_pdftex_SOURCES = dummy.cxx
+ 
+-pdf_tangle = WEBINPUTS=.:$(srcdir)/pdftexdir AM_V_P=$(AM_V_P) $(SHELL) ./tangle-sh $@ $(TANGLE)
++pdf_tangle = WEBINPUTS=`cygpath -ua .`:`cygpath -ua $(srcdir)`/pdftexdir AM_V_P=$(AM_V_P) $(SHELL) ./tangle-sh $@ $(TANGLE)
+ 
+ pdftex_CPPFLAGS = $(pdftex_cppflags)
+ pdftex_CXXFLAGS = $(WARNING_CXXFLAGS)
+diff -urN texlive-source/texk/web2c/pmpostdir/am/pmpost.am.orig texlive-source/texk/web2c/pmpostdir/am/pmpost.am
+--- texlive-source/texk/web2c/pmpostdir/am/pmpost.am.orig	2023-05-02 17:26:43.000000000 +0200
++++ texlive-source/texk/web2c/pmpostdir/am/pmpost.am	2024-07-01 18:25:56.320255600 +0200
+@@ -60,9 +60,9 @@
+ endif WIN32
+ 
+ # Creating one file: just one rule
+-pmp_ctangle = $(ctangle_silent)CWEBINPUTS=.:$(srcdir)/pmpostdir $(ctangle)
++pmp_ctangle = $(ctangle_silent)CWEBINPUTS=`cygpath -ua .`:`cygpath -ua $(srcdir)`/pmpostdir $(ctangle)
+ # Creating several files: need stamp file and two rules with identical recipes
+-pmp_ctangle_sh = CWEBINPUTS=.:$(srcdir)/pmpostdir AM_V_P=$(AM_V_P) $(SHELL) ./tangle-sh $@ $(CTANGLE)
++pmp_ctangle_sh = CWEBINPUTS=`cygpath -ua .`:`cygpath -ua $(srcdir)`/pmpostdir AM_V_P=$(AM_V_P) $(SHELL) ./tangle-sh $@ $(CTANGLE)
+ 
+ ## pMetaPost C sources
+ nodist_pmpost_SOURCES = $(pmp_c_h) $(pmpmath_c_h) $(pmpmathbinary_c_h) \
+diff -urN texlive-source/texk/web2c/ptexdir/am/ptex.am.orig texlive-source/texk/web2c/ptexdir/am/ptex.am
+--- texlive-source/texk/web2c/ptexdir/am/ptex.am.orig	2023-05-02 17:26:43.000000000 +0200
++++ texlive-source/texk/web2c/ptexdir/am/ptex.am	2024-07-01 18:27:36.262842400 +0200
+@@ -8,7 +8,7 @@
+ ptex_cppflags = $(PTEXENC_INCLUDES) $(AM_CPPFLAGS) $(ZLIB_INCLUDES)
+ ptex_ldadd = libkanji.a $(pproglib) $(PTEXENC_LIBS) $(LDADD) $(ZLIB_LIBS)
+ ptex_dependencies = libkanji.a $(pproglib) $(PTEXENC_DEPEND) $(ZLIB_DEPEND) $(default_dependencies)
+-p_tangle = $(tangle_silent)WEBINPUTS=.:$(srcdir)/ptexdir:$(srcdir) $(buildenv) $(TANGLE)
++p_tangle = $(tangle_silent)WEBINPUTS=`cygpath -ua .`:`cygpath -ua $(srcdir)`/ptexdir:`cygpath -ua $(srcdir)` $(buildenv) $(TANGLE)
+ 
+ 
+ ## pTeX library
+diff -urN texlive-source/texk/web2c/uptexdir/am/uptex.am.orig texlive-source/texk/web2c/uptexdir/am/uptex.am
+--- texlive-source/texk/web2c/uptexdir/am/uptex.am.orig	2023-05-02 17:26:43.000000000 +0200
++++ texlive-source/texk/web2c/uptexdir/am/uptex.am	2024-07-01 18:28:53.067444000 +0200
+@@ -8,7 +8,7 @@
+ uptex_cppflags = $(PTEXENC_INCLUDES) $(AM_CPPFLAGS) $(ZLIB_INCLUDES)
+ uptex_ldadd = libukanji.a $(pproglib) $(PTEXENC_LIBS) $(LDADD) $(ZLIB_LIBS)
+ uptex_dependencies = libukanji.a $(pproglib) $(PTEXENC_DEPEND) $(ZLIB_DEPEND) $(default_dependencies)
+-up_tangle = $(tangle_silent)WEBINPUTS=.:$(srcdir)/uptexdir:$(srcdir) $(buildenv) $(TANGLE)
++up_tangle = $(tangle_silent)WEBINPUTS=`cygpath -ua .`:`cygpath -ua $(srcdir)`/uptexdir:`cygpath -ua $(srcdir)` $(buildenv) $(TANGLE)
+ 
+ upweb_programs = upbibtex updvitype uppltotf uptftopl
+ 
+diff -urN texlive-source/texk/web2c/xetexdir/am/xetex.am.orig texlive-source/texk/web2c/xetexdir/am/xetex.am
+--- texlive-source/texk/web2c/xetexdir/am/xetex.am.orig	2023-05-02 17:26:43.000000000 +0200
++++ texlive-source/texk/web2c/xetexdir/am/xetex.am	2024-07-01 18:30:15.864686600 +0200
+@@ -15,7 +15,7 @@
+ # Force Automake to use CXXLD for linking
+ nodist_EXTRA_xetex_SOURCES = dummy.cxx
+ 
+-xe_tangle = WEBINPUTS=.:$(srcdir)/xetexdir AM_V_P=$(AM_V_P) $(SHELL) ./tangle-sh $@ $(OTANGLE)
++xe_tangle = WEBINPUTS=`cygpath -ua .`:`cygpath -ua $(srcdir)`/xetexdir AM_V_P=$(AM_V_P) $(SHELL) ./tangle-sh $@ $(OTANGLE)
+ 
+ libxetex = libxetex.a
+ 

--- a/mingw-w64-texlive-bin/0007-stat.patch
+++ b/mingw-w64-texlive-bin/0007-stat.patch
@@ -1,0 +1,26 @@
+diff --git a/texk/web2c/lib/texmfmp.c b/texk/web2c/lib/texmfmp.c
+index e7379c60c0..804209882c 100644
+--- a/texk/web2c/lib/texmfmp.c
++++ b/texk/web2c/lib/texmfmp.c
+@@ -174,6 +174,8 @@ FILE *Poptr;
+ #undef xfopen
+ #define fopen fsyscp_fopen
+ #define xfopen fsyscp_xfopen
++#undef stat
++#define stat _stat
+ #include <wchar.h>
+ int
+ fsyscp_stat(const char *path, struct stat *buffer)
+diff --git a/texk/dvipdfm-x/dpxfile.c b/texk/dvipdfm-x/dpxfile.c
+index 2ffa246049..895b085f18 100644
+--- a/texk/dvipdfm-x/dpxfile.c
++++ b/texk/dvipdfm-x/dpxfile.c
+@@ -160,6 +160,8 @@ static char  _tmpbuf[PATH_MAX+1];
+ #endif /* MIKTEX */
+ 
+ #if defined(_WIN32)
++#undef stat
++#define stat _stat
+ extern int utf8name_failed;
+ int fsyscp_stat(const char *path, struct stat *buffer)
+ {

--- a/mingw-w64-texlive-bin/PKGBUILD
+++ b/mingw-w64-texlive-bin/PKGBUILD
@@ -53,13 +53,15 @@ source=(
     "0002-fix-lauchers-mingw32.patch"
     "0003-runscript-always-quote-args.patch"
     "0004-add-missing-includes-dvisvgm.patch"
-    "0005-untighten_version_check_zlib.patch")
+    "0005-untighten_version_check_zlib.patch"
+    "0006-workaround-pathconf.patch")
 sha256sums=('d3eca31c6a16a168f66471ce3837b7c950826967162eab04d58233f52462527e'
             '86ef2a99b2f0caed42777419837d9b539af1d1c8a101701e539e5467bb88662e'
             'decff8db61302c2a1760cfd4b42aaf0e25fcb7d2b9621cea3ec3f4c2557976a1'
             'c22ad079777082ebb7fe90e64d3f0d20b75756e50af776f2d4c1b9f9e692dba3'
             '46d9572ae1e178377f9ab4c11696cb1fbff0999b9719c6e17b5dbbe790b267a3'
-            'f805930ee0396aea3c6d189c078ad57d4c5c9212f6f3cb7f25e0c74b8151e0b1')
+            'f805930ee0396aea3c6d189c078ad57d4c5c9212f6f3cb7f25e0c74b8151e0b1'
+            'e0fd72b6863156520bc7f30e446a991df6f35ec36de7a5ab2f767a091c2ea451')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -80,6 +82,9 @@ prepare() {
     # https://github.com/debian-tex/texlive-bin/blob/6dae83df50df3edc/debian/patches/untighten_version_check_zlib.diff
     apply_patch_with_msg 0005-untighten_version_check_zlib.patch
 
+    # Remove when https://github.com/msys2/msys2-runtime/issues/208 is fixed:
+    apply_patch_with_msg 0006-workaround-pathconf.patch
+
     # from https://github.com/archlinux/svntogit-packages/blob/packages/texlive-bin/trunk/PKGBUILD#L21
     # bibtex-x needs kpathsea flags
     sed -i '/AC_SEARCH_LIBS/a KPSE_KPATHSEA_FLAGS' texk/bibtex-x/configure.ac
@@ -98,6 +103,10 @@ prepare() {
     popd
 
     pushd texk/bibtex-x
+    autoreconf -fiv
+    popd
+
+    pushd texk/web2c
     autoreconf -fiv
     popd
 }

--- a/mingw-w64-texlive-bin/PKGBUILD
+++ b/mingw-w64-texlive-bin/PKGBUILD
@@ -98,6 +98,7 @@ prepare() {
     # t4ht expects to be un /usr/share/texmf/bin/t4ht (FS#27251)
     sed -i s/SELFAUTOPARENT/TEXMFROOT/ texk/tex4htk/t4ht.c
 
+    msg2 "Running autoreconf for all (sub-)projects with changed configuration files"
     autoreconf -fiv
     # WTF?
     pushd texk/chktex
@@ -125,7 +126,7 @@ build() {
    mkdir -p Work
    cd Work
    echo "--> Initial configuration..."
-   CXXFLAGS+=" -std=gnu++14"
+   CXX+=" -std=gnu++17"
    CFLAGS+=" -Wno-error=incompatible-pointer-types"
    # we use temporary prefix to avoid messing the existing
    # $pkgdir/usr/share/texmf tree
@@ -167,8 +168,8 @@ build() {
    echo "-------------------------------------------------------"
    make
 
-   msg "Building Lauchers"
-   # let's build lauchers first
+   msg "Building Launchers"
+   # let's build launchers first
    # it is present in ../texk/texlive/windows_mingw_wrapper wrapper
 
    # first delete *.exe and *.dll from the locations

--- a/mingw-w64-texlive-bin/PKGBUILD
+++ b/mingw-w64-texlive-bin/PKGBUILD
@@ -54,14 +54,16 @@ source=(
     "0003-runscript-always-quote-args.patch"
     "0004-add-missing-includes-dvisvgm.patch"
     "0005-untighten_version_check_zlib.patch"
-    "0006-workaround-pathconf.patch")
+    "0006-workaround-pathconf.patch"
+    "0007-stat.patch")
 sha256sums=('d3eca31c6a16a168f66471ce3837b7c950826967162eab04d58233f52462527e'
             '86ef2a99b2f0caed42777419837d9b539af1d1c8a101701e539e5467bb88662e'
             'decff8db61302c2a1760cfd4b42aaf0e25fcb7d2b9621cea3ec3f4c2557976a1'
             'c22ad079777082ebb7fe90e64d3f0d20b75756e50af776f2d4c1b9f9e692dba3'
             '46d9572ae1e178377f9ab4c11696cb1fbff0999b9719c6e17b5dbbe790b267a3'
             'f805930ee0396aea3c6d189c078ad57d4c5c9212f6f3cb7f25e0c74b8151e0b1'
-            'e0fd72b6863156520bc7f30e446a991df6f35ec36de7a5ab2f767a091c2ea451')
+            'e0fd72b6863156520bc7f30e446a991df6f35ec36de7a5ab2f767a091c2ea451'
+            'e4682accd42f3cde2df65628a13c1ba2b19fb779207dc6dad832d1c7b7cb4ab6')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -84,6 +86,10 @@ prepare() {
 
     # Remove when https://github.com/msys2/msys2-runtime/issues/208 is fixed:
     apply_patch_with_msg 0006-workaround-pathconf.patch
+
+    # https://github.com/TeX-Live/texlive-source/commit/1622d0ff6363d5cb2a4a81cdffb72b78fe7c6ef9
+    # https://github.com/TeX-Live/texlive-source/commit/21a44442e9932284f5d7dc724ac35ef01bd683dc
+    apply_patch_with_msg 0007-stat.patch
 
     # from https://github.com/archlinux/svntogit-packages/blob/packages/texlive-bin/trunk/PKGBUILD#L21
     # bibtex-x needs kpathsea flags
@@ -120,6 +126,7 @@ build() {
    cd Work
    echo "--> Initial configuration..."
    CXXFLAGS+=" -std=gnu++14"
+   CFLAGS+=" -Wno-error=incompatible-pointer-types"
    # we use temporary prefix to avoid messing the existing
    # $pkgdir/usr/share/texmf tree
    ../configure --prefix="${MINGW_PREFIX}" -C \

--- a/mingw-w64-texlive-bin/PKGBUILD
+++ b/mingw-w64-texlive-bin/PKGBUILD
@@ -4,7 +4,7 @@ pkgbase=mingw-w64-texlive-bin
 pkgname=("${MINGW_PACKAGE_PREFIX}-texlive-bin" "${MINGW_PACKAGE_PREFIX}-libsynctex")
 pkgver=2023.20230523
 pkgdesc="TeX Live binaries (mingw-w64)"
-pkgrel=6
+pkgrel=7
 license=('GPL')
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -52,12 +52,14 @@ source=(
     "0001-Remove-DLUASOCKET_INET_PTON-from-Makefile.patch"
     "0002-fix-lauchers-mingw32.patch"
     "0003-runscript-always-quote-args.patch"
-    "0004-add-missing-includes-dvisvgm.patch")
+    "0004-add-missing-includes-dvisvgm.patch"
+    "0005-untighten_version_check_zlib.patch")
 sha256sums=('d3eca31c6a16a168f66471ce3837b7c950826967162eab04d58233f52462527e'
             '86ef2a99b2f0caed42777419837d9b539af1d1c8a101701e539e5467bb88662e'
             'decff8db61302c2a1760cfd4b42aaf0e25fcb7d2b9621cea3ec3f4c2557976a1'
             'c22ad079777082ebb7fe90e64d3f0d20b75756e50af776f2d4c1b9f9e692dba3'
-            '46d9572ae1e178377f9ab4c11696cb1fbff0999b9719c6e17b5dbbe790b267a3')
+            '46d9572ae1e178377f9ab4c11696cb1fbff0999b9719c6e17b5dbbe790b267a3'
+            'f805930ee0396aea3c6d189c078ad57d4c5c9212f6f3cb7f25e0c74b8151e0b1')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -73,6 +75,10 @@ prepare() {
     apply_patch_with_msg 0001-Remove-DLUASOCKET_INET_PTON-from-Makefile.patch
     apply_patch_with_msg 0003-runscript-always-quote-args.patch
     apply_patch_with_msg 0004-add-missing-includes-dvisvgm.patch
+
+    # https://github.com/msys2/MINGW-packages/issues/18251
+    # https://github.com/debian-tex/texlive-bin/blob/6dae83df50df3edc/debian/patches/untighten_version_check_zlib.diff
+    apply_patch_with_msg 0005-untighten_version_check_zlib.patch
 
     # from https://github.com/archlinux/svntogit-packages/blob/packages/texlive-bin/trunk/PKGBUILD#L21
     # bibtex-x needs kpathsea flags


### PR DESCRIPTION
This is an attempt to fix some build errors of the texlive-bin package. It is based on the changes from #19921.

It works around the issue with the conversion of path lists (https://github.com/msys2/msys2-runtime/issues/208) by manually converting the respective paths from relative to absolute using `cygpath`.
It also cherry-picks some fixes from upstream and uses the `-Wno-error=incompatible-pointer-types` work-around to avoid some build errors with GCC 14.

It still fails with errors (in an ICU header iiuc). Maybe, someone has hints how to fix that or would like to continue from here.

It fails with errors like the following for me locally:
```
In file included from C:/msys64/mingw64/include/unicode/ubidi.h:26,
                 from ../../../texk/web2c/xetexdir/XeTeXLayoutInterface.cpp:37:
C:/msys64/mingw64/include/unicode/localpointer.h:561:26: error: 'auto' parameter not permitted in this context
  561 | template <typename Type, auto closeFunction>
      |                          ^~~~
C:/msys64/mingw64/include/unicode/localpointer.h:573:76: error: template argument 2 is invalid
  573 |     explicit LocalOpenPointer(std::unique_ptr<Type, decltype(closeFunction)> &&p)
      |                                                                            ^
C:/msys64/mingw64/include/unicode/localpointer.h:583:78: error: template argument 2 is invalid
  583 |     LocalOpenPointer &operator=(std::unique_ptr<Type, decltype(closeFunction)> &&p) {
      |                                                                              ^
C:/msys64/mingw64/include/unicode/localpointer.h:599:59: error: template argument 2 is invalid
  599 |     operator std::unique_ptr<Type, decltype(closeFunction)> () && {
      |                                                           ^
C:/msys64/mingw64/include/unicode/ubidi.h:579:1: note: invalid template non-type parameter
  579 | U_DEFINE_LOCAL_OPEN_POINTER(LocalUBiDiPointer, UBiDi, ubidi_close);
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```
