### PR TITLE
gst-plugins-bad: enable some more plugins

### DIFF
--- a/mingw-w64-gst-plugins-bad/PKGBUILD
+++ b/mingw-w64-gst-plugins-bad/PKGBUILD
@@ -8,7 +8,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-gst-plugins-bad-libs"
          "${MINGW_PACKAGE_PREFIX}-gst-plugins-bad"
          "${MINGW_PACKAGE_PREFIX}-gst-plugin-opencv")
 pkgver=1.26.7
-pkgrel=1
+pkgrel=2
 pkgdesc="GStreamer Multimedia Framework Bad Plugins (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -63,6 +63,10 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-libxml2"
   "${MINGW_PACKAGE_PREFIX}-libmicrodns"
   "${MINGW_PACKAGE_PREFIX}-libmpcdec"
+  "${MINGW_PACKAGE_PREFIX}-libde265"
+  "${MINGW_PACKAGE_PREFIX}-libva"
+  "${MINGW_PACKAGE_PREFIX}-libopenmpt"
+  "${MINGW_PACKAGE_PREFIX}-sbc"
   "${MINGW_PACKAGE_PREFIX}-nettle"
   "${MINGW_PACKAGE_PREFIX}-openal"
   "${MINGW_PACKAGE_PREFIX}-opencv"
@@ -146,14 +150,11 @@ build() {
     -Ddirectfb=disabled \
     -Dflite=disabled \
     -Dladspa=disabled \
-    -Dlibde265=disabled \
     -Dlv2=disabled \
     -Dmpeg2enc=disabled \
     -Dmplex=disabled \
     -Dneon=disabled \
-    -Dopenmpt=disabled \
     -Dopenni2=disabled \
-    -Dsbc=disabled \
     -Dsctp=enabled \
     -Dteletext=disabled \
     -Dvoaacenc=disabled \
@@ -162,12 +163,9 @@ build() {
     -Diqa=disabled \
     -Dmagicleap=disabled \
     -Dv4l2codecs=disabled \
-    -Dva=disabled \
-    -Dwasapi2=disabled \
     -Davtp=disabled \
     -Dsvthevcenc=disabled \
     -Dzxing=disabled \
-    -Dasio=disabled \
     -Dgpl=enabled \
     -Dgs=disabled \
     -Disac=disabled \
@@ -206,6 +204,8 @@ package_gst-plugins-bad-libs() {
     "${MINGW_PACKAGE_PREFIX}-vulkan-loader"
     "${MINGW_PACKAGE_PREFIX}-directx-headers"
     "${MINGW_PACKAGE_PREFIX}-directxmath"
+    "${MINGW_PACKAGE_PREFIX}-libnice"
+    "${MINGW_PACKAGE_PREFIX}-libva"
   )
   cd "${srcdir}/build-${MSYSTEM}"
 
@@ -253,7 +253,6 @@ package_gst-plugins-bad() {
     "${MINGW_PACKAGE_PREFIX}-liblc3"
     "${MINGW_PACKAGE_PREFIX}-libmodplug"
     "${MINGW_PACKAGE_PREFIX}-libmpeg2"
-    "${MINGW_PACKAGE_PREFIX}-libnice"
     "${MINGW_PACKAGE_PREFIX}-librsvg"
     "${MINGW_PACKAGE_PREFIX}-libsndfile"
     "${MINGW_PACKAGE_PREFIX}-libsrtp"
@@ -262,6 +261,10 @@ package_gst-plugins-bad() {
     "${MINGW_PACKAGE_PREFIX}-libxml2"
     "${MINGW_PACKAGE_PREFIX}-libmicrodns"
     "${MINGW_PACKAGE_PREFIX}-libmpcdec"
+    "${MINGW_PACKAGE_PREFIX}-libde265"
+    "${MINGW_PACKAGE_PREFIX}-libva"
+    "${MINGW_PACKAGE_PREFIX}-libopenmpt"
+    "${MINGW_PACKAGE_PREFIX}-sbc"
     "${MINGW_PACKAGE_PREFIX}-nettle"
     "${MINGW_PACKAGE_PREFIX}-openal"
     "${MINGW_PACKAGE_PREFIX}-openexr"


### PR DESCRIPTION
They were disabled because dependencies were missing or they failed to build.