### PR TITLE
rust-analyzer: update to 20240812

### DIFF
--- a/mingw-w64-rust-analyzer/PKGBUILD
+++ b/mingw-w64-rust-analyzer/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=rust-analyzer
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-_pkgver=2024-08-05
+_pkgver=2024-08-12
 pkgver=${_pkgver//-}
 pkgrel=1
 pkgdesc="A Rust compiler front-end for IDEs (mingw-w64)"
@@ -12,10 +12,11 @@ mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://rust-analyzer.github.io'
 msys2_repository_url='https://github.com/rust-lang/rust-analyzer'
 license=('spdx:Apache-2.0 OR MIT')
+conflicts=("${MINGW_PACKAGE_PREFIX}-rust<1.80.0-2")
 depends=("${MINGW_PACKAGE_PREFIX}-rust-src")
 makedepends=('git')
 source=("git+${msys2_repository_url}.git#tag=${_pkgver}")
-sha256sums=('7bc2e1ac1267a88f94818124180e476488e5b820585fcb6ab983e44fca85b05b')
+sha256sums=('16479c8305f6013041b15d4b9169c944d480b17240dd1cafabc3bb70e647ab36')
 
 prepare() {
   cd "${_realname}"
@@ -27,7 +28,7 @@ build() {
   cd "${_realname}"
 
   export CFG_RELEASE=1
-  # profile dev-rel enables level 2 debug info
+  # profile dev-rel enables level 2 debug info for better debugger backtraces
   cargo build --frozen --profile dev-rel -p rust-analyzer
 }
 


### PR DESCRIPTION
~and add it as optional dependency for helix~ reverted, helix fails to build now