### PR TITLE
sdl3-image: update/fix configuration options:

### DIFF
--- a/mingw-w64-sdl3-image/PKGBUILD
+++ b/mingw-w64-sdl3-image/PKGBUILD
@@ -4,7 +4,7 @@ _realname=sdl3-image
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=3.2.4
-pkgrel=1
+pkgrel=2
 pkgdesc="A simple library to load images of various formats as SDL surfaces (Version 3) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -33,6 +33,7 @@ build() {
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
   extra_config+=("-DSDLIMAGE_INSTALL=ON"
+                 "-DSDLIMAGE_BACKEND_STB=OFF"
                  "-DSDLIMAGE_JXL=ON")
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \


### PR DESCRIPTION
- Disable STB option so that libjpg and libpng are actually used.

(This is a similar case to #23804 )
