### PR TITLE
mingw-w64-gcc: Allow the gcc driver to expand wildcards

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -237,6 +237,7 @@ build() {
     --enable-checking=release \
     --with-arch=${_arch} \
     --with-tune=generic \
+    --enable-mingw-wildcard \
     --enable-languages=${_languages} \
     --enable-shared \
     --enable-static \


### PR DESCRIPTION
https://github.com/msys2/MINGW-packages/issues/22559

https://github.com/gcc-mirror/gcc/blob/master/gcc/config/i386/driver-mingw32.cc

This options sets _dowildcard to 1 which makes mingw-w64 expand the wildcard somehow.