### PR TITLE
{lib,}mediainfo: update to 26.05

### DIFF
--- a/mingw-w64-libmediainfo/PKGBUILD
+++ b/mingw-w64-libmediainfo/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libmediainfo
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=25.04
+pkgver=26.05
 pkgrel=1
 pkgdesc="Supplies technical and tag information about media files (mingw-w64)"
 arch=('any')
@@ -34,12 +34,10 @@ depends=(
 
 source=("https://mediaarea.net/download/source/${_realname}/${pkgver}/${_realname}_${pkgver}.tar.bz2"
         001-fix-win32-build.patch
-        002-dllname.patch
-        003-libmedainfo-reader-allow-shared-curl-linking.patch)
-sha256sums=('a5c5ce1e21d40c6907c47a9459c3b5f36cd5c7a0e5800f87419da10b9267becd'
+        002-dllname.patch)
+sha256sums=('736222cb45966412f50276461b7cd50488794948063fadd39c9a675ba20a3f4a'
             'e5ff9f586b07c638bfea79055543c5f9b24f88b74ccba38f3176b432ba55e30e'
-            'c13a7ad987431c518233566592408b2f26d00622a901f893ba066023884512dd'
-            '7f1e47c682d502600621d58acd857af526a428609db64c4d4ac8883d07f858e6')
+            'c13a7ad987431c518233566592408b2f26d00622a901f893ba066023884512dd')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -54,8 +52,7 @@ prepare() {
 
   apply_patch_with_msg \
     001-fix-win32-build.patch \
-    002-dllname.patch \
-    003-libmedainfo-reader-allow-shared-curl-linking.patch
+    002-dllname.patch
 }
 
 build() {

--- a/mingw-w64-mediainfo/PKGBUILD
+++ b/mingw-w64-mediainfo/PKGBUILD
@@ -2,11 +2,11 @@
 
 _wx_basever=3.2
 
-_realname=mediainfo 
+_realname=mediainfo
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-gui")
-pkgver=25.04
+pkgver=26.05
 pkgrel=1
 pkgdesc="Supplies technical and tag information about media files (mingw-w64)"
 arch=('any')
@@ -33,7 +33,7 @@ depends=(
 )
 source=("https://mediaarea.net/download/source/${_realname}/${pkgver}/${_realname}_${pkgver}.tar.xz"
         001-missing-rc-mingw.patch)
-sha256sums=('4b2553fe9104332d3baca5fe61b6b87af4d493108c5b863801cdb0a4826a33ae'
+sha256sums=('f852093f9050022d699606eeabb38b24da5523d0212fab64dc4e4d3e46b56de1'
             '116567243123b6d18e7e25c79e268be858301a7c269de213fc57e6dfec3ae203')
 noextract=("${_realname}_${pkgver}.tar.xz")
 


### PR DESCRIPTION
* libmediainfo: drop 003-libmedainfo-reader-allow-shared-curl-linking.patch, fixed in https://gitlab.kitware.com/cmake/cmake/-/merge_requests/10646