### PR TITLE
fix glade-gtk2 crash

### DIFF
--- a/mingw-w64-fd/PKGBUILD
+++ b/mingw-w64-fd/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=fd
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=10.2.0
+pkgver=10.3.0
 pkgrel=1
 pkgdesc='Simple, fast and user-friendly alternative to find (mingw-w64)'
 arch=('any')
@@ -17,7 +17,7 @@ msys2_references=(
   'purl: pkg:cargo/fd-find'
 )
 source=("${url}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha512sums=('db7a41d0dd448d73a88f7920b0d67d5d99864fef0a7d64a91523a55af9fd745e6520df8aee808f4131a07acd34730571d94a20e1e6aa1336c6f3caaab593d4ab')
+sha512sums=('fa7d03cbc4abab02db8ed5cc7f3cb91ba87a6b4a609186edb40db80420a31a7ef671558e7a172008d8d31d9f7ef46ad9f58503129e1a253e36f1c2c15135595b')
 
 prepare() {
   cd "${_realname}-${pkgver}"


### PR DESCRIPTION
fix issue https://github.com/msys2/MINGW-packages/issues/25288
This is a known bug.
https://gitlab.gnome.org/Archive/glade/-/issues/403
And it is fixed by Christian Hergert.
https://gitlab.gnome.org/Archive/glade/-/merge_requests/83/diffs