### PR TITLE
fpm: update to v0.11.0

### DIFF
--- a/mingw-w64-fpm/001-fix-windows-CRLF.patch
+++ b/mingw-w64-fpm/001-fix-windows-CRLF.patch
@@ -1,0 +1,105 @@
+diff --git a/src/fpm_filesystem.F90 b/src/fpm_filesystem.F90
+index a0066708d..0e7e221b7 100644
+--- a/src/fpm_filesystem.F90
++++ b/src/fpm_filesystem.F90
+@@ -7,7 +7,7 @@ module fpm_filesystem
+                                OS_UNKNOWN, OS_LINUX, OS_MACOS, OS_WINDOWS, &
+                                OS_CYGWIN, OS_SOLARIS, OS_FREEBSD, OS_OPENBSD
+     use fpm_environment, only: separator, get_env, os_is_unix
+-    use fpm_strings, only: f_string, replace, string_t, split, split_first_last, dilate, str_begins_with_str
++    use fpm_strings, only: f_string, replace, string_t, split, split_lines_first_last, dilate, str_begins_with_str
+     use iso_c_binding, only: c_char, c_ptr, c_int, c_null_char, c_associated, c_f_pointer
+     use fpm_error, only : fpm_stop, error_t, fatal_error
+     implicit none
+@@ -51,8 +51,6 @@ module fpm_filesystem
+     end interface
+ #endif
+ 
+-    character(*), parameter :: eol = new_line('a')    !! End of line
+-
+ contains
+ 
+ !> Extract filename from path with/without suffix
+@@ -319,7 +317,7 @@ function read_lines_expanded(filename) result(lines)
+         return
+     end if
+ 
+-    call split_first_last(content, eol, first, last)  ! TODO: \r (< macOS X), \n (>=macOS X/Linux/Unix), \r\n (Windows)
++    call split_lines_first_last(content, first, last)  
+ 
+     ! allocate lines from file content string
+     allocate (lines(size(first)))
+@@ -344,7 +342,7 @@ function read_lines(filename) result(lines)
+         return
+     end if
+ 
+-    call split_first_last(content, eol, first, last)  ! TODO: \r (< macOS X), \n (>=macOS X/Linux/Unix), \r\n (Windows)
++    call split_lines_first_last(content, first, last) 
+ 
+     ! allocate lines from file content string
+     allocate (lines(size(first)))
+diff --git a/src/fpm_strings.f90 b/src/fpm_strings.f90
+index bf43a4b53..b03927199 100644
+--- a/src/fpm_strings.f90
++++ b/src/fpm_strings.f90
+@@ -42,7 +42,7 @@ use iso_c_binding, only: c_char, c_ptr, c_int, c_null_char, c_associated, c_f_po
+ implicit none
+ 
+ private
+-public :: f_string, lower, upper, split, split_first_last, str_ends_with, string_t, str_begins_with_str
++public :: f_string, lower, upper, split, split_first_last, split_lines_first_last, str_ends_with, string_t, str_begins_with_str
+ public :: to_fortran_name, is_fortran_name
+ public :: string_array_contains, string_cat, len_trim, operator(.in.), fnv_1a
+ public :: replace, resize, str, join, glob
+@@ -551,6 +551,51 @@ pure subroutine split_first_last(string, set, first, last)
+ 
+ end subroutine split_first_last
+ 
++!! Author: Federico Perini
++!! Computes the first and last indices of lines in input string, delimited
++!! by either CR, LF, or CRLF, and stores them into first and last output
++!! arrays.
++pure subroutine split_lines_first_last(string, first, last)
++    character(*), intent(in) :: string
++    integer, allocatable, intent(out) :: first(:)
++    integer, allocatable, intent(out) :: last(:)
++
++    integer, dimension(len(string) + 1) :: istart, iend
++    integer :: p, n, slen
++    character, parameter :: CR = achar(13)
++    character, parameter :: LF = new_line('A')
++
++    slen = len(string)
++
++    n = 0
++    if (slen > 0) then
++        p = 1
++        do while (p <= slen)
++            
++            if (index(CR//LF, string(p:p)) == 0) then
++                n = n + 1
++                istart(n) = p
++                do while (p <= slen)
++                    if (index(CR//LF, string(p:p)) /= 0) exit
++                    p = p + 1
++                end do
++                iend(n) = p - 1
++            end if
++            
++            ! Handle Windows CRLF by skipping LF after CR
++            if (p < slen) then 
++               if (string(p:p) == CR .and. string(p+1:p+1) == LF) p = p + 1
++            endif
++            
++            p = p + 1
++        end do
++    end if
++
++    first = istart(:n)
++    last = iend(:n)
++
++end subroutine split_lines_first_last
++
+ !! Author: Milan Curcic
+ !! If back is absent, computes the leftmost token delimiter in string whose
+ !! position is > pos. If back is present and true, computes the rightmost

--- a/mingw-w64-fpm/PKGBUILD
+++ b/mingw-w64-fpm/PKGBUILD
@@ -3,10 +3,11 @@
 _realname=fpm
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.10.0
+pkgver=0.11.0
 pkgrel=1
+_bootstrap_ver=0.8.2
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 pkgdesc="Fortran package manager (mingw-w64)"
 url="https://github.com/fortran-lang/fpm"
 license=('spdx:MIT')
@@ -16,11 +17,19 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 makedepends=("${MINGW_PACKAGE_PREFIX}-fc"
              "git")
 optdepends=("git: Support for fetching projects with git")
-source=(${_realname}-${pkgver}.zip::"${url}/releases/download/v${pkgver}/fpm-${pkgver}.zip"
-        ${_realname}-${pkgver}.F90::"${url}/releases/download/v${pkgver}/fpm-${pkgver}.F90")
-sha256sums=('00d687e17bdada4dcae0ff1ea2e01bad287dcc77a74c3bbde0c9ff9633b655bb'
-            '48e563db74af6b9396ebe4a67bd371210e2ea8c6e2b3cc230e68183ce7509422')
-noextract=(${_realname}-${pkgver}.F90)
+_bootstrap_src=${_realname}-${bootstrap}.F90
+source=("${url}/releases/download/v${pkgver}/fpm-${pkgver}.zip"
+        "${url}/releases/download/v${_bootstrap_ver}/fpm-${_bootstrap_ver}.F90"
+        "001-fix-windows-CRLF.patch")
+sha256sums=('f6c998c9afd39eb42c7e80a306cfbed5faa77eaa42eb4f75b93864c338db1795'
+            '0c95309f365a40900108f3325e17e99a0456ce76046c37326349bf61b3df447a'
+            'e942e9763668ad42d865c14c6b04e315fd8e722fb59aeb2ad0e8cf9f7b96fb5a')
+noextract=(${_bootstrap_src})
+
+prepare() {
+  cd "${srcdir}/fpm-${pkgver}"
+  patch -p1 -i "${srcdir}"/001-fix-windows-CRLF.patch
+}
 
 build() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -34,7 +43,7 @@ build() {
   fi
 
   mkdir -p "${_build}/bootstrap"
-  "${_fc}" -J "${_build}/bootstrap" -o "${_build}/bootstrap/fpm" "${srcdir}"/${_realname}-${pkgver}.F90
+  "${_fc}" -J "${_build}/bootstrap" -o "${_build}/bootstrap/fpm" "${srcdir}"/fpm-${_bootstrap_ver}.F90
 
   "${_build}/bootstrap/fpm" install \
     --compiler "${_fc}" \
@@ -44,6 +53,8 @@ build() {
 
 package() {
   cd "${srcdir}/${_realname}-${pkgver}"
+
   install -Dm755 build-${MSYSTEM}/bin/fpm "${pkgdir}"${MINGW_PREFIX}/bin/fpm
+
   install -Dm644 LICENSE "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
 }


### PR DESCRIPTION
Compile mingw-w64-fpm using a more stable single-source fpm bootstrap file fpm-0.8.2.F90 and update the mingw-w64-fpm version to 0.11.0.