### PR TITLE
librsvg: rebuild and fix build with newer rust

### DIFF
--- a/mingw-w64-librsvg/0006-fix-query-with-rust-1-82.patch
+++ b/mingw-w64-librsvg/0006-fix-query-with-rust-1-82.patch
@@ -1,0 +1,44 @@
+--- librsvg-2.59.1/meson/query-rustc.py.orig	2024-10-18 18:16:27.452857900 +0200
++++ librsvg-2.59.1/meson/query-rustc.py	2024-10-18 18:15:59.154317500 +0200
+@@ -64,7 +64,6 @@
+ 
+ if __name__ == "__main__":
+     args = parser.parse_args()
+-    dummy_out = tempfile.NamedTemporaryFile()
+     query = args.query
+     query_arg = None
+     rustc_cmd = [Path(args.RUSTC).as_posix()]
+@@ -85,17 +84,23 @@
+     if args.target:
+         rustc_cmd.extend(['--target', args.target])
+ 
+-    # We need these for '--print=native-static-libs' on Windows
+-    if query == 'native-static-libs':
+-        rustc_cmd.extend(['--crate-type', 'staticlib'])
+-        rustc_cmd.append(os.devnull)
+-        rustc_cmd.extend(['-o', dummy_out.name])
++    fd, dummy_out = tempfile.mkstemp()
++    os.close(fd)
++    try:
++        # We need these for '--print=native-static-libs' on Windows
++        if query == 'native-static-libs':
++            rustc_cmd.extend(['--crate-type', 'staticlib'])
++            rustc_cmd.append(os.devnull)
++            rustc_cmd.extend(['-o', dummy_out])
++
++        query_results = subprocess.run(
++            rustc_cmd,
++            capture_output=True,
++            text=True,
++        )
++    finally:
++        os.unlink(dummy_out)
+ 
+-    query_results = subprocess.run(
+-        rustc_cmd,
+-        capture_output=True,
+-        text=True,
+-    )
+     if query == 'native-static-libs':
+         retrieve_native_static_libs_from_output(query_results.stderr)
+     elif query == 'default-host-toolchain' or query == 'stable-actual-version':

--- a/mingw-w64-librsvg/PKGBUILD
+++ b/mingw-w64-librsvg/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
 pkgver=2.59.1
-pkgrel=1
+pkgrel=2
 pkgdesc="SVG rendering library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -34,13 +34,15 @@ source=("https://download.gnome.org/sources/librsvg/${pkgver%.*}/${_realname}-${
         "glib-rs.patch"
         "0002-avoid-link-whole.patch"
         "0004-add-option-for-disabling-convert.patch"
-        "0005-update-clang-rust-target.patch")
+        "0005-update-clang-rust-target.patch"
+        "0006-fix-query-with-rust-1-82.patch")
 sha256sums=('6116267c7ddabfd4daaf1c341326da0a773139a7223e885ae40ee09bd6986ef6'
             'fee90a615ce05be7a32932cfb8adf2c4bbb4700e80d37713c981fb24c0c56238'
             'e0f5accba0ff47d9cdf79f506ea76ea0b373edaf6845a23180a00c15e0a8691d'
             '4cb597eef01a636ad7007b3a47b76e395f30b2347183b5acb1af94d39577a239'
             '0e042886d313b37f5db5e0405a5e37b3d3e4a6c66f94186677406136fa0e7a17'
-            '0bbfddf52999ca9f1ac94c732a4b361528d48b3298f7126ec184c58bc94904eb')
+            '0bbfddf52999ca9f1ac94c732a4b361528d48b3298f7126ec184c58bc94904eb'
+            '66188e272e74296734287c50ed142855f73defa675bd97176bd77f93c4a16b36')
 msys2_repository_url="https://gitlab.gnome.org/GNOME/librsvg"
 noextract=("${_realname}-${pkgver}.tar.xz")
 
@@ -65,6 +67,9 @@ prepare() {
 
   # https://github.com/msys2/MINGW-packages/pull/21901#issuecomment-2412443698
   patch -p1 -i "${srcdir}/0005-update-clang-rust-target.patch"
+
+  # https://gitlab.gnome.org/GNOME/librsvg/-/issues/1134
+  patch -p1 -i "${srcdir}/0006-fix-query-with-rust-1-82.patch"
 
   echo "" >> Cargo.toml
   echo "[patch.crates-io]" >> Cargo.toml


### PR DESCRIPTION
rust 1.82.0 doesn't like the target temp file being open while writing to it