### PR TITLE
SFCGAL: Bump to 1.5.2

### DIFF
--- a/mingw-w64-python-pysfcgal/PKGBUILD
+++ b/mingw-w64-python-pysfcgal/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=pysfcgal
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
-pkgver=1.5.1
+pkgver=1.5.2
 pkgrel=1
 pkgdesc='Python SFCGAL binding (mingw-w64)'
 arch=('any')
@@ -24,7 +24,7 @@ makedepends=(
     ${MINGW_PACKAGE_PREFIX}-python-cffi
     ${MINGW_PACKAGE_PREFIX}-cc)
 source=(https://gitlab.com/SFCGAL/pysfcgal/-/archive/v${pkgver}/pysfcgal-v${pkgver}.tar.gz)
-sha256sums=('1207d4dad15eb7d18e5fcd1ffa33d8f7968505c26ec1ddbb520ecd6f0a487315')
+sha256sums=('322c174ed05005a192441da357ea648b7fb4e0abb8bdc6e4535f6cdaae403870')
 
 prepare() {
   rm -rf python-build-${MSYSTEM} | true
@@ -42,5 +42,5 @@ package() {
   ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
     --root="${pkgdir}" --optimize=1 --skip-build
 
-  install -Dm644 LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+  install -Dm644 LICENSE.md "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
 }

--- a/mingw-w64-python-pysfcgal/PKGBUILD
+++ b/mingw-w64-python-pysfcgal/PKGBUILD
@@ -19,28 +19,26 @@ depends=(
     ${MINGW_PACKAGE_PREFIX}-python-cffi
 )
 makedepends=(
+    ${MINGW_PACKAGE_PREFIX}-cc
+    ${MINGW_PACKAGE_PREFIX}-python-build
+    ${MINGW_PACKAGE_PREFIX}-python-installer
     ${MINGW_PACKAGE_PREFIX}-python-setuptools
     ${MINGW_PACKAGE_PREFIX}-python-wheel
-    ${MINGW_PACKAGE_PREFIX}-python-cffi
-    ${MINGW_PACKAGE_PREFIX}-cc)
+)
 source=(https://gitlab.com/SFCGAL/pysfcgal/-/archive/v${pkgver}/pysfcgal-v${pkgver}.tar.gz)
 sha256sums=('322c174ed05005a192441da357ea648b7fb4e0abb8bdc6e4535f6cdaae403870')
 
-prepare() {
-  rm -rf python-build-${MSYSTEM} | true
-  cp -r "${_realname}-v${pkgver}" "python-build-${MSYSTEM}"
-}
-
 build() {
-  cd "${srcdir}/python-build-${MSYSTEM}"
-  ${MINGW_PREFIX}/bin/python setup.py build
+  cp -r "${_realname}-v${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 package() {
   cd "${srcdir}/python-build-${MSYSTEM}"
-  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX} \
-    --root="${pkgdir}" --optimize=1 --skip-build
 
-  install -Dm644 LICENSE.md "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE.md "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE.md"
 }

--- a/mingw-w64-sfcgal/PKGBUILD
+++ b/mingw-w64-sfcgal/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=sfcgal
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.5.1
+pkgver=1.5.2
 pkgrel=1
 pkgdesc="Wrapper around CGAL that intents to implement 2D and 3D operations on OGC standards models (mingw-w64)"
 arch=('any')
@@ -21,7 +21,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-mpfr"
          "${MINGW_PACKAGE_PREFIX}-cgal")
 source=(https://gitlab.com/SFCGAL/SFCGAL/-/archive/v${pkgver}/SFCGAL-v${pkgver}.tar.gz)
-sha256sums=('ea5d1662fada7de715ad564dc810c3059024ed81ae393f5352489f706fdfa3b1')
+sha256sums=('b946b3c20d53f6e2703046085f0fcfea6c1a4081163f7bedd30b1195801efdd2')
 
 build() {
   mkdir ${srcdir}/build-${MSYSTEM} && cd ${srcdir}/build-${MSYSTEM}


### PR DESCRIPTION
SFCGAL and PySFCGAL 1.5.2:

- https://gitlab.com/sfcgal/SFCGAL/-/releases/v1.5.2
- https://gitlab.com/sfcgal/PySFCGAL/-/releases/v1.5.2