### PR TITLE
mpv: Enable cdda and dvdnav options

### DIFF
--- a/mingw-w64-mpv/PKGBUILD
+++ b/mingw-w64-mpv/PKGBUILD
@@ -5,7 +5,7 @@ _realname=mpv
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.39.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Video player based on MPlayer/mplayer2 (mingw-w64)"
 url="https://mpv.io/"
 msys2_repository_url="https://github.com/mpv-player/mpv"
@@ -59,6 +59,8 @@ build() {
       --prefix="${MINGW_PREFIX}" \
       --wrap-mode=nodownload \
       --buildtype=plain \
+      -Dcdda=enabled \
+      -Ddvdnav=enabled \
       -Dlibmpv=true \
       -Djavascript=enabled \
       $([[ ${CARCH} == aarch64 ]] && echo "-Dgl=disabled") \


### PR DESCRIPTION
Those are disabled by default in meson_options.txt and were enabled before switching to meson. https://github.com/msys2/MINGW-packages/blob/e0d5ae00d1b21721da4371249145735b3c113cc1/mingw-w64-mpv/PKGBUILD#L73-L91

* Fixes #23211 