### PR TITLE
python: fix python-config output path format

### DIFF
--- a/mingw-w64-python/0122-fixup-add-python-config-sh.patch
+++ b/mingw-w64-python/0122-fixup-add-python-config-sh.patch
@@ -1,0 +1,25 @@
+From 1b241aa8572ee8cd4131fffca838b6bbdf5a7b5e Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Wed, 12 Feb 2025 22:29:34 +0100
+Subject: [PATCH 122/N] fixup! add python config sh
+
+OSTYPE has changed in MSYS2, so check for both the old and
+the new value:
+https://github.com/msys2/MSYS2-packages/commit/076c4a94a618413c8b22bed40ee13649434f5145
+---
+ Misc/python-config.sh.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Misc/python-config.sh.in b/Misc/python-config.sh.in
+index e0e048a..195c317 100644
+--- a/Misc/python-config.sh.in
++++ b/Misc/python-config.sh.in
+@@ -30,7 +30,7 @@ installed_prefix ()
+     # Since we don't know where the output from this script will end up
+     # we keep all paths in Windows-land since MSYS2 can handle that
+     # while native tools can't handle paths in MSYS2-land.
+-    if [ "$OSTYPE" = "msys" ]; then
++    if [ "$OSTYPE" = "cygwin" ] || [ "$OSTYPE" = "msys" ] ; then
+         RESULT=$(cd "$RESULT" && pwd -W)
+     fi
+     echo $RESULT

--- a/mingw-w64-python/PKGBUILD
+++ b/mingw-w64-python/PKGBUILD
@@ -23,7 +23,7 @@ else
   pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}${_pybasever}")
 fi
 pkgver=${_pybasever}.9
-pkgrel=1
+pkgrel=2
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -175,7 +175,8 @@ source=("https://www.python.org/ftp/python/${pkgver%rc?}/Python-${pkgver}.tar.xz
         0118-socketmodule-fix-captilization-of-headers.patch
         0119-mingw_smoketests-build-extension-in-a-venv.patch
         0120-venvlauncher-try-looking-for-the-versioned-.exe-firs.patch
-        0121-CI-update-actions.patch)
+        0121-CI-update-actions.patch
+        0122-fixup-add-python-config-sh.patch)
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -309,7 +310,8 @@ prepare() {
   0118-socketmodule-fix-captilization-of-headers.patch \
   0119-mingw_smoketests-build-extension-in-a-venv.patch \
   0120-venvlauncher-try-looking-for-the-versioned-.exe-firs.patch \
-  0121-CI-update-actions.patch
+  0121-CI-update-actions.patch \
+  0122-fixup-add-python-config-sh.patch
  
   autoreconf -vfi
 }
@@ -543,4 +545,5 @@ sha256sums=('7220835d9f90b37c006e9842a8dff4580aaca4318674f947302b8d28f3f81112'
             '4ea41cb0660086b6b86aee3f4524351a3044fc40018648762ffae03b3ac4bd3d'
             'c264420d7a52353cbe170b17d5e06edc2d631bf5e0d345bbf2c60933fba92332'
             '182599440e7c5d71142d130e371c092eb5d99c8831ba298546faa83b6166d32e'
-            'a75463d32bb82bbe45b425ec6d60d0ed2db3ab63b1c2c211ada79ecb53c61792')
+            'a75463d32bb82bbe45b425ec6d60d0ed2db3ab63b1c2c211ada79ecb53c61792'
+            '66eca4fc8ca80fbe3510be4a7c9e460aaf01f6374dedfc7a13b993f8b73d36b3')


### PR DESCRIPTION
Since https://github.com/msys2/MSYS2-packages/commit/076c4a94a618413c8b22bed40ee13649434f5145 python-config would output cygwin paths instead of Windows paths since OSTYPE has changed.

This adjusts python-config to check for the new value.