### PR TITLE
planarity: add version 4.0.1.0 (new package)

### DIFF
--- a/mingw-w64-planarity/PKGBUILD
+++ b/mingw-w64-planarity/PKGBUILD
@@ -1,0 +1,54 @@
+# Maintainer: Dirk Stolle
+
+_realname=planarity
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=4.0.1.0
+pkgrel=1
+pkgdesc="Program and library for planarity-related graph algorithms (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/graph-algorithms/edge-addition-planarity-suite'
+msys2_references=(
+  'archlinux: planarity'
+  'gentoo: sci-mathematics/planarity'
+)
+license=('spdx:BSD-3-Clause')
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+source=("https://github.com/graph-algorithms/edge-addition-planarity-suite/releases/download/Version_${pkgver}/planarity-${pkgver}.tar.gz")
+sha256sums=('b80de8b5e6cbbe00684c614cf7d040bb10f7c0ad6f850fd2d10c2e533c6026f5')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+
+  autoreconf -fiv
+}
+
+build() {
+  mkdir -p "build-${MSYSTEM}" && cd "build-${MSYSTEM}"
+
+  ../"${_realname}-${pkgver}"/configure \
+    --prefix="${MINGW_PREFIX}" \
+    --build="${MINGW_CHOST}" \
+    --host="${MINGW_CHOST}" \
+    --target="${MINGW_CHOST}" \
+    --enable-static \
+    --enable-shared
+
+  make
+}
+
+check() {
+  cd "build-${MSYSTEM}"
+
+  make check
+}
+
+package() {
+  cd "build-${MSYSTEM}"
+
+  make install DESTDIR="${pkgdir}"
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE.TXT" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
planarity is required to build passagemath-planarity, one of the packages of passagemath (<https://github.com/msys2/MINGW-packages/issues/24738>), so let's package it.


planarity is also available in several other distributions, for example:
* Arch Linux: https://archlinux.org/packages/extra/x86_64/planarity/
* Debian: https://packages.debian.org/trixie/source/edge-addition-planarity-suite
* Gentoo: https://packages.gentoo.org/packages/sci-mathematics/planarity
* Fedora: https://packages.fedoraproject.org/pkgs/planarity/planarity/