### PR TITLE
qt-installer-framework: Update to 4.9.0

### DIFF
--- a/mingw-w64-qt-installer-framework/PKGBUILD
+++ b/mingw-w64-qt-installer-framework/PKGBUILD
@@ -4,8 +4,8 @@ _realname=installer-framework
 pkgbase=mingw-w64-qt-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-qt-${_realname}"
 pkgdesc="The Qt Installer Framework used for the Qt SDK installer (mingw-w64)"
-pkgver=4.8.1
-pkgrel=2
+pkgver=4.9.0
+pkgrel=1
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://wiki.qt.io/Qt-Installer-Framework'
@@ -39,10 +39,8 @@ source=(https://download.qt.io/official_releases/qt-${_realname}/${pkgver}/${_re
         "0010-fix-version-pass-to-windres.patch"
         "0011-fix-redefined-mode_t.patch"
         "0012-get_timezone-not-available-on-msvcrt.patch"
-        "qt6_7.patch"::"https://github.com/qtproject/installer-framework/commit/0b1103b41db101d2a509e1bdf5385b29410e41e9.patch"
-        "qt6_8.patch"::"https://github.com/qtproject/installer-framework/commit/d24e8c20ea263e4528f11553a4dfbd93433b203e.patch"
         "qt6_8_2.patch"::"https://github.com/qtproject/installer-framework/commit/252c1e8554130f4f097752913481eceed171a510.patch")
-sha256sums=('150265e124ebfb6947fecff0e6b727f91576090b775459354b00f92b85321558'
+sha256sums=('4e6d937e5b64d9817df5f7308f9972f09b4d693588f556a71cbcf3fcdcf154d2'
             '4100a93ac7e117a32430d22187a4ebe94e7830d94d2c23b85651bc1d95821409'
             '3de4920ee4f04cce6bc791b01e2ee9894958b26c47dcac7a4e2843eb429154b5'
             '2aaf51f346edb6db2367262d0d8e1bb77d0afee51fabd5b2766038a97ebf0ca6'
@@ -51,8 +49,6 @@ sha256sums=('150265e124ebfb6947fecff0e6b727f91576090b775459354b00f92b85321558'
             '2129715e22dac176a669b7c3776b4d7f0bc66a3c01ad262b89dd23ca3825a324'
             'a2eaac4c11e0b6a41f3289657d9e95894a5ed6d625ea98cc41fd4356d2d22a8e'
             '51d50531fa3cc4f68473d51812f5feea128690dc8bc7de379bf9888dae9b9d46'
-            '7e1961f741f0de55b01d568b57a3f4a25841c774b6eb293866272e048d73412a'
-            '586e80274375ace226476ecc8014a8391d9ac1fc70d9e382fb1b25582e815fb8'
             '7550bff6736344f29b9e447c19b2416dbcfb4125e580b5582ca7013c37c43943')
 
 # Helper macros to help make tasks easier #
@@ -65,11 +61,10 @@ apply_patch_with_msg() {
 }
 
 prepare() {
+  mv "${srcdir}"/${_realname}-everywhere-src-master "${srcdir}"/${_realname}-everywhere-src-${pkgver%.*}
   cd "${srcdir}"/${_realname}-everywhere-src-${pkgver%.*}
 
   apply_patch_with_msg \
-    qt6_7.patch \
-    qt6_8.patch \
     qt6_8_2.patch
 
   apply_patch_with_msg \


### PR DESCRIPTION
drop two patches included in the release