### PR TITLE
octave: remove unzip from checkdepends

### DIFF
--- a/mingw-w64-octave/PKGBUILD
+++ b/mingw-w64-octave/PKGBUILD
@@ -50,7 +50,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-fltk"
              "${MINGW_PACKAGE_PREFIX}-portaudio"
              "${MINGW_PACKAGE_PREFIX}-rapidjson")
-checkdepends=("unzip"
+checkdepends=("${MINGW_PACKAGE_PREFIX}-libarchive" # unzip
               "zip")
 optdepends=("unzip: for decompressing .zip archives"
             "zip: for compressing .zip archives"
@@ -134,7 +134,8 @@ build() {
 
 check() {
   cd "${srcdir}"/build-${MSYSTEM}
-  make check || true
+  install -Dm755 "$(command -v bsdunzip)" "${srcdir}/bin/unzip"
+  PATH="${srcdir}/bin:$PATH" make check || :
 }
 
 package() {


### PR DESCRIPTION
This is optdepends too. So this might not help removing `unzip` from repo...