### PR TITLE
python-rencode: depends on python-pytest for checks

### DIFF
--- a/mingw-w64-python-rencode/PKGBUILD
+++ b/mingw-w64-python-rencode/PKGBUILD
@@ -4,7 +4,7 @@ _realname=rencode
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=1.0.6
-pkgrel=7
+pkgrel=8
 pkgdesc="Python module for fast (basic) object serialization similar to bencode (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -20,6 +20,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-cython0"
              "${MINGW_PACKAGE_PREFIX}-cc")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
 options=(!strip)
 source=("https://github.com/aresch/rencode/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
         python-rencode-typecode-dos.patch)


### PR DESCRIPTION
python-rencode pepends on python-pytest for checks, so it should be listed in PKGBUILD.
The `check()` step calls pytest and therefore fails, if there is no pytest module.