### PR TITLE
python-passagemath-homfly: add version 10.6.38 (new package)

### DIFF
--- a/mingw-w64-passagemath-homfly/0001-allow-newer-cysignals.patch
+++ b/mingw-w64-passagemath-homfly/0001-allow-newer-cysignals.patch
@@ -1,0 +1,59 @@
+diff --git a/PKG-INFO b/PKG-INFO.modified
+index da2af3e..132b16b 100644
+--- a/PKG-INFO
++++ b/PKG-INFO
+@@ -29,7 +29,6 @@ Classifier: Programming Language :: Python :: Implementation :: CPython
+ Classifier: Topic :: Scientific/Engineering :: Mathematics
+ Requires-Python: <3.15,>=3.10
+ Description-Content-Type: text/x-rst
+-Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
+ Requires-Dist: cysignals!=1.12.0,>=1.11.2
+ Provides-Extra: test
+ Requires-Dist: passagemath-graphs; extra == "test"
+diff --git a/pyproject.toml b/pyproject.toml.modified
+index a60bce7..7810941 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -7,7 +7,7 @@ requires = [
+     'passagemath-environment ~= 10.6.38.0',
+     'passagemath-objects ~= 10.6.38.0',
+     'cython >=3.0.8, <3.2.0', 'cython >=3.0.8,<3.2.0',
+-    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
++    'cysignals >=1.11.2, != 1.12.0',
+     'pkgconfig',
+ ]
+ build-backend = "setuptools.build_meta"
+@@ -16,7 +16,7 @@ build-backend = "setuptools.build_meta"
+ name = "passagemath-homfly"
+ description = "passagemath: Homfly polynomials of knots/links with libhomfly"
+ dependencies = [
+-    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
++    'cysignals >=1.11.2, != 1.12.0',
+ ]
+ dynamic = ["version"]
+ license = "GPL-2.0-or-later"
+diff --git a/passagemath_homfly.egg-info/requires.txt b/passagemath_homfly.egg-info/requires.txt.modified
+index 38f48ce..c252984 100644
+--- a/passagemath_homfly.egg-info/requires.txt
++++ b/passagemath_homfly.egg-info/requires.txt
+@@ -1,8 +1,5 @@
+ cysignals!=1.12.0,>=1.11.2
+
+-[:sys_platform == "win32"]
+-cysignals<1.12.4
+-
+ [test]
+ passagemath-graphs
+ passagemath-repl
+diff --git a/passagemath_homfly.egg-info/PKG-INFO b/passagemath_homfly.egg-info/PKG-INFO.modified
+index da2af3e..132b16b 100644
+--- a/passagemath_homfly.egg-info/PKG-INFO
++++ b/passagemath_homfly.egg-info/PKG-INFO
+@@ -29,7 +29,6 @@ Classifier: Programming Language :: Python :: Implementation :: CPython
+ Classifier: Topic :: Scientific/Engineering :: Mathematics
+ Requires-Python: <3.15,>=3.10
+ Description-Content-Type: text/x-rst
+-Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
+ Requires-Dist: cysignals!=1.12.0,>=1.11.2
+ Provides-Extra: test
+ Requires-Dist: passagemath-graphs; extra == "test"

--- a/mingw-w64-passagemath-homfly/PKGBUILD
+++ b/mingw-w64-passagemath-homfly/PKGBUILD
@@ -1,0 +1,54 @@
+# Maintainer: Dirk Stolle
+
+_realname=passagemath-homfly
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=10.6.38
+pkgrel=1
+pkgdesc="passagemath: Homfly polynomials of knots/links with libhomfly (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/passagemath/passagemath'
+msys2_references=(
+  'purl: pkg:pypi/passagemath-homfly'
+)
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-libhomfly"
+         "${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-cysignals")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cython"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-environment"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-objects"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-setup"
+             "${MINGW_PACKAGE_PREFIX}-python-pkgconfig"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz"
+        "0001-allow-newer-cysignals.patch")
+sha256sums=('3f3461f94f1c5ebdc45036d8a0e397901aab0a4103195f327a41a8910459c3c6'
+            '0f902f3a9c5bbea8ef21ce2454c75be7debe5e12239e8d4466199fe2a0ee97d6')
+
+prepare() {
+  cd "${_realname/-/_}-${pkgver}"
+
+  patch -Np1 -i "${srcdir}/0001-allow-newer-cysignals.patch"
+}
+
+build() {
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+}


### PR DESCRIPTION
This PR adds python-passagemath-homfly, a package to provide some functionality from passagemath (https://github.com/msys2/MINGW-packages/issues/24738).

Now that libhomfly is available in MSYS2 (#26604), this part of passagemath can be built, too.