### PR TITLE
gnuplot: fix path translation

### DIFF
--- a/mingw-w64-gnuplot/01-gnuplot.patch
+++ b/mingw-w64-gnuplot/01-gnuplot.patch
@@ -1,42 +1,6 @@
-diff --unified '--color=auto' -r gnuplot-5.4.0.orig/config/mingw/Makefile gnuplot-5.4.0/config/mingw/Makefile
---- gnuplot-5.4.0.orig/config/mingw/Makefile	2020-04-10 09:15:40.000000000 +0530
-+++ gnuplot-5.4.0/config/mingw/Makefile	2020-09-06 20:38:04.140186600 +0530
-@@ -784,19 +784,19 @@
- $(HELPFILE): $(BUILDHELPFILE)
- 	$(CP) $^ $@
- 
--htmlhelp.def: /c/Windows/System32/hhctrl.ocx
--ifndef MINGW64
--	pexports $^ > $@
--else
--	gendef - $^ > $@
--endif
-+#htmlhelp.def: /c/Windows/System32/hhctrl.ocx
-+#ifndef MINGW64
-+#	pexports $^ > $@
-+#else
-+#	gendef - $^ > $@
-+#endif
- 
--prntvpt.def: /c/Windows/System32/prntvpt.dll
--ifndef MINGW64
--	pexports $^ > $@
--else
--	gendef - $^ > $@
--endif
-+#prntvpt.def: /c/Windows/System32/prntvpt.dll
-+#ifndef MINGW64
-+#	pexports $^ > $@
-+#else
-+#	gendef - $^ > $@
-+#endif
- 
- # Working directory for patched Japanese sources 
- JA = ja/
-diff --unified '--color=auto' -r gnuplot-5.4.0.orig/configure.ac gnuplot-5.4.0/configure.ac
---- gnuplot-5.4.0.orig/configure.ac	2020-07-12 05:59:47.000000000 +0530
-+++ gnuplot-5.4.0/configure.ac	2020-09-06 20:04:48.475405900 +0530
-@@ -37,6 +37,8 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -38,6 +38,8 @@
  AC_C_STRINGIZE
  AC_PROG_LN_S
  
@@ -45,7 +9,7 @@ diff --unified '--color=auto' -r gnuplot-5.4.0.orig/configure.ac gnuplot-5.4.0/c
  if test "${build}" != "${host}"
  then
    CC=${CC-${host_alias-gcc}}
-@@ -50,6 +52,8 @@
+@@ -51,6 +53,8 @@
    CC_FOR_BUILD="${CC}"
    AC_PROG_CC
  
@@ -54,30 +18,27 @@ diff --unified '--color=auto' -r gnuplot-5.4.0.orig/configure.ac gnuplot-5.4.0/c
    # We must set the default linker to the linker used by gcc for the correct
    # operation of libtool.  If LD is not defined and we are using gcc, try to
    # set the LD default to the ld used by gcc.
-@@ -59,7 +63,10 @@
+@@ -60,7 +64,9 @@
      then
        case $build in
        *-*-mingw*)
 -        gcc_prog_ld=`$CC -print-prog-name=ld 2>&1 | tr -d '\015'` ;;
 +        gcc_prog_ld=`$CC -print-prog-name=ld 2>&1 | tr -d '\015'`
 +        AC_MSG_NOTICE([MINGW environment detected, executing MINGW type build])
-+        #AC_CONFIG_LINKS([src/config.h:config/config.mgw])
 +        build_mingw=yes ;;
        *)
          gcc_prog_ld=`$CC -print-prog-name=ld 2>&1` ;;
        esac
-@@ -955,6 +962,8 @@
- 
- AM_CONDITIONAL(BUILD_GPCAIRO, test "${build_gpcairo}" = yes)
- 
+@@ -78,6 +84,7 @@
+ fi
+ AM_PROG_CC_C_O
+ AC_SUBST(CC_FOR_BUILD)
 +AM_CONDITIONAL(BUILD_MINGW, test "${build_mingw}" = yes)
