### PR TITLE
tree-sitter, libwasmtime: remove static libs

### DIFF
--- a/mingw-w64-tree-sitter/PKGBUILD
+++ b/mingw-w64-tree-sitter/PKGBUILD
@@ -4,7 +4,7 @@ _realname=tree-sitter
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.24.3
-pkgrel=1
+pkgrel=2
 pkgdesc="An incremental parsing system for programming tools (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -29,14 +29,6 @@ source=("https://github.com/tree-sitter/tree-sitter/archive/v${pkgver}/${_realna
 sha256sums=('0a8d0cf8e09caba22ed0d8439f7fa1e3d8453800038e43ccad1f34ef29537da1')
 noextract=("${_realname}-${pkgver}.tar.gz")
 
-_env() {
-  export LIBGIT2_NO_VENDOR=1
-  export OPENSSL_NO_VENDOR=1
-  export PKG_CONFIG_ALL_DYNAMIC=1
-  export LIBSSH2_SYS_USE_PKG_CONFIG=1
-  export MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX="
-}
-
 prepare() {
   tar -xzf "${_realname}-${pkgver}.tar.gz" || true
   cd "${_realname}-${pkgver}"
@@ -52,19 +44,11 @@ build() {
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
-  _env
-  cmake \
-    -GNinja \
-    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
-    "${extra_config[@]}" \
-    -DBUILD_SHARED_LIBS=OFF \
-    -DTREE_SITTER_FEATURE_WASM=ON \
-    -DWASMTIME_INCLUDE_DIR="${MINGW_PREFIX}/include/wasmtime" \
-    -DWASMTIME_LIBRARY="${MINGW_PREFIX}/lib/libwasmtime.a" \
-    -S "${_realname}-${pkgver}/lib" \
-    -B "build-${MSYSTEM}-static"
-
-  cmake --build "build-${MSYSTEM}-static"
+  export LIBGIT2_NO_VENDOR=1
+  export OPENSSL_NO_VENDOR=1
+  export LIBSSH2_SYS_USE_PKG_CONFIG=1
+  export MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX="
+  export CFLAGS+=" -Wno-incompatible-pointer-types"
 
   cmake \
     -GNinja \
@@ -75,9 +59,9 @@ build() {
     -DWASMTIME_INCLUDE_DIR="${MINGW_PREFIX}/include/wasmtime" \
     -DWASMTIME_LIBRARY="${MINGW_PREFIX}/bin/wasmtime.dll" \
     -S "${_realname}-${pkgver}/lib" \
-    -B "build-${MSYSTEM}-shared"
+    -B "build-${MSYSTEM}"
 
-  cmake --build "build-${MSYSTEM}-shared"
+  cmake --build "build-${MSYSTEM}"
 
   cargo build \
     --frozen \
@@ -86,8 +70,7 @@ build() {
 }
 
 package() {
-  DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}-static"
-  DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}-shared"
+  DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}"
 
   install -m755 "${_realname}-${pkgver}/target/optimize/tree-sitter.exe" "${pkgdir}${MINGW_PREFIX}/bin/tree-sitter.exe"
 

--- a/mingw-w64-wasmtime/PKGBUILD
+++ b/mingw-w64-wasmtime/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-lib${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
 pkgver=26.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A fast and secure runtime for WebAssembly (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -58,26 +58,14 @@ build() {
   cmake \
     -GNinja \
     -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
-    -DBUILD_SHARED_LIBS=OFF \
-    -DWASMTIME_FASTEST_RUNTIME=ON \
-    -DWASMTIME_TARGET="$(rustc -vV | sed -n 's/host: //p')" \
-    "${extra_config[@]}" \
-    -S "${_realname}/crates/c-api" \
-    -B "build-${MSYSTEM}-static"
-
-  cmake --build "build-${MSYSTEM}-static"
-
-  cmake \
-    -GNinja \
-    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
     -DBUILD_SHARED_LIBS=ON \
     -DWASMTIME_FASTEST_RUNTIME=ON \
     -DWASMTIME_TARGET="$(rustc -vV | sed -n 's/host: //p')" \
     "${extra_config[@]}" \
     -S "${_realname}/crates/c-api" \
-    -B "build-${MSYSTEM}-shared"
+    -B "build-${MSYSTEM}"
 
-  cmake --build "build-${MSYSTEM}-shared"
+  cmake --build "build-${MSYSTEM}"
 
   cargo build \
     --frozen \
@@ -111,15 +99,15 @@ package_wasmtime() {
 package_libwasmtime() {
   pkgdesc+=' (C-API)'
   conflicts=("${MINGW_PACKAGE_PREFIX}-libwasmer")
-  options=('!strip')
 
-  DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}-static"
-  DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}-shared"
-  install -Dm644 "build-${MSYSTEM}-shared/include/wasmtime/conf.h" \
+  DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}"
+  install -Dm644 "build-${MSYSTEM}/include/wasmtime/conf.h" \
     "${pkgdir}${MINGW_PREFIX}/include/wasmtime/conf.h"
   install -d "${pkgdir}${MINGW_PREFIX}/bin"
 
   mv "${pkgdir}${MINGW_PREFIX}/lib/wasmtime.dll" "${pkgdir}${MINGW_PREFIX}/bin/wasmtime.dll"
+  rm "${pkgdir}${MINGW_PREFIX}/lib/libwasmtime.a"
+
   install -Dm644 "${_realname}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/lib${_realname}/LICENSE"
 }
 


### PR DESCRIPTION
libwasmtime.a is broken, so make both packages dynamic only