### PR TITLE
gimp: disable debug console

### DIFF
--- a/mingw-w64-gimp/PKGBUILD
+++ b/mingw-w64-gimp/PKGBUILD
@@ -5,7 +5,7 @@ _pkgver=3.0.0
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=${_pkgver}
-pkgrel=1
+pkgrel=2
 pkgdesc="GNU Image Manipulation Program (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -118,6 +118,7 @@ build() {
     -Dlibunwind=false \
     -Dlinux-input=disabled \
     -Dxcursor=disabled \
+    -Dwin32-debug-console=disabled \
     "build-${MSYSTEM}" \
     "gimp-${_pkgver}"
 


### PR DESCRIPTION
it's not needed for release binaries

fixes https://github.com/msys2/MINGW-packages/issues/22629