### PR TITLE
[New package] arrow-adbc-glib 22

### DIFF
--- a/mingw-w64-arrow-adbc-glib/PKGBUILD
+++ b/mingw-w64-arrow-adbc-glib/PKGBUILD
@@ -11,13 +11,13 @@ mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://github.com/apache/arrow-adbc"
 license=('Apache-2.0')
 depends=("${MINGW_PACKAGE_PREFIX}-glib2"
-         "${MINGW_PACKAGE_PREFIX}-arrow"
-         "${MINGW_PACKAGE_PREFIX}-nanoarrow"
          "${MINGW_PACKAGE_PREFIX}-arrow-adbc")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
         "${MINGW_PACKAGE_PREFIX}-cmake"
 		"${MINGW_PACKAGE_PREFIX}-meson"
         "${MINGW_PACKAGE_PREFIX}-ninja"
+        "${MINGW_PACKAGE_PREFIX}-arrow"
+        "${MINGW_PACKAGE_PREFIX}-nanoarrow"
 		"${MINGW_PACKAGE_PREFIX}-gobject-introspection"
         "${MINGW_PACKAGE_PREFIX}-pkgconf")
 options=('staticlibs' 'strip' 'emptydirs')


### PR DESCRIPTION
Add PKGBUILD for mingw-w64-arrow-adbc-glib package, 

it depends on mingw-w64-arrow-adbc package, pls merge it first.