### PR TITLE
zed: update to 0.212.7

### DIFF
--- a/mingw-w64-zed/PKGBUILD
+++ b/mingw-w64-zed/PKGBUILD
@@ -3,8 +3,9 @@
 _realname=zed
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
-         "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
-pkgver=0.212.6
+         #"${MINGW_PACKAGE_PREFIX}-${_realname}-docs"
+)
+pkgver=0.212.7
 pkgrel=1
 pkgdesc="A high-performance, multiplayer code editor (mingw-w64)"
 arch=('any')
@@ -47,7 +48,7 @@ source=("git+${msys2_repository_url}.git#tag=v${pkgver}"
         "zstd-sys-remove-statik.patch"
         "zed-fix-docs-build.patch"
         "zed-wsl-set-proper-cli-name.patch")
-sha256sums=('417873509efa057377a071ca7f28e4afd0d62c681bce9ae66b3f90efe1b1c3a5'
+sha256sums=('f9502ad6d761a228c64d2c710625f813489d33db084e8fa19fc06702ce2e69ae'
             '91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748'
             '48f4900ceb02d3aaf9a1020f33d56629156e96759f456c0e7ca18bfcf910767b'
             'acaf155e37120a1af8918854a457939cad71e59bca2ced866f89795ed6b0a7b2'
@@ -63,7 +64,7 @@ prepare() {
   # wsl script is hardcoded with zed.exe name
   patch -Np1 -i ../zed-wsl-set-proper-cli-name.patch
   # use patched *-sys crates
-  sed -i '/\[patch\.crates-io\]/a zstd-sys = { path = "../zstd-sys-2.0.16+zstd.1.5.7" }' Cargo.toml
+  sed -i '/\[patch\.crates-io\]/a zstd-sys.path = "../zstd-sys-2.0.16+zstd.1.5.7"' Cargo.toml
 
   # change git config so `pet*` crates would be fetched without error; requires Windows registry
   # changes, see https://zed.dev/docs/development/windows#build-fails-path-too-long for details
@@ -100,8 +101,9 @@ build() {
 
   cargo build --release --frozen -p zed -p cli
 
-  cd docs
-  mdbook build
+  # mdbook 0.5.0 is not supported currently
+  #cd docs
+  #mdbook build
 }
 
 check() {


### PR DESCRIPTION
disable docs build until upstream adds support for mdbook 0.5.0