### PR TITLE
python-passagemath-polyhedra: add version 10.6.43 (new package)

### DIFF
--- a/mingw-w64-passagemath-polyhedra/PKGBUILD
+++ b/mingw-w64-passagemath-polyhedra/PKGBUILD
@@ -1,0 +1,57 @@
+# Maintainer: Dirk Stolle
+
+_realname=passagemath-polyhedra
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=10.6.43
+pkgrel=1
+pkgdesc="passagemath: Convex polyhedra in arbitrary dimension, mixed integer linear optimization (mingw-w64)"
+arch=('any')
+# Only mingw64 and ucrt, because ppl (+ passagemath-ppl) fails to build on clang.
+mingw_arch=('mingw64' 'ucrt64') # 'clang64' 'clangarm64'
+url='https://github.com/passagemath/passagemath'
+msys2_references=(
+  'purl: pkg:pypi/passagemath-polyhedra'
+)
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-cysignals"
+         "${MINGW_PACKAGE_PREFIX}-python-gmpy2"
+         "${MINGW_PACKAGE_PREFIX}-python-memory-allocator"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-environment"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-glpk"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-modules"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-ppl"
+)
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cython"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-python-pkgconfig"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-setup"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+# There are more potential optional dependencies, but they are not packaged yet.
+optdepends=("${MINGW_PACKAGE_PREFIX}-python-cvxopt"
+            "${MINGW_PACKAGE_PREFIX}-python-passagemath-cddlib"
+            "${MINGW_PACKAGE_PREFIX}-python-passagemath-flint"
+            "${MINGW_PACKAGE_PREFIX}-python-passagemath-graphs"
+            "${MINGW_PACKAGE_PREFIX}-python-passagemath-plot")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
+sha256sums=('0376cff7a0f5b80cea0bb7ff6ee3303b691816287b3d2eb708496acf00e572b0')
+
+build() {
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+}


### PR DESCRIPTION
This PR adds python-passagemath-polyhedra, a package to provide some functionality from passagemath (https://github.com/msys2/MINGW-packages/issues/24738).


Only for UCRT64 + MINGW64 for now, because ppl (https://github.com/msys2/MINGW-packages/pull/27197 / https://github.com/msys2/MINGW-packages/pull/27199) fails to build with clang at the moment. As a result, the direct dependency passagemath-ppl (https://github.com/msys2/MINGW-packages/pull/27200) is also not available on clang-based environments.