### PR TITLE
mimalloc: drop mimalloc-redirect, not open source

### DIFF
--- a/mingw-w64-mimalloc/PKGBUILD
+++ b/mingw-w64-mimalloc/PKGBUILD
@@ -5,7 +5,7 @@ _realname=mimalloc
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.2.2
-pkgrel=2
+pkgrel=3
 pkgdesc='General-purpose allocator with excellent performance characteristics (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -37,6 +37,7 @@ build() {
       -DMI_BUILD_OBJECT=OFF \
       -DMI_INSTALL_TOPLEVEL=ON \
       -DMI_BUILD_TESTS=OFF \
+      -DMI_WIN_REDIRECT=OFF \
       -S ${_realname}-${pkgver} \
       -B build-${MSYSTEM}
 


### PR DESCRIPTION
It just copies pre-built binaries that mimalloc has in git.

See https://github.com/microsoft/mimalloc/issues/836