### PR TITLE
openvr: add missing dlfcn dependency

### DIFF
--- a/mingw-w64-openvr/PKGBUILD
+++ b/mingw-w64-openvr/PKGBUILD
@@ -4,13 +4,13 @@ _realname=openvr
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.2.3
-pkgrel=1
+pkgrel=2
 pkgdesc="API and SDK that allows access to VR hardware from multiple vendors (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://github.com/ValveSoftware/openvr/"
 license=('spdx:BSD-3-Clause')
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs ${MINGW_PACKAGE_PREFIX}-dlfcn")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"


### PR DESCRIPTION
Look at the .pc file it has -ldl flag on --libs