### PR TITLE
GCC: use msys tzdata at runtime

### DIFF
--- a/mingw-w64-gcc/0001-libstdc-Search-for-tzdata-on-Windows-msys.patch
+++ b/mingw-w64-gcc/0001-libstdc-Search-for-tzdata-on-Windows-msys.patch
@@ -1,0 +1,78 @@
+From 6b50be573c35011012140e7e191c235719495cab Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bj=C3=B6rn=20Sch=C3=A4pers?= <bjoern@hazardy.de>
+Date: Mon, 7 Jul 2025 13:10:49 +0200
+Subject: [PATCH] libstdc++: Search for tzdata on Windows (msys)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Windows does not provide a tzdata.zi, but msys does. Use this, if
+available, instead of the embedded (and possibly outdated) database.
+
+libstdc++-v3/Changelog:
+
+	Use msys provided time zone information.
+
+	* src/c++20/tzdb.cc (zoneinfo_file): On Windows look relative
+	from the DLL path for the time zone information.
+
+Signed-off-by: Björn Schäpers <bjoern@hazardy.de>
+---
+ libstdc++-v3/src/c++20/tzdb.cc | 34 ++++++++++++++++++++++++++++++++++
+ 1 file changed, 34 insertions(+)
+
+diff --git a/libstdc++-v3/src/c++20/tzdb.cc b/libstdc++-v3/src/c++20/tzdb.cc
+index 6e244dc656d..9923d14b7a7 100644
+--- a/libstdc++-v3/src/c++20/tzdb.cc
++++ b/libstdc++-v3/src/c++20/tzdb.cc
+@@ -44,6 +44,12 @@
+ # include <cstdlib>   // getenv
+ #endif
+ 
++#if _GLIBCXX_HAVE_WINDOWS_H
++# define WIN32_LEAN_AND_MEAN
++# include <windows.h>
++# include <psapi.h>
++#endif
++
+ #if defined __GTHREADS && ATOMIC_POINTER_LOCK_FREE == 2
+ # define USE_ATOMIC_LIST_HEAD 1
+ // TODO benchmark atomic<shared_ptr<>> vs mutex.
+@@ -1144,6 +1150,34 @@ namespace std::chrono
+ #ifdef _GLIBCXX_ZONEINFO_DIR
+       else
+ 	path = _GLIBCXX_ZONEINFO_DIR;
++#endif
++#ifdef _GLIBCXX_HAVE_WINDOWS_H
++      if (path.empty())
++	{
++	  HMODULE dll_module;
++	  if (GetModuleHandleExA(
++		  GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS
++		      | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
++		  reinterpret_cast<const char *>(&zoneinfo_file), &dll_module))
++	    {
++	      char dll_path[MAX_PATH];
++	      if (GetModuleFileNameA(dll_module, dll_path, MAX_PATH) != 0)
++		{
++		  string_view dll_path_view = dll_path;
++		  auto pos = dll_path_view.find_last_of('\\');
++		  dll_path_view = dll_path_view.substr(0, pos);
++		  if (dll_path_view.ends_with("\\bin"))
++		    {
++		      constexpr string_view remaining_path = "share\\zoneinfo";
++		      dll_path_view.remove_suffix(3); // Remove bin
++		      path.reserve(dll_path_view.size()
++				   + remaining_path.size());
++		      path = dll_path_view;
++		      path += remaining_path;
++		    }
++		}
++	    }
++	}
+ #endif
+       if (!path.empty())
+ 	path.append(filename);
+-- 
+2.50.0
+

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -51,7 +51,7 @@ else
   _sourcedir=${_realname}-${_version}-${_snapshot}
   _url=https://gcc.gnu.org/pub/gcc/snapshots/${_version}-${_snapshot}
 fi
-pkgrel=6
+pkgrel=7
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -95,6 +95,7 @@ source=(${_url}/${_sourcedir}.tar.xz{,.sig}
         2001-fix-building-rust-on-mingw-w64.patch
         3001-fix-codeview-crashes.patch
         9002-native-tls.patch
+        0001-libstdc-Search-for-tzdata-on-Windows-msys.patch
         cf588f1a8e7406ced5b08f32f9d23f015a240a31.patch::https://gcc.gnu.org/cgit/gcc/patch/?id=cf588f1a8e7406ced5b08f32f9d23f015a240a31)
 sha256sums=('e2b09ec21660f01fecffb715e0120265216943f038d0e48a9868713e54f06cea'
             'SKIP'
@@ -113,6 +114,7 @@ sha256sums=('e2b09ec21660f01fecffb715e0120265216943f038d0e48a9868713e54f06cea'
             'a411f59953553a3d01dd64c79b1acbb91eca092c4cb01bfd26b1c51c3eb798e8'
             'f21f9ab731e9cab8fd4ca8c289497f859ef7004e6fa0507877dc2559ac2071c3'
             'd977683efc6f6b4dd675a8f1978416d22d5b5d1fa53614b9a18bc18efa231391'
+            '29392b22067ee63c06f111f3bc40a0ab6872970555527f452b4f579cced0f552'
             'fca7f20abc77eebcf91a18acc5bcc6b5e092822a5def80bac9eeec8d020276b2')
 validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.org
               86CFFCA918CF3AF47147588051E8B148A9999C34  # evangelos@foutrelis.com
@@ -177,6 +179,10 @@ prepare() {
   # https://github.com/msys2/MINGW-packages/issues/24209
   apply_patch_with_msg \
     cf588f1a8e7406ced5b08f32f9d23f015a240a31.patch
+
+  # Use MSYS zoneinfo
+  apply_patch_with_msg \
+    0001-libstdc-Search-for-tzdata-on-Windows-msys.patch
 
   # apply_patch_with_msg \
   #   9002-native-tls.patch
@@ -288,6 +294,7 @@ build() {
     --with-bugurl="https://github.com/msys2/MINGW-packages/issues" \
     --with-gnu-as \
     --with-gnu-ld \
+    --with-libstdcxx-zoneinfo="yes" \
     "${_extra_config[@]}"
 
   # While we're debugging -fopenmp problems at least.
@@ -304,7 +311,7 @@ build() {
 
 package_gcc-libs() {
   pkgdesc="GNU Compiler Collection (libraries) for MinGW-w64"
-  depends=("${MINGW_PACKAGE_PREFIX}-libwinpthread")
+  depends=("${MINGW_PACKAGE_PREFIX}-libwinpthread" "${MINGW_PACKAGE_PREFIX}-tzdata")
   provides=("${MINGW_PACKAGE_PREFIX}-omp" "${MINGW_PACKAGE_PREFIX}-cc-libs")
 
   # Licensing information


### PR DESCRIPTION
Instead of the hard compiled version shipped with gcc.