### PR TITLE
octave: update to 11.1.0

### DIFF
--- a/mingw-w64-octave/0003-no-community-support.patch
+++ b/mingw-w64-octave/0003-no-community-support.patch
@@ -6,16 +6,16 @@
 # Parent  89850bb5eb31f776d527aa14295100be61a1e7b4
 Add note about no community support for CLANG*64 versions.
 
-diff -r 89850bb5eb31 -r aaffb33108d3 liboctave/version.cc
---- octave-9.1.0/liboctave/version.cc.orig	2024-03-15 18:57:08.844733200 +0100
-+++ octave-9.1.0/liboctave/version.cc	2024-03-15 18:59:07.632471500 +0100
-@@ -76,7 +76,8 @@
+diff -urN octave-11.1.0/liboctave/version.cc.orig octave-11.1.0/liboctave/version.cc
+--- octave-11.1.0/liboctave/version.cc.orig	2026-02-18 18:54:40.000000000 +0100
++++ octave-11.1.0/liboctave/version.cc	2026-02-23 10:04:59.860669800 +0100
+@@ -69,7 +69,8 @@
+   std::string br = (html ? "<br>\n" : "\n");
  
-   return "GNU Octave, version " OCTAVE_VERSION
-          + br
+   return "GNU Octave (" OCTAVE_CANONICAL_HOST_TYPE ") version " OCTAVE_VERSION + br
 -         + OCTAVE_COPYRIGHT;
-+         + OCTAVE_COPYRIGHT
-+         "\n\nThis version is not supported by the Octave community.\n";
++         + OCTAVE_COPYRIGHT + br + br
++         + "This version is not supported by the Octave community.";
  }
  
  std::string

--- a/mingw-w64-octave/PKGBUILD
+++ b/mingw-w64-octave/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=octave
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-pkgver=10.3.0
-pkgrel=2
+pkgver=11.1.0
+pkgrel=1
 pkgdesc="GNU Octave: Interactive programming environment for numerical computations (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -65,9 +65,9 @@ source=(https://ftpmirror.gnu.org/gnu/octave/octave-$pkgver.tar.xz{,.sig}
         "0003-no-community-support.patch"
         "0005-makeinfo-perl.patch")
 validpgpkeys=('DBD9C84E39FE1AAE99F04446B05F05B75D36644B')  # John W. Eaton
-sha256sums=('92ae9bf2edcd288bd2df9fd0b4f7aa719b49d3940fceb154c5fdcd846f254da1'
+sha256sums=('8b3e2d0ec1809e8a2bed11de779014b6eb6a469c0caad1b339d29a6126e3cb6a'
             'SKIP'
-            'e53af21ad087e10a2906506589aab89ab8b43f4e3e4994b4c28e4d8ae83639ad'
+            '30e4bc5913796efcf944be13dec230b4046858f8b1e5f4d786099daba4f7ade4'
             '2df9666d75bb8dd4f549ec857c75aa3ec64b21fd3c9aa25a0d4127b284ec6822')
 
 apply_patch_with_msg() {


### PR DESCRIPTION
The GNU servers are intermittently unavailable or extremely slow in recent months. Download the source tarball from one of the mirrors instead.

Also, refresh patch for CLANG* environments.