### PR TITLE
pgmodeler: link against import libs

### DIFF
--- a/mingw-w64-pgmodeler/PKGBUILD
+++ b/mingw-w64-pgmodeler/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-plugins")
 pkgver=1.2.1
 _plugsha=a7baf113deec9888f22fc91ffca740562a02ae57
-pkgrel=2
+pkgrel=3
 pkgdesc="PostgreSQL Database Modeler: an open source CASE tool for modeling PostgreSQL databases (mingw-w64)"
 url="https://pgmodeler.io"
 msys2_repository_url="https://github.com/pgmodeler/pgmodeler"
@@ -60,10 +60,10 @@ package_pgmodeler() {
           LANGDIR="${pkgdir}${MINGW_PREFIX}"/share/pgmodeler/lang \
           SAMPLESDIR="${pkgdir}${MINGW_PREFIX}"/share/pgmodeler/samples \
           SCHEMASDIR="${pkgdir}${MINGW_PREFIX}"/share/pgmodeler/schemas \
-          PGSQL_LIB="${MINGW_PREFIX}"/bin/libpq.dll \
+          PGSQL_LIB="${MINGW_PREFIX}"/lib/libpq.dll.a \
           PGSQL_INC="${MINGW_PREFIX}"/include \
           XML_INC="${MINGW_PREFIX}"/include/libxml2 \
-          XML_LIB="${MINGW_PREFIX}"/bin/libxml2-16.dll \
+          XML_LIB="${MINGW_PREFIX}"/lib/libxml2.dll.a \
           NO_UPDATE_CHECK=MSYS2doesthis \
           QMAKE_CXXFLAGS_RELEASE+="${CXXFLAGS} ${CPPFLAGS}" \
           pgmodeler.pro


### PR DESCRIPTION
It was linking against the libxml2 dll directly which breaks our current hack to remove DLLMain from the imports.

Adjust to use import libs.