### PR TITLE
Pyside compiler

### DIFF
--- a/mingw-w64-pyside2/022-fix-hardcoded-compiler.patch
+++ b/mingw-w64-pyside2/022-fix-hardcoded-compiler.patch
@@ -1,0 +1,16 @@
+--- pyside-setup-opensource-src-5.15.18/sources/shiboken2/ApiExtractor/clangparser/compilersupport.cpp.orig	2025-10-04 09:15:58.000000000 +0300
++++ pyside-setup-opensource-src-5.15.18/sources/shiboken2/ApiExtractor/clangparser/compilersupport.cpp	2026-05-13 13:54:26.082239100 +0300
+@@ -297,7 +297,12 @@
+ // Added !defined(Q_OS_DARWIN) due to PYSIDE-1032
+ #  if defined(CMAKE_CXX_COMPILER) && !defined(Q_OS_DARWIN)
+     Q_UNUSED(defaultCompiler)
+-    return QString::fromLocal8Bit(CMAKE_CXX_COMPILER);
++    QString buildCompiler = QString::fromLocal8Bit(CMAKE_CXX_COMPILER);
++    QFileInfo comp_info(buildCompiler);
++    if (comp_info.exists()) {
++        return buildCompiler;
++    }
++    return comp_info.fileName();
+ #  else
+     return defaultCompiler;
+ #  endif

--- a/mingw-w64-pyside2/PKGBUILD
+++ b/mingw-w64-pyside2/PKGBUILD
@@ -8,7 +8,7 @@ pkgname=(${MINGW_PACKAGE_PREFIX}-shiboken2
          ${MINGW_PACKAGE_PREFIX}-${_realname}-tools)
 pkgdesc="Provides LGPL Qt5 bindings for Python and related tools for binding generation (mingw-w64)"
 pkgver=5.15.18
