### PR TITLE
symmetrica: add version 3.1.0 (new package)

### DIFF
--- a/mingw-w64-symmetrica/PKGBUILD
+++ b/mingw-w64-symmetrica/PKGBUILD
@@ -1,0 +1,57 @@
+# Maintainer: Dirk Stolle
+
+_realname=symmetrica
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=3.1.0
+pkgrel=1
+pkgdesc="Some package (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://www.algorithm.uni-bayreuth.de/en/research/SYMMETRICA/index.html'
+msys2_repository_url='https://gitlab.com/sagemath/symmetrica'
+msys2_references=(
+  'archlinux: symmetrica'
+  'gentoo: sci-libs/symmetrica'
+)
+license=('spdx:0BSD')
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+# Use the version from the SageMath team instead of the version from University of Bayreuth,
+# because it contains fixes for newer compilers like GCC 15 with C23.
+source=("https://gitlab.com/sagemath/symmetrica/-/archive/${pkgver}/symmetrica-${pkgver}.tar.gz")
+sha256sums=('de567da3138806efeb15d686442d05d90b8ffc49d52fb681d2c5a0e3a427b991')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+  autoreconf -fiv
+}
+
+build() {
+  mkdir -p "build-${MSYSTEM}" && cd "build-${MSYSTEM}"
+
+  ../"${_realname}-${pkgver}"/configure \
+    --prefix="${MINGW_PREFIX}" \
+    --build="${MINGW_CHOST}" \
+    --host="${MINGW_CHOST}" \
+    --target="${MINGW_CHOST}" \
+    --enable-doc \
+    --enable-static \
+    --enable-shared
+
+  make
+}
+
+check() {
+  cd "build-${MSYSTEM}"
+
+  make check
+}
+
+package() {
+  cd "build-${MSYSTEM}"
+
+  make install DESTDIR="${pkgdir}"
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
It is required to build passagemath-combinat, one of the packages of passagemath (<https://github.com/msys2/MINGW-packages/issues/24738>), so let's package it.

passagemath-combinat will then be added in a later PR, once symmetrica is available in MSYS2.

By the way, symmetrica is also available in several other distributions, for example:
* Arch Linux: https://archlinux.org/packages/extra/x86_64/symmetrica/
* Debian: https://packages.debian.org/trixie/source/symmetrica
* Gentoo: https://packages.gentoo.org/packages/sci-libs/symmetrica
* Fedora: https://packages.fedoraproject.org/pkgs/symmetrica/