### PR TITLE
SoapyHackRF: Fix package name typo

### DIFF
--- a/mingw-w64-soapyhackrf/PKGBUILD
+++ b/mingw-w64-soapyhackrf/PKGBUILD
@@ -1,4 +1,4 @@
-_realname=soapyrhackrf
+_realname=soapyhackrf
 _pkgname=SoapyHackRF
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"


### PR DESCRIPTION
I am really sorry about this...

Last time, an "r" made it into the wrong place...