### PR TITLE
sirocco: add version 2.1.1 (new package)

### DIFF
--- a/mingw-w64-sirocco/PKGBUILD
+++ b/mingw-w64-sirocco/PKGBUILD
@@ -1,0 +1,54 @@
+# Maintainer: Dirk Stolle
+
+_realname=sirocco
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=2.1.1
+pkgrel=1
+pkgdesc="C++ library that allows to compute piecewise linear approximations of the path followed by the root of a complex polynomial (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/miguelmarco/SIROCCO2'
+msys2_references=(
+  'archlinux: sirocco'
+)
+license=('spdx:GPL-3.0-only')
+depends=("${MINGW_PACKAGE_PREFIX}-mpfr")
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/miguelmarco/SIROCCO2/archive/refs/tags/${pkgver}.tar.gz")
+sha256sums=('8fbcf3ba18846c802480c165772e1a853e13673b1cda25cee7b84847e1ad4e07')
+
+prepare() {
+  cd "SIROCCO2-${pkgver}"
+
+  autoreconf -fiv
+}
+
+build() {
+  mkdir -p "build-${MSYSTEM}" && cd "build-${MSYSTEM}"
+
+  ../"SIROCCO2-${pkgver}"/configure \
+    --prefix="${MINGW_PREFIX}" \
+    --build="${MINGW_CHOST}" \
+    --host="${MINGW_CHOST}" \
+    --target="${MINGW_CHOST}" \
+    --enable-static \
+    --enable-shared
+
+  make
+}
+
+check() {
+  cd "build-${MSYSTEM}"
+
+  make check
+}
+
+package() {
+  cd "build-${MSYSTEM}"
+
+  make install DESTDIR="${pkgdir}"
+
+  install -Dm644 "${srcdir}/SIROCCO2-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
sirocco is required to build passagemath-sirocco, one of the packages of passagemath (<https://github.com/msys2/MINGW-packages/issues/24738>).

sirocco is also available in some other distributions, for example:
* Arch Linux: https://archlinux.org/packages/extra/x86_64/sirocco/
* Alpine Linux (edge): https://pkgs.alpinelinux.org/package/edge/testing/x86_64/libsirocco
* openSUSE: https://build.opensuse.org/package/show/openSUSE:Factory/sirocco