### PR TITLE
libjpeg-turbo: Include LICENSE.md in package

### DIFF
--- a/mingw-w64-libjpeg-turbo/PKGBUILD
+++ b/mingw-w64-libjpeg-turbo/PKGBUILD
@@ -5,7 +5,7 @@ _realname=libjpeg-turbo
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.0.4
-pkgrel=1
+pkgrel=2
 pkgdesc="JPEG image codec with accelerated baseline compression and decompression (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -78,5 +78,6 @@ package() {
   cd "${srcdir}/${_realname}-${pkgver}"
   install -Dm644 README.ijg            "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/README.ijg"
   install -Dm644 README.md  "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/README.md"
+  install -Dm644 LICENSE.md  "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.md"
   install -Dm644 simd/nasm/jsimdext.inc "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/simd/jsimdext.inc"
 }


### PR DESCRIPTION
I was compiling the list of licenses I'm using for a project I'm working on and found that the license file was missing from the libjpeg-turbo package. This PR adds it in.