### PR TITLE
kate, helix: change optdepends for LSPs

### DIFF
--- a/mingw-w64-helix/PKGBUILD
+++ b/mingw-w64-helix/PKGBUILD
@@ -4,7 +4,7 @@ _realname=helix
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=24.07
-pkgrel=2
+pkgrel=3
 pkgdesc="A post-modern modal text editor (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -14,6 +14,9 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-mdbook"
              "git")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+optdepends=("${MINGW_PACKAGE_PREFIX}-rust-analuzer: Rust LSP"
+            "${MINGW_PACKAGE_PREFIX}-clang: for clangd"
+            "${MINGW_PACKAGE_PREFIX}-lldb: for lldb-dap")
 source=("$url/archive/$pkgver/${_realname}-${pkgver}.tar.gz"
         'icon.patch'
         'disable-lto.patch'

--- a/mingw-w64-helix/PKGBUILD
+++ b/mingw-w64-helix/PKGBUILD
@@ -14,7 +14,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-mdbook"
              "git")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
-optdepends=("${MINGW_PACKAGE_PREFIX}-rust-analuzer: Rust LSP"
+optdepends=("${MINGW_PACKAGE_PREFIX}-rust-analyzer: Rust LSP"
             "${MINGW_PACKAGE_PREFIX}-clang: for clangd"
             "${MINGW_PACKAGE_PREFIX}-lldb: for lldb-dap")
 source=("$url/archive/$pkgver/${_realname}-${pkgver}.tar.gz"

--- a/mingw-w64-kate/PKGBUILD
+++ b/mingw-w64-kate/PKGBUILD
@@ -5,7 +5,7 @@ _realname=kate
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=24.08.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Advanced text editor (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -55,7 +55,7 @@ optdepends=(
   "${MINGW_PACKAGE_PREFIX}-breeze-icons: application icon theme"
   "${MINGW_PACKAGE_PREFIX}-clang: C and C++ LSP support"
   "${MINGW_PACKAGE_PREFIX}-konsole: open a terminal in Kate"
-  "${MINGW_PACKAGE_PREFIX}-rust: Rust LSP support"
+  "${MINGW_PACKAGE_PREFIX}-rust-analyzer: Rust LSP support"
   "git: git-blame plugin"
 )
 groups=(


### PR DESCRIPTION
helix: add some LSPs available from repo (can be found with `hx --health`)
kate: change rust to rust-analyzer