### PR TITLE
openxr-sdk: update to 1.1.58

### DIFF
--- a/mingw-w64-openxr-sdk/PKGBUILD
+++ b/mingw-w64-openxr-sdk/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=openxr-sdk
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-pkgver=1.1.53
+pkgver=1.1.59.1
 pkgrel=1
 pkgdesc='OpenXR is a royalty-free, open standard that provides high-performance access to Augmented Reality (AR) and Virtual Reality (VR) (mingw-w64)'
 arch=('any')
@@ -26,7 +26,7 @@ source=("https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/download/rel
         002-libname-def-file.patch
         003-disable-version-script.patch
         004-fix-cmake-install-dir.patch)
-sha256sums=('1bf766990ff47dfb9b32df201777f666a6399aaab4a249e43b7ad676ad240a3c'
+sha256sums=('b436aa008c51a09de06d15c470b26b3171835fcf52fc6de1631d4aa997b0f2ac'
             'SKIP'
             'eba681cdb04e735166d6d651e58cd34907304ac3399534fb9d45f8bd94205cde'
             'a3e8aacb197336ac707f4871757ad56758a1753d2ca630678ed24b2df7d33bbf'


### PR DESCRIPTION
**Edit:**
Build fails for both 1.1.54 as well as 1.1.58 with an error like [this](https://github.com/msys2/MINGW-packages/actions/runs/25026740276/job/73299400534?pr=29203#step:9:562):
```
  [25/54] Building CXX object src/loader/CMakeFiles/openxr_loader.dir/loader_init_data.cpp.obj
  FAILED: [code=1] src/loader/CMakeFiles/openxr_loader.dir/loader_init_data.cpp.obj 
  D:\M\msys64\ucrt64\bin\g++.exe -DNOMINMAX -DOPENXR_HAVE_COMMON_CONFIG -DXRAPI_DLL_EXPORT -DXR_CURRENT_API_MAJOR_VERSION=1 -DXR_CURRENT_API_MINOR_VERSION=1 -DXR_CURRENT_API_PATCH_VERSION=54 -DXR_OS_WINDOWS -DXR_USE_GRAPHICS_API_OPENGL -DXR_USE_PLATFORM_WIN32 -DXR_USE_TIMESPEC -Dopenxr_loader_EXPORTS -ID:/_/B/src/OpenXR-SDK-Source-release-1.1.54/include -ID:/_/B/src/build-UCRT64/include -ID:/_/B/src/OpenXR-SDK-Source-release-1.1.54/src/common -ID:/_/B/src/OpenXR-SDK-Source-release-1.1.54/src/loader/.. -ID:/_/B/src/build-UCRT64/src/loader/.. -ID:/_/B/src/OpenXR-SDK-Source-release-1.1.54/src/loader/. -ID:/_/B/src/build-UCRT64/src/loader -march=nocona -msahf -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wp,-D__USE_MINGW_ANSI_STDIO=1 -Wall -Werror=unused-parameter -Wpointer-arith -O3 -DNDEBUG -std=gnu++17 -fvisibility=hidden -fno-rtti -ffunction-sections -fdata-sections -Wextra -fno-strict-aliasing -fno-builtin-memcmp -Wimplicit-fallthrough=0 -Werror=undef -Werror=missing-braces -Werror=unreachable-code -MD -MT src/loader/CMakeFiles/openxr_loader.dir/loader_init_data.cpp.obj -MF src\loader\CMakeFiles\openxr_loader.dir\loader_init_data.cpp.obj.d -o src/loader/CMakeFiles/openxr_loader.dir/loader_init_data.cpp.obj -c D:/_/B/src/OpenXR-SDK-Source-release-1.1.54/src/loader/loader_init_data.cpp
  In file included from D:/_/B/src/OpenXR-SDK-Source-release-1.1.54/src/common/xr_dependencies.h:18,
                   from D:/_/B/src/OpenXR-SDK-Source-release-1.1.54/src/loader/loader_platform.hpp:16,
                   from D:/_/B/src/OpenXR-SDK-Source-release-1.1.54/src/loader/runtime_interface.hpp:12,
                   from D:/_/B/src/OpenXR-SDK-Source-release-1.1.54/src/loader/loader_init_data.cpp:11:
  D:/_/B/src/OpenXR-SDK-Source-release-1.1.54/src/common/xr_dependencies.h:19:58: error: 'WINAPI_PARTITION_SYSTEM' is not defined, evaluates to '0' [-Werror=undef]
     19 | #if !(WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM))
        |                                                          ^~~~~~~~~~~~~~~~~~~~~~~
  D:/_/B/src/OpenXR-SDK-Source-release-1.1.54/src/common/xr_dependencies.h:19:58: error: 'WINAPI_PARTITION_SYSTEM' is not defined, evaluates to '0' [-Werror=undef]
     19 | #if !(WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM))
        |                                                          ^~~~~~~~~~~~~~~~~~~~~~~
  cc1plus.exe: some warnings being treated as errors
```
It's likely a problem with the C/C++ headers we have, likely `/ucrt64/include/winapifamily.h` which looks a bit small / incomplete. (Should have some more `#define`s.) Nothing I can do here now.