### PR TITLE
libavif: update to 1.2.1

### DIFF
--- a/mingw-w64-libavif/PKGBUILD
+++ b/mingw-w64-libavif/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=libavif
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.2.0
-pkgrel=2
+pkgver=1.2.1
+pkgrel=1
 pkgdesc="Library for encoding and decoding .avif files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -22,15 +22,17 @@ depends=("${MINGW_PACKAGE_PREFIX}-aom"
          "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
          "${MINGW_PACKAGE_PREFIX}-libpng"
          "${MINGW_PACKAGE_PREFIX}-libsharpyuv"
+         "${MINGW_PACKAGE_PREFIX}-libxml2"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-gdk-pixbuf2"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
-             "${MINGW_PACKAGE_PREFIX}-cc")
+             "${MINGW_PACKAGE_PREFIX}-cc"
+             "git")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-gtest")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/AOMediaCodec/libavif/archive/v${pkgver}.tar.gz")
-sha512sums=('f88eda1c699910a20e63a0aa0bcf782fb67b477c4d99aa88723628a53b0d849f35f73ff6a2e8bb53e170dc77662bde4a5c5c38b655f5adcfb73ddcf7ec264805')
+sha512sums=('13eb641a17c59d70c465995dca6f921e7a40867053b8d8f0792a68aeaf9dde029daacc77df2049ebb8235ae3b1a35651f5b38a37914bdafe3b8884c64822b1e8')
 
 prepare() {
   cd "${_realname}-${pkgver}"
@@ -59,6 +61,7 @@ build() {
     -DAVIF_CODEC_AOM=SYSTEM \
     -DAVIF_CODEC_DAV1D=SYSTEM \
     -DAVIF_LIBSHARPYUV=SYSTEM \
+    -DAVIF_LIBXML2=SYSTEM \
     -S "${_realname}-${pkgver}" \
     -B "build-${MSYSTEM}-static"
 
@@ -76,6 +79,7 @@ build() {
     -DAVIF_CODEC_DAV1D=SYSTEM \
     -DAVIF_BUILD_GDK_PIXBUF=ON \
     -DAVIF_LIBSHARPYUV=SYSTEM \
+    -DAVIF_LIBXML2=SYSTEM \
     -S "${_realname}-${pkgver}" \
     -B "build-${MSYSTEM}-shared"
 


### PR DESCRIPTION
I'm puzzled how 1.2.0 was built, nothing substantial was changed w.r.t. libargparse dependency since?!

https://github.com/AOMediaCodec/libavif/compare/v1.2.0...v1.2.1

It now looks like git needs to be added as makedepends for FetchContent to work (and also libxml2 for some new functionality...).