### PR TITLE
xournalpp: update to 1.3.0

### DIFF
--- a/mingw-w64-xournalpp/PKGBUILD
+++ b/mingw-w64-xournalpp/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=xournalpp
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.2.10
+pkgver=1.3.0
 pkgrel=1
 pkgdesc='Handwriting notetaking software with PDF annotation support (mingw-w64)'
 arch=('any')
@@ -33,6 +33,7 @@ depends=(
   "${MINGW_PACKAGE_PREFIX}-pango"
   "${MINGW_PACKAGE_PREFIX}-poppler"
   "${MINGW_PACKAGE_PREFIX}-portaudio"
+  "${MINGW_PACKAGE_PREFIX}-qpdf"
   "${MINGW_PACKAGE_PREFIX}-zlib"
 )
 # rsvg and imagemagick for icon generation
@@ -47,7 +48,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-pkgconf"
 )
 source=("https://github.com/xournalpp/xournalpp/archive/v${pkgver}/${_realname}-v${pkgver}.tar.gz")
-sha256sums=('92189df9239db719adc41227f8c808f6fbb83449227067d20ca78a2f015804a4')
+sha256sums=('fd80fb4935e82dcc01b8373569ffd0eda286df1d3ea45a46f36969bef5ee8933')
 
 build() {
   declare -a extra_config
@@ -63,6 +64,7 @@ build() {
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       "${extra_config[@]}" \
       -DBUILD_SHARED_LIBS=ON \
+      -DENABLE_CPPTRACE=OFF \
       -S "${_realname}-${pkgver}" \
       -B "build-${MSYSTEM}"
 


### PR DESCRIPTION
add qpdf. cpp-trace seems missing there, so disable for now