### PR TITLE
codeblocks: patches gcc 15.x bug issue

### DIFF
--- a/mingw-w64-codeblocks/201-Build-Fix-compilation-with-MSYS2-GCC-15.1.patch
+++ b/mingw-w64-codeblocks/201-Build-Fix-compilation-with-MSYS2-GCC-15.1.patch
@@ -1,0 +1,10 @@
+--- a/src/include/globals.h
++++ b/src/include/globals.h
+@@ -6,6 +6,7 @@
+ #ifndef SDK_GLOBALS_H
+ #define SDK_GLOBALS_H
+ 
++#include <cstdint>
+ #include <map>
+ #include <memory>
+ #include <vector>

--- a/mingw-w64-codeblocks/PKGBUILD
+++ b/mingw-w64-codeblocks/PKGBUILD
@@ -6,7 +6,7 @@ _realname=codeblocks
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=25.03
-pkgrel=2
+pkgrel=3
 pkgdesc="A free C, C++ and Fortran IDE (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -29,8 +29,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "zip"
              "subversion")
 optdepends=("${MINGW_PACKAGE_PREFIX}-clang-tools-extra: needed by Clangd_Client plugin")
-source=("https://downloads.sourceforge.net/project/codeblocks/Sources/${pkgver}/${_realname}_${pkgver}.tar.xz")
-sha256sums=('b0f6aa5908d336d7f41f9576b2418ac7d27efbc59282aa8c9171d88cea74049e')
+source=("https://downloads.sourceforge.net/project/codeblocks/Sources/${pkgver}/${_realname}_${pkgver}.tar.xz"
+        '201-Build-Fix-compilation-with-MSYS2-GCC-15.1.patch')
+sha256sums=('b0f6aa5908d336d7f41f9576b2418ac7d27efbc59282aa8c9171d88cea74049e'
+            'def05b152e3a79db04135a9b23ddfd3373dcf813254eaeca7a21c0989dc7bf1a')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -42,6 +44,8 @@ apply_patch_with_msg() {
 
 prepare() {
   cd "${_realname}_${pkgver}"
+
+  apply_patch_with_msg 201-Build-Fix-compilation-with-MSYS2-GCC-15.1.patch
 
   ./bootstrap
 }


### PR DESCRIPTION
The provides helps to avoid future run-time issues with CB plugins like the FORTRAN plugin using a different base version of wxWidgets. The CB plugin needs to depend on the wxWidgets versioned of the Code::Blocks IDE. 

The maintainer rejected fixing the problem before it happens.