### PR TITLE
notepad++: Fix document controls in CLANG based builds

### DIFF
--- a/mingw-w64-notepad++/002-windres-codepage.patch
+++ b/mingw-w64-notepad++/002-windres-codepage.patch
@@ -1,0 +1,12 @@
+diff -bur notepad-plus-plus-8.7.9-o/PowerEditor/gcc/makefile notepad-plus-plus-8.7.9/PowerEditor/gcc/makefile
+--- notepad-plus-plus-8.7.9-o/PowerEditor/gcc/makefile	2025-04-09 16:31:12.313789400 -0600
++++ notepad-plus-plus-8.7.9/PowerEditor/gcc/makefile	2025-04-09 16:31:36.979775200 -0600
+@@ -44,7 +44,7 @@
+ 
+ CXXFLAGS := -include $(GCC_DIRECTORY)/gcc-fixes.h -std=c++20
+ RC := $(CROSS_COMPILE)windres
+-RCFLAGS :=
++RCFLAGS := --codepage=65001
+ CPP_PATH := $(SCINTILLA_DIRECTORY)/include $(LEXILLA_DIRECTORY)/include
+ CPP_DEFINE := UNICODE _UNICODE OEMRESOURCE NOMINMAX _WIN32_WINNT=_WIN32_WINNT_WIN7 NTDDI_VERSION=NTDDI_WIN7 TIXML_USE_STL TIXMLA_USE_STL
+ LD := $(CXX)

--- a/mingw-w64-notepad++/PKGBUILD
+++ b/mingw-w64-notepad++/PKGBUILD
@@ -2,7 +2,7 @@ _realname=notepad++
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=8.7.9
-pkgrel=2
+pkgrel=3
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 pkgdesc="Notepad++ is a free (as in “free speech” and also as in “free beer”) source code editor and Notepad replacement that supports several languages."
@@ -22,13 +22,15 @@ source=(
   msys2.readme.txt
   msys2.create.portable.sh
   001-aarch64.patch
+  002-windres-codepage.patch
 )
 validpgpkeys=('14BCE4362749B2B51F8C71226C429F1D8D84F46E')
 sha256sums=('fb2ca0ed1a9c2ff1bb7a9d5a4b45eb59ec053008268c92d33563b3fecaebf8a1'
             'bbb81ac3893a3701cdf6a193666d063b223bffcae4f78bf6e09ad81099ece508'
             'f4468e0fa0e476fc77282cb0b3cff845ed8bce91a816a7c04e8d272abf5c5b1c'
             '2643cce3dbd5fcb65481be4afe7bf6fdea084cde134e04b38dd07239e1f09d59'
-            'b8b0ba1750837d771ee3b7fa7e766f220b6e291a0f4f52c07b11e6c5c9fd2750')
+            'b8b0ba1750837d771ee3b7fa7e766f220b6e291a0f4f52c07b11e6c5c9fd2750'
+            '552d9300422184c945aad3daba639367f9dd831a9855f83be927e31c8942bc64')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -42,7 +44,8 @@ prepare() {
   cd "${srcdir}/notepad-plus-plus-${pkgver}"
 
   apply_patch_with_msg \
-    001-aarch64.patch
+    001-aarch64.patch \
+    002-windres-codepage.patch
 }
 
 build() {


### PR DESCRIPTION
Fixes https://github.com/msys2/MINGW-packages/issues/23915
<img width="531" alt="image" src="https://github.com/user-attachments/assets/6095176c-084c-48ab-919c-27410aa64648" />
