### PR TITLE
arpack: Fix running parallel tests

### DIFF
--- a/mingw-w64-arpack/0001-parallel-tests.patch
+++ b/mingw-w64-arpack/0001-parallel-tests.patch
@@ -1,0 +1,35 @@
+--- arpack-ng-3.9.1/CMakeLists.txt.orig	2023-10-14 13:55:37.000000000 +0200
++++ arpack-ng-3.9.1/CMakeLists.txt	2025-11-26 11:01:34.458510600 +0100
+@@ -72,7 +72,7 @@
+         get_filename_component(lwe ${l} NAME_WE)
+         add_executable(${lwe} ${parpackexample_DIR}/${l} )
+         target_link_libraries(${lwe} parpack arpack MPI::MPI_Fortran)
+-        add_test(NAME "${lwe}_ex" COMMAND mpiexec -n 2 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${lwe})
++        add_test(NAME "${lwe}_ex" COMMAND ${MPIEXEC_EXECUTABLE} -n 2 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${lwe})
+     endforeach()
+ endfunction(pexamples)
+ 
+@@ -674,7 +674,7 @@
+ 
+     add_executable(issue46 PARPACK/TESTS/MPI/issue46.f)
+     target_link_libraries(issue46 parpack arpack BLAS::BLAS LAPACK::LAPACK ${EXTRA_LDFLAGS})
+-    add_test(issue46_tst mpiexec -n 2 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/issue46)
++    add_test(issue46_tst ${MPIEXEC_EXECUTABLE} -n 2 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/issue46)
+   endif()
+ 
+   if(ICB)
+@@ -783,12 +783,12 @@
+       add_executable(icb_parpack_c PARPACK/TESTS/MPI/icb_parpack_c.c)
+       target_include_directories(icb_parpack_c PUBLIC ${PROJECT_SOURCE_DIR}/ICB MPI::MPI_C) # Get parpack.h mpi.h
+       target_link_libraries(icb_parpack_c parpack arpack BLAS::BLAS LAPACK::LAPACK ${EXTRA_LDFLAGS} MPI::MPI_C)
+-      add_test(icb_parpack_c_tst mpiexec -n 2 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/icb_parpack_c)
++      add_test(icb_parpack_c_tst ${MPIEXEC_EXECUTABLE} -n 2 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/icb_parpack_c)
+ 
+       add_executable(icb_parpack_cpp PARPACK/TESTS/MPI/icb_parpack_cpp.cpp)
+       target_include_directories(icb_parpack_cpp PUBLIC ${PROJECT_SOURCE_DIR}/ICB MPI::MPI_CXX) # Get parpack.hpp mpi.h
+       target_link_libraries(icb_parpack_cpp parpack arpack BLAS::BLAS LAPACK::LAPACK ${EXTRA_LDFLAGS} MPI::MPI_CXX)
+-      add_test(icb_parpack_cpp_tst mpiexec -n 2 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/icb_parpack_cpp)
++      add_test(icb_parpack_cpp_tst ${MPIEXEC_EXECUTABLE} -n 2 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/icb_parpack_cpp)
+     endif()
+   endif()
+ endfunction(build_tests)

--- a/mingw-w64-arpack/PKGBUILD
+++ b/mingw-w64-arpack/PKGBUILD
@@ -10,7 +10,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          $([[ "${CARCH}" == "i686" ]] || echo "${MINGW_PACKAGE_PREFIX}-${_realname}64")
          $([[ "${CARCH}" != "x86_64" ]] || echo "${MINGW_PACKAGE_PREFIX}-p${_realname}"))
 pkgver=3.9.1
-pkgrel=5
+pkgrel=6
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 pkgdesc="Fortran77 subroutines designed to solve large scale eigenvalue problems (mingw-w64)"
@@ -25,8 +25,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-fc"
              $([[ "${CARCH}" == "i686" ]] || echo "${MINGW_PACKAGE_PREFIX}-openblas64"))
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}-ng")
 options=('!buildflags')
