### PR TITLE
New package: winpbcopy

### DIFF
--- a/mingw-w64-winpbcopy/PKGBUILD
+++ b/mingw-w64-winpbcopy/PKGBUILD
@@ -1,0 +1,46 @@
+# Maintainer: Andrew Udvare <audvare@gmail.com>
+
+_realname=winpbcopy
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.0.4
+pkgrel=1
+pkgdesc="pbcopy/paste for Windows."
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+provides=("${MINGW_PACKAGE_PREFIX}-pb"{copy,paste})
+msys2_references=()
+license=('spdx:MIT')
+url="https://github.com/Tatsh/winpbcopy"
+depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
+         "${MINGW_PACKAGE_PREFIX}-libwinpthread")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-cmocka"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
+source=("https://github.com/Tatsh/${_realname}/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('fce1e00655704b18ff3af77301656c135dae034b2a592f4d5e15a45b907d1971')
+
+build() {
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -G Ninja \
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+    -S "${_realname}-${pkgver}" \
+    -B "build-${MSYSTEM}"
+
+  cmake --build "build-${MSYSTEM}"
+}
+
+check() {
+  cmake -DBUILD_TESTS=ON -S ../${_realname}-${pkgver} -B "build-${MSYSTEM}" -DCMAKE_BUILD_TYPE=Debug
+  cmake --build "build-${MSYSTEM}-Debug" --config Debug
+  ctest --test-dir "build-${MSYSTEM}-Debug" --output-on-failure || true
+}
+
+package() {
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}/bin/cmake" --install "build-${MSYSTEM}" --config Release
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE.txt" \
+    "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.txt"
+}


### PR DESCRIPTION
Introducing my package winpbcopy to bring `pbcopy` and `pbpaste` commands to Windows.

`pbcopy` is virtually the same as `clip`, but there is no equivalent `paste` command officially. This package provides `pbpaste` to read the default `CF_TEXT` clipboard and print it to stdout.

Comes with man pages and a complete test suite.

I am used to typing `pbcopy` + `pbpaste` on Linux (where I have an alias) and macOS.
