### PR TITLE
pip: make externally managed warning an error outside of CI

### DIFF
--- a/mingw-w64-python-pip/0002-only-warn-for-externally-managed.patch
+++ b/mingw-w64-python-pip/0002-only-warn-for-externally-managed.patch
@@ -1,13 +1,16 @@
---- pip-24.1.2/src/pip/_internal/utils/misc.py.orig	2024-07-07 20:36:57.000000000 +0200
-+++ pip-24.1.2/src/pip/_internal/utils/misc.py	2024-11-02 11:26:52.752980600 +0100
-@@ -612,7 +612,9 @@
+--- pip-26.0/src/pip/_internal/utils/misc.py.orig	2026-01-31 02:15:05.000000000 +0100
++++ pip-26.0/src/pip/_internal/utils/misc.py	2026-01-31 09:05:18.730562700 +0100
+@@ -604,7 +604,12 @@
      marker = os.path.join(sysconfig.get_path("stdlib"), "EXTERNALLY-MANAGED")
      if not os.path.isfile(marker):
          return
 -    raise ExternallyManagedEnvironment.from_config(marker)
 +    exc = ExternallyManagedEnvironment.from_config(marker)
-+    exc.kind = "warning"
-+    logger.warning("%s", exc, extra={"rich": True})
++    if "CI" in os.environ:
++        exc.kind = "warning"
++        logger.warning("%s", exc, extra={"rich": True})
++    else:
++        raise exc
  
  
  def is_console_interactive() -> bool:

--- a/mingw-w64-python-pip/PKGBUILD
+++ b/mingw-w64-python-pip/PKGBUILD
@@ -5,7 +5,7 @@ _realname=pip
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=26.0
-pkgrel=1
+pkgrel=2
 pkgdesc="The PyPA recommended tool for installing Python packages. (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -30,7 +30,7 @@ source=(
 )
 sha256sums=('3ce220a0a17915972fbf1ab451baae1521c4539e778b28127efa79b974aff0fa'
             'e6cac9043f43cd32914a618191ac5852e4bbcc12ecf0314424d9e1a544358b69'
-            'be196f12feee11fe1caccbdeff9a31ac077120de7b6e85679ea54b6dd2df8f5b')
+            '18d3a57398bc2ee3c40e1700534a5a578cad344e9a28a4755af53ea996f6425e')
 
 prepare() {
   cd "${_realname}-${pkgver}"


### PR DESCRIPTION
Back in 4447a7ba7971d3480 we enabled PEP 668, but patched pip to only show the warning and not abort in case installing outside of a venv, to avoid too much fallout.

One motivation for this change was to avoid users falling into the trap of using pip and installing incompatible packages breaking the MSYS2 provided packages, or leading to errors during pacman upgrades due to file conflicts.

This mainly affects developer installations and not CI, where the environment is mostly ephemeral, and using pip this way isn't that bad since the env will be thrown away anyway.

To make things more strict, while considering these two use cases we now show a warning in case the "CI" env var is set (that's the default in GitHub and GitLab for example), and error out if not.

As pointed out in the warning, just pass "--break-system-packages" to pip if you know what you are doing.