### PR TITLE
ogre3d: Update to 14.5.1 and fix Bites loading of its own DLL

### DIFF
--- a/mingw-w64-ogre3d/017-samplebrowser-ogrebites-rc.patch
+++ b/mingw-w64-ogre3d/017-samplebrowser-ogrebites-rc.patch
@@ -1,0 +1,26 @@
+diff -bur ogre-14.5.1-orig/Components/Bites/src/OgreWIN32ConfigDialog.cpp ogre-14.5.1/Components/Bites/src/OgreWIN32ConfigDialog.cpp
+--- ogre-14.5.1-orig/Components/Bites/src/OgreWIN32ConfigDialog.cpp	2026-01-18 13:17:46.218635200 -0700
++++ ogre-14.5.1/Components/Bites/src/OgreWIN32ConfigDialog.cpp	2026-01-18 14:12:13.403028500 -0700
+@@ -59,6 +59,10 @@
+ #endif
+     };
+ 
++// Stringify macros for version numbers
++#define OGRE_BITES_STRINGIFY(x) #x
++#define OGRE_BITES_TOSTRING(x) OGRE_BITES_STRINGIFY(x)
++
+     ConfigDialog::ConfigDialog() : mImpl(new ConfigDialog::PrivateData())
+     {
+ 		#ifdef __MINGW32__
+@@ -66,9 +70,9 @@
+                 mImpl->mHInstance = GetModuleHandle( NULL );
+ 			#else
+ 				#if OGRE_DEBUG_MODE == 1
+-        		    mImpl->mHInstance = GetModuleHandle("OgreMain_d.dll");
++        		    mImpl->mHInstance = GetModuleHandle("OgreBites_d-" OGRE_BITES_TOSTRING(OGRE_VERSION_MAJOR) "." OGRE_BITES_TOSTRING(OGRE_VERSION_MINOR) ".dll");
+ 				#else
+-					mImpl->mHInstance = GetModuleHandle("OgreMain.dll");
++					mImpl->mHInstance = GetModuleHandle("OgreBites-" OGRE_BITES_TOSTRING(OGRE_VERSION_MAJOR) "." OGRE_BITES_TOSTRING(OGRE_VERSION_MINOR) ".dll");
+ 				#endif
+ 			#endif
+ 		#else

--- a/mingw-w64-ogre3d/PKGBUILD
+++ b/mingw-w64-ogre3d/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=ogre3d
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=14.5.0
-_imgui_ver=1.92.1
+pkgver=14.5.1
+_imgui_ver=1.92.5
 pkgrel=1
 pkgdesc="A cross-platform 3D game engine (mingw-w64)"
 arch=('any')
@@ -46,14 +46,16 @@ source=("https://github.com/OGRECave/ogre/archive/v${pkgver}/${_realname}-${pkgv
         004-use-mingw-w64-directx.patch
         010-missing-include.patch
         015-export-symbols-samples-plugin.patch
-        016-fix-plugins-install-destination.patch)
-sha256sums=('ed8455e766c039ff3f2815ebcb1a976a49789741b4e4f49b3364b5f35d0b717a'
-            '32c237c2abf67a2ffccaac17192f711d4a787554b4133187a153d49057d6109c'
+        016-fix-plugins-install-destination.patch
+        017-samplebrowser-ogrebites-rc.patch)
+sha256sums=('7be194cd8ca5a075c2786bd76b7fce14ce3aa7e96fb4687ba6d68d8db940225d'
+            '0eb50fe9aeba1a51f96b5843c7f630a32ed2e9362d693c61b87e4fa870cf826d'
             '81fbe2f951be7f5b5bded24a3050be3188e164d321df9124b5abfb543234a128'
             'c7ca64dbd9a8f3f0271c12739807021a5c0782d254c4142c6e86746a96a44438'
             '2850af66e34003415e86b4f17c24e117b221f64ab98e1cef45b5102c9c48350d'
             '004842e88cbbc76d09356fbddf5bc123b1b0fc7b2e64b8677b2a2316df7d9099'
-            'ed6e383b1b4f1b84f1e93288540789c8fca0693a5dc9e3b4f840a63adbf5daac')
+            'ed6e383b1b4f1b84f1e93288540789c8fca0693a5dc9e3b4f840a63adbf5daac'
+            '3edd27a5b35e794cdd7075bea27ba1455e81c4130afdc039a4675bad8c627b6d')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -70,7 +72,8 @@ prepare() {
     004-use-mingw-w64-directx.patch \
     010-missing-include.patch \
     015-export-symbols-samples-plugin.patch \
-    016-fix-plugins-install-destination.patch
+    016-fix-plugins-install-destination.patch \
+    017-samplebrowser-ogrebites-rc.patch
 }
 
 build() {


### PR DESCRIPTION
Fixes https://github.com/msys2/MINGW-packages/issues/27209
<img width="913" height="862" alt="image" src="https://github.com/user-attachments/assets/ac252822-8364-4b41-a06c-93e5520ddcad" />
<img width="1509" height="1169" alt="image" src="https://github.com/user-attachments/assets/462c4b1a-afc7-46fa-8696-2c9e0b6f9fc6" />

