### PR TITLE
cargo-msrv: add for CLANG64

### DIFF
--- a/mingw-w64-cargo-msrv/.gitignore
+++ b/mingw-w64-cargo-msrv/.gitignore
@@ -1,0 +1,1 @@
+/cargo-msrv

--- a/mingw-w64-cargo-msrv/PKGBUILD
+++ b/mingw-w64-cargo-msrv/PKGBUILD
@@ -7,40 +7,47 @@ pkgver=0.18.4
 pkgrel=1
 pkgdesc="Find the minimum supported Rust version (MSRV) for your project (mingw-w64)"
 arch=('any')
-mingw_arch=('ucrt64') # 'clang64' 'clangarm64') # add when we have stable *-windows-gnullvm toolchains
+mingw_arch=('ucrt64' 'clang64') # 'clangarm64') # fails while building aws-lc-sys (rust-bindgen issue?)
 url='https://github.com/foresterre/cargo-msrv'
 license=('spdx:Apache-2.0 OR MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-rustup")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-nasm"
-             "${MINGW_PACKAGE_PREFIX}-rust-bindgen")
-source=("${url}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('9e8d743a9948ec91e4d82ce34b8f0f9e65385ed78739cb36376f65049d8b8da5')
+             "${MINGW_PACKAGE_PREFIX}-rust-bindgen"
+             'git')
+source=("git+${url}#tag=v${pkgver}")
+sha256sums=('1a9c9d2b4cdadf399f1edb43b07407355ec5ab15a6348a0aac9a9f98c3f77130')
 
 prepare() {
-  cd "${_realname}-${pkgver}"
+  cd "${_realname}"
 
+  export RUST_CHOST=${CARCH}-pc-windows-gnu
+  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
+    RUST_CHOST=${CARCH}-pc-windows-gnullvm
+  fi
   # have to specify target otherwise MSVC tooclhain is used
-  export RUSTUP_TOOLCHAIN=stable-${CARCH}-pc-windows-gnu
+  export RUSTUP_TOOLCHAIN=stable-${RUST_CHOST}
+  cargo update -p aws-lc-rs --precise 1.13.1
   cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
 }
 
 build() {
-  cd "${_realname}-${pkgver}"
+  cd "${_realname}"
 
-  export RUSTUP_TOOLCHAIN=stable-${CARCH}-pc-windows-gnu
+  # this somehow fixes build for CLANG64, but not for CLANGARM64
+  export AWS_LC_SYS_EFFECTIVE_TARGET="${CARCH}-pc-windows-gnu"
   cargo build --release --frozen
 }
 
 check() {
-  cd "${_realname}-${pkgver}"
+  cd "${_realname}"
 
   cargo test --release --frozen
 }
 
 package() {
-  cd "${_realname}-${pkgver}"
+  cd "${_realname}"
 
   cargo install \
     --offline \


### PR DESCRIPTION
still useless because there is no stable compilers older than 1.91.0, but you can specify compilation target