### PR TITLE
libogg: Update to 1.3.6 + cleanups

### DIFF
--- a/mingw-w64-libogg/PKGBUILD
+++ b/mingw-w64-libogg/PKGBUILD
@@ -3,19 +3,21 @@
 _realname=libogg
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.3.5
+pkgver=1.3.6
 pkgrel=1
 pkgdesc="Ogg bitstream and framing library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://xiph.org/"
-license=('BSD')
+msys2_repository_url="https://github.com/xiph/ogg"
+license=('spdx:BSD-3-Clause')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cc")
 source=("https://downloads.xiph.org/releases/ogg/${_realname}-${pkgver}.tar.gz"
         "libogg-1.3.4-versioned-dll-cmake.patch")
-sha256sums=('0eb4b4b9420a0f51db142ba3f9c64b333f826532dc0f48c6410ae51f4799b664'
-            '7f635d4ca41c75dc52206749b6346c174c6a028de09604c6d66929bcdabf6c33')
+sha256sums=('83e6704730683d004d20e21b8f7f55dcb3383cdf84c0daedf30bde175f774638'
+            '18772896694597eb60ab3f9fb6bc7629759d51a7fa0c1645da1f8d7ba11c1bf8')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
@@ -34,39 +36,38 @@ build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}-static" && cd "${srcdir}/build-${MSYSTEM}-static"
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-    ${MINGW_PREFIX}/bin/cmake \
-      -G'MSYS Makefiles' \
-      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    cmake \
+      -GNinja \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       "${extra_config[@]}" \
       -DBUILD_SHARED_LIBS=OFF \
       -DBUILD_TESTING=OFF \
-      ../${_realname}-${pkgver}
+      "../${_realname}-${pkgver}"
 
-  make
+  cmake --build .
 
   # Shared
   mkdir -p "${srcdir}/build-${MSYSTEM}-shared" && cd "${srcdir}/build-${MSYSTEM}-shared"
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-    ${MINGW_PREFIX}/bin/cmake \
-      -G'MSYS Makefiles' \
-      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    cmake \
+      -GNinja \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      -DCMAKE_DLL_NAME_WITH_SOVERSION=ON \
       "${extra_config[@]}" \
       -DBUILD_SHARED_LIBS=ON \
       -DBUILD_TESTING=OFF \
-      ../${_realname}-${pkgver}
+      "../${_realname}-${pkgver}"
 
-  make
+  cmake --build .
 }
 
 package() {
   # Static
-  cd "${srcdir}/build-${MSYSTEM}-static"
-  make DESTDIR="${pkgdir}" install
+  DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}-static"
 
   # Shared
-  cd "${srcdir}/build-${MSYSTEM}-shared"
-  make DESTDIR="${pkgdir}" install
+  DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}-shared"
 
   # m4
   install -Dm644 "${srcdir}"/${_realname}-${pkgver}/ogg.m4 "${pkgdir}"${MINGW_PREFIX}/share/aclocal/ogg.m4

--- a/mingw-w64-libogg/libogg-1.3.4-versioned-dll-cmake.patch
+++ b/mingw-w64-libogg/libogg-1.3.4-versioned-dll-cmake.patch
@@ -1,21 +1,3 @@
-diff -Naur libogg-1.3.4.orig/CMakeLists.txt libogg-1.3.4/CMakeLists.txt
---- libogg-1.3.4.orig/CMakeLists.txt	2019-09-02 15:05:06.093041600 -0400
-+++ libogg-1.3.4/CMakeLists.txt	2019-09-02 15:08:44.811923200 -0400
-@@ -103,6 +103,14 @@
-     VERSION ${LIB_VERSION}
-     PUBLIC_HEADER "${OGG_HEADERS}"
- )
-+if(WIN32)
-+    set_target_properties(ogg
-+        PROPERTIES
-+        OUTPUT_NAME ogg
-+        RUNTIME_OUTPUT_NAME ogg-${LIB_SOVERSION}
-+        ARCHIVE_OUTPUT_NAME ogg
-+    )
-+endif()
- 
- if(BUILD_FRAMEWORK)
-     set_target_properties(ogg PROPERTIES
 diff -Naur libogg-1.3.4.orig/win32/ogg.def libogg-1.3.4/win32/ogg.def
 --- libogg-1.3.4.orig/win32/ogg.def	2019-09-02 15:05:06.093041600 -0400
 +++ libogg-1.3.4/win32/ogg.def	2019-09-02 15:08:44.811923200 -0400


### PR DESCRIPTION
* use CMAKE_DLL_NAME_WITH_SOVERSION instead of patching
* use ninja
* cleanup