### PR TITLE
rust: update to 1.81.0

### DIFF
--- a/mingw-w64-rust/0008-disable-self-contained-for-gnu-targets.patch
+++ b/mingw-w64-rust/0008-disable-self-contained-for-gnu-targets.patch
@@ -1,10 +1,10 @@
---- rustc-1.80.1-src/compiler/rustc_codegen_ssa/src/back/link.rs.orig
-+++ rustc-1.80.1-src/compiler/rustc_codegen_ssa/src/back/link.rs
+--- rustc-1.81.0-src/compiler/rustc_codegen_ssa/src/back/link.rs.orig
++++ rustc-1.81.0-src/compiler/rustc_codegen_ssa/src/back/link.rs
 @@ -1807,6 +1807,9 @@ fn detect_self_contained_mingw(sess: &Session) -> bool {
  /// instead of being found somewhere on the host system.
  /// We only provide such support for a very limited number of targets.
  fn self_contained_components(sess: &Session, crate_type: CrateType) -> LinkSelfContainedComponents {
-+    if sess.target.options.os == "windows" {
++    if sess.target.options.os == "windows" && sess.target.options.env == "gnu" {
 +        return LinkSelfContainedComponents::empty();
 +    }
      // Turn the backwards compatible bool values for `self_contained` into fully inferred

--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -9,7 +9,7 @@ if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
 fi
 
 rust_dist_server=https://static.rust-lang.org/dist
-#rust_dist_server=https://dev-static.rust-lang.org/dist/2024-06-10
+#rust_dist_server=https://dev-static.rust-lang.org/dist/2024-09-03
 
 embed_manifest_version=1.3.1
 embed_manifest_url=https://gitlab.com/careyevans/embed-manifest/-/archive/v${embed_manifest_version}/embed-manifest-v${embed_manifest_version}.tar.gz
@@ -19,7 +19,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-rust-wasm")
          "${MINGW_PACKAGE_PREFIX}-rust-src")
-pkgver=1.80.1
+pkgver=1.81.0
 pkgrel=1
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
@@ -38,7 +38,6 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-libssh2"
              "${MINGW_PACKAGE_PREFIX}-lldb"
              "${MINGW_PACKAGE_PREFIX}-llvm"
-             "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-openssl"
              "${MINGW_PACKAGE_PREFIX}-python"
              "${MINGW_PACKAGE_PREFIX}-autotools"
@@ -52,21 +51,24 @@ source=("${rust_dist_server}/${_realname}c-${pkgver}-src.tar.gz"{,.asc}
         "0004-compiler-Use-wasm-ld-for-wasm-targets.patch"
         "0005-win32-config.patch"
         "0007-clang-subsystem.patch"
-        "0008-disable-self-contained.patch"
+        "0008-disable-self-contained-for-gnu-targets.patch"
         "0011-disable-uac-for-installer.patch"
-        "0012-vendor-embed-manifest.patch")
+        "0012-vendor-embed-manifest.patch"
+        # remove after 1.82.0 release
+        "fix-bootstrap-on-windows.patch")
 noextract=(${_realname}c-${pkgver}-src.tar.gz)
-sha256sums=('2c0b8f643942dcb810cbcc50f292564b1b6e44db5d5f45091153996df95d2dc4'
+sha256sums=('872448febdff32e50c3c90a7e15f9bb2db131d13c588fe9071b0ed88837ccfa7'
             'SKIP'
             '24ef6d949c0b5b1940c1d6a7aad78d86012152fb8845a1644bc939350d7b75e2'
-            'd545368d561f122c6d7844458eca93340adfd46b4f095f28fd058d869db94cc5'
+            '3254e26a03cbbe23ab77add05a3de8717b9711428330280dc3ee7a2c924d8c3c'
             '7cb1773c288ffb1c1e751edc49b1890c84bf9c362742bc5225d19d474edb73a0'
             '56882f1a0f1404c10c7726d6cc37444f2b343e72b969badfcb43760f80db0f32'
             '7d1c4e49524b835a8eadc961b39f5594b12a522a1e24368999be2c7e85399e4e'
             '87955818066f02e4a39c36a789caf45c524cf4a41f04ee1b0cc685bd5205e63e'
-            'ee9516e16c3ab713c91186f73a03dedfd14090b53a1c46b5c9fe5c1a0c909259'
+            '98bc3f2bd7371a5b8d14fd7b03bf05574e206d1d9e52bcfbe66d71398504da3c'
             '761d73328d9695a7a2bd2a10be8225f4a56801fee54cbb51c0841b7f16e2bde6'
-            '23fc45f4e718770375be1c5196f035075de16d25e8f895100a3d1d2492995f86')
+            '23fc45f4e718770375be1c5196f035075de16d25e8f895100a3d1d2492995f86'
+            '0a9800a4f5e833fc435e86457a1b7a41f32d4bd2c1185d1eada90b28bdf6230c')
 validpgpkeys=('108F66205EAEB0AAA8DD5E1C85AB96E6FA1BE5FE'  # Rust Language (Tag and Release Signing Key) <rust-key@rust-lang.org>
               '474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard <tstellar@redhat.com>
               'B6C8F98282B944E3B0D5C2530FC3042E345AD05D') # Hans Wennborg <hans@chromium.org>
@@ -102,12 +104,12 @@ prepare() {
   # move embed-manifest crate into rust source vendor directory
   mv ${srcdir}/embed-manifest-v${embed_manifest_version} ${srcdir}/${_realname}c-${pkgver}-src/vendor/embed-manifest
 
-  # 0008-disable-self-contained.patch disables it only for windows targets
+  # 0008-disable-self-contained-for-gnu-targets.patch allows self-contained for non-windows-gnu targets
   cd ${srcdir}/${_realname}c-${pkgver}-src
   apply_patch_with_msg \
     0001-rustc-llvm-fix-libs.patch \
     0005-win32-config.patch \
-    0008-disable-self-contained.patch
+    0008-disable-self-contained-for-gnu-targets.patch
 
   if [[ $MINGW_PACKAGE_PREFIX == *-clang-i686 || $MINGW_PACKAGE_PREFIX == *-clang-x86_64 ]]; then
     apply_patch_with_msg \
@@ -124,6 +126,10 @@ prepare() {
     apply_patch_with_msg \
       0004-compiler-Use-wasm-ld-for-wasm-targets.patch
   fi
+
+  # https://github.com/rust-lang/rust/pull/128977
+  apply_patch_with_msg \
+    fix-bootstrap-on-windows.patch
 }
 
 build() {
@@ -188,11 +194,12 @@ build() {
 
   # substitute the values in config.toml
   local _prefix="$(cygpath -m ${MINGW_PREFIX})"
-  cp -f "${srcdir}/config.toml" "${srcdir}/${_realname}c-${pkgver}-src"
-  sed -i "s|%PREFIX%|${_prefix}|g" "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
-  sed -i "s|%INSTALL_PREFIX%|${MINGW_PREFIX}|g" "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
-  sed -i "s|%OSTYPE%|${OSTYPE}|g" "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
-  sed -i "s|%PKGREL%|${pkgrel}|g" "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
+  cp "${srcdir}/config.toml" "${srcdir}/${_realname}c-${pkgver}-src"
+  sed -i -e "s|%PREFIX%|${_prefix}|g" \
+         -e "s|%INSTALL_PREFIX%|${MINGW_PREFIX}|g" \
+         -e "s|%OSTYPE%|${OSTYPE}|g" \
+         -e "s|%PKGREL%|${pkgrel}|g" \
+         "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
   if [ "${_bootstrapping}" = "no" ]; then
     sed -i "/^\[build\]/a rustc = \"${_prefix}/bin/rustc.exe\"\ncargo = \"${_prefix}/bin/cargo.exe\"" "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
   fi
@@ -272,8 +279,8 @@ package_rust-wasm() {
   cd "${srcdir}/${MSYSTEM}"
 
   cp -a dest-wasm/* "$pkgdir"
-  install -Dm644 "${srcdir}"/${_realname}c-${pkgver}-src/LICENSE-APACHE "${pkgdir}${MINGW_PREFIX}/share/licenses/$pkgname/LICENSE-APACHE"
-  install -Dm644 "${srcdir}"/${_realname}c-${pkgver}-src/LICENSE-MIT "${pkgdir}${MINGW_PREFIX}/share/licenses/$pkgname/LICENSE-MIT"
+  install -Dm644 "${srcdir}"/${_realname}c-${pkgver}-src/LICENSE-APACHE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-wasm/LICENSE-APACHE"
+  install -Dm644 "${srcdir}"/${_realname}c-${pkgver}-src/LICENSE-MIT "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-wasm/LICENSE-MIT"
 }
 
 package_rust-src() {
@@ -281,8 +288,8 @@ package_rust-src() {
   depends=("${MINGW_PACKAGE_PREFIX}-rust")
 
   cd "${srcdir}/${MSYSTEM}"
-  install -Dm644 "${srcdir}"/${_realname}c-${pkgver}-src/LICENSE-APACHE "${pkgdir}${MINGW_PREFIX}/share/licenses/$pkgname/LICENSE-APACHE"
-  install -Dm644 "${srcdir}"/${_realname}c-${pkgver}-src/LICENSE-MIT "${pkgdir}${MINGW_PREFIX}/share/licenses/$pkgname/LICENSE-MIT"
+  install -Dm644 "${srcdir}"/${_realname}c-${pkgver}-src/LICENSE-APACHE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-src/LICENSE-APACHE"
+  install -Dm644 "${srcdir}"/${_realname}c-${pkgver}-src/LICENSE-MIT "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-src/LICENSE-MIT"
 
   install -d "${pkgdir}${MINGW_PREFIX}/lib/rustlib/"
   cp -a dest-src "${pkgdir}${MINGW_PREFIX}/lib/rustlib/src"

--- a/mingw-w64-rust/config.toml
+++ b/mingw-w64-rust/config.toml
@@ -2,11 +2,7 @@
 profile = "dist"
 
 # see src/bootstrap/src/utils/change_tracker.rs
-change-id = 125535
-
-[llvm]
-static-libstdcpp = false
-ninja = true
+change-id = 127866
 
 [build]
 build = "%OSTYPE%"
@@ -25,7 +21,6 @@ tools = [
   "rust-analyzer-proc-macro-srv",
   "analysis",
   "src",
-  "rust-demangler",
 ]
 sanitizers = true
 profiler = true
@@ -43,6 +38,7 @@ channel = "stable"
 description = "Rev%PKGREL%, Built by MSYS2 project"
 rpath = false
 frame-pointers = true
+lld = false
 codegen-tests = false
 deny-warnings = false
 backtrace-on-ice = true

--- a/mingw-w64-rust/fix-bootstrap-on-windows.patch
+++ b/mingw-w64-rust/fix-bootstrap-on-windows.patch
@@ -1,0 +1,58 @@
+diff --git a/src/bootstrap/src/core/download.rs b/src/bootstrap/src/core/download.rs
+index 56a8528d0a1..b8e862da149 100644
+--- a/src/bootstrap/src/core/download.rs
++++ b/src/bootstrap/src/core/download.rs
+@@ -706,9 +706,7 @@ pub(crate) fn maybe_download_ci_llvm(&self) {
+             let file_times = fs::FileTimes::new().set_accessed(now).set_modified(now);
+ 
+             let llvm_config = llvm_root.join("bin").join(exe("llvm-config", self.build));
+-            let llvm_config_file = t!(File::options().write(true).open(llvm_config));
+-
+-            t!(llvm_config_file.set_times(file_times));
++            t!(crate::utils::helpers::set_file_times(llvm_config, file_times));
+ 
+             if self.should_fix_bins_and_dylibs() {
+                 let llvm_lib = llvm_root.join("lib");
+diff --git a/src/bootstrap/src/lib.rs b/src/bootstrap/src/lib.rs
+index a8555b2c367..da18cc3b3a1 100644
+--- a/src/bootstrap/src/lib.rs
++++ b/src/bootstrap/src/lib.rs
+@@ -41,7 +41,9 @@
+ use crate::core::config::{DryRun, Target};
+ use crate::core::config::{LlvmLibunwind, TargetSelection};
+ use crate::utils::exec::{command, BehaviorOnFailure, BootstrapCommand, CommandOutput};
+-use crate::utils::helpers::{self, dir_is_empty, exe, libdir, mtime, output, symlink_dir};
++use crate::utils::helpers::{
++    self, dir_is_empty, exe, libdir, mtime, output, set_file_times, symlink_dir,
++};
+ 
+ mod core;
+ mod utils;
+@@ -1737,9 +1739,7 @@ fn copy_link_internal(&self, src: &Path, dst: &Path, dereference_symlinks: bool)
+             let file_times = fs::FileTimes::new()
+                 .set_accessed(t!(metadata.accessed()))
+                 .set_modified(t!(metadata.modified()));
+-
+-            let dst_file = t!(fs::File::open(dst));
+-            t!(dst_file.set_times(file_times));
++            t!(set_file_times(dst, file_times));
+         }
+     }
+ 
+diff --git a/src/bootstrap/src/utils/helpers.rs b/src/bootstrap/src/utils/helpers.rs
+index 773a873e47c..a0df1ff364e 100644
+--- a/src/bootstrap/src/utils/helpers.rs
++++ b/src/bootstrap/src/utils/helpers.rs
+@@ -545,3 +545,12 @@ pub fn get_closest_merge_base_commit(
+ 
+     Ok(output_result(git.as_command_mut())?.trim().to_owned())
+ }
++
++pub fn set_file_times<P: AsRef<Path>>(path: P, times: fs::FileTimes) -> io::Result<()> {
++    let f = if cfg!(windows) {
++        fs::File::options().write(true).open(path)?
++    } else {
++        fs::File::open(path)?
++    };
++    f.set_times(times)
++}


### PR DESCRIPTION
- disable self-contained for \*-windows-gnu\* targets only
- fix license installation for rust-wasm and rust-src packages