### PR TITLE
nextpnr: patch 3rd party code to add missing include

### DIFF
--- a/mingw-w64-nextpnr/004-fix-cstdint-3rdparty-json11.patch
+++ b/mingw-w64-nextpnr/004-fix-cstdint-3rdparty-json11.patch
@@ -1,0 +1,33 @@
+From 0c060512c1bf6719391e2d3351c8cb757bec29cc Mon Sep 17 00:00:00 2001
+From: Gabriel Somlo <gsomlo@gmail.com>
+Date: Thu, 23 Jan 2025 07:53:52 -0500
+Subject: [PATCH] Fix undefined type error in 3rdparty/json11/json11.cpp
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Under certain conditions (e.g., building on Fedora 42
+using gcc-15.0.1), compilation fails with the following
+error:
+
+    "error: ‘uint8_t’ does not name a type"
+
+Explicitly include <cstdint> to prevent that situation.
+
+Signed-off-by: Gabriel Somlo <gsomlo@gmail.com>
+---
+ 3rdparty/json11/json11.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/3rdparty/json11/json11.cpp b/3rdparty/json11/json11.cpp
+index a0fcf866cc..b6c95e0447 100644
+--- a/3rdparty/json11/json11.cpp
++++ b/3rdparty/json11/json11.cpp
+@@ -23,6 +23,7 @@
+ #include <cassert>
+ #include <cmath>
+ #include <cstdlib>
++#include <cstdint>
+ #include <cstdio>
+ #include <climits>
+ #include <cerrno>

--- a/mingw-w64-nextpnr/PKGBUILD
+++ b/mingw-w64-nextpnr/PKGBUILD
@@ -4,7 +4,7 @@ _realname=nextpnr
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.7
-pkgrel=5
+pkgrel=6
 pkgdesc="Portable FPGA place and route tool (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -31,11 +31,13 @@ makedepends=(
 source=("${_realname}::git+https://github.com/YosysHQ/${_realname}.git#tag=${_realname}-${pkgver}"
         "001-fix-find-boost-built-with-cmake.patch"
         "002-fix-build-with-boost-1.85.patch::https://github.com/YosysHQ/nextpnr/commit/f0859503.patch"
-        "003-fix-build-with-clang-19.patch")
+        "003-fix-build-with-clang-19.patch"
+        "004-fix-cstdint-3rdparty-json11.patch")
 sha256sums=('ed14f31c68a1ec2e7dbae78ebfb3a0a1baa16d9e5c6d0252ffae6485f61906a4'
             '69f73e0ea3111f7580dc57b62bfefb0943b67de6c9245364f435abf58973d820'
             '4e93475cc6c09b93b707d64e06779f419eddcc6f705e5f568180795f0915f745'
-            '8ef99dcca08c7e6b23ca709a7cc083160ef5d78b485606c617697142c31585b9')
+            '8ef99dcca08c7e6b23ca709a7cc083160ef5d78b485606c617697142c31585b9'
+            '75ac30a3c2d61dba368a4215d55bc5127b463c11608e44cad17d9a8bdf46a82f')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -55,7 +57,8 @@ prepare() {
   apply_patch_with_msg \
     001-fix-find-boost-built-with-cmake.patch \
     002-fix-build-with-boost-1.85.patch \
-    003-fix-build-with-clang-19.patch
+    003-fix-build-with-clang-19.patch \
+    004-fix-cstdint-3rdparty-json11.patch
 
   git submodule update --init --recursive --depth=1
 }


### PR DESCRIPTION
Taken from upstream commit
<https://github.com/YosysHQ/nextpnr/commit/0c060512c1bf6719391e2d3351c8cb757bec29cc> which is part of newer nextnpr versions.


