### PR TITLE
rust: fix import library generating for gnullvm targets

### DIFF
--- a/mingw-w64-rust/0013-generate-import-libraries-on-gnullvm.patch
+++ b/mingw-w64-rust/0013-generate-import-libraries-on-gnullvm.patch
@@ -1,0 +1,14 @@
+--- rustc-1.81.0-src/src/tools/cargo/src/cargo/core/compiler/build_context/target_info.rs
++++ rustc-1.81.0-src/src/tools/cargo/src/cargo/core/compiler/build_context/target_info.rs
+@@ -389,7 +389,10 @@ impl TargetInfo {
+                     crate_type: Some(crate_type.clone()),
+                     should_replace_hyphens: true,
+                 });
+-            } else if target_triple.ends_with("windows-gnu") && suffix == ".dll" {
++            } else if suffix == ".dll"
++                && (target_triple.ends_with("windows-gnu")
++                    || target_triple.ends_with("windows-gnullvm"))
++            {
+                 // See https://cygwin.com/cygwin-ug-net/dll.html for more
+                 // information about GNU import libraries.
+                 // LD can link DLL directly, but LLD requires the import library.

--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -20,7 +20,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-rust-wasm")
          "${MINGW_PACKAGE_PREFIX}-rust-src")
 pkgver=1.81.0
-pkgrel=4
+pkgrel=5
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64' 'clang32')
@@ -53,6 +53,8 @@ source=("${rust_dist_server}/${_realname}c-${pkgver}-src.tar.gz"{,.asc}
         "0008-disable-self-contained-for-gnu-targets.patch"
         "0011-disable-uac-for-installer.patch"
         "0012-vendor-embed-manifest.patch"
+        # remove after 1.83.0 release
+        "0013-generate-import-libraries-on-gnullvm.patch"
         # remove after 1.82.0 release
         "fix-bootstrap-on-windows.patch")
 noextract=(${_realname}c-${pkgver}-src.tar.gz)
@@ -66,6 +68,7 @@ sha256sums=('872448febdff32e50c3c90a7e15f9bb2db131d13c588fe9071b0ed88837ccfa7'
             '98bc3f2bd7371a5b8d14fd7b03bf05574e206d1d9e52bcfbe66d71398504da3c'
             '761d73328d9695a7a2bd2a10be8225f4a56801fee54cbb51c0841b7f16e2bde6'
             '23fc45f4e718770375be1c5196f035075de16d25e8f895100a3d1d2492995f86'
+            '7ebec5945f9fd38729da513fba8679efbad19bdde8a5d0d8ea097e5b9a7a99db'
             '0a9800a4f5e833fc435e86457a1b7a41f32d4bd2c1185d1eada90b28bdf6230c')
 validpgpkeys=('108F66205EAEB0AAA8DD5E1C85AB96E6FA1BE5FE'  # Rust Language (Tag and Release Signing Key) <rust-key@rust-lang.org>
               '474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard <tstellar@redhat.com>
@@ -111,7 +114,8 @@ prepare() {
 
   if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then
     apply_patch_with_msg \
-      0011-disable-uac-for-installer.patch
+      0011-disable-uac-for-installer.patch \
+      0013-generate-import-libraries-on-gnullvm.patch
   fi
   apply_patch_with_msg \
     0012-vendor-embed-manifest.patch
@@ -125,10 +129,10 @@ prepare() {
   apply_patch_with_msg \
     fix-bootstrap-on-windows.patch
 
-  # update windows-targets to support i686-pc-windows-gnullvm
+  # update windows-targets to support i686-pc-windows-gnullvm. remove after 1.82.0 release
   if [[ ${MSYSTEM} == CLANG32 ]]; then
     cd src/bootstrap
-    cargo update -p windows-targets@0.52.0 --precise 0.52.5
+    cargo update -p windows-targets@0.52.0 --precise 0.52.6
   fi
 }
 


### PR DESCRIPTION
backport of https://github.com/rust-lang/cargo/pull/14451
required for #22101 