### PR TITLE
curl: Update to 8.10.0

### DIFF
--- a/mingw-w64-curl/0001-Make-cURL-relocatable.patch
+++ b/mingw-w64-curl/0001-Make-cURL-relocatable.patch
@@ -1,14 +1,14 @@
---- a/lib/CMakeLists.txt
-+++ b/lib/CMakeLists.txt
+--- curl-8.10.0/lib/CMakeLists.txt.orig	2024-09-11 07:37:35.000000000 +0200
++++ curl-8.10.0/lib/CMakeLists.txt	2024-09-11 12:37:27.324344400 +0200
 @@ -24,6 +24,7 @@
  set(LIB_NAME libcurl)
  set(LIBCURL_OUTPUT_NAME libcurl CACHE STRING "Basename of the curl library")
- add_definitions(-DBUILDING_LIBCURL)
+ add_definitions("-DBUILDING_LIBCURL")
 +set(CURL_BINDIR "${CMAKE_INSTALL_PREFIX}/bin")
  
- configure_file(curl_config.h.cmake
-   ${CMAKE_CURRENT_BINARY_DIR}/curl_config.h)
-@@ -59,6 +60,8 @@
+ configure_file("curl_config.h.cmake" "${CMAKE_CURRENT_BINARY_DIR}/curl_config.h")
+ 
+@@ -57,6 +58,8 @@
    target_link_libraries(curlu PRIVATE ${CURL_LIBS})
  endif()
  

--- a/mingw-w64-curl/0004-more-static-fixes.patch
+++ b/mingw-w64-curl/0004-more-static-fixes.patch
@@ -1,7 +1,0 @@
---- curl-8.9.0/libcurl.pc.in.orig	2024-07-24 09:26:57.979608300 +0200
-+++ curl-8.9.0/libcurl.pc.in	2024-07-24 09:30:11.854635400 +0200
-@@ -38,3 +38,4 @@
- Libs: -L${libdir} -lcurl @LIBCURL_NO_SHARED@
- Libs.private: @LIBCURL_LIBS@
- Cflags: -I${includedir} @CPPFLAG_CURL_STATICLIB@
-+Cflags.private: -DCURL_STATICLIB

--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -6,8 +6,8 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          $([[ ${CARCH} == i686 ]] || echo \
            "${MINGW_PACKAGE_PREFIX}-${_realname}-gnutls" \
            "${MINGW_PACKAGE_PREFIX}-${_realname}-winssl"))
-pkgver=8.9.1
-pkgrel=2
+pkgver=8.10.0
+pkgrel=1
 pkgdesc="Command line tool and library for transferring data with URLs (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -48,16 +48,12 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 source=("https://github.com/curl/curl/releases/download/${_realname}-${pkgver//./_}/${_realname}-${pkgver}.tar.xz"{,.asc}
         "pathtools.c"
         "pathtools.h"
-        "0001-Make-cURL-relocatable.patch"
-        "0004-more-static-fixes.patch"
-        "https://raw.githubusercontent.com/curl/curl/curl-8_9_1/CMake/FindNettle.cmake")
-sha256sums=('f292f6cc051d5bbabf725ef85d432dfeacc8711dd717ea97612ae590643801e5'
+        "0001-Make-cURL-relocatable.patch")
+sha256sums=('e6b142f0e85e954759d37e26a3627e2278137595be80e3a860c4353e4335e5a0'
             'SKIP'
             'ebf471173f5ee9c4416c10a78760cea8afaf1a4a6e653977321e8547ce7bf3c0'
             '1585ef1b61cf53a2ca27049c11d49e0834683dfda798f03547761375df482a90'
-            '67cafabd99ad1e636e042d052409afdfb52de4e3893b47413ad366e486c1c0a7'
-            'dbfdcd3be9588234174ea264e9371dab5e834572f4005dd4baa0a6da53ef9f8f'
-            'ca189ce53a2f2f7702eaa89a74c577276963c86157f09694fe03f4eead736946')
+            '69d3a70dedb931526cc3e627b526086c41ebe9fa265c91ede03e1008cde50b45')
 validpgpkeys=('27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2')  # Daniel Stenberg
 
 apply_patch_with_msg() {
@@ -77,12 +73,8 @@ prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   cp -fHv "${srcdir}"/pathtools.[ch] lib/
 
-  # https://github.com/curl/curl/pull/14285#issuecomment-2259880050
-  cp "${srcdir}/FindNettle.cmake" CMake
-
   apply_patch_with_msg \
-    0001-Make-cURL-relocatable.patch \
-    0004-more-static-fixes.patch
+    0001-Make-cURL-relocatable.patch
 }
 
 do_build() {
@@ -111,7 +103,6 @@ do_build() {
   elif [ "${_variant}" = "-gnutls" ]; then
     _variant_config+=("-DCURL_DEFAULT_SSL_BACKEND=gnutls")
     _variant_config+=("-DCURL_USE_GNUTLS=ON")
-    _variant_config+=("-DCURL_USE_SCHANNEL=ON")
     _variant_config+=('-DUSE_NGHTTP2=ON')
     _variant_config+=('-DUSE_NGTCP2=ON')
     _variant_config+=('-DUSE_NGHTTP3=ON')


### PR DESCRIPTION
* 0001-Make-cURL-relocatable.patch: refresh
* 0004-more-static-fixes.patch: fixed upstream
* FindNettle.cmake: fixed upstream
* Removal of CURL_USE_SCHANNEL for gnutls, this errors out now as not supported. I don't know if that just worked by accident before, or just the error was missing before. Either way, upstream doesn't support multiple backends with http3.