### PR TITLE
llama.cpp : upgrade to b4404 and switch on curl library dependent features

### DIFF
--- a/mingw-w64-llama.cpp/PKGBUILD
+++ b/mingw-w64-llama.cpp/PKGBUILD
@@ -4,14 +4,15 @@ _realname=llama.cpp
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 epoch=1
-pkgver=b4394
-pkgrel=2
+pkgver=b4404
+pkgrel=1
 pkgdesc="Library and tools for running inference with Meta's LLaMA model (and derivatives) in C/C++ (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64' 'mingw64')
 url="https://github.com/ggerganov/llama.cpp"
 license=('spdx:MIT')
 depends=(
+  "${MINGW_PACKAGE_PREFIX}-curl"
   "${MINGW_PACKAGE_PREFIX}-gcc-libs"
   "${MINGW_PACKAGE_PREFIX}-omp"
   "${MINGW_PACKAGE_PREFIX}-opencl-icd"
@@ -29,7 +30,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-vulkan-headers"
 )
 source=("https://github.com/ggerganov/llama.cpp/archive/${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('da7b0b0b6cc9a2c1e7a88da2177ab650462cce32ad4d2a23d6ddd0dda72e5a33')
+sha256sums=('ec16aa08daa58f804190e446bd010a941057391d66e5627d067f1fc3cc3f87ff')
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
@@ -50,6 +51,7 @@ build() {
       -DLLAMA_BUILD_EXAMPLES=ON \
       -DLLAMA_ALL_WARNINGS=OFF \
       -DLLAMA_BUILD_TESTS=OFF \
+      -DLLAMA_CURL=ON \
       -DGGML_RPC=ON \
       -DGGML_BLAS=ON \
       -DGGML_BLAS_VENDOR=OpenBLAS \


### PR DESCRIPTION
It is now possible to switch on curl dependent features since the build errors on MSYS2 have been fixed through merging of https://github.com/ggerganov/llama.cpp/pull/11013