### PR TITLE
streamlink: update to 8.1.0

### DIFF
--- a/mingw-w64-streamlink/PKGBUILD
+++ b/mingw-w64-streamlink/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=streamlink
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=7.6.0
+pkgver=8.1.0
 pkgrel=1
 pkgdesc="A CLI utility that extracts streams from various services and pipes them into a video player of choice. (mingw-w64)"
 arch=('any')
@@ -20,7 +20,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-"{build,installer,setuptools})
 optdepends=("${MINGW_PACKAGE_PREFIX}-ffmpeg: Required to play streams that are made up of separate audio and video streams, eg. YouTube 1080p+")
 options=('!strip')
 source=("https://github.com/${_realname}/${_realname}/releases/download/${pkgver}/${_realname}-${pkgver}.tar.gz"{,.asc})
-sha256sums=('a1df953fab7dab55c61f563b533ce237159a1b48f6159bec95e907857fc09266'
+sha256sums=('acd297219a0cbaaffe4e292290554b9c45408fa9f6e4dc1211d1ccd1f4a44039'
             'SKIP')
 validpgpkeys=('CDAC41B9122470FAF357A9D344448A298D5C3618') # Streamlink signing key <streamlink@protonmail.com>
 


### PR DESCRIPTION
Just a trivial version bump. Changelogs of unpackaged releases:

- https://streamlink.github.io/changelog.html#streamlink-8-0-0-2025-11-11
- https://streamlink.github.io/changelog.html#streamlink-8-1-0-2025-12-14

----

While updating the PKGBUILD, I noticed that it currently doesn't include the `check()` function, most likely because [`pytest-trio`](https://github.com/python-trio/pytest-trio) is missing from the package repos, which is a dependency for running Streamlink's tests.

> error: target not found: mingw-w64-x86_64-python-pytest-trio

The tests requiring this dependency could be masked by running `pytest -k 'not trio'`, but it would also require to override the forced import of the pytest-trio plugin in Streamlink's `pyproject.toml`:
https://github.com/streamlink/streamlink/blob/8.1.0/pyproject.toml#L194-L200

See the relevant `check()` function for running pytest:
https://gitlab.archlinux.org/archlinux/packaging/packages/streamlink/-/blob/8.1.0-1/PKGBUILD?ref_type=tags#L28-33

Considering that I'm just the dev/maintainer of Streamlink and am not using MSYS2 or even Windows, and just want the package to be up2date, I don't want to add missing PKGBUILDs just for the sake of adding `check()` here.

Thanks