### PR TITLE
libpng: update to 1.6.52

### DIFF
--- a/mingw-w64-libpng/PKGBUILD
+++ b/mingw-w64-libpng/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libpng
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.6.51
+pkgver=1.6.52
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -21,7 +21,7 @@ msys2_references=(
 )
 source=("https://downloads.sourceforge.net/sourceforge/libpng/${_realname}-${pkgver}.tar.xz"
         "libpng-${pkgver}-apng.patch::https://raw.githubusercontent.com/mozilla/gecko-dev/3f2c4cf90aa8c839a7d346022c6a77ad3713d486/media/libpng/apng.patch")
-sha256sums=('a050a892d3b4a7bb010c3a95c7301e49656d72a64f1fc709a90b8aded192bed2'
+sha256sums=('36bd726228ec93a3b6c22fdb49e94a67b16f2fe9b39b78b7cb65772966661ccc'
             '4ebab105c07e819ad41101eb7a02d680d180b2534e04504ff4a583e02eb5da52')
 validpgpkeys=('8048643BA2C840F4F92A195FF54984BFA16C640F')  # Glenn Randers-Pehrson (mozilla) <glennrp+bmo@gmail.com>
 


### PR DESCRIPTION
libpng 1.6.52 includes a fix for CVE-2025-66293. See <https://www.libpng.org/pub/png/libpng.html>.