### PR TITLE
upx: fix scrolling in-place and output truncation

### DIFF
--- a/mingw-w64-upx/001-scrolling.patch
+++ b/mingw-w64-upx/001-scrolling.patch
@@ -1,0 +1,13 @@
+https://github.com/upx/upx/issues/953
+--- a/src/console/s_win32.cpp       2026-03-05 08:57:29.000000000 -0600
++++ b/src/console/s_win32.cpp   2026-06-05 09:59:12.472968300 -0500
+@@ -359,7 +359,8 @@
+ }
+
+ static int scrollUp(screen_t *this, int lines) {
+-    lines = do_scroll(this, lines, 0);
++    for (int i = 0; i < lines; i++) printf("\n");
++    fflush(stdout);
+     this->data->scroll_counter += lines;
+     return lines;
+ }

--- a/mingw-w64-upx/PKGBUILD
+++ b/mingw-w64-upx/PKGBUILD
@@ -22,11 +22,16 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cmake"
   "${MINGW_PACKAGE_PREFIX}-ninja"
 )
-source=("https://github.com/${_realname}/${_realname}/releases/download/v${pkgver}/${_realname}-${pkgver}-src.tar.xz")
-sha256sums=('8eb914115b306fd9fd2110bd3d27ddb8ae7c5a03bb965f7d10f046a3a4ff9dfe')
+source=("https://github.com/${_realname}/${_realname}/releases/download/v${pkgver}/${_realname}-${pkgver}-src.tar.xz"
+        '001-scrolling.patch')
+sha256sums=('8eb914115b306fd9fd2110bd3d27ddb8ae7c5a03bb965f7d10f046a3a4ff9dfe'
+            'eaa5e1673a8e41e956216c1da0bdc0650a7f66ea5300e995ea6e25d504f28d67')
 
 prepare() {
   mv "${srcdir}/${_realname}-${pkgver}-src" "${srcdir}/${_realname}-${pkgver}"
+
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -Np1 -i "${srcdir}/001-scrolling.patch"
 }
 
 build() {

--- a/mingw-w64-upx/PKGBUILD
+++ b/mingw-w64-upx/PKGBUILD
@@ -31,6 +31,7 @@ prepare() {
   mv "${srcdir}/${_realname}-${pkgver}-src" "${srcdir}/${_realname}-${pkgver}"
 
   cd "${srcdir}/${_realname}-${pkgver}"
+  # https://github.com/upx/upx/issues/953#issuecomment-4632972248
   patch -Np1 -i "${srcdir}/001-scrolling.patch"
 }
 


### PR DESCRIPTION
This fixes a bug in upx that causes scrolling in-place in a very narrow area once cursor approaches the bottom of a terminal.
How to reproduce:
1. work in console for a while so that it gets full and cursor reaches the bottom
2. Try to invoke `upx --help`

The ways to overcome the issue are:
1. piping through cat or less
2. reducing terminal height to less than 24 lines

It was reported upstream, but the chances it gets fixed there look slim.