### PR TITLE
python-lrcalc: add version 2.1 (new package)

### DIFF
--- a/mingw-w64-python-lrcalc/PKGBUILD
+++ b/mingw-w64-python-lrcalc/PKGBUILD
@@ -1,0 +1,44 @@
+# Maintainer: Dirk Stolle
+
+_realname=lrcalc
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=2.1
+pkgrel=1
+pkgdesc="Littlewood-Richardson calculator - Python bindings (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://sites.math.rutgers.edu/~asbuch/lrcalc/'
+msys2_repository_url='https://bitbucket.org/asbuch/lrcalc'
+msys2_references=(
+  'archlinux: lrcalc'
+  'gentoo: dev-python/lrcalc'
+  'purl: pkg:pypi/lrcalc'
+)
+license=('spdx:GPL-3.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-lrcalc=$pkgver"
+         "${MINGW_PACKAGE_PREFIX}-python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cython"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!strip')
+source=("https://sites.math.rutgers.edu/~asbuch/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('996ac00e6ea8321ef09b34478f5379f613933c3254aeba624b6419b8afa5df57')
+
+build() {
+  cp -r "${_realname}-${pkgver}/python" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 ../${_realname}-${pkgver}/LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}


### PR DESCRIPTION
These are the Python bindings for lrcalc (see <https://github.com/msys2/MINGW-packages/pull/26404>).