### PR TITLE
sqlitebrowser: Update to 3.13.1 and build with SQLCipher

### DIFF
--- a/mingw-w64-sqlitebrowser/0001-sqlitebrowser-install.patch
+++ b/mingw-w64-sqlitebrowser/0001-sqlitebrowser-install.patch
@@ -2,19 +2,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index d0209c56..442b170b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -486,7 +486,7 @@ if(WIN32 AND MSVC)
-     endif()
- endif()
- 
--if(NOT WIN32)
-+if(NOT WIN32 OR MINGW)
- 	install(TARGETS ${PROJECT_NAME}
- 		RUNTIME DESTINATION bin
- 		LIBRARY DESTINATION lib)
-@@ -496,7 +496,7 @@ if(ENABLE_TESTING)
- 	add_subdirectory(src/tests)
- endif()
- 
+@@ -528,3 +528,3 @@ if(ENABLE_TESTING)
 -if(UNIX)
 +if(UNIX OR MINGW)
  	install(FILES src/icons/${PROJECT_NAME}.png

--- a/mingw-w64-sqlitebrowser/0002-sqlitebrowser-linking.patch
+++ b/mingw-w64-sqlitebrowser/0002-sqlitebrowser-linking.patch
@@ -1,22 +1,21 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index d0209c56..0b605e6c 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -347,7 +347,7 @@ if(WIN32)
- 			COMMAND windres "-I${CMAKE_CURRENT_SOURCE_DIR}" "-i${CMAKE_CURRENT_SOURCE_DIR}/src/winapp.rc" -o "${CMAKE_CURRENT_BINARY_DIR}/sqlbicon.o" VERBATIM)
- 		set(SQLB_SRC ${SQLB_SRC} "${CMAKE_CURRENT_BINARY_DIR}/sqlbicon.o")
- 		set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-subsystem,windows")
--		set(WIN32_STATIC_LINK -Wl,-Bstatic -lssl -lcrypto -lws2_32)
-+		set(WIN32_LINK -lssl -lcrypto -lws2_32)
- 		set(ADDITIONAL_LIBS lzma)
- 	ELSE( MINGW )
- 		set(SQLB_SRC ${SQLB_SRC} "${CMAKE_CURRENT_SOURCE_DIR}/src/winapp.rc")
-@@ -452,7 +452,7 @@ set(QT_LIBS Qt5::Gui Qt5::Test Qt5::PrintSupport Qt5::Widgets Qt5::Network Qt5::
+diff -bur sqlitebrowser-3.13.1-orig/CMakeLists.txt sqlitebrowser-3.13.1/CMakeLists.txt
+--- sqlitebrowser-3.13.1-orig/CMakeLists.txt	2025-02-19 23:35:50 +0000
++++ sqlitebrowser-3.13.1/CMakeLists.txt	2025-02-19 23:36:29 +0000
+@@ -417,7 +417,7 @@
+         )
+         target_sources(${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/sqlbicon.o")
+         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-subsystem,windows")
+-        set(WIN32_STATIC_LINK -Wl,-Bstatic -lssl -lcrypto -lws2_32)
++        set(WIN32_LINK -lssl -lcrypto -lws2_32)
+         set(ADDITIONAL_LIBS lzma)
+     else()
+         target_sources(${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/winapp.rc")
+@@ -485,7 +485,7 @@
  target_link_libraries(${PROJECT_NAME}
      ${LPTHREAD}
      ${QT_LIBS}
 -    ${WIN32_STATIC_LINK}
 +    ${WIN32_LINK}
-     ${LIBSQLITE}
-     ${ADDITIONAL_LIBS})
- if(QHexEdit_FOUND)
+     ${ADDITIONAL_LIBS}
+ )
+ 

--- a/mingw-w64-sqlitebrowser/PKGBUILD
+++ b/mingw-w64-sqlitebrowser/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=sqlitebrowser
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-pkgver=3.12.2
-pkgrel=3
+pkgver=3.13.1
+pkgrel=1
 pkgdesc='SQLite Database browser is a Qt GUI editor for SQLite databases (mingw-w64)'
 url='https://sqlitebrowser.org/'
 msys2_repository_url="https://github.com/sqlitebrowser/sqlitebrowser"
@@ -12,6 +12,7 @@ arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 license=('spdx:MPL-2.0 OR GPL-3.0-or-later')
 depends=("${MINGW_PACKAGE_PREFIX}-qt5-base"
+         "${MINGW_PACKAGE_PREFIX}-sqlcipher"
          "${MINGW_PACKAGE_PREFIX}-sqlite3")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
@@ -20,9 +21,9 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 source=("https://github.com/sqlitebrowser/sqlitebrowser/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
         "0001-sqlitebrowser-install.patch"
         "0002-sqlitebrowser-linking.patch")
-sha256sums=('645f98d38e5d128a449e93cebf03c8070f9eacd2d16b10e433a781d54a9d478a'
-            '340b343f2d86bae6f4666d77ed16f7c2d1f2986370833d4ecd000b6835a0c0b9'
-            '826845aae4fa5312d057989b929ef45473c388c6636e8ad7d018c9e1ca591349')
+sha256sums=('1044ba67d649cabc459eb887c016f70d6a404ad651390ab33bf7859dc7f1b67b'
+            'f42dca177ec7a51ca847ee8f89430acd415e4be8e94f5db84acd62cb066f7b81'
+            '5e2851cc51dde429d8383675e3b8e178ef5a123b54413f7bda4307061c01eaf2')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
@@ -47,6 +48,7 @@ build() {
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     "${extra_config[@]}" \
     -DBUILD_STABLE_VERSION=ON \
+    -Dsqlcipher=ON \
     -Wno-dev \
     ../${_realname}-${pkgver}
 


### PR DESCRIPTION
I wish that they supported https://utelle.github.io/SQLite3MultipleCiphers/ instead of just SQLCipher. 
 
The encrypted DBs I need support are not supported by SQLCipher alone which requires `[System.Data.SQLite] RC4` as https://github.com/msys2/MINGW-packages/pull/23246 does 😢 

![image](https://github.com/user-attachments/assets/09d13779-dbc6-4083-90b6-a3a926570723)

![image](https://github.com/user-attachments/assets/be3c4659-b2fc-4fe3-907a-b5756bb3f6ad)
