### PR TITLE
fastfetch: restore cppwinrt as makedepends

### DIFF
--- a/mingw-w64-fastfetch/PKGBUILD
+++ b/mingw-w64-fastfetch/PKGBUILD
@@ -5,7 +5,7 @@ _realname=fastfetch
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.63.1
-pkgrel=1
+pkgrel=2
 pkgdesc="An actively maintained, feature-rich and performance oriented, neofetch like system information tool (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -34,7 +34,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 # WinRT support is broken for GCC, reenable after
 # https://github.com/fastfetch-cli/fastfetch/issues/2341 is resolved.
 if [[ ${CC} != gcc ]]; then
-  depends+=("${MINGW_PACKAGE_PREFIX}-cppwinrt")
+  makedepends+=("${MINGW_PACKAGE_PREFIX}-cppwinrt")
 fi
 optdepends=("${MINGW_PACKAGE_PREFIX}-vulkan-loader: For Vulkan detection support"
             "${MINGW_PACKAGE_PREFIX}-opencl-icd: For OpenCL detection support"


### PR DESCRIPTION
cppwinrt is a header-only library. It is only a make dependency.