### PR TITLE
passagemath: update to 10.6.42

### DIFF
--- a/mingw-w64-passagemath-bliss/PKGBUILD
+++ b/mingw-w64-passagemath-bliss/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-bliss
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.41
+pkgver=10.6.42
 pkgrel=1
 pkgdesc="passagemath: Graph (iso/auto)morphisms with bliss (mingw-w64)"
 arch=('any')
@@ -29,7 +29,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('e16d5668dccb6cf6f5334b5ef0f9f9bb3408d7a4a4a09351448c4307a0630a07')
+sha256sums=('c32d668aa49860ec3e7e079c44e3242dc0b14b93fabe231ca0b6778686450fe5')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-categories/PKGBUILD
+++ b/mingw-w64-passagemath-categories/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-categories
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.41
+pkgver=10.6.42
 pkgrel=1
 pkgdesc="passagemath: Sage categories and basic rings (mingw-w64)"
 arch=('any')
@@ -31,7 +31,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('e9773f07c1254843ecbda6977a299254c969c1eaede9afcba19330fb8c8f9fea')
+sha256sums=('714654b70a0d1ff52542f95e207e3a58771c614290b9c9c763e8c50dfb6a18e6')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-cddlib/PKGBUILD
+++ b/mingw-w64-passagemath-cddlib/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-cddlib
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.41
+pkgver=10.6.42
 pkgrel=1
 pkgdesc="passagemath: Polynomial system solving through algebraic methods with cddlib (mingw-w64)"
 arch=('any')
@@ -28,7 +28,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('30359de252a39a66f0b3782c86935f63147d21b757ba6c83eb78d0578899da95')
+sha256sums=('e12f8861e117073f13a5641807ac5f627123709619fddc3197ca37ae2add29cf')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-cliquer/PKGBUILD
+++ b/mingw-w64-passagemath-cliquer/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-cliquer
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.41
+pkgver=10.6.42
 pkgrel=1
 pkgdesc="passagemath: Finding cliques in graphs with cliquer (mingw-w64)"
 arch=('any')
@@ -30,7 +30,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('dc009088034fea32ea0b64ba99e1e83e81322e85aa90b3a5c2f5890d865d4874')
+sha256sums=('7e6bf746e5c4214c1a8dae97d65b09182370788f0111e419de4564aea6186557')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-cmr/PKGBUILD
+++ b/mingw-w64-passagemath-cmr/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-cmr
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.41
+pkgver=10.6.42
 pkgrel=1
 pkgdesc="passagemath: Combinatorial matrix recognition (mingw-w64)"
 arch=('any')
@@ -30,7 +30,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('8cf59ad501d6a48fde52fdd02093dc5147e052caeff95f76d0b7cedacd9fae17')
+sha256sums=('dd3193869b1a9bf2a8a0a2222054d2378e3aa01710d1723c05f5fc23d1196ddc')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-combinat/PKGBUILD
+++ b/mingw-w64-passagemath-combinat/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-combinat
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.41
+pkgver=10.6.42
 pkgrel=1
 pkgdesc="passagemath: Algebraic combinatorics, combinatorial representation theory (mingw-w64)"
 arch=('any')
@@ -32,7 +32,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('81089041d69a60d13dcd391bd7381dc3e9e43bc28340e1b704f950c77fa91bac')
+sha256sums=('4216ab976118cb552afe4ea1ef8e959d92306e30fbcd80bfb2339bf0386ddb8e')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-environment/PKGBUILD
+++ b/mingw-w64-passagemath-environment/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=passagemath-environment
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=10.6.41
+pkgver=10.6.42
 pkgrel=1
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgdesc="Subset of the Sage library providing the connection to the system and software environment (mingw-w64)"
@@ -22,7 +22,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('ceb6697ff63cba526f800e77930ac22aadbe48bbbb14ae24ae99fe189c60398c')
+sha256sums=('748a797b4af46c70d79856c40f9dfb8a603bff32e87963a43bac305268298159')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-glpk/PKGBUILD
+++ b/mingw-w64-passagemath-glpk/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-glpk
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.41
+pkgver=10.6.42
 pkgrel=1
 pkgdesc="passagemath: Linear and mixed integer linear optimization backend using GLPK (mingw-w64)"
 arch=('any')
@@ -34,7 +34,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('3e7e162798f0718fcf972ab891faeadb151d25d7dfe028b7bd1001b6d92206b4')
+sha256sums=('379a0a9ff8cc08cd9ca3c066b98eaf7af08dbb2cf55e85ac89989344fe924379')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-graphs/PKGBUILD
+++ b/mingw-w64-passagemath-graphs/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-graphs
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.41
+pkgver=10.6.42
 pkgrel=1
 pkgdesc="passagemath: Graphs, posets, hypergraphs, designs, abstract complexes, combinatorial polyhedra, abelian sandpiles, quivers (mingw-w64)"
 arch=('any')
@@ -31,7 +31,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-boost"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('2b6c2a826bb94d9cf4de8920d229fb6ebdec21730ba3b19c215c0ac87048765c')
+sha256sums=('bc97032a5c815df393c41fea76f70604bd9c2513c9ad10fc8dbe638d57439b4e')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-homfly/PKGBUILD
+++ b/mingw-w64-passagemath-homfly/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-homfly
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.41
+pkgver=10.6.42
 pkgrel=1
 pkgdesc="passagemath: Homfly polynomials of knots/links with libhomfly (mingw-w64)"
 arch=('any')
