### PR TITLE
msys2: Add kproperty package

### DIFF
--- a/mingw-w64-kproperty-qt5/PKGBUILD
+++ b/mingw-w64-kproperty-qt5/PKGBUILD
@@ -1,0 +1,72 @@
+# Maintainer (MSYS2): Ilya Lesnov <gnoksel@gmail.com>
+# Based on ArchLinux PKGBUILD
+
+_variant=-${KF5_VARIANT:-shared}
+source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
+_kde_f5_init_package "${_variant}" "kproperty"
+pkgver=3.2.0
+pkgrel=1
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+msys2_references=(
+  'archlinux: kproperty'
+)
+pkgdesc='A property editing framework with editor widget similar to what is known from Qt Designer (mingw-w64)'
+url='https://apps.kde.org/kexi-3.3/'
+license=('LGPL')
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+depends=()
+if [ "${_variant}" = "-static" ]; then
+  _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}"
+else
+  makedepends+=("${MINGW_PACKAGE_PREFIX}-qt5-tools")
+  depends+=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-kconfig-qt5"
+         "${MINGW_PACKAGE_PREFIX}-kcoreaddons-qt5"
+         "${MINGW_PACKAGE_PREFIX}-kguiaddons-qt5"
+         "${MINGW_PACKAGE_PREFIX}-kwidgetsaddons-qt5"
+         "${MINGW_PACKAGE_PREFIX}-qt5-base")
+fi
+groups=("${MINGW_PACKAGE_PREFIX}-kf5")
+source=("https://download.kde.org/stable/${_basename}/src/${_basename}-$pkgver.tar.xz"{,.sig})
+sha256sums=('67af0c2d74715957bd5373a6a30589ff0a996cb1d267dfd0538dccaa9a768dfa'
+            'SKIP')
+validpgpkeys=(4866BAF713B465677A4059643C7C0E201B6524DB) # Jarosław Staniek <staniek@kde.org>
+
+prepare() {
+
+  mkdir -p build-${MSYSTEM}${_variant}
+  cd "${_basename}-$pkgver"
+  sed -e '/SetKPropertyCMakePolicies/d' -i CMakeLists.txt
+}
+
+build() {
+  local -a extra_config
+  cd build-${MSYSTEM}${_variant}
+  
+  if [ "${_variant}" = "-static" ]; then
+    extra_config+=( -DBUILD_SHARED_LIBS=NO )
+  fi
+  
+   _kde_f5_build_env
+
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G 'Unix Makefiles' \
+	-DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
+	"${_kde_f5_KDE_INSTALL_DIRS[@]}" \
+	-DBUILD_QCH=OFF \
+    -DBUILD_TESTING=OFF \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+	-DECM_DIR=${MINGW_PREFIX}/share/ECM \
+    "${extra_config[@]}" \
+     ../${_basename}-${pkgver}
+
+  ${MINGW_PREFIX}/bin/cmake.exe --build .
+}
+
+package() {
+  cd build-${MSYSTEM}${_variant}
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install ./
+}


### PR DESCRIPTION
## Description
Adds kproperty package to MSYS2 repository. KProperty is a property editing framework with editor widget similar to what is known from Qt Designer.

## Changes
- Initial package submission for kproperty 3.2.0
- Compatible with ucrt64, mingw64, clang64, and clangarm64 architectures

## Package Details
- **Package name:** `mingw-w64-{arch}-kproperty`
- **Version:** 3.2.0 (release 1)
- **Dependencies:** kconfig-qt5, kcoreaddons-qt5, kguiaddons-qt5, kwidgetsaddons-qt5, qt5-base
- **Build system:** CMake with Unix Makefiles generator

## Build Instructions
```bash
# Build for ucrt64
MINGW_ARCH=ucrt64 makepkg-mingw -sLf

# Build all architectures
for arch in mingw64 ucrt64 clang64 clangarm64; do
  MINGW_ARCH=$arch makepkg-mingw -sLf
done
```
## Testing
-    Successful build on ucrt64
-    Package installation and removal
-    Basic library functionality test
-    No conflicts with existing packages