### PR TITLE
gcc: backport fix for "error: non-template type used as a template"

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -51,7 +51,7 @@ else
   _sourcedir=${_realname}-${_version}-${_snapshot}
   _url=https://gcc.gnu.org/pub/gcc/snapshots/${_version}-${_snapshot}
 fi
-pkgrel=5
+pkgrel=6
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -94,7 +94,8 @@ source=(${_url}/${_sourcedir}.tar.xz{,.sig}
         0200-add-m-no-align-vector-insn-option-for-i386.patch
         2001-fix-building-rust-on-mingw-w64.patch
         3001-fix-codeview-crashes.patch
-        9002-native-tls.patch)
+        9002-native-tls.patch
+        cf588f1a8e7406ced5b08f32f9d23f015a240a31.patch::https://gcc.gnu.org/cgit/gcc/patch/?id=cf588f1a8e7406ced5b08f32f9d23f015a240a31)
 sha256sums=('e2b09ec21660f01fecffb715e0120265216943f038d0e48a9868713e54f06cea'
             'SKIP'
             'bce81824fc89e5e62cca350de4c17a27e27a18a1a1ad5ca3492aec1fc5af3234'
@@ -111,7 +112,8 @@ sha256sums=('e2b09ec21660f01fecffb715e0120265216943f038d0e48a9868713e54f06cea'
             '1484911163634f30324827619c873a6267b377abba0df8bbedfd128163c53ea4'
             'a411f59953553a3d01dd64c79b1acbb91eca092c4cb01bfd26b1c51c3eb798e8'
             'f21f9ab731e9cab8fd4ca8c289497f859ef7004e6fa0507877dc2559ac2071c3'
-            'd977683efc6f6b4dd675a8f1978416d22d5b5d1fa53614b9a18bc18efa231391')
+            'd977683efc6f6b4dd675a8f1978416d22d5b5d1fa53614b9a18bc18efa231391'
+            'fca7f20abc77eebcf91a18acc5bcc6b5e092822a5def80bac9eeec8d020276b2')
 validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.org
               86CFFCA918CF3AF47147588051E8B148A9999C34  # evangelos@foutrelis.com
               13975A70E63C361C73AE69EF6EEB81F8981C74C7  # richard.guenther@gmail.com
@@ -170,6 +172,11 @@ prepare() {
   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=120051
   apply_patch_with_msg \
     3001-fix-codeview-crashes.patch
+
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=120495
+  # https://github.com/msys2/MINGW-packages/issues/24209
+  apply_patch_with_msg \
+    cf588f1a8e7406ced5b08f32f9d23f015a240a31.patch
 
   # apply_patch_with_msg \
   #   9002-native-tls.patch


### PR DESCRIPTION
Fixes #24209