### PR TITLE
python-fido2: add version 2.1.1 (new package)

### DIFF
--- a/mingw-w64-python-fido2/PKGBUILD
+++ b/mingw-w64-python-fido2/PKGBUILD
@@ -5,12 +5,15 @@ pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=2.1.1
 pkgrel=1
-pkgdesc="For communicating with a FIDO device over USB as well as verifying attestation and assertion signatures."
+pkgdesc="For communicating with a FIDO device over USB as well as verifying attestation and assertion signatures (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
-url='https://github.com/Yubico/python-fido2'
+url='https://developers.yubico.com/python-fido2/'
 msys2_repository_url='https://github.com/Yubico/python-fido2'
+msys2_changelog_url='https://developers.yubico.com/python-fido2/Release_Notes.html'
 msys2_references=(
+  'archlinux: python-fido2'
+  'gentoo: dev-python/fido2'
   'purl: pkg:pypi/fido2'
 )
 license=('spdx:Apache-2.0')
@@ -37,14 +40,14 @@ prepare() {
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
-  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
+  python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 package() {
-  cd "${srcdir}"/python-build-${MSYSTEM}
+  cd "python-build-${MSYSTEM}"
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    python -m installer --prefix=${MINGW_PREFIX} \
     --destdir="${pkgdir}" dist/*.whl
 
   install -Dm644 COPYING "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/COPYING"

--- a/mingw-w64-python-fido2/PKGBUILD
+++ b/mingw-w64-python-fido2/PKGBUILD
@@ -1,0 +1,51 @@
+# Maintainer: Antoine Martin <totaam@xpra.org>
+
+_realname=fido2
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=2.1.1
+pkgrel=1
+pkgdesc="For communicating with a FIDO device over USB as well as verifying attestation and assertion signatures."
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/Yubico/python-fido2'
+msys2_repository_url='https://github.com/Yubico/python-fido2'
+msys2_references=(
+  'purl: pkg:pypi/fido2'
+)
+license=('spdx:Apache-2.0')
+depends=("${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-cryptography"
+         "${MINGW_PACKAGE_PREFIX}-libfido2")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-python-wheel"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-libfido2")
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('f1379f845870cc7fc64c7f07323c3ce41e8c96c37054e79e0acd5630b3fec5ac')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+  sed -i \
+    -e 's|requires = \["poetry-core"\]|requires = ["setuptools","wheel"]|' \
+    -e 's|build-backend = "poetry.core.masonry.api"|build-backend = "setuptools.build_meta"|' \
+    -e 's|, *email *= *"[^"]*"||g' \
+    -e '/^readme *=/d' \
+    pyproject.toml
+}
+
+build() {
+  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "${srcdir}"/python-build-${MSYSTEM}
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 COPYING "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/COPYING"
+}


### PR DESCRIPTION
This new package will be used by the upcoming xpra v6.5 to replace the deprecated `python-u2f` package for authentication:
https://github.com/Xpra-org/xpra/issues/4516

The project lives here:
https://github.com/Yubico/python-fido2

Pypi link:
https://pypi.org/project/fido2/