### PR TITLE
lapack: update to 3.12.1

### DIFF
--- a/mingw-w64-lapack/PKGBUILD
+++ b/mingw-w64-lapack/PKGBUILD
@@ -10,7 +10,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-blas64"
          "${MINGW_PACKAGE_PREFIX}-cblas64"
          "${MINGW_PACKAGE_PREFIX}-lapacke64")
-pkgver=3.12.0
+pkgver=3.12.1
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -26,8 +26,31 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-fc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
-source=(https://github.com/Reference-LAPACK/lapack/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz)
-sha256sums=('eac9570f8e0ad6f30ce4b963f4f033f0f643e7c3912fc9ee6cd99120675ad48b')
+source=(https://github.com/Reference-LAPACK/lapack/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz
+        0001-sized-init-with-integer-8.patch::https://patch-diff.githubusercontent.com/raw/Reference-LAPACK/lapack/pull/1094.patch
+        0002-type-mismatch-with-integer-8.patch::https://github.com/Reference-LAPACK/lapack/commit/0799b59571a4bbb434c62ef2346146123aa19d8d.patch
+        0003-line-reflow-with-integer-8.patch::https://github.com/Reference-LAPACK/lapack/pull/1099.patch)
+sha256sums=('2ca6407a001a474d4d4d35f3a61550156050c48016d949f0da0529c0aa052422'
+            '658a558b012101089322e3af8246568e635776eebcdb588803af7f245f676513'
+            '1cd1328111c562c635bcc5d69b1088f763825674445c2c011f02fd4846665dcd'
+            'dce6370e0f4d1d8c4cbac4c8c50e87e3f6f7ab3d62903760b6abc1aa8158e221')
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Np1 -i "${srcdir}/$_patch"
+  done
+}
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+
+  apply_patch_with_msg \
+    0001-sized-init-with-integer-8.patch \
+    0002-type-mismatch-with-integer-8.patch \
+    0003-line-reflow-with-integer-8.patch
+}
 
 build() {
   declare -a _extra_config


### PR DESCRIPTION
Cherry-pick some patches from upstream to support building with `-integer-8` (i.e., the 64-bit integer variants of the libraries).