### PR TITLE
podman-compose: update to 1.5.0

### DIFF
--- a/mingw-w64-podman-compose/PKGBUILD
+++ b/mingw-w64-podman-compose/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=podman-compose
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.3.0
+pkgver=1.5.0
 pkgrel=1
 pkgdesc="Get and set values in your .env file in local and production servers (mingw-w64)"
 arch=('any')
@@ -25,7 +25,7 @@ makedepends=(
 )
 options=("!strip")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('e65a70e8fa26bd195d2017ac5893149b40c0df5a0c20d480a338c4f60218b1fa')
+sha256sums=('5cc09362852711ce5d27648e41cb5fd058ea5a75acbcdec2f8d0b0c114a18e8e')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"


### PR DESCRIPTION
Update podman-compose to version 1.5.0.

_(Also see #24762, the update for podman 5.5.2. Both updates should work independently from each other, but it's probably a good idea to handle them in the same run.)_