### PR TITLE
gcc: Use `-cc` in `makedepends`

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -51,7 +51,7 @@ else
   _sourcedir=${_realname}-${_version}-${_snapshot}
   _url=https://gcc.gnu.org/pub/gcc/snapshots/${_version}-${_snapshot}
 fi
-pkgrel=8
+pkgrel=9
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -60,7 +60,7 @@ msys2_references=(
   "cpe: cpe:/a:gnu:gcc"
 )
 license=('spdx:GPL-3.0-or-later')
-makedepends=("${MINGW_PACKAGE_PREFIX}-${_realname}"
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              $([[ "$_enable_ada" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-ada")
              $([[ "$_enable_rust" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-rust")
              "${MINGW_PACKAGE_PREFIX}-autotools"


### PR DESCRIPTION
This allows bootstrapping GCC with Clang. Installing gcc-compat isn't an option, because GCC configure attempts to check for Ada support in the host compiler, but Clang forwards the Ada source file back to 'gcc' which is actually Clang itself, resulting in infinite recursion.