### PR TITLE
luarocks: fix C modules installation/removal on CLANG64 and CLANGARM64

### DIFF
--- a/mingw-w64-lua-luarocks/0001-luarocks_msys2_mingw_w64.patch
+++ b/mingw-w64-lua-luarocks/0001-luarocks_msys2_mingw_w64.patch
@@ -41,15 +41,20 @@ diff -Naur luarocks-3.7.0.orig/spec/util/test_env.lua luarocks-3.7.0/spec/util/t
 diff -Naur luarocks-3.7.0.orig/src/luarocks/core/cfg.lua luarocks-3.7.0/src/luarocks/core/cfg.lua
 --- luarocks-3.7.0.orig/src/luarocks/core/cfg.lua	2021-04-13 23:53:36.000000000 +0200
 +++ luarocks-3.7.0/src/luarocks/core/cfg.lua	2021-07-25 17:51:51.829906200 +0200
-@@ -414,6 +414,7 @@
-          defaults.makefile = "Makefile"
-          defaults.cmake_generator = "MSYS Makefiles"
-          defaults.local_cache = home.."/.cache/luarocks"
-+		 defaults.variables.PWD = "cd"
-          defaults.variables.MAKE = os.getenv("MAKE") or "make"
-          defaults.variables.CC = os.getenv("CC") or "gcc"
-          defaults.variables.RC = os.getenv("WINDRES") or "windres"
-@@ -745,7 +749,7 @@
+@@ -454,6 +454,12 @@
+       end
+    end
+ 
++   if platforms.msys2_mingw_w64 then
++      defaults.variables.PWD = "cd"
++      defaults.variables.CC = os.getenv("CC") or "cc"
++      defaults.variables.LD = os.getenv("CC") or "cc"
++   end
++
+    if platforms.bsd then
+       defaults.variables.MAKE = "gmake"
+       defaults.gcc_rpath = false
+@@ -784,11 +790,13 @@
  
     local defaults = make_defaults(cfg.lua_version, processor, platforms, cfg.home)
  
@@ -58,6 +63,12 @@ diff -Naur luarocks-3.7.0.orig/src/luarocks/core/cfg.lua luarocks-3.7.0/src/luar
        local tools = { "SEVENZ", "CP", "FIND", "LS", "MD5SUM", "WGET", }
        for _, tool in ipairs(tools) do
           defaults.variables[tool] = '"' .. hardcoded.WIN_TOOLS .. "/" .. defaults.variables[tool] .. '.exe"'
+       end
++   elseif platforms.msys2_mingw_w64 then
++      defaults.fs_use_modules = false
+    else
+       defaults.fs_use_modules = true
+    end
 diff -Naur luarocks-3.7.0.orig/src/luarocks/fs/msys2_mingw_w64.lua luarocks-3.7.0/src/luarocks/fs/msys2_mingw_w64.lua
 --- luarocks-3.7.0.orig/src/luarocks/fs/msys2_mingw_w64.lua	1970-01-01 01:00:00.000000000 +0100
 +++ luarocks-3.7.0/src/luarocks/fs/msys2_mingw_w64.lua	2021-07-25 17:52:51.477791300 +0200

--- a/mingw-w64-lua-luarocks/0001-luarocks_msys2_mingw_w64.patch
+++ b/mingw-w64-lua-luarocks/0001-luarocks_msys2_mingw_w64.patch
@@ -10,18 +10,7 @@ diff -Naur luarocks-3.7.0.orig/spec/util/test_env.lua luarocks-3.7.0/spec/util/t
 +         test_env.MSYS2_MINGW_W64 = true
        elseif argument:find("^lua_dir=") then
           test_env.LUA_DIR = argument:match("^lua_dir=(.*)$")
-       elseif argument:find("^lua_interpreter=") then
-@@ -429,7 +431,9 @@
-       return execute_output("find " .. path .. " -type f -exec stat -f \"%z %N\" {} \\; | md5")
-    elseif test_env.TEST_TARGET_OS == "windows" then
-       return execute_output("\"" .. Q(test_env.testing_paths.win_tools .. "/find") .. " " .. Q(path)
--         .. " -printf \"%s %p\"\" > temp_sum.txt && certUtil -hashfile temp_sum.txt && del temp_sum.txt")
-+         .. " -printf \"%s %p\"\" > temp_sum.txt && "
-+         .. "C:\\Windows\\System32\\certUtil -hashfile temp_sum.txt && "
-+		 .. "del temp_sum.txt")
-    end
- end
- 
+       elseif argument:find("^lua=") then
 @@ -823,10 +827,14 @@
     if test_env.TEST_TARGET_OS == "windows" then
        if test_env.MINGW then
@@ -38,37 +27,6 @@ diff -Naur luarocks-3.7.0.orig/spec/util/test_env.lua luarocks-3.7.0/spec/util/t
     end
  
     table.insert(lines, "}")
