### PR TITLE
chore: replace `| true` with `|| true`

### DIFF
--- a/mingw-w64-bzip2/PKGBUILD
+++ b/mingw-w64-bzip2/PKGBUILD
@@ -29,12 +29,12 @@ sha256sums=('ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269'
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   # remove files that are created by patches.
-  rm -rf README.CYGMING | true
-  rm -rf aclocal.m4 | true
-  rm -rf configure.ac | true
-  rm -rf libbz2.def.in | true
-  rm -rf bzip2.pc.in | true
-  rm -rf Makefile.in | true
+  rm -rf README.CYGMING || true
+  rm -rf aclocal.m4 || true
+  rm -rf configure.ac || true
+  rm -rf libbz2.def.in || true
+  rm -rf bzip2.pc.in || true
+  rm -rf Makefile.in || true
 
   patch -p1 -i "$srcdir/"bzip2-cygming-1.0.6.src.all.patch
   patch -p1 -i "$srcdir/"bzip2-buildsystem.all.patch

--- a/mingw-w64-cmdpack/PKGBUILD
+++ b/mingw-w64-cmdpack/PKGBUILD
@@ -18,7 +18,7 @@ sha256sums=('6ce7029c0f2b0fbc6a1e26fb3ad8003ed18836aa3ef35f148ec51cde0b703307')
 
 prepare() {
   cd "$srcdir"
-  rm -rf build-${MSYSTEM} | true
+  rm -rf build-${MSYSTEM} || true
   cp -r "${_realname}-$pkgver" "build-${MSYSTEM}"
 }
 

--- a/mingw-w64-cunit/PKGBUILD
+++ b/mingw-w64-cunit/PKGBUILD
@@ -34,7 +34,7 @@ prepare() {
 
 build() {
   cd "${srcdir}"/${_distname}-${_distver}
-  rm -rf "${srcdir}"/build-${MSYSTEM} | true
+  rm -rf "${srcdir}"/build-${MSYSTEM} || true
   mkdir -p "${srcdir}"/build-${MSYSTEM} 
   cp -Rf "${srcdir}"/${_distname}-${_distver}/* "${srcdir}"/build-${MSYSTEM} 
   cd "${srcdir}"/build-${MSYSTEM}

--- a/mingw-w64-evcxr/PKGBUILD
+++ b/mingw-w64-evcxr/PKGBUILD
@@ -32,7 +32,7 @@ build() {
 check() {
   cd "${_realname}-${pkgver}"
 
-  cargo test --release --frozen | true
+  cargo test --release --frozen || true
 }
 
 package_evcxr_repl() {

--- a/mingw-w64-ffmpeg-python/PKGBUILD
+++ b/mingw-w64-ffmpeg-python/PKGBUILD
@@ -40,7 +40,7 @@ prepare() {
   patch -Np1 -i ../0001-remove-unused-pytest-runner-dep.patch
 
   cd "$srcdir"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-freeimage/PKGBUILD
+++ b/mingw-w64-freeimage/PKGBUILD
@@ -88,7 +88,7 @@ prepare() {
 
 build() {
   cd "${srcdir}"
-  rm -rf build-${MSYSTEM} | true
+  rm -rf build-${MSYSTEM} || true
   cp -r "${_realname}" "build-${MSYSTEM}"
 
   msg "Building freeimage..."

--- a/mingw-w64-goxel/PKGBUILD
+++ b/mingw-w64-goxel/PKGBUILD
@@ -35,7 +35,7 @@ prepare() {
 build() {
   msg "Build for ${MSYSTEM}"
 
-  rm -rf build-${MSYSTEM} | true
+  rm -rf build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "build-${MSYSTEM}"
   cd "${srcdir}/build-${MSYSTEM}"
 

--- a/mingw-w64-leptosfmt/PKGBUILD
+++ b/mingw-w64-leptosfmt/PKGBUILD
@@ -32,7 +32,7 @@ prepare() {
 
 build() {
   cd "${srcdir}"
-  rm -rf "build-${MSYSTEM}" | true
+  rm -rf "build-${MSYSTEM}" || true
   cp -r "${_realname}-${pkgver}" "build-${MSYSTEM}"
   cd "build-${MSYSTEM}"
 

--- a/mingw-w64-mdbook/PKGBUILD
+++ b/mingw-w64-mdbook/PKGBUILD
@@ -31,7 +31,7 @@ prepare() {
 
 build() {
   cd "${srcdir}"
-  rm -rf "build-${MSYSTEM}" | true
+  rm -rf "build-${MSYSTEM}" || true
   cp -r "${_realName}-${pkgver}" "build-${MSYSTEM}"
   cd "build-${MSYSTEM}"
 
@@ -40,7 +40,7 @@ build() {
     --release \
     --frozen
 
-  mkdir completions | true
+  mkdir completions || true
   "./target/release/${_realname}.exe" completions bash > "completions/${_realname}.bash"
   "./target/release/${_realname}.exe" completions fish > "completions/${_realname}.fish"
   "./target/release/${_realname}.exe" completions zsh > "completions/_${_realname}"

--- a/mingw-w64-opencamlib/PKGBUILD
+++ b/mingw-w64-opencamlib/PKGBUILD
@@ -50,7 +50,7 @@ build() {
     _extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
-  rm -rf "${srcdir}-build-${MSYSTEM}-cxx" | true
+  rm -rf "${srcdir}-build-${MSYSTEM}-cxx" || true
   mkdir -p "${srcdir}/build-${MSYSTEM}-cxx" && cd "${srcdir}/build-${MSYSTEM}-cxx"
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
@@ -67,7 +67,7 @@ build() {
 
   ${MINGW_PREFIX}/bin/cmake --build .
 
-  rm -rf "${srcdir}-build-${MSYSTEM}-py" | true
+  rm -rf "${srcdir}-build-${MSYSTEM}-py" || true
   mkdir -p "${srcdir}/build-${MSYSTEM}-py" && cd "${srcdir}/build-${MSYSTEM}-py"
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \

--- a/mingw-w64-pelican/PKGBUILD
+++ b/mingw-w64-pelican/PKGBUILD
@@ -47,7 +47,7 @@ prepare() {
   patch -p1 -i "${srcdir}"/0001-pelican-4.11.0-dependencies-fix.patch
 
   cd "${srcdir}"
-  rm -rf "python-build-${MSYSTEM}" | true
+  rm -rf "python-build-${MSYSTEM}" || true
   cp -r "pelican-${pkgver}" "python-build-${MSYSTEM}"
 }
 
@@ -59,7 +59,7 @@ build() {
 check() {
   cd "${srcdir}/python-build-${MSYSTEM}"
   PYTHONPATH="${srcdir}/python-build-${MSYSTEM}/build/lib" \
-    ${MINGW_PREFIX}/bin/nosetests | true
+    ${MINGW_PREFIX}/bin/nosetests || true
 }
 
 package() {

--- a/mingw-w64-podman/PKGBUILD
+++ b/mingw-w64-podman/PKGBUILD
@@ -35,7 +35,7 @@ noextract=("${_realname}-${pkgver}.tar.gz")
 
 prepare() {
     echo "Extracting ${_realname}-${pkgver}.tar.gz ..."
-    tar -xzf ${_realname}-${pkgver}.tar.gz | true
+    tar -xzf ${_realname}-${pkgver}.tar.gz || true
     rm -rf build-${MSYSTEM}
     cp -r ${_realname}-${pkgver} build-${MSYSTEM}
     cp -r "gvisor-tap-vsock-${_GV_VERSION#v}" "build-proxy-${MSYSTEM}"

--- a/mingw-w64-pyqt-builder/PKGBUILD
+++ b/mingw-w64-pyqt-builder/PKGBUILD
@@ -34,7 +34,7 @@ prepare() {
   patch -p1 -i "${srcdir}/001-mingw-python.patch"
 
   cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-pyqt5-sip/PKGBUILD
+++ b/mingw-w64-pyqt5-sip/PKGBUILD
@@ -25,7 +25,7 @@ sha256sums=('71c37db75a0664325de149f43e2a712ec5fa1f90429a21dafbca005cb6767f94')
 
 prepare() {
   cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "PyQt5_sip-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-pyqt5/PKGBUILD
+++ b/mingw-w64-pyqt5/PKGBUILD
@@ -59,7 +59,7 @@ sha256sums=('fda45743ebb4a27b4b1a51c6d8ef455c4c1b5d610c90d2934c7802b5c1557c52')
 
 prepare() {
   cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r PyQt5-${pkgver} python-build-${MSYSTEM}
 }
 

--- a/mingw-w64-pyqt6-sip/PKGBUILD
+++ b/mingw-w64-pyqt6-sip/PKGBUILD
@@ -24,7 +24,7 @@ sha256sums=('869c5b48afe38e55b1ee0dd72182b0886e968cc509b98023ff50010b013ce1be')
 
 prepare() {
   cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "PyQt6_sip-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-pyqt6/PKGBUILD
+++ b/mingw-w64-pyqt6/PKGBUILD
@@ -60,7 +60,7 @@ sha256sums=('45dd60aa69976de1918b5ced6b4e7b6a25abd2a919ecef5fd5826ecc76718889')
 
 prepare() {
   cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r PyQt6-${pkgver} python-build-${MSYSTEM}
 }
 

--- a/mingw-w64-python-argh/PKGBUILD
+++ b/mingw-w64-python-argh/PKGBUILD
@@ -26,7 +26,7 @@ sha256sums=('f30023d8be14ca5ee6b1b3eeab829151d7bbda464ae07dc4dd5347919c5892f9')
 
 prepare() {
   cd "${srcdir}"
-  rm -rf "python-build-${MSYSTEM}" | true
+  rm -rf "python-build-${MSYSTEM}" || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-argon2_cffi/PKGBUILD
+++ b/mingw-w64-python-argon2_cffi/PKGBUILD
@@ -26,7 +26,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('879c3e79a2729ce768ebb7d36d4609e3a78a4ca2ec3a9f12286ca057e3d0db08')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-arrow/PKGBUILD
+++ b/mingw-w64-python-arrow/PKGBUILD
@@ -29,7 +29,7 @@ sha256sums=('d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85')
 
 prepare() {
   cd "$srcdir"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-binaryornot/PKGBUILD
+++ b/mingw-w64-python-binaryornot/PKGBUILD
@@ -26,7 +26,7 @@ sha256sums=('dcacb1343219da5fbbb7828a46b946768c6df07b65453195954cbbecf14c1c83')
 
 prepare() {
   cd "$srcdir"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_pyname//_/-}-$pkgver" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-biscuits/PKGBUILD
+++ b/mingw-w64-python-biscuits/PKGBUILD
@@ -26,7 +26,7 @@ sha256sums=('041ee6da5af6b0f1eb327a8b5d73930eddc5d9d8b3daf7fbe00301564abd9510')
 
 prepare() {
   cd "$srcdir"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-bootstrap-flask/PKGBUILD
+++ b/mingw-w64-python-bootstrap-flask/PKGBUILD
@@ -29,10 +29,10 @@ source=("${msys2_repository_url}/archive/${pkgver}/${_realname}-${pkgver}.tar.gz
 sha256sums=('dff9539c3cd3f72aecbd6108568aaac2d3b6bbd4e2e7c11db8d6c7c36154b373')
 
 prepare() {
-  rm -rf "python-build-${MSYSTEM}" | true
+  rm -rf "python-build-${MSYSTEM}" || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 
-  rm -rf "python-install-${MSYSTEM}" | true
+  rm -rf "python-install-${MSYSTEM}" || true
 }
 
 build() {

--- a/mingw-w64-python-bsddb3/PKGBUILD
+++ b/mingw-w64-python-bsddb3/PKGBUILD
@@ -40,7 +40,7 @@ prepare() {
   sed -i -e "s|elif os.name == 'nt':|elif os.name == 'FOO':|g" setup{2,3}.py
 
   cd "${srcdir}"
-  rm -rf "python-build-${MSYSTEM}" | true
+  rm -rf "python-build-${MSYSTEM}" || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-cabarchive/PKGBUILD
+++ b/mingw-w64-python-cabarchive/PKGBUILD
@@ -32,7 +32,7 @@ sha256sums=(
 
 prepare() {
   cd "$srcdir"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
 
   cp -r "${_realname//_/-}-$pkgver" "python-build-${MSYSTEM}"
 }

--- a/mingw-w64-python-click-default-group/PKGBUILD
+++ b/mingw-w64-python-click-default-group/PKGBUILD
@@ -31,7 +31,7 @@ sha256sums=('eb3f3c99ec0d456ca6cd2a7f08f7d4e91771bef51b01bdd9580cc6450fe1251e')
 
 prepare() {
   cd "$srcdir"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname//-/_}-$pkgver" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-cliff/PKGBUILD
+++ b/mingw-w64-python-cliff/PKGBUILD
@@ -36,7 +36,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('e949b585b9b64549de87388cefd49e87dd63095ce2b9f3b98f9123d7cd94be1a')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 
   # Set version for pbr

--- a/mingw-w64-python-cloup/PKGBUILD
+++ b/mingw-w64-python-cloup/PKGBUILD
@@ -34,7 +34,7 @@ source=("https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${
 sha256sums=('519f524d3c64040e49a0866b5fc0bfd6af3eac0d3d6a4b2b50b33ab0247db2d7')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_pyname//_/-}-$pkgver" "python-build-${MSYSTEM}"
   export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}
 }

--- a/mingw-w64-python-colorama/PKGBUILD
+++ b/mingw-w64-python-colorama/PKGBUILD
@@ -34,7 +34,7 @@ apply_patch_with_msg() {
 prepare() {
   cd "${srcdir}"
 
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-constantly/PKGBUILD
+++ b/mingw-w64-python-constantly/PKGBUILD
@@ -23,7 +23,7 @@ source=(https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realnam
 sha256sums=('aa92b70a33e2ac0bb33cd745eb61776594dc48764b06c35e0efd050b7f1c7cbd')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-cvxopt/PKGBUILD
+++ b/mingw-w64-python-cvxopt/PKGBUILD
@@ -35,7 +35,7 @@ sha256sums=('8059cef41f1f115c87bc9b75fec9f86db95e7f0afcf03a52d619ba433e443bcb')
 
 prepare() {
   cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 
   # Set version for setuptools_scm

--- a/mingw-w64-python-diff-match-patch/PKGBUILD
+++ b/mingw-w64-python-diff-match-patch/PKGBUILD
@@ -22,7 +22,7 @@ source=("https://pypi.io/packages/source/${_realname:0:1}/${_realname}/${_realna
 sha256sums=('beae57a99fa48084532935ee2968b8661db861862ec82c6f21f4acdd6d835073')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname//-/_}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-distlib/PKGBUILD
+++ b/mingw-w64-python-distlib/PKGBUILD
@@ -29,7 +29,7 @@ sha256sums=('feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d'
 
 prepare() {
   cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 
   cd "python-build-${MSYSTEM}"

--- a/mingw-w64-python-distro/PKGBUILD
+++ b/mingw-w64-python-distro/PKGBUILD
@@ -23,7 +23,7 @@ source=("https://pypi.io/packages/source/${_realname:0:1}/${_realname}/${_realna
 sha256sums=('2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-feedgenerator/PKGBUILD
+++ b/mingw-w64-python-feedgenerator/PKGBUILD
@@ -28,7 +28,7 @@ sha256sums=('0eaa955f1f0bcb5b87ac195af740f06ff9fff4a40ed30b8a7c6bbebb264d4dd1')
 
 prepare() {
   cd "${srcdir}"
-  rm -rf "python-build-${MSYSTEM}" | true
+  rm -rf "python-build-${MSYSTEM}" || true
   cp -r "feedgenerator-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-flask-babel/PKGBUILD
+++ b/mingw-w64-python-flask-babel/PKGBUILD
@@ -38,10 +38,10 @@ prepare() {
 
   cd "${srcdir}"
 
-  rm -rf "python-build-${MSYSTEM}" | true
+  rm -rf "python-build-${MSYSTEM}" || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 
-  rm -rf "python-install-${MSYSTEM}" | true
+  rm -rf "python-install-${MSYSTEM}" || true
 }
 
 build() {

--- a/mingw-w64-python-flask-login/PKGBUILD
+++ b/mingw-w64-python-flask-login/PKGBUILD
@@ -29,7 +29,7 @@ source=("https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${
 sha256sums=('5e23d14a607ef12806c699590b89d0f0e0d67baeec599d75947bf9c147330333')
 
 prepare() {
-  rm -rf "python-build-${MSYSTEM}" | true
+  rm -rf "python-build-${MSYSTEM}" || true
   cp -r "${_pyname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-flask-migrate/PKGBUILD
+++ b/mingw-w64-python-flask-migrate/PKGBUILD
@@ -29,7 +29,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_pyname
 sha256sums=('1a336b06eb2c3ace005f5f2ded8641d534c18798d64061f6ff11f79e1434126d')
 
 prepare() {
-  rm -rf "python-build-${MSYSTEM}" | true
+  rm -rf "python-build-${MSYSTEM}" || true
   cp -r "${_pyname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-flask-sqlalchemy/PKGBUILD
+++ b/mingw-w64-python-flask-sqlalchemy/PKGBUILD
@@ -31,7 +31,7 @@ source=("https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_realname/-
 sha256sums=('e4b68bb881802dda1a7d878b2fc84c06d1ee57fb40b874d3dc97dabfa36b8312')
 
 prepare() {
-  rm -rf "python-build-${MSYSTEM}" | true
+  rm -rf "python-build-${MSYSTEM}" || true
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-flask-wtf/PKGBUILD
+++ b/mingw-w64-python-flask-wtf/PKGBUILD
@@ -37,7 +37,7 @@ prepare() {
 
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}"
 
-  rm -rf "python-install-${MSYSTEM}" | true
+  rm -rf "python-install-${MSYSTEM}" || true
 }
 
 build() {

--- a/mingw-w64-python-glcontext/PKGBUILD
+++ b/mingw-w64-python-glcontext/PKGBUILD
@@ -23,7 +23,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('57168edcd38df2fc0d70c318edf6f7e59091fba1cd3dadb289d0aa50449211ef')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-gssapi/PKGBUILD
+++ b/mingw-w64-python-gssapi/PKGBUILD
@@ -59,7 +59,7 @@ cdef gss_OID GSS_KRB5_NT_PRINCIPAL_NAME = <gss_OID> GSS_KRB5_NT_PRINCIPAL_NAME_s
 EOF
 
   cd "$srcdir"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-$pkgver" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-gsutil/PKGBUILD
+++ b/mingw-w64-python-gsutil/PKGBUILD
@@ -40,7 +40,7 @@ prepare() {
   sed -e "s|httplib2==0.20.4|httplib2>=0.20.4|g" -i setup.py
 
   cd "$srcdir"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-hacking/PKGBUILD
+++ b/mingw-w64-python-hacking/PKGBUILD
@@ -29,7 +29,7 @@ prepare() {
   sed -e 's|~=|>=|' -i requirements.txt
 
   cd "${srcdir}"
-  rm -rf "python-build-${MSYSTEM}" | true
+  rm -rf "python-build-${MSYSTEM}" || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 
   # set version for python-pbr

--- a/mingw-w64-python-invoke/PKGBUILD
+++ b/mingw-w64-python-invoke/PKGBUILD
@@ -25,7 +25,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('515bf49b4a48932b79b024590348da22f39c4942dff991ad1fb8b8baea1be707')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 
   rm -Rf invoke/vendor/yaml2

--- a/mingw-w64-python-ipympl/PKGBUILD
+++ b/mingw-w64-python-ipympl/PKGBUILD
@@ -27,7 +27,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('eda69602a010af2a42e8ebd069b0ee0dbe8df7fc69d7c1e8b99fece0a2fe613f')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-jaraco.context/PKGBUILD
+++ b/mingw-w64-python-jaraco.context/PKGBUILD
@@ -30,7 +30,7 @@ sha256sums=('f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3')
 
 prepare() {
   cd "$srcdir"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_pyname}-$pkgver" "python-build-${MSYSTEM}"
   export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}
 }

--- a/mingw-w64-python-jaraco.envs/PKGBUILD
+++ b/mingw-w64-python-jaraco.envs/PKGBUILD
@@ -36,7 +36,7 @@ prepare() {
   pushd "${_realname//_/-}-$pkgver"
   patch -p1 -i "${srcdir}"/0001-mingw-python-fix.patch
   popd
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname//_/-}-$pkgver" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-jaraco.path/PKGBUILD
+++ b/mingw-w64-python-jaraco.path/PKGBUILD
@@ -26,7 +26,7 @@ source=("https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${
 sha256sums=('1263c4bb481002e83a96e9253915b33241ac3e1ed6219a2793d3121f65159107')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_pyname}-$pkgver" "python-build-${MSYSTEM}"
   export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}
 }

--- a/mingw-w64-python-jinja-docs/PKGBUILD
+++ b/mingw-w64-python-jinja-docs/PKGBUILD
@@ -23,7 +23,7 @@ source=(https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${p
 sha256sums=('0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_pyname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-jsonrpc-server/PKGBUILD
+++ b/mingw-w64-python-jsonrpc-server/PKGBUILD
@@ -36,7 +36,7 @@ prepare() {
   cd "${srcdir}"/${_pyname}-${pkgver}
   patch -p1 -i "${srcdir}/002-python-jsonrpc-server-0.4.0-fix-test.patch"
 
-  rm -rf "versioneer.py" | true
+  rm -rf "versioneer.py" || true
 }
 
 build() {

--- a/mingw-w64-python-jupyter-nbclient/PKGBUILD
+++ b/mingw-w64-python-jupyter-nbclient/PKGBUILD
@@ -30,7 +30,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('1e54091b16e6da39e297b0ece3e10f6f29f4ac4e8ee515d29f8a7099bd6553c9')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-jupyter-nbviewer/PKGBUILD
+++ b/mingw-w64-python-jupyter-nbviewer/PKGBUILD
@@ -41,7 +41,7 @@ prepare() {
   sed -i "s|newrelic!=2.80.0.60||g" requirements.txt
   sed -i "s|pylibmc||g" requirements.txt
 
-  rm -f "${srcdir}"/${_realname}-${pkgver}/versioneer.py | true
+  rm -f "${srcdir}"/${_realname}-${pkgver}/versioneer.py || true
 }
 
 build() {

--- a/mingw-w64-python-jupyter_client/PKGBUILD
+++ b/mingw-w64-python-jupyter_client/PKGBUILD
@@ -32,7 +32,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('d556811419a4f2d96c869af34e854e3f059b7cc2d6d01a9cd9c85c267691be3e')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-jupyter_console/PKGBUILD
+++ b/mingw-w64-python-jupyter_console/PKGBUILD
@@ -36,7 +36,7 @@ sha256sums=('566a4bf31c87adbfadf22cdf846e3069b59a71ed5da71d6ba4d8aaad14a53539')
 
 prepare() {
   cd "${srcdir}"
-  rm -rf "python-build-${MSYSTEM}" | true
+  rm -rf "python-build-${MSYSTEM}" || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-jupyter_core/PKGBUILD
+++ b/mingw-w64-python-jupyter_core/PKGBUILD
@@ -34,7 +34,7 @@ source=(https://pypi.org/packages/source/${_realname::1}/${_realname/_/-}/${_rea
 sha256sums=('4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-jupyter_notebook_shim/PKGBUILD
+++ b/mingw-w64-python-jupyter_notebook_shim/PKGBUILD
@@ -26,7 +26,7 @@ source=("https://github.com/jupyter/notebook_shim/releases/download/v${pkgver}/$
 sha256sums=('b4b2cfa1b65d98307ca24361f5b30fe785b53c3fd07b7a47e89acb5e6ac638cb')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-labelme/PKGBUILD
+++ b/mingw-w64-python-labelme/PKGBUILD
@@ -34,7 +34,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('556c793b33b32de47324d60182c356ccefcbf8ae4a9217392b5f6a32ea5251e1')
 
 prepare() {
-  rm -rf "$srcdir/python-build-${MSYSTEM}" | true
+  rm -rf "$srcdir/python-build-${MSYSTEM}" || true
   cp -r "$srcdir/${_realname}-${pkgver}" "$srcdir/python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-language-server/PKGBUILD
+++ b/mingw-w64-python-language-server/PKGBUILD
@@ -51,7 +51,7 @@ prepare() {
   patch -p1 -i "${srcdir}/001-python-language-server-0.36.2-fix-versioneer.patch"
   patch -p1 -i "${srcdir}/002-python-language-server-0.36.2-fix-setup.patch"
 
-  rm -rf "versioneer.py" | true
+  rm -rf "versioneer.py" || true
 }
 
 build() {

--- a/mingw-w64-python-lief/PKGBUILD
+++ b/mingw-w64-python-lief/PKGBUILD
@@ -59,7 +59,7 @@ prepare() {
   # https://github.com/lief-project/LIEF/commit/d09a8d53
   patch -p1 -i "${srcdir}"/002-fix-build-with-nanobind-2.12.patch
 
-  rm -rf "${srcdir}"/build-${MSYSTEM} | true
+  rm -rf "${srcdir}"/build-${MSYSTEM} || true
   cp -r "${srcdir}"/LIEF-${pkgver} "${srcdir}"/build-${MSYSTEM}
 }
 

--- a/mingw-w64-python-lsp-black/PKGBUILD
+++ b/mingw-w64-python-lsp-black/PKGBUILD
@@ -28,7 +28,7 @@ sha256sums=('8286d2d310c566844b3c116b824ada6fccfa6ba228b1a09a0526b74c04e0805f')
 
 prepare() {
   cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_pyname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-lsp-jsonrpc/PKGBUILD
+++ b/mingw-w64-python-lsp-jsonrpc/PKGBUILD
@@ -27,7 +27,7 @@ sha256sums=('4688e453eef55cd952bff762c705cedefa12055c0aec17a06f595bcc002cc912')
 
 prepare() {
   cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
   export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}
 }

--- a/mingw-w64-python-lxml/PKGBUILD
+++ b/mingw-w64-python-lxml/PKGBUILD
@@ -53,7 +53,7 @@ prepare() {
 }
 
 build() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
 
   python -m build --wheel --skip-dependency-check --no-isolation \

--- a/mingw-w64-python-lzo/PKGBUILD
+++ b/mingw-w64-python-lzo/PKGBUILD
@@ -30,7 +30,7 @@ prepare() {
   sed -i -e 's|lzo2.lib|lib/liblzo2.a|g' setup.py
 
   cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_pyname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-matplotlib/PKGBUILD
+++ b/mingw-w64-python-matplotlib/PKGBUILD
@@ -48,7 +48,7 @@ sha256sums=('fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358')
 
 prepare() {
   cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 
   # Set version for setuptools_scm

--- a/mingw-w64-python-moderngl/PKGBUILD
+++ b/mingw-w64-python-moderngl/PKGBUILD
@@ -30,7 +30,7 @@ sha256sums=('52936a98ccb2f2e1d6e3cb18528b2919f6831e7e3f924e788b5873badce5129b')
 
 prepare() {
   cd "$srcdir"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_pyname//_/-}-$pkgver" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-nodeenv/PKGBUILD
+++ b/mingw-w64-python-nodeenv/PKGBUILD
@@ -25,7 +25,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-numexpr/PKGBUILD
+++ b/mingw-w64-python-numexpr/PKGBUILD
@@ -35,7 +35,7 @@ prepare() {
   patch -p1 -i "${srcdir}"/001-fix-building-on-mingw.patch
 
   cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-numpydoc/PKGBUILD
+++ b/mingw-w64-python-numpydoc/PKGBUILD
@@ -30,7 +30,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('3f7970f6eee30912260a6b31ac72bba2432830cd6722569ec17ee8d3ef5ffa01')
 
 prepare() {
-  rm -rf "${srcdir}/python-build-${MSYSTEM}" | true
+  rm -rf "${srcdir}/python-build-${MSYSTEM}" || true
   cp -r "${srcdir}/${_realname}-${pkgver}" "${srcdir}/python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-nvidia-ml/PKGBUILD
+++ b/mingw-w64-python-nvidia-ml/PKGBUILD
@@ -24,7 +24,7 @@ sha256sums=('f0254dc7400647680a072ee02509bfd46102b60bdfeca321576d4d4817e7fe97')
 
 prepare() {
   cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_srcname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-olefile/PKGBUILD
+++ b/mingw-w64-python-olefile/PKGBUILD
@@ -23,7 +23,7 @@ sha256sums=('599383381a0bf3dfbd932ca0ca6515acd174ed48870cbf7fee123d698c192c1c')
 
 prepare() {
   cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-oslo-config/PKGBUILD
+++ b/mingw-w64-python-oslo-config/PKGBUILD
@@ -38,7 +38,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname/-/_}/${_re
 sha256sums=('c405a40a8b05aa97bb5c24bb0b849981a7a5b7d56304df40632722312c58eaca')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}"
 
   export PBR_VERSION=$pkgver

--- a/mingw-w64-python-packaging/PKGBUILD
+++ b/mingw-w64-python-packaging/PKGBUILD
@@ -25,7 +25,7 @@ sha256sums=('ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661')
 
 prepare() {
   cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-pandas/PKGBUILD
+++ b/mingw-w64-python-pandas/PKGBUILD
@@ -45,7 +45,7 @@ prepare() {
 }
 
 build() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
 
   ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation

--- a/mingw-w64-python-pandocfilters/PKGBUILD
+++ b/mingw-w64-python-pandocfilters/PKGBUILD
@@ -22,7 +22,7 @@ source=("https://pypi.io/packages/source/p/pandocfilters/pandocfilters-${pkgver}
 sha256sums=('002b4a555ee4ebc03f8b66307e287fa492e4a77b4ea14d3f934328297bb4939e')
 
 prepare() {
-  rm -rf "python-build-${MSYSTEM}" | true
+  rm -rf "python-build-${MSYSTEM}" || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-pesq/PKGBUILD
+++ b/mingw-w64-python-pesq/PKGBUILD
@@ -27,7 +27,7 @@ source=("https://pypi.org/packages/source/${_realname:0:1}/${_realname}/${_realn
 sha256sums=('b724b28f73fb638522982bd68e8c3c0957e2f45210639a460233b17aa7fc890b')
 
 build() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
 
   ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation

--- a/mingw-w64-python-pexpect/PKGBUILD
+++ b/mingw-w64-python-pexpect/PKGBUILD
@@ -24,7 +24,7 @@ sha256sums=('ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f')
 
 prepare() {
   cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-pillow/PKGBUILD
+++ b/mingw-w64-python-pillow/PKGBUILD
@@ -36,7 +36,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5')
 
 prepare() {
-  rm -rf "python-build-${MSYSTEM}" | true
+  rm -rf "python-build-${MSYSTEM}" || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
   cd "python-build-${MSYSTEM}"
 }

--- a/mingw-w64-python-pivy/PKGBUILD
+++ b/mingw-w64-python-pivy/PKGBUILD
@@ -53,7 +53,7 @@ prepare() {
 }
 
 build() {
-  rm -rf "python-build-${MSYSTEM}" | true
+  rm -rf "python-build-${MSYSTEM}" || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
 
   GENERATOR="Ninja" \

--- a/mingw-w64-python-pluggy/PKGBUILD
+++ b/mingw-w64-python-pluggy/PKGBUILD
@@ -24,7 +24,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 
   export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}

--- a/mingw-w64-python-pooch/PKGBUILD
+++ b/mingw-w64-python-pooch/PKGBUILD
@@ -27,7 +27,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('76561f0de68a01da4df6af38e9955c4c9d1a5c90da73f7e40276a5728ec83d10')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 
   # Set version for setuptools_scm

--- a/mingw-w64-python-protobuf/PKGBUILD
+++ b/mingw-w64-python-protobuf/PKGBUILD
@@ -35,7 +35,7 @@ prepare() {
   patch -p1 -i "${srcdir}"/001-no-python-static-lib.patch
   patch -p1 -i "${srcdir}"/002-fix-build-on-clangarm64.patch
 
-  rm -rf "${srcdir}"/python-build-${MSYSTEM} | true
+  rm -rf "${srcdir}"/python-build-${MSYSTEM} || true
   cp -r "${srcdir}"/${_realname}-${pkgver} "${srcdir}"/"python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-psutil/PKGBUILD
+++ b/mingw-w64-python-psutil/PKGBUILD
@@ -58,7 +58,7 @@ prepare() {
     0003-avoid-symbol-errors.patch
 
   cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-py2exe/PKGBUILD
+++ b/mingw-w64-python-py2exe/PKGBUILD
@@ -49,7 +49,7 @@ build() {
   ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
   popd
 
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
   cd "${srcdir}/python-build-${MSYSTEM}"
   ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation

--- a/mingw-w64-python-pybox2d/PKGBUILD
+++ b/mingw-w64-python-pybox2d/PKGBUILD
@@ -25,7 +25,7 @@ sha256sums=('5471722f290b7285dcbdee9bef61d1cb424e5a610fa6e19e9ddeb854c7e3b937')
 
 prepare() {
   cd "${srcdir}"
-  rm -rf "python-build-${MSYSTEM}" | true
+  rm -rf "python-build-${MSYSTEM}" || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
 
   ${MINGW_PREFIX}/bin/swig -python -c++ -IBox2D -small -O -includeall -ignoremissing -w201 \

--- a/mingw-w64-python-pydocstyle/PKGBUILD
+++ b/mingw-w64-python-pydocstyle/PKGBUILD
@@ -24,7 +24,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('7ce43f0c0ac87b07494eb9c0b462c0b73e6ff276807f204d6b53edc72b7e44e1')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r ${_realname}-${pkgver} python-build-${MSYSTEM}
 }
 

--- a/mingw-w64-python-pyfasttextureutils/PKGBUILD
+++ b/mingw-w64-python-pyfasttextureutils/PKGBUILD
@@ -33,7 +33,7 @@ pkgver() {
 
 prepare() {
   cd "$srcdir"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "PyFastTextureUtils" "python-build-${MSYSTEM}"
   cd "${srcdir}/python-build-${MSYSTEM}"
   patch -Np2 -i ../minmax.patch

--- a/mingw-w64-python-pystemmer/PKGBUILD
+++ b/mingw-w64-python-pystemmer/PKGBUILD
@@ -29,7 +29,7 @@ sha256sums=('083cc3ed90f4c3b0668f8e31c2925cbb4db3bf0fd6d710e0ad0914f33685f7df')
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
 
-  rm -rf "${srcdir}"/python-build-${MSYSTEM} | true
+  rm -rf "${srcdir}"/python-build-${MSYSTEM} || true
   cp -r "${srcdir}"/"${_realname}-${pkgver}" "${srcdir}"/"python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-pyswarm/PKGBUILD
+++ b/mingw-w64-python-pyswarm/PKGBUILD
@@ -24,7 +24,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('1401E8E39FC624B48DB39F1E928B1FC4D8204B96AA6CE2EF97D192740972F2E1')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-pytest-checkdocs/PKGBUILD
+++ b/mingw-w64-python-pytest-checkdocs/PKGBUILD
@@ -27,7 +27,7 @@ sha256sums=('393868583f2d0314f8c5828fd94f7d28699543f6a0a925356d7e274e2952297e')
 
 prepare() {
   cd "$srcdir"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_pyname//_/-}-$pkgver" "python-build-${MSYSTEM}"
   export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}
 }

--- a/mingw-w64-python-pytest-datafiles/PKGBUILD
+++ b/mingw-w64-python-pytest-datafiles/PKGBUILD
@@ -29,7 +29,7 @@ sha256sums=('05fc3eef2429fe26ae42283cccb1f3831b53b12d4bd8b4734bf42973d4af6e16')
 
 prepare() {
   cd "$srcdir"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_pyname}-$pkgver" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-pytest-xdist/PKGBUILD
+++ b/mingw-w64-python-pytest-xdist/PKGBUILD
@@ -26,7 +26,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}"
 
   # Set version for setuptools_scm

--- a/mingw-w64-python-pyvisa/PKGBUILD
+++ b/mingw-w64-python-pyvisa/PKGBUILD
@@ -26,7 +26,7 @@ source=("${url}/archive/${pkgver}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('3e12abe3c7fdd9d26f81a5bc1cb489be2dfd8cf3f767008566b7fea555de4696')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
   export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}
 }

--- a/mingw-w64-python-qasync/PKGBUILD
+++ b/mingw-w64-python-qasync/PKGBUILD
@@ -28,7 +28,7 @@ sha256sums=('8dc768fd1ee5de1044c7c305eccf2d39d24d87803ea71189d4024fb475f4985f')
 prepare() {
   cd "${srcdir}"
 
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-qdarkstyle/PKGBUILD
+++ b/mingw-w64-python-qdarkstyle/PKGBUILD
@@ -30,7 +30,7 @@ sha256sums=('0c0b7f74a6e92121008992b369bab60468157db1c02cd30d64a5e9a3b402f1ae')
 
 prepare() {
   cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_pyname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-qtconsole/PKGBUILD
+++ b/mingw-w64-python-qtconsole/PKGBUILD
@@ -33,7 +33,7 @@ sha256sums=('27b485b9161925924c1d8e78e66bb342e6e3bc49bf675d0a67b49bad9c291521')
 
 prepare() {
   cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-qtpy/PKGBUILD
+++ b/mingw-w64-python-qtpy/PKGBUILD
@@ -35,7 +35,7 @@ prepare() {
   patch -p1 -i "$srcdir"/001-restore-qtwebkit-support.patch
 
   cd "$srcdir"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_pyname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-referencing/PKGBUILD
+++ b/mingw-w64-python-referencing/PKGBUILD
@@ -30,7 +30,7 @@ noextract=(${_realname}-${pkgver}.tar.gz)
 sha256sums=('44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   tar -xf ${_realname}-${pkgver}.tar.gz || true
 }
 

--- a/mingw-w64-python-requests-toolbelt/PKGBUILD
+++ b/mingw-w64-python-requests-toolbelt/PKGBUILD
@@ -22,7 +22,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-rst2pdf/PKGBUILD
+++ b/mingw-w64-python-rst2pdf/PKGBUILD
@@ -43,7 +43,7 @@ prepare() {
   sed -i 's/"packaging~=25\.0"/"packaging~=26.0"/' pyproject.toml
   cd -
 
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 
   # Set version for setuptools_scm

--- a/mingw-w64-python-ruamel.yaml.clib/PKGBUILD
+++ b/mingw-w64-python-ruamel.yaml.clib/PKGBUILD
@@ -26,7 +26,7 @@ source=("https://files.pythonhosted.org/packages/source/${_realname:0:1}/${_real
 sha256sums=('46e4cc8c43ef6a94885f72512094e482114a8a706d3c555a34ed4b0d20200600')
 
 prepare() {
-  rm -rf "python-build-${MSYSTEM}" | true
+  rm -rf "python-build-${MSYSTEM}" || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-send2trash/PKGBUILD
+++ b/mingw-w64-python-send2trash/PKGBUILD
@@ -25,7 +25,7 @@ source=("https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${
 sha256sums=('b18e7a3966d99871aefeb00cfbcfdced55ce4871194810fc71f4aa484b953abf')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_pyname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-setuptools/PKGBUILD
+++ b/mingw-w64-python-setuptools/PKGBUILD
@@ -95,7 +95,7 @@ prepare() {
   mv "setuptools/command/launcher manifest.xml" "setuptools"
 
   cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-$pkgver" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-shapely/PKGBUILD
+++ b/mingw-w64-python-shapely/PKGBUILD
@@ -30,7 +30,7 @@ sha256sums=('2ed4ecb28320a433db18a5bf029986aa8afcfd740745e78847e330d5d94922a9'
 
 prepare() {
   cd "${srcdir}"
-  rm -rf "python-build-${MSYSTEM}" | true
+  rm -rf "python-build-${MSYSTEM}" || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 
   cd "python-build-${MSYSTEM}"

--- a/mingw-w64-python-slugify/PKGBUILD
+++ b/mingw-w64-python-slugify/PKGBUILD
@@ -30,7 +30,7 @@ sha256sums=('59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856')
 
 prepare() {
   cd "$srcdir"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_pyname//_/-}-$pkgver" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-sqlmodel/PKGBUILD
+++ b/mingw-w64-python-sqlmodel/PKGBUILD
@@ -24,7 +24,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('d583ec237b14103809f74e8630032bc40ab68cd6b754a610f0813c56911a547b')
 
 prepare() {
-  rm -rf "python-build-${MSYSTEM}" | true
+  rm -rf "python-build-${MSYSTEM}" || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-srt/PKGBUILD
+++ b/mingw-w64-python-srt/PKGBUILD
@@ -24,7 +24,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('4884315043a4f0740fd1f878ed6caa376ac06d70e135f306a6dc44632eed0cc0')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname//_/-}-$pkgver" "python-build-${MSYSTEM}"
   export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}
 }

--- a/mingw-w64-python-starlette/PKGBUILD
+++ b/mingw-w64-python-starlette/PKGBUILD
@@ -32,7 +32,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-statsd/PKGBUILD
+++ b/mingw-w64-python-statsd/PKGBUILD
@@ -23,7 +23,7 @@ sha256sums=('99763da81bfea8daf6b3d22d11aaccb01a8d0f52ea521daab37e758a4ca7d128')
 
 prepare() {
   cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-statsmodels/PKGBUILD
+++ b/mingw-w64-python-statsmodels/PKGBUILD
@@ -39,7 +39,7 @@ prepare() {
   patch -p1 -i "${srcdir}"/001-dont-include-extra-files.patch
 
   cd "${srcdir}"
-  rm -rf "python-build-${MSYSTEM}" | true
+  rm -rf "python-build-${MSYSTEM}" || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-tabulate/PKGBUILD
+++ b/mingw-w64-python-tabulate/PKGBUILD
@@ -31,7 +31,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname//-/_}-$pkgver" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-testtools/PKGBUILD
+++ b/mingw-w64-python-testtools/PKGBUILD
@@ -27,7 +27,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('5be5bbc1f0fa0f8b60aca6ceec07845d41d0c475cf445bfadb4d2c45ec397ea3')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 
   # Set version for pbr

--- a/mingw-w64-python-toml/PKGBUILD
+++ b/mingw-w64-python-toml/PKGBUILD
@@ -26,7 +26,7 @@ sha256sums=('b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f'
 
 prepare() {
   cp -v test.toml "${_realname}-$pkgver"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-u-msgpack/PKGBUILD
+++ b/mingw-w64-python-u-msgpack/PKGBUILD
@@ -25,7 +25,7 @@ sha256sums=('b801a83d6ed75e6df41e44518b4f2a9c221dc2da4bcd5380e3a0feda520bc61a')
 
 prepare() {
   cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_pyname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-ujson/PKGBUILD
+++ b/mingw-w64-python-ujson/PKGBUILD
@@ -27,7 +27,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('5b7e96406c301a1366534479a7352ec40ec68bb327c0c119091635acd5925e35')
 
 prepare() {
-  rm -rf "python-build-${MSYSTEM}" | true
+  rm -rf "python-build-${MSYSTEM}" || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 
   # Set version for setuptools_scm

--- a/mingw-w64-python-wordcloud/PKGBUILD
+++ b/mingw-w64-python-wordcloud/PKGBUILD
@@ -30,7 +30,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('df17c468ff903bd0aba4f87c6540745d13a4931220dd4937cb363ad85a4771b9')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname//_/-}-$pkgver" "python-build-${MSYSTEM}"
   export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}
 }

--- a/mingw-w64-python-wsproto/PKGBUILD
+++ b/mingw-w64-python-wsproto/PKGBUILD
@@ -25,7 +25,7 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('ad565f26ecb92588a3e43bc3d96164de84cd9902482b130d0ddbaa9664a85065')
 
 prepare() {
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-python-wtforms/PKGBUILD
+++ b/mingw-w64-python-wtforms/PKGBUILD
@@ -36,7 +36,7 @@ sha256sums=('83a0c8fa07f6c1ca35985c54b5eb8815c2e6b75b7d4511c6c13a2af0370522e0')
 prepare() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 
-  rm -rf python-install-${MSYSTEM} | true
+  rm -rf python-install-${MSYSTEM} || true
 }
 
 build() {

--- a/mingw-w64-python-yapf/PKGBUILD
+++ b/mingw-w64-python-yapf/PKGBUILD
@@ -30,7 +30,7 @@ sha256sums=('00d3aa24bfedff9420b2e0d5d9f5ab6d9d4268e72afbf59bb3fa542781d5218e')
 
 prepare() {
   cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-rustlings/PKGBUILD
+++ b/mingw-w64-rustlings/PKGBUILD
@@ -34,7 +34,7 @@ prepare() {
 
 build() {
   cd "${srcdir}"
-  rm -rf "build-${MSYSTEM}" | true
+  rm -rf "build-${MSYSTEM}" || true
   cp -r "${_realname}-${pkgver}" "build-${MSYSTEM}"
   cd "build-${MSYSTEM}"
 
@@ -48,7 +48,7 @@ check() {
 
   "${MINGW_PREFIX}/bin/cargo.exe" test \
     --release \
-    --frozen | true
+    --frozen || true
 }
 
 package() {

--- a/mingw-w64-sip/PKGBUILD
+++ b/mingw-w64-sip/PKGBUILD
@@ -48,7 +48,7 @@ prepare() {
     002-wrappers.patch
 
   cd "${srcdir}"
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 
   # Set version for setuptools_scm

--- a/mingw-w64-tiled/PKGBUILD
+++ b/mingw-w64-tiled/PKGBUILD
@@ -38,7 +38,7 @@ prepare() {
 }
 
 build() {
-  rm -rf build-${MSYSTEM} | true
+  rm -rf build-${MSYSTEM} || true
   cp -r "${srcdir}/${_realname}-${pkgver}" "${srcdir}/build-${MSYSTEM}"
   cd "${srcdir}/build-${MSYSTEM}"
 

--- a/mingw-w64-trunk/PKGBUILD
+++ b/mingw-w64-trunk/PKGBUILD
@@ -31,7 +31,7 @@ prepare() {
 
 build() {
   cd "${srcdir}"
-  rm -rf "build-${MSYSTEM}" | true
+  rm -rf "build-${MSYSTEM}" || true
   cp -r "${_realname}-${pkgver}" "build-${MSYSTEM}"
   cd "${srcdir}/build-${MSYSTEM}"
 

--- a/mingw-w64-wwrando/PKGBUILD
+++ b/mingw-w64-wwrando/PKGBUILD
@@ -33,7 +33,7 @@ sha256sums=('9d05501ff5468aa5d790cb10c7daaed50700f81b7254bc9cdbfe3c3f28c50d19')
 prepare() {
   cd "${srcdir}"
 
-  rm -rf python-build-${MSYSTEM} | true
+  rm -rf python-build-${MSYSTEM} || true
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 

--- a/mingw-w64-wxPython/PKGBUILD
+++ b/mingw-w64-wxPython/PKGBUILD
@@ -51,7 +51,7 @@ prepare() {
 }
 
 build() {
-  rm -rf build-${MSYSTEM} | true
+  rm -rf build-${MSYSTEM} || true
   cp -r ${_pyname}-${pkgver} build-${MSYSTEM} && cd build-${MSYSTEM}
 
   declare -a _extra_config


### PR DESCRIPTION
`| true` is a misuse of pipe and will fail if bash is configured with `set -o pipefail`. `|| true` acts correctly at all times and is better in semantic.

Not bumping pkgrel as this is just an improvement in code tidy.