### PR TITLE
libipt update to 2.1.2

### DIFF
--- a/mingw-w64-libipt/PKGBUILD
+++ b/mingw-w64-libipt/PKGBUILD
@@ -1,19 +1,21 @@
+# Maintainer: Simon Sobisch https://github.com/GitMensch
+
 _realname=libipt
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgbase="mingw-w64-${_realname}"
-pkgver=2.1.1
+pkgver=2.1.2
 pkgrel=1
 pkgdesc='Intel(R) Processor Trace decoder library (mingw-w64)'
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64')
 url='https://github.com/intel/libipt'
 license=('spdx:BSD-3-Clause')
-makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
-           #  'pandoc' # Only required for building the manpage, we likely don't want that
-             "${MINGW_PACKAGE_PREFIX}-cc"
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             #'pandoc' # Only required for building the manpage, we likely don't want that
              'git')
-source=("${_realname}"::"git+${url}#tag=v${pkgver}")
-sha256sums=('SKIP')
+source=("${url}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('713d3e76b6c3073b122a9f5b6c025bc301a0436582f132caf782814363acf60f')
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
@@ -40,7 +42,7 @@ build() {
       -DPTXED=OFF \
       -DSIDEBAND=ON \
       -DCMAKE_C_FLAGS="-D__STDC_NO_THREADS__" \
-      ../${_realname}
+      ../${_realname}-${pkgver}
 
   "${MINGW_PREFIX}"/bin/cmake.exe --build .
 }
@@ -56,6 +58,8 @@ package() {
 
   DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
 
-  install -Dm644 "${srcdir}/${_realname}/README"  "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}/README"
-  install -Dm644 "${srcdir}/${_realname}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/README" \
+    "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}/README"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" \
+    "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
https://github.com/intel/libipt/releases/tag/v2.1.2, [commits since 2.1.1](https://github.com/intel/libipt/compare/v2.1.1...v2.1.2) include one bugfix on error handling, otherwise support for newer processors

note: I haven't done any tests with the result, just updating a package I've used in the past