### PR TITLE
new package: icecream 2.1.8

### DIFF
--- a/mingw-w64-python-icecream/PKGBUILD
+++ b/mingw-w64-python-icecream/PKGBUILD
@@ -1,0 +1,48 @@
+# Maintainer: Antoine Martin <totaam@xpra.org>
+
+_realname=icecream
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=2.1.8
+pkgrel=1
+pkgdesc="Icecream makes print debugging a little sweeter"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/gruns/icecream'
+msys2_repository_url='https://github.com/gruns/icecream/'
+msys2_references=(
+  'purl: pkg:pypi/icecream'
+)
+license=('spdx:MIT')
+depends=(
+    ${MINGW_PACKAGE_PREFIX}-python
+    ${MINGW_PACKAGE_PREFIX}-python-asttokens
+    ${MINGW_PACKAGE_PREFIX}-python-colorama
+    ${MINGW_PACKAGE_PREFIX}-python-executing
+    ${MINGW_PACKAGE_PREFIX}-python-pygments)
+makedepends=(
+    ${MINGW_PACKAGE_PREFIX}-python-build
+    ${MINGW_PACKAGE_PREFIX}-python-installer
+    ${MINGW_PACKAGE_PREFIX}-python-setuptools)
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('37269bbc62b02f0d85bfaf3a0eb4df272c967fad059f7ddcdaee5303ea2b2a62')
+
+build() {
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+check() {
+  cd "${srcdir}/python-build-${MSYSTEM}"
+  # ${MINGW_PREFIX}/bin/python -m pytest
+}
+
+package() {
+  cd "${srcdir}"/python-build-${MSYSTEM}
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}


### PR DESCRIPTION
This is needed by paramiko 4, which will be updated next.