### PR TITLE
mingw-w64-codeblocks: Update _revision to 13539

### DIFF
--- a/mingw-w64-codeblocks/PKGBUILD
+++ b/mingw-w64-codeblocks/PKGBUILD
@@ -6,7 +6,7 @@ _realname=codeblocks
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 _basever=20.03
-_revision=13538
+_revision=13539
 pkgver=${_basever}.r${_revision}
 pkgrel=1
 pkgdesc="Cross-platform C/C++ IDE (mingw-w64)"
@@ -29,6 +29,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-boost"
              "zip"
              "subversion")
+optdepends=("${MINGW_PACKAGE_PREFIX}-clang-tools-extra: needed by Clangd_Client plugin")
 source=("$_realname::svn+https://svn.code.sf.net/p/codeblocks/code/trunk#revision=$_revision"
         "004-disable-parallel-make-for-SmartIndent.patch")
 sha256sums=('SKIP'
@@ -59,7 +60,7 @@ build() {
   ../${_realname}/configure \
     --prefix="${MINGW_PREFIX}" \
     --disable-pch \
-    --with-contrib-plugins=all,-wxsmith,-wxsmithcontrib,-wxsmithaui
+    --with-contrib-plugins=all,-wxsmith,-wxsmithcontrib,-wxsmithaui,-Valgrind
 
   make
 }


### PR DESCRIPTION
Stop building Valgrind plugin because Valgrind does not exist for Windows. 
Add optdepends on ${MINGW_PACKAGE_PREFIX}-clang-tools-extra.