### PR TITLE
pcre2: update to 10.46

### DIFF
--- a/mingw-w64-pcre2/PKGBUILD
+++ b/mingw-w64-pcre2/PKGBUILD
@@ -3,14 +3,16 @@
 _realname=pcre2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=10.45
+pkgver=10.46
 pkgrel=1
 pkgdesc="A library that implements Perl 5-style regular expressions (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://pcre.org/"
 msys2_repository_url="https://github.com/PhilipHazel/pcre2"
+msys2_changelog_url="https://github.com/PCRE2Project/pcre2/blob/master/NEWS"
 msys2_references=(
+  "archlinux: pcre2"
   "cpe: cpe:/a:pcre:pcre"
   "cpe: cpe:/a:pcre:pcre2"
 )
@@ -21,7 +23,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-bzip2"
          "${MINGW_PACKAGE_PREFIX}-wineditline"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 source=(https://github.com/PhilipHazel/pcre2/releases/download/${_realname}-${pkgver}/${_realname}-${pkgver}.tar.bz2{,.sig})
-sha256sums=('21547f3516120c75597e5b30a992e27a592a31950b5140e7b8bfde3f192033c4'
+sha256sums=('15fbc5aba6beee0b17aecb04602ae39432393aba1ebd8e39b7cabf7db883299f'
             'SKIP')
 validpgpkeys=('A95536204A3BB489715231282A98E77EB6F24CA8') # Nicholas Wilson <nicholas@nicholaswilson.me.uk>
 


### PR DESCRIPTION
This update addresses CVE-2025-58050 in pcre2.