### PR TITLE
cargo-tauri: update to 2.6.2

### DIFF
--- a/mingw-w64-cargo-tauri/PKGBUILD
+++ b/mingw-w64-cargo-tauri/PKGBUILD
@@ -4,7 +4,7 @@ _basename=tauri
 _realname=cargo-${_basename}
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.5.0
+pkgver=2.6.2
 pkgrel=1
 pkgdesc='Command line interface for building Tauri apps (mingw-w64)'
 arch=('any')
@@ -16,10 +16,11 @@ msys2_references=(
   'purl: pkg:cargo/tauri'
 )
 license=('spdx:MIT OR Apache-2.0')
-makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
+makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
+             'git')
 source=("${msys2_repository_url}/archive/${_basename}-cli-v${pkgver}/${_basename}-${_basename}-cli-v${pkgver}.tar.gz")
 noextract=("${_basename}-${_basename}-cli-v${pkgver}.tar.gz")
-sha256sums=('63545497b0a54380cd270fafe94e813c08d4f49685246fca413ba56ca76ac647')
+sha256sums=('be5fb6b51d2c5e7670c276851f4cc14a802d3e58b2745d369ca9e35455af9dc4')
 
 prepare() {
   [[ -d "${srcdir}/${_basename}-${_basename}-cli-v${pkgver}" ]] && rm -rf "${srcdir}/${_basename}-${_basename}-cli-v${pkgver}"
@@ -29,7 +30,10 @@ prepare() {
 
   cd "${srcdir}/${_basename}-${_basename}-cli-v${pkgver}/crates/tauri-cli"
 
-  "${MINGW_PREFIX}/bin/cargo.exe" fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  "${MINGW_PREFIX}/bin/cargo.exe" fetch \
+    --locked \
+    --config='net.git-fetch-with-cli=true' \
+    --target "$(rustc -vV | sed -n 's/host: //p')"
 }
 
 build() {


### PR DESCRIPTION
All good with local build, but failure to fetch crates in `CI`:
```
==> Starting prepare()...
      Updating git repository `[https://github.com/tauri-apps/schemars.git`](https://github.com/tauri-apps/schemars.git%60)
  error: failed to load source for dependency `schemars_derive`
  
  Caused by:
    Unable to update https://github.com/tauri-apps/schemars.git?branch=feat%2Fpreserve-description-newlines#c30f9848
  
  Caused by:
    failed to clone into: C:\Users\runneradmin\.cargo\git\db\schemars-756e8af8bf64fdcc
  
  Caused by:
    revision c30f98480e6e4742aa72202d55d5264c6b2e6476 not found
  
  Caused by:
    network failure seems to have happened
    if a proxy or similar is necessary `net.git-fetch-with-cli` may help here
    https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
  
  Caused by:
    the SSL certificate is invalid; class=Ssl (16)
  ==> ERROR: A failure occurred in prepare().
      Aborting...
```