### PR TITLE
python-pytorch: update to 2.12.0

### DIFF
--- a/mingw-w64-python-pytorch/0003-pytorch-mingw-port.patch
+++ b/mingw-w64-python-pytorch/0003-pytorch-mingw-port.patch
@@ -18,7 +18,7 @@ index 60501c6b53..e4b148e293 100644
 @@ -42,7 +42,11 @@ C10_API static Tensor run_pointwise_binary_tensor(
        std::string_view unary_post_op_algorithm);
  };
- 
+
 +#if defined(__MINGW32__)
 +Tensor _weight_int4pack_mm_cpu_tensor(
 +#else
@@ -204,48 +204,29 @@ index 86a7b75f97..fcd3fcee7e 100644
  #endif // defined(_WIN32)
  
  // Creates the filename pattern passed to and completed by `mkstemp`.
-diff --git a/caffe2/CMakeLists.txt b/caffe2/CMakeLists.txt
-index 0a419e46a5..3040a9f55d 100644
---- a/caffe2/CMakeLists.txt
-+++ b/caffe2/CMakeLists.txt
-@@ -1586,6 +1586,12 @@ if(MSVC AND BUILD_SHARED_LIBS)
-   target_compile_options(torch_cpu PRIVATE "-DONNX_BUILD_MAIN_LIB")
- endif()
- 
-+if(MINGW AND BUILD_SHARED_LIBS)
-+  # ONNX is linked statically into torch_cpu. Export the small ONNX surface used
-+  # by torch_python so it does not carry a second protobuf registry.
-+  target_sources(torch_cpu PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/torch_cpu_mingw_exports.def")
-+endif()
-+
- caffe2_interface_library(torch_cpu torch_cpu_library)
- 
- if(USE_CUDA)
-diff --git a/caffe2/torch_cpu_mingw_exports.def b/caffe2/torch_cpu_mingw_exports.def
-new file mode 100644
-index 0000000000..180cd89240
---- /dev/null
-+++ b/caffe2/torch_cpu_mingw_exports.def
-@@ -0,0 +1,11 @@
-+EXPORTS
-+  _ZN10onnx_torch10GraphProtoC1EPN6google8protobuf5ArenaE
-+  _ZN10onnx_torch15shape_inference11InferShapesERNS_10ModelProtoEPKNS_15ISchemaRegistryERKNS_21ShapeInferenceOptionsEPSt13unordered_mapINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEENS_16TensorShapeProtoESt4hashISF_ESt8equal_toISF_ESaISt4pairIKSF_SG_EEE
-+  _ZN10onnx_torch16OpSchemaRegistry8InstanceEv
-+  _ZN10onnx_torch16TensorShapeProto8CopyFromERKS0_
-+  _ZN10onnx_torch16TensorShapeProtoC1EPN6google8protobuf5ArenaE
-+  _ZN10onnx_torch16TensorShapeProtoD1Ev
-+  _ZN10onnx_torch28_TypeProto_default_instance_E DATA
-+  _ZN10onnx_torch29_GraphProto_default_instance_E DATA
-+  _ZN10onnx_torch35_TensorShapeProto_default_instance_E DATA
-+  _ZN10onnx_torch9TypeProto5ClearEv
+diff --git a/c10/util/typeid.h b/c10/util/typeid.h
+index 737d7d51dd..c31df628c 100644
+--- a/c10/util/typeid.h
++++ b/c10/util/typeid.h
+@@ -646,7 +646,7 @@ createTypeMetaData() {
+ #define CAFFE_DEFINE_KNOWN_TYPE(T, ident)                   \
+   template uint16_t TypeMeta::addTypeMetaData<T>();         \
+   namespace detail {                                        \
+-  EXPORT_IF_NOT_GCC const uint16_t ident##_metadata_index = \
++  extern EXPORT_IF_NOT_GCC const uint16_t ident##_metadata_index = \
+       TypeMeta::addTypeMetaData<T>();                       \
+   } // namespace detail
+
+ // Unlike CAFFE_KNOWN_TYPE, CAFFE_DECLARE_KNOWN_TYPE avoids a function
 diff --git a/caffe2/utils/string_utils.h b/caffe2/utils/string_utils.h
 index 6bf3b867b5..12bfd23783 100644
 --- a/caffe2/utils/string_utils.h
 +++ b/caffe2/utils/string_utils.h
-@@ -1,6 +1,7 @@
+@@ -1,6 +1,8 @@
  #pragma once
  
  #include <algorithm>
++#include <array>
 +#include <cstdint>
  #include <memory>
  #include <string>
@@ -572,14 +553,15 @@ diff --git a/torch/csrc/profiler/kineto_shim.h b/torch/csrc/profiler/kineto_shim
 index c4efd7785b..d518194fe1 100644
 --- a/torch/csrc/profiler/kineto_shim.h
 +++ b/torch/csrc/profiler/kineto_shim.h
-@@ -1,5 +1,6 @@
+@@ -1,5 +1,7 @@
  #pragma once
  
++#include <array>
 +#include <cstdint>
  #include <memory>
  #include <string>
  
-@@ -12,7 +13,38 @@
+@@ -12,7 +14,81 @@
  #undef USE_KINETO
  #endif
  
@@ -588,51 +570,79 @@ index c4efd7785b..d518194fe1 100644
 +#else
 +namespace libkineto {
 +enum class ActivityType : uint8_t {
-+  CPU_OP,
-+  CPU_INSTANT_EVENT,
-+  USER_ANNOTATION,
-+  EXTERNAL_CORRELATION,
-+  XPU_RUNTIME,
-+  XPU_DRIVER,
-+  CUDA_RUNTIME,
-+  CUDA_DRIVER,
-+  PYTHON_FUNCTION,
-+  PRIVATEUSE1_RUNTIME,
-+  PRIVATEUSE1_DRIVER,
-+  GPU_MEMCPY,
-+  GPU_MEMSET,
-+  GPU_USER_ANNOTATION,
-+  CONCURRENT_KERNEL,
-+  GLOW_RUNTIME,
-+  OVERHEAD,
-+  MTIA_CCP_EVENTS,
-+  MTIA_RUNTIME,
-+  MTIA_INSIGHT,
-+  HPU_OP,
-+  CUDA_PROFILER_RANGE,
-+  CUDA_SYNC,
-+  COLLECTIVE_COMM,
++  CPU_OP = 0,
++  USER_ANNOTATION = 1,
++  GPU_USER_ANNOTATION = 2,
++  GPU_MEMCPY = 3,
++  GPU_MEMSET = 4,
++  CONCURRENT_KERNEL = 5,
++  EXTERNAL_CORRELATION = 6,
++  CUDA_RUNTIME = 7,
++  CUDA_DRIVER = 8,
++  CPU_INSTANT_EVENT = 9,
++  PYTHON_FUNCTION = 10,
++  OVERHEAD = 11,
++  MTIA_RUNTIME = 12,
++  MTIA_CCP_EVENTS = 13,
++  MTIA_INSIGHT = 14,
++  CUDA_SYNC = 15,
++  CUDA_EVENT = 16,
++  MTIA_COUNTERS = 17,
++  GLOW_RUNTIME = 18,
++  CUDA_PROFILER_RANGE = 19,
++  HPU_OP = 20,
++  XPU_RUNTIME = 21,
++  XPU_DRIVER = 22,
++  COLLECTIVE_COMM = 23,
++  PRIVATEUSE1_RUNTIME = 24,
++  PRIVATEUSE1_DRIVER = 25,
++  ENUM_COUNT = 26,
++  OPTIONAL_ACTIVITY_TYPE_START = GLOW_RUNTIME,
 +};
++
++struct _ActivityTypeName {
++  const char* name;
++  ActivityType type;
++};
++
++inline constexpr std::array<_ActivityTypeName, static_cast<int>(ActivityType::ENUM_COUNT) + 1> _activityTypeNames{{
++    {"cpu_op", ActivityType::CPU_OP},
++    {"user_annotation", ActivityType::USER_ANNOTATION},
++    {"gpu_user_annotation", ActivityType::GPU_USER_ANNOTATION},
++    {"gpu_memcpy", ActivityType::GPU_MEMCPY},
++    {"gpu_memset", ActivityType::GPU_MEMSET},
++    {"kernel", ActivityType::CONCURRENT_KERNEL},
++    {"external_correlation", ActivityType::EXTERNAL_CORRELATION},
++    {"cuda_runtime", ActivityType::CUDA_RUNTIME},
++    {"cuda_driver", ActivityType::CUDA_DRIVER},
++    {"cpu_instant_event", ActivityType::CPU_INSTANT_EVENT},
++    {"python_function", ActivityType::PYTHON_FUNCTION},
++    {"overhead", ActivityType::OVERHEAD},
++    {"mtia_runtime", ActivityType::MTIA_RUNTIME},
++    {"mtia_ccp_events", ActivityType::MTIA_CCP_EVENTS},
++    {"mtia_insight", ActivityType::MTIA_INSIGHT},
++    {"cuda_sync", ActivityType::CUDA_SYNC},
++    {"cuda_event", ActivityType::CUDA_EVENT},
++    {"mtia_counters", ActivityType::MTIA_COUNTERS},
++    {"glow_runtime", ActivityType::GLOW_RUNTIME},
++    {"cuda_profiler_range", ActivityType::CUDA_PROFILER_RANGE},
++    {"hpu_op", ActivityType::HPU_OP},
++    {"xpu_runtime", ActivityType::XPU_RUNTIME},
++    {"xpu_driver", ActivityType::XPU_DRIVER},
++    {"collective_comm", ActivityType::COLLECTIVE_COMM},
++    {"privateuse1_runtime", ActivityType::PRIVATEUSE1_RUNTIME},
++    {"privateuse1_driver", ActivityType::PRIVATEUSE1_DRIVER},
++    {"ENUM_COUNT", ActivityType::ENUM_COUNT},
++}};
++
++inline const char* toString(ActivityType t) {
++  return _activityTypeNames[static_cast<int>(t)].name;
++}
 +} // namespace libkineto
 +#endif
  
  #include <torch/csrc/Export.h>
  #include <torch/csrc/profiler/api.h>
-diff --git a/torch/csrc/utils/python_arg_parser.cpp b/torch/csrc/utils/python_arg_parser.cpp
-index 999bd00b3b..d1264c2303 100644
---- a/torch/csrc/utils/python_arg_parser.cpp
-+++ b/torch/csrc/utils/python_arg_parser.cpp
-@@ -756,8 +756,8 @@ auto handle_torch_function_indexing(
-   py::object func =
-       PyObject_FastGetAttrString(THPVariableClass, (char*)func_name);
-   py::object args = (val == nullptr)
--      ? py::make_tuple(py::handle(self), py::handle(index))
--      : py::make_tuple(py::handle(self), py::handle(index), py::handle(val));
-+      ? py::object(py::make_tuple(py::handle(self), py::handle(index)))
-+      : py::object(py::make_tuple(py::handle(self), py::handle(index), py::handle(val)));
-   return handle_torch_function_no_python_arg_parser(
-       overridable_args,
-       args.ptr(),
 diff --git a/torch/headeronly/macros/Export.h b/torch/headeronly/macros/Export.h
 index 14b26c18e7..c877efa1ef 100644
 --- a/torch/headeronly/macros/Export.h
@@ -692,6 +702,19 @@ index 6fa82347ac..da62c48d52 100644
  
  // Copied from folly/portability/Fcntl.h
  #define O_CLOEXEC _O_NOINHERIT
+diff --git a/tools/autograd/gen_autograd_functions.py b/tools/autograd/gen_autograd_functions.py
+index 0297d6d1da..a1fb6eba58 100644
+--- a/tools/autograd/gen_autograd_functions.py
++++ b/tools/autograd/gen_autograd_functions.py
+@@ -54,7 +54,7 @@ FUNCTION_DECLARATION = CodeTemplate(
+     """\
+-#ifdef _WIN32
++#ifdef _MSC_VER
+ struct ${op} : public ${superclass} {
+   TORCH_API ${op}() = default;
+ #else
+ struct TORCH_API ${op} : public ${superclass} {
+ #endif
 diff --git a/setup.py b/setup.py
 index 0decaf66ed..fccea1225c 100644
 --- a/setup.py

--- a/mingw-w64-python-pytorch/PKGBUILD
+++ b/mingw-w64-python-pytorch/PKGBUILD
@@ -3,12 +3,12 @@
 _realname=pytorch
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=2.11.0
-pkgrel=2
+pkgver=2.12.0
+pkgrel=1
 _srcdir=${_realname}-v${pkgver}
 pkgdesc="Tensors and dynamic neural networks in Python (mingw-w64)"
 arch=('any')
-mingw_arch=('ucrt64')
+mingw_arch=('ucrt64' 'clang64')
 url="https://pytorch.org/"
 msys2_repository_url="https://github.com/pytorch/pytorch"
 msys2_references=(
@@ -57,10 +57,10 @@ source=("https://github.com/pytorch/pytorch/releases/download/v${pkgver}/pytorch
         "0003-pytorch-mingw-port.patch"
         "0004-third_party-onnx-optional-macro.patch"
         "0005-fix-build-with-glog-0.7.patch")
-sha256sums=('ab3fde9e7e382f45ac942be6ea2c2ef362c5ccd6f55ed6d5f35e6ea81d3ab88e'
+sha256sums=('7cc1deb309f402ad67e9f45bbe311a40def4db19d66fddb9b01950f9bfc5ccb1'
             'ee509420cada0283dc0a5ad2a6c0128e9482e253f98666329d87526a1b4db150'
             '80ea46b21ddf7fc841222a2e4753206d192a025242e33c17163dfced27b8468c'
-            'a76d096a86161891cb658018890426dd33b39e71bfabd79d46c96768d886879a'
+            '747411809edfaaaadf13ee337bf4a78a8e88018f3c1a0dfc4a59b434cee955a8'
             'ab4972112b3f3791d113a884ece1ddd1f81a63ac6970df044d0867aa75df2eb4'
             'a4be93a18407e794cce2b1185476f7d31db42fb3a974a2c3b66f7bfe2f6365d3')
 noextract=("pytorch-v${pkgver}.tar.gz")
@@ -88,7 +88,7 @@ prepare() {
 }
 
 build() {
-  cd "${srcdir}/${_srcdir}"
+  cp -r "${_srcdir}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
 
   export PYTORCH_BUILD_VERSION="${pkgver}"
   export PYTORCH_BUILD_NUMBER=1
@@ -128,11 +128,11 @@ build() {
   CFLAGS+=" -w"
   CXXFLAGS+=" -w"
 
-  ${MINGW_PREFIX}/bin/python setup.py bdist_wheel
+  ${MINGW_PREFIX}/bin/python setup.py build bdist_wheel
 }
 
 package() {
-  cd "${srcdir}/${_srcdir}"
+  cd "${srcdir}/python-build-${MSYSTEM}"
 
   local _install_dir=$(mktemp -d)
   local _install_dest=$(cygpath -m "${_install_dir}")


### PR DESCRIPTION
@MehdiChinoune fixing pytorch to be more mantainable, how it used to work before, you just had to fix linker errors by building first getting errors, then using the linking errors from gcc to extract the symbols that you wanted.. with that `.def` hack. I found a better way. This should be easier to update.