@@ -29,7 +29,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('b4269d4b8302676fab4acc75c31d801b932554287ff8682a12db47f1819bab20')
+sha256sums=('657434be241b14244e60695f1f2a47630a6096a4c2731d67c715279e940f730a')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-modules/PKGBUILD
+++ b/mingw-w64-passagemath-modules/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-modules
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.41
+pkgver=10.6.42
 pkgrel=1
 pkgdesc="passagemath: Vectors, matrices, tensors, vector spaces, affine spaces, modules and algebras, additive groups, quadratic forms, homology, coding theory, matroids (mingw-w64)"
 arch=('any')
@@ -35,7 +35,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('b68d5cbdcc186de3c334709f9f8af2381a8ed708e4e07aa1762d8ef8fdd4b0bd')
+sha256sums=('f2b54e7346ec393c80e3caf46dac522a724fc73ca2ebcd3c55170318dd192ffc')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-nauty/PKGBUILD
+++ b/mingw-w64-passagemath-nauty/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-nauty
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.41
+pkgver=10.6.42
 pkgrel=1
 pkgdesc="passagemath: Find automorphism groups of graphs, generate non-isomorphic graphs with nauty (mingw-w64)"
 arch=('any')
@@ -29,7 +29,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('ffac61f1b62b76daa4592b034d2f75e9110c1b2991197318c043d59fd2163ce2')
+sha256sums=('2975b24ca35c106163424a7fc4d62d751e7da7bd316bd9918da8ff248b01d523')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-ntl/PKGBUILD
+++ b/mingw-w64-passagemath-ntl/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-ntl
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.41
+pkgver=10.6.42
 pkgrel=1
 pkgdesc="passagemath: Computational Number Theory with NTL (mingw-w64)"
 arch=('any')
@@ -35,7 +35,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('881463e38efa845515f2c44bb6713d46cecff9425b723037c7faf0ce174f7a3d')
+sha256sums=('b9d6c30a6ba4aa90b3f61b090dbaea8cfb4d65c5d98cd633b53fc16c216f2d31')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-objects/PKGBUILD
+++ b/mingw-w64-passagemath-objects/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=passagemath-objects
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=10.6.41
+pkgver=10.6.42
 pkgrel=1
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgdesc="Part of the Sage library making object, element/parent framework, categories and the coercion system available (mingw-w64)"
@@ -31,7 +31,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('660613553c84b2001d421f9b507e21c92d6cc4cc9caed45dab4b4edd344bf8ba')
+sha256sums=('e2216dbd6bf882d8b0a37466ed100b9a5933be74edd7639955855eedcd7b2bc9')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-planarity/PKGBUILD
+++ b/mingw-w64-passagemath-planarity/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-planarity
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.41
+pkgver=10.6.42
 pkgrel=1
 pkgdesc="passagemath: Graph planarity with the edge addition planarity suite (mingw-w64)"
 arch=('any')
@@ -29,7 +29,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-boost"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('0ef365b987077001e830c23b29de283b6898a24683ab765781daedfcc7fb6b84')
+sha256sums=('c5c5933ef8455f61079613505dd6fdd6bff8760fb9cca56f1f62e54117ed21ab')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-plot/PKGBUILD
+++ b/mingw-w64-passagemath-plot/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-plot
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.41
+pkgver=10.6.42
 pkgrel=1
 pkgdesc="passagemath: Plotting and graphics with Matplotlib, Three.JS, etc. (mingw-w64)"
 arch=('any')
@@ -36,7 +36,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('57aa6bda5f860814363a425c0b7561570e99ed67bc71fd05641bfe191eb14376')
+sha256sums=('cf99ef5441332b877c6d6ad22615f0d2f7b3998e66887c2735bea091f9d649ef')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-rankwidth/PKGBUILD
+++ b/mingw-w64-passagemath-rankwidth/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-rankwidth
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.41
+pkgver=10.6.42
 pkgrel=1
 pkgdesc="passagemath: Rankwidth and rank decompositions of graphs (mingw-w64)"
 arch=('any')
@@ -29,7 +29,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('3b60599c0430be08887a97b3773e54036454072fcd7d38057cc7cad96a7ec2d3')
+sha256sums=('38abb2979fee316ee81fc68a711d541a6e5e6aceff21daadabc613eb56bf9584')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-repl/PKGBUILD
+++ b/mingw-w64-passagemath-repl/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-repl
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.41
+pkgver=10.6.42
 pkgrel=1
 pkgdesc="passagemath: IPython kernel, Sage preparser, doctester (mingw-w64)"
 arch=('any')
@@ -27,7 +27,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('a1be147f846e7bebd141ebdc5b421339370d69dcf9e5f747b0796a9e1436938c')
+sha256sums=('83661ce3c422c2dd4d253a0cad752832bd51c8e639aae88ea507554ceb25bd8d')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-setup/PKGBUILD
+++ b/mingw-w64-passagemath-setup/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-setup
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.6.41
+pkgver=10.6.42
 pkgrel=1
 pkgdesc="passagemath: build system of the Sage library (mingw-w64)"
 arch=('any')
@@ -21,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
 optdepends=("${MINGW_PACKAGE_PREFIX}-python-jinja: for autogen feature")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('2c948011e9236999d7146b36353d9765c91f86dbb65c72174f64717f728441c3')
+sha256sums=('fe190fffd07bfea01f38af61fc5cf302dff35f3474db03c7e045e79cfafb83c0')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"


### PR DESCRIPTION
See https://github.com/passagemath/passagemath/releases/tag/passagemath-10.6.42

Important change for MSYS2 is <https://github.com/passagemath/passagemath/pull/1878> which gets us closer to packaging passagemath-flint for MSYS2.