### PR TITLE
highs: update to 1.13.1

### DIFF
--- a/mingw-w64-highs/PKGBUILD
+++ b/mingw-w64-highs/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=HiGHS
 pkgbase=mingw-w64-highs
 pkgname=("${MINGW_PACKAGE_PREFIX}-highs")
-pkgver=1.13.0
+pkgver=1.13.1
 pkgrel=1
 pkgdesc="High performance linear optimization software (mingw-w64)"
 arch=('any')
@@ -19,7 +19,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-fc")
 source=("https://github.com/ERGO-Code/${_realname}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('422e45cb6b10d503258ee894cb37916c087813451f311d1906dcc9701fda8647')
+sha256sums=('d491448e585dbf08cd8945ca5dcbbe3b784d73b9c68eea4e7456274619d56164')
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
@@ -55,9 +55,4 @@ package() {
 
   install -Dm644 "${srcdir}"/${_realname}-${pkgver}/LICENSE.txt \
     "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.txt
-
-  # Move doc files that get wrongly placed in /ucrt64 (or /clang64, or ...).
-  # Also see <https://github.com/ERGO-Code/HiGHS/issues/2811>.
-  mv "${pkgdir}"${MINGW_PREFIX}/*.{md,txt} \
-    "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/
 }


### PR DESCRIPTION
Issue with the wrong location for some documentation files has been fixed upstream, so the workaround is not required anymore.