For reference:
Build in autobuild queue failed (https://github.com/msys2/msys2-autobuild/actions/runs/20848592632/job/59898177569?check_suite_focus=true#step:12:13403):
```
2026-01-09T11:24:29.1862490Z D:/W/B/src/nextpnr/3rdparty/json11/json11.cpp: In function 'void json11::dump(const std::string&, std::string&)':
2026-01-09T11:24:29.2643029Z D:/W/B/src/nextpnr/3rdparty/json11/json11.cpp:96:32: error: 'uint8_t' does not name a type
2026-01-09T11:24:29.3901737Z    96 |         } else if (static_cast<uint8_t>(ch) <= 0x1f) {
2026-01-09T11:24:29.4679090Z       |                                ^~~~~~~
2026-01-09T11:24:29.6713196Z D:/W/B/src/nextpnr/3rdparty/json11/json11.cpp:28:1: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
2026-01-09T11:24:29.8748727Z    27 | #include <climits>
2026-01-09T11:24:29.8749585Z   +++ |+#include <cstdint>
2026-01-09T11:24:30.0631068Z    28 | #include <cerrno>
2026-01-09T11:24:30.0637639Z D:/W/B/src/nextpnr/3rdparty/json11/json11.cpp:100:32: error: 'uint8_t' does not name a type
2026-01-09T11:24:30.2663638Z   100 |         } else if (static_cast<uint8_t>(ch) == 0xe2 && static_cast<uint8_t>(value[i+1]) == 0x80
2026-01-09T11:24:30.4552704Z       |                                ^~~~~~~
2026-01-09T11:24:30.4555599Z D:/W/B/src/nextpnr/3rdparty/json11/json11.cpp:100:32: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
2026-01-09T11:24:30.4561423Z D:/W/B/src/nextpnr/3rdparty/json11/json11.cpp:100:68: error: 'uint8_t' does not name a type
2026-01-09T11:24:30.6578053Z   100 |         } else if (static_cast<uint8_t>(ch) == 0xe2 && static_cast<uint8_t>(value[i+1]) == 0x80
2026-01-09T11:24:30.8609529Z       |                                                                    ^~~~~~~
2026-01-09T11:24:30.8614495Z D:/W/B/src/nextpnr/3rdparty/json11/json11.cpp:100:68: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
2026-01-09T11:24:31.0490435Z D:/W/B/src/nextpnr/3rdparty/json11/json11.cpp:101:35: error: 'uint8_t' does not name a type
2026-01-09T11:24:31.0498252Z   101 |                    && static_cast<uint8_t>(value[i+2]) == 0xa8) {
2026-01-09T11:24:31.2441843Z       |                                   ^~~~~~~
2026-01-09T11:24:31.4716714Z D:/W/B/src/nextpnr/3rdparty/json11/json11.cpp:101:35: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
2026-01-09T11:24:31.6434501Z D:/W/B/src/nextpnr/3rdparty/json11/json11.cpp:104:32: error: 'uint8_t' does not name a type
2026-01-09T11:24:31.6590956Z   104 |         } else if (static_cast<uint8_t>(ch) == 0xe2 && static_cast<uint8_t>(value[i+1]) == 0x80
2026-01-09T11:24:31.6746886Z       |                                ^~~~~~~
2026-01-09T11:24:31.8466320Z D:/W/B/src/nextpnr/3rdparty/json11/json11.cpp:104:32: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
2026-01-09T11:24:31.8476855Z D:/W/B/src/nextpnr/3rdparty/json11/json11.cpp:104:68: error: 'uint8_t' does not name a type
2026-01-09T11:24:31.8621936Z   104 |         } else if (static_cast<uint8_t>(ch) == 0xe2 && static_cast<uint8_t>(value[i+1]) == 0x80
2026-01-09T11:24:32.0492642Z       |                                                                    ^~~~~~~
2026-01-09T11:24:32.0660454Z D:/W/B/src/nextpnr/3rdparty/json11/json11.cpp:104:68: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
2026-01-09T11:24:32.2378522Z D:/W/B/src/nextpnr/3rdparty/json11/json11.cpp:105:35: error: 'uint8_t' does not name a type
2026-01-09T11:24:32.2690354Z   105 |                    && static_cast<uint8_t>(value[i+2]) == 0xa9) {
2026-01-09T11:24:32.4414600Z       |                                   ^~~~~~~
2026-01-09T11:24:32.4571190Z D:/W/B/src/nextpnr/3rdparty/json11/json11.cpp:105:35: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
2026-01-09T11:24:32.4659766Z D:/W/B/src/nextpnr/3rdparty/json11/json11.cpp: In function 'std::string json11::esc(char)':
2026-01-09T11:24:32.6437254Z D:/W/B/src/nextpnr/3rdparty/json11/json11.cpp:331:21: error: 'uint8_t' does not name a type
2026-01-09T11:24:32.6601824Z   331 |     if (static_cast<uint8_t>(c) >= 0x20 && static_cast<uint8_t>(c) <= 0x7f) {
2026-01-09T11:24:32.7539136Z       |                     ^~~~~~~
2026-01-09T11:24:32.8478279Z D:/W/B/src/nextpnr/3rdparty/json11/json11.cpp:331:21: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
2026-01-09T11:24:32.8532386Z D:/W/B/src/nextpnr/3rdparty/json11/json11.cpp:331:56: error: 'uint8_t' does not name a type
2026-01-09T11:24:33.1945967Z   331 |     if (static_cast<uint8_t>(c) >= 0x20 && static_cast<uint8_t>(c) <= 0x7f) {
2026-01-09T11:24:33.2499459Z       |                                                        ^~~~~~~
2026-01-09T11:24:33.2857687Z D:/W/B/src/nextpnr/3rdparty/json11/json11.cpp:331:56: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
```
This PR tries to fix that.