### PR TITLE
nsis: enable for clangarm64

### DIFF
--- a/mingw-w64-nsis/PKGBUILD
+++ b/mingw-w64-nsis/PKGBUILD
@@ -9,7 +9,7 @@ url='https://nsis.sourceforge.io/'
 pkgdesc='Windows installer development tool (mingw-w64)'
 license=('spdx:Zlib')
 arch=(any)
-mingw_arch=('mingw64' 'ucrt64' 'clang64' 'mingw32')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 msys2_references=(
   "cpe: cpe:2.3:a:nullsoft:nullsoft_scriptable_install_system"
 )


### PR DESCRIPTION
Enables clangarm64

Not sure if it builds, so made draft for now.

Edit: not supported currently - https://sourceforge.net/p/nsis/feature-requests/579/