### PR TITLE
[protobuf] Path the pkg-config file to use the right flags for static libraries.

### DIFF
--- a/mingw-w64-abseil-cpp/PKGBUILD
+++ b/mingw-w64-abseil-cpp/PKGBUILD
@@ -4,7 +4,7 @@ _realname=abseil-cpp
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=20250512.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Abseil Common Libraries (C++) from Google (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -81,11 +81,11 @@ build() {
 }
 
 package() {
+  cd "${srcdir}/build-static-${MSYSTEM}"
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
+
   cd "${srcdir}/build-shared-${MSYSTEM}"
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
   install -Dm644 "${srcdir}"/${_realname}-${pkgver}/LICENSE \
     "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
-
-  cd "${srcdir}/build-static-${MSYSTEM}"
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
 }

--- a/mingw-w64-abseil-cpp/PKGBUILD
+++ b/mingw-w64-abseil-cpp/PKGBUILD
@@ -46,7 +46,6 @@ prepare() {
 }
 
 build() {
-  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
   declare -a _extra_config
   if check_option "debug" "n"; then
@@ -55,6 +54,7 @@ build() {
     _extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
+  mkdir -p "${srcdir}/build-shared-${MSYSTEM}" && cd "${srcdir}/build-shared-${MSYSTEM}"
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake \
       -GNinja \
@@ -65,15 +65,27 @@ build() {
       -DABSL_PROPAGATE_CXX_STD=ON \
       -DCMAKE_CXX_STANDARD=17 \
       ../${_realname}-${pkgver}
+  ${MINGW_PREFIX}/bin/cmake --build .
 
+  mkdir -p "${srcdir}/build-static-${MSYSTEM}" && cd "${srcdir}/build-static-${MSYSTEM}"
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake \
+      -GNinja \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      "${_extra_config[@]}" \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DABSL_PROPAGATE_CXX_STD=ON \
+      -DCMAKE_CXX_STANDARD=17 \
+      ../${_realname}-${pkgver}
   ${MINGW_PREFIX}/bin/cmake --build .
 }
 
 package() {
-  cd "${srcdir}/build-${MSYSTEM}"
-
+  cd "${srcdir}/build-shared-${MSYSTEM}"
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
-
   install -Dm644 "${srcdir}"/${_realname}-${pkgver}/LICENSE \
     "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+
+  cd "${srcdir}/build-static-${MSYSTEM}"
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
 }

--- a/mingw-w64-protobuf/0005-pkgconfig-that-understands-static-libraries.patch
+++ b/mingw-w64-protobuf/0005-pkgconfig-that-understands-static-libraries.patch
@@ -1,0 +1,20 @@
+diff -u -r a/cmake/protobuf-lite.pc.cmake b/cmake/protobuf-lite.pc.cmake
+--- a/cmake/protobuf-lite.pc.cmake	2025-05-28 18:52:59.000000000 +0200
++++ b/cmake/protobuf-lite.pc.cmake	2025-09-21 19:57:43.318803100 +0200
+@@ -9,4 +9,5 @@
+ Requires: @_protobuf_PC_REQUIRES@
+ Libs: -L${libdir} -lprotobuf-lite @CMAKE_THREAD_LIBS_INIT@
+ Cflags: -I${includedir} @_protobuf_PC_CFLAGS@
++Cflags.private: -UPROTOBUF_USE_DLLS
+ Conflicts: protobuf
+Only in b/cmake: protobuf-lite.pc.cmake~
+diff -u -r a/cmake/protobuf.pc.cmake b/cmake/protobuf.pc.cmake
+--- a/cmake/protobuf.pc.cmake	2025-05-28 18:52:59.000000000 +0200
++++ b/cmake/protobuf.pc.cmake	2025-09-21 19:57:28.771314100 +0200
+@@ -9,4 +9,5 @@
+ Requires: @_protobuf_PC_REQUIRES@
+ Libs: -L${libdir} -lprotobuf@protobuf_LIBRARY_POSTFIX@ @CMAKE_THREAD_LIBS_INIT@
+ Cflags: -I${includedir} @_protobuf_PC_CFLAGS@
++Cflags.private: -UPROTOBUF_USE_DLLS
+ Conflicts: protobuf-lite
+Only in b/cmake: protobuf.pc.cmake~

--- a/mingw-w64-protobuf/PKGBUILD
+++ b/mingw-w64-protobuf/PKGBUILD
@@ -28,12 +28,14 @@ source=(https://github.com/protocolbuffers/${_realname}/releases/download/v${pkg
         0001-fix-building-shared-libs-with-clang.patch
         0002-windres-invocation.patch
         0003-demote-error-about-buildtime-runtime-version-difference-to-warning.patch
-        0004-fix-build-with-gcc-15.patch)
+        0004-fix-build-with-gcc-15.patch
+	0005-pkgconfig-that-understands-static-libraries.patch)
 sha256sums=('12bfd76d27b9ac3d65c00966901609e020481b9474ef75c7ff4601ac06fa0b82'
             '0e8d4fcfad5bb0b635f1e1bbd2f4f85cb4d73b0a61fc33fae5136f062a40cfba'
             '174f714b842d5153c79c5fda1ae775ee002aea11d53cb5d5f51cb5c4b9e63d29'
             '2b680e1c642ccd5bb70b3dcf7217c27360bc0b74f63d8afb66dd668173d9b2dd'
-            'cb3594f1412422681768709c63139622b9f89c21f12b9bafa256ca44df8daa51')
+            'cb3594f1412422681768709c63139622b9f89c21f12b9bafa256ca44df8daa51'
+            'd118346d092caa8a3d6c02d88207d7cd9318fe3077b6b36cf32d1da79fe4128c')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -55,6 +57,9 @@ prepare() {
     apply_patch_with_msg \
       0004-fix-build-with-gcc-15.patch
   fi
+
+  apply_patch_with_msg \
+    0005-pkgconfig-that-understands-static-libraries.patch
 }
 
 build() {


### PR DESCRIPTION
Protobuf needs PROTOBUF_USE_DLLS set when it's compiled as a dynamic library, but not when it's compiled as a static library. The current PKGBUILD always installs the pkg-config file for the dynamic library configuration meaning that the flags are wrong when used as a static library and as a result linking fails.

This change rather crudely patches the pkg-config file so that it works properly with both. It's crude because .pc files don't really support this, meaning it's a bit hacky, but it does work. This really needs to be fixed properly upstream.

Fixes: #25629