### PR TITLE
verilator: Fix msys2 perl bug

### DIFF
--- a/mingw-w64-verilator/0001-Use-msys2-perl-since-it-doesn-t-work-with-windows-pe.patch
+++ b/mingw-w64-verilator/0001-Use-msys2-perl-since-it-doesn-t-work-with-windows-pe.patch
@@ -1,0 +1,22 @@
+From 2a401e94c6b056cf4143f3a56519840614e816cc Mon Sep 17 00:00:00 2001
+From: kreijstal <rainb@tfwno.gf>
+Date: Sun, 25 Aug 2024 11:19:44 +0200
+Subject: [PATCH] Use msys2 perl, since it doesn't work with windows perl
+
+---
+ bin/redirect | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bin/redirect b/bin/redirect
+index 0e7becf..d767de3 100644
+--- a/bin/redirect
++++ b/bin/redirect
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env perl
++#!/usr/bin/perl
+ ######################################################################
+ #
+ # Copyright 2003-2024 by Wilson Snyder. This program is free software; you
+-- 
+2.46.0
+

--- a/mingw-w64-verilator/PKGBUILD
+++ b/mingw-w64-verilator/PKGBUILD
@@ -4,7 +4,7 @@ _realname=verilator
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.026
-pkgrel=1
+pkgrel=2
 pkgdesc="The fastest free Verilog HDL simulator (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -15,14 +15,19 @@ groups=("${MINGW_PACKAGE_PREFIX}-eda")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-python"
-             "help2man")
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+             "help2man") 
+# Will not build correctly if perl-w64 is installed on the machine!
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "perl") 
 
-source=("https://github.com/${_realname}/${_realname}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('87fdecf3967007d9ee8c30191ff2476f2a33635d0e0c6e3dbf345cc2f0c50b78')
+source=("https://github.com/${_realname}/${_realname}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
+"0001-Use-msys2-perl-since-it-doesn-t-work-with-windows-pe.patch"
+)
+sha256sums=('87fdecf3967007d9ee8c30191ff2476f2a33635d0e0c6e3dbf345cc2f0c50b78'
+            '36e4268d4af11dcf15277a212f6dd0e5b05d4f98eafe381d46768c67aa90926c')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
+  patch -Np1 -i "${srcdir}/0001-Use-msys2-perl-since-it-doesn-t-work-with-windows-pe.patch"
   cp /usr/include/FlexLexer.h src/
   autoconf
 }


### PR DESCRIPTION
using msys2 perl instead of mingw perl, becuase otherwise verilator doesn't work? should fix #21706