### PR TITLE
inkscape: Update to 1.4.2

### DIFF
--- a/mingw-w64-inkscape/PKGBUILD
+++ b/mingw-w64-inkscape/PKGBUILD
@@ -5,8 +5,8 @@
 _realname=inkscape
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.4.1
-pkgrel=2
+pkgver=1.4.2
+pkgrel=1
 pkgdesc="Vector graphics editor using the SVG file format (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -76,12 +76,14 @@ source=("https://media.inkscape.org/dl/resources/file/${_realname}-${pkgver}.tar
         inkscape-1.0.1-unbundle.patch
         inkscape-1.0.1-install-layout.patch
         007-no-console-clang.patch
-        008-fix-glib-2-84-build.patch)
-sha256sums=('74796a8af4e14a0d5d5c1cc58d3ec1ea6d488a04306dd6e8d32c11f0748d7232'
+        008-fix-glib-2-84-build.patch
+        https://gitlab.com/inkscape/inkscape/-/commit/40f5b15b7e29908b79c54e81db6f340936102e08.patch)
+sha256sums=('2000530c7917e5260c9e8575a7154ff6926643d2006487d714e304a963f0c782'
             '92387251c1740f1a57cde9e587cc673ef1600813617bd2c9db65598c324a24d4'
             '131b2e1190637df0554ef1ee8cf46440689584375c117d057ab47d5871c58128'
             'c49d38b7c1a66e4b40e1b75fb055b730eb863a67a74d899da6d4d6db6baedcec'
-            '776c6bae0eb646313f30e1945438f678e19edc2ea5dcd1851ca89cd4d01d2fd9')
+            '776c6bae0eb646313f30e1945438f678e19edc2ea5dcd1851ca89cd4d01d2fd9'
+            'a789592ad19ee26c0085145095adf06a5e3243fc2ee3f3de4a3e0cb2e3933609')
 noextract=("${_realname}-${pkgver}.tar.xz")
 
 apply_patch_with_msg() {
@@ -107,6 +109,9 @@ prepare() {
   # https://gitlab.com/inkscape/inkscape/-/issues/5615
   apply_patch_with_msg \
     008-fix-glib-2-84-build.patch
+
+  apply_patch_with_msg \
+    40f5b15b7e29908b79c54e81db6f340936102e08.patch
 }
 
 build() {


### PR DESCRIPTION
and backport a poppler build fix