### PR TITLE
gperf: update to 3.3

### DIFF
--- a/mingw-w64-gperf/PKGBUILD
+++ b/mingw-w64-gperf/PKGBUILD
@@ -3,38 +3,37 @@
 _realname=gperf
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=3.2
+pkgver=3.3
 pkgrel=1
 pkgdesc="Perfect hash function generator (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://www.gnu.org/software/gperf/"
-license=('GPL3')
+license=('spdx:GPL-3.0')
 depends=("${MINGW_PACKAGE_PREFIX}-cc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools" "${MINGW_PACKAGE_PREFIX}-cc")
 source=("https://ftp.gnu.org/pub/gnu/gperf/${_realname}-${pkgver}.tar.gz"{,.sig})
-sha256sums=('e0ddadebb396906a3e3e4cac2f697c8d6ab92dffa5d365a5bc23c7d41d30ef62'
+sha256sums=('fd87e0aba7e43ae054837afd6cd4db03a3f2693deb3619085e6ed9d8d9604ad8'
             'SKIP')
 validpgpkeys=('E0FFBD975397F77A32AB76ECB6301D9E1BBEAC08') # Bruno Haible (Free Software Development) <bruno@clisp.org>
 
 build() {
-  mkdir "${srcdir}"/build-${MSYSTEM}
-  cd "${srcdir}"/build-${MSYSTEM}
+  mkdir build-${MSYSTEM}
+  cd build-${MSYSTEM}
   ../${_realname}-${pkgver}/configure \
-    --build=${MINGW_CHOST} \
-    --host=${MINGW_CHOST} \
-    --target=${MINGW_CHOST} \
-    --prefix=${MINGW_PREFIX}
+    --prefix=${MINGW_PREFIX} \
+    --docdir=${MINGW_PREFIX}/share/doc/gperf
   make
 }
 
 check() {
-  cd "${srcdir}"/build-${MSYSTEM}
+  cd build-${MSYSTEM}
   make check
 }
 
 package() {
-  cd "${srcdir}"/build-${MSYSTEM}
+  cd build-${MSYSTEM}
   make DESTDIR="${pkgdir}" install
-  rm -rf "${pkgdir}"${MINGW_PREFIX}/share
+
+  install -Dm644 "${srcdir}"/${_realname}-${pkgver}/COPYING "${pkgdir}"${MINGW_PREFIX}/share/licenses/gperf/LICENSE
 }


### PR DESCRIPTION
- remove `--host` and `--target`, because we are not cross-compiling
- install doc, info and man files
- install license file