### PR TITLE
python-imagecodecs: update to 2026.5.10

### DIFF
--- a/mingw-w64-python-imagecodecs/0001-deflate.patch
+++ b/mingw-w64-python-imagecodecs/0001-deflate.patch
@@ -1,11 +1,11 @@
 --- a/setup.py
 +++ b/setup.py
-@@ -139,7 +139,7 @@
-     'brunsli': ext(libraries=['brunslidec-c', 'brunslienc-c']),
-     'bz2': ext(libraries=['bz2']),
+@@ -180,7 +180,7 @@
+         include_dirs=['3rdparty/ccitt'],
+     ),
      'cms': ext(libraries=['lcms2']),
 -    'deflate': ext(libraries=['deflate']),
 +    'deflate': ext(libraries=['deflate'],define_macros=[('LIBDEFLATE_DLL', 1)]),
-     # 'exr': ext(
-     #     sources=['3rdparty/tinyexr/tinyexr.cc'],
-     #     include_dirs=['3rdparty/tinyexr'],
+     'exr': ext(libraries=['OpenEXRCore-3_4']),
+     'gif': ext(libraries=['gif']),
+     'h5checksum': ext(

--- a/mingw-w64-python-imagecodecs/PKGBUILD
+++ b/mingw-w64-python-imagecodecs/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=imagecodecs
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=2026.3.6
-pkgrel=2
+pkgver=2026.5.10
+pkgrel=1
 pkgdesc="Image transformation, compression, and decompression codecs (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -48,7 +48,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
         "0001-deflate.patch")
-sha256sums=('471b8a4d1b3843cbf7179b45f7d7261f0c0b28809efc1ca6c47822477b143b85'
+sha256sums=('1c0c46860f35e4637c2df70ebe8aa15141f6c4202a698e63757a4d7917a85acc'
             '51e7f4d58ef17d230bf9755832902982b4c228c153d30c65749d2312c3bbf281')
 
 prepare() {

--- a/mingw-w64-python-imagecodecs/PKGBUILD
+++ b/mingw-w64-python-imagecodecs/PKGBUILD
@@ -49,7 +49,7 @@ options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
         "0001-deflate.patch")
 sha256sums=('1c0c46860f35e4637c2df70ebe8aa15141f6c4202a698e63757a4d7917a85acc'
-            '51e7f4d58ef17d230bf9755832902982b4c228c153d30c65749d2312c3bbf281')
+            'f3416e6c6d99bda6ee65c82c386f98454de0686ecd6f409a9fc90ee44dcd0a38')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"


### PR DESCRIPTION
Will try to enable new codecs (exr, wavpack, also wic?) in a separate PR later...