### PR TITLE
prettier: update to 3.8.3

### DIFF
--- a/mingw-w64-prettier/PKGBUILD
+++ b/mingw-w64-prettier/PKGBUILD
@@ -6,7 +6,7 @@
 _realname=prettier
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.8.2
+pkgver=3.8.3
 pkgrel=1
 pkgdesc='An opinionated code formatter (mingw-w64)'
 arch=('any')
@@ -21,7 +21,7 @@ license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-nodejs")
 source=("https://registry.npmjs.org/${_realname}/-/${_realname}-${pkgver}.tgz"
         "prettier.sh")
-sha256sums=('917b771c007ff5d11cc96d4fa37df8fac86dd472b74ac0bbdcd70dfafab04c03'
+sha256sums=('c8a850e71b7366f1bac1885e05b2f929d47168009f3b6914413902ca8b980fde'
             'b3a516743b4e7dc4a9a7923c4d66b53fc750619f2c5fa7ec8cca974f95f74d06')
 
 package() {


### PR DESCRIPTION
[Changelog](https://github.com/prettier/prettier/releases/tag/3.8.3)