### PR TITLE
lldb-dap: fix extremely slow backtrace request

### DIFF
--- a/mingw-w64-lldb/PKGBUILD
+++ b/mingw-w64-lldb/PKGBUILD
@@ -11,7 +11,7 @@ _version=18.1.8
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
-pkgrel=1
+pkgrel=2
 pkgdesc="Next generation, high-performance debugger (mingw-w64)"
 url="https://lldb.llvm.org/"
 msys2_references=(
@@ -39,11 +39,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 _url=https://github.com/llvm/llvm-project/releases/download/${_tag}
 _pkgfn=$_realname-$pkgver.src
 source=($_url/$_pkgfn.tar.xz{,.sig}
-        ${_url}/cmake-${pkgver}.src.tar.xz{,.sig})
+        ${_url}/cmake-${pkgver}.src.tar.xz{,.sig}
+        "104874.patch"::"https://github.com/llvm/llvm-project/pull/104874.patch")
 sha256sums=('cac2db253ee3566c01774a888cc0ac3853f1e141c5c9962f04ee562bdb0af426'
             'SKIP'
             '59badef592dd34893cd319d42b323aaa990b452d05c7180ff20f23ab1b41e837'
-            'SKIP')
+            'SKIP'
+            '87695f7128fe0fb3f0b698a132f6d18cbe513d35ff1e0ebe25afac395ead8e9f')
 validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Google.
               '474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard
               'D574BD5D1D0E98895E3BF90044F2485E45D59042') # Tobias Hieta
@@ -52,13 +54,14 @@ apply_patch_with_msg() {
   for _patch in "$@"
   do
     msg2 "Applying ${_patch}"
-    patch -Nbp1 -i "${srcdir}/${_patch}"
+    patch -Nbp2 -i "${srcdir}/${_patch}"
   done
 }
 
 prepare() {
   mv cmake-$pkgver.src cmake
   cd ${srcdir}/$_pkgfn
+  apply_patch_with_msg 104874.patch
 }
 
 build() {


### PR DESCRIPTION
I am using `lldb-dap` in VSCode for debugging with the help of https://github.com/llvm/vscode-lldb. I noticed that `StackTrace` request was extremely slow. In my tests it takes 10s and makes debugging almost impossible. Luckily someone has fixed it in llvm https://github.com/llvm/llvm-project/pull/104874. This is a backport. Now `StackTrace` is instant.