### PR TITLE
python-pygments: Split docs into separate package

### DIFF
--- a/mingw-w64-python-pygments-docs/PKGBUILD
+++ b/mingw-w64-python-pygments-docs/PKGBUILD
@@ -1,0 +1,42 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Ray Donnelly <mingw.android@gmail.com>
+
+_pyname=Pygments
+_realname=pygments
+# this is a separate package to break the pygments <-> sphinx dependency cycle
+pkgbase=mingw-w64-python-${_realname}-docs
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}-docs")
+pkgver=2.17.2
+pkgrel=3
+pkgdesc="Python syntax highlighter (mingw-w64) (documentation)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+msys2_references=(
+  'pypi: Pygments'
+  "cpe: cpe:/a:pygments:pygments"
+)
+url="https://pygments.org/"
+msys2_repository_url="https://github.com/pygments/pygments"
+license=('spdx:BSD-2-Clause')
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-python-sphinx"
+  "${MINGW_PACKAGE_PREFIX}-python-wcag-contrast-ratio"
+)
+source=("https://pypi.org/packages/source/P/Pygments/${_realname}-${pkgver}.tar.gz")
+sha256sums=('da46cec9fd2de5be3a8a784f434e4c4ab670b4ff54d605c4c2717e9d49c4c367')
+
+prepare() {
+  rm -rf python-build-${MSYSTEM} | true
+  cp -r ${_pyname}-${pkgver} python-build-${MSYSTEM}
+}
+
+build () {
+  cd "${srcdir}/python-build-${MSYSTEM}"
+  make -C doc html
+}
+
+package() {
+  cd "${srcdir}/python-build-${MSYSTEM}"
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/share/doc"
+  cp -rT doc/_build/html "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"
+}

--- a/mingw-w64-python-pygments-docs/PKGBUILD
+++ b/mingw-w64-python-pygments-docs/PKGBUILD
@@ -6,8 +6,8 @@ _realname=pygments
 # this is a separate package to break the pygments <-> sphinx dependency cycle
 pkgbase=mingw-w64-python-${_realname}-docs
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}-docs")
-pkgver=2.17.2
-pkgrel=3
+pkgver=2.18.0
+pkgrel=1
 pkgdesc="Python syntax highlighter (mingw-w64) (documentation)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -22,16 +22,11 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-sphinx"
   "${MINGW_PACKAGE_PREFIX}-python-wcag-contrast-ratio"
 )
-source=("https://pypi.org/packages/source/P/Pygments/${_realname}-${pkgver}.tar.gz")
-sha256sums=('da46cec9fd2de5be3a8a784f434e4c4ab670b4ff54d605c4c2717e9d49c4c367')
-
-prepare() {
-  rm -rf python-build-${MSYSTEM} | true
-  cp -r ${_pyname}-${pkgver} python-build-${MSYSTEM}
-}
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199')
 
 build () {
-  cd "${srcdir}/python-build-${MSYSTEM}"
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
   make -C doc html
 }
 

--- a/mingw-w64-python-pygments/PKGBUILD
+++ b/mingw-w64-python-pygments/PKGBUILD
@@ -9,7 +9,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=2.17.2
-pkgrel=2
+pkgrel=3
 pkgdesc="Python syntax highlighter (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -24,10 +24,10 @@ depends=("${MINGW_PACKAGE_PREFIX}-python")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
              "${MINGW_PACKAGE_PREFIX}-python-hatchling"
-             "${MINGW_PACKAGE_PREFIX}-python-sphinx"
-             "${MINGW_PACKAGE_PREFIX}-python-wcag-contrast-ratio")
-checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest"
-              "${MINGW_PACKAGE_PREFIX}-python-pytest-cov")
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-lxml"
+              "${MINGW_PACKAGE_PREFIX}-python-pytest"
+              "${MINGW_PACKAGE_PREFIX}-python-wcag-contrast-ratio")
 options=(!strip)
 source=("https://pypi.org/packages/source/P/Pygments/${_realname}-${pkgver}.tar.gz")
 sha256sums=('da46cec9fd2de5be3a8a784f434e4c4ab670b4ff54d605c4c2717e9d49c4c367')
@@ -40,7 +40,6 @@ prepare() {
 build () {
   cd "${srcdir}/python-build-${MSYSTEM}"
   ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
-  make -C doc html
 }
 
 check() {
@@ -57,7 +56,5 @@ package() {
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
 
-  mkdir -p "$pkgdir${MINGW_PREFIX}/share/doc"
-  cp -rT doc/_build/html "$pkgdir${MINGW_PREFIX}/share/doc/${_realname}"
   install -Dm644 doc/pygmentize.1 -t "$pkgdir${MINGW_PREFIX}/share/man/man1"
 }

--- a/mingw-w64-python-pygments/PKGBUILD
+++ b/mingw-w64-python-pygments/PKGBUILD
@@ -5,11 +5,8 @@ _pyname=Pygments
 _realname=pygments
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=2.17.2
-pkgrel=3
+pkgver=2.18.0
+pkgrel=1
 pkgdesc="Python syntax highlighter (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -28,17 +25,12 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-lxml"
               "${MINGW_PACKAGE_PREFIX}-python-pytest"
               "${MINGW_PACKAGE_PREFIX}-python-wcag-contrast-ratio")
-options=(!strip)
-source=("https://pypi.org/packages/source/P/Pygments/${_realname}-${pkgver}.tar.gz")
-sha256sums=('da46cec9fd2de5be3a8a784f434e4c4ab670b4ff54d605c4c2717e9d49c4c367')
-
-prepare() {
-  rm -rf python-build-${MSYSTEM} | true
-  cp -r ${_pyname}-${pkgver} python-build-${MSYSTEM}
-}
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199')
 
 build () {
-  cd "${srcdir}/python-build-${MSYSTEM}"
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
   ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
 }
 


### PR DESCRIPTION
This helps to break the cyclic dependency between python-pygments and python-sphinx. The similar change was done with python-jinja.