### PR TITLE
ossia-score: disable fetchcontent

### DIFF
--- a/mingw-w64-ossia-score/PKGBUILD
+++ b/mingw-w64-ossia-score/PKGBUILD
@@ -4,7 +4,7 @@ _realname=ossia-score
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=3.2.4
-pkgrel=3
+pkgrel=4
 pkgdesc="ossia score, an interactive sequencer for the intermedia arts"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -72,6 +72,7 @@ build() {
     -DSCORE_DEPLOYMENT_BUILD=1 \
     -DSCORE_MSYS2_PACKAGE=1 \
     -DOSSIA_USE_SYSTEM_LIBRARIES=1 \
+    -DFETCHCONTENT_FULLY_DISCONNECTED=1 \
     -DSCORE_DISABLED_PLUGINS="score-plugin-jit;score-plugin-faust" \
     -DCMAKE_C_USE_RESPONSE_FILE_FOR_OBJECTS=1 \
     -DCMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS=1 \


### PR DESCRIPTION
to avoid it git cloning some missing optional dependencies, which then fail to build.