### PR TITLE
luarocks: update to 3.13.0

### DIFF
--- a/mingw-w64-lua-luarocks/PKGBUILD
+++ b/mingw-w64-lua-luarocks/PKGBUILD
@@ -5,7 +5,7 @@
 _realname=luarocks
 pkgbase=mingw-w64-lua-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-lua-${_realname}")
-pkgver=3.12.2
+pkgver=3.13.0
 pkgrel=1
 pkgdesc="the package manager for Lua modules (mingw-w64)"
 arch=('any')
@@ -18,11 +18,11 @@ license=("spdx:MIT")
 depends=("${MINGW_PACKAGE_PREFIX}-lua"
          "unzip"
          "zip")
-makedepends=("${MINGW_PACKAGE_PREFIX}-cc" "${MINGW_PACKAGE_PREFIX}-autotools")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
 install=${_realname}-${MSYSTEM}.install
 source=("https://luarocks.org/releases/${_realname}-${pkgver}.tar.gz"
         "0001-luarocks_msys2_mingw_w64.patch")
-sha256sums=('b0e0c85205841ddd7be485f53d6125766d18a81d226588d2366931e9a1484492'
+sha256sums=('245bf6ec560c042cb8948e3d661189292587c5949104677f1eecddc54dbe7e37'
             '48e2e8c9cd1eaf7f18b38c25d474a4cd39dddb88b92152e278d04dffdcda2a90')
 
 prepare() {


### PR DESCRIPTION
Removed autotools from makedepends, because the configure script is not generated. It is hand written.