### PR TITLE
winkerberos 0.13.0

### DIFF
--- a/mingw-w64-python-winkerberos/PKGBUILD
+++ b/mingw-w64-python-winkerberos/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=winkerberos
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=0.12.2
+pkgver=0.13.0
 pkgrel=1
 pkgdesc="High level interface to SSPI for Kerberos client auth (mingw-w64)"
 arch=('any')
@@ -20,7 +20,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-cc")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('ff91daed04727a0362892802ee093d8da11f08536393526bdf3bc64e04079faa')
+sha256sums=('f3fbb67346fe8ed697e125724b0699d5c2a15b9a5f9151d25a1be88df8dac427')
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"


### PR DESCRIPTION
https://github.com/mongodb/winkerberos/releases/tag/0.13.0

Adds support for Python 3.14