### PR TITLE
python-ipython: update to 9.9.0

### DIFF
--- a/mingw-w64-python-ipython/PKGBUILD
+++ b/mingw-w64-python-ipython/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=ipython
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=8.37.0
-pkgrel=2
+pkgver=9.9.0
+pkgrel=1
 pkgdesc="An enhanced Interactive Python shell (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -20,6 +20,7 @@ license=('spdx:BSD-3-Clause')
 depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-colorama"
          "${MINGW_PACKAGE_PREFIX}-python-decorator"
+         "${MINGW_PACKAGE_PREFIX}-python-ipython-pygments-lexers"
          "${MINGW_PACKAGE_PREFIX}-python-jedi"
          "${MINGW_PACKAGE_PREFIX}-python-matplotlib-inline"
          "${MINGW_PACKAGE_PREFIX}-python-prompt_toolkit"
@@ -27,10 +28,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-stack-data"
          "${MINGW_PACKAGE_PREFIX}-python-traitlets"
          "winpty")
-if [[ ${CARCH} != i686 ]]; then
 optdepends=("${MINGW_PACKAGE_PREFIX}-python-qtconsole: for ipython qtconsole"
             "${MINGW_PACKAGE_PREFIX}-python-ipython-ipyparallel: for IPython.parallel")
-fi
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
@@ -43,7 +42,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest"
               "${MINGW_PACKAGE_PREFIX}-python-numpy")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('ca815841e1a41a1e6b73a0b08f3038af9b2252564d01fc405356d34033012216')
+sha256sums=('48fbed1b2de5e2c7177eefa144aba7fcb82dac514f09b57e2ac9da34ddb54220')
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"


### PR DESCRIPTION
* add dependency python-ipython-pygments-lexers
* make optdepends unconditionally, as i686 is no longer supported for it.