### PR TITLE
[luarocks] fix compiler issues on CLANG64 and CLANGARM64, and update to 3.11.1

### DIFF
--- a/mingw-w64-lua-luarocks/0001-luarocks_msys2_mingw_w64.patch
+++ b/mingw-w64-lua-luarocks/0001-luarocks_msys2_mingw_w64.patch
@@ -1,13 +1,13 @@
 diff file generated from Sutou Kouhei PR -> https://github.com/luarocks/luarocks/pull/1230/files
 diff -Naur luarocks-3.11.1.orig/spec/util/test_env.lua luarocks-3.11.1/spec/util/test_env.lua
---- luarocks-3.11.1.orig/spec/util/test_env.lua	2024-05-31 14:38:00.000000000 -0300
-+++ luarocks-3.11.1/spec/util/test_env.lua	2025-01-02 09:22:19.774792872 -0300
+--- luarocks-3.11.1.orig/spec/util/test_env.lua	2025-01-02 19:39:04.839185833 -0300
++++ luarocks-3.11.1/spec/util/test_env.lua	2025-01-03 16:50:56.709365565 -0300
 @@ -359,6 +359,8 @@
           test_env.MINGW = true
        elseif argument == "vs" then
           test_env.MINGW = false
 +      elseif argument == "msys2_mingw_w64" then
-+         test_env.MINGW2_MINGW_W64 = true
++         test_env.MSYS2_MINGW_W64 = true
        elseif argument:find("^lua_dir=") then
           test_env.LUA_DIR = argument:match("^lua_dir=(.*)$")
        elseif argument:find("^lua=") then
@@ -15,21 +15,21 @@ diff -Naur luarocks-3.11.1.orig/spec/util/test_env.lua luarocks-3.11.1/spec/util
     if test_env.TEST_TARGET_OS == "windows" then
        if test_env.MINGW then
           table.insert(lines, [[SYSTEM = "mingw",]])
-+      elseif test_env.MINGW2_MINGW_W64 then
++      elseif test_env.MSYS2_MINGW_W64 then
 +         table.insert(lines, [[SYSTEM = "msys2_mingw_w64",]])
        else
           table.insert(lines, [[SYSTEM = "windows",]])
        end
 -      table.insert(lines, ("WIN_TOOLS = %q,"):format(testing_paths.win_tools))
-+      if not test_env.MINGW2_MINGW_W64 then
++      if not test_env.MSYS2_MINGW_W64 then
 +        table.insert(lines, ("WIN_TOOLS = %q,"):format(testing_paths.win_tools))
 +      end
     end
  
     table.insert(lines, "}")
 diff -Naur luarocks-3.11.1.orig/src/luarocks/core/cfg.lua luarocks-3.11.1/src/luarocks/core/cfg.lua
---- luarocks-3.11.1.orig/src/luarocks/core/cfg.lua	2024-05-31 14:38:00.000000000 -0300
-+++ luarocks-3.11.1/src/luarocks/core/cfg.lua	2025-01-02 12:45:30.784641405 -0300
+--- luarocks-3.11.1.orig/src/luarocks/core/cfg.lua	2025-01-02 19:39:04.835185776 -0300
++++ luarocks-3.11.1/src/luarocks/core/cfg.lua	2025-01-02 19:39:04.828185677 -0300
 @@ -451,10 +451,11 @@
           defaults.makefile = "Makefile"
           defaults.cmake_generator = "MSYS Makefiles"
@@ -66,7 +66,7 @@ diff -Naur luarocks-3.11.1.orig/src/luarocks/core/cfg.lua luarocks-3.11.1/src/lu
     if cfg.variables.LUA and not cfg.variables.LUA_BINDIR then
 diff -Naur luarocks-3.11.1.orig/src/luarocks/fs/msys2_mingw_w64.lua luarocks-3.11.1/src/luarocks/fs/msys2_mingw_w64.lua
 --- luarocks-3.11.1.orig/src/luarocks/fs/msys2_mingw_w64.lua	1969-12-31 21:00:00.000000000 -0300
-+++ luarocks-3.11.1/src/luarocks/fs/msys2_mingw_w64.lua	2025-01-02 09:38:08.062449763 -0300
++++ luarocks-3.11.1/src/luarocks/fs/msys2_mingw_w64.lua	2025-01-02 19:39:04.828185677 -0300
 @@ -0,0 +1,12 @@
 +--- MSYS2 + Mingw-w64 implementation of filesystem and platform abstractions.
 +local msys2_mingw_w64 = {}
