### PR TITLE
rav1e: update to 0.8.0

### DIFF
--- a/mingw-w64-rav1e/PKGBUILD
+++ b/mingw-w64-rav1e/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=rav1e
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.7.1
-pkgrel=7
+pkgver=0.8.0
+pkgrel=1
 pkgdesc='An AV1 encoder focused on speed and safety (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -17,16 +17,13 @@ license=('spdx:BSD-2-Clause')
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-cargo-c"
              $([[ "${CARCH}" == "aarch64"  ]] || echo "${MINGW_PACKAGE_PREFIX}-nasm"))
-source=("https://github.com/xiph/rav1e/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
-        "https://github.com/xiph/rav1e/releases/download/v${pkgver}/Cargo.lock")
-sha256sums=('da7ae0df2b608e539de5d443c096e109442cdfa6c5e9b4014361211cf61d030c'
-            '4482976bfb7647d707f9a01fa1a3848366988f439924b5c8ac7ab085fba24240')
+options=('!strip')
+source=("https://github.com/xiph/rav1e/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('2580bb4b4efae50e0a228e8ba80db1f73805a0e6f6a8c22bee066c90afb35ba0')
 
 prepare() {
-  cp Cargo.lock "${_realname}-${pkgver}"
   cd "${_realname}-${pkgver}"
 
-  cargo update -p cc
   cargo fetch --locked
 }
 
@@ -35,15 +32,14 @@ build() {
 
   export WINAPI_NO_BUNDLED_LIBRARIES=1
   cargo build \
-    --release \
     --frozen \
-    --offline
+    --profile release-strip
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
     cargo capi build \
       --meson-paths \
-      --release \
       --frozen \
+      --profile release-strip \
       --prefix="${MINGW_PREFIX}"
 }
 
@@ -51,8 +47,8 @@ check() {
   cd "${_realname}-${pkgver}"
 
   cargo test \
-    --release \
-    --frozen
+    --frozen \
+    --profile release-strip
 }
 
 package() {
@@ -63,15 +59,16 @@ package() {
     --offline \
     --no-track \
     --path . \
-    --root "${pkgdir}${MINGW_PREFIX}"
+    --root "${pkgdir}${MINGW_PREFIX}" \
+    --profile release-strip
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
     cargo capi install \
       --meson-paths \
-      --release \
       --frozen \
       --prefix="${MINGW_PREFIX}" \
-      --destdir="${pkgdir}"
+      --destdir="${pkgdir}" \
+      --profile release-strip
 
   # Remove def file
   rm -f "${pkgdir}"${MINGW_PREFIX}/lib/*.def


### PR DESCRIPTION
lockfile is provided in upstream tarball