### PR TITLE
[new package] mingw-w64-prettier 3.8.1

### DIFF
--- a/mingw-w64-prettier/PKGBUILD
+++ b/mingw-w64-prettier/PKGBUILD
@@ -1,0 +1,40 @@
+# Maintainer: Marvin Zhang <marvin.beeblebrox@gmail.com>
+# Contributor: Daniel M. Capella <polyzen@archlinux.org>
+# Contributor: Jerome Leclanche <jerome@leclan.ch>
+# Contributor: Maxim Baz <archlinux at maximbaz dot com>
+
+_realname=prettier
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=3.8.1
+pkgrel=1
+pkgdesc='An opinionated code formatter (mingw-w64)'
+arch=('any')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
+url='https://prettier.io'
+msys2_repository_url='https://github.com/prettier/prettier'
+msys2_references=(
+  'archlinux: prettier'
+  'purl: pkg:npm/prettier'
+)
+license=('spdx:MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-nodejs")
+source=("https://registry.npmjs.org/${_realname}/-/${_realname}-${pkgver}.tgz"
+        "prettier.sh")
+sha256sums=('5531dc6006ad06b642d5342438909f85dc53e87c50556753c908229b213fb4f4'
+            'b3a516743b4e7dc4a9a7923c4d66b53fc750619f2c5fa7ec8cca974f95f74d06')
+
+package() {
+  "${MINGW_PREFIX}"/bin/npm install -g \
+    --cache "${srcdir}/npm-cache" \
+    --prefix "${pkgdir}${MINGW_PREFIX}" \
+    "${srcdir}/${_realname}-${pkgver}.tgz"
+
+  # Fix the shell wrapper to handle winpty correctly
+  # npm's default wrapper uses 'exec node "C:/path/to/script.cjs" "$@"'
+  # which breaks when `node` invokes winpty or when cygpath mangles arguments.
+  install -Dm755 "${srcdir}/prettier.sh" "${pkgdir}${MINGW_PREFIX}/bin/prettier"
+
+  install -Dm644 "${srcdir}/package/LICENSE" \
+    "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}

--- a/mingw-w64-prettier/prettier.sh
+++ b/mingw-w64-prettier/prettier.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+_node_exe="$(dirname "${BASH_SOURCE[0]}")/node.exe"
+if [ ! -f "$_node_exe" ]; then
+  _node_exe="node"
+fi
+_script="$(dirname "${BASH_SOURCE[0]}")/../lib/node_modules/prettier/bin/prettier.cjs"
+
+if [ -t 0 -a -t 1 -a -x /usr/bin/winpty ]; then
+  /usr/bin/winpty "$_node_exe" "$_script" "$@"
+else
+  exec "$_node_exe" "$_script" "$@"
+fi


### PR DESCRIPTION
Add initial package for `prettier`. Follows the npm-based installation pattern similar to the `mingw-w64-eslint` package.

CI passed in fork repository.