### PR TITLE
python-fastapi: update to 0.116.0

### DIFF
--- a/mingw-w64-python-fastapi/PKGBUILD
+++ b/mingw-w64-python-fastapi/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=fastapi
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=0.115.12
+pkgver=0.116.0
 pkgrel=1
 pkgdesc='FastAPI framework, high performance, easy to learn, fast to code, ready for production (mingw-w64)'
 arch=('any')
@@ -29,8 +29,8 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-python-email-validator: for email validatio
             "${MINGW_PACKAGE_PREFIX}-python-websockets: for WebSockets support"
             "${MINGW_PACKAGE_PREFIX}-uvicorn: for Uvicorn as ASGI server")
 options=('!strip')
-source=("${url}/archive/${pkgver}${_realname}-$pkgver.tar.gz")
-sha256sums=('a333ccfd85b9abdcc94fd278fcd397c85c4007f881810fbc0fc713a04c5f2004')
+source=("${url}/archive/${pkgver}/${_realname}-$pkgver.tar.gz")
+sha256sums=('453dcb5dd67053f1b75c805cdc25790ea75593eb3e460d3ef5044133c02d90c5')
 
 prepare() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"


### PR DESCRIPTION
Also fixed source path [mistake](https://github.com/msys2/MINGW-packages/commit/b8a461af4018a2677b54504407181aa783c2f125#diff-9a99a970fcf016d2e6b89bd20b6e778e56755b974f1973c5558fd1a8b7a6b805R32).