### PR TITLE
add winloop as optional dependency

### DIFF
--- a/mingw-w64-python-xpra/PKGBUILD
+++ b/mingw-w64-python-xpra/PKGBUILD
@@ -46,6 +46,7 @@ optdepends=(
     "${MINGW_PACKAGE_PREFIX}-python-ldap3: LDAP authentication via python-ldap3"
     "${MINGW_PACKAGE_PREFIX}-python-cryptography: AES packet encryption"
     "${MINGW_PACKAGE_PREFIX}-python-aioquic: QUIC transport"
+    "${MINGW_PACKAGE_PREFIX}-python-winloop: faster loop for QUIC transport"
     "${MINGW_PACKAGE_PREFIX}-python-zeroconf: mDNS support"
     "${MINGW_PACKAGE_PREFIX}-python-nvidia-ml: nvidia GPU support"
     "${MINGW_PACKAGE_PREFIX}-python-pyopengl-accelerate: OpenGL-accelerate support")


### PR DESCRIPTION
Now that the winloop builds are available in the repositories: https://github.com/msys2/MINGW-packages/pull/25643
Add a soft dependency so xpra users can learn about it.