### PR TITLE
templates: remove some `${srcdir}` references

### DIFF
--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-git.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-git.sh
@@ -23,13 +23,13 @@ sha256sums=('SKIP'
             'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
 
 pkgver() {
-  cd "${srcdir}/${_realname}"
+  cd "${_realname}"
 
   git describe --long "${_commit}" | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//g'
 }
 
 prepare() {
-  cd "${srcdir}/${_realname}"
+  cd "${_realname}"
 
   patch -Np1 -i "${srcdir}/0001-A-really-important-fix.patch"
   patch -Np1 -i "${srcdir}/0002-A-less-important-fix.patch"

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-tarball.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-tarball.sh
@@ -21,7 +21,7 @@ sha256sums=('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
             'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc')
 
 prepare() {
-  cd "${srcdir}"/${_realname}-${pkgver}
+  cd "${_realname}-${pkgver}"
 
   patch -Np1 -i "${srcdir}"/0001-A-really-important-fix.patch
   patch -Np1 -i "${srcdir}"/0002-A-less-important-fix.patch

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.autotools-tarball.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.autotools-tarball.sh
@@ -18,13 +18,13 @@ sha256sums=('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
             'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
 
 prepare() {
-  cd "${srcdir}/${_realname}-${pkgver}"
+  cd "${_realname}-${pkgver}"
 
   patch -p1 -i "${srcdir}/0001-A-fix.patch"
 }
 
 build() {
-  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
+  mkdir -p "build-${MSYSTEM}" && cd "build-${MSYSTEM}"
 
   ../"${_realname}-${pkgver}"/configure \
     --prefix="${MINGW_PREFIX}" \
@@ -38,13 +38,13 @@ build() {
 }
 
 check() {
-  cd "${srcdir}/build-${MSYSTEM}"
+  cd "build-${MSYSTEM}"
 
   make check
 }
 
 package() {
-  cd "${srcdir}/build-${MSYSTEM}"
+  cd "build-${MSYSTEM}"
 
   make install DESTDIR="${pkgdir}"
 

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.cargo-tarball.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.cargo-tarball.sh
@@ -19,7 +19,7 @@ sha256sums=('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
             'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc')
 
 prepare() {
-  cd "${srcdir}/${_realname}-${pkgver}"
+  cd "${_realname}-${pkgver}"
 
   patch -Np1 -i "${srcdir}"/0001-A-really-important-fix.patch
   patch -Np1 -i "${srcdir}"/0002-A-less-important-fix.patch
@@ -29,19 +29,19 @@ prepare() {
 }
 
 build() {
-  cd "${srcdir}/${_realname}-${pkgver}"
+  cd "${_realname}-${pkgver}"
 
   cargo build --release --frozen
 }
 
 check() {
-  cd "${srcdir}/${_realname}-${pkgver}"
+  cd "${_realname}-${pkgver}"
 
   cargo test --release --frozen
 }
 
 package() {
-  cd "${srcdir}/${_realname}-${pkgver}"
+  cd "${_realname}-${pkgver}"
 
   cargo install \
     --offline \

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.meson-tarball.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.meson-tarball.sh
@@ -22,7 +22,7 @@ sha256sums=('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
             'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc')
 
 prepare() {
-  cd "${srcdir}"/${_realname}-${pkgver}
+  cd "${_realname}-${pkgver}"
 
   patch -Np1 -i "${srcdir}"/0001-A-really-important-fix.patch
   patch -Np1 -i "${srcdir}"/0002-A-less-important-fix.patch

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.python.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.python.sh
@@ -22,7 +22,7 @@ sha256sums=('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
             'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc')
 
 prepare() {
-  cd "${srcdir}/${_realname}-${pkgver}"
+  cd "${_realname}-${pkgver}"
 
   patch -Np1 -i "${srcdir}/0001-A-really-important-fix.patch"
   patch -Np1 -i "${srcdir}/0002-A-less-important-fix.patch"
@@ -34,7 +34,6 @@ prepare() {
 
 build() {
   msg "Python build for ${MSYSTEM}"
-  cd "${srcdir}"
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
 
   python -m build --wheel --skip-dependency-check --no-isolation
@@ -42,7 +41,7 @@ build() {
 
 check() {
   msg "Python test for ${MSYSTEM}"
-  cd "${srcdir}/python-build-${MSYSTEM}"
+  cd "python-build-${MSYSTEM}"
 
 # The test command will usually depend upon what is contained in the tox.ini file
 # or in the [testenv:py] section of the pyproject.toml file.
@@ -51,7 +50,7 @@ check() {
 
 package() {
   msg "Python install for ${MSYSTEM}"
-  cd "${srcdir}/python-build-${MSYSTEM}"
+  cd "python-build-${MSYSTEM}"
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
     python -m installer --prefix=${MINGW_PREFIX} \


### PR DESCRIPTION
every functions start at `${srcdir}`. it's not required to pass full paths to `cd`