### PR TITLE
python-gmpy2: update to 2.2.2

### DIFF
--- a/mingw-w64-python-gmpy2/PKGBUILD
+++ b/mingw-w64-python-gmpy2/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=gmpy2
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=2.2.1
-pkgrel=2
+pkgver=2.2.2
+pkgrel=1
 pkgdesc="Provides C-coded Python modules for fast multiple-precision arithmetic (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -12,7 +12,7 @@ msys2_references=(
   'archlinux: python-gmpy2'
   'purl: pkg:pypi/gmpy2'
 )
-msys2_repository_url='https://github.com/aleaxit/gmpy'
+msys2_repository_url='https://github.com/gmpy2/gmpy2'
 url='https://gmpy2.readthedocs.io/'
 license=('spdx:LGPL-3.0-or-later OR GPL-3.0-or-later')
 depends=(
@@ -28,7 +28,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-setuptools"
 )
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('e83e07567441b78cb87544910cb3cc4fe94e7da987e93ef7622e76fb96650432')
+sha256sums=('d9b8c81e0f5e1a3cabf1ea8d154b29b5ef6e33b8f4e4c37b3da957b2dd6a3fa8')
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"


### PR DESCRIPTION
gmpy2 had a maintainer change (see https://github.com/gmpy2/gmpy2/issues/605) and the repository URL also changed.