### PR TITLE
zlib: Revert definition of `z_off_t` to `long`

### DIFF
--- a/mingw-w64-zlib/04-fix-largefile-support.patch
+++ b/mingw-w64-zlib/04-fix-largefile-support.patch
@@ -1,11 +1,26 @@
---- a/zconf.h.in
-+++ b/zconf.h.in
-@@ -504,7 +504,7 @@
- #  define z_off_t long
+--- zlib-1.3.2.orig/zconf.h     2026-02-17 20:47:06.000000000 +0800
++++ zlib-1.3.2/zconf.h  2026-03-05 15:10:21.915014500 +0800
+@@ -516,7 +516,7 @@
  #endif
- 
+
+ #ifndef z_off_t
+-#  define z_off_t long long
++#  define z_off_t long
+ #endif
+
+ #if !defined(_WIN32) && defined(Z_LARGE64)
+--- zlib-1.3.2.orig/zconf.h.in  2026-02-17 20:47:06.000000000 +0800
++++ zlib-1.3.2/zconf.h.in       2026-03-05 15:10:47.663570700 +0800
+@@ -516,10 +516,10 @@
+ #endif
+
+ #ifndef z_off_t
+-#  define z_off_t long long
++#  define z_off_t long
+ #endif
+
 -#if !defined(_WIN32) && defined(Z_LARGE64)
 +#if (defined(_WIN32) && defined(__GNUC__) && defined(_LARGEFILE64_SOURCE)) || defined(Z_LARGE64)
  #  define z_off64_t off64_t
- #else
- #  if defined(_WIN32) && !defined(__GNUC__) && !defined(Z_SOLO)
+ #elif defined(__MINGW32__)
+ #  define z_off64_t long long

--- a/mingw-w64-zlib/PKGBUILD
+++ b/mingw-w64-zlib/PKGBUILD
@@ -8,7 +8,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-minizip")
 pkgver=1.3.2
-pkgrel=1
+pkgrel=2
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 license=('spdx:Zlib')
@@ -35,7 +35,7 @@ sha256sums=('d7a0654783a4da529d1bb793b7ad9c3318020af77667bcae35f95d0e42a792f3'
             'SKIP'
             'b58b353d976d6fdd9a5094e60fa39439d4f14e9bf8be4a8bd475f2cd47f10226'
             '7287d12db57dcf0f66964c861100bf06ebe1ddcb243e7ee0773fcab1b2935596'
-            '4cdc6991ff2adfb9561d2f83c2661c26547eb0e2ac278d82def661eefdf57cfa'
+            '8e1cdf8edfc6ac08b0e660ca42a977942a88fab3ff59c01c87ba96500e2c3e63'
             'fb83292f494f649ea7f1835aa4abea61acc593d7f90625741d42cd99cac0e075'
             '0be98a7e660e7c068856f08b9e92d6c73a6b0d88c3e29a9716140b147f7c23c5'
             '0774e1368851504115f732f66230ca4a8a9cd60d4ba014502f65cc19b0b4d8bc')


### PR DESCRIPTION
mingw-w64 has `<unistd.h>`, so when building zlib itself `z_off_t` is defined as `off_t` [^1] which is `long` and is always 32-bit.

On the other hand, user code doesn't include `<zconf.h>` and uses another definition, which zlib 1.3.2 has changed to `long long` [^2]. Not only is this an ABI break, the calling convention of `gzseek()` is subject to inclusion of `<zconf.h>` and causes undefined behavior.

This has been reported upstream [^3].

[^1]: https://github.com/madler/zlib/blob/09a1572aa624e5ddb6c075dc013880de70b1b9b9/zconf.h.in#L495
[^2]: https://github.com/madler/zlib/commit/c5e87dcdef72abfb599579bb1b8176948be979c9
[^3]: https://github.com/madler/zlib/issues/1202


