### PR TITLE
CI: change order of jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,10 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          { msystem: MINGW64, runner: windows-2022 },
-          { msystem: MINGW32, runner: windows-2022 },
           { msystem: UCRT64, runner: windows-2022 },
           { msystem: CLANG64, runner: windows-2022 },
+          { msystem: MINGW64, runner: windows-2022 },
+          { msystem: MINGW32, runner: windows-2022 },
           { msystem: CLANG32, runner: windows-2022 },
           # { msystem: CLANGARM64, runner: ['Windows', 'ARM64', 'CI'] }
         ]


### PR DESCRIPTION
so it will be sorted by priority: UCRT64 -> CLANG64 -> MINGW64 -> MINGW32 -> CLANG32. this changes the default job shown in "checks" tab, as it's a bit annoying to switch to UCRT64 job because MINGW64 is disabled for a particular package