### PR TITLE
gimp3: add provides and conflicts fields

### DIFF
--- a/mingw-w64-gimp3/PKGBUILD
+++ b/mingw-w64-gimp3/PKGBUILD
@@ -6,7 +6,7 @@ _pkgver=3.0.0
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=${_pkgver}${_pkgversuffix}
-pkgrel=2
+pkgrel=3
 pkgdesc="GNU Image Manipulation Program (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -17,6 +17,8 @@ msys2_references=(
   "cpe: cpe:/a:gimp:gimp"
 )
 license=('spdx:GPL-3.0-or-later AND LGPL-3.0-or-later')
+provides=("${MINGW_PACKAGE_PREFIX}-gimp")
+conflicts=("${MINGW_PACKAGE_PREFIX}-gimp")
 depends=("${MINGW_PACKAGE_PREFIX}-aalib"
          "${MINGW_PACKAGE_PREFIX}-appstream-glib"
          "${MINGW_PACKAGE_PREFIX}-atk"


### PR DESCRIPTION
gimp3 actually has some files that conflict with gimp package (at first gimp.exe)