### PR TITLE
rpi-imager: add package

### DIFF
--- a/mingw-w64-rpi-imager/0001-rpi-imager-cmake-disable-bundled-dependencies.patch
+++ b/mingw-w64-rpi-imager/0001-rpi-imager-cmake-disable-bundled-dependencies.patch
@@ -1,0 +1,97 @@
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -50,8 +50,9 @@
+ elseif (WIN32)
+     set(DEPENDENCIES acceleratedcryptographichash.cpp dependencies/mountutils/src/windows/functions.cpp dependencies/drivelist/src/windows/list.cpp
+         windows/winfile.cpp windows/winfile.h windows/winwlancredentials.h windows/winwlancredentials.cpp
+-        windows/rpi-imager.rc wlanapi_delayed.lib)
+-    set(EXTRALIBS setupapi ${CMAKE_CURRENT_BINARY_DIR}/wlanapi_delayed.lib)
++        windows/rpi-imager.rc)
++    set(EXTRALIBS setupapi wlanapi)
++    if(MSVC)
+     add_custom_command(
+         OUTPUT wlanapi_delayed.lib
+         COMMAND ${CMAKE_DLLTOOL} --input-def "${CMAKE_CURRENT_SOURCE_DIR}/windows/wlanapi.def"
+@@ -59,6 +60,7 @@ elseif (WIN32)
+         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/windows/wlanapi.def
+         VERBATIM
+     )
++    endif(MSVC)
+ endif()
+ 
+ include_directories(BEFORE .)
+@@ -171,17 +173,29 @@
+ 
+     find_package(OpenSSL REQUIRED)
+ 
++    find_package(ZLIB REQUIRED)
++    if(ZLIB_FOUND)
++        set(EXTRALIBS ${EXTRALIBS} ZLIB::ZLIB)
++    else()
+     # Bundled zlib
+     add_subdirectory(dependencies/zlib-1.2.13)
+     set(ZLIB_LIBRARY zlibstatic)
+     set(ZLIB_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/zlib-1.2.13 CACHE PATH "zlib include dir")
++    endif()
+ 
++    find_package(CURL REQUIRED)
++    if(NOT CURL_FOUND)
+     # Bundled libcurl
+     set(CMAKE_CURL_INCLUDES)
+     set(CURL_LIBRARIES cmcurl)
+     add_subdirectory(dependencies/cmcurl)
+     set(CURL_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/cmcurl/include)
++    endif()
+ 
++    find_package(LibLZMA REQUIRED)
++    if(LIBLZMA_FOUND)
++        set(EXTRALIBS ${EXTRALIBS} LibLZMA::LibLZMA)
++    else()
+     # Bundled liblzma
+     add_subdirectory(dependencies/cmliblzma)
+     set(LIBLZMA_HAS_AUTO_DECODER 1)
+@@ -189,14 +203,22 @@
+     set(LIBLZMA_HAS_LZMA_PRESET 1)
+     set(LIBLZMA_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/cmliblzma/liblzma/api)
+     set(LIBLZMA_LIBRARY cmliblzma)
++    endif()
+ 
++    find_package(zstd REQUIRED)
++    if(zstd_FOUND)
++        set(EXTRALIBS ${EXTRALIBS} zstd::libzstd_shared)
++    else()
+     # Bundled zstd
+     set(ZSTD_BUILD_PROGRAMS OFF)
+     set(ZSTD_BUILD_SHARED OFF)
+     add_subdirectory(dependencies/zstd-1.5.4/build/cmake)
+     set(ZSTD_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/zstd-1.5.4/lib CACHE PATH "zstd include dir")
+     set(ZSTD_LIBRARY libzstd_static)
++    endif()
+ 
++    find_package(LibArchive REQUIRED)
++    if(NOT LibArchive_FOUND)
+     # Bundled libarchive
+     set(ENABLE_TEST OFF CACHE BOOL "")
+     set(ENABLE_TAR OFF CACHE BOOL "")
+@@ -207,11 +229,13 @@
+     set_target_properties(archive PROPERTIES EXCLUDE_FROM_ALL 1)
+     set(LibArchive_LIBRARIES archive_static)
+     set(LibArchive_INCLUDE_DIR dependencies/libarchive-3.6.2/libarchive)
++    endif()
+ 
+     # Bundled fat32format
+     add_subdirectory(dependencies/fat32format)
+     add_dependencies(${PROJECT_NAME} fat32format)
+ 
++    if(MSVC)
+     # Strip debug symbols
+     add_custom_command(TARGET ${PROJECT_NAME}
+         POST_BUILD
+@@ -271,6 +295,7 @@
+             "${CMAKE_BINARY_DIR}/deploy/imageformats/qtiff.dll"
+             "${CMAKE_BINARY_DIR}/deploy/imageformats/qwebp.dll"
+             "${CMAKE_BINARY_DIR}/deploy/imageformats/qgif.dll")
++    endif(MSVC)
+ 
+ elseif(APPLE)
+     find_package(ZLIB REQUIRED)

