### PR TITLE
gimp: rebuild with GCC 14

### DIFF
--- a/mingw-w64-gimp/0009-build-fix-svg-pixbuf-loader-check-with-librsvg-2.59.patch
+++ b/mingw-w64-gimp/0009-build-fix-svg-pixbuf-loader-check-with-librsvg-2.59.patch
@@ -1,0 +1,31 @@
+From 2b0b73b0a1f9564874939f335675091f66c43050 Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Sat, 16 Nov 2024 17:16:01 +0100
+Subject: [PATCH] build: fix svg pixbuf loader check with librsvg 2.59+
+
+Since librsvg moved to meson the loader modules are named differently
+and building gimp2 on Windows fails to detect them in configure.
+
+Adjust the checks to the new filenames.
+---
+ configure.ac | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 71b71397ece..6f405ad6766 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2504,8 +2504,8 @@ if test "x$enable_vector_icons" != "xno"; then
+     # error: cannot check for file existence when cross compiling
+     # So let's test files the shell way.
+     if (test "x$platform_win32" = "xyes" &&
+-        test -f "$gdk_pixbuf_moduledir/libpixbufloader-svg.dll") ||
+-       test -f "$gdk_pixbuf_moduledir/libpixbufloader-svg.so"; then
++        test -f "$gdk_pixbuf_moduledir/pixbufloader_svg.dll") ||
++       test -f "$gdk_pixbuf_moduledir/libpixbufloader_svg.so"; then
+       # We must not use $PKG_CONFIG nor PKG_CHECK_* macros because we need
+       # to make sure we use the native pkg-config (in case we cross-compile).
+       if pkg-config --atleast-version=glib_required_version glib-2.0 &&
+-- 
+GitLab
+

