### PR TITLE
keystone: set CMake policy version to fix build with newer CMake

### DIFF
--- a/mingw-w64-keystone/0004-modern-cmake-fix.patch
+++ b/mingw-w64-keystone/0004-modern-cmake-fix.patch
@@ -1,0 +1,93 @@
+From f3f792cc05080a4bcc3c2886c0c7cee9294c4a05 Mon Sep 17 00:00:00 2001
+From: Jordan Moore <lockbox@struct.foo>
+Date: Mon, 2 Jun 2025 16:58:31 -0400
+Subject: [PATCH] fix: build with modern cmake
+
+---
+ CMakeLists.txt        | 19 +------------------
+ kstool/CMakeLists.txt |  2 +-
+ llvm/CMakeLists.txt   | 15 +--------------
+ 3 files changed, 3 insertions(+), 33 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 938d4983..9ce08362 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ # Keystone Assembler Engine (www.keystone-engine.org)
+ # By Nguyen Anh Quynh, 2016
+ 
+-cmake_minimum_required(VERSION 2.8.7)
++cmake_minimum_required(VERSION 3.10.0)
+ project(keystone)
+ 
+ set(KEYSTONE_VERSION_MAJOR 0)
+@@ -15,23 +15,6 @@ if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+   set(CMAKE_BUILD_TYPE "Debug")
+ endif()
+ 
+-if (POLICY CMP0022)
+-  cmake_policy(SET CMP0022 NEW) # automatic when 2.8.12 is required
+-endif()
+-
+-if (POLICY CMP0051)
+-  # CMake 3.1 and higher include generator expressions of the form
+-  # $<TARGETLIB:obj> in the SOURCES property.  These need to be
+-  # stripped everywhere that access the SOURCES property, so we just
+-  # defer to the OLD behavior of not including generator expressions
+-  # in the output for now.
+-  cmake_policy(SET CMP0051 OLD)
+-endif()
+-
+-if (POLICY CMP0063)
+-  set(CMAKE_POLICY_DEFAULT_CMP0063 NEW) # automatic when 3.3.2 is required
+-endif()
+-
+ if (CMAKE_VERSION VERSION_LESS 3.1.20141117)
+   set(cmake_3_2_USES_TERMINAL)
+ else()
+diff --git a/kstool/CMakeLists.txt b/kstool/CMakeLists.txt
+index d28da481..25113821 100644
+--- a/kstool/CMakeLists.txt
++++ b/kstool/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ # Kstool for Keystone assembler engine.
+ # By Nguyen Anh Quynh, 2016
+ 
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 3.10.0)
+ 
+ project(kstool)
+ 
+diff --git a/llvm/CMakeLists.txt b/llvm/CMakeLists.txt
+index d926b082..518613a5 100644
+--- a/llvm/CMakeLists.txt
++++ b/llvm/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ # See docs/CMake.html for instructions about how to build LLVM with CMake.
+ 
+-cmake_minimum_required(VERSION 2.8.7)
++cmake_minimum_required(VERSION 3.10.0)
+ 
+ set(LLVM_INSTALL_TOOLCHAIN_ONLY ON)
+ 
+@@ -9,19 +9,6 @@ if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+   set(CMAKE_BUILD_TYPE "Debug")
+ endif()
+ 
+-if(POLICY CMP0022)
+-  cmake_policy(SET CMP0022 NEW) # automatic when 2.8.12 is required
+-endif()
+-
+-if (POLICY CMP0051)
+-  # CMake 3.1 and higher include generator expressions of the form
+-  # $<TARGETLIB:obj> in the SOURCES property.  These need to be
+-  # stripped everywhere that access the SOURCES property, so we just
+-  # defer to the OLD behavior of not including generator expressions
+-  # in the output for now.
+-  cmake_policy(SET CMP0051 OLD)
+-endif()
+-
+ if(CMAKE_VERSION VERSION_LESS 3.1.20141117)
+   set(cmake_3_2_USES_TERMINAL)
+ else()

--- a/mingw-w64-keystone/PKGBUILD
+++ b/mingw-w64-keystone/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=0.9.2
-pkgrel=7
+pkgrel=8
 pkgdesc="Lightweight multi-platform, multi-architecture assembler framework (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -25,17 +25,20 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 source=("https://github.com/keystone-engine/keystone/archive/${pkgver}/${_realname}-${pkgver}.tar.gz"
         "0001-cmake-install-dir.patch"
         "0002-kstool-win-msys2.patch"
-        "0003-python-load-dll-from-prefix.patch")
+        "0003-python-load-dll-from-prefix.patch"
+        "0004-modern-cmake-fix.patch")
 sha256sums=('c9b3a343ed3e05ee168d29daf89820aff9effb2c74c6803c2d9e21d55b5b7c24'
             'f7aa8aff0a2fed76364b6a29e2fa09bff5bdde5cb839c45494f8bbd17bb38c3f'
             'a1754bd710dfbbedd49e186862bfd0e9f06fc2c60f8534f669ef6ca817641c27'
-            '77077fb2a450605a2fefadb6fb9ba316167ba55fa13d044de80dbc3b9ddfb02f')
+            '77077fb2a450605a2fefadb6fb9ba316167ba55fa13d044de80dbc3b9ddfb02f'
+            'e04a3b4e1e0b24c1f511b1a63717d74760eb4a31e4565260f35eccc0d5d8dde1')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   patch -p1 -i "${srcdir}"/0001-cmake-install-dir.patch
   patch -p1 -i "${srcdir}"/0002-kstool-win-msys2.patch
   patch -p1 -i "${srcdir}"/0003-python-load-dll-from-prefix.patch
+  patch -p1 -i "${srcdir}"/0004-modern-cmake-fix.patch
 }
 
 build() {


### PR DESCRIPTION
Otherwise build fails with messages like

```
CMake Error at CMakeLists.txt:4 (cmake_minimum_required):
   Compatibility with CMake < 3.5 has been removed from CMake.

   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
   to tell CMake that the project requires at least <min> but has been updated
   to work with policies introduced by <max> or earlier.

   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```