### PR TITLE
svt-av1: Disable LTO to fix static library

### DIFF
--- a/mingw-w64-svt-av1/PKGBUILD
+++ b/mingw-w64-svt-av1/PKGBUILD
@@ -4,7 +4,7 @@ _realname=SVT-AV1
 pkgbase=mingw-w64-svt-av1
 pkgname=("${MINGW_PACKAGE_PREFIX}-svt-av1")
 pkgver=2.3.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Scalable Video Technology AV1 encoder and decoder (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -39,6 +39,7 @@ build() {
       "${extra_config[@]}" \
       -DBUILD_SHARED_LIBS=OFF \
       -DREPRODUCIBLE_BUILDS=ON \
+      -DSVT_AV1_LTO=OFF \
       ../${_realname}-v${pkgver}
 
   ${MINGW_PREFIX}/bin/cmake --build .
@@ -54,6 +55,7 @@ build() {
       -DBUILD_SHARED_LIBS=ON \
       -DCMAKE_DLL_NAME_WITH_SOVERSION=ON \
       -DREPRODUCIBLE_BUILDS=ON \
+      -DSVT_AV1_LTO=OFF \
       ../${_realname}-v${pkgver}
 
   ${MINGW_PREFIX}/bin/cmake --build .


### PR DESCRIPTION

    This fixes linking error with static library.
    ld.exe: test.c:(.text+0x15): undefined reference to `svt_av1_get_version'

* Fixes #22439 