### PR TITLE
[new-package] python-spyder-vim 0.1.0

### DIFF
--- a/mingw-w64-python-spyder-vim/PKGBUILD
+++ b/mingw-w64-python-spyder-vim/PKGBUILD
@@ -1,0 +1,34 @@
+# Maintainer: Konstantin Podsvirov <konstantin@podsvirov.pro>
+
+_realname=spyder-vim
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=0.1.0
+pkgrel=1
+pkgdesc='A plugin for Spyder to enable Vim keybindings (mingw-w64)'
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64')
+url='https://github.com/spyder-ide/spyder-vim'
+license=('spdx:MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-spyder")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build" "${MINGW_PACKAGE_PREFIX}-python-installer")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('97c2ef31ae9bb24af1853d3741081cc27867f4c170e031a07daa213cc79577ca')
+
+build() {
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE.txt"
+}


### PR DESCRIPTION
Looks like this Spyder's plugin do not support latest Spyder (version 6):

```console
$ spyder
<class 'spyder_vim.spyder.plugin.SpyderVim'>: QWidget(parent: Optional[QWidget] = None, flags: Union[Qt.WindowFlags, Qt.WindowType] = Qt.WindowFlags()): argument 1 has unexpected type 'Editor'
Traceback (most recent call last):
  File "C:/msys64/ucrt64/lib/python3.12/site-packages/spyder/app/mainwindow.py", line 765, in setup
    plugin_instance = PLUGIN_REGISTRY.register_plugin(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/ucrt64/lib/python3.12/site-packages/spyder/api/plugin_registration/registry.py", line 344, in register_plugin
    instance = self._instantiate_spyder5_plugin(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/ucrt64/lib/python3.12/site-packages/spyder/api/plugin_registration/registry.py", line 198, in _instantiate_spyder5_plugin
    self._notify_plugin_dependencies(plugin_name)
  File "C:/msys64/ucrt64/lib/python3.12/site-packages/spyder/api/plugin_registration/registry.py", line 267, in _notify_plugin_dependencies
    plugin_instance._on_plugin_available(plugin)
  File "C:/msys64/ucrt64/lib/python3.12/site-packages/spyder/api/plugin_registration/mixins.py", line 99, in _on_plugin_available
    method()
  File "C:/msys64/ucrt64/lib/python3.12/site-packages/spyder_vim/spyder/plugin.py", line 64, in on_editor_available
    self.vim_cmd = VimWidget(editor, self.main)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/ucrt64/lib/python3.12/site-packages/spyder_vim/spyder/widgets.py", line 1524, in __init__
    QLineEdit.__init__(self, editor_widget)
TypeError: QWidget(parent: Optional[QWidget] = None, flags: Union[Qt.WindowFlags, Qt.WindowType] = Qt.WindowFlags()): argument 1 has unexpected type 'Editor'
```