### PR TITLE
rio: update to 0.2.29

### DIFF
--- a/mingw-w64-rio/PKGBUILD
+++ b/mingw-w64-rio/PKGBUILD
@@ -2,17 +2,27 @@
 _realname=rio
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.2.27
+pkgver=0.2.29
 pkgrel=1
 pkgdesc="A hardware-accelerated GPU terminal emulator focusing to run in desktops and browsers (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://github.com/raphamorim/rio"
 license=('spdx:MIT')
+msys2_references=(
+  'archlinux: rio'
+  'aur: rio-git'
+  'purl: pkg:cargo/rioterm'
+  'purl: pkg:cargo/corcovado'
+  'purl: pkg:cargo/rio-backend'
+  'purl: pkg:cargo/rio-proc-macros'
+  'purl: pkg:cargo/rio-window'
+  'purl: pkg:cargo/sugarloaf'
+)
 depends=("${MINGW_PACKAGE_PREFIX}-cc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
 source=("https://github.com/raphamorim/${_realname}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('87d82f4fe3c4530252df9a2102e694ed953bc171ebb3b2b00bbdc849f874b94d')
+sha256sums=('2f6568bafc80c3b171e70098037469d567512281ba6e5b6bca17f53849cbaf99')
 
 prepare() {
   cd "${_realname}-${pkgver}"


### PR DESCRIPTION
Maybe I've overdone it a bit with the package URLs, but all of them are in the Git repository of rio, so it's probably not wrong to have them there.