### PR TITLE
tuxpaint: update to 0.9.34

### DIFF
--- a/mingw-w64-tuxpaint/001-makefile.patch
+++ b/mingw-w64-tuxpaint/001-makefile.patch
@@ -1,177 +1,64 @@
 diff --git a/Makefile b/Makefile
-index ed849d7d..5356be6f 100644
+index 8a69bbf58..1f30b428e 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -26,47 +26,14 @@ endif
- 
- MAGIC_API_VERSION:=0x00000009
- 
--# Need to know the OS
--SYSNAME:=$(shell uname -s)
--ifeq ($(findstring MINGW32, $(SYSNAME)),MINGW32)
--  OS:=windows
+@@ -32,13 +32,15 @@ MAGIC_API_VERSION:=0x0000000B
+ SYSNAME:=$(shell uname -s)
+ ifeq ($(findstring MINGW32, $(SYSNAME)),MINGW32)
+   OS:=windows
 -  GPERF:=/usr/bin/gperf
 -  MINGW_DIR:=/mingw32
--else
--  ifeq ($(findstring MINGW64, $(SYSNAME)),MINGW64)
--    OS:=windows
++  PREFIX ?= /usr
++  GPERF:=$(PREFIX)/bin/gperf
++  MINGW_DIR:=$(PREFIX)
+ else
+   ifeq ($(findstring MINGW64, $(SYSNAME)),MINGW64)
+     OS:=windows
 -    GPERF:=/usr/bin/gperf
 -    MINGW_DIR:=/mingw64
--  else
--    ifeq ($(SYSNAME),Darwin)
--      OS:=macos
--      GPERF:=/usr/bin/gperf
--
--      CC:=$(shell xcrun -f clang)
--      ARCHS:=$(shell uname -m)
--      MINVER:=10.8
--      SDKROOT:=$(shell xcrun --show-sdk-path)
--      HOSTROOT:=/opt/local
--    else
--      ifeq ($(SYSNAME),BeOS)
--        OS:=beos
--        GPERF:=$(shell finddir B_USER_BIN_DIRECTORY)/gperf
--      else
--        ifeq ($(SYSNAME),Haiku)
--          OS:=beos
--          GPERF:=$(shell finddir B_SYSTEM_BIN_DIRECTORY)/gperf
--          STDC_LIB:=-lstdc++
--          ifeq ($(shell gcc --version | cut -c 1-6),2.95.3)
--            STDC_LIB:=-lstdc++.r4
--          endif
--        else
--          OS:=linux
--          GPERF:=/usr/bin/gperf
--        endif
--      endif
--    endif
--  endif
--endif
-+PREFIX ?= /usr/local
-+BINDIR ?= $(PREFIX)/bin
-+LIBDIR ?= $(PREFIX)/lib
-+SHAREDIR ?= $(PREFIX)/share
-+INCLUDEDIR ?= $(PREFIX)/include
-+OS := windows
-+GPERF := $(BINDIR)/gperf
-+MINGW_DIR := $(PREFIX)
- 
- # CROSS COMPILATION OVERRIDES
- #
-@@ -156,7 +123,7 @@ beos_SO_TYPE:=so
++    PREFIX ?= /usr
++    GPERF:=$(PREFIX)/bin/gperf
++    MINGW_DIR:=$(PREFIX)
+   else
+     ifeq ($(SYSNAME),Darwin)
+       OS:=macos
+@@ -164,7 +166,7 @@ beos_SO_TYPE:=so
  linux_SO_TYPE:=so
  SO_TYPE:=$($(OS)_SO_TYPE)
  
 -windows_LIBMINGW:=-L/usr/local/lib -lmingw32
-+windows_LIBMINGW:=-L$(LIBDIR) -lmingw32
++windows_LIBMINGW:=-L$(PREFIX)/lib -lmingw32
  LIBMINGW:=$($(OS)_LIBMINGW)
  
  windows_EXE_EXT:=.exe
