### PR TITLE
python3.12: add `EXTERNALLY-MANAGED` for PEP 668

### DIFF
--- a/mingw-w64-python3.12/EXTERNALLY-MANAGED
+++ b/mingw-w64-python3.12/EXTERNALLY-MANAGED
@@ -1,0 +1,15 @@
+[externally-managed]
+Error=To install Python packages system-wide, try 'pacman -S
+ $MINGW_PACKAGE_PREFIX-python-xyz', where xyz is the package you
+ are trying to install.
+
+ If you wish to install a non-MSYS2-packaged Python package,
+ create a virtual environment using 'python -m venv path/to/venv'.
+ Then use path/to/venv/bin/python and path/to/venv/bin/pip.
+
+ If you wish to install a non-MSYS2 packaged Python application,
+ it may be easiest to use 'pipx install xyz', which will manage a
+ virtual environment for you. Make sure you have $MINGW_PACKAGE_PREFIX-python-pipx
+ installed via pacman.
+
+

--- a/mingw-w64-python3.12/PKGBUILD
+++ b/mingw-w64-python3.12/PKGBUILD
@@ -369,6 +369,10 @@ package() {
   install -m755 "${srcdir}/Python-${pkgver}"/Tools/i18n/{msgfmt,pygettext}.py "${pkgdir}${MINGW_PREFIX}"/lib/python${_pybasever}/Tools/i18n/
   install -m755 "${srcdir}/Python-${pkgver}"/Tools/scripts/{README,*py} "${pkgdir}${MINGW_PREFIX}"/lib/python${_pybasever}/Tools/scripts/
 
+  # License
+  install -Dm644 "${srcdir}/Python-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}${_pybasever}/LICENSE"
+
+
   # fixup shebangs
   for fscripts in 2to3 2to3-${_pybasever} idle3 idle${_pybasever} pydoc3 pydoc${_pybasever}; do
     sed -e '1 { s|^#!.*$|#!/usr/bin/env python'"${_pybasever}"'.exe| }' -i "${pkgdir}${MINGW_PREFIX}"/bin/${fscripts}

--- a/mingw-w64-python3.12/PKGBUILD
+++ b/mingw-w64-python3.12/PKGBUILD
@@ -23,7 +23,7 @@ else
   pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}${_pybasever}")
 fi
 pkgver=${_pybasever}.5
-pkgrel=1
+pkgrel=2
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -53,6 +53,7 @@ makedepends=(
 )
 #options=('debug' '!strip')
 source=("https://www.python.org/ftp/python/${pkgver%rc?}/Python-${pkgver}.tar.xz"
+        "EXTERNALLY-MANAGED"
         0001-sysconfig-make-_sysconfigdata.py-relocatable.patch
         0002-build-add-with-nt-threads-and-make-it-default-on-min.patch
         0003-Define-MS_WINDOWS-and-others-when-compiling-with-MIN.patch
@@ -372,6 +373,8 @@ package() {
   # License
   install -Dm644 "${srcdir}/Python-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}${_pybasever}/LICENSE"
 
+  # PEP668
+  install -Dm644 "${srcdir}/EXTERNALLY-MANAGED" -t "${pkgdir}${MINGW_PREFIX}/lib/python${_pybasever}/"
 
   # fixup shebangs
   for fscripts in 2to3 2to3-${_pybasever} idle3 idle${_pybasever} pydoc3 pydoc${_pybasever}; do
@@ -405,6 +408,7 @@ package() {
 }
 
 sha256sums=('fa8a2e12c5e620b09f53e65bcd87550d2e5a1e2e04bf8ba991dcc55113876397'
+            '3981fed74ee7d43ad69bd67e634e03d7bf6890558a87062380112e195688728a'
             'c25c4d3b262438814ceefbc938f7710766071b541f5e46c017162b1cf564a59e'
             'cacfd20cd8d5050d92967bd7f73fed374fe051ee0a8e44e5edbc2ac2cf21b5c6'
             '2f9841e5eb70404d20b4fb0fecf95b75438e50ae6b0080e370edb1fd6f58b710'


### PR DESCRIPTION
![mintty_uiVaiD9ym6](https://github.com/user-attachments/assets/0f48f62c-8c96-4b8e-bac2-bfc2f9725172)
