### PR TITLE
fpm: add gcc15 patch

### DIFF
--- a/mingw-w64-fpm/PKGBUILD
+++ b/mingw-w64-fpm/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.12.0
 _bootstrap_ver=0.8.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Fortran package manager (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64') # 'clang64' 'clangarm64')
@@ -21,9 +21,25 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-fc"
              "git")
 optdepends=("git: Support for fetching projects with git")
 source=("${url}/releases/download/v${pkgver}/fpm-${pkgver}.zip"
-        "${url}/releases/download/v${_bootstrap_ver}/fpm-${_bootstrap_ver}.F90")
+        "${url}/releases/download/v${_bootstrap_ver}/fpm-${_bootstrap_ver}.F90"
+        "fpm_0_12_0_gcc15_bugfix.patch")
 sha256sums=('b519b614c693dc26f553f0eb902fc707adab9d1759f17ff098412c14d6b290fe'
-            '0c95309f365a40900108f3325e17e99a0456ce76046c37326349bf61b3df447a')
+            '0c95309f365a40900108f3325e17e99a0456ce76046c37326349bf61b3df447a'
+            '3b3263865a4b2c4d91ee34229adfa09fd1151af4c25fad2394d7b61ae564c10e')
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying ${_patch}"
+    patch -Nbp1 -i "${srcdir}/${_patch}"
+  done
+}
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  apply_patch_with_msg fpm_0_12_0_gcc15_bugfix.patch
+}
 
 build() {
   cd "${srcdir}/${_realname}-${pkgver}"

--- a/mingw-w64-fpm/fpm_0_12_0_gcc15_bugfix.patch
+++ b/mingw-w64-fpm/fpm_0_12_0_gcc15_bugfix.patch
@@ -1,0 +1,53 @@
+diff --git a/src/fpm_compile_commands.F90 b/src/fpm_compile_commands.F90
+index d085204447..826250aa30 100644
+--- a/src/fpm_compile_commands.F90
++++ b/src/fpm_compile_commands.F90
+@@ -55,8 +55,34 @@ module fpm_compile_commands
+         
+     end type compile_command_table_t    
+     
++    interface compile_command_t
++        module procedure cct_new
++    end interface compile_command_t
++    
+     contains
+     
++    !> Override default initializer (GCC 15 bug)
++    type(compile_command_t) function cct_new(directory,arguments,file) result(cct)
++        character(len=*), intent(in) :: directory,file
++        character(len=*), optional, intent(in) :: arguments(:)
++        
++        integer :: i,n
++        
++        cct%directory = string_t(trim(directory))
++        cct%file = string_t(trim(file))
++        
++        if (present(arguments)) then 
++           n = size(arguments)
++        else
++           n = 0
++        endif
++        allocate(cct%arguments(n))
++        do i=1,n
++            cct%arguments(i) = string_t(trim(arguments(i)))
++        end do
++        
++    end function cct_new  
++      
+     !> Cleanup compile command
+     elemental subroutine compile_command_destroy(self)
+     
+@@ -281,10 +307,9 @@ subroutine cct_register(self, command, target_os, error)
+         ! Fallback: use last argument if not found
+         if (len_trim(source_file)==0) source_file = trim(args(n))
+ 
+-        ! Fill in the compile_command_t
+-        cmd = compile_command_t(directory = string_t(cwd), &
+-                                arguments = [(string_t(trim(args(i))), i=1,n)], &
+-                                file = string_t(source_file))
++        ! Fill in the compile_command_t. 
++        ! Use non-default initializer due to gcc 15 bug
++        cmd = compile_command_t(cwd, args, source_file)
+         
+         ! Add it to the structure
+         !$omp critical (command_update)


### PR DESCRIPTION
fpm v0.12.0 crashes due to a gcc-15.1 bug:
https://fortran-lang.discourse.group/t/error-building-csv-fortran-with-fpm/9760/5

Fix: patch source using https://github.com/fortran-lang/fpm/pull/1147/files

cc: @zoziha @MehdiChinoune 