### PR TITLE
add python-aioquic

### DIFF
--- a/mingw-w64-python-aioquic/PKGBUILD
+++ b/mingw-w64-python-aioquic/PKGBUILD
@@ -1,0 +1,51 @@
+# Maintainer: Antoine Martin <totaam@xpra.org>
+
+_realname=aioquic
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=1.2.0
+pkgrel=1
+pkgdesc="a library for the QUIC network protocol in Python (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+msys2_references=(
+  'pypi: aioquic'
+)
+url='https://github.com/aiortc/aioquic'
+license=('spdx:BSD-3-Clause')
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-build"
+         "${MINGW_PACKAGE_PREFIX}-python-installer"
+         "${MINGW_PACKAGE_PREFIX}-cc"
+         "${MINGW_PACKAGE_PREFIX}-python-pyopenssl"
+         "${MINGW_PACKAGE_PREFIX}-python-cryptography"
+         "${MINGW_PACKAGE_PREFIX}-python-certifi"
+         "${MINGW_PACKAGE_PREFIX}-python-pylsqpack"
+)
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python-wheel")
+source=("https://pypi.io/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('f91263bb3f71948c5c8915b4d50ee370004f20a416f67fab3dcc90556c7e7199')
+
+prepare() {
+  cd "${srcdir}"
+  rm -rf python-build-${MSYSTEM} | true
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
+}
+
+build() {
+  cd "${srcdir}/python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "${srcdir}/python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix="${MINGW_PREFIX}" \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}

--- a/mingw-w64-python-aioquic/PKGBUILD
+++ b/mingw-w64-python-aioquic/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=1.2.0
 pkgrel=1
-pkgdesc="a library for the QUIC network protocol in Python (mingw-w64)"
+pkgdesc="QUIC and HTTP/3 implementation in Python (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 msys2_references=(
@@ -13,35 +13,31 @@ msys2_references=(
 )
 url='https://github.com/aiortc/aioquic'
 license=('spdx:BSD-3-Clause')
-depends=("${MINGW_PACKAGE_PREFIX}-python"
-         "${MINGW_PACKAGE_PREFIX}-python-build"
-         "${MINGW_PACKAGE_PREFIX}-python-installer"
-         "${MINGW_PACKAGE_PREFIX}-cc"
-         "${MINGW_PACKAGE_PREFIX}-python-pyopenssl"
-         "${MINGW_PACKAGE_PREFIX}-python-cryptography"
-         "${MINGW_PACKAGE_PREFIX}-python-certifi"
-         "${MINGW_PACKAGE_PREFIX}-python-pylsqpack"
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-openssl"
+  "${MINGW_PACKAGE_PREFIX}-python"
+  "${MINGW_PACKAGE_PREFIX}-python-certifi"
+  "${MINGW_PACKAGE_PREFIX}-python-cryptography"
+  "${MINGW_PACKAGE_PREFIX}-python-pylsqpack"
+  "${MINGW_PACKAGE_PREFIX}-python-pyopenssl"
+  "${MINGW_PACKAGE_PREFIX}-python-service-identity"
 )
-makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
-             "${MINGW_PACKAGE_PREFIX}-python-setuptools"
-             "${MINGW_PACKAGE_PREFIX}-python-wheel")
-source=("https://pypi.io/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-python-build"
+  "${MINGW_PACKAGE_PREFIX}-python-installer"
+  "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+)
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('f91263bb3f71948c5c8915b4d50ee370004f20a416f67fab3dcc90556c7e7199')
 
-prepare() {
-  cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
-  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
-}
-
 build() {
-  cd "${srcdir}/python-build-${MSYSTEM}"
-
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
   python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 package() {
-  cd "${srcdir}/python-build-${MSYSTEM}"
+  cd "python-build-${MSYSTEM}"
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
     python -m installer --prefix="${MINGW_PREFIX}" \

--- a/mingw-w64-python-service-identity/PKGBUILD
+++ b/mingw-w64-python-service-identity/PKGBUILD
@@ -1,0 +1,48 @@
+# Maintainer: Biswapriyo Nath <nathbappai@gmail.com>
+
+_realname=service-identity
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=24.1.0
+pkgrel=1
+pkgdesc="Service Identity Verification for pyOpenSSL and cryptography (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+msys2_references=(
+  'archlinux: python-service-identity'
+  'pypi: service-identity'
+)
+msys2_repository_url='https://github.com/pyca/service-identity/'
+url='https://service-identity.readthedocs.io/'
+license=('spdx:MIT')
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-python"
+  "${MINGW_PACKAGE_PREFIX}-python-attrs"
+  "${MINGW_PACKAGE_PREFIX}-python-cryptography"
+  "${MINGW_PACKAGE_PREFIX}-python-pyasn1"
+  "${MINGW_PACKAGE_PREFIX}-python-pyasn1-modules"
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-python-build"
+  "${MINGW_PACKAGE_PREFIX}-python-hatch-fancy-pypi-readme"
+  "${MINGW_PACKAGE_PREFIX}-python-hatchling"
+  "${MINGW_PACKAGE_PREFIX}-python-installer"
+)
+optdepends=("${MINGW_PACKAGE_PREFIX}-python-idna: for Internationalized Domain Names support")
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname/-/_}/${_realname/-/_}-${pkgver}.tar.gz")
+sha256sums=('6829c9d62fb832c2e1c435629b0a8c476e1929881f28bee4d20bc24161009221')
+
+build() {
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix="${MINGW_PREFIX}" \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}


### PR DESCRIPTION
Add [`python-aioquic`](https://github.com/aiortc/aioquic) so we can add support for the [QUIC transport](https://github.com/Xpra-org/xpra/blob/master/docs/Network/QUIC.md) in [`xpra`](https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-python-xpra/PKGBUILD). (this optional dependency will be submitted later as a separate PR)

This PR depends on `python-pylsqpack`: https://github.com/msys2/MINGW-packages/pull/22255