### PR TITLE
cargo-leptos: enable CLANGARM64

### DIFF
--- a/mingw-w64-cargo-leptos/PKGBUILD
+++ b/mingw-w64-cargo-leptos/PKGBUILD
@@ -5,10 +5,10 @@ _realname=cargo-${_basename}
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.2.21
-pkgrel=1
+pkgrel=2
 pkgdesc='Build tool for Leptos (mingw-w64)'
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://leptos.dev/'
 msys2_repository_url='https://github.com/leptos-rs/cargo-leptos'
 msys2_references=(
@@ -25,6 +25,8 @@ sha256sums=('3f6f7f0a28b33653387c7c7d0b1aa5b50b4a2343009540c28e9a3c63ad36a091')
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
+  # update psm to fix aarch64 build issue
+  cargo update -p psm@0.1.23 --precise 0.1.24
   "${MINGW_PREFIX}/bin/cargo.exe" fetch --target "$(rustc -vV | sed -n 's/host: //p')"
 }
 


### PR DESCRIPTION
psm package update fixes aarch64 gnullvm support