### PR TITLE
mingw-w64-uutils-coreutils: Use default value of LN

### DIFF
--- a/mingw-w64-uutils-coreutils/PKGBUILD
+++ b/mingw-w64-uutils-coreutils/PKGBUILD
@@ -36,9 +36,8 @@ package() {
     DESTDIR="${pkgdir}" \
     PREFIX="${MINGW_PREFIX}" \
     PROG_PREFIX=uu- \
-    PROFILE=release \
-    MULTICALL=y \
-    LN="ln -vf"
+    PROFILE=release-fast \
+    MULTICALL=y
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/uutils-${_realname}/LICENSE"
 }


### PR DESCRIPTION
Cleanup PKGBUILD by default value (it seems `OS` is OK).
Also prepare PROFILE=release-fast (overwritten by release at 0.4.0 yet but works at next release).