### PR TITLE
godot: update to 4.4

### DIFF
--- a/mingw-w64-godot/001-fix-llvm-duplicate-symbol.patch
+++ b/mingw-w64-godot/001-fix-llvm-duplicate-symbol.patch
@@ -1,13 +1,13 @@
 diff --git a/drivers/wasapi/audio_driver_wasapi.cpp b/drivers/wasapi/audio_driver_wasapi.cpp
-index a349a66..40e1d5a 100644
+index 28b3a3b..6c72756 100644
 --- a/drivers/wasapi/audio_driver_wasapi.cpp
 +++ b/drivers/wasapi/audio_driver_wasapi.cpp
-@@ -97,7 +97,7 @@ __CRT_UUID_DECL(IAudioClient3, 0x7ED4EE07, 0x8E67, 0x4CD4, 0x8C, 0x1A, 0x2B, 0x7
+@@ -102,7 +102,7 @@ __CRT_UUID_DECL(IAudioClient3, 0x7ED4EE07, 0x8E67, 0x4CD4, 0x8C, 0x1A, 0x2B, 0x7
  	const PROPERTYKEY id = { { a, b, c, { d, e, f, g, h, i, j, k, } }, l };
  /* clang-format on */
  
--DEFINE_PROPERTYKEY(PKEY_Device_FriendlyName, 0xa45c254e, 0xdf1c, 0x4efd, 0x80, 0x20, 0x67, 0xd1, 0x46, 0xa8, 0x50, 0xe0, 14);
-+// DEFINE_PROPERTYKEY(PKEY_Device_FriendlyName, 0xa45c254e, 0xdf1c, 0x4efd, 0x80, 0x20, 0x67, 0xd1, 0x46, 0xa8, 0x50, 0xe0, 14);
+-DEFINE_PROPERTYKEY(PKEY_Device_FriendlyNameGodot, 0xa45c254e, 0xdf1c, 0x4efd, 0x80, 0x20, 0x67, 0xd1, 0x46, 0xa8, 0x50, 0xe0, 14);
++// DEFINE_PROPERTYKEY(PKEY_Device_FriendlyNameGodot, 0xa45c254e, 0xdf1c, 0x4efd, 0x80, 0x20, 0x67, 0xd1, 0x46, 0xa8, 0x50, 0xe0, 14);
  #endif
  
  const CLSID CLSID_MMDeviceEnumerator = __uuidof(MMDeviceEnumerator);

--- a/mingw-w64-godot/002-enforcing-pkgconfig-for-syslib.patch
+++ b/mingw-w64-godot/002-enforcing-pkgconfig-for-syslib.patch
@@ -1,11 +1,11 @@
 diff --git a/platform/windows/detect.py b/platform/windows/detect.py
-index b4830c5..bdaa150 100644
+index bbdcb9e..60bd8c0 100644
 --- a/platform/windows/detect.py
 +++ b/platform/windows/detect.py
-@@ -825,6 +825,82 @@ def configure_mingw(env: "SConsEnvironment"):
-     # resrc
-     env.Append(BUILDERS={"RES": env.Builder(action=build_res_file, suffix=".o", src_suffix=".rc")})
+@@ -903,6 +903,79 @@ def configure_mingw(env: "SConsEnvironment"):
+         env.Prepend(CPPPATH=["#thirdparty/angle/include"])
  
+     env.Append(CPPDEFINES=["MINGW_ENABLED", ("MINGW_HAS_SECURE_API", 1)])
 +    # freetype depends on libpng and zlib, so bundling one of them while keeping others
 +    # as shared libraries leads to weird issues
 +    if env["builtin_freetype"] or env["builtin_libpng"] or env["builtin_zlib"]:
@@ -73,9 +73,6 @@ index b4830c5..bdaa150 100644
 +    if not env["builtin_openxr"]:
 +        env.ParseConfig("pkg-config openxr --cflags --libs")
 +
-+    if not env["builtin_squish"]:
-+        env.ParseConfig("pkg-config libsquish --cflags --libs")
-+
 +    if not env["builtin_zlib"]:
 +        env.ParseConfig("pkg-config zlib --cflags --libs")
 +
@@ -83,5 +80,5 @@ index b4830c5..bdaa150 100644
 +        env.ParseConfig("pkg-config libzstd --cflags --libs")
 +
  
+ 
  def configure(env: "SConsEnvironment"):
-     # Validate arch.

--- a/mingw-w64-godot/PKGBUILD
+++ b/mingw-w64-godot/PKGBUILD
@@ -5,8 +5,8 @@
 _realname=godot
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-pkgver=4.3
-pkgrel=3
+pkgver=4.4
+pkgrel=1
 pkgdesc='An advanced, feature packed, multi-platform 2D and 3D game engine (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -36,20 +36,18 @@ depends=("${MINGW_PACKAGE_PREFIX}-brotli"
          "${MINGW_PACKAGE_PREFIX}-wslay"
          "${MINGW_PACKAGE_PREFIX}-mbedtls"
          "${MINGW_PACKAGE_PREFIX}-openxr-sdk"
-         "${MINGW_PACKAGE_PREFIX}-libsquish"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-zstd")
 optdepends=()
 source=("https://github.com/godotengine/godot/releases/download/${pkgver}-stable/${_realname}-${pkgver}-stable.tar.xz"
-        "001-fix-llvm-duplicate-symbol.patch"
+        #"001-fix-llvm-duplicate-symbol.patch"
         "002-enforcing-pkgconfig-for-syslib.patch")
-sha256sums=('751e55bfad8e04b846f9cf7b6eb80e058986a2cb1b103fc0fe6a4d8526a20e56'
-            '47fe087a3bf5cf64bbf168c327c48eb947ec623b4476dbad342b756d566b73c3'
-            '65f9750dc991df3d53edba40ea48ab802c5550cc70b9bfcb9274dfd83e7f2906')
+sha256sums=('74053aa6a19b8751fec89a527c722e32de4d94442ec2525970c108aea89dd3e8'
+            '133971d7ae5c2d0689b19dc09faa3d2ef5aefa4a848f8e1c1efe305051d1f88f')
 
 prepare() {
   cd ${_realname}-${pkgver}-stable
-  patch -p1 -i "../../001-fix-llvm-duplicate-symbol.patch"
+  #patch -p1 -i "../../001-fix-llvm-duplicate-symbol.patch"
   patch -p1 -i "../../002-enforcing-pkgconfig-for-syslib.patch"
 }
 
@@ -85,7 +83,6 @@ build() {
     builtin_wslay=no\
     builtin_mbedtls=no\
     builtin_openxr=no\
-    builtin_squish=no\
     builtin_zlib=no\
     builtin_zstd=no\
     "${extra_config[@]}"


### PR DESCRIPTION
Update Godot game engine to 4.4-stable.

There are few changes:
1. Jolt-physic is introduced in this new release, but for some reasons their build scripts do not allow using an external instance of it. Therefore we can not dynamically link to msys2's Jolt-physic. Maybe it contains modifications just for Godot.
2. libsquish is removed.
3. Patch used for LLVM workaround is no longer needed but ketp just in case the issue comes back again. I would like to keep it for at least 1 stable release and see how things going on 4.5-stable.