### PR TITLE
nsis: Update to 3.11

### DIFF
--- a/mingw-w64-nsis/010-fix-clang-rc-file.patch
+++ b/mingw-w64-nsis/010-fix-clang-rc-file.patch
@@ -1,6 +1,5 @@
-diff -ur a/Contrib/Makensisw/resource.rc b/Contrib/Makensisw/resource.rc
---- a/Contrib/Makensisw/resource.rc	2021-09-21 00:48:42.000000000 +0800
-+++ b/Contrib/Makensisw/resource.rc	2024-05-24 23:54:20.255260700 +0800
+--- nsis-3.11-src/Contrib/Makensisw/resource.rc.orig	2024-06-12 13:03:58 +0200
++++ nsis-3.11-src/Contrib/Makensisw/resource.rc	2025-04-24 22:59:33 +0200
 @@ -63,35 +63,35 @@
  // Menu
  //
@@ -47,7 +46,7 @@ diff -ur a/Contrib/Makensisw/resource.rc b/Contrib/Makensisw/resource.rc
          BEGIN
              MENUITEM "&Defined in Script/Compiler Default", IDM_COMPRESSOR_SCRIPT
              MENUITEM "&ZLIB",                       IDM_ZLIB
-@@ -102,29 +102,29 @@
+@@ -102,30 +102,30 @@
              MENUITEM "LZMA (solid)",                IDM_LZMA_SOLID
              MENUITEM "&Best Compressor",            IDM_BEST
          END
@@ -65,6 +64,7 @@ diff -ur a/Contrib/Makensisw/resource.rc b/Contrib/Makensisw/resource.rc
          MENUITEM "&Window Info",                IDM_WNDSPY
          MENUITEM "&Lookup",                     IDM_LOOKUP
          MENUITEM "Generate &GUID",              IDM_GUIDGEN
+         MENUITEM "&Add/Remove Programs",        IDM_ARP
 -        MENUITEM "", -1, MFT_SEPARATOR
 +        MENUITEM SEPARATOR
          MENUITEM "Clear Recent &Files List",    IDM_CLEAR_MRU_LIST
@@ -85,7 +85,7 @@ diff -ur a/Contrib/Makensisw/resource.rc b/Contrib/Makensisw/resource.rc
          MENUITEM "&About MakeNSISW",            IDM_ABOUT
      END
  END
-@@ -172,7 +172,6 @@
+@@ -173,7 +173,6 @@
      WS_MAXIMIZEBOX | WS_POPUP | WS_VISIBLE | WS_CLIPCHILDREN | WS_CAPTION | 
      WS_SYSMENU | WS_THICKFRAME
  CAPTION "MakeNSISW"

--- a/mingw-w64-nsis/012-fix-zlib-is-none-if-not-found.patch
+++ b/mingw-w64-nsis/012-fix-zlib-is-none-if-not-found.patch
@@ -1,0 +1,11 @@
+--- nsis-3.11-src/Source/Tests/SConscript.orig	2025-04-24 23:16:32 +0200
++++ nsis-3.11-src/Source/Tests/SConscript	2025-04-24 23:24:57 +0200
+@@ -141,7 +141,7 @@
+ 
+ 	# build test program
+ 	tests = env.Program(target, tests + required_obj)
+-	if env['PLATFORM'] == 'win32' and 'ZLIB_W32_DLL' in env:
++	if env['PLATFORM'] == 'win32' and 'ZLIB_W32_DLL' in env and env['ZLIB_W32_DLL']:
+ 		import os.path
+ 		env.Depends(tests, env.InstallAs(
+ 			os.path.basename(str(env['ZLIB_W32_DLL'])), 

--- a/mingw-w64-nsis/PKGBUILD
+++ b/mingw-w64-nsis/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=nsis
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.10
-pkgrel=2
+pkgver=3.11
+pkgrel=1
 url='https://nsis.sourceforge.io/'
 pkgdesc='Windows installer development tool (mingw-w64)'
 license=('spdx:Zlib')
@@ -25,8 +25,9 @@ source=("https://sourceforge.net/projects/nsis/files/NSIS%203/${pkgver}/${_realn
         008-fix-uninitialized-vars.patch
         009-fix-clang-asm.patch
         010-fix-clang-rc-file.patch
-        011-add-arm64-support.patch)
-sha256sums=('11b54a6307ab46fef505b2700aaf6f62847c25aa6eebaf2ae0aab2f17f0cb297'
+        011-add-arm64-support.patch
+        012-fix-zlib-is-none-if-not-found.patch)
+sha256sums=('19e72062676ebdc67c11dc032ba80b979cdbffd3886c60b04bb442cdd401ff4b'
             '184635b95a441ffe82f7164f09419dc5594265ddb5b96666c4083e63095f291a'
             '1a14c915f67ad7b4e30727853e2c15f39adb6be9a78f51e08ab19851040870c7'
             'e76bc23c4f683f8e2158bf84b8c1207c861475c22bbad79ddb9cfb4df48aa6ef'
@@ -36,8 +37,9 @@ sha256sums=('11b54a6307ab46fef505b2700aaf6f62847c25aa6eebaf2ae0aab2f17f0cb297'
             'fd79c2f470aaf2a6248cbfa48034a3adefe6e90066431f4d7adc0da076b632c8'
             'f4422b218f4f17a17b33485c76238b8cf8159a20f3fdd1e44e2838b4aaab03ba'
             '385af959dba8bf2333303844e7a765fb8e1df39c2cf245dde8aa945efe694ff8'
-            '22549f35edde30b712b3c40acbf9127a59b792b5c8afb32cf07207ac2010729f'
-            'b25703cf1881188da6b29aa2b278c4fa413f705df8cef32640a3169d42e301fd')
+            '669325bdf7d02729f0f7507a7e4e2bd1a4a51968c4d333879ed23cb8af188922'
+            'b25703cf1881188da6b29aa2b278c4fa413f705df8cef32640a3169d42e301fd'
+            '2113523b03954304f5305de8c68b27fef7aa2c80d1b49224c5049b1e02863ad5')
 
 # Circumvent problem where makepkg will add the exe extension to some files
 # when compressing the 64-bit package
@@ -61,7 +63,8 @@ prepare() {
     005-fix-call-to-non-constexpr-function.patch \
     006-force-c++11.patch \
     007-fix-mingw-compile.patch \
-    008-fix-uninitialized-vars.patch
+    008-fix-uninitialized-vars.patch \
+    012-fix-zlib-is-none-if-not-found.patch
 
   if [[ ${MSYSTEM} == CLANG* ]]; then
     _apply_patch_with_msg \


### PR DESCRIPTION
* 010-fix-clang-rc-file.patch: refresh
* 012-fix-zlib-is-none-if-not-found.patch: fixes scons error if cppunit is installed env['ZLIB_W32_DLL'] is None there and is checked for everywhere except there