### PR TITLE
meld: Create separate console and gui executables

### DIFF
--- a/mingw-w64-meld3/PKGBUILD
+++ b/mingw-w64-meld3/PKGBUILD
@@ -5,7 +5,7 @@ _realname=meld
 pkgbase=mingw-w64-${_realname}3
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}3"
 pkgver=3.23.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Visual diff and merge tool (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -37,7 +37,7 @@ source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname
 sha256sums=('983c2a4240e025a2109c7738198710e9d6b063c910b048332d14690cf538c2a6'
             'e7445dd7d7280dfba815909e6e52de3eb549653f5a02c2744a15707c68428332'
             'f2087bd98576626d0293adb4c0d4d3c1adbf5bd0d7ab1bf83836592984d75200'
-            '1f52efc76ef1e229e431063df998078cdef0c48a813561218d0ee0ac98665699')
+            '236293721606ce1277d446e28a460c46c2aecda3a0ff4c5fcc2297f2729ea417')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -76,7 +76,7 @@ package() {
 
   python3 "${srcdir}/pyscript2exe.py" "${pkgdir}${MINGW_PREFIX}/bin/meld"
 
-  ${MINGW_PREFIX}/bin/rcedit.exe "${pkgdir}${MINGW_PREFIX}/bin/meld.exe" \
+  ${MINGW_PREFIX}/bin/rcedit.exe "${pkgdir}${MINGW_PREFIX}/bin/meldw.exe" \
     --set-icon "../${_realname}-${pkgver}/data/icons/org.gnome.meld.ico"
 
   MSYS2_ARG_CONV_EXCL="-d" \

--- a/mingw-w64-meld3/pyscript2exe.py
+++ b/mingw-w64-meld3/pyscript2exe.py
@@ -6,14 +6,20 @@ foobar.py -> foobar.exe + foobar-script.py
 import sys
 import re
 import os
+import shutil
 from setuptools.command.easy_install import get_win_launcher
 
 path = sys.argv[1]
+root, ext = os.path.splitext(path)
 with open(path, "rb") as f:
     data = f.read()
 with open(path, "wb") as f:
-    f.write(re.sub(b"^#![^\n\r]*", b'#!pythonw.exe', data))
-root, ext = os.path.splitext(path)
+    f.write(re.sub(b"^#![^\n\r]*", b'#!python.exe', data))
 with open(root + ".exe", "wb") as f:
+    f.write(get_win_launcher("cli"))
+shutil.copy(path, root + "-script.py")
+with open(path, "wb") as f:
+    f.write(re.sub(b"^#![^\n\r]*", b'#!pythonw.exe', data))
+with open(root + "w.exe", "wb") as f:
     f.write(get_win_launcher("gui"))
-os.rename(path, root + "-script.pyw")
+os.rename(path, root + "w-script.pyw")


### PR DESCRIPTION
There's now a blocking, console based, `meld.exe`  and a non-blocking, gui based `meldw.exe`

Fixes https://github.com/msys2/MINGW-packages/issues/24494