-diff -Naur luarocks-3.7.0.orig/src/luarocks/core/cfg.lua luarocks-3.7.0/src/luarocks/core/cfg.lua
---- luarocks-3.7.0.orig/src/luarocks/core/cfg.lua	2021-04-13 23:53:36.000000000 +0200
-+++ luarocks-3.7.0/src/luarocks/core/cfg.lua	2021-07-25 17:51:51.829906200 +0200
-@@ -454,6 +454,12 @@
-       end
-    end
- 
-+   if platforms.msys2_mingw_w64 then
-+      defaults.variables.PWD = "cd"
-+      defaults.variables.CC = os.getenv("CC") or "cc"
-+      defaults.variables.LD = os.getenv("CC") or "cc"
-+   end
-+
-    if platforms.bsd then
-       defaults.variables.MAKE = "gmake"
-       defaults.gcc_rpath = false
-@@ -784,11 +790,13 @@
- 
-    local defaults = make_defaults(cfg.lua_version, processor, platforms, cfg.home)
- 
--   if platforms.windows and hardcoded.WIN_TOOLS then
-+   if platforms.windows and not platforms.msys2_mingw_w64 and hardcoded.WIN_TOOLS then
-       local tools = { "SEVENZ", "CP", "FIND", "LS", "MD5SUM", "WGET", }
-       for _, tool in ipairs(tools) do
-          defaults.variables[tool] = '"' .. hardcoded.WIN_TOOLS .. "/" .. defaults.variables[tool] .. '.exe"'
-       end
-+   elseif platforms.msys2_mingw_w64 then
-+      defaults.fs_use_modules = false
-    else
-       defaults.fs_use_modules = true
-    end
 diff -Naur luarocks-3.7.0.orig/src/luarocks/fs/msys2_mingw_w64.lua luarocks-3.7.0/src/luarocks/fs/msys2_mingw_w64.lua
 --- luarocks-3.7.0.orig/src/luarocks/fs/msys2_mingw_w64.lua	1970-01-01 01:00:00.000000000 +0100
 +++ luarocks-3.7.0/src/luarocks/fs/msys2_mingw_w64.lua	2021-07-25 17:52:51.477791300 +0200

--- a/mingw-w64-lua-luarocks/PKGBUILD
+++ b/mingw-w64-lua-luarocks/PKGBUILD
@@ -6,7 +6,7 @@ _realname=luarocks
 pkgbase=mingw-w64-lua-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-lua-${_realname}")
 pkgver=3.9.2
-pkgrel=1
+pkgrel=2
 pkgdesc="the package manager for Lua modules (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -23,7 +23,7 @@ install=${_realname}-${MSYSTEM}.install
 source=("https://luarocks.org/releases/${_realname}-${pkgver}.tar.gz"
         "0001-luarocks_msys2_mingw_w64.patch")
 sha256sums=('bca6e4ecc02c203e070acdb5f586045d45c078896f6236eb46aa33ccd9b94edb'
-            '9c0e3c836ac6fc2f528a6e3f8bcca1bc9aa76af5c660068d28e5fda9d0e74240')
+            '076de448936709348977c4d6ca570af3ba047b4045928c56f98d430c7714d102')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"

--- a/mingw-w64-lua-luarocks/PKGBUILD
+++ b/mingw-w64-lua-luarocks/PKGBUILD
@@ -5,8 +5,8 @@
 _realname=luarocks
 pkgbase=mingw-w64-lua-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-lua-${_realname}")
-pkgver=3.9.2
-pkgrel=2
+pkgver=3.11.1
+pkgrel=1
 pkgdesc="the package manager for Lua modules (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -21,13 +21,25 @@ depends=("${MINGW_PACKAGE_PREFIX}-lua"
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc" "${MINGW_PACKAGE_PREFIX}-autotools")
 install=${_realname}-${MSYSTEM}.install
 source=("https://luarocks.org/releases/${_realname}-${pkgver}.tar.gz"
-        "0001-luarocks_msys2_mingw_w64.patch")
-sha256sums=('bca6e4ecc02c203e070acdb5f586045d45c078896f6236eb46aa33ccd9b94edb'
-            '076de448936709348977c4d6ca570af3ba047b4045928c56f98d430c7714d102')
+        "0001-luarocks_msys2_mingw_w64.patch"
+        "0002-fix-CC-clang64-clangarm64.patch::https://github.com/luarocks/luarocks/pull/1754.patch"
+        "0003-fix-package-removal.patch::https://github.com/luarocks/luarocks/pull/1756.patch")
+sha256sums=('c3fb3d960dffb2b2fe9de7e3cb004dc4d0b34bb3d342578af84f84325c669102'
+            '48e2e8c9cd1eaf7f18b38c25d474a4cd39dddb88b92152e278d04dffdcda2a90'
+            'd13210147a4d17a4b9d731e2ca944fb22f93b49b3734d78ef02bbc2b0f8ceb7d'
+            '4f600ec5a98d4b038c603be4e69af2f3be72528a73afaa959ed7829047f563f0')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   patch -p1 -i "${srcdir}"/0001-luarocks_msys2_mingw_w64.patch
+
+  # Fixes https://github.com/msys2/MINGW-packages/issues/23493
+  # This patch should be removed on any release after 3.11.1
+  patch -p1 -i "${srcdir}"/0002-fix-CC-clang64-clangarm64.patch
+
+  # Fixes https://github.com/luarocks/luarocks/issues/1755
+  # This patch should also be removed on any release after 3.11.1
+  patch -p1 -i "${srcdir}"/0003-fix-package-removal.patch
 }
 
 build() {


### PR DESCRIPTION
## Description

Fixes [https://github.com/msys2/MINGW-packages/issues/23493](https://github.com/msys2/MINGW-packages/issues/23493)
Fixes the upstream issue [https://github.com/luarocks/luarocks/issues/1428](https://github.com/luarocks/luarocks/issues/1428) for MSYS2, because even though it was supposed to be fixed at [https://github.com/luarocks/luarocks/pull/1616](https://github.com/luarocks/luarocks/pull/1616), it still happens on MSYS2 even after a LuaRocks upgrade.

Changes:

* The first addition of code is responsible to fix [https://github.com/msys2/MINGW-packages/issues/23493](https://github.com/msys2/MINGW-packages/issues/23493);
* The second addition of code fixes [https://github.com/luarocks/luarocks/issues/1428](https://github.com/luarocks/luarocks/issues/1428).

> [!NOTE]
> 
> I'll try to upstream these changes.