### PR TITLE
qt6-declarative: should also build vectorimage

### DIFF
--- a/mingw-w64-qt6-declarative/PKGBUILD
+++ b/mingw-w64-qt6-declarative/PKGBUILD
@@ -1,4 +1,5 @@
 # Contributor: Mehdi Chinoune <mehdi.chinoune@hotmail.com>
+# Contributor: Gary Wang <opensource@blumia.net>
 
 _realname=qt6-declarative
 pkgbase=mingw-w64-${_realname}
@@ -6,7 +7,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
 _qtver=6.8.1
 pkgver=${_qtver/-/}
-pkgrel=1
+pkgrel=2
 pkgdesc='Classes for QML and JavaScript languages (mingw-w64)'
 arch=(any)
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -22,6 +23,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-qt6-shadertools"
              "${MINGW_PACKAGE_PREFIX}-qt6-languageserver"
+             "${MINGW_PACKAGE_PREFIX}-qt6-svg"
              "rsync")
 _pkgfn="${_realname/6-/}-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz"
@@ -62,7 +64,8 @@ build() {
 
 package_qt6-declarative() {
   depends=("${MINGW_PACKAGE_PREFIX}-qt6-base")
-  optdepends=("${MINGW_PACKAGE_PREFIX}-qt6-shadertools"
+  optdepends=("${MINGW_PACKAGE_PREFIX}-qt6-svg: for QtQuickVectorImage and svgtoqml"
+              "${MINGW_PACKAGE_PREFIX}-qt6-shadertools"
               "${MINGW_PACKAGE_PREFIX}-qt6-languageserver")
   conflicts=("${MINGW_PACKAGE_PREFIX}-qt6-quickcontrols2")
   replaces=("${MINGW_PACKAGE_PREFIX}-qt6-quickcontrols2")


### PR DESCRIPTION
Currently the VectorImage QML component is missing caused by not having `Qt::Svg` module while building qt-declarative. This patch adds such dependency as [it's also what Arch Linux did currently](https://gitlab.archlinux.org/archlinux/packaging/packages/qt6-declarative/-/blob/32cc4776bae9a733b4825111cbd72c7b28aa53d7/PKGBUILD#L25).