### PR TITLE
binutils: Update to 2.45.1

### DIFF
--- a/mingw-w64-binutils/PKGBUILD
+++ b/mingw-w64-binutils/PKGBUILD
@@ -5,8 +5,8 @@
 _realname=binutils
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.45
-pkgrel=2
+pkgver=2.45.1
+pkgrel=1
 pkgdesc="A set of programs to assemble and manipulate binary and object files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -33,9 +33,8 @@ source=(https://ftp.gnu.org/gnu/binutils/${_realname}-${pkgver}.tar.bz2{,.sig}
         libiberty-unlink-handle-windows-nul.patch
         3001-hack-libiberty-link-order.patch
         4000-fix-DEBUG_S_INLINEELINES.patch
-        b09f71c1c4680a639ab83bb273aea1f3f4380a6a.patch::"https://sourceware.org/git/?p=binutils-gdb.git;a=patch;h=b09f71c1c4680a639ab83bb273aea1f3f4380a6a"
 )
-sha256sums=('1393f90db70c2ebd785fb434d6127f8888c559d5eeb9c006c354b203bab3473e'
+sha256sums=('860daddec9085cb4011279136fc8ad29eb533e9446d7524af7f517dd18f00224'
             'SKIP'
             '2c99345fc575c3a060d6677537f636c6c4154fac0fde508070f3b6296c1060d4'
             '4e8ac055df61b1b5d6ae29dc87e1154737c2e87c7b244b44866702cabf1a5d18'
@@ -45,10 +44,10 @@ sha256sums=('1393f90db70c2ebd785fb434d6127f8888c559d5eeb9c006c354b203bab3473e'
             'a094660ec95996c00b598429843b7869037732146442af567ada9f539bd40480'
             '7ccbd418695733c50966068fa9755a6abb156f53af23701d2bc097c63e9e0030'
             '604628156c08f3e361de60329af250fab6839e23e61e289f8369a7e18a04e277'
-            '5ed35a728b956ad49a5e196ae59f681666f2754f0a4903b9280a430d7a312ea8'
-            'a7689ac11dd3be5e37a56aa892b0500a4906addf32d6204fdc79b943cf12d7a2')
+            '5ed35a728b956ad49a5e196ae59f681666f2754f0a4903b9280a430d7a312ea8')
 validpgpkeys=('EAF1C276A747E9ED86210CBAC3126D3B4AE55E93'  # Tristan Gingold <gingold@adacore.com>
-              '3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F') # Nick Clifton <nickc@redhat.com>
+              '3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F'  # Nick Clifton <nickc@redhat.com>
+              '5EF3A41171BB77E6110ED2D01F3D03348DB1A3E2') # Sam James <sam@cmpct.info>
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -97,10 +96,6 @@ prepare() {
   # https://github.com/msys2/MINGW-packages/issues/24148
   # https://sourceware.org/bugzilla/show_bug.cgi?id=32942
   patch -p1 -i "${srcdir}/4000-fix-DEBUG_S_INLINEELINES.patch"
-
-  # https://github.com/msys2/MINGW-packages/issues/24998
-  # https://sourceware.org/bugzilla/show_bug.cgi?id=33244
-  patch -p1 -i "${srcdir}/b09f71c1c4680a639ab83bb273aea1f3f4380a6a.patch"
 }
 
 build() {


### PR DESCRIPTION
* b09f71c1c4680a639ab83bb273aea1f3f4380a6a.patch: included in this release

signing key advertised here:
https://sourceware.org/pipermail/binutils/2025-November/145592.html