### PR TITLE
new-package: pspg 5.8.12

### DIFF
--- a/mingw-w64-pspg/PKGBUILD
+++ b/mingw-w64-pspg/PKGBUILD
@@ -1,0 +1,48 @@
+_realname=pspg
+pkgbase=mingw-w64-${realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=5.8.12
+pkgrel=1
+pkgdesc='Feature-rich table-oriented pager for PostgreSQL, MySQL, pgcli, CSV, and TSV (mingw-w64)'
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/okbob/pspg'
+# TODO move me once PRs merged
+msys2_repository_url='https://github.com/mlt/pspg'
+msys2_references=(
+  'anitya: 16511'
+  'arch: pspg'
+)
+license=('BSD-2')
+depends=("${MINGW_PACKAGE_PREFIX}-ncurses"
+#         "${MINGW_PACKAGE_PREFIX}-pdcurses"
+         "${MINGW_PACKAGE_PREFIX}-postgresql"
+         "${MINGW_PACKAGE_PREFIX}-readline")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-autotools"
+             'git')
+source=("${_realname}-${pkgver}::git+${msys2_repository_url}")
+# source=("${_realname}-${pkgver}.tar.gz::${url}/archive/refs/tags/${pkgver}.tar.gz")
+sha256sums=('SKIP')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  ./autogen.sh
+}
+
+build() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  # PANEL_LIBS=-lpdcurses_vt CURSES_LIBS=-lpdcurses_vt \
+  # CFLAGS="-I $MINGW_PREFIX/include/pdcurses -DPDC_WIDE=Y -DPDC_FORCE_UTF8=Y" \
+  ./configure --prefix=$MINGW_PREFIX
+  make
+}
+
+package() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  make DESTDIR="${pkgdir}" install
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  install -Dm644 README.md "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}/README.md"
+  install -Dm644 bash-completion.sh "${pkgdir}${MINGW_PREFIX}/share/bash-completion/completions/${_realname}"
+  install -Dm644 pspg.1 "${pkgdir}${MINGW_PREFIX}/share/man/man1/pspg.1"
+}


### PR DESCRIPTION
Pager for psql and tabular files.
This would greatly benefit from #28593 making postgresql package a weak dependency. I'm inclined to build it without use of libpq as pager only (still can be used with psql).
This is a placeholder for now due to WIP with some changes pending upstream simi/pspg#2.
<img width="721" height="412" alt="image" src="https://github.com/user-attachments/assets/1113815f-f997-40fe-bbac-b021f38caf3d" />
