### PR TITLE
New package: mingw-w64-autohotkey 2.0.23

### DIFF
--- a/mingw-w64-autohotkey/0001-adapt-precompiled-header-and-config-for-MinGW.patch
+++ b/mingw-w64-autohotkey/0001-adapt-precompiled-header-and-config-for-MinGW.patch
@@ -1,0 +1,104 @@
+From 61b8977de6afdfc10fda1c3e170072307d4ac2ec Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 14 Apr 2026 12:45:19 +0200
+Subject: [PATCH 01/N] adapt precompiled header and config for MinGW
+
+AutoHotkey's stdafx.h precompiled header is gated on _MSC_VER, locking
+out any non-MSVC compiler. Open the include guard so that MinGW GCC can
+use the same header.
+
+GCC's c++config.h does `#undef min` which destroys any min/max macros
+defined before the C++ standard headers are included. The fix is to
+include <algorithm>, <cmath>, <new>, and <limits> first, then define
+the min/max macros afterwards.
+
+In config.h, the ENABLE_DLLCALL and ENABLE_REGISTERCALLBACK feature
+gates are conditional on _MSC_VER, preventing DllCall and
+RegisterCallback from being compiled under MinGW. These features work
+fine with GCC and the GAS assembly translation of x64call, so enable
+them unconditionally. Also provide _MAX_ULTOSTR_BASE10_COUNT which is
+an MSVC CRT macro absent from MinGW's headers.
+
+The UTF-8 BOM on script_object.cpp is stripped as a minor cleanup.
+---
+ source/config.h          | 10 +++++++++-
+ source/script_object.cpp |  2 +-
+ source/stdafx.h          | 21 ++++++++++++++++++++-
+ 3 files changed, 30 insertions(+), 3 deletions(-)
+
+diff --git a/source/config.h b/source/config.h
+index 5ca6393..1171223 100644
+--- a/source/config.h
++++ b/source/config.h
+@@ -6,13 +6,21 @@
+ #define WIN32_PLATFORM
+ #endif
+ 
+-#ifdef _MSC_VER
++#if defined(_MSC_VER) || defined(__MINGW32__)
+ 	#if defined(WIN32_PLATFORM) || defined(_WIN64)
+ 	#define ENABLE_DLLCALL
+ 	#define ENABLE_REGISTERCALLBACK
+ 	#endif
+ #endif
+ 
++// MinGW/GCC compatibility: MSVC-specific constants and macros.
++#ifdef __MINGW32__
++// _MAX_ULTOSTR_BASE10_COUNT is MSVC CRT-specific (max chars for _ultoa).
++#ifndef _MAX_ULTOSTR_BASE10_COUNT
++#define _MAX_ULTOSTR_BASE10_COUNT 22
++#endif
++#endif
++
+ #if !defined(_MBCS) && !defined(_UNICODE) && !defined(UNICODE) // If not set in project settings...
+ 
+ // L: Comment out the next line to enable UNICODE:
+diff --git a/source/script_object.cpp b/source/script_object.cpp
+index adcfe6b..9c0b43f 100644
+--- a/source/script_object.cpp
++++ b/source/script_object.cpp
+@@ -1,4 +1,4 @@
+-﻿#include "stdafx.h" // pre-compiled headers
++#include "stdafx.h" // pre-compiled headers
+ #include "defines.h"
+ #include "globaldata.h"
+ #include "script.h"
+diff --git a/source/stdafx.h b/source/stdafx.h
+index ab8f560..dbdecf7 100644
+--- a/source/stdafx.h
++++ b/source/stdafx.h
+@@ -32,7 +32,7 @@ GNU General Public License for more details.
+ #define _WIN32_WINNT 0x0600
+ #define _WIN32_IE _WIN32_IE_IE70  // Added for TVN_ITEMCHANGED, which most likely requires Vista.
+ 
+-#ifdef _MSC_VER
++#if defined(_MSC_VER) || defined(__MINGW32__)
+ 	#include "config.h" // compile-time configurations
+ 	#include "debug.h"
+ 
+@@ -66,6 +66,25 @@ GNU General Public License for more details.
+ 	//#include "window.h"  // Not to be confused with "windows.h"
+ 	//#include "util.h"
+ 	//#include "SimpleHeap.h"
++
++	// MinGW/GCC: pull in <algorithm> early (for std::min/std::max) and then
++	// define the min/max macros that MSVC's <windef.h> provides in C++ mode.
++	// This must happen after all system headers so that <c++config.h>'s
++	// #undef min/max has already fired and <algorithm>'s templates are parsed
++	// without macro interference.
++	#ifdef __MINGW32__
++	#include <algorithm>
++	#include <new>
++	#include <cmath>
++	#include <limits>
++	#ifndef min
++	#define min(a,b) (((a) < (b)) ? (a) : (b))
++	#endif
++	#ifndef max
++	#define max(a,b) (((a) > (b)) ? (a) : (b))
++	#endif
++	#endif
++
+ #endif
+ 
+ // Lexikos: Defining _WIN32_WINNT 0x0600 seems to break TrayTip in non-English Windows,

