### PR TITLE
[new-package] add rio terminal

### DIFF
--- a/mingw-w64-rio/PKGBUILD
+++ b/mingw-w64-rio/PKGBUILD
@@ -1,0 +1,44 @@
+_realname=rio
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.1.14
+pkgrel=1
+pkgdesc="A hardware-accelerated GPU terminal emulator powered by WebGPU (mingw-w64)"
+arch=('any')
+mingw_arch=( 'clang64')
+url="https://github.com/raphamorim/rio"
+license=('MIT')
+makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
+             "${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-pkgconf"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-freetype"
+             "${MINGW_PACKAGE_PREFIX}-python"
+             "${MINGW_PACKAGE_PREFIX}-fontconfig"
+             "${MINGW_PACKAGE_PREFIX}-gcc-compat")
+source=("${url}/archive/refs/tags/v${pkgver}.tar.gz"
+        "mingw-build.patch") 
+sha256sums=('9013fdcd65ec64285adb83d18c18310a1e52e37f16183dec47e2fa62d862f2d8'
+            '95894173cf17b1bf27e1dcac0edde83fad274a4b2e4fbd632f295ce5f4c31948')
+
+prepare() {
+  cd "${_realname}-${pkgver}" 
+
+  patch -Np1 -i "${srcdir}/mingw-build.patch"
+
+  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+}
+
+build() {
+  cd "${_realname}-${pkgver}"
+
+  cargo build --frozen --release --all-features
+}
+
+package() {
+  cd "${_realname}-${pkgver}"
+
+  install -Dm0755 -t "${pkgdir}${MINGW_PREFIX}/bin/" "target/release/${_realname}"
+  install -Dm0644 -t "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}/" "README.md"
+  install -Dm0644 -t "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/" "LICENSE"
+}

--- a/mingw-w64-rio/mingw-build.patch
+++ b/mingw-w64-rio/mingw-build.patch
@@ -1,0 +1,21 @@
+From 280bc46287a5ca82257916c3feaf08570f167750 Mon Sep 17 00:00:00 2001
+From: Raphael Amorim <rapha850@gmail.com>
+Date: Tue, 3 Sep 2024 17:51:18 +0200
+Subject: [PATCH] specify linker
+
+---
+ .cargo/config.toml | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/.cargo/config.toml b/.cargo/config.toml
+index 8f29ab77e..0b6931183 100644
+--- a/.cargo/config.toml
++++ b/.cargo/config.toml
+@@ -1,3 +1,7 @@
++[target.x86_64-pc-windows-gnu]
++linker = "x86_64-w64-mingw32-gcc"
++ar = "x86_64-w64-mingw32-gcc-ar"
++
+ [alias]
+ test-config = "test --release -p rio-config --"
+ test-rio = "test --release -p rioterm --"


### PR DESCRIPTION
Because of a msys2 rust bug, it can be compiled on mingw64/ucrt64 but only on debug mode and not on release. 
see https://github.com/raphamorim/rio/issues/635
