### PR TITLE
python-nvidia-ml 12.560.30

### DIFF
--- a/mingw-w64-python-nvidia-ml/PKGBUILD
+++ b/mingw-w64-python-nvidia-ml/PKGBUILD
@@ -7,8 +7,8 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=12.535.133
-pkgrel=2
+pkgver=12.560.30
+pkgrel=1
 pkgdesc="Python bindings to the NVIDIA Management Library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -23,7 +23,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 source=("https://pypi.org/packages/source/${_srcname::1}/${_srcname}/${_srcname}-${pkgver}.tar.gz")
-sha256sums=('b1559af0d57dd20955bf58d05afff7b166ddd44947eb3051c9905638799eb1dc')
+sha256sums=('f0254dc7400647680a072ee02509bfd46102b60bdfeca321576d4d4817e7fe97')
 
 prepare() {
   cd "${srcdir}"
@@ -34,11 +34,6 @@ prepare() {
 build() {
   cd "${srcdir}/python-build-${MSYSTEM}"
   ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
-}
-
-check() {
-  cd "${srcdir}/python-build-${MSYSTEM}"
-  ${MINGW_PREFIX}/bin/python -m pytest
 }
 
 package() {


### PR DESCRIPTION
This update also removes the `check()` function as there are no tests to run, so it would fail.