### PR TITLE
git-lfs: remove unzip from makedepends

### DIFF
--- a/mingw-w64-git-lfs/PKGBUILD
+++ b/mingw-w64-git-lfs/PKGBUILD
@@ -18,8 +18,7 @@ msys2_references=(
 )
 license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-git")
-makedepends=("unzip"
-             "${MINGW_PACKAGE_PREFIX}-go"
+makedepends=("${MINGW_PACKAGE_PREFIX}-go"
              #"${MINGW_PACKAGE_PREFIX}-ruby"
              )
 options=('!strip')


### PR DESCRIPTION
I don't think it is used.