### PR TITLE
hdf5: fixes for static libraries

### DIFF
--- a/mingw-w64-hdf5/0005-fix-extracted-library-names.patch
+++ b/mingw-w64-hdf5/0005-fix-extracted-library-names.patch
@@ -1,7 +1,11 @@
---- a/CMakeFilters.cmake
-+++ b/CMakeFilters.cmake
-@@ -129,7 +129,7 @@
-         if (NOT WIN32) #windows has a list of names
+--- hdf5-1.14.6/CMakeFilters.cmake.orig	2025-05-06 12:03:12.331650800 +0200
++++ hdf5-1.14.6/CMakeFilters.cmake	2025-05-06 12:29:16.750076100 +0200
+@@ -126,10 +126,10 @@
+         endif ()
+         set (H5_ZLIB_INCLUDE_DIR_GEN ${ZLIB_INCLUDE_DIR})
+         set (H5_ZLIB_INCLUDE_DIRS ${H5_ZLIB_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIR})
+-        if (NOT WIN32) #windows has a list of names
++        if (NOT MSVC) #windows has a list of names
            # The FindZLIB.cmake module does not set an OUTPUT_NAME
            # on the target. The target returned is: ZLIB::ZLIB
 -          get_filename_component (libname ${ZLIB_LIBRARIES} NAME_WLE)
@@ -9,6 +13,20 @@
            string (REGEX REPLACE "^lib" "" libname ${libname})
            set_target_properties (ZLIB::ZLIB PROPERTIES OUTPUT_NAME ${libname})
          endif ()
+@@ -190,6 +190,13 @@
+       set (H5_SZIP_INCLUDE_DIRS ${H5_SZIP_INCLUDE_DIRS} ${SZIP_INCLUDE_DIR})
+       if(LIBAEC_PACKAGE_NAME STREQUAL "libaec")
+         set (LINK_COMP_LIBS ${LINK_COMP_LIBS} libaec::sz libaec::aec)
++        # The targets do not set an OUTPUT_NAME on the target.
++        get_filename_component (libname ${SZIP_LIBRARY} NAME_WE)
++        string (REGEX REPLACE "^lib" "" libname ${libname})
++        set_target_properties (libaec::sz PROPERTIES OUTPUT_NAME ${libname})
++        get_filename_component (libname ${libaec_LIBRARY} NAME_WE)
++        string (REGEX REPLACE "^lib" "" libname ${libname})
++        set_target_properties (libaec::aec PROPERTIES OUTPUT_NAME ${libname})
+       else ()
+         set (LINK_COMP_LIBS ${LINK_COMP_LIBS} ${SZIP_LIBRARIES})
+       endif ()
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
 @@ -1204,7 +1204,12 @@

