### PR TITLE
Kicad update to version 8.0.5

### DIFF
--- a/mingw-w64-kicad-doc/PKGBUILD
+++ b/mingw-w64-kicad-doc/PKGBUILD
@@ -15,7 +15,8 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-ca"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-pl"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-ru"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-zh")
-pkgver=8.0.2
+_job_id='7765204080' # this is want is needed to change for new version
+pkgver=8.0.5
 pkgrel=1
 pkgdesc="Documentation for KiCad (mingw-w64)"
 arch=(any)
@@ -33,8 +34,8 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-kicad-meta"
 # https://kicad-downloads.s3.cern.ch/docs/kicad-doc-8.0.0-rc3.tar.gz
 # Use the more current build artifact from the release tag instead:
 # https://gitlab.com/kicad/services/kicad-doc/-/artifacts
-source=("${_realname}-${pkgver}.zip::https://gitlab.com/kicad/services/kicad-doc/-/jobs/6731879825/artifacts/download")
-sha256sums=('8b12ccd6eb09c3ebd76e193f71b0bda88649fe0cfbb7e217915407ef5faeb34a')
+source=("${_realname}-${pkgver}.zip::https://gitlab.com/kicad/services/kicad-doc/-/jobs/${_job_id}/artifacts/download")
+sha256sums=('bd9625c2e336f561373b2f604da45e56cb51e84adfdab6df9c1c8e2ee1382ab9')
 
 prepare() {
   cd ${srcdir}

--- a/mingw-w64-kicad-library/PKGBUILD
+++ b/mingw-w64-kicad-library/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-footprints"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-templates"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-packages3D"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-meta")
-pkgver=8.0.2
+pkgver=8.0.5
 pkgrel=1
 pkgdesc="Support libraries for KiCad (mingw-w64)"
 arch=('any')
@@ -26,10 +26,10 @@ source=("https://gitlab.com/kicad/libraries/kicad-footprints/-/archive/${pkgver}
         "https://gitlab.com/kicad/libraries/kicad-symbols/-/archive/${pkgver}/kicad-symbols-${pkgver}.tar.bz2"
         "https://gitlab.com/kicad/libraries/kicad-templates/-/archive/${pkgver}/kicad-templates-${pkgver}.tar.bz2"
         "https://gitlab.com/kicad/libraries/kicad-packages3D/-/archive/${pkgver}/kicad-packages3D-${pkgver}.tar.bz2")
