### PR TITLE
python-pdm-backend: update to 2.4.7

### DIFF
--- a/mingw-w64-python-pdm-backend/PKGBUILD
+++ b/mingw-w64-python-pdm-backend/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=pdm-backend
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=2.4.6
-pkgrel=3
+pkgver=2.4.7
+pkgrel=1
 pkgdesc="The build backend used by PDM that supports latest packaging standards (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -20,11 +20,12 @@ depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-tomli-w")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer")
-checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-editables"
+              "${MINGW_PACKAGE_PREFIX}-python-pytest")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz"
         "python-pdm-backend-2.3.1-devendor.patch")
-sha256sums=('5dd9cd581a4f18d57ff506a5b3aad7c8df31e5949b6fd854bbc34c38107e4532'
+sha256sums=('a509d083850378ce919d41e7a2faddfc57a1764d376913c66731125d6b14110f'
             'c87e46b7903c770700a0325bde0420f74d123780e61d5350339775ecc971001a')
 noextract=("${_realname/-/_}-${pkgver}.tar.gz")
 


### PR DESCRIPTION
Checks also need python-editables.