### PR TITLE
fix freecad 1.1.1 uiloader and python

### DIFF
--- a/mingw-w64-freecad/006-uiloader-ownership.patch
+++ b/mingw-w64-freecad/006-uiloader-ownership.patch
@@ -1,0 +1,109 @@
+Fix dangling pointer returned by PySide QUiLoader methods on MinGW/UCRT64.
+
+On MinGW, Qt's C++ QUiLoader isn't built as a usable library, so the
+FreeCAD UiLoader delegates to PySide's Python QUiLoader via
+uiloader.callMemberFunction(...). PySide returns a Python wrapper that
+owns the underlying C++ widget. When the local Py::Object goes out of
+scope at the end of each method, Py_DECREF deletes the C++ widget and
+the caller receives a dangling pointer. Subsequent access later crashes
+in Shiboken (e.g. getWrapperName() / Object::newObject()) with heap
+corruption (0xc0000374) or SIGSEGV.
+
+Symptoms: clicking BIM Views / New Arch File or Arch Wall on Windows
+crashes with 'libshiboken: Internal C++ object (QWidget) already
+deleted.' or a raw SIGSEGV with freed vtable bytes.
+
+Fix: call Shiboken::Object::releaseOwnership() on the returned wrapper
+so Py_DECREF destroys only the Python wrapper, not the C++ widget. The
+caller then re-wraps the surviving raw pointer via fromQWidget() +
+WrapperManager with ownership=false, which is the intended lifecycle.
+
+Add a reusable helper PythonWrapper::releaseOwnership() and apply it to
+all 5 UiLoader methods that delegate to PySide and return raw pointers:
+load, createWidget, createLayout, createActionGroup, createAction.
+
+--- a/src/Gui/PythonWrapper.h	2026-04-19 08:27:34.866578428 +0200
++++ b/src/Gui/PythonWrapper.h	2026-04-19 08:28:10.535179322 +0200
+@@ -55,6 +55,11 @@
+ 
+     bool toCString(const Py::Object&, std::string&);
+     QObject* toQObject(const Py::Object&);
++    // Tell Shiboken that Python no longer owns the C++ object wrapped by
++    // pyobject. Use when a Python method returns a wrapper with ownership but
++    // we need the underlying C++ object to outlive the wrapper (e.g. raw
++    // pointers returned to caller after the PyCXX handle goes out of scope).
++    void releaseOwnership(const Py::Object&);
+     qsizetype toEnum(PyObject* pyPtr);
+     qsizetype toEnum(const Py::Object& pyobject);
+     Py::Object toStandardButton(qsizetype);
+--- a/src/Gui/PythonWrapper.cpp	2026-04-19 08:27:34.858578293 +0200
++++ b/src/Gui/PythonWrapper.cpp	2026-04-19 08:28:18.410311927 +0200
+@@ -592,6 +592,18 @@
+     return qt_getCppType<QObject>(pyobject.ptr());
+ }
+ 
++void PythonWrapper::releaseOwnership(const Py::Object& pyobject)
++{
++#if defined(HAVE_SHIBOKEN) && defined(HAVE_PYSIDE)
++    PyObject* raw = pyobject.ptr();
++    if (raw && Shiboken::Object::checkType(raw)) {
++        Shiboken::Object::releaseOwnership(reinterpret_cast<SbkObject*>(raw));
++    }
++#else
++    Q_UNUSED(pyobject);
++#endif
++}
++
+ qsizetype PythonWrapper::tryEnum(PyObject* pyPtr)
+ {
+     if (PyObject* number = PyNumber_Long(pyPtr)) {
+--- a/src/Gui/UiLoader.cpp	2026-04-19 08:27:34.850578158 +0200
++++ b/src/Gui/UiLoader.cpp	2026-04-19 08:28:42.497717383 +0200
+@@ -292,6 +292,11 @@
+         args[0] = wrap.fromQObject(device);
+         args[1] = wrap.fromQObject(parentWidget);
+         Py::Object form(uiloader.callMemberFunction("load", args));
++        // PySide returns a wrapper that owns the C++ widget. Disown it before
++        // `form` goes out of scope, otherwise Py_DECREF would delete the
++        // widget and we'd return a dangling pointer. The caller re-wraps the
++        // raw pointer via fromQWidget()+WrapperManager with ownership=false.
++        wrap.releaseOwnership(form);
+         return qobject_cast<QWidget*>(wrap.toQObject(form));
+     }
+     catch (Py::Exception& e) {
+@@ -344,6 +349,8 @@
+         args[1] = wrap.fromQObject(parent);
+         args[2] = Py::String(name.toStdString());
+         Py::Object form(uiloader.callMemberFunction("createWidget", args));
++        // See QUiLoader::load() for ownership rationale.
++        wrap.releaseOwnership(form);
+         return qobject_cast<QWidget*>(wrap.toQObject(form));
+     }
+     catch (Py::Exception& e) {
+@@ -362,6 +369,8 @@
+         args[1] = wrap.fromQObject(parent);
+         args[2] = Py::String(name.toStdString());
+         Py::Object form(uiloader.callMemberFunction("createLayout", args));
++        // See QUiLoader::load() for ownership rationale.
++        wrap.releaseOwnership(form);
+         return qobject_cast<QLayout*>(wrap.toQObject(form));
+     }
+     catch (Py::Exception& e) {
+@@ -379,6 +388,8 @@
+         args[0] = wrap.fromQObject(parent);
+         args[1] = Py::String(name.toStdString());
+         Py::Object action(uiloader.callMemberFunction("createActionGroup", args));
++        // See QUiLoader::load() for ownership rationale.
++        wrap.releaseOwnership(action);
+         return qobject_cast<QActionGroup*>(wrap.toQObject(action));
+     }
+     catch (Py::Exception& e) {
+@@ -396,6 +407,8 @@
+         args[0] = wrap.fromQObject(parent);
+         args[1] = Py::String(name.toStdString());
+         Py::Object action(uiloader.callMemberFunction("createAction", args));
++        // See QUiLoader::load() for ownership rationale.
++        wrap.releaseOwnership(action);
+         return qobject_cast<QAction*>(wrap.toQObject(action));
+     }
+     catch (Py::Exception& e) {

--- a/mingw-w64-freecad/PKGBUILD
+++ b/mingw-w64-freecad/PKGBUILD
@@ -4,7 +4,7 @@ _realname=freecad
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.1.1
-pkgrel=1
+pkgrel=2
 _OS_commit=9e8a885
 pkgdesc="Free and Opensource multiplatform 3D parametric modeler (mingw-w64)"
 arch=('any')
@@ -38,6 +38,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
          "${MINGW_PACKAGE_PREFIX}-yaml-cpp"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          git)
+optdepends=("${MINGW_PACKAGE_PREFIX}-ifcopenshell: IFC import/export support")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
@@ -55,13 +56,15 @@ source=("https://github.com/FreeCAD/FreeCAD/archive/${pkgver}/${_realname}-${pkg
         "001-missing-export.patch"
         "003-cstdint.patch"
         "004-std-less.patch"
-        "005-std-abs.patch")
+        "005-std-abs.patch"
+        "006-uiloader-ownership.patch")
 sha256sums=('873702bb6564e0d393fe1a0db1ee38e11a14e54780237f9ba6041fe9cd5d1170'
             'ebd6ffd5a186516cd76ecdb8e492c62ec305aa5c50de42046d6bde7fd1bf6cfb'
             'd9a27b4771e6d7302686ef0525ec706ca558761017047e0b571ffe08d769bdc9'
             '6ea4f31739cd14924db67e0ce6d856bd1a68beb574bb2dd7278f04f1b16e4f95'
             '67b4aaa38bd18a623ade93e39a284a50f332eaa9704cbacef55721763fcfe5cd'
-            '5b75aa4ab35ca73d1dd5546f3ab131865596d5b94c70fdb01193b2956e499e37')
+            '5b75aa4ab35ca73d1dd5546f3ab131865596d5b94c70fdb01193b2956e499e37'
+            '1ef692989208541e72e60d6ec75846c21d6c178772c682dae1d8ea88461741ff')
 options=('!strip') #'debug'
 
 apply_patch_with_msg() {
@@ -76,6 +79,7 @@ prepare() {
   mv OndselSolver FreeCAD-${pkgver}/src/3rdParty
 
   unix2dos ${srcdir}/004-std-less.patch
+  unix2dos ${srcdir}/006-uiloader-ownership.patch
 
   cd FreeCAD-${pkgver}
 
@@ -83,7 +87,8 @@ prepare() {
     001-missing-export.patch \
     003-cstdint.patch \
     004-std-less.patch \
-    005-std-abs.patch
+    005-std-abs.patch \
+    006-uiloader-ownership.patch
 
   # opencascade defines HAVE_TBB which makes FreeCAD uses TBB without linking to it.
   sed -i "s|HAVE_TBB|HAVE_NOT_TBB|g" src/Mod/Import/App/ImportOCAF.cpp

--- a/mingw-w64-ifcopenshell/001-hdf5-target-fallback.patch
+++ b/mingw-w64-ifcopenshell/001-hdf5-target-fallback.patch
@@ -1,0 +1,36 @@
+--- a/cmake/CMakeLists.txt
++++ b/cmake/CMakeLists.txt
+@@ -349,8 +349,31 @@
+ endif()
+ 
+ if(HDF5_SUPPORT)
+-    find_package(HDF5 REQUIRED COMPONENTS C CXX)
+-    set(IFCOPENSHELL_LIBRARIES ${IFCOPENSHELL_LIBRARIES} hdf5::hdf5_cpp)
++    # HDF5 CMake packaging varies: upstream/Vcpkg expose the namespaced alias
++    # hdf5::hdf5_cpp, while some distributions (notably MSYS2) only expose
++    # unnamespaced hdf5_cpp-shared / hdf5_cpp-static targets via CONFIG mode.
++    # CMake's bundled MODULE-mode FindHDF5 on Windows fabricates .lib paths
++    # that don't exist in MSYS2, so try CONFIG first.
++    find_package(HDF5 CONFIG QUIET COMPONENTS C CXX)
++    if(NOT HDF5_FOUND)
++        find_package(HDF5 REQUIRED COMPONENTS C CXX)
++    endif()
++    # Resolve a single target/libraries spec we can feed to all consumers.
++    # IfcConvert's CMakeLists references ${HDF5_LIBRARIES} directly, which is
++    # populated by MODULE mode but NOT by CONFIG mode — so propagate it here.
++    if(TARGET hdf5::hdf5_cpp)
++        set(_ifopsh_hdf5_target hdf5::hdf5_cpp)
++    elseif(TARGET hdf5_cpp-shared)
++        set(_ifopsh_hdf5_target hdf5_cpp-shared)
++    elseif(TARGET hdf5_cpp-static)
++        set(_ifopsh_hdf5_target hdf5_cpp-static)
++    else()
++        set(_ifopsh_hdf5_target ${HDF5_CXX_LIBRARIES})
++    endif()
++    set(IFCOPENSHELL_LIBRARIES ${IFCOPENSHELL_LIBRARIES} ${_ifopsh_hdf5_target})
++    if(NOT HDF5_LIBRARIES)
++        set(HDF5_LIBRARIES ${_ifopsh_hdf5_target})
++    endif()
+ 
+     add_definitions(-DWITH_HDF5)
+     set(SWIG_DEFINES ${SWIG_DEFINES} -DWITH_HDF5)

--- a/mingw-w64-ifcopenshell/002-svgfill-mingw-noimplib.patch
+++ b/mingw-w64-ifcopenshell/002-svgfill-mingw-noimplib.patch
@@ -1,0 +1,25 @@
+--- a/src/svgfill/CMakeLists.txt
++++ b/src/svgfill/CMakeLists.txt
+@@ -51,12 +51,18 @@
+ if(WIN32)
+     # both the library and the executable now result in a file with basename svgfill,
+     # on linux the the library is prefixed with lib as libsvgfill.a. Windows does not
+-    # have this mechanism, so on windows the linker would be created an import library
++    # have this mechanism, so on windows the linker would be creating an import library
+     # for the executable, also named svgfill.lib. This naming conflict results in:
+     #     LINK : fatal error LNK1149: output filename matches input filename
+-    # This flag tells the linker not to generate an import library and therefore no
+-    # conflict occurs.
+-    target_link_options(svgfill_exe PRIVATE "/NOIMPLIB")
++    if(MSVC)
++        # MSVC understands /NOIMPLIB to suppress the import library.
++        target_link_options(svgfill_exe PRIVATE "/NOIMPLIB")
++    else()
++        # MinGW / GCC: disable exe implib generation by clearing ENABLE_EXPORTS,
++        # which otherwise causes cmake to pass -Wl,--out-implib=libsvgfill.dll.a
++        # and collide with the shared-library import lib of the same name.
++        set_target_properties(svgfill_exe PROPERTIES ENABLE_EXPORTS OFF)
++    endif()
+ endif()
+ 
+ install(

--- a/mingw-w64-ifcopenshell/003-python-init-dll-dir-mingw.patch
+++ b/mingw-w64-ifcopenshell/003-python-init-dll-dir-mingw.patch
@@ -1,0 +1,33 @@
+--- a/src/ifcopenshell-python/ifcopenshell/__init__.py
++++ b/src/ifcopenshell-python/ifcopenshell/__init__.py
+@@ -82,6 +82,30 @@
+ python_distribution = os.path.join(platform_system, platform_architecture, "python%s.%s" % python_version_tuple[:2])
+ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "lib", python_distribution)))
+ 
++# On Windows, Python >= 3.8 no longer searches PATH for native-extension DLL
++# dependencies. That's fine when this package is loaded from the same MSYS2
++# python.exe that lives in <MINGW_PREFIX>/bin next to libTK*.dll, libboost*.dll
++# etc. — the PE loader searches the host exe's directory. But when
++# ifcopenshell is loaded from an *embedded* Python (e.g. FreeCAD's
++# FreeCADCmd.exe) that lives in a different directory, the wrapper's DLL
++# dependencies go unresolved and the import fails with a cryptic
++# "DLL load failed" / "IfcOpenShell not built for ..." message. Explicitly
++# register <MINGW_PREFIX>/bin as a DLL search path to fix that case.
++if sys.platform == "win32" and hasattr(os, "add_dll_directory"):
++    _mingw_prefix = os.environ.get("MINGW_PREFIX")
++    if not _mingw_prefix:
++        # ifcopenshell lives at <prefix>/lib/pythonX.Y/site-packages/ifcopenshell
++        # so four parents up is <prefix>.
++        _mingw_prefix = os.path.normpath(
++            os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..", "..")
++        )
++    _mingw_bin = os.path.join(_mingw_prefix, "bin")
++    if os.path.isdir(_mingw_bin):
++        try:
++            os.add_dll_directory(_mingw_bin)
++        except OSError:
++            pass
++
+ try:
+     from . import ifcopenshell_wrapper
+ except Exception:

--- a/mingw-w64-ifcopenshell/004-svgfill-svgpp-cache-var.patch
+++ b/mingw-w64-ifcopenshell/004-svgfill-svgpp-cache-var.patch
@@ -1,0 +1,11 @@
+--- a/src/svgfill/CMakeLists.txt
++++ b/src/svgfill/CMakeLists.txt
+@@ -36,7 +36,7 @@ find_package(Boost)
+ find_package(LibXml2 REQUIRED)
+ find_package(CGAL REQUIRED)
+
+-set(SVGPP_INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/svgpp/include")
++set(SVGPP_INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/svgpp/include" CACHE PATH "Path to svgpp include directory")
+ if(NOT EXISTS ${SVGPP_INCLUDE})
+     message(
+         FATAL_ERROR

--- a/mingw-w64-ifcopenshell/PKGBUILD
+++ b/mingw-w64-ifcopenshell/PKGBUILD
@@ -1,0 +1,145 @@
+# Maintainer: Kreijstal <kreijstal@hotmail.com>
+# Contributor: Cyril Waechter <cyril[at]biminsight[dot]ch> (AUR reference)
+
+_realname=ifcopenshell
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+_vername=bonsai
+_pkgver=0.8.5-post1
+pkgver=${_pkgver//-/_}
+pkgrel=1
+pkgdesc="Open source IFC library and geometry engine (mingw-w64)"
+arch=('any')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
+url='https://ifcopenshell.org/'
+msys2_repository_url='https://github.com/IfcOpenShell/IfcOpenShell'
+license=('spdx:LGPL-3.0-or-later')
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-cc-libs"
+  "${MINGW_PACKAGE_PREFIX}-boost-libs"
+  "${MINGW_PACKAGE_PREFIX}-hdf5"
+  "${MINGW_PACKAGE_PREFIX}-libxml2"
+  "${MINGW_PACKAGE_PREFIX}-mpfr"
+  "${MINGW_PACKAGE_PREFIX}-gmp"
+  "${MINGW_PACKAGE_PREFIX}-opencascade"
+  "${MINGW_PACKAGE_PREFIX}-python"
+  "${MINGW_PACKAGE_PREFIX}-python-numpy"
+  "${MINGW_PACKAGE_PREFIX}-python-shapely"
+  "${MINGW_PACKAGE_PREFIX}-python-typing_extensions"
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+  "${MINGW_PACKAGE_PREFIX}-ninja"
+  "${MINGW_PACKAGE_PREFIX}-boost"
+  "${MINGW_PACKAGE_PREFIX}-cgal"
+  "${MINGW_PACKAGE_PREFIX}-eigen3"
+  "${MINGW_PACKAGE_PREFIX}-lld"
+  "${MINGW_PACKAGE_PREFIX}-nlohmann-json"
+  "${MINGW_PACKAGE_PREFIX}-svgpp"
+  "${MINGW_PACKAGE_PREFIX}-swig"
+)
+source=("https://github.com/IfcOpenShell/IfcOpenShell/archive/refs/tags/${_vername}-${_pkgver}.tar.gz"
+        "001-hdf5-target-fallback.patch"
+        "002-svgfill-mingw-noimplib.patch"
+        "003-python-init-dll-dir-mingw.patch"
+        "004-svgfill-svgpp-cache-var.patch")
+sha256sums=('d2d566cf97e784de10c70f3be747cf7bf7b19a1ccb711b7bcf25cf884325c76d'
+            '3e76ca1c2efcaad3ba893a6d2d0df5a5a8dd4a2ecec9d583c20ede9af1654003'
+            '19ae15aedec6bb2783c488085275c5fb2c3ff807e8ccea9749a5564ced88df16'
+            '46b67742bd92d4ed37d2b4f9603ed3bb5a67510425fc21c98591bd35d48406d1'
+            '6388baaec79d0af9b56024130ecee42af0a8c418f327c5fa20e0aa1a1f1e5fb4')
+
+_iosdir="IfcOpenShell-${_vername}-${_pkgver}"
+
+prepare() {
+  # svgpp is supplied by mingw-w64-${MINGW_PACKAGE_PREFIX}-svgpp at
+  # ${MINGW_PREFIX}/include/svgpp/. Patch 004 makes SVGPP_INCLUDE a CACHE PATH
+  # so we can redirect svgfill's submodule check at the system location below.
+  cd "${srcdir}/${_iosdir}"
+  patch -Nbp1 -i "${srcdir}/001-hdf5-target-fallback.patch"
+  patch -Nbp1 -i "${srcdir}/002-svgfill-mingw-noimplib.patch"
+  patch -Nbp1 -i "${srcdir}/003-python-init-dll-dir-mingw.patch"
+  patch -Nbp1 -i "${srcdir}/004-svgfill-svgpp-cache-var.patch"
+}
+
+build() {
+  local _py_ver
+  _py_ver=$(${MINGW_PREFIX}/bin/python -c 'import sys;print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+
+  # Use LLVM lld instead of GNU ld. MinGW's ld has O(n^2)-ish behavior on
+  # heavy C++ template linking; IfcParse ships ~36 huge per-schema object
+  # files (Ifc2x3/Ifc4/Ifc4x1/Ifc4x2/Ifc4x3 variants) that made GNU ld peak
+  # at 7 GB RAM and not finish. lld handles the link faster AND enforces the
+  # PE export-table ordinal limit (65535) correctly — without lld, GNU ld
+  # silently misbuilds when that limit is exceeded.
+  #
+  # --exclude-all-symbols: MinGW's default behavior exports every non-static
+  # symbol from a DLL. libIfcParse.dll contains ~244k exportable symbols (8
+  # IFC schemas × thousands of class template instantiations), which blows
+  # past the PE format's 16-bit ordinal ceiling of 65535. Disabling the
+  # default auto-export means only symbols explicitly marked with the
+  # IFC_PARSE_API (__declspec(dllexport)) annotation get exported, which is
+  # what upstream expects on MSVC builds anyway.
+  local _ld_flags="-fuse-ld=lld -Wl,--exclude-all-symbols"
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DPYTHON_MODULE_INSTALL_DIR=" \
+    ${MINGW_PREFIX}/bin/cmake \
+      -S "${_iosdir}/cmake" \
+      -B "build-${MSYSTEM}" \
+      -G Ninja \
+      -Wno-dev \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      -DSVGPP_INCLUDE="${MINGW_PREFIX}/include" \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_EXE_LINKER_FLAGS_INIT="${_ld_flags}" \
+      -DCMAKE_SHARED_LINKER_FLAGS_INIT="${_ld_flags}" \
+      -DCMAKE_MODULE_LINKER_FLAGS_INIT="${_ld_flags}" \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DBUILD_EXAMPLES=OFF \
+      -DBUILD_QTVIEWER=OFF \
+      -DBUILD_IFCPYTHON=ON \
+      -DBUILD_CONVERT=ON \
+      -DBUILD_GEOMSERVER=ON \
+      -DWITH_OPENCASCADE=ON \
+      -DWITH_CGAL=ON \
+      -DCGAL_WITH_GMPXX=OFF \
+      -DWITH_GMPXX=OFF \
+      -DCOLLADA_SUPPORT=OFF \
+      -DGLTF_SUPPORT=ON \
+      -DHDF5_SUPPORT=ON \
+      -DIFCXML_SUPPORT=ON \
+      -DUSD_SUPPORT=OFF \
+      -DEIGEN_DIR="${MINGW_PREFIX}/include/eigen3" \
+      -DOCC_INCLUDE_DIR="${MINGW_PREFIX}/include/opencascade" \
+      -DOCC_LIBRARY_DIR="${MINGW_PREFIX}/lib" \
+      -DHDF5_INCLUDE_DIR="${MINGW_PREFIX}/include" \
+      -DHDF5_LIBRARY_DIR="${MINGW_PREFIX}/lib" \
+      -DLIBXML2_INCLUDE_DIR="${MINGW_PREFIX}/include/libxml2" \
+      -DLIBXML2_LIBRARIES="${MINGW_PREFIX}/lib/libxml2.dll.a" \
+      -DGMP_INCLUDE_DIR="${MINGW_PREFIX}/include" \
+      -DMPFR_INCLUDE_DIR="${MINGW_PREFIX}/include" \
+      -DJSON_INCLUDE_DIR="${MINGW_PREFIX}/include" \
+      -DSWIG_EXECUTABLE="${MINGW_PREFIX}/bin/swig.exe" \
+      -DPython_ROOT_DIR="${MINGW_PREFIX}" \
+      -DPython_FIND_REGISTRY=NEVER \
+      -DPython_FIND_STRATEGY=LOCATION \
+      -DPython_EXECUTABLE="${MINGW_PREFIX}/bin/python" \
+      -DPython3_ROOT_DIR="${MINGW_PREFIX}" \
+      -DPython3_FIND_REGISTRY=NEVER \
+      -DPython3_FIND_STRATEGY=LOCATION \
+      -DPython3_EXECUTABLE="${MINGW_PREFIX}/bin/python" \
+      -DPYTHON_EXECUTABLE="${MINGW_PREFIX}/bin/python" \
+      -DPYTHON_MODULE_INSTALL_DIR="${MINGW_PREFIX}/lib/python${_py_ver}/site-packages"
+
+  ${MINGW_PREFIX}/bin/cmake --build "build-${MSYSTEM}"
+}
+
+package() {
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install "build-${MSYSTEM}"
+
+  install -Dm644 "${srcdir}/${_iosdir}/COPYING" \
+    "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+  install -Dm644 "${srcdir}/${_iosdir}/COPYING.LESSER" \
+    "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.LESSER"
+}

--- a/mingw-w64-svgpp/PKGBUILD
+++ b/mingw-w64-svgpp/PKGBUILD
@@ -1,0 +1,33 @@
+# Maintainer: Kreijstal <kreijstal@hotmail.com>
+
+_realname=svgpp
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.3.1
+pkgrel=1
+pkgdesc="C++ SVG framework, header-only (mingw-w64)"
+arch=('any')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/svgpp/svgpp'
+msys2_repository_url='https://github.com/svgpp/svgpp'
+license=('spdx:BSL-1.0')
+depends=("${MINGW_PACKAGE_PREFIX}-boost-libs")
+makedepends=()
+source=("https://github.com/svgpp/svgpp/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('be8a89df72d01cf062cc9815dd64c9576b4d20910d6d7aee7f0ea26484dc5e76')
+
+package() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  # Header-only library: install all svgpp headers under the standard
+  # include dir so consumers can `#include <svgpp/svgpp.hpp>` without any
+  # extra -I flags. svgpp also ships a sibling `exboost/` directory that
+  # some of its headers include via `<exboost/parameter.hpp>` (it's a
+  # vendored fix for Boost.Parameter quirks), so ship both.
+  install -d "${pkgdir}${MINGW_PREFIX}/include"
+  cp -r "include/svgpp" "${pkgdir}${MINGW_PREFIX}/include/"
+  cp -r "include/exboost" "${pkgdir}${MINGW_PREFIX}/include/"
+
+  # License
+  install -Dm644 LICENSE_1_0.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE_1_0.txt"
+}


### PR DESCRIPTION
freecad on msys2 has a bug, just open it, launch BIM and try to create a wall. This pkg avoids this issue. This adds 2 more dependencies, but makes freecad usable.