### PR TITLE
emacs: adapt to gcc 15 and remove obsolete workaround

### DIFF
--- a/mingw-w64-emacs/004-gcc-15.patch
+++ b/mingw-w64-emacs/004-gcc-15.patch
@@ -1,0 +1,42 @@
+commit 6c2aaedfcebb310e0c948d6972f90cc7d96193f9
+Author: Eli Zaretskii <eliz@gnu.org>
+Date:   Wed Apr 30 14:06:44 2025 +0300
+
+    Fix compilation errors in emacsclient.c with MinGW GCC 15
+    
+    * lib-src/emacsclient.c (set_fg, get_wc): Declare using actual
+    function signatures.
+    (w32_give_focus): Cast return value of 'GetProcAddress' to correct
+    pointer types.  (Bug#78160)
+
+diff --git a/lib-src/emacsclient.c b/lib-src/emacsclient.c
+index 2cf90f4039b..ddfe19ffbd6 100644
+--- a/lib-src/emacsclient.c
++++ b/lib-src/emacsclient.c
+@@ -1715,8 +1715,13 @@ set_socket (bool no_exit_if_error)
+ }
+ 
+ #ifdef HAVE_NTGUI
+-FARPROC set_fg;  /* Pointer to AllowSetForegroundWindow.  */
+-FARPROC get_wc;  /* Pointer to RealGetWindowClassA.  */
++typedef void (* VOIDFNPTR) (void);
++typedef BOOL (WINAPI *AllowSetForegroundWindow_proc) (DWORD);
++/* Pointer to AllowSetForegroundWindow.  */
++static AllowSetForegroundWindow_proc set_fg;
++typedef UINT (WINAPI *RealGetWindowClassA_proc) (HWND, LPSTR, UINT);
++/* Pointer to RealGetWindowClassA.  */
++static RealGetWindowClassA_proc get_wc;
+ 
+ void w32_set_user_model_id (void);
+ 
+@@ -1794,8 +1799,8 @@ w32_give_focus (void)
+      emacsclient can allow Emacs to grab the focus by calling the function
+      AllowSetForegroundWindow.  Unfortunately, older Windows (W95, W98 and
+      NT) lack this function, so we have to check its availability.  */
+-  if ((set_fg = GetProcAddress (user32, "AllowSetForegroundWindow"))
+-      && (get_wc = GetProcAddress (user32, "RealGetWindowClassA")))
++  if ((set_fg = (AllowSetForegroundWindow_proc) (VOIDFNPTR) GetProcAddress (user32, "AllowSetForegroundWindow"))
++      && (get_wc = (RealGetWindowClassA_proc) (VOIDFNPTR) GetProcAddress (user32, "RealGetWindowClassA")))
+     EnumWindows (w32_find_emacs_process, (LPARAM) 0);
+ }
+ #endif /* HAVE_NTGUI */

--- a/mingw-w64-emacs/PKGBUILD
+++ b/mingw-w64-emacs/PKGBUILD
@@ -8,7 +8,7 @@ _realname=emacs
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=30.1
-pkgrel=1
+pkgrel=2
 pkgdesc="The extensible, customizable, self-documenting, real-time display editor (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -45,6 +45,7 @@ source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.xz"{,.s
         "001-ucrt.patch"
         "002-clang-fixes.patch"
         "003-aarch64-fixes.patch"
+        "004-gcc-15.patch"
         "emacs-ARM64.manifest")
 # source=("https://alpha.gnu.org/gnu/${_realname}/pretest/${_realname}-${pkgver}.tar.xz"{,.sig})
 sha256sums=('6ccac1ae76e6af93c6de1df175e8eb406767c23da3dd2a16aa67e3124a6f138f'
@@ -52,6 +53,7 @@ sha256sums=('6ccac1ae76e6af93c6de1df175e8eb406767c23da3dd2a16aa67e3124a6f138f'
             '8093c4c6dc8006c11fd33a78c5aefcb2b5b1f05e5afb9bd3da7d5b146dfc112c'
             'd8732584a8f3bfd0badbd16d15384b7098e25c5df48632beb02d35f6050c358b'
             'd128982d87af1e524ae809147613168153f0e5c1efb0ef633793df47b762c9e1'
+            'd3ec183f5fed9f317a3dbeeef32925e55e47bdf5da970456c99f09f5fcdb7172'
             'bfe64602dbeeec85799c1156ca4f3837fdac42a076e83a4221768db3417220e1')
 validpgpkeys=('28D3BED851FDF3AB57FEF93C233587A47C207910'
               '17E90D521672C04631B1183EE78DAE0F3115E06B'
@@ -66,6 +68,7 @@ prepare() {
   patch -Np1 -i "${srcdir}/001-ucrt.patch"
   patch -Np1 -i "${srcdir}/002-clang-fixes.patch"
   patch -Np1 -i "${srcdir}/003-aarch64-fixes.patch"
+  patch -Np1 -i "${srcdir}/004-gcc-15.patch"
 
   ./autogen.sh
 }
@@ -80,8 +83,6 @@ build() {
 
   # Required for nanosleep with clang
   export LDFLAGS="${LDFLAGS} -lpthread"
-  # -D_FORTIFY_SOURCE breaks build
-  CFLAGS=${CFLAGS//"-Wp,-D_FORTIFY_SOURCE=2"}
 
   ../${_realname}-${pkgver}/configure \
     --prefix="${MINGW_PREFIX}" \


### PR DESCRIPTION
https://github.com/msys2/MINGW-packages/issues/17343#issuecomment-2368903501

The workaround is no longer necessary because the issue was fixed upstream.