### PR TITLE
dwarfstack: Enable aarch64 builds

### DIFF
--- a/mingw-w64-dwarfstack/001-aarch64-stack.patch
+++ b/mingw-w64-dwarfstack/001-aarch64-stack.patch
@@ -1,0 +1,17 @@
+diff -bur dwarfstack-2.2-orig/src/dwst-exception.c dwarfstack-2.2/src/dwst-exception.c
+--- dwarfstack-2.2-orig/src/dwst-exception.c	2025-01-31 20:35:01.142760700 -0700
++++ dwarfstack-2.2/src/dwst-exception.c	2025-01-31 20:35:07.981744200 -0700
+@@ -54,7 +54,12 @@
+ // csp ... current stack pointer
+ // cip ... current instruction pointer
+ // cfp ... current frame pointer
+-#ifdef _WIN64
++#if defined(_M_ARM64)
++#define csp Sp
++#define cip Pc
++#define cfp Fp
++#define MACH_TYPE IMAGE_FILE_MACHINE_ARM64
++#elif defined(_WIN64)
+ #define csp Rsp
+ #define cip Rip
+ #define cfp Rbp

--- a/mingw-w64-dwarfstack/002-no-int-conversion.patch
+++ b/mingw-w64-dwarfstack/002-no-int-conversion.patch
@@ -1,0 +1,12 @@
+diff -burr dwarfstack-2.2-orig/Makefile dwarfstack-2.2/Makefile
+--- dwarfstack-2.2-orig/Makefile	2025-01-31 20:48:07.493309900 -0700
++++ dwarfstack-2.2/Makefile	2025-01-31 20:48:10.773219000 -0700
+@@ -10,7 +10,7 @@
+ OPT = -O3
+ FRAME_POINTER = -fno-omit-frame-pointer -fno-optimize-sibling-calls
+ INCLUDE = -I$(SRC_DIR)libdwarf -I$(SRC_DIR)mgwhelp -I$(SRC_DIR)include
+-WARN = -Wall -Wextra -Wno-implicit-fallthrough
++WARN = -Wall -Wextra -Wno-implicit-fallthrough -Wno-int-conversion
+ CFLAGS = $(CPPFLAGS) $(OPT) $(WARN) $(FRAME_POINTER) $(INCLUDE)
+ CFLAGS_STATIC = $(CFLAGS) -DDWST_STATIC
+ CFLAGS_SHARED = $(CFLAGS) -DDWST_SHARED

--- a/mingw-w64-dwarfstack/PKGBUILD
+++ b/mingw-w64-dwarfstack/PKGBUILD
@@ -4,16 +4,33 @@ _realname=dwarfstack
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Provides stacktrace with source file/line information (mingw-w64)"
 arch=('any')
-mingw_arch=( 'mingw64' 'ucrt64' 'clang64')
+mingw_arch=( 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://github.com/ssbssa/dwarfstack"
 license=('spdx:LGPL-2.1-or-later')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
-source=("https://github.com/ssbssa/${_realname}/archive/${pkgver}/${_realname}-${pkgver}.tar.gz.tar.gz")
-sha256sums=('1fca1d12756941c4c932b50f9abe56a3756f012a1e93deef553e141a78cc2709')
+source=("https://github.com/ssbssa/${_realname}/archive/${pkgver}/${_realname}-${pkgver}.tar.gz.tar.gz"
+        "001-aarch64-stack.patch")
+sha256sums=('1fca1d12756941c4c932b50f9abe56a3756f012a1e93deef553e141a78cc2709'
+            '424eddaf3bd3dbf68a923592f58ffe7224e4a7e3245be1e2a76bad74326c39c9')
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying ${_patch}"
+    patch -Nbp1 --binary -i "${srcdir}/${_patch}"
+  done
+}
+
+prepare() {
+  cd ${_realname}-${pkgver}
+
+  apply_patch_with_msg \
+    001-aarch64-stack.patch
+}
 
 build() {
   cp -r "${srcdir}/${_realname}-${pkgver}" "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"

--- a/mingw-w64-dwarfstack/PKGBUILD
+++ b/mingw-w64-dwarfstack/PKGBUILD
@@ -13,9 +13,11 @@ license=('spdx:LGPL-2.1-or-later')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
 source=("https://github.com/ssbssa/${_realname}/archive/${pkgver}/${_realname}-${pkgver}.tar.gz.tar.gz"
-        "001-aarch64-stack.patch")
+        "001-aarch64-stack.patch"
+        "002-no-int-conversion.patch")
 sha256sums=('1fca1d12756941c4c932b50f9abe56a3756f012a1e93deef553e141a78cc2709'
-            '424eddaf3bd3dbf68a923592f58ffe7224e4a7e3245be1e2a76bad74326c39c9')
+            '424eddaf3bd3dbf68a923592f58ffe7224e4a7e3245be1e2a76bad74326c39c9'
+            'c8a22b5d7e5e290f745d292518e85d0b2b3b484c4d011aaaf1faf97291b83883')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -29,7 +31,8 @@ prepare() {
   cd ${_realname}-${pkgver}
 
   apply_patch_with_msg \
-    001-aarch64-stack.patch
+    001-aarch64-stack.patch \
+    002-no-int-conversion.patch
 }
 
 build() {


### PR DESCRIPTION
```
Hernan@SURFACE7 CLANGARM64 
$ ./exception.exe
application crashed
code: 0xC0000005 (ACCESS_VIOLATION)
write access violation at 0x0000000000001234
base address: 0x00007FF6DB1C0000 (exception.exe)
    stack 00: 0x00007FF6DB1C1BB0 (crasher.c:10:6) [crasher]
    stack 01: 0x00007FF6DB1C146F (exception.c:117:3) [c]
    stack 02: 0x00007FF6DB1C1483 (exception.c:122:3) [b]
    stack 03: 0x00007FF6DB1C1497 (exception.c:127:3) [a]
    stack 04: 0x00007FF6DB1C14CF (exception.c:134:3) [main]
    stack 05: 0x00007FF6DB1C13CF (crtexe.c:266:15) [__tmainCRTStartup]
Segmentation fault
```