### PR TITLE
calceph: update to 4.0.5

### DIFF
--- a/mingw-w64-calceph/PKGBUILD
+++ b/mingw-w64-calceph/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=calceph
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=4.0.4
+pkgver=4.0.5
 pkgrel=1
 pkgdesc='The CALCEPH Library is designed to access the binary planetary ephemeris files, such INPOPxx and JPL DExxx ephemeris files (mingw-w64)'
 url='https://www.imcce.fr/inpop/calceph'
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-fc")
 )
 source=("https://www.imcce.fr/content/medias/recherche/equipes/asd/calceph/${_realname}-${pkgver}.tar.gz")
-sha256sums=('20c9f0bd720c5cfe99a7b342babda3ff91428adfec9d55357b380b4a13205d60')
+sha256sums=('3460d8a3e10a86e7fe0228d5d9abcda589713b8ed3ee007ce061ae01f8c2e1ea')
 
 build() {
  


### PR DESCRIPTION
update to the minor version 4.0.5