### PR TITLE
hexchat: update to new upstream

### DIFF
--- a/mingw-w64-hexchat/PKGBUILD
+++ b/mingw-w64-hexchat/PKGBUILD
@@ -3,13 +3,13 @@
 _realname=hexchat
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.16.2
-pkgrel=7
+pkgver=3.0.1
+pkgrel=1
 pkgdesc='A popular and easy to use graphical IRC (chat) client (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
-url='https://hexchat.github.io/'
-msys2_repository_url="https://github.com/hexchat/hexchat"
+url='https://gitlab.com/bgermann/hexchat'
+msys2_repository_url="https://gitlab.com/bgermann/hexchat"
 msys2_references=(
   "cpe: cpe:/a:hexchat_project:hexchat"
 )
@@ -19,7 +19,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-dbus-glib"
          "${MINGW_PACKAGE_PREFIX}-gdk-pixbuf2"
          "${MINGW_PACKAGE_PREFIX}-gettext-runtime"
          "${MINGW_PACKAGE_PREFIX}-glib2"
-         "${MINGW_PACKAGE_PREFIX}-gtk2"
+         "${MINGW_PACKAGE_PREFIX}-gtk3"
          "${MINGW_PACKAGE_PREFIX}-libwinpthread"
          "${MINGW_PACKAGE_PREFIX}-openssl"
          "${MINGW_PACKAGE_PREFIX}-pango")
@@ -36,10 +36,10 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-enchant: Spell check"
             "${MINGW_PACKAGE_PREFIX}-luajit: Lua plugin"
             #"${MINGW_PACKAGE_PREFIX}-perl: Perl plugin"
             "${MINGW_PACKAGE_PREFIX}-python-cffi: Python plugin")
-source=("https://github.com/hexchat/hexchat/releases/download/v${pkgver}/hexchat-${pkgver}.tar.xz"
+source=("https://gitlab.com/bgermann/hexchat/-/archive/v${pkgver}/hexchat-v${pkgver}.tar.gz"
         0001-meson-add-winpthread.patch
         0002-fix-plugin-search.patch)
-sha256sums=('2e88340a8da274b87373ec0740746da78120cc6fbfdd201a4dd6999cac790e4a'
+sha256sums=('125d5715b0e7dc14f8d71b6f2b0cc5bf88ed9db67c6ae565e6168829ab6e2284'
             '39dc5fe131bcd8575e0d3fd274fa4bf3b59e1d9873ad629ff176028619edf268'
             '02d87882b514628acdb05ffe21a716eb74a97dc28eae517f88a1db3c62f0c19f')
 
@@ -59,9 +59,6 @@ build() {
     _extra_config+=("--buildtype=debug")
   fi
 
-  #
-  # Options are from upstream/.github/workflows/msys-build.yml
-  #
   MSYS2_ARG_CONV_EXCL="--prefix=" \
   ${MINGW_PREFIX}/bin/meson.exe \
     --prefix="${MINGW_PREFIX}" \


### PR DESCRIPTION
This updates the upstream from the abandoned GTK 2 version to a recent GTK 3 fork.