### PR TITLE
python-cysignals: add version 1.12.6 (new package)

### DIFF
--- a/mingw-w64-python-cysignals/PKGBUILD
+++ b/mingw-w64-python-cysignals/PKGBUILD
@@ -1,0 +1,52 @@
+# Contributor: Dirk Stolle
+
+_realname=cysignals
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=1.12.6
+pkgrel=1
+pkgdesc="Interrupt and signal handling for Cython (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/sagemath/cysignals'
+msys2_references=(
+  'archlinux: python-cysignals'
+  'gentoo: dev-python/cysignals'
+  'purl: pkg:pypi/cysignals'
+)
+license=('spdx:LGPL-3.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cython"
+             "${MINGW_PACKAGE_PREFIX}-meson-python"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('3ef3a37bdb244821b85475a08e2762ca1019570b369e321504995fa9a54675ce')
+
+build() {
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+check() {
+  cd "python-build-${MSYSTEM}"
+
+  # Test in virtual env., because tests need installed package.
+  python -m venv --system-site-packages test-env
+  test-env/bin/python -m installer dist/*.whl
+  test-env/bin/python -m pytest -v
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}


### PR DESCRIPTION
This is required as one of the dependencies for passagemath packages (https://github.com/msys2/MINGW-packages/issues/24738).

It is also present in some other distributions, for example:
* Arch Linux: https://archlinux.org/packages/extra/x86_64/python-cysignals/
* Debian: https://packages.debian.org/trixie/source/cysignals
* Fedora: https://packages.fedoraproject.org/pkgs/python-cysignals/
* Gentoo: https://packages.gentoo.org/packages/dev-python/cysignals