### PR TITLE
emacs: fix libtree-sitter linking

### DIFF
--- a/mingw-w64-emacs/004-libtree-sitter.patch
+++ b/mingw-w64-emacs/004-libtree-sitter.patch
@@ -1,0 +1,11 @@
+--- a/lisp/term/w32-win.el
++++ b/lisp/term/w32-win.el
+@@ -314,7 +314,7 @@
+ '(gccjit "libgccjit-0.dll")
+        ;; MSYS2 distributes libtree-sitter.dll, without API version
+        ;; number...
+-       '(tree-sitter "libtree-sitter.dll" "libtree-sitter-0.dll")))
++       '(tree-sitter "libtree-sitter.dll" "libtree-sitter-0.dll" "libtree-sitter-0.24.dll")))
+
+ ;;; multi-tty support
+ (defvar w32-initialized nil

--- a/mingw-w64-emacs/PKGBUILD
+++ b/mingw-w64-emacs/PKGBUILD
@@ -8,7 +8,7 @@ _realname=emacs
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=29.4
-pkgrel=2
+pkgrel=3
 pkgdesc="The extensible, customizable, self-documenting, real-time display editor (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -45,6 +45,8 @@ source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.xz"{,.s
         "001-ucrt.patch"
         "002-clang-fixes.patch"
         "003-aarch64-fixes.patch"
+        # current patch implementation requires change after each libtree-sitter soversion bump
+        "004-libtree-sitter.patch"
         "emacs-ARM64.manifest")
 # source=("https://alpha.gnu.org/gnu/${_realname}/pretest/${_realname}-${pkgver}.tar.xz"{,.sig})
 sha256sums=('ba897946f94c36600a7e7bb3501d27aa4112d791bfe1445c61ed28550daca235'
@@ -52,6 +54,7 @@ sha256sums=('ba897946f94c36600a7e7bb3501d27aa4112d791bfe1445c61ed28550daca235'
             'e1347064ec30094e21679764f784fa7557738946485359041473e6e9d7f3c3dc'
             'd8732584a8f3bfd0badbd16d15384b7098e25c5df48632beb02d35f6050c358b'
             'd128982d87af1e524ae809147613168153f0e5c1efb0ef633793df47b762c9e1'
+            '542cbe816eaa835a600920ea80d4aaacd82ccf902f961cbeee9c6451bdff374b'
             'bfe64602dbeeec85799c1156ca4f3837fdac42a076e83a4221768db3417220e1')
 validpgpkeys=('28D3BED851FDF3AB57FEF93C233587A47C207910'
               '17E90D521672C04631B1183EE78DAE0F3115E06B'
@@ -66,6 +69,7 @@ prepare() {
   patch -Np1 -i "${srcdir}/001-ucrt.patch"
   patch -Np1 -i "${srcdir}/002-clang-fixes.patch"
   patch -Np1 -i "${srcdir}/003-aarch64-fixes.patch"
+  patch -Np1 -i "${srcdir}/004-libtree-sitter.patch"
 
   ./autogen.sh
 }


### PR DESCRIPTION
introducing soversion broke emacs build due to hardcoded library names. I'm actually not familiar with this syntax so I added hardcoded name with soversion that must be changed at every libtree-sitter update... contributions welcome 
fixes #22508