### PR TITLE
mingw-w64-wxwidgets3.3: Add provides and conflicts

### DIFF
--- a/mingw-w64-wxwidgets3.3/PKGBUILD
+++ b/mingw-w64-wxwidgets3.3/PKGBUILD
@@ -16,7 +16,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-common"
          "${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-qt-libs"
          "${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-qt")
 pkgver=${_wx_basever}.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -230,6 +230,8 @@ package_wxwidgets3.3-common() {
 package_wxwidgets3.3-msw-cb_headers() {
   pkgdesc="private wxWidgets ${_wx_basever} MSW headers needed by Code::Blocks (mingw-w64)"
   depends=("${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-common")
+  provides=("${MINGW_PACKAGE_PREFIX}-wxwidgets-msw-cb_headers")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-wxwidgets-msw-cb_headers")
 
   mkdir -p "${pkgdir}"${MINGW_PREFIX}/include/wx-${_wx_basever}/wx/msw/private
   cd "${pkgdir}"${MINGW_PREFIX}/include/wx-${_wx_basever}/wx/msw/private
@@ -281,7 +283,9 @@ package_wxwidgets3.3-msw() {
   pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX (mingw-w64)"
   depends=("${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-msw-libs"
            "${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-common")
-  provides=("${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}")
+  provides=("${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}"
+            "${MINGW_PACKAGE_PREFIX}-wxwidgets-msw")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-wxwidgets-msw")
 
 
   mkdir -p "${pkgdir}"${MINGW_PREFIX}/lib
@@ -352,6 +356,8 @@ package_wxwidgets3.3-gtk3() {
   pkgdesc="GTK+3 implementation of wxWidgets ${_wx_basever} C++ GUI API (mingw-w64)"
   depends=("${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-gtk3-libs"
            "${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-common")
+  provides=("${MINGW_PACKAGE_PREFIX}-wxwidgets-gtk3")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-wxwidgets-gtk3")
 
   mkdir -p "${pkgdir}"${MINGW_PREFIX}/lib
   cp -a --recursive "${srcdir}/install-gtk3-${MSYSTEM}-static${MINGW_PREFIX}/lib/wx/" \
@@ -397,6 +403,8 @@ package_wxwidgets3.3-qt() {
   pkgdesc="Qt implementation of wxWidgets ${_wx_basever} C++ GUI API (mingw-w64)"
   depends=("${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-qt-libs"
            "${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-common")
+  provides=("${MINGW_PACKAGE_PREFIX}-wxwidgets-qt")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-wxwidgets-qt")
 
   mkdir -p "${pkgdir}"${MINGW_PREFIX}/lib
   cp -a --recursive "${srcdir}"/install-qt-${MSYSTEM}-shared${MINGW_PREFIX}/lib/wx/ \


### PR DESCRIPTION
See also PR #24292 Both PRs are needed to improve switching from one set of packages to another