### PR TITLE
amf-headers: update to 1.5.0

### DIFF
--- a/mingw-w64-amf-headers/PKGBUILD
+++ b/mingw-w64-amf-headers/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=amf-headers
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.4.36.0
+pkgver=1.5.0
 pkgrel=1
 pkgdesc='Header files for AMD Advanced Media Framework (mingw-w64)'
 arch=('any')
@@ -11,7 +11,7 @@ mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://github.com/GPUOpen-LibrariesAndSDKs/AMF/'
 license=('spdx:MIT')
 source=("https://github.com/GPUOpen-LibrariesAndSDKs/AMF/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('4abdf1ffecbffc78bfd74a9376595d14aecfa1a419147bcaa6113cf24bb28060')
+sha256sums=('bf80ee4a77a731c5a2351b4dd74f524a18806a70099ba66a8058d91aac1150b5')
 
 prepare() {
   cd "AMF-${pkgver}"


### PR DESCRIPTION
Needed to fix FFmpeg build after: https://code.ffmpeg.org/FFmpeg/FFmpeg/pulls/21015
See: https://fate.ffmpeg.org/report.cgi?slot=msys2-clang64&time=20260120000751