### PR TITLE
luajit: update to 2.1.1734355927

### DIFF
--- a/mingw-w64-luajit/PKGBUILD
+++ b/mingw-w64-luajit/PKGBUILD
@@ -5,9 +5,9 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 # LuaJIT has abandoned versioned releases and now advises using git HEAD
 # https://github.com/LuaJIT/LuaJIT/issues/665#issuecomment-784452583
-_commit="19878ec05c239ccaf5f3d17af27670a963e25b8b"
+_commit="f73e649a954b599fc184726c376476e7a5c439ca"
 _basever=2.1
-pkgver=2.1.1732813678
+pkgver=2.1.1734355927
 pkgrel=1
 pkgdesc="Just-in-time compiler and drop-in replacement for Lua 5.1 (mingw-w64)"
 arch=('any')
@@ -30,7 +30,7 @@ source=("${_realname}"::"git+https://luajit.org/git/luajit.git#commit=${_commit}
         002-fix-pkg-config-file.patch
         003-lua51-modules-paths.patch
         004-fix-default-cc.patch)
-sha256sums=('5fcdb5e5fba4fd7f09e5921ed0619ea9874b4749bd712e6b393ce29e39ed794e'
+sha256sums=('ffc475728d39d0415d85199752bb3bb09c7b37a25be11979030ee92717dc513f'
             '0cadf1b6c67c910c81ccb7a6152148dccfb0f1c6b50cdb09a5707cd45e7cbe85'
             '4df486e82b0bbeead01dcf6001e90c51477a3a8ac18611d60d7067f2c7013428'
             'a3d8c7c7724cd5a4173c6ddcbc854aa3424b78fb6c9d4b6c57ed2ebd6c2dd366'


### PR DESCRIPTION
## Notes

During this update, in the CI logs on my branch, I noticed some unusual ```wtdccm``` DLL runtime dependency of ```luajit```'s binary artifacts on every MSYS2 environment (mingw64, ucrt64, ...):

![Screenshot from 2024-12-20 13-43-17](https://github.com/user-attachments/assets/b7558339-95a4-4874-82c2-3c1aa1fc5d2f)

However, downloading the UCRT64 generated artifacts from GitHub, and running MSVC's dumpbin to list dependencies, I got these outputs:
* ```luajit.exe``` interpreter:
    
    ```cmd
    dumpbin /DEPENDENTS luajit.exe
    ```
![Screenshot from 2024-12-20 13-43-54](https://github.com/user-attachments/assets/f085a059-f986-4e82-b33b-de2017bfe9c9)

* ```lua51.dll```:
    
    ```cmd
    dumpbin /DEPENDENTS lua51.dll
    ```
![Screenshot from 2024-12-20 13-44-16](https://github.com/user-attachments/assets/a2f3939b-c624-476b-94e2-92d9b61acfb4)

## Conclusion

In my POV, it seems to be safe, because that ```wtdccm``` DLL most likely is some CI-related thing, and MSVC didn't list it as dependency. I tried to google for such dll, but I didn't find anything valuable to report here.

Maybe someone has a better explanation for this. Feel free to investigate further before merging.