### PR TITLE
cargo-c: update to 0.10.11

### DIFF
--- a/mingw-w64-cargo-c/PKGBUILD
+++ b/mingw-w64-cargo-c/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=cargo-c
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.10.9
-pkgrel=3
+pkgver=0.10.11
+pkgrel=1
 pkgdesc='A cargo subcommand to build and install C-ABI compatibile dynamic and static libraries (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -22,19 +22,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-openssl")
 options=('!strip')
 source=("https://github.com/lu-zero/cargo-c/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
-        "https://patch-diff.githubusercontent.com/raw/lu-zero/cargo-c/pull/444.patch"
         "${_realname}-${pkgver}.Cargo.lock"::"https://github.com/lu-zero/cargo-c/releases/download/v${pkgver}/Cargo.lock")
-sha256sums=('4542e39aa67bf8712c60f21701cc8e8b5153d0344afe1b618f121f696b578a7f'
-            '4c939d795be6f6645c24a4ff198183393915d490756eabdfbfd34c2446a71480'
-            '387e25aa120f945c5455557ca7815b8085090b825d2d4fd0b46cc9fdce0c34bc')
+sha256sums=('8a6d6dc589d6d70bd7eb95971e3c608240e1f9c938dd5b54a049977333b59f05'
+            'c65ee1fcd2fefa0a3c572477243c64326f21ff5c85b960a7975663141121eb91')
 
 prepare() {
     cp "${_realname}-${pkgver}.Cargo.lock" "${_realname}-${pkgver}/Cargo.lock"
     cd "${_realname}-${pkgver}"
-
-    # https://github.com/lu-zero/cargo-c/issues/443
-    patch -Np1 < ../444.patch
-    cargo update -p implib
 
     cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
 }
@@ -51,6 +45,7 @@ build() {
     cd "${_realname}-${pkgver}"
 
     _env
+    export RUSTFLAGS="$RUSTFLAGS -C target-feature=-crt-static"
     cargo build --frozen --profile release-strip
 }
 

--- a/mingw-w64-gst-plugins-rs/PKGBUILD
+++ b/mingw-w64-gst-plugins-rs/PKGBUILD
@@ -53,11 +53,5 @@ package() {
   cd $_realname-$_tag
   MSYS2_ARG_CONV_EXCL="--prefix=" cargo cinstall "${_cargo_opts[@]}" --destdir="$pkgdir"
 
-  # https://github.com/lu-zero/cargo-c/issues/443
-  dlltool \
-    -D"libgstrsinter.dll" \
-    -d"${pkgdir}${MINGW_PREFIX}/lib/gstreamer-1.0/gstrsinter.def" \
-    -l"${pkgdir}${MINGW_PREFIX}/lib/gstreamer-1.0/libgstrsinter.dll.a"
-
   install -Dm644 -t "$pkgdir/$MINGW_PREFIX"/share/licenses/$_realname/ LICENSE*
 }

--- a/mingw-w64-keepawake/PKGBUILD
+++ b/mingw-w64-keepawake/PKGBUILD
@@ -74,12 +74,6 @@ package_libkeepawake() {
       --prefix="${MINGW_PREFIX}" \
       --destdir="${pkgdir}"
 
-  # https://github.com/lu-zero/cargo-c/issues/443
-  dlltool \
-    -D"libkeepawake.dll" \
-    -d"${pkgdir}${MINGW_PREFIX}/lib/keepawake.def" \
-    -l"${pkgdir}${MINGW_PREFIX}/lib/libkeepawake.dll.a"
-
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/lib${_realname}/LICENSE"
 }
 

--- a/mingw-w64-libdovi/PKGBUILD
+++ b/mingw-w64-libdovi/PKGBUILD
@@ -61,11 +61,5 @@ package() {
         --prefix="${MINGW_PREFIX}" \
         --destdir="${pkgdir}"
 
-  # https://github.com/lu-zero/cargo-c/issues/443
-  dlltool \
-    -D"libdovi.dll" \
-    -d"${pkgdir}${MINGW_PREFIX}/lib/dovi.def" \
-    -l"${pkgdir}${MINGW_PREFIX}/lib/libdovi.dll.a"
-
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-libimagequant/PKGBUILD
+++ b/mingw-w64-libimagequant/PKGBUILD
@@ -46,12 +46,6 @@ package() {
     --prefix=${MINGW_PREFIX} \
     --manifest-path imagequant-sys/Cargo.toml
 
-  # https://github.com/msys2/MINGW-packages/issues/23358
-  dlltool \
-    -D"${pkgdir}${MINGW_PREFIX}/bin/libimagequant.dll" \
-    -d"${pkgdir}${MINGW_PREFIX}/lib/imagequant.def" \
-    -l"${pkgdir}${MINGW_PREFIX}/lib/libimagequant.dll.a"
-
   # Remove def file
   rm -f "${pkgdir}"${MINGW_PREFIX}/lib/*.def
 

--- a/mingw-w64-rav1e/PKGBUILD
+++ b/mingw-w64-rav1e/PKGBUILD
@@ -73,12 +73,6 @@ package() {
       --prefix="${MINGW_PREFIX}" \
       --destdir="${pkgdir}"
 
-  # https://github.com/lu-zero/cargo-c/issues/443
-  dlltool \
-    -D"librav1e.dll" \
-    -d"${pkgdir}${MINGW_PREFIX}/lib/rav1e.def" \
-    -l"${pkgdir}${MINGW_PREFIX}/lib/librav1e.dll.a"
-
   # Remove def file
   rm -f "${pkgdir}"${MINGW_PREFIX}/lib/*.def
 


### PR DESCRIPTION
- remove backport
- remove workarounds for rdeps for future updates/rebuilds