### PR TITLE
m4rie: add version 20250128 (new package)

### DIFF
--- a/mingw-w64-m4rie/PKGBUILD
+++ b/mingw-w64-m4rie/PKGBUILD
@@ -1,0 +1,55 @@
+# Maintainer: Dirk Stolle
+
+_realname=m4rie
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=20250128
+pkgrel=1
+pkgdesc="Algorithms for linear algebra over GF(2^e) for 2 <= e <= 16 (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/malb/m4rie'
+msys2_references=(
+  'archlinux: m4rie'
+  'gentoo: sci-libs/m4rie'
+)
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-m4ri")
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+source=("https://github.com/malb/m4rie/releases/download/${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('96f1adafd50e6a0b51dc3aa1cb56cb6c1361ae7c10d97dc35c3fa70822a55bd7')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+
+  autoreconf -fiv
+}
+
+build() {
+  mkdir -p "build-${MSYSTEM}" && cd "build-${MSYSTEM}"
+
+  ../"${_realname}-${pkgver}"/configure \
+    --prefix="${MINGW_PREFIX}" \
+    --build="${MINGW_CHOST}" \
+    --host="${MINGW_CHOST}" \
+    --target="${MINGW_CHOST}" \
+    --enable-static \
+    --enable-shared
+
+  make
+}
+
+check() {
+  cd "build-${MSYSTEM}"
+
+  make check
+}
+
+package() {
+  cd "build-${MSYSTEM}"
+
+  make install DESTDIR="${pkgdir}"
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
m4rie is required to build some of the packages of passagemath (<https://github.com/msys2/MINGW-packages/issues/24738>), so let's package it.

m4rie is also available in several other distributions, for example:
* Arch Linux: https://archlinux.org/packages/extra/x86_64/m4rie/
* Debian: https://packages.debian.org/source/trixie/libm4rie
* Gentoo: https://packages.gentoo.org/packages/sci-libs/m4rie
* Fedora: https://packages.fedoraproject.org/pkgs/m4rie/