### PR TITLE
Fix msmpi for urtc64 running on aarch64

### DIFF
--- a/mingw-w64-msmpi/PKGBUILD
+++ b/mingw-w64-msmpi/PKGBUILD
@@ -67,12 +67,12 @@ build() {
     sed -e "s|gfortran|flang|g" -i ${mpic}
   fi
   cflags="-s -O2 -DNDEBUG"
-  $CC ${cflags} -o bin/mpicc.exe -DCC "${mpic}"
-  $CC ${cflags} -o bin/mpicxx.exe -DCXX "${mpic}"
+  $CC ${cflags} -mwindows -o bin/mpicc.exe -DCC "${mpic}"
+  $CC ${cflags} -mwindows -o bin/mpicxx.exe -DCXX "${mpic}"
   cp bin/mpicxx.exe bin/mpic++.exe
 
   # Fortran Compiler wrappers
-  $CC ${cflags} -o bin/mpifort.exe -DFC "${mpic}"
+  $CC ${cflags} -mwindows -o bin/mpifort.exe -DFC "${mpic}"
   cp bin/mpifort.exe bin/mpif77.exe
   cp bin/mpifort.exe bin/mpif90.exe
 


### PR DESCRIPTION
I hit a problem where the standard msmpi package had an undefined reference to WinMain when running mpicc. This seems to fix the issue.