### PR TITLE
gitoxide: package shell completions; do not depend on sqlite

### DIFF
--- a/mingw-w64-gitoxide/PKGBUILD
+++ b/mingw-w64-gitoxide/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gitoxide
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.39.0
-pkgrel=1
+pkgrel=2
 pkgdesc="An idiomatic, lean, fast & safe pure Rust implementation of Git (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -13,17 +13,9 @@ license=('spdx:Apache-2.0 OR MIT')
 msys2_references=(
   'archlinux: gitoxide'
 )
-depends=("${MINGW_PACKAGE_PREFIX}-sqlite3")
-makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
-             "${MINGW_PACKAGE_PREFIX}-pkgconf"
-             'git')
+makedepends=("${MINGW_PACKAGE_PREFIX}-rust" 'git')
 source=("git+${url}.git#tag=v${pkgver}")
 sha256sums=('3b182386e8bf4026fa7c91a3d750c213f17d33ab42969d01c07c8c07ae757549')
-
-_env() {
-  export WINAPI_NO_BUNDLED_LIBRARIES=1
-  export LIBSQLITE3_SYS_USE_PKG_CONFIG=1
-}
 
 prepare() {
   cd "${_realname}"
@@ -34,7 +26,7 @@ prepare() {
 build() {
   cd "${_realname}"
 
-  _env
+  export WINAPI_NO_BUNDLED_LIBRARIES=1
   cargo build \
     --release \
     --locked \
@@ -47,7 +39,7 @@ build() {
 check() {
   cd "${_realname}"
 
-  _env
+  export WINAPI_NO_BUNDLED_LIBRARIES=1
   cargo test \
     --release \
     --locked \
@@ -58,7 +50,15 @@ check() {
 }
 
 package() {
-  install -Dm755 "${_realname}"/target/release/{gix,ein} -t "${pkgdir}${MINGW_PREFIX}/bin/"
+  for _bin in gix ein; do
+    install -Dm755 -t "${pkgdir}${MINGW_PREFIX}/bin" "${_realname}/target/release/${_bin}"
+
+    # install completions
+    local _complete="${pkgdir}${MINGW_PREFIX}/bin/${_bin} completions -s"
+    $_complete bash | install -Dm644 /dev/stdin "${pkgdir}${MINGW_PREFIX}/share/bash-completion/completions/${_bin}"
+    $_complete zsh | install -Dm644 /dev/stdin "${pkgdir}${MINGW_PREFIX}/share/zsh/site-functions/_${_bin}"
+    $_complete fish | install -Dm644 /dev/stdin "${pkgdir}${MINGW_PREFIX}/share/fish/vendor_completions.d/${_bin}.fish"
+  done
 
   install -Dm644 "${_realname}"/LICENSE-{APACHE,MIT} -t "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/"
 }


### PR DESCRIPTION
also turns out libsqlite3-sys is no longer built with max-pure feature