### PR TITLE
llama.cpp: update to b4394

### DIFF
--- a/mingw-w64-llama.cpp/PKGBUILD
+++ b/mingw-w64-llama.cpp/PKGBUILD
@@ -1,26 +1,35 @@
 _realname=llama.cpp
-_realver=b3091
+_realver=b4394
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=b3091.r0.g2b33896
+epoch=1
+pkgver=b4394.r0.g16cdce7
 pkgrel=1
-pkgdesc="Port of Facebook's LLaMA model in C/C++ (mingw-w64)"
+pkgdesc="Library and tools for running inference with Meta's LLaMA model (and derivatives) in C/C++ (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64' 'mingw64')
 url="https://github.com/ggerganov/llama.cpp"
 license=('spdx:MIT')
 depends=(
-  "${MINGW_PACKAGE_PREFIX}-openblas"
   "${MINGW_PACKAGE_PREFIX}-gcc-libs"
+  "${MINGW_PACKAGE_PREFIX}-openblas64"
+  "${MINGW_PACKAGE_PREFIX}-vulkan-loader"
+  "${MINGW_PACKAGE_PREFIX}-shaderc"
+  "${MINGW_PACKAGE_PREFIX}-opencl-icd"
+  "${MINGW_PACKAGE_PREFIX}-python"
+  "${MINGW_PACKAGE_PREFIX}-python-numpy"
 )
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cmake"
   "${MINGW_PACKAGE_PREFIX}-ninja"
   "${MINGW_PACKAGE_PREFIX}-cc"
-  'git'
+  "${MINGW_PACKAGE_PREFIX}-openmp"
+  "${MINGW_PACKAGE_PREFIX}-vulkan-headers"
+  "${MINGW_PACKAGE_PREFIX}-opencl-headers"
+  "git"
 )
 source=("${_realname}"::"git+https://github.com/ggerganov/llama.cpp.git#tag=${_realver}")
