### PR TITLE
python-fido2: use the correct build backend

### DIFF
--- a/mingw-w64-python-fido2/PKGBUILD
+++ b/mingw-w64-python-fido2/PKGBUILD
@@ -4,7 +4,7 @@ _realname=fido2
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=2.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc="For communicating with a FIDO device over USB as well as verifying attestation and assertion signatures (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -22,20 +22,14 @@ depends=("${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-libfido2")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
-             "${MINGW_PACKAGE_PREFIX}-python-wheel"
-             "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python-poetry-core"
              "${MINGW_PACKAGE_PREFIX}-libfido2")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
 sha256sums=('0d8122e690096ad82afde42ac9d6433a4eeffda64084f36341ea02546b181dd1')
 
 prepare() {
   cd "${_realname}-${pkgver}"
-  sed -i \
-    -e 's|requires = \["poetry-core"\]|requires = ["setuptools","wheel"]|' \
-    -e 's|build-backend = "poetry.core.masonry.api"|build-backend = "setuptools.build_meta"|' \
-    -e 's|, *email *= *"[^"]*"||g' \
-    -e '/^readme *=/d' \
-    pyproject.toml
+
 }
 
 build() {


### PR DESCRIPTION
for some reason it was falling back to setuptools