### PR TITLE
python-pycparser: Update to 3.0

### DIFF
--- a/mingw-w64-python-pycparser/PKGBUILD
+++ b/mingw-w64-python-pycparser/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=pycparser
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=2.23
-pkgrel=2
+pkgver=3.0
+pkgrel=1
 pkgdesc='Complete parser of the C language, written in pure Python (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -21,25 +21,24 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2')
+sha256sums=('600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29')
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
-  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
-  cd pycparser
-  ${MINGW_PREFIX}/bin/python _build_tables.py
+
+  python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 check() {
   cd "${srcdir}/python-build-${MSYSTEM}"
-  ${MINGW_PREFIX}/bin/python -m unittest discover
+  python -m unittest discover
 }
 
 package() {
   cd "${srcdir}"/python-build-${MSYSTEM}
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    python -m installer --prefix=${MINGW_PREFIX} \
     --destdir="${pkgdir}" dist/*.whl
   
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"


### PR DESCRIPTION
_build_tables is gone, and in theory only needed when the ast is patched, which we don't do from what I see