### PR TITLE
uutils-coreutils: depend on gcc-libs

### DIFF
--- a/mingw-w64-uutils-coreutils/PKGBUILD
+++ b/mingw-w64-uutils-coreutils/PKGBUILD
@@ -4,7 +4,7 @@ _realname=coreutils
 pkgbase=mingw-w64-uutils-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-uutils-${_realname}")
 pkgver=0.0.30
-pkgrel=1
+pkgrel=2
 pkgdesc="Cross-platform Rust rewrite of the GNU coreutils (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -14,7 +14,7 @@ msys2_references=(
   'purl: pkg:cargo/coreutils'
 )
 license=('spdx:MIT')
-depends=("${MINGW_PACKAGE_PREFIX}-oniguruma")
+depends=("${MINGW_PACKAGE_PREFIX}-oniguruma" "${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust" "${MINGW_PACKAGE_PREFIX}-pkgconf")
 source=("https://github.com/uutils/coreutils/archive/${pkgver}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('732c0ac646be7cc59a51cdfdb2d0ff1a4d2501c28f900a2d447c77729fdfca22')
@@ -29,6 +29,7 @@ build() {
   cd "${_realname}-${pkgver}"
 
   export RUSTONIG_DYNAMIC_LIBONIG=1
+  export RUSTFLAGS="$RUSTFLAGS -C target-feature=-crt-static"
   make PROFILE=release
 }
 


### PR DESCRIPTION
linking dynamic libonig making rustc link libunwind.dll on CLANG* automatically. unconditional dependency on gcc-libs shouldn't hurt too much there. also set RUSTFLAGS to explicitly disable crt-static