### PR TITLE
Groonga: Update to 15.1.7

### DIFF
--- a/mingw-w64-groonga/PKGBUILD
+++ b/mingw-w64-groonga/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=groonga
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=15.1.5
-pkgrel=2
+pkgver=15.1.7
+pkgrel=1
 pkgdesc="An opensource fulltext search engine (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -30,7 +30,7 @@ makedepends=("git"
              "${MINGW_PACKAGE_PREFIX}-rapidjson"
              "${MINGW_PACKAGE_PREFIX}-ruby"
              "${MINGW_PACKAGE_PREFIX}-xsimd")
-sha256sums=('7513bd4014022152651613598d5670a221087ac201ae46563523b0ce090e9e46'
+sha256sums=('899a414a0636f7568d1a11845fe3dd75b701f72106a7a26f30bc950af5876616'
             'SKIP'
             '5fbb336487a6522e2f7bff01ea3cdd714d4c27de3cc65d5a6ecb2eedeb6fc2c4'
             '823f83e2043fc4b98c5971a12a65c1c4cb472b49b0e812052746aa591b7cdf44')


### PR DESCRIPTION
Groonga version15.1.7 has just released [here](https://github.com/groonga/groonga/releases/tag/v15.1.7).