### PR TITLE
qpdf: update to 12.3.1

### DIFF
--- a/mingw-w64-qpdf/PKGBUILD
+++ b/mingw-w64-qpdf/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=qpdf
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=12.3.0
+pkgver=12.3.1
 pkgrel=1
 pkgdesc="QPDF: A Content-Preserving PDF Transformation System (mingw-w64)"
 arch=('any')
@@ -22,11 +22,10 @@ depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
          "${MINGW_PACKAGE_PREFIX}-gnutls"
          "${MINGW_PACKAGE_PREFIX}-libjpeg"
          "${MINGW_PACKAGE_PREFIX}-zlib")
-source=(https://github.com/qpdf/qpdf/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz{,.asc}
+source=(https://github.com/qpdf/qpdf/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz
         001-do-not-copy-dlls.patch
         002-do-not-change-library-prefix-and-suffix.patch)
-sha256sums=('5e59dbea264ce096bcaf230ea2a2fb1d991a9d56d940fd54c1a7570b48dde04b'
-            'SKIP'
+sha256sums=('6de2a390b807a881bba2ab1abb080e985c2338a64137807ed28a946a258ffc89'
             '4e1193db33b7887d3a751e41463af0e1fb3734aadcf5c5ffed1336b5ec54b84e'
             '423f029fd9edd3712423e69aadcac704e4c04e2220f47e17c2585c332def23a1')
 validpgpkeys=('C2C96B10011FE009E6D1DF828A75D10998012C7E') # Jay Berkenbilt <ejb@ql.org>


### PR DESCRIPTION
Signature file is not provided for release 12.3.1.
Maybe they will add it later?