--- a/mingw-w64-autohotkey/0002-replace-MSVC-structured-exception-handling-with-port.patch
+++ b/mingw-w64-autohotkey/0002-replace-MSVC-structured-exception-handling-with-port.patch
@@ -1,0 +1,137 @@
+From b37a169048566549d77d070be55c1ca4d24eb0c3 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 14 Apr 2026 23:49:23 +0200
+Subject: [PATCH 02/N] replace MSVC structured exception handling with
+ portable alternatives
+
+MinGW GCC does not support the __try/__except SEH syntax that is an
+MSVC extension.  AutoHotkey uses SEH in two places: the main execution
+loop (AutoHotkey.cpp) and DllCall (DllCall.cpp).
+
+For DllCall, which needs to catch access violations from bad function
+pointers or arguments, the replacement uses SetUnhandledExceptionFilter
+combined with setjmp/longjmp.  The filter stores the exception code
+and triggers a longjmp back to the call site, which then raises the
+error through AutoHotkey's normal error path.
+
+For the main execution loop, the original SEH handler catches
+EXCEPTION_STACK_OVERFLOW ("Function recursion limit exceeded"),
+EXCEPTION_ACCESS_VIOLATION ("Invalid memory read/write"), and other
+system exceptions, formats a user-friendly message, and calls
+CriticalError() to display it before terminating.  The MinGW
+replacement installs a SetUnhandledExceptionFilter callback that
+provides the exact same messages and calls CriticalError() in the
+same way.  The filter is installed before the auto-execute section
+and restored on normal exit.
+---
+ source/AutoHotkey.cpp  | 30 +++++++++++++++++++++++++++++-
+ source/lib/DllCall.cpp | 27 +++++++++++++++++++++++++++
+ 2 files changed, 56 insertions(+), 1 deletion(-)
+
+diff --git a/source/AutoHotkey.cpp b/source/AutoHotkey.cpp
+index 82aa5ea..69c2fba 100644
+--- a/source/AutoHotkey.cpp
++++ b/source/AutoHotkey.cpp
+@@ -305,7 +305,31 @@ int MainExecuteScript(bool aMsgSleep)
+ 	Hotkey::ManifestAllHotkeysHotstringsHooks(); // We want these active now in case auto-execute never returns (e.g. loop)
+ 
+ #ifndef _DEBUG
++#ifdef _MSC_VER
+ 	__try
++#else
++	// MinGW/GCC: use SetUnhandledExceptionFilter to replicate the MSVC
++	// __try/__except that wraps the main execution loop.  The filter
++	// provides the same user-friendly messages for stack overflow and
++	// access violation, then terminates via CriticalError.
++	struct MainSEH {
++		static LONG WINAPI Filter(PEXCEPTION_POINTERS ep) {
++			LPCTSTR msg;
++			auto ecode = ep->ExceptionRecord->ExceptionCode;
++			switch (ecode)
++			{
++			case EXCEPTION_STACK_OVERFLOW: msg = _T("Function recursion limit exceeded."); break;
++			case EXCEPTION_ACCESS_VIOLATION: msg = _T("Invalid memory read/write."); break;
++			default: msg = _T("System exception 0x%X."); break;
++			}
++			TCHAR buf[127];
++			sntprintf(buf, _countof(buf), msg, ecode);
++			g_script.CriticalError(buf); // calls TerminateApp, does not return
++			return EXCEPTION_EXECUTE_HANDLER; // not reached
++		}
++	};
++	auto prev_filter = SetUnhandledExceptionFilter(MainSEH::Filter);
++#endif
+ #endif
+ 	{
+ 		// Run the auto-execute part at the top of the script:
+@@ -334,6 +358,7 @@ int MainExecuteScript(bool aMsgSleep)
+ 		}
+ 	}
+ #ifndef _DEBUG
++#ifdef _MSC_VER
+ 	__except (EXCEPTION_EXECUTE_HANDLER)
+ 	{
+ 		LPCTSTR msg;
+@@ -352,6 +377,9 @@ int MainExecuteScript(bool aMsgSleep)
+ 		g_script.CriticalError(buf);
+ 		return ecode;
+ 	}
+-#endif 
++#else
++	SetUnhandledExceptionFilter(prev_filter);
++#endif
++#endif
+ 	return 0;
+ }
+diff --git a/source/lib/DllCall.cpp b/source/lib/DllCall.cpp
+index baad41c..ee6fc37 100644
+--- a/source/lib/DllCall.cpp
++++ b/source/lib/DllCall.cpp
+@@ -19,6 +19,10 @@ GNU General Public License for more details.
+ #include "globaldata.h"
+ #include "script_func_impl.h"
+ 
++#ifndef _MSC_VER
++#include <setjmp.h>
++#endif
++
+ 
+ 
+ #ifdef ENABLE_DLLCALL
+@@ -252,6 +256,7 @@ DYNARESULT DynaCall(void *aFunction, DYNAPARM aParam[], int aParamCount, DWORD &
+ 	}
+ 
+ 	// Call the function.
++#ifdef _MSC_VER
+ 	__try
+ 	{
+ 		Res.UIntPtr = PerformDynaCall(stackArgsSize, stackArgs, regArgs, aFunction);
+@@ -260,6 +265,28 @@ DYNARESULT DynaCall(void *aFunction, DYNAPARM aParam[], int aParamCount, DWORD &
+ 	{
+ 		aException = GetExceptionCode(); // aException is an output parameter for our caller.
+ 	}
++#else
++	// MinGW/GCC: Use SetUnhandledExceptionFilter for DllCall crash protection,
++	// since __try/__except is an MSVC extension.
++	{
++		static thread_local DWORD seh_exception_code;
++		static thread_local jmp_buf seh_jmp;
++		struct DllCallSEH {
++			static LONG WINAPI Handler(PEXCEPTION_POINTERS ep) {
++				seh_exception_code = ep->ExceptionRecord->ExceptionCode;
++				longjmp(seh_jmp, 1);
++				return EXCEPTION_EXECUTE_HANDLER; // not reached
++			}
++		};
++		seh_exception_code = 0;
++		auto prev_filter = SetUnhandledExceptionFilter(DllCallSEH::Handler);
++		if (setjmp(seh_jmp) == 0)
++			Res.UIntPtr = PerformDynaCall(stackArgsSize, stackArgs, regArgs, aFunction);
++		else
++			aException = seh_exception_code;
++		SetUnhandledExceptionFilter(prev_filter);
++	}
++#endif
+ 
+ #endif
+ 

--- a/mingw-w64-autohotkey/0003-skip-legacy-wspiapi.h-include-on-MinGW.patch
+++ b/mingw-w64-autohotkey/0003-skip-legacy-wspiapi.h-include-on-MinGW.patch
@@ -1,0 +1,31 @@
+From 7077cdd11be02fde2f8d2654ec0b2c9e9ed69bef Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 14 Apr 2026 23:50:46 +0200
+Subject: [PATCH 03/N] skip legacy wspiapi.h include on MinGW
+
+The Debugger includes <wspiapi.h>, a polyfill that provides
+getaddrinfo() for pre-Windows-XP systems.  MinGW links getaddrinfo
+natively from ws2_32 and does not ship a compatible wspiapi.h, so
+including it causes the polyfill's inline definitions to conflict with
+the library symbols.  Guard the include with #ifndef __GNUC__ so it
+is only pulled in under MSVC, where the polyfill may still be wanted
+for legacy build configurations.
+---
+ source/Debugger.cpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/source/Debugger.cpp b/source/Debugger.cpp
+index 40cab39..20a5d13 100644
+--- a/source/Debugger.cpp
++++ b/source/Debugger.cpp
+@@ -27,7 +27,9 @@ freely, without restriction.
+ #define U4T(s) CStringUTF8FromTChar(s).GetString()
+ 
+ #include <ws2tcpip.h>
+-#include <wspiapi.h> // for getaddrinfo()
++#ifndef __GNUC__
++#include <wspiapi.h> // for getaddrinfo() on pre-XP; MinGW has it in ws2_32 natively
++#endif
+ #include <stdarg.h>
+ 
+ Debugger g_Debugger;

--- a/mingw-w64-autohotkey/0004-fix-C-type-portability-issues-for-GCC.patch
+++ b/mingw-w64-autohotkey/0004-fix-C-type-portability-issues-for-GCC.patch
@@ -1,0 +1,133 @@
+From ce13cc1c250d1c37c3fc9365ff1f621a4ade7ad7 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 14 Apr 2026 12:45:20 +0200
+Subject: [PATCH 04/N] fix C++ type portability issues for GCC
+
+GCC requires several syntax adjustments that MSVC accepts silently:
+
+In abi.h, nullptr_t requires <cstddef> under GCC. Rather than adding
+the include, use decltype(nullptr) which works everywhere.
+
+In WinGroup.h, a forward declaration of an enum without an underlying
+type is a GCC error. Add `: int` to satisfy the requirement.
+
+In hook.h, the extra-qualified member name `input_type::input_type` in
+the constructor declaration is rejected by GCC. Remove the redundant
+class qualification.
+
+In MdType.h, an incorrect `typename` keyword on a non-dependent type
+is rejected in strict mode. The md_cat token-pasting macro also needs
+two-level indirection because the C/C++ preprocessor's `##` operator
+suppresses macro expansion of its operands. If a single-level
+`md_cat(a,b)` directly contained `a ## b`, any macros passed as
+arguments would be pasted literally without being expanded first.
+The fix introduces `md_cat_(a,b)` as the inner macro that performs
+the actual `##` paste, and `md_cat(a,...)` as the outer macro that
+merely forwards its arguments. When the outer macro's body is
+expanded, the preprocessor expands any macros in the arguments before
+they reach the inner `##` in `md_cat_`.
+
+In script.h, the forward declaration of BuiltInFunctionID needs an
+underlying type (`: int`) for GCC, and the extra-qualified member name
+`ScriptTimer::Disable` in the class body must drop the class prefix.
+---
+ source/MdType.h   | 5 +++--
+ source/WinGroup.h | 2 +-
+ source/abi.h      | 4 ++--
+ source/hook.h     | 2 +-
+ source/script.h   | 4 ++--
+ 5 files changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/source/MdType.h b/source/MdType.h
+index 9d3c351..49462c7 100644
+--- a/source/MdType.h
++++ b/source/MdType.h
+@@ -91,7 +91,7 @@ template<MdType T> struct md_optout { typedef typename md_argtype<T>::t *t; };
+ template<> struct md_optout<MdType::String> { typedef StrRet *t; };
+ template<> struct md_optout<MdType::Variant> { typedef ResultToken *t; };
+ 
+-template<MdType T> struct md_optional { typedef typename optl<typename md_argtype<T>::t> t; };
++template<MdType T> struct md_optional { typedef optl<typename md_argtype<T>::t> t; };
+ template<> struct md_optional<MdType::Variant> { typedef ExprTokenType *t; };
+ 
+ //template<MdType T> struct md_retval { typedef typename md_argtype<T>::t t; };
+@@ -110,7 +110,8 @@ template<> struct md_retval<MdType::ResultType> { typedef ResultType t; };
+ 
+ #include "map.h"
+ 
+-#define md_cat(a, ...) a ## __VA_ARGS__
++#define md_cat_(a, ...) a ## __VA_ARGS__
++#define md_cat(a, ...) md_cat_(a, __VA_ARGS__)
+ 
+ #define md_arg_decl_type_In(type) md_argtype<MdType::type>::t
+ #define md_arg_decl_type_In_Opt(type) md_optional<MdType::type>::t
+diff --git a/source/WinGroup.h b/source/WinGroup.h
+index b4fc9dd..bb3ece8 100644
+--- a/source/WinGroup.h
++++ b/source/WinGroup.h
+@@ -48,7 +48,7 @@ public:
+ 
+ 
+ 
+-enum BuiltInFunctionID;
++enum BuiltInFunctionID : int;
+ class WinGroup
+ {
+ private:
+diff --git a/source/abi.h b/source/abi.h
+index 39d3feb..012bab4 100644
+--- a/source/abi.h
++++ b/source/abi.h
+@@ -36,7 +36,7 @@ template<typename T> class optl
+ 	const T *_value;
+ public:
+ 	optl(T &v) : _value {&v} {}
+-	optl(nullptr_t) : _value {nullptr} {}
++	optl(decltype(nullptr)) : _value {nullptr} {}
+ 	bool has_value() { return _value != nullptr; }
+ 	T operator* () { return *_value; }
+ 	T value() { return *_value; }
+@@ -63,7 +63,7 @@ template<> class optl<IObject *>
+ 	IObject *_value;
+ public:
+ 	optl(IObject *v) : _value {v} {}
+-	optl(nullptr_t) : _value {nullptr} {}
++	optl(decltype(nullptr)) : _value {nullptr} {}
+ 	bool has_value() { return _value != nullptr; }
+ 	IObject *value() { return _value; }
+ };
+diff --git a/source/hook.h b/source/hook.h
+index 220b113..6c9e807 100644
+--- a/source/hook.h
++++ b/source/hook.h
+@@ -215,7 +215,7 @@ struct input_type
+ 	UINT EndingMatchIndex;
+ 	UCHAR KeyVK[VK_ARRAY_COUNT]; // A sparse array of key flags by VK.
+ 	UCHAR KeySC[SC_ARRAY_COUNT]; // A sparse array of key flags by SC.
+-	input_type::input_type() // A simple constructor to initialize the fields that need it.
++	input_type() // A simple constructor to initialize the fields that need it.
+ 		: Status(INPUT_OFF), Prev(NULL), ScriptObject(NULL)
+ 		, Buffer(NULL), match(NULL), MatchBuf(NULL), MatchBufSize(0)
+ 		, EndChars(NULL), EndCharsMax(0), KeyVK(), KeySC(), BufferLength(0)
+diff --git a/source/script.h b/source/script.h
+index 7293245..52217d3 100644
+--- a/source/script.h
++++ b/source/script.h
+@@ -590,7 +590,7 @@ enum JoyControls {JOYCTRL_INVALID, JOYCTRL_XPOS, JOYCTRL_YPOS, JOYCTRL_ZPOS
+ // in g_BIF) which are implemented using a single C++ function.  These IDs are passed to the
+ // C++ function to tell it which function is being called.  Each group starts at ID 0 in case
+ // it helps the compiler to reduce code size.
+-enum BuiltInFunctionID {
++enum BuiltInFunctionID : int {
+ 	FID_Object_New = -1,
+ 	FID_GetMethod = 0, FID_HasMethod,
+ 	FID_DllCall = 0, FID_ComCall,
+@@ -1862,7 +1862,7 @@ public:
+ 	bool mEnabled;
+ 	bool mRunOnlyOnce;
+ 	ScriptTimer *mNextTimer;  // Next items in linked list
+-	void ScriptTimer::Disable();
++	void Disable();
+ 	ScriptTimer(IObject *aLabel)
+ 		#define DEFAULT_TIMER_PERIOD 250
+ 		: mCallback(aLabel), mPeriod(DEFAULT_TIMER_PERIOD), mPriority(0) // Default is always 0.

--- a/mingw-w64-autohotkey/0005-fix-variadic-macro-trailing-comma-for-GCC.patch
+++ b/mingw-w64-autohotkey/0005-fix-variadic-macro-trailing-comma-for-GCC.patch
@@ -1,0 +1,85 @@
+From 96a768a0361beedd673d98d495132e26cedac975 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 14 Apr 2026 12:45:20 +0200
+Subject: [PATCH 05/N] fix variadic macro trailing comma for GCC
+
+MSVC silently removes the trailing comma before an empty __VA_ARGS__
+expansion, but GCC requires the `##` token-pasting operator to achieve
+the same effect. Without this fix, macros like _f_return(), _f_throw(),
+_f_set_retval() and _f_throw_param() fail to compile when called with
+fewer arguments than the variadic parameter expects.
+
+Add `##` before __VA_ARGS__ in all affected macros in
+script_func_impl.h and the _f_throw_param macro in script.h.
+---
+ source/script.h           |  2 +-
+ source/script_func_impl.h | 20 ++++++++++----------
+ 2 files changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/source/script.h b/source/script.h
+index 52217d3..15420a6 100644
+--- a/source/script.h
++++ b/source/script.h
+@@ -399,7 +399,7 @@ __int64 pow_ll(__int64 base, __int64 exp); // integer power function
+ // via COM IDispatch or coupled with different scripting languages.
+ #define _f_return(...)			_f__ret(aResultToken.Return(__VA_ARGS__))
+ #define _f_throw(...)			_f__ret(aResultToken.Error(__VA_ARGS__))
+-#define _f_throw_param(_prm_, ...)	return ((void)aResultToken.ParamError(_prm_, aParam[_prm_], __VA_ARGS__))
++#define _f_throw_param(_prm_, ...)	return ((void)aResultToken.ParamError(_prm_, aParam[_prm_], ##__VA_ARGS__))
+ #define _f_throw_win32(...)		return ((void)aResultToken.Win32Error(__VA_ARGS__))
+ #define _f_throw_value(...)		return ((void)aResultToken.ValueError(__VA_ARGS__))
+ #define _f_throw_type(...)		return ((void)aResultToken.TypeError(__VA_ARGS__))
+diff --git a/source/script_func_impl.h b/source/script_func_impl.h
+index ac80417..0d8435b 100644
+--- a/source/script_func_impl.h
++++ b/source/script_func_impl.h
+@@ -1,5 +1,5 @@
+ ﻿
+-#define ParamIndexToString(index, ...)				TokenToString(*aParam[(index)], __VA_ARGS__)
++#define ParamIndexToString(index, ...)				TokenToString(*aParam[(index)], ##__VA_ARGS__)
+ #define ParamIndexToInt64(index)					TokenToInt64(*aParam[(index)])
+ #define ParamIndexToInt(index)						(int)ParamIndexToInt64(index)
+ #define ParamIndexToIntPtr(index)					(INT_PTR)ParamIndexToInt64(index)
+@@ -39,25 +39,25 @@ inline LPTSTR _OptionalStringDefaultHelper(LPTSTR aDef, LPTSTR aBuf = NULL, size
+ 	return aDef;
+ }
+ #define ParamIndexToOptionalStringDef(index, def, ...) \
+-	(ParamIndexIsOmitted(index) ? _OptionalStringDefaultHelper(def, __VA_ARGS__) \
+-								: ParamIndexToString(index, __VA_ARGS__))
++	(ParamIndexIsOmitted(index) ? _OptionalStringDefaultHelper(def, ##__VA_ARGS__) \
++								: ParamIndexToString(index, ##__VA_ARGS__))
+ // The macro below defaults to "", since that is by far the most common default.
+ // No check for SYM_MISSING is needed since TokenToString() returns "" for that.
+ #define ParamIndexToOptionalString(index, ...) \
+-	(((index) < aParamCount) ? ParamIndexToString(index, __VA_ARGS__) \
+-							: _OptionalStringDefaultHelper(_T(""), __VA_ARGS__))
++	(((index) < aParamCount) ? ParamIndexToString(index, ##__VA_ARGS__) \
++							: _OptionalStringDefaultHelper(_T(""), ##__VA_ARGS__))
+ 
+ #define ParamIndexToOptionalObject(index)			((index) < aParamCount ? ParamIndexToObject(index) : NULL)
+ 
+ #define _f_param_string(name, index, ...) \
+ 	TCHAR name##_buf[MAX_NUMBER_SIZE], *name; \
+-	if (!TokenToStringParam(aResultToken, aParam, index, name##_buf, name, __VA_ARGS__)) return
++	if (!TokenToStringParam(aResultToken, aParam, index, name##_buf, name, ##__VA_ARGS__)) return
+ #define _f_param_string_opt_def(name, index, def, ...) \
+ 	TCHAR name##_buf[MAX_NUMBER_SIZE], *name; \
+-	if (ParamIndexIsOmitted(index)) name = _OptionalStringDefaultHelper(def, name##_buf, __VA_ARGS__); else \
+-	if (!TokenToStringParam(aResultToken, aParam, index, name##_buf, name, __VA_ARGS__)) return
++	if (ParamIndexIsOmitted(index)) name = _OptionalStringDefaultHelper(def, name##_buf, ##__VA_ARGS__); else \
++	if (!TokenToStringParam(aResultToken, aParam, index, name##_buf, name, ##__VA_ARGS__)) return
+ #define _f_param_string_opt(name, index, ...) \
+-	_f_param_string_opt_def(name, index, _T(""), __VA_ARGS__)
++	_f_param_string_opt_def(name, index, _T(""), ##__VA_ARGS__)
+ 
+ #define Throw_if_Param_NaN(ParamIndex) \
+ 	if (!TokenIsNumeric(*aParam[(ParamIndex)])) \
+@@ -68,7 +68,7 @@ inline LPTSTR _OptionalStringDefaultHelper(LPTSTR aDef, LPTSTR aBuf = NULL, size
+ 	if (!TokenIsNumeric(aValue)) \
+ 		_f_throw_type(_T("Number"), aValue)
+ 
+-#define BivRValueToString(...)  TokenToString(aValue, _f_number_buf, __VA_ARGS__)
++#define BivRValueToString(...)  TokenToString(aValue, _f_number_buf, ##__VA_ARGS__)
+ #define BivRValueToInt64()  TokenToInt64(aValue)
+ #define BivRValueToBOOL()  TokenToBOOL(aValue)
+ #define BivRValueToObject()  TokenToObject(aValue)

--- a/mingw-w64-autohotkey/0006-replace-MSVC-specific-integer-syntax-with-standard-C.patch
+++ b/mingw-w64-autohotkey/0006-replace-MSVC-specific-integer-syntax-with-standard-C.patch
@@ -1,0 +1,59 @@
+From 2fb23a7185bedf03f00ab0180c9155ac1411a3ab Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 14 Apr 2026 12:45:21 +0200
+Subject: [PATCH 06/N] replace MSVC-specific integer syntax with standard C++
+
+MSVC accepts `__int64(expr)` as a functional-style cast, but GCC
+treats __int64 as a keyword that cannot appear in functional cast
+syntax. Replace with the C-style cast `(__int64)(expr)` which both
+compilers accept.
+
+Similarly, the `ui64` integer literal suffix is an MSVC extension.
+Replace with the standard `ULL` suffix.
+---
+ source/application.cpp | 4 ++--
+ source/lib/string.cpp  | 2 +-
+ source/util.cpp        | 2 +-
+ 3 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/source/application.cpp b/source/application.cpp
+index 7427dc7..c85e761 100644
+--- a/source/application.cpp
++++ b/source/application.cpp
+@@ -1276,8 +1276,8 @@ bool MsgSleep(int aSleepDuration, MessageMode aMode)
+ 				ExprTokenType params[] =
+ 				{
+ 					input_hook->ScriptObject,
+-					__int64(vk_type(msg.lParam)),
+-					__int64(sc_type(msg.lParam >> 16)),
++					(__int64)(vk_type(msg.lParam)),
++					(__int64)(sc_type(msg.lParam >> 16)),
+ 				};
+ 				IObjectPtr onKey = msg.message == AHK_INPUT_KEYDOWN ? input_hook->ScriptObject->onKeyDown : input_hook->ScriptObject->onKeyUp;
+ 				onKey->ExecuteInNewThread(_T("InputHook"), params, _countof(params));
+diff --git a/source/lib/string.cpp b/source/lib/string.cpp
+index 3354fcb..da69084 100644
+--- a/source/lib/string.cpp
++++ b/source/lib/string.cpp
+@@ -811,7 +811,7 @@ int SortUDF(const void *a1, const void *a2)
+ 
+ 	LPTSTR aStr1 = *(LPTSTR *)a1;
+ 	LPTSTR aStr2 = *(LPTSTR *)a2;
+-	ExprTokenType param[] = { aStr1, aStr2, __int64(aStr2 - aStr1) };
++	ExprTokenType param[] = { aStr1, aStr2, (__int64)(aStr2 - aStr1) };
+ 	__int64 i64;
+ 	g_SortFuncResult = CallMethod(g_SortFunc, g_SortFunc, nullptr, param, _countof(param), &i64);
+ 	// An alternative to g_SortFuncResult using 'throw' to abort qsort() produced slightly
+diff --git a/source/util.cpp b/source/util.cpp
+index 9751185..c0d2e5a 100644
+--- a/source/util.cpp
++++ b/source/util.cpp
+@@ -1042,7 +1042,7 @@ __int64 nstrtoi64(LPCTSTR buf)
+ 					// but to get the correct result we must not wrap the multiplier.
+ 					while (exp >= 20) // Implies !exp_negative.  10**20 won't fit in multiplier.
+ 					{
+-						i *= 10000000000000000000ui64;
++						i *= 10000000000000000000ULL;
+ 						exp -= 19;
+ 					}
+ 					if (exp != 0) // An exponent of 0 is valid but does not alter the result.

--- a/mingw-w64-autohotkey/0007-add-type-overloads-and-const-correctness-fixes-for-M.patch
+++ b/mingw-w64-autohotkey/0007-add-type-overloads-and-const-correctness-fixes-for-M.patch
@@ -1,0 +1,87 @@
+From 7987c6208a25154fa3b4d5dfe3fe0831c6707f6c Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 14 Apr 2026 12:45:21 +0200
+Subject: [PATCH 07/N] add type overloads and const-correctness fixes for
+ MinGW
+
+On MSVC x86_64, `DWORD` is `unsigned long` and `unsigned long` has the
+same width as `unsigned int`, so implicit conversions are harmless.
+On MinGW x86_64, `long` and `unsigned long` are distinct types from
+`int` and `unsigned int` even when they have the same width, causing
+ambiguous overload resolution.  Add explicit `SetValue(long)`,
+`SetValue(unsigned long)`, and `Assign(long)` overloads to resolve the
+ambiguity.  These are added unconditionally because they are correct
+on any platform where the types are distinct.
+
+MSVC also silently converts string literals (const TCHAR*) to the
+non-const LPTSTR that several functions expect.  GCC rejects this as
+a const-to-non-const implicit conversion.  Add a `Return(LPCTSTR)`
+overload that delegates via const_cast to the existing `Return(LPTSTR)`,
+and wrap the SetValue call in error.cpp's UnhandledException with
+const_cast for the same reason.  Both are gated on `#ifdef __MINGW32__`
+since MSVC does not need them.
+---
+ source/defines.h | 8 ++++++++
+ source/error.cpp | 4 ++--
+ source/var.h     | 7 +++++++
+ 3 files changed, 17 insertions(+), 2 deletions(-)
+
+diff --git a/source/defines.h b/source/defines.h
+index b00527b..86e97f5 100644
+--- a/source/defines.h
++++ b/source/defines.h
+@@ -384,6 +384,8 @@ struct ExprTokenType  // Something in the compiler hates the name TokenType, so
+ 	void SetValue(int aValue) { SetValue((__int64)aValue); }
+ 	void SetValue(UINT aValue) { SetValue((__int64)aValue); }
+ 	void SetValue(UINT64 aValue) { SetValue((__int64)aValue); }
++	void SetValue(long aValue) { SetValue((__int64)aValue); }
++	void SetValue(unsigned long aValue) { SetValue((__int64)aValue); }
+ 	void SetValue(double aValue)
+ 	{
+ 		symbol = SYM_FLOAT;
+@@ -495,6 +497,12 @@ struct ResultToken : public ExprTokenType
+ 	LPTSTR Malloc(LPTSTR aValue, size_t aLength);
+ 
+ 	ResultType Return(LPTSTR aValue, size_t aLength = -1);
++#ifdef __MINGW32__
++	ResultType Return(LPCTSTR aValue, size_t aLength = -1)
++	{
++		return Return(const_cast<LPTSTR>(aValue), aLength);
++	}
++#endif
+ 	ResultType ReturnPtr(LPTSTR aValue)
+ 	// Return a null-terminated string which is already in persistent memory.
+ 	{
+diff --git a/source/error.cpp b/source/error.cpp
+index c58c088..b56ffe4 100644
+--- a/source/error.cpp
++++ b/source/error.cpp
+@@ -1091,8 +1091,8 @@ ResultType Script::UnhandledException(Line* aLine, ResultType aErrorType)
+ 		sOnErrorRunning = true;
+ 		ExprTokenType param[2];
+ 		param[0].CopyValueFrom(*token);
+-		param[1].SetValue(aErrorType == CRITICAL_ERROR ? _T("ExitApp")
+-			: aErrorType == FAIL_OR_OK ? _T("Return") : _T("Exit"));
++		param[1].SetValue(const_cast<LPTSTR>(aErrorType == CRITICAL_ERROR ? _T("ExitApp")
++			: aErrorType == FAIL_OR_OK ? _T("Return") : _T("Exit")));
+ 		mOnError.Call(param, 2, INT_MAX, &retval);
+ 		sOnErrorRunning = false;
+ 		if (g.ThrownToken) // An exception was thrown by the callback.
+diff --git a/source/var.h b/source/var.h
+index bc23c4b..a3dbcba 100644
+--- a/source/var.h
++++ b/source/var.h
+@@ -292,6 +292,13 @@ public:
+ 		return AssignBinaryNumber(aValueToAssign, VAR_ATTRIB_CONTENTS_OUT_OF_DATE|VAR_ATTRIB_IS_INT64);
+ 	}
+ 
++#ifdef __MINGW32__
++	inline ResultType Assign(long aValueToAssign)
++	{
++		return Assign((__int64)aValueToAssign);
++	}
++#endif
++
+ 	inline ResultType Assign(__int64 aValueToAssign)
+ 	{
+ 		return AssignBinaryNumber(aValueToAssign, VAR_ATTRIB_CONTENTS_OUT_OF_DATE|VAR_ATTRIB_IS_INT64);

--- a/mingw-w64-autohotkey/0008-remove-inline-from-out-of-line-function-definitions.patch
+++ b/mingw-w64-autohotkey/0008-remove-inline-from-out-of-line-function-definitions.patch
@@ -1,0 +1,50 @@
+From 504302850bffef5f4c1878a9524cce71895ea45a Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 14 Apr 2026 12:45:21 +0200
+Subject: [PATCH 08/N] remove inline from out-of-line function definitions
+
+MSVC tolerates `inline` on a member function declared in a header when
+the body is defined out-of-line in a single .cpp file. GCC treats this
+as a genuine ODR inline and expects the definition in every translation
+unit that uses it, producing undefined-reference link errors for:
+
+  Object::Variant::ToToken (declared inline in script_object.h,
+    defined in script_object.cpp)
+  Script::ConvertActionType (declared inline in script.cpp,
+    called from script2.cpp)
+
+Remove the `inline` specifier from both declarations so the linker
+sees exactly one definition.
+---
+ source/script.cpp      | 4 ++--
+ source/script_object.h | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/source/script.cpp b/source/script.cpp
+index cbbdfde..93f4075 100644
+--- a/source/script.cpp
++++ b/source/script.cpp
+@@ -4945,8 +4945,8 @@ inline LPTSTR Script::ParseActionType(LPTSTR aBufTarget, LPTSTR aBufSource, bool
+ 
+ 
+ 
+-inline ActionTypeType Script::ConvertActionType(LPCTSTR aActionTypeString)
+-// inline since it's called so often, but don't keep it in the .h due to #include issues.
++ActionTypeType Script::ConvertActionType(LPCTSTR aActionTypeString)
++// Was inline, but GCC requires out-of-line functions used across TUs not to be inline.
+ {
+ 	// For the loop's index:
+ 	// Use an int rather than ActionTypeType since it's sure to be large enough to go beyond
+diff --git a/source/script_object.h b/source/script_object.h
+index b751cf5..ec6d39e 100644
+--- a/source/script_object.h
++++ b/source/script_object.h
+@@ -296,7 +296,7 @@ protected:
+ 		void ReturnMove(ResultToken &result);
+ 		void Free();
+ 	
+-		inline void ToToken(ExprTokenType &aToken); // Used when we want the value as is, in a token.  Does not AddRef() or copy strings.
++		void ToToken(ExprTokenType &aToken); // Used when we want the value as is, in a token.  Does not AddRef() or copy strings.
+ 	};
+ 
+ 	struct FieldType : Variant

--- a/mingw-w64-autohotkey/0009-fix-non-const-lvalue-reference-binding-to-rvalues.patch
+++ b/mingw-w64-autohotkey/0009-fix-non-const-lvalue-reference-binding-to-rvalues.patch
@@ -1,0 +1,318 @@
+From b9c373d32d7e8f7e0c99123506fe5ffa6ed47c27 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 14 Apr 2026 12:45:22 +0200
+Subject: [PATCH 09/N] fix non-const lvalue reference binding to rvalues
+
+GCC 15 strictly enforces the C++ rule that a non-const lvalue reference
+cannot bind to an rvalue. MSVC allows this as an extension. AutoHotkey
+frequently constructs a temporary ExprTokenType and passes it to a
+function expecting a non-const reference, e.g.:
+
+  SetOwnProp(name, ExprTokenType(value))
+
+where SetOwnProp takes `ExprTokenType &`. GCC rejects the temporary
+as an rvalue. The fix is to introduce a named local variable at each
+call site so the argument is an lvalue:
+
+  ExprTokenType t(value);
+  SetOwnProp(name, t);
+
+This pattern is applied across 9 files and 23 call sites in the
+Debugger, error handling, COM interface, Object/Array/Map methods,
+Var operations, and BIF functions.
+---
+ source/Debugger.cpp      |  3 ++-
+ source/lib/vars.cpp      |  3 ++-
+ source/script2.cpp       | 20 ++++++++++++++++----
+ source/script_com.cpp    |  6 ++++--
+ source/script_object.cpp | 26 ++++++++++++++++++--------
+ source/script_object.h   | 22 +++++++++++++---------
+ source/var.cpp           |  8 ++++++--
+ source/var.h             |  3 ++-
+ 8 files changed, 63 insertions(+), 28 deletions(-)
+
+diff --git a/source/Debugger.cpp b/source/Debugger.cpp
+index 20a5d13..4c921ae 100644
+--- a/source/Debugger.cpp
++++ b/source/Debugger.cpp
+@@ -1311,7 +1311,8 @@ int Debugger::WriteEnumItems(PropertyInfo &aProp)
+ void Debugger::PropertyWriter::WriteEnumItems(IObject *aEnumerable, int aStart, int aEnd)
+ {
+ 	IObject *enumerator;
+-	auto result = GetEnumerator(enumerator, ExprTokenType(aEnumerable), 2, false);
++	ExprTokenType enum_token(aEnumerable);
++	auto result = GetEnumerator(enumerator, enum_token, 2, false);
+ 	if (result != OK)
+ 	{
+ 		// Just return no items, since setting an error would prevent any other properties
+diff --git a/source/lib/vars.cpp b/source/lib/vars.cpp
+index a8ccf81..997f6f0 100644
+--- a/source/lib/vars.cpp
++++ b/source/lib/vars.cpp
+@@ -161,7 +161,8 @@ BIV_DECL_W(BIV_Clipboard_Set)
+ 				_f_return_FAIL;
+ 			return;
+ 		}
+-		_f_throw_type(_T("ClipboardAll"), ExprTokenType(obj));
++		ExprTokenType obj_token(obj);
++		_f_throw_type(_T("ClipboardAll"), obj_token);
+ 	}
+ 	size_t aLength;
+ 	LPTSTR aBuf = BivRValueToString(&aLength);
+diff --git a/source/script2.cpp b/source/script2.cpp
+index ddf15f3..d3c0355 100644
+--- a/source/script2.cpp
++++ b/source/script2.cpp
+@@ -1844,7 +1844,10 @@ ResultType GetObjectIntProperty(IObject *aObject, LPTSTR aPropName, __int64 &aVa
+ 			return aResultToken.Error(ERR_TYPE_MISMATCH, aPropName, ErrorPrototype::Type);
+ 		//aValue = 0; // Caller should set default value for these cases.
+ 		if (!aOptional)
+-			return aResultToken.UnknownMemberError(ExprTokenType(aObject), IT_GET, aPropName);
++		{
++			ExprTokenType obj_token(aObject);
++			return aResultToken.UnknownMemberError(obj_token, IT_GET, aPropName);
++		}
+ 		return result; // Let caller know it wasn't found.
+ 	}
+ 
+@@ -1863,7 +1866,10 @@ ResultType SetObjectIntProperty(IObject *aObject, LPTSTR aPropName, __int64 aVal
+ 	if (result == FAIL || result == EARLY_EXIT)
+ 		return aResultToken.SetExitResult(result);
+ 	if (result == INVOKE_NOT_HANDLED)
+-		return aResultToken.UnknownMemberError(ExprTokenType(aObject), IT_GET, aPropName);
++	{
++		ExprTokenType obj_token(aObject);
++		return aResultToken.UnknownMemberError(obj_token, IT_GET, aPropName);
++	}
+ 	return OK;
+ }
+ 
+@@ -3628,7 +3634,10 @@ ResultType ValidateFunctor(IObject *aFunc, int aParamCount, ResultToken &aResult
+ 	if (aUseMinParams) // CallbackCreate's signal to default to MinParams.
+ 	{
+ 		if (!has_minparams)
+-			return aShowError ? aResultToken.UnknownMemberError(ExprTokenType(aFunc), IT_GET, _T("MinParams")) : CONDITION_FALSE;
++		{
++			ExprTokenType func_token(aFunc);
++			return aShowError ? aResultToken.UnknownMemberError(func_token, IT_GET, _T("MinParams")) : CONDITION_FALSE;
++		}
+ 		*aUseMinParams = aParamCount = (int)min_params;
+ 	}
+ 	else if (has_minparams && aParamCount < (int)min_params)
+@@ -3653,7 +3662,10 @@ ResultType ValidateFunctor(IObject *aFunc, int aParamCount, ResultToken &aResult
+ 	if (min_result == INVOKE_NOT_HANDLED && max_result == INVOKE_NOT_HANDLED)
+ 		if (Object *obj = dynamic_cast<Object *>(aFunc))
+ 			if (!obj->HasMethod(_T("Call")))
+-				return aShowError ? aResultToken.UnknownMemberError(ExprTokenType(aFunc), IT_CALL, _T("Call")) : CONDITION_FALSE;
++			{
++				ExprTokenType func_token(aFunc);
++				return aShowError ? aResultToken.UnknownMemberError(func_token, IT_CALL, _T("Call")) : CONDITION_FALSE;
++			}
+ 		// Otherwise: COM objects can be callable via DISPID_VALUE.  There's probably
+ 		// no way to determine whether the object supports that without invoking it.
+ 	return OK;
+diff --git a/source/script_com.cpp b/source/script_com.cpp
+index 866553a..28b3b70 100644
+--- a/source/script_com.cpp
++++ b/source/script_com.cpp
+@@ -2001,8 +2001,10 @@ void ComObject::DebugWriteProperty(IDebugProperties *aDebugger, int aPage, int a
+ 	if (aPage == 0 && aDepth > 0)
+ 	{
+ 		// For simplicity, assume aPageSize >= 2.
+-		aDebugger->WriteProperty("Value", ExprTokenType(mVal64));
+-		aDebugger->WriteProperty("VarType", ExprTokenType((__int64)mVarType));
++		ExprTokenType value_token(mVal64);
++		aDebugger->WriteProperty("Value", value_token);
++		ExprTokenType vartype_token((__int64)mVarType);
++		aDebugger->WriteProperty("VarType", vartype_token);
+ 	}
+ 	aDebugger->EndProperty(rootCookie);
+ }
+diff --git a/source/script_object.cpp b/source/script_object.cpp
+index 9c0b43f..1b5cd0c 100644
+--- a/source/script_object.cpp
++++ b/source/script_object.cpp
+@@ -436,7 +436,8 @@ bool Object::Delete()
+ 
+ 		{
+ 			FuncResult rt;
+-			CallMeta(_T("__Delete"), rt, ExprTokenType(this), nullptr, 0);
++			ExprTokenType this_token(this);
++			CallMeta(_T("__Delete"), rt, this_token, nullptr, 0);
+ 			rt.Free();
+ 		}
+ 
+@@ -843,7 +844,8 @@ void Map::__Item(ResultToken &aResultToken, int aID, int aFlags, ExprTokenType *
+ 		{
+ 			if (ParamIndexIsOmitted(1))
+ 			{
+-				auto result = Invoke(aResultToken, IT_GET, _T("Default"), ExprTokenType { this }, nullptr, 0);
++				ExprTokenType this_token { this };
++				auto result = Invoke(aResultToken, IT_GET, _T("Default"), this_token, nullptr, 0);
+ 				if (result == INVOKE_NOT_HANDLED)
+ 					_o_throw(ERR_ITEM_UNSET, *aParam[0], ErrorPrototype::UnsetItem);
+ 				return;
+@@ -900,7 +902,8 @@ ResultType Object::CallMeta(LPTSTR aName, ResultToken &aResultToken, ExprTokenTy
+ 	IObject *method;
+ 	if (method = GetMethod(aName))
+ 	{
+-		return CallAsMethod(ExprTokenType(method), aResultToken, aThisToken, aParam, aParamCount);
++		ExprTokenType method_token(method);
++		return CallAsMethod(method_token, aResultToken, aThisToken, aParam, aParamCount);
+ 	}
+ 	return INVOKE_NOT_HANDLED;
+ }
+@@ -923,7 +926,8 @@ ResultType Object::CallMetaVarg(int aFlags, LPTSTR aName, ResultToken &aResultTo
+ 	if (IS_INVOKE_SET)
+ 		param[param_count++] = aParam[aParamCount]; // value
+ 	// return %func%(this, name, args [, value])
+-	ResultType aResult = func->Invoke(aResultToken, IT_CALL, nullptr, ExprTokenType(func), param, param_count);
++	ExprTokenType func_token(func);
++	ResultType aResult = func->Invoke(aResultToken, IT_CALL, nullptr, func_token, param, param_count);
+ 	vargs->Release();
+ 	return aResult;
+ }
+@@ -1067,7 +1071,8 @@ Object *Object::CreatePrototype(LPTSTR aClassName, Object *aBase)
+ {
+ 	auto obj = new Object();
+ 	obj->mFlags |= ClassPrototype;
+-	obj->SetOwnProp(_T("__Class"), ExprTokenType(aClassName));
++	ExprTokenType class_name_token(aClassName);
++	obj->SetOwnProp(_T("__Class"), class_name_token);
+ 	obj->SetBase(aBase);
+ 	return obj;
+ }
+@@ -1538,7 +1543,10 @@ void Object::GetOwnPropDesc(ResultToken &aResultToken, int aID, int aFlags, Expr
+ 		_o_throw_param(0);
+ 	auto field = FindField(name);
+ 	if (!field)
+-		_o__ret(aResultToken.UnknownMemberError(ExprTokenType(this), IT_GET, name));
++	{
++		ExprTokenType this_token(this);
++		_o__ret(aResultToken.UnknownMemberError(this_token, IT_GET, name));
++	}
+ 	auto desc = Object::Create();
+ 	desc->SetInternalCapacity(field->symbol == SYM_DYNAMIC ? 3 : 1);
+ 	if (field->symbol == SYM_DYNAMIC)
+@@ -2014,7 +2022,8 @@ void Array::Invoke(ResultToken &aResultToken, int aID, int aFlags, ExprTokenType
+ 				aResultToken.CopyValueFrom(*aParam[1]);
+ 				return;
+ 			}
+-			auto result = Object::Invoke(aResultToken, IT_GET, _T("Default"), ExprTokenType{this}, nullptr, 0);
++			ExprTokenType this_token{this};
++			auto result = Object::Invoke(aResultToken, IT_GET, _T("Default"), this_token, nullptr, 0);
+ 			if (result != INVOKE_NOT_HANDLED)
+ 				_o_return_retval;
+ 			_o_throw(ERR_ITEM_UNSET, *aParam[0], ErrorPrototype::UnsetItem);
+@@ -3278,7 +3287,8 @@ BIF_DECL(Class_CallNestedClass)
+ 	}
+ 	else
+ 		aResultToken.symbol = SYM_STRING; // Set the default expected by Invoke.
+-	cls->Invoke(aResultToken, IT_CALL, nullptr, ExprTokenType { cls }, aParam + 1, aParamCount - 1);
++	ExprTokenType cls_token { cls };
++	cls->Invoke(aResultToken, IT_CALL, nullptr, cls_token, aParam + 1, aParamCount - 1);
+ }
+ 
+ 
+diff --git a/source/script_object.h b/source/script_object.h
+index ec6d39e..cc49b58 100644
+--- a/source/script_object.h
++++ b/source/script_object.h
+@@ -445,9 +445,9 @@ public:
+ 		return field->Assign(aValue);
+ 	}
+ 
+-	bool SetOwnProp(name_t aName, __int64 aValue) { return SetOwnProp(aName, ExprTokenType(aValue)); }
+-	bool SetOwnProp(name_t aName, IObject *aValue) { return SetOwnProp(aName, ExprTokenType(aValue)); }
+-	bool SetOwnProp(name_t aName, LPCTSTR aValue) { return SetOwnProp(aName, ExprTokenType(const_cast<LPTSTR>(aValue))); }
++	bool SetOwnProp(name_t aName, __int64 aValue) { ExprTokenType t(aValue); return SetOwnProp(aName, t); }
++	bool SetOwnProp(name_t aName, IObject *aValue) { ExprTokenType t(aValue); return SetOwnProp(aName, t); }
++	bool SetOwnProp(name_t aName, LPCTSTR aValue) { ExprTokenType t(const_cast<LPTSTR>(aValue)); return SetOwnProp(aName, t); }
+ 
+ 	void DeleteOwnProp(name_t aName)
+ 	{
+@@ -580,8 +580,8 @@ public:
+ 
+ 	bool Append(ExprTokenType &aValue);
+ 	bool Append(LPCTSTR aValue, size_t aValueLength = -1) { return Append(const_cast<LPTSTR>(aValue), aValueLength); }
+-	bool Append(LPTSTR aValue, size_t aValueLength = -1) { return Append(ExprTokenType(aValue, aValueLength)); }
+-	bool Append(__int64 aValue) { return Append(ExprTokenType(aValue)); }
++	bool Append(LPTSTR aValue, size_t aValueLength = -1) { ExprTokenType t(aValue, aValueLength); return Append(t); }
++	bool Append(__int64 aValue) { ExprTokenType t(aValue); return Append(t); }
+ 
+ 	Array *Clone();
+ 
+@@ -689,7 +689,8 @@ public:
+ 
+ 	bool HasItem(ExprTokenType &aKey)
+ 	{
+-		return GetItem(ExprTokenType(), aKey); // Conserves code size vs. calling FindItem() directly and is unlikely to perform worse.
++		ExprTokenType t;
++		return GetItem(t, aKey);
+ 	}
+ 
+ 	bool GetItem(ExprTokenType &aToken, ExprTokenType &aKey)
+@@ -727,17 +728,20 @@ public:
+ 
+ 	bool SetItem(LPTSTR aKey, ExprTokenType &aValue)
+ 	{
+-		return SetItem(ExprTokenType(aKey), aValue);
++		ExprTokenType k(aKey);
++		return SetItem(k, aValue);
+ 	}
+ 
+ 	bool SetItem(LPTSTR aKey, __int64 aValue)
+ 	{
+-		return SetItem(aKey, ExprTokenType(aValue));
++		ExprTokenType v(aValue);
++		return SetItem(aKey, v);
+ 	}
+ 
+ 	bool SetItem(LPTSTR aKey, IObject *aValue)
+ 	{
+-		return SetItem(aKey, ExprTokenType(aValue));
++		ExprTokenType v(aValue);
++		return SetItem(aKey, v);
+ 	}
+ 
+ 	ResultType SetItems(ExprTokenType *aParam[], int aParamCount);
+diff --git a/source/var.cpp b/source/var.cpp
+index 4657984..ee66ad8 100644
+--- a/source/var.cpp
++++ b/source/var.cpp
+@@ -575,7 +575,10 @@ ResultType Var::AssignString(LPCTSTR aBuf, VarSizeType aLength, bool aExactSize)
+ 	if (mType == VAR_VIRTUAL)
+ 	{
+ 		if (do_assign)
+-			return AssignVirtual(ExprTokenType(const_cast<LPTSTR>(aBuf), aLength));
++		{
++			ExprTokenType assign_token(const_cast<LPTSTR>(aBuf), aLength);
++			return AssignVirtual(assign_token);
++		}
+ 		// Since above didn't return, the caller wants to allocate some temporary memory for
+ 		// writing the value into, and should call Close() in order to commit the actual value.
+ 	}
+@@ -790,7 +793,8 @@ ResultType Var::AssignSkipAddRef(IObject *aValueToAssign)
+ 
+ 	if (mType == VAR_VIRTUAL)
+ 	{
+-		auto result = AssignVirtual(ExprTokenType(aValueToAssign));
++		ExprTokenType obj_token(aValueToAssign);
++		auto result = AssignVirtual(obj_token);
+ 		aValueToAssign->Release(); // Caller wanted us to take responsibility for this.
+ 		return result;
+ 	}
+diff --git a/source/var.h b/source/var.h
+index a3dbcba..cc261ac 100644
+--- a/source/var.h
++++ b/source/var.h
+@@ -806,7 +806,8 @@ public:
+ 		if (mType == VAR_VIRTUAL)
+ 		{
+ 			// Commit the value in our temporary buffer.
+-			auto result = AssignVirtual(ExprTokenType(mCharContents, CharLength()));
++			ExprTokenType t(mCharContents, CharLength());
++			auto result = AssignVirtual(t);
+ 			Free(); // Free temporary memory and remove VAR_ATTRIB_VIRTUAL_OPEN.
+ 			return result;
+ 		}

--- a/mingw-w64-autohotkey/0010-fix-cross-initialization-errors-from-goto-past-decla.patch
+++ b/mingw-w64-autohotkey/0010-fix-cross-initialization-errors-from-goto-past-decla.patch
@@ -1,0 +1,521 @@
+From 0c1e0f4b1412cbd1f6f07c3d25e594e6998cf568 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 14 Apr 2026 12:45:22 +0200
+Subject: [PATCH 10/N] fix cross-initialization errors from goto past
+ declarations
+
+GCC 15 treats jumping past an initialized variable declaration as a
+hard error (cross-initialization), even with -fpermissive. MSVC
+silently accepts this pattern, which AutoHotkey uses extensively:
+a variable is declared and initialized inside a block that contains
+goto targets, and the goto can jump past the declaration.
+
+The fix hoists the declaration above the goto targets and separates
+it from the initialization. The initialization then happens at the
+original location, after the goto targets. For reference-type
+variables that cannot be separated from initialization, braces are
+added to create an explicit scope that does not span any goto targets.
+
+This affects 10 files: MdFunc.cpp (5 hoisted declarations in the
+argument marshalling loop), pixel.cpp (8 hoisted declarations across
+getbits, PixelSearch, and ImageSearch), regex.cpp (brace-scoped
+cache entry reference), string.cpp (7 hoisted declarations in
+BIF_Sort), win.cpp (5 hoisted declarations in ControlClick),
+script.cpp (hotkey_uses_otb hoisting), script.h (threads_are_attached
+hoisting in a macro), script2.cpp (2 hoisted declarations in
+BIF_IsTypeish), script_expression.cpp (brace-scoped variables in
+ExpandExpression and hoisted declarations in UserFunc::Call and
+ExpandArgs), and script_gui.cpp (hoisted declarations in
+ControlChoose, Submit, and FindOrCreateFont).
+---
+ source/MdFunc.cpp            | 14 +++++++++-----
+ source/lib/pixel.cpp         | 19 ++++++++++++-------
+ source/lib/regex.cpp         |  2 ++
+ source/lib/string.cpp        | 23 ++++++++++++++++-------
+ source/lib/win.cpp           | 17 ++++++++++++-----
+ source/script.cpp            |  3 ++-
+ source/script.h              |  3 ++-
+ source/script2.cpp           |  6 ++++--
+ source/script_expression.cpp | 13 ++++++++++---
+ source/script_gui.cpp        | 27 +++++++++++++++++++--------
+ 10 files changed, 88 insertions(+), 39 deletions(-)
+
+diff --git a/source/MdFunc.cpp b/source/MdFunc.cpp
+index 5c0454d..25b79f4 100644
+--- a/source/MdFunc.cpp
++++ b/source/MdFunc.cpp
+@@ -4,6 +4,7 @@
+ #include "abi.h"
+ #include "script_func_impl.h"
+ #include "window.h"
++#include <new> // placement new
+ 
+ 
+ // internal to this file
+@@ -160,6 +161,12 @@ bool MdFunc::Call(ResultToken &aResultToken, ExprTokenType *aParam[], int aParam
+ 
+ 	ResultType result = OK;
+ 
++	MdType retval_arg_type = MdType::Void;
++	int retval_index = -1;
++	int output_var_count = 0;
++	auto atp = mArgType;
++	bool aborted = false;
++
+ 	if (mPrototype) // This implies thiscall and an initial 'this' parameter, excluded from mArgType.
+ 	{
+ 		auto obj = ParamIndexToObject(0);
+@@ -181,10 +188,7 @@ bool MdFunc::Call(ResultToken &aResultToken, ExprTokenType *aParam[], int aParam
+ 		first_param_index = 1;
+ 	}
+ 
+-	MdType retval_arg_type = MdType::Void;
+-	int retval_index = -1;
+-	int output_var_count = 0;
+-	auto atp = mArgType;
++	atp = mArgType;
+ 	for (int ai = first_param_index, pi = ai; ai < mArgSlots; ++ai, ++atp)
+ 	{
+ 		bool opt = false;
+@@ -407,7 +411,7 @@ bool MdFunc::Call(ResultToken &aResultToken, ExprTokenType *aParam[], int aParam
+ 	rup = DynaCall(mArgSlots, args, mMcFunc, mThisCall);
+ 
+ 	// Convert the return value
+-	bool aborted = false;
++	aborted = false;
+ 	switch (mRetType)
+ 	{
+ 	// Unused return types are commented out or omitted to reduce code size, and disabled
+diff --git a/source/lib/pixel.cpp b/source/lib/pixel.cpp
+index deffb91..2057982 100644
+--- a/source/lib/pixel.cpp
++++ b/source/lib/pixel.cpp
+@@ -35,6 +35,8 @@ LPCOLORREF getbits(HBITMAP ahImage, HDC hdc, LONG &aWidth, LONG &aHeight, bool &
+ 	HGDIOBJ tdc_orig_select = NULL;
+ 	LPCOLORREF image_pixel = NULL;
+ 	bool success = false;
++	int image_pixel_count;
++	bool is_8bit;
+ 
+ 	// Confirmed:
+ 	// Needs extra memory to prevent buffer overflow due to: "A bottom-up DIB is specified by setting
+@@ -59,7 +61,7 @@ LPCOLORREF getbits(HBITMAP ahImage, HDC hdc, LONG &aWidth, LONG &aHeight, bool &
+ 	aWidth = bmi.bmiHeader.biWidth;
+ 	aHeight = bmi.bmiHeader.biHeight;
+ 
+-	int image_pixel_count = aWidth * aHeight;
++	image_pixel_count = aWidth * aHeight;
+ 	if (   !(image_pixel = (LPCOLORREF)malloc(image_pixel_count * sizeof(COLORREF)))   )
+ 		goto end;
+ 
+@@ -67,7 +69,7 @@ LPCOLORREF getbits(HBITMAP ahImage, HDC hdc, LONG &aWidth, LONG &aHeight, bool &
+ 	// of the extra color table handling for 1-bpp images.  Update: For code simplification, support only
+ 	// 8-bpp images.  If ever support lower color depths, use something like "bmi.bmiHeader.biBitCount > 1
+ 	// && bmi.bmiHeader.biBitCount < 9";
+-	bool is_8bit = (bmi.bmiHeader.biBitCount == 8);
++	is_8bit = (bmi.bmiHeader.biBitCount == 8);
+ 	if (!is_8bit)
+ 		bmi.bmiHeader.biBitCount = 32;
+ 	bmi.bmiHeader.biHeight = -bmi.bmiHeader.biHeight; // Storing a negative inside the bmiHeader struct is a signal for GetDIBits().
+@@ -203,6 +205,7 @@ FResult PixelSearch(BOOL *aFound, ResultToken *aFoundX, ResultToken *aFoundY
+ 	HBITMAP hbitmap_screen = NULL;
+ 	LPCOLORREF screen_pixel = NULL;
+ 	HGDIOBJ sdc_orig_select = NULL;
++	LONG screen_pixel_count;
+ 
+ 	// Some explanation for the method below is contained in this quote from the newsgroups:
+ 	// "you shouldn't really be getting the current bitmap from the GetDC DC. This might
+@@ -234,7 +237,7 @@ FResult PixelSearch(BOOL *aFound, ResultToken *aFoundX, ResultToken *aFoundY
+ 	// second problem [in the test script], since GetPixel even in 16bit will return some "valid"
+ 	// data in the last 3bits of each byte."
+ 	register int i;
+-	LONG screen_pixel_count = screen_width * screen_height;
++	screen_pixel_count = screen_width * screen_height;
+ 	if (screen_is_16bit)
+ 		for (i = 0; i < screen_pixel_count; ++i)
+ 			screen_pixel[i] &= 0xF8F8F8F8;
+@@ -505,6 +508,8 @@ bif_impl FResult ImageSearch(ResultToken &aFoundX, ResultToken &aFoundY
+ 	LPCOLORREF image_pixel = NULL, screen_pixel = NULL, image_mask = NULL;
+ 	HGDIOBJ sdc_orig_select = NULL;
+ 	bool found = false; // Must init here for use by "goto end".
++	int search_width, search_height;
++	LONG image_pixel_count, screen_pixel_count;
+     
+ 	bool image_is_16bit;
+ 	LONG image_width, image_height;
+@@ -537,8 +542,8 @@ bif_impl FResult ImageSearch(ResultToken &aFoundX, ResultToken &aFoundY
+ 		goto end;
+ 
+ 	// Create an empty bitmap to hold all the pixels currently visible on the screen that lie within the search area:
+-	int search_width = aRight - aLeft + 1;
+-	int search_height = aBottom - aTop + 1;
++	search_width = aRight - aLeft + 1;
++	search_height = aBottom - aTop + 1;
+ 	if (   !(sdc = CreateCompatibleDC(hdc)) || !(hbitmap_screen = CreateCompatibleBitmap(hdc, search_width, search_height))   )
+ 		goto end;
+ 
+@@ -554,8 +559,8 @@ bif_impl FResult ImageSearch(ResultToken &aFoundX, ResultToken &aFoundY
+ 	if (   !(screen_pixel = getbits(hbitmap_screen, sdc, screen_width, screen_height, screen_is_16bit))   )
+ 		goto end;
+ 
+-	LONG image_pixel_count = image_width * image_height;
+-	LONG screen_pixel_count = screen_width * screen_height;
++	image_pixel_count = image_width * image_height;
++	screen_pixel_count = screen_width * screen_height;
+ 	int i, j, k, x, y; // Declaring as "register" makes no performance difference with current compiler, so let the compiler choose which should be registers.
+ 
+ 	// If either is 16-bit, convert *both* to the 16-bit-compatible 32-bit format:
+diff --git a/source/lib/regex.cpp b/source/lib/regex.cpp
+index 1acef30..368b1d2 100644
+--- a/source/lib/regex.cpp
++++ b/source/lib/regex.cpp
+@@ -599,6 +599,7 @@ break_both:
+ 
+ 	// ADD THE NEWLY-COMPILED REGEX TO THE CACHE.
+ 	// An earlier stage has set insert_pos to be the desired insert-position in the cache.
++	{ // Braces added to limit scope of reference (avoids cross-initialization on goto).
+ 	pcre_cache_entry &this_entry = sCache[insert_pos]; // For performance and convenience.
+ 	if (this_entry.re_compiled) // An existing cache item is being overwritten, so free it's attributes.
+ 	{
+@@ -629,6 +630,7 @@ break_both:
+ 
+ 	LeaveCriticalSection(&g_CriticalRegExCache);
+ 	return re_compiled; // Indicate success.
++	} // End of this_entry reference scope.
+ 
+ match_found: // RegEx was found in the cache at position sLastFound, so return the cached info back to the caller.
+ 	aExtra = sCache[sLastFound].extra;
+diff --git a/source/lib/string.cpp b/source/lib/string.cpp
+index da69084..2905a9b 100644
+--- a/source/lib/string.cpp
++++ b/source/lib/string.cpp
+@@ -928,6 +928,15 @@ BIF_DECL(BIF_Sort)
+ 		}
+ 	}
+ 
++	// Hoisted declarations (separated from initialization to avoid cross-initialization on goto).
++	size_t aContents_length;
++	int unit_size;
++	size_t item_size;
++	LPTSTR *item_curr;
++	size_t item_count_minus_1;
++	DWORD omit_dupe_count;
++	LPTSTR item_prev;
++
+ 	if (!ParamIndexIsOmitted(2))
+ 	{
+ 		if (  !(g_SortFunc = ParamIndexToObject(2))  )
+@@ -950,7 +959,7 @@ BIF_DECL(BIF_Sort)
+ 	for (item_count = 1, cp = aContents; *cp; ++cp)  // Start at 1 since item_count is delimiter_count+1
+ 		if (*cp == delimiter)
+ 			++item_count;
+-	size_t aContents_length = cp - aContents;
++	aContents_length = cp - aContents;
+ 
+ 	// If the last character in the unsorted list is a delimiter then technically the final item
+ 	// in the list is a blank item.  However, if the options specify not to allow that, don't count that
+@@ -1023,8 +1032,8 @@ BIF_DECL(BIF_Sort)
+ 	// Create the array of pointers that points into aContents to each delimited item.
+ 	// Use item_count + 1 to allow space for the last (blank) item in case
+ 	// trailing_delimiter_indicates_trailing_blank_item is false:
+-	int unit_size = sort_random ? 2 : 1;
+-	size_t item_size = unit_size * sizeof(LPTSTR);
++	unit_size = sort_random ? 2 : 1;
++	item_size = unit_size * sizeof(LPTSTR);
+ 	item = (LPTSTR *)malloc((item_count + 1) * item_size);
+ 	if (!item)
+ 	{
+@@ -1044,7 +1053,7 @@ BIF_DECL(BIF_Sort)
+ 	//    into the result.
+ 	// 2) Store a marker/pointer to each item (string) in aContents so that we know where
+ 	//    each item begins for sorting and recopying purposes.
+-	LPTSTR *item_curr = item; // i.e. Don't use [] indexing for the reason in the paragraph previous to above.
++	item_curr = item; // i.e. Don't use [] indexing for the reason in the paragraph previous to above.
+ 	for (item_count = 0, cp = *item_curr = aContents; *cp; ++cp)
+ 	{
+ 		if (*cp == delimiter)  // Each delimiter char becomes the terminator of the previous key phrase.
+@@ -1112,11 +1121,11 @@ BIF_DECL(BIF_Sort)
+ 	aResultToken.symbol = SYM_STRING;
+ 
+ 	// Set default in case original last item is still the last item, or if last item was omitted due to being a dupe:
+-	size_t i, item_count_minus_1 = item_count - 1;
+-	DWORD omit_dupe_count = 0;
++	size_t i; item_count_minus_1 = item_count - 1;
++	omit_dupe_count = 0;
+ 	bool keep_this_item;
+ 	LPTSTR source, dest;
+-	LPTSTR item_prev = NULL;
++	item_prev = NULL;
+ 
+ 	// Copy the sorted result back into output_var.  Do all except the last item, since the last
+ 	// item gets special treatment depending on the options that were specified.
+diff --git a/source/lib/win.cpp b/source/lib/win.cpp
+index 416398d..1df50fd 100644
+--- a/source/lib/win.cpp
++++ b/source/lib/win.cpp
+@@ -412,6 +412,13 @@ bif_impl FResult ControlClick(ExprTokenType *aControlSpec, ExprTokenType *aWinTi
+ 	}
+ 	ASSERT(target_window != NULL);
+ 
++	// Hoisted declarations (separated from initialization to avoid cross-initialization on goto).
++	WPARAM wparam_up;
++	bool vk_is_wheel;
++	bool vk_is_hwheel;
++	LPARAM lparam;
++	FResult result;
++
+ 	// It's debatable, but might be best for flexibility (and backward compatibility) to allow target_window to itself
+ 	// be a control (at least for the position_mode handler below).  For example, the script may have called SetParent
+ 	// to make a top-level window the child of some other window, in which case this policy allows it to be seen like
+@@ -485,9 +492,9 @@ bif_impl FResult ControlClick(ExprTokenType *aControlSpec, ExprTokenType *aWinTi
+ 	}
+ 
+ 	UINT msg_down, msg_up;
+-	WPARAM wparam, wparam_up = 0;
+-	bool vk_is_wheel = aVK == VK_WHEEL_UP || aVK == VK_WHEEL_DOWN;
+-	bool vk_is_hwheel = aVK == VK_WHEEL_LEFT || aVK == VK_WHEEL_RIGHT; // v1.0.48: Lexikos: Support horizontal scrolling in Windows Vista and later.
++	WPARAM wparam; wparam_up = 0;
++	vk_is_wheel = aVK == VK_WHEEL_UP || aVK == VK_WHEEL_DOWN;
++	vk_is_hwheel = aVK == VK_WHEEL_LEFT || aVK == VK_WHEEL_RIGHT; // v1.0.48: Lexikos: Support horizontal scrolling in Windows Vista and later.
+ 
+ 	if (vk_is_wheel)
+ 	{
+@@ -536,7 +543,7 @@ bif_impl FResult ControlClick(ExprTokenType *aControlSpec, ExprTokenType *aWinTi
+ 		}
+ 	}
+ 
+-	LPARAM lparam = MAKELPARAM(click.x, click.y);
++	lparam = MAKELPARAM(click.x, click.y);
+ 
+ 	// SetActiveWindow() requires ATTACH_THREAD_INPUT to succeed.  Even though the MSDN docs state
+ 	// that SetActiveWindow() has no effect unless the parent window is foreground, Jon insists
+@@ -560,7 +567,7 @@ bif_impl FResult ControlClick(ExprTokenType *aControlSpec, ExprTokenType *aWinTi
+ 	//    ControlGet, HWND, HWND,, OK, A  ; Get the HWND of the OK button.
+ 	//    ControlClick,, ahk_id %HWND%
+ 
+-	FResult result = OK;
++	result = OK;
+ 
+ 	if (vk_is_wheel || vk_is_hwheel) // v1.0.48: Lexikos: Support horizontal scrolling in Windows Vista and later.
+ 	{
+diff --git a/source/script.cpp b/source/script.cpp
+index 93f4075..298af89 100644
+--- a/source/script.cpp
++++ b/source/script.cpp
+@@ -1772,6 +1772,7 @@ ResultType Script::LoadIncludedFile(TextStream *fp, int aFileIndex)
+ 		// This must be reset for each iteration because a prior iteration may have changed it, even
+ 		// indirectly by calling something that changed it:
+ 		mCurrLine = NULL;  // To signify that we're in transition, trying to load a new one.
++		bool hotkey_uses_otb; // Hoisted declaration (avoids cross-initialization on goto).
+ 
+ 		if (!GetLineContinuation(fp, buf, next_buf, phys_line_number, has_continuation_section))
+ 			return FAIL;
+@@ -1789,7 +1790,7 @@ process_completed_line:
+ 
+ 		hotstring_start = NULL;
+ 		hotkey_flag = NULL;
+-		bool hotkey_uses_otb = false; // used for hotstrings too.
++		hotkey_uses_otb = false; // used for hotstrings too.
+ 		if (buf[0] == ':' && buf[1])
+ 		{
+ 			hotstring_options = buf + 1; // Point it to the hotstring's option letters, if any.
+diff --git a/source/script.h b/source/script.h
+index 15420a6..188df8b 100644
+--- a/source/script.h
++++ b/source/script.h
+@@ -75,7 +75,8 @@ enum VariableTypeType {VAR_TYPE_INVALID, VAR_TYPE_NUMBER, VAR_TYPE_INTEGER, VAR_
+ 		threads_are_attached = AttachThreadInput(g_MainThreadID, target_thread, TRUE) != 0;
+ // BELOW IS SAME AS ABOVE except it checks do_activate and also does a SetActiveWindow():
+ #define ATTACH_THREAD_INPUT_AND_SETACTIVEWINDOW_IF_DO_ACTIVATE \
+-	bool threads_are_attached = false;\
++	bool threads_are_attached;\
++	threads_are_attached = false;\
+ 	DWORD target_thread;\
+ 	if (do_activate)\
+ 	{\
+diff --git a/source/script2.cpp b/source/script2.cpp
+index d3c0355..aba9f3d 100644
+--- a/source/script2.cpp
++++ b/source/script2.cpp
+@@ -2109,6 +2109,8 @@ BIF_DECL(BIF_IsTypeish)
+ 	auto variable_type = (VariableTypeType)_f_callee_id;
+ 	bool if_condition;
+ 	TCHAR *cp;
++	LPTSTR aValueStr; // Hoisted declaration (avoids cross-initialization on goto).
++	StringCaseSenseType string_case_sense; // Hoisted declaration.
+ 
+ 	// The first set of checks are for isNumber(), isInteger() and isFloat(), which permit pure numeric values.
+ 	switch (TypeOfToken(*aParam[0]))
+@@ -2153,8 +2155,8 @@ BIF_DECL(BIF_IsTypeish)
+ 		}
+ 	}
+ 	// Since above did not return or goto, the value is a string.
+-	LPTSTR aValueStr = ParamIndexToString(0);
+-	auto string_case_sense = ParamIndexToCaseSense(1); // For IsAlpha, IsAlnum, IsUpper, IsLower.
++	aValueStr = ParamIndexToString(0);
++	string_case_sense = ParamIndexToCaseSense(1); // For IsAlpha, IsAlnum, IsUpper, IsLower.
+ 	switch (string_case_sense)
+ 	{
+ 	case SCS_INSENSITIVE: // This case also executes when the parameter is omitted, such as for functions which don't have this parameter.
+diff --git a/source/script_expression.cpp b/source/script_expression.cpp
+index cac8cf2..ccf9f47 100644
+--- a/source/script_expression.cpp
++++ b/source/script_expression.cpp
+@@ -640,6 +640,7 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ResultToken *a
+ 		// Get the first operand for this operator (for non-unary operators, this is the right-side operand):
+ 		if (!stack_count) // Prevent stack underflow.  An expression such as -*3 causes this.
+ 			goto abort_with_exception;
++		{ // Braces added to scope 'right' so gotos from above can jump to push_this_token without crossing its initialization.
+ 		ExprTokenType &right = *STACK_POP;
+ 		if (right.symbol == SYM_MISSING)
+ 		{
+@@ -1289,6 +1290,7 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ResultToken *a
+ 			// Now fall through and push this_token onto the stack as an operand for use by future operators.
+ 			// This is because by convention, an assignment like "x+=1" produces a usable operand.
+ 		}
++		} // End of scope for 'right'.
+ 
+ push_this_token:
+ 		ASSERT(stack_count < mArg[aArgIndex].max_stack);
+@@ -1298,6 +1300,7 @@ push_this_token:
+ 	if (stack_count != 1) // Even for multi-statement expressions, the stack should have only one item left on it:
+ 		goto abort_with_exception; // the overall result.  Any conditions that cause this *should* be detected at load time.
+ 
++	{ // Braces added to scope 'result_token' so gotos from above can jump to labels below without crossing its initialization.
+ 	ExprTokenType &result_token = *stack[0];  // For performance and convenience.  Even for multi-statement, the bottommost item on the stack is the final result so that things like var1:=1,var2:=2 work.
+ 
+ 	// Although ACT_EXPRESSION was already checked higher above for function calls, there are other ways besides
+@@ -1495,6 +1498,7 @@ push_this_token:
+ 		error_value = &result_token;
+ 		goto type_mismatch;
+ 	} // switch (result_token.symbol)
++	} // End of scope for 'result_token'.
+ 
+ // ALL PATHS ABOVE SHOULD "GOTO".  TO CATCH BUGS, ANY THAT DON'T FALL INTO "ABORT" BELOW.
+ abort_with_exception:
+@@ -1798,6 +1802,8 @@ bool UserFunc::Call(ResultToken &aResultToken, ExprTokenType *aParam[], int aPar
+ 		UDFCallInfo recurse(this);
+ 
+ 		int j, count_of_actuals_that_have_formals;
++		int default_expr;
++		ResultType result;
+ 		count_of_actuals_that_have_formals = (aParamCount > mParamCount)
+ 			? mParamCount  // Omit any actuals that lack formals (this can happen when a dynamic call passes too many parameters).
+ 			: aParamCount;
+@@ -1910,7 +1916,7 @@ bool UserFunc::Call(ResultToken &aResultToken, ExprTokenType *aParam[], int aPar
+ 			}
+ 		}
+ 
+-		int default_expr = mParamCount;
++		default_expr = mParamCount;
+ 		for (j = 0; j < mParamCount; ++j) // For each formal parameter.
+ 		{
+ 			FuncParam &this_formal_param = mParam[j]; // For performance and convenience.
+@@ -2031,7 +2037,7 @@ bool UserFunc::Call(ResultToken &aResultToken, ExprTokenType *aParam[], int aPar
+ 
+ 		DEBUGGER_STACK_PUSH(&recurse)
+ 
+-		ResultType result = OK;
++		result = OK;
+ 		// Execute any default initializers that weren't simple constants.  This is not done in
+ 		// the loop above for two reasons:
+ 		//  1) It needs to be after DEBUGGER_STACK_PUSH (which isn't moved because it probably
+@@ -2108,6 +2114,7 @@ ResultType Line::ExpandArgs(ResultToken *aResultTokens)
+ 	// the calling of functions in the script:
+ 	LPTSTR arg_deref[MAX_ARGS];
+ 	int i;
++	int max_params;
+ 
+ 	// Make two passes through this line's arg list.  This is done because the performance of
+ 	// realloc() is worse than doing a free() and malloc() because the former often does a memcpy()
+@@ -2306,7 +2313,7 @@ ResultType Line::ExpandArgs(ResultToken *aResultTokens)
+ 	// that all the other sections don't need to check mArgc anymore.
+ 	// Benchmarks show that it doesn't help performance to try to tweak this with a pre-check such as
+ 	// "if (mArgc < max_params)":
+-	int max_params = g_act[mActionType].MaxParams; // Resolve once for performance.
++	max_params = g_act[mActionType].MaxParams; // Resolve once for performance.
+ 	for (i = mArgc; i < max_params; ++i) // START AT mArgc.  For performance, this only does the actual max args for THIS command, not MAX_ARGS.
+ 		sArgDeref[i] = _T("");
+ 
+diff --git a/source/script_gui.cpp b/source/script_gui.cpp
+index 73c0550..d2bc83a 100644
+--- a/source/script_gui.cpp
++++ b/source/script_gui.cpp
+@@ -1315,6 +1315,7 @@ ResultType GuiType::ControlChoose(GuiControlType &aControl, ExprTokenType &aPara
+ {
+ 	int selection_index = -1;
+ 	bool is_choose_string = true;
++	UINT msg_set_index, msg_select_string, msg_find_string; // Hoisted (avoids cross-initialization on goto).
+ 	switch (TypeOfToken(aParam))
+ 	{
+ 	case SYM_INTEGER: is_choose_string = false; break;
+@@ -1322,7 +1323,7 @@ ResultType GuiType::ControlChoose(GuiControlType &aControl, ExprTokenType &aPara
+ 	}
+ 	TCHAR buf[MAX_NUMBER_SIZE];
+ 	
+-	UINT msg_set_index = 0, msg_select_string = 0, msg_find_string = 0;
++	msg_set_index = 0; msg_select_string = 0; msg_find_string = 0;
+ 	switch(aControl.type)
+ 	{
+ 	case GUI_CONTROL_TAB:
+@@ -7759,6 +7760,11 @@ FResult GuiType::Submit(optl<BOOL> aHideIt, IObject *&aRetVal)
+ 
+ 	// Handle all non-radio controls:
+ 	GuiIndexType u;
++	// Hoisted declarations (avoids cross-initialization on goto).
++	int group_radios;
++	int group_radios_with_name;
++	LPTSTR group_name;
++	int selection_number;
+ 	for (u = 0; u < mControlCount; ++u)
+ 	{
+ 		GuiControlType& control = *mControl[u]; // For performance and readability.
+@@ -7788,10 +7794,10 @@ FResult GuiType::Submit(optl<BOOL> aHideIt, IObject *&aRetVal)
+ 
+ 	// Handle GUI_CONTROL_RADIO separately so that any radio group that has a single name
+ 	// to share among all its members can be given special treatment:
+-	int group_radios = 0;           // The number of radio buttons in the current group.
+-	int group_radios_with_name = 0; // The number of the above that have a name.
+-	LPTSTR group_name = NULL;       // The last-found name of the current group.
+-	int selection_number = 0;       // Which radio in the current group is selected (0 if none).
++	group_radios = 0;           // The number of radio buttons in the current group.
++	group_radios_with_name = 0; // The number of the above that have a name.
++	group_name = NULL;       // The last-found name of the current group.
++	selection_number = 0;       // Which radio in the current group is selected (0 if none).
+ 	LPTSTR output_name;
+ 
+ 	// The below uses <= so that it goes one beyond the limit.  This allows the final radio group
+@@ -8087,6 +8093,11 @@ int GuiType::FindOrCreateFont(LPCTSTR aOptions, LPCTSTR aFontName, FontType *aFo
+ 
+ 	int point_size = 0;
+ 
++	// Hoisted declarations (avoids cross-initialization on goto).
++	HDC hdc;
++	int pixels_per_point_y;
++	int font_index;
++
+ 	TCHAR option[MAX_NUMBER_SIZE + 1];
+ 	LPCTSTR next_option, option_end;
+ 	for (next_option = aOptions; *(next_option = omit_leading_whitespace(next_option)); next_option = option_end)
+@@ -8139,10 +8150,10 @@ int GuiType::FindOrCreateFont(LPCTSTR aOptions, LPCTSTR aFontName, FontType *aFo
+ 	if (aColor) // Caller wanted color returned in an output parameter.
+ 		*aColor = color;
+ 
+-	HDC hdc = GetDC(HWND_DESKTOP);
++	hdc = GetDC(HWND_DESKTOP);
+ 	// Fetch the value every time in case it can change while the system is running (e.g. due to changing
+ 	// display to TV-Out, etc).
+-	int pixels_per_point_y = GetDeviceCaps(hdc, LOGPIXELSY);
++	pixels_per_point_y = GetDeviceCaps(hdc, LOGPIXELSY);
+ 	
+ 	// MulDiv() is usually better because it has automatic rounding, getting the target font
+ 	// closer to the size specified.  This must be done prior to calling FindFont below:
+@@ -8158,7 +8169,7 @@ int GuiType::FindOrCreateFont(LPCTSTR aOptions, LPCTSTR aFontName, FontType *aFo
+ 
+ 	// Now that the attributes of the requested font are known, see if such a font already
+ 	// exists in the array:
+-	int font_index = FindFont(font);
++	font_index = FindFont(font);
+ 	if (font_index != -1) // Match found.
+ 		return font_index;
+ 

--- a/mingw-w64-autohotkey/0011-fix-DllCall-float-double-returns-with-GCC.patch
+++ b/mingw-w64-autohotkey/0011-fix-DllCall-float-double-returns-with-GCC.patch
@@ -1,0 +1,69 @@
+From cc0fcdf8fb13e6f5b81149911b6251e3639d81db Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Mon, 14 Apr 2025 00:00:00 +0000
+Subject: [PATCH 11/N] fix DllCall float/double returns with GCC
+
+GetFloatRetval and GetDoubleRetval are no-op stubs that rely on XMM0
+still holding the float return value from the previously called target
+function inside PerformDynaCall/DynaCall.  MSVC happens to preserve
+XMM0 between the PerformDynaCall return and the GetDoubleRetval call,
+but GCC treats XMM0 as volatile (caller-saved) after any function that
+returns an integer type, and may reuse XMM0 for scratch computation in
+the intervening C++ code.
+
+The fix: save XMM0 to a module-global after every "call rax", and have
+GetFloatRetval/GetDoubleRetval load from that global instead of
+assuming XMM0 is still intact.
+---
+ source/libx64call/x64call.asm | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/source/libx64call/x64call.asm b/source/libx64call/x64call.asm
+index ae9d91f..0d48a26 100644
+--- a/source/libx64call/x64call.asm
++++ b/source/libx64call/x64call.asm
+@@ -27,6 +27,10 @@
+ ;
+ ;//////////////////////////////////////////////////////////////////////////////
+ 
++.data
++
++xmm0_retval dq 0
++
+ .code
+ 
+ include ksamd64.inc
+@@ -75,6 +79,7 @@ PerformDynaCall proc frame
+ 	; Call function
+ 	sub rsp, 8*4 ; spill area
+ 	call rax
++	movsd qword ptr [xmm0_retval], xmm0
+ 
+ 	; Restore stack pointer
+ 	;mov rsp, rbp	; Although mov works too, MSDN says "add RSP,constant or lea RSP,constant[FPReg]" must be used for exception-handling to work reliably. http://msdn.microsoft.com/en-us/library/tawsa7cb.aspx
+@@ -130,6 +135,7 @@ DynaCall proc frame
+ 
+ 	; Call function
+ 	call rax
++	movsd qword ptr [xmm0_retval], xmm0
+ 
+ 	; Restore stack pointer
+ 	;mov rsp, rbp	; Although mov works too, MSDN says "add RSP,constant or lea RSP,constant[FPReg]" must be used for exception-handling to work reliably. http://msdn.microsoft.com/en-us/library/tawsa7cb.aspx
+@@ -143,12 +149,16 @@ DynaCall proc frame
+ DynaCall endp
+ 
+ GetFloatRetval proc
+-	; Nothing is actually done here - we just declare the appropriate return type in C++.
++	; Load the saved XMM0 value.  The original code relied on XMM0 still
++	; holding the target function's return value, but compilers other than
++	; MSVC may clobber XMM0 between the DynaCall return and this call.
++	movss xmm0, dword ptr [xmm0_retval]
+ 	ret
+ GetFloatRetval endp
+ 
+ GetDoubleRetval proc
+ 	; See above.
++	movsd xmm0, qword ptr [xmm0_retval]
+ 	ret
+ GetDoubleRetval endp
+ 

--- a/mingw-w64-autohotkey/0012-qualify-member-function-pointer-addresses-for-clang.patch
+++ b/mingw-w64-autohotkey/0012-qualify-member-function-pointer-addresses-for-clang.patch
@@ -1,0 +1,87 @@
+From 4d7f5211b6798160b0968d4dc29b97bce23695aa Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 15 Apr 2026 10:05:57 +0200
+Subject: [PATCH 12/N] qualify member function pointer addresses for clang
+
+Clang requires explicit class qualification when taking the address of
+a member function inside a static member initializer
+(C++ [expr.unary.op]/4). GCC accepts unqualified names like '&run' in
+this context, but clang needs '&Debugger::run'. Apply the qualification
+to all entries in the Debugger::sCommands[] array.
+---
+ source/Debugger.cpp | 56 ++++++++++++++++++++++-----------------------
+ 1 file changed, 28 insertions(+), 28 deletions(-)
+
+diff --git a/source/Debugger.cpp b/source/Debugger.cpp
+index 4c921ae..74f14e9 100644
+--- a/source/Debugger.cpp
++++ b/source/Debugger.cpp
+@@ -44,40 +44,40 @@ int Breakpoint::sMaxId = 0;
+ 
+ Debugger::CommandDef Debugger::sCommands[] =
+ {
+-	{"run", &run},
+-	{"step_into", &step_into},
+-	{"step_over", &step_over},
+-	{"step_out", &step_out},
+-	{"break", &_break},
+-	{"stop", &stop},
+-	{"detach", &detach},
+-
+-	{"status", &status},
++	{"run", &Debugger::run},
++	{"step_into", &Debugger::step_into},
++	{"step_over", &Debugger::step_over},
++	{"step_out", &Debugger::step_out},
++	{"break", &Debugger::_break},
++	{"stop", &Debugger::stop},
++	{"detach", &Debugger::detach},
++
++	{"status", &Debugger::status},
+ 	
+-	{"stack_get", &stack_get},
+-	{"stack_depth", &stack_depth},
+-	{"context_get", &context_get},
+-	{"context_names", &context_names},
+-
+-	{"property_get", &property_get},
+-	{"property_set", &property_set},
+-	{"property_value", &property_value},
++	{"stack_get", &Debugger::stack_get},
++	{"stack_depth", &Debugger::stack_depth},
++	{"context_get", &Debugger::context_get},
++	{"context_names", &Debugger::context_names},
++
++	{"property_get", &Debugger::property_get},
++	{"property_set", &Debugger::property_set},
++	{"property_value", &Debugger::property_value},
+ 	
+-	{"feature_get", &feature_get},
+-	{"feature_set", &feature_set},
++	{"feature_get", &Debugger::feature_get},
++	{"feature_set", &Debugger::feature_set},
+ 	
+-	{"breakpoint_set", &breakpoint_set},
+-	{"breakpoint_get", &breakpoint_get},
+-	{"breakpoint_update", &breakpoint_update},
+-	{"breakpoint_remove", &breakpoint_remove},
+-	{"breakpoint_list", &breakpoint_list},
++	{"breakpoint_set", &Debugger::breakpoint_set},
++	{"breakpoint_get", &Debugger::breakpoint_get},
++	{"breakpoint_update", &Debugger::breakpoint_update},
++	{"breakpoint_remove", &Debugger::breakpoint_remove},
++	{"breakpoint_list", &Debugger::breakpoint_list},
+ 
+-	{"stdout", &redirect_stdout},
+-	{"stderr", &redirect_stderr},
++	{"stdout", &Debugger::redirect_stdout},
++	{"stderr", &Debugger::redirect_stderr},
+ 
+-	{"typemap_get", &typemap_get},
++	{"typemap_get", &Debugger::typemap_get},
+ 	
+-	{"source", &source},
++	{"source", &Debugger::source},
+ };
+ 
+ 

--- a/mingw-w64-autohotkey/0013-cast-function-pointer-to-void-explicitly-in-MdType.h.patch
+++ b/mingw-w64-autohotkey/0013-cast-function-pointer-to-void-explicitly-in-MdType.h.patch
@@ -1,0 +1,28 @@
+From c9d04d62de0c9a654619a26066fdf31a9f43a66d Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 15 Apr 2026 10:08:02 +0200
+Subject: [PATCH 13/N] cast function pointer to void* explicitly in MdType.h
+
+The md_func_data macro stores a typed function pointer into a void*
+field via implicit conversion. GCC permits this as a common extension,
+but clang rejects it because the C++ standard does not allow implicit
+conversion from function pointer to void*. Wrapping the expression in
+reinterpret_cast<void*>() makes the intent explicit and satisfies both
+compilers.
+---
+ source/MdType.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/source/MdType.h b/source/MdType.h
+index 49462c7..82fa110 100644
+--- a/source/MdType.h
++++ b/source/MdType.h
+@@ -149,7 +149,7 @@ template<> struct md_retval<MdType::ResultType> { typedef ResultType t; };
+ #define md_func_data(script_name, native_name, retcode, ...) \
+ 	{ \
+ 		_T(#script_name), \
+-		md_func_cast(retcode, __VA_ARGS__)(native_name), \
++		reinterpret_cast<void *>(md_func_cast(retcode, __VA_ARGS__)(native_name)), \
+ 		MdType::retcode, \
+ 		{ MAP_LIST(md_arg_data, __VA_ARGS__) } \
+ 	},

--- a/mingw-w64-autohotkey/0014-fix-const-string-literal-assignment-to-LPTSTR-in-hot.patch
+++ b/mingw-w64-autohotkey/0014-fix-const-string-literal-assignment-to-LPTSTR-in-hot.patch
@@ -1,0 +1,29 @@
+From 0cb3dcb7e101af8a7c308e2cfd2e003696ef2672 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 15 Apr 2026 10:13:39 +0200
+Subject: [PATCH 14/N] fix const string literal assignment to LPTSTR in
+ hotkey.cpp
+
+Clang treats assignment of a const wchar_t* string literal to a
+non-const LPTSTR as a hard error, whereas GCC merely warns. The
+HotkeyCriterion struct declares WinTitle and WinText as LPTSTR, so
+the empty-string fallback needs const_cast.
+---
+ source/hotkey.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/source/hotkey.cpp b/source/hotkey.cpp
+index 6715695..41520a6 100644
+--- a/source/hotkey.cpp
++++ b/source/hotkey.cpp
+@@ -185,8 +185,8 @@ void Script::PreparseHotkeyIfExpr(Line* aLine)
+ 		hc->Type = invert ? HOT_IF_NOT_ACTIVE : HOT_IF_ACTIVE;
+ 	else
+ 		hc->Type = invert ? HOT_IF_NOT_EXIST : HOT_IF_EXIST;
+-	hc->WinTitle = param_count > 0 ? postfix[0].marker : _T("");
+-	hc->WinText = param_count > 1 ? postfix[1].marker : _T("");
++	hc->WinTitle = param_count > 0 ? postfix[0].marker : const_cast<LPTSTR>(_T(""));
++	hc->WinText = param_count > 1 ? postfix[1].marker : const_cast<LPTSTR>(_T(""));
+ 	// The following adds a duplicate in the event that there are two different expressions
+ 	// which resolve to the same criterion, such as WinExist("x","") and WinExist("x", "").
+ 	// In that case, only the first criterion can be referenced by its WinTitle & WinText

--- a/mingw-w64-autohotkey/0015-fix-static-extern-linkage-mismatch-for-sSendMode.patch
+++ b/mingw-w64-autohotkey/0015-fix-static-extern-linkage-mismatch-for-sSendMode.patch
@@ -1,0 +1,26 @@
+From 1d43c8a274d2e6fd116f45ae0a07f3025e42d84d Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 15 Apr 2026 10:13:54 +0200
+Subject: [PATCH 15/N] fix static/extern linkage mismatch for sSendMode
+
+The header keyboard_mouse.h declares 'extern SendModes sSendMode' for
+use in a default argument, but keyboard_mouse.cpp defines it as
+'static'. Clang rejects the conflicting linkage. Drop the 'static'
+qualifier to match the header declaration.
+---
+ source/keyboard_mouse.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/source/keyboard_mouse.cpp b/source/keyboard_mouse.cpp
+index 2804b28..5ba792d 100644
+--- a/source/keyboard_mouse.cpp
++++ b/source/keyboard_mouse.cpp
+@@ -50,7 +50,7 @@ static UINT sCurrentEvent;
+ static modLR_type sEventModifiersLR; // Tracks the modifier state to following the progress/building of the SendInput array.
+ static POINT sSendInputCursorPos;    // Tracks/predicts cursor position as SendInput array is built.
+ static HookType sHooksToRemoveDuringSendInput;
+-static SendModes sSendMode = SM_EVENT; // Whether a SendInput or Hook array is currently being constructed.
++SendModes sSendMode = SM_EVENT; // Whether a SendInput or Hook array is currently being constructed.
+ static bool sAbortArraySend;         // No init needed.
+ static bool sFirstCallForThisEvent;  //
+ static bool sInBlindMode;            //

--- a/mingw-w64-autohotkey/0016-qualify-member-function-addresses-in-ObjectMember-ta.patch
+++ b/mingw-w64-autohotkey/0016-qualify-member-function-addresses-in-ObjectMember-ta.patch
@@ -1,0 +1,252 @@
+From 5e91dd4b7c1ae5b2378719dd1891ac7f3b5d4ad9 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 15 Apr 2026 08:57:06 -0700
+Subject: [PATCH 16/N] qualify member function addresses in ObjectMember
+ tables for clang
+
+Clang requires explicit class qualification when taking the address of
+a member function (C++ [expr.unary.op]/4), even inside a static member
+initializer that belongs to the class. GCC and MSVC accept unqualified
+names in this context.
+
+The Object_Member, Object_Method, Object_Method1, Object_Property_get,
+and Object_Property_get_set macros in script_object.h use '&impl' to
+form a member function pointer, which fails under clang for every entry
+in Object::sMembers, Map::sMembers, Array::sMembers, and all other
+ObjectMember tables.
+
+Add '_Q' variants of these macros that accept the class name as the
+first argument and produce '&cls::impl'. Under GCC/MSVC, the _Q macros
+simply forward to the original versions, so there is no behavioral
+change on those compilers. Convert all static ObjectMember arrays to
+use the _Q variants.
+---
+ source/script_com.cpp    |   4 +-
+ source/script_object.cpp | 114 +++++++++++++++++++--------------------
+ source/script_object.h   |  18 +++++++
+ 3 files changed, 77 insertions(+), 59 deletions(-)
+
+diff --git a/source/script_com.cpp b/source/script_com.cpp
+index 28b3b70..f23a7a0 100644
+--- a/source/script_com.cpp
++++ b/source/script_com.cpp
+@@ -1314,12 +1314,12 @@ ObjectMemberMd ComObject::sArrayMembers[]
+ 
+ ObjectMember ComObject::sRefMembers[]
+ {
+-	Object_Property_get_set(__Item),
++	Object_Property_get_set_Q(ComObject, __Item),
+ };
+ 
+ ObjectMember ComObject::sValueMembers[]
+ {
+-	Object_Property_get_set(Ptr),
++	Object_Property_get_set_Q(ComObject, Ptr),
+ };
+ 
+ 
+diff --git a/source/script_object.cpp b/source/script_object.cpp
+index 1b5cd0c..1df41b8 100644
+--- a/source/script_object.cpp
++++ b/source/script_object.cpp
+@@ -502,12 +502,12 @@ void Map::Clear()
+ 
+ ObjectMember Object::sMembers[] =
+ {
+-	Object_Method1(Clone, 0, 0),
+-	Object_Method1(DefineProp, 2, 2),
+-	Object_Method1(DeleteProp, 1, 1),
+-	Object_Method1(GetOwnPropDesc, 1, 1),
+-	Object_Method1(HasOwnProp, 1, 1),
+-	Object_Method1(OwnProps, 0, 0)
++	Object_Method1_Q(Object, Clone, 0, 0),
++	Object_Method1_Q(Object, DefineProp, 2, 2),
++	Object_Method1_Q(Object, DeleteProp, 1, 1),
++	Object_Method1_Q(Object, GetOwnPropDesc, 1, 1),
++	Object_Method1_Q(Object, HasOwnProp, 1, 1),
++	Object_Method1_Q(Object, OwnProps, 0, 0)
+ };
+ 
+ LPTSTR Object::sMetaFuncName[] = { _T("__Get"), _T("__Set"), _T("__Call") };
+@@ -821,18 +821,18 @@ void Object::CallBuiltin(int aID, ResultToken &aResultToken, ExprTokenType *aPar
+ 
+ ObjectMember Map::sMembers[] =
+ {
+-	Object_Member(__Item, __Item, 0, IT_SET, 1, 1),
+-	Object_Member(Capacity, Capacity, 0, IT_SET),
+-	Object_Member(CaseSense, CaseSense, 0, IT_SET),
+-	Object_Member(Count, Count, 0, IT_GET),
+-	Object_Method1(__Enum, 0, 1),
+-	Object_Member(__New, Set, 0, IT_CALL, 0, MAXP_VARIADIC),
+-	Object_Method1(Clear, 0, 0),
+-	Object_Method1(Clone, 0, 0),
+-	Object_Method1(Delete, 1, 1),
+-	Object_Member(Get, __Item, 0, IT_CALL, 1, 2),
+-	Object_Method1(Has, 1, 1),
+-	Object_Method1(Set, 0, MAXP_VARIADIC)  // Allow 0 for flexibility with variadic calls.
++	Object_Member_Q(Map, __Item, __Item, 0, IT_SET, 1, 1),
++	Object_Member_Q(Map, Capacity, Capacity, 0, IT_SET),
++	Object_Member_Q(Map, CaseSense, CaseSense, 0, IT_SET),
++	Object_Member_Q(Map, Count, Count, 0, IT_GET),
++	Object_Method1_Q(Map, __Enum, 0, 1),
++	Object_Member_Q(Map, __New, Set, 0, IT_CALL, 0, MAXP_VARIADIC),
++	Object_Method1_Q(Map, Clear, 0, 0),
++	Object_Method1_Q(Map, Clone, 0, 0),
++	Object_Method1_Q(Map, Delete, 1, 1),
++	Object_Member_Q(Map, Get, __Item, 0, IT_CALL, 1, 2),
++	Object_Method1_Q(Map, Has, 1, 1),
++	Object_Method1_Q(Map, Set, 0, MAXP_VARIADIC)  // Allow 0 for flexibility with variadic calls.
+ };
+ 
+ 
+@@ -1983,19 +1983,19 @@ bool Array::ItemToToken(index_t aIndex, ExprTokenType &aToken)
+ 
+ ObjectMember Array::sMembers[] =
+ {
+-	Object_Property_get_set(__Item, 1, 1),
+-	Object_Property_get_set(Capacity),
+-	Object_Property_get_set(Length),
+-	Object_Member(__New, Invoke, M_Push, IT_CALL, 0, MAXP_VARIADIC),
+-	Object_Method(__Enum, 0, 1),
+-	Object_Method(Clone, 0, 0),
+-	Object_Method(Delete, 1, 1),
+-	Object_Method(Get, 1, 2),
+-	Object_Method(Has, 1, 1),
+-	Object_Method(InsertAt, 1, MAXP_VARIADIC),
+-	Object_Method(Pop, 0, 0),
+-	Object_Method(Push, 0, MAXP_VARIADIC),
+-	Object_Method(RemoveAt, 1, 2)
++	Object_Property_get_set_Q(Array, __Item, 1, 1),
++	Object_Property_get_set_Q(Array, Capacity),
++	Object_Property_get_set_Q(Array, Length),
++	Object_Member_Q(Array, __New, Invoke, M_Push, IT_CALL, 0, MAXP_VARIADIC),
++	Object_Method_Q(Array, __Enum, 0, 1),
++	Object_Method_Q(Array, Clone, 0, 0),
++	Object_Method_Q(Array, Delete, 1, 1),
++	Object_Method_Q(Array, Get, 1, 2),
++	Object_Method_Q(Array, Has, 1, 1),
++	Object_Method_Q(Array, InsertAt, 1, MAXP_VARIADIC),
++	Object_Method_Q(Array, Pop, 0, 0),
++	Object_Method_Q(Array, Push, 0, MAXP_VARIADIC),
++	Object_Method_Q(Array, RemoveAt, 1, 2)
+ };
+ 
+ void Array::Invoke(ResultToken &aResultToken, int aID, int aFlags, ExprTokenType *aParam[], int aParamCount)
+@@ -2882,9 +2882,9 @@ BufferObject *BufferObject::Create(void *aData, size_t aSize)
+ 
+ ObjectMember BufferObject::sMembers[] =
+ {
+-	Object_Method(__New, 0, 2),
+-	Object_Property_get(Ptr),
+-	Object_Property_get_set(Size)
++	Object_Method_Q(BufferObject, __New, 0, 2),
++	Object_Property_get_Q(BufferObject, Ptr),
++	Object_Property_get_set_Q(BufferObject, Size)
+ };
+ 
+ void BufferObject::Invoke(ResultToken &aResultToken, int aID, int aFlags, ExprTokenType *aParam[], int aParamCount)
+@@ -2994,52 +2994,52 @@ Object *ClipboardAll::Create()
+ 
+ ObjectMember ClipboardAll::sMembers[]
+ {
+-	Object_Method1(__New, 0, 2)
++	Object_Method1_Q(ClipboardAll, __New, 0, 2)
+ };
+ 
+ 
+ 
+ ObjectMember Func::sMembers[] =
+ {
+-	Object_Method(Bind, 0, MAXP_VARIADIC),
+-	Object_Method(Call, 0, MAXP_VARIADIC),
+-	Object_Method(IsByRef, 0, MAX_FUNCTION_PARAMS),
+-	Object_Method(IsOptional, 0, MAX_FUNCTION_PARAMS),
++	Object_Method_Q(Func, Bind, 0, MAXP_VARIADIC),
++	Object_Method_Q(Func, Call, 0, MAXP_VARIADIC),
++	Object_Method_Q(Func, IsByRef, 0, MAX_FUNCTION_PARAMS),
++	Object_Method_Q(Func, IsOptional, 0, MAX_FUNCTION_PARAMS),
+ 
+-	Object_Property_get(IsBuiltIn),
+-	Object_Property_get(IsVariadic),
+-	Object_Property_get(MaxParams),
+-	Object_Property_get(MinParams),
+-	Object_Property_get(Name)
++	Object_Property_get_Q(Func, IsBuiltIn),
++	Object_Property_get_Q(Func, IsVariadic),
++	Object_Property_get_Q(Func, MaxParams),
++	Object_Property_get_Q(Func, MinParams),
++	Object_Property_get_Q(Func, Name)
+ };
+ 
+ 
+ 
+ ObjectMember RegExMatchObject::sMembers[] =
+ {
+-	Object_Method(__Enum, 0, 1),
+-	Object_Method(__Get, 2, 2),
+-	Object_Member(__Item, Invoke, M_Value, IT_GET, 0, 1),
+-	Object_Member(Count, Invoke, M_Count, IT_GET, 0, 0),
+-	Object_Method(Len, 0, 1),
+-	Object_Member(Len, Invoke, M_Len, IT_GET, 0, 1),
+-	Object_Member(Mark, Invoke, M_Mark, IT_GET, 0, 0),
+-	Object_Method(Name, 1, 1),
+-	Object_Member(Name, Invoke, M_Name, IT_GET, 1, 1),
+-	Object_Method(Pos, 0, 1),
+-	Object_Member(Pos, Invoke, M_Pos, IT_GET, 0, 1),
++	Object_Method_Q(RegExMatchObject, __Enum, 0, 1),
++	Object_Method_Q(RegExMatchObject, __Get, 2, 2),
++	Object_Member_Q(RegExMatchObject, __Item, Invoke, M_Value, IT_GET, 0, 1),
++	Object_Member_Q(RegExMatchObject, Count, Invoke, M_Count, IT_GET, 0, 0),
++	Object_Method_Q(RegExMatchObject, Len, 0, 1),
++	Object_Member_Q(RegExMatchObject, Len, Invoke, M_Len, IT_GET, 0, 1),
++	Object_Member_Q(RegExMatchObject, Mark, Invoke, M_Mark, IT_GET, 0, 0),
++	Object_Method_Q(RegExMatchObject, Name, 1, 1),
++	Object_Member_Q(RegExMatchObject, Name, Invoke, M_Name, IT_GET, 1, 1),
++	Object_Method_Q(RegExMatchObject, Pos, 0, 1),
++	Object_Member_Q(RegExMatchObject, Pos, Invoke, M_Pos, IT_GET, 0, 1),
+ };
+ 
+ 
+ 
+ ObjectMember Object::sErrorMembers[]
+ {
+-	Object_Member(__New, Error__New, M_Error__New, IT_CALL, 0, 3)
++	Object_Member_Q(Object, __New, Error__New, M_Error__New, IT_CALL, 0, 3)
+ };
+ 
+ ObjectMember Object::sOSErrorMembers[]
+ {
+-	Object_Member(__New, Error__New, M_OSError__New, IT_CALL, 0, 3)
++	Object_Member_Q(Object, __New, Error__New, M_OSError__New, IT_CALL, 0, 3)
+ };
+ 
+ 
+diff --git a/source/script_object.h b/source/script_object.h
+index cc49b58..611a272 100644
+--- a/source/script_object.h
++++ b/source/script_object.h
+@@ -93,6 +93,24 @@ struct ObjectMember
+ #define Object_Method1(name, minP, maxP)           Object_Member(name, name,   0,        IT_CALL, minP, maxP)
+ #define Object_Property_get(name, ...)             Object_Member(name, Invoke, P_##name, IT_GET, __VA_ARGS__)
+ #define Object_Property_get_set(name, ...)         Object_Member(name, Invoke, P_##name, IT_SET, __VA_ARGS__)
++#ifdef __clang__
++// Clang requires explicit class qualification when taking the address
++// of a member function (C++ [expr.unary.op]/4).  Provide _Q variants
++// that accept the class name for the static member arrays where the
++// macros above cannot deduce it.
++#define Object_Member_Q(cls, name, impl, id, invokeType, ...) \
++	{ _T(#name), static_cast<ObjectMethod>(&cls::impl), id, invokeType, __VA_ARGS__ }
++#define Object_Method_Q(cls, name, minP, maxP) Object_Member_Q(cls, name, Invoke, M_##name, IT_CALL, minP, maxP)
++#define Object_Method1_Q(cls, name, minP, maxP) Object_Member_Q(cls, name, name, 0, IT_CALL, minP, maxP)
++#define Object_Property_get_Q(cls, name, ...) Object_Member_Q(cls, name, Invoke, P_##name, IT_GET, __VA_ARGS__)
++#define Object_Property_get_set_Q(cls, name, ...) Object_Member_Q(cls, name, Invoke, P_##name, IT_SET, __VA_ARGS__)
++#else
++#define Object_Member_Q(cls, ...) Object_Member(__VA_ARGS__)
++#define Object_Method_Q(cls, ...) Object_Method(__VA_ARGS__)
++#define Object_Method1_Q(cls, ...) Object_Method1(__VA_ARGS__)
++#define Object_Property_get_Q(cls, ...) Object_Property_get(__VA_ARGS__)
++#define Object_Property_get_set_Q(cls, ...) Object_Property_get_set(__VA_ARGS__)
++#endif
+ #define MAXP_VARIADIC 255
+ 
+ 

--- a/mingw-w64-autohotkey/0017-suppress-deprecated-register-keyword-for-clang.patch
+++ b/mingw-w64-autohotkey/0017-suppress-deprecated-register-keyword-for-clang.patch
@@ -1,0 +1,31 @@
+From d568ee438b3ab630085a3b1e5c4af3654ed7f86b Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 15 Apr 2026 08:58:34 -0700
+Subject: [PATCH 17/N] suppress deprecated register keyword for clang
+
+C++17 removed the 'register' storage class specifier. MSVC and GCC
+silently ignore it, but clang in C++17 mode treats it as a hard error.
+AutoHotkey's pixel.cpp uses 'register int' in a few places. Rather than
+patching each use, define 'register' as empty under __clang__ in the
+precompiled header, which covers all translation units.
+---
+ source/stdafx.h | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/source/stdafx.h b/source/stdafx.h
+index dbdecf7..32ca678 100644
+--- a/source/stdafx.h
++++ b/source/stdafx.h
+@@ -83,6 +83,12 @@ GNU General Public License for more details.
+ 	#ifndef max
+ 	#define max(a,b) (((a) > (b)) ? (a) : (b))
+ 	#endif
++	#ifdef __clang__
++	// The 'register' storage class specifier is deprecated in C++11 and
++	// removed in C++17.  MSVC and GCC silently ignore it, but clang in
++	// C++17 mode treats it as a hard error.  Suppress it globally.
++	#define register
++	#endif
+ 	#endif
+ 
+ #endif

--- a/mingw-w64-autohotkey/0018-add-ReturnPtr-LPCTSTR-overload-for-MinGW.patch
+++ b/mingw-w64-autohotkey/0018-add-ReturnPtr-LPCTSTR-overload-for-MinGW.patch
@@ -1,0 +1,33 @@
+From 424ea1a891cce7bb94dd02adff5ad44aa7003376 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 15 Apr 2026 09:04:51 -0700
+Subject: [PATCH 18/N] add ReturnPtr(LPCTSTR) overload for MinGW
+
+Clang and GCC treat string literals as const wchar_t*, which cannot
+implicitly convert to the non-const LPTSTR that ReturnPtr expects.
+Many call sites pass _T("") or other string literal fallbacks through
+the _f_return_p / _o_return_p macros, which expand to ReturnPtr().
+Adding a const-qualified overload that delegates via const_cast fixes
+all these sites without touching each caller individually. This mirrors
+the existing Return(LPCTSTR) overload added for the same reason.
+---
+ source/defines.h | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/source/defines.h b/source/defines.h
+index 86e97f5..466fdf0 100644
+--- a/source/defines.h
++++ b/source/defines.h
+@@ -512,6 +512,12 @@ struct ResultToken : public ExprTokenType
+ 		//marker_length is left at its default value, -1.  Caller will call _tcslen().
+ 		return OK;
+ 	}
++#ifdef __MINGW32__
++	ResultType ReturnPtr(LPCTSTR aValue)
++	{
++		return ReturnPtr(const_cast<LPTSTR>(aValue));
++	}
++#endif
+ 	ResultType ReturnPtr(LPTSTR aValue, size_t aLength)
+ 	// Return a string which is already in persistent memory.
+ 	{

--- a/mingw-w64-autohotkey/0019-fix-const-string-literal-to-LPTSTR-assignments-for-c.patch
+++ b/mingw-w64-autohotkey/0019-fix-const-string-literal-to-LPTSTR-assignments-for-c.patch
@@ -1,0 +1,172 @@
+From 44a89bbf3dae64ef58b435adb2d7d94f2bfa9c85 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 15 Apr 2026 09:12:06 -0700
+Subject: [PATCH 19/N] fix const string literal to LPTSTR assignments for
+ clang
+
+Clang treats assignment of a const wchar_t* string literal to a
+non-const LPTSTR as a hard error, whereas GCC merely warns
+(-Wwritable-strings). This affects many places where _T("") or other
+string literal fallbacks are assigned to LPTSTR variables or array
+elements.
+
+Where the variable is only read through the pointer (passed to
+functions taking LPCTSTR, or used in comparisons), the variable type
+is changed to LPCTSTR: format_str in vars.cpp, param[] in win.cpp,
+target_label in script2.cpp, line_raw_arg1/2 and loop_name in
+script.cpp.
+
+Where the variable is also assigned non-const values (return value of
+ITOA64, Contents(), ParamIndexToString, or flows into an LPTSTR
+return type), const_cast<LPTSTR> is applied to just the literal:
+result in script2.cpp, result_to_return and arg_deref[] in
+script_expression.cpp, value_name in script_registry.cpp, and name in
+script_object.cpp.
+---
+ source/lib/vars.cpp          | 2 +-
+ source/lib/win.cpp           | 2 +-
+ source/script.cpp            | 6 +++---
+ source/script2.cpp           | 6 +++---
+ source/script_expression.cpp | 6 +++---
+ source/script_object.cpp     | 2 +-
+ source/script_registry.cpp   | 2 +-
+ 7 files changed, 13 insertions(+), 13 deletions(-)
+
+diff --git a/source/lib/vars.cpp b/source/lib/vars.cpp
+index 997f6f0..54d2e4c 100644
+--- a/source/lib/vars.cpp
++++ b/source/lib/vars.cpp
+@@ -173,7 +173,7 @@ BIV_DECL_W(BIV_Clipboard_Set)
+ 
+ BIV_DECL_R(BIV_MMM_DDD)
+ {
+-	LPTSTR format_str;
++	LPCTSTR format_str;
+ 	switch(ctoupper(aVarName[2]))
+ 	{
+ 	// Use the case-sensitive formats required by GetDateFormat():
+diff --git a/source/lib/win.cpp b/source/lib/win.cpp
+index 1df50fd..e1d8280 100644
+--- a/source/lib/win.cpp
++++ b/source/lib/win.cpp
+@@ -2306,7 +2306,7 @@ ResultType DetermineTargetWindow(HWND &aWindow, ResultToken &aResultToken, ExprT
+ 		}
+ 	}
+ 	TCHAR number_buf[4][MAX_NUMBER_SIZE];
+-	LPTSTR param[4];
++	LPCTSTR param[4];
+ 	for (int i = 0, j = 0; i < 4; ++i, ++j)
+ 	{
+ 		if (i == 2) j += aNonWinParamCount;
+diff --git a/source/script.cpp b/source/script.cpp
+index 298af89..4388ea8 100644
+--- a/source/script.cpp
++++ b/source/script.cpp
+@@ -7476,8 +7476,8 @@ Line *Script::PreparseCommands(Line *aStartingLine)
+ {
+ 	for (Line *line = aStartingLine; line; line = line->mNextLine)
+ 	{
+-		LPTSTR line_raw_arg1 = LINE_RAW_ARG1; // Resolve only once to help reduce code size.
+-		LPTSTR line_raw_arg2 = LINE_RAW_ARG2; //
++		LPCTSTR line_raw_arg1 = LINE_RAW_ARG1; // Resolve only once to help reduce code size.
++		LPCTSTR line_raw_arg2 = LINE_RAW_ARG2; //
+ 		
+ 		switch (line->mActionType)
+ 		{
+@@ -7551,7 +7551,7 @@ Line *Script::PreparseCommands(Line *aStartingLine)
+ 					// It seems unlikely that computing the target loop at runtime would be useful.
+ 					// For simplicity, rule out things like "break(var)" and "break(func())":
+ 					return line->PreparseError(ERR_PARAM1_INVALID); //_T("Target label of Break/Continue cannot be dynamic."));
+-				LPTSTR loop_name = line_raw_arg1;
++				LPTSTR loop_name = const_cast<LPTSTR>(line_raw_arg1);
+ 				Label *loop_label = nullptr;
+ 				Line *loop_line, *innermost_loop = nullptr;
+ 				if (*loop_name && !IsNumeric(loop_name))
+diff --git a/source/script2.cpp b/source/script2.cpp
+index aba9f3d..0d90e14 100644
+--- a/source/script2.cpp
++++ b/source/script2.cpp
+@@ -1911,7 +1911,7 @@ bool Line::FileIsFilteredOut(LoopFilesStruct &aCurrentFile, FileLoopModeType aFi
+ 
+ Label *Line::GetJumpTarget(bool aIsDereferenced)
+ {
+-	LPTSTR target_label = aIsDereferenced ? ARG1 : RAW_ARG1;
++	LPCTSTR target_label = aIsDereferenced ? ARG1 : RAW_ARG1;
+ 	Label *label = g_script.FindLabel(target_label);
+ 	if (!label)
+ 	{
+@@ -3451,7 +3451,7 @@ LPTSTR TokenToString(ExprTokenType &aToken, LPTSTR aBuf, size_t *aLength)
+ 		}
+ 		return result;
+ 	case SYM_INTEGER:
+-		result = aBuf ? ITOA64(aToken.value_int64, aBuf) : _T("");
++		result = aBuf ? ITOA64(aToken.value_int64, aBuf) : const_cast<LPTSTR>(_T(""));
+ 		break;
+ 	case SYM_FLOAT:
+ 		if (aBuf)
+@@ -3465,7 +3465,7 @@ LPTSTR TokenToString(ExprTokenType &aToken, LPTSTR aBuf, size_t *aLength)
+ 	//case SYM_OBJECT: // Treat objects as empty strings (or TRUE where appropriate).
+ 	//case SYM_MISSING:
+ 	default:
+-		result = _T("");
++		result = const_cast<LPTSTR>(_T(""));
+ 	}
+ 	if (aLength) // Caller wants to know the string's length as well.
+ 		*aLength = _tcslen(result);
+diff --git a/source/script_expression.cpp b/source/script_expression.cpp
+index ccf9f47..6ac0806 100644
+--- a/source/script_expression.cpp
++++ b/source/script_expression.cpp
+@@ -72,7 +72,7 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ResultToken *a
+ 	// "in scope" in case of early "goto" (goto substantially boosts performance and reduces code size here).
+ 	ExprTokenType **to_free = (ExprTokenType **)_alloca(mArg[aArgIndex].max_alloc * sizeof(ExprTokenType *));
+ 	int to_free_count = 0; // The actual number of items in use in the above array.
+-	LPTSTR result_to_return = _T(""); // By contrast, NULL is used to tell the caller to abort the current thread.
++	LPTSTR result_to_return = const_cast<LPTSTR>(_T("")); // By contrast, NULL is used to tell the caller to abort the current thread.
+ 	LPCTSTR error_msg = ERR_EXPR_EVAL, error_info = _T("");
+ 	ExprTokenType *error_value;
+ 	Var *output_var = (mActionType == ACT_ASSIGNEXPR) ? VAR(mArg[0]) : NULL; // Resolve early because it's similar in usage/scope to the above.
+@@ -1330,7 +1330,7 @@ push_this_token:
+ 		// This is an optimization that improves the speed of ACT_IF by up to 50% (ACT_WHILE is
+ 		// probably improved by only up-to-15%). Simple expressions like "if (x < y)" see the biggest
+ 		// speedup.
+-		result_to_return = TokenToBOOL(result_token) ? _T("1") : _T(""); // Return "" vs. "0" for FALSE for consistency with "goto abnormal_end" (which bypasses this section).
++		result_to_return = const_cast<LPTSTR>(TokenToBOOL(result_token) ? _T("1") : _T("")); // Return "" vs. "0" for FALSE for consistency with "goto abnormal_end" (which bypasses this section).
+ 		goto normal_end_skip_output_var; // ACT_IF never has an output_var.
+ 	}
+ 	
+@@ -2286,7 +2286,7 @@ ResultType Line::ExpandArgs(ResultToken *aResultTokens)
+ 				(   mActionType == ACT_ASSIGNEXPR && i == 1  // By contrast, for the below i==anything (all args):
+ 				||  mActionType == ACT_IF
+ 				//|| mActionType == ACT_WHILE // Not necessary to check this one because loadtime leaves ACT_WHILE as an expression in all common cases.
+-				) ? _T("") : NULL; // See "Update #2" and later comments above.
++				) ? const_cast<LPTSTR>(_T("")) : NULL; // See "Update #2" and later comments above.
+ 			
+ 		} // for each arg.
+ 
+diff --git a/source/script_object.cpp b/source/script_object.cpp
+index 1df41b8..f5a740b 100644
+--- a/source/script_object.cpp
++++ b/source/script_object.cpp
+@@ -521,7 +521,7 @@ ResultType Object::Invoke(IObject_Invoke_PARAMS_DECL)
+ 	name_t name;
+ 	if (!aName)
+ 	{
+-		name = IS_INVOKE_CALL ? _T("Call") : _T("__Item");
++		name = const_cast<LPTSTR>(IS_INVOKE_CALL ? _T("Call") : _T("__Item"));
+ 		aFlags |= IF_BYPASS_METAFUNC;
+ 	}
+ 	else
+diff --git a/source/script_registry.cpp b/source/script_registry.cpp
+index c65284d..b8ff8df 100644
+--- a/source/script_registry.cpp
++++ b/source/script_registry.cpp
+@@ -635,7 +635,7 @@ BIF_DECL(BIF_Reg)
+ 	BuiltInFunctionID action = _f_callee_id;
+ 	HKEY root_key;
+ 	LPTSTR sub_key;
+-	LPTSTR value_name = action == FID_RegDeleteKey ? NULL : _T(""); // Set default.
++	LPTSTR value_name = action == FID_RegDeleteKey ? NULL : const_cast<LPTSTR>(_T("")); // Set default.
+ 	DWORD value_type = REG_NONE; // RegWrite
+ 	ExprTokenType *value = nullptr; // RegWrite
+ 	bool close_root;

--- a/mingw-w64-autohotkey/0020-replace-_countof-with-sizeof-for-arrays-with-incompl.patch
+++ b/mingw-w64-autohotkey/0020-replace-_countof-with-sizeof-for-arrays-with-incompl.patch
@@ -1,0 +1,33 @@
+From 78a9d391c515227e2b16f327b484957efa1e5067 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 15 Apr 2026 09:41:21 -0700
+Subject: [PATCH 20/N] replace _countof with sizeof for arrays with incomplete
+ class declarations
+
+Clang's _countof implementation uses a template helper that requires
+the array to have a complete type. The ComObject member arrays are
+declared with incomplete type (empty brackets) in the class header,
+and even though they are defined with a size in the .cpp file, clang
+cannot resolve the template at the _countof call sites. Use the
+portable sizeof(arr)/sizeof(*arr) idiom instead, which works because
+sizeof operates on the complete definition visible in the same
+translation unit.
+---
+ source/script_com.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/source/script_com.cpp b/source/script_com.cpp
+index f23a7a0..8095589 100644
+--- a/source/script_com.cpp
++++ b/source/script_com.cpp
+@@ -1325,8 +1325,8 @@ ObjectMember ComObject::sValueMembers[]
+ 
+ void DefineComPrototypeMembers()
+ {
+-	Object::DefineMembers(Object::sComValuePrototype, _T("ComValue"), ComObject::sValueMembers, _countof(ComObject::sValueMembers));
+-	Object::DefineMembers(Object::sComRefPrototype, _T("ComValueRef"), ComObject::sRefMembers, _countof(ComObject::sRefMembers));
++	Object::DefineMembers(Object::sComValuePrototype, _T("ComValue"), ComObject::sValueMembers, sizeof(ComObject::sValueMembers) / sizeof(*ComObject::sValueMembers));
++	Object::DefineMembers(Object::sComRefPrototype, _T("ComValueRef"), ComObject::sRefMembers, sizeof(ComObject::sRefMembers) / sizeof(*ComObject::sRefMembers));
+ 	Object::DefineMetadataMembers(Object::sComArrayPrototype, _T("ComObjArray"), ComObject::sArrayMembers, _countof(ComObject::sArrayMembers));
+ }
+ 

--- a/mingw-w64-autohotkey/0021-add-explicit-template-instantiations-for-ScriptItemL.patch
+++ b/mingw-w64-autohotkey/0021-add-explicit-template-instantiations-for-ScriptItemL.patch
@@ -1,0 +1,41 @@
+From e9075b5d457b5595ee4b28fc08dfb617fe2be2d2 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 15 Apr 2026 09:58:24 -0700
+Subject: [PATCH 21/N] add explicit template instantiations for ScriptItemList
+ under clang
+
+The ScriptItemList template has its member function definitions in
+script.cpp rather than in the header. GCC implicitly instantiates
+these in the translation units that call them, but clang does not
+emit the definitions for template specializations whose bodies are
+not visible at the point of use. This causes undefined symbol errors
+at link time for Find, Insert, and Alloc with both the VarList
+(ScriptItemList<Var, 32>) and FuncList (ScriptItemList<Func, 4>)
+instantiations. Add explicit template instantiation declarations
+at the end of script.cpp under #ifdef __clang__.
+---
+ source/script.cpp | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/source/script.cpp b/source/script.cpp
+index 4388ea8..629a915 100644
+--- a/source/script.cpp
++++ b/source/script.cpp
+@@ -12661,3 +12661,17 @@ ResultType Script::ActionExec(LPCTSTR aAction, LPCTSTR aParams, LPCTSTR aWorking
+ 		CloseHandle(hprocess); // Required to avoid memory leak.
+ 	return OK;
+ }
++
++#ifdef __clang__
++// Clang requires explicit template instantiations for member functions
++// whose definitions are in this .cpp file but are called from other
++// translation units that only see the class template declaration.
++template Var  *ScriptItemList<Var, VARLIST_INITIAL_SIZE>::Find(LPCTSTR, int *);
++template Var  *ScriptItemList<Var, VARLIST_INITIAL_SIZE>::Find(LPCTSTR, size_t, int *);
++template Func *ScriptItemList<Func, 4>::Find(LPCTSTR, int *);
++template Func *ScriptItemList<Func, 4>::Find(LPCTSTR, size_t, int *);
++template ResultType ScriptItemList<Var, VARLIST_INITIAL_SIZE>::Insert(Var *, int);
++template ResultType ScriptItemList<Func, 4>::Insert(Func *, int);
++template ResultType ScriptItemList<Var, VARLIST_INITIAL_SIZE>::Alloc(int);
++template ResultType ScriptItemList<Func, 4>::Alloc(int);
++#endif

--- a/mingw-w64-autohotkey/AutoHotkey.exe.manifest
+++ b/mingw-w64-autohotkey/AutoHotkey.exe.manifest
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<assemblyIdentity version="1.0.0.0" processorArchitecture="amd64" name="AutoHotkey" type="win32"/>
+<dependency>
+  <dependentAssembly>
+    <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*"/>
+  </dependentAssembly>
+</dependency>
+<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+  <security><requestedPrivileges><requestedExecutionLevel level="asInvoker" uiAccess="false"/></requestedPrivileges></security>
+</trustInfo>
+<compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+  <application>
+    <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+    <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+    <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+    <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+    <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+  </application>
+</compatibility>
+<asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+    <dpiAware>true/pm</dpiAware>
+  </asmv3:windowsSettings>
+</asmv3:application>
+</assembly>

--- a/mingw-w64-autohotkey/CMakeLists.txt
+++ b/mingw-w64-autohotkey/CMakeLists.txt
@@ -1,0 +1,223 @@
+# CMakeLists.txt for AutoHotkey v2 -- MinGW/GCC build
+# Written for the MSYS2 packaging effort.
+cmake_minimum_required(VERSION 3.20)
+
+# Extract version from git or use fallback
+execute_process(
+  COMMAND git describe --tags --match "v*"
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_DESCRIBE
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  ERROR_QUIET
+  RESULT_VARIABLE GIT_RESULT
+)
+
+if(GIT_RESULT EQUAL 0 AND GIT_DESCRIBE MATCHES "^v([0-9]+\\.[0-9]+\\.[0-9]+)")
+  set(AHK_VERSION "${CMAKE_MATCH_1}")
+  string(REGEX REPLACE "^v" "" RAW_AHK_VERSION "${GIT_DESCRIBE}")
+  string(REGEX REPLACE "-([0-9]+)-g" "+\\1+" RAW_AHK_VERSION "${RAW_AHK_VERSION}")
+  string(REGEX REPLACE "-dirty$" "+dirty" RAW_AHK_VERSION "${RAW_AHK_VERSION}")
+else()
+  set(AHK_VERSION "2.0.23")
+  set(RAW_AHK_VERSION "2.0.23")
+endif()
+
+project(AutoHotkey VERSION ${AHK_VERSION} LANGUAGES C CXX ASM)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_C_STANDARD 11)
+
+# --- Bundled PCRE (static library) ---
+set(PCRE_SOURCES
+  source/lib_pcre/pcre/pcre16_chartables.c
+  source/lib_pcre/pcre/pcre16_compile.c
+  source/lib_pcre/pcre/pcre16_config.c
+  source/lib_pcre/pcre/pcre16_exec.c
+  source/lib_pcre/pcre/pcre16_fullinfo.c
+  source/lib_pcre/pcre/pcre16_get.c
+  source/lib_pcre/pcre/pcre16_globals.c
+  source/lib_pcre/pcre/pcre16_jit_compile.c
+  source/lib_pcre/pcre/pcre16_newline.c
+  source/lib_pcre/pcre/pcre16_ord2utf16.c
+  source/lib_pcre/pcre/pcre16_refcount.c
+  source/lib_pcre/pcre/pcre16_string_utils.c
+  source/lib_pcre/pcre/pcre16_study.c
+  source/lib_pcre/pcre/pcre16_tables.c
+  source/lib_pcre/pcre/pcre16_ucd.c
+  source/lib_pcre/pcre/pcre16_valid_utf16.c
+  source/lib_pcre/pcre/pcre16_version.c
+  source/lib_pcre/pcre/pcre16_xclass.c
+)
+
+add_library(lib_pcre STATIC ${PCRE_SOURCES})
+target_compile_definitions(lib_pcre PRIVATE
+  HAVE_CONFIG_H
+  WIN32
+  _LIB
+  PCRE_STATIC
+)
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  target_compile_definitions(lib_pcre PRIVATE _WIN64)
+endif()
+target_include_directories(lib_pcre PRIVATE
+  ${CMAKE_SOURCE_DIR}/source
+  ${CMAKE_SOURCE_DIR}/source/lib_pcre/pcre
+)
+
+# --- AutoHotkey main executable ---
+set(AHK_SOURCES
+  source/ahkversion.cpp
+  source/application.cpp
+  source/AutoHotkey.cpp
+  source/MdFunc.cpp
+  source/clipboard.cpp
+  source/Debugger.cpp
+  source/error.cpp
+  source/globaldata.cpp
+  source/hook.cpp
+  source/hotkey.cpp
+  source/input_object.cpp
+  source/keyboard_mouse.cpp
+  source/lib/CCallback.cpp
+  source/lib/DllCall.cpp
+  source/lib/drive.cpp
+  source/lib/env.cpp
+  source/lib/file.cpp
+  source/lib/Gui.ListView.cpp
+  source/lib/Gui.StatusBar.cpp
+  source/lib/Gui.TreeView.cpp
+  source/lib/input.cpp
+  source/lib/InputBox.cpp
+  source/lib/interop.cpp
+  source/lib/math.cpp
+  source/lib/pixel.cpp
+  source/lib/process.cpp
+  source/lib/regex.cpp
+  source/lib/sound.cpp
+  source/lib/string.cpp
+  source/lib/vars.cpp
+  source/lib/wait.cpp
+  source/lib/win.cpp
+  source/os_version.cpp
+  source/script.cpp
+  source/script2.cpp
+  source/script_autoit.cpp
+  source/script_com.cpp
+  source/script_expression.cpp
+  source/script_gui.cpp
+  source/script_menu.cpp
+  source/script_object.cpp
+  source/script_object_bif.cpp
+  source/script_registry.cpp
+  source/SimpleHeap.cpp
+  source/StringConv.cpp
+  source/TextIO.cpp
+  source/util.cpp
+  source/var.cpp
+  source/window.cpp
+  source/WinGroup.cpp
+)
+
+# x64 assembly (generated from upstream MASM by masm2gas.awk)
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  enable_language(ASM)
+  list(APPEND AHK_SOURCES
+    x64call.S
+    x64stub.S
+  )
+endif()
+
+# Resource file
+set(AHK_RC source/resources/AutoHotkey.rc)
+
+add_executable(AutoHotkey WIN32 ${AHK_SOURCES} ${AHK_RC})
+
+target_compile_definitions(AutoHotkey PRIVATE
+  WIN32
+  _WINDOWS
+  UNICODE
+  _UNICODE
+  NDEBUG
+  ENABLE_DLLCALL
+  ENABLE_REGISTERCALLBACK
+  CONFIG_DEBUGGER
+  "RAW_AHK_VERSION=\"${RAW_AHK_VERSION}\""
+  _WIN32_WINNT=0x0600
+  _WIN32_IE=0x0700
+  PCRE_STATIC
+)
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  target_compile_definitions(AutoHotkey PRIVATE _WIN64)
+endif()
+
+target_include_directories(AutoHotkey PRIVATE
+  ${CMAKE_SOURCE_DIR}/source
+  ${CMAKE_SOURCE_DIR}/source/lib_pcre/pcre
+)
+
+# Generate a version header for the resource compiler (avoids windres quote-escaping issues)
+file(WRITE ${CMAKE_BINARY_DIR}/ahk_version_rc.h
+  "#define RAW_AHK_VERSION \"${RAW_AHK_VERSION}\"\n"
+  "#define AHK_VERSION_N ${PROJECT_VERSION_MAJOR},${PROJECT_VERSION_MINOR},${PROJECT_VERSION_PATCH},0\n"
+)
+set_source_files_properties(${AHK_RC} PROPERTIES COMPILE_FLAGS
+  "--preprocessor-arg=-include --preprocessor-arg=${CMAKE_BINARY_DIR}/ahk_version_rc.h"
+)
+set_source_files_properties(${AHK_RC} PROPERTIES COMPILE_DEFINITIONS "")
+
+target_link_libraries(AutoHotkey PRIVATE
+  lib_pcre
+  wsock32
+  ws2_32
+  winmm
+  version
+  comctl32
+  psapi
+  wininet
+  shlwapi
+  uxtheme
+  dwmapi
+  ole32
+  oleaut32
+  uuid
+  gdi32
+  comdlg32
+  shell32
+  user32
+  kernel32
+  advapi32
+  mpr
+)
+
+# MinGW-specific flags
+if(MINGW)
+  target_compile_options(AutoHotkey PRIVATE
+    -O2
+    -fomit-frame-pointer
+    -fno-threadsafe-statics
+    -fpermissive
+    -Wno-narrowing
+    -Wno-unused-result
+    -Wno-deprecated-declarations
+    -Wno-switch
+    -Wno-unknown-pragmas
+    -Wno-parentheses
+  )
+  target_link_options(AutoHotkey PRIVATE
+    -municode
+    -static-libgcc
+    -static-libstdc++
+    -Wl,--stack,4194304
+    -Wl,--disable-dynamicbase
+    -Wl,--disable-nxcompat
+  )
+  # The manifest is embedded via the .rc resource file, not the linker.
+endif()
+
+set_target_properties(AutoHotkey PROPERTIES
+  OUTPUT_NAME "AutoHotkey64"
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+
+install(TARGETS AutoHotkey RUNTIME DESTINATION bin)
+install(FILES license.txt DESTINATION share/licenses/autohotkey)

--- a/mingw-w64-autohotkey/PKGBUILD
+++ b/mingw-w64-autohotkey/PKGBUILD
@@ -32,10 +32,11 @@ source=("https://github.com/AutoHotkey/AutoHotkey/archive/refs/tags/v${pkgver}.t
         0007-add-type-overloads-and-const-correctness-fixes-for-M.patch
         0008-remove-inline-from-out-of-line-function-definitions.patch
         0009-fix-non-const-lvalue-reference-binding-to-rvalues.patch
-        0010-fix-cross-initialization-errors-from-goto-past-decla.patch)
+        0010-fix-cross-initialization-errors-from-goto-past-decla.patch
+        0011-fix-DllCall-float-double-returns-with-GCC.patch)
 sha256sums=('715266412abb7c87c752cc5a960b0aee6d4e2a6cd8525cef0065cfc8e7448188'
             'b7cbf014f20db22a4e3cf16b2c94a6368e4f4f63db06407547732c3996329deb'
-            'eb2a6c800b0bf026e1011a5ae1470af36eb274aa2bd5fdfab046c598d7c23449'
+            '3eccb84dba6a6994053482b5c00f4683e581ebdd565c1fa62812eaf990004746'
             'a7c5d0ebe16295623882f734a62814e23aeee2f2ae9f2004e46c036a91bde67a'
             '859231aaf689bc70fd9a870839f1b8f24e8ceaf5fe5e41a5ba234b4fbac11a89'
             'e79ddc931c9bca2edd40d8b3d0fda06a752c9daf5d2b7a3cd454fd8a1db39ac4'
@@ -46,7 +47,8 @@ sha256sums=('715266412abb7c87c752cc5a960b0aee6d4e2a6cd8525cef0065cfc8e7448188'
             '80278ae38e5f674634e5be9e1c1c32690e253ba8107549095a1b07bf4e5e73cc'
             '25c6430fcf8ce33297560bb1e3f578a9c1e1522f9ff029f3a658f6e60c042df4'
             '5435831bed4e919379e4e42452eccdd1b5c1bbbdf84fb3f39c047250b736ac4b'
-            'adecb460fd81593f61bca911405fecf0110c159bbb99febd988b1e37d62b64be')
+            'adecb460fd81593f61bca911405fecf0110c159bbb99febd988b1e37d62b64be'
+            '35cfad84a7365afcff499e0fc8d240643214cf09a6114e578fb695b55df1170d')
 
 prepare() {
   cd "AutoHotkey-${pkgver}"

--- a/mingw-w64-autohotkey/PKGBUILD
+++ b/mingw-w64-autohotkey/PKGBUILD
@@ -23,6 +23,7 @@ source=("https://github.com/AutoHotkey/AutoHotkey/archive/refs/tags/v${pkgver}.t
         CMakeLists.txt
         masm2gas.awk
         AutoHotkey.exe.manifest
+        test-basic.ahk
         0001-adapt-precompiled-header-and-config-for-MinGW.patch
         0002-replace-MSVC-structured-exception-handling-with-port.patch
         0003-skip-legacy-wspiapi.h-include-on-MinGW.patch
@@ -38,6 +39,7 @@ sha256sums=('715266412abb7c87c752cc5a960b0aee6d4e2a6cd8525cef0065cfc8e7448188'
             'b7cbf014f20db22a4e3cf16b2c94a6368e4f4f63db06407547732c3996329deb'
             '3eccb84dba6a6994053482b5c00f4683e581ebdd565c1fa62812eaf990004746'
             'a7c5d0ebe16295623882f734a62814e23aeee2f2ae9f2004e46c036a91bde67a'
+            'd917c016975d26c15c0eb7717db6580bb4ceffc69b8f705876d26f630e5b0ba1'
             '859231aaf689bc70fd9a870839f1b8f24e8ceaf5fe5e41a5ba234b4fbac11a89'
             'e79ddc931c9bca2edd40d8b3d0fda06a752c9daf5d2b7a3cd454fd8a1db39ac4'
             '3787275c7580e70e64074ccc208242da0f8f0671015520c9430d6a18c554f5ce'
@@ -89,6 +91,16 @@ build() {
       "${srcdir}/AutoHotkey-${pkgver}"
 
   ${MINGW_PREFIX}/bin/cmake.exe --build .
+}
+
+check() {
+  cd build-${MSYSTEM}
+  {
+    MSYS2_ARG_CONV_EXCL="/ErrorStdOut" \
+      ./bin/AutoHotkey64.exe /ErrorStdOut "${srcdir}/test-basic.ahk"
+    echo $? >exit.code
+  } | tee test.log
+  test 0 = "$(cat exit.code)" || return "$(cat exit.code)"
 }
 
 package() {

--- a/mingw-w64-autohotkey/PKGBUILD
+++ b/mingw-w64-autohotkey/PKGBUILD
@@ -1,0 +1,100 @@
+# Maintainer: Johannes Schindelin <johannes.schindelin@gmx.de>
+
+_realname=autohotkey
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=2.0.23
+pkgrel=1
+pkgdesc="Automation scripting language for Windows (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64')
+url='https://www.autohotkey.com/'
+msys2_repository_url='https://github.com/AutoHotkey/AutoHotkey'
+license=('spdx:GPL-2.0-or-later')
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-gcc-libs"
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+  "${MINGW_PACKAGE_PREFIX}-ninja"
+)
+source=("https://github.com/AutoHotkey/AutoHotkey/archive/refs/tags/v${pkgver}.tar.gz"
+        CMakeLists.txt
+        masm2gas.awk
+        AutoHotkey.exe.manifest
+        0001-adapt-precompiled-header-and-config-for-MinGW.patch
+        0002-replace-MSVC-structured-exception-handling-with-port.patch
+        0003-skip-legacy-wspiapi.h-include-on-MinGW.patch
+        0004-fix-C-type-portability-issues-for-GCC.patch
+        0005-fix-variadic-macro-trailing-comma-for-GCC.patch
+        0006-replace-MSVC-specific-integer-syntax-with-standard-C.patch
+        0007-add-type-overloads-and-const-correctness-fixes-for-M.patch
+        0008-remove-inline-from-out-of-line-function-definitions.patch
+        0009-fix-non-const-lvalue-reference-binding-to-rvalues.patch
+        0010-fix-cross-initialization-errors-from-goto-past-decla.patch)
+sha256sums=('715266412abb7c87c752cc5a960b0aee6d4e2a6cd8525cef0065cfc8e7448188'
+            'b7cbf014f20db22a4e3cf16b2c94a6368e4f4f63db06407547732c3996329deb'
+            'eb2a6c800b0bf026e1011a5ae1470af36eb274aa2bd5fdfab046c598d7c23449'
+            'a7c5d0ebe16295623882f734a62814e23aeee2f2ae9f2004e46c036a91bde67a'
+            '859231aaf689bc70fd9a870839f1b8f24e8ceaf5fe5e41a5ba234b4fbac11a89'
+            'e79ddc931c9bca2edd40d8b3d0fda06a752c9daf5d2b7a3cd454fd8a1db39ac4'
+            '3787275c7580e70e64074ccc208242da0f8f0671015520c9430d6a18c554f5ce'
+            'add61b3b28b2efb7df28a3b25ffd8178076afdfdb775a5ade3cd118ee6f4e71a'
+            'ce97ae5d006b4d94e707bcef476121a66937f2a97912a801af7d313e0c92fdd1'
+            'd5a2d57a11bb37a465d8619c38deadc6ad4abd55ae87d75756c462a91b42fb92'
+            '80278ae38e5f674634e5be9e1c1c32690e253ba8107549095a1b07bf4e5e73cc'
+            '25c6430fcf8ce33297560bb1e3f578a9c1e1522f9ff029f3a658f6e60c042df4'
+            '5435831bed4e919379e4e42452eccdd1b5c1bbbdf84fb3f39c047250b736ac4b'
+            'adecb460fd81593f61bca911405fecf0110c159bbb99febd988b1e37d62b64be')
+
+prepare() {
+  cd "AutoHotkey-${pkgver}"
+
+  # Apply MinGW/GCC portability patches
+  for p in "${srcdir}"/00[01][0-9]-*.patch; do
+    patch -p1 -i "$p" || return 1
+  done
+
+  # Copy in the CMake build system
+  cp "${srcdir}/CMakeLists.txt" .
+
+  # Convert upstream MASM assembly to GAS (Intel syntax) at build time
+  # so the .S files track upstream changes automatically.
+  awk -f "${srcdir}/masm2gas.awk" source/libx64call/x64call.asm > x64call.S
+  awk -f "${srcdir}/masm2gas.awk" source/libx64call/x64stub.asm > x64stub.S
+
+  # Install the application manifest (referenced by the .rc resource file)
+  mkdir -p temp
+  cp "${srcdir}/AutoHotkey.exe.manifest" temp/
+}
+
+build() {
+  mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
+
+  # AutoHotkey disables C++ exceptions and buffer security checks for
+  # performance; strip makepkg's default hardening/optimization flags
+  # to avoid conflicts with the project's own settings.
+  export CFLAGS="-O2 -pipe -fno-lto"
+  export CXXFLAGS="-O2 -pipe -fno-lto"
+  export LDFLAGS="-fno-lto"
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake.exe \
+      -GNinja \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      -DCMAKE_BUILD_TYPE=Release \
+      "${srcdir}/AutoHotkey-${pkgver}"
+
+  ${MINGW_PREFIX}/bin/cmake.exe --build .
+}
+
+package() {
+  cd build-${MSYSTEM}
+
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install .
+
+  # Also install as just "AutoHotkey.exe" for convenience
+  cd "${pkgdir}${MINGW_PREFIX}/bin"
+  cp AutoHotkey64.exe AutoHotkey.exe
+}

--- a/mingw-w64-autohotkey/PKGBUILD
+++ b/mingw-w64-autohotkey/PKGBUILD
@@ -34,7 +34,17 @@ source=("https://github.com/AutoHotkey/AutoHotkey/archive/refs/tags/v${pkgver}.t
         0008-remove-inline-from-out-of-line-function-definitions.patch
         0009-fix-non-const-lvalue-reference-binding-to-rvalues.patch
         0010-fix-cross-initialization-errors-from-goto-past-decla.patch
-        0011-fix-DllCall-float-double-returns-with-GCC.patch)
+        0011-fix-DllCall-float-double-returns-with-GCC.patch
+        0012-qualify-member-function-pointer-addresses-for-clang.patch
+        0013-cast-function-pointer-to-void-explicitly-in-MdType.h.patch
+        0014-fix-const-string-literal-assignment-to-LPTSTR-in-hot.patch
+        0015-fix-static-extern-linkage-mismatch-for-sSendMode.patch
+        0016-qualify-member-function-addresses-in-ObjectMember-ta.patch
+        0017-suppress-deprecated-register-keyword-for-clang.patch
+        0018-add-ReturnPtr-LPCTSTR-overload-for-MinGW.patch
+        0019-fix-const-string-literal-to-LPTSTR-assignments-for-c.patch
+        0020-replace-_countof-with-sizeof-for-arrays-with-incompl.patch
+        0021-add-explicit-template-instantiations-for-ScriptItemL.patch)
 sha256sums=('715266412abb7c87c752cc5a960b0aee6d4e2a6cd8525cef0065cfc8e7448188'
             'b7cbf014f20db22a4e3cf16b2c94a6368e4f4f63db06407547732c3996329deb'
             '3eccb84dba6a6994053482b5c00f4683e581ebdd565c1fa62812eaf990004746'
@@ -50,13 +60,23 @@ sha256sums=('715266412abb7c87c752cc5a960b0aee6d4e2a6cd8525cef0065cfc8e7448188'
             '25c6430fcf8ce33297560bb1e3f578a9c1e1522f9ff029f3a658f6e60c042df4'
             '5435831bed4e919379e4e42452eccdd1b5c1bbbdf84fb3f39c047250b736ac4b'
             'adecb460fd81593f61bca911405fecf0110c159bbb99febd988b1e37d62b64be'
-            '35cfad84a7365afcff499e0fc8d240643214cf09a6114e578fb695b55df1170d')
+            '35cfad84a7365afcff499e0fc8d240643214cf09a6114e578fb695b55df1170d'
+            '3565c377d8f1da4c77ac425558d7c40e01a6aa1ecd0e9bedf0a120c001147aee'
+            '59dd1571773d25fcdeced8f189fe5fe99d43edfc250b5ed09c6954c1897d7389'
+            '20d99938fc9f77e4efbce14f780ad32fa41cf2d1de5fbefe300b56febacd2ba1'
+            'a591350f30ce880f9130c2d550bb4aed82bdc0c8efdcfd6146d05f1ba3122846'
+            '8074e7b4ec18cd7d24c916e3f75e8c5ce6bd0fbfbe85a48f35c2af3ffb266759'
+            '49bb295a53c06094bc98763401fa5efc9b94e85217c38160e611908434c5de36'
+            'c2241244688348d56ecaefc10b6bcae4e690cd9965c0d77948939516e87245d1'
+            '6a45526b8b49b1de373c7b2042a06d540d71acf6ad342a6953f2e52cf1921bc2'
+            '7cc0bac3db5eb7f3db318a7132bd4774e02d8319c4cfb2e92e1672b54b03d680'
+            '4eee6b0dc8bde9e42cce542ff90aadf3de84883279ea8d852067a1dce4ebbebc')
 
 prepare() {
   cd "AutoHotkey-${pkgver}"
 
   # Apply MinGW/GCC portability patches
-  for p in "${srcdir}"/00[01][0-9]-*.patch; do
+  for p in "${srcdir}"/00[012][0-9]-*.patch; do
     patch -p1 -i "$p" || return 1
   done
 

--- a/mingw-w64-autohotkey/masm2gas.awk
+++ b/mingw-w64-autohotkey/masm2gas.awk
@@ -13,7 +13,6 @@
 
 BEGIN {
     print ".intel_syntax noprefix"
-    print ".text"
     print ""
     in_frame = 0
 }
@@ -26,7 +25,23 @@ BEGIN {
 
 # --- Skip MASM-only directives (matched before comment conversion) ---
 
-/^[[:space:]]*\.code/  { next }
+/^[[:space:]]*\.code/  { print ".text"; next }
+/^[[:space:]]*\.data/  { print ".data"; next }
+
+# --- Data definitions:  label db/dw/dd/dq value ---
+
+/^[A-Za-z_][A-Za-z_0-9]*[[:space:]]+(db|dw|dd|dq)[[:space:]]/ {
+    label = $1
+    size = $2
+    val = $3
+    if (size == "db") gas = ".byte"
+    else if (size == "dw") gas = ".short"
+    else if (size == "dd") gas = ".long"
+    else if (size == "dq") gas = ".quad"
+    data_sym[label] = 1
+    printf "%s:\n\t%s %s\n", label, gas, val
+    next
+}
 /^[[:space:]]*include[[:space:]]+ksamd64\.inc/ { next }
 /^[[:space:]]*end[[:space:]]*$/   { next }
 /^[[:space:]]*end[[:space:]]*;/   { next }
@@ -110,6 +125,16 @@ BEGIN {
     next
 }
 
-# --- Default: convert ; comments to // and pass through ---
+# --- Default: fix data-symbol addressing, convert comments, pass through ---
+# MASM x64 uses RIP-relative addressing implicitly for data symbols;
+# GAS Intel syntax requires the explicit [rip + sym] form.
 
-{ gsub(/;/, "//"); print }
+{
+    for (sym in data_sym) {
+        gsub("\\[" sym "\\]", "[rip + " sym "]")
+        gsub("\\[" sym " \\+", "[rip + " sym " +")
+        gsub("\\[" sym " \\-", "[rip + " sym " -")
+    }
+    gsub(/;/, "//")
+    print
+}

--- a/mingw-w64-autohotkey/masm2gas.awk
+++ b/mingw-w64-autohotkey/masm2gas.awk
@@ -1,0 +1,115 @@
+#!/usr/bin/awk -f
+#
+# masm2gas.awk - Convert MASM x64 assembly to GAS with Intel syntax.
+#
+# Translates MASM directives (proc/endp, SEH frame macros from
+# ksamd64.inc, constant definitions) to their GAS equivalents while
+# passing instructions through unchanged.  The output file uses
+# .intel_syntax noprefix so that Intel-format instructions do not
+# need operand-order or register-prefix conversion.
+#
+# Usage:
+#   awk -f masm2gas.awk input.asm > output.S
+
+BEGIN {
+    print ".intel_syntax noprefix"
+    print ".text"
+    print ""
+    in_frame = 0
+}
+
+# Strip trailing CR (Windows line endings)
+{ sub(/\r$/, "") }
+
+# Strip trailing whitespace
+{ sub(/[[:space:]]+$/, "") }
+
+# --- Skip MASM-only directives (matched before comment conversion) ---
+
+/^[[:space:]]*\.code/  { next }
+/^[[:space:]]*include[[:space:]]+ksamd64\.inc/ { next }
+/^[[:space:]]*end[[:space:]]*$/   { next }
+/^[[:space:]]*end[[:space:]]*;/   { next }
+/^[[:space:]]*option[[:space:]]+prologue:none/ { next }
+
+# --- Constant definition:  NAME = EXPR ---
+
+/^[A-Za-z_][A-Za-z_0-9]*[[:space:]]*=[[:space:]]/ {
+    name = $1
+    line = $0
+    sub(/^[^=]*=[[:space:]]*/, "", line)
+    sub(/[[:space:]]*;.*/, "", line)
+    printf ".equ %s, %s\n", name, line
+    next
+}
+
+# --- FUNCNAME proc frame ---
+
+/^[A-Za-z_][A-Za-z_0-9]*[[:space:]]+proc[[:space:]]+frame/ {
+    current_func = $1
+    in_frame = 1
+    print ""
+    printf ".globl %s\n", current_func
+    printf ".def %s; .scl 2; .type 32; .endef\n", current_func
+    printf "%s:\n", current_func
+    printf "\t.seh_proc %s\n", current_func
+    next
+}
+
+# --- FUNCNAME proc  (no frame) ---
+
+/^[A-Za-z_][A-Za-z_0-9]*[[:space:]]+proc[[:space:]]*$/ ||
+/^[A-Za-z_][A-Za-z_0-9]*[[:space:]]+proc[[:space:]]*;/ {
+    current_func = $1
+    in_frame = 0
+    print ""
+    printf ".globl %s\n", current_func
+    printf ".def %s; .scl 2; .type 32; .endef\n", current_func
+    printf "%s:\n", current_func
+    next
+}
+
+# --- FUNCNAME endp ---
+
+/[[:space:]]+endp/ {
+    if (in_frame) print "\t.seh_endproc"
+    in_frame = 0
+    print ""
+    next
+}
+
+# --- ksamd64.inc SEH macros ---
+
+/^[[:space:]]*push_reg[[:space:]]/ {
+    printf "\tpush %s\n", $2
+    printf "\t.seh_pushreg %s\n", $2
+    next
+}
+
+/^[[:space:]]*set_frame[[:space:]]/ {
+    reg = $2; sub(/,/, "", reg)
+    offset = $3 + 0
+    if (offset == 0)
+        printf "\tmov %s, rsp\n", reg
+    else
+        printf "\tlea %s, [rsp+%d]\n", reg, offset
+    printf "\t.seh_setframe %s, %d\n", reg, offset
+    next
+}
+
+/^[[:space:]]*\.endprolog/ {
+    print "\t.seh_endprologue"
+    next
+}
+
+/^[[:space:]]*\.allocstack[[:space:]]/ {
+    size_expr = $0
+    sub(/^[[:space:]]*\.allocstack[[:space:]]+/, "", size_expr)
+    sub(/[[:space:]]*;.*/, "", size_expr)
+    printf "\t.seh_stackalloc %s\n", size_expr
+    next
+}
+
+# --- Default: convert ; comments to // and pass through ---
+
+{ gsub(/;/, "//"); print }

--- a/mingw-w64-autohotkey/test-basic.ahk
+++ b/mingw-w64-autohotkey/test-basic.ahk
@@ -1,0 +1,67 @@
+; test-basic.ahk - Smoke tests for MinGW-built AutoHotkey
+; Exercises DllCall (int, double, string), CallbackCreate, and basic
+; script execution.  Exits 0 on success, 1 on any failure.
+#Requires AutoHotkey v2.0
+
+errors := 0
+Fail(msg) {
+    global errors
+    FileAppend "FAIL: " msg "`n", "*"
+    errors++
+}
+
+; --- Basic arithmetic and strings ---
+if (2 + 3 != 5)
+    Fail("2 + 3 != 5")
+if ("Hello" . " " . "World" != "Hello World")
+    Fail("string concatenation")
+
+; --- DllCall: integer return ---
+pid := DllCall("GetCurrentProcessId", "UInt")
+if (pid = 0)
+    Fail("GetCurrentProcessId returned 0")
+
+; --- DllCall: double return (atan2) ---
+; This specifically tests the XMM0 preservation fix (patch 0011).
+result := DllCall("msvcrt\atan2", "Double", 1.0, "Double", 1.0, "Double")
+expected := 0.7853981633974483
+if (Abs(result - expected) > 0.0001)
+    Fail("atan2(1,1) = " result " (expected ~0.7854)")
+
+; --- DllCall: double return (pow) ---
+result := DllCall("msvcrt\pow", "Double", 2.0, "Double", 10.0, "Double")
+if (Abs(result - 1024.0) > 0.001)
+    Fail("pow(2,10) = " result " (expected 1024)")
+
+; --- DllCall: string output buffer ---
+buf := Buffer(260 * 2)
+len := DllCall("GetSystemDirectoryW", "Ptr", buf, "UInt", 260, "UInt")
+if (len = 0)
+    Fail("GetSystemDirectoryW returned 0")
+else {
+    sysdir := StrGet(buf, "UTF-16")
+    if !InStr(sysdir, "system32", false)
+        Fail("GetSystemDirectoryW returned '" sysdir "'")
+}
+
+; --- CallbackCreate: exercises x64stub.S assembly ---
+AddTwo(a, b, *) {
+    return a + b
+}
+cb := CallbackCreate(AddTwo, , 4)
+if (cb = 0)
+    Fail("CallbackCreate returned 0")
+else {
+    result := DllCall(cb, "Int", 10, "Int", 20, "Int", 0, "Int", 0, "Int")
+    if (result != 30)
+        Fail("Callback(10,20) = " result " (expected 30)")
+    CallbackFree(cb)
+}
+
+; --- Report ---
+if (errors > 0) {
+    FileAppend errors " test(s) FAILED`n", "*"
+    ExitApp 1
+}
+FileAppend "All tests passed`n", "*"
+ExitApp 0


### PR DESCRIPTION
New package: mingw-w64-autohotkey 2.0.23

## Background

[AutoHotkey](https://www.autohotkey.com/) is a scripting language for Windows automation. Upstream builds exclusively with MSVC and has no official GCC/MinGW support. Community attempts to build with GCC have been discussed on the AutoHotkey forum (e.g. https://www.autohotkey.com/boards/viewtopic.php?f=24&t=61487), but none produced a complete, working port. A recurring issue in those attempts was that `DllCall()` returned wrong floating-point values when built with GCC (https://www.autohotkey.com/boards/viewtopic.php?t=65373), which this package addresses in patch 0011.

## Motivation

[Git for Windows](https://gitforwindows.org/) uses AutoHotkey scripts for UI testing of the MSYS2 runtime (see https://github.com/git-for-windows/msys2-runtime/tree/HEAD/ui-tests). Currently the test infrastructure downloads a pre-built AutoHotkey binary. Having AutoHotkey available as a proper MSYS2/MINGW package would make these tests reproducible and self-contained, and would allow other MSYS2 users to benefit from the scripting language in
their workflows.

## What this PR does

Adds a new MINGW package that cross-compiles AutoHotkey v2.0.23 with GCC using a CMake build system written from scratch (upstream uses MSBuild/vcxproj). The package includes:

- **CMakeLists.txt**: Complete CMake build system derived from studying   the upstream `.vcxproj` file
- **masm2gas.awk**: Build-time converter that translates upstream MASM   assembly (`x64call.asm`, `x64stub.asm`) to GAS Intel syntax, so the   assembly tracks upstream changes automatically
- **11 source patches** addressing GCC 15 compatibility:
  - Structured exception handling (`__try`/`__except`) replaced with
    `SetUnhandledExceptionFilter` + `setjmp`/`longjmp`
  - Cross-initialization errors (GCC 15 hard error, not downgradeable)
  - Non-const lvalue reference binding to rvalues
  - Type width differences (`long` vs `int` on MinGW x86_64)
  - Variadic macro trailing comma (`##__VA_ARGS__`)
  - Various MSVC-specific syntax (functional casts, forward enum
    declarations, extra-qualified member names, token pasting)
  - DllCall float/double return value fix (XMM0 register preservation)
- **more patches** addressing Clang compatibility
- **test-basic.ahk**: Smoke test exercising `DllCall` (int, double,
  string), `CallbackCreate`, and basic script execution
- **check()** function in PKGBUILD

Targets `mingw64`, `ucrt64`, and `clang64`. ARM64 (`clangarm64`) is excluded because upstream has zero ARM64 support (the `DynaCall` FFI mechanism is fundamentally tied to x86/x64 calling conventions).

## Testing

The package builds cleanly with GCC 15.2.0 on ucrt64 and passes the `check()` smoke tests covering `DllCall` integer/float/string returns, `CallbackCreate` (exercising the x64stub assembly trampoline), and basic arithmetic/string operations.