### PR TITLE
New Package: sdl3-mixer

### DIFF
--- a/mingw-w64-sdl3-mixer/PKGBUILD
+++ b/mingw-w64-sdl3-mixer/PKGBUILD
@@ -1,0 +1,96 @@
+# Maintainer: Jordan Irwin <antumdeluge@gmail.com>
+
+_realname=sdl3-mixer
+pkgbase=mingw-w64-${_realname}
+pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
+pkgver=3.0.0r1985.g3026d341
+pkgrel=1
+pkgdesc="A simple multi-channel audio mixer (Version 3) (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url="https://github.com/libsdl-org/SDL_mixer"
+license=('spdx:Zlib')
+makedepends=("git"
+            "${MINGW_PACKAGE_PREFIX}-cmake"
+            "${MINGW_PACKAGE_PREFIX}-ninja"
+            "${MINGW_PACKAGE_PREFIX}-cc")
+depends=("${MINGW_PACKAGE_PREFIX}-sdl3"
+         "${MINGW_PACKAGE_PREFIX}-flac"
+         "${MINGW_PACKAGE_PREFIX}-wavpack"
+         "${MINGW_PACKAGE_PREFIX}-fluidsynth"
+         "${MINGW_PACKAGE_PREFIX}-libvorbis"
+         "${MINGW_PACKAGE_PREFIX}-libxmp"
+         "${MINGW_PACKAGE_PREFIX}-mpg123"
+         "${MINGW_PACKAGE_PREFIX}-opusfile"
+         "${MINGW_PACKAGE_PREFIX}-libgme")
+_commit='3026d3411cfe6a639b57d5a76ac027ef0e661e4f'
+source=("${_realname}"::"git+${url}.git#commit=${_commit}")
+sha256sums=('SKIP')
+validpgpkeys=('1528635D8053A57F77D1E08630A59377A7763BE6') # Sam Lantinga <slouken@libsdl.org>
+
+pkgver() {
+  cd "${srcdir}/${_realname}"
+  printf "3.0.0r%s.g%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+build() {
+  mkdir -p "${srcdir}/build-${MSYSTEM}-static" "${srcdir}/build-${MSYSTEM}-shared"
+
+  declare -a _extra_config
+  if check_option "debug" "n"; then
+    _extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    _extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  declare -a _common_config
+  _common_config+=(
+    -DSDLMIXER_MOD_XMP=ON
+    -DSDLMIXER_OGG=ON
+    -DSDLMIXER_VORBIS_STB=OFF
+    -DSDLMIXER_FLAC_LIBFLAC=ON # FIXME: can't link statically to libflac
+    -DSDLMIXER_FLAC_DRFLAC=OFF
+    -DSDLMIXER_MP3_MPG123=ON
+    -DSDLMIXER_MP3_DRMP3=OFF
+    -DSDLMIXER_OPUS=ON
+    -DSDLMIXER_WAVPACK=ON
+    -DSDLMIXER_MIDI_FLUIDSYNTH=ON
+    -DSDLMIXER_GME=ON
+  )
+
+  # FIXME: linking dynamically to dependencies
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    cmake \
+      -G Ninja \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      "${_extra_config[@]}" \
+      -DBUILD_SHARED_LIBS=OFF \
+      "${_common_config[@]}" \
+      -DSDLMIXER_MOD_XMP_SHARED=OFF \
+      -DSDLMIXER_MP3_MPG123_SHARED=OFF \
+      -DSDLMIXER_OPUS_SHARED=OFF \
+      -DSDLMIXER_WAVPACK_SHARED=OFF \
+      -DSDLMIXER_MIDI_FLUIDSYNTH_SHARED=OFF \
+      -DSDLMIXER_GME_SHARED=OFF \
+      -S "${srcdir}/${_realname}" \
+      -B "${srcdir}/build-${MSYSTEM}-static"
+
+  cmake --build "${srcdir}/build-${MSYSTEM}-static"
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    cmake \
+      -G Ninja \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      "${_extra_config[@]}" \
+      -DBUILD_SHARED_LIBS=ON \
+      "${_common_config[@]}" \
+      -S "${srcdir}/${_realname}" \
+      -B "${srcdir}/build-${MSYSTEM}-shared"
+
+  cmake --build "${srcdir}/build-${MSYSTEM}-shared"
+}
+
+package() {
+  DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}-static"
+  DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}-shared"
+}


### PR DESCRIPTION
Pre-release package that works with SDL3.

Currently only shared library will build. The following error occurs when trying to build static:

```
CMake Error at C:/Environment/MSYS2/mingw64/lib/cmake/FLAC/targets.cmake:61 (set_target_properties):
  The link interface of target "FLAC::FLAC" contains:

    Threads::Threads

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  C:/Environment/MSYS2/mingw64/lib/cmake/FLAC/flac-config.cmake:32 (include)
  CMakeLists.txt:645 (find_package)


-- Generating done (0.1s)
CMake Generate step failed.  Build files cannot be regenerated correctly.
```

**Update:** Static package now builds, but links dynamically to dependencies. The above error still occurs when trying to set `-DSDLMIXER_FLAC_LIBFLAC_SHARED=OFF` or `-DSDLMIXER_DEPS_SHARED=OFF`.