### PR TITLE
python-fpdf2: add version 2.8.5 (new package)

### DIFF
--- a/mingw-w64-python-fpdf2/PKGBUILD
+++ b/mingw-w64-python-fpdf2/PKGBUILD
@@ -1,0 +1,43 @@
+# Contributor: Dirk Stolle
+
+_realname=fpdf2
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=2.8.5
+pkgrel=1
+pkgdesc="Simple and fast PDF document generation in Python (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://py-pdf.github.io/fpdf2/'
+msys2_repository_url='https://github.com/py-pdf/fpdf2'
+msys2_changelog_url='https://github.com/py-pdf/fpdf2/blob/master/CHANGELOG.md'
+msys2_references=(
+  'purl: pkg:pypi/fpdf2'
+)
+license=('spdx:LGPL-3.0-only')
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-defusedxml"
+         "${MINGW_PACKAGE_PREFIX}-python-fonttools"
+         "${MINGW_PACKAGE_PREFIX}-python-pillow")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('af4491ef2e0a5fe476f9d61362925658949c995f7e804438c0e81008f1550247')
+
+build() {
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}


### PR DESCRIPTION
It's required by ocrmypdf 17.2.0. See <https://github.com/msys2/MINGW-packages/pull/27892#issuecomment-3897674385>.