### PR TITLE
new package: winloop

### DIFF
--- a/mingw-w64-python-winloop/PKGBUILD
+++ b/mingw-w64-python-winloop/PKGBUILD
@@ -1,0 +1,44 @@
+# Maintainer: Antoine Martin <antoine@xpra.org>
+
+_realname=winloop
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=0.2.2
+pkgrel=1
+pkgdesc="An alternative library for uvloop compatibility with MS Windows"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+msys2_references=(
+  'purl: pkg:pypi/winloop'
+)
+url="https://github.com/Vizonex/Winloop"
+license=('spdx:MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-libuv")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-cython"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('b967a8bcc45cb9a6845e5d4fc77a493b8b9928b44b9230ff336b9b10ae399132')
+
+build() {
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+check() {
+  cd "${srcdir}/python-build-${MSYSTEM}"
+  pytest -k 'not test_integration_with_listener_ipv6' tests || warning "Tests failed"
+}
+
+package() {
+  cd "${srcdir}/python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 README.md "${pkgdir}${MINGW_PREFIX}/share/doc/python-winloop/README.md"
+}


### PR DESCRIPTION
https://github.com/Vizonex/Winloop is _An Alternative library for uvloop compatibility with windows_ ...

It can be used by https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-python-xpra to speed up the QUIC transport.

Support for MSYS2 was added in this PR: https://github.com/Vizonex/Winloop/pull/65