### PR TITLE
emacs-pdf-tools-server: Update to 1.3.0

### DIFF
--- a/mingw-w64-emacs-pdf-tools-server/PKGBUILD
+++ b/mingw-w64-emacs-pdf-tools-server/PKGBUILD
@@ -4,7 +4,7 @@ _realname=emacs-pdf-tools-server
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 # Issues may arise if not used with the same release of the pdf-tools emacs package
-pkgver=1.1.0
+pkgver=1.3.0
 pkgrel=1
 pkgdesc="Emacs support library for PDF files (mingw-w64)"
 arch=("any")
@@ -25,7 +25,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 optdepends=("${MINGW_PACKAGE_PREFIX}-imagemagick")
 source=("https://github.com/vedang/pdf-tools/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
 noextract=(${_realname}-${pkgver}.tar.gz)
-sha256sums=("bb5badef03e27411e62290d71c9e4657952230b6bd557c8523699d42c30a3866")
+sha256sums=("0bc01cb55eaf82d0a2e9209c4dcc9a25eb986381f414f5625e5b5cfd7b06c9bc")
 
 prepare() {
   # Workaround for symlinks in tarball and the different package and git repo
@@ -44,8 +44,6 @@ prepare() {
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
 
-  # For vasprintf
-  CFLAGS+=" -D_GNU_SOURCE" \
   CXXFLAGS+=" -std=c++17" \
   ../"${_realname}-${pkgver}"/server/configure \
     --prefix="${MINGW_PREFIX}" \


### PR DESCRIPTION
Previous workaround for `vasprintf` was fixed upstream [1]

[1]: https://github.com/vedang/pdf-tools/pull/308