### PR TITLE
libbraiding: add version 1.3.1 (new package)

### DIFF
--- a/mingw-w64-libbraiding/PKGBUILD
+++ b/mingw-w64-libbraiding/PKGBUILD
@@ -1,0 +1,60 @@
+# Maintainer: Dirk Stolle
+
+_realname=libbraiding
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.3.1
+pkgrel=1
+pkgdesc="library to compute several properties of braids, including centralizer and conjugacy check (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/miguelmarco/libbraiding'
+msys2_references=(
+  'archlinux: libbraiding'
+  'gentoo: sci-libs/libbraiding'
+)
+license=('spdx:GPL-3.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-cc-libs")
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+source=("https://github.com/miguelmarco/libbraiding/releases/download/${pkgver}/${_realname}-${pkgver}.tar.gz"
+        "https://github.com/miguelmarco/libbraiding/raw/refs/tags/${pkgver}/LICENSE")
+sha256sums=('d1738c3ad64a90ca0ad968d2e3c9069b0de08abcf37fb44a151a229d88203950'
+            '8ceb4b9ee5adedde47b31e975c1d90c73ad27b6b165a1dcd80c7c545eb65b903')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+
+  autoreconf -vi
+}
+
+build() {
+  mkdir -p "build-${MSYSTEM}" && cd "build-${MSYSTEM}"
+
+  ../"${_realname}-${pkgver}"/configure \
+    --prefix="${MINGW_PREFIX}" \
+    --build="${MINGW_CHOST}" \
+    --host="${MINGW_CHOST}" \
+    --target="${MINGW_CHOST}" \
+    --enable-static \
+    --enable-shared
+
+  sed -i 's|allow_undefined=yes|allow_undefined=no|g' libtool
+  # sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool
+
+  make
+}
+
+check() {
+  cd "build-${MSYSTEM}"
+
+  make check
+}
+
+package() {
+  cd "build-${MSYSTEM}"
+
+  make install DESTDIR="${pkgdir}"
+
+  install -Dm644 "${srcdir}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
libbraiding (https://github.com/miguelmarco/libbraiding) is a C++ library for computations on braid groups.
(It's also required to build some of the packages of passagemath (https://github.com/msys2/MINGW-packages/issues/24738), and that's why I'm packaging it here.)

libbraiding is also available in several other distributions, for example:
* Arch Linux: https://archlinux.org/packages/extra/x86_64/libbraiding/
* Debian: https://packages.debian.org/trixie/source/libbraiding
* Gentoo: https://packages.gentoo.org/packages/sci-libs/libbraiding
* Fedora: https://packages.fedoraproject.org/pkgs/libbraiding/
