### PR TITLE
python-passagemath-planarity: add version 10.6.39 (new package)

### DIFF
--- a/mingw-w64-passagemath-planarity/0001-allow-newer-cysignals.patch
+++ b/mingw-w64-passagemath-planarity/0001-allow-newer-cysignals.patch
@@ -1,0 +1,13 @@
+diff --git a/pyproject.toml b/pyproject.toml.modified
+index bd0d05d..f1ebef5 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -6,7 +6,7 @@ requires = [
+     'passagemath-setup ~= 10.6.39.0',
+     'passagemath-environment ~= 10.6.39.0',
+     'cython >=3.0.8, <3.2.0', 'cython >=3.0.8,<3.2.0',
+-    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
++    'cysignals >=1.11.2, != 1.12.0',
+     'pkgconfig',
+ ]
+ build-backend = "setuptools.build_meta"

--- a/mingw-w64-passagemath-planarity/PKGBUILD
+++ b/mingw-w64-passagemath-planarity/PKGBUILD
@@ -1,0 +1,55 @@
+# Maintainer: Dirk Stolle
+
+_realname=passagemath-planarity
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=10.6.39
+pkgrel=1
+pkgdesc="passagemath: Graph planarity with the edge addition planarity suite (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/passagemath/passagemath'
+msys2_references=(
+  'purl: pkg:pypi/passagemath-planarity'
+)
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-planarity"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-graphs")
+makedepends=("${MINGW_PACKAGE_PREFIX}-boost"
+             "${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cython"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-cysignals"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-environment"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-setup"
+             "${MINGW_PACKAGE_PREFIX}-python-pkgconfig"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz"
+        "0001-allow-newer-cysignals.patch")
+sha256sums=('aa84e06cedccf35823e24e4b82262f56e8e6f004b73da63656e5cda328c71400'
+            'e7a3a10f2ab8a965de4e4c70f83085f25eb60e1ac33787a11d74341ab89f0f9a')
+
+prepare() {
+  cd "${_realname/-/_}-${pkgver}"
+
+  # Loosen a constraint on cysignals so that the version packaged in MSYS2 is accepted.
+  patch -Nbp1 -i "${srcdir}/0001-allow-newer-cysignals.patch"
+}
+
+build() {
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+}


### PR DESCRIPTION
This PR adds python-passagemath-planarity, a package to provide some functionality from passagemath (https://github.com/msys2/MINGW-packages/issues/24738).

Now that planarity is part of MSYS2 (#26702), this piece of passagemath can be built, too.