### PR TITLE
python-dulwich: don't sed exes

### DIFF
--- a/mingw-w64-python-dulwich/PKGBUILD
+++ b/mingw-w64-python-dulwich/PKGBUILD
@@ -4,7 +4,7 @@ _realname=dulwich
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=0.22.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Python Git Library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -39,6 +39,8 @@ check() {
   "${MINGW_PREFIX}"/bin/python -m pytest
 }
 
+_opt="$(shopt -p extglob)"
+shopt -s extglob
 package() {
   cd "${srcdir}/python-build-${MSYSTEM}"
 
@@ -46,9 +48,14 @@ package() {
     ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
     --destdir="${pkgdir}" dist/*.whl
 
-  for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*; do
+  local _opt="$(shopt -p extglob)"
+  shopt -s extglob
+  for _f in "${pkgdir}${MINGW_PREFIX}"/bin/!(*.exe); do
     sed -e '1 { s/^#!.*python.*$/#!\/usr\/bin\/env python3/ }' -i ${_f}
   done
+  eval "${_opt}"
 
   install -Dm644 COPYING "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
 }
+eval "${_opt}"
+unset _opt


### PR DESCRIPTION
Apparently this corrupts the exe.

Fixes #21582 