### PR TITLE
rust: update to 1.89.0

### DIFF
--- a/mingw-w64-rust/.gitignore
+++ b/mingw-w64-rust/.gitignore
@@ -1,0 +1,5 @@
+/rustc-perf
+/143928.patch
+/144159.patch
+/144164.patch
+/144254.patch

--- a/mingw-w64-rust/0014-rustc-perf-less-verbose.patch
+++ b/mingw-w64-rust/0014-rustc-perf-less-verbose.patch
@@ -1,0 +1,10 @@
+--- a/src/tools/opt-dist/src/training.rs
++++ b/src/tools/opt-dist/src/training.rs
+@@ -39,7 +39,6 @@
+         "--include",
+         crates.join(",").as_str(),
+     ])
+-    .env("RUST_LOG", "collector=debug")
+     .env("RUSTC", env.rustc_stage_0().as_str())
+     .env("RUSTC_BOOTSTRAP", "1")
+     .workdir(&env.rustc_perf_dir());

--- a/mingw-w64-rust/0015-lesser-llvm-build.patch
+++ b/mingw-w64-rust/0015-lesser-llvm-build.patch
@@ -1,0 +1,11 @@
+we don't need tools when collecting profiles with opt-dist
+--- a/src/bootstrap/src/core/build_steps/llvm.rs
++++ b/src/bootstrap/src/core/build_steps/llvm.rs
+@@ -349,6 +349,7 @@
+         cfg.define("LLVM_INSTALL_UTILS", "ON");
+ 
+         if builder.config.llvm_profile_generate {
++            cfg.define("LLVM_INCLUDE_TOOLS", "OFF");
+             cfg.define("LLVM_BUILD_INSTRUMENTED", "IR");
+             if let Ok(llvm_profile_dir) = std::env::var("LLVM_PROFILE_DIR") {
+                 cfg.define("LLVM_PROFILE_DATA_DIR", llvm_profile_dir);

--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -7,9 +7,12 @@ _bootstrapping=yes
 if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then
   _bootstrapping=no
 fi
+if [[ $CARCH != i686 ]]; then
+  _pgo=1
+fi
 
 rust_dist_server=https://static.rust-lang.org/dist
-#rust_dist_server=https://dev-static.rust-lang.org/dist/2025-06-23
+#rust_dist_server=https://dev-static.rust-lang.org/dist/2025-08-04
 
 _realname=rust
 pkgbase=mingw-w64-${_realname}
@@ -18,8 +21,8 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-rust-wasm" \
          "${MINGW_PACKAGE_PREFIX}-rust-emscripten" \
          "${MINGW_PACKAGE_PREFIX}-rust-src"))
-pkgver=1.88.0
-pkgrel=3
+pkgver=1.89.0
+pkgrel=1
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -40,27 +43,51 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-libgit2"
              "${MINGW_PACKAGE_PREFIX}-libssh2"
              "${MINGW_PACKAGE_PREFIX}-llvm"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-openssl"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-python"
              "${MINGW_PACKAGE_PREFIX}-sqlite3"
              $([[ "$_bootstrapping" == "no" ]] && echo "${MINGW_PACKAGE_PREFIX}-rust")
-             $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-wasi-libc ${MINGW_PACKAGE_PREFIX}-wasm-component-ld ${MINGW_PACKAGE_PREFIX}-emscripten")
              "${MINGW_PACKAGE_PREFIX}-xz"
              "${MINGW_PACKAGE_PREFIX}-zstd"
-             "${MINGW_PACKAGE_PREFIX}-zlib")
+             "${MINGW_PACKAGE_PREFIX}-zlib"
+             $([[ ${CARCH} == i686 ]] || echo \
+             "${MINGW_PACKAGE_PREFIX}-emscripten" \
+             "${MINGW_PACKAGE_PREFIX}-wasi-libc" \
+             "${MINGW_PACKAGE_PREFIX}-wasm-component-ld")
+             $((( _pgo )) && echo \
+             "${MINGW_PACKAGE_PREFIX}-compiler-rt" \
+             "${MINGW_PACKAGE_PREFIX}-lld")
+             'git')
 source=("${rust_dist_server}/${_realname}c-${pkgver}-src.tar.gz"{,.asc}
+        "rustc-perf::git+https://github.com/rust-lang/rustc-perf.git#commit=6a70166b92a1b1560cb3cf056427b011b2a1f2bf"
         "bootstrap.toml"
         "0001-rustc-llvm-fix-libs.patch"
         "0004-compiler-Use-wasm-ld-for-wasm-targets.patch"
-        "0008-disable-self-contained-for-gnu-targets.patch")
+        "0008-disable-self-contained-for-gnu-targets.patch"
+        "0014-rustc-perf-less-verbose.patch"
+        # patches in case of doing PGO for LLVM with opt-dist
+        #"0015-lesser-llvm-build.patch"
+        #"https://patch-diff.githubusercontent.com/raw/rust-lang/rust/pull/143898.patch"
+        # various backports. most of them to be removed after 1.90.0 update
+        "https://patch-diff.githubusercontent.com/raw/rust-lang/rust/pull/143928.patch"
+        "https://patch-diff.githubusercontent.com/raw/rust-lang/rust/pull/144159.patch"
+        "https://patch-diff.githubusercontent.com/raw/rust-lang/rust/pull/144164.patch"
+        "https://patch-diff.githubusercontent.com/raw/rust-lang/rust/pull/144254.patch")
 noextract=(${_realname}c-${pkgver}-src.tar.gz)
