### PR TITLE
gnucobol: switch json dependency

### DIFF
--- a/mingw-w64-gnucobol/PKGBUILD
+++ b/mingw-w64-gnucobol/PKGBUILD
@@ -6,7 +6,7 @@ _realname=gnucobol
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=3.2
-pkgrel=2
+pkgrel=3
 epoch=1
 pkgdesc="GnuCOBOL, a free and modern COBOL compiler (mingw-w64)"
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-svn" "${MINGW_PACKAGE_PREFIX}-gnu-cobol-svn")
@@ -17,13 +17,13 @@ url="https://www.gnu.org/software/gnucobol/"
 msys2_references=(
   "cpe: cpe:/a:gnucobol_project:gnucobol"
 )
-license=('spdx:GPL-3.0-or-later AND spdx:LGPL-3.0-only')
+license=('spdx:GPL-3.0-or-later AND LGPL-3.0-or-later AND GFDL-1.3-or-later')
 # note: the final binaries will call cc, therefore it is a dependency
 depends=("${MINGW_PACKAGE_PREFIX}-cc"
          "${MINGW_PACKAGE_PREFIX}-gmp"
          "${MINGW_PACKAGE_PREFIX}-gettext-runtime"
          "${MINGW_PACKAGE_PREFIX}-ncurses"
-         "${MINGW_PACKAGE_PREFIX}-cjson"
+         "${MINGW_PACKAGE_PREFIX}-json-c"
          "${MINGW_PACKAGE_PREFIX}-libxml2"
          "${MINGW_PACKAGE_PREFIX}-db")
 
@@ -35,7 +35,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-cc"
 #            "${MINGW_PACKAGE_PREFIX}-json-c: support for JSON GENERATE"
 #            "${MINGW_PACKAGE_PREFIX}-libxml2: support for XML GENERATE")
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools" "${MINGW_PACKAGE_PREFIX}-gettext-tools")
-# Note: it actually needs the one from the build environment (MSYS)
+# Note: "make test" actually needs a version from the build environment (MSYS)
 checkdepends=(perl)
 
 # local definitions
@@ -43,7 +43,7 @@ checkdepends=(perl)
 source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.xz"{,.sig}
         "cobenv.sh"
         "cobenv.cmd"
-        "https://www.itl.nist.gov/div897/ctg/suites/newcob.val.Z"
+        "https://web.archive.org/web/20240322143655if_/https://www.itl.nist.gov/div897/ctg/suites/newcob.val.Z"
         0001-gnucobol-extras-include-srcdir.patch
         )
 sha256sums=('3bb48af46ced4779facf41fdc2ee60e4ccb86eaa99d010b36685315df39c2ee2'
@@ -71,7 +71,7 @@ build() {
     CPPLAGS="-D__USE_MINGW_ANSI_STDIO=1" \
     PERL="/usr/bin/perl" \
     --with-db --without-vbisam --without-disam --without-cisam \
-    --with-xml2 --with-json=cjson --with-curses=ncursesw \
+    --with-xml2 --with-json=json-c --with-curses=ncursesw \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \


### PR DESCRIPTION
json-c is the dependency most used with other package managers - and it is still available for mingw32

additional:
* fixed license from LGPL-3.0-only to LGPL-3.0-or-later
* use internet archive for static download (test dependency) that has gone offline

Note: pulling this may be postponed if the package is to be made available for MINGW32 (see #22133) which could be integrated into this PR (or be made available before/later separately, especially if it doesn't need an update to pkgrel).