### PR TITLE
msgpack-c: update to 6.0.2

### DIFF
--- a/mingw-w64-msgpack-c/PKGBUILD
+++ b/mingw-w64-msgpack-c/PKGBUILD
@@ -3,51 +3,39 @@
 _realname=msgpack-c
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=5.0.0
+pkgver=6.0.2
 pkgrel=1
 pkgdesc="MessagePack implementation for C and C++ (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://github.com/msgpack/msgpack-c"
 license=('spdx:BSL-1.0')
-makedepends=("${MINGW_PACKAGE_PREFIX}-gtest"
-             "${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-ninja"
-             "${MINGW_PACKAGE_PREFIX}-zlib"
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-cc")
-depends=()
 source=("https://github.com/msgpack/msgpack-c/releases/download/c-${pkgver}/msgpack-c-${pkgver}.tar.gz")
-sha256sums=('eb6d77f32dbaaae9174d96cacfe02af30bf1ea329c45018074cd95ac6e6fa6e5')
+sha256sums=('5e90943f6f5b6ff6f4bda9146ada46e7e455af3a77568f6d503f35618c1b2a12')
 
 build() {
-  [[ -d "${srcdir}/build-${MSYSTEM}" ]] && rm -rf "${srcdir}/build-${MSYSTEM}"
-  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
-
+  declare -a extra_config
   if check_option "debug" "n"; then
     extra_config+=("-DCMAKE_BUILD_TYPE=Release")
   else
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
-  MSYS2_ARG_CONV_EXCL='-DCMAKE_INSTALL_PREFIX=' \
-    ${MINGW_PREFIX}/bin/cmake \
-      -G "Ninja" \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    cmake -B "build-${MSYSTEM}" -S "msgpack-c-${pkgver}" \
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-      ${extra_config} \
       -DMSGPACK_BUILD_EXAMPLES=OFF \
       -DMSGPACK_BUILD_TESTS=OFF \
-      ../msgpack-c-${pkgver}
+      -DMSGPACK_ENABLE_SHARED=ON \
+      -DMSGPACK_ENABLE_STATIC=ON \
+      "${extra_config[@]}"
 
-  ${MINGW_PREFIX}/bin/cmake --build .
-}
-
-check() {
-  cd "${srcdir}/build-${MSYSTEM}"
-  ${MINGW_PREFIX}/bin/ctest || true
+  cmake --build "build-${MSYSTEM}"
 }
 
 package() {
-  cd "${srcdir}/build-${MSYSTEM}"
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
-  install -Dm644 ${srcdir}/msgpack-c-${pkgver}/LICENSE_1_0.txt ${okgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE_1_0.txt
+  DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}"
+  install -Dm644 ${srcdir}/msgpack-c-${pkgver}/LICENSE_1_0.txt -t ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}
 }


### PR DESCRIPTION
I've revised it in accordance with `mingw-w64-PKGBUILD-templates`. However, I'm not sure how to proceed with examples and tests which the numerous dependencies involved (e.g. cjson, dart, valgrind), and I finally just disable it.