### PR TITLE
python-filelock: update to 3.21.2

### DIFF
--- a/mingw-w64-python-filelock/PKGBUILD
+++ b/mingw-w64-python-filelock/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=filelock
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=3.20.3
-pkgrel=2
+pkgver=3.21.2
+pkgrel=1
 pkgdesc="A platform independent file lock (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -23,9 +23,12 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-hatchling"
              "${MINGW_PACKAGE_PREFIX}-python-hatch-vcs")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest"
-              "${MINGW_PACKAGE_PREFIX}-python-pytest-timeout")
+              "${MINGW_PACKAGE_PREFIX}-python-pytest-asyncio"
+              "${MINGW_PACKAGE_PREFIX}-python-pytest-mock"
+              "${MINGW_PACKAGE_PREFIX}-python-pytest-timeout"
+              "${MINGW_PACKAGE_PREFIX}-python-virtualenv")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1')
+sha256sums=('cfd218cfccf8b947fce7837da312ec3359d10ef2a47c8602edd59e0bacffb708')
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
@@ -34,7 +37,7 @@ build() {
 
 check() {
   cd "${srcdir}/python-build-${MSYSTEM}"
-  PYTHONPATH=src ${MINGW_PREFIX}/bin/pytest tests || warning "Tests failed"
+  PYTHONPATH=src ${MINGW_PREFIX}/bin/pytest tests
 }
 
 package() {


### PR DESCRIPTION
* also add missing checkdepends