### PR TITLE
add pylsqpack

### DIFF
--- a/mingw-w64-python-pylsqpack/PKGBUILD
+++ b/mingw-w64-python-pylsqpack/PKGBUILD
@@ -1,0 +1,40 @@
+# Maintainer: Antoine Martin <totaam@xpra.org>
+
+_realname=pylsqpack
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=0.3.18
+pkgrel=1
+pkgdesc="a wrapper around the ls-qpack library. It provides Python Decoder and Encoder objects to read or write HTTP/3 headers compressed with QPACK (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+msys2_references=(
+  'pypi: pylsqpack'
+)
+url='https://github.com/aiortc/pylsqpack'
+license=('spdx:BSD-3-Clause')
+depends=("${MINGW_PACKAGE_PREFIX}-python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python-wheel"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+source=("https://pypi.io/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('45ae55e721877505f4d5ccd49591d69353f2a548a8673dfafb251d385b3c097f')
+
+prepare() {
+  cd "${srcdir}"
+  rm -rf python-build-${MSYSTEM} | true
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
+}
+
+build() {
+  cd "${srcdir}/python-build-${MSYSTEM}"
+  ${MINGW_PREFIX}/bin/python ./setup.py build
+}
+
+package() {
+  cd "${srcdir}/python-build-${MSYSTEM}"
+  ${MINGW_PREFIX}/bin/python setup.py install --prefix=${MINGW_PREFIX}
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}


### PR DESCRIPTION
This library is required by [`aioquic`](https://github.com/aiortc/aioquic), PR: https://github.com/msys2/MINGW-packages/pull/22254

---

Sorry about the duplicate (closed) PR https://github.com/msys2/MINGW-packages/pull/22253, the `cc` dependency was missing and when I forced pushed the wrong commit head, it closed that PR.

Incidentally, what is the correct (and preferably efficient) process for verifying that the list of dependencies of a new `PKGBUILD` is correct when working with an existing installation?
Isn't waiting for the CI to run is a little bit of waste of your github runner resources?