### PR TITLE
Add human-theme-gtk

### DIFF
--- a/mingw-w64-human-theme-gtk/PKGBUILD
+++ b/mingw-w64-human-theme-gtk/PKGBUILD
@@ -1,0 +1,39 @@
+# Maintainer: Fabrice Creuzot (luigifab) <code~luigifab~fr>
+
+_realname=human-theme-gtk
+pkgbase=mingw-w64-$_realname
+pkgname=${MINGW_PACKAGE_PREFIX}-$_realname
+pkgver=3.1.0
+pkgrel=1
+pkgdesc='Human theme for GTK (mingw-w64)'
+arch=('any')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/luigifab/human-theme'
+msys2_repository_url='https://github.com/luigifab/human-theme'
+license=('spdx:GPL-3.0-or-later' 'spdx:LGPL-2.1-or-later' 'spdx:CC-BY-SA-3.0-or-later')
+makedepends=("${MINGW_PACKAGE_PREFIX}-7zip" "${MINGW_PACKAGE_PREFIX}-python")
+source=("https://github.com/luigifab/human-theme/archive/v${pkgver}/human-theme-${pkgver}.tar.gz")
+noextract=("human-theme-$pkgver.tar.gz")
+sha256sums=('1a0695960316f35b05ea854acf90607b3034f8b800d9534b3aee6840b6a83ed9')
+
+prepare() {
+  7z x -bso0 -bsp0 "human-theme-$pkgver.tar.gz"
+  7z x -bso0 -bsp0 -snld20 -ttar "human-theme-$pkgver.tar"
+  rm "human-theme-$pkgver.tar"
+  python "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/replace-symlinks.py "human-theme-${pkgver}"
+  mv "human-theme-${pkgver}" "$pkgname-$pkgver"
+}
+
+package() {
+  cd "$pkgname-$pkgver"
+
+  # the entire source code is GPL-3.0-or-later, except */metacity-1/* which is LGPL-2.1-or-later,
+  # and */gtk-2.0/* which is CC-BY-SA-3.0-or-later
+  install -dm 755 "$pkgdir/${MINGW_PREFIX}/share/themes/"
+  cp -a src/Human/         "$pkgdir/${MINGW_PREFIX}/share/themes/"
+  cp -a src/Human-blue/    "$pkgdir/${MINGW_PREFIX}/share/themes/"
+  cp -a src/Human-green/   "$pkgdir/${MINGW_PREFIX}/share/themes/"
+  cp -a src/Human-orange/  "$pkgdir/${MINGW_PREFIX}/share/themes/"
+
+  install -Dpm 644 LICENSE "$pkgdir/${MINGW_PREFIX}/share/licenses/$_realname/LICENSE"
+}


### PR DESCRIPTION
The PKGBUILD is based on [mingw-w64-breeze](https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-breeze/PKGBUILD) and [mingw-w64-awf](https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-awf/PKGBUILD).

It looks good for me!
And normally it is displayed in awf-gtk.