### PR TITLE
virglrenderer: Update to 1.1.0

### DIFF
--- a/mingw-w64-virglrenderer/PKGBUILD
+++ b/mingw-w64-virglrenderer/PKGBUILD
@@ -3,11 +3,12 @@
 _realname=virglrenderer
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-pkgver=1.0.1
-pkgrel=2
+pkgver=1.1.0
+pkgrel=1
 pkgdesc='A virtual 3D GPU library, that allows the guest operating system to use the host GPU to accelerate 3D rendering (mingw-w64)'
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+# clang disabled until attribute gcc_struct is supported, see https://github.com/msys2/MINGW-packages/pull/21903#issue-2521206281
+mingw_arch=('mingw64' 'ucrt64')
 url='https://docs.mesa3d.org/drivers/virgl/'
 msys2_repository_url="https://gitlab.freedesktop.org/virgl/virglrenderer"
 msys2_references=(
@@ -22,24 +23,14 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-ninja")
-source=("https://gitlab.freedesktop.org/virgl/${_realname}/-/archive/${pkgver}/${_realname}-${pkgver}.tar.bz2"
-        "https://gitlab.freedesktop.org/virgl/virglrenderer/-/commit/6810fe91a3db6831c4c41102fa058e850be5dbee.patch"
-        "https://raw.githubusercontent.com/kjliew/qemu-3dfx/aafe2f3e/virgil3d/MINGW-packages/0001-Virglrenderer-on-Windows-and-macOS.patch")
-sha256sums=('53cb8fadd08f5260ee57833fc2488565481438bc7a8e34f3e114d12cc9d9db9a'
-            '4c95741e1a5438244c1c04ca6363055b4b0e05c91a979348250978edc60d5750'
-            '80f83e1f171600991df54d10dce704a77a8609ad34b23b904568cbf86ea339bf')
+source=("https://gitlab.freedesktop.org/virgl/${_realname}/-/archive/${pkgver}/${_realname}-${pkgver}.tar.bz2")
+sha256sums=('5c680ab2dec434b28252fd2353f1e212d4d87beedbf6c1e74ae7e3d0f655b1bd')
 
 noextract=("${_realname}-${pkgver}.tar.bz2")
 
 prepare() {
   echo "Extracting ${_realname}-${pkgver}.tar.bz2 ..."
   tar -xjf "${srcdir}/${_realname}-${pkgver}.tar.bz2" || true
-
-  cd "${srcdir}/${_realname}-${pkgver}"
-  # https://gitlab.freedesktop.org/virgl/virglrenderer/-/merge_requests/1418
-  patch -p1 -i "${srcdir}/6810fe91a3db6831c4c41102fa058e850be5dbee.patch"
-  # https://gitlab.freedesktop.org/virgl/virglrenderer/-/issues/217
-  patch -p2 -i "${srcdir}/0001-Virglrenderer-on-Windows-and-macOS.patch"
 }
 
 build() {
@@ -52,7 +43,6 @@ build() {
     _extra_config+=("--buildtype=debug")
   fi
 
-  CFLAGS+=" -mno-ms-bitfields"
   MSYS2_ARG_CONV_EXCL="--prefix" \
   ${MINGW_PREFIX}/bin/meson setup \
     --prefix="${MINGW_PREFIX}" \


### PR DESCRIPTION
No patching or CFLAGS required for MINGW64/UCRT64.

Only minimal patches for CLANG64.

For CLANG64 the same issues as documented in QEMU PR https://github.com/msys2/MINGW-packages/pull/21540 occur as they did in previous builds.
```
[32/47] Compiling C object src/libvirgl.a.p/vrend_blitter.c.obj
../virglrenderer-1.1.0/src/vrend_blitter.c:94:8: warning: unknown attribute 'gcc_struct' ignored [-Wunknown-attributes]
   94 | struct PACKED blit_prog_key {
      |        ^~~~~~
../virglrenderer-1.1.0/src/mesa/util/macros.h:207:35: note: expanded from macro 'PACKED'
  207 | #    define PACKED __attribute__((gcc_struct,__packed__))
      |                                   ^~~~~~~~~~
1 warning generated.
```

If QEMU is the only package requiring virglrenderer, maybe we should drop CLANG-builds for virglrenderer as we did with QEMU until https://github.com/llvm/llvm-project/pull/71148 is merged?

Is there a way to check the reverse dependencies of virglrenderer?