### PR TITLE
croc: new package

### DIFF
--- a/mingw-w64-croc/PKGBUILD
+++ b/mingw-w64-croc/PKGBUILD
@@ -1,0 +1,62 @@
+# Contributor: Dirk Stolle
+
+_realname=croc
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=10.2.5
+pkgrel=1
+pkgdesc='Easily and securely send things from one computer to another.'
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/schollz/croc'
+msys2_references=(
+  'anitya: 350834'
+  'archlinux: croc'
+  'gentoo: net-misc/croc'
+  'purl: pkg:golang/github.com/schollz/croc/v10'
+)
+license=('MIT')
+makedepends=("${MINGW_PACKAGE_PREFIX}-go" "${MINGW_PACKAGE_PREFIX}-cc")
+options=(!strip)
+source=("$pkgname-v$pkgver.tar.gz::$url/releases/download/v$pkgver/${_realname}_v${pkgver}_src.tar.gz")
+sha256sums=('505969cd4c9f9deba3e81525e324b6575735fc8fd48398e2d07cd78c908914bf')
+
+build() {
+  cd "${_realname}-v${pkgver}"
+
+  # set Go flags
+  export CC=cc
+  export GOOS=windows
+  export GOROOT=${MINGW_PREFIX}/lib/go
+  export CGO_CPPFLAGS="${CPPFLAGS}"
+  export CGO_CFLAGS="${CFLAGS}"
+  export CGO_CXXFLAGS="${CXXFLAGS}"
+  export CGO_LDFLAGS="${LDFLAGS}"
+  export GOFLAGS='-trimpath -ldflags=-linkmode=external -mod=vendor -modcacherw -buildvcs=false'
+  case "${CARCH}" in
+    i686|x86_64)
+      GOFLAGS+=" -buildmode=pie"
+      ;;
+  esac
+
+  go build -v \
+    -ldflags "${GO_LDFLAGS}" \
+    -o croc.exe \
+    .
+}
+
+check() {
+  cd "${_realname}-v${pkgver}"
+
+  go test -v ./...
+}
+
+package() {
+  cd "${_realname}-v${pkgver}"
+
+  # binary
+  install -Dm755 -t "$pkgdir/${MINGW_PREFIX}/bin" croc.exe
+
+  # license
+  install -Dm644 -t "$pkgdir/${MINGW_PREFIX}/share/licenses/$_realname/" LICENSE
+}

--- a/mingw-w64-croc/PKGBUILD
+++ b/mingw-w64-croc/PKGBUILD
@@ -17,7 +17,6 @@ msys2_references=(
 )
 license=('MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-go" "${MINGW_PACKAGE_PREFIX}-cc")
-options=(!strip)
 source=("$pkgname-v$pkgver.tar.gz::$url/releases/download/v$pkgver/${_realname}_v${pkgver}_src.tar.gz")
 sha256sums=('505969cd4c9f9deba3e81525e324b6575735fc8fd48398e2d07cd78c908914bf')
 
@@ -40,7 +39,6 @@ build() {
   esac
 
   go build -v \
-    -ldflags "${GO_LDFLAGS}" \
     -o croc.exe \
     .
 }


### PR DESCRIPTION
croc is a command-line tool to enable easy file transfer from one computer to another.
It's packaged in
* [Arch Linux](https://archlinux.org/packages/extra/x86_64/croc/)
* [Gentoo](https://packages.gentoo.org/packages/net-misc/croc)
* [T2 SDE](https://t2linux.com/packages/croc)
* [Void Linux](https://github.com/void-linux/void-packages/blob/c5f6c4638e7bb6695c637ea8f0bf0b3a200cf4c9/srcpkgs/croc/template)

... and a few others.