### PR TITLE
mimalloc: remove the `lib` prefix when enabling mimalloc-redirect

### DIFF
--- a/mingw-w64-mimalloc/0002-remove-the-lib-prefix-when-enabling-mimalloc-redirec.patch
+++ b/mingw-w64-mimalloc/0002-remove-the-lib-prefix-when-enabling-mimalloc-redirec.patch
@@ -1,0 +1,27 @@
+From d2c834f3f37f5e473002def7fbf4cf0c567dcdb8 Mon Sep 17 00:00:00 2001
+From: Peiyuan Song <squallatf@gmail.com>
+Date: Mon, 24 Mar 2025 09:39:42 +0800
+Subject: [PATCH] remove the `lib` prefix when enabling mimalloc-redirect for
+ mingw
+
+---
+ CMakeLists.txt | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0d780fa1..e5c5f46a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -592,6 +592,9 @@ if(MI_BUILD_SHARED)
+     # install(FILES "$<TARGET_FILE_DIR:mimalloc>/${mi_libname}.dll.pdb" DESTINATION ${CMAKE_INSTALL_LIBDIR})
+   endif()
+   if(WIN32 AND MI_WIN_REDIRECT)
++    if(MINGW)
++      set_property(TARGET mimalloc PROPERTY PREFIX "")
++    endif()
+     # On windows, link and copy the mimalloc redirection dll too.
+     if(CMAKE_GENERATOR_PLATFORM STREQUAL "arm64ec")
+       set(MIMALLOC_REDIRECT_SUFFIX "-arm64ec")
+-- 
+2.49.0.windows.1
+

--- a/mingw-w64-mimalloc/PKGBUILD
+++ b/mingw-w64-mimalloc/PKGBUILD
@@ -5,7 +5,7 @@ _realname=mimalloc
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.2.2
-pkgrel=1
+pkgrel=2
 pkgdesc='General-purpose allocator with excellent performance characteristics (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -16,14 +16,17 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 source=("https://github.com/microsoft/${_realname}/archive/refs/tags/v${pkgver}.tar.gz"
-        "0001-fix-import-lib.patch")
+        "0001-fix-import-lib.patch"
+        "0002-remove-the-lib-prefix-when-enabling-mimalloc-redirec.patch")
 sha256sums=('0f9dc18b1b0b664e68dd57c537b9edc3e8c3b5e12932cff0d4277134318ee930'
-            '23d4e33be33e542ba891c3b6c953c115c0a59e65e4f132ce90adb15df7695a3e')
+            '23d4e33be33e542ba891c3b6c953c115c0a59e65e4f132ce90adb15df7695a3e'
+            '24d056016a817d334e3edd296d589bfd989f3084635b24c7d8f01ccd3c23879c')
 
 prepare() {
   cd ${_realname}-${pkgver}
 
   patch -Np1 -i ../0001-fix-import-lib.patch
+  patch -Np1 -i ../0002-remove-the-lib-prefix-when-enabling-mimalloc-redirec.patch
 }
 
 build() {


### PR DESCRIPTION
The mimalloc-redirect feature supports only the following library names: `mimalloc.dll`, `mimalloc-override.dll`, `mimalloc-secure.dll`, `mimalloc-secure-debug.dll`, `mimalloc-debug.dll`, and `mimalloc-release.dll`, none of which include the `lib` prefix.
https://github.com/microsoft/mimalloc/pull/1045