### PR TITLE
binutils: update to 2.43

### DIFF
--- a/mingw-w64-binutils/2001-ld-option-to-move-default-bases-under-4GB.patch
+++ b/mingw-w64-binutils/2001-ld-option-to-move-default-bases-under-4GB.patch
@@ -1,4 +1,4 @@
-From 613f4ee841ab6932a7c900d770765e42458d4d46 Mon Sep 17 00:00:00 2001
+From 00482eb5a21d4402d11351eaa4f32741b7b88b51 Mon Sep 17 00:00:00 2001
 From: Jeremy Drake <github@jdrake.com>
 Date: Thu, 10 Sep 2020 10:28:28 -0700
 Subject: [PATCH] ld option to move default bases under 4GB.
@@ -7,14 +7,15 @@ Some (buggy) programs have 'latent pointer truncation' issues, and
 setting the ImageBase below 4GB indicates to Windows that it's not safe
 to relocate these using ASLR in such a way as to trigger them.
 ---
- ld/emultempl/pep.em | 50 ++++++++++++++++++++++++++++++++++++++++++---
- 1 file changed, 47 insertions(+), 3 deletions(-)
+ ld/emultempl/pep.em | 46 +++++++++++++++++++++++++++++++++++++++++++--
+ ld/ldlex.h          |  2 ++
+ 2 files changed, 46 insertions(+), 2 deletions(-)
 
 diff --git a/ld/emultempl/pep.em b/ld/emultempl/pep.em
-index c6fd8b8f8d9..312f8d6d566 100644
+index 00c4ea9e15a..439e2eb83d4 100644
 --- a/ld/emultempl/pep.em
 +++ b/ld/emultempl/pep.em
-@@ -132,18 +132,26 @@ fragment <<EOF
+@@ -137,18 +137,26 @@ fragment <<EOF
  #define NT_EXE_IMAGE_BASE \
    ((bfd_vma) (${move_default_addr_high} ? 0x100400000LL \
  					: 0x140000000LL))
@@ -41,7 +42,7 @@ index c6fd8b8f8d9..312f8d6d566 100644
  #else
  #undef  NT_EXE_IMAGE_BASE
  #define NT_EXE_IMAGE_BASE \
-@@ -176,6 +184,7 @@ static int support_old_code = 0;
+@@ -181,6 +189,7 @@ static int support_old_code = 0;
  static lang_assignment_statement_type *image_base_statement = 0;
  static unsigned short pe_dll_characteristics = DEFAULT_DLL_CHARACTERISTICS;
  static bool insert_timestamp = true;
@@ -49,18 +50,7 @@ index c6fd8b8f8d9..312f8d6d566 100644
  static const char *emit_build_id;
  #ifdef PDB_H
  static int pdb;
-@@ -310,7 +319,9 @@ enum options
-   OPTION_DISABLE_NO_SEH,
-   OPTION_DISABLE_NO_BIND,
-   OPTION_DISABLE_WDM_DRIVER,
--  OPTION_DISABLE_TERMINAL_SERVER_AWARE
-+  OPTION_DISABLE_TERMINAL_SERVER_AWARE,
-+  OPTION_DEFAULT_IMAGE_BASE_LOW,
-+  OPTION_DEFAULT_IMAGE_BASE_HIGH
- };
- 
- static void
-@@ -402,6 +413,10 @@ gld${EMULATION_NAME}_add_options
+@@ -334,6 +343,10 @@ gld${EMULATION_NAME}_add_options
      {"disable-no-bind", no_argument, NULL, OPTION_DISABLE_NO_BIND},
      {"disable-wdmdriver", no_argument, NULL, OPTION_DISABLE_WDM_DRIVER},
      {"disable-tsaware", no_argument, NULL, OPTION_DISABLE_TERMINAL_SERVER_AWARE},
@@ -71,7 +61,7 @@ index c6fd8b8f8d9..312f8d6d566 100644
      {NULL, no_argument, NULL, 0}
    };
  
-@@ -538,6 +553,10 @@ gld${EMULATION_NAME}_list_options (FILE *file)
+@@ -470,6 +483,10 @@ gld${EMULATION_NAME}_list_options (FILE *file)
    fprintf (file, _("  --[disable-]wdmdriver              Driver uses the WDM model\n"));
    fprintf (file, _("  --[disable-]tsaware                Image is Terminal Server aware\n"));
    fprintf (file, _("  --build-id[=STYLE]                 Generate build ID\n"));
@@ -82,7 +72,7 @@ index c6fd8b8f8d9..312f8d6d566 100644
  #ifdef PDB_H
    fprintf (file, _("  --pdb=[FILENAME]                   Generate PDB file\n"));
  #endif
-@@ -949,6 +968,12 @@ gld${EMULATION_NAME}_handle_option (int optc)
+@@ -884,6 +901,12 @@ gld${EMULATION_NAME}_handle_option (int optc)
        if (strcmp (optarg, "none"))
  	emit_build_id = xstrdup (optarg);
        break;
@@ -95,7 +85,7 @@ index c6fd8b8f8d9..312f8d6d566 100644
  #ifdef PDB_H
      case OPTION_PDB:
        pdb = 1;
-@@ -995,7 +1020,14 @@ static bfd_vma
+@@ -930,7 +953,14 @@ static bfd_vma
  compute_dll_image_base (const char *ofile)
  {
    bfd_vma hash = (bfd_vma) strhash (ofile);
@@ -111,7 +101,7 @@ index c6fd8b8f8d9..312f8d6d566 100644
  }
  #endif
  
