### PR TITLE
python-pyvisa: new package

### DIFF
--- a/mingw-w64-python-pyvisa/PKGBUILD
+++ b/mingw-w64-python-pyvisa/PKGBUILD
@@ -1,0 +1,54 @@
+# Maintainer: fsagbuya <fa@m-labs.ph>
+
+_realname=pyvisa
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=1.14.1
+pkgrel=1
+pkgdesc="Python VISA bindings for GPIB, RS232, TCPIP and USB instruments (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+url="https://github.com/pyvisa/pyvisa"
+msys2_references=(
+  'pypi: PyVISA'
+)
+license=('MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-typing_extensions")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm"
+             "${MINGW_PACKAGE_PREFIX}-python-wheel")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
+options=('!strip')
+source=("${_realname}-${pkgver}.tar.gz::${url}/archive/refs/tags/${pkgver}.tar.gz")
+sha256sums=('4e6aada5677a88c1a77f89aec55cc7b52dbb87015484ec3c1f7c646c9fc9ad02')
+
+prepare() {
+  cd "${srcdir}"
+  rm -rf python-build-${MSYSTEM} | true
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
+  export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}
+}
+
+build() {
+  msg "Python build for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
+  ${MINGW_PREFIX}/bin/python -m build --wheel --no-isolation
+}
+
+check() {
+  msg "Python test for ${MSYSTEM}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
+  ${MINGW_PREFIX}/bin/python -m pytest -v --pyargs pyvisa \
+    --ignore=pyvisa/testsuite/test_cmd_line_tools.py || warning "Tests failed"
+}
+
+package() {
+  cd "${srcdir}/python-build-${MSYSTEM}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}

--- a/mingw-w64-python-pyvisa/PKGBUILD
+++ b/mingw-w64-python-pyvisa/PKGBUILD
@@ -7,16 +7,17 @@ pkgver=1.14.1
 pkgrel=1
 pkgdesc="Python VISA bindings for GPIB, RS232, TCPIP and USB instruments (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://github.com/pyvisa/pyvisa"
 msys2_references=(
   'pypi: PyVISA'
 )
-license=('MIT')
+license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-typing_extensions")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm"
              "${MINGW_PACKAGE_PREFIX}-python-wheel")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")


### PR DESCRIPTION
### Description

Added `python-pyvisa` package.

Full build log [here](https://gist.github.com/fsagbuya/ae5d20e1819b5a6095b2216695bf1865).

Tested in `CLANG64` shell:
```
$ python
Python 3.11.9 (main, Apr 12 2024, 09:55:30)  [GCC Clang 18.1.3 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import pyvisa
>>> print(pyvisa.__version__)
1.14.1
```