### PR TITLE
mingw-w64-SDL_ttf: relocatable pkg-config file

### DIFF
--- a/mingw-w64-SDL_ttf/PKGBUILD
+++ b/mingw-w64-SDL_ttf/PKGBUILD
@@ -4,7 +4,7 @@ _realname=SDL_ttf
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.0.11
-pkgrel=7
+pkgrel=8
 pkgdesc="A library that allows you to use TrueType fonts in your SDL applications (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -68,5 +68,14 @@ build() {
 package() {
   cd "${srcdir}/build-${MSYSTEM}"
   make DESTDIR="${pkgdir}" install
+
+  # Rewrite the hardcoded prefix in installed pkg-config files so consumers
+  # resolve it from the .pc file's actual location at query time.
+  # CMake on Windows cannot translate the MSYS2-internal Unix-style mount
+  # path /${MSYSTEM,,} that autoconf substitutes here.
+  for _pc in "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/*.pc; do
+    sed -i 's|^prefix=.*|prefix=${pcfiledir}/../..|' "${_pc}"
+  done
+
   install -Dm644 "${srcdir}"/${_realname}-${pkgver}/COPYING "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
Rewrite the hardcoded prefix in installed pkg-config files to use `${pcfiledir}/../..` so consumers resolve it from the `.pc` file's actual location at query time. CMake cannot translate the MSYS2-internal Unix-style mount path `/${MSYSTEM,,}` that autoconf substitutes here, which prevents projects using `pkg_check_modules(SDL_ttf ...)` from configuring against the installed package.

Closes: https://github.com/msys2/MINGW-packages/issues/25061