### PR TITLE
update to PDCursesMod 4.5.4

### DIFF
--- a/mingw-w64-pdcurses/PKGBUILD
+++ b/mingw-w64-pdcurses/PKGBUILD
@@ -8,7 +8,7 @@ provides=("${MINGW_PACKAGE_PREFIX}-curses")
 # No replace or conflict as the installed names are different
 #replaces=("${MINGW_PACKAGE_PREFIX}-ncurses" "${MINGW_PACKAGE_PREFIX}-termcap")
 #conflicts=("${MINGW_PACKAGE_PREFIX}-ncurses" "${MINGW_PACKAGE_PREFIX}-termcap")
-pkgver=4.5.3
+pkgver=4.5.4
 pkgrel=1
 pkgdesc="Curses library on the Win32 API (mingw-w64)"
 # ports that are available with this package
@@ -21,7 +21,7 @@ license=('Public Domain')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
 changelog=${_realname}.changelog
 source=("https://github.com/Bill-Gray/PDCursesMod/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('5be1c4a1ba42c958deb219e6fe45fd3315444bc47cfe0c89f5ac0d8c00cc5930')
+sha256sums=('d5efc7f2b7107abe382bdf8bac0a9bfd8e716facbca2bb9cf12dfeb8e1122c4b')
 
 #prepare() {
 #  cd PDCursesMod-${pkgver}

--- a/mingw-w64-pdcurses/pdcurses.changelog
+++ b/mingw-w64-pdcurses/pdcurses.changelog
@@ -1,11 +1,34 @@
-This is a redacted changelog for parts related to MSYS2.
+This is a redacted changelog for parts related to published MSYS2 packages.
 
 For the full list, especially ports not included in MSYS or other operating 
 systems see its [docs/HISTORY.md][1], and/or the [Git log][2] for extreme
 detail.
 
-[1]: https://github.com/Bill-Gray/PDCursesMod/blob/v4.5.3/docs/HISTORY.md
+[1]: https://github.com/Bill-Gray/PDCursesMod/blob/v4.5.4/docs/HISTORY.md
 [2]: https://github.com/Bill-Gray/PDCursesMod/commits/
+
+PDCursesMod 4.5.4 - 2026 Jan 07
+================================
+
+Minor new features
+------------------
+
+- Blinking and PDC_gotoyx() code is almost identical between several ports,
+  including WinGUI. This allows the cursor to blink in all of those ports and
+  (in some cases) for the caret and hollow-box cursor styles to be supported.
+
+Bug fixes
+---------
+
+- WinGUI : mouse modifiers (Ctr, Alt, Shift) became 'stuck' from the previous keys
+  hit, and were not turned off when the modifier keys in question were released.
+  
+- WinGUI : positions returned for mouse wheel events were wrong.
+
+- WinCon : a typo prevented mouse wheel events from working at all.
+
+- Fullwidth characters are now shown correctly for 32-bit chtypes (if the font
+  actually has glyphs for them).
 
 
 PDCursesMod 4.5.3 - 2025 Aug 11
@@ -43,7 +66,6 @@ Bug fixes
   objects,  resulting in warnings/errors when built to that standard.
 
 
-
 PDCursesMod 4.5.1- 2025 May 12
 =============================
 
@@ -78,6 +100,7 @@ Bug fixes
   triple-clicks has been abstracted into `common/mouse.c`,  and is now used
   by the WinCon,  WinGUI,  x11new,  and VT platforms (and will probably be
   used eventually by most other platforms).
+
 
 PDCursesMod 4.5.0 - 2024 Dec 31
 =================================


### PR DESCRIPTION
PDCursesMod 4.5.4 - 2026 Jan 07
================================

Minor new features
------------------

- Blinking and PDC_gotoyx() code is almost identical between several ports,
  including WinGUI. This allows the cursor to blink in all of those ports and
  (in some cases) for the caret and hollow-box cursor styles to be supported.

Bug fixes
---------

- WinGUI : mouse modifiers (Ctr, Alt, Shift) became 'stuck' from the previous keys
  hit, and were not turned off when the modifier keys in question were released.

- WinGUI : positions returned for mouse wheel events were wrong.

- WinCon : a typo prevented mouse wheel events from working at all.

- Fullwidth characters are now shown correctly for 32-bit chtypes (if the font
  actually has glyphs for them).