### PR TITLE
creduce: backport llvm 21 support from cvice

### DIFF
--- a/mingw-w64-creduce/003-llvm21.patch
+++ b/mingw-w64-creduce/003-llvm21.patch
@@ -1,0 +1,120 @@
+diff -Nur creduce/clang_delta/CommonRenameClassRewriteVisitor.h creduce-orig/clang_delta/CommonRenameClassRewriteVisitor.h
+--- creduce/clang_delta/CommonRenameClassRewriteVisitor.h	2025-11-23 17:06:45.944165100 +0100
++++ creduce-orig/clang_delta/CommonRenameClassRewriteVisitor.h	2025-11-23 17:00:44.931567400 +0100
+@@ -310,7 +310,12 @@
+     dyn_cast<DependentTemplateSpecializationType>(Ty);
+   TransAssert(DTST && "Bad DependentTemplateSpecializationType!");
+ 
+-  const IdentifierInfo *IdInfo = DTST->getIdentifier();
++  const IdentifierInfo *IdInfo =
++#if LLVM_VERSION_MAJOR > 20
++    DTST->getDependentTemplateName().getName().getIdentifier();
++#else
++    DTST->getIdentifier();
++#endif
+   std::string IdName = IdInfo->getName().str();
+   std::string Name;
+   if (getNewNameByName(IdName, Name)) {
+diff -Nur creduce/clang_delta/RemoveNamespace.cpp creduce-orig/clang_delta/RemoveNamespace.cpp
+--- creduce/clang_delta/RemoveNamespace.cpp	2025-11-23 17:06:46.529827700 +0100
++++ creduce-orig/clang_delta/RemoveNamespace.cpp	2025-11-23 17:02:04.695912400 +0100
+@@ -440,7 +440,12 @@
+     dyn_cast<DependentTemplateSpecializationType>(Ty);
+   TransAssert(DTST && "Bad DependentTemplateSpecializationType!");
+ 
+-  const IdentifierInfo *IdInfo = DTST->getIdentifier();
++  const IdentifierInfo *IdInfo =
++#if LLVM_VERSION_MAJOR > 20
++    DTST->getDependentTemplateName().getName().getIdentifier();
++#else
++    DTST->getIdentifier();
++#endif
+   std::string IdName = IdInfo->getName().str();
+   std::string Name;
+ 
+@@ -563,7 +568,9 @@
+         break;
+       }
+       case NestedNameSpecifier::TypeSpec: // Fall-through
++#if LLVM_VERSION_MAJOR <= 20
+       case NestedNameSpecifier::TypeSpecWithTemplate:
++#endif
+         TraverseTypeLoc(Loc.getTypeLoc());
+         break;
+       default:
+diff -Nur creduce/clang_delta/RemoveUnusedFunction.cpp creduce-orig/clang_delta/RemoveUnusedFunction.cpp
+--- creduce/clang_delta/RemoveUnusedFunction.cpp	2025-11-23 17:06:45.975874900 +0100
++++ creduce-orig/clang_delta/RemoveUnusedFunction.cpp	2025-11-23 17:02:39.264543600 +0100
+@@ -254,7 +254,11 @@
+ 
+   if (FD->isReferenced() ||
+       FD->isMain() ||
++#if LLVM_VERSION_MAJOR > 20
++      FD->hasAttr<DeviceKernelAttr>() ||
++#else
+       FD->hasAttr<OpenCLKernelAttr>() ||
++#endif
+       ConsumerInstance->hasReferencedSpecialization(CanonicalFD) ||
+       ConsumerInstance->isInlinedSystemFunction(CanonicalFD) ||
+       ConsumerInstance->isInReferencedSet(CanonicalFD) ||
+diff -Nur creduce/clang_delta/RenameFun.cpp creduce-orig/clang_delta/RenameFun.cpp
+--- creduce/clang_delta/RenameFun.cpp	2025-11-23 17:06:45.975874900 +0100
++++ creduce-orig/clang_delta/RenameFun.cpp	2025-11-23 17:03:36.259131600 +0100
+@@ -261,7 +261,11 @@
+ {
+   std::string Name = FD->getNameAsString();
+   // Skip special functions
++#if LLVM_VERSION_MAJOR > 20
++  if (isSpecialFun(Name) || FD->hasAttr<DeviceKernelAttr>())
++#else
+   if (isSpecialFun(Name) || FD->hasAttr<OpenCLKernelAttr>())
++#endif
+     FunToNameMap[FD] = Name;
+ 
+   if (FunToNameMap.find(FD) != FunToNameMap.end())
+diff -Nur creduce/clang_delta/Transformation.cpp creduce-orig/clang_delta/Transformation.cpp
+--- creduce/clang_delta/Transformation.cpp	2025-11-23 17:06:46.545483200 +0100
++++ creduce-orig/clang_delta/Transformation.cpp	2025-11-23 17:01:46.110619000 +0100
+@@ -638,7 +638,10 @@
+         return NAD->getNamespace()->getCanonicalDecl();
+       }
+       case NestedNameSpecifier::TypeSpec: // Fall-through
+-      case NestedNameSpecifier::TypeSpecWithTemplate: {
++#if LLVM_VERSION_MAJOR <= 20
++      case NestedNameSpecifier::TypeSpecWithTemplate:
++#endif
++      {
+         const Type *Ty = NNS->getAsType();
+         if (const RecordType *RT = Ty->getAs<RecordType>())
+           return RT->getDecl();
+diff -Nur creduce/clang_delta/TransformationManager.cpp creduce-orig/clang_delta/TransformationManager.cpp
+--- creduce/clang_delta/TransformationManager.cpp	2025-11-23 17:06:46.545483200 +0100
++++ creduce-orig/clang_delta/TransformationManager.cpp	2025-11-23 17:06:02.474050300 +0100
+@@ -125,7 +125,12 @@
+     ClangInstance->createFileManager();
+ 
+     if(CLCPath != NULL && ClangInstance->hasFileManager() &&
+-       ClangInstance->getFileManager().getDirectory(CLCPath, false)) {
++#if LLVM_VERSION_MAJOR > 20
++       ClangInstance->getFileManager().getDirectoryRef(CLCPath, false)
++#else
++       ClangInstance->getFileManager().getDirectory(CLCPath, false)
++#endif
++    ) {
+         Args.push_back("-I");
+         Args.push_back(CLCPath);
+     }
+@@ -147,7 +152,12 @@
+ 
+   TargetInfo *Target = 
+     TargetInfo::CreateTargetInfo(ClangInstance->getDiagnostics(),
+-                                 ClangInstance->getInvocation().TargetOpts);
++#if LLVM_VERSION_MAJOR > 20
++                                 ClangInstance->getInvocation().getTargetOpts()
++#else
++                                 ClangInstance->getInvocation().TargetOpts
++#endif
++                                 );
+   ClangInstance->setTarget(Target);
+ 
+   if (const char *env = getenv("CREDUCE_INCLUDE_PATH")) {

--- a/mingw-w64-creduce/PKGBUILD
+++ b/mingw-w64-creduce/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 pkgver=2.10.0.r110.g31e855e
-pkgrel=2
+pkgrel=3
 _commit=31e855e290970cba0286e5032971509c0e7c0a80
 pkgdesc="A C program reducer (mingw-w64)"
 arch=('any')
@@ -23,13 +23,16 @@ depends=('perl-Benchmark-Timer'
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-clang"
+             "${MINGW_PACKAGE_PREFIX}-llvm"
              "git")
 source=(${_realname}::git+https://github.com/csmith-project/creduce#commit=${_commit}
         "001-llvm19.patch"
-        "002-llvm20.patch")
+        "002-llvm20.patch"
+        "003-llvm21.patch")
 sha256sums=('94887099adcc2e98dc829fb2c00b587aa8693346951bfca7674fd9086925b9e8'
             '67fd2736c16699d4e0e35c13c247c4c59ee9c0ce7c3f75403956aec0ab0f04eb'
-            '3ad5859c447ccbabee7da5818354ab91f11aeabc71948ff906eabbae508fe246')
+            '3ad5859c447ccbabee7da5818354ab91f11aeabc71948ff906eabbae508fe246'
+            'ef19134cb2872fa0d75bf7fbe067f2404fd0fc115b85028898f96ebe19f5c3dd')
 
 pkgver() {
   cd "${srcdir}/${_realname}"
@@ -53,11 +56,16 @@ prepare() {
 
   apply_patch_with_msg \
     002-llvm20.patch
+
+  # Based on https://github.com/marxin/cvise/commit/68262f7d6de584b6474801827cb7dfc68011de25
+  apply_patch_with_msg \
+    003-llvm21.patch
 }
 
 build() {
   mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
 
+  CFLAGS+=" -std=gnu17"
   ../${_realname}/configure \
       --prefix=${MINGW_PREFIX} \
       --build=${MINGW_CHOST} \


### PR DESCRIPTION
use gnu17 to avoid conflicts with "constexpr" in gnu23

Fixes #26507