### PR TITLE
python-passagemath-categories: add version 10.6.37 (new package)

### DIFF
--- a/mingw-w64-passagemath-categories/PKGBUILD
+++ b/mingw-w64-passagemath-categories/PKGBUILD
@@ -1,0 +1,48 @@
+# Maintainer: Dirk Stolle
+
+_realname=passagemath-categories
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=10.6.37
+pkgrel=1
+pkgdesc="passagemath: Sage categories and basic rings (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/passagemath/passagemath'
+msys2_references=(
+  'purl: pypi/passagemath-categories'
+)
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-memory-allocator"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-objects")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cython"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-cysignals"
+             "${MINGW_PACKAGE_PREFIX}-python-gmpy2"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-jinja"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-environment"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-setup"
+             "${MINGW_PACKAGE_PREFIX}-python-pkgconfig"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
+sha256sums=('27db3a09ea7ca413d5f501f5c4da38e7e04ddde0f65f2525bd00679eec71d4b1')
+
+build() {
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+}


### PR DESCRIPTION
This PR adds python-passagemath-categories, a package to provide some functionality from passagemath (https://github.com/msys2/MINGW-packages/issues/24738).