### PR TITLE
gtkmm-4.0: update to 4.20

### DIFF
--- a/mingw-w64-gtkmm-4.0/PKGBUILD
+++ b/mingw-w64-gtkmm-4.0/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=gtkmm
 pkgbase=mingw-w64-${_realname}-4.0
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-4.0"
-pkgver=4.18.0
-pkgrel=3
+pkgver=4.20.0
+pkgrel=1
 pkgdesc="C++ bindings for GTK+4 (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -25,7 +25,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-pkgconf")
 source=("https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz")
-sha256sums=('2ee31c15479fc4d8e958b03c8b5fbbc8e17bc122c2a2f544497b4e05619e33ec')
+sha256sums=('daad9bf9b70f90975f91781fc7a656c923a91374261f576c883cd3aebd59c833')
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"


### PR DESCRIPTION
This is required to unbreak gtkmm: https://github.com/dune3d/dune3d/actions/runs/19801357516/job/56729089914