### PR TITLE
python-passagemath-nauty: add version 10.6.38 (new package)

### DIFF
--- a/mingw-w64-passagemath-nauty/0001-allow-newer-cysignals.patch
+++ b/mingw-w64-passagemath-nauty/0001-allow-newer-cysignals.patch
@@ -1,0 +1,59 @@
+diff --git a/PKG-INFO b/PKG-INFO
+index da2af3e..132b16b 100644
+--- a/PKG-INFO
++++ b/PKG-INFO
+@@ -29,7 +29,6 @@ Classifier: Programming Language :: Python :: Implementation :: CPython
+ Classifier: Topic :: Scientific/Engineering :: Mathematics
+ Requires-Python: <3.15,>=3.10
+ Description-Content-Type: text/x-rst
+-Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
+ Requires-Dist: cysignals!=1.12.0,>=1.11.2
+ Requires-Dist: passagemath-environment~=10.6.38.0
+ Requires-Dist: passagemath-graphs~=10.6.38.0
+diff --git a/pyproject.toml b/pyproject.toml
+index a60bce7..7810941 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -7,7 +7,7 @@ requires = [
+     'passagemath-setup ~= 10.6.38.0',
+     'passagemath-environment ~= 10.6.38.0',
+     'cython >=3.0.8, <3.2.0', 'cython >=3.0.8,<3.2.0',
+-    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
++    'cysignals >=1.11.2, != 1.12.0',
+ ]
+ build-backend = "setuptools.build_meta"
+
+@@ -15,7 +15,7 @@ build-backend = "setuptools.build_meta"
+ name = "passagemath-nauty"
+ description = "passagemath: Find automorphism groups of graphs, generate non-isomorphic graphs with nauty"
+ dependencies = [
+-    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
++    'cysignals >=1.11.2, != 1.12.0',
+     'passagemath-environment ~= 10.6.38.0',
+     'passagemath-graphs ~= 10.6.38.0',
+ ]
+diff --git a/passagemath_nauty.egg-info/requires.txt b/passagemath_nauty.egg-info/requires.txt
+index 38f48ce..c252984 100644
+--- a/passagemath_nauty.egg-info/requires.txt
++++ b/passagemath_nauty.egg-info/requires.txt
+@@ -2,8 +2,5 @@ cysignals!=1.12.0,>=1.11.2
+ passagemath-environment~=10.6.38.0
+ passagemath-graphs~=10.6.38.0
+
+-[:sys_platform == "win32"]
+-cysignals<1.12.4
+-
+ [test]
+ passagemath-repl
+diff --git a/passagemath_nauty.egg-info/PKG-INFO b/passagemath_nauty.egg-info/PKG-INFO.modified
+index da2af3e..132b16b 100644
+--- a/passagemath_nauty.egg-info/PKG-INFO
++++ b/passagemath_nauty.egg-info/PKG-INFO
+@@ -29,7 +29,6 @@ Classifier: Programming Language :: Python :: Implementation :: CPython
+ Classifier: Topic :: Scientific/Engineering :: Mathematics
+ Requires-Python: <3.15,>=3.10
+ Description-Content-Type: text/x-rst
+-Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
+ Requires-Dist: cysignals!=1.12.0,>=1.11.2
+ Requires-Dist: passagemath-environment~=10.6.38.0
+ Requires-Dist: passagemath-graphs~=10.6.38.0

--- a/mingw-w64-passagemath-nauty/PKGBUILD
+++ b/mingw-w64-passagemath-nauty/PKGBUILD
@@ -1,0 +1,55 @@
+# Maintainer: Dirk Stolle
+
+_realname=passagemath-nauty
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=10.6.38
+pkgrel=1
+pkgdesc="passagemath: Find automorphism groups of graphs, generate non-isomorphic graphs with nauty (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/passagemath/passagemath'
+msys2_references=(
+  'purl: pkg:pypi/passagemath-nauty'
+)
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-nauty"
+         "${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-cysignals"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-environment"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-graphs")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cython"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-setup"
+             "${MINGW_PACKAGE_PREFIX}-python-pkgconfig"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz"
+        "0001-allow-newer-cysignals.patch")
+sha256sums=('3bb820ae97440df220df13c1ac5fb1d51a032b981f2bb7139a11d6abf496bb44'
+            '55667930b60e76f9d58443ad4a94d67c4b842e1aabcfbaff5f454f0395d92726')
+
+prepare() {
+  cd "${_realname/-/_}-${pkgver}"
+
+  # Loosen a constraint on cysignals so that the version packaged in MSYS2 is accepted.
+  patch -Nbp1 -i "${srcdir}/0001-allow-newer-cysignals.patch"
+}
+
+build() {
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+}


### PR DESCRIPTION
This PR adds python-passagemath-nauty, a package to provide some functionality from passagemath (https://github.com/msys2/MINGW-packages/issues/24738).