### PR TITLE
Revert "drop 32-bit for some librsvg rdeps (6/N)"

### DIFF
--- a/mingw-w64-ghostscript/PKGBUILD
+++ b/mingw-w64-ghostscript/PKGBUILD
@@ -6,7 +6,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=10.05.0
 pkgrel=1
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 msys2_references=(
   'archlinux: ghostscript'
   "cpe: cpe:/a:artifex:ghostscript"


### PR DESCRIPTION
Reverts msys2/MINGW-packages#23821 because it's a dependency of gimp 🤦