### PR TITLE
add a template for cargo-c built package

### DIFF
--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.cargo-c-tarball.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.cargo-c-tarball.sh
@@ -1,0 +1,65 @@
+# Maintainer: Some One <some.one@some.email.com>
+
+_realname=somepackage
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.0
+pkgrel=1
+pkgdesc="Some package (mingw-w64)"
+arch=('any')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
+url='https://www.somepackage.org/'
+license=('LICENSE')
+makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
+             "${MINGW_PACKAGE_PREFIX}-cargo-c")
+source=("https://www.somepackage.org/${_realname}/${_realname}-${pkgver}.tar.gz"
+        "0001-An-important-fix.patch"
+        "0002-A-less-important-fix.patch")
+sha256sums=('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+            'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+            'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+
+  patch -Np1 -i "${srcdir}"/0001-A-really-important-fix.patch
+  patch -Np1 -i "${srcdir}"/0002-A-less-important-fix.patch
+
+  cargo fetch --locked
+}
+
+build() {
+  cd "${_realname}-${pkgver}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    cargo cbuild \
+      --meson-paths \
+      --release \
+      --frozen \
+      --all-features \
+      --prefix="${MINGW_PREFIX}"
+}
+
+check() {
+  cd "${_realname}-${pkgver}"
+
+  cargo test --release --frozen
+}
+
+package() {
+  cd "${_realname}-${pkgver}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    cargo cinstall \
+      --meson-paths \
+      --release \
+      --frozen \
+      --all-features \
+      --prefix="${MINGW_PREFIX}" \
+      --destdir="${pkgdir}"
+
+  # Remove def file
+  rm -f "${pkgdir}"${MINGW_PREFIX}/lib/*.def
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
with cargo-c downstream patch being dropped in 631e0ec2122c1b87f2dfb6588e3dbb2538ce0405 we start using `--meson-paths` option to get `lib` prefix for libraries. create a template to make this a bit more clear for maintainers