### PR TITLE
gegl: Update to 0.4.50

### DIFF
--- a/mingw-w64-gegl/PKGBUILD
+++ b/mingw-w64-gegl/PKGBUILD
@@ -5,8 +5,8 @@ _realname=gegl
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
-pkgver=0.4.48
-pkgrel=3
+pkgver=0.4.50
+pkgrel=1
 pkgdesc="Generic Graphics Library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -53,26 +53,12 @@ depends=("${MINGW_PACKAGE_PREFIX}-babl"
          "${MINGW_PACKAGE_PREFIX}-SDL2"
          "${MINGW_PACKAGE_PREFIX}-suitesparse")
 noextract=("${_realname}-${pkgver}.tar.xz")
-source=(https://download.gimp.org/pub/gegl/${pkgver%.*}/${_realname}-${pkgver}.tar.xz
-        "https://gitlab.gnome.org/GNOME/gegl/-/commit/66de8124f496617eee8e6b5c68138a00343882db.patch"
-        "https://gitlab.gnome.org/GNOME/gegl/-/commit/298b6a2afb87b4b5b15c6e715967b57534cd0af0.patch"
-        "https://gitlab.gnome.org/GNOME/gegl/-/commit/b009ef056fb031fcb5dc7f94f7a0c733d542d64d.patch")
-sha256sums=('418c26d94be8805d7d98f6de0c6825ca26bd74fcacb6c188da47533d9ee28247'
-            'd558ee613e17a9174a34346610b50206e86a53b008021ee4b2f35fcc191d1d60'
-            'bc65623e3895131b469e2861f71d1bc575733febd139b877abf5f96475308151'
-            '5d40fa7df6cf2751251ed8fda797f735d0a3bc2a9324b173453c89b2aeaccbc9')
+source=(https://download.gimp.org/pub/gegl/${pkgver%.*}/${_realname}-${pkgver}.tar.xz)
+sha256sums=('6084969b06ee86ca71142133773f27e13f02e5a6a22c2cfce452ecaaddb790c1')
 
 prepare() {
   tar -xf "${_realname}-${pkgver}.tar.xz" || true
   tar -xf "${_realname}-${pkgver}.tar.xz" || true
-  cd "${_realname}-${pkgver}"
-
-  ## ffmpeg v7 backports
-  patch -Np1 -i ../66de8124f496617eee8e6b5c68138a00343882db.patch
-  patch -Np1 -i ../298b6a2afb87b4b5b15c6e715967b57534cd0af0.patch
-
-  # mingw32 build fix
-  patch -Np1 -i ../b009ef056fb031fcb5dc7f94f7a0c733d542d64d.patch
 }
 
 build() {


### PR DESCRIPTION
Needed for GIMP 3 RC1