### PR TITLE
pdcurses: update to PDCursesMod 4.5.1

### DIFF
--- a/mingw-w64-pdcurses/PKGBUILD
+++ b/mingw-w64-pdcurses/PKGBUILD
@@ -8,20 +8,20 @@ provides=("${MINGW_PACKAGE_PREFIX}-curses")
 # No replace or conflict as the installed names are different
 #replaces=("${MINGW_PACKAGE_PREFIX}-ncurses" "${MINGW_PACKAGE_PREFIX}-termcap")
 #conflicts=("${MINGW_PACKAGE_PREFIX}-ncurses" "${MINGW_PACKAGE_PREFIX}-termcap")
-pkgver=4.4.0
+pkgver=4.5.1
 pkgrel=1
 pkgdesc="Curses library on the Win32 API (mingw-w64)"
 # ports that are available with this package
 _pdcports="wincon wingui vt"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://www.projectpluto.com/win32a.htm"
 msys2_repository_url="https://github.com/Bill-Gray/PDCursesMod"
 license=('Public Domain')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+changelog=${_realname}.changelog
 source=("https://github.com/Bill-Gray/PDCursesMod/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('a53bf776623decb9e4b2c2ffe43e52d83fe4455ffd20229b4ba36c92918f67dd')
+sha256sums=('21f896f553972de5647a39ac5793ddeaece9a126e60bd14111973801f9006201')
 
 #prepare() {
 #  cd PDCursesMod-${pkgver}
@@ -33,6 +33,7 @@ build() {
 
   for pdc_port in ${_pdcports}; do
     cp -rf ${pdc_port} ${pdc_port}-shared-${MSYSTEM}
+    CFLAGS+=" -std=c17" \
     make -C ${pdc_port}-shared-${MSYSTEM} \
         CC=${MINGW_PREFIX}/bin/cc \
         STRIP=${MINGW_PREFIX}/bin/strip \
@@ -44,6 +45,7 @@ build() {
         DLL=Y
 
     cp -rf ${pdc_port} ${pdc_port}-static-${MSYSTEM}
+    CFLAGS+=" -std=c17" \
     make -C ${pdc_port}-static-${MSYSTEM} \
         CC=${MINGW_PREFIX}/bin/cc \
         STRIP=${MINGW_PREFIX}/bin/strip \

--- a/mingw-w64-pdcurses/pdcurses.changelog
+++ b/mingw-w64-pdcurses/pdcurses.changelog
@@ -1,0 +1,128 @@
+PDCursesMod 4.5.1- 2025 May 12
+=============================
+
+Minor new features
+------------------
+
+- `testcurs` now allows one to specify mouse mask parameters more precisely,
+  and/or to set a zero mouse interval (which should result in clicks being
+  converted to presses and releases).  Also,  can test using the ncurses
+  mouse interface instead of the 'classic' undocumented SysV mouse interface.
+
+Bug fixes
+---------
+
+- When restarting Curses,  the foreground/background weren't stored,
+  resulting in odd colors.
+
+- The ncurses forms library does not build correctly for wide characters.
+  Until it's fixed,  it and the tests relying on it are only built in
+  narrow-character (8-bit) mode
+
+- Fixed possible read-outside-bounds error in UTF8 conversion.
+
+- `testcurs` called scanw() with a "plain" %s format specifier.  The lack of
+  a width left it open to buffer overflow if more than 79 bytes were entered.
+
+- VT build failed when using GNU make to cross-compile demos and tests for
+  Windows using MinGW.
+
+- Mouse input inconsistently respected `mousemask()` on most platforms.
+  The common logic for combining press/releases into clicks,  double- and
+  triple-clicks has been abstracted into `common/mouse.c`,  and is now used
+  by the WinCon,  WinGUI,  x11new,  and VT platforms (and will probably be
+  used eventually by most other platforms).
+
+PDCursesMod 4.5.0 - 2024 Dec 31
+=================================
+
+Major new features
+------------------
+
+- The ncurses 'menu' library can be compiled and used with PDCursesMod,
+  and the ncurses program 'demo_menus' built to test it out.  (The
+  'forms' library can be built in 8-bit character mode -- it currently
+  uses ncurses internals for wide mode -- but doesn't appear to
+  actually work yet.)
+
+Minor new features
+------------------
+
+- Added is_cbreak(), is_echo(), is_nl(), is_raw() functions to access
+  members of the non-opaque SCREEN struct.  The first two replace
+  PDC_getcbreak() and PDC_getecho().
+
+- Windows can be created,  moved,  and resized that go off the right
+  and bottom edges of the screen,  a la ncurses.  (I think this was
+  an acknowledgment of the fact that after resizing a screen,  windows
+  might go over those edges anyway.)  Windows still cannot go off the
+  left or top edges. 
+
+- Added a new 'test' program for the issues mentioned above with
+  scrolling and winsertln(), wdeleteln(), winsdelln().
+
+- Three new small test programs to investigate various aspects of
+  how curses works (or doesn't work).
+
+- The 'tests' programs can now be built,  on some platforms,  with
+  'make -f Makefile tests'.
+
+- Switched from defaulting to ncurses-6.4 tests to ncurses-6.5.
+
+- WinGUI now defaults to resizable windows,  similar to SDLn,  WinCon,
+  and X11. 
+
+- winsnstr() handled 513 _bytes_ from the input,  instead of the clearly
+  intended 513 wchar_ts.  This worked,  but was an unnecessarily low
+  limitation.  It is now fixed,  and the function can now handle
+  arbitrarily long strings via recursion.  Added some code to test this
+  in 'show_col.c'.
+
+- PDC_wcwidth( ) updated from Unicode 14.0.0 to 16.0.0 
+
+Bug fixes
+---------
+
+- In WinGUI,  we could potentially read memory out of bounds.  From
+  slipher.
+
+- In WinGUI,  theoretically 'monospaced' fonts were not necessarily
+  monospaced.  Reverted to drawing each character separately.
+
+- In WinGUI,  when redrawing a string of characters,  the preceding and
+  subsequent glyphs were also redrawn.  This was apparently needed at
+  one time to avoid stray pixels, but appears to be unnecessary now.
+
+- In WinGUI and WinCon,  PDC_clearclipboard() would fail if the clipboard
+  was not open.
+
+- If napms() was called with a negative value,  it would lock.
+
+- wsetscrreg() required the cursor for the window to be positioned
+  between the 'top' and 'bottom' of the new scroll region.
+
+- wdeleteln() would delete the line currently under the cursor,  then
+  bring up lines down to the end of the current scroll region,  inserting
+  a blank line there.  It really should delete all the way to the bottom
+  of the window.
+
+- The 'picsview' demo had a possible buffer overrun error.
+
+- Removed an assert() in mvwin() when the window was moved outside the
+  screen area.  Some programs (including 'test_pan') assume they can try
+  moving a window,  then check the return value to see if it was actually
+  on screen.
+
+- PDC_set_box_type() has been removed,  because it's an unneeded redundancy.
+  You can get double-lined or thick-lined boxes,  and/or rounded corners,
+  via the standard Curses wborder_set() function,  and it'll work with
+  ncurses and other libraries.  'test_pan' revised to provide an example
+  of how that's done.
+
+- printw() overflowed a buffer when asked to output more than 512 bytes.
+
+- PDC_wcstombs() could overflow a buffer in the UTF8 decoding.
+
+- panel_hidden() is now portable, returning TRUE (1) and FALSE (0) instead
+  of OK (0) and ERR (-1) This may break existing applications, so you possibly
+  want to check for the PDCursesMod build (PDC_BUILD < 4500).


### PR DESCRIPTION
Side question: is it ok to have the following long list in the commit log details, or should I drop that (if it should be reduced, then how)?


potential relevant changes since previous PDCursesMod 4.4.0 from [HISTORY.md](https://github.com/Bill-Gray/PDCursesMod/releases):

PDCursesMod 4.5.1- 2025 May 12
=============================

Minor new features
------------------

- `testcurs` now allows one to specify mouse mask parameters more precisely, and/or to set a zero mouse interval (which should result in clicks being converted to presses and releases).  Also,  can test using the ncurses mouse interface instead of the 'classic' undocumented SysV mouse interface.

Bug fixes
---------

- When restarting Curses,  the foreground/background weren't stored, resulting in odd colors.

- The ncurses forms library does not build correctly for wide characters. Until it's fixed,  it and the tests relying on it are only built in narrow-character (8-bit) mode

- Fixed possible read-outside-bounds error in UTF8 conversion.

- `testcurs` called scanw() with a "plain" %s format specifier.  The lack of a width left it open to buffer overflow if more than 79 bytes were entered.

- VT build failed when using GNU make to cross-compile demos and tests for Windows using MinGW.

- Mouse input inconsistently respected `mousemask()` on most platforms. The common logic for combining press/releases into clicks,  double- and triple-clicks has been abstracted into `common/mouse.c`,  and is now used by the WinCon,  WinGUI,  x11new,  and VT platforms (and will probably be used eventually by most other platforms).

PDCursesMod 4.5.0 - 2024 Dec 31
=================================

Major new features
------------------

- The ncurses 'menu' library can be compiled and used with PDCursesMod, and the ncurses program 'demo_menus' built to test it out.  (The 'forms' library can be built in 8-bit character mode -- it currently uses ncurses internals for wide mode -- but doesn't appear to actually work yet.)

Minor new features
------------------

- Added is_cbreak(), is_echo(), is_nl(), is_raw() functions to access members of the non-opaque SCREEN struct.  The first two replace PDC_getcbreak() and PDC_getecho().

- Windows can be created,  moved,  and resized that go off the right and bottom edges of the screen,  a la ncurses.  (I think this was an acknowledgment of the fact that after resizing a screen,  windows might go over those edges anyway.)  Windows still cannot go off the left or top edges. 

- Added a new 'test' program for the issues mentioned above with scrolling and winsertln(), wdeleteln(), winsdelln().

- Three new small test programs to investigate various aspects of how curses works (or doesn't work).

- The 'tests' programs can now be built,  on some platforms,  with 'make -f Makefile tests'.

- Switched from defaulting to ncurses-6.4 tests to ncurses-6.5.

- WinGUI now defaults to resizable windows,  similar to SDLn,  WinCon, and X11. 

- winsnstr() handled 513 _bytes_ from the input,  instead of the clearly intended 513 wchar_ts.  This worked,  but was an unnecessarily low limitation.  It is now fixed,  and the function can now handle arbitrarily long strings via recursion.  Added some code to test this in 'show_col.c'.

- PDC_wcwidth( ) updated from Unicode 14.0.0 to 16.0.0 

Bug fixes
---------

- In WinGUI,  we could potentially read memory out of bounds.  From slipher.

- In WinGUI,  theoretically 'monospaced' fonts were not necessarily monospaced.  Reverted to drawing each character separately.

- In WinGUI,  when redrawing a string of characters,  the preceding and subsequent glyphs were also redrawn.  This was apparently needed at one time to avoid stray pixels, but appears to be unnecessary now.

- In WinGUI and WinCon,  PDC_clearclipboard() would fail if the clipboard was not open.

- If napms() was called with a negative value,  it would lock.

- wsetscrreg() required the cursor for the window to be positioned between the 'top' and 'bottom' of the new scroll region.

- wdeleteln() would delete the line currently under the cursor,  then bring up lines down to the end of the current scroll region,  inserting a blank line there.  It really should delete all the way to the bottom of the window.

- The 'picsview' demo had a possible buffer overrun error.

- Removed an assert() in mvwin() when the window was moved outside the screen area.  Some programs (including 'test_pan') assume they can try moving a window,  then check the return value to see if it was actually on screen.

- PDC_set_box_type() has been removed,  because it's an unneeded redundancy. You can get double-lined or thick-lined boxes,  and/or rounded corners, via the standard Curses wborder_set() function,  and it'll work with ncurses and other libraries.  'test_pan' revised to provide an example of how that's done.

- printw() overflowed a buffer when asked to output more than 512 bytes.

- PDC_wcstombs() could overflow a buffer in the UTF8 decoding.

- panel_hidden() is now portable, returning TRUE (1) and FALSE (0) instead of OK (0) and ERR (-1) This may break existing applications, so you possibly want to check for the PDCursesMod build (PDC_BUILD < 4500).
