### PR TITLE
python-rencode: update to 1.0.8

### DIFF
--- a/mingw-w64-python-rencode/0001-Remove-extra-compile-args.patch
+++ b/mingw-w64-python-rencode/0001-Remove-extra-compile-args.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Jan Alexander Steffens (heftig)" <heftig@archlinux.org>
+Date: Fri, 20 Jun 2025 18:48:26 +0200
+Subject: [PATCH] Remove extra compile args
+
+These are hazardous and cause unintended incompatibilities,
+`-march=native` especially so, as it's dependent on the build machine.
+
+Fixes: https://github.com/aresch/rencode/issues/38
+---
+ build.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/build.py b/build.py
+index 658ada290a7a..0d170a3f7c15 100644
+--- a/build.py
++++ b/build.py
+@@ -11,7 +11,7 @@ from setuptools import Extension
+ from setuptools.command.build_ext import build_ext
+ 
+ 
+-COMPILE_ARGS = ["-march=native", "-O3", "-msse", "-msse2", "-mfma", "-mfpmath=sse"]
++COMPILE_ARGS: list[str] = []
+ LINK_ARGS: list[str] = []
+ INCLUDE_DIRS: list[str] = []
+ LIBRARIES: list[str] = []

--- a/mingw-w64-python-rencode/PKGBUILD
+++ b/mingw-w64-python-rencode/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=rencode
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=1.0.6
-pkgrel=8
+pkgver=1.0.8
+pkgrel=1
 pkgdesc="Python module for fast (basic) object serialization similar to bencode (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -17,30 +17,45 @@ license=('spdx:GPL-3.0-or-later')
 depends=("${MINGW_PACKAGE_PREFIX}-python")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-poetry-core"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-cython0"
              "${MINGW_PACKAGE_PREFIX}-cc")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
 options=(!strip)
 source=("https://github.com/aresch/rencode/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
+        0001-Remove-extra-compile-args.patch
         python-rencode-typecode-dos.patch)
-sha256sums=('0ed61111f053ea37511da86ca7aed2a3cfda6bdaa1f54a237c4b86eea52f0733'
+sha256sums=('480aab74948a7f339b749b5c39bdb4caf15429f4b49a998c770d5f371098d351'
+            'cb70f0a73164b4e676aee990c0cfb2fe8789b07569aaa161a469ccf828986a0c'
             '72046868ae82f7c9576fb9160bcf686cc893b5f104ee8b126c36466d06f21eb7')
 
 prepare() {
   cd "${srcdir}"
   rm -rf python-build-${MSYSTEM} | true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
+
+  cd "python-build-${MSYSTEM}"
+
+  # https://github.com/aresch/rencode/issues/38
+  patch -p1 -i "${srcdir}/0001-Remove-extra-compile-args.patch"
+
+  # build.py seems to be a special name, and it prevents building of a wheel
+  mv build.py cython_build.py
+  sed -i 's/build.py/cython_build.py/' pyproject.toml
 }
 
 build() {
   cd "${srcdir}/python-build-${MSYSTEM}"
+  ${MINGW_PREFIX}/bin/python cython_build.py
   ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 check() {
   cd "${srcdir}/python-build-${MSYSTEM}"
-  ${MINGW_PREFIX}/bin/python -m pytest
+  ${MINGW_PREFIX}/bin/python -m venv --system-site-packages testenv
+  testenv/bin/python -m installer dist/*.whl
+  testenv/bin/python -m pytest
 }
 
 package() {


### PR DESCRIPTION
Update python-rencode to 1.0.8.

Depends on python-pytest for checks, even in 1.0.6.