### PR TITLE
python-kiwisolver: update to 1.5.0

### DIFF
--- a/mingw-w64-python-kiwisolver/PKGBUILD
+++ b/mingw-w64-python-kiwisolver/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=kiwisolver
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=1.4.9
-pkgrel=3
+pkgver=1.5.0
+pkgrel=1
 pkgdesc="A fast implementation of the Cassowary constraint solver (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -25,7 +25,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-cc")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('c3b22c26c6fd6811b0ae8363b95ca8ce4ea3c202d3d0975b2914310ceb1bcc4d')
+sha256sums=('d4193f3d9dc3f6f79aaed0e5637f45d98850ebf01f7ca20e69457f3e8946b66a')
 
 prepare() {
   cd "${srcdir}"/"${_realname}-${pkgver}"
@@ -41,7 +41,8 @@ build() {
 
 check() {
   cd "${srcdir}/python-build-${MSYSTEM}"
-  "${MINGW_PREFIX}"/bin/python -m pytest || warning "Tests failed"
+  PYTHONPATH=$(find "$PWD/build" -type d -name 'lib.mingw*python*') \
+  "${MINGW_PREFIX}"/bin/python -m pytest
 }
 
 package() {


### PR DESCRIPTION
Also fix `check()` step by setting `PYTHONPATH` for test execution.