@@ -82,8 +82,8 @@ diff -Naur luarocks-3.11.1.orig/src/luarocks/fs/msys2_mingw_w64.lua luarocks-3.1
 +return msys2_mingw_w64
 \ No newline at end of file
 diff -Naur luarocks-3.11.1.orig/src/luarocks/fs/unix/tools.lua luarocks-3.11.1/src/luarocks/fs/unix/tools.lua
---- luarocks-3.11.1.orig/src/luarocks/fs/unix/tools.lua	2024-05-31 14:38:00.000000000 -0300
-+++ luarocks-3.11.1/src/luarocks/fs/unix/tools.lua	2025-01-02 09:42:04.457415235 -0300
+--- luarocks-3.11.1.orig/src/luarocks/fs/unix/tools.lua	2025-01-02 19:39:04.834185762 -0300
++++ luarocks-3.11.1/src/luarocks/fs/unix/tools.lua	2025-01-02 19:39:04.828185677 -0300
 @@ -155,13 +155,13 @@
     end
  end

--- a/mingw-w64-lua-luarocks/0001-luarocks_msys2_mingw_w64.patch
+++ b/mingw-w64-lua-luarocks/0001-luarocks_msys2_mingw_w64.patch
@@ -1,55 +1,50 @@
 diff file generated from Sutou Kouhei PR -> https://github.com/luarocks/luarocks/pull/1230/files
-diff -Naur luarocks-3.7.0.orig/spec/util/test_env.lua luarocks-3.7.0/spec/util/test_env.lua
---- luarocks-3.7.0.orig/spec/util/test_env.lua	2021-04-13 23:53:36.000000000 +0200
-+++ luarocks-3.7.0/spec/util/test_env.lua	2021-07-25 17:43:16.413491100 +0200
-@@ -248,6 +248,8 @@
+diff -Naur luarocks-3.11.1.orig/spec/util/test_env.lua luarocks-3.11.1/spec/util/test_env.lua
+--- luarocks-3.11.1.orig/spec/util/test_env.lua	2024-05-31 14:38:00.000000000 -0300
++++ luarocks-3.11.1/spec/util/test_env.lua	2025-01-02 09:22:19.774792872 -0300
+@@ -359,6 +359,8 @@
           test_env.MINGW = true
        elseif argument == "vs" then
           test_env.MINGW = false
-+	  elseif argument == "msys2_mingw_w64" then
-+         test_env.MSYS2_MINGW_W64 = true
++      elseif argument == "msys2_mingw_w64" then
++         test_env.MINGW2_MINGW_W64 = true
        elseif argument:find("^lua_dir=") then
           test_env.LUA_DIR = argument:match("^lua_dir=(.*)$")
-       elseif argument:find("^lua_interpreter=") then
-@@ -429,7 +431,9 @@
-       return execute_output("find " .. path .. " -type f -exec stat -f \"%z %N\" {} \\; | md5")
-    elseif test_env.TEST_TARGET_OS == "windows" then
-       return execute_output("\"" .. Q(test_env.testing_paths.win_tools .. "/find") .. " " .. Q(path)
--         .. " -printf \"%s %p\"\" > temp_sum.txt && certUtil -hashfile temp_sum.txt && del temp_sum.txt")
-+         .. " -printf \"%s %p\"\" > temp_sum.txt && "
-+         .. "C:\\Windows\\System32\\certUtil -hashfile temp_sum.txt && "
-+		 .. "del temp_sum.txt")
-    end
- end
- 
-@@ -823,10 +827,14 @@
+       elseif argument:find("^lua=") then
+@@ -954,10 +956,14 @@
     if test_env.TEST_TARGET_OS == "windows" then
        if test_env.MINGW then
           table.insert(lines, [[SYSTEM = "mingw",]])
-+	  elseif test_env.MSYS2_MINGW_W64 then
++      elseif test_env.MINGW2_MINGW_W64 then
 +         table.insert(lines, [[SYSTEM = "msys2_mingw_w64",]])
        else
           table.insert(lines, [[SYSTEM = "windows",]])
        end
 -      table.insert(lines, ("WIN_TOOLS = %q,"):format(testing_paths.win_tools))
-+      if not test_env.MSYS2_MINGW_W64 then
-+         table.insert(lines, ("WIN_TOOLS = %q,"):format(testing_paths.win_tools))
-+	  end
++      if not test_env.MINGW2_MINGW_W64 then
++        table.insert(lines, ("WIN_TOOLS = %q,"):format(testing_paths.win_tools))
++      end
     end
  
     table.insert(lines, "}")
