### PR TITLE
PKGBUILD-templates: get rid of $MINGW_PREFIX/bin

### DIFF
--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-git.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-git.sh
@@ -44,7 +44,7 @@ build() {
   fi
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-    "${MINGW_PREFIX}"/bin/cmake.exe \
+    cmake \
       -GNinja \
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       "${extra_config[@]}" \
@@ -52,15 +52,15 @@ build() {
       -S "${_realname}" \
       -B "build-${MSYSTEM}"
 
-  "${MINGW_PREFIX}"/bin/cmake.exe --build "build-${MSYSTEM}"
+  cmake --build "build-${MSYSTEM}"
 }
 
 check() {
-  "${MINGW_PREFIX}"/bin/cmake.exe --build "build-${MSYSTEM}" --target test
+  cmake --build "build-${MSYSTEM}" --target test
 }
 
 package() {
-  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install "build-${MSYSTEM}"
+  DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}"
 
   install -Dm644 "${srcdir}/${_realname}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-tarball.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-tarball.sh
@@ -36,7 +36,7 @@ build() {
   fi
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-    "${MINGW_PREFIX}"/bin/cmake.exe \
+    cmake \
       -GNinja \
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       "${extra_config[@]}" \
@@ -44,15 +44,15 @@ build() {
       -S "${_realname}-${pkgver}" \
       -B "build-${MSYSTEM}"
 
-  "${MINGW_PREFIX}"/bin/cmake.exe --build "build-${MSYSTEM}"
+  cmake --build "build-${MSYSTEM}"
 }
 
 check() {
-  "${MINGW_PREFIX}"/bin/cmake.exe --build "build-${MSYSTEM}" --target test
+  cmake --build "build-${MSYSTEM}" --target test
 }
 
 package() {
-  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install "build-${MSYSTEM}"
+  DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}"
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.python.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.python.sh
@@ -37,7 +37,7 @@ build() {
   cd "${srcdir}"
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
 
-  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
+  python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 check() {
@@ -46,7 +46,7 @@ check() {
 
 # The test command will usually depend upon what is contained in the tox.ini file
 # or in the [testenv:py] section of the pyproject.toml file.
-  ${MINGW_PREFIX}/bin/python -m pytest
+  python -m pytest
 }
 
 package() {
@@ -54,7 +54,7 @@ package() {
   cd "${srcdir}/python-build-${MSYSTEM}"
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    python -m installer --prefix=${MINGW_PREFIX} \
     --destdir="${pkgdir}" dist/*.whl
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"


### PR DESCRIPTION
There is really no need to, we can depend on PATH there