### PR TITLE
librsvg: drop LLD workaround

### DIFF
--- a/mingw-w64-librsvg/PKGBUILD
+++ b/mingw-w64-librsvg/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
 pkgver=2.59.2
-pkgrel=1
+pkgrel=2
 pkgdesc="SVG rendering library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -32,12 +32,10 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-gtk3: for rsvg-view-3")
 source=("https://download.gnome.org/sources/librsvg/${pkgver%.*}/${_realname}-${pkgver}.tar.xz"
         "glib-0.20.0.tar.gz::https://crates.io/api/v1/crates/glib/0.20.0/download"
         "glib-rs.patch"
-        "0002-avoid-link-whole.patch"
         "0004-add-option-for-disabling-convert.patch")
 sha256sums=('ecd293fb0cc338c170171bbc7bcfbea6725d041c95f31385dc935409933e4597'
             'fee90a615ce05be7a32932cfb8adf2c4bbb4700e80d37713c981fb24c0c56238'
             'e0f5accba0ff47d9cdf79f506ea76ea0b373edaf6845a23180a00c15e0a8691d'
-            '4cb597eef01a636ad7007b3a47b76e395f30b2347183b5acb1af94d39577a239'
             '0e042886d313b37f5db5e0405a5e37b3d3e4a6c66f94186677406136fa0e7a17')
 msys2_repository_url="https://gitlab.gnome.org/GNOME/librsvg"
 noextract=("${_realname}-${pkgver}.tar.xz")
@@ -52,11 +50,6 @@ prepare() {
   patch -p1 -i "${srcdir}/glib-rs.patch"
 
   cd "${srcdir}/${_realname}-${pkgver}"
-
-  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
-    # https://github.com/msys2/MINGW-packages/issues/21017
-    patch -p1 -i "${srcdir}/0002-avoid-link-whole.patch"
-  fi
 
   # fails to link for the static build, so skip for now
   patch -p1 -i "${srcdir}/0004-add-option-for-disabling-convert.patch"


### PR DESCRIPTION
Stacked on top of https://github.com/msys2/MINGW-packages/pull/23136