### PR TITLE
update xpra to v6.2.1

### DIFF
--- a/mingw-w64-python-xpra/PKGBUILD
+++ b/mingw-w64-python-xpra/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=xpra
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=6.2.0
-pkgrel=3
+pkgver=6.2.1
+pkgrel=1
 pkgdesc='Remote access client/server software (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -28,6 +28,7 @@ depends=(
     ${MINGW_PACKAGE_PREFIX}-python-pillow
     ${MINGW_PACKAGE_PREFIX}-python-pyopengl
     ${MINGW_PACKAGE_PREFIX}-python-setproctitle
+    ${MINGW_PACKAGE_PREFIX}-python-pyvda
     ${MINGW_PACKAGE_PREFIX}-xxhash
     ${MINGW_PACKAGE_PREFIX}-libx264)
 optdepends=(
@@ -60,7 +61,7 @@ makedepends=(
     ${MINGW_PACKAGE_PREFIX}-pygobject-devel)
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
         "0001-fix-build.patch")
-sha256sums=('7f5baf7daa0de5697829cff553e56197f186978f36be8bbe8fb1b72103857dd6'
+sha256sums=('8b87a6052d259f7c94125de9200b8020976b7d0049126d9608c6b0cf6518dfec'
             '71a752dbfe8f6b6252e03cca3251dbdb14a844bab669f575b7f26002f4efd31b')
 
 prepare() {


### PR DESCRIPTION
also adds the pyvda dependency for workspace support (#22482)