### PR TITLE
openblas: Properly enable dynamic cores on ARM64

### DIFF
--- a/mingw-w64-openblas/PKGBUILD
+++ b/mingw-w64-openblas/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-openblas
 pkgname=("${MINGW_PACKAGE_PREFIX}-openblas"
          $([[ "${CARCH}" == "i686" ]] || echo "${MINGW_PACKAGE_PREFIX}-openblas64"))
 pkgver=0.3.28
-pkgrel=2
+pkgrel=3
 pkgdesc="An optimized BLAS library based on GotoBLAS2 1.13 BSD, providing optimized blas, lapack, and cblas (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -66,8 +66,8 @@ _build_openblas() {
 
   if [[ ${CARCH} == aarch64 ]]; then
     # Clang wasn't able to compile all the kernels inside the arm64 folder,
-    # Enable only the cores known to run Windows on ARM
-    _extra_config+=("-DTARGET=CORTEXA53" "-DDYNAMIC_LIST=\"ARMV8 CORTEXA53 CORTEXA55 CORTEXA57 CORTEXA72 CORTEXA73 CORTEXA510 CORTEXA710 CORTEXX1 CORTEXX2\"")
+    # Enable only the cores known to build on Windows on ARM
+    _extra_config+=("-DTARGET=CORTEXA53" "-DDYNAMIC_ARCH=ON" "-DDYNAMIC_LIST='CORTEXA53;CORTEXA57;CORTEXA72;CORTEXA73;CORTEXA76;CORTEXX1;THUNDERX;TSV110;EMAG8180'")
   else
     _extra_config+=("-DTARGET=CORE2" "-DDYNAMIC_ARCH=ON")
   fi


### PR DESCRIPTION
Turns out that, for `DYNAMIC_LIST` to considered, `DYNAMIC_ARCH=ON` is also required