### PR TITLE
rankwidth: add version 0.9 (new package)

### DIFF
--- a/mingw-w64-rankwidth/0001-igraph-get-adjacency.patch
+++ b/mingw-w64-rankwidth/0001-igraph-get-adjacency.patch
@@ -1,0 +1,13 @@
+diff --git a/rw-0.9/simplerw.c b/rw-0.9/simplerw.c.modified
+index 339f16d..1f002c5 100644
+--- a/rw-0.9/simplerw.c
++++ b/rw-0.9/simplerw.c
+@@ -134,7 +134,7 @@ int read_graph(const char *format, const char * filename)
+ 		igraph_destroy(&igraph);
+ 		return(-1);
+ 	}
+-	igraph_get_adjacency(&igraph, &imatrix, IGRAPH_GET_ADJACENCY_BOTH, 0);
++	igraph_get_adjacency(&igraph, &imatrix, IGRAPH_GET_ADJACENCY_BOTH, 0, IGRAPH_LOOPS_ONCE);
+ 	igraph_destroy(&igraph);
+ 	if(igraph_matrix_nrow(&imatrix) > MAX_VERTICES)
+ 	{

--- a/mingw-w64-rankwidth/PKGBUILD
+++ b/mingw-w64-rankwidth/PKGBUILD
@@ -1,0 +1,57 @@
+# Contributor: Dirk Stolle
+
+_realname=rankwidth
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=0.9
+pkgrel=1
+pkgdesc="A program that calculates rank-width and rank-decompositions (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://sourceforge.net/projects/rankwidth/'
+msys2_references=(
+  'archlinux: rankwidth'
+  'gentoo: sci-mathematics/rw'
+)
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-igraph")
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+source=("https://master.dl.sourceforge.net/project/rankwidth/rw-${pkgver}.tar.gz"
+        "0001-igraph-get-adjacency.patch")
+sha256sums=('c1e03506fe25cdfcb428c051fc56b2d2affb5b06fba3f2ce756631466befb441'
+            'e48c10ece7c23787a088fb35beb3411cabaa7f8384d0e66499ca0a83c6d6f5f5')
+
+prepare() {
+  cd "rw-${pkgver}"
+
+  patch -Nbp2 -i "${srcdir}/0001-igraph-get-adjacency.patch"
+}
+
+build() {
+  mkdir -p "build-${MSYSTEM}" && cd "build-${MSYSTEM}"
+
+  ../"rw-${pkgver}"/configure \
+    --prefix="${MINGW_PREFIX}" \
+    --build="${MINGW_CHOST}" \
+    --host="${MINGW_CHOST}" \
+    --target="${MINGW_CHOST}" \
+    --enable-static \
+    --enable-shared
+
+  make
+}
+
+check() {
+  cd "build-${MSYSTEM}"
+
+  make check
+}
+
+package() {
+  cd "build-${MSYSTEM}"
+
+  make install DESTDIR="${pkgdir}"
+
+  install -Dm644 "${srcdir}/rw-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
rankwidth is required to build passagemath-rankwidth, one of the packages of passagemath (<https://github.com/msys2/MINGW-packages/issues/24738>), so let's package it.


rankwidth is also available in several other distributions, for example:
* Arch Linux: https://archlinux.org/packages/extra/x86_64/rankwidth/
* Debian: https://packages.debian.org/source/trixie/rw
* Gentoo: https://packages.gentoo.org/packages/sci-mathematics/rw