### PR TITLE
python-pathspec: update to 1.0.3

### DIFF
--- a/mingw-w64-python-pathspec/PKGBUILD
+++ b/mingw-w64-python-pathspec/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=pathspec
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=0.12.1
-pkgrel=4
+pkgver=1.0.3
+pkgrel=1
 pkgdesc='Utility library for gitignore style pattern matching of file paths (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -17,8 +17,10 @@ depends=("${MINGW_PACKAGE_PREFIX}-python")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
              "${MINGW_PACKAGE_PREFIX}-python-flit-core")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
+options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712')
+sha256sums=('bac5cf97ae2c2876e2d25ebb15078eb04d76e4b98921ee31c6f85ade8b59444d')
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
@@ -27,7 +29,7 @@ build() {
 
 check() {
   cd "${srcdir}/python-build-${MSYSTEM}"
-  ${MINGW_PREFIX}/bin/python -m unittest discover pathspec/tests || warning "Tests failed"
+  ${MINGW_PREFIX}/bin/pytest || warning "Tests failed"
 }
 
 package() {


### PR DESCRIPTION
Also fixed the check logic & add the no-strip option.