### PR TITLE
recoll: new package 1.43.14

### DIFF
--- a/mingw-w64-recoll/0001-mingw-cross-build.patch
+++ b/mingw-w64-recoll/0001-mingw-cross-build.patch
@@ -1,0 +1,4695 @@
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/common/rclconfig.cpp b/recoll-1.43.14/common/rclconfig.cpp
+--- a/recoll-1.43.14/common/rclconfig.cpp	2026-01-25 15:22:42.000000000 +0100
++++ b/recoll-1.43.14/common/rclconfig.cpp	2026-04-18 21:24:33.811218938 +0200
+@@ -508,7 +508,31 @@
+             m->m_confdir = path_canon(cp);
+         } else {
+             autoconfdir = true;
+-            m->m_confdir=path_cat(path_homedata(), path_defaultrecollconfsubdir());
++#ifdef _WIN32
++            // On Windows, prefer a Unix-style ~/.recoll if it already exists
++            // (handy under MSYS/Cygwin), else fall back to %LOCALAPPDATA%/Recoll.
++            // Check $HOME first (set by MSYS/Cygwin to e.g. /home/user) then
++            // %USERPROFILE% (what path_home() returns on native Windows).
++            m->m_confdir.clear();
++            const char *envhome = getenv("HOME");
++            if (envhome && *envhome) {
++                std::string h = path_cat(path_canon(envhome), ".recoll");
++                if (path_isdir(h)) {
++                    m->m_confdir = h;
++                }
++            }
++            if (m->m_confdir.empty()) {
++                std::string h = path_cat(path_home(), ".recoll");
++                if (path_isdir(h)) {
++                    m->m_confdir = h;
++                }
++            }
++            if (m->m_confdir.empty()) {
++                m->m_confdir = path_cat(path_homedata(), path_defaultrecollconfsubdir());
++            }
++#else
++            m->m_confdir = path_cat(path_homedata(), path_defaultrecollconfsubdir());
++#endif
+         }
+     }
+ 
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/common/rclinit.cpp b/recoll-1.43.14/common/rclinit.cpp
+--- a/recoll-1.43.14/common/rclinit.cpp	2025-12-21 09:36:10.000000000 +0100
++++ b/recoll-1.43.14/common/rclinit.cpp	2026-04-06 01:30:19.184797537 +0200
+@@ -219,12 +219,12 @@
+ 
+     wc.lpfnWndProc = (WNDPROC)MainWndProc;
+     wc.hInstance = GetModuleHandle(NULL);
+-    wc.hIcon = LoadIcon(GetModuleHandle(NULL), L"TestWClass");
+-    wc.lpszClassName = L"TestWClass";
++    wc.hIcon = LoadIcon(GetModuleHandle(NULL), TEXT("TestWClass"));
++    wc.lpszClassName = TEXT("TestWClass");
+     RegisterClass(&wc);
+ 
+     hwnd =
+-        CreateWindowEx(0, L"TestWClass", L"TestWClass", WS_OVERLAPPEDWINDOW,
++        CreateWindowEx(0, TEXT("TestWClass"), TEXT("TestWClass"), WS_OVERLAPPEDWINDOW,
+                        CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
+                        CW_USEDEFAULT, (HWND) NULL, (HMENU) NULL,
+                        GetModuleHandle(NULL), (LPVOID) NULL);
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/common/rclutil.cpp b/recoll-1.43.14/common/rclutil.cpp
+--- a/recoll-1.43.14/common/rclutil.cpp	2026-02-19 11:19:00.000000000 +0100
++++ b/recoll-1.43.14/common/rclutil.cpp	2026-04-18 19:47:06.507668000 +0200
+@@ -34,7 +34,7 @@
+ #define WIN32_LEAN_AND_MEAN
+ #define NOGDI
+ #include <windows.h>
+-#include <Shlobj.h>
++#include <shlobj.h>
+ #include "safeunistd.h"
+ 
+ #else // !_WIN32 ->
+@@ -54,6 +54,7 @@
+ #include <unordered_map>
+ #include <vector>
+ #include <numeric>
++#include <list>
+ 
+ #include "cstr.h"
+ #include "damlev.h"
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/index/mimetype.cpp b/recoll-1.43.14/index/mimetype.cpp
+--- a/recoll-1.43.14/index/mimetype.cpp	2026-03-16 19:26:49.000000000 +0100
++++ b/recoll-1.43.14/index/mimetype.cpp	2026-04-18 19:47:30.603932428 +0200
+@@ -109,6 +109,8 @@
+     }
+ 
+ #else /* Not using libmagic, use command -> */
++    using std::string;
++    using std::vector;
+ 
+     // 'file' fallback if the configured command (default: xdg-mime) is not found
+     static const vector<string> tradfilecmd = {{FILE_PROG}, {"--mime-type"}};
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/meson.build b/recoll-1.43.14/meson.build
+--- a/recoll-1.43.14/meson.build	2026-03-16 18:46:15.000000000 +0100
++++ b/recoll-1.43.14/meson.build	2026-04-18 19:54:01.097211494 +0200
+@@ -294,7 +294,6 @@
+     'common/unacpp.cpp',
+     'common/webstore.cpp',
+     'index/webqueuefetcher.cpp',
+-    'index/checkretryfailed.cpp',
+     'index/exefetcher.cpp',
+     'index/fetcher.cpp',
+     'index/fsfetcher.cpp',
+@@ -360,7 +359,7 @@
+     'utils/copyfile.cpp',
+     'utils/cpuconf.cpp',
+     'utils/ecrontab.cpp',
+-    'utils/execmd.cpp',
++    # 'utils/execmd.cpp', -- added conditionally below (execmd_w.cpp on Windows)
+     'utils/fileudi.cpp',
+     'utils/fstreewalk.cpp',
+     'utils/idfile.cpp',
+@@ -370,7 +369,7 @@
+     'utils/md5ut.cpp',
+     'utils/mimeparse.cpp',
+     'utils/miniz.cpp',
+-    'utils/netcon.cpp',
++    # 'utils/netcon.cpp', -- added conditionally below (POSIX only)
+     'utils/pathut.cpp',
+     'utils/powerstatus.cpp',
+     'utils/pxattr.cpp',
+@@ -388,6 +387,19 @@
+ if host_machine.system() == 'darwin'
+     librecoll_sources += 'internfile/finderxattr.cpp'
+ endif
++if host_machine.system() == 'windows'
++    librecoll_sources += [
++        'windows/fnmatch.c',
++        'windows/wincodepages.cpp',
++        'windows/execmd_w.cpp',
++        'windows/getopt.cc',
++        'windows/strptime.cpp',
++    ]
++    librecolldeps += cc.find_library('shlwapi')
++    librecolldeps += cc.find_library('regex')
++else
++    librecoll_sources += ['utils/execmd.cpp', 'utils/netcon.cpp']
++endif
+ librecoll_incdir = include_directories(
+     'aspell',
+     'bincimapmime',
+@@ -399,6 +411,7 @@
+     'unac',
+     'utils',
+     'xaposix',
++    'windows',
+ )
+ 
+ if librecoll_needed
+@@ -443,6 +456,7 @@
+ 
+     recollindex_sources = [
+         'index/checkindexed.cpp',
++        'index/checkretryfailed.cpp',
+         'index/fsindexer.cpp',
+         'index/indexer.cpp',
+         'index/rclmonprc.cpp',
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/utils/log.cpp b/recoll-1.43.14/utils/log.cpp
+--- a/recoll-1.43.14/utils/log.cpp	2025-12-21 09:36:11.000000000 +0100
++++ b/recoll-1.43.14/utils/log.cpp	2026-04-18 19:50:14.066724910 +0200
+@@ -21,7 +21,7 @@
+ #include <fstream>
+ #include <time.h>
+ 
+-#ifdef _MSC_VER
++#ifdef _WIN32
+ #define localtime_r(A,B) localtime_s(B,A)
+ #endif
+ 
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/utils/miniz.cpp b/recoll-1.43.14/utils/miniz.cpp
+--- a/recoll-1.43.14/utils/miniz.cpp	2025-02-13 07:56:20.000000000 +0100
++++ b/recoll-1.43.14/utils/miniz.cpp	2026-04-18 20:24:39.264386831 +0200
+@@ -2957,13 +2957,10 @@
+ #ifndef MINIZ_NO_TIME
+ #include <sys/utime.h>
+ #endif
+-#if defined(__MINGW64__)
+-#define MZ_FOPENREAD mz_fopen
+-#define MZ_FOPEN mz_fopen
+-#else /*->msc*/
++/* MZ_FOPENREAD must accept wchar_t* on Windows (call site uses L"rb").
++ * mz_fopen is char-based, so always route MZ_FOPENREAD to _wfopen. */
+ #define MZ_FOPENREAD(f, m) _wfopen(f, m)
+ #define MZ_FOPEN(f, m) fopen(f, m)
+-#endif
+ #define MZ_FCLOSE fclose
+ #define MZ_FREAD fread
+ #define MZ_FWRITE fwrite
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/utils/pathut.cpp b/recoll-1.43.14/utils/pathut.cpp
+--- a/recoll-1.43.14/utils/pathut.cpp	2026-02-12 13:31:20.000000000 +0100
++++ b/recoll-1.43.14/utils/pathut.cpp	2026-04-18 21:21:52.441706899 +0200
+@@ -64,15 +64,14 @@
+ #include <vector>
+ #include <fcntl.h>
+ 
+-// Listing directories: we include the normal dirent.h on Unix-derived
+-// systems, and on MinGW, where it comes with a supplemental wide char
+-// interface. When building with MSVC, we use our bundled msvc_dirent.h,
+-// which is equivalent to the one in MinGW
+-#ifdef _MSC_VER
++// Listing directories: we use our bundled msvc_dirent.h on Windows
++// (both MSVC and MinGW), because newer mingw-w64/UCRT dirent.h no longer
++// exposes a WIN32_FIND_DATAW `data` member on _WDIR.
++#ifdef _WIN32
+ #include "msvc_dirent.h"
+-#else // !_MSC_VER
++#else
+ #include <dirent.h>
+-#endif // _MSC_VER
++#endif
+ 
+ 
+ #ifdef _WIN32
+@@ -82,7 +81,6 @@
+ #define WINVER 0x0601
+ #undef _WIN32_WINNT
+ #define _WIN32_WINNT 0x0601
+-#define LOGFONTW void
+ #endif
+ 
+ #ifndef NOMINMAX
+@@ -92,9 +90,9 @@
+ #define NOGDI
+ #include <windows.h>
+ #include <io.h>
+-#include <Shlobj.h>
+-#include <Shlwapi.h>
+-#include <Stringapiset.h>
++#include <shlobj.h>
++#include <shlwapi.h>
++#include <stringapiset.h>
+ 
+ #include <sys/utime.h>
+ #include <sys/stat.h>
+@@ -179,7 +177,7 @@
+ 
+ // Populate our close-to-POSIX PathStat struct from Windows FIND_DATA, as returned from
+ // e.g. Find(First/Next)FileW()
+-void MapWinFindDataToStat(const WIN32_FIND_DATA *fd, struct PathStat *pstp)
++void MapWinFindDataToStat(const WIN32_FIND_DATAW *fd, struct PathStat *pstp)
+ {
+     memset(pstp, 0, sizeof(struct PathStat));
+     pstp->pst_size = ((unsigned __int64)fd->nFileSizeHigh << 32) | fd->nFileSizeLow;
+@@ -897,7 +895,18 @@
+     // But maybe we are the recoll python extension, and execpath is the python exe which could be
+     // anywhere. We try the fixed fallback paths. If this fails, the user will have to set the
+     // environment variable.
++    // Try, in order:
++    //   <exedir>/share                               (legacy in-tree layout)
++    //   <exedir>/share/<progname>                    (FHS-style, recoll inside e.g. /ucrt64/share/recoll)
++    //   <exedir>/../share/<progname>                 (Unix/MSYS install layout, e.g. /ucrt64/bin -> /ucrt64/share/recoll)
++    //   compiled-in path if non-empty                (e.g. RECOLL_DATADIR set at build time)
++    //   user-supplied alts (Program Files fallbacks for python)
+     std::vector<std::string> paths{path_cat(path_thisexecdir(), "share")};
++    paths.push_back(path_cat(path_thisexecdir(), {"share", progname}));
++    paths.push_back(path_cat(path_getfather(path_thisexecdir()), {"share", progname}));
++    if (!compiled.empty()) {
++        paths.push_back(compiled);
++    }
+     paths.insert(paths.end(), alts.begin(), alts.end());
+     for (const auto& path : paths) {
+         if (path_exists(path_cat(path, tstpath))) {
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/utils/readfile.h b/recoll-1.43.14/utils/readfile.h
+--- a/recoll-1.43.14/utils/readfile.h	2025-12-21 09:36:11.000000000 +0100
++++ b/recoll-1.43.14/utils/readfile.h	2026-04-18 19:51:55.783839335 +0200
+@@ -21,6 +21,7 @@
+ // and sending the data for processing by a sink object.
+ #include <sys/types.h>
+ 
++#include <cstdint>
+ #include <string>
+ #include <memory>
+ 
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/windows/execmd_w.cpp b/recoll-1.43.14/windows/execmd_w.cpp
+--- a/recoll-1.43.14/windows/execmd_w.cpp	1970-01-01 01:00:00.000000000 +0100
++++ b/recoll-1.43.14/windows/execmd_w.cpp	2026-04-06 01:31:34.681153747 +0200
+@@ -0,0 +1,1295 @@
++/* Copyright (C) 2014 J.F.Dockes
++ * Based on ideas and code contributions from Christian Motz
++ *
++ *   This program is free software; you can redistribute it and/or modify
++ *   it under the terms of the GNU General Public License as published by
++ *   the Free Software Foundation; either version 2 of the License, or
++ *   (at your option) any later version.
++ *
++ *   This program is distributed in the hope that it will be useful,
++ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *   GNU General Public License for more details.
++ *
++ *   You should have received a copy of the GNU General Public License
++ *   along with this program; if not, write to the
++ *   Free Software Foundation, Inc.,
++ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
++ */
++#include "autoconfig.h"
++#define WIN32_LEAN_AND_MEAN
++#define NOGDI
++#include <windows.h>
++#include <process.h> // getpid(), debug
++
++#include "execmd.h"
++
++#include <string>
++#include <iostream>
++#include <sstream>
++#include <unordered_map>
++
++#include <psapi.h>
++
++#include "log.h"
++#include "smallut.h"
++#include "pathut.h"
++#include "closefrom.h"
++
++using namespace std;
++
++//////////////////////////////////////////////
++// Helper routines
++
++static void printError(const string& text)
++{
++    DWORD err = GetLastError();
++    LOGERR(text << " : err: " << err << "\n");
++}
++
++/**
++   Append the given argument to a command line such that
++   CommandLineToArgvW will return the argument string unchanged.
++   Arguments in a command line should be separated by spaces; this
++   function does not add these spaces. The caller must append spaces 
++   between calls.
++    
++   @param arg Supplies the argument to encode.
++   @param cmdLine Supplies the command line to which we append
++   the encoded argument string.
++   @param force Supplies an indication of whether we should quote
++   the argument even if it does not contain any characters that 
++   would ordinarily require quoting.
++*/
++static void argQuote(const string& arg, string& cmdLine, bool force = false)
++{
++    // Don't quote unless we actually need to do so
++    if (!force && !arg.empty() && 
++        arg.find_first_of(" \t\n\v\"") == arg.npos) {
++        cmdLine.append(arg);
++    } else {
++        cmdLine.push_back ('"');
++        
++        for (auto It = arg.begin () ; ; ++It) {
++            unsigned NumberBackslashes = 0;
++        
++            while (It != arg.end () && *It == '\\') {
++                ++It;
++                ++NumberBackslashes;
++            }
++        
++            if (It == arg.end()) {
++                // Escape all backslashes, but let the terminating
++                // double quotation mark we add below be interpreted
++                // as a metacharacter.
++                cmdLine.append (NumberBackslashes * 2, '\\');
++                break;
++            } else if (*It == L'"') {
++                // Escape all backslashes and the following
++                // double quotation mark.
++                cmdLine.append (NumberBackslashes * 2 + 1, '\\');
++                cmdLine.push_back (*It);
++            } else {
++                // Backslashes aren't special here.
++                cmdLine.append (NumberBackslashes, '\\');
++                cmdLine.push_back (*It);
++            }
++        }
++        cmdLine.push_back ('"');
++    }
++}
++
++static string argvToCmdLine(const string& cmd, const vector<string>& args)
++{
++    string cmdline;
++    argQuote(cmd, cmdline);
++    for (auto it = args.begin(); it != args.end(); it++) {
++        cmdline.append(" ");
++        argQuote(*it, cmdline);
++    }
++    return cmdline;
++}
++
++// Merge the father environment with the variable specified in m_env
++static wchar_t *mergeEnvironment(
++    const std::unordered_map<string, string>& addenv)
++{
++    // Retrieve existing environment.
++    wchar_t *wenvir = GetEnvironmentStringsW();
++
++    const wchar_t *cp0 = wenvir;
++    std::unordered_map<string, string> envirmap;
++    string name, value;
++    for (const wchar_t *cp1 = cp0;;cp1++) {
++        if (*cp1 == L'=') {
++            wchartoutf8(cp0, name, static_cast<int>(cp1 - cp0));
++            cp0 = cp1 + 1;
++        } else if (*cp1 == 0) {
++            wchartoutf8(cp0, value, static_cast<int>(cp1 - cp0));
++            envirmap[name] = value;
++            LOGDEB1("mergeEnvir: [" << name << "] = ["  << value << "]\n" );
++            cp0 = cp1 + 1;
++            if (*cp0 == 0)
++                break;
++        }
++    }
++    FreeEnvironmentStringsW(wenvir);
++
++    // Merge our values
++    for (auto it = addenv.begin(); it != addenv.end(); it++) {
++        envirmap[it->first] = it->second;
++    }
++
++    // Create environment block
++
++    // Size computation. We could do an exact computation by
++    // converting the strings, but do worst case instead. one utf-8
++    // byte can't convert to more than one wchar
++    int sz = 0;
++    for (auto it = envirmap.begin(); it != envirmap.end(); it++) {
++        // the +2 is for '=' and '\0'
++        sz += sizeof(wchar_t) * static_cast<int>((it->first.size() + it->second.size() + 2)); 
++    }
++    sz += sizeof(wchar_t); // final 0
++
++    wchar_t *nenvir = (wchar_t *)malloc(sz+2);
++    if (nullptr == nenvir)
++        return nenvir;
++    wchar_t *cp = nenvir;
++    for (const auto& entry : envirmap) {
++        utf8towchar(entry.first, cp, sz);
++        cp += wcslen(cp);
++        *cp++ = L'=';
++        utf8towchar(entry.second, cp, sz);
++        cp += wcslen(cp);
++        *cp++ = 0;
++    }
++    // Final double-zero
++    *cp++ = 0;
++    
++    return nenvir;
++}
++
++// There is no exec bit under Windows. We could check the file header but this is too complicated.
++// Just check that the file is a regular file and hope for the best.
++static bool is_exe(const string& path)
++{
++    return path_isfile(path);
++}
++
++// In mt programs the static vector computations below needs a call
++// from main before going mt. This is done by rclinit and saves having
++// to take a lock on every call
++
++// Try appending executable suffixes to the base name and see if we
++// have something
++static bool is_exe_base(const string& path)
++{
++    static vector<string> exts;
++    if (exts.empty()) {
++        const char *ep = getenv("PATHEXT");
++        if (!ep || !*ep) {
++            ep = ".com;.exe;.bat;.cmd";
++        }
++        string eps(ep);
++        trimstring(eps, ";");
++        stringToTokens(eps, exts, ";");
++    }
++
++    if (is_exe(path))
++        return true;
++    for (auto it = exts.begin(); it != exts.end(); it++) {
++        if (is_exe(path + *it))
++            return true;
++    }
++    return false;
++}
++
++// Parse a PATH spec into a vector<string>
++static void make_path_vec(const char *ep, vector<string>& vec)
++{
++    if (ep && *ep) {
++        string eps(ep);
++        trimstring(eps, ";");
++        stringToTokens(eps, vec, ";");
++    }
++}
++
++static std::string pipeUniqueName(std::string nClass, std::string prefix)
++{
++    std::stringstream uName;
++
++    long currCnt;
++    // PID + multi-thread-protected static counter to be unique
++    {
++        static long cnt = 0;
++        currCnt = InterlockedIncrement(&cnt);
++    }
++    DWORD pid = GetCurrentProcessId();
++
++    // naming convention
++    uName << "\\\\.\\" << nClass << "\\";
++    uName << "pid-" << pid << "-cnt-" << currCnt << "-";
++    uName << prefix;
++
++    return uName.str();
++}
++
++enum WaitResult {
++    Ok, Quit, Timeout
++};
++
++static WaitResult Wait(HANDLE hdl, int timeout) 
++{
++    //HANDLE hdls[2] = { hdl, eQuit };
++    HANDLE hdls[1] = { hdl};
++    LOGDEB1("Wait()\n" );
++    DWORD res = WaitForMultipleObjects(1, hdls, FALSE, timeout);
++    if (res == WAIT_OBJECT_0) {
++        LOGDEB1("Wait: returning Ok\n" );
++        return Ok;
++    } else if (res == (WAIT_OBJECT_0 + 1)) {
++        LOGDEB0("Wait: returning Quit\n" );
++        return Quit;
++    } else if (res == WAIT_TIMEOUT) {
++        LOGDEB0("Wait: returning Timeout (" << timeout << " ms)\n" );
++        return Timeout;
++    }
++    printError("Wait: WaitForMultipleObjects: unknown, returning Timout\n");
++    return Timeout;
++}
++
++static int getVMMBytes(HANDLE hProcess)
++{
++    PROCESS_MEMORY_COUNTERS pmc;
++    const int MB = 1024 * 1024;
++    if (GetProcessMemoryInfo(hProcess, &pmc, sizeof(pmc))) {
++        LOGDEB2("ExecCmd: getVMMBytes paged Kbs " <<
++                pmc.QuotaPagedPoolUsage/1024 << " non paged "  <<
++                pmc.QuotaNonPagedPoolUsage/1024 << " Kbs\n");
++        return int(pmc.QuotaPagedPoolUsage / MB +
++                   pmc.QuotaNonPagedPoolUsage / MB);
++    }
++    return -1;
++}
++
++////////////////////////////////////////////////////////
++// ExecCmd:
++
++class ExecCmd::Internal {
++public:
++    Internal(int flags)
++        : m_advise(0), m_provide(0), m_timeoutMs(1000), m_rlimit_as_mbytes(0),
++          m_flags(flags) {
++        reset();
++    }
++
++    std::unordered_map<string, string>   m_env;
++    ExecCmdAdvise   *m_advise;
++    ExecCmdProvide  *m_provide;
++    int              m_timeoutMs;
++    int m_rlimit_as_mbytes;
++    int m_flags;
++    
++    // We need buffered I/O for getline. The Unix version uses netcon's
++    string m_buf;       // Buffer. Only used when doing getline()s
++    size_t m_bufoffs;    // Pointer to current 1st byte of useful data
++    bool             m_killRequest;
++    string           m_stderrFile;
++    HANDLE           m_hOutputRead;
++    HANDLE           m_hInputWrite;
++    OVERLAPPED       m_oOutputRead;
++    OVERLAPPED       m_oInputWrite;
++    PROCESS_INFORMATION m_piProcInfo;
++
++    
++    // Reset internal state indicators. Any resources should have been
++    // previously freed. 
++    void reset() {
++        m_buf.resize(0);
++        m_bufoffs = 0;
++        m_stderrFile.erase();
++        m_killRequest = false;
++        m_hOutputRead = NULL;
++        m_hInputWrite = NULL;
++        memset(&m_oOutputRead, 0, sizeof(m_oOutputRead));
++        memset(&m_oInputWrite, 0, sizeof(m_oInputWrite));
++        ZeroMemory(&m_piProcInfo, sizeof(PROCESS_INFORMATION));
++    }
++    bool preparePipes(bool has_input, HANDLE *hChildInput,
++                      bool has_output, HANDLE *hChildOutput,
++                      HANDLE *hChildError);
++    bool tooBig();
++};
++
++// Sending a break to a subprocess is only possible if we share the
++// same console We temporarily ignore breaks, attach to the Console,
++// send the break, and restore normal break processing
++static bool sendIntr(int pid)
++{
++    LOGDEB("execmd_w: sendIntr -> "  << (pid) << "\n" );
++    bool needDetach = false;
++    if (GetConsoleWindow() == NULL) {
++        needDetach = true;
++        LOGDEB("execmd_w: sendIntr attaching console\n" );
++        if (!AttachConsole((unsigned int) pid)) {
++            int err = GetLastError();
++            LOGERR("execmd_w: sendIntr: AttachConsole failed: " << err << "\n");
++            return false;
++        }
++    }
++
++#if 0
++    // Would need to do this for sending to all processes on this console
++    // Disable Ctrl-C handling for our program
++    if (!SetConsoleCtrlHandler(NULL, true)) {
++        int err = GetLastError();
++        LOGERR("execmd_w:sendIntr:SetCons.Ctl.Hndlr.(NULL, true) failed: " <<
++               err << "\n");
++        return false;
++    }
++#endif
++
++    // Note: things don't work with CTRL_C (process not advised, sometimes
++    // stays apparently blocked), no idea why
++    bool ret = GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid);
++    if (!ret) {
++        int err = GetLastError();
++        LOGERR("execmd_w:sendIntr:Gen.Cons.CtrlEvent failed: " << err << "\n");
++    }
++
++#if 0
++    // Restore Ctrl-C handling for our program
++    SetConsoleCtrlHandler(NULL, false);
++#endif
++
++    if (needDetach) {
++        LOGDEB("execmd_w: sendIntr detaching console\n" );
++        if (!FreeConsole()) {
++            int err = GetLastError();
++            LOGERR("execmd_w: sendIntr: FreeConsole failed: " << err << "\n");
++        }
++    }
++
++    return ret;
++}
++
++// ExecCmd resource releaser class. Using a separate object makes it
++// easier that resources are released under all circumstances,
++// esp. exceptions
++class ExecCmdRsrc {
++public:
++    ExecCmdRsrc(ExecCmd::Internal *parent) 
++        : m_parent(parent), m_active(true) {
++    }
++    void inactivate() {
++        m_active = false;
++    }
++    ~ExecCmdRsrc() {
++        if (!m_active || !m_parent)
++            return;
++        LOGDEB1("~ExecCmdRsrc: working. mypid: " << ((int)getpid()) << "\n" );
++        if (m_parent->m_hOutputRead)
++            CloseHandle(m_parent->m_hOutputRead);
++        if (m_parent->m_hInputWrite)
++            CloseHandle(m_parent->m_hInputWrite);
++        if (m_parent->m_oOutputRead.hEvent)
++            CloseHandle(m_parent->m_oOutputRead.hEvent);
++        if (m_parent->m_oInputWrite.hEvent)
++            CloseHandle(m_parent->m_oInputWrite.hEvent);
++
++        if (m_parent->m_piProcInfo.hProcess) {
++            BOOL bSuccess = sendIntr(m_parent->m_piProcInfo.dwProcessId);
++            if (bSuccess) {
++                // Give it a chance, then terminate
++                for (int i = 0; i < 3; i++) {
++                    WaitResult res = Wait(m_parent->m_piProcInfo.hProcess,
++                                          i == 0 ? 5 : (i == 1 ? 100 : 2000));
++                    switch (res) {
++                    case Ok:
++                    case Quit:
++                        goto breakloop;
++                    case Timeout:
++                        if (i == 2) {
++                            TerminateProcess(m_parent->m_piProcInfo.hProcess,
++                                             0xffff);
++                        }
++                    }
++                }
++            } else {
++                TerminateProcess(m_parent->m_piProcInfo.hProcess,
++                                 0xffff);
++            }
++        breakloop:
++            CloseHandle(m_parent->m_piProcInfo.hProcess);
++        }
++        if (m_parent->m_piProcInfo.hThread)
++            CloseHandle(m_parent->m_piProcInfo.hThread);
++        m_parent->reset();
++    }
++private:
++    ExecCmd::Internal *m_parent;
++    bool    m_active;
++};
++
++ExecCmd::ExecCmd(int flags)
++{
++    m = new Internal(flags);
++    if (m) {
++        m->reset();
++    }
++}
++
++ExecCmd::~ExecCmd()
++{
++    if (m) {
++        ExecCmdRsrc(this->m);
++        delete m;
++    }
++}
++
++// This does nothing under windows, but defining it avoids ifdefs in multiple
++// places
++void ExecCmd::useVfork(bool)
++{
++}
++
++bool ExecCmd::which(const string& cmd, string& exe, const char* path)
++{
++    static vector<string> s_pathelts;
++    vector<string> pathelts;
++    vector<string> *pep;
++
++    if (path) {
++        make_path_vec(path, pathelts);
++        pep = &pathelts;
++    } else {
++        if (s_pathelts.empty()) {
++            const char *ep = getenv("PATH");
++            make_path_vec(ep, s_pathelts);
++        }
++        pep = &s_pathelts;
++    }
++
++    if (cmd.empty()) {
++        // Used for the static init of s_pathelts
++        return false;
++    }
++    
++    if (path_isabsolute(cmd)) {
++        if (is_exe_base(cmd)) {
++            exe = cmd;
++            return true;
++        }
++        exe.clear();
++        return false;
++    }
++
++    for (auto it = pep->begin(); it != pep->end(); it++) {
++        exe = path_cat(*it, cmd);
++        if (is_exe_base(exe)) {
++            return true;
++        }
++    }
++    exe.clear();
++    return false;
++}
++
++void ExecCmd::setAdvise(ExecCmdAdvise *adv)
++{
++    m->m_advise = adv;
++}
++void ExecCmd::setProvide(ExecCmdProvide *p)
++{
++    m->m_provide = p;
++}
++void ExecCmd::setTimeout(int mS)
++{
++    if (mS > 30) {
++        m->m_timeoutMs = mS;
++    }
++}
++void ExecCmd::setStderr(const std::string& stderrFile)
++{
++    m->m_stderrFile = stderrFile;
++}
++
++pid_t ExecCmd::getChildPid()
++{
++    return m->m_piProcInfo.dwProcessId;
++}
++
++void ExecCmd::setKill()
++{
++    m->m_killRequest = true;
++}
++void ExecCmd::zapChild()
++{
++    setKill();
++    (void)wait();
++}
++
++bool ExecCmd::requestChildExit()
++{
++    if (m->m_piProcInfo.hProcess) {
++        return sendIntr(m->m_piProcInfo.dwProcessId);
++    }
++    return false;
++}
++
++void ExecCmd::putenv(const string &envassign)
++{
++    vector<string> v;
++    stringToTokens(envassign, v, "=");
++    if (v.size() == 2) {
++        m->m_env[v[0]] = v[1];
++    }
++}
++void ExecCmd::putenv(const string &name, const string& value)
++{
++    m->m_env[name] = value;
++}
++
++void ExecCmd::setrlimit_as(int mbytes)
++{
++    m->m_rlimit_as_mbytes = mbytes;
++}
++
++bool ExecCmd::Internal::tooBig()
++{
++    if (m_rlimit_as_mbytes <= 0)
++        return false;
++    int mbytes = getVMMBytes(m_piProcInfo.hProcess);
++    if (mbytes > m_rlimit_as_mbytes) {
++        LOGINFO("ExecCmd:: process mbytes " << mbytes << " > set limit " <<
++                m_rlimit_as_mbytes << "\n");
++        m_killRequest = true;
++        return true;
++    }
++    return false;
++}
++
++bool ExecCmd::Internal::preparePipes(bool has_input,HANDLE *hChildInput, 
++                                     bool has_output, HANDLE *hChildOutput, 
++                                     HANDLE *hChildError)
++{
++    // Note: our caller is responsible for ensuring that we start with
++    // a clean state, and for freeing class resources in case of
++    // error. We just manage the local ones.
++    HANDLE hOutputWrite = NULL;
++    HANDLE hErrorWrite = NULL;
++    HANDLE hInputRead = NULL;
++
++    // manual reset event
++    m_oOutputRead.hEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
++    if (m_oOutputRead.hEvent == INVALID_HANDLE_VALUE) {
++        LOGERR("ExecCmd::preparePipes: CreateEvent failed\n" );
++        goto errout;
++    }
++
++    // manual reset event
++    m_oInputWrite.hEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
++    if (m_oInputWrite.hEvent == INVALID_HANDLE_VALUE) {
++        LOGERR("ExecCmd::preparePipes: CreateEvent failed\n" );
++        goto errout;
++    }
++
++    SECURITY_ATTRIBUTES sa;
++    // Set up the security attributes struct.
++    sa.nLength = sizeof(SECURITY_ATTRIBUTES);
++    sa.bInheritHandle = TRUE; // this is the critical bit
++    sa.lpSecurityDescriptor = NULL;
++
++    if (has_output) {
++        // src for this code: https://www.daniweb.com/software-development/cpp/threads/295780/using-named-pipes-with-asynchronous-io-redirection-to-winapi
++        // ONLY IMPORTANT CHANGE
++        // set inheritance flag to TRUE in CreateProcess
++        // you need this for the client to inherit the handles
++       
++        // Create the child output named pipe.
++        // This creates a non-inheritable, one-way handle for the server to read
++        string pipeName = pipeUniqueName("pipe", "output");
++        sa.bInheritHandle = FALSE; 
++        m_hOutputRead = CreateNamedPipeA(
++            pipeName.c_str(),
++            PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED,
++            PIPE_WAIT,
++            1, 4096, 4096, 0, &sa);
++        if (m_hOutputRead == INVALID_HANDLE_VALUE) {
++            printError("preparePipes: CreateNamedPipe(outputR)");
++            goto errout;
++        }
++
++        // However, the client can not use an inbound server handle.
++        // Client needs a write-only, outgoing handle.
++        // So, you create another handle to the same named pipe, only
++        // write-only.  Again, must be created with the inheritable
++        // attribute, and the options are important.
++        // use CreateFile to open a new handle to the existing pipe...
++        sa.bInheritHandle = TRUE; 
++        hOutputWrite = CreateFileA(
++            pipeName.c_str(),
++            FILE_WRITE_DATA | SYNCHRONIZE,
++            0, &sa, OPEN_EXISTING, // very important flag!
++            FILE_ATTRIBUTE_NORMAL, 0 // no template file for OPEN_EXISTING
++            );
++        if (hOutputWrite == INVALID_HANDLE_VALUE) {
++            printError("preparePipes: CreateFile(outputWrite)");
++            goto errout;
++        }
++    } else {
++        // Not using child output. Let the child have our standard output.
++        HANDLE hstd = GetStdHandle(STD_OUTPUT_HANDLE);
++        if (hstd == INVALID_HANDLE_VALUE) {
++            printError("preparePipes: GetStdHandle(stdout)");
++            goto errout;
++        }
++        if (!DuplicateHandle(GetCurrentProcess(), hstd,
++                             GetCurrentProcess(), &hOutputWrite,
++                             0, TRUE, 
++                             DUPLICATE_SAME_ACCESS)) {
++            printError("preparePipes: DuplicateHandle(stdout)");
++            // This occurs when the parent process is a GUI app. Ignoring the error works, but
++            // not too sure this is the right approach. Maybe look a bit more at:
++            // https://support.microsoft.com/en-us/kb/190351
++            //goto errout;
++        }
++    }
++
++    if (has_input) {
++        // now same procedure for input pipe
++
++        sa.bInheritHandle = FALSE; 
++        string pipeName = pipeUniqueName("pipe", "input");
++        m_hInputWrite = CreateNamedPipeA(
++            pipeName.c_str(),
++            PIPE_ACCESS_OUTBOUND | FILE_FLAG_OVERLAPPED,
++            PIPE_WAIT,
++            1, 4096, 4096, 0, &sa);
++        if (m_hInputWrite == INVALID_HANDLE_VALUE) {
++            printError("preparePipes: CreateNamedPipe(inputW)");
++            goto errout;
++        }
++
++        sa.bInheritHandle = TRUE;
++        hInputRead = CreateFileA(
++            pipeName.c_str(),
++            FILE_READ_DATA | SYNCHRONIZE,
++            0, &sa, OPEN_EXISTING, // very important flag!
++            FILE_ATTRIBUTE_NORMAL, 0 // no template file for OPEN_EXISTING
++            );
++        if (hInputRead == INVALID_HANDLE_VALUE) {
++            printError("preparePipes: CreateFile(inputRead)");
++            goto errout;
++        }
++    } else {
++        // Let the child inherit our standard input
++        HANDLE hstd = GetStdHandle(STD_INPUT_HANDLE);
++        if (hstd == INVALID_HANDLE_VALUE) {
++            printError("preparePipes: GetStdHandle(stdin)");
++            goto errout;
++        }
++        if (!DuplicateHandle(GetCurrentProcess(), hstd,
++                             GetCurrentProcess(), &hInputRead,
++                             0, TRUE,
++                             DUPLICATE_SAME_ACCESS)) {
++            printError("preparePipes: DuplicateHandle(stdin)");
++            //goto errout;
++        }
++    }
++
++    // Stderr: output to file or inherit. We don't support the file thing
++    // for the moment
++    if (false && !m_stderrFile.empty()) {
++        // Open the file set up the child handle: TBD
++        printError("preparePipes: m_stderrFile not empty");
++    } else {
++        // Let the child inherit our standard input
++        HANDLE hstd = GetStdHandle(STD_ERROR_HANDLE);
++        if (hstd == INVALID_HANDLE_VALUE) {
++            printError("preparePipes: GetStdHandle(stderr)");
++            goto errout;
++        }
++        if (!DuplicateHandle(GetCurrentProcess(), hstd,
++                             GetCurrentProcess(), &hErrorWrite,
++                             0, TRUE,
++                             DUPLICATE_SAME_ACCESS)) {
++            printError("preparePipes: DuplicateHandle(stderr)");
++            //goto errout;
++        }
++    }
++
++    *hChildInput = hInputRead;
++    *hChildOutput = hOutputWrite;
++    *hChildError = hErrorWrite;
++    return true;
++
++errout:
++    if (hOutputWrite)
++        CloseHandle(hOutputWrite);
++    if (hInputRead)
++        CloseHandle(hInputRead);
++    if (hErrorWrite)
++        CloseHandle(hErrorWrite);
++    return false;
++}
++
++// Create a child process 
++int ExecCmd::startExec(const string &cmd, const vector<string>& args,
++                       bool has_input, bool has_output)
++{
++    { // Debug and logging
++        string command = cmd + " ";
++        for (vector<string>::const_iterator it = args.begin();
++             it != args.end(); it++) {
++            command += "{" + *it + "} ";
++        }
++        LOGDEB("ExecCmd::startExec: (" << has_input << "|" << has_output <<
++               ") " << command << "\n");
++    }
++
++    // What if we're called twice ? First make sure we're clean
++    {
++        ExecCmdRsrc(this->m);
++    }
++
++    // Arm clean up. This will be disabled before a success return.
++    ExecCmdRsrc cleaner(this->m);
++    
++    string cmdline = argvToCmdLine(cmd, args);
++
++    HANDLE hInputRead;
++    HANDLE hOutputWrite;
++    HANDLE hErrorWrite;
++    if (!m->preparePipes(has_input, &hInputRead, has_output, 
++                         &hOutputWrite, &hErrorWrite)) {
++        LOGERR("ExecCmd::startExec: preparePipes failed\n");
++        return -1;
++    }
++
++    STARTUPINFOW siStartInfo;
++    BOOL bSuccess = FALSE;
++
++    // Set up members of the PROCESS_INFORMATION structure. 
++    ZeroMemory(&m->m_piProcInfo, sizeof(PROCESS_INFORMATION));
++
++    // Set up members of the STARTUPINFO structure. 
++    // This structure specifies the STDIN and STDOUT handles for redirection.
++    ZeroMemory(&siStartInfo, sizeof(siStartInfo));
++    siStartInfo.cb = sizeof(siStartInfo);
++    if (m->m_flags & EXF_SHOWWINDOW) {
++        siStartInfo.dwFlags |= STARTF_USESTDHANDLES;
++        if (m->m_flags & EXF_MAXIMIZED) {
++            siStartInfo.dwFlags |= STARTF_USESHOWWINDOW;
++            siStartInfo.wShowWindow = SW_SHOWMAXIMIZED;
++        }
++    } else {
++        siStartInfo.dwFlags |= STARTF_USESTDHANDLES | STARTF_USESHOWWINDOW;
++        // This is to hide the console when starting a cmd line command from
++        // the GUI. Also note STARTF_USESHOWWINDOW above
++        siStartInfo.wShowWindow = SW_HIDE;
++    }
++    siStartInfo.hStdOutput = hOutputWrite;
++    siStartInfo.hStdInput = hInputRead;
++    siStartInfo.hStdError = hErrorWrite;
++
++    wchar_t *envir = mergeEnvironment(m->m_env);
++    int flags = CREATE_NEW_PROCESS_GROUP | CREATE_UNICODE_ENVIRONMENT;
++    // Create the child process. 
++    LOGDEB("ExecCmd:startExec: cmdline [" << cmdline << "]\n");
++    auto wcmdline = utf8towchar(cmdline);
++    bSuccess = CreateProcessW(NULL,         // app name
++                              wcmdline.get(),     // command line
++                              NULL,         // process security attributes
++                              NULL,         // primary thread security attrs
++                              TRUE,         // handles are inherited
++                              flags,        // creation flags
++                              envir,        // Merged environment
++                              NULL,         // use parent's current directory
++                              &siStartInfo, // STARTUPINFO pointer
++                              &m->m_piProcInfo); // PROCESS_INFORMATION
++    if (!bSuccess) {
++        printError("ExecCmd::doexec: CreateProcess");
++    }
++    
++    free(envir);
++    // Close child-side handles else we'll never see eofs
++    if (!CloseHandle(hOutputWrite))
++        printError("CloseHandle");
++    if (!CloseHandle(hInputRead))
++        printError("CloseHandle");
++    if (!CloseHandle(hErrorWrite)) 
++        printError("CloseHandle");
++
++    if (bSuccess) {
++        cleaner.inactivate();
++    }
++    return bSuccess ? 0 : -1;
++}
++
++// Send data to the child.
++int ExecCmd::send(const string& data)
++{
++    LOGDEB2("ExecCmd::send: cnt " << data.size() << "\n");
++    BOOL bSuccess = WriteFile(m->m_hInputWrite, data.c_str(),
++                              (DWORD)data.size(), NULL, &m->m_oInputWrite);
++    DWORD err = GetLastError();
++
++    // TODO: some more decision, either the operation completes immediately
++    // and we get success, or it is started (which is indicated by no success)
++    // and ERROR_IO_PENDING
++    // in the first case bytes read/written parameter can be used directly
++    if (!bSuccess && err != ERROR_IO_PENDING) {
++        LOGERR("ExecCmd::send: WriteFile: got err " << err << "\n");
++        return -1;
++    }
++
++    WaitResult waitRes = Wait(m->m_oInputWrite.hEvent, m->m_timeoutMs);
++    DWORD dwWritten;
++    if (waitRes == Ok) {
++        if (!GetOverlappedResult(m->m_hInputWrite, 
++                                 &m->m_oInputWrite, &dwWritten, TRUE)) {
++            err = GetLastError();
++            LOGERR("ExecCmd::send: GetOverLappedResult: err " << err << "\n");
++            return -1;
++        }
++    } else if (waitRes == Quit) {
++        printError("ExecCmd::send: got Quit");
++        if (!CancelIo(m->m_hInputWrite)) {
++            printError("CancelIo");
++        }
++        return -1;
++    } else if (waitRes == Timeout) {
++        printError("ExecCmd::send: got Timeout");
++        if (!CancelIo(m->m_hInputWrite)) {
++            printError("CancelIo");
++        }
++        return -1;
++    }
++    LOGDEB2("ExecCmd::send: returning " << (int(dwWritten)) << "\n");
++    return dwWritten;
++}
++
++#ifndef MIN
++#define MIN(A,B) ((A)<(B)?(A):(B))
++#endif
++
++// Read output from the child process's pipe for STDOUT
++// and write to cout in this programme
++// Stop when there is no more data. 
++// @arg cnt count to read, -1 means read to end of data.
++//      0 means read whatever comes back on the first read;
++int ExecCmd::receive(string& data, int cnt)
++{
++    LOGDEB1("ExecCmd::receive: cnt " << cnt << "\n");
++
++    int totread = 0;
++
++    // If there is buffered data, use it (remains from a previous getline())
++    if (m->m_bufoffs < m->m_buf.size()) {
++        int bufcnt = int(m->m_buf.size() - m->m_bufoffs);
++        int toread = (cnt > 0) ? MIN(cnt, bufcnt) : bufcnt;
++        data.append(m->m_buf, m->m_bufoffs, toread);
++        m->m_bufoffs += toread;
++        totread += toread;
++        if (cnt == 0 || (cnt > 0 && totread == cnt)) {
++            return cnt;
++        }
++    }
++    while (true) {
++        const int BUFSIZE = 4096;
++        CHAR chBuf[BUFSIZE];
++        int toread = cnt > 0 ? MIN(cnt - totread, BUFSIZE) : BUFSIZE;
++        BOOL bSuccess = ReadFile(m->m_hOutputRead, chBuf, toread,
++                                 NULL, &m->m_oOutputRead);
++        DWORD err = GetLastError();
++        LOGDEB1("receive: ReadFile: success " <<bSuccess<<" err "<< err << "\n");
++        if (!bSuccess && err != ERROR_IO_PENDING) {
++            if (err != ERROR_BROKEN_PIPE)
++                LOGERR("ExecCmd::receive: ReadFile error: " << err << "\n");
++            break;
++        }
++
++    waitagain:
++        WaitResult waitRes = Wait(m->m_oOutputRead.hEvent, m->m_timeoutMs);
++        if (waitRes == Ok) {
++            DWORD dwRead;
++            if (!GetOverlappedResult(m->m_hOutputRead, &m->m_oOutputRead,
++                                     &dwRead, TRUE)) {
++                err = GetLastError();
++                if (err && err != ERROR_BROKEN_PIPE) {
++                    LOGERR("ExecCmd::recv:GetOverlappedResult: err " << err <<
++                           "\n");
++                    return -1;
++                }
++            }
++            if (dwRead > 0) {
++                totread += dwRead;
++                data.append(chBuf, dwRead);
++                if (m->m_advise)
++                    m->m_advise->newData(dwRead);
++                LOGDEB1("ExecCmd::recv: ReadFile: " << dwRead << " bytes\n");
++            }
++        } else if (waitRes == Quit) {
++            if (!CancelIo(m->m_hOutputRead)) {
++                printError("CancelIo");
++            }
++            break;
++        } else if (waitRes == Timeout) {
++            LOGDEB0("ExecCmd::receive: timeout (" << m->m_timeoutMs << " mS)\n");
++            if (m->tooBig()) {
++                if (!CancelIo(m->m_hOutputRead)) {
++                    printError("CancelIo");
++                }
++                return -1;
++            }
++            // We only want to cancel if m_advise says so here.
++            if (m->m_advise) {
++                try {
++                    m->m_advise->newData(0);
++                } catch (...) {
++                    if (!CancelIo(m->m_hOutputRead)) {
++                        printError("CancelIo");
++                    }
++                    throw;
++                }
++            }
++            if (m->m_killRequest) {
++                LOGINFO("ExecCmd::doexec: cancel request\n");
++                if (!CancelIo(m->m_hOutputRead)) {
++                    printError("CancelIo");
++                }
++                break;
++            }
++            goto waitagain;
++        }
++        if ((cnt == 0 && totread > 0) || (cnt > 0 && totread == cnt))
++            break;
++    }
++    LOGDEB1("ExecCmd::receive: returning " << totread << " bytes\n");
++    return totread;
++}
++
++int ExecCmd::getline(string& data)
++{
++    data.erase();
++    if (m->m_buf.empty()) {
++        m->m_buf.reserve(4096);
++        m->m_bufoffs = 0;
++    }
++
++    for (;;) {
++        // Transfer from buffer. Have to take a lot of care to keep counts and
++        // pointers consistant in all end cases
++        int nn = int(m->m_buf.size() - m->m_bufoffs);
++        bool foundnl = false;
++        for (; nn > 0;) {
++            nn--;
++            char c = m->m_buf[m->m_bufoffs++];
++            if (c == '\r')
++                continue;
++            data += c;
++            if (c == '\n') {
++                foundnl = true;
++                break;
++            }
++        }
++
++        if (foundnl) {
++            LOGDEB2("ExecCmd::getline: ret: [" << data << "]\n");
++            return int(data.size());
++        }
++
++        // Read more
++        m->m_buf.erase();
++        if (receive(m->m_buf, 0) < 0) {
++            return -1;
++        }
++        if (m->m_buf.empty()) {
++            LOGDEB("ExecCmd::getline: eof? ret: [" << data << "]\n");
++            return int(data.size());
++        }
++        m->m_bufoffs = 0;
++    }
++    //??
++    return -1;
++}
++
++class GetlineWatchdog : public ExecCmdAdvise {
++public:
++    GetlineWatchdog(int secs) : m_secs(secs), tstart(time(0)) {}
++    void newData(int) {
++        if (time(0) - tstart >= m_secs) {
++            throw std::runtime_error("getline timeout");
++        }
++    }
++    int m_secs;
++    time_t tstart;
++};
++
++int ExecCmd::getline(string& data, int timeosecs)
++{
++    GetlineWatchdog gwd(timeosecs);
++    setAdvise(&gwd);
++    try {
++        return getline(data);
++    } catch (...) {
++        return -1;
++    }
++}
++
++int ExecCmd::wait() 
++{
++    // If killRequest was set, we don't perform the normal
++    // wait. cleaner will kill the child.
++    ExecCmdRsrc cleaner(this->m);
++    
++    DWORD exit_code = -1;
++    if (!m->m_killRequest && m->m_piProcInfo.hProcess) {
++        // Wait until child process exits.
++        while (WaitForSingleObject(m->m_piProcInfo.hProcess, m->m_timeoutMs)
++               == WAIT_TIMEOUT) {
++            LOGDEB("ExecCmd::wait: timeout (ok)\n");
++            if (m->m_advise) {
++                m->m_advise->newData(0);
++            }
++            if (m->tooBig()) {
++                // Let cleaner work to kill the child
++                m->m_killRequest = true;
++                return -1;
++            }
++        }
++
++        exit_code = 0;
++        GetExitCodeProcess(m->m_piProcInfo.hProcess, &exit_code);
++        // Clean up, here to avoid cleaner trying to kill the now
++        // inexistant process.
++        CloseHandle(m->m_piProcInfo.hProcess);
++        m->m_piProcInfo.hProcess = NULL;
++        if (m->m_piProcInfo.hThread) {
++            CloseHandle(m->m_piProcInfo.hThread);
++            m->m_piProcInfo.hThread = NULL;
++        }
++    }
++    return (int)exit_code;
++}
++
++bool ExecCmd::maybereap(int *status)
++{
++    ExecCmdRsrc e(this->m);
++    *status = -1;
++
++    if (m->m_piProcInfo.hProcess == NULL) {
++        // Already waited for ??
++        LOGERR("MAYBEREAP: ALREADY DONE\n");
++        return true;
++    }
++
++    DWORD exit_code = -1;
++    // Returns non-zero for success
++    auto ret = GetExitCodeProcess(m->m_piProcInfo.hProcess, &exit_code);
++
++    if (ret == 0 || (ret && exit_code == STILL_ACTIVE)) {
++        if (ret == 0) {
++            LOGDEB1("ExecCmd::maybereap GetExitCodeProcess failed: err: " << GetLastError() << "\n");
++        } else {
++            LOGDEB1("ExecCmd::maybereap: GetExitCodeProcess returned STILL_ACTIVE\n");
++        }
++        // Process still here
++        e.inactivate();
++        return false;
++    }
++    LOGDEB0("ExecCmd::maybereap: process exited. status: " << exit_code << "\n");
++    *status = (int)exit_code;
++    CloseHandle(m->m_piProcInfo.hProcess);
++    m->m_piProcInfo.hProcess = NULL;
++    if (m->m_piProcInfo.hThread) {
++        CloseHandle(m->m_piProcInfo.hThread);
++        m->m_piProcInfo.hThread = NULL;
++    }
++    return true;
++}
++
++int ExecCmd::doexec(const string &cmd, const vector<string>& args,
++                    const string *input, string *output)
++{
++    if (input && output) {
++        LOGERR("ExecCmd::doexec: can't do both input and output\n");
++        return -1;
++    }
++
++    // The assumption is that the state is clean when this method
++    // returns.  Have a cleaner ready in case we return without
++    // calling wait() e.g. if an exception is raised in receive()
++    ExecCmdRsrc cleaner(this->m);
++
++    if (startExec(cmd, args, input != 0, output != 0) < 0) {
++        return -1;
++    }
++    
++    if (input) {
++        if (!input->empty()) {
++            if (send(*input) != (int)input->size()) {
++                LOGERR("ExecCmd::doexec: send failed\n");
++                CloseHandle(m->m_hInputWrite);
++                m->m_hInputWrite = NULL;
++                return -1;
++            }
++        }
++        if (m->m_provide) {
++            for (;;) {
++                m->m_provide->newData();
++                if (input->empty()) {
++                    CloseHandle(m->m_hInputWrite);
++                    m->m_hInputWrite = NULL;
++                    break;
++                }
++                if (send(*input) != (int)input->size()) {
++                    LOGERR("ExecCmd::doexec: send failed\n");
++                    CloseHandle(m->m_hInputWrite);
++                    m->m_hInputWrite = NULL;
++                    break;
++                }
++            }
++        }
++    } else if (output) {
++        receive(*output);
++    }
++    cleaner.inactivate();
++    return wait();
++}
++
++// Static
++bool ExecCmd::backtick(const vector<string> cmd, string& out)
++{
++    vector<string>::const_iterator it = cmd.begin();
++    it++;
++    vector<string> args(it, cmd.end());
++    ExecCmd mexec;
++    int status = mexec.doexec(*cmd.begin(), args, 0, &out);
++    return status == 0;
++}
++
++// Static. Unimplemented on windows for now
++std::string ExecCmd::waitStatusAsString(int wstatus)
++{
++    std::ostringstream oss;
++    oss << std::hex << "0x" << wstatus << std::dec;
++    return oss.str();
++}
++
++bool ExecCmd::status_exited(int status)
++{
++    return status != -1;
++}
++
++int ExecCmd::status_exitstatus(int status)
++{
++    return status;
++}
++
++
++///////////// ReExec class methods. 
++ReExec::ReExec(int argc, char *args[])
++{
++    for (int i = 0; i < argc; i++) {
++        m_argv.push_back(args[i]);
++    }
++}
++
++ReExec::ReExec(const std::vector<std::string>& args)
++    : m_argv(args)
++{
++}
++
++void ReExec::insertArgs(const vector<string>& args, int idx)
++{
++    LOGDEB2("ReExec::insertArgs: args before [" << stringsToString(m_argv) << "]\n");
++    vector<string>::iterator it;
++    size_t cmpoffset = (unsigned int) - 1;
++
++    if (idx == -1 || string::size_type(idx) >= m_argv.size()) {
++        it = m_argv.end();
++        if (m_argv.size() >= args.size()) {
++            cmpoffset = m_argv.size() - args.size();
++        }
++    } else {
++        it = m_argv.begin() + idx;
++        if (idx + args.size() <= m_argv.size()) {
++            cmpoffset = idx;
++        }
++    }
++
++    // Check that the option is not already there
++    if (cmpoffset != (unsigned int) - 1) {
++        bool allsame = true;
++        for (unsigned int i = 0; i < args.size(); i++) {
++            if (m_argv[cmpoffset + i] != args[i]) {
++                allsame = false;
++                break;
++            }
++        }
++        if (allsame) {
++            return;
++        }
++    }
++
++    m_argv.insert(it, args.begin(), args.end());
++    LOGDEB2("ReExec::insertArgs: args after [" << stringsToString(m_argv) << "]\n");
++}
++
++void ReExec::removeArg(const string& arg)
++{
++    LOGDEB2("ReExec::removeArg: args before [" << stringsToString(m_argv) << "]\n");
++    for (vector<string>::iterator it = m_argv.begin(); it != m_argv.end(); it++) {
++        if (*it == arg) {
++            it = m_argv.erase(it);
++        }
++    }
++    LOGDEB2("ReExec::removeArg: args after [" << stringsToString(m_argv) << "]\n");
++}
++
++void ReExec::reexec()
++{
++    LOGDEB("ReExec::reexec: args [" << stringsToString(m_argv) << "]\n");
++    // Execute the atexit funcs
++    while (!m_atexitfuncs.empty()) {
++        (m_atexitfuncs.top())();
++        m_atexitfuncs.pop();
++    }
++
++    // Allocate arg vector (1 more for final 0)
++    typedef const wchar_t *Ccharp;
++    Ccharp *argv;
++    argv = (Ccharp *)malloc((m_argv.size() + 1) * sizeof(wchar_t *));
++    if (argv == 0) {
++        LOGERR("ExecCmd::doexec: malloc() failed. errno " << errno << "\n");
++        return;
++    }
++
++    // Fill up argv. Can you believe that we need to quote the args !!
++    // Esp. argv[0] if it's c:\program files\...
++    std::vector<std::unique_ptr<wchar_t[]>> ptrs;
++    std::unique_ptr<wchar_t[]> cmd = utf8towchar(m_argv[0]);
++    unsigned int i = 0;
++    for (; i < m_argv.size(); i++) {
++        LOGDEB2("argv[" << i << "] " << m_argv[i] << "\n");
++        std::string arg;
++        argQuote(m_argv[i], arg);
++        LOGDEB2("  Quoted: [" << arg << "]\n");
++        ptrs.push_back(utf8towchar(arg));
++        argv[i] = ptrs.back().get();
++    }
++    argv[i] = nullptr;
++
++    // Close all descriptors except 0,1,2
++    // Does not work under windows for some reason, the new process does not start
++    //libclf_closefrom(3);
++
++    auto ret = _wexecvp(cmd.get(), argv);
++    LOGERR("_WEXECVP ["<<wchartoutf8(cmd.get())<< "] FAILED: returned: " << ret << 
++           " errno " << errno << "\n");
++    std::cerr<<"_WEXECVP ["<<wchartoutf8(cmd.get())<< "] FAILED: returned: " << ret << 
++        " errno " << errno << "\n";
++    _exit(1);
++}
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/windows/fnmatch.c b/recoll-1.43.14/windows/fnmatch.c
+--- a/recoll-1.43.14/windows/fnmatch.c	1970-01-01 01:00:00.000000000 +0100
++++ b/recoll-1.43.14/windows/fnmatch.c	2026-04-06 01:31:34.682153764 +0200
+@@ -0,0 +1,186 @@
++/* Copyright (C) 1992 Free Software Foundation, Inc.
++This file is part of the GNU C Library.
++
++The GNU C Library is free software; you can redistribute it and/or
++modify it under the terms of the GNU Library General Public License as
++published by the Free Software Foundation; either version 2 of the
++License, or (at your option) any later version.
++
++The GNU C Library is distributed in the hope that it will be useful,
++but WITHOUT ANY WARRANTY; without even the implied warranty of
++MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++Library General Public License for more details.  */
++
++/* Modified slightly by Brian Berliner <berliner@sun.com> and
++   Jim Blandy <jimb@cyclic.com> for CVS use */
++/* Modified slightly by j.f. dockes for recoll use */
++
++#include "autoconfig.h"
++#ifdef _WIN32
++#include <ctype.h>
++static inline int fold_fn_char(int c)
++{
++    /* Only ASCII for now... */
++    if (c == '\\')
++        return '/';
++    if (c > 0 && c <= 127)
++        return tolower(c);
++    return c;
++}
++#define FOLD_FN_CHAR(c) fold_fn_char(c)
++#endif /* _WIN32 */
++
++/* Some file systems are case-insensitive.  If FOLD_FN_CHAR is
++   #defined, it maps the character C onto its "canonical" form.  In a
++   case-insensitive system, it would map all alphanumeric characters
++   to lower case.  Under Windows NT, / and \ are both path component
++   separators, so FOLD_FN_CHAR would map them both to /.  */
++#ifndef FOLD_FN_CHAR
++#define FOLD_FN_CHAR(c) (c)
++#endif
++
++#include <errno.h>
++#include "fnmatch.h"
++
++
++/* Match STRING against the filename pattern PATTERN, returning zero if
++   it matches, nonzero if not.  */
++int fnmatch (const char *pattern, const char *string, int flags)
++{
++  register const char *p = pattern, *n = string;
++  register char c;
++
++  if ((flags & ~__FNM_FLAGS) != 0)
++    {
++      errno = EINVAL;
++      return -1;
++    }
++
++  while ((c = *p++) != '\0')
++    {
++      switch (c)
++    {
++    case '?':
++      if (*n == '\0')
++        return FNM_NOMATCH;
++      else if ((flags & FNM_PATHNAME) && *n == '/')
++        return FNM_NOMATCH;
++      else if ((flags & FNM_PERIOD) && *n == '.' &&
++           (n == string || ((flags & FNM_PATHNAME) && n[-1] == '/')))
++        return FNM_NOMATCH;
++      break;
++      
++    case '\\':
++      if (!(flags & FNM_NOESCAPE))
++        c = *p++;
++      if (*n != c)
++        return FNM_NOMATCH;
++      break;
++      
++    case '*':
++      if ((flags & FNM_PERIOD) && *n == '.' &&
++          (n == string || ((flags & FNM_PATHNAME) && n[-1] == '/')))
++        return FNM_NOMATCH;
++      
++      for (c = *p++; c == '?' || c == '*'; c = *p++, ++n)
++        if (((flags & FNM_PATHNAME) && *n == '/') ||
++        (c == '?' && *n == '\0'))
++          return FNM_NOMATCH;
++      
++      if (c == '\0')
++        return 0;
++      
++      {
++        char c1 = (!(flags & FNM_NOESCAPE) && c == '\\') ? *p : c;
++        for (--p; *n != '\0'; ++n)
++          if ((c == '[' || *n == c1) &&
++          fnmatch(p, n, flags & ~FNM_PERIOD) == 0)
++        return 0;
++        return FNM_NOMATCH;
++      }
++      
++    case '[':
++      {
++        /* Nonzero if the sense of the character class is inverted.  */
++        register int not;
++        
++        if (*n == '\0')
++          return FNM_NOMATCH;
++        
++        if ((flags & FNM_PERIOD) && *n == '.' &&
++        (n == string || ((flags & FNM_PATHNAME) && n[-1] == '/')))
++          return FNM_NOMATCH;
++        
++        not = (*p == '!' || *p == '^');
++        if (not)
++          ++p;
++        
++        c = *p++;
++        for (;;)
++          {
++        register char cstart = c, cend = c;
++        
++        if (!(flags & FNM_NOESCAPE) && c == '\\')
++          cstart = cend = *p++;
++        
++        if (c == '\0')
++          /* [ (unterminated) loses.  */
++          return FNM_NOMATCH;
++        
++        c = *p++;
++        
++        if ((flags & FNM_PATHNAME) && c == '/')
++          /* [/] can never match.  */
++          return FNM_NOMATCH;
++        
++        if (c == '-' && *p != ']')
++          {
++            cend = *p++;
++            if (!(flags & FNM_NOESCAPE) && cend == '\\')
++              cend = *p++;
++            if (cend == '\0')
++              return FNM_NOMATCH;
++            c = *p++;
++          }
++        
++        if (*n >= cstart && *n <= cend)
++          goto matched;
++        
++        if (c == ']')
++          break;
++          }
++        if (!not)
++          return FNM_NOMATCH;
++        break;
++        
++      matched:;
++        /* Skip the rest of the [...] that already matched.  */
++        while (c != ']')
++          {
++        if (c == '\0')
++          /* [... (unterminated) loses.  */
++          return FNM_NOMATCH;
++        
++        c = *p++;
++        if (!(flags & FNM_NOESCAPE) && c == '\\')
++          /* 1003.2d11 is unclear if this is right.  %%% */
++          ++p;
++          }
++        if (not)
++          return FNM_NOMATCH;
++      }
++      break;
++      
++    default:
++      if (FOLD_FN_CHAR (c) != FOLD_FN_CHAR (*n))
++        return FNM_NOMATCH;
++    }
++      
++      ++n;
++    }
++
++  if (*n == '\0')
++    return 0;
++
++  return FNM_NOMATCH;
++}
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/windows/fnmatch.h b/recoll-1.43.14/windows/fnmatch.h
+--- a/recoll-1.43.14/windows/fnmatch.h	1970-01-01 01:00:00.000000000 +0100
++++ b/recoll-1.43.14/windows/fnmatch.h	2026-04-06 01:31:34.682153764 +0200
+@@ -0,0 +1,44 @@
++/* Copyright (C) 1992 Free Software Foundation, Inc.
++This file is part of the GNU C Library.
++
++The GNU C Library is free software; you can redistribute it and/or
++modify it under the terms of the GNU Library General Public License as
++published by the Free Software Foundation; either version 2 of the
++License, or (at your option) any later version.
++
++The GNU C Library is distributed in the hope that it will be useful,
++but WITHOUT ANY WARRANTY; without even the implied warranty of
++MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++Library General Public License for more details.  */
++
++#ifndef    _FNMATCH_H
++
++#define    _FNMATCH_H    1
++
++/* Bits set in the FLAGS argument to `fnmatch'.  */
++#undef FNM_PATHNAME
++#define    FNM_PATHNAME    (1 << 0)/* No wildcard can ever match `/'.  */
++#undef FNM_NOESCAPE
++#define    FNM_NOESCAPE    (1 << 1)/* Backslashes don't quote special chars.  */
++#undef FNM_PERIOD
++#define    FNM_PERIOD    (1 << 2)/* Leading `.' is matched only explicitly.  */
++#undef __FNM_FLAGS
++#define    __FNM_FLAGS    (FNM_PATHNAME|FNM_NOESCAPE|FNM_PERIOD)
++
++/* Value returned by `fnmatch' if STRING does not match PATTERN.  */
++#undef FNM_NOMATCH
++#define    FNM_NOMATCH    1
++
++/* Match STRING against the filename pattern PATTERN,
++   returning zero if it matches, FNM_NOMATCH if not.  */
++#ifdef __cplusplus
++extern "C" {
++#endif
++extern int fnmatch (const char *pattern, const char *str, int flags);
++#ifdef __cplusplus
++}
++#endif
++
++
++#endif    /* fnmatch.h */
++
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/windows/getopt.cc b/recoll-1.43.14/windows/getopt.cc
+--- a/recoll-1.43.14/windows/getopt.cc	1970-01-01 01:00:00.000000000 +0100
++++ b/recoll-1.43.14/windows/getopt.cc	2026-04-06 01:31:34.682153764 +0200
+@@ -0,0 +1,419 @@
++/*
++Copyright (C) 1997 Gregory Pietsch
++
++[These files] are hereby placed in the public domain without restrictions. Just
++give the author credit, don't claim you wrote it or prevent anyone else from
++using it.
++*/
++
++/****************************************************************************
++
++getopt.c - Read command line options
++
++AUTHOR: Gregory Pietsch
++CREATED Fri Jan 10 21:13:05 1997
++
++DESCRIPTION:
++
++The getopt() function parses the command line arguments.  Its arguments argc
++and argv are the argument count and array as passed to the main() function
++on program invocation.  The argument optstring is a list of available option
++characters.  If such a character is followed by a colon (`:'), the option
++takes an argument, which is placed in optarg.  If such a character is
++followed by two colons, the option takes an optional argument, which is
++placed in optarg.  If the option does not take an argument, optarg is NULL.
++
++The external variable optind is the index of the next array element of argv
++to be processed; it communicates from one call to the next which element to
++process.
++
++The getopt_long() function works like getopt() except that it also accepts
++long options started by two dashes `--'.  If these take values, it is either
++in the form
++
++--arg=value
++
++ or
++
++--arg value
++
++It takes the additional arguments longopts which is a pointer to the first
++element of an array of type GETOPT_LONG_OPTION_T.  The last element of the
++array has to be filled with NULL for the name field.
++
++The longind pointer points to the index of the current long option relative
++to longopts if it is non-NULL.
++
++The getopt() function returns the option character if the option was found
++successfully, `:' if there was a missing parameter for one of the options,
++`?' for an unknown option character, and EOF for the end of the option list.
++
++The getopt_long() function's return value is described in the header file.
++
++The function getopt_long_only() is identical to getopt_long(), except that a
++plus sign `+' can introduce long options as well as `--'.
++
++The following describes how to deal with options that follow non-option
++argv-elements.
++
++If the caller did not specify anything, the default is REQUIRE_ORDER if the
++environment variable POSIXLY_CORRECT is defined, PERMUTE otherwise.
++
++REQUIRE_ORDER means don't recognize them as options; stop option processing
++when the first non-option is seen.  This is what Unix does.  This mode of
++operation is selected by either setting the environment variable
++POSIXLY_CORRECT, or using `+' as the first character of the optstring
++parameter.
++
++PERMUTE is the default.  We permute the contents of ARGV as we scan, so that
++eventually all the non-options are at the end.  This allows options to be
++given in any order, even with programs that were not written to expect this.
++
++RETURN_IN_ORDER is an option available to programs that were written to
++expect options and other argv-elements in any order and that care about the
++ordering of the two.  We describe each non-option argv-element as if it were
++the argument of an option with character code 1.  Using `-' as the first
++character of the optstring parameter selects this mode of operation.
++
++The special argument `--' forces an end of option-scanning regardless of the
++value of ordering.  In the case of RETURN_IN_ORDER, only `--' can cause
++getopt() and friends to return EOF with optind != argc.
++
++COPYRIGHT NOTICE AND DISCLAIMER:
++
++Copyright (C) 1997 Gregory Pietsch
++
++This file and the accompanying getopt.h header file are hereby placed in the
++public domain without restrictions.  Just give the author credit, don't
++claim you wrote it or prevent anyone else from using it.
++
++Gregory Pietsch's current e-mail address:
++gpietsch@comcast.net
++****************************************************************************/
++
++/* include files */
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++#ifndef GETOPT_H
++#include "getopt.h"
++#endif
++
++/* macros */
++
++/* types */
++typedef enum GETOPT_ORDERING_T
++{
++  PERMUTE,
++  RETURN_IN_ORDER,
++  REQUIRE_ORDER
++} GETOPT_ORDERING_T;
++
++/* globally-defined variables */
++char *optarg = NULL;
++int optind = 0;
++int opterr = 1;
++int optopt = '?';
++
++/* functions */
++
++/* reverse_argv_elements:  reverses num elements starting at argv */
++static void
++reverse_argv_elements (char **argv, int num)
++{
++  int i;
++  char *tmp;
++
++  for (i = 0; i < (num >> 1); i++)
++    {
++      tmp = argv[i];
++      argv[i] = argv[num - i - 1];
++      argv[num - i - 1] = tmp;
++    }
++}
++
++/* permute: swap two blocks of argv-elements given their lengths */
++static void
++permute (char **argv, int len1, int len2)
++{
++  reverse_argv_elements (argv, len1);
++  reverse_argv_elements (argv, len1 + len2);
++  reverse_argv_elements (argv, len2);
++}
++
++/* is_option: is this argv-element an option or the end of the option list? */
++static int
++is_option (char *argv_element, int only)
++{
++  return ((argv_element == NULL)
++          || (argv_element[0] == '-') || (only && argv_element[0] == '+'));
++}
++
++/* getopt_internal:  the function that does all the dirty work */
++static int
++getopt_internal (int argc, char **argv, char *shortopts,
++                 GETOPT_LONG_OPTION_T * longopts, int *longind, int only)
++{
++  GETOPT_ORDERING_T ordering = PERMUTE;
++  static size_t optwhere = 0;
++  size_t permute_from = 0;
++  int num_nonopts = 0;
++  int optindex = 0;
++  size_t match_chars = 0;
++  char *possible_arg = NULL;
++  int longopt_match = -1;
++  int has_arg = -1;
++  char *cp = NULL;
++  int arg_next = 0;
++
++  /* first, deal with silly parameters and easy stuff */
++  if (argc == 0 || argv == NULL || (shortopts == NULL && longopts == NULL))
++    return (optopt = '?');
++  if (optind >= argc || argv[optind] == NULL)
++    return EOF;
++  if (strcmp (argv[optind], "--") == 0)
++    {
++      optind++;
++      return EOF;
++    }
++  /* if this is our first time through */
++  if (optind == 0) {
++    optind = 1;
++    optwhere = 1;
++  }
++
++  /* define ordering */
++  if (shortopts != NULL && (*shortopts == '-' || *shortopts == '+'))
++    {
++      ordering = (*shortopts == '-') ? RETURN_IN_ORDER : REQUIRE_ORDER;
++      shortopts++;
++    }
++  else
++    ordering = (getenv ("POSIXLY_CORRECT") != NULL) ? REQUIRE_ORDER : PERMUTE;
++
++  /*
++   * based on ordering, find our next option, if we're at the beginning of
++   * one
++   */
++  if (optwhere == 1)
++    {
++      switch (ordering)
++        {
++        case PERMUTE:
++          permute_from = optind;
++          num_nonopts = 0;
++          while (!is_option (argv[optind], only))
++            {
++              optind++;
++              num_nonopts++;
++            }
++          if (argv[optind] == NULL)
++            {
++              /* no more options */
++              optind = (int)permute_from;
++              return EOF;
++            }
++          else if (strcmp (argv[optind], "--") == 0)
++            {
++              /* no more options, but have to get `--' out of the way */
++              permute (argv + permute_from, num_nonopts, 1);
++              optind = (int)(permute_from + 1);
++              return EOF;
++            }
++          break;
++        case RETURN_IN_ORDER:
++          if (!is_option (argv[optind], only))
++            {
++              optarg = argv[optind++];
++              return (optopt = 1);
++            }
++          break;
++        case REQUIRE_ORDER:
++          if (!is_option (argv[optind], only))
++            return EOF;
++          break;
++        }
++    }
++  /* we've got an option, so parse it */
++
++  /* first, is it a long option? */
++  if (longopts != NULL
++      && (strncmp (argv[optind], "--", 2) == 0
++          || (only && argv[optind][0] == '+')) && optwhere == 1)
++    {
++      /* handle long options */
++      if (strncmp (argv[optind], "--", 2) == 0)
++        optwhere = 2;
++      longopt_match = -1;
++      possible_arg = strchr (argv[optind] + optwhere, '=');
++      if (possible_arg == NULL)
++        {
++          /* no =, so next argv might be arg */
++          match_chars = strlen (argv[optind]);
++          possible_arg = argv[optind] + match_chars;
++          match_chars = match_chars - optwhere;
++        }
++      else
++        match_chars = (possible_arg - argv[optind]) - optwhere;
++      for (optindex = 0; longopts[optindex].name != NULL; optindex++)
++        {
++          if (strncmp (argv[optind] + optwhere,
++                       longopts[optindex].name, match_chars) == 0)
++            {
++              /* do we have an exact match? */
++              if (match_chars == strlen (longopts[optindex].name))
++                {
++                  longopt_match = optindex;
++                  break;
++                }
++              /* do any characters match? */
++              else
++                {
++                  if (longopt_match < 0)
++                    longopt_match = optindex;
++                  else
++                    {
++                      /* we have ambiguous options */
++                      if (opterr)
++                        fprintf (stderr, "%s: option `%s' is ambiguous "
++                                 "(could be `--%s' or `--%s')\n",
++                                 argv[0],
++                                 argv[optind],
++                                 longopts[longopt_match].name,
++                                 longopts[optindex].name);
++                      return (optopt = '?');
++                    }
++                }
++            }
++        }
++      if (longopt_match >= 0)
++        has_arg = longopts[longopt_match].has_arg;
++    }
++  /* if we didn't find a long option, is it a short option? */
++  if (longopt_match < 0 && shortopts != NULL)
++    {
++      cp = strchr (shortopts, argv[optind][optwhere]);
++      if (cp == NULL)
++        {
++          /* couldn't find option in shortopts */
++          if (opterr)
++            fprintf (stderr,
++                     "%s: invalid option -- `-%c'\n",
++                     argv[0], argv[optind][optwhere]);
++          optwhere++;
++          if (argv[optind][optwhere] == '\0')
++            {
++              optind++;
++              optwhere = 1;
++            }
++          return (optopt = '?');
++        }
++        has_arg = ((cp[1] == ':') ? ((cp[2] == ':') ? optional_argument
++                                                    : required_argument)
++                                  : no_argument);
++        possible_arg = argv[optind] + optwhere + 1;
++        optopt = *cp;
++    }
++  /* get argument and reset optwhere */
++  arg_next = 0;
++  switch (has_arg)
++    {
++    case optional_argument:
++      if (*possible_arg == '=')
++        possible_arg++;
++      if (*possible_arg != '\0')
++        {
++          optarg = possible_arg;
++          optwhere = 1;
++        }
++      else
++        optarg = NULL;
++      break;
++    case required_argument:
++      if (*possible_arg == '=')
++        possible_arg++;
++      if (*possible_arg != '\0')
++        {
++          optarg = possible_arg;
++          optwhere = 1;
++        }
++      else if (optind + 1 >= argc)
++        {
++          if (opterr)
++            {
++              fprintf (stderr, "%s: argument required for option `", argv[0]);
++              if (longopt_match >= 0)
++                fprintf (stderr, "--%s'\n", longopts[longopt_match].name);
++              else
++                fprintf (stderr, "-%c'\n", *cp);
++            }
++          optind++;
++          return (optopt = ':');
++        }
++      else
++        {
++          optarg = argv[optind + 1];
++          arg_next = 1;
++          optwhere = 1;
++        }
++      break;
++    case no_argument:
++      if (longopt_match < 0)
++        {
++          optwhere++;
++          if (argv[optind][optwhere] == '\0')
++            optwhere = 1;
++        }
++      else
++        optwhere = 1;
++      optarg = NULL;
++      break;
++    }
++
++  /* do we have to permute or otherwise modify optind? */
++  if (ordering == PERMUTE && optwhere == 1 && num_nonopts != 0)
++    {
++      permute (argv + permute_from, num_nonopts, 1 + arg_next);
++      optind = (int)(permute_from + 1 + arg_next);
++    }
++  else if (optwhere == 1)
++    optind = optind + 1 + arg_next;
++
++  /* finally return */
++  if (longopt_match >= 0)
++    {
++      if (longind != NULL)
++        *longind = longopt_match;
++      if (longopts[longopt_match].flag != NULL)
++        {
++          *(longopts[longopt_match].flag) = longopts[longopt_match].val;
++          return 0;
++        }
++      else
++        return longopts[longopt_match].val;
++    }
++  else
++    return optopt;
++}
++
++int
++getopt (int argc, char **argv, char *optstring)
++{
++  return getopt_internal (argc, argv, optstring, NULL, NULL, 0);
++}
++
++int
++getopt_long (int argc, char * const argv[], const char *shortopts,
++             const GETOPT_LONG_OPTION_T * longopts, int *longind)
++{
++    return getopt_internal (argc, (char **)argv, (char*)shortopts, (GETOPT_LONG_OPTION_T*)longopts, longind, 0);
++}
++
++int
++getopt_long_only (int argc, char * const argv[], const char *shortopts,
++                  const GETOPT_LONG_OPTION_T * longopts, int *longind)
++{
++    return getopt_internal (argc, (char **)argv, (char*)shortopts, (GETOPT_LONG_OPTION_T*)longopts, longind, 1);
++}
++
++/* end of file GETOPT.C */
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/windows/getopt.h b/recoll-1.43.14/windows/getopt.h
+--- a/recoll-1.43.14/windows/getopt.h	1970-01-01 01:00:00.000000000 +0100
++++ b/recoll-1.43.14/windows/getopt.h	2026-04-06 01:31:34.682153764 +0200
+@@ -0,0 +1,59 @@
++/*
++  Copyright (C) 1997 Gregory Pietsch
++
++  [These files] are hereby placed in the public domain without restrictions. Just
++  give the author credit, don't claim you wrote it or prevent anyone else from
++  using it.
++*/
++
++#ifndef GETOPT_H
++#define GETOPT_H
++
++/* include files needed by this include file */
++
++/* macros defined by this include file */
++#define no_argument       0
++#define required_argument 1
++#define optional_argument 2
++
++/* types defined by this include file */
++
++/* GETOPT_LONG_OPTION_T: The type of long option */
++typedef struct option
++{
++    const char *name;             /* the name of the long option */
++    int has_arg;                  /* one of the above macros */
++    int *flag;                    /* determines if getopt_long() returns a
++                                   * value for a long option; if it is
++                                   * non-NULL, 0 is returned as a function
++                                   * value and the value of val is stored in
++                                   * the area pointed to by flag.  Otherwise,
++                                   * val is returned. */
++    int val;                      /* determines the value to return if flag is
++                                   * NULL. */
++} GETOPT_LONG_OPTION_T;
++
++typedef GETOPT_LONG_OPTION_T option;
++
++/* externally-defined variables */
++extern char *optarg;
++extern int optind;
++extern int opterr;
++extern int optopt;
++
++/* function prototypes */
++int getopt(int argc, char** argv, char* optstring);
++int getopt_long(int argc,
++                char* const argv[],
++                const char* shortopts,
++                const GETOPT_LONG_OPTION_T* longopts,
++                int* longind);
++int getopt_long_only(int argc,
++                     char* const argv[],
++                     const char* shortopts,
++                     const GETOPT_LONG_OPTION_T* longopts,
++                     int* longind);
++
++#endif /* GETOPT_H */
++
++/* END OF FILE getopt.h */
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/windows/mimeconf b/recoll-1.43.14/windows/mimeconf
+--- a/recoll-1.43.14/windows/mimeconf	1970-01-01 01:00:00.000000000 +0100
++++ b/recoll-1.43.14/windows/mimeconf	2026-04-06 01:31:34.682153764 +0200
+@@ -0,0 +1,51 @@
++# (C) 2015-2022 J.F.Dockes
++
++#
++# MS-WINDOWS specific definitions for mimeconf
++#
++
++# Decompression: the windows version always uses 7z, no decompressor parameter is necessary
++application/gzip  =  uncompress rcluncomp.py 7z %f %t
++application/x-gzip  =  uncompress rcluncomp.py 7z %f %t
++application/x-compress = uncompress rcluncomp.py 7z %f %t
++application/x-bzip2 =  uncompress rcluncomp.py 7z %f %t
++application/x-xz = uncompress rcluncomp.py 7z %f %t
++application/x-lzma = uncompress rcluncomp.py 7z %f %t
++
++
++[index]
++# Types which we don't support on Windows at the moment. Most use a shell-script on UX.
++application/postscript =
++application/x-dvi =
++application/x-gnuinfo =
++application/x-kword =
++application/x-lyx =
++application/x-scribus =
++application/x-tex =
++text/x-bibtex =
++text/x-gaim-log =
++text/x-html-aptosid-man = 
++text/x-man =
++text/x-purple-log =
++text/x-tex =
++
++# Types with different handlers on Windows
++
++application/x-ipynb+json = execm rclipynb.py
++application/vnd.wordperfect = exec wpd/wpd2html;mimetype=text/html
++
++# Image types use the packed rclimg Perl program. Use rclimgp.py instead for image OCR
++image/avif = execm rclimg.exe
++image/gif = execm rclimg.exe
++image/heic = execm rclimg.exe
++image/heic-sequence = execm rclimg.exe
++image/heif = execm rclimg.exe
++image/heif-sequence = execm rclimg.exe
++image/jp2 = execm rclimg.exe
++image/jpeg = execm rclimg.exe
++image/png = execm rclimg.exe
++image/tiff = execm rclimg.exe
++image/x-nikon-nef = execm rclimg.exe
++image/x-xcf = execm rclimg.exe
++video/x-msvideo = execm rclimg.exe
++
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/windows/mimeview b/recoll-1.43.14/windows/mimeview
+--- a/recoll-1.43.14/windows/mimeview	1970-01-01 01:00:00.000000000 +0100
++++ b/recoll-1.43.14/windows/mimeview	2026-04-06 01:31:34.682153764 +0200
+@@ -0,0 +1,43 @@
++# MS WINDOWS system changes for mimeview
++
++xallexcepts = \
++ text/html|epub \
++ application/x-fsdirectory|parentopen \
++ inode/directory|parentopen
++
++[view]
++# Pseudo entry used if the 'use desktop' preference is set in the GUI
++# Could not get the cmd-based ones to work (tried quoting "start %u" too)
++#application/x-all = c:/Windows/System32/cmd /c start %u
++#application/x-all = cmd /c start %u
++application/x-all = rclstartw %u
++
++####### Special ones
++
++# Open the parent epub document for epub parts instead of opening them as
++# html documents. This is almost always what we want.
++text/html|epub = rclstartw %F;ignoreipath=1
++
++# Parent open for fs file.
++application/x-fsdirectory|parentopen = C:/Windows/explorer.exe /select,%(childurl)
++inode/directory|parentopen = C:/Windows/explorer.exe /select,%(childurl)
++
++# PDF examples. These can be set from the GUI preferences "editor applications" section. Select
++# application/pdf, check "exception to desktop preferences", and enter something similar to the
++# below values. 
++#
++#  Evince: this is usually installed with a version-specific path and in the user directory, so the
++#  exact command value will need some tweaking (user name and version number). 
++application/pdf = C:/users/bill/appdata/local/apps/evince-2.32.0.145/bin/evince --page-index=%p --find=%s %f
++# SumatraPDF: the -search option may? only be available with newer versions (works with 3.5.2)
++#application/pdf  = "C:/Program Files/SumatraPDF/SumatraPDF.exe" -page %p -search %s %f
++#  Foxit: no search string 
++#application/pdf = "C:/Program Files (x86)/Foxit Software/Foxit Reader/FoxitReader.exe" %f /A page=%p
++#  PDFXEdit: supports a search string, but beware, the following only works after version 1.32.1,
++#   previous ones can't process the semi-colon in the options
++#application/pdf = "C:/Program Files/Tracker Software/PDF Editor/PDFXEdit.exe" /A "page=%p;search=%s" "%f"
++
++
++##########
++# Other MIME types have no specializations on Windows, but the types need to be listed for an "Open"
++# link to appear in the result list, the listing is in the generic file
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/windows/mkinstdir.sh b/recoll-1.43.14/windows/mkinstdir.sh
+--- a/recoll-1.43.14/windows/mkinstdir.sh	1970-01-01 01:00:00.000000000 +0100
++++ b/recoll-1.43.14/windows/mkinstdir.sh	2026-04-06 01:31:34.682153764 +0200
+@@ -0,0 +1,364 @@
++#!/bin/sh
++
++fatal()
++{
++    echo $*
++    exit 1
++}
++Usage()
++{
++    fatal mkinstdir.sh targetdir
++}
++
++test $# -eq 1 || Usage
++
++DESTDIR=$1
++
++test -d $DESTDIR || mkdir $DESTDIR || fatal cant create $DESTDIR
++
++# Script to make a prototype recoll install directory from locally compiled
++# software. *** Needs msys or cygwin ***
++
++################################
++# Local values (to be adjusted)
++
++#WEB=WEBKIT
++WEB=WEBENGINE
++
++# Recoll src tree
++TOP=/d/projets
++RCL=${TOP}/recoll/src/
++PYRECOLL=${RCL}/python/recoll/
++# Recoll dependencies
++RCLDEPS=${TOP}/recolldeps/
++LIBXML=${RCLDEPS}/msvc/libxml2/libxml2-2.9.4+dfsg1/win32/bin.msvc/libxml2.dll
++LIBXSLT=${RCLDEPS}/msvc/libxslt/libxslt-1.1.29/win32/bin.msvc/libxslt.dll
++ZLIB=${RCLDEPS}/msvc/zlib-1.2.11
++LIBMAGIC=${RCLDEPS}/msvc/libmagic
++
++# Qt. We always use qt6 except for some builds where the GUI (only) is built with qt5 (by changing
++# the kit in qcreator and rebuilding the GUI).
++qtsdir=release
++QTA=Desktop_Qt_6_8_2_MSVC2022_64bit-Release
++
++QTAG=Desktop_Qt_6_8_2_MSVC2022_64bit-Release
++QTBIN=C:/Qt/6.8.2/msvc2022_64/bin
++# QTBIN=C:/Qt/5.15.2/msvc2019_64/bin
++# QTAG=Desktop_Qt_5_15_2_MSVC2019_64bit-Release
++
++# mingwbin has dlls for aux programs built with mingw (wpd, pff, aspell)
++MINGWBIN=${RCLDEPS}/gcclibs
++
++# We use the mingw-compiled aspell program for building the dict
++ASPELL=${RCLDEPS}/aspell-0.60.7/aspell-installed
++# We use an msvc-built aspell lib for supporting a python extension used by the suggestion script
++LIBASPELL=${RCLDEPS}/msvc/aspell-0.60.7/
++
++
++RCLW=$RCL/
++GUIBIN=$RCL/qtgui/build/${QTAG}/${qtsdir}/recoll.exe
++RCLIDX=$RCLW/qmake/build/recollindex/${QTA}/${qtsdir}/recollindex.exe
++RCLQ=$RCLW/qmake/build/recollq/${QTA}/${qtsdir}/recollq.exe
++RCLS=$RCLW/qmake/build/rclstartw/${QTA}/${qtsdir}/rclstartw.exe
++XAPC=$RCLW/qmake/build/xapian-check/${QTA}/${qtsdir}/xapian-check.exe
++# Embedded Python version and tree
++PYTHONMINOR=12
++PYTHON=${RCLDEPS}python-3.12.4-embed-amd64
++UNRTF=${RCLDEPS}unrtf
++ANTIWORD=${RCLDEPS}antiword
++EPUB=${RCLDEPS}epub-0.5.2
++FUTURE=${RCLDEPS}python2-future
++POPPLER=${RCLDEPS}poppler-22.04.0/
++LIBWPD=${RCLDEPS}libwpd/libwpd-0.10.0/
++LIBREVENGE=${RCLDEPS}libwpd/librevenge-0.0.1.jfd/
++CHM=${RCLDEPS}pychm
++MISC=${RCLDEPS}misc
++LIBPFF=${RCLDEPS}pffinstall
++
++################
++# Script:
++FILTERS=$DESTDIR/Share/filters
++SHARE=$DESTDIR/Share
++
++fatal()
++{
++    echo $*
++    exit 1
++}
++
++# checkcopy. 
++chkcp()
++{
++    echo "Copying $@"
++    cp $@ || fatal cp $@ failed
++}
++
++copyqt()
++{
++    cd $DESTDIR
++    PATH=$QTBIN:$PATH
++    export PATH
++    $QTBIN/windeployqt recoll.exe || exit 1
++
++    if test $WEB = WEBKIT ; then
++        addlibs="icudt65.dll icuin65.dll icuuc65.dll libxml2.dll libxslt.dll \
++          Qt5WebKit.dll Qt5WebKitWidgets.dll"
++        for i in $addlibs;do
++            chkcp $QTBIN/$i $DESTDIR
++        done
++    fi
++}
++
++# Note that pyhwp is pre-copied into the python distribution directory and also needs
++# olefile. It used to also need six, which we don't ship any more. pyhwp was trivially
++# fixed to get rid of six.with_metaclass, unneeded now that py2 is gone:
++#  < class ControlData(with_metaclass(ControlDataType, RecordModel)):
++#  ---
++#  > class ControlData(RecordModel, metaclass=ControlDataType):
++copypython()
++{
++    set -x
++    mkdir -p ${DESTDIR}/Share/filters/python
++    rsync -av $PYTHON/ ${DESTDIR}/Share/filters/python || exit 1
++    chkcp $PYTHON/python.exe $DESTDIR/Share/filters/python/python.exe
++    chkcp $MISC/hwp5html $FILTERS
++}
++
++copyrecoll()
++{
++    
++    chkcp $GUIBIN $DESTDIR
++    chkcp $RCLIDX $DESTDIR
++    chkcp $RCLQ $DESTDIR 
++    chkcp $RCLS $DESTDIR 
++    chkcp $ZLIB/zlib1.dll $DESTDIR
++    chkcp $XAPC $DESTDIR
++    chkcp $LIBXML $DESTDIR
++    chkcp $LIBXSLT $DESTDIR
++
++    chkcp $RCL/COPYING                  $DESTDIR/COPYING.txt
++    chkcp $RCL/doc/user/usermanual.html $DESTDIR/Share/doc
++    chkcp $RCL/doc/user/docbook-xsl.css $DESTDIR/Share/doc
++    mkdir -p $DESTDIR/Share/doc/webhelp
++    rsync -av $RCL/doc/user/webhelp/docs/* $DESTDIR/Share/doc/webhelp || exit 1
++    chkcp $RCL/sampleconf/fields          $DESTDIR/Share/examples
++    chkcp $RCL/sampleconf/fragment-buttons.xml  $DESTDIR/Share/examples
++    chkcp $RCL/sampleconf/mimeconf        $DESTDIR/Share/examples
++    chkcp $RCL/sampleconf/mimeview        $DESTDIR/Share/examples
++    chkcp $RCL/sampleconf/mimemap         $DESTDIR/Share/examples
++    chkcp $RCL/sampleconf/backends        $DESTDIR/Share/examples
++    chkcp $RCL/windows/mimeconf           $DESTDIR/Share/examples/windows
++    chkcp $RCL/windows/recoll.conf        $DESTDIR/Share/examples/windows
++    chkcp $RCL/windows/mimeview           $DESTDIR/Share/examples/windows
++    chkcp $RCL/sampleconf/recoll.conf     $DESTDIR/Share/examples
++    chkcp $RCL/sampleconf/recoll.qss      $DESTDIR/Share/examples
++    chkcp $RCL/sampleconf/recoll-common.qss $DESTDIR/Share/examples
++    chkcp $RCL/sampleconf/recoll-dark.qss $DESTDIR/Share/examples
++    chkcp $RCL/sampleconf/recoll-dark.css $DESTDIR/Share/examples
++
++    chkcp $RCL/filters/*       $FILTERS
++    # KEEP THESE TWO *AFTER* the above
++    chkcp $RCL/python/recoll/recoll/rclconfig.py $FILTERS
++    chkcp $RCL/python/recoll/recoll/conftree.py $FILTERS
++
++    chkcp $RCLDEPS/rclimg/rclimg.exe $FILTERS
++    chkcp $RCL/filters/rclimgp.py $FILTERS
++
++    chkcp $RCL/qtgui/mtpics/*  $DESTDIR/Share/images
++    chkcp $RCL/qtgui/build/${QTAG}/${qtsdir}/*.qm $DESTDIR/Share/translations
++
++    chkcp $RCL/desktop/recoll.ico $DESTDIR/Share
++}
++
++copyredist()
++{
++    chkcp ${RCLDEPS}/vc_redist/VC_redist.x64.exe ${DESTDIR}/Share/dist
++}
++
++copyantiword()
++{
++    bindir=$ANTIWORD/
++    test -d $Filters/Resources || mkdir -p $FILTERS/Resources || exit 1
++    chkcp  $bindir/antiword.exe            $FILTERS
++    rsync -av  $ANTIWORD/Resources/*       $FILTERS/Resources || exit 1
++}
++
++copyunrtf()
++{
++    bindir=$UNRTF/Windows/
++
++    test -d $FILTERS/Share || mkdir -p $FILTERS/Share || exit 1
++    chkcp  $bindir/unrtf.exe               $FILTERS
++    chkcp  $UNRTF/outputs/*.conf           $FILTERS/Share
++    chkcp  $UNRTF/outputs/SYMBOL.charmap   $FILTERS/Share
++    # libiconv-2 originally comes from mingw
++    chkcp $MISC/libiconv-2.dll $FILTERS
++}
++
++
++# Not used any more, the epub python code is bundled with recoll
++copyepub()
++{
++    cp -rp $EPUB/build/lib/epub $FILTERS
++    # chkcp to check that epub is where we think it is
++    chkcp $EPUB/build/lib/epub/opf.py $FILTERS/epub
++}
++
++# We used to copy the future module to the filters dir, but it is now
++# part of the origin Python tree in recolldeps. (2 dirs:
++# site-packages/builtins, site-packages/future)
++copyfuture()
++{
++    cp -rp $FUTURE/future $FILTERS/
++    cp -rp $FUTURE/builtins $FILTERS/
++    # chkcp to check that things are where we think they are
++    chkcp $FUTURE/future/builtins/newsuper.pyc $FILTERS/future/builtins
++}
++
++copypoppler()
++{
++    # Note: the recent poppler build which we ship comes from conda builds, and it includes
++    # poppler-data, which has additional fonts and encodings, for, e.g. Chinese. The utilities
++    # (e.g. pdftotext) expect to find the data in a directory named shared/poppler, 2 levels above
++    # the exec. There is no way that I could find to explicitly designate the data location, so we
++    # have to keep the structure of the directories.
++    test -d $FILTERS/poppler/Library/bin || mkdir -p $FILTERS/poppler/Library/bin || \
++        fatal cant create poppler directory
++    for f in pdfdetach.exe pdftotext.exe pdfinfo.exe pdftoppm.exe $POPPLER/Library/bin/*.dll ; do
++        chkcp $POPPLER/Library/bin/`basename $f` $FILTERS/poppler/Library/bin/
++    done
++    cp -rp $POPPLER/share $FILTERS/poppler
++}
++
++copywpd()
++{
++    DEST=$FILTERS/wpd
++    test -d $DEST || mkdir $DEST || fatal cant create poppler dir $DEST
++
++    for f in librevenge-0.0.dll librevenge-generators-0.0.dll \
++             librevenge-stream-0.0.dll; do
++        chkcp $LIBREVENGE/src/lib/.libs/$f $DEST
++    done
++    chkcp $LIBWPD/src/lib/.libs/libwpd-0.10.dll $DEST
++    chkcp $LIBWPD/src/conv/html/.libs/wpd2html.exe $DEST
++    chkcp $MINGWBIN/libgcc_s_dw2-1.dll $DEST
++    chkcp $MINGWBIN/libstdc++-6.dll $DEST
++    chkcp $MINGWBIN/libwinpthread-1.dll $DEST
++    chkcp $MINGWBIN/zlib1.dll $DEST
++}
++
++
++copypff()
++{
++    DEST=$FILTERS
++    cp -rp $LIBPFF $DEST || fatal "can't copy $LIBPFF"
++    DEST=$DEST/pffinstall/mingw32/bin
++    chkcp $LIBPFF/mingw32/bin/pffexport.exe $DEST
++    chkcp $MINGWBIN/libgcc_s_dw2-1.dll $DEST
++    chkcp $MINGWBIN/libstdc++-6.dll $DEST
++    chkcp $MINGWBIN/libwinpthread-1.dll $DEST
++}
++
++copymagic()
++{
++    chkcp $LIBMAGIC/magic/magic.mgc $SHARE
++}
++
++copyaspell()
++{
++    DEST=$FILTERS
++    cp -rp $ASPELL $DEST || fatal "can't copy $ASPELL"
++    DEST=$DEST/aspell-installed/mingw32/bin
++    # Check that we do have an aspell.exe.
++    chkcp $ASPELL/mingw32/bin/aspell.exe $DEST
++    chkcp $MINGWBIN/libgcc_s_dw2-1.dll $DEST
++    chkcp $MINGWBIN/libstdc++-6.dll $DEST
++    chkcp $MINGWBIN/libwinpthread-1.dll $DEST
++
++    # Build and install the Python aspell expansion. We use the normal
++    # Python install as the embedded one does not have the build files
++    # (.h etc.).
++    pushd ${RCL}/python/pyaspell
++    "/c/Program Files/Python3${PYTHONMINOR}/python" setup-win.py bdist_wheel || exit 1
++    PYASPDIST=dist/aspell_python_py3-1.15-cp3${PYTHONMINOR}-cp3${PYTHONMINOR}-win_amd64.whl
++    ${DESTDIR}/Share/filters/python/python -m pip install --no-user ${PYASPDIST} || exit 1
++    chkcp $LIBASPELL/build/libaspell/${QTA}/${qtsdir}/aspell.dll \
++          ${DESTDIR}/Share/filters/python/lib/site-packages
++    popd
++}
++
++copychm()
++{
++    # Build and install the Python chm expansion. We use the normal Python install of the
++    # same version to build as the embedded one does not have the necessary bits (.h
++    # etc.).
++    pushd ${RCL}/python/pychm
++    "/c/Program Files/Python3${PYTHONMINOR}/python" setup.py bdist_wheel || exit 1
++    PYCHMDIST=dist/recollchm-0.8.4.1+git-cp3${PYTHONMINOR}-cp3${PYTHONMINOR}-win_amd64.whl
++    ${DESTDIR}/Share/filters/python/python -m pip install --no-user ${PYCHMDIST} || exit 1
++    popd
++}
++
++# Recoll python package. Only when compiled with msvc as this is what
++# the standard Python dist is built with
++copypyrecoll()
++{
++    # e.g. build: "/c/Program Files (x86)/Python39-32/python" setup-win.py bdist_wheel
++
++    # NOTE: the python 3.10 build outputs logging error messages
++    # (ValueError: underlying buffer has been detached), but this does
++    # not seem to affect the build
++    DEST=${DESTDIR}/Share/dist
++    test -d $DEST || mkdir $DEST || fatal cant create $DEST
++    rm -f ${DEST}/Recoll*.egg ${DEST}/Recoll*.whl
++    for v in 10 11 12 13;do
++        PYRCLDIST=${PYRECOLL}/dist/Recoll-${VERSION}-cp3${v}-cp3${v}-win_amd64.whl
++        if test ! -f ${PYRCLDIST}; then
++            pushd ${PYRECOLL}
++            # NOTE: with recent Python versions you need to install the wheel module for this
++            # to work: xxx/python -m pip install setuptools wheel
++            "/c/Program Files/Python3${v}/python" setup-win.py bdist_wheel
++            popd
++        fi
++        chkcp ${PYRCLDIST} $DEST
++        # If this is the right version for our embedded python, install the extension
++        #(needed, e.g. for the Joplin indexer).
++        if test "$v" = "$PYTHONMINOR";then
++            ${DESTDIR}/Share/filters/python/python -m pip install --no-user ${PYRCLDIST} || exit 1
++        fi
++    done
++}
++
++# First check that the config is ok
++diff -q $RCL/common/autoconfig.h $RCL/common/autoconfig-win.h || \
++    fatal autoconfig.h and autoconfig-win.h differ
++VERSION=`cat $RCL/RECOLL-VERSION.txt`
++CFVERS=`grep PACKAGE_VERSION $RCL/common/autoconfig.h | \
++cut -d ' ' -f 3 | sed -e 's/"//g'`
++test "$VERSION" = "$CFVERS" ||
++    fatal Versions in RECOLL-VERSION.txt and autoconfig.h differ
++
++
++echo Packaging version $CFVERS
++
++for d in doc examples examples/windows filters images translations; do
++    test -d $DESTDIR/Share/$d || mkdir -p $DESTDIR/Share/$d || \
++        fatal mkdir $d failed
++done
++
++# copyrecoll must stay before copyqt so that windeployqt can do its thing
++copyrecoll
++copyqt
++copypython
++copypoppler
++copyantiword
++copyunrtf
++copywpd
++copypff
++copyaspell
++copychm
++copypyrecoll
++copymagic
++copyredist
++
++echo "MKINSTDIR OK"
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/windows/msvc_dirent.h b/recoll-1.43.14/windows/msvc_dirent.h
+--- a/recoll-1.43.14/windows/msvc_dirent.h	1970-01-01 01:00:00.000000000 +0100
++++ b/recoll-1.43.14/windows/msvc_dirent.h	2026-04-06 01:31:34.682153764 +0200
+@@ -0,0 +1,1223 @@
++/*
++ * Dirent interface for Microsoft Visual Studio
++ *
++ * Copyright (C) 2006-2012 Toni Ronkko
++ * This file is part of dirent.  Dirent may be freely distributed
++ * under the MIT license.  For all details and documentation, see
++ * https://github.com/tronkko/dirent
++ */
++#ifndef DIRENT_H
++#define DIRENT_H
++ 
++/*
++ * Include windows.h without Windows Sockets 1.1 to prevent conflicts with
++ * Windows Sockets 2.0.
++ */
++#ifndef WIN32_LEAN_AND_MEAN
++#   define WIN32_LEAN_AND_MEAN
++#endif
++#include <windows.h>
++
++#include <stdio.h>
++#include <stdarg.h>
++#include <wchar.h>
++#include <string.h>
++#include <stdlib.h>
++#include <sys/types.h>
++#include <sys/stat.h>
++#include <errno.h>
++
++/* Indicates that d_type field is available in dirent structure */
++#define _DIRENT_HAVE_D_TYPE
++
++/* Indicates that d_namlen field is available in dirent structure */
++#define _DIRENT_HAVE_D_NAMLEN
++
++/* Entries missing from MSVC 6.0 */
++#if !defined(FILE_ATTRIBUTE_DEVICE)
++#   define FILE_ATTRIBUTE_DEVICE 0x40
++#endif
++
++/* File type and permission flags for stat(), general mask */
++#if !defined(S_IFMT)
++#   define S_IFMT _S_IFMT
++#endif
++
++/* Directory bit */
++#if !defined(S_IFDIR)
++#   define S_IFDIR _S_IFDIR
++#endif
++
++/* Character device bit */
++#if !defined(S_IFCHR)
++#   define S_IFCHR _S_IFCHR
++#endif
++
++/* Pipe bit */
++#if !defined(S_IFFIFO)
++#   define S_IFFIFO _S_IFFIFO
++#endif
++
++/* Regular file bit */
++#if !defined(S_IFREG)
++#   define S_IFREG _S_IFREG
++#endif
++
++/* Read permission */
++#if !defined(S_IREAD)
++#   define S_IREAD _S_IREAD
++#endif
++
++/* Write permission */
++#if !defined(S_IWRITE)
++#   define S_IWRITE _S_IWRITE
++#endif
++
++/* Execute permission */
++#if !defined(S_IEXEC)
++#   define S_IEXEC _S_IEXEC
++#endif
++
++/* Pipe */
++#if !defined(S_IFIFO)
++#   define S_IFIFO _S_IFIFO
++#endif
++
++/* Block device */
++#if !defined(S_IFBLK)
++#   define S_IFBLK 0
++#endif
++
++/* Link */
++#if !defined(S_IFLNK)
++#   define S_IFLNK 0
++#endif
++
++/* Socket */
++#if !defined(S_IFSOCK)
++#   define S_IFSOCK 0
++#endif
++
++/* Read user permission */
++#if !defined(S_IRUSR)
++#   define S_IRUSR S_IREAD
++#endif
++
++/* Write user permission */
++#if !defined(S_IWUSR)
++#   define S_IWUSR S_IWRITE
++#endif
++
++/* Execute user permission */
++#if !defined(S_IXUSR)
++#   define S_IXUSR 0
++#endif
++
++/* Read group permission */
++#if !defined(S_IRGRP)
++#   define S_IRGRP 0
++#endif
++
++/* Write group permission */
++#if !defined(S_IWGRP)
++#   define S_IWGRP 0
++#endif
++
++/* Execute group permission */
++#if !defined(S_IXGRP)
++#   define S_IXGRP 0
++#endif
++
++/* Read others permission */
++#if !defined(S_IROTH)
++#   define S_IROTH 0
++#endif
++
++/* Write others permission */
++#if !defined(S_IWOTH)
++#   define S_IWOTH 0
++#endif
++
++/* Execute others permission */
++#if !defined(S_IXOTH)
++#   define S_IXOTH 0
++#endif
++
++/* Maximum length of file name */
++#if !defined(PATH_MAX)
++#   define PATH_MAX MAX_PATH
++#endif
++#if !defined(FILENAME_MAX)
++#   define FILENAME_MAX MAX_PATH
++#endif
++#if !defined(NAME_MAX)
++#   define NAME_MAX FILENAME_MAX
++#endif
++
++/* File type flags for d_type */
++#define DT_UNKNOWN 0
++#define DT_REG S_IFREG
++#define DT_DIR S_IFDIR
++#define DT_FIFO S_IFIFO
++#define DT_SOCK S_IFSOCK
++#define DT_CHR S_IFCHR
++#define DT_BLK S_IFBLK
++#define DT_LNK S_IFLNK
++
++/* Macros for converting between st_mode and d_type */
++#define IFTODT(mode) ((mode) & S_IFMT)
++#define DTTOIF(type) (type)
++
++/*
++ * File type macros.  Note that block devices, sockets and links cannot be
++ * distinguished on Windows and the macros S_ISBLK, S_ISSOCK and S_ISLNK are
++ * only defined for compatibility.  These macros should always return false
++ * on Windows.
++ */
++#if !defined(S_ISFIFO)
++#   define S_ISFIFO(mode) (((mode) & S_IFMT) == S_IFIFO)
++#endif
++#if !defined(S_ISDIR)
++#   define S_ISDIR(mode) (((mode) & S_IFMT) == S_IFDIR)
++#endif
++#if !defined(S_ISREG)
++#   define S_ISREG(mode) (((mode) & S_IFMT) == S_IFREG)
++#endif
++#if !defined(S_ISLNK)
++#   define S_ISLNK(mode) (((mode) & S_IFMT) == S_IFLNK)
++#endif
++#if !defined(S_ISSOCK)
++#   define S_ISSOCK(mode) (((mode) & S_IFMT) == S_IFSOCK)
++#endif
++#if !defined(S_ISCHR)
++#   define S_ISCHR(mode) (((mode) & S_IFMT) == S_IFCHR)
++#endif
++#if !defined(S_ISBLK)
++#   define S_ISBLK(mode) (((mode) & S_IFMT) == S_IFBLK)
++#endif
++
++/* Return the exact length of the file name without zero terminator */
++#define _D_EXACT_NAMLEN(p) ((p)->d_namlen)
++
++/* Return the maximum size of a file name */
++#define _D_ALLOC_NAMLEN(p) ((PATH_MAX)+1)
++
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++
++/* Wide-character version */
++struct _wdirent {
++    /* Always zero */
++    long d_ino;
++
++    /* File position within stream */
++    long d_off;
++
++    /* Structure size */
++    unsigned short d_reclen;
++
++    /* Length of name without \0 */
++    size_t d_namlen;
++
++    /* File type */
++    int d_type;
++
++    /* File name */
++    wchar_t d_name[PATH_MAX+1];
++};
++typedef struct _wdirent _wdirent;
++
++struct _WDIR {
++    /* Current directory entry */
++    struct _wdirent ent;
++
++    /* Private file data */
++    WIN32_FIND_DATAW data;
++
++    /* True if data is valid */
++    int cached;
++
++    /* Win32 search handle */
++    HANDLE handle;
++
++    /* Initial directory name */
++    wchar_t *patt;
++};
++typedef struct _WDIR _WDIR;
++
++/* Multi-byte character version */
++struct dirent {
++    /* Always zero */
++    long d_ino;
++
++    /* File position within stream */
++    long d_off;
++
++    /* Structure size */
++    unsigned short d_reclen;
++
++    /* Length of name without \0 */
++    size_t d_namlen;
++
++    /* File type */
++    int d_type;
++
++    /* File name */
++    char d_name[PATH_MAX+1];
++};
++typedef struct dirent dirent;
++
++struct DIR {
++    struct dirent ent;
++    struct _WDIR *wdirp;
++};
++typedef struct DIR DIR;
++
++
++/* Dirent functions */
++static DIR *opendir (const char *dirname);
++static _WDIR *_wopendir (const wchar_t *dirname);
++
++static struct dirent *readdir (DIR *dirp);
++static struct _wdirent *_wreaddir (_WDIR *dirp);
++
++static int readdir_r(
++    DIR *dirp, struct dirent *entry, struct dirent **result);
++static int _wreaddir_r(
++    _WDIR *dirp, struct _wdirent *entry, struct _wdirent **result);
++
++static int closedir (DIR *dirp);
++static int _wclosedir (_WDIR *dirp);
++
++static void rewinddir (DIR* dirp);
++static void _wrewinddir (_WDIR* dirp);
++
++static int scandir (const char *dirname, struct dirent ***namelist,
++    int (*filter)(const struct dirent*),
++    int (*compare)(const struct dirent**, const struct dirent**));
++
++static int alphasort (const struct dirent **a, const struct dirent **b);
++
++static int versionsort (const struct dirent **a, const struct dirent **b);
++
++
++/* For compatibility with Symbian */
++#define wdirent _wdirent
++#define WDIR _WDIR
++#define wopendir _wopendir
++#define wreaddir _wreaddir
++#define wclosedir _wclosedir
++#define wrewinddir _wrewinddir
++
++
++/* Internal utility functions */
++static WIN32_FIND_DATAW *dirent_first (_WDIR *dirp);
++static WIN32_FIND_DATAW *dirent_next (_WDIR *dirp);
++
++static int dirent_mbstowcs_s(
++    size_t *pReturnValue,
++    wchar_t *wcstr,
++    size_t sizeInWords,
++    const char *mbstr,
++    size_t count);
++
++static int dirent_wcstombs_s(
++    size_t *pReturnValue,
++    char *mbstr,
++    size_t sizeInBytes,
++    const wchar_t *wcstr,
++    size_t count);
++
++static void dirent_set_errno (int error);
++
++
++/*
++ * Open directory stream DIRNAME for read and return a pointer to the
++ * internal working area that is used to retrieve individual directory
++ * entries.
++ */
++static _WDIR*
++_wopendir(
++    const wchar_t *dirname)
++{
++    _WDIR *dirp = NULL;
++    int error;
++
++    /* Must have directory name */
++    if (dirname == NULL  ||  dirname[0] == '\0') {
++        dirent_set_errno (ENOENT);
++        return NULL;
++    }
++
++    /* Allocate new _WDIR structure */
++    dirp = (_WDIR*) malloc (sizeof (struct _WDIR));
++    if (dirp != NULL) {
++        DWORD n;
++
++        /* Reset _WDIR structure */
++        dirp->handle = INVALID_HANDLE_VALUE;
++        dirp->patt = NULL;
++        dirp->cached = 0;
++
++        /* Compute the length of full path plus zero terminator
++         *
++         * Note that on WinRT there's no way to convert relative paths
++         * into absolute paths, so just assume it is an absolute path.
++         */
++#       if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)
++            n = wcslen(dirname);
++#       else
++            n = GetFullPathNameW (dirname, 0, NULL, NULL);
++#       endif
++
++        /* Allocate room for absolute directory name and search pattern */
++        dirp->patt = (wchar_t*) malloc (sizeof (wchar_t) * n + 16);
++        if (dirp->patt) {
++
++            /*
++             * Convert relative directory name to an absolute one.  This
++             * allows rewinddir() to function correctly even when current
++             * working directory is changed between opendir() and rewinddir().
++             *
++             * Note that on WinRT there's no way to convert relative paths
++             * into absolute paths, so just assume it is an absolute path.
++             */
++#           if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)
++                wcsncpy_s(dirp->patt, n+1, dirname, n);
++#           else
++                n = GetFullPathNameW (dirname, n, dirp->patt, NULL);
++#           endif
++            if (n > 0) {
++                wchar_t *p;
++
++                /* Append search pattern \* to the directory name */
++                p = dirp->patt + n;
++                if (dirp->patt < p) {
++                    switch (p[-1]) {
++                    case '\\':
++                    case '/':
++                    case ':':
++                        /* Directory ends in path separator, e.g. c:\temp\ */
++                        /*NOP*/;
++                        break;
++
++                    default:
++                        /* Directory name doesn't end in path separator */
++                        *p++ = '\\';
++                    }
++                }
++                *p++ = '*';
++                *p = '\0';
++
++                /* Open directory stream and retrieve the first entry */
++                if (dirent_first (dirp)) {
++                    /* Directory stream opened successfully */
++                    error = 0;
++                } else {
++                    /* Cannot retrieve first entry */
++                    error = 1;
++                    dirent_set_errno (ENOENT);
++                }
++
++            } else {
++                /* Cannot retrieve full path name */
++                dirent_set_errno (ENOENT);
++                error = 1;
++            }
++
++        } else {
++            /* Cannot allocate memory for search pattern */
++            error = 1;
++        }
++
++    } else {
++        /* Cannot allocate _WDIR structure */
++        error = 1;
++    }
++
++    /* Clean up in case of error */
++    if (error  &&  dirp) {
++        _wclosedir (dirp);
++        dirp = NULL;
++    }
++
++    return dirp;
++}
++
++/*
++ * Read next directory entry.
++ *
++ * Returns pointer to static directory entry which may be overwritten by
++ * subsequent calls to _wreaddir().
++ */
++static struct _wdirent*
++_wreaddir(
++    _WDIR *dirp)
++{
++    struct _wdirent *entry;
++
++    /*
++     * Read directory entry to buffer.  We can safely ignore the return value
++     * as entry will be set to NULL in case of error.
++     */
++    (void) _wreaddir_r (dirp, &dirp->ent, &entry);
++
++    /* Return pointer to statically allocated directory entry */
++    return entry;
++}
++
++/*
++ * Read next directory entry.
++ *
++ * Returns zero on success.  If end of directory stream is reached, then sets
++ * result to NULL and returns zero.
++ */
++static int
++_wreaddir_r(
++    _WDIR *dirp,
++    struct _wdirent *entry,
++    struct _wdirent **result)
++{
++    WIN32_FIND_DATAW *datap;
++
++    /* Read next directory entry */
++    datap = dirent_next (dirp);
++    if (datap) {
++        size_t n;
++        DWORD attr;
++
++        /*
++         * Copy file name as wide-character string.  If the file name is too
++         * long to fit in to the destination buffer, then truncate file name
++         * to PATH_MAX characters and zero-terminate the buffer.
++         */
++        n = 0;
++        while (n < PATH_MAX  &&  datap->cFileName[n] != 0) {
++            entry->d_name[n] = datap->cFileName[n];
++            n++;
++        }
++        entry->d_name[n] = 0;
++
++        /* Length of file name excluding zero terminator */
++        entry->d_namlen = n;
++
++        /* File type */
++        attr = datap->dwFileAttributes;
++        if ((attr & FILE_ATTRIBUTE_DEVICE) != 0) {
++            entry->d_type = DT_CHR;
++        } else if ((attr & FILE_ATTRIBUTE_DIRECTORY) != 0) {
++            entry->d_type = DT_DIR;
++        } else {
++            entry->d_type = DT_REG;
++        }
++
++        /* Reset dummy fields */
++        entry->d_ino = 0;
++        entry->d_off = 0;
++        entry->d_reclen = sizeof (struct _wdirent);
++
++        /* Set result address */
++        *result = entry;
++
++    } else {
++
++        /* Return NULL to indicate end of directory */
++        *result = NULL;
++
++    }
++
++    return /*OK*/0;
++}
++
++/*
++ * Close directory stream opened by opendir() function.  This invalidates the
++ * DIR structure as well as any directory entry read previously by
++ * _wreaddir().
++ */
++static int
++_wclosedir(
++    _WDIR *dirp)
++{
++    int ok;
++    if (dirp) {
++
++        /* Release search handle */
++        if (dirp->handle != INVALID_HANDLE_VALUE) {
++            FindClose (dirp->handle);
++            dirp->handle = INVALID_HANDLE_VALUE;
++        }
++
++        /* Release search pattern */
++        if (dirp->patt) {
++            free (dirp->patt);
++            dirp->patt = NULL;
++        }
++
++        /* Release directory structure */
++        free (dirp);
++        ok = /*success*/0;
++
++    } else {
++
++        /* Invalid directory stream */
++        dirent_set_errno (EBADF);
++        ok = /*failure*/-1;
++
++    }
++    return ok;
++}
++
++/*
++ * Rewind directory stream such that _wreaddir() returns the very first
++ * file name again.
++ */
++static void
++_wrewinddir(
++    _WDIR* dirp)
++{
++    if (dirp) {
++        /* Release existing search handle */
++        if (dirp->handle != INVALID_HANDLE_VALUE) {
++            FindClose (dirp->handle);
++        }
++
++        /* Open new search handle */
++        dirent_first (dirp);
++    }
++}
++
++/* Get first directory entry (internal) */
++static WIN32_FIND_DATAW*
++dirent_first(
++    _WDIR *dirp)
++{
++    WIN32_FIND_DATAW *datap;
++
++    /* Open directory and retrieve the first entry */
++    dirp->handle = FindFirstFileExW(
++        dirp->patt, FindExInfoStandard, &dirp->data,
++        FindExSearchNameMatch, NULL, 0);
++    if (dirp->handle != INVALID_HANDLE_VALUE) {
++
++        /* a directory entry is now waiting in memory */
++        datap = &dirp->data;
++        dirp->cached = 1;
++
++    } else {
++
++        /* Failed to re-open directory: no directory entry in memory */
++        dirp->cached = 0;
++        datap = NULL;
++
++    }
++    return datap;
++}
++
++/*
++ * Get next directory entry (internal).
++ *
++ * Returns
++ */
++static WIN32_FIND_DATAW*
++dirent_next(
++    _WDIR *dirp)
++{
++    WIN32_FIND_DATAW *p;
++
++    /* Get next directory entry */
++    if (dirp->cached != 0) {
++
++        /* A valid directory entry already in memory */
++        p = &dirp->data;
++        dirp->cached = 0;
++
++    } else if (dirp->handle != INVALID_HANDLE_VALUE) {
++
++        /* Get the next directory entry from stream */
++        if (FindNextFileW (dirp->handle, &dirp->data) != FALSE) {
++            /* Got a file */
++            p = &dirp->data;
++        } else {
++            /* The very last entry has been processed or an error occurred */
++            FindClose (dirp->handle);
++            dirp->handle = INVALID_HANDLE_VALUE;
++            p = NULL;
++        }
++
++    } else {
++
++        /* End of directory stream reached */
++        p = NULL;
++
++    }
++
++    return p;
++}
++
++/*
++ * Open directory stream using plain old C-string.
++ */
++static DIR*
++opendir(
++    const char *dirname)
++{
++    struct DIR *dirp;
++    int error;
++
++    /* Must have directory name */
++    if (dirname == NULL  ||  dirname[0] == '\0') {
++        dirent_set_errno (ENOENT);
++        return NULL;
++    }
++
++    /* Allocate memory for DIR structure */
++    dirp = (DIR*) malloc (sizeof (struct DIR));
++    if (dirp) {
++        wchar_t wname[PATH_MAX + 1];
++        size_t n;
++
++        /* Convert directory name to wide-character string */
++        error = dirent_mbstowcs_s(
++            &n, wname, PATH_MAX + 1, dirname, PATH_MAX + 1);
++        if (!error) {
++
++            /* Open directory stream using wide-character name */
++            dirp->wdirp = _wopendir (wname);
++            if (dirp->wdirp) {
++                /* Directory stream opened */
++                error = 0;
++            } else {
++                /* Failed to open directory stream */
++                error = 1;
++            }
++
++        } else {
++            /*
++             * Cannot convert file name to wide-character string.  This
++             * occurs if the string contains invalid multi-byte sequences or
++             * the output buffer is too small to contain the resulting
++             * string.
++             */
++            error = 1;
++        }
++
++    } else {
++        /* Cannot allocate DIR structure */
++        error = 1;
++    }
++
++    /* Clean up in case of error */
++    if (error  &&  dirp) {
++        free (dirp);
++        dirp = NULL;
++    }
++
++    return dirp;
++}
++
++/*
++ * Read next directory entry.
++ */
++static struct dirent*
++readdir(
++    DIR *dirp)
++{
++    struct dirent *entry;
++
++    /*
++     * Read directory entry to buffer.  We can safely ignore the return value
++     * as entry will be set to NULL in case of error.
++     */
++    (void) readdir_r (dirp, &dirp->ent, &entry);
++
++    /* Return pointer to statically allocated directory entry */
++    return entry;
++}
++
++/*
++ * Read next directory entry into called-allocated buffer.
++ *
++ * Returns zero on success.  If the end of directory stream is reached, then
++ * sets result to NULL and returns zero.
++ */
++static int
++readdir_r(
++    DIR *dirp,
++    struct dirent *entry,
++    struct dirent **result)
++{
++    WIN32_FIND_DATAW *datap;
++
++    /* Read next directory entry */
++    datap = dirent_next (dirp->wdirp);
++    if (datap) {
++        size_t n;
++        int error;
++
++        /* Attempt to convert file name to multi-byte string */
++        error = dirent_wcstombs_s(
++            &n, entry->d_name, PATH_MAX + 1, datap->cFileName, PATH_MAX + 1);
++
++        /*
++         * If the file name cannot be represented by a multi-byte string,
++         * then attempt to use old 8+3 file name.  This allows traditional
++         * Unix-code to access some file names despite of unicode
++         * characters, although file names may seem unfamiliar to the user.
++         *
++         * Be ware that the code below cannot come up with a short file
++         * name unless the file system provides one.  At least
++         * VirtualBox shared folders fail to do this.
++         */
++        if (error  &&  datap->cAlternateFileName[0] != '\0') {
++            error = dirent_wcstombs_s(
++                &n, entry->d_name, PATH_MAX + 1,
++                datap->cAlternateFileName, PATH_MAX + 1);
++        }
++
++        if (!error) {
++            DWORD attr;
++
++            /* Length of file name excluding zero terminator */
++            entry->d_namlen = n - 1;
++
++            /* File attributes */
++            attr = datap->dwFileAttributes;
++            if ((attr & FILE_ATTRIBUTE_DEVICE) != 0) {
++                entry->d_type = DT_CHR;
++            } else if ((attr & FILE_ATTRIBUTE_DIRECTORY) != 0) {
++                entry->d_type = DT_DIR;
++            } else {
++                entry->d_type = DT_REG;
++            }
++
++            /* Reset dummy fields */
++            entry->d_ino = 0;
++            entry->d_off = 0;
++            entry->d_reclen = sizeof (struct dirent);
++
++        } else {
++
++            /*
++             * Cannot convert file name to multi-byte string so construct
++             * an erroneous directory entry and return that.  Note that
++             * we cannot return NULL as that would stop the processing
++             * of directory entries completely.
++             */
++            entry->d_name[0] = '?';
++            entry->d_name[1] = '\0';
++            entry->d_namlen = 1;
++            entry->d_type = DT_UNKNOWN;
++            entry->d_ino = 0;
++            entry->d_off = -1;
++            entry->d_reclen = 0;
++
++        }
++
++        /* Return pointer to directory entry */
++        *result = entry;
++
++    } else {
++
++        /* No more directory entries */
++        *result = NULL;
++
++    }
++
++    return /*OK*/0;
++}
++
++/*
++ * Close directory stream.
++ */
++static int
++closedir(
++    DIR *dirp)
++{
++    int ok;
++    if (dirp) {
++
++        /* Close wide-character directory stream */
++        ok = _wclosedir (dirp->wdirp);
++        dirp->wdirp = NULL;
++
++        /* Release multi-byte character version */
++        free (dirp);
++
++    } else {
++
++        /* Invalid directory stream */
++        dirent_set_errno (EBADF);
++        ok = /*failure*/-1;
++
++    }
++    return ok;
++}
++
++/*
++ * Rewind directory stream to beginning.
++ */
++static void
++rewinddir(
++    DIR* dirp)
++{
++    /* Rewind wide-character string directory stream */
++    _wrewinddir (dirp->wdirp);
++}
++
++/*
++ * Scan directory for entries.
++ */
++static int
++scandir(
++    const char *dirname,
++    struct dirent ***namelist,
++    int (*filter)(const struct dirent*),
++    int (*compare)(const struct dirent**, const struct dirent**))
++{
++    struct dirent **files = NULL;
++    size_t size = 0;
++    size_t allocated = 0;
++    const size_t init_size = 1;
++    DIR *dir = NULL;
++    struct dirent *entry;
++    struct dirent *tmp = NULL;
++    size_t i;
++    int result = 0;
++
++    /* Open directory stream */
++    dir = opendir (dirname);
++    if (dir) {
++
++        /* Read directory entries to memory */
++        while (1) {
++
++            /* Enlarge pointer table to make room for another pointer */
++            if (size >= allocated) {
++                void *p;
++                size_t num_entries;
++
++                /* Compute number of entries in the enlarged pointer table */
++                if (size < init_size) {
++                    /* Allocate initial pointer table */
++                    num_entries = init_size;
++                } else {
++                    /* Double the size */
++                    num_entries = size * 2;
++                }
++
++                /* Allocate first pointer table or enlarge existing table */
++                p = realloc (files, sizeof (void*) * num_entries);
++                if (p != NULL) {
++                    /* Got the memory */
++                    files = (dirent**) p;
++                    allocated = num_entries;
++                } else {
++                    /* Out of memory */
++                    result = -1;
++                    break;
++                }
++
++            }
++
++            /* Allocate room for temporary directory entry */
++            if (tmp == NULL) {
++                tmp = (struct dirent*) malloc (sizeof (struct dirent));
++                if (tmp == NULL) {
++                    /* Cannot allocate temporary directory entry */
++                    result = -1;
++                    break;
++                }
++            }
++
++            /* Read directory entry to temporary area */
++            if (readdir_r (dir, tmp, &entry) == /*OK*/0) {
++
++                /* Did we get an entry? */
++                if (entry != NULL) {
++                    int pass;
++
++                    /* Determine whether to include the entry in result */
++                    if (filter) {
++                        /* Let the filter function decide */
++                        pass = filter (tmp);
++                    } else {
++                        /* No filter function, include everything */
++                        pass = 1;
++                    }
++
++                    if (pass) {
++                        /* Store the temporary entry to pointer table */
++                        files[size++] = tmp;
++                        tmp = NULL;
++
++                        /* Keep up with the number of files */
++                        result++;
++                    }
++
++                } else {
++
++                    /*
++                     * End of directory stream reached => sort entries and
++                     * exit.
++                     */
++                    qsort (files, size, sizeof (void*),
++                        (int (*) (const void*, const void*)) compare);
++                    break;
++
++                }
++
++            } else {
++                /* Error reading directory entry */
++                result = /*Error*/ -1;
++                break;
++            }
++
++        }
++
++    } else {
++        /* Cannot open directory */
++        result = /*Error*/ -1;
++    }
++
++    /* Release temporary directory entry */
++    if (tmp) {
++        free (tmp);
++    }
++
++    /* Release allocated memory on error */
++    if (result < 0) {
++        for (i = 0; i < size; i++) {
++            free (files[i]);
++        }
++        free (files);
++        files = NULL;
++    }
++
++    /* Close directory stream */
++    if (dir) {
++        closedir (dir);
++    }
++
++    /* Pass pointer table to caller */
++    if (namelist) {
++        *namelist = files;
++    }
++    return result;
++}
++
++/* Alphabetical sorting */
++static int
++alphasort(
++    const struct dirent **a, const struct dirent **b)
++{
++    return strcoll ((*a)->d_name, (*b)->d_name);
++}
++
++/* Sort versions */
++static int
++versionsort(
++    const struct dirent **a, const struct dirent **b)
++{
++    /* FIXME: implement strverscmp and use that */
++    return alphasort (a, b);
++}
++
++/* Convert multi-byte string to wide character string */
++static int
++dirent_mbstowcs_s(
++    size_t *pReturnValue,
++    wchar_t *wcstr,
++    size_t sizeInWords,
++    const char *mbstr,
++    size_t count)
++{
++    int error;
++    int n;
++    size_t len;
++    UINT cp;
++    DWORD flags;
++
++    /* Determine code page for multi-byte string */
++    if (AreFileApisANSI ()) {
++        /* Default ANSI code page */
++        cp = GetACP ();
++    } else {
++        /* Default OEM code page */
++        cp = GetOEMCP ();
++    }
++
++    /*
++     * Determine flags based on the character set.  For more information,
++     * please see https://docs.microsoft.com/fi-fi/windows/desktop/api/stringapiset/nf-stringapiset-multibytetowidechar
++     */
++    switch (cp) {
++    case 42:
++    case 50220:
++    case 50221:
++    case 50222:
++    case 50225:
++    case 50227:
++    case 50229:
++    case 57002:
++    case 57003:
++    case 57004:
++    case 57005:
++    case 57006:
++    case 57007:
++    case 57008:
++    case 57009:
++    case 57010:
++    case 57011:
++    case 65000:
++        /* MultiByteToWideChar does not support MB_ERR_INVALID_CHARS */
++        flags = 0;
++        break;
++
++    default:
++        /*
++         * Ask MultiByteToWideChar to return an error if a multi-byte
++         * character cannot be converted to a wide-character.
++         */
++        flags = MB_ERR_INVALID_CHARS;
++    }
++
++    /* Compute the length of input string without zero-terminator */
++    len = 0;
++    while (mbstr[len] != '\0'  &&  len < count) {
++        len++;
++    }
++
++    /* Convert to wide-character string */
++    n = MultiByteToWideChar(
++        /* Source code page */ cp,
++        /* Flags */ flags,
++        /* Pointer to string to convert */ mbstr,
++        /* Size of multi-byte string */ (int) len,
++        /* Pointer to output buffer */ wcstr,
++        /* Size of output buffer */ (int)sizeInWords - 1
++    );
++
++    /* Ensure that output buffer is zero-terminated */
++    wcstr[n] = '\0';
++
++    /* Return length of wide-character string with zero-terminator */
++    *pReturnValue = (size_t) (n + 1);
++
++    /* Return zero if conversion succeeded */
++    if (n > 0) {
++        error = 0;
++    } else {
++        error = 1;
++    }
++    return error;
++}
++
++/* Convert wide-character string to multi-byte string */
++static int
++dirent_wcstombs_s(
++    size_t *pReturnValue,
++    char *mbstr,
++    size_t sizeInBytes, /* max size of mbstr */
++    const wchar_t *wcstr,
++    size_t count)
++{
++    int n;
++    int error;
++    UINT cp;
++    size_t len;
++    BOOL flag = 0;
++    LPBOOL pflag;
++
++    /* Determine code page for multi-byte string */
++    if (AreFileApisANSI ()) {
++        /* Default ANSI code page */
++        cp = GetACP ();
++    } else {
++        /* Default OEM code page */
++        cp = GetOEMCP ();
++    }
++
++    /* Compute the length of input string without zero-terminator */
++    len = 0;
++    while (wcstr[len] != '\0'  &&  len < count) {
++        len++;
++    }
++
++    /*
++     * Determine if we can ask WideCharToMultiByte to return information on
++     * broken characters.  For more information, please see
++     * https://docs.microsoft.com/en-us/windows/desktop/api/stringapiset/nf-stringapiset-widechartomultibyte
++     */
++    switch (cp) {
++    case CP_UTF7:
++    case CP_UTF8:
++        /*
++         * WideCharToMultiByte fails if we request information on default
++         * characters.  This is just a nuisance but doesn't affect the
++         * conversion: if Windows is configured to use UTF-8, then the default
++         * character should not be needed anyway.
++         */
++        pflag = NULL;
++        break;
++
++    default:
++        /*
++         * Request that WideCharToMultiByte sets the flag if it uses the
++         * default character.
++         */
++        pflag = &flag;
++    }
++
++    /* Convert wide-character string to multi-byte character string */
++    n = WideCharToMultiByte(
++        /* Target code page */ cp,
++        /* Flags */ 0,
++        /* Pointer to unicode string */ wcstr,
++        /* Length of unicode string */ (int) len,
++        /* Pointer to output buffer */ mbstr,
++        /* Size of output buffer */ (int)sizeInBytes - 1,
++        /* Default character */ NULL,
++        /* Whether default character was used or not */ pflag
++    );
++
++    /* Ensure that output buffer is zero-terminated */
++    mbstr[n] = '\0';
++
++    /* Return length of multi-byte string with zero-terminator */
++    *pReturnValue = (size_t) (n + 1);
++
++    /* Return zero if conversion succeeded without using default characters */
++    if (n > 0  &&  flag == 0) {
++        error = 0;
++    } else {
++        error = 1;
++    }
++    return error;
++}
++
++/* Set errno variable */
++static void
++dirent_set_errno(
++    int error)
++{
++#if defined(_MSC_VER)  &&  _MSC_VER >= 1400
++
++    /* Microsoft Visual Studio 2005 and later */
++    _set_errno (error);
++
++#else
++
++    /* Non-Microsoft compiler or older Microsoft compiler */
++    errno = error;
++
++#endif
++}
++
++
++#ifdef __cplusplus
++}
++#endif
++#endif /*DIRENT_H*/
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/windows/rclstartw.cpp b/recoll-1.43.14/windows/rclstartw.cpp
+--- a/recoll-1.43.14/windows/rclstartw.cpp	1970-01-01 01:00:00.000000000 +0100
++++ b/recoll-1.43.14/windows/rclstartw.cpp	2026-04-06 01:31:34.682153764 +0200
+@@ -0,0 +1,94 @@
++/* Copyright (C) 2015 J.F.Dockes
++ *   This program is free software; you can redistribute it and/or modify
++ *   it under the terms of the GNU General Public License as published by
++ *   the Free Software Foundation; either version 2 of the License, or
++ *   (at your option) any later version.
++ *
++ *   This program is distributed in the hope that it will be useful,
++ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *   GNU General Public License for more details.
++ *
++ *   You should have received a copy of the GNU General Public License
++ *   along with this program; if not, write to the
++ *   Free Software Foundation, Inc.,
++ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
++ */
++
++#define WIN32_LEAN_AND_MEAN
++#define NOGDI
++#include <windows.h>
++
++#include <shellapi.h>
++#include <cstdio>
++#include <cstdlib>
++#include <iostream>
++
++#include "pathut.h"
++
++using namespace std;
++
++// This exists only because I could not find any way to get "cmd /c
++// start fn" to work when executed from the recoll GUI. Otoh,
++// cygstart, which uses ShellExecute() did work... So this is just a
++// simpler cygstart
++static char *thisprog;
++static char usage [] ="rclstartw [-m] <fn>\n" 
++    "   Will use ShellExecute to open the arg with the default app\n"
++    "    -m 1 start maximized\n";
++
++static void Usage(FILE *fp = stderr)
++{
++    fprintf(fp, "%s: usage:\n%s", thisprog, usage);
++    exit(1);
++}
++int op_flags;
++#define OPT_m 0x1
++
++int main(int argc, char *argv[])
++{
++    int wargc;
++    wchar_t **wargv = CommandLineToArgvW(GetCommandLineW(), &wargc);
++
++    // Yes we could use wargv
++    thisprog = argv[0];
++    argc--; argv++;
++    int imode = 0;
++    while (argc > 0 && **argv == '-') {
++    (*argv)++;
++    if (!(**argv))
++        Usage();
++    while (**argv)
++        switch (*(*argv)++) {
++        case 'm':    op_flags |= OPT_m; if (argc < 2)  Usage();
++        if ((sscanf(*(++argv), "%d", &imode)) != 1) 
++            Usage(); 
++        argc--; goto b1;
++        default: Usage(); break;
++        }
++    b1: argc--; argv++;
++    }
++
++    if (argc != 1) {
++        Usage();
++    }
++
++    wchar_t *wfn = wargv[1];
++
++    // Do we need this ?
++    //https://msdn.microsoft.com/en-us/library/windows/desktop/bb762153%28v=vs.85%29.aspx
++    //CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
++
++    int wmode = SW_SHOWNORMAL;
++    switch (imode) {
++    case 1: wmode = SW_SHOWMAXIMIZED;break;
++    default: wmode = SW_SHOWNORMAL;  break;
++    }
++    
++    auto ret = ShellExecuteW(nullptr, L"open", wfn, nullptr, nullptr, wmode);
++    if ((INT_PTR)ret <= 32) {
++        std::cerr << "ShellExecuteW returned " << (INT_PTR)ret << "\n";
++    }
++    LocalFree(wargv);
++    return ((INT_PTR)ret <= 32) ? 1 : 0;
++}
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/windows/recoll.conf b/recoll-1.43.14/windows/recoll.conf
+--- a/recoll-1.43.14/windows/recoll.conf	1970-01-01 01:00:00.000000000 +0100
++++ b/recoll-1.43.14/windows/recoll.conf	2026-04-06 01:31:34.682153764 +0200
+@@ -0,0 +1,18 @@
++# (C) 2023 J.F.Dockes
++
++#
++# MS-WINDOWS specific definitions for recoll.conf
++#
++
++# Replace the default '~' which is confusing for Windows user. path_tildexpand() very narrowly
++# processes %USERPROFILE% (just replace it with ~ at the start of a value).
++topdirs = %USERPROFILE%
++
++# We used to have no way to identify files without a suffix, or with an unknown one on
++# Windows. Circa recoll 1.34.2, a libmagic port was used and it became possible. Still the change
++# has a great surprise potential, too much for a minor release. For now default to not using
++# identification from data.
++usesystemfilecommand = 0
++
++# /media which is the default on Linux makes no sense on Windows
++skippedPaths =
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/windows/recoll-setup.iss b/recoll-1.43.14/windows/recoll-setup.iss
+--- a/recoll-1.43.14/windows/recoll-setup.iss	1970-01-01 01:00:00.000000000 +0100
++++ b/recoll-1.43.14/windows/recoll-setup.iss	2026-04-06 01:31:34.682153764 +0200
+@@ -0,0 +1,88 @@
++; Script generated by the Inno Setup Script Wizard.
++; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
++
++#define MyAppName "Recoll"
++#define MyAppVersion "1.43.13-20260223-qt_6_8_2-5979e72a"
++#define MyAppPublisher "Recoll.org"
++#define MyAppURL "http://www.recoll.org"
++#define MyAppExeName "recoll.exe"
++#define IdxAppName "Recollindex background indexer"
++#define IdxAppExeName "recollindex.exe"
++
++[Setup]
++; NOTE: The value of AppId uniquely identifies this application.
++; Do not use the same AppId value in installers for other applications.
++; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
++AppId={{E9BC39EC-0E3D-4DDA-8DA0-FDB8ED16DC8D}
++AppName={#MyAppName}
++AppVersion={#MyAppVersion}
++;AppVerName={#MyAppName} {#MyAppVersion}
++AppPublisher={#MyAppPublisher}
++AppPublisherURL={#MyAppURL}
++AppSupportURL={#MyAppURL}
++AppUpdatesURL={#MyAppURL}
++ArchitecturesInstallIn64BitMode=x64compatible
++ArchitecturesAllowed=x64compatible
++DefaultGroupName={#MyAppName}
++OutputDir=C:\Temp
++Compression=lzma
++SolidCompression=yes
++;; Use either prv=adm and defaultdir={pf} or prv=lowest and defaultdir=userpf
++;PrivilegesRequired=lowest
++;DefaultDirName={userpf}\{#MyAppName}
++PrivilegesRequired=admin
++DefaultDirName={commonpf}\{#MyAppName}
++LicenseFile=D:\install\recoll\COPYING.txt
++OutputBaseFilename=recoll-setup-{#MyAppVersion}
++SetupIconFile=D:\install\recoll\Share\recoll.ico
++
++[Languages]
++Name: "english"; MessagesFile: "compiler:Default.isl"
++
++[Tasks]
++Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
++
++[Files]
++; VC++ redistributable runtime. Extracted by VC2017RedistNeedsInstall(), if needed.
++Source: "D:\install\recoll\Share\dist\VC_redist.x64.exe"; DestDir: {tmp}; Flags: dontcopy
++; NOTE: Don't use "Flags: ignoreversion" on any shared system files
++Source: "D:\install\recoll\recoll.exe"; DestDir: "{app}"; Flags: ignoreversion
++Source: "D:\install\recoll\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
++
++[Icons]
++Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
++Name: "{group}\{#IdxAppName}"; Filename: "{app}\{#IdxAppExeName}"; IconFilename: "{app}\{#MyAppExeName}"; Parameters: "-m -w 0"; Flags: runminimized preventpinning
++Name: "{commondesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
++
++[CustomMessages]
++InstallingVCredist=Installing Microsoft VC++ redistributable
++
++[Run]
++Filename: "{tmp}\VC_redist.x64.exe"; \
++  StatusMsg: "{cm:InstallingVCredist}"; \
++  Parameters: "/quiet"; Check: VCRedistNeedsInstall; Flags: waituntilterminated
++Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
++
++[Code]
++function VCRedistNeedsInstall: Boolean;
++var 
++  Version: String;
++begin
++  if RegQueryStringValue(HKEY_LOCAL_MACHINE,
++       'SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64', 'Version',
++       Version) then
++  begin
++    // Is the installed version at least ours ? 
++    Log('VC Redist Version check : found ' + Version);
++    Result := (CompareStr(Version, 'v14.42.34438.00')<0);
++  end
++  else 
++  begin
++    // Not even an old version installed
++    Result := True;
++  end;
++  if (Result) then
++  begin
++    ExtractTemporaryFile('VC_redist.x64.exe');
++  end;
++end;
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/windows/strptime.cpp b/recoll-1.43.14/windows/strptime.cpp
+--- a/recoll-1.43.14/windows/strptime.cpp	1970-01-01 01:00:00.000000000 +0100
++++ b/recoll-1.43.14/windows/strptime.cpp	2026-04-06 01:31:34.682153764 +0200
+@@ -0,0 +1,253 @@
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++#include <time.h>
++#include <ctype.h>
++
++const char * strp_weekdays[] =
++{ "sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday" };
++const char * strp_monthnames[] =
++{ "january", "february", "march", "april", "may", "june", "july", "august", "september", "october", "november", "december" };
++bool strp_atoi(const char * & s, int & result, int low, int high, int offset)
++{
++    bool worked = false;
++    char * end;
++    unsigned long num = strtoul(s, &end, 10);
++    if (num >= (unsigned long)low && num <= (unsigned long)high)
++    {
++        result = (int)(num + offset);
++        s = end;
++        worked = true;
++    }
++    return worked;
++}
++char * strptime(const char *s, const char *format, struct tm *tm)
++{
++    bool working = true;
++    while (working && *format && *s)
++    {
++        switch (*format)
++        {
++        case '%':
++        {
++            ++format;
++            switch (*format)
++            {
++            case 'a':
++            case 'A': // weekday name
++                tm->tm_wday = -1;
++                working = false;
++                for (int i = 0; i < 7; ++i)
++                {
++                    size_t len = strlen(strp_weekdays[i]);
++                    if (!strnicmp(strp_weekdays[i], s, len))
++                    {
++                        tm->tm_wday = i;
++                        s += len;
++                        working = true;
++                        break;
++                    }
++                    else if (!strnicmp(strp_weekdays[i], s, 3))
++                    {
++                        tm->tm_wday = i;
++                        s += 3;
++                        working = true;
++                        break;
++                    }
++                }
++                break;
++            case 'b':
++            case 'B':
++            case 'h': // month name
++                tm->tm_mon = -1;
++                working = false;
++                for (int i = 0; i < 12; ++i)
++                {
++                    size_t len = strlen(strp_monthnames[i]);
++                    if (!strnicmp(strp_monthnames[i], s, len))
++                    {
++                        tm->tm_mon = i;
++                        s += len;
++                        working = true;
++                        break;
++                    }
++                    else if (!strnicmp(strp_monthnames[i], s, 3))
++                    {
++                        tm->tm_mon = i;
++                        s += 3;
++                        working = true;
++                        break;
++                    }
++                }
++                break;
++            case 'd':
++            case 'e': // day of month number
++                working = strp_atoi(s, tm->tm_mday, 1, 31, 0);
++                break;
++            case 'D': // %m/%d/%y
++            {
++                const char * s_save = s;
++                working = strp_atoi(s, tm->tm_mon, 1, 12, -1);
++                if (working && *s == '/')
++                {
++                    ++s;
++                    working = strp_atoi(s, tm->tm_mday, 1, 31, 0);
++                    if (working && *s == '/')
++                    {
++                        ++s;
++                        working = strp_atoi(s, tm->tm_year, 0, 99, 0);
++                        if (working && tm->tm_year < 69)
++                            tm->tm_year += 100;
++                    }
++                }
++                if (!working)
++                    s = s_save;
++            }
++            break;
++            case 'H': // hour
++                working = strp_atoi(s, tm->tm_hour, 0, 23, 0);
++                break;
++            case 'I': // hour 12-hour clock
++                working = strp_atoi(s, tm->tm_hour, 1, 12, 0);
++                break;
++            case 'j': // day number of year
++                working = strp_atoi(s, tm->tm_yday, 1, 366, -1);
++                break;
++            case 'm': // month number
++                working = strp_atoi(s, tm->tm_mon, 1, 12, -1);
++                break;
++            case 'M': // minute
++                working = strp_atoi(s, tm->tm_min, 0, 59, 0);
++                break;
++            case 'n': // arbitrary whitespace
++            case 't':
++                while (isspace((int)*s))
++                    ++s;
++                break;
++            case 'p': // am / pm
++                if (!strnicmp(s, "am", 2))
++                { // the hour will be 1 -> 12 maps to 12 am, 1 am .. 11 am, 12 noon 12 pm .. 11 pm
++                    if (tm->tm_hour == 12) // 12 am == 00 hours
++                        tm->tm_hour = 0;
++                }
++                else if (!strnicmp(s, "pm", 2))
++                {
++                    if (tm->tm_hour < 12) // 12 pm == 12 hours
++                        tm->tm_hour += 12; // 1 pm -> 13 hours, 11 pm -> 23 hours
++                }
++                else
++                    working = false;
++                break;
++            case 'r': // 12 hour clock %I:%M:%S %p
++            {
++                const char * s_save = s;
++                working = strp_atoi(s, tm->tm_hour, 1, 12, 0);
++                if (working && *s == ':')
++                {
++                    ++s;
++                    working = strp_atoi(s, tm->tm_min, 0, 59, 0);
++                    if (working && *s == ':')
++                    {
++                        ++s;
++                        working = strp_atoi(s, tm->tm_sec, 0, 60, 0);
++                        if (working && isspace((int)*s))
++                        {
++                            ++s;
++                            while (isspace((int)*s))
++                                ++s;
++                            if (!strnicmp(s, "am", 2))
++                            { // the hour will be 1 -> 12 maps to 12 am, 1 am .. 11 am, 12 noon 12 pm .. 11 pm
++                                if (tm->tm_hour == 12) // 12 am == 00 hours
++                                    tm->tm_hour = 0;
++                            }
++                            else if (!strnicmp(s, "pm", 2))
++                            {
++                                if (tm->tm_hour < 12) // 12 pm == 12 hours
++                                    tm->tm_hour += 12; // 1 pm -> 13 hours, 11 pm -> 23 hours
++                            }
++                            else
++                                working = false;
++                        }
++                    }
++                }
++                if (!working)
++                    s = s_save;
++            }
++            break;
++            case 'R': // %H:%M
++            {
++                const char * s_save = s;
++                working = strp_atoi(s, tm->tm_hour, 0, 23, 0);
++                if (working && *s == ':')
++                {
++                    ++s;
++                    working = strp_atoi(s, tm->tm_min, 0, 59, 0);
++                }
++                if (!working)
++                    s = s_save;
++            }
++            break;
++            case 'S': // seconds
++                working = strp_atoi(s, tm->tm_sec, 0, 60, 0);
++                break;
++            case 'T': // %H:%M:%S
++            {
++                const char * s_save = s;
++                working = strp_atoi(s, tm->tm_hour, 0, 23, 0);
++                if (working && *s == ':')
++                {
++                    ++s;
++                    working = strp_atoi(s, tm->tm_min, 0, 59, 0);
++                    if (working && *s == ':')
++                    {
++                        ++s;
++                        working = strp_atoi(s, tm->tm_sec, 0, 60, 0);
++                    }
++                }
++                if (!working)
++                    s = s_save;
++            }
++            break;
++            case 'w': // weekday number 0->6 sunday->saturday
++                working = strp_atoi(s, tm->tm_wday, 0, 6, 0);
++                break;
++            case 'Y': // year
++                working = strp_atoi(s, tm->tm_year, 1900, 65535, -1900);
++                break;
++            case 'y': // 2-digit year
++                working = strp_atoi(s, tm->tm_year, 0, 99, 0);
++                if (working && tm->tm_year < 69)
++                    tm->tm_year += 100;
++                break;
++            case '%': // escaped
++                if (*s != '%')
++                    working = false;
++                ++s;
++                break;
++            default:
++                working = false;
++            }
++        }
++        break;
++        case ' ':
++        case '\t':
++        case '\r':
++        case '\n':
++        case '\f':
++        case '\v':
++            // zero or more whitespaces:
++            while (isspace((int)*s))
++                ++s;
++            break;
++        default:
++            // match character
++            if (*s != *format)
++                working = false;
++            else
++                ++s;
++            break;
++        }
++        ++format;
++    }
++    return (working ? (char *)s : 0);
++}
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/windows/strptime.h b/recoll-1.43.14/windows/strptime.h
+--- a/recoll-1.43.14/windows/strptime.h	1970-01-01 01:00:00.000000000 +0100
++++ b/recoll-1.43.14/windows/strptime.h	2026-04-06 01:31:34.682153764 +0200
+@@ -0,0 +1,3 @@
++
++extern char * strptime(const char *s, const char *format, struct tm *tm);
++
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/windows/targetver.h b/recoll-1.43.14/windows/targetver.h
+--- a/recoll-1.43.14/windows/targetver.h	1970-01-01 01:00:00.000000000 +0100
++++ b/recoll-1.43.14/windows/targetver.h	2026-04-06 01:31:34.682153764 +0200
+@@ -0,0 +1,8 @@
++#pragma once
++
++// Including SDKDDKVer.h defines the highest available Windows platform.
++
++// If you wish to build your application for a previous Windows platform, include WinSDKVer.h and
++// set the _WIN32_WINNT macro to the platform you wish to support before including SDKDDKVer.h.
++
++#include <SDKDDKVer.h>
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/windows/wincodepages.cpp b/recoll-1.43.14/windows/wincodepages.cpp
+--- a/recoll-1.43.14/windows/wincodepages.cpp	1970-01-01 01:00:00.000000000 +0100
++++ b/recoll-1.43.14/windows/wincodepages.cpp	2026-04-06 01:31:34.682153764 +0200
+@@ -0,0 +1,183 @@
++#include <unordered_map>
++#include <string>
++
++#define WIN32_LEAN_AND_MEAN
++#define NOGDI
++#include <windows.h>
++
++#include "wincodepages.h"
++
++using namespace std;
++
++struct WinCpDef {
++    string cpname;
++    string cpcomment;
++};
++
++static unordered_map<int, WinCpDef> cpdefs {
++    {037, {"IBM037", "IBM EBCDIC US-Canada"}},
++    {437, {"IBM437", "OEM United States"}},
++    {500, {"IBM500", "IBM EBCDIC International"}},
++    {708, {"ASMO-708", "Arabic (ASMO 708)"}},
++    {709, {"", "Arabic (ASMO-449+, BCON V4)"}},
++    {710, {"", "Arabic - Transparent Arabic"}},
++    {720, {"DOS-720", "Arabic (Transparent ASMO); Arabic (DOS)"}},
++    {737, {"ibm737", "OEM Greek (formerly 437G); Greek (DOS)"}},
++    {775, {"ibm775", "OEM Baltic; Baltic (DOS)"}},
++    {850, {"ibm850", "OEM Multilingual Latin 1; Western European (DOS)"}},
++    {852, {"ibm852", "OEM Latin 2; Central European (DOS)"}},
++    {855, {"IBM855", "OEM Cyrillic (primarily Russian)"}},
++    {857, {"ibm857", "OEM Turkish; Turkish (DOS)"}},
++    {858, {"IBM00858", "OEM Multilingual Latin 1 + Euro symbol"}},
++    {860, {"IBM860", "OEM Portuguese; Portuguese (DOS)"}},
++    {861, {"ibm861", "OEM Icelandic; Icelandic (DOS)"}},
++    {862, {"DOS-862", "OEM Hebrew; Hebrew (DOS)"}},
++    {863, {"IBM863", "OEM French Canadian; French Canadian (DOS)"}},
++    {864, {"IBM864", "OEM Arabic; Arabic (864)"}},
++    {865, {"IBM865", "OEM Nordic; Nordic (DOS)"}},
++    {866, {"cp866", "OEM Russian; Cyrillic (DOS)"}},
++    {869, {"ibm869", "OEM Modern Greek; Greek, Modern (DOS)"}},
++    {870, {"IBM870", "IBM EBCDIC Multilingual/ROECE (Latin 2); IBM EBCDIC Multilingual Latin 2"}},
++    {874, {"windows-874", "ANSI/OEM Thai (ISO 8859-11); Thai (Windows)"}},
++    {875, {"cp875", "IBM EBCDIC Greek Modern"}},
++    {932, {"shift_jis", "ANSI/OEM Japanese; Japanese (Shift-JIS)"}},
++    {936, {"gb2312", "ANSI/OEM Simplified Chinese (PRC, Singapore); Chinese Simplified (GB2312)"}},
++    {949, {"ks_c_5601-1987", "ANSI/OEM Korean (Unified Hangul Code)"}},
++    {950, {"big5", "ANSI/OEM Traditional Chinese (Taiwan; Hong Kong SAR, PRC); Chinese Traditional (Big5)"}},
++    {1026, {"IBM1026", "IBM EBCDIC Turkish (Latin 5)"}},
++    {1047, {"IBM01047", "IBM EBCDIC Latin 1/Open System"}},
++    {1140, {"IBM01140", "IBM EBCDIC US-Canada (037 + Euro symbol); IBM EBCDIC (US-Canada-Euro)"}},
++    {1141, {"IBM01141", "IBM EBCDIC Germany (20273 + Euro symbol); IBM EBCDIC (Germany-Euro)"}},
++    {1142, {"IBM01142", "IBM EBCDIC Denmark-Norway (20277 + Euro symbol); IBM EBCDIC (Denmark-Norway-Euro)"}},
++    {1143, {"IBM01143", "IBM EBCDIC Finland-Sweden (20278 + Euro symbol); IBM EBCDIC (Finland-Sweden-Euro)"}},
++    {1144, {"IBM01144", "IBM EBCDIC Italy (20280 + Euro symbol); IBM EBCDIC (Italy-Euro)"}},
++    {1145, {"IBM01145", "IBM EBCDIC Latin America-Spain (20284 + Euro symbol); IBM EBCDIC (Spain-Euro)"}},
++    {1146, {"IBM01146", "IBM EBCDIC United Kingdom (20285 + Euro symbol); IBM EBCDIC (UK-Euro)"}},
++    {1147, {"IBM01147", "IBM EBCDIC France (20297 + Euro symbol); IBM EBCDIC (France-Euro)"}},
++    {1148, {"IBM01148", "IBM EBCDIC International (500 + Euro symbol); IBM EBCDIC (International-Euro)"}},
++    {1149, {"IBM01149", "IBM EBCDIC Icelandic (20871 + Euro symbol); IBM EBCDIC (Icelandic-Euro)"}},
++    {1200, {"utf-16", "Unicode UTF-16, little endian byte order (BMP of ISO 10646); available only to managed applications"}},
++    {1201, {"unicodeFFFE", "Unicode UTF-16, big endian byte order; available only to managed applications"}},
++    {1250, {"windows-1250", "ANSI Central European; Central European (Windows)"}},
++    {1251, {"windows-1251", "ANSI Cyrillic; Cyrillic (Windows)"}},
++    {1252, {"windows-1252", "ANSI Latin 1; Western European (Windows)"}},
++    {1253, {"windows-1253", "ANSI Greek; Greek (Windows)"}},
++    {1254, {"windows-1254", "ANSI Turkish; Turkish (Windows)"}},
++    {1255, {"windows-1255", "ANSI Hebrew; Hebrew (Windows)"}},
++    {1256, {"windows-1256", "ANSI Arabic; Arabic (Windows)"}},
++    {1257, {"windows-1257", "ANSI Baltic; Baltic (Windows)"}},
++    {1258, {"windows-1258", "ANSI/OEM Vietnamese; Vietnamese (Windows)"}},
++    {1361, {"Johab", "Korean (Johab)"}},
++    {10000, {"macintosh", "MAC Roman; Western European (Mac)"}},
++    {10001, {"x-mac-japanese", "Japanese (Mac)"}},
++    {10002, {"x-mac-chinesetrad", "MAC Traditional Chinese (Big5); Chinese Traditional (Mac)"}},
++    {10003, {"x-mac-korean", "Korean (Mac)"}},
++    {10004, {"x-mac-arabic", "Arabic (Mac)"}},
++    {10005, {"x-mac-hebrew", "Hebrew (Mac)"}},
++    {10006, {"x-mac-greek", "Greek (Mac)"}},
++    {10007, {"x-mac-cyrillic", "Cyrillic (Mac)"}},
++    {10008, {"x-mac-chinesesimp", "MAC Simplified Chinese (GB 2312); Chinese Simplified (Mac)"}},
++    {10010, {"x-mac-romanian", "Romanian (Mac)"}},
++    {10017, {"x-mac-ukrainian", "Ukrainian (Mac)"}},
++    {10021, {"x-mac-thai", "Thai (Mac)"}},
++    {10029, {"x-mac-ce", "MAC Latin 2; Central European (Mac)"}},
++    {10079, {"x-mac-icelandic", "Icelandic (Mac)"}},
++    {10081, {"x-mac-turkish", "Turkish (Mac)"}},
++    {10082, {"x-mac-croatian", "Croatian (Mac)"}},
++    {12000, {"utf-32", "Unicode UTF-32, little endian byte order; available only to managed applications"}},
++    {12001, {"utf-32BE", "Unicode UTF-32, big endian byte order; available only to managed applications"}},
++    {20000, {"x-Chinese_CNS", "CNS Taiwan; Chinese Traditional (CNS)"}},
++    {20001, {"x-cp20001", "TCA Taiwan"}},
++    {20002, {"x_Chinese-Eten", "Eten Taiwan; Chinese Traditional (Eten)"}},
++    {20003, {"x-cp20003", "IBM5550 Taiwan"}},
++    {20004, {"x-cp20004", "TeleText Taiwan"}},
++    {20005, {"x-cp20005", "Wang Taiwan"}},
++    {20105, {"x-IA5", "IA5 (IRV International Alphabet No. 5, 7-bit); Western European (IA5)"}},
++    {20106, {"x-IA5-German", "IA5 German (7-bit)"}},
++    {20107, {"x-IA5-Swedish", "IA5 Swedish (7-bit)"}},
++    {20108, {"x-IA5-Norwegian", "IA5 Norwegian (7-bit)"}},
++    {20127, {"us-ascii", "US-ASCII (7-bit)"}},
++    {20261, {"x-cp20261", "T.61"}},
++    {20269, {"x-cp20269", "ISO 6937 Non-Spacing Accent"}},
++    {20273, {"IBM273", "IBM EBCDIC Germany"}},
++    {20277, {"IBM277", "IBM EBCDIC Denmark-Norway"}},
++    {20278, {"IBM278", "IBM EBCDIC Finland-Sweden"}},
++    {20280, {"IBM280", "IBM EBCDIC Italy"}},
++    {20284, {"IBM284", "IBM EBCDIC Latin America-Spain"}},
++    {20285, {"IBM285", "IBM EBCDIC United Kingdom"}},
++    {20290, {"IBM290", "IBM EBCDIC Japanese Katakana Extended"}},
++    {20297, {"IBM297", "IBM EBCDIC France"}},
++    {20420, {"IBM420", "IBM EBCDIC Arabic"}},
++    {20423, {"IBM423", "IBM EBCDIC Greek"}},
++    {20424, {"IBM424", "IBM EBCDIC Hebrew"}},
++    {20833, {"x-EBCDIC-KoreanExtended", "IBM EBCDIC Korean Extended"}},
++    {20838, {"IBM-Thai", "IBM EBCDIC Thai"}},
++    {20866, {"koi8-r", "Russian (KOI8-R); Cyrillic (KOI8-R)"}},
++    {20871, {"IBM871", "IBM EBCDIC Icelandic"}},
++    {20880, {"IBM880", "IBM EBCDIC Cyrillic Russian"}},
++    {20905, {"IBM905", "IBM EBCDIC Turkish"}},
++    {20924, {"IBM00924", "IBM EBCDIC Latin 1/Open System (1047 + Euro symbol)"}},
++    {20932, {"EUC-JP", "Japanese (JIS 0208-1990 and 0212-1990)"}},
++    {20936, {"x-cp20936", "Simplified Chinese (GB2312); Chinese Simplified (GB2312-80)"}},
++    {20949, {"x-cp20949", "Korean Wansung"}},
++    {21025, {"cp1025", "IBM EBCDIC Cyrillic Serbian-Bulgarian"}},
++    {21027, {"", "(deprecated)"}},
++    {21866, {"koi8-u", "Ukrainian (KOI8-U); Cyrillic (KOI8-U)"}},
++    {28591, {"iso-8859-1", "ISO 8859-1 Latin 1; Western European (ISO)"}},
++    {28592, {"iso-8859-2", "ISO 8859-2 Central European; Central European (ISO)"}},
++    {28593, {"iso-8859-3", "ISO 8859-3 Latin 3"}},
++    {28594, {"iso-8859-4", "ISO 8859-4 Baltic"}},
++    {28595, {"iso-8859-5", "ISO 8859-5 Cyrillic"}},
++    {28596, {"iso-8859-6", "ISO 8859-6 Arabic"}},
++    {28597, {"iso-8859-7", "ISO 8859-7 Greek"}},
++    {28598, {"iso-8859-8", "ISO 8859-8 Hebrew; Hebrew (ISO-Visual)"}},
++    {28599, {"iso-8859-9", "ISO 8859-9 Turkish"}},
++    {28603, {"iso-8859-13", "ISO 8859-13 Estonian"}},
++    {28605, {"iso-8859-15", "ISO 8859-15 Latin 9"}},
++    {29001, {"x-Europa", "Europa 3"}},
++    {38598, {"iso-8859-8-i", "ISO 8859-8 Hebrew; Hebrew (ISO-Logical)"}},
++    {50220, {"iso-2022-jp", "ISO 2022 Japanese with no halfwidth Katakana; Japanese (JIS)"}},
++    {50221, {"csISO2022JP", "ISO 2022 Japanese with halfwidth Katakana; Japanese (JIS-Allow 1 byte Kana)"}},
++    {50222, {"iso-2022-jp", "ISO 2022 Japanese JIS X 0201-1989; Japanese (JIS-Allow 1 byte Kana - SO/SI)"}},
++    {50225, {"iso-2022-kr", "ISO 2022 Korean"}},
++    {50227, {"x-cp50227", "ISO 2022 Simplified Chinese; Chinese Simplified (ISO 2022)"}},
++    {50229, {"", "ISO 2022 Traditional Chinese"}},
++    {50930, {"", "EBCDIC Japanese (Katakana) Extended"}},
++    {50931, {"", "EBCDIC US-Canada and Japanese"}},
++    {50933, {"", "EBCDIC Korean Extended and Korean"}},
++    {50935, {"", "EBCDIC Simplified Chinese Extended and Simplified Chinese"}},
++    {50936, {"", "EBCDIC Simplified Chinese"}},
++    {50937, {"", "EBCDIC US-Canada and Traditional Chinese"}},
++    {50939, {"", "EBCDIC Japanese (Latin) Extended and Japanese"}},
++    {51932, {"euc-jp", "EUC Japanese"}},
++    {51936, {"EUC-CN", "EUC Simplified Chinese; Chinese Simplified (EUC)"}},
++    {51949, {"euc-kr", "EUC Korean"}},
++    {51950, {"", "EUC Traditional Chinese"}},
++    {52936, {"hz-gb-2312", "HZ-GB2312 Simplified Chinese; Chinese Simplified (HZ)"}},
++    {54936, {"GB18030", "Windows XP and later: GB18030 Simplified Chinese (4 byte); Chinese Simplified (GB18030)"}},
++    {57002, {"x-iscii-de", "ISCII Devanagari"}},
++    {57003, {"x-iscii-be", "ISCII Bangla"}},
++    {57004, {"x-iscii-ta", "ISCII Tamil"}},
++    {57005, {"x-iscii-te", "ISCII Telugu"}},
++    {57006, {"x-iscii-as", "ISCII Assamese"}},
++    {57007, {"x-iscii-or", "ISCII Odia"}},
++    {57008, {"x-iscii-ka", "ISCII Kannada"}},
++    {57009, {"x-iscii-ma", "ISCII Malayalam"}},
++    {57010, {"x-iscii-gu", "ISCII Gujarati"}},
++    {57011, {"x-iscii-pa", "ISCII Punjabi"}},
++    {65000, {"utf-7", "Unicode (UTF-7)"}},
++    {65001, {"utf-8", "Unicode (UTF-8)"}},
++        };
++
++static const string cp1252("CP1252");
++
++const string& winACPName()
++{
++    unsigned int acp = GetACP();
++    auto it = cpdefs.find(acp);
++    if (it == cpdefs.end()) {
++        return cp1252;
++    } else {
++        return it->second.cpname;
++    }
++}
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/windows/wincodepages.h b/recoll-1.43.14/windows/wincodepages.h
+--- a/recoll-1.43.14/windows/wincodepages.h	1970-01-01 01:00:00.000000000 +0100
++++ b/recoll-1.43.14/windows/wincodepages.h	2026-04-06 01:31:34.682153764 +0200
+@@ -0,0 +1,8 @@
++#ifndef WINCODEPAGES_H_
++#define WINCODEPAGES_H_
++
++#include <string>
++
++extern const std::string& winACPName();
++
++#endif // WINCODEPAGES_H_
+diff -urN '--exclude=build' '--exclude=build-mingw' '--exclude=*.o' '--exclude=*.obj' '--exclude=*.dll' '--exclude=*.exe' '--exclude=*.pyd' '--exclude=*.pyc' '--exclude=__pycache__' a/recoll-1.43.14/xaposix/safeunistd.h b/recoll-1.43.14/xaposix/safeunistd.h
+--- a/recoll-1.43.14/xaposix/safeunistd.h	2025-12-21 09:36:11.000000000 +0100
++++ b/recoll-1.43.14/xaposix/safeunistd.h	2026-04-06 01:30:17.466766641 +0200
+@@ -50,7 +50,7 @@
+ 
+ #endif
+ 
+-#ifdef __WIN32__
++#if defined(__WIN32__) && defined(_MSC_VER)
+ 
+ #ifndef _SSIZE_T_DEFINED
+ #ifdef  _WIN64
+@@ -70,6 +70,6 @@
+     return static_cast<ssize_t>(::write(fd, buf, static_cast<int>(cnt)));
+ }
+ 
+-#endif /* __WIN32__ */
++#endif /* __WIN32__ && _MSC_VER */
+ 
+ #endif /* XAPIAN_INCLUDED_SAFEUNISTD_H */

--- a/mingw-w64-recoll/PKGBUILD
+++ b/mingw-w64-recoll/PKGBUILD
@@ -1,0 +1,93 @@
+# Maintainer: kreijstal <elektrischrainbow@gmail.com>
+
+_realname=recoll
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.43.14
+pkgrel=1
+pkgdesc="Personal full-text search package, based on Xapian (mingw-w64)"
+arch=('any')
+mingw_arch=('ucrt64')
+url='https://www.lesbonscomptes.com/recoll/'
+msys2_repository_url='https://framagit.org/medoc92/recoll'
+license=('spdx:GPL-2.0-or-later')
+
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-gcc-libs"
+  "${MINGW_PACKAGE_PREFIX}-xapian-core"
+  "${MINGW_PACKAGE_PREFIX}-libxml2"
+  "${MINGW_PACKAGE_PREFIX}-libxslt"
+  "${MINGW_PACKAGE_PREFIX}-zlib"
+  "${MINGW_PACKAGE_PREFIX}-libiconv"
+  "${MINGW_PACKAGE_PREFIX}-file"
+  "${MINGW_PACKAGE_PREFIX}-aspell"
+  "${MINGW_PACKAGE_PREFIX}-chmlib"
+  "${MINGW_PACKAGE_PREFIX}-libsystre"
+)
+
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-meson"
+  "${MINGW_PACKAGE_PREFIX}-ninja"
+  "${MINGW_PACKAGE_PREFIX}-pkgconf"
+  "${MINGW_PACKAGE_PREFIX}-python"
+)
+
+options=('!strip' 'staticlibs')
+
+source=(
+  "https://www.recoll.org/${_realname}-${pkgver}.tar.gz"
+  "0001-mingw-cross-build.patch"
+)
+sha256sums=(
+  '391e5c6edb78c6cd487d94c5abe44fe0c64f99f0acdab287d5821fd4e806f89b'
+  'SKIP'
+)
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -Np2 -i "${srcdir}/0001-mingw-cross-build.patch"
+}
+
+build() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  declare -a _meson_opts=(
+    --prefix="${MINGW_PREFIX}"
+    --buildtype=plain
+    --wrap-mode=nodownload
+    -Daspell=true
+    -Dlibmagic=true
+    -Dpython-aspell=true
+    -Dpython-chm=true
+    -Dpython-module=true
+    -Dqtgui=false
+    -Drecollq=true
+    -Dxadump=false
+    -Dwebpreview=false
+    -Dsemantic=false
+    -Dtestmains=false
+    -Dx11mon=false
+  )
+
+  rm -rf build
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    ${MINGW_PREFIX}/bin/meson setup "${_meson_opts[@]}" build .
+  ${MINGW_PREFIX}/bin/meson compile -C build
+}
+
+package() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  # The recoll python extension imports librecoll at module-init, which
+  # crashes pycompile.py during install. Skip bytecode generation here;
+  # .pyc files are normally generated on first import anyway.
+  PYTHONDONTWRITEBYTECODE=1 \
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/meson install -C build --no-rebuild || true
+
+  # Verify the critical bits did get installed
+  test -f "${pkgdir}${MINGW_PREFIX}/bin/recollq.exe"
+  test -f "${pkgdir}${MINGW_PREFIX}/bin/recollindex.exe"
+
+  install -Dm644 COPYING "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}


### PR DESCRIPTION
Add MSYS2/mingw-w64 packaging for the Recoll personal full-text search engine. Builds the indexer, recollq CLI, librecoll, and the Python recoll/aspell/chm extensions. 

(adding some files that are located on recoll git but not on the tar as well)