### PR TITLE
python-sphinx: Update to 9.1.0 + rename roman-numerals

### DIFF
--- a/mingw-w64-python-roman-numerals/PKGBUILD
+++ b/mingw-w64-python-roman-numerals/PKGBUILD
@@ -1,16 +1,19 @@
 # Maintainer: Biswapriyo Nath <nathbappai@gmail.com>
 
-_realname=roman-numerals-py
+_realname=roman-numerals
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=3.1.0
-pkgrel=3
+pkgrel=1
 pkgdesc="Manipulate well-formed Roman numerals (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 msys2_references=(
-  'purl: pkg:pypi/roman-numerals-py'
+  'purl: pkg:pypi/roman-numerals'
 )
+provides=("${MINGW_PACKAGE_PREFIX}-python-roman-numerals-py=${pkgver}")
+replaces=("${MINGW_PACKAGE_PREFIX}-python-roman-numerals-py")
+conflicts=("${MINGW_PACKAGE_PREFIX}-python-roman-numerals-py")
 url='https://github.com/AA-Turner/roman-numerals/tree/master/python'
 msys2_repository_url='https://github.com/AA-Turner/roman-numerals/tree/master/python'
 license=('spdx:0BSD OR CC0-1.0')
@@ -20,7 +23,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname//-/_}/${_realname//-/_}-${pkgver}.tar.gz")
-sha256sums=('be4bf804f083a4ce001b5eb7e3c0862479d10f94c936f6c4e5f250aa5ff5bd2d')
+sha256sums=('384e36fc1e8d4bd361bdb3672841faae7a345b3f708aae9895d074c878332551')
 
 build() {
   cp -r "${_realname//-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-python-sphinx/PKGBUILD
+++ b/mingw-w64-python-sphinx/PKGBUILD
@@ -5,8 +5,8 @@ _pyname=Sphinx
 _realname=sphinx
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=8.2.3
-pkgrel=3
+pkgver=9.1.0
+pkgrel=1
 pkgdesc="Python documentation generator (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -25,7 +25,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-python-babel"
          "${MINGW_PACKAGE_PREFIX}-python-packaging"
          "${MINGW_PACKAGE_PREFIX}-python-pygments"
          "${MINGW_PACKAGE_PREFIX}-python-requests"
-         "${MINGW_PACKAGE_PREFIX}-python-roman-numerals-py"
+         "${MINGW_PACKAGE_PREFIX}-python-roman-numerals"
          "${MINGW_PACKAGE_PREFIX}-python-snowballstemmer"
          "${MINGW_PACKAGE_PREFIX}-python-sphinx-alabaster-theme"
          "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-applehelp"
@@ -44,7 +44,7 @@ fi
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-defusedxml"
               "${MINGW_PACKAGE_PREFIX}-python-pytest")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348')
+sha256sums=('7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb')
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"


### PR DESCRIPTION
the package was renamed upstream, but still provides the same module