### PR TITLE
python-cryptography: update to 44.0.0

### DIFF
--- a/mingw-w64-python-cryptography/PKGBUILD
+++ b/mingw-w64-python-cryptography/PKGBUILD
@@ -8,12 +8,11 @@ conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
            "${MINGW_PACKAGE_PREFIX}-python-${_realname}3")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
           "${MINGW_PACKAGE_PREFIX}-python-${_realname}3")
-pkgver=42.0.8
-pkgrel=3
+pkgver=44.0.0
+pkgrel=1
 pkgdesc="A package designed to expose cryptographic recipes and primitives to Python developers (mingw-w64)"
-license=('spdx:Apache-2.0')
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://cryptography.io/'
 msys2_repository_url='https://github.com/pyca/cryptography'
 msys2_references=(
@@ -22,13 +21,15 @@ msys2_references=(
   "cpe: cpe:/a:cryptography_project:cryptography"
   "cpe: cpe:/a:python-cryptography_project:python-cryptography"
 )
+license=('spdx:BSD-3-Clause OR Apache-2.0')
 depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-cffi"
          "${MINGW_PACKAGE_PREFIX}-openssl")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"
-             "${MINGW_PACKAGE_PREFIX}-python-setuptools-rust"
+             "${MINGW_PACKAGE_PREFIX}-python-maturin"
+             "${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-pkgconf")
 checkdepends=(
@@ -38,10 +39,12 @@ checkdepends=(
               "${MINGW_PACKAGE_PREFIX}-python-hypothesis"
               "${MINGW_PACKAGE_PREFIX}-python-pytz")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('8d09d05439ce7baa8e9e95b07ec5b6c886f548deb7e0f69ef25f64b3bce842f2')
+sha256sums=('cd4e834f340b4293430701e772ec543b0fbe6c2dea510a5286fe0acabe153a02')
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  export _PYTHON_HOST_PLATFORM=$(python -c "import sysconfig, sys; sys.stdout.write(sysconfig.get_platform())")
   ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
 }
 
@@ -58,5 +61,5 @@ package() {
     ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
     --destdir="${pkgdir}" dist/*.whl
 
-  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+  install -Dm644 LICENSE "${pkgdir}"${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE
 }

--- a/mingw-w64-python-pyopenssl/PKGBUILD
+++ b/mingw-w64-python-pyopenssl/PKGBUILD
@@ -6,17 +6,17 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=24.3.0
 pkgrel=1
 pkgdesc="Python wrapper module around the OpenSSL library (mingw-w64)"
-url='https://www.pyopenssl.org'
-license=('spdx:Apache-2.0')
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://www.pyopenssl.org'
+msys2_repository_url='https://github.com/pyca/pyopenssl/'
 msys2_references=(
   'archlinux: python-pyopenssl'
   'pypi: pyOpenSSL'
   "cpe: cpe:/a:pyopenssl:pyopenssl"
   "cpe: cpe:/a:pyopenssl_project:pyopenssl"
 )
-msys2_repository_url='https://github.com/pyca/pyopenssl/'
+license=('spdx:Apache-2.0')
 depends=("${MINGW_PACKAGE_PREFIX}-openssl"
          "${MINGW_PACKAGE_PREFIX}-python-cryptography")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"


### PR DESCRIPTION
I got an error from `pip check`:
```
cryptography 44.0.0 is not supported on this platform
```
Does someone know how to fix this error?