### PR TITLE
ggml: enable GGML_CPU_ALL_VARIANTS

### DIFF
--- a/mingw-w64-ggml/0001-disable-sapphirerapids.patch
+++ b/mingw-w64-ggml/0001-disable-sapphirerapids.patch
@@ -1,0 +1,11 @@
+--- ggml/src/CMakeLists.txt.orig	2026-04-21 21:15:33.108745000 +0200
++++ ggml/src/CMakeLists.txt	2026-04-21 21:15:41.806785300 +0200
+@@ -379,7 +379,7 @@
+             ggml_add_cpu_backend_variant(zen4           SSE42 AVX F16C FMA AVX2 BMI2 AVX512 AVX512_VBMI AVX512_VNNI AVX512_BF16)
+         endif()
+         ggml_add_cpu_backend_variant(alderlake          SSE42 AVX F16C FMA AVX2 BMI2 AVX_VNNI)
+-        if (NOT MSVC)
++        if (NOT MSVC AND NOT MINGW)
+             # MSVC doesn't support AMX
+             ggml_add_cpu_backend_variant(sapphirerapids SSE42 AVX F16C FMA AVX2 BMI2 AVX512 AVX512_VBMI AVX512_VNNI AVX512_BF16 AMX_TILE AMX_INT8)
+         endif()

--- a/mingw-w64-ggml/PKGBUILD
+++ b/mingw-w64-ggml/PKGBUILD
@@ -4,7 +4,7 @@ _realname=ggml
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.10.0.r0.g1c40d85a
-pkgrel=1
+pkgrel=2
 pkgdesc="Tensor library for machine learning (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -30,8 +30,17 @@ makedepends=(
   "git"
 )
 _commit="1c40d85a4dcfcd62176f649b8682433bb1a6caef"
-source=("git+https://github.com/ggml-org/ggml.git#commit=${_commit}")
-sha256sums=('8e92ab597ba006677f040dc8cab36ea8afb51f66c77667c2eea7c7354075019a')
+source=("git+https://github.com/ggml-org/ggml.git#commit=${_commit}"
+        "0001-disable-sapphirerapids.patch")
+sha256sums=('8e92ab597ba006677f040dc8cab36ea8afb51f66c77667c2eea7c7354075019a'
+            'be918b079cb47df58a0dc24c516ae6185628af1ea7a812d5b08e0a34c5928a3a')
+
+prepare() {
+  cd "${_realname}"
+
+  # clang hangs building the sapphirerapids DLL
+  patch -p1 -i "../0001-disable-sapphirerapids.patch"
+}
 
 pkgver() {
   cd "${_realname}"
@@ -46,9 +55,13 @@ build() {
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
-  # if [[ ${CARCH} == x86_64 ]]; then
-  #   extra_config+=("-DGGML_BACKEND_DL=ON" "-DGGML_CPU_ALL_VARIANTS=ON")
-  # fi
+  if [[ ${CARCH} == x86_64 ]]; then
+    extra_config+=("-DGGML_BACKEND_DL=ON" "-DGGML_CPU_ALL_VARIANTS=ON")
+  fi
+  if [[ ${MSYSTEM} == CLANG* ]]; then
+    # fails to build with gcc
+    extra_config+=("-DGGML_LTO=ON")
+  fi
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     cmake \
@@ -66,7 +79,6 @@ build() {
       -DGGML_NATIVE=OFF \
       -DGGML_CCACHE=OFF \
       -DGGML_ALL_WARNINGS=OFF \
-      -DGGML_WIN_VER="0x603" \
       -DGGML_BUILD_EXAMPLES=OFF \
       -DGGML_BUILD_TESTS=OFF \
       -DPython3_EXECUTABLE=${MINGW_PREFIX}/bin/python \


### PR DESCRIPTION
* building sapphirerapids hangs, so skip that
* LTO for clang, fails with gcc
* remove unused winver option