### PR TITLE
pip: import distlib from a wheel

### DIFF
--- a/mingw-w64-python-distlib/PKGBUILD
+++ b/mingw-w64-python-distlib/PKGBUILD
@@ -5,7 +5,7 @@ _realname=distlib
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=0.4.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Low-level components of distutils2/packaging (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -83,6 +83,12 @@ package() {
   MSYS2_ARG_CONV_EXCL="--prefix=" \
     ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
     --destdir="${pkgdir}" dist/*.whl
+
+  # install wheel into pip/_vendor
+  local _pyver=$(python -c "import sys;sys.stdout.write('.'.join(map(str, sys.version_info[:2])))")
+  local _pip_vendor="${pkgdir}${MINGW_PREFIX}/lib/python${_pyver}/site-packages/pip/_vendor"
+  mkdir -p "$_pip_vendor"
+  cp dist/*.whl "$_pip_vendor"
 
   install -Dm644 LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
 }

--- a/mingw-w64-python-pip/0001-use-system-distlib.patch
+++ b/mingw-w64-python-pip/0001-use-system-distlib.patch
@@ -1,10 +1,11 @@
 --- pip-21.1.1/src/pip/_vendor/__init__.py.orig	2021-05-23 16:02:55.105064300 +0530
 +++ pip-21.1.1/src/pip/_vendor/__init__.py	2021-05-23 16:10:22.105230100 +0530
-@@ -46,6 +46,8 @@
+@@ -46,6 +46,9 @@
          base, head = vendored_name.rsplit(".", 1)
          setattr(sys.modules[base], head, sys.modules[modulename])
  
 +# Use system distlib rather than the one vendored.
++sys.path[:] = glob.glob(os.path.join(WHEEL_DIR, "*.whl")) + sys.path
 +vendored("distlib")
  
  # If we're operating in a debundled setup, then we want to go ahead and trigger

--- a/mingw-w64-python-pip/PKGBUILD
+++ b/mingw-w64-python-pip/PKGBUILD
@@ -5,7 +5,7 @@ _realname=pip
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=25.3
-pkgrel=1
+pkgrel=2
 pkgdesc="The PyPA recommended tool for installing Python packages. (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -29,7 +29,7 @@ source=(
   "0002-only-warn-for-externally-managed.patch"
 )
 sha256sums=('8d0538dbbd7babbd207f261ed969c65de439f6bc9e5dbd3b3b9a77f25d95f343'
-            'c7f98690afa60e59324f1ce52e72bd7809cbfaba4e29a2d933f08c1a025f8246'
+            'e6cac9043f43cd32914a618191ac5852e4bbcc12ecf0314424d9e1a544358b69'
             'be196f12feee11fe1caccbdeff9a31ac077120de7b6e85679ea54b6dd2df8f5b')
 
 prepare() {


### PR DESCRIPTION
This makes it possible to run pip with venv python that doesn't have access to the system-site-packages to import distlib.

It's a bit weird that distlib installs into the pip dir, but that seems like the easiest change to make this work.

Fixes #27113