### PR TITLE
fltk: update to 1.4.3

### DIFF
--- a/mingw-w64-fltk/PKGBUILD
+++ b/mingw-w64-fltk/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=fltk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.4.2
-pkgrel=2
+pkgver=1.4.3
+pkgrel=1
 pkgdesc="C++ user interface toolkit (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -25,7 +25,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 source=("https://github.com/${_realname}/${_realname}/archive/release-${pkgver}/${_realname}-${pkgver}.tar.gz"
         "001-fltk-config-uuid-shared.patch"
         "002-fix-cmake-config-install-destination.patch")
-sha256sums=('de076793fd8487a5a55e0763ac0e85b115d3761cd1aa4869dbf3fc9e779dfca8'
+sha256sums=('6a11c0bf91b7b193a87a1928c32a953f36d7dd4b65fef3e9d0c40a51882f97a6'
             '30ea78d49d15dcc6cb567ab08d0c13f0ddcb1844dc9b22ebcd3bd80dd88f640e'
             '96825fb284f86b3bd9c7872b15dbdafd66932435094f4287ffc9d159e2b52c22')
 


### PR DESCRIPTION
According to FLTK develoeprs: https://www.fltk.org/articles.php?L1984
>  Its ABI and API are 100% backwards compatible with FLTK 1.4.0.