### PR TITLE
mingw-w64-objfw: Depend on clang

### DIFF
--- a/mingw-w64-objfw/PKGBUILD
+++ b/mingw-w64-objfw/PKGBUILD
@@ -12,15 +12,15 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-libobjfw"
          "${MINGW_PACKAGE_PREFIX}-ofgctester")
 pkgbase=mingw-w64-${_realname}
 pkgver=1.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Portable, lightweight framework for the Objective-C language (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://objfw.nil.im/"
 msys2_repository_url="https://github.com/ObjFW/ObjFW"
 license=('spdx:LGPL-3.0-only')
-makedepends=("${MINGW_PACKAGE_PREFIX}-clang"
-             "${MINGW_PACKAGE_PREFIX}-openssl")
+depends=("${MINGW_PACKAGE_PREFIX}-clang")
+makedepends=("${MINGW_PACKAGE_PREFIX}-openssl")
 groups=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 source=("https://objfw.nil.im/downloads/${_realname}-${pkgver}.tar.gz")
 sha256sums=('3704b5bf2f27b9327be8e3b8f87745b9cf37c5d3d1e957600617023ee2b3eb12')


### PR DESCRIPTION
I'm not entirely sure if this does what I want, so careful review would be appreciated.

Basically, what I want is that installing the group depends on clang, but none of the packages of the group should itself depend on clang. Would this work?