### PR TITLE
python-geoalchemy2: support spatialite databases

### DIFF
--- a/mingw-w64-python-geoalchemy2/0001-geoalchemy2-0.17.1-search-spatialite.patch
+++ b/mingw-w64-python-geoalchemy2/0001-geoalchemy2-0.17.1-search-spatialite.patch
@@ -1,0 +1,27 @@
+diff -Naur geoalchemy2-0.17.1.orig/geoalchemy2/admin/dialects/sqlite.py geoalchemy2-0.17.1/geoalchemy2/admin/dialects/sqlite.py
+--- geoalchemy2-0.17.1.orig/geoalchemy2/admin/dialects/sqlite.py	2025-02-19 18:15:51.981848600 +0300
++++ geoalchemy2-0.17.1/geoalchemy2/admin/dialects/sqlite.py	2025-02-19 18:25:01.252520600 +0300
+@@ -1,6 +1,8 @@
+ """This module defines specific functions for SQLite dialect."""
+ 
+ import os
++import sys
++import pathlib
+ from typing import Optional
+ 
+ from sqlalchemy import text
+@@ -30,7 +32,13 @@
+         dbapi_conn: The DBAPI connection.
+     """
+     if "SPATIALITE_LIBRARY_PATH" not in os.environ:
+-        raise RuntimeError("The SPATIALITE_LIBRARY_PATH environment variable is not set.")
++        mod_path = None
++        if os.name == "nt":
++            mod_path = pathlib.Path(sys.executable).parent.joinpath('mod_spatialite.dll')
++        if mod_path and mod_path.exists():
++            os.environ["SPATIALITE_LIBRARY_PATH"] = str(mod_path.absolute())
++        else:
++            raise RuntimeError("The SPATIALITE_LIBRARY_PATH environment variable is not set.")
+     dbapi_conn.enable_load_extension(True)
+     dbapi_conn.load_extension(os.environ["SPATIALITE_LIBRARY_PATH"])
+     dbapi_conn.enable_load_extension(False)

--- a/mingw-w64-python-geoalchemy2/PKGBUILD
+++ b/mingw-w64-python-geoalchemy2/PKGBUILD
@@ -4,7 +4,7 @@ _realname=geoalchemy2
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=0.17.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Geospatial extension to SQLAlchemy (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -15,16 +15,21 @@ depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-packaging"
          "${MINGW_PACKAGE_PREFIX}-python-shapely"
          "${MINGW_PACKAGE_PREFIX}-python-sqlalchemy")
+optdepends=("${MINGW_PACKAGE_PREFIX}-libspatialite: support for SpatiaLite databases")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm")
 options=('!strip')
-source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('ff5bbe0db5a4ff979f321c8aa1a7556f444ea30cda5146189b1a177ae5bec69d')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
+        '0001-geoalchemy2-0.17.1-search-spatialite.patch');
+sha256sums=('ff5bbe0db5a4ff979f321c8aa1a7556f444ea30cda5146189b1a177ae5bec69d'
+            '13d320aef21f0ea56d6b6d70fc11c22c75e3fbb28e0ecc95da8805dae5ff4bec')
 
 prepare() {
   cd "${_realname}-${pkgver}"
+
+  patch -p1 -i "${srcdir}"/0001-geoalchemy2-0.17.1-search-spatialite.patch
 
   # Set version for setuptools_scm
   export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}


### PR DESCRIPTION
Patch for auto resolve path to spatialite module (currently [path should be set manually](https://geoalchemy-2.readthedocs.io/en/latest/spatialite_dialect.html)).

I suggest checking the patch here, then suggest it to the upstream repository.