### PR TITLE
python-pi-heif: add version 1.1.1 (new package)

### DIFF
--- a/mingw-w64-python-pi-heif/PKGBUILD
+++ b/mingw-w64-python-pi-heif/PKGBUILD
@@ -7,7 +7,7 @@ pkgver=1.1.1
 pkgrel=1
 pkgdesc="Python interface for libheif library - lightweight version without encoding (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64')
 url="https://github.com/bigcat88/pillow_heif"
 msys2_references=(
   'purl: pkg:pypi/pi-heif'


### PR DESCRIPTION
Based on https://github.com/msys2/MINGW-packages/pull/26475.