### PR TITLE
nanobind: Remove redundant robin_map submodule download

### DIFF
--- a/mingw-w64-nanobind/PKGBUILD
+++ b/mingw-w64-nanobind/PKGBUILD
@@ -4,8 +4,8 @@ _realname=nanobind
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.2.0
-pkgrel=1
-pkgdesc="nanobind: tiny and efficient C++/Python bindings (mingw-w64)"
+pkgrel=2
+pkgdesc="tiny and efficient C++/Python bindings (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://github.com/wjakob/nanobind'
@@ -23,24 +23,11 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-scikit-build-core"
 )
 options=('!strip')
-robin_map_commit='188c45569cc2a5dd768077c193830b51d33a5020'
-source=(
-  "https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
-  "https://github.com/Tessil/robin-map/archive/${robin_map_commit}.tar.gz"
-)
-sha256sums=(
-  '53fa7a6227bddecaa4a0710e0b8dc18fad4c8ded7a0a31d6eddcf68009ead603'
-  '2f4be670fa4f53c3261ed7af392b414a00e75591f87da0a8dd525de376430747'
-)
-
-prepare() {
-  rm -rf build-${MSYSTEM} | true
-  cp -r "${_realname}-${pkgver}" "build-${MSYSTEM}"
-  cp -r robin-map-${robin_map_commit} "build-${MSYSTEM}/ext/robin_map"
-}
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('53fa7a6227bddecaa4a0710e0b8dc18fad4c8ded7a0a31d6eddcf68009ead603')
 
 build() {
-  cd "build-${MSYSTEM}"
+  cp -r "${_realname}-${pkgver}" "build-${MSYSTEM}" && cd "build-${MSYSTEM}"
   ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
 }
 
@@ -58,6 +45,6 @@ package() {
     ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
     --destdir="${pkgdir}" dist/*.whl
 
-  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }
 


### PR DESCRIPTION
robin_map module is already included in nanobind tarball from pypi.