### PR TITLE
poco: Fix missing symbol in Poco::Net and enable aarch64 builds

### DIFF
--- a/mingw-w64-poco/PKGBUILD
+++ b/mingw-w64-poco/PKGBUILD
@@ -4,10 +4,10 @@ _realname=poco
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.14.2
-pkgrel=1
+pkgrel=2
 pkgdesc="POrtable COmponents C++ Libraries (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://pocoproject.org/"
 msys2_references=(
   "cpe: cpe:2.3:a:pocoproject:poco"
@@ -34,12 +34,14 @@ source=(https://pocoproject.org/releases/${_realname}-${pkgver}/${_realname}-${p
         001-fix-build-on-mingw.patch
         011-cmake-mingw.patch
         012-dll-resources.patch
-        013-templates-export.patch)
+        013-templates-export.patch
+        014-poco-net-attribute-order.patch::https://github.com/pocoproject/poco/pull/5167.patch)
 sha256sums=('7738a4c880f08e89318fc53915f86be5a0e70f14eb1e7f0e1767c8781c40d794'
             '2b2a4ccc48061874a8c8d36d96ac6f2d40b01130a5c10816232cba1988a6c97a'
             'c5084394e28bf9bcfaaa3491ff28ca963efd57a79fb20aea6368f0a2490fb1ea'
             '8059fc9bb6b158f7705323358d38c9d952061b546d6ae8fbd3c4ac2493677a0a'
-            '6d67531c0c11f6fd3892a899230c746ad0dc7d7c6e11146e4b81b3b1031b1a9f')
+            '6d67531c0c11f6fd3892a899230c746ad0dc7d7c6e11146e4b81b3b1031b1a9f'
+            '745f84373f242d7ca86bf23d3093022524d993e88120a10e59d2f73ef7b5b495')
 
 _apply_patch_with_msg() {
   for _patch in "$@"
@@ -55,7 +57,8 @@ prepare() {
     001-fix-build-on-mingw.patch \
     011-cmake-mingw.patch \
     012-dll-resources.patch \
-    013-templates-export.patch
+    013-templates-export.patch \
+    014-poco-net-attribute-order.patch
 }
 
 build() {


### PR DESCRIPTION
Fixes https://github.com/msys2/MINGW-packages/issues/27016
```cpp
#include <Poco/Net/Net.h>

int main()
{
    auto &net = pocoNetworkInitializer;

    return 0;
}
```
```
 objdump -p poco-test.exe | grep -B 2 pocoNetworkInitializer
        DLL Name: libPocoNet-112.dll
        vma:     Ordinal  Hint  Member-Name  Bound-To
        00008410  <none>  0e10  pocoNetworkInitializer
```