### PR TITLE
slepc: update to 3.22.0

### DIFF
--- a/mingw-w64-petsc/PKGBUILD
+++ b/mingw-w64-petsc/PKGBUILD
@@ -33,7 +33,7 @@ _realname=petsc
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-${_realname}-build")
 pkgver=3.22.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Sparse iterative (non)linear solver package (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -284,6 +284,9 @@ _package_build() {
     sed -r -i \
       -e "s%(PETSC_(C|F)C_INCLUDES)[[:space:]]+.*$%\\1 = -I${sb} -I${si}%" \
       -e "s%(PETSC_(C|F)C_INCLUDES_INSTALL)[[:space:]]+.*$%\\1 = -I${pb} -I${pi}%" \
+      -e "s%(wPETSC_DIR)[[:space:]]+.*$%\\1 = ${MINGW_PREFIX}/src/${_realname}%" \
+      -e "s%(PREFIXDIR)[[:space:]]+.*$%\\1 = ${MINGW_PREFIX}/src/${_realname}/${build}%" \
+      -e "/^PETSC_WITH_EXTERNAL_LIB/s%${srcdir}/build-${MSYSTEM}/${_realname}-${pkgver}%${MINGW_PREFIX}/src/${_realname}%g" \
       ${_realname}/${build}/lib/petsc/conf/petscvariables
   done
   echo "

--- a/mingw-w64-slepc/PKGBUILD
+++ b/mingw-w64-slepc/PKGBUILD
@@ -27,8 +27,8 @@
 _realname=slepc
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=3.20.1
-pkgrel=2
+pkgver=3.22.0
+pkgrel=1
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
 pkgdesc="Scalable library for eigenvalue problem computations (mingw-w64)"
@@ -49,7 +49,7 @@ source=("https://slepc.upv.es/download/distrib/${_realname}-${pkgver}.tar.gz"
         'tclbuildtest.tcl'
         'slepc.test')
 noextract=("${_realname}-${pkgver}.tar.gz")
-sha256sums=('5a36b664895881d3858d0644f56bf7bb922bdab70d732fa11cbf6442fec11806'
+sha256sums=('45eb4d085875b50108c91fd9168ed17bc9158cc3b1e530ac843b26d9981c3db0'
             'ec5072630e1c0309fe383669e9187790cd135a393c67bc4bc35cf60b0ba396ff'
             '15c7af25b91406d5fe5f26cfe00963b6cfde1c3dd466eb25f1b6fae299934966'
             '47237bd53f15e9d204b7c871ef887d9b6d11e0add1409a6eeb1a122f4b302265')
@@ -66,7 +66,7 @@ build() {
     export SLEPC_DIR=`pwd`
     export PETSC_ARCH=${build}
     export PETSC_DIR=${MINGW_PREFIX}/src/petsc
-    /usr/bin/python configure 
+    /usr/bin/python configure
     make
     (
       cd ${build}/lib
@@ -98,7 +98,7 @@ package() {
   )
   (
     cd src/eps/tutorials
-    cp ex1.c ex1f.F ${pkgdir}${MINGW_PREFIX}/share/test/${_realname}
+    cp ex1.c ex1f.F90 ${pkgdir}${MINGW_PREFIX}/share/test/${_realname}
   )
   for build in ${petsc_builds}; do
     (


### PR DESCRIPTION
Building SLEPc requires making the PETSc build package more relocatable.
