### PR TITLE
libhomfly: add version 1.03 (new package)

### DIFF
--- a/mingw-w64-libhomfly/PKGBUILD
+++ b/mingw-w64-libhomfly/PKGBUILD
@@ -1,0 +1,50 @@
+# Maintainer: Dirk Stolle
+
+_realname=libhomfly
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.03
+pkgrel=1
+pkgdesc="Library to compute the homfly polynomial of a link (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/miguelmarco/libhomfly'
+msys2_references=(
+  'anitya: 27573'
+  'archlinux: libhomfly'
+  'gentoo: sci-libs/libhomfly'
+)
+license=('spdx:Unlicense')
+depends=("${MINGW_PACKAGE_PREFIX}-gc")
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+source=("https://github.com/miguelmarco/libhomfly/archive/${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('2d39075633f1f5bd3179fe2cf47e05dde471dca05546cc4cc50943f537242acc')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+
+  autoreconf -fiv
+}
+
+build() {
+  mkdir -p "build-${MSYSTEM}" && cd "build-${MSYSTEM}"
+
+  ../"${_realname}-${pkgver}"/configure \
+    --prefix="${MINGW_PREFIX}" \
+    --build="${MINGW_CHOST}" \
+    --host="${MINGW_CHOST}" \
+    --target="${MINGW_CHOST}" \
+    --enable-static \
+    --enable-shared
+
+  make
+}
+
+package() {
+  cd "build-${MSYSTEM}"
+
+  make install DESTDIR="${pkgdir}"
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
libhomfly is required to build passagemath-homfly, one of the packages of passagemath (<https://github.com/msys2/MINGW-packages/issues/24738>), so let's package it.


libhomfly is also available in several other distributions, for example:
* Arch Linux: https://archlinux.org/packages/extra/x86_64/libhomfly/
* Debian: https://packages.debian.org/source/trixie/libhomfly
* Gentoo: https://packages.gentoo.org/packages/sci-libs/libhomfly
* Void Linux: https://github.com/void-linux/void-packages/tree/master/srcpkgs/libhomfly