### PR TITLE
Catch2: update to 3.12.0

### DIFF
--- a/mingw-w64-catch/0001-fix-clang-regression.patch
+++ b/mingw-w64-catch/0001-fix-clang-regression.patch
@@ -1,0 +1,17 @@
+Disable this test due to regression of Clang 20,
+should be removed when https://github.com/catchorg/Catch2/issues/2991 is fixed.
+--- a/tests/SelfTest/UsageTests/Misc.tests.cpp.orig	2025-12-29 05:31:54 +0800
++++ b/tests/SelfTest/UsageTests/Misc.tests.cpp	2026-01-11 18:23:00 +0800
+@@ -388,9 +388,9 @@
+     REQUIRE(x.size() > 0);
+ }
+ 
+-TEMPLATE_PRODUCT_TEST_CASE("Product with differing arities", "[template][product]", std::tuple, (int, (int, double), (int, double, float))) {
+-    REQUIRE(std::tuple_size<TestType>::value >= 1);
+-}
++// TEMPLATE_PRODUCT_TEST_CASE("Product with differing arities", "[template][product]", std::tuple, (int, (int, double), (int, double, float))) {
++//     REQUIRE(std::tuple_size<TestType>::value >= 1);
++// }
+ 
+ using MyTypes = std::tuple<int, char, float>;
+ TEMPLATE_LIST_TEST_CASE("Template test case with test types specified inside std::tuple", "[template][list]", MyTypes)

--- a/mingw-w64-catch/0002-fix-null-file.patch
+++ b/mingw-w64-catch/0002-fix-null-file.patch
@@ -1,0 +1,23 @@
+Should be removed after https://github.com/catchorg/Catch2/pull/3059 is merged and released.
+--- a/tests/CMakeLists.txt.orig	2026-01-11 18:32:12 +0800
++++ b/tests/CMakeLists.txt	2026-01-11 18:32:18 +0800
+@@ -483,7 +483,7 @@
+     FAIL_REGULAR_EXPRESSION "No tests ran"
+ )
+ 
+-if(MSVC)
++if(WIN32)
+   set(_NullFile "NUL")
+ else()
+   set(_NullFile "/dev/null")
+--- a/tests/ExtraTests/CMakeLists.txt.orig	2025-12-29 05:31:54 +0800
++++ b/tests/ExtraTests/CMakeLists.txt	2026-01-11 18:32:41 +0800
+@@ -273,7 +273,7 @@
+     FAIL_REGULAR_EXPRESSION "X27 ERROR"
+ )
+ 
+-if(MSVC)
++if(WIN32)
+   set(_NullFile "NUL")
+ else()
+   set(_NullFile "/dev/null")

--- a/mingw-w64-catch/PKGBUILD
+++ b/mingw-w64-catch/PKGBUILD
@@ -1,9 +1,11 @@
 # Maintainer: David Grayson <davidegrayson@gmail.com>
+# Contributor: dragon-archer <dragon-archer@outlook.com>
 
 _realname=catch
+_projname=Catch2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.11.0
+pkgver=3.12.0
 pkgrel=1
 pkgdesc="A modern, C++-native, header-only, test framework for unit-tests, TDD and BDD using C++11 and later (mingw-w64)"
 arch=('any')
@@ -15,11 +17,31 @@ msys2_references=(
 url='https://github.com/catchorg/Catch2'
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-ninja"
-             "${MINGW_PACKAGE_PREFIX}-python")
+             "${MINGW_PACKAGE_PREFIX}-ninja")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python")
 license=('spdx:BSL-1.0')
-source=(https://github.com/catchorg/Catch2/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz)
-sha256sums=('82fa1cb59dc28bab220935923f7469b997b259eb192fb9355db62da03c2a3137')
+source=("${url}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
+        '0001-fix-clang-regression.patch'
+        '0002-fix-null-file.patch')
+sha256sums=('e077079f214afc99fee940d91c14cf1a8c1d378212226bb9f50efff75fe07b23'
+            '5c795cb09098554f687212108a4f756a96756698a2fa4d3f7b89927ab5e46cb7'
+            '165024d82086afcdf6e58f437e81d6d799a1f5aaf752d9cf9c6ad8543eab4bc8')
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+prepare() {
+  cd "${srcdir}/${_projname}-${pkgver}"
+
+  apply_patch_with_msg \
+    0001-fix-clang-regression.patch \
+    0002-fix-null-file.patch
+}
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
@@ -36,19 +58,25 @@ build() {
     -G"Ninja" \
     ${_extra_config[@]} \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    "../Catch2-${pkgver}"
+    -S "../${_projname}-${pkgver}"
 
   ${MINGW_PREFIX}/bin/cmake.exe --build ./
 }
 
 check() {
   cd "${srcdir}/build-${MSYSTEM}"
-  projects/SelfTest.exe
+  # Disable -Werror due to another problem since Clang 20 from https://github.com/catchorg/Catch2/issues/2991
+  ${MINGW_PREFIX}/bin/cmake.exe -DCATCH_DEVELOPMENT_BUILD=ON -DCATCH_ENABLE_WERROR=OFF -S "../${_projname}-${pkgver}"
+  ${MINGW_PREFIX}/bin/cmake.exe --build ./
+
+  # Exclude ApprovalTests as 0001-fix-clang-regression.patch reduced the total
+  # number of tests, causing ApprovalTests to fail.
+  ${MINGW_PREFIX}/bin/ctest.exe --output-on-failure -E ApprovalTests
 }
 
 package() {
   cd "${srcdir}/build-${MSYSTEM}"
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install ./
 
-  install -Dm644 "${srcdir}"/Catch2-${pkgver}/LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.txt"
+  install -Dm644 "${srcdir}/${_projname}-${pkgver}/LICENSE.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.txt"
 }


### PR DESCRIPTION
* move python from makedepends to checkdepends
* fix checks

Also, how about renaming it to Catch2, so that it matches the repo name?