### PR TITLE
libxml2: Update to 2.14.5

### DIFF
--- a/mingw-w64-libxml2/0030-pkgconfig-add-Cflags-private.patch
+++ b/mingw-w64-libxml2/0030-pkgconfig-add-Cflags-private.patch
@@ -1,7 +1,0 @@
---- a/libxml-2.0.pc.in
-+++ b/libxml-2.0.pc.in
-@@ -11,3 +11,4 @@
- Libs: -L${libdir} -lxml2
- Libs.private: @ICU_LIBS@ @THREAD_LIBS@ @Z_LIBS@ @LZMA_LIBS@ @ICONV_LIBS@ @M_LIBS@ @WIN32_EXTRA_LIBADD@ @LIBS@
- Cflags: @XML_INCLUDEDIR@ @XML_CFLAGS@
-+Cflags.private: -DLIBXML_STATIC

--- a/mingw-w64-libxml2/PKGBUILD
+++ b/mingw-w64-libxml2/PKGBUILD
@@ -5,7 +5,7 @@ _realname=libxml2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
-pkgver=2.13.8
+pkgver=2.14.5
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -25,16 +25,16 @@ msys2_references=(
 )
 install=${_realname}-${MSYSTEM}.install
 source=("https://download.gnome.org/sources/libxml2/${pkgver%.*}/${_realname}-${pkgver}.tar.xz"
+        "https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.8.tar.xz"
         https://www.w3.org/XML/Test/xmlts20130923.tar.gz
         0027-decoding-segfault.patch
         0029-xml2-config-win-paths.patch
-        0030-pkgconfig-add-Cflags-private.patch
         0031-apply-msvc-relocation.patch)
-sha256sums=('277294cb33119ab71b2bc81f2f445e9bc9435b893ad15bb2cd2b0e859a0ee84a'
+sha256sums=('03d006f3537616833c16c53addcdc32a0eb20e55443cba4038307e3fa7d8d44b'
+            '277294cb33119ab71b2bc81f2f445e9bc9435b893ad15bb2cd2b0e859a0ee84a'
             '9b61db9f5dbffa545f4b8d78422167083a8568c59bd1129f94138f936cf6fc1f'
             '0391a4b267ba7251ca74ff2e98bf4c0332a14b618e8147a9341ec5617e45d9d9'
             '278b4531da3d2aabda080c412c5122b471202dd6df67768b38bb0c31c7a0e508'
-            '06c0afaf1b8dec10d6f23dec983026cddf992528ffbc1cc50418302fabf9dee0'
             'bd28c2b20290f787d28cc9986253b5e0157e729a7cd2fd4cfaa07cde736d1ef2')
 
 # Helper macros to help make tasks easier #
@@ -48,10 +48,16 @@ apply_patch_with_msg() {
 # =========================================== #
 
 prepare() {
-  cd ${_realname}-${pkgver}
+  cd "${_realname}-2.13.8"
 
   apply_patch_with_msg \
-    0030-pkgconfig-add-Cflags-private.patch \
+    0031-apply-msvc-relocation.patch
+
+  NOCONFIGURE=1 ./autogen.sh
+
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  apply_patch_with_msg \
     0031-apply-msvc-relocation.patch
 
   # https://gitlab.gnome.org/GNOME/libxml2/-/issues/64
@@ -68,6 +74,22 @@ prepare() {
 }
 
 build() {
+  # 2.13 build
+  msg2 "Building 2.13 for ${MSYSTEM}"
+  mkdir -p "${srcdir}"/build-2.13-${MSYSTEM} && cd "${srcdir}"/build-2.13-${MSYSTEM}
+  ../${_realname}-2.13.8/configure \
+    --prefix=${MINGW_PREFIX} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --build="${MINGW_CHOST}" \
+    --without-python \
+    --with-modules \
+    --with-legacy \
+    --disable-static \
+    --enable-shared \
+    --with-threads=win32
+  make
+
   # Static build
   msg2 "Building static for ${MSYSTEM}"
   mkdir -p "${srcdir}"/build-static-${MSYSTEM} && cd "${srcdir}"/build-static-${MSYSTEM}
@@ -79,6 +101,8 @@ build() {
     --without-python \
     --with-modules \
     --with-legacy \
+    --with-http \
+    --with-lzma \
     --enable-static \
     --disable-shared \
     --with-threads=win32 \
@@ -96,6 +120,8 @@ build() {
     --with-python=${MINGW_PREFIX}/bin/python \
     --with-modules \
     --with-legacy \
+    --with-http \
+    --with-lzma \
     --disable-static \
     --enable-shared \
     --with-threads=win32
@@ -113,6 +139,9 @@ check() {
 }
 
 package_libxml2() {
+  # Install 2.13
+  make -C "${srcdir}"/build-2.13-${MSYSTEM} install-libLTLIBRARIES DESTDIR="${pkgdir}"
+
   # First install shared
   make -C "${srcdir}"/build-shared-${MSYSTEM} install DESTDIR="${pkgdir}"
 


### PR DESCRIPTION
Since clang depends on libxml2 indirectly we keep an old 2.13 DLL around, so we can rebuild everything.

Can be droppped again once that's done.

for libxml2: enable all legacy features like html/lzma to reduce the fallout. We can look into that once the rebuild is done.

0030-pkgconfig-add-Cflags-private.patch: fixed upstream