### PR TITLE
qt5-base: Change OpenGL to use "dynamic" mode to support fallback

### DIFF
--- a/mingw-w64-qt5-base/PKGBUILD
+++ b/mingw-w64-qt5-base/PKGBUILD
@@ -227,7 +227,7 @@ build() {
     -shared \
     -make-tool make \
     -I${MINGW_PREFIX}/include/mariadb \
-    -opengl desktop \
+    -opengl dynamic \
     -dbus \
     -fontconfig \
     -icu \

--- a/mingw-w64-qt5-base/PKGBUILD
+++ b/mingw-w64-qt5-base/PKGBUILD
@@ -25,7 +25,6 @@ msys2_references=(
 license=('spdx:LGPL-3.0-only WITH Qt-GPL-exception-1.0 AND GPL-3.0-or-later AND GPL-2.0-or-later AND GFDL-1.3-no-invariants-only')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
-             "${MINGW_PACKAGE_PREFIX}-angleproject"
              "${MINGW_PACKAGE_PREFIX}-dbus"
              "${MINGW_PACKAGE_PREFIX}-double-conversion"
              "${MINGW_PACKAGE_PREFIX}-egl-headers"
@@ -273,7 +272,8 @@ package_qt5-base() {
            "${MINGW_PACKAGE_PREFIX}-zstd")
   if [[ ${CARCH} != i686 ]]; then
     optdepends=("${MINGW_PACKAGE_PREFIX}-libmariadbclient: MySQL/MariaDB driver"
-                "${MINGW_PACKAGE_PREFIX}-postgresql: PostgreSQL driver")
+                "${MINGW_PACKAGE_PREFIX}-postgresql: PostgreSQL driver"
+                "${MINGW_PACKAGE_PREFIX}-angleproject: ANGLE OpenGL ES API translation layer")
   fi
   if [[ ${CARCH} == x86_64 ]]; then
     optdepends+=("${MINGW_PACKAGE_PREFIX}-firebird: Firebird/iBase driver")

--- a/mingw-w64-qt5-base/PKGBUILD
+++ b/mingw-w64-qt5-base/PKGBUILD
@@ -25,10 +25,13 @@ msys2_references=(
 license=('spdx:LGPL-3.0-only WITH Qt-GPL-exception-1.0 AND GPL-3.0-or-later AND GPL-2.0-or-later AND GFDL-1.3-no-invariants-only')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
+             "${MINGW_PACKAGE_PREFIX}-angleproject"
              "${MINGW_PACKAGE_PREFIX}-dbus"
              "${MINGW_PACKAGE_PREFIX}-double-conversion"
+             "${MINGW_PACKAGE_PREFIX}-egl-headers"
              "${MINGW_PACKAGE_PREFIX}-fontconfig"
              "${MINGW_PACKAGE_PREFIX}-freetype"
+             "${MINGW_PACKAGE_PREFIX}-gles-headers"
              "${MINGW_PACKAGE_PREFIX}-harfbuzz"
              "${MINGW_PACKAGE_PREFIX}-icu"
              "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"


### PR DESCRIPTION
Changing to -opengl dynamic will enable fallback code for loading ANGLE (libEGL.dll and libGLESv2.dll from package mingw-*-angleproject) as well as software rasterizers (opengl32sw.dll) at runtime. Currently -opengl desktop will only work with full-fledged OpenGL 2.x+ implementation, that is: Qt Quick 2 will not work in VMs without 3D acceleration.