### PR TITLE
rustup: various improvements

### DIFF
--- a/mingw-w64-rustup/PKGBUILD
+++ b/mingw-w64-rustup/PKGBUILD
@@ -4,7 +4,8 @@ _realname=rustup
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.28.2
-pkgrel=1
+pkgrel=2
+_zstd_sys_ver='2.0.15+zstd.1.5.7'
 pkgdesc="The Rust toolchain installer (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -14,16 +15,17 @@ msys2_references=(
   'archlinux: rustup'
 )
 depends=(
-  "${MINGW_PACKAGE_PREFIX}-curl"
   "${MINGW_PACKAGE_PREFIX}-xz"
-  "${MINGW_PACKAGE_PREFIX}-zstd"
 )
 makedepends=(
   "git"
   "${MINGW_PACKAGE_PREFIX}-rust"
   "${MINGW_PACKAGE_PREFIX}-rust-bindgen"
   "${MINGW_PACKAGE_PREFIX}-cmake"
+  "${MINGW_PACKAGE_PREFIX}-pkgconf"
   "${MINGW_PACKAGE_PREFIX}-nasm"
+  "${MINGW_PACKAGE_PREFIX}-zlib"
+  "${MINGW_PACKAGE_PREFIX}-zstd"
 )
 optdepends=(
   "${MINGW_PACKAGE_PREFIX}-gdb: rust-gdb script"
@@ -32,7 +34,6 @@ optdepends=(
 provides=("${MINGW_PACKAGE_PREFIX}-rust")
 conflicts=("${MINGW_PACKAGE_PREFIX}-rust")
 install='post.install'
-options=("!lto")
 source=(
   "${url}/archive/${pkgver}/rustup-${pkgver}.tar.gz"
   "rustup-profile.sh"
@@ -51,7 +52,13 @@ prepare() {
 build() {
   cd "${_realname}-${pkgver}"
 
-  cargo build --release --frozen --features no-self-update --bin rustup-init
+  export RUSTFLAGS="${RUSTFLAGS/+crt-static/-crt-static}"
+  cargo build \
+    --release \
+    --frozen \
+    --no-default-features \
+    --features "no-self-update reqwest-rustls-tls" \
+    --bin rustup-init
 }
 
 package() {


### PR DESCRIPTION
- depend on actually linked libraries
- use shared libunwind on CLANG
- don't build deprecated curl backend: https://github.com/rust-lang/rustup/blob/5cabb50dddf3cf77050df892d28aa32cd0a4159a/CHANGELOG.md?plain=1#L9