### PR TITLE
rust-bindgen: update to 0.72.1

### DIFF
--- a/mingw-w64-rust-bindgen/PKGBUILD
+++ b/mingw-w64-rust-bindgen/PKGBUILD
@@ -18,7 +18,7 @@ license=('spdx:BSD-3-Clause')
 depends=("${MINGW_PACKAGE_PREFIX}-clang" "${MINGW_PACKAGE_PREFIX}-cc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-mdbook")
-source=("${msys2_repository_url}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
+source=("${msys2_repository_url}/archive/refs/tags/v${pkgver}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('4ffb17061b2d71f19c5062d2e17e64107248f484f9775c0b7d30a16a8238dfd1')
 
 prepare() {


### PR DESCRIPTION
Source tarball fetched for tag has changed from time to time... The file I downloaded locally is different from the file in CI.