### PR TITLE
octave: update to 9.3.0

### DIFF
--- a/mingw-w64-octave/0005-makeinfo-perl.patch
+++ b/mingw-w64-octave/0005-makeinfo-perl.patch
@@ -1,0 +1,22 @@
+# HG changeset patch
+# User Markus Mützel <markus.muetzel@gmx.de>
+# Date 1647626170 -3600
+#      Fri Mar 18 18:56:10 2022 +0100
+# Branch stable
+# Node ID fa26a529cf60ee8e048390eac38c33f92d4d8b11
+# Parent  4d2da8a3dca69327150b4ecc5e6b7bb9630877e5
+Set up for correctly executing makeinfo perl script on Windows.
+* scripts/startup/version-rcfile: On Windows, perl scripts cannot be executed
+using the shebang mechanism. Set up for calling it with perl explicitly instead.
+diff -r 4d2da8a3dca6 -r fa26a529cf60 scripts/startup/version-rcfile
+--- a/scripts/startup/version-rcfile	Thu Mar 17 16:41:42 2022 +0100
++++ b/scripts/startup/version-rcfile	Fri Mar 18 18:56:10 2022 +0100
+@@ -25,3 +25,8 @@
+ if (strcmp (PAGER (), "less") && isempty (getenv ("LESS")))
+   PAGER_FLAGS ('-e -X -P"-- less ?pB(%pB\\%):--. (f)orward, (b)ack, (q)uit$"');
+ endif
++
++## On Windows, perl scripts must be run using the perl interpreter
++[~, tempval] = system ("cygpath -w /usr/bin");
++makeinfo_program (sprintf ("%s && cd %s && perl makeinfo", tempval(1:2), strtrim (tempval)));
++clear ("tempval");

--- a/mingw-w64-octave/PKGBUILD
+++ b/mingw-w64-octave/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=octave
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-pkgver=9.2.0
-pkgrel=3
+pkgver=9.3.0
+pkgrel=1
 pkgdesc="GNU Octave: Interactive programming environment for numerical computations (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -65,7 +65,7 @@ source=(https://ftp.gnu.org/gnu/octave/octave-$pkgver.tar.xz{,.sig}
         "0002-mk-doc-cache-path.patch"
         "0003-no-community-support.patch")
 validpgpkeys=('DBD9C84E39FE1AAE99F04446B05F05B75D36644B')  # John W. Eaton
-sha256sums=('21417afb579105b035cac0bea09201522e384893ae90a781b8727efa32765807'
+sha256sums=('712468513db7e13b76f28c4b82cdba7d6f3f634c836ddb27a7a8fe9d708145f3'
             'SKIP'
             'aa5bd559d9774abc0f0c930a606762d1e452cc90278d16d8ae83561c0cae3bf8'
             'e53af21ad087e10a2906506589aab89ab8b43f4e3e4994b4c28e4d8ae83639ad')
@@ -97,11 +97,7 @@ build() {
 
   declare -a _extra_config
   if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
-    # Libtool still needs some hints how to handle LLVM Flang:
-    _extra_config+=("--enable-fortran-calling-convention=gfortran"
-                    "ac_cv_f77_compiler_gnu=yes"
-                    "lt_cv_prog_gnu_ld=yes"
-                    "F77=${MINGW_PREFIX}/bin/flang")
+    _extra_config+=("F77=${MINGW_PREFIX}/bin/flang")
     # The headers from some dependent libraries (graphicsmagick++?) cause a
     # torrent of warnings about deprecated declarations.  Sometimes to the
     # point that the build crashes with garbled characters in the terminal

--- a/mingw-w64-octave/PKGBUILD
+++ b/mingw-w64-octave/PKGBUILD
@@ -43,7 +43,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-readline"
          "${MINGW_PACKAGE_PREFIX}-suitesparse"
          "${MINGW_PACKAGE_PREFIX}-sundials"
-         "${MINGW_PACKAGE_PREFIX}-texinfo"
+         "texinfo"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-cc"
@@ -63,12 +63,14 @@ optdepends=("unzip: for decompressing .zip archives"
             "${MINGW_PACKAGE_PREFIX}-portaudio: audio support")
 source=(https://ftp.gnu.org/gnu/octave/octave-$pkgver.tar.xz{,.sig}
         "0002-mk-doc-cache-path.patch"
-        "0003-no-community-support.patch")
+        "0003-no-community-support.patch"
+        "0005-makeinfo-perl.patch")
 validpgpkeys=('DBD9C84E39FE1AAE99F04446B05F05B75D36644B')  # John W. Eaton
 sha256sums=('712468513db7e13b76f28c4b82cdba7d6f3f634c836ddb27a7a8fe9d708145f3'
             'SKIP'
             'aa5bd559d9774abc0f0c930a606762d1e452cc90278d16d8ae83561c0cae3bf8'
-            'e53af21ad087e10a2906506589aab89ab8b43f4e3e4994b4c28e4d8ae83639ad')
+            'e53af21ad087e10a2906506589aab89ab8b43f4e3e4994b4c28e4d8ae83639ad'
+            '2df9666d75bb8dd4f549ec857c75aa3ec64b21fd3c9aa25a0d4127b284ec6822')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -82,7 +84,8 @@ prepare() {
   cd "${_realname}-${pkgver}"
 
   apply_patch_with_msg \
-    0002-mk-doc-cache-path.patch
+    0002-mk-doc-cache-path.patch \
+    0005-makeinfo-perl.patch
 
   if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
     apply_patch_with_msg \


### PR DESCRIPTION
`libtool` and `autoconf` have been patched to better support LLVM Flang in the meantime. So, remove the workarounds that were needed earlier.