### PR TITLE
python-language-server: unbundle vendored versioneer

### DIFF
--- a/mingw-w64-python-language-server/PKGBUILD
+++ b/mingw-w64-python-language-server/PKGBUILD
@@ -4,7 +4,7 @@ _realname=language-server
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=0.36.2
-pkgrel=4
+pkgrel=5
 pkgdesc="An implementation of the Language Server Protocol for Python (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -12,14 +12,15 @@ msys2_references=(
   'pypi: python-language-server'
 )
 url="https://github.com/palantir/python-language-server"
-license=('MIT')
+license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-future"
          "${MINGW_PACKAGE_PREFIX}-python-jedi"
          "${MINGW_PACKAGE_PREFIX}-python-jsonrpc-server"
          "${MINGW_PACKAGE_PREFIX}-python-pluggy"
          "${MINGW_PACKAGE_PREFIX}-python-ujson")
-makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python-versioneer")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-coverage"
               "${MINGW_PACKAGE_PREFIX}-python-pytest"
               "${MINGW_PACKAGE_PREFIX}-python-pytest-cov"
@@ -44,6 +45,8 @@ prepare() {
 
   patch -p1 -i "${srcdir}/001-python-language-server-0.36.2-fix-versioneer.patch"
   patch -p1 -i "${srcdir}/002-python-language-server-0.36.2-fix-setup.patch"
+
+  rm -rf "versioneer.py" | true
 }
 
 build() {


### PR DESCRIPTION
The bundled version is outdated and incompatible with Python 3.12.