### PR TITLE
cppdap: update to 1.65

### DIFF
--- a/mingw-w64-cppdap/PKGBUILD
+++ b/mingw-w64-cppdap/PKGBUILD
@@ -1,22 +1,27 @@
 # Contributor: Mehdi Chinoune <mehdi.chinoune@hotmail.com>
+# Contributor: Justin Caselman <justin.caselman@keysight.com>
 
 _realname=cppdap
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_pkgver=1.58.0-a
+_pkgver=1.65
 pkgver=${_pkgver/-/}
+# tags are missing, see https://github.com/google/cppdap/issues/132
+_commit="37c744c294cbb24943a3913bbb67860d1609008c"
 pkgrel=1
 pkgdesc="C++ library for the Debug Adapter Protocol (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
-url='https://www.somepackage.org/'
+url='https://github.com/google/cppdap'
 license=('spdx:Apache-2.0')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
-             "${MINGW_PACKAGE_PREFIX}-jsoncpp")
-source=("${_realname}-${pkgver}.tar.gz::https://github.com/google/cppdap/archive/dap-${_pkgver}.tar.gz")
-sha256sums=('5d35ca5db78570b6bef698e3365f79bd82a4f78e8393546387f78d7bdb2a2a08')
+             "${MINGW_PACKAGE_PREFIX}-jsoncpp"
+             "git")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+source=("${_realname}"::"git+https://github.com/google/cppdap.git#commit=${_commit}")
+sha256sums=('3984fe87c3895b36db7bd2677602aed172f4587e517b38429efa53de7d47a303')
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
@@ -28,13 +33,15 @@ build() {
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
+  LDFLAGS+=" -Wl,--export-all-symbols" \
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     "${MINGW_PREFIX}"/bin/cmake.exe \
       -GNinja \
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       "${extra_config[@]}" \
       -DCPPDAP_USE_EXTERNAL_JSONCPP_PACKAGE=ON \
-      ../${_realname}-dap-${_pkgver}
+      -DBUILD_SHARED_LIBS=ON \
+      ../${_realname}
 
   "${MINGW_PREFIX}"/bin/cmake.exe --build .
 }
@@ -44,5 +51,5 @@ package() {
 
   DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
 
-  install -Dm644 "${srcdir}/${_realname}-dap-${_pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  install -Dm644 "${srcdir}/${_realname}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
* Updates cppdap to [ver 1.65 ](https://github.com/google/cppdap/commit/37c744c294cbb24943a3913bbb67860d1609008c)
  * Switch to git commit source since the project does not generate github release archives