### PR TITLE
gcc: Fix atomicity of reference counters in `std::{shared,weak}_ptr`

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -53,7 +53,7 @@ else
   _url=https://gcc.gnu.org/pub/gcc/snapshots/${_version}-${_snapshot}
 fi
 _libdir=lib/gcc/${CHOST}/${pkgver}
-pkgrel=3
+pkgrel=4
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -232,6 +232,9 @@ build() {
   # This configure check fails with msvcrt due to
   # https://github.com/mingw-w64/mingw-w64/issues/163
   export gcc_cv_have_tls=yes
+
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=125312
+  export glibcxx_cv_atomic_word=yes
 
   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105507#c3
   # At least with mingw32 + dwarf-2 exceptions there can only be one libgcc in


### PR DESCRIPTION
See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=125312

At the moment, reference counters in `std::{shared,weak}_ptr` are incorrectly implemented using global mutexes.

Files that may be affected (there may be much more):

* **$** grep -Flr __exchange_and_add /mingw64/{bin,lib}
/mingw64/bin/cmake.exe
/mingw64/bin/cpack.exe
/mingw64/bin/ctest.exe
/mingw64/bin/gdb-multiarch.exe
/mingw64/bin/gdb.exe
/mingw64/bin/gdbserver-multiarch.exe
/mingw64/bin/gdbserver.exe
/mingw64/bin/libboost_cobalt-mt.dll
/mingw64/bin/libboost_filesystem-mt.dll
/mingw64/bin/libboost_graph-mt.dll
/mingw64/bin/libboost_locale-mt.dll
/mingw64/bin/libboost_log-mt.dll
/mingw64/bin/libboost_log_setup-mt.dll
/mingw64/bin/libboost_serialization-mt.dll
/mingw64/bin/libboost_wserialization-mt.dll
/mingw64/bin/libcppdap.dll
/mingw64/bin/libmpdec++-4.dll
/mingw64/bin/libstdc++-6.dll
/mingw64/bin/pzstd.exe
/mingw64/lib/libboost_cobalt-mt.a
/mingw64/lib/libboost_filesystem-mt.a
/mingw64/lib/libboost_graph-mt.a
/mingw64/lib/libboost_locale-mt.a
/mingw64/lib/libboost_log-mt.a
/mingw64/lib/libboost_log_setup-mt.a
/mingw64/lib/libboost_serialization-mt.a
/mingw64/lib/libboost_wserialization-mt.a
/mingw64/lib/libmpdec++.a
/mingw64/lib/libstdc++.a
/mingw64/lib/libstdc++.dll.a
/mingw64/lib/libstdc++exp.a
/mingw64/lib/libstdc++fs.a
/mingw64/lib/libsupc++.a
