### PR TITLE
Rebuild some packages without python-wheel

### DIFF
--- a/mingw-w64-meson/PKGBUILD
+++ b/mingw-w64-meson/PKGBUILD
@@ -4,7 +4,7 @@ _realname=meson
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.5.1
-pkgrel=1
+pkgrel=2
 pkgdesc="High-productivity build system (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -22,7 +22,6 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-build"
   "${MINGW_PACKAGE_PREFIX}-python-installer"
   "${MINGW_PACKAGE_PREFIX}-python-setuptools"
-  "${MINGW_PACKAGE_PREFIX}-python-wheel"
 )
 optdepends=("${MINGW_PACKAGE_PREFIX}-ccache: for a faster compilation"
             "${MINGW_PACKAGE_PREFIX}-sccache: for a faster compilation (preferred over ccache)")

--- a/mingw-w64-python-certifi/PKGBUILD
+++ b/mingw-w64-python-certifi/PKGBUILD
@@ -4,7 +4,7 @@ _realname=certifi
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=2024.7.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Python package for providing Mozilla's CA Bundle (mingw-w64)"
 url='https://github.com/certifi/python-certifi'
 license=('spdx:MPL-2.0')
@@ -17,8 +17,7 @@ msys2_references=(
 depends=("${MINGW_PACKAGE_PREFIX}-python")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
-             "${MINGW_PACKAGE_PREFIX}-python-setuptools"
-             "${MINGW_PACKAGE_PREFIX}-python-wheel")
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b')
 

--- a/mingw-w64-python-werkzeug/PKGBUILD
+++ b/mingw-w64-python-werkzeug/PKGBUILD
@@ -4,7 +4,7 @@ _realname=werkzeug
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=3.0.3
-pkgrel=1
+pkgrel=2
 pkgdesc='Swiss Army knife of Python web development (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -18,8 +18,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-markupsafe")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
-             "${MINGW_PACKAGE_PREFIX}-python-flit-core"
-             "${MINGW_PACKAGE_PREFIX}-python-wheel")
+             "${MINGW_PACKAGE_PREFIX}-python-flit-core")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('097e5bfda9f0aba8da6b8545146def481d06aa7d3266e7448e2cccf67dd8bd18')
 

--- a/mingw-w64-python-yaml/PKGBUILD
+++ b/mingw-w64-python-yaml/PKGBUILD
@@ -11,7 +11,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=6.0.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Python bindings for YAML, using fast libYAML library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -27,7 +27,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-python"
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"
-             "${MINGW_PACKAGE_PREFIX}-python-wheel"
              "${MINGW_PACKAGE_PREFIX}-cython"
              "${MINGW_PACKAGE_PREFIX}-cc")
 source=("https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname,,}-${pkgver}.tar.gz"

--- a/mingw-w64-python-zstandard/PKGBUILD
+++ b/mingw-w64-python-zstandard/PKGBUILD
@@ -4,7 +4,7 @@ _realname=zstandard
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=0.22.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Python bindings to the Zstandard (zstd) compression library (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -19,8 +19,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-python")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
-             "${MINGW_PACKAGE_PREFIX}-python-setuptools"
-             "${MINGW_PACKAGE_PREFIX}-python-wheel")
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-hypothesis")
 optdepends=("${MINGW_PACKAGE_PREFIX}-python-cffi")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"


### PR DESCRIPTION
it should not longer be needed with newer setuptools