### PR TITLE
gnucobol: fix building discrepancy

### DIFF
--- a/mingw-w64-gnucobol/0001-gnucobol-extras-include-srcdir.patch
+++ b/mingw-w64-gnucobol/0001-gnucobol-extras-include-srcdir.patch
@@ -1,8 +1,10 @@
---- a/extras/Makefile.am
-+++ b/extras/Makefile.am
-@@ -30,6 +30,6 @@
-
- SUFFIXES = .cob .$(COB_MODULE_EXT)
+diff --git a/extras/Makefile.in b/extras/Makefile.in
+index 857dea6..4cfc0a9 100644
+--- a/extras/Makefile.in
++++ b/extras/Makefile.in
+@@ -612,9 +612,9 @@ uninstall-am: uninstall-extrasDATA
+ .PRECIOUS: Makefile
+ 
  .cob.$(COB_MODULE_EXT):
 -	("$(top_builddir)/pre-inst-env" $(COBC) -m -Wall -O2 -o "$@" "$<" || \
 -	 "$(top_builddir)/pre-inst-env" $(COBC) -m -Wall     -o "$@" "$<" || \
@@ -10,3 +12,6 @@
 +	("$(top_builddir)/pre-inst-env" $(COBC) -I$(top_srcdir) -m -Wall -O2 -o "$@" "$<" || \
 +	 "$(top_builddir)/pre-inst-env" $(COBC) -I$(top_srcdir) -m -Wall     -o "$@" "$<" || \
 +	 "$(top_builddir)/pre-inst-env" $(COBC) -I$(top_srcdir) -m -Wall -vv -o "$@" "$<")
+ 
+ # Tell versions [3.59,3.63) of GNU make to not export all variables.
+ # Otherwise a system limit (for SysV at least) may be exceeded.

--- a/mingw-w64-gnucobol/0002-deprecated-ucrt-functions.patch
+++ b/mingw-w64-gnucobol/0002-deprecated-ucrt-functions.patch
@@ -1,0 +1,13 @@
+diff --git a/libcob/common.h b/libcob/common.h
+index c01965e..ae03c64 100644
+--- a/libcob/common.h
++++ b/libcob/common.h
+@@ -337,7 +337,7 @@ only usable with COB_USE_VC2013_OR_GREATER */
+ #define daylight	_daylight
+ #endif /* __BORLANDC__ */
+ 
+-#ifdef __ORANGEC__
++#if defined(__ORANGEC__) || defined(_UCRT)
+ #define timezone		_timezone
+ #define tzname			_tzname
+ #define daylight		_daylight

--- a/mingw-w64-gnucobol/0003-missing-libxml2-header.patch
+++ b/mingw-w64-gnucobol/0003-missing-libxml2-header.patch
@@ -1,0 +1,12 @@
+diff --git a/libcob/common.c b/libcob/common.c
+index eef27ff..cb22742 100644
+--- a/libcob/common.c
++++ b/libcob/common.c
+@@ -136,6 +136,7 @@
+ #if defined (WITH_XML2)
+ #include <libxml/xmlversion.h>
+ #include <libxml/xmlwriter.h>
++#include <libxml/parser.h> // for xmlCleanupParser
+ #endif
+ 
+ #if defined (WITH_CJSON)

--- a/mingw-w64-gnucobol/PKGBUILD
+++ b/mingw-w64-gnucobol/PKGBUILD
@@ -6,8 +6,7 @@ _realname=gnucobol
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=3.2
-pkgrel=3
-epoch=1
+pkgrel=4
 pkgdesc="GnuCOBOL, a free and modern COBOL compiler (mingw-w64)"
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-svn" "${MINGW_PACKAGE_PREFIX}-gnu-cobol-svn")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-svn" "${MINGW_PACKAGE_PREFIX}-gnu-cobol-svn")
@@ -26,58 +25,64 @@ depends=("${MINGW_PACKAGE_PREFIX}-cc"
          "${MINGW_PACKAGE_PREFIX}-json-c"
          "${MINGW_PACKAGE_PREFIX}-libxml2"
          "${MINGW_PACKAGE_PREFIX}-db")
