### PR TITLE
gdk-pixbuf2: Update to 2.44.4

### DIFF
--- a/mingw-w64-gdk-pixbuf2/0004-build-all-loaders-plus-gdi.patch
+++ b/mingw-w64-gdk-pixbuf2/0004-build-all-loaders-plus-gdi.patch
@@ -1,18 +1,18 @@
---- gdk-pixbuf-2.42.9/meson.build.orig	2022-08-11 09:42:23.286806100 +0200
-+++ gdk-pixbuf-2.42.9/meson.build	2022-08-11 09:43:15.784358900 +0200
-@@ -293,7 +293,7 @@
+--- gdk-pixbuf-2.44.4/meson.build.orig	2025-11-23 12:34:29.375863600 +0100
++++ gdk-pixbuf-2.44.4/meson.build	2025-11-23 12:35:22.361552700 +0100
+@@ -352,7 +352,7 @@
  
  # Don't check and build the jpeg loader if native_windows_loaders is true
- jpeg_opt = get_option('jpeg')
+ jpeg_opt = get_option('jpeg').disable_auto_if(glycin_dep.found() or enabled_loaders.contains('android'))
 -if not jpeg_opt.disabled() and not native_windows_loaders
 +if not jpeg_opt.disabled()
    jpeg_dep = dependency(is_msvc_like ? 'jpeg' : 'libjpeg', required: false)
  
    # Finally, look for the dependency in a fallback
-@@ -324,7 +324,7 @@
+@@ -383,7 +383,7 @@
  
  # Don't check and build the tiff loader if native_windows_loaders is true
- tiff_opt = get_option('tiff')
+ tiff_opt = get_option('tiff').disable_auto_if(glycin_dep.found())
 -if not tiff_opt.disabled() and not native_windows_loaders
 +if not tiff_opt.disabled()
    # We currently don't have a fallback subproject, but this handles error

--- a/mingw-w64-gdk-pixbuf2/PKGBUILD
+++ b/mingw-w64-gdk-pixbuf2/PKGBUILD
@@ -6,8 +6,8 @@ _realname=gdk-pixbuf2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
-pkgver=2.42.12
-pkgrel=5
+pkgver=2.44.4
+pkgrel=1
 pkgdesc="An image loading library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -43,9 +43,9 @@ source=("https://download.gnome.org/sources/gdk-pixbuf/${pkgver%.*}/gdk-pixbuf-$
         fix-missing-meson-dep.patch
         gdk-pixbuf-query-loaders.hook.in)
 noextract=("gdk-pixbuf-${pkgver}.tar.xz")
-sha256sums=('b9505b3445b9a7e48ced34760c3bcb73e966df3ac94c95a148cb669ab748e3c7'
+sha256sums=('93a1aac3f1427ae73457397582a2c38d049638a801788ccbd5f48ca607bdbd17'
             '21bd9b2ba1447267c84f1b445cbcf50c62299254856c1c227cc7ba4babc9f27e'
-            'edc53917fc286f1eaca1cf5a4411feb6253543d8373a7d661a5dd354c31db015'
+            'f265628da99c0bc2a9a9a40a27d7ea0b8b783bf38200c14ee8db4ed879facbec'
             'c7a0e09fd611a6de0ed91348ba6776ad5c2c4fee4d834c61628318a374bc9318'
             '6277c30e763c7889a3446e2ce8c7b8dbe7212678497b2905582de8159831e3fb')
 
@@ -88,6 +88,8 @@ build() {
     -Dinstalled_tests=false
     -Drelocatable=true
     -Dnative_windows_loaders=true
+    -Dglycin=disabled
+    -Dandroid=disabled
     -Dothers=enabled
   )
 
@@ -100,7 +102,7 @@ build() {
     "${_meson_options[@]}" \
     --default-library=static \
     -Dbuiltin_loaders=windows \
-    -Dgtk_doc=false \
+    -Ddocumentation=false \
     -Dintrospection=disabled \
     "gdk-pixbuf-${pkgver}" \
     "build-${MSYSTEM}-static"
@@ -112,7 +114,7 @@ build() {
     "${_meson_options[@]}" \
     --default-library=shared \
     -Dbuiltin_loaders=all \
-    -Dgtk_doc=true \
+    -Ddocumentation=true \
     "gdk-pixbuf-${pkgver}" \
     "build-${MSYSTEM}-shared"
 


### PR DESCRIPTION
* 0004-build-all-loaders-plus-gdi.patch: refresh

disable some new meson build options, and rename deprecated gtk_doc to documentation