### PR TITLE
meshoptimizer: update to 1.0.1

### DIFF
--- a/mingw-w64-meshoptimizer/PKGBUILD
+++ b/mingw-w64-meshoptimizer/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=meshoptimizer
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.0
+pkgver=1.0.1
 pkgrel=1
 pkgdesc="Mesh optimization library that makes meshes smaller and faster to render (mingw-w64)"
 arch=('any')
@@ -17,7 +17,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 source=("https://github.com/zeux/meshoptimizer/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('30d1c3651986b2074e847b17223a7269c9612ab7f148b944250f81214fed4993')
+sha256sums=('9579624541e27e1cd01379c87e1295407e72c49e4b5b3e2f948393f3b68258ac')
 
 build() {
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \


### PR DESCRIPTION
Hm, might want to patch the project version in CMakeLists... or drop this update altogether, it only affects javascript we don't ship anyway?