### PR TITLE
SWI-Prolog 9.2.6: fixed dependencies fixed

### DIFF
--- a/mingw-w64-swi-prolog/PKGBUILD
+++ b/mingw-w64-swi-prolog/PKGBUILD
@@ -2,12 +2,12 @@
 
 _realname=swi-prolog
 pkgbase=mingw-w64-${_realname}
-pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-full" "${MINGW_PACKAGE_PREFIX}-${_realname}-core" "${MINGW_PACKAGE_PREFIX}-${_realname}-packages" "${MINGW_PACKAGE_PREFIX}-${_realname}-archive" "${MINGW_PACKAGE_PREFIX}-${_realname}-bdb" "${MINGW_PACKAGE_PREFIX}-${_realname}-pcre2" "${MINGW_PACKAGE_PREFIX}-${_realname}-yaml" "${MINGW_PACKAGE_PREFIX}-${_realname}-ssl" "${MINGW_PACKAGE_PREFIX}-${_realname}-doc" "${MINGW_PACKAGE_PREFIX}-${_realname}-examples" "${MINGW_PACKAGE_PREFIX}-${_realname}-tests")
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-full" "${MINGW_PACKAGE_PREFIX}-${_realname}-core" "${MINGW_PACKAGE_PREFIX}-${_realname}-packages" "${MINGW_PACKAGE_PREFIX}-${_realname}-archive" "${MINGW_PACKAGE_PREFIX}-${_realname}-bdb" "${MINGW_PACKAGE_PREFIX}-${_realname}-pcre2" "${MINGW_PACKAGE_PREFIX}-${_realname}-yaml" "${MINGW_PACKAGE_PREFIX}-${_realname}-ssl" "${MINGW_PACKAGE_PREFIX}-${_realname}-python" "${MINGW_PACKAGE_PREFIX}-${_realname}-doc" "${MINGW_PACKAGE_PREFIX}-${_realname}-examples" "${MINGW_PACKAGE_PREFIX}-${_realname}-tests")
 pkgver=9.2.6
-pkgrel=1
+pkgrel=2
 pkgdesc="Prolog environment (mingw-w64)"
 arch=(any)
-mingw_arch=('mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://www.swi-prolog.org/"
 msys2_references=("cpe: cpe:/a:swi-prolog:swi-prolog")
 license=('spdx:BSD-2-Clause')
@@ -15,8 +15,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-gmp"
          "${MINGW_PACKAGE_PREFIX}-libwinpthread-git"
          "${MINGW_PACKAGE_PREFIX}-zlib")
-optdepends=("${MINGW_PACKAGE_PREFIX}-readline: support for readline"
-            "${MINGW_PACKAGE_PREFIX}-python: python interface")
+optdepends=("${MINGW_PACKAGE_PREFIX}-readline: support for readline")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
@@ -93,8 +92,9 @@ package_swi-prolog-core() {
 }
 
 package_swi-prolog-packages() {
-  pkgdesc="SWI-Prolog with base packages"
+  pkgdesc="Base packages for SWI-Prolog"
   conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}<9.2.6")
+  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}-core")
 
   cd "${srcdir}/build-${MSYSTEM}"
   DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake -DCMAKE_INSTALL_COMPONENT=Core_packages -P cmake_install.cmake
@@ -104,7 +104,7 @@ package_swi-prolog-packages() {
 }
 
 package_swi-prolog-archive() {
-  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}-packages"
+  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}-core"
            "${MINGW_PACKAGE_PREFIX}-libarchive")
   conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}<9.2.6")
   pkgdesc="Libarchive binding for SWI-Prolog"
