### PR TITLE
[TEST] rust: update config.toml

### DIFF
--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -60,7 +60,7 @@ noextract=(${_realname}c-${pkgver}-src.tar.gz)
 sha256sums=('872448febdff32e50c3c90a7e15f9bb2db131d13c588fe9071b0ed88837ccfa7'
             'SKIP'
             '24ef6d949c0b5b1940c1d6a7aad78d86012152fb8845a1644bc939350d7b75e2'
-            '3254e26a03cbbe23ab77add05a3de8717b9711428330280dc3ee7a2c924d8c3c'
+            '3529c569217d5c18dd7b675e0ff1477b4f0386c73b6d8314fe709341bb561d74'
             '7cb1773c288ffb1c1e751edc49b1890c84bf9c362742bc5225d19d474edb73a0'
             '56882f1a0f1404c10c7726d6cc37444f2b343e72b969badfcb43760f80db0f32'
             '7d1c4e49524b835a8eadc961b39f5594b12a522a1e24368999be2c7e85399e4e'
@@ -156,13 +156,13 @@ build() {
 
   if [[ $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
     # We have to do the following because rust doesn't count x86_64-w64-mingw32 as a target triple
-    OSTYPE="$CARCH-pc-windows-gnullvm"
+    export OSTYPE="$CARCH-pc-windows-gnullvm"
 
     # Otherwise it uses gcc during bootstrap, even when we build for clang
     export CARGO_TARGET_${CARCH^^}_PC_WINDOWS_GNULLVM_LINKER="${CC}"
   else
     # We have to do the following because rust doesn't count x86_64-w64-mingw32 as a target triple
-    OSTYPE="$CARCH-pc-windows-gnu"
+    export OSTYPE="$CARCH-pc-windows-gnu"
 
     # Otherwise it uses gcc during bootstrap, even when we build for clang
     export CARGO_TARGET_${CARCH^^}_PC_WINDOWS_GNU_LINKER="${CC}"
@@ -193,19 +193,17 @@ build() {
   export RUST_BACKTRACE=1
 
   # substitute the values in config.toml
-  local _prefix="$(cygpath -m ${MINGW_PREFIX})"
-  cp "${srcdir}/config.toml" "${srcdir}/${_realname}c-${pkgver}-src"
-  sed -i -e "s|%PREFIX%|${_prefix}|g" \
-         -e "s|%INSTALL_PREFIX%|${MINGW_PREFIX}|g" \
-         -e "s|%OSTYPE%|${OSTYPE}|g" \
-         -e "s|%PKGREL%|${pkgrel}|g" \
-         "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
+  export MSYS2_ENV_CONV_EXCL='INSTALL_PREFIX'
+  export INSTALL_PREFIX="${MINGW_PREFIX}"
+  export PKGREL="${pkgrel}"
+  envsubst < "${srcdir}/config.toml" > "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
+
   if [ "${_bootstrapping}" = "no" ]; then
-    sed -i "/^\[build\]/a rustc = \"${_prefix}/bin/rustc.exe\"\ncargo = \"${_prefix}/bin/cargo.exe\"" "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
+    sed -i '/^\[build\]/,/^$/ s|^#||g' "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
   fi
   # generate debuginfo only for non-i686 targets
   if check_option "debug" "y" && [ "${CARCH}" != i686 ]; then
-    sed -i '/^\[rust\]/a debug = true\ndebuginfo-level-std = 2' "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
+    sed -i 's/^#debug/debug/g' "${srcdir}/${_realname}c-${pkgver}-src/config.toml"
   fi
 
   # Add target wasm32-*

--- a/mingw-w64-rust/config.toml
+++ b/mingw-w64-rust/config.toml
@@ -5,12 +5,15 @@ profile = "dist"
 change-id = 127866
 
 [build]
-build = "%OSTYPE%"
-host = ["%OSTYPE%"]
+#cargo = "$MINGW_PREFIX/bin/cargo.exe"
+#rustc = "$MINGW_PREFIX/bin/rustc.exe"
+#rustfmt = "$MINGW_PREFIX/bin/rustfmt.exe"
+build = "$OSTYPE"
+host = ["$OSTYPE"]
 target = [
-  "%OSTYPE%",
+  "$OSTYPE",
 ]
-python = "%PREFIX%/bin/python.exe"
+python = "$MINGW_PREFIX/bin/python.exe"
 locked-deps = true
 vendor = true
 tools = [
@@ -29,13 +32,16 @@ profiler = true
 docs = false
 
 [install]
-prefix = "%INSTALL_PREFIX%"
+prefix = "$INSTALL_PREFIX"
 sysconfdir = "etc"
 
 [rust]
+#debug = true
 codegen-units-std = 1
+#debuginfo-level-std = 2
+parallel-compiler = false
 channel = "stable"
-description = "Rev%PKGREL%, Built by MSYS2 project"
+description = "Rev$PKGREL, Built by MSYS2 project"
 rpath = false
 frame-pointers = true
 lld = false
@@ -49,8 +55,8 @@ backtrace-on-ice = true
 compression-formats = ["gz"]
 include-mingw-linker = false
 
-[target.%OSTYPE%]
-llvm-config = "%PREFIX%/bin/llvm-config.exe"
+[target.$OSTYPE]
+llvm-config = "$MINGW_PREFIX/bin/llvm-config.exe"
 
 [target.wasm32-unknown-unknown]
 sanitizers = false
@@ -59,14 +65,14 @@ profiler = false
 [target.wasm32-wasip1]
 sanitizers = false
 profiler = false
-wasi-root = "%PREFIX%/share/wasi-sysroot"
+wasi-root = "$MINGW_PREFIX/share/wasi-sysroot"
 
 [target.wasm32-wasip1-threads]
 sanitizers = false
 profiler = false
-wasi-root = "%PREFIX%/share/wasi-sysroot"
+wasi-root = "$MINGW_PREFIX/share/wasi-sysroot"
 
 [target.wasm32-wasip2]
 sanitizers = false
 profiler = false
-wasi-root = "%PREFIX%/share/wasi-sysroot"
+wasi-root = "$MINGW_PREFIX/share/wasi-sysroot"


### PR DESCRIPTION
change the way how values are substituted, use `envsubst`
explicitly disable parallel compiler (nightly only feature)
add commented config values which are uncommented in some conditions (`_bootstrap=no` or `debug = true`)

DO NOT MERGE, I don't want to break gnullvm-related PRs