### PR TITLE
aria2: fix build with new gettext

### DIFF
--- a/mingw-w64-aria2/0001-less-strict-gettext-checks.patch
+++ b/mingw-w64-aria2/0001-less-strict-gettext-checks.patch
@@ -1,0 +1,11 @@
+--- aria2-1.37.0/configure.ac.orig	2023-11-15 10:49:41.000000000 +0100
++++ aria2-1.37.0/configure.ac	2025-02-09 20:32:40.120585500 +0100
+@@ -737,7 +737,7 @@
+ 
+ # Checks for library functions.
+ AM_GNU_GETTEXT([external])
+-AM_GNU_GETTEXT_VERSION([0.18])
++AM_GNU_GETTEXT_REQUIRE_VERSION([0.18])
+ AC_FUNC_ERROR_AT_LINE
+ AC_PROG_GCC_TRADITIONAL
+ 

--- a/mingw-w64-aria2/PKGBUILD
+++ b/mingw-w64-aria2/PKGBUILD
@@ -4,7 +4,7 @@ _realname=aria2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.37.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A multi-protocol & multi-source, cross platform download utility (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -30,12 +30,17 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-pkgconf")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-cppunit")
 optdepends=("${MINGW_PACKAGE_PREFIX}-ruby: aria2rpc and aria2mon")
-source=("https://github.com/aria2/aria2/releases/download/release-${pkgver}/aria2-${pkgver}.tar.xz")
-sha256sums=('60a420ad7085eb616cb6e2bdf0a7206d68ff3d37fb5a956dc44242eb2f79b66b')
+source=("https://github.com/aria2/aria2/releases/download/release-${pkgver}/aria2-${pkgver}.tar.xz"
+        "0001-less-strict-gettext-checks.patch")
+sha256sums=('60a420ad7085eb616cb6e2bdf0a7206d68ff3d37fb5a956dc44242eb2f79b66b'
+            'f2b27d92c6976ad20cc7a43aaa75576911a2fa5291dbb360cd5fd01d3114ad25')
 
 prepare() {
   cd "${_realname}-${pkgver}"
-  autoreconf -ifv || autoreconf -ifv
+
+  patch -Np1 -i ../0001-less-strict-gettext-checks.patch
+
+  autoreconf -ifv
 }
 
 build() {


### PR DESCRIPTION
It would fail with this otherwise:

error: gettext infrastructure mismatch: using a Makefile.in.in from gettext version 0.18 but the autoconf macros are from gettext version 0.22