### PR TITLE
flang-rt: Avoid duplicate definition of `std::__libcpp_verbose_abort`

### DIFF
--- a/mingw-w64-flang/0104-avoid-duplicate-definition.patch
+++ b/mingw-w64-flang/0104-avoid-duplicate-definition.patch
@@ -1,0 +1,76 @@
+From 7d8040450de11d5268c5e6fe96dc31ef01e10f07 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Markus=20M=C3=BCtzel?= <markus.muetzel@gmx.de>
+Date: Sun, 11 Jan 2026 19:57:00 +0100
+Subject: [PATCH] flang-rt: Avoid duplicate definition of
+ `std::__libcpp_verbose_abort`.
+
+If a project depends on the Fortran runtime and on libc++, linking fails
+because `std::__libcpp_verbose_abort` is defined in both libraries.
+
+Avoid that duplicate definition by defining `_LIBCPP_VERBOSE_ABORT` before
+including any C++ headers and by renaming that symbol in the Fortran runtime
+to `flang_rt_verbose_abort`.
+---
+ cmake/modules/AddFlangRT.cmake |  6 ++++++
+ lib/runtime/io-api-minimal.cpp |  7 +++----
+ lib/runtime/io-api-minimal.h   | 12 ++++++++++++
+ 3 files changed, 21 insertions(+), 4 deletions(-)
+ create mode 100644 lib/runtime/io-api-minimal.h
+
+diff --git a/cmake/modules/AddFlangRT.cmake b/cmake/modules/AddFlangRT.cmake
+index 923507764d69..e8b714693a8a 100644
+--- a/cmake/modules/AddFlangRT.cmake
++++ b/cmake/modules/AddFlangRT.cmake
+@@ -317,6 +317,12 @@ function (add_flangrt_library name)
+           "$<$<COMPILE_LANGUAGE:CXX>:-Wp,-U_LIBCPP_ENABLE_ASSERTIONS>")
+     endif ()
+ 
++    # Use own function in place of `std::__libcpp_verbose_abort` in the Fortran
++    # runtime to avoid an unwanted dependency on the symbol provided by libc++.
++    target_compile_options(${tgtname} PRIVATE
++      $<$<COMPILE_LANGUAGE:CXX>:"-D_LIBCPP_VERBOSE_ABORT(...)=flang_rt_verbose_abort(__VA_ARGS__)" -include "${FLANG_RT_SOURCE_DIR}/lib/runtime/io-api-minimal.h">
++      )
++
+     # Non-GTest unittests depend on LLVMSupport
+     if (ARG_LINK_TO_LLVM)
+       if (LLVM_LINK_LLVM_DYLIB)
+diff --git a/lib/runtime/io-api-minimal.cpp b/lib/runtime/io-api-minimal.cpp
+index fdf7183ed517..dad1c1e901e1 100644
+--- a/lib/runtime/io-api-minimal.cpp
++++ b/lib/runtime/io-api-minimal.cpp
+@@ -147,11 +147,10 @@ bool IODEF(OutputLogical)(Cookie cookie, bool truth) {
+ } // namespace Fortran::runtime::io
+ 
+ #if defined(_LIBCPP_VERBOSE_ABORT)
+-// Provide own definition for `std::__libcpp_verbose_abort` to avoid dependency
+-// on the version provided by libc++.
++// Provide function that is used in place of `std::__libcpp_verbose_abort` in
++// the Fortran runtime to avoid dependency on the symbol provided by libc++.
+ 
+-void std::__libcpp_verbose_abort(char const *format, ...) noexcept(
+-    noexcept(std::__libcpp_verbose_abort(""))) {
++void flang_rt_verbose_abort(char const *format, ...) {
+   va_list list;
+   va_start(list, format);
+   std::vfprintf(stderr, format, list);
+diff --git a/lib/runtime/io-api-minimal.h b/lib/runtime/io-api-minimal.h
+new file mode 100644
+index 000000000000..5ea5c2ea56fc
+--- /dev/null
++++ b/lib/runtime/io-api-minimal.h
+@@ -0,0 +1,12 @@
++//===-- lib/runtime/io-api-minimal.h --------------------------*- C++ -*-===//
++//
++// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
++// See https://llvm.org/LICENSE.txt for license information.
++// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
++//
++//===----------------------------------------------------------------------===//
++
++// Declare function that is used in place of `std::__libcpp_verbose_abort` in
++// the Fortran runtime to avoid dependency on the symbol provided by libc++.
++
++void flang_rt_verbose_abort(char const *format, ...);
+-- 
+2.51.0.windows.2
+

--- a/mingw-w64-flang/PKGBUILD
+++ b/mingw-w64-flang/PKGBUILD
@@ -8,7 +8,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-rt")
 _pkgver=21.1.8
 pkgver=${_pkgver/-/}
-pkgrel=1
+pkgrel=2
 pkgdesc="Fortran frontend for LLVM (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -42,14 +42,16 @@ source=("${_url}/${_pkgfn}.tar.xz"{,.sig}
         "0005-Fix-c_long_double-value-on-mingw-aarch64.patch"
         "0101-add-municode-flag-on-mingw.patch"
         "0102-do-not-use-clock_gettime-on-mingw.patch"
-        "0103-fix-build-on-mingw.patch")
+        "0103-fix-build-on-mingw.patch"
+        "0104-avoid-duplicate-definition.patch")
 sha256sums=('4633a23617fa31a3ea51242586ea7fb1da7140e426bd62fc164261fe036aa142'
             'SKIP'
             '77fb0612217b6af7a122f586a9d0d334cd48bb201509bf72e8f8e6244616e895'
             'a1811227e2a26c2786b0c8577528580e679111f6c0889afea57d08333e2d5e4f'
             'cb7c7f8f00076c904263a1aeb1bdd68625f18b2d0246adb6f38588cd6e1c9d09'
             '215941eb952b3bc054d5f21e4db06d13aca44fb18f7a7800eb1d3e89cf9845da'
-            'f4efcbd6baf9d26652b0111dafd5686a03ff167b466b5d84da94965d56ff2f4e')
+            'f4efcbd6baf9d26652b0111dafd5686a03ff167b466b5d84da94965d56ff2f4e'
+            '424916de0c48b2fa7514b2cd0a2fb1b96ccd05634d39b357d9289f23d92440a4')
 validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Google.
               '474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard
               '71046D1E9C6656BDD61171873E83BABF4A4F9E85'  # Cullen Rhodes
