### PR TITLE
zed: update to 0.194.3

### DIFF
--- a/mingw-w64-zed/.gitignore
+++ b/mingw-w64-zed/.gitignore
@@ -1,1 +1,2 @@
 /zed
+/0ca0914ccae465e951591f2958d7d5eea67410fe.patch

--- a/mingw-w64-zed/PKGBUILD
+++ b/mingw-w64-zed/PKGBUILD
@@ -4,7 +4,7 @@ _realname=zed
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
-pkgver=0.193.3
+pkgver=0.194.3
 pkgrel=1
 pkgdesc="A high-performance, multiplayer code editor (mingw-w64)"
 arch=('any')
@@ -38,18 +38,23 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-clang-tools-extra: for a better C/C++ langu
             "${MINGW_PACKAGE_PREFIX}-ollama: provides LLMs for assistance panel"
             "${MINGW_PACKAGE_PREFIX}-pyright: for a better Python language support"
             "${MINGW_PACKAGE_PREFIX}-rust-analyzer: for a better Rust language support"
-            'git: for a better Git integration')
+            'git: for a better Git integration'
+            'openssh: for a SSH remote')
 source=("git+${msys2_repository_url}.git#tag=v${pkgver}"
         "zstd-sys.tar.gz::https://crates.io/api/v1/crates/zstd-sys/2.0.15+zstd.1.5.7/download"
-        "zstd-sys-remove-statik.patch")
-sha256sums=('6abf8af6127e16919a455f01d134f8cfd48d3d3435aeedeed40d31ab28794a09'
+        "zstd-sys-remove-statik.patch"
+        "https://github.com/zed-industries/zed/commit/0ca0914ccae465e951591f2958d7d5eea67410fe.patch")
+sha256sums=('a8ac741ef0640506c8fccf9b0df20b422251be2a884a91e9cb6029c372c1e8d3'
             'eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237'
-            '48f4900ceb02d3aaf9a1020f33d56629156e96759f456c0e7ca18bfcf910767b')
+            '48f4900ceb02d3aaf9a1020f33d56629156e96759f456c0e7ca18bfcf910767b'
+            '50a3dfe00b9863bbfd0c99215b4f5a1ee76aec7f3f1c4556e0668b45d0e85847')
 
 prepare() {
   cd "${_realname}"
   rm rust-toolchain.toml
 
+  # backport SSH support
+  patch -Np1 -i ../0ca0914ccae465e951591f2958d7d5eea67410fe.patch
   # link system deps dynamically
   patch -d "../zstd-sys-2.0.15+zstd.1.5.7" -i "../zstd-sys-remove-statik.patch"
   # use patched *-sys crates


### PR DESCRIPTION
backport SSH support for Windows. note that it's still far to be perfect

cc @podsvirov 

fixes #23954