### PR TITLE
ghdl: update to 5.0.1

### DIFF
--- a/mingw-w64-ghdl/PKGBUILD
+++ b/mingw-w64-ghdl/PKGBUILD
@@ -1,10 +1,11 @@
-
 _realname=ghdl
 pkgbase="mingw-w64-${_realname}"
-pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-llvm"
-         "${MINGW_PACKAGE_PREFIX}-${_realname}-mcode")
-pkgver=4.1.0
-pkgrel=4
+pkgname=(
+  "${MINGW_PACKAGE_PREFIX}-${_realname}-llvm"
+  "${MINGW_PACKAGE_PREFIX}-${_realname}-mcode"
+)
+pkgver=5.0.1
+pkgrel=1
 pkgdesc='GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64')
@@ -22,15 +23,12 @@ makedepends=(
 )
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
 options=(!emptydirs)
-source=("https://github.com/ghdl/ghdl/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
-        001-support-llvm-19.patch::https://github.com/ghdl/ghdl/commit/6a9c70dd.patch)
-sha256sums=('0aab531b45a6613b0918f3ac6ec717b8acfad051d1abb1c39eb7490590c7a324'
-            'e3792de2e2cbd6ef96a53d9f2a1f025bc5f88c063ae523979e86e95a47a09841')
-
-prepare() {
-  cd ${_realname}-${pkgver}
-  patch -p1 -i "${srcdir}"/001-support-llvm-19.patch
-}
+source=(
+  "https://github.com/ghdl/ghdl/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
+)
+sha256sums=(
+  'a4cef27312a158c28498eeb62a470007354755b267adb62005a04b66143a1f92'
+)
 
 build() {
   echo "Building ghdl-llvm..."


### PR DESCRIPTION
This PR bumps ghdl for MinGW64 and UCRT64 from 4.1.0 to 5.0.1.

The patch for LLVM-19 isn't required anymore.