### PR TITLE
opencolorio: build using sse2neon from repo

### DIFF
--- a/mingw-w64-opencolorio/PKGBUILD
+++ b/mingw-w64-opencolorio/PKGBUILD
@@ -6,7 +6,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 pkgver=2.4.2
-pkgrel=2
+pkgrel=3
 pkgdesc="A color management framework for visual effects and animation (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -29,6 +29,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-pybind11"
              "${MINGW_PACKAGE_PREFIX}-pystring"
              "${MINGW_PACKAGE_PREFIX}-python"
+             $( [[ "${CARCH}" != "aarch64" ]] \
+                || echo "${MINGW_PACKAGE_PREFIX}-sse2neon" )
              "${MINGW_PACKAGE_PREFIX}-zlib")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-openshadinglanguage")
 optdepends=("${MINGW_PACKAGE_PREFIX}-python: Python bindings")


### PR DESCRIPTION
@lazka I don't think this works around the upstream issue though...