### PR TITLE
qt6: update to 6.8.0 - Part1

### DIFF
--- a/mingw-w64-qt6-3d/PKGBUILD
+++ b/mingw-w64-qt6-3d/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-3d
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.7.2
+_qtver=6.8.0
 pkgver=${_qtver/-/}
 pkgrel=1
 pkgdesc='C++ and QML APIs for easy inclusion of 3D graphics (mingw-w64)'
@@ -28,7 +28,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "rsync")
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('8bc087d904973133186e58471845c5df376bbfdcfcf079fda287e1cda27c8adf')
+sha256sums=('3a11919e15437c351b742dbf4e0115ce51aa969cba844dd6388aae14810c7b7d')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-5compat/PKGBUILD
+++ b/mingw-w64-qt6-5compat/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-5compat
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.7.2
+_qtver=6.8.0
 pkgver=${_qtver/-/}
 pkgrel=1
 pkgdesc='Module that contains unsupported Qt 5 APIs (mingw-w64)'
@@ -26,7 +26,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "rsync")
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('8826b5189efc4d9bdb64fdb1aa89d0fdf4e53c60948ed7995621ed046e38c003')
+sha256sums=('3c9b05fdd70b6bd6ec152e6b43f2a5f4c7b31c9eb342d62fa8450d63f5835e30')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-activeqt/PKGBUILD
+++ b/mingw-w64-qt6-activeqt/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-activeqt
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.7.2
+_qtver=6.8.0
 pkgver=${_qtver/-/}
 pkgrel=1
 pkgdesc='Qt5 ActiveQt Module - ActiveX components (mingw-w64)'
@@ -26,7 +26,7 @@ _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz"
         001-appending-qt6-to-remove-qt5-conflict.patch
         002-Handle-win64-in-dumpcpp-and-MetaObjectGenerator-read.patch)