-
-# the optional depencies cannot be used for creating the binary packages, moved to depends
-#optdepends=("${MINGW_PACKAGE_PREFIX}-gettext: support for internationalization"
-#            "${MINGW_PACKAGE_PREFIX}-ncurses: support for extended screenio"
-#            "${MINGW_PACKAGE_PREFIX}-pdcurses: support for screenio"
-#            "${MINGW_PACKAGE_PREFIX}-cjson: support for JSON GENERATE"
-#            "${MINGW_PACKAGE_PREFIX}-json-c: support for JSON GENERATE"
-#            "${MINGW_PACKAGE_PREFIX}-libxml2: support for XML GENERATE")
-makedepends=("${MINGW_PACKAGE_PREFIX}-autotools" "${MINGW_PACKAGE_PREFIX}-gettext-tools")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gettext-tools"
+             "${MINGW_PACKAGE_PREFIX}-pkgconf")
 # Note: "make test" actually needs a version from the build environment (MSYS)
 checkdepends=(perl)
-
-# local definitions
-#source=("https://alpha.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.xz"{,.sig}
 source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.xz"{,.sig}
         "cobenv.sh"
         "cobenv.cmd"
         "https://web.archive.org/web/20240322143655if_/https://www.itl.nist.gov/div897/ctg/suites/newcob.val.Z"
         0001-gnucobol-extras-include-srcdir.patch
+        0002-deprecated-ucrt-functions.patch
+        0003-missing-libxml2-header.patch
         )
 sha256sums=('3bb48af46ced4779facf41fdc2ee60e4ccb86eaa99d010b36685315df39c2ee2'
             'SKIP'
             '05a859975a39428823933c4612a7d8137c3ab1bf6c5127b1f35ec39533fb7c69'
             '244afbd011b0c0141753c7259173d9f49f161a97c7252b52369e0cec50147308'
             '1e9a92ddbd5d730cbeb764281f7810c22b18e0163985b09675393ab22bbd61f9'
-            'd8ee50c9f22849081783cc65c62536aa1f4e017fa683c4041400e5dde8b30159')
+            '4c0a506334d358c6cfc607b8be3aff3fccf19df82232be385c8b298fd7a5cb8b'
+            '4eb7b851401200c845cdf900fc8a8ca9fa50afdcfb92cb26febf0b1c85b25dc7'
+            '337a5453a19dda5e189a5e17f3941025ea67969ebb884d632eea955c1f097e2b')
 validpgpkeys=('B9459D0CA8A740B323235CDF13E96B53C005604E')
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying ${_patch}"
+    patch -Np1 -i "${srcdir}/${_patch}"
+  done
+}
 
 prepare() {
   cd "${_realname}-${pkgver}"
   cp ${srcdir}/newcob.val.Z tests/cobol85/
 
-  patch -p1 -i "${srcdir}/0001-gnucobol-extras-include-srcdir.patch"
-  autoreconf -fiv
+  apply_patch_with_msg \
+    0001-gnucobol-extras-include-srcdir.patch \
+    0002-deprecated-ucrt-functions.patch \
+    0003-missing-libxml2-header.patch
 }
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
 
   export lt_cv_deplibs_check_method='pass_all'   # libncurses with unconforming name
-  CFLAGS+=" -Wno-implicit-function-declaration" \
   ../${_realname}-${pkgver}/configure \
-    CPPLAGS="-D__USE_MINGW_ANSI_STDIO=1" \
     PERL="/usr/bin/perl" \
-    --with-db --without-vbisam --without-disam --without-cisam \
-    --with-xml2 --with-json=json-c --with-curses=ncursesw \
-    --build=${MINGW_CHOST} \
-    --host=${MINGW_CHOST} \
-    --target=${MINGW_CHOST} \
+    CURSES_LIBS="$(ncursesw6-config --libs)" \
     --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
     --infodir=${MINGW_PREFIX}/share/info \
     --mandir=${MINGW_PREFIX}/share/man \
+    --with-curses=ncursesw \
+    --with-json=json-c \
+    --with-db \
+    --with-xml2 \
+    --without-cisam \
+    --without-disam \
+    --without-vbisam \
     --disable-rpath \
     --enable-shared \
     --disable-static


### PR DESCRIPTION
- PKGBUILD cleanup
- add missing libxml2 header
- fix deprecated ucrt functions

@GitMensch 

@lazka can we remove `epoch=1` ?