### PR TITLE
gdk-pixbuf2: update optdepends

### DIFF
--- a/mingw-w64-gdk-pixbuf2/PKGBUILD
+++ b/mingw-w64-gdk-pixbuf2/PKGBUILD
@@ -7,7 +7,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
 pkgver=2.42.12
-pkgrel=1
+pkgrel=2
 pkgdesc="An image loading library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -28,6 +28,12 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
          "${MINGW_PACKAGE_PREFIX}-libpng"
          "${MINGW_PACKAGE_PREFIX}-libtiff")
+optdepends=("${MINGW_PACKAGE_PREFIX}-libwmf: Load .wmf and .apm"
+            "${MINGW_PACKAGE_PREFIX}-libavif: Load .avif"
+            "${MINGW_PACKAGE_PREFIX}-libheif: Load .heif, .heic, and .avif"
+            "${MINGW_PACKAGE_PREFIX}-libjxl: Load .jxl"
+            "${MINGW_PACKAGE_PREFIX}-librsvg: Load .svg, .svgz, and .svg.gz"
+            "${MINGW_PACKAGE_PREFIX}-webp-pixbuf-loader: Load .webp")
 install=${_realname}-${MSYSTEM}.install
 source=("https://download.gnome.org/sources/gdk-pixbuf/${pkgver%.*}/gdk-pixbuf-${pkgver}.tar.xz"
         0003-fix-dllmain.patch


### PR DESCRIPTION
* libwmf: Load .wmf and .apm
* libavif: Load .avif
* libheif: Load .heif, .heic, and .avif
* libjxl: Load .jxl
* librsvg: Load .svg, .svgz, and .svg.gz
* webp-pixbuf-loader: Load .webp