-sha256sums=('c0aab390ce7ebb07f7053abfea14c2750b8c3910700a5765713cfd2596bf02f8'
+sha256sums=('2319df34c52e98bf20e69e09c3bba194d28c7ae5922a67e36601d4e881d5cc5b'
             '66b9460aeb5dd1144a04448cc461811157b100cb765e84d6af24fd83476a4217'
             '93e1c08068e45372fb02e9a33e3366b5067817ea7de4bba4e91b6c165645cb41')
 

--- a/mingw-w64-qt6-base/001-appending-qt6-to-remove-qt5-conflict.patch
+++ b/mingw-w64-qt6-base/001-appending-qt6-to-remove-qt5-conflict.patch
@@ -8,14 +8,17 @@
      SOURCES
          cachekeys.h
          generators/mac/pbuilder_pbx.cpp generators/mac/pbuilder_pbx.h
-@@ -145,3 +144,7 @@
- qt_internal_add_docs(${target_name}
+@@ -125,6 +125,10 @@
      doc/qmake.qdocconf
  )
-+
+ 
 +set_target_properties(${target_name} PROPERTIES
 +    OUTPUT_NAME qmake-qt6
 +)
++
+ qt_internal_return_unless_building_tools()
+ 
+ #### Keys ignored in scope 1:.:.:qmake.pro:<TRUE>:
 --- a/src/tools/qtpaths/CMakeLists.txt
 +++ b/src/tools/qtpaths/CMakeLists.txt
 @@ -10,7 +10,6 @@

--- a/mingw-w64-qt6-base/PKGBUILD
+++ b/mingw-w64-qt6-base/PKGBUILD
@@ -4,9 +4,9 @@ _realname=qt6-base
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.7.2
+_qtver=6.8.0
 pkgver=${_qtver/-/}
-pkgrel=2
+pkgrel=1
 pkgdesc="A cross-platform application and UI framework (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -45,6 +45,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "rsync")
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz"
+        https://github.com/qt/qtbase/commit/a6b350acbcbb38839f7c2f217dd1a055fe50efa7.patch
         001-appending-qt6-to-remove-qt5-conflict.patch
         002-fix-qtdocs-helpers-cmake.patch
         003-adjust-qmake-conf-mingw.patch
@@ -54,10 +55,10 @@ source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/subm
         007-Fix-crashes-in-rasterization-code-using-setjmp.patch
         009-qfileinfo-undefine-mingw-stat.patch
         010-export-some-constexpr-variables.patch
-        011-qt6-windeployqt-fixes.patch
-        https://download.qt.io/official_releases/qt/6.7/CVE-2024-39936-qtbase-6.7.patch)
-sha256sums=('c5f22a5e10fb162895ded7de0963328e7307611c688487b5d152c9ee64767599'
-            '31465d25af40e2722764d86b85b43ebc7d29844836172259b16780ec8c4ed3bd'
+        011-qt6-windeployqt-fixes.patch)
+sha256sums=('1bad481710aa27f872de6c9f72651f89a6107f0077003d0ebfcc9fd15cba3c75'
+            '4e1706e84557ff1cba7a5e15e3fd723a0858e3f7584126597351c234189d27df'
+            'b1ac154c3062ebcd96fec653d276cd4bfa2e8bc7433e97e49a6a25d7b5a6e646'
             '3848318bccdfa21a139ccdb70f8226358c4a7ed3943231494aab3df83025d7c7'
             '68156b8b7717a0ce19c4b991942469171bfa048cd5c90765115a546e65669a1d'
             'ed5b61bcb367bbda459bec903d796ea45604278f577a988d602ade07ec6bf363'
@@ -66,8 +67,7 @@ sha256sums=('c5f22a5e10fb162895ded7de0963328e7307611c688487b5d152c9ee64767599'
             '3a256533401a48aff7e3c4b02118d62a0cccc2b3566c6e550e7b467aca3e496f'
             'f4261d43a142a24e5fa3b23e25813754839db84078cc8c6dc611139bf531e64a'
             '23656a7839d7dcb763d022722d723493c847914b0639bab861ddb05d823af5b7'
-            '742a15191e618a50c1fb4b93e87dda73a2bd130a6cb829cb2026256ec2c252e4'
-            'fb23b0dfd37a9008726fee97b30fd342681943db0e4c759f5f21f01d61b9975d')
+            '742a15191e618a50c1fb4b93e87dda73a2bd130a6cb829cb2026256ec2c252e4')
 
 # Use the right mkspecs file
 if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
@@ -89,6 +89,7 @@ prepare() {
   cd $srcdir/${_pkgfn}
 
   apply_patch_with_msg \
+    a6b350acbcbb38839f7c2f217dd1a055fe50efa7.patch \
     001-appending-qt6-to-remove-qt5-conflict.patch \
     002-fix-qtdocs-helpers-cmake.patch \
     003-adjust-qmake-conf-mingw.patch \
@@ -97,8 +98,7 @@ prepare() {
     006-qt-6.2.0-dont-add-resource-files-to-qmake-libs.patch \
     007-Fix-crashes-in-rasterization-code-using-setjmp.patch \
     009-qfileinfo-undefine-mingw-stat.patch \
-    011-qt6-windeployqt-fixes.patch \
-    CVE-2024-39936-qtbase-6.7.patch
+    011-qt6-windeployqt-fixes.patch
 
   if [[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]]; then
     apply_patch_with_msg \

--- a/mingw-w64-qt6-charts/PKGBUILD
+++ b/mingw-w64-qt6-charts/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-charts
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.7.2
+_qtver=6.8.0
 pkgver=${_qtver/-/}
 pkgrel=1
 pkgdesc='Provides a set of easy to use chart components (mingw-w64)'
@@ -25,7 +25,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "rsync")
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('00f6a437458b7f2c4e81d748dbe2a077567a9e6ad8d8e3820b36c39dc5279bda')
+sha256sums=('1923daac0d1a69b03a4cb119b147c2e3f5080f642af365098fd8771a465b132f')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-connectivity/PKGBUILD
+++ b/mingw-w64-qt6-connectivity/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-connectivity
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.7.2
+_qtver=6.8.0
 pkgver=${_qtver/-/}
 pkgrel=1
 pkgdesc='Provides access to Bluetooth hardware (mingw-w64)'
@@ -24,7 +24,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "rsync")
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('8ed321b242f0e956473a295fa31670271f9b3acb797508644cb740f89f6c08e8')
+sha256sums=('bbbefb6cc07507fcc961362b3380553eba6400aa15480600126793ba3dc21788')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-datavis3d/PKGBUILD
+++ b/mingw-w64-qt6-datavis3d/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-datavis3d
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.7.2
+_qtver=6.8.0
 pkgver=${_qtver/-/}
 pkgrel=1
 pkgdesc='Qt6 Data Visualization module (mingw-w64)'
@@ -25,7 +25,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "rsync")
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('c0ebc87d95deb595106fc68ed7e6de05149a18917d68cff40905c57fc6694e53')
+sha256sums=('35f2965d13b078d6ca42c76d70a491042f0b0b533b2ec4d12ecc35e282534cff')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-declarative/PKGBUILD
+++ b/mingw-w64-qt6-declarative/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-declarative
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.7.2
+_qtver=6.8.0
 pkgver=${_qtver/-/}
 pkgrel=1
 pkgdesc='Classes for QML and JavaScript languages (mingw-w64)'
