### PR TITLE
uutils-diffutils: replace invalid launchers

### DIFF
--- a/mingw-w64-uutils-diffutils/PKGBUILD
+++ b/mingw-w64-uutils-diffutils/PKGBUILD
@@ -3,7 +3,7 @@ _realname=diffutils
 pkgbase=mingw-w64-uutils-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-uutils-${_realname}")
 pkgver=0.5.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Rust rewrite of ${_realname} (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -13,11 +13,14 @@ msys2_references=(
 )
 license=('spdx:MIT' 'spdx:APACHE')
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
-source=("${url}/archive/refs/tags/v${pkgver}.tar.gz")
-sha256sums=('4c05d236ebddef7738446980a59cd13521b6990ea02242db6b32321dd93853ca')
+source=("${url}/archive/refs/tags/v${pkgver}.tar.gz"
+"prefix-name.patch::${url}/commit/92006cbe83b903784e1c420390eaab5abe629fad.patch")
+sha256sums=('4c05d236ebddef7738446980a59cd13521b6990ea02242db6b32321dd93853ca'
+            'fc92b79e424165facf38255726d880c5026b553061f005705d393d960135ec5a')
 
 prepare() {
   cd "${_realname}-${pkgver}"
+  patch -Np1 -i ../prefix-name.patch
   cargo fetch --locked --target "${RUST_CHOST}"
 }
 
@@ -28,12 +31,8 @@ build(){
 
 package() {
   cd "${_realname}-$pkgver"
-  # prefixed names are not supported...
-  install -Dm755 "target/release/${_realname}" "${pkgdir}${MINGW_PREFIX}/lib/uutils"
-  echo -e "#!/bin/sh\nexec ${MINGW_PREFIX}/lib/uutils/diffutils diff \$@" > uu-diff
-  echo -e "#!/bin/sh\nexec ${MINGW_PREFIX}/lib/uutils/diffutils cmp \$@" > uu-cmp
-  install -Dm755 uu-diff -t "${pkgdir}${MINGW_PREFIX}/bin"
-  install -Dm755 uu-cmp -t "${pkgdir}${MINGW_PREFIX}/bin"
+  install -Dm755 "target/release/${_realname}" "${pkgdir}${MINGW_PREFIX}/bin/uu-diff"
+  (cd "${pkgdir}${MINGW_PREFIX}/bin" && ln uu-diff uu-cmp)
   install -Dm644 LICENSE-MIT -t "${pkgdir}${MINGW_PREFIX}/share/licenses/uutils-${_realname}"
   install -Dm644 LICENSE-APACHE -t "${pkgdir}${MINGW_PREFIX}/share/licenses/uutils-${_realname}"
 }

--- a/mingw-w64-uutils-diffutils/PKGBUILD
+++ b/mingw-w64-uutils-diffutils/PKGBUILD
@@ -14,7 +14,7 @@ msys2_references=(
 license=('spdx:MIT' 'spdx:APACHE')
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
 source=("${url}/archive/refs/tags/v${pkgver}.tar.gz"
-"prefix-name.patch::${url}/commit/92006cbe83b903784e1c420390eaab5abe629fad.patch")
+        "prefix-name.patch::${url}/commit/92006cbe83b903784e1c420390eaab5abe629fad.patch")
 sha256sums=('4c05d236ebddef7738446980a59cd13521b6990ea02242db6b32321dd93853ca'
             'fc92b79e424165facf38255726d880c5026b553061f005705d393d960135ec5a')
 


### PR DESCRIPTION
`/ucrt64/lib/uutils.exe` is invalid