### PR TITLE
itk: update to 5.4.4

### DIFF
--- a/mingw-w64-itk/PKGBUILD
+++ b/mingw-w64-itk/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=itk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=5.4.2
-pkgrel=4
+pkgver=5.4.4
+pkgrel=1
 pkgdesc='An open-source C++ toolkit for medical image processing (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -60,15 +60,12 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 optdepends=("${MINGW_PACKAGE_PREFIX}-opencv: ITK-OpenCV bridge"
             "${MINGW_PACKAGE_PREFIX}-vtk: ITK-VTK bridge")
 source=("https://github.com/InsightSoftwareConsortium/ITK/archive/v${pkgver}/ITK-${pkgver}.tar.gz"
-        https://github.com/InsightSoftwareConsortium/ITK/commit/4f275769e37fa29754166c7eded2d84c0b33991a.patch
         libminc-pr-129.patch)
-sha256sums=('931c4edf7ae57eede3fc611992941edce64bea508cf5c8741c2a4c2f56eceff1'
-            'a66b459b42f4daeffc0278af16b20ea12f765f237f38844cba8f6957580424bb'
+sha256sums=('683027617442391220eb79869d71652a54c4b47517ca6ca14d4b01c2583f5a1c'
             '14c1fe4b41fa77aed8483dbece655740dd485e8d78184c9351063a5fb77fa0b4')
 
 prepare() {
   cd "ITK-${pkgver}"
-  patch -p1 -i "${srcdir}"/4f275769e37fa29754166c7eded2d84c0b33991a.patch
   patch -p1 -i "${srcdir}"/libminc-pr-129.patch
 }
 


### PR DESCRIPTION
~Both of the patches are now included upstream and are not required anymore.~
The patch from 4f275769e37fa29754166c7eded2d84c0b33991a.patch (https://github.com/InsightSoftwareConsortium/ITK/commit/4f275769e37fa29754166c7eded2d84c0b33991a) is now included in version 5.4.4 as commit with different hash, see https://github.com/InsightSoftwareConsortium/ITK/commit/9c87ac96d1f55bcda8bb40ed6ef17502ea19bd38.