### PR TITLE
gnutls: Update to 3.8.13

### DIFF
--- a/mingw-w64-gnutls/PKGBUILD
+++ b/mingw-w64-gnutls/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gnutls
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.8.12
+pkgver=3.8.13
 pkgrel=1
 pkgdesc="A library which provides a secure layer over a reliable transport layer (mingw-w64)"
 arch=('any')
@@ -39,7 +39,7 @@ source=(https://www.gnupg.org/ftp/gcrypt/gnutls/v${pkgver%.*}/${_realname}-${pkg
         0003-gnutls-fix-external-libtasn1-detection.patch
         0004-disable-broken-examples.patch
         0005-remove-coverage-rules.patch)
-sha256sums=('a7b341421bfd459acf7a374ca4af3b9e06608dcd7bd792b2bf470bea012b8e51'
+sha256sums=('ffed8ec1bf09c2426d4f14aae377de4753b53e537d685e604e99a8b16ca9c97e'
             'SKIP'
             '7941d0a98b46b48cc85985a2edf6576a699f854d9147e794c713465ec07958ab'
             '6493f69e782d60fe04de4b0040987e99851c522d0baf2fe25d10b85b63e97863'
@@ -49,6 +49,7 @@ validpgpkeys=('0424D4EE81A0E3D119C6F835EDA21E94B565716F')  # "Simon Josefsson <s
 validpgpkeys+=('1F42418905D8206AA754CCDC29EE58B996865171') # "Nikos Mavrogiannopoulos <nmav@gnutls.org>
 validpgpkeys+=('462225C3B46F34879FC8496CD605848ED7E69871') # "Daiki Ueno <ueno@unixuser.org>"
 validpgpkeys+=('5D46CB0F763405A7053556F47A75A648B3F9220C') # Zoltan Fridrich <zfridric at redhat.com>
+validpgpkeys+=('E987AB7F7E89667776D05B3BB0E9DD20B29F1432') # Alexander Sosedkin <monk at unboiled.info>
 
 apply_patch_with_msg() {
   for _fname in "$@"


### PR DESCRIPTION
For the new signing key see
https://lists.gnutls.org/pipermail/gnutls-help/2026-April/004922.html