### PR TITLE
mesa: update to 26.0.0

### DIFF
--- a/mingw-w64-mesa/0001-replace-undefined-NULL-with-0.patch
+++ b/mingw-w64-mesa/0001-replace-undefined-NULL-with-0.patch
@@ -1,0 +1,13 @@
+diff --git a/src/util/os_misc.h b/src/util/os_misc.h
+index 03cd59c..00a2561 100644
+--- a/src/util/os_misc.h
++++ b/src/util/os_misc.h
+@@ -148,7 +148,7 @@ os_set_option(const char *name, const char *value, bool override);
+ static inline void
+ os_unset_option(const char *name)
+ {
+-   os_set_option(name, NULL, true);
++   os_set_option(name, 0, true);
+ }
+ 
+ /*

--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=25.3.5
+pkgver=26.0.0
 pkgrel=1
 pkgdesc="Open-source implementation of the OpenGL, Vulkan and OpenCL specifications (mingw-w64)"
 arch=('any')
@@ -44,10 +44,12 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 optdepends=("${MINGW_PACKAGE_PREFIX}-opengl-man-pages: for the OpenGL API man pages"
             "${MINGW_PACKAGE_PREFIX}-vulkan-validation-layers: to debug applications using Vulkan graphics")
 source=(https://mesa.freedesktop.org/archive/${_realname}-${pkgver}.tar.xz{,.sig}
-        0000-addrlib-workaround-old-cpu-target.patch)
-sha256sums=('be472413475082df945e0f9be34f5af008baa03eb357e067ce5a611a2d44c44b'
+        0000-addrlib-workaround-old-cpu-target.patch
+        0001-replace-undefined-NULL-with-0.patch)
+sha256sums=('2a44e98e64d5c36cec64633de2d0ec7eff64703ee25b35364ba8fcaa84f33f72'
             'SKIP'
-            '4e511b1ab380d0e7d1f152f89c82665e5ef7de96f26de1b5597aa1db85cfc5a4')
+            '4e511b1ab380d0e7d1f152f89c82665e5ef7de96f26de1b5597aa1db85cfc5a4'
+            '9c69d5c85fb99ce85214cafe42318ea30429c0c27962184548912bdb4076010a')
 validpgpkeys=('8703B6700E7EE06D7A39B8D6EDAE37B02CEB490D' # Emil Velikov <emil.l.velikov@gmail.com>
               '946D09B5E4C9845E63075FF1D961C596A7203456' # Andres Gomez <tanty@igalia.com>
               'E3E8F480C52ADD73B278EE78E1ECBE07D7D70895' # Juan Antonio Suárez Romero (Igalia, S.L.) <jasuarez@igalia.com>"
@@ -82,7 +84,8 @@ prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
 
   apply_patch_with_msg \
-    0000-addrlib-workaround-old-cpu-target.patch
+    0000-addrlib-workaround-old-cpu-target.patch \
+    0001-replace-undefined-NULL-with-0.patch
 
   # Tie clang clc linking mode to static-libclc instead of shared-llvm
   sed -e "s|_shared_llvm|false|g" \


### PR DESCRIPTION
For some reasons, a 6 years old file now has its NULL undefined. I replaced that with 0, and it should work without any issues.