### PR TITLE
mingw-w64-cvise: avoid manager-backed process monitor on Windows

### DIFF
--- a/mingw-w64-cvise/014-avoid-manager-for-process-monitor.patch
+++ b/mingw-w64-cvise/014-avoid-manager-for-process-monitor.patch
@@ -1,0 +1,242 @@
+--- a/cvise/utils/process.py
++++ b/cvise/utils/process.py
+@@ -6,7 +6,6 @@
+ import contextlib
+ import heapq
+ import multiprocessing
+-import multiprocessing.managers
+ import os
+ import queue
+ import shlex
+@@ -25,6 +24,7 @@
+ from cvise.utils import sigmonitor
+ 
+ _mp_task_loss_workaround_obj: MPTaskLossWorkaround | None = None
++_process_event_pid_queue = None
+ 
+ 
+ @unique
+@@ -44,8 +44,8 @@
+ class ProcessMonitor:
+     """Keeps track of subprocesses spawned by Pebble workers."""
+ 
+-    def __init__(self, mpmanager: multiprocessing.managers.SyncManager, parallel_tests: int):
+-        self.pid_queue: queue.Queue = mpmanager.Queue()
++    def __init__(self, parallel_tests: int):
++        self.pid_queue = multiprocessing.SimpleQueue()
+         self._lock = threading.Lock()
+         self._worker_to_child_pids: dict[int, set[int]] = {}
+         # Remember dead worker PIDs, so that we can distinguish an early-reported child PID (arriving before
+@@ -56,6 +56,9 @@
+         self._thread = threading.Thread(target=self._thread_main)
+         self._killer = ProcessKiller()
+ 
++    def worker_process_initializer(self):
++        return _ProcessEventNotifierInitializer(self.pid_queue)
++
+     def __enter__(self):
+         self._killer.__enter__()
+         self._thread.start()
+@@ -268,9 +271,9 @@
+ 
+     _EVENT_LOOP_STEP = 1  # seconds
+ 
+-    def __init__(self, pid_queue: queue.Queue | None):
++    def __init__(self, pid_queue: queue.Queue | None = None):
+         self._my_pid = os.getpid()
+-        self._pid_queue = pid_queue
++        self._pid_queue = pid_queue if pid_queue is not None else _process_event_pid_queue
+ 
+     def run_process(
+         self,
+@@ -387,7 +390,7 @@
+         # Don't use Manager-based synchronization primitives because of their poor performance. Don't use Queue since
+         # it uses background threads which breaks our assumptions and isn't compatible with quick exit on signals.
+         self._task_status_queue = multiprocessing.SimpleQueue()
+-        self._task_exit_flag = multiprocessing.Event()
++        self._task_exit_flag = multiprocessing.Value('b', False)
+ 
+     def initialize_in_worker(self) -> None:
+         """Must be called in a worker process in order to initialize global state needed later."""
+@@ -416,7 +419,7 @@
+             time.sleep(self._POLL_LOOP_STEP)  # SimpleQueue doesn't provide polling
+ 
+         # 3. Shut down all tasks - use graceful termination for the successfully started ones, and cancel the lost ones.
+-        self._task_exit_flag.set()
++        self._task_exit_flag.value = True
+         start_time = time.monotonic()
+         while time.monotonic() < start_time + self._DEADLINE:
+             pump_task_queue()
+@@ -431,7 +434,7 @@
+         # 4. Cleanup; make sure to free the pool if the graceful termination above didn't finish within the timeout.
+         for future in futures:
+             future.cancel()
+-        self._task_exit_flag.clear()
++        self._task_exit_flag.value = False
+ 
+     @staticmethod
+     def _job(task_id: int) -> None:
+@@ -439,10 +442,20 @@
+         status_queue = _mp_task_loss_workaround_obj._task_status_queue
+         exit_flag = _mp_task_loss_workaround_obj._task_exit_flag
+         status_queue.put((task_id, os.getpid()))
+-        while not exit_flag.wait(timeout=MPTaskLossWorkaround._POLL_LOOP_STEP):
++        while not exit_flag.value:
++            time.sleep(MPTaskLossWorkaround._POLL_LOOP_STEP)
+             sigmonitor.maybe_raise_exc()
+ 
+ 
++@dataclass
++class _ProcessEventNotifierInitializer:
++    pid_queue: object
++
++    def __call__(self) -> None:
++        global _process_event_pid_queue
++        _process_event_pid_queue = self.pid_queue
++
++
+ @contextlib.contextmanager
+ def _auto_kill_on_timeout(proc: subprocess.Popen) -> Iterator[None]:
+     try:
+--- a/cvise/utils/testing.py
++++ b/cvise/utils/testing.py
+@@ -8,7 +8,6 @@
+ import multiprocessing
+ import os
+ import platform
+-import queue
+ import shutil
+ import subprocess
+ import sys
+@@ -38,7 +37,12 @@
+ )
+ from cvise.utils.folding import FoldingManager, FoldingStateIn, FoldingStateOut
+ from cvise.utils.hint import is_special_hint_type, load_hints
+-from cvise.utils.process import MPContextHook, MPTaskLossWorkaround, ProcessEventNotifier, ProcessMonitor
++from cvise.utils.process import (
++    MPContextHook,
++    MPTaskLossWorkaround,
++    ProcessEventNotifier,
++    ProcessMonitor,
++)
+ from cvise.utils.readkey import KeyLogger
+ 
+ MAX_PASS_INCREASEMENT_THRESHOLD = 3
+@@ -61,7 +65,6 @@
+     test_case: Path
+     tmp_dir: Path
+     job_timeout: int
+-    pid_queue: queue.Queue
+     dependee_bundle_paths: list[Path]
+ 
+     def run(self) -> Any:
+@@ -71,7 +74,7 @@
+                 self.test_case,
+                 tmp_dir=self.tmp_dir,
+                 job_timeout=self.job_timeout,
+-                process_event_notifier=ProcessEventNotifier(self.pid_queue),
++                process_event_notifier=ProcessEventNotifier(),
+                 dependee_hints=dependee_hints,
+             )
+         except UnicodeDecodeError:
+@@ -90,7 +93,6 @@
+     new_tmp_dir: Path
+     pass_succeeded_state: Any
+     job_timeout: int
+-    pid_queue: queue.Queue
+     dependee_bundle_paths: list[Path]
+ 
+     def run(self) -> Any:
+@@ -101,7 +103,7 @@
+             new_tmp_dir=self.new_tmp_dir,
+             succeeded_state=self.pass_succeeded_state,
+             job_timeout=self.job_timeout,
+-            process_event_notifier=ProcessEventNotifier(self.pid_queue),
++            process_event_notifier=ProcessEventNotifier(),
+             dependee_hints=dependee_hints,
+         )
+ 
+@@ -123,7 +125,6 @@
+         all_test_cases: set[Path],
+         should_copy_current_test_case: bool,
+         transform,
+-        pid_queue: queue.Queue | None = None,
+     ):
+         self.state = state
+         self.folder: Path = folder
+@@ -132,7 +133,6 @@
+         self.result: PassResult | None = None
+         self.order = order
+         self.transform = transform
+-        self.pid_queue = pid_queue
+         self.test_case: Path = test_case
+         self.should_copy_current_test_case = should_copy_current_test_case
+         self.all_test_cases: set[Path] = all_test_cases
+@@ -176,7 +176,7 @@
+             (result, self.state) = self.transform(
+                 self.test_case_path,
+                 self.state,
+-                process_event_notifier=ProcessEventNotifier(self.pid_queue),
++                process_event_notifier=ProcessEventNotifier(),
+                 original_test_case=self.test_case.resolve(),
+                 written_paths=written_paths,
+             )
+@@ -209,7 +209,7 @@
+         # interestingness test, or because C-Vise abruptly kills our job without a chance for a proper cleanup).
+         with tempfile.TemporaryDirectory(dir=self.folder, prefix='overridetmp') as tmp_override:
+             env = override_tmpdir_env(os.environ.copy(), Path(tmp_override))
+-            stdout, stderr, returncode = ProcessEventNotifier(self.pid_queue).run_process(
++            stdout, stderr, returncode = ProcessEventNotifier().run_process(
+                 str(self.test_script), shell=True, env=env, cwd=self.folder
+             )
+             return returncode, stdout, stderr
+@@ -493,8 +493,7 @@
+         )
+ 
+         self.key_logger = None if self.skip_key_off else KeyLogger()
+-        self.mpmanager = multiprocessing.Manager()
+-        self.process_monitor = ProcessMonitor(self.mpmanager, self.parallel_tests)
++        self.process_monitor = ProcessMonitor(self.parallel_tests)
+         self.mplogger = mplogging.MPLogger(self.parallel_tests)
+         self.worker_pool: pebble.ProcessPool | None = None
+         self.mp_task_loss_workaround = MPTaskLossWorkaround(self.parallel_tests)
+@@ -510,6 +509,7 @@
+         self.exit_stack.enter_context(self.process_monitor)
+ 
+         worker_initializers = [
++            self.process_monitor.worker_process_initializer(),
+             self.mplogger.worker_process_initializer(),
+             self.mp_task_loss_workaround.initialize_in_worker,
+         ]
+@@ -1227,7 +1227,6 @@
+                 test_case=self.current_test_case,
+                 tmp_dir=tmp_dir,
+                 job_timeout=self.timeout,
+-                pid_queue=self.process_monitor.pid_queue,
+                 dependee_bundle_paths=dependee_bundle_paths,
+             )
+         else:
+@@ -1238,7 +1237,6 @@
+                 new_tmp_dir=tmp_dir,
+                 pass_succeeded_state=ctx.taken_succeeded_state,
+                 job_timeout=self.timeout,
+-                pid_queue=self.process_monitor.pid_queue,
+                 dependee_bundle_paths=dependee_bundle_paths,
+             )
+         init_timeout = self.INIT_TIMEOUT_FACTOR * self.timeout
+@@ -1284,7 +1282,6 @@
+             self.test_cases,
+             should_copy_current_test_case,
+             ctx.pass_.transform,
+-            self.process_monitor.pid_queue,
+         )
+         future = self.worker_pool.schedule(
+             _worker_process_job_wrapper, args=[self.order, env.run], timeout=self.timeout
+@@ -1324,7 +1321,6 @@
+             self.test_cases,
+             should_copy_current_test_case,
+             FoldingManager.transform,
+-            self.process_monitor.pid_queue,
+         )
+         future = self.worker_pool.schedule(
+             _worker_process_job_wrapper, args=[self.order, env.run], timeout=self.timeout

--- a/mingw-w64-cvise/015-fix-preprocessed-param-to-global-crash.patch
+++ b/mingw-w64-cvise/015-fix-preprocessed-param-to-global-crash.patch
@@ -1,0 +1,121 @@
+--- a/clang_delta/CommonParameterRewriteVisitor.h
++++ b/clang_delta/CommonParameterRewriteVisitor.h
+@@ -48,6 +48,9 @@
+ bool CommonParameterRewriteVisitor<T, Trans>::VisitCXXConstructExpr(
+        clang::CXXConstructExpr *CE)
+ {
++  if (ConsumerInstance->isInIncludedFile(CE))
++    return true;
++
+   const clang::CXXConstructorDecl *CtorD = CE->getConstructor();
+   if (CtorD->getCanonicalDecl() == ConsumerInstance->TheFuncDecl)
+     AllConstructExprs.push_back(CE);
+@@ -94,6 +97,9 @@
+ bool CommonParameterRewriteVisitor<T, Trans>::VisitCallExpr(
+        clang::CallExpr *CallE)
+ {
++  if (ConsumerInstance->isInIncludedFile(CallE))
++    return true;
++
+   const clang::FunctionDecl *CalleeDecl = NULL;
+   const clang::Expr *E = CallE->getCallee();
+   if (const clang::UnresolvedLookupExpr *UE =
+--- a/clang_delta/Transformation.cpp
++++ b/clang_delta/Transformation.cpp
+@@ -84,6 +84,14 @@
+ {
+   Context = &context;
+   SrcManager = &Context->getSourceManager();
++  SourceLocation MainFileLoc =
++      SrcManager->getLocForStartOfFile(SrcManager->getMainFileID());
++  PresumedLoc MainPresumedLoc = SrcManager->getPresumedLoc(MainFileLoc);
++  if (MainPresumedLoc.isValid()) {
++    MainFileName = MainPresumedLoc.getFilename();
++  } else {
++    MainFileName.clear();
++  }
+   TheRewriter.setSourceMgr(Context->getSourceManager(),
+                            Context->getLangOpts());
+   Hints = std::make_unique<HintsBuilder>(Context->getSourceManager(), Context->getLangOpts());
+@@ -1191,7 +1198,23 @@
+ bool Transformation::isInIncludedFile(SourceLocation Loc) const
+ {
+   Loc = getRealLocation(Loc);
+-  return SrcManager->getFileID(Loc) != SrcManager->getMainFileID();
++  if (Loc.isInvalid())
++    return true;
++
++  if (SrcManager->isInSystemHeader(Loc) ||
++      SrcManager->isInExternCSystemHeader(Loc))
++    return true;
++
++  if (SrcManager->getFileID(Loc) != SrcManager->getMainFileID())
++    return true;
++
++  if (!MainFileName.empty()) {
++    PresumedLoc Presumed = SrcManager->getPresumedLoc(Loc);
++    if (Presumed.isValid() && (MainFileName != Presumed.getFilename()))
++      return true;
++  }
++
++  return false;
+ }
+ 
+ bool Transformation::isInIncludedFile(const Decl *D) const
+--- a/clang_delta/Transformation.h
++++ b/clang_delta/Transformation.h
+@@ -381,6 +381,8 @@
+   std::string ReferenceValue;
+ 
+   bool WarnOnCounterOutOfBounds;
++
++  std::string MainFileName;
+ };
+ 
+ class TransNameQueryVisitor;
+--- a/clang_delta/tests/param-to-global/preprocessed.ii
++++ b/clang_delta/tests/param-to-global/preprocessed.ii
+@@ -0,0 +1,9 @@
++# 1 "header.hpp" 1 3
++int ignored(int x);
++# 1 "main.cc" 2
++struct S {
++  bool f(int a, int b) {
++    return a + b;
++  }
++};
++bool g(S* s, int x, int y) { return s->f(x, y); }
+--- a/clang_delta/tests/param-to-global/preprocessed.output
++++ b/clang_delta/tests/param-to-global/preprocessed.output
+@@ -0,0 +1,10 @@
++# 1 "header.hpp" 1 3
++int ignored(int x);
++# 1 "main.cc" 2
++struct S {
++  int f_a;
++bool f( int b) {
++    return f_a + b;
++  }
++};
++bool g(S* s, int x, int y) { return s->f( y); }
+--- a/clang_delta/tests/test_clang_delta.py
++++ b/clang_delta/tests/test_clang_delta.py
+@@ -377,6 +377,18 @@
+     def test_param_to_global_macro(self):
+         self.check_clang_delta('param-to-global/macro.c', '--transformation=param-to-global --counter=1')
+ 
++    def test_param_to_global_preprocessed(self):
++        self.check_query_instances(
++            'param-to-global/preprocessed.ii',
++            '--query-instances=param-to-global',
++            'Available transformation instances: 5',
++        )
++        self.check_clang_delta(
++            'param-to-global/preprocessed.ii',
++            '--transformation=param-to-global --counter=1',
++            'param-to-global/preprocessed.output',
++        )
++
+     def test_reduce_array_dim_non_type_temp_arg(self):
+         self.check_clang_delta(
+             'reduce-array-dim/non-type-temp-arg.cpp',

--- a/mingw-w64-cvise/016-fix-callexpr-to-value-rewrite-crash.patch
+++ b/mingw-w64-cvise/016-fix-callexpr-to-value-rewrite-crash.patch
@@ -1,0 +1,70 @@
+--- a/clang_delta/RewriteUtils.cpp
++++ b/clang_delta/RewriteUtils.cpp
+@@ -721,27 +721,35 @@
+ bool RewriteUtils::replaceExpr(const Expr *E,
+                                const std::string &ES)
+ {
+   SourceRange ExprRange = E->getSourceRange();
++  SourceLocation StartLoc = ExprRange.getBegin();
++  SourceLocation EndLoc = ExprRange.getEnd();
++
++  if (StartLoc.isMacroID()) {
++    StartLoc = SrcManager->getExpansionLoc(StartLoc);
++  }
++  if (SrcManager->isMacroBodyExpansion(EndLoc) ||
++      SrcManager->isMacroArgExpansion(EndLoc)) {
++    // Expand macro-end locations to a real source interval before rewriting.
++    EndLoc = getExpansionEndLoc(EndLoc);
++  }
++  else if (EndLoc.isMacroID()) {
++    EndLoc = SrcManager->getExpansionLoc(EndLoc);
++  }
++
++  if (StartLoc.isInvalid() || EndLoc.isInvalid() ||
++      !Rewriter::isRewritable(StartLoc) ||
++      !Rewriter::isRewritable(EndLoc)) {
++    return false;
++  }
++
++  ExprRange = SourceRange(StartLoc, EndLoc);
+ 
+   int RangeSize = TheRewriter->getRangeSize(ExprRange);
+   if (RangeSize == -1) {
+-    SourceLocation StartLoc = ExprRange.getBegin();
+-    if (StartLoc.isMacroID()) {
+-      StartLoc = SrcManager->getExpansionLoc(StartLoc);
+-    }
+-    SourceLocation EndLoc = ExprRange.getEnd();
+-    if (SrcManager->isMacroBodyExpansion(EndLoc) ||
+-        SrcManager->isMacroArgExpansion(EndLoc)) {
+-      // FIXME: handle cases below:
+-      // #define macro bar(1,2);
+-      // int bar(int p1, int p2) { return p1 + p2; }
+-      // void foo(void) { int x = macro }
+-      EndLoc = getExpansionEndLoc(EndLoc);
+-    }
+-    Hints->AddPatch(SourceRange(StartLoc, EndLoc), ES);
+-    return !(TheRewriter->ReplaceText(SourceRange(StartLoc, EndLoc), ES));
++    return false;
+   }
+ 
+   Hints->AddPatch(ExprRange, ES);
+   return !(TheRewriter->ReplaceText(ExprRange, ES));
+ }
+--- a/clang_delta/tests/test_clang_delta.py
++++ b/clang_delta/tests/test_clang_delta.py
+@@ -158,7 +158,14 @@
+             begin_index=0,
+             end_index=1,
+         )
+ 
++    def test_callexpr_to_value_macro3(self):
++        self.check_clang_delta(
++            'callexpr-to-value/macro3.cc',
++            '--transformation=callexpr-to-value --counter=1',
++            'callexpr-to-value/macro3.cc',
++        )
++
+     def test_callexpr_to_value_test1(self):
+         self.check_clang_delta(
+             'callexpr-to-value/test1.c',

--- a/mingw-w64-cvise/017-fix-callexpr-to-value-generate-hints-order.patch
+++ b/mingw-w64-cvise/017-fix-callexpr-to-value-generate-hints-order.patch
@@ -1,0 +1,30 @@
+--- a/clang_delta/CallExprToValue.cpp
++++ b/clang_delta/CallExprToValue.cpp
+@@ -105,8 +105,9 @@ void CallExprToValue::HandleTranslationUnit(ASTContext &Ctx)
+   NamePostfix = NameQueryWrap->getMaxNamePostfix() + 1;
+ 
+   if (ToCounter == std::numeric_limits<int>::max()) {
+-    for (const auto &Inst : Instances)
+-      replaceCallExpr(Inst);
++    for (auto I = Instances.rbegin(), E = Instances.rend(); I != E; ++I)
++      replaceCallExpr(*I);
++    Hints->ReverseOrder();
+   } else {
+     replaceCallExpr(Instances[TransformationCounter - 1]);
+   }
+--- a/clang_delta/tests/test_clang_delta.py
++++ b/clang_delta/tests/test_clang_delta.py
+@@ -209,6 +209,13 @@ class TestClangDelta(unittest.TestCase):
+         self.check_clang_delta_hints(
+             'callexpr-to-value/test4.c',
+             '--transformation=callexpr-to-value',
++            begin_index=None,
++            end_index=None,
++            output_file='callexpr-to-value/test4.output',
++        )
++        self.check_clang_delta_hints(
++            'callexpr-to-value/test4.c',
++            '--transformation=callexpr-to-value',
+             begin_index=0,
+             end_index=1,
+         )

--- a/mingw-w64-cvise/PKGBUILD
+++ b/mingw-w64-cvise/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 _pkgver=2.12.0
 pkgver=2.12.0.r301
-pkgrel=2
+pkgrel=3
 pkgdesc="Super-parallel Python port of the C-Reduce (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -53,7 +53,11 @@ source=("${_realname}::git+https://github.com/marxin/cvise#commit=${_commit}"
         "004-add-basic-bash-support.patch"
         "005-fix-readFile-call.patch"
         "006-platform-mp-start-method.patch"
-        "013-fix-atomic-replace-on-windows.patch")
+        "013-fix-atomic-replace-on-windows.patch"
+        "014-avoid-manager-for-process-monitor.patch"
+        "015-fix-preprocessed-param-to-global-crash.patch"
+        "016-fix-callexpr-to-value-rewrite-crash.patch"
+        "017-fix-callexpr-to-value-generate-hints-order.patch")
 sha256sums=('dc22c7cd9a660576185c79b78e62ece1eb2aff480173a4550b9166797062b019'
             '71fbe46ac0c0c39129543a9531e587ee6be23aee7c69b5b8dbc03869dd7a39f4'
             'ab215fe791b19621848914b33980c7dd8f1f161b654884d5fa31d409949e52ff'
@@ -61,7 +65,11 @@ sha256sums=('dc22c7cd9a660576185c79b78e62ece1eb2aff480173a4550b9166797062b019'
             '9dd2b999ef7bc14c611f91a7cc95eef30d13eac850616df684cc5941956eff45'
             '82bf7b515e55c0d8f433ac93227199fb5088bef62f2d35105f5abd69a5a285e1'
             'f6cad4ec9101d6ae62d8dfb791c32cb277e732fbc6368421793f84740ace4d57'
-            '5154e47cc1dde40b65607adfc41cef7593e34dee5a5974de4285a9b77a70b897')
+            '5154e47cc1dde40b65607adfc41cef7593e34dee5a5974de4285a9b77a70b897'
+            'bd17943eafad3032fa9277b34de5059f5d495c3aa614b8ec32f82479fb20f286'
+            '0d4a1c2bb54ff78d0c640501d87a868eb891721b96b4f1bdc47639ef09d991c2'
+            'e031858f4be41566a71ae27293f3fa1b0a8bd370645d6253e4e18da389b7baf8'
+            'bab0e1946fb589b433dbf3db3ddd767e24496dbde3cb8ccf88a40a2f7da74932')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -85,7 +93,11 @@ prepare() {
     004-add-basic-bash-support.patch \
     005-fix-readFile-call.patch \
     006-platform-mp-start-method.patch \
-    013-fix-atomic-replace-on-windows.patch
+    013-fix-atomic-replace-on-windows.patch \
+    014-avoid-manager-for-process-monitor.patch \
+    015-fix-preprocessed-param-to-global-crash.patch \
+    016-fix-callexpr-to-value-rewrite-crash.patch \
+    017-fix-callexpr-to-value-generate-hints-order.patch
 
   sed -i "s|-Werror||g" CMakeLists.txt
 }


### PR DESCRIPTION
also fix multiple clang_delta crashes.

After my latest patch cvise did start, but it didn't work. I noticed it today when I needed to reduce something. Anyway I fixed the problems in cvise and then `clang_delta` started crashing. I also fixed the crashes in `clang_delta`. Now it actually works, I used to successfully reduce C++ code.