### PR TITLE
python-uharfbuzz: add version 0.53.3 (new package)

### DIFF
--- a/mingw-w64-python-uharfbuzz/PKGBUILD
+++ b/mingw-w64-python-uharfbuzz/PKGBUILD
@@ -1,0 +1,61 @@
+# Contributor: Dirk Stolle
+
+_realname=uharfbuzz
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=0.53.3
+pkgrel=1
+pkgdesc="HarfBuzz Python binding (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://uharfbuzz.readthedocs.io/'
+msys2_repository_url='https://github.com/harfbuzz/uharfbuzz'
+msys2_references=(
+  'purl: pkg:pypi/uharfbuzz'
+)
+license=('spdx:Apache-2.0')
+depends=("${MINGW_PACKAGE_PREFIX}-harfbuzz"
+         "${MINGW_PACKAGE_PREFIX}-python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cython"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-pkgconfig"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('9a87175c14d1361322ce2a3504e63c6b66062934a5edf47266aed5b33416806c')
+
+prepare() {
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}
+}
+
+build() {
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  export USE_SYSTEM_LIBS=1
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+check() {
+  cd "python-build-${MSYSTEM}"
+
+  # run tests in venv
+  python -m venv --system-site-packages test-venv
+  test-venv/bin/python -m installer dist/*.whl
+  test-venv/bin/python -m pytest || echo "Some tests failed."
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}


### PR DESCRIPTION
It's required as dependency of ocrmypdf 17.2.0. See <https://github.com/msys2/MINGW-packages/pull/27892#issuecomment-3897674385>.