### PR TITLE
kde-apps: update to 25.12.2 (part 1/n)

### DIFF
--- a/mingw-w64-ark/PKGBUILD
+++ b/mingw-w64-ark/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=ark
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=25.08.3
+pkgver=25.12.2
 pkgrel=1
 pkgdesc="Archiving Tool (mingw-w64)"
 arch=('any')
@@ -63,7 +63,7 @@ source=(
   "0001-ark-define-QT_STAT_LNK-macro.patch"
   "0002-ark-disable-zip-plugin.patch"
 )
-sha256sums=('ca4fb7295f090280df02d24b64f113e10c6f618138b387bc1fd7a2c561de554f'
+sha256sums=('abd7350914c65a763cac513cd679f635555b618c1df183b331134f7b3229a478'
             'SKIP'
             'ad2dd0f258b1258df779a69ee629fdd3c34d95dc34539b0c70020a27ea995036'
             '06df815353f73edbde4edbdc945118f52cd849041f61bae142dccdae9a091442')

--- a/mingw-w64-elisa/PKGBUILD
+++ b/mingw-w64-elisa/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=elisa
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=25.08.3
+pkgver=25.12.2
 pkgrel=1
 pkgdesc="A simple music player aiming to provide a nice experience for its users (mingw-w64)"
 arch=('any')
@@ -50,7 +50,7 @@ groups=(
   "${MINGW_PACKAGE_PREFIX}-kde-multimedia"
 )
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('63674bbd058a518d740bd9880d65a9af6a816fc33fb904cc1f0c0c248447dd13'
+sha256sums=('e64b92d62202b5a5d2bbb7d048a06ac633fbfe21cc8af9ee46f1991e97e674b7'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>


### PR DESCRIPTION
* ark: update to 25.12.2
* elisa: update to 25.12.2

Those built in <https://github.com/msys2/MINGW-packages/pull/27847> (https://github.com/msys2/MINGW-packages/actions/runs/21917510861/job/63288563530?pr=27847), so this should be fine.