### PR TITLE
cargo-*: depend on rust

### DIFF
--- a/mingw-w64-cargo-c/PKGBUILD
+++ b/mingw-w64-cargo-c/PKGBUILD
@@ -5,7 +5,7 @@ _realname=cargo-c
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.10.18
-pkgrel=1
+pkgrel=2
 pkgdesc='A cargo subcommand to build and install C-ABI compatibile dynamic and static libraries (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -16,7 +16,8 @@ msys2_references=(
   'purl: pkg:cargo/cargo-c'
 )
 license=('spdx:MIT')
-depends=("${MINGW_PACKAGE_PREFIX}-sqlite3"
+depends=("${MINGW_PACKAGE_PREFIX}-rust"
+         "${MINGW_PACKAGE_PREFIX}-sqlite3"
          "${MINGW_PACKAGE_PREFIX}-libssh2"
          "${MINGW_PACKAGE_PREFIX}-libgit2")
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust"

--- a/mingw-w64-cargo-component/PKGBUILD
+++ b/mingw-w64-cargo-component/PKGBUILD
@@ -14,8 +14,7 @@ msys2_references=(
   'purl: pkg:cargo/cargo-component'
 )
 license=('spdx:Apache-2.0')
-depends=("${MINGW_PACKAGE_PREFIX}-rust-wasm")
-makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
+depends=("${MINGW_PACKAGE_PREFIX}-rust" "${MINGW_PACKAGE_PREFIX}-rust-wasm")
 source=("${url}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('04ded8443b34687641d0bf01fa682ce46c1a9300af3f13ea5cf1bf5487d6f8b1')
 

--- a/mingw-w64-cargo-create-tauri-app/PKGBUILD
+++ b/mingw-w64-cargo-create-tauri-app/PKGBUILD
@@ -5,7 +5,7 @@ _realname=cargo-${_basename}
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.6.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Rapidly scaffold out a new tauri app project (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -14,7 +14,7 @@ msys2_references=(
   'purl: pkg:cargo/create-tauri-app'
 )
 license=('spdx:MIT OR Apache-2.0')
-makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
+depends=("${MINGW_PACKAGE_PREFIX}-rust")
 source=("${url}/archive/${_basename}-v${pkgver}/${_basename}-${_basename}-v${pkgver}.tar.gz")
 sha256sums=('4276d826717c6ec763c92f90e93609bf9e080a24812d0c958334e5f45a4e81e3')
 

--- a/mingw-w64-cargo-leptos/PKGBUILD
+++ b/mingw-w64-cargo-leptos/PKGBUILD
@@ -18,9 +18,9 @@ msys2_references=(
 license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-binaryen"
          "${MINGW_PACKAGE_PREFIX}-cargo-generate"
+         "${MINGW_PACKAGE_PREFIX}-rust"
          "${MINGW_PACKAGE_PREFIX}-rust-wasm")
 makedepends=("${MINGW_PACKAGE_PREFIX}-lld"
-             "${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-openssl")
 source=("${msys2_repository_url}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")

--- a/mingw-w64-cargo-local-registry/PKGBUILD
+++ b/mingw-w64-cargo-local-registry/PKGBUILD
@@ -4,7 +4,7 @@ _realname=cargo-local-registry
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.2.8
-pkgrel=1
+pkgrel=2
 pkgdesc="A cargo subcommand to manage local registries (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -14,11 +14,11 @@ msys2_references=(
   'purl: pkg:cargo/cargo-local-registry'
 )
 license=('spdx:MIT OR Apache-2.0')
-depends=("${MINGW_PACKAGE_PREFIX}-zlib"
+depends=("${MINGW_PACKAGE_PREFIX}-rust"
+         "${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-libssh2")
          #"${MINGW_PACKAGE_PREFIX}-libgit2")
-makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
-             "${MINGW_PACKAGE_PREFIX}-pkgconf"
+makedepends=("${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-openssl")
 source=("${url}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('7247741a99736b321a015fe4979482842b30f0923325435a48063593c3027751')

--- a/mingw-w64-cargo-tauri/PKGBUILD
+++ b/mingw-w64-cargo-tauri/PKGBUILD
@@ -5,7 +5,7 @@ _realname=cargo-${_basename}
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.9.4
-pkgrel=1
+pkgrel=2
 pkgdesc='Command line interface for building Tauri apps (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -16,8 +16,8 @@ msys2_references=(
   'purl: pkg:cargo/tauri'
 )
 license=('spdx:MIT OR Apache-2.0')
-makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
-             'git')
+depends=("${MINGW_PACKAGE_PREFIX}-rust")
+makedepends=('git')
 source=("${msys2_repository_url}/archive/${_basename}-cli-v${pkgver}/${_basename}-${_basename}-cli-v${pkgver}.tar.gz")
 noextract=("${_basename}-${_basename}-cli-v${pkgver}.tar.gz")
 sha256sums=('9bb95e1ce7dd6383b781d58b282259f7b7452741f36a1ee272b5308332ea1624')


### PR DESCRIPTION
cargo subcommands obviously require cargo, some packages even require the whole rust toolchain. cargo-msrv depends on rustup, so cargo is already pulled