### PR TITLE
add pyvda

### DIFF
--- a/mingw-w64-python-pyvda/PKGBUILD
+++ b/mingw-w64-python-pyvda/PKGBUILD
@@ -1,0 +1,37 @@
+# Maintainer: Antoine Martin <totaam@xpra.org>
+
+_realname=pyvda
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=0.4.3
+pkgrel=1
+pkgdesc="Python bindings for ls-qpack (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+msys2_references=(
+  'pypi: pyvda'
+)
+url='https://github.com/mrob95/pyvda'
+license=('spdx:MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-comtypes"
+         "${MINGW_PACKAGE_PREFIX}-python-pywin32")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('a4ba4c782e7a935c43b0a1355c5af3efe1b52b143c84bd18c40d28ccf5861343')
+
+build() {
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}

--- a/mingw-w64-python-pyvda/PKGBUILD
+++ b/mingw-w64-python-pyvda/PKGBUILD
@@ -17,6 +17,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-comtypes"
          "${MINGW_PACKAGE_PREFIX}-python-pywin32")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('a4ba4c782e7a935c43b0a1355c5af3efe1b52b143c84bd18c40d28ccf5861343')


### PR DESCRIPTION
The [pyvda](https://github.com/mrob95/pyvda) library adds workspace support to [mingw-w64-python-xpra](https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-python-xpra).

I will make a separate PR for adding the dependency to xpra once merged.
Thanks!