### PR TITLE
SFCGAL: Update to 2.0.0

### DIFF
--- a/mingw-w64-python-pysfcgal/PKGBUILD
+++ b/mingw-w64-python-pysfcgal/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=pysfcgal
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
-pkgver=1.5.2
-pkgrel=2
+pkgver=2.0.0
+pkgrel=1
 pkgdesc='Python SFCGAL binding (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -12,7 +12,7 @@ url='https://gitlab.com/SFCGAL/pysfcgal'
 msys2_references=(
   'pypi: PySFCGAL'
 )
-license=('spdx:MIT')
+license=('spdx:GPL-3.0-or-later')
 depends=(
     ${MINGW_PACKAGE_PREFIX}-python
     ${MINGW_PACKAGE_PREFIX}-sfcgal
@@ -25,7 +25,7 @@ makedepends=(
     ${MINGW_PACKAGE_PREFIX}-python-setuptools
 )
 source=(https://gitlab.com/SFCGAL/pysfcgal/-/archive/v${pkgver}/pysfcgal-v${pkgver}.tar.gz)
-sha256sums=('322c174ed05005a192441da357ea648b7fb4e0abb8bdc6e4535f6cdaae403870')
+sha256sums=('fad4832d0264b1d20dc5425366d6dbc6321efac88298ff7bd0ea7a796738488f')
 
 build() {
   cp -r "${_realname}-v${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-sfcgal/PKGBUILD
+++ b/mingw-w64-sfcgal/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=sfcgal
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.5.2
-pkgrel=2
+pkgver=2.0.0
+pkgrel=1
 pkgdesc="Wrapper around CGAL that intents to implement 2D and 3D operations on OGC standards models (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -22,7 +22,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-mpfr"
          "${MINGW_PACKAGE_PREFIX}-cgal")
 source=(https://gitlab.com/SFCGAL/SFCGAL/-/archive/v${pkgver}/SFCGAL-v${pkgver}.tar.gz)
-sha256sums=('b946b3c20d53f6e2703046085f0fcfea6c1a4081163f7bedd30b1195801efdd2')
+sha256sums=('11843953f49e7e4432c42fd27d54e1ff7ca55d0cc72507725c2a5d840c2c6535')
 
 build() {
   mkdir ${srcdir}/build-${MSYSTEM} && cd ${srcdir}/build-${MSYSTEM}
@@ -35,7 +35,7 @@ build() {
   fi
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-  ${MINGW_PREFIX}/bin/cmake \
+  ${MINGW_PREFIX}/bin/cmake -Wno-dev \
       -G"Ninja" \
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
       ${_extra_config[@]} \


### PR DESCRIPTION
Update SFCGAL and PySFCGAL to 2.0.0
Fix PySFCGAL license SPDX