### PR TITLE
scotch: update to 7.0.5

### DIFF
--- a/mingw-w64-scotch/PKGBUILD
+++ b/mingw-w64-scotch/PKGBUILD
@@ -5,15 +5,16 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-int64")
 pkgdesc='Graph partitioning and sparse matrix ordering package (mingw-w64)'
-pkgver=7.0.4
-pkgrel=3
+pkgver=7.0.5
+pkgrel=1
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://www.labri.fr/perso/pelegrin/scotch/"
 msys2_repository_url="https://gitlab.inria.fr/scotch/scotch"
 license=('spdx:CECILL-C')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
-         "${MINGW_PACKAGE_PREFIX}-libsystre")
+         "${MINGW_PACKAGE_PREFIX}-libsystre"
+         "${MINGW_PACKAGE_PREFIX}-libwinpthread-git")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              $([[ ${CARCH} == aarch64 ]] || echo "${MINGW_PACKAGE_PREFIX}-msmpi"))
 options=('!strip')
@@ -22,7 +23,7 @@ source=("https://gitlab.inria.fr/scotch/scotch/-/archive/v${pkgver}/${_realname}
         "Makefile.idx64.inc"
         "0002-pipe-fix.patch"
         "0004-dummysizes-regex.patch")
-sha256sums=('8ef4719d6a3356e9c4ca7fefd7e2ac40deb69779a5c116f44da75d13b3d2c2c3'
+sha256sums=('385507a9712bb9057497b9ac3f24ad2132bd3f3f8c7a62e78324fc58f2a0079b'
             '4221b69dcc53230ff4d6bc18e3982f6d39971a99fc17f4dab609fc19b99d8a30'
             'c52bf0598332d8139a37606e7ea9376b7f841059047c0c977b205a763fc7e97a'
             'b6e76b1d2f35b3fcc771b97a35a468d6314ee3a619defef18b82fc7654638a49'
@@ -39,12 +40,11 @@ _build_scotch() {
   _idx_makefile_inc=$1
   _idx_suffix=$2
 
-  # remove previous build artifacts
-  cd "${srcdir}/${_realname}-v${pkgver}"
-  rm -rfd include lib bin include${_idx_suffix} lib${_idx_suffix} bin${_idx_suffix}
+  cp -r "${srcdir}/${_realname}-v${pkgver}" "${srcdir}/build-${MSYSTEM}-idx${_idx_suffix}"
+  cd "${srcdir}/build-${MSYSTEM}-idx${_idx_suffix}"
 
-  cp -p "${srcdir}/${_idx_makefile_inc}" "${srcdir}/${_realname}-v${pkgver}/src/Makefile.inc"
-  cd "${srcdir}/${_realname}-v${pkgver}/src"
+  cp -p "${srcdir}/${_idx_makefile_inc}" "${srcdir}/build-${MSYSTEM}-idx${_idx_suffix}/src/Makefile.inc"
+  cd "${srcdir}/build-${MSYSTEM}-idx${_idx_suffix}/src"
 
   if [[ ${CARCH} != aarch64 ]]; then
     make scotch ptscotch esmumps ptesmumps
@@ -58,20 +58,14 @@ _build_scotch() {
     -Wl,--out-implib,lib${_realname}.dll.a -Wl,--whole-archive lib${_realname}.a lib${_realname}err.a -Wl,--no-whole-archive \
     -pthread
 
+  mv "${srcdir}/build-${MSYSTEM}-idx${_idx_suffix}/include/metis.h" "${srcdir}/build-${MSYSTEM}-idx${_idx_suffix}/include/scotchmetis.h"
+
   if [[ ${CARCH} != aarch64 ]]; then
     mpicc -shared -o libpt${_realname}.dll -Wl,--enable-auto-import -Wl,--export-all-symbols,-no-undefined \
       -Wl,--out-implib,libpt${_realname}.dll.a -Wl,--whole-archive libpt${_realname}.a libpt${_realname}err.a -Wl,--no-whole-archive \
       -L. -l${_realname} -pthread
-  fi
 
-  cd "${srcdir}/${_realname}-v${pkgver}"
-  mv include include${_idx_suffix}
-  mv lib lib${_idx_suffix}
-  mv bin bin${_idx_suffix}
-  cd include${_idx_suffix}
-  mv metis.h scotchmetis.h
-  if [[ ${CARCH} != aarch64 ]]; then
-    mv parmetis.h ptscotchparmetis.h
+    mv "${srcdir}/build-${MSYSTEM}-idx${_idx_suffix}/include/parmetis.h" "${srcdir}/build-${MSYSTEM}-idx${_idx_suffix}/include/ptscotchparmetis.h"
   fi
 }
 
@@ -121,11 +115,11 @@ _package_scotch() {
     " | sed '/^\s*$/d;s/^\s*//' > "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/ptscotch.pc"
   fi  
   (
-    cd include${_idx_suffix}
+    cd "${srcdir}/build-${MSYSTEM}-idx${_idx_suffix}"/include
     install -m644 *.h "${pkgdir}${MINGW_PREFIX}/include"
   )
   (
-    cd lib${_idx_suffix}
+    cd "${srcdir}/build-${MSYSTEM}-idx${_idx_suffix}"/lib
     install -m644 lib*.a "${pkgdir}${MINGW_PREFIX}/lib"
     install -m644 lib*.dll "${pkgdir}${MINGW_PREFIX}/bin"
   )

--- a/mingw-w64-scotch/PKGBUILD
+++ b/mingw-w64-scotch/PKGBUILD
@@ -132,7 +132,6 @@ package_scotch()
 
 package_scotch-int64() {
   pkgdesc="Graph partitioning and sparse matrix ordering package with 64-bit indexing (mingw-w64)"
-  provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
   conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
   _package_scotch "64"
 }


### PR DESCRIPTION
Also, take better care to not mix build artifacts for 32-bit and 64-bit indexing. 
Fixes #22540.

~~Additionally, add missing dependency to libwinpthread.~~ (Edit: That might not have actually been missing. But it might be a new feature in version 7.0.5. I haven't checked that though.)