### PR TITLE
mcqd: add version 1.0.0 (new package)

### DIFF
--- a/mingw-w64-mcqd/PKGBUILD
+++ b/mingw-w64-mcqd/PKGBUILD
@@ -1,0 +1,39 @@
+# Contributor: Dirk Stolle
+
+_realname=mcqd
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.0.0
+pkgrel=1
+pkgdesc="Maximum Clique Algorithm for finding a maximum clique in an undirected graph (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='http://insilab.org/maxclique/'
+msys2_references=(
+  'archlinux: mcqd'
+)
+license=('spdx:GPL-3.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-cc-libs")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
+source=("https://gitlab.com/janezkonc/mcqd/-/archive/v${pkgver}/mcqd-v${pkgver}.tar.gz")
+sha256sums=('37ff68ff88e047c929990d4c12ce474753f6f9c49324661a3aa1cfe77c26ad9d')
+
+build() {
+  mkdir -p "build-${MSYSTEM}" && cd "build-${MSYSTEM}"
+
+  ${CXX} ${CXXFLAGS} ${LDFLAGS} ../${_realname}-v${pkgver}/mcqd.cpp -o mcqd.exe
+}
+
+check() {
+  cd "build-${MSYSTEM}"
+
+  ./mcqd.exe ../${_realname}-v${pkgver}/test.clq
+}
+
+package() {
+  cd "build-${MSYSTEM}"
+
+  install -Dm755 "${srcdir}/build-${MSYSTEM}/mcqd.exe" "${pkgdir}${MINGW_PREFIX}/bin//mcqd.exe"
+  install -Dm644 "${srcdir}/${_realname}-v${pkgver}/mcqd.h" "${pkgdir}${MINGW_PREFIX}/include//mcqd.h"
+  install -Dm644 "${srcdir}/${_realname}-v${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}


### PR DESCRIPTION
This PR adds MaxCliqueDyn (mcqd), a "fast exact algorithm for finding a maximum clique in an undirected graph" (http://insilab.org/maxclique/).

It's required as a dependency of passagemath-mcqd.

mcqd is also available in a few other distributions, for example:
* Arch Linux: https://archlinux.org/packages/extra/x86_64/mcqd/
* openSUSE: https://build.opensuse.org/package/show/openSUSE:Factory/mcqd