### PR TITLE
python-passagemath-repl: add version 10.6.37 (new package)

### DIFF
--- a/mingw-w64-passagemath-repl/PKGBUILD
+++ b/mingw-w64-passagemath-repl/PKGBUILD
@@ -1,0 +1,44 @@
+# Maintainer: Dirk Stolle
+
+_realname=passagemath-repl
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=10.6.37
+pkgrel=1
+pkgdesc="passagemath: IPython kernel, Sage preparser, doctester (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/passagemath/passagemath'
+msys2_references=(
+  'purl: pkg:pypi/passagemath-repl'
+)
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-python-ipython"
+         "${MINGW_PACKAGE_PREFIX}-python-ipykernel"
+         "${MINGW_PACKAGE_PREFIX}-python-ipywidgets"
+         "${MINGW_PACKAGE_PREFIX}-python-jupyter_client"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-environment"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-objects"
+         "${MINGW_PACKAGE_PREFIX}-python-typing_extensions")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-setup"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
+sha256sums=('b090e532ddd9d630833f2418f9aa744ae99c42f4f8ff15b571d8d8a7996beb73')
+
+build() {
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+}


### PR DESCRIPTION
This PR adds python-passagemath-repl, a package to provide some functionality from passagemath (https://github.com/msys2/MINGW-packages/issues/24738).


Failed to build locally on my machine, but seems to be fine here in CI.