### PR TITLE
alacritty: use signed version of repo

### DIFF
--- a/mingw-w64-alacritty/PKGBUILD
+++ b/mingw-w64-alacritty/PKGBUILD
@@ -21,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              'git')
 checkdepends=("${MINGW_PACKAGE_PREFIX}-ttf-dejavu")
 optdepends=("${MINGW_PACKAGE_PREFIX}-ncurses: for alacritty terminfo database")
-source=("git+${msys2_repository_url}.git#tag=v${pkgver}")
+source=("git+${msys2_repository_url}.git#tag=v${pkgver}?signed")
 validpgpkeys=('4DAA67A9EA8B91FCC15B699C85CDAE3C164BA7B4'  # Christian Dürr <contact@christianduerr.com>
               'A56EF308A9F1256C25ACA3807EA8F8B94622A6A9') # Kirill Chibisov <contact@kchibisov.com>
 sha256sums=('e339261179f7edcaf9c28b1646d5a6761e76eae62078f07c308e8efa9ace18bb')


### PR DESCRIPTION
back in days when I added this package, I dropped git source because there were no repo checksums. when I brought it back, I didn't mind using signed source at all. no rebuild, just doing this so I won't forgot