### PR TITLE
SDL2_mixer: Do not link to LGPL library

### DIFF
--- a/mingw-w64-SDL2_mixer/PKGBUILD
+++ b/mingw-w64-SDL2_mixer/PKGBUILD
@@ -4,7 +4,7 @@ _realname=SDL2_mixer
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.8.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A simple multi-channel audio mixer (Version 2) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -18,7 +18,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-fluidsynth"
          "${MINGW_PACKAGE_PREFIX}-libvorbis"
          "${MINGW_PACKAGE_PREFIX}-libmodplug"
-         "${MINGW_PACKAGE_PREFIX}-mpg123"
          "${MINGW_PACKAGE_PREFIX}-opusfile")
 source=("https://github.com/libsdl-org/SDL_mixer/releases/download/release-${pkgver}/SDL2_mixer-${pkgver}.zip"{,.sig})
 sha256sums=('02df784cc68723419dd266530ee6964f810a6f02a27b03ecc85689c2e5e442ce'
@@ -39,8 +38,9 @@ build() {
     --disable-music-flac-shared
     --enable-music-mp3
     --disable-music-mp3-mad-gpl
-    --enable-music-mp3-mpg123
+    --disable-music-mp3-mpg123
     --disable-music-mp3-mpg123-shared
+    --enable-music-mp3-minimp3
     --enable-music-opus
     --disable-music-opus-shared
   )


### PR DESCRIPTION
I'd like to statically link the binary for my game, but I cannot do so if SDL2_mixer relies on libmpg123, since it is LGPL licensed and my software is not GPL licensed. Luckily SDL2_mixer supports using the single header library called minimp3 now, which is included in the SDL2_mixer repo. Building with it works perfectly for PSP and Vita, so I'm assuming it should work just fine for Windows as well.

I've marked this one as draft, because I'm not 100% sure how I'll test this yet. I just wanted to have it up in case someone spots a clear error in my work here. I'll update once I've tested this.