### PR TITLE
libwasmtime: fix LICENSE file destination

### DIFF
--- a/mingw-w64-wasmtime/PKGBUILD
+++ b/mingw-w64-wasmtime/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-lib${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
 pkgver=25.0.1
-pkgrel=2
+pkgrel=3
 pkgdesc="A fast and secure runtime for WebAssembly (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -108,7 +108,7 @@ package_libwasmtime() {
   install -d "${pkgdir}${MINGW_PREFIX}/bin"
 
   mv "${pkgdir}${MINGW_PREFIX}/lib/wasmtime.dll" "${pkgdir}${MINGW_PREFIX}/bin/wasmtime.dll"
-  install -Dm644 "${_realname}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  install -Dm644 "${_realname}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/lib${_realname}/LICENSE"
 }
 
 package_wasmtime-docs() {


### PR DESCRIPTION
Fix error when install both wasmtime and libwasmtime:
```
error: failed to commit transaction (conflicting files)
/ucrt64/share/licenses/wasmtime/LICENSE exists in both 'mingw-w64-ucrt-x86_64-wasmtime' and 'mingw-64-ucrt-x86_64-libwasmtime'
```