### PR TITLE
m4ri: update to 20251207

### DIFF
--- a/mingw-w64-m4ri/PKGBUILD
+++ b/mingw-w64-m4ri/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=m4ri
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=20251206
+pkgver=20251207
 pkgrel=1
 _commit=3c25b8fcdb27fd11c2a1e1c5bcd98793bd1b2030
 pkgdesc="Algorithms for linear algebra over GF_2 (mingw-w64)"
@@ -20,21 +20,11 @@ depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
          "${MINGW_PACKAGE_PREFIX}-libpng")
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-cc")
-source=("https://github.com/malb/m4ri/releases/download/${pkgver}/m4ri-${pkgver}.tar.gz"
-        "0001-upstream-pr-37.diff")
-sha256sums=('2b9c1ba4fae834725308ffd3b61862f511c17545009a56c3ba965e0c33c23821'
-            '4a7afb75f45ee59a510f634fc6570a4cb24be9fa3bd03b33cd82559b637aece8')
+source=("https://github.com/malb/m4ri/releases/download/${pkgver}/m4ri-${pkgver}.tar.gz")
+sha256sums=('7b195a4d88fa827b9ec6d087c3cac739ab6e5100da05faaed3a1d2c20ca3a930')
 
 prepare() {
   cd "${_realname}-${pkgver}"
-
-  # The CPU detection code in version 20251206, added in upstream PR 37 (see
-  # <https://github.com/malb/m4ri/pull/37>) does not work on ARM64. Therefore,
-  # it gets reverted here, but only when in the CLANGARM64 environment.
-  if [[ "${MSYSTEM}" == "CLANGARM64" ]]
-  then
-    patch --reverse -p1 -i "${srcdir}/0001-upstream-pr-37.diff"
-  fi
 
   autoreconf -fiv
 }


### PR DESCRIPTION
The patch to revert upstream PR 37 is not required anymore in the new version, because it was fixed in <https://github.com/malb/m4ri/pull/39>. :)