### PR TITLE
iml: add version 1.0.5 (new package)

### DIFF
--- a/mingw-w64-iml/PKGBUILD
+++ b/mingw-w64-iml/PKGBUILD
@@ -1,0 +1,60 @@
+# Maintainer: Dirk Stolle
+
+_realname=iml
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.0.5
+pkgrel=1
+pkgdesc="Integer Matrix Library (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://cs.uwaterloo.ca/~astorjoh/iml.html'
+msys2_references=(
+  'anitya: 7660'
+  'archlinux: iml'
+  'gentoo: sci-libs/iml'
+)
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-cblas"
+         "${MINGW_PACKAGE_PREFIX}-gmp")
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+source=("https://cs.uwaterloo.ca/~astorjoh/${_realname}-${pkgver}.tar.bz2")
+sha256sums=('1dad666850895a5709b00b97422e2273f293cfadea7697a9f90b90953e847c2a')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+
+  autoreconf -fiv
+}
+
+build() {
+  mkdir -p "build-${MSYSTEM}" && cd "build-${MSYSTEM}"
+
+  ../"${_realname}-${pkgver}"/configure \
+    --prefix="${MINGW_PREFIX}" \
+    --build="${MINGW_CHOST}" \
+    --host="${MINGW_CHOST}" \
+    --target="${MINGW_CHOST}" \
+    --with-cblas=-lcblas \
+    --with-gmp-include="${MINGW_PREFIX}/include" \
+    --with-gmp-lib="${MINGW_PREFIX}/bin ${MINGW_PREFIX}/lib" \
+    --enable-static \
+    --enable-shared
+
+  make
+}
+
+check() {
+  cd "build-${MSYSTEM}"
+
+  make check
+}
+
+package() {
+  cd "build-${MSYSTEM}"
+
+  make install DESTDIR="${pkgdir}"
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
IML (https://cs.uwaterloo.ca/~astorjoh/iml.html) is a library "which implements algorithms for computing exact solutions to dense systems of linear equations over the integers". It's also required to build some of the packages of passagemath (<https://github.com/msys2/MINGW-packages/issues/24738>), and that's why I'm packaging it here.

IML is also available in several other distributions, for example:
* Arch Linux: https://archlinux.org/packages/extra/x86_64/iml/
* Debian: https://packages.debian.org/trixie/source/iml
* Gentoo: https://packages.gentoo.org/packages/sci-libs/iml
* Fedora: https://packages.fedoraproject.org/pkgs/iml/