### PR TITLE
binutils: Fix error messages for MSVCRT builds

### DIFF
--- a/mingw-w64-binutils/0011-libiberty-Preserve-errno-across-calls-to-libiberty_v.patch
+++ b/mingw-w64-binutils/0011-libiberty-Preserve-errno-across-calls-to-libiberty_v.patch
@@ -1,0 +1,78 @@
+From e963c946dc2a130cc1eabdbb11936642356ec02c Mon Sep 17 00:00:00 2001
+From: LIU Hao <lh_mouse@126.com>
+Date: Mon, 9 Feb 2026 21:44:07 +0800
+Subject: [PATCH] libiberty: Preserve `errno` across calls to
+ `libiberty_vprintf_buffer_size()`
+
+The MSVCRT `strtoul()` function resets `errno` to zero upon success. On such
+a system, `libiberty_vprintf_buffer_size()` can clobber `errno` like this:
+
+   MINGW64 ~
+   $ ld nonexistent.file
+   C:\MSYS64\mingw64\bin\ld.exe: cannot find nonexistent.file: No error
+
+libiberty/ChangeLog:
+
+	* vprintf-support.c (do_strtoul): New function.
+	(libiberty_vprintf_buffer_size): Replace `strtoul` with `do_strtoul`.
+
+Signed-off-by: LIU Hao <lh_mouse@126.com>
+---
+ libiberty/vprintf-support.c | 20 ++++++++++++++++++--
+ 1 file changed, 18 insertions(+), 2 deletions(-)
+
+diff --git a/libiberty/vprintf-support.c b/libiberty/vprintf-support.c
+index 5a998fbf4ae..905e86b0437 100644
+--- a/libiberty/vprintf-support.c
++++ b/libiberty/vprintf-support.c
+@@ -27,6 +27,7 @@ Floor, Boston, MA 02110-1301, USA.  */
+ # define va_copy(d,s)  __va_copy((d),(s))
+ #endif
+ #include <stdio.h>
++#include <errno.h>
+ #ifdef HAVE_STRING_H
+ #include <string.h>
+ #endif
+@@ -37,6 +38,21 @@ extern unsigned long strtoul ();
+ #endif
+ #include "libiberty.h"
+ 
++static inline unsigned long
++do_strtoul (const char *str, char **endptr, int base)
++  {
++#ifdef _WIN32
++    /* The MSVCRT `strtoul()` function resets `errno` to zero upon success.
++       We must preserve it across this call.  */
++    int saved_errno = errno;
++#endif
++    long value = strtoul (str, endptr, base);
++#ifdef _WIN32
++    errno = saved_errno;
++#endif
++    return value;
++  }
++
+ int
+ libiberty_vprintf_buffer_size (const char *format, va_list args)
+ {
+@@ -65,7 +81,7 @@ libiberty_vprintf_buffer_size (const char *format, va_list args)
+ 	      total_width += abs (va_arg (ap, int));
+ 	    }
+ 	  else
+-	    total_width += strtoul (p, (char **) &p, 10);
++	    total_width += do_strtoul (p, (char **) &p, 10);
+ 	  if (*p == '.')
+ 	    {
+ 	      ++p;
+@@ -75,7 +91,7 @@ libiberty_vprintf_buffer_size (const char *format, va_list args)
+ 		  total_width += abs (va_arg (ap, int));
+ 		}
+ 	      else
+-	      total_width += strtoul (p, (char **) &p, 10);
++		total_width += do_strtoul (p, (char **) &p, 10);
+ 	    }
+ 	  do
+ 	    {
+-- 
+2.53.0
+

--- a/mingw-w64-binutils/PKGBUILD
+++ b/mingw-w64-binutils/PKGBUILD
@@ -7,7 +7,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.46
 _sourcedir=binutils-with-gold-${pkgver}
-pkgrel=1
+pkgrel=2
 pkgdesc="A set of programs to assemble and manipulate binary and object files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -28,6 +28,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 source=(https://ftp.gnu.org/gnu/binutils/${_sourcedir}.tar.bz2{,.sig}
         0002-check-for-unusual-file-harder.patch
         0010-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch
+        0011-libiberty-Preserve-errno-across-calls-to-libiberty_v.patch
         2001-ld-option-to-move-default-bases-under-4GB.patch
         2003-Revert-Restore-old-behaviour-of-windres-so-that-opti.patch
         reproducible-import-libraries.patch
@@ -38,6 +39,7 @@ sha256sums=('b8c9a3d796dc0b0e8ea935dc24c5c8d6f345eb177ada5ac6a5b1122c77d62158'
             'SKIP'
             '2c99345fc575c3a060d6677537f636c6c4154fac0fde508070f3b6296c1060d4'
             '4e8ac055df61b1b5d6ae29dc87e1154737c2e87c7b244b44866702cabf1a5d18'
+            '90890cf76f820e61d4eeeef356b0d08ff0c7a90a07691b42a37a1e17abc29cda'
             '9945635f4a67712616202f09cbb66cf70df01be168c2c8054c455bb58bf334dd'
             '3e3c53b0751a6389cd50dcbd7f78b52aaa55113414da01d3415592af18809702'
             'a094660ec95996c00b598429843b7869037732146442af567ada9f539bd40480'
@@ -60,7 +62,8 @@ prepare() {
 
   apply_patch_with_msg \
     0002-check-for-unusual-file-harder.patch \
-    0010-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch
+    0010-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch \
+    0011-libiberty-Preserve-errno-across-calls-to-libiberty_v.patch
 
   # Add an option to change default bases back below 4GB to ease transition
   # https://github.com/msys2/MINGW-packages/issues/7027


### PR DESCRIPTION
Subject: [PATCH] libiberty: Preserve `errno` across calls to  `libiberty_vprintf_buffer_size()` 

The MSVCRT `strtoul()` function resets `errno` to zero upon success. On such a system, `libiberty_vprintf_buffer_size()` can clobber `errno` like this:

* **MINGW64 ~
$** ld nonexistent.file
C:\MSYS64\mingw64\bin\ld.exe: cannot find nonexistent.file: No error
