### PR TITLE
emacs: Fix building with newer versions of mingw64-w64 headers

### DIFF
--- a/mingw-w64-emacs/005-lseek.patch
+++ b/mingw-w64-emacs/005-lseek.patch
@@ -1,0 +1,13 @@
+--- emacs-30.2/nt/inc/ms-w32.h.orig	2025-01-04 12:05:30.000000000 +0100
++++ emacs-30.2/nt/inc/ms-w32.h	2025-12-10 10:31:12.089835100 +0100
+@@ -328,8 +328,8 @@
+ #endif
+ #define isatty    _isatty
+ #define _longjmp  longjmp
+-/* MinGW64 defines lseek to invoke lseek64.  */
+-#ifndef lseek
++/* MinGW64 declares lseek to invoke lseek64.  */
++#ifdef _MSC_VER
+ #define lseek     _lseek
+ #endif
+ #define popen     _popen

--- a/mingw-w64-emacs/PKGBUILD
+++ b/mingw-w64-emacs/PKGBUILD
@@ -8,7 +8,7 @@ _realname=emacs
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=30.2
-pkgrel=5
+pkgrel=6
 pkgdesc="The extensible, customizable, self-documenting, real-time display editor (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -42,11 +42,12 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 # Don't zip info files because the built-in info reader uses gzip to
 # decompress them. gzip is not available as a mingw binary.
 options=('!zipman')
-source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.xz"{,.sig}
+source=("https://ftpmirror.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.xz"{,.sig}
         "001-ucrt.patch"
         "002-clang-fixes.patch"
         "003-aarch64-fixes.patch"
         "004-dll-versions.patch"
+        "005-lseek.patch"
         "emacs-ARM64.manifest")
 # source=("https://alpha.gnu.org/gnu/${_realname}/pretest/${_realname}-${pkgver}.tar.xz"{,.sig})
 sha256sums=('b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9'
@@ -55,21 +56,32 @@ sha256sums=('b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9'
             'd8732584a8f3bfd0badbd16d15384b7098e25c5df48632beb02d35f6050c358b'
             'd128982d87af1e524ae809147613168153f0e5c1efb0ef633793df47b762c9e1'
             '1fcba307b278a7794ecca4f09e7ce1a715b4ee255badd3fa376ca1ef1aa7246f'
+            'b91e8a63f6afef93fad119f5b4b5bca132bb7f5564df6f26d085dcfa9e28c64c'
             'bfe64602dbeeec85799c1156ca4f3837fdac42a076e83a4221768db3417220e1')
 validpgpkeys=('28D3BED851FDF3AB57FEF93C233587A47C207910'
               '17E90D521672C04631B1183EE78DAE0F3115E06B'
               'E6C9029C363AD41D787A8EBB91C1262F01EB8D39'
               'CEA1DE21AB108493CC9C65742E82323B8F4353EE')
 
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Np1 -i "${srcdir}/$_patch"
+  done
+}
+
 prepare() {
   cp "${srcdir}/emacs-ARM64.manifest" "${_realname}-${pkgver}/nt"
 
   cd "${_realname}-${pkgver}"
 
-  patch -Np1 -i "${srcdir}/001-ucrt.patch"
-  patch -Np1 -i "${srcdir}/002-clang-fixes.patch"
-  patch -Np1 -i "${srcdir}/003-aarch64-fixes.patch"
-  patch -Np1 -i "${srcdir}/004-dll-versions.patch"
+  apply_patch_with_msg \
+    001-ucrt.patch \
+    002-clang-fixes.patch \
+    003-aarch64-fixes.patch \
+    004-dll-versions.patch \
+    005-lseek.patch
 
   # Fail if 004-dll-versions.patch needs to be updated
   _dllname_xml=$(dlltool --identify "${MINGW_PREFIX}/lib/libxml2.dll.a")


### PR DESCRIPTION
Also download tarball from mirror server.