### PR TITLE
python-passagemath-modules: add version 10.6.37 (new package)

### DIFF
--- a/mingw-w64-passagemath-modules/0001-allow-newer-cysignals.patch
+++ b/mingw-w64-passagemath-modules/0001-allow-newer-cysignals.patch
@@ -1,0 +1,60 @@
+diff --git a/PKG-INFO b/PKG-INFO
+index da2af3e..132b16b 100644
+--- a/PKG-INFO
++++ b/PKG-INFO
+@@ -30,7 +30,6 @@ Classifier: Topic :: Scientific/Engineering :: Mathematics
+ Requires-Python: <3.15,>=3.10
+ Description-Content-Type: text/x-rst
+ Requires-Dist: gmpy2~=2.1.b999
+-Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
+ Requires-Dist: cysignals!=1.12.0,>=1.11.2
+ Requires-Dist: memory_allocator
+ Requires-Dist: passagemath-categories~=10.6.37.0
+diff --git a/pyproject.toml b/pyproject.toml
+index a60bce7..7810941 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -15,7 +15,7 @@ requires = [
+     'cython >=3.0.8, <3.2.0', 'cython >=3.0.8,<3.2.0',
+     'gmpy2 ~=2.1.b999',
+     'numpy >=1.19', 'numpy >=1.22.4',
+-    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
++    'cysignals >=1.11.2, != 1.12.0',
+     'memory_allocator',
+ ]
+ build-backend = "setuptools.build_meta"
+@@ -25,7 +25,7 @@ name = "passagemath-modules"
+ description = "passagemath: Vectors, matrices, tensors, vector spaces, affine spaces, modules and algebras, additive groups, quadratic forms, homology, coding theory, matroids"
+ dependencies = [
+     'gmpy2 ~=2.1.b999',
+-    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
++    'cysignals >=1.11.2, != 1.12.0',
+     'memory_allocator',
+     'passagemath-categories ~= 10.6.37.0',
+     'passagemath-environment ~= 10.6.37.0',
+diff --git a/passagemath_modules.egg-info/requires.txt b/passagemath_modules.egg-info/requires.txt
+index 38f48ce..c252984 100644
+--- a/passagemath_modules.egg-info/requires.txt
++++ b/passagemath_modules.egg-info/requires.txt
+@@ -5,9 +5,6 @@ passagemath-categories~=10.6.37.0
+ passagemath-environment~=10.6.37.0
+ mpmath<1.4,>=1.1.0
+
+-[:sys_platform == "win32"]
+-cysignals<1.12.4
+-
+ [AA]
+ passagemath-modules[NumberField]
+ 
+diff --git a/passagemath_modules.egg-info/PKG-INFO b/passagemath_modules.egg-info/PKG-INFO
+index da2af3e..132b16b 100644
+--- a/passagemath_modules.egg-info/PKG-INFO
++++ b/passagemath_modules.egg-info/PKG-INFO
+@@ -30,7 +30,6 @@ Classifier: Topic :: Scientific/Engineering :: Mathematics
+ Requires-Python: <3.15,>=3.10
+ Description-Content-Type: text/x-rst
+ Requires-Dist: gmpy2~=2.1.b999
+-Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
+ Requires-Dist: cysignals!=1.12.0,>=1.11.2
+ Requires-Dist: memory_allocator
+ Requires-Dist: passagemath-categories~=10.6.37.0

--- a/mingw-w64-passagemath-modules/PKGBUILD
+++ b/mingw-w64-passagemath-modules/PKGBUILD
@@ -1,0 +1,60 @@
+# Maintainer: Dirk Stolle
+
+_realname=passagemath-modules
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=10.6.37
+pkgrel=1
+pkgdesc="passagemath: Vectors, matrices, tensors, vector spaces, affine spaces, modules and algebras, additive groups, quadratic forms, homology, coding theory, matroids (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/passagemath/passagemath'
+msys2_references=(
+  'purl: pkg:pypi/passagemath-modules'
+)
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-gsl"
+         "${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-cysignals"
+         "${MINGW_PACKAGE_PREFIX}-python-gmpy2"
+         "${MINGW_PACKAGE_PREFIX}-python-memory-allocator"
+         "${MINGW_PACKAGE_PREFIX}-python-mpmath"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-categories"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-environment")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cython"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-jinja"
+             "${MINGW_PACKAGE_PREFIX}-python-numpy"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-setup"
+             "${MINGW_PACKAGE_PREFIX}-python-pkgconfig"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz"
+        "0001-allow-newer-cysignals.patch")
+sha256sums=('214041eba5db1f297b012bace2b423b522a19bec36118ed55d7ebeedb23640b1'
+            '69de1ae8ec74311af149884d7457e6402f2eb8ebbcf81319fb1e72972a1c25b8')
+
+prepare() {
+  cd "${_realname/-/_}-${pkgver}"
+
+  patch -Nbp1 -i "${srcdir}/0001-allow-newer-cysignals.patch"
+}
+
+build() {
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+}


### PR DESCRIPTION
This PR adds python-passagemath-modules, a package to provide more functionality from passagemath (https://github.com/msys2/MINGW-packages/issues/24738).