-@@ -192,10 +159,9 @@ PAPER_LIB:=$(call linktest,,-lpaper,)
- PNG:=$(call linktest,libpng,-lpng,)
- PNG:=$(if $(PNG),$(PNG),$(call linktest,,-lpng12,))
+@@ -228,7 +230,7 @@ ARCH_HEADERS:=$($(OS)_ARCH_HEADERS)
  
--FRIBIDI_LIB:=$(shell $(PKG_CONFIG) --libs fribidi)
- FRIBIDI_CFLAGS:=$(shell $(PKG_CONFIG) --cflags fribidi)
- 
--windows_ARCH_LINKS:=-lgdi32 -lcomdlg32 $(PNG) -lz -lwinspool -lshlwapi $(FRIBIDI_LIB) -liconv -limagequant -mwindows
-+windows_ARCH_LINKS:=-lgdi32 -lcomdlg32 $(PNG) $(shell $(PKG_CONFIG) --libs zlib iconv imagequant fribidi) -lwinspool -lshlwapi -mwindows
- macos_ARCH_LINKS:=$(FRIBIDI_LIB) -limagequant -lSDLmain -Wl,-framework,AppKit -Wl,-framework,Cocoa $(shell $(PKG_CONFIG) --libs pangoft2)
- ios_ARCH_LINKS=$(FRIBIDI_LIB) -limagequant -ljpeg -lbz2 $(shell $(PKG_CONFIG) --libs freetype2 libtiff-4 libwebp libffi harfbuzz libmpg123 ogg vorbisenc vorbisidec libxml-2.0 pangoft2 libpcre)
- beos_ARCH_LINKS:=-lintl $(PNG) -lz -lbe -lnetwork -liconv $(FRIBIDI_LIB) $(PAPER_LIB) $(STDC_LIB) -limagequant
-@@ -208,14 +174,6 @@ beos_ARCH_HEADERS:=src/BeOS_print.h
- linux_ARCH_HEADERS:=
- ARCH_HEADERS:=$($(OS)_ARCH_HEADERS)
- 
--# Where things will go when ultimately installed:
--# For macOS and iOS, the prefix is relative to DESTDIR.
+ # Where things will go when ultimately installed:
+ # For macOS and iOS, the prefix is relative to DESTDIR.
 -windows_PREFIX:=/usr/local
--macos_PREFIX:=Resources
--ios_PREFIX:=.
--linux_PREFIX:=/usr/local
--PREFIX:=$($(OS)_PREFIX)
--
- # Root directory to place files when creating packages.
- # PKG_ROOT is the old name for this, and should be undefined.
- # macOS and iOS are set up as bundles, with all files under the bundle.
-@@ -231,28 +189,25 @@ else
- endif
- 
- # Program:
--BIN_PREFIX:=$(DESTDIR)$(PREFIX)/bin
-+BIN_PREFIX:=$(DESTDIR)$(BINDIR)
- 
- # Data:
--DATA_PREFIX:=$(DESTDIR)$(PREFIX)/share/tuxpaint
-+DATA_PREFIX:=$(DESTDIR)$(SHAREDIR)/tuxpaint
- 
- # Locale files
--LOCALE_PREFIX=$(DESTDIR)$(PREFIX)/share/locale
-+LOCALE_PREFIX=$(DESTDIR)$(SHAREDIR)/locale
- 
- # IM files
--IM_PREFIX=$(DESTDIR)$(PREFIX)/share/tuxpaint/im
--
--# Libraries
--LIBDIR=$(PREFIX)
-+IM_PREFIX=$(DESTDIR)$(SHAREDIR)/tuxpaint/im
++windows_PREFIX:=$(PREFIX)
+ os2_PREFIX:=c:/extras/tuxpaint
+ macos_PREFIX:=Resources
+ ios_PREFIX:=.
+@@ -266,7 +268,7 @@ LIBDIR=$(PREFIX)
  
  # Magic Tool plug-ins
