### PR TITLE
python-coverage: update to 7.11.3

### DIFF
--- a/mingw-w64-python-coverage/PKGBUILD
+++ b/mingw-w64-python-coverage/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=coverage
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=7.10.7
+pkgver=7.11.3
 pkgrel=1
 pkgdesc="Code coverage measurement for Python (mingw-w64)"
 arch=('any')
@@ -14,8 +14,8 @@ msys2_references=(
   'gentoo: dev-python/coverage'
   'purl: pkg:pypi/coverage'
 )
-msys2_repository_url='https://github.com/nedbat/coveragepy'
-msys2_changelog_url='https://github.com/nedbat/coveragepy/blob/master/CHANGES.rst'
+msys2_repository_url='https://github.com/coveragepy/coveragepy'
+msys2_changelog_url='https://github.com/coveragepy/coveragepy/blob/main/CHANGES.rst'
 url='https://coverage.readthedocs.io/'
 license=('spdx:Apache-2.0')
 depends=("${MINGW_PACKAGE_PREFIX}-python")
@@ -25,7 +25,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-cc")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('f4ab143ab113be368a3e9b795f9cd7906c5ef407d6173fe9675a902e1fffc239')
+sha256sums=('0f59387f5e6edbbffec2281affb71cdc85e0776c1745150a3ab9b6c1d016106b')
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"


### PR DESCRIPTION
GitHub repo moved from <https://github.com/nedbat/coveragepy> to <https://github.com/coveragepy/coveragepy>.