### PR TITLE
Libuhd bugfixes

### DIFF
--- a/mingw-w64-libuhd/0001-libraries_headers_and_pthread_setname_np_cast.patch
+++ b/mingw-w64-libuhd/0001-libraries_headers_and_pthread_setname_np_cast.patch
@@ -306,35 +306,35 @@ index 7854782c0..d8e8db85b 100644
      char result[max_pathlen];
      const size_t result_len =
 diff --git a/host/lib/utils/thread.cpp b/host/lib/utils/thread.cpp
-index c5e1b5156..7146f2a9e 100644
+index c5e1b5156..9c01429e3 100644
 --- a/host/lib/utils/thread.cpp
 +++ b/host/lib/utils/thread.cpp
-@@ -178,9 +178,9 @@ void uhd::set_thread_affinity(const std::vector<size_t>& cpu_affinity_list)
+@@ -9,6 +9,7 @@
+ #include <uhd/utils/log.hpp>
+ #include <uhd/utils/thread.hpp>
+ #include <vector>
++#include <pthread.h>
  
+ bool uhd::set_thread_priority_safe(float priority, bool realtime)
+ {
+@@ -179,7 +180,7 @@ void uhd::set_thread_affinity(const std::vector<size_t>& cpu_affinity_list)
  void uhd::set_thread_name(boost::thread* thrd, const std::string& name)
  {
--#ifdef HAVE_PTHREAD_SETNAME
+ #ifdef HAVE_PTHREAD_SETNAME
 -    pthread_setname_np(thrd->native_handle(), name.substr(0, 16).c_str());
--#endif /* HAVE_PTHREAD_SETNAME */
-+//#ifdef HAVE_PTHREAD_SETNAME
-+//    pthread_setname_np(thrd->native_handle(), name.substr(0, 16).c_str());
-+//#endif /* HAVE_PTHREAD_SETNAME */
++    pthread_setname_np((pthread_t) thrd->native_handle(), name.substr(0, 16).c_str());
+ #endif /* HAVE_PTHREAD_SETNAME */
  #ifdef HAVE_THREAD_SETNAME_DUMMY
      // Then we can't set the thread name. This function may get called
-     // before the logger starts, and thus can't log any error messages.
-@@ -191,9 +191,9 @@ void uhd::set_thread_name(boost::thread* thrd, const std::string& name)
- 
+@@ -192,7 +193,7 @@ void uhd::set_thread_name(boost::thread* thrd, const std::string& name)
  void uhd::set_thread_name(std::thread* thrd, const std::string& name)
  {
--#ifdef HAVE_PTHREAD_SETNAME
+ #ifdef HAVE_PTHREAD_SETNAME
 -    pthread_setname_np(thrd->native_handle(), name.substr(0, 16).c_str());
--#endif /* HAVE_PTHREAD_SETNAME */
-+//#ifdef HAVE_PTHREAD_SETNAME
-+//    pthread_setname_np(thrd->native_handle(), name.substr(0, 16).c_str());
-+//#endif /* HAVE_PTHREAD_SETNAME */
++    pthread_setname_np((pthread_t) thrd->native_handle(), name.substr(0, 16).c_str());
+ #endif /* HAVE_PTHREAD_SETNAME */
  #ifdef HAVE_THREAD_SETNAME_DUMMY
      // Then we can't set the thread name. This function may get called
-     // before the logger starts, and thus can't log any error messages.
 diff --git a/host/tests/CMakeLists.txt b/host/tests/CMakeLists.txt
 index bac599811..682ce01c2 100644
 --- a/host/tests/CMakeLists.txt
@@ -398,3 +398,32 @@ index 81b5e84f9..a87fa17e9 100644
  #include <stdint.h>
  #include <ctime>
  #include <map>
+diff --git a/host/utils/uhd_images_downloader.py.in b/host/utils/uhd_images_downloader.py.in
+index 43f729036..efcfb2592 100644
+--- a/host/utils/uhd_images_downloader.py.in
++++ b/host/utils/uhd_images_downloader.py.in
+@@ -1,4 +1,4 @@
+-#!@RUNTIME_PYTHON_EXECUTABLE@
++#!/usr/bin/env python3
+ #
+ # Copyright 2018 Ettus Research, a National Instruments Company
+ # Copyright 2020 Ettus Research, a National Instruments Brand
+@@ -44,6 +44,7 @@ import sys
+ import tempfile
+ import zipfile
+ import platform
++import subprocess
+ from urllib.parse import urljoin  # Python 3
+ 
+ # For all the non-core-library imports, we will be extra paranoid and be very
+@@ -64,7 +65,9 @@ _USERNAME_VARIABLE        = "UHD_IMAGES_USER"
+ _PASSWORD_VARIABLE        = "UHD_IMAGES_PASSWORD"
+ _DEFAULT_TARGET_REGEX     = "(fpga|fw|windrv)_default"
+ _BASE_DIR_STRUCTURE_PARTS = ["share", "uhd", "images"]
+-_DEFAULT_INSTALL_PATH     = os.path.join("@CMAKE_INSTALL_PREFIX@", *_BASE_DIR_STRUCTURE_PARTS)
++_DEFAULT_INSTALL_PATH_UNIX = os.path.join("@CMAKE_INSTALL_PREFIX@", *_BASE_DIR_STRUCTURE_PARTS)
++_DEFAULT_INSTALL_PATH     = subprocess.check_output(["cygpath.exe", "-m",
++                            _DEFAULT_INSTALL_PATH_UNIX]).decode('utf-8').strip()
+ _DEFAULT_BASE_URL         = "https://files.ettus.com/binaries/cache/"
+ _INVENTORY_FILENAME       = "inventory.json"
+ _DEFAULT_BUFFER_SIZE      = 8192

--- a/mingw-w64-libuhd/PKGBUILD
+++ b/mingw-w64-libuhd/PKGBUILD
@@ -36,7 +36,7 @@ prepare() {
 }
 
 build() {
-  local _site_packages=$(${MINGW_PREFIX}/bin/python -c "import site; a = site.getsitepackages()[0].split('/')[3:]; b = '/'.join(a); print(b)")
+  local _pyver=$(${MINGW_PREFIX}/bin/python -c "import sys;sys.stdout.write('.'.join(map(str, sys.version_info[:2])))")
 
   declare -a extra_config
   if check_option "debug" "n"; then
@@ -52,7 +52,7 @@ build() {
       -DPYTHON_EXECUTABLE="${MINGW_PREFIX}"/bin/python \
       -DENABLE_EXAMPLES=ON \
       -DENABLE_PYTHON_API=ON \
-      -DUHD_PYTHON_DIR="${_site_packages}" \
+      -DUHD_PYTHON_DIR="lib/python${_pyver}/site-packages" \
       -DENABLE_UTILS=ON \
       -DENABLE_TESTS=OFF \
       -DENABLE_E100=ON \

--- a/mingw-w64-libuhd/PKGBUILD
+++ b/mingw-w64-libuhd/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libuhd
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=4.7.0.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Universal Software Radio Peripheral (USRP) userspace driver (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -25,18 +25,18 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-mako"
              "${MINGW_PACKAGE_PREFIX}-python-numpy")
 source=("https://github.com/EttusResearch/uhd/archive/v${pkgver}/libuhd-${pkgver}.tar.gz"
-        0001-libraries_headers_and_no_pthread_setname_np.patch)
+        0001-libraries_headers_and_pthread_setname_np_cast.patch)
 sha256sums=('afe56842587ce72d6a57535a2b15c061905f0a039abcc9d79f0106f072a00d10'
-            'e97e1c6a3f1d29d658eb554fe4f206cec0ccddb4459585f221b151118e5f5cfa')
+            'a5f7d2164dfd2c07d22941dc52a86dde9389d4f2f126541bb7c3cfe889d0c0d0')
 
 prepare() {
   cd "${srcdir}"/uhd-${pkgver}
 
-  patch -Np1 -i "${srcdir}"/0001-libraries_headers_and_no_pthread_setname_np.patch
+  patch -Np1 -i "${srcdir}"/0001-libraries_headers_and_pthread_setname_np_cast.patch
 }
 
 build() {
-  local _pyver=$(${MINGW_PREFIX}/bin/python -c "import sys;sys.stdout.write('.'.join(map(str, sys.version_info[:2])))")
+  local _site_packages=$(${MINGW_PREFIX}/bin/python -c "import site; a = site.getsitepackages()[0].split('/')[3:]; b = '/'.join(a); print(b)")
 
   declare -a extra_config
   if check_option "debug" "n"; then
@@ -52,7 +52,7 @@ build() {
       -DPYTHON_EXECUTABLE="${MINGW_PREFIX}"/bin/python \
       -DENABLE_EXAMPLES=ON \
       -DENABLE_PYTHON_API=ON \
-      -DUHD_PYTHON_DIR="lib/python${_pyver}/site-packages" \
+      -DUHD_PYTHON_DIR="${_site_packages}" \
       -DENABLE_UTILS=ON \
       -DENABLE_TESTS=OFF \
       -DENABLE_E100=ON \
@@ -70,5 +70,16 @@ check() {
 
 package() {
   DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install "build-${MSYSTEM}"
+
+  # copy uhd_images_downloader.py and usrp2_card_burner.py to ${MINGW_PREFIX}/bin
+  # so they can be executed
+  if [ -f "${pkgdir}/${MINGW_PREFIX}"/lib/uhd/utils/uhd_images_downloader.py ]; then
+    cp "${pkgdir}/${MINGW_PREFIX}"/lib/uhd/utils/uhd_images_downloader.py \
+    "${pkgdir}/${MINGW_PREFIX}"/bin/uhd_images_downloader
+  fi
+  if [ -f "${pkgdir}/${MINGW_PREFIX}"/lib/uhd/utils/usrp2_card_burner.py ]; then
+    cp "${pkgdir}/${MINGW_PREFIX}"/lib/uhd/utils/usrp2_card_burner.py \
+    "${pkgdir}/${MINGW_PREFIX}"/bin/usrp2_card_burner
+  fi
 
 }


### PR DESCRIPTION
- There was a small section of code commented out because I couldn't get it to build. A
  simple cast fixes this. Now we can use pthread_setname_np to set thread names.

- Use cygpath.exe to set a proper path for the _DEFAULT_INSTALL_PATH for uhd_images_downloader

- Move uhd_images_downlader.py and usrp2_card_burner.py to ${MINGW_PREFIX}/bin and change
  their names to uhd_images_downloader and usrp_card_burner respectively. The reflects the
  contents of /usr/bin in the arch package.

- Re enable @ognevny 's fix to -DUHD_PYTHON_DIR that was deleted in error by my first push.