### PR TITLE
gimp: rebuild without python2 for ucrt64 and clang64

### DIFF
--- a/mingw-w64-gimp/PKGBUILD
+++ b/mingw-w64-gimp/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gimp
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.10.38
-pkgrel=3
+pkgrel=4
 pkgdesc="GNU Image Manipulation Program (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -24,6 +24,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-babl"
          "${MINGW_PACKAGE_PREFIX}-ghostscript"
          "${MINGW_PACKAGE_PREFIX}-glib-networking"
          "${MINGW_PACKAGE_PREFIX}-gtk-update-icon-cache"
+         "${MINGW_PACKAGE_PREFIX}-gtk2"
          "${MINGW_PACKAGE_PREFIX}-hicolor-icon-theme"
          "${MINGW_PACKAGE_PREFIX}-iso-codes"
          "${MINGW_PACKAGE_PREFIX}-jasper"
@@ -38,12 +39,13 @@ depends=("${MINGW_PACKAGE_PREFIX}-babl"
          "${MINGW_PACKAGE_PREFIX}-openexr"
          "${MINGW_PACKAGE_PREFIX}-openjpeg2"
          "${MINGW_PACKAGE_PREFIX}-poppler"
-         "${MINGW_PACKAGE_PREFIX}-python2-pygtk"
-         "${MINGW_PACKAGE_PREFIX}-python2-gobject2"
+         $([[ ${MSYSTEM} == MINGW* ]] && echo \
+           "${MINGW_PACKAGE_PREFIX}-python2-pygtk"
+           "${MINGW_PACKAGE_PREFIX}-python2-gobject2")
          "${MINGW_PACKAGE_PREFIX}-xpm-nox")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools"
-             "${MINGW_PACKAGE_PREFIX}-pygobject2-devel"
+             $([[ ${MSYSTEM} == MINGW* ]] && echo "${MINGW_PACKAGE_PREFIX}-pygobject2-devel")
              "${MINGW_PACKAGE_PREFIX}-gtk-doc"
              "${MINGW_PACKAGE_PREFIX}-libjxl"
              "intltool")
@@ -101,8 +103,15 @@ prepare() {
 build() {
   mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
 
+  declare -a _python
+  if [[ ${MSYSTEM} == MINGW* ]]; then
+    _python=("--enable-python")
+    export PYTHON="${MINGW_PREFIX}/bin/python2"
+  else
+    _python=("--disable-python")
+  fi
+
   CFLAGS+=" -Wno-error=int-conversion" CXXFLAGS+=" -Wno-error=int-conversion" \
-  PYTHON="${MINGW_PREFIX}/bin/python2" \
   ../${_realname}-${pkgver}/configure \
     --prefix="${MINGW_PREFIX}" \
     --build=${MINGW_CHOST} \
@@ -111,7 +120,7 @@ build() {
     --sysconfdir="${MINGW_PREFIX}"/etc \
     --enable-mp \
     --enable-gimp-console \
-    --enable-python \
+    "${_python[@]}" \
     --without-aa \
     --with-pdbgen \
     --with-directx-sdk="${MINGW_PREFIX}"/${MINGW_CHOST} \
@@ -129,7 +138,9 @@ package() {
   make DESTDIR="${pkgdir}" install
 
   ln -s gimptool-2.0 "${pkgdir}${MINGW_PREFIX}/bin/gimptool.exe"
-  sed -e "s|${MINGW_PREFIX}/bin/python2|python2w.exe|g" -i "${pkgdir}${MINGW_PREFIX}"/lib/gimp/2.0/interpreters/pygimp.interp
+  if [[ ${MSYSTEM} == MINGW* ]]; then
+    sed -e "s|${MINGW_PREFIX}/bin/python2|python2w.exe|g" -i "${pkgdir}${MINGW_PREFIX}"/lib/gimp/2.0/interpreters/pygimp.interp
+  fi
   rm -f "${pkgdir}${MINGW_PREFIX}/lib/*.def"
   rm -f "${pkgdir}${MINGW_PREFIX}/lib/gimp/2.0/modules/*.dll.a"
 


### PR DESCRIPTION
*as discussed below*:

mingw32 and mingw64 is used by gimp devs to make release. for remaining envs there is no sense to keep EOLed version of python, users can switch to gimp3, which is about to release soon