### PR TITLE
mingw-w64-librdkafka: Update to 2.12.1

### DIFF
--- a/mingw-w64-librdkafka/PKGBUILD
+++ b/mingw-w64-librdkafka/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=librdkafka
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.11.1
+pkgver=2.12.1
 pkgrel=1
 pkgdesc="The Apache Kafka C/C++ client library (mingw-w64)"
 arch=('any')
@@ -23,7 +23,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-cyrus-sasl"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-zstd")
 source=("https://github.com/confluentinc/librdkafka/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('a2c87186b081e2705bb7d5338d5a01bc88d43273619b372ccb7bb0d264d0ca9f')
+sha256sums=('ec103fa05cb0f251e375f6ea0b6112cfc9d0acd977dc5b69fdc54242ba38a16f')
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"


### PR DESCRIPTION
Updating librdkafka version from 2.11.1 to 2.12.1 as confluent kafka libraries require newer version