### PR TITLE
Groonga: Update to 15.0.0

### DIFF
--- a/mingw-w64-groonga/PKGBUILD
+++ b/mingw-w64-groonga/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=groonga
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=14.1.3
+pkgver=15.0.0
 pkgrel=1
 pkgdesc="An opensource fulltext search engine (mingw-w64)"
 arch=('any')
@@ -28,7 +28,7 @@ makedepends=("git"
              "${MINGW_PACKAGE_PREFIX}-rapidjson"
              "${MINGW_PACKAGE_PREFIX}-ruby"
              "${MINGW_PACKAGE_PREFIX}-xsimd")
-sha256sums=('d0e84232cec53209e3b2d1952471aa75d3b8b9c59a68632043d4657e10cd65d9'
+sha256sums=('e4450fa797aebadf8d282cfd5b325e3baefe6b51874fdd743aff32815d62c1ff'
             'SKIP')
 validpgpkeys=('2701F317CFCCCB975CADE9C2624CF77434839225') # Groonga Key <packages@groonga.org>
 


### PR DESCRIPTION
Groonga version15.0.0 has just released [here](https://github.com/groonga/groonga/releases/tag/v15.0.0).