### PR TITLE
pyside2: hack to make it work with Python 3.14

### DIFF
--- a/mingw-w64-pyside2/021-py314-metaclass-compat.patch
+++ b/mingw-w64-pyside2/021-py314-metaclass-compat.patch
@@ -1,0 +1,21 @@
+--- pyside-setup-opensource-src-5.15.18/sources/shiboken2/libshiboken/basewrapper.cpp.orig	2025-10-04 08:15:58.000000000 +0200
++++ pyside-setup-opensource-src-5.15.18/sources/shiboken2/libshiboken/basewrapper.cpp	2026-02-22 11:54:04.421186700 +0100
+@@ -1169,7 +1169,18 @@
+ {
+     typeSpec->slots[0].pfunc = reinterpret_cast<void *>(baseType ? baseType : SbkObject_TypeF());
+ 
++#if PY_VERSION_HEX >= 0x030e0000
++    // HACK: Python 3.14 rejects metaclasses with custom tp_new in PyType_FromSpec.
++    // Temporarily replace with stock tp_new, then restore.
++    SbkObjectType_TypeF()->tp_new = PyType_Type.tp_new;
++#endif
++
+     PyObject *heaptype = SbkType_FromSpecWithBases(typeSpec, baseTypes);
++
++#if PY_VERSION_HEX >= 0x030e0000
++    SbkObjectType_TypeF()->tp_new = SbkObjectTypeTpNew;
++#endif
++
+     heaptype->ob_type = SbkObjectType_TypeF();
+     Py_INCREF(Py_TYPE(heaptype));
+     auto *type = reinterpret_cast<SbkObjectType *>(heaptype);

--- a/mingw-w64-pyside2/PKGBUILD
+++ b/mingw-w64-pyside2/PKGBUILD
@@ -8,7 +8,7 @@ pkgname=(${MINGW_PACKAGE_PREFIX}-shiboken2
          ${MINGW_PACKAGE_PREFIX}-${_realname}-tools)
 pkgdesc="Provides LGPL Qt5 bindings for Python and related tools for binding generation (mingw-w64)"
 pkgver=5.15.18
-pkgrel=5
+pkgrel=6
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://doc.qt.io/qtforpython-5/"
@@ -55,7 +55,8 @@ source=(https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-${p
         Use-public-version-of-PyLong_AsInt-for-Python-3.13.patch
         Do-the-transition-to-Python-3.13.patch
         Fix-condition-to-allow-3.13-for-wheel-creation.patch
-        020-python314.patch)
+        020-python314.patch
+        021-py314-metaclass-compat.patch)
 noextract=("${_pkgfqn}.tar.xz")
 sha256sums=('aa13963698991589fdec4f19735c6fd7200b7544ba521d64a69e2cea365fd98b'
             '8120f1d29c4fe6928ab58d01586370af6d7c03f5a4c656d3e80ea03965a032d5'
@@ -68,7 +69,8 @@ sha256sums=('aa13963698991589fdec4f19735c6fd7200b7544ba521d64a69e2cea365fd98b'
             'e6340091cfaf9ab1cb8cf6d60ee60a07a1a38a3dcaf3974a9c4705e1f87df705'
             'a35ec1dd8b50aa296e775baa389253b42dc3bb1e1cf1c08afc117a03856aaa08'
             '0f8549de5c6e98488277de9f6c548443b0ff6eca39a1253aca23b3389febab6f'
-            'a94c3f8881c586d5349b5220867bd4c4081dd8816a468530990673e6578860b1')
+            'a94c3f8881c586d5349b5220867bd4c4081dd8816a468530990673e6578860b1'
+            '28ddcf088105dcdd7ce8d9938ee49ebebc50c75d565330df8e334354106d5027')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -104,6 +106,11 @@ prepare() {
 
   apply_patch_with_msg \
     020-python314.patch
+
+  # https://github.com/msys2/MINGW-packages/issues/27991
+  # https://github.com/python/cpython/issues/123909
+  apply_patch_with_msg \
+    021-py314-metaclass-compat.patch
 }
 
 build() {


### PR DESCRIPTION
SbkType_FromSpecWithBases() fails because custom tp_new is no longer allowed in 3.14, and because there is no error handling there it crashes. Work around by setting a tp_new later anyway. Not sure what that could break, but maybe it gives us another year until 3.15.

Fixes #27991