### PR TITLE
python-llvmlite: update to 0.44.0rc2; python-numba: update to 0.61.0rc2

### DIFF
--- a/mingw-w64-python-llvmlite/PKGBUILD
+++ b/mingw-w64-python-llvmlite/PKGBUILD
@@ -3,11 +3,8 @@
 _realname=llvmlite
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=0.43.0
-pkgrel=3
+pkgver=0.44.0rc2
+pkgrel=1
 pkgdesc='Lightweight LLVM python binding for writing JIT compilers (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -31,7 +28,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
         "multi-defs.patch"
         "path_fix.patch")
-sha256sums=('ae2b5b5c3ef67354824fb75517c8db5fbe93bc02cd9671f3c62271626bc041d5'
+sha256sums=('7731d125071842c2465ecd9fd59736da7ae70d8c6d04566ede98296e8779a8ed'
             'b4610934ac8fd7e614d9ea920856ff6da2fbeb146028a664ada8543b8b33ec56'
             '813ecc48f18543f0d36b03c7596a1a6a26be31b9cfa44f1111ac232821844a79')
 
@@ -44,7 +41,7 @@ apply_patch_with_msg() {
 }
 
 prepare() {
-  cd "$srcdir/${_realname}-${pkgver}"
+  cd "${_realname}-${pkgver}"
 
   apply_patch_with_msg \
     multi-defs.patch \
@@ -54,8 +51,7 @@ prepare() {
 }
 
 build() {
-  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
-  cd "${srcdir}/python-build-${MSYSTEM}"
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
 
   if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
     # A hack to make it build on clang* environments
@@ -65,17 +61,17 @@ build() {
   export CMAKE_GENERATOR="Ninja"
   export LLVM_DIR=${MINGW_PREFIX}/opt/llvm-15/lib/cmake/llvm
 
-  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
+  python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 package() {
-  cd "${srcdir}/python-build-${MSYSTEM}"
+  cd "python-build-${MSYSTEM}"
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    python -m installer --prefix=${MINGW_PREFIX} \
     --destdir="${pkgdir}" dist/*.whl
 
-  local _py3ver=$(${MINGW_PREFIX}/bin/python -c "import sys;sys.stdout.write('.'.join(map(str, sys.version_info[:2])))")
+  local _py3ver=$(python -c "import sys;sys.stdout.write('.'.join(map(str, sys.version_info[:2])))")
   install -Dm644 ffi/build/libllvmlite.dll "${pkgdir}${MINGW_PREFIX}/lib/python${_py3ver}/site-packages/llvmlite/binding/llvmlite.dll"
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"

--- a/mingw-w64-python-numba/5e917b96ae7033e994f185cb37329a07e56d51b6.patch
+++ b/mingw-w64-python-numba/5e917b96ae7033e994f185cb37329a07e56d51b6.patch
@@ -1,0 +1,44 @@
+diff --git a/numba/__init__.py b/numba/__init__.py
+index 28a723384b3..737766ce457 100644
+--- a/numba/__init__.py
++++ b/numba/__init__.py
+@@ -39,6 +39,11 @@ def extract_version(mod):
+                f"{numpy_version[0]}.{numpy_version[1]}.")
+         raise ImportError(msg)
+ 
++    if numpy_version > (2, 1):
++        msg = (f"Numba needs NumPy 2.1 or less. Got NumPy "
++               f"{numpy_version[0]}.{numpy_version[1]}.")
++        raise ImportError(msg)
++
+     try:
+         import scipy
+     except ImportError:
+diff --git a/setup.py b/setup.py
+index 41188b846fe..f5f80dfe191 100644
+--- a/setup.py
++++ b/setup.py
+@@ -21,8 +21,9 @@
+ 
+ min_python_version = "3.10"
+ max_python_version = "3.14"  # exclusive
+-min_numpy_build_version = "1.11"
++min_numpy_build_version = "2.0.0rc1"
+ min_numpy_run_version = "1.24"
++max_numpy_run_version = "2.2"
+ min_llvmlite_version = "0.44.0dev0"
+ max_llvmlite_version = "0.45"
+ 
+@@ -366,10 +367,10 @@ def check_file_at_path(path2file):
+ 
+ packages = find_packages(include=["numba", "numba.*"])
+ 
+-build_requires = ['numpy >={}'.format(min_numpy_build_version)]
++build_requires = ['numpy >={},<{}'.format(min_numpy_build_version, max_numpy_run_version)]
+ install_requires = [
+     'llvmlite >={},<{}'.format(min_llvmlite_version, max_llvmlite_version),
+-    'numpy >={}'.format(min_numpy_run_version),
++    'numpy >={},<{}'.format(min_numpy_run_version, max_numpy_run_version),
+ ]
+ 
+ metadata = dict(

--- a/mingw-w64-python-numba/PKGBUILD
+++ b/mingw-w64-python-numba/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=numba
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=0.60.0
-pkgrel=6
+pkgver=0.61.0rc2
+pkgrel=1
 pkgdesc='NumPy aware dynamic Python compiler using LLVM (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -28,30 +28,27 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
 optdepends=("${MINGW_PACKAGE_PREFIX}-python-scipy")
 options=('!emptydirs' '!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
-        "001-fix-build-with-numpy-2.0.1.patch")
-sha256sums=('5df6158e5584eece5fc83294b949fd30b9f1125df7708862205217e068aabf16'
-            'a0aef12c07a204935c49f316d8da0a0f3b70325840d6a8b244888a96f65b52ff')
+        "5e917b96ae7033e994f185cb37329a07e56d51b6.patch")
+sha256sums=('630b8ff1ddd567b488cb09c439cebcf750b95f960562f43e234c94a334fee14b'
+            'bad9d6aca6d1330c5bd02b570a8d923b99738f15beb95f600185445901b0d274')
 
 prepare() {
-  cd ${_realname}-${pkgver}
-  # https://github.com/numpy/numpy/issues/27083
-  patch -p1 -i "${srcdir}"/001-fix-build-with-numpy-2.0.1.patch
+  cd "${_realname}-${pkgver}"
 
-  cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
-  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
+  # drop pinning numpy version from https://github.com/numba/numba/commit/5e917b96ae7033e994f185cb37329a07e56d51b6
+  patch -R -p1 -i ../5e917b96ae7033e994f185cb37329a07e56d51b6.patch
 }
 
 build() {
-  cd "${srcdir}/python-build-${MSYSTEM}"
-  NUMBA_DISABLE_TBB=1 \
-    ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  NUMBA_DISABLE_TBB=1 python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 package() {
-  cd "${srcdir}/python-build-${MSYSTEM}"
+  cd "python-build-${MSYSTEM}"
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    python -m installer --prefix=${MINGW_PREFIX} \
     --destdir="${pkgdir}" dist/*.whl
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"


### PR DESCRIPTION
update numba due to ImportError raised because of numpy version. this requires llvmlite update