### PR TITLE
Bump artifact actions and disable archiving

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,18 +84,19 @@ jobs:
 
       - name: "Upload binaries"
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.msystem }}-packages
           path: ${{ steps.facts.outputs.drive }}/_/artifacts/*.pkg.tar.*
           if-no-files-found: ignore
+          archive: false
 
   check:
     needs: [build]
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         continue-on-error: true
         with:
           name: UCRT64-packages
@@ -140,7 +141,7 @@ jobs:
             repo: clang64
 
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         id: artifacts
         continue-on-error: true
         with:


### PR DESCRIPTION
Upgrade actions/upload-artifact from v6 to v7 and actions/download-artifact from v7 to v8 in workflow. Also set archive: false on the Upload binaries step to avoid creating zip archives of produced packages. These updates use newer action releases and preserve artifact file layout across jobs (build -> check and related jobs).

(message generated by Copilot)