### PR TITLE
golang: backport fix for cgo+clang21

### DIFF
--- a/mingw-w64-go/PKGBUILD
+++ b/mingw-w64-go/PKGBUILD
@@ -5,7 +5,7 @@ _realname=go
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.25.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Go Lang (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -22,9 +22,11 @@ depends=()
 makedepends=("${MINGW_PACKAGE_PREFIX}-${_realname}"
              "${MINGW_PACKAGE_PREFIX}-cc")
 options=('!strip')
-source=("https://go.dev/dl/go${pkgver}.src.tar.gz"{,.asc})
+source=("https://go.dev/dl/go${pkgver}.src.tar.gz"{,.asc}
+        'https://github.com/golang/go/commit/ea00650784bc2909580c7decf729f668349aa939.patch')
 sha256sums=('d010c109cee94d80efe681eab46bdea491ac906bf46583c32e9f0dbb0bd1a594'
-            'SKIP')
+            'SKIP'
+            '552128de5b73f495277df42de6895d9cbf14d6c8afe0db6658e1d136f1840960')
 validpgpkeys=('EB4C1BFD4F042F6DDDCCEC917721F63BD38B4796')
 noextract=(go${pkgver}.src.tar.gz)
 
@@ -40,6 +42,11 @@ apply_patch_with_msg() {
 
 prepare() {
   tar -xzf "${srcdir}"/go${pkgver}.src.tar.gz -C "${srcdir}" || true
+
+  cd "${_realname}"
+  # https://github.com/golang/go/issues/75219
+  apply_patch_with_msg \
+    ea00650784bc2909580c7decf729f668349aa939.patch
 }
 
 build() {


### PR DESCRIPTION
Fixes #25660