### PR TITLE
mingw-w64: default msvcrt to msvcr80 on MINGW64

### DIFF
--- a/mingw-w64-crt-git/PKGBUILD
+++ b/mingw-w64-crt-git/PKGBUILD
@@ -4,7 +4,7 @@ _realname=crt
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 pkgver=12.0.0.r297.g0be496546
-pkgrel=1
+pkgrel=2
 _commit='0be496546aca8f820e00a88ccba8d28c14b73484'
 pkgdesc='MinGW-w64 CRT for Windows (mingw-w64)'
 arch=('any')
@@ -53,6 +53,8 @@ build() {
 
   if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]] || [[ $MINGW_PACKAGE_PREFIX == *-ucrt-* ]]; then
     _extra_config+=("--with-default-msvcrt=ucrt")
+  elif [[ ${MSYSTEM} == MINGW64 ]]; then
+    _extra_config+=("--with-default-msvcrt=msvcr80")
   else
     _extra_config+=("--with-default-msvcrt=msvcrt")
   fi

--- a/mingw-w64-headers-git/PKGBUILD
+++ b/mingw-w64-headers-git/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 pkgdesc="MinGW-w64 headers for Windows (mingw-w64)"
 pkgver=12.0.0.r297.g0be496546
-pkgrel=1
+pkgrel=2
 _commit='0be496546aca8f820e00a88ccba8d28c14b73484'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -39,6 +39,8 @@ build() {
 
   if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]] || [[ $MINGW_PACKAGE_PREFIX == *-ucrt-* ]]; then
     _extra_config+=("--with-default-msvcrt=ucrt")
+  elif [[ ${MSYSTEM} == MINGW64 ]]; then
+    _extra_config+=("--with-default-msvcrt=msvcr80")
   else
     _extra_config+=("--with-default-msvcrt=msvcrt")
   fi


### PR DESCRIPTION
I have encountered an issue today while updating posgresql. It fails to build on MINGW64 because PG uses some functions only available when `__MSVCRT_VERSION>=0x800` (which correspond to `MSVC-2005`). but the default value of `__MSVCRT_VERSION__` when choosing msvcrt is `0x700`.
Many functions are not available for `__MSVCRT_VERSION<0x800` https://github.com/search?q=repo%3Amingw-w64%2Fmingw-w64+__MSVCRT_VERSION__+0x800&type=code
This PR makes MINGW64 default to `msvcr80` (`__MSVCRT_VERSION=0x800`).

I don't know what implications/consequences does this change have!. Does the user have to install MSVCR80.dll?

@mstorsjo @Biswa96 @lazka