### PR TITLE
podman: Update to 5.5.0

### DIFF
--- a/mingw-w64-podman/PKGBUILD
+++ b/mingw-w64-podman/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=podman
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=5.4.2
+pkgver=5.5.0
 pkgrel=1
 pkgdesc='Tool for running OCI-based containers in pods (mingw-w64)'
 arch=('any')
@@ -21,21 +21,26 @@ makedepends=(
     "git" "man-db"  # needed during the build
 )
 options=('!strip')
-_GV_VERSION="0.8.4"  # See GVPROXY_VERSION in Makefile
+_GV_VERSION="v0.8.6"  # See gvisor-tap-vsock in go.mod
 source=("https://github.com/containers/podman/archive/v$pkgver/${_realname}-${pkgver}.tar.gz"
-        "https://github.com/containers/gvisor-tap-vsock/archive/v${_GV_VERSION}/gvisor-tap-vsock-${_GV_VERSION}.tar.gz")
-sha256sums=('8da62c25956441b14d781099e803e38410a5753e5c7349bcd34615b9ca5ed4f2'
-            '6a2645a3627bdf1d8bfe4a41ecf97956df987464aade18e1574f67e21950e0d1')
+        "https://github.com/containers/gvisor-tap-vsock/archive/${_GV_VERSION}/gvisor-tap-vsock-${_GV_VERSION#v}.tar.gz")
+sha256sums=('a4abfc72ef9a59ba80d081ea604ad2976ff967ae526e50e234edc1d2481bd9d1'
+            'eb08309d452823ca7e309da2f58c031bb42bb1b1f2f0bf09ca98b299e326b215')
 noextract=("${_realname}-${pkgver}.tar.gz")
 
 prepare() {
     echo "Extracting ${_realname}-${pkgver}.tar.gz ..."
     tar -xzf ${_realname}-${pkgver}.tar.gz | true
     rm -rf build-${MSYSTEM}
-
     cp -r ${_realname}-${pkgver} build-${MSYSTEM}
+    cp -r "gvisor-tap-vsock-${_GV_VERSION#v}" "build-proxy-${MSYSTEM}"
 
-    cp -r "gvisor-tap-vsock-${_GV_VERSION}" "build-proxy-${MSYSTEM}"
+    cd "${srcdir}/build-${MSYSTEM}"
+    _gomod_gv_version=$(go list -m -f '{{.Version}}' github.com/containers/gvisor-tap-vsock)
+    if [[ "${_gomod_gv_version}" != "$_GV_VERSION" ]]; then
+        echo "Error: _GV_VERSION does not match the version (${_gomod_gv_version}) in go.mod"
+        exit 1
+    fi
 }
 
 build() {


### PR DESCRIPTION
the source of gvisor-tap-vsock version moved from the makefile to go.mod