### PR TITLE
libplist: fix detection of newer Python versions

### DIFF
--- a/mingw-w64-libplist/001-ax_python_devel.patch
+++ b/mingw-w64-libplist/001-ax_python_devel.patch
@@ -1,0 +1,512 @@
+Update ax_python_devel.m4 with latest upstream version.
+
+Latest version can be downloaded from:
+https://git.savannah.gnu.org/gitweb/?p=autoconf-archive.git;a=blob_plain;f=m4/ax_python_devel.m4
+
+diff -urN libplist-2.6.0/m4/ax_python_devel.m4.orig libplist-2.6.0/m4/ax_python_devel.m4
+--- libplist-2.6.0/m4/ax_python_devel.m4.orig	2023-12-18 17:51:23.000000000 +0100
++++ libplist-2.6.0/m4/ax_python_devel.m4	2024-11-04 17:33:23.396575400 +0100
+@@ -4,7 +4,7 @@
+ #
+ # SYNOPSIS
+ #
+-#   AX_PYTHON_DEVEL([version])
++#   AX_PYTHON_DEVEL([version[,optional]])
+ #
+ # DESCRIPTION
+ #
+@@ -23,6 +23,11 @@
+ #   version number. Don't use "PYTHON_VERSION" for this: that environment
+ #   variable is declared as precious and thus reserved for the end-user.
+ #
++#   By default this will fail if it does not detect a development version of
++#   python.  If you want it to continue, set optional to true, like
++#   AX_PYTHON_DEVEL([], [true]).  The ax_python_devel_found variable will be
++#   "no" if it fails.
++#
+ #   This macro should work for all versions of Python >= 2.1.0. As an end
+ #   user, you can disable the check for the python version by setting the
+ #   PYTHON_NOVERSIONCHECK environment variable to something else than the
+@@ -67,10 +72,18 @@
+ #   modified version of the Autoconf Macro, you may extend this special
+ #   exception to the GPL to apply to your modified version as well.
+ 
+-#serial 21
++#serial 37
+ 
+ AU_ALIAS([AC_PYTHON_DEVEL], [AX_PYTHON_DEVEL])
+ AC_DEFUN([AX_PYTHON_DEVEL],[
++	# Get whether it's optional
++	if test -z "$2"; then
++	   ax_python_devel_optional=false
++	else
++	   ax_python_devel_optional=$2
++	fi
++	ax_python_devel_found=yes
++
+ 	#
+ 	# Allow the use of a (user set) custom python version
+ 	#
+@@ -81,21 +94,26 @@
+ 
+ 	AC_PATH_PROG([PYTHON],[python[$PYTHON_VERSION]])
+ 	if test -z "$PYTHON"; then
+-	   AC_MSG_ERROR([Cannot find python$PYTHON_VERSION in your system path])
++	   AC_MSG_WARN([Cannot find python$PYTHON_VERSION in your system path])
++	   if ! $ax_python_devel_optional; then
++	      AC_MSG_ERROR([Giving up, python development not available])
++	   fi
++	   ax_python_devel_found=no
+ 	   PYTHON_VERSION=""
+ 	fi
+ 
+-	#
+-	# Check for a version of Python >= 2.1.0
+-	#
+-	AC_MSG_CHECKING([for a version of Python >= '2.1.0'])
+-	ac_supports_python_ver=`$PYTHON -c "import sys; \
++	if test $ax_python_devel_found = yes; then
++	   #
++	   # Check for a version of Python >= 2.1.0
++	   #
++	   AC_MSG_CHECKING([for a version of Python >= '2.1.0'])
++	   ac_supports_python_ver=`$PYTHON -c "import sys; \
+ 		ver = sys.version.split ()[[0]]; \
+ 		print (ver >= '2.1.0')"`
+-	if test "$ac_supports_python_ver" != "True"; then
++	   if test "$ac_supports_python_ver" != "True"; then
+ 		if test -z "$PYTHON_NOVERSIONCHECK"; then
+ 			AC_MSG_RESULT([no])
+-			AC_MSG_FAILURE([
++			AC_MSG_WARN([
+ This version of the AC@&t@_PYTHON_DEVEL macro
+ doesn't work properly with versions of Python before
+ 2.1.0. You may need to re-run configure, setting the
+@@ -104,58 +122,119 @@
+ Moreover, to disable this check, set PYTHON_NOVERSIONCHECK
+ to something else than an empty string.
+ ])
++			if ! $ax_python_devel_optional; then
++			   AC_MSG_FAILURE([Giving up])
++			fi
++			ax_python_devel_found=no
++			PYTHON_VERSION=""
+ 		else
+ 			AC_MSG_RESULT([skip at user request])
+ 		fi
+-	else
++	   else
+ 		AC_MSG_RESULT([yes])
++	   fi
+ 	fi
+ 
+-	#
+-	# if the macro parameter ``version'' is set, honour it
+-	#
+-	if test -n "$1"; then
++	if test $ax_python_devel_found = yes; then
++	   #
++	   # If the macro parameter ``version'' is set, honour it.
++	   # A Python shim class, VPy, is used to implement correct version comparisons via
++	   # string expressions, since e.g. a naive textual ">= 2.7.3" won't work for
++	   # Python 2.7.10 (the ".1" being evaluated as less than ".3").
++	   #
++	   if test -n "$1"; then
+ 		AC_MSG_CHECKING([for a version of Python $1])
+-		ac_supports_python_ver=`$PYTHON -c "import sys; \
+-			ver = sys.version.split ()[[0]]; \
++                cat << EOF > ax_python_devel_vpy.py
++class VPy:
++    def vtup(self, s):
++        return tuple(map(int, s.strip().replace("rc", ".").split(".")))
++    def __init__(self):
++        import sys
++        self.vpy = tuple(sys.version_info)[[:3]]
++    def __eq__(self, s):
++        return self.vpy == self.vtup(s)
++    def __ne__(self, s):
++        return self.vpy != self.vtup(s)
++    def __lt__(self, s):
++        return self.vpy < self.vtup(s)
++    def __gt__(self, s):
++        return self.vpy > self.vtup(s)
++    def __le__(self, s):
++        return self.vpy <= self.vtup(s)
++    def __ge__(self, s):
++        return self.vpy >= self.vtup(s)
++EOF
++		ac_supports_python_ver=`$PYTHON -c "import ax_python_devel_vpy; \
++                        ver = ax_python_devel_vpy.VPy(); \
+ 			print (ver $1)"`
++                rm -rf ax_python_devel_vpy*.py* __pycache__/ax_python_devel_vpy*.py*
+ 		if test "$ac_supports_python_ver" = "True"; then
+-		   AC_MSG_RESULT([yes])
++			AC_MSG_RESULT([yes])
+ 		else
+ 			AC_MSG_RESULT([no])
+-			AC_MSG_ERROR([this package requires Python $1.
++			AC_MSG_WARN([this package requires Python $1.
+ If you have it installed, but it isn't the default Python
+ interpreter in your system path, please pass the PYTHON_VERSION
+ variable to configure. See ``configure --help'' for reference.
+ ])
++			if ! $ax_python_devel_optional; then
++			   AC_MSG_ERROR([Giving up])
++			fi
++			ax_python_devel_found=no
+ 			PYTHON_VERSION=""
+ 		fi
++	   fi
+ 	fi
+ 
+-	#
+-	# Check if you have distutils, else fail
+-	#
+-	AC_MSG_CHECKING([for the distutils Python package])
+-	ac_distutils_result=`$PYTHON -c "import distutils" 2>&1`
+-	if test $? -eq 0; then
++	if test $ax_python_devel_found = yes; then
++	   #
++	   # Check if you have distutils, else fail
++	   #
++	   AC_MSG_CHECKING([for the sysconfig Python package])
++	   ac_sysconfig_result=`$PYTHON -c "import sysconfig" 2>&1`
++	   if test $? -eq 0; then
+ 		AC_MSG_RESULT([yes])
+-	else
++		IMPORT_SYSCONFIG="import sysconfig"
++	   else
+ 		AC_MSG_RESULT([no])
+-		AC_MSG_ERROR([cannot import Python module "distutils".
++
++		AC_MSG_CHECKING([for the distutils Python package])
++		ac_sysconfig_result=`$PYTHON -c "from distutils import sysconfig" 2>&1`
++		if test $? -eq 0; then
++			AC_MSG_RESULT([yes])
++			IMPORT_SYSCONFIG="from distutils import sysconfig"
++		else
++			AC_MSG_WARN([cannot import Python module "distutils".
+ Please check your Python installation. The error was:
+-$ac_distutils_result])
+-		PYTHON_VERSION=""
++$ac_sysconfig_result])
++			if ! $ax_python_devel_optional; then
++			   AC_MSG_ERROR([Giving up])
++			fi
++			ax_python_devel_found=no
++			PYTHON_VERSION=""
++		fi
++	   fi
+ 	fi
+ 
+-	#
+-	# Check for Python include path
+-	#
+-	AC_MSG_CHECKING([for Python include path])
+-	if test -z "$PYTHON_CPPFLAGS"; then
+-		python_path=`$PYTHON -c "import distutils.sysconfig; \
+-			print (distutils.sysconfig.get_python_inc ());"`
+-		plat_python_path=`$PYTHON -c "import distutils.sysconfig; \
+-			print (distutils.sysconfig.get_python_inc (plat_specific=1));"`
++	if test $ax_python_devel_found = yes; then
++	   #
++	   # Check for Python include path
++	   #
++	   AC_MSG_CHECKING([for Python include path])
++	   if test -z "$PYTHON_CPPFLAGS"; then
++		if test "$IMPORT_SYSCONFIG" = "import sysconfig"; then
++			# sysconfig module has different functions
++			python_path=`$PYTHON -c "$IMPORT_SYSCONFIG; \
++				print (sysconfig.get_path ('include'));"`
++			plat_python_path=`$PYTHON -c "$IMPORT_SYSCONFIG; \
++				print (sysconfig.get_path ('platinclude'));"`
++		else
++			# old distutils way
++			python_path=`$PYTHON -c "$IMPORT_SYSCONFIG; \
++				print (sysconfig.get_python_inc ());"`
++			plat_python_path=`$PYTHON -c "$IMPORT_SYSCONFIG; \
++				print (sysconfig.get_python_inc (plat_specific=1));"`
++		fi
+ 		if test -n "${python_path}"; then
+ 			if test "${plat_python_path}" != "${python_path}"; then
+ 				python_path="-I$python_path -I$plat_python_path"
+@@ -164,22 +243,22 @@
+ 			fi
+ 		fi
+ 		PYTHON_CPPFLAGS=$python_path
+-	fi
+-	AC_MSG_RESULT([$PYTHON_CPPFLAGS])
+-	AC_SUBST([PYTHON_CPPFLAGS])
+-
+-	#
+-	# Check for Python library path
+-	#
+-	AC_MSG_CHECKING([for Python library path])
+-	if test -z "$PYTHON_LIBS"; then
++	   fi
++	   AC_MSG_RESULT([$PYTHON_CPPFLAGS])
++	   AC_SUBST([PYTHON_CPPFLAGS])
++
++	   #
++	   # Check for Python library path
++	   #
++	   AC_MSG_CHECKING([for Python library path])
++	   if test -z "$PYTHON_LIBS"; then
+ 		# (makes two attempts to ensure we've got a version number
+ 		# from the interpreter)
+ 		ac_python_version=`cat<<EOD | $PYTHON -
+ 
+ # join all versioning strings, on some systems
+ # major/minor numbers could be in different list elements
+-from distutils.sysconfig import *
++from sysconfig import *
+ e = get_config_var('VERSION')
+ if e is not None:
+ 	print(e)
+@@ -190,7 +269,7 @@
+ 				ac_python_version=$PYTHON_VERSION
+ 			else
+ 				ac_python_version=`$PYTHON -c "import sys; \
+-					print (sys.version[[:3]])"`
++					print ("%d.%d" % sys.version_info[[:2]])"`
+ 			fi
+ 		fi
+ 
+@@ -202,8 +281,8 @@
+ 		ac_python_libdir=`cat<<EOD | $PYTHON -
+ 
+ # There should be only one
+-import distutils.sysconfig
+-e = distutils.sysconfig.get_config_var('LIBDIR')
++$IMPORT_SYSCONFIG
++e = sysconfig.get_config_var('LIBDIR')
+ if e is not None:
+ 	print (e)
+ EOD`
+@@ -211,8 +290,8 @@
+ 		# Now, for the library:
+ 		ac_python_library=`cat<<EOD | $PYTHON -
+ 
+-import distutils.sysconfig
+-c = distutils.sysconfig.get_config_vars()
++$IMPORT_SYSCONFIG
++c = sysconfig.get_config_vars()
+ if 'LDVERSION' in c:
+ 	print ('python'+c[['LDVERSION']])
+ else:
+@@ -231,83 +310,140 @@
+ 		else
+ 			# old way: use libpython from python_configdir
+ 			ac_python_libdir=`$PYTHON -c \
+-			  "from distutils.sysconfig import get_python_lib as f; \
++			  "from sysconfig import get_python_lib as f; \
+ 			  import os; \
+ 			  print (os.path.join(f(plat_specific=1, standard_lib=1), 'config'));"`
+ 			PYTHON_LIBS="-L$ac_python_libdir -lpython$ac_python_version"
+ 		fi
+ 
+-		if test -z "PYTHON_LIBS"; then
+-			AC_MSG_ERROR([
++		if test -z "$PYTHON_LIBS"; then
++			AC_MSG_WARN([
+   Cannot determine location of your Python DSO. Please check it was installed with
+   dynamic libraries enabled, or try setting PYTHON_LIBS by hand.
+ 			])
++			if ! $ax_python_devel_optional; then
++			   AC_MSG_ERROR([Giving up])
++			fi
++			ax_python_devel_found=no
++			PYTHON_VERSION=""
+ 		fi
++	   fi
+ 	fi
+-	AC_MSG_RESULT([$PYTHON_LIBS])
+-	AC_SUBST([PYTHON_LIBS])
+ 
+-	#
+-	# Check for site packages
+-	#
+-	AC_MSG_CHECKING([for Python site-packages path])
+-	if test -z "$PYTHON_SITE_PKG"; then
+-		PYTHON_SITE_PKG=`$PYTHON -c "import distutils.sysconfig; \
+-			print (distutils.sysconfig.get_python_lib(0,0));"`
+-	fi
+-	AC_MSG_RESULT([$PYTHON_SITE_PKG])
+-	AC_SUBST([PYTHON_SITE_PKG])
+-
+-	#
+-	# libraries which must be linked in when embedding
+-	#
+-	AC_MSG_CHECKING(python extra libraries)
+-	if test -z "$PYTHON_EXTRA_LIBS"; then
+-	   PYTHON_EXTRA_LIBS=`$PYTHON -c "import distutils.sysconfig; \
+-                conf = distutils.sysconfig.get_config_var; \
++	if test $ax_python_devel_found = yes; then
++	   AC_MSG_RESULT([$PYTHON_LIBS])
++	   AC_SUBST([PYTHON_LIBS])
++
++	   #
++	   # Check for site packages
++	   #
++	   AC_MSG_CHECKING([for Python site-packages path])
++	   if test -z "$PYTHON_SITE_PKG"; then
++		if test "$IMPORT_SYSCONFIG" = "import sysconfig"; then
++			PYTHON_SITE_PKG=`$PYTHON -c "
++$IMPORT_SYSCONFIG;
++if hasattr(sysconfig, 'get_default_scheme'):
++    scheme = sysconfig.get_default_scheme()
++else:
++    scheme = sysconfig._get_default_scheme()
++if scheme == 'posix_local':
++    # Debian's default scheme installs to /usr/local/ but we want to find headers in /usr/
++    scheme = 'posix_prefix'
++prefix = '$prefix'
++if prefix == 'NONE':
++    prefix = '$ac_default_prefix'
++sitedir = sysconfig.get_path('purelib', scheme, vars={'base': prefix})
++print(sitedir)"`
++		else
++			# distutils.sysconfig way
++			PYTHON_SITE_PKG=`$PYTHON -c "$IMPORT_SYSCONFIG; \
++				print (sysconfig.get_python_lib(0,0));"`
++		fi
++	   fi
++	   AC_MSG_RESULT([$PYTHON_SITE_PKG])
++	   AC_SUBST([PYTHON_SITE_PKG])
++
++	   #
++	   # Check for platform-specific site packages
++	   #
++	   AC_MSG_CHECKING([for Python platform specific site-packages path])
++	   if test -z "$PYTHON_PLATFORM_SITE_PKG"; then
++		if test "$IMPORT_SYSCONFIG" = "import sysconfig"; then
++			PYTHON_PLATFORM_SITE_PKG=`$PYTHON -c "
++$IMPORT_SYSCONFIG;
++if hasattr(sysconfig, 'get_default_scheme'):
++    scheme = sysconfig.get_default_scheme()
++else:
++    scheme = sysconfig._get_default_scheme()
++if scheme == 'posix_local':
++    # Debian's default scheme installs to /usr/local/ but we want to find headers in /usr/
++    scheme = 'posix_prefix'
++prefix = '$prefix'
++if prefix == 'NONE':
++    prefix = '$ac_default_prefix'
++sitedir = sysconfig.get_path('platlib', scheme, vars={'platbase': prefix})
++print(sitedir)"`
++		else
++			# distutils.sysconfig way
++			PYTHON_PLATFORM_SITE_PKG=`$PYTHON -c "$IMPORT_SYSCONFIG; \
++				print (sysconfig.get_python_lib(1,0));"`
++		fi
++	   fi
++	   AC_MSG_RESULT([$PYTHON_PLATFORM_SITE_PKG])
++	   AC_SUBST([PYTHON_PLATFORM_SITE_PKG])
++
++	   #
++	   # libraries which must be linked in when embedding
++	   #
++	   AC_MSG_CHECKING(python extra libraries)
++	   if test -z "$PYTHON_EXTRA_LIBS"; then
++	      PYTHON_EXTRA_LIBS=`$PYTHON -c "$IMPORT_SYSCONFIG; \
++                conf = sysconfig.get_config_var; \
+                 print (conf('LIBS') + ' ' + conf('SYSLIBS'))"`
+-	fi
+-	AC_MSG_RESULT([$PYTHON_EXTRA_LIBS])
+-	AC_SUBST(PYTHON_EXTRA_LIBS)
+-
+-	#
+-	# linking flags needed when embedding
+-	#
+-	AC_MSG_CHECKING(python extra linking flags)
+-	if test -z "$PYTHON_EXTRA_LDFLAGS"; then
+-		PYTHON_EXTRA_LDFLAGS=`$PYTHON -c "import distutils.sysconfig; \
+-			conf = distutils.sysconfig.get_config_var; \
++	   fi
++	   AC_MSG_RESULT([$PYTHON_EXTRA_LIBS])
++	   AC_SUBST(PYTHON_EXTRA_LIBS)
++
++	   #
++	   # linking flags needed when embedding
++	   #
++	   AC_MSG_CHECKING(python extra linking flags)
++	   if test -z "$PYTHON_EXTRA_LDFLAGS"; then
++		PYTHON_EXTRA_LDFLAGS=`$PYTHON -c "$IMPORT_SYSCONFIG; \
++			conf = sysconfig.get_config_var; \
+ 			print (conf('LINKFORSHARED'))"`
+-	fi
+-	AC_MSG_RESULT([$PYTHON_EXTRA_LDFLAGS])
+-	AC_SUBST(PYTHON_EXTRA_LDFLAGS)
+-
+-	#
+-	# final check to see if everything compiles alright
+-	#
+-	AC_MSG_CHECKING([consistency of all components of python development environment])
+-	# save current global flags
+-	ac_save_LIBS="$LIBS"
+-	ac_save_LDFLAGS="$LDFLAGS"
+-	ac_save_CPPFLAGS="$CPPFLAGS"
+-	LIBS="$ac_save_LIBS $PYTHON_LIBS $PYTHON_EXTRA_LIBS $PYTHON_EXTRA_LIBS"
+-	LDFLAGS="$ac_save_LDFLAGS $PYTHON_EXTRA_LDFLAGS"
+-	CPPFLAGS="$ac_save_CPPFLAGS $PYTHON_CPPFLAGS"
+-	AC_LANG_PUSH([C])
+-	AC_LINK_IFELSE([
++		# Hack for macos, it sticks this in here.
++		PYTHON_EXTRA_LDFLAGS=`echo $PYTHON_EXTRA_LDFLAGS | sed 's/CoreFoundation.*$/CoreFoundation/'`
++	   fi
++	   AC_MSG_RESULT([$PYTHON_EXTRA_LDFLAGS])
++	   AC_SUBST(PYTHON_EXTRA_LDFLAGS)
++
++	   #
++	   # final check to see if everything compiles alright
++	   #
++	   AC_MSG_CHECKING([consistency of all components of python development environment])
++	   # save current global flags
++	   ac_save_LIBS="$LIBS"
++	   ac_save_LDFLAGS="$LDFLAGS"
++	   ac_save_CPPFLAGS="$CPPFLAGS"
++	   LIBS="$ac_save_LIBS $PYTHON_LIBS $PYTHON_EXTRA_LIBS"
++	   LDFLAGS="$ac_save_LDFLAGS $PYTHON_EXTRA_LDFLAGS"
++	   CPPFLAGS="$ac_save_CPPFLAGS $PYTHON_CPPFLAGS"
++	   AC_LANG_PUSH([C])
++	   AC_LINK_IFELSE([
+ 		AC_LANG_PROGRAM([[#include <Python.h>]],
+ 				[[Py_Initialize();]])
+ 		],[pythonexists=yes],[pythonexists=no])
+-	AC_LANG_POP([C])
+-	# turn back to default flags
+-	CPPFLAGS="$ac_save_CPPFLAGS"
+-	LIBS="$ac_save_LIBS"
+-	LDFLAGS="$ac_save_LDFLAGS"
++	   AC_LANG_POP([C])
++	   # turn back to default flags
++	   CPPFLAGS="$ac_save_CPPFLAGS"
++	   LIBS="$ac_save_LIBS"
++	   LDFLAGS="$ac_save_LDFLAGS"
+ 
+-	AC_MSG_RESULT([$pythonexists])
++	   AC_MSG_RESULT([$pythonexists])
+ 
+-        if test ! "x$pythonexists" = "xyes"; then
+-	   AC_MSG_FAILURE([
++	   if test ! "x$pythonexists" = "xyes"; then
++	      AC_MSG_WARN([
+   Could not link test program to Python. Maybe the main Python library has been
+   installed in some non-standard library path. If so, pass it to configure,
+   via the LIBS environment variable.
+@@ -317,8 +453,13 @@
+    You probably have to install the development version of the Python package
+    for your distribution.  The exact name of this package varies among them.
+   ============================================================================
+-	   ])
+-	  PYTHON_VERSION=""
++	      ])
++	      if ! $ax_python_devel_optional; then
++		 AC_MSG_ERROR([Giving up])
++	      fi
++	      ax_python_devel_found=no
++	      PYTHON_VERSION=""
++	   fi
+ 	fi
+ 
+ 	#

--- a/mingw-w64-libplist/003-fix-py-soext.patch
+++ b/mingw-w64-libplist/003-fix-py-soext.patch
@@ -6,7 +6,7 @@ index 67a05bb..c520acf 100644
              if [test "x$CYTHON" != "xfalse"]; then
                AM_PATH_PYTHON([3.0], [CYTHON_PYTHON])
              fi
-+            PYTHON_SO=`$PYTHON -c "import distutils.sysconfig, sys; get = distutils.sysconfig.get_config_var; sys.stdout.write(get('EXT_SUFFIX') or get('SO') or '.so');"`
++            PYTHON_SO=`$PYTHON -c "import sysconfig, sys; get = sysconfig.get_config_var; sys.stdout.write(get('EXT_SUFFIX') or get('SO') or '.so');"`
 +            AC_SUBST(PYTHON_SO)
  else
              CYTHON=false

--- a/mingw-w64-libplist/PKGBUILD
+++ b/mingw-w64-libplist/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libplist
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.6.0
-pkgrel=2
+pkgrel=3
 pkgdesc='A library to handle Apple Property List format in binary or XML (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -21,16 +21,29 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cython")
 optdepends=("${MINGW_PACKAGE_PREFIX}-python: Python bindings")
 source=("https://github.com/libimobiledevice/libplist/releases/download/${pkgver}/libplist-${pkgver}.tar.bz2"
+        001-ax_python_devel.patch
         002-dont-include-winmain-in-static.patch
         003-fix-py-soext.patch)
 sha256sums=('67be9ee3169366589c92dc7c22809b90f51911dd9de22520c39c9a64fb047c9c'
+            'cb6837f5dafff50a4a367dc6c71c86b7d40c68a9e676d8b121977a0db13bfdaf'
             'c48f22728e25a78ee70eaf20f559d3119b7c2140ccd1863005214a7c508267e5'
             '3b63489e0dc9bebe6e547bffb0f708275a9d8fc5d789ebc43dca7b61bd63673d')
 
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Np1 -i "${srcdir}/$_patch"
+  done
+}
+
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
-  patch -p1 -i ${srcdir}/002-dont-include-winmain-in-static.patch
-  patch -p1 -i ${srcdir}/003-fix-py-soext.patch
+  
+  apply_patch_with_msg \
+    001-ax_python_devel.patch \
+    002-dont-include-winmain-in-static.patch \
+    003-fix-py-soext.patch
 
   autoreconf -fiv
 }

--- a/mingw-w64-libplist/PKGBUILD
+++ b/mingw-w64-libplist/PKGBUILD
@@ -27,7 +27,7 @@ source=("https://github.com/libimobiledevice/libplist/releases/download/${pkgver
 sha256sums=('67be9ee3169366589c92dc7c22809b90f51911dd9de22520c39c9a64fb047c9c'
             'cb6837f5dafff50a4a367dc6c71c86b7d40c68a9e676d8b121977a0db13bfdaf'
             'c48f22728e25a78ee70eaf20f559d3119b7c2140ccd1863005214a7c508267e5'
-            '3b63489e0dc9bebe6e547bffb0f708275a9d8fc5d789ebc43dca7b61bd63673d')
+            'c9190d4697bc3d97fa20b66a54f2b9f8fe2527560376e2dae8d168e79cbd272c')
 
 apply_patch_with_msg() {
   for _patch in "$@"


### PR DESCRIPTION
Addtionally, change patch to no longer use the `distutils` module.
