### PR TITLE
python-installer: Zero lpReserved2 and cbReserved2 fields in simple_launcher STARTUPINFOW

### DIFF
--- a/mingw-w64-python-installer/004-zero-reservered-fields-in-startupinfo.patch
+++ b/mingw-w64-python-installer/004-zero-reservered-fields-in-startupinfo.patch
@@ -1,0 +1,37 @@
+From 63deda9f0a881c7577a70744fbd19e73f7a6dcdb Mon Sep 17 00:00:00 2001
+From: Joel Holdsworth <jholdsworth@nvidia.com>
+Date: Wed, 17 Jul 2024 11:35:16 -0700
+Subject: [PATCH] Zero lpReserved2 and cbReserved2 fields in STARTUPINFOW
+
+simple_launcher currently copies the values of lpReserved2 and cbReserved2 from
+the parent process to the child. In some cases, these fields are used to pass
+information. For example, the MSVC C runtime uses the fields as part of its
+_spawn implementation to pass file descriptor information to the child. However,
+this information is invalid in the grand-child proces.
+
+This issue is a cause of a bug when CMake attempts to launch a python-installer
+child process:
+
+  * https://gitlab.kitware.com/cmake/cmake/-/issues/25996
+
+This patch corrects the issue by zeroing the fields.
+---
+ launcher.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/launcher.c b/launcher.c
+index c965d19..d15ab91 100644
+--- a/launcher.c
++++ b/launcher.c
+@@ -519,6 +519,8 @@ run_child(wchar_t * cmdline)
+     assert(ok, "Job information setting failed");
+     memset(&si, 0, sizeof(si));
+     GetStartupInfoW(&si);
++    si.lpReserved2 = NULL;
++    si.cbReserved2 = 0;
+ /*
+  * See https://github.com/pypa/pip/issues/10444#issuecomment-973396812
+  */
+-- 
+2.45.1
+

--- a/mingw-w64-python-installer/PKGBUILD
+++ b/mingw-w64-python-installer/PKGBUILD
@@ -24,12 +24,14 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
         "simple_launcher"::"git+https://bitbucket.org/vinay.sajip/simple_launcher.git#commit=${_launcher_commit}"
         "001-launcher-relative.patch"
         "002-launcher-stderr-missing.patch"
-        "003-launcher-secure-api-shim.patch")
+        "003-launcher-secure-api-shim.patch"
+        "004-zero-reservered-fields-in-startupinfo.patch")
 sha256sums=('a26d3e3116289bb08216e0d0f7d925fcef0b0194eedfa0c944bcaaa106c4b631'
             'SKIP'
             'c83360c3ffca0b278b05841a3a39b784df42a4d5fbaf2823c2a7e3f32fe8ebc4'
             'e95b68c14bffddd6dd859bdb2c8feb733bbcd5c9d4a37105df4196bfa01923c5'
-            '0b6ab782f1550ea0e52a8869cf9c78c405a9ed9dda1e9d9eb60a4126787db208')
+            '0b6ab782f1550ea0e52a8869cf9c78c405a9ed9dda1e9d9eb60a4126787db208'
+            'ccb341afa03809257d0c9c6c5d323b9998d21ff972789eb8c1734d5bc2a7fbff')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -42,6 +44,8 @@ prepare() {
   patch -Np1 -i "${srcdir}/002-launcher-stderr-missing.patch"
 
   patch -Np1 -i "${srcdir}/003-launcher-secure-api-shim.patch"
+
+  patch -Np1 -i "${srcdir}/004-zero-reservered-fields-in-startupinfo.patch"
 }
 
 build() {


### PR DESCRIPTION
simple_launcher currently copies the values of lpReserved2 and cbReserved2 from the parent process to the child. In some cases, these fields are used to pass information. For example, the MSVC C runtime uses the fields as part of its _spawn implementation to pass file descriptor information to the child. However, this information is invalid in the grand-child proces.

This issue is a cause of a bug when CMake attempts to launch a python-installer child process:

  * https://gitlab.kitware.com/cmake/cmake/-/issues/25996

This patch corrects the issue by applying a patch to zero the fields.