### PR TITLE
mingw-w64-docx2txt-rs: new package (v0.2.0)

### DIFF
--- a/mingw-w64-docx2txt-rs/PKGBUILD
+++ b/mingw-w64-docx2txt-rs/PKGBUILD
@@ -1,0 +1,48 @@
+_realname=docx2txt-rs
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=0.2.0
+pkgrel=1
+pkgdesc="Rust rewrite of docx2txt for Git for Windows, dropping the Perl dependency (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/dscho/docx2txt-rs'
+msys2_repository_url='https://github.com/dscho/docx2txt-rs'
+msys2_references=(
+  'purl: pkg:cargo/docx2txt'
+)
+license=('spdx:GPL-3.0-or-later')
+makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
+source=("${url}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('25321fa9a937590017419eab8e285076b9530af588bb4c580bcee59285c3f41e')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+
+  cargo fetch --locked --target "${RUST_CHOST}"
+}
+
+build() {
+  cd "${_realname}-${pkgver}"
+
+  cargo build --release --frozen
+}
+
+check() {
+  cd "${_realname}-${pkgver}"
+
+  cargo test --release --frozen
+}
+
+package() {
+  cd "${_realname}-${pkgver}"
+
+  cargo install \
+    --offline \
+    --no-track \
+    --frozen \
+    --path . \
+    --root "${pkgdir}${MINGW_PREFIX}"
+
+  install -Dm644 COPYING "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}


### PR DESCRIPTION
This adds a PKGBUILD for [docx2txt-rs](https://github.com/dscho/docx2txt-rs), a Rust rewrite of [docx2txt](http://docx2txt.sourceforge.net/).

### Motivation

As discussed in git-for-windows/git#5393, Git for Windows is working toward dropping its Perl dependency. One of the remaining consumers is `docx2txt.pl`, a Perl script used by Git's `astextplain` textconv driver to diff `.docx` files.

The original docx2txt (v1.4, by Sandeep Kumar) has been unmaintained since May 2014, over a decade with no releases, no bug fixes, and no upstream activity on SourceForge. It also ships without any test suite.

`docx2txt-rs` is a from-scratch Rust rewrite that produces byte-identical output to the Perl original on all tested fixtures. Unlike the original, it comes with a comprehensive test suite that covers both Word-saved documents and programmatically generated fixtures exercising every regex in the conversion pipeline.

### PKGBUILD

The PKGBUILD follows the established pattern for simple Rust packages in this repository (e.g. `mingw-w64-powersession-rs`): `cargo fetch --locked` / `cargo build --release --frozen` / `cargo test --release --frozen` / `cargo install`.
