### PR TITLE
qt6-base: better fallback path for freetype

### DIFF
--- a/mingw-w64-qt6-base/008-freetype-fonts-fallback-dir.patch
+++ b/mingw-w64-qt6-base/008-freetype-fonts-fallback-dir.patch
@@ -1,0 +1,33 @@
+Use a more reasonable fallback directory for fonts on Windows.
+
+The existing fallback points to a directory that no longer exists by default
+which causes warnings like the following on run-time:
+
+```
+QFontDatabase: Cannot find font directory C:/msys64/mingw64/qt6/libs/fonts.
+Note that Qt no longer ships fonts. Deploy some (from
+https://dejavu-fonts.github.io/ for example) or switch to fontconfig.
+```
+
+diff -urN qtbase-everywhere-src-6.9.1/src/gui/text/qplatformfontdatabase.cpp.orig qtbase-everywhere-src-6.9.1/src/gui/text/qplatformfontdatabase.cpp
+--- qtbase-everywhere-src-6.9.1/src/gui/text/qplatformfontdatabase.cpp.orig	2025-05-28 12:22:57.000000000 +0200
++++ qtbase-everywhere-src-6.9.1/src/gui/text/qplatformfontdatabase.cpp	2025-06-27 15:11:39.750452000 +0200
+@@ -361,8 +361,17 @@
+ QString QPlatformFontDatabase::fontDir() const
+ {
+     QString fontpath = qEnvironmentVariable("QT_QPA_FONTDIR");
+-    if (fontpath.isEmpty())
++    if (fontpath.isEmpty()) {
++#ifdef Q_OS_WIN
++        QString windir = qEnvironmentVariable("WINDIR");
++        if (windir.isEmpty())
++            fontpath = "C:/Windows/Fonts"_L1;
++        else
++            fontpath = windir + "/Fonts"_L1;
++#else
+         fontpath = QLibraryInfo::path(QLibraryInfo::LibrariesPath) + "/fonts"_L1;
++#endif
++    }
+ 
+     return fontpath;
+ }

--- a/mingw-w64-qt6-base/PKGBUILD
+++ b/mingw-w64-qt6-base/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
 _qtver=6.9.1
 pkgver=${_qtver/-/}
-pkgrel=1
+pkgrel=2
 pkgdesc="A cross-platform application and UI framework (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -52,6 +52,7 @@ source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/subm
         005-qt-6.7.0-opengl-header.patch
         006-qt-6.2.0-dont-add-resource-files-to-qmake-libs.patch
         007-Fix-crashes-in-rasterization-code-using-setjmp.patch
+        008-freetype-fonts-fallback-dir.patch
         009-qfileinfo-undefine-mingw-stat.patch
         010-export-some-constexpr-variables.patch
         011-qt6-windeployqt-fixes.patch)
@@ -63,6 +64,7 @@ sha256sums=('40caedbf83cc9a1959610830563565889878bc95f115868bbf545d1914acf28e'
             'a2afc74d181864409dc96eca368b647c0f79e25751db88e3263f2d1101edf8e4'
             '4085a10b290b8e3d930de535cbad2ba3e643432cba433aa2b28fe664f86d38a3'
             '3a256533401a48aff7e3c4b02118d62a0cccc2b3566c6e550e7b467aca3e496f'
+            'e2fbd970a20773f0d914f6ffc96aafc8212192227577ec007a460e35398038bf'
             'f4261d43a142a24e5fa3b23e25813754839db84078cc8c6dc611139bf531e64a'
             '23656a7839d7dcb763d022722d723493c847914b0639bab861ddb05d823af5b7'
             '742a15191e618a50c1fb4b93e87dda73a2bd130a6cb829cb2026256ec2c252e4')
@@ -94,6 +96,7 @@ prepare() {
     005-qt-6.7.0-opengl-header.patch \
     006-qt-6.2.0-dont-add-resource-files-to-qmake-libs.patch \
     007-Fix-crashes-in-rasterization-code-using-setjmp.patch \
+    008-freetype-fonts-fallback-dir.patch \
     009-qfileinfo-undefine-mingw-stat.patch \
     011-qt6-windeployqt-fixes.patch
 


### PR DESCRIPTION
Use a more reasonable fallback directory for fonts on Windows. The existing fallback points to a directory that no longer exists by default which causes warnings like the following on run-time:

```
QFontDatabase: Cannot find font directory C:/msys64/mingw64/qt6/libs/fonts.
Note that Qt no longer ships fonts. Deploy some (from
https://dejavu-fonts.github.io/ for example) or switch to fontconfig.
```

The change is motivated by reports from Octave users. The proposed change would affect *all* downstream users of `QFontDatabase` though (in a positive way - I think).
@MehdiChinoune, @lazka, others: Is this change acceptable?

Note: Qt6 doesn't support fontconfig for Windows.
