### PR TITLE
rust: don't generate debuginfo on i686

### DIFF
--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -20,7 +20,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-rust-docs")
          "${MINGW_PACKAGE_PREFIX}-rust-src")
 pkgver=1.80.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
@@ -57,7 +57,7 @@ noextract=(${_realname}c-${pkgver}-src.tar.gz)
 sha256sums=('6f606c193f230f6b2cae4576f7b24d50f5f9b25dff11dbf9b22f787d3521d672'
             'SKIP'
             '24ef6d949c0b5b1940c1d6a7aad78d86012152fb8845a1644bc939350d7b75e2'
-            '1d7f9e5a5ada1a1381647bd9041a6971c5205fc6d47a98b7b6d2c70ed27a14f7'
+            '920b227cff09b772d88e5d4a8b90f6bad6a0adf93dfb767e078738ae23b15742'
             '7cb1773c288ffb1c1e751edc49b1890c84bf9c362742bc5225d19d474edb73a0'
             '7d1c4e49524b835a8eadc961b39f5594b12a522a1e24368999be2c7e85399e4e'
             '87955818066f02e4a39c36a789caf45c524cf4a41f04ee1b0cc685bd5205e63e'
@@ -181,6 +181,9 @@ build() {
   if [ "${_bootstrapping}" = "no" ]; then
     sed -i "/^\[build\]/a rustc = \"${_bindir}/rustc.exe\"\ncargo = \"${_bindir}/cargo.exe\"" "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
   fi
+  if [ "${CARCH}" != i686 ]; then
+    sed -i '/^\[rust\]/a debuginfo-level = 1\ndebuginfo-level-std = 2' "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
+  fi
 
   # Building out of tree is not officially supported so we have to workaround some things like vendored deps
   cp -r ../${_realname}c-${pkgver}-src/.cargo .
@@ -250,6 +253,7 @@ package_rust-docs() {
 
 package_rust-src() {
   pkgdesc='Source code for the Rust standard library (mingw-w64)'
+  depends=("${MINGW_PACKAGE_PREFIX}-rust")
 
   cd "${srcdir}/${MSYSTEM}"
   install -Dm644 "${srcdir}"/${_realname}c-${pkgver}-src/LICENSE-APACHE "${pkgdir}${MINGW_PREFIX}/share/licenses/$pkgname/LICENSE-APACHE"

--- a/mingw-w64-rust/config.toml
+++ b/mingw-w64-rust/config.toml
@@ -39,8 +39,6 @@ sysconfdir = "etc"
 
 [rust]
 codegen-units-std = 1
-debuginfo-level = 1
-debuginfo-level-std = 2
 channel = "stable"
 description = "Rev%PKGREL%, Built by MSYS2 project"
 rpath = false


### PR DESCRIPTION
it takes too much memory to do that