### PR TITLE
slim-simulator: update to version 4.3

### DIFF
--- a/mingw-w64-slim-simulator/PKGBUILD
+++ b/mingw-w64-slim-simulator/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=slim-simulator
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.2.2
+pkgver=4.3
 pkgrel=1
 pkgdesc="SLiM forward simulation software package for population genetics (mingw-w64)"
 arch=('any')
@@ -11,10 +11,10 @@ license=("spdx:GPL-3.0-or-later")
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake")
-depends=("${MINGW_PACKAGE_PREFIX}-qt5-base")
+depends=("${MINGW_PACKAGE_PREFIX}-qt6-base")
 source=("https://github.com/MesserLab/SLiM/releases/download/v${pkgver}/SLiM.zip"
         "0001-Remove-Qt-version-check.patch")
-sha256sums=('5ab394255026c8f34f1362cf36301ea7c1c6b1c7693f1d91c854f1511c245174'
+sha256sums=('a5ca02b901f43ade9462f08fd319a5d404e413cf165e27b72e78ce32c81b7dd3'
             '11679c3844de8d86b98f392ed1bf3711b15c7b5cc89eb2639c9e34fce3ede8c1')
 
 # Helper macros to help make tasks easier #


### PR DESCRIPTION
Updating to latest version. q5 dependency changed to qt6 in new version.