### PR TITLE
gimp: Update to 3.0.8

### DIFF
--- a/mingw-w64-gimp/PKGBUILD
+++ b/mingw-w64-gimp/PKGBUILD
@@ -3,9 +3,8 @@
 _realname=gimp
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_pkgver=3.0.6
-pkgver=${_pkgver}
-pkgrel=3
+pkgver=3.0.8
+pkgrel=1
 pkgdesc="GNU Image Manipulation Program (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'ucrt64' 'clang64' 'clangarm64')
@@ -85,8 +84,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-libxslt"
              "${MINGW_PACKAGE_PREFIX}-qoi"
              "${MINGW_PACKAGE_PREFIX}-vala")
-source=("https://download.gimp.org/pub/gimp/v3.0/gimp-${_pkgver}.tar.xz")
-sha256sums=('246c225383c72ef9f0dc7703b7d707084bbf177bd2900e94ce466a62862e296b')
+source=("https://download.gimp.org/pub/gimp/v3.0/gimp-${pkgver}.tar.xz")
+sha256sums=('feb498acc01b26827cff1ff95aa8fb82cdd6a60d7abf773cfcd19abeafca3386')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -97,7 +96,7 @@ apply_patch_with_msg() {
 }
 
 prepare() {
-  cd "gimp-${_pkgver}"
+  cd "gimp-${pkgver}"
 }
 
 build() {
@@ -120,9 +119,9 @@ build() {
     -Dlibunwind=false \
     -Dlinux-input=disabled \
     -Dxcursor=disabled \
-    -Dwin32-debug-console=disabled \
+    -Dbash-completion=disabled \
     "build-${MSYSTEM}" \
-    "gimp-${_pkgver}"
+    "gimp-${pkgver}"
 
   meson compile -C "build-${MSYSTEM}"
 }
@@ -136,6 +135,6 @@ package() {
 
   rm -f "${pkgdir}${MINGW_PREFIX}/lib/gimp/3.0/modules/*.dll.a"
 
-  install -Dm644 "gimp-${_pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
-  install -Dm644 "gimp-${_pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+  install -Dm644 "gimp-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  install -Dm644 "gimp-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }


### PR DESCRIPTION
win32-debug-console option got removed in
https://gitlab.gnome.org/GNOME/gimp/-/commit/ccde514bdb357ecb88a9624baf74d6d2a4bf52fc

Disable completion install, requires bash-completion.pc which we only have for cygwin. could be patched maybe.