### PR TITLE
sccache: build dist-server binary

### DIFF
--- a/mingw-w64-sccache/PKGBUILD
+++ b/mingw-w64-sccache/PKGBUILD
@@ -4,7 +4,7 @@ _realname=sccache
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.10.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Shared compilation cache (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -51,14 +51,14 @@ build() {
   cd "${_realname}-${pkgver}"
 
   _env
-  cargo build --release --frozen
+  cargo build --release --frozen --features all,dist-server
 }
 
 check() {
   cd "${_realname}-${pkgver}"
 
   _env
-  cargo test --release --frozen
+  cargo test --release --frozen --features all,dist-server
 }
 
 package() {
@@ -70,7 +70,8 @@ package() {
     --offline \
     --no-track \
     --path . \
-    --root "${pkgdir}${MINGW_PREFIX}"
+    --root "${pkgdir}${MINGW_PREFIX}" \
+    --features all,dist-server
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
I don't know whether this fixes clang issue (very likely not), but I've looked into Arch recipe and found this. so why not