### PR TITLE
sdl3-ttf: add harfbuzz to depends.

### DIFF
--- a/mingw-w64-sdl3-ttf/PKGBUILD
+++ b/mingw-w64-sdl3-ttf/PKGBUILD
@@ -4,14 +4,15 @@ _realname=sdl3-ttf
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=3.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A library that allows you to use TrueType fonts in your SDL applications (Version 3) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://github.com/libsdl-org/SDL_ttf"
 license=('spdx:Zlib')
 depends=("${MINGW_PACKAGE_PREFIX}-sdl3"
-         "${MINGW_PACKAGE_PREFIX}-freetype")
+         "${MINGW_PACKAGE_PREFIX}-freetype"
+         "${MINGW_PACKAGE_PREFIX}-harfbuzz")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cc")


### PR DESCRIPTION
It was already enabled, but was missed in 'depends' list.
