### PR TITLE
[new package] shim_executable

### DIFF
--- a/mingw-w64-shim_executable/001-cwd.patch
+++ b/mingw-w64-shim_executable/001-cwd.patch
@@ -1,0 +1,29 @@
+https://github.com/jphilbert/shim_executable/pull/3
+diff --git a/shim.cpp b/shim.cpp
+index 2515d5b..6aa0e0d 100644
+--- a/shim.cpp
++++ b/shim.cpp
+@@ -184,8 +184,9 @@ All other argument are passed to the parent executable.
+                         (alias --shimgen-gui)
+ 
+     --shim-UseTargetWorkingDirectory
+-                    Set the working directory to the target path. By default
+-                        the application will use the shim's path. Useful when
++                    Set the working directory to the target path. By default 
++                        the application will use the shim's path for GUI and 
++                        shell current path for console. This option is useful when
+                         programs need to be running from where they are located
+                         (usually indicates programs that have issues being run
+                         globally).
+@@ -337,7 +338,10 @@ int ShimMain() {
+     appArgs += L" ";
+   appArgs += calling_args;
+ 
+-  wstring working_dir = shimArgUseTarget ? appDir : shimDir;
++  // for console application, set wd to where the shim was called from
++  wstring fallback_dir = shimType == L"CONSOLE" ? currDir : shimDir;
++
++  wstring working_dir = shimArgUseTarget ? appDir : fallback_dir;
+   
+   
+   

--- a/mingw-w64-shim_executable/002-widen.patch
+++ b/mingw-w64-shim_executable/002-widen.patch
@@ -1,0 +1,145 @@
+--- src/shim.cpp.orig	2026-04-14 21:58:05.831925700 -0500
++++ src/shim.cpp	2026-04-14 23:17:03.820642200 -0500
+@@ -278,7 +278,7 @@
+   wstring appArgs   = L"";
+   wstring shimType  = L"";
+   
+-  if (!GetResourceData("SHIM_PATH", appPath)) {
++  if (!GetResourceData(L"SHIM_PATH", appPath)) {
+     LOG(1)  << "Shim has no application path. ";
+     LOG(-1) << "Shim is no longer valid and must be regenerated.";
+     return exitCode;
+@@ -297,8 +297,8 @@
+     exitCode = 0;
+ 
+   appDir = filesystem::path(appPath).parent_path().c_str();
+-  GetResourceData("SHIM_ARGS", appArgs);
+-  GetResourceData("SHIM_TYPE", shimType);
++  GetResourceData(L"SHIM_ARGS", appArgs);
++  GetResourceData(L"SHIM_TYPE", shimType);
+ 
+   // Here forward we'll just use shimArgWait
+   if (shimType == L"CONSOLE")
+--- src/include/resource_functions.h.orig	2026-04-14 17:29:19.830815300 -0500
++++ src/include/resource_functions.h	2026-04-14 23:13:18.526186500 -0500
+@@ -31,13 +31,13 @@
+ 
+ 
+ // ---------------------------- Read Resources ----------------------------- // 
+-bool HasResourceData(LPCSTR name) {
++bool HasResourceData(LPCTSTR name) {
+   if (FindResource(NULL, name, RT_RCDATA)) 
+     return true;
+   return false;
+ }
+ 
+-bool GetResourceData(LPCSTR name, wstring& arg) {
++bool GetResourceData(LPCTSTR name, wstring& arg) {
+   // Get the resource handle if it exists 
+   HRSRC     resource    = FindResource(NULL, name, RT_RCDATA);
+   if (!resource) return false;
+@@ -52,7 +52,7 @@
+   return true;
+ }
+ 
+-bool GetResourceFile(string name, const filesystem::path& path) {
++bool GetResourceFile(wstring name, const filesystem::path& path) {
+   // Get the resource handle if it exists 
+   HRSRC     resource    = FindResource(NULL, name.c_str(), RT_RCDATA);
+   if (!resource) return false;
+@@ -79,7 +79,7 @@
+ 
+ 
+ // ----------------------------- Add Resources ----------------------------- // 
+-BOOL AddResourceData (filesystem::path target, LPCSTR name, wstring arg) {
++BOOL AddResourceData (filesystem::path target, LPCTSTR name, wstring arg) {
+   HANDLE resource   = BeginUpdateResourceW(target.c_str(), FALSE);
+   BOOL bUpdate      = UpdateResource(
+       resource,                 // Handle
+@@ -104,7 +104,7 @@
+ HANDLE resource_handle;
+ 
+ BOOL CALLBACK enumLangsFunc(HMODULE hModule, LPCTSTR lpType, LPCTSTR lpName,
+-                   WORD wLang, LONG lParam) {
++                   WORD wLang, LONG_PTR lParam) {
+     
+   HRSRC hRes =          FindResourceEx(hModule, lpType, lpName, wLang);
+   HGLOBAL hResLoad =    LoadResource(hModule, hRes);
+@@ -114,20 +114,20 @@
+                  lpResLock,                        // ptr to resource info
+                  SizeofResource(hModule, hRes));   // size of resource info
+ 
+-  string log_str = "Copied ";
++  wstring log_str = L"Copied ";
+   
+   if (lpType == RT_ICON)
+-    log_str += "ICON ";
++    log_str += L"ICON ";
+   else if (lpType == RT_VERSION)
+-    log_str += "VERSION ";
++    log_str += L"VERSION ";
+   else if (lpType == RT_GROUP_ICON)
+-    log_str += "ICON GROUP ";
++    log_str += L"ICON GROUP ";
+ 
+-  log_str += "resource ";
++  log_str += L"resource ";
+   if (!IS_INTRESOURCE(lpName))
+     log_str += lpName;
+   else
+-    log_str += to_string((USHORT)lpName);
++    log_str += to_wstring((uintptr_t)lpName);
+ 
+   LOG(3) << log_str;
+ 
+@@ -135,12 +135,12 @@
+ }
+ 
+ BOOL CALLBACK enumNamesFunc(HMODULE hModule, LPCTSTR lpType, LPTSTR lpName,
+-                   LONG lParam) {
++                   LONG_PTR lParam) {
+   EnumResourceLanguages(hModule, lpType, lpName, enumLangsFunc, 0);
+   return TRUE;
+ }
+ 
+-BOOL CALLBACK enumTypesFunc(HMODULE hModule, LPTSTR lpType, LONG lParam) {
++BOOL CALLBACK enumTypesFunc(HMODULE hModule, LPTSTR lpType, LONG_PTR lParam) {
+   // Only Copy Icons and Version Info
+   if(lpType == RT_ICON || lpType == RT_VERSION || lpType == RT_GROUP_ICON)
+     EnumResourceNames(hModule, lpType, enumNamesFunc, 0);
+--- src/include/utility_functions.h.orig	2026-04-14 17:29:19.833812000 -0500
++++ src/include/utility_functions.h	2026-04-14 23:14:24.821586600 -0500
+@@ -120,7 +120,7 @@
+ 
+ 
+ filesystem::path GetExecPath() {
+-  CHAR cExePath[MAX_PATH];  
++  TCHAR cExePath[MAX_PATH];  
+   GetModuleFileName(NULL, cExePath, MAX_PATH);
+   return filesystem::path(cExePath);
+ }  
+--- src/shim_executable.cpp.orig	2026-04-14 23:43:28.322259900 -0500
++++ src/shim_executable.cpp	2026-04-14 23:25:09.887076800 -0500
+@@ -33,7 +33,7 @@
+ 
+ // ----------------- Unpack the Shim from this Application ----------------- // 
+ BOOL UnpackShim(const filesystem::path& path, wstring shim_type) {
+-  return GetResourceFile("SHIM_" + NarrowString(shim_type), path);
++  return GetResourceFile(L"SHIM_" + shim_type, path);
+ }
+ 
+ 
+@@ -535,10 +535,10 @@
+   CopyResources(output_path, input_path);    
+ 
+   // Add Shim Arguments
+-  AddResourceData(output_path, "SHIM_PATH", input_path);
+-  AddResourceData(output_path, "SHIM_TYPE", shim_type);  
++  AddResourceData(output_path, L"SHIM_PATH", input_path);
++  AddResourceData(output_path, L"SHIM_TYPE", shim_type);  
+   if (!command_args.empty()) 
+-    AddResourceData(output_path, "SHIM_ARGS", command_args);
++    AddResourceData(output_path, L"SHIM_ARGS", command_args);
+ 
+ 
+   // -------------------------------- Done --------------------------------- // 

--- a/mingw-w64-shim_executable/Makefile.msys2
+++ b/mingw-w64-shim_executable/Makefile.msys2
@@ -1,0 +1,42 @@
+CPPFLAGS += -DUNICODE -D_UNICODE
+CXXFLAGS += -std=c++17 -Os -ffunction-sections -fdata-sections -I include -fpermissive -Wno-unqualified-std-cast-call
+RCFLAGS = -O coff -I include
+LDFLAGS += -static -municode -lshlwapi -s -Wl,--gc-sections
+SHIMS = shim_gui.exe shim_console.exe
+RC ?= windres
+all: shim_executable.exe
+
+# ---------------------------------- SHIMS ----------------------------------- #
+%.res: %.rc | include/version.h
+	echo Compiling $@
+	$(RC) $(RCFLAGS) -o $@ -i $<
+
+shim_console.exe: shim.res shim.o
+	echo Building $@
+	$(CXX) -o $@ -mconsole $^ $(LDFLAGS)
+
+shim_gui.exe: shim.res shim.o
+	echo Building $@
+	$(CXX) -o $@ -mwindows $^ $(LDFLAGS)
+
+# ----------------------------- Main Application ----------------------------- #
+shim_executable.res: $(SHIMS)
+
+shim_executable.exe: shim_executable.o shim_executable.res
+	echo Building $@
+	$(CXX) -o $@ $^ $(LDFLAGS)
+
+# --------------------------- Post Build Clean-Up ---------------------------- #
+cleanup: 
+	echo Removing intermediate files
+	rm *.o
+	rm *.res
+	rm $(SHIMS)
+
+	echo Created checksum
+	sha256sum shim_executable.exe > shim_executable.sha256
+
+	echo Renamed and moved to .\bin
+	mkdir -p bin
+	mv shim_executable.exe .\bin\shim_exec.exe
+	mv shim_executable.sha256 .\bin\shim_exec.sha256

--- a/mingw-w64-shim_executable/PKGBUILD
+++ b/mingw-w64-shim_executable/PKGBUILD
@@ -1,0 +1,47 @@
+_realname=shim_executable
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=2.3.r1.g65d5d07
+pkgrel=1
+pkgdesc="Make Shims for Executables (like Chocolatey and Scoop) (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url="https://github.com/jphilbert/shim_executable"
+msys2_repository_url=$url
+license=('spdx:MIT')
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "git"
+)
+_commit='65d5d07ed12e789104a837fb344b19fc892b78ed'
+source=("git+${url}.git#commit=$_commit"
+        '001-cwd.patch'
+        '002-widen.patch'
+        'Makefile.msys2')
+sha256sums=('8122bd3ebded0ae1f0da63b59b48a1f8489e8ab68af6daa2d61b41aa765f6c89'
+            '4fcccf4a4823cbf7d8f4b0694c6857fba4cf5d32f9ec020d58ba65250c50dc60'
+            '69917e5d62f000b62193d6736829d85105846f77099a5da07a9162bd93ed9312'
+            '7728446adadcf1ac5d0518d08590385bc9545739da566eaa0c89d274ab70cfaa')
+options=(!strip) # we do it on our own
+
+pkgver() {
+  cd "${_realname}"
+  git describe --tags --long "${_commit}" | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//g'
+}
+
+prepare() {
+  cd "${_realname}"
+  patch -Np1 -i "${srcdir}/001-cwd.patch"
+  patch -Np1 -i "${srcdir}/002-widen.patch"
+}
+
+build() {
+  cd "${srcdir}/${_realname}"
+  make -f "${srcdir}/Makefile.msys2"
+}
+
+package() {
+  cd "${srcdir}/${_realname}"
+  install -Dm755 shim_executable.exe "${pkgdir}${MINGW_PREFIX}/bin/shim_exec.exe"
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}


### PR DESCRIPTION
[This software](https://github.com/jphilbert/shim_executable) helps make lightweight PE redirectors aka shims, e.g.
```sh
$ shim_exec.exe "C:/Program Files/GnuPG/bin/gpg.exe" /usr/bin/gpg
SHIM_EXEC has successfully created 'C:/msys64/usr/bin/gpg'
$ gpg --shim-noop
===============================================================================
GPG - SHIM
===============================================================================
This is a shim for GPG built with SHIM EXECUTABLE (v2.3.0)
See https://github.com/jphilbert/shim_executable for additional information

Shim Path:      'C:\msys64\usr\bin'
Current Path:   'C:\dev\MINGW-packages\mingw-w64-shim_executable'

Command Line Parameters:
  GUI:          No
  Log:          No
  NoOp:         Yes
  Exit:         No
  Wait:         No
  Use Target:   No
  App Args:     <NONE>

Embedded Parameters:
  Shim Type:    CONSOLE
  App Name:     'gpg'
  App Path:     'C:/Program Files/GnuPG/bin'
  App Args:     <NONE>

INFO  - Waiting for process to finish
        (default for CONSOLE shim)

Creating process for application
  APP: 'C:/Program Files/GnuPG/bin/gpg.exe'
  ARG: ''
  DIR: 'C:\dev\MINGW-packages\mingw-w64-shim_executable'
-------------------------------------------------------------------------------
Shim Exiting: NoOp
-------------------------------------------------------------------------------
```

Towards #28628