### PR TITLE
libheif: enable openjph on mingw32

### DIFF
--- a/mingw-w64-libheif/PKGBUILD
+++ b/mingw-w64-libheif/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libheif
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.21.0
-pkgrel=1
+pkgrel=2
 pkgdesc="HEIF image decoder/encoder library and tools (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -30,8 +30,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
          "${MINGW_PACKAGE_PREFIX}-libx264"
          "${MINGW_PACKAGE_PREFIX}-openh264"
          "${MINGW_PACKAGE_PREFIX}-openjpeg2"
+         "${MINGW_PACKAGE_PREFIX}-openjph"
          $([[ ${CARCH} == i686 ]] || echo \
-            "${MINGW_PACKAGE_PREFIX}-openjph" \
             "${MINGW_PACKAGE_PREFIX}-rav1e" \
             "${MINGW_PACKAGE_PREFIX}-svt-av1" )
          "${MINGW_PACKAGE_PREFIX}-SDL2"
@@ -51,9 +51,9 @@ build() {
   fi
 
   if [[ ${CARCH} == i686 ]]; then
-    extra_config+=("-DWITH_OPENJPH_ENCODER=OFF" "-DWITH_RAV1E=OFF" "-DWITH_SvtEnc=OFF")
+    extra_config+=("-DWITH_RAV1E=OFF" "-DWITH_SvtEnc=OFF")
   else
-    extra_config+=("-DWITH_OPENJPH_ENCODER=ON" "-DWITH_RAV1E=ON" "-DWITH_SvtEnc=ON")
+    extra_config+=("-DWITH_RAV1E=ON" "-DWITH_SvtEnc=ON")
   fi
 
   # Keep "-DX265_API_IMPORTS" flag due to https://github.com/strukturag/libheif/issues/357
@@ -72,6 +72,7 @@ build() {
       -DWITH_JPEG_ENCODER=ON \
       -DWITH_OpenJPEG_DECODER=ON \
       -DWITH_OpenJPEG_ENCODER=ON \
+      -DWITH_OPENJPH_ENCODER=ON \
       -DX265_CFLAGS="-DX265_API_IMPORTS" \
       ../${_realname}-${pkgver}
 


### PR DESCRIPTION
For parity. It's been available since it became a hard dependency for openexr.