### PR TITLE
fontconfig: fix missing conf.d files

### DIFF
--- a/mingw-w64-fontconfig/0012-conf-copy-drive-relative.patch
+++ b/mingw-w64-fontconfig/0012-conf-copy-drive-relative.patch
@@ -1,0 +1,11 @@
+--- fontconfig-2.18.0/conf.d/link_confs.py.orig	2026-05-27 06:39:52.987813300 +0200
++++ fontconfig-2.18.0/conf.d/link_confs.py	2026-05-27 06:43:28.641401500 +0200
+@@ -13,7 +13,7 @@
+     parser.add_argument('links', nargs='+')
+     args = parser.parse_args()
+ 
+-    if os.path.isabs(args.confpath):
++    if os.path.isabs(args.confpath) or args.confpath.startswith(('/', '\\')):
+         destdir = os.environ.get('DESTDIR')
+         if destdir:
+             # c:\destdir + c:\prefix must produce c:\destdir\prefix

--- a/mingw-w64-fontconfig/PKGBUILD
+++ b/mingw-w64-fontconfig/PKGBUILD
@@ -5,7 +5,7 @@ _realname=fontconfig
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.18.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A library for configuring and customizing font access (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -24,15 +24,18 @@ depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
 install=${_realname}-${MSYSTEM}.install
 source=("https://gitlab.freedesktop.org/fontconfig/fontconfig/-/archive/${pkgver}/fontconfig-${pkgver}.tar.gz"
         0011-conf-copy-instead-of-symlink.patch
+        0012-conf-copy-drive-relative.patch
         fontconfig.hook.in)
 sha256sums=('5c94af4828988af6b1a8484ddba13b521162687f9e5129bd8f267b8f4cfbf619'
             '73ed74a1f4624466084d219e2fbc0d5780da9f63763f1307629251e58cccf2cd'
+            'bb754488fbe89158eb756823757a612bdc26c1fdf0389316dc495caf027e4763'
             'ad4ce48983045d7f39b40ca9e04d4be2eaa9177b89dcc516388d779c131a88bc')
 
 prepare() {
   cd "${_realname}-${pkgver}"
 
   patch -p1 -i "${srcdir}"/0011-conf-copy-instead-of-symlink.patch
+  patch -p1 -i "${srcdir}"/0012-conf-copy-drive-relative.patch
 }
 
 build() {


### PR DESCRIPTION
The isabs() change in Python 3.13 made it skip merging the install path which resulted in all files in /etc/fonts/conf.d/ not being installed. Hack around it.

Fixes #29691