### PR TITLE
iir: update to 1.10.0

### DIFF
--- a/mingw-w64-iir/PKGBUILD
+++ b/mingw-w64-iir/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=iir
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.9.5
+pkgver=1.10.0
 pkgrel=1
 pkgdesc="DSP IIR realtime filter library written in C++ (mingw-w64)"
 arch=('any')
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cc")
 source=("https://github.com/berndporr/iir1/archive/${pkgver}/${_realname}1-${pkgver}.tar.gz")
-sha256sums=('beb16142e08e5f68010c6e5014dea2276ea49b71a258439eff09c5ee3f781d88')
+sha256sums=('13b53f14d276adf6cafd3564fcda1d4b3e72342108d1c40ec4b4f0c7fc3ac95a')
 
 prepare() {
   cd "${srcdir}"/${_realname}1-${pkgver}
@@ -47,7 +47,7 @@ build() {
 check() {
   cd "${srcdir}/build-${MSYSTEM}"
 
-  "${MINGW_PREFIX}"/bin/ctest | true
+  "${MINGW_PREFIX}"/bin/ctest || true
 }
 
 package() {


### PR DESCRIPTION
Additionally, the test command logic in check() is fixed.