### PR TITLE
gettext: do not include DllMain symbol in the static build

### DIFF
--- a/mingw-w64-gettext/0001-restore-DllMain-symbol.patch
+++ b/mingw-w64-gettext/0001-restore-DllMain-symbol.patch
@@ -5,7 +5,7 @@
  {
  }
 +
-+#ifdef _WIN32
++#if (defined _WIN32 && defined DLL_EXPORT)
 +#include <windows.h>
 +
 +# define HAS_DEVICE(P) \

--- a/mingw-w64-gettext/PKGBUILD
+++ b/mingw-w64-gettext/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-runtime"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-libtextstyle"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-tools")
 pkgver=0.24
-pkgrel=1
+pkgrel=2
 pkgdesc="GNU internationalization library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -31,7 +31,7 @@ source=(https://ftp.gnu.org/pub/gnu/${_realname}/${_realname}-${pkgver}.tar.lz{,
         0024-disable-gnu-format.patch)
 sha256sums=('0eb4153c3fc066d050242541156e8fd1ad74e80e4c08c2cc9f426e68e3d98015'
             'SKIP'
-            'e3a933c96a711bbb5ba6e584dd35f897dc7043da90a5682c05b137a0ad93bc7a'
+            'bfd38442d899bee75dc5d919f2bfe4a8fd827eff3fdcf45966f9de5bb5d6f283'
             'cbc2f533012d646521afa20f8b256917fce040741ff42cf53fb6dd7123a6670a'
             'ec39103d851262c02c27b7038f3c538e03afaefc6aa050311d62519d192ff38c'
             '380dbddee2f9e2feee4c1435e8a942b5d11d0125e60c3350ebb10c19b19011aa'


### PR DESCRIPTION
Fixes #23166