### PR TITLE
tk: avoid a segmentation fault

### DIFF
--- a/mingw-w64-tk/PKGBUILD
+++ b/mingw-w64-tk/PKGBUILD
@@ -7,7 +7,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _basever=8.6.17
 _patch=
 pkgver=${_basever}${_patch}
-pkgrel=1
+pkgrel=2
 pkgdesc="A windowing toolkit for use with tcl (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -18,10 +18,12 @@ depends=("${MINGW_PACKAGE_PREFIX}-tcl>=${_basever}")
 options=() # '!strip' 'debug')
 source=("https://downloads.sourceforge.net/sourceforge/tcl/${_realname}${pkgver}-src.tar.gz"
         004-install-man.mingw.patch
-        005-install-pkgconf.mingw.patch)
+        005-install-pkgconf.mingw.patch
+        avoid-segmentation-fault.patch)
 sha256sums=('e4982df6f969c08bf9dd858a6891059b4a3f50dc6c87c10abadbbe2fc4838946'
             'e6e843eff45b2cd2e371bb732209a0d65dcb23ddcd51bc1d2e372efc071a6c37'
-            'b968a0fdeacb01f920759fa7e04628a2b08a22b5db4ae9022dfae153e0a3d36a')
+            'b968a0fdeacb01f920759fa7e04628a2b08a22b5db4ae9022dfae153e0a3d36a'
+            '8a16bd2c11eb3595f1356da9fd876e4b5c4e6eb77c32c7e58ccf6b0d6b2fd6eb')
 
 _apply_patch_with_msg() {
   for _patch in "$@"
@@ -35,7 +37,8 @@ prepare() {
   cd "${srcdir}/${_realname}${_basever}"
   _apply_patch_with_msg \
     004-install-man.mingw.patch \
-    005-install-pkgconf.mingw.patch
+    005-install-pkgconf.mingw.patch \
+    avoid-segmentation-fault.patch
 
   # Using the static libgcc library is problematic when sharing
   # resources across dynamic link libraries, so we must use

--- a/mingw-w64-tk/avoid-segmentation-fault.patch
+++ b/mingw-w64-tk/avoid-segmentation-fault.patch
@@ -1,0 +1,14 @@
+diff tk8.6.17/win/Makefile.in tk8.6.17-no-segfault/win/Makefile.in
+index 3d89da5..980041b 100644
+--- tk8.6.17/win/Makefile.in
++++ tk8.6.17-no-segfault/win/Makefile.in
+@@ -723,6 +723,9 @@ tkUnixScale.$(OBJEXT): ${UNIX_DIR}/tkUnixScale.c
+ tkWindow.$(OBJEXT): ${GENERIC_DIR}/tkWindow.c configure Makefile tkUuid.h
+ 	$(CC) -c $(CC_SWITCHES) -I. -DBUILD_tk @DEPARG@ $(CC_OBJNAME)
+ 
++# Prevent a segmentation fault after TkFinalize() was called (twice)
++tkWin32Dll.$(OBJEXT): CFLAGS += -O1
++
+ # Extra dependency info
+ tkConsole.$(OBJEXT): configure Makefile
+ tkMain.$(OBJEXT): configure Makefile


### PR DESCRIPTION
**Note**: Usually, I would spend a little more time to analyze issues like this one. But I [discovered](https://github.com/msys2/MINGW-packages/pull/26173#issuecomment-3502658650) this problem [when testing Git for Windows v2.52.0-rc1](https://github.com/git-for-windows/git/pull/5937#issuecomment-3503046271), and this bug is a blocker.

There is code in Tk that emulates structured exception handling even when `gcc` does not support the common `__try { ... } __except` constructs. This code is written in assembler (so far, only i686 and x86_64 variants exist, for aarch64 the entire `TkFinalize()` call is skipped "since we don't have corresponding assembler-code", see https://github.com/tcltk/tk/blob/core-8-6-17/win/tkWin32Dll.c#L127.

However, it seems that with one of the recent mingw-w64-gcc upgrades in the MSYS2 project (between Tk v8.6.16 and v8.6.17, `gcc.exe` was updated nine times, from 14.2.0-3 to 15.2.0-8), _some_ optimization was introduced that interacts badly with that assember code, and as a consequence there is a segmentation fault after `TkFinalize()` is called from `DllMain()` upon `DLL_PROCESS_DETACH`.

This affects Git for Windows because `gitk` and Git GUI are both Tk programs, and both of them reliably exit with a segmentation fault now.

Let's work around this, for now. It does seem as if the segmentation fault can be avoided simply by downgrading optimization from `-O2` to `-O1` when compiling the `tkWin32Dll.c` file specifically.