### PR TITLE
gswin64c for mingw-w64-ucrt-x86_64-ghostscript

### DIFF
--- a/mingw-w64-ghostscript/PKGBUILD
+++ b/mingw-w64-ghostscript/PKGBUILD
@@ -121,8 +121,7 @@ package() {
 
   install -D -m644 "${srcdir}"/${_realname}-${pkgver}/LICENSE "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname}/LICENSE
 
-  cp "${pkgdir}"${MINGW_PREFIX}/bin/{gsc,gswin32c}.exe
-  cp "${pkgdir}"${MINGW_PREFIX}/bin/{gsc,gs}.exe
+  cp "${pkgdir}"${MINGW_PREFIX}/bin/{gs,gsc,gswin64c}.exe
 
   # remove unwanted localized man-pages
   rm -rf "${pkgdir}${MINGW_PREFIX}"/share/man/[^man1]*


### PR DESCRIPTION
hi,

provide `gswin64C` with GhostScript 64-bit package (see https://github.com/msys2/MINGW-packages/issues/27803).

regards, lacsaP.