### PR TITLE
llvm-openmp: Export symbols with gfortran name mangling

### DIFF
--- a/mingw-w64-llvm-openmp/003-export-symbols-with-name-mangling-for-flang.patch
+++ b/mingw-w64-llvm-openmp/003-export-symbols-with-name-mangling-for-flang.patch
@@ -1,0 +1,131 @@
+From dcac047d58084fe74c9c314a3f04446a2b8059a5 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Markus=20M=C3=BCtzel?= <markus.muetzel@gmx.de>
+Date: Sun, 18 Jan 2026 09:56:36 +0100
+Subject: [PATCH] [openmp]: Export symbols with gfortran name mangling
+
+LLVM Flang lowers OpenMP instructions to name mangled symbols with trailing
+underscore which leads to linker errors like the following:
+```
+ld.lld: error: undefined symbol: omp_get_thread_num_
+```
+
+Work around that by exporting symbols with the name mangling used by LLVM
+Flang for MinGW targets (which is the gfortran name mangling).
+---
+ runtime/src/CMakeLists.txt       |  1 +
+ runtime/src/kmp_ftn_gfortran.cpp | 32 +++++++++++++++++++++++++
+ runtime/src/kmp_version.h        |  1 +
+ runtime/tools/generate-def.py    | 28 ++++++++++++++++++++++
+ 4 files changed, 62 insertions(+)
+ create mode 100644 runtime/src/kmp_ftn_gfortran.cpp
+
+diff --git a/runtime/src/CMakeLists.txt b/runtime/src/CMakeLists.txt
+index 0c0804776a77..dc143321b744 100644
+--- a/runtime/src/CMakeLists.txt
++++ b/runtime/src/CMakeLists.txt
+@@ -138,6 +138,7 @@ endif()
+ # Files common to stubs and normal library
+ libomp_append(LIBOMP_CXXFILES kmp_ftn_cdecl.cpp)
+ libomp_append(LIBOMP_CXXFILES kmp_ftn_extra.cpp)
++libomp_append(LIBOMP_CXXFILES kmp_ftn_gfortran.cpp)
+ libomp_append(LIBOMP_CXXFILES kmp_version.cpp)
+ libomp_append(LIBOMP_CXXFILES ompt-general.cpp IF_TRUE LIBOMP_OMPT_SUPPORT)
+ libomp_append(LIBOMP_CXXFILES ompd-specific.cpp IF_TRUE LIBOMP_OMPD_SUPPORT)
+diff --git a/runtime/src/kmp_ftn_gfortran.cpp b/runtime/src/kmp_ftn_gfortran.cpp
+new file mode 100644
+index 000000000000..d8993180730b
+--- /dev/null
++++ b/runtime/src/kmp_ftn_gfortran.cpp
+@@ -0,0 +1,32 @@
++/*
++ * kmp_ftn_gfortran.cpp -- Fortran gfortran linkage support for OpenMP.
++ */
++
++//===----------------------------------------------------------------------===//
++//
++// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
++// See https://llvm.org/LICENSE.txt for license information.
++// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
++//
++//===----------------------------------------------------------------------===//
++
++#include "kmp.h"
++#include "kmp_affinity.h"
++
++#if KMP_OS_WINDOWS
++#if defined(__MINGW32__)
++#define KMP_FTN_ENTRIES KMP_FTN_APPEND
++#endif
++#endif
++
++// Note: This string is not printed when KMP_VERSION=1.
++char const __kmp_version_ftngfortran[] =
++    KMP_VERSION_PREFIX "Fortran gfortran OMP support: "
++#ifdef KMP_FTN_ENTRIES
++                       "yes";
++#define FTN_STDCALL /* no stdcall */
++#include "kmp_ftn_os.h"
++#include "kmp_ftn_entry.h"
++#else
++                       "no";
++#endif /* KMP_FTN_ENTRIES */
+diff --git a/runtime/src/kmp_version.h b/runtime/src/kmp_version.h
+index 6ce40eecb5de..34b7b33210e8 100644
+--- a/runtime/src/kmp_version.h
++++ b/runtime/src/kmp_version.h
+@@ -55,6 +55,7 @@ extern char const __kmp_version_nested_stats_reporting[];
+ extern char const __kmp_version_ftnstdcall[];
+ extern char const __kmp_version_ftncdecl[];
+ extern char const __kmp_version_ftnextra[];
++extern char const __kmp_version_ftngfortran[];
+ 
+ void __kmp_print_version_1(void);
+ void __kmp_print_version_2(void);
+diff --git a/runtime/tools/generate-def.py b/runtime/tools/generate-def.py
+index 6781fe74fdc1..b5190a668081 100644
+--- a/runtime/tools/generate-def.py
++++ b/runtime/tools/generate-def.py
+@@ -50,6 +50,33 @@ class DllExports(object):
+                     "ordinal": newordinal,
+                 }
+ 
++    def add_underscore_entries(self):
++        # Ignored entries are C/C++ only functions
++        ignores = [
++            "omp_alloc",
++            "omp_free",
++            "omp_calloc",
++            "omp_realloc",
++            "omp_aligned_alloc",
++            "omp_aligned_calloc",
++        ]
++        keys = list(self.exports.keys())
++        for entry in keys:
++            info = self.exports[entry]
++            if info["obsolete"] or info["is_data"] or entry in ignores:
++                continue
++            if entry.startswith("omp_") or entry.startswith("kmp_"):
++                newentry = entry + "_"
++                if info["ordinal"]:
++                    newordinal = info["ordinal"] + 2000
++                else:
++                    newordinal = None
++                self.exports[newentry] = {
++                    "obsolete": False,
++                    "is_data": False,
++                    "ordinal": newordinal,
++                }
++
+     @staticmethod
+     def create(inputFile, defs=None):
+         """Creates DllExports object from inputFile"""
+@@ -226,6 +253,7 @@ def main():
+         defs = set(commandArgs.defs)
+     dllexports = DllExports.create(commandArgs.dllexports, defs)
+     dllexports.add_uppercase_entries()
++    dllexports.add_underscore_entries()
+     try:
+         output = open(commandArgs.output, "w") if commandArgs.output else sys.stdout
+         generate_def(dllexports, output, commandArgs.no_ordinals, commandArgs.name)
+-- 
+2.51.0.windows.2

