### PR TITLE
use `rustc --print host-tuple`

### DIFF
--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.cargo-tarball.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.cargo-tarball.sh
@@ -25,7 +25,7 @@ prepare() {
   patch -Np1 -i "${srcdir}"/0002-A-less-important-fix.patch
 
   # if cargo wants to make an http request at build stage, use `cargo fetch --locked` instead
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-aichat/PKGBUILD
+++ b/mingw-w64-aichat/PKGBUILD
@@ -20,7 +20,7 @@ sha256sums=('e194cc89afc213a6e3169738221cae641c347421c4f2aacd5d6f4f7cc6edb387')
 
 prepare() {
   cd "${_realname}-${pkgver}"
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-alacritty/PKGBUILD
+++ b/mingw-w64-alacritty/PKGBUILD
@@ -29,7 +29,7 @@ sha256sums=('e339261179f7edcaf9c28b1646d5a6761e76eae62078f07c308e8efa9ace18bb')
 prepare() {
   cd "${_realname}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-asm-lsp/PKGBUILD
+++ b/mingw-w64-asm-lsp/PKGBUILD
@@ -35,7 +35,7 @@ zstd-sys = { path = "../zstd-sys-2.0.13+zstd.1.5.6" }
 END
 
   cargo update -p zstd-sys
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-bat/PKGBUILD
+++ b/mingw-w64-bat/PKGBUILD
@@ -33,7 +33,7 @@ sha256sums=('eb5addff1d189100ed411c7c43ce4f414935fd6985a39f6344e6866102d4dd29')
 prepare() {
   cd "${_realname}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-blake3/PKGBUILD
+++ b/mingw-w64-blake3/PKGBUILD
@@ -31,7 +31,7 @@ prepare() {
   cargo fetch \
     --locked \
     --manifest-path="${_realname}-${pkgver}"/b3sum/Cargo.toml \
-    --target "$(rustc -vV | sed -n 's/host: //p')"
+    --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-cargo-about/PKGBUILD
+++ b/mingw-w64-cargo-about/PKGBUILD
@@ -33,7 +33,7 @@ zstd-sys = { path = "../zstd-sys-2.0.16+zstd.1.5.7" }
 END
 
   cargo update -p zstd-sys
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-cargo-component/PKGBUILD
+++ b/mingw-w64-cargo-component/PKGBUILD
@@ -22,7 +22,7 @@ sha256sums=('04ded8443b34687641d0bf01fa682ce46c1a9300af3f13ea5cf1bf5487d6f8b1')
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-cargo-create-tauri-app/PKGBUILD
+++ b/mingw-w64-cargo-create-tauri-app/PKGBUILD
@@ -21,7 +21,7 @@ sha256sums=('4276d826717c6ec763c92f90e93609bf9e080a24812d0c958334e5f45a4e81e3')
 prepare() {
   cd "${srcdir}/${_basename}-${_basename}-v${pkgver}"
 
-  "${MINGW_PREFIX}/bin/cargo.exe" fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  "${MINGW_PREFIX}/bin/cargo.exe" fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-cargo-edit/PKGBUILD
+++ b/mingw-w64-cargo-edit/PKGBUILD
@@ -22,7 +22,7 @@ sha256sums=('f242010b4b0b8ccd245693858d26a35f70bef572a209f4977d192c1215e861c6')
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-cargo-generate/PKGBUILD
+++ b/mingw-w64-cargo-generate/PKGBUILD
@@ -31,7 +31,7 @@ prepare() {
   # bump git2 crate
   cargo upgrade -p git2@0.20.0
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-cargo-leptos/PKGBUILD
+++ b/mingw-w64-cargo-leptos/PKGBUILD
@@ -29,7 +29,7 @@ sha256sums=('ada691f4c0ae5a37994c8b2815791807287f36ff010d20889029b517c734431e')
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
-  "${MINGW_PREFIX}/bin/cargo.exe" fetch --target "$(rustc -vV | sed -n 's/host: //p')"
+  "${MINGW_PREFIX}/bin/cargo.exe" fetch --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-cargo-local-registry/PKGBUILD
+++ b/mingw-w64-cargo-local-registry/PKGBUILD
@@ -32,7 +32,7 @@ prepare() {
   export LIBSSH2_SYS_USE_PKG_CONFIG=1
 
   cargo update -p cc
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-cargo-msrv/PKGBUILD
+++ b/mingw-w64-cargo-msrv/PKGBUILD
@@ -29,7 +29,7 @@ prepare() {
   # have to specify target otherwise MSVC tooclhain is used
   export RUSTUP_TOOLCHAIN=stable-${RUST_CHOST}
   cargo update -p aws-lc-rs --precise 1.13.1
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-cargo-tauri/PKGBUILD
+++ b/mingw-w64-cargo-tauri/PKGBUILD
@@ -33,7 +33,7 @@ prepare() {
   "${MINGW_PREFIX}/bin/cargo.exe" fetch \
     --locked \
     --config='net.git-fetch-with-cli=true' \
-    --target "$(rustc -vV | sed -n 's/host: //p')"
+    --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-cbindgen/PKGBUILD
+++ b/mingw-w64-cbindgen/PKGBUILD
@@ -27,7 +27,7 @@ prepare() {
   cd "${_realname}-${pkgver}"
   rm rust-toolchain.toml
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-cotp/PKGBUILD
+++ b/mingw-w64-cotp/PKGBUILD
@@ -24,7 +24,7 @@ sha256sums=('6234805a8eb20a71d2acb07ad8d7827bd5c98c653b7eb733bab0f90cbb9f6212')
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-czkawka/PKGBUILD
+++ b/mingw-w64-czkawka/PKGBUILD
@@ -33,7 +33,7 @@ prepare() {
   # like upstream does for release binaries
   sed -i 's|#lto|lto|;s|#codegen-units|codegen-units|' Cargo.toml
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-delta/PKGBUILD
+++ b/mingw-w64-delta/PKGBUILD
@@ -45,7 +45,7 @@ ntapi = { path = "../ntapi-0.4.1" }
 END
 
   cargo update -p ntapi
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-dust/PKGBUILD
+++ b/mingw-w64-dust/PKGBUILD
@@ -34,7 +34,7 @@ ntapi = { path = "../ntapi-0.4.1" }
 END
 
   cargo update -p ntapi
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-edit/PKGBUILD
+++ b/mingw-w64-edit/PKGBUILD
@@ -18,8 +18,8 @@ sha256sums=('e4ba6ff1bfecfeff2492306f5850c714bf50ffdb3cc3bb5be3aa987289f240fe')
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
-  RUSTC_BOOTSTRAP=1 cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')" \
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
+  RUSTC_BOOTSTRAP=1 cargo fetch --locked --target "$(rustc --print host-tuple)" \
     --manifest-path="${MINGW_PREFIX}/lib/rustlib/src/rust/library/std/Cargo.toml"
 }
 

--- a/mingw-w64-evcxr/PKGBUILD
+++ b/mingw-w64-evcxr/PKGBUILD
@@ -19,7 +19,7 @@ sha256sums=('904b397ac402d71d32587971477529acf6226ea1ae8c08c4558c2f670793fbda')
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-eza/PKGBUILD
+++ b/mingw-w64-eza/PKGBUILD
@@ -37,7 +37,7 @@ prepare() {
   cd "${_realname}"
 
   rm rust-toolchain.toml
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-fd/PKGBUILD
+++ b/mingw-w64-fd/PKGBUILD
@@ -22,7 +22,7 @@ sha512sums=('fa7d03cbc4abab02db8ed5cc7f3cb91ba87a6b4a609186edb40db80420a31a7ef67
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-gitoxide/PKGBUILD
+++ b/mingw-w64-gitoxide/PKGBUILD
@@ -21,7 +21,7 @@ sha256sums=('72c9c16dd8d173df0f8b32a06bf228fb0219d5d08bbccc7815926cd0765a7962')
 prepare() {
   cd "${_realname}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-gitui/PKGBUILD
+++ b/mingw-w64-gitui/PKGBUILD
@@ -37,7 +37,7 @@ _env() {
 prepare() {
   cd "${_realname}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-hayagriva/PKGBUILD
+++ b/mingw-w64-hayagriva/PKGBUILD
@@ -26,7 +26,7 @@ prepare() {
 
   # lockfile is not generated upstream, regenerate it manually after update
   cp ../Cargo.lock .
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-helix/PKGBUILD
+++ b/mingw-w64-helix/PKGBUILD
@@ -42,7 +42,7 @@ prepare() {
   patch -Np1 -i ../fix-runtime-dir.patch
 
   rm rust-toolchain.toml
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-hexyl/PKGBUILD
+++ b/mingw-w64-hexyl/PKGBUILD
@@ -22,7 +22,7 @@ sha256sums=('52853b4edede889b40fd6ff132e1354d957d1f26ee0c26ebdea380f8ce82cb0b')
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-hyperfine/PKGBUILD
+++ b/mingw-w64-hyperfine/PKGBUILD
@@ -21,7 +21,7 @@ sha256sums=('d1c782a54b9ebcdc1dedf8356a25ee11e11099a664a7d9413fdd3742138fa140')
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-jj/PKGBUILD
+++ b/mingw-w64-jj/PKGBUILD
@@ -28,7 +28,7 @@ sha256sums=('3d533e489b9c78a24c870ee5c86c715cea1023af3a500bf3fe4f393a254920a6')
 prepare() {
   cd "${_realname}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-just/PKGBUILD
+++ b/mingw-w64-just/PKGBUILD
@@ -26,7 +26,7 @@ sha256sums=('6827df1e70ff888db7723f2c23e2eb57a5712df09acf28b92752510c21220bdb')
 prepare() {
   cd "${_realname}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-leptosfmt/PKGBUILD
+++ b/mingw-w64-leptosfmt/PKGBUILD
@@ -27,7 +27,7 @@ prepare() {
   rm -rf "${srcdir}/${_realname}-${pkgver}/prettyplease"
   cp -r "${srcdir}/prettyplease-${_ppsha}" "${srcdir}/${_realname}-${pkgver}/prettyplease"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-lsd/PKGBUILD
+++ b/mingw-w64-lsd/PKGBUILD
@@ -34,7 +34,7 @@ prepare() {
   cd "${_realname}-${pkgver}"
 
   cargo update -p cc --precise 1.1.10
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-maturin/PKGBUILD
+++ b/mingw-w64-maturin/PKGBUILD
@@ -27,7 +27,7 @@ sha256sums=('2c2ae37144811d365509889ed7220b0598487f1278c2441829c3abf56cc6324a')
 prepare() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-mdbook-admonish/PKGBUILD
+++ b/mingw-w64-mdbook-admonish/PKGBUILD
@@ -25,7 +25,7 @@ prepare() {
   cp -r "${_realname}-${pkgver}" "build-${MSYSTEM}"
   cd "${srcdir}/build-${MSYSTEM}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-mdbook-pikchr/PKGBUILD
+++ b/mingw-w64-mdbook-pikchr/PKGBUILD
@@ -26,7 +26,7 @@ prepare() {
 
   sed -e "s/https:\/\/raw.githubusercontent.com\/podsvirov\/mdbook-pikchr\/master\/docs\///" -i docs/README.md
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-mdbook/PKGBUILD
+++ b/mingw-w64-mdbook/PKGBUILD
@@ -25,7 +25,7 @@ sha256sums=('d46f3b79e210eed383b6966847ea86ec441b6b505e9d9d868294bb9742130c9c')
 prepare() {
   cd "${srcdir}/${_realName}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-mdcat/PKGBUILD
+++ b/mingw-w64-mdcat/PKGBUILD
@@ -21,7 +21,7 @@ sha256sums=('460024d9795eb578be09ec2284af243627721151aa001aae6ffb5589380b2ba1')
 prepare() {
   cd "${_realname}-${_realname}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-minidump-stackwalk/PKGBUILD
+++ b/mingw-w64-minidump-stackwalk/PKGBUILD
@@ -22,7 +22,7 @@ sha256sums=('f33f63b82e38f264205d7735aa58bad1b27de2139ce2678d3a1aa2c2e880f683')
 prepare() {
   cp -r "${_projectname}-${pkgver}" "build-${MSYSTEM}" && cd "build-${MSYSTEM}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-neocmakelsp/PKGBUILD
+++ b/mingw-w64-neocmakelsp/PKGBUILD
@@ -27,7 +27,7 @@ prepare() {
   cd "${_realname}-${pkgver}"
   patch -p1 -i "${srcdir}/0001-neocmakelsp-meson-disable-cargo-build.patch"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-onefetch/PKGBUILD
+++ b/mingw-w64-onefetch/PKGBUILD
@@ -42,7 +42,7 @@ zstd-sys = { path = "../zstd-sys-2.0.13+zstd.1.5.6" }
 END
 
   cargo update -p zstd-sys
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-paper-terminal/PKGBUILD
+++ b/mingw-w64-paper-terminal/PKGBUILD
@@ -19,7 +19,7 @@ sha256sums=('3d6726ae0861371a49cf69410294b73b38c7efa666dc7840ee6b29e6ff3088ee')
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-powersession-rs/PKGBUILD
+++ b/mingw-w64-powersession-rs/PKGBUILD
@@ -18,7 +18,7 @@ sha256sums=('e2f6a08bbed401fbc8e423cb27f768d9f763cd572ca29bb0e547f0dd6a8429ef')
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-procs/PKGBUILD
+++ b/mingw-w64-procs/PKGBUILD
@@ -20,7 +20,7 @@ sha256sums=('7b287ac253fd1d202b0ea6a9a8ba2ed97598cf8e7dfd539bd40e382c6dc6d350')
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-python-pywinpty/PKGBUILD
+++ b/mingw-w64-python-pywinpty/PKGBUILD
@@ -26,7 +26,7 @@ sha256sums=('312cf39153a8736c617d45ce8b6ad6cd2107de121df91c455b10ce6bba7a39b2')
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-python-rpds-py/PKGBUILD
+++ b/mingw-w64-python-rpds-py/PKGBUILD
@@ -28,7 +28,7 @@ sha256sums=('abd4df20485a0983e2ca334a216249b6186d6e3c1627e106651943dbdb791aea')
 prepare() {
   cd "${_realname/-/_}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-repgrep/PKGBUILD
+++ b/mingw-w64-repgrep/PKGBUILD
@@ -30,7 +30,7 @@ prepare() {
   sed -i "s|\"ASCIIDOCTOR\"|\"${_asciidoctor}\"|g" build.rs
 
   rm rust-toolchain.toml
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-rio/PKGBUILD
+++ b/mingw-w64-rio/PKGBUILD
@@ -27,7 +27,7 @@ sha256sums=('5e81be53216c3b48744ed9f380f67f7579faec8c6cb477d173de45d47ee6ff4e')
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-ripgrep-all/PKGBUILD
+++ b/mingw-w64-ripgrep-all/PKGBUILD
@@ -31,7 +31,7 @@ prepare() {
   # - ...and eventually it failes (problems with compiling using MSVC)
   rm rust-toolchain.toml
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-ripgrep/PKGBUILD
+++ b/mingw-w64-ripgrep/PKGBUILD
@@ -27,7 +27,7 @@ prepare() {
   tar -xzf "${_realname}-${pkgver}.tar.gz" || true
   cd "${_realname}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-rust-analyzer/PKGBUILD
+++ b/mingw-w64-rust-analyzer/PKGBUILD
@@ -21,7 +21,7 @@ sha256sums=('9c12677c6ae004b875eb23145737007e043d78af6bc8b74cde2d272ae6a9bad4')
 prepare() {
   cd "${_realname}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-rust-bindgen/PKGBUILD
+++ b/mingw-w64-rust-bindgen/PKGBUILD
@@ -24,7 +24,7 @@ sha256sums=('1da7050a17fdab0e20d5d8c20d48cddce2973e8b7cb0afc15185bfad22f8ce5b')
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-rustlings/PKGBUILD
+++ b/mingw-w64-rustlings/PKGBUILD
@@ -29,7 +29,7 @@ prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   cp dev/Cargo.toml dev-Cargo.toml
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-rustscan/PKGBUILD
+++ b/mingw-w64-rustscan/PKGBUILD
@@ -25,7 +25,7 @@ prepare() {
   # actually include 2.4.1 update commit
   patch -Np1 -i ../b1f008a9c987f7e879ccf74bdab5ecfea9e74fb9.patch
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-rustup/PKGBUILD
+++ b/mingw-w64-rustup/PKGBUILD
@@ -52,7 +52,7 @@ prepare() {
   cd "${_realname}-${pkgver}"
 
   cargo update -p aws-lc-rs --precise 1.13.1
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-sad/PKGBUILD
+++ b/mingw-w64-sad/PKGBUILD
@@ -19,7 +19,7 @@ sha256sums=('a67902b9edb287861668ee3e39482c17b41c60e244ece62b3f8016250286294f')
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-samply/PKGBUILD
+++ b/mingw-w64-samply/PKGBUILD
@@ -19,7 +19,7 @@ sha256sums=('7002789471f8ef3a36f4d4db7be98f2847724e2b81a53c5e23d5cae022fb704b')
 prepare() {
   mv "${_realname}-${_realname}-v${pkgver}" "${_realname}-${pkgver}"
   cd "${_realname}-${pkgver}/${_realname}"
-  cargo fetch --target "$(rustc -vV | sed -n 's/host: //p')" --locked
+  cargo fetch --target "$(rustc --print host-tuple)" --locked
 }
 
 build() {

--- a/mingw-w64-sd/PKGBUILD
+++ b/mingw-w64-sd/PKGBUILD
@@ -22,7 +22,7 @@ sha256sums=('2adc1dec0d2c63cbffa94204b212926f2735a59753494fca72c3cfe4001d472f')
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-starship/PKGBUILD
+++ b/mingw-w64-starship/PKGBUILD
@@ -28,7 +28,7 @@ prepare() {
   tar -xzf "${_realname}-${pkgver}.tar.gz" || true
   cd "${_realname}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-stork/PKGBUILD
+++ b/mingw-w64-stork/PKGBUILD
@@ -26,7 +26,7 @@ prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
   export OPENSSL_NO_VENDOR=1
-  ${MINGW_PREFIX}/bin/cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  ${MINGW_PREFIX}/bin/cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-svg2pdf/PKGBUILD
+++ b/mingw-w64-svg2pdf/PKGBUILD
@@ -17,7 +17,7 @@ sha256sums=('882bb7992cfa79395788d577d3ca79c1a7f53597a23abe7a09a2b1180ee9a44e')
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-tree-sitter/PKGBUILD
+++ b/mingw-w64-tree-sitter/PKGBUILD
@@ -46,7 +46,7 @@ prepare() {
 # END
 
 #   cargo update -p rquickjs-sys
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-trunk/PKGBUILD
+++ b/mingw-w64-trunk/PKGBUILD
@@ -26,7 +26,7 @@ sha256sums=('8687bcf96bdc4decee88458745bbb760ad31dfd109e955cf455c2b64caeeae2f')
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-turbo/PKGBUILD
+++ b/mingw-w64-turbo/PKGBUILD
@@ -45,7 +45,7 @@ END
 
   rm rust-toolchain.toml
   cargo update -p zstd-sys --config='net.git-fetch-with-cli=true'
-  RUSTC_BOOTSTRAP=1 cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  RUSTC_BOOTSTRAP=1 cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-typst-lsp/PKGBUILD
+++ b/mingw-w64-typst-lsp/PKGBUILD
@@ -18,7 +18,7 @@ prepare() {
   cd "${_realname}"
 
   cargo update -p time
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-typst/PKGBUILD
+++ b/mingw-w64-typst/PKGBUILD
@@ -29,7 +29,7 @@ prepare() {
   ${MINGW_PREFIX}/bin/cargo fetch \
     --locked \
     --config='net.git-fetch-with-cli=true' \
-    --target "$(rustc -vV | sed -n 's/host: //p')"
+    --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-typstudio/PKGBUILD
+++ b/mingw-w64-typstudio/PKGBUILD
@@ -35,7 +35,7 @@ prepare() {
   "${MINGW_PREFIX}/bin/cargo" fetch \
     --locked \
     --manifest-path src-tauri/Cargo.toml \
-    --target "$(rustc -vV | sed -n 's/host: //p')"
+    --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-uutils-coreutils/PKGBUILD
+++ b/mingw-w64-uutils-coreutils/PKGBUILD
@@ -23,7 +23,7 @@ sha256sums=('422b4bab88d6a4da9eabcc947b4e8e0c7fbd123c88700f8750da45910bfb03b6')
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 # spliting build() sometimes cause building twice at make build

--- a/mingw-w64-vivid/PKGBUILD
+++ b/mingw-w64-vivid/PKGBUILD
@@ -23,7 +23,7 @@ sha256sums=('88db6158dad60aba66ae16f2cd1b09f515625940a33bada65da5562a03538e49')
 prepare() {
   cd "vivid-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-wac/PKGBUILD
+++ b/mingw-w64-wac/PKGBUILD
@@ -20,7 +20,7 @@ prepare() {
   # For more info see: https://github.com/rust-lang/cc-rs/pull/1176
   cargo update -p cc
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-wasm-bindgen/PKGBUILD
+++ b/mingw-w64-wasm-bindgen/PKGBUILD
@@ -33,7 +33,7 @@ prepare() {
 
   cargo fetch --locked \
     --config='net.git-fetch-with-cli=true' \
-    --target "$(rustc -vV | sed -n 's/host: //p')"
+    --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-wasm-component-ld/PKGBUILD
+++ b/mingw-w64-wasm-component-ld/PKGBUILD
@@ -23,7 +23,7 @@ sha256sums=('27fd97d775a20737e5ee55b345200d23ae381f437886a54fe3a7a374e291e744')
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-wasm-pack/PKGBUILD
+++ b/mingw-w64-wasm-pack/PKGBUILD
@@ -49,7 +49,7 @@ zstd-sys = { path = "../zstd-sys-2.0.11+zstd.1.5.6" }
 END
 
   cargo update -p bzip2-sys -p zstd-sys
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-wasm-server-runner/PKGBUILD
+++ b/mingw-w64-wasm-server-runner/PKGBUILD
@@ -25,7 +25,7 @@ prepare() {
   cargo update -p aws-lc-rs --precise 1.13.1
   cargo update -p wasm-bindgen-cli-support --precise 0.2.104
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-wasmer/PKGBUILD
+++ b/mingw-w64-wasmer/PKGBUILD
@@ -31,7 +31,7 @@ prepare() {
 
   patch -Np1 -i "../reproducible-builds.patch"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-wasmtime/PKGBUILD
+++ b/mingw-w64-wasmtime/PKGBUILD
@@ -43,7 +43,7 @@ zstd-sys = { path = "../zstd-sys-2.0.9+zstd.1.5.5" }
 END
 
   cargo update -p zstd-sys
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {
@@ -65,7 +65,7 @@ build() {
       -DBUILD_SHARED_LIBS=ON \
       -DWASMTIME_FASTEST_RUNTIME=ON \
       -DCMAKE_CXX_STANDARD=17 \
-      -DWASMTIME_TARGET="$(rustc -vV | sed -n 's/host: //p')" \
+      -DWASMTIME_TARGET="$(rustc --print host-tuple)" \
       "${extra_config[@]}" \
       -S "${_realname}/crates/c-api" \
       -B "build-${MSYSTEM}"

--- a/mingw-w64-watchexec/PKGBUILD
+++ b/mingw-w64-watchexec/PKGBUILD
@@ -23,7 +23,7 @@ sha256sums=('52201822ab00bfaf6757f953f667870b3aada52f887813e94b4f322f239ff8fb')
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-wezterm/PKGBUILD
+++ b/mingw-w64-wezterm/PKGBUILD
@@ -37,7 +37,7 @@ prepare() {
 
   git submodule update --init --recursive
   cargo update -p cc
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-yazi/PKGBUILD
+++ b/mingw-w64-yazi/PKGBUILD
@@ -30,7 +30,7 @@ _env() {
 prepare() {
   cd "${_realname}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-zed/PKGBUILD
+++ b/mingw-w64-zed/PKGBUILD
@@ -72,7 +72,7 @@ prepare() {
   fi
 
   cargo update -p zstd-sys
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
   # generate license for whole Zed contents
   #sh script/generate-licenses
 }

--- a/mingw-w64-zizmor/PKGBUILD
+++ b/mingw-w64-zizmor/PKGBUILD
@@ -38,7 +38,7 @@ apply_patch_with_msg() {
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-zola/PKGBUILD
+++ b/mingw-w64-zola/PKGBUILD
@@ -19,7 +19,7 @@ prepare() {
   cd "${_realname}-${pkgver}"
 
   # if cargo wants to make an http request at build stage, use `cargo fetch --locked` instead
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {

--- a/mingw-w64-zoxide/PKGBUILD
+++ b/mingw-w64-zoxide/PKGBUILD
@@ -22,7 +22,7 @@ sha256sums=('1b276edbf328aafc86afe1ebce41f45ccba3a3125412e89c8c5d8e825b0c7407')
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
 }
 
 build() {


### PR DESCRIPTION
it does the same as `rustc -vV | sed -n 's/host: //p'` but obviously faster and cleaner