### PR TITLE
gmsh: Enable aarch64 builds

### DIFF
--- a/mingw-w64-gmsh/0005-aarch64-image-base.patch
+++ b/mingw-w64-gmsh/0005-aarch64-image-base.patch
@@ -1,0 +1,12 @@
+diff -bur gmsh-4.13.1-source-o/CMakeLists.txt gmsh-4.13.1-source/CMakeLists.txt
+--- gmsh-4.13.1-source-o/CMakeLists.txt	2025-04-09 05:37:34.446557200 -0600
++++ gmsh-4.13.1-source/CMakeLists.txt	2025-04-09 05:37:51.048837600 -0600
+@@ -1812,7 +1812,7 @@
+ 
+ # OS specific linker options
+ if(WIN32 AND NOT MSVC)
+-  set(FLAGS "-Wl,--stack,16777216 -Wl,--image-base -Wl,0x10000000")
++  set(FLAGS "-Wl,--stack,16777216 -Wl")
+   if(HAVE_FLTK)
+     set(APPFLAGS "${FLAGS} -municode -mwindows")
+     if(HAVE_64BIT_SIZE_T)

--- a/mingw-w64-gmsh/PKGBUILD
+++ b/mingw-w64-gmsh/PKGBUILD
@@ -7,7 +7,7 @@ pkgver=4.13.1
 pkgrel=4
 pkgdesc="3D finite element mesh generator with built-in CAD engine and post-processor (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://gmsh.info"
 msys2_repository_url="https://gitlab.onelab.info/gmsh/gmsh/"
 license=("spdx:GPL-2.0-or-later")
@@ -29,11 +29,15 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 source=(https://gmsh.info/src/gmsh-${pkgver}-source.tgz
         0001-fix-link-lib-name.patch
         0002-fix-dynamic-linking.patch
-        0003-fltk-1.4.patch::https://gitlab.onelab.info/gmsh/gmsh/-/commit/3b3f0f7e16430939b345889a9e31b50104d5baf3.patch)
+        0003-fltk-1.4.patch::https://gitlab.onelab.info/gmsh/gmsh/-/commit/3b3f0f7e16430939b345889a9e31b50104d5baf3.patch
+        0004-cmake-4.0.patch::https://gitlab.onelab.info/gmsh/gmsh/-/commit/499461f6d57b156bc76a8fdc607097426a8545a5.patch
+        0005-aarch64-image-base.patch)
 sha256sums=('77972145f431726026d50596a6a44fb3c1c95c21255218d66955806b86edbe8d'
             'e575ae8fc757694affb6749dc9d52c336691b06159845655ef2ac27aebae8159'
             '4d3f5c4190529e3d45b786adab83f0d65e726357d7367f682ff95b733a88a8c3'
-            'f06d4ce2d45b640531d4556fb3fa41741903a4b27a2f28b1d3a1a82be77a42d0')
+            'f06d4ce2d45b640531d4556fb3fa41741903a4b27a2f28b1d3a1a82be77a42d0'
+            '7b692c1e78168d7fc43b451a34c104079819fe89e80c97f5ba80005040389b0c'
+            '67a06fe851d807d5ba73cfaa32e323ff7fadb4334d19b81d1933e7e8bf21ed22')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -49,7 +53,25 @@ prepare() {
   apply_patch_with_msg \
     0001-fix-link-lib-name.patch \
     0002-fix-dynamic-linking.patch \
-    0003-fltk-1.4.patch
+    0003-fltk-1.4.patch \
+    0004-cmake-4.0.patch
+
+  if [[ ${CARCH} == aarch64 ]]; then
+    apply_patch_with_msg \
+      0005-aarch64-image-base.patch
+
+    # The icons are only provided in binary format for 32 bits
+    # and 64bits without source code
+    msg2 "Creating aarch64 icon resource binary"
+
+    echo "#define IDI_ICON 101" >> src/fltk/Win64Icon.h
+    echo "#include \"Win64Icon.h\"" >> src/fltk/Win64Icon.rc
+    echo "IDI_ICON ICON \"Win64Icon.ico\"" >> src/fltk/Win64Icon.rc
+
+   "${MINGW_PREFIX}"/bin/windres  \
+    -i "src/fltk/Win64Icon.rc" \
+    -o "src/fltk/Win64Icon.res"
+  fi
 }
 
 build() {


### PR DESCRIPTION
Requires https://github.com/msys2/MINGW-packages/pull/23911
![image](https://github.com/user-attachments/assets/38380578-464c-4329-bb8e-4c178ce84cee)

