### PR TITLE
c3c: update to 0.8.0_1

### DIFF
--- a/mingw-w64-c3c/PKGBUILD
+++ b/mingw-w64-c3c/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=c3c
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.8.0
+pkgver=0.8.0_1
 pkgrel=1
 pkgdesc="Compiler for the C3 language (mingw-w64)"
 arch=('any')
@@ -23,7 +23,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "git")
 source=("git+${msys2_repository_url}.git#tag=v${pkgver}"
         "install-man.patch")
-sha256sums=('e25b72edfbb2ccd22f3f39cc7b214fa77bbc4a068fbb88871945c6f981a132bc'
+sha256sums=('de8fefe120531bc09e9dd2be74ba0ca8ab7c1a324b447ebf8384ac7722f984a1'
             'c800461ae8d1c6be4bb76018a7aee93b5d980664959195ba85c1195686fa5f4d')
 
 prepare() {


### PR DESCRIPTION
the strangest way to release patch versions, but vercmp says it's higher