### PR TITLE
Update: blueprint-compiler 0.16.0 to 0.18.0

### DIFF
--- a/mingw-w64-blueprint-compiler/PKGBUILD
+++ b/mingw-w64-blueprint-compiler/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=blueprint-compiler
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-pkgver=0.16.0
+pkgver=0.18.0
 pkgrel=1
 pkgdesc='A markup language for GTK user interfaces (mingw-w64)' 
 url='https://jwestman.pages.gitlab.gnome.org/blueprint-compiler/'
@@ -14,7 +14,7 @@ mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 depends=(${MINGW_PACKAGE_PREFIX}-python-gobject)
 makedepends=(${MINGW_PACKAGE_PREFIX}-meson)
 source=(https://gitlab.gnome.org/jwestman/blueprint-compiler/-/archive/v$pkgver/blueprint-compiler-v$pkgver.tar.gz)
-sha256sums=('01feb8263fe7a450b0a9fed0fd54cf88947aaf00f86cc7da345f8b39a0e7bd30')
+sha256sums=('703c7ccd23cb6f77a8fe9c8cae0f91de9274910ca953de77135b6e79dbff1fc3')
 
 build() {
   MSYS2_ARG_CONV_EXCL="--prefix=" \


### PR DESCRIPTION
Blueprint compiler updated from 0.16.0 to 0.18.0

To match the latest versions of #25319   and #25942 

NOTE: I tested it with GTK 4.18 and Libadwaita 1.7 and it seems to work.