### PR TITLE
podman: update to 5.6.1

### DIFF
--- a/mingw-w64-podman/PKGBUILD
+++ b/mingw-w64-podman/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=podman
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=5.6.0
+pkgver=5.6.1
 pkgrel=1
 pkgdesc='Tool for running OCI-based containers in pods (mingw-w64)'
 arch=('any')
@@ -14,6 +14,7 @@ msys2_references=(
   "archlinux: podman"
   "cpe: cpe:/a:podman_project:podman"
   "gentoo: app-containers/podman"
+  "purl: pkg:golang/github.com/containers/podman/v5"
 )
 license=('spdx:Apache-2.0')
 makedepends=(
@@ -27,7 +28,7 @@ options=('!strip')
 _GV_VERSION="v0.8.6"  # See gvisor-tap-vsock in go.mod
 source=("https://github.com/containers/podman/archive/v$pkgver/${_realname}-${pkgver}.tar.gz"
         "https://github.com/containers/gvisor-tap-vsock/archive/${_GV_VERSION}/gvisor-tap-vsock-${_GV_VERSION#v}.tar.gz")
-sha256sums=('8d1cbab138506749c55bd0ca5a7e437ebdfc7f8c4eda100bf2642b2b231bbe1f'
+sha256sums=('e4fccc003dac77bae9127968c93388b6bf59d6b9ef8ffbdda21696613f729f3c'
             'eb08309d452823ca7e309da2f58c031bb42bb1b1f2f0bf09ca98b299e326b215')
 noextract=("${_realname}-${pkgver}.tar.gz")
 


### PR DESCRIPTION
This update addressed GHSA-wp3j-xq48-xpjw / CVE-2025-9566 in the podman package.