### PR TITLE
pcre2: set --enable-jit

### DIFF
--- a/mingw-w64-pcre2/PKGBUILD
+++ b/mingw-w64-pcre2/PKGBUILD
@@ -4,7 +4,7 @@ _realname=pcre2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=10.44
-pkgrel=1
+pkgrel=2
 pkgdesc="A library that implements Perl 5-style regular expressions (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -27,6 +27,7 @@ validpgpkeys=('45F68D54BBE23FB3039B46E59766E084FB0F43D8') # Philip Hazel <Philip
 
 build() {
   local -a _common_config=(
+    --enable-jit
     --enable-pcre2-8
     --enable-pcre2-16
     --enable-pcre2-32


### PR DESCRIPTION
Enable JIT compiler support. This option is enabled in various other package repositories including Arch, Debian, vcpkg, and Homebrew. I've only performed light testing and only on a CLANGARM64 build.