### PR TITLE
libuhd: fix python library install path

### DIFF
--- a/mingw-w64-libuhd/PKGBUILD
+++ b/mingw-w64-libuhd/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libuhd
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=4.7.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Universal Software Radio Peripheral (USRP) userspace driver (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -32,7 +32,7 @@ prepare() {
 }
 
 build() {
-  local _site_packages=$(${MINGW_PREFIX}/bin/python -c "import site; a = site.getsitepackages()[0].split('/')[3:]; b = '/'.join(a); print(b)")
+  local _pyver=$(${MINGW_PREFIX}/bin/python -c "import sys;sys.stdout.write('.'.join(map(str, sys.version_info[:2])))")
 
   declare -a extra_config
   if check_option "debug" "n"; then
@@ -48,7 +48,7 @@ build() {
       -DPYTHON_EXECUTABLE="${MINGW_PREFIX}"/bin/python \
       -DENABLE_EXAMPLES=ON \
       -DENABLE_PYTHON_API=ON \
-      -DUHD_PYTHON_DIR="${_site_packages}" \
+      -DUHD_PYTHON_DIR="lib/python${_pyver}/site-packages" \
       -DENABLE_UTILS=ON \
       -DENABLE_TESTS=OFF \
       -DENABLE_E100=ON \


### PR DESCRIPTION
@chrisjohgorman I tried this and it worked _locally_

I think that `-DUHD_PYTHON_DIR` can be removed at all