### PR TITLE
ninja: build with cmake+make; fix missing manifest

### DIFF
--- a/mingw-w64-ninja/0001-fix-manifest-build.patch
+++ b/mingw-w64-ninja/0001-fix-manifest-build.patch
@@ -1,0 +1,17 @@
+--- ninja-1.12.1/CMakeLists.txt.orig	2025-06-07 20:26:58.068523900 +0200
++++ ninja-1.12.1/CMakeLists.txt	2025-06-07 20:27:07.480625600 +0200
+@@ -193,7 +193,7 @@
+ 	target_link_libraries(ninja PRIVATE libninja libninja-re2c)
+ 
+ 	if(WIN32)
+-		target_sources(ninja PRIVATE windows/ninja.manifest)
++		target_sources(ninja PRIVATE windows/ninja.rc)
+ 	endif()
+ endif()
+ 
+--- ninja-1.12.1/windows/ninja.rc.orig	1970-01-01 01:00:00.000000000 +0100
++++ ninja-1.12.1/windows/ninja.rc	1970-01-01 01:00:00.000000000 +0100
+@@ -0,0 +1,3 @@
++#include <windows.h>
++
++1 RT_MANIFEST "ninja.manifest"

--- a/mingw-w64-ninja/PKGBUILD
+++ b/mingw-w64-ninja/PKGBUILD
@@ -4,25 +4,50 @@ _realname=ninja
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.12.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Ninja is a small build system with a focus on speed (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://ninja-build.org"
+msys2_repository_url="https://github.com/ninja-build/ninja"
 license=('spdx:Apache-2.0')
-makedepends=("re2c" "${MINGW_PACKAGE_PREFIX}-python" "${MINGW_PACKAGE_PREFIX}-cc")
-source=("https://github.com/ninja-build/ninja/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('821bdff48a3f683bc4bb3b6f0b5fe7b2d647cf65d52aeb63328c91a6c6df285a')
+makedepends=(
+  "re2c"
+  "make"
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+  "${MINGW_PACKAGE_PREFIX}-cc")
+source=("https://github.com/ninja-build/ninja/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
+        "0001-fix-manifest-build.patch")
+sha256sums=('821bdff48a3f683bc4bb3b6f0b5fe7b2d647cf65d52aeb63328c91a6c6df285a'
+            '22ed317cf053a59b7334cbca1547b09da9efea1c8021ae6ed842ab21f1f52a31')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+  patch -p1 < "${srcdir}/0001-fix-manifest-build.patch"
+}
 
 build() {
-  mkdir -p "${pkgdir}${MINGW_PREFIX}"/bin
-  cd "${srcdir}"/ninja-${pkgver}
-  ${MINGW_PREFIX}/bin/python3 configure.py --bootstrap --platform mingw
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    cmake \
+      "-GMSYS Makefiles" \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      -DBUILD_TESTING=OFF \
+      "${extra_config[@]}" \
+      -S "${_realname}-${pkgver}" \
+      -B "build-${MSYSTEM}"
+
+  cmake --build "build-${MSYSTEM}"
 }
 
 package() {
-  mkdir -p "${pkgdir}${MINGW_PREFIX}"/bin
-  mv "${srcdir}/ninja-${pkgver}/ninja.exe" "${pkgdir}${MINGW_PREFIX}"/bin/
-  mkdir -p "${pkgdir}${MINGW_PREFIX}"/lib
-  mv "${srcdir}/ninja-${pkgver}/build/libninja.a" "${pkgdir}${MINGW_PREFIX}"/lib/
+  DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}"
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }


### PR DESCRIPTION
Fixes #24479

the static lib is gone now, but from what I understand that's private anyway