### PR TITLE
rust: enable native TLS for GCC environments

### DIFF
--- a/mingw-w64-rust/0017-enable-native-tls-for-gcc-envs.patch
+++ b/mingw-w64-rust/0017-enable-native-tls-for-gcc-envs.patch
@@ -1,0 +1,10 @@
+--- a/compiler/rustc_target/src/spec/base/windows_gnu.rs
++++ b/compiler/rustc_target/src/spec/base/windows_gnu.rs
+@@ -101,6 +101,7 @@ pub(crate) fn opts() -> TargetOptions {
+         emit_debug_gdb_scripts: false,
+         requires_uwtable: true,
+         eh_frame_header: false,
++        has_thread_local: true,
+         debuginfo_kind: DebuginfoKind::Dwarf,
+         // FIXME(davidtwco): Support Split DWARF on Windows GNU - may require LLVM changes to
+         // output DWO, despite using DWARF, doesn't use ELF..

--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -21,7 +21,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
            "${MINGW_PACKAGE_PREFIX}-rust-wasm" \
            "${MINGW_PACKAGE_PREFIX}-rust-emscripten"))
 pkgver=1.95.0
-pkgrel=5
+pkgrel=6
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -64,6 +64,7 @@ source=("${rust_dist_server}/${_realname}c-${pkgver}-src.tar.xz"{,.asc}
         "0004-compiler-Use-wasm-ld-for-wasm-targets.patch"
         "0008-disable-self-contained-for-gnu-targets.patch"
         "0016-allow-shared-llvm-for-all.patch"
+        "0017-enable-native-tls-for-gcc-envs.patch"
         # patches in case of doing PGO for LLVM with opt-dist
         #"0015-lesser-llvm-build.patch"
 )
@@ -75,7 +76,8 @@ sha256sums=('62b67230754da642a264ca0cb9fc08820c54e2ed7b3baba0289876d4cdb48c08'
             'db5d0dbeaaab5bd22c71ef35d1978960dd7e79cc153e5eeb72a5f635255991de'
             '56882f1a0f1404c10c7726d6cc37444f2b343e72b969badfcb43760f80db0f32'
             '767db21e86364eb6777404ba6eee94133b5878ad42fa34afa9aea641ab533759'
-            '691f9dcaeb8a340fd279eea1d54a9077305e0a74a32d8cf020a85e50b1956553')
+            '691f9dcaeb8a340fd279eea1d54a9077305e0a74a32d8cf020a85e50b1956553'
+            '45e4f00d325e6d2110198526df1919ae760b050eef85b9d6f3f88b79115b29da')
 validpgpkeys=('108F66205EAEB0AAA8DD5E1C85AB96E6FA1BE5FE'  # Rust Language (Tag and Release Signing Key) <rust-key@rust-lang.org>
               '474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard <tstellar@redhat.com>
               'B6C8F98282B944E3B0D5C2530FC3042E345AD05D') # Hans Wennborg <hans@chromium.org>
@@ -105,7 +107,8 @@ prepare() {
     0002-bootstrap-Change-bash-completion-dir.patch \
     0008-disable-self-contained-for-gnu-targets.patch \
     0004-compiler-Use-wasm-ld-for-wasm-targets.patch \
-    0016-allow-shared-llvm-for-all.patch
+    0016-allow-shared-llvm-for-all.patch \
+    0017-enable-native-tls-for-gcc-envs.patch
 }
 
 build() {

--- a/mingw-w64-zed/PKGBUILD
+++ b/mingw-w64-zed/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          #"${MINGW_PACKAGE_PREFIX}-${_realname}-docs"
 )
 pkgver=1.3.6
-pkgrel=1
+pkgrel=2
 pkgdesc="A high-performance, multiplayer code editor (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')


### PR DESCRIPTION
portioned from rust-lang/rust#156819

cc @mati865 