### PR TITLE
python-id: update 1.6.0

### DIFF
--- a/mingw-w64-python-id/PKGBUILD
+++ b/mingw-w64-python-id/PKGBUILD
@@ -3,24 +3,26 @@
 _realname=id
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=1.5.0
-pkgrel=3
+pkgver=1.6.0
+pkgrel=1
 pkgdesc='A tool for generating OIDC identities (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://pypi.org/project/id/'
 msys2_repository_url='https://github.com/di/id'
 msys2_references=(
+  'archlinux: python-id'
+  'gentoo: dev-python/id'
   'purl: pkg:pypi/id'
 )
 license=('Apache-2.0')
-depends=("${MINGW_PACKAGE_PREFIX}-python-requests")
+depends=("${MINGW_PACKAGE_PREFIX}-python-urllib3")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-flit-core"
              "${MINGW_PACKAGE_PREFIX}-python-installer")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('292cb8a49eacbbdbce97244f47a97b4c62540169c976552e497fd57df0734c1d')
+sha256sums=('4ca6e16f99e34d87ff2d9044fdf3bf278fcff33de56745a3734af9101fff6269')
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"


### PR DESCRIPTION
Packages does now need urllib3 instead of requests as dependency.