### PR TITLE
eog-plugins: remove gdata dependency

### DIFF
--- a/mingw-w64-eog-plugins/PKGBUILD
+++ b/mingw-w64-eog-plugins/PKGBUILD
@@ -4,7 +4,7 @@ _realname=eog-plugins
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=44.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Eye of GNOME graphics viewer program - plugins (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -13,7 +13,6 @@ msys2_repository_url="https://gitlab.gnome.org/GNOME/eog-plugins"
 license=("spdx:GPL-2.0-or-later")
 depends=("${MINGW_PACKAGE_PREFIX}-eog"
          "${MINGW_PACKAGE_PREFIX}-libexif"
-         "${MINGW_PACKAGE_PREFIX}-libgdata"
          "${MINGW_PACKAGE_PREFIX}-libpeas"
          "${MINGW_PACKAGE_PREFIX}-gettext-runtime"
          "${MINGW_PACKAGE_PREFIX}-gtk-update-icon-cache"
@@ -36,6 +35,7 @@ build() {
       --auto-features=enabled \
       --buildtype=plain \
       -Dplugin_map=false \
+      -Dplugin_postasa=false \
       "build-${MSYSTEM}" \
       "${_realname}-${pkgver}"
 


### PR DESCRIPTION
gdata is unmaintained and one of the last things pulling in libsoup v2. Disable the "postasa" which depends on it.