### PR TITLE
[new package] wasi-compiler-rt 22.1.7

### DIFF
--- a/mingw-w64-wasi-compiler-rt/PKGBUILD
+++ b/mingw-w64-wasi-compiler-rt/PKGBUILD
@@ -1,0 +1,120 @@
+# Maintainer: Maksim Bondarenkov <maksapple2306@gmail.com>
+
+_realname=wasi-compiler-rt
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=22.1.7
+pkgrel=1
+pkgdesc="Compiler runtime libraries for clang (WASI) (mingw-w64)"
+arch=('any')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
+url="https://compiler-rt.llvm.org/"
+license=('Apache-2.0 WITH LLVM-exception')
+depends=("${MINGW_PACKAGE_PREFIX}-wasi-libc")
+makedepends=("${MINGW_PACKAGE_PREFIX}-llvm"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-python"
+             "${MINGW_PACKAGE_PREFIX}-clang"
+             "${MINGW_PACKAGE_PREFIX}-lld")
+options=('!buildflags' '!strip')
+_source_base="https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkgver}"
+source=("${_source_base}/llvm-project-${pkgver}.src.tar.xz"{,.sig})
+sha256sums=('5cc4a3f12bba50b6bdfb4b61bdc852117a0ff2517807c3902fc13267fb93562e'
+            'SKIP')
+validpgpkeys=('474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard <tstellar@redhat.com>
+              'D574BD5D1D0E98895E3BF90044F2485E45D59042'  # Tobias Hieta <tobias@hieta.se>
+              'FFB3368980F3E6BB5737145A316C56D064CACBA5'  # Douglas Yung <douglas.yung@sony.com>
+              '71046D1E9C6656BDD61171873E83BABF4A4F9E85'  # Cullen Rhodes <cullen.rhodes@arm.com>
+)
+noextract=("llvm-project-${pkgver}.src.tar.xz")
+
+prepare() {
+  plain "Extracting llvm-project-${pkgver}.src.tar.xz due to symlink(s) without pre-existing target(s)"
+  ${MINGW_PREFIX}/bin/bsdtar -xJf "${srcdir}"/llvm-project-${pkgver}.src.tar.xz -C "${srcdir}" || true
+
+  cd "llvm-project-${pkgver}.src/cmake"
+  # Platform files have been copied from
+  # https://github.com/WebAssembly/wasi-sdk/tree/main/cmake/Platform
+  mkdir Platform
+  echo 'set(WASI 1)' > Platform/WASI.cmake
+}
+
+build() {
+  local _resource_dir
+  _resource_dir="$(cygpath -u "$(clang --print-resource-dir)")"
+
+  # Build options are derived from
+  # https://github.com/WebAssembly/wasi-sdk/blob/main/cmake/wasi-sdk-sysroot.cmake
+  local cmake_args=(
+    -G Ninja
+    -DCMAKE_AR="${MINGW_PREFIX}/bin/llvm-ar.exe"
+    -DCMAKE_ASM_COMPILER="${MINGW_PREFIX}/bin/clang.exe"
+    -DCMAKE_BUILD_TYPE=Release
+    -DCMAKE_CXX_COMPILER="${MINGW_PREFIX}/bin/clang++.exe"
+    -DCMAKE_CXX_COMPILER_WORKS=ON
+    -DCMAKE_CXX_FLAGS=-fno-exceptions
+    -DCMAKE_CXX_LINKER_DEPFILE_SUPPORTED=OFF
+    -DCMAKE_C_COMPILER="${MINGW_PREFIX}/bin/clang.exe"
+    -DCMAKE_C_COMPILER_WORKS=ON
+    -DCMAKE_C_FLAGS=-fno-exceptions
+    -DCMAKE_C_LINKER_DEPFILE_SUPPORTED=OFF
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}"
+    -DCMAKE_RANLIB="${MINGW_PREFIX}/bin/llvm-ranlib.exe"
+    -DCMAKE_SYSROOT="${MINGW_PREFIX}/share/wasi-sysroot"
+    -DCMAKE_SYSTEM_NAME=WASI
+    -DCMAKE_SYSTEM_PROCESSOR=wasm32
+    -DCMAKE_SYSTEM_VERSION=1
+    -DCOMPILER_RT_BAREMETAL_BUILD=ON
+    -DCOMPILER_RT_BUILD_CTX_PROFILE=OFF
+    -DCOMPILER_RT_BUILD_GWP_ASAN=OFF
+    -DCOMPILER_RT_BUILD_LIBFUZZER=OFF
+    -DCOMPILER_RT_BUILD_MEMPROF=OFF
+    -DCOMPILER_RT_BUILD_ORC=OFF
+    -DCOMPILER_RT_BUILD_PROFILE=OFF
+    -DCOMPILER_RT_BUILD_SANITIZERS=OFF
+    -DCOMPILER_RT_BUILD_XRAY=OFF
+    -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON
+    -DCOMPILER_RT_HAS_FPIC_FLAG=OFF
+    -DCOMPILER_RT_INCLUDE_TESTS=OFF
+    -DCOMPILER_RT_INSTALL_PATH="${_resource_dir}"
+    -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON
+  )
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DCOMPILER_RT_INSTALL_PATH=" \
+    cmake \
+      -B "build-${MSYSTEM}-wasip1" \
+      -S "llvm-project-${pkgver}.src/compiler-rt" \
+      "${cmake_args[@]}" \
+      -DCMAKE_{ASM,CXX,C}_COMPILER_TARGET=wasm32-wasip1
+  cmake --build "build-${MSYSTEM}-wasip1"
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DCOMPILER_RT_INSTALL_PATH=" \
+    cmake \
+      -B "build-${MSYSTEM}-wasip1-threads" \
+      -S "llvm-project-${pkgver}.src/compiler-rt" \
+      "${cmake_args[@]}" \
+      -DCMAKE_{ASM,CXX,C}_COMPILER_TARGET=wasm32-wasip1-threads
+  cmake --build "build-${MSYSTEM}-wasip1-threads"
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DCOMPILER_RT_INSTALL_PATH=" \
+    cmake \
+      -B "build-${MSYSTEM}-wasip2" \
+      -S "llvm-project-${pkgver}.src/compiler-rt" "${cmake_args[@]}" \
+      -DCMAKE_{ASM,CXX,C}_COMPILER_TARGET=wasm32-wasip2
+  cmake --build "build-${MSYSTEM}-wasip2"
+}
+
+package() {
+  DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}-wasip1"
+  DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}-wasip1-threads"
+  DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}-wasip2"
+
+  local _resource_dir
+  _resource_dir="$(cygpath -u "$(clang --print-resource-dir)")"
+
+  mkdir "${pkgdir}/${_resource_dir}/lib/wasm32-unknown-wasi" && cd "${pkgdir}/${_resource_dir}/lib/wasm32-unknown-wasi"
+  ln -f ../wasm32-unknown-wasip1/libclang_rt.builtins.a libclang_rt.builtins.a
+
+  install -Dm644 "${srcdir}/llvm-project-${pkgver}.src/compiler-rt/LICENSE.TXT" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
missing thing from wasi-sdk. after pushing that wasi-libc should be rebuild with `-DBUILTINS_LIB=` (yeah there will be a cycle)