### PR TITLE
[new package] gnustep-xctest

### DIFF
--- a/mingw-w64-gnustep-xctest/PKGBUILD
+++ b/mingw-w64-gnustep-xctest/PKGBUILD
@@ -1,0 +1,45 @@
+# Maintainer: Frederik Carlier <frederik.carlier@keysight.com>
+
+_realname=tools-xctest
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=0.1.1
+pkgrel=1
+pkgdesc="Testing framework for Objective-C, providing functionalities identical to Apple's XCTest (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64')
+url='https://gnustep.github.io/'
+license=('spdx:LGPL-2.1-or-later')
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-clang"
+             "${MINGW_PACKAGE_PREFIX}-lld"
+             "${MINGW_PACKAGE_PREFIX}-gnustep-make"
+             rsync)
+depends=("${MINGW_PACKAGE_PREFIX}-gnustep-base")
+source=("https://github.com/gnustep/tools-xctest/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('d72d9a32cb271746f0058379ff81e593dd7e6fb3d1686d7dabe8ec986b3571ae')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+}
+
+build() {
+  rsync --recursive --times --links "${srcdir}/${_realname}-${pkgver}"/* "${srcdir}/build-${MSYSTEM}"
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  CC="$MINGW_PREFIX/bin/clang" \
+  CXX="$MINGW_PREFIX/bin/clang++" \
+  make
+}
+
+check() {
+  cd "${srcdir}/build-${MSYSTEM}"
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  make install DESTDIR="${pkgdir}"
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING.LIB" "${pkgdir}${MINGW_PREFIX}/share/licenses/gnustep-xctest/COPYING.LIB"
+}


### PR DESCRIPTION
This is a test framework for Objective C applications, which attempts to be compatible with Apple's xctest.