### PR TITLE
mcfgthread: Update to 2.1.1

### DIFF
--- a/mingw-w64-mcfgthread/PKGBUILD
+++ b/mingw-w64-mcfgthread/PKGBUILD
@@ -4,7 +4,7 @@ _realname=mcfgthread
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}"-libs)
-pkgver=2.0.1
+pkgver=2.1.1
 pkgrel=1
 pkgdesc="An efficient gthread implementation, providing C++11 threading support (mingw-w64)"
 arch=('any')
@@ -20,7 +20,7 @@ makedepends=(
   "git"
 )
 source=("git+https://github.com/lhmouse/mcfgthread.git#tag=v${pkgver%.*}-ga.${pkgver##*.}")
-sha256sums=('a33be150c3c736f43a37fb34e2af82ebb8c73f00cd0c39bfc10e478e8efe091f')
+sha256sums=('a2a38a6875bbe713b08027dbe39a5daa0e72206f2eee3a5713929ed5716d417f')
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"


### PR DESCRIPTION
https://github.com/lhmouse/mcfgthread/releases/tag/v2.1-ga.1

