### PR TITLE
python-passagemath-environment: add version 10.6.36 (new package)

### DIFF
--- a/mingw-w64-passagemath-environment/PKGBUILD
+++ b/mingw-w64-passagemath-environment/PKGBUILD
@@ -1,0 +1,39 @@
+# Contributor: Dirk Stolle
+
+_realname=passagemath-environment
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=10.6.36
+pkgrel=1
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgdesc="Subset of the Sage library providing the connection to the system and software environment (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/passagemath/passagemath'
+msys2_references=(
+  'purl: pkg:pypi/passagemath-environment'
+)
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-packaging"
+         "${MINGW_PACKAGE_PREFIX}-python-platformdirs")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
+sha256sums=('564ad8fa2a6678d9734d45325e5ecccd07dedc0ce78d2eddf229110b19936ca7')
+
+build() {
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+}


### PR DESCRIPTION
This pull request adds the first "real" package for passagemath (see <https://github.com/msys2/MINGW-packages/issues/24738>). It is still of limited use, I guess, until some more passagemath packages are available.


