### PR TITLE
[lua, lua53] use fseek solution for mingw compilers provided by Lua's author

### DIFF
--- a/mingw-w64-lua/0004-fix-fseek-on-mingw.patch
+++ b/mingw-w64-lua/0004-fix-fseek-on-mingw.patch
@@ -1,14 +1,17 @@
-diff -Naur a/src/liolib.c b/src/liolib.c
---- a/src/liolib.c	2024-06-13 19:15:09.000000000 -0300
-+++ b/src/liolib.c	2024-06-27 18:04:03.461495748 -0300
-@@ -123,8 +123,8 @@
- #define l_ftell(f)		ftello(f)
- #define l_seeknum		off_t
+diff -Naur a/src/luaconf.h b/src/luaconf.h
+--- a/src/luaconf.h	2024-06-13 19:15:10.000000000 -0300
++++ b/src/luaconf.h	2024-10-17 12:49:27.896223751 -0300
+@@ -795,7 +795,13 @@
+ */
  
--#elif defined(LUA_USE_WINDOWS) && !defined(_CRTIMP_TYPEINFO) \
--   && defined(_MSC_VER) && (_MSC_VER >= 1400)	/* }{ */
-+#elif defined(LUA_USE_WINDOWS) && (defined(__MINGW32__) || !defined(_CRTIMP_TYPEINFO) \
-+   && defined(_MSC_VER) && (_MSC_VER >= 1400))	/* }{ */
  
- /* Windows (but not DDK) and Visual C++ 2005 or higher */
- #define l_fseek(f,o,w)		_fseeki64(f,o,w)
++#if defined(liolib_c) && defined(__MINGW32__)
++#include <sys/types.h>
+ 
++#define l_fseek(f,o,w) fseeko(f,o,w)
++#define l_ftell(f) ftello(f)
++#define l_seeknum off_t
++#endif
+ 
+ 
+ #endif

--- a/mingw-w64-lua/PKGBUILD
+++ b/mingw-w64-lua/PKGBUILD
@@ -7,7 +7,7 @@ _realname=lua
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.4.7
-pkgrel=2
+pkgrel=3
 pkgdesc="A powerful light-weight programming language designed for extending applications. (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -30,7 +30,7 @@ sha256sums=('9fbf5e28ef86c69858f6d3d34eccc32e911c1a28b4120ff3e84aaa70cfbf1e30'
             '37246417ce7b1d062cb52012c087793c961527e5b6da5318cf573244a477f528'
             '5f0c29865f9645a61ca62b1860f26ffac8b3458bd5e7b7a9c92daae0927a1914'
             '2294a245794fac0ec6a6bae990ca2cb7c77b8426026192b5446480abd2a2fd21'
-            '9a7cb30b9d6f2a0e4479c4235415670686752553647ff63155ab0c61f9db2310'
+            'd623a75905666f599dbb37dd653d69b9c92d84a67e4ea3fc57bfcb1714826c42'
             '0e9f1fab745c8d6cd1fe37a32c8bd6cca665692aac5c130237e648abef86f632'
             '142fb08b41a807b192b4b2c166696a1830a1c97967e5099ad0e579bf500e1da4')
 

--- a/mingw-w64-lua53/PKGBUILD
+++ b/mingw-w64-lua53/PKGBUILD
@@ -7,7 +7,7 @@ _realname=lua53
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.3.6
-pkgrel=5
+pkgrel=6
 pkgdesc="A powerful light-weight programming language designed for extending applications. Version 5.3.x (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -30,7 +30,7 @@ sha256sums=('fc5fd69bb8736323f026672b1b7235da613d7177e72558893a0bdcd320466d60'
             '98d2ea184c151236747003f2d2afd0da71d1875d2868e3ac7358b5cf4925cd2b'
             '40e1d39f289d65e1b689b741689ab6a83bcfb4264f8b2d0d550f96ab3072bb24'
             '86daf43473959330706c7992fda2a7d67c849b3591eca8ca2f527d61328a9c75'
-            '4cd6769d9327554869b635e3e119519ee71490c1c3f371075e44c7d828a4a20e'
+            '1827c6f0b1f93d6187dd4ac6b585d47c9613aa04cc16210a96dfd70ec6ba0e54'
             '142fb08b41a807b192b4b2c166696a1830a1c97967e5099ad0e579bf500e1da4')
 
 prepare() {

--- a/mingw-w64-lua53/fix-fseek-on-mingw.patch
+++ b/mingw-w64-lua53/fix-fseek-on-mingw.patch
@@ -1,14 +1,17 @@
-diff -Naur a/src/liolib.c b/src/liolib.c
---- a/src/liolib.c	2020-09-14 12:34:00.000000000 -0300
-+++ b/src/liolib.c	2024-06-27 18:06:27.801668564 -0300
-@@ -111,8 +111,8 @@
- #define l_ftell(f)		ftello(f)
- #define l_seeknum		off_t
+diff -Naur a/src/luaconf.h b/src/luaconf.h
+--- a/src/luaconf.h	2020-09-14 12:34:01.000000000 -0300
++++ b/src/luaconf.h	2024-10-17 12:47:20.901419421 -0300
+@@ -783,7 +783,13 @@
+ */
  
--#elif defined(LUA_USE_WINDOWS) && !defined(_CRTIMP_TYPEINFO) \
--   && defined(_MSC_VER) && (_MSC_VER >= 1400)	/* }{ */
-+#elif defined(LUA_USE_WINDOWS) && (defined(__MINGW32__) || !defined(_CRTIMP_TYPEINFO) \
-+   && defined(_MSC_VER) && (_MSC_VER >= 1400))	/* }{ */
  
- /* Windows (but not DDK) and Visual C++ 2005 or higher */
- #define l_fseek(f,o,w)		_fseeki64(f,o,w)
++#if defined(liolib_c) && defined(__MINGW32__)
++#include <sys/types.h>
+ 
++#define l_fseek(f,o,w) fseeko(f,o,w)
++#define l_ftell(f) ftello(f)
++#define l_seeknum off_t
++#endif
+ 
+ 
+ #endif


### PR DESCRIPTION
## Description

Around 4 months ago, in order to fix [https://github.com/msys2/MINGW-packages/issues/20892](https://github.com/msys2/MINGW-packages/issues/20892), I submitted a PR [https://github.com/msys2/MINGW-packages/pull/21266](https://github.com/msys2/MINGW-packages/pull/21266) that got merged with a workaround given by myself.

Today, looking for that issue in the Lua mailing list, I found that someone reported it at [http://lua-users.org/lists/lua-l/2015-05/msg00315.html](http://lua-users.org/lists/lua-l/2015-05/msg00315.html) and got a final solution at [http://lua-users.org/lists/lua-l/2015-05/msg00370.html](http://lua-users.org/lists/lua-l/2015-05/msg00370.html) provided by **Roberto Ierusalimschy** (Lua's author).

Thus, this current PR is just replacing my old solution with the one provided by Lua's author.

## Tests

1. You need to have any file larger than 32-bits range. By the way, I used Ubuntu 24.04 iso, which is 6.1 GB
2. Write the following Lua script to a file (```fseek-test.lua```):

```lua
f = assert(io.open("ubuntu-24.04-desktop-amd64.iso"))

print(f:seek("end"))

f:close()
```

3. Run the script on current Lua ```lua fseek-test.lua``` or Lua 5.3 ```lua5.3 fseek-test.lua```
4. The expected result is the file size in bytes (```6114656256``` for my file).

**P.S.**: I did test Lua's author solution provided here on mingw32, mingw64, ucrt64, clang32 and clang64, and it worked nicely (x64 machine).