### PR TITLE
mingw-w64-sdl12-compat: relocatable pkg-config files

### DIFF
--- a/mingw-w64-sdl12-compat/PKGBUILD
+++ b/mingw-w64-sdl12-compat/PKGBUILD
@@ -4,7 +4,7 @@ _realname=sdl12-compat
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.2.74
-pkgrel=1
+pkgrel=2
 pkgdesc="SDL 1.2 runtime compatibility library using SDL 2.0"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -69,6 +69,14 @@ package() {
   cd "${srcdir}/build-${MSYSTEM}"
 
   DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
+
+  # Rewrite the hardcoded prefix in installed pkg-config files so consumers
+  # resolve it from the .pc file's actual location at query time.
+  # CMake on Windows cannot translate the MSYS2-internal Unix-style mount
+  # path /${MSYSTEM,,} that the upstream CMake build substitutes here.
+  for _pc in "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/*.pc; do
+    sed -i 's|^prefix=.*|prefix=${pcfiledir}/../..|' "${_pc}"
+  done
 
   install -Dm644 "${srcdir}/${_realname}-release-${pkgver}/LICENSE.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.txt"
 }


### PR DESCRIPTION
Rewrite the hardcoded prefix in installed pkg-config files to use `${pcfiledir}/../..` so consumers resolve it from the `.pc` file's actual location at query time. CMake cannot translate the MSYS2-internal Unix-style mount path `/${MSYSTEM,,}` that the upstream CMake build substitutes here, which prevents projects using `pkg_check_modules(sdl12_compat ...)` from configuring against the installed package.