### PR TITLE
pip: in case of EXTERNALLY-MANAGED only warn instead of erroring out

### DIFF
--- a/mingw-w64-python-pip/0002-only-warn-for-externally-managed.patch
+++ b/mingw-w64-python-pip/0002-only-warn-for-externally-managed.patch
@@ -1,0 +1,13 @@
+--- pip-24.1.2/src/pip/_internal/utils/misc.py.orig	2024-07-07 20:36:57.000000000 +0200
++++ pip-24.1.2/src/pip/_internal/utils/misc.py	2024-11-02 11:26:52.752980600 +0100
+@@ -612,7 +612,9 @@
+     marker = os.path.join(sysconfig.get_path("stdlib"), "EXTERNALLY-MANAGED")
+     if not os.path.isfile(marker):
+         return
+-    raise ExternallyManagedEnvironment.from_config(marker)
++    exc = ExternallyManagedEnvironment.from_config(marker)
++    exc.kind = "warning"
++    logger.warning("%s", exc, extra={"rich": True})
+ 
+ 
+ def is_console_interactive() -> bool:

--- a/mingw-w64-python-pip/PKGBUILD
+++ b/mingw-w64-python-pip/PKGBUILD
@@ -8,7 +8,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=24.1.2
-pkgrel=2
+pkgrel=3
 pkgdesc="The PyPA recommended tool for installing Python packages. (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -29,14 +29,21 @@ options=('!strip')
 source=(
   "https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
   "0001-use-system-distlib.patch"
+  "0002-only-warn-for-externally-managed.patch"
 )
 sha256sums=('e5458a0b89f2755e0ee8c0c77613fe5273e05f337907874d64f13171a898a7ff'
-            'c7f98690afa60e59324f1ce52e72bd7809cbfaba4e29a2d933f08c1a025f8246')
+            'c7f98690afa60e59324f1ce52e72bd7809cbfaba4e29a2d933f08c1a025f8246'
+            'be196f12feee11fe1caccbdeff9a31ac077120de7b6e85679ea54b6dd2df8f5b')
 
 prepare() {
   cd "${_realname}-${pkgver}"
   rm -r src/pip/_vendor/distlib
   patch -p1 -i ${srcdir}/0001-use-system-distlib.patch
+
+  # To avoid breaking too many systems while still warning the users that it's not recommended
+  # to use pip outside of a venv, downgrade the error to a warning, for now.
+  # https://github.com/msys2/MINGW-packages/pull/22368#issuecomment-2452503886
+  patch -p1 -i ${srcdir}/0002-only-warn-for-externally-managed.patch
 }
 
 build() {


### PR DESCRIPTION
We want users to move away from breaking their systems with pip, and upstream provides PEP 668 for this where pip will error out if the system packages are marked as externally managed (by pacman in this case).

In MSYS2 though it's not that easy to use venvs (mixing with system site packages is sometimes required), though things have improved with setuptools/meson-python/rust tooling in the last year. Also in many cases MSYS2 is mainly used in CI, so it's fine to break things as it's just a temporary VM.

To get the message still out there we downgrade the error to warning.

In the future we can escalate this further by making it an error in non-CI envs, and adding a sleep in CI, so it gets annoying but doesn't break things right away.

![Screenshot 2024-11-02 112516](https://github.com/user-attachments/assets/e52be291-f0b8-4123-9cfe-60ee433f0ac1)
