### PR TITLE
x265: switch back to using release tarballs

### DIFF
--- a/mingw-w64-x265/PKGBUILD
+++ b/mingw-w64-x265/PKGBUILD
@@ -5,7 +5,7 @@ _realname=x265
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Open Source H265/HEVC video encoder (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -24,12 +24,11 @@ msys2_references=(
   "cpe: cpe:/a:multicorewareinc:x265"
   "cpe: cpe:/a:multicorewareinc:x265_high_efficiency_video_coding"
 )
-source=("${_realname}-${pkgver}.tar.gz"::"https://bitbucket.org/multicoreware/x265_git/get/${pkgver}.tar.gz")
-sha256sums=('7d23cdcdbd510728202c0dfbf7c51eda26a395de2096c504c2b10d6035711102')
+source=("${_realname}-${pkgver}.tar.gz"::"https://bitbucket.org/multicoreware/x265_git/downloads/x265_${pkgver}.tar.gz")
+sha256sums=('a31699c6a89806b74b0151e5e6a7df65de4b49050482fe5ebf8a4379d7af8f29')
 
 
 prepare() {
-  mv "${srcdir}"/"multicoreware-x265_git-"* "${srcdir}"/x265_${pkgver}
   cd "${srcdir}"/x265_${pkgver}
 
   for d in 8 10 12; do


### PR DESCRIPTION
Back with 3.4 there was no tarball so we switched to bitbucket generated tarballs.

In the case of the 4.1 tag the version info is outdated resulting in the wrong version displayed when running x265, which was fixed after tagging the release, and which was then used to roll the tarball.

See https://bitbucket.org/multicoreware/x265_git/commits/branch/Release_4.1

Switch back to the tarballs to fix this.

Fixes #22931