### PR TITLE
tesseract-ocr: Update to 5.5.2

### DIFF
--- a/mingw-w64-tesseract-ocr/PKGBUILD
+++ b/mingw-w64-tesseract-ocr/PKGBUILD
@@ -4,8 +4,8 @@
 _realname=tesseract-ocr
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=5.5.1
-pkgrel=3
+pkgver=5.5.2
+pkgrel=1
 pkgdesc="Tesseract OCR (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -35,7 +35,7 @@ source=(https://github.com/tesseract-ocr/tesseract/archive/${pkgver}/${_realname
         0002-fix-soversion-with-cmake.patch
         0003-install-pango_training.patch
         0004-fix-build-on-clangarm64.patch)
-sha256sums=('a7a3f2a7420cb6a6a94d80c24163e183cf1d2f1bed2df3bbc397c81808a57237'
+sha256sums=('6235ea0dae45ea137f59c09320406f5888383741924d98855bd2ce0d16b54f21'
             '9cf5d576fcc47564f11265841e5ca839001e7e6f38ff7f7aacf46d15a96b00ff'
             '2d7eaabdb8c56459eddd782a936b2f8512d28b697ebdb33556feb96571b14135'
             'aede606a2ddd54ee29f9d5b52c5d2eaa2bf84113f92793c24a206fac872b3320'
@@ -75,6 +75,7 @@ build() {
     -DOPENMP_BUILD=ON \
     -DBUILD_TRAINING_TOOLS=OFF \
     -DUSE_SYSTEM_ICU=ON \
+    -DENABLE_PRECOMPILED_HEADERS=OFF \
     -DBUILD_SHARED_LIBS=OFF \
     -DSW_BUILD=OFF \
     "${_extra_config[@]}" \
@@ -91,6 +92,7 @@ build() {
     -DOPENMP_BUILD=ON \
     -DBUILD_TRAINING_TOOLS=ON \
     -DUSE_SYSTEM_ICU=ON \
+    -DENABLE_PRECOMPILED_HEADERS=OFF \
     -DBUILD_SHARED_LIBS=ON \
     -DSW_BUILD=OFF \
     "${_extra_config[@]}" \


### PR DESCRIPTION
Disable precompiled headers, cmake includes math.h before any user code which breaks _USE_MATH_DEFINES being used.