### PR TITLE
gemini-cli: update to 0.20.0 and refactor to reduce installed size

### DIFF
--- a/mingw-w64-gemini-cli/PKGBUILD
+++ b/mingw-w64-gemini-cli/PKGBUILD
@@ -1,7 +1,7 @@
 _realname=gemini-cli
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.19.4
+pkgver=0.20.0
 pkgrel=1
 pkgdesc="An open-source AI agent that brings the power of Gemini directly into your terminal. (mingw-w64)"
 arch=('any')
@@ -14,29 +14,26 @@ msys2_references=(
 )
 license=('Apache-2.0')
 depends=(${MINGW_PACKAGE_PREFIX}-nodejs)
-makedepends=(${MINGW_PACKAGE_PREFIX}-cc)
-source=("https://registry.npmjs.org/@google/$_realname/-/$_realname-$pkgver.tgz"
+makedepends=(git
+             ${MINGW_PACKAGE_PREFIX}-cc
+             ${MINGW_PACKAGE_PREFIX}-jq)
+source=("git+$url.git#tag=v$pkgver"
         "tree-sitter-bash-mingw-fix.patch"
         "node-pty-support-to-build-with-mingw-w64-in-windows.patch"
         "node-pty-fix-type-errors.patch"
         "node-pty-fix-windows-arm-defs.patch")
-sha256sums=('2ae7ab76decd7133d2fd72993860e5860c4fcbe3b570855de73db11cb417b4b5'
+sha256sums=('c9310a59b59e9ed715d13fe38c3e6cc169a60ee28092463c547e76a71b71823e'
             '78a7e0a5579e236c3565e60b297a3ec8206a6b5dd81642029a37239d2fd9d104'
             'd68987126a3ca395c042f0513ecef0ae0de3a8813fe4023334f764f74e786aa1'
             '0afd76a0332c7ae8700622b7517d03dfea0ee308ca444d0b64a7ebd07bc78b80'
             '452c8b12820ca1ec206727ec2d68eb30b47d83a03088301598534029ef551b98')
-noextract=("${_realname}-${pkgver}.tgz")
 
-package() {
-  # Install with --ignore-scripts first to download dependencies without building
-  npm install -g \
-    --cache npm-cache \
-    --prefix "${pkgdir}${MINGW_PREFIX}" \
-    --ignore-scripts \
-    "${_realname}-${pkgver}.tgz"
+prepare() {
+  cd $_realname
+  npm clean-install --ignore-scripts
 
   # Patch tree-sitter-bash for MinGW compatibility
-  local _node_modules_dir="${pkgdir}${MINGW_PREFIX}/lib/node_modules/@google/gemini-cli/node_modules"
+  local _node_modules_dir="node_modules"
   # https://github.com/tree-sitter/tree-sitter-bash/pull/314
   patch -Np1 -d "${_node_modules_dir}/tree-sitter-bash" -i "${srcdir}/tree-sitter-bash-mingw-fix.patch"
   # https://github.com/microsoft/node-pty/pull/828
@@ -45,8 +42,26 @@ package() {
   patch -Np1 -d "${_node_modules_dir}/node-pty" -i "${srcdir}/node-pty-fix-type-errors.patch"
   # Fix Windows ARM definitions
   patch -Np1 -d "${_node_modules_dir}/node-pty" -i "${srcdir}/node-pty-fix-windows-arm-defs.patch"
+}
 
-  # Run install scripts
-  npm rebuild \
-    --prefix "${pkgdir}${MINGW_PREFIX}/lib/node_modules/@google/gemini-cli"
+build() {
+  cd $_realname
+  npm run bundle
+  local bundled=$(jq '.dependencies + .optionalDependencies | keys' package.json)
+  npm pkg set --json bundledDependencies="$bundled"
+  npm pack
+}
+
+check() {
+  cd $_realname
+  npm run build
+  npm test
+}
+
+package() {
+  cd $_realname
+  npm install --global --offline --prefix "${pkgdir}${MINGW_PREFIX}" \
+    google-$_realname-$pkgver.tgz
+  install -vDm644 -t "${pkgdir}${MINGW_PREFIX}/share/doc/$_realname" README.md
+  install -vDm644 -t "${pkgdir}${MINGW_PREFIX}/share/licenses/$_realname" LICENSE
 }


### PR DESCRIPTION
* Follow Arch Linux's refactor to reduce installed size
* See also: https://gitlab.archlinux.org/archlinux/packaging/packages/gemini-cli/-/commit/e3afb1f4de888a1b49463bcbddb444b28a583c1b