-pkgrel=6
+pkgrel=7
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://doc.qt.io/qtforpython-5/"
@@ -56,7 +56,8 @@ source=(https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-${p
         Do-the-transition-to-Python-3.13.patch
         Fix-condition-to-allow-3.13-for-wheel-creation.patch
         020-python314.patch
-        021-py314-metaclass-compat.patch)
+        021-py314-metaclass-compat.patch
+        022-fix-hardcoded-compiler.patch)
 noextract=("${_pkgfqn}.tar.xz")
 sha256sums=('aa13963698991589fdec4f19735c6fd7200b7544ba521d64a69e2cea365fd98b'
             '8120f1d29c4fe6928ab58d01586370af6d7c03f5a4c656d3e80ea03965a032d5'
@@ -70,7 +71,8 @@ sha256sums=('aa13963698991589fdec4f19735c6fd7200b7544ba521d64a69e2cea365fd98b'
             'a35ec1dd8b50aa296e775baa389253b42dc3bb1e1cf1c08afc117a03856aaa08'
             '0f8549de5c6e98488277de9f6c548443b0ff6eca39a1253aca23b3389febab6f'
             'a94c3f8881c586d5349b5220867bd4c4081dd8816a468530990673e6578860b1'
-            '28ddcf088105dcdd7ce8d9938ee49ebebc50c75d565330df8e334354106d5027')
+            '28ddcf088105dcdd7ce8d9938ee49ebebc50c75d565330df8e334354106d5027'
+            'e60382962cd8592ad76c87553f591ae2875eb4ca88e15039fff6fcbf2bc31d0b')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -111,6 +113,9 @@ prepare() {
   # https://github.com/python/cpython/issues/123909
   apply_patch_with_msg \
     021-py314-metaclass-compat.patch
+
+  apply_patch_with_msg \
+    022-fix-hardcoded-compiler.patch
 }
 
 build() {
@@ -152,7 +157,7 @@ package_shiboken2() {
   done
 
   # Conflicts with shiboken6
-  rm "$pkgdir"${MINGW_PREFIX}/bin/shiboken_tool.py
+  mv "$pkgdir"${MINGW_PREFIX}/bin/shiboken_tool{,2}.py
 
   for _f in "${pkgdir}${MINGW_PREFIX}"/lib/cmake/Shiboken2-${pkgver}/*.cmake; do
     sed -e "s|${MINGW_PREFIX}|\$\{_IMPORT_PREFIX\}|g" -i "${_f}"
@@ -215,6 +220,8 @@ package_pyside2-tools() {
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install build-${MSYSTEM}/sources/pyside2-tools
 
   rm -f "${pkgdir}"${MINGW_PREFIX}/bin/{rcc,uic,designer}.exe  # provided by qt5-base
+  # Conflicts with pyside6-tools
+  mv "$pkgdir"${MINGW_PREFIX}/bin/pyside_tool{,2}.py
 }
 
 # template start; name=mingw-w64-splitpkg-wrappers; version=1.0;

--- a/mingw-w64-pyside6/004-fix-hardcoded-compiler.patch
+++ b/mingw-w64-pyside6/004-fix-hardcoded-compiler.patch
@@ -1,0 +1,16 @@
+--- pyside-setup-everywhere-src-6.11.0/sources/shiboken6_generator/ApiExtractor/clangparser/compilersupport.cpp.orig	2026-05-13 14:46:56.568835800 +0300
++++ pyside-setup-everywhere-src-6.11.0/sources/shiboken6_generator/ApiExtractor/clangparser/compilersupport.cpp	2026-05-13 14:47:33.285719500 +0300
+@@ -338,7 +338,12 @@
+ QString compilerFromCMake()
+ {
+ #ifdef CMAKE_CXX_COMPILER
+-    return QString::fromLocal8Bit(CMAKE_CXX_COMPILER);
++    QString buildCompiler = QString::fromLocal8Bit(CMAKE_CXX_COMPILER);
++    QFileInfo comp_info(buildCompiler);
++    if (comp_info.exists()) {
++        return buildCompiler;
++    }
++    return comp_info.fileName();
+ #else
+     return {};
+ #endif

--- a/mingw-w64-pyside6/PKGBUILD
+++ b/mingw-w64-pyside6/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=(${MINGW_PACKAGE_PREFIX}-shiboken6
          ${MINGW_PACKAGE_PREFIX}-${_realname}
          ${MINGW_PACKAGE_PREFIX}-${_realname}-tools)
 pkgver=6.11.0
-pkgrel=3
+pkgrel=4
 pkgdesc="Enables the use of Qt6 APIs in Python applications (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -58,12 +58,14 @@ source=(https://download.qt.io/official_releases/QtForPython/pyside6/PySide6-${p
         001-fix-building-on-mingw.patch
         002-fix-install-header-files.patch
         003-fix-build-with-llvm-22.patch
+        004-fix-hardcoded-compiler.patch
         https://invent.kde.org/qt/pyside/pyside-setup/-/commit/c9d602ab.patch
         https://invent.kde.org/qt/pyside/pyside-setup/-/commit/05e32847.patch)
 sha256sums=('48d5c44d7c3ed861055d5491486e6a220ef5006573cae01a5fae3fb69d786336'
             '8faabf95564166ee9b439f40904ed8846bf90d37e8a84479e7f89dbdf238c38b'
             '3bc87409ea3dc41847f1d5d7612fd97931b67f1b40510b465543a8ef5c9764ff'
             '706add8e6447738beede6441a08d7ec617def039fcd83f04cd5768e52dba57f7'
+            '764c0f7157727a75567da77164e4f9084686d1065df4326727744ce7a85c3380'
             '67da2a6f80ba394925f5913d51b11644f38c7753e1a26f89915ca0932da4310e'
             'db4877f111320cde42adfc593aed13954209614e55e560992f4123a54efaea51')
 
@@ -86,6 +88,9 @@ prepare() {
   # Fix build with LLVM-22
   apply_patch_with_msg \
     003-fix-build-with-llvm-22.patch
+
+  apply_patch_with_msg \
+    004-fix-hardcoded-compiler.patch
 }
 
 build() {


### PR DESCRIPTION
When building shiboken generator build compiler hardcoded with full path from cmake CMAKE_CXX_COMPILER variable. To avoid this return only compiler executable if full path not exists