### PR TITLE
zed: update to 0.170.1

### DIFF
--- a/mingw-w64-zed/PKGBUILD
+++ b/mingw-w64-zed/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=zed
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.169.3
+pkgver=0.170.1
 pkgrel=1
 pkgdesc="A high-performance, multiplayer code editor (mingw-w64)"
 arch=('any')
@@ -42,11 +42,13 @@ fi
 source=("git+${msys2_repository_url}.git#tag=v${pkgver}"
         "zstd-sys.tar.gz::https://crates.io/api/v1/crates/zstd-sys/2.0.13+zstd.1.5.6/download"
         "zed-dont-vendor-cargo-about.patch"
+        "zed-set-rustflags.patch"
         "zstd-sys-remove-statik.patch"
         "22876.patch")
-sha256sums=('887841e4709db833fca3f9de608d9474664fac9a0692833a469518c6c5f2abf3'
+sha256sums=('64dea9a05f608bff06f3648b3e86c8666bcf04a488f039060fa58cec9693b918'
             '38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa'
             'b126b7a9e3cc8d3d68c49dbfc184d54691b10172dbfd3272d4c2f43424cfca5b'
+            '9a566344d0dddeffffda7d57c0798592193f24744997927c28207968a16ff101'
             '48f4900ceb02d3aaf9a1020f33d56629156e96759f456c0e7ca18bfcf910767b'
             '4e9e95ae76de5b9ed0405a56d36bb1b7cc8f7be61ebe6e033aaaf09c2ef4e973')
 
@@ -59,6 +61,9 @@ prepare() {
   patch -Np1 -i "../22876.patch"
   # use system cargo about to generate license file
   patch -Np1 -i "../zed-dont-vendor-cargo-about.patch"
+  # apply `-Cforce-frame-pointers=yes` in .cargo/config.toml instead of env var to apply other
+  # compilation flags
+  patch -Np1 -i "../zed-set-rustflags.patch"
   # link system deps dynamically
   patch -d "../zstd-sys-2.0.13+zstd.1.5.6" -i "../zstd-sys-remove-statik.patch"
   # use patched *-sys crates
@@ -93,11 +98,9 @@ build() {
   export ZED_UPDATE_EXPLANATION='Updates are handled by pacman'
   export CARGO_PROFILE_RELEASE_DEBUG=0
   export RELEASE_VERSION="${pkgver} (Rev${pkgrel}, Built by MSYS2 project)"
-  # keyboard shortcuts are broken when compiled with ld
-  # https://github.com/msys2/MINGW-packages/issues/22071
-  if [[ $MINGW_PACKAGE_PREFIX != *-clang-* ]]; then
-    export RUSTFLAGS+=" -Clink-arg=-fuse-ld=lld"
-  fi
+  # apply RUSTFLAGS from .cargo/config.toml instead of env var. use lld linker to fix keyboard
+  # shortcuts https://github.com/msys2/MINGW-packages/issues/22071
+  unset RUSTFLAGS
 
   cargo build --release --frozen -p zed
 }

--- a/mingw-w64-zed/zed-set-rustflags.patch
+++ b/mingw-w64-zed/zed-set-rustflags.patch
@@ -1,0 +1,10 @@
+--- a/.cargo/config.toml
++++ b/.cargo/config.toml
+@@ -1,6 +1,6 @@
+ [build]
+ # v0 mangling scheme provides more detailed backtraces around closures
+-rustflags = ["-C", "symbol-mangling-version=v0", "--cfg", "tokio_unstable"]
++rustflags = ["-C", "symbol-mangling-version=v0", "--cfg", "tokio_unstable", "-Cforce-frame-pointers=yes", "-Clink-arg=-fuse-ld=lld"]
+ 
+ [alias]
+ xtask = "run --package xtask --"


### PR DESCRIPTION
zed-set-rustflags.patch: cargo has a strange behavior regarding applying compilation flags. it ignores flags from .cargo/config.toml in case of RUSTFLAGS env var is set. this makes some useful flags ignored