### PR TITLE
git: synchronize with Git for Windows v2.53.0(3)

### DIFF
--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -17,7 +17,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
 	 "${MINGW_PACKAGE_PREFIX}-gitk"
 	 "${MINGW_PACKAGE_PREFIX}-${_realname}-gui"
 	 "${MINGW_PACKAGE_PREFIX}-${_realname}-for-windows-addons")
-tag=2.53.0.windows.2
+tag=2.53.0.windows.3
 pkgver=${tag/.windows./.}
 pkgrel=1
 pkgdesc="The fast distributed version control system (mingw-w64)"
@@ -62,7 +62,7 @@ source=("${_realname}"::"git+https://github.com/git-for-windows/git.git#tag=v$ta
 # resulting in different sha256sums.
 export GIT_CONFIG_PARAMETERS="${GIT_CONFIG_PARAMETERS:+$GIT_CONFIG_PARAMETERS }'core.autocrlf=false' 'core.eol=lf'"
 
-sha256sums=('e2cb117e65e0829c96310f161d5c4a8ed23893fb3c7ec15d121e0949c45d1168'
+sha256sums=('656c650f4f305acf5e841f41011456c304e834f56f1510128740d44fb07b6646'
             'a9dcba5aebc93ae7aacdee03275780fc6c0f15e88fda30c93041e75851e75090'
             '7e6c5f3dc6a4209dca0e1f38880b2978500a5c745c04bc60dbeda5fc48e8d3cb'
             '80b0b11efe5a2f9b4cd92f28c260d0b3aad8b809c34ed95237c59b73e08ade0b'


### PR DESCRIPTION
This is a security bug fix release, addressing CVE-2026-32631, see the full announcement [here](https://github.com/git-for-windows/git/releases/tag/v2.53.0.windows.3).