### PR TITLE
python-rencode: build with cython3

### DIFF
--- a/mingw-w64-python-rencode/PKGBUILD
+++ b/mingw-w64-python-rencode/PKGBUILD
@@ -4,7 +4,7 @@ _realname=rencode
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=1.0.8
-pkgrel=1
+pkgrel=2
 pkgdesc="Python module for fast (basic) object serialization similar to bencode (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -19,10 +19,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
              "${MINGW_PACKAGE_PREFIX}-python-poetry-core"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"
-             "${MINGW_PACKAGE_PREFIX}-cython0"
+             "${MINGW_PACKAGE_PREFIX}-cython"
              "${MINGW_PACKAGE_PREFIX}-cc")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
-options=(!strip)
+options=('!strip')
 source=("https://github.com/aresch/rencode/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
         0001-Remove-extra-compile-args.patch
         python-rencode-typecode-dos.patch)
@@ -31,37 +31,31 @@ sha256sums=('480aab74948a7f339b749b5c39bdb4caf15429f4b49a998c770d5f371098d351'
             '72046868ae82f7c9576fb9160bcf686cc893b5f104ee8b126c36466d06f21eb7')
 
 prepare() {
-  cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
-  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
-
-  cd "python-build-${MSYSTEM}"
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
 
   # https://github.com/aresch/rencode/issues/38
-  patch -p1 -i "${srcdir}/0001-Remove-extra-compile-args.patch"
-
-  # build.py seems to be a special name, and it prevents building of a wheel
-  mv build.py cython_build.py
-  sed -i 's/build.py/cython_build.py/' pyproject.toml
+  patch -p1 -i ../0001-Remove-extra-compile-args.patch
 }
 
 build() {
-  cd "${srcdir}/python-build-${MSYSTEM}"
-  ${MINGW_PREFIX}/bin/python cython_build.py
-  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
+  # Running in the source dir won't work, as
+  # ./build.py will be ran instead of python-build
+  python -m build --wheel --skip-dependency-check --no-isolation "python-build-${MSYSTEM}"
 }
 
 check() {
-  cd "${srcdir}/python-build-${MSYSTEM}"
-  ${MINGW_PREFIX}/bin/python -m venv --system-site-packages testenv
+  cd "python-build-${MSYSTEM}"
+
+  python -m venv --system-site-packages testenv
   testenv/bin/python -m installer dist/*.whl
   testenv/bin/python -m pytest
 }
 
 package() {
-  cd "${srcdir}/python-build-${MSYSTEM}"
+  cd "python-build-${MSYSTEM}"
+
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-    "${MINGW_PREFIX}"/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    python -m installer --prefix=${MINGW_PREFIX} \
     --destdir="${pkgdir}" dist/*.whl
 
   install -Dm644 COPYING "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/COPYING"


### PR DESCRIPTION
build workaround taken from Arch