### PR TITLE
[new package] rufus 4.5

### DIFF
--- a/mingw-w64-rufus/PKGBUILD
+++ b/mingw-w64-rufus/PKGBUILD
@@ -1,0 +1,42 @@
+# Maintainer: Maksim Bondarenkov <maksapple2306@gmail.com>
+
+_realname=rufus
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=4.5
+pkgrel=1
+pkgdesc="The Reliable USB Formatting Utility (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64')
+url='https://rufus.ie'
+msys2_repository_url='https://github.com/pbatard/rufus'
+license=('spdx:GPL-3.0-or-later')
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+source=("${msys2_repository_url}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('4e8135f1d6be9f85cc93b49ac4bb70082315884b207f36c771cb320c24473564')
+
+build() {
+  mkdir -p "build-${MSYSTEM}" && cd "build-${MSYSTEM}"
+
+  unset CPPFLAGS
+  ../"${_realname}-${pkgver}"/configure \
+    --prefix="${MINGW_PREFIX}" \
+    --enable-silent-rules \
+    --disable-debug
+
+  make
+}
+
+check() {
+  cd "build-${MSYSTEM}"
+
+  make check
+}
+
+package() {
+  cd "build-${MSYSTEM}"
+
+  install -Dm755 src/rufus.exe "${pkgdir}${MINGW_PREFIX}/bin/rufus.exe"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.txt"
+}


### PR DESCRIPTION
UCRT64 fails with
```
 In file included from C:/_/B/src/rufus-4.5/src/libcdio/iso9660/iso9660_fs.c:28:
  C:/_/B/src/rufus-4.5/src/libcdio/config.h:43:18: error: static declaration of '_fseeki64' follows non-static declaration
     43 | #define fseeko64 _fseeki64
        |                  ^~~~~~~~~
  In file included from C:/_/B/src/rufus-4.5/src/libcdio/iso9660/iso9660_fs.c:37:
  D:/M/msys64/ucrt64/include/stdio.h:650:23: note: previous declaration of '_fseeki64' with type 'int(FILE *, long long int,  int)' {aka 'int(struct _iobuf *, long long int,  int)'}
    650 |   _CRTIMP int __cdecl _fseeki64(FILE *_File,__int64 _Offset,int _Origin);
        |                       ^~~~~~~~~
  In file included from C:/_/B/src/rufus-4.5/src/libcdio/iso9660/iso9660_private.h:29,
                   from C:/_/B/src/rufus-4.5/src/libcdio/iso9660/iso9660.c:28:
  C:/_/B/src/rufus-4.5/src/libcdio/config.h:43:18: error: static declaration of '_fseeki64' follows non-static declaration
     43 | #define fseeko64 _fseeki64
        |                  ^~~~~~~~~
  In file included from C:/_/B/src/rufus-4.5/src/libcdio/iso9660/iso9660.c:42:
  D:/M/msys64/ucrt64/include/stdio.h:650:23: note: previous declaration of '_fseeki64' with type 'int(FILE *, long long int,  int)' {aka 'int(struct _iobuf *, long long int,  int)'}
    650 |   _CRTIMP int __cdecl _fseeki64(FILE *_File,__int64 _Offset,int _Origin);
        |                       ^~~~~~~~~
```
CLANG64 fails as llvm-dlltool isn't supported