### PR TITLE
Build both shared and static versions of the abseil libraries.

### DIFF
--- a/mingw-w64-abseil-cpp/PKGBUILD
+++ b/mingw-w64-abseil-cpp/PKGBUILD
@@ -4,7 +4,7 @@ _realname=abseil-cpp
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=20250512.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Abseil Common Libraries (C++) from Google (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -81,11 +81,11 @@ build() {
 }
 
 package() {
+  cd "${srcdir}/build-static-${MSYSTEM}"
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
+
   cd "${srcdir}/build-shared-${MSYSTEM}"
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
   install -Dm644 "${srcdir}"/${_realname}-${pkgver}/LICENSE \
     "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
-
-  cd "${srcdir}/build-static-${MSYSTEM}"
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
 }

--- a/mingw-w64-abseil-cpp/PKGBUILD
+++ b/mingw-w64-abseil-cpp/PKGBUILD
@@ -46,7 +46,6 @@ prepare() {
 }
 
 build() {
-  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
   declare -a _extra_config
   if check_option "debug" "n"; then
@@ -55,6 +54,7 @@ build() {
     _extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
+  mkdir -p "${srcdir}/build-shared-${MSYSTEM}" && cd "${srcdir}/build-shared-${MSYSTEM}"
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake \
       -GNinja \
@@ -65,15 +65,27 @@ build() {
       -DABSL_PROPAGATE_CXX_STD=ON \
       -DCMAKE_CXX_STANDARD=17 \
       ../${_realname}-${pkgver}
+  ${MINGW_PREFIX}/bin/cmake --build .
 
+  mkdir -p "${srcdir}/build-static-${MSYSTEM}" && cd "${srcdir}/build-static-${MSYSTEM}"
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake \
+      -GNinja \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      "${_extra_config[@]}" \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DABSL_PROPAGATE_CXX_STD=ON \
+      -DCMAKE_CXX_STANDARD=17 \
+      ../${_realname}-${pkgver}
   ${MINGW_PREFIX}/bin/cmake --build .
 }
 
 package() {
-  cd "${srcdir}/build-${MSYSTEM}"
-
+  cd "${srcdir}/build-shared-${MSYSTEM}"
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
-
   install -Dm644 "${srcdir}"/${_realname}-${pkgver}/LICENSE \
     "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+
+  cd "${srcdir}/build-static-${MSYSTEM}"
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
 }


### PR DESCRIPTION
Previously, the package would contain only the dynamically linked version of the libraries. This changes the build script to build both dynamic and static libraries.

Fixes: #17852
