### PR TITLE
rust: extend msys2_references

### DIFF
--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -26,6 +26,7 @@ mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://www.rust-lang.org/"
 msys2_repository_url="https://github.com/rust-lang/rust"
 msys2_references=(
+  'anitya: 7635'
   'archlinux: rust'
   "cpe: cpe:/a:rust-lang:rust"
 )


### PR DESCRIPTION
This is to distinguish between [Rust](https://release-monitoring.org/project/7635/) and the [Rubygem of the same name](https://release-monitoring.org/project/129160/).