### PR TITLE
New Package: add plutovg v1.3.2

### DIFF
--- a/mingw-w64-plutovg/PKGBUILD
+++ b/mingw-w64-plutovg/PKGBUILD
@@ -44,18 +44,9 @@ build() {
 package() {
   DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}"
 
-  _docfiles=(
-    "${srcdir}/${_realname}-${pkgver}/README.md"
-    "${srcdir}/${_realname}-${pkgver}/smiley.png"
-  )
-  _docdirs=(
-    "${srcdir}/build-${MSYSTEM}/examples"
-  )
-  for _docfile in "${_docfiles[@]}"; do
-    install -D -v -m644 "${_docfile}" "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}/$(basename "${_docfile}")"
-  done
-  for _docdir in "${_docdirs[@]}"; do
-    cp -rv "${_docdir}" "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}/$(basename "${_docdir}")"
-  done
+  install -D -v -m644 "${srcdir}/${_realname}-${pkgver}/README.md" "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}/README.md"
+  install -D -v -m644 "${srcdir}/${_realname}-${pkgver}/smiley.png" "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}/smiley.png"
+  cp -rv "${srcdir}/${_realname}-${pkgver}/examples" "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}/examples"
+  install -Dm755 "${srcdir}/build-${MSYSTEM}/examples/smiley.exe" "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}/examples/smiley.exe"
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
plutovg: a standalone 2D vector graphics library in C

pkgver=1.3.2
pkgrel=1
mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')

url=https://github.com/sammycage/plutovg
references AUR packages:
- https://aur.archlinux.org/packages/plutovg
- https://aur.archlinux.org/packages/plutovg-git

May warn about package containing reference to `$(cygpath -m /)` when copying example files to `${MINGW_PREFIX}/share/doc/plutovg/examples` but could be ignored.