### PR TITLE
qt5: Remove OpenSSL arch suffix in dll name lookup in ARM64

### DIFF
--- a/mingw-w64-qt5-base/0030-ssl-dll-suffix.patch
+++ b/mingw-w64-qt5-base/0030-ssl-dll-suffix.patch
@@ -1,0 +1,12 @@
+diff -bur qtbase-orig/src/network/ssl/qsslsocket_openssl_symbols.cpp qtbase/src/network/ssl/qsslsocket_openssl_symbols.cpp
+--- qtbase-orig/src/network/ssl/qsslsocket_openssl_symbols.cpp	2026-01-24 18:34:56.233892500 -0700
++++ qtbase/src/network/ssl/qsslsocket_openssl_symbols.cpp	2026-01-24 18:35:28.597004900 -0700
+@@ -692,7 +692,7 @@
+ #if defined(Q_PROCESSOR_X86_64)
+ #define QT_SSL_SUFFIX "-x64"
+ #elif defined(Q_PROCESSOR_ARM_64)
+-#define QT_SSL_SUFFIX "-arm64"
++#define QT_SSL_SUFFIX
+ #elif defined(Q_PROCESSOR_ARM_32)
+ #define QT_SSL_SUFFIX "-arm"
+ #else

--- a/mingw-w64-qt5-base/PKGBUILD
+++ b/mingw-w64-qt5-base/PKGBUILD
@@ -13,7 +13,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
 _qtver=5.15.18
 pkgver=5.15.18+kde+r109
-pkgrel=4
+pkgrel=5
 pkgdesc="A cross-platform application and UI framework (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -82,7 +82,8 @@ source=(git+https://invent.kde.org/qt/qt/$_pkgfn#commit=$_commit
         0026-fix-mingw-win32-winnt-detection.patch
         0027-qt-5.7.0-qdbus-manager-quit.patch
         0028-work-around-pyside2-brokenness.patch
-        0029-fix-conflict-with-qt6.patch)
+        0029-fix-conflict-with-qt6.patch
+        0030-ssl-dll-suffix.patch)
 sha256sums=('8e435d7d64a899ddd226456e0a4a838bca070dc49f77550b7707e2261e5b158e'
             'a74eec5be1aee1bd3a37af0955b7c5f3d36d54bc64c07e4c2edd5526cdc3cad5'
             'e0a535278057f42e43952405e567c23cc493ef6badeeb3bbce0154953cd545a5'
@@ -112,7 +113,8 @@ sha256sums=('8e435d7d64a899ddd226456e0a4a838bca070dc49f77550b7707e2261e5b158e'
             '6ceed12f98254c37fb3b1ab68a84214c922bd2c402fea89fa65638d56e567bbb'
             '03dc899326676cc6e9e6b4e77634ccea3693449bf8627653dc7fdb74378ad264'
             '8dd074ab427ccd439e34f50ed8b03228d71c09a5375050ad5d47064ff6b00d8f'
-            'f276f74fc4585b1f2d01d4bc1391d3e86f69ac1efb4e297f9898fa4cc0d14fbb')
+            'f276f74fc4585b1f2d01d4bc1391d3e86f69ac1efb4e297f9898fa4cc0d14fbb'
+            '043975ca67767c38d9cbf6d76b99486cca286a2419243471b9fb4e46302c8283')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -158,7 +160,8 @@ prepare() {
     0024-fix-synqt-with-git-build.patch \
     0025-enable-avx-support.patch \
     0026-fix-mingw-win32-winnt-detection.patch \
-    0029-fix-conflict-with-qt6.patch
+    0029-fix-conflict-with-qt6.patch \
+    0030-ssl-dll-suffix.patch
 
   # For: https://github.com/msys2/MINGW-packages/issues/10158
   # From: https://invent.kde.org/packaging/craft-blueprints-kde/-/blob/master/libs/qt5/qtbase/.qt-kde-5.15/qdbus-manager-quit-5.7.patch


### PR DESCRIPTION
Fixes https://github.com/msys2/MINGW-packages/issues/27547