### PR TITLE
godot-cpp: Update to 10.0.0rc1

### DIFF
--- a/mingw-w64-godot-cpp/PKGBUILD
+++ b/mingw-w64-godot-cpp/PKGBUILD
@@ -3,7 +3,8 @@
 _realname=godot-cpp
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-pkgver=4.5
+pkgver=10.0.0rc1
+_version=10.0.0-rc1
 pkgrel=1
 pkgdesc='C++ bindings for the Godot script API (mingw-w64)'
 arch=('any')
@@ -13,17 +14,17 @@ msys2_repository_url="https://github.com/godotengine/godot-cpp"
 license=('spdx:MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-godot=$pkgver"
+             "${MINGW_PACKAGE_PREFIX}-godot"
              "${MINGW_PACKAGE_PREFIX}-python")
-source=("https://github.com/godotengine/godot-cpp/archive/godot-${pkgver}-stable.tar.gz")
-sha256sums=('ac78539c0042554c494ea419549d2de88758d448721aeb0e5d41129aa87e339c')
+source=("https://github.com/godotengine/godot-cpp/archive/${_version}.tar.gz")
+sha256sums=('6a34530e81eed5bca407d68c6598be521d89d604a795bd9ed2bee9e4a7b0fee7')
 
 prepare() {
-  cd "${_realname}-godot-${pkgver}-stable"
+  cd "${_realname}-${_version}"
 }
 
 build() {
-  cd "${_realname}-godot-${pkgver}-stable"
+  cd "${_realname}-${_version}"
 
   cd gdextension
   godot --display-driver headless --dump-extension-api --dump-gdextension-interface
@@ -39,7 +40,7 @@ build() {
 }
 
 package() {
-  cd "${_realname}-godot-${pkgver}-stable"
+  cd "${_realname}-${_version}"
 
   install -dm755 "${pkgdir}${MINGW_PREFIX}"/{lib,include}
   install -Dm644 build/bin/libgodot-cpp.*.*.*.a "${pkgdir}${MINGW_PREFIX}"/lib/libgodot-cpp.a


### PR DESCRIPTION
version is no longer linked to godot, see
https://github.com/godotengine/godot-cpp/issues/1923

and 4.5 no longer builds with 4.6, so use the rc