### PR TITLE
libarchive: avoid absolute unix path in .pc file for iconv

### DIFF
--- a/mingw-w64-libarchive/PKGBUILD
+++ b/mingw-w64-libarchive/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libarchive
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.8.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Multi-format archive and compression library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -53,6 +53,7 @@ build() {
     --without-lzo2 \
     --without-nettle \
     --with-openssl \
+    --without-libiconv-prefix \
     --with-cng
 
   make


### PR DESCRIPTION
Fixes #24533