### PR TITLE
[new package] fortls-v3.1.2

### DIFF
--- a/mingw-w64-python-fortls/PKGBUILD
+++ b/mingw-w64-python-fortls/PKGBUILD
@@ -16,7 +16,8 @@ msys2_references=(
 )
 license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-python"
-         "${MINGW_PACKAGE_PREFIX}-python-json5")
+         "${MINGW_PACKAGE_PREFIX}-python-json5"
+         "${MINGW_PACKAGE_PREFIX}-python-packaging")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
              "${MINGW_PACKAGE_PREFIX}-python-wheel"

--- a/mingw-w64-python-fortls/PKGBUILD
+++ b/mingw-w64-python-fortls/PKGBUILD
@@ -1,0 +1,39 @@
+# Maintainer: ZUO Zhihua (zuo.zhihua@qq.com)
+
+_pyname=fortls
+_realname=${_pyname}
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=3.1.2
+pkgrel=1
+pkgdesc="A modern Language Server for Fortran. (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url="https://github.com/fortran-lang/fortls"
+msys2_references=(
+  'pypi: fortls'
+  'aur: fortls'
+)
+license=('spdx:MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-json5")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-wheel"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm")
+options=(!strip)
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('93ea78598492ac699f7cefb624e89bf5012d44604d07fbe5ad4a31e32fc977bc')
+
+build() {
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "${srcdir}"/python-build-${MSYSTEM}
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+}


### PR DESCRIPTION
[`fortls`](https://github.com/fortran-lang/fortls) is a Language Server for Fortran that provides code completion, diagnostics, hovering, and more.
This package is also available in the AUR repository. For details, see its [PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=fortls) in the AUR repository.