### PR TITLE
[new package] cargo-msrv 0.18.4

### DIFF
--- a/mingw-w64-cargo-msrv/PKGBUILD
+++ b/mingw-w64-cargo-msrv/PKGBUILD
@@ -1,0 +1,53 @@
+# Maintainer: Maksim Bondarenkov <maksapple2306@gmail.com>
+
+_realname=cargo-msrv
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.18.4
+pkgrel=1
+pkgdesc="Find the minimum supported Rust version (MSRV) for your project (mingw-w64)"
+arch=('any')
+mingw_arch=('ucrt64') # 'clang64' 'clangarm64') # add when we have stable *-windows-gnullvm toolchains
+url='https://github.com/foresterre/cargo-msrv'
+license=('spdx:Apache-2.0 OR MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-rustup")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-nasm"
+             "${MINGW_PACKAGE_PREFIX}-rust-bindgen")
+source=("${url}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('9e8d743a9948ec91e4d82ce34b8f0f9e65385ed78739cb36376f65049d8b8da5')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+
+  # have to specify target otherwise MSVC tooclhain is used
+  export RUSTUP_TOOLCHAIN=stable-${CARCH}-pc-windows-gnu
+  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+}
+
+build() {
+  cd "${_realname}-${pkgver}"
+
+  export RUSTUP_TOOLCHAIN=stable-${CARCH}-pc-windows-gnu
+  cargo build --release --frozen
+}
+
+check() {
+  cd "${_realname}-${pkgver}"
+
+  cargo test --release --frozen
+}
+
+package() {
+  cd "${_realname}-${pkgver}"
+
+  cargo install \
+    --offline \
+    --no-track \
+    --frozen \
+    --path . \
+    --root "${pkgdir}${MINGW_PREFIX}"
+
+  install -Dm644 LICENSE-{APACHE,MIT} -t "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/"
+}


### PR DESCRIPTION
currently UCRT64 only, CLANG* will be enabled after Rust 1.91.0 release which will have stable *-pc-windows-gnullvm toolchain. actually it still will be useless, because there would be no other stable releases for them...