### PR TITLE
mumps: C driver consistency fix

### DIFF
--- a/mingw-w64-mumps/0001-makefile.inc.patch
+++ b/mingw-w64-mumps/0001-makefile.inc.patch
@@ -155,7 +155,7 @@ diff -urN MUMPS_5.3.1.orig/Makefile.inc.PAR MUMPS_5.3.1/Makefile.inc.PAR
 +
 +#COMPILER OPTIONS
 +OPTF    = $(FFLAGS) -I. -fopenmp -DBLR_MT
-+OPTC    = $(CFLAGS) -I.
++OPTC    = $(CFLAGS) -I. -fopenmp -DBLR_MT
 +OPTL    = $(CFLAGS) -fopenmp
 +
 +# CHOOSE BETWEEN USING THE SEQUENTIAL OR THE PARALLEL VERSION.
@@ -478,7 +478,7 @@ diff -urN MUMPS_5.3.1.orig/Makefile.inc.SHM MUMPS_5.3.1/Makefile.inc.SHM
 +
 +#COMPILER OPTIONS
 +OPTF    = $(FFLAGS) -I. -fopenmp -DBLR_MT
-+OPTC    = $(CFLAGS) -I.
++OPTC    = $(CFLAGS) -I. -fopenmp -DBLR_MT
 +OPTL    = $(CFLAGS) -fopenmp
 +
 +#Sequential:

--- a/mingw-w64-mumps/PKGBUILD
+++ b/mingw-w64-mumps/PKGBUILD
@@ -33,7 +33,7 @@ _realname=mumps
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.9.0
-pkgrel=2
+pkgrel=3
 pkgdesc="MUltifrontal Massively Parallel sparse direct solver (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -60,7 +60,7 @@ source=("https://mumps-solver.org/MUMPS_${pkgver}.tar.gz"
         "buildme-0.tm"
         "xyz-0.tm")
 sha256sums=('02c6efdb91749ec0f82351d40f3f860547272a1eb1d899126a4265b4d6bcc4ca'
-            '9d6df2d18a2fbf512a5808168335b712a1728a6979c5bc8b977ac73d7a0a6da1'
+            '9964c88184f19644ef66c219114708f1276ffc2ccd1a34c1f8dd72aa866f4159'
             'bbefd4a5f841536132f32c1ffc684a58b778901cd777445ca817dbb34d983450'
             '357c13b985e75604fd9f59f2f174e6c75fd9133d0806e2db2d584d33e32b108d'
             'e967554f139833fe6f10ccc5fcd82a346b480b2827475ea9bd50eeb5d017b2b0'


### PR DESCRIPTION
This patch fixes the library crash when used with OMP/MPI C code.