### PR TITLE
gnuradio: fixup dependencies

### DIFF
--- a/mingw-w64-gnuradio/PKGBUILD
+++ b/mingw-w64-gnuradio/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gnuradio
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=3.10.11.0
-pkgrel=4
+pkgrel=5
 pkgdesc="General purpose DSP and SDR toolkit (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64')
@@ -15,12 +15,14 @@ msys2_references=(
 )
 license=(spdx:GPL-3.0-or-later)
 depends=("${MINGW_PACKAGE_PREFIX}-codec2"
+  "${MINGW_PACKAGE_PREFIX}-boost"
   "${MINGW_PACKAGE_PREFIX}-gcc-libs"
   "${MINGW_PACKAGE_PREFIX}-gmp"
   "${MINGW_PACKAGE_PREFIX}-gsl"
   "${MINGW_PACKAGE_PREFIX}-gsm"
   "${MINGW_PACKAGE_PREFIX}-gtk3"
   "${MINGW_PACKAGE_PREFIX}-libad9361-iio"
+  "${MINGW_PACKAGE_PREFIX}-libiio"
   "${MINGW_PACKAGE_PREFIX}-libuhd" 
   "${MINGW_PACKAGE_PREFIX}-libunwind"
   "${MINGW_PACKAGE_PREFIX}-fftw"
@@ -29,6 +31,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-codec2"
   "${MINGW_PACKAGE_PREFIX}-python-click"
   "${MINGW_PACKAGE_PREFIX}-python-click-plugins"
   "${MINGW_PACKAGE_PREFIX}-python-gobject"
+  "${MINGW_PACKAGE_PREFIX}-python-cairo"
   "${MINGW_PACKAGE_PREFIX}-python-jsonschema"
   "${MINGW_PACKAGE_PREFIX}-python-mako"
   "${MINGW_PACKAGE_PREFIX}-python-matplotlib"
@@ -38,6 +41,10 @@ depends=("${MINGW_PACKAGE_PREFIX}-codec2"
   "${MINGW_PACKAGE_PREFIX}-python-pyzmq"
   "${MINGW_PACKAGE_PREFIX}-python-scipy"
   "${MINGW_PACKAGE_PREFIX}-python-qtpy"
+  "${MINGW_PACKAGE_PREFIX}-python-pyqt5"
+  "${MINGW_PACKAGE_PREFIX}-python-pyqtgraph"
+  "${MINGW_PACKAGE_PREFIX}-python-lxml"
+  "${MINGW_PACKAGE_PREFIX}-python-pyopengl"
   "${MINGW_PACKAGE_PREFIX}-qt5-base"
   "${MINGW_PACKAGE_PREFIX}-angleproject"
   "${MINGW_PACKAGE_PREFIX}-qwt-qt5"
@@ -45,30 +52,25 @@ depends=("${MINGW_PACKAGE_PREFIX}-codec2"
   "${MINGW_PACKAGE_PREFIX}-soapysdr"
   "${MINGW_PACKAGE_PREFIX}-portaudio"
   "${MINGW_PACKAGE_PREFIX}-libsndfile"
-  "${MINGW_PACKAGE_PREFIX}-spdlog")
+  "${MINGW_PACKAGE_PREFIX}-spdlog"
+  "${MINGW_PACKAGE_PREFIX}-fmt"
+  "${MINGW_PACKAGE_PREFIX}-zeromq")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
-             "${MINGW_PACKAGE_PREFIX}-boost"
              "${MINGW_PACKAGE_PREFIX}-cppzmq"
              "${MINGW_PACKAGE_PREFIX}-doxygen"
-             "${MINGW_PACKAGE_PREFIX}-gtk3"
-             "${MINGW_PACKAGE_PREFIX}-libiio"
              "${MINGW_PACKAGE_PREFIX}-pybind11"
-             "${MINGW_PACKAGE_PREFIX}-python-cairo"
-             "${MINGW_PACKAGE_PREFIX}-python-gobject"
              "${MINGW_PACKAGE_PREFIX}-python-packaging"
-             "${MINGW_PACKAGE_PREFIX}-python-pip"
-             "${MINGW_PACKAGE_PREFIX}-python-pyqt5"
-             "${MINGW_PACKAGE_PREFIX}-python-pyqtgraph"
-             "${MINGW_PACKAGE_PREFIX}-python-pytest" # only required for tests
-             "${MINGW_PACKAGE_PREFIX}-zeromq")
-checkdepends=("${MINGW_PACKAGE_PREFIX}-python-jsonschema"
-              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+             "${MINGW_PACKAGE_PREFIX}-python-pip")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools"
+              "${MINGW_PACKAGE_PREFIX}-python-pytest")
+optdepends=("${MINGW_PACKAGE_PREFIX}-soapyrtlsdr: install to use RTL-SDR devices with gnuradio")
 options=('!strip')
 source=("https://github.com/${_realname}/${_realname}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
         "https://github.com/gnuradio/gnuradio/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz.asc"
         0001-cmake-Install-python-wrapper-exe-for-scripts-on-Wind.patch
+        numpy-2.0.patch
         gnuradio-blocks-and-examples-path.hook.in
         gnuradio-blocks-and-examples-path.script.in
         LICENSE.txt)
