### PR TITLE
python-spyder: update to 6.1.4

### DIFF
--- a/mingw-w64-python-spyder/PKGBUILD
+++ b/mingw-w64-python-spyder/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=spyder
 pkgbase=mingw-w64-python-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-python-${_realname}
-pkgver=6.1.3
+pkgver=6.1.4
 pkgrel=1
 pkgdesc='The Scientific Python Development Environment (mingw-w64)'
 arch=('any')
@@ -18,7 +18,6 @@ license=('spdx:MIT')
 depends=(
     ${MINGW_PACKAGE_PREFIX}-python
     ${MINGW_PACKAGE_PREFIX}-python-aiohttp
-    ${MINGW_PACKAGE_PREFIX}-python-atomicwrites
     ${MINGW_PACKAGE_PREFIX}-python-asyncssh
     ${MINGW_PACKAGE_PREFIX}-python-bcrypt
     ${MINGW_PACKAGE_PREFIX}-python-chardet
@@ -78,8 +77,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
 options=(!strip)
 source=(https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz
         spyder-requirements-fix.patch)
-sha256sums=('c770116328b74d6e6c82b304946fd2e0f9ef7da0af125e9816e399dfda523f16'
-            '4bb677a29c222de00ad1e4c156c0e1c64753f0c5528287713046c7188a3e0746')
+sha256sums=('1c6139710af071053fc3149181f8604e5f3a3a4fa1054073a649b969fef2de32'
+            '8202b6e606b8adb2e6a9a308f775e90dd263ce874e8636e01540f2b609975bfd')
 
 prepare() {
   cd ${_realname}-${pkgver}

--- a/mingw-w64-python-spyder/spyder-requirements-fix.patch
+++ b/mingw-w64-python-spyder/spyder-requirements-fix.patch
@@ -14,11 +14,11 @@
      'pyqt5': [
          'pyqt5>=5.15,<5.16',
 -        'pyqtwebengine>=5.15,<5.16',
-         'qtconsole>=5.7.1,<5.8.0',
+         'qtconsole>=5.7.2,<5.8.0',
      ],
      'pyqt6': [
          'pyqt6>=6.5,<7',
 -        'pyqt6-webengine>=6.5,<7',
-         'qtconsole>=5.7.1,<5.8.0',
+         'qtconsole>=5.7.2,<5.8.0',
      ],
      'pyside6': [


### PR DESCRIPTION
Dependency on atomicwrites has been dropped by upstream.