### PR TITLE
abseil-cpp: Workaround compiler error due to absence of ICalendar definition

### DIFF
--- a/mingw-w64-abseil-cpp/0004-abseil-workaround-disable-local-time-zone.patch
+++ b/mingw-w64-abseil-cpp/0004-abseil-workaround-disable-local-time-zone.patch
@@ -1,0 +1,12 @@
+--- a/absl/time/internal/cctz/src/time_zone_lookup.cc
++++ b/absl/time/internal/cctz/src/time_zone_lookup.cc
+@@ -41,7 +41,8 @@
+ #if ((defined(_WIN32_WINNT_WIN10) && !defined(__MINGW32__)) ||        \
+      (defined(NTDDI_WIN10_NI) && NTDDI_VERSION >= NTDDI_WIN10_NI)) && \
+     (_WIN32_WINNT >= _WIN32_WINNT_WINXP)
+-#define USE_WIN32_LOCAL_TIME_ZONE
++// TODO: Remove this wrokaround when ICalendar is added in windows.globalization.idl
++// #define USE_WIN32_LOCAL_TIME_ZONE
+ #include <roapi.h>
+ #include <tchar.h>
+ #include <wchar.h>

--- a/mingw-w64-abseil-cpp/PKGBUILD
+++ b/mingw-w64-abseil-cpp/PKGBUILD
@@ -4,7 +4,7 @@ _realname=abseil-cpp
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=20240722.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Abseil Common Libraries (C++) from Google (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -22,11 +22,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 source=("https://github.com/abseil/abseil-cpp/archive/$pkgver/$_realname-$pkgver.tar.gz"
         "0001-abseil-Fix-compiler-warnings.patch"
         "0002-abseil-Remove-librt-library.patch"
-        "0003-fix-linking-abseil_dll.patch")
+        "0003-fix-linking-abseil_dll.patch"
+        "0004-abseil-workaround-disable-local-time-zone.patch")
 sha256sums=('f50e5ac311a81382da7fa75b97310e4b9006474f9560ac46f54a9967f07d4ae3'
             '30fb7526d1c89f722dd0ce0c467e034370140fbf07a1ad4f91df301c7f442551'
             '8946282db6a225b385729deb345b57e3ee75f4e859dbbc49ab7bc5604d71192f'
-            '67ee0328f1aa8e3ad24231b2e6ef6a78963218e087cc6a7230e2d4e61b27a741')
+            '67ee0328f1aa8e3ad24231b2e6ef6a78963218e087cc6a7230e2d4e61b27a741'
+            'db11ab4b7ed756135019ea63137234c9e6b5843b6b3c95f97f1e53fb30bc0eab')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -42,7 +44,8 @@ prepare() {
   apply_patch_with_msg \
     0001-abseil-Fix-compiler-warnings.patch \
     0002-abseil-Remove-librt-library.patch \
-    0003-fix-linking-abseil_dll.patch
+    0003-fix-linking-abseil_dll.patch \
+    0004-abseil-workaround-disable-local-time-zone.patch
 }
 
 build() {


### PR DESCRIPTION
This fixes the following compiler error.
time_zone_lookup.cc:102:14: error: use of undeclared identifier 'RuntimeClass_Windows_Globalization_Calendar'
