### PR TITLE
libfido2: update to 1.17.0 + python-fido2: update to 2.2.0

### DIFF
--- a/mingw-w64-libfido2/PKGBUILD
+++ b/mingw-w64-libfido2/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=libfido2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.16.0
-pkgrel=2
+pkgver=1.17.0
+pkgrel=1
 pkgdesc="Library functionality for FIDO 2.0, including communication with a device over USB (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -22,7 +22,7 @@ source=("https://developers.yubico.com/libfido2/Releases/libfido2-${pkgver}.tar.
         "001-fixed-link-cmd.patch"
         "002-no-version-script.patch"
         "003-fix-diagnostic-build.patch")
-sha256sums=('8c2b6fb279b5b42e9ac92ade71832e485852647b53607c43baaafbbcecea04e4'
+sha256sums=('c1012c8871d71b65872fd5ff1a9d6b0838a55683a03e85ba97479ce57129c736'
             'SKIP'
             '3134757a26e80eb1917036d4402551fa517e4e0e678c54dcf6c166b714de2bf2'
             'c4592b59f3714803df029b8ae4ced3d1474e90d591a36fc9a84bb1e90888230e'

--- a/mingw-w64-python-fido2/PKGBUILD
+++ b/mingw-w64-python-fido2/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=fido2
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=2.1.1
+pkgver=2.2.0
 pkgrel=1
 pkgdesc="For communicating with a FIDO device over USB as well as verifying attestation and assertion signatures (mingw-w64)"
 arch=('any')
@@ -26,7 +26,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-libfido2")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('f1379f845870cc7fc64c7f07323c3ce41e8c96c37054e79e0acd5630b3fec5ac')
+sha256sums=('0d8122e690096ad82afde42ac9d6433a4eeffda64084f36341ea02546b181dd1')
 
 prepare() {
   cd "${_realname}-${pkgver}"


### PR DESCRIPTION
https://www.yubico.com/support/security-advisories/ysa-2026-01/