### PR TITLE
Add cmake-bootstrap

### DIFF
--- a/mingw-w64-cmake-bootstrap/0003-fix-find-python-on-mingw-aarch64.patch
+++ b/mingw-w64-cmake-bootstrap/0003-fix-find-python-on-mingw-aarch64.patch
@@ -1,0 +1,13 @@
+--- a/Modules/FindPython/Support.cmake
++++ b/Modules/FindPython/Support.cmake
+@@ -970,8 +970,8 @@
+         ERROR_QUIET
+         OUTPUT_STRIP_TRAILING_WHITESPACE)
+       string(TOUPPER "${platform}" platform)
+-      if (result OR ((target_arm AND NOT platform MATCHES "ARM") OR
+-                     (NOT target_arm AND platform MATCHES "ARM")))
++      if (result OR ((target_arm AND NOT (platform MATCHES "ARM" OR platform MATCHES "AARCH64")) OR
++                     (NOT target_arm AND (platform MATCHES "ARM" OR platform MATCHES "AARCH64"))))
+         # interpreter not usable or has wrong architecture
+         if (result)
+           set_property (CACHE _${_PYTHON_PREFIX}_Interpreter_REASON_FAILURE PROPERTY VALUE "Cannot use the interpreter \"${_${_PYTHON_PREFIX}_EXECUTABLE}\"")

--- a/mingw-w64-cmake-bootstrap/0005-Default-to-ninja-generator.patch
+++ b/mingw-w64-cmake-bootstrap/0005-Default-to-ninja-generator.patch
@@ -1,0 +1,14 @@
+--- cmake-3.21.0/Source/cmake.cxx.orig	2021-07-19 20:15:00.027000000 +0200
++++ cmake-3.21.0/Source/cmake.cxx	2021-07-19 20:16:17.719000700 +0200
+@@ -2179,7 +2179,10 @@
+       return gen;
+     }
+   }
+-#if defined(_WIN32) && !defined(__CYGWIN__) && !defined(CMAKE_BOOT_MINGW)
++#if defined(_WIN32) && defined(__MINGW32__) && !defined(CMAKE_BOOT_MINGW)
++  return std::unique_ptr<cmGlobalGenerator>(
++    cm::make_unique<cmGlobalNinjaGenerator>(this));
++#elif defined(_WIN32) && !defined(__CYGWIN__) && !defined(CMAKE_BOOT_MINGW)
+   std::string found;
+   // Try to find the newest VS installed on the computer and
+   // use that as a default if -G is not specified

--- a/mingw-w64-cmake-bootstrap/PKGBUILD
+++ b/mingw-w64-cmake-bootstrap/PKGBUILD
@@ -1,0 +1,63 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Ray Donnelly <mingw.android@gmail.com>
+
+_realname=cmake
+pkgbase=mingw-w64-${_realname}-bootstrap
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-bootstrap")
+pkgver=3.30.3
+pkgrel=1
+pkgdesc="A cross-platform open-source make system"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+url="https://www.cmake.org/"
+msys2_repository_url="https://gitlab.kitware.com/cmake/cmake"
+msys2_references=(
+  'archlinux: cmake'
+  "cpe: cpe:2.3:a:cmake_project:cmake"
+)
+license=("spdx:MIT")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-ninja"
+         "${MINGW_PACKAGE_PREFIX}-pkgconf")
+conflicts=("${MINGW_PACKAGE_PREFIX}-cmake")
+provides=("${MINGW_PACKAGE_PREFIX}-cmake=${pkgver}")
+source=("https://github.com/Kitware/CMake/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz"
+        "0003-fix-find-python-on-mingw-aarch64.patch"
+        "0005-Default-to-ninja-generator.patch")
+sha256sums=('6d5de15b6715091df7f5441007425264bdd477809f80333fdf95f846aaff88e4'
+            '557b5cbc05d4d50b3a67a7892391fcaa5cd95c492cdb4338d86305d1f4a3b88a'
+            '426818278090704d2a12f62ef3dfd94c47b11fa2784bb842989b7f6a09ee7aa2')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+
+  patch -Np1 -i "${srcdir}/0003-fix-find-python-on-mingw-aarch64.patch"
+  patch -Np1 -i "${srcdir}/0005-Default-to-ninja-generator.patch"
+
+  find . -name "*.orig" -exec rm -f {} \;
+}
+
+build() {
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
+
+  MSYSTEM=MINGW MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX="\
+    "${srcdir}/${_realname}-${pkgver}"/configure \
+    --prefix=${MINGW_PREFIX} \
+    --datadir=share/cmake \
+    --docdir=share/doc/cmake \
+    --mandir=share/man \
+    --no-system-libs \
+    --no-qt-gui \
+    --parallel=${NUMBER_OF_PROCESSORS} \
+    -- \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX}
+
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  make install DESTDIR="${pkgdir}"
+}

--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -14,7 +14,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.30.3
 _rc=""
 _pkgver=${pkgver}${_rc}
-pkgrel=1
+pkgrel=2
 pkgdesc="A cross-platform open-source make system"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -26,7 +26,7 @@ msys2_references=(
 )
 license=("spdx:MIT")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
-             $( (( _bootstrap )) || echo "${MINGW_PACKAGE_PREFIX}-cmake")
+             $( (( _bootstrap )) || echo "${MINGW_PACKAGE_PREFIX}-cmake-bootstrap")
              "${MINGW_PACKAGE_PREFIX}-python-sphinx"
              "${MINGW_PACKAGE_PREFIX}-bzip2"
              "${MINGW_PACKAGE_PREFIX}-ncurses"


### PR DESCRIPTION
A cmake variant that doesn't depend on any external dependencies and can be used for bootstrapping an env, and building a full cmake.