### PR TITLE
nasm: Update to 3.01

### DIFF
--- a/mingw-w64-nasm/PKGBUILD
+++ b/mingw-w64-nasm/PKGBUILD
@@ -14,8 +14,13 @@ msys2_references=(
   "cpe: cpe:/a:nasm:netwide_assembler"
 )
 options=('!makeflags')
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-zlib"
+)
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-autotools")
+             "${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-asciidoc"
+             "xmlto")
 source=(https://www.nasm.us/pub/nasm/releasebuilds/${pkgver}/${_realname}-${pkgver}.tar.xz)
 sha256sums=('b7324cbe86e767b65f26f467ed8b12ad80e124e3ccb89076855c98e43a9eddd4')
 


### PR DESCRIPTION
nasm: update to 3.01

- Upstream release notes: https://www.nasm.us/docs/3.01/nasmac.html
- Update version and checksum
- Builds successfully on Mingw 
