### PR TITLE
mongo-c-driver: rename from mongoc to mongo-c-driver

### DIFF
--- a/mingw-w64-mongo-c-driver/PKGBUILD
+++ b/mingw-w64-mongo-c-driver/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Tao Zuhong <taozuhong@hotmail.com>
 
-_realname=mongoc
+_realname=mongo-c-driver
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.1.0


### PR DESCRIPTION
Arch Linux also uses [mongo-c-driver](https://archlinux.org/packages/extra/x86_64/mongo-c-driver/) as package name.