### PR TITLE
fastfetch: update to 2.57.0

### DIFF
--- a/mingw-w64-fastfetch/PKGBUILD
+++ b/mingw-w64-fastfetch/PKGBUILD
@@ -1,9 +1,10 @@
 # Maintainer: Biswapriyo Nath <nathbappai@gmail.com>
+# Contributor: dragon-archer <dragon-archer@outlook.com>
 
 _realname=fastfetch
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.56.1
+pkgver=2.57.0
 pkgrel=1
 pkgdesc="An actively maintained, feature-rich and performance oriented, neofetch like system information tool (mingw-w64)"
 arch=('any')
@@ -27,13 +28,20 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-vulkan-headers"
              "${MINGW_PACKAGE_PREFIX}-opencl-icd"
              "${MINGW_PACKAGE_PREFIX}-opencl-headers"
-             "${MINGW_PACKAGE_PREFIX}-cppwinrt")
+             "${MINGW_PACKAGE_PREFIX}-cppwinrt"
+             "${MINGW_PACKAGE_PREFIX}-python")
 optdepends=("${MINGW_PACKAGE_PREFIX}-vulkan-loader: For Vulkan detection support"
             "${MINGW_PACKAGE_PREFIX}-opencl-icd: For OpenCL detection support"
             "${MINGW_PACKAGE_PREFIX}-chafa: For chafa image protocol support"
             "${MINGW_PACKAGE_PREFIX}-imagemagick: For sixel image protocol support")
 source=("https://github.com/fastfetch-cli/fastfetch/archive/${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('6ffd75c32b2a885fd8497867645ac837ed37d588c94e0df05408cdaa0c8fd2c7')
+noextract=("${_realname}-${pkgver}.tar.gz")
+sha256sums=('3bad5a66d8c641b69ed2e8c630eecb5eed8a6ee283a3b4fe97051b16cbef1b54')
+
+prepare() {
+  # Workaround for symlinks in archive, see <https://www.msys2.org/docs/symlinks/>.
+  bsdtar -xzf "${srcdir}/${_realname}-${pkgver}.tar.gz" 2>/dev/null || bsdtar -xzf "${srcdir}/${_realname}-${pkgver}.tar.gz"
+}
 
 build() {
   declare -a extra_config
@@ -55,6 +63,14 @@ build() {
     ../${_realname}-${pkgver}
 
   ${MINGW_PREFIX}/bin/cmake --build .
+}
+
+check() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  "${MINGW_PREFIX}"/bin/cmake -DBUILD_TESTS=ON ../${_realname}-${pkgver}
+  "${MINGW_PREFIX}"/bin/cmake --build .
+  "${MINGW_PREFIX}"/bin/ctest --output-on-failure
 }
 
 package() {


### PR DESCRIPTION
* workaround for symlinks in archive
* add python as makedepends
* add check()