### PR TITLE
meson: work around g-ir-scanner failing with ccache

### DIFF
--- a/mingw-w64-meson/PKGBUILD
+++ b/mingw-w64-meson/PKGBUILD
@@ -4,7 +4,7 @@ _realname=meson
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.10.0
-pkgrel=1
+pkgrel=2
 pkgdesc="High-productivity build system (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -30,12 +30,14 @@ source=("https://github.com/mesonbuild/${_realname}/releases/download/${pkgver}/
         'color-term.patch'
         '0002-Default-to-sys.prefix-as-the-default-prefix.patch'
         '0004-fix-gtk-doc.patch'
-        'install-man.patch')
+        'install-man.patch'
+        'https://github.com/mesonbuild/meson/pull/15387.patch')
 sha256sums=('8071860c1f46a75ea34801490fd1c445c9d75147a65508cd3a10366a7006cc1c'
             '5805aed0a117536eb16dd8eef978c6be57c2471b655ede63e25517c28b4f4cf0'
             '032b38f0b2765dc88e1fcb34e27b69b611e07c869c13c6e703bcf182e586fccb'
             'bc43a2695498885afa08f2aeb927d6958741aa1a9fc66850de1a6c79fdf59241'
-            '0682a36cb75e545a78b81293303835a16171f25baf949905dc08029436efff84')
+            '0682a36cb75e545a78b81293303835a16171f25baf949905dc08029436efff84'
+            'dda29950cd44fa947b2eecea33d764b8c276e3cbf58897780128d3b551fe7209')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -53,6 +55,10 @@ prepare() {
     0002-Default-to-sys.prefix-as-the-default-prefix.patch \
     0004-fix-gtk-doc.patch \
     install-man.patch
+
+  # https://github.com/msys2/MINGW-packages/issues/26812
+  apply_patch_with_msg \
+    15387.patch
 }
 
 build() {


### PR DESCRIPTION
See https://github.com/mesonbuild/meson/pull/15387 and https://github.com/msys2/MINGW-packages/issues/26812