### PR TITLE
tomlplusplus: Fix dll path in cmake imported location

### DIFF
--- a/mingw-w64-tomlplusplus/0001-tomlplusplus-fix-cmake-imported-location.patch
+++ b/mingw-w64-tomlplusplus/0001-tomlplusplus-fix-cmake-imported-location.patch
@@ -1,0 +1,21 @@
+--- a/cmake/tomlplusplusConfig.cmake.meson.in
++++ b/cmake/tomlplusplusConfig.cmake.meson.in
+@@ -20,7 +20,7 @@
+   # Set the path to the installed library so that users can link to it
+   if (@compile_library@)
+     set_target_properties(tomlplusplus::tomlplusplus PROPERTIES
+-      IMPORTED_LOCATION "${PACKAGE_PREFIX_DIR}/@libdir@/@lib_name@"
++      IMPORTED_LOCATION "${PACKAGE_PREFIX_DIR}/@bindir@/@lib_name@"
+     )
+     # compile_options not quoted on purpose
+     target_compile_options(tomlplusplus::tomlplusplus INTERFACE @compile_options@)
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -81,6 +81,7 @@
+ 			'compile_library': true,
+ 			'compile_options': cmake_compile_options,
+ 			'includedir': get_option('includedir'),
++			'bindir': get_option('bindir'),
+ 			'libdir': get_option('libdir'),
+ 			'lib_name': lib_name
+ 		})

--- a/mingw-w64-tomlplusplus/PKGBUILD
+++ b/mingw-w64-tomlplusplus/PKGBUILD
@@ -4,7 +4,7 @@ _realname=tomlplusplus
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.4.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Header-only TOML config file parser and serializer for C++17 (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -14,8 +14,15 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-cc")
-source=("https://github.com/marzer/${_realname}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('8517f65938a4faae9ccf8ebb36631a38c1cadfb5efa85d9a72e15b9e97d25155')
+source=("https://github.com/marzer/${_realname}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
+        0001-tomlplusplus-fix-cmake-imported-location.patch)
+sha256sums=('8517f65938a4faae9ccf8ebb36631a38c1cadfb5efa85d9a72e15b9e97d25155'
+            '8042359f9a9eb7244e137fff8e8e54c2b877fc5e5430aae82dd56a07499f7cec')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+  patch -p1 -i "${srcdir}"/0001-tomlplusplus-fix-cmake-imported-location.patch
+}
 
 build() {
   MSYS2_ARG_CONV_EXCL="--prefix=" \


### PR DESCRIPTION
* Fixes #22988 