-@@ -1020,13 +1052,25 @@ gld${EMULATION_NAME}_set_symbols (void)
+@@ -955,13 +985,25 @@ gld${EMULATION_NAME}_set_symbols (void)
  #ifdef DLL_SUPPORT
  	  init[IMAGEBASEOFF].value = (pep_enable_auto_image_base
  				      ? compute_dll_image_base (output_filename)
@@ -138,5 +128,16 @@ index c6fd8b8f8d9..312f8d6d566 100644
        init[MSIMAGEBASEOFF].value = init[IMAGEBASEOFF].value;
      }
  
--- 
-2.32.0
+diff --git a/ld/ldlex.h b/ld/ldlex.h
+index defe3fcbbb9..6c5e631171b 100644
+--- a/ld/ldlex.h
++++ b/ld/ldlex.h
+@@ -389,6 +389,8 @@ enum option_values
+   OPTION_DISABLE_NO_BIND,
+   OPTION_DISABLE_WDM_DRIVER,
+   OPTION_DISABLE_TERMINAL_SERVER_AWARE,
++  OPTION_DEFAULT_IMAGE_BASE_LOW,
++  OPTION_DEFAULT_IMAGE_BASE_HIGH,
+   /* Used by emultempl/pep.em.  */
+   OPTION_DISABLE_HIGH_ENTROPY_VA,
+   OPTION_HIGH_ENTROPY_VA,

--- a/mingw-w64-binutils/PKGBUILD
+++ b/mingw-w64-binutils/PKGBUILD
@@ -5,8 +5,8 @@
 _realname=binutils
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.42
-pkgrel=2
+pkgver=2.43
+pkgrel=1
 pkgdesc="A set of programs to assemble and manipulate binary and object files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -33,18 +33,18 @@ source=(https://ftp.gnu.org/gnu/binutils/${_realname}-${pkgver}.tar.bz2{,.sig}
         libiberty-unlink-handle-windows-nul.patch
         3001-hack-libiberty-link-order.patch
 )
-sha256sums=('aa54850ebda5064c72cd4ec2d9b056c294252991486350d9a97ab2a6dfdfaf12'
+sha256sums=('fed3c3077f0df7a4a1aa47b080b8c53277593ccbb4e5e78b73ffb4e3f265e750'
             'SKIP'
             '2c99345fc575c3a060d6677537f636c6c4154fac0fde508070f3b6296c1060d4'
             '4e8ac055df61b1b5d6ae29dc87e1154737c2e87c7b244b44866702cabf1a5d18'
             '5f3fc3949172d2d6e7cd595f9359077e012391a8c3c2aebc02e30fa656ded833'
-            '328ed91bdc9c729ab19f2a566d2d1cbb5ac1beb4775bd71d85e9777b4ed4c17a'
+            '081aa14e688c7c72c3a869aac70ea362cbc3ef7906ada7acf68e874510ba8ee5'
             'd584f1cd9e94cba0e9b27625c4acc8ad5242cd625c9b44839d42fc116072568c'
             'a094660ec95996c00b598429843b7869037732146442af567ada9f539bd40480'
             '7ccbd418695733c50966068fa9755a6abb156f53af23701d2bc097c63e9e0030'
             '604628156c08f3e361de60329af250fab6839e23e61e289f8369a7e18a04e277')
-validpgpkeys=('EAF1C276A747E9ED86210CBAC3126D3B4AE55E93'
-              '3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F')
+validpgpkeys=('EAF1C276A747E9ED86210CBAC3126D3B4AE55E93'  # Tristan Gingold <gingold@adacore.com>
+              '3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F') # Nick Clifton <nickc@redhat.com>
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -106,23 +106,23 @@ build() {
   fi
 
   ../${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \
-    --prefix=${MINGW_PREFIX} \
-    --disable-werror \
-    --enable-lto \
-    --with-sysroot=${MINGW_PREFIX} \
-    --with-libiconv-prefix=${MINGW_PREFIX} \
-    "${extra_config[@]}" \
-    --enable-nls \
-    --disable-rpath \
     --disable-multilib \
-    --enable-install-libiberty \
-    --enable-plugins \
+    --disable-rpath \
     --disable-shared \
+    --disable-werror \
     --enable-deterministic-archives \
-    --with-system-zlib
+    --enable-install-libiberty \
+    --enable-lto \
+    --enable-nls \
+    --enable-plugins \
+    --with-libiconv-prefix=${MINGW_PREFIX} \
+    --with-sysroot=${MINGW_PREFIX} \
+    --with-system-zlib \
+    "${extra_config[@]}"
 
   make
 }
@@ -140,12 +140,9 @@ package() {
   make DESTDIR=${pkgdir} install
 
   # https://github.com/msys2/MINGW-packages/issues/7890
-  rm "${pkgdir}${MINGW_PREFIX}/lib/bfd-plugins/libdep.a"
+  rm ${pkgdir}${MINGW_PREFIX}/lib/bfd-plugins/libdep.*
 
   find ${pkgdir}${MINGW_PREFIX}/share -type f -iname "opcodes.mo" -o -iname "bfd.mo" | xargs -rtl1 rm
 
-  install -Dm644 ${srcdir}/${_realname}-${pkgver}/COPYING      ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING
-  install -Dm644 ${srcdir}/${_realname}-${pkgver}/COPYING.LIB  ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.LIB
-  install -Dm644 ${srcdir}/${_realname}-${pkgver}/COPYING3     ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING3
-  install -Dm644 ${srcdir}/${_realname}-${pkgver}/COPYING3.LIB ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING3.LIB
+  install -Dm644 ${srcdir}/${_realname}-${pkgver}/COPYING* -t ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}
 }


### PR DESCRIPTION
`0410-windres-handle-spaces.patch` and `0500-fix-weak-undef-symbols-after-image-base-change.patch` is unused, Could I remove it?