### PR TITLE
rust-analyzer: update to 20240819

### DIFF
--- a/mingw-w64-rust-analyzer/PKGBUILD
+++ b/mingw-w64-rust-analyzer/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=rust-analyzer
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-_pkgver=2024-08-12
+_pkgver=2024-08-19
 pkgver=${_pkgver//-}
 pkgrel=1
 pkgdesc="A Rust compiler front-end for IDEs (mingw-w64)"
@@ -16,7 +16,7 @@ conflicts=("${MINGW_PACKAGE_PREFIX}-rust<1.80.0-2")
 depends=("${MINGW_PACKAGE_PREFIX}-rust-src")
 makedepends=('git')
 source=("git+${msys2_repository_url}.git#tag=${_pkgver}")
-sha256sums=('16479c8305f6013041b15d4b9169c944d480b17240dd1cafabc3bb70e647ab36')
+sha256sums=('29008efe52b3f13db64b7606ffd3516dc0c2d2ed93e15d8d1c3aaa68b0af7b42')
 
 prepare() {
   cd "${_realname}"
@@ -27,7 +27,7 @@ prepare() {
 build() {
   cd "${_realname}"
 
-  export CFG_RELEASE=1
+  export CFG_RELEASE="${pkgver}-${pkgrel} (Built by MSYS2 project)"
   # profile dev-rel enables level 2 debug info for better debugger backtraces
   cargo build --frozen --profile dev-rel -p rust-analyzer
 }


### PR DESCRIPTION
`CFG_RELEASE` sets a version of binary, so use custom version string