### PR TITLE
emacs: fix tree-sitter 0.26 compat patch

### DIFF
--- a/mingw-w64-emacs/006-tree-sitter-0.26.patch
+++ b/mingw-w64-emacs/006-tree-sitter-0.26.patch
@@ -1,93 +1,47 @@
-diff --git a/src/treesit.c b/src/treesit.c
-index bf982de580bd..69751b5ea106 100644
 --- a/src/treesit.c
 +++ b/src/treesit.c
-@@ -35,7 +35,11 @@ along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.  */
- # include "w32common.h"
- 
- /* In alphabetical order.  */
-+#if TREE_SITTER_LANGUAGE_VERSION >= 15
-+#undef ts_language_abi_version
-+#else
- #undef ts_language_version
-+#endif
- #undef ts_node_child
- #undef ts_node_child_by_field_name
- #undef ts_node_child_count
-@@ -90,7 +94,11 @@ along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.  */
+@@ -89,7 +89,7 @@
  #undef ts_tree_get_changed_ranges
  #undef ts_tree_root_node
- 
-+#if TREE_SITTER_LANGUAGE_VERSION >= 15
+
+-DEF_DLL_FN (uint32_t, ts_language_version, (const TSLanguage *));
 +DEF_DLL_FN (uint32_t, ts_language_abi_version, (const TSLanguage *));
-+#else
- DEF_DLL_FN (uint32_t, ts_language_version, (const TSLanguage *));
-+#endif
  DEF_DLL_FN (TSNode, ts_node_child, (TSNode, uint32_t));
  DEF_DLL_FN (TSNode, ts_node_child_by_field_name,
  	    (TSNode, const char *, uint32_t));
-@@ -167,7 +175,11 @@ init_treesit_functions (void)
+@@ -166,7 +166,7 @@
    if (!library)
      return false;
- 
-+#if TREE_SITTER_LANGUAGE_VERSION >= 15
+
+-  LOAD_DLL_FN (library, ts_language_version);
 +  LOAD_DLL_FN (library, ts_language_abi_version);
-+#else
-   LOAD_DLL_FN (library, ts_language_version);
-+#endif
    LOAD_DLL_FN (library, ts_node_child);
    LOAD_DLL_FN (library, ts_node_child_by_field_name);
    LOAD_DLL_FN (library, ts_node_child_count);
-@@ -225,7 +237,11 @@ init_treesit_functions (void)
+@@ -224,7 +224,7 @@
    return true;
  }
- 
-+#if TREE_SITTER_LANGUAGE_VERSION >= 15
+
+-#define ts_language_version fn_ts_language_version
 +#define ts_language_abi_version fn_ts_language_abi_version
-+#else
- #define ts_language_version fn_ts_language_version
-+#endif
  #define ts_node_child fn_ts_node_child
  #define ts_node_child_by_field_name fn_ts_node_child_by_field_name
  #define ts_node_child_count fn_ts_node_child_count
-@@ -711,6 +727,22 @@ treesit_load_language_push_for_each_suffix (Lisp_Object lib_base_name,
-     }
- }
- 
-+/* This function is a compatibility shim.  Tree-sitter 0.25 introduced
-+   ts_language_abi_version as a replacement for ts_language_version, and
-+   tree-sitter 0.26 removed ts_language_version.  Here we use the fact
-+   that 0.25 bumped TREE_SITTER_LANGUAGE_VERSION to 15, to use the new
-+   function instead of the old one, when Emacs is compiled against
-+   tree-sitter version 0.25 or newer.  */
-+static uint32_t
-+treesit_language_abi_version (const TSLanguage *ts_lang)
-+{
-+#if TREE_SITTER_LANGUAGE_VERSION >= 15
-+  return ts_language_abi_version (ts_lang);
-+#else
-+  return ts_language_version (ts_lang);
-+#endif
-+}
-+
- /* Load the dynamic library of LANGUAGE_SYMBOL and return the pointer
-    to the language definition.
- 
-@@ -746,7 +778,7 @@
+@@ -746,7 +746,7 @@
      {
        *signal_symbol = Qtreesit_load_language_error;
        *signal_data = list2 (Qversion_mismatch,
 -			    make_fixnum (ts_language_version (lang)));
-+               make_fixnum (ts_language_abi_version (lang)));
++			    make_fixnum (ts_language_abi_version (lang)));
        return NULL;
      }
    return lang;
-@@ -914,7 +946,7 @@ Return nil if a grammar library for LANGUAGE is not available.  */)
-       TSLanguage *ts_language = lang.lang;
+@@ -817,7 +817,7 @@
+ 						       &signal_data);
        if (ts_language == NULL)
  	return Qnil;
 -      uint32_t version =  ts_language_version (ts_language);
-+      uint32_t version =  treesit_language_abi_version (ts_language);
++      uint32_t version =  ts_language_abi_version (ts_language);
        return make_fixnum((ptrdiff_t) version);
      }
  }

--- a/mingw-w64-emacs/PKGBUILD
+++ b/mingw-w64-emacs/PKGBUILD
@@ -8,7 +8,7 @@ _realname=emacs
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=30.2
-pkgrel=7
+pkgrel=8
 pkgdesc="The extensible, customizable, self-documenting, real-time display editor (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -58,7 +58,7 @@ sha256sums=('b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9'
             'd128982d87af1e524ae809147613168153f0e5c1efb0ef633793df47b762c9e1'
             '1fcba307b278a7794ecca4f09e7ce1a715b4ee255badd3fa376ca1ef1aa7246f'
             'b91e8a63f6afef93fad119f5b4b5bca132bb7f5564df6f26d085dcfa9e28c64c'
-            '347865464b588212d77851741f2675efa852a9d5ba0d2922e23231ebaa1f2985'
+            'b10fba0dc6f5e353e9401d315181c4e289b69132b18532a4bf614edab6bff352'
             'bfe64602dbeeec85799c1156ca4f3837fdac42a076e83a4221768db3417220e1')
 validpgpkeys=('28D3BED851FDF3AB57FEF93C233587A47C207910'
               '17E90D521672C04631B1183EE78DAE0F3115E06B'


### PR DESCRIPTION
Just borrow the CI, I'll tell if it really works.

ref: https://github.com/d12frosted/homebrew-emacs-plus/blob/master/patches/emacs-30/treesit-compatibility.patch