### PR TITLE
tme: Update to 0.12rc13

### DIFF
--- a/mingw-w64-tme/PKGBUILD
+++ b/mingw-w64-tme/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=tme
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.12rc12
+pkgver=0.12rc13
 pkgrel=1
 pkgdesc="The Machine Emulator, or tme, provides a general-purpose framework for computer emulation. (mingw-w64)"
 arch=('any')
@@ -18,7 +18,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gtk4"
          "${MINGW_PACKAGE_PREFIX}-libvncserver"
          "${MINGW_PACKAGE_PREFIX}-libltdl")
 source=("https://github.com/phabrics/nme/releases/download/${pkgver}/${_realname}-${pkgver}.tar.xz")
-sha256sums=('cd67faeef202578794df9280eb6f19b4361fa10e0de9bf082d5ed181321c1f14')
+sha256sums=('fdddfbb0dd41acaab5da57530b31205aebedd8ee3e2b096715f8846f187b9a30')
 options=('libtool')
 
 build() {
@@ -28,15 +28,13 @@ build() {
       --prefix="${MINGW_PREFIX}" \
       --build="${MINGW_CHOST}" \
       --host="${MINGW_CHOST}" \
-      --disable-ltdl-install \
-      --disable-lto \
-      CPPFLAGS=-Wno-int-conversion 
+      --disable-ltdl-install
 
-    make tmesh_LDFLAGS= 
+    make
 }
 
 package() {
     cd "${srcdir}/build-${MSYSTEM}"
-    make install DESTDIR="${pkgdir}" tmesh_LDFLAGS= 
+    make install DESTDIR="${pkgdir}"
     install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }


### PR DESCRIPTION
Fix for module library directory search paths. Adjusted timer interrupts to get sun2 emulation working correctly. Improved mouse handling for relative modes like in SDL2. Other minor fixes and compilation improvements.