### PR TITLE
python: enable LTO for CLANG* envs

### DIFF
--- a/mingw-w64-python/PKGBUILD
+++ b/mingw-w64-python/PKGBUILD
@@ -23,7 +23,7 @@ else
   pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}${_pybasever}")
 fi
 pkgver=${_pybasever}.8
-pkgrel=1
+pkgrel=2
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -310,7 +310,7 @@ prepare() {
   0119-mingw_smoketests-build-extension-in-a-venv.patch \
   0120-venvlauncher-try-looking-for-the-versioned-.exe-firs.patch \
   0121-fixup-CI-test-the-build-and-add-some-mingw-specific-.patch
- 
+
   autoreconf -vfi
 }
 
@@ -321,7 +321,9 @@ build() {
     # Upstream defaults to -O3, so we can do too
     CFLAGS+=" -O3"
     # FIXME: https://github.com/msys2-contrib/cpython-mingw/issues/10
-    # _extra_config+=("--with-lto")
+    if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then
+      _extra_config+=("--with-lto")
+    fi
   else
     CFLAGS+=" -O0 -ggdb"
     CXXFLAGS+=" -O0 -ggdb"


### PR DESCRIPTION
Using a toy script from https://github.com/msys2/MINGW-packages/issues/22917 this reduces the time it takes from 723.7 ms to 670.4 ms on my PC.