### PR TITLE
python-sphinxcontrib-programoutput: update to 0.20 + adjust license info

### DIFF
--- a/mingw-w64-python-sphinxcontrib-programoutput/PKGBUILD
+++ b/mingw-w64-python-sphinxcontrib-programoutput/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=sphinxcontrib-programoutput
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=0.19
+pkgver=0.20
 pkgrel=1
 pkgdesc="Sphinx extension to insert the output of arbitrary commands into documents (mingw-w64)"
 arch=('any')
@@ -13,22 +13,22 @@ msys2_repository_url='https://github.com/OpenNTI/sphinxcontrib-programoutput'
 msys2_references=(
   'purl: pkg:pypi/sphinxcontrib-programoutput'
 )
-license=('spdx:BSD-3-Clause')
+license=('spdx:BSD-2-Clause')
 depends=("${MINGW_PACKAGE_PREFIX}-python-sphinx")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname/-/_}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('787ca068b7e1205ed492ea20a23a8e599c3b4edb8c43bacf564e5ec7c30c7dad')
+sha256sums=('5c4282c1c7fc9b5a23febe16ae038b6392d7ce068d186ad4870ba22e74db0711')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
 
-  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
+  python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 package() {
-  cd "${srcdir}/python-build-${MSYSTEM}"
+  cd "python-build-${MSYSTEM}"
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
     ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
@@ -36,4 +36,3 @@ package() {
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
 }
-


### PR DESCRIPTION
License has been clarified by upstream, it's BSD-2-Clause.