### PR TITLE
libavif: slim down static builds

### DIFF
--- a/mingw-w64-libavif/PKGBUILD
+++ b/mingw-w64-libavif/PKGBUILD
@@ -47,13 +47,11 @@ build() {
     -DBUILD_SHARED_LIBS=OFF \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     "${extra_config[@]}" \
-    -DAVIF_BUILD_APPS=SYSTEM \
     -DAVIF_CODEC_AOM=SYSTEM \
     -DAVIF_CODEC_DAV1D=SYSTEM \
     -DAVIF_CODEC_RAV1E=SYSTEM \
     -DAVIF_CODEC_SVT=$( [[ ${CARCH} == i686 ]] &&
                         echo "OFF" || echo "SYSTEM" ) \
-    -DAVIF_BUILD_GDK_PIXBUF=ON \
     -DAVIF_LIBSHARPYUV=SYSTEM \
     -S "${_realname}-${pkgver}" \
     -B "build-${MSYSTEM}-static"


### PR DESCRIPTION
Has no affect on current package (these targets get overwritten by shared versions anyway), so no release bump.

Only affects future build times.