### PR TITLE
gcc: clean outdated configs

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -185,9 +185,7 @@ build() {
   mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
 
   declare -a _extra_config
-  if check_option "debug" "n"; then
-    _extra_config+=("--disable-libstdcxx-debug")
-  else
+  if check_option "debug" "y"; then
     _extra_config+=("--enable-libstdcxx-debug")
   fi
 
@@ -212,7 +210,6 @@ build() {
   fi
   if [ "$_enable_lto" == "yes" ]; then
     _languages+=",lto"
-    _extra_config+=("--enable-lto")
   else
     _extra_config+=("--disable-lto")
   fi
@@ -226,27 +223,17 @@ build() {
     _languages+=",jit"
   fi
 
-  # so libgomp DLL gets built despide static libdl
-  export lt_cv_deplibs_check_method='pass_all'
-
   ../${_sourcedir}/configure \
     --prefix=${MINGW_PREFIX} \
     --with-local-prefix=${MINGW_PREFIX}/local \
     --libexecdir=${MINGW_PREFIX}/lib \
-    --enable-bootstrap \
     --enable-checking=release \
     --with-arch=${_arch} \
     --with-tune=generic \
     --enable-mingw-wildcard \
     --enable-languages=${_languages} \
-    --enable-shared \
-    --enable-static \
-    --enable-libatomic \
     --enable-threads=${_threads} \
-    --enable-graphite \
     --enable-fully-dynamic-string \
-    --enable-libstdcxx-backtrace=yes \
-    --enable-libstdcxx-filesystem-ts \
     --enable-libstdcxx-time \
     --disable-libstdcxx-pch \
     --enable-libgomp \
@@ -257,14 +244,9 @@ build() {
     --disable-nls \
     --disable-werror \
     --disable-symvers \
-    --with-libiconv \
     --with-system-zlib \
-    --with-{gmp,mpfr,mpc,isl}=${MINGW_PREFIX} \
     --with-pkgversion="Rev${pkgrel}, Built by MSYS2 project" \
     --with-bugurl="https://github.com/msys2/MINGW-packages/issues" \
-    --with-gnu-as \
-    --with-gnu-ld \
-    --with-libstdcxx-zoneinfo="yes" \
     "${_extra_config[@]}"
 
   # While we're debugging -fopenmp problems at least.

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -53,7 +53,7 @@ else
   _url=https://gcc.gnu.org/pub/gcc/snapshots/${_version}-${_snapshot}
 fi
 _libdir=lib/gcc/${CHOST}/${pkgver}
-pkgrel=2
+pkgrel=4
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -228,26 +228,6 @@ build() {
 
   # so libgomp DLL gets built despide static libdl
   export lt_cv_deplibs_check_method='pass_all'
-
-  # This configure check fails with msvcrt due to
-  # https://github.com/mingw-w64/mingw-w64/issues/163
-  export gcc_cv_have_tls=yes
-
-  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105507#c3
-  # At least with mingw32 + dwarf-2 exceptions there can only be one libgcc in
-  # process, or exceptions will no longer work. Since some of the gcc deps are
-  # linked dynamically like gmp/zlib/zstd and those pull in libgcc we can't
-  # allow libgcc to be linked statically. The default is "-static-libstdc++
-  # -static-libgcc" for both, so we drop "-static-libgcc" here:
-  # GCC 14 Update: Since we dropped 32bit Ada with GCC 14.1 and GCC doesn't use
-  # exceptions elsewhere this could in theory be removed, in case it makes problems.
-  _extra_config+=(
-    '--with-boot-ldflags="-static-libstdc++"'
-    '--with-stage1-ldflags="-static-libstdc++"'
-  )
-
-  # In addition adaint.c does `#include <accctrl.h>` which pulls in msxml.h, hacky hack:
-  CPPFLAGS+=" -DCOM_NO_WINDOWS_H"
 
   ../${_sourcedir}/configure \
     --prefix=${MINGW_PREFIX} \


### PR DESCRIPTION
Will rebase after #29280 is merged

Removed list:
- [x] `export lt_cv_deplibs_check_method='pass_all'`
- [x] `export gcc_cv_have_tls=yes`
- [x] `--with-boot-ldflags="-static-libstdc++"`, `--with-stage1-ldflags="-static-libstdc++"`
- [x] `CPPFLAGS+=" -DCOM_NO_WINDOWS_H"`

To try:
- [x] `--enable-bootstrap`
- [x] `--enable-shared`, `--enable-static`
- [x] `--enable-graphite`, `--with-libiconv`
- [x] `--with-gnu-as`, `--with-gnu-ld`
- [x] `--enable-libatomic`, `--enable-libstdcxx-backtrace=yes`, `--enable-libstdcxx-filesystem-ts`, `--with-libstdcxx-zoneinfo="yes"`
- [x] `--with-{gmp,mpfr,mpc,isl}=${MINGW_PREFIX}`

To discuss:
- [ ] `--enable-fully-dynamic-string` (Since we use C++11 abi, this in theory makes no change.)