### PR TITLE
zed: update to 0.233.8

### DIFF
--- a/mingw-w64-zed/PKGBUILD
+++ b/mingw-w64-zed/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          #"${MINGW_PACKAGE_PREFIX}-${_realname}-docs"
 )
-pkgver=0.232.2
+pkgver=0.233.8
 pkgrel=1
 pkgdesc="A high-performance, multiplayer code editor (mingw-w64)"
 arch=('any')
@@ -48,7 +48,7 @@ source=("git+${msys2_repository_url}.git#tag=v${pkgver}"
         "zstd-sys-remove-statik.patch"
         "zed-fix-docs-build.patch"
         "zed-wsl-set-proper-cli-name.patch")
-sha256sums=('db8848a0486ea7a4930261b06306753b35bf078dd9785ff90d6d9737764ebf0a'
+sha256sums=('7211b846ee098c12ce1bb6ca9162216277471160887860dcb569f8f5df7d71c0'
             '91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748'
             '48f4900ceb02d3aaf9a1020f33d56629156e96759f456c0e7ca18bfcf910767b'
             'acaf155e37120a1af8918854a457939cad71e59bca2ced866f89795ed6b0a7b2'
@@ -58,7 +58,7 @@ prepare() {
   cd "${_realname}"
   rm rust-toolchain.toml
 
-  patch -p1 -i ../zed-fix-docs-build.patch
+  # patch -p1 -i ../zed-fix-docs-build.patch
   # link system deps dynamically
   patch -d ../zstd-sys-2.0.16+zstd.1.5.7 -i ../zstd-sys-remove-statik.patch
   # wsl script is hardcoded with zed.exe name


### PR DESCRIPTION
don't apply patch for docs, has conflicts. anyway it's not needed right now