### PR TITLE
rust: update to 1.80.1

### DIFF
--- a/mingw-w64-rust/0008-disable-self-contained.patch
+++ b/mingw-w64-rust/0008-disable-self-contained.patch
@@ -1,12 +1,12 @@
---- rustc-1.75.0-src/compiler/rustc_codegen_ssa/src/back/link.rs.orig	2023-12-21 17:55:28.000000000 +0100
-+++ rustc-1.75.0-src/compiler/rustc_codegen_ssa/src/back/link.rs	2023-12-22 13:17:31.361178700 +0100
-@@ -1708,7 +1708,9 @@
- /// Various toolchain components used during linking are used from rustc distribution
+--- rustc-1.80.1-src/compiler/rustc_codegen_ssa/src/back/link.rs.orig
++++ rustc-1.80.1-src/compiler/rustc_codegen_ssa/src/back/link.rs
+@@ -1807,6 +1807,9 @@ fn detect_self_contained_mingw(sess: &Session) -> bool {
  /// instead of being found somewhere on the host system.
  /// We only provide such support for a very limited number of targets.
-+#[allow(warnings)]
  fn self_contained_components(sess: &Session, crate_type: CrateType) -> LinkSelfContainedComponents {
-+    return LinkSelfContainedComponents::empty();
++    if sess.target.options.os == "windows" {
++        return LinkSelfContainedComponents::empty();
++    }
      // Turn the backwards compatible bool values for `self_contained` into fully inferred
      // `LinkSelfContainedComponents`.
      let self_contained =

--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -19,8 +19,8 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-rust-wasm")
          "${MINGW_PACKAGE_PREFIX}-rust-src")
-pkgver=1.80.0
-pkgrel=4
+pkgver=1.80.1
+pkgrel=1
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
@@ -56,15 +56,15 @@ source=("${rust_dist_server}/${_realname}c-${pkgver}-src.tar.gz"{,.asc}
         "0011-disable-uac-for-installer.patch"
         "0012-vendor-embed-manifest.patch")
 noextract=(${_realname}c-${pkgver}-src.tar.gz)
-sha256sums=('6f606c193f230f6b2cae4576f7b24d50f5f9b25dff11dbf9b22f787d3521d672'
+sha256sums=('2c0b8f643942dcb810cbcc50f292564b1b6e44db5d5f45091153996df95d2dc4'
             'SKIP'
             '24ef6d949c0b5b1940c1d6a7aad78d86012152fb8845a1644bc939350d7b75e2'
-            '829d72862663cb2002f57aee3471b496137f9093e3330ed8f5db80f37663eaf7'
+            'd545368d561f122c6d7844458eca93340adfd46b4f095f28fd058d869db94cc5'
             '7cb1773c288ffb1c1e751edc49b1890c84bf9c362742bc5225d19d474edb73a0'
             '56882f1a0f1404c10c7726d6cc37444f2b343e72b969badfcb43760f80db0f32'
             '7d1c4e49524b835a8eadc961b39f5594b12a522a1e24368999be2c7e85399e4e'
             '87955818066f02e4a39c36a789caf45c524cf4a41f04ee1b0cc685bd5205e63e'
-            '7a3b5722ff576b0661f36796f088dee4ce318b5dbc3fdcd65b48972de68a0edf'
+            'ee9516e16c3ab713c91186f73a03dedfd14090b53a1c46b5c9fe5c1a0c909259'
             '761d73328d9695a7a2bd2a10be8225f4a56801fee54cbb51c0841b7f16e2bde6'
             '23fc45f4e718770375be1c5196f035075de16d25e8f895100a3d1d2492995f86')
 validpgpkeys=('108F66205EAEB0AAA8DD5E1C85AB96E6FA1BE5FE'  # Rust Language (Tag and Release Signing Key) <rust-key@rust-lang.org>
@@ -102,6 +102,7 @@ prepare() {
   # move embed-manifest crate into rust source vendor directory
   mv ${srcdir}/embed-manifest-v${embed_manifest_version} ${srcdir}/${_realname}c-${pkgver}-src/vendor/embed-manifest
 
+  # 0008-disable-self-contained.patch disables it only for windows targets
   cd ${srcdir}/${_realname}c-${pkgver}-src
   apply_patch_with_msg \
     0001-rustc-llvm-fix-libs.patch \
@@ -185,6 +186,7 @@ build() {
 
   export RUST_BACKTRACE=1
 
+  # substitute the values in config.toml
   local _prefix="$(cygpath -m ${MINGW_PREFIX})"
   cp -f "${srcdir}/config.toml" "${srcdir}/${_realname}c-${pkgver}-src"
   sed -i "s|%PREFIX%|${_prefix}|g" "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
@@ -194,14 +196,14 @@ build() {
   if [ "${_bootstrapping}" = "no" ]; then
     sed -i "/^\[build\]/a rustc = \"${_prefix}/bin/rustc.exe\"\ncargo = \"${_prefix}/bin/cargo.exe\"" "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
   fi
-  # generating debug info causes OOMing on i686
-  if [ "${CARCH}" != i686 ]; then
-    sed -i '/^\[rust\]/a debuginfo-level = 1\ndebuginfo-level-std = 2' "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
+  # generate debuginfo only for non-i686 targets
+  if check_option "debug" "y" && [ "${CARCH}" != i686 ]; then
+    sed -i '/^\[rust\]/a debug = true\ndebuginfo-level-std = 2' "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
   fi
 
   # Add target wasm32-*
   if [[ ${CARCH} != i686 ]]; then
-    sed -i '/target = \[/a\  "wasm32-wasip1", "wasm32-wasip1-threads", "wasm32-wasip2",' "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
+    sed -i '/target = \[/a\  "wasm32-unknown-unknown", "wasm32-wasip1", "wasm32-wasip1-threads", "wasm32-wasip2",' "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
   fi
 
   # Building out of tree is not officially supported so we have to workaround some things like vendored deps
@@ -249,8 +251,6 @@ package_rust() {
   cd "${srcdir}/${MSYSTEM}"
 
   cp -a dest-rust/* "$pkgdir"
-  install -Dm644 ${srcdir}/${_realname}c-${pkgver}-src/LICENSE-APACHE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE-APACHE"
-  install -Dm644 ${srcdir}/${_realname}c-${pkgver}-src/LICENSE-MIT "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE-MIT"
 
   # delete unnecessary files, e.g. components and manifest files only used for the uninstall script
   cd "$pkgdir"/${MINGW_PREFIX}/lib/rustlib
@@ -266,6 +266,8 @@ package_rust-wasm() {
   depends=("${MINGW_PACKAGE_PREFIX}-lld"
            "${MINGW_PACKAGE_PREFIX}-rust"
            "${MINGW_PACKAGE_PREFIX}-wasm-component-ld")
+  # object files provided for wasm32-* targets can't be stripped with MSYS2 toolchain
+  options=('!strip')
 
   cd "${srcdir}/${MSYSTEM}"
 
@@ -282,8 +284,8 @@ package_rust-src() {
   install -Dm644 "${srcdir}"/${_realname}c-${pkgver}-src/LICENSE-APACHE "${pkgdir}${MINGW_PREFIX}/share/licenses/$pkgname/LICENSE-APACHE"
   install -Dm644 "${srcdir}"/${_realname}c-${pkgver}-src/LICENSE-MIT "${pkgdir}${MINGW_PREFIX}/share/licenses/$pkgname/LICENSE-MIT"
 
-  install -d "${pkgdir}/${MINGW_PREFIX}/lib/rustlib/"
-  cp -a dest-src "${pkgdir}/${MINGW_PREFIX}/lib/rustlib/src"
+  install -d "${pkgdir}${MINGW_PREFIX}/lib/rustlib/"
+  cp -a dest-src "${pkgdir}${MINGW_PREFIX}/lib/rustlib/src"
 }
 
 # template start; name=mingw-w64-splitpkg-wrappers; version=1.0;

--- a/mingw-w64-rust/config.toml
+++ b/mingw-w64-rust/config.toml
@@ -42,9 +42,12 @@ codegen-units-std = 1
 channel = "stable"
 description = "Rev%PKGREL%, Built by MSYS2 project"
 rpath = false
+frame-pointers = true
 codegen-tests = false
 deny-warnings = false
 backtrace-on-ice = true
+# FIXME: CFG can be enabled only for MSVC targets as for https://github.com/rust-lang/rust/pull/74103
+# control-flow-guard = true
 
 [dist]
 compression-formats = ["gz"]


### PR DESCRIPTION
- add debuginfo only if `debug` option is set (see https://github.com/msys2/MINGW-packages/pull/21581#issuecomment-2276354980)
- add missing wasm32-unknown-unknown target
- remove self-contained directory for all targets
- `rust`: remove license installation as `rustdoc` is now a part of main package (it installs license files in doc directory)
- `rust-wasm`: don't strip binaries, add missing `wasi-libc` dependency
- enable frame-pointers ~and CFG (addresses #16833)~ in config.toml