-+
- dnl Enable subsystem to generate statistical summary of file contents
- AC_ARG_ENABLE(stats,dnl
- [  --disable-stats         Omit calculation of statistical summary of data],
-diff --unified '--color=auto' -r gnuplot-5.4.0.orig/demo/plugin/Makefile.am gnuplot-5.4.0/demo/plugin/Makefile.am
---- gnuplot-5.4.0.orig/demo/plugin/Makefile.am	2017-12-22 23:02:30.000000000 +0530
-+++ gnuplot-5.4.0/demo/plugin/Makefile.am	2020-09-06 20:05:12.659453700 +0530
+ 
+ dnl large file support
+ AC_CHECK_TYPES([off_t])
+--- a/demo/plugin/Makefile.am
++++ b/demo/plugin/Makefile.am
 @@ -4,7 +4,7 @@
  noinst_PROGRAMS = demo_plugin.so
  
@@ -87,12 +48,11 @@ diff --unified '--color=auto' -r gnuplot-5.4.0.orig/demo/plugin/Makefile.am gnup
  demo_plugin_so_LDFLAGS = -shared
  
  # Note: Solaris SunPro C compiler needs these flags instead
-diff --unified '--color=auto' -r gnuplot-5.4.0.orig/docs/Makefile.am gnuplot-5.4.0/docs/Makefile.am
---- gnuplot-5.4.0.orig/docs/Makefile.am	2020-04-10 22:24:28.000000000 +0530
-+++ gnuplot-5.4.0/docs/Makefile.am	2020-09-06 20:03:02.506859700 +0530
-@@ -50,6 +50,11 @@
- 
- AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/term
+--- a/docs/Makefile.am
++++ b/docs/Makefile.am
+@@ -38,6 +38,11 @@
+ AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/term \
+               -I./ja/term
  
 +if BUILD_MINGW
 +AM_CPPFLAGS += -DWINDOWS_NO_GUI
@@ -102,23 +62,21 @@ diff --unified '--color=auto' -r gnuplot-5.4.0.orig/docs/Makefile.am gnuplot-5.4
  # Documentation will be prepared for all terminals in CORETERM
  # even if the terminal itself is not included in the build.
  
-diff --unified '--color=auto' -r gnuplot-5.4.0.orig/Makefile.am gnuplot-5.4.0/Makefile.am
---- gnuplot-5.4.0.orig/Makefile.am	2020-03-31 22:58:16.000000000 +0530
-+++ gnuplot-5.4.0/Makefile.am	2020-09-06 20:01:49.907467200 +0530
+--- a/Makefile.am
++++ b/Makefile.am
 @@ -7,6 +7,8 @@
  PATCHLEVEL PGPKEYS README RELEASE_NOTES \
- configure.vms win
+ win
  
 +dist_doc_DATA = FAQ.pdf README RELEASE_NOTES Copyright NEWS BUGS
 +
  DISTCLEANFILES = stamp-h
  
  ACLOCAL_AMFLAGS = -I m4
-diff --unified '--color=auto' -r gnuplot-5.4.0.orig/src/command.c gnuplot-5.4.0/src/command.c
---- gnuplot-5.4.0.orig/src/command.c	2020-06-11 03:03:34.000000000 +0530
-+++ gnuplot-5.4.0/src/command.c	2020-09-06 19:57:28.950915200 +0530
-@@ -112,7 +112,7 @@
- int thread_rl_RetCode = -1; /* return code from readline in a thread */
+--- a/src/command.c
++++ b/src/command.c
+@@ -107,7 +107,7 @@
+ static TBOOLEAN pause_internal;    /* flag to indicate not to use a dialog box */
  #endif /* OS2_IPC */
  
 -#ifndef _WIN32
@@ -126,19 +84,9 @@ diff --unified '--color=auto' -r gnuplot-5.4.0.orig/src/command.c gnuplot-5.4.0/
  # include "help.h"
  #endif
  
-@@ -2839,7 +2839,7 @@
- 
- 
- #ifdef NO_GIH
--#ifdef _WIN32
-+#ifdef _MSC_VER
- void
- help_command()
- {
-diff --unified '--color=auto' -r gnuplot-5.4.0.orig/src/Makefile.am gnuplot-5.4.0/src/Makefile.am
---- gnuplot-5.4.0.orig/src/Makefile.am	2020-03-31 22:58:16.000000000 +0530
-+++ gnuplot-5.4.0/src/Makefile.am	2020-09-06 20:06:11.275225300 +0530
-@@ -93,6 +93,27 @@
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -99,6 +99,60 @@
  # Hercules and original pc graphics driver code
  # corgraph.asm header.mac hrcgraph.asm pcgraph.asm lineproc.mac
  
@@ -154,22 +102,13 @@ diff --unified '--color=auto' -r gnuplot-5.4.0.orig/src/Makefile.am gnuplot-5.4.
 +AM_LDFLAGS = 
 +
 +gnuplot_SOURCES += win/winmain.c win/wgnuplib.c win/wgraph.c win/wprinter.c \
-+win/wpause.c win/wgdiplus.cpp win/wd2d.cpp win/wtext.h plot.h\
-+gpexecute.c
++win/wpause.c win/wgdiplus.cpp win/wd2d.cpp win/wtext.h plot.h gpexecute.c
 +
 +gnuplot_CPPFLAGS = $(AM_CPPFLAGS) -DPIPES -DWGP_CONSOLE
 +gnuplot_LDADD += -lkernel32 -lgdi32 -lwinspool -lcomdlg32 -lcomctl32 \
 + -ladvapi32 -lshell32 -lmsimg32 -lgdiplus -lshlwapi -ld2d1 -ld3d11 -ldwrite \
 + -lprntvpt -lwindowscodecs -lole32 -lgobject-2.0
 +gnuplot_LDFLAGS = $(AM_LDFLAGS) -mconsole -municode
-+
- if BUILD_WXWIDGETS
- gnuplot_SOURCES += wxterminal/wxt_gui.cpp
- endif
-@@ -103,6 +122,41 @@
- 
- if BUILD_BITMAP
- gnuplot_SOURCES += bitmap.c
 +
 +#wgnuplot section
 +bin_PROGRAMS += wgnuplot
@@ -203,20 +142,18 @@ diff --unified '--color=auto' -r gnuplot-5.4.0.orig/src/Makefile.am gnuplot-5.4.
 +	windres $(RCFLAGS) $< wgplt_res.$(O)
 +	echo wgplt_res.$(O)
 +
-+endif
++endif # BUILD_MINGW
 +
+ if BUILD_WXWIDGETS
+ gnuplot_SOURCES += wxterminal/wxt_gui.cpp
  endif
- 
- if DEVELOPMENT_VERSION
-diff --unified '--color=auto' -r gnuplot-5.4.0.orig/src/win/winmain.c gnuplot-5.4.0/src/win/winmain.c
---- gnuplot-5.4.0.orig/src/win/winmain.c	2020-04-10 22:24:28.000000000 +0530
-+++ gnuplot-5.4.0/src/win/winmain.c	2020-09-06 19:58:17.437576400 +0530
-@@ -368,7 +368,8 @@
+--- a/src/win/winmain.c
++++ b/src/win/winmain.c
+@@ -372,7 +372,7 @@
      else
  	lang = GetLanguageCode();
  
 -    filename = (LPTSTR) malloc((_tcslen(szModuleName) + _tcslen(name) + _tcslen(lang) + _tcslen(ext) + 1) * sizeof(TCHAR));
-+    //filename = (LPTSTR) malloc((_tcslen(szModuleName) + _tcslen(name) + _tcslen(lang) + _tcslen(ext) + 1) * sizeof(TCHAR));
 +    filename = (LPTSTR) malloc(1024 * sizeof(TCHAR));
      if (filename) {
  	_tcscpy(filename, szModuleName);

--- a/mingw-w64-gnuplot/02-wxwidgets-3.2.patch
+++ b/mingw-w64-gnuplot/02-wxwidgets-3.2.patch
@@ -1,6 +1,6 @@
 --- a/src/wxterminal/wxt_gui.cpp
 +++ b/src/wxterminal/wxt_gui.cpp
-@@ -638,7 +638,7 @@
+@@ -623,7 +623,7 @@
  
  		RECT rect;
  		rect.left = rect.top = 0;
@@ -9,7 +9,7 @@
  		rect.right  = MulDiv(panel->plot.device_xmax, dpi, 10);
  		rect.bottom = MulDiv(panel->plot.device_ymax, dpi, 10);
  		HDC hmf = CreateEnhMetaFileW(NULL, fullpathFilename.wc_str(), &rect, NULL);
-@@ -708,7 +708,7 @@
+@@ -693,7 +693,7 @@
  		wxSize ppi = wxdc->GetPPI();
  		unsigned dpi = 96;
  #ifdef _WIN32

--- a/mingw-w64-gnuplot/04-mingw-path-translation.patch
+++ b/mingw-w64-gnuplot/04-mingw-path-translation.patch
@@ -1,0 +1,165 @@
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -2,16 +2,16 @@
+ AUTOMAKE_OPTIONS = foreign subdir-objects
+ 
+ # in the spirit of automake ...
+-pkglibexecdir = $(libexecdir)/@PACKAGE@/@VERSION_MAJOR@
++pkglibexecdir = $(libexecdir)
+ 
+ # Where to send email about bugs and comments (locally)
+ EMAIL = gnuplot-bugs@lists.sourceforge.net
+ 
+ # Default help file location
+-HELPFILE=@GIHDIR@/gnuplot.gih
++HELPFILE=share/$(PACKAGE)/$(VERSION_MAJOR)/gnuplot.gih
+ 
+ # Generic default driver location
+-GNUPLOT_DRIVER_DIR=$(pkglibexecdir)
++GNUPLOT_DRIVER_DIR=bin
+ 
+ # Default X11 driver location
+ X11_DRIVER_DIR=$(pkglibexecdir)
+@@ -20,16 +20,16 @@
+ QT_DRIVER_DIR=$(pkglibexecdir)
+ 
+ # Default lua driver location
+-GNUPLOT_LUA_DIR=$(pkgdatadir)/$(VERSION_MAJOR)/lua
++GNUPLOT_LUA_DIR=share/$(PACKAGE)/$(VERSION_MAJOR)/lua
+ 
+ # Default javascript location
+-GNUPLOT_JS_DIR=$(pkgdatadir)/$(VERSION_MAJOR)/js
++GNUPLOT_JS_DIR=share/$(PACKAGE)/$(VERSION_MAJOR)/js
+ 
+ # Default Postscript prologues location
+-GNUPLOT_PS_DIR=$(pkgdatadir)/$(VERSION_MAJOR)/PostScript
++GNUPLOT_PS_DIR=share/$(PACKAGE)/$(VERSION_MAJOR)/PostScript
+ 
+ # System-wide initialization file
+-GNUPLOT_SHARE_DIR=$(pkgdatadir)/$(VERSION_MAJOR)
++GNUPLOT_SHARE_DIR=share/$(PACKAGE)/$(VERSION_MAJOR)
+ 
+ # There is probably no need to edit anything below this line
+ 
+--- a/src/command.c
++++ b/src/command.c
+@@ -3449,7 +3449,7 @@
+ #  if defined(MSDOS) || defined(OS2)
+ 	help_ptr = HelpFile;
+ #  else
+-	help_ptr = HELPFILE;
++	help_ptr = RelativePathToGnuplot(HELPFILE);  
+ #  endif
+ 
+ # else				/* !SHELFIND */
+--- a/src/show.c
++++ b/src/show.c
+@@ -1164,7 +1164,7 @@
+ 	    char *driverdir = getenv("GNUPLOT_DRIVER_DIR");
+ #ifdef GNUPLOT_DRIVER_DIR
+ 	    if (!driverdir)
+-		driverdir = GNUPLOT_DRIVER_DIR;
++		driverdir = RelativePathToGnuplot(GNUPLOT_DRIVER_DIR);
+ #endif
+ 	    fprintf(stderr, "GNUPLOT_DRIVER_DIR = \"%s\"\n",
+ 		    driverdir ? driverdir : "");
+@@ -1175,23 +1175,23 @@
+ 
+ #ifdef GNUPLOT_PS_DIR
+ 	    if (psdir == NULL)
+-		psdir = GNUPLOT_PS_DIR;
++		psdir = RelativePathToGnuplot(GNUPLOT_PS_DIR);
+ #endif
+ 	    if (psdir != NULL)
+ 		fprintf(stderr, "GNUPLOT_PS_DIR     = \"%s\"\n", psdir);
+ 	}
+ 
+ 	{
+-#ifndef _WIN32
++#ifndef _MSC_VER
+ 	    char *helpfile = NULL;
+ 	    if ((helpfile = getenv("GNUHELP")) == NULL)
+ # if defined(MSDOS) || defined(OS2)
+ 		helpfile = HelpFile;
+ # else
+-		helpfile = HELPFILE;
++		helpfile = RelativePathToGnuplot(HELPFILE);
+ # endif
+ 	fprintf(stderr, "HELPFILE           = \"%s\"\n", helpfile);
+-#else /* _WIN32 */
++#else /* _MSC_VER */
+ 	    fprintf(stderr, "HELPFILE           = \"" TCHARFMT "\"\n", winhelpname);
+ #endif
+ 	}
+--- a/src/syscfg.h
++++ b/src/syscfg.h
+@@ -103,13 +103,21 @@
+ # if !defined(__WATCOMC__) || (__WATCOMC__ <= 1290)
+ #  define S_IFIFO  _S_IFIFO
+ # endif
+-# define HOME    "GNUPLOT"
+-# define PLOTRC  "gnuplot.ini"
+-# define SHELL   "\\command.com"
+-# define DIRSEP1 '\\'
+-# define DIRSEP2 '/'
+-# define PATHSEP ';'
+-# define GNUPLOT_HISTORY_FILE "~\\gnuplot_history"
++# ifdef _MSC_VER
++#  define HOME    "GNUPLOT"
++#  define PLOTRC  "gnuplot.ini"
++#  define SHELL   "\\command.com"
++#  define DIRSEP1 '\\'
++#  define DIRSEP2 '/'
++#  define PATHSEP ';'
++#  define GNUPLOT_HISTORY_FILE "~\\gnuplot_history"
++# else
++#  define HOME    "HOME"
++#  define PLOTRC  "~/.gnuplot"
++#  define DIRSEP1 '/'
++#  define DIRSEP2 '\\'
++#  define GNUPLOT_HISTORY_FILE "~/.gnuplot_history"
++# endif
+ /* Flags for windows.h:
+    Minimal required platform is Windows 7, see
+    https://msdn.microsoft.com/en-us/library/windows/desktop/aa383745.aspx
+--- a/src/win/winmain.c
++++ b/src/win/winmain.c
+@@ -311,16 +311,22 @@
+ #ifdef UNICODE
+     LPSTR ansi_dir = AnsiText(szPackageDir, encoding);
+     LPSTR rel_path = (char *) gp_realloc(ansi_dir, strlen(ansi_dir) + strlen(path) + 1, "RelativePathToGnuplot");
++    LPSTR s;
+     if (rel_path == NULL) {
+ 	free(ansi_dir);
+ 	return (LPSTR) path;
+     }
+ #else
+     char * rel_path = (char * ) gp_alloc(strlen(szPackageDir) + strlen(path) + 1, "RelativePathToGnuplot");
++    char *s;
+     strcpy(rel_path, szPackageDir);
+ #endif
+     /* szPackageDir is guaranteed to have a trailing backslash */
+     strcat(rel_path, path);
++    /* convert slashes to backslashes */
++    for (s = rel_path;*s != NUL; s++)
++	if (*s == DIRSEP2)
++	    *s = DIRSEP1;
+     return rel_path;
+ }
+ 
+@@ -401,6 +401,7 @@
+     else
+ 	szLanguageCode = NULL;
+ 
++#ifdef NO_GIH
+     /* help file name */
+     GetPrivateProfileString(section, TEXT("HelpFile"), TEXT(""), profile, 80, file);
+     if (profile[0] != NUL) {
+@@ -413,6 +420,7 @@
+ 	/* default name is "wgnuplot-LL.chm" */
+ 	winhelpname = LocalisedFile(name, hlpext, TEXT(HELPFILE));
+     }
++#endif
+ 
+     /* menu file name */
+     GetPrivateProfileString(section, TEXT("MenuFile"), TEXT(""), profile, 80, file);

--- a/mingw-w64-gnuplot/05-fix-parallel-building.patch
+++ b/mingw-w64-gnuplot/05-fix-parallel-building.patch
@@ -1,0 +1,11 @@
+--- a/demo/Makefile.am
++++ b/demo/Makefile.am
+@@ -20,7 +20,7 @@
+ 
+ all: $(BINARY_FILES)
+ 
+-$(BINARY_FILES): ../src/bf_test $(top_srcdir)/demo/dodecahedron.dat
++$(BINARY_FILES) &: ../src/bf_test $(top_srcdir)/demo/dodecahedron.dat
+ 	@echo Creating binary data files
+ 	test "$(top_srcdir)" = "$(top_builddir)" || cp $(top_srcdir)/demo/dodecahedron.dat .
+ 	@../src/bf_test

--- a/mingw-w64-gnuplot/PKGBUILD
+++ b/mingw-w64-gnuplot/PKGBUILD
@@ -9,7 +9,7 @@ _realname=gnuplot
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=6.0.3
-pkgrel=1
+pkgrel=2
 pkgdesc="Plotting package which outputs to PostScript, PNG, GIF, and others (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -35,22 +35,23 @@ depends=("${MINGW_PACKAGE_PREFIX}-cairo"
          "${MINGW_PACKAGE_PREFIX}-qt6-5compat"
          "${MINGW_PACKAGE_PREFIX}-qt6-base"
          "${MINGW_PACKAGE_PREFIX}-qt6-svg"
-         #"${MINGW_PACKAGE_PREFIX}-readline"
          "${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-msw-libs")
