### PR TITLE
openssl: Use arch suffix in libraries in ARM64 just like in x64

### DIFF
--- a/mingw-w64-openssl/004-arch-suffix.patch
+++ b/mingw-w64-openssl/004-arch-suffix.patch
@@ -1,0 +1,25 @@
+diff -bur openssl-3.6.0-orig/Configurations/10-main.conf openssl-3.6.0/Configurations/10-main.conf
+--- openssl-3.6.0-orig/Configurations/10-main.conf	2026-01-27 06:06:25.778001900 -0700
++++ openssl-3.6.0/Configurations/10-main.conf	2026-01-27 06:06:37.119230300 -0700
+@@ -1744,7 +1744,7 @@
+         uplink_arch      => undef,
+         perlasm_scheme   => "mingw64",
+         shared_rcflag    => "--target=pe-x86-64",
+-        multilib         => "64",
++        multilib         => "-x64",
+     },
+ 
+     "mingwarm64" => {
+diff -bur openssl-3.6.0-orig/Configurations/platform/mingw.pm openssl-3.6.0/Configurations/platform/mingw.pm
+--- openssl-3.6.0-orig/Configurations/platform/mingw.pm	2026-01-27 06:06:25.780510300 -0700
++++ openssl-3.6.0/Configurations/platform/mingw.pm	2026-01-27 06:06:40.823174800 -0700
+@@ -33,8 +33,7 @@
+     return platform::BASE::__concat(platform::BASE->sharedname($_[1]),
+                                     "-",
+                                     $_[0]->shlib_version_as_filename(),
+-                                    ($config{target} eq "mingw64"
+-                                         ? "-x64" : ""));
++                                    ($target{multilib} // '' ));
+ }
+ 
+ # With Mingw and other DLL producers, there isn't any "simpler" shared

--- a/mingw-w64-openssl/PKGBUILD
+++ b/mingw-w64-openssl/PKGBUILD
@@ -4,7 +4,7 @@ _realname=openssl
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=3.6.1
-pkgrel=1
+pkgrel=2
 pkgdesc="The Open Source toolkit for Secure Sockets Layer and Transport Layer Security (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -21,11 +21,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 options=('!buildflags')
 source=("https://github.com/openssl/openssl/releases/download/openssl-${pkgver}/openssl-${pkgver}.tar.gz"{,.asc}
         '002-relocation.patch'
+        '004-arch-suffix.patch'
         'pathtools.c'
         'pathtools.h')
 sha256sums=('b1bfedcd5b289ff22aee87c9d600f515767ebf45f77168cb6d64f231f518a82e'
             'SKIP'
             '3e9a8abb6ff5fb7bdb450742fb7bd85513a4abbe85594228620379bcac7c02ef'
+            '6a686ef69c2b196fb1420389ccd0db84582fd288942560d5eba963c11ce8595a'
             'ebf471173f5ee9c4416c10a78760cea8afaf1a4a6e653977321e8547ce7bf3c0'
             '1585ef1b61cf53a2ca27049c11d49e0834683dfda798f03547761375df482a90')
 # https://openssl-library.org/source/index.html
@@ -47,7 +49,8 @@ prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
 
   apply_patch_with_msg \
-     002-relocation.patch
+     002-relocation.patch \
+     004-arch-suffix.patch
 
   test ! -d "${startdir}/../mingw-w64-pathtools" || {
     cmp "${startdir}/../mingw-w64-pathtools/pathtools.c" "${srcdir}/pathtools.c" &&


### PR DESCRIPTION
Fixes #27547
Supersedes  #27548