### PR TITLE
double-conversion: Fix build with cmake 4

### DIFF
--- a/mingw-w64-double-conversion/PKGBUILD
+++ b/mingw-w64-double-conversion/PKGBUILD
@@ -4,7 +4,7 @@ _realname=double-conversion
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=3.3.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Binary-decimal and decimal-binary routines for IEEE doubles (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -25,6 +25,7 @@ build() {
     ${MINGW_PREFIX}/bin/cmake \
       -G'Ninja' \
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      -DCMAKE_POLICY_VERSION_MINIMUM=4.0 \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_LIBDIR=lib \
       -DBUILD_SHARED_LIBS=ON \
@@ -39,6 +40,7 @@ build() {
     ${MINGW_PREFIX}/bin/cmake \
       -G'Ninja' \
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      -DCMAKE_POLICY_VERSION_MINIMUM=4.0 \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_LIBDIR=lib \
       -DBUILD_SHARED_LIBS=OFF \


### PR DESCRIPTION
```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

This workaround can be removed on next release, following https://github.com/google/double-conversion/pull/246.