-sha256sums=('ec957fcc7a59adaa7b30b541274b261ac7077918670ccd0382ece9fd11ba0bdf'
-            'c8b8e79d76b3bb3768e42c3f084489abb489a81b3e404efef518d69eada08831'
-            '6aeefadd69f9a24cc63dcd460266d721ddfad5faf2e4c9d0c47ecdbfcdeb4fbf'
-            '2bb1df0bbf054fa0c89206770322c30079f6b5f36ea70024be155deab9ca1d21')
+sha256sums=('00cc89a980ce6810dce20561376ad665d995dd3de92d398722fad4afbe522f5e'
+            'f79a8b8022d9338c308126500058f9823714160da427a6feca1dd6874631f4fb'
+            '45c30e8544755aaa55bdf462d01f919463438a7f523d2d9a5860da7a3bcf0846'
+            '4745c4b48c67845184a8a2e20cad3c548c38c80f82e8a44b180c764a524e147f')
 
 build() {
   declare -a _extra_config

--- a/mingw-w64-kicad/007-Fix-compilation-with-Boost-1.86.patch
+++ b/mingw-w64-kicad/007-Fix-compilation-with-Boost-1.86.patch
@@ -1,0 +1,29 @@
+From f4f9513f808fae515acf8253269a4eec9a667cd5 Mon Sep 17 00:00:00 2001
+From: Ian McInerney <ian.s.mcinerney@ieee.org>
+Date: Tue, 27 Aug 2024 11:49:28 +0100
+Subject: [PATCH] Fix compilation with Boost 1.86
+
+Boost 1.86 removed the boost::random dependency from boost::uuid, so
+we need to include those headers on our own now to use the random
+mersenne twister implementation.
+
+(cherry picked from commit a9e115925a5168034f60d0fe1e7b369861f84b82)
+---
+ common/kiid.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/common/kiid.cpp b/common/kiid.cpp
+index 4c7e8eb18c..80aea3e55d 100644
+--- a/common/kiid.cpp
++++ b/common/kiid.cpp
+@@ -25,6 +25,7 @@
+ 
+ #include <kiid.h>
+ 
++#include <boost/random/mersenne_twister.hpp>
+ #include <boost/uuid/uuid_generators.hpp>
+ #include <boost/uuid/uuid_io.hpp>
+ #include <boost/functional/hash.hpp>
+-- 
+2.45.2.windows.1
+

--- a/mingw-w64-kicad/008-KIID-Use-Boost-uuids-own-hash-function-fix-Boost-1.8.patch
+++ b/mingw-w64-kicad/008-KIID-Use-Boost-uuids-own-hash-function-fix-Boost-1.8.patch
@@ -1,0 +1,47 @@
+From 9fdd825681fb5c639470f8a68f1bf4cf73cc5cd1 Mon Sep 17 00:00:00 2001
+From: John Beard <john.j.beard@gmail.com>
+Date: Sat, 7 Sep 2024 16:13:42 +0100
+Subject: [PATCH] KIID: Use Boost uuids own hash function (fix Boost 1.86)
+
+Not only is this simpler, but it should be compatible
+with all Boost versions (the cast is a problem in 1.86)
+and it was also 'improved' in 1.86 for better mixing.
+
+Fixes: https://gitlab.com/kicad/code/kicad/-/issues/18651
+(cherry picked from commit 9a3ebfba404e43d82b5c194e01f6afb67909bf88)
+---
+ common/kiid.cpp | 11 +----------
+ 1 file changed, 1 insertion(+), 10 deletions(-)
+
+diff --git a/common/kiid.cpp b/common/kiid.cpp
+index 80aea3e55d..81266cbd22 100644
+--- a/common/kiid.cpp
++++ b/common/kiid.cpp
+@@ -28,7 +28,6 @@
+ #include <boost/random/mersenne_twister.hpp>
+ #include <boost/uuid/uuid_generators.hpp>
+ #include <boost/uuid/uuid_io.hpp>
+-#include <boost/functional/hash.hpp>
+ 
+ #if BOOST_VERSION >= 106700
+ #include <boost/uuid/entropy_error.hpp>
+@@ -236,15 +235,7 @@ timestamp_t KIID::AsLegacyTimestamp() const
+ 
+ size_t KIID::Hash() const
+ {
+-    size_t hash = 0;
+-
+-    // Note: this is NOT little-endian/big-endian safe, but as long as it's just used
+-    // at runtime it won't matter.
+-
+-    for( int i = 0; i < 4; ++i )
+-        boost::hash_combine( hash, reinterpret_cast<const uint32_t*>( m_uuid.data )[i] );
+-
+-    return hash;
++    return boost::uuids::hash_value( m_uuid );
+ }
+ 
+ 
+-- 
+2.45.2.windows.1
+

--- a/mingw-w64-kicad/009-Fix-Boost-1.86-SHA1-one-last-time.patch
+++ b/mingw-w64-kicad/009-Fix-Boost-1.86-SHA1-one-last-time.patch
@@ -1,0 +1,39 @@
+From 9779ee0fd3c8891d80b0a75edc1ce673d7a82b0a Mon Sep 17 00:00:00 2001
+From: John Beard <john.j.beard@gmail.com>
+Date: Tue, 10 Sep 2024 12:08:12 +0100
+Subject: [PATCH] Fix Boost 1.86 SHA1 one last time
+
+There's a change in Boost 1.86 that breaks the SHA1 hashing
+in 3D cache.
+
+The master KiCad branch ditches SHA1 entirely here, but it's quite
+an invasive change to backport. So apply a sticking plaster for
+the remainder of v8.
+
+Relates-To: https://gitlab.archlinux.org/archlinux/packaging/packages/kicad/-/issues/1
+---
+ 3d-viewer/3d_cache/3d_cache.cpp | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/3d-viewer/3d_cache/3d_cache.cpp b/3d-viewer/3d_cache/3d_cache.cpp
+index 33c04d0fff..72dd50d734 100644
+--- a/3d-viewer/3d_cache/3d_cache.cpp
++++ b/3d-viewer/3d_cache/3d_cache.cpp
+@@ -381,7 +381,13 @@ bool S3D_CACHE::getSHA1( const wxString& aFileName, unsigned char* aSHA1Sum )
+ 
+     fclose( fp );
+     unsigned int digest[5];
+-    dblock.get_digest( digest );
++    // V8 only
++    // Boost 1.86 and later changed digest_type from uchar[20] from int[5]
++    // But KiCad 8.99 and later use MurmurHash3 here, so just do a fairly ugly cast to keep
++    // this going for another few months.
++    static_assert( sizeof( digest ) == sizeof( boost::uuids::detail::sha1::digest_type& ),
++                   "SHA1 digest size mismatch" );
++    dblock.get_digest( reinterpret_cast<boost::uuids::detail::sha1::digest_type&>( digest ) );
+ 
+     // ensure MSB order
+     for( int i = 0; i < 5; ++i )
+-- 
+2.45.2.windows.1
+

--- a/mingw-w64-kicad/PKGBUILD
+++ b/mingw-w64-kicad/PKGBUILD
@@ -9,8 +9,8 @@ _wx_basever=3.2
 _realname=kicad
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=8.0.2
-pkgrel=2
+pkgver=8.0.5
+pkgrel=1
 pkgdesc="Software for the creation of electronic schematic diagrams and printed circuit board artwork (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -70,14 +70,21 @@ source=(
   '004-fix-loading-ngspice-dll.patch'
   '005-clang-fmt-workaround.patch'
   '006-ki-6.0-rewrite-kiwin32_rc_for_clang.patch'
+  # Patches 007,008,and 009 are from 8.0 git branch
+  '007-Fix-compilation-with-Boost-1.86.patch'
+  '008-KIID-Use-Boost-uuids-own-hash-function-fix-Boost-1.8.patch'
+  '009-Fix-Boost-1.86-SHA1-one-last-time.patch'
 )
