### PR TITLE
prettier: update to 3.8.2

### DIFF
--- a/mingw-w64-prettier/PKGBUILD
+++ b/mingw-w64-prettier/PKGBUILD
@@ -6,7 +6,7 @@
 _realname=prettier
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.8.1
+pkgver=3.8.2
 pkgrel=1
 pkgdesc='An opinionated code formatter (mingw-w64)'
 arch=('any')
@@ -21,7 +21,7 @@ license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-nodejs")
 source=("https://registry.npmjs.org/${_realname}/-/${_realname}-${pkgver}.tgz"
         "prettier.sh")
-sha256sums=('5531dc6006ad06b642d5342438909f85dc53e87c50556753c908229b213fb4f4'
+sha256sums=('917b771c007ff5d11cc96d4fa37df8fac86dd472b74ac0bbdcd70dfafab04c03'
             'b3a516743b4e7dc4a9a7923c4d66b53fc750619f2c5fa7ec8cca974f95f74d06')
 
 package() {


### PR DESCRIPTION
See: [Changelog](https://github.com/prettier/prettier/blob/main/CHANGELOG.md#382)