### PR TITLE
SDL2_image: drop mingw32

### DIFF
--- a/mingw-w64-SDL2_image/PKGBUILD
+++ b/mingw-w64-SDL2_image/PKGBUILD
@@ -7,7 +7,7 @@ pkgver=2.8.8
 pkgrel=1
 pkgdesc="A simple library to load images of various formats as SDL surfaces (Version 2) (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://github.com/libsdl-org/SDL_image"
 msys2_references=(
   "cpe: cpe:/a:libsdl:sdl2_image"


### PR DESCRIPTION
actually it should be `drop some 32-bit for librsvg rdeps (5/N)`, but there's only one package...

follow-up to #23723 