### PR TITLE
kde-apps: update to 25.12.2 (part 4/n)

### DIFF
--- a/mingw-w64-libkexiv2/PKGBUILD
+++ b/mingw-w64-libkexiv2/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=libkexiv2
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=25.08.3
+pkgver=25.12.2
 pkgrel=1
 pkgdesc='A library to manipulate pictures metadata (mingw-w64)'
 arch=('any')
@@ -26,7 +26,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-ninja"
 )
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('0806898554b62a6f834d33bb481923d82bde91b1692ba7b146fec94b9a503d03'
+sha256sums=('b8d914d03ca96b4e2d3a1707af424980a7f0685b109220b25efb76ed7e7778b6'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>

--- a/mingw-w64-lokalize/PKGBUILD
+++ b/mingw-w64-lokalize/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=lokalize
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=25.08.3
+pkgver=25.12.2
 pkgrel=1
 pkgdesc="Computer-Aided Translation System (mingw-w64)"
 arch=('any')
@@ -52,7 +52,7 @@ groups=(
 )
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig}
         '0002-lokalize-22.04.3-fix-cast.patch')
-sha256sums=('079e3fcda3a74ef7acb1b3063eeeb10237e736466bd49953762a65d08ef11483'
+sha256sums=('ca223a1e394c3e30ff3633ef20fea2d63a5a2060008328f38e942617f16b6ece'
             'SKIP'
             'd11a8f48dfc0dcd8d85f0b364a917f40d5d7b01bcd74726336c557e6e18339fe')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>

--- a/mingw-w64-okular/PKGBUILD
+++ b/mingw-w64-okular/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=okular
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=25.12.1
+pkgver=25.12.2
 pkgrel=1
 pkgdesc='Document Viewer (mingw-w64)'
 arch=('any')
@@ -73,7 +73,7 @@ groups=(
   "${MINGW_PACKAGE_PREFIX}-kde-utilities"
 )
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('989044c64489f0349584e54a3df212984ea3b8b130b8e2df7a285dfa4b16e6eb'
+sha256sums=('9c84a80fe2a3dd0990b56432912244b6f5761a1a6abda452f3da6e7e6a88937f'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>

--- a/mingw-w64-umbrello/PKGBUILD
+++ b/mingw-w64-umbrello/PKGBUILD
@@ -5,7 +5,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=umbrello
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=25.08.3
+pkgver=25.12.2
 pkgrel=1
 pkgdesc="UML modeller (mingw-w64)"
 arch=('any')
@@ -38,7 +38,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-ki18n-qt5${_namesuff}"
          "${MINGW_PACKAGE_PREFIX}-kcrash-qt5${_namesuff}"
          "${MINGW_PACKAGE_PREFIX}-hicolor-icon-theme")
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('9048a6159c8486248a95b956ed08c1954ac21708b89a81fe6a3b0aa7a5207a2c'
+sha256sums=('7a2019690819ba6e8a13f755df544f0b805169a0035a63ae6bdc7dc5f2f559c2'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>


### PR DESCRIPTION
* libkexiv2: update to 25.12.2
* lokalize: update to 25.12.2
* okular: update to 25.12.2
* umbrello: update to 25.12.2

Succeeded on UCRT64 in https://github.com/msys2/MINGW-packages/pull/27847 (https://github.com/msys2/MINGW-packages/actions/runs/21918828504/job/63293221701?pr=27847), so let's give it a try.

_Edit:_ Also succeeded on CLANGARM64 in #27847 (see https://github.com/msys2/MINGW-packages/actions/runs/21918828504/job/63293221755?pr=27847).