### PR TITLE
python-installer: don't use "<launcher_dir>" with normal scripts

### DIFF
--- a/mingw-w64-python-installer/001-launcher-relative.patch
+++ b/mingw-w64-python-installer/001-launcher-relative.patch
@@ -1,11 +1,20 @@
---- installer-0.5.1/src/installer/__main__.py.orig	2022-06-19 18:30:28.683232600 +0200
-+++ installer-0.5.1/src/installer/__main__.py	2022-06-19 18:32:39.694046700 +0200
-@@ -86,7 +86,7 @@
-     with WheelFile.open(args.wheel) as source:
-         destination = SchemeDictionaryDestination(
-             scheme_dict=_get_scheme_dict(source.distribution, prefix=args.prefix),
--            interpreter=sys.executable,
-+            interpreter= r'<launcher_dir>\python.exe',
-             script_kind=get_launcher_kind(),
-             bytecode_optimization_levels=bytecode_levels,
-             destdir=args.destdir,
+--- installer-0.7.0/src/installer/destinations.py.orig	2025-11-28 19:46:57.490807700 +0100
++++ installer-0.7.0/src/installer/destinations.py	2025-11-28 19:48:13.717915600 +0100
+@@ -199,7 +199,7 @@
+         path_ = os.fspath(path)
+ 
+         if scheme == "scripts":
+-            with fix_shebang(stream, self.interpreter) as stream_with_different_shebang:
++            with fix_shebang(stream, '/usr/bin/env ' + os.path.splitext(os.path.basename(self.interpreter))[0]) as stream_with_different_shebang:
+                 return self.write_to_fs(
+                     scheme, path_, stream_with_different_shebang, is_executable
+                 )
+@@ -224,7 +224,7 @@
+           filesystem interaction.
+         """
+         script = Script(name, module, attr, section)
+-        script_name, data = script.generate(self.interpreter, self.script_kind)
++        script_name, data = script.generate("<launcher_dir>\\" + os.path.basename(self.interpreter), self.script_kind)
+ 
+         with io.BytesIO(data) as stream:
+             entry = self.write_to_fs(

--- a/mingw-w64-python-installer/PKGBUILD
+++ b/mingw-w64-python-installer/PKGBUILD
@@ -4,7 +4,7 @@ _realname=installer
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=0.7.0
-pkgrel=4
+pkgrel=5
 pkgdesc="A low-level library for installing from a Python wheel distribution (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -27,8 +27,8 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
         "003-launcher-secure-api-shim.patch"
         "004-zero-reservered-fields-in-startupinfo.patch")
 sha256sums=('a26d3e3116289bb08216e0d0f7d925fcef0b0194eedfa0c944bcaaa106c4b631'
-            'SKIP'
-            'c83360c3ffca0b278b05841a3a39b784df42a4d5fbaf2823c2a7e3f32fe8ebc4'
+            '0dc8e2a1e21943a2c81ef4fd22c058a561626b2ba0efa38784df1f4a28a71e8b'
+            'a03dc0cb9272a233831ab41ed55d9a64196ab10a750d0517c67745cc5214eb79'
             'e95b68c14bffddd6dd859bdb2c8feb733bbcd5c9d4a37105df4196bfa01923c5'
             '0b6ab782f1550ea0e52a8869cf9c78c405a9ed9dda1e9d9eb60a4126787db208'
             'ccb341afa03809257d0c9c6c5d323b9998d21ff972789eb8c1734d5bc2a7fbff')
@@ -36,6 +36,9 @@ sha256sums=('a26d3e3116289bb08216e0d0f7d925fcef0b0194eedfa0c944bcaaa106c4b631'
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
+  # To keep the generated launchers and scipts relocatable:
+  # * For python launchers we use "<launcher_dir>\<interpreter>.exe" which simple_launcher understands
+  # * For old-style scripts we use '/usr/bin/env <interpreter>' which at least cygwin understands
   patch -Np1 -i "${srcdir}/001-launcher-relative.patch"
 
   cd "${srcdir}/simple_launcher"


### PR DESCRIPTION
installer not only generates launcher scripts, it also rewrites shebangs for old-style setuptools scripts. In that case we need to write a real shebang and not just one which simple_launcher understands.

Instead of patching the source interpreter path, derive the relocatable shebang from it in both places.

This came up in
https://github.com/msys2/MINGW-packages/issues/24738#issuecomment-3579042058