### PR TITLE
meson: backport a fix for `autolib` sections in Cargo subprojects

### DIFF
--- a/mingw-w64-meson/PKGBUILD
+++ b/mingw-w64-meson/PKGBUILD
@@ -4,7 +4,7 @@ _realname=meson
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.6.0
-pkgrel=2
+pkgrel=3
 pkgdesc="High-productivity build system (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -31,13 +31,15 @@ source=("https://github.com/mesonbuild/${_realname}/releases/download/${pkgver}/
         '0002-Default-to-sys.prefix-as-the-default-prefix.patch'
         '0004-fix-gtk-doc.patch'
         'install-man.patch'
-        "https://patch-diff.githubusercontent.com/raw/mesonbuild/meson/pull/12861.patch")
+        "https://patch-diff.githubusercontent.com/raw/mesonbuild/meson/pull/12861.patch"
+        "https://github.com/mesonbuild/meson/commit/b131b2dc76ff0b14d755b1a3bbf7ce9565f49b0d.patch")
 sha256sums=('999b65f21c03541cf11365489c1fad22e2418bb0c3d50ca61139f2eec09d5496'
             '5805aed0a117536eb16dd8eef978c6be57c2471b655ede63e25517c28b4f4cf0'
             '032b38f0b2765dc88e1fcb34e27b69b611e07c869c13c6e703bcf182e586fccb'
             '0f9177102976bbcbdf50c1da49842783a0c77be939e839f1bf91dcaba6a5cdee'
             '0682a36cb75e545a78b81293303835a16171f25baf949905dc08029436efff84'
-            'cf346c13f9548d7c4f61ecc399ec9797cc642c3e39867deed8c788d825b877f6')
+            '999e0751148bd47c4496509210618cdba5e7baeb2601fbf810a88fc193bd0378'
+            'cea131f81247fe783ecd4657cd8f98f00884248d088a7fc5383e4ef2a3361e9a')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -58,6 +60,9 @@ prepare() {
 
   # https://github.com/mesonbuild/meson/pull/12861
   apply_patch_with_msg 12861.patch
+
+  # support autolib field for Cargo subprojects
+  apply_patch_with_msg b131b2dc76ff0b14d755b1a3bbf7ce9565f49b0d.patch
 }
 
 build() {


### PR DESCRIPTION
at one moment cargo subprojects start failing to extract because of new `autolib` section in Cargo.toml. add an upstream fix for this section support