### PR TITLE
arturo: add version 0.10.0 - Arizona Bark (new package)

### DIFF
--- a/mingw-w64-arturo/001-no-static-linking.patch
+++ b/mingw-w64-arturo/001-no-static-linking.patch
@@ -1,0 +1,63 @@
+--- a/build.nims
++++ b/build.nims
+@@ -188,7 +188,7 @@
+         if config.isDeveloper and not flags.contains("NOWEBVIEW"):
+             discard gorgeEx "src\\extras\\webview\\deps\\build.bat"
+             #discard gorgeEx "src\\extras\\webview\\deps\\build-new.bat"
+-        --passL:"\"-static-libstdc++ -static-libgcc -Wl,-Bstatic -lstdc++ -Wl,-Bdynamic\""
++        --passL:""
+         --gcc.linkerexe:"g++"
+ 
+     proc unixHostSpecific() =
+--- a/src/extras/pfd.nim
++++ b/src/extras/pfd.nim
+@@ -20,14 +20,14 @@
+ #=======================================
+ 
+ when defined(windows):
+-    {.compile("pfd/pfd.cc","-std=c++11 -static-libstdc++ -DSTRSAFE_NO_DEPRECATE").}
++    {.compile("pfd/pfd.cc","-std=c++11 -DSTRSAFE_NO_DEPRECATE").}
+ else:
+     {.compile("pfd/pfd.cc","-std=c++11").}
+ 
+ {.passC: "-I" & parentDir(currentSourcePath()) .}
+ 
+ when defined(windows):
+-    {.passL:"-static-libstdc++ -L -lversion -lole32 -luuid -lshell32 -luser32 -lkernel32 -lgdi32 -lcomctl32 -loleaut32".}
++    {.passL:"-L -lversion -lole32 -luuid -lshell32 -luser32 -lkernel32 -lgdi32 -lcomctl32 -loleaut32".}
+ else:
+     {.passL:"-lstdc++".}
+ 
+--- a/src/extras/webview.nim
++++ b/src/extras/webview.nim
+@@ -37,7 +37,7 @@
+     {.passL: "-lstdc++ -framework WebKit".}
+ elif defined(windows):
+     {.passC: "-DWEBVIEW_EDGE=1 -mwindows".}
+-    {.passL: """-static-libstdc++ -std=c++17 -L""" & currentSourcePath().splitPath.head & """/webview/deps/dlls/x64 -lwebview -lWebView2Loader""".}
++    {.passL: """-std=c++17 -lwebview""".}
+ 
+ {.push header: "webview/webview.h", cdecl.}
+ 
+--- a/src/library/Net.nim
++++ b/src/library/Net.nim
+@@ -39,7 +39,7 @@
+         else:
+             {.passL: "src/deps/openssl/macos/amd64/libssl.a src/deps/openssl/macos/amd64/libcrypto.a".}
+     elif defined(windows): 
+-        {.passL: "-Bstatic -Lsrc/deps/openssl/windows/amd64 -lssl -lcrypto -Bdynamic -lws2_32 -lcrypt32".}
++        {.passL: "-lssl -lcrypto -lws2_32 -lcrypt32".}
+ 
+ #=======================================
+ # Libraries
+--- a/src/vm/values/custom/vregex.nim
++++ b/src/vm/values/custom/vregex.nim
+@@ -25,7 +25,7 @@
+     else:
+         {.passL: "src/deps/pcre/macos/amd64/libpcre.a".}
+ elif defined(windows): 
+-    {.passL: "-Bstatic -Lsrc/deps/pcre/windows/amd64 -lpcre -Bdynamic".}
++    {.passL: "-lpcre".}
+ 
+ #=======================================
+ # Libraries

--- a/mingw-w64-arturo/PKGBUILD
+++ b/mingw-w64-arturo/PKGBUILD
@@ -1,0 +1,58 @@
+# Maintainer: Arturo Programming Language <https://github.com/arturo-lang>
+
+_realname=arturo
+pkgbase=mingw-w64-${_realname}
+pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
+pkgver=0.10.0
+pkgrel=1
+pkgdesc="Simple, expressive & portable programming language for efficient scripting. (mingw-w64)"
+arch=('any')
+mingw_arch=('ucrt64')
+url="https://arturo-lang.io/"
+msys2_repository_url="https://github.com/arturo-lang/arturo"
+license=("spdx:MIT")
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-cc-libs"
+  "${MINGW_PACKAGE_PREFIX}-gmp"
+  "${MINGW_PACKAGE_PREFIX}-libwinpthread"
+  "${MINGW_PACKAGE_PREFIX}-mpfr"
+  "${MINGW_PACKAGE_PREFIX}-openssl"
+  "${MINGW_PACKAGE_PREFIX}-sqlite3"
+  "${MINGW_PACKAGE_PREFIX}-webview"
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-nim"
+  "${MINGW_PACKAGE_PREFIX}-pkgconf"
+  "${MINGW_PACKAGE_PREFIX}-pcre"
+)
+source=("https://github.com/arturo-lang/arturo/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
+        "001-no-static-linking.patch")
+sha256sums=('408646496895753608ad9dc6ddfbfa25921c03c4c7356f2832a9a63f4a7dc351'
+            '51af1d69911ff49af86e97f578aa4f1a651f04c359623f71c07b8387f70ed515')
+
+prepare() {
+  cd ${_realname}-${pkgver}
+  patch -p1 -i "${srcdir}"/001-no-static-linking.patch
+}
+
+build() {
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("--release")
+  else
+    extra_config+=("--debug")
+  fi
+
+  cd "${srcdir}/${_realname}-${pkgver}"
+  # Using dev flag to build webview DLLs
+  nim build.nims "${extra_config[@]}" -l --dev
+}
+
+package() {
+  install -d "${pkgdir}"${MINGW_PREFIX}/bin
+  cp "${srcdir}"/${_realname}-${pkgver}/bin/*.exe "${pkgdir}"${MINGW_PREFIX}/bin/
+
+  install -Dm644 "${srcdir}"/${_realname}-${pkgver}/LICENSE \
+    "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+}


### PR DESCRIPTION
## Proposal

This PR proposals the addition of the [Arturo Programming Language](https://arturo-lang.io), currently at the version 0.10.0, called Arizona Bark, to this package repository.

This PR would not be possible without the help of @drkameleon, thanks a lot! :tada:

## Notes

We've been testing the building of this package on CI. Our implementation may be seen here: https://github.com/arturo-lang/mingw64.

Currently the build takes ~15 minutes since we need to build nim 2.2.6 from source.

- Closes #27490

## Other Questions

If this is possible, I would like to know how could we add a License for our repository https://github.com/arturo-lang/mingw64. I understand that this should be under the BSD-3 License, but who is the owner of the copyright? Should it be "Arturo Programming Language" there?
This would be great to know since I don't want to let that repository unlicensed, also, we include a more files beyond the package itself, like the readme and the github workflow... Thanks a lot in advance! :wink: