### PR TITLE
arturo: fix runtime dependencies (v0.10.0 - Arizona Bark)

### DIFF
--- a/mingw-w64-arturo/002-fix-sqlite3-dependency-name.patch
+++ b/mingw-w64-arturo/002-fix-sqlite3-dependency-name.patch
@@ -1,0 +1,16 @@
+--- a/src/extras/db_connector/sqlite3.nim	2026-01-15 04:43:13.000000000 -0300
++++ b/src/extras/db_connector/sqlite3.nim	2026-01-29 18:27:34.356482300 -0300
+@@ -11,12 +11,7 @@
+   {.push styleChecks: off.}
+ 
+ when defined(windows):
+-  when defined(nimOldDlls):
+-    const Lib = "sqlite3.dll"
+-  elif defined(cpu64):
+-    const Lib = "sqlite3_64.dll"
+-  else:
+-    const Lib = "sqlite3_32.dll"
++  const Lib = "libsqlite3-0.dll"
+ elif defined(macosx):
+   const
+     Lib = "libsqlite3(|.0).dylib"

--- a/mingw-w64-arturo/PKGBUILD
+++ b/mingw-w64-arturo/PKGBUILD
@@ -4,7 +4,7 @@ _realname=arturo
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=0.10.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Simple, expressive & portable programming language for efficient scripting. (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64')
@@ -26,14 +26,23 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-nim"
   "${MINGW_PACKAGE_PREFIX}-pkgconf"
 )
-source=("https://github.com/arturo-lang/arturo/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
-        "001-no-static-linking.patch")
-sha256sums=('408646496895753608ad9dc6ddfbfa25921c03c4c7356f2832a9a63f4a7dc351'
-            '51af1d69911ff49af86e97f578aa4f1a651f04c359623f71c07b8387f70ed515')
+
+source=(
+  "https://github.com/arturo-lang/arturo/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
+  "001-no-static-linking.patch"
+  "002-fix-sqlite3-dependency-name.patch"
+)
+
+sha256sums=(
+  '408646496895753608ad9dc6ddfbfa25921c03c4c7356f2832a9a63f4a7dc351'
+  '51af1d69911ff49af86e97f578aa4f1a651f04c359623f71c07b8387f70ed515'
+  '3c82b594998c4eed8614bdb7b45bb2eb3ee07a92b6e38d4695b36b59298ebd04'
+)
 
 prepare() {
   cd ${_realname}-${pkgver}
   patch -p1 -i "${srcdir}"/001-no-static-linking.patch
+  patch -p1 -i "${srcdir}"/002-fix-sqlite3-dependency-name.patch
 }
 
 build() {


### PR DESCRIPTION
I've faced some issues when trying to run arturo after #27514.
The reason? We try to load the wrong Sqlite3 dll at runtime, so I added a patch to it.