### PR TITLE
kicad-[doc,library]: Update to 9.0.0

### DIFF
--- a/mingw-w64-kicad-doc/PKGBUILD
+++ b/mingw-w64-kicad-doc/PKGBUILD
@@ -15,8 +15,10 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-ca"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-pl"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-ru"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-zh")
-_job_id='7765204080' # this is want is needed to change for new version
-pkgver=8.0.5
+
+# https://gitlab.com/kicad/services/kicad-doc/-/jobs/9178132758/artifacts/browse/archive/
+_job_id='9178132758' # this is needed to change for new version
+pkgver=9.0.0
 pkgrel=1
 pkgdesc="Documentation for KiCad (mingw-w64)"
 arch=(any)
@@ -34,14 +36,8 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-kicad-meta"
 # https://kicad-downloads.s3.cern.ch/docs/kicad-doc-8.0.0-rc3.tar.gz
 # Use the more current build artifact from the release tag instead:
 # https://gitlab.com/kicad/services/kicad-doc/-/artifacts
-source=("${_realname}-${pkgver}.zip::https://gitlab.com/kicad/services/kicad-doc/-/jobs/${_job_id}/artifacts/download")
-sha256sums=('bd9625c2e336f561373b2f604da45e56cb51e84adfdab6df9c1c8e2ee1382ab9')
-
-prepare() {
-  cd "${srcdir}"
-
-  tar -xzf "${srcdir}"/archive/kicad-doc-unknown.tar.gz -C "${srcdir}"
-}
+source=("${_realname}-${pkgver}.tar.gz::https://gitlab.com/kicad/services/kicad-doc/-/jobs/${_job_id}/artifacts/raw/archive/kicad-doc-unknown.tar.gz")
+sha256sums=('fec4e4ae87ad174666effb10b0c2b76ff684fef5f38ac6bc09aee62c79c9105b')
 
 build_lang() {
   cd "${srcdir}/kicad-doc-unknown/share/doc/kicad/help"

--- a/mingw-w64-kicad-library/PKGBUILD
+++ b/mingw-w64-kicad-library/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-footprints"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-templates"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-packages3D"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-meta")
-pkgver=8.0.5
+pkgver=9.0.0
 pkgrel=1
 pkgdesc="Support libraries for KiCad (mingw-w64)"
 arch=('any')
@@ -26,10 +26,10 @@ source=("https://gitlab.com/kicad/libraries/kicad-footprints/-/archive/${pkgver}
         "https://gitlab.com/kicad/libraries/kicad-symbols/-/archive/${pkgver}/kicad-symbols-${pkgver}.tar.bz2"
         "https://gitlab.com/kicad/libraries/kicad-templates/-/archive/${pkgver}/kicad-templates-${pkgver}.tar.bz2"
         "https://gitlab.com/kicad/libraries/kicad-packages3D/-/archive/${pkgver}/kicad-packages3D-${pkgver}.tar.bz2")
-sha256sums=('00cc89a980ce6810dce20561376ad665d995dd3de92d398722fad4afbe522f5e'
-            'f79a8b8022d9338c308126500058f9823714160da427a6feca1dd6874631f4fb'
-            '45c30e8544755aaa55bdf462d01f919463438a7f523d2d9a5860da7a3bcf0846'
-            '4745c4b48c67845184a8a2e20cad3c548c38c80f82e8a44b180c764a524e147f')
+sha256sums=('2c55de89d1558623d9c370bda3c11e3b01522c591ac9cfffc4e80ed2cae75392'
+            '13dc2ec96f2827754c013d99cb8cfafdf60b4dbdb984234cfbee9331bb23f46f'
+            'cb670d3450aced975dad7461d7f9356415e7b3b816ebdf75c06af51504ece256'
+            'd2bc1a757517d3467dff5bb39535480b46db988b3caf36e8b8a313f9bcb627df')
 
 build() {
   declare -a _extra_config


### PR DESCRIPTION
Requires https://github.com/msys2/MINGW-packages/pull/23507 to be built first