### PR TITLE
treedec: move Boost from makedepends to depends

### DIFF
--- a/mingw-w64-treedec/PKGBUILD
+++ b/mingw-w64-treedec/PKGBUILD
@@ -1,10 +1,10 @@
 _realname=treedec
 pkgbase=mingw-w64-${_realname}
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.9.3
-pkgrel=1
+pkgrel=2
 pkgdesc='Algorithms for computing tree decompositions of graphs'
-arch=(any)
+arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://github.com/freetdi/tdlib/'
 msys2_repository_url='https://gitlab.com/freetdi/treedec'
@@ -12,9 +12,8 @@ msys2_references=(
   'archlinux: treedec'
 )
 license=('spdx:GPL-2.0-or-later AND GPL-3.0-or-later')
-depends=()
+depends=("${MINGW_PACKAGE_PREFIX}-boost")
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
-             "${MINGW_PACKAGE_PREFIX}-boost"
              "${MINGW_PACKAGE_PREFIX}-cc"
              "git")
 conflicts=("${MINGW_PACKAGE_PREFIX}-tdlib")
@@ -33,7 +32,7 @@ prepare() {
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
-  
+
   ../${_realname}/configure \
     --prefix=${MINGW_PREFIX}
 }
@@ -49,4 +48,3 @@ package() {
   install -Dm644 "${srcdir}/${_realname}/GPL-3" \
     "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/GPL-3"
 }
-


### PR DESCRIPTION
The treedec header files include various headers from Boost, so using treedec without having Boost headers installed is going to fail in many cases.

During the treedec review (https://github.com/msys2/MINGW-packages/pull/26852) I didn't notice, because my system already had Boost installed, so everything seemed to work fine.