### PR TITLE
openssl: Update to 3.4.0

### DIFF
--- a/mingw-w64-openssl/002-relocation.patch
+++ b/mingw-w64-openssl/002-relocation.patch
@@ -1,114 +1,60 @@
---- a/crypto/build.info
-+++ b/crypto/build.info
+--- openssl-3.4.0/crypto/defaults.c.orig	2024-10-26 22:31:02.982502600 +0200
++++ openssl-3.4.0/crypto/defaults.c	2024-10-26 22:42:06.278689000 +0200
+@@ -12,6 +12,7 @@
+ #include "internal/thread_once.h"
+ #include "internal/cryptlib.h"
+ #include "internal/e_os.h"
++#include "pathtools.h"
+ 
+ #if defined(_WIN32) && defined(OSSL_WINCTX)
+ 
+@@ -148,6 +149,12 @@
+     if (!RUN_ONCE(&defaults_setup_init, do_defaults_setup))
+         return NULL;
+     return (const char *)openssldirptr;
++#elif defined(__MINGW32__)
++    static char * reloc = NULL;
++    if (reloc == NULL) {
++        reloc = single_path_relocation_lib(OPENSSLBIN, OPENSSLDIR);
++    }
++    return reloc;
+ # else
+     return OPENSSLDIR;
+ #endif
+@@ -164,6 +171,12 @@
+     if (!RUN_ONCE(&defaults_setup_init, do_defaults_setup))
+         return NULL;
+     return (const char *)enginesdirptr;
++#elif defined(__MINGW32__)
++    static char * reloc = NULL;
++    if (reloc == NULL) {
++        reloc = single_path_relocation_lib(OPENSSLBIN, ENGINESDIR);
++    }
++    return reloc;
+ #else
+     return ENGINESDIR;
+ #endif
+@@ -180,6 +193,12 @@
+     if (!RUN_ONCE(&defaults_setup_init, do_defaults_setup))
+         return NULL;
+     return (const char *)modulesdirptr;
++#elif defined(__MINGW32__)
++    static char * reloc = NULL;
++    if (reloc == NULL) {
++        reloc = single_path_relocation_lib(OPENSSLBIN, MODULESDIR);
++    }
++    return reloc;
+ #else
+     return MODULESDIR;
+ #endif
+--- openssl-3.4.0/crypto/build.info.orig	2024-10-22 14:26:59.000000000 +0200
++++ openssl-3.4.0/crypto/build.info	2024-10-26 22:39:26.015573200 +0200
 @@ -107,7 +107,7 @@
-         cversion.c info.c cpt_err.c ebcdic.c uid.c o_time.c o_dir.c \
-         o_fopen.c getenv.c o_init.c init.c trace.c provider.c provider_child.c \
-         punycode.c passphrase.c sleep.c deterministic_nonce.c quic_vlint.c \
--        time.c
-+        time.c pathtools.c
+         comp_methods.c cversion.c info.c cpt_err.c ebcdic.c uid.c o_time.c \
+         o_dir.c o_fopen.c getenv.c o_init.c init.c trace.c provider.c \
+         provider_child.c punycode.c passphrase.c sleep.c deterministic_nonce.c \
+-        quic_vlint.c time.c defaults.c
++        quic_vlint.c time.c defaults.c pathtools.c
  SOURCE[../providers/libfips.a]=$UTIL_COMMON
  
  SOURCE[../libcrypto]=$UPLINKSRC
