### PR TITLE
Add PKGBUILD for WNU Binutils package

### DIFF
--- a/mingw-w64-wnu-binutils/PKGBUILD
+++ b/mingw-w64-wnu-binutils/PKGBUILD
@@ -17,7 +17,7 @@ sha256sums=('SKIP')  # Replace with actual checksum
 
 build() {
   cd "${srcdir}/${_realname}-v${pkgver}/1.x.x/1.0.x/1.0.0"
-  ${MINGW_PREFIX}/bin/mingw32-make all nm CC="${MINGW_PREFIX}/bin/gcc"
+  make all nm CC="${MINGW_PREFIX}/bin/gcc"
 }
 
 check() {


### PR DESCRIPTION
This PKGBUILD file defines the build process for WNU Binutils, including installation of binaries, documentation, and license files.