### PR TITLE
pymol: fix launch script handling

### DIFF
--- a/mingw-w64-pymol/PKGBUILD
+++ b/mingw-w64-pymol/PKGBUILD
@@ -4,7 +4,7 @@ _realname=pymol
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=3.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Molecular visualization system on an Open Source foundation (mingw-w64)"
 arch=(any)
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -34,14 +34,18 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!strip')
 _archive="pymol-open-source-$pkgver"
 source=("$_url/archive/v$pkgver/$_archive.tar.gz"
-        "support-to-build-pymol-with-mingw-w64.patch")
+        "support-to-build-pymol-with-mingw-w64.patch"
+        "fix-update-launch-script-handling-for-mingw-w64-msys.patch")
 sha256sums=('54306d65060bd58ed8b3dab1a8af521aeb4fd417871f15f463ff05ccb4e121fe'
-            '52ee00040581e82a7c090c80082125994345d250b8ad0b16b87ac611d6297cf9')
+            '784e2f29c73cd361a80b5c0ea14b8ca2820b19ffaefe37ad138bb567a8c802b5'
+            '8f0aa54849bfbd3b738a93fa4ffdc875e07bfdbb58eaaf0de8950b14c3b8336f')
 
 prepare() {
   cd "${_archive}"
   # Backport https://github.com/schrodinger/pymol-open-source/pull/486
   patch -Np1 -i "${srcdir}/support-to-build-pymol-with-mingw-w64.patch"
+  # Backport https://github.com/schrodinger/pymol-open-source/pull/487
+  patch -Np1 -i "${srcdir}/fix-update-launch-script-handling-for-mingw-w64-msys.patch"
   # unpin over-aggressive dependency pinning
   sed -i -e '/numpy/s/>.*"/"/g' pyproject.toml
   # avoid duplicate binary creation

--- a/mingw-w64-pymol/fix-update-launch-script-handling-for-mingw-w64-msys.patch
+++ b/mingw-w64-pymol/fix-update-launch-script-handling-for-mingw-w64-msys.patch
@@ -1,0 +1,62 @@
+From cea1d914003fdac072ac48f87e1a2d06adbc6eb4 Mon Sep 17 00:00:00 2001
+From: Zhou Qiankang <wszqkzqk@qq.com>
+Date: Wed, 10 Dec 2025 12:30:00 +0800
+Subject: [PATCH] fix: update launch script handling for mingw-w64/msys2 on
+ Windows
+
+Signed-off-by: Zhou Qiankang <wszqkzqk@qq.com>
+---
+ setup.py | 35 ++++++++++++++++++++---------------
+ 1 file changed, 20 insertions(+), 15 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index a75045eb..aba651bd 100644
+--- a/setup.py
++++ b/setup.py
+@@ -508,23 +508,28 @@ class install_pymol(install):
+ 
+         with open(launch_script, "w") as out:
+             if WIN:
+-                # paths relative to launcher, if possible
+-                try:
+-                    python_exe = "%~dp0\\" + os.path.relpath(
+-                        python_exe, self.install_scripts
+-                    )
+-                except ValueError:
+-                    pass
+-                try:
+-                    pymol_file = "%~dp0\\" + os.path.relpath(
+-                        pymol_file, self.install_scripts
+-                    )
+-                except ValueError:
+-                    pymol_file = os.path.abspath(pymol_file)
+-
+                 if not self.pymol_path_is_default:
+                     out.write(f"set PYMOL_PATH={pymol_path}" + os.linesep)
+-                out.write('"%s" "%s"' % (python_exe, pymol_file))
++
++                if is_mingw:
++                    python_exe = "%~dp0\\python.exe"
++                    out.write('"%s" -m pymol' % python_exe)
++                else:
++                    # paths relative to launcher, if possible
++                    try:
++                        python_exe = "%~dp0\\" + os.path.relpath(
++                            python_exe, self.install_scripts
++                        )
++                    except ValueError:
++                        pass
++                    try:
++                        pymol_file = "%~dp0\\" + os.path.relpath(
++                            pymol_file, self.install_scripts
++                        )
++                    except ValueError:
++                        pymol_file = os.path.abspath(pymol_file)
++                    out.write('"%s" "%s"' % (python_exe, pymol_file))
++
+                 out.write(" %*" + os.linesep)
+             else:
+                 out.write("#!/bin/sh" + os.linesep)
+-- 
+2.50.1.windows.1
+

--- a/mingw-w64-pymol/support-to-build-pymol-with-mingw-w64.patch
+++ b/mingw-w64-pymol/support-to-build-pymol-with-mingw-w64.patch
@@ -1,4 +1,4 @@
-From 3d09924d3b6c1bcdbb427d4c566bbdd155204ba3 Mon Sep 17 00:00:00 2001
+From 0727afbc914a0230333e83ff9ae1c9cd6100d880 Mon Sep 17 00:00:00 2001
 From: Zhou Qiankang <wszqkzqk@qq.com>
 Date: Sun, 23 Nov 2025 11:56:46 +0800
 Subject: [PATCH] build: support to build pymol with mingw-w64 on Windows
@@ -65,7 +65,7 @@ index 470733852..632f52877 100644
    typedef unsigned __int64 ov_uint64;
  #else
 diff --git a/setup.py b/setup.py
-index ec7237a86..09d0743bf 100644
+index ec7237a86..a75045eb1 100644
 --- a/setup.py
 +++ b/setup.py
 @@ -31,6 +31,13 @@
@@ -75,7 +75,7 @@ index ec7237a86..09d0743bf 100644
 +# check for mingw compiler on windows
 +is_mingw = False
 +if WIN:
-+    from distutils import ccompiler
++    from setuptools._distutils import ccompiler
 +    is_mingw = ccompiler.get_default_compiler() == 'mingw32'
 +
 +


### PR DESCRIPTION
* Backport https://github.com/schrodinger/pymol-open-source/pull/487
* Prevent hardcoded paths in pymol.bat launcher