### PR TITLE
Fix windeploy-qt6

### DIFF
--- a/mingw-w64-qt6-base/001-appending-qt6-to-remove-qt5-conflict.patch
+++ b/mingw-w64-qt6-base/001-appending-qt6-to-remove-qt5-conflict.patch
@@ -119,3 +119,14 @@
  
  isEmpty(LRELEASE_DIR): LRELEASE_DIR = .qm
  isEmpty(QM_FILES_RESOURCE_PREFIX): QM_FILES_RESOURCE_PREFIX = i18n
+--- a/tools/windeployqt/qmlutils.cpp
++++ b/tools/windeployqt/qmlutils.cpp
+@@ -86,7 +86,7 @@ QmlImportScanResult runQmlImportScanner(const QString &directory, const QStringL
+     unsigned long exitCode;
+     QByteArray stdOut;
+     QByteArray stdErr;
+-    const QString binary = QStringLiteral("qmlimportscanner");
++    const QString binary = QStringLiteral("qmlimportscanner-qt6");
+     if (!runProcess(binary, arguments, QDir::currentPath(), &exitCode, &stdOut, &stdErr,
+                     errorMessage, timeout))
+         return result;

--- a/mingw-w64-qt6-declarative/PKGBUILD
+++ b/mingw-w64-qt6-declarative/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
 _qtver=6.10.0
 pkgver=${_qtver/-/}
-pkgrel=1
+pkgrel=2
 pkgdesc='Classes for QML and JavaScript languages (mingw-w64)'
 arch=(any)
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -77,6 +77,9 @@ package_qt6-declarative() {
 
   install -d "$pkgdir${MINGW_PREFIX}"/share/licenses/${_realname}
   install -Dm644 $_pkgfn/LICENSES/* -t "$pkgdir${MINGW_PREFIX}"/share/licenses/${_realname}
+
+  # windeployqt expects to find qmlimportscanner next to it
+  ln "${pkgdir}"${MINGW_PREFIX}/share/qt6/bin/qmlimportscanner.exe "${pkgdir}"${MINGW_PREFIX}/bin/qmlimportscanner-qt6.exe
 }
 
 package_qt6-declarative-debug() {


### PR DESCRIPTION
windeployqt expects to find qmlimportscanner next to it

This fixes this issue

```shell
windeployqt6.exe --qmldir ../src/QML/ ZeGrapher.exe
C:\msys64\home\adelk\ZeGrapher\deploy-windows\ZeGrapher.exe 64 bit, release executable [QML]
Scanning ..\src\QML\:
Process failed to start: The system cannot find the file specified.
```

Also reported on a [Reddit post](https://www.reddit.com/r/QtFramework/comments/1aumhy3/windeployqt_vs_windeployqt6_issues/)

It also expects `lconvert` in `/bin`