### PR TITLE
libjpeg-turbo: Update to 3.1.0

### DIFF
--- a/mingw-w64-libjpeg-turbo/0001-header-compat.mingw.patch
+++ b/mingw-w64-libjpeg-turbo/0001-header-compat.mingw.patch
@@ -1,5 +1,5 @@
---- libjpeg-turbo-1.2.90/jmorecfg.h.orig	2013-04-04 15:08:10 +0400
-+++ libjpeg-turbo-1.2.90/jmorecfg.h	2013-04-04 16:23:13 +0400
+--- libjpeg-turbo-1.2.90/src/jmorecfg.h.orig	2013-04-04 15:08:10 +0400
++++ libjpeg-turbo-1.2.90/src/jmorecfg.h	2013-04-04 16:23:13 +0400
 @@ -12,6 +12,12 @@
   * optimizations.  Most users will not need to touch this file.
   */

--- a/mingw-w64-libjpeg-turbo/PKGBUILD
+++ b/mingw-w64-libjpeg-turbo/PKGBUILD
@@ -4,8 +4,8 @@
 _realname=libjpeg-turbo
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.0.4
-pkgrel=2
+pkgver=3.1.0
+pkgrel=1
 pkgdesc="JPEG image codec with accelerated baseline compression and decompression (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -28,10 +28,10 @@ replaces=("${MINGW_PACKAGE_PREFIX}-libjpeg")
 source=(https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/${pkgver}/libjpeg-turbo-${pkgver}.tar.gz{,.sig}
         "0001-header-compat.mingw.patch"
         "libjpeg-turbo-1.3.1-libmng-compatibility.patch")
-sha256sums=('99130559e7d62e8d695f2c0eaeef912c5828d5b84a0537dcb24c9678c9d5b76b'
+sha256sums=('9564c72b1dfd1d6fe6274c5f95a8d989b59854575d4bbee44ade7bc17aa9bc93'
             'SKIP'
-            '166264f617734b33ac55ec8b70e6636d4e409c0d837667afe158e9d28200e6dd'
-            '16336caddc949a8a082f39c218b3289288d144bb3b87f62565ed1b294ff8e526')
+            'f0609ad801831a549cbc15eeee5ab45fb9df344e607491f6f1ad762519d50089'
+            '2154ecce25b3b2aae5eeabd52c8a1480ec78f1cd50bb8e989e30de54d50e3ec6')
 validpgpkeys=('0338C8D8D9FDA62CF9C421BD7EC2DBB6F4DBF434')
 
 prepare() {
@@ -71,7 +71,7 @@ package() {
 
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install .
 
-  cp "${srcdir}"/${_realname}-${pkgver}/{jinclude,transupp}.h ${pkgdir}${MINGW_PREFIX}/include/
+  cp "${srcdir}"/${_realname}-${pkgver}/src/{jinclude,transupp}.h ${pkgdir}${MINGW_PREFIX}/include/
 
   # Licenses
   # See https://www.libjpeg-turbo.org/About/License

--- a/mingw-w64-libjpeg-turbo/libjpeg-turbo-1.3.1-libmng-compatibility.patch
+++ b/mingw-w64-libjpeg-turbo/libjpeg-turbo-1.3.1-libmng-compatibility.patch
@@ -1,6 +1,6 @@
 diff -Naur libjpeg-turbo-1.3.1-orig/jpeglib.h libjpeg-turbo-1.3.1/jpeglib.h
---- libjpeg-turbo-1.3.1-orig/jpeglib.h	2013-01-19 03:42:31.000000000 +0400
-+++ libjpeg-turbo-1.3.1/jpeglib.h	2014-06-28 15:36:12.956400000 +0400
+--- libjpeg-turbo-1.3.1-orig/src/jpeglib.h	2013-01-19 03:42:31.000000000 +0400
++++ libjpeg-turbo-1.3.1/src/jpeglib.h	2014-06-28 15:36:12.956400000 +0400
 @@ -28,6 +28,7 @@
  #endif
  #include "jmorecfg.h"		/* seldom changed options */


### PR DESCRIPTION
* files moved under src/

the patches and headers are all questionable since I can't find any context, but let's leave as is for now.