### PR TITLE
gf2x: add version 1.3.0 (new package)

### DIFF
--- a/mingw-w64-gf2x/001-fix-include.patch
+++ b/mingw-w64-gf2x/001-fix-include.patch
@@ -1,0 +1,33 @@
+From a2f0fd388c12ca0b9f4525c6cfbc515418dcbaf8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Emmanuel=20Thom=C3=A9?= <Emmanuel.Thome@inria.fr>
+Date: Thu, 17 Sep 2020 23:40:54 +0200
+Subject: [PATCH] fix #include in configure test
+
+See there: https://trac.sagemath.org/ticket/30494
+---
+ config/acinclude.m4 | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/config/acinclude.m4 b/config/acinclude.m4
+index 53faf0b..07c1384 100644
+--- a/config/acinclude.m4
++++ b/config/acinclude.m4
+@@ -661,6 +661,7 @@ AC_DEFUN([GF2X_PROG_CC_FOR_BUILD_WORKS],
+ # remove anything that might look like compiler output to our "||" expression
+ rm -f conftest* a.out b.out a.exe a_out.exe
+ cat >conftest.c <<EOF
++#include <stdlib.h>
+ int
+ main ()
+ {
+@@ -699,6 +700,7 @@ AC_DEFUN([GF2X_PROG_EXEEXT_FOR_BUILD],
+ AC_CACHE_CHECK([for build system executable suffix],
+                gf2x_cv_prog_exeext_for_build,
+ [cat >conftest.c <<EOF
++#include <stdlib.h>
+ int
+ main ()
+ {
+-- 
+GitLab
+

--- a/mingw-w64-gf2x/PKGBUILD
+++ b/mingw-w64-gf2x/PKGBUILD
@@ -1,0 +1,66 @@
+# Maintainer: Dirk Stolle
+
+_realname=gf2x
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.3.0
+pkgrel=1
+pkgdesc="A library for multiplying polynomials over the binary field (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://gitlab.inria.fr/gf2x/gf2x'
+msys2_references=(
+  'anitya: 6340'
+  'archlinux: gf2x'
+  'gentoo: dev-libs/gf2x'
+)
+license=('spdx:GPL-3.0-or-later')
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+source=("${_realname}-${pkgver}.tar.gz"::"https://gitlab.inria.fr/gf2x/gf2x/-/archive/gf2x-${pkgver}/gf2x-gf2x-${pkgver}.tar.gz"
+        '001-fix-include.patch')
+noextract=("${_realname}-${pkgver}.tar.gz")
+sha256sums=('11bcf98b620c60c2ee3b4460b02b7be741f14cfdc26b542f22c92950926575e0'
+            'ae021d15308d8806f1967eec84954b0cf95b09d537cb499e067e21071291f7b0')
+
+prepare() {
+  # Workaround for symlinks in archive, see <https://www.msys2.org/docs/symlinks/>.
+  bsdtar -xzf "${srcdir}/${_realname}-${pkgver}.tar.gz" 2>/dev/null || bsdtar -xzf "${srcdir}/${_realname}-${pkgver}.tar.gz"
+
+  # Adjust name from gf2x-gf2x-x.y.z to gf2x-x.y.z.
+  mv "${srcdir}/${_realname}-${_realname}-${pkgver}"  "${srcdir}/${_realname}-${pkgver}"
+
+  cd "${_realname}-${pkgver}"
+
+  # Apply commit a2f0fd388c12ca0b9f4525c6cfbc515418dcbaf8 to fix build.
+  # See <https://gitlab.inria.fr/gf2x/gf2x/-/commit/a2f0fd388c12ca0b9f4525c6cfbc515418dcbaf8>.
+  patch -Np1 -i "${srcdir}/001-fix-include.patch"
+
+  autoreconf -fiv
+}
+
+build() {
+  mkdir -p "build-${MSYSTEM}" && cd "build-${MSYSTEM}"
+
+  ../${_realname}-${pkgver}/configure \
+    --prefix="${MINGW_PREFIX}" \
+    --build="${MINGW_CHOST}" \
+    --host="${MINGW_CHOST}" \
+    --target="${MINGW_CHOST}" \
+    --enable-static \
+    --enable-shared
+
+  make
+}
+
+check() {
+  cd "build-${MSYSTEM}"
+  make -k check
+}
+
+package() {
+  cd "build-${MSYSTEM}"
+  make prefix="${pkgdir}${MINGW_PREFIX}" install
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
gf2x is a package which is used by several mathematical applications either directly or indirectly.

It's already packaged in
* Arch Linux: https://archlinux.org/packages/extra/x86_64/gf2x/
* Debian: https://packages.debian.org/source/trixie/gf2x
* Fedora: https://packages.fedoraproject.org/pkgs/gf2x/
* Gentoo: https://packages.gentoo.org/packages/dev-libs/gf2x

... and [a few other distributions](https://repology.org/project/gf2x/versions).