### PR TITLE
gpgme: disable docs for CLANGARM64 environment

### DIFF
--- a/mingw-w64-gpgme/0011-disable-docs.patch
+++ b/mingw-w64-gpgme/0011-disable-docs.patch
@@ -1,0 +1,33 @@
+Disable building the documentation to work around an issue (segfault?) with
+one of the generator executables in the CLANGARM64 environment:
+```
+  incd="`test -f defsincdate || echo './'`defsincdate"; \
+  ./mkdefsinc -C . --date "`cat $incd 2>/dev/null`" \
+      gpgme.texi uiserver.texi lesser.texi gpl.texi >defs.inc
+  mkdefsinc: taking date from 'gpgme.texi'
+  make[2]: *** [Makefile:905: defs.inc] Error 139
+```
+
+diff -urN gpgme-1.23.2/Makefile.am.orig gpgme-1.23.2/Makefile.am
+--- gpgme-1.23.2/Makefile.am.orig	2023-08-31 11:19:00.000000000 +0200
++++ gpgme-1.23.2/Makefile.am	2024-11-07 09:06:17.328590400 +0100
+@@ -48,7 +48,7 @@
+ tests =
+ endif
+ 
+-SUBDIRS = src ${tests} doc lang
++SUBDIRS = src ${tests} lang
+ 
+ # Fix the version of the spec file.
+ dist-hook: gen-ChangeLog
+diff -urN gpgme-1.23.2/lang/qt/Makefile.am.orig gpgme-1.23.2/lang/qt/Makefile.am
+--- gpgme-1.23.2/lang/qt/Makefile.am.orig	2018-12-03 10:37:25.000000000 +0100
++++ gpgme-1.23.2/lang/qt/Makefile.am	2024-11-07 09:18:47.655681200 +0100
+@@ -24,6 +24,6 @@
+ tests =
+ endif
+ 
+-SUBDIRS = src ${tests} doc
++SUBDIRS = src ${tests}
+ 
+ EXTRA_DIST = README

--- a/mingw-w64-gpgme/PKGBUILD
+++ b/mingw-w64-gpgme/PKGBUILD
@@ -10,7 +10,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
            "${MINGW_PACKAGE_PREFIX}-qgpgme-qt6" \
            "${MINGW_PACKAGE_PREFIX}-python-gpgme"))
 pkgver=1.23.2
-pkgrel=6
+pkgrel=7
 pkgdesc="A C wrapper library for GnuPG (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -48,6 +48,7 @@ source=("https://www.gnupg.org/ftp/gcrypt/${_realname}/${_realname}-${pkgver}.ta
         0008-no-py2.patch
         0009-fix-broken-version.patch
         0010-m4-check-python-exit-code.patch
+        0011-disable-docs.patch
         relocatable-cmake.patch
         gpgmepp-portable-types.patch)
 #These might be signed by any of these keys https://gnupg.org/signature_key.html
@@ -66,6 +67,7 @@ sha256sums=('9499e8b1f33cccb6815527a1bc16049d35a6198a6c5fae0185f2bd561bce5224'
             '0b0d511f9d47844d3fd806864310d9abbeb1285d43f6ffa33babf55a4a410458'
             'ace3d5166372e0422a625f76a2890d70f2916d9239ade74e58bd23077e9c1c6b'
             '5e8e7e773a09ed1e1724c9d7216eaaecce52af49152513366026a2fa3245d762'
+            'a1fd47dd1849066dd1dd85d1252da046c76647e32ee58a9ea3541e31c4b64684'
             '81f412ffdeeb2a0757248b517fbda9caae9913b1552c88abb8347faa4d1efea2'
             'a110b40d146a7c561140b68831027f61d2132e1069d2476b2e0a4034bc54fae1')
 
@@ -92,6 +94,13 @@ prepare() {
     0010-m4-check-python-exit-code.patch \
     relocatable-cmake.patch \
     gpgmepp-portable-types.patch
+
+  # The generator for the documentation segfaults in the CLANGARM64 environment.
+  # Disable building the documentation in that environment.
+  if [[ ${MSYSTEM} == CLANGARM64 ]]; then
+    _apply_patch_with_msg \
+      0011-disable-docs.patch
+  fi
 
   autoreconf -ivf
 }


### PR DESCRIPTION
Building fails in the CLANGARM64 environment with a segfault(?) when trying to run one of the generator executables built during the build process:
```
  incd="`test -f defsincdate || echo './'`defsincdate"; \
  ./mkdefsinc -C . --date "`cat $incd 2>/dev/null`" \
      gpgme.texi uiserver.texi lesser.texi gpl.texi >defs.inc
  mkdefsinc: taking date from 'gpgme.texi'
  make[2]: *** [Makefile:905: defs.inc] Error 139
```

Disable building the documentation for the CLANGARM64 environment as a workaround.