### PR TITLE
python-bsddb3: avoid build error with GCC 14

### DIFF
--- a/mingw-w64-python-bsddb3/PKGBUILD
+++ b/mingw-w64-python-bsddb3/PKGBUILD
@@ -45,7 +45,7 @@ prepare() {
 build() {
   cd "${srcdir}/python-build-${CARCH}"
 
-  CFLAGS+=" -DUNICODE -D_UNICODE"
+  CFLAGS+=" -DUNICODE -D_UNICODE -Wno-error=incompatible-pointer-types"
 
   if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
     CFLAGS+=" -Wno-incompatible-function-pointer-types"


### PR DESCRIPTION
Disable error on warning for incompatible pointer types.