### PR TITLE
glaze: update to 5.6.0

### DIFF
--- a/mingw-w64-glaze/PKGBUILD
+++ b/mingw-w64-glaze/PKGBUILD
@@ -27,6 +27,7 @@ build() {
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
+  CXXFLAGS+=" -D__LP64__" \
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     cmake \
       -GNinja \
@@ -34,6 +35,7 @@ build() {
       "${extra_config[@]}" \
       -Dglaze_ENABLE_FUZZING=OFF \
       -Dglaze_DEVELOPER_MODE=OFF \
+      -Dglaze_BUILD_INTEROP=ON \
       -S "${_realname}-${pkgver}" \
       -B "build-${MSYSTEM}"
 

--- a/mingw-w64-glaze/PKGBUILD
+++ b/mingw-w64-glaze/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=glaze
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=5.5.5
+pkgver=5.6.0
 pkgrel=1
 pkgdesc="An Extremely fast, In-Memory JSON and Interface Library for Modern C++ (mingw-w64)"
 arch=('any')
@@ -17,7 +17,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cc")
 source=("$url/archive/v$pkgver/${_realname}-$pkgver.tar.gz")
-sha256sums=('c2ae536d634aa12f49ac7521f169d2891af55b3376648cbb0053daadb78b6ef1')
+sha256sums=('6f21e4186ce14b5243a5d2e58419f45fda260da2c0fa9ef793a5c46eaa05b2b3')
 
 build() {
   declare -a extra_config

--- a/mingw-w64-glaze/PKGBUILD
+++ b/mingw-w64-glaze/PKGBUILD
@@ -27,7 +27,6 @@ build() {
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
-  CXXFLAGS+=" -D__LP64__" \
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     cmake \
       -GNinja \
@@ -35,7 +34,6 @@ build() {
       "${extra_config[@]}" \
       -Dglaze_ENABLE_FUZZING=OFF \
       -Dglaze_DEVELOPER_MODE=OFF \
-      -Dglaze_BUILD_INTEROP=ON \
       -S "${_realname}-${pkgver}" \
       -B "build-${MSYSTEM}"
 


### PR DESCRIPTION
This version adds a new option `glaze_BUILD_INTEROP`, but I'm getting [build errors](https://github.com/user-attachments/files/21856650/log.txt) with it enabled, so I've left it off.