### PR TITLE
python-milc: update to 1.9.0

### DIFF
--- a/mingw-w64-python-milc/0001-temp-remove-types-colorama.patch
+++ b/mingw-w64-python-milc/0001-temp-remove-types-colorama.patch
@@ -1,8 +1,8 @@
 --- a/setup.py
 +++ b/setup.py
 @@ -51,7 +51,6 @@
-             "colorama",
              "halo",
+             "platformdirs",
              "spinners",
 -            "types-colorama",
          ],

--- a/mingw-w64-python-milc/PKGBUILD
+++ b/mingw-w64-python-milc/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=milc
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=1.8.0
-pkgrel=2
+pkgver=1.9.0
+pkgrel=1
 pkgdesc="Opinionated Batteries-Included Python 3 CLI Framework (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -14,17 +14,17 @@ msys2_references=(
 url='https://milc.clueboard.co'
 license=('MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-python"
-         "${MINGW_PACKAGE_PREFIX}-python-appdirs"
          "${MINGW_PACKAGE_PREFIX}-python-argcomplete"
          "${MINGW_PACKAGE_PREFIX}-python-colorama"
-         "${MINGW_PACKAGE_PREFIX}-python-halo")
+         "${MINGW_PACKAGE_PREFIX}-python-halo"
+         "${MINGW_PACKAGE_PREFIX}-python-platformdirs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 source=(
   "https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
   "0001-temp-remove-types-colorama.patch")
-sha256sums=('cabe658de07ab97f937c7672b8a604cc825174c28d66d3afd047a9b4b2770bbe'
-            'e13bdfffe291017c5d2c4e26c7343ced894c43f4844db5dfca2f1b484178853a')
+sha256sums=('c02ac9a23148a1fb4f339022e929a658ab2c8fe8c1cad10a9bb1226358cc71ce'
+            'bd917622257c828f28dada2c241f40801961b761e3d06bcec2dedf9d7ddc0a9f')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"


### PR DESCRIPTION
Bumping to latest release as requirement for updating `mingw-w64-x86_64-python-qmk` to `1.1.6`.