### PR TITLE
zed: update to 0.149.3

### DIFF
--- a/mingw-w64-zed/PKGBUILD
+++ b/mingw-w64-zed/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=zed
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.148.1
+pkgver=0.149.3
 pkgrel=1
 pkgdesc="A high-performance, multiplayer code editor (mingw-w64)"
 arch=('any')
@@ -35,14 +35,14 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-ollama: provides LLMs for assistance panel"
             "${MINGW_PACKAGE_PREFIX}-clang: for a better C/C++ language support"
             "${MINGW_PACKAGE_PREFIX}-rust-analyzer: for a better Rust language support")
 source=("git+${msys2_repository_url}.git#tag=v${pkgver}"
-        "zstd-sys.tar.gz::https://crates.io/api/v1/crates/zstd-sys/2.0.10+zstd.1.5.6/download"
-        "curl-sys.tar.gz::https://crates.io/api/v1/crates/curl-sys/0.4.67+curl-8.3.0/download"
+        "zstd-sys.tar.gz::https://crates.io/api/v1/crates/zstd-sys/2.0.13+zstd.1.5.6/download"
+        "curl-sys.tar.gz::https://crates.io/api/v1/crates/curl-sys/0.4.74+curl-8.9.0/download"
         "zed-download-pc-windows-gnu-assets.patch"
         "curl-sys-use-pkgconfig.patch"
         "zstd-sys-remove-statik.patch")
-sha256sums=('9368b31c177da4fbe950185a1b5306e078744120c60cc9d2f9b699155ec62bfe'
-            'c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa'
-            '3cc35d066510b197a0f72de863736641539957628c8a42e70e27c66849e77c34'
+sha256sums=('f8656c88f70e4dfe9d6b727a19f3447ecdffccf5c4e27b5bc0acd0cb01fa1dac'
+            '38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa'
+            '8af10b986114528fcdc4b63b6f5f021b7057618411046a4de2ba0f0149a097bf'
             '94ca0bc7ae6f73bc4cdb9dd02af2946541b2bee7c71f279a4eeef1f987e76fe4'
             '0e008fc69c67a5e79b05815625ffcef2d008e6b5a4bb0350c90772c49d2ca748'
             '48f4900ceb02d3aaf9a1020f33d56629156e96759f456c0e7ca18bfcf910767b')
@@ -55,10 +55,10 @@ prepare() {
   # download assets for x86_64-pc-windows-gnu target for some extensions
   patch -Np1 -i "${srcdir}/zed-download-pc-windows-gnu-assets.patch"
   # link system deps dynamically
-  patch -d "../curl-sys-0.4.67+curl-8.3.0" -i "${srcdir}/curl-sys-use-pkgconfig.patch"
-  patch -d "../zstd-sys-2.0.10+zstd.1.5.6" -i "${srcdir}/zstd-sys-remove-statik.patch"
+  patch -d "../curl-sys-0.4.74+curl-8.9.0" -i "${srcdir}/curl-sys-use-pkgconfig.patch"
+  patch -d "../zstd-sys-2.0.13+zstd.1.5.6" -i "${srcdir}/zstd-sys-remove-statik.patch"
   # use patched *-sys crates
-  sed -i '/\[patch\.crates-io\]/a curl-sys = { path = "../curl-sys-0.4.67+curl-8.3.0" }\nzstd-sys = { path = "../zstd-sys-2.0.10+zstd.1.5.6" }' Cargo.toml
+  sed -i '/\[patch\.crates-io\]/a curl-sys = { path = "../curl-sys-0.4.74+curl-8.9.0" }\nzstd-sys = { path = "../zstd-sys-2.0.13+zstd.1.5.6" }' Cargo.toml
   cargo update -p curl-sys -p zstd-sys
 
   cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
@@ -75,8 +75,7 @@ build() {
   export LIBSQLITE3_SYS_USE_PKG_CONFIG=1
   export ZED_UPDATE_EXPLANATION='Updates are handled by pacman'
   if [[ $MINGW_PACKAGE_PREFIX != *-clang-* ]]; then
-    export CFLAGS+=" -Wno-incompatible-pointer-types"
-    export RUSTFLAGS="-Clink-arg=-fuse-ld=lld"
+    export RUSTFLAGS="-Clink-arg=-fuse-ld=lld -Cforce-frame-pointers=yes"
   fi
 
   cargo build --release --frozen -p zed


### PR DESCRIPTION
upstream silently pushed v0.149.3 tag, while only pre-release is avialable in upstream releases