### PR TITLE
icu: update to 77.1

### DIFF
--- a/mingw-w64-icu/.gitignore
+++ b/mingw-w64-icu/.gitignore
@@ -1,0 +1,1 @@
+reverse_of_ICU-22610.patch

--- a/mingw-w64-icu/PKGBUILD
+++ b/mingw-w64-icu/PKGBUILD
@@ -5,10 +5,10 @@
 _realname=icu
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=76.1
+pkgver=77.1
 pkgrel=1
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 pkgdesc="International Components for Unicode library (mingw-w64)"
 url="https://icu.unicode.org/home/"
 msys2_repository_url="https://github.com/unicode-org/icu"
@@ -21,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools"
              "autoconf-archive")
 source=(https://github.com/unicode-org/icu/releases/download/release-${pkgver//./-}/icu4c-${pkgver//./_}-src.tgz
-        https://sources.debian.org/data/main/i/icu/76.1-2/debian/patches/reverse_of_ICU-22610.patch
+        https://sources.debian.org/data/main/i/icu/76.1-3/debian/patches/reverse_of_ICU-22610.patch
         0011-sbin-dir.mingw.patch
         0012-libprefix.mingw.patch
         0014-mingwize-pkgdata.mingw.patch
@@ -29,7 +29,7 @@ source=(https://github.com/unicode-org/icu/releases/download/release-${pkgver//.
         0016-icu-pkgconfig.patch
         0021-mingw-static-libraries-without-s.patch
         0023-fix-twice-include-platform_make_fragment.patch)
-sha256sums=('dfacb46bfe4747410472ce3e1144bf28a102feeaa4e3875bac9b4c6cf30f4f3e'
+sha256sums=('588e431f77327c39031ffbb8843c0e3bc122c211374485fa87dc5f3faff24061'
             'c515e2b37e230895080d36207dfe078eb638f974220baa487ede2593e820944c'
             '4f4787caeccf70607cf0cbde0c005f05f5c6de1543265a927839122405b4054f'
             'e7ecdafe85e18a4a4b5f29bbfde38776521a848e5b65089a2379b90e59f1592d'

--- a/mingw-w64-qt5-base/0023-fix-build-with-perl-cygwin.patch
+++ b/mingw-w64-qt5-base/0023-fix-build-with-perl-cygwin.patch
@@ -1,0 +1,11 @@
+--- a/bin/syncqt.pl
++++ b/bin/syncqt.pl
+@@ -54,7 +54,7 @@
+ use warnings;
+ use English qw(-no_match_vars );
+ 
+-my $normalizePath_fixDrive = ($^O eq "msys" ? 1 : 0);
++my $normalizePath_fixDrive = ($^O eq "cygwin" ? 1 : 0);
+ 
+ ######################################################################
+ # Syntax:  normalizePath(\$path)

--- a/mingw-w64-qt5-base/PKGBUILD
+++ b/mingw-w64-qt5-base/PKGBUILD
@@ -10,13 +10,13 @@ fi
 _realname=qt5-base
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
-         $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-${_realname}-debug"))
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
 _qtver=5.15.16
 pkgver=${_qtver}+kde+r130
-pkgrel=2
+pkgrel=3
 pkgdesc="A cross-platform application and UI framework (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://www.qt.io/'
 msys2_references=(
   'archlinux: qt5-base'
@@ -43,10 +43,9 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-vulkan-headers"
              "${MINGW_PACKAGE_PREFIX}-zlib"
              "${MINGW_PACKAGE_PREFIX}-zstd"
-             $([[ ${CARCH} != x86_64 ]] || echo "${MINGW_PACKAGE_PREFIX}-firebird")
-             $([[ ${CARCH} == i686 ]] || echo \
-               "${MINGW_PACKAGE_PREFIX}-libmariadbclient" \
-               "${MINGW_PACKAGE_PREFIX}-postgresql")
+             "${MINGW_PACKAGE_PREFIX}-firebird"
+             "${MINGW_PACKAGE_PREFIX}-libmariadbclient"
+             "${MINGW_PACKAGE_PREFIX}-postgresql"
              "git"
              "rsync")
 _pkgfn="${_realname/5-/}"
@@ -74,6 +73,7 @@ source=(git+https://invent.kde.org/qt/qt/$_pkgfn#commit=$_commit
         0020-fix-and-enable-iconv-codec.patch
         0021-enable-mingw-schannel-alpn.patch
         0022-qt-5.8.0-cast-errors.patch
+        0023-fix-build-with-perl-cygwin.patch
         0024-fix-synqt-with-git-build.patch
         0025-enable-avx-support.patch
         0026-fix-mingw-win32-winnt-detection.patch
@@ -102,6 +102,7 @@ sha256sums=('6aa5ed0d12c6053c648311550003c3d10f061871531a96a27968d67478728f2c'
             'c9bdd0ce5f30c6eb940675e45e14179bbab41b743e88cec4679c20dc2d8c9cbf'
             'fec3f368973c004c3fccea4e9d816eb42c02dcb2355714d5c833c8b74b428f11'
             '5397862593005d9af4b218396c4a3975b0e0f039992562ffef4672c0738c4df0'
+            '8276745ca159550a152354e36c36032a2fdbbf58caf9eedd0d95df255cd643d2'
             '18b3dccd9141773026b2a13a79df42ec9196bc6ad77f5feedcbd304b02fa0e6f'
             'e5d22486bf809d9422103471766f4a11d3090acaf9104cfaf333bad1aa1dcc6c'
             '6ceed12f98254c37fb3b1ab68a84214c922bd2c402fea89fa65638d56e567bbb'
@@ -148,6 +149,7 @@ prepare() {
     0020-fix-and-enable-iconv-codec.patch \
     0021-enable-mingw-schannel-alpn.patch \
     0022-qt-5.8.0-cast-errors.patch \
+    0023-fix-build-with-perl-cygwin.patch \
     0024-fix-synqt-with-git-build.patch \
     0025-enable-avx-support.patch \
     0026-fix-mingw-win32-winnt-detection.patch
@@ -162,14 +164,9 @@ prepare() {
     0028-work-around-pyside2-brokenness.patch
 
   local _ARCH_TUNE=
-  case ${MINGW_CHOST} in
-    i686*)
-      _ARCH_TUNE="-march=pentium4 -mtune=generic"
-    ;;
-    x86_64*)
-      _ARCH_TUNE="-march=nocona -msahf -mtune=generic"
-    ;;
-  esac
+  if [[ ${CARCH} == x86_64 ]]; then
+    _ARCH_TUNE="-march=nocona -msahf -mtune=generic"
+  fi
 
   BIGOBJ_FLAGS="-Wa,-mbig-obj"
 
@@ -201,26 +198,9 @@ build() {
 
   declare -a _extra_config
   if check_option "debug" "n"; then
-    _extra_config+=("-release")
-    if [[ ${CARCH} != i686 ]]; then
-      _extra_config+=("-force-debug-info" "-separate-debug-info")
-    fi
+    _extra_config+=("-release" "-force-debug-info" "-separate-debug-info")
   else
     _extra_config+=("-debug")
-  fi
-
-  if [[ ${CARCH} == x86_64 ]]; then
-    _extra_config+=("-plugin-sql-ibase")
-  fi
-
-  if [[ ${CARCH} != i686 ]]; then
-    _extra_config+=("-plugin-sql-psql" "-plugin-sql-mysql")
-  fi
-
-  if [[ ${CARCH} != i686 ]]; then
-    _opengl=dynamic
-  else
-    _opengl=desktop
   fi
 
   ../${_pkgfn}/configure.bat \
@@ -232,7 +212,7 @@ build() {
     -opensource \
     -confirm-license \
     -platform ${_platform} \
-    -opengl ${_opengl} \
+    -opengl dynamic \
     -shared \
     -make-tool make \
     -I${MINGW_PREFIX}/include/mariadb \
@@ -250,6 +230,9 @@ build() {
     -system-zlib \
     -no-iconv \
     -plugin-sql-odbc \
+    -plugin-sql-ibase \
+    -plugin-sql-psql \
+    -plugin-sql-mysql \
     "${_extra_config[@]}"
 
   make
@@ -276,15 +259,11 @@ package_qt5-base() {
            "${MINGW_PACKAGE_PREFIX}-vulkan"
            "${MINGW_PACKAGE_PREFIX}-zlib"
            "${MINGW_PACKAGE_PREFIX}-zstd")
-  if [[ ${CARCH} != i686 ]]; then
-    optdepends=("${MINGW_PACKAGE_PREFIX}-libmariadbclient: MySQL/MariaDB driver"
-                "${MINGW_PACKAGE_PREFIX}-postgresql: PostgreSQL driver"
-                "${MINGW_PACKAGE_PREFIX}-angleproject: ANGLE OpenGL ES API translation layer")
-  fi
-  if [[ ${CARCH} == x86_64 ]]; then
-    optdepends+=("${MINGW_PACKAGE_PREFIX}-firebird: Firebird/iBase driver")
-  fi
-  groups=($([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-qt5"))
+  optdepends=("${MINGW_PACKAGE_PREFIX}-firebird: Firebird/iBase driver"
+              "${MINGW_PACKAGE_PREFIX}-libmariadbclient: MySQL/MariaDB driver"
+              "${MINGW_PACKAGE_PREFIX}-postgresql: PostgreSQL driver"
+              "${MINGW_PACKAGE_PREFIX}-angleproject: ANGLE OpenGL ES API translation layer")
+  groups=("${MINGW_PACKAGE_PREFIX}-qt5")
 
   cd build-${MSYSTEM}
 
@@ -300,11 +279,9 @@ package_qt5-base() {
   install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_realname}
   install -Dm644 $srcdir/${_pkgfn}/LICENSE* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_realname}
 
-  if [[ ${CARCH} != i686 ]]; then
   # Seperate debug-info files
   mv -f "${pkgdir}${MINGW_PREFIX}/lib"/*.debug "${pkgdir}${MINGW_PREFIX}/bin"/ || true
   rsync -armR --remove-source-files --include="*/" --include="*.debug" --exclude="*" --prune-empty-dirs "${pkgdir}"/.${MINGW_PREFIX} "${srcdir}"/${MSYSTEM}-debug/
-  fi
 
   # Fix paths in *.pri, *prl and *.pc files:
   #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m "${pkgdir}"${MINGW_PREFIX})

--- a/mingw-w64-qtwebkit/PKGBUILD
+++ b/mingw-w64-qtwebkit/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _pkgver=5.212.0-alpha4
 pkgver=${_pkgver//-/}
-pkgrel=21
+pkgrel=22
 pkgdesc="Webkit module for Qt5 (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -15,14 +15,6 @@ msys2_references=(
   "cpe: cpe:/a:qt:qtwebkit"
 )
 license=(spdx:LGPL-2.0-only AND BSD-3-Clause)
-makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-ruby"
-             "${MINGW_PACKAGE_PREFIX}-pkgconf"
-             "${MINGW_PACKAGE_PREFIX}-python"
-             "${MINGW_PACKAGE_PREFIX}-qt5-tools"
-             "dos2unix"
-             "gperf")
 depends=("${MINGW_PACKAGE_PREFIX}-icu"
          "${MINGW_PACKAGE_PREFIX}-libxml2"
          "${MINGW_PACKAGE_PREFIX}-libxslt"
@@ -34,6 +26,14 @@ depends=("${MINGW_PACKAGE_PREFIX}-icu"
          "${MINGW_PACKAGE_PREFIX}-qt5-sensors"
          "${MINGW_PACKAGE_PREFIX}-qt5-webchannel"
          "${MINGW_PACKAGE_PREFIX}-woff2")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ruby"
+             "${MINGW_PACKAGE_PREFIX}-pkgconf"
+             "${MINGW_PACKAGE_PREFIX}-python"
+             "${MINGW_PACKAGE_PREFIX}-qt5-tools"
+             "dos2unix"
+             "gperf")
 source=(https://github.com/annulen/webkit/releases/download/qtwebkit-${_pkgver}/${_realname}-${_pkgver}.tar.xz
         0001-fix-build-with-gcc-14.patch
         0003-qtwebkit-mfence-mingw.patch
@@ -165,6 +165,7 @@ build() {
   ${MINGW_PREFIX}/bin/cmake \
     -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
     "${_extra_config[@]}" \
     -DPORT=Qt \
     -DUSE_QT_MULTIMEDIA=ON \


### PR DESCRIPTION
I managed to rebuild all dependent packages except qt5-base and qtwebkit. The latter needs the first to be built first.
There is a regression in msys2-runtime, but I don't know when did it happen.