### PR TITLE
openssl: Update to 3.3.2

### DIFF
--- a/mingw-w64-openssl/PKGBUILD
+++ b/mingw-w64-openssl/PKGBUILD
@@ -3,12 +3,12 @@
 _realname=openssl
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=3.3.1
+pkgver=3.3.2
 pkgrel=1
 pkgdesc="The Open Source toolkit for Secure Sockets Layer and Transport Layer Security (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
-url='https://www.openssl.org/'
+url='https://openssl-library.org'
 msys2_repository_url="https://github.com/openssl/openssl"
 msys2_references=(
   'archlinux: openssl'
@@ -24,20 +24,15 @@ source=("https://github.com/openssl/openssl/releases/download/openssl-${pkgver}/
         '002-relocation.patch'
         'pathtools.c'
         'pathtools.h')
-sha256sums=('777cd596284c883375a2a7a11bf5d2786fc5413255efab20c50d6ffe6d020b7e'
+sha256sums=('2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281'
             'SKIP'
             '21b96771b401442570e885c2d5689a359a91e86dcbf5511db3667202b6c1fa8a'
             '8a2d91826bd1a8fd6d3a981d2a71cfb3170060f64a053eafd8e3b32f6a30ac3b'
             'ebf471173f5ee9c4416c10a78760cea8afaf1a4a6e653977321e8547ce7bf3c0'
             '1585ef1b61cf53a2ca27049c11d49e0834683dfda798f03547761375df482a90')
-
-# https://www.openssl.org/community/otc.html
+# https://openssl-library.org/source/index.html
 validpgpkeys=(
-  '8657ABB260F056B1E5190839D9C4D26D0E604491' # Matt Caswell <matt@openssl.org>
-  '7953AC1FBC3DC8B3B292393ED5E9E43F7DF9EE8C' # Richard Levitte <richard@levitte.org>
-  'A21FAB74B0088AA361152586B8EF1A6BA9DA2D5C' # Tomáš Mráz <tm@t8m.info>
-  'B7C1C14360F353A36862E4D5231C84CDDCC69C45' # Paul Dale <pauli@openssl.org>
-  'EFC0A467D613CB83C7ED6D30D894E2CE8B3D79F5' # OpenSSL security team <openssl-security@openssl.org>
+  'BA5473A2B0587B07FB27CF2D216094DFD0CB81EF' # openssl@openssl.org
 )
 
 # Helper macros to help make tasks easier #


### PR DESCRIPTION
new domain and new signing key (see https://openssl-library.org/source/index.html)