### PR TITLE
fastfetch: add a missing build dependency

### DIFF
--- a/mingw-w64-fastfetch/PKGBUILD
+++ b/mingw-w64-fastfetch/PKGBUILD
@@ -4,7 +4,7 @@ _realname=fastfetch
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.38.0
-pkgrel=1
+pkgrel=2
 pkgdesc="An actively maintained, feature-rich and performance oriented, neofetch like system information tool (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -19,6 +19,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-vulkan-loader"
              "${MINGW_PACKAGE_PREFIX}-vulkan-headers"
              "${MINGW_PACKAGE_PREFIX}-opencl-icd"
+             "${MINGW_PACKAGE_PREFIX}-opencl-headers"
              "${MINGW_PACKAGE_PREFIX}-cppwinrt")
 optdepends=("${MINGW_PACKAGE_PREFIX}-vulkan-loader: For Vulkan detection support"
             "${MINGW_PACKAGE_PREFIX}-opencl-icd: For OpenCL detection support"


### PR DESCRIPTION
OpenCL needs both headers & runtime (icd) to be built with.

Ref: https://github.com/fastfetch-cli/fastfetch/issues/1621