### PR TITLE
virglrenderer: Fix QEMU crash if D3D feature isn't enabled

### DIFF
--- a/mingw-w64-virglrenderer/PKGBUILD
+++ b/mingw-w64-virglrenderer/PKGBUILD
@@ -4,7 +4,7 @@ _realname=virglrenderer
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=1.0.1
-pkgrel=1
+pkgrel=2
 pkgdesc='A virtual 3D GPU library, that allows the guest operating system to use the host GPU to accelerate 3D rendering (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -23,8 +23,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 source=("https://gitlab.freedesktop.org/virgl/${_realname}/-/archive/${pkgver}/${_realname}-${pkgver}.tar.bz2"
+        "https://gitlab.freedesktop.org/virgl/virglrenderer/-/commit/6810fe91a3db6831c4c41102fa058e850be5dbee.patch"
         "https://raw.githubusercontent.com/kjliew/qemu-3dfx/aafe2f3e/virgil3d/MINGW-packages/0001-Virglrenderer-on-Windows-and-macOS.patch")
 sha256sums=('53cb8fadd08f5260ee57833fc2488565481438bc7a8e34f3e114d12cc9d9db9a'
+            '4c95741e1a5438244c1c04ca6363055b4b0e05c91a979348250978edc60d5750'
             '80f83e1f171600991df54d10dce704a77a8609ad34b23b904568cbf86ea339bf')
 
 noextract=("${_realname}-${pkgver}.tar.bz2")
@@ -34,6 +36,8 @@ prepare() {
   tar -xjf "${srcdir}/${_realname}-${pkgver}.tar.bz2" || true
 
   cd "${srcdir}/${_realname}-${pkgver}"
+  # https://gitlab.freedesktop.org/virgl/virglrenderer/-/merge_requests/1418
+  patch -p1 -i "${srcdir}/6810fe91a3db6831c4c41102fa058e850be5dbee.patch"
   # https://gitlab.freedesktop.org/virgl/virglrenderer/-/issues/217
   patch -p2 -i "${srcdir}/0001-Virglrenderer-on-Windows-and-macOS.patch"
 }


### PR DESCRIPTION
See https://gitlab.com/qemu-project/qemu/-/issues/2490 for the problem.

This commit adds a patch merged to virglrenderer to solve this problem.