### PR TITLE
android-tools: update to 35.0.2

### DIFF
--- a/mingw-w64-android-tools/0001-android-tools-cmake.patch
+++ b/mingw-w64-android-tools/0001-android-tools-cmake.patch
@@ -8,21 +8,21 @@
  	adb/sysdeps/errno.cpp
 -	adb/sysdeps/posix/network.cpp
  	${ADB_APP_PROCESSES_PROTO_SRCS} ${ADB_APP_PROCESSES_PROTO_HDRS}
- 	${ADB_DEVCIES_PROTO_SRCS} ${ADB_DEVICES_PROTO_HDRS}
+ 	${ADB_HOST_PROTO_SRCS} ${ADB_HOST_PROTO_HDRS}
  	${ADB_KNOWN_HOSTS_PROTO_SRCS} ${ADB_KNOWN_HOSTS_PROTO_HDRS}
  	${ADB_KEY_TYPE_PROTO_SRCS} ${ADB_KEY_TYPE_PROTO_HDRS}
  	${ADB_PAIRING_PROTO_SRCS} ${ADB_PAIRING_PROTO_HDRS})
  
 -if(APPLE)
 +if(WIN32)
- 	list(APPEND libadb_SOURCES
--		adb/client/usb_osx.cpp)
++	list(APPEND libadb_SOURCES
 +		adb/client/usb_windows.cpp
 +		adb/sysdeps_win32.cpp
 +		adb/sysdeps/win32/errno.cpp
 +		adb/sysdeps/win32/stat.cpp)
 +elseif(APPLE)
-+	list(APPEND libadb_SOURCES
+ 	list(APPEND libadb_SOURCES
+-		adb/client/usb_osx.cpp)
 +		adb/client/usb_osx.cpp
 +		adb/sysdeps_unix.cpp
 +		adb/sysdeps/posix/network.cpp)
@@ -267,14 +267,14 @@
 --- a/vendor/CMakeLists.mkbootimg.txt
 +++ b/vendor/CMakeLists.mkbootimg.txt
 @@ -1,7 +1,7 @@
- set(MKBOOTIMG_SCRIPTS_DIR "${CMAKE_INSTALL_FULL_DATADIR}/android-tools/mkbootimg")
+ set(MKBOOTIMG_SCRIPTS_DIR ${CMAKE_INSTALL_DATADIR}/android-tools/mkbootimg)
  install(PROGRAMS mkbootimg/mkbootimg.py DESTINATION ${MKBOOTIMG_SCRIPTS_DIR})
 -add_custom_target(mkbootimg_symlink ALL COMMAND ${CMAKE_COMMAND} -E create_symlink
--	${MKBOOTIMG_SCRIPTS_DIR}/mkbootimg.py
+-	../${MKBOOTIMG_SCRIPTS_DIR}/mkbootimg.py
 +add_custom_target(mkbootimg_symlink ALL COMMAND ${CMAKE_COMMAND} -E copy
 +	${CMAKE_CURRENT_SOURCE_DIR}/mkbootimg/mkbootimg.py
  	${CMAKE_CURRENT_BINARY_DIR}/mkbootimg)
- install(FILES ${CMAKE_CURRENT_BINARY_DIR}/mkbootimg DESTINATION bin)
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/mkbootimg DESTINATION ${CMAKE_INSTALL_BINDIR})
  install(FILES mkbootimg/gki/generate_gki_certificate.py DESTINATION ${MKBOOTIMG_SCRIPTS_DIR}/gki)
 --- a/vendor/CMakeLists.partition.txt
 +++ b/vendor/CMakeLists.partition.txt
@@ -311,7 +311,7 @@
  find_package(Threads REQUIRED)
  
  check_symbol_exists(strlcpy "string.h" HAVE_STRLCPY)
-@@ -100,25 +100,40 @@
+@@ -110,24 +110,39 @@
  include_directories(${PROTOBUF_INCLUDE_DIRS})
  include_directories(${CMAKE_CURRENT_BINARY_DIR})
  
@@ -325,7 +325,6 @@
 +endif(WIN32)
 +
  include(CMakeLists.libbase.txt)
- include(CMakeLists.libandroidfw.txt)
  include(CMakeLists.adb.txt)
  include(CMakeLists.sparse.txt)
  include(CMakeLists.fastboot.txt)
@@ -355,7 +354,7 @@
  	lpadd
  	lpdump
  	lpflash
