### PR TITLE
mingw-w64-git: upgrade to Git for Windows 2.54.0

### DIFF
--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -17,7 +17,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
 	 "${MINGW_PACKAGE_PREFIX}-gitk"
 	 "${MINGW_PACKAGE_PREFIX}-${_realname}-gui"
 	 "${MINGW_PACKAGE_PREFIX}-${_realname}-for-windows-addons")
-tag=2.53.0.windows.3
+tag=2.54.0.windows.1
 pkgver=${tag/.windows./.}
 pkgrel=1
 pkgdesc="The fast distributed version control system (mingw-w64)"
@@ -62,7 +62,7 @@ source=("${_realname}"::"git+https://github.com/git-for-windows/git.git#tag=v$ta
 # resulting in different sha256sums.
 export GIT_CONFIG_PARAMETERS="${GIT_CONFIG_PARAMETERS:+$GIT_CONFIG_PARAMETERS }'core.autocrlf=false' 'core.eol=lf'"
 
-sha256sums=('656c650f4f305acf5e841f41011456c304e834f56f1510128740d44fb07b6646'
+sha256sums=('af7f323d7ef853cae221dea140d8f610cab1ab90cb5b520f95544269dc51deb2'
             'a9dcba5aebc93ae7aacdee03275780fc6c0f15e88fda30c93041e75851e75090'
             '7e6c5f3dc6a4209dca0e1f38880b2978500a5c745c04bc60dbeda5fc48e8d3cb'
             '80b0b11efe5a2f9b4cd92f28c260d0b3aad8b809c34ed95237c59b73e08ade0b'
@@ -112,7 +112,7 @@ prepare () {
 	USE_ASCIIDOCTOR = YesPlease
 	COMPAT_CFLAGS += $COMPAT_CFLAGS
 	LDFLAGS = $LDFLAGS
-  DEFAULT_EDITOR = $_DEFAULT_EDITOR
+	DEFAULT_EDITOR = $_DEFAULT_EDITOR
 	EOF
 
   cp ../git-bash.adoc Documentation/
@@ -549,7 +549,6 @@ package_git-for-windows-addons () {
     "${MINGW_PACKAGE_PREFIX}-${_realname}-subtree"
     "${MINGW_PACKAGE_PREFIX}-${_realname}-credential-wincred"
     "${MINGW_PACKAGE_PREFIX}-${_realname}-send-email"
-    "${MINGW_PACKAGE_PREFIX}-${_realname}-svn"
     "${MINGW_PACKAGE_PREFIX}-gitk"
     "${MINGW_PACKAGE_PREFIX}-${_realname}-gui")
   pkgdesc="Git for Windows extra executables and wrappers (mingw-w64)"


### PR DESCRIPTION
This PR synchronizes the `mingw-w64-git` package definition from [Git for Windows](https://github.com/git-for-windows/MINGW-packages/tree/main/mingw-w64-git).

See https://github.com/git-for-windows/git/releases/tag/v2.54.0.windows.1 for the release notes.

This branch was pushed by https://github.com/git-for-windows/git-for-windows-automation/actions/runs/24683029944 (and manually fixed up by me 😉)