### PR TITLE
tbb: Update to 2022.3.0

### DIFF
--- a/mingw-w64-tbb/002-fix-link-flags-on-mingw.patch
+++ b/mingw-w64-tbb/002-fix-link-flags-on-mingw.patch
@@ -9,14 +9,3 @@
      set(TBB_LIB_LINK_FLAGS ${TBB_LIB_LINK_FLAGS} -Wl,-z,relro,-z,now,-z,noexecstack)
  endif()
  
---- oneTBB-2022.2.0/cmake/compilers/Clang.cmake.orig	2025-08-05 06:50:02.426524500 +0200
-+++ oneTBB-2022.2.0/cmake/compilers/Clang.cmake	2025-08-05 06:50:13.563552300 +0200
-@@ -65,7 +65,7 @@
- # Clang flags to prevent compiler from optimizing out security checks
- set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} -Wformat -Wformat-security -Werror=format-security -fPIC $<$<NOT:$<BOOL:${EMSCRIPTEN}>>:-fstack-protector-strong>)
- 
--if (NOT APPLE AND NOT ANDROID_PLATFORM AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-+if (NOT APPLE AND NOT ANDROID_PLATFORM AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64")
-     set(TBB_LIB_COMPILE_FLAGS ${TBB_LIB_COMPILE_FLAGS} -fstack-clash-protection $<$<NOT:$<BOOL:${EMSCRIPTEN}>>:-fcf-protection=full>)
- endif()
- 

--- a/mingw-w64-tbb/PKGBUILD
+++ b/mingw-w64-tbb/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=oneTBB
 pkgbase=mingw-w64-tbb
 pkgname=("${MINGW_PACKAGE_PREFIX}-tbb")
-pkgver=2022.2.0
+pkgver=2022.3.0
 pkgrel=1
 pkgdesc='oneAPI Threading Building Blocks (mingw-w64)'
 arch=(any)
@@ -23,9 +23,9 @@ source=("https://github.com/uxlfoundation/oneTBB/archive/v${pkgver}/${_realname}
         001-fix-using-TBB-with-Debug-build-type.patch
         002-fix-link-flags-on-mingw.patch
         003-fix-getting-assembler-version-on-mingw.patch)
-sha256sums=('f0f78001c8c8edb4bddc3d4c5ee7428d56ae313254158ad1eec49eced57f6a5b'
+sha256sums=('01598a46c1162c27253a0de0236f520fd8ee8166e9ebb84a4243574f88e6e50a'
             '094c556a1087563a3a5810db0fa81aed6432b3a8e91aab9a747e9a55ea262f2a'
-            '68e228b4cb2226192ac06d2b73eb4fe33c1ebae18e465d299d4f37da1ea3d9e7'
+            '7df24d43baf17e5abb25ea49f40f72936fa9d1bcd2f185d7efb5a852e65c00b0'
             'd51db2fc6acbb6022fe1e9b0188d0b5bc7041b9db0905cad8a58d6fde3d1750e')
 
 apply_patch_with_msg() {


### PR DESCRIPTION
* 002-fix-link-flags-on-mingw.patch: partly no longer needed since https://github.com/uxlfoundation/oneTBB/commit/e57411968661ab1205322ba1c84fc1cd90a306c6