### PR TITLE
yaml-cpp: move to latest available commit

### DIFF
--- a/mingw-w64-yaml-cpp/PKGBUILD
+++ b/mingw-w64-yaml-cpp/PKGBUILD
@@ -25,7 +25,7 @@ sha256sums=('2268ef558b845176d5937cf405fe44ee884154f1ef3c8bfa06e01e4fb832ceda')
 
 pkgver() {
   cd "${srcdir}/${_realname}-${pkgver}"
-  git describe --long ${_commit} --tags | sed 's/creduce-//g;s/\([^-]*-g\)/r\1/;s/-/./g;s/^v//g'
+  git describe --long ${_commit} --tags | sed 's/yaml-cpp-//g;s/\([^-]*-g\)/r\1/;s/-/./g;s/^v//g'
 }
 
 build() {


### PR DESCRIPTION
Upstream haven't had a release in a while, and there is no sight that one is coming, update to latest available commit on git upstream.

First wanted to just apply this patch: https://github.com/jbeder/yaml-cpp/commit/47cd2725d61e54719933b83ea51c64ad60c24066 but turns out build is broken on latest CMake, tried to patch that too but had even more build failures. 

Upstream tag request: https://github.com/jbeder/yaml-cpp/issues/1356

This is my first PR to this project, sorry if I missed something, tried to follow the existing commit style 