### PR TITLE
llvm-15: Add ARM and RISCV targets

### DIFF
--- a/mingw-w64-llvm-15/PKGBUILD
+++ b/mingw-w64-llvm-15/PKGBUILD
@@ -19,7 +19,7 @@ _version=15.0.7
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
-pkgrel=2
+pkgrel=3
 pkgdesc="C language family frontend for LLVM 15 (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -165,7 +165,7 @@ build() {
 
   local _projects="clang;compiler-rt"
 
-  platform_config+=(-DLLVM_TARGETS_TO_BUILD="AArch64;X86")
+  platform_config+=(-DLLVM_TARGETS_TO_BUILD="AArch64;ARM;RISCV;X86")
 
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
 


### PR DESCRIPTION
We need it at https://github.com/m-labs/artiq . 

Previously, llvmlite was depending on LLVM 14, which had these targets. Now it retargeted to newer LLVM, which broke both our platforms. 