### PR TITLE
python-passagemath-iml: add version 10.6.46 (new package)

### DIFF
--- a/mingw-w64-passagemath-iml/PKGBUILD
+++ b/mingw-w64-passagemath-iml/PKGBUILD
@@ -1,0 +1,49 @@
+# Maintainer: Dirk Stolle
+
+_realname=passagemath-iml
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=10.6.46
+pkgrel=1
+pkgdesc="passagemath: Linear Algebra with IML (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64')
+url='https://github.com/passagemath/passagemath'
+msys2_references=(
+  'purl: pkg:pypi/passagemath-iml'
+)
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-gmp"
+         "${MINGW_PACKAGE_PREFIX}-iml"
+         "${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-cysignals"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-environment"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-categories"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-flint"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-modules")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cython"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-pkgconfig"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-setup"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
+sha256sums=('cb51b00e1ce5df512808028a9786d41caa4905a90f5139432e7e85a601a7060d')
+
+build() {
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+}


### PR DESCRIPTION
This PR adds python-passagemath-iml, a package to provide some functionality from passagemath (https://github.com/msys2/MINGW-packages/issues/24738). passagemath-m4ri-m4rie was added to passagemath in [passagemath 10.6.46](https://github.com/passagemath/passagemath/releases/tag/passagemath-10.6.46).

Note: For the check step to succeed, passagemath-environment, passagemath-categories, passagemath-flint and passagemath-modules need to be version 10.6.46, too. But that may not be the case (yet), because the passagemath 10.6.46 update has been merged only a few minutes ago.