### PR TITLE
osm-gps-map: switch to libsoup3

### DIFF
--- a/mingw-w64-osm-gps-map/PKGBUILD
+++ b/mingw-w64-osm-gps-map/PKGBUILD
@@ -26,7 +26,7 @@ makedepends=(
     "${MINGW_PACKAGE_PREFIX}-gtk-doc"
 )
 source=(https://github.com/nzjrs/osm-gps-map/releases/download/${pkgver}/${_realname}-${pkgver}.tar.gz
-        https://github.com/void-linux/void-packages/commit/f6b0cf8ca04678301773327b9a2d5efb043dae3d/srcpkgs/libosmgpsmap/patches/libsoup-3.patch) 
+        https://raw.githubusercontent.com/void-linux/void-packages/f6b0cf8ca04678301773327b9a2d5efb043dae3d/srcpkgs/libosmgpsmap/patches/libsoup-3.patch) 
 sha256sums=('ddec11449f37b5dffb4bca134d024623897c6140af1f9981a8acc512dbf6a7a5'
             '045c8c9a6a317aea89158154818399815525f5b5cb0340332f92b250d73e5bc6')
 

--- a/mingw-w64-osm-gps-map/PKGBUILD
+++ b/mingw-w64-osm-gps-map/PKGBUILD
@@ -22,23 +22,18 @@ depends=(
 makedepends=(
     "${MINGW_PACKAGE_PREFIX}-cc"
     "${MINGW_PACKAGE_PREFIX}-autotools"
-    "${MINGW_PACKAGE_PREFIX}-gnome-common"
     "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
     "${MINGW_PACKAGE_PREFIX}-gtk-doc"
 )
 source=(https://github.com/nzjrs/osm-gps-map/releases/download/${pkgver}/${_realname}-${pkgver}.tar.gz
-        https://github.com/nzjrs/osm-gps-map/commit/118fd8052f1df6fde7baa0fbeaf1a8cd97c94ab3.patch
-        https://github.com/nzjrs/osm-gps-map/commit/c7186ce3e423119bed0c148172d458491fb49dfc.patch) 
+        https://github.com/void-linux/void-packages/commit/f6b0cf8ca04678301773327b9a2d5efb043dae3d/srcpkgs/libosmgpsmap/patches/libsoup-3.patch) 
 sha256sums=('ddec11449f37b5dffb4bca134d024623897c6140af1f9981a8acc512dbf6a7a5'
-            '9f62195ebafeb7b4f114f31314b2bf71d2b7c93492ba53274c64f050e53cd143'
-            '62c9c8f054d19499c0118197f041e39580a029dedeca0d4c28cade7070a1fcbf')
+            '045c8c9a6a317aea89158154818399815525f5b5cb0340332f92b250d73e5bc6')
 
 prepare() {
     cd "${srcdir}/${_realname}-${pkgver}"
-    # https://github.com/nzjrs/osm-gps-map/issues/85 (prerequisite for the next patch)
-    patch -p1 -i "${srcdir}/118fd8052f1df6fde7baa0fbeaf1a8cd97c94ab3.patch"
-    # https://github.com/nzjrs/osm-gps-map/issues/96
-    patch -p1 -i "${srcdir}/c7186ce3e423119bed0c148172d458491fb49dfc.patch"
+    # https://github.com/nzjrs/osm-gps-map/issues/96 (rebased by Void Linux)
+    patch -p1 -i "${srcdir}/libsoup-3.patch"
     # autoreconf to get updated libtool files for clang
     autoreconf -fiv
 }

--- a/mingw-w64-osm-gps-map/PKGBUILD
+++ b/mingw-w64-osm-gps-map/PKGBUILD
@@ -4,7 +4,7 @@ _realname=osm-gps-map
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.2.0
-pkgrel=3
+pkgrel=4
 pkgdesc="A Gtk+ Widget for Displaying OpenStreetMap tiles. (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -17,7 +17,7 @@ depends=(
     "${MINGW_PACKAGE_PREFIX}-gettext-runtime"
     "${MINGW_PACKAGE_PREFIX}-glib2"
     "${MINGW_PACKAGE_PREFIX}-gtk3"
-    "${MINGW_PACKAGE_PREFIX}-libsoup"
+    "${MINGW_PACKAGE_PREFIX}-libsoup3"
 )
 makedepends=(
     "${MINGW_PACKAGE_PREFIX}-cc"
@@ -26,11 +26,19 @@ makedepends=(
     "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
     "${MINGW_PACKAGE_PREFIX}-gtk-doc"
 )
-source=(https://github.com/nzjrs/osm-gps-map/releases/download/${pkgver}/${_realname}-${pkgver}.tar.gz) 
-sha256sums=('ddec11449f37b5dffb4bca134d024623897c6140af1f9981a8acc512dbf6a7a5')
+source=(https://github.com/nzjrs/osm-gps-map/releases/download/${pkgver}/${_realname}-${pkgver}.tar.gz
+        https://github.com/nzjrs/osm-gps-map/commit/118fd8052f1df6fde7baa0fbeaf1a8cd97c94ab3.patch
+        https://github.com/nzjrs/osm-gps-map/commit/c7186ce3e423119bed0c148172d458491fb49dfc.patch) 
+sha256sums=('ddec11449f37b5dffb4bca134d024623897c6140af1f9981a8acc512dbf6a7a5'
+            '9f62195ebafeb7b4f114f31314b2bf71d2b7c93492ba53274c64f050e53cd143'
+            '62c9c8f054d19499c0118197f041e39580a029dedeca0d4c28cade7070a1fcbf')
 
 prepare() {
     cd "${srcdir}/${_realname}-${pkgver}"
+    # https://github.com/nzjrs/osm-gps-map/issues/85 (prerequisite for the next patch)
+    patch -p1 -i "${srcdir}/118fd8052f1df6fde7baa0fbeaf1a8cd97c94ab3.patch"
+    # https://github.com/nzjrs/osm-gps-map/issues/96
+    patch -p1 -i "${srcdir}/c7186ce3e423119bed0c148172d458491fb49dfc.patch"
     # autoreconf to get updated libtool files for clang
     autoreconf -fiv
 }


### PR DESCRIPTION
A few distros are already patching the same way as libsoup2 is insecure and there is no ETA on new release from upstram... E.g.:

https://salsa.debian.org/debian-gis-team/osm-gps-map/-/commit/d2224755698c9f57c18273601fe6239a0d290684

https://github.com/Homebrew/homebrew-core/blob/bccf5505eadeebe4195577c65b7b74564d23196b/Formula/o/osm-gps-map.rb