### PR TITLE
Enable fox for clangarm64

### DIFF
--- a/mingw-w64-fox/PKGBUILD
+++ b/mingw-w64-fox/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=fox
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.6.57
-pkgrel=5
+pkgver=1.6.59
+pkgrel=1
 pkgdesc="C++ user interface toolkit (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -20,7 +20,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc" "${MINGW_PACKAGE_PREFIX}-autotools")
 options=('strip')
 source=("http://fox-toolkit.org/ftp/${_realname}-${pkgver}.tar.gz"
         fox-2-FXTrayIcon.patch)
-sha256sums=('65ef15de9e0f3a396dc36d9ea29c158b78fad47f7184780357b929c94d458923'
+sha256sums=('48f33d2dd5371c2d48f6518297f0ef5bbf3fcd37719e99f815dc6fc6e0f928ae'
             '200e604581b20bfaa35a8747c293d43e3024ce554b23c47c466b3ca11341b209')
 
 prepare() {

--- a/mingw-w64-fox/PKGBUILD
+++ b/mingw-w64-fox/PKGBUILD
@@ -4,10 +4,10 @@ _realname=fox
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.6.57
-pkgrel=4
+pkgrel=5
 pkgdesc="C++ user interface toolkit (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="http://www.fox-toolkit.org"
 license=('LGPLv2+ with exceptions')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
@@ -32,6 +32,8 @@ prepare() {
 build() {
   [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}
   cp -rf ${_realname}-${pkgver} build-${MSYSTEM} && cd build-${MSYSTEM}
+
+  CPPFLAGS+=" -Wno-register"
 
   ./configure \
     --prefix=${MINGW_PREFIX} \


### PR DESCRIPTION
"-Wno-register" avoids lot of clang errors kind of:
```
  error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
```