### PR TITLE
neovim: update to 0.10.1

### DIFF
--- a/mingw-w64-neovim/0001-cmake-disable-bundling.patch
+++ b/mingw-w64-neovim/0001-cmake-disable-bundling.patch
@@ -1,11 +1,13 @@
+diff --git a/src/nvim/CMakeLists.txt b/src/nvim/CMakeLists.txt
+index d9cc695c..42465eca 100644
 --- a/src/nvim/CMakeLists.txt
 +++ b/src/nvim/CMakeLists.txt
-@@ -668,7 +668,7 @@
-   endif()
+@@ -726,7 +726,7 @@ if(ENABLE_LTO)
  endif()
  
+ add_custom_target(nvim_runtime_deps)
 -if(WIN32)
 +if(FALSE)
    # Copy DLLs and third-party tools to bin/ and install them along with nvim
-   add_custom_target(nvim_runtime_deps ALL
-     COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_BINARY_DIR}/windows_runtime_deps/
+   add_custom_command(TARGET nvim_runtime_deps
+     COMMAND ${CMAKE_COMMAND} -E ${COPY_DIRECTORY} ${PROJECT_BINARY_DIR}/windows_runtime_deps/

--- a/mingw-w64-neovim/PKGBUILD
+++ b/mingw-w64-neovim/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=neovim
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.9.5
-pkgrel=5
+pkgver=0.10.1
+pkgrel=1
 pkgdesc='Fork of Vim aiming to improve user experience, plugins, and GUIs (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -25,14 +25,15 @@ depends=("${MINGW_PACKAGE_PREFIX}-gettext-runtime"
          "${MINGW_PACKAGE_PREFIX}-unibilium")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-lua51-lpeg"
+             "${MINGW_PACKAGE_PREFIX}-make"
              "${MINGW_PACKAGE_PREFIX}-lua51-mpack"
              "${MINGW_PACKAGE_PREFIX}-gettext-tools"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/neovim/neovim/archive/refs/tags/v${pkgver}.tar.gz"
-        0001-cmake-disable-bundling.patch)
-sha256sums=('fe74369fc30a32ec7a086b1013acd0eacd674e7570eb1acc520a66180c9e9719'
-            '89a7ac9bad682e9d1b008900ae4b1d2098bfa942d31ade7ea7283295b39aefe5')
+        "0001-cmake-disable-bundling.patch")
+sha256sums=('edce96e79903adfcb3c41e9a8238511946325ea9568fde177a70a614501af689'
+            '356ecd2d571ef9bc30bdcdc55dc27b39a9283019dadaac748b508cb9f71ea0f5')
+
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
@@ -53,17 +54,30 @@ build() {
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
-  CFLAGS+=" -Wno-format -Wno-format-extra-args" \
-  CXXFLAGS+=" -Wno-format -Wno-format-extra-args" \
+  CFLAGS+=" -Wno-format -Wno-format-extra-args"
+  CXXFLAGS+=" -Wno-format -Wno-format-extra-args"
+
+  # Build only lpeg statically
+  "${MINGW_PREFIX}"/bin/cmake.exe \
+      -GNinja \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      -DUSE_BUNDLED=OFF \
+      -DUSE_BUNDLED_LPEG=ON \
+      "${extra_config[@]}" \
+      -B "${srcdir}/${_realname}-${pkgver}/.deps" \
+      "${srcdir}/${_realname}-${pkgver}/cmake.deps"
+
+  "${MINGW_PREFIX}"/bin/cmake.exe --build "${srcdir}/${_realname}-${pkgver}/.deps"
+
+  # MSYS2_ARG_CONV_EXCL is necessary so that -DCMAKE_INSTALL_PREFIX is passed correctly
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     "${MINGW_PREFIX}"/bin/cmake.exe \
       -GNinja \
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
-      -DUSE_BUNDLED_NVIMQT=OFF \
       "${extra_config[@]}" \
       ../${_realname}-${pkgver}
 
-  "${MINGW_PREFIX}"/bin/cmake.exe --build .
+  "${MINGW_PREFIX}"/bin/cmake.exe --build "${srcdir}/build-${MSYSTEM}"
 }
 
 check() {


### PR DESCRIPTION
This PR updates neovim from 0.9.5 to 0.10.1 and fixes an issue during the compilation process while linking against `lpeg.dll` which is not easily possible. To circumvent the problem, neovim is patched to load the dll through Lua's `dlopen` mechanism instead. See #21313 for more details.