### PR TITLE
Groonga 15.2.1

### DIFF
--- a/mingw-w64-groonga/001-aarch64.patch
+++ b/mingw-w64-groonga/001-aarch64.patch
@@ -21,18 +21,3 @@ diff -bur groonga-15.0.4-o/vendor/mruby-source/include/throw.h groonga-15.0.4/ve
 +#elif defined(__MINGW64__) && defined(__GNUC__) && __GNUC__ >= 4 && !defined(_M_ARM64)
  #define MRB_SETJMP __builtin_setjmp
  #define MRB_LONGJMP __builtin_longjmp
- #elsediff -bur groonga-15.0.4-o/lib/windows.c groonga-15.0.4/lib/windows.c
---- a/lib/windows.c	2025-04-18 02:59:44.604000500 -0600
-+++ b/lib/windows.c	2025-04-18 03:03:42.141936100 -0600
-@@ -403,6 +401,11 @@
-   frame.AddrPC.Offset = context->Rip;
-   frame.AddrFrame.Offset = context->Rbp;
-   frame.AddrStack.Offset = context->Rsp;
-+# elif defined(_M_ARM64)
-+  machine_type = IMAGE_FILE_MACHINE_ARM64;
-+  frame.AddrPC.Offset = context->Pc;
-+  frame.AddrFrame.Offset = context->Fp;
-+  frame.AddrStack.Offset = context->Sp;
- # else /* _M_IX86 */
- #  error "Intel x86, Intel Itanium and x64 are only supported architectures"
- # endif /* _M_IX86 */

--- a/mingw-w64-groonga/PKGBUILD
+++ b/mingw-w64-groonga/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=groonga
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=15.1.7
-pkgrel=3
+pkgver=15.2.1
+pkgrel=1
 pkgdesc="An opensource fulltext search engine (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -29,9 +29,9 @@ makedepends=("git"
              "${MINGW_PACKAGE_PREFIX}-rapidjson"
              "${MINGW_PACKAGE_PREFIX}-ruby"
              "${MINGW_PACKAGE_PREFIX}-xsimd")
-sha256sums=('899a414a0636f7568d1a11845fe3dd75b701f72106a7a26f30bc950af5876616'
+sha256sums=('77d9aa56e33c0986bbec6ddd2ee897aba6c347cff45fce988f2708145e0c9d77'
             'SKIP'
-            '5fbb336487a6522e2f7bff01ea3cdd714d4c27de3cc65d5a6ecb2eedeb6fc2c4')
+            'cb7a5888bf4fbe9af075d81a00cc82d2126521208128d4c9e5035654e58a5144')
 validpgpkeys=('2701F317CFCCCB975CADE9C2624CF77434839225') # Groonga Key <packages@groonga.org>
 
 apply_patch_with_msg() {


### PR DESCRIPTION
Groonga version 15.2.1 has just been released [here](https://github.com/groonga/groonga/releases/tag/v15.2.1).
This update also removes the lib/windows.c patch for ARM64 support, as the fix has been merged upstream.

ref: https://github.com/groonga/groonga/pull/2653.