### PR TITLE
uutils-coreutils: MULTICALL=y and drop SELinux stubs

### DIFF
--- a/mingw-w64-uutils-coreutils/PKGBUILD
+++ b/mingw-w64-uutils-coreutils/PKGBUILD
@@ -18,7 +18,7 @@ msys2_references=(
 license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-oniguruma" "${MINGW_PACKAGE_PREFIX}-cc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust" "${MINGW_PACKAGE_PREFIX}-pkgconf")
-source=("${url}/archive/${_commit}.tar.zst")
+source=("${url}/archive/${_commit}.tar.gz")
 #source=("${url}/archive/${pkgver}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('469cd4c306fe12c1d72f7858f3e68ee21899f54947e62a5a4bffe17f22a3d221 ')
 

--- a/mingw-w64-uutils-coreutils/PKGBUILD
+++ b/mingw-w64-uutils-coreutils/PKGBUILD
@@ -4,7 +4,8 @@
 _realname=coreutils
 pkgbase=mingw-w64-uutils-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-uutils-${_realname}")
-pkgver=0.2.2
+_commit=8b6613782b15607d4f302bddf55a57f84db4a9ad # supporting make LN= for hardlink
+pkgver=0.2.2.g$_commit
 pkgrel=1
 pkgdesc="Cross-platform Rust rewrite of the GNU coreutils (mingw-w64)"
 arch=('any')
@@ -17,27 +18,32 @@ msys2_references=(
 license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-oniguruma" "${MINGW_PACKAGE_PREFIX}-cc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust" "${MINGW_PACKAGE_PREFIX}-pkgconf")
-source=("https://github.com/uutils/coreutils/archive/${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('4a847a3aaf241d11f07fdc04ef36d73c722759675858665bc17e94f56c4fbfb3')
+source=("${url}/archive/${_commit}.tar.zst")
+#source=("${url}/archive/${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('469cd4c306fe12c1d72f7858f3e68ee21899f54947e62a5a4bffe17f22a3d221 ')
 
 prepare() {
-  cd "${_realname}-${pkgver}"
-
+  #cd "${_realname}-${pkgver}"
+  cd "${_realname}-${_commit}"
   cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
 }
 
 export RUSTONIG_DYNAMIC_LIBONIG=1
 export RUSTFLAGS="${RUSTFLAGS/+crt-static/-crt-static}"
+
 # spliting build() sometimes cause building twice at make build
 package() {
-  cd "${_realname}-${pkgver}"
+  #cd "${_realname}-${pkgver}"
+  cd "${_realname}-${_commit}"
 
   make install \
     DESTDIR="${pkgdir}" \
     PREFIX="${MINGW_PREFIX}" \
-    SKIP_UTILS='stty' \
+    SKIP_UTILS='stty runcon chcon' \
     PROG_PREFIX=uu- \
-    PROFILE=release
+    PROFILE=release \
+    MULTICALL=y \
+    LN="ln -vf"
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/uutils-${_realname}/LICENSE"
 }


### PR DESCRIPTION
Reduce binary size by:
1. Enabling multicall hardkink
2. Dropping stub binaries

note: We can manually export some RUSTFLAGS from release-fast profile.