### PR TITLE
libxml2: restore Python bindings again

### DIFF
--- a/mingw-w64-libxml2/PKGBUILD
+++ b/mingw-w64-libxml2/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
 pkgver=2.15.1
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 pkgdesc="XML parsing library, version 2 (mingw-w64)"
@@ -17,7 +17,9 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-tools"
              "${MINGW_PACKAGE_PREFIX}-libxslt"
              "${MINGW_PACKAGE_PREFIX}-docbook-xsl"
-             "${MINGW_PACKAGE_PREFIX}-doxygen")
+             "${MINGW_PACKAGE_PREFIX}-doxygen"
+             "${MINGW_PACKAGE_PREFIX}-python")
+optdepends=("${MINGW_PACKAGE_PREFIX}-python: Python bindings")
 license=('spdx:MIT')
 url="https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home"
 msys2_repository_url="https://gitlab.gnome.org/GNOME/libxml2"
@@ -94,7 +96,7 @@ build() {
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \
     --build="${MINGW_CHOST}" \
-    --without-python \
+    --with-python \
     --with-modules \
     --with-legacy \
     --with-http \
@@ -114,6 +116,9 @@ check() {
 package_libxml2() {
   # First install shared
   make -C "${srcdir}"/build-shared-${MSYSTEM} install DESTDIR="${pkgdir}"
+
+  MSYS2_ARG_CONV_EXCL="-p" python -m compileall \
+    -o 0 -o 1 -q -s"${pkgdir}" -p"/" "${pkgdir}${MINGW_PREFIX}/lib/python"*
 
   # then manually install static
   install -m 0644 "${srcdir}"/build-static-${MSYSTEM}/.libs/libxml2.a "${pkgdir}${MINGW_PREFIX}"/lib/


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/gimp-help needs it still