### PR TITLE
fastfetch: update to 2.63.1

### DIFF
--- a/mingw-w64-fastfetch/PKGBUILD
+++ b/mingw-w64-fastfetch/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=fastfetch
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.62.1
+pkgver=2.63.1
 pkgrel=1
 pkgdesc="An actively maintained, feature-rich and performance oriented, neofetch like system information tool (mingw-w64)"
 arch=('any')
@@ -30,15 +30,16 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-vulkan-headers"
              "${MINGW_PACKAGE_PREFIX}-opencl-icd"
              "${MINGW_PACKAGE_PREFIX}-opencl-headers"
-             "${MINGW_PACKAGE_PREFIX}-cppwinrt"
+             # WinRT support is broken, reenable after https://github.com/fastfetch-cli/fastfetch/issues/2341 is resolved.
+             # "${MINGW_PACKAGE_PREFIX}-cppwinrt"
              "${MINGW_PACKAGE_PREFIX}-python")
 optdepends=("${MINGW_PACKAGE_PREFIX}-vulkan-loader: For Vulkan detection support"
             "${MINGW_PACKAGE_PREFIX}-opencl-icd: For OpenCL detection support"
             "${MINGW_PACKAGE_PREFIX}-chafa: For chafa image protocol support"
             "${MINGW_PACKAGE_PREFIX}-imagemagick: For sixel image protocol support")
-source=("https://github.com/fastfetch-cli/fastfetch/archive/${pkgver}/${_realname}-${pkgver}.tar.gz")
+source=("${url}/archive/${pkgver}/${_realname}-${pkgver}.tar.gz")
 noextract=("${_realname}-${pkgver}.tar.gz")
-sha256sums=('8c4833e55b8b445a32c7cb7570007b5e10a9ee4cee74a494004ba61e88b12b26')
+sha256sums=('6e124699ea20fb02c5bc402c0012543303ee75ca55ad664f96bc6cd414d7e6b3')
 
 prepare() {
   # Workaround for symlinks in archive, see <https://www.msys2.org/docs/symlinks/>.

--- a/mingw-w64-fastfetch/PKGBUILD
+++ b/mingw-w64-fastfetch/PKGBUILD
@@ -31,7 +31,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-opencl-icd"
              "${MINGW_PACKAGE_PREFIX}-opencl-headers"
              "${MINGW_PACKAGE_PREFIX}-python")
-# WinRT support is broken, reenable after https://github.com/fastfetch-cli/fastfetch/issues/2341 is resolved.
+# WinRT support is broken for GCC, reenable after
+# https://github.com/fastfetch-cli/fastfetch/issues/2341 is resolved.
 if [[ ${CC} != gcc ]]; then
   depends+=("${MINGW_PACKAGE_PREFIX}-cppwinrt")
 fi

--- a/mingw-w64-fastfetch/PKGBUILD
+++ b/mingw-w64-fastfetch/PKGBUILD
@@ -30,9 +30,11 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-vulkan-headers"
              "${MINGW_PACKAGE_PREFIX}-opencl-icd"
              "${MINGW_PACKAGE_PREFIX}-opencl-headers"
-             # WinRT support is broken, reenable after https://github.com/fastfetch-cli/fastfetch/issues/2341 is resolved.
-             # "${MINGW_PACKAGE_PREFIX}-cppwinrt"
              "${MINGW_PACKAGE_PREFIX}-python")
+# WinRT support is broken, reenable after https://github.com/fastfetch-cli/fastfetch/issues/2341 is resolved.
+if [[ ${CC} == gcc ]]; then
+  depends+=("${MINGW_PACKAGE_PREFIX}-cppwinrt")
+fi
 optdepends=("${MINGW_PACKAGE_PREFIX}-vulkan-loader: For Vulkan detection support"
             "${MINGW_PACKAGE_PREFIX}-opencl-icd: For OpenCL detection support"
             "${MINGW_PACKAGE_PREFIX}-chafa: For chafa image protocol support"

--- a/mingw-w64-fastfetch/PKGBUILD
+++ b/mingw-w64-fastfetch/PKGBUILD
@@ -32,7 +32,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-opencl-headers"
              "${MINGW_PACKAGE_PREFIX}-python")
 # WinRT support is broken, reenable after https://github.com/fastfetch-cli/fastfetch/issues/2341 is resolved.
-if [[ ${CC} == gcc ]]; then
+if [[ ${CC} != gcc ]]; then
   depends+=("${MINGW_PACKAGE_PREFIX}-cppwinrt")
 fi
 optdepends=("${MINGW_PACKAGE_PREFIX}-vulkan-loader: For Vulkan detection support"


### PR DESCRIPTION
* WinRT support is broken, disable it for now. See https://github.com/fastfetch-cli/fastfetch/issues/2341 for details