### PR TITLE
python-passagemath-gsl: add version 10.8.1 (new package)

### DIFF
--- a/mingw-w64-passagemath-gsl/PKGBUILD
+++ b/mingw-w64-passagemath-gsl/PKGBUILD
@@ -1,0 +1,55 @@
+# Maintainer: Dirk Stolle
+
+_realname=passagemath-gsl
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=10.8.1
+pkgrel=1
+pkgdesc="passagemath: Numerics with the GNU Scientific Library (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/passagemath/passagemath'
+msys2_repository_url='https://github.com/passagemath/passagemath'
+msys2_references=(
+  'purl: pkg:pypi/passagemath-gsl'
+)
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-gsl"
+         "${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-cysignals"
+         "${MINGW_PACKAGE_PREFIX}-python-memory-allocator"
+         "${MINGW_PACKAGE_PREFIX}-python-numpy"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-categories"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-environment"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-modules"
+)
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cython"
+             "${MINGW_PACKAGE_PREFIX}-gmp"
+             "${MINGW_PACKAGE_PREFIX}-mpc"
+             "${MINGW_PACKAGE_PREFIX}-mpfr"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-jinja"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-setup"
+             "${MINGW_PACKAGE_PREFIX}-python-pkgconfig"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
+sha256sums=('55d6dfb8deb1d4eb1eda13780e0f78667f849f07867005ff75a0fb5b6b517db2')
+
+build() {
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+}


### PR DESCRIPTION
This PR adds python-passagemath-gsl, a package to provide some functionality from passagemath (https://github.com/msys2/MINGW-packages/issues/24738). passagemath-gsl was added to passagemath in [passagemath 10.8.1](https://github.com/passagemath/passagemath/releases/tag/passagemath-10.8.1).