### PR TITLE
osl: update to 1.14.8.0

### DIFF
--- a/mingw-w64-openshadinglanguage/PKGBUILD
+++ b/mingw-w64-openshadinglanguage/PKGBUILD
@@ -19,7 +19,9 @@ depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
          #"${MINGW_PACKAGE_PREFIX}-llvm-libs"
          "${MINGW_PACKAGE_PREFIX}-openimageio"
          "${MINGW_PACKAGE_PREFIX}-partio"
-         "${MINGW_PACKAGE_PREFIX}-pugixml")
+         "${MINGW_PACKAGE_PREFIX}-pugixml"
+         "${MINGW_PACKAGE_PREFIX}-zlib"
+         "${MINGW_PACKAGE_PREFIX}-zstd")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"


### PR DESCRIPTION
No idea why CLANGARM64 only was picking up the runner pre-installed LLVM 20 instead of the MSYS2 one when no `LLVM_ROOT` was specified, while the same worked on CLANG64...

Also, should it w/ the swicth to LLVM 21 now be built w/ LLVM_STATIC instead on depending on shared libs?

Edit: the last failure is due to a different reason, and just needs a re-run I hope.