### PR TITLE
passagemath-libbraiding: add version 10.6.43 (new package)

### DIFF
--- a/mingw-w64-passagemath-libbraiding/PKGBUILD
+++ b/mingw-w64-passagemath-libbraiding/PKGBUILD
@@ -1,0 +1,56 @@
+# Maintainer: Dirk Stolle
+
+_realname=passagemath-libbraiding
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+# Note: Adjust dependencies when updating to 10.6.44 or newer. See comment below.
+pkgver=10.6.43
+pkgrel=1
+pkgdesc="passagemath: Braid computations with libbraiding (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/passagemath/passagemath'
+msys2_references=(
+  'purl: pkg:pypi/passagemath-libbraiding'
+)
+license=('spdx:GPL-2.0-or-later')
+# Some of the dependencies can be removed in the next versions (likely 10.6.44), because they are
+# no longer required. See <https://github.com/passagemath/passagemath/pull/1935> for details.
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-iml"
+         "${MINGW_PACKAGE_PREFIX}-libbraiding"
+         "${MINGW_PACKAGE_PREFIX}-m4rie"
+         "${MINGW_PACKAGE_PREFIX}-mpc"
+         "${MINGW_PACKAGE_PREFIX}-mpfr"
+         "${MINGW_PACKAGE_PREFIX}-python-cysignals"
+         "${MINGW_PACKAGE_PREFIX}-python-memory-allocator"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-objects"
+)
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cython"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-categories"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-environment"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-setup"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-python-pkgconfig"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
+sha256sums=('b4b7425e098b6dfd04375b54e557e47f581bdb63439030c0b206826be008df67')
+
+build() {
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+}


### PR DESCRIPTION
This PR adds python-passagemath-libbraiding, a package to provide some functionality from passagemath (https://github.com/msys2/MINGW-packages/issues/24738).

Now that libbraiding (<https://github.com/msys2/MINGW-packages/pull/27174>) is available, that package can be built, too.
The list of dependencies for passagemath-libbraiding has been reduced in a recent pull request (<https://github.com/passagemath/passagemath/pull/1935>), but it's not yet part of the release. However, since that PR also removed the dependency for linbox - which is not yet packaged in MSYS2 - this package should basically "work".