### PR TITLE
libetonyek: Enable aarch64 builds

### DIFF
--- a/mingw-w64-libetonyek/PKGBUILD
+++ b/mingw-w64-libetonyek/PKGBUILD
@@ -7,7 +7,7 @@ pkgver=0.1.12
 pkgrel=2
 pkgdesc="Library for import of Apple Keynote presentations. (mingw-w64)"
 arch=('any')
-mingw_arch=('ucrt64' 'clang64')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
 url='https://wiki.documentfoundation.org/DLP/Libraries/libetonyek'
 msys2_references=(
   'archlinux: libetonyek'


### PR DESCRIPTION
Requires https://github.com/msys2/MINGW-packages/pull/24003