### PR TITLE
python-numba: restore patch to remove numpy version pinning

### DIFF
--- a/mingw-w64-python-numba/5e917b96ae7033e994f185cb37329a07e56d51b6.patch
+++ b/mingw-w64-python-numba/5e917b96ae7033e994f185cb37329a07e56d51b6.patch
@@ -1,0 +1,40 @@
+--- a/numba/__init__.py
++++ b/numba/__init__.py
+@@ -39,6 +39,11 @@ def extract_version(mod):
+                f"{numpy_version[0]}.{numpy_version[1]}.")
+         raise ImportError(msg)
+ 
++    if numpy_version > (2, 1):
++        msg = (f"Numba needs NumPy 2.1 or less. Got NumPy "
++               f"{numpy_version[0]}.{numpy_version[1]}.")
++        raise ImportError(msg)
++
+     try:
+         import scipy
+     except ImportError:
+--- a/setup.py
++++ b/setup.py
+@@ -21,8 +21,9 @@
+ 
+ min_python_version = "3.10"
+ max_python_version = "3.14"  # exclusive
+-min_numpy_build_version = "1.11"
++min_numpy_build_version = "2.0.0rc1"
+ min_numpy_run_version = "1.24"
++max_numpy_run_version = "2.2"
+ min_llvmlite_version = "0.44.0dev0"
+ max_llvmlite_version = "0.45"
+ 
+@@ -366,10 +367,10 @@ def check_file_at_path(path2file):
+ 
+ packages = find_packages(include=["numba", "numba.*"])
+ 
+-build_requires = ['numpy >={}'.format(min_numpy_build_version)]
++build_requires = ['numpy >={},<{}'.format(min_numpy_build_version, max_numpy_run_version)]
+ install_requires = [
+     'llvmlite >={},<{}'.format(min_llvmlite_version, max_llvmlite_version),
+-    'numpy >={}'.format(min_numpy_run_version),
++    'numpy >={},<{}'.format(min_numpy_run_version, max_numpy_run_version),
+ ]
+ 
+ metadata = dict(

--- a/mingw-w64-python-numba/PKGBUILD
+++ b/mingw-w64-python-numba/PKGBUILD
@@ -27,8 +27,17 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-cc")
 optdepends=("${MINGW_PACKAGE_PREFIX}-python-scipy")
 options=('!emptydirs' '!strip')
-source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('888d2e89b8160899e19591467e8fdd4970e07606e1fbc248f239c89818d5f925')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
+        "5e917b96ae7033e994f185cb37329a07e56d51b6.patch")
+sha256sums=('888d2e89b8160899e19591467e8fdd4970e07606e1fbc248f239c89818d5f925'
+            '2c5f979f8a0c29736253f3b3718527237d0d5df72d4419f249c515622e3b1bb9')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+
+  # drop pinning numpy version from https://github.com/numba/numba/commit/5e917b96ae7033e994f185cb37329a07e56d51b6
+  patch -R -p1 -i ../5e917b96ae7033e994f185cb37329a07e56d51b6.patch
+}
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"


### PR DESCRIPTION
it was removed in 258f6e303f1e4c29b794ecc55517c2c030b3220c while actually [it's not fixed](https://github.com/numba/numba/blob/0.61.0/numba/__init__.py#L42-L45)