### PR TITLE
flang: inherit target specific code for BIND(C) on Windows

### DIFF
--- a/mingw-w64-flang/0003-flang-Inherit-target-specific-code-for-BIND-C-types.patch
+++ b/mingw-w64-flang/0003-flang-Inherit-target-specific-code-for-BIND-C-types.patch
@@ -1,0 +1,50 @@
+From afd990ed84c308d5d4d06f461d6bf80b670ddf16 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Markus=20M=C3=BCtzel?= <markus.muetzel@gmx.de>
+Date: Mon, 3 Mar 2025 10:32:22 +0100
+Subject: [PATCH] [flang] Inherit target specific code for BIND(C) types on
+ Windows (#114035)
+
+Inherit target specific code for Windows i386 and x86_64 from the classes that
+define that code for the respective processors on non-Windows operating
+systems.
+Only overload parts that differ.
+
+That allows re-using the existing implementation for BIND(C) types on
+non-Windows x86_64 also for Windows x86_64 targets.
+---
+ lib/Optimizer/CodeGen/Target.cpp | 12 ++++--------
+ 1 file changed, 4 insertions(+), 8 deletions(-)
+
+diff --git a/lib/Optimizer/CodeGen/Target.cpp b/lib/Optimizer/CodeGen/Target.cpp
+index 2a1eb0bc33f5..b03c1dd492ab 100644
+--- a/lib/Optimizer/CodeGen/Target.cpp
++++ b/lib/Optimizer/CodeGen/Target.cpp
+@@ -199,10 +199,8 @@ struct TargetI386 : public GenericTarget<TargetI386> {
+ //===----------------------------------------------------------------------===//
+ 
+ namespace {
+-struct TargetI386Win : public GenericTarget<TargetI386Win> {
+-  using GenericTarget::GenericTarget;
+-
+-  static constexpr int defaultWidth = 32;
++struct TargetI386Win : public TargetI386 {
++  using TargetI386::TargetI386;
+ 
+   CodeGenSpecifics::Marshalling
+   complexArgumentType(mlir::Location loc, mlir::Type eleTy) const override {
+@@ -718,10 +716,8 @@ struct TargetX86_64 : public GenericTarget<TargetX86_64> {
+ //===----------------------------------------------------------------------===//
+ 
+ namespace {
+-struct TargetX86_64Win : public GenericTarget<TargetX86_64Win> {
+-  using GenericTarget::GenericTarget;
+-
+-  static constexpr int defaultWidth = 64;
++struct TargetX86_64Win : public TargetX86_64 {
++  using TargetX86_64::TargetX86_64;
+ 
+   CodeGenSpecifics::Marshalling
+   complexArgumentType(mlir::Location loc, mlir::Type eleTy) const override {
+-- 
+2.47.1.windows.2
+

--- a/mingw-w64-flang/PKGBUILD
+++ b/mingw-w64-flang/PKGBUILD
@@ -9,7 +9,7 @@ _version=19.1.7
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
-pkgrel=1
+pkgrel=2
 pkgdesc="Fortran frontend for LLVM (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -41,6 +41,7 @@ source=("${_url}/${_pkgfn}.tar.xz"{,.sig}
         "${_url}/cmake-${pkgver}.src.tar.xz"{,.sig}
         "0001-fold-double-bessel-functions-on-windows.patch"
         "0002-cmake-22162.patch"
+        "0003-flang-Inherit-target-specific-code-for-BIND-C-types.patch"
         "0004-do-not-define-pid_t-on-mingw.patch"
         "0005-Fix-c_long_double-value-on-mingw-aarch64.patch"
         "0006-Rename-flang-new-flang-experimental-exec-to-flang.patch"
@@ -52,6 +53,7 @@ sha256sums=('632d598e990500c021a47b4f981efd39518d363b03d99da5ba4c1b14d838c40b'
             'SKIP'
             'ae666c454909f6695bcd69f067b9c5abf8a6e82ce2930955b8598ab3b58a5204'
             '77fb0612217b6af7a122f586a9d0d334cd48bb201509bf72e8f8e6244616e895'
+            'bb7336e461a09d4af29cde2fd32081c8fcca7f93e9f9b6779eb074b3780fd002'
             '90bec8f2a9a8d62b57959722f3b15a54dfdaf24e0a5ea884bf6b1288d0853be8'
             'a1811227e2a26c2786b0c8577528580e679111f6c0889afea57d08333e2d5e4f'
             'f1b7a186e4890a67adc8e56800c7a91e72f04f14df3db20d7bcf7eaa149aa567'
@@ -77,6 +79,7 @@ prepare() {
   apply_patch_with_msg \
     "0001-fold-double-bessel-functions-on-windows.patch" \
     "0002-cmake-22162.patch" \
+    "0003-flang-Inherit-target-specific-code-for-BIND-C-types.patch" \
     "0004-do-not-define-pid_t-on-mingw.patch" \
     "0005-Fix-c_long_double-value-on-mingw-aarch64.patch" \
     "0007-add-municode-flag-on-mingw.patch" \


### PR DESCRIPTION
Prompted by @MehdiChinoune's comment in https://github.com/llvm/llvm-project/issues/114035#issuecomment-2693354786.

I tried building the example in the original comment in that issue. It is executing fine for me with the changes from here.

@MehdiChinoune: Did you come across other projects that failed to compile with that error?