### PR TITLE
c-ares: update to 1.33.0

### DIFF
--- a/mingw-w64-c-ares/PKGBUILD
+++ b/mingw-w64-c-ares/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=c-ares
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.29.0
+pkgver=1.33.0
 pkgrel=1
 pkgdesc="C library that performs DNS requests and name resolves asynchronously (mingw-w64)"
 arch=('any')
@@ -23,12 +23,12 @@ license=("spdx:MIT")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
-source=(#"https://c-ares.org/download/${_realname}-${pkgver}.tar.gz"{,.asc}
-        "https://github.com/${_realname}/${_realname}/releases/download/${_realname//-}-${pkgver//./_}/${_realname}-${pkgver}.tar.gz"{,.asc}
+source=("https://github.com/${_realname}/${_realname}/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz"{,.asc}
         0002-cares-pkgconfig-fix-paths-and-flags.patch)
-validpgpkeys=('914C533DF9B2ADA2204F586D78E11C6B279D5C91'
-              '27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2') # Daniel Stenberg <daniel@haxx.se>
-sha256sums=('0b89fa425b825c4c7bc708494f374ae69340e4d1fdc64523bdbb2750bfc02ea7'
+validpgpkeys=('27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2'  # Daniel Stenberg <daniel@haxx.se>
+              'DA7D64E4C82C6294CB73A20E22E3D13B5411B7CA') # Brad House <brad@brad-house.com>
+
+sha256sums=('3e41df2f172041eb4ecb754a464c11ccc5046b2a1c8b1d6a40dac45d3a3b2346'
             'SKIP'
             '86e83d0677c8b53ced256eab53aa63e6bc665f1b935b849df7352109e89a3c0e')
 


### PR DESCRIPTION
c-ares is currently listed as 1.29.0 in MSYS2, this PR should update it to the current release of 1.33.0 which has many Windows-specific fixes.

Fixes #21585 