### PR TITLE
openssl: Use makepkg CFLAGS

### DIFF
--- a/mingw-w64-openssl/PKGBUILD
+++ b/mingw-w64-openssl/PKGBUILD
@@ -63,7 +63,7 @@ prepare() {
   msg2 "Using sed to force makepkg-mingw CFLAGS instead of hardcoded ones"
   cd "${srcdir}/${_realname}-${pkgver}/Configurations"
   sed -i -e "/^[[:space:]]*\"mingw-common\"/,/release/ s/-O3/${CFLAGS}/" 10-main.conf
-  grep -qE "\s*release\s*=>.+-fstack-protector-strong" 10-main.conf || { echo "...sed failed"; return 1; }
+  grep -q --fixed-strings -- "${CFLAGS}" 10-main.conf  || { echo "...sed failed"; return 1; }
 }
 
 build() {

--- a/mingw-w64-openssl/PKGBUILD
+++ b/mingw-w64-openssl/PKGBUILD
@@ -4,7 +4,7 @@ _realname=openssl
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=3.6.2
-pkgrel=1
+pkgrel=2
 pkgdesc="The Open Source toolkit for Secure Sockets Layer and Transport Layer Security (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -59,14 +59,15 @@ prepare() {
 
   cp -fHv "${srcdir}"/pathtools.c crypto/
   cp -fHv "${srcdir}"/pathtools.h ./
+
+  msg2 "Using sed to force makepkg-mingw CFLAGS instead of hardcoded ones"
+  cd "${srcdir}/${_realname}-${pkgver}/Configurations"
+  sed -i -e "/^[[:space:]]*\"mingw-common\"/,/release/ s/-O3/${CFLAGS}/" 10-main.conf
+  grep -qE "\s*release\s*=>.+-fstack-protector-strong" 10-main.conf || { echo "...sed failed"; return 1; }
 }
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
-
-  # Use mingw cflags instead of hardcoded ones
-  sed -i -e '/^"mingw"/ s/-fomit-frame-pointer -O3 -Wall/-O2 -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions --param=ssp-buffer-size=4/' \
-    "${srcdir}"/${_realname}-${pkgver}/Configurations/10-main.conf
 
   case "${CARCH}" in
     i?86)


### PR DESCRIPTION
[Flags used in previous UCRT64 build](https://github.com/msys2/MINGW-packages/actions/runs/24091369228/job/70278338310#step:9:451)

> gcc  -I. -Iinclude -Iapps/include -I../openssl-3.6.2 -I../openssl-3.6.2/include -I../openssl-3.6.2/apps/include  -m64 -Wall **-O3** -DL_ENDIAN -DOPENSSL_PIC -DOPENSSLDIR="\"/ucrt64/etc/ssl\"" -DENGINESDIR="\"/ucrt64/lib/engines-3\"" -DMODULESDIR="\"/ucrt64/lib/ossl-modules\"" -DUNICODE -D_UNICODE -DWIN32_LEAN_AND_MEAN -D_MT -DOPENSSL_BUILDING_OPENSSL -DZLIB -DZLIB_SHARED -DNDEBUG -DOPENSSLBIN="\"/ucrt64/bin\"" -MMD -MF apps/lib/libapps-lib-app_params.d.tmp -c -o apps/lib/libapps-lib-app_params.obj ../openssl-3.6.2/apps/lib/app_params.c

New

> gcc  -I. -Iinclude -Iapps/include -I../openssl-3.6.2 -I../openssl-3.6.2/include -I../openssl-3.6.2/apps/include  -m64 -Wall **-march=nocona -msahf -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wp,-D__USE_MINGW_ANSI_STDIO=1** -DL_ENDIAN -DOPENSSL_PIC -DOPENSSLDIR="\"/ucrt64/etc/ssl\"" -DENGINESDIR="\"/ucrt64/lib/engines-3\"" -DMODULESDIR="\"/ucrt64/lib/ossl-modules\"" -DUNICODE -D_UNICODE -DWIN32_LEAN_AND_MEAN -D_MT -DOPENSSL_BUILDING_OPENSSL -DZLIB -DZLIB_SHARED -DNDEBUG -DOPENSSLBIN="\"/ucrt64/bin\"" -MMD -MF apps/lib/libapps-lib-app_libctx.d.tmp -c -o apps/lib/libapps-lib-app_libctx.obj ../openssl-3.6.2/apps/lib/app_libctx.c

[Flags used in previous CLANGARM64 build](https://github.com/msys2/MINGW-packages/actions/runs/24091369228/job/70278338402#step:9:457)

> clang  -I. -Iinclude -Iapps/include -I../openssl-3.6.2 -I../openssl-3.6.2/include -I../openssl-3.6.2/apps/include  -Wa,--noexecstack -Qunused-arguments -Wall **-O3** -DL_ENDIAN -DOPENSSL_PIC -DOPENSSLDIR="\"/clangarm64/etc/ssl\"" -DENGINESDIR="\"/clangarm64/lib/engines-3\"" -DMODULESDIR="\"/clangarm64/lib/ossl-modules\"" -DUNICODE -D_UNICODE -DWIN32_LEAN_AND_MEAN -D_MT -DOPENSSL_BUILDING_OPENSSL -DZLIB -DZLIB_SHARED -DNDEBUG -DOPENSSLBIN="\"/clangarm64/bin\"" -MMD -MF apps/lib/libapps-lib-app_libctx.d.tmp -c -o apps/lib/libapps-lib-app_libctx.obj ../openssl-3.6.2/apps/lib/app_libctx.c


New

> clang  -I. -Iinclude -Iapps/include -I../openssl-3.6.2 -I../openssl-3.6.2/include -I../openssl-3.6.2/apps/include  -Wa,--noexecstack -Qunused-arguments -Wall **-march=armv8.1-a -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wp,-D__USE_MINGW_ANSI_STDIO=1** -DL_ENDIAN -DOPENSSL_PIC -DOPENSSLDIR="\"/clangarm64/etc/ssl\"" -DENGINESDIR="\"/clangarm64/lib/engines-3\"" -DMODULESDIR="\"/clangarm64/lib/ossl-modules\"" -DUNICODE -D_UNICODE -DWIN32_LEAN_AND_MEAN -D_MT -DOPENSSL_BUILDING_OPENSSL -DZLIB -DZLIB_SHARED -DNDEBUG -DOPENSSLBIN="\"/clangarm64/bin\"" -MMD -MF apps/lib/libapps-lib-app_libctx.d.tmp -c -o apps/lib/libapps-lib-app_libctx.obj ../openssl-3.6.2/apps/lib/app_libctx.c
