### PR TITLE
sox-ng: dependency cleanups

### DIFF
--- a/mingw-w64-sox-ng/PKGBUILD
+++ b/mingw-w64-sox-ng/PKGBUILD
@@ -4,20 +4,19 @@ _realname=sox-ng
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=14.6.0.4
-pkgrel=1
+pkgrel=2
 pkgdesc="SoX is the Swiss Army Knife of sound processing utilities (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://codeberg.org/sox_ng/sox_ng"
 license=("GPL")
-makedepends=(autoconf-archive git
+makedepends=(autoconf-archive
              ${MINGW_PACKAGE_PREFIX}-autotools
              ${MINGW_PACKAGE_PREFIX}-cc
              ${MINGW_PACKAGE_PREFIX}-pkgconf)
 depends=(${MINGW_PACKAGE_PREFIX}-cc-libs
              ${MINGW_PACKAGE_PREFIX}-flac
              ${MINGW_PACKAGE_PREFIX}-gsm
-             ${MINGW_PACKAGE_PREFIX}-id3lib
              ${MINGW_PACKAGE_PREFIX}-lame
              ${MINGW_PACKAGE_PREFIX}-libao
              ${MINGW_PACKAGE_PREFIX}-libid3tag
@@ -31,7 +30,11 @@ depends=(${MINGW_PACKAGE_PREFIX}-cc-libs
              ${MINGW_PACKAGE_PREFIX}-twolame
              ${MINGW_PACKAGE_PREFIX}-vo-amrwbenc
              ${MINGW_PACKAGE_PREFIX}-wavpack
+             ${MINGW_PACKAGE_PREFIX}-speex
+             ${MINGW_PACKAGE_PREFIX}-speexdsp
+             ${MINGW_PACKAGE_PREFIX}-fftw
              ${MINGW_PACKAGE_PREFIX}-omp)
+optdepends=("${MINGW_PACKAGE_PREFIX}-ffmpeg: to decode otherwise unsupported formats")
 source=("https://codeberg.org/sox_ng/sox_ng/releases/download/sox_ng-${pkgver}/sox_ng-${pkgver}.tar.gz"
         "0002-fix-missing-exports.patch"
         "0003-missing-include.patch")


### PR DESCRIPTION
id3lib and git are not used

Add speex, speexdsp, fftw, which is can use, and opt depend on ffmpeg since it can shell out to that if needed (it's not linking it)