### PR TITLE
zed: update to 0.159.9

### DIFF
--- a/mingw-w64-zed/PKGBUILD
+++ b/mingw-w64-zed/PKGBUILD
@@ -3,12 +3,11 @@
 _realname=zed
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.159.7
+pkgver=0.159.9
 pkgrel=1
 pkgdesc="A high-performance, multiplayer code editor (mingw-w64)"
 arch=('any')
-# ucrt64 is disabled due to https://github.com/msys2/MINGW-packages/issues/22071
-mingw_arch=('clang64')
+mingw_arch=('ucrt64' 'clang64')
 url='https://zed.dev'
 msys2_repository_url='https://github.com/zed-industries/zed'
 msys2_documentation_url='https://zed.dev/docs'
@@ -20,7 +19,8 @@ msys2_references=(
   'gentoo: app-editors/zed'
 )
 depends=(#"${MINGW_PACKAGE_PREFIX}-libgit2"
-         "${MINGW_PACKAGE_PREFIX}-zstd")
+         "${MINGW_PACKAGE_PREFIX}-zstd"
+         "${MINGW_PACKAGE_PREFIX}-nodejs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
@@ -29,6 +29,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-openssl"
              #"${MINGW_PACKAGE_PREFIX}-sqlite3"
              "${MINGW_PACKAGE_PREFIX}-cargo-about"
+             "${MINGW_PACKAGE_PREFIX}-lld"
              'git')
 options=('!lto')
 optdepends=("${MINGW_PACKAGE_PREFIX}-ollama: provides LLMs for assistance panel"
@@ -43,7 +44,7 @@ source=("git+${msys2_repository_url}.git#tag=v${pkgver}"
         "zed-dont-vendor-cargo-about.patch"
         "zed-use-vendored-pet.patch"
         "zstd-sys-remove-statik.patch")
-sha256sums=('eef61ba8de830f1d7beee5cd1acb4684d3c71cce12dd4de9e1b7929d52628f2e'
+sha256sums=('e825c83496809f5aa5aa22d0479b017d2a70a7bd1b92148f48e1b127fd4c76a4'
             '38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa'
             'c01a0af9ade104cd706ebe6b7f2c001f7f2a6a1f3379f6724589891e90819fbd'
             '5cbf1cb9c1e3436f8db242b74da519d12542dd94f720be4a8c1ece7cb54c849d'
@@ -92,6 +93,9 @@ build() {
   export ZED_UPDATE_EXPLANATION='Updates are handled by pacman'
   export CARGO_PROFILE_RELEASE_DEBUG=0
   export RELEASE_VERSION="${pkgver} (Rev${pkgrel}, Built by MSYS2 project)"
+  if [[ $MINGW_PACKAGE_PREFIX != *-clang-* ]]; then
+    export RUSTFLAGS+=" -Clink-arg=-fuse-ld=lld"
+  fi
 
   cargo build --release --frozen -p zed
 }


### PR DESCRIPTION
it's actually a dummy release to test the bot. update contains no changes, but I've found that using lld fixes #22071. I shouldn't have remove that workaround...