### PR TITLE
crystal: Support non-bootstrapped builds

### DIFF
--- a/mingw-w64-crystal/PKGBUILD
+++ b/mingw-w64-crystal/PKGBUILD
@@ -1,10 +1,11 @@
 # Maintainer: Quinton Miller <nicetas.c@gmail.com>
 
+_bootstrap=0
 _realname=crystal
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.15.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Fast and statically typed, compiled language with Ruby-like syntax (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'mingw64' 'clang64')
@@ -31,16 +32,19 @@ depends=(
 )
 makedepends=(
   "git"
+  $( (( !_bootstrap )) && echo "${MINGW_PACKAGE_PREFIX}-crystal")
 )
 checkdepends=(
   "${MINGW_PACKAGE_PREFIX}-lld" # needed for linking std_spec
 )
 source=(
   "$pkgname-$pkgver::git+${msys2_repository_url}.git#tag=${pkgver}"
-  https://github.com/crystal-lang/crystal/releases/download/1.15.0/crystal-1.15.0-windows-x86_64-gnu-unsupported.zip # stage 0 compiler
+  $( (( _bootstrap )) && echo "https://github.com/crystal-lang/crystal/releases/download/1.15.0/crystal-1.15.0-windows-x86_64-gnu-unsupported.zip" ) # stage 0 compiler
 )
-sha256sums=('626fed60399d7f1dc83e2e5a2ecde20d235e19a3dcf6d70d6f52ec4de063b32b'
-            '7d7df1b4a99cb3f938106ba45e0b55ce1d9913491999f1acaa57da168a18becb')
+sha256sums=(
+  '626fed60399d7f1dc83e2e5a2ecde20d235e19a3dcf6d70d6f52ec4de063b32b'
+  $( (( _bootstrap )) && echo '7d7df1b4a99cb3f938106ba45e0b55ce1d9913491999f1acaa57da168a18becb' )
+)
 
 prepare() {
   cd "$pkgname-$pkgver"
@@ -53,7 +57,12 @@ prepare() {
 
 build() {
   cd "$pkgname-$pkgver"
-  CRYSTAL="$srcdir/bin/crystal.exe" make interpreter=1 release=1
+  if (( _bootstrap ))
+  then
+    CRYSTAL="$srcdir/bin/crystal.exe" make interpreter=1 release=1
+  else
+    make interpreter=1 release=1
+  fi
 }
 
 check() {


### PR DESCRIPTION
The bootstrap will be back again when we have a stage 0 compiler for ARM64 Windows.