### PR TITLE
live-photo-conv: update to 0.40.1

### DIFF
--- a/mingw-w64-live-photo-conv/PKGBUILD
+++ b/mingw-w64-live-photo-conv/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=live-photo-conv
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.4.7
+pkgver=0.40.1
 pkgrel=1
 pkgdesc="A cross-platform tool to process live photos of Google Android (mingw-w64)"
 arch=('any')
@@ -13,6 +13,8 @@ license=('spdx:LGPL-2.1-or-later')
 depends=(
     "${MINGW_PACKAGE_PREFIX}-glib2"
     "${MINGW_PACKAGE_PREFIX}-gexiv2"
+    "${MINGW_PACKAGE_PREFIX}-gtk4"
+    "${MINGW_PACKAGE_PREFIX}-libadwaita"
     "${MINGW_PACKAGE_PREFIX}-gstreamer"
     "${MINGW_PACKAGE_PREFIX}-gst-plugins-base"
     "${MINGW_PACKAGE_PREFIX}-gst-plugins-good"
@@ -35,7 +37,7 @@ optdepends=(
     "${MINGW_PACKAGE_PREFIX}-webp-pixbuf-loader: Support to save photos as .webp with GStreamer and GdkPixbuf backend"
 )
 source=("git+https://github.com/wszqkzqk/${_realname}.git#tag=${pkgver}")
-sha256sums=('4a50aeae2bbafd1635c5dbd204b9da40fb4be74930fa98a371d6e4d4f4800809')
+sha256sums=('277824a2db88641477d9b3783ada8c2c3f101778ef10b2335128893437cb7e84')
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"


### PR DESCRIPTION
Add GUI support with GTK / LibAdwaita

<img width="855" height="1200" alt="图片" src="https://github.com/user-attachments/assets/1fc45336-31d9-467c-9074-74330589a226" />
