### PR TITLE
lapack: avoid file conflicts in packages

### DIFF
--- a/mingw-w64-lapack/PKGBUILD
+++ b/mingw-w64-lapack/PKGBUILD
@@ -11,7 +11,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-cblas64"
          "${MINGW_PACKAGE_PREFIX}-lapacke64")
 pkgver=3.12.1
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 pkgdesc="Linear Algebra PACKage (mingw-w64)"
@@ -197,6 +197,8 @@ package_lapacke64() {
   for _shared in OFF ON; do
     DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install build-${MSYSTEM}-sh-${_shared}-64-ON/LAPACKE
   done
+
+  rm -r "$pkgdir"${MINGW_PREFIX}/include # provided by lapacke
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" -t "$pkgdir"${MINGW_PREFIX}/share/licenses/lapacke64/
 }

--- a/mingw-w64-lapack/PKGBUILD
+++ b/mingw-w64-lapack/PKGBUILD
@@ -32,8 +32,8 @@ source=(https://github.com/Reference-LAPACK/lapack/archive/v${pkgver}/${_realnam
         0003-line-reflow-with-integer-8.patch::https://github.com/Reference-LAPACK/lapack/pull/1099.patch)
 sha256sums=('2ca6407a001a474d4d4d35f3a61550156050c48016d949f0da0529c0aa052422'
             '658a558b012101089322e3af8246568e635776eebcdb588803af7f245f676513'
-            '1cd1328111c562c635bcc5d69b1088f763825674445c2c011f02fd4846665dcd'
-            'dce6370e0f4d1d8c4cbac4c8c50e87e3f6f7ab3d62903760b6abc1aa8158e221')
+            'cc66e988e10562e597112f20ceae8f5362aa3155448d02100d5d6fd88991d8f1'
+            '9e67bf22b94d6ca24d7b4b5bf98ea4a239619fd40a7457fb483a7b91f2bb158d')
 
 apply_patch_with_msg() {
   for _patch in "$@"


### PR DESCRIPTION
Remove the headers from the lapacke64 package. They are provided by the lapacke package to which there already is an optional dependency.
