### PR TITLE
python: backport shutil.which fixes

### DIFF
--- a/mingw-w64-python/PKGBUILD
+++ b/mingw-w64-python/PKGBUILD
@@ -23,7 +23,7 @@ else
   pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}${_pybasever}")
 fi
 pkgver=${_pybasever}.7
-pkgrel=2
+pkgrel=3
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -54,6 +54,7 @@ makedepends=(
 #options=('debug' '!strip')
 source=("https://www.python.org/ftp/python/${pkgver%rc?}/Python-${pkgver}.tar.xz"
         "EXTERNALLY-MANAGED"
+        https://github.com/python/cpython/commit/29648980d440e70ade4e0975b8d6aa83214866ed.patch
         0001-sysconfig-make-_sysconfigdata.py-relocatable.patch
         0002-build-add-with-nt-threads-and-make-it-default-on-min.patch
         0003-Define-MS_WINDOWS-and-others-when-compiling-with-MIN.patch
@@ -305,7 +306,10 @@ prepare() {
   0117-sysconfig.get_platform-use-consistent-naming.patch \
   0118-Add-ucrt-to-version-string.patch \
   0119-socketmodule-fix-captilization-of-headers.patch
- 
+
+  # https://github.com/python/cpython/issues/127001
+  patch -Np1 -i "${srcdir}/29648980d440e70ade4e0975b8d6aa83214866ed.patch"
+
   autoreconf -vfi
 }
 
@@ -415,6 +419,7 @@ package() {
 
 sha256sums=('24887b92e2afd4a2ac602419ad4b596372f67ac9b077190f459aba390faf5550'
             '3981fed74ee7d43ad69bd67e634e03d7bf6890558a87062380112e195688728a'
+            'b5c9ad802d6f3614aefbaec593c1c670dd1918b56e4ac9a682a6f23dfba579fa'
             '770dce22043bc1af5492fe946fb92cfcc9938058296e495e61895fb767339f8b'
             '1de135dac2a086c307a31c17b15e5e54a78b02c124518d5fe90393473ae97908'
             'c22cbb174ab1b017f90cd24a583cc04c908c1329b825e90a55ba6160754f9dc8'


### PR DESCRIPTION
This affects MSYS2 specifically since it would find the msys "cmd" bash script when running shutil.which("cmd") instead of the system cmd.exe.