### PR TITLE
fltk: update to 1.4.2

### DIFF
--- a/mingw-w64-fltk/PKGBUILD
+++ b/mingw-w64-fltk/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=fltk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.4.1
-pkgrel=2
+pkgver=1.4.2
+pkgrel=1
 pkgdesc="C++ user interface toolkit (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -24,7 +24,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-cc")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/${_realname}/${_realname}/archive/release-${pkgver}.tar.gz"
         "001-fltk-config-uuid-shared.patch")
-sha256sums=('26d3e521cbf3498f122fa86f6e45fc33b84135f9eb2125f6366ef09e8eae8c91'
+sha256sums=('de076793fd8487a5a55e0763ac0e85b115d3761cd1aa4869dbf3fc9e779dfca8'
             '30ea78d49d15dcc6cb567ab08d0c13f0ddcb1844dc9b22ebcd3bd80dd88f640e')
 
 prepare() {


### PR DESCRIPTION
According to FLTK: "[Its ABI and API are 100% backwards compatible with FLTK 1.4.0](https://www.fltk.org/articles.php?L1972)". Therefore there is no need to rebuild other packages that depend on it.