### PR TITLE
libp11: update to 0.4.18

### DIFF
--- a/mingw-w64-libp11/0002-provider_c-win32-config.patch
+++ b/mingw-w64-libp11/0002-provider_c-win32-config.patch
@@ -1,0 +1,14 @@
+--- src/provider.c.orig	2026-02-23 17:11:17.579060500 -0600
++++ src/provider.c	2026-02-23 17:08:27.816826400 -0600
+@@ -27,9 +27,9 @@
+  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ 
+-#ifndef _WIN32
++#ifndef _MSC_VER
+ #include "config.h"
+-#endif /* _WIN32 */
++#endif /* _MSC_VER */
+ 
+ #include "util.h"
+ 

--- a/mingw-w64-libp11/0003-automake-no-lib-prefix.patch
+++ b/mingw-w64-libp11/0003-automake-no-lib-prefix.patch
@@ -1,0 +1,16 @@
+--- src/Makefile.am.orig	2026-02-24 12:22:03.853426000 -0600
++++ src/Makefile.am	2026-02-24 12:21:41.156910900 -0600
+@@ -147,11 +147,13 @@
+ check-local: $(LTLIBRARIES)
+ 	cd .libs && $(LN_S) -f pkcs11$(SHARED_EXT) libpkcs11$(SHARED_EXT)
+ 
++if !WIN32
+ install-exec-hook:
+ 	cd '$(DESTDIR)$(enginesexecdir)' && $(LN_S) -f pkcs11$(SHARED_EXT) libpkcs11$(SHARED_EXT)
+ if LIBP11_OSSL_PROVIDER
+ 	cd '$(DESTDIR)$(providersexecdir)' && $(LN_S) -f pkcs11prov$(SHARED_EXT) libpkcs11$(SHARED_EXT)
+ endif
++endif
+ 
+ # ----------------------------------------------------------
+ # Windows def file target

--- a/mingw-w64-libp11/PKGBUILD
+++ b/mingw-w64-libp11/PKGBUILD
@@ -3,34 +3,44 @@
 _realname=libp11
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.4.16
-pkgrel=3
+pkgver=0.4.18
+pkgrel=1
 pkgdesc="A library implementing a small layer on top of the PKCS11 API (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://github.com/OpenSC/libp11"
 msys2_repository_url='https://github.com/OpenSC/libp11'
+msys2_references=(
+  'archlinux: libp11'
+  'anitya: 1699'
+)
 license=('spdx:LGPL-2.1-or-later')
 makedepends=("${MINGW_PACKAGE_PREFIX}-openssl"
              "${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-cc")
 depends=("${MINGW_PACKAGE_PREFIX}-openssl")
-# optdepends("${MINGW_PACKAGE_PREFIX}-p11-kit: seamless PKCS#11 modules integration")
+optdepends=("${MINGW_PACKAGE_PREFIX}-p11-kit: seamless PKCS#11 modules integration")
 source=("https://github.com/OpenSC/libp11/releases/download/libp11-${pkgver}/libp11-${pkgver}.tar.gz"{,.asc}
         0001-relocate-pkgconfig-install-paths.patch
+        0002-provider_c-win32-config.patch
+        0003-automake-no-lib-prefix.patch
         "engine_h_win32.patch"
         "readme.msys2")
-sha256sums=('97777640492fa9e5831497e5892e291dfbf39a7b119d9cb6abb3ec8c56d17553'
+sha256sums=('9292de67ca73aba1deacf577c9086b595765f36ef47712cfeb49fa31f6e772fb'
             'SKIP'
             '2637e24bd085de10d1330a7df71ffa1d4d25265d55ce38f03788a8b641c614cc'
+            '3592316f9384c02364a0f2afc67a0ff651728e666b566e526dca4e04de66b7c5'
+            'a494c75cb168bb84b80c5d771fcb7137694362f9b7522ec5aa51e3079e3be668'
             '199b35e7e6dac997c7cc08096e9d7bc3ba8ab1c222b5d63b4eeaadaafa5ceeca'
-            '73d7e42d25a6f109f089066e6e6c483471ab7b4f78e3401f9d3783a2fd151667')
+            '4bf65aea50c96933049b260d0bd83665f09b142e57b8d587ba32c5c24b2fe65a')
 validpgpkeys=('AC915EA30645D9D3D4DAE4FEB1048932DD3AAAA3') # Michał Trojnara <Michal.Trojnara@stunnel.org>
 
 prepare() {
   cd "${_realname}-${pkgver}"
   patch -p1 -i "${srcdir}"/engine_h_win32.patch
   patch -p1 -i "${srcdir}"/0001-relocate-pkgconfig-install-paths.patch
+  patch -p0 -i "${srcdir}"/0002-provider_c-win32-config.patch
+  patch -p0 -i "${srcdir}"/0003-automake-no-lib-prefix.patch
 
   autoreconf -fi
 }