@@ -116,9 +116,22 @@ package_swi-prolog-archive() {
   cp -R "${srcdir}/Archive_interface${MINGW_PREFIX}"/lib/swipl/* "${pkgdir}${MINGW_PREFIX}"/lib/swipl/
 }
 
+package_swi-prolog-python() {
+  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}-core"
+           "${MINGW_PACKAGE_PREFIX}-python")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}<9.2.6")
+  pkgdesc="Python binding for SWI-Prolog"
+
+  cd "${srcdir}/build-${MSYSTEM}"
+  DESTDIR=${srcdir}/Python_interface "${MINGW_PREFIX}"/bin/cmake -DCMAKE_INSTALL_COMPONENT=Python_interface -P cmake_install.cmake
+
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/lib/swipl"
+  cp -R "${srcdir}/Python_interface${MINGW_PREFIX}"/lib/swipl/* "${pkgdir}${MINGW_PREFIX}"/lib/swipl/
+}
+
 package_swi-prolog-bdb() {
   depends=("${MINGW_PACKAGE_PREFIX}-db"
-           "${MINGW_PACKAGE_PREFIX}-${_realname}-packages")
+           "${MINGW_PACKAGE_PREFIX}-${_realname}-core")
   conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}<9.2.6")
   pkgdesc="Berkeley DB interface for SWI-Prolog"
 
@@ -130,7 +143,7 @@ package_swi-prolog-bdb() {
 }
 
 package_swi-prolog-pcre2() {
-  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}-packages"
+  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}-core"
            "${MINGW_PACKAGE_PREFIX}-pcre2")
   conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}<9.2.6")
   pkgdesc="Regular expressions for SWI-Prolog"
@@ -143,7 +156,7 @@ package_swi-prolog-pcre2() {
 }
 
 package_swi-prolog-yaml() {
-  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}-packages"
+  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}-core"
            "${MINGW_PACKAGE_PREFIX}-libyaml")
   conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}<9.2.6")
   pkgdesc="YAML support in SWI-Prolog"
@@ -156,7 +169,8 @@ package_swi-prolog-yaml() {
 }
 
 package_swi-prolog-ssl() {
-  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}-packages"
+  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}-core"
+           "${MINGW_PACKAGE_PREFIX}-${_realname}-packages"
            "${MINGW_PACKAGE_PREFIX}-openssl")
   conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}<9.2.6")
   pkgdesc="OpenSSL/LibreSSL binding for SWI-Prolog"
@@ -169,7 +183,8 @@ package_swi-prolog-ssl() {
 }
 
 package_swi-prolog-doc() {
-  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}-packages")
+  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}-core"
+           "${MINGW_PACKAGE_PREFIX}-${_realname}-packages")
   conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}<9.2.6")
   pkgdesc="Documentation for SWI-Prolog"
 
@@ -181,7 +196,8 @@ package_swi-prolog-doc() {
 }
 
 package_swi-prolog-examples() {
-  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}-packages")
+  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}-core"
+           "${MINGW_PACKAGE_PREFIX}-${_realname}-packages")
   conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}<9.2.6")
   pkgdesc="Examples for SWI-Prolog"
 
@@ -193,7 +209,8 @@ package_swi-prolog-examples() {
 }
 
 package_swi-prolog-tests() {
-  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}-packages")
+  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}-core"
+           "${MINGW_PACKAGE_PREFIX}-${_realname}-packages")
   conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}<9.2.6")
   pkgdesc="Unit tests for SWI-Prolog"
 
@@ -205,12 +222,14 @@ package_swi-prolog-tests() {
 }
 
 package_swi-prolog-full() {
-  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}-packages"
+  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}-core"
+           "${MINGW_PACKAGE_PREFIX}-${_realname}-packages"
            "${MINGW_PACKAGE_PREFIX}-${_realname}-archive"
            "${MINGW_PACKAGE_PREFIX}-${_realname}-bdb"
            "${MINGW_PACKAGE_PREFIX}-${_realname}-pcre2"
            "${MINGW_PACKAGE_PREFIX}-${_realname}-yaml"
            "${MINGW_PACKAGE_PREFIX}-${_realname}-ssl"
+           "${MINGW_PACKAGE_PREFIX}-${_realname}-python"
            "${MINGW_PACKAGE_PREFIX}-${_realname}-doc"
            "${MINGW_PACKAGE_PREFIX}-${_realname}-examples"
            "${MINGW_PACKAGE_PREFIX}-${_realname}-tests")


### PR DESCRIPTION
fixed sub-package description for *-archive
added missing dependency
added support for python binding