### PR TITLE
mesa: Restore optimization lost in 21ac180

### DIFF
--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -4,7 +4,7 @@ _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=24.2.7
-pkgrel=1
+pkgrel=2
 pkgdesc="Open-source implementation of the OpenGL, Vulkan and OpenCL specifications (mingw-w64)"
 url="https://www.mesa3d.org/"
 msys2_references=(
@@ -109,11 +109,17 @@ build() {
   -Dvulkan-drivers=swrast,amd,microsoft-experimental
   )
 
+  if [[ "${CARCH}" == "aarch64" ]]; then
+    _cc_march=armv8-a
+  else
+    _cc_march=core2
+  fi
+
   MSYS2_ARG_CONV_EXCL="--prefix=" \
   PROCESSOR_ARCHITECTURE="${CARCH}" \
   ${MINGW_PREFIX}/bin/meson setup \
-  -Dc_args="${CFLAGS}" \
-  -Dcpp_args="${CXXFLAGS}" \
+  -Dc_args="${CFLAGS} -march=${_cc_march}" \
+  -Dcpp_args="${CXXFLAGS} -march=${_cc_march}" \
   "${_meson_options[@]}" \
   "build-${MSYSTEM}" \
   "${_realname}-${pkgver}"


### PR DESCRIPTION
21ac180 switched to default makepkg-mingw CFLAGS and CXXFLAGS, losing CPU march optimization.
The optimization could have been restored in next commit, keeping the other compiler flags, but it wasn't..