### PR TITLE
passagemath: update to 10.6.39

### DIFF
--- a/mingw-w64-passagemath-categories/PKGBUILD
+++ b/mingw-w64-passagemath-categories/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-categories
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.38
+pkgver=10.6.39
 pkgrel=1
 pkgdesc="passagemath: Sage categories and basic rings (mingw-w64)"
 arch=('any')
@@ -31,7 +31,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('ac829a482eb7c0984d3dc4a356378c65434e48ef7fe214fe38dda04dba36013f')
+sha256sums=('9ebe10b7a2a9dbdbed6786922788b7da5e04043f8d23ebba45f8f54c58d8aa7f')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-cddlib/0001-allow-newer-cysignals.patch
+++ b/mingw-w64-passagemath-cddlib/0001-allow-newer-cysignals.patch
@@ -5,7 +5,7 @@ index da2af3e..132b16b 100644
 @@ -30,7 +30,6 @@ Classifier: Topic :: Scientific/Engineering :: Mathematics
  Requires-Python: <3.15,>=3.10
  Description-Content-Type: text/x-rst
- Requires-Dist: passagemath-environment~=10.6.38.0
+ Requires-Dist: passagemath-environment~=10.6.39.0
 -Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
  Requires-Dist: cysignals!=1.12.0,>=1.11.2
  Provides-Extra: test
@@ -15,8 +15,8 @@ index a60bce7..7810941 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
 @@ -7,7 +7,7 @@ requires = [
-     'passagemath-setup ~= 10.6.38.0',
-     'passagemath-environment ~= 10.6.38.0',
+     'passagemath-setup ~= 10.6.39.0',
+     'passagemath-environment ~= 10.6.39.0',
      'cython >=3.0.8, <3.2.0', 'cython >=3.0.8,<3.2.0',
 -    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
 +    'cysignals >=1.11.2, != 1.12.0',
@@ -26,7 +26,7 @@ index a60bce7..7810941 100644
 @@ -16,7 +16,7 @@ name = "passagemath-cddlib"
  description = "passagemath: Polynomial system solving through algebraic methods with cddlib"
  dependencies = [
-     'passagemath-environment ~= 10.6.38.0',
+     'passagemath-environment ~= 10.6.39.0',
 -    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
 +    'cysignals >=1.11.2, != 1.12.0',
  ]
@@ -37,7 +37,7 @@ index 38f48ce..c252984 100644
 --- a/passagemath_cddlib.egg-info/requires.txt
 +++ b/passagemath_cddlib.egg-info/requires.txt
 @@ -1,9 +1,6 @@
- passagemath-environment~=10.6.38.0
+ passagemath-environment~=10.6.39.0
  cysignals!=1.12.0,>=1.11.2
 
 -[:sys_platform == "win32"]
@@ -53,7 +53,7 @@ index da2af3e..132b16b 100644
 @@ -30,7 +30,6 @@ Classifier: Topic :: Scientific/Engineering :: Mathematics
  Requires-Python: <3.15,>=3.10
  Description-Content-Type: text/x-rst
- Requires-Dist: passagemath-environment~=10.6.38.0
+ Requires-Dist: passagemath-environment~=10.6.39.0
 -Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
  Requires-Dist: cysignals!=1.12.0,>=1.11.2
  Provides-Extra: test

--- a/mingw-w64-passagemath-cddlib/PKGBUILD
+++ b/mingw-w64-passagemath-cddlib/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-cddlib
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.38
+pkgver=10.6.39
 pkgrel=1
 pkgdesc="passagemath: Polynomial system solving through algebraic methods with cddlib (mingw-w64)"
 arch=('any')
@@ -29,13 +29,14 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz"
         "0001-allow-newer-cysignals.patch")
