### PR TITLE
xpra 6.2.2

### DIFF
--- a/mingw-w64-python-xpra/PKGBUILD
+++ b/mingw-w64-python-xpra/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=xpra
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=6.2.1
+pkgver=6.2.2
 pkgrel=1
 pkgdesc='Remote access client/server software (mingw-w64)'
 arch=('any')
@@ -61,7 +61,7 @@ makedepends=(
     ${MINGW_PACKAGE_PREFIX}-pygobject-devel)
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
         "0001-fix-build.patch")
-sha256sums=('8b87a6052d259f7c94125de9200b8020976b7d0049126d9608c6b0cf6518dfec'
+sha256sums=('ac6753820b9fae96bf88b09adb7340e19bd874e735ccc56a3ec920e5e001e4ee'
             '71a752dbfe8f6b6252e03cca3251dbdb14a844bab669f575b7f26002f4efd31b')
 
 prepare() {
@@ -75,8 +75,8 @@ build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
   cd "python-build-${MSYSTEM}"
 
-  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation \
-    -C--without-cuda_kernels -C--with-data -C--without-docs -C--with-modules -C-without-warn
+  XPRA_EXTRA_BUILD_ARGS="--without-nvidia --without-docs" ${MINGW_PREFIX}/bin/python -m build \
+          --wheel --skip-dependency-check --no-isolation
 }
 
 package() {


### PR DESCRIPTION
also use env vars to pass arguments to setup.py because the '-C' switches don't seem to work properly