### PR TITLE
python-asgiref: update to 3.9.1

### DIFF
--- a/mingw-w64-python-asgiref/PKGBUILD
+++ b/mingw-w64-python-asgiref/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=asgiref
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=3.9.0
+pkgver=3.9.1
 pkgrel=1
 pkgdesc="Reference ASGI adapters and channel layers (mingw-w64)"
 arch=('any')
@@ -21,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest-asyncio"
               "${MINGW_PACKAGE_PREFIX}-python-pytest")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('3dd2556d0f08c4fab8a010d9ab05ef8c34565f6bf32381d17505f7ca5b273767')
+sha256sums=('a5ab6582236218e5ef1648f242fd9f10626cfd4de8dc377db215d5d5098e3142')
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"


### PR DESCRIPTION
Update python-asgiref to 3.9.1.