---- a/crypto/engine/eng_list.c
-+++ b/crypto/engine/eng_list.c
-@@ -12,6 +12,7 @@
- #define OPENSSL_SUPPRESS_DEPRECATED
- 
- #include "eng_local.h"
-+#include "pathtools.h"
- 
- /*
-  * The linked-list of pointers to engine types. engine_list_head incorporates
-@@ -454,8 +455,13 @@
-      * Prevent infinite recursion if we're looking for the dynamic engine.
-      */
-     if (strcmp(id, "dynamic")) {
--        if ((load_dir = ossl_safe_getenv("OPENSSL_ENGINES")) == NULL)
--            load_dir = ENGINESDIR;
-+        if ((load_dir = ossl_safe_getenv("OPENSSL_ENGINES")) == NULL) {
-+            static char * reloc = NULL;
-+            if (reloc == NULL) {
-+                reloc = single_path_relocation_lib(OPENSSLBIN, ENGINESDIR);
-+            }
-+            load_dir = reloc;
-+        }
-         iterator = ENGINE_by_id("dynamic");
-         if (!iterator || !ENGINE_ctrl_cmd_string(iterator, "ID", id, 0) ||
-             !ENGINE_ctrl_cmd_string(iterator, "DIR_LOAD", "2", 0) ||
---- a/crypto/x509/x509_def.c
-+++ b/crypto/x509/x509_def.c
-@@ -9,27 +9,44 @@
- 
- #include <stdio.h>
- #include "internal/cryptlib.h"
-+#include "pathtools.h"
- #include <openssl/crypto.h>
- #include <openssl/x509.h>
- 
- const char *X509_get_default_private_dir(void)
- {
--    return X509_PRIVATE_DIR;
-+    static char * reloc = NULL;
-+    if (reloc == NULL) {
-+        reloc = single_path_relocation_lib(OPENSSLBIN, X509_PRIVATE_DIR);
-+    }
-+    return reloc;
- }
- 
- const char *X509_get_default_cert_area(void)
- {
--    return X509_CERT_AREA;
-+    static char * reloc = NULL;
-+    if (reloc == NULL) {
-+        reloc = single_path_relocation_lib(OPENSSLBIN, X509_CERT_AREA);
-+    }
-+    return reloc;
- }
- 
- const char *X509_get_default_cert_dir(void)
- {
--    return X509_CERT_DIR;
-+    static char * reloc = NULL;
-+    if (reloc == NULL) {
-+        reloc = single_path_relocation_lib(OPENSSLBIN, X509_CERT_DIR);
-+    }
-+    return reloc;
- }
- 
- const char *X509_get_default_cert_file(void)
- {
--    return X509_CERT_FILE;
-+    static char * reloc = NULL;
-+    if (reloc == NULL) {
-+        reloc = single_path_relocation_lib(OPENSSLBIN, X509_CERT_FILE);
-+    }
-+    return reloc;
- }
- 
- const char *X509_get_default_cert_dir_env(void)
---- a/crypto/provider_core.c
-+++ b/crypto/provider_core.c
-@@ -30,6 +30,7 @@
- #include "internal/core.h"
- #include "provider_local.h"
- #include "crypto/context.h"
-+#include "pathtools.h"
- #ifndef FIPS_MODULE
- # include <openssl/self_test.h>
- #endif
-@@ -916,8 +917,13 @@
- 
-             if (load_dir == NULL) {
-                 load_dir = ossl_safe_getenv("OPENSSL_MODULES");
--                if (load_dir == NULL)
--                    load_dir = MODULESDIR;
-+                if (load_dir == NULL) {
-+                    static char * reloc = NULL;
-+                    if (reloc == NULL) {
-+                        reloc = single_path_relocation_lib(OPENSSLBIN, MODULESDIR);
-+                    }
-+                    load_dir = reloc;
-+                }
-             }
- 
-             DSO_ctrl(prov->module, DSO_CTRL_SET_FLAGS,

--- a/mingw-w64-openssl/PKGBUILD
+++ b/mingw-w64-openssl/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=openssl
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=3.3.2
+pkgver=3.4.0
 pkgrel=1
 pkgdesc="The Open Source toolkit for Secure Sockets Layer and Transport Layer Security (mingw-w64)"
 arch=('any')
@@ -24,10 +24,10 @@ source=("https://github.com/openssl/openssl/releases/download/openssl-${pkgver}/
         '002-relocation.patch'
         'pathtools.c'
         'pathtools.h')
-sha256sums=('2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281'
+sha256sums=('e15dda82fe2fe8139dc2ac21a36d4ca01d5313c75f99f46c4e8a27709b7294bf'
             'SKIP'
             '21b96771b401442570e885c2d5689a359a91e86dcbf5511db3667202b6c1fa8a'
-            '8a2d91826bd1a8fd6d3a981d2a71cfb3170060f64a053eafd8e3b32f6a30ac3b'
+            '163f01573b83a12df4bec2022339d0517cbb779538e7d2d0c0bb25da50614f5a'
             'ebf471173f5ee9c4416c10a78760cea8afaf1a4a6e653977321e8547ce7bf3c0'
             '1585ef1b61cf53a2ca27049c11d49e0834683dfda798f03547761375df482a90')
 # https://openssl-library.org/source/index.html
@@ -109,7 +109,7 @@ check() {
 package() {
   cd "${srcdir}/build-${MSYSTEM}"
 
-  make install DESTDIR="${pkgdir}"
+  make -j1 install DESTDIR="${pkgdir}"
 
   # https://github.com/openssl/openssl/issues/24298
   for pcfile in "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/*.pc; do


### PR DESCRIPTION
Refresh 002-relocation.patch.

The whole openssl dir code was changed upstream and now has everything in one place with the option to read the dirs from the Windows registry if built with OSSL_WINCTX defined.

The registry parts are from what I see namespaced by version and written by the official installer, so we probably don't want to use that to avoid any conflicts with the official installation.

The upside though is that we need to add relocation in fewer places now, and even the "openssl info" commands will use the new functions to now show proper Windows paths instead of the configure time cygwin ones.

Besides that there shouldn't be any functional change.