### PR TITLE
qt5: restore some MINGW32 packages

### DIFF
--- a/mingw-w64-qt5-speech/PKGBUILD
+++ b/mingw-w64-qt5-speech/PKGBUILD
@@ -3,12 +3,12 @@
 _realname=qt5-speech
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
-         "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
+         $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-${_realname}-debug"))
 pkgver=5.15.15
-pkgrel=1
+pkgrel=2
 pkgdesc="Qt module to make text to speech and speech recognition easy (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://www.qt.io/'
 msys2_references=(
   "cpe: cpe:/a:qt:qt"
@@ -46,7 +46,7 @@ package_qt5-speech() {
   depends=("${MINGW_PACKAGE_PREFIX}-qt5-base")
   optdepends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative"
               "${MINGW_PACKAGE_PREFIX}-qt5-multimedia")
-  groups=("${MINGW_PACKAGE_PREFIX}-qt5")
+  groups=($([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-qt5"))
 
   cd build-${MSYSTEM}
 
@@ -62,9 +62,11 @@ package_qt5-speech() {
   install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_realname}
   install -Dm644 $srcdir/${_pkgfn/opensource-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_realname}
 
+  if [[ ${CARCH} != i686 ]]; then
   # Seperate debug-info files
   mv -f "${pkgdir}${MINGW_PREFIX}/lib"/*.debug "${pkgdir}${MINGW_PREFIX}/bin"/ || true
   rsync -armR --remove-source-files --include="*/" --include="*.debug" --exclude="*" --prune-empty-dirs ${pkgdir}/.${MINGW_PREFIX} ${srcdir}/${MSYSTEM}-debug/
+  fi
 
   # Fix paths in *.pri, *prl and *.pc files:
   #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})

--- a/mingw-w64-qt5-winextras/PKGBUILD
+++ b/mingw-w64-qt5-winextras/PKGBUILD
@@ -3,12 +3,12 @@
 _realname=qt5-winextras
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
-         "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
+         $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-${_realname}-debug"))
 pkgver=5.15.15
-pkgrel=1
+pkgrel=2
 pkgdesc="Provides platform-specific APIs for Windows (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://www.qt.io/'
 msys2_references=(
   "cpe: cpe:/a:qt:qt"
@@ -39,7 +39,7 @@ package_qt5-winextras() {
   depends=("${MINGW_PACKAGE_PREFIX}-qt5-base")
   optdepends=("${MINGW_PACKAGE_PREFIX}-qt5-declarative"
               "${MINGW_PACKAGE_PREFIX}-qt5-multimedia")
-  groups=("${MINGW_PACKAGE_PREFIX}-qt5")
+  groups=($([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-qt5"))
 
   cd build-${MSYSTEM}
 
@@ -55,9 +55,11 @@ package_qt5-winextras() {
   install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_realname}
   install -Dm644 $srcdir/${_pkgfn/opensource-/}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_realname}
 
+  if [[ ${CARCH} != i686 ]]; then
   # Seperate debug-info files
   mv -f "${pkgdir}${MINGW_PREFIX}/lib"/*.debug "${pkgdir}${MINGW_PREFIX}/bin"/ || true
   rsync -armR --remove-source-files --include="*/" --include="*.debug" --exclude="*" --prune-empty-dirs ${pkgdir}/.${MINGW_PREFIX} ${srcdir}/${MSYSTEM}-debug/
+  fi
 
   # Fix paths in *.pri, *prl and *.pc files:
   #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})


### PR DESCRIPTION
Following a discussion on Discord, see:
https://www.discord.com/channels/792780131906617355/794220101741838401/1283064557660803083 brought about by https://github.com/msys2/MINGW-packages/commit/a4f0579e14509d27927a94498c35e1ccddf29bf5 I suggested to restore for a while a couple of Qt5 packages that the [Mudlet](https://github.com/Mudlet/Mudlet) project I code for uses for its 32-Bit Windows builds until we have migrated as many of our Windows users up to 64-Bit builds as possible.

I was hoping that one of the MSYS2+Mingw-w64 team would have been able to find the time to make this change but after a couple of weeks of nothing happening I have decided to try and do it myself.