### PR TITLE
llvm: enable pgo for non-i686 GCC environments

### DIFF
--- a/mingw-w64-llvm/PKGBUILD
+++ b/mingw-w64-llvm/PKGBUILD
@@ -13,6 +13,9 @@ if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then
   _pgo=1
 else
   _compiler=clang
+  if [[ ${CARCH} != i686 ]]; then
+    _pgo=1
+  fi
 fi
 
 _realname=llvm
@@ -29,7 +32,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-llvm"
          "${MINGW_PACKAGE_PREFIX}-lld")
 _pkgver=20.1.8
 pkgver=${_pkgver/-/}
-pkgrel=1
+pkgrel=2
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -50,9 +53,11 @@ makedepends=($([[ "$_compiler" == "clang" ]] && echo \
              "${MINGW_PACKAGE_PREFIX}-libffi"
              "${MINGW_PACKAGE_PREFIX}-z3"
              "${MINGW_PACKAGE_PREFIX}-python"
-             $((( _clangprefix )) && echo \
+             $((( _pgo )) && echo \
                "${MINGW_PACKAGE_PREFIX}-compiler-rt" \
-               "${MINGW_PACKAGE_PREFIX}-libc++")
+               "${MINGW_PACKAGE_PREFIX}-libc++" \
+               "${MINGW_PACKAGE_PREFIX}-lld" \
+               "${MINGW_PACKAGE_PREFIX}-llvm-tools")
              "git"
              )
 _url=https://github.com/llvm/llvm-project/releases/download/llvmorg-${_pkgver}
@@ -205,6 +210,7 @@ build() {
   fi
 
   if (( _pgo )); then
+    common_cmake_args+=("-DLLVM_ENABLE_LLD=ON")
     # Build Clang with instrumentation.
     mkdir -p "${srcdir}"/build-${MSYSTEM}-instrument && cd "${srcdir}"/build-${MSYSTEM}-instrument
     ${MINGW_PREFIX}/bin/cmake.exe \
@@ -245,7 +251,6 @@ build() {
 
     platform_config+=(
       -DLLVM_ENABLE_LIBCXX=ON
-      -DLLVM_ENABLE_LLD=ON
       -DLLVM_INSTALL_BINUTILS_SYMLINKS=ON
       -DCLANG_DEFAULT_LINKER=lld
       -DCLANG_DEFAULT_RTLIB=compiler-rt


### PR DESCRIPTION
locally built successfully. I'll try with #22778 later and update this comment. enabling PGO for GCC envs requires _clangprefix'ed dependencies to be used + lld for a build.

fixes #24881

update: this doesn't work in my PR due to lld crash...
update2: hello world compiles with gcc+lld and clang+lld