### PR TITLE
fltk: disable GDI+

### DIFF
--- a/mingw-w64-fltk/PKGBUILD
+++ b/mingw-w64-fltk/PKGBUILD
@@ -4,7 +4,7 @@ _realname=fltk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.4.1
-pkgrel=1
+pkgrel=2
 pkgdesc="C++ user interface toolkit (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -61,6 +61,7 @@ build() {
     -DFLTK_USE_SYSTEM_LIBPNG=ON \
     -DFLTK_USE_SYSTEM_ZLIB=ON \
     -DFLTK_BUILD_SHARED_LIBS=ON \
+    -DFLTK_GRAPHICS_GDIPLUS=OFF \
     "../${_realname}-release-${pkgver}"
 
   ${MINGW_PREFIX}/bin/cmake.exe --build ./


### PR DESCRIPTION
If FLTK is built with GDI+, unloading the library leads to a deadlock (at least in Octave).
See also: https://octave.discourse.group/t/6097/11

Following up on the discussion in #22620.
