### PR TITLE
Reapply "lf: update to 38"

### DIFF
--- a/mingw-w64-lf/PKGBUILD
+++ b/mingw-w64-lf/PKGBUILD
@@ -5,7 +5,7 @@
 _realname=lf
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=37
+pkgver=38
 pkgrel=1
 pkgdesc='A terminal file manager inspired by ranger'
 arch=('any')
@@ -20,8 +20,8 @@ msys2_references=(
 license=('MIT')
 makedepends=('git' "${MINGW_PACKAGE_PREFIX}-go" "${MINGW_PACKAGE_PREFIX}-cc")
 source=("$pkgname::git+$url#tag=r$pkgver")
-sha512sums=('d98c8d7a17be0bac63548e9202bf8a59cd86a83331f63482e94690bf9ff54d4e16a113f6cfb0b4ef573987301eb16bceecb843afe24bed1624605ac4c0f58112')
-b2sums=('86605bf120de10a292638e2319802fd8e0ae98331e6f0029bfdfa70b7695dc5b7ce9e32ba26d854892ddd78e53ff56fd3e79232aa4dbb24cc3f088b02bc161ba')
+sha512sums=('f945054b40d6a522d4430eae24280acbb8c1185d2f063970fccc6f088757cf4052fc54945bf471979e3a86ef6cf3a9cd3a59a4c103c31f9388bc72a7020935e2')
+b2sums=('017317b995551f7db73cde99008453e278e615788f0b6000921a9965aed9e506c040c08b827908ccc44469330bbf4a7630bae9061a192849733ae4b52021e330')
 
 pkgver() {
   cd "$pkgname"


### PR DESCRIPTION
This reverts commit 68d0063f8d6e28a68fd6d30cb03b3ddbc68f0da4.
After <https://github.com/msys2/MINGW-packages/pull/25661> this should now also build on clangarm64 again.