### PR TITLE
libxml2: remove DllMain from the import lib

### DIFF
--- a/mingw-w64-libxml2/PKGBUILD
+++ b/mingw-w64-libxml2/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
 pkgver=2.14.6
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 pkgdesc="XML parsing library, version 2 (mingw-w64)"
@@ -15,6 +15,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-libiconv"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-tools"
              "${MINGW_PACKAGE_PREFIX}-python")
 optdepends=("${MINGW_PACKAGE_PREFIX}-python: Python bindings")
 license=('spdx:MIT')
@@ -133,6 +134,14 @@ package_libxml2() {
   local PREFIX_DEPS=$(cygpath -am ${MINGW_PREFIX})
   sed -s "s|${PREFIX_DEPS}\/lib|\${libdir}|g" -i "${pkgdir}"${MINGW_PREFIX}/bin/xml2-config
   sed -s "s|${PREFIX_DEPS}\/lib|\${libdir}|g" -i "${pkgdir}"${MINGW_PREFIX}/lib/pkgconfig/libxml-2.0.pc
+
+  # Strip DllMain from import library until all reverse dependencies are fixed
+  # https://github.com/msys2/MINGW-packages/issues/25716
+  _imp_lib="${pkgdir}${MINGW_PREFIX}/lib/libxml2.dll.a"
+  _dll_name=$(dlltool --identify "${_imp_lib}")
+  gendef - "${pkgdir}${MINGW_PREFIX}/bin/${_dll_name}" > orig.def
+  grep -Ev 'DllMain' orig.def > stripped.def
+  dlltool -d stripped.def -D "${_dll_name}" -l "${_imp_lib}"
 
   mkdir -p dest${MINGW_PREFIX}/share
   mv "${pkgdir}${MINGW_PREFIX}"/share/{doc,gtk-doc} dest${MINGW_PREFIX}/share


### PR DESCRIPTION
Next steps:

* rebuild all reverse deps
* remove the DllMain export also in the DLL

See #25716