### PR TITLE
arpack: package PARPACK

### DIFF
--- a/mingw-w64-arpack/PKGBUILD
+++ b/mingw-w64-arpack/PKGBUILD
@@ -7,9 +7,10 @@
 _realname=arpack
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
-         $([[ "${CARCH}" == "i686" ]] || echo "${MINGW_PACKAGE_PREFIX}-${_realname}64"))
+         $([[ "${CARCH}" == "i686" ]] || echo "${MINGW_PACKAGE_PREFIX}-${_realname}64")
+         $([[ "${CARCH}" != "x86_64" ]] || echo "${MINGW_PACKAGE_PREFIX}-p${_realname}"))
 pkgver=3.9.1
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 pkgdesc="Fortran77 subroutines designed to solve large scale eigenvalue problems (mingw-w64)"
@@ -19,6 +20,7 @@ depends=($([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_P
 makedepends=("${MINGW_PACKAGE_PREFIX}-fc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
+             $([[ "${CARCH}" != "x86_64" ]] || echo "${MINGW_PACKAGE_PREFIX}-msmpi")
              "${MINGW_PACKAGE_PREFIX}-openblas"
              $([[ "${CARCH}" == "i686" ]] || echo "${MINGW_PACKAGE_PREFIX}-openblas64"))
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}-ng")
@@ -51,6 +53,7 @@ _build_arpack() {
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
       -DCMAKE_BUILD_TYPE=${_build_type} \
       -DICB=ON \
+      -DTESTS=OFF \
       ${_idx_opt} \
       ../${_realname}-ng-${pkgver}
 
@@ -60,48 +63,52 @@ _build_arpack() {
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}-static-32" && cd "${srcdir}/build-${MSYSTEM}-static-32"
 
+  if [ "${CARCH}" == "x86_64" ]; then
+    _parpack_option="-DMPI=ON"
+  fi
+
   msg2 "Build static ARPACK with 32-bit indexing"
-  _build_arpack "-DBUILD_SHARED_LIBS=OFF -DTESTS=OFF"
+  _build_arpack "-DBUILD_SHARED_LIBS=OFF ${_parpack_option}"
 
   mkdir -p "${srcdir}/build-${MSYSTEM}-shared-32" && cd "${srcdir}/build-${MSYSTEM}-shared-32"
 
   msg2 "Build shared ARPACK with 32-bit indexing"
-  _build_arpack "-DTESTS=OFF"
+  _build_arpack "${_parpack_option}"
 
 
   if [ "${CARCH}" != "i686" ]; then
     mkdir -p "${srcdir}/build-${MSYSTEM}-static-64" && cd "${srcdir}/build-${MSYSTEM}-static-64"
 
     msg2 "Build static ARPACK with 64-bit indexing"
-    _build_arpack "-DINTERFACE64=1 -DITF64SUFFIX=_64 -DBUILD_SHARED_LIBS=OFF -DBLAS_LIBRARIES=openblas_64 -DTESTS=OFF"
+    _build_arpack "-DINTERFACE64=1 -DITF64SUFFIX=_64 -DBUILD_SHARED_LIBS=OFF -DBLAS_LIBRARIES=openblas_64"
 
     mkdir -p "${srcdir}/build-${MSYSTEM}-shared-64" && cd "${srcdir}/build-${MSYSTEM}-shared-64"
 
     msg2 "Build shared ARPACK with 64-bit indexing"
-    _build_arpack "-DINTERFACE64=1 -DITF64SUFFIX=_64 -DBLAS_LIBRARIES=openblas_64 -DTESTS=OFF ${_flang_int_64}"
+    _build_arpack "-DINTERFACE64=1 -DITF64SUFFIX=_64 -DBLAS_LIBRARIES=openblas_64"
   fi
 }
 
 check() {
   cd "${srcdir}/build-${MSYSTEM}-static-32"
   msg2 "Static check with 32-bit indexing"
-  _build_arpack "-DTESTS=ON"
+  ${MINGW_PREFIX}/bin/cmake -DTESTS=ON ../${_realname}-ng-${pkgver}
   ${MINGW_PREFIX}/bin/cmake --build . --target test || true
 
   cd "${srcdir}/build-${MSYSTEM}-shared-32"
   msg2 "Shared check with 32-bit indexing"
-  _build_arpack "-DTESTS=ON"
+  ${MINGW_PREFIX}/bin/cmake -DTESTS=ON ../${_realname}-ng-${pkgver}
   ${MINGW_PREFIX}/bin/cmake --build . --target test || true
 
   if [ "${CARCH}" != "i686" ]; then
     cd "${srcdir}/build-${MSYSTEM}-static-64"
     msg2 "Static check with 64-bit indexing"
-    _build_arpack "-DTESTS=ON"
+    ${MINGW_PREFIX}/bin/cmake -DTESTS=ON ../${_realname}-ng-${pkgver}
     ${MINGW_PREFIX}/bin/cmake --build . --target test || true
 
     cd "${srcdir}/build-${MSYSTEM}-shared-64"
     msg2 "Shared check with 64-bit indexing"
-    _build_arpack "-DTESTS=ON"
+    ${MINGW_PREFIX}/bin/cmake -DTESTS=ON ../${_realname}-ng-${pkgver}
     ${MINGW_PREFIX}/bin/cmake --build . --target test || true
   fi
 }
@@ -110,11 +117,11 @@ package_arpack() {
   pkgdesc="Fortran77 subroutines designed to solve large scale eigenvalue problems (mingw-w64)"
   depends+=("${MINGW_PACKAGE_PREFIX}-openblas")
 
-  #Static Install
+  # Static Install
   cd "${srcdir}/build-${MSYSTEM}-static-32"
   DESTDIR=${pkgdir} ${MINGW_PREFIX}/bin/cmake --install .
 
-  #Shared Install
+  # Shared Install
   cd "${srcdir}/build-${MSYSTEM}-shared-32"
   DESTDIR=${pkgdir} ${MINGW_PREFIX}/bin/cmake --install .
   install -Dm644 ${srcdir}/${_realname}-ng-${pkgver}/COPYING ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING
@@ -125,6 +132,29 @@ package_arpack() {
     sed -e "s|${MINGW_PREFIX}|\$\{_IMPORT_PREFIX\}|g" -i ${_f}
   done
 
+  if [ "${CARCH}" == "x86_64" ]; then
+    # separate files for PARPACK
+    mkdir -p ${srcdir}/${MSYSTEM}-PARPACK/bin
+    mkdir -p ${srcdir}/${MSYSTEM}-PARPACK/include/arpack
+    mkdir -p ${srcdir}/${MSYSTEM}-PARPACK/lib/pkgconfig
+    mv ${pkgdir}${MINGW_PREFIX}/bin/libparpack* ${srcdir}/${MSYSTEM}-PARPACK/bin/
+    mv ${pkgdir}${MINGW_PREFIX}/include/arpack/parpack* ${srcdir}/${MSYSTEM}-PARPACK/include/arpack/
+    mv ${pkgdir}${MINGW_PREFIX}/lib/libparpack* ${srcdir}/${MSYSTEM}-PARPACK/lib/
+    mv ${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/parpack* ${srcdir}/${MSYSTEM}-PARPACK/lib/pkgconfig/
+  fi
+}
+
+package_parpack() {
+  pkgdesc="Fortran77 subroutines designed to solve large scale eigenvalue problems with MPI (mingw-w64)"
+  depends+=("${MINGW_PACKAGE_PREFIX}-arpack"
+            "${MINGW_PACKAGE_PREFIX}-openblas"
+            "${MINGW_PACKAGE_PREFIX}-msmpi")
+  provides=()
+  conflicts=()
+  replaces=()
+
+  mkdir -p ${pkgdir}${MINGW_PREFIX}
+  cp -rf ${srcdir}/${MSYSTEM}-PARPACK/* ${pkgdir}${MINGW_PREFIX}
 }
 
 package_arpack64() {
@@ -134,11 +164,11 @@ package_arpack64() {
   conflicts=()
   replaces=()
 
-  #Static Install
+  # Static Install
   cd "${srcdir}/build-${MSYSTEM}-static-64"
   DESTDIR=${pkgdir} ${MINGW_PREFIX}/bin/cmake --install .
 
-  #Shared Install
+  # Shared Install
   cd "${srcdir}/build-${MSYSTEM}-shared-64"
   DESTDIR=${pkgdir} ${MINGW_PREFIX}/bin/cmake --install .
   install -Dm644 ${srcdir}/${_realname}-ng-${pkgver}/COPYING ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}64/COPYING


### PR DESCRIPTION
Package files for PARPACK in a split package to keep the dependency on MSMPI separate.
