### PR TITLE
img2pdf: update to 0.6.3

### DIFF
--- a/mingw-w64-img2pdf/PKGBUILD
+++ b/mingw-w64-img2pdf/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=img2pdf
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.6.1
-pkgrel=3
+pkgver=0.6.3
+pkgrel=1
 pkgdesc="Losslessly convert raster images to PDF"
 arch=(any)
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -16,10 +16,10 @@ options=('!strip')
 depends=("${MINGW_PACKAGE_PREFIX}-python-pillow"
          "${MINGW_PACKAGE_PREFIX}-python-pikepdf")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
-             "${MINGW_PACKAGE_PREFIX}-python-installer"
-             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+             "${MINGW_PACKAGE_PREFIX}-python-flit-core"
+             "${MINGW_PACKAGE_PREFIX}-python-installer")
 source=(https://files.pythonhosted.org/packages/source/i/${_realname}/${_realname}-${pkgver}.tar.gz)
-sha256sums=('306e279eb832bc159d7d6294b697a9fbd11b4be1f799b14b3b2174fb506af289')
+sha256sums=('219518020f5bd242bdc46493941ea3f756f664c2e86f2454721e74353f58cd95')
 
 prepare() {
   rm -rf python-build-${MSYSTEM} || true


### PR DESCRIPTION
Upstream switched build backend to flit-core.