### PR TITLE
libgpg-error: update to v1.60

### DIFF
--- a/mingw-w64-libgpg-error/PKGBUILD
+++ b/mingw-w64-libgpg-error/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=libgpg-error
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.59
-pkgrel=2
+pkgver=1.60
+pkgrel=1
 pkgdesc="Support library for libgcrypt (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -27,7 +27,7 @@ validpgpkeys=('5B80C5754298F0CB55D8ED6ABCEF7E294B092E28'  # Andre Heinecke (Rele
               '6DAA6E64A76D2840571B4902528897B826403ADA'  # Werner Koch (dist signing 2020)
               'AC8E115BF73E2D8D47FA9908E98E9B2D19C6C8BD'  # Niibe Yutaka (GnuPG Release Key)
               '02F38DFF731FF97CB039A1DA549E695E905BA208') # GnuPG.com (Release Signing Key 2021)
-sha256sums=('a19bc5087fd97026d93cb4b45d51638d1a25202a5e1fbc3905799f424cfa6134'
+sha256sums=('11b2a738e212f3eab0fe8637bc341d3181ca964e97bb2654de91aab7dae4ce09'
             'SKIP'
             '143cfc654adf37924c6e9dd4990b91f037ac835d736b42dfa725315afe100fa0'
             '118ae7c56ef6a3f57cbf834d06b17e3f6a9af4d5fa63fb07cdf2fe4a172c92be'


### PR DESCRIPTION
Taken from <https://github.com/msys2/MINGW-packages/pull/29232>, because that seems to be the least intrusive part of the update and can probably be merged independently of the gnupg update.

**Edit:** Somehow GPG key retrieval (and the following signature verification) fails terribly in most builds. Shouldn't happen, because it passed in #29232.