### PR TITLE
ocio: remove OSL circular dependency

### DIFF
--- a/mingw-w64-opencolorio/PKGBUILD
+++ b/mingw-w64-opencolorio/PKGBUILD
@@ -6,7 +6,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 pkgver=2.3.2
-pkgrel=2
+pkgrel=3
 pkgdesc="A color management framework for visual effects and animation (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -29,8 +29,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-pybind11"
              "${MINGW_PACKAGE_PREFIX}-pystring"
              "${MINGW_PACKAGE_PREFIX}-python"
-             "${MINGW_PACKAGE_PREFIX}-openshadinglanguage"
              "${MINGW_PACKAGE_PREFIX}-zlib")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-openshadinglanguage")
 optdepends=("${MINGW_PACKAGE_PREFIX}-python: Python bindings")
 source=(https://github.com/AcademySoftwareFoundation/OpenColorIO/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz
         0003-fix-python-sitearch.patch)


### PR DESCRIPTION
OSL is used only for optional unit tests, [currently not even built](https://github.com/msys2/MINGW-packages/blob/735bfdb3c592adde4c386d2578a16d6aaf2aeebb/mingw-w64-opencolorio/PKGBUILD#L69) (so it could be removed completely even).