### PR TITLE
unicorn: do not use unsupported flags for aarch64 target

### DIFF
--- a/mingw-w64-unicorn/003-aarch64.patch
+++ b/mingw-w64-unicorn/003-aarch64.patch
@@ -1,0 +1,29 @@
+Assume that the target architecture is aarch64 if it is neither i686 nor
+x86_64.
+
+This is probably not upstreamable. But it should be good enough for the
+architectures that are supported by MSYS2.
+
+diff -urN unicorn-2.0.1.post1/CMakeLists.txt.orig unicorn-2.0.1.post1/CMakeLists.txt
+--- unicorn-2.0.1.post1/CMakeLists.txt.orig	2022-11-16 15:16:49.000000000 +0100
++++ unicorn-2.0.1.post1/CMakeLists.txt	2024-11-06 09:04:28.474013400 +0100
+@@ -137,10 +137,15 @@
+             set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -m32")
+             set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -m32")
+         else()
+-            set(UNICORN_TARGET_ARCH "i386")
+-            set(UNICORN_CFLAGS -m64 -mcx16)
+-            set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -m64")
+-            set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -m64")
++            string(FIND "${UC_COMPILER_VERSION}" "x86_64" UC_RET)
++            if(${UC_RET} GREATER_EQUAL "0")
++                set(UNICORN_TARGET_ARCH "i386")
++                set(UNICORN_CFLAGS -m64 -mcx16)
++                set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -m64")
++                set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -m64")
++            else()
++                set(UNICORN_TARGET_ARCH "aarch64")
++            endif()
+         endif()
+     elseif(ANDROID_ABI)
+         string(FIND "${ANDROID_ABI}" "arm64" UC_RET)

--- a/mingw-w64-unicorn/PKGBUILD
+++ b/mingw-w64-unicorn/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-unicorn"
          "${MINGW_PACKAGE_PREFIX}-python-unicorn")
 pkgver=2.0.1.post1
-pkgrel=4
+pkgrel=5
 pkgdesc="A lightweight multi-platform, multi-architecture CPU emulator framework based on QEMU (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -24,17 +24,29 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 source=("https://github.com/unicorn-engine/unicorn/archive/${pkgver}/${_realname}-${pkgver}.tar.gz"
         "001-bindings-python.patch"
-        "002-getpagesize-clang.patch")
+        "002-getpagesize-clang.patch"
+        "003-aarch64.patch")
 sha512sums=('8694d6bc92e3424a8ad050316413d53e56e0f55e7cad7517fb3e98e670a0f1768b060ead8f195da13607cec89a964364f05a8b9d0dc074f4ac5e51026f8343ad'
             '966ba5eeae1e72c400fc7f6a7f3a9b14afb9b0abf02c53e1ca18b7cad9e84705b8fd86fe8f42fd5d59a4bab312986952cc07119f4b1d70d4973850b16f5e1aa9'
-            'ba35ee611ee312c851a07533caaf8a7a6c6a398fe3544c9ba843a2e3c333859ef0433fbbee28ff0aaa61893f44cea45691339fcc05779a3837ae5fdbdd87577a')
+            'ba35ee611ee312c851a07533caaf8a7a6c6a398fe3544c9ba843a2e3c333859ef0433fbbee28ff0aaa61893f44cea45691339fcc05779a3837ae5fdbdd87577a'
+            'd60d90c34bc23bef3bf2b41421c0b85a88c2905db6bb1c26f5e8cf5c918198c7b1ebccf34202d0f3958eba026a438413f9db573228609f5f91e50f9f66de0bc7')
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying ${_patch}"
+    patch -Nbp1 -i "${srcdir}/${_patch}"
+  done
+}
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
   pwd
 
-  patch -Np1 -i "${srcdir}"/001-bindings-python.patch
-  patch -Np1 -i "${srcdir}"/002-getpagesize-clang.patch
+  apply_patch_with_msg \
+    001-bindings-python.patch \
+    002-getpagesize-clang.patch \
+    003-aarch64.patch
 }
 
 build() {


### PR DESCRIPTION
Assume that the target architecture is aarch64 if it is neither i686 nor
x86_64.

This is probably not upstreamable. But it should be good enough for the
architectures that are supported by MSYS2.

I can't test locally if this actually fixes the build issue for CLANGARM64.