### PR TITLE
Enable KLU on ngspice

### DIFF
--- a/mingw-w64-ngspice/PKGBUILD
+++ b/mingw-w64-ngspice/PKGBUILD
@@ -5,7 +5,7 @@ _realname=ngspice
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=42
-pkgrel=1
+pkgrel=2
 pkgdesc="Mixed-level/Mixed-signal circuit simulator based on Spice3f5, Cider1b1, and Xspice (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -56,6 +56,7 @@ build() {
     --enable-openmp
     --enable-xspice
     --enable-cider
+    --enable-klu
   )
 
   # FS#45230, create so lib


### PR DESCRIPTION
According to https://ngspice.sourceforge.io/applic.html the default windows distribution has KLU enabled by default the reason for enabling this is for faster simulations on skywater-pdk https://github.com/google/skywater-pdk/issues/374

I am thinking once osdi support gets better we can also enable osdi support for verilog-a.