### PR TITLE
gnutls: fix the static build

### DIFF
--- a/mingw-w64-gnutls/PKGBUILD
+++ b/mingw-w64-gnutls/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gnutls
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.8.9
-pkgrel=1
+pkgrel=2
 pkgdesc="A library which provides a secure layer over a reliable transport layer (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -92,8 +92,10 @@ build() {
     --disable-rpath \
     --disable-gtk-doc \
     --with-libiconv-prefix=${MINGW_PREFIX} \
+    --without-libintl-prefix \
     --disable-libdane \
     --disable-tests \
+    --without-p11-kit \
     "${extra_config[@]}" \
     gl_cv_double_slash_root=yes
 
@@ -114,6 +116,7 @@ build() {
     --disable-rpath \
     --disable-gtk-doc \
     --with-libiconv-prefix=${MINGW_PREFIX} \
+    --without-libintl-prefix \
     --disable-libdane \
     --disable-tests \
     "${extra_config[@]}" \
@@ -136,6 +139,10 @@ package() {
 
   cd "${srcdir}/build-${MSYSTEM}-shared"
   make DESTDIR="${pkgdir}" install
+
+  # Since we use --without-p11-kit for the static build
+  # use the static .pc which doesn't have p11-kit in Requires.private
+  cp "${srcdir}/build-${MSYSTEM}-static/lib/gnutls.pc" "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/gnutls.pc"
 
   find "${pkgdir}${MINGW_PREFIX}" -name '*.def' -o -name '*.exp' | xargs -rtl1 rm
   local PREFIX_DEPS=$(cygpath -am ${MINGW_PREFIX})


### PR DESCRIPTION
* p11-kit does not support static builds, so avoid depending on it for the static lib only
* make sure p11-kit is also not in Requires.private by using the static .pc file
* Fix libintl import lib being referenced by path in the .pc file by passing --without-libintl-prefix

This fixes static linking against libgnutls.

Fixes #23287