### PR TITLE
pcaudiolib: fix CoInitialize to allow RPC_E_CHANGED_MODE

### DIFF
--- a/mingw-w64-pcaudiolib/001-fix-build-on-mingw.patch
+++ b/mingw-w64-pcaudiolib/001-fix-build-on-mingw.patch
@@ -167,7 +167,7 @@ index e3b37e6..7a0f219 100644
  		return NULL;
  
 diff --git a/src/xaudio2.cpp b/src/xaudio2.cpp
-index bb9d5be..0fc2936 100644
+index bb9d5be..ca4edbb 100644
 --- a/src/xaudio2.cpp
 +++ b/src/xaudio2.cpp
 @@ -147,6 +147,12 @@ xaudio2_object_flush(struct audio_object *object)
@@ -195,20 +195,19 @@ index bb9d5be..0fc2936 100644
  
  	XAUDIO2_VOICE_STATE state = { 0 };
  	self->source->GetState(&state);
-@@ -199,15 +204,20 @@ create_xaudio2_object(const char *device,
+@@ -199,7 +204,10 @@ create_xaudio2_object(const char *device,
                        const char *application_name,
                        const char *description)
  {
 -	CoInitialize(NULL);
-+	HRESULT hr = CoInitializeEx(NULL, COINIT_MULTITHREADED);
-+	if (FAILED(hr) && hr != (HRESULT)0x80010106) {
++	HRESULT coinit_hr = CoInitializeEx(NULL, COINIT_MULTITHREADED);
++	if (FAILED(coinit_hr) && coinit_hr != (HRESULT)0x80010106) {
 +		return NULL;
 +	}
  
  	IXAudio2 *audio = NULL;
--	HRESULT hr = XAudio2Create(&audio, 0, XAUDIO2_DEFAULT_PROCESSOR);
-+	hr = XAudio2Create(&audio, 0, XAUDIO2_DEFAULT_PROCESSOR);
- 	if (FAILED(hr) || audio == NULL) {
+ 	HRESULT hr = XAudio2Create(&audio, 0, XAUDIO2_DEFAULT_PROCESSOR);
+@@ -207,7 +215,9 @@ create_xaudio2_object(const char *device,
  		if (audio != NULL)
  			audio->Release();
  

--- a/mingw-w64-pcaudiolib/001-fix-build-on-mingw.patch
+++ b/mingw-w64-pcaudiolib/001-fix-build-on-mingw.patch
@@ -202,7 +202,7 @@ index bb9d5be..491189a 100644
  {
 -	CoInitialize(NULL);
 +	HRESULT hr = CoInitializeEx(NULL, COINIT_MULTITHREADED);
-+	if (FAILED(hr)) {
++	if (FAILED(hr) && hr != (HRESULT)0x80010106) {
 +		return NULL;
 +	}
  

--- a/mingw-w64-pcaudiolib/001-fix-build-on-mingw.patch
+++ b/mingw-w64-pcaudiolib/001-fix-build-on-mingw.patch
@@ -1,20 +1,19 @@
 diff --git a/Makefile.am b/Makefile.am
-index b04ba53..32de095 100644
+index b04ba53..c58a58a 100644
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -3,8 +3,11 @@
+@@ -3,7 +3,10 @@ AUTOMAKE_OPTIONS = subdir-objects
  localedir  = $(datadir)/locale
  
  AM_CFLAGS = \
 -	-Isrc/include
 +	-I$(top_srcdir)/src/include
- 
++
 +AM_CXXFLAGS = \
 +	-I$(top_srcdir)/src/include
-+
+ 
  ACLOCAL_AMFLAGS = -I m4
  
- lib_LTLIBRARIES =
 @@ -57,7 +60,8 @@ src_libpcaudio_la_LDFLAGS = -version-info $(LIBPCAUDIO_VERSION) \
  	${ALSA_LIBS} \
  	${PULSEAUDIO_LIBS} \
@@ -168,7 +167,7 @@ index e3b37e6..7a0f219 100644
  		return NULL;
  
 diff --git a/src/xaudio2.cpp b/src/xaudio2.cpp
-index bb9d5be..491189a 100644
+index bb9d5be..0fc2936 100644
 --- a/src/xaudio2.cpp
 +++ b/src/xaudio2.cpp
 @@ -147,6 +147,12 @@ xaudio2_object_flush(struct audio_object *object)
@@ -196,7 +195,7 @@ index bb9d5be..491189a 100644
  
  	XAUDIO2_VOICE_STATE state = { 0 };
  	self->source->GetState(&state);
-@@ -199,10 +204,13 @@ create_xaudio2_object(const char *device,
+@@ -199,15 +204,20 @@ create_xaudio2_object(const char *device,
                        const char *application_name,
                        const char *description)
  {
@@ -212,3 +211,10 @@ index bb9d5be..491189a 100644
  	if (FAILED(hr) || audio == NULL) {
  		if (audio != NULL)
  			audio->Release();
+ 
+-		CoUninitialize();
++		if (coinit_hr != (HRESULT)0x80010106) {
++			CoUninitialize();
++		}
+ 		return NULL;
+ 	}

--- a/mingw-w64-pcaudiolib/PKGBUILD
+++ b/mingw-w64-pcaudiolib/PKGBUILD
@@ -1,4 +1,4 @@
-# Maintainer: Michael Rans <rans@email.com>
+# Maintainer: Mike Rans <rans@email.com>
 
 _realname=pcaudiolib
 pkgbase=mingw-w64-${_realname}

--- a/mingw-w64-pcaudiolib/PKGBUILD
+++ b/mingw-w64-pcaudiolib/PKGBUILD
@@ -1,4 +1,4 @@
-# Maintainer: Mike Rans <rans@email.com>
+# Maintainer: Michael Rans <rans@email.com>
 
 _realname=pcaudiolib
 pkgbase=mingw-w64-${_realname}
@@ -17,7 +17,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 source=("https://github.com/espeak-ng/pcaudiolib/releases/download/${pkgver}/pcaudiolib-${pkgver}.tar.gz"
         "001-fix-build-on-mingw.patch")
 sha256sums=('e8bd15f460ea171ccd0769ea432e188532a7fb27fa73ec2d526088a082abaaad'
-            'eb4a76ffd3ffd2d409aee1abf25bcb05f28cb8ba04da91ef71bdb2ae0559a9f1')
+            '43d8ce85ceaf6c2859feab0b66337fc414470d6a267d7862fe0327f7c4bc6eef')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}


### PR DESCRIPTION
XAudio2 requires Multi Threaded Apartment to work reliably. If it was pre-initialized as Single Threaded Apartment, an error code is returned RPC_E_CHANGED_MODE (0x80010106), but this can be safely ignored.