### PR TITLE
rustup: remove debugger scripts links

### DIFF
--- a/mingw-w64-rustup/PKGBUILD
+++ b/mingw-w64-rustup/PKGBUILD
@@ -4,7 +4,7 @@ _realname=rustup
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.28.2
-pkgrel=2
+pkgrel=3
 pkgdesc="The Rust toolchain installer (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -39,7 +39,7 @@ source=(
 )
 sha256sums=('5987dcb828068a4a5e29ba99ab26f2983ac0c6e2e4dc3e5b3a3c0fafb69abbc0'
             'dec8fd8b2838e7e5866a0bfbae2be89647c7c70a46c0ada1406accf4017322e9')
-_binlinks=('cargo' 'rustc' 'rustdoc' 'rust-gdb' 'rust-lldb' 'rustfmt' 'cargo-fmt' 'cargo-clippy' 'clippy-driver' 'cargo-miri')
+_binlinks=('cargo' 'rustc' 'rustdoc' 'rustfmt' 'cargo-fmt' 'cargo-clippy' 'clippy-driver' 'cargo-miri')
 
 prepare() {
   cd "${_realname}-${pkgver}"


### PR DESCRIPTION
they are broken due to .exe extension anyway