### PR TITLE
doxygen: backport fix for 'register' undef issue

### DIFF
--- a/mingw-w64-doxygen/PKGBUILD
+++ b/mingw-w64-doxygen/PKGBUILD
@@ -4,7 +4,7 @@ _realname=doxygen
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.13.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A documentation system for C++, C, Java, IDL and PHP (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -34,10 +34,12 @@ if [[ ${CARCH} != i686 ]]; then
 fi
 source=(https://www.doxygen.nl/files/${_realname}-${pkgver}.src.tar.gz
         cmake-mingw.patch
-        0002-clang-19-fix.patch)
+        0002-clang-19-fix.patch
+        https://patch-diff.githubusercontent.com/raw/doxygen/doxygen/pull/11302.patch)
 sha256sums=('99434f8130f68be4a4a817e540620aedf95c617c68cc73434de04207abaaae46'
             '2b86315039128992f750e3f9793cb4a769e1ff62e77a00ae391d83810bc6f920'
-            '8bd57267943b74e1bc4cae2c87da0255d747b6a2d35276fbfeb45f817947e991')
+            '8bd57267943b74e1bc4cae2c87da0255d747b6a2d35276fbfeb45f817947e991'
+            '567c3b27baadf3e34c5af9c14909e1f05196950c80e75de42d5c71c56ca7192f')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -57,6 +59,10 @@ prepare() {
   # https://github.com/doxygen/doxygen/issues/10928
   apply_patch_with_msg \
     0002-clang-19-fix.patch
+
+  # https://github.com/doxygen/doxygen/pull/11302
+  apply_patch_with_msg \
+    11302.patch
 }
 
 build() {

--- a/mingw-w64-headers-git/PKGBUILD
+++ b/mingw-w64-headers-git/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 pkgdesc="MinGW-w64 headers for Windows (mingw-w64)"
 pkgver=12.0.0.r459.g63f3f2846
-pkgrel=2
+pkgrel=3
 _commit='63f3f284635f4a1a09828acd2e6f6bea1eacb0e7'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -20,10 +20,8 @@ provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 options=('!strip' '!emptydirs')
 source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64#commit=$_commit"
-        "https://github.com/mingw-w64/mingw-w64/commit/f0044963d7ba0c90deea42d434fa790b4cf29f50.patch"
         0001-remove-ireference-boolean.patch)
 sha256sums=('9744d8767fa49d631c8b411df20bd285e9bce7261850f78d7edf65db1798ac05'
-            '878a23b1d47192e935782cc0210bee7106f20d375f12c6a0286ab2ae41641865'
             'cad48616325b5e70afa4e02424021fc8d54e17dcbf86eae3df990d3500080236')
 
 pkgver() {
@@ -34,10 +32,6 @@ pkgver() {
 prepare() {
   cd "${srcdir}/mingw-w64"
   git apply "${srcdir}/0001-remove-ireference-boolean.patch"
-
-  # breaks doxygen, see
-  # https://sourceforge.net/p/mingw-w64/mailman/message/59112743/
-  git apply -R "${srcdir}/f0044963d7ba0c90deea42d434fa790b4cf29f50.patch"
 }
 
 build() {


### PR DESCRIPTION
See https://github.com/doxygen/doxygen/pull/11302

This means we can remove the revert from mingw-w64 headers which was using the register keyword.