### PR TITLE
catch: update to 3.15.0

### DIFF
--- a/mingw-w64-catch/PKGBUILD
+++ b/mingw-w64-catch/PKGBUILD
@@ -5,8 +5,8 @@ _realname=catch
 _projname=Catch2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.14.0
-pkgrel=2
+pkgver=3.15.0
+pkgrel=1
 pkgdesc="A modern, C++-native, header-only, test framework for unit-tests, TDD and BDD using C++11 and later (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -23,7 +23,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python")
 license=('spdx:BSL-1.0')
 source=("${url}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
         '0001-fix-clang-regression.patch')
-sha256sums=('ba2a939efead3c833c499cf487e185762f419a71d30158cd1b43c6079c586490'
+sha256sums=('9650c55e497759cc39b977e45524bc8acb15256061c112080916ab6cb0b1ea66'
             '5c795cb09098554f687212108a4f756a96756698a2fa4d3f7b89927ab5e46cb7')
 
 apply_patch_with_msg() {


### PR DESCRIPTION
**Edit:** OpenAL 1.25.2 failed to build despite adjusted patches, so now this PR is Catch 3.15.0 instead.