### PR TITLE
ppl: add version 1.2 (new package)

### DIFF
--- a/mingw-w64-ppl/0001-make-test-immune-from-LTO.patch
+++ b/mingw-w64-ppl/0001-make-test-immune-from-LTO.patch
@@ -1,0 +1,26 @@
+From d7cd42677f9c59590127badb4c0972df5a65f6bc Mon Sep 17 00:00:00 2001
+From: Roberto Bagnara <roberto.bagnara@bugseng.com>
+Date: Sun, 9 Aug 2020 08:08:05 +0200
+Subject: [PATCH] Make test immune from LTO.
+
+---
+ m4/ac_check_fpu_control.m4 | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/m4/ac_check_fpu_control.m4 b/m4/ac_check_fpu_control.m4
+index 707dc7981..b69fa802d 100644
+--- a/m4/ac_check_fpu_control.m4
++++ b/m4/ac_check_fpu_control.m4
+@@ -49,9 +49,9 @@ main() {
+ 
+ #else
+ 
+-     float  nf1 =  -3, pf1 = 3,  f2 =  5;
+-     double nd1 =  -7, pd1 = 7,  d2 = 11;
+-long double nl1 = -13, pl1 = 13, l2 = 17;
++     volatile float  nf1 =  -3, pf1 = 3,  f2 =  5;
++     volatile double nd1 =  -7, pd1 = 7,  d2 = 11;
++volatile long double nl1 = -13, pl1 = 13, l2 = 17;
+ 
+       float nf[2], pf[2];
+      double nd[2], pd[2];

--- a/mingw-w64-ppl/PKGBUILD
+++ b/mingw-w64-ppl/PKGBUILD
@@ -1,0 +1,79 @@
+# Maintainer: Dirk Stolle
+
+_realname=ppl
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.2
+pkgrel=1
+pkgdesc="Parma Polyhedra Library - convex polyhedra + numerical abstractions (mingw-w64)"
+arch=('any')
+# Builds for clang64 and clangarm64 currently fail, see the build logs of the
+# pull request <https://github.com/msys2/MINGW-packages/pull/27197>. Until that
+# is fixed, the package is not built for clang-based environments.
+mingw_arch=('mingw64' 'ucrt64')
+url='https://bugseng.com/products/ppl'
+msys2_documentation_url='https://support.bugseng.com/ppl/'
+msys2_repository_url='https://github.com/BUGSENG/PPL'
+msys2_references=(
+  'anitya: 17287'
+  'archlinux: ppl'
+  'gentoo: dev-libs/ppl'
+)
+license=('spdx:GPL-3.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
+         "${MINGW_PACKAGE_PREFIX}-glpk"
+         "${MINGW_PACKAGE_PREFIX}-gmp")
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+# Documentation, including HTML and PDF variants, is ca. 1520 files, while the whole package with
+# documentation is ca. 1560 files. Therefore, documentation is disabled. Maybe it should be split
+# into a separate docs package.
+options=(!docs)
+source=("https://support.bugseng.com/ppl/download/ftp/releases/${pkgver}/ppl-${pkgver}.tar.gz"
+        "0001-make-test-immune-from-LTO.patch"
+)
+sha256sums=('6bc36dd4a87abc429d8f9c00c53e334e5041a9b0857cfc00dbad6ef14294aac8'
+            '1703c76fac3375652b0f7aaa64c825eb9cf7aac6264ddc045e1ddbee8f96cd39')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+
+  # Fix configure check broken by LTO (Fedora).
+  # See <https://github.com/BUGSENG/PPL/commit/d7cd42677f9c59590127badb4c0972df5a65f6bc>.
+  patch -Np1 -i "${srcdir}/0001-make-test-immune-from-LTO.patch"
+
+  # Fix detection of C++11 features (Fedora)
+  sed -i 's,== 201103L,>= 201103L,g' m4/ac_check_cxx11.m4
+}
+
+build() {
+  mkdir -p "build-${MSYSTEM}" && cd "build-${MSYSTEM}"
+
+  ../"${_realname}-${pkgver}"/configure \
+    --prefix="${MINGW_PREFIX}" \
+    --build="${MINGW_CHOST}" \
+    --host="${MINGW_CHOST}" \
+    --target="${MINGW_CHOST}" \
+    --enable-interfaces="c,cxx" \
+    --enable-static \
+    --enable-shared
+
+  # Note: ppl has a few more interfaces, e.g. for Java and for several Prolog variants. However,
+  # these are not used so we do not build them.
+
+  make
+}
+
+check() {
+  cd "build-${MSYSTEM}"
+
+  make check || echo "Some tests failed."
+}
+
+package() {
+  cd "build-${MSYSTEM}"
+
+  make install DESTDIR="${pkgdir}"
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
_(This is the same pull request as <https://github.com/msys2/MINGW-packages/pull/27197>, but without builds for the Clang-based environments. They can be added later when the problems with Clang are fixed.)_

---

This PR adds the Parma Polyhedra Library (PPL) (https://bugseng.com/products/ppl), a library which "provides numerical abstractions especially targeted at applications in the field of analysis and verification of complex systems."
It's required as an indirect dependency of passagemath-polyhedra (https://github.com/msys2/MINGW-packages/pull/27201) via passagemath-ppl (https://github.com/msys2/MINGW-packages/pull/27200).

PPL is also available in several other distributions, for example:
* Arch Linux: https://archlinux.org/packages/extra/x86_64/ppl/
* Debian: https://packages.debian.org/trixie/source/ppl
* Fedora: https://packages.fedoraproject.org/pkgs/ppl/
* Gentoo: https://packages.gentoo.org/packages/dev-libs/ppl