### PR TITLE
civse: fix missing import in reloc patch

### DIFF
--- a/mingw-w64-cvise/002-make-relocatable.patch
+++ b/mingw-w64-cvise/002-make-relocatable.patch
@@ -18,22 +18,24 @@
          destdir + os.path.join('@CMAKE_INSTALL_FULL_DATADIR@', '@cvise_PACKAGE@'),
          os.path.join(script_path, 'cvise'),
      ]
---- a/cvise/utils/externalprograms.py
-+++ b/cvise/utils/externalprograms.py
-@@ -29,7 +29,7 @@
+--- cvise-2.12.0/cvise/utils/externalprograms.py.orig	2025-09-23 22:51:29.000000000 +0200
++++ cvise-2.12.0/cvise/utils/externalprograms.py	2025-11-23 14:48:15.469213300 +0100
+@@ -29,7 +29,8 @@
              path = shutil.which(prog, path=local_folder)
  
              if not path:
 -                search = os.path.join('@CMAKE_INSTALL_FULL_LIBEXECDIR@', '@cvise_PACKAGE@')
++                import sys
 +                search = os.path.join(sys.prefix, 'lib', '@cvise_PACKAGE@')
                  path = shutil.which(prog, path=search)
              if not path:
                  search = DESTDIR + os.path.join('@CMAKE_INSTALL_FULL_LIBEXECDIR@', '@cvise_PACKAGE@')
-@@ -42,6 +42,6 @@
+@@ -42,6 +43,7 @@
              programs[prog] = path
  
      # Special case for clang-format
 -    programs['clang-format'] = '@CLANG_FORMAT_PATH@'
++    import shutil
 +    programs['clang-format'] = shutil.which(os.path.basename('@CLANG_FORMAT_PATH@'))
  
      return programs

--- a/mingw-w64-cvise/PKGBUILD
+++ b/mingw-w64-cvise/PKGBUILD
@@ -4,7 +4,7 @@ _realname=cvise
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.12.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Super-parallel Python port of the C-Reduce (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -38,8 +38,8 @@ source=("https://github.com/marxin/cvise/archive/v${pkgver}/${_realname}-${pkgve
         "003-fix-cvise-delta.patch"
         "004-add-basic-bash-support.patch"
         "005-fix-build-with-llvm-21.patch::https://github.com/marxin/cvise/commit/68262f7d.patch")
-sha256sums=('7eb3b2ec4e64e3033cb47e35363336f50b1313a34a106609ad1110c532389779'
-            'b37883a30063e45f29b41425a660014aaf302578202df6bf0b293ec9afe1ffb0'
+sha256sums=('d015050cfc4015460ca5793378c4899a36104ddcf084f29f0f5f6233f6187cb1'
+            'c40d6b9ffcefae8da178f6de718ea089f8a4dd641cea7e63f3e12d2553de5dab'
             '2544e65b5100f72961066e314d0ee0ccded1241e2c48c0d85e8157c932a6966b'
             'f2ad4266b9d3d43c44320725f97f4b6f94172a77dd2e38917ada20ffc25dc637'
             'd12cde7a8e7327df06db7adfb4c52f623c758048ede8ff77b9ec504c41ce1e4a')


### PR DESCRIPTION
Import inline to avoid future surprises.
Also the archive checksum changed for some reason..

Fixes #26512