### PR TITLE
chicken: Update to 5.4.0

### DIFF
--- a/mingw-w64-chicken/PKGBUILD
+++ b/mingw-w64-chicken/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=chicken
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=5.3.0
-pkgrel=2
+pkgver=5.4.0
+pkgrel=1
 pkgdesc='Feature rich R5RS Scheme compiler and interpreter (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -15,15 +15,20 @@ msys2_references=(
 license=('BSD')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
 source=("https://code.call-cc.org/releases/$pkgver/${_realname}-$pkgver.tar.gz")
-sha256sums=('c3ad99d8f9e17ed810912ef981ac3b0c2e2f46fb0ecc033b5c3b6dca1bdb0d76')
+sha256sums=('3c5d4aa61c1167bf6d9bf9eaf891da7630ba9f5f3c15bf09515a7039bfcdec5f')
 
 build() {
   cd "${srcdir}/${_realname}-${pkgver}"
-  make -j1 PLATFORM=mingw-msys PREFIX="${MINGW_PREFIX}"
+
+  if [[ $MINGW_PACKAGE_PREFIX != *-clang-* ]]; then
+    CFLAGS+=" -Wno-incompatible-pointer-types"
+  fi
+
+  make PLATFORM=mingw-msys PREFIX="${MINGW_PREFIX}" C_COMPILER="${CC}" C_COMPILER_OPTIMIZATION_OPTIONS="${CFLAGS}"
 }
 
 package() {
   cd "${srcdir}/${_realname}-${pkgver}"
-  make -j1 PLATFORM=mingw-msys DESTDIR="${pkgdir}" PREFIX="${MINGW_PREFIX}" install
+  make PLATFORM=mingw-msys DESTDIR="${pkgdir}" PREFIX="${MINGW_PREFIX}" install
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
* It doesn't respect CC, so pass explicitely.
* Also pass CFLAGS while at it.
* Silence build warning/error with newer GCC
* Try enabling parallel make