### PR TITLE
vsg: Fix macro clash in aarch64 when including PipelineBarrier.h

### DIFF
--- a/mingw-w64-vulkanscenegraph/0003-arm64-macro-clash.patch
+++ b/mingw-w64-vulkanscenegraph/0003-arm64-macro-clash.patch
@@ -1,0 +1,24 @@
+diff -bur VulkanSceneGraph-1.1.10-orig/include/vsg/commands/PipelineBarrier.h VulkanSceneGraph-1.1.10/include/vsg/commands/PipelineBarrier.h
+--- VulkanSceneGraph-1.1.10-orig/include/vsg/commands/PipelineBarrier.h	2025-03-15 02:15:16 -0600
++++ VulkanSceneGraph-1.1.10/include/vsg/commands/PipelineBarrier.h	2025-03-15 02:17:37 -0600
+@@ -17,6 +17,11 @@
+ #include <vsg/state/Buffer.h>
+ #include <vsg/state/Image.h>
+ 
++#ifdef _M_ARM64
++#pragma push_macro("MemoryBarrier")
++#undef MemoryBarrier
++#endif
++
+ namespace vsg
+ {
+ 
+@@ -157,3 +162,7 @@
+     VSG_type_name(vsg::PipelineBarrier);
+ 
+ } // namespace vsg
++
++#ifdef _M_ARM64
++#pragma pop_macro("MemoryBarrier")
++#endif
+\ No newline at end of file

--- a/mingw-w64-vulkanscenegraph/PKGBUILD
+++ b/mingw-w64-vulkanscenegraph/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname,,}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname,,}"
          "${MINGW_PACKAGE_PREFIX}-${_realname,,}-docs")
 pkgver=1.1.10
-pkgrel=1
+pkgrel=2
 pkgdesc="Vulkan & C++17 based Scene Graph Project (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -26,9 +26,11 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
 # The '0001-vsg-1.1.3-devendor-glslang.patch' patch
 # copied from https://github.com/microsoft/vcpkg/pull/38294
 source=("${msys2_repository_url}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
-        '0002-vsg-1.1.3-fix-win32-window.patch')
+        '0002-vsg-1.1.3-fix-win32-window.patch'
+        '0003-arm64-macro-clash.patch')
 sha256sums=('b430132ba5454e0616ff5334a7cb9196c0e8f10a925c2106e80a78d6f24ae4b5'
-            '2e6d8b0c2434a98eb67a70afb8643f109592dcea2e6afdbe2f6fe59e6783d792')
+            '2e6d8b0c2434a98eb67a70afb8643f109592dcea2e6afdbe2f6fe59e6783d792'
+            '3f6c1b96edfc24b970287f540a252ba6685b94522a5e92fcfd8f3bc85f091960')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -44,7 +46,8 @@ prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
   apply_patch_with_msg \
-    0002-vsg-1.1.3-fix-win32-window.patch
+    0002-vsg-1.1.3-fix-win32-window.patch \
+    0003-arm64-macro-clash.patch
 }
 
 build() {


### PR DESCRIPTION
This is a known issue from eons ago when there are functions, classes or methods called `MemoryBarrier`. This only affects ARM64:
https://bugreports.qt.io/browse/QTBUG-77388?jql=reporter%20%3D%20hernan.c.martinez
https://codereview.qt-project.org/c/qt/qtbase/+/277243
