### PR TITLE
rust: don't build out of tree

### DIFF
--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -17,7 +17,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-rust-wasm")
          "${MINGW_PACKAGE_PREFIX}-rust-src")
 pkgver=1.83.0
-pkgrel=3
+pkgrel=4
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -53,7 +53,7 @@ noextract=(${_realname}c-${pkgver}-src.tar.gz)
 sha256sums=('722d773bd4eab2d828d7dd35b59f0b017ddf9a97ee2b46c1b7f7fac5c8841c6e'
             'SKIP'
             '200b9ff220857e53e184257720a14553b2f4aa02577d2ed9842d45d4b9654810'
-            '832765ebf86dca77ea371decb9937f77dbf3a377cbb2240d9016f2a82d23b363'
+            'd4253c4b72c789a3a7f276ad75673d8c67c28af76e1d7711919509c667fcfbf8'
             '7cb1773c288ffb1c1e751edc49b1890c84bf9c362742bc5225d19d474edb73a0'
             '56882f1a0f1404c10c7726d6cc37444f2b343e72b969badfcb43760f80db0f32'
             '98bc3f2bd7371a5b8d14fd7b03bf05574e206d1d9e52bcfbe66d71398504da3c'
@@ -109,15 +109,15 @@ prepare() {
 }
 
 build() {
-  mkdir -p "${MSYSTEM}" && cd "${MSYSTEM}"
+  cd "${_realname}c-${pkgver}-src"
 
   # hack to inject the bootstrap compiler
   if [[ $_bootstrapping != "no" && $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
-    mkdir -p "build/cache/${_stage0date}/"
+    mkdir -p "build-${MSYSTEM}/cache/${_stage0date}/"
     cp -f "${srcdir}/cargo-${_stage0version}-dev-aarch64-pc-windows-gnullvm.tar.xz" \
       "${srcdir}/rust-std-${_stage0version}-dev-aarch64-pc-windows-gnullvm.tar.xz" \
       "${srcdir}/rustc-${_stage0version}-dev-aarch64-pc-windows-gnullvm.tar.xz" \
-      "build/cache/${_stage0date}/"
+      "build-${MSYSTEM}/cache/${_stage0date}/"
   fi
 
   if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then
@@ -153,32 +153,29 @@ build() {
   export MSYS2_ENV_CONV_EXCL='INSTALL_PREFIX'
   export INSTALL_PREFIX="${MINGW_PREFIX}"
   export PKGREL="${pkgrel}"
-  envsubst < ../config.toml > "../${_realname}c-${pkgver}-src/config.toml"
+  envsubst < ../config.toml > config.toml
 
   if [ "${_bootstrapping}" = "no" ]; then
-    sed -i '/^\[build\]/,/^$/ s|^#||g' "../${_realname}c-${pkgver}-src/config.toml"
+    sed -i '/^\[build\]/,/^$/ s|^#||g' config.toml
   fi
   # generate debuginfo only for non-i686 targets
   if check_option "debug" "y" && [ "${CARCH}" != i686 ]; then
-    sed -i 's/^#debug/debug/g' "../${_realname}c-${pkgver}-src/config.toml"
+    sed -i 's/^#debug/debug/g' config.toml
   fi
 
   # Add target wasm32-*
   if [[ ${CARCH} != i686 ]]; then
-    sed -i '/target = \[/a\  "wasm32-unknown-unknown", "wasm32-wasip1", "wasm32-wasip1-threads", "wasm32-wasip2",' "../${_realname}c-${pkgver}-src/config.toml"
+    sed -i '/target = \[/a\  "wasm32-unknown-unknown", "wasm32-wasip1", "wasm32-wasip1-threads", "wasm32-wasip2",' config.toml
   fi
-
-  # Building out of tree is not officially supported so we have to workaround some things like vendored deps
-  cp -r ../${_realname}c-${pkgver}-src/.cargo .
-  sed -i "s|directory = \"vendor\"|directory = \"../${_realname}c-${pkgver}-src/vendor\"|" .cargo/config.toml
 
   local -a _rust_build=()
   _rust_build+=("--stage" "2")
   #_rust_build+=("--verbose")
 
   # create the install at a temporary directory
-  DESTDIR="$PWD"/dest-rust python ../${_realname}c-${pkgver}-src/x.py install "${_rust_build[@]}"
+  DESTDIR="$PWD/build-$MSYSTEM/dest-rust" python x.py install "${_rust_build[@]}"
 
+  cd build-${MSYSTEM}
   if [[ ${CARCH} != i686 ]]; then
     # move wasm32-* targets out of the way for splitting
     mkdir -p dest-wasm${MINGW_PREFIX}/lib/rustlib
@@ -186,14 +183,15 @@ build() {
   fi
 
   # move src out of the way for splitting
-  mv dest-rust${MINGW_PREFIX}/lib/rustlib/src dest-src
+  mkdir -p dest-src${MINGW_PREFIX}/lib/rustlib
+  mv dest-rust${MINGW_PREFIX}/lib/rustlib/src dest-src${MINGW_PREFIX}/lib/rustlib
 
   rm -f dest-rust${MINGW_PREFIX}/lib/rustlib/$OSTYPE/lib/self-contained/*
 }
 
 check() {
-  cd "${MSYSTEM}"
-  python ../${_realname}c-${pkgver}-src/x.py test --stage 2 --exclude src/test/debuginfo
+  cd "${_realname}c-${pkgver}-src"
+  python x.py test --stage 2 --exclude src/test/debuginfo
 }
 
 package_rust() {
@@ -208,7 +206,7 @@ package_rust() {
   conflicts=("${MINGW_PACKAGE_PREFIX}-rust-docs")
   replaces=("${MINGW_PACKAGE_PREFIX}-rust-docs")
 
-  cd "${MSYSTEM}"
+  cd "${_realname}c-${pkgver}-src/build-${MSYSTEM}"
 
   cp -a dest-rust/* "${pkgdir}"
 
@@ -233,24 +231,20 @@ package_rust-wasm() {
   # object files provided for wasm32-* targets can't be stripped with MSYS2 toolchain
   options=('!strip')
 
-  cd "${MSYSTEM}"
+  cd "${_realname}c-${pkgver}-src/build-${MSYSTEM}"
 
   cp -a dest-wasm/* "${pkgdir}"
-  install -Dm644 ../${_realname}c-${pkgver}-src/LICENSE-{APACHE,MIT} -t \
-    "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-wasm/"
+  install -Dm644 ../LICENSE-{APACHE,MIT} -t "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-wasm"
 }
 
 package_rust-src() {
   pkgdesc='Source code for the Rust standard library (mingw-w64)'
   depends=("${MINGW_PACKAGE_PREFIX}-rust")
 
-  cd "${MSYSTEM}"
+  cd "${_realname}c-${pkgver}-src/build-$MSYSTEM"
 
-  install -Dm644 ../${_realname}c-${pkgver}-src/LICENSE-{APACHE,MIT} -t \
-    "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-src/"
-
-  install -d "${pkgdir}${MINGW_PREFIX}/lib/rustlib/"
-  cp -a dest-src "${pkgdir}${MINGW_PREFIX}/lib/rustlib/src"
+  cp -a dest-src/* "${pkgdir}"
+  install -Dm644 ../LICENSE-{APACHE,MIT} -t "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-src"
 }
 
 # template start; name=mingw-w64-splitpkg-wrappers; version=1.0;

--- a/mingw-w64-rust/config.toml
+++ b/mingw-w64-rust/config.toml
@@ -14,6 +14,7 @@ host = ["$OSTYPE"]
 target = [
   "$OSTYPE",
 ]
+build-dir = "build-$MSYSTEM"
 python = "$MINGW_PREFIX/bin/python.exe"
 locked-deps = true
 vendor = true


### PR DESCRIPTION
this is not supported upstream, but a workaround was used. set build-dir in config.toml, make dest dirs names contain $MSYSTEM to match previous behavior

asking @filnet as a workaround's author is it ok to do so