### PR TITLE
[do not merge] mupdf bump version to 1.26.2

### DIFF
--- a/mingw-w64-mupdf/001-makerules-search-system-libraries.patch
+++ b/mingw-w64-mupdf/001-makerules-search-system-libraries.patch
@@ -1,11 +1,24 @@
 --- a/Makerules
 +++ b/Makerules
-@@ -171,7 +171,7 @@
-   CFLAGS += -DCLUSTER
+@@ -90,7 +93,12 @@
+   SO := dylib
+ else
+   LDREMOVEUNREACH := -Wl,--gc-sections
+-  SO := so
++  ifeq ($(OS),$(filter $(OS),Linux MINGW Windows_NT))
++    SO := dll
++    EXE := .exe
++  else
++    SO := so
++  endif
  endif
  
--ifeq ($(OS),Linux)
-+ifeq ($(OS),$(filter $(OS),Linux MINGW Windows_NT))
-     LINUX_OR_OPENBSD := yes
- endif
- ifeq ($(OS),OpenBSD)
+ SANITIZE_FLAGS += -fsanitize=address
+@@ -216,7 +224,7 @@
+ 
+ else
+ 
+-  ifeq ($(OS),Linux)
++  ifeq ($(OS),$(filter $(OS),Linux MINGW Windows_NT))
+     HAVE_OBJCOPY := yes
+   endif

--- a/mingw-w64-mupdf/002-makerules-fix-gl-libraries.patch
+++ b/mingw-w64-mupdf/002-makerules-fix-gl-libraries.patch
@@ -1,11 +1,10 @@
 --- a/Makerules
 +++ b/Makerules
-@@ -270,7 +270,7 @@
-       SYS_GLUT_LIBS := $(shell pkg-config --libs glut gl)
+@@ -298,6 +298,6 @@
+       SYS_GLUT_LIBS := $(shell pkg-config --libs glut)
      else
        SYS_GLUT_CFLAGS :=
--      SYS_GLUT_LIBS := -lglut -lGL
 +      SYS_GLUT_LIBS := -lfreeglut -lopengl32
+-      SYS_GLUT_LIBS := -lglut
      endif
    endif
- 

--- a/mingw-w64-mupdf/003-makerules-fix-inline-error.patch
+++ b/mingw-w64-mupdf/003-makerules-fix-inline-error.patch
@@ -1,0 +1,11 @@
+--- a/Makerules
++++ b/Makerules
+@@ -375,3 +375,7 @@
+   HAVE_LIBCRYPTO=no
+   CFLAGS += -pthread
+ endif
++
++ifeq ($(OS),$(filter $(OS),Linux MINGW Windows_NT))
++  CFLAGS += -DWIN32 -msse4.1
++endif
+\ No newline at end of file

--- a/mingw-w64-mupdf/004-makefile-ld-no-z.patch
+++ b/mingw-w64-mupdf/004-makefile-ld-no-z.patch
@@ -1,0 +1,11 @@
+--- a/Makefile
++++ b/Makefile
+@@ -83,7 +83,7 @@
+ endif
+ LINK_CMD = $(QUIET_LINK) $(MKTGTDIR) ; $(CC) $(EXE_LDFLAGS) $(LDFLAGS) -o $@ $^ $(LIBS)
+ TAGS_CMD = $(QUIET_TAGS) ctags
+-OBJCOPY_CMD = $(QUIET_OBJCOPY) $(MKTGTDIR) ; $(LD) -r -b binary -z noexecstack -o $@ $<
++OBJCOPY_CMD = $(QUIET_OBJCOPY) $(MKTGTDIR) ; $(LD) -r -b binary -o $@ $<
+ SYMLINK_CMD = $(QUIET_SYMLINK) $(MKTGTDIR) ; ln -sf
+ 
+ ifeq ($(shared),yes)

