### PR TITLE
sccache: update blake3 crate to fix CLANG* binary

### DIFF
--- a/mingw-w64-sccache/PKGBUILD
+++ b/mingw-w64-sccache/PKGBUILD
@@ -5,7 +5,7 @@ _realname=sccache
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.12.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Shared compilation cache (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -46,6 +46,8 @@ zstd-sys = { path = "../zstd-sys-2.0.10+zstd.1.5.6" }
 END
 
   cargo update -p zstd-sys
+  # fix CLANG* issue: https://github.com/mozilla/sccache/issues/2373
+  cargo update -p blake3 --precise 1.8.2
   cargo fetch --locked
 }
 


### PR DESCRIPTION
older versions of blake3 crate didn't support gnullvm targets: BLAKE3-team/BLAKE3#399

fixes #23793

cc @ZachBacon can you test it from artifacts?