### PR TITLE
innoextract: update to the most recent version ("1.10-dev")

### DIFF
--- a/mingw-w64-innoextract/PKGBUILD
+++ b/mingw-w64-innoextract/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=innoextract
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.9
-pkgrel=10
+pkgver=1.10dev.82.6e9e34e
+pkgrel=1
 pkgdesc="A tool to extract installers created by Inno Setup (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -14,20 +14,18 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-boost"
-             "${MINGW_PACKAGE_PREFIX}-python")
+             "${MINGW_PACKAGE_PREFIX}-python"
+             "git")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-boost-libs"
          "${MINGW_PACKAGE_PREFIX}-xz")
-source=("https://constexpr.org/innoextract/files/${_realname}-${pkgver}.tar.gz"{,.sig}
-        "001-fix-build-against-boost-1.85.patch::https://github.com/dscharrer/innoextract/commit/264c2fe6.patch")
-sha256sums=('6344a69fc1ed847d4ed3e272e0da5998948c6b828cb7af39c6321aba6cf88126'
-            'SKIP'
-            '891436a9d3278ddc3342fef24004b28b8fb6c49cd3534843bea1cb4f0f8508ed')
+source=("git+https://github.com/dscharrer/innoextract#commit=6e9e34ed0876014fdb46e684103ef8c3605e382e")
+sha256sums=('9e12fe63358bfa1b9ed4810f850d2e628ef7b87acc1ad44fc4d35e1b3a8e2a8e')
 validpgpkeys=("ADE9653703D4ADE0E997758128555A66D7E1DEC9") # Daniel Scharrer <daniel@constexpr.org>
 
-prepare() {
-  cd ${_realname}-${pkgver}
-  patch -p1 -i "${srcdir}"/001-fix-build-against-boost-1.85.patch
+pkgver() {
+  cd ${_realname}
+  printf "1.10dev.%s.%s" "$(git rev-list --count 1.9..HEAD)" "$(git rev-parse --short HEAD)"
 }
 
 build() {
@@ -48,7 +46,7 @@ build() {
     "${_extra_config[@]}" \
     -DUSE_STATIC_LIBS=OFF \
     -DPYTHON_EXECUTABLE=${MINGW_PREFIX}/bin/python \
-    ../${_realname}-${pkgver}
+    ../${_realname}
 
   ${MINGW_PREFIX}/bin/cmake.exe --build ./
 }
@@ -57,10 +55,10 @@ package() {
   cd "${srcdir}"/build-${MSYSTEM}
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install ./
 
-  install -Dm644 "${srcdir}"/${_realname}-${pkgver}/README.md \
+  install -Dm644 "${srcdir}"/${_realname}/README.md \
     "${pkgdir}"${MINGW_PREFIX}/share/doc/${_realname}/README.md
-  install -Dm644 "${srcdir}"/${_realname}-${pkgver}/CHANGELOG \
+  install -Dm644 "${srcdir}"/${_realname}/CHANGELOG \
     "${pkgdir}"${MINGW_PREFIX}/share/doc/${_realname}/CHANGELOG
-  install -Dm644 "${srcdir}"/${_realname}-${pkgver}/LICENSE \
+  install -Dm644 "${srcdir}"/${_realname}/LICENSE \
     "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
 }


### PR DESCRIPTION
There have been 82 revisions since version 1.9 was tagged, over 1,600 days passed, and https://github.com/dscharrer/innoextract/issues/176 does not exactly suggest that any new version will be tagged any time soon.

Yet version 1.9 is incompatible with many an InnoSetup version, while the code actually has been updated to handle the most recent one in https://github.com/dscharrer/innoextract/commit/e58f295d80c3.

So let's switch to the most recent development version (according to https://github.com/dscharrer/innoextract/blob/HEAD/VERSION it is "1.10-dev").

I verified manually that this version of `innoextract` can handle the recent Git for Windows installers, for example, while the most recent one in MSYS2 cannot.