### PR TITLE
passagemath-cliquer: add version 10.6.39 (new package)

### DIFF
--- a/mingw-w64-passagemath-cliquer/0001-allow-newer-cysignals.patch
+++ b/mingw-w64-passagemath-cliquer/0001-allow-newer-cysignals.patch
@@ -1,0 +1,13 @@
+diff --git a/pyproject.toml b/pyproject.toml.modified
+index a60bce7..7810941 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -9,7 +9,7 @@ requires = [
+     'passagemath-environment ~= 10.6.39.0',
+     'passagemath-objects ~= 10.6.39.0',
+     'cython >=3.0.8, <3.2.0', 'cython >=3.0.8,<3.2.0',
+-    'cysignals <1.12.4; sys_platform == "win32"', 'cysignals >=1.11.2, != 1.12.0',
++    'cysignals >=1.11.2, != 1.12.0',
+ ]
+ build-backend = "setuptools.build_meta"
+ 

--- a/mingw-w64-passagemath-cliquer/PKGBUILD
+++ b/mingw-w64-passagemath-cliquer/PKGBUILD
@@ -1,0 +1,56 @@
+# Maintainer: Dirk Stolle
+
+_realname=passagemath-cliquer
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=10.6.39
+pkgrel=1
+pkgdesc="passagemath: Finding cliques in graphs with cliquer (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/passagemath/passagemath'
+msys2_references=(
+  'purl: pkg:pypi/passagemath-cliquer'
+)
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-cliquer"
+         "${MINGW_PACKAGE_PREFIX}-python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cython"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-cysignals"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-pkgconfig"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-categories"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-environment"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-objects"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-setup"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz"
+        "0001-allow-newer-cysignals.patch")
+sha256sums=('1a52d748c27ab2ea8abd9f29519dca9983be5be6c8f3ed2d8685113b9e26be13'
+            'd87a469e1fcc80fa707769b850cc7ec8605541372eee861d608cb059b23c0163')
+
+prepare() {
+  cd "${_realname/-/_}-${pkgver}"
+
+  # Loosen a constraint on cysignals so that the version packaged in MSYS2 is accepted.
+  patch -Nbp1 -i "${srcdir}/0001-allow-newer-cysignals.patch"
+}
+
+build() {
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+}


### PR DESCRIPTION
This PR adds python-passagemath-cliquer, a package to provide some functionality from passagemath (https://github.com/msys2/MINGW-packages/issues/24738).

Now that cliquer is part of MSYS2 (#26716), this package of passagemath can be built, too.