### PR TITLE
python-maturin: update to 1.8.0

### DIFF
--- a/mingw-w64-python-maturin/PKGBUILD
+++ b/mingw-w64-python-maturin/PKGBUILD
@@ -43,8 +43,8 @@ package() {
     --destdir="${pkgdir}" dist/*.whl
 
   local _complete="${pkgdir}${MINGW_PREFIX}/bin/maturin completions"
-  $_complete bash | install -Dm644 /dev/stdin "${pkgdir}${MINGW_PREFIX}/share/bash-completion/completions/rg"
-  $_complete zsh | install -Dm644 /dev/stdin "${pkgdir}${MINGW_PREFIX}/share/zsh/site-functions/_rg"
-  $_complete fish | install -Dm644 /dev/stdin "${pkgdir}${MINGW_PREFIX}/share/fish/vendor_completions.d/rg.fish"
+  $_complete bash | install -Dm644 /dev/stdin "${pkgdir}${MINGW_PREFIX}/share/bash-completion/completions/maturin"
+  $_complete zsh | install -Dm644 /dev/stdin "${pkgdir}${MINGW_PREFIX}/share/zsh/site-functions/_maturin"
+  $_complete fish | install -Dm644 /dev/stdin "${pkgdir}${MINGW_PREFIX}/share/fish/vendor_completions.d/maturin.fish"
   install -Dm644 license-{apache,mit} -t "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/"
 }

--- a/mingw-w64-python-maturin/PKGBUILD
+++ b/mingw-w64-python-maturin/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=maturin
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
-pkgver=1.7.8
+pkgver=1.8.0
 pkgrel=1
 pkgdesc='Build and publish crates with pyo3, rust-cpython and cffi bindings as well as rust binaries as python packages (mingw-w64)'
 arch=('any')
@@ -20,7 +20,7 @@ makedepends=(
     "${MINGW_PACKAGE_PREFIX}-python-setuptools-rust")
 options=('!strip')
 source=("https://pypi.io/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('649c6ef3f0fa4c5f596140d761dc5a4d577c485cc32fb5b9b344a8280352880d')
+sha256sums=('2f4abdf33e87ccb0d035a838e832945c6f7374222eacde508fafc752dda8ba6e')
 
 prepare() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
@@ -42,5 +42,9 @@ package() {
     python -m installer --prefix=${MINGW_PREFIX} \
     --destdir="${pkgdir}" dist/*.whl
 
+  local _complete="${pkgdir}${MINGW_PREFIX}/bin/maturin completions"
+  $_complete bash | install -Dm644 /dev/stdin "${pkgdir}${MINGW_PREFIX}/share/bash-completion/completions/rg"
+  $_complete zsh | install -Dm644 /dev/stdin "${pkgdir}${MINGW_PREFIX}/share/zsh/site-functions/_rg"
+  $_complete fish | install -Dm644 /dev/stdin "${pkgdir}${MINGW_PREFIX}/share/fish/vendor_completions.d/rg.fish"
   install -Dm644 license-{apache,mit} -t "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/"
 }


### PR DESCRIPTION
generate shell completions