### PR TITLE
zlib-ng: add msys2_references

### DIFF
--- a/mingw-w64-zlib-ng/PKGBUILD
+++ b/mingw-w64-zlib-ng/PKGBUILD
@@ -7,6 +7,11 @@ pkgver=2.2.4
 pkgrel=1
 pkgdesc='zlib replacement with optimizations for next generation systems (mingw-w64)'
 url='https://github.com/zlib-ng/zlib-ng'
+msys2_references=(
+  'anitya: 115592'
+  'archlinux: zlib-ng'
+  'archlinux: zlib-ng-compat'
+)
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 license=("spdx:Zlib")


### PR DESCRIPTION
Not sure whether this works, because there are two ArchLinux packages, zlib-ng and zlib-ng-compat, which are part of the same package in MSYS2.