### PR TITLE
protobuf: update to 35.0

### DIFF
--- a/mingw-w64-protobuf/PKGBUILD
+++ b/mingw-w64-protobuf/PKGBUILD
@@ -5,8 +5,8 @@ _realname=protobuf
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 # Note: make sure to update python-protobuf to match this version
-pkgver=33.5
-pkgrel=5
+pkgver=35.0
+pkgrel=1
 pkgdesc="Protocol Buffers - Google's data interchange format (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -25,12 +25,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 source=(https://github.com/protocolbuffers/${_realname}/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz
-        0001-fix-build-on-clangarm64.patch::https://github.com/protocolbuffers/protobuf/commit/0e84323c.patch
         0002-windres-invocation.patch
         0003-demote-error-about-buildtime-runtime-version-difference-to-warning.patch
         0005-pkgconfig-that-understands-static-libraries.patch)
-sha256sums=('c6c7c27fadc19d40ab2eaa23ff35debfe01f6494a8345559b9bb285ce4144dd1'
-            '7a584ecac368c360493da594440d0d3ee3f63d1152908ef74aad560709caa655'
+sha256sums=('8f907baca4b34a3b4854103ba5811e418fb6e2ff11fe0d8df9e8280b11d79926'
             '174f714b842d5153c79c5fda1ae775ee002aea11d53cb5d5f51cb5c4b9e63d29'
             '2b680e1c642ccd5bb70b3dcf7217c27360bc0b74f63d8afb66dd668173d9b2dd'
             'd118346d092caa8a3d6c02d88207d7cd9318fe3077b6b36cf32d1da79fe4128c')
@@ -46,7 +44,6 @@ apply_patch_with_msg() {
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   apply_patch_with_msg \
-    0001-fix-build-on-clangarm64.patch \
     0002-windres-invocation.patch \
     0003-demote-error-about-buildtime-runtime-version-difference-to-warning.patch \
     0005-pkgconfig-that-understands-static-libraries.patch
@@ -60,7 +57,7 @@ build() {
     _extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
-  echo "Building static library"
+  msg2 "Building static library"
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe \
       -Wno-dev \
@@ -76,7 +73,7 @@ build() {
 
   ${MINGW_PREFIX}/bin/cmake.exe --build build-${MSYSTEM}-static
 
-  echo "Building shared library"
+  msg2 "Building shared library"
   CXXFLAGS+=" -Wno-ignored-attributes" \
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe \

--- a/mingw-w64-python-protobuf/003-fix-longjmp.patch
+++ b/mingw-w64-python-protobuf/003-fix-longjmp.patch
@@ -1,0 +1,11 @@
+--- a/upb/port/def.inc
++++ b/upb/port/def.inc
+@@ -371,7 +371,7 @@
+ // Android uses a custom libc that does not implement all of posix, but it has
+ // had sigsetjmp/siglongjmp forever on arm and since API 12 on x86. Apple has
+ // sigsetjmp, but does not define the posix feature test macro.
+-#if defined(__APPLE__) || defined(_POSIX_C_SOURCE) || defined(__ANDROID__)
++#if !defined(__MINGW32__) && (defined(__APPLE__) || defined(_POSIX_C_SOURCE) || defined(__ANDROID__))
+ // avoid setting/restoring signal mask, which involves costly syscalls
+ #define UPB_SETJMP(buf) sigsetjmp(buf, 0)
+ #define UPB_LONGJMP(buf, val) siglongjmp(buf, val)

--- a/mingw-w64-python-protobuf/PKGBUILD
+++ b/mingw-w64-python-protobuf/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=protobuf
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=6.33.5
+pkgver=7.35.0
 pkgrel=1
 pkgdesc="Protocol Buffers (mingw-w64)"
 arch=('any')
@@ -25,15 +25,15 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-cc")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
         "001-no-python-static-lib.patch"
-        "002-fix-build-on-clangarm64.patch::https://github.com/protocolbuffers/protobuf/commit/0e84323c.patch")
-sha256sums=('6ddcac2a081f8b7b9642c09406bc6a4290128fce5f471cddd165960bb9119e5c'
+        "003-fix-longjmp.patch")
+sha256sums=('a2efd84605f41e559f1881b0912b44099d0a2ac9bf46b3474823f10fb393b0e6'
             'e864e7964ad7693e6ce8dc3b91c779184457ce82fc075d2099bfcbc18e6808a3'
-            '7a584ecac368c360493da594440d0d3ee3f63d1152908ef74aad560709caa655')
+            'bd38a5def883ab208f6ce136594127f3b0f070a7deb07b856a763d7d295f7612')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
   patch -p1 -i "${srcdir}"/001-no-python-static-lib.patch
-  patch -p1 -i "${srcdir}"/002-fix-build-on-clangarm64.patch
+  patch -p1 -i "${srcdir}"/003-fix-longjmp.patch
 
   rm -rf "${srcdir}"/python-build-${MSYSTEM} || true
   cp -r "${srcdir}"/${_realname}-${pkgver} "${srcdir}"/"python-build-${MSYSTEM}"
@@ -41,7 +41,6 @@ prepare() {
 
 build() {
   cd "${srcdir}/python-build-${MSYSTEM}"
-  CFLAGS+=" -Wno-int-conversion" \
   ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
 }
 


### PR DESCRIPTION
* python-protobuf: update to 7.35.0
* patch 0e84323c is already included
* MinGW doesn't provide siglongjmp, use longjmp instead