### PR TITLE
[gtk4] Enable accesskit during build phase

### DIFF
--- a/mingw-w64-gtk4/PKGBUILD
+++ b/mingw-w64-gtk4/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-media-gstreamer")
 pkgver=4.18.6
-pkgrel=1
+pkgrel=2
 pkgdesc="GObject-based multi-platform GUI toolkit (v4) (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -37,7 +37,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
          "${MINGW_PACKAGE_PREFIX}-pango"
          "${MINGW_PACKAGE_PREFIX}-vulkan-loader"
          "${MINGW_PACKAGE_PREFIX}-gtk-update-icon-cache"
-         "${MINGW_PACKAGE_PREFIX}-shared-mime-info")
+         "${MINGW_PACKAGE_PREFIX}-shared-mime-info"
+         "${MINGW_PACKAGE_PREFIX}-accesskit-c")
 source=("https://download.gnome.org/sources/gtk/${pkgver:0:4}/gtk-${pkgver}.tar.xz"
         "001-fix-font-rendering.patch")
 sha256sums=('e1817c650ddc3261f9a8345b3b22a26a5d80af154630dedc03cc7becefffd0fa'
@@ -77,6 +78,7 @@ build() {
     -Dwayland-backend=false \
     -Dwin32-backend=true \
     -Dintrospection=enabled \
+    -Daccesskit=enabled \
     ../gtk-${pkgver}
 
   ${MINGW_PREFIX}/bin/meson.exe compile


### PR DESCRIPTION
## Goal

Since GTK `4.18`, AccessKit a11y backend is available ([blog post about it](https://blog.gtk.org/2025/05/12/an-accessibility-update/)).

This PR enable `accesskit` during build of GTK4 so GTK4 applications can now have accessibility in Windows.

## Information

- Add `accesskit-c` as dependency
- Enable `accesskit` during build phase

Also, this was tested to make accessibility works for Gajim under Windows and is also documented here:
https://dev.gajim.org/gajim/gajim/-/issues/11147#note_218968