### PR TITLE
sequoia-sq: correct runtime dependencies

### DIFF
--- a/mingw-w64-sequoia-sq/PKGBUILD
+++ b/mingw-w64-sequoia-sq/PKGBUILD
@@ -4,7 +4,7 @@ _realname=sequoia-sq
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.3.1
-pkgrel=2
+pkgrel=3
 pkgdesc='Command-line frontends for Sequoia (mingw-w64)'
 url='https://sequoia-pgp.org/'
 msys2_repository_url='https://gitlab.com/sequoia-pgp/sequoia-sq'
@@ -12,14 +12,12 @@ arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
 license=('spdx:LGPL-2.0-or-later')
 depends=(
-  "${MINGW_PACKAGE_PREFIX}-bzip2"
   "${MINGW_PACKAGE_PREFIX}-gmp"
   "${MINGW_PACKAGE_PREFIX}-openssl"
   "${MINGW_PACKAGE_PREFIX}-sqlite3"
   "${MINGW_PACKAGE_PREFIX}-nettle"
 )
 makedepends=(
-  "${MINGW_PACKAGE_PREFIX}-bzip2"
   "${MINGW_PACKAGE_PREFIX}-capnproto"
   "${MINGW_PACKAGE_PREFIX}-rust"
   "${MINGW_PACKAGE_PREFIX}-cc"
@@ -47,6 +45,7 @@ build() {
   export CARGO_TARGET_DIR=../target
   export ASSET_OUT_DIR=../target
   export LIBCLANG_PATH="${MINGW_PREFIX}/bin"
+  export LIBSQLITE3_SYS_USE_PKG_CONFIG=1
   # NOTE: we select specific (default) features, as there are multiple crypto backends
   cargo build --release --frozen --features default
 }


### PR DESCRIPTION
- bzip2 is linked only when bzip2-sys is patched
- use an environment variable to link sqlite3