### PR TITLE
python-nidaqmx: new package

### DIFF
--- a/mingw-w64-python-decouple/PKGBUILD
+++ b/mingw-w64-python-decouple/PKGBUILD
@@ -1,0 +1,38 @@
+# Maintainer: fsagbuya <fa@m-labs.ph>
+
+_realname=python-decouple
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=3.8
+pkgrel=1
+pkgdesc="Decouple helps you to organize your settings so that you can change parameters without having to redeploy your app (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url="https://github.com/HBNetwork/python-decouple"
+msys2_references=(
+  'pypi: python-decouple'
+)
+license=('spdx:MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('ba6e2657d4f376ecc46f77a3a615e058d93ba5e465c01bbe57289bfb7cce680f')
+
+build() {
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}

--- a/mingw-w64-python-hightime/PKGBUILD
+++ b/mingw-w64-python-hightime/PKGBUILD
@@ -1,0 +1,45 @@
+# Maintainer: fsagbuya <fa@m-labs.ph>
+
+_realname=hightime
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=0.2.2
+pkgrel=1
+pkgdesc="Hightime allows for up to yoctosecond precision replacements for the datetime datetime and timedelta types (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url="https://github.com/ni/hightime"
+msys2_references=(
+  'pypi: hightime'
+)
+license=('spdx:MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
+options=('!strip')
+source=("${_realname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('058996409f78c58d603188138ab17b800fa9e6ae600bfb18f0ed9727f0447660')
+
+build() {
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+check() {
+  cd "python-build-${MSYSTEM}"
+
+  python -m pytest tests || warning "Tests failed"
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}

--- a/mingw-w64-python-nidaqmx/0001-use-poetry-core-backend.patch
+++ b/mingw-w64-python-nidaqmx/0001-use-poetry-core-backend.patch
@@ -1,0 +1,15 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 3779276..b5f3a81 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -127,8 +127,8 @@ markers = [
+ ]
+ 
+ [build-system]
+-requires = ["poetry>=1.2"]
+-build-backend = "poetry.masonry.api"
++requires = ["poetry-core"]
++build-backend = "poetry.core.masonry.api"
+ 
+ [tool.mypy]
+ files = "generated/,tests/"

--- a/mingw-w64-python-nidaqmx/PKGBUILD
+++ b/mingw-w64-python-nidaqmx/PKGBUILD
@@ -1,0 +1,54 @@
+# Maintainer: fsagbuya <fa@m-labs.ph>
+
+_realname=nidaqmx
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=1.0.1
+pkgrel=1
+pkgdesc="A Python API for interacting with NI-DAQmx (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url="https://nidaqmx-python.readthedocs.io/"
+msys2_repository_url="https://github.com/ni/nidaqmx-python"
+msys2_references=(
+    'pypi: nidaqmx'
+)
+license=('spdx:MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-click"
+         "${MINGW_PACKAGE_PREFIX}-python-decouple"
+         "${MINGW_PACKAGE_PREFIX}-python-deprecation"
+         "${MINGW_PACKAGE_PREFIX}-python-hightime"
+         "${MINGW_PACKAGE_PREFIX}-python-numpy"
+         "${MINGW_PACKAGE_PREFIX}-python-requests"
+         "${MINGW_PACKAGE_PREFIX}-python-tzlocal")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-poetry-core")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
+        "0001-use-poetry-core-backend.patch")
+sha256sums=('fcbb0ff8f1f618b38ea5fab8a8c6ed24cc32d4b4e935cb1221ce4480e428de9f'
+            '243c74402bdb75bd9dd668f4e879f300a5bca2156c5969f225f48ab00a4fe899')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+
+  patch -Np1 -i "${srcdir}/0001-use-poetry-core-backend.patch"
+}
+
+build() {
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}

--- a/mingw-w64-python-tzlocal/PKGBUILD
+++ b/mingw-w64-python-tzlocal/PKGBUILD
@@ -1,0 +1,39 @@
+# Maintainer: fsagbuya <fa@m-labs.ph>
+
+_realname=tzlocal
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=5.2
+pkgrel=1
+pkgdesc="tzinfo object for the local timezone (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url="https://github.com/regebro/tzlocal"
+msys2_references=(
+  'pypi: tzlocal'
+)
+license=('spdx:MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-tzdata")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('8d399205578f1a9342816409cc1e46a93ebd5755e39ea2d85334bea911bf0e6e')
+
+build() {
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}


### PR DESCRIPTION
### Description

Added `python-nidaqmx` package.

Tested in `CLANG64` shell:
```
$ python
Python 3.11.9 (main, Apr 12 2024, 09:55:30)  [GCC Clang 18.1.3 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import nidaqmx
>>> print(nidaqmx.__version__)
1.0.1
```

Need to package dependencies:
- [x] hightime
- [x] python-decouple
- [x] tzlocal