### PR TITLE
pango: Update to 1.57.1

### DIFF
--- a/mingw-w64-pango/PKGBUILD
+++ b/mingw-w64-pango/PKGBUILD
@@ -5,8 +5,8 @@ _realname=pango
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
-pkgver=1.56.4
-pkgrel=3
+pkgver=1.57.1
+pkgrel=1
 pkgdesc="A library for layout and rendering of text (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -30,14 +30,11 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
              "${MINGW_PACKAGE_PREFIX}-gi-docgen"
              "${MINGW_PACKAGE_PREFIX}-python-docutils")
-source=("https://download.gnome.org/sources/pango/${pkgver:0:4}/${_realname}-${pkgver}.tar.xz"
-        "https://gitlab.gnome.org/GNOME/pango/-/merge_requests/883.patch")
-sha256sums=('17065e2fcc5f5a5bdbffc884c956bfc7c451a96e8c4fb2f8ad837c6413cb5a01'
-            'b34c429bef61f2ad02eb74d03ce4c5d32c5b866de17227839054ad157414826b')
+source=("https://download.gnome.org/sources/pango/${pkgver:0:4}/${_realname}-${pkgver}.tar.xz")
+sha256sums=('e65d6d117080dc3aeeb7d8b4b3b518f7383aa2e6cfce23117c623cd624764c2f')
 
 prepare() {
   cd "${_realname}-${pkgver}"
-  patch -p1 -i "${srcdir}/883.patch"
 }
 
 build() {


### PR DESCRIPTION
I've asked:

mclasen: I believe that I said at some point that
I've given up on even/odd versioning for pango.
whether a pango release is officially stable or not, the forcing function is what gtk requires: gtk main needs pango 1.57