### PR TITLE
[new package] Arrow ADBC 22

### DIFF
--- a/mingw-w64-arrow-adbc/PKGBUILD
+++ b/mingw-w64-arrow-adbc/PKGBUILD
@@ -1,0 +1,148 @@
+# Maintainer: Taozuhong <taozuhong@gmail.com>
+
+_realname=arrow-adbc
+pkgbase=mingw-w64-${_realname}
+pkgname=(
+  "${MINGW_PACKAGE_PREFIX}-${_realname}"
+  "${MINGW_PACKAGE_PREFIX}-${_realname}-driver-bigquery"
+  "${MINGW_PACKAGE_PREFIX}-${_realname}-driver-flightsql"
+  "${MINGW_PACKAGE_PREFIX}-${_realname}-driver-postgresql"
+  "${MINGW_PACKAGE_PREFIX}-${_realname}-driver-sqlite"
+  "${MINGW_PACKAGE_PREFIX}-${_realname}-driver-snowflake"
+)
+pkgver=22
+pkgrel=1
+pkgdesc="Database connectivity API for Apache Arrow (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url="https://arrow.apache.org/adbc/current/index.html"
+license=('Apache-2.0')
+depends=("${MINGW_PACKAGE_PREFIX}-arrow"
+         "${MINGW_PACKAGE_PREFIX}-nanoarrow")
+makedepends=("git"
+			 "${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-go"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+			 "${MINGW_PACKAGE_PREFIX}-postgresql"
+             "${MINGW_PACKAGE_PREFIX}-pkgconf")
+options=('staticlibs' 'strip' 'emptydirs')
+source=("$_realname::git+https://github.com/apache/arrow-adbc#tag=apache-arrow-adbc-$pkgver")
+# sha256sums=('SKIP')
+sha512sums=('8a33b7655d2c09d57888fc59d314320296f8d5590c8fcc5282be27a91354be070bf3988daaf5393fe6bea6f72e9b4d37586a64f3a9548899bb5246d30f13449d')
+
+
+build() {
+  cd "${srcdir}/arrow-adbc"
+   
+  # Update Go compiler path 
+  export GOROOT=${MINGW_PREFIX}/lib/go
+  
+  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
+  mkdir -p ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}  
+  
+  declare -a _extra_config
+  if check_option "debug" "n"; then
+    _extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    _extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    "${MINGW_PREFIX}"/bin/cmake.exe \
+      -GNinja \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+	  -D CMAKE_BUILD_TYPE=Release
+	  -D CMAKE_INSTALL_PREFIX=/usr
+	  -D ADBC_BUILD_PYTHON=ON \
+	  -D ADBC_DRIVER_MANAGER=ON \
+	  -D ADBC_DRIVER_BIGQUERY=ON \
+	  -D ADBC_DRIVER_FLIGHTSQL=ON \
+	  -D ADBC_DRIVER_POSTGRESQL=ON \
+	  -D ADBC_DRIVER_SQLITE=ON \
+	  -D ADBC_DRIVER_SNOWFLAKE=ON \
+	  -W no-dev \
+      "${_extra_config[@]}" \
+      ${srcdir}/arrow-adbc/c
+
+  "${MINGW_PREFIX}"/bin/cmake.exe --build .
+}
+
+package_arrow-adbc() {
+  depends=(
+    glibc
+    gcc-libs
+  )
+  optdepends=(
+    '${MINGW_PACKAGE_PREFIX}-${_realname}-driver-bigquery: BigQuery driver'
+    '${MINGW_PACKAGE_PREFIX}-${_realname}-driver-flightsql: Flight SQL driver'
+    '${MINGW_PACKAGE_PREFIX}-${_realname}-driver-postgresql: PostgreSQL driver'
+    '${MINGW_PACKAGE_PREFIX}-${_realname}-driver-sqlite: SQLite driver'
+    '${MINGW_PACKAGE_PREFIX}-${_realname}-driver-snowflake: Snowflake driver'
+  )
+
+  cd "${srcdir}/build-${MINGW_CHOST}/adbc_driver_manager"
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
+}
+
+package_arrow-adbc-driver-bigquery() {
+  pkgdesc+=' - BigQuery driver'
+  depends=(
+    glibc
+    gcc-libs
+    ${MINGW_PACKAGE_PREFIX}-${_realname}
+  )
+
+  cd "${srcdir}/build-${MINGW_CHOST}/adbc_driver_bigquery"
+  # python -m installer --destdir="$pkgdir" dist/*.whl
+}
+
+package_arrow-adbc-driver-flightsql() {
+  pkgdesc+=' - Flight SQL driver'
+  depends=(
+    glibc
+    gcc-libs
+    ${MINGW_PACKAGE_PREFIX}-${_realname}
+ )
+
+  cd "${srcdir}/build-${MINGW_CHOST}/adbc_driver_flightsql"
+  # python -m installer --destdir="$pkgdir" dist/*.whl
+}
+
+package_arrow-adbc-driver-postgresql() {
+  pkgdesc+=' - PostgreSQL driver'
+  depends=(
+    glibc
+    gcc-libs
+    ${MINGW_PACKAGE_PREFIX}-${_realname}
+    postgresql-libs
+  )
+
+  cd "${srcdir}/build-${MINGW_CHOST}/adbc_driver_postgresql"
+  # python -m installer --destdir="$pkgdir" dist/*.whl
+}
+
+package_arrow-adbc-driver-sqlite() {
+  pkgdesc+=' - SQLite driver'
+  depends=(
+    glibc
+    gcc-libs
+    ${MINGW_PACKAGE_PREFIX}-${_realname}
+    sqlite
+  )
+
+  cd "${srcdir}/build-${MINGW_CHOST}/adbc_driver_sqlite"
+  # python -m installer --destdir="$pkgdir" dist/*.whl
+}
+
+package_arrow-adbc-driver-snowflake() {
+  pkgdesc+=' - Snowflake driver'
+  depends=(
+    glibc
+    gcc-libs
+    ${MINGW_PACKAGE_PREFIX}-${_realname}
+  )
+
+  cd "${srcdir}/build-${MINGW_CHOST}/adbc_driver_snowflake"
+  # python -m installer --destdir="$pkgdir" dist/*.whl
+}


### PR DESCRIPTION
I need help, thanks in advance.
```
==> Making package: mingw-w64-arrow-adbc 22-1 (Tue Jan 20 16:26:55 2026)
==> Checking runtime dependencies...
==> Checking buildtime dependencies...
==> Retrieving sources...
  -> Cloning arrow-adbc git repo...
Cloning into bare repository '/d/Github/msys/arrow-adbc'...
fatal: unable to access 'https://github.com/apache/arrow-adbc/': SSL certificate OpenSSL verify result: unable to get local issuer certificate (20)
==> ERROR: Failure while downloading arrow-adbc git repo
    Aborting...
```
