### PR TITLE
libftdi: install Python files in correct prefix

### DIFF
--- a/mingw-w64-libftdi/0003-no-distutils.patch
+++ b/mingw-w64-libftdi/0003-no-distutils.patch
@@ -15,9 +15,9 @@ diff -urN libftdi1-1.5/python/CMakeLists.txt.orig libftdi1-1.5/python/CMakeLists
 +prefix = sys.prefix
 +
 +if platlib.startswith(prefix):
-+    print(platlib[len(prefix):].lstrip(os.sep))
++    print(os.path.join('${CMAKE_INSTALL_PREFIX}', platlib[len(prefix):].lstrip(os.sep)))
 +else:
-+    print(platlib)
++    print(os.path.join('${CMAKE_INSTALL_PREFIX}', platlib))
 +"
                    OUTPUT_VARIABLE _ABS_PYTHON_MODULE_PATH
                    OUTPUT_STRIP_TRAILING_WHITESPACE )

--- a/mingw-w64-libftdi/PKGBUILD
+++ b/mingw-w64-libftdi/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libftdi
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.5
-pkgrel=9
+pkgrel=10
 pkgdesc='Library to talk to FTDI chips, with Python 3 bindings (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -29,7 +29,7 @@ source=("https://www.intra2net.com/en/developer/libftdi/download/libftdi1-${pkgv
 sha256sums=('7c7091e9c86196148bd41177b4590dccb1510bfe6cea5bf7407ff194482eb049'
             '71d5a8de43a61c7e26531c722862dc7c4135e4b494498d2bd140019f9693741c'
             '71e542e4847642ec38e7929c208e61183ef2ff7c65ae21200101bb0a02635735'
-            'c37417465dc3b0591e0b0afdd115e3cd2348080820767fd23d5ecabae6f1501c')
+            '8bdf184d7f0e6be2e7802202f9a415652eb05d84f324202632d10abdb68c0190')
 
 apply_patch_with_msg() {
   for _patch in "$@"


### PR DESCRIPTION
Fixes #22399.