### PR TITLE
gmsh: update to 4.13.1

### DIFF
--- a/mingw-w64-gmsh/PKGBUILD
+++ b/mingw-w64-gmsh/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=gmsh
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.11.1
-pkgrel=3
+pkgver=4.13.1
+pkgrel=1
 pkgdesc="3D finite element mesh generator with built-in CAD engine and post-processor (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -28,14 +28,10 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 source=(https://gmsh.info/src/gmsh-${pkgver}-source.tgz
         0001-fix-link-lib-name.patch
-        0002-fix-dynamic-linking.patch
-        0003-missing-include.patch::https://gitlab.onelab.info/gmsh/gmsh/-/commit/fb81a9c9.patch
-        0004-missing-include-2.patch::https://gitlab.onelab.info/gmsh/gmsh/-/commit/aceb09c8.patch)
-sha256sums=('c5fe1b7cbd403888a814929f2fd0f5d69e27600222a18c786db5b76e8005b365'
+        0002-fix-dynamic-linking.patch)
+sha256sums=('77972145f431726026d50596a6a44fb3c1c95c21255218d66955806b86edbe8d'
             'e575ae8fc757694affb6749dc9d52c336691b06159845655ef2ac27aebae8159'
-            '4d3f5c4190529e3d45b786adab83f0d65e726357d7367f682ff95b733a88a8c3'
-            'c315dc4912191b2821fe44b9e75799cb6503bf800010c6bb9d34ee0ed5f0398f'
-            'beb9404bbb9377e6240b369dd70cfc317209202cb32bdc55f4e6fc5837b2da12')
+            '4d3f5c4190529e3d45b786adab83f0d65e726357d7367f682ff95b733a88a8c3')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -50,9 +46,7 @@ prepare() {
 
   apply_patch_with_msg \
     0001-fix-link-lib-name.patch \
-    0002-fix-dynamic-linking.patch \
-    0003-missing-include.patch \
-    0004-missing-include-2.patch
+    0002-fix-dynamic-linking.patch
 }
 
 build() {


### PR DESCRIPTION
Remove patches from upstream that are part of the newer version.