### PR TITLE
libc++: update to 22.1.0

### DIFF
--- a/mingw-w64-libc++/PKGBUILD
+++ b/mingw-w64-libc++/PKGBUILD
@@ -8,7 +8,7 @@ _realname=libc++
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-libunwind")
-_pkgver=21.1.8
+_pkgver=22.1.0
 pkgver=${_pkgver/-/}
 pkgrel=1
 arch=(any)
@@ -33,7 +33,7 @@ if [[ ${MINGW_PACKAGE_PREFIX} != *-clang-* ]]; then
 fi
 _url=https://github.com/llvm/llvm-project/releases/download/llvmorg-${_pkgver}
 source=("${_url}/llvm-project-${_pkgver}.src.tar.xz"{,.sig})
-sha256sums=('4633a23617fa31a3ea51242586ea7fb1da7140e426bd62fc164261fe036aa142'
+sha256sums=('25d2e2adc4356d758405dd885fcfd6447bce82a90eb78b6b87ce0934bd077173'
             'SKIP')
 validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Google.
               '474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard
@@ -72,7 +72,7 @@ build() {
   # Targeting Win 7 will just lead to libc++ looking
   # up new APIs at runtime, so there is no downside really
   local _win32_winnt
-  if [[ ${MSYSTEM} == CLANGARM64 ]]; then
+  if [[ ${MSYSTEM} != MINGW* ]]; then # drop support for Windos 7 in UCRT64 & CLANG64, see #28170
       _win32_winnt=0xA00 # Windows 10
   else
       _win32_winnt=0x601 # Windows 7


### PR DESCRIPTION
drops support for Windows 7 in UCRT64 & CLANG64, see #28170