### PR TITLE
sfcgal: fix .pc file missing libdir

### DIFF
--- a/mingw-w64-sfcgal/0001-fix-pc-missing-libdir.patch
+++ b/mingw-w64-sfcgal/0001-fix-pc-missing-libdir.patch
@@ -1,0 +1,28 @@
+From 225ad79eb9c37ed658b505d2f6afb8a65d59de65 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Lo=C3=AFc=20Bartoletti?= <loic.bartoletti@oslandia.com>
+Date: Tue, 3 Jun 2025 10:01:04 +0200
+Subject: [PATCH 1/4] fix(CMake): Define CMAKE_INSTALL_FULL_LIBDIR if not
+ defined before
+
+Fix issue for MSYS2/MinGW
+---
+ CMakeLists.txt | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ff22a016..14fc262b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -225,6 +225,10 @@ if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
+   set(CMAKE_INSTALL_LIBDIR "${_LIBDIR_DEFAULT}" CACHE PATH "object code libraries (${_LIBDIR_DEFAULT})")
+ endif()
+ 
++if(NOT DEFINED CMAKE_INSTALL_FULL_LIBDIR)
++    set(CMAKE_INSTALL_FULL_LIBDIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
++endif()
++
+ SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}")
+ SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+ #SET(CMAKE_MACOSX_RPATH ON)
+-- 
+GitLab

--- a/mingw-w64-sfcgal/PKGBUILD
+++ b/mingw-w64-sfcgal/PKGBUILD
@@ -4,7 +4,7 @@ _realname=sfcgal
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Wrapper around CGAL that intents to implement 2D and 3D operations on OGC standards models (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -21,8 +21,17 @@ depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
          "${MINGW_PACKAGE_PREFIX}-gmp"
          "${MINGW_PACKAGE_PREFIX}-mpfr"
          "${MINGW_PACKAGE_PREFIX}-cgal")
-source=(https://gitlab.com/SFCGAL/SFCGAL/-/archive/v${pkgver}/SFCGAL-v${pkgver}.tar.gz)
-sha256sums=('cb73a0496c61a5c7bf0ccc68c42e4378bfc441b242e9dee894067e24d2e21d0f')
+source=(https://gitlab.com/SFCGAL/SFCGAL/-/archive/v${pkgver}/SFCGAL-v${pkgver}.tar.gz
+        0001-fix-pc-missing-libdir.patch)
+sha256sums=('cb73a0496c61a5c7bf0ccc68c42e4378bfc441b242e9dee894067e24d2e21d0f'
+            '9170fa039e7f2afc7ab5b42631cc916ddec407dc0c0aa7b3d7d1759f6d0f4a71')
+
+prepare() {
+  cd "SFCGAL-v${pkgver}"
+
+  # https://gitlab.com/sfcgal/SFCGAL/-/merge_requests/515
+  patch -p1 -i "${srcdir}"/0001-fix-pc-missing-libdir.patch
+}
 
 build() {
   mkdir "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}


### PR DESCRIPTION
In case of libtool this leads to:

libtool:   error: require no space between '-L' and '-lSFCGAL'