### PR TITLE
[DONT MERGE] zed: test rebuild

### DIFF
--- a/mingw-w64-zed/PKGBUILD
+++ b/mingw-w64-zed/PKGBUILD
@@ -5,8 +5,8 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          #"${MINGW_PACKAGE_PREFIX}-${_realname}-docs"
 )
-pkgver=1.1.7
-pkgrel=1
+pkgver=1.1.5
+pkgrel=444
 pkgdesc="A high-performance, multiplayer code editor (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -49,7 +49,7 @@ source=("git+${msys2_repository_url}.git#tag=v${pkgver}"
         "zstd-sys-remove-statik.patch"
         "zed-fix-docs-build.patch"
         "zed-wsl-set-proper-cli-name.patch")
-sha256sums=('b34ea4cb6a55c9dbecbe272342ad3f070c07c439c002a036df133b56863bd514'
+sha256sums=('17a8bbae862a11acdf03036474419184118d2f5b0b287f7b8b04fd19d89a391f'
             '91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748'
             '48f4900ceb02d3aaf9a1020f33d56629156e96759f456c0e7ca18bfcf910767b'
             'acaf155e37120a1af8918854a457939cad71e59bca2ced866f89795ed6b0a7b2'


### PR DESCRIPTION
I wanted to test whether rust become faster after native TLS transition (probably not, because LLVM and rustc-driver still link to `__emutls_` symbols)