-diff -Naur luarocks-3.7.0.orig/src/luarocks/core/cfg.lua luarocks-3.7.0/src/luarocks/core/cfg.lua
---- luarocks-3.7.0.orig/src/luarocks/core/cfg.lua	2021-04-13 23:53:36.000000000 +0200
-+++ luarocks-3.7.0/src/luarocks/core/cfg.lua	2021-07-25 17:51:51.829906200 +0200
-@@ -414,6 +414,7 @@
+diff -Naur luarocks-3.11.1.orig/src/luarocks/core/cfg.lua luarocks-3.11.1/src/luarocks/core/cfg.lua
+--- luarocks-3.11.1.orig/src/luarocks/core/cfg.lua	2024-05-31 14:38:00.000000000 -0300
++++ luarocks-3.11.1/src/luarocks/core/cfg.lua	2025-01-02 12:45:30.784641405 -0300
+@@ -451,10 +451,11 @@
           defaults.makefile = "Makefile"
           defaults.cmake_generator = "MSYS Makefiles"
-          defaults.local_cache = home.."/.cache/luarocks"
-+		 defaults.variables.PWD = "cd"
+          defaults.local_cache = dir.path(home, ".cache", "luarocks")
++         defaults.variables.PWD = "cd"
           defaults.variables.MAKE = os.getenv("MAKE") or "make"
-          defaults.variables.CC = os.getenv("CC") or "gcc"
+-         defaults.variables.CC = os.getenv("CC") or "gcc"
++         defaults.variables.CC = os.getenv("CC") or "cc"
           defaults.variables.RC = os.getenv("WINDRES") or "windres"
-@@ -745,7 +749,7 @@
+-         defaults.variables.LD = os.getenv("CC") or "gcc"
++         defaults.variables.LD = os.getenv("CC") or "cc"
+          defaults.variables.MT = os.getenv("MT") or nil
+          defaults.variables.AR = os.getenv("AR") or "ar"
+          defaults.variables.RANLIB = os.getenv("RANLIB") or "ranlib"
+@@ -807,7 +808,7 @@
  
     local defaults = make_defaults(cfg.lua_version, processor, platforms, cfg.home)
  
@@ -57,10 +52,21 @@ diff -Naur luarocks-3.7.0.orig/src/luarocks/core/cfg.lua luarocks-3.7.0/src/luar
 +   if platforms.windows and not platforms.msys2_mingw_w64 and hardcoded.WIN_TOOLS then
        local tools = { "SEVENZ", "CP", "FIND", "LS", "MD5SUM", "WGET", }
        for _, tool in ipairs(tools) do
-          defaults.variables[tool] = '"' .. hardcoded.WIN_TOOLS .. "/" .. defaults.variables[tool] .. '.exe"'
-diff -Naur luarocks-3.7.0.orig/src/luarocks/fs/msys2_mingw_w64.lua luarocks-3.7.0/src/luarocks/fs/msys2_mingw_w64.lua
---- luarocks-3.7.0.orig/src/luarocks/fs/msys2_mingw_w64.lua	1970-01-01 01:00:00.000000000 +0100
-+++ luarocks-3.7.0/src/luarocks/fs/msys2_mingw_w64.lua	2021-07-25 17:52:51.477791300 +0200
+          defaults.variables[tool] = '"' .. dir.path(hardcoded.WIN_TOOLS, defaults.variables[tool] .. '.exe') .. '"'
+@@ -816,6 +817,10 @@
+       defaults.fs_use_modules = true
+    end
+ 
++   if platforms.windows and (platforms.msys2_mingw_64 or (platforms.msys and platforms.mingw)) then
++      defaults.fs_use_modules = false
++   end
++
+    -- if only cfg.variables.LUA is given in config files,
+    -- derive LUA_BINDIR and LUA_DIR from them.
+    if cfg.variables.LUA and not cfg.variables.LUA_BINDIR then
+diff -Naur luarocks-3.11.1.orig/src/luarocks/fs/msys2_mingw_w64.lua luarocks-3.11.1/src/luarocks/fs/msys2_mingw_w64.lua
+--- luarocks-3.11.1.orig/src/luarocks/fs/msys2_mingw_w64.lua	1969-12-31 21:00:00.000000000 -0300
++++ luarocks-3.11.1/src/luarocks/fs/msys2_mingw_w64.lua	2025-01-02 09:38:08.062449763 -0300
 @@ -0,0 +1,12 @@
 +--- MSYS2 + Mingw-w64 implementation of filesystem and platform abstractions.
 +local msys2_mingw_w64 = {}