--- a/mingw-w64-rpi-imager/0002-rpi-imager-include-missing-header.patch
+++ b/mingw-w64-rpi-imager/0002-rpi-imager-include-missing-header.patch
@@ -1,0 +1,10 @@
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -3,6 +3,7 @@
+  * Copyright (C) 2020 Raspberry Pi Ltd
+  */
+ 
++#include <iostream>
+ #include <QFileInfo>
+ #include <QGuiApplication>
+ #include <QQmlApplicationEngine>

--- a/mingw-w64-rpi-imager/PKGBUILD
+++ b/mingw-w64-rpi-imager/PKGBUILD
@@ -1,0 +1,90 @@
+# Maintainer: Biswapriyo Nath <nathbappai@gmail.com>
+
+_realname=rpi-imager
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.8.5
+pkgrel=1
+pkgdesc="Raspberry Pi Imaging Utility (mingw-w64)"
+arch=('any')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
+msys2_references=(
+  'archlinux: rpi-imager'
+)
+url='https://www.raspberrypi.com/software'
+license=('spdx:Apache-2.0')
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-curl"
+  "${MINGW_PACKAGE_PREFIX}-gcc-libs"
+  "${MINGW_PACKAGE_PREFIX}-libarchive"
+  "${MINGW_PACKAGE_PREFIX}-libwinpthread"
+  "${MINGW_PACKAGE_PREFIX}-openssl"
+  "${MINGW_PACKAGE_PREFIX}-qt5-base"
+  "${MINGW_PACKAGE_PREFIX}-qt5-declarative"
+  "${MINGW_PACKAGE_PREFIX}-qt5-winextras"
+  "${MINGW_PACKAGE_PREFIX}-xz"
+  "${MINGW_PACKAGE_PREFIX}-zlib"
+  "${MINGW_PACKAGE_PREFIX}-zstd"
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+  "${MINGW_PACKAGE_PREFIX}-ninja"
+  "${MINGW_PACKAGE_PREFIX}-qt5-quickcontrols2"
+  "${MINGW_PACKAGE_PREFIX}-qt5-svg"
+  "${MINGW_PACKAGE_PREFIX}-qt5-tools"
+  "${MINGW_PACKAGE_PREFIX}-winpthreads"
+)
+source=(
+  "https://github.com/raspberrypi/rpi-imager/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
+  0001-rpi-imager-cmake-disable-bundled-dependencies.patch
+  0002-rpi-imager-include-missing-header.patch
+)
+noextract=("${_realname}-${pkgver}.tar.gz")
+sha256sums=('443e2ca2132067cc67038c82d890f70fd744da2503588852f014435dd11fb786'
+            '0e4e8e2077b6eb7b1d8f3280f0ccc28c56287dfb7a104b5b25ce30b35ea07fca'
+            '4b8e42ea8c0da8c7bc69b737432811d3acb1e4f2ffbb44358b070bd5c155a081')
+
+_apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying ${_patch}"
+    patch -p1 -i "${srcdir}/${_patch}"
+  done
+}
+
+prepare() {
+  tar -xf "${_realname}-${pkgver}.tar.gz" || true
+
+  cd "${_realname}-${pkgver}"
+
+  _apply_patch_with_msg \
+    0001-rpi-imager-cmake-disable-bundled-dependencies.patch \
+    0002-rpi-imager-include-missing-header.patch
+}
+
+build() {
+  declare -a _extra_config
+  if check_option "debug" "n"; then
+    _extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    _extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    cmake \
+      -GNinja \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      "${_extra_config[@]}" \
+      -DENABLE_CHECK_VERSION=OFF \
+      -DENABLE_TELEMETRY=OFF \
+      -S "${_realname}-${pkgver}/src" \
+      -B "build-${MSYSTEM}"
+
+  cmake --build "build-${MSYSTEM}"
+}
+
+package() {
+  install -Dm755 "build-${MSYSTEM}/rpi-imager.exe" "${pkgdir}${MINGW_PREFIX}/bin/rpi-imager.exe"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/license.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/license.txt"
+}


### PR DESCRIPTION
I have used the package with Raspberry Pi 4B to write bootloader and Raspberry Pi OS.

<details><summary>Click here to see the screenshot of rpi-imager</summary>

![image](https://github.com/user-attachments/assets/41f28f72-81d0-437c-8095-3f8b0a375480)

</summary>