### PR TITLE
new package: ocrmypdf

### DIFF
--- a/mingw-w64-ocrmypdf/PKGBUILD
+++ b/mingw-w64-ocrmypdf/PKGBUILD
@@ -37,6 +37,7 @@ sha256sums=('a0f6509e7780b286391f8847fae1811d2b157b14283ad74a2431d6755c5c0ed0')
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+  sed -i '/^[[:space:]]*"pi-heif",/d' pyproject.toml
   ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
 }
 


### PR DESCRIPTION
* A tool to add an OCR text layer to scanned PDF files, allowing them to be searched
* Waiting for `python-pdfminer` in the staging repo to be ready