### PR TITLE
zed: update to 0.171.3

### DIFF
--- a/mingw-w64-zed/.gitignore
+++ b/mingw-w64-zed/.gitignore
@@ -1,1 +1,2 @@
 /zed
+/0e0534831155cd22c1af226fc31f59c52248cb1b.patch

--- a/mingw-w64-zed/PKGBUILD
+++ b/mingw-w64-zed/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=zed
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.170.4
+pkgver=0.171.3
 pkgrel=1
 pkgdesc="A high-performance, multiplayer code editor (mingw-w64)"
 arch=('any')
@@ -43,11 +43,13 @@ source=("git+${msys2_repository_url}.git#tag=v${pkgver}"
         "zstd-sys.tar.gz::https://crates.io/api/v1/crates/zstd-sys/2.0.13+zstd.1.5.6/download"
         "zed-dont-vendor-cargo-about.patch"
         "zed-set-rustflags.patch"
+        "https://github.com/zed-industries/zed/commit/0e0534831155cd22c1af226fc31f59c52248cb1b.patch"
         "zstd-sys-remove-statik.patch")
-sha256sums=('75d941ef0b6c4b60fd2bfbc62987fa27a14d263a79f3e20613f7e5cbab3a831b'
+sha256sums=('a41bf9a5fc794ea7959afd425f62f6e321387628adef8efc72bbc121f97cd278'
             '38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa'
             'b126b7a9e3cc8d3d68c49dbfc184d54691b10172dbfd3272d4c2f43424cfca5b'
-            '9a566344d0dddeffffda7d57c0798592193f24744997927c28207968a16ff101'
+            '86bad9a2bb0356bdd820a6ac73ec3f736f784b4d487af9a8f6bdc0c3e5b309d1'
+            '4ea7341ba0af09d225c888beeb77e2ed30fe2ac162e1800584a95eb074a0499d'
             '48f4900ceb02d3aaf9a1020f33d56629156e96759f456c0e7ca18bfcf910767b')
 
 prepare() {
@@ -57,10 +59,14 @@ prepare() {
 
   # https://github.com/zed-industries/zed/pull/22876
   git cherry-pick -n d1be419fff415329b38f26aff90488700702c82a
+  # remove collab support to avoid wevrtc compilation
+  # https://github.com/zed-industries/zed/pull/23518
+  patch -Np1 -i "../0e0534831155cd22c1af226fc31f59c52248cb1b.patch"
   # use system cargo about to generate license file
   patch -Np1 -i "../zed-dont-vendor-cargo-about.patch"
   # apply `-Cforce-frame-pointers=yes` in .cargo/config.toml instead of env var to apply other
-  # compilation flags
+  # compilation flags; remove +crt-static which is added for webrtc; use lld linker to fix keyboard
+  # shortcuts https://github.com/msys2/MINGW-packages/issues/22071
   patch -Np1 -i "../zed-set-rustflags.patch"
   # link system deps dynamically
   patch -d "../zstd-sys-2.0.13+zstd.1.5.6" -i "../zstd-sys-remove-statik.patch"
@@ -96,8 +102,7 @@ build() {
   export ZED_UPDATE_EXPLANATION='Updates are handled by pacman'
   export CARGO_PROFILE_RELEASE_DEBUG=0
   export RELEASE_VERSION="${pkgver} (Rev${pkgrel}, Built by MSYS2 project)"
-  # apply RUSTFLAGS from .cargo/config.toml instead of env var. use lld linker to fix keyboard
-  # shortcuts https://github.com/msys2/MINGW-packages/issues/22071
+  # apply RUSTFLAGS from .cargo/config.toml instead of env var
   unset RUSTFLAGS
 
   cargo build --release --frozen -p zed

--- a/mingw-w64-zed/zed-set-rustflags.patch
+++ b/mingw-w64-zed/zed-set-rustflags.patch
@@ -1,3 +1,5 @@
+diff --git a/.cargo/config.toml b/.cargo/config.toml
+index 07cbc23195..fcc5fd7b3d 100644
 --- a/.cargo/config.toml
 +++ b/.cargo/config.toml
 @@ -1,6 +1,6 @@
@@ -8,3 +10,10 @@
  
  [alias]
  xtask = "run --package xtask --"
+@@ -23,6 +23,4 @@ rustflags = ["-C", "link-args=-Objc -all_load"]
+ rustflags = [
+     "--cfg",
+     "windows_slim_errors",        # This cfg will reduce the size of `windows::core::Error` from 16 bytes to 4 bytes
+-    "-C",
+-    "target-feature=+crt-static", # This fixes the linking issue when compiling livekit on Windows
+ ]


### PR DESCRIPTION
- zed-set-rustflags.patch: update to remove `+crt-static`
- add a backport to remove collab support for non-MSVC targets (it requires webrtc, hoping we'll get it working soon)