### PR TITLE
rust: build only rustc and cargo for i686

### DIFF
--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -18,7 +18,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-rust-wasm" \
          "${MINGW_PACKAGE_PREFIX}-rust-src"))
 pkgver=1.85.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -55,7 +55,7 @@ noextract=(${_realname}c-${pkgver}-src.tar.gz)
 sha256sums=('0f2995ca083598757a8d9a293939e569b035799e070f419a686b0996fb94238a'
             'SKIP'
             'da0705f5abaaab7168ccc14f8f340ded61be2bd3ebea86b9834b6acbc8495de8'
-            '77683ad54bf01bfab2af2aa45c098a92b760982f1f996c00d9e490af999b5deb'
+            '8d0aa6a34497f63d451d4bcbf6f48fc0e70ee87419a3ea82535a43f4a07246ba'
             '7cb1773c288ffb1c1e751edc49b1890c84bf9c362742bc5225d19d474edb73a0'
             '56882f1a0f1404c10c7726d6cc37444f2b343e72b969badfcb43760f80db0f32'
             '98bc3f2bd7371a5b8d14fd7b03bf05574e206d1d9e52bcfbe66d71398504da3c'
@@ -166,6 +166,7 @@ build() {
   # Add target wasm32-*
   if [[ ${CARCH} != i686 ]]; then
     sed -i '/target = \[/a\  "wasm32-unknown-unknown", "wasm32-wasip1", "wasm32-wasip1-threads", "wasm32-wasip2",' config.toml
+    sed -i '/tools = \[/a\  "clippy", "rustdoc", "rustfmt", "rust-analyzer-proc-macro-srv", "analysis", "src",' config.toml
   fi
 
   local -a _rust_build=()
@@ -180,11 +181,10 @@ build() {
     # move wasm32-* targets out of the way for splitting
     mkdir -p dest-wasm${MINGW_PREFIX}/lib/rustlib
     mv dest-rust${MINGW_PREFIX}/lib/rustlib/wasm32* dest-wasm${MINGW_PREFIX}/lib/rustlib
+    # move src out of the way for splitting
+    mkdir -p dest-src${MINGW_PREFIX}/lib/rustlib
+    mv dest-rust${MINGW_PREFIX}/lib/rustlib/src dest-src${MINGW_PREFIX}/lib/rustlib
   fi
-
-  # move src out of the way for splitting
-  mkdir -p dest-src${MINGW_PREFIX}/lib/rustlib
-  mv dest-rust${MINGW_PREFIX}/lib/rustlib/src dest-src${MINGW_PREFIX}/lib/rustlib
 
   rm -f dest-rust${MINGW_PREFIX}/lib/rustlib/$OSTYPE/lib/self-contained/*
 }

--- a/mingw-w64-rust/config.toml
+++ b/mingw-w64-rust/config.toml
@@ -20,12 +20,6 @@ locked-deps = true
 vendor = true
 tools = [
   "cargo",
-  "clippy",
-  "rustdoc",
-  "rustfmt",
-  "rust-analyzer-proc-macro-srv",
-  "analysis",
-  "src",
 ]
 sanitizers = true
 profiler = true


### PR DESCRIPTION
cc #23346

there is no sense of using rustfmt or clippy in i686 if you have x86_64 working