### PR TITLE
OpenSceneGraph: drop ffmpeg support

### DIFF
--- a/mingw-w64-OpenSceneGraph/PKGBUILD
+++ b/mingw-w64-OpenSceneGraph/PKGBUILD
@@ -7,7 +7,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 _pkgver=3.6.5
 pkgver=${_pkgver//-/}
-pkgrel=42
+pkgrel=43
 pkgdesc="Open source high performance 3D graphics toolkit (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -21,7 +21,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-boost-libs"
          "${MINGW_PACKAGE_PREFIX}-collada-dom"
          "${MINGW_PACKAGE_PREFIX}-curl"
          "${MINGW_PACKAGE_PREFIX}-dcmtk"
-         "${MINGW_PACKAGE_PREFIX}-ffmpeg4.4"
          "${MINGW_PACKAGE_PREFIX}-fltk"
          "${MINGW_PACKAGE_PREFIX}-freetype"
          "${MINGW_PACKAGE_PREFIX}-cc-libs"
@@ -132,6 +131,7 @@ build() {
     "${_extra_config[@]}" \
     -DCMAKE_CXX_STANDARD=14 \
     -DCURL_NO_CURL_CMAKE=ON \
+    -DCMAKE_DISABLE_FIND_PACKAGE_FFmpeg=ON \
     -DwxWidgets_CONFIG_EXECUTABLE=${MINGW_PREFIX}/bin/wx-config-${_wx_basever} \
     -DBUILD_OSG_EXAMPLES=ON \
     -DOSG_AGGRESSIVE_WARNINGS=OFF \


### PR DESCRIPTION
so we can get rid of old ffmpeg
upstream is unmaintained, so unlikely this will be fixed Debian did the same thing.