### PR TITLE
pyinstaller-hooks-contrib: update to 2025.8

### DIFF
--- a/mingw-w64-pyinstaller-hooks-contrib/PKGBUILD
+++ b/mingw-w64-pyinstaller-hooks-contrib/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=pyinstaller-hooks-contrib
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2025.7
+pkgver=2025.8
 pkgrel=1
 pkgdesc='Community maintained hooks for PyInstaller (mingw-w64)'
 arch=('any')
@@ -20,7 +20,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname//-/_}-${pkgver}.tar.gz")
-sha256sums=('b0c19dbe9a8428665d2c5c4538eaa16b683579aabd7f2ecd31f41b116c4e4e57')
+sha256sums=('3402ad41dfe9b5110af134422e37fc5d421ba342c6cb980bd67cb30b7415641c')
 
 build() {
   cp -r "${_realname//-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"


### PR DESCRIPTION
Includes [bugfix ](https://github.com/pyinstaller/pyinstaller-hooks-contrib/pull/927) especially for `MSYS2` environment