### PR TITLE
eog: Add optional dependencies for image formats support

### DIFF
--- a/mingw-w64-eog/PKGBUILD
+++ b/mingw-w64-eog/PKGBUILD
@@ -30,6 +30,10 @@ depends=("${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme"
          "${MINGW_PACKAGE_PREFIX}-libxml2"
          "${MINGW_PACKAGE_PREFIX}-shared-mime-info"
          "${MINGW_PACKAGE_PREFIX}-zlib")
+optdepends=("${MINGW_PACKAGE_PREFIX}-libavif: Load .avif"
+            "${MINGW_PACKAGE_PREFIX}-libheif: Load .heif, .heic, and .avif"
+            "${MINGW_PACKAGE_PREFIX}-libjxl: Load .jxl"
+            "${MINGW_PACKAGE_PREFIX}-webp-pixbuf-loader: Load .webp")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"


### PR DESCRIPTION
Added some of `gdk-pixbuf2` package optdepends. Searching for 'pixbuf', I found `jp2-pixbuf-loader` but `eog` was not able to open a test jp2 file I made with gimp with it.