### PR TITLE
mesonlsp: rebuild to remove unneded deps

### DIFF
--- a/mingw-w64-mesonlsp/PKGBUILD
+++ b/mingw-w64-mesonlsp/PKGBUILD
@@ -4,7 +4,7 @@ _realname=mesonlsp
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.3.7
-pkgrel=3
+pkgrel=4
 pkgdesc='Meson language server (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64')
@@ -15,15 +15,16 @@ depends=("${MINGW_PACKAGE_PREFIX}-curl"
          "${MINGW_PACKAGE_PREFIX}-pkgconf"
          "${MINGW_PACKAGE_PREFIX}-libtree-sitter"
          "${MINGW_PACKAGE_PREFIX}-dlfcn"
-         "${MINGW_PACKAGE_PREFIX}-tomlplusplus"
-         'git'
-         'mercurial'
-         'subversion')
+         "${MINGW_PACKAGE_PREFIX}-tomlplusplus")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-nlohmann-json"
-             "${MINGW_PACKAGE_PREFIX}-gtest")
+             "${MINGW_PACKAGE_PREFIX}-gtest"
+             'git')
+optdepends=('git: for `git` wrapper'
+            'mercurial: for `hg` wrapper'
+            'subversion: for `svn` wrapper')
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-lsprotocol"
               "${MINGW_PACKAGE_PREFIX}-python-pygls")
 source=("git+${url}.git#tag=v${pkgver}"
@@ -43,8 +44,7 @@ prepare() {
   cd "${_realname}"
 
   # apply patches that also fix build
-  git cherry-pick -n 8edb5af16db9d7651a88ae19d0574195a02e40b6
-  git cherry-pick -n 851eb422851406ca4221e7bd866cd97b51c9ac06
+  git cherry-pick -n 8edb5af16db9d7651a88ae19d0574195a02e40b6 851eb422851406ca4221e7bd866cd97b51c9ac06
 }
 
 build() {


### PR DESCRIPTION
the upstream repo was archived on March actually, so probably it worth to drop the package