### PR TITLE
[new package] turbo 2.0.9

### DIFF
--- a/mingw-w64-turbo/PKGBUILD
+++ b/mingw-w64-turbo/PKGBUILD
@@ -1,0 +1,67 @@
+# Maintainer: Maksim Bondarenkov <maksapple2306@gmail.com>
+
+_realname=turbo
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=2.0.9
+pkgrel=1
+pkgdesc="Incremental bundler and build system optimized for JavaScript and TypeScript (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64')
+url='https://turbo.build'
+msys2_repository_url='https://github.com/vercel/turbo'
+license=('spdx:MPL-2.0')
+depends=("${MINGW_PACKAGE_PREFIX}-zlib"
+         "${MINGW_PACKAGE_PREFIX}-zstd")
+makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
+             "${MINGW_PACKAGE_PREFIX}-capnproto"
+             "${MINGW_PACKAGE_PREFIX}-protobuf"
+             "${MINGW_PACKAGE_PREFIX}-pkgconf"
+             "${MINGW_PACKAGE_PREFIX}-openssl"
+             "${MINGW_PACKAGE_PREFIX}-fontconfig"
+             "${MINGW_PACKAGE_PREFIX}-freetype"
+             'git')
+options=('!strip')
+source=("git+${msys2_repository_url}.git#tag=v${pkgver}"
+        "zstd-sys.tar.gz::https://crates.io/api/v1/crates/zstd-sys/2.0.10+zstd.1.5.6/download"
+        "turbo-enable-lazy_cell.patch"
+        "zstd-sys-remove-statik.patch")
+sha256sums=('14f2c25620a23492c4b963960f1017a16dc832c43786885988998f17f66042c7'
+            'c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa'
+            'b295ce57777c8b7be2ef2bbd03fca5968e6b8653fcb5c6ceafa47705c387e9bd'
+            '48f4900ceb02d3aaf9a1020f33d56629156e96759f456c0e7ca18bfcf910767b')
+
+prepare() {
+  cd "${_realname}"
+
+  rm -f rust-toolchain.toml
+  patch -Np1 -i ../turbo-enable-lazy_cell.patch
+
+  patch -d ../zstd-sys-2.0.10+zstd.1.5.6 -i ../zstd-sys-remove-statik.patch
+  sed -i.orig '/\[patch\.crates-io\]/a zstd-sys = { path = "../zstd-sys-2.0.10+zstd.1.5.6" }' Cargo.toml
+
+  cargo update -p zstd-sys
+  RUSTC_BOOTSTRAP=1 cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+}
+
+build() {
+  cd "${_realname}"
+
+  export RUSTC_BOOTSTRAP=1
+  export OPENSSL_NO_VENDOR=1
+  export PKG_CONFIG_ALL_DYNAMIC=1
+  export ZSTD_SYS_USE_PKG_CONFIG=1
+  export TURBO_TELEMETRY_DISABLED=1
+  cargo build --frozen --profile release-turborepo -p turbo
+}
+
+package() {
+  install -Dm755 "${_realname}/target/release-turborepo/turbo" "${pkgdir}${MINGW_PREFIX}/bin/turbo"
+
+  local _complete="${_realname}/target/release-turborepo/turbo completion"
+  $_complete bash | install -Dm644 /dev/stdin "${pkgdir}${MINGW_PREFIX}/share/bash-completion/completions/${_realname}"
+  $_complete fish | install -Dm644 /dev/stdin "${pkgdir}${MINGW_PREFIX}/share/fish/vendor_completions.d/${_realname}.fish"
+  $_complete zsh | install -Dm644 /dev/stdin "${pkgdir}${MINGW_PREFIX}/share/zsh/site-functions/_${_realname}"
+
+  install -Dm644 "${_realname}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}

--- a/mingw-w64-turbo/turbo-enable-lazy_cell.patch
+++ b/mingw-w64-turbo/turbo-enable-lazy_cell.patch
@@ -1,0 +1,10 @@
+--- a/crates/turborepo-lib/src/lib.rs
++++ b/crates/turborepo-lib/src/lib.rs
+@@ -2,6 +2,7 @@
+ #![feature(box_patterns)]
+ #![feature(error_generic_member_access)]
+ #![feature(hash_extract_if)]
++#![feature(lazy_cell)]
+ #![feature(option_get_or_insert_default)]
+ #![feature(once_cell_try)]
+ #![feature(panic_info_message)]

--- a/mingw-w64-turbo/zstd-sys-remove-statik.patch
+++ b/mingw-w64-turbo/zstd-sys-remove-statik.patch
@@ -1,0 +1,10 @@
+--- a/build.rs
++++ b/build.rs
+@@ -41,7 +41,6 @@ fn generate_bindings(_: Vec<&str>, _: Vec<PathBuf>) {}
+
+ fn pkg_config() -> (Vec<&'static str>, Vec<PathBuf>) {
+     let library = pkg_config::Config::new()
+-        .statik(true)
+         .cargo_metadata(!cfg!(feature = "non-cargo"))
+         .probe("libzstd")
+         .expect("Can't probe for zstd in pkg-config");


### PR DESCRIPTION
`RUSTC_BOOTSTRAP=1` allows stable compiler to use nightly features