### PR TITLE
python-passagemath-ntl: fix runtime dependency

### DIFF
--- a/mingw-w64-passagemath-ntl/PKGBUILD
+++ b/mingw-w64-passagemath-ntl/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=10.8.1
-pkgrel=1
+pkgrel=2
 pkgdesc="passagemath: Computational Number Theory with NTL (mingw-w64)"
 arch=('any')
 # Builds for clang64 and clangarm64 currently have problems with ntl, so it's
@@ -18,6 +18,7 @@ msys2_references=(
 )
 license=('spdx:GPL-2.0-or-later')
 depends=("${MINGW_PACKAGE_PREFIX}-ntl"
+         "${MINGW_PACKAGE_PREFIX}-mpfi"
          "${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-cysignals"
          "${MINGW_PACKAGE_PREFIX}-python-memory-allocator"
@@ -26,7 +27,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-ntl"
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cython"
              "${MINGW_PACKAGE_PREFIX}-m4ri"
-             "${MINGW_PACKAGE_PREFIX}-mpfi"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"


### PR DESCRIPTION
Looks like MPFI is also required at runtime, not just during build.