### PR TITLE
aws-c-s3: update to 0.8.6

### DIFF
--- a/mingw-w64-aws-c-s3/PKGBUILD
+++ b/mingw-w64-aws-c-s3/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=aws-c-s3
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.8.3
+pkgver=0.8.6
 pkgrel=1
 pkgdesc='C99 library implementation for communicating with the S3 service, designed for maximizing throughput on high bandwidth EC2 instances (mingw-w64)'
 arch=('any')
@@ -20,7 +20,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 source=("https://github.com/awslabs/aws-c-s3/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('c1c233317927091ee966bb297db2e6adbb596d6e5f981dbc724b0831b7e8f07d')
+sha256sums=('583fb207c20a2e68a8e2990d62668b96c9662cf864f7c13c87d9ede09d61f8e5')
 
 build() {
   declare -a _extra_config


### PR DESCRIPTION
Updating to 0.8.7 fails locally with internal compiler error, and 0.9.0 does not compile, so it's only 0.8.6 for now.