### PR TITLE
img2pdf: new package

### DIFF
--- a/mingw-w64-img2pdf/PKGBUILD
+++ b/mingw-w64-img2pdf/PKGBUILD
@@ -16,8 +16,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-python-pillow"
          "${MINGW_PACKAGE_PREFIX}-python-pikepdf")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
-             "${MINGW_PACKAGE_PREFIX}-python-setuptools"
-             "${MINGW_PACKAGE_PREFIX}-python-wheel")
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 source=(https://files.pythonhosted.org/packages/source/i/${_realname}/${_realname}-${pkgver}.tar.gz)
 sha256sums=('306e279eb832bc159d7d6294b697a9fbd11b4be1f799b14b3b2174fb506af289')
 

--- a/mingw-w64-img2pdf/PKGBUILD
+++ b/mingw-w64-img2pdf/PKGBUILD
@@ -1,0 +1,39 @@
+# Maintainer: wszqkzqk <wszqkzqk@qq.com>
+
+_realname=img2pdf
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=0.6.1
+pkgrel=1
+pkgdesc="Losslessly convert raster images to PDF"
+arch=(any)
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url="https://gitlab.mister-muffin.de/josch/img2pdf"
+license=('spdx:LGPL-3.0-only')
+msys2_references=("archlinux: $_realname")
+options=('!strip')
+depends=("${MINGW_PACKAGE_PREFIX}-python-pillow"
+         "${MINGW_PACKAGE_PREFIX}-python-pikepdf")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python-wheel")
+source=(https://files.pythonhosted.org/packages/source/i/${_realname}/${_realname}-${pkgver}.tar.gz)
+sha256sums=('306e279eb832bc159d7d6294b697a9fbd11b4be1f799b14b3b2174fb506af289')
+
+prepare() {
+  rm -rf python-build-${MSYSTEM} || true
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
+}
+
+build() {
+  cd "python-build-${MSYSTEM}"
+  python -m build --wheel --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+      --destdir="$pkgdir" dist/*.whl
+}


### PR DESCRIPTION
* Losslessly convert raster images to PDF