### PR TITLE
json-glib: Update to 1.10.0

### DIFF
--- a/mingw-w64-json-glib/PKGBUILD
+++ b/mingw-w64-json-glib/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=json-glib
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.8.0
+pkgver=1.10.0
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -14,15 +14,17 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
-             "${MINGW_PACKAGE_PREFIX}-gtk-doc")
+             "${MINGW_PACKAGE_PREFIX}-python-docutils")
 options=('strip' 'staticlibs')
 license=('spdx:LGPL-2.1-or-later')
 url="https://wiki.gnome.org/Projects/JsonGlib"
 source=("https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz")
-sha256sums=('97ef5eb92ca811039ad50a65f06633f1aae64792789307be7170795d8b319454')
+sha256sums=('1bca8d66d96106ecc147df3133b95a5bb784f1fa6f15d06dd7c1a8fb4a10af7b')
 msys2_repository_url="https://gitlab.gnome.org/GNOME/json-glib"
+noextract=("${_realname}-${pkgver}.tar.xz")
 
 prepare() {
+  bsdtar -xf "${_realname}-${pkgver}.tar.xz" || bsdtar -xf "${_realname}-${pkgver}.tar.xz" || true
   cd "${srcdir}"/${_realname}-${pkgver}
 }
 
@@ -34,8 +36,12 @@ build() {
   MSYS2_ARG_CONV_EXCL="--prefix=" \
   meson setup \
     --prefix="${MINGW_PREFIX}" \
+    --wrap-mode=nodownload \
+    --auto-features=enabled \
     --buildtype plain \
     -Dman=true \
+    -Dinstalled_tests=false \
+    -Ddocumentation=disabled \
     ../${_realname}-${pkgver}
 
   ninja
@@ -45,7 +51,6 @@ package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
 
   DESTDIR="${pkgdir}" ninja install
-  rm -r "${pkgdir}${MINGW_PREFIX}"/{libexec,share}/installed-tests
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }


### PR DESCRIPTION
* docutils is used for generating man pages now
* enable auto features and disable the ones we don't need
* disable installed tests instead of deleting them afterwards