### PR TITLE
okular: Add breeze dependency

### DIFF
--- a/mingw-w64-okular/PKGBUILD
+++ b/mingw-w64-okular/PKGBUILD
@@ -5,7 +5,7 @@ _realname=okular
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=26.04.0
-pkgrel=3
+pkgrel=4
 pkgdesc='Document Viewer (mingw-w64)'
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -17,6 +17,7 @@ msys2_repository_url='https://invent.kde.org/graphics/okular/'
 url='https://apps.kde.org/okular/'
 license=('spdx:GPL-2.0-or-later AND LGPL-2.0-or-later')
 depends=(
+  "${MINGW_PACKAGE_PREFIX}-breeze"
   "${MINGW_PACKAGE_PREFIX}-discount"
   "${MINGW_PACKAGE_PREFIX}-djvulibre"
   "${MINGW_PACKAGE_PREFIX}-freetype"
@@ -63,7 +64,6 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-ninja"
 )
 optdepends=(
-  "${MINGW_PACKAGE_PREFIX}-breeze-icons: application icon theme"
   "${MINGW_PACKAGE_PREFIX}-ebook-tools: mobi and epub support"
   "${MINGW_PACKAGE_PREFIX}-kdegraphics-mobipocket: mobi support"
   "${MINGW_PACKAGE_PREFIX}-unrar: Comic Book Archive support"


### PR DESCRIPTION
Add `breeze` as a runtime dependency for Okular.

Okular 26.04.0 calls `KStyleManager::initStyle()` on Windows. KF6 falls back to the Breeze widget style when no explicit widget style is configured, but the current package only pulls `breeze-icons`, so the actual `breeze6.dll` Qt style plugin can be missing. In Windows dark mode this can leave Okular with light/dark palette text applied over a light toolbar.

`breeze` already depends on `breeze-icons`, so the separate `breeze-icons` optdep becomes redundant.

Closes #29583
