### PR TITLE
Static libraries fix and pkg-config .pc file for mingw-w64-angleproject package

### DIFF
--- a/mingw-w64-angleproject/002-buildflags-fixes.patch
+++ b/mingw-w64-angleproject/002-buildflags-fixes.patch
@@ -1,5 +1,5 @@
 diff --git a/BUILD.gn b/BUILD.gn
-index 964d51123..14bc8fb6c 100644
+index 964d511238..1a99c6095d 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
 @@ -14,7 +14,10 @@ if (angle_has_build) {
@@ -117,15 +117,16 @@ index 964d51123..14bc8fb6c 100644
    }
  
    if (angle_enable_metal) {
-@@ -1469,6 +1476,7 @@ if (angle_enable_gl_desktop_frontend) {
+@@ -1469,6 +1476,8 @@ if (angle_enable_gl_desktop_frontend) {
  
  angle_static_library("libGLESv2_static") {
    sources = libglesv2_sources
++  complete_static_lib = true
 +  output_name = "libGLESv2"
    if (angle_enable_gl_desktop_frontend) {
      sources += libglesv2_gl_sources
      defines = [ "ANGLE_ENABLE_GL_DESKTOP_FRONTEND" ]
-@@ -1614,6 +1622,7 @@ if (angle_enable_vulkan) {
+@@ -1614,6 +1623,7 @@ if (angle_enable_vulkan) {
  }
  
  libEGL_template("libEGL_static") {

--- a/mingw-w64-angleproject/004-swiftshader-updates.patch
+++ b/mingw-w64-angleproject/004-swiftshader-updates.patch
@@ -1,5 +1,5 @@
 diff --git a/src/Reactor/BUILD.gn b/src/Reactor/BUILD.gn
-index 67dfeb0ec..ceb96a5d7 100644
+index 67dfeb0ec..5df50ba8a 100644
 --- a/src/Reactor/BUILD.gn
 +++ b/src/Reactor/BUILD.gn
 @@ -16,7 +16,7 @@ import("reactor.gni")
@@ -11,7 +11,19 @@ index 67dfeb0ec..ceb96a5d7 100644
      cflags = [
        "/wd4141",  # 'inline' used more than once. (LLVM 7.0)
        "/wd4146",  # unary minus operator applied to unsigned type. (LLVM 7.0)
-@@ -109,7 +109,7 @@ if (supports_subzero) {
+@@ -104,12 +104,19 @@ if (supports_subzero) {
+     } else if (is_mac) {
+       include_dirs += [ "../../third_party/llvm-subzero/build/MacOS/include/" ]
+     }
++
++    if (is_clang) {
++      defines += [
++        "__STDC_CONSTANT_MACROS",
++        "__STDC_LIMIT_MACROS"
++      ]
++    }
+   }
+ 
    config("swiftshader_subzero_private_config") {
      cflags = []
  
@@ -20,7 +32,7 @@ index 67dfeb0ec..ceb96a5d7 100644
        cflags += [
          "/wd4005",
          "/wd4018",
-@@ -155,7 +155,7 @@ if (supports_subzero) {
+@@ -155,7 +162,7 @@ if (supports_subzero) {
    config("swiftshader_reactor_with_subzero_private_config") {
      cflags = []
  

--- a/mingw-w64-angleproject/PKGBUILD
+++ b/mingw-w64-angleproject/PKGBUILD
@@ -6,25 +6,26 @@ _realname=angleproject
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.1.r21358.2e285bb5
-pkgrel=8
+pkgrel=9
 pkgdesc='A conformant OpenGL ES implementation for Windows, Mac, Linux, iOS and Android (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://chromium.googlesource.com/angle/angle'
 license=('spdx:BSD-3-Clause')
-depends=("${MINGW_PACKAGE_PREFIX}-jsoncpp"
+depends=("${MINGW_PACKAGE_PREFIX}-egl-headers"
+         "${MINGW_PACKAGE_PREFIX}-gles-headers"
+         "${MINGW_PACKAGE_PREFIX}-jsoncpp"
          "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
          "${MINGW_PACKAGE_PREFIX}-libpng"
          "${MINGW_PACKAGE_PREFIX}-rapidjson"
-         "${MINGW_PACKAGE_PREFIX}-zlib"
-         "${MINGW_PACKAGE_PREFIX}-egl-headers"
-         "${MINGW_PACKAGE_PREFIX}-gles-headers")
+         "${MINGW_PACKAGE_PREFIX}-zlib")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-gn"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-python"
-             "git")
+             "git"
+             "unzip")
 _commit=("2e285bb591f78af3b5b1f83617e06f9ef9067924")
 source=("${_realname}::git+https://chromium.googlesource.com/angle/angle.git#commit=${_commit}"
         "bare-clones/build::git+https://chromium.googlesource.com/chromium/src/build.git#commit=ccb49e801879c107ed6e96a84eb227f65ce4823b"
@@ -51,7 +52,8 @@ source=("${_realname}::git+https://chromium.googlesource.com/angle/angle.git#com
         jsoncpp.gn
         png.gn
         rjson.gn
-        zlib.gn)
+        zlib.gn
+        angleproject.pc)
 sha256sums=('SKIP'
             'SKIP'
             'SKIP'
@@ -66,9 +68,9 @@ sha256sums=('SKIP'
             'SKIP'
             'SKIP'
             '573a9e12727926e2ddddf0863bed926ef3764ec64ab75d27e3ec48648849786d'
-            'c7fc66c1c0b154eb61c666f845720b576187984d139f64ef452467d5efff4509'
+            '926b273b0f32ce81b7508dea3dff8447e2f98bd84caa2c67fd52ede5e53a7213'
             '04bcb05dc2f349639bf4e62ee92d758b756e56532ceb9184c2d7dca01e67a38e'
-            'c3ee4b4194c041db225bcf3f699bf1042ddc0c845b1da142ca07a8bf1f7f80f8'
+            '55d291668fe98f9b095983fe9c17a7336097d3f6028a59ca749b77dac92be5b1'
             'ced98a61919f7fdb10dbff26dfbd4ea11b034eaaeb3433f0fa5c4c998519e171'
             '276799dbae43ab2577547dcc7912353619ade2ba878b28947ddef545f48afffa'
             '7fc7f35aedc101fe325c161c42d2966f974ec789025750705ceb0caf259fc1f6'
@@ -77,7 +79,8 @@ sha256sums=('SKIP'
             '86013781c2700219d4f64d7ac34ad16c40fcca9a641371385f67f642e23c643b'
             'f0fb05348bf2de599eff35e2d35e3336b9720b6bd2799af9d186c05ff45d34f0'
             '044afff420a1c8ad896f79fb8ae03878f6063bdb0a25dab0b8e4bff092e3d3ac'
-            '4dc3baf79ba7c95b52cbbafce81b26e6d165d4ae7e0dcc2eabe0250466edf178')
+            '4dc3baf79ba7c95b52cbbafce81b26e6d165d4ae7e0dcc2eabe0250466edf178'
+            'a9f0b7c82d8ce614df8940508d3f098cca9596d1150c654559aac21749ca170b')
 noextract=("swiftshader.zip")
 
 apply_patch_with_msg() {
@@ -111,7 +114,7 @@ prepare() {
 
   echo ":: Extracting SwiftShader"
   cd "${srcdir}"
-  bsdtar -xf swiftshader.zip || bsdtar -xf swiftshader.zip
+  unzip -q swiftshader.zip
   mv swiftshader-* SwiftShader
 
   echo ":: Patching SwiftShader directory"
@@ -161,6 +164,11 @@ prepare() {
 
   echo ":: Generating angle_commit.h"
   python src/commit_id.py gen src/common/angle_commit.h
+
+  sed -e "s|@PREFIX@|${MINGW_PREFIX}|g" \
+      -e "s|@NAME@|${_realname}|g" \
+      -e "s|@DESCRIPTION@|${pkgdesc}|g" \
+      -e "s|@VERSION@|${pkgver}|g" -i "${srcdir}"/angleproject.pc
 }
 
 build() {
@@ -239,4 +247,7 @@ package() {
 
   # Copy license
   install -Dm644 LICENSE "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+
+  # Copy pkg-config file
+  install -Dm644 "${srcdir}"/angleproject.pc "${pkgdir}"${MINGW_PREFIX}/lib/pkgconfig/angleproject.pc
 }

--- a/mingw-w64-angleproject/angleproject.pc
+++ b/mingw-w64-angleproject/angleproject.pc
@@ -1,0 +1,12 @@
+prefix=@PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: @NAME@
+Description: @DESCRIPTION@
+Version: @VERSION@
+Requires: zlib
+Libs: -L${libdir} -lEGL -lGLESv2 -lcfgmgr32 -lgdi32 -ld3d9 -ldxgi -ldxguid
+Cflags: -I${includedir}
+Cflags.private: -DKHRONOS_STATIC


### PR DESCRIPTION
The `libGLESv2.a` static library bundled with `mingw-w64-angleproject` has lots of undefined symbols, because its `libANGLE` dependency is not built as a static library, but as a group of objects that are linked directly in the shared DLL library. While this works if you are building with ANGLE sources, it have problems as a package. So these modifications bring the `libangle.a` static library, so we can link against `libGLESv2.a` without any missing dependency.

Additionally, this PR also brings the `angleproject.pc`, which allows using `pkg-config` to get all the required information about ANGLE's libraries.