### PR TITLE
python-archinfo: update to 9.2.164

### DIFF
--- a/mingw-w64-python-archinfo/PKGBUILD
+++ b/mingw-w64-python-archinfo/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=archinfo
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=9.2.157
+pkgver=9.2.164
 pkgrel=1
 pkgdesc="Classes with architecture-specific information useful to other projects (mingw-w64)"
 arch=('any')
@@ -27,7 +27,7 @@ optdepends=(
   "${MINGW_PACKAGE_PREFIX}-python-pyvex"
 )
 source=("${url}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha512sums=('840843eb82e77208e3b55c2e3f59d99616e7f28b93a3f1eaefd5762ffbd29e6eacea6e6f651584d8246428cef8bec0997a65ecbf18bfe96cdf4b11133f548ee0')
+sha512sums=('c9ff2f2c1bce4d909246715e11f9632aa1cda72dedebc948b8d6db7a80161b621fc7f70054d3d7dbe97c8999fedaa097da961d468f95b9915f78ecca9f4e886e')
 
 
 build() {


### PR DESCRIPTION
Update python-archinfo to 9.2.164.