@@ -82,7 +84,8 @@ prepare() {
   apply_patch_with_msg \
     "0101-add-municode-flag-on-mingw.patch" \
     "0102-do-not-use-clock_gettime-on-mingw.patch" \
-    "0103-fix-build-on-mingw.patch"
+    "0103-fix-build-on-mingw.patch" \
+    "0104-avoid-duplicate-definition.patch"
 }
 
 build() {
@@ -143,7 +146,7 @@ build() {
 
 check() {
   cd "${srcdir}"/build-${MSYSTEM}
-  ${MINGW_PREFIX}/bin/cmake.exe -DFLANG_INCLUDE_TESTS=ON ../${_pkgfn}
+  ${MINGW_PREFIX}/bin/cmake.exe -DFLANG_INCLUDE_TESTS=ON ../${_pkgfn}/flang
   ${MINGW_PREFIX}/bin/cmake.exe --build .
   ${MINGW_PREFIX}/bin/cmake.exe --build . -- check-flang || true
 }


### PR DESCRIPTION
If a project depends on the Flang runtime and on libc++, linking fails because `std::__libcpp_verbose_abort` is defined in both libraries.

Avoid that duplicate definition by defining `_LIBCPP_VERBOSE_ABORT` before including any C++ headers and by renaming that symbol in the Flang runtime to `flang_verbose_abort`.

The function that is modified by the new patch in the Flang runtime was originally introduced [here](https://reviews.llvm.org/D158957) to solve an undefined symbol error when linking pure-Fortran projects with the Flang runtime.
Providing a definition for that symbol in the Flang runtime works correctly for ELF or Mach-O because that symbol has weak linkage in libc++. But for COFF, this now causes multiple-definition errors for projects that are linking to the Flang runtime *and* to libc++ (because COFF doesn't support weak symbols iiuc).
The linker errors for COFF look like this:
```
ld.lld: error: duplicate symbol: std::__1::__libcpp_verbose_abort(char const*, ...)
>>> defined at libflang_rt.runtime.a(io-api-minimal.cpp.obj)
>>> defined at libc++.dll.a(libc++.dll)
```

Maybe, this problem should have been resolved differently already back then. But it feels like it is easier now that flang-rt is more separated from flang in the LLVM monorepo.

@mstorsjo: You helped reviewing D158957 for LLVM 17. I hope it is ok pinging you for this PR again. Does this change look good to you? Do you think something like this could be accepted in upstream LLVM, too?