### PR TITLE
Populate msys2_repository_url

### DIFF
--- a/mingw-w64-cppdap/PKGBUILD
+++ b/mingw-w64-cppdap/PKGBUILD
@@ -13,6 +13,7 @@ pkgdesc="C++ library for the Debug Adapter Protocol (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://github.com/google/cppdap'
+msys2_repository_url=${url}
 license=('spdx:Apache-2.0')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
@@ -20,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-jsoncpp"
              "git")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
-source=("${_realname}"::"git+https://github.com/google/cppdap.git#commit=${_commit}")
+source=("${_realname}"::"git+${msys2_repository_url}.git#commit=${_commit}")
 sha256sums=('3984fe87c3895b36db7bd2677602aed172f4587e517b38429efa53de7d47a303')
 
 build() {

--- a/mingw-w64-fribidi/PKGBUILD
+++ b/mingw-w64-fribidi/PKGBUILD
@@ -9,7 +9,8 @@ pkgdesc="A Free Implementation of the Unicode Bidirectional Algorithm (mingw-w64
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 license=('spdx:LGPL-2.1-or-later')
-url="https://github.com/fribidi/fribidi/"
+url="https://github.com/fribidi/fribidi"
+msys2_repository_url=${url}
 msys2_references=(
   "cpe: cpe:/a:gnu:fribidi"
 )
@@ -18,7 +19,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-cc")
-source=("https://github.com/fribidi/fribidi/releases/download/v${pkgver}/fribidi-${pkgver}.tar.xz")
+source=("${msys2_repository_url}/releases/download/v${pkgver}/fribidi-${pkgver}.tar.xz")
 sha256sums=('1b1cde5b235d40479e91be2f0e88a309e3214c8ab470ec8a2744d82a5a9ea05c')
 
 build() {

--- a/mingw-w64-gdk-pixbuf2/PKGBUILD
+++ b/mingw-w64-gdk-pixbuf2/PKGBUILD
@@ -12,6 +12,7 @@ pkgdesc="An image loading library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://gitlab.gnome.org/GNOME/gdk-pixbuf"
+msys2_repository_url=${url}
 msys2_references=(
   "cpe: cpe:/a:gnome:gdk-pixbuf"
   "cpe: cpe:/a:gnome:gdkpixbuf"

--- a/mingw-w64-giflib/PKGBUILD
+++ b/mingw-w64-giflib/PKGBUILD
@@ -9,6 +9,7 @@ pkgdesc="A library for reading and writing gif images (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://sourceforge.net/projects/giflib"
+msys2_repository_url=${url}
 msys2_references=(
   "cpe: cpe:/a:giflib_project:giflib"
 )

--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -12,6 +12,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.82.4
 pkgrel=1
 url="https://gitlab.gnome.org/GNOME/glib"
+msys2_repository_url=${url}
 msys2_references=(
   "cpe: cpe:/a:gnome:glib"
 )

--- a/mingw-w64-graphite2/PKGBUILD
+++ b/mingw-w64-graphite2/PKGBUILD
@@ -13,12 +13,13 @@ msys2_references=(
   "cpe: cpe:/a:sil:graphite2"
 )
 url="https://github.com/silnrsi/graphite"
+msys2_repository_url=${url}
 license=('spdx:LGPL-2.1-or-later')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-python"
              "${MINGW_PACKAGE_PREFIX}-cc")
-source=("https://github.com/silnrsi/graphite/releases/download/${pkgver}/${_realname}-${pkgver}.tgz"
+source=("${msys2_repository_url}/releases/download/${pkgver}/${_realname}-${pkgver}.tgz"
         "001-graphite2-1.3.12-win64.patch"
         "002-graphite2-1.2.1-pkgconfig.patch"
         "003-graphite2-1.3.12-staticbuild.patch"

--- a/mingw-w64-highway/PKGBUILD
+++ b/mingw-w64-highway/PKGBUILD
@@ -9,13 +9,14 @@ pkgdesc="C++ library for SIMD (Single Instruction, Multiple Data) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://github.com/google/highway'
+msys2_repository_url=${url}
 license=('spdx:Apache-2.0')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 #checkdepends=("${MINGW_PACKAGE_PREFIX}-gtest")
-source=("https://github.com/google/highway/releases/download/${pkgver}/${_realname}-${pkgver}.tar.gz"{,.asc}
+source=("${msys2_repository_url}/releases/download/${pkgver}/${_realname}-${pkgver}.tar.gz"{,.asc}
         "https://patch-diff.githubusercontent.com/raw/google/highway/pull/2229.patch")
 sha256sums=('58e9d5d41d6573ad15245ad76aec53a69499ca7480c092d899c4424812ed906f'
             'SKIP'

--- a/mingw-w64-http-parser/PKGBUILD
+++ b/mingw-w64-http-parser/PKGBUILD
@@ -11,9 +11,10 @@ pkgdesc="Parser for HTTP Request/Response written in C (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://github.com/nodejs/http-parser'
+msys2_repository_url=${url}
 license=('MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
-source=(${_realname}-${pkgver}.tar.gz::"https://github.com/nodejs/http-parser/archive/v${pkgver}.tar.gz")
+source=(${_realname}-${pkgver}.tar.gz::"${msys2_repository_url}/archive/v${pkgver}.tar.gz")
 sha256sums=('467b9e30fd0979ee301065e70f637d525c28193449e1b13fbcb1b1fab3ad224f')
 
 prepare() {

--- a/mingw-w64-lerc/PKGBUILD
+++ b/mingw-w64-lerc/PKGBUILD
@@ -9,6 +9,7 @@ pkgdesc="Limited Error Raster Compression library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://github.com/Esri/lerc"
+msys2_repository_url=${url}
 license=('spdx:Apache-2.0')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"

--- a/mingw-w64-libbacktrace/PKGBUILD
+++ b/mingw-w64-libbacktrace/PKGBUILD
@@ -9,12 +9,13 @@ pkgdesc="Library to produce symbolic backtraces (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://github.com/ianlancetaylor/libbacktrace"
+msys2_repository_url=${url}
 license=('spdx:BSD-3-Clause')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools"
              'git')
-source=("git+https://github.com/ianlancetaylor/libbacktrace.git#commit=${_commit}"
+source=("git+${msys2_repository_url}.git#commit=${_commit}"
         "0001-libbacktrace-no-undefined.patch"
         "libbacktrace.pc")
 sha256sums=('3c5ebe9ae7a92e2f2e451211ee0c544ac9f035aa28c7195fe36fd9911088abcb'

--- a/mingw-w64-libdeflate/PKGBUILD
+++ b/mingw-w64-libdeflate/PKGBUILD
@@ -9,6 +9,7 @@ pkgdesc="Heavily optimized library for DEFLATE/zlib/gzip compression and decompr
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://github.com/ebiggers/libdeflate'
+msys2_repository_url=${url}
 license=('spdx:MIT')
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cc"

--- a/mingw-w64-libdovi/PKGBUILD
+++ b/mingw-w64-libdovi/PKGBUILD
@@ -10,6 +10,7 @@ pkgdesc='Library to read and write Dolby Vision metadata (C-API)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://github.com/quietvoid/dovi_tool/tree/main/dolby_vision'
+msys2_repository_url='https://github.com/quietvoid/dovi_tool'
 license=('spdx:MIT')
 msys2_references=(
   'archlinux: libdovi'
@@ -17,7 +18,7 @@ msys2_references=(
 )
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-cargo-c")
-source=("https://github.com/quietvoid/dovi_tool/archive/refs/tags/libdovi-${pkgver}.tar.gz")
+source=("${msys2_repository_url}/archive/refs/tags/libdovi-${pkgver}.tar.gz")
 sha256sums=('4cd7a4c418fd8af1da13278ce7524c15b7fdf61e1fe53663aa291c68c5062777')
 
 prepare() {

--- a/mingw-w64-libkqueue/PKGBUILD
+++ b/mingw-w64-libkqueue/PKGBUILD
@@ -9,6 +9,7 @@ pkgdesc="Libkqueue (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://github.com/mheily/libkqueue'
+msys2_repository_url=${url}
 license=('spdx: ISC AND BSD-2-Clause')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=(
@@ -18,7 +19,7 @@ makedepends=(
   'git'
 )
 source=(
-  "git+https://github.com/mheily/libkqueue.git#tag=v${pkgver}"
+  "git+${msys2_repository_url}.git#tag=v${pkgver}"
   0001-libkqueue-cmake-remove-werror.patch
   0002-libkqueue-cmake-fix-static-library-name.patch
   0003-libkqueue-cmake-fix-install-directory.patch

--- a/mingw-w64-liblc3/PKGBUILD
+++ b/mingw-w64-liblc3/PKGBUILD
@@ -9,12 +9,13 @@ pkgdesc="Low Complexity Communication Codec library and tools (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://github.com/google/liblc3'
+msys2_repository_url=${url}
 license=('spdx:Apache-2.0')
 makedepends=("${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-cc")
-source=("https://github.com/google/liblc3/archive/refs/tags/v${pkgver}.tar.gz")
+source=("${msys2_repository_url}/archive/refs/tags/v${pkgver}.tar.gz")
 sha256sums=('276752ff54ce6a77d54ec133397b9d7e71f90caf3d9afa32d8b0e891b8ecb8af')
 
 build() {

--- a/mingw-w64-libraqm/PKGBUILD
+++ b/mingw-w64-libraqm/PKGBUILD
@@ -9,6 +9,7 @@ pkgdesc="A library that encapsulates the logic for complex text layout (mingw-w6
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://github.com/HOST-Oman/libraqm"
+msys2_repository_url=${url}
 depends=("${MINGW_PACKAGE_PREFIX}-freetype"
          "${MINGW_PACKAGE_PREFIX}-harfbuzz"
          "${MINGW_PACKAGE_PREFIX}-fribidi")
@@ -17,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gtk-doc"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-cc")
 license=('spdx:MIT')
-source=("${_realname}-$pkgver".tar.gz::"https://github.com/HOST-Oman/libraqm/archive/v${pkgver}.tar.gz")
+source=("${_realname}-$pkgver".tar.gz::"${msys2_repository_url}/archive/v${pkgver}.tar.gz")
 sha256sums=('db68fd9f034fc40ece103e511ffdf941d69f5e935c48ded8a31590468e42ba72')
 
 build() {

--- a/mingw-w64-libtiff/PKGBUILD
+++ b/mingw-w64-libtiff/PKGBUILD
@@ -11,6 +11,7 @@ pkgdesc="Library for manipulation of TIFF images (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://libtiff.gitlab.io/libtiff/"
+msys2_repository_url="https://gitlab.com/libtiff/libtiff"
 msys2_references=(
   "cpe: cpe:/a:libtiff:libtiff"
   "cpe: cpe:/a:remotesensing:libtiff"

--- a/mingw-w64-libwebp/PKGBUILD
+++ b/mingw-w64-libwebp/PKGBUILD
@@ -10,6 +10,7 @@ pkgdesc="A library to encode and decode images in WebP format (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://developers.google.com/speed/webp/'
+msys2_repository_url="https://github.com/webmproject/libwebp"
 msys2_references=(
   "cpe: cpe:/a:webmproject:libwebp"
 )
@@ -22,7 +23,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 provides=("${MINGW_PACKAGE_PREFIX}-libsharpyuv")
-source=(${_realname}-${pkgver}.tar.gz::https://github.com/webmproject/libwebp/archive/v${pkgver}.tar.gz
+source=(${_realname}-${pkgver}.tar.gz::${msys2_repository_url}/archive/v${pkgver}.tar.gz
         0001-mingw-cmake-output.patch)
 sha256sums=('668c9aba45565e24c27e17f7aaf7060a399f7f31dba6c97a044e1feacb930f37'
             '30ed42b782af427f57049abada30ce6d4d62318ee13014585cb352b570c68e3d')

--- a/mingw-w64-p11-kit/PKGBUILD
+++ b/mingw-w64-p11-kit/PKGBUILD
@@ -11,6 +11,7 @@ pkgdesc="Library to work with PKCS#11 modules (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://p11-glue.freedesktop.org/p11-kit.html"
+msys2_repository_url="https://github.com/p11-glue/p11-kit"
 msys2_references=(
   "cpe: cpe:/a:p11-kit_project:p11-kit"
 )
@@ -25,7 +26,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              #"${MINGW_PACKAGE_PREFIX}-meson"
              #"${MINGW_PACKAGE_PREFIX}-ninja"
              )
-source=(https://github.com/p11-glue/p11-kit/releases/download/${pkgver}/${_realname}-${pkgver}.tar.xz{,.sig}
+source=(${msys2_repository_url}/releases/download/${pkgver}/${_realname}-${pkgver}.tar.xz{,.sig}
         0001-allow-gtkdocize.all.patch
         0002-fix-includes.patch
         0004-fix-abspath-check.all.patch

--- a/mingw-w64-pixman/PKGBUILD
+++ b/mingw-w64-pixman/PKGBUILD
@@ -10,6 +10,7 @@ pkgdesc="The pixel-manipulation library for X and cairo (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://gitlab.freedesktop.org/pixman/pixman"
+msys2_repository_url=${url}
 msys2_references=(
   'cpe: cpe:/a:pixman:pixman'
 )

--- a/mingw-w64-rtmpdump/PKGBUILD
+++ b/mingw-w64-rtmpdump/PKGBUILD
@@ -9,6 +9,7 @@ pkgdesc="A tool to download rtmp streams (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://rtmpdump.mplayerhq.hu/"
+msys2_repository_url="https://git.ffmpeg.org/rtmpdump"
 msys2_references=(
   "cpe: cpe:/a:rtmpdump_project:rtmpdump"
 )
@@ -25,7 +26,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-nettle"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 _commit="f1b83c10d8beb43fcc70a6e88cf4325499f25857"
-source=("$_realname::git+https://git.ffmpeg.org/rtmpdump#commit=${_commit}"
+source=("$_realname::git+${msys2_repository_url}#commit=${_commit}"
         0001-mingw.mingw.patch
         0002-no-fPIC.mingw.patch
         0003-better-w32-threading.all.patch

--- a/mingw-w64-speex/PKGBUILD
+++ b/mingw-w64-speex/PKGBUILD
@@ -10,13 +10,14 @@ arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 license=('BSD')
 url="https://speex.org/"
+msys2_repository_url="https://gitlab.xiph.org/xiph/speex"
 msys2_references=(
   "cpe: cpe:/a:xiph:speex"
 )
 depends=("${MINGW_PACKAGE_PREFIX}-libogg" "${MINGW_PACKAGE_PREFIX}-speexdsp")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools")
-source=("https://gitlab.xiph.org/xiph/speex/-/archive/Speex-${pkgver}/speex-Speex-${pkgver}.tar.gz")
+source=("${msys2_repository_url}/-/archive/Speex-${pkgver}/speex-Speex-${pkgver}.tar.gz")
 sha256sums=('beaf2642e81a822eaade4d9ebf92e1678f301abfc74a29159c4e721ee70fdce0')
 
 prepare() {

--- a/mingw-w64-srt/PKGBUILD
+++ b/mingw-w64-srt/PKGBUILD
@@ -10,6 +10,7 @@ arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 license=('spdx:MPL-2.0')
 url="https://www.srtalliance.org/"
+msys2_repository_url="https://github.com/Haivision/srt"
 msys2_references=(
   "cpe: cpe:/a:srtalliance:secure_reliable_transport"
 )
@@ -20,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-pkgconf")
-source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/Haivision/srt/archive/v${pkgver}.tar.gz"
+source=("${_realname}-${pkgver}.tar.gz"::"${msys2_repository_url}/archive/v${pkgver}.tar.gz"
         0006-no-msvc-compat-headers.patch)
 sha256sums=('d0a8b600fe1b4eaaf6277530e3cfc8f15b8ce4035f16af4a5eb5d4b123640cdd'
             '18af8a55e898b12074e797a212eda5e6f3c935dcc37745eb97a60591e80ab64e')

--- a/mingw-w64-svt-av1/PKGBUILD
+++ b/mingw-w64-svt-av1/PKGBUILD
@@ -9,6 +9,7 @@ pkgdesc="Scalable Video Technology AV1 encoder and decoder (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://gitlab.com/AOMediaCodec/SVT-AV1'
+msys2_repository_url=${url}
 license=('spdx:BSD-3-Clause-Clear')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"


### PR DESCRIPTION
This populates the `msys2_repository_url` property for a couple of packages, helping expose that information in the SBOM which is generated for MSYS2.