### PR TITLE
ftxui: add version 6.1.9

### DIFF
--- a/mingw-w64-ftxui/PKGBUILD
+++ b/mingw-w64-ftxui/PKGBUILD
@@ -1,0 +1,58 @@
+# Contributor: Dirk Stolle
+
+_realname=ftxui
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=6.1.9
+pkgrel=1
+pkgdesc="A C++ Functional Terminal User Interface (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/ArthurSonzogni/FTXUI'
+msys2_references=(
+  'anitya: 373193'
+  'aur: ftxui'
+)
+license=('spdx:MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
+         "${MINGW_PACKAGE_PREFIX}-libwinpthread")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-gtest"
+             "${MINGW_PACKAGE_PREFIX}-ninja")
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/ArthurSonzogni/FTXUI/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('45819c1e54914783d4a1ca5633885035d74146778a1f74e1213cdb7b76340e71')
+
+build() {
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    cmake \
+      -GNinja \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      "${extra_config[@]}" \
+      -D FTXUI_ENABLE_INSTALL=ON \
+      -D FTXUI_BUILD_EXAMPLES=ON \
+      -D FTXUI_BUILD_TESTS=ON \
+      -D FTXUI_BUILD_DOCS=ON \
+      -DBUILD_SHARED_LIBS=ON \
+      -S "${_realname}-${pkgver}" \
+      -B "build-${MSYSTEM}"
+
+  cmake --build "build-${MSYSTEM}"
+}
+
+check() {
+  cmake --build "build-${MSYSTEM}" --target test
+}
+
+package() {
+  DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}"
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
Closes #25940.


Currently it's just the main package. Documentation and example executables (as seen in the [AUR package for ftxui](https://aur.archlinux.org/packages/ftxui)) are not packaged yet.