--INCLUDE_PREFIX:=$(DESTDIR)$(PREFIX)/include
+ INCLUDE_PREFIX:=$(DESTDIR)$(PREFIX)/include
 -MAGIC_PREFIX:=$(DESTDIR)$(LIBDIR)/lib$(LIBDIRSUFFIX)/tuxpaint/plugins
-+INCLUDE_PREFIX:=$(DESTDIR)$(INCLUDEDIR)
-+MAGIC_PREFIX:=$(DESTDIR)$(LIBDIR)/tuxpaint/plugins
++MAGIC_PREFIX:=$(DESTDIR)$(LIBDIR)/lib/tuxpaint/plugins
  
  # Docs and man page:
--DOC_PREFIX:=$(DESTDIR)$(PREFIX)/share/doc/tuxpaint-$(VER_VERSION)
--MAN_PREFIX:=$(DESTDIR)$(PREFIX)/share/man
--DEVMAN_PREFIX:=$(DESTDIR)$(PREFIX)/share/man
-+DOC_PREFIX:=$(DESTDIR)$(SHAREDIR)/doc/tuxpaint-$(VER_VERSION)
-+MAN_PREFIX:=$(DESTDIR)$(SHAREDIR)/man
-+DEVMAN_PREFIX:=$(DESTDIR)$(SHAREDIR)/man
- 
- # BASH tab-completion file:
- COMPLETIONDIR:=$(DESTDIR)/etc/bash_completion.d
-@@ -269,12 +224,12 @@ ifeq ($(SYSNAME),Haiku)
- endif
- 
- # Icons and launchers:
--ICON_PREFIX:=$(DESTDIR)$(PREFIX)/share/pixmaps
--NEWICON_PREFIX:=$(DESTDIR)$(PREFIX)/share/icons/hicolor
--X11_ICON_PREFIX:=$(DESTDIR)$(PREFIX)/share/pixmaps
-+ICON_PREFIX:=$(DESTDIR)$(SHAREDIR)/pixmaps
-+NEWICON_PREFIX:=$(DESTDIR)$(SHAREDIR)/icons/hicolor
-+X11_ICON_PREFIX:=$(DESTDIR)$(SHAREDIR)/pixmaps
- 
- # Appstream metainfo
--METAINFO_PREFIX=$(DESTDIR)$(PREFIX)/share/metainfo
-+METAINFO_PREFIX=$(DESTDIR)$(SHAREDIR)/metainfo
- 
- # Maemo flag
- MAEMOFLAG:=
-@@ -1057,9 +1012,9 @@ install-dlls:
- 	@cp -R win32/etc/ $(BIN_PREFIX)
- 	@echo
- 	@echo "...Installing Library Modules..."
--	@mkdir -p $(BIN_PREFIX)/lib/gdk-pixbuf-2.0/2.10.0/loaders
--	@cp $(MINGW_DIR)/lib/gdk-pixbuf-2.0/2.10.0/loaders/*.dll $(BIN_PREFIX)/lib/gdk-pixbuf-2.0/2.10.0/loaders
--	@strip -s $(BIN_PREFIX)/lib/gdk-pixbuf-2.0/2.10.0/loaders/*.dll
-+	@mkdir -p $(BIN_PREFIX)/gdk-pixbuf-2.0/2.10.0/loaders
-+	@cp $(MINGW_DIR)/lib/gdk-pixbuf-2.0/2.10.0/loaders/*.dll $(BIN_PREFIX)/gdk-pixbuf-2.0/2.10.0/loaders
-+	@strip -s $(BIN_PREFIX)/gdk-pixbuf-2.0/2.10.0/loaders/*.dll
- 
- # Install symlink:
- .PHONY: install-haiku
-@@ -1432,7 +1387,7 @@ obj:
+ DOC_PREFIX:=$(DESTDIR)$(PREFIX)/share/doc/tuxpaint-$(VER_VERSION)
+@@ -1463,7 +1465,7 @@ obj:
  MAGIC_SDL_CPPFLAGS:=$(shell $(PKG_CONFIG) $(SDL_PCNAME) --cflags)
  
  # FIXME: Expose SDL_rotozoom to Magic API? -bjk 2021.09.06
--windows_MAGIC_SDL_LIBS:=-L/usr/local/lib $(LIBMINGW) $(shell $(PKG_CONFIG) $(SDL_PCNAME) --libs) -lSDL2_image -lSDL2_ttf $(SDL_MIXER_LIB)
-+windows_MAGIC_SDL_LIBS:=-L$(LIBDIR) $(LIBMINGW) $(shell $(PKG_CONFIG) $(SDL_PCNAME) --libs) -lSDL2_image -lSDL2_ttf $(SDL_MIXER_LIB)
- macos_MAGIC_SDL_LIBS:=-L/usr/local/lib $(shell $(PKG_CONFIG) $(SDL_PCNAME) --libs) -lSDL2_image -lSDL2_ttf $(SDL_MIXER_LIB)
- ios_MAGIC_SDL_LIBS:=$(shell $(PKG_CONFIG) $(SDL_PCNAME) --libs) -lSDL2_image -lSDL2_ttf $(SDL_MIXER_LIB)
- beos_MAGIC_SDL_LIBS:=-L/usr/local/lib $(shell $(PKG_CONFIG) $(SDL_PCNAME) --libs) -lSDL2_image -lSDL2_ttf $(SDL_MIXER_LIB)
-@@ -1469,4 +1424,3 @@ magic-plugins:	src/tp_magic_api.h $(MAGIC_SO)
+-windows_MAGIC_SDL_LIBS:=-L/usr/local/lib $(LIBMINGW) $(shell $(PKG_CONFIG) $(SDL_PCNAME) --libs) -lSDL2_image -lSDL2_ttf $(SDL_MIXER_LIB) -lSDL2_gfx
++windows_MAGIC_SDL_LIBS:=-L$(PREFIX)/lib $(LIBMINGW) $(shell $(PKG_CONFIG) $(SDL_PCNAME) --libs) -lSDL2_image -lSDL2_ttf $(SDL_MIXER_LIB) -lSDL2_gfx
+ os2_MAGIC_SDL_LIBS:=-L/@unixroot/usr/lib $(shell $(PKG_CONFIG) $(SDL_PCNAME) --libs) -lSDL2_image -lSDL2_ttf $(SDL_MIXER_LIB)
+ macos_MAGIC_SDL_LIBS:=-L/usr/local/lib $(shell $(PKG_CONFIG) $(SDL_PCNAME) --libs) -lSDL2_image -lSDL2_ttf $(SDL_MIXER_LIB) -lSDL2_gfx
+ ios_MAGIC_SDL_LIBS:=$(shell $(PKG_CONFIG) $(SDL_PCNAME) --libs) -lSDL2_image -lSDL2_ttf $(SDL_MIXER_LIB) -lSDL2_gfx
+@@ -1503,4 +1505,3 @@ magic-plugins:	src/tp_magic_api.h $(MAGIC_SO)
  
  test-png:	src/test-png.c
  	$(CC) $(PNG_CFLAGS) src/test-png.c -o test-png $(PNG)

--- a/mingw-w64-tuxpaint/PKGBUILD
+++ b/mingw-w64-tuxpaint/PKGBUILD
@@ -4,14 +4,13 @@ _realname=tuxpaint
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
-pkgver=0.9.32
+pkgver=0.9.34
 pkgrel=1
 pkgdesc='Drawing program designed for young children (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://tuxpaint.org/'
 license=('spdx:GPL-2.0-only')
-backup=("${MINGW_PREFIX:1}/etc/tuxpaint/tuxpaint.conf")
 depends=("${MINGW_PACKAGE_PREFIX}-cairo"
          "${MINGW_PACKAGE_PREFIX}-gettext-runtime"
          "${MINGW_PACKAGE_PREFIX}-zlib"
@@ -29,46 +28,40 @@ depends=("${MINGW_PACKAGE_PREFIX}-cairo"
          "${MINGW_PACKAGE_PREFIX}-SDL2_pango"
          "${MINGW_PACKAGE_PREFIX}-SDL2_ttf")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-gperf"
              "${MINGW_PACKAGE_PREFIX}-imagemagick"
              "${MINGW_PACKAGE_PREFIX}-libpaper"
              "${MINGW_PACKAGE_PREFIX}-gettext-tools")
 options=('!emptydirs')
-optdepends=("${MINGW_PACKAGE_PREFIX}-python2: zh_tw font generator script"
-            #"${MINGW_PACKAGE_PREFIX}-tuxpaint-stamps: more stamps"
+optdepends=(#"${MINGW_PACKAGE_PREFIX}-tuxpaint-stamps: more stamps"
             #"${MINGW_PACKAGE_PREFIX}-tuxpaint-config: configuration manager"
-            "${MINGW_PACKAGE_PREFIX}-fontforge: zh_tw doc generator script"
-            'bash: for tp-magic-config, tuxpaint-import, zh_tw doc generator scripts')
+            "${MINGW_PACKAGE_PREFIX}-fontforge: zh_tw doc generator script")
 source=("https://downloads.sourceforge.net/sourceforge/tuxpaint/${_realname}-${pkgver}.tar.gz"
         "001-makefile.patch")
-sha256sums=('09cce22241481dc1360fc4bc5d4da1d31815d7a2563b9e9fa217a672ba974bf2'
-            '9ddc1f7ad6102867ab3eb36573f64ae14fed96130adbd514357b406a14c236d7')
+sha256sums=('b761df5ed386a9e04a6809ab3e0cbf2126f10b770527cb2b5f190ff5e370ed03'
+            'a9f6428c6e23c9869db450999e6181a487dd9ec36070a1c8bc5cd69b8ff41e85')
 noextract=("${_realname}-${pkgver}.tar.gz")
 
 prepare() {
   tar -xzf "${_realname}-${pkgver}.tar.gz" || true
-  cd "${srcdir}/${_realname}-${pkgver}"
+  cd "${_realname}-${pkgver}"
 
   patch -Np1 -i "${srcdir}/001-makefile.patch"
-
-  for _f in docs/outdated/zh_tw/mkTuxpaintIM.py fonts/locale/zh_tw_docs/maketuxfont.py; do
-    sed -i '0,/python$/s//python2/' $_f
-  done
 }
 
 build() {
-  cd "${srcdir}/${_realname}-${pkgver}"
-
-  make PREFIX="${MINGW_PREFIX}" \
+  make -C "${_realname}-${pkgver}"\
+    PREFIX="${MINGW_PREFIX}" \
     LDFLAGS="${LDFLAGS}" \
     OPTFLAGS="${CFLAGS} -ffast-math" FASTMATH="${CFLAGS} -ffast-math" \
     all
 }
 
 package_tuxpaint() {
-  cd "${srcdir}/${_realname}-${pkgver}"
+  backup=("${MINGW_PREFIX:1}/etc/tuxpaint/tuxpaint.conf")
 
-  make \
+  make -C "${_realname}-${pkgver}" \
     PREFIX="${MINGW_PREFIX}" \
     GNOME_PREFIX="${MINGW_PREFIX}" \
     COMPLETIONDIR="${pkgdir}${MINGW_PREFIX}/share/bash-completion/completions" \
@@ -81,7 +74,9 @@ package_tuxpaint() {
 }
 
 package_tuxpaint-docs() {
-  cd "${srcdir}/${_realname}-${pkgver}"
+  pkgdesc+=" (Documentation)"
+  depends=()
+  optdepends=()
 
   mv dest/* "${pkgdir}"
 }


### PR DESCRIPTION
- cleanup patch
- remove python2 from optdepends, as a part of python2 removal