### PR TITLE
Rename python-hererocks to hererocks

### DIFF
--- a/mingw-w64-hererocks/PKGBUILD
+++ b/mingw-w64-hererocks/PKGBUILD
@@ -10,6 +10,7 @@ arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://github.com/luarocks/hererocks'
 msys2_references=(
+  'aur: hererocks'
   'purl: pkg:pypi/hererocks'
 )
 license=('spdx:MIT')


### PR DESCRIPTION
This is used as a cli tool rather than as a python library, so it doesn't make much sense to have the `python-` prefix. This name also matches the aur package.