### PR TITLE
python-wtforms: update to 3.2.2

### DIFF
--- a/mingw-w64-python-wtforms/PKGBUILD
+++ b/mingw-w64-python-wtforms/PKGBUILD
@@ -4,13 +4,14 @@ _realname=wtforms
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-python-${_realname}-docs")
-pkgver=3.2.1
-pkgrel=3
+pkgver=3.2.2
+pkgrel=1
 pkgdesc='A flexible forms validation and rendering library for Python (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://wtforms.readthedocs.io/'
-msys2_repository_url='https://github.com/wtforms/wtforms'
+msys2_repository_url='https://github.com/pallets-eco/wtforms'
+msys2_changelog_url='https://github.com/pallets-eco/wtforms/blob/main/CHANGES.rst'
 msys2_references=(
   'purl: pkg:pypi/wtforms'
 )
@@ -30,10 +31,9 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-babel"
 # We do not use the pypi tarball, as there is no docs directory in it
 #source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
 source=("${msys2_repository_url}/archive/${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('151cf8ea3eab3e67b470198fc9bb1a63543c10cbf174f94eef3704a44e98a9a5')
+sha256sums=('83a0c8fa07f6c1ca35985c54b5eb8815c2e6b75b7d4511c6c13a2af0370522e0')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 
   rm -rf python-install-${MSYSTEM} | true


### PR DESCRIPTION
This also updates the repository URL. The repo was moved more than a year ago, GH just redirected it for us when building.