### PR TITLE
llvm: split a new package llvm-tools

### DIFF
--- a/mingw-w64-llvm/PKGBUILD
+++ b/mingw-w64-llvm/PKGBUILD
@@ -10,9 +10,7 @@
 if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then
   _clangprefix=1
   _compiler=clang
-  if [[ ${CARCH} != i686 ]]; then
-    _pgo=1
-  fi
+  _pgo=1
 else
   _compiler=clang
 fi
@@ -20,6 +18,7 @@ fi
 _realname=llvm
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-llvm"
+         "${MINGW_PACKAGE_PREFIX}-llvm-tools"
          "${MINGW_PACKAGE_PREFIX}-llvm-libs"
          "${MINGW_PACKAGE_PREFIX}-clang"
          "${MINGW_PACKAGE_PREFIX}-clang-libs"
@@ -30,11 +29,12 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-llvm"
          "${MINGW_PACKAGE_PREFIX}-lld")
 _pkgver=20.1.5
 pkgver=${_pkgver/-/}
-pkgrel=1
+pkgrel=2
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://llvm.org/"
+msys2_repository_url="https://github.com/llvm/llvm-project"
 msys2_references=(
   "cpe: cpe:/a:llvm:llvm"
 )
@@ -309,15 +309,17 @@ check() {
 package_clang() {
   pkgdesc="C language family frontend for LLVM (mingw-w64)"
   url="https://clang.llvm.org/"
-  depends=("${MINGW_PACKAGE_PREFIX}-llvm=${pkgver}"
-           "${MINGW_PACKAGE_PREFIX}-clang-libs=${pkgver}"
+  depends=("${MINGW_PACKAGE_PREFIX}-clang-libs=${pkgver}"
            $( ((_clangprefix)) && echo \
              "${MINGW_PACKAGE_PREFIX}-compiler-rt=${pkgver}" \
+             "${MINGW_PACKAGE_PREFIX}-llvm-tools=${pkgver}" \
              "${MINGW_PACKAGE_PREFIX}-crt" \
              "${MINGW_PACKAGE_PREFIX}-headers" \
              "${MINGW_PACKAGE_PREFIX}-lld=${pkgver}" \
-             "${MINGW_PACKAGE_PREFIX}-winpthreads" \
-             || echo "${MINGW_PACKAGE_PREFIX}-gcc"))
+             "${MINGW_PACKAGE_PREFIX}-winpthreads" || echo \
+             "${MINGW_PACKAGE_PREFIX}-llvm-libs=${pkgver}" \
+             "${MINGW_PACKAGE_PREFIX}-gcc"))
+  optdepends=("${MINGW_PACKAGE_PREFIX}-llvm=${pkgver}")
   provides=($( (( _clangprefix )) && echo \
              "${MINGW_PACKAGE_PREFIX}-cc" \
              || true ))
@@ -432,25 +434,16 @@ package_lld() {
 
 package_llvm() {
   pkgdesc="Low Level Virtual Machine (mingw-w64)"
-  depends=("${MINGW_PACKAGE_PREFIX}-llvm-libs=${pkgver}")
+  depends=("${MINGW_PACKAGE_PREFIX}-llvm-libs=${pkgver}"
+           "${MINGW_PACKAGE_PREFIX}-llvm-tools=${pkgver}")
 
   # Disable automatic installation of components that go into subpackages
   # -i.orig to check what has been removed in-case it starts dropping more than it should
-  sed -i.orig '/\(clang\|lld\)\/cmake_install.cmake/d' build-${MSYSTEM}/tools/cmake_install.cmake
+  sed -i.orig '/tools\/cmake_install.cmake/d' build-${MSYSTEM}/cmake_install.cmake
   sed -i.orig '/compiler-rt\/cmake_install.cmake/d' build-${MSYSTEM}/projects/cmake_install.cmake
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install build-${MSYSTEM}
 
   install -Dm644 "${srcdir}"/llvm/LICENSE.TXT "${pkgdir}"${MINGW_PREFIX}/share/licenses/llvm/LICENSE
-
-  # Runtime libraries
-  rm -rf "${srcdir}"/llvm-libs
-  mkdir -p "${srcdir}"/llvm-libs/${MINGW_PREFIX}/bin
-  mv -f "${pkgdir}"${MINGW_PREFIX}/bin/lib{LLVM-*,LTO,Remarks}.dll "${srcdir}"/llvm-libs/${MINGW_PREFIX}/bin
-
-  # Provide gcov on CLANG*
-  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
-    cp "${pkgdir}"${MINGW_PREFIX}/bin/llvm-cov.exe "${pkgdir}"${MINGW_PREFIX}/bin/gcov.exe
-  fi
 
   # Install CMake stuff
   install -d "${pkgdir}"${MINGW_PREFIX}/share/llvm/cmake/{modules,platforms}
@@ -460,6 +453,31 @@ package_llvm() {
   # fix cmake files.
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
   sed -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i "${pkgdir}"/${MINGW_PREFIX}/lib/cmake/llvm/LLVMExports.cmake
+}
+
+package_llvm-tools() {
+  pkgdesc="Low Level Virtual Machine - Tools (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-llvm-libs=${pkgver}")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-llvm<20.1.5-2")
+
+  # Disable automatic installation of components that go into subpackages
+  # -i.orig to check what has been removed in-case it starts dropping more than it should
+  sed -i.orig '/\(clang\|lld\)\/cmake_install.cmake/d' build-${MSYSTEM}/tools/cmake_install.cmake
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install build-${MSYSTEM}/tools
+
+  # Runtime libraries
+  rm -rf "${srcdir}"/llvm-libs
+  mkdir -p "${srcdir}"/llvm-libs/${MINGW_PREFIX}/bin
+  mv -f "${pkgdir}"${MINGW_PREFIX}/bin/lib{LLVM-*,LTO,Remarks}.dll "${srcdir}"/llvm-libs/${MINGW_PREFIX}/bin
+  # remove duplicate headers already in llvm package
+  rm -r "${pkgdir}"${MINGW_PREFIX}/include/llvm-c
+
+  install -Dm644 "${srcdir}"/llvm/LICENSE.TXT "${pkgdir}"${MINGW_PREFIX}/share/licenses/llvm-tools/LICENSE
+
+  # Provide gcov on CLANG*
+  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
+    cp "${pkgdir}"${MINGW_PREFIX}/bin/llvm-cov.exe "${pkgdir}"${MINGW_PREFIX}/bin/gcov.exe
+  fi
 }
 
 package_llvm-libs() {


### PR DESCRIPTION
This is to minimize toolchain installation size on clang* environments.