### PR TITLE
rustfs: update to 1.0.0-alpha.98

### DIFF
--- a/mingw-w64-rustfs/PKGBUILD
+++ b/mingw-w64-rustfs/PKGBUILD
@@ -3,9 +3,9 @@
 _realname=rustfs
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_pkgver=1.0.0-alpha.89
+_pkgver=1.0.0-alpha.98
 pkgver=${_pkgver//-/_}
-_consolever=0.1.5
+_consolever=0.1.7
 pkgrel=1
 pkgdesc="High-performance, memory-safe distributed object storage (mingw-w64)"
 arch=('any')
@@ -36,8 +36,8 @@ source=(
 )
 noextract=("rustfs-${_pkgver}.tar.gz"
            "rustfs-console-v${_consolever}.zip")
-sha256sums=('bd4ba41dd75ef9ae133f053cb07a962d3a021021428d91047e02b6047d4b7e4f'
-            '3fb4e699b905735982d20b4d42d1bcda48f43614ce1dfd0ccb060e69b93802ca')
+sha256sums=('32586e9bd7f9970f4ec2f07a42ed61d7294defe5596f7698a515f3bfd1cdcfef'
+            'e9c11e4a45ddbc7fb094480fa72518d919cfb86a506ce4b7795549531fb958ab')
 
 prepare() {
   echo "Extracting ${_realname}-${_pkgver}.tar.gz ..."
@@ -63,8 +63,8 @@ build() {
   cd "${_realname}-${_pkgver}"
 
   export RUSTUP_TOOLCHAIN=stable-${RUST_CHOST}
-  # For more info see https://github.com/msys2/MINGW-packages/pull/28451
-  export AWS_LC_SYS_CFLAGS=-O0
+  # For more info see https://github.com/msys2/MINGW-packages/pull/29061
+  export RUSTFLAGS="${RUSTFLAGS} --cfg tokio_unstable"
 
   # Generate protobuf/flatbuffers code (uses protoc/flatc from distro)
   cargo run --release --frozen --bin gproto


### PR DESCRIPTION
Error:
```console
     Compiling tokio v1.52.1
  error: The `io-uring` feature requires `--cfg tokio_unstable`.
     --> C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.52.1\src\lib.rs:481:1
      |
  481 | compile_error!("The `io-uring` feature requires `--cfg tokio_unstable`.");
      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  
     Compiling indexmap v2.14.0
     Compiling slab v0.4.12
     Compiling yoke v0.8.2
     Compiling http v1.4.0
     Compiling zerovec-derive v0.11.3
     Compiling tracing-attributes v0.1.31
     Compiling futures-channel v0.3.32
     Compiling tracing-core v0.1.36
     Compiling version_check v0.9.5
     Compiling tracing v0.1.44
     Compiling zerovec v0.11.6
     Compiling crypto-common v0.2.1
  error: could not compile `tokio` (lib) due to 1 previous error
  warning: build failed, waiting for other jobs to finish...
  ==> ERROR: A failure occurred in build().
      Aborting...
```