### PR TITLE
cargo-tauri: update to 2.11.1

### DIFF
--- a/mingw-w64-cargo-tauri/PKGBUILD
+++ b/mingw-w64-cargo-tauri/PKGBUILD
@@ -4,7 +4,7 @@ _basename=tauri
 _realname=cargo-${_basename}
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.11.0
+pkgver=2.11.1
 pkgrel=1
 pkgdesc='Command line interface for building Tauri apps (mingw-w64)'
 arch=('any')
@@ -20,7 +20,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-rust")
 makedepends=("${MINGW_PACKAGE_PREFIX}-git")
 source=("${msys2_repository_url}/archive/${_basename}-cli-v${pkgver}/${_basename}-${_basename}-cli-v${pkgver}.tar.gz")
 noextract=("${_basename}-${_basename}-cli-v${pkgver}.tar.gz")
-sha256sums=('0687cf2580d0bc7cbada20b955643e8df6adcc0165d810286889ea402a3d5b78')
+sha256sums=('3d709445fc388057d9249547067813d917206b0f3880610929bcbeabbe78ba9d')
 
 prepare() {
   [[ -d "${srcdir}/${_basename}-${_basename}-cli-v${pkgver}" ]] && rm -rf "${srcdir}/${_basename}-${_basename}-cli-v${pkgver}"


### PR DESCRIPTION
This should take care of <https://github.com/advisories/GHSA-7gmj-67g7-phm9>.

CC: @podsvirov