### PR TITLE
ncurses: don't install nc_win32.h

### DIFF
--- a/mingw-w64-ncurses/PKGBUILD
+++ b/mingw-w64-ncurses/PKGBUILD
@@ -4,7 +4,7 @@ _realname=ncurses
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=6.6
-pkgrel=1
+pkgrel=2
 pkgdesc="System V Release 4.0 curses emulation library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -89,6 +89,9 @@ package() {
   cd "${srcdir}"/build-${MSYSTEM}
 
   make DESTDIR="${pkgdir}" install
+
+  # https://github.com/msys2/MINGW-packages/issues/27676#issuecomment-3902356595
+  rm "${pkgdir}"${MINGW_PREFIX}/include/ncursesw/nc_win32.h
 
   cp -r "${pkgdir}"${MINGW_PREFIX}/include/ncursesw "${pkgdir}"${MINGW_PREFIX}/include/ncurses
   cp "${pkgdir}"${MINGW_PREFIX}/lib/libncursesw.a "${pkgdir}"${MINGW_PREFIX}/lib/libncurses.a


### PR DESCRIPTION
it's not supposed to be installed, see
https://github.com/msys2/MINGW-packages/issues/27676#issuecomment-3902356595

Fixes #27676