### PR TITLE
[new package] python-toptica-lasersdk 3.2.0

### DIFF
--- a/mingw-w64-python-toptica-lasersdk/PKGBUILD
+++ b/mingw-w64-python-toptica-lasersdk/PKGBUILD
@@ -1,0 +1,40 @@
+# Maintainer: fsagbuya <fa@m-labs.ph>
+
+_realname=toptica-lasersdk
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=3.2.0
+pkgrel=1
+pkgdesc="TOPTICA Python Laser SDK (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url="https://toptica.github.io/python-lasersdk"
+msys2_references=(
+  'pypi: toptica_lasersdk'
+)
+license=('spdx:MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-ifaddr"
+         "${MINGW_PACKAGE_PREFIX}-python-pyserial")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!strip')
+source=("https://pypi.org/packages/source/t/toptica_lasersdk/toptica_lasersdk-${pkgver}.tar.gz")
+sha256sums=('SKIP')
+
+build() {
+  cp -r "toptica_lasersdk-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}


### PR DESCRIPTION
### Description

Added `python-toptica-lasersdk` package.

Tested in `CLANG64` shell:
```
$ lasersdk_gen
usage: lasersdk_gen [-h] [-m name] [-ul level] [-a] [-d] [-p cmd mon] [-c name] model_xml

Generate Python code from a DeCoP system description.

positional arguments:
  model_xml             DeCoP system description file or device IP address

options:
  -h, --help            show this help message and exit
  -m name, --module name
                        set the name of the generated Python module
  -ul level, --userlevel level
                        include properties up to this user level
  -a, --async           generate asynchronous Python code
  -d, --download        download system model from a device
  -p cmd mon, --ports cmd mon
                        set default ports for network connections
  -c name, --class name
                        set the name of the device class

```