### PR TITLE
luajit: update to 2.1.1744318430

### DIFF
--- a/mingw-w64-luajit/PKGBUILD
+++ b/mingw-w64-luajit/PKGBUILD
@@ -5,14 +5,14 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 # LuaJIT has abandoned versioned releases and now advises using git HEAD
 # https://github.com/LuaJIT/LuaJIT/issues/665#issuecomment-784452583
-_commit="e0a7ea8a924d8137e6950b97c3e36f17264f6c79"
+_commit="eec7a8016c3381b949b5d84583800d05897fa960"
 _basever=2.1
-pkgver=2.1.1744014795
+pkgver=2.1.1744318430
 pkgrel=1
 pkgdesc="Just-in-time compiler and drop-in replacement for Lua 5.1 (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
-url="https://luajit.org/"
+url="http://luajit.org/"
 msys2_repository_url='https://repo.or.cz/w/luajit-2.0.git'
 msys2_references=(
   "cpe: cpe:/a:luajit:luajit"
@@ -25,12 +25,12 @@ provides=("${MINGW_PACKAGE_PREFIX}-lua51"
 replaces=("${MINGW_PACKAGE_PREFIX}-lua51"
           "${MINGW_PACKAGE_PREFIX}-luajit-git")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc" "git")
-source=("${_realname}"::"git+https://luajit.org/git/luajit.git#commit=${_commit}"
+source=("${_realname}"::"git+http://luajit.org/git/luajit.git#commit=${_commit}"
         001-mintty-cygpty-isatty.patch
         002-fix-pkg-config-file.patch
         003-lua51-modules-paths.patch
         004-fix-default-cc.patch)
-sha256sums=('5f074dd856b89e3a2a7238a1a1228092b1e102ab95469c23d94205484bfbdf18'
+sha256sums=('05066e58ca71b1f942629a8c70adc91c0da6b89de19947461dbc808c9e43224a'
             '0cadf1b6c67c910c81ccb7a6152148dccfb0f1c6b50cdb09a5707cd45e7cbe85'
             '4df486e82b0bbeead01dcf6001e90c51477a3a8ac18611d60d7067f2c7013428'
             'a3d8c7c7724cd5a4173c6ddcbc854aa3424b78fb6c9d4b6c57ed2ebd6c2dd366'


### PR DESCRIPTION
## Changes

1. The usual update changes
2. Changed from `https://luajit.org` to `http://luajit.org` (read the details below).

> [!NOTE]
> 
> At the time of writing, LuaJIT website [https://luajit.org](https://luajit.org) is running a self-signed certificate, and this is causing a problem to build the package when fetching the source code.

## Details

Looks like that LuaJIT is changing from `https` to `http` as it can be seen in the following screenshots:

* If you browse the git repo configured on `msys2_repository_url` at [https://repo.or.cz/w/luajit-2.0.git](https://repo.or.cz/w/luajit-2.0.git), it is showing the `http` address in the homepage URL and repository URL:

    ![image](https://github.com/user-attachments/assets/36263aef-697f-44d0-a6e1-3fb9073ef382)

* If you visit LuaJIT's GitHub mirror [https://github.com/LuaJIT/LuaJIT](https://github.com/LuaJIT/LuaJIT) and hover the link to LuaJIT website, it is pointing to [http://luajit.org](http://luajit.org) too:

    ![image](https://github.com/user-attachments/assets/f00dd517-1e7b-45ec-aac0-ee72a43b129b)