### PR TITLE
ocrmypdf: update to 17.3.0

### DIFF
--- a/mingw-w64-ocrmypdf/PKGBUILD
+++ b/mingw-w64-ocrmypdf/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=ocrmypdf
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=17.2.0
+pkgver=17.3.0
 pkgrel=1
 pkgdesc="A tool to add an OCR text layer to scanned PDF files, allowing them to be searched (mingw-w64)"
 arch=('any')
@@ -39,12 +39,11 @@ depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-unpaper")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-hatchling"
-             "${MINGW_PACKAGE_PREFIX}-python-hatch-vcs"
              "${MINGW_PACKAGE_PREFIX}-python-installer")
 options=('!strip')
 source=("https://files.pythonhosted.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
         "0001-pypdfium2-optional.patch")
-sha256sums=('ad4dc266f6cf63608716707a76c54177687c422c75ee301d454b3d9b1d9b434a'
+sha256sums=('4022f13aad3f405e330056a07aa8bd63714b48b414693831b56e2cf2c325f52d'
             '0963f066a1c790c723abf9e94a0c6a38ba608992ea7de6bb3cda63177cd2fc3b')
 
 prepare() {


### PR DESCRIPTION
python-hatch-vcs is no longer needed during builds.