@@ -80,6 +82,7 @@ validpgpkeys=(
 sha256sums=('9ca658e6c4af9cfe144770757b34ab0edd23f6dcfaa6c5c46a7546233e5ecd29'
             'SKIP'
             'aa9c79f6ab923c566f57d90117fa7e82549c26230538ffb3a2b1c0246fc31c19'
+            'e3a2d9f63318b56f87829d224232724d9c815b46c6c7086ac3c5b6ae8980bc7b'
             'b2f014a69b32afcb207e4d2e8e163fc04968594d7d4c3184b9ea5c8cf2a29329'
             'caa9a6cc253d508abcd01545f26b46df0d708d24f69b7dc59183d631872721ed'
             '86dc4bc79c9fa4d5dc3ae5558441d5bb8b8736403e70997cf9ae8f671ab5d0ca')
@@ -90,6 +93,7 @@ prepare() {
   # Patch number 0001 is credited to Ryan Volz <ryan.volz@gmail.com> and licensed under the 
   # BSD-3-Clause license
   patch -Np1 -i "${srcdir}/0001-cmake-Install-python-wrapper-exe-for-scripts-on-Wind.patch"
+  patch -Np1 -i "${srcdir}/numpy-2.0.patch"
 }
 
 build() {
@@ -124,10 +128,9 @@ build() {
   "${MINGW_PREFIX}"/bin/cmake.exe --build "build-${MSYSTEM}"
 }
 
-# FIXME - the tests build with master branch, but fail on maint-3.10, reenable when working
-#check() {
-#  "${MINGW_PREFIX}"/bin/cmake.exe --build "build-${MSYSTEM}" --target test || warning "Tests failed"
-#}
+check() {
+  "${MINGW_PREFIX}"/bin/cmake.exe --build "build-${MSYSTEM}" --target test || warning "Tests failed"
+}
 
 package() {
 

--- a/mingw-w64-gnuradio/numpy-2.0.patch
+++ b/mingw-w64-gnuradio/numpy-2.0.patch
@@ -1,0 +1,14 @@
+diff -ru gnuradio-3.10.10.0.orig/gr-digital/python/digital/qa_correlate_access_code_XX_ts.py gnuradio-3.10.10.0/gr-digital/python/digital/qa_correlate_access_code_XX_ts.py
+--- gnuradio-3.10.10.0.orig/gr-digital/python/digital/qa_correlate_access_code_XX_ts.py	2024-06-22 20:20:18.131467726 +0200
++++ gnuradio-3.10.10.0/gr-digital/python/digital/qa_correlate_access_code_XX_ts.py	2024-06-22 20:41:54.924980041 +0200
+@@ -74,8 +74,8 @@
+         # header contains packet length, twice (bit-swapped)
+         header = numpy.array([(payload_len & 0xFF00) >> 8, payload_len & 0xFF] * 2, dtype=numpy.uint8)
+         # make sure we've built the length header correctly
+-        self.assertEqual(header[0] * 256 + header[1], header[2] * 256 + header[3])
+-        self.assertEqual(header[0] * 256 + header[1], len(payload))
++        self.assertEqual(int(header[0]) * 256 + int(header[1]), int(header[2]) * 256 + int(header[3]))
++        self.assertEqual(int(header[0]) * 256 + int(header[1]), len(payload))
+ 
+         packet = numpy.concatenate((header, payload))
+         pad = (0,) * PADDING_LEN


### PR DESCRIPTION
- bump pkgrel
- remove makedepends on `gtk3` and `python-gobject` that were added to depends by https://github.com/msys2/MINGW-packages/pull/21553
- enable check to run test suite.  one case, `qa_throttle`, fails.
- add numpy-2.0.patch from arch to fix test case `qa_correlate_access_code`
- used `namcap` and `ntldd.exe` fix dependencies
  - moved packages from makedepends to depends as they were determined to be dependencies
  - removed dependencies that were installed as a dependency of another package eg. `libiio` is a dependency of `libad9361-iio`, `python-cairo` is a dependency of `python-gobject` and `fmt` is a dependency of `spdlog`.
  - added packages that were python dependencies determined by `namcap`, `python-lxml`, `pyqtgraph` and `python-pyqt5`
  - added dependency to `python-pyopengl` as it is a dependency `gnuradio-companion` in arch and an optional dependency for `pyqtgraph`.
  - added `optdepends` for `soapyrtlsdr`