-makedepends=(
-  "${MINGW_PACKAGE_PREFIX}-cc"
-  "${MINGW_PACKAGE_PREFIX}-autotools"
-  "${MINGW_PACKAGE_PREFIX}-qt6-tools"
-  "${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-msw"
-)
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-qt6-tools"
+             "${MINGW_PACKAGE_PREFIX}-wxwidgets${_wx_basever}-msw")
 source=("https://downloads.sourceforge.net/sourceforge/${_realname}/${_realname}-${pkgver}.tar.gz"
         "01-gnuplot.patch"
         "02-wxwidgets-3.2.patch"
-        "03-fix-build-doc2web.patch")
+        "03-fix-build-doc2web.patch"
+        "04-mingw-path-translation.patch"
+        "05-fix-parallel-building.patch")
 sha256sums=('ec52e3af8c4083d4538152b3f13db47f6d29929a3f6ecec5365c834e77f251ab'
-            '9b8af2d8eb24f0e8048a388949d8905a79b69208cf7eadd34a763a0c582b8f9e'
-            '06f8076446c4174d5972a252ae18a7f672fd25f4131b3dd1d65399c1f3b52697'
-            '427fa4d801d7c9117526790ee082af91c472c551d4cd4b45078efe856f6a92f9')
+            '7b2b1ba994a658c2464276224ed0854eac1f35ad626cd1a7f4d16da45495975f'
+            '62324380d6e842316f818b60e9be2712fea84c919cf28d5df1b268106e261778'
+            '427fa4d801d7c9117526790ee082af91c472c551d4cd4b45078efe856f6a92f9'
+            '442c70bf341e614853bba78d45ac258a31c8838945e8abd7af93229abd7277ca'
+            '70b8cd62aa22749fdee07c678d3487033a45ac9db28c5cadecf49bdecf56f181')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -61,11 +62,13 @@ apply_patch_with_msg() {
 }
 
 prepare() {
-  cd "${srcdir}"/${_realname}-${pkgver}
+  cd ${_realname}-${pkgver}
   apply_patch_with_msg \
     01-gnuplot.patch \
     02-wxwidgets-3.2.patch \
-    03-fix-build-doc2web.patch
+    03-fix-build-doc2web.patch \
+    04-mingw-path-translation.patch \
+    05-fix-parallel-building.patch
 
   sed -i "s/AC_PATH_PROG(WX_CONFIG, wx-config,/AC_PATH_PROG(WX_CONFIG, wx-config-${_wx_basever},/" configure.ac
 
@@ -73,13 +76,14 @@ prepare() {
 }
 
 build() {
-  mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
+  mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
 
   CFLAGS+=" -std=c17" \
   CXXFLAGS+=" -Wno-ignored-attributes" \
   ../${_realname}-${pkgver}/configure \
       --prefix=${MINGW_PREFIX} \
       --libexecdir=${MINGW_PREFIX}/bin \
+      --datadir=${MINGW_PREFIX}/share \
       --with-caca \
       --with-lua \
       --without-latex \
@@ -91,13 +95,12 @@ build() {
       --disable-raise-console \
       "${_extra_config[@]}"
 
-  make pkglibexecdir=${MINGW_PREFIX}/bin LRELEASE=${MINGW_PREFIX}/bin/lrelease-qt6 || \
-  make pkglibexecdir=${MINGW_PREFIX}/bin LRELEASE=${MINGW_PREFIX}/bin/lrelease-qt6 -j1
+  make LRELEASE=${MINGW_PREFIX}/bin/lrelease-qt6
 }
 
 package() {
-  cd "${srcdir}"/build-${MSYSTEM}
-  make install pkglibexecdir=${MINGW_PREFIX}/bin DESTDIR="${pkgdir}"
+  cd build-${MSYSTEM}
+  make DESTDIR="${pkgdir}" install
   
   install -Dm644 "${srcdir}"/${_realname}-${pkgver}/Copyright \
     "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE


### PR DESCRIPTION
Fixes #24580 and (maybe) #24581

- rebase patches
- fix path translation
- fix parallel build

```
gnuplot> show version long

        G N U P L O T
        Version 6.0 patchlevel 3    last modified 2025-06-07

        Copyright (C) 1986-1993, 1998, 2004, 2007-2025
        Thomas Williams, Colin Kelley and many others

        gnuplot home:     http://www.gnuplot.info
        faq, bugs, etc:   type "help FAQ"
        immediate help:   type "help"  (plot window: hit 'h')

Compile options:
    +READLINE  -LIBREADLINE  +HISTORY
    +UNICODE  +OBJECTS  +STATS  +WATCHPOINTS  +POLARGRID
    +COMPLEX_FUNCS  +LIBCERF
    +GD_PNG  +GD_JPEG  +GD_TTF  +GD_GIF  +ANIMATION
    -USE_CWDRC  +USE_MOUSE  +HIDDEN3D_QUADTREE
    +FUNCTIONBLOCKS +CHI_SHAPES
    64-bit integer arithmetic
    sizeof(struct coordinate) = 64 with extra coordinate
GNUPLOT_DRIVER_DIR = "C:/MSYS64/ucrt64/bin"
GNUPLOT_PS_DIR     = "C:/MSYS64/ucrt64/share/gnuplot/6.0/PostScript"
HELPFILE           = "C:/MSYS64/ucrt64/share/gnuplot/6.0/gnuplot.gih"
libcaca version    : 0.99.beta20
```

```
gnuplot> help
 `join(array, "sep")` concatenates the string elements of an array into a
 single string containing fields delimited by the character sequence in "sep".
 Non-string array elements generate an empty field.
 For examples, see `counting_words`.


Help topics available:
                      csv               iteration         rectangle
    2D                dashtype          join              reset
    3D                data-file         key               rgbcolor
    ?                 datafile          label             sampling
    PM3D              datastrings       layers            scope
    animation         demos             lighting          set
    argv              deprecated        line-editing      show
    arrays            ellipse           linecolor         special-filenames
    arrowstyle        elliptic          linestyles        split
    automated         enhanced          linetypes         startup
    autoscale         environment       local             stats
    background        epoch             mixing_macros_backquotes string
    batch/interactive escape            mouse             style
    beeswarm          expressions       multiple          substitution
    binary            fenceplots        new               surface
    call              fillcolor         newhistogram      syntax
Press return for more:
```