### PR TITLE
gspell: Update to 1.14.1

### DIFF
--- a/mingw-w64-gspell/PKGBUILD
+++ b/mingw-w64-gspell/PKGBUILD
@@ -3,28 +3,27 @@
 _realname=gspell
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.14.0
-pkgrel=4
+pkgver=1.14.1
+pkgrel=1
 pkgdesc="Spell-checking library for GTK applications (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://gitlab.gnome.org/GNOME/gspell"
 license=('spdx:LGPL-2.1-or-later')
-depends=("${MINGW_PACKAGE_PREFIX}-gtk3"
+depends=("${MINGW_PACKAGE_PREFIX}-enchant"
+         "${MINGW_PACKAGE_PREFIX}-gettext-runtime"
+         "${MINGW_PACKAGE_PREFIX}-glib2"
+         "${MINGW_PACKAGE_PREFIX}-gtk3"
          "${MINGW_PACKAGE_PREFIX}-icu"
-         "${MINGW_PACKAGE_PREFIX}-enchant")
+         "${MINGW_PACKAGE_PREFIX}-pango")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-vala"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
              "${MINGW_PACKAGE_PREFIX}-gtk-doc")
-source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz)
-sha256sums=('64ea1d8e9edc1c25b45a920e80daf67559d1866ffcd7f8432fecfea6d0fe8897')
-
-prepare() {
-  cd "${srcdir}"/${_realname}-${pkgver}
-}
+source=("https://gitlab.gnome.org/GNOME/gspell/-/archive/${pkgver}/${_realname}-${pkgver}.tar.bz2")
+sha256sums=('31c1ee70e730a45964ad12da0b1f49426878e8a670edd22b03f5cdc54a186237')
 
 build() {
   MSYS2_ARG_CONV_EXCL="--prefix=" \
@@ -33,6 +32,7 @@ build() {
       --wrap-mode=nodownload \
       --auto-features=enabled \
       --buildtype=plain \
+      -Dtests=false \
       -Dinstall_tests=false \
       "build-${MSYSTEM}" \
       "${_realname}-${pkgver}"


### PR DESCRIPTION
For gspell, *.tar.xz tarballs are no longer available on download.gnome.org for the new versions. See:
- https://discourse.gnome.org/t/new-way-of-releasing-gspell/31753
- https://gitlab.gnome.org/GNOME/gspell/-/commit/de7091cf01ad6b8a7c55cb6c3eaa6bd2eda5403f

So for the source, do something similar to libgedit-gfls, which is a similar library, also hosted on GNOME's GitLab.

Additional note: I'm the upstream maintainer ;-)