### PR TITLE
Revert "exiv2: update to 0.28.6"

### DIFF
--- a/mingw-w64-exiv2/PKGBUILD
+++ b/mingw-w64-exiv2/PKGBUILD
@@ -5,15 +5,14 @@
 _realname=exiv2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.28.6
-pkgrel=1
+pkgver=0.28.5
+pkgrel=2
 pkgdesc="Exif/IPTC/Xmp C++ metadata library and tools (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
 url='https://exiv2.org/'
 msys2_repository_url="https://github.com/Exiv2/exiv2"
 msys2_references=(
-  'anitya: 769'
   'archlinux: exiv2'
   "cpe: cpe:/a:exiv2:exiv2"
   "cygwin: exiv2"
@@ -35,7 +34,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
          "${MINGW_PACKAGE_PREFIX}-libwinpthread"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 source=("https://github.com/Exiv2/${_realname}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('9d481117b97afa5324bf3ea0ad79f5c2939ae94ba0d0f5f8eb23aee16d9ec58d')
+sha256sums=('e1671f744e379a87ba0c984617406fdf8c0ad0c594e5122f525b2fb7c28d394d')
 
 build() {
   declare -a extra_config


### PR DESCRIPTION
This reverts commit 78bf1c32edf507a35f01977d0f05ed336864f9cd.

The nex Exiv2 release crahes GIMP and blocks our release. Downgrading it on MSYS2 would leave some time to debug and fix the issue.

While everything was fine until today, we suddenly started experiencing crashes of GIMP inside libexiv2: https://gitlab.gnome.org/GNOME/gimp/-/jobs/5470854#L5037

Unfortunately this is blocking our development release which was planned today.
We will obviously look at it and work with Exiv2 developers to fix it, but could this be downgraded in the meantime please?

P.S.: I just did a simple revert. Maybe I need to bump `pkgrel` too? Should I leave the `anitya` ID which was added in the reverted commit?