### PR TITLE
python-passagemath-m4ri-m4rie: add version 10.6.45 (new package)

### DIFF
--- a/mingw-w64-passagemath-m4ri-m4rie/PKGBUILD
+++ b/mingw-w64-passagemath-m4ri-m4rie/PKGBUILD
@@ -1,0 +1,53 @@
+# Maintainer: Dirk Stolle
+
+_realname=passagemath-m4ri-m4rie
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=10.6.45
+pkgrel=1
+pkgdesc="passagemath: Linear Algebra with m4ri and m4rie (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/passagemath/passagemath'
+msys2_references=(
+  'purl: pkg:pypi/passagemath-m4ri-m4rie'
+)
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-gmp"
+         "${MINGW_PACKAGE_PREFIX}-libgd"
+         "${MINGW_PACKAGE_PREFIX}-m4ri"
+         "${MINGW_PACKAGE_PREFIX}-m4rie"
+         "${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-cysignals"
+         "${MINGW_PACKAGE_PREFIX}-python-memory-allocator"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-categories"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-environment"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-modules"
+)
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cython"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-numpy"
+             "${MINGW_PACKAGE_PREFIX}-python-pkgconfig"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-setup"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname//-/_}-${pkgver}.tar.gz")
+sha256sums=('118058d2af32212bb6bdab0bd3f0bf8cca83c5ffd13581e6ffcd8ed65e420ec9')
+
+build() {
+  cp -r "${_realname//-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+}


### PR DESCRIPTION
This PR adds python-passagemath-m4ri-m4rie, a package to provide some functionality from passagemath (https://github.com/msys2/MINGW-packages/issues/24738). passagemath-m4ri-m4rie was added to passagemath in [passagemath 10.6.44](https://github.com/passagemath/passagemath/releases/tag/passagemath-10.6.44).

Note: The package also needs the passagemath-environment package from the passagemath 10.6.45 update (https://github.com/msys2/MINGW-packages/pull/27284) in staging, otherwise the build will fail, because earlier versions do not contain the upstream fix from https://github.com/passagemath/passagemath/pull/1947 yet. Just retrigger the build in a few hours, if it failed during the first attempt.
(For the check step to succeed, passagemath-categories and passagemath-modules need to be version 10.6.45, too.)