### PR TITLE
gumbo-parser: update to 0.13.2

### DIFF
--- a/mingw-w64-gumbo-parser/PKGBUILD
+++ b/mingw-w64-gumbo-parser/PKGBUILD
@@ -3,7 +3,7 @@
 _realname='gumbo-parser'
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.13.1
+pkgver=0.13.2
 pkgrel=1
 pkgdesc='HTML5 parsing library in pure C99 (mingw-w64)'
 arch=('any')
@@ -14,7 +14,7 @@ license=('spdx:Apache-2.0')
 checkdepends=("${MINGW_PACKAGE_PREFIX}-gtest")
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools" "${MINGW_PACKAGE_PREFIX}-cc")
 source=("${url}archive/${pkgver}.tar.gz")
-sha256sums=('1a054d1e53d556641a6666537247411a77b0c18ef6ad5df23e30d2131676ef81')
+sha256sums=('dbdc159dc8e5c6f3f254e50bce689dd9e439064ff06c165d5653410a5714ab66')
 
 prepare() {
   cd "${_realname}"


### PR DESCRIPTION
**Edit:** Needs rebuild of qt-creator: https://github.com/msys2/MINGW-packages/actions/runs/27660278159/job/81804165325?pr=30034#step:3:256

**2nd Edit:** Rebuild of Qt Creator fails with litehtml 0.10. Looks like some types have been renamed/removed/moved to different headers: https://github.com/msys2/MINGW-packages/actions/runs/27661247040/job/81805901453?pr=30034 That would need to be patched, so scratch that and only update gumbo-parser.