### PR TITLE
double-conversion: update to 3.4.0

### DIFF
--- a/mingw-w64-double-conversion/PKGBUILD
+++ b/mingw-w64-double-conversion/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=double-conversion
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=3.3.1
-pkgrel=3
+pkgver=3.4.0
+pkgrel=1
 pkgdesc="Binary-decimal and decimal-binary routines for IEEE doubles (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -14,16 +14,13 @@ depends=("${MINGW_PACKAGE_PREFIX}-cc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
-source=("https://github.com/google/double-conversion/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
-        cmake-version.patch
+source=("${url}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
         cmake-dual-lib.patch)
-sha256sums=('fe54901055c71302dcdc5c3ccbe265a6c191978f3761ce1414d0895d6b0ea90e'
-            '677de958606a7884147525cd985d0b133c95eafaac580d0eed1fd84ff339eedf'
+sha256sums=('42fd4d980ea86426e457b24bdfa835a6f5ad9517ddb01cdb42b99ab9c8dd5dc9'
             '66e1bf3216676dce9f5149e7a1b381e692653679e206f0e729fe5e9d158459a6')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
-  patch -p1 -i ${srcdir}/cmake-version.patch
   patch -p1 -i ${srcdir}/cmake-dual-lib.patch
 }
 

--- a/mingw-w64-double-conversion/cmake-version.patch
+++ b/mingw-w64-double-conversion/cmake-version.patch
@@ -1,9 +1,0 @@
-diff -Naur double-conversion-3.3.1-orig/CMakeLists.txt double-conversion-3.3.1/CMakeLists.txt
---- double-conversion-3.3.1-orig/CMakeLists.txt	2025-02-14 13:03:13.000000000 +0300
-+++ double-conversion-3.3.1/CMakeLists.txt	2025-05-23 21:15:21.673245400 +0300
-@@ -1,4 +1,4 @@
--cmake_minimum_required(VERSION 3.0)
-+cmake_minimum_required(VERSION 3.15...4.0.1)
- project(double-conversion VERSION 3.3.0)
- 
- option(BUILD_SHARED_LIBS "Build shared libraries (.dll/.so) instead of static ones (.lib/.a)" OFF)


### PR DESCRIPTION
cmake-version.patch has been incoporated in upstream, so drops it