### PR TITLE
meld3: provide an .exe launcher

### DIFF
--- a/mingw-w64-meld3/PKGBUILD
+++ b/mingw-w64-meld3/PKGBUILD
@@ -5,7 +5,7 @@ _realname=meld
 pkgbase=mingw-w64-${_realname}3
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}3"
 pkgver=3.22.3
-pkgrel=1
+pkgrel=2
 pkgdesc="Visual diff and merge tool (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -27,11 +27,14 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-ninja"
-             "${MINGW_PACKAGE_PREFIX}-itstool")
+             "${MINGW_PACKAGE_PREFIX}-itstool"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz
-        '0001-relocate.patch')
+        '0001-relocate.patch'
+        'pyscript2exe.py')
 sha256sums=('37f7f29eb1ff0fec4d8b088d5483c556de1089f6d018fe6d481993caf2499d84'
-            'e7445dd7d7280dfba815909e6e52de3eb549653f5a02c2744a15707c68428332')
+            'e7445dd7d7280dfba815909e6e52de3eb549653f5a02c2744a15707c68428332'
+            'e57174517b08cf8f9fb4f43a381d342d23d2db3cad661107f35ca21c39b5734d')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -58,9 +61,8 @@ package() {
 
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/meson.exe install
 
-  # Fix shebang line
-  sed -e "s|/usr/bin/python|${MINGW_PREFIX}/bin/python|g" -i "${pkgdir}${MINGW_PREFIX}/bin/meld"
+  python3 "${srcdir}/pyscript2exe.py" "${pkgdir}${MINGW_PREFIX}/bin/meld"
 
   MSYS2_ARG_CONV_EXCL="-d" \
-    python -m compileall -q -d"${MINGW_PREFIX}" "${pkgdir}${MINGW_PREFIX}"
+    python -m compileall -q -d"${MINGW_PREFIX}/lib" "${pkgdir}${MINGW_PREFIX}/lib"
 }

--- a/mingw-w64-meld3/pyscript2exe.py
+++ b/mingw-w64-meld3/pyscript2exe.py
@@ -1,0 +1,19 @@
+"""
+Creates an exe launcher for Python scripts for the executing interpreter.
+foobar.py -> foobar.exe + foobar-script.py
+"""
+
+import sys
+import re
+import os
+from setuptools.command.easy_install import get_win_launcher
+
+path = sys.argv[1]
+with open(path, "rb") as f:
+    data = f.read()
+with open(path, "wb") as f:
+    f.write(re.sub(b"^#![^\n\r]*", b'', data))
+root, ext = os.path.splitext(path)
+with open(root + ".exe", "wb") as f:
+    f.write(get_win_launcher("cli"))
+os.rename(path, root + "-script.py")


### PR DESCRIPTION
So it can be started from native tools

Adjust compileall to not byte compile .py script in /bin