### PR TITLE
libgda: remove libsoup support

### DIFF
--- a/mingw-w64-libgda/PKGBUILD
+++ b/mingw-w64-libgda/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libgda
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=6.0.0
-pkgrel=5
+pkgrel=6
 pkgdesc="GDA (GNOME Data Access) library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -25,7 +25,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-cairo"
          "${MINGW_PACKAGE_PREFIX}-iso-codes"
          "${MINGW_PACKAGE_PREFIX}-json-glib"
          "${MINGW_PACKAGE_PREFIX}-libsecret"
-         "${MINGW_PACKAGE_PREFIX}-libsoup"
          "${MINGW_PACKAGE_PREFIX}-libxml2"
          "${MINGW_PACKAGE_PREFIX}-libxslt"
          "${MINGW_PACKAGE_PREFIX}-glade"
@@ -112,6 +111,7 @@ build() {
     -Ddoc=true \
     -Dexperimental=true \
     -Dldap=true \
+    -Dlibsoup=false \
     ../${_realname}-${pkgver}
 
   meson compile || meson compile


### PR DESCRIPTION
we want to drop it and this is the only remaining user