### PR TITLE
Groonga: Update to 15.0.9

### DIFF
--- a/mingw-w64-groonga/PKGBUILD
+++ b/mingw-w64-groonga/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=groonga
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=15.0.4
-pkgrel=3
+pkgver=15.0.9
+pkgrel=1
 pkgdesc="An opensource fulltext search engine (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -30,7 +30,7 @@ makedepends=("git"
              "${MINGW_PACKAGE_PREFIX}-rapidjson"
              "${MINGW_PACKAGE_PREFIX}-ruby"
              "${MINGW_PACKAGE_PREFIX}-xsimd")
-sha256sums=('1123d4101a55ea183c290792ce39253e07f84740e561da70c69f4ce9875357f4'
+sha256sums=('f9969d2f8025a31dd201d8ce0e5db3a1547144e6191f75a9bbb1d771b7f0def2'
             'SKIP'
             '5fbb336487a6522e2f7bff01ea3cdd714d4c27de3cc65d5a6ecb2eedeb6fc2c4'
             '823f83e2043fc4b98c5971a12a65c1c4cb472b49b0e812052746aa591b7cdf44')


### PR DESCRIPTION
Groonga version15.0.9 has just released [here](https://github.com/groonga/groonga/releases/tag/v15.0.9).