### PR TITLE
autohotkey: upgrade to 2.0.26

### DIFF
--- a/mingw-w64-autohotkey/PKGBUILD
+++ b/mingw-w64-autohotkey/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=autohotkey
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.0.25
-pkgrel=3
+pkgver=2.0.26
+pkgrel=1
 pkgdesc="Automation scripting language for Windows (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -45,7 +45,7 @@ source=("https://github.com/AutoHotkey/AutoHotkey/archive/refs/tags/v${pkgver}.t
         0019-fix-const-string-literal-to-LPTSTR-assignments-for-c.patch
         0020-replace-_countof-with-sizeof-for-arrays-with-incompl.patch
         0021-add-explicit-template-instantiations-for-ScriptItemL.patch)
-sha256sums=('083d1f3b084969064528dfa59c66a0d73b0a99a0b80d85c9d267b1df7b058526'
+sha256sums=('bd11ee00ba75657dcedf3c6c671621bc6ee27cc90802395840a449cce77c5228'
             'de4e313ea798fe5c8f76df1f76c6470ce6492358240615783327fd1502415740'
             '3eccb84dba6a6994053482b5c00f4683e581ebdd565c1fa62812eaf990004746'
             'a7c5d0ebe16295623882f734a62814e23aeee2f2ae9f2004e46c036a91bde67a'


### PR DESCRIPTION
From https://github.com/AutoHotkey/AutoHotkey/releases/tag/v2.0.26:

- Fixed ControlGetItems/ControlGetChoice not throwing for Tab controls.

- Fixed error reporting for ComObjArray().__Enum(), if it ever fails.

- Fixed `TraySetIcon("HBITMAP:" handle)` without `*`.

The existing patch series applies cleanly to the new tarball via `patch -p1` (with line-offset adjustments only), so only `pkgver`, `pkgrel`, and the source-tarball SHA-256 needed updating. A full `makepkg-mingw` build with `check()` enabled (which runs `test-basic.ahk` against the built `AutoHotkey64.exe`) succeeds in the MINGW64 environment.