-sha256sums=('3a97544434848ae3d193d1d6bc83d6f24cb85c261ad95f955fde47ec64cfcfbe'
+sha256sums=('2576f9f440dd99b0151bd28f59aa0ac6102d5c4f3ed4ef8a810c8dd05057250d'
             'SKIP'
-            '54ffdf1f995edae7302112f4f8cb376c0193eccdc331a93383ac5c496afe59c7'
+            '549b63a9e2b460a02bafbb7f7fd4a101a067be6a02c6d2b0108ea2123aee0f3a'
+            'ebb90532e08fc1cb4ec8af6a3de66519fb6f168a2a4f075355082dea3be0ce60'
             '7cb1773c288ffb1c1e751edc49b1890c84bf9c362742bc5225d19d474edb73a0'
             '56882f1a0f1404c10c7726d6cc37444f2b343e72b969badfcb43760f80db0f32'
-            '87b68c2dfbe996d3ef439278e1ac90997fc4ea192f449e8f00262360a551386a')
+            '87b68c2dfbe996d3ef439278e1ac90997fc4ea192f449e8f00262360a551386a'
+            '6a8d987186785901d8a6e347d6ec3bccd84c869c9fa1a57cb9a30c8f6a3ce3ac'
+            'd8dd34d2474aa550c1e2089dfb7d75b5cf63174bb673e9fb5b233598c53115a6'
+            '6ba3bf8fa7b9196dc97f5e3c00718311471e3bbac0a7641e0ef88c190b830c7f'
+            '191addeef0af122bc09ef0a6578d7eaa62afbb30080227cdd1baa75d4671686d'
+            '8b81f31a3069f63694d375f7ece7bac5a711f10a9c06b803d9bca675dde33cf7')
 validpgpkeys=('108F66205EAEB0AAA8DD5E1C85AB96E6FA1BE5FE'  # Rust Language (Tag and Release Signing Key) <rust-key@rust-lang.org>
               '474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard <tstellar@redhat.com>
               'B6C8F98282B944E3B0D5C2530FC3042E345AD05D') # Hans Wennborg <hans@chromium.org>
