### PR TITLE
supertuxkart: Make it buildable with CMake 4.0 and enable aarch64 builds

### DIFF
--- a/mingw-w64-supertuxkart/PKGBUILD
+++ b/mingw-w64-supertuxkart/PKGBUILD
@@ -4,10 +4,10 @@ _realname=supertuxkart
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Kart racing game featuring Tux and his friends (mingw-w64)"
 arch=('any')
-mingw_arch=('ucrt64' 'clang64')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
 url='https://supertuxkart.net'
 msys2_repository_url="https://github.com/supertuxkart/stk-code"
 license=('spdx:GPL-3.0-or-later')
@@ -38,13 +38,15 @@ source=("https://github.com/supertuxkart/stk-code/releases/download/${pkgver}/Su
         "add-missing-header.patch::https://github.com/supertuxkart/stk-code/commit/0163e3fa88b72634c3ddff5304c9086b649f53b1.patch"
         "add-missing-header2.patch::https://github.com/supertuxkart/stk-code/commit/27eb0f3116921492e183ad3aa685ddb147ed7183.patch"
         "fix-missing-rotation.patch::https://github.com/supertuxkart/stk-code/commit/0c2b81ac1f9ff29f5012a98f530880b87f416337.patch"
-        "${_realname}-${pkgver}-fix-crash.patch::https://github.com/Benau/stk-code/commit/8544f19b59208ae93fc3db0cf41bd386c6aefbcb.patch")
+        "${_realname}-${pkgver}-fix-crash.patch::https://github.com/supertuxkart/stk-code/commit/8544f19b59208ae93fc3db0cf41bd386c6aefbcb.patch"
+        "require-cmake-3.6.patch::https://github.com/supertuxkart/stk-code/commit/7d4e8433c124c08c62f5335e2a884aeea71cf184.patch")
 sha256sums=('9890392419baf4715313f14d5ad60746f276eed36eb580636caf44e2532c0f03'
             '8a88bf3e9fcfc2204e6ce33686edcaca99660e1a3b15ccaef8e7bbc1fcf003b3'
             '2b7d656c8daf34ea13bb65164e86619793076e410b4435bf2bd145f4d9df6617'
             '8e5054c6345af9baa7ae97483ce91d20a9095941b1a60d663ce2ef74a0c70343'
             '56a97314b89617eb8659a4164ec8ccc5a961c8a743bc99ba4af9a272f0e42202'
-            'f27b4156d6052a0e23ae958788531458a713bb566fd2d563854f03034b8fbbe9')
+            'f27b4156d6052a0e23ae958788531458a713bb566fd2d563854f03034b8fbbe9'
+            'c32425c14acea9b75fdc08bb1c58de237c95cfd1d154455297fbdda6424f7add')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -62,7 +64,8 @@ prepare() {
     "add-missing-header.patch" \
     "add-missing-header2.patch" \
     "fix-missing-rotation.patch" \
-    "${_realname}-${pkgver}-fix-crash.patch"
+    "${_realname}-${pkgver}-fix-crash.patch" \
+    "require-cmake-3.6.patch"
 }
 
 build() {


### PR DESCRIPTION
Requires https://github.com/msys2/MINGW-packages/pull/23886

![image](https://github.com/user-attachments/assets/aac3e068-5650-48b4-b360-afd0125402f7)
