### PR TITLE
python-passagemath-glpk: add version 10.6.37 (new package)

### DIFF
--- a/mingw-w64-passagemath-glpk/0001-allow-newer-cysignals.patch
+++ b/mingw-w64-passagemath-glpk/0001-allow-newer-cysignals.patch
@@ -1,0 +1,58 @@
+diff --git a/PKG-INFO b/PKG-INFO
+index da2af3e..132b16b 100644
+--- a/PKG-INFO
++++ b/PKG-INFO
+@@ -31,7 +31,6 @@ Requires-Python: <3.15,>=3.10
+ Description-Content-Type: text/x-rst
+ Requires-Dist: passagemath-objects~=10.6.37.0
+ Requires-Dist: memory_allocator
+-Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
+ Requires-Dist: cysignals!=1.12.0,>=1.11.2
+ Provides-Extra: test
+ 
+diff --git a/pyproject.toml b/pyproject.toml
+index a60bce7..7810941 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -10,7 +10,7 @@ requires = [
+     'passagemath-objects ~= 10.6.37.0',
+     'cython >=3.0.8, <3.2.0', 'cython >=3.0.8,<3.2.0',
+     'memory_allocator',
+-    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
++    'cysignals >=1.11.2, != 1.12.0',
+ ]
+ build-backend = "setuptools.build_meta"
+
+@@ -20,7 +20,7 @@ description = "passagemath: Linear and mixed integer linear optimization backend
+ dependencies = [
+     'passagemath-objects ~= 10.6.37.0',
+     'memory_allocator',
+-    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
++    'cysignals >=1.11.2, != 1.12.0',
+ ]
+ dynamic = ["version"]
+ license = "GPL-2.0-or-later"
+diff --git a/passagemath_glpk.egg-info/requires.txt b/passagemath_glpk.egg-info/requires.txt
+index 38f48ce..c252984 100644
+--- a/passagemath_glpk.egg-info/requires.txt
++++ b/passagemath_glpk.egg-info/requires.txt
+@@ -2,7 +2,4 @@ passagemath-objects~=10.6.37.0
+ memory_allocator
+ cysignals!=1.12.0,>=1.11.2
+
+-[:sys_platform == "win32"]
+-cysignals<1.12.4
+-
+ [test]
+diff --git a/passagemath_glpk.egg-info/PKG-INFO b/passagemath_glpk.egg-info/PKG-INFO
+index da2af3e..132b16b 100644
+--- a/passagemath_glpk.egg-info/PKG-INFO
++++ b/passagemath_glpk.egg-info/PKG-INFO
+@@ -31,7 +31,6 @@ Requires-Python: <3.15,>=3.10
+ Description-Content-Type: text/x-rst
+ Requires-Dist: passagemath-objects~=10.6.37.0
+ Requires-Dist: memory_allocator
+-Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
+ Requires-Dist: cysignals!=1.12.0,>=1.11.2
+ Provides-Extra: test
+ 

--- a/mingw-w64-passagemath-glpk/PKGBUILD
+++ b/mingw-w64-passagemath-glpk/PKGBUILD
@@ -1,0 +1,61 @@
+# Maintainer: Dirk Stolle
+
+_realname=passagemath-glpk
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=10.6.37
+pkgrel=1
+pkgdesc="passagemath: Linear and mixed integer linear optimization backend using GLPK (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/passagemath/passagemath'
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-glpk"
+         "${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-cysignals"
+         "${MINGW_PACKAGE_PREFIX}-python-memory-allocator"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-objects")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cython"
+             "${MINGW_PACKAGE_PREFIX}-gmp"
+             "${MINGW_PACKAGE_PREFIX}-mpc"
+             "${MINGW_PACKAGE_PREFIX}-mpfr"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-categories"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-environment"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-setup"
+             "${MINGW_PACKAGE_PREFIX}-python-pkgconfig"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz"
+        "0001-allow-newer-cysignals.patch")
+sha256sums=('2dd57703430e30c3d46a6b7912def5ff81f5bd5c185430a9c88f45a2659af62b'
+            '134c86f85f07022f59ccc191df82658ce15b67b5583653893eaf27d0a7d633b3')
+
+prepare() {
+  cd "${_realname/-/_}-${pkgver}"
+
+  patch -Np1 -i "${srcdir}/0001-allow-newer-cysignals.patch"
+}
+
+build() {
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  # fix to link zlib as -lz instead of -lzlib
+  sed -i 's/ZLIB_LIBRARIES/z/g' sage/libs/glpk/env.pxd
+  sed -i 's/ZLIB_LIBRARIES/z/g' sage/libs/glpk/graph.pxd
+  sed -i 's/ZLIB_LIBRARIES/z/g' sage/libs/glpk/lp.pxd
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+}


### PR DESCRIPTION
This PR adds python-passagemath-glpk, a package to provide some functionality from passagemath (https://github.com/msys2/MINGW-packages/issues/24738).

Version 10.6.38 of passagemath has already been released but is not yet available on PyPI, so I'll continue with 10.6.37 until that changes.