### PR TITLE
mingw-w64-SDL_image: relocatable pkg-config file

### DIFF
--- a/mingw-w64-SDL_image/PKGBUILD
+++ b/mingw-w64-SDL_image/PKGBUILD
@@ -4,7 +4,7 @@ _realname=SDL_image
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=1.2.12
-pkgrel=8
+pkgrel=9
 pkgdesc="A simple library to load images of various formats as SDL surfaces (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -51,6 +51,15 @@ package() {
   cd "${srcdir}/build-${MSYSTEM}/"
 
   make DESTDIR="${pkgdir}/" install
+
+  # Rewrite the hardcoded prefix in installed pkg-config files so consumers
+  # resolve it from the .pc file's actual location at query time.
+  # CMake on Windows cannot translate the MSYS2-internal Unix-style mount
+  # path /${MSYSTEM,,} that autoconf substitutes here.
+  for _pc in "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/*.pc; do
+    sed -i 's|^prefix=.*|prefix=${pcfiledir}/../..|' "${_pc}"
+  done
+
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" \
     "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
Rewrite the hardcoded prefix in installed pkg-config files to use `${pcfiledir}/../..` so consumers resolve it from the `.pc` file's actual location at query time. CMake cannot translate the MSYS2-internal Unix-style mount path `/${MSYSTEM,,}` that autoconf substitutes here, which prevents projects using `pkg_check_modules(SDL_image ...)` from configuring against the installed package.

Closes: https://github.com/msys2/MINGW-packages/issues/25061