### PR TITLE
gst-plugins-bad: check for necessary header in configure test

### DIFF
--- a/mingw-w64-gst-plugins-bad/0004-check-d3d11-header.patch
+++ b/mingw-w64-gst-plugins-bad/0004-check-d3d11-header.patch
@@ -1,0 +1,25 @@
+Avoid build error in CLANGARM64 environment:
+```
+  [669/1237] Compiling C++ object sys/d3d11/libgstd3d11.dll.p/gstd3d11window_swapchainpanel.cpp.obj
+  FAILED: sys/d3d11/libgstd3d11.dll.p/gstd3d11window_swapchainpanel.cpp.obj 
+  "clang++" "-Isys/d3d11/libgstd3d11.dll.p" "-Isys/d3d11" "-I../gst-plugins-bad-1.24.9/sys/d3d11" "-I." "-I../gst-plugins-bad-1.24.9" "-Igst-libs" "-I../gst-plugins-bad-1.24.9/gst-libs" "-Igst-libs/gst/codecs" "-Igst-libs/gst/d3d11" "-Igst-libs/gst/dxva" "-IC:/msys64/clangarm64/include/gstreamer-1.0" "-IC:/msys64/clangarm64/include/glib-2.0" "-IC:/msys64/clangarm64/lib/glib-2.0/include" "-IC:/msys64/clangarm64/include/orc-0.4" "-IC:/msys64/clangarm64/include/directxmath" "-fdiagnostics-color=always" "-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST" "-D_FILE_OFFSET_BITS=64" "-Wall" "-Winvalid-pch" "-Wno-non-virtual-dtor" "-fvisibility=hidden" "-fno-strict-aliasing" "-Wformat-nonliteral" "-Wmissing-declarations" "-Wredundant-decls" "-Wwrite-strings" "-Wformat" "-Wformat-security" "-Winit-self" "-Wmissing-include-dirs" "-Waddress" "-Wno-multichar" "-Wvla" "-Wpointer-arith" "-O2" "-pipe" "-Wp,-D_FORTIFY_SOURCE=2" "-fstack-protector-strong" "-Wp,-D__USE_MINGW_ANSI_STDIO=1" "-DHAVE_CONFIG_H" "-DGST_USE_UNSTABLE_API" "-DHAVE_WINMM" "-Wno-redundant-decls" -MD -MQ sys/d3d11/libgstd3d11.dll.p/gstd3d11window_swapchainpanel.cpp.obj -MF "sys/d3d11/libgstd3d11.dll.p/gstd3d11window_swapchainpanel.cpp.obj.d" -o sys/d3d11/libgstd3d11.dll.p/gstd3d11window_swapchainpanel.cpp.obj "-c" ../gst-plugins-bad-1.24.9/sys/d3d11/gstd3d11window_swapchainpanel.cpp
+
+  [trimmed loads of missing-braces warnings from Clang]
+
+ ../gst-plugins-bad-1.24.9/sys/d3d11/gstd3d11window_swapchainpanel.cpp:32:10: fatal error: 'windows.ui.xaml.media.dxinterop.h' file not found
+     32 | #include <windows.ui.xaml.media.dxinterop.h>
+        |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  62 warnings and 1 error generated.
+```
+
+diff -urN gst-plugins-bad-1.24.9/gst-libs/gst/d3d11/meson.build.orig gst-plugins-bad-1.24.9/gst-libs/gst/d3d11/meson.build
+--- gst-plugins-bad-1.24.9/gst-libs/gst/d3d11/meson.build.orig	2024-10-30 21:33:30.000000000 +0100
++++ gst-plugins-bad-1.24.9/gst-libs/gst/d3d11/meson.build	2024-11-20 12:49:56.619766000 +0100
+@@ -77,6 +77,7 @@
+ if runtimeobject_lib.found() and d3dcompiler_lib.found()
+   d3d11_winapi_app = cxx.compiles('''#include <winapifamily.h>
+       #include <windows.applicationmodel.core.h>
++      #include <windows.ui.xaml.media.dxinterop.h>
+       #include <wrl.h>
+       #include <wrl/wrappers/corewrappers.h>
+       #include <d3d11_4.h>

--- a/mingw-w64-gst-plugins-bad/PKGBUILD
+++ b/mingw-w64-gst-plugins-bad/PKGBUILD
@@ -8,7 +8,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-gst-plugins-bad-libs"
          "${MINGW_PACKAGE_PREFIX}-gst-plugins-bad"
          $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-gst-plugin-opencv"))
 pkgver=1.24.9
-pkgrel=2
+pkgrel=3
 pkgdesc="GStreamer Multimedia Framework Bad Plugins (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -85,22 +85,37 @@ makedepends=(
 source=("${url}/src/${_realname}/${_realname}-${pkgver}.tar.xz"{,.asc}
         "0001-meson-fix-vulkan.patch"
         "0002-fix-vulkan-mkenum.patch"
-        "0003-enable-mediafoundation-plugin.patch")
+        "0003-enable-mediafoundation-plugin.patch"
+        "0004-check-d3d11-header.patch")
 sha256sums=('36fcf7a9af0a753b43bb03b9835246f74d72f7124369e66a1e2dc7b04f5a5cab'
             'SKIP'
             '000907bb77b31bd5717297aaa9f7ab7d01a0c9a0e7966fd05f077e786b8e652f'
             '5ca55fdfc4c5d10d2319f83dddac8130c2ffab67b1248d2233cdcb188d5a0fd3'
-            '5cf2daa1b967112139e780a256957642cd005c25b1572e892d03021d1dec60ef')
+            '5cf2daa1b967112139e780a256957642cd005c25b1572e892d03021d1dec60ef'
+            '547248d0ea092dee103c452f5d12fc0302237244b3184d00bcb3afdac2476470')
 validpgpkeys=('D637032E45B8C6585B9456565D2EEE6F6F349D7C') # Tim Müller <tim@gstreamer-foundation.org>
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying ${_patch}"
+    patch -Nbp1 -i "${srcdir}/${_patch}"
+  done
+}
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
-  patch -Np1 -i "${srcdir}/0001-meson-fix-vulkan.patch"
-  patch -Np1 -i "${srcdir}/0002-fix-vulkan-mkenum.patch"
+  apply_patch_with_msg \
+    0001-meson-fix-vulkan.patch \
+    0002-fix-vulkan-mkenum.patch
 
   # https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/merge_requests/1882
   # Update 1.22: disabled mediafoundation again due to new missing APIs
-  patch -Np1 -i "${srcdir}/0003-enable-mediafoundation-plugin.patch"
+  apply_patch_with_msg \
+    0003-enable-mediafoundation-plugin.patch
+
+  apply_patch_with_msg \
+    0004-check-d3d11-header.patch
 }
 
 build() {


### PR DESCRIPTION
Fixes build issue in CLANGARM64 environment (see #22550).

I can't test if the change actually fixes the build issues. But if the compilation is currently failing because that header can't be found, the configuration test should also fail for the same reason. The failing configuration test would avoid compiling the problematic source files.
