### PR TITLE
qgis: update to 3.44.0

### DIFF
--- a/mingw-w64-qgis/PKGBUILD
+++ b/mingw-w64-qgis/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=qgis
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.42.0
-pkgrel=2
+pkgver=3.44.0
+pkgrel=1
 pkgdesc='Geographic Information System (GIS) that supports vector, raster & database formats (mingw-w64)'
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -24,25 +24,25 @@ depends=("${MINGW_PACKAGE_PREFIX}-draco"
          "${MINGW_PACKAGE_PREFIX}-libxml2"
          "${MINGW_PACKAGE_PREFIX}-libzip"
          "${MINGW_PACKAGE_PREFIX}-opencl-icd"
-         "${MINGW_PACKAGE_PREFIX}-pdal"
+         #"${MINGW_PACKAGE_PREFIX}-pdal"
          "${MINGW_PACKAGE_PREFIX}-proj"
          "${MINGW_PACKAGE_PREFIX}-protobuf"
          "${MINGW_PACKAGE_PREFIX}-python-gdal"
          "${MINGW_PACKAGE_PREFIX}-python-owslib"
-         "${MINGW_PACKAGE_PREFIX}-python-pyqt6"
-         "${MINGW_PACKAGE_PREFIX}-python-qscintilla-qt6"
-         "${MINGW_PACKAGE_PREFIX}-qca-qt6"
-         "${MINGW_PACKAGE_PREFIX}-qt6-3d"
-         "${MINGW_PACKAGE_PREFIX}-qt6-base"
-         "${MINGW_PACKAGE_PREFIX}-qt6-declarative"
-         "${MINGW_PACKAGE_PREFIX}-qt6-location"
-         "${MINGW_PACKAGE_PREFIX}-qt6-multimedia"
-         "${MINGW_PACKAGE_PREFIX}-qt6-serialport"
-         "${MINGW_PACKAGE_PREFIX}-qt6-svg"
-         "${MINGW_PACKAGE_PREFIX}-qt6-tools"
-         "${MINGW_PACKAGE_PREFIX}-qtkeychain-qt6"
-         "${MINGW_PACKAGE_PREFIX}-qscintilla-qt6"
-         "${MINGW_PACKAGE_PREFIX}-qwt-qt6"
+         "${MINGW_PACKAGE_PREFIX}-python-pyqt5"
+         "${MINGW_PACKAGE_PREFIX}-python-qscintilla-qt5"
+         "${MINGW_PACKAGE_PREFIX}-qca-qt5"
+         "${MINGW_PACKAGE_PREFIX}-qt5-3d"
+         "${MINGW_PACKAGE_PREFIX}-qt5-base"
+         "${MINGW_PACKAGE_PREFIX}-qt5-declarative"
+         "${MINGW_PACKAGE_PREFIX}-qt5-location"
+         "${MINGW_PACKAGE_PREFIX}-qt5-multimedia"
+         "${MINGW_PACKAGE_PREFIX}-qt5-serialport"
+         "${MINGW_PACKAGE_PREFIX}-qt5-svg"
+         "${MINGW_PACKAGE_PREFIX}-qt5-tools"
+         "${MINGW_PACKAGE_PREFIX}-qtkeychain-qt5"
+         "${MINGW_PACKAGE_PREFIX}-qscintilla-qt5"
+         "${MINGW_PACKAGE_PREFIX}-qwt-qt5"
          "${MINGW_PACKAGE_PREFIX}-sqlite3"
          "${MINGW_PACKAGE_PREFIX}-spatialindex"
          "${MINGW_PACKAGE_PREFIX}-zlib"
@@ -63,7 +63,7 @@ source=("https://qgis.org/downloads/${_realname}-$pkgver.tar.bz2"
         "001-fix-building-with-mingw-w64-clang.patch"
         "002-fix-settingstree-init-order-clang.patch"
         "004-fix-customwidgets-install.patch")
-sha256sums=('04b743397ee2375a1a0521578131fc514752f84db2f86225a9551d1f87e704e8'
+sha256sums=('81e5088060f38ab4e9835b05e5eec1ba7cc2eb903105830808b60215ae2cd320'
             '82d8839992f08a26ea7caf5e908e5f4111806df211ae5cec91e2b86e49b43e75'
             '47e6471b92b85d97e58b617da326c15622c01786c19eb7d4d5814483becb75e4'
             '216dc67ef707f2e918afb7d190c9ea75c11065dea0d23d11b94cab5d8463bac3')
@@ -105,6 +105,7 @@ build() {
   fi
   CXXFLAGS+=" -Wno-deprecated-declarations"
 
+  LDFLAGS+=" -Wl,--stack,8388608" \
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake -Wno-dev \
     -G"Ninja" \
@@ -116,23 +117,23 @@ build() {
     -DQGIS_DATA_SUBDIR=share \
     -DQGIS_LIBEXEC_SUBDIR=bin \
     -DQGIS_PLUGIN_SUBDIR=lib/qgis/plugins \
-    -DQT_PLUGINS_DIR=share/qt6/plugins \
+    -DQT_PLUGINS_DIR=share/qt5/plugins \
     -DPREFER_INTERNAL_LIBS=OFF \
     -DWITH_INTERNAL_POLY2TRI=ON \
     -DWITH_INTERNAL_MESHOPTIMIZER=ON \
     -DWITH_INTERNAL_NLOHMANN_JSON=OFF \
-    -DBUILD_WITH_QT6=ON \
     -DWITH_3D=ON \
     -DWITH_BINDINGS=ON \
     -DWITH_CUSTOM_WIDGETS=ON \
     -DWITH_EPT=ON \
-    -DWITH_PDAL=ON \
+    -DWITH_PDAL=OFF \
     -DWITH_POSTGRESQL=ON \
     -DWITH_QTWEBKIT=OFF \
     -DWITH_QUICK=ON \
     -DWITH_QWTPOLAR=ON \
     -DENABLE_TESTS=OFF \
     -DWITH_GRASS=OFF \
+    -DPEDANTIC=OFF \
     ../${_realname}-$pkgver
 
   ${MINGW_PREFIX}/bin/cmake --build .


### PR DESCRIPTION
Revert to Qt5 to make it build on UCRT64 as the compiler crashes unexpectedly with no error message.
the app now launches but only UCRT64.