### PR TITLE
python-av: Add 16.0.1

### DIFF
--- a/mingw-w64-python-av/PKGBUILD
+++ b/mingw-w64-python-av/PKGBUILD
@@ -1,0 +1,45 @@
+# Maintainer: Christoph Reiter <reiter.christoph@gmail.com>
+
+_realname=python-av
+_name=PyAV
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=16.0.1
+pkgrel=1
+pkgdesc="Pythonic bindings for FFmpeg (mingw-w64)"
+arch=('any')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
+url="https://github.com/PyAV-Org/PyAV"
+license=("spdx:BSD-3-Clause")
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-ffmpeg"
+  "${MINGW_PACKAGE_PREFIX}-python"
+  "${MINGW_PACKAGE_PREFIX}-python-numpy"
+  "${MINGW_PACKAGE_PREFIX}-python-pillow"
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-python-build"
+  "${MINGW_PACKAGE_PREFIX}-python-installer"
+  "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+  "${MINGW_PACKAGE_PREFIX}-cython"
+)
+options=('!strip')
+source=("${_name}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('a4451b8328d492f17ceb4881db606ffa2c0fceba4508597cfb14ca823a9f66b0')
+
+build() {
+  cd "${_name}-${pkgver}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "${_name}-${pkgver}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -vDm 644 LICENSE.txt -t "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/"
+}


### PR DESCRIPTION
newer manim depends on this, but it only works with an old version (v13), which doesn't support newer ffmpeg (v8).

Since we can't update manim at least add this package to hopefully make the update easier in the future.