### PR TITLE
pymol: switch to pyqt6

### DIFF
--- a/mingw-w64-pymol/PKGBUILD
+++ b/mingw-w64-pymol/PKGBUILD
@@ -4,7 +4,7 @@ _realname=pymol
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=3.1.0
-pkgrel=4
+pkgrel=5
 pkgdesc="Molecular visualization system on an Open Source foundation (mingw-w64)"
 arch=(any)
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -19,7 +19,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-freetype"
          "${MINGW_PACKAGE_PREFIX}-glew"
          "${MINGW_PACKAGE_PREFIX}-glm"
          "${MINGW_PACKAGE_PREFIX}-libxml2"
-         "${MINGW_PACKAGE_PREFIX}-python-pyqt5"
+         "${MINGW_PACKAGE_PREFIX}-python-pyqt6"
          "${MINGW_PACKAGE_PREFIX}-netcdf"
          "${MINGW_PACKAGE_PREFIX}-netcdf-cxx"
          "${MINGW_PACKAGE_PREFIX}-python"


### PR DESCRIPTION
* Follow archlinux's change at https://gitlab.archlinux.org/archlinux/packaging/packages/pymol/-/commit/1f5d6fddc24b4be06a8dc99ef871423cda664bc8