### PR TITLE
sfml: remove unzip from makedepends

### DIFF
--- a/mingw-w64-sfml/PKGBUILD
+++ b/mingw-w64-sfml/PKGBUILD
@@ -26,8 +26,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-flac"
          "${MINGW_PACKAGE_PREFIX}-openal")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-ninja"
-             "unzip")
+             "${MINGW_PACKAGE_PREFIX}-ninja")
 source=("https://github.com/SFML/SFML/archive/${pkgver}/SFML-${pkgver}.tar.gz"
         mingw-w64-msys2.patch
         fix-pkgconfig-generation.patch)


### PR DESCRIPTION
not seen on Arch