### PR TITLE
zed: remove some workarounds

### DIFF
--- a/mingw-w64-zed/PKGBUILD
+++ b/mingw-w64-zed/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
 pkgver=0.191.7
-pkgrel=1
+pkgrel=2
 pkgdesc="A high-performance, multiplayer code editor (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64') # clangarm64 crashes at startup https://github.com/kvark/blade/issues/222
@@ -29,7 +29,6 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-protobuf"
              #"${MINGW_PACKAGE_PREFIX}-sqlite3"
              "${MINGW_PACKAGE_PREFIX}-cargo-about"
-             "${MINGW_PACKAGE_PREFIX}-lld"
              "${MINGW_PACKAGE_PREFIX}-mdbook"
              "${MINGW_PACKAGE_PREFIX}-rust-bindgen"
              "${MINGW_PACKAGE_PREFIX}-nasm"
@@ -71,9 +70,8 @@ prepare() {
 build() {
   cd "${_realname}"
 
-  # our protoc fails
-  #export PROTOC="${MINGW_PREFIX}/bin/protoc.exe"
-  #export PROTOC_INCLUDE="${MINGW_PREFIX}/include"
+  export PROTOC="${MINGW_PREFIX}/bin/protoc.exe"
+  export PROTOC_INCLUDE="${MINGW_PREFIX}/include"
   export OPENSSL_NO_VENDOR=1
   export LIBGIT2_NO_VENDOR=1
   export PKG_CONFIG_ALL_DYNAMIC=1
@@ -84,10 +82,9 @@ build() {
   export ZED_UPDATE_EXPLANATION='Updates are handled by pacman'
   export CARGO_PROFILE_RELEASE_DEBUG=0
   export RELEASE_VERSION="${pkgver} (Rev${pkgrel}, Built by MSYS2 project)"
-  # should be synced with .cargo/config.toml. use lld linker to fix keyboard shortcuts
-  # https://github.com/msys2/MINGW-packages/issues/22071
-  export RUSTFLAGS="${RUSTFLAGS/+crt-static/-crt-static} -C link-arg=-fuse-ld=lld
-    -C symbol-mangling-version=v0 --cfg tokio_unstable --cfg windows_slim_errors"
+  # should be synced with .cargo/config.toml
+  export RUSTFLAGS="${RUSTFLAGS/+crt-static/-crt-static} -C symbol-mangling-version=v0
+    --cfg tokio_unstable --cfg windows_slim_errors"
 
   cargo build --release --frozen -p zed -p cli
 


### PR DESCRIPTION
rebuild with our protoc and with ld on GCC environments

locally tested UCRT64 artifact, anyone feel free to do the same (previous time it also succeeded for me but not for other users)