### PR TITLE
doxygen: llvm19 build fixes

### DIFF
--- a/mingw-w64-doxygen/0002-clang-19-fix.patch
+++ b/mingw-w64-doxygen/0002-clang-19-fix.patch
@@ -1,0 +1,40 @@
+--- doxygen-Release_1_12_0/CMakeLists.txt.orig	2024-08-07 09:32:57.000000000 +0200
++++ doxygen-Release_1_12_0/CMakeLists.txt	2024-11-16 23:52:07.619291200 +0100
+@@ -82,7 +82,7 @@
+ endif()
+ 
+ # use C++17 standard for compiling
+-set(CMAKE_CXX_STANDARD 17)
++set(CMAKE_CXX_STANDARD 20)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ set(CMAKE_CXX_EXTENSIONS ON)
+ 
+@@ -170,7 +170,7 @@
+ endif()
+ 
+ # needed for JavaCC
+-set(JAVA_CC_EXTRA_FLAGS "-DJAVACC_CHAR_TYPE=\"unsigned char\"")
++set(JAVA_CC_EXTRA_FLAGS "-DJAVACC_CHAR_TYPE=\"char8_t\"")
+ set(CMAKE_CXX_FLAGS       "${CMAKE_CXX_FLAGS}       ${JAVA_CC_EXTRA_FLAGS}")
+ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${JAVA_CC_EXTRA_FLAGS}")
+ 
+--- doxygen-Release_1_12_0/src/portable.cpp.orig	2024-11-17 00:13:04.143190500 +0100
++++ doxygen-Release_1_12_0/src/portable.cpp	2024-11-17 00:13:12.551015300 +0100
+@@ -660,7 +660,7 @@
+   std::ios_base::openmode mode = std::ofstream::out | std::ofstream::binary;
+   if (append) mode |= std::ofstream::app;
+ #if defined(__clang__) && defined(__MINGW32__)
+-  return std::ofstream(fs::path(fileName.str()).wstring(), mode);
++  return std::ofstream(fs::path(fileName.str()).string(), mode);
+ #else
+   return std::ofstream(fs::path(fileName.str()), mode);
+ #endif
+@@ -672,7 +672,7 @@
+   if (binary)     mode |= std::ios::binary;
+   if (openAtEnd)  mode |= std::ios::ate;
+ #if defined(__clang__) && defined(__MINGW32__)
+-  return std::ifstream(fs::path(fileName.str()).wstring(), mode);
++  return std::ifstream(fs::path(fileName.str()).string(), mode);
+ #else
+   return std::ifstream(fs::path(fileName.str()), mode);
+ #endif

--- a/mingw-w64-doxygen/PKGBUILD
+++ b/mingw-w64-doxygen/PKGBUILD
@@ -4,7 +4,7 @@ _realname=doxygen
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.12.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A documentation system for C++, C, Java, IDL and PHP (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -32,9 +32,13 @@ if [[ ${CARCH} != i686 ]]; then
   optdepends=("${MINGW_PACKAGE_PREFIX}-qt6-base: for doxywizard")
 fi
 source=(https://github.com/doxygen/doxygen/archive/Release_${pkgver//./_}/${_realname}-${pkgver}.tar.gz
-        cmake-mingw.patch)
+        cmake-mingw.patch
+        https://github.com/doxygen/doxygen/commit/cff64a87dea7596fd506a85521d4df4616dc845f.patch
+        0002-clang-19-fix.patch)
 sha256sums=('5ca35e1258020df5fe8b21c3656aed156c317def4a81b7fe52f452edc9f35768'
-            '2b86315039128992f750e3f9793cb4a769e1ff62e77a00ae391d83810bc6f920')
+            '2b86315039128992f750e3f9793cb4a769e1ff62e77a00ae391d83810bc6f920'
+            '031022927c7b43c90c53971e6c7e7a807e7f3c860e2d5b8c4d158d06cc8445ce'
+            '8bd57267943b74e1bc4cae2c87da0255d747b6a2d35276fbfeb45f817947e991')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -49,6 +53,12 @@ prepare() {
 
   apply_patch_with_msg \
     cmake-mingw.patch
+
+  # llvm 19 fixes
+  # https://github.com/doxygen/doxygen/issues/10928
+  apply_patch_with_msg \
+    cff64a87dea7596fd506a85521d4df4616dc845f.patch \
+    0002-clang-19-fix.patch
 }
 
 build() {


### PR DESCRIPTION
libcxx removed various things:
https://releases.llvm.org/19.1.0/projects/libcxx/docs/ReleaseNotes.html#deprecations-and-removals