### PR TITLE
python-memory-allocator: add version 0.1.4 (new package)

### DIFF
--- a/mingw-w64-python-memory-allocator/PKGBUILD
+++ b/mingw-w64-python-memory-allocator/PKGBUILD
@@ -1,0 +1,52 @@
+# Contributor: Dirk Stolle
+
+_realname=memory-allocator
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=0.1.4
+pkgrel=1
+pkgdesc="Memory allocation extension class for Cython (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/sagemath/memory_allocator'
+msys2_references=(
+  'archlinux: python-memory-allocator'
+  'gentoo: dev-python/memory-allocator'
+  'purl: pkg:pypi/memory-allocator'
+)
+license=('spdx:GPL-3.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-cython"
+         "${MINGW_PACKAGE_PREFIX}-python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
+sha256sums=('d609216b03031967e2b45a804b12ff9029578f4ec019fde42cf6aed6ca09efe4')
+
+build() {
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+check() {
+  cd "python-build-${MSYSTEM}"
+
+  # Run tests in virtual environment.
+  python -m venv --system-site-packages test-env
+  test-env/bin/python setup.py build_ext -i
+  test-env/bin/python test.py
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}


### PR DESCRIPTION
This memory allocation extension class for Cython is required as one of the dependencies for passagemath packages (<https://github.com/msys2/MINGW-packages/issues/24738>).

It's already present in a few other distributions, for example:
* Arch Linux: https://archlinux.org/packages/extra/x86_64/python-memory-allocator/
* Debian: https://packages.debian.org/trixie/source/memory-allocator
* Gentoo: https://packages.gentoo.org/packages/dev-python/memory-allocator