### PR TITLE
kde-apps: update to 25.12.2 (part 3/n)

### DIFF
--- a/mingw-w64-konsole/PKGBUILD
+++ b/mingw-w64-konsole/PKGBUILD
@@ -4,8 +4,8 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=konsole
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=25.08.3
-pkgrel=2
+pkgver=25.12.2
+pkgrel=1
 pkgdesc='KDE terminal emulator (mingw-w64)'
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -61,7 +61,7 @@ groups=(
   "${MINGW_PACKAGE_PREFIX}-kde-utilities"
 )
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('095a7ff10df3c70779b356fb3b5984062bbc698bbed966230e3dbccf6af36615'
+sha256sums=('8220069844051b584c553b7e7da4c3c1ec66f9a79f2f386baa1a9b91436f5046'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>

--- a/mingw-w64-konversation/PKGBUILD
+++ b/mingw-w64-konversation/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=konversation
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=25.08.3
+pkgver=25.12.2
 pkgrel=1
 pkgdesc="User-friendly and fully-featured IRC client (mingw-w64)"
 arch=('any')
@@ -66,7 +66,7 @@ groups=(
   "${MINGW_PACKAGE_PREFIX}-kde-network"
 )
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('5e45b78c32d8f7275ccdc50d9780c5ae903418ed8c7974d5d98968dc3685808d'
+sha256sums=('fe7f8e4e4be2e80d1f367c4339eb227852e69f533d2d4145d9d2005c0d7021f2'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>

--- a/mingw-w64-kqtquickcharts/PKGBUILD
+++ b/mingw-w64-kqtquickcharts/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=kqtquickcharts
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=25.08.3
+pkgver=25.12.2
 pkgrel=1
 pkgdesc="A QtQuick plugin to render beautiful and interactive charts (mingw-w64)"
 arch=('any')
@@ -22,7 +22,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-qt6-base"
          "${MINGW_PACKAGE_PREFIX}-qt6-declarative")
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig}
         '0001-kqtquickcharts-22.08.1-fix-prefix.patch')
-sha256sums=('8f29a9cb1af7e351e85bb77e66d082d304e859d25bb550e74d65f759f0110c11'
+sha256sums=('bc7a5868c97309147cffa665606043af8f76c71b4000446f41d7f5ed5c10447c'
             'SKIP'
             'c239447ab092b19a2fe22d0c34e193c4af89cceebf321061f4221c1abdeda2dd')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>

--- a/mingw-w64-ktouch/PKGBUILD
+++ b/mingw-w64-ktouch/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=ktouch
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=25.08.3
+pkgver=25.12.2
 pkgrel=1
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -47,7 +47,7 @@ makedepends=(
 )
 optdepends=("${MINGW_PACKAGE_PREFIX}-breeze-icons: application icon theme")
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('471bc69be3638695737a46ad0381471d52f2fdd7ac39f6486b18080a1a99f81c'
+sha256sums=('9ea5e4b490f3a85fd0542cc43c277a1ee0323f1616b8dddff5147fb4db995c45'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>


### PR DESCRIPTION
* konsole: update to 25.12.2
* konversation: update to 25.12.2
* kqtquickcharts: update to 25.12.2
* ktouch: update to 25.12.2

Succeeded on UCRT64 in https://github.com/msys2/MINGW-packages/pull/27847 (https://github.com/msys2/MINGW-packages/actions/runs/21918828504/job/63293221701?pr=27847), so let's give it a try.