### PR TITLE
exiv2: rename pkgbase of the 0.27 variant

### DIFF
--- a/mingw-w64-exiv2-0.27/PKGBUILD
+++ b/mingw-w64-exiv2-0.27/PKGBUILD
@@ -3,14 +3,15 @@
 # Contributor: Miloš Komarčević <miloskomarcevic@aim.com>
 
 _realname=exiv2
-pkgbase=mingw-w64-${_realname}
+pkgbase=mingw-w64-${_realname}-0.27
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.27.7
-pkgrel=4
+pkgrel=5
 pkgdesc="Exif/IPTC/Xmp C++ metadata library and tools (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64')
 url='https://exiv2.org/'
+msys2_repository_url="https://github.com/Exiv2/exiv2"
 msys2_references=(
   "cpe: cpe:/a:andreas_huggel:exiv2"
   "cpe: cpe:/a:exiv2:exiv2"


### PR DESCRIPTION
so we get two packages in the web UI. having multiple packages for the same pkgbase with different versions is not handled very well there since it's uncommon.