### PR TITLE
rust: add gnullvm target for CLANG{32,64} envs

### DIFF
--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -20,7 +20,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-rust-wasm")
          "${MINGW_PACKAGE_PREFIX}-rust-src")
 pkgver=1.81.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
@@ -211,6 +211,11 @@ build() {
   # Add target wasm32-*
   if [[ ${CARCH} != i686 ]]; then
     sed -i '/target = \[/a\  "wasm32-unknown-unknown", "wasm32-wasip1", "wasm32-wasip1-threads", "wasm32-wasip2",' "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
+  fi
+
+  # Add target *-gnullvm
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-i686 || $MINGW_PACKAGE_PREFIX == *-clang-x86_64 ]]; then
+    sed -i "/target = \[/a\  \"${CARCH}-pc-windows-gnullvm\"," "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
   fi
 
   # Building out of tree is not officially supported so we have to workaround some things like vendored deps


### PR DESCRIPTION
Prerequisite to disable bootstrap for CLANG envs: #219002