### PR TITLE
gnuradio: Add deps needed by gnuradio-companion.

### DIFF
--- a/mingw-w64-gnuradio/PKGBUILD
+++ b/mingw-w64-gnuradio/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gnuradio
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=3.10.11.0
-pkgrel=3
+pkgrel=4
 pkgdesc="General purpose DSP and SDR toolkit (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64')
@@ -19,6 +19,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-codec2"
   "${MINGW_PACKAGE_PREFIX}-gmp"
   "${MINGW_PACKAGE_PREFIX}-gsl"
   "${MINGW_PACKAGE_PREFIX}-gsm"
+  "${MINGW_PACKAGE_PREFIX}-gtk3"
   "${MINGW_PACKAGE_PREFIX}-libad9361-iio"
   "${MINGW_PACKAGE_PREFIX}-libuhd" 
   "${MINGW_PACKAGE_PREFIX}-libunwind"
@@ -27,6 +28,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-codec2"
   "${MINGW_PACKAGE_PREFIX}-volk"
   "${MINGW_PACKAGE_PREFIX}-python-click"
   "${MINGW_PACKAGE_PREFIX}-python-click-plugins"
+  "${MINGW_PACKAGE_PREFIX}-python-gobject"
   "${MINGW_PACKAGE_PREFIX}-python-jsonschema"
   "${MINGW_PACKAGE_PREFIX}-python-mako"
   "${MINGW_PACKAGE_PREFIX}-python-matplotlib"


### PR DESCRIPTION
This PR adds python-gobject and gtk3 as dependencies for gnuradio.  These dependences are needed to run gnuradio-companion

Without python-gobject, attempting to run gnuradio-companion fails with the following error:

```
$ gnuradio-companion.exe
ModuleNotFoundError

Failed to initialize GTK. If you are running over ssh, did you enable X forwarding and start ssh with -X?

(No module named 'gi')
```

Without gtk3, attempting to run gnuradio-companion fails with the following error:

```
$ gnuradio-companion.exe
While trying to display an error message, another error occurred
Namespace Gtk not available
The original error message follows.
ValueError

Failed to initialize GTK. If you are running over ssh, did you enable X forwarding and start ssh with -X?

(Namespace Gtk not available)
```



