### PR TITLE
Groonga: Update to 15.0.4

### DIFF
--- a/mingw-w64-groonga/PKGBUILD
+++ b/mingw-w64-groonga/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=groonga
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=15.0.3
+pkgver=15.0.4
 pkgrel=1
 pkgdesc="An opensource fulltext search engine (mingw-w64)"
 arch=('any')
@@ -28,7 +28,7 @@ makedepends=("git"
              "${MINGW_PACKAGE_PREFIX}-rapidjson"
              "${MINGW_PACKAGE_PREFIX}-ruby"
              "${MINGW_PACKAGE_PREFIX}-xsimd")
-sha256sums=('2728f32f73a20a9b4bf500f11f49418c45e2842a04bebaf3dce0d038b452d114'
+sha256sums=('1123d4101a55ea183c290792ce39253e07f84740e561da70c69f4ce9875357f4'
             'SKIP')
 validpgpkeys=('2701F317CFCCCB975CADE9C2624CF77434839225') # Groonga Key <packages@groonga.org>
 


### PR DESCRIPTION
Groonga version15.0.4 has just released [here](https://github.com/groonga/groonga/releases/tag/v15.0.4).