### PR TITLE
python-aiosignal: Update to 1.4.0

### DIFF
--- a/mingw-w64-python-aiosignal/PKGBUILD
+++ b/mingw-w64-python-aiosignal/PKGBUILD
@@ -14,7 +14,8 @@ msys2_references=(
 url='https://github.com/aio-libs/aiosignal'
 license=('spdx:Apache-2.0')
 depends=("${MINGW_PACKAGE_PREFIX}-python"
-         "${MINGW_PACKAGE_PREFIX}-python-frozenlist")
+         "${MINGW_PACKAGE_PREFIX}-python-frozenlist"
+         "${MINGW_PACKAGE_PREFIX}-python-typing_extensions")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")

--- a/mingw-w64-python-aiosignal/PKGBUILD
+++ b/mingw-w64-python-aiosignal/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=aiosignal
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=1.3.2
+pkgver=1.4.0
 pkgrel=1
 pkgdesc="A list of registered asynchronous callbacks (mingw-w64)"
 arch=('any')
@@ -20,7 +20,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('a8c255c66fafb1e499c9351d0bf32ff2d8a0321595ebac3b93713656d2436f54')
+sha256sums=('f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7')
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"


### PR DESCRIPTION
Required for https://github.com/msys2/MINGW-packages/pull/24787 to pass.