### PR TITLE
curl: Update to 8.11.1

### DIFF
--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -6,8 +6,8 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          $([[ ${CARCH} == i686 ]] || echo \
            "${MINGW_PACKAGE_PREFIX}-${_realname}-gnutls" \
            "${MINGW_PACKAGE_PREFIX}-${_realname}-winssl"))
-pkgver=8.11.0
-pkgrel=2
+pkgver=8.11.1
+pkgrel=1
 pkgdesc="Command line tool and library for transferring data with URLs (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -49,16 +49,12 @@ source=("https://github.com/curl/curl/releases/download/${_realname}-${pkgver//.
         "pathtools.c"
         "pathtools.h"
         "0001-Make-cURL-relocatable.patch"
-        "netrc-regression-1.patch::https://github.com/curl/curl/commit/f5c616930b5cf148b1b2632da4f5963ff48bdf88.patch"
-        "netrc-regression-2.patch::https://github.com/curl/curl/commit/0cdde0fdfbeb8c35420f6d03fa4b77ed73497694.patch"
         )
-sha256sums=('db59cf0d671ca6e7f5c2c5ec177084a33a79e04c97e71cf183a5cdea235054eb'
+sha256sums=('c7ca7db48b0909743eaef34250da02c19bc61d4f1dcedd6603f109409536ab56'
             'SKIP'
             'ebf471173f5ee9c4416c10a78760cea8afaf1a4a6e653977321e8547ce7bf3c0'
             '1585ef1b61cf53a2ca27049c11d49e0834683dfda798f03547761375df482a90'
-            '69d3a70dedb931526cc3e627b526086c41ebe9fa265c91ede03e1008cde50b45'
-            '708429a4e0b387dc9addc1f9166e07e5db22da42221887ddab9533c9e2bd1ca8'
-            'd817dd3746476bc513edd24a4f9a32674c3d5a04484bf80d894c1d2add67e8e2')
+            '69d3a70dedb931526cc3e627b526086c41ebe9fa265c91ede03e1008cde50b45')
 validpgpkeys=('27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2')  # Daniel Stenberg
 
 apply_patch_with_msg() {
@@ -79,9 +75,7 @@ prepare() {
   cp -fHv "${srcdir}"/pathtools.[ch] lib/
 
   apply_patch_with_msg \
-    0001-Make-cURL-relocatable.patch \
-    netrc-regression-1.patch \
-    netrc-regression-2.patch
+    0001-Make-cURL-relocatable.patch
 }
 
 do_build() {


### PR DESCRIPTION
remove backports included in the new release