### PR TITLE
rust-wasm: add target wasm32-unknown-emscripten

### DIFF
--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -16,9 +16,10 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          $([[ ${CARCH} == i686 ]] || echo \
          "${MINGW_PACKAGE_PREFIX}-rust-wasm" \
+         "${MINGW_PACKAGE_PREFIX}-rust-emscripten" \
          "${MINGW_PACKAGE_PREFIX}-rust-src"))
 pkgver=1.87.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -42,7 +43,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python"
              "${MINGW_PACKAGE_PREFIX}-sqlite3"
              $([[ "$_bootstrapping" == "no" ]] && echo "${MINGW_PACKAGE_PREFIX}-rust")
-             $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-wasi-libc ${MINGW_PACKAGE_PREFIX}-wasm-component-ld")
+             $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-wasi-libc ${MINGW_PACKAGE_PREFIX}-wasm-component-ld ${MINGW_PACKAGE_PREFIX}-emscripten")
              "${MINGW_PACKAGE_PREFIX}-xz"
              "${MINGW_PACKAGE_PREFIX}-zstd"
              "${MINGW_PACKAGE_PREFIX}-zlib")
@@ -54,7 +55,7 @@ source=("${rust_dist_server}/${_realname}c-${pkgver}-src.tar.gz"{,.asc}
 noextract=(${_realname}c-${pkgver}-src.tar.gz)
 sha256sums=('149bb9fd29be592da4e87900fc68f0629a37bf6850b46339dd44434c04fd8e76'
             'SKIP'
-            'aefcbb914d3f34918241731248da3bc1288b3104f042a6d4e86492038100e620'
+            '4450ad9b3acd4cb694f1b4356545aabdbc1074fadba01c5f6f09639c2d94f786'
             '7cb1773c288ffb1c1e751edc49b1890c84bf9c362742bc5225d19d474edb73a0'
             '56882f1a0f1404c10c7726d6cc37444f2b343e72b969badfcb43760f80db0f32'
             '87b68c2dfbe996d3ef439278e1ac90997fc4ea192f449e8f00262360a551386a')
@@ -160,7 +161,7 @@ build() {
 
   # Add target wasm32-*
   if [[ ${CARCH} != i686 ]]; then
-    sed -i -e '/target = \[/a\  "wasm32-unknown-unknown", "wasm32-wasip1", "wasm32v1-none", "wasm32-wasip1-threads", "wasm32-wasip2",' \
+    sed -i -e '/target = \[/a\  "wasm32-unknown-unknown", "wasm32-unknown-emscripten", "wasm32-wasip1", "wasm32v1-none", "wasm32-wasip1-threads", "wasm32-wasip2",' \
            -e '/tools = \[/a\  "clippy", "rustdoc", "rustfmt", "rust-analyzer-proc-macro-srv", "analysis", "src",' bootstrap.toml
   fi
 
@@ -173,6 +174,9 @@ build() {
 
   cd build-${MSYSTEM}
   if [[ ${CARCH} != i686 ]]; then
+    # move wasm32-unknown-emscripten out of the way for splitting
+    mkdir -p dest-emscripten${MINGW_PREFIX}/lib/rustlib
+    mv dest-rust${MINGW_PREFIX}/lib/rustlib/wasm32-unknown-emscripten dest-emscripten${MINGW_PREFIX}/lib/rustlib
     # move wasm32-* targets out of the way for splitting
     mkdir -p dest-wasm${MINGW_PREFIX}/lib/rustlib
     mv dest-rust${MINGW_PREFIX}/lib/rustlib/wasm32{,v1}-* dest-wasm${MINGW_PREFIX}/lib/rustlib
@@ -238,6 +242,27 @@ package_rust-wasm() {
   popd
 
   install -Dm644 ../LICENSE-{APACHE,MIT} -t "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-wasm"
+}
+
+package_rust-emscripten() {
+  pkgdesc="Emscripten target for Rust (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-rust" "${MINGW_PACKAGE_PREFIX}-emscripten")
+  options=('!strip')
+
+  cd "${_realname}c-${pkgver}-src/build-${MSYSTEM}"
+
+  cp -a dest-emscripten/* "${pkgdir}"
+
+  pushd "${pkgdir}${MINGW_PREFIX}"/lib/rustlib
+    llvm-strip --strip-debug wasm32*/lib/*.rlib
+  popd
+
+  # manually add self-contained linkers to make emscripten target happy
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/lib/rustlib/$OSTYPE/bin/gcc-ld/"
+  cp "${MINGW_PREFIX}"/bin/{ld{,64}.lld,lld-link,wasm-ld} \
+    "${pkgdir}${MINGW_PREFIX}/lib/rustlib/$OSTYPE/bin/gcc-ld/"
+
+  install -Dm644 ../LICENSE-{APACHE,MIT} -t "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-emscripten"
 }
 
 package_rust-src() {

--- a/mingw-w64-rust/bootstrap.toml
+++ b/mingw-w64-rust/bootstrap.toml
@@ -72,6 +72,15 @@ linker = "$MINGW_PREFIX/bin/wasm-ld.exe"
 default-linker = "wasm-ld.exe"
 profiler = false
 
+[target.wasm32-unknown-emscripten]
+cc = "$MINGW_PREFIX/lib/emscripten/emcc.bat"
+cxx = "$MINGW_PREFIX/lib/emscripten/em++.bat"
+ar = "$MINGW_PREFIX/lib/emscripten/emar.bat"
+ranlib = "$MINGW_PREFIX/lib/emscripten/emranlib.bat"
+linker = "$MINGW_PREFIX/bin/wasm-ld.exe"
+default-linker = "wasm-ld.exe"
+profiler = false
+
 [target.wasm32v1-none]
 cc = "$MINGW_PREFIX/bin/clang.exe"
 cxx = "$MINGW_PREFIX/bin/clang++.exe"


### PR DESCRIPTION
closes #24312

_Just for note:_ 
- [wams32-unknown-emscripten](https://doc.rust-lang.org/stable/rustc/platform-support/wasm32-unknown-emscripten.html)
- [Alon Zakai's Blog](https://kripken.github.io/blog/): [Small WebAssembly Binaries with Rust + Emscripten](https://kripken.github.io/blog/binaryen/2018/04/18/rust-emscripten.html)

Cc: @ognevny, @kripken, @hoodmane, @juntyr