### PR TITLE
libressl: update to 4.3.2

### DIFF
--- a/mingw-w64-libressl/PKGBUILD
+++ b/mingw-w64-libressl/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libressl
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.2.1
+pkgver=4.3.2
 pkgrel=1
 pkgdesc="Free version of the TLS/crypto stack forked from OpenSSL (mingw-w64)"
 arch=('any')
@@ -18,12 +18,11 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 optdepends=("${MINGW_PACKAGE_PREFIX}-ca-certificates")
-options=('strip')
 source=("https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/${_realname}-${pkgver}.tar.gz"{,.asc}
         "0001-relocation.patch"
         "0002-add-prefix.patch"
         "pathtools."{c,h})
-sha256sums=('6d5c2f58583588ea791f4c8645004071d00dfa554a5bf788a006ca1eb5abd70b'
+sha256sums=('edf01aee24c65d69e6a9efcb9d44bcda682ff9d4f3bbbd95e794e1dfa90847b5'
             'SKIP'
             'd61ec3b913786f43c8587f36a11b48e1ddc3ce1181e534b41de0f9dc4818846c'
             'e17ede3e4ccb4fd990cc5375834c91117e5cf1e483b63eb7ceea2110a30b6bfb'
@@ -68,6 +67,7 @@ build() {
       -DBUILD_SHARED_LIBS=ON \
       -DLIBRESSL_INSTALL_CMAKEDIR=lib/cmake/LibreSSL \
       -DOPENSSLDIR=${MINGW_PREFIX}/etc/${_realname} \
+      -DLIBRESSL_TESTS=OFF \
       "${extra_config[@]}"
 
   MSYS2_ARG_CONV_EXCL="-DOPENSSLBIN=;-DOPENSSLDIR=;-DTLS_DEFAULT_CA_FILE=" \
@@ -75,7 +75,10 @@ build() {
 }
 
 check() {
-  cmake --build "build-${MSYSTEM}" --target test || true
+  cmake -DLIBRESSL_TESTS=ON -S "${_realname}-${pkgver}" -B "build-${MSYSTEM}"
+  cmake --build "build-${MSYSTEM}"
+  # 132 passed, 2 .sh not runned
+  ctest --test-dir "build-${MSYSTEM}" --output-on-failure || true
 }
 
 package() {


### PR DESCRIPTION
* 'strip' is enabled by default
* only build tests in check()