### PR TITLE
libgphoto2: enable dng export

### DIFF
--- a/mingw-w64-libgphoto2/PKGBUILD
+++ b/mingw-w64-libgphoto2/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libgphoto2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.5.34
-pkgrel=1
+pkgrel=2
 pkgdesc="The libgphoto2 camera access and control library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -16,6 +16,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-libsystre"
          "${MINGW_PACKAGE_PREFIX}-libxml2"
          "${MINGW_PACKAGE_PREFIX}-libgd"
          "${MINGW_PACKAGE_PREFIX}-libexif"
+         "${MINGW_PACKAGE_PREFIX}-libtiff"
          "${MINGW_PACKAGE_PREFIX}-libusb"
          "${MINGW_PACKAGE_PREFIX}-libiconv"
          "${MINGW_PACKAGE_PREFIX}-curl"


### PR DESCRIPTION
(A transitive dep anyway for the -1 build so -2 bump is perhaps optional, but needs to be explicit since this version...)