-sha256sums=('c72c6b7ca9c57e887e0bce94b113cc237cb59c09fb83f4eb490192bb6a7e67a0')
+sha256sums=('64d706b84ad9a8cb4529566f816d000f0ed66d81f98b7af7d31d8e5c7284335c')
 
 pkgver() {
   cd "${srcdir}/${_realname}"
@@ -48,11 +57,14 @@ build() {
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       "${extra_config[@]}" \
       -DBUILD_SHARED_LIBS=ON \
-      -DLLAMA_BLAS=ON \
-      -DLLAMA_BLAS_VENDOR=OpenBLAS \
-      -DLLAMA_WIN_VER="0x603" \
-      -DLLAMA_NATIVE=OFF \
-      -DLLAMA_CCACHE=OFF \
+      -DGGML_RPC=ON \
+      -DGGML_BLAS=ON \
+      -DGGML_BLAS_VENDOR=OpenBLAS \
+      -DGGML_VULKAN=ON \
+      -DGGML_OPENCL=ON \
+      -DGGML_OPENCL_USE_ADRENO_KERNELS=OFF \
+      -DGGML_NATIVE=OFF \
+      -DGGML_CCACHE=OFF \
       ../${_realname}
 
   "${MINGW_PREFIX}"/bin/cmake.exe --build .
@@ -63,15 +75,19 @@ package() {
 
   DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
 
-  # Install the examples by prefixing them with llama.cpp
-  # except main.exe, which gets installed as plain llama.cpp.exe
+  # Rename output files by prefixing them with llama (if not already prefixed and if not DLL)
   cd "${pkgdir}${MINGW_PREFIX}"
-  for i in bin/*.{exe,py}; do
-    mv "${i}" "${pkgdir}${MINGW_PREFIX}/bin/${_realname}-${i//bin\//}"
+  for i in bin/*.{exe,py,dll}; do    
+    filename=$(basename "$i")
+    
+    if [[ ! ("$filename" =~ ^llama || "$filename" =~ \.dll$) ]]; then
+      mv "${i}" "${pkgdir}${MINGW_PREFIX}/bin/llama-${filename}"
+    else
+      mv "${i}" "${pkgdir}${MINGW_PREFIX}/bin/${filename}"
+    fi
   done
+
   cd -
-  mv "${pkgdir}${MINGW_PREFIX}/bin/${_realname}-main.exe" \
-    "${pkgdir}${MINGW_PREFIX}/bin/${_realname}.exe"
 
   install -Dm644 "${srcdir}/${_realname}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-llama.cpp/PKGBUILD
+++ b/mingw-w64-llama.cpp/PKGBUILD
@@ -1,9 +1,10 @@
+
+
 _realname=llama.cpp
-_realver=b4394
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 epoch=1
-pkgver=b4394.r0.g16cdce7
+pkgver=b4394
 pkgrel=1
 pkgdesc="Library and tools for running inference with Meta's LLaMA model (and derivatives) in C/C++ (mingw-w64)"
 arch=('any')
@@ -12,34 +13,23 @@ url="https://github.com/ggerganov/llama.cpp"
 license=('spdx:MIT')
 depends=(
   "${MINGW_PACKAGE_PREFIX}-gcc-libs"
-  "${MINGW_PACKAGE_PREFIX}-openblas64"
-  "${MINGW_PACKAGE_PREFIX}-vulkan-loader"
-  "${MINGW_PACKAGE_PREFIX}-shaderc"
+  "${MINGW_PACKAGE_PREFIX}-omp"
   "${MINGW_PACKAGE_PREFIX}-opencl-icd"
+  "${MINGW_PACKAGE_PREFIX}-openblas"
   "${MINGW_PACKAGE_PREFIX}-python"
   "${MINGW_PACKAGE_PREFIX}-python-numpy"
+  "${MINGW_PACKAGE_PREFIX}-vulkan-loader"
 )
 makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
   "${MINGW_PACKAGE_PREFIX}-cmake"
   "${MINGW_PACKAGE_PREFIX}-ninja"
-  "${MINGW_PACKAGE_PREFIX}-cc"
-  "${MINGW_PACKAGE_PREFIX}-openmp"
-  "${MINGW_PACKAGE_PREFIX}-vulkan-headers"
   "${MINGW_PACKAGE_PREFIX}-opencl-headers"
-  "git"
+  "${MINGW_PACKAGE_PREFIX}-shaderc"
+  "${MINGW_PACKAGE_PREFIX}-vulkan-headers"
 )
-source=("${_realname}"::"git+https://github.com/ggerganov/llama.cpp.git#tag=${_realver}")
-sha256sums=('64d706b84ad9a8cb4529566f816d000f0ed66d81f98b7af7d31d8e5c7284335c')
-
-pkgver() {
-  cd "${srcdir}/${_realname}"
-
-  git describe --long --tags --abbrev=7 | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
-}
-
-prepare() {
-  cd "${srcdir}/${_realname}"
-}
+source=("https://github.com/ggerganov/llama.cpp/archive/${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('da7b0b0b6cc9a2c1e7a88da2177ab650462cce32ad4d2a23d6ddd0dda72e5a33')
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
@@ -57,6 +47,9 @@ build() {
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       "${extra_config[@]}" \
       -DBUILD_SHARED_LIBS=ON \
+      -DLLAMA_ALL_WARNINGS=OFF \
+      -DLLAMA_BUILD_TESTS=OFF \
+      -DLLAMA_BUILD_EXAMPLES=OFF \
       -DGGML_RPC=ON \
       -DGGML_BLAS=ON \
       -DGGML_BLAS_VENDOR=OpenBLAS \
@@ -65,7 +58,8 @@ build() {
       -DGGML_OPENCL_USE_ADRENO_KERNELS=OFF \
       -DGGML_NATIVE=OFF \
       -DGGML_CCACHE=OFF \
-      ../${_realname}
+      -DPython3_EXECUTABLE=${MINGW_PREFIX}/bin/python \
+      ../${_realname}-${pkgver}
 
   "${MINGW_PREFIX}"/bin/cmake.exe --build .
 }
@@ -89,5 +83,6 @@ package() {
 
   cd -
 
-  install -Dm644 "${srcdir}/${_realname}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  install -Dm644 "${srcdir}"/${_realname}-${pkgver}/LICENSE \
+    "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
 }


### PR DESCRIPTION
* Introduce epoch field to indicate that new package version numbering scheme beginning with letter b is newer than old scheme beginning with letter r
* Amend output file renaming logic since llama.cpp outputs have changed significantly since last package update: only target files not already prefixed with word 'llama' (skipping DLLs), change prefix to 'llama' instead of 'llama.cpp' (consistent with new default convention), remove logic for renaming file 'main.exe' since this no longer exists (we instead have llama-cli and llama-server)
* Optimise build configuration: include more backends for GGML (Vulkan and OpenCL), add preferred openblas64 library as dependency, add openmp as build dependency, other option tweaks similar to ArchLinux PKGBUILD script
* More informative package description