### PR TITLE
rust: enable Control Flow Guard on gnullvm

### DIFF
--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -20,7 +20,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-rust-wasm")
          "${MINGW_PACKAGE_PREFIX}-rust-src")
 pkgver=1.83.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -60,7 +60,7 @@ sha256sums=('722d773bd4eab2d828d7dd35b59f0b017ddf9a97ee2b46c1b7f7fac5c8841c6e'
             'SKIP'
             '24ef6d949c0b5b1940c1d6a7aad78d86012152fb8845a1644bc939350d7b75e2'
             '200b9ff220857e53e184257720a14553b2f4aa02577d2ed9842d45d4b9654810'
-            '832765ebf86dca77ea371decb9937f77dbf3a377cbb2240d9016f2a82d23b363'
+            '82b8ece75c57053765ab295120264ae06cfdb2c0d29332f921498bbbdfd5dfe1'
             '7cb1773c288ffb1c1e751edc49b1890c84bf9c362742bc5225d19d474edb73a0'
             '56882f1a0f1404c10c7726d6cc37444f2b343e72b969badfcb43760f80db0f32'
             '98bc3f2bd7371a5b8d14fd7b03bf05574e206d1d9e52bcfbe66d71398504da3c'
@@ -183,6 +183,11 @@ build() {
   # Add target wasm32-*
   if [[ ${CARCH} != i686 ]]; then
     sed -i '/target = \[/a\  "wasm32-unknown-unknown", "wasm32-wasip1", "wasm32-wasip1-threads", "wasm32-wasip2",' "../${_realname}c-${pkgver}-src/config.toml"
+  fi
+
+  # Enable CFGuard for gnullvm
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then
+    sed -i "s/^#control-flow-guard/control-flow-guard/g" "../${_realname}c-${pkgver}-src/config.toml"
   fi
 
   # Building out of tree is not officially supported so we have to workaround some things like vendored deps

--- a/mingw-w64-rust/config.toml
+++ b/mingw-w64-rust/config.toml
@@ -50,8 +50,8 @@ lld = false
 codegen-tests = false
 deny-warnings = false
 backtrace-on-ice = true
-# FIXME: CFG can be enabled only for MSVC targets as for https://github.com/rust-lang/rust/pull/74103
-# control-flow-guard = true
+# FIXME: CFG is enabled for gnullvm targets only
+#control-flow-guard = true
 
 [dist]
 compression-formats = ["gz"]


### PR DESCRIPTION
It works but not sure whether we should do it.