### PR TITLE
pillow: revert upstream build change

### DIFF
--- a/mingw-w64-python-pillow/0001-Revert-build-Mode.c-as-a-common-library.patch
+++ b/mingw-w64-python-pillow/0001-Revert-build-Mode.c-as-a-common-library.patch
@@ -1,0 +1,76 @@
+From ebc4611badc32cda12bb40eab496a33e616962d5 Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Wed, 29 Oct 2025 21:15:43 +0100
+Subject: [PATCH] Revert "build Mode.c as a common library"
+
+This reverts commit 28adda9299daac9cd4ee349474d7618c16152d2d.
+---
+ setup.py | 25 ++++++++++++++++---------
+ 1 file changed, 16 insertions(+), 9 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 3a72a0742..fec8659bf 100644
+--- a/setup.py
++++ b/setup.py
+@@ -107,6 +107,7 @@ _LIB_IMAGING = (
+     "JpegDecode",
+     "JpegEncode",
+     "Matrix",
++    "Mode",
+     "ModeFilter",
+     "Negative",
+     "Offset",
+@@ -1011,6 +1012,17 @@ class pil_build_ext(build_ext):
+ 
+         self.summary_report(feature)
+ 
++    def build_extension(self, ext):
++        # Append the extension name (not including "PIL.") to the temp build directory
++        # so that each module builds to its own directory. We need to make a (shallow)
++        # copy of 'self' here so that we don't overwrite this value when running in
++        # parallel.
++        import copy
++
++        self_copy = copy.copy(self)
++        self_copy.build_temp = os.path.join(self.build_temp, ext.name[4:])
++        build_ext.build_extension(self_copy, ext)
++
+     def summary_report(self, feature: ext_feature) -> None:
+         print("-" * 68)
+         print("PIL SETUP SUMMARY")
+@@ -1076,20 +1088,16 @@ def debug_build() -> bool:
+     return hasattr(sys, "gettotalrefcount") or FUZZING_BUILD
+ 
+ 
+-libraries: list[tuple[str, _BuildInfo]] = [
+-    ("pil_imaging_mode", {"sources": ["src/libImaging/Mode.c"]}),
+-]
+-
+ files: list[str | os.PathLike[str]] = ["src/_imaging.c"]
+ for src_file in _IMAGING:
+     files.append("src/" + src_file + ".c")
+ for src_file in _LIB_IMAGING:
+     files.append(os.path.join("src/libImaging", src_file + ".c"))
+ ext_modules = [
+-    Extension("PIL._imaging", files, libraries=["pil_imaging_mode"]),
+-    Extension("PIL._imagingft", ["src/_imagingft.c"], libraries=["pil_imaging_mode"]),
+-    Extension("PIL._imagingcms", ["src/_imagingcms.c"], libraries=["pil_imaging_mode"]),
+-    Extension("PIL._webp", ["src/_webp.c"], libraries=["pil_imaging_mode"]),
++    Extension("PIL._imaging", files),
++    Extension("PIL._imagingft", ["src/_imagingft.c", "src/libImaging/Mode.c"]),
++    Extension("PIL._imagingcms", ["src/_imagingcms.c", "src/libImaging/Mode.c"]),
++    Extension("PIL._webp", ["src/_webp.c", "src/libImaging/Mode.c"]),
+     Extension("PIL._avif", ["src/_avif.c"]),
+     Extension("PIL._imagingtk", ["src/_imagingtk.c", "src/Tk/tkImaging.c"]),
+     Extension("PIL._imagingmath", ["src/_imagingmath.c"]),
+@@ -1101,7 +1109,6 @@ try:
+     setup(
+         cmdclass={"build_ext": pil_build_ext},
+         ext_modules=ext_modules,
+-        libraries=libraries,
+         zip_safe=not (debug_build() or PLATFORM_MINGW),
+     )
+ except RequiredDependencyException as err:
+-- 
+2.51.2
+

--- a/mingw-w64-python-pillow/PKGBUILD
+++ b/mingw-w64-python-pillow/PKGBUILD
@@ -4,7 +4,7 @@ _realname=pillow
 pkgbase=mingw-w64-python-pillow
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-pillow")
 pkgver=12.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Python Imaging Library (PIL) fork Python3 version (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -31,19 +31,24 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-tk")
 optdepends=("${MINGW_PACKAGE_PREFIX}-tk: for the ImageTK module")
-source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('87d4f8125c9988bfbed67af47dd7a953e2fc7b0cc1e7800ec6d2080d490bb353')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
+        "0001-Revert-build-Mode.c-as-a-common-library.patch")
+sha256sums=('87d4f8125c9988bfbed67af47dd7a953e2fc7b0cc1e7800ec6d2080d490bb353'
+            'af97ebd6fa6ec30f7bcdff84b2bce6ef5ad44d7b58f15a91cfdf794ad4bd235c')
 
 prepare() {
   rm -rf "python-build-${MSYSTEM}" | true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
+  cd "python-build-${MSYSTEM}"
+
+  # Revert of https://github.com/python-pillow/Pillow/commit/28adda9299daac9cd4ee349474d7618c16152d2d
+  # See https://github.com/msys2/MINGW-packages/issues/26007
+  patch -p1 -i "${srcdir}/0001-Revert-build-Mode.c-as-a-common-library.patch"
 }
 
 build() {
   cd "${srcdir}/python-build-${MSYSTEM}"
 
-  # setuptools doesn't handle the archiver correctly in LLVM environments
-  AR="ar" \
   ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
 }
 


### PR DESCRIPTION
Creating a static lib with setuptools seems to make problems with clangarm64. Until we know more try a revert.

See #26007