### PR TITLE
rust: update to 1.88.0

### DIFF
--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -9,7 +9,7 @@ if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then
 fi
 
 rust_dist_server=https://static.rust-lang.org/dist
-#rust_dist_server=https://dev-static.rust-lang.org/dist/2025-05-10
+#rust_dist_server=https://dev-static.rust-lang.org/dist/2025-06-23
 
 _realname=rust
 pkgbase=mingw-w64-${_realname}
@@ -18,8 +18,8 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-rust-wasm" \
          "${MINGW_PACKAGE_PREFIX}-rust-emscripten" \
          "${MINGW_PACKAGE_PREFIX}-rust-src"))
-pkgver=1.87.0
-pkgrel=2
+pkgver=1.88.0
+pkgrel=1
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -53,27 +53,15 @@ source=("${rust_dist_server}/${_realname}c-${pkgver}-src.tar.gz"{,.asc}
         "0004-compiler-Use-wasm-ld-for-wasm-targets.patch"
         "0008-disable-self-contained-for-gnu-targets.patch")
 noextract=(${_realname}c-${pkgver}-src.tar.gz)
-sha256sums=('149bb9fd29be592da4e87900fc68f0629a37bf6850b46339dd44434c04fd8e76'
+sha256sums=('3a97544434848ae3d193d1d6bc83d6f24cb85c261ad95f955fde47ec64cfcfbe'
             'SKIP'
-            '4450ad9b3acd4cb694f1b4356545aabdbc1074fadba01c5f6f09639c2d94f786'
+            'ae20ed1d60c3419893fca87e66c7b75ebb0c9eca621e1ac01761c813ad95c16f'
             '7cb1773c288ffb1c1e751edc49b1890c84bf9c362742bc5225d19d474edb73a0'
             '56882f1a0f1404c10c7726d6cc37444f2b343e72b969badfcb43760f80db0f32'
             '87b68c2dfbe996d3ef439278e1ac90997fc4ea192f449e8f00262360a551386a')
 validpgpkeys=('108F66205EAEB0AAA8DD5E1C85AB96E6FA1BE5FE'  # Rust Language (Tag and Release Signing Key) <rust-key@rust-lang.org>
               '474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard <tstellar@redhat.com>
               'B6C8F98282B944E3B0D5C2530FC3042E345AD05D') # Hans Wennborg <hans@chromium.org>
-
-# hack the bootstrap
-_stage0date="2022-08-11"
-_stage0version="1.63.0"
-if [[ $_bootstrapping != "no" && $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
-  source+=("https://github.com/mati865/rust-gnullvm-builds/releases/download/${_stage0version}-v2/cargo-${_stage0version}-dev-aarch64-pc-windows-gnullvm.tar.xz"
-           "https://github.com/mati865/rust-gnullvm-builds/releases/download/${_stage0version}-v2/rust-std-${_stage0version}-dev-aarch64-pc-windows-gnullvm.tar.xz"
-           "https://github.com/mati865/rust-gnullvm-builds/releases/download/${_stage0version}-v2/rustc-${_stage0version}-dev-aarch64-pc-windows-gnullvm.tar.xz")
-  noextract+=("cargo-${_stage0version}-dev-aarch64-pc-windows-gnullvm.tar.xz"
-              "rust-std-${_stage0version}-dev-aarch64-pc-windows-gnullvm.tar.xz"
-              "rustc-${_stage0version}-dev-aarch64-pc-windows-gnullvm.tar.xz")
-fi
 
 # =========================================== #
 #   Helper macros to help make tasks easier   #
@@ -108,20 +96,10 @@ prepare() {
 build() {
   cd "${_realname}c-${pkgver}-src"
 
-  # hack to inject the bootstrap compiler
-  if [[ $_bootstrapping != "no" && $MINGW_PACKAGE_PREFIX == *-clang-aarch64 ]]; then
-    mkdir -p "build-${MSYSTEM}/cache/${_stage0date}/"
-    cp -f "${srcdir}/cargo-${_stage0version}-dev-aarch64-pc-windows-gnullvm.tar.xz" \
-      "${srcdir}/rust-std-${_stage0version}-dev-aarch64-pc-windows-gnullvm.tar.xz" \
-      "${srcdir}/rustc-${_stage0version}-dev-aarch64-pc-windows-gnullvm.tar.xz" \
-      "build-${MSYSTEM}/cache/${_stage0date}/"
-  fi
-
+  # We have to do the following because rust doesn't count x86_64-w64-mingw32 as a target triple
   if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then
-    # We have to do the following because rust doesn't count x86_64-w64-mingw32 as a target triple
     export OSTYPE="$CARCH-pc-windows-gnullvm"
   else
-    # We have to do the following because rust doesn't count x86_64-w64-mingw32 as a target triple
     export OSTYPE="$CARCH-pc-windows-gnu"
   fi
 
@@ -170,14 +148,16 @@ build() {
   #_rust_build+=("--verbose")
 
   # create the install at a temporary directory
-  DESTDIR="$PWD/build-$MSYSTEM/dest-rust" python x.py install "${_rust_build[@]}"
+  DESTDIR="$PWD/build-$MSYSTEM/dest-rust" \
+  RUSTFLAGS="${RUSTFLAGS/+crt-static/-crt-static}" \
+    python x.py install "${_rust_build[@]}"
 
   cd build-${MSYSTEM}
   if [[ ${CARCH} != i686 ]]; then
     # move wasm32-unknown-emscripten out of the way for splitting
     mkdir -p dest-emscripten${MINGW_PREFIX}/lib/rustlib
     mv dest-rust${MINGW_PREFIX}/lib/rustlib/wasm32-unknown-emscripten dest-emscripten${MINGW_PREFIX}/lib/rustlib
-    # move wasm32-* targets out of the way for splitting
+    # move other wasm targets out of the way for splitting
     mkdir -p dest-wasm${MINGW_PREFIX}/lib/rustlib
     mv dest-rust${MINGW_PREFIX}/lib/rustlib/wasm32{,v1}-* dest-wasm${MINGW_PREFIX}/lib/rustlib
     # move src out of the way for splitting
@@ -254,7 +234,7 @@ package_rust-emscripten() {
   cp -a dest-emscripten/* "${pkgdir}"
 
   pushd "${pkgdir}${MINGW_PREFIX}"/lib/rustlib
-    llvm-strip --strip-debug wasm32*/lib/*.rlib
+    llvm-strip --strip-debug wasm32-*/lib/*.rlib
   popd
 
   # manually add self-contained linkers to make emscripten target happy

--- a/mingw-w64-rust/bootstrap.toml
+++ b/mingw-w64-rust/bootstrap.toml
@@ -2,7 +2,7 @@
 profile = "dist"
 
 # see src/bootstrap/src/utils/change_tracker.rs
-change-id = 138986
+change-id = 140732
 
 [build]
 #cargo = "$MINGW_PREFIX/bin/cargo.exe"
@@ -61,7 +61,6 @@ cxx = "$MINGW_PREFIX/bin/clang++.exe"
 ar = "$MINGW_PREFIX/bin/llvm-ar.exe"
 ranlib = "$MINGW_PREFIX/bin/llvm-ranlib.exe"
 llvm-config = "$MINGW_PREFIX/bin/llvm-config.exe"
-crt-static = true
 
 [target.wasm32-unknown-unknown]
 cc = "$MINGW_PREFIX/bin/clang.exe"


### PR DESCRIPTION
this is then first Rust relase that downgrades i686-mingw target to tier 2. that means that std and host tools are guaranteed to build, but full test suite won't be run for this target: https://doc.rust-lang.org/nightly/rustc/target-tier-policy.html#tier-2-target-policy. currently this doesn't mean that 32-bit Rust will be dropped soon, but now you should be aware of possible issues while using it as a host

config change: 
- remove crt-static option, it didn't do what expected (this will link libunwind dynamically for gnullvm tools)

@mati865 I guess removing stage0 hack for aarch64 gnullvm won't hurt, right? and I saw you put an effort to make gnullvm targets tier 2 with **host tools**, so we can truly bootstrap all the targets soon