### PR TITLE
zed: update to 0.177.9

### DIFF
--- a/mingw-w64-zed/.gitignore
+++ b/mingw-w64-zed/.gitignore
@@ -1,2 +1,3 @@
 /zed
 /aws-lc-rs
+/aws-lc

--- a/mingw-w64-zed/PKGBUILD
+++ b/mingw-w64-zed/PKGBUILD
@@ -4,7 +4,7 @@ _realname=zed
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
-pkgver=0.177.8
+pkgver=0.177.9
 pkgrel=1
 pkgdesc="A high-performance, multiplayer code editor (mingw-w64)"
 arch=('any')
@@ -44,24 +44,27 @@ if [[ ${MSYSTEM} != CLANG* ]]; then
   optdepends+=("${MINGW_PACKAGE_PREFIX}-mesonlsp: for 'Meson' extension")
 fi
 source=("git+${msys2_repository_url}.git#tag=v${pkgver}"
-        "git+https://github.com/aws/aws-lc-rs.git#tag=aws-lc-sys/v0.25.0"
+        "git+https://github.com/aws/aws-lc-rs.git#tag=aws-lc-sys/v0.27.0"
+        "git+https://github.com/aws/aws-lc.git"
         "zstd-sys.tar.gz::https://crates.io/api/v1/crates/zstd-sys/2.0.13+zstd.1.5.6/download"
         "aws-lc-clang-build.patch"
         "zed-dont-vendor-cargo-about.patch"
         "zstd-sys-remove-statik.patch")
-sha256sums=('204e79e0543c9139c04851649c0474909e818efb49576f2cb34b4038912f6420'
-            'f7ef2e96d54e33481b5e4838ee3336a9382b8b7a24767ca47fd39069aa466723'
+sha256sums=('de20f2230ead24800fdf9ef21dcdc7fbcd4d3004ed945a7006c3e4b87aab62dc'
+            '371b865c75caa66947b3b8e4e001e4255577c8320ba8875ae5212d3dc7dcc3a1'
+            'SKIP'
             '38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa'
             '2e3d7ef6fdb3ef8a2ec11207e8120ea34553888116ea8a032cb425a8a6261c39'
             'b126b7a9e3cc8d3d68c49dbfc184d54691b10172dbfd3272d4c2f43424cfca5b'
             '48f4900ceb02d3aaf9a1020f33d56629156e96759f456c0e7ca18bfcf910767b')
 
 prepare() {
+  (cd aws-lc-rs
+  git config submodule."aws-lc-sys/aws-lc".url "${srcdir}/aws-lc"
+  git config submodule."aws-lc-fips-sys/aws-lc".url "${srcdir}/aws-lc"
+  git -c protocol.file.allow=always submodule update --init --recursive)
+
   cd "${_realname}"
-
-  # fetch submodules for aws-lc-rs locally
-  git -C ../aws-lc-rs submodule update --init --recursive
-
   rm rust-toolchain.toml
 
   # use system cargo about to generate license file
@@ -83,7 +86,7 @@ prepare() {
     git config --global core.longpaths true
   fi
 
-  cargo update -p aws-lc-sys -p zstd-sys
+  cargo update -p aws-lc-rs -p aws-lc-sys -p zstd-sys
   cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
   # generate license for whole Zed contents
   sh script/generate-licenses
@@ -108,9 +111,6 @@ build() {
   # https://github.com/msys2/MINGW-packages/issues/22071
   export RUSTFLAGS="$RUSTFLAGS -C link-arg=-fuse-ld=lld -C symbol-mangling-version=v0
     -C target-feature=-crt-static --cfg tokio_unstable --cfg windows_slim_errors"
-
-  # set path to aws-lc include explicitly: https://github.com/aws/aws-lc-rs/issues/696
-  export CFLAGS="$CFLAGS -I$(cygpath -am ${srcdir}/aws-lc-rs/aws-lc-sys/aws-lc/include)"
 
   cargo build --release --frozen -p zed -p cli
 


### PR DESCRIPTION
aws-lc-sys@0.27.0 fixed CFLAGS handling so a compile flag workaround is not needed