### PR TITLE
wasi-libc: rebuild with our compiler rt

### DIFF
--- a/mingw-w64-wasi-libc/PKGBUILD
+++ b/mingw-w64-wasi-libc/PKGBUILD
@@ -64,7 +64,6 @@ build() {
     -DCMAKE_SYSTEM_VERSION=1
     -DCMAKE_C_FLAGS="-fno-exceptions"
     -DCMAKE_ASM_FLAGS="-fno-exceptions"
-    -DBUILTINS_LIB="${_resource_dir}/lib/${target/wasm32/wasm32-unknown}/libclang_rt.builtins.a"
   )
   if check_option "debug" "n"; then
     cmake_options+=("-DCMAKE_BUILD_TYPE=Release")
@@ -75,7 +74,7 @@ build() {
   local target
   for target in "${_targets[@]}"; do
     MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DCMAKE_SYSROOT=" \
-      cmake "${cmake_options[@]}" -B build-${MSYSTEM}-${target} -DTARGET_TRIPLE="${target}"
+      cmake "${cmake_options[@]}" -B build-${MSYSTEM}-${target} -DTARGET_TRIPLE="${target}" -DBUILTINS_LIB="${_resource_dir}/lib/${target/wasm32/wasm32-unknown}/libclang_rt.builtins.a"
     cmake --build build-${MSYSTEM}-${target}
   done
 }

--- a/mingw-w64-wasi-libc/PKGBUILD
+++ b/mingw-w64-wasi-libc/PKGBUILD
@@ -1,9 +1,11 @@
+# Maintainer: Maksim Bondarenkov <maksapple2306@gmail.com>
+
 _realname=wasi-libc
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0+571+2fc32bc8
-_commit=2fc32bc81b9f07f8d9525edea59bfbaf760c06d6 # tags/wasi-sdk-31
-pkgrel=1
+_commit=2fc32bc81b9f07f8d9525edea59bfbaf760c06d6 # tags/wasi-sdk-32
+pkgrel=2
 epoch=1
 pkgdesc="WASI libc implementation for WebAssembly (mingw-w64)"
 arch=('any')
@@ -17,6 +19,7 @@ license=('spdx:Apache-2.0 WITH LLVM-exception AND Apache-2.0 AND MIT')
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-clang"
   "${MINGW_PACKAGE_PREFIX}-llvm"
+  "${MINGW_PACKAGE_PREFIX}-wasi-compiler-rt"
   "${MINGW_PACKAGE_PREFIX}-wasm-component-ld"
   "${MINGW_PACKAGE_PREFIX}-wasm-pkg-tools"
   "${MINGW_PACKAGE_PREFIX}-wasm-tools"
@@ -38,6 +41,8 @@ pkgver() {
 }
 
 build() {
+  # build options are derived from
+  # https://github.com/WebAssembly/wasi-sdk/blob/main/cmake/wasi-sdk-sysroot.cmake
   local cmake_options=(
     -Wno-dev
     -S ${_realname}
@@ -46,16 +51,20 @@ build() {
     -DBUILD_SHARED=OFF
     -DCMAKE_C_COMPILER="${MINGW_PREFIX}/bin/clang.exe"
     -DCMAKE_C_COMPILER_WORKS=ON
+    -DCMAKE_CXX_COMPILER="${MINGW_PREFIX}/bin/clang++.exe"
+    -DCMAKE_CXX_COMPILER_WORKS=ON
     -DCMAKE_AR="${MINGW_PREFIX}/bin/llvm-ar.exe"
     -DCMAKE_NM="${MINGW_PREFIX}/bin/llvm-nm.exe"
     -DCMAKE_RANLIB="${MINGW_PREFIX}/bin/llvm-ranlib.exe"
     -DCMAKE_C_LINKER_DEPFILE_SUPPORTED=OFF
+    -DCMAKE_CXX_LINKER_DEPFILE_SUPPORTED=OFF
     -DCMAKE_SYSROOT="${MINGW_PREFIX}/share/wasi-sysroot"
     -DCMAKE_SYSTEM_NAME=WASI
     -DCMAKE_SYSTEM_PROCESSOR=wasm32
     -DCMAKE_SYSTEM_VERSION=1
-    -DCMAKE_C_FLAGS="-Wno-deprecated -fno-exceptions"
-    -DCMAKE_ASM_FLAGS="-Wno-deprecated -fno-exceptions"
+    -DCMAKE_C_FLAGS="-fno-exceptions"
+    -DCMAKE_ASM_FLAGS="-fno-exceptions"
+    -DBUILTINS_LIB="${_resource_dir}/lib/${target/wasm32/wasm32-unknown}/libclang_rt.builtins.a"
   )
   if check_option "debug" "n"; then
     cmake_options+=("-DCMAKE_BUILD_TYPE=Release")


### PR DESCRIPTION
introduces cycle, which is probably should be resolved as wasi-compiler-rt -> wasi-libc