### PR TITLE
gegl: build fixes for ffmpeg 8

### DIFF
--- a/mingw-w64-gegl/0002-ffmpeg8.patch
+++ b/mingw-w64-gegl/0002-ffmpeg8.patch
@@ -1,0 +1,20 @@
+--- gegl-0.4.62/operations/external/ff-load.c.orig	2025-08-31 22:28:31.950778300 +0200
++++ gegl-0.4.62/operations/external/ff-load.c	2025-08-31 22:33:55.397609700 +0200
+@@ -349,7 +349,7 @@
+   if (frame < 2 || frame > prevframe + 64 || frame < prevframe )
+   {
+     int64_t seek_target = av_rescale_q (((frame) * AV_TIME_BASE * 1.0) / o->frame_rate
+-, AV_TIME_BASE_Q, p->video_stream->time_base) / p->video_ctx->ticks_per_frame;
++, AV_TIME_BASE_Q, p->video_stream->time_base) / (p->video_ctx->codec_descriptor->props & AV_CODEC_PROP_FIELDS ? 2 : 1);
+ 
+     if (av_seek_frame (p->video_fcontext, p->video_index, seek_target, (AVSEEK_FLAG_BACKWARD )) < 0)
+       fprintf (stderr, "video seek error!\n");
+@@ -403,7 +403,7 @@
+                   break;
+                 }
+               got_picture = 1;
+-              if ((pkt.dts == pkt.pts) || (p->lavc_frame->key_frame!=0))
++              if ((pkt.dts == pkt.pts) || (p->lavc_frame->flags & AV_FRAME_FLAG_KEY))
+                 {
+                   // cur_dts and first_dts are moved to libavformat/internal.h
+                   /*

--- a/mingw-w64-gegl/PKGBUILD
+++ b/mingw-w64-gegl/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
 pkgver=0.4.62
-pkgrel=1
+pkgrel=2
 pkgdesc="Generic Graphics Library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -54,9 +54,11 @@ depends=("${MINGW_PACKAGE_PREFIX}-babl"
          $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-suitesparse"))
 noextract=("${_realname}-${pkgver}.tar.xz")
 source=(https://download.gimp.org/pub/gegl/${pkgver%.*}/${_realname}-${pkgver}.tar.xz
-        "0001-disable-codeview.patch")
+        "0001-disable-codeview.patch"
+        "0002-ffmpeg8.patch")
 sha256sums=('5887576371ebf1d9e90797d10e4b9a7f1658228d4827583e79e1db3d94505c6c'
-            'f1e5d02bb7e57ead285f3d9417670aafe664e766e20c24f40ee95e6e8f90d404')
+            'f1e5d02bb7e57ead285f3d9417670aafe664e766e20c24f40ee95e6e8f90d404'
+            '6826a769f73abfaa1eb4530cdb1d69d44704cf414d69a0e6700831ff1a662b5d')
 
 prepare() {
   tar -xf "${_realname}-${pkgver}.tar.xz" || true
@@ -64,6 +66,9 @@ prepare() {
 
   cd "${_realname}-${pkgver}"
   patch -p1 -i "${srcdir}/0001-disable-codeview.patch"
+
+  # https://gitlab.gnome.org/GNOME/gegl/-/issues/428
+  patch -p1 -i "${srcdir}/0002-ffmpeg8.patch"
 }
 
 build() {


### PR DESCRIPTION
Replace removed APIs with newer variants suggested in the deprecations:

* https://github.com/FFmpeg/FFmpeg/commit/7d1d61cc5f57708434ba720b03234b3dd93a4d1e
* https://github.com/FFmpeg/FFmpeg/commit/3e06f6f04020bef32fa42bc9d7f96e76a46453aa