### PR TITLE
new package: pdfminer

### DIFF
--- a/mingw-w64-python-pdfminer/PKGBUILD
+++ b/mingw-w64-python-pdfminer/PKGBUILD
@@ -26,14 +26,8 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
 source=("${url}/archive/${pkgver}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('1a0eaa1447008bf4f33be37e3703ae3c51109613c5b0aa5117711354c06abc4a')
 
-prepare() {
-  cd "${srcdir}"
-  rm -rf "python-build-${MSYSTEM}" || true
-  cp -r "${_realname}.six-${pkgver}" "python-build-${MSYSTEM}"
-}
-
 build() {
-  cd "${srcdir}/python-build-${MSYSTEM}"
+  cp -r "${_realname}.six-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
   SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver} \
     python -m build --wheel --no-isolation
 }


### PR DESCRIPTION
A python PDF parser, required by [ocrmypdf](https://github.com/ocrmypdf/OCRmyPDF) (I may add `ocrmypdf` later if this PR merged).