### PR TITLE
projectchrono: fix pychono module

### DIFF
--- a/mingw-w64-projectchrono/PKGBUILD
+++ b/mingw-w64-projectchrono/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          $([[ ${CARCH} == aarch64 ]] || echo "${MINGW_PACKAGE_PREFIX}-${_realname}-docs"))
 pkgver=10.0.0
 _mjver=2.7.9
-pkgrel=1
+pkgrel=2
 pkgdesc='High-performance C++ library for multiphysics and multibody dynamics simulations (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -22,6 +22,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
          "${MINGW_PACKAGE_PREFIX}-omp"
          "${MINGW_PACKAGE_PREFIX}-opencascade"
          "${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-numpy"
          "${MINGW_PACKAGE_PREFIX}-vsgimgui"
          "${MINGW_PACKAGE_PREFIX}-vsgxchange"
          "${MINGW_PACKAGE_PREFIX}-vulkan-loader"
@@ -84,6 +85,7 @@ build() {
       -DIrrlicht_ROOT="${MINGW_PREFIX}" \
       -DIrrlicht_INCLUDE_DIR="${MINGW_PREFIX}/include/irrlicht" \
       -DIrrlicht_LIBRARY="${MINGW_PREFIX}/lib/libirrlicht.dll.a" \
+      -DPython3_ROOT_DIR="${MINGW_PREFIX}" \
       -DBUILD_DEMOS=OFF \
       -DBUILD_TESTING=OFF \
       -S "${_basename}-${pkgver}" \


### PR DESCRIPTION
Before changes:

```console
  ==== Chrono Python module ====
  
  -- Find Python
  -- Found Python3: C:/hostedtoolcache/windows/Python/3.14.4/x64/python3.exe (found version "3.14.4") found components: Interpreter Development Development.Module Development.Embed missing components: NumPy
  --   Python version:       3.14.4
  --   Python NumPy found?   FALSE
```

We found `python3.exe` from `CI` environment (not `MSYS2`).

And we get error when trying to import:
```console
$ python3 -c "import pychrono"
...
ImportError: DLL load failed while importing _core
```

After changes:

```console
  ==== Chrono Python module ====
  -- Find Python
  -- Found Python3: D:/M/msys64/clang64/bin/python3.14.exe (found version "3.14.4") found components: Interpreter Development NumPy Development.Module Development.Embed
  --   Python version:       3.14.4
  --   Python NumPy found?   TRUE
  --   Python NumPy version: 2.4.1
```

Without import error :-)