### PR TITLE
crystal: update to 1.20.0

### DIFF
--- a/mingw-w64-crystal/PKGBUILD
+++ b/mingw-w64-crystal/PKGBUILD
@@ -1,11 +1,11 @@
 # Maintainer: Quinton Miller <nicetas.c@gmail.com>
 
-_bootstrap=1
+_bootstrap=0
 _realname=crystal
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.19.1
-pkgrel=2
+pkgver=1.20.0
+pkgrel=1
 pkgdesc="Fast and statically typed, compiled language with Ruby-like syntax (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'mingw64' 'clang64' 'clangarm64')
@@ -39,19 +39,17 @@ makedepends=(
 checkdepends=(
   "${MINGW_PACKAGE_PREFIX}-lld" # needed for linking std_spec
 )
-source=("${_realname}::git+${msys2_repository_url}.git#tag=${pkgver}"
-        "https://github.com/crystal-lang/crystal/commit/710d9a5e.patch")
-sha256sums=('d4c02eef2f5ecf84112172ca965cd4691779371ddd3400f4c4bfbc4a7e117b48'
-            '06c17c82d8bc91d5b3cab77c96bb61caf5d20e53697d5aea78a799419476961b')
+source=("${_realname}::git+${msys2_repository_url}.git#tag=${pkgver}")
+sha256sums=('314c7ab0789b0a32ea768e5c3b380f41bd9cc6081e4b371993d3a4664ac4f227')
 
 if (( _bootstrap )); then
   # stage 0 compiler
   if [[ ${MSYSTEM} == CLANGARM64 ]]; then
-    source+=("https://github.com/crystal-lang/crystal/releases/download/1.18.2/crystal-1.18.2-windows-aarch64-gnu-unsupported.zip")
-    sha256sums+=('c5e04a43681ed9881f93b3e3e2704d2ae9db9413fc01e18218d9d6ef33ef758a')
+    source+=("https://github.com/crystal-lang/crystal/releases/download/1.20.0/crystal-1.20.0-1-windows-aarch64-gnu-unsupported.zip")
+    sha256sums+=('61c7c6768f4218b56749c5592c9d84e7c9b4b686e4db56f647187a71ddfdb109')
   else
-    source+=("https://github.com/crystal-lang/crystal/releases/download/1.18.2/crystal-1.18.2-windows-x86_64-gnu-unsupported.zip")
-    sha256sums+=('cdf43d3eaa91e20c002fa42000f32d85a83c210340c410b0ffd0584e91c01665')
+    source+=("https://github.com/crystal-lang/crystal/releases/download/1.20.0/crystal-1.20.0-1-windows-x86_64-gnu-unsupported.zip")
+    sha256sums+=('fcc12762149369d1f9403a9074d46f138c8b30b597dafcede1fa6744edfe5ac1')
   fi
 fi
 
@@ -62,8 +60,6 @@ prepare() {
     git config core.symlinks true &&
     MSYS='winsymlinks:nativestrict' git restore --source=HEAD :/
   fi
-
-  git apply "${srcdir}"/710d9a5e.patch
 }
 
 build() {


### PR DESCRIPTION
The patch 710d9a5e.patch is part of the new release, that's why it is dropped here.

Furthermore, the bootstrap setting is changed to zero. We already have crystal, so we can use the current crystal to build the new version of crystal.