### PR TITLE
gcc: backport fixed the behavior issues with std::system_category

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -51,7 +51,7 @@ else
   _sourcedir=${_realname}-${_version}-${_snapshot}
   _url=https://gcc.gnu.org/pub/gcc/snapshots/${_version}-${_snapshot}
 fi
-pkgrel=10
+pkgrel=11
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -96,7 +96,8 @@ source=(${_url}/${_sourcedir}.tar.xz{,.sig}
         3001-fix-codeview-crashes.patch
         9002-native-tls.patch
         724f36504aa8573883e1919c6968665f8af28aef.patch::https://gcc.gnu.org/cgit/gcc/patch/?id=724f36504aa8573883e1919c6968665f8af28aef
-        e28494e08092c4096a015563c0ba0494ce1edf81.patch::https://gcc.gnu.org/cgit/gcc/patch/?id=e28494e08092c4096a015563c0ba0494ce1edf81)
+        e28494e08092c4096a015563c0ba0494ce1edf81.patch::https://gcc.gnu.org/cgit/gcc/patch/?id=e28494e08092c4096a015563c0ba0494ce1edf81
+        9e2c62a7d397b050427568c83ff5a4c21eb49365.patch::https://gcc.gnu.org/cgit/gcc/patch/?id=9e2c62a7d397b050427568c83ff5a4c21eb49365)
 sha256sums=('438fd996826b0c82485a29da03a72d71d6e3541a83ec702df4271f6fe025d24e'
             'SKIP'
             'bce81824fc89e5e62cca350de4c17a27e27a18a1a1ad5ca3492aec1fc5af3234'
@@ -115,7 +116,8 @@ sha256sums=('438fd996826b0c82485a29da03a72d71d6e3541a83ec702df4271f6fe025d24e'
             'f21f9ab731e9cab8fd4ca8c289497f859ef7004e6fa0507877dc2559ac2071c3'
             'd977683efc6f6b4dd675a8f1978416d22d5b5d1fa53614b9a18bc18efa231391'
             '8624143d339cfff0be7d8795737b0fb00ca41f2a19915bbf6705a5d7bf9c99a1'
-            'f4e7f8f5a67fd571453e4d41575455f7e4b5cd7288b5e2d7d3a26a3506bae949')
+            'f4e7f8f5a67fd571453e4d41575455f7e4b5cd7288b5e2d7d3a26a3506bae949'
+            '14f5821186c52cf93806ecc1ac87e3280794a8f8b53b7c85570c753ef2fffba8')
 validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.org
               86CFFCA918CF3AF47147588051E8B148A9999C34  # evangelos@foutrelis.com
               13975A70E63C361C73AE69EF6EEB81F8981C74C7  # richard.guenther@gmail.com
@@ -179,6 +181,10 @@ prepare() {
   apply_patch_with_msg \
     724f36504aa8573883e1919c6968665f8af28aef.patch \
     e28494e08092c4096a015563c0ba0494ce1edf81.patch
+
+  # Fix libstdc++ std::system_category
+  apply_patch_with_msg \
+    9e2c62a7d397b050427568c83ff5a4c21eb49365.patch
 
   # apply_patch_with_msg \
   #   9002-native-tls.patch


### PR DESCRIPTION
This patch fixes a behavior issue caused by the missing `FORMAT_MESSAGE_IGNORE_INSERTS` flag when using `FormatMessageA` to format error messages in `std::system_category().message(int)`.