### PR TITLE
python-pytorch: fix missing import libraries

### DIFF
--- a/mingw-w64-python-pytorch/0003-pytorch-mingw-port.patch
+++ b/mingw-w64-python-pytorch/0003-pytorch-mingw-port.patch
@@ -650,3 +650,11 @@
              extra_compile_args += ["/Z7"]
              extra_link_args += ["/DEBUG:FULL"]
          else:
+@@ -1792,6 +1794,7 @@
+             "lib/*.dylib*",
+             "lib/*.dll",
+             "lib/*.lib",
++            "lib/*.dll.a",
+         ]
+         # XXX: Why not use wildcards ["lib/aotriton.images/*", "lib/aotriton.images/**/*"] here?
+         aotriton_image_path = TORCH_DIR / "lib" / "aotriton.images"

--- a/mingw-w64-python-pytorch/PKGBUILD
+++ b/mingw-w64-python-pytorch/PKGBUILD
@@ -62,7 +62,7 @@ source=("https://github.com/pytorch/pytorch/releases/download/v${pkgver}/pytorch
 sha256sums=('7cc1deb309f402ad67e9f45bbe311a40def4db19d66fddb9b01950f9bfc5ccb1'
             'ee509420cada0283dc0a5ad2a6c0128e9482e253f98666329d87526a1b4db150'
             '80ea46b21ddf7fc841222a2e4753206d192a025242e33c17163dfced27b8468c'
-            '804f16de9d9b157604eb1d613fd136b998ac6edd6da4bd1cb0541188189cf367'
+            'd61948f4b0dbffc962e919dad264d98074d20c6925c4fe91775ad176f238c79a'
             'ab4972112b3f3791d113a884ece1ddd1f81a63ac6970df044d0867aa75df2eb4'
             'a4be93a18407e794cce2b1185476f7d31db42fb3a974a2c3b66f7bfe2f6365d3'
             'a09716dee7ed8a532c33208291bc4c71885a1b48f4ce075628ccd2993bf4d7b3')


### PR DESCRIPTION
I tried using PyTorch in CMake, but got an error:
```
CMake Error at D:/msys64/ucrt64/lib/python3.14/site-packages/torch/share/cmake/Caffe2/Caffe2Targets.cmake:124 (message):
  The imported target "c10" references the file

     "D:/msys64/ucrt64/lib/python3.14/site-packages/torch/lib/libc10.dll.a"

  but this file does not exist.  Possible reasons include:

  * The file was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and contained

     "D:/msys64/ucrt64/lib/python3.14/site-packages/torch/share/cmake/Caffe2/Caffe2Targets.cmake"

  but not all the files it references.

Call Stack (most recent call first):
  D:/msys64/ucrt64/lib/python3.14/site-packages/torch/share/cmake/Caffe2/Caffe2Config.cmake:121 (include)
  D:/msys64/ucrt64/lib/python3.14/site-packages/torch/share/cmake/Torch/TorchConfig.cmake:62 (find_package)
  CMakeLists.txt:6 (find_package)
```
I did not find these files in the installation package. To solve this problem, we should copy these library files into the package.