### PR TITLE
wolfssl: new package

### DIFF
--- a/mingw-w64-wolfssl/PKGBUILD
+++ b/mingw-w64-wolfssl/PKGBUILD
@@ -1,0 +1,72 @@
+# Maintainer: Yang Kun <ikspress@outlook.com>
+
+_realname=wolfssl
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=5.7.6
+pkgrel=1
+pkgdesc="Lightweight, portable, C-language-based SSL/TLS library"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://www.wolfssl.com/products/wolfssl/'
+license=('spdx:GPL-2.0-or-later')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
+source=("https://github.com/wolfssl/wolfssl/archive/v${pkgver}-stable/${_realname}-${pkgver}-stable.tar.gz")
+sha256sums=('52b1e439e30d1ed8162a16308a8525a862183b67aa30373b11166ecbab000d63')
+validpgpkeys=('A2A48E7BCB96C5BECB987314EBC80E415CA29677') # wolfSSL <secure@wolfssl.com>
+
+build() {
+  local cmake_options=(
+    "-DCMAKE_DLL_NAME_WITH_SOVERSION=ON"
+    "-DWOLFSSL_CURVE25519=ON"
+    "-DWOLFSSL_CURVE448=ON"
+    "-DWOLFSSL_ED25519=ON"
+    "-DWOLFSSL_ED448=ON"
+    "-DWOLFSSL_REPRODUCIBLE_BUILD=ON"
+    "-DWOLFSSL_SNI=ON"
+  )
+  if check_option "debug" "n"; then
+    cmake_options+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    cmake_options+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  # Shared Build
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    cmake -GNinja -B "build-${MSYSTEM}-shared" -S "${_realname}-${pkgver}-stable" \
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+    -DBUILD_SHARED_LIBS=ON \
+    "${cmake_options[@]}"
+
+  cmake --build "build-${MSYSTEM}-shared"
+
+  # Static Build
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    cmake -GNinja -B "build-${MSYSTEM}-static" -S "${_realname}-${pkgver}-stable" \
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+    -DBUILD_SHARED_LIBS=OFF \
+    "${cmake_options[@]}"
+
+  cmake --build "build-${MSYSTEM}-static"
+}
+
+check() {
+  # Shared Check
+  PATH="$PWD/build-${MSYSTEM}-shared":$PATH cmake --build "build-${MSYSTEM}-shared" --target test || true
+
+  # Static Check
+  cmake --build "build-${MSYSTEM}-static" --target test || true
+}
+
+package() {
+  # Static Install
+  DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}-static"
+
+  # Shared Install
+  DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}-shared"
+
+  # License
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}-stable/COPYING" -t "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
+}


### PR DESCRIPTION
The content in `cmake_options` variable is taken from [Arch Linux](https://gitlab.archlinux.org/archlinux/packaging/packages/wolfssl/-/blob/main/PKGBUILD?ref_type=heads#L31).

I haven't test it on CLANGARM64.