### PR TITLE
python-virtualenv: update to 20.35.3

### DIFF
--- a/mingw-w64-python-virtualenv/PKGBUILD
+++ b/mingw-w64-python-virtualenv/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=virtualenv
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-virtualenv")
-pkgver=20.35.2
+pkgver=20.35.3
 pkgrel=1
 pkgdesc="Virtual Python Environment builder (mingw-w64)"
 arch=('any')
@@ -27,7 +27,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-hatch-vcs")
 options=('!strip')
 source=(https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz)
-sha256sums=('332b71e3a0d62051a6b893f533deac9bc2e987599eb8e3328654b8faada95263')
+sha256sums=('4f1a845d131133bdff10590489610c98c168ff99dc75d6c96853801f7f67af44')
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"


### PR DESCRIPTION
Those folks put out three new versions within the last two days (https://virtualenv.pypa.io/en/latest/changelog.html). Isn't that getting a bit stressful?