### PR TITLE
7Zip: reposition .sfx file next to executable

### DIFF
--- a/mingw-w64-7zip/PKGBUILD
+++ b/mingw-w64-7zip/PKGBUILD
@@ -4,7 +4,7 @@ _realname=7zip
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=25.01
-pkgrel=1
+pkgrel=2
 pkgdesc="A file archiver with a high compression ratio (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -51,7 +51,7 @@ package() {
 
   install -D -m755 $(find CPP/7zip/Bundles/ -name \*.dll) -t "${pkgdir}"${MINGW_PREFIX}/bin/
   install -D -m755 CPP/7zip/UI/Console/_o/7z.exe "${pkgdir}"${MINGW_PREFIX}/bin/7z.exe
-  install -D -m755 CPP/7zip/Bundles/SFXCon/_o/7zCon.exe "${pkgdir}"${MINGW_PREFIX}/lib/7zip/7zCon.sfx
+  install -D -m755 CPP/7zip/Bundles/SFXCon/_o/7zCon.exe "${pkgdir}"${MINGW_PREFIX}/bin/7zCon.sfx
 
   install -d "${pkgdir}"${MINGW_PREFIX}/share/doc/7zip
   install -D -m644 "${srcdir}"/DOC/* "${pkgdir}"${MINGW_PREFIX}/share/doc/7zip


### PR DESCRIPTION
When using `7z` to make a "Self-extracting" archive the executable (`7Z.exe` on Windows OSes) when given the command line argument `-sfx7z*.sfx` expects to find the "extra" code to include in the archive a file `7z*.sfx` (to provide the test/extraction) functionality to be alongside the executable in the same directory. The Mingw-w64 project provides just one of these "modules" - `7zCon.sfx` which provides a basic "Command line" interface that allows for extraction (default) or testing (with a `-t` command line argument to the "self-extracting" archive).

However, this (actually an executable programme file) is currently located in the `{baseDir}/lib/7zip` directory and it is not seen there by the `7z.exe` exectuable; testing has revealed that moving the file to the `{baseDir}/bin` directory - so it is in the same directory as the main application, is sufficient (and is as documentated [here](https://documentation.help/7-Zip/sfx.htm)) to get things to work as expected. Given that the file - though it has a "weird" `.sfx` extension is identified (by `file`) as a normal executable (and not a library) it doesn't seem unreasonable to me to relocate it as this PR sets out to do.