### PR TITLE
python-distlib: Fix filename of resource object file

### DIFF
--- a/mingw-w64-python-distlib/PKGBUILD
+++ b/mingw-w64-python-distlib/PKGBUILD
@@ -5,7 +5,7 @@ _realname=distlib
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=0.4.0
-pkgrel=3
+pkgrel=4
 pkgdesc="Low-level components of distutils2/packaging (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -49,20 +49,20 @@ build() {
     _cli_cflags+=" -s"
   fi
 
-  windres --input PC/launcher.rc --output PC/resources.res --output-format=coff
+  windres --input PC/launcher.rc --output PC/resources.o --output-format=coff
 
   case "${MINGW_CHOST}" in
   i686-w64-mingw32)
-    cc $_cli_cflags -o distlib/t32.exe PC/launcher.c PC/resources.res $_cli_lflags
-    cc $_gui_cflags -o distlib/w32.exe PC/launcher.c PC/resources.res $_gui_lflags
+    cc $_cli_cflags -o distlib/t32.exe PC/launcher.c PC/resources.o $_cli_lflags
+    cc $_gui_cflags -o distlib/w32.exe PC/launcher.c PC/resources.o $_gui_lflags
     ;;
   x86_64-w64-mingw32)
-    cc $_cli_cflags -o distlib/t64.exe PC/launcher.c PC/resources.res $_cli_lflags
-    cc $_gui_cflags -o distlib/w64.exe PC/launcher.c PC/resources.res $_gui_lflags
+    cc $_cli_cflags -o distlib/t64.exe PC/launcher.c PC/resources.o $_cli_lflags
+    cc $_gui_cflags -o distlib/w64.exe PC/launcher.c PC/resources.o $_gui_lflags
     ;;
   aarch64-w64-mingw32)
-    cc $_cli_cflags -o distlib/t64-arm.exe PC/launcher.c PC/resources.res $_cli_lflags
-    cc $_gui_cflags -o distlib/w64-arm.exe PC/launcher.c PC/resources.res $_gui_lflags
+    cc $_cli_cflags -o distlib/t64-arm.exe PC/launcher.c PC/resources.o $_cli_lflags
+    cc $_gui_cflags -o distlib/w64-arm.exe PC/launcher.c PC/resources.o $_gui_lflags
     ;;
   *)
     echo "Unsupported CHOST ${MINGW_CHOST}" && false


### PR DESCRIPTION
This is same with 01cb69ea485e00ce623146a5c301e6e83dd35ad2.