### PR TITLE
Adjust PKGBUILDs for CPPFLAGS removal from makepkg

### DIFF
--- a/mingw-w64-grpc/PKGBUILD
+++ b/mingw-w64-grpc/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-python-grpcio")
 pkgver=1.64.2
-pkgrel=2
+pkgrel=3
 _opencensus_proto_ver=0.4.1
 pkgdesc="Google's high performance, open source, general RPC framework (mingw-w64)"
 arch=('any')
@@ -80,7 +80,8 @@ build() {
 
   # remove __USE_MINGW_ANSI_STDIO=1 define, it breaks grpc string handling for
   # cases like 'gpr_log(GPR_DEBUG, "Failed to free %" PRIuPTR ...'
-  CPPFLAGS="${CPPFLAGS//-D__USE_MINGW_ANSI_STDIO=1/}"
+  CFLAGS="${CFLAGS//-Wp,-D__USE_MINGW_ANSI_STDIO=1/}"
+  CXXFLAGS="${CXXFLAGS//-Wp,-D__USE_MINGW_ANSI_STDIO=1/}"
   # add STRSAFE_NO_DEPRECATE define, otherwise strsafe breaks libc++ headers
   CXXFLAGS+=" -DSTRSAFE_NO_DEPRECATE"
   case "${CARCH}" in

--- a/mingw-w64-openldap/PKGBUILD
+++ b/mingw-w64-openldap/PKGBUILD
@@ -4,7 +4,7 @@ _realname=openldap
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.6.8
-pkgrel=1
+pkgrel=2
 pkgdesc="OpenLDAP Software is an open source implementation of the Lightweight Directory Access Protocol (only client) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -66,7 +66,6 @@ build() {
 
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
 
-  unset CPPFLAGS
   export lt_cv_deplibs_check_method='pass_all'
   CFLAGS+=" -Wno-implicit-int" \
   ../${_realname}-${pkgver}/configure \

--- a/mingw-w64-rufus/PKGBUILD
+++ b/mingw-w64-rufus/PKGBUILD
@@ -4,7 +4,7 @@ _realname=rufus
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.5
-pkgrel=1
+pkgrel=2
 pkgdesc="The Reliable USB Formatting Utility (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64')
@@ -30,7 +30,6 @@ prepare() {
 build() {
   mkdir -p "build-${MSYSTEM}" && cd "build-${MSYSTEM}"
 
-  unset CPPFLAGS
   ../"${_realname}-${pkgver}"/configure \
     --prefix="${MINGW_PREFIX}" \
     --enable-silent-rules \

--- a/mingw-w64-winpthreads-git/PKGBUILD
+++ b/mingw-w64-winpthreads-git/PKGBUILD
@@ -6,7 +6,7 @@ _realname=winpthreads
 pkgbase=mingw-w64-${_realname}-git
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git" "${MINGW_PACKAGE_PREFIX}-libwinpthread-git")
 pkgver=12.0.0.r247.g121331cff
-pkgrel=1
+pkgrel=2
 _commit='121331cffde0a4b6d738b017307d38feb8c513c9'
 pkgdesc="MinGW-w64 winpthreads library (mingw-w64)"
 url="https://www.mingw-w64.org/"
@@ -47,9 +47,11 @@ prepare() {
 build() {
   mkdir -p "${srcdir}"/build-${MSYSTEM} && cd ${srcdir}/build-${MSYSTEM}
 
-  declare -a extra_config
   # https://github.com/msys2/MINGW-packages/issues/7043
-  extra_config+=("CPPFLAGS=${CPPFLAGS//-D__USE_MINGW_ANSI_STDIO=1/}")
+  CFLAGS="${CFLAGS//-Wp,-D__USE_MINGW_ANSI_STDIO=1/}"
+  CXXFLAGS="${CXXFLAGS//-Wp,-D__USE_MINGW_ANSI_STDIO=1/}"
+
+  declare -a extra_config
   if check_option "debug" "y"; then
     extra_config+=("CFLAGS=-O0 -g -DWINPTHREAD_DBG")
     extra_config+=("CXXFLAGS=-O0 -g -DWINPTHREAD_DBG")


### PR DESCRIPTION
See https://github.com/msys2/MSYS2-packages/issues/4860 It was moved from CPPFLAGS to CFLAGS/CXXFLAGS.