### PR TITLE
python-imagecodecs: enable htj2k and meshopt

### DIFF
--- a/mingw-w64-python-imagecodecs/PKGBUILD
+++ b/mingw-w64-python-imagecodecs/PKGBUILD
@@ -4,7 +4,7 @@ _realname=imagecodecs
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=2026.1.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Image transformation, compression, and decompression codecs (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -46,13 +46,18 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
-        "0001-deflate.patch")
+        "0001-deflate.patch"
+        "https://github.com/cgohlke/imagecodecs/pull/135.patch")
 sha256sums=('1bf7fd913bfcc33d72b788aa2ccdcfae163beb04eb380dec9c8d05bcee956caa'
-            '51e7f4d58ef17d230bf9755832902982b4c228c153d30c65749d2312c3bbf281')
+            '51e7f4d58ef17d230bf9755832902982b4c228c153d30c65749d2312c3bbf281'
+            '7d216162e16ece89a54f374cf47f6d5870109c40dcabafa92d1a32cc2ee2cc7a')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   patch -p1 -i "${srcdir}"/0001-deflate.patch
+
+  # https://github.com/cgohlke/imagecodecs/pull/135
+  patch -p1 -i "${srcdir}"/135.patch
 }
 
 build() {


### PR DESCRIPTION
x-ref https://github.com/cgohlke/imagecodecs/pull/135