### PR TITLE
python: enable tail-call for Clang

### DIFF
--- a/mingw-w64-python/PKGBUILD
+++ b/mingw-w64-python/PKGBUILD
@@ -23,7 +23,7 @@ else
   pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}${_pybasever}")
 fi
 pkgver=${_pybasever}.6
-pkgrel=1
+pkgrel=2
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -279,7 +279,7 @@ prepare() {
   0103-configure-allow-older-autoconf.patch \
   0104-tests-allow-sys.abiflags-to-exist.patch \
   0105-makesetup-make-sure-to-link-the-built-libpython.patch
- 
+
   autoreconf -vfi
 }
 
@@ -297,6 +297,11 @@ build() {
     CFLAGS+=" -O0 -ggdb"
     CXXFLAGS+=" -O0 -ggdb"
     _extra_config+=("--with-pydebug")
+  fi
+
+  # FIXME: enable for all once GCC stops crashing
+  if [[ ${MSYSTEM} == CLANG* ]]; then
+    _extra_config+=("--with-tail-call-interp")
   fi
 
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"


### PR DESCRIPTION
Only Clang envs because GCC ICEs with that option.