### PR TITLE
llvm: fix cmake warning

### DIFF
--- a/mingw-w64-llvm/PKGBUILD
+++ b/mingw-w64-llvm/PKGBUILD
@@ -236,7 +236,7 @@ build() {
     )
   fi
 
-  local _projects="clang;clang-tools-extra;compiler-rt;lld"
+  local _projects="clang;clang-tools-extra;lld"
 
   case "${CARCH}" in
     x86_64|i?86)
@@ -263,6 +263,7 @@ build() {
   ${MINGW_PREFIX}/bin/cmake.exe \
     -GNinja \
     -DLLVM_ENABLE_PROJECTS="${_projects}" \
+    -DLLVM_ENABLE_RUNTIMES="compiler-rt" \
     -DLLVM_ENABLE_RTTI=ON \
     -DLLVM_INSTALL_UTILS=ON \
     -DLIBCLANG_BUILD_STATIC=ON \


### PR DESCRIPTION
```
CMake Warning at CMakeLists.txt:185 (message):
  Using LLVM_ENABLE_PROJECTS=compiler-rt is deprecated now, and will become a
  fatal error in a future release.  Please use
  -DLLVM_ENABLE_RUNTIMES=compiler-rt or see the instructions at
  https://compiler-rt.llvm.org/ for building the runtimes.
```