### PR TITLE
kicad: fix building with libc++ from LLVM 19

### DIFF
--- a/mingw-w64-kicad/007-llvm-libcxx-19.patch
+++ b/mingw-w64-kicad/007-llvm-libcxx-19.patch
@@ -1,0 +1,46 @@
+Fix building with libc++ from LLVM 19
+
+Avoid instantiating the std::char_traits<T> template with arbitrary types.
+That is no longer possible with the implementation of the C++ STL from LLVM 19.
+
+diff -urN kicad-8.0.6/eeschema/sch_io/easyedapro/sch_io_easyedapro.cpp.orig kicad-8.0.6/eeschema/sch_io/easyedapro/sch_io_easyedapro.cpp
+--- kicad-8.0.6/eeschema/sch_io/easyedapro/sch_io_easyedapro.cpp.orig	2024-10-13 21:12:40.000000000 +0200
++++ kicad-8.0.6/eeschema/sch_io/easyedapro/sch_io_easyedapro.cpp	2025-01-10 23:13:55.672983900 +0100
+@@ -205,7 +205,7 @@
+             std::vector<nlohmann::json> lines;
+             while( zip.CanRead() )
+             {
+-                nlohmann::json js = nlohmann::json::parse( txt.ReadLine() );
++                nlohmann::json js = nlohmann::json::parse( txt.ReadLine().utf8_string() );
+                 lines.emplace_back( js );
+             }
+ 
+@@ -257,7 +257,7 @@
+             if( !line.Contains( wxS( "ATTR" ) ) )
+                 continue; // Don't bother parsing
+ 
+-            nlohmann::json js = nlohmann::json::parse( line );
++            nlohmann::json js = nlohmann::json::parse( line.utf8_string() );
+             if( js.at( 0 ) == "ATTR" && js.at( 3 ) == "Symbol" )
+             {
+                 aSymbolNameList.Add( js.at( 4 ).get<wxString>() );
+--- kicad-8.0.6/thirdparty/compoundfilereader/compoundfilereader.h.orig	2024-10-13 21:12:40.000000000 +0200
++++ kicad-8.0.6/thirdparty/compoundfilereader/compoundfilereader.h	2025-01-10 22:59:47.868651800 +0100
+@@ -79,7 +79,7 @@
+ 
+ struct COMPOUND_FILE_ENTRY
+ {
+-    uint16_t name[32];
++    char16_t name[32];
+     uint16_t nameLen;
+     uint8_t type;
+     uint8_t colorFlag;
+@@ -131,7 +131,7 @@
+     }
+ };
+ 
+-typedef std::basic_string<uint16_t> utf16string;
++typedef std::basic_string<char16_t> utf16string;
+ typedef std::function<int(const COMPOUND_FILE_ENTRY*, const utf16string& dir, int level)>
+     EnumFilesCallback;
+ 

--- a/mingw-w64-kicad/PKGBUILD
+++ b/mingw-w64-kicad/PKGBUILD
@@ -10,7 +10,7 @@ _realname=kicad
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=8.0.6
-pkgrel=2
+pkgrel=3
 pkgdesc="Software for the creation of electronic schematic diagrams and printed circuit board artwork (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -70,6 +70,7 @@ source=(
   '004-fix-loading-ngspice-dll.patch'
   '005-clang-fmt-workaround.patch'
   '006-ki-6.0-rewrite-kiwin32_rc_for_clang.patch'
+  '007-llvm-libcxx-19.patch'
 )
 sha256sums=('f808ecb7ff588d9f6c70ec5938072c28ededaaed37fb7b4fe5eaaea57253f06c'
             '3c51482f1e452e37e75c06a65996aa5d631a93e82fbef7dd8274ae8ebbd53601'
@@ -77,7 +78,8 @@ sha256sums=('f808ecb7ff588d9f6c70ec5938072c28ededaaed37fb7b4fe5eaaea57253f06c'
             'd8d5f4bdd0aa6d8a907710c523f6f95840636cb2ef69e5275c6ed4966f134353'
             'f35a96c2393c21c266dbcd42616df64f9ee13b2423478bf6de029a3ad4e0ee8a'
             'bc7ad66d81d56dcfc237dfffe31fff58addff98622f65f64c45df11f70088c37'
-            '3155b9515ec7c094221441ce337c566c346bf76bb7aa42e86660cfdfb599e307')
+            '3155b9515ec7c094221441ce337c566c346bf76bb7aa42e86660cfdfb599e307'
+            '5531acad48988772e4453f42ac749f4001170e4be892d3f224b37e0e606ab5ab')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -97,7 +99,8 @@ prepare() {
     003-ki-6.0-code-fixes-for-GNUC-CLANG.patch \
     004-fix-loading-ngspice-dll.patch \
     005-clang-fmt-workaround.patch \
-    006-ki-6.0-rewrite-kiwin32_rc_for_clang.patch
+    006-ki-6.0-rewrite-kiwin32_rc_for_clang.patch \
+    007-llvm-libcxx-19.patch
 }
 
 build() {


### PR DESCRIPTION
Avoid instantiating the std::char_traits<T> template with arbitrary types.
That is no longer possible with the implementation of the C++ STL from LLVM 19.
