### PR TITLE
kde-apps: update to 25.12.2 (part 2/n)

### DIFF
--- a/mingw-w64-kcachegrind/PKGBUILD
+++ b/mingw-w64-kcachegrind/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=kcachegrind
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=25.08.3
+pkgver=25.12.2
 pkgrel=1
 pkgdesc="Visualization of Performance Profiling Data (mingw-w64)"
 arch=('any')
@@ -51,7 +51,7 @@ source=(
   "https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig}
   0001-zap-bad-constexpr.patch
 )
-sha256sums=('aec838dfa806b438d198f5bb66a2a9925ecdb86d09da86c593a21302052b0bbe'
+sha256sums=('46e837b3ad12f9dbea68eed040219ce7e66ac58b47fc29430a1a4f93d7591b07'
             'SKIP'
             '0ba354fdb797a498c457767f98e1babbd4e83114808b7108754c417ffd9716ea')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>

--- a/mingw-w64-kdeconnect/0004-kdeconnect-cmake-disable-checking-winsdk.patch
+++ b/mingw-w64-kdeconnect/0004-kdeconnect-cmake-disable-checking-winsdk.patch
@@ -1,8 +1,8 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -94,7 +94,7 @@
- find_package(KF6 ${KF_MIN_VERSION} REQUIRED COMPONENTS I18n ConfigWidgets DBusAddons IconThemes Notifications
-     KIO KCMUtils Service Solid Kirigami People WindowSystem GuiAddons DocTools Crash)
+@@ -110,7 +110,7 @@ endif()
+ find_package(KF6 ${KF_MIN_VERSION} REQUIRED COMPONENTS I18n DBusAddons IconThemes Notifications
+     KIO ColorScheme Service Solid Kirigami People WindowSystem GuiAddons Crash ItemModels)
  
 -if (WIN32)
 +if (MSVC)

--- a/mingw-w64-kdeconnect/PKGBUILD
+++ b/mingw-w64-kdeconnect/PKGBUILD
@@ -4,8 +4,8 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=kdeconnect
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=25.08.3
-pkgrel=3
+pkgver=25.12.2
+pkgrel=1
 pkgdesc="Adds communication between KDE and your smartphone (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -61,18 +61,16 @@ groups=(
   "${MINGW_PACKAGE_PREFIX}-kde-network"
 )
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-kde-${pkgver}.tar.xz"{,.sig}
-        https://invent.kde.org/network/kdeconnect-kde/-/commit/55e3302d56e1eb22ff174d8f6afd7a7b1c9db819.patch
         "0001-kdeconnect-workaround-missing-in4addr_any.patch"
         "0002-kdeconnect-cmake-add-fexceptions.patch"
         "0003-kdeconnect-remove-in-sal.patch"
         "0004-kdeconnect-cmake-disable-checking-winsdk.patch")
-sha256sums=('6e41f1f22e85f5e70a92dd6ca3e6968364896de37afe5daeb7cda599f03e5e2b'
+sha256sums=('d0504bbc3572f7e131983786eddb9c580986e5e46bb44b94a6df77a8777e4ef2'
             'SKIP'
-            'ab8bf619f0c7f781c521809d50a9f1a232075ebadd7b16b6b487ced876ffc2e4'
             'd026cc43404dfdfe6060cad2818f57fcdf00c1f5ab683762a0f07de0c771f51d'
             'e8a0a39da7da94893b100a384cb8738f13470291c14dfae9ccf68835ac4cec55'
             '35b447bef8eec27e601d43c58af8cd0ebd92534b92e76faf369936fed0db0d26'
-            '38c72e5e6219fc6ca25efb5daf2618404d01e24210d4129460baaf9b3d39fcae')
+            'e0caf4525f52bb6face4e191f5a2133c5aa114f2d979cfd2e0652fa5d541f783')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>
               D81C0CB38EB725EF6691C385BB463350D6EF31EF) # Heiko Becker <heiko.becker@kde.org>
@@ -89,7 +87,6 @@ prepare() {
   cd "${_realname}-kde-${pkgver}"
 
   _apply_patch_with_msg \
-    55e3302d56e1eb22ff174d8f6afd7a7b1c9db819.patch \
     0001-kdeconnect-workaround-missing-in4addr_any.patch \
     0002-kdeconnect-cmake-add-fexceptions.patch \
     0003-kdeconnect-remove-in-sal.patch \

--- a/mingw-w64-kdegraphics-mobipocket/PKGBUILD
+++ b/mingw-w64-kdegraphics-mobipocket/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=kdegraphics-mobipocket
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=25.08.3
+pkgver=25.12.2
 pkgrel=1
 pkgdesc='A library to handle mobipocket files (mingw-w64)'
 arch=('any')
@@ -26,7 +26,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-ninja"
 )
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('a4f8ff1632270c11695095732661995d9639f8333c8d63730654d787dcc3b554'
+sha256sums=('f0f5aa2ec442c8c1225a90aa41a19bc754cab48beee380221ba4993367803ac4'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>


### PR DESCRIPTION
* kcachegrind: update to 25.12.2
* kdeconnect: update to 25.12.2
* kdegraphics-mobipocket: update to 25.12.2

Those built in <https://github.com/msys2/MINGW-packages/pull/27847>, so this should be fine.