### PR TITLE
python-coverage: update to 7.6.0

### DIFF
--- a/mingw-w64-python-coverage/PKGBUILD
+++ b/mingw-w64-python-coverage/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=7.5.1
+pkgver=7.6.0
 pkgrel=1
 pkgdesc="Code coverage measurement for Python (mingw-w64)"
 arch=('any')
@@ -24,7 +24,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-cc")
 options=(!strip)
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('54de9ef3a9da981f7af93eafde4ede199e0846cd819eb27c88e2b712aae9708c')
+sha256sums=('289cc803fa1dc901f84701ac10c9ee873619320f2f9aff38794db4a4a0268d51')
 
 prepare() { 
   rm -rf python-build-${MSYSTEM} | true


### PR DESCRIPTION
This updates Coverage.py to v7.6.0.