### PR TITLE
uutils-coreutils: enable multicall

### DIFF
--- a/mingw-w64-uutils-coreutils/PKGBUILD
+++ b/mingw-w64-uutils-coreutils/PKGBUILD
@@ -5,7 +5,7 @@ _realname=coreutils
 pkgbase=mingw-w64-uutils-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-uutils-${_realname}")
 pkgver=0.2.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Cross-platform Rust rewrite of the GNU coreutils (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -17,27 +17,33 @@ msys2_references=(
 license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-oniguruma" "${MINGW_PACKAGE_PREFIX}-cc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust" "${MINGW_PACKAGE_PREFIX}-pkgconf")
-source=("https://github.com/uutils/coreutils/archive/${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('4a847a3aaf241d11f07fdc04ef36d73c722759675858665bc17e94f56c4fbfb3')
+source=("https://github.com/uutils/coreutils/archive/${pkgver}/${_realname}-${pkgver}.tar.gz"
+        "support-custom-ln.patch")
+sha256sums=('4a847a3aaf241d11f07fdc04ef36d73c722759675858665bc17e94f56c4fbfb3'
+            '2a6619e8732ede7802fb81256084561a6635947ac7697064334ad06dfa08b223')
 
 prepare() {
   cd "${_realname}-${pkgver}"
 
+  patch -Np1 -i ../support-custom-ln.patch
+
   cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
 }
 
-export RUSTONIG_DYNAMIC_LIBONIG=1
-export RUSTFLAGS="${RUSTFLAGS/+crt-static/-crt-static}"
 # spliting build() sometimes cause building twice at make build
 package() {
   cd "${_realname}-${pkgver}"
 
-  make install \
+  export RUSTONIG_DYNAMIC_LIBONIG=1
+  export RUSTFLAGS="${RUSTFLAGS/+crt-static/-crt-static}"
+  make -O install \
     DESTDIR="${pkgdir}" \
     PREFIX="${MINGW_PREFIX}" \
     SKIP_UTILS='stty' \
     PROG_PREFIX=uu- \
-    PROFILE=release
+    PROFILE=release \
+    MULTICALL=y \
+    LN="ln -vf"
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/uutils-${_realname}/LICENSE"
 }

--- a/mingw-w64-uutils-coreutils/support-custom-ln.patch
+++ b/mingw-w64-uutils-coreutils/support-custom-ln.patch
@@ -1,0 +1,28 @@
+--- a/GNUmakefile
++++ b/GNUmakefile
+@@ -69,6 +69,13 @@ TOYBOX_SRC  := $(TOYBOX_ROOT)/toybox-$(TOYBOX_VER)
+ #------------------------------------------------------------------------
+ OS ?= $(shell uname -s)
+ 
++# Windows does not allow symlink by default.
++# Allow to override LN for AppArmor.
++ifeq ($(OS),Windows_NT)
++	LN ?= ln -f
++endif
++LN ?= ln -sf
++
+ ifdef SELINUX_ENABLED
+ 	override SELINUX_ENABLED := 0
+ # Now check if we should enable it (only on non-Windows)
+@@ -462,9 +489,9 @@
+ ifeq (${MULTICALL}, y)
+ 	$(INSTALL) $(BUILDDIR)/coreutils $(INSTALLDIR_BIN)/$(PROG_PREFIX)coreutils
+ 	$(foreach prog, $(filter-out coreutils, $(INSTALLEES)), \
+-		cd $(INSTALLDIR_BIN) && ln -fs $(PROG_PREFIX)coreutils $(PROG_PREFIX)$(prog) $(newline) \
++		cd $(INSTALLDIR_BIN) && $(LN) $(PROG_PREFIX)coreutils $(PROG_PREFIX)$(prog) $(newline) \
+ 	)
+-	$(if $(findstring test,$(INSTALLEES)), cd $(INSTALLDIR_BIN) && ln -fs $(PROG_PREFIX)coreutils $(PROG_PREFIX)[)
++	$(if $(findstring test,$(INSTALLEES)), cd $(INSTALLDIR_BIN) && $(LN) $(PROG_PREFIX)coreutils $(PROG_PREFIX)[)
+ else
+ 	$(foreach prog, $(INSTALLEES), \
+ 		$(INSTALL) $(BUILDDIR)/$(prog) $(INSTALLDIR_BIN)/$(PROG_PREFIX)$(prog) $(newline) \


### PR DESCRIPTION
backport a patch that adds support for custom `ln` invocation. so use hardlinks (like for rustup) to save space