### PR TITLE
dcmtk: fix compilation with clang 19

### DIFF
--- a/mingw-w64-dcmtk/PKGBUILD
+++ b/mingw-w64-dcmtk/PKGBUILD
@@ -4,7 +4,7 @@ _realname=dcmtk
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=3.6.8
-pkgrel=2
+pkgrel=3
 pkgdesc="A collection of libraries and applications implementing large parts of the DICOM standard (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -31,15 +31,27 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-icu"
             "${MINGW_PACKAGE_PREFIX}-libiconv")
 source=("https://dicom.offis.de/download/dcmtk/dcmtk${pkgver//./}/${_realname}-${pkgver}.tar.gz"
         "001-fix-cmake-config-install-destination.patch"
-        "002-properly-detect-canonical-host.patch")
+        "002-properly-detect-canonical-host.patch"
+        "003-fixed-compilation-with-gcc-15.patch"::"https://git.dcmtk.org/?p=dcmtk.git;a=patch;h=c29bebcd19bb963d72dcd00ca8745f60f6b9a39e")
 sha256sums=('232076655503138debf2f624109f1799e539354f186ce4e04b27cf82a9d8720f'
             'ff124b6f26c5a5982268597c6285e2e320a248a090046b45618e79cb8a6fc099'
-            'b9cd641267f9aeb055608f045cc91ad5b99b071897aa849ed3282aa03b5ae925')
+            'b9cd641267f9aeb055608f045cc91ad5b99b071897aa849ed3282aa03b5ae925'
+            '46ead518b98b55d8eb442f7550b080891d74d6612bb89a1fd9426ee31a598ba1')
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying ${_patch}"
+    patch -Nbp1 -i "${srcdir}/${_patch}"
+  done
+}
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
-  patch -p1 -i "${srcdir}"/001-fix-cmake-config-install-destination.patch
-  patch -p1 -i "${srcdir}"/002-properly-detect-canonical-host.patch
+  apply_patch_with_msg \
+    001-fix-cmake-config-install-destination.patch \
+    002-properly-detect-canonical-host.patch \
+    003-fixed-compilation-with-gcc-15.patch
 
   cd config
   ./rootconf


### PR DESCRIPTION
Cherry-pick patch from upstream.

See the build error in #22550.
```
[snip]
  In file included from D:/M/msys64/clang64/include/dcmtk/ofstd/ofmem.h:27:
  D:/M/msys64/clang64/include/dcmtk/ofstd/ofutil.h:79:18: error: no member named 'pt' in 'OFrvalue_storage<T, >'
     79 |         : t( rhs.pt ) {}
        |              ~~~ ^
```