@@ -75,10 +81,10 @@ diff -Naur luarocks-3.7.0.orig/src/luarocks/fs/msys2_mingw_w64.lua luarocks-3.7.
 +
 +return msys2_mingw_w64
 \ No newline at end of file
-diff -Naur luarocks-3.7.0.orig/src/luarocks/fs/unix/tools.lua luarocks-3.7.0/src/luarocks/fs/unix/tools.lua
---- luarocks-3.7.0.orig/src/luarocks/fs/unix/tools.lua	2021-04-13 23:53:36.000000000 +0200
-+++ luarocks-3.7.0/src/luarocks/fs/unix/tools.lua	2021-07-25 17:54:45.618437900 +0200
-@@ -152,13 +152,13 @@
+diff -Naur luarocks-3.11.1.orig/src/luarocks/fs/unix/tools.lua luarocks-3.11.1/src/luarocks/fs/unix/tools.lua
+--- luarocks-3.11.1.orig/src/luarocks/fs/unix/tools.lua	2024-05-31 14:38:00.000000000 -0300
++++ luarocks-3.11.1/src/luarocks/fs/unix/tools.lua	2025-01-02 09:42:04.457415235 -0300
+@@ -155,13 +155,13 @@
     end
  end
  
@@ -94,7 +100,7 @@ diff -Naur luarocks-3.7.0.orig/src/luarocks/fs/unix/tools.lua luarocks-3.7.0/src
        return true
     else
        return nil, "failed extracting " .. infile
-@@ -171,7 +171,7 @@
+@@ -174,7 +174,7 @@
  -- If not given, name is derived from input file.
  -- @return boolean: true on success; nil and error message on failure.
  function tools.gunzip(infile, outfile)
@@ -103,7 +109,7 @@ diff -Naur luarocks-3.7.0.orig/src/luarocks/fs/unix/tools.lua luarocks-3.7.0/src
  end
  
  --- Uncompresses a .bz2 file.
-@@ -180,7 +180,7 @@
+@@ -183,7 +183,7 @@
  -- If not given, name is derived from input file.
  -- @return boolean: true on success; nil and error message on failure.
  function tools.bunzip2(infile, outfile)

--- a/mingw-w64-lua-luarocks/PKGBUILD
+++ b/mingw-w64-lua-luarocks/PKGBUILD
@@ -5,7 +5,7 @@
 _realname=luarocks
 pkgbase=mingw-w64-lua-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-lua-${_realname}")
-pkgver=3.9.2
+pkgver=3.11.1
 pkgrel=1
 pkgdesc="the package manager for Lua modules (mingw-w64)"
 arch=('any')
@@ -22,8 +22,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-lua"
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc" "${MINGW_PACKAGE_PREFIX}-autotools")
 source=("https://luarocks.org/releases/${_realname}-${pkgver}.tar.gz"
 		"0001-luarocks_msys2_mingw_w64.patch")
-sha256sums=('bca6e4ecc02c203e070acdb5f586045d45c078896f6236eb46aa33ccd9b94edb'
-            '9c0e3c836ac6fc2f528a6e3f8bcca1bc9aa76af5c660068d28e5fda9d0e74240')
+sha256sums=('c3fb3d960dffb2b2fe9de7e3cb004dc4d0b34bb3d342578af84f84325c669102'
+            '0b71986fa24324bf2d014ef89b7b8e7e481b0c42f7b5e27fb76daae9eeaea9a0')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"

--- a/mingw-w64-lua-luarocks/PKGBUILD
+++ b/mingw-w64-lua-luarocks/PKGBUILD
@@ -23,7 +23,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc" "${MINGW_PACKAGE_PREFIX}-autotools")
 source=("https://luarocks.org/releases/${_realname}-${pkgver}.tar.gz"
 		"0001-luarocks_msys2_mingw_w64.patch")
 sha256sums=('c3fb3d960dffb2b2fe9de7e3cb004dc4d0b34bb3d342578af84f84325c669102'
-            '0b71986fa24324bf2d014ef89b7b8e7e481b0c42f7b5e27fb76daae9eeaea9a0')
+            'd1f9699036c7293544eb37cf0a2a87af86b591b844f31e0433aa64b8040d46c6')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"


### PR DESCRIPTION
> [!WARNING]
> 
> It is a long PR. Two issues are reproduced, and the working fix is shown.

## Description

Today, I found that the current package ```mingw-w64-lua-luarocks``` has two independent issues:

