### PR TITLE
tree-sitter-markdown: update to 0.5.3

### DIFF
--- a/mingw-w64-tree-sitter-markdown/PKGBUILD
+++ b/mingw-w64-tree-sitter-markdown/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=tree-sitter-markdown
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.5.2
+pkgver=0.5.3
 pkgrel=1
 pkgdesc='Markdown grammar for tree-sitter (mingw-w64)'
 arch=('any')
@@ -20,18 +20,13 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-tree-sitter"
   "${MINGW_PACKAGE_PREFIX}-nodejs"
 )
-source=("${_realname}-${pkgver}.tar.gz::${msys2_repository_url}/releases/download/v${pkgver}/${_realname}.tar.gz"
-        "fix-cmake-install.patch")
-sha256sums=('e566f53ee7f0bc1bd3c3775e74e29a78b80db84bc663951eec3615ca55626fac'
-            'd65baa285b7948099d12e3f75f07f4745361794b648f4ae9da320e226b6d13f0')
+source=("${_realname}-${pkgver}.tar.gz::${msys2_repository_url}/releases/download/v${pkgver}/${_realname}.tar.gz")
+sha256sums=('22e40c51810e64c6bf073f0147f3abc167473206789e6dcbed4ba198ff3ca119')
 noextract=("${_realname}-${pkgver}.tar.gz")
 
 prepare() {
   mkdir -p "${_realname}-${pkgver}"
   tar -xf "${_realname}-${pkgver}.tar.gz" -C "${_realname}-${pkgver}" || true
-
-  # https://github.com/tree-sitter-grammars/tree-sitter-markdown/pull/219
-  patch -d "${_realname}-${pkgver}" -p1 -i ../fix-cmake-install.patch
 }
 
 build() {


### PR DESCRIPTION
remove patch, fixed upstream