### PR TITLE
mcfgthread: Upgrade to 2.4.1

### DIFF
--- a/mingw-w64-mcfgthread/PKGBUILD
+++ b/mingw-w64-mcfgthread/PKGBUILD
@@ -4,7 +4,7 @@ _realname=mcfgthread
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}"-libs)
-pkgver=2.3.2
+pkgver=2.4.1
 pkgrel=1
 pkgdesc="An efficient gthread implementation, providing C++11 threading support (mingw-w64)"
 arch=('any')
@@ -21,7 +21,7 @@ makedepends=(
   "git"
 )
 source=("git+https://github.com/lhmouse/mcfgthread.git#tag=v${pkgver%.*}-ga.${pkgver##*.}")
-sha256sums=('c9b749e561651f9c4b8c73b93c3acbf955d547404fee858da265afa2ca54c2a3')
+sha256sums=('127254a357b3e64e58baf26e275644b1a0567d568eda18e85875d93c1f662218')
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
@@ -36,9 +36,6 @@ build() {
     ../${_realname}
 
   meson compile
-
-  rm -rf "${srcdir}${MINGW_PREFIX}"
-  DESTDIR="${srcdir}" meson install
 }
 
 check() {
@@ -50,19 +47,15 @@ package_mcfgthread() {
   pkgdesc+=" (devel)"
   depends=("${MINGW_PACKAGE_PREFIX}-${_realname}-libs=${pkgver}")
 
-  mkdir -p "${pkgdir}${MINGW_PREFIX}"
-  cd "${srcdir}${MINGW_PREFIX}"
-  cp --parents -r include -t "${pkgdir}${MINGW_PREFIX}"
-  cp --parents -r lib -t "${pkgdir}${MINGW_PREFIX}"
+  cd "${srcdir}/build-${MSYSTEM}"
+  DESTDIR="${pkgdir}" meson install --tags devel
 }
 
 package_mcfgthread-libs() {
   pkgdesc+=" (libs)"
 
-  mkdir -p "${pkgdir}${MINGW_PREFIX}"
-  cd "${srcdir}${MINGW_PREFIX}"
-  cp --parents -r bin/libmcfgthread-${pkgver%%.*}.dll -t "${pkgdir}${MINGW_PREFIX}"
-  cp --parents -r bin/libmcfgthread-minimal-${pkgver%%.*}.dll -t "${pkgdir}${MINGW_PREFIX}"
+  cd "${srcdir}/build-${MSYSTEM}"
+  DESTDIR="${pkgdir}" meson install --tags runtime
 }
 
 # template start; name=mingw-w64-splitpkg-wrappers; version=1.0;


### PR DESCRIPTION
https://github.com/lhmouse/mcfgthread/releases/tag/v2.4-ga.1

Instead of installing DLLs, headers & libs explicitly, this now uses `meson install --tags`.
