### PR TITLE
codeblocks: Update and apply patch to fix run-time issue

### DIFF
--- a/mingw-w64-codeblocks/005-codeblocks-plugin-fix.patch
+++ b/mingw-w64-codeblocks/005-codeblocks-plugin-fix.patch
@@ -1,0 +1,11 @@
+--- a/src/sdk/configmanager.cpp	(revision 13538)
++++ b/src/sdk/configmanager.cpp	(working copy)
+@@ -1497,7 +1497,7 @@
+     if (plugin_path_global.IsEmpty())
+     {
+         if (platform::windows)
+-            ConfigManager::plugin_path_global = app_path + _T("/../lib/codeblocks/plugins");
++            ConfigManager::plugin_path_global = app_path + _T("\\..\\lib\\codeblocks\\plugins");
+         else if (platform::macosx)
+             ConfigManager::plugin_path_global = data_path_global + _T("/plugins");
+         else

--- a/mingw-w64-codeblocks/PKGBUILD
+++ b/mingw-w64-codeblocks/PKGBUILD
@@ -6,9 +6,9 @@ _realname=codeblocks
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 _basever=20.03
-_revision=13539
+_revision=13542
 pkgver=${_basever}.r${_revision}
-pkgrel=2
+pkgrel=1
 pkgdesc="Cross-platform C/C++ IDE (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -33,10 +33,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 optdepends=("${MINGW_PACKAGE_PREFIX}-clang-tools-extra: needed by Clangd_Client plugin")
 source=("$_realname::svn+https://svn.code.sf.net/p/codeblocks/code/trunk#revision=$_revision"
         "001-makefile-wxsmith-add-no-undefined.patch"
-        "004-disable-parallel-make-for-SmartIndent.patch")
+        "004-disable-parallel-make-for-SmartIndent.patch"
+        # See https://sourceforge.net/p/codeblocks/tickets/1497/
+        "005-codeblocks-plugin-fix.patch")
 sha256sums=('SKIP'
             '1e425d9360d248b5cd4ec19a1bb9057bf27c2a6d75efbfa4c5fe288b4ae9ce2a'
-            '4dff5050d2fad37fe29cef40b354c39f70526f0ece3aa895b2e07885cc647089')
+            '4dff5050d2fad37fe29cef40b354c39f70526f0ece3aa895b2e07885cc647089'
+            'ae26053653c5b373ed6be3da9af36207c9a4b90a1c48da9f26b19b5e772efa10')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -50,7 +53,8 @@ prepare() {
   cd "${_realname}"
   apply_patch_with_msg \
     001-makefile-wxsmith-add-no-undefined.patch \
-    004-disable-parallel-make-for-SmartIndent.patch
+    004-disable-parallel-make-for-SmartIndent.patch \
+    005-codeblocks-plugin-fix.patch
 
   # Workaround: error: definition of static data member 'wxsArrayStringEditorDlg::sm_eventTable' of dllimport'd class
   grep -rl "PLUGIN_EXPORT " src/plugins/contrib/wxSmith | xargs -i sed -i "s/PLUGIN_EXPORT //g" {}


### PR DESCRIPTION
The patch removes an invalid message when installing an cbplugin file.

Tim S.