### PR TITLE
tomlplusplus: Fix wrong library location according to CMake

### DIFF
--- a/mingw-w64-tomlplusplus/PKGBUILD
+++ b/mingw-w64-tomlplusplus/PKGBUILD
@@ -28,6 +28,7 @@ build() {
       "${_realname}-${pkgver}"
 
   meson compile -C "build-${MSYSTEM}"
+  sed -i 's/lib/bin/' "build-${MSYSTEM}/src/tomlplusplusConfig.cmake"
 }
 
 package() {


### PR DESCRIPTION
Fixes #22988 