### PR TITLE
python-boto: updates for Python 3.12

### DIFF
--- a/mingw-w64-python-boto/0001-escape-backslash-in-strings.patch
+++ b/mingw-w64-python-boto/0001-escape-backslash-in-strings.patch
@@ -1,0 +1,26 @@
+Escape backslash characters in strings.
+
+diff -urN boto-2.49.0/boto/__init__.py.orig boto-2.49.0/boto/__init__.py
+--- boto-2.49.0/boto/__init__.py.orig	2018-07-11 22:42:42.000000000 +0200
++++ boto-2.49.0/boto/__init__.py	2024-11-06 10:37:26.382606400 +0100
+@@ -1136,7 +1136,7 @@
+     * gs://bucket
+     * s3://bucket
+     * filename (which could be a Unix path like /a/b/c or a Windows path like
+-      C:\a\b\c)
++      C:\\a\\b\\c)
+ 
+     The last example uses the default scheme ('file', unless overridden).
+     """
+diff -urN boto-2.49.0/boto/pyami/config.py.orig boto-2.49.0/boto/pyami/config.py
+--- boto-2.49.0/boto/pyami/config.py.orig	2018-07-11 19:35:36.000000000 +0200
++++ boto-2.49.0/boto/pyami/config.py	2024-11-06 10:27:59.943008800 +0100
+@@ -95,7 +95,7 @@
+     def load_from_path(self, path):
+         file = open(path)
+         for line in file.readlines():
+-            match = re.match("^#import[\s\t]*([^\s^\t]*)[\s\t]*$", line)
++            match = re.match("^#import[\\s\t]*([^\\s^\t]*)[\\s\t]*$", line)
+             if match:
+                 extended_file = match.group(1)
+                 (dir, file) = os.path.split(path)

--- a/mingw-w64-python-boto/0002-update-vendored-six.patch
+++ b/mingw-w64-python-boto/0002-update-vendored-six.patch
@@ -1,0 +1,37 @@
+From 6483c19cb7f6029924bd1ad970dbcf04d3f4189d Mon Sep 17 00:00:00 2001
+From: Brett Cannon <brett@python.org>
+Date: Fri, 26 Mar 2021 16:34:05 -0700
+Subject: [PATCH] Implement find_spec() for _SixMetaPathImporter
+
+---
+ six.py | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/boto/vendored/six.py b/boto/vendored/six.py
+index d162d09c..5e7f0ce4 100644
+--- a/boto/vendored/six.py
++++ b/boto/vendored/six.py
+@@ -71,6 +71,11 @@ def __len__(self):
+             MAXSIZE = int((1 << 63) - 1)
+         del X
+ 
++if PY34:
++    from importlib.util import spec_from_loader
++else:
++    spec_from_loader = None
++
+ 
+ def _add_doc(func, doc):
+     """Add documentation to a function."""
+@@ -186,6 +191,11 @@ def find_module(self, fullname, path=None):
+             return self
+         return None
+ 
++    def find_spec(self, fullname, path, target=None):
++        if fullname in self.known_modules:
++            return spec_from_loader(fullname, self)
++        return None
++
+     def __get_module(self, fullname):
+         try:
+             return self.known_modules[fullname]

--- a/mingw-w64-python-boto/PKGBUILD
+++ b/mingw-w64-python-boto/PKGBUILD
@@ -15,7 +15,8 @@ url='https://github.com/boto/boto/'
 license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-python")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python"
-             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python-zombie-imp")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
         "0001-escape-backslash-in-strings.patch"
         "0002-update-vendored-six.patch")

--- a/mingw-w64-python-boto/PKGBUILD
+++ b/mingw-w64-python-boto/PKGBUILD
@@ -4,20 +4,37 @@ _realname=boto
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=2.49.0
-pkgrel=3
+pkgrel=4
 pkgdesc="Amazon Web Services Library (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 msys2_references=(
   'pypi: boto'
 )
-url='https://www.somepackage.org/'
-license=('MIT')
+url='https://github.com/boto/boto/'
+license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-python")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
-source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
+        "0001-escape-backslash-in-strings.patch")
+sha256sums=('ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a'
+            '78da0522f7cc61e52742c5256df2ec8bf83dfd31a2a740918a7bcce7093e79d1')
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying ${_patch}"
+    patch -Nbp1 -i "${srcdir}/${_patch}"
+  done
+}
+
+prepare() {
+  cd "${srcdir}"/${_realname}-${pkgver}
+
+  apply_patch_with_msg \
+    0001-escape-backslash-in-strings.patch
+}
 
 build() {
   cd "${srcdir}"

--- a/mingw-w64-python-boto/PKGBUILD
+++ b/mingw-w64-python-boto/PKGBUILD
@@ -17,9 +17,11 @@ depends=("${MINGW_PACKAGE_PREFIX}-python")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
-        "0001-escape-backslash-in-strings.patch")
+        "0001-escape-backslash-in-strings.patch"
+        "0002-update-vendored-six.patch")
 sha256sums=('ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a'
-            '78da0522f7cc61e52742c5256df2ec8bf83dfd31a2a740918a7bcce7093e79d1')
+            '78da0522f7cc61e52742c5256df2ec8bf83dfd31a2a740918a7bcce7093e79d1'
+            '6eb5e3ad725828240a48da8e9c38ddec1d49d057439cd551762b53c2df4e01f4')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -33,7 +35,8 @@ prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
 
   apply_patch_with_msg \
-    0001-escape-backslash-in-strings.patch
+    0001-escape-backslash-in-strings.patch \
+    0002-update-vendored-six.patch
 }
 
 build() {

--- a/mingw-w64-python-zombie-imp/PKGBUILD
+++ b/mingw-w64-python-zombie-imp/PKGBUILD
@@ -1,0 +1,33 @@
+_realname=zombie-imp
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=0.0.2
+pkgrel=1
+pkgdesc="A copy of the imp module that was removed in Python 3.12 (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/encukou/zombie-imp'
+license=('spdx:PSF-2.0')
+depends=("${MINGW_PACKAGE_PREFIX}-python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!strip')
+source=(${_realname}-${pkgver}.tar.gz::"https://github.com/encukou/${_realname}/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('08c6c53fc78f5ff45508b4d515f723f9dc07891e6b978435fb8eab1fe3185380')
+
+build() {
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}


### PR DESCRIPTION
Fix some compatibility issues with Python 3.12.

Fedora is using `zombie-imp` to build this package. So, do the same here.
https://src.fedoraproject.org/rpms/python-boto/blob/rawhide/f/python-boto.spec#_63
