### PR TITLE
octave: add dependency on qt6-svg

### DIFF
--- a/mingw-w64-octave/PKGBUILD
+++ b/mingw-w64-octave/PKGBUILD
@@ -4,7 +4,7 @@ _realname=octave
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=11.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="GNU Octave: Interactive programming environment for numerical computations (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -33,13 +33,10 @@ depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
          "${MINGW_PACKAGE_PREFIX}-pcre2"
          "${MINGW_PACKAGE_PREFIX}-qhull"
          "${MINGW_PACKAGE_PREFIX}-qrupdate"
-         $([[ ${CARCH} == i686 ]] && echo \
-           "${MINGW_PACKAGE_PREFIX}-qscintilla-qt5" \
-           "${MINGW_PACKAGE_PREFIX}-qt5-base" \
-           "${MINGW_PACKAGE_PREFIX}-qt5-tools" || echo \
-           "${MINGW_PACKAGE_PREFIX}-qscintilla-qt6" \
-           "${MINGW_PACKAGE_PREFIX}-qt6-base" \
-           "${MINGW_PACKAGE_PREFIX}-qt6-tools")
+         "${MINGW_PACKAGE_PREFIX}-qscintilla-qt6"
+         "${MINGW_PACKAGE_PREFIX}-qt6-base"
+         "${MINGW_PACKAGE_PREFIX}-qt6-svg"
+         "${MINGW_PACKAGE_PREFIX}-qt6-tools"
          "${MINGW_PACKAGE_PREFIX}-readline"
          "${MINGW_PACKAGE_PREFIX}-suitesparse"
          "${MINGW_PACKAGE_PREFIX}-sundials"


### PR DESCRIPTION
It is needed to correctly display .svg icons in the GUI. 
Also, remove a condition for the (former) 32-bit package.