### PR TITLE
ada-url: add msys2_references

### DIFF
--- a/mingw-w64-ada-url/PKGBUILD
+++ b/mingw-w64-ada-url/PKGBUILD
@@ -10,6 +10,10 @@ arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
 url='https://github.com/ada-url/ada'
 license=('spdx:Apache-2.0 OR MIT')
+msys2_references=(
+  'anitya: 370270'
+  'archlinux: ada'
+)
 depends=("${MINGW_PACKAGE_PREFIX}-cc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"


### PR DESCRIPTION
Not sure whether this is sufficient to get proper upstream version tracking, but it's a start.