### PR TITLE
Add qucs-s

### DIFF
--- a/mingw-w64-qucs-s/PKGBUILD
+++ b/mingw-w64-qucs-s/PKGBUILD
@@ -1,0 +1,59 @@
+# Maintainer: Kreijstal <kreijstal@hotmail.com>
+
+_realname=qucs-s
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=24.4.1
+pkgrel=1
+pkgdesc="A spin-off of Qucs that supports other free SPICE circuit simulators like ngspice with the same Qucs GUI"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/ra3xdh/qucs_s'
+license=('spdx:gpl-2.0')
+groups=("${MINGW_PACKAGE_PREFIX}-eda")
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-qt6-base"
+  "${MINGW_PACKAGE_PREFIX}-gcc-libs"
+  "${MINGW_PACKAGE_PREFIX}-ngspice"
+  "${MINGW_PACKAGE_PREFIX}-qt6-svg"
+  "${MINGW_PACKAGE_PREFIX}-qt6-charts"
+
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+  "${MINGW_PACKAGE_PREFIX}-ninja"
+  "${MINGW_PACKAGE_PREFIX}-qt6-tools"
+  "${MINGW_PACKAGE_PREFIX}-python"
+  "${MINGW_PACKAGE_PREFIX}-gperf"
+)
+source=(
+  "https://github.com/ra3xdh/qucs_s/releases/download/${pkgver}/${_realname}-${pkgver}.tar.gz"
+)
+sha256sums=('214bcc151cd8bc06c8365420d1a2ef0a6d46b154acfd8b4b51ecf5d9f112eda9')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+}
+
+build() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    cmake \
+    -GNinja \
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+    -DCMAKE_BUILD_TYPE="Release" \
+    -DWITH_QT6=ON \
+    -DCI_VERSION="${pkgver}" \
+    ..
+
+  cmake --build .
+}
+
+
+package() {
+  cd "${srcdir}/${_realname}-${pkgver}/build-${MSYSTEM}"
+  DESTDIR="${pkgdir}" cmake --install .
+}


### PR DESCRIPTION
This an eletrical schematic and simulator using ngspice and quics own simulator.

Xyce can be used but Xyce hasn't been packaged yet.

What is also great is https://github.com/ra3xdh/qucs_s has msys2 on their CI