### PR TITLE
emacs: use patch to update DLL names

### DIFF
--- a/mingw-w64-emacs/004-dll-versions.patch
+++ b/mingw-w64-emacs/004-dll-versions.patch
@@ -1,0 +1,20 @@
+--- emacs-30.2/lisp/term/w32-win.el.orig	2025-03-01 15:42:10.000000000 +0100
++++ emacs-30.2/lisp/term/w32-win.el	2025-09-23 17:33:55.923110200 +0200
+@@ -287,7 +287,7 @@
+        (if (>= libgnutls-version 30400)
+ 	   '(gnutls "libgnutls-30.dll")
+ 	 '(gnutls "libgnutls-28.dll" "libgnutls-26.dll"))
+-       '(libxml2 "libxml2-2.dll" "libxml2.dll")
++       '(libxml2 "libxml2-16.dll" "libxml2-2.dll" "libxml2.dll")
+        '(zlib "zlib1.dll" "libz-1.dll")
+        '(lcms2 "liblcms2-2.dll")
+        '(gccjit "libgccjit-0.dll")
+@@ -303,7 +303,7 @@
+            '(tree-sitter "libtree-sitter-0.24.dll"
+                          "libtree-sitter.dll"
+                          "libtree-sitter-0.dll")
+-         '(tree-sitter "libtree-sitter-0.25.dll"))))
++         '(tree-sitter "libtree-sitter-0.26.dll" "libtree-sitter-0.25.dll"))))
+ 
+ ;;; multi-tty support
+ (defvar w32-initialized nil

--- a/mingw-w64-emacs/PKGBUILD
+++ b/mingw-w64-emacs/PKGBUILD
@@ -8,7 +8,7 @@ _realname=emacs
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=30.2
-pkgrel=3
+pkgrel=4
 pkgdesc="The extensible, customizable, self-documenting, real-time display editor (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -46,6 +46,7 @@ source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.xz"{,.s
         "001-ucrt.patch"
         "002-clang-fixes.patch"
         "003-aarch64-fixes.patch"
+        "004-dll-versions.patch"
         "emacs-ARM64.manifest")
 # source=("https://alpha.gnu.org/gnu/${_realname}/pretest/${_realname}-${pkgver}.tar.xz"{,.sig})
 sha256sums=('b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9'
@@ -53,6 +54,7 @@ sha256sums=('b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9'
             '8093c4c6dc8006c11fd33a78c5aefcb2b5b1f05e5afb9bd3da7d5b146dfc112c'
             'd8732584a8f3bfd0badbd16d15384b7098e25c5df48632beb02d35f6050c358b'
             'd128982d87af1e524ae809147613168153f0e5c1efb0ef633793df47b762c9e1'
+            '1fcba307b278a7794ecca4f09e7ce1a715b4ee255badd3fa376ca1ef1aa7246f'
             'bfe64602dbeeec85799c1156ca4f3837fdac42a076e83a4221768db3417220e1')
 validpgpkeys=('28D3BED851FDF3AB57FEF93C233587A47C207910'
               '17E90D521672C04631B1183EE78DAE0F3115E06B'
@@ -67,14 +69,13 @@ prepare() {
   patch -Np1 -i "${srcdir}/001-ucrt.patch"
   patch -Np1 -i "${srcdir}/002-clang-fixes.patch"
   patch -Np1 -i "${srcdir}/003-aarch64-fixes.patch"
+  patch -Np1 -i "${srcdir}/004-dll-versions.patch"
 
-  # we likely have DLL with soversion
-  # otherwise there will be a message about missing dll
-  # TODO: in future updates workaround should be applied for lisp/term/w32-nt.el
+  # Fail if 004-dll-versions.patch needs to be updated
   _dllname_xml=$(dlltool --identify "${MINGW_PREFIX}/lib/libxml2.dll.a")
   _dllname_tree_sitter=$(dlltool --identify "${MINGW_PREFIX}/lib/libtree-sitter.dll.a")
-  sed -i -E "s/\(libxml2(.+)\)/(libxml2\1 \"$_dllname_xml\")/" lisp/term/w32-win.el
-  sed -i -E "s/\(libtree-sitter(.+)\)/(libtree-sitter\1 \"$_dllname_tree_sitter\")/" lisp/term/w32-win.el
+  grep -Fq "$_dllname_xml" lisp/term/w32-win.el || { echo "$_dllname_xml not found" >&2; return 1; }
+  grep -Fq "$_dllname_tree_sitter" lisp/term/w32-win.el || { echo "$_dllname_tree_sitter not found" >&2; return 1; }
 
   ./autogen.sh
 }


### PR DESCRIPTION
And use "dlltool --identify" to get the real names and fail if it needs to be updated.

So we get an error if the patch no longer applies, and if the DLL names change.

Fixes #25668
Fixes #25667