-sha256sums=('7a2df1b03b47fbde50b428997db7fa9f47e0bb91175503761f1b442839e1b77d'
-            'a4cf12487b9b6672aa46f031050ca42c19e9d06adf96fb0732d566ac595c2c04')
+sha256sums=('e1c0a0498a50390852f20ccdd572de6e926feeca1699c9c09b711ac7c73cf15e'
+            'a942fe61e67ff6f981efcc5e6d0d5630ef5e610e39ab7bd73c77c48b059b62cf')
 
 prepare() {
   cd "${_realname/-/_}-${pkgver}"
 
-  patch -Np1 -i "${srcdir}/0001-allow-newer-cysignals.patch"
+  # Loosen a constraint on cysignals so that the version packaged in MSYS2 is accepted.
+  patch -Nbp1 -i "${srcdir}/0001-allow-newer-cysignals.patch"
 }
 
 build() {

--- a/mingw-w64-passagemath-cmr/0001-allow-newer-cysignals.patch
+++ b/mingw-w64-passagemath-cmr/0001-allow-newer-cysignals.patch
@@ -8,15 +8,15 @@ index da2af3e..132b16b 100644
  Description-Content-Type: text/x-rst
 -Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
  Requires-Dist: cysignals!=1.12.0,>=1.11.2
- Requires-Dist: passagemath-modules~=10.6.38.0
- Requires-Dist: passagemath-graphs~=10.6.38.0
+ Requires-Dist: passagemath-modules~=10.6.39.0
+ Requires-Dist: passagemath-graphs~=10.6.39.0
 diff --git a/pyproject.toml b/pyproject.toml
 index a60bce7..7810941 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
 @@ -9,7 +9,7 @@ requires = [
-     'passagemath-modules ~= 10.6.38.0',
-     'passagemath-graphs ~= 10.6.38.0',
+     'passagemath-modules ~= 10.6.39.0',
+     'passagemath-graphs ~= 10.6.39.0',
      'cython >=3.0.8, <3.2.0', 'cython >=3.0.8,<3.2.0',
 -    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
 +    'cysignals >=1.11.2, != 1.12.0',
@@ -29,23 +29,23 @@ index a60bce7..7810941 100644
  dependencies = [
 -    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
 +    'cysignals >=1.11.2, != 1.12.0',
-     'passagemath-modules ~= 10.6.38.0',
-     'passagemath-graphs ~= 10.6.38.0',
+     'passagemath-modules ~= 10.6.39.0',
+     'passagemath-graphs ~= 10.6.39.0',
  ]
 diff --git a/passagemath_cmr.egg-info/requires.txt b/passagemath_cmr.egg-info/requires.txt
 index 38f48ce..c252984 100644
 --- a/passagemath_cmr.egg-info/requires.txt
 +++ b/passagemath_cmr.egg-info/requires.txt
 @@ -2,9 +2,6 @@ cysignals!=1.12.0,>=1.11.2
- passagemath-modules~=10.6.38.0
- passagemath-graphs~=10.6.38.0
+ passagemath-modules~=10.6.39.0
+ passagemath-graphs~=10.6.39.0
 
 -[:sys_platform == "win32"]
 -cysignals<1.12.4
 -
  [test]
- passagemath-repl~=10.6.38.0
- passagemath-pari~=10.6.38.0
+ passagemath-repl~=10.6.39.0
+ passagemath-pari~=10.6.39.0
 diff --git a/passagemath_cmr.egg-info/PKG-INFO b/passagemath_cmr.egg-info/PKG-INFO
 index da2af3e..132b16b 100644
 --- a/passagemath_cmr.egg-info/PKG-INFO
@@ -56,5 +56,5 @@ index da2af3e..132b16b 100644
  Description-Content-Type: text/x-rst
 -Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
  Requires-Dist: cysignals!=1.12.0,>=1.11.2
- Requires-Dist: passagemath-modules~=10.6.38.0
- Requires-Dist: passagemath-graphs~=10.6.38.0
+ Requires-Dist: passagemath-modules~=10.6.39.0
+ Requires-Dist: passagemath-graphs~=10.6.39.0

--- a/mingw-w64-passagemath-cmr/PKGBUILD
+++ b/mingw-w64-passagemath-cmr/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-cmr
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.38
+pkgver=10.6.39
 pkgrel=1
 pkgdesc="passagemath: Combinatorial matrix recognition (mingw-w64)"
 arch=('any')
@@ -31,13 +31,14 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz"
         "0001-allow-newer-cysignals.patch")
-sha256sums=('9d4c0c4fbf27a6b713c12655470f422e24e23a91b978eafccb6ae2a566b04110'
-            '52075d200cf3eae6c2f90399d214df6084b1f035561082d15731339125a1ef18')
+sha256sums=('6b7224b30d370f175c050f3fd30411f88db612943514f5d2691e731cf154777e'
+            'a1d7fa3c574adf40065e5618a45c9c9f91e1f461a483bcb7c1b7a096b096ac17')
 
 prepare() {
   cd "${_realname/-/_}-${pkgver}"
 
-  patch -Np1 -i "${srcdir}/0001-allow-newer-cysignals.patch"
+  # Loosen a constraint on cysignals so that the version packaged in MSYS2 is accepted.
+  patch -Nbp1 -i "${srcdir}/0001-allow-newer-cysignals.patch"
 }
 
 build() {

--- a/mingw-w64-passagemath-combinat/0001-allow-newer-cysignals.patch
+++ b/mingw-w64-passagemath-combinat/0001-allow-newer-cysignals.patch
@@ -9,13 +9,13 @@ index da2af3e..132b16b 100644
 -Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
  Requires-Dist: cysignals!=1.12.0,>=1.11.2
  Requires-Dist: memory_allocator
- Requires-Dist: passagemath-categories~=10.6.38.0
+ Requires-Dist: passagemath-categories~=10.6.39.0
 diff --git a/pyproject.toml b/pyproject.toml.modified
 index a60bce7..7810941 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
 @@ -9,7 +9,7 @@ requires = [
-     'passagemath-categories ~= 10.6.38.0',
+     'passagemath-categories ~= 10.6.39.0',
      'cython >=3.0.8, <3.2.0', 'cython >=3.0.8,<3.2.0',
      'gmpy2 ~=2.1.b999',
 -    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
@@ -30,15 +30,15 @@ index a60bce7..7810941 100644
 -    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
 +    'cysignals >=1.11.2, != 1.12.0',
      'memory_allocator',
-     'passagemath-categories ~= 10.6.38.0',
-     'passagemath-environment ~= 10.6.38.0',
+     'passagemath-categories ~= 10.6.39.0',
+     'passagemath-environment ~= 10.6.39.0',
 diff --git a/passagemath_objects.egg-info/requires.txt b/passagemath_objects.egg-info/requires.txt.modified
 index 38f48ce..c252984 100644
 --- a/passagemath_combinat.egg-info/requires.txt
 +++ b/passagemath_combinat.egg-info/requires.txt
 @@ -4,9 +4,6 @@ memory_allocator
- passagemath-categories~=10.6.38.0
- passagemath-environment~=10.6.38.0
+ passagemath-categories~=10.6.39.0
+ passagemath-environment~=10.6.39.0
 
 -[:sys_platform == "win32"]
 -cysignals<1.12.4
@@ -57,4 +57,4 @@ index da2af3e..132b16b 100644
 -Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
  Requires-Dist: cysignals!=1.12.0,>=1.11.2
  Requires-Dist: memory_allocator
- Requires-Dist: passagemath-categories~=10.6.38.0
+ Requires-Dist: passagemath-categories~=10.6.39.0

--- a/mingw-w64-passagemath-combinat/PKGBUILD
+++ b/mingw-w64-passagemath-combinat/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-combinat
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.38
+pkgver=10.6.39
 pkgrel=1
 pkgdesc="passagemath: Algebraic combinatorics, combinatorial representation theory (mingw-w64)"
 arch=('any')
@@ -33,8 +33,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz"
         "0001-allow-newer-cysignals.patch")
-sha256sums=('16c16b9e28b311574343fab5121b837b6d7b3039a37dec1a9a8bc2cde94bc62e'
-            '41fd1f5cbda708ee029e4c4304d87ba979292f5691d1e0f8652ce68e21ff9ff7')
+sha256sums=('e4dc92f53b740b5a51a1112ac4aff3e8573ad8109eb662041e7688cd4194bc27'
+            'a1d3ae4dd5170fd2cc294e62eea2ebe2e3aa92feb5945991f3ce79ae6b9db69b')
 
 prepare() {
   cd "${_realname/-/_}-${pkgver}"

--- a/mingw-w64-passagemath-environment/PKGBUILD
+++ b/mingw-w64-passagemath-environment/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=passagemath-environment
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=10.6.38
-pkgrel=2
+pkgver=10.6.39
+pkgrel=1
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgdesc="Subset of the Sage library providing the connection to the system and software environment (mingw-w64)"
 arch=('any')
@@ -22,7 +22,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('edb8126ed54867f44d729565e89601ac88895fef813183d510c9cb78624ad9fc')
+sha256sums=('0b7dc52623e8302a49fb8628330c4ba1c85725ce8a2a49bcf73816e8f88362d7')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-glpk/0001-allow-newer-cysignals.patch
+++ b/mingw-w64-passagemath-glpk/0001-allow-newer-cysignals.patch
@@ -4,7 +4,7 @@ index da2af3e..132b16b 100644
 +++ b/PKG-INFO
 @@ -31,7 +31,6 @@ Requires-Python: <3.15,>=3.10
  Description-Content-Type: text/x-rst
- Requires-Dist: passagemath-objects~=10.6.38.0
+ Requires-Dist: passagemath-objects~=10.6.39.0
  Requires-Dist: memory_allocator
 -Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
  Requires-Dist: cysignals!=1.12.0,>=1.11.2
@@ -15,7 +15,7 @@ index a60bce7..7810941 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
 @@ -10,7 +10,7 @@ requires = [
-     'passagemath-objects ~= 10.6.38.0',
+     'passagemath-objects ~= 10.6.39.0',
      'cython >=3.0.8, <3.2.0', 'cython >=3.0.8,<3.2.0',
      'memory_allocator',
 -    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
@@ -25,7 +25,7 @@ index a60bce7..7810941 100644
 
 @@ -20,7 +20,7 @@ description = "passagemath: Linear and mixed integer linear optimization backend
  dependencies = [
-     'passagemath-objects ~= 10.6.38.0',
+     'passagemath-objects ~= 10.6.39.0',
      'memory_allocator',
 -    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
 +    'cysignals >=1.11.2, != 1.12.0',
@@ -36,7 +36,7 @@ diff --git a/passagemath_glpk.egg-info/requires.txt b/passagemath_glpk.egg-info/
 index 38f48ce..c252984 100644
 --- a/passagemath_glpk.egg-info/requires.txt
 +++ b/passagemath_glpk.egg-info/requires.txt
-@@ -2,7 +2,4 @@ passagemath-objects~=10.6.38.0
+@@ -2,7 +2,4 @@ passagemath-objects~=10.6.39.0
  memory_allocator
  cysignals!=1.12.0,>=1.11.2
 
@@ -50,7 +50,7 @@ index da2af3e..132b16b 100644
 +++ b/passagemath_glpk.egg-info/PKG-INFO
 @@ -31,7 +31,6 @@ Requires-Python: <3.15,>=3.10
  Description-Content-Type: text/x-rst
- Requires-Dist: passagemath-objects~=10.6.38.0
+ Requires-Dist: passagemath-objects~=10.6.39.0
  Requires-Dist: memory_allocator
 -Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
  Requires-Dist: cysignals!=1.12.0,>=1.11.2

--- a/mingw-w64-passagemath-glpk/PKGBUILD
+++ b/mingw-w64-passagemath-glpk/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-glpk
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.38
+pkgver=10.6.39
 pkgrel=1
 pkgdesc="passagemath: Linear and mixed integer linear optimization backend using GLPK (mingw-w64)"
 arch=('any')
@@ -35,13 +35,14 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz"
         "0001-allow-newer-cysignals.patch")
-sha256sums=('43c3ad9de2dd1c8125c55f9f99c2133d7225ec36abb4a2bb73a432a1d5010086'
-            'f4f296f2169cccb2f3a47fc3c132635ffb9e74485c213533ea06fb9ef5d983aa')
+sha256sums=('1bb8db8488bfab93da54544a0aaa3e78824b3b868ae03d0023d22e6c21af5894'
+            'c7496b2f17919da244e676834ac1f0021db148dea7553eb546cb0fa3fccbc629')
 
 prepare() {
   cd "${_realname/-/_}-${pkgver}"
 
-  patch -Np1 -i "${srcdir}/0001-allow-newer-cysignals.patch"
+  # Loosen a constraint on cysignals so that the version packaged in MSYS2 is accepted.
+  patch -Nbp1 -i "${srcdir}/0001-allow-newer-cysignals.patch"
 }
 
 build() {

--- a/mingw-w64-passagemath-graphs/0001-allow-newer-cysignals.patch
+++ b/mingw-w64-passagemath-graphs/0001-allow-newer-cysignals.patch
@@ -9,13 +9,13 @@ index da2af3e..132b16b 100644
 -Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
  Requires-Dist: cysignals!=1.12.0,>=1.11.2
  Requires-Dist: memory_allocator
- Requires-Dist: passagemath-categories~=10.6.38.0
+ Requires-Dist: passagemath-categories~=10.6.39.0
 diff --git a/pyproject.toml b/pyproject.toml
 index a60bce7..7810941 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
 @@ -9,7 +9,7 @@ requires = [
-     'passagemath-categories ~= 10.6.38.0',
+     'passagemath-categories ~= 10.6.39.0',
      'cython >=3.0.8, <3.2.0', 'cython >=3.0.8,<3.2.0',
      'gmpy2 ~=2.1.b999',
 -    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
@@ -30,15 +30,15 @@ index a60bce7..7810941 100644
 -    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
 +    'cysignals >=1.11.2, != 1.12.0',
      'memory_allocator',
-     'passagemath-categories ~= 10.6.38.0',
-     'passagemath-conf ~= 10.6.38.0 ; sys_platform != "win32"',
+     'passagemath-categories ~= 10.6.39.0',
+     'passagemath-conf ~= 10.6.39.0 ; sys_platform != "win32"',
 diff --git a/passagemath_graphs.egg-info/requires.txt b/passagemath_graphs.egg-info/requires.txt
 index 38f48ce..c252984 100644
 --- a/passagemath_graphs.egg-info/requires.txt
 +++ b/passagemath_graphs.egg-info/requires.txt
-@@ -7,9 +7,6 @@ passagemath-environment~=10.6.38.0
+@@ -7,9 +7,6 @@ passagemath-environment~=10.6.39.0
  [:sys_platform != "win32"]
- passagemath-conf~=10.6.38.0
+ passagemath-conf~=10.6.39.0
 
 -[:sys_platform == "win32"]
 -cysignals<1.12.4
@@ -57,4 +57,4 @@ index da2af3e..132b16b 100644
 -Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
  Requires-Dist: cysignals!=1.12.0,>=1.11.2
  Requires-Dist: memory_allocator
- Requires-Dist: passagemath-categories~=10.6.38.0
+ Requires-Dist: passagemath-categories~=10.6.39.0

--- a/mingw-w64-passagemath-graphs/PKGBUILD
+++ b/mingw-w64-passagemath-graphs/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-graphs
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.38
+pkgver=10.6.39
 pkgrel=1
 pkgdesc="passagemath: Graphs, posets, hypergraphs, designs, abstract complexes, combinatorial polyhedra, abelian sandpiles, quivers (mingw-w64)"
 arch=('any')
@@ -32,12 +32,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-boost"
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz"
         "0001-allow-newer-cysignals.patch")
-sha256sums=('e8920a6f03f4ec18bfc1d946ff80ea62bfe932caa5498885317aaa7f61f05405'
-            '9f3ed954643cfa0b4b93fbeccf349fd25cefd569a677bc3d21e955bfcbb63f0b')
+sha256sums=('721c49157cdd55e479a7c8c49e9bcf56247d8acb8c2ff340734cdabdbb1b3a72'
+            '45f8087009e637c264340458566de4572df1e382b50e26b55f4c8a1f0c400e80')
 
 prepare() {
   cd "${_realname/-/_}-${pkgver}"
 
+  # Loosen a constraint on cysignals so that the version packaged in MSYS2 is accepted.
   patch -Nbp1 -i "${srcdir}/0001-allow-newer-cysignals.patch"
 }
 

--- a/mingw-w64-passagemath-homfly/0001-allow-newer-cysignals.patch
+++ b/mingw-w64-passagemath-homfly/0001-allow-newer-cysignals.patch
@@ -15,8 +15,8 @@ index a60bce7..7810941 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
 @@ -7,7 +7,7 @@ requires = [
-     'passagemath-environment ~= 10.6.38.0',
-     'passagemath-objects ~= 10.6.38.0',
+     'passagemath-environment ~= 10.6.39.0',
+     'passagemath-objects ~= 10.6.39.0',
      'cython >=3.0.8, <3.2.0', 'cython >=3.0.8,<3.2.0',
 -    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
 +    'cysignals >=1.11.2, != 1.12.0',

--- a/mingw-w64-passagemath-homfly/PKGBUILD
+++ b/mingw-w64-passagemath-homfly/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-homfly
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.38
+pkgver=10.6.39
 pkgrel=1
 pkgdesc="passagemath: Homfly polynomials of knots/links with libhomfly (mingw-w64)"
 arch=('any')
@@ -30,13 +30,14 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz"
         "0001-allow-newer-cysignals.patch")
-sha256sums=('3f3461f94f1c5ebdc45036d8a0e397901aab0a4103195f327a41a8910459c3c6'
-            '0f902f3a9c5bbea8ef21ce2454c75be7debe5e12239e8d4466199fe2a0ee97d6')
+sha256sums=('ae04248d485fd910ba6c2f296b5ca944164d93484c920364daa40db84dde589d'
+            '8080982f313b42c752fec48b8db9fee1be7b5e83eb190af213b8ce6436437fd9')
 
 prepare() {
   cd "${_realname/-/_}-${pkgver}"
 
-  patch -Np1 -i "${srcdir}/0001-allow-newer-cysignals.patch"
+  # Loosen a constraint on cysignals so that the version packaged in MSYS2 is accepted.
+  patch -Nbp1 -i "${srcdir}/0001-allow-newer-cysignals.patch"
 }
 
 build() {

--- a/mingw-w64-passagemath-modules/0001-allow-newer-cysignals.patch
+++ b/mingw-w64-passagemath-modules/0001-allow-newer-cysignals.patch
@@ -9,7 +9,7 @@ index da2af3e..132b16b 100644
 -Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
  Requires-Dist: cysignals!=1.12.0,>=1.11.2
  Requires-Dist: memory_allocator
- Requires-Dist: passagemath-categories~=10.6.38.0
+ Requires-Dist: passagemath-categories~=10.6.39.0
 diff --git a/pyproject.toml b/pyproject.toml
 index a60bce7..7810941 100644
 --- a/pyproject.toml
@@ -30,14 +30,14 @@ index a60bce7..7810941 100644
 -    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
 +    'cysignals >=1.11.2, != 1.12.0',
      'memory_allocator',
-     'passagemath-categories ~= 10.6.38.0',
-     'passagemath-environment ~= 10.6.38.0',
+     'passagemath-categories ~= 10.6.39.0',
+     'passagemath-environment ~= 10.6.39.0',
 diff --git a/passagemath_modules.egg-info/requires.txt b/passagemath_modules.egg-info/requires.txt
 index 38f48ce..c252984 100644
 --- a/passagemath_modules.egg-info/requires.txt
 +++ b/passagemath_modules.egg-info/requires.txt
-@@ -5,9 +5,6 @@ passagemath-categories~=10.6.38.0
- passagemath-environment~=10.6.38.0
+@@ -5,9 +5,6 @@ passagemath-categories~=10.6.39.0
+ passagemath-environment~=10.6.39.0
  mpmath<1.4,>=1.1.0
 
 -[:sys_platform == "win32"]
@@ -57,4 +57,4 @@ index da2af3e..132b16b 100644
 -Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
  Requires-Dist: cysignals!=1.12.0,>=1.11.2
  Requires-Dist: memory_allocator
- Requires-Dist: passagemath-categories~=10.6.38.0
+ Requires-Dist: passagemath-categories~=10.6.39.0

--- a/mingw-w64-passagemath-modules/PKGBUILD
+++ b/mingw-w64-passagemath-modules/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-modules
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.38
+pkgver=10.6.39
 pkgrel=1
 pkgdesc="passagemath: Vectors, matrices, tensors, vector spaces, affine spaces, modules and algebras, additive groups, quadratic forms, homology, coding theory, matroids (mingw-w64)"
 arch=('any')
@@ -36,12 +36,13 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz"
         "0001-allow-newer-cysignals.patch")
-sha256sums=('e75001a5c86bde1a54b81806775fd8d7c56e9f8aaa29f058d9928dc7bd770616'
-            'e10a30a8beb8866b66684e963b1fb3aade29e49b00247386508ca66a109cbe27')
+sha256sums=('be07440831011619329ee987dfe2fcee810900cee233aa371666586465546bba'
+            '9eca0e933972643d8482933218d71b901b5e7e23d5eee6e3dd38d6490df5ae4d')
 
 prepare() {
   cd "${_realname/-/_}-${pkgver}"
 
+  # Loosen a constraint on cysignals so that the version packaged in MSYS2 is accepted.
   patch -Nbp1 -i "${srcdir}/0001-allow-newer-cysignals.patch"
 }
 

--- a/mingw-w64-passagemath-nauty/0001-allow-newer-cysignals.patch
+++ b/mingw-w64-passagemath-nauty/0001-allow-newer-cysignals.patch
@@ -8,15 +8,15 @@ index da2af3e..132b16b 100644
  Description-Content-Type: text/x-rst
 -Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
  Requires-Dist: cysignals!=1.12.0,>=1.11.2
- Requires-Dist: passagemath-environment~=10.6.38.0
- Requires-Dist: passagemath-graphs~=10.6.38.0
+ Requires-Dist: passagemath-environment~=10.6.39.0
+ Requires-Dist: passagemath-graphs~=10.6.39.0
 diff --git a/pyproject.toml b/pyproject.toml
 index a60bce7..7810941 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
 @@ -7,7 +7,7 @@ requires = [
-     'passagemath-setup ~= 10.6.38.0',
-     'passagemath-environment ~= 10.6.38.0',
+     'passagemath-setup ~= 10.6.39.0',
+     'passagemath-environment ~= 10.6.39.0',
      'cython >=3.0.8, <3.2.0', 'cython >=3.0.8,<3.2.0',
 -    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
 +    'cysignals >=1.11.2, != 1.12.0',
@@ -29,16 +29,16 @@ index a60bce7..7810941 100644
  dependencies = [
 -    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
 +    'cysignals >=1.11.2, != 1.12.0',
-     'passagemath-environment ~= 10.6.38.0',
-     'passagemath-graphs ~= 10.6.38.0',
+     'passagemath-environment ~= 10.6.39.0',
+     'passagemath-graphs ~= 10.6.39.0',
  ]
 diff --git a/passagemath_nauty.egg-info/requires.txt b/passagemath_nauty.egg-info/requires.txt
 index 38f48ce..c252984 100644
 --- a/passagemath_nauty.egg-info/requires.txt
 +++ b/passagemath_nauty.egg-info/requires.txt
 @@ -2,8 +2,5 @@ cysignals!=1.12.0,>=1.11.2
- passagemath-environment~=10.6.38.0
- passagemath-graphs~=10.6.38.0
+ passagemath-environment~=10.6.39.0
+ passagemath-graphs~=10.6.39.0
 
 -[:sys_platform == "win32"]
 -cysignals<1.12.4
@@ -55,5 +55,5 @@ index da2af3e..132b16b 100644
  Description-Content-Type: text/x-rst
 -Requires-Dist: cysignals<1.12.4; sys_platform == "win32"
  Requires-Dist: cysignals!=1.12.0,>=1.11.2
- Requires-Dist: passagemath-environment~=10.6.38.0
- Requires-Dist: passagemath-graphs~=10.6.38.0
+ Requires-Dist: passagemath-environment~=10.6.39.0
+ Requires-Dist: passagemath-graphs~=10.6.39.0

--- a/mingw-w64-passagemath-nauty/PKGBUILD
+++ b/mingw-w64-passagemath-nauty/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-nauty
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.38
+pkgver=10.6.39
 pkgrel=1
 pkgdesc="passagemath: Find automorphism groups of graphs, generate non-isomorphic graphs with nauty (mingw-w64)"
 arch=('any')
@@ -30,8 +30,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz"
         "0001-allow-newer-cysignals.patch")
-sha256sums=('3bb820ae97440df220df13c1ac5fb1d51a032b981f2bb7139a11d6abf496bb44'
-            '55667930b60e76f9d58443ad4a94d67c4b842e1aabcfbaff5f454f0395d92726')
+sha256sums=('f49c99b97e6292049fce31a1785e23b6c4e944f6d6eac5d9183f2a6a52108412'
+            'fda252fb982f20abbbbd3fdeb67c6557122b63dae521b3a039465996b89708a9')
 
 prepare() {
   cd "${_realname/-/_}-${pkgver}"

--- a/mingw-w64-passagemath-objects/0001-allow-newer-cysignals.patch
+++ b/mingw-w64-passagemath-objects/0001-allow-newer-cysignals.patch
@@ -15,7 +15,7 @@ index a60bce7..7810941 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
 @@ -7,7 +7,7 @@ requires = [
-     'passagemath-environment ~= 10.6.38.0',
+     'passagemath-environment ~= 10.6.39.0',
      'cython >=3.0.8, <3.2.0', 'cython >=3.0.8,<3.2.0',
      'gmpy2 ~=2.1.b999',
 -    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',

--- a/mingw-w64-passagemath-objects/PKGBUILD
+++ b/mingw-w64-passagemath-objects/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=passagemath-objects
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=10.6.38
+pkgver=10.6.39
 pkgrel=1
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgdesc="Part of the Sage library making object, element/parent framework, categories and the coercion system available (mingw-w64)"
@@ -32,8 +32,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz"
         "0001-allow-newer-cysignals.patch")
-sha256sums=('91b99fecc59745b8e260a126858ed514ce20d26bf1a14fc22ac6e9dadb90bede'
-            '57d9a7be4b57d28d19995d4979522e71614ac0a4c30006cca463bf4191b63cc6')
+sha256sums=('d54f3aa2caafd27f5fe296053c6e47d7caaf5d8d8f201a6a811c8fe4c2e032fb'
+            '3d754215f70ee9f4b239075d7f290bc9dc8fa22f698ba9e4342040a1f65fe387')
 
 prepare() {
   cd "${_realname/-/_}-${pkgver}"

--- a/mingw-w64-passagemath-repl/PKGBUILD
+++ b/mingw-w64-passagemath-repl/PKGBUILD
@@ -4,8 +4,8 @@ _realname=passagemath-repl
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.38
-pkgrel=2
+pkgver=10.6.39
+pkgrel=1
 pkgdesc="passagemath: IPython kernel, Sage preparser, doctester (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -27,7 +27,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('01d2fc4246b8ffdba468a5bbf544d250a92e6cdf7f8a1c4ba6efe32867bc496b')
+sha256sums=('d6d777f37faac35fdc3b2e326bcfdfedbae5b54fd6e5148c07d9dc5f94f57f23')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-setup/PKGBUILD
+++ b/mingw-w64-passagemath-setup/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-setup
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.38
+pkgver=10.6.39
 pkgrel=1
 pkgdesc="passagemath: build system of the Sage library (mingw-w64)"
 arch=('any')
@@ -21,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
 optdepends=("${MINGW_PACKAGE_PREFIX}-python-jinja: for autogen feature")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('f04ed16acf7a1a73b922bf5b9d3eede56b76fdf917d923d9724f78a6966eddd0')
+sha256sums=('7e2d4c89abd8cfa24f57ffceb034ddd249c8867727ea7b255b6b38ff39b7bb3b')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"


### PR DESCRIPTION
See <https://github.com/passagemath/passagemath/releases/tag/passagemath-10.6.39>.

Most relevant change of that release for us is probably <https://github.com/passagemath/passagemath/pull/1836>.