### PR TITLE
cmake: remove _bootstrap

### DIFF
--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -1,12 +1,10 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 # Contributor: Ray Donnelly <mingw.android@gmail.com>
 
-_bootstrap=0
-
 _realname=cmake
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
-         $( [[ _bootstrap == 1 || ${CARCH} == i686 ]] || echo \
+         $( [[ ${CARCH} == i686 ]] || echo \
            "${MINGW_PACKAGE_PREFIX}-ccmake" \
            "${MINGW_PACKAGE_PREFIX}-${_realname}-cmcldeps" \
            "${MINGW_PACKAGE_PREFIX}-${_realname}-gui" \
@@ -26,7 +24,7 @@ msys2_references=(
 )
 license=("spdx:MIT")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
-             $( (( _bootstrap )) || echo "${MINGW_PACKAGE_PREFIX}-cmake-bootstrap")
+             "${MINGW_PACKAGE_PREFIX}-cmake-bootstrap"
              "${MINGW_PACKAGE_PREFIX}-python-sphinx"
              "${MINGW_PACKAGE_PREFIX}-bzip2"
              "${MINGW_PACKAGE_PREFIX}-ncurses"
@@ -101,69 +99,39 @@ build() {
 
   declare -a _extra_config
 
-  if (( _bootstrap )); then
-    if [[ ${CARCH} != i686 ]]; then
-      _extra_config+=("--qt-gui" "--qt-qmake=${MINGW_PREFIX}/bin/qmake6.exe" "--sphinx-html")
-    fi
-    if [[ ${MINGW_PACKAGE_PREFIX} != *-clang- ]]; then
-      _fc_compiler=gfortran
-    else
-      _fc_compiler=flang
-    fi
-
-    MSYSTEM=MINGW FC=${MINGW_PREFIX}/bin/${_fc_compiler}.exe \
-      "${srcdir}"/${_realname}-${_pkgver}/configure  \
-      --prefix=${MINGW_PREFIX}                      \
-      --datadir=share/cmake                         \
-      --docdir=share/doc/cmake                      \
-      --mandir=share/man                            \
-      --system-libs                                 \
-      --parallel=${NUMBER_OF_PROCESSORS}            \
-      --sphinx-man                                  \
-      --bootstrap-system-jsoncpp                    \
-      --bootstrap-system-libuv                      \
-      --bootstrap-system-librhash                   \
-      "${_extra_config[@]}"
-
-    make
+  if check_option "debug" "n"; then
+    _extra_config+=("-DCMAKE_BUILD_TYPE=Release")
   else
-    if check_option "debug" "n"; then
-      _extra_config+=("-DCMAKE_BUILD_TYPE=Release")
-    else
-      _extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
-    fi
-    if [[ ${CARCH} != i686 ]]; then
-      export PATH=${MINGW_PREFIX}/share/qt6/bin:$PATH
-      _extra_config+=("-DSPHINX_HTML=ON" "-DSPHINX_QTHELP=ON" "-DBUILD_QtDialog=ON" "-DBUILD_CursesDialog=ON")
-    fi
-    MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-    ${MINGW_PREFIX}/bin/cmake.exe -Wno-dev \
-      -GNinja \
-      "${_extra_config[@]}" \
-      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-      -DCMake_INSTALL_COMPONENTS=ON \
-      -DCMAKE_DATA_DIR=share/cmake \
-      -DCMAKE_DOC_DIR=share/doc/cmake \
-      -DCMAKE_MAN_DIR=share/man \
-      -DCMAKE_INFO_DIR=share/info \
-      -DCMAKE_USE_SYSTEM_LIBRARIES=ON \
-      -DSPHINX_MAN=ON \
-      -DBUILD_TESTING=OFF \
-      -DPython_EXECUTABLE=${MINGW_PREFIX}/bin/python \
-      ../${_realname}-${_pkgver}
-    ${MINGW_PREFIX}/bin/cmake.exe --build .
+    _extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
+  if [[ ${CARCH} != i686 ]]; then
+    export PATH=${MINGW_PREFIX}/share/qt6/bin:$PATH
+    _extra_config+=("-DSPHINX_HTML=ON" "-DSPHINX_QTHELP=ON" "-DBUILD_QtDialog=ON" "-DBUILD_CursesDialog=ON")
+  fi
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake.exe -Wno-dev \
+    -GNinja \
+    "${_extra_config[@]}" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DCMake_INSTALL_COMPONENTS=ON \
+    -DCMAKE_DATA_DIR=share/cmake \
+    -DCMAKE_DOC_DIR=share/doc/cmake \
+    -DCMAKE_MAN_DIR=share/man \
+    -DCMAKE_INFO_DIR=share/info \
+    -DCMAKE_USE_SYSTEM_LIBRARIES=ON \
+    -DSPHINX_MAN=ON \
+    -DBUILD_TESTING=OFF \
+    -DPython_EXECUTABLE=${MINGW_PREFIX}/bin/python \
+    ../${_realname}-${_pkgver}
+  ${MINGW_PREFIX}/bin/cmake.exe --build .
 }
 
 check() {
   cd "${srcdir}/build-${MSYSTEM}"
-  if (( _bootstrap )); then
-    ./bin/ctest.exe -j$(($(nproc)+1))
-  else
-    ${MINGW_PREFIX}/bin/cmake -DBUILD_TESTING=ON ../${_realname}-${_pkgver}
-    ${MINGW_PREFIX}/bin/cmake --build .
-    ${MINGW_PREFIX}/bin/ctest.exe -j$(($(nproc)+1)) || msg2 "Tests failed"
-  fi
+
+  ${MINGW_PREFIX}/bin/cmake -DBUILD_TESTING=ON ../${_realname}-${_pkgver}
+  ${MINGW_PREFIX}/bin/cmake --build .
+  ${MINGW_PREFIX}/bin/ctest.exe -j$(($(nproc)+1)) || msg2 "Tests failed"
 }
 
 package_cmake() {
@@ -173,17 +141,12 @@ package_cmake() {
   fi
 
   cd "${srcdir}/build-${MSYSTEM}"
-  if (( _bootstrap )); then
-    ./bin/cmake.exe \
-      -DCMAKE_INSTALL_PREFIX:PATH=${pkgdir}${MINGW_PREFIX} \
-      -DCMAKE_INSTALL_LOCAL_ONLY:BOOL=OFF -P cmake_install.cmake
-  else
-    DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install . --component cmake
-    DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install . --component cpack
-    DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install . --component ctest
-    DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install . --component sphinx-man
-    DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install . --component Unspecified
-  fi
+
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install . --component cmake
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install . --component cpack
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install . --component ctest
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install . --component sphinx-man
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install . --component Unspecified
 
   if [[ ${CARCH} != i686 ]]; then
     install -d "${pkgdir}${MINGW_PREFIX}"/share/emacs/site-lisp/


### PR DESCRIPTION
cmake-bootstrap is now used for such purpose, so no need to keep "dead code" in general cmake package