### PR TITLE
New package: kate-wakatime

### DIFF
--- a/mingw-w64-kate-wakatime/PKGBUILD
+++ b/mingw-w64-kate-wakatime/PKGBUILD
@@ -1,0 +1,61 @@
+# Maintainer: Andrew Udvare <audvare@gmail.com>
+
+source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks
+_realname=kate-wakatime
+pkgbase="mingw-w64-${_realname}"
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.5.3
+pkgrel=1
+pkgdesc="Kate plugin to interface with WakaTime."
+arch=('any')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
+msys2_repository_url="https://github.com/Tatsh/kate-wakatime"
+url="https://github.com/Tatsh/kate-wakatime"
+license=('spdx:MIT')
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-cc-libs"
+  "${MINGW_PACKAGE_PREFIX}-kcompletion"
+  "${MINGW_PACKAGE_PREFIX}-ki18n"
+  "${MINGW_PACKAGE_PREFIX}-kparts"
+  "${MINGW_PACKAGE_PREFIX}-ktexteditor"
+  "${MINGW_PACKAGE_PREFIX}-kwidgetsaddons"
+  "${MINGW_PACKAGE_PREFIX}-kxmlgui"
+  "${MINGW_PACKAGE_PREFIX}-qt6-base"
+  "${MINGW_PACKAGE_PREFIX}-wakatime"
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+  "${MINGW_PACKAGE_PREFIX}-extra-cmake-modules"
+  "${MINGW_PACKAGE_PREFIX}-ninja"
+  "${MINGW_PACKAGE_PREFIX}-qt6-declarative"
+  "${MINGW_PACKAGE_PREFIX}-qt6-tools"
+)
+source=("https://github.com/Tatsh/${_realname}/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('388ca44007dd909d222fe62567d34dced72724186d3103675df8f332f2875188')
+
+build() {
+  declare -a _extra_config
+  if check_option "debug" "n"; then
+    _extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    _extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  _kde_build_env
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    "${MINGW_PREFIX}"/bin/cmake.exe \
+      -GNinja \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      "${_KDE_INSTALL_DIRS[@]}" \
+      -DBUILD_TESTING=OFF \
+      "${_extra_config[@]}" \
+      -S "${_realname}-${pkgver}" \
+      -B "build-${MSYSTEM}"
+
+  "${MINGW_PREFIX}"/bin/cmake.exe --build "build-${MSYSTEM}"
+}
+
+package() {
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install "build-${MSYSTEM}"
+}


### PR DESCRIPTION
[kate-wakatime project](https://github.com/Tatsh/kate-wakatime)

[Linked as an official plugin](https://wakatime.com/kate)

This is my plugin for Kate to send statistics to [WakaTime](https://wakatime.com/) or any compatible host like self-hosted [Wakapi](https://github.com/muety/wakapi).

Related: https://github.com/Tatsh/kate-wakatime/issues/49
