### PR TITLE
python-ipython: update 9.13.0

### DIFF
--- a/mingw-w64-python-ipython/PKGBUILD
+++ b/mingw-w64-python-ipython/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=ipython
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=9.12.0
+pkgver=9.13.0
 pkgrel=1
 pkgdesc="An enhanced Interactive Python shell (mingw-w64)"
 arch=('any')
@@ -24,6 +24,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-python-jedi"
          "${MINGW_PACKAGE_PREFIX}-python-matplotlib-inline"
          "${MINGW_PACKAGE_PREFIX}-python-prompt_toolkit"
+         "${MINGW_PACKAGE_PREFIX}-python-psutil"
          "${MINGW_PACKAGE_PREFIX}-python-pygments"
          "${MINGW_PACKAGE_PREFIX}-python-stack-data"
          "${MINGW_PACKAGE_PREFIX}-python-traitlets"
@@ -42,7 +43,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest"
               "${MINGW_PACKAGE_PREFIX}-python-numpy")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('01daa83f504b693ba523b5a407246cabde4eb4513285a3c6acaff11a66735ee4')
+sha256sums=('7e834b6afc99f020e3f05966ced34792f40267d64cb1ea9043886dab0dde5967')
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"


### PR DESCRIPTION
ipython now also depends on `psutil>=7`.