### PR TITLE
starpu: disable opencl

### DIFF
--- a/mingw-w64-starpu/PKGBUILD
+++ b/mingw-w64-starpu/PKGBUILD
@@ -4,7 +4,7 @@ _realname=starpu
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.4.7
-pkgrel=1
+pkgrel=2
 pkgdesc='StarPU is a task programming library for hybrid architectures (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -19,12 +19,12 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          $([[ ${CARCH} == aarch64 ]] || echo "${MINGW_PACKAGE_PREFIX}-leveldb")
          "${MINGW_PACKAGE_PREFIX}-libwinpthread-git"
          #"${MINGW_PACKAGE_PREFIX}-openblas"
-         "${MINGW_PACKAGE_PREFIX}-opencl-icd"
+         #"${MINGW_PACKAGE_PREFIX}-opencl-icd"
 )
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cc"
   "${MINGW_PACKAGE_PREFIX}-autotools"
-  "${MINGW_PACKAGE_PREFIX}-opencl-headers"
+  #"${MINGW_PACKAGE_PREFIX}-opencl-headers"
   #"${MINGW_PACKAGE_PREFIX}-python"
   #"${MINGW_PACKAGE_PREFIX}-python-setuptools"
   #"${MINGW_PACKAGE_PREFIX}-python-joblib"
@@ -53,9 +53,9 @@ build() {
     --prefix=${MINGW_PREFIX} \
     --enable-hdf5 \
     --enable-maxcpus=64 \
-    --enable-opencl \
+    --disable-opencl \
     --enable-quick-check \
-    --enable-socl \
+    --disable-socl \
     --disable-build-doc \
     --disable-build-examples \
     --disable-fortran \


### PR DESCRIPTION
This option currently does nothing and prevents the compilation of dependent packages