### PR TITLE
ktx-software: new package

### DIFF
--- a/mingw-w64-ktx-software/PKGBUILD
+++ b/mingw-w64-ktx-software/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=ktx-software
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.3.2
+pkgver=4.4.0
 pkgrel=1
 pkgdesc="KTX (Khronos Texture) Library and Tools (mingw-w64)"
 arch=('any')
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 optdepends=()
 source=("${_realname}"-${pkgver}.tar.gz"::https://codeload.github.com/KhronosGroup/KTX-Software/tar.gz/refs/tags/v${pkgver}")
-sha256sums=('74a114f465442832152e955a2094274b446c7b2427c77b1964c85c173a52ea1f')
+sha256sums=('3585d76edcdcbe3a671479686f8c81c1c10339f419e4b02a9a6f19cc6e4e0612')
 
 build() {
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \

--- a/mingw-w64-ktx-software/PKGBUILD
+++ b/mingw-w64-ktx-software/PKGBUILD
@@ -12,13 +12,24 @@ url="https://www.khronos.org/ktx/"
 msys2_repository_url="https://github.com/KhronosGroup/KTX-Software/"
 msys2_references=()
 license=("spdx:Apache-2.0")
-depends=("${MINGW_PACKAGE_PREFIX}-opencl-headers")
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-opencl-icd"
+)
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-ninja")
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-opencl-headers"
+             )
 optdepends=()
 source=("${_realname}"-${pkgver}.tar.gz"::https://codeload.github.com/KhronosGroup/KTX-Software/tar.gz/refs/tags/v${pkgver}")
 sha256sums=('3585d76edcdcbe3a671479686f8c81c1c10339f419e4b02a9a6f19cc6e4e0612')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+
+  # make sure we don't use prebuilt stuff
+  rm -rf "external/basisu/OpenCL/lib"
+}
 
 build() {
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \

--- a/mingw-w64-ktx-software/PKGBUILD
+++ b/mingw-w64-ktx-software/PKGBUILD
@@ -1,0 +1,46 @@
+# Maintainer: Felix Xing (Felixaszx) <felixaszx@outlook.com>
+
+_realname=ktx-software
+pkgbase="mingw-w64-${_realname}"
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=4.3.2
+pkgrel=1
+pkgdesc="KTX (Khronos Texture) Library and Tools (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url="https://www.khronos.org/ktx/"
+msys2_repository_url="https://github.com/KhronosGroup/KTX-Software/"
+msys2_references=()
+license=("spdx:Apache-2.0")
+depends=("${MINGW_PACKAGE_PREFIX}-opencl-headers")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
+optdepends=()
+source=("${_realname}"-${pkgver}.tar.gz"::https://codeload.github.com/KhronosGroup/KTX-Software/tar.gz/refs/tags/v${pkgver}")
+sha256sums=('74a114f465442832152e955a2094274b446c7b2427c77b1964c85c173a52ea1f')
+
+build() {
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    cmake \
+          -GNinja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+          -DBUILD_TESTING=OFF \
+          -DASTCENC_ISA_NATIVE=ON \
+          -DBASISU_SUPPORT_OPENCL=ON \
+          -DKTX_FEATURE_TESTS=OFF \
+          -S "${_realname}-${pkgver}" \
+          -B "build-${MSYSTEM}"
+
+  cmake --build "build-${MSYSTEM}"
+}
+
+package() {
+  cd "${srcdir}"
+
+  DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE.md" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+
+  cp -r "${srcdir}/${_realname}-${pkgver}/LICENSES" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
+}


### PR DESCRIPTION
This pr will add KTX-software, provides many command line tools and a library for building, testing, and viewing KTX (Khronos Texture) format.

Texts below are copied from their [website](https://www.khronos.org/ktx/):
KTX (Khronos Texture) is an efficient, lightweight container format for reliably distributing GPU textures to diverse platforms and applications. The contents of a KTX file can range from a simple base-level 2D texture to a cubemap array texture with mipmaps. KTX files hold all the parameters needed for efficient texture loading into 3D APIs such as OpenGL® and Vulkan®, including access to individual mipmap levels