### PR TITLE
zed: update to 0.199.6

### DIFF
--- a/mingw-w64-zed/.gitignore
+++ b/mingw-w64-zed/.gitignore
@@ -1,3 +1,1 @@
 /zed
-/zed-use-directx.patch
-/zed-improve-text-rendering.patch

--- a/mingw-w64-zed/PKGBUILD
+++ b/mingw-w64-zed/PKGBUILD
@@ -4,11 +4,11 @@ _realname=zed
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
-pkgver=0.198.6
+pkgver=0.199.6
 pkgrel=1
 pkgdesc="A high-performance, multiplayer code editor (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
 url='https://zed.dev'
 msys2_repository_url='https://github.com/zed-industries/zed'
 msys2_documentation_url='https://zed.dev/docs'
@@ -44,14 +44,10 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-clang-tools-extra: for a better C/C++ langu
 source=("git+${msys2_repository_url}.git#tag=v${pkgver}"
         "zstd-sys.tar.gz::https://crates.io/api/v1/crates/zstd-sys/2.0.15+zstd.1.5.7/download"
         "zstd-sys-remove-statik.patch"
-        "zed-use-directx.patch::https://github.com/zed-industries/zed/commit/15ad9863296d427966098f6b9864d5b819725101.patch"
-        "zed-improve-text-rendering.patch::https://github.com/zed-industries/zed/commit/b31f893408e275ce9ab2e1ec611651246644d778.patch"
         "zed-fix-docs-build.patch")
-sha256sums=('a1cf120a7f8aad51d100b8d5faa19c72053d5a77ce6102cb1690b8fdfe3260c0'
+sha256sums=('fed038645e281a6637e2512f6b15c7c20bdf2908c8d47159ceeb743e9e2d26cd'
             'eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237'
             '48f4900ceb02d3aaf9a1020f33d56629156e96759f456c0e7ca18bfcf910767b'
-            '193bad69474ccf6b65cb52048f813a239a47965c60ee42b4c03068290b3aacce'
-            '63de021676c066fbd596ff77633664f994f84d0e608b4f10f8354c82fe279ea2'
             'acaf155e37120a1af8918854a457939cad71e59bca2ced866f89795ed6b0a7b2')
 
 prepare() {
@@ -59,9 +55,6 @@ prepare() {
   rm rust-toolchain.toml
 
   patch -p1 -i ../zed-fix-docs-build.patch
-  # use directx instead of vulkan and improve text rendering. backports from v0.199.x
-  patch -p1 -i ../zed-use-directx.patch
-  patch -p1 -i ../zed-improve-text-rendering.patch
   # link system deps dynamically
   patch -d ../zstd-sys-2.0.15+zstd.1.5.7 -i ../zstd-sys-remove-statik.patch
   # use patched *-sys crates


### PR DESCRIPTION
- remove backports
- drop MINGW64, now Zed requires symbols from UCRT