### PR TITLE
Groonga: Update to 14.1.1

### DIFF
--- a/mingw-w64-groonga/PKGBUILD
+++ b/mingw-w64-groonga/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=groonga
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=14.1.0
-pkgrel=2
+pkgver=14.1.1
+pkgrel=1
 pkgdesc="An opensource fulltext search engine (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -28,7 +28,7 @@ makedepends=("git"
              "${MINGW_PACKAGE_PREFIX}-rapidjson"
              "${MINGW_PACKAGE_PREFIX}-ruby"
              "${MINGW_PACKAGE_PREFIX}-xsimd")
-sha256sums=('6507e5003beb5937d0c163959b7722cdf972da26779fd317a59513d29453096a'
+sha256sums=('c79c086101fc4fe92c48c2004101d69e997ad63b8d3e575a12ab887eb045d548'
             'SKIP')
 validpgpkeys=('2701F317CFCCCB975CADE9C2624CF77434839225') # Groonga Key <packages@groonga.org>
 


### PR DESCRIPTION
Groonga version14.1.1 has just released [here](https://github.com/groonga/groonga/releases/tag/v14.1.1).