### PR TITLE
gst-plugins-rs: rebuild for dynamic libunwind in CLANG

### DIFF
--- a/mingw-w64-gst-plugins-rs/PKGBUILD
+++ b/mingw-w64-gst-plugins-rs/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=1.26.2
 _tag=gstreamer-${pkgver}
-pkgrel=1
+pkgrel=2
 pkgdesc='GStreamer plugins written in Rust (mingw-w64)'
 arch=(any)
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -54,6 +54,7 @@ fi
 build() {
   cd "${_realname}-${_tag}"
 
+  export RUSTFLAGS="${RUSTFLAGS/+crt-static/-crt-static}"
   MSYS2_ARG_CONV_EXCL="--prefix=" cargo cbuild "${_cargo_opts[@]}"
 }
 


### PR DESCRIPTION
this will reduce binaries' size (but for CLANG only)

update: actually package size reduced from 109.70 MiB