### PR TITLE
Groonga: Update to 15.0.1

### DIFF
--- a/mingw-w64-groonga/PKGBUILD
+++ b/mingw-w64-groonga/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=groonga
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=15.0.0
+pkgver=15.0.1
 pkgrel=1
 pkgdesc="An opensource fulltext search engine (mingw-w64)"
 arch=('any')
@@ -28,7 +28,7 @@ makedepends=("git"
              "${MINGW_PACKAGE_PREFIX}-rapidjson"
              "${MINGW_PACKAGE_PREFIX}-ruby"
              "${MINGW_PACKAGE_PREFIX}-xsimd")
-sha256sums=('e4450fa797aebadf8d282cfd5b325e3baefe6b51874fdd743aff32815d62c1ff'
+sha256sums=('7976cf55b0e5d581d738c2dd0528250035d1194e26d05b60b806483618b71791'
             'SKIP')
 validpgpkeys=('2701F317CFCCCB975CADE9C2624CF77434839225') # Groonga Key <packages@groonga.org>
 


### PR DESCRIPTION
Groonga version15.0.1 has just released [here](https://github.com/groonga/groonga/releases/tag/v15.0.1).