### PR TITLE
libde265: fix symbol visibility

### DIFF
--- a/mingw-w64-libde265/PKGBUILD
+++ b/mingw-w64-libde265/PKGBUILD
@@ -41,7 +41,7 @@ build() {
   [[ -d "${srcdir}"/build-${MSYSTEM} ]] && rm -rf "${srcdir}"/build-${MSYSTEM}
   mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
 
-  CPPFLAGS='-I$(top_srcdir)/libde265 -I$(top_srcdir) -I$(top_srcdir)/sherlock265' \
+  CPPFLAGS='-I$(top_srcdir)/libde265 -I$(top_srcdir) -I$(top_srcdir)/sherlock265 -DLIBDE265_EXPORTS' \
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \


### PR DESCRIPTION
Edit: turns out this requires more upstream patches, so dropping until the next release.