### PR TITLE
pyside6: Update to 6.9.0

### DIFF
--- a/mingw-w64-pyside6/003-skip-remote.patch
+++ b/mingw-w64-pyside6/003-skip-remote.patch
@@ -1,0 +1,26 @@
+--- pyside-setup-everywhere-src-6.9.0/sources/pyside6/CMakeLists.txt.orig	2025-03-31 12:17:07.000000000 +0200
++++ pyside-setup-everywhere-src-6.9.0/sources/pyside6/CMakeLists.txt	2025-04-18 19:31:32.274928300 +0200
+@@ -25,9 +25,9 @@
+     add_subdirectory(libpysideqml)
+ endif()
+ 
+-if(Qt${QT_MAJOR_VERSION}RemoteObjects_FOUND)
+-    add_subdirectory(libpysideremoteobjects)
+-endif()
++#if(Qt${QT_MAJOR_VERSION}RemoteObjects_FOUND)
++#    add_subdirectory(libpysideremoteobjects)
++#endif()
+ 
+ if(Qt${QT_MAJOR_VERSION}UiTools_FOUND)
+     add_subdirectory(plugins/uitools)
+--- pyside-setup-everywhere-src-6.9.0/sources/pyside6/cmake/PySideHelpers.cmake.orig	2025-03-31 12:17:07.000000000 +0200
++++ pyside-setup-everywhere-src-6.9.0/sources/pyside6/cmake/PySideHelpers.cmake	2025-04-18 20:04:30.988060300 +0200
+@@ -105,7 +105,7 @@
+         QuickControls2
+         QuickTest
+         QuickWidgets
+-        RemoteObjects
++#        RemoteObjects
+         Scxml
+         Sensors
+         SerialPort

--- a/mingw-w64-pyside6/PKGBUILD
+++ b/mingw-w64-pyside6/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=(${MINGW_PACKAGE_PREFIX}-shiboken6
          ${MINGW_PACKAGE_PREFIX}-${_realname}
          ${MINGW_PACKAGE_PREFIX}-${_realname}-tools)
-pkgver=6.8.2
+pkgver=6.9.0
 pkgrel=1
 pkgdesc="Enables the use of Qt6 APIs in Python applications (mingw-w64)"
 arch=('any')
