### PR TITLE
New package: winprefs

### DIFF
--- a/mingw-w64-winprefs/PKGBUILD
+++ b/mingw-w64-winprefs/PKGBUILD
@@ -1,0 +1,46 @@
+# Maintainer: Andrew Udvare <audvare@gmail.com>
+
+_realname=winprefs
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.4.0
+pkgrel=1
+pkgdesc="Tool to export registry paths to script and code formats (native component only)."
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-${_realname}w")
+msys2_references=()
+license=('spdx:MIT')
+url="https://github.com/Tatsh/winprefs"
+depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
+         "${MINGW_PACKAGE_PREFIX}-libwinpthread")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-cmocka"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
+source=("https://github.com/Tatsh/${_realname}/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('0e8a957c1f68fcf296943ec235ca198487e3f6010f06c55bd1274e612ad51b26')
+
+build() {
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -G Ninja \
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+    -S "${_realname}-${pkgver}" \
+    -B "build-${MSYSTEM}"
+
+  cmake --build "build-${MSYSTEM}"
+}
+
+check() {
+  cmake -DBUILD_TESTS=ON -S ../${_realname}-${pkgver} -B "build-${MSYSTEM}" -DCMAKE_BUILD_TYPE=Debug
+  cmake --build "build-${MSYSTEM}-Debug" --config Debug
+  ctest --test-dir "build-${MSYSTEM}-Debug" --output-on-failure || true
+}
+
+package() {
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}/bin/cmake" --install "build-${MSYSTEM}" --config Release
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE.txt" \
+    "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.txt"
+}


