### PR TITLE
Add patch to build gr-network with boost 1.87

### DIFF
--- a/mingw-w64-gnuradio/PKGBUILD
+++ b/mingw-w64-gnuradio/PKGBUILD
@@ -4,10 +4,10 @@ _realname=gnuradio
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=3.10.11.0
-pkgrel=10
+pkgrel=11
 pkgdesc="General purpose DSP and SDR toolkit (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://gnuradio.org/'
 msys2_repository_url="https://github.com/gnuradio/gnuradio"
 msys2_references=(
@@ -72,6 +72,7 @@ source=("https://github.com/${_realname}/${_realname}/archive/v${pkgver}/${_real
         "https://github.com/gnuradio/gnuradio/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz.asc"
         0001-cmake-Install-python-wrapper-exe-for-scripts-on-Wind.patch
         https://github.com/gnuradio/gnuradio/commit/16ef847807553d65b80666b238643794b0b93d71.patch
+        https://github.com/gnuradio/gnuradio/commit/111a4ff8b868791dae74d8cdf8c1e0684840f51a.patch
         numpy-2.0.patch
         gnuradio-blocks-and-examples-path.hook.in
         gnuradio-blocks-and-examples-path.script.in
@@ -85,6 +86,7 @@ sha256sums=('9ca658e6c4af9cfe144770757b34ab0edd23f6dcfaa6c5c46a7546233e5ecd29'
             'SKIP'
             'aa9c79f6ab923c566f57d90117fa7e82549c26230538ffb3a2b1c0246fc31c19'
             '05f60071b421d9bd30cc4744dbaa035581c77dd03e8da94c12083fa619be3868'
+            '844d5157489fcd25467b98cbb48c4a52cc95eba41dc32a1c39c48fa75e21be19'
             'e3a2d9f63318b56f87829d224232724d9c815b46c6c7086ac3c5b6ae8980bc7b'
             'b2f014a69b32afcb207e4d2e8e163fc04968594d7d4c3184b9ea5c8cf2a29329'
             'caa9a6cc253d508abcd01545f26b46df0d708d24f69b7dc59183d631872721ed'
@@ -97,6 +99,7 @@ prepare() {
   # BSD-3-Clause license
   patch -Np1 -i "${srcdir}/0001-cmake-Install-python-wrapper-exe-for-scripts-on-Wind.patch"
   patch -Np1 -i "${srcdir}/16ef847807553d65b80666b238643794b0b93d71.patch"
+  patch -Np1 -i "${srcdir}/111a4ff8b868791dae74d8cdf8c1e0684840f51a.patch"
   patch -Np1 -i "${srcdir}/numpy-2.0.patch"
 }
 
@@ -120,8 +123,6 @@ build() {
       -DBoost_CHRONO_LIBRARY_RELEASE="${MINGW_PREFIX}/bin/libboost_chrono-mt.dll" \
       -DBoost_DATE_TIME_LIBRARY_RELEASE="${MINGW_PREFIX}/bin/libboost_date_time-mt.dll" \
       -DBoost_PROGRAM_OPTIONS_LIBRARY_RELEASE="${MINGW_PREFIX}/bin/libboost_program_options-mt.dll" \
-      -DBoost_REGEX_LIBRARY_RELEASE="${MINGW_PREFIX}/bin/libboost_regex-mt.dll" \
-      -DBoost_SYSTEM_LIBRARY_RELEASE="${MINGW_PREFIX}/bin/libboost_system-mt.dll" \
       -DBoost_THREAD_LIBRARY_RELEASE="${MINGW_PREFIX}/bin/libboost_thread-mt.dll" \
       -DBoost_UNIT_TEST_FRAMEWORK_LIBRARY_RELEASE="${MINGW_PREFIX}/bin/libboost_unit_test_framework-mt.dll" \
       -DENABLE_CTRLPORT_THRIFT=OFF \


### PR DESCRIPTION
- also, update to build for clang64 and calangarm64 as they both have python-scipy again.
- remove references to unused Boost_REGEX_LIBRARY_RELEASE and Boost_SYSTEM_LIBRARY_RELEASE.
- update pkgrel.