### PR TITLE
python-passagemath-graphs: add new optional dependencies

### DIFF
--- a/mingw-w64-passagemath-graphs/PKGBUILD
+++ b/mingw-w64-passagemath-graphs/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=10.6.47
-pkgrel=1
+pkgrel=2
 pkgdesc="passagemath: Graphs, posets, hypergraphs, designs, abstract complexes, combinatorial polyhedra, abelian sandpiles, quivers (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -34,8 +34,11 @@ optdepends=(
   "${MINGW_PACKAGE_PREFIX}-python-passagemath-cliquer: find cliques in graphs with cliquer"
   "${MINGW_PACKAGE_PREFIX}-python-passagemath-cmr: combinatorial matrix recognition"
   "${MINGW_PACKAGE_PREFIX}-python-passagemath-homfly: Homfly polynomials of knots/links with libhomfly"
+  "${MINGW_PACKAGE_PREFIX}-python-passagemath-mcqd: finding maximum cliques with mcqd"
   "${MINGW_PACKAGE_PREFIX}-python-passagemath-nauty: find automorphism groups of graphs, generate non-isomorphic graphs with nauty"
   "${MINGW_PACKAGE_PREFIX}-python-passagemath-planarity: graph planarity with the planarity suite"
+  "${MINGW_PACKAGE_PREFIX}-python-passagemath-plantri: generating planar graphs with plantri and fullgen"
+  "${MINGW_PACKAGE_PREFIX}-python-passagemath-polyhedra: Convex polyhedra in arbitrary dimension, mixed integer linear optimization"
   "${MINGW_PACKAGE_PREFIX}-python-passagemath-rankwidth: rankwidth and rank decompositions of graphs with rw"
   "${MINGW_PACKAGE_PREFIX}-python-passagemath-tdlib: tree decompositions with tdlib"
 )


### PR DESCRIPTION
A few more passagemath packages have been added in the recent weeks, so a few more optional dependencies can be added to passagemath-graphs.