### PR TITLE
libc++: Pass global CPPFLAGS to CMake via CXXFLAGS

### DIFF
--- a/mingw-w64-libc++/PKGBUILD
+++ b/mingw-w64-libc++/PKGBUILD
@@ -12,7 +12,7 @@ _version=18.1.8
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
-pkgrel=1
+pkgrel=2
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
 url="https://libcxx.llvm.org/"
@@ -98,7 +98,7 @@ build() {
 
   CC=${MINGW_PREFIX}/bin/clang.exe \
   CXX=${MINGW_PREFIX}/bin/clang++.exe \
-  CXXFLAGS+=" -D_WIN32_WINNT=${_win32_winnt}" \
+  CXXFLAGS+=" -D_WIN32_WINNT=${_win32_winnt} $CPPFLAGS" \
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe \
     -GNinja \


### PR DESCRIPTION
CMake doesn't react to the global env variable CPPFLAGS; feed the contents of it to CMake via CXXFLAGS.

This makes sure that libc++ is built with -D__USE_MINGW_ANSI_STDIO=1, which fixes the formatting output of long doubles on x86.

This should fix issues #21768 and #17795.