### PR TITLE
New package: mingw-w64-r

### DIFF
--- a/mingw-w64-r/PKGBUILD
+++ b/mingw-w64-r/PKGBUILD
@@ -12,10 +12,8 @@ license=('GPL-2.0-or-later')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-fc"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
-             "texinfo"
-             "texinfo-tex"
              "unzip")
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
          "${MINGW_PACKAGE_PREFIX}-bzip2"
          "${MINGW_PACKAGE_PREFIX}-cairo"
          "${MINGW_PACKAGE_PREFIX}-curl"
@@ -31,8 +29,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "winpty"
          "make")
-checkdepends=("diffutils"
-              "unzip")
 source=("https://cran.r-project.org/src/base/R-4/R-${pkgver}.tar.gz"
         "clang20.diff"
         "wrapper.sh")

--- a/mingw-w64-r/PKGBUILD
+++ b/mingw-w64-r/PKGBUILD
@@ -1,0 +1,74 @@
+# Maintainer: Jeroen Ooms <jeroen@berkeley.edu>
+_realname=r
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=4.6.0
+pkgrel=1
+pkgdesc="Software environment for statistical computing (mingw-w64)"
+arch=('any')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
+url='https://www.r-project.org/'
+license=('GPL-2.0-or-later')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-fc"
+             "${MINGW_PACKAGE_PREFIX}-pkgconf"
+             "texinfo"
+             "texinfo-tex"
+             "unzip")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-bzip2"
+         "${MINGW_PACKAGE_PREFIX}-cairo"
+         "${MINGW_PACKAGE_PREFIX}-curl"
+         "${MINGW_PACKAGE_PREFIX}-icu"
+         "${MINGW_PACKAGE_PREFIX}-libdeflate"
+         "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
+         "${MINGW_PACKAGE_PREFIX}-libpng"
+         "${MINGW_PACKAGE_PREFIX}-libtiff"
+         "${MINGW_PACKAGE_PREFIX}-omp"
+         "${MINGW_PACKAGE_PREFIX}-pcre2"
+         "${MINGW_PACKAGE_PREFIX}-tk"
+         "${MINGW_PACKAGE_PREFIX}-xz"
+         "${MINGW_PACKAGE_PREFIX}-zlib"
+         "winpty"
+         "make")
+checkdepends=("diffutils"
+              "unzip")
+source=("https://cran.r-project.org/src/base/R-4/R-${pkgver}.tar.gz"
+        "clang20.diff"
+        "wrapper.sh")
+sha256sums=('b8dc9b4543660c7b596b87938df532394350360976527d344228ee0ed12e45ec'
+            '119016a804498dc39bd003ce4e3ea9dc3b4afdbcce779a41711e2add6faa5900'
+            '0d9658d9f4ad628cd9373406e2ab7663e040904ed2639f13619493af96c1f627')
+noextract=(R-${pkgver}.tar.gz)
+
+prepare() {
+  MSYS="winsymlinks:lnk" tar -xf "R-${pkgver}.tar.gz"
+  cd ${srcdir}/R-${pkgver}
+  patch -Np1 -i "${srcdir}"/clang20.diff
+}
+
+build() {
+  cd ${srcdir}/R-${pkgver}/src/gnuwin32
+  echo "WIN =" > MkRules.local
+  if [[ ${MSYSTEM} == CLANG* ]]; then
+    echo "USE_LLVM = 1" >> MkRules.local
+  fi
+  echo "MY_TCLTK=${MINGW_PREFIX}" >> ${srcdir}/R-${pkgver}/etc/Renviron.site
+  make all
+  make cairodevices
+  make recommended
+
+  # Smoke test
+  ${srcdir}/R-${pkgver}/bin/R -e "library(stats);library(tcltk);sessionInfo()"
+}
+
+package() {
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/opt/R
+  cd ${srcdir}/R-${pkgver}/
+  cp -Rf bin etc include share library modules doc ${pkgdir}${MINGW_PREFIX}/opt/R/
+  rm -f ${pkgdir}${MINGW_PREFIX}/opt/R/*/*.in
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/bin
+  cp ${srcdir}/wrapper.sh ${pkgdir}${MINGW_PREFIX}/bin/R
+  cp ${srcdir}/wrapper.sh ${pkgdir}${MINGW_PREFIX}/bin/Rscript
+  cp ${srcdir}/wrapper.sh ${pkgdir}${MINGW_PREFIX}/bin/Rgui
+}

--- a/mingw-w64-r/PKGBUILD
+++ b/mingw-w64-r/PKGBUILD
@@ -34,7 +34,7 @@ source=("https://cran.r-project.org/src/base/R-4/R-${pkgver}.tar.gz"
         "wrapper.sh")
 sha256sums=('b8dc9b4543660c7b596b87938df532394350360976527d344228ee0ed12e45ec'
             '119016a804498dc39bd003ce4e3ea9dc3b4afdbcce779a41711e2add6faa5900'
-            '0d9658d9f4ad628cd9373406e2ab7663e040904ed2639f13619493af96c1f627')
+            '56ba617029fa3c214f59ffec2bab98e4592798ffb67dc9380373ae72a36673f1')
 noextract=(R-${pkgver}.tar.gz)
 
 prepare() {
@@ -59,10 +59,13 @@ build() {
 }
 
 package() {
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/opt/R
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/R
   cd ${srcdir}/R-${pkgver}/
-  cp -Rf bin etc include share library modules doc ${pkgdir}${MINGW_PREFIX}/opt/R/
-  rm -f ${pkgdir}${MINGW_PREFIX}/opt/R/*/*.in
+  cp -Rf bin etc include library modules share doc ${pkgdir}${MINGW_PREFIX}/lib/R/
+  rm -f ${pkgdir}${MINGW_PREFIX}/lib/R/*/*.in
+  # NB: Renviron.site only understands Windows paths
+  #echo "R_SHARE_DIR=${MINGW_PREFIX}/share/R/share" >> ${pkgdir}${MINGW_PREFIX}/lib/R/etc/Renviron.site
+  #echo "R_DOC_DIR=${MINGW_PREFIX}/share/R/doc" >> ${pkgdir}${MINGW_PREFIX}/lib/R/etc/Renviron.site
   mkdir -p ${pkgdir}${MINGW_PREFIX}/bin
   cp ${srcdir}/wrapper.sh ${pkgdir}${MINGW_PREFIX}/bin/R
   cp ${srcdir}/wrapper.sh ${pkgdir}${MINGW_PREFIX}/bin/Rscript

--- a/mingw-w64-r/clang20.diff
+++ b/mingw-w64-r/clang20.diff
@@ -1,0 +1,28 @@
+diff --git a/src/gnuwin32/MkRules.rules b/src/gnuwin32/MkRules.rules
+index 7252d1d449..aa8b1b4aad 100644
+--- a/src/gnuwin32/MkRules.rules
++++ b/src/gnuwin32/MkRules.rules
+@@ -161,7 +161,7 @@ else
+   FC=$(BINPREF)flang $(M_ARCH)
+   ## Fortran_main is needed/available only in some builds of llvm/flang-new
+   LIBFM = $(or $(and $(wildcard $(EXT_LIBS)/lib/libFortran_main.a),-lFortran_main),)
+-  FLIBS=-lFortranRuntime -lFortranDecimal $(LIBFM) -lc++ -lm
++  FLIBS=-lflang_rt.runtime -lFortranDecimal $(LIBFM) -lc++ -lm
+ endif
+ LINKER=$(MAIN_LD)
+ MAIN_LD=$(CC)
+diff --git a/src/include/Makefile.win b/src/include/Makefile.win
+index 38816ca294..4ba799f35c 100644
+--- a/src/include/Makefile.win
++++ b/src/include/Makefile.win
+@@ -39,8 +39,8 @@ fixh: $(GW32_HEADERS) $(OBJ_HEADERS)
+ 	@$(ECHO) done > fixh
+ 
+ config.h: ../gnuwin32/fixed/h/config.h ../../VERSION
+-	@$(SED) -e 's/@VERSION@/$(VER)/' \
+-                -e 's/@CC_VER@/$(CC_VER)/' -e 's/@FC_VER@/$(FC_VER)/' $< > $@
++	@$(SED) -e 's|@VERSION@|$(VER)|' \
++                -e 's|@CC_VER@|$(CC_VER)|' -e 's|@FC_VER@|$(FC_VER)|' $< > $@
+ 
+ Rconfig.h: ../gnuwin32/fixed/h/Rconfig.h
+ 	@cp $< $@

--- a/mingw-w64-r/wrapper.sh
+++ b/mingw-w64-r/wrapper.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec ${MSYSTEM_PREFIX}/opt/R/bin/$(basename "$0") "$@"

--- a/mingw-w64-r/wrapper.sh
+++ b/mingw-w64-r/wrapper.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec ${MSYSTEM_PREFIX}/opt/R/bin/$(basename "$0") "$@"
+exec ${MSYSTEM_PREFIX}/lib/R/bin/$(basename "$0") "$@"


### PR DESCRIPTION
R is developed to build with mingw-w64, however normally it is shipped as a standalone program using an installer. In order to package it for msys2 I basically package up the directory which normally would be what is placed under "C:/Program Files/R/" by the installer.
