### PR TITLE
python-jupyter_console: Do not strip launcher executable

### DIFF
--- a/mingw-w64-python-jupyter_console/PKGBUILD
+++ b/mingw-w64-python-jupyter_console/PKGBUILD
@@ -8,7 +8,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=6.6.3
-pkgrel=3
+pkgrel=4
 pkgdesc='An IPython-like terminal frontend for Jupyter kernels in any language (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -32,6 +32,7 @@ makedepends=(
     ${MINGW_PACKAGE_PREFIX}-python-build
     ${MINGW_PACKAGE_PREFIX}-python-installer
     ${MINGW_PACKAGE_PREFIX}-python-hatchling)
+options=('!strip')
 source=(https://pypi.org/packages/source/${_realname::1}/${_realname/_/-}/${_realname}-${pkgver}.tar.gz)
 sha256sums=('566a4bf31c87adbfadf22cdf846e3069b59a71ed5da71d6ba4d8aaad14a53539')
 


### PR DESCRIPTION

    This fixes the following runtime error.
    
    $ jupyter-console.exe
    Fatal error in launcher: Unable to find an appended archive.

Fixes #22214