--- a/mingw-w64-hdf5/0006-link-static-libs.patch
+++ b/mingw-w64-hdf5/0006-link-static-libs.patch
@@ -1,0 +1,72 @@
+Link static libraries to static libaec (if available).
+
+diff -urN hdf5-1.14.6/CMakeFilters.cmake.orig  hdf5-1.14.6/CMakeFilters.cmake
+--- hdf5-1.14.6/CMakeFilters.cmake.orig	2025-05-06 17:05:45.975918900 +0200
++++ hdf5-1.14.6/CMakeFilters.cmake	2025-05-06 17:10:12.003570400 +0200
+@@ -189,16 +189,32 @@
+       set (H5_SZIP_INCLUDE_DIR_GEN ${SZIP_INCLUDE_DIR})
+       set (H5_SZIP_INCLUDE_DIRS ${H5_SZIP_INCLUDE_DIRS} ${SZIP_INCLUDE_DIR})
+       if(LIBAEC_PACKAGE_NAME STREQUAL "libaec")
++        if (TARGET libaec::sz-static AND TARGET libaec::aec-static)
++          set (LINK_COMP_STATIC_LIBS ${LINK_COMP_LIBS} libaec::sz-static libaec::aec-static)
++        else ()
++          set (LINK_COMP_STATIC_LIBS ${LINK_COMP_LIBS} libaec::sz-static libaec::aec-static)
++        endif ()
+         set (LINK_COMP_LIBS ${LINK_COMP_LIBS} libaec::sz libaec::aec)
+         # The targets do not set an OUTPUT_NAME on the target.
+         get_filename_component (libname ${SZIP_LIBRARY} NAME_WE)
+         string (REGEX REPLACE "^lib" "" libname ${libname})
+-        set_target_properties (libaec::sz PROPERTIES OUTPUT_NAME ${libname})
++        get_target_property(_aliased libaec::sz ALIASED_TARGET)
++        if (_aliased)
++          set_target_properties (${_aliased} PROPERTIES OUTPUT_NAME ${libname})
++        else ()
++          set_target_properties (libaec::sz PROPERTIES OUTPUT_NAME ${libname})
++        endif ()
+         get_filename_component (libname ${libaec_LIBRARY} NAME_WE)
+         string (REGEX REPLACE "^lib" "" libname ${libname})
+-        set_target_properties (libaec::aec PROPERTIES OUTPUT_NAME ${libname})
++        get_target_property(_aliased libaec::aec ALIASED_TARGET)
++        if (_aliased)
++          set_target_properties (${_aliased} PROPERTIES OUTPUT_NAME ${libname})
++        else ()
++          set_target_properties (libaec::aec PROPERTIES OUTPUT_NAME ${libname})
++        endif ()
+       else ()
+         set (LINK_COMP_LIBS ${LINK_COMP_LIBS} ${SZIP_LIBRARIES})
++        set (LINK_COMP_STATIC_LIBS ${LINK_COMP_LIBS} ${SZIP_LIBRARIES})
+       endif ()
+     endif ()
+     message (VERBOSE "H5_SZIP_FOUND=${SZIP_FOUND} and LINK_COMP_LIBS=${LINK_COMP_LIBS}")
+@@ -207,6 +223,7 @@
+       EXTERNAL_SZIP_LIBRARY (${HDF5_ALLOW_EXTERNAL_SUPPORT} ${HDF5_ENABLE_SZIP_ENCODING})
+       message (VERBOSE "Filter SZIP is built using library AEC")
+       set (LINK_COMP_LIBS ${LINK_COMP_LIBS} ${H5_SZIP_STATIC_LIBRARY})
++      set (LINK_COMP_STATIC_LIBS ${LINK_COMP_LIBS} ${H5_SZIP_STATIC_LIBRARY})
+     endif ()
+   endif ()
+   message (VERBOSE "LINK_COMP_LIBS=${LINK_COMP_LIBS}")
+diff -urN hdf5-1.14.6/CMakeLists.txt.orig  hdf5-1.14.6/CMakeLists.txt
+--- hdf5-1.14.6/CMakeLists.txt.orig	2025-05-06 16:50:44.209827000 +0200
++++ hdf5-1.14.6/CMakeLists.txt	2025-05-06 16:51:11.201751500 +0200
+@@ -1001,7 +1001,7 @@
+ if (HDF5_ALLOW_EXTERNAL_SUPPORT MATCHES "GIT" OR HDF5_ALLOW_EXTERNAL_SUPPORT MATCHES "TGZ")
+   if ((H5_ZLIB_FOUND AND ZLIB_USE_EXTERNAL) OR (H5_SZIP_FOUND AND SZIP_USE_EXTERNAL))
+     if (BUILD_STATIC_LIBS)
+-      add_dependencies (${HDF5_LIB_TARGET} ${LINK_COMP_LIBS})
++      add_dependencies (${HDF5_LIB_TARGET} ${LINK_COMP_STATIC_LIBS})
+     endif ()
+     if (BUILD_SHARED_LIBS)
+       add_dependencies (${HDF5_LIBSH_TARGET} ${LINK_COMP_LIBS})
+diff -urN hdf5-1.14.6/src/CMakeLists.txt.orig  hdf5-1.14.6/src/CMakeLists.txt
+--- hdf5-1.14.6/src/CMakeLists.txt.orig	2025-05-06 12:48:38.916814200 +0200
++++ hdf5-1.14.6/src/CMakeLists.txt	2025-05-06 16:53:52.789588400 +0200
+@@ -1086,7 +1086,7 @@
+   )
+   TARGET_C_PROPERTIES (${HDF5_LIB_TARGET} STATIC)
+   target_link_libraries (${HDF5_LIB_TARGET}
+-      PRIVATE ${LINK_LIBS} ${LINK_COMP_LIBS}
++      PRIVATE ${LINK_LIBS} ${LINK_COMP_STATIC_LIBS}
+       PUBLIC "$<$<PLATFORM_ID:Windows>:${LINK_PUB_LIBS}>" "$<$<NOT:$<PLATFORM_ID:Windows>>:${CMAKE_DL_LIBS}>" "$<$<BOOL:${HDF5_ENABLE_PARALLEL}>:MPI::MPI_C>"
+   )
+   if (NOT WIN32)

