### PR TITLE
android-tools: rebuild

### DIFF
--- a/mingw-w64-android-tools/0004-leave-wstat-as-is.patch
+++ b/mingw-w64-android-tools/0004-leave-wstat-as-is.patch
@@ -1,0 +1,11 @@
+--- android-tools-35.0.2/vendor/adb/sysdeps/win32/stat.cpp.orig	2025-11-11 08:57:16.178051100 +0100
++++ android-tools-35.0.2/vendor/adb/sysdeps/win32/stat.cpp	2025-11-11 09:12:44.269015400 +0100
+@@ -28,7 +28,7 @@
+ // Version of stat() that takes a UTF-8 path.
+ int adb_stat(const char* path, struct adb_stat* s) {
+ // This definition of wstat seems to be missing from <sys/stat.h>.
+-#if defined(_FILE_OFFSET_BITS) && (_FILE_OFFSET_BITS == 64)
++#if defined(_FILE_OFFSET_BITS) && (_FILE_OFFSET_BITS == 64) && !defined(__MINGW32__)
+ #ifdef _USE_32BIT_TIME_T
+ #define wstat _wstat32i64
+ #else

--- a/mingw-w64-android-tools/PKGBUILD
+++ b/mingw-w64-android-tools/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=35.0.2
 _tag=${pkgver}
-pkgrel=4
+pkgrel=5
 pkgdesc='Android platform tools (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -29,7 +29,8 @@ source=("https://github.com/nmeum/android-tools/releases/download/${_tag}/${_rea
         "AdbWinApi.def"
         "0001-android-tools-cmake.patch"
         "0002-android-tools-vendor.patch"
-        "0003-fix-building-with-gcc-mingw.patch")
+        "0003-fix-building-with-gcc-mingw.patch"
+        "0004-leave-wstat-as-is.patch")
 noextract=("${_realname}-${_tag}.tar.xz")
 sha256sums=('d2c3222280315f36d8bfa5c02d7632b47e365bfe2e77e99a3564fb6576f04097'
             'a7bdcc611b29e2ccea87a39ea86e451839bb18631376bde0e3e72d1cab499a51'
@@ -37,7 +38,8 @@ sha256sums=('d2c3222280315f36d8bfa5c02d7632b47e365bfe2e77e99a3564fb6576f04097'
             'e6fc31c148e120fc69be53e0464434c492ab0eaa0dbc8f18dd3c19eb2dd2577b'
             '89e43362c47586418d886809564e0a20f98c8b0c817d48151fc32d3515153984'
             'cb82aacba65f581c74e2c50097731e997aa741af9b281628b2940172e6d315d1'
-            '528e7a2dbf366832d6ae339e013de7c311efb7fa9139ce3478bc18fe29b0542d')
+            '528e7a2dbf366832d6ae339e013de7c311efb7fa9139ce3478bc18fe29b0542d'
+            '4c670ab8a96da18f26741bad300a8c218ac50cfa96efb713d36a6883d774c300')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -58,7 +60,8 @@ prepare() {
   apply_patch_with_msg \
     0001-android-tools-cmake.patch \
     0002-android-tools-vendor.patch \
-    0003-fix-building-with-gcc-mingw.patch
+    0003-fix-building-with-gcc-mingw.patch \
+    0004-leave-wstat-as-is.patch
 }
 
 build() {


### PR DESCRIPTION
Avoid re-defining wstat, so the types match.
In theory this should be the same, but clang got stricter I guess.

* Fixes #24664 