-source=(https://github.com/opencollab/arpack-ng/archive/${pkgver}/${_realname}-${pkgver}.tar.gz)
-sha256sums=('f6641deb07fa69165b7815de9008af3ea47eb39b2bb97521fbf74c97aba6e844')
+source=(https://github.com/opencollab/arpack-ng/archive/${pkgver}/${_realname}-${pkgver}.tar.gz
+        0001-parallel-tests.patch)
+sha256sums=('f6641deb07fa69165b7815de9008af3ea47eb39b2bb97521fbf74c97aba6e844'
+            '8bf923fb87d51bb313fc154d070941b932e74d6b7094e699fa84da6a913e3817')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -35,6 +37,13 @@ apply_patch_with_msg() {
     msg2 "Applying ${_fname}"
     patch -Nbp1 -i "${srcdir}"/${_fname}
   done
+}
+
+prepare() {
+  cd "${_realname}-ng-${pkgver}"
+
+  apply_patch_with_msg \
+    0001-parallel-tests.patch
 }
 
 _build_arpack() {
@@ -90,26 +99,47 @@ build() {
 }
 
 check() {
+  # This is the default installation location for Microsoft MPI.
+  # It might need to be adjusted dependent on the system where the tests are run.
+  MSMPI_BIN="/c/Program Files/Microsoft MPI/Bin"
+  #: ${MSMPI_BIN:="/c/Program Files/Microsoft MPI/Bin"}
+
   cd "${srcdir}/build-${MSYSTEM}-static-32"
   msg2 "Static check with 32-bit indexing"
-  ${MINGW_PREFIX}/bin/cmake -DTESTS=ON ../${_realname}-ng-${pkgver}
-  ${MINGW_PREFIX}/bin/cmake --build . --target test || true
+  ${MINGW_PREFIX}/bin/cmake \
+    -DTESTS=ON \
+    -DMPIEXEC_EXECUTABLE="${MSMPI_BIN}/mpiexec.exe" \
+    ../${_realname}-ng-${pkgver}
+  ${MINGW_PREFIX}/bin/cmake --build .
+  ${MINGW_PREFIX}/bin/ctest .
 
   cd "${srcdir}/build-${MSYSTEM}-shared-32"
   msg2 "Shared check with 32-bit indexing"
-  ${MINGW_PREFIX}/bin/cmake -DTESTS=ON ../${_realname}-ng-${pkgver}
-  ${MINGW_PREFIX}/bin/cmake --build . --target test || true
+  ${MINGW_PREFIX}/bin/cmake \
+    -DTESTS=ON \
+    -DMPIEXEC_EXECUTABLE="${MSMPI_BIN}/mpiexec.exe" \
+    ../${_realname}-ng-${pkgver}
+  ${MINGW_PREFIX}/bin/cmake --build .
+  ${MINGW_PREFIX}/bin/ctest .
 
   if [ "${CARCH}" != "i686" ]; then
     cd "${srcdir}/build-${MSYSTEM}-static-64"
     msg2 "Static check with 64-bit indexing"
-    ${MINGW_PREFIX}/bin/cmake -DTESTS=ON ../${_realname}-ng-${pkgver}
-    ${MINGW_PREFIX}/bin/cmake --build . --target test || true
+    ${MINGW_PREFIX}/bin/cmake \
+      -DTESTS=ON \
+      -DMPIEXEC_EXECUTABLE="${MSMPI_BIN}/mpiexec.exe" \
+      ../${_realname}-ng-${pkgver}
+    ${MINGW_PREFIX}/bin/cmake --build .
+    ${MINGW_PREFIX}/bin/ctest .
 
     cd "${srcdir}/build-${MSYSTEM}-shared-64"
     msg2 "Shared check with 64-bit indexing"
-    ${MINGW_PREFIX}/bin/cmake -DTESTS=ON ../${_realname}-ng-${pkgver}
-    ${MINGW_PREFIX}/bin/cmake --build . --target test || true
+    ${MINGW_PREFIX}/bin/cmake \
+      -DTESTS=ON \
+      -DMPIEXEC_EXECUTABLE="${MSMPI_BIN}/mpiexec.exe" \
+      ../${_realname}-ng-${pkgver}
+    ${MINGW_PREFIX}/bin/cmake --build .
+    ${MINGW_PREFIX}/bin/ctest .
   fi
 }
 


### PR DESCRIPTION
By default, the mpiexec executable is not on the PATH after installing MSMPI on Windows.

Change the check rules to point to the default installation location of that executable.

I tried to validate the changes from #27330 by re-building this pure-Fortran package when I came across this issue of its check rules. There should be no actual functional difference of the re-built package.

The packages built and their checks passed for me locally in the CLANG64 environment using the build artifacts from that PR.
