### PR TITLE
python-jsonrpc-server: unbundle vendored versioneer

### DIFF
--- a/mingw-w64-python-jsonrpc-server/PKGBUILD
+++ b/mingw-w64-python-jsonrpc-server/PKGBUILD
@@ -4,7 +4,7 @@ _realname=jsonrpc-server
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=0.4.0
-pkgrel=6
+pkgrel=7
 pkgdesc="Python library implementing asynchronous JSON RPC server (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -16,7 +16,8 @@ license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-future"
          "${MINGW_PACKAGE_PREFIX}-python-ujson")
-makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python-versioneer")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-coverage"
               "${MINGW_PACKAGE_PREFIX}-python-pytest"
               "${MINGW_PACKAGE_PREFIX}-python-pytest-cov"
@@ -33,6 +34,8 @@ prepare() {
   cd "${srcdir}"/python-${_realname}-${pkgver}
   patch -p1 -i "${srcdir}/001-python-jsonrpc-server-0.4.0-fix-versioneer.patch"
   patch -p1 -i "${srcdir}/002-python-jsonrpc-server-0.4.0-fix-test.patch"
+
+  rm -rf "versioneer.py" | true
 
   cd "${srcdir}"
   rm -rf "python-build-${MSYSTEM}" | true

--- a/mingw-w64-python-jupyter-nbviewer/PKGBUILD
+++ b/mingw-w64-python-jupyter-nbviewer/PKGBUILD
@@ -4,7 +4,7 @@ _realname=nbviewer
 pkgbase=mingw-w64-python-jupyter-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-jupyter-${_realname}
 pkgver=1.0.1
-pkgrel=5
+pkgrel=6
 pkgdesc='Render Jupyter Notebooks as static web pages (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -27,11 +27,14 @@ depends=(
 makedepends=(
     ${MINGW_PACKAGE_PREFIX}-python-setuptools
     ${MINGW_PACKAGE_PREFIX}-python-invoke
+    ${MINGW_PACKAGE_PREFIX}-python-versioneer
 )
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/jupyter/${_realname}/archive/${pkgver}.tar.gz")
 sha256sums=('2fe0b0ee8ec5c8e2e173b8f15a22e42ba583fc6d4fa60ddb7aa40e9ee972f268')
 
 prepare() {
+  rm -f "${srcdir}"/${_realname}-${pkgver}/versioneer.py | true
+
   rm -rf python-build-${MSYSTEM} | true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }


### PR DESCRIPTION
The bundled version is outdated and incompatible with Python 3.12.