### PR TITLE
plantri: add version 5.5 (new package)

### DIFF
--- a/mingw-w64-plantri/PKGBUILD
+++ b/mingw-w64-plantri/PKGBUILD
@@ -1,0 +1,61 @@
+# Maintainer: Dirk Stolle
+
+_realname=plantri
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=5.5
+pkgrel=1
+pkgdesc="Program for generation of certain types of planar graph (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://users.cecs.anu.edu.au/~bdm/plantri/'
+msys2_references=(
+  'archlinux: plantri'
+)
+license=('spdx:Apache-2.0')
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+source=("https://users.cecs.anu.edu.au/~bdm/plantri/plantri${pkgver/./}.tar.gz")
+sha256sums=('911cdf5bcca7294eb80f8f79fefc148183f7ba81da15b3aa4d6d2401a3bc7ded')
+
+prepare() {
+  cd "${_realname}${pkgver/./}"
+
+  # Delete hard-coded flags in makefile, we have our own values for that.
+  sed -e '/CC=/d' -e '/CFLAGS=/d' -e '/LDFLAGS=/d' -i makefile
+
+  # Do not measure CPU time, because that requires <sys/times.h> header which is
+  # not available in MSYS2 / MinGW64.
+  sed -e 's/#define CPUTIME 1/#define CPUTIME 0/' -i plantri.c
+}
+
+build() {
+  cd "${_realname}${pkgver/./}"
+
+  # Additional compiler flag to avoid <sys/times.h> stuff in fullgen.c.
+  CFLAGS+=" -DNOTIMES=1"
+
+  make
+}
+
+check() {
+  cd "${_realname}${pkgver/./}"
+
+  # There is no check target in makefile, so let's just call one of the programs instead.
+  ./fullgen.exe 20
+}
+
+package() {
+  cd "${_realname}${pkgver/./}"
+
+  # Makefile of plantri does not provide an install target, so we have to install everything here.
+
+  # executables
+  install -Dm755 "plantri.exe" "${pkgdir}${MINGW_PREFIX}/bin/plantri.exe"
+  install -Dm755 "fullgen.exe" "${pkgdir}${MINGW_PREFIX}/bin/fullgen.exe"
+  # documentation
+  install -Dm644 "plantri-guide.txt" "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}/plantri-guide.txt"
+  install -Dm644 "fullgen-guide.txt" "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}/fullgen-guide.txt"
+  #license
+  install -Dm644 "${srcdir}/${_realname}${pkgver/./}/LICENSE-2.0.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
This PR adds plantri (https://users.cecs.anu.edu.au/~bdm/plantri/), a program for generation of certain types of planar graph.
It's required as a dependency of passagemath-plantri.

plantri is also available in some other distributions, for example:
* Arch Linux: https://archlinux.org/packages/extra/x86_64/plantri/
* Fedora: https://packages.fedoraproject.org/pkgs/plantri/
* openSUSE: https://build.opensuse.org/package/show/openSUSE:Factory/plantri