### PR TITLE
Revert "cbindgen: update to 0.29.0"

### DIFF
--- a/mingw-w64-cbindgen/PKGBUILD
+++ b/mingw-w64-cbindgen/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=cbindgen
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.29.0
+pkgver=0.28.0
 pkgrel=1
 pkgdesc="A project for generating C bindings from Rust code (mingw-w64)"
 arch=('any')
@@ -18,7 +18,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-cmake"
               "${MINGW_PACKAGE_PREFIX}-cython"
               "${MINGW_PACKAGE_PREFIX}-python")
 source=("${url}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('6697f449d4a15d814d991249a611af961c97e36d9344c7ced6df35c5c25b40cc')
+sha256sums=('b0ed39dda089cafba583e407183e43de151d2ae9d945d74fb4870db7e4ca858e')
 
 prepare() {
   cd "${_realname}-${pkgver}"


### PR DESCRIPTION
Reverts msys2/MINGW-packages#24326

it should be blocked on msys2/MSYS2-packages#5413