### PR TITLE
python-passagemath-graphs: add version 10.6.37 (new package)

### DIFF
--- a/mingw-w64-passagemath-graphs/0001-allow-newer-cysignals.patch
+++ b/mingw-w64-passagemath-graphs/0001-allow-newer-cysignals.patch
@@ -1,0 +1,60 @@
+diff --git a/PKG-INFO b/PKG-INFO
+index da2af3e..132b16b 100644
+--- a/PKG-INFO
++++ b/PKG-INFO
+@@ -30,7 +30,6 @@ Classifier: Topic :: Scientific/Engineering :: Mathematics
+ Requires-Python: <3.15,>=3.10
+ Description-Content-Type: text/x-rst
+ Requires-Dist: gmpy2~=2.1.b999
+-Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
+ Requires-Dist: cysignals!=1.12.0,>=1.11.2
+ Requires-Dist: memory_allocator
+ Requires-Dist: passagemath-categories~=10.6.37.0
+diff --git a/pyproject.toml b/pyproject.toml
+index a60bce7..7810941 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -9,7 +9,7 @@ requires = [
+     'passagemath-categories ~= 10.6.37.0',
+     'cython >=3.0.8, <3.2.0', 'cython >=3.0.8,<3.2.0',
+     'gmpy2 ~=2.1.b999',
+-    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
++    'cysignals >=1.11.2, != 1.12.0',
+     'memory_allocator',
+ ]
+ build-backend = "setuptools.build_meta"
+@@ -19,7 +19,7 @@ name = "passagemath-graphs"
+ description = "passagemath: Graphs, posets, hypergraphs, designs, abstract complexes, combinatorial polyhedra, abelian sandpiles, quivers"
+ dependencies = [
+     'gmpy2 ~=2.1.b999',
+-    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
++    'cysignals >=1.11.2, != 1.12.0',
+     'memory_allocator',
+     'passagemath-categories ~= 10.6.37.0',
+     'passagemath-conf ~= 10.6.37.0 ; sys_platform != "win32"',
+diff --git a/passagemath_graphs.egg-info/requires.txt b/passagemath_graphs.egg-info/requires.txt
+index 38f48ce..c252984 100644
+--- a/passagemath_graphs.egg-info/requires.txt
++++ b/passagemath_graphs.egg-info/requires.txt
+@@ -7,9 +7,6 @@ passagemath-environment~=10.6.37.0
+ [:sys_platform != "win32"]
+ passagemath-conf~=10.6.37.0
+
+-[:sys_platform == "win32"]
+-cysignals<1.12.4
+-
+ [benzene]
+ passagemath-benzene
+ 
+diff --git a/passagemath_graphs.egg-info/PKG-INFO b/passagemath_graphs.egg-info/PKG-INFO
+index da2af3e..132b16b 100644
+--- a/passagemath_graphs.egg-info/PKG-INFO
++++ b/passagemath_graphs.egg-info/PKG-INFO
+@@ -30,7 +30,6 @@ Classifier: Topic :: Scientific/Engineering :: Mathematics
+ Requires-Python: <3.15,>=3.10
+ Description-Content-Type: text/x-rst
+ Requires-Dist: gmpy2~=2.1.b999
+-Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
+ Requires-Dist: cysignals!=1.12.0,>=1.11.2
+ Requires-Dist: memory_allocator
+ Requires-Dist: passagemath-categories~=10.6.37.0

--- a/mingw-w64-passagemath-graphs/PKGBUILD
+++ b/mingw-w64-passagemath-graphs/PKGBUILD
@@ -1,0 +1,56 @@
+# Maintainer: Dirk Stolle
+
+_realname=passagemath-graphs
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=10.6.37
+pkgrel=1
+pkgdesc="passagemath: Graphs, posets, hypergraphs, designs, abstract complexes, combinatorial polyhedra, abelian sandpiles, quivers (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/passagemath/passagemath'
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-cysignals"
+         "${MINGW_PACKAGE_PREFIX}-python-gmpy2"
+         "${MINGW_PACKAGE_PREFIX}-python-memory-allocator"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-categories"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-environment")
+makedepends=("${MINGW_PACKAGE_PREFIX}-boost"
+             "${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cython"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-pkgconfig"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-setup"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz"
+        "0001-allow-newer-cysignals.patch")
+sha256sums=('465fb12d31310860855c94096bd80a3a9122c361e62df142c58c6a34beb58be9'
+            '2c1b92b242ac84168baf9714f597af873979159ac0a5c41e45196dedb73118a4')
+
+prepare() {
+  cd "${_realname/-/_}-${pkgver}"
+
+  patch -Nbp1 -i "${srcdir}/0001-allow-newer-cysignals.patch"
+}
+
+build() {
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  # Avoid warnings that may cause compilation to fail.
+  CFLAGS+=" -Wno-incompatible-pointer-types"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+}


### PR DESCRIPTION
This PR adds python-passagemath-graphs, a package to provide some functionality from passagemath (https://github.com/msys2/MINGW-packages/issues/24738).