### PR TITLE
ccache: update to 4.13.6

### DIFF
--- a/mingw-w64-ccache/PKGBUILD
+++ b/mingw-w64-ccache/PKGBUILD
@@ -4,8 +4,8 @@
 _realname=ccache
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.13.2
-pkgrel=2
+pkgver=4.13.6
+pkgrel=1
 pkgdesc="Compiler cache that speeds up recompilation by caching previous compilations (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'mingw32' 'ucrt64' 'clang64' 'clangarm64')
@@ -33,8 +33,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
            "${MINGW_PACKAGE_PREFIX}-libblake3"))
 source=("https://github.com/ccache/ccache/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.xz"{,.minisig}
         "0001-generate-docs-bash.patch")
-sha256sums=('4a0d835f1b3fd7e2ac58a511718bbc902532941f377f7990a3d33b5cf8733ba6'
-            'bf448a3cb0bb2325290ab397158cd392ae26fbab3186ed17bb0ea7afbc5c016c'
+sha256sums=('a7de667ca08cf67c3c8af9f213f6aa701a1188a2b3163fb74483858ce5e79fbb'
+            'a45a1b58566df6c648dc0b4473ed12d8fc077137e46e4ccea96c64f784b091fc'
             '55e60c7413774387f0b2b36f654fa5ad736e828c95372d85a65d15c8a784fb12')
 validpgpkeys=('5A939A71A46792CF57866A51996DDA075594ADB8') # Joel Rosdahl <joel@rosdahl.net>
 
@@ -63,11 +63,6 @@ build() {
     extra_config+=("-DREDIS_STORAGE_BACKEND=OFF")
   else
     extra_config+=("-DREDIS_STORAGE_BACKEND=ON")
-  fi
-
-  if [[ "${CC}" == "gcc" ]]; then
-    # https://github.com/fmtlib/fmt/issues/4133
-    CXXFLAGS+=" -Wno-error=stringop-overflow"
   fi
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \


### PR DESCRIPTION
* no longer need -Wno-error=stringop-overflow for GCC