### PR TITLE
luajit: update to 2.1.1748459687

### DIFF
--- a/mingw-w64-luajit/PKGBUILD
+++ b/mingw-w64-luajit/PKGBUILD
@@ -5,14 +5,14 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 # LuaJIT has abandoned versioned releases and now advises using git HEAD
 # https://github.com/LuaJIT/LuaJIT/issues/665#issuecomment-784452583
-_commit="eec7a8016c3381b949b5d84583800d05897fa960"
+_commit="f9140a622a0c44a99efb391cc1c2358bc8098ab7"
 _basever=2.1
-pkgver=2.1.1744318430
+pkgver=2.1.1748459687
 pkgrel=1
 pkgdesc="Just-in-time compiler and drop-in replacement for Lua 5.1 (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
-url="http://luajit.org/"
+url="https://luajit.org/"
 msys2_repository_url='https://repo.or.cz/w/luajit-2.0.git'
 msys2_references=(
   "cpe: cpe:/a:luajit:luajit"
@@ -25,12 +25,12 @@ provides=("${MINGW_PACKAGE_PREFIX}-lua51"
 replaces=("${MINGW_PACKAGE_PREFIX}-lua51"
           "${MINGW_PACKAGE_PREFIX}-luajit-git")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc" "git")
-source=("${_realname}"::"git+http://luajit.org/git/luajit.git#commit=${_commit}"
+source=("${_realname}"::"git+https://luajit.org/git/luajit.git#commit=${_commit}"
         001-mintty-cygpty-isatty.patch
         002-fix-pkg-config-file.patch
         003-lua51-modules-paths.patch
         004-fix-default-cc.patch)
-sha256sums=('05066e58ca71b1f942629a8c70adc91c0da6b89de19947461dbc808c9e43224a'
+sha256sums=('efcfa6960ef481633432b1df97b5e833bfaddf557ea62887f9134de208c5bf1a'
             '0cadf1b6c67c910c81ccb7a6152148dccfb0f1c6b50cdb09a5707cd45e7cbe85'
             '4df486e82b0bbeead01dcf6001e90c51477a3a8ac18611d60d7067f2c7013428'
             'a3d8c7c7724cd5a4173c6ddcbc854aa3424b78fb6c9d4b6c57ed2ebd6c2dd366'


### PR DESCRIPTION
notable changes: restored https on LuaJIT links that were disabled in the previous update.