### PR TITLE
Update v8 and fix static build

### DIFF
--- a/mingw-w64-v8/014-heap-use-proper-sources.patch
+++ b/mingw-w64-v8/014-heap-use-proper-sources.patch
@@ -53,9 +53,9 @@ index 554caddf..61c3e2f7 100644
  
  asm(
  #ifdef __APPLE__
-@@ -64,3 +104,5 @@ asm(
+@@ -71,3 +111,5 @@ asm(
      ".Lfunc_end0-PushAllRegistersAndIterateStack        \n"
  #endif  // !defined(__APPLE__)
-     );
+     ".cfi_endproc                                      \n");
 +
 +#endif // !_WIN64

--- a/mingw-w64-v8/015-abseil-build-as-static-lib.patch
+++ b/mingw-w64-v8/015-abseil-build-as-static-lib.patch
@@ -1,8 +1,8 @@
 diff --git a/BUILD.gn b/BUILD.gn
-index f227c834..9f3b4a60 100644
+index 0df9c0a5..9f3b4a60 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -16,39 +16,8 @@ config("absl_component_build") {
+@@ -16,48 +16,8 @@ config("absl_component_build") {
    defines = [ "ABSL_CONSUME_DLL" ]
  }
  
@@ -40,9 +40,19 @@ index f227c834..9f3b4a60 100644
 -      }
 -    }
 -  }
+-  if (is_win) {
+-    all_dependent_configs = [ "//tools/win/DebugVisualizers:absl" ]
+-    inputs = [
+-      # absl.natvis listed as an input here instead of in
+-      # //tools/win/DebugVisualizers:absl to prevent unnecessary size increase
+-      # in generated build files.
+-      "//tools/win/DebugVisualizers/absl.natvis",
+-    ]
+-  }
  }
  
  group("absl_component_deps") {
+
 diff --git a/absl.gni b/absl.gni
 index 48e1ce78..a4721461 100644
 --- a/absl.gni
@@ -65,7 +75,7 @@ index 98e75941..c4aa2f85 100644
      "//third_party/abseil-cpp/absl/meta:type_traits",
    ]
 +  if (is_mingw) {
-+    libs = [ ":libpthread.a" ]
++    libs = [ "pthread" ]
 +  }
  }
  

--- a/mingw-w64-v8/PKGBUILD
+++ b/mingw-w64-v8/PKGBUILD
@@ -1,10 +1,11 @@
 # Maintainer: Rodrigo Hernandez <kwizatz@aeongames.com>
 # Contributor: Raed Rizqie <raed.rizqie@gmail.com>
 
+# Prefer V8 versions from Chrome stable: https://chromiumdash.appspot.com/releases?platform=Windows
 _realname=v8
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=14.0.210
+pkgver=14.1.146.11
 pkgrel=1
 pkgdesc="Fast and modern Javascript engine (mingw-w64)"
 arch=('any')
@@ -26,7 +27,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 source=("https://github.com/v8/v8/archive/refs/tags/${pkgver}.tar.gz"
         "bare-clones/build::git+https://chromium.googlesource.com/chromium/src/build.git#commit=cb592905b1f94a0c315dccb59939f91ef869592c"
         "bare-clones/clang::git+https://chromium.googlesource.com/chromium/src/tools/clang.git#commit=d6072980974f9a4922d2eb27e4fd244ca3017031"
-        "bare-clones/abseil-cpp::git+https://chromium.googlesource.com/chromium/src/third_party/abseil-cpp.git#commit=cae4b6a3990e1431caa09c7b2ed1c76d0dfeab17"
+        "bare-clones/abseil-cpp::git+https://chromium.googlesource.com/chromium/src/third_party/abseil-cpp.git#commit=5141e83267542f8869adf18b5bd6440440d6801e"
         "bare-clones/dragonbox::git+https://chromium.googlesource.com/external/github.com/jk-jeon/dragonbox.git#commit=6c7c925b571d54486b9ffae8d9d18a822801cbda"
         "bare-clones/fast_float::git+https://chromium.googlesource.com/external/github.com/fastfloat/fast_float.git#commit=cb1d42aaa1e14b09e1452cfdef373d051b8c02a4"
         "bare-clones/fp16::git+https://chromium.googlesource.com/external/github.com/Maratyszcza/FP16.git#commit=0a92994d729ff76a58f692d3028ca1b64b145d91"
@@ -57,10 +58,10 @@ source=("https://github.com/v8/v8/archive/refs/tags/${pkgver}.tar.gz"
         "v8_libbase.pc"
         "v8_libplatform.pc"
         "v8.pc")
-sha256sums=('a8d553be4130bc5e95e4bb7635958e8f79ecd34aef32de23d3bd7db0b3203760'
+sha256sums=('5e776e074ac4ca8f7e7bae921ff0d7333b1ec394a637b3716bc4613b8cb5b350'
             '5eb934ca43dfaccad43358820d8a84f1b8229d6330d2e0db1e827081b6858b99'
             'f58b2605f036b8c9c7992635ad5f2070abe4d527314915874766d654ae4eb429'
-            '812f67ab2c4269b101df3af90a452867398a668b46c4997cbbde4fffe6c5cbfa'
+            'f414ee2585cf1f418c8e9aa37642bf682608687923220d39379c1565fb14597b'
             '7a6c373f8694e540f5a767b315670ccef5526baa41f5427f02db2e4bf261765c'
             'be05ebb53b7468e246aac2a22d1ce748c25e2e0cc5d0227e16272a00827092ff'
             '5d0c4f261d36707f926fa9ef9a39349f1cccac8ae6443a8f8571c1625eb90c41'
@@ -83,8 +84,8 @@ sha256sums=('a8d553be4130bc5e95e4bb7635958e8f79ecd34aef32de23d3bd7db0b3203760'
             '1ef6854b6a68101ab177a7a95389e9b03e7b8c4e3223320dfc9ce4405cbf5bfe'
             '1d03e6c517528a31f6ff38d251b011e34a667f0b60968817b573677501dc20c1'
             '37a29668fb02d4fa60062c02f0d24dce4ab9b7fce4d7f5a8e6eca745fa125be2'
-            '5b1c2a1c4faefdbb918640b394a100b08c5b9940547d4ce5a04b8d9dc40559a7'
-            '7e3555a4128d8b69cd9733b14b114d27063667ae0687b693c51fd1881f847e93'
+            '99599bd2b3e12844c5fac3c7b1d80f37e17453230eeac5e8e10d2f920f20c6a8'
+            '7406684a272b853f671df119ecc802df35945e437e0e3a418a6005356c72dd4b'
             'a4275f41723cc990f2f43559ce716100830a8ce3f38e4878f6bf36d70d47b646'
             'e1bc88af48143f29f5805b8ac5d77addef1b09318d1f5f127a9281872c00303b'
             '7e1e39a3dc69632f7bf9182c92405186ce709aca921cf0abefadb6fa8b825510'


### PR DESCRIPTION
Note I have removed the forced static linking to `:libpthread.a"` in abseil because this causes applications to crash.

What happens is that by forcing a static copy of libpthreads to be embedded in libv8, and the application using libv8 also needing to link pthreads, we end up with two versions of libpthreads in the same application. These can conflict. Because libpthreads is part of the toolchain it should be linked by the final application and not be embedded in another library.