### PR TITLE
fastfetch: update to 2.24.0

### DIFF
--- a/mingw-w64-fastfetch/PKGBUILD
+++ b/mingw-w64-fastfetch/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=fastfetch
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.23.0
+pkgver=2.24.0
 pkgrel=1
 pkgdesc="A neofetch-like tool for fetching system information and displaying them in a pretty way (mingw-w64)"
 arch=('any')
@@ -11,7 +11,9 @@ mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://github.com/fastfetch-cli/fastfetch"
 license=('spdx:MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-chafa"
              "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-imagemagick"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-vulkan-loader"
@@ -21,7 +23,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 optdepends=("${MINGW_PACKAGE_PREFIX}-vulkan-loader: For Vulkan support detection"
             "${MINGW_PACKAGE_PREFIX}-opencl-icd: For OpenCL support detection")
 source=("https://github.com/fastfetch-cli/fastfetch/archive/${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('3c92dd2cb15faf55d87846eda8d14456af2d0e0938998434144074c695c57529')
+sha256sums=('675ac3f9dbe00277416744fa36a28fc9cd1284d17f055a4db339063bfc6a8209')
 
 build() {
   declare -a extra_config


### PR DESCRIPTION
New deps `imagemagick` and `chafa` added for image logo printing.

https://github.com/fastfetch-cli/fastfetch/releases/tag/2.24.0