### PR TITLE
libpng: Update to 1.6.45

### DIFF
--- a/mingw-w64-libpng/PKGBUILD
+++ b/mingw-w64-libpng/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libpng
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.6.44
+pkgver=1.6.45
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -18,11 +18,10 @@ msys2_references=(
   "cpe: cpe:/a:greg_roelofs:libpng"
   "cpe: cpe:/a:libpng:libpng"
 )
-# apng: https://github.com/mozilla/gecko-dev/commits/master/media/libpng/apng.patch
 source=("https://downloads.sourceforge.net/sourceforge/libpng/${_realname}-${pkgver}.tar.xz"
-        "https://raw.githubusercontent.com/mozilla/gecko-dev/8c08a880a379953fedc7a16515bb13db0e837179/media/libpng/apng.patch")
-sha256sums=('60c4da1d5b7f0aa8d158da48e8f8afa9773c1c8baa5d21974df61f1886b8ce8e'
-            '93a47b192b1018a13ac53eed8c25c890c5c8538755b1dd042adf291863ebe5a7')
+        "https://downloads.sourceforge.net/project/libpng-apng/libpng16/${pkgver}/${_realname}-${pkgver}-apng.patch.gz")
+sha256sums=('926485350139ffb51ef69760db35f78846c805fef3d59bfdcb2fba704663f370'
+            '6ae9549638af1e5b26907e015671d00a5761eea93e326f576dfe82b08567274c')
 validpgpkeys=('8048643BA2C840F4F92A195FF54984BFA16C640F')  # Glenn Randers-Pehrson (mozilla) <glennrp+bmo@gmail.com>
 
 prepare() {
@@ -33,7 +32,7 @@ prepare() {
   # Arch dropped it some time ago:
   # https://gitlab.archlinux.org/archlinux/packaging/packages/libpng/-/commit/bc95b152de9709a21c2938d5a
   # Maybe we should too?
-  patch -p1 -i "${srcdir}/apng.patch"
+  patch -p1 -i "${srcdir}/libpng-${pkgver}-apng.patch"
 
   # autoreconf to get updated libtool files with clang support
   autoreconf -fiv


### PR DESCRIPTION
~~And try dropping the apng patches~~

~~* Arch dropped them long ago~~
~~* Gentoo is working on it~~

~~(see the removed comment for links)~~