### PR TITLE
uutils-coreutils: 0.5.0, Embedded tldr example to manpages

### DIFF
--- a/mingw-w64-uutils-coreutils/PKGBUILD
+++ b/mingw-w64-uutils-coreutils/PKGBUILD
@@ -4,8 +4,9 @@
 _realname=coreutils
 pkgbase=mingw-w64-uutils-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-uutils-${_realname}")
-pkgver=0.4.0
+pkgver=0.5.0
 pkgrel=1
+_tldrver=2.3
 pkgdesc="Cross-platform Rust rewrite of the GNU coreutils (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -17,11 +18,17 @@ msys2_references=(
 license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-oniguruma" "${MINGW_PACKAGE_PREFIX}-cc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust" "${MINGW_PACKAGE_PREFIX}-pkgconf")
-source=("https://github.com/uutils/coreutils/archive/${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('5f0c3f97b807e72edccc844c6a685ec9862199f16a665df07de5b1d20ec21233')
+source=("https://github.com/uutils/coreutils/archive/${pkgver}/${_realname}-${pkgver}.tar.gz"
+        "tldr-${_tldrver}.zip::https://github.com/tldr-pages/tldr/releases/download/v${_tldrver}/tldr.zip")
+sha256sums=('83535e10c3273c31baa2f553dfa0ceb4148914e9c1a9c5b00d19fbda5b2d4d7d'
+            '30ab57b78bfd8ff51a5d4acfb2d8e86a9e281437bf665dd0257ebd13d70c507b')
+noextract=("tldr-${_tldrver}.zip")
 
 prepare() {
   cd "${_realname}-${pkgver}"
+
+  # Embedded tldr example to manpages
+  mv "${srcdir}/tldr-${_tldrver}.zip" docs/tldr.zip
 
   cargo fetch --locked --target "${RUST_CHOST}"
 }
@@ -32,7 +39,7 @@ package() {
 
   export RUSTONIG_DYNAMIC_LIBONIG=1
   export RUSTFLAGS="${RUSTFLAGS/+crt-static/-crt-static}"
-  make -O install \
+  make install \
     DESTDIR="${pkgdir}" \
     PREFIX="${MINGW_PREFIX}" \
     PROG_PREFIX=uu- \


### PR DESCRIPTION
`GNUMakefile` no longer use `install -v` to install locales. So `make -O` does not break `cargo`'s log.