### PR TITLE
python-py2exe: disable building for any environment

### DIFF
--- a/mingw-w64-python-py2exe/PKGBUILD
+++ b/mingw-w64-python-py2exe/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=py2exe
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
-pkgver=0.13.0.1
-pkgrel=5
+pkgver=0.13.0.2
+pkgrel=1
 pkgdesc='A distutils extension to create standalone Windows programs from Python code (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -25,19 +25,15 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cc")
 source=(https://github.com/py2exe/${_realname}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz
         001-setup-fix.patch
-        002-mingw-fix.patch
-        https://patch-diff.githubusercontent.com/raw/py2exe/py2exe/pull/211.patch)
-sha256sums=('1d8ea4c79e372ae44833f3fd7f7285a2bf6282f34c902d4d891ff742be789881'
+        002-mingw-fix.patch)
+sha256sums=('ef2907f5b82ec8b2259bea41a2d7d798ecd67aa4a92a74a06550b9123dadd8a4'
             'dabe972096c34f5e9ffd0023794807cc665a8870cd6bef6985f9d7197ec4d717'
-            '3ac8b13f12ca901a07f3ca87b494f5c97ea31192715b6f1fb36563b458462a0f'
-            '052f0ffb64f157b2dcdf7a84e950ca2745e8c7eea013ee12e9327799186be458')
+            '3ac8b13f12ca901a07f3ca87b494f5c97ea31192715b6f1fb36563b458462a0f')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   patch -p1 -i ${srcdir}/001-setup-fix.patch
   patch -p1 -i ${srcdir}/002-mingw-fix.patch
-  # https://github.com/py2exe/py2exe/pull/211
-  patch -p1 -i ${srcdir}/211.patch
 }
 
 build() {

--- a/mingw-w64-python-py2exe/PKGBUILD
+++ b/mingw-w64-python-py2exe/PKGBUILD
@@ -7,7 +7,11 @@ pkgver=0.13.0.2
 pkgrel=1
 pkgdesc='A distutils extension to create standalone Windows programs from Python code (mingw-w64)'
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+# py2exe is currently incompatible to Python 3.12 or newer:
+# https://github.com/py2exe/py2exe/issues/191
+# Re-enable if this is fixed upstream.
+#mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+mingw_arch=()
 msys2_references=(
   'pypi: py2exe'
 )


### PR DESCRIPTION
It is currently incompatible with Python 3.12 or newer:
https://github.com/py2exe/py2exe/issues/191