### PR TITLE
pidgin: Update to 2.14.14 and enable aarch64 builds

### DIFF
--- a/mingw-w64-pidgin/PKGBUILD
+++ b/mingw-w64-pidgin/PKGBUILD
@@ -4,11 +4,11 @@
 _realname='pidgin'
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.14.13
+pkgver=2.14.14
 pkgrel=1
 pkgdesc='Multi-protocol instant messaging client (mingw-w64)'
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://pidgin.im'
 msys2_references=(
   "cpe: cpe:/a:pidgin:libpurple"
@@ -51,7 +51,7 @@ source=("https://downloads.sourceforge.net/${_realname}/${_realname}-${pkgver}.t
         001-autotools-and-fhs.patch
         002-build-fixes.patch
         003-build-fixes.patch)
-sha256sums=('120049dc8e17e09a2a7d256aff2191ff8491abb840c8c7eb319a161e2df16ba8'
+sha256sums=('0ffc9994def10260f98a55cd132deefa8dc4a9835451cc0e982747bd458e2356'
             'SKIP'
             '5852d78f97e344226e598f2342b7a1b276f25eec71903bacdc9f68849804df85'
             'bdc8fc0e707206ec340711c25c7ef5be453be1cff93b1678908ebe71907600d7'
@@ -78,8 +78,8 @@ build() {
     cp -r "${srcdir}/${_realname}-${pkgver}" "${srcdir}/build-${MSYSTEM}"
     cd "${srcdir}/build-${MSYSTEM}"
 
-    CFLAGS+=" -Wno-deprecated-declarations -Wno-int-conversion" \
-    CXXFLAGS+=" -Wno-deprecated-declarations -Wno-int-conversion" \
+    CFLAGS+=" -Wno-deprecated-declarations -Wno-int-conversion -Wno-incompatible-pointer-types" \
+    CXXFLAGS+=" -Wno-deprecated-declarations -Wno-int-conversion -Wno-incompatible-pointer-types" \
     INTLTOOL_PERL=/usr/bin/perl ./configure \
         --prefix=${MINGW_PREFIX} \
         --build=${MINGW_CHOST} \


### PR DESCRIPTION
Requires:
- https://github.com/msys2/MINGW-packages/pull/23490
- https://github.com/msys2/MINGW-packages/pull/23489
- https://github.com/msys2/MINGW-packages/pull/23486
- https://github.com/msys2/MINGW-packages/pull/23491
<img width="661" alt="image" src="https://github.com/user-attachments/assets/e428ce5e-22d3-4dfa-be39-26f1c8df535f" />