--- a/mingw-w64-mupdf/005-gl-main-no-msc-ver.patch
+++ b/mingw-w64-mupdf/005-gl-main-no-msc-ver.patch
@@ -1,0 +1,15 @@
+--- a/platform/gl/gl-main.c
++++ b/platform/gl/gl-main.c
+@@ -3079,11 +3079,7 @@
+ }
+ #endif
+ 
+-#ifdef _MSC_VER
+ int main_utf8(int argc, char **argv)
+-#else
+-int main(int argc, char **argv)
+-#endif
+ {
+ 	const char *trace_file_name = NULL;
+ 	const char *profile_name = NULL;
+

--- a/mingw-w64-mupdf/006-makerules-win32-build.patch
+++ b/mingw-w64-mupdf/006-makerules-win32-build.patch
@@ -1,0 +1,14 @@
+--- a/Makerules
++++ b/Makerules
+@@ -212,6 +212,11 @@
+   CFLAGS += -DCLUSTER
+ endif
+ 
++ifeq ($(OS),$(filter $(OS),Linux MINGW Windows_NT))
++  WINDRES := windres
++  HAVE_WIN32 := yes
++endif
++
+ ifeq ($(OS),Darwin)
+   HAVE_GLUT := yes
+   SYS_GLUT_CFLAGS := -Wno-deprecated-declarations

--- a/mingw-w64-mupdf/007-makefile-win32-build.patch
+++ b/mingw-w64-mupdf/007-makefile-win32-build.patch
@@ -1,0 +1,67 @@
+--- a/Makefile
++++ b/Makefile
+@@ -36,6 +36,11 @@
+   endif
+ endif
+ 
++ifeq ($(HAVE_WIN32),yes)
++  WIN32_LIBS := -lcomdlg32 -lgdi32
++  WIN32_LDFLAGS := -Wl,-subsystem,windows
++endif
++
+ VERSION_MAJOR = $(shell grep "define FZ_VERSION_MAJOR" include/mupdf/fitz/version.h | cut -d ' ' -f 3)
+ VERSION_MINOR = $(shell grep "define FZ_VERSION_MINOR" include/mupdf/fitz/version.h | cut -d ' ' -f 3)
+ VERSION_PATCH = $(shell grep "define FZ_VERSION_PATCH" include/mupdf/fitz/version.h | cut -d ' ' -f 3)
+@@ -66,6 +66,7 @@
+   QUIET_LINK_SO = @ echo "    LINK_SO $@" ;
+   QUIET_RM = @ echo "    RM $@" ;
+   QUIET_TAGS = @ echo "    TAGS $@" ;
++  QUIET_WINDRES = @ echo "    WINDRES $@" ;
+   QUIET_OBJCOPY = @ echo "    OBJCOPY $@" ;
+   QUIET_SYMLINK = @ echo "    SYMLINK $@" ;
+ endif
+@@ -81,5 +82,6 @@
+ ifdef RANLIB
+   RANLIB_CMD = $(QUIET_RANLIB) $(RANLIB) $@
+ endif
++WINDRES_CMD = $(QUIET_WINDRES) $(MKTGTDIR) ; $(WINDRES) $< $@
+ LINK_CMD = $(QUIET_LINK) $(MKTGTDIR) ; $(CC) $(EXE_LDFLAGS) $(LDFLAGS) -o $@ $^ $(LIBS)
+ TAGS_CMD = $(QUIET_TAGS) ctags
+@@ -160,6 +162,9 @@
+ $(OUT)/platform/%.o : platform/%.c
+ 	$(CC_CMD) $(WARNING_CFLAGS)
+ 
++$(OUT)/%.o: %.rc
++	$(WINDRES_CMD)
++
+ .PRECIOUS : $(OUT)/%.o # Keep intermediates from chained rules
+ 
+ # --- File lists ---
+@@ -353,6 +358,9 @@
+ ifeq ($(HAVE_GLUT),yes)
+   MUVIEW_GLUT_SRC += $(sort $(wildcard platform/gl/*.c))
+   MUVIEW_GLUT_OBJ := $(MUVIEW_GLUT_SRC:%.c=$(OUT)/%.o)
++ifeq ($(HAVE_WIN32),yes)
++  MUVIEW_GLUT_OBJ += $(OUT)/platform/gl/gl-winres.o
++endif
+   MUVIEW_GLUT_EXE := $(OUT)/mupdf-gl
+   $(MUVIEW_GLUT_EXE) : $(MUVIEW_GLUT_OBJ) $(MUPDF_LIB) $(THIRD_LIB) $(THIRD_GLUT_LIB) $(PKCS7_LIB)
+ 	$(LINK_CMD) $(THIRD_LIBS) $(LIBCRYPTO_LIBS) $(THIRD_GLUT_LIBS)
+@@ -369,6 +377,16 @@
+   VIEW_APPS += $(MUVIEW_X11_EXE)
+ endif
+ 
++ifeq ($(HAVE_WIN32),yes)
++  MUVIEW_WIN32_EXE := $(OUT)/mupdf-w32
++  MUVIEW_WIN32_OBJ += $(OUT)/platform/x11/pdfapp.o
++  MUVIEW_WIN32_OBJ += $(OUT)/platform/x11/win_main.o
++  MUVIEW_WIN32_OBJ += $(OUT)/platform/x11/win_res.o
++  $(MUVIEW_WIN32_EXE) : $(MUVIEW_WIN32_OBJ) $(MUPDF_LIB) $(THIRD_LIB) $(PKCS7_LIB)
++	$(LINK_CMD) $(THIRD_LIBS) $(WIN32_LDFLAGS) $(WIN32_LIBS) $(LIBCRYPTO_LIBS)
++  VIEW_APPS += $(MUVIEW_WIN32_EXE)
++endif
++
+ ifeq ($(HAVE_X11),yes)
+ ifeq ($(HAVE_CURL),yes)
+ ifeq ($(HAVE_PTHREAD),yes)
+

--- a/mingw-w64-mupdf/PKGBUILD
+++ b/mingw-w64-mupdf/PKGBUILD
@@ -8,8 +8,8 @@ pkgname=(
   "${MINGW_PACKAGE_PREFIX}-mupdf-gl"
   "${MINGW_PACKAGE_PREFIX}-mupdf-tools"
 )
-pkgver=1.24.3
-pkgrel=2
+pkgver=1.26.2
+pkgrel=1
 pkgdesc='Lightweight PDF and XPS viewer (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -29,6 +29,12 @@ depends=(
   "${MINGW_PACKAGE_PREFIX}-openjpeg2"
   "${MINGW_PACKAGE_PREFIX}-openssl"
   "${MINGW_PACKAGE_PREFIX}-gumbo-parser"
+  "${MINGW_PACKAGE_PREFIX}-mujs"
+  "${MINGW_PACKAGE_PREFIX}-leptonica"
+  "${MINGW_PACKAGE_PREFIX}-zint"
+  "${MINGW_PACKAGE_PREFIX}-zxing-cpp"
+  "${MINGW_PACKAGE_PREFIX}-tesseract-ocr"
+  "${MINGW_PACKAGE_PREFIX}-jxrlib"
 )
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cc"
@@ -40,11 +46,21 @@ makedepends=(
 source=("https://mupdf.com/downloads/archive/${_realname}-${pkgver}-source.tar.lz"
         "001-makerules-search-system-libraries.patch"
         "002-makerules-fix-gl-libraries.patch"
+        "003-makerules-fix-inline-error.patch"
+        "004-makefile-ld-no-z.patch"
+        "005-gl-main-no-msc-ver.patch"
+        "006-makerules-win32-build.patch"
+        "007-makefile-win32-build.patch"
 )
 noextract=("${_realname}-${pkgver}-source.tar.lz")
-sha256sums=('656fbea2210e9720d69bd199fc85b19d70ece2a3c91d85f5d5d2147ebea42db3'
-            'ab93d8d1ff69752ef897fa56134d17d8dda1ea19ee7a9c368090ed7effb3101c'
-            '082b0fd6f162b91ff2bc263e24440ad7297e1ab5db7e1e2d76f1f0d5215af8ad')
+sha256sums=('a7c92b27f0cc0284d97f3841329d7f3814926a6068186df1c02c40dcb7c22004'
+            'd0f98dead83ac341cbe21de9ccd3c27538763ab4f88fdea6776900c138d429e4'
+            '9cdf7a1e009be8fa2b1fc270910a401c322ae9df2f2d67dd671191c3af27168c'
+            '87207bd875fef3a37eea83beee1319d22f4f4f6b8afaa41eb53df9ada10b4d52'
+            '86bc8619b105e9ea71e8c4e1a6a67921998462d126869936321a9a16ab18f165'
+            'a59822a881fdd89c4e53e8017bda36f5b4a79f381f32335c232d3e8ff887fe99'
+            '7cca1318264066ee9fff57ad8441f996ec937e4f2fcc454296c8dafb03380c04'
+            'cf6437e19761a6766e4be619fa82c59bc71a205a7f17091396b382cb05a6eb94')
 
 prepare() {
   tar -xf "${_realname}-${pkgver}-source.tar.lz" || true
@@ -52,18 +68,25 @@ prepare() {
   cd "${_realname}-${pkgver}-source"
 
   # remove bundled packages, we want our system libraries
-  rm -rf thirdparty/{freeglut,freetype,harfbuzz,jbig2dec,libjpeg,openjpeg,zlib}
+  rm -rf thirdparty/{curl,freetype,freeglut,harfbuzz,jbig2dec,libjpeg,openjpeg,brotli,tesseract,zint,zxing-cpp,zlib,gumbo-parser,leptonica,mujs}
 
   patch -p1 -i "${srcdir}/001-makerules-search-system-libraries.patch"
   patch -p1 -i "${srcdir}/002-makerules-fix-gl-libraries.patch"
+  patch -p1 -i "${srcdir}/003-makerules-fix-inline-error.patch"
+  patch -p1 -i "${srcdir}/004-makefile-ld-no-z.patch"
+  patch -p1 -i "${srcdir}/005-gl-main-no-msc-ver.patch"
+  patch -p1 -i "${srcdir}/006-makerules-win32-build.patch"
+  patch -p1 -i "${srcdir}/007-makefile-win32-build.patch"
 }
 
 build() {
   [[ -d build-${MSYSTEM} ]] && rm -rf build-${MSYSTEM}
   cp -r ${_realname}-${pkgver}-source build-${MSYSTEM} && cd build-${MSYSTEM}
 
-  make USE_SYSTEM_LIBS=yes HAVE_GLUT=yes HAVE_WIN32=yes WINDRES=windres prefix=${MINGW_PREFIX} \
-    DESTDIR=install build=release libs apps install
+  make USE_SYSTEM_LIBS=yes USE_SYSTEM_JPEGXR=yes USE_SYSTEM_MUJS=yes \
+       HAVE_GLUT=yes HAVE_WIN32=yes \
+       WINDRES=windres prefix=${MINGW_PREFIX} DESTDIR=install build=release \
+       all install install-extra-apps
 }
 
 package_libmupdf() {


### PR DESCRIPTION
I made this PR originaly just for myself, but since msys2's mupdf haven't got a update for a long time, I think it might be helpful to upstream it, hopfully someone with better knowledge can take over from this point.

Potential Issues:
1. Not sure if the dependencies are correct.
2. `shared=yes` build does not work, but most linux distros use it.
3. Upstream removed MINGW support from Makefile since 1.26.0