### PR TITLE
xeve: Update to 0.5.1 and enable aarch64 builds

### DIFF
--- a/mingw-w64-xeve/002-sys-sse2neon.patch
+++ b/mingw-w64-xeve/002-sys-sse2neon.patch
@@ -1,0 +1,12 @@
+diff -bur xeve-0.5.1-orig/src_base/neon/xeve_tq_neon.c xeve-0.5.1/src_base/neon/xeve_tq_neon.c
+--- xeve-0.5.1-orig/src_base/neon/xeve_tq_neon.c	2025-04-03 03:02:28.189114800 -0600
++++ xeve-0.5.1/src_base/neon/xeve_tq_neon.c	2025-04-03 03:02:59.117786700 -0600
+@@ -30,7 +30,7 @@
+ 
+ #include "xeve_def.h"
+ #include "xeve_tq_neon.h"
+-#include "sse2neon.h"
++#include <sse2neon/sse2neon.h>
+ 
+ 
+ typedef union {

--- a/mingw-w64-xeve/PKGBUILD
+++ b/mingw-w64-xeve/PKGBUILD
@@ -3,27 +3,40 @@
 _realname=xeve
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.5.0
-pkgrel=2
+pkgver=0.5.1
+pkgrel=1
 pkgdesc="MPEG-5 EVC (Essential Video Coding) encoder (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://github.com/mpeg5/xeve/'
 license=('spdx:BSD-3-Clause')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
-             "${MINGW_PACKAGE_PREFIX}-cc")
+             "${MINGW_PACKAGE_PREFIX}-cc"
+             $([[ ${CARCH} == aarch64 ]] && echo "${MINGW_PACKAGE_PREFIX}-sse2neon"))
 source=("https://github.com/mpeg5/xeve/archive/refs/tags/v${pkgver}.tar.gz"
-        "010-xeve-disable-werror.patch")
-sha256sums=('4fb593921d2a0b48621f410ccd704d67d6ed1d08ab0aa7c5d5fef519ce596e8a'
-            '8c4b607f34a5d39e824f86d00ab101849595cb49a2f67eed131487d658ec7206')
+        "010-xeve-disable-werror.patch"
+        "002-sys-sse2neon.patch")
+sha256sums=('238c95ddd1a63105913d9354045eb329ad9002903a407b5cf1ab16bad324c245'
+            '8c4b607f34a5d39e824f86d00ab101849595cb49a2f67eed131487d658ec7206'
+            'e297b65a9d7bc251c9944c28ba389716e3a345a0ef71795a47030911d74b360f')
+
+apply_patch_with_msg() {
+  for _fname in "$@"
+  do
+    msg2 "Applying ${_fname}"
+    patch -Nbp1 -i "${srcdir}"/${_fname}
+  done
+}
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
 
   echo "v${pkgver}" > version.txt
 
-  patch -Np1 -i "${srcdir}"/010-xeve-disable-werror.patch
+  apply_patch_with_msg \
+    010-xeve-disable-werror.patch \
+    002-sys-sse2neon.patch
 }
 
 build() {


### PR DESCRIPTION
Simply using a newer sse2neon got it to compile