### PR TITLE
Fix perl module makedepends

### DIFF
--- a/mingw-w64-perl-encode-compat/PKGBUILD
+++ b/mingw-w64-perl-encode-compat/PKGBUILD
@@ -5,7 +5,7 @@ _realname="${_perlname,,}"
 pkgbase=mingw-w64-perl-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-perl-${_realname}")
 pkgver=0.07
-pkgrel=3
+pkgrel=4
 pkgdesc="Encode::compat - Encode.pm emulation layer (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -13,7 +13,10 @@ url="https://metacpan.org/release/Encode-compat"
 license=('GPL' 'PerlArtistic')
 groups=("${MINGW_PACKAGE_PREFIX}-perl-modules")
 depends=("${MINGW_PACKAGE_PREFIX}-perl")
-makedepends=("${MINGW_PACKAGE_PREFIX}-python")
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-make"
+  "${MINGW_PACKAGE_PREFIX}-python"
+)
 options=('!emptydirs')
 source=(
   "https://www.cpan.org/authors/id/A/AU/AUTRIJUS/${_perlname}-${pkgver}.tar.gz"

--- a/mingw-w64-perl-file-which/PKGBUILD
+++ b/mingw-w64-perl-file-which/PKGBUILD
@@ -5,7 +5,7 @@ _realname="${_perlname,,}"
 pkgbase=mingw-w64-perl-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-perl-${_realname}")
 pkgver=1.24
-pkgrel=3
+pkgrel=4
 pkgdesc="Perl implementation of the which utility as an API (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -15,7 +15,10 @@ groups=("${MINGW_PACKAGE_PREFIX}-perl-modules")
 depends=(
   "${MINGW_PACKAGE_PREFIX}-perl"
 )
-makedepends=("${MINGW_PACKAGE_PREFIX}-python")
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-make"
+  "${MINGW_PACKAGE_PREFIX}-python"
+)
 options=('!emptydirs')
 source=(
   "https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/${_perlname}-${pkgver}.tar.gz"

--- a/mingw-w64-perl-html-tagset/PKGBUILD
+++ b/mingw-w64-perl-html-tagset/PKGBUILD
@@ -5,7 +5,7 @@ _realname="${_perlname,,}"
 pkgbase=mingw-w64-perl-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-perl-${_realname}")
 pkgver=3.20
-pkgrel=3
+pkgrel=4
 pkgdesc="data tables useful in parsing HTML (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -15,7 +15,10 @@ depends=(
   "${MINGW_PACKAGE_PREFIX}-perl"
 )
 options=('!emptydirs')
-makedepends=("${MINGW_PACKAGE_PREFIX}-python")
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-make"
+  "${MINGW_PACKAGE_PREFIX}-python"
+)
 license=(unknown)
 source=(
   "https://cpan.metacpan.org/authors/id/P/PE/PETDANCE/${_perlname}-${pkgver}.tar.gz"

--- a/mingw-w64-perl-io-string/PKGBUILD
+++ b/mingw-w64-perl-io-string/PKGBUILD
@@ -5,7 +5,7 @@ _realname="${_perlname,,}"
 pkgbase=mingw-w64-perl-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-perl-${_realname}")
 pkgver=1.08
-pkgrel=3
+pkgrel=4
 pkgdesc="Emulate file interface for in-core strings (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -16,7 +16,10 @@ depends=(
   "${MINGW_PACKAGE_PREFIX}-perl"
 )
 options=('!emptydirs')
-makedepends=("${MINGW_PACKAGE_PREFIX}-python")
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-make"
+  "${MINGW_PACKAGE_PREFIX}-python"
+)
 source=(
   "https://cpan.metacpan.org/authors/id/G/GA/GAAS/${_perlname}-${pkgver}.tar.gz"
   "patchmakefile.py"

--- a/mingw-w64-perl-win32-tieregistry/PKGBUILD
+++ b/mingw-w64-perl-win32-tieregistry/PKGBUILD
@@ -5,7 +5,7 @@ _realname="${_perlname,,}"
 pkgbase=mingw-w64-perl-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-perl-${_realname}")
 pkgver=0.30
-pkgrel=3
+pkgrel=4
 pkgdesc="Manipulate the Win32 Registry (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -18,7 +18,10 @@ depends=(
   "${MINGW_PACKAGE_PREFIX}-perl-win32-winerror"
   "${MINGW_PACKAGE_PREFIX}-perl-win32api-registry"
 )
-makedepends=("${MINGW_PACKAGE_PREFIX}-python")
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-make"
+  "${MINGW_PACKAGE_PREFIX}-python"
+)
 options=('!emptydirs')
 source=(
   "https://cpan.metacpan.org/authors/id/C/CH/CHORNY/${_perlname}-${pkgver}.tar.gz"


### PR DESCRIPTION
Each of these modules uses `mingw32-make` without declaring it as a build-time dependency. As a result, these packages have failed to rebuild and are stuck at the Perl 4.32.1 build. This patch-set corrects the issue by adding `${MINGW_PACKAGE_PREFIX}-make` to the `makedepends` and bumping the `pkgrel`.