-@@ -126,11 +141,11 @@
+@@ -135,11 +150,11 @@
  	lpunpack
  	make_f2fs
  	sload_f2fs

--- a/mingw-w64-android-tools/0002-android-tools-vendor.patch
+++ b/mingw-w64-android-tools/0002-android-tools-vendor.patch
@@ -1,14 +1,3 @@
---- a/vendor/boringssl/crypto/curve25519/internal.h
-+++ b/vendor/boringssl/crypto/curve25519/internal.h
-@@ -32,7 +32,7 @@
- #endif
- 
- #if !defined(OPENSSL_NO_ASM) && !defined(OPENSSL_SMALL) && \
--    defined(__GNUC__) && defined(__x86_64__)
-+    defined(__GNUC__) && defined(__x86_64__) && !defined(OPENSSL_WINDOWS)
- #define BORINGSSL_FE25519_ADX
- 
- // fiat_curve25519_adx_mul is defined in
 --- a/vendor/boringssl/include/openssl/target.h
 +++ b/vendor/boringssl/include/openssl/target.h
 @@ -78,8 +78,13 @@

--- a/mingw-w64-android-tools/PKGBUILD
+++ b/mingw-w64-android-tools/PKGBUILD
@@ -3,16 +3,15 @@
 _realname=android-tools
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=35.0.1
+pkgver=35.0.2
 _tag=${pkgver}
-pkgrel=3
+pkgrel=1
 pkgdesc='Android platform tools (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='http://tools.android.com/'
 license=('spdx:Apache-2.0')
 depends=("${MINGW_PACKAGE_PREFIX}-brotli"
-         "${MINGW_PACKAGE_PREFIX}-libusb"
          "${MINGW_PACKAGE_PREFIX}-lz4"
          "${MINGW_PACKAGE_PREFIX}-pcre2"
          "${MINGW_PACKAGE_PREFIX}-protobuf"
@@ -31,12 +30,12 @@ source=("https://github.com/nmeum/android-tools/releases/download/${_tag}/${_rea
         "0002-android-tools-vendor.patch"
         "0003-fix-building-with-gcc-mingw.patch")
 noextract=("${_realname}-${_tag}.tar.xz")
-sha256sums=('654030c7f96d25d7224cd6861fac14a043cf1d3980f40288cdfbe219f94ffaf9'
-            'd3e73acccaa8bf9210cca264c314076f456d47f2f011f298c66e0962523fb73c'
-            '7f399058428d1a9386de95b28518d299159ab121bb7cb2eb420bd10a3c0e2e5e'
+sha256sums=('d2c3222280315f36d8bfa5c02d7632b47e365bfe2e77e99a3564fb6576f04097'
+            'a7bdcc611b29e2ccea87a39ea86e451839bb18631376bde0e3e72d1cab499a51'
+            'd504ae37cd1519311ef29e90fcb5216df3db82e72fda0edacce72489273807a3'
             'e6fc31c148e120fc69be53e0464434c492ab0eaa0dbc8f18dd3c19eb2dd2577b'
-            '72460a77aaac6d630da0d959c8e614ec6953cce9e3468bf96431225cb4c8617b'
-            'c167119777d8d1750f3988e68453b6a0d91e015242e57698824d04304fb4ace1'
+            '89e43362c47586418d886809564e0a20f98c8b0c817d48151fc32d3515153984'
+            'cb82aacba65f581c74e2c50097731e997aa741af9b281628b2940172e6d315d1'
             '528e7a2dbf366832d6ae339e013de7c311efb7fa9139ce3478bc18fe29b0542d')
 
 # Helper macros to help make tasks easier #
@@ -76,8 +75,8 @@ build() {
       -GNinja \
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       "${_extra_config[@]}" \
-      -DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON \
-      -Dprotobuf_MODULE_COMPATIBLE=ON \
+      -DANDROID_TOOLS_USE_BUNDLED_FMT=ON \
+      -DANDROID_TOOLS_USE_BUNDLED_LIBUSB=ON \
       ../${_realname}-${_tag}
 
   "${MINGW_PREFIX}"/bin/cmake.exe --build .


### PR DESCRIPTION
vendor/boringssl/crypto/curve25519/internal.h hunk was added in upstream. https://boringssl.googlesource.com/boringssl.git/+/80b08dfe5ef7d9190fa28d8204f2f7e8612134ee%5E%21/

use bundled libusb as explained in release page.