### PR TITLE
rust: use hand-written config.toml

### DIFF
--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -20,7 +20,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-rust-docs")
          "${MINGW_PACKAGE_PREFIX}-rust-src")
 pkgver=1.80.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
@@ -46,6 +46,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-zlib")
 source=("${rust_dist_server}/${_realname}c-${pkgver}-src.tar.gz"{,.asc}
         "${embed_manifest_url}"
+        "config.toml"
         "0001-rustc-llvm-fix-libs.patch"
         "0005-win32-config.patch"
         "0007-clang-subsystem.patch"
@@ -56,6 +57,7 @@ noextract=(${_realname}c-${pkgver}-src.tar.gz)
 sha256sums=('6f606c193f230f6b2cae4576f7b24d50f5f9b25dff11dbf9b22f787d3521d672'
             'SKIP'
             '24ef6d949c0b5b1940c1d6a7aad78d86012152fb8845a1644bc939350d7b75e2'
+            '1d7f9e5a5ada1a1381647bd9041a6971c5205fc6d47a98b7b6d2c70ed27a14f7'
             '7cb1773c288ffb1c1e751edc49b1890c84bf9c362742bc5225d19d474edb73a0'
             '7d1c4e49524b835a8eadc961b39f5594b12a522a1e24368999be2c7e85399e4e'
             '87955818066f02e4a39c36a789caf45c524cf4a41f04ee1b0cc685bd5205e63e'
@@ -151,14 +153,10 @@ build() {
     export CARGO_TARGET_${CARCH^^}_PC_WINDOWS_GNU_LINKER="${CC}"
   fi
 
-  local -a _rust_conf=()
-  if [ "${_bootstrapping}" = "no" ]; then
-    _rust_conf+=("--local-rust-root=$(cygpath -m ${MINGW_PREFIX})")
-  fi
-  _rust_conf+=("--enable-vendor")
-
+  local _build_docs=true
   if [[ ${CARCH} == i686 ]]; then
-    _rust_conf+=("--disable-docs" "--disable-compiler-docs")
+    _build_docs=false
+    LDFLAGS+=" -Wl,--large-address-aware"
   fi
 
   # The rust build uses git if it's available but can't handle cygwin git paths
@@ -173,24 +171,16 @@ build() {
 
   export RUST_BACKTRACE=1
 
-  MSYS2_ARG_CONV_EXCL="--prefix;--sysconfdir;--localstatedir" \
-  ../${_realname}c-${pkgver}-src/configure \
-    --prefix=${MINGW_PREFIX} \
-    --sysconfdir=${MINGW_PREFIX}/etc \
-    --localstatedir=${MINGW_PREFIX}/var/lib \
-    --build=$OSTYPE \
-    --host=$OSTYPE \
-    --target=$OSTYPE \
-    --release-channel=stable \
-    --release-description="Rev${pkgrel}, Built by MSYS2 project" \
-    --enable-ninja \
-    --enable-extended \
-    --disable-llvm-static-stdcpp \
-    --disable-codegen-tests \
-    --set='dist.include-mingw-linker=false' \
-    --llvm-root=${MINGW_PREFIX} \
-    --python=${MINGW_PREFIX}/bin/python \
-    "${_rust_conf[@]}"
+  local _bindir="$(cygpath -m ${MINGW_PREFIX}/bin)"
+  cp -f "${srcdir}/config.toml" "${srcdir}/${_realname}c-${pkgver}-src"
+  sed -i "s|%PREFIX%|${MINGW_PREFIX}|g" "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
+  sed -i "s|%OSTYPE%|${OSTYPE}|g" "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
+  sed -i "s|%PKGREL%|${pkgrel}|g" "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
+  sed -i "s|%BUILD_DOCS%|${_build_docs}|g" "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
+  sed -i "s|%BINDIR%|${_bindir}|g" "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
+  if [ "${_bootstrapping}" = "no" ]; then
+    sed -i "/^\[build\]/a rustc = \"${_bindir}/rustc.exe\"\ncargo = \"${_bindir}/cargo.exe\"" "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
+  fi
 
   # Building out of tree is not officially supported so we have to workaround some things like vendored deps
   cp -r ../${_realname}c-${pkgver}-src/.cargo .
@@ -230,7 +220,6 @@ package_rust() {
            "${MINGW_PACKAGE_PREFIX}-curl"
            "${MINGW_PACKAGE_PREFIX}-libxml2"
            "${MINGW_PACKAGE_PREFIX}-libssh2")
-  optdepends=("${MINGW_PACKAGE_PREFIX}-rust-src: Required for rust-analyzer component")
 
   cd "${srcdir}/${MSYSTEM}"
 

--- a/mingw-w64-rust/config.toml
+++ b/mingw-w64-rust/config.toml
@@ -1,0 +1,80 @@
+# see src/bootstrap/defaults/
+profile = "dist"
+
+# see src/bootstrap/src/utils/change_tracker.rs
+change-id = 125535
+
+[llvm]
+static-libstdcpp = false
+ninja = true
+
+[build]
+build = "%OSTYPE%"
+host = ["%OSTYPE%"]
+target = [
+  "%OSTYPE%",
+]
+python = "python.exe"
+locked-deps = true
+vendor = true
+tools = [
+  "cargo",
+  "clippy",
+  "rustdoc",
+  "rustfmt",
+  "rust-analyzer-proc-macro-srv",
+  "analysis",
+  "src",
+  "rust-demangler",
+]
+sanitizers = true
+profiler = true
+
+# Generating docs fails with the wasm32-* targets
+docs = %BUILD_DOCS%
+
+[install]
+prefix = "%PREFIX%"
+sysconfdir = "etc"
+
+[rust]
+codegen-units-std = 1
+debuginfo-level = 1
+debuginfo-level-std = 2
+channel = "stable"
+description = "Rev%PKGREL%, Built by MSYS2 project"
+rpath = false
+codegen-tests = false
+deny-warnings = false
+backtrace-on-ice = true
+
+[dist]
+compression-formats = ["gz"]
+include-mingw-linker = false
+
+[target.%OSTYPE%]
+llvm-config = "%BINDIR%/llvm-config.exe"
+
+# [target.wasm32-unknown-unknown]
+# sanitizers = false
+# profiler = false
+
+# [target.wasm32-wasi]
+# sanitizers = false
+# profiler = false
+# wasi-root = "%PREFIX%/share/wasi-sysroot"
+
+# [target.wasm32-wasip1]
+# sanitizers = false
+# profiler = false
+# wasi-root = "%PREFIX%/share/wasi-sysroot"
+
+# [target.wasm32-wasip1-threads]
+# sanitizers = false
+# profiler = false
+# wasi-root = "%PREFIX%/share/wasi-sysroot"
+
+# [target.wasm32-wasip2]
+# sanitizers = false
+# profiler = false
+# wasi-root = "%PREFIX%/share/wasi-sysroot"


### PR DESCRIPTION
all previous configs should be the same as before, but:
- ~linked against shared llvm~ not supported
- remove rust-analyzer component (it will be added as separate package)
- add some extra options (copied from Arch)
- comment wasm-related configs (@ArchGuyWu you need to also append wasm targets to build.targets field)

edit: 
- ~add gettext-tools to makedepends for docs~ didn't fix anything