### PR TITLE
python-cx-freeze: backport a patch for python-lief bump

### DIFF
--- a/mingw-w64-python-cx-freeze/PKGBUILD
+++ b/mingw-w64-python-cx-freeze/PKGBUILD
@@ -7,7 +7,7 @@ _realname=cx-freeze
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=8.3.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Creates standalone executables from Python scripts, with the same performance (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -43,37 +43,37 @@ checkdepends=(
 options=(!strip)
 source=(
   "https://pypi.org/packages/source/${_realname::1}/${_realname/-/_}/${_realname/-/_}-${pkgver}.tar.gz"
+  "c787ff9383c6f83a45a4c7324d681a3929d63bd1.patch"
   #"${url}/archive/${pkgver}/${_realname}-${pkgver}.tar.gz"
 )
-sha256sums=(
-  '491998d513f04841ec7967e2a3792db198597bde8a0c9333706b1f96060bdb35'
-)
+sha256sums=('491998d513f04841ec7967e2a3792db198597bde8a0c9333706b1f96060bdb35'
+            'ab698b98d9936832a64779593a3100a078372a42e839729ad8bda477e764a5fe')
 
 prepare() {
-  cd "${srcdir}"/cx_Freeze-${pkgver}
-  # ignore version check for setuptools
+  cd cx_freeze-${pkgver}
+  # ignore version check for setuptools and bump lief version
   sed -i 's/"setuptools>=.*"/"setuptools"/' pyproject.toml
+  patch -Np1 -i ../c787ff9383c6f83a45a4c7324d681a3929d63bd1.patch
 
   rm -Rf "${srcdir}"/python-${_realname}-${MSYSTEM}
-  cp -a "${srcdir}"/cx_Freeze-${pkgver} "${srcdir}"/python-${_realname}-${MSYSTEM}
+  cp -a "${srcdir}"/cx_freeze-${pkgver} "${srcdir}"/python-${_realname}-${MSYSTEM}
 }
 
 build() {
   cd python-${_realname}-${MSYSTEM}
-  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
+  python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 check() {
   cd python-${_realname}-${MSYSTEM}
-  ${MINGW_PREFIX}/bin/pip install cx_Freeze -f dist --no-deps --no-index
-  ${MINGW_PREFIX}/bin/pytest -nauto --cov="cx_Freeze"
+  pip install cx_Freeze -f dist --no-deps --no-index
+  pytest -nauto --cov="cx_Freeze"
 }
 
 package() {
   cd python-${_realname}-${MSYSTEM}
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    python -m installer --prefix=${MINGW_PREFIX} \
     --destdir="${pkgdir}" dist/*.whl
   install -Dm644 LICENSE.md "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE.md"
 }
-

--- a/mingw-w64-python-cx-freeze/c787ff9383c6f83a45a4c7324d681a3929d63bd1.patch
+++ b/mingw-w64-python-cx-freeze/c787ff9383c6f83a45a4c7324d681a3929d63bd1.patch
@@ -1,0 +1,44 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -49,7 +49,7 @@ dependencies = [
+     # Windows
+     "cabarchive>=0.2.4 ;sys_platform == 'win32'",
+     "cx_Logging>=3.1 ;sys_platform == 'win32' and platform_machine != 'ARM64'",
+-    "lief>=0.15.1,<=0.16.5 ;sys_platform == 'win32' and platform_machine != 'ARM64'",
++    "lief>=0.15.1,<=0.16.6 ;sys_platform == 'win32'",
+     "striprtf>=0.0.26 ;sys_platform == 'win32'",
+ ]
+ dynamic = ["version"]
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -11,5 +11,5 @@ patchelf>=0.14 ;sys_platform == 'linux' and platform_machine == 's390x'
+ dmgbuild>=1.6.1 ;sys_platform == 'darwin'
+ cabarchive>=0.2.4 ;sys_platform == 'win32'
+ cx_Logging>=3.1 ;sys_platform == 'win32' and platform_machine != 'ARM64'
+-lief>=0.15.1,<=0.16.5 ;sys_platform == 'win32' and platform_machine != 'ARM64'
++lief>=0.15.1,<=0.16.6 ;sys_platform == 'win32'
+ striprtf>=0.0.26 ;sys_platform == 'win32'
+--- a/tests/test_dep_parser.py
++++ b/tests/test_dep_parser.py
+@@ -24,7 +24,9 @@
+ 
+ if IS_WINDOWS:
+     PACKAGE_VERSION = [("imagehlp", "bind")]
+-    if not IS_ARM_64:
++    if IS_ARM_64:
++        PACKAGE_VERSION += [("lief", "0.16.6")]
++    else:
+         # use 0.16.4 to work with pypi and conda versions
+         PACKAGE_VERSION += [("lief", "0.15.1"), ("lief", "0.16.4")]
+ elif IS_MINGW:
+--- a/tests/test_windows_manifest.py
++++ b/tests/test_windows_manifest.py
+@@ -77,7 +77,7 @@ def test_manifest(tmp_package) -> None:
+ LIEF_VERSIONS = []
+ if IS_WINDOWS:
+     if IS_ARM_64:
+-        LIEF_VERSIONS += ["disabled"]
++        LIEF_VERSIONS += ["0.16.6"]
+     else:
+         # use 0.16.4 to work with pypi and conda versions
+         LIEF_VERSIONS += ["0.15.1", "0.16.4"]


### PR DESCRIPTION
to satisfy python-lief [PR](https://github.com/msys2/MINGW-packages/pull/24407) check