### PR TITLE
python-passagemath-cddlib: add version 10.6.37 (new package)

### DIFF
--- a/mingw-w64-passagemath-cddlib/0001-allow-newer-cysignals.patch
+++ b/mingw-w64-passagemath-cddlib/0001-allow-newer-cysignals.patch
@@ -1,0 +1,60 @@
+diff --git a/PKG-INFO b/PKG-INFO
+index da2af3e..132b16b 100644
+--- a/PKG-INFO
++++ b/PKG-INFO
+@@ -30,7 +30,6 @@ Classifier: Topic :: Scientific/Engineering :: Mathematics
+ Requires-Python: <3.15,>=3.10
+ Description-Content-Type: text/x-rst
+ Requires-Dist: passagemath-environment~=10.6.37.0
+-Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
+ Requires-Dist: cysignals!=1.12.0,>=1.11.2
+ Provides-Extra: test
+ Requires-Dist: passagemath-polyhedra; extra == "test"
+diff --git a/pyproject.toml b/pyproject.toml
+index a60bce7..7810941 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -7,7 +7,7 @@ requires = [
+     'passagemath-setup ~= 10.6.37.0',
+     'passagemath-environment ~= 10.6.37.0',
+     'cython >=3.0.8, <3.2.0', 'cython >=3.0.8,<3.2.0',
+-    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
++    'cysignals >=1.11.2, != 1.12.0',
+ ]
+ build-backend = "setuptools.build_meta"
+
+@@ -16,7 +16,7 @@ name = "passagemath-cddlib"
+ description = "passagemath: Polynomial system solving through algebraic methods with cddlib"
+ dependencies = [
+     'passagemath-environment ~= 10.6.37.0',
+-    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
++    'cysignals >=1.11.2, != 1.12.0',
+ ]
+ dynamic = ["version"]
+ license = "GPL-2.0-or-later"
+diff --git a/passagemath_cddlib.egg-info/requires.txt b/passagemath_cddlib.egg-info/requires.txt
+index 38f48ce..c252984 100644
+--- a/passagemath_cddlib.egg-info/requires.txt
++++ b/passagemath_cddlib.egg-info/requires.txt
+@@ -1,9 +1,6 @@
+ passagemath-environment~=10.6.37.0
+ cysignals!=1.12.0,>=1.11.2
+
+-[:sys_platform == "win32"]
+-cysignals<1.12.4
+-
+ [test]
+ passagemath-polyhedra
+ passagemath-flint
+diff --git a/passagemath_cddlib.egg-info/PKG-INFO b/passagemath_cddlib.egg-info/PKG-INFO
+index da2af3e..132b16b 100644
+--- a/passagemath_cddlib.egg-info/PKG-INFO
++++ b/passagemath_cddlib.egg-info/PKG-INFO
+@@ -30,7 +30,6 @@ Classifier: Topic :: Scientific/Engineering :: Mathematics
+ Requires-Python: <3.15,>=3.10
+ Description-Content-Type: text/x-rst
+ Requires-Dist: passagemath-environment~=10.6.37.0
+-Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
+ Requires-Dist: cysignals!=1.12.0,>=1.11.2
+ Provides-Extra: test
+ Requires-Dist: passagemath-polyhedra; extra == "test"

--- a/mingw-w64-passagemath-cddlib/PKGBUILD
+++ b/mingw-w64-passagemath-cddlib/PKGBUILD
@@ -1,0 +1,53 @@
+# Maintainer: Dirk Stolle
+
+_realname=passagemath-cddlib
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=10.6.37
+pkgrel=1
+pkgdesc="passagemath: Polynomial system solving through algebraic methods with cddlib (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/passagemath/passagemath'
+msys2_references=(
+  'purl: pkg:pypi/passagemath-cddlib'
+)
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-cysignals"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-environment")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cddlib"
+             "${MINGW_PACKAGE_PREFIX}-cython"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-setup"
+             "${MINGW_PACKAGE_PREFIX}-python-pkgconfig"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz"
+        "0001-allow-newer-cysignals.patch")
+sha256sums=('a5ebc0a81a256d072cbc0d743a62d6b6d84768f38d35873bb8711a063a0c626e'
+            'c31624f1ddb0c6677bece2618f1fa9909da64d8993bdf3ad00a8daee5bf21cca')
+
+prepare() {
+  cd "${_realname/-/_}-${pkgver}"
+
+  patch -Np1 -i "${srcdir}/0001-allow-newer-cysignals.patch"
+}
+
+build() {
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+}


### PR DESCRIPTION
This PR adds python-passagemath-cddlib, a package to provide some functionality from passagemath (https://github.com/msys2/MINGW-packages/issues/24738).

Version 10.6.38 of passagemath has already been released but is not yet available on PyPI, so I'll continue with 10.6.37 until that changes.