### PR TITLE
python-passagemath-highs: add version 10.8.1 (new package)

### DIFF
--- a/mingw-w64-passagemath-highs/PKGBUILD
+++ b/mingw-w64-passagemath-highs/PKGBUILD
@@ -1,0 +1,54 @@
+# Maintainer: Dirk Stolle
+
+_realname=passagemath-highs
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=10.8.1
+pkgrel=1
+pkgdesc="passagemath: Linear and mixed integer linear optimization backend using HiGHS (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/passagemath/passagemath'
+msys2_repository_url='https://github.com/passagemath/passagemath'
+msys2_references=(
+  'purl: pkg:pypi/passagemath-highs'
+)
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-highs"
+         "${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-cysignals"
+         "${MINGW_PACKAGE_PREFIX}-python-memory-allocator"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-objects"
+)
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cython"
+             "${MINGW_PACKAGE_PREFIX}-gmp"
+             "${MINGW_PACKAGE_PREFIX}-mpc"
+             "${MINGW_PACKAGE_PREFIX}-mpfr"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-categories"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-environment"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-objects"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-setup"
+             "${MINGW_PACKAGE_PREFIX}-python-pkgconfig"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
+sha256sums=('dc6c9d2921678e7486ad06c7ae309e70a231d42d662eb290e106c575def57f0a')
+
+build() {
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+}

--- a/mingw-w64-passagemath-polyhedra/PKGBUILD
+++ b/mingw-w64-passagemath-polyhedra/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=10.8.1
-pkgrel=1
+pkgrel=2
 pkgdesc="passagemath: Convex polyhedra in arbitrary dimension, mixed integer linear optimization (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -44,6 +44,7 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-python-cvxopt"
             "${MINGW_PACKAGE_PREFIX}-python-passagemath-flint"
             "${MINGW_PACKAGE_PREFIX}-python-passagemath-graphs"
             # "${MINGW_PACKAGE_PREFIX}-python-passagemath-groups"
+            "${MINGW_PACKAGE_PREFIX}-python-passagemath-highs"
             # "${MINGW_PACKAGE_PREFIX}-python-passagemath-latte-4ti2"
             # "${MINGW_PACKAGE_PREFIX}-python-passagemath-linbox"
             # "${MINGW_PACKAGE_PREFIX}-python-passagemath-palp"


### PR DESCRIPTION
This PR adds python-passagemath-highs, a package to provide some functionality from passagemath (<https://github.com/msys2/MINGW-packages/issues/24738>). passagemath-highs was added to passagemath in passagemath 10.8.1.

It also adds python-passagemath-highs to the optional dependencies of python-passagemath-polyhedra.