### PR TITLE
autohotkey: bump to v2.0.24

### DIFF
--- a/mingw-w64-autohotkey/PKGBUILD
+++ b/mingw-w64-autohotkey/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=autohotkey
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.0.23
-pkgrel=3
+pkgver=2.0.24
+pkgrel=1
 pkgdesc="Automation scripting language for Windows (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -45,7 +45,7 @@ source=("https://github.com/AutoHotkey/AutoHotkey/archive/refs/tags/v${pkgver}.t
         0019-fix-const-string-literal-to-LPTSTR-assignments-for-c.patch
         0020-replace-_countof-with-sizeof-for-arrays-with-incompl.patch
         0021-add-explicit-template-instantiations-for-ScriptItemL.patch)
-sha256sums=('715266412abb7c87c752cc5a960b0aee6d4e2a6cd8525cef0065cfc8e7448188'
+sha256sums=('994af4027f601b2913d106e989ce0bfd38d51b3d2b807c957fdf3d919f2012fa'
             'de4e313ea798fe5c8f76df1f76c6470ce6492358240615783327fd1502415740'
             '3eccb84dba6a6994053482b5c00f4683e581ebdd565c1fa62812eaf990004746'
             'a7c5d0ebe16295623882f734a62814e23aeee2f2ae9f2004e46c036a91bde67a'


### PR DESCRIPTION
From https://www.autohotkey.com/docs/v2/ChangeLog.htm:

## 2.0.24 - April 19, 2026
Fixed navigation with Tab key in a Gui with a nested Gui (+Parent).

### UX/Dash
* Added an optional check for AutoHotkey updates, disabled by default. [based on UX PR AutoHotkey/AutoHotkey#11 by kczx3]

* Fixed errors being raised when arrow keys are used in the Help Files menu. [UX PR AutoHotkey/AutoHotkey#24 by iPhilip]

* Fixed `install-version.ahk` to delete the temporary ".staging" directory after installing an upgrade.

* Fixed Help Files menu to be displayed at the button, not at the mouse cursor.

* Changed "New script" to add the file to recent files.