### PR TITLE
use mingw git in packaging if we're not strictly required to use msys…

### DIFF
--- a/mingw-w64-cargo-tauri/PKGBUILD
+++ b/mingw-w64-cargo-tauri/PKGBUILD
@@ -17,7 +17,7 @@ msys2_references=(
 )
 license=('spdx:MIT OR Apache-2.0')
 depends=("${MINGW_PACKAGE_PREFIX}-rust")
-makedepends=('git')
+makedepends=("${MINGW_PACKAGE_PREFIX}-git")
 source=("${msys2_repository_url}/archive/${_basename}-cli-v${pkgver}/${_basename}-${_basename}-cli-v${pkgver}.tar.gz")
 noextract=("${_basename}-${_basename}-cli-v${pkgver}.tar.gz")
 sha256sums=('af537feacfc2d148cf5ce8f5fc53cb2571a310d89ec428cb4d403b1690676384')

--- a/mingw-w64-dotslash/PKGBUILD
+++ b/mingw-w64-dotslash/PKGBUILD
@@ -14,7 +14,7 @@ license=('spdx:Apache-2.0 OR MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-bzip2" "${MINGW_PACKAGE_PREFIX}-zstd")
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
-             'git')
+             "${MINGW_PACKAGE_PREFIX}-git")
 options=('!strip')
 source=("${url}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
         "bzip2-sys.tar.gz::https://crates.io/api/v1/crates/bzip2-sys/0.1.11+1.0.8/download"

--- a/mingw-w64-openai-codex/PKGBUILD
+++ b/mingw-w64-openai-codex/PKGBUILD
@@ -16,7 +16,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-dotslash"
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-openssl"
-             'git')
+             "${MINGW_PACKAGE_PREFIX}-git")
 optdepends=(
   "${MINGW_PACKAGE_PREFIX}-ripgrep: accelerated large-repo search"
   "git: allow for repository actions"

--- a/mingw-w64-pixi/PKGBUILD
+++ b/mingw-w64-pixi/PKGBUILD
@@ -12,7 +12,7 @@ url='https://pixi.sh/'
 msys2_repository_url="https://github.com/prefix-dev/pixi/"
 license=('spdx:BSD-3-Clause')
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
-             'git')
+             "${MINGW_PACKAGE_PREFIX}-git")
 options=('!strip')
 source=("${msys2_repository_url}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
         "0001-fix-msvc-style-flags.patch"

--- a/mingw-w64-rustfs/PKGBUILD
+++ b/mingw-w64-rustfs/PKGBUILD
@@ -27,7 +27,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-openssl"
   "${MINGW_PACKAGE_PREFIX}-flatbuffers"
   "${MINGW_PACKAGE_PREFIX}-protobuf"
-  'git'
+  "${MINGW_PACKAGE_PREFIX}-git"
   'unzip'
 )
 source=(

--- a/mingw-w64-tinymist/PKGBUILD
+++ b/mingw-w64-tinymist/PKGBUILD
@@ -17,7 +17,7 @@ msys2_references=(
   'purl: pkg:cargo/tinymist'
 )
 license=('spdx:Apache-2.0')
-makedepends=("${MINGW_PACKAGE_PREFIX}-rust" 'git')
+makedepends=("${MINGW_PACKAGE_PREFIX}-rust" "${MINGW_PACKAGE_PREFIX}-git")
 source=("${msys2_repository_url}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('215c08d8a10ff51e15711f0684eafc85d119dc98db57f4f47ec7bf5987ea681e')
 

--- a/mingw-w64-tree-sitter/PKGBUILD
+++ b/mingw-w64-tree-sitter/PKGBUILD
@@ -24,7 +24,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-rust-bindgen"
              "${MINGW_PACKAGE_PREFIX}-libwasmtime")
-checkdepends=('git')
+checkdepends=("${MINGW_PACKAGE_PREFIX}-git")
 source=("https://github.com/tree-sitter/tree-sitter/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('8e012493b2103e0471d3aba8048b73bc1a3138132974e2fd8bfb89a63e62f478')
 noextract=("${_realname}-${pkgver}.tar.gz")

--- a/mingw-w64-typst/PKGBUILD
+++ b/mingw-w64-typst/PKGBUILD
@@ -19,7 +19,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-xz")
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-openssl"
-             'git')
+             "${MINGW_PACKAGE_PREFIX}-git")
 source=("https://github.com/typst/typst/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('70a56445020ca05efc571c7b07a1a9f52eb93842d420518693c077ae74e54142')
 

--- a/mingw-w64-wasm-tools/PKGBUILD
+++ b/mingw-w64-wasm-tools/PKGBUILD
@@ -13,10 +13,10 @@ msys2_repository_url="https://github.com/bytecodealliance/wasm-tools"
 license=('spdx:Apache-2.0 WITH LLVM-exception AND Apache-2.0 AND MIT')
 # Update using ./retrieve-testsuite-commit.sh <pkgver>
 _wasm_testsuite_commit=e999a1051925895022ab06abc25b23ca300ab0d0
-makedepends=("${MINGW_PACKAGE_PREFIX}-rust" 'git')
+makedepends=("${MINGW_PACKAGE_PREFIX}-rust" "${MINGW_PACKAGE_PREFIX}-git")
 source=(
   "https://github.com/bytecodealliance/${_realname}/archive/refs/tags/v${pkgver}/${_realname}-${pkgver}.tar.gz"
-	"https://github.com/WebAssembly/testsuite/archive/${_wasm_testsuite_commit}/wasm-testsuite-${_wasm_testsuite_commit}.tar.gz"
+  "https://github.com/WebAssembly/testsuite/archive/${_wasm_testsuite_commit}/wasm-testsuite-${_wasm_testsuite_commit}.tar.gz"
 )
 sha256sums=('f8fc02ceec50f0188e4128159535e6c4195594e74c56ecc1db3113e62feb477d'
             'e289c03b4586b92f5e59e30078c4ea96d79fbdc59d993e866c694893473c315c')

--- a/mingw-w64-wgsl-analyzer/PKGBUILD
+++ b/mingw-w64-wgsl-analyzer/PKGBUILD
@@ -13,7 +13,7 @@ url='https://wgsl-analyzer.github.io/'
 msys2_repository_url='https://github.com/wgsl-analyzer/wgsl-analyzer'
 license=('spdx:MIT OR Apache-2.0')
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
-             'git')
+             "${MINGW_PACKAGE_PREFIX}-git")
 source=("${msys2_repository_url}/archive/${_pkgver}/${_realname}-${_pkgver}.tar.gz")
 sha256sums=('f0c93d63c6795d136a6e8bd75f1ae6d53f9204b3f830d9999faf75c0c88e8b2e')
 


### PR DESCRIPTION
…version

self-explanatory. we need msys git only for source repositories fetching. cargo operations and tests can rely on mingw version