### PR TITLE
libyuv: update to 1924.r2921.644251f25

### DIFF
--- a/mingw-w64-libyuv/PKGBUILD
+++ b/mingw-w64-libyuv/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=(${MINGW_PACKAGE_PREFIX}-${_realname})
 provides=(${MINGW_PACKAGE_PREFIX}-${_realname}-git)
 conflicts=(${MINGW_PACKAGE_PREFIX}-${_realname}-git)
 replaces=(${MINGW_PACKAGE_PREFIX}-${_realname}-git)
-pkgver=1922.r2903.deeb764bb
+pkgver=1924.r2921.644251f25
 pkgrel=1
 pkgdesc="YUV conversion and scaling library (mingw-w64)"
 arch=('any')
@@ -20,11 +20,11 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              'git')
 depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
          "${MINGW_PACKAGE_PREFIX}-libjpeg")
-_commit="deeb764bb92b6305ee0cb5dae7a5940fdb457fa9"
+_commit="644251f252a84bf8ce91ff0aca86a9b16b069ab8"
 source=("${_realname}::git+https://chromium.googlesource.com/${_realname}/${_realname}#commit=${_commit}"
         "libyuv.pc.in"
         "pkgconfig-cmake.patch")
-sha256sums=('448bd6e46f9f88540210d9fbee3dff348d9d92de8855b2b76f53d067a75bfad1'
+sha256sums=('34c2b6bad7e82992452258cf42d2bfad0694c9c637bd3ef9ca496355b44a65d0'
             '86aaa22252e033e62931e7c3fe3a6be4143a8ca532f95c1346b1e6b278c1947f'
             'b7fc89b8a8da6b3dd2165b9be3408545b3e6ec6e7cae34a50843c5a24f8313c0')
 


### PR DESCRIPTION
Syncs w/ [version referenced by libavif](https://github.com/AOMediaCodec/libavif/commit/267f924c90938f81b97458754c9c8e36d9c224ee) and should ideally be done together w/ #29700 @lazka 

Luckily no new APIs are being used this time.