### PR TITLE
tree-siiter-lua: update to 0.4.1

### DIFF
--- a/mingw-w64-tree-sitter-lua/PKGBUILD
+++ b/mingw-w64-tree-sitter-lua/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=tree-sitter-lua
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.4.0
-pkgrel=2
+pkgver=0.4.1
+pkgrel=1
 pkgdesc='Lua grammar for tree-sitter (mingw-w64)'
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -18,14 +18,15 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cc"
   "${MINGW_PACKAGE_PREFIX}-cmake"
   "${MINGW_PACKAGE_PREFIX}-tree-sitter"
+  "${MINGW_PACKAGE_PREFIX}-nodejs"
 )
-source=("${_realname}-${pkgver}.tar.gz::${msys2_repository_url}/releases/download/v${pkgver}/${_realname}.tar.gz")
-sha256sums=('e01fa3a1531f62be02d0c4c22b5b917eaeec7eb3dc15b562015bc1c60deeb8f2')
-noextract=("${_realname}-${pkgver}.tar.gz")
+source=("${msys2_repository_url}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('cef44b8773bde69d427b5e50ca95e417c86c0be91caa37a6782c90d6f529da70')
 
 prepare() {
-  mkdir -p "${_realname}-${pkgver}"
-  tar -xf "${_realname}-${pkgver}.tar.gz" -C "${_realname}-${pkgver}" || true
+  cd "${_realname}-${pkgver}"
+
+  tree-sitter generate src/grammar.json
 }
 
 build() {


### PR DESCRIPTION
switching to source archive as a full tarball is not provided somehow