### PR TITLE
mcfgthread: Update to 2.2.2

### DIFF
--- a/mingw-w64-mcfgthread/PKGBUILD
+++ b/mingw-w64-mcfgthread/PKGBUILD
@@ -4,7 +4,7 @@ _realname=mcfgthread
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}"-libs)
-pkgver=2.2.1
+pkgver=2.2.2
 pkgrel=1
 pkgdesc="An efficient gthread implementation, providing C++11 threading support (mingw-w64)"
 arch=('any')
@@ -20,7 +20,7 @@ makedepends=(
   "git"
 )
 source=("git+https://github.com/lhmouse/mcfgthread.git#tag=v${pkgver%.*}-ga.${pkgver##*.}")
-sha256sums=('939f830db452a649f51838bdcae22d606dda1cb21b744cd53905fb384a07c7d9')
+sha256sums=('9f908262d15a72c60377bf03c766a6b6183c3dd83d19a3786b06bc6fd9dc0caa')
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"


### PR DESCRIPTION
https://github.com/lhmouse/mcfgthread/releases/tag/v2.2-ga.2
