### PR TITLE
notepad++: Update to 8.8.2

### DIFF
--- a/mingw-w64-notepad++/PKGBUILD
+++ b/mingw-w64-notepad++/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=notepad++
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=8.8.1
+pkgver=8.8.2
 pkgrel=1
 pkgdesc="Notepad++ is a free source code editor and Notepad replacement that supports several languages. (mingw-w64)"
 arch=('any')
@@ -24,7 +24,7 @@ source=(
   001-aarch64.patch
 )
 validpgpkeys=('14BCE4362749B2B51F8C71226C429F1D8D84F46E')
-sha256sums=('0686000e690d354bb675e85f50c7dfb4691c2dd34fce0f9a57e7a317bb0bd79e'
+sha256sums=('8a5d675b869704f65eb3e349788a8ef4ab3e45dc92732b672db064d9fad07906'
             'bbb81ac3893a3701cdf6a193666d063b223bffcae4f78bf6e09ad81099ece508'
             'f4468e0fa0e476fc77282cb0b3cff845ed8bce91a816a7c04e8d272abf5c5b1c'
             '2643cce3dbd5fcb65481be4afe7bf6fdea084cde134e04b38dd07239e1f09d59'


### PR DESCRIPTION
see ReleaseNotes https://notepad-plus-plus.org/news/v882-fix-security-issue/