### PR TITLE
libxslt: Update to 1.1.44

### DIFF
--- a/mingw-w64-libxslt/PKGBUILD
+++ b/mingw-w64-libxslt/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=libxslt
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.1.43
-pkgrel=4
+pkgver=1.1.44
+pkgrel=1
 pkgdesc="XML stylesheet transformation library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -17,11 +17,11 @@ depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
          "${MINGW_PACKAGE_PREFIX}-libxml2")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools")
-source=("https://download.gnome.org/sources/libxslt/${pkgver%.*}/${_realname}-${pkgver}.tar.xz"
+source=("https://gitlab.gnome.org/GNOME/libxslt/-/archive/v${pkgver}/libxslt-v${pkgver}.tar.gz"
         '0001-pkgconfig-add-cflags-private.patch'
         '0003-fix-concurrent-directory-creation.all.patch'
         '0010-xslt-config-win-paths.patch')
-sha256sums=('5a3d6b383ca5afc235b171118e90f5ff6aa27e9fea3303065231a6d403f0183a'
+sha256sums=('f306393d1913ca42946429e22baaa36dd6639de9b23b19765023961bea01dd6e'
             '7ece75b9f1ff1e3e1c37adcc0e5f236f80a0a6546f506125da8694533f73c2e3'
             '322053cefed25e89e2c0f87720df7ee2cc5b090213e91724c8980cafa3f9c942'
             '9e7a75d479e5cd799b52ccfe5762c18f4d9af0dc687fab257ef2dec6e71a08f1')
@@ -46,7 +46,7 @@ del_file_exists() {
 # =========================================== #
 
 prepare() {
-  cd "${srcdir}/${_realname}-${pkgver}"
+  cd "${srcdir}/${_realname}-v${pkgver}"
   apply_patch_with_msg \
     "0001-pkgconfig-add-cflags-private.patch" \
     "0003-fix-concurrent-directory-creation.all.patch" \
@@ -59,7 +59,7 @@ build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}-static" && cd "${srcdir}/build-${MSYSTEM}-static"
 
   CPPFLAGS+=" -DLIBXML_STATIC -DLIBEXSLT_STATIC -DLIBXSLT_STATIC" \
-  ../${_realname}-${pkgver}/configure \
+  ../${_realname}-v${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \
@@ -74,7 +74,7 @@ build() {
 
   mkdir -p "${srcdir}/build-${MSYSTEM}-shared" && cd "${srcdir}/build-${MSYSTEM}-shared"
 
- ../${_realname}-${pkgver}/configure \
+ ../${_realname}-v${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \


### PR DESCRIPTION
there is no tarball (new maintainer, so might take some time), so just use gitlab instead.