### PR TITLE
vk-bootstrap: Update to 1.4.305

### DIFF
--- a/mingw-w64-vk-bootstrap/PKGBUILD
+++ b/mingw-w64-vk-bootstrap/PKGBUILD
@@ -3,40 +3,45 @@
 _realname=vk-bootstrap
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.3.302
+pkgver=1.4.305
 pkgrel=1
 pkgdesc="A utility library that jump starts initialization of Vulkan (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://charles-lunarg.github.io/vk-bootstrap/"
 msys2_repository_url="https://github.com/charles-lunarg/vk-bootstrap"
-msys2_references=()
 license=("spdx:MIT")
 depends=("${MINGW_PACKAGE_PREFIX}-vulkan-headers")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
-optdepends=()
-source=("${_realname}"-${pkgver}.tar.gz"::https://codeload.github.com/charles-lunarg/${_realname}/tar.gz/refs/tags/v${pkgver}")
-sha256sums=('3b7eb60443cb7c8a334d7a76766e8f703d9e81b43fa8b5bd2983578cbb373970')
+source=("https://github.com/charles-lunarg/vk-bootstrap/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('2606528368ad8b62956d237050c36749df8f21a1b5db61df7b39ad65950654a8')
 
 build() {
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     cmake \
-          -GNinja \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
-          -DBUILD_SHARED_LIBS=ON \
-          -DVK_BOOTSTRAP_TEST=OFF \
-          -S "${_realname}-${pkgver}" \
-          -B "build-${MSYSTEM}"
+      -GNinja \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      -DBUILD_SHARED_LIBS=ON \
+      -DVK_BOOTSTRAP_TEST=OFF \
+      "${extra_config[@]}" \
+      -S "${_realname}-${pkgver}" \
+      -B "build-${MSYSTEM}"
 
   cmake --build "build-${MSYSTEM}"
 }
 
 package() {
-  cd "${srcdir}"
-
   DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}"
-  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE.txt" \
+    "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
The upstream skipped 1.4.304 and jump to 1.4.305. I think our vulkan headers will be updated to 305 soon anyway.