@@ -83,16 +110,21 @@ prepare() {
   plain "Extracting ${_realname}c-${pkgver}-src.tar.gz"
   tar -xzf ${_realname}c-${pkgver}-src.tar.gz || true
 
-  # 0008-disable-self-contained-for-gnu-targets.patch allows self-contained for non-windows-gnu targets
   cd ${_realname}c-${pkgver}-src
-  apply_patch_with_msg \
-    0001-rustc-llvm-fix-libs.patch \
-    0008-disable-self-contained-for-gnu-targets.patch
-
-  if [[ ${CARCH} != i686 ]]; then
+  if (( ! _pgo )); then
     apply_patch_with_msg \
-      0004-compiler-Use-wasm-ld-for-wasm-targets.patch
+      0001-rustc-llvm-fix-libs.patch
   fi
+
+  # 0008-disable-self-contained-for-gnu-targets.patch allows self-contained for non-windows-gnu targets
+  apply_patch_with_msg \
+    0008-disable-self-contained-for-gnu-targets.patch \
+    0004-compiler-Use-wasm-ld-for-wasm-targets.patch \
+    0014-rustc-perf-less-verbose.patch \
+    143928.patch \
+    144159.patch \
+    144164.patch \
+    144254.patch
 }
 
 build() {
@@ -121,6 +153,7 @@ build() {
   # - remove --stage 2
 
   export RUST_BACKTRACE=1
+  export RUST_LOG=info
   # force some system libraries
   export LIBSQLITE3_SYS_USE_PKG_CONFIG=1
   export LIBSSH2_SYS_USE_PKG_CONFIG=1
@@ -139,21 +172,43 @@ build() {
     sed -i 's/^#debug/debug/g' bootstrap.toml
   fi
 
-  # Add target wasm32-*, tools and enable LTO for non-i686
+  # Add wasm32-* targets, tools and enable LTO for non-i686
   if [[ ${CARCH} != i686 ]]; then
     sed -i -e '/target = \[/a\  "wasm32-unknown-unknown", "wasm32-unknown-emscripten", "wasm32-wasip1", "wasm32v1-none", "wasm32-wasip1-threads", "wasm32-wasip2",' \
            -e '/tools = \[/a\  "clippy", "rustdoc", "rustfmt", "rust-analyzer-proc-macro-srv", "analysis", "src",' \
            -e 's/#lto/lto/' bootstrap.toml
   fi
 
-  local -a _rust_build=()
-  _rust_build+=("--stage" "2")
-  #_rust_build+=("--verbose")
-
-  # create the install at a temporary directory
-  DESTDIR="$PWD/build-$MSYSTEM/dest-rust" \
-  RUSTFLAGS="${RUSTFLAGS/+crt-static/-crt-static}" \
-    python x.py install "${_rust_build[@]}"
+  if (( _pgo )); then
+    sed -i 's/#use-lld/use-lld/' bootstrap.toml
+    # LLVM must be build for GCC envs, otherwise lld fails to link our LLVM while profiling rustc
+    if [[ ${MSYSTEM} != CLANG* ]]; then
+      sed -i -e '/^\[llvm\]/,/^$/ s|^#||g' -e 's/llvm-config/#llvm-config/' bootstrap.toml
+    fi
+    # build opt-dist tool which manages PGO build
+    python x.py build opt-dist --target="$OSTYPE"
+    local _pgo_opts=(--target-triple="$OSTYPE"
+                     --checkout-dir="$PWD"
+                     --llvm-dir="${MINGW_PREFIX}"
+                     --llvm-shared=false
+                     --build-llvm=false
+                     --python="${MINGW_PREFIX}/bin/python.exe"
+                     --artifact-dir=opt-artifacts-${MSYSTEM}
+                     --build-dir=build-${MSYSTEM}
+                     --rustc-perf-checkout-dir="${srcdir}/rustc-perf")
+    # CLANG* don't have prebuilt stage0
+    if [[ ${MSYSTEM} == CLANG* ]]; then
+      _pgo_opts+=(--stage0-root="${MINGW_PREFIX}")
+    fi
+    # run opt-dist to get rustc optimized with PGO
+    CXXFLAGS="$CXXFLAGS -fuse-ld=lld" \
+    DESTDIR="$PWD/build-$MSYSTEM/dest-rust" \
+    RUSTFLAGS="${RUSTFLAGS/+crt-static/-crt-static}" \
+    build-${MSYSTEM}/${OSTYPE}/stage0-tools-bin/opt-dist local ${_pgo_opts[@]} -- \
+      python x.py install
+  else
+    DESTDIR="$PWD/build-$MSYSTEM/dest-rust" python x.py install --stage 2
+  fi
 
   cd build-${MSYSTEM}
   if [[ ${CARCH} != i686 ]]; then
@@ -178,12 +233,14 @@ check() {
 
 package_rust() {
   depends=("${MINGW_PACKAGE_PREFIX}-cc"
-           "${MINGW_PACKAGE_PREFIX}-libxml2"
            "${MINGW_PACKAGE_PREFIX}-libgit2"
            "${MINGW_PACKAGE_PREFIX}-libssh2"
            "${MINGW_PACKAGE_PREFIX}-sqlite3"
-           "${MINGW_PACKAGE_PREFIX}-zstd"
            "${MINGW_PACKAGE_PREFIX}-zlib")
+  # these dependencies are linked with our LLVM library, which has more features enabled
+  if [[ ${MSYSTEM} == CLANG* ]]; then
+    depends+=("${MINGW_PACKAGE_PREFIX}-libxml2" "${MINGW_PACKAGE_PREFIX}-zstd")
+  fi
   if [[ ${CARCH} != i686 ]]; then
     optdepends=("${MINGW_PACKAGE_PREFIX}-gdb: for rust-gdb script"
                 "${MINGW_PACKAGE_PREFIX}-lldb: for rust-lldb script")
@@ -252,7 +309,7 @@ package_rust-src() {
   pkgdesc='Source code for the Rust standard library (mingw-w64)'
   depends=("${MINGW_PACKAGE_PREFIX}-rust")
 
-  cd "${_realname}c-${pkgver}-src/build-$MSYSTEM"
+  cd "${_realname}c-${pkgver}-src/build-${MSYSTEM}"
 
   cp -a dest-src/* "${pkgdir}"
   install -Dm644 ../LICENSE-{APACHE,MIT} -t "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-src"

--- a/mingw-w64-rust/bootstrap.toml
+++ b/mingw-w64-rust/bootstrap.toml
@@ -2,7 +2,13 @@
 profile = "dist"
 
 # see src/bootstrap/src/utils/change_tracker.rs
-change-id = 140732
+change-id = 142379
+
+[llvm]
+#download-ci-llvm = false
+#link-shared = false
+#use-linker = "lld"
+#build-config = { "Python3_EXECUTABLE" = "$MINGW_PREFIX/bin/python.exe" }
 
 [build]
 #cargo = "$MINGW_PREFIX/bin/cargo.exe"
@@ -24,6 +30,7 @@ tools = [
   "cargo",
 ]
 profiler = true
+metrics = true
 ccache = false
 
 # Generating docs fails with the wasm32-* targets
@@ -35,6 +42,7 @@ sysconfdir = "etc"
 
 [rust]
 #debug = true
+codegen-units = 1
 codegen-units-std = 1
 #debuginfo-level-std = 2
 channel = "stable"
@@ -42,6 +50,7 @@ rpath = false
 frame-pointers = true
 llvm-bitcode-linker = false
 lld = false
+#use-lld = "external"
 llvm-tools = false
 codegen-tests = false
 deny-warnings = false
@@ -50,6 +59,7 @@ remap-debuginfo = false
 # FIXME: Control Flow Guard works only on gnullvm targets, in other cases it's ignored
 # https://github.com/rust-lang/rust/pull/132965
 control-flow-guard = true
+new-symbol-mangling = true
 #lto = "fat"
 
 [dist]
@@ -62,6 +72,7 @@ cc = "$MINGW_PREFIX/bin/clang.exe"
 cxx = "$MINGW_PREFIX/bin/clang++.exe"
 ar = "$MINGW_PREFIX/bin/llvm-ar.exe"
 ranlib = "$MINGW_PREFIX/bin/llvm-ranlib.exe"
+linker = "$MINGW_PREFIX/bin/clang.exe"
 llvm-config = "$MINGW_PREFIX/bin/llvm-config.exe"
 
 [target.wasm32-unknown-unknown]


### PR DESCRIPTION
- perform PGO for rustc via opt-dist tool (addresses #19273):
  - various backports (available in 1.90.0) to match our environment better and fix some bugs
  - do not profile LLVM, because it makes backend performance even worse: https://github.com/rust-lang/rust/issues/144318
  - on UCRT64 do a separate LLVM build with clang+lld so it will be linkable with PGOed rustc
  - bootstrap.toml changes to match requirements for opt-dist (and get some more optimizations)
- CXXFLAGS workaround to actually perform LTO for llvm-wrapper (from rustc_llvm)
- ensure that clang+lld is used for whole build on non-i686