### PR TITLE
rust-analyzer: update to 20250804

### DIFF
--- a/mingw-w64-rust-analyzer/PKGBUILD
+++ b/mingw-w64-rust-analyzer/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=rust-analyzer
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-_pkgver=2025-07-28
+_pkgver=2025-08-04
 pkgver=${_pkgver//-}
 pkgrel=1
 pkgdesc="A Rust compiler front-end for IDEs (mingw-w64)"
@@ -16,7 +16,7 @@ conflicts=("${MINGW_PACKAGE_PREFIX}-rust<1.80.0-2")
 depends=("${MINGW_PACKAGE_PREFIX}-rust-src")
 makedepends=('git')
 source=("git+${msys2_repository_url}.git#tag=${_pkgver}")
-sha256sums=('6391b8839448f51cc8a13c59d01cba59933936e7c937d0dc0c38d94b50cc57b7')
+sha256sums=('566c44df347506efff56393631f1f59a5402bacf54c06e49a306aa9d9c4592d8')
 
 prepare() {
   cd "${_realname}"


### PR DESCRIPTION
I somehow missed previous version, and new version was untagged...