### PR TITLE
pyinstaller: update to 6.11.0

### DIFF
--- a/mingw-w64-pyinstaller-hooks-contrib/PKGBUILD
+++ b/mingw-w64-pyinstaller-hooks-contrib/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=pyinstaller-hooks-contrib
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2024.8
+pkgver=2024.9
 pkgrel=1
 pkgdesc='Community maintained hooks for PyInstaller (mingw-w64)'
 arch=('any')
@@ -17,7 +17,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname//-/_}-${pkgver}.tar.gz")
-sha256sums=('29b68d878ab739e967055b56a93eb9b58e529d5b054fbab7a2f2bacf80cef3e2')
+sha256sums=('4793869f370d1dc4806c101efd2890e3c3e703467d8d27bb5a3db005ebfb008d')
 
 build() {
   cp -r "${_realname//-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-pyinstaller/PKGBUILD
+++ b/mingw-w64-pyinstaller/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=pyinstaller
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=6.10.0
-pkgrel=3
+pkgver=6.11.0
+pkgrel=0
 pkgdesc='Bundles a Python application and all its dependencies into a single package (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -23,7 +23,14 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-wheel")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('143840f8056ff7b910bf8f16f6cd92cc10a6c2680bb76d0a25d558d543d21270')
+sha256sums=('cb4d433a3db30d9d17cf5f2cf7bb4df80a788d493c1d67dd822dc5791d9864af')
+
+prepare() {
+  cd "${_realname}-${pkgver}"/PyInstaller/bootloader
+
+  # Remove unused bootloaders
+  for bl in $(ls | grep -v Windows-64bit | grep -v images); do rm -rf $bl; done
+}
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"


### PR DESCRIPTION
Windows Security treat `PyInstaller/bootloader/Windows-32bit-intel/*.exe` files as `Trojan:Win32/Wacatac.B!ml` for me.
But for bootloaders from `6.10.0` version all good.
Can anybody check or confirm this?