### PR TITLE
libmikmod: disable openal output.

### DIFF
--- a/mingw-w64-libmikmod/PKGBUILD
+++ b/mingw-w64-libmikmod/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libmikmod
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.3.12
-pkgrel=1
+pkgrel=2
 pkgdesc="A portable sound library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -19,8 +19,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              #"${MINGW_PACKAGE_PREFIX}-SDL"
              #"${MINGW_PACKAGE_PREFIX}-SDL2"
              )
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
-         "${MINGW_PACKAGE_PREFIX}-openal")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 source=(https://downloads.sourceforge.net/mikmod/${_realname}-${pkgver}.tar.gz)
 sha256sums=('adef6214863516a4a5b44ebf2c71ef84ecdfeb3444973dacbac70911c9bc67e9')
 
@@ -37,8 +36,8 @@ build() {
     --enable-shared \
     --enable-static \
     --disable-sdl \
-    --disable-sdl2 \
-    --enable-openal
+    --disable-xaudio2 \
+    --disable-openal
 
   make
 }


### PR DESCRIPTION
windows native output drivers are more than enough.

( CC @Biswa96 as the last updater of the pkg )
