### PR TITLE
uutils-coreutils: Avoid building twice

### DIFF
--- a/mingw-w64-uutils-coreutils/PKGBUILD
+++ b/mingw-w64-uutils-coreutils/PKGBUILD
@@ -26,14 +26,9 @@ prepare() {
   cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
 }
 
-build() {
-  cd "${_realname}-${pkgver}"
-
-  export RUSTONIG_DYNAMIC_LIBONIG=1
-  export RUSTFLAGS="${RUSTFLAGS/+crt-static/-crt-static}"
-  make PROFILE=release SKIP_UTILS='stty'
-}
-
+export RUSTONIG_DYNAMIC_LIBONIG=1
+export RUSTFLAGS="${RUSTFLAGS/+crt-static/-crt-static}"
+# spliting build() sometimes cause building twice at make build
 package() {
   cd "${_realname}-${pkgver}"
 


### PR DESCRIPTION
Spliting build() sometimes cause building twice at make build.
Arch dropped `build()` even it is part packaging guideline.

(`cargo` only install is needed for proper packaging guideline.)