### PR TITLE
gimp3: update to 3.0.0RC2

### DIFF
--- a/mingw-w64-gimp3/0002-skip-test-env.patch
+++ b/mingw-w64-gimp3/0002-skip-test-env.patch
@@ -1,6 +1,5 @@
-diff -bur gimp3-2.99.12.r3.g02739dd6e6-c/app/tests/meson.build gimp3-2.99.12.r3.g02739dd6e6/app/tests/meson.build
---- gimp3-2.99.12.r3.g02739dd6e6-c/app/tests/meson.build	2022-08-23 22:34:33.774184400 -0600
-+++ gimp3-2.99.12.r3.g02739dd6e6/app/tests/meson.build	2022-08-23 22:35:38.433049400 -0600
+--- a/app/tests/meson.build
++++ b/app/tests/meson.build
 @@ -44,10 +44,10 @@
    'xcf',
  ]
@@ -14,5 +13,6 @@ diff -bur gimp3-2.99.12.r3.g02739dd6e6-c/app/tests/meson.build gimp3-2.99.12.r3.
 +# error(cmd.stderr().strip())
 +# endif
  
- foreach test_name : app_tests
-   test_exe = executable(test_name,
+ # Prevent parallel builds for the tests
+ # The tests must not be run in parallel or in a different order as specified
+

--- a/mingw-w64-gimp3/PKGBUILD
+++ b/mingw-w64-gimp3/PKGBUILD
@@ -1,12 +1,12 @@
 # Maintainer: Alexey Pavlov <Alexpux@gmail.com>
 
 _realname=gimp3
-_pkgversuffix=RC1
+_pkgversuffix=RC2
 _pkgver=3.0.0
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=${_pkgver}${_pkgversuffix}
-pkgrel=3
+pkgrel=1
 pkgdesc="GNU Image Manipulation Program (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -56,6 +56,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-aalib"
          "${MINGW_PACKAGE_PREFIX}-lua51-lgi"
          "${MINGW_PACKAGE_PREFIX}-maxflow"
          "${MINGW_PACKAGE_PREFIX}-mypaint-brushes"
+         "${MINGW_PACKAGE_PREFIX}-omp"
          "${MINGW_PACKAGE_PREFIX}-openexr"
          "${MINGW_PACKAGE_PREFIX}-pango"
          "${MINGW_PACKAGE_PREFIX}-poppler"
@@ -69,15 +70,16 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-gettext-tools"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
+             $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-libbacktrace")
              "${MINGW_PACKAGE_PREFIX}-libxslt"
              "${MINGW_PACKAGE_PREFIX}-qoi")
 source=("https://download.gimp.org/pub/gimp/v3.0/gimp-${_pkgver}-${_pkgversuffix}.tar.xz"
         0001-clang-rc-files-fix.patch
         0002-skip-test-env.patch
         0003-dont-install-external-files.patch)
-sha256sums=('b3d0b264c5e38e789faaf3417003397f3240014c59c7f417f9ca3bd39c5ffb66'
+sha256sums=('f4d2f96df180ce5543f8b2b35707b9bf11459f00f726ca73da2f406d686d9db7'
             'f9e0c2fe6d602a5254e4e023a5cb1f66f0ba64c60df925676c2190283ae11747'
-            '511a2a969d1ff3254b4f2453cdfbc3a86a60e2379adf9f6ed5735454a45ef6ee'
+            '3b7dc1dd42f858d0ef93874164686bdee47cc5e456e60c6d3a63c307244ad6d9'
             '00ea605eef20f35f0d8ebb30020322d33c86846f9a156eec3b697289930568a8')
 
 apply_patch_with_msg() {
@@ -89,7 +91,7 @@ apply_patch_with_msg() {
 }
 
 prepare() {
-  cd "${srcdir}/gimp-${_pkgver}-${_pkgversuffix}"
+  cd "gimp-${_pkgver}-${_pkgversuffix}"
   apply_patch_with_msg \
     0001-clang-rc-files-fix.patch \
     0002-skip-test-env.patch \
@@ -97,50 +99,40 @@ prepare() {
 }
 
 build() {
-  mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
-
   CFLAGS+=" -Wno-incompatible-pointer-types" \
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-  ${MINGW_PREFIX}/bin/meson.exe setup \
+  meson setup \
     --buildtype=plain \
     --auto-features=enabled \
     --prefix=${MINGW_PREFIX} \
     -Daa=disabled \
     -Dalsa=disabled \
     -Dappdata-test=disabled \
+    -Dbug-report-url="https://github.com/msys2/MINGW-packages/issues" \
+    -Dcheck-update=no \
     -Ddirectx-sdk-dir="${MINGW_PREFIX}" \
-    -Denable-multiproc=true \
-    -Dg-ir-doc=false \
     -Dgi-docgen=disabled \
     -Dgudev=disabled \
     -Dheadless-tests=disabled \
     -Djavascript=disabled \
+    -Dlibunwind=false \
     -Dlinux-input=disabled \
     -Dxcursor=disabled \
-    -Dwin32-debug-console=true \
-    -Denable-default-bin=disabled \
-    ../gimp-${_pkgver}-${_pkgversuffix}
+    "build-${MSYSTEM}" \
+    "gimp-${_pkgver}-${_pkgversuffix}"
 
-  ${MINGW_PREFIX}/bin/meson.exe compile
+  meson compile -C "build-${MSYSTEM}"
 }
 
 package() {
-  cd "${srcdir}"/build-${MSYSTEM}
-  ${MINGW_PREFIX}/bin/meson.exe install --destdir="${pkgdir}"
+  meson install -C "build-${MSYSTEM}" --destdir="${pkgdir}"
 
   # Adjust the python interpreter path
   sed -e "s|\=.*|\=python3w.exe|g" -i "${pkgdir}${MINGW_PREFIX}"/lib/gimp/3.0/interpreters/pygimp.interp
   sed -e "s|::python3|::python3w.exe|g" -i "${pkgdir}${MINGW_PREFIX}"/lib/gimp/3.0/interpreters/pygimp.interp
 
-  # enable-default-bin uses symlinks, so disable it and copy manually instead
-  for _prog in "${pkgdir}${MINGW_PREFIX}/bin/"*-3.0.exe; do
-    _baseprog=$(basename "$_prog")
-    install -Dm755 "${_prog}" \
-      "${pkgdir}${MINGW_PREFIX}/bin/${_baseprog//-3.0/}"
-  done
-
   rm -f "${pkgdir}${MINGW_PREFIX}/lib/gimp/3.0/modules/*.dll.a"
 
-  install -Dm644 "${srcdir}/gimp-${_pkgver}-${_pkgversuffix}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
-  install -Dm644 "${srcdir}/gimp-${_pkgver}-${_pkgversuffix}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+  install -Dm644 "gimp-${_pkgver}-${_pkgversuffix}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  install -Dm644 "gimp-${_pkgver}-${_pkgversuffix}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }


### PR DESCRIPTION
- `0002-skip-test-env.patch`: refresh
- remove options that are set to default value
- add `omp` as dependency explicitly
- `enable-default-bin` is fixed upstream
- add libbacktrace for non-i686 environments
- explicitly disable `libunwind` as it can't be found by meson (because gimp uses libunwind not from LLVM)