### PR TITLE
autohotkey: drop -static-libgcc -static-libstdc++

### DIFF
--- a/mingw-w64-autohotkey/CMakeLists.txt
+++ b/mingw-w64-autohotkey/CMakeLists.txt
@@ -205,8 +205,6 @@ if(MINGW)
   )
   target_link_options(AutoHotkey PRIVATE
     -municode
-    -static-libgcc
-    -static-libstdc++
     -Wl,--stack,4194304
     -Wl,--disable-dynamicbase
     -Wl,--disable-nxcompat

--- a/mingw-w64-autohotkey/PKGBUILD
+++ b/mingw-w64-autohotkey/PKGBUILD
@@ -4,7 +4,7 @@ _realname=autohotkey
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.0.23
-pkgrel=2
+pkgrel=3
 pkgdesc="Automation scripting language for Windows (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -46,7 +46,7 @@ source=("https://github.com/AutoHotkey/AutoHotkey/archive/refs/tags/v${pkgver}.t
         0020-replace-_countof-with-sizeof-for-arrays-with-incompl.patch
         0021-add-explicit-template-instantiations-for-ScriptItemL.patch)
 sha256sums=('715266412abb7c87c752cc5a960b0aee6d4e2a6cd8525cef0065cfc8e7448188'
-            'b7cbf014f20db22a4e3cf16b2c94a6368e4f4f63db06407547732c3996329deb'
+            'de4e313ea798fe5c8f76df1f76c6470ce6492358240615783327fd1502415740'
             '3eccb84dba6a6994053482b5c00f4683e581ebdd565c1fa62812eaf990004746'
             'a7c5d0ebe16295623882f734a62814e23aeee2f2ae9f2004e46c036a91bde67a'
             'd917c016975d26c15c0eb7717db6580bb4ceffc69b8f705876d26f630e5b0ba1'


### PR DESCRIPTION
Instead of linking statically to these libraries (which was a left-over from the effort to get this thing to build with GCC at all), the AutoHotKey executable now links dynamically (size improvements are moderate, 10% for GCC, 15% for Clang). Prompted by https://github.com/msys2/MINGW-packages/pull/29023#issuecomment-4271107699