### PR TITLE
openexr: update to 3.3.3

### DIFF
--- a/mingw-w64-openexr/PKGBUILD
+++ b/mingw-w64-openexr/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=openexr
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=3.3.2
+pkgver=3.3.3
 pkgrel=1
 pkgdesc='A high dynamic-range image file format library (mingw-w64)'
 arch=('any')
@@ -32,10 +32,12 @@ replaces=(
 )
 source=("https://github.com/openexr/openexr/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
         0006-cmake-soversion.patch
-        0007-export-TypedAttribute-value.patch)
-sha256sums=('5013e964de7399bff1dd328cbf65d239a989a7be53255092fa10b85a8715744d'
+        0007-export-TypedAttribute-value.patch
+        "https://github.com/AcademySoftwareFoundation/openexr/pull/2011.patch")
+sha256sums=('0ffbd842a7ee2128d44affdea30f42294b4061293cde3aa75b61a53573413d1e'
             '5653da878ebbf5f3087bb529213931b48e151aef082b34e19d189e22be0411e7'
-            '204777b48cde1c4d390789f10c5e429d5295be701f68a7937a90d0ecf271c048')
+            '204777b48cde1c4d390789f10c5e429d5295be701f68a7937a90d0ecf271c048'
+            'e88b851dafb7ecb34b8dce94b8f935cab6b3e1821a56289f6ea1ae0650361bdd')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -49,14 +51,14 @@ apply_patch_with_msg() {
 prepare(){
   cd "${srcdir}/${_realname}-${pkgver}"
 
+  # https://github.com/AcademySoftwareFoundation/openexr/pull/2011
   apply_patch_with_msg \
     0006-cmake-soversion.patch \
-    0007-export-TypedAttribute-value.patch
+    0007-export-TypedAttribute-value.patch \
+    2011.patch
 }
 
 build() {
-  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
-
   declare -a extra_config
   if check_option "debug" "n"; then
     extra_config+=("-DCMAKE_BUILD_TYPE=Release")
@@ -67,16 +69,17 @@ build() {
   CXXFLAGS+=" -Wno-ignored-attributes"
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-    ${MINGW_PREFIX}/bin/cmake \
+    cmake \
       -GNinja \
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
       ${extra_config[@]} \
       -DBUILD_SHARED_LIBS=ON \
       -DBUILD_TESTING=OFF \
       -DOPENEXR_BUILD_EXAMPLES=OFF \
-      ../${_realname}-${pkgver}
+      -S "${_realname}-${pkgver}" \
+      -B "build-${MSYSTEM}"
 
-  ${MINGW_PREFIX}/bin/cmake --build .
+  cmake --build "build-${MSYSTEM}"
 }
 
 check() {
@@ -87,8 +90,7 @@ check() {
 }
 
 package() {
-  cd "${srcdir}/build-${MSYSTEM}"
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install ./
+  DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}"
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE.md" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.md"
 }


### PR DESCRIPTION
MINGW32 failure reported [upstream](https://github.com/AcademySoftwareFoundation/openexr/issues/2009).