### PR TITLE
libgig: add package

### DIFF
--- a/mingw-w64-libgig/PKGBUILD
+++ b/mingw-w64-libgig/PKGBUILD
@@ -1,0 +1,52 @@
+# Maintainer: Kreijstal <kreijstal@hotmail.com>
+
+_realname=libgig
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=4.4.1
+pkgrel=1
+pkgdesc="C++ library for loading, modifying and creating .gig, .dls, .kmp and SF2 files (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url="https://www.linuxsampler.org/libgig/"
+license=('spdx:gpl-2.0-or-later')
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-libsndfile")
+source=("https://download.linuxsampler.org/packages/${_realname}-${pkgver}.tar.bz2"
+        "libgig-4.3.0-libdir.patch")
+sha256sums=('fdc89efab1f906128e6c54729967577e8d0462017018bc12551257df5dfe3aa4'
+            'bfdc3a58af846f7eb8864dd489010b04957f29873a7b3c249460b3f4b02956ee')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+  autoreconf -fiv
+  patch -p1 -i "${srcdir}/libgig-4.3.0-libdir.patch"
+}
+
+build() {
+  mkdir -p "build-${MSYSTEM}" && cd "build-${MSYSTEM}"
+  export lt_cv_deplibs_check_method='pass_all'
+
+  ../"${_realname}-${pkgver}"/configure \
+    --prefix="${MINGW_PREFIX}" \
+    --build="${MINGW_CHOST}" \
+    --host="${MINGW_CHOST}" \
+    --target="${MINGW_CHOST}" \
+    --enable-shared \
+    --enable-static
+
+  make
+}
+
+check() {
+  cd "build-${MSYSTEM}"
+  make check
+}
+
+package() {
+  cd "build-${MSYSTEM}"
+  make DESTDIR="${pkgdir}" install
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}

