### PR TITLE
python-installer: Fix filename of resource object file

### DIFF
--- a/mingw-w64-python-installer/PKGBUILD
+++ b/mingw-w64-python-installer/PKGBUILD
@@ -4,7 +4,7 @@ _realname=installer
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=0.7.0
-pkgrel=6
+pkgrel=7
 pkgdesc="A low-level library for installing from a Python wheel distribution (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -53,7 +53,7 @@ prepare() {
 
 build() {
   cd "${srcdir}/simple_launcher"
-  windres --input launcher.rc --output resources.res --output-format=coff
+  windres --input launcher.rc --output resources.o --output-format=coff
 
   local _gui_cflags="$CFLAGS $CPPFLAGS -mwindows"
   local _cli_cflags="$CFLAGS $CPPFLAGS -D_CONSOLE"
@@ -62,16 +62,16 @@ build() {
 
   case "${MINGW_CHOST}" in
   i686-w64-mingw32)
-    cc $_cli_cflags -o t32.exe launcher.c resources.res $_cli_lflags
-    cc $_gui_cflags -o w32.exe launcher.c resources.res $_gui_lflags
+    cc $_cli_cflags -o t32.exe launcher.c resources.o $_cli_lflags
+    cc $_gui_cflags -o w32.exe launcher.c resources.o $_gui_lflags
     ;;
   x86_64-w64-mingw32)
-    cc $_cli_cflags -o t64.exe launcher.c resources.res $_cli_lflags
-    cc $_gui_cflags -o w64.exe launcher.c resources.res $_gui_lflags
+    cc $_cli_cflags -o t64.exe launcher.c resources.o $_cli_lflags
+    cc $_gui_cflags -o w64.exe launcher.c resources.o $_gui_lflags
     ;;
   aarch64-w64-mingw32)
-    cc $_cli_cflags -o t64-arm.exe launcher.c resources.res $_cli_lflags
-    cc $_gui_cflags -o w64-arm.exe launcher.c resources.res $_gui_lflags
+    cc $_cli_cflags -o t64-arm.exe launcher.c resources.o $_cli_lflags
+    cc $_gui_cflags -o w64-arm.exe launcher.c resources.o $_gui_lflags
     ;;
   *)
     echo "Unsupported CHOST ${MINGW_CHOST}" && false


### PR DESCRIPTION
It's a COFF object file so should have an extension of `.o`. GCC 16 will pass `.res` files to windres which will cause an error in the future.