### PR TITLE
make: fix sprintf formatting issues causing --output-sync issues

### DIFF
--- a/mingw-w64-make/007-fix-w32-printf-modifier.patch
+++ b/mingw-w64-make/007-fix-w32-printf-modifier.patch
@@ -1,0 +1,26 @@
+Fix MS-specific format specifier in osync_get_mutex.
+
+The %I length modifier alone is ambiguous; use %I64x to match the
+(unsigned long long) cast. Otherwise osync_get_mutex in w32os.c writes
+a string that is either empty or garbage, and the following error
+appears:
+    *** invalid output sync mutex: <garbage>.  Stop.
+
+or, when the string starts with NUL:
+
+    : option '--sync-mutex' requires an argument
+
+Upstream fix:
+https://git.savannah.gnu.org/cgit/make.git/commit/?id=b3802782de3eff2c0f1eda9e7c0befd8cd142162
+
+--- a/src/w32/w32os.c
++++ b/src/w32/w32os.c
+@@ -433,7 +433,7 @@ osync_get_mutex ()
+       /* Prepare the mutex handle string for our children.
+          2 hex digits per byte + 2 characters for "0x" + null.  */
+       mutex = xmalloc ((2 * sizeof (osync_handle)) + 2 + 1);
+-      sprintf (mutex, "0x%Ix", (unsigned long long)(DWORD_PTR)osync_handle);
++      sprintf (mutex, "0x%I64x", (unsigned long long)(DWORD_PTR)osync_handle);
+     }
+
+   return mutex;

--- a/mingw-w64-make/PKGBUILD
+++ b/mingw-w64-make/PKGBUILD
@@ -12,7 +12,7 @@ _prog_name=mingw32-make
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=4.4.1
-pkgrel=4
+pkgrel=5
 pkgdesc="GNU make utility to maintain groups of programs (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -34,6 +34,7 @@ source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.gz"
         'make-4.2.1-Makefile.am-gcc-only-link-libgnumake-1.dll.a.patch'
         '005-fix-default-cxx.patch'
         '006-fix-build-with-gcc-15.patch'
+        '007-fix-w32-printf-modifier.patch'
         'make-check-load-feature.mak'
         'mk_temp.c')
 sha256sums=('dd16fb1d67bfab79a72f5e8390735c49e3e8e70b4945a15ab1f81ddb78658fb3'
@@ -43,6 +44,7 @@ sha256sums=('dd16fb1d67bfab79a72f5e8390735c49e3e8e70b4945a15ab1f81ddb78658fb3'
             'f28d1596ac8f60bbe6042f3467627646ae7e7243e4f73652f9682255758ecdb9'
             'bd6a597d76b35a48020dc335040c96f562439970595a21014469b73b3b6c805a'
             'c5125d642ca6ae9b5788648aa51ecc7a44e829cf443b44768c9a66c85d85689d'
+            '8dc48c3f1d8b02728157a6fba833accb251ba0bdbe7a401da4704700da4c486c'
             '3d6ece384425ff1c3f691efeb7c97e89bb11825bb6648995552dfcb52afe661d'
             '61d4f57c311cf2e27ccf4d1da847216730f304cf17c5c386721182ffe2d4b1aa')
 
@@ -71,7 +73,8 @@ prepare() {
     make-linebuf-mingw.patch \
     make-4.3_undef-HAVE_STRUCT_DIRENT_D_TYPE.patch \
     005-fix-default-cxx.patch \
-    006-fix-build-with-gcc-15.patch
+    006-fix-build-with-gcc-15.patch \
+    007-fix-w32-printf-modifier.patch
   # https://lists.gnu.org/archive/html/bug-make/2022-11/msg00017.html
   apply_patch_with_msg \
     make-4.4-timestamps.patch


### PR DESCRIPTION
For some reason, switching to autotools in pkgrel4 exposed this bug that is actually upstream in make.
The sprintf method in w32os.c/osync_get_mutex uses an MSVC specific formatter "%I". This then results in a garbage string for the mutex hex number. I think it is this bug here: https://savannah.gnu.org/bugs/index.php?64806 I added a comment there as well, so it might get fixed upstream someday as well.

This fixes https://github.com/msys2/MINGW-packages/issues/29218