### PR TITLE
ixion: attempt to fix Boost-related build error

### DIFF
--- a/mingw-w64-ixion/003-boost.m4-update.patch
+++ b/mingw-w64-ixion/003-boost.m4-update.patch
@@ -1,0 +1,35 @@
+From bfe5ab6adadda265d575fec9c192e6f53f2ef9f5 Mon Sep 17 00:00:00 2001
+From: Kohei Yoshida <kohei.yoshida@gmail.com>
+Date: Fri, 4 Apr 2025 21:08:55 -0400
+Subject: [PATCH] Update boost.m4 from the latest upstream
+
+---
+ m4/boost.m4 | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/m4/boost.m4 b/m4/boost.m4
+index 706035d3..342516e4 100644
+--- a/m4/boost.m4
++++ b/m4/boost.m4
+@@ -1332,11 +1332,16 @@ BOOST_DEFUN([String_Algo],
+ # --------------------------------
+ # Look for Boost.System.  For the documentation of PREFERRED-RT-OPT, see the
+ # documentation of BOOST_FIND_LIB above.  This library was introduced in Boost
+-# 1.35.0.
++# 1.35.0 and is header only since 1.70.
+ BOOST_DEFUN([System],
+-[BOOST_FIND_LIB([system], [$1],
++[
++if test $boost_major_version -ge 170; then
++  BOOST_FIND_HEADER([boost/system/error_code.hpp])
++else
++  BOOST_FIND_LIB([system], [$1],
+                 [boost/system/error_code.hpp],
+                 [boost::system::error_code e; e.clear();], [], [], [$2])
++fi
+ ])# BOOST_SYSTEM
+ 
+ 
+-- 
+GitLab
+

--- a/mingw-w64-ixion/PKGBUILD
+++ b/mingw-w64-ixion/PKGBUILD
@@ -4,7 +4,7 @@ _realname=ixion
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.20.0
-pkgrel=2
+pkgrel=3
 pkgdesc="A general purpose formula parser & interpreter. (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -26,10 +26,12 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-python: Python bindings"
             "${MINGW_PACKAGE_PREFIX}-vulkan-loader: Vulkan compute engine")
 source=("https://gitlab.com/ixion/ixion/-/archive/${pkgver}/${_realname}-${pkgver}.tar.bz2"
         "001-fix-build-on-mingw.patch"
-        "002-do-not-search-for-boost-system.patch")
+        "002-do-not-search-for-boost-system.patch"
+        "003-boost.m4-update.patch")
 sha256sums=('39e54cd486fed458c2a6e83a5e658d4c2e818862355b33645bb1342449428463'
             'f5554b215c7be10f48a2567824acf54a7b97831b4e4723d76edd4fede31931fd'
-            '0bef56f5fe568a3131d187c95d7efec62e8617f23e02c3c20b6642da1e195837')
+            '0bef56f5fe568a3131d187c95d7efec62e8617f23e02c3c20b6642da1e195837'
+            '0fdf9c1e34dfbdf55b4f2f347b9fbb1b8fe6fd35b6a0575d2aa6c58eae160920')
 
 prepare() {
   cd ${_realname}-${pkgver}


### PR DESCRIPTION
Build in [autobuild currently fails](https://github.com/msys2/msys2-autobuild/actions/runs/20848592632/job/59898177563?check_suite_focus=true#step:12:11526) with
```
2026-01-09T11:09:39.2964584Z checking for Boost headers version >= 1.36.0... no
2026-01-09T11:09:39.2965571Z configure: error: cannot find Boost headers version >= 1.36.0
2026-01-09T11:09:39.7399169Z ==> ERROR: A failure occurred in build().
2026-01-09T11:09:39.7599776Z     Aborting...
```
despite having Boost installed. This PR attempts to fix it.

It's a long shot, but the same patch is used in Arch Linux, so let's give it a try.


**Edit:** Didn't work, closing.