### PR TITLE
ocaml: update to 5.4.0

### DIFF
--- a/mingw-w64-ocaml/PKGBUILD
+++ b/mingw-w64-ocaml/PKGBUILD
@@ -7,9 +7,9 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-compiler-libs"
          $( (( _bootstrap_flexdll )) && echo "${MINGW_PACKAGE_PREFIX}-flexdll-bootstrap"))
-pkgver=5.2.0
+pkgver=5.4.0
 pkgrel=1
-_flexdll_ver=0.43
+_flexdll_ver=0.44
 pkgdesc="An industrial strength programming language supporting functional, imperative and object-oriented styles (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64')
@@ -28,8 +28,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 source=("https://caml.inria.fr/distrib/ocaml-${pkgver%.*}/${_realname}-${pkgver}.tar.xz"
         "https://github.com/ocaml/flexdll/archive/${_flexdll_ver}/flexdll-${_flexdll_ver}.tar.gz"
         "0001-fix-misc-h.patch")
-sha256sums=('2f4bf479f51479f9bf8c7f1694a6ea7336bbf774f4ad6da6b59d1ad4939dd8a7'
-            '10e171ab7d2f8b2f238b53bb9944d4b26686f5703fbc1c059532791bc91be949'
+sha256sums=('dfaa8a2e11c799bc1765d8bef44911406ee5f4803027190382a939f88c912266'
+            'b7c6a92286f1f3065324d51083dcb16eec436a4e6e3b8df7cf836b6d7a8b9491'
             '24d20cc5fc9c0f70e5c54c2378f0be612ae474425dd5918b321469fb887eb358')
 install=ocaml-${MSYSTEM}.install
 
@@ -67,6 +67,10 @@ build() {
     --prefix=${MINGW_PREFIX} \
     --mandir=${MINGW_PREFIX}/share/man \
     "${_extra_config[@]}"
+
+  # The build rules force creating symlinks. But that causes issues if they end
+  # up in the binary package. Make copies instead.
+  sed -i 's/^LN = .*/LN = cp -pR/' Makefile.build_config
 
   make world.opt
 }


### PR DESCRIPTION
This is essentially the same as #27352 with an additional change to make sure that no symbolic links end up in the binary package.