### PR TITLE
mold: on windows, mimalloc should be loaded before other libraries

### DIFF
--- a/mingw-w64-mold/0001-on-windows-mimalloc-should-be-loaded-before-other-li.patch
+++ b/mingw-w64-mold/0001-on-windows-mimalloc-should-be-loaded-before-other-li.patch
@@ -1,0 +1,30 @@
+From d9ff76ef46f2dc75315ffcc183da3719a2005f70 Mon Sep 17 00:00:00 2001
+From: Peiyuan Song <squallatf@gmail.com>
+Date: Mon, 24 Mar 2025 10:27:45 +0800
+Subject: [PATCH] on windows, mimalloc should be loaded before other libraries.
+
+---
+ CMakeLists.txt | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 228fcb4e..b9ea9312 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -192,7 +192,12 @@ cmake_dependent_option(
+ if(MOLD_USE_MIMALLOC)
+   if(MOLD_USE_SYSTEM_MIMALLOC)
+     find_package(mimalloc REQUIRED)
+-    target_link_libraries(mold PRIVATE mimalloc)
++    if (WIN32)
++      get_target_property(libraries mold LINK_LIBRARIES)
++      set_property(TARGET mold PROPERTY LINK_LIBRARIES "mimalloc;${libraries}")
++    else()
++      target_link_libraries(mold PRIVATE mimalloc)
++    endif()
+   else()
+     function(mold_add_mimalloc)
+       set(MI_BUILD_STATIC ON CACHE INTERNAL "")
+-- 
+2.49.0.windows.1
+

--- a/mingw-w64-mold/PKGBUILD
+++ b/mingw-w64-mold/PKGBUILD
@@ -4,7 +4,7 @@ _realname=mold
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.37.1
-pkgrel=2
+pkgrel=3
 pkgdesc="A Modern Linker (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -25,9 +25,11 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 source=("https://github.com/rui314/mold/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
-        "002-cmake-copy-instead-symlink.patch")
+        "002-cmake-copy-instead-symlink.patch"
+        "0001-on-windows-mimalloc-should-be-loaded-before-other-li.patch")
 sha256sums=('b8e36086c95bd51e9829c9755c138f5c4daccdd63b6c35212b84229419f3ccbe'
-            '0c0c755132035defbe857977fd1c0dcd4251f4a241506f1f249ce5be3c534576')
+            '0c0c755132035defbe857977fd1c0dcd4251f4a241506f1f249ce5be3c534576'
+            '976ffb1807daeb395418cd4161b70910def0409034b38aaf838328de75de87cb')
 noextract=(${_realname}-${pkgver}.tar.gz)
 
 prepare() {
@@ -35,6 +37,7 @@ prepare() {
   cd ${_realname}-${pkgver}
 
   patch -p1 -i "${srcdir}"/002-cmake-copy-instead-symlink.patch
+  patch -p1 -i "${srcdir}"/0001-on-windows-mimalloc-should-be-loaded-before-other-li.patch
 }
 
 build() {


### PR DESCRIPTION
Depends on #23754