### PR TITLE
libheif: update to 1.19.2

### DIFF
--- a/mingw-w64-libheif/PKGBUILD
+++ b/mingw-w64-libheif/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=libheif
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.19.1
-pkgrel=2
+pkgver=1.19.2
+pkgrel=1
 pkgdesc="HEIF image decoder/encoder library and tools (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -27,6 +27,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libpng"
          "${MINGW_PACKAGE_PREFIX}-libtiff"
          "${MINGW_PACKAGE_PREFIX}-libsharpyuv"
+         "${MINGW_PACKAGE_PREFIX}-openh264"
          "${MINGW_PACKAGE_PREFIX}-openjpeg2"
          $( [[ ${CARCH} == i686 ]] || \
             echo "${MINGW_PACKAGE_PREFIX}-openjph" )
@@ -35,18 +36,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
             echo "${MINGW_PACKAGE_PREFIX}-svt-av1" )
          "${MINGW_PACKAGE_PREFIX}-x265"
          "${MINGW_PACKAGE_PREFIX}-zlib")
-source=("https://github.com/strukturag/libheif/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz"
-        "https://github.com/strukturag/libheif/commit/26050190264a1c70d27963712a083ac284267c06.patch")
-sha256sums=('994913eb2a29c00c146d6f3d61e07d9ff0d8e9eccb0624d87e4be8b108c74e4b'
-            '8e609fb6f318f8541eaa4d8c43bfdc8f85e66ab5ee9d7d0c2ff0a7e1f4dd6bb3')
-
-prepare() {
-  cd "${_realname}-${pkgver}"
-  
-  # use dllexport for all Windows compilers
-  # https://github.com/strukturag/libheif/commit/26050190264a1c70d27963712a083ac284267c06
-  patch -Np1 -i "${srcdir}"/26050190264a1c70d27963712a083ac284267c06.patch
-}
+source=("https://github.com/strukturag/libheif/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('f73eb786e75ef1f815ed3d37aca9eadd41dc1d26dfde11f8a4f92f911622d19e')
 
 build() {
   mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
@@ -65,6 +56,7 @@ build() {
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
       "${extra_config[@]}" \
       -DBUILD_SHARED_LIBS=ON \
+      -DBUILD_TESTING=OFF \
       -DENABLE_PLUGIN_LOADING=OFF \
       -DWITH_HEADER_COMPRESSION=ON \
       -DWITH_KVAZAAR=ON \


### PR DESCRIPTION
Enable OpenH264 codec
Disable tests, fail to build