### PR TITLE
python-rapidfuzz: fix clang build

### DIFF
--- a/mingw-w64-python-rapidfuzz/0001-fix-build-clang.patch
+++ b/mingw-w64-python-rapidfuzz/0001-fix-build-clang.patch
@@ -1,0 +1,11 @@
+--- rapidfuzz-3.13.0/src/rapidfuzz/FeatureDetector/CpuInfo.cpp.orig	2025-05-30 23:26:55.714422900 +0200
++++ rapidfuzz-3.13.0/src/rapidfuzz/FeatureDetector/CpuInfo.cpp	2022-11-09 13:37:21.000000000 +0100
+@@ -2,7 +2,7 @@
+ #include "CpuInfo.hpp"
+ #include <string.h>
+ 
+-#if defined(_WIN32) && (defined(_MSC_VER) || defined(__clang__))
++#if defined(_WIN32) && defined(_MSC_VER)
+ #include <intrin.h>
+ 
+ __forceinline void cpuid(int32_t out[4], int32_t eax, int32_t ecx)

--- a/mingw-w64-python-rapidfuzz/PKGBUILD
+++ b/mingw-w64-python-rapidfuzz/PKGBUILD
@@ -4,7 +4,7 @@ _realname=rapidfuzz
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=3.13.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Rapid fuzzy string matching. (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -26,10 +26,16 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-cc")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest-cov"
               "${MINGW_PACKAGE_PREFIX}-python-pytest")
-source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('d2eaf3839e52cbcc0accbe9817a67b4b0fcf70aaeb229cfddc1c28061f9ce5d8')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
+        "0001-fix-build-clang.patch")
+sha256sums=('d2eaf3839e52cbcc0accbe9817a67b4b0fcf70aaeb229cfddc1c28061f9ce5d8'
+            'd40345312c73b0f5d1c2f95ba678210228820892e3d162f9d90240c08557cb9b')
 
 prepare(){
+  cd "RapidFuzz-${pkgver}"
+  patch -p1 -i "${srcdir}/0001-fix-build-clang.patch"
+  cd -
+
   cp -r "RapidFuzz-${pkgver}" "python-build-${MSYSTEM}"
   rm -rf "python-build-${MSYSTEM}/extern"
   cp -r "${_realname}-${pkgver}/extern" "python-build-${MSYSTEM}/extern"


### PR DESCRIPTION
CpuInfo.cpp:15:12: error: '__builtin_ia32_xgetbv' needs target feature xsave

just avoid the MSVC code path