### PR TITLE
qt5-base: Change OpenGL to "dynamic" mode to support fallbacks

### DIFF
--- a/mingw-w64-qt5-base/PKGBUILD
+++ b/mingw-w64-qt5-base/PKGBUILD
@@ -13,7 +13,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-${_realname}-debug"))
 _qtver=5.15.14
 pkgver=${_qtver}+kde+r141
-pkgrel=1
+pkgrel=2
 pkgdesc="A cross-platform application and UI framework (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')

--- a/mingw-w64-qt5-base/PKGBUILD
+++ b/mingw-w64-qt5-base/PKGBUILD
@@ -27,8 +27,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-dbus"
              "${MINGW_PACKAGE_PREFIX}-double-conversion"
+             "${MINGW_PACKAGE_PREFIX}-egl-headers"
              "${MINGW_PACKAGE_PREFIX}-fontconfig"
              "${MINGW_PACKAGE_PREFIX}-freetype"
+             "${MINGW_PACKAGE_PREFIX}-gles-headers"
              "${MINGW_PACKAGE_PREFIX}-harfbuzz"
              "${MINGW_PACKAGE_PREFIX}-icu"
              "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
@@ -227,7 +229,7 @@ build() {
     -shared \
     -make-tool make \
     -I${MINGW_PREFIX}/include/mariadb \
-    -opengl desktop \
+    -opengl dynamic \
     -dbus \
     -fontconfig \
     -icu \
@@ -270,7 +272,8 @@ package_qt5-base() {
            "${MINGW_PACKAGE_PREFIX}-zstd")
   if [[ ${CARCH} != i686 ]]; then
     optdepends=("${MINGW_PACKAGE_PREFIX}-libmariadbclient: MySQL/MariaDB driver"
-                "${MINGW_PACKAGE_PREFIX}-postgresql: PostgreSQL driver")
+                "${MINGW_PACKAGE_PREFIX}-postgresql: PostgreSQL driver"
+                "${MINGW_PACKAGE_PREFIX}-angleproject: ANGLE OpenGL ES API translation layer")
   fi
   if [[ ${CARCH} == x86_64 ]]; then
     optdepends+=("${MINGW_PACKAGE_PREFIX}-firebird: Firebird/iBase driver")


### PR DESCRIPTION
Changing to -opengl dynamic will enable fallback code for loading ANGLE (libEGL.dll and libGLESv2.dll from package mingw-*-angleproject) as well as software rasterizers (opengl32sw.dll) at runtime. Currently -opengl desktop will only work with full-fledged OpenGL 2.x+ implementation, that is: Qt Quick 2 will not work in VMs or systems without 3D acceleration.