### PR TITLE
opencv: fix ffmpeg 8 build

### DIFF
--- a/mingw-w64-opencv/PKGBUILD
+++ b/mingw-w64-opencv/PKGBUILD
@@ -7,7 +7,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=4.12.0
-pkgrel=3
+pkgrel=4
 pkgdesc="Open Source Computer Vision Library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -70,7 +70,8 @@ source=(https://github.com/opencv/opencv/archive/${pkgver}/${_realname}-${pkgver
         '0021-requires-vtk.patch'
         '0104-rgbd-module-missing-include.patch'
         '0106-use-find-package-with-hdf5.patch'
-        '0200-qt69-build-fix.patch')
+        '0200-qt69-build-fix.patch'
+        https://github.com/opencv/opencv/commit/90c444abd387ffa70b2e72a34922903a2f0f4f5a.patch)
 sha256sums=('44c106d5bb47efec04e531fd93008b3fcd1d27138985c5baf4eafac0e1ec9e9d'
             '4197722b4c5ed42b476d42e29beb29a52b6b25c34ec7b4d589c3ae5145fee98e'
             '42e7622b8863ded52c21f1bb57de62dd0089e057002cee1dee7f3064e3fdaea2'
@@ -81,7 +82,8 @@ sha256sums=('44c106d5bb47efec04e531fd93008b3fcd1d27138985c5baf4eafac0e1ec9e9d'
             'f572f94eb3e438eb1e0700ee04b9c999cd3216b39ba04321148137cecf6bbcb5'
             'c6c92cf39dfe45b8fb41d80ac0de3cd304e8b695420b307fd4320a105d8fe9f4'
             '01db42dc6fec466433ebe701be4fa21d5cb439cc156b04d969290a98e18f7467'
-            '7ec93b30b5790803c566790fc39d3177fd5947c1e82144e0d90762e7122ad893')
+            '7ec93b30b5790803c566790fc39d3177fd5947c1e82144e0d90762e7122ad893'
+            '4811cf490195a7b2952e075c4d713593326bc54fcfa42a33e19d7ed025bb5b6f')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -110,7 +112,8 @@ prepare() {
     0008-mingw-w64-cmake-lib-path.patch \
     0014-python-install-path.patch \
     0015-windres-cant-handle-spaces-in-defines.patch \
-    0021-requires-vtk.patch
+    0021-requires-vtk.patch \
+    90c444abd387ffa70b2e72a34922903a2f0f4f5a.patch
 
   # https://github.com/opencv/opencv/issues/27223
   apply_patch_with_msg \
@@ -179,7 +182,6 @@ build() {
     -DOPENCV_GENERATE_PKGCONFIG=ON \
     -DOPENCV_PYTHON_INSTALL_PATH=lib \
     -DOPENCV_SKIP_CMAKE_ROOT_CONFIG=ON \
-    -DOPENCV_FFMPEG_USE_FIND_PACKAGE=ON \
     -DOPENCV_FFMPEG_SKIP_DOWNLOAD=ON \
     -DOPENCV_FORCE_VTK=ON \
     -DOPENCV_DLLVERSION="" \
@@ -195,7 +197,7 @@ build() {
 
   ${MINGW_PREFIX}/bin/cmake --build .
 }
-
+ 
 package_opencv() {
   cd "${srcdir}/build-${MSYSTEM}"
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .


### PR DESCRIPTION
backport patch

Disable OPENCV_FFMPEG_USE_FIND_PACKAGE, it wasn't doing anything in CI as there is no cmake ffmpeg config. Locally it would pick some random qt6 script and just skip ffmpeg.