### PR TITLE
openimageio: update to 3.0.9.0

### DIFF
--- a/mingw-w64-openimageio/PKGBUILD
+++ b/mingw-w64-openimageio/PKGBUILD
@@ -54,11 +54,13 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-python: bindings support"
 source=(https://github.com/AcademySoftwareFoundation/OpenImageIO/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz
         0000-workaround-ansidecl-h-PTR-define-conflict.patch
         0001-Fix-building-on-mingw-w64-aarch64.patch
-        0002-mingw-putenv.patch)
+        0002-mingw-putenv.patch
+        https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/4851.patch)
 sha256sums=('2618f024d33b03fd003ce272e9a2a78d3bffd4c78cf8a1a058a9def715bb8bc9'
             '9e4e21333676268a91c0f4e7676aeab7658e5f748e7e5cfe43a92f0fd7931229'
             '91bd9a6a07f448a6dd8d1ff9a1c8cefaedb8cdd77029b84b6fc02fe9a7cf71f0'
-            'a03bcafded0808f9894d26b55a2bf26e69ce0676bf73d8a512ec1546de16ca34')
+            'a03bcafded0808f9894d26b55a2bf26e69ce0676bf73d8a512ec1546de16ca34'
+            'c21c0f9676b8d0f280768bf7ddeee6c8bab7ce08903ace4d692e059d6b60c84a')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -75,6 +77,9 @@ prepare() {
     0000-workaround-ansidecl-h-PTR-define-conflict.patch \
     0001-Fix-building-on-mingw-w64-aarch64.patch \
     0002-mingw-putenv.patch
+
+  # https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/4851
+  apply_patch_with_msg 4851.patch
 }
 
 build() {

--- a/mingw-w64-openimageio/PKGBUILD
+++ b/mingw-w64-openimageio/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=openimageio
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.0.8.1
-pkgrel=3
+pkgver=3.0.9.0
+pkgrel=1
 pkgdesc="A library for reading and writing images, including classes, utilities, and applications (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -55,7 +55,7 @@ source=(https://github.com/AcademySoftwareFoundation/OpenImageIO/archive/v${pkgv
         0000-workaround-ansidecl-h-PTR-define-conflict.patch
         0001-Fix-building-on-mingw-w64-aarch64.patch
         0002-mingw-putenv.patch)
-sha256sums=('1b9b0d27e802243c1aa490b951580d10e8be645459f8080bfa0ed6f213e1082a'
+sha256sums=('2618f024d33b03fd003ce272e9a2a78d3bffd4c78cf8a1a058a9def715bb8bc9'
             '9e4e21333676268a91c0f4e7676aeab7658e5f748e7e5cfe43a92f0fd7931229'
             '91bd9a6a07f448a6dd8d1ff9a1c8cefaedb8cdd77029b84b6fc02fe9a7cf71f0'
             'a03bcafded0808f9894d26b55a2bf26e69ce0676bf73d8a512ec1546de16ca34')


### PR DESCRIPTION
Ah, needs https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/4851 now...