1. On ```CLANG64``` and ```CLANGARM64``` environments, ```luarocks``` is built with a configuration to fallback to ```gcc``` as the default C compiler, which causes Lua modules written in C fail to build / install;
2. ```luarocks``` fails to uninstall [luafilesystem](https://luarocks.org/modules/hisham/luafilesystem) properly after a previous ```lfs``` package installation.

> [!NOTE]
> 
> Issue 2 has already been reported upstream [https://github.com/luarocks/luarocks/issues/1428](https://github.com/luarocks/luarocks/issues/1428), and fixed at [https://github.com/luarocks/luarocks/pull/1616](https://github.com/luarocks/luarocks/pull/1616). However, it still persists here without a proper fix.

Of lesser importance, MSYS2 is running version 3.9.2, while the latest ```luarocks``` release is 3.11.1.

> [!TIP]
> 
> I verified (cloned the branch and installed) that [https://github.com/msys2/MINGW-packages/pull/20461](https://github.com/msys2/MINGW-packages/pull/20461) updates to 3.11.1, but the issues described here still persists with the solution provided there. So, I would like to invite @sewbacca and @Biswa96 to review this PR.

## Table of Contents

* Reproduction of Issue 1
* Reproduction of Issue 2
* After the fix

### Reproduction of Issue 1

1. Close any MSYS2 shell and launch a fresh ```CLANG64``` shell

> [!IMPORTANT]
> 
> * ```CC``` environment variable must not be set
>  * Make sure that ```luafilesystem``` is not installed for the current environment (either by ```luarocks```, or by ```mingw-w64-clang-x86_64-lua-luafilesystem```).

2. Install ```luarocks```:
    ```bash
    pacman -S ${MINGW_PACKAGE_PREFIX}-lua-luarocks
    ```
    
3. Try to install any Lua package that has components written in C. For instance, [luafilesystem](https://luarocks.org/modules/hisham/luafilesystem) is enough for the test:
    ```bash
    luarocks install luafilesystem
    ```
    
    The resulting output should be like this:
    
    ![issue-compiler](https://github.com/user-attachments/assets/5ed0ebc7-4f68-4795-a96d-6f9f3739f0cd)

4. Leave the shell opened and untouched for the reproduction of the issue 2.

### Reproduction of Issue 2

> [!NOTE]
> 
>  We are going to continue with the shell left opened from the issue 1.

1. The issue 1 can be remedied by setting the ```CC``` environment variable, because ```luarocks``` will use it to build the C parts of a Lua module. So, set ```CC``` environment variable to the correct compiler:
    ```bash
    export CC=cc
    ```
    
2. Try again to install ```luafilesystem``` (it should succeed):
    ```bash
    luarocks install luafilesystem
    ```
    
3. List ```luarocks``` and check that ```luafilesystem``` was installed properly:
    ```bash
    luarocks list
    ```

4. Remove ```luafilesystem``` through ```luarocks```:
    ```bash
    luarocks remove luafilesystem
    ```

5. Check that ```luarocks``` said to have removed ```luafilesystem``` properly, but did not:
    ```bash
    lua -e "print(require 'lfs')"
    ```

> [!NOTE]
> 
> ```lfs.dll``` can still be found at ```/clang64/lib/lua/5.4/lfs.dll```

6. Go ahead and remove it manually:
    ```bash
    rm ${MINGW_PREFIX}/lib/lua/5.4/lfs.dll
    ```

    ![issue-lfs](https://github.com/user-attachments/assets/e39125c3-8b21-4bfb-afc0-e4a887373760)

### After the fix

#### Initial setup

1. Close any MSYS2 shell and launch a fresh ```CLANG64``` shell

> [!NOTE]
> 
> Ideally, ```CC``` environment variable should not be set. Remember that issue 1 can be bypassed by setting ```CC```.

2. Uninstall ```luarocks``` in case it is already installed, and also make sure that ```luafilesystem``` is not installed for the current environment (either by ```luarocks```, or by ```mingw-w64-clang-x86_64-lua-luafilesystem```);
3. Download GitHub artifacts from the build and install them.

#### Check that issues 1 and 2 were fixed

1. Install ```luafilesystem```:
    ```bash
    luarocks install luafilesystem
    ```
    
3. List ```luarocks``` and check that ```luafilesystem``` was installed properly:
    ```bash
    luarocks list
    ```

4. Remove ```luafilesystem``` through ```luarocks```:
    ```bash
    luarocks remove luafilesystem
    ```

5. Check that ```luarocks``` removed ```luafilesystem``` properly, and it cannot find ```lfs.dll``` anymore
    ```bash
    lua -e "print(require 'lfs')"
    ```
    
    ![final-result](https://github.com/user-attachments/assets/2e3cb216-549d-4f47-9d69-e61fe77561ab)
