### PR TITLE
ntl: add version 11.6.0 (new package)

### DIFF
--- a/mingw-w64-ntl/PKGBUILD
+++ b/mingw-w64-ntl/PKGBUILD
@@ -33,13 +33,23 @@ prepare() {
 build() {
   cd ${_realname}-${pkgver}/src
 
+  local -a extra_config
+  if [[ ${MSYSTEM} == CLANG64 ]]; then
+    extra_config+=("CXX=clang++" "TUNE=x86")
+  elif [[ ${MSYSTEM} == CLANGARM64 ]]; then
+    extra_config+=("CXX=clang++" "TUNE=generic")
+  else
+    # ucrt64 + mingw64
+    extra_config+=("TUNE=x86")
+  fi
+
   ./configure \
     DEF_PREFIX="${MINGW_PREFIX}" \
     SHARED=on \
     NTL_GF2X_LIB=on \
     NTL_GMP_LIP=on \
     NATIVE=off \
-    TUNE=generic \
+    "${extra_config[@]}" \
     LIBTOOL=libtool \
     LIBTOOL_LINK_FLAGS="-no-undefined" \
     CXXFLAGS="${CXXFLAGS}" LDFLAGS="${LDFLAGS}"


### PR DESCRIPTION
"NTL is a high-performance, portable C++ library providing data structures and algorithms for manipulating signed, arbitrary length integers, and for vectors, matrices, and polynomials over the integers and over finite fields." (Source: https://libntl.org/)

Packages for it exist in various distributions, for example
* Arch Linux: https://archlinux.org/packages/extra/x86_64/ntl/
* Cygwin (yay!): https://cygwin.com/packages/summary/ntl-src.html
* Debian: https://packages.debian.org/trixie/source/ntl
* Fedora: https://packages.fedoraproject.org/pkgs/ntl/
* Gentoo: https://packages.gentoo.org/packages/dev-libs/ntl

It builds on top of `gf2x` which was added in <https://github.com/msys2/MINGW-packages/pull/26306>.

--

**Edit:** A few notes on the build srcipt.
* `prepare()`, `check()` as well as most build flags are copied from Arch's PKGBUILD file.
* The usual `mkdir -p "build-${MSYSTEM}" && cd "build-${MSYSTEM}"` from the template is replaced, because some paths in the configure script cannot handle builds from another directory than `src`. 