@@ -54,15 +54,19 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 _pkgfn=pyside-setup-everywhere-src-${pkgver}
 source=(https://download.qt.io/official_releases/QtForPython/pyside6/PySide6-${pkgver}-src/${_pkgfn}.tar.xz
         001-fix-building-on-mingw.patch
-        002-fix-build-qtexampleicons.patch)
-sha256sums=('8422e9aa403f4119e3192853e9b0cfa09e57e3e0a1a3393e7fdf394179c112f8'
+        002-fix-build-qtexampleicons.patch
+        003-skip-remote.patch)
+sha256sums=('315b73bb7570d5b9e6793a8d3fafd1d2dd7f43d35eebb01d2b554ea206aad88e'
             '5f71b618e0ad687e9282fa4b8c3815beaf69b78666516bfce57cb039822f4ac6'
-            'ad762d906e5e736b87e8fe92efd42045fe51206e6b6845e37d298a15a53ccfa3')
+            'ad762d906e5e736b87e8fe92efd42045fe51206e6b6845e37d298a15a53ccfa3'
+            '8fd95fe629efc2e492c0a0351a7aec3716a79804ac3ffe5b9676b23d859c0d7c')
 
 prepare() {
   cd "${srcdir}"/${_pkgfn}
   patch -p1 -i "${srcdir}"/001-fix-building-on-mingw.patch
   patch -p1 -i "${srcdir}"/002-fix-build-qtexampleicons.patch
+  # https://github.com/msys2/MINGW-packages/pull/23888#issue-2974803968
+  patch -p1 -i "${srcdir}"/003-skip-remote.patch
 }
 
 build() {


### PR DESCRIPTION
```
C:\Windows\system32\cmd.exe /C "cd . && D:\M\msys64\ucrt64\bin\g++.exe -march=nocona -msahf -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wp,-D__USE_MINGW_ANSI_STDIO=1 -DNOMINMAX -Os -DNDEBUG  -Wl,--gc-sections -shared -o sources\pyside6\PySide6\QtRemoteObjects.cp312-mingw_x86_64_ucrt_gnu.pyd -Wl,--major-image-version,0,--minor-image-version,0 sources/pyside6/PySide6/QtRemoteObjects/CMakeFiles/QtRemoteObjects.dir/PySide6/QtRemoteObjects/qabstractitemmodelreplica_wrapper.cpp.obj sources/pyside6/PySide6/QtRemoteObjects/CMakeFiles/QtRemoteObjects.dir/PySide6/QtRemoteObjects/qconnectionabstractserver_wrapper.cpp.obj sources/pyside6/PySide6/QtRemoteObjects/CMakeFiles/QtRemoteObjects.dir/PySide6/QtRemoteObjects/qremoteobjectabstractpersistedstore_wrapper.cpp.obj sources/pyside6/PySide6/QtRemoteObjects/CMakeFiles/QtRemoteObjects.dir/PySide6/QtRemoteObjects/qremoteobjectdynamicreplica_wrapper.cpp.obj sources/pyside6/PySide6/QtRemoteObjects/CMakeFiles/QtRemoteObjects.dir/PySide6/QtRemoteObjects/qremoteobjecthost_wrapper.cpp.obj sources/pyside6/PySide6/QtRemoteObjects/CMakeFiles/QtRemoteObjects.dir/PySide6/QtRemoteObjects/qremoteobjecthostbase_wrapper.cpp.obj sources/pyside6/PySide6/QtRemoteObjects/CMakeFiles/QtRemoteObjects.dir/PySide6/QtRemoteObjects/qremoteobjectnode_wrapper.cpp.obj sources/pyside6/PySide6/QtRemoteObjects/CMakeFiles/QtRemoteObjects.dir/PySide6/QtRemoteObjects/qremoteobjectpendingcall_wrapper.cpp.obj sources/pyside6/PySide6/QtRemoteObjects/CMakeFiles/QtRemoteObjects.dir/PySide6/QtRemoteObjects/qremoteobjectpendingcallwatcher_wrapper.cpp.obj sources/pyside6/PySide6/QtRemoteObjects/CMakeFiles/QtRemoteObjects.dir/PySide6/QtRemoteObjects/qremoteobjectregistry_wrapper.cpp.obj sources/pyside6/PySide6/QtRemoteObjects/CMakeFiles/QtRemoteObjects.dir/PySide6/QtRemoteObjects/qremoteobjectregistryhost_wrapper.cpp.obj sources/pyside6/PySide6/QtRemoteObjects/CMakeFiles/QtRemoteObjects.dir/PySide6/QtRemoteObjects/qremoteobjectreplica_wrapper.cpp.obj sources/pyside6/PySide6/QtRemoteObjects/CMakeFiles/QtRemoteObjects.dir/PySide6/QtRemoteObjects/qtremoteobjects_wrapper.cpp.obj sources/pyside6/PySide6/QtRemoteObjects/CMakeFiles/QtRemoteObjects.dir/PySide6/QtRemoteObjects/qremoteobjectsettingsstore_wrapper.cpp.obj sources/pyside6/PySide6/QtRemoteObjects/CMakeFiles/QtRemoteObjects.dir/PySide6/QtRemoteObjects/qremoteobjectsourcelocationinfo_wrapper.cpp.obj sources/pyside6/PySide6/QtRemoteObjects/CMakeFiles/QtRemoteObjects.dir/PySide6/QtRemoteObjects/qtroclientfactory_wrapper.cpp.obj sources/pyside6/PySide6/QtRemoteObjects/CMakeFiles/QtRemoteObjects.dir/PySide6/QtRemoteObjects/qtroclientiodevice_wrapper.cpp.obj sources/pyside6/PySide6/QtRemoteObjects/CMakeFiles/QtRemoteObjects.dir/PySide6/QtRemoteObjects/qtroiodevicebase_wrapper.cpp.obj sources/pyside6/PySide6/QtRemoteObjects/CMakeFiles/QtRemoteObjects.dir/PySide6/QtRemoteObjects/qtroserverfactory_wrapper.cpp.obj sources/pyside6/PySide6/QtRemoteObjects/CMakeFiles/QtRemoteObjects.dir/PySide6/QtRemoteObjects/qtroserveriodevice_wrapper.cpp.obj sources/pyside6/PySide6/QtRemoteObjects/CMakeFiles/QtRemoteObjects.dir/PySide6/QtRemoteObjects/qtremoteobjects_module_wrapper.cpp.obj  sources/pyside6/libpyside/libpyside6.cp312-mingw_x86_64_ucrt_gnu.dll.a  sources/pyside6/libpysideremoteobjects/libpyside6remoteobjects.a  sources/shiboken6/libshiboken/libshiboken6.cp312-mingw_x86_64_ucrt_gnu.dll.a  D:/M/msys64/ucrt64/lib/libpython3.12.dll.a  D:/M/msys64/ucrt64/lib/libQt6RemoteObjects.dll.a  D:/M/msys64/ucrt64/lib/libQt6Network.dll.a  -lws2_32  D:/M/msys64/ucrt64/lib/libQt6Core.dll.a  -lmpr  -luserenv  -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32 && cd ."
D:/M/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: sources/pyside6/libpysideremoteobjects/libpyside6remoteobjects.a(pysiderephandler.cpp.obj):pysiderephandler.cpp:(.text+0x167b): undefined reference to `PySide::pyStringToQString(_object*)'
D:/M/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: sources/pyside6/libpysideremoteobjects/libpyside6remoteobjects.a(pysidedynamicclass.cpp.obj):pysidedynamicclass.cpp:(.text$_ZN10SourceDefs22capsule_method_handlerEP7_objectS1_[_ZN10SourceDefs22capsule_method_handlerEP7_objectS1_]+0x28a): undefined reference to `PySide::retrieveMetaObject(_object*)'
D:/M/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: sources/pyside6/libpysideremoteobjects/libpyside6remoteobjects.a(pysidedynamicclass.cpp.obj):pysidedynamicclass.cpp:(.text$_ZN10SourceDefs22capsule_method_handlerEP7_objectS1_[_ZN10SourceDefs22capsule_method_handlerEP7_objectS1_]+0x394): undefined reference to `PySide::retrieveMetaObject(_object*)'
D:/M/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: sources/pyside6/libpysideremoteobjects/libpyside6remoteobjects.a(pysidedynamicclass.cpp.obj):pysidedynamicclass.cpp:(.text$_Z22createDynamicClassImplI11ReplicaDefs20QRemoteObjectReplicaEP11_typeobjectP11QMetaObject[_Z22createDynamicClassImplI11ReplicaDefs20QRemoteObjectReplicaEP11_typeobjectP11QMetaObject]+0x2ff): undefined reference to `PySideProperty_TypeF'
D:/M/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: sources/pyside6/libpysideremoteobjects/libpyside6remoteobjects.a(pysidedynamicclass.cpp.obj):pysidedynamicclass.cpp:(.text$_Z22createDynamicClassImplI10SourceDefs7QObjectEP11_typeobjectP11QMetaObject[_Z22createDynamicClassImplI10SourceDefs7QObjectEP11_typeobjectP11QMetaObject]+0x2ff): undefined reference to `PySideProperty_TypeF'
```

Both those things seem to be new in 6.9.0, and optional, so maybe just skip them for now.