### PR TITLE
gst-plugins-rs: Enable feature for newer GTK

### DIFF
--- a/mingw-w64-gst-plugins-rs/PKGBUILD
+++ b/mingw-w64-gst-plugins-rs/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=1.26.1
 _tag=gstreamer-${pkgver}
-pkgrel=2
+pkgrel=3
 pkgdesc='GStreamer plugins written in Rust (mingw-w64)'
 arch=(any)
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -42,7 +42,8 @@ _cargo_opts=(--workspace
              --library-type=cdylib
              --prefix="${MINGW_PREFIX}"
              --exclude gst-plugin-csound
-             --exclude gst-plugin-vvdec)
+             --exclude gst-plugin-vvdec
+             --features gtk_v4_16)
 
 if [[ ${CARCH} == aarch64 ]]; then
   _cargo_opts+=(--exclude gst-plugin-ndi


### PR DESCRIPTION
Otherwise gtk4paintablesink is going to use (GSK) shader render nodes, which aren't supported anymore.

Cfr https://gitlab.archlinux.org/archlinux/packaging/packages/gst-plugins-rs/-/blob/main/PKGBUILD?ref_type=heads#L91