### PR DESCRIPTION
[winprefs](https://github.com/Tatsh/winprefs) is my utility to mass dump the registry to various formats usable in other code. Effectively it is a code snippet generator.

Interface:

```
Usage: winprefs.exe [OPTION...] [REG_PATH]

If a path to a value name is specified, the output directory argument is ignored and the line is printed to standard output.

Options:
  -F, --format=FORMAT Format to output. Options: c, cs, c#, ps, ps1, powershell, reg. Default: reg.
  -K, --deploy-key    Deploy key for committing.
  -c, --commit        Commit changes.
  -d, --debug         Enable debug logging.
  -f, --output-file   Output filename.
  -m, --max-depth=INT Set maximum depth.
  -o, --output-dir    Output directory.
  -h, --help          Display this help and exit.
```

Because this is a native app it is extremely fast. It does have a [PowerShell module](https://www.powershellgallery.com/packages/WinPrefs) but this only includes the native component.

`winprefs.exe` is the normal CLI version. `winprefsw.exe` accepts the same arguments but does not print to standard output, useful for automated tasks.

It can use Git to save changes, and even push when given a key.

Example output:

Default output to standard output with maximum depth 3:

```
$ winprefs -f - -m3
reg add "HKCU\AppEvents\Schemes" /ve /t REG_SZ /d ".Default" /f
reg add "HKCU\AppEvents\Schemes" /v "packagebase" /t REG_SZ /d "C:\WINDOWS\media" /f
reg add "HKCU\Console\%%%%Startup" /v "DelegationConsole" /t REG_SZ /d "{2EACA947-7F5F-4CFA-BA87-8F7FBEEFBE69}" /f
reg add "HKCU\Console\%%%%Startup" /v "DelegationTerminal" /t REG_SZ /d "{E12CFF52-A866-4C77-9A90-F570A7AA2C6B}" /f
...
```

C# output, custom path (even binary values are printed properly):

```
$ winprefs -f - -F cs -m3 'HKCU\System\GameConfigStore'
Registry.SetValue("HKEY_CURRENT_USER\\System\\GameConfigStore\\Children\\069e9773-6b7f-4613-b22a-447602fe702c", "Type", 1, RegistryValueKind.DWord);
Registry.SetValue("HKEY_CURRENT_USER\\System\\GameConfigStore\\Children\\069e9773-6b7f-4613-b22a-447602fe702c", "Revision", 2513, RegistryValueKind.DWord);
Registry.SetValue("HKEY_CURRENT_USER\\System\\GameConfigStore\\Children\\069e9773-6b7f-4613-b22a-447602fe702c", "Flags", 51, RegistryValueKind.DWord);
Registry.SetValue("HKEY_CURRENT_USER\\System\\GameConfigStore\\Children\\069e9773-6b7f-4613-b22a-447602fe702c", "Parent", { 0x01, 0x00, 0x00, 0x00, 0xd0, 0x8c, 0x9d, 0xdf, 0x01, 0x15, 0xd1, 0x11, 0x8c, 0x7a, 0x00, 0xc0, 0x4f, 0xc2, 0x97, 0xeb, 0x01, 0x00, 0x00, 0x00, 0xd6, 0x5c, 0xb9, 0x8a, 0x93, 0x3c, 0xb1, 0x44, 0x95, 0xea, 0x9c, 0x2d, 0xe8, 0xd8, 0x20, 0x9a, 0x04, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x66, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00, 0xae, 0xd4, 0xe3, 0xe7, 0x1a, 0x4d, 0xd5, 0xbc, 0x95, 0xe8, 0xe2, 0xff, 0xa2, 0xf9, 0x03, 0x01, 0x4a, 0xf4, 0x67, 0xdf, 0x34, 0xfb, 0x83, 0x2c, 0x86, 0xc8, 0x65, 0x7a, 0xac, 0x1e, 0x9a, 0xbe, 0x00, 0x00, 0x00, 0x00, 0x0e, 0x80, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00, 0x36, 0x47, 0xca, 0x5d, 0xeb, 0x14, 0x8b, 0x05, 0xec, 0x8d, 0x10, 0xc6, 0x27, 0xcd, 0xe4, 0x49, 0x0c, 0xb7, 0xbf, 0x44, 0x7a, 0x97, 0x08, 0xa9, 0xff, 0x24, 0x77, 0x62, 0x4e, 0xfa, 0x61, 0xfe, 0x20, 0x00, 0x00, 0x00, 0x03, 0xb0, 0xef, 0x6e, 0x6b, 0xfa, 0x2e, 0x9f, 0xb8, 0x89, 0x71, 0xe9, 0x22, 0x5e, 0x47, 0x6a, 0x35, 0x12, 0x9e, 0xd8, 0x86, 0x2d, 0xde, 0x59, 0x86, 0x71, 0xbe, 0x40, 0xfe, 0x7b, 0x4b, 0xeb, 0x40, 0x00, 0x00, 0x00, 0x2e, 0xa5, 0x4e, 0x9c, 0x67, 0x18, 0x00, 0x9e, 0x5b, 0xd4, 0x49, 0xbd, 0xe6, 0x97, 0x9b, 0x4a, 0xa5, 0x98, 0x6a, 0x4a, 0xf7, 0x99, 0x63, 0xe3, 0x95, 0x56, 0x29, 0xc7, 0xa1, 0xd9, 0xd4, 0xac, 0x30, 0x52, 0x32, 0xff, 0xdb, 0x5b, 0xee, 0x12, 0xd2, 0x98, 0xe9, 0xb7, 0xa6, 0xb7, 0x83, 0xaa, 0xb7, 0x3f, 0xa9, 0xc1, 0x55, 0x0d, 0x08, 0x53, 0xe2, 0x56, 0x13, 0x08, 0x4f, 0x41, 0xd2, 0x33 }, RegistryValueKind.Binary);
...
```

PowerShell output:

```
$ winprefs -f - -F powershell
if (!(Test-Path 'HKCU:\AppEvents\Schemes')) { New-Item -Path 'HKCU:\AppEvents\Schemes' -Force | Out-Null } New-ItemProperty -LiteralPath 'HKCU:\AppEvents\Schemes' -Name '(Default)' -PropertyType String -Force -Value '.Default'
if (!(Test-Path 'HKCU:\AppEvents\Schemes')) { New-Item -Path 'HKCU:\AppEvents\Schemes' -Force | Out-Null } New-ItemProperty -LiteralPath 'HKCU:\AppEvents\Schemes' -Name 'packagebase' -PropertyType String -Force -Value 'C:\WINDOWS\media'
...
```
