### PR TITLE
Rename gcc-libs to cc-libs

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -51,7 +51,7 @@ else
   _sourcedir=${_realname}-${_version}-${_snapshot}
   _url=https://gcc.gnu.org/pub/gcc/snapshots/${_version}-${_snapshot}
 fi
-pkgrel=4
+pkgrel=5
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -298,7 +298,7 @@ build() {
 package_gcc-libs() {
   pkgdesc="GNU Compiler Collection (libraries) for MinGW-w64"
   depends=("${MINGW_PACKAGE_PREFIX}-libwinpthread")
-  provides=("${MINGW_PACKAGE_PREFIX}-omp")
+  provides=("${MINGW_PACKAGE_PREFIX}-omp" "${MINGW_PACKAGE_PREFIX}-cc-libs")
 
   # Licensing information
 

--- a/mingw-w64-libc++/PKGBUILD
+++ b/mingw-w64-libc++/PKGBUILD
@@ -10,7 +10,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-libunwind")
 _pkgver=20.1.5
 pkgver=${_pkgver/-/}
-pkgrel=1
+pkgrel=2
 arch=(any)
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://libcxx.llvm.org/"
@@ -116,6 +116,7 @@ package_libc++() {
   provides=("${MINGW_PACKAGE_PREFIX}-libc++abi"
             $( (( _clangprefix )) && echo \
              "${MINGW_PACKAGE_PREFIX}-gcc-libs" \
+             "${MINGW_PACKAGE_PREFIX}-cc-libs" \
              || true))
   depends=($( (( _clangprefix )) && echo \
              "${MINGW_PACKAGE_PREFIX}-libunwind" \


### PR DESCRIPTION
They are not provided by gcc in the clang envs, so make this more clear.