### PR TITLE
[new-package] stk 5.0.1

### DIFF
--- a/mingw-w64-stk/PKGBUILD
+++ b/mingw-w64-stk/PKGBUILD
@@ -1,0 +1,62 @@
+# Maintainer: Kreijstal <kreijstal@hotmail.com>
+# Contributor: Tres Finocchiaro <tres.finocchiaro@gmail.com>
+
+_realname=stk
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=5.0.1
+pkgrel=1
+pkgdesc="The Synthesis ToolKit in C++ (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url="https://ccrma.stanford.edu/software/stk/"
+license=('spdx:MIT')
+depends=($([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-jack2"))
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+source=("https://github.com/thestk/${_realname}/archive/${pkgver}/${_realname}-${pkgver}.tar.gz"
+        "146.patch::https://patch-diff.githubusercontent.com/raw/thestk/stk/pull/146.patch") #once released and merged remove this
+sha256sums=('1dd1a5063efa43d4bc9792d1394b395672fb2222cdb0e56c7c8e3f6db22ece86'
+            '8be5201c55efb7a294550af43ad84439b78f6087a2a3b75477bc6b2b6479dc21')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -p1 -i "${srcdir}/146.patch"
+}
+
+build() {
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  export RAWWAVE_PATH="${MINGW_PREFIX}/share/${_realname}/rawwaves/"
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  CXXFLAGS="-D_USE_MATH_DEFINES" \
+    ${MINGW_PREFIX}/bin/cmake \
+    -GNinja \
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+    "${extra_config[@]}" \
+    -DBUILD_SHARED_LIBS=ON \
+    ../${_realname}-${pkgver}
+
+  ${MINGW_PREFIX}/bin/cmake --build .
+}
+
+check() {
+  cd "${srcdir}/build-${MSYSTEM}"
+  ${MINGW_PREFIX}/bin/ctest .
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/share/stk/rawwaves/"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/rawwaves/"*.raw "${pkgdir}${MINGW_PREFIX}/share/stk/rawwaves/"
+}

--- a/mingw-w64-stk/PKGBUILD
+++ b/mingw-w64-stk/PKGBUILD
@@ -11,7 +11,9 @@ arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://ccrma.stanford.edu/software/stk/"
 license=('spdx:MIT')
-depends=($([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-jack2"))
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-libwinpthread"
+         $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-jack2"))
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cc")


### PR DESCRIPTION
Adds [The Synthesis ToolKit in C++ (STK)](https://ccrma.stanford.edu/software/stk/)

Caveats:
* `jack2` is temporarily disabled for `*-clang-*`, the dependency does not yet exist for those.

```
pkg/mingw-w64-clang-aarch64-stk/
└── clangarm64
    ├── bin
    │   └── libstk.dll
    ├── include
    │   └── stk
    │       ├── ADSR.h
    │        [...]
    │       └── WvOut.h
    ├── lib
    │   ├── cmake
    │   │   └── stk
    │   │       ├── stk-config-release.cmake
    │   │       └── stk-config.cmake
    │   ├── libstk.a
    │   └── libstk.dll.a
    └── share
        ├── licenses
        │   └── stk
        │       └── LICENSE
        └── stk
            └── rawwaves
                ├── ahh.raw
                 [...]
                └── twopeaks.raw
```


Related downstream:
* https://github.com/LMMS/lmms/issues/7526#issuecomment-2686158914
* https://github.com/LMMS/lmms/pull/7736