### PR TITLE
sfcgal: Update to 2.3.0

### DIFF
--- a/mingw-w64-sfcgal/PKGBUILD
+++ b/mingw-w64-sfcgal/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=sfcgal
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.2.0
-pkgrel=3
+pkgver=2.3.0
+pkgrel=1
 pkgdesc="Wrapper around CGAL that intents to implement 2D and 3D operations on OGC standards models (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -16,14 +16,16 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-boost"
              "${MINGW_PACKAGE_PREFIX}-cgal"
-             "${MINGW_PACKAGE_PREFIX}-pkgconf")
+             "${MINGW_PACKAGE_PREFIX}-pkgconf"
+             "${MINGW_PACKAGE_PREFIX}-nlohmann-json"
+             "${MINGW_PACKAGE_PREFIX}-eigen3")
 depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
          "${MINGW_PACKAGE_PREFIX}-boost-libs"
          "${MINGW_PACKAGE_PREFIX}-gmp"
          "${MINGW_PACKAGE_PREFIX}-mpfr"
          "${MINGW_PACKAGE_PREFIX}-cgal")
 source=(https://gitlab.com/SFCGAL/SFCGAL/-/archive/v${pkgver}/SFCGAL-v${pkgver}.tar.gz)
-sha256sums=('bb6bb77ddb58523d8c229764de23699f99c1a7011d873419afd2a67df85602a2')
+sha256sums=('5f6aa1838e5ae31523ebf410cde0240b7a88d7e062b7ffff945e4fae2aaba0fa')
 
 build() {
   mkdir "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
@@ -39,6 +41,7 @@ build() {
   ${MINGW_PREFIX}/bin/cmake -Wno-dev \
       -G"Ninja" \
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      -DSFCGAL_WITH_EIGEN=ON \
       ${_extra_config[@]} \
       ../SFCGAL-v${pkgver}
 


### PR DESCRIPTION
SFCGAL 2.3 has two new dependencies: eigen3 and nlohmann-json.

cc @lbartoletti 