### PR TITLE
winpthreads: fix SIGFPE crash when unmasking FPU exceptions on mingw32

### DIFF
--- a/mingw-w64-winpthreads/PKGBUILD
+++ b/mingw-w64-winpthreads/PKGBUILD
@@ -6,7 +6,7 @@ _realname=winpthreads
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-libwinpthread")
 pkgver=13.0.0.r488.g3fedac280
-pkgrel=1
+pkgrel=2
 _commit='3fedac28018c447ccdd9519c9d556340dfa1c87e'
 pkgdesc="MinGW-w64 winpthreads library (mingw-w64)"
 url="https://www.mingw-w64.org/"
@@ -49,6 +49,11 @@ build() {
   # https://github.com/msys2/MINGW-packages/issues/7043
   CFLAGS="${CFLAGS//-Wp,-D__USE_MINGW_ANSI_STDIO=1/}"
   CXXFLAGS="${CXXFLAGS//-Wp,-D__USE_MINGW_ANSI_STDIO=1/}"
+
+  # https://github.com/msys2/MINGW-packages/issues/27566
+  if [[ ${MSYSTEM} == MINGW32 ]]; then
+    LDFLAGS="${LDFLAGS//-Wl,--no-seh/}"
+  fi
 
   declare -a extra_config
   if check_option "debug" "y"; then


### PR DESCRIPTION
The default MINGW32 LDFLAGS in MSYS2 include '-Wl,--no-seh', which strips Structured Exception Handling (SEH) tables. On i686 (32-bit), this leads to immediate SIGFPE crashes (Exit 136) in applications that unmask FPU exceptions, e.g., libgc with GC_allow_register_threads(). This patch removes the problematic flag.

This fixes https://github.com/msys2/MINGW-packages/issues/27566