### PR TITLE
librime: add default plugins (lua, octagram, predict, proto)

### DIFF
--- a/mingw-w64-librime/PKGBUILD
+++ b/mingw-w64-librime/PKGBUILD
@@ -5,30 +5,45 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.16.1
 pkgrel=2
+_octagramcommit=dfcc15115788c828d9dd7b4bff68067d3ce2ffb8
+_luacommit=68f9c364a2d25a04c7d4794981d7c796b05ab627
+_protocommit=657a923cd4c333e681dc943e6894e6f6d42d25b4
+_predictcommit=920bd41ebf6f9bf6855d14fbe80212e54e749791
 pkgdesc="Rime Input Method Engine Library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://rime.im/'
 msys2_repository_url="https://github.com/rime/librime"
 license=('spdx:BSD-3-Clause')
-depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
+depends=("${MINGW_PACKAGE_PREFIX}-capnproto"
+         "${MINGW_PACKAGE_PREFIX}-cc-libs"
+         "${MINGW_PACKAGE_PREFIX}-glog"
          "${MINGW_PACKAGE_PREFIX}-leveldb"
+         "${MINGW_PACKAGE_PREFIX}-lua"
+         "${MINGW_PACKAGE_PREFIX}-marisa"
          "${MINGW_PACKAGE_PREFIX}-opencc"
-         "${MINGW_PACKAGE_PREFIX}-yaml-cpp"
-         "${MINGW_PACKAGE_PREFIX}-glog")
-optdepends=("${MINGW_PACKAGE_PREFIX}-rime-data: Rime schema repository from plum")
+         "${MINGW_PACKAGE_PREFIX}-yaml-cpp")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-boost"
-             "${MINGW_PACKAGE_PREFIX}-marisa")
+             'git')
+optdepends=("${MINGW_PACKAGE_PREFIX}-rime-data: Rime schema repository from plum")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-gtest")
 source=("https://github.com/rime/librime/archive/${pkgver}/${_realname}-${pkgver}.tar.gz"
         "001-fix-librime-path.patch"
-        "002-librime-fix-llvm-rc.patch")
+        "002-librime-fix-llvm-rc.patch"
+        "git+https://github.com/lotem/librime-octagram.git#commit=$_octagramcommit"
+        "git+https://github.com/hchunhui/librime-lua.git#commit=$_luacommit"
+        "git+https://github.com/lotem/librime-proto.git#commit=$_protocommit"
+        "git+https://github.com/rime/librime-predict.git#commit=$_predictcommit")
 sha256sums=('944909b5d9fb81171b044b7f2ea89922bd73457fcc5105798a259173288cd2d9'
             '8fe90184aadd788f1ec87d2b009016f9c1c6e4ecdaf92d7e3d4c2255c36a1ccb'
-            'fcddd5b4f817ba4bda81cd428ff8b6962ed8e4124722e1de99875697e354c355')
+            'fcddd5b4f817ba4bda81cd428ff8b6962ed8e4124722e1de99875697e354c355'
+            'bf35605a708ffd23755232d7234a9719be8f7a898dee88f0e2b8b85b5342e378'
+            'f731d38012ce52c7d3bd5fd2e5d110526c2809c0308bf2417b141f81774421d0'
+            'e1255c9e3dbdca2c9c24f363e141aa352047e51de096ee663a0bb203e39bb38b'
+            '79f8b5351c1f67f3b91f042f5fe66035323f680538642cc7ea4d6dc40cb4fadc')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -43,11 +58,14 @@ prepare() {
   apply_patch_with_msg \
     001-fix-librime-path.patch \
     002-librime-fix-llvm-rc.patch
+  cd plugins
+  ln -sf "$srcdir"/librime-octagram
+  ln -sf "$srcdir"/librime-lua
+  ln -sf "$srcdir"/librime-proto
+  ln -sf "$srcdir"/librime-predict
 }
 
 build() {
-  mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
-
   declare -a _extra_config
   if check_option "debug" "n"; then
     _extra_config+=("-DCMAKE_BUILD_TYPE=Release")
@@ -55,7 +73,7 @@ build() {
     _extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
-  export CXXFLAGS="$CXXFLAGS -DNDEBUG -DGLOG_USE_GLOG_EXPORT -DGLOG_USE_GFLAGS -DGFLAGS_IS_A_DLL=1"
+  CXXFLAGS+=" -DNDEBUG -DGLOG_USE_GLOG_EXPORT -DGLOG_USE_GFLAGS -DGFLAGS_IS_A_DLL=1" \
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe -Wno-dev \
     -G"Ninja" \
@@ -63,21 +81,23 @@ build() {
     -DCMAKE_DLL_NAME_WITH_SOVERSION=ON \
     "${_extra_config[@]}" \
     -DBUILD_TEST=OFF \
-    "../${_realname}-${pkgver}"
+    -DBoost_USE_STATIC_LIBS=OFF \
+    -S ${_realname}-${pkgver} \
+    -B build-${MSYSTEM}
 
-  ${MINGW_PREFIX}/bin/cmake --build .
+  ${MINGW_PREFIX}/bin/cmake --build build-${MSYSTEM}
 }
 
 check() {
-  cd "${srcdir}/build-${MSYSTEM}"
-  ${MINGW_PREFIX}/bin/cmake -DBUILD_TEST=ON ../${_realname}-${pkgver}
-  ${MINGW_PREFIX}/bin/cmake --build .
+  ${MINGW_PREFIX}/bin/cmake -DBUILD_TEST=ON -DLUA_VERSION=lua -S ${_realname}-${pkgver} -B build-${MSYSTEM}
+  ${MINGW_PREFIX}/bin/cmake --build build-${MSYSTEM}
 
-  PATH=${PATH}:"${srcdir}/build-${MSYSTEM}/bin" ${MINGW_PREFIX}/bin/ctest .
+  PATH="${PATH}":"${srcdir}"/build-${MSYSTEM}/bin \
+  ${MINGW_PREFIX}/bin/ctest --test-dir build-${MSYSTEM} --output-on-failure
 }
 
 package() {
-  cd "${srcdir}/build-${MSYSTEM}"
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
-  install -Dm644 "${srcdir}"/${_realname}-${pkgver}/LICENSE "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install build-${MSYSTEM}
+  install -Dm644 "${srcdir}"/${_realname}-${pkgver}/LICENSE \
+    "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
 }


### PR DESCRIPTION
Other package managers include plugins in their librime builds by default. Homebrew's `librime` adds `librime-lua`, `librime-octagram`, `librime-predict` and `librime-proto` [1], while Arch Linux's `librime` also includes the deprecated `librime-charcode` [2].

Since `librime-charcode` has been officially deprecated [3], this commit adds only the four non-deprecated plugins to the MSYS2 `librime` package, introducing dependencies on `lua` and `capnproto`. The check function now explicitly sets `-DLUA_VERSION=lua` to ensure tests pass.

Use the same plugin commit references as specified in the Arch Linux PKGBUILD. 

[1] https://github.com/Homebrew/homebrew-core/blob/16ef9985c94096d9a9090c033b1cf298611ae992/Formula/lib/librime.rb

 [2] https://gitlab.archlinux.org/archlinux/packaging/packages/librime/-/blob/main/PKGBUILD?ref_type=heads 

[3] https://github.com/rime/librime?tab=readme-ov-file#plugins

Edit: add `git` into `makedepends` 