### PR TITLE
zed: update to 0.169.2

### DIFF
--- a/mingw-w64-zed/PKGBUILD
+++ b/mingw-w64-zed/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=zed
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.168.3
+pkgver=0.169.2
 pkgrel=1
 pkgdesc="A high-performance, multiplayer code editor (mingw-w64)"
 arch=('any')
@@ -44,7 +44,7 @@ source=("git+${msys2_repository_url}.git#tag=v${pkgver}"
         "zed-dont-vendor-cargo-about.patch"
         "zstd-sys-remove-statik.patch"
         "22876.patch")
-sha256sums=('e8ab88e188e66eb9e348889f89b7c6c1603e783551c54468f5f1467dde759f75'
+sha256sums=('aeae9582d89e9b207bea4ecf3e9b3cd62c950ebea4d096acf1693ad5b20f59fc'
             '38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa'
             'b126b7a9e3cc8d3d68c49dbfc184d54691b10172dbfd3272d4c2f43424cfca5b'
             '48f4900ceb02d3aaf9a1020f33d56629156e96759f456c0e7ca18bfcf910767b'


### PR DESCRIPTION
this update can probably break python projects with venv on root (with MinGW CPython). let me know if this is an issue for you