### PR TITLE
libxml2: fix regression for parsing from stdin

### DIFF
--- a/mingw-w64-libxml2/0040-workaround-xmllint-stdin-error.patch
+++ b/mingw-w64-libxml2/0040-workaround-xmllint-stdin-error.patch
@@ -1,0 +1,36 @@
+diff --git a/xmlIO.c b/xmlIO.c
+index 6f322783..d78ad693 100644
+--- a/xmlIO.c
++++ b/xmlIO.c
+@@ -1169,7 +1169,15 @@ xmlInputFromFd(xmlParserInputBufferPtr buf, int fd, int unzip) {
+         xzFile xzStream;
+         off_t pos;
+ 
++#ifdef _WIN32
++        /*
++         * Windows doesn't seem to return an error for unseekable
++         * files.
++         */
++        pos = -1;
++#else
+         pos = lseek(fd, 0, SEEK_CUR);
++#endif
+ 
+         copy = dup(fd);
+         if (copy == -1)
+@@ -1208,7 +1216,15 @@ xmlInputFromFd(xmlParserInputBufferPtr buf, int fd, int unzip) {
+         gzFile gzStream;
+         off_t pos;
+ 
++#ifdef _WIN32
++        /*
++         * Windows doesn't seem to return an error for unseekable
++         * files.
++         */
++        pos = -1;
++#else
+         pos = lseek(fd, 0, SEEK_CUR);
++#endif
+ 
+         copy = dup(fd);
+         if (copy == -1)

--- a/mingw-w64-libxml2/PKGBUILD
+++ b/mingw-w64-libxml2/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
 pkgver=2.13.8
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 pkgdesc="XML parsing library, version 2 (mingw-w64)"
@@ -29,13 +29,15 @@ source=("https://download.gnome.org/sources/libxml2/${pkgver%.*}/${_realname}-${
         0027-decoding-segfault.patch
         0029-xml2-config-win-paths.patch
         0030-pkgconfig-add-Cflags-private.patch
-        0031-apply-msvc-relocation.patch)
+        0031-apply-msvc-relocation.patch
+        0040-workaround-xmllint-stdin-error.patch)
 sha256sums=('277294cb33119ab71b2bc81f2f445e9bc9435b893ad15bb2cd2b0e859a0ee84a'
             '9b61db9f5dbffa545f4b8d78422167083a8568c59bd1129f94138f936cf6fc1f'
             '0391a4b267ba7251ca74ff2e98bf4c0332a14b618e8147a9341ec5617e45d9d9'
             '278b4531da3d2aabda080c412c5122b471202dd6df67768b38bb0c31c7a0e508'
             '06c0afaf1b8dec10d6f23dec983026cddf992528ffbc1cc50418302fabf9dee0'
-            'bd28c2b20290f787d28cc9986253b5e0157e729a7cd2fd4cfaa07cde736d1ef2')
+            'bd28c2b20290f787d28cc9986253b5e0157e729a7cd2fd4cfaa07cde736d1ef2'
+            'dbb1c730f8f0f75ab4696d80f94476ae0ed53d7830819d27a0406e3cdd5ee028')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -63,6 +65,11 @@ prepare() {
   # https://github.com/msys2/MINGW-packages/issues/10577
   apply_patch_with_msg \
     0029-xml2-config-win-paths.patch
+
+  # https://gitlab.gnome.org/GNOME/libxml2/-/issues/951
+  # https://github.com/msys2/MINGW-packages/issues/24888
+  apply_patch_with_msg \
+    0040-workaround-xmllint-stdin-error.patch
 
   NOCONFIGURE=1 ./autogen.sh
 }


### PR DESCRIPTION
When using xmllint for example.

Using this patch for now to fix the regression.
Might need adjustments, see upstream issue.

Fixes #24888