### PR TITLE
Add mman-win32 library

### DIFF
--- a/mingw-w64-mman-win32/PKGBUILD
+++ b/mingw-w64-mman-win32/PKGBUILD
@@ -1,0 +1,64 @@
+# Maintainer: PlusNinetySix <PlusNinetySix@gmail.com>
+
+_realname=mman-win32
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=r31.fedbdbf
+pkgrel=1
+pkgdesc="A light implementation of the mmap functions for MinGW."
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url="https://github.com/alitrack/mman-win32"
+license=('spdx:MIT')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-cc"
+             'git')
+_commit='fedbdbf167241503c4a8250c1666be580890c4e2'
+source=("${_realname}"::"git+https://github.com/alitrack/mman-win32.git#commit=${_commit}")
+sha256sums=('cae2052bed1cadd7b5c82f38a3130c62855d06798ec792929bd26c46db67f0b1')
+
+pkgver() {
+  cd "${srcdir}/${_realname}"
+
+  printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+prepare() {
+  cd "${srcdir}/${_realname}"
+  #CMake 4.x errors out on any required minimum version less than 3.5.
+  sed -i 's/cmake_minimum_required *(VERSION 2\.8)/cmake_minimum_required (VERSION 3.10)/' CMakeLists.txt
+}
+
+build() {
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+  
+  for _shared in ON OFF; do
+	MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+		cmake \
+		-GNinja \
+		-DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+		"${extra_config[@]}" \
+		-DBUILD_SHARED_LIBS=${_shared} \
+		-S "${srcdir}/${_realname}" \
+		-B "build-${MSYSTEM}-shared-${_shared}"
+	
+	cmake --build "build-${MSYSTEM}-shared-${_shared}"
+  done
+}
+
+package() {
+  for _shared in ON OFF; do
+	DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}-shared-${_shared}"
+	if [[ ${_shared} -eq ON ]]; then
+		strip --strip-unneeded "${pkgdir}/${MINGW_PREFIX}/bin/libmman.dll"
+	else
+		strip -g "${pkgdir}/${MINGW_PREFIX}/lib/libmman.a"
+	fi
+  done
+}


### PR DESCRIPTION
Adds the mman-win32 library for use under MinGW environments.