### PR TITLE
emacs: put back workaround for #17343

### DIFF
--- a/mingw-w64-emacs/PKGBUILD
+++ b/mingw-w64-emacs/PKGBUILD
@@ -8,7 +8,7 @@ _realname=emacs
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=30.1
-pkgrel=2
+pkgrel=3
 pkgdesc="The extensible, customizable, self-documenting, real-time display editor (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -83,6 +83,10 @@ build() {
 
   # Required for nanosleep with clang
   export LDFLAGS="${LDFLAGS} -lpthread"
+  # -D_FORTIFY_SOURCE produces a broken emacs. See
+  # https://github.com/msys2/MINGW-packages/issues/17343
+  # https://github.com/msys2/MINGW-packages/issues/24539
+  CFLAGS=${CFLAGS//"-Wp,-D_FORTIFY_SOURCE=2"}
 
   ../${_realname}-${pkgver}/configure \
     --prefix="${MINGW_PREFIX}" \


### PR DESCRIPTION
The case for `read' was fixed upstream long time ago, but it seems that another function is affected by the same issue on newer versions of the runtime. Instead of playing whack-a-mole, simply remove -D_FORTIFY_SOURCE from now on.

Fixes https://github.com/msys2/MINGW-packages/issues/24539