### PR TITLE
gnustep-gui: Add NSMenu patch fixes

### DIFF
--- a/mingw-w64-gnustep-gui/PKGBUILD
+++ b/mingw-w64-gnustep-gui/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gnustep-gui
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.31.1
-pkgrel=3
+pkgrel=4
 pkgdesc="GNUstep GUI Library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -26,15 +26,24 @@ source=("https://github.com/gnustep/libs-gui/releases/download/gui-${pkgver//./_
         # GSCodingFlags incorrectly packed on MSYS2 (merged to master)
         "https://github.com/gnustep/libs-gui/commit/4d508632758f72b43e2a1450fa24d861dc9eecbd.diff"
         # Fix NSSliderCell not handling integerValue on MSYS2 (merged to master)
-        "https://github.com/gnustep/libs-gui/commit/3b02ac1d9da1a8184c4a5d27999f95ee5bf34719.diff")
+        "https://github.com/gnustep/libs-gui/commit/3b02ac1d9da1a8184c4a5d27999f95ee5bf34719.diff"
+        ## Fix issue where NSMenu is not getting updated (PR https://github.com/gnustep/libs-gui/pull/304) 
+        ## This fix works, but long term the community would prefer a better fix (Unknown at this time)
+        "https://github.com/gnustep/libs-gui/commit/4be0d3d1e4fa0641883c58c662f6c837f6be9e8a.diff"
+        # Fix NSButtonCell alternateContents trying to set an NSImage instead of NSString as an alternateTitle (merged to master)
+        "https://github.com/gnustep/libs-gui/commit/9901bbcb4c432fa114351ded9d88be4495f3b729.diff")
 sha256sums=('b5bf50bf86a391e541d3d37fe600175e95e5a004180d43b55aee9ca1d575e8f9'
             '695acc856f24c5910d7f0c7550729f15f2b7ce2fd773ab5726d198b6cd225770'
-            'b314604367f99333d0a185e68173702f50b5afad5e9d1d5d1cfef46017fa8732')
+            'b314604367f99333d0a185e68173702f50b5afad5e9d1d5d1cfef46017fa8732'
+            'd0e4133bd7388436d4813d1852643955f9cfa73d43d4d77a1b2bca90ac494ea0'
+            '704a3b4c27618d67c72ef57b4c29477546688bd5ad38a488c0ff9c65aa684105')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   patch -p1 -i ${srcdir}/4d508632758f72b43e2a1450fa24d861dc9eecbd.diff
   patch -p1 -i ${srcdir}/3b02ac1d9da1a8184c4a5d27999f95ee5bf34719.diff
+  patch -p1 -i ${srcdir}/4be0d3d1e4fa0641883c58c662f6c837f6be9e8a.diff
+  patch -p1 -i ${srcdir}/9901bbcb4c432fa114351ded9d88be4495f3b729.diff
 }
 
 build() {


### PR DESCRIPTION
This MR adds 2 patches to GNUstep GUI that fixes various problems with NSMenu items. Patching until the community is ready for an official release.