### PR TITLE
sundials: update to 7.3.0

### DIFF
--- a/mingw-w64-sundials/PKGBUILD
+++ b/mingw-w64-sundials/PKGBUILD
@@ -37,7 +37,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
            "${MINGW_PACKAGE_PREFIX}-superlu_dist"))
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-fc"
+             $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-fc")
              $([[ "$_enable_mpi" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-msmpi"))
 optdepends=("${MINGW_PACKAGE_PREFIX}-python: for running examples")
 source=(https://github.com/LLNL/sundials/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz
@@ -95,6 +95,15 @@ build() {
                     "-DMPI_CXX_COMPILER=${MINGW_PREFIX}/bin/mpicxx.exe")
   fi
 
+  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
+    _extra_config+=("-DBUILD_FORTRAN_MODULE_INTERFACE=OFF"
+                    "-DEXAMPLES_ENABLE_F2003=OFF")
+  else
+    _extra_config+=("-DBUILD_FORTRAN_MODULE_INTERFACE=ON"
+                    "-DEXAMPLES_ENABLE_F2003=ON"
+                    "-DFortran_INSTALL_MODDIR=include/sundials/fortran")
+  fi
+
   I_MPI_ROOT="" \
   CFLAGS+=" -Wno-return-type -Wno-deprecated-declarations" \
   LDFLAGS+=" -Wl,--export-all-symbols" \
@@ -103,7 +112,6 @@ build() {
     -D BUILD_ARKODE=ON \
     -D BUILD_CVODE=ON \
     -D BUILD_CVODES=ON \
-    -D BUILD_FORTRAN_MODULE_INTERFACE=ON \
     -D BUILD_IDA=ON \
     -D BUILD_IDAS=ON \
     -D BUILD_KINSOL=ON \
@@ -136,7 +144,6 @@ build() {
     -D ENABLE_XBRAID=OFF \
     -D EXAMPLES_ENABLE_C=ON \
     -D EXAMPLES_ENABLE_CXX=ON \
-    -D EXAMPLES_ENABLE_F2003=ON \
     -D EXAMPLES_INSTALL=ON \
     -D EXAMPLES_INSTALL_PATH=${MINGW_PREFIX}/share/sundials/examples \
     -D LAPACK_LIBRARIES=${MINGW_PREFIX}/lib/libopenblas.dll.a \
@@ -146,7 +153,6 @@ build() {
     -D SUNDIALS_PRECISION=DOUBLE \
     -D SUNDIALS_LAPACK_CASE=LOWER \
     -D SUNDIALS_LAPACK_UNDERSCORES=ONE \
-    -D Fortran_INSTALL_MODDIR=include/sundials/fortran \
     -B build-${MSYSTEM} \
     -S ${_realname}-${pkgver}
 

--- a/mingw-w64-sundials/PKGBUILD
+++ b/mingw-w64-sundials/PKGBUILD
@@ -13,7 +13,7 @@ fi
 _realname=sundials
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=7.2.1
+pkgver=7.3.0
 pkgrel=1
 pkgdesc="SUite of Nonlinear and DIfferential/ALgebraic equation Solvers (mingw-w64)"
 arch=('any')
@@ -43,7 +43,7 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-python: for running examples")
 source=(https://github.com/LLNL/sundials/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz
         '0001-fix-building-openmp-example-with-flang.patch'
         '0008-sundials-petsc-pkg-config-module.patch')
-sha256sums=('3781e3f7cdf372ca12f7fbe64f561a8b9a507b8a8b2c4d6ce28d8e4df4befbea'
+sha256sums=('fd970a9023f8ea37b81c5065c067bf1726f656b39f5907b48169a6f98d306ba7'
             '785b7a824702fcc3267cec5d3f9c418dee2940efc9513516c642fd3129e36eb5'
             '46f341d50e97960fd93ee516e7ade99ca5ac87db7d5d077ae09d26da3e4f7355')
 


### PR DESCRIPTION
Also, do not build Fortran modules in CLANG* environments.
Attempting to build them with LLVM Flang fails with errors like:
```
  D:\M\msys64\clang64\bin\flang.exe -ID:\_\B\src\sundials-7.3.0\src\sundials\fmod_int64 -ID:/_/B/src/sundials-7.3.0/include -ID:/_/B/src/build-CLANG64/include -ID:/_/B/src/sundials-7.3.0/src/sundials -ID:/_/B/src/build-CLANG64/src/sundials -ID:/_/B/src/build-CLANG64/fortran_SHARED -O3 -module-dirfortran_SHARED -ffixed-line-length-72 -c src/sundials/fmod_int64/CMakeFiles/sundials_fcore_mod_obj_shared.dir/fsundials_core_mod.f90-pp.f90 -o src/sundials/fmod_int64/CMakeFiles/sundials_fcore_mod_obj_shared.dir/fsundials_core_mod.f90.obj
  error: loc("D:/_/B/src/sundials-7.3.0/src/sundials/fmod_int64/fsundials_core_mod.f90":699:16): D:/M/B/src/flang-20.1.1.src/lib/Optimizer/CodeGen/Target.cpp:105: not yet implemented: returning BIND(C) derived type for this target
  LLVM ERROR: aborting
  PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace.
  Stack dump:
  0.	Program arguments: D:/M/msys64/clang64/bin/flang -fc1 -triple x86_64-w64-windows-gnu -emit-obj -I D:\\_\\B\\src\\sundials-7.3.0\\src\\sundials\\fmod_int64 -I D:/_/B/src/sundials-7.3.0/include -I D:/_/B/src/build-CLANG64/include -I D:/_/B/src/sundials-7.3.0/src/sundials -I D:/_/B/src/build-CLANG64/src/sundials -I D:/_/B/src/build-CLANG64/fortran_SHARED -ffixed-line-length=72 -mrelocation-model pic -pic-level 2 -target-cpu x86-64 -fversion-loops-for-stride -module-dir fortran_SHARED -resource-dir D:/M/msys64/clang64/lib/clang/20 -mframe-pointer=none -O3 -o src/sundials/fmod_int64/CMakeFiles/sundials_fcore_mod_obj_shared.dir/fsundials_core_mod.f90.obj -x f95-cpp-input src/sundials/fmod_int64/CMakeFiles/sundials_fcore_mod_obj_shared.dir/fsundials_core_mod.f90-pp.f90
```