### PR TITLE
kdeconnect: Fix building in absence of Windows SDK

### DIFF
--- a/mingw-w64-kdeconnect/0004-kdeconnect-cmake-disable-checking-winsdk.patch
+++ b/mingw-w64-kdeconnect/0004-kdeconnect-cmake-disable-checking-winsdk.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -94,7 +94,7 @@
+ find_package(KF6 ${KF_MIN_VERSION} REQUIRED COMPONENTS I18n ConfigWidgets DBusAddons IconThemes Notifications
+     KIO KCMUtils Service Solid Kirigami People WindowSystem GuiAddons DocTools Crash)
+ 
+-if (WIN32)
++if (MSVC)
+     get_filename_component(WINDOWS_KITS_DIR
+         "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots;KitsRoot10]" ABSOLUTE)
+     file(READ "${WINDOWS_KITS_DIR}/SDKManifest.xml" SDK_MANIFEST)

--- a/mingw-w64-kdeconnect/PKGBUILD
+++ b/mingw-w64-kdeconnect/PKGBUILD
@@ -63,13 +63,15 @@ source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realna
         "https://invent.kde.org/network/kdeconnect-kde/-/commit/5b47c968ea14d9e093be73f81f3c3bef26370c3c.patch"
         "0001-kdeconnect-workaround-missing-in4addr_any.patch"
         "0002-kdeconnect-workaround-disable-plugins.patch"
-        "0003-kdeconnect-remove-in-sal.patch")
+        "0003-kdeconnect-remove-in-sal.patch"
+        "0004-kdeconnect-cmake-disable-checking-winsdk.patch")
 sha256sums=('f9d7b55d52ae8d07432922afd84af19cd373df07b45eb97d381bcd2db4d5d1e6'
             'SKIP'
             'ca1e3c1b716f52b3784f4f854a8366833ef68fe0282d7210551490cd78905d5a'
             'd026cc43404dfdfe6060cad2818f57fcdf00c1f5ab683762a0f07de0c771f51d'
             '08d0923884bbb24e6e115eee12e30fb6c38b9a41d7c7964e799785012dad077a'
-            '7e1646656dbdefb23066d02449c5bc4c5cb3a07db035a80d0302ce02daecb270')
+            '7e1646656dbdefb23066d02449c5bc4c5cb3a07db035a80d0302ce02daecb270'
+            '38c72e5e6219fc6ca25efb5daf2618404d01e24210d4129460baaf9b3d39fcae')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>
               D81C0CB38EB725EF6691C385BB463350D6EF31EF) # Heiko Becker <heiko.becker@kde.org>
@@ -89,7 +91,8 @@ prepare() {
     5b47c968ea14d9e093be73f81f3c3bef26370c3c.patch \
     0001-kdeconnect-workaround-missing-in4addr_any.patch \
     0002-kdeconnect-workaround-disable-plugins.patch \
-    0003-kdeconnect-remove-in-sal.patch
+    0003-kdeconnect-remove-in-sal.patch \
+    0004-kdeconnect-cmake-disable-checking-winsdk.patch
 }
 
 build() {


### PR DESCRIPTION

    This should fix the following cmake error which happend in clangarm64.
    
    CMake Error at CMakeLists.txt:104 (file):
      file failed to open for reading (No such file or directory):
        /registry/SDKManifest.xml
