### PR TITLE
roswell: update to 26.02.116

### DIFF
--- a/mingw-w64-roswell/PKGBUILD
+++ b/mingw-w64-roswell/PKGBUILD
@@ -2,7 +2,7 @@
 _realname=roswell
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=24.10.115
+pkgver=26.02.116
 pkgrel=1
 pkgdesc="Lisp installer and launcher (mingw-w64)"
 url="https://github.com/roswell/roswell"
@@ -15,7 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-cc")
 optdepends=()
 source=("https://github.com/roswell/roswell/archive/v$pkgver.tar.gz")
-sha256sums=('9c23cb263d4645caaae21cda8f1f5793b0f08ee5c5338aab5974cb4f473d1c4b')
+sha256sums=('edece1aa4a807ee36f44061aa802354c722cb5bd80b5056b19aa982c14709a6c')
 
 build() {
   cd "${srcdir}"/${_realname}-${pkgver}


### PR DESCRIPTION
I updated the pkgver to the latest roswell version to `26.02.116`
I updated the checksum with  `updpkgsums`

I build it locally to verify that it built correctly:

``` bash
...
 /usr/bin/install -c -m 644 lisp/list-env.lisp lisp/util-template.lisp lisp/util-use.lisp lisp/use-asdf.lisp lisp/use-env.lisp '/home/andre/MINGW-packages/mingw-w64-roswell/pkg/mingw-w64-x86_64-roswell/mingw64/etc/roswell'
make[2]: Leaving directory '/home/andre/MINGW-packages/mingw-w64-roswell/src/roswell-26.02.116'
make[1]: Leaving directory '/home/andre/MINGW-packages/mingw-w64-roswell/src/roswell-26.02.116'
==> Tidying install...
  -> Removing libtool files...
  -> Purging unwanted files...
  -> Stripping unneeded symbols from binaries and libraries...
  -> Compressing man and info pages...
==> Checking for packaging issues...
==> Creating package "mingw-w64-x86_64-roswell"...
  -> Generating .PKGINFO file...
  -> Generating .BUILDINFO file...
  -> Generating .MTREE file...
  -> Compressing package...
==> Finished making: mingw-w64-roswell 26.02.116-1 (Thu, May 21, 2026  7:43:43 PM)
 Shell  andre   mingw-w64-roswell   update-roswell ≡ 
```

In the case that my PR will be rejected, please briefly let me know the reason.

Thank you,