### PR TITLE
python-passagemath-rankwidth: add version 10.6.39 (new package)

### DIFF
--- a/mingw-w64-passagemath-rankwidth/0001-allow-newer-cysignals.patch
+++ b/mingw-w64-passagemath-rankwidth/0001-allow-newer-cysignals.patch
@@ -1,0 +1,13 @@
+diff --git a/pyproject.toml b/pyproject.toml.modified
+index a60bce7..7810941 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -6,7 +6,7 @@ requires = [
+     'passagemath-setup ~= 10.6.39.0',
+     'passagemath-environment ~= 10.6.39.0',
+     'cython >=3.0.8, <3.2.0', 'cython >=3.0.8,<3.2.0',
+-    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
++    'cysignals >=1.11.2, != 1.12.0',
+     'pkgconfig',
+ ]
+ build-backend = "setuptools.build_meta"

--- a/mingw-w64-passagemath-rankwidth/PKGBUILD
+++ b/mingw-w64-passagemath-rankwidth/PKGBUILD
@@ -1,0 +1,55 @@
+# Maintainer: Dirk Stolle
+
+_realname=passagemath-rankwidth
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=10.6.39
+pkgrel=1
+pkgdesc="passagemath: Rankwidth and rank decompositions of graphs (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/passagemath/passagemath'
+msys2_references=(
+  'purl: pkg:pypi/passagemath-rankwidth'
+)
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-graphs"
+         "${MINGW_PACKAGE_PREFIX}-rankwidth")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cython"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-cysignals"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-environment"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-setup"
+             "${MINGW_PACKAGE_PREFIX}-python-pkgconfig"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz"
+        "0001-allow-newer-cysignals.patch")
+sha256sums=('325b99b1c39d9f3e63fb808c60d8da225c96223f009dc6fd3d6feaec7855460b'
+            'e9225ca0dd3f20c85292ae51b346252ca373b8f6f4553d5b58914bb87f3365e7')
+
+prepare() {
+  cd "${_realname/-/_}-${pkgver}"
+
+  # Loosen a constraint on cysignals so that the version packaged in MSYS2 is accepted.
+  patch -Nbp1 -i "${srcdir}/0001-allow-newer-cysignals.patch"
+}
+
+build() {
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+}


### PR DESCRIPTION
This PR adds python-passagemath-rankwidth, a package to provide some functionality from passagemath (https://github.com/msys2/MINGW-packages/issues/24738).

Now that rankwidth is available in MSYS2 (#26662), this part of passagemath can be built, too.