--- a/mingw-w64-hdf5/PKGBUILD
+++ b/mingw-w64-hdf5/PKGBUILD
@@ -7,7 +7,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _ver=1.14.6
 __patch=
 pkgver=${_ver}${_patch//-/.}
-pkgrel=2
+pkgrel=3
 pkgdesc="General purpose library and file format for storing scientific data (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -45,7 +45,7 @@ sha256sums=('e4defbac30f50d64e1556374aa49e574417c9e72c6b1de7a4ff88c4b1bea6e9b'
             '101b6b41bd2e3fad9be2b3a72d5a9235fa90d4a900879b687e26521ee1a2fd8c'
             '4119aebc5d8afab3594c58821a104f252fb8c1bcc5bc12292deb53ac48778577'
             '6f9305be4aa849e90e66471100b0480855dc5ac91c4468100ede60127206ad60'
-            '45b5611af144cae97bc5270e0c3353de8ede542fb0891eb9071431e549aab2e9')
+            'c64e938d99ec88b4bb4ec1637e78dcf8aa3b8df592e390d1e85e0b778c3057ea')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {

--- a/mingw-w64-hdf5/PKGBUILD
+++ b/mingw-w64-hdf5/PKGBUILD
@@ -37,7 +37,8 @@ source=("https://support.hdfgroup.org/releases/hdf5/v${_filever%_*}/v${_filever}
         "0001-hdf5-pkgconfig-use-requires-private.patch"
         "0002-dynamic-allocation-functions.patch"
         "0003-define-__STDC_WANT_IEC_60559_TYPES_EXT__-early.patch"
-        "0005-fix-extracted-library-names.patch")
+        "0005-fix-extracted-library-names.patch"
+        "0006-link-static-libs.patch")
 sha256sums=('e4defbac30f50d64e1556374aa49e574417c9e72c6b1de7a4ff88c4b1bea6e9b'
             'e236f5805152b25065c206922d7ec1bab05b233adac51bbd0fb1e546326162f6'
             '9d172a7f6b8f54fdbf840e032708acade4ab88c81262b45bfa85d203810962a9'
@@ -45,7 +46,8 @@ sha256sums=('e4defbac30f50d64e1556374aa49e574417c9e72c6b1de7a4ff88c4b1bea6e9b'
             '101b6b41bd2e3fad9be2b3a72d5a9235fa90d4a900879b687e26521ee1a2fd8c'
             '4119aebc5d8afab3594c58821a104f252fb8c1bcc5bc12292deb53ac48778577'
             '6f9305be4aa849e90e66471100b0480855dc5ac91c4468100ede60127206ad60'
-            'c64e938d99ec88b4bb4ec1637e78dcf8aa3b8df592e390d1e85e0b778c3057ea')
+            'c64e938d99ec88b4bb4ec1637e78dcf8aa3b8df592e390d1e85e0b778c3057ea'
+            '45b8411d6efe1a7b72ea3767ff9020abeded2d4f7536940795b9d82cd0aeba58')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -67,7 +69,8 @@ prepare() {
     0001-hdf5-pkgconfig-use-requires-private.patch \
     0002-dynamic-allocation-functions.patch \
     0003-define-__STDC_WANT_IEC_60559_TYPES_EXT__-early.patch \
-    0005-fix-extracted-library-names.patch
+    0005-fix-extracted-library-names.patch \
+    0006-link-static-libs.patch
 }
 
 build() {
@@ -86,14 +89,13 @@ build() {
     _extra_config+=("-DHDF5_BUILD_FORTRAN=ON")
   fi
 
-  CFLAGS+=" -Wno-implicit-function-declaration" \
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake \
       -Wno-dev \
       -GNinja \
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
       -DCMAKE_DLL_NAME_WITH_SOVERSION=ON \
-      -DCMAKE_C_FLAGS="-Wno-error=incompatible-pointer-types" \
+      -DCMAKE_C_FLAGS="-Wno-implicit-function-declaration -Wno-error=incompatible-pointer-types" \
       -DBUILD_TESTING=OFF \
       "${_extra_config[@]}" \
       -DCMAKE_SKIP_RPATH=ON \

--- a/mingw-w64-libaec/0001-export-targets-for-shared-and-static.patch
+++ b/mingw-w64-libaec/0001-export-targets-for-shared-and-static.patch
@@ -1,0 +1,128 @@
+Export separate targets for shared and for static libraries.
+
+diff -urN libaec-v1.1.3/cmake/libaec-config.cmake.in.orig libaec-v1.1.3/cmake/libaec-config.cmake.in
+--- libaec-v1.1.3/cmake/libaec-config.cmake.in.orig	2025-05-06 16:15:50.757950300 +0200
++++ libaec-v1.1.3/cmake/libaec-config.cmake.in	2025-05-06 16:27:44.518380600 +0200
+@@ -26,17 +26,21 @@
+ 
+ find_path(libaec_INCLUDE_DIR NAMES libaec.h DOC "AEC include directory")
+ find_path(SZIP_INCLUDE_DIR NAMES szlib.h DOC "SZIP include directory")
++find_library(libaec-shared_LIBRARY NAMES aec DOC "AEC library")
++find_library(SZIP-shared_LIBRARY NAMES sz szip DOC "SZIP compatible version of the AEC library")
++if (MSVC)
++  find_library(libaec-static_LIBRARY NAMES aec-static.lib DOC "AEC library")
++  find_library(SZIP-static_LIBRARY NAMES szip-static.lib DOC "SZIP compatible version of the AEC library")
++else ()
++  find_library(libaec-static_LIBRARY NAMES libaec.a DOC "AEC library")
++  find_library(SZIP-static_LIBRARY NAMES libsz.a DOC "SZIP compatible version of the AEC library")
++endif ()
+ if (libaec_USE_STATIC_LIBS)
+-  if (MSVC)
+-    find_library(libaec_LIBRARY NAMES aec-static.lib DOC "AEC library")
+-    find_library(SZIP_LIBRARY NAMES szip-static.lib DOC "SZIP compatible version of the AEC library")
+-  else ()
+-    find_library(libaec_LIBRARY NAMES libaec.a DOC "AEC library")
+-    find_library(SZIP_LIBRARY NAMES libsz.a DOC "SZIP compatible version of the AEC library")
+-  endif ()
++  set(libaec_LIBRARY ${libaec-static_LIBRARY})
++  set(SZIP_LIBRARY ${SZIP-static_LIBRARY})
+ else ()
+-  find_library(libaec_LIBRARY NAMES aec DOC "AEC library")
+-  find_library(SZIP_LIBRARY NAMES sz szip DOC "SZIP compatible version of the AEC library")
++  set(libaec_LIBRARY ${libaec-shared_LIBRARY})
++  set(SZIP_LIBRARY ${SZIP-shared_LIBRARY})
+ endif ()
+ 
+ # Check version here
+@@ -55,38 +59,58 @@
+ )
+ 
+ if (libaec_FOUND)
+-  if (libaec_USE_STATIC_LIBS)
+-    add_library(libaec::aec STATIC IMPORTED)
+-  else ()
+-    add_library(libaec::aec SHARED IMPORTED)
+-    target_compile_definitions(libaec::aec INTERFACE LIBAEC_SHARED)
++  if (libaec-static_LIBRARY)
++    add_library(libaec::aec-static STATIC IMPORTED)
++    set_target_properties(libaec::aec-static PROPERTIES
++      IMPORTED_LOCATION "${libaec-static_LIBRARY}"
++      INTERFACE_INCLUDE_DIRECTORIES "${libaec_INCLUDE_DIR}"
++    )
++  endif ()
++  if (libaec-static_LIBRARY)
++    add_library(libaec::aec-shared STATIC IMPORTED)
++    target_compile_definitions(libaec::aec-shared INTERFACE LIBAEC_SHARED)
+     if (WIN32)
+-      set_target_properties(libaec::aec PROPERTIES
++      set_target_properties(libaec::aec-shared PROPERTIES
+         IMPORTED_IMPLIB "${libaec_LIBRARY}"
+       )
+     endif ()
++    set_target_properties(libaec::aec-shared PROPERTIES
++      IMPORTED_LOCATION "${libaec-shared_LIBRARY}"
++      INTERFACE_INCLUDE_DIRECTORIES "${libaec_INCLUDE_DIR}"
++    )
++  endif ()
++  if (libaec_USE_STATIC_LIBS)
++    add_library(libaec::aec ALIAS libaec::aec-static)
++  else ()
++    add_library(libaec::aec ALIAS libaec::aec-shared)
+   endif ()
+-  set_target_properties(libaec::aec PROPERTIES
+-    IMPORTED_LOCATION "${libaec_LIBRARY}"
+-    INTERFACE_INCLUDE_DIRECTORIES "${libaec_INCLUDE_DIR}"
+-  )
+ 
+   # SZIP
+-  if (libaec_USE_STATIC_LIBS)
+-    add_library(libaec::sz STATIC IMPORTED)
+-  else ()
+-    add_library(libaec::sz SHARED IMPORTED)
+-    target_compile_definitions(libaec::sz INTERFACE LIBAEC_SHARED)
++  if (SZIP-static_LIBRARY)
++    add_library(libaec::sz-static STATIC IMPORTED)
++    set_target_properties(libaec::sz-static PROPERTIES
++      IMPORTED_LOCATION "${SZIP-static_LIBRARY}"
++      INTERFACE_INCLUDE_DIRECTORIES "${SZIP_INCLUDE_DIR}"
++    )
++  endif ()
++  if (libaec-static_LIBRARY)
++    add_library(libaec::sz-shared SHARED IMPORTED)
++    target_compile_definitions(libaec::sz-shared INTERFACE LIBAEC_SHARED)
+     if (WIN32)
+-      set_target_properties(libaec::sz PROPERTIES
+-        IMPORTED_IMPLIB "${SZIP_LIBRARY}"
++      set_target_properties(libaec::sz-shared PROPERTIES
++        IMPORTED_IMPLIB "${SZIP-shared_LIBRARY}"
+       )
+     endif ()
++    set_target_properties(libaec::sz-shared PROPERTIES
++      IMPORTED_LOCATION "${SZIP-shared_LIBRARY}"
++      INTERFACE_INCLUDE_DIRECTORIES "${SZIP_INCLUDE_DIR}"
++    )
++  endif ()
++  if (libaec_USE_STATIC_LIBS)
++    add_library(libaec::sz ALIAS libaec::sz-static)
++  else ()
++    add_library(libaec::sz ALIAS libaec::sz-shared)
+   endif ()
+-  set_target_properties(libaec::sz PROPERTIES
+-    IMPORTED_LOCATION "${SZIP_LIBRARY}"
+-    INTERFACE_INCLUDE_DIRECTORIES "${SZIP_INCLUDE_DIR}"
+-  )
+ 
+   # Set SZIP variables.
+   set(SZIP_FOUND TRUE)
+@@ -95,7 +119,11 @@
+ 
+ mark_as_advanced(
+   libaec_LIBRARY
++  libaec-shared_LIBRARY
++  libaec-static_LIBRARY
+   libaec_INCLUDE_DIR
+   SZIP_LIBRARY
++  SZIP-shared_LIBRARY
++  SZIP-static_LIBRARY
+   SZIP_INCLUDE_DIR
+ )

--- a/mingw-w64-libaec/PKGBUILD
+++ b/mingw-w64-libaec/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libaec
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.1.3
-pkgrel=3
+pkgrel=4
 pkgdesc="Adaptive Entropy Coding library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -17,16 +17,30 @@ provides=("${MINGW_PACKAGE_PREFIX}-szip")
 replaces=("${MINGW_PACKAGE_PREFIX}-szip")
 source=("https://gitlab.dkrz.de/k202009/libaec/-/archive/v${pkgver}/libaec-v${pkgver}.tar.bz2"
         https://patch-diff.githubusercontent.com/raw/MathisRosenhauer/libaec/pull/34.patch
+        "0001-export-targets-for-shared-and-static.patch"
         "0005-cmake-fix-cmake-install.patch")
 sha256sums=('46216f9d2f2d3ffea4c61c9198fe0236f7f316d702f49065c811447186d18222'
             '6f21d732c139592c18d867bbed43a27150ae513b425fa70f6c9eb7f054561dd3'
+            '0e28a08f0b8394fed422c984fb6e107b9c3ffed743883907d1d64921633c4d88'
             '3076466b341dc7d84df965c68accbce45833c4bc4671b0e6c98645a44ae13f06')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying ${_patch}"
+    patch -Nbp1 -i "${srcdir}/${_patch}"
+  done
+}
 
 prepare() {
   cd "${srcdir}/${_realname}-v${pkgver}"
+
   # https://github.com/MathisRosenhauer/libaec/pull/34
-  patch -p1 -i "${srcdir}"/34.patch
-  patch -p1 -i "${srcdir}"/0005-cmake-fix-cmake-install.patch
+  apply_patch_with_msg \
+    34.patch \
+    0001-export-targets-for-shared-and-static.patch \
+    0005-cmake-fix-cmake-install.patch
 }
 
 build() {


### PR DESCRIPTION
The static libraries were linking to the shared libaec libraries. Build the static and shared libraries separately to be able to link to the respective libaec libraries.

Fix extraction of library names that are used in pkg-config file for static linking.
