### PR TITLE
skia: use git archive instead of a clone

### DIFF
--- a/mingw-w64-skia/PKGBUILD
+++ b/mingw-w64-skia/PKGBUILD
@@ -5,7 +5,7 @@ _realname=skia
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=130.r73211.b988efa0
-pkgrel=1
+pkgrel=2
 pkgdesc="Skia is a complete 2D graphic library for drawing Text, Geometries, and Images (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -28,7 +28,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
          "${MINGW_PACKAGE_PREFIX}-libwebp"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 _commit="b988efa06f8aa3bfeaa18c5b8c716ff244ab43cf"
-source=("${_realname}::git+https://skia.googlesource.com/skia.git#commit=${_commit}"
+source=("${_realname}.tar.gz::https://github.com/google/skia/archive/${_commit}.tar.gz"
         "bare-clones/zlib::git+https://chromium.googlesource.com/chromium/src/third_party/zlib.git#commit=646b7f569718921d7d4b5b8e22572ff6c76f2596"
         "0001-add-pkgconfig-support.patch"
         "0002-add-mingw-toolchain-skia.patch"
@@ -36,7 +36,7 @@ source=("${_realname}::git+https://skia.googlesource.com/skia.git#commit=${_comm
         "0004-misc-mingw-fixes.patch"
         "0005-external-packages-update.patch"
         "skia.pc")
-sha256sums=('a54e568796abc25c9018f876a827305958591946387909cea1e8ad9c6fca52f6'
+sha256sums=('6ae175029bcf3e7e7368aa9dc0f744b59f4c0e0e096dc204a65c5560761f6f6e'
             '967acb8025f9af3f1a5d4d4e9ab671a65fd9b1a52e93081683f84167077c979b'
             '7440572487b8bc33ac7a8445de0cc4148e0d47b538ba46f4952ba8cc97e0fa52'
             '252f49523d53a2b74d0efb60678de1ca491df28c71ee4d1504684a1414ec3503'
@@ -53,12 +53,16 @@ apply_patch_with_msg() {
 }
 
 pkgver() {
-  cd ${_realname}
+  git clone --filter=blob:none --revision "${_commit}" https://skia.googlesource.com/skia.git skia_temp
+  cd skia_temp
   local _milestone=$(grep -Eo "Milestone ([0-9]+)" RELEASE_NOTES.md | head -1 | cut -f 2 -d ' ')
   printf "%s.r%s.%s" "${_milestone}" "$(git rev-list --count HEAD)" "$(git rev-parse --short=8 "${_commit}")"
+  cd ..
+  rm -Rf skia_temp
 }
 
 prepare() {
+  mv "${_realname}-${_commit}" "${_realname}"
   cd ${_realname}
   apply_patch_with_msg \
     0001-add-pkgconfig-support.patch \


### PR DESCRIPTION
The clone is 4GB, which is too much for GitHub.
Do some temporary git hackery to keep the pkgver() logic though.