### PR TITLE
SDL2_mixer: Enable modplug library dependency explicitly

### DIFF
--- a/mingw-w64-SDL2_mixer/PKGBUILD
+++ b/mingw-w64-SDL2_mixer/PKGBUILD
@@ -4,7 +4,7 @@ _realname=SDL2_mixer
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.8.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A simple multi-channel audio mixer (Version 2) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -35,6 +35,8 @@ build() {
 
   local -a _common_config
   _common_config+=(
+    --enable-music-mod-modplug
+    --disable-music-mod-modplug-shared
     --disable-music-ogg-shared
     --disable-music-flac-shared
     --enable-music-mp3
@@ -48,7 +50,7 @@ build() {
   [[ -d "${srcdir}/build-${MSYSTEM}-static" ]] && rm -rf "${srcdir}/build-${MSYSTEM}-static"
   mkdir -p "${srcdir}/build-${MSYSTEM}-static" && cd "${srcdir}/build-${MSYSTEM}-static"
 
-  CPPFLAGS+=" -DFLAC__NO_DLL" \
+  CPPFLAGS+=" -DFLAC__NO_DLL -DMODPLUG_STATIC" \
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \


### PR DESCRIPTION
* Fixes #22517 