--- a/mingw-w64-libgig/libgig-4.3.0-libdir.patch
+++ b/mingw-w64-libgig/libgig-4.3.0-libdir.patch
@@ -1,0 +1,106 @@
+diff -ruN a/Makefile.in b/Makefile.in
+--- a/Makefile.in	2021-05-09 12:55:07.000000000 +0200
++++ b/Makefile.in	2021-06-02 23:39:07.663208161 +0200
+@@ -72,8 +72,8 @@
+ am__make_keepgoing = (target_option=k; $(am__make_running_with_option))
+ pkgdatadir = $(datadir)/@PACKAGE@
+ pkgincludedir = $(includedir)/@PACKAGE@
+-pkglibdir = $(libdir)/@PACKAGE@
+-pkglibexecdir = $(libexecdir)/@PACKAGE@
++pkglibdir = $(libdir)/
++pkglibexecdir = $(libexecdir)/
+ am__cd = CDPATH="$${ZSH_VERSION+.}$(PATH_SEPARATOR)" && cd
+ install_sh_DATA = $(install_sh) -c -m 644
+ install_sh_PROGRAM = $(install_sh) -c
+diff -ruN a/akai.pc.in b/akai.pc.in
+--- a/akai.pc.in	2014-06-01 02:10:36.000000000 +0200
++++ b/akai.pc.in	2021-06-02 23:40:03.743599169 +0200
+@@ -1,6 +1,6 @@
+ prefix=@prefix@
+ exec_prefix=@exec_prefix@
+-libdir=@libdir@/libgig
++libdir=@libdir@
+ includedir=@includedir@/libgig
+ 
+ Name: akai
+diff -ruN a/doc/Makefile.in b/doc/Makefile.in
+--- a/doc/Makefile.in	2021-05-09 12:55:07.000000000 +0200
++++ b/doc/Makefile.in	2021-06-02 23:38:44.833042452 +0200
+@@ -71,8 +71,8 @@
+ am__make_keepgoing = (target_option=k; $(am__make_running_with_option))
+ pkgdatadir = $(datadir)/@PACKAGE@
+ pkgincludedir = $(includedir)/@PACKAGE@
+-pkglibdir = $(libdir)/@PACKAGE@
+-pkglibexecdir = $(libexecdir)/@PACKAGE@
++pkglibdir = $(libdir)/
++pkglibexecdir = $(libexecdir)/
+ am__cd = CDPATH="$${ZSH_VERSION+.}$(PATH_SEPARATOR)" && cd
+ install_sh_DATA = $(install_sh) -c -m 644
+ install_sh_PROGRAM = $(install_sh) -c
+diff -ruN a/gig.pc.in b/gig.pc.in
+--- a/gig.pc.in	2014-06-01 02:10:36.000000000 +0200
++++ b/gig.pc.in	2021-06-02 23:39:42.633454558 +0200
+@@ -1,6 +1,6 @@
+ prefix=@prefix@
+ exec_prefix=@exec_prefix@
+-libdir=@libdir@/libgig
++libdir=@libdir@
+ includedir=@includedir@/libgig
+ 
+ Name: gig
+diff -ruN a/man/Makefile.in b/man/Makefile.in
+--- a/man/Makefile.in	2021-05-09 12:55:07.000000000 +0200
++++ b/man/Makefile.in	2021-06-02 23:46:43.075891911 +0200
+@@ -71,8 +71,8 @@
+ am__make_keepgoing = (target_option=k; $(am__make_running_with_option))
+ pkgdatadir = $(datadir)/@PACKAGE@
+ pkgincludedir = $(includedir)/@PACKAGE@
+-pkglibdir = $(libdir)/@PACKAGE@
+-pkglibexecdir = $(libexecdir)/@PACKAGE@
++pkglibdir = $(libdir)/
++pkglibexecdir = $(libexecdir)/
+ am__cd = CDPATH="$${ZSH_VERSION+.}$(PATH_SEPARATOR)" && cd
+ install_sh_DATA = $(install_sh) -c -m 644
+ install_sh_PROGRAM = $(install_sh) -c
+diff -ruN a/src/Makefile.in b/src/Makefile.in
+--- a/src/Makefile.in	2021-05-09 12:55:08.000000000 +0200
++++ b/src/Makefile.in	2021-06-02 23:42:54.591337164 +0200
+@@ -73,8 +73,8 @@
+ am__make_keepgoing = (target_option=k; $(am__make_running_with_option))
+ pkgdatadir = $(datadir)/@PACKAGE@
+ pkgincludedir = $(includedir)/@PACKAGE@
+-pkglibdir = $(libdir)/@PACKAGE@
+-pkglibexecdir = $(libexecdir)/@PACKAGE@
++pkglibdir = $(libdir)/
++pkglibexecdir = $(libexecdir)/
+ am__cd = CDPATH="$${ZSH_VERSION+.}$(PATH_SEPARATOR)" && cd
+ install_sh_DATA = $(install_sh) -c -m 644
+ install_sh_PROGRAM = $(install_sh) -c
+diff -ruN a/src/testcases/Makefile.in b/src/testcases/Makefile.in
+--- a/src/testcases/Makefile.in	2021-05-09 12:55:08.000000000 +0200
++++ b/src/testcases/Makefile.in	2021-06-02 23:46:15.145752714 +0200
+@@ -71,8 +71,8 @@
+ am__make_keepgoing = (target_option=k; $(am__make_running_with_option))
+ pkgdatadir = $(datadir)/@PACKAGE@
+ pkgincludedir = $(includedir)/@PACKAGE@
+-pkglibdir = $(libdir)/@PACKAGE@
+-pkglibexecdir = $(libexecdir)/@PACKAGE@
++pkglibdir = $(libdir)/
++pkglibexecdir = $(libexecdir)/
+ am__cd = CDPATH="$${ZSH_VERSION+.}$(PATH_SEPARATOR)" && cd
+ install_sh_DATA = $(install_sh) -c -m 644
+ install_sh_PROGRAM = $(install_sh) -c
+diff -ruN a/src/tools/Makefile.in b/src/tools/Makefile.in
+--- a/src/tools/Makefile.in	2021-05-09 12:55:08.000000000 +0200
++++ b/src/tools/Makefile.in	2021-06-02 23:43:49.008313519 +0200
+@@ -72,8 +72,8 @@
+ am__make_keepgoing = (target_option=k; $(am__make_running_with_option))
+ pkgdatadir = $(datadir)/@PACKAGE@
+ pkgincludedir = $(includedir)/@PACKAGE@
+-pkglibdir = $(libdir)/@PACKAGE@
+-pkglibexecdir = $(libexecdir)/@PACKAGE@
++pkglibdir = $(libdir)/
++pkglibexecdir = $(libexecdir)/
+ am__cd = CDPATH="$${ZSH_VERSION+.}$(PATH_SEPARATOR)" && cd
+ install_sh_DATA = $(install_sh) -c -m 644
+ install_sh_PROGRAM = $(install_sh) -c


### PR DESCRIPTION
fix #22740
the .patch comes from arch is so that the shared files are not namespaced, unless this is desirable for msys2?