### PR TITLE
libidn2: remove unistring workaround

### DIFF
--- a/mingw-w64-libidn2/PKGBUILD
+++ b/mingw-w64-libidn2/PKGBUILD
@@ -6,7 +6,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _basever=2.3.8
 _subver=
 pkgver=${_basever}${_subver}
-pkgrel=2
+pkgrel=3
 pkgdesc="Implementation of the Stringprep, Punycode and IDNA specifications (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -33,9 +33,6 @@ prepare() {
 
   # https://gitlab.com/libidn/libidn2/-/issues/108
   AUTOPOINT=true autoreconf -ivf
-
-  # https://gitlab.com/libidn/libidn2/-/issues/126
-  touch unistring/unistr/unistring-notinline.h
 }
 
 build() {


### PR DESCRIPTION
it seems to build fine with the newest version