### PR TITLE
pdal: update to 2.9.2

### DIFF
--- a/mingw-w64-pdal/PKGBUILD
+++ b/mingw-w64-pdal/PKGBUILD
@@ -3,15 +3,17 @@
 _realname=pdal
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.9.0
-pkgrel=4
+pkgver=2.9.2
+pkgrel=1
 pkgdesc="A C++ library for translating and manipulating point cloud data (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://www.pdal.io"
 msys2_repository_url="https://github.com/PDAL/PDAL"
 msys2_references=(
+  'anitya: 138228'
   'archlinux: pdal'
+  'gentoo: sci-libs/pdal'
 )
 license=('spdx:BSD-3-Clause')
 depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
@@ -37,7 +39,7 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-draco: Draco plugin, Read data in the draco
             "${MINGW_PACKAGE_PREFIX}-postgresql: PostgreSQL PointCloud plugin, read/write PostgreSQL PointCloud objects"
             "${MINGW_PACKAGE_PREFIX}-tiledb: TileDB plugin, read/write data from TileDB")
 source=("https://github.com/PDAL/PDAL/releases/download/${pkgver}/PDAL-${pkgver}-src.tar.bz2")
-sha256sums=('f0be2f6575021d0c4751d5babd4c1096d4e5934f86f8461914e9f9c6dc63567d')
+sha256sums=('a74bbc7f4e4f709ed589dbbb851926a63c391c974e3fc40a4c3ff34f7923021b')
 
 build() {
   mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}


### PR DESCRIPTION
Will probably need rebuilds for qgis and vtk.

Edit: package-grokker does not list any packages for rebuild - a surprise, but I'm not complaining.