-sha256sums=('7d26964384300a260b7975207a6ac28d393aeb270d1b837f9eadba95ab940465'
+sha256sums=('04e539d2b48957d2808fdf57274557021391e622f963b5cd8840b8331ee91b99'
             '3c51482f1e452e37e75c06a65996aa5d631a93e82fbef7dd8274ae8ebbd53601'
             '2924a86849c02aecd21cded0bd2069353fca33c3364f9b41f9bfdd80e19085cf'
             'd8d5f4bdd0aa6d8a907710c523f6f95840636cb2ef69e5275c6ed4966f134353'
             'f35a96c2393c21c266dbcd42616df64f9ee13b2423478bf6de029a3ad4e0ee8a'
             'bc7ad66d81d56dcfc237dfffe31fff58addff98622f65f64c45df11f70088c37'
-            '3155b9515ec7c094221441ce337c566c346bf76bb7aa42e86660cfdfb599e307')
+            '3155b9515ec7c094221441ce337c566c346bf76bb7aa42e86660cfdfb599e307'
+            'c986c80756d566d7178c7a9afcc8dc05297d93d897bffa42a9aade572feddfee'
+            '5473f506c6639b1e98c454f38178675f9386dcaa20e0ba75d983aff0fee741d7'
+            '2293fda3fcecfada2308ae090679710b67f52226425c708c6601b0261ba3a31b')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -97,7 +104,10 @@ prepare() {
     003-ki-6.0-code-fixes-for-GNUC-CLANG.patch \
     004-fix-loading-ngspice-dll.patch \
     005-clang-fmt-workaround.patch \
-    006-ki-6.0-rewrite-kiwin32_rc_for_clang.patch
+    006-ki-6.0-rewrite-kiwin32_rc_for_clang.patch \
+    007-Fix-compilation-with-Boost-1.86.patch \
+    008-KIID-Use-Boost-uuids-own-hash-function-fix-Boost-1.8.patch \
+    009-Fix-Boost-1.86-SHA1-one-last-time.patch
 }
 
 build() {


### PR DESCRIPTION
Had to add three patch files from 8.0 git branch because of boost library upgrade issues.