### PR TITLE
streamlink: update to 8.4.0

### DIFF
--- a/mingw-w64-streamlink/PKGBUILD
+++ b/mingw-w64-streamlink/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=streamlink
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=8.3.0
+pkgver=8.4.0
 pkgrel=1
 pkgdesc="A CLI utility that extracts streams from various services and pipes them into a video player of choice. (mingw-w64)"
 arch=('any')
@@ -20,7 +20,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-"{build,installer,setuptools})
 optdepends=("${MINGW_PACKAGE_PREFIX}-ffmpeg: Required to play streams that are made up of separate audio and video streams, eg. YouTube 1080p+")
 options=('!strip')
 source=("https://github.com/${_realname}/${_realname}/releases/download/${pkgver}/${_realname}-${pkgver}.tar.gz"{,.asc})
-sha256sums=('6cffe55b42df3b3c2e6dd1c0cc41fc01477afbc496ba86740ffa5eec5c333d34'
+sha256sums=('f477e9493336bcb7c3a2b10eea72a60ae9a7f49e968ada0d4d01bff78eac44bb'
             'SKIP')
 validpgpkeys=('CDAC41B9122470FAF357A9D344448A298D5C3618') # Streamlink signing key <streamlink@protonmail.com>
 


### PR DESCRIPTION
Release changelog:
https://streamlink.github.io/changelog.html#streamlink-8-4-0-2026-05-06

Resolves [CVE-2026-44353](https://nvd.nist.gov/vuln/detail/CVE-2026-44353) / [GHSA-hgqw-6m45-hw5f](https://github.com/streamlink/streamlink/security/advisories/GHSA-hgqw-6m45-hw5f)