### PR TITLE
quickjs-ng: Update to 0.15.0

### DIFF
--- a/mingw-w64-quickjs-ng/PKGBUILD
+++ b/mingw-w64-quickjs-ng/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=quickjs-ng
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.12.1
+pkgver=0.15.0
 pkgrel=1
 pkgdesc="Small and embeddable JavaScript engine (mingw-w64)"
 url="https://quickjs-ng.github.io/quickjs"
@@ -20,7 +20,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cc")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/quickjs-ng/quickjs/archive/refs/tags/v${pkgver}.tar.gz")
-sha256sums=('c2c54b76ca2f52ffea49658a61c5111449cfe0f94e62510bd3bd7a12e2e18884')
+sha256sums=('d65f951fa9d347a912a53ec2c151bd0ac79bf73d445788e67670ca1b894c67c4')
 
 build() {
   declare -a extra_config
@@ -35,6 +35,7 @@ build() {
       -GNinja \
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       -DBUILD_SHARED_LIBS=ON \
+      -DQJS_BUILD_LIBC=ON \
       -DCMAKE_DLL_NAME_WITH_SOVERSION=ON \
       "${extra_config[@]}" \
       -S "quickjs-${pkgver}" \


### PR DESCRIPTION
https://github.com/quickjs-ng/quickjs/releases/tag/v0.15.0