--- a/mingw-w64-gimp/0010-fix-compatibility-with-libheif-1.18.0.patch
+++ b/mingw-w64-gimp/0010-fix-compatibility-with-libheif-1.18.0.patch
@@ -1,0 +1,56 @@
+Since libheif 1.18.0, codecs can be dynamically loaded at runtime and it is
+not possible anymore to determine the available codecs at compile-time.
+You'll get an unknown codec error at runtime if you try to use an
+unavailable codec.
+
+See: https://github.com/strukturag/libheif/commit/cf0d89c6e0809427427583290547a7757428cf5a
+
+diff -urN gimp-2.10.38/configure.ac.orig gimp-2.10.38/configure.ac
+--- gimp-2.10.38/configure.ac.orig	2024-11-17 14:10:59.244775200 +0100
++++ gimp-2.10.38/configure.ac	2024-11-17 14:11:10.329184400 +0100
+@@ -1815,10 +1815,15 @@
+ # these as last resort, outputting a warning.
+ have_libheif=no
+ have_libheif_1_4_0=no
++have_libheif_1_14_0=no
+ if test "x$with_libheif" != xno; then
++  have_libheif_1_14_0=yes
+   have_libheif_1_4_0=yes
+   have_libheif=yes
+-  PKG_CHECK_MODULES(LIBHEIF, libheif > 1.5.1,,
++  PKG_CHECK_MODULES(LIBHEIF, libheif > 1.5.1,
++    [
++      PKG_CHECK_MODULES(LIBHEIF, libheif > 1.14.0,,[have_libheif_1_14_0=no])
++    ],
+     [
+       PKG_CHECK_MODULES(LIBHEIF, libheif = 1.4.0,,
+         [
+@@ -1843,13 +1848,24 @@
+ can_import_avif=no
+ can_export_avif=no
+ if test "x$have_libheif" = xyes; then
+-  can_import_heic=`$PKG_CONFIG --variable=builtin_h265_decoder libheif`
+-  can_export_heic=`$PKG_CONFIG --variable=builtin_h265_encoder libheif`
++  if test "x$have_libheif_1_14_0" = xyes; then
++    # Since libheif 1.14.0, codecs can be dynamically loaded at runtime and it is
++    # not possible anymore to determine the available codecs at compile-time.
++    # You'll get an unknown codec error at runtime if you try to use an
++    # unavailable codec.
++    can_import_heic=yes
++    can_export_heic=yes
++    can_import_avif=yes
++    can_export_avif=yes
++  else
++    can_import_heic=`$PKG_CONFIG --variable=builtin_h265_decoder libheif`
++    can_export_heic=`$PKG_CONFIG --variable=builtin_h265_encoder libheif`
++    can_import_avif=`$PKG_CONFIG --variable=builtin_avif_decoder libheif`
++    can_export_avif=`$PKG_CONFIG --variable=builtin_avif_encoder libheif`
++  fi
+   if test "x$can_import_heic" = xyes; then
+     MIME_TYPES="$MIME_TYPES;image/heif;image/heic"
+   fi
+-  can_import_avif=`$PKG_CONFIG --variable=builtin_avif_decoder libheif`
+-  can_export_avif=`$PKG_CONFIG --variable=builtin_avif_encoder libheif`
+   if test "x$can_import_avif" = xyes; then
+     MIME_TYPES="$MIME_TYPES;image/avif"
+   fi

--- a/mingw-w64-gimp/PKGBUILD
+++ b/mingw-w64-gimp/PKGBUILD
@@ -57,6 +57,7 @@ source=(https://download.gimp.org/pub/gimp/v${pkgver%.*}/${_realname}-${pkgver}.
         0007-clang-rc-files-fix.patch
         0008-avoid-incompatible-pointer-cast.patch::https://gitlab.gnome.org/GNOME/gimp/-/commit/24df4f1fc800f11e44c44f8036e7d8d7ee90b62a.patch
         0009-build-fix-svg-pixbuf-loader-check-with-librsvg-2.59.patch
+        0010-fix-compatibility-with-libheif-1.18.0.patch
         https://gitlab.gnome.org/GNOME/gimp/-/commit/13284c8953b43e349dc94a6c5bcc9dbf4e98533f.patch)
 sha256sums=('50a845eec11c8831fe8661707950f5b8446e35f30edfb9acf98f85c1133f856e'
             'f7f9badc547f1a0317b95e012530db8df63b7c7038c9d9ff8d0b510c86f43439'
@@ -67,6 +68,7 @@ sha256sums=('50a845eec11c8831fe8661707950f5b8446e35f30edfb9acf98f85c1133f856e'
             'f4f8258b352530b0f9dd1ebd4f4730125caa4d047ca17bf9e5180b52be19c117'
             '49f8078b10bcd5fe98236e51a3272651f80be630ae97ab2ec9aa00bd9c7ef503'
             '1a733dec028116e2d891a830e7935a84bde22a31fa58759bf43bdf751c77e3b8'
+            'e1787a1cfb796973a3d711db9dc60b7606126bfc4b8a4365d8d32b743c60c8c6'
             '3d346b0d7cb9ab534501f5e1a5d543a54dc16bb16b884a2fc42382c6a5b82cbf')
 
 apply_patch_with_msg() {
@@ -88,6 +90,7 @@ prepare() {
     0007-clang-rc-files-fix.patch \
     0008-avoid-incompatible-pointer-cast.patch \
     0009-build-fix-svg-pixbuf-loader-check-with-librsvg-2.59.patch \
+    0010-fix-compatibility-with-libheif-1.18.0.patch \
     13284c8953b43e349dc94a6c5bcc9dbf4e98533f.patch
 
   sed -e "s|-Wl,-rpath '-Wl,\$\$ORIGIN/../lib'||g" -i app/Makefile.am

--- a/mingw-w64-gimp/PKGBUILD
+++ b/mingw-w64-gimp/PKGBUILD
@@ -56,6 +56,7 @@ source=(https://download.gimp.org/pub/gimp/v${pkgver%.*}/${_realname}-${pkgver}.
         0005-fix-link-python-plugins.patch
         0007-clang-rc-files-fix.patch
         0008-avoid-incompatible-pointer-cast.patch::https://gitlab.gnome.org/GNOME/gimp/-/commit/24df4f1fc800f11e44c44f8036e7d8d7ee90b62a.patch
+        0009-build-fix-svg-pixbuf-loader-check-with-librsvg-2.59.patch
         https://gitlab.gnome.org/GNOME/gimp/-/commit/13284c8953b43e349dc94a6c5bcc9dbf4e98533f.patch)
 sha256sums=('50a845eec11c8831fe8661707950f5b8446e35f30edfb9acf98f85c1133f856e'
             'f7f9badc547f1a0317b95e012530db8df63b7c7038c9d9ff8d0b510c86f43439'
@@ -65,6 +66,7 @@ sha256sums=('50a845eec11c8831fe8661707950f5b8446e35f30edfb9acf98f85c1133f856e'
             '01651bb582b2120aae67752f6a28c0750ea690d46259d855e28f8b18da567bf5'
             'f4f8258b352530b0f9dd1ebd4f4730125caa4d047ca17bf9e5180b52be19c117'
             '49f8078b10bcd5fe98236e51a3272651f80be630ae97ab2ec9aa00bd9c7ef503'
+            '1a733dec028116e2d891a830e7935a84bde22a31fa58759bf43bdf751c77e3b8'
             '3d346b0d7cb9ab534501f5e1a5d543a54dc16bb16b884a2fc42382c6a5b82cbf')
 
 apply_patch_with_msg() {
@@ -85,6 +87,7 @@ prepare() {
     0005-fix-link-python-plugins.patch \
     0007-clang-rc-files-fix.patch \
     0008-avoid-incompatible-pointer-cast.patch \
+    0009-build-fix-svg-pixbuf-loader-check-with-librsvg-2.59.patch \
     13284c8953b43e349dc94a6c5bcc9dbf4e98533f.patch
 
   sed -e "s|-Wl,-rpath '-Wl,\$\$ORIGIN/../lib'||g" -i app/Makefile.am

--- a/mingw-w64-gimp/PKGBUILD
+++ b/mingw-w64-gimp/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gimp
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.10.38
-pkgrel=1
+pkgrel=2
 pkgdesc="GNU Image Manipulation Program (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -55,6 +55,7 @@ source=(https://download.gimp.org/pub/gimp/v${pkgver%.*}/${_realname}-${pkgver}.
         0004-replace-pygtk-codegen.patch
         0005-fix-link-python-plugins.patch
         0007-clang-rc-files-fix.patch
+        0008-avoid-incompatible-pointer-cast.patch::https://gitlab.gnome.org/GNOME/gimp/-/commit/24df4f1fc800f11e44c44f8036e7d8d7ee90b62a.patch
         https://gitlab.gnome.org/GNOME/gimp/-/commit/13284c8953b43e349dc94a6c5bcc9dbf4e98533f.patch)
 sha256sums=('50a845eec11c8831fe8661707950f5b8446e35f30edfb9acf98f85c1133f856e'
             'f7f9badc547f1a0317b95e012530db8df63b7c7038c9d9ff8d0b510c86f43439'
@@ -63,6 +64,7 @@ sha256sums=('50a845eec11c8831fe8661707950f5b8446e35f30edfb9acf98f85c1133f856e'
             '98b6212e669eb3a93877514ee6d3284cb3a44ae6d57b6ecb29de3a076db3dbd2'
             '01651bb582b2120aae67752f6a28c0750ea690d46259d855e28f8b18da567bf5'
             'f4f8258b352530b0f9dd1ebd4f4730125caa4d047ca17bf9e5180b52be19c117'
+            '49f8078b10bcd5fe98236e51a3272651f80be630ae97ab2ec9aa00bd9c7ef503'
             '3d346b0d7cb9ab534501f5e1a5d543a54dc16bb16b884a2fc42382c6a5b82cbf')
 
 apply_patch_with_msg() {
@@ -82,6 +84,7 @@ prepare() {
     0004-replace-pygtk-codegen.patch \
     0005-fix-link-python-plugins.patch \
     0007-clang-rc-files-fix.patch \
+    0008-avoid-incompatible-pointer-cast.patch \
     13284c8953b43e349dc94a6c5bcc9dbf4e98533f.patch
 
   sed -e "s|-Wl,-rpath '-Wl,\$\$ORIGIN/../lib'||g" -i app/Makefile.am


### PR DESCRIPTION
Cherry-pick patch from upstream to avoid warnings that are elevated to an error in GCC 14.

See build error in #22550.
```
../../../gimp-2.10.38/plug-ins/file-tiff/file-tiff-load.c:1372:56: error: passing argument 2 of 'gimp_image_get_resolution' from incompatible pointer type [-Wincompatible-pointer-types]
 1372 |                     gimp_image_get_resolution (*image, &xres, &yres);
      |                                                        ^~~~~
      |                                                        |
      |                                                        gfloat * {aka float *}
In file included from ../../../gimp-2.10.38/libgimp/gimp_pdb_headers.h:55,
                 from ../../../gimp-2.10.38/libgimp/gimp.h:66,
                 from ../../../gimp-2.10.38/plug-ins/file-tiff/file-tiff-load.c:52:
../../../gimp-2.10.38/libgimp/gimpimage_pdb.h:179:86: note: expected 'gdouble *' {aka 'double *'} but argument is of type 'gfloat *' {aka 'float *'}
  179 |                                                                 gdouble             *xresolution,
      |                                                                 ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
../../../gimp-2.10.38/plug-ins/file-tiff/file-tiff-load.c:1372:63: error: passing argument 3 of 'gimp_image_get_resolution' from incompatible pointer type [-Wincompatible-pointer-types]
 1372 |                     gimp_image_get_resolution (*image, &xres, &yres);
      |                                                               ^~~~~
      |                                                               |
      |                                                               gfloat * {aka float *}
../../../gimp-2.10.38/libgimp/gimpimage_pdb.h:180:86: note: expected 'gdouble *' {aka 'double *'} but argument is of type 'gfloat *' {aka 'float *'}