### PR TITLE
libtool: fix using LLVM Flang 19 as the linker driver for shared libraries

### DIFF
--- a/mingw-w64-libtool/0008-flang-linker-driver-options.patch
+++ b/mingw-w64-libtool/0008-flang-linker-driver-options.patch
@@ -1,0 +1,14 @@
+If LLVM Flang is used as the linker driver, it fails on the `-Xlinker` flag.
+Pass options to the linker with the `-Wl,` flag instead.
+
+--- libtool-2.5.4/m4/libtool.m4.orig	2025-03-03 15:56:09.384559000 +0100
++++ libtool-2.5.4/m4/libtool.m4	2025-03-03 15:57:39.772092900 +0100
+@@ -5264,7 +5264,7 @@
+       _LT_TAGVAR(file_list_spec, $1)='@'
+ 
+       if $LD --help 2>&1 | $GREP 'auto-import' > /dev/null; then
+-        _LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags -o $output_objdir/$soname $wl--enable-auto-image-base -Xlinker --out-implib -Xlinker $lib'
++        _LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags -o $output_objdir/$soname $wl--enable-auto-image-base $wl--out-implib,$lib'
+ 	# If the export-symbols file already is a .def file, use it as
+ 	# is; otherwise, prepend EXPORTS...
+ 	_LT_TAGVAR(archive_expsym_cmds, $1)='if _LT_DLL_DEF_P([$export_symbols]); then

--- a/mingw-w64-libtool/PKGBUILD
+++ b/mingw-w64-libtool/PKGBUILD
@@ -5,7 +5,7 @@ _realname=libtool
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-libtool" "${MINGW_PACKAGE_PREFIX}-libltdl")
 pkgver=2.5.4
-pkgrel=1
+pkgrel=2
 pkgdesc="A generic library support script (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -29,6 +29,7 @@ source=(https://ftp.gnu.org/gnu/libtool/${_realname}-${pkgver}.tar.xz{,.sig}
         0005-libtool-include-process.h.patch
         0006-Pass-various-flags-to-GCC.patch
         0007-msysize.patch
+        0008-flang-linker-driver-options.patch
         0011-Pick-up-clang_rt-static-archives-compiler-internal-l.patch
         0013-Allow-statically-linking-compiler-support-libraries-.patch
         0014-Support-llvm-objdump-f-output.patch)
@@ -41,6 +42,7 @@ sha256sums=('f81f5860666b0bc7d84baddefa60d1cb9fa6fceb2398cc3baca6afaa60266675'
             '0dd70a4f955ed4cd94a0d13b784b7db7dddbd4d1d6ee5b092202f8b9496fd3eb'
             '2cb1b61247a4632698ac7e26c496c3ad8c1b4fde080d301994dbddc0794a4bf4'
             'acec8e76b0d65c7b5f442203b2446d92a2f81ceaaa211cd2e6b8a036f5115280'
+            '5b63612976d5f64f1b2805358ca42364ec0482b1db32d3aaa7db5e28638a797a'
             'de68dc9387f47ee129f55b2f525a7d222374ddd8915f4f42af05f185b779b826'
             '8069e887aeeab7491f15e00547fa66d9b9e86407f5a23f37a6d8c7d165de752e'
             'e62e836f018339974f5ef7cf81bc0a4252901158eb0824eb62d0270206093ad7')
@@ -68,6 +70,7 @@ prepare() {
     0005-libtool-include-process.h.patch \
     0006-Pass-various-flags-to-GCC.patch \
     0007-msysize.patch \
+    0008-flang-linker-driver-options.patch \
     0011-Pick-up-clang_rt-static-archives-compiler-internal-l.patch \
     0013-Allow-statically-linking-compiler-support-libraries-.patch \
     0014-Support-llvm-objdump-f-output.patch


### PR DESCRIPTION
If LLVM Flang 19 is used as the linker driver, it fails on the `-Xlinker` flag.
Pass options to the linker with the `-Wl,` flag instead.

This change is required to build fgsl with LLVM Flang (see #23563).
