### PR TITLE
cliquer: add version 1.23 (new package)

### DIFF
--- a/mingw-w64-cliquer/0001-fix-timing-code.patch
+++ b/mingw-w64-cliquer/0001-fix-timing-code.patch
@@ -1,0 +1,290 @@
+diff --git a/lib/cliquer.c b/lib/cliquer.c
+index 49d0ad5..8cdbf71 100644
+--- a/lib/cliquer.c
++++ b/lib/cliquer.c
+@@ -11,7 +11,9 @@
+ #include <limits.h>
+ #include <unistd.h>
+ #include <sys/time.h>
++#if !defined(__MINGW64__)
+ #include <sys/times.h>
++#endif
+ 
+ #include "cliquer/cliquer.h"
+ 
+@@ -33,7 +35,9 @@ clique_options *clique_default_options=&clique_default_options_struct;
+ static int *clique_size;      /* c[i] == max. clique size in {0,1,...,i-1} */
+ static set_t current_clique;  /* Current clique being searched. */
+ static set_t best_clique;     /* Largest/heaviest clique found so far. */
++#if !defined(__MINGW64__)
+ static struct tms cputimer;      /* Timer for opts->time_function() */
++#endif
+ static struct timeval realtimer; /* Timer for opts->time_function() */
+ static int clique_list_count=0;  /* No. of cliques in opts->clique_list[] */
+ static int weight_multiplier=1;  /* Weights multiplied by this when passing
+@@ -60,9 +64,7 @@ int old_clique_list_count = clique_list_count;          \
+ int old_weight_multiplier = weight_multiplier;          \
+ int **old_temp_list = temp_list;                        \
+ int old_temp_count = temp_count;                        \
+-struct tms old_cputimer;                                \
+ struct timeval old_realtimer;                           \
+-memcpy(&old_cputimer,&cputimer,sizeof(struct tms));       \
+ memcpy(&old_realtimer,&realtimer,sizeof(struct timeval));
+ 
+ #define ENTRANCE_RESTORE() \
+@@ -73,12 +75,13 @@ clique_list_count = old_clique_list_count;              \
+ weight_multiplier = old_weight_multiplier;              \
+ temp_list = old_temp_list;                              \
+ temp_count = old_temp_count;                            \
+-memcpy(&cputimer,&old_cputimer,sizeof(struct tms));       \
+ memcpy(&realtimer,&old_realtimer,sizeof(struct timeval));
+ 
+ 
+ /* Number of clock ticks per second (as returned by sysconf(_SC_CLK_TCK)) */
++#if !defined(__MINGW64__)
+ static int clocks_per_sec=0;
++#endif
+ 
+ 
+ 
+@@ -138,7 +141,9 @@ static boolean false_function(set_t clique,graph_t *g,clique_options *opts);
+  */
+ static int unweighted_clique_search_single(int *table, int min_size,
+ 					   graph_t *g, clique_options *opts) {
++#if !defined(__MINGW64__)
+ 	struct tms tms;
++#endif
+ 	struct timeval timeval;
+ 	int i,j;
+ 	int v,w;
+@@ -179,13 +184,19 @@ static int unweighted_clique_search_single(int *table, int min_size,
+ 
+ 		if (opts && opts->time_function) {
+ 			gettimeofday(&timeval,NULL);
++#if !defined(__MINGW64__)
+ 			times(&tms);
++#endif
+ 			if (!opts->time_function(entrance_level,
+ 						 i+1,g->n,clique_size[v] *
+ 						 weight_multiplier,
++                                                 #if !defined(__MINGW64__)
+ 						 (double)(tms.tms_utime-
+ 							  cputimer.tms_utime)/
+ 						 clocks_per_sec,
++                                                 #else
++                                                 0,
++                                                 #endif
+ 						 timeval.tv_sec-
+ 						 realtimer.tv_sec+
+ 						 (double)(timeval.tv_usec-
+@@ -335,7 +346,9 @@ static int unweighted_clique_search_all(int *table, int start,
+ 					boolean maximal, graph_t *g,
+ 					clique_options *opts) {
+ 	struct timeval timeval;
++#if !defined(__MINGW64__)
+ 	struct tms tms;
++#endif
+ 	int i,j;
+ 	int v;
+ 	int *newtable;
+@@ -376,13 +389,19 @@ static int unweighted_clique_search_all(int *table, int start,
+ 
+ 		if (opts->time_function) {
+ 			gettimeofday(&timeval,NULL);
++#if !defined(__MINGW64__)
+ 			times(&tms);
++#endif
+ 			if (!opts->time_function(entrance_level,
+ 						 i+1,g->n,min_size *
+ 						 weight_multiplier,
++#if !defined(__MINGW64__)
+ 						 (double)(tms.tms_utime-
+ 							  cputimer.tms_utime)/
+ 						 clocks_per_sec,
++#else
++                                                 0,
++#endif
+ 						 timeval.tv_sec-
+ 						 realtimer.tv_sec+
+ 						 (double)(timeval.tv_usec-
+@@ -539,7 +558,9 @@ static int weighted_clique_search_single(int *table, int min_weight,
+ 					 int max_weight, graph_t *g,
+ 					 clique_options *opts) {
+ 	struct timeval timeval;
++#if !defined(__MINGW64__)
+ 	struct tms tms;
++#endif
+ 	int i,j;
+ 	int v;
+ 	int *newtable;
+@@ -629,13 +650,19 @@ static int weighted_clique_search_single(int *table, int min_weight,
+ 
+ 		if (opts->time_function) {
+ 			gettimeofday(&timeval,NULL);
++#if !defined(__MINGW64__)
+ 			times(&tms);
++#endif
+ 			if (!opts->time_function(entrance_level,
+ 						 i+1,g->n,clique_size[v] *
+ 						 weight_multiplier,
++#if !defined(__MINGW64__)
+ 						 (double)(tms.tms_utime-
+ 							  cputimer.tms_utime)/
+ 						 clocks_per_sec,
++#else
++                                                 0,
++#endif
+ 						 timeval.tv_sec-
+ 						 realtimer.tv_sec+
+ 						 (double)(timeval.tv_usec-
+@@ -687,7 +714,9 @@ static int weighted_clique_search_all(int *table, int start,
+ 				      boolean maximal, graph_t *g,
+ 				      clique_options *opts) {
+ 	struct timeval timeval;
++#if !defined(__MINGW64__)
+ 	struct tms tms;
++#endif
+ 	int i,j;
+ 	int v;
+ 	int *newtable;
+@@ -730,13 +759,19 @@ static int weighted_clique_search_all(int *table, int start,
+ 
+ 		if (opts->time_function) {
+ 			gettimeofday(&timeval,NULL);
++#if !defined(__MINGW64__)
+ 			times(&tms);
++#endif
+ 			if (!opts->time_function(entrance_level,
+ 						 i+1,g->n,clique_size[v] *
+ 						 weight_multiplier,
++#if !defined(__MINGW64__)
+ 						 (double)(tms.tms_utime-
+ 							  cputimer.tms_utime)/
+ 						 clocks_per_sec,
++#else
++                                                 0,
++#endif
+ 						 timeval.tv_sec-
+ 						 realtimer.tv_sec+
+ 						 (double)(timeval.tv_usec-
+@@ -1106,9 +1141,11 @@ set_t clique_unweighted_find_single(graph_t *g,int min_size,int max_size,
+ 		return NULL;
+ 	}
+ 
++#if !defined(__MINGW64__)
+ 	if (clocks_per_sec==0)
+ 		clocks_per_sec=sysconf(_SC_CLK_TCK);
+ 	ASSERT(clocks_per_sec>0);
++#endif
+ 
+ 	/* Dynamic allocation */
+ 	current_clique=set_new(g->n);
+@@ -1119,7 +1156,9 @@ set_t clique_unweighted_find_single(graph_t *g,int min_size,int max_size,
+ 
+ 	/* "start clock" */
+ 	gettimeofday(&realtimer,NULL);
++#if !defined(__MINGW64__)
+ 	times(&cputimer);
++#endif
+ 
+ 	/* reorder */
+ 	if (opts->reorder_function) {
+@@ -1230,9 +1269,11 @@ int clique_unweighted_find_all(graph_t *g, int min_size, int max_size,
+ 		return 0;
+ 	}
+ 
++#if !defined(__MINGW64__)
+ 	if (clocks_per_sec==0)
+ 		clocks_per_sec=sysconf(_SC_CLK_TCK);
+ 	ASSERT(clocks_per_sec>0);
++#endif
+ 
+ 	/* Dynamic allocation */
+ 	current_clique=set_new(g->n);
+@@ -1246,7 +1287,9 @@ int clique_unweighted_find_all(graph_t *g, int min_size, int max_size,
+ 
+ 	/* "start clock" */
+ 	gettimeofday(&realtimer,NULL);
++#if !defined(__MINGW64__)
+ 	times(&cputimer);
++#endif
+ 
+ 	/* reorder */
+ 	if (opts->reorder_function) {
+@@ -1380,9 +1423,11 @@ set_t clique_find_single(graph_t *g,int min_weight,int max_weight,
+ 		return NULL;
+ 	}
+ 
++#if !defined(__MINGW64__)
+ 	if (clocks_per_sec==0)
+ 		clocks_per_sec=sysconf(_SC_CLK_TCK);
+ 	ASSERT(clocks_per_sec>0);
++#endif
+ 
+ 	/* Check whether we can use unweighted routines. */
+ 	if (!graph_weighted(g)) {
+@@ -1417,7 +1462,9 @@ set_t clique_find_single(graph_t *g,int min_weight,int max_weight,
+ 
+ 	/* "start clock" */
+ 	gettimeofday(&realtimer,NULL);
++#if !defined(__MINGW64__)
+ 	times(&cputimer);
++#endif
+ 
+ 	/* reorder */
+ 	if (opts->reorder_function) {
+@@ -1539,9 +1586,11 @@ int clique_find_all(graph_t *g, int min_weight, int max_weight,
+ 		return 0;
+ 	}
+ 
++#if !defined(__MINGW64__)
+ 	if (clocks_per_sec==0)
+ 		clocks_per_sec=sysconf(_SC_CLK_TCK);
+ 	ASSERT(clocks_per_sec>0);
++#endif
+ 
+ 	if (!graph_weighted(g)) {
+ 		min_weight=DIV_UP(min_weight,g->weights[0]);
+@@ -1573,7 +1622,9 @@ int clique_find_all(graph_t *g, int min_weight, int max_weight,
+ 
+ 	/* "start clock" */
+ 	gettimeofday(&realtimer,NULL);
++#if !defined(__MINGW64__)
+ 	times(&cputimer);
++#endif
+ 
+ 	/* reorder */
+ 	if (opts->reorder_function) {
+diff --git a/lib/reorder.c b/lib/reorder.c
+index 9ec127d..add2b12 100644
+--- a/lib/reorder.c
++++ b/lib/reorder.c
+@@ -9,7 +9,9 @@
+ #include "cliquer/reorder.h"
+ 
+ #include <time.h>
++#if !defined(__MINGW64__)
+ #include <sys/times.h>
++#endif
+ #include <stdlib.h>
+ 
+ #include <limits.h>
+@@ -406,12 +408,18 @@ int *reorder_by_degree(graph_t *g, boolean weighted) {
+  *       is called using the system time.
+  */
+ int *reorder_by_random(graph_t *g, boolean weighted) {
++#if !defined(__MINGW64__)
+ 	struct tms t;
++#endif
+ 	int i,r;
+ 	int *new;
+ 	boolean *used;
+ 
++#if !defined(__MINGW64__)
+ 	srand(times(&t)+time(NULL));
++#else
++	srand(time(NULL));
++#endif
+ 
+ 	new=calloc(g->n, sizeof(int));
+ 	used=calloc(g->n, sizeof(boolean));

--- a/mingw-w64-cliquer/PKGBUILD
+++ b/mingw-w64-cliquer/PKGBUILD
@@ -1,0 +1,67 @@
+# Maintainer: Dirk Stolle
+
+_realname=cliquer
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.23
+pkgrel=1
+pkgdesc="A set of C routines for finding cliques in an arbitrary weighted graph (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://users.aalto.fi/~pat/cliquer.html'
+msys2_repository_url='https://github.com/dimpase/autocliquer'
+msys2_references=(
+  'archlinux: cliquer'
+  'gentoo: sci-mathematics/cliquer'
+)
+license=('spdx:GPL-2.0-or-later')
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+source=("https://github.com/dimpase/autocliquer/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
+        "0001-fix-timing-code.patch")
+noextract=("${_realname}-${pkgver}.tar.gz")
+sha256sums=('089b06d8898a6cf55db3ee100888d1c0099e083db93eba5d1440bfe85ad85b11'
+            '2c702be9f7a33f270f20679c4f9791c118d7b7427ad016a3e9f00d8082d41b34')
+
+prepare() {
+  # Workaround for symlinks in archive, see <https://www.msys2.org/docs/symlinks/>.
+  bsdtar -xzf "${srcdir}/${_realname}-${pkgver}.tar.gz" 2>/dev/null || bsdtar -xzf "${srcdir}/${_realname}-${pkgver}.tar.gz"
+
+  cd "auto${_realname}-${pkgver}"
+  # Remove references to <sys/times.h> (not present in MINGW / MSYS2) and its
+  # functions to make cliquer build.
+  # Patch originally by pranavrajpal at GitHub, taken from passagemath
+  # <https://github.com/passagemath/passagemath/commit/a90633c0c1cf7637abf04ad9030bcd626a1f32c1>,
+  # slightly modified.
+  patch -Nbp1 -i "${srcdir}/0001-fix-timing-code.patch"
+
+  autoreconf -fiv
+}
+
+build() {
+  mkdir -p "build-${MSYSTEM}" && cd "build-${MSYSTEM}"
+
+  ../"auto${_realname}-${pkgver}"/configure \
+    --prefix="${MINGW_PREFIX}" \
+    --build="${MINGW_CHOST}" \
+    --host="${MINGW_CHOST}" \
+    --target="${MINGW_CHOST}" \
+    --enable-static \
+    --enable-shared
+
+  make
+}
+
+check() {
+  cd "build-${MSYSTEM}"
+
+  make check
+}
+
+package() {
+  cd "build-${MSYSTEM}"
+
+  make install DESTDIR="${pkgdir}"
+
+  install -Dm644 "${srcdir}/auto${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
cliquer is required to build passagemath-cliquer, one of the packages of passagemath (<https://github.com/msys2/MINGW-packages/issues/24738>).


cliquer is also available in several other distributions, for example:
* Arch Linux: https://archlinux.org/packages/extra/x86_64/cliquer/
* Debian: https://packages.debian.org/trixie/source/cliquer
* Gentoo: https://packages.gentoo.org/packages/sci-mathematics/cliquer
* Fedora: https://packages.fedoraproject.org/pkgs/cliquer/