### PR TITLE
live-media: update to 2022.12.01

### DIFF
--- a/mingw-w64-live-media/PKGBUILD
+++ b/mingw-w64-live-media/PKGBUILD
@@ -6,8 +6,8 @@
 _realname=live-media
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2022.04.26
-pkgrel=2
+pkgver=2022.12.01
+pkgrel=1
 pkgdesc="A set of C++ libraries for multimedia streaming (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -27,7 +27,7 @@ source=("https://download.videolan.org/contrib/live555/live.${pkgver}.tar.gz"
         0004-live555-formatmessage.patch
         0005-Fix-testProgs-static-lib-link-order.patch
         0006-mingw-NO_GETIFADDRS.patch)
-sha256sums=('24fd24d53da1ac8f8282173039e99c9952186c18404b1fc3b1d4c0e9f49414e7'
+sha256sums=('057c1d3dc24c26b33e14c4dc3592885adf220403a1e1255e8a101e233c69c108'
             '8611cb5eb31571d4026a66d47a98f2a08abf3b6c3ac373ee0c28638a3bf3c4dc'
             'ae6303f91d09ebc89ff622db9b622567fb98728630b1639786d62dcb1cea9dce'
             '6111b8119b80eca6a2fdd1c116f2e3509d62098d3c36944bd1bf83bb03342c87'


### PR DESCRIPTION
Update live-media to 2022.12.01.

There are newer versions of live-media, but this one builds without having to got through patches or adjusting the build logic. I figured having a small update, although not to the newest version, is still better than no update at all. However, I am not sure whether this is acceptable for you. If you feel differently, then you are free to reject this pull request.