### PR TITLE
libheif: add upstream TIFF decoder patch

### DIFF
--- a/mingw-w64-libheif/PKGBUILD
+++ b/mingw-w64-libheif/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libheif
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.18.0
-pkgrel=1
+pkgrel=2
 pkgdesc="HEIF image decoder/encoder library and tools (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -36,14 +36,17 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-x265"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 source=("https://github.com/strukturag/libheif/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz"
-        https://github.com/strukturag/libheif/pull/1236.patch)
+        https://github.com/strukturag/libheif/pull/1236.patch
+        https://github.com/strukturag/libheif/pull/1237.patch)
 sha256sums=('3f25f516d84401d7c22a24ef313ae478781b95f235c250b06152701c401055c3'
-            '9e99909ab81c5ff3cee2b91176171973a72654a8aeaff2f6c94390a5962f2826')
+            '9e99909ab81c5ff3cee2b91176171973a72654a8aeaff2f6c94390a5962f2826'
+            '41f8dc860b138540b6c02add50c9c6d1e69a1e44f053b898c8d567dbf355e954')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
 
   patch -Np1 -i "${srcdir}"/1236.patch
+  patch -Np1 -i "${srcdir}"/1237.patch
 }
 
 build() {
@@ -74,8 +77,6 @@ build() {
       -DWITH_JPEG_ENCODER=ON \
       -DWITH_OpenJPEG_DECODER=ON \
       -DWITH_OpenJPEG_ENCODER=ON \
-      -DWITH_OPENJPH_DECODER=$( [[ ${CARCH} == i686 ]] &&
-                        echo "OFF" || echo "ON" ) \
       -DWITH_OPENJPH_ENCODER=$( [[ ${CARCH} == i686 ]] &&
                         echo "OFF" || echo "ON" ) \
       -DX265_CFLAGS="-DX265_API_IMPORTS" \


### PR DESCRIPTION
Also, the `WITH_OPENJPH_DECODER` option is currently unused/not implemented.