### PR TITLE
binutils: Update to 2.44

### DIFF
--- a/mingw-w64-binutils/0110-binutils-mingw-gnu-print.patch
+++ b/mingw-w64-binutils/0110-binutils-mingw-gnu-print.patch
@@ -51,32 +51,6 @@ index 14a768f8889..b1f056f115a 100644
  
  #else /* __GNUC__ < 2 || defined(VMS) */
  
-diff --git a/gold/configure b/gold/configure
-index b9f062b68eb..fde982191c5 100755
---- a/gold/configure
-+++ b/gold/configure
-@@ -10204,7 +10204,7 @@ else
- /* end confdefs.h.  */
- 
- template<typename T> extern void foo(const char*, ...)
--  __attribute__ ((__format__ (__printf__, 1, 2)));
-+  __attribute__ ((__format__ (gnu_printf, 1, 2)));
- template<typename T> void foo(const char* format, ...) {}
- void bar() { foo<int>("%s\n", "foo"); }
- 
-diff --git a/gold/configure.ac b/gold/configure.ac
-index 1716a779416..cae29866f38 100644
---- a/gold/configure.ac
-+++ b/gold/configure.ac
-@@ -679,7 +679,7 @@ AC_CACHE_CHECK([whether we can use attributes with template functions],
- [gold_cv_template_attribute],
- [AC_COMPILE_IFELSE([AC_LANG_SOURCE([
- template<typename T> extern void foo(const char*, ...)
--  __attribute__ ((__format__ (__printf__, 1, 2)));
-+  __attribute__ ((__format__ (gnu_printf, 1, 2)));
- template<typename T> void foo(const char* format, ...) {}
- void bar() { foo<int>("%s\n", "foo"); }
- ])], [gold_cv_template_attribute=yes], [gold_cv_template_attribute=no])])
 diff --git a/include/ansidecl.h b/include/ansidecl.h
 index 0515228f325..7c2b9f18306 100644
 --- a/include/ansidecl.h

--- a/mingw-w64-binutils/2001-ld-option-to-move-default-bases-under-4GB.patch
+++ b/mingw-w64-binutils/2001-ld-option-to-move-default-bases-under-4GB.patch
@@ -42,14 +42,14 @@ index 00c4ea9e15a..439e2eb83d4 100644
  #else
  #undef  NT_EXE_IMAGE_BASE
  #define NT_EXE_IMAGE_BASE \
-@@ -181,6 +189,7 @@ static int support_old_code = 0;
+@@ -181,6 +189,7 @@
  static lang_assignment_statement_type *image_base_statement = 0;
  static unsigned short pe_dll_characteristics = DEFAULT_DLL_CHARACTERISTICS;
  static bool insert_timestamp = true;
 +static bool high_default_bases = true;
+ static bool orphan_init_done;
  static const char *emit_build_id;
  #ifdef PDB_H
- static int pdb;
 @@ -334,6 +343,10 @@ gld${EMULATION_NAME}_add_options
      {"disable-no-bind", no_argument, NULL, OPTION_DISABLE_NO_BIND},
      {"disable-wdmdriver", no_argument, NULL, OPTION_DISABLE_WDM_DRIVER},

--- a/mingw-w64-binutils/PKGBUILD
+++ b/mingw-w64-binutils/PKGBUILD
@@ -5,7 +5,7 @@
 _realname=binutils
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.43.1
+pkgver=2.44
 pkgrel=1
 pkgdesc="A set of programs to assemble and manipulate binary and object files (mingw-w64)"
 arch=('any')
@@ -33,12 +33,12 @@ source=(https://ftp.gnu.org/gnu/binutils/${_realname}-${pkgver}.tar.bz2{,.sig}
         libiberty-unlink-handle-windows-nul.patch
         3001-hack-libiberty-link-order.patch
 )
-sha256sums=('becaac5d295e037587b63a42fad57fe3d9d7b83f478eb24b67f9eec5d0f1872f'
+sha256sums=('f66390a661faa117d00fab2e79cf2dc9d097b42cc296bf3f8677d1e7b452dc3a'
             'SKIP'
             '2c99345fc575c3a060d6677537f636c6c4154fac0fde508070f3b6296c1060d4'
             '4e8ac055df61b1b5d6ae29dc87e1154737c2e87c7b244b44866702cabf1a5d18'
-            '5f3fc3949172d2d6e7cd595f9359077e012391a8c3c2aebc02e30fa656ded833'
-            '0b6e1b4c72aa0af0627a75df2bd85774e21a8528deb684c0403c57ece1746199'
+            '79eab27a3b0aeaddcdac49c93b5e3ee1bfac7e9782fc4d17d64061a52362e76a'
+            '9945635f4a67712616202f09cbb66cf70df01be168c2c8054c455bb58bf334dd'
             'd584f1cd9e94cba0e9b27625c4acc8ad5242cd625c9b44839d42fc116072568c'
             'a094660ec95996c00b598429843b7869037732146442af567ada9f539bd40480'
             '7ccbd418695733c50966068fa9755a6abb156f53af23701d2bc097c63e9e0030'


### PR DESCRIPTION
* 0110-binutils-mingw-gnu-print.patch: gold was removed, so remove gold hunks
* 2001-ld-option-to-move-default-bases-under-4GB.patch: refresh