### PR TITLE
pkgconf: backport fix for prefix relocation edge case

### DIFF
--- a/mingw-w64-pkgconf/PKGBUILD
+++ b/mingw-w64-pkgconf/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 epoch=1
 pkgver=2.5.1
-pkgrel=1
+pkgrel=2
 pkgdesc='pkg-config compatible utility which does not depend on glib'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -21,11 +21,17 @@ conflicts=("${MINGW_PACKAGE_PREFIX}-pkg-config")
 replaces=("${MINGW_PACKAGE_PREFIX}-pkg-config")
 makedepends=("${MINGW_PACKAGE_PREFIX}-meson" "${MINGW_PACKAGE_PREFIX}-cc")
 groups=("${MINGW_PACKAGE_PREFIX}-toolchain")
-source=("https://github.com/pkgconf/pkgconf/archive/pkgconf-$pkgver/$_realname-$pkgver.tar.gz")
-sha256sums=('79721badcad1987dead9c3609eb4877ab9b58821c06bdacb824f2c8897c11f2a')
+source=("https://github.com/pkgconf/pkgconf/archive/pkgconf-$pkgver/$_realname-$pkgver.tar.gz"
+        "pkgconf-issue-535-minimal-backport.patch")
+sha256sums=('79721badcad1987dead9c3609eb4877ab9b58821c06bdacb824f2c8897c11f2a'
+            '77d01b1ed6a1d7d16a6ac45567fb8534ac27657766acad138c259d72c84b6b22')
 
 prepare() {
   mv "${_realname}-${_realname}-${pkgver}" "${_realname}-${pkgver}"
+
+  cd "${_realname}-${pkgver}"
+  # https://github.com/pkgconf/pkgconf/issues/535
+  patch -p1 -i "${srcdir}"/pkgconf-issue-535-minimal-backport.patch
 }
 
 build() {

--- a/mingw-w64-pkgconf/pkgconf-issue-535-minimal-backport.patch
+++ b/mingw-w64-pkgconf/pkgconf-issue-535-minimal-backport.patch
@@ -1,0 +1,65 @@
+diff --git a/libpkgconf/pkg.c b/libpkgconf/pkg.c
+index 491c0de..c80269b 100644
+--- a/libpkgconf/pkg.c
++++ b/libpkgconf/pkg.c
+@@ -65,6 +65,20 @@ str_has_suffix(const char *str, const char *suffix)
+	return !strncasecmp(str + str_len - suf_len, suffix, suf_len);
+ }
+ 
++static inline char *
++path_sep_rchr(char *buf)
++{
++	char *pathbuf = strrchr(buf, PKG_DIR_SEP_S);
++#ifdef _WIN32
++	char *altpathbuf = strrchr(buf, '/');
++
++	if (altpathbuf != NULL && (pathbuf == NULL || altpathbuf > pathbuf))
++		pathbuf = altpathbuf;
++#endif
++
++	return pathbuf;
++}
++
+ static char *
+ pkg_get_parent_dir(pkgconf_pkg_t *pkg)
+ {
+@@ -130,9 +144,7 @@ pkg_get_parent_dir(pkgconf_pkg_t *pkg)
+	}
+ #endif
+ 
+-	pathbuf = strrchr(buf, PKG_DIR_SEP_S);
+-	if (pathbuf == NULL)
+-		pathbuf = strrchr(buf, '/');
++	pathbuf = path_sep_rchr(buf);
+	if (pathbuf != NULL)
+		pathbuf[0] = '\0';
+ 
+@@ -283,15 +295,11 @@ determine_prefix(const pkgconf_pkg_t *pkg, char *buf, size_t buflen)
+	pkgconf_strlcpy(buf, pkg->filename, buflen);
+	pkgconf_path_relocate(buf, buflen);
+ 
+-	pathiter = strrchr(buf, PKG_DIR_SEP_S);
+-	if (pathiter == NULL)
+-		pathiter = strrchr(buf, '/');
++	pathiter = path_sep_rchr(buf);
+	if (pathiter != NULL)
+		pathiter[0] = '\0';
+ 
+-	pathiter = strrchr(buf, PKG_DIR_SEP_S);
+-	if (pathiter == NULL)
+-		pathiter = strrchr(buf, '/');
++	pathiter = path_sep_rchr(buf);
+	if (pathiter == NULL)
+		return NULL;
+ 
+@@ -301,9 +309,7 @@ determine_prefix(const pkgconf_pkg_t *pkg, char *buf, size_t buflen)
+ 
+	/* okay, work backwards and do it again. */
+	pathiter[0] = '\0';
+-	pathiter = strrchr(buf, PKG_DIR_SEP_S);
+-	if (pathiter == NULL)
+-		pathiter = strrchr(buf, '/');
++	pathiter = path_sep_rchr(buf);
+	if (pathiter == NULL)
+		return NULL;
+ 


### PR DESCRIPTION
This includes a minimal backport of the issue fixed in pkgconf master already.

Fixes #25061