### PR TITLE
pcre2: Update to 10.45

### DIFF
--- a/mingw-w64-pcre2/PKGBUILD
+++ b/mingw-w64-pcre2/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=pcre2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=10.44
-pkgrel=2
+pkgver=10.45
+pkgrel=1
 pkgdesc="A library that implements Perl 5-style regular expressions (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -21,9 +21,9 @@ depends=("${MINGW_PACKAGE_PREFIX}-bzip2"
          "${MINGW_PACKAGE_PREFIX}-wineditline"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 source=(https://github.com/PhilipHazel/pcre2/releases/download/${_realname}-${pkgver}/${_realname}-${pkgver}.tar.bz2{,.sig})
-sha256sums=('d34f02e113cf7193a1ebf2770d3ac527088d485d4e047ed10e5d217c6ef5de96'
+sha256sums=('21547f3516120c75597e5b30a992e27a592a31950b5140e7b8bfde3f192033c4'
             'SKIP')
-validpgpkeys=('45F68D54BBE23FB3039B46E59766E084FB0F43D8') # Philip Hazel <Philip.Hazel@gmail.com>
+validpgpkeys=('A95536204A3BB489715231282A98E77EB6F24CA8') # Nicholas Wilson <nicholas@nicholaswilson.me.uk>
 
 build() {
   local -a _common_config=(
@@ -83,5 +83,5 @@ package() {
   cd "${pkgdir}${MINGW_PREFIX}/share"
   mkdir -p licenses/${_realname}
   mv doc/${_realname}/COPYING licenses/${_realname}
-  mv doc/${_realname}/LICENCE licenses/${_realname}
+  mv doc/${_realname}/LICENCE.md licenses/${_realname}
 }


### PR DESCRIPTION
See https://github.com/PCRE2Project/pcre2/blob/c421b939e7e1e7caf8a3de89b86f8e3fa83317e4/SECURITY.md for the signing key change