### PR TITLE
python-hatch-fancy-pypi-readme: add MINGW32 arch

### DIFF
--- a/mingw-w64-python-hatch-fancy-pypi-readme/PKGBUILD
+++ b/mingw-w64-python-hatch-fancy-pypi-readme/PKGBUILD
@@ -4,10 +4,10 @@ _realname=hatch-fancy-pypi-readme
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=25.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Fancy PyPI READMEs with Hatch (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://github.com/hynek/hatch-fancy-pypi-readme'
 msys2_references=(
   'purl: pkg:pypi/hatch-fancy-pypi-readme'


### PR DESCRIPTION
The python-hatch-fancy-pypi-readme package is a build dependency of python-pytest-cov version 7.0.0, so it's required to build the new version of python-pytest-cov.

Also see <https://github.com/msys2/MINGW-packages/pull/25476>.