### PR TITLE
lrcalc: add version 2.1 (new package)

### DIFF
--- a/mingw-w64-lrcalc/PKGBUILD
+++ b/mingw-w64-lrcalc/PKGBUILD
@@ -1,0 +1,51 @@
+# Maintainer: Dirk Stolle
+
+_realname=lrcalc
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=2.1
+pkgrel=1
+pkgdesc="Littlewood-Richardson calculator (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://sites.math.rutgers.edu/~asbuch/lrcalc/'
+msys2_repository_url='https://bitbucket.org/asbuch/lrcalc'
+msys2_references=(
+  'archlinux: lrcalc'
+  'gentoo: sci-mathematics/lrcalc'
+)
+license=('spdx:GPL-3.0-or-later')
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+source=("https://sites.math.rutgers.edu/~asbuch/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('996ac00e6ea8321ef09b34478f5379f613933c3254aeba624b6419b8afa5df57')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+
+  # Replace paths in README (documentation).
+  sed -i "s|/usr/local/share|${MINGW_PREFIX}/share|g" README
+}
+
+build() {
+  # Using in-source build, because out-of-source build fails.
+  cd "${_realname}-${pkgver}"
+
+  ./configure \
+    --prefix="${MINGW_PREFIX}" \
+    --build="${MINGW_CHOST}" \
+    --host="${MINGW_CHOST}" \
+    --target="${MINGW_CHOST}" \
+    --enable-static \
+    --enable-shared
+
+  make
+}
+
+package() {
+  cd "${_realname}-${pkgver}"
+
+  make install DESTDIR="${pkgdir}"
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
lrcalc is the Littlewood-Richardson Calculator. It is "a program designed to compute Littlewood-Richardson coefficients. [...] The program can compute single Littlewood-Richardson coefficients, products of Schur functions, or skew Schur functions." - https://sites.math.rutgers.edu/~asbuch/lrcalc/

~~This pull request also adds the Python bindings for the lrcalc library.~~
_Edit: No Python bindings yet due to build problems._

Packages for lrcalc exist in various distributions, for example:
* Arch Linux: https://archlinux.org/packages/extra/x86_64/lrcalc/
* Debian: https://packages.debian.org/trixie/source/lrcalc
  (Debian also has the [python-lrcalc package](https://tracker.debian.org/pkg/python-lrcalc), but currently only in experimental.)
* Fedora: https://packages.fedoraproject.org/pkgs/lrcalc/
* Gentoo: https://packages.gentoo.org/packages/sci-mathematics/lrcalc
  (Gentoo has the Python bindings, too: https://packages.gentoo.org/packages/dev-python/lrcalc)
* ... and others.