### PR TITLE
transmission: Update to 4.1.1

### DIFF
--- a/mingw-w64-transmission/PKGBUILD
+++ b/mingw-w64-transmission/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-cli"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-gtk"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-qt")
-pkgver=4.1.0
+pkgver=4.1.1
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -38,7 +38,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 source=("https://github.com/transmission/transmission/releases/download/${pkgver}/transmission-${pkgver}.tar.xz"
         "0001-transmission-relocate-web-dir.patch"
         "0003-disable-com.patch")
-sha256sums=('dcd28c1c9e6126229c4c17dbc9e95c9fd4aed7e76f4a1f2a74604c8cddec49d6'
+sha256sums=('e743283ee03a42c4d0b08fed2bd52b554aa6c9f65b4d4d45b795c32d98762a79'
             '6e898ad756af8a907c5a0afc19dd684d723b0cea43e2c31b97003f867b13a535'
             '609a5c53140ed936aea875d11b53724ba527db150beda828a8f9527fff83c9a5')
 noextract=("transmission-${pkgver}.tar.xz")
@@ -143,8 +143,6 @@ package_transmission-qt() {
   DESTDIR="${pkgdir}" cmake --install .
 
   rm -rf "${pkgdir}${MINGW_PREFIX}/etc"
-  # icons conflict with gtk version
-  rm -rf "${pkgdir}${MINGW_PREFIX}/share/icons/"
 
   cd "${srcdir}/${_realname}-${pkgver}"
 


### PR DESCRIPTION
the icon conflict is fixed, so remove the workaround