--- a/mingw-w64-llvm-openmp/PKGBUILD
+++ b/mingw-w64-llvm-openmp/PKGBUILD
@@ -9,7 +9,7 @@ pkgbase=mingw-w64-llvm-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-llvm-${_realname}")
 _pkgver=21.1.8
 pkgver=${_pkgver/-/}
-pkgrel=1
+pkgrel=2
 pkgdesc="LLVM OpenMP Library (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -35,13 +35,15 @@ _pkgfn=${_realname}-${_pkgver}.src
 source=($_url/$_pkgfn.tar.xz{,.sig}
         ${_url}/cmake-${pkgver}.src.tar.xz{,.sig}
         "001-cast-to-make-gcc-happy.patch"
-        "002-hacks-for-static-linking.patch")
+        "002-hacks-for-static-linking.patch"
+        "003-export-symbols-with-name-mangling-for-flang.patch")
 sha256sums=('856b023748b41ac7b2c83fd8e9f765ff48a4df2fe6777d2811ef7c7ed8f2f977'
             'SKIP'
             '85735f20fd8c81ecb0a09abb0c267018475420e93b65050cc5b7634eab744de9'
             'SKIP'
             '11352ffbe7559a7170f2abd52b3552c877fbcf8fc82cff77b421e8b130a4dd66'
-            '08e39ea52a99204528740196a13cc29daf1b65a6e230fbd7bdd745dde5d11ef3')
+            '08e39ea52a99204528740196a13cc29daf1b65a6e230fbd7bdd745dde5d11ef3'
+            'fa81c3b1c937f090129f74a7553b4c2cbcf0e1fb223cff020cf1a7357441d147')
 validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Google.
               '474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard
               '71046D1E9C6656BDD61171873E83BABF4A4F9E85'  # Cullen Rhodes
@@ -65,7 +67,9 @@ prepare() {
     apply_patch_with_msg \
       "001-cast-to-make-gcc-happy.patch"
   fi
-  apply_patch_with_msg 002-hacks-for-static-linking.patch
+  apply_patch_with_msg \
+    002-hacks-for-static-linking.patch \
+    003-export-symbols-with-name-mangling-for-flang.patch
 }
 
 build() {


### PR DESCRIPTION
LLVM Flang lowers OpenMP functions to name mangled symbols with trailing underscore which leads to linker errors like the following:
```
ld.lld: error: undefined symbol: omp_get_thread_num_
```

Work around that by exporting symbols with the name mangling used by LLVM Flang for MinGW targets (which is the gfortran name mangling).