### PR TITLE
[New package] asiosdk

### DIFF
--- a/mingw-w64-asiosdk/PKGBUILD
+++ b/mingw-w64-asiosdk/PKGBUILD
@@ -1,4 +1,4 @@
-# Maintainer: Your Name <your.email@example.com>
+# Maintainer: EZ4Stephen
 
 _realname=asiosdk
 pkgbase=mingw-w64-${_realname}

--- a/mingw-w64-asiosdk/PKGBUILD
+++ b/mingw-w64-asiosdk/PKGBUILD
@@ -1,0 +1,22 @@
+# Maintainer: Your Name <your.email@example.com>
+
+_realname=asiosdk
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=2.3.4
+pkgrel=1
+pkgdesc="Steinberg's ASIO SDK - low latency audio API (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url="https://www.steinberg.net/developers/"
+license=('spdx:GPL-3.0-only')
+source=("https://download.steinberg.net/sdk_downloads/ASIO-SDK_${pkgver}_2025-10-15.zip")
+sha256sums=('d5ebf0c20dd2c5f43771fd0c1418f4b361bf52434ee670097cfa6b3a335e2eca')
+
+package() {
+  cd "${srcdir}/ASIOSDK"
+  install -Dm644 common/* -t "${pkgdir}${MINGW_PREFIX}/include/asiosdk/common/"
+  install -Dm644 host/*.h host/*.cpp -t "${pkgdir}${MINGW_PREFIX}/include/asiosdk/host/"
+  install -Dm644 host/pc/* -t "${pkgdir}${MINGW_PREFIX}/include/asiosdk/host/pc/"
+  install -Dm644 common/LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/${pkgname}/LICENSE"
+}

--- a/mingw-w64-portaudio/0004-update-cmake-minimum-version.patch
+++ b/mingw-w64-portaudio/0004-update-cmake-minimum-version.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,7 +5,7 @@
+ # http://www.portaudio.com/trac/wiki/TutorialDir/Compile/CMake
+ #
+ 
+-CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
++CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
+ 
+ # Check if the user is building PortAudio stand-alone or as part of a larger
+ # project.  If this is part of a larger project (i.e. the CMakeLists.txt has

--- a/mingw-w64-portaudio/PKGBUILD
+++ b/mingw-w64-portaudio/PKGBUILD
@@ -6,7 +6,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 epoch=1
 pkgver=19.7.0
 _tarver=190700_20210406
-pkgrel=4
+pkgrel=5
 pkgdesc="A free, cross-platform, open source, audio I/O library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -17,18 +17,21 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-pkgconf"
   "${MINGW_PACKAGE_PREFIX}-cmake"
   "${MINGW_PACKAGE_PREFIX}-ninja"
+  "${MINGW_PACKAGE_PREFIX}-asiosdk"
 )
 depends=("${MINGW_PACKAGE_PREFIX}-cc-libs")
 source=("http://files.portaudio.com/archives/pa_stable_v${_tarver}.tgz"
         0001-clang-fix.patch
         0002-cmake-add-cpp-binding.patch
         0003-pa_getversioninfo-fix.patch
+        0004-update-cmake-minimum-version.patch
         CMakeLists.txt
         portaudiocpp.pc.in)
 sha256sums=('47efbf42c77c19a05d22e627d42873e991ec0c1357219c0d74ce6a2948cb2def'
             '2c1ef1727d45f2140ef0a29ffa0553c7b9a1b59e1a223e8892a7792a860f2922'
             '22e485926fb875fba2a5c3011a1bbe5de99c1ef4560677105f767e66c8fb6324'
             '8f12f41692880c9dffb4f8147af2394df2bd0b2b762ae3fc09e1555eb27b9acb'
+            '5dcd128122442ada7740948f434cd3d023526534d172438ebbaeb024f36ab92e'
             '6af7c2c023483af698edd5063a0dce7cebb65eb40a256e6269ffd6ad32895dd4'
             'e48867fb8eb4ceda8e646879a03525b9bacbbaf154585c81478b06eef1c9d6a5')
 
@@ -41,6 +44,7 @@ prepare() {
   patch -p1 -i "${srcdir}/0001-clang-fix.patch"
   patch -p1 -i "${srcdir}/0002-cmake-add-cpp-binding.patch"
   patch -p1 -i "${srcdir}/0003-pa_getversioninfo-fix.patch"
+  patch -p1 -i "${srcdir}/0004-update-cmake-minimum-version.patch"
 }
 
 build() {
@@ -57,6 +61,7 @@ build() {
     ${MINGW_PREFIX}/bin/cmake \
       -GNinja \
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      -DASIOSDK_ROOT_DIR=${MINGW_PREFIX}/include/asiosdk \
       "${extra_config[@]}" \
       ../${_realname}
 


### PR DESCRIPTION
Adds steinberg's asiosdk under its open source license variant.
Also adds it as a dependency to portaudio.
Closes #30062 .