### PR TITLE
New Package: add plutosvg v0.0.7

### DIFF
--- a/mingw-w64-plutosvg/PKGBUILD
+++ b/mingw-w64-plutosvg/PKGBUILD
@@ -9,6 +9,7 @@ pkgdesc="Tiny SVG rendering library in C. (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://github.com/sammycage/plutosvg"
+msys2_repository_url="https://github.com/sammycage/plutosvg"
 msys2_references=(
   "aur : plutosvg"
 )
@@ -21,7 +22,6 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-cc")
 source=("${_realname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz")
 sha256sums=('78561b571ac224030cdc450ca2986b4de915c2ba7616004a6d71a379bffd15f3')
-
 
 build() {
   declare -a extra_config
@@ -37,6 +37,7 @@ build() {
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       "${extra_config[@]}" \
       -DBUILD_SHARED_LIBS=ON \
+      -DCMAKE_DLL_NAME_WITH_SOVERSION=ON \
       -S "${_realname}-${pkgver}" \
       -B "build-${MSYSTEM}" \
       -DCMAKE_SKIP_RPATH=ON \
@@ -45,7 +46,6 @@ build() {
 
   cmake --build "build-${MSYSTEM}"
 }
-
 
 package() {
   DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}"


### PR DESCRIPTION
plutosvg: tiny SVG rendering library in C

pkgver=0.0.7
pkgrel=1
mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')

url=https://github.com/sammycage/plutosvg
references AUR packages:
- https://aur.archlinux.org/packages/plutosvg
- https://aur.archlinux.org/packages/plutosvg-git

May warn about package containing reference to `$(cygpath -m /)` when copying example files to `${MINGW_PREFIX}/share/doc/plutosvg/examples` but could be ignored.