### PR TITLE
cargo-local-registry: update to 0.2.7

### DIFF
--- a/mingw-w64-cargo-local-registry/PKGBUILD
+++ b/mingw-w64-cargo-local-registry/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=cargo-local-registry
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.2.6
-pkgrel=3
+pkgver=0.2.7
+pkgrel=1
 pkgdesc="A cargo subcommand to manage local registries (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -14,44 +14,41 @@ msys2_references=(
   'purl: pkg:cargo/cargo-local-registry'
 )
 license=('spdx:MIT OR Apache-2.0')
-depends=("${MINGW_PACKAGE_PREFIX}-zlib" "${MINGW_PACKAGE_PREFIX}-libssh2")
+depends=("${MINGW_PACKAGE_PREFIX}-zlib"
+         "${MINGW_PACKAGE_PREFIX}-libssh2")
+         #"${MINGW_PACKAGE_PREFIX}-libgit2")
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-openssl")
-source=("${url}/archive/${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('b42e4904e4db100c27d81cf94a034438b20ae6dbb34d0fee39012f2d548680ca')
+source=("${url}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('8a9803c7758ad163760626d37f0744884b8d1d5905c25d00359af773befa392b')
 
 prepare() {
-  cd "${srcdir}/${_realname}-${pkgver}"
+  cd "${_realname}-${pkgver}"
 
-  export LIBZ_SYS_STATIC=0
-  export LIBGIT2_NO_VENDOR=1
+  # not compatible with libgit2 1.9+
+  # export LIBGIT2_NO_VENDOR=1
   export OPENSSL_NO_VENDOR=1
   export LIBSSH2_SYS_USE_PKG_CONFIG=1
-  # update windows-targets to fix windows-gnullvm dependency specification
-  "${MINGW_PREFIX}/bin/cargo.exe" update -p windows-targets@0.48.0 --precise 0.48.1
 
-  "${MINGW_PREFIX}/bin/cargo.exe" fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo update -p cc
+  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
 }
 
 build() {
-  cd "${srcdir}/${_realname}-${pkgver}"
+  cd "${_realname}-${pkgver}"
 
-  "${MINGW_PREFIX}/bin/cargo.exe" build \
-    --release \
-    --frozen
+  cargo build --release --frozen
 }
 
 check() {
-  cd "${srcdir}/${_realname}-${pkgver}"
+  cd "${_realname}-${pkgver}"
 
-  "${MINGW_PREFIX}/bin/cargo.exe" test \
-    --release \
-    --frozen
+  cargo test --release --frozen
 }
 
 package() {
-  cd "${srcdir}/${_realname}-${pkgver}"
+  cd "${_realname}-${pkgver}"
 
   install -Dm755 "target/release/${_realname}.exe" "${pkgdir}${MINGW_PREFIX}/bin/${_realname}.exe"
   install -Dm644 "README.md" "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}/README.md"


### PR DESCRIPTION
while working on https://github.com/msys2/MINGW-packages/pull/23050 I found that this package is not updated. the update contains some fixes for build. cherry-pick changes from libgit2-1.9.0 branch while at it