### PR TITLE
uutils-coreutils: try to remove stty workaround

### DIFF
--- a/mingw-w64-uutils-coreutils/PKGBUILD
+++ b/mingw-w64-uutils-coreutils/PKGBUILD
@@ -5,7 +5,7 @@ _realname=coreutils
 pkgbase=mingw-w64-uutils-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-uutils-${_realname}")
 pkgver=0.2.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Cross-platform Rust rewrite of the GNU coreutils (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -35,7 +35,7 @@ package() {
   make install \
     DESTDIR="${pkgdir}" \
     PREFIX="${MINGW_PREFIX}" \
-    SKIP_UTILS='stty' \
+    OS=Windows_NT \
     PROG_PREFIX=uu- \
     PROFILE=release
 


### PR DESCRIPTION
it seems that OS detection is broken in upstream Makefile, so hardcode OS=Windows_NT