### PR TITLE
cmake-bootstrap: Update to 4.0.2

### DIFF
--- a/mingw-w64-cmake-bootstrap/PKGBUILD
+++ b/mingw-w64-cmake-bootstrap/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=cmake
 pkgbase=mingw-w64-${_realname}-bootstrap
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-bootstrap")
-pkgver=4.0.1
+pkgver=4.0.2
 pkgrel=1
 pkgdesc="A cross-platform open-source make system"
 arch=('any')
@@ -18,7 +18,6 @@ msys2_references=(
 license=("spdx:MIT")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
 depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
-         "${MINGW_PACKAGE_PREFIX}-ninja"
          "${MINGW_PACKAGE_PREFIX}-pkgconf")
 conflicts=(
   "${MINGW_PACKAGE_PREFIX}-cmake"
@@ -29,7 +28,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-cmake=${pkgver}")
 source=("https://github.com/Kitware/CMake/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz"
         "0003-fix-find-python-on-mingw-aarch64.patch"
         "0005-Default-to-ninja-generator.patch")
-sha256sums=('d630a7e00e63e520b25259f83d425ef783b4661bdc8f47e21c7f23f3780a21e1'
+sha256sums=('1c3a82c8ca7cf12e0b17178f9d0c32f7ac773bd5651a98fcfd80fbf4977f8d48'
             '557b5cbc05d4d50b3a67a7892391fcaa5cd95c492cdb4338d86305d1f4a3b88a'
             '426818278090704d2a12f62ef3dfd94c47b11fa2784bb842989b7f6a09ee7aa2')
 


### PR DESCRIPTION
Remove the ninja dep since we build ninja with cmake too now since https://github.com/msys2/MINGW-packages/pull/24505 and this avoids a cycle.