@@ -26,7 +26,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz"
         001-appending-qt6-to-remove-qt5-conflict.patch)
-sha256sums=('4c29cba1af8c42d425d8eb6e01bad24cb80f4b983d71eef566a0542dfdb9b999'
+sha256sums=('3b41a36b42e919a3aa0da1f71107591504200f41707bee2ad8e8d4f99b5644c2'
             'b08b7a9cd263eaa2f09ec1b7718d79c253b4e30f3a1f47df6c89fa2e85d7659d')
 
 # Helper macros to help make tasks easier #

--- a/mingw-w64-qt6-languageserver/PKGBUILD
+++ b/mingw-w64-qt6-languageserver/PKGBUILD
@@ -2,9 +2,8 @@
 
 _realname=qt6-languageserver
 pkgbase=mingw-w64-${_realname}
-pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
-         "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.7.2
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+_qtver=6.8.0
 pkgver=${_qtver/-/}
 pkgrel=1
 pkgdesc='Qt Language Server (mingw-w64)'
@@ -17,14 +16,15 @@ msys2_references=(
   "cpe: cpe:/a:qt:qt"
 )
 license=('spdx:LGPL-3.0-only WITH Qt-GPL-exception-1.0 AND BSD-3-Clause AND GFDL-1.3-no-invariants-only AND GPL-2.0-only AND GPL-3.0-only')
+depends=("${MINGW_PACKAGE_PREFIX}-qt6-base")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
-             "${MINGW_PACKAGE_PREFIX}-qt6-base"
-             "rsync")
+             "${MINGW_PACKAGE_PREFIX}-qt6-base")
+groups=("${MINGW_PACKAGE_PREFIX}-qt6")
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('b659fe655144ffa061e3ae509eadb42ae373230517295a96935434340e101a92')
+sha256sums=('fbf7152c8ca4d1dbdd30205e64a830f378d7ac5ac0b5f02eecab9d7501065cef')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
@@ -40,35 +40,9 @@ build() {
   ${MINGW_PREFIX}/bin/cmake --build .
 }
 
-package_qt6-languageserver() {
-  depends=("${MINGW_PACKAGE_PREFIX}-qt6-base")
-  groups=("${MINGW_PACKAGE_PREFIX}-qt6")
-
+package() {
   DESTDIR=${pkgdir} ${MINGW_PREFIX}/bin/cmake --install build-${MSYSTEM}
-
-  # Seperate debug-info files
-  rsync -armR --remove-source-files --include="*/" --include="*.debug" --exclude="*" --prune-empty-dirs ${pkgdir}/.${MINGW_PREFIX} ${srcdir}/${MSYSTEM}-debug/
 
   install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_realname}
   install -Dm644 $_pkgfn/LICENSES/* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_realname}
 }
-
-package_qt6-languageserver-debug() {
-  depends=("${MINGW_PACKAGE_PREFIX}-qt6-base-debug"
-           "${MINGW_PACKAGE_PREFIX}-${_realname}")
-  groups=("${MINGW_PACKAGE_PREFIX}-qt6-debug")
-  options=('!strip')
-
-  cp -rf ${srcdir}/${MSYSTEM}-debug${MINGW_PREFIX} "${pkgdir}"/
-}
-
-# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
-# vim: set ft=bash :
-
-# generate wrappers
-for _name in "${pkgname[@]}"; do
-  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
-  _func="$(declare -f "${_short}")"
-  eval "${_func/#${_short}/package_${_name}}"
-done
-# template end;

--- a/mingw-w64-qt6-multimedia/PKGBUILD
+++ b/mingw-w64-qt6-multimedia/PKGBUILD
@@ -6,9 +6,9 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-ffmpeg"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-wmf")
-_qtver=6.7.2
+_qtver=6.8.0
 pkgver=${_qtver/-/}
-pkgrel=2
+pkgrel=1
 pkgdesc='Classes for audio, video, radio and camera functionality (mingw-w64)'
 arch=(any)
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -31,7 +31,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz"
         001-export-some-constexpr-variables.patch)
-sha256sums=('8ef835115acb9a1d3d2c9f23cfacb43f2c537e3786a8ab822299a2a7765651d3'
+sha256sums=('28766aa562fa7aa7dfa8420defd6ece90a891a0496b8d8a4c51958182d73cfcd'
             'e1694338779eb499341618c62d11f832f2b7f1f90c8a20345932530a61203105')
 
 prepare() {

--- a/mingw-w64-qt6-quick3d/PKGBUILD
+++ b/mingw-w64-qt6-quick3d/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-quick3d
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.7.2
+_qtver=6.8.0
 pkgver=${_qtver/-/}
 pkgrel=1
 pkgdesc='Qt module and API for defining 3D content in Qt Quick (mingw-w64)'
@@ -29,7 +29,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz"
         001-appending-qt6-to-remove-qt5-conflict.patch)
-sha256sums=('bb8ff9aec6da2e2d3b3986cc859333a98b2f3d4bbe564c5733e8f1a089d15270'
+sha256sums=('3e95044ee2da33db1a6fa3f834b09e71b2491c4899bac3a3bdf0c10b06f0223f'
             '211bb1f042bf9c0ddedb15b0e3d62b94e3b247dc96294fd92f4d8035784f1c7d')
 
 # Helper macros to help make tasks easier #

--- a/mingw-w64-qt6-quicktimeline/PKGBUILD
+++ b/mingw-w64-qt6-quicktimeline/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-quicktimeline
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.7.2
+_qtver=6.8.0
 pkgver=${_qtver/-/}
 pkgrel=1
 pkgdesc='Qt module for keyframe-based timeline construction (mingw-w64)'
@@ -24,7 +24,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "rsync")
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('21eddea01cf095cede10362eea4fb8402ffd06868c88d50a757c8c1f6b0719eb')
+sha256sums=('1106a41bd8081903058a47a2bca3a147d594d15cc21006aa45f38c6e1dd91f08')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-shadertools/PKGBUILD
+++ b/mingw-w64-qt6-shadertools/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-shadertools
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.7.2
+_qtver=6.8.0
 pkgver=${_qtver/-/}
 pkgrel=1
 pkgdesc='APIs and tools in this module provide the producer functionality for the shader pipeline that allows Qt Quick to operate on Vulkan, Metal, and Direct3D, in addition to OpenGL. (mingw-w64)'
@@ -25,7 +25,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "rsync")
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('edfa34c0ac8c00fcaa949df1d8e7a77d89dadd6386e683ce6c3e3b117e2f7cc1')
+sha256sums=('44692dc93482374bf3b39e96c881fa08275f0bf82958b68a7e3c796b76d4c4cb')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-svg/PKGBUILD
+++ b/mingw-w64-qt6-svg/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-svg
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.7.2
+_qtver=6.8.0
 pkgver=${_qtver/-/}
 pkgrel=1
 pkgdesc='Classes for displaying the contents of SVG files (mingw-w64)'
@@ -24,7 +24,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "rsync")
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('fb0d1286a35be3583fee34aeb5843c94719e07193bdf1d4d8b0dc14009caef01')
+sha256sums=('cf7a593d5e520f8177240610d9e55d5b75b0887fe5f385554ff64377f1646199')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}

--- a/mingw-w64-qt6-tools/PKGBUILD
+++ b/mingw-w64-qt6-tools/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-tools
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.7.2
+_qtver=6.8.0
 pkgver=${_qtver/-/}
 pkgrel=1
 pkgdesc='A cross-platform application and UI framework (Development Tools, QtHelp) (mingw-w64)'
@@ -29,7 +29,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz"
         001-appending-qt6-to-remove-qt5-conflict.patch)
-sha256sums=('58e855ad1b2533094726c8a425766b63a04a0eede2ed85086860e54593aa4b2a'
+sha256sums=('403115d8268503c6cc6e43310c8ae28eb9e605072a5d04e4a2de8b6af39981f7'
             '1f6e7a9be264e4679090fb0b6f10e702cee099b270802ca08910baed38030b4c')
 
 # Helper macros to help make tasks easier #

--- a/mingw-w64-qt6-translations/PKGBUILD
+++ b/mingw-w64-qt6-translations/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=qt6-translations
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-_qtver=6.7.2
+_qtver=6.8.0
 pkgver=${_qtver/-/}
 pkgrel=1
 pkgdesc='A cross-platform application and UI framework (Translations) (mingw-w64)'
@@ -24,7 +24,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 groups=("${MINGW_PACKAGE_PREFIX}-qt6")
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz")
-sha256sums=('9845780b5dc1b7279d57836db51aeaf2e4a1160c42be09750616f39157582ca9')
+sha256sums=('84bf2b67c243cd0c50a08acd7bfa9df2b1965028511815c1b6b65a0687437cb6')
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}


### PR DESCRIPTION
* Rebase qt6-base patches.
* Import a patch to fix qt6-base compilation.
* Remove debug package for qt6-languageserver because it now builds static library only without debug files.

Fixes #22267

