### PR TITLE
harfbuzz: Update to 10.1.0

### DIFF
--- a/mingw-w64-harfbuzz/PKGBUILD
+++ b/mingw-w64-harfbuzz/PKGBUILD
@@ -8,7 +8,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-icu"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-utils"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
-pkgver=10.0.1
+pkgver=10.1.0
 pkgrel=1
 pkgdesc="OpenType text shaping engine"
 arch=('any')
@@ -38,7 +38,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python-fonttools"
               "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 source=("https://github.com/harfbuzz/harfbuzz/releases/download/${pkgver}/harfbuzz-${pkgver}.tar.xz"
         "001-fix-build-with-chafa.patch")
-sha256sums=('b2cb13bd351904cb9038f907dc0dee0ae07127061242fe3556b2795c4e9748fc'
+sha256sums=('6ce3520f2d089a33cef0fc48321334b8e0b72141f6a763719aaaecd2779ecb82'
             '26b37a1ca9872973905ecb96bcbe3f054472252320956faa74428206900d360e')
 noextract=("harfbuzz-${pkgver}.tar.xz")
 
@@ -79,7 +79,6 @@ build() {
     -Dintrospection=disabled \
     -Dgobject=enabled \
     -Dicu=enabled \
-    -Dcpp_std=c++17 \
     -Dgdi=enabled \
     -Dgraphite=enabled \
     -Ddirectwrite=enabled \
@@ -101,7 +100,6 @@ build() {
     -Dintrospection=enabled \
     -Dgobject=enabled \
     -Dicu=enabled \
-    -Dcpp_std=c++17 \
     -Dgdi=enabled \
     -Dgraphite=enabled \
     -Ddirectwrite=enabled \


### PR DESCRIPTION
drop cpp_std workaround for newer icu, harfbuzz now sets it automatically