### PR TITLE
dav1d: update to 1.5.0

### DIFF
--- a/mingw-w64-dav1d/PKGBUILD
+++ b/mingw-w64-dav1d/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=dav1d
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.4.3
+pkgver=1.5.0
 pkgrel=1
 pkgdesc="AV1 cross-platform decoder focused on speed and correctness (mingw-w64)"
 arch=('any')
@@ -23,7 +23,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-xxhash")
 source=("https://downloads.videolan.org/pub/videolan/dav1d/${pkgver}/dav1d-${pkgver}.tar.xz"{,.asc}
         "0001-dll-version.patch")
-sha256sums=('42fe524bcc82ea3a830057178faace22923a79bad3d819a4962d8cfc54c36f19'
+sha256sums=('14bd6f5157808ed9aedcafbe50df689d304fd4810ac20be6eec1ab037436afd6'
             'SKIP'
             '7fc584e69c156d7d9805b38912f07f417ccd1cce5fe4ee457761e8bea9128d04')
 validpgpkeys=('65F7C6B4206BD057A7EB73787180713BE58D1ADC') # VideoLAN Release Signing Key


### PR DESCRIPTION
> WARNING: we removed some of the SSE2 optimizations, so if you care about systems without SSSE3, you should be careful when updating!

There is however runtime CPU detection, so this should affect only a (small?) portion of users w/ very old CPUs...