### PR TITLE
python-passagemath-ppl: add version 0.8.10.2 (new package)

### DIFF
--- a/mingw-w64-passagemath-ppl/PKGBUILD
+++ b/mingw-w64-passagemath-ppl/PKGBUILD
@@ -1,0 +1,63 @@
+# Maintainer: Dirk Stolle
+
+_realname=passagemath-ppl
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=0.8.10.2
+pkgrel=1
+pkgdesc="Python wrapper to the C++ Parma Polyhedra Library, PPL, pplpy fork (mingw-w64)"
+arch=('any')
+# No clang64 and clagarm64, because the PPL is currently only packaged for the
+# GCC-based environments.
+mingw_arch=('mingw64' 'ucrt64')
+url='https://github.com/passagemath/passagemath-ppl'
+msys2_references=(
+  'archlinux: python-pplpy'
+  'gentoo: dev-python/pplpy'
+  'purl: pkg:pypi/passagemath-ppl'
+)
+license=('spdx:GPL-3.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-gmp"
+         "${MINGW_PACKAGE_PREFIX}-ppl"
+         "${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-cysignals"
+         "${MINGW_PACKAGE_PREFIX}-python-gmpy2")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cython"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python-sphinx")
+# passagemath-ppl is a fork of the pplpy package, the original Python wrapper
+# for PPL. So it conflicts with any potential pplpy package, but according to
+# the documentation it should also be compatible to it. So we do the trinity of
+# conflicts, replaces, and provides here for pplpy.
+conflicts=("${MINGW_PACKAGE_PREFIX}-python-pplpy")
+replaces=("${MINGW_PACKAGE_PREFIX}-python-pplpy")
+provides=("${MINGW_PACKAGE_PREFIX}-python-pplpy")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
+sha256sums=('ceadbb1855a0c740f2335692f667a6a9e1db20af4a700fda82de85d8ad38d775')
+
+build() {
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+
+  _python_path=$(find "$PWD" -type d -name 'lib.*cpython*')
+  PYTHONPATH="${_python_path}" make -C docs html
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/share/doc/pplpy"
+  cp -r docs/build/html/* "${pkgdir}${MINGW_PREFIX}/share/doc/pplpy"
+
+  install -Dm644 LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}


### PR DESCRIPTION
This PR adds python-passagemath-ppl, a package to provide some functionality from passagemath (https://github.com/msys2/MINGW-packages/issues/24738).