### PR TITLE
Revert "headers-git: Workaround some data types in winrt headers"

### DIFF
--- a/mingw-w64-headers-git/PKGBUILD
+++ b/mingw-w64-headers-git/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 pkgdesc="MinGW-w64 headers for Windows (mingw-w64)"
 pkgver=12.0.0.r335.g6cd6fee9c
-pkgrel=1
+pkgrel=2
 _commit='6cd6fee9c063c50917618ded6e7e31246a7714ee'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -60,12 +60,6 @@ package() {
   rm ${pkgdir}${MINGW_PREFIX}/include/pthread_signal.h
   rm ${pkgdir}${MINGW_PREFIX}/include/pthread_time.h
   rm ${pkgdir}${MINGW_PREFIX}/include/pthread_unistd.h
-
-  # Workaround: Remove after https://bugs.winehq.org/show_bug.cgi?id=55347 is fixed
-  sed -i "s/enum DirectXAlphaMode/ABI::Windows::Graphics::DirectX::DirectXAlphaMode/g" "${pkgdir}${MINGW_PREFIX}"/include/windows.ui.composition.h
-  sed -i "s/enum DirectXPixelFormat/ABI::Windows::Graphics::DirectX::DirectXPixelFormat/g" "${pkgdir}${MINGW_PREFIX}"/include/{windows.graphics.capture.h,windows.ui.composition.h}
-  sed -i "s/enum VirtualKey/ABI::Windows::System::VirtualKey/g" "${pkgdir}${MINGW_PREFIX}"/include/windows.ui.core.h
-  sed -i "s/struct Point/ABI::Windows::Foundation::Point/g" "${pkgdir}${MINGW_PREFIX}"/include/windows.ui.core.h
 
   install -Dm644 ${srcdir}/mingw-w64/mingw-w64-headers/ddk/readme.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/ddk-readme.txt
   install -Dm644 ${srcdir}/mingw-w64/COPYING ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING


### PR DESCRIPTION
The fix was added in
https://github.com/mingw-w64/mingw-w64/commit/b70f2474437017368c99ca202809f20c4f773855

This reverts commit 456b445974f39d9bf82c15a007a9b7785c5a5292