### PR TITLE
tree-sitter (grammars): use correct source tarball

### DIFF
--- a/mingw-w64-tree-sitter-c/PKGBUILD
+++ b/mingw-w64-tree-sitter-c/PKGBUILD
@@ -4,7 +4,7 @@ _realname=tree-sitter-c
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.24.1
-pkgrel=1
+pkgrel=2
 pkgdesc='C grammar for tree-sitter (mingw-w64)'
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -19,12 +19,13 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cmake"
   "${MINGW_PACKAGE_PREFIX}-tree-sitter"
 )
-source=("https://github.com/tree-sitter/${_realname}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('25dd4bb3dec770769a407e0fc803f424ce02c494a56ce95fedc525316dcf9b48')
+source=("${_realname}-${pkgver}.tar.gz::${msys2_repository_url}/releases/download/v${pkgver}/${_realname}.tar.gz")
+sha256sums=('5a82a33dc5483f46d9a571f8ee769f6825752202cc2694299007a9da9417b9e5')
+noextract=("${_realname}-${pkgver}.tar.gz")
 
 prepare() {
-  cd "${_realname}-${pkgver}"
-  tree-sitter generate src/grammar.json
+  mkdir -p "${_realname}-${pkgver}"
+  tar -xf "${_realname}-${pkgver}.tar.gz" -C "${_realname}-${pkgver}" || true
 }
 
 build() {

--- a/mingw-w64-tree-sitter-lua/PKGBUILD
+++ b/mingw-w64-tree-sitter-lua/PKGBUILD
@@ -4,7 +4,7 @@ _realname=tree-sitter-lua
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.4.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Lua grammar for tree-sitter (mingw-w64)'
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -19,12 +19,13 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cmake"
   "${MINGW_PACKAGE_PREFIX}-tree-sitter"
 )
-source=("https://github.com/tree-sitter-grammars/${_realname}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('b0977aced4a63bb75f26725787e047b8f5f4a092712c840ea7070765d4049559')
+source=("${_realname}-${pkgver}.tar.gz::${msys2_repository_url}/releases/download/v${pkgver}/${_realname}.tar.gz")
+sha256sums=('e01fa3a1531f62be02d0c4c22b5b917eaeec7eb3dc15b562015bc1c60deeb8f2')
+noextract=("${_realname}-${pkgver}.tar.gz")
 
 prepare() {
-  cd "${_realname}-${pkgver}"
-  tree-sitter generate src/grammar.json
+  mkdir -p "${_realname}-${pkgver}"
+  tar -xf "${_realname}-${pkgver}.tar.gz" -C "${_realname}-${pkgver}" || true
 }
 
 build() {

--- a/mingw-w64-tree-sitter-vimdoc/PKGBUILD
+++ b/mingw-w64-tree-sitter-vimdoc/PKGBUILD
@@ -4,7 +4,7 @@ _realname=tree-sitter-vimdoc
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=4.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Vim help file grammar for tree-sitter (mingw-w64)'
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -18,12 +18,13 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cc"
   "${MINGW_PACKAGE_PREFIX}-tree-sitter"
 )
-source=("https://github.com/neovim/${_realname}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('8096794c0f090b2d74b7bff94548ac1be3285b929ec74f839bd9b3ff4f4c6a0b')
+source=("${_realname}-${pkgver}.tar.gz::${msys2_repository_url}/releases/download/v${pkgver}/${_realname}.tar.gz")
+sha256sums=('d4770d9843cac4664dbe6813d7ca7e2eccff8dfdc6be85a2d31d1590c5b17aee')
+noextract=("${_realname}-${pkgver}.tar.gz")
 
 prepare() {
-  cd "${_realname}-${pkgver}"
-  tree-sitter generate src/grammar.json
+  mkdir -p "${_realname}-${pkgver}"
+  tar -xf "${_realname}-${pkgver}.tar.gz" -C "${_realname}-${pkgver}" || true
 }
 
 build() {


### PR DESCRIPTION
as recommended in releases page: `NOTE: Download tree-sitter-${lang}.tar.gz for the complete source code.`