### PR TITLE
cx-freeze: add missing msilib dependency

### DIFF
--- a/mingw-w64-python-cx-freeze/PKGBUILD
+++ b/mingw-w64-python-cx-freeze/PKGBUILD
@@ -7,7 +7,7 @@ _realname=cx-freeze
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=8.5.3
-pkgrel=2
+pkgrel=3
 pkgdesc="Creates standalone executables from Python scripts with the same performance as the original script (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -22,6 +22,7 @@ depends=(
   "${MINGW_PACKAGE_PREFIX}-python-setuptools"
   "${MINGW_PACKAGE_PREFIX}-python-lief"
   "${MINGW_PACKAGE_PREFIX}-python-freeze-core"
+  "${MINGW_PACKAGE_PREFIX}-python-msilib"
 )
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-build"

--- a/mingw-w64-python-msilib/PKGBUILD
+++ b/mingw-w64-python-msilib/PKGBUILD
@@ -1,0 +1,39 @@
+# Maintainer: Christoph Reiter <reiter.christoph@gmail.com>
+
+_pyname=python_msilib
+_realname=python-msilib
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=0.5.0
+pkgrel=1
+pkgdesc="Read and write Microsoft Installer files (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/marcelotduarte/python-msilib'
+msys2_references=(
+  'pypi:python-msilib'
+)
+license=('spdx:PSF-2.0')
+depends=("${MINGW_PACKAGE_PREFIX}-python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+source=(https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${pkgver}.tar.gz)
+sha256sums=('5d9d0c2af2cafbc50d484cce4cfab1cb8cfd65d705d7111d216bc525a059113b')
+
+build() {
+  cp -r "${_pyname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
New with Python 3.13

See https://github.com/marcelotduarte/cx_Freeze/blob/0971e3fd656ab60fd92dbcf93f0a0ae694302167/pyproject.toml#L48

Fixes #27295