### PR TITLE
autohotkey: upgrade to 2.0.25

### DIFF
--- a/mingw-w64-autohotkey/PKGBUILD
+++ b/mingw-w64-autohotkey/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=autohotkey
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.0.24
+pkgver=2.0.25
 pkgrel=1
 pkgdesc="Automation scripting language for Windows (mingw-w64)"
 arch=('any')
@@ -45,7 +45,7 @@ source=("https://github.com/AutoHotkey/AutoHotkey/archive/refs/tags/v${pkgver}.t
         0019-fix-const-string-literal-to-LPTSTR-assignments-for-c.patch
         0020-replace-_countof-with-sizeof-for-arrays-with-incompl.patch
         0021-add-explicit-template-instantiations-for-ScriptItemL.patch)
-sha256sums=('994af4027f601b2913d106e989ce0bfd38d51b3d2b807c957fdf3d919f2012fa'
+sha256sums=('083d1f3b084969064528dfa59c66a0d73b0a99a0b80d85c9d267b1df7b058526'
             'de4e313ea798fe5c8f76df1f76c6470ce6492358240615783327fd1502415740'
             '3eccb84dba6a6994053482b5c00f4683e581ebdd565c1fa62812eaf990004746'
             'a7c5d0ebe16295623882f734a62814e23aeee2f2ae9f2004e46c036a91bde67a'


### PR DESCRIPTION
From https://www.autohotkey.com/docs/v2/ChangeLog.htm#v2.0.25:

- Fixed ByRef alias to global var becoming unset in recursive calls.

- Fixed error raised by Hotkey() not transferring control correctly.