### PR TITLE
python-django: update to 5.2.7

### DIFF
--- a/mingw-w64-python-django/PKGBUILD
+++ b/mingw-w64-python-django/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=django
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=5.2.6
+pkgver=5.2.7
 pkgrel=1
 pkgdesc="A high-level Python Web framework that encourages rapid development and clean design (mingw-w64)"
 arch=('any')
@@ -31,7 +31,7 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-python-bcrypt: for bcrypt support"
 options=('!strip')
 source=(#"Django-${pkgver}.tar.gz"::"https://www.djangoproject.com/download/${pkgver}/tarball/"
         https://github.com/django/django/archive/${pkgver}/${_realname}-${pkgver}.tar.gz)
-sha512sums=('371925672a13af3b3897e742f1279c0dc863c9640541561e967fb6aa5e58447465afb647710686e9dd5d5c50182759845aeb261f7614077aa39c870c0a7e918a')
+sha512sums=('55e37326bc92519ef86f0566855097c5cb6190cd29b627cccb42d1c897fcae8774bd14814e810956f8521211cabe91baf954ad63fb8993e615ee0f6dc1742eb7')
 noextract=(${_realname}-${pkgver}.tar.gz)
 
 prepare() {


### PR DESCRIPTION
See <https://www.djangoproject.com/weblog/2025/oct/01/security-releases/> (contains fixes for CVE-2025-59681 + CVE-2025-59682).