### PR TITLE
gxml: Update to 0.20.4

### DIFF
--- a/mingw-w64-gxml/PKGBUILD
+++ b/mingw-w64-gxml/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gxml
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.20.0
+pkgver=0.20.4
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
@@ -23,8 +23,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-cc")
 license=('spdx:LGPL-2.1-or-later')
 url="https://wiki.gnome.org/GXml"
-source=("https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz")
-sha256sums=('0a0fc4f305ba9ea2f1f76aadfd660fd50febdc7a5e151f9559c81b2bd362d87b')
+source=("https://gitlab.gnome.org/GNOME/gxml/-/archive/${pkgver}/gxml-${pkgver}.tar.gz")
+sha256sums=('237f5d3984b6aa7378bfa030b7dadfad43041720f097bb5b4104e84829d741a5')
 msys2_repository_url="https://gitlab.gnome.org/GNOME/gxml"
 
 prepare() {
@@ -40,12 +40,12 @@ build() {
   export CFLAGS="${CFLAGS} -Wno-incompatible-function-pointer-types"
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-  ${MINGW_PREFIX}/bin/meson \
+  ${MINGW_PREFIX}/bin/meson setup \
     --prefix="${MINGW_PREFIX}" \
     --buildtype plain \
     ../${_realname}-${pkgver}
 
-  ninja
+  meson compile
 }
 
 package() {


### PR DESCRIPTION
switch to using gitlab archive since the newer tarballs are missing