### PR TITLE
freeimage: Add include <cstdint> to compile with GCC 15.1

### DIFF
--- a/mingw-w64-freeimage/FreeImage-3.18.0_unbundle.patch
+++ b/mingw-w64-freeimage/FreeImage-3.18.0_unbundle.patch
@@ -645,9 +645,17 @@ diff -rupN FreeImage/Source/Metadata/XTIFF.cpp FreeImage-new/Source/Metadata/XTI
  		if(skip_write_field(tif, tag_id)) {
  			// skip tags that are already handled by the LibTIFF writing process
 diff -rupN FreeImage/Source/Utilities.h FreeImage-new/Source/Utilities.h
---- FreeImage/Source/Utilities.h	2016-04-11 15:15:32.000000000 +0200
-+++ FreeImage-new/Source/Utilities.h	2018-08-01 00:16:29.826825358 +0200
-@@ -446,12 +446,12 @@ SwapLong(DWORD *lp) {
+--- FreeImage/Source/Utilities.h	2016-04-11 16:15:32.000000000 +0300
++++ FreeImage-new/Source/Utilities.h	2025-05-14 13:10:24.557205700 +0300
+@@ -51,6 +51,7 @@
+ #include <algorithm>
+ #include <limits>
+ #include <memory>
++#include <cstdint>
+ 
+ // ==========================================================
+ //   Bitmap palette and pixels alignment
+@@ -446,12 +447,12 @@ SwapLong(DWORD *lp) {
  }
   
  inline void
@@ -662,3 +670,4 @@ diff -rupN FreeImage/Source/Utilities.h FreeImage-new/Source/Utilities.h
  		DWORD ul[2];
  	} tmp, result;
  	tmp.sv = *arg;
+

--- a/mingw-w64-freeimage/PKGBUILD
+++ b/mingw-w64-freeimage/PKGBUILD
@@ -40,7 +40,7 @@ source=("https://downloads.sourceforge.net/sourceforge/freeimage/${_realname}${p
         'freeimage-libtiff-4.4.0.patch')
 sha256sums=('f41379682f9ada94ea7b34fe86bf9ee00935a3147be41b6569c9605a53e438fd'
             'ccb04cd703530d73b123f84310287a0318e13786a7320b7e81a33f2dccb445ca'
-            'cf1691984936e7cd2883c84cea9155a0fb706d1fd0ded89c765a9d00fd5849ae'
+            'a1480bc158002c9f4b093f9199ec708eb931f45ca1d7ec0af6508626c70fc0b9'
             '71c25974c25dfced11b08206aae6e759675b53bae061be5f34fa1107beec9233'
             'cacb6ae3a2cebf8208d34ea01423a5309ee88ff649afbbb371e49cfeb57d8331'
             '1f743835f4b06bf14a8ce01b7125e5eed886939dca3853814c5ca46d500d275a')


### PR DESCRIPTION
This PR resolves this build error:

```
MINGW64 /b/mingw-w64-freeimage
# makepkg
==> Making package: mingw-w64-freeimage 3.18.0-14 (Wed, May 14, 2025  1:29:38 PM)
==> Checking runtime dependencies...
==> Checking buildtime dependencies...
==> Retrieving sources...
  -> Found FreeImage3180.zip
  -> Found FreeImage-3.18.0_mingw-makefiles.patch
  -> Found FreeImage-3.18.0_unbundle.patch
  -> Found freeimage-libraw-0.20.patch
  -> Found freeimage-libraw-0.21.patch
  -> Found freeimage-libtiff-4.4.0.patch
==> Validating source files with sha256sums...
    FreeImage3180.zip ... Passed
    FreeImage-3.18.0_mingw-makefiles.patch ... Passed
    FreeImage-3.18.0_unbundle.patch ... Passed
    freeimage-libraw-0.20.patch ... Passed
    freeimage-libraw-0.21.patch ... Passed
    freeimage-libtiff-4.4.0.patch ... Passed
==> Extracting sources...
  -> Extracting FreeImage3180.zip with bsdtar
==> Starting prepare()...
  -> Applying FreeImage-3.18.0_mingw-makefiles.patch
patching file Makefile.fip
patching file Makefile.gnu
  -> Applying FreeImage-3.18.0_unbundle.patch
patching file genfipsrclist.sh
patching file gensrclist.sh
patching file Source/FreeImage/J2KHelper.cpp
patching file Source/FreeImage/Plugin.cpp
patching file Source/FreeImage/PluginEXR.cpp
patching file Source/FreeImage/PluginJ2K.cpp
patching file Source/FreeImage/PluginJP2.cpp
patching file Source/FreeImage/PluginJPEG.cpp
patching file Source/FreeImage/PluginJXR.cpp
patching file Source/FreeImage/PluginPNG.cpp
patching file Source/FreeImage/PluginRAW.cpp
patching file Source/FreeImage/PluginTIFF.cpp
patching file Source/FreeImage/PluginWebP.cpp
patching file Source/FreeImage/PSDParser.cpp
patching file Source/FreeImage/ZLibInterface.cpp
patching file Source/FreeImage.h
patching file Source/FreeImageToolkit/JPEGTransform.cpp
patching file Source/Metadata/TagConversion.cpp
patching file Source/Metadata/XTIFF.cpp
patching file Source/Utilities.h
  -> Applying freeimage-libraw-0.20.patch
patching file Source/FreeImage/PluginRAW.cpp
  -> Applying freeimage-libraw-0.21.patch
patching file Source/FreeImage/PluginRAW.cpp
  -> Applying freeimage-libtiff-4.4.0.patch
patching file Source/Metadata/XTIFF.cpp
==> Starting build()...
==> Building freeimage...
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/BitmapAccess.cpp -o Source/FreeImage/BitmapAccess.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/ColorLookup.cpp -o Source/FreeImage/ColorLookup.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/ConversionRGBA16.cpp -o Source/FreeImage/ConversionRGBA16.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/ConversionRGBAF.cpp -o Source/FreeImage/ConversionRGBAF.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/FreeImage.cpp -o Source/FreeImage/FreeImage.o
gcc -std=gnu11 -O3 -fPIC -fexceptions -fvisibility=hidden -D__ANSI__ -DFREEIMAGE_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -DOPJ_STATIC -DNO_LCMS -DDISABLE_PERF_MEASUREMENT -D__ANSI__ -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -c Source/FreeImage/FreeImageC.c -o Source/FreeImage/FreeImageC.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/FreeImageIO.cpp -o Source/FreeImage/FreeImageIO.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/GetType.cpp -o Source/FreeImage/GetType.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/LFPQuantizer.cpp -o Source/FreeImage/LFPQuantizer.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/MemoryIO.cpp -o Source/FreeImage/MemoryIO.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/PixelAccess.cpp -o Source/FreeImage/PixelAccess.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/J2KHelper.cpp -o Source/FreeImage/J2KHelper.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/MNGHelper.cpp -o Source/FreeImage/MNGHelper.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/Plugin.cpp -o Source/FreeImage/Plugin.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/PluginBMP.cpp -o Source/FreeImage/PluginBMP.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/PluginCUT.cpp -o Source/FreeImage/PluginCUT.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/PluginDDS.cpp -o Source/FreeImage/PluginDDS.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/PluginEXR.cpp -o Source/FreeImage/PluginEXR.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/PluginG3.cpp -o Source/FreeImage/PluginG3.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/PluginGIF.cpp -o Source/FreeImage/PluginGIF.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/PluginHDR.cpp -o Source/FreeImage/PluginHDR.o
Source/FreeImage/J2KHelper.cpp: In function 'opj_image_t* FIBITMAPToJ2KImage(int, FIBITMAP*, const opj_cparameters_t*)':
Source/FreeImage/J2KHelper.cpp:487:37: warning: 'opj_image_comptparm::bpp' is deprecated: Use prec instead [-Wdeprecated-declarations]
  487 |                         cmptparm[i].bpp = prec;
      |                                     ^~~
In file included from Source/FreeImage/J2KHelper.cpp:24:
C:/msys64/mingw64/include/openjpeg-2.5/openjpeg.h:756:45: note: declared here
  756 |     OPJ_DEPRECATED_STRUCT_MEMBER(OPJ_UINT32 bpp, "Use prec instead");
      |                                             ^~~
C:/msys64/mingw64/include/openjpeg-2.5/openjpeg.h:80:83: note: in definition of macro 'OPJ_DEPRECATED_STRUCT_MEMBER'
   80 | #define OPJ_DEPRECATED_STRUCT_MEMBER(memb, msg) __attribute__ ((deprecated(msg))) memb
      |                                                                                   ^~~~
Source/FreeImage/J2KHelper.cpp:487:37: warning: 'opj_image_comptparm::bpp' is deprecated: Use prec instead [ttps://gcc.gnu.org/onlinedocs/gcc-15.1.0/gcc/Warning-Options.html#index-Wdeprecated-declarations-Wdeprecated-declarationsm]
  487 |                         cmptparm[i].bpp = prec;
      |                                     ^~~
C:/msys64/mingw64/include/openjpeg-2.5/openjpeg.h:756:45: note: declared here
  756 |     OPJ_DEPRECATED_STRUCT_MEMBER(OPJ_UINT32 bpp, "Use prec instead");
      |                                             ^~~
C:/msys64/mingw64/include/openjpeg-2.5/openjpeg.h:80:83: note: in definition of macro 'OPJ_DEPRECATED_STRUCT_MEMBER'
   80 | #define OPJ_DEPRECATED_STRUCT_MEMBER(memb, msg) __attribute__ ((deprecated(msg))) memb
      |                                                                                   ^~~~
Source/FreeImage/J2KHelper.cpp:487:37: warning: 'opj_image_comptparm::bpp' is deprecated: Use prec instead [ttps://gcc.gnu.org/onlinedocs/gcc-15.1.0/gcc/Warning-Options.html#index-Wdeprecated-declarations-Wdeprecated-declarationsm]
  487 |                         cmptparm[i].bpp = prec;
      |                                     ^~~
C:/msys64/mingw64/include/openjpeg-2.5/openjpeg.h:756:45: note: declared here
  756 |     OPJ_DEPRECATED_STRUCT_MEMBER(OPJ_UINT32 bpp, "Use prec instead");
      |                                             ^~~
C:/msys64/mingw64/include/openjpeg-2.5/openjpeg.h:80:83: note: in definition of macro 'OPJ_DEPRECATED_STRUCT_MEMBER'
   80 | #define OPJ_DEPRECATED_STRUCT_MEMBER(memb, msg) __attribute__ ((deprecated(msg))) memb
      |                                                                                   ^~~~
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/PluginICO.cpp -o Source/FreeImage/PluginICO.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/PluginIFF.cpp -o Source/FreeImage/PluginIFF.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/PluginJ2K.cpp -o Source/FreeImage/PluginJ2K.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/PluginJNG.cpp -o Source/FreeImage/PluginJNG.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/PluginJP2.cpp -o Source/FreeImage/PluginJP2.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/PluginJPEG.cpp -o Source/FreeImage/PluginJPEG.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/PluginJXR.cpp -o Source/FreeImage/PluginJXR.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/PluginKOALA.cpp -o Source/FreeImage/PluginKOALA.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/PluginMNG.cpp -o Source/FreeImage/PluginMNG.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/PluginPCD.cpp -o Source/FreeImage/PluginPCD.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/PluginPCX.cpp -o Source/FreeImage/PluginPCX.o
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/PluginPFM.cpp -o Source/FreeImage/PluginPFM.o
In file included from Source/FreeImage/FreeImage.cpp:30:
Source/Utilities.h:449:1: error: variable or field 'SwapInt64' declared void
  449 | SwapInt64(uint64_t *arg) {
      | ^~~~~~~~~
Source/Utilities.h:449:11: error: 'uint64_t' was not declared in this scope
  449 | SwapInt64(uint64_t *arg) {
      |           ^~~~~~~~
Source/Utilities.h:54:1: note: 'uint64_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
   53 | #include <memory>
  +++ |+#include <cstdint>
   54 |
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/PluginPICT.cpp -o Source/FreeImage/PluginPICT.o
Source/Utilities.h:449:21: error: 'arg' was not declared in this scope
  449 | SwapInt64(uint64_t *arg) {
      |                     ^~~
g++ -std=gnu++11 -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -D__ANSI__ -DFREEIMAGE_EXPORTS -DOPJ_EXPORTS -I. -ISource -ISource/Metadata -ISource/FreeImageToolkit -I/mingw64/include/jxrlib -IC:/msys64/mingw64/include/OpenEXR -pthread -IC:/msys64/mingw64/include/Imath -IC:/msys64/mingw64/include/openjpeg-2.5 -IC:/msys64/mingw64/include/libraw -IC:/msys64/mingw64/include/libpng16 -DLIBDEFLATE_DLL -IC:/msys64/mingw64/include/webp -c Source/FreeImage/PluginPNG.cpp -o Source/FreeImage/PluginPNG.o
make: *** [Makefile.gnu:66: Source/FreeImage/FreeImage.o] Error 1
make: *** Waiting for unfinished jobs....
Source/FreeImage/PluginEXR.cpp:70:36: warning: 'Imath_3_1::Int64' is deprecated: use uint64_t [-Wdeprecated-declarations]
   70 |         virtual Imath::Int64 tellg() {
      |                                    ^
In file included from Source/FreeImage/PluginEXR.cpp:41:
C:/msys64/mingw64/include/Imath/ImathInt64.h:37:32: note: declared here
   37 | typedef long long unsigned int Int64;
      |                                ^~~~~
Source/FreeImage/PluginEXR.cpp:74:44: warning: 'Imath_3_1::Int64' is deprecated: use uint64_t [-Wdeprecated-declarations]
   74 |         virtual void seekg(Imath::Int64 pos) {
      |                                            ^
C:/msys64/mingw64/include/Imath/ImathInt64.h:37:32: note: declared here
   37 | typedef long long unsigned int Int64;
      |                                ^~~~~
Source/FreeImage/PluginEXR.cpp:104:36: warning: 'Imath_3_1::Int64' is deprecated: use uint64_t [-Wdeprecated-declarations]
  104 |         virtual Imath::Int64 tellp() {
      |                                    ^
C:/msys64/mingw64/include/Imath/ImathInt64.h:37:32: note: declared here
   37 | typedef long long unsigned int Int64;
      |                                ^~~~~
Source/FreeImage/PluginEXR.cpp:108:44: warning: 'Imath_3_1::Int64' is deprecated: use uint64_t [-Wdeprecated-declarations]
  108 |         virtual void seekp(Imath::Int64 pos) {
      |                                            ^
C:/msys64/mingw64/include/Imath/ImathInt64.h:37:32: note: declared here
   37 | typedef long long unsigned int Int64;
      |                                ^~~~~
In file included from Source/FreeImage/Plugin.cpp:37:
Source/Utilities.h:449:1: error: variable or field 'SwapInt64' declared void
  449 | SwapInt64(uint64_t *arg) {
      | ^~~~~~~~~
Source/Utilities.h:449:11: error: 'uint64_t' was not declared in this scope
  449 | SwapInt64(uint64_t *arg) {
      |           ^~~~~~~~
Source/Utilities.h:54:1: note: 'uint64_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
   53 | #include <memory>
  +++ |+#include <cstdint>
   54 |
Source/Utilities.h:449:21: error: 'arg' was not declared in this scope
  449 | SwapInt64(uint64_t *arg) {
      |                     ^~~
make: *** [Makefile.gnu:66: Source/FreeImage/Plugin.o] Error 1
In file included from Source/FreeImage/PluginJPEG.cpp:44:
Source/Utilities.h:449:1: error: variable or field 'SwapInt64' declared void
  449 | SwapInt64(uint64_t *arg) {
      | ^~~~~~~~~
Source/Utilities.h:449:11: error: 'uint64_t' was not declared in this scope
  449 | SwapInt64(uint64_t *arg) {
      |           ^~~~~~~~
Source/Utilities.h:54:1: note: 'uint64_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
   53 | #include <memory>
  +++ |+#include <cstdint>
   54 |
Source/Utilities.h:449:21: error: 'arg' was not declared in this scope
  449 | SwapInt64(uint64_t *arg) {
      |                     ^~~
make: *** [Makefile.gnu:66: Source/FreeImage/PluginJPEG.o] Error 1
==> ERROR: A failure occurred in build().
    Aborting...

```