--- a/mingw-w64-libp11/readme.msys2
+++ b/mingw-w64-libp11/readme.msys2
@@ -1,8 +1,61 @@
-This package is built to leverage p11-kit proxy.
+﻿This package has both OpenSC engine and provider for OpenSSL as well as standalone wrapper
+library to talk to PKCS#11 middleware. It is built to leverage p11-kit proxy allowing to
+use multiple hardware tokens with a single OpenSSL configuration.
 
-Normally, one would specify PKCS#11 module to use explicitly, e.g. for YubiKey
+There are too many moving parts while some are optional and there are plenty of similarly
+named DLLs. Therefore, here is beginner-friendly overview showing dependencies and
+potential entry points for application.
+
+            +---------------------------+
+            |       OpenSSL PKCS#11     |<--??? e.g. curl
+            +----------+----------------+
+            | provider | engine(legacy) |
+            +----------+----------------+
+               |     |        |
+         +-----+     +--+     +------------+
+         |              |                  |
+         v              v                  v
++-----------------+  +------------------+---------------+
+| pkcs11-provider |  |  pkcs11prov.dll  |  pkcs11.dll   |
+| (mature         |  +------------------+---------------+
+|    alternative) |  | (statically linked) libp11-3.dll |<-???
++-----------------+  +----------------------------------+
+       |      |                  |            |
+       |      v                  v            |
+       |  +--------------------------------+  |
+       |  | p11-kit proxy libp11-kit-0.dll |<-|---???
+       |  +--------------------------------+  |
+       |                  |                   |
+       v                  v                   v
+  +----------------------------------------------+
+  | Vendor-specific PKCS#11 modules (middleware) |<--??? e.g. Firefox
+  +---------------+-------------------+----------+
+  | libykcs11.dll | opensc-pkcs11.dll |   ...    |   ??? e.g., Chrome
+  +---------------+-------------------+----------+     |
+                 |            |                        v
+yubico-piv-tool  v            |  +-------------+  +----------+
+  |    +--------------+       |  |    Vendor   |<-| CAPI/CSP |
+  +--->| libykpiv.dll |       |  | mini-driver |  | CNG/KSP  |
+       +--------------+       |  +-------------+  +----------+
+            |                 |         |
+            v                 v         v
+    +---------------------------------------------+
+    | PC/SC, Windows Smart Card API  WinSCard.dll |<--??? e.g. ykman
+    +---------------------------------------------+
+               |
+               v
+     +---------------+ USB CCID +--------------+
+     | kernel driver |--------->| Hardware key |
+     +---------------+          +--------------+
+
+Normally, one would specify PKCS#11 module to use explicitly for either OpenSSL engine
+(legacy) or provider via environment variables, e.g. for YubiKey
 
   $ PKCS11_MODULE_PATH=libykcs11.dll openssl pkeyutl -engine pkcs11 -keyform engine \
+  -inkey "pkcs11:object=Private key for PIV Authentication;type=private;pin-value=123456" \
+  -sign -in data.txt -out data.sig
+
+  $ PKCS11_MODULE_PATH=libykcs11.dll openssl pkeyutl -provider pkcs11prov \
   -inkey "pkcs11:object=Private key for PIV Authentication;type=private;pin-value=123456" \
   -sign -in data.txt -out data.sig
 
@@ -15,11 +68,21 @@ location along with a properly configured module, e.g. by creating a file
 
   module: C:\Program Files\OpenSC Project\OpenSC\pkcs11\opensc-pkcs11.dll
 
-then you would be able to use it implicitly, e.g.
+then you would be able to use it implicitly, e.g. using OpenSSL engine
 
   $ openssl pkeyutl -engine pkcs11 -keyform engine \
   -inkey "pkcs11:token=some_cn;type=private;pin-value=123456" \
   -sign -in data.txt -out data.sig
+
+or using OpenSSL provider
+
+  $ openssl pkeyutl -provider pkcs11prov \
+  -inkey "pkcs11:token=some_cn;type=private;pin-value=123456" \
+  -sign -in data.txt -out data.sig
+
+If you set everything up properly in openssl.cnf, you should be able to simply use
+
+  $ openssl pkeyutl -inkey pkcs11: -sign -in data.txt -out data.sig
 
 You should be able to check whether your module is set up properly by running
 
@@ -34,4 +97,4 @@ will result in an error.
   ls: cannot access 'C:/msys64/ucrt64/bin/../lib/p11-kit-proxy.dll': No such file or directory
 
 However the proxy and the main library (libp11-kit-0.dll) are essentially the same.  This is a
-bug in p11-kit packaging.
+bug in p11-kit packaging discussed at https://github.com/msys2/MINGW-packages/pull/22595 .


### PR DESCRIPTION
- make use of p11-kit proxy for pkcs11prov (missing include for config.h with macro definition)
- Remove a copy of each library with lib- prefix