### PR TITLE
python-passagemath-flint: add version 10.6.42 (new package)

### DIFF
--- a/mingw-w64-passagemath-flint/001-pull-request-1911-one-of-three.patch
+++ b/mingw-w64-passagemath-flint/001-pull-request-1911-one-of-three.patch
@@ -1,0 +1,23 @@
+From d6b6384d905adbb0520aacef53b59f2b0bc97f8c Mon Sep 17 00:00:00 2001
+From: Matthias Koeppe <mkoeppe@math.ucdavis.edu>
+Date: Fri, 19 Dec 2025 21:22:45 -0800
+Subject: [PATCH 1/3] src/sage/rings/polynomial/weil/weil_polynomials.pyx: Do
+ not use a path relative to src root
+
+---
+ src/sage/rings/polynomial/weil/weil_polynomials.pyx | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/sage/rings/polynomial/weil/weil_polynomials.pyx b/src/sage/rings/polynomial/weil/weil_polynomials.pyx
+index 375877db581..18760595fd7 100644
+--- a/src/sage/rings/polynomial/weil/weil_polynomials.pyx
++++ b/src/sage/rings/polynomial/weil/weil_polynomials.pyx
+@@ -59,7 +59,7 @@ from sage.libs.gmp.mpz cimport mpz_set
+ from sage.libs.flint.fmpz cimport *
+ from sage.libs.flint.fmpz_vec cimport *
+ 
+-cdef extern from "sage/rings/polynomial/weil/power_sums.c":
++cdef extern from "power_sums.c":
+     ctypedef struct ps_static_data_t:
+         pass
+ 

--- a/mingw-w64-passagemath-flint/PKGBUILD
+++ b/mingw-w64-passagemath-flint/PKGBUILD
@@ -1,0 +1,67 @@
+# Maintainer: Dirk Stolle
+
+_realname=passagemath-flint
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=10.6.42
+pkgrel=1
+pkgdesc="passagemath: Fast computations with MPFI and FLINT (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64')
+url='https://github.com/passagemath/passagemath'
+msys2_references=(
+  'purl: pkg:pypi/passagemath-flint'
+)
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-flint"
+         "${MINGW_PACKAGE_PREFIX}-gsl"
+         "${MINGW_PACKAGE_PREFIX}-mpfi"
+         "${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-numpy"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-categories"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-ntl")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cython"
+             "${MINGW_PACKAGE_PREFIX}-mpc"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-cysignals"
+             "${MINGW_PACKAGE_PREFIX}-python-gmpy2"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-jinja"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-environment"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-modules"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-setup"
+             "${MINGW_PACKAGE_PREFIX}-python-pkgconfig"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz"
+        "001-pull-request-1911-one-of-three.patch")
+sha256sums=('4f62aa53fdb1fa382e290422356e4c7d2291b1b361ab1796842b9a2a5b8b1ebf'
+            'b8aa78b830fcc8e62ac44457ee1ce529e58ac639063b7f0f340f1d03ed9ac67b')
+
+prepare() {
+  cd "${_realname/-/_}-${pkgver}"
+
+  # Patch relevant part of upstream pull request 1911 for flint, see
+  # <https://github.com/passagemath/passagemath/pull/1911>.
+  # Can be remove once the next release (probably 10.6.43) is out, because that change is already
+  # merged.
+  patch -Nbp2 -i "${srcdir}/001-pull-request-1911-one-of-three.patch"
+}
+
+build() {
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+}


### PR DESCRIPTION
This PR adds python-passagemath-flint, a package to provide some functionality from passagemath (https://github.com/msys2/MINGW-packages/issues/24738).

The clang64 and clangarm64 environments are not supported, for the same reason that passagemath-ntl (https://github.com/msys2/MINGW-packages/pull/26772) is not supported there, because passagemath-flint depends on passagemath-ntl.