### PR TITLE
helix: update to 24.07

### DIFF
--- a/mingw-w64-helix/PKGBUILD
+++ b/mingw-w64-helix/PKGBUILD
@@ -12,7 +12,6 @@ url="https://github.com/helix-editor/helix"
 license=('spdx:MPL-2.0')
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-mdbook"
-             "patch"
              "git")
 source=("$url/archive/$pkgver/${_realname}-${pkgver}.tar.gz"
         'icon.patch'

--- a/mingw-w64-helix/PKGBUILD
+++ b/mingw-w64-helix/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=helix
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=23.10
+pkgver=24.07
 pkgrel=1
 pkgdesc="A post-modern modal text editor (mingw-w64)"
 arch=('any')
@@ -12,11 +12,16 @@ url="https://github.com/helix-editor/helix"
 license=('spdx:MPL-2.0')
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-mdbook"
+             "patch"
              "git")
 source=("$url/archive/$pkgver/${_realname}-${pkgver}.tar.gz"
+        'icon.patch'
+        'disable-lto.patch'
         'helix.sh')
 noextract=("${_realname}-${pkgver}.tar.gz")
-sha256sums=('a1a98b24692ba8fc648245bebc3511b27eb4edf9eb97d97d8aed7157316d01e8'
+sha256sums=('0f466ed2de039a7eca6faf29fc0db712c92e1a59d0bdc7e8916c717ceee8b3b3'
+            '23df99ca2934a06b4f8422dca7bb0c1628e139869962c92ee59f5f3449e61d3d'
+            'b00901a867835eda4e13654590ff9380568dee7ed9ac3f4b8e0951c89b0b6d8f'
             'c557a1e313586decf3d00fcf67e9a3f6139a2850b2e267b14d33e45636e84790')
 
 prepare() {
@@ -46,6 +51,9 @@ END
     "vendor/windows-targets-0.48.0/Cargo.toml"
   sed -i -e 's/\("Cargo.toml":\)"[^"]\+"/\1"'"$(sha256sum "vendor/windows-targets-0.48.0/Cargo.toml" | cut -d' ' -f1)"'"/' \
     "vendor/windows-targets-0.48.0/.cargo-checksum.json"
+
+  patch -Np1 -i ../icon.patch
+  patch -Np1 -i ../disable-lto.patch
 }
 
 build() {

--- a/mingw-w64-helix/PKGBUILD
+++ b/mingw-w64-helix/PKGBUILD
@@ -19,7 +19,7 @@ source=("$url/archive/$pkgver/${_realname}-${pkgver}.tar.gz"
         'helix.sh')
 noextract=("${_realname}-${pkgver}.tar.gz")
 sha256sums=('0f466ed2de039a7eca6faf29fc0db712c92e1a59d0bdc7e8916c717ceee8b3b3'
-            '23df99ca2934a06b4f8422dca7bb0c1628e139869962c92ee59f5f3449e61d3d'
+            'f45f0656cb1ceb5c90925c80b093335622f9ad3f64d4e2c8a3a0ea0ab43d900e'
             'b00901a867835eda4e13654590ff9380568dee7ed9ac3f4b8e0951c89b0b6d8f'
             'c557a1e313586decf3d00fcf67e9a3f6139a2850b2e267b14d33e45636e84790')
 

--- a/mingw-w64-helix/PKGBUILD
+++ b/mingw-w64-helix/PKGBUILD
@@ -13,6 +13,7 @@ license=('spdx:MPL-2.0')
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-mdbook"
              "git")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 source=("$url/archive/$pkgver/${_realname}-${pkgver}.tar.gz"
         'icon.patch'
         'disable-lto.patch'

--- a/mingw-w64-helix/disable-lto.patch
+++ b/mingw-w64-helix/disable-lto.patch
@@ -1,0 +1,13 @@
+diff --git a/Cargo.toml b/Cargo.toml
+index 9be265fc..9a9aa9a4 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -20,7 +20,7 @@ default-members = [
+ ]
+ 
+ [profile.release]
+-lto = "thin"
++# lto = "thin"
+ # debug = true
+ 
+ [profile.opt]

--- a/mingw-w64-helix/icon.patch
+++ b/mingw-w64-helix/icon.patch
@@ -1,5 +1,5 @@
 diff --git a/helix-term/build.rs b/helix-term/build.rs
-index 6bebf00c..17e0d7f0 100644
+index 60a64659..63276a06 100644
 --- a/helix-term/build.rs
 +++ b/helix-term/build.rs
 @@ -17,6 +17,7 @@ mod windows_rc {
@@ -31,7 +31,7 @@ index 6bebf00c..17e0d7f0 100644
 +        let command = command.arg(format!(
 +            "--include-dir={}",
 +            env::var("CARGO_MANIFEST_DIR")
-+                .expect("CARGO_MANIFEST_DIR should have been set by Cargo")
++                .unwrap()
 +        ));
 +
 +        let status = command

--- a/mingw-w64-helix/icon.patch
+++ b/mingw-w64-helix/icon.patch
@@ -1,0 +1,64 @@
+diff --git a/helix-term/build.rs b/helix-term/build.rs
+index 6bebf00c..17e0d7f0 100644
+--- a/helix-term/build.rs
++++ b/helix-term/build.rs
+@@ -17,6 +17,7 @@ mod windows_rc {
+     use std::{env, io, path::Path, path::PathBuf, process};
+ 
+     pub(crate) fn link_icon_in_windows_exe(icon_path: &str) {
++        #[cfg(target_env = "msvc")]
+         let rc_exe = find_rc_exe().expect("Windows SDK is to be installed along with MSVC");
+ 
+         let output = env::var("OUT_DIR").expect("Env var OUT_DIR should have been set by compiler");
+@@ -26,12 +27,43 @@ pub(crate) fn link_icon_in_windows_exe(icon_path: &str) {
+         write_resource_file(&rc_path, icon_path).unwrap();
+ 
+         let resource_file = PathBuf::from(&output_dir).join("resource.lib");
++
++        #[cfg(target_env = "msvc")]
+         compile_with_toolkit_msvc(rc_exe, resource_file, rc_path);
+ 
++        #[cfg(target_env = "gnu")]
++        compile_with_windres_gnu(resource_file, rc_path);
++
+         println!("cargo:rustc-link-search=native={}", output_dir.display());
+         println!("cargo:rustc-link-lib=dylib=resource");
+     }
+ 
++    #[cfg(target_env = "gnu")]
++    fn compile_with_windres_gnu(output: PathBuf, input: PathBuf) {
++        let mut command = process::Command::new("windres.exe");
++        let command = command.arg(format!(
++            "--include-dir={}",
++            env::var("CARGO_MANIFEST_DIR")
++                .expect("CARGO_MANIFEST_DIR should have been set by Cargo")
++        ));
++
++        let status = command
++            .arg(format!("--output={}", output.display()))
++            .arg(format!("{}", input.display()))
++            .output()
++            .unwrap();
++
++        println!(
++            "Windres Output:\n{}\n------",
++            String::from_utf8_lossy(&status.stdout)
++        );
++        println!(
++            "Windres Error:\n{}\n------",
++            String::from_utf8_lossy(&status.stderr)
++        );
++    }
++
++    #[cfg(target_env = "msvc")]
+     fn compile_with_toolkit_msvc(rc_exe: PathBuf, output: PathBuf, input: PathBuf) {
+         let mut command = process::Command::new(rc_exe);
+         let command = command.arg(format!(
+@@ -56,6 +88,7 @@ fn compile_with_toolkit_msvc(rc_exe: PathBuf, output: PathBuf, input: PathBuf) {
+         );
+     }
+ 
++    #[cfg(target_env = "msvc")]
+     fn find_rc_exe() -> io::Result<PathBuf> {
+         let find_reg_key = process::Command::new("reg")
+             .arg("query")


### PR DESCRIPTION
icon.patch: use windres to add icon when target_env is gnu
disable-lto.patch: PKGBUILD failed at cargo test --locked --release, alternatively test without --release can work too
This is my first time to create a pull request, sorry in advanced if I cause any problems.