### PR TITLE
gtk4: backport memory leak fix

### DIFF
--- a/mingw-w64-gtk4/002-fix-memory-leak.patch
+++ b/mingw-w64-gtk4/002-fix-memory-leak.patch
@@ -1,0 +1,13 @@
+diff --git a/gsk/gpu/gskglimage.c b/gsk/gpu/gskglimage.c
+index d2ea417b23..8adae431f6 100644
+--- a/gsk/gpu/gskglimage.c
++++ b/gsk/gpu/gskglimage.c
+@@ -46,7 +46,7 @@ gsk_gl_image_finalize (GObject *object)
+   if (self->texture_id && self->framebuffer_id)
+     glDeleteFramebuffers (1, &self->framebuffer_id);
+ 
+-  if (gsk_gpu_image_get_flags (GSK_GPU_IMAGE (self)) & GSK_GPU_IMAGE_TOGGLE_REF)
++  if (self->owns_texture)
+     glDeleteTextures (1, &self->texture_id);
+ 
+   G_OBJECT_CLASS (gsk_gl_image_parent_class)->finalize (object);

--- a/mingw-w64-gtk4/PKGBUILD
+++ b/mingw-w64-gtk4/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-media-gstreamer")
 pkgver=4.16.1
-pkgrel=1
+pkgrel=2
 pkgdesc="GObject-based multi-platform GUI toolkit (v4) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -37,10 +37,12 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-shared-mime-info")
 source=("https://download.gnome.org/sources/gtk/${pkgver:0:4}/gtk-${pkgver}.tar.xz"
         "https://gitlab.gnome.org/GNOME/gtk/-/commit/b569470b87d143d30c2388046c9a6450696f19b8.patch"
-        "001-fix-font-rendering.patch")
+        "001-fix-font-rendering.patch"
+        "002-fix-memory-leak.patch")
 sha256sums=('926a1eabd481f9bfa25538f95016fdfcfaf963b2f90b40ae69e90def5499215c'
             '50e6ac71f2081f80d334a5be5c8c49b9c1c3fab001c1f4ca0f2556d7f2ec92ed'
-            'a2c6e3350bd9c1744da6b7714b25cbd419645b731435f7d295a9f99da3c1479f')
+            'a2c6e3350bd9c1744da6b7714b25cbd419645b731435f7d295a9f99da3c1479f'
+            'ebe07e2c797bcb82c319a2f8a7549853ebb8235721baeda64a66dc08b17ce866')
 
 prepare() {
   cd gtk-${pkgver}
@@ -51,6 +53,9 @@ prepare() {
   # Needed since https://gitlab.gnome.org/GNOME/gtk/-/commit/5f7cab4632c93acb3c7c818b5c69e92d657fe8de
   # otherwise the revert above is ignored too
   patch -Np1 -i ../001-fix-font-rendering.patch
+
+  # https://gitlab.gnome.org/GNOME/gtk/-/issues/7013
+  patch -Np1 -i ../002-fix-memory-leak.patch
 }
 
 build() {


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/gtk/-/issues/7013#note_2227756