### PR TITLE
sqlite: don't require dlopen on Windows

### DIFF
--- a/mingw-w64-sqlite3/0005-dont-require-dlopen-on-windows.patch
+++ b/mingw-w64-sqlite3/0005-dont-require-dlopen-on-windows.patch
@@ -1,0 +1,40 @@
+--- sqlite-src-3500300/autosetup/sqlite-config.tcl.orig	2025-07-17 15:33:03.000000000 +0200
++++ sqlite-src-3500300/autosetup/sqlite-config.tcl	2025-07-30 08:04:33.581819200 +0200
+@@ -1410,7 +1410,7 @@
+ #
+ # - defines LDFLAGS_DLOPEN to any linker flags needed for this
+ #   feature.  It may legally be empty on some systems where dlopen()
+-#   is in libc.
++#   is in libc or on Windows where LoadLibrary is used.
+ #
+ # - If the feature is not available, adds
+ #   -DSQLITE_OMIT_LOAD_EXTENSION=1 to the feature flags list.
+@@ -1418,11 +1418,23 @@
+   define LDFLAGS_DLOPEN ""
+   set found 0
+   proj-if-opt-truthy load-extension {
+-    set found [proj-check-function-in-lib dlopen dl]
+-    if {$found} {
+-      define LDFLAGS_DLOPEN [get-define lib_dlopen]
+-      undefine lib_dlopen
+-    } else {
++    switch -glob -- [get-define host] {
++      *-*-mingw* - *windows* {
++        # Windows uses LoadLibrary/GetProcAddress which are always available
++        set found 1
++        msg-result "Using Windows LoadLibrary for loadable extensions."
++      }
++      default {
++        # Unix-like systems use dlopen
++        set found [proj-check-function-in-lib dlopen dl]
++        if {$found} {
++          define LDFLAGS_DLOPEN [get-define lib_dlopen]
++          undefine lib_dlopen
++        }
++      }
++    }
++    
++    if {!$found} {
+       if {[proj-opt-was-provided load-extension]} {
+         # Explicit --enable-load-extension: fail if not found
+         proj-indented-notice -error {

--- a/mingw-w64-sqlite3/0005-remove-dl-flags.patch
+++ b/mingw-w64-sqlite3/0005-remove-dl-flags.patch
@@ -1,9 +1,0 @@
---- sqlite-src-3500300/sqlite3.pc.in
-+++ sqlite-src-3500300/sqlite3.pc.in
-@@ -9,5 +9,5 @@ Name: SQLite
- Description: SQL database engine
- Version: @PACKAGE_VERSION@
- Libs: -L${libdir} -lsqlite3
--Libs.private: @LDFLAGS_MATH@ @LDFLAGS_ZLIB@ @LDFLAGS_DLOPEN@ @LDFLAGS_PTHREAD@ @LDFLAGS_ICU@
-+Libs.private: @LDFLAGS_MATH@ @LDFLAGS_ZLIB@ @LDFLAGS_PTHREAD@ @LDFLAGS_ICU@
- Cflags: -I${includedir}

--- a/mingw-w64-sqlite3/PKGBUILD
+++ b/mingw-w64-sqlite3/PKGBUILD
@@ -10,7 +10,7 @@ _sqlite_year=2025
 _amalgamationver=3500300
 _docver=${_amalgamationver}
 pkgver=3.50.3
-pkgrel=2
+pkgrel=3
 pkgdesc="A C library that implements an SQL database engine (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -23,17 +23,15 @@ msys2_references=(
 license=(PublicDomain)
 depends=("${MINGW_PACKAGE_PREFIX}-readline"
          "${MINGW_PACKAGE_PREFIX}-zlib")
-# dlfcn: it checks for dlopen in autosetup, but then doesn't use it, so just a build dep
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-tcl"
-             "${MINGW_PACKAGE_PREFIX}-dlfcn")
+             "${MINGW_PACKAGE_PREFIX}-tcl")
 source=(https://www.sqlite.org/${_sqlite_year}/sqlite-src-${_amalgamationver}.zip
         https://www.sqlite.org/${_sqlite_year}/sqlite-doc-${_docver}.zip
         0001-sqlite-pcachetrace-include-sqlite3.patch
         0002-fix-building-sqldiff.patch
         0003-do-not-install-tclsqlite3-with-make.patch
         0004-dont-misuse-tcl-extern.patch
-        0005-remove-dl-flags.patch
+        0005-dont-require-dlopen-on-windows.patch
         Makefile.ext.in
         README.md.in
         LICENSE)
@@ -43,7 +41,7 @@ sha256sums=('119862654b36e252ac5f8add2b3d41ba03f4f387b48eb024956c36ea91012d3f'
             'cf5c47c30e97f5493d2fad730a9bfcd33d20a0a052571e8e35b88f388d368724'
             'a500428a3434075932de84247b1405f3d73e7ed0a8b664eb20a736bd02d6ed29'
             '8dd2377afaad17fa85049be90bfc2bd757350343b3f64ff9bfbbcf3736593a34'
-            '1f6c78b81b1cf426bb582973a8a18557f14c7e96de3e0080f209c9c3f2a3b1a1'
+            'a6ffc29cc0612c48145a9296532d60a6e571ab5ef13aefba52abf79fa0e3e2ab'
             '84b64569978dde5b63799099b0fbb3336943ef877170beb84483020c67e25b3c'
             '5ca42f1f92abfb61bacc9ff60f5836cc56e2ce2af52264f918cb06c3d566d562'
             '0b76663a90e034f3d7f2af5bfada4cedec5ebc275361899eccc5c18e6f01ff1f')
@@ -56,7 +54,7 @@ prepare() {
   patch -p1 -i "${srcdir}/0001-sqlite-pcachetrace-include-sqlite3.patch"
   patch -p1 -i "${srcdir}/0002-fix-building-sqldiff.patch"
   patch -p1 -i "${srcdir}/0004-dont-misuse-tcl-extern.patch"
-  patch -p1 -i "${srcdir}/0005-remove-dl-flags.patch"
+  patch -p1 -i "${srcdir}/0005-dont-require-dlopen-on-windows.patch"
 }
 
 build() {


### PR DESCRIPTION
Followup to https://github.com/msys2/MINGW-packages/pull/24985