### PR TITLE
pixi: add new version 0.62.2 (new package)

### DIFF
--- a/mingw-w64-pixi/0001-fix-msvc-style-flags.patch
+++ b/mingw-w64-pixi/0001-fix-msvc-style-flags.patch
@@ -1,0 +1,11 @@
+--- a/.cargo/config.toml
++++ b/.cargo/config.toml
+@@ -5,7 +5,7 @@ linker = "rust-lld"
+ [target.'cfg(all(target_env = "msvc", target_os = "windows"))']
+ rustflags = ["-C", "target-feature=+crt-static"]
+ 
+-[target.'cfg(all(windows, debug_assertions))']
++[target.'cfg(all(target_env = "msvc", target_os = "windows", debug_assertions))']
+ rustflags = [
+   # increase the stack size to prevent overflowing the stack in debug
+   "-C",

--- a/mingw-w64-pixi/0002-skip-invalid-tests.patch
+++ b/mingw-w64-pixi/0002-skip-invalid-tests.patch
@@ -1,0 +1,13 @@
+Should be removed after https://github.com/prefix-dev/pixi/pull/5179 is merged into the next release.
+diff --git a/crates/pixi/tests/integration_rust/build_tests.rs b/crates/pixi/tests/integration_rust/build_tests.rs
+index 1f49d9131..a69e95cf8 100644
+--- a/crates/pixi/tests/integration_rust/build_tests.rs
++++ b/crates/pixi/tests/integration_rust/build_tests.rs
+@@ -548,6 +548,7 @@ backend.version = "0.1.0"
+ /// Test that demonstrates using PassthroughBackend with PixiControl
+ /// to test build operations without requiring actual backend processes.
+ #[tokio::test]
++#[ignore]
+ async fn test_different_variants_have_different_caches() {
+     setup_tracing();
+ 

--- a/mingw-w64-pixi/0003-skip-git-related-tests.patch
+++ b/mingw-w64-pixi/0003-skip-git-related-tests.patch
@@ -1,0 +1,62 @@
+These tests cannot work with msys2 git as it cannot handle `file:///C:/path/to/repo` style URLs.
+Ignore them until mingw-w64-git is available.
+--- a/crates/pixi/tests/integration_rust/add_tests.rs
++++ b/crates/pixi/tests/integration_rust/add_tests.rs
+@@ -256,6 +256,7 @@ async fn add_functionality_os() {
+ 
+ /// Test the `pixi add --pypi` functionality (using local mocks)
+ #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
++#[cfg(not(windows))]
+ async fn add_pypi_functionality() {
+     use crate::common::pypi_index::{Database as PyPIDatabase, PyPIPackage};
+ 
+@@ -779,6 +780,7 @@ async fn add_dependency_pinning_strategy() {
+ 
+ /// Test adding a git dependency with a specific branch (using local fixture)
+ #[tokio::test]
++#[cfg(not(windows))]
+ async fn add_git_deps() {
+     setup_tracing();
+ 
+@@ -889,6 +891,7 @@ preview = ['pixi-build']
+ 
+ /// Test adding a git dependency with a specific commit (using local fixture)
+ #[tokio::test]
++#[cfg(not(windows))]
+ async fn add_git_with_specific_commit() {
+     setup_tracing();
+ 
+@@ -945,6 +948,7 @@ preview = ['pixi-build']"#,
+ 
+ /// Test adding a git dependency with a specific tag (using local fixture)
+ #[tokio::test]
++#[cfg(not(windows))]
+ async fn add_git_with_tag() {
+     setup_tracing();
+ 
+--- a/crates/pixi/tests/integration_rust/update_tests.rs
++++ b/crates/pixi/tests/integration_rust/update_tests.rs
+@@ -158,6 +158,7 @@ async fn test_update_single_package() {
+ }
+ 
+ #[tokio::test]
++#[cfg(not(windows))]
+ async fn test_update_conda_package_doesnt_update_git_pypi() {
+     setup_tracing();
+ 
+@@ -258,6 +259,7 @@ async fn test_update_conda_package_doesnt_update_git_pypi() {
+ }
+ 
+ #[tokio::test]
++#[cfg(not(windows))]
+ async fn test_update_conda_package_doesnt_update_git_pypi_pinned() {
+     setup_tracing();
+ 
+@@ -321,6 +323,7 @@ async fn test_update_conda_package_doesnt_update_git_pypi_pinned() {
+ }
+ 
+ #[tokio::test]
++#[cfg(not(windows))]
+ async fn test_update_git_pypi_when_requested() {
+     setup_tracing();
+ 

--- a/mingw-w64-pixi/PKGBUILD
+++ b/mingw-w64-pixi/PKGBUILD
@@ -1,0 +1,65 @@
+# Contributor: dragon-archer <dragon-archer@outlook.com>
+
+_realname=pixi
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.62.2
+pkgrel=1
+pkgdesc='A fast, modern, and reproducible package management tool for developers of all backgrounds. (mingw-w64)'
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64')
+url='https://pixi.sh/'
+msys2_repository_url="https://github.com/prefix-dev/pixi/"
+license=('spdx:BSD-3-Clause')
+makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
+             'git')
+options=('!strip')
+source=("${msys2_repository_url}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
+        "0001-fix-msvc-style-flags.patch"
+        "0002-skip-invalid-tests.patch"
+        "0003-skip-git-related-tests.patch")
+sha256sums=('dba8db9c836a3bf3c6054588f4334150fe3bb7b4960c778e76f4001a18fa8e2f'
+            '4a8eda460377088600df73440675e7aeea49a4c45936dc046a981575c2a0119b'
+            '382e332b712b5565bbb607c6421fbea230d917252d6154ecdf51d56b77e61eb8'
+            '390625bfececb5f18da61efaf11a3b8b4dc322f42b2f0413d0ff917333449b9e')
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+
+  apply_patch_with_msg \
+    0001-fix-msvc-style-flags.patch \
+    0002-skip-invalid-tests.patch \
+    0003-skip-git-related-tests.patch
+
+  ${MINGW_PREFIX}/bin/cargo fetch \
+    --locked \
+    --config='net.git-fetch-with-cli=true' \
+    --target "${RUST_CHOST}"
+}
+
+build() {
+  cd "${_realname}-${pkgver}"
+
+  ${MINGW_PREFIX}/bin/cargo build --frozen --profile dist
+}
+
+check() {
+  cd "${_realname}-${pkgver}"
+
+  ${MINGW_PREFIX}/bin/cargo test --frozen --profile dist
+}
+
+package() {
+  cd "${_realname}-${pkgver}"
+
+  install -Dt "${pkgdir}${MINGW_PREFIX}/bin" target/dist/${_realname}
+  install -Dm644 LICENSE -t "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
+}


### PR DESCRIPTION
Fix #22501

Disabled some git related tests, as they use urls like `file:///C:/path/`, which will be interpreted as `/C:/path` by msys2 git. Works fine with Git for Windows.

CLANGARM64 seemes to fail a test, disable it for now