### PR TITLE
python-passagemath-combinat: add version 10.6.37 (new package)

### DIFF
--- a/mingw-w64-passagemath-combinat/0001-allow-newer-cysignals.patch
+++ b/mingw-w64-passagemath-combinat/0001-allow-newer-cysignals.patch
@@ -1,0 +1,60 @@
+diff --git a/PKG-INFO b/PKG-INFO.modified
+index da2af3e..132b16b 100644
+--- a/PKG-INFO
++++ b/PKG-INFO
+@@ -30,7 +30,6 @@ Classifier: Topic :: Scientific/Engineering :: Mathematics
+ Requires-Python: <3.15,>=3.10
+ Description-Content-Type: text/x-rst
+ Requires-Dist: gmpy2~=2.1.b999
+-Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
+ Requires-Dist: cysignals!=1.12.0,>=1.11.2
+ Requires-Dist: memory_allocator
+ Requires-Dist: passagemath-categories~=10.6.37.0
+diff --git a/pyproject.toml b/pyproject.toml.modified
+index a60bce7..7810941 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -9,7 +9,7 @@ requires = [
+     'passagemath-categories ~= 10.6.37.0',
+     'cython >=3.0.8, <3.2.0', 'cython >=3.0.8,<3.2.0',
+     'gmpy2 ~=2.1.b999',
+-    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
++    'cysignals >=1.11.2, != 1.12.0',
+     'memory_allocator',
+ ]
+ build-backend = "setuptools.build_meta"
+@@ -19,7 +19,7 @@ name = "passagemath-combinat"
+ description = "passagemath: Algebraic combinatorics, combinatorial representation theory"
+ dependencies = [
+     'gmpy2 ~=2.1.b999',
+-    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
++    'cysignals >=1.11.2, != 1.12.0',
+     'memory_allocator',
+     'passagemath-categories ~= 10.6.37.0',
+     'passagemath-environment ~= 10.6.37.0',
+diff --git a/passagemath_objects.egg-info/requires.txt b/passagemath_objects.egg-info/requires.txt.modified
+index 38f48ce..c252984 100644
+--- a/passagemath_combinat.egg-info/requires.txt
++++ b/passagemath_combinat.egg-info/requires.txt
+@@ -4,9 +4,6 @@ memory_allocator
+ passagemath-categories~=10.6.37.0
+ passagemath-environment~=10.6.37.0
+
+-[:sys_platform == "win32"]
+-cysignals<1.12.4
+-
+ [findstat]
+ requests>=2.13.0
+ 
+diff --git a/passagemath_objects.egg-info/PKG-INFO b/passagemath_objects.egg-info/PKG-INFO.modified
+index da2af3e..132b16b 100644
+--- a/passagemath_combinat.egg-info/PKG-INFO
++++ b/passagemath_combinat.egg-info/PKG-INFO
+@@ -30,7 +30,6 @@ Classifier: Topic :: Scientific/Engineering :: Mathematics
+ Requires-Python: <3.15,>=3.10
+ Description-Content-Type: text/x-rst
+ Requires-Dist: gmpy2~=2.1.b999
+-Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
+ Requires-Dist: cysignals!=1.12.0,>=1.11.2
+ Requires-Dist: memory_allocator
+ Requires-Dist: passagemath-categories~=10.6.37.0

--- a/mingw-w64-passagemath-combinat/PKGBUILD
+++ b/mingw-w64-passagemath-combinat/PKGBUILD
@@ -1,0 +1,55 @@
+# Maintainer: Dirk Stolle
+
+_realname=passagemath-combinat
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=10.6.37
+pkgrel=1
+pkgdesc="passagemath: Algebraic combinatorics, combinatorial representation theory (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/passagemath/passagemath'
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-cysignals"
+         "${MINGW_PACKAGE_PREFIX}-python-gmpy2"
+         "${MINGW_PACKAGE_PREFIX}-python-memory-allocator"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-categories"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-environment"
+         "${MINGW_PACKAGE_PREFIX}-symmetrica"
+)
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cython"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-setup"
+             "${MINGW_PACKAGE_PREFIX}-python-pkgconfig"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz"
+        "0001-allow-newer-cysignals.patch")
+sha256sums=('f31e625c1cd2b262ae42f75185ef6cc4be4736658a76eca1ed80d566241597ac'
+            'eb0f2d99c4d7c57245381eed6161003d1cac22e0535e1db575e2964db7e1d712')
+
+prepare() {
+  cd "${_realname/-/_}-${pkgver}"
+
+  # Loosen a constraint on cysignals so that the version packaged in MSYS2 is accepted.
+  patch -Nbp1 -i "${srcdir}/0001-allow-newer-cysignals.patch"
+}
+
+build() {
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+}


### PR DESCRIPTION
This PR adds python-passagemath-combinat, a package to provide some functionality from passagemath (https://github.com/msys2/MINGW-packages/issues/24738).