### PR TITLE
python-imagecodecs: enable exr and wavpack

### DIFF
--- a/mingw-w64-python-imagecodecs/PKGBUILD
+++ b/mingw-w64-python-imagecodecs/PKGBUILD
@@ -4,7 +4,7 @@ _realname=imagecodecs
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=2026.5.10
-pkgrel=1
+pkgrel=2
 pkgdesc="Image transformation, compression, and decompression codecs (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -34,10 +34,12 @@ depends=("${MINGW_PACKAGE_PREFIX}-blosc"
          "${MINGW_PACKAGE_PREFIX}-libultrahdr"
          "${MINGW_PACKAGE_PREFIX}-libwebp"
          "${MINGW_PACKAGE_PREFIX}-meshoptimizer"
+         "${MINGW_PACKAGE_PREFIX}-openexr"
          "${MINGW_PACKAGE_PREFIX}-openjpeg2"
          "${MINGW_PACKAGE_PREFIX}-openjph"
          "${MINGW_PACKAGE_PREFIX}-python-numpy"
          "${MINGW_PACKAGE_PREFIX}-snappy"
+         "${MINGW_PACKAGE_PREFIX}-wavpack"
          "${MINGW_PACKAGE_PREFIX}-zopfli")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
@@ -47,13 +49,17 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
-        "0001-deflate.patch")
+        "0001-deflate.patch"
+        https://patch-diff.githubusercontent.com/raw/cgohlke/imagecodecs/pull/139.patch)
 sha256sums=('1c0c46860f35e4637c2df70ebe8aa15141f6c4202a698e63757a4d7917a85acc'
-            'f3416e6c6d99bda6ee65c82c386f98454de0686ecd6f409a9fc90ee44dcd0a38')
+            'f3416e6c6d99bda6ee65c82c386f98454de0686ecd6f409a9fc90ee44dcd0a38'
+            'fa92d3e267ecbc4d7e63e85ecc9f36a4246a28ce3f7c414af350ef672f4f96cd')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   patch -p1 -i "${srcdir}"/0001-deflate.patch
+  # https://github.com/cgohlke/imagecodecs/pull/139
+  patch -p1 -i "${srcdir}"/139.patch
 }
 
 build() {


### PR DESCRIPTION
Patch sent upstream: https://github.com/cgohlke/imagecodecs/pull/139

Wasn't able to build the WIC extension OOTB though, missing symbols:
```
gcc -shared -Wl,--enable-auto-image-base -march=nocona -msahf -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wp,-D__USE_MINGW_ANSI_STDIO=1 -s build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o build/temp.mingw_x86_64_ucrt_gnu-cpython-314/build/imagecodecs/_wic.o build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/_wic.def -LC:/msys64/ucrt64/lib -lole32 -loleaut32 -lpython3 -o build/lib.mingw_x86_64_ucrt_gnu-cpython-314/imagecodecs/_wic.pyd
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0x29a): undefined reference to `operator delete(void*, unsigned long long)'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0x406): undefined reference to `operator delete(void*, unsigned long long)'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0x668): undefined reference to `std::__get_once_callable()'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0xf0f): undefined reference to `std::__get_once_callable()'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0xf1c): undefined reference to `std::__get_once_call()'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe:
 build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0xf2a): undefined reference to `__once_proxy'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0xf42): undefined reference to `std::__get_once_callable()'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0xf4e): undefined reference to `std::__get_once_call()'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0xf7a): undefined reference to `std::__get_once_callable()'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0xf84): undefined reference to `std::__get_once_call()'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0xfb8): undefined reference to `std::__throw_system_error(int)'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0x1103): undefined reference to `operator new(unsigned long long, std::nothrow_t const&)'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0x12f8): undefined reference to `operator delete(void*, unsigned long long)'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0x1329): undefined reference to `operator delete(void*, unsigned long long)'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0x1431): undefined reference to `operator new(unsigned long long, std::nothrow_t const&)'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0x1538): undefined reference to `operator delete(void*, unsigned long long)'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0x17d5): undefined reference to `operator delete(void*, unsigned long long)'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0x1af8): undefined reference to `operator new(unsigned long long, std::nothrow_t const&)'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0x1c0e): undefined reference to `operator delete(void*, unsigned long long)'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0x1c35): undefined reference to `operator delete(void*, unsigned long long)'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0x1e40): undefined reference to `operator new(unsigned long long, std::nothrow_t const&)'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0x246c): undefined reference to `operator delete(void*, unsigned long long)'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0x2495): undefined reference to `operator delete(void*, unsigned long long)'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0x26b8): undefined reference to `__cxa_guard_acquire'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0x26d4): undefined reference to `__cxa_guard_release'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0x26f0): undefined reference to `__cxa_guard_abort'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0x994): undefined reference to `operator delete(void*, unsigned long long)'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.text+0x9c4): undefined reference to `operator delete(void*, unsigned long long)'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.xdata+0x84): undefined reference to `__gxx_personality_seh0'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.xdata+0x94): undefined reference to `__gxx_personality_seh0'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.xdata+0xbc): undefined reference to `__gxx_personality_seh0'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.xdata+0xcc): undefined reference to `__gxx_personality_seh0'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.xdata+0xe8): undefined reference to `__gxx_personality_seh0'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.xdata+0x100): more undefined references to `__gxx_personality_seh0' follow
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.rdata+0x70): undefined reference to `vtable for __cxxabiv1::__si_class_type_info'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.rdata+0xb0): undefined reference to `vtable for __cxxabiv1::__si_class_type_info'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.rdata$_ZTI8IUnknown[_ZTI8IUnknown]+0x0): undefined reference to `vtable for __cxxabiv1::__class_type_info'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.rdata$_ZTI17ISequentialStream[_ZTI17ISequentialStream]+0x0): undefined reference to `vtable for __cxxabiv1::__si_class_type_info'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.rdata$_ZTI7IStream[_ZTI7IStream]+0x0): undefined reference to `vtable for __cxxabiv1::__si_class_type_info'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.rdata$.refptr._ZSt7nothrow[.refptr._ZSt7nothrow]+0x0): undefined reference to `std::nothrow'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: build/temp.mingw_x86_64_ucrt_gnu-cpython-314/3rdparty/wic/wic.o:wic.cpp:(.rdata$.refptr.__once_proxy[.refptr.__once_proxy]+0x0): undefined reference to `__once_proxy'
collect2.exe: error: ld returned 1 exit status
```
Needs `libstdc++` perhaps? If so, how to handle `libc++` on clang envs?