### PR TITLE
pelican: update to 4.12.0

### DIFF
--- a/mingw-w64-pelican/0001-pelican-4.11.0-dependencies-fix.patch
+++ b/mingw-w64-pelican/0001-pelican-4.11.0-dependencies-fix.patch
@@ -1,10 +1,10 @@
---- pelican-4.11.0.orig/pyproject.toml	2025-01-17 14:05:53.209946700 +0300
-+++ pelican-4.11.0/pyproject.toml	2025-01-17 14:07:19.985504600 +0300
-@@ -39,7 +39,7 @@
+--- pelican-4.12.0.orig/pyproject.toml	2026-04-20 18:29:45.000000000 +0300
++++ pelican-4.12.0/pyproject.toml	2026-04-22 20:03:58.280592500 +0300
+@@ -38,7 +38,7 @@
      "feedgenerator>=2.1.0",
      "jinja2>=3.1.2",
      "ordered-set>=4.1.0",
--    "pygments>=2.16.1,<2.19.0",
+-    "pygments>=2.16.1,<2.20.0",
 +    "pygments>=2.16.1",
      "python-dateutil>=2.8.2",
      "rich>=13.6.0",

--- a/mingw-w64-pelican/PKGBUILD
+++ b/mingw-w64-pelican/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=pelican
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=4.11.0
-pkgrel=3
+pkgver=4.12.0
+pkgrel=1
 pkgdesc='Static site generator supporting Markdown and reStructuredText (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -38,8 +38,8 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-python-markdown: Markdown support")
 options=(!strip)
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
         '0001-pelican-4.11.0-dependencies-fix.patch')
-sha256sums=('b90234487b818d391733acc1306b785934009749b1fc112b879df9bd89478bd8'
-            '0d61a8ea8113a6c25fd6aada4b22e6fcf6088704d14c69a672df1333cc45936e')
+sha256sums=('3983b5d2dc84c7bdf967154359077a2b78c0bbd2f7dcc55292133a7779609458'
+            '79f2d0899686629a030de9db37e269cb710e4bfd977e18fc75562e170527ea76')
 
 prepare() {
   cd "pelican-${pkgver}"

--- a/mingw-w64-python-docutils/PKGBUILD
+++ b/mingw-w64-python-docutils/PKGBUILD
@@ -4,8 +4,8 @@
 _realname=docutils
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=0.21.2
-pkgrel=4
+pkgver=0.22.4
+pkgrel=1
 pkgdesc="Set of tools for processing plaintext docs into formats such as HTML, XML, or LaTeX (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -25,7 +25,7 @@ makedepends=(
 )
 options=(!strip)
 source=(https://pypi.io/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz)
-sha256sums=('3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f')
+sha256sums=('4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968')
 noextract=(${_realname}-${pkgver}.tar.gz)
 
 prepare() {
@@ -55,6 +55,6 @@ package() {
     --destdir="${pkgdir}" dist/*.whl
 
   # setup license
-  install -D -m644 COPYING.txt "${pkgdir}"${MINGW_PREFIX}/share/licenses/python-${_realname}/COPYING.txt
-  install -D -m644 licenses/*.txt "${pkgdir}"${MINGW_PREFIX}/share/licenses/python-${_realname}/
+  install -D -m644 COPYING.rst "${pkgdir}"${MINGW_PREFIX}/share/licenses/python-${_realname}/COPYING.txt
+  install -D -m644 licenses/*.{rst,txt} "${pkgdir}"${MINGW_PREFIX}/share/licenses/python-${_realname}/
 }


### PR DESCRIPTION
Also `python-docutils` update to `0.22.4`.