### PR TITLE
mosquitto: Update to 2.0.20

### DIFF
--- a/mingw-w64-mosquitto/0002-mosquitto-2.0.18-pkgconf-static-cflags.patch
+++ b/mingw-w64-mosquitto/0002-mosquitto-2.0.18-pkgconf-static-cflags.patch
@@ -1,20 +1,20 @@
-diff -Naur mosquitto-2.0.18.orig/libmosquitto.pc.in mosquitto-2.0.18/libmosquitto.pc.in
---- mosquitto-2.0.18.orig/libmosquitto.pc.in	2024-04-10 00:32:55.137531100 +0300
-+++ mosquitto-2.0.18/libmosquitto.pc.in	2024-04-10 21:47:48.600521000 +0300
-@@ -7,4 +7,6 @@
+--- mosquitto-2.0.20/libmosquitto.pc.in.orig	2024-12-01 12:42:30.793527700 +0100
++++ mosquitto-2.0.20/libmosquitto.pc.in	2024-12-01 12:41:15.482166800 +0100
+@@ -7,4 +7,7 @@
  Description: mosquitto MQTT library (C bindings)
  Version: @VERSION@
  Cflags: -I${includedir}
 +Cflags.private: -DLIBMOSQUITTO_STATIC
  Libs: -L${libdir} -lmosquitto
 +Requires.private: libssl
-diff -Naur mosquitto-2.0.18.orig/libmosquittopp.pc.in mosquitto-2.0.18/libmosquittopp.pc.in
---- mosquitto-2.0.18.orig/libmosquittopp.pc.in	2024-04-10 00:32:54.809404400 +0300
-+++ mosquitto-2.0.18/libmosquittopp.pc.in	2024-04-10 21:47:48.616141900 +0300
-@@ -7,4 +7,6 @@
++Libs.private: -lpthread
+--- mosquitto-2.0.20/libmosquittopp.pc.in.orig	2024-12-01 12:41:42.374178700 +0100
++++ mosquitto-2.0.20/libmosquittopp.pc.in	2024-12-01 12:41:33.484505100 +0100
+@@ -7,4 +7,7 @@
  Description: mosquitto MQTT library (C++ bindings)
  Version: @VERSION@
  Cflags: -I${includedir}
 +Cflags.private: -DLIBMOSQUITTO_STATIC
  Libs: -L${libdir} -lmosquittopp
 +Requires.private: libssl
++Libs.private: -lpthread

--- a/mingw-w64-mosquitto/0003-use-winpthreads.patch
+++ b/mingw-w64-mosquitto/0003-use-winpthreads.patch
@@ -1,0 +1,28 @@
+--- mosquitto-2.0.20/CMakeLists.txt.orig	2024-12-01 11:19:17.655712400 +0100
++++ mosquitto-2.0.20/CMakeLists.txt	2024-12-01 11:19:26.299160200 +0100
+@@ -72,7 +72,7 @@
+ option(WITH_THREADING "Include client library threading support?" ON)
+ if (WITH_THREADING)
+ 	add_definitions("-DWITH_THREADING")
+-	if(WIN32)
++	if(MSVC)
+ 		find_package(Pthreads4W REQUIRED)
+ 	endif()
+ endif (WITH_THREADING)
+--- mosquitto-2.0.20/lib/CMakeLists.txt.orig	2024-10-16 21:25:30.000000000 +0200
++++ mosquitto-2.0.20/lib/CMakeLists.txt	2024-12-01 11:42:46.319116200 +0100
+@@ -92,12 +92,12 @@
+ target_link_libraries(libmosquitto PRIVATE ${LIBRARIES})
+ 
+ if (WITH_THREADING)
+-	if(WIN32)
++	if(MSVC)
+ 		 target_link_libraries(libmosquitto PRIVATE PThreads4W::PThreads4W)
+ 	else()
+ 		set(THREADS_PREFER_PTHREAD_FLAG ON)
+ 		find_package(Threads REQUIRED)
+-
++		set (LIBRARIES ${LIBRARIES} Threads::Threads)
+ 		target_link_libraries(libmosquitto PRIVATE Threads::Threads)
+ 	endif()
+ endif()

--- a/mingw-w64-mosquitto/PKGBUILD
+++ b/mingw-w64-mosquitto/PKGBUILD
@@ -3,12 +3,13 @@
 _realname=mosquitto
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.0.18
-pkgrel=4
+pkgver=2.0.20
+pkgrel=1
 pkgdesc="An Open Source MQTT Broker (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://mosquitto.org"
+msys2_repository_url="https://github.com/eclipse-mosquitto/mosquitto"
 msys2_references=(
   "cpe: cpe:/a:eclipse:mosquitto"
 )
@@ -25,11 +26,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-docbook-xsl")
 source=("https://mosquitto.org/files/source/mosquitto-${pkgver}.tar.gz"{,.asc}
         '0001-mosquitto-2.0.18-fix-static-libname.patch'
-        '0002-mosquitto-2.0.18-pkgconf-static-cflags.patch')
-sha256sums=('d665fe7d0032881b1371a47f34169ee4edab67903b2cd2b4c083822823f4448a'
+        '0002-mosquitto-2.0.18-pkgconf-static-cflags.patch'
+        '0003-use-winpthreads.patch')
+sha256sums=('ebd07d89d2a446a7f74100ad51272e4a8bf300b61634a7812e19f068f2759de8'
             'SKIP'
             '153ad2cf3fd8708be469ba2c638e9951ef27841fbd3305b96e5b37781fe5fd09'
-            '6ce467f87cd3b2c1b57d2ed069d922410ce03744f8115156785438434fcb2377')
+            'c19505bec196a82c1c7955314355645eba737998cc99468a2c9836843c8a7c06'
+            'f4c6e6046ba0e678248299165854d975016d4f520b8e2aff7a11e1e3c961788e')
 validpgpkeys=('A0D6EEA1DCAE49A635A3B2F0779B22DFB3E717B7') # Roger A. Light <roger@atchoo.org>
 
 prepare() {
@@ -37,6 +40,8 @@ prepare() {
 
   patch -p1 -i "${srcdir}/0001-mosquitto-2.0.18-fix-static-libname.patch"
   patch -p1 -i "${srcdir}/0002-mosquitto-2.0.18-pkgconf-static-cflags.patch"
+  # It's trying to use Pthreads4W, which we don't have 
+  patch -p1 -i "${srcdir}/0003-use-winpthreads.patch"
 }
 
 build() {
@@ -47,6 +52,10 @@ build() {
     _extra_config+=("-DCMAKE_BUILD_TYPE=Release")
   else
     _extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  if [[ $MINGW_PACKAGE_PREFIX != *-clang-* ]]; then
+    CFLAGS+=" -Wno-incompatible-pointer-types"
   fi
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \


### PR DESCRIPTION
It now requires threading and fails to build if disabled (likely not tested upstream) so try using winpthreads. Hopefully good enough.