### PR TITLE
[new package] ts-node 10.9.2

### DIFF
--- a/mingw-w64-ts-node/PKGBUILD
+++ b/mingw-w64-ts-node/PKGBUILD
@@ -1,0 +1,28 @@
+# Maintainer: Konstantin Podsvirov <konstantin@podsvirov.su>
+
+_realname=ts-node
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=10.9.2
+pkgrel=1
+pkgdesc='TypeScript execution and REPL for node.js (mingw-w64)'
+arch=('any')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
+url='https://typestrong.org/ts-node/'
+msys2_repository_url='https://github.com/TypeStrong/ts-node'
+msys2_references=(
+  'purl: pkg:npm/ts-node'
+)
+license=('spdx:MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-nodejs"
+         "${MINGW_PACKAGE_PREFIX}-typescript")
+source=("https://registry.npmjs.org/${_realname}/-/${_realname}-${pkgver}.tgz")
+sha256sums=('0290b8a665925d581da75499425c7156b1f433619af62b0ea51d159c18dff968')
+noextract=("${_realname}-${pkgver}.tgz")
+
+package() {
+  "${MINGW_PREFIX}"/bin/npm install -g \
+    --cache "${srcdir}/npm-cache" \
+    --prefix "${pkgdir}${MINGW_PREFIX}" \
+    "${srcdir}/${_realname}-${pkgver}.tgz"
+}


### PR DESCRIPTION
Packaged good, but after run...:
```console
$ ts-node
> const x = 10 # type enter there
| # type enter there
| # type enter there
| # type Ctrl-c to done input...
> .exit
```
Line `const x = 10` not interpreted and `ts-node` just type `|` charset...