### PR TITLE
[new package] kstatusnotifieritem

### DIFF
--- a/mingw-w64-kstatusnotifieritem/PKGBUILD
+++ b/mingw-w64-kstatusnotifieritem/PKGBUILD
@@ -1,0 +1,68 @@
+# Maintainer: Gary Wang <opensource@blumia.net>
+
+source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks
+_realname=kstatusnotifieritem
+pkgbase="mingw-w64-${_realname}"
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=6.10.0
+pkgrel=1
+pkgdesc="A library for extracting file metadata (mingw-w64)"
+arch=('any')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
+msys2_references=(
+  'archlinux: kstatusnotifieritem'
+)
+msys2_repository_url='https://invent.kde.org/frameworks/kstatusnotifieritem/'
+url='https://community.kde.org/Frameworks/'
+license=('spdx:LGPL-2.0-or-later')
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-kwindowsystem"
+  "${MINGW_PACKAGE_PREFIX}-qt6-base"
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+  "${MINGW_PACKAGE_PREFIX}-extra-cmake-modules"
+  "${MINGW_PACKAGE_PREFIX}-gettext-tools"
+  "${MINGW_PACKAGE_PREFIX}-ninja"
+  "${MINGW_PACKAGE_PREFIX}-qt6-tools"
+)
+groups=("${MINGW_PACKAGE_PREFIX}-kf6")
+source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_realname}-${pkgver}.tar.xz"{,.sig})
+sha256sums=('4fa19843a737b43674d19b9ad31466c6aa64bbe27709073c3e2c33aa03bfac22'
+            'SKIP')
+validpgpkeys=(
+  'E0A3EB202F8E57528E13E72FD7574483BB57B18D' # Jonathan Esk-Riddell <jr@jriddell.org>
+  '90A968ACA84537CC27B99EAF2C8DF587A6D4AAC1' # Nicolas Fella <nicolas.fella@kde.org>
+)
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+}
+
+build() {
+  declare -a _extra_config
+  if check_option "debug" "n"; then
+    _extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    _extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  _kde_build_env
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    "${MINGW_PREFIX}"/bin/cmake.exe \
+      -GNinja \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      "${_KDE_INSTALL_DIRS[@]}" \
+      -DBUILD_QCH=OFF \
+      -DBUILD_TESTING=OFF \
+      "${_extra_config[@]}" \
+      -S "${_realname}-${pkgver}" \
+      -B "build-${MSYSTEM}"
+
+  "${MINGW_PREFIX}"/bin/cmake.exe --build "build-${MSYSTEM}"
+}
+
+package() {
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install "build-${MSYSTEM}"
+}


### PR DESCRIPTION
This is a tier 2 KDE Framework package/library, which is required to build some KDE applications (NeoChat for example).

Note: GPG key is not tested since I have no idea about how to test it properly.