### PR TITLE
gmsh: avoid issue with FLTK 1.4

### DIFF
--- a/mingw-w64-gmsh/PKGBUILD
+++ b/mingw-w64-gmsh/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gmsh
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.13.1
-pkgrel=3
+pkgrel=4
 pkgdesc="3D finite element mesh generator with built-in CAD engine and post-processor (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -28,10 +28,12 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 source=(https://gmsh.info/src/gmsh-${pkgver}-source.tgz
         0001-fix-link-lib-name.patch
-        0002-fix-dynamic-linking.patch)
+        0002-fix-dynamic-linking.patch
+        0003-fltk-1.4.patch::https://gitlab.onelab.info/gmsh/gmsh/-/commit/3b3f0f7e16430939b345889a9e31b50104d5baf3.patch)
 sha256sums=('77972145f431726026d50596a6a44fb3c1c95c21255218d66955806b86edbe8d'
             'e575ae8fc757694affb6749dc9d52c336691b06159845655ef2ac27aebae8159'
-            '4d3f5c4190529e3d45b786adab83f0d65e726357d7367f682ff95b733a88a8c3')
+            '4d3f5c4190529e3d45b786adab83f0d65e726357d7367f682ff95b733a88a8c3'
+            'f06d4ce2d45b640531d4556fb3fa41741903a4b27a2f28b1d3a1a82be77a42d0')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -46,7 +48,8 @@ prepare() {
 
   apply_patch_with_msg \
     0001-fix-link-lib-name.patch \
-    0002-fix-dynamic-linking.patch
+    0002-fix-dynamic-linking.patch \
+    0003-fltk-1.4.patch
 }
 
 build() {


### PR DESCRIPTION
Cherry-pick patch from upstream.

Fixes #23374.