### PR TITLE
gst-plugins-base: Fix compiler error with gcc 15

### DIFF
--- a/mingw-w64-gst-plugins-base/0001-fix-gcc15-compiler-error.patch
+++ b/mingw-w64-gst-plugins-base/0001-fix-gcc15-compiler-error.patch
@@ -1,0 +1,37 @@
+--- a/gst-libs/gst/audio/gstaudioutilsprivate.c
++++ b/gst-libs/gst/audio/gstaudioutilsprivate.c
+@@ -218,13 +218,16 @@
+ }
+ 
+ #ifdef G_OS_WIN32
++typedef HANDLE (WINAPI * AvSetMmThreadCharacteristicsPtr) (LPCSTR, LPDWORD);
++typedef BOOL (WINAPI * AvRevertMmThreadCharacteristicsPtr) (HANDLE);
++
+ /* *INDENT-OFF* */
+ static struct
+ {
+   HMODULE dll;
+ 
+-  FARPROC AvSetMmThreadCharacteristics;
+-  FARPROC AvRevertMmThreadCharacteristics;
++  AvSetMmThreadCharacteristicsPtr AvSetMmThreadCharacteristics;
++  AvRevertMmThreadCharacteristicsPtr AvRevertMmThreadCharacteristics;
+ } _gst_audio_avrt_tbl = { 0 };
+ /* *INDENT-ON* */
+ #endif
+@@ -246,6 +249,7 @@
+     }
+ 
+     _gst_audio_avrt_tbl.AvSetMmThreadCharacteristics =
++        (AvSetMmThreadCharacteristicsPtr)
+         GetProcAddress (_gst_audio_avrt_tbl.dll,
+         "AvSetMmThreadCharacteristicsA");
+     if (!_gst_audio_avrt_tbl.AvSetMmThreadCharacteristics) {
+@@ -255,6 +259,7 @@
+     }
+ 
+     _gst_audio_avrt_tbl.AvRevertMmThreadCharacteristics =
++        (AvRevertMmThreadCharacteristicsPtr)
+         GetProcAddress (_gst_audio_avrt_tbl.dll,
+         "AvRevertMmThreadCharacteristics");
+ 

--- a/mingw-w64-gst-plugins-base/PKGBUILD
+++ b/mingw-w64-gst-plugins-base/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gst-plugins-base
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.26.1
-pkgrel=2
+pkgrel=3
 pkgdesc="GStreamer Multimedia Framework Base Plugins (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -29,10 +29,19 @@ depends=("${MINGW_PACKAGE_PREFIX}-graphene"
          "${MINGW_PACKAGE_PREFIX}-iso-codes"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 conflicts=("${MINGW_PACKAGE_PREFIX}-gst-plugins-bad<1.16.0")
-source=("${url}/src/${_realname}/${_realname}-${pkgver}.tar.xz"{,.asc})
+source=("${url}/src/${_realname}/${_realname}-${pkgver}.tar.xz"{,.asc}
+        0001-fix-gcc15-compiler-error.patch)
 sha256sums=('659553636f84dcf388cad5cf6530e02b0b2d3dc450e76199287ba9db6a6c5226'
-            'SKIP')
+            'SKIP'
+            '18d06e01acf7d4539eb9b0983de30b4d5c5b70d62421190aed3b2cd0dbb7702a')
 validpgpkeys=('D637032E45B8C6585B9456565D2EEE6F6F349D7C') # Tim Müller <tim@gstreamer-foundation.org>
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+
+  # https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/8904
+  patch -p1 -i "${srcdir}"/0001-fix-gcc15-compiler-error.patch
+}
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
@@ -42,7 +51,6 @@ build() {
     --prefix="${MINGW_PREFIX}" \
     --buildtype plain \
     --wrap-mode=nofallback \
-    -Dc_std=gnu18 \
     -Dauto_features=enabled \
     -Dpackage-origin='https://www.msys2.org' \
     -Dtests=disabled \


### PR DESCRIPTION
This reverts the workaround from c25fe7e95fb27afdc25b82f80ac31f69061b8a4c commit.