### PR TITLE
libmariadbclient: update to 3.4.9

### DIFF
--- a/mingw-w64-libmariadbclient/PKGBUILD
+++ b/mingw-w64-libmariadbclient/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=libmariadbclient
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.4.8
-pkgrel=3
+pkgver=3.4.9
+pkgrel=1
 pkgdesc="MariaDB client libraries (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -24,11 +24,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 depends=("${MINGW_PACKAGE_PREFIX}-curl"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-zstd")
-source=(https://mirror.rackspace.com/mariadb/connector-c-${pkgver}/mariadb-connector-c-${pkgver}-src.tar.gz{,.asc}
+source=(https://github.com/mariadb-corporation/mariadb-connector-c/archive/v${pkgver}/mariadb-connector-c-${pkgver}-src.tar.gz
         001-mingw-build.patch
         003-gcc-fix-use_VA_ARGS.patch)
-sha256sums=('156aed3b49f857d0ac74fb76f1982968bcbfd8382da3f5b6ae71f616729920d7'
-            'SKIP'
+sha256sums=('2c70b74393d589df0bde9b3e17cb7b571d30a45aaf006eda7a273120fb660f3a'
             '64ad2b8c85fb369c20c1941c896c2a7d5202a8b7259e9e31922c8d0bfcbfd198'
             'fc08055e5d63e310e2658b15f6e1f00b59f2aad2dec37560c01954fac6af4a6e')
 validpgpkeys=("177F4010FE56CA3336300305F1656F24C74CD1D8") #MariaDB Package Signing Key <package-signing-key@mariadb.org>
@@ -42,7 +41,7 @@ apply_patch_with_msg() {
 }
 
 prepare() {
-  cd "${srcdir}"/mariadb-connector-c-${pkgver}-src
+  cd "${srcdir}"/mariadb-connector-c-${pkgver}
   apply_patch_with_msg \
     001-mingw-build.patch \
     003-gcc-fix-use_VA_ARGS.patch
@@ -80,7 +79,7 @@ build() {
     -DCLIENT_PLUGIN_MYSQL_CLEAR_PASSWORD=STATIC \
     -DCLIENT_PLUGIN_MYSQL_OLD_PASSWORD=STATIC \
     -DCLIENT_PLUGIN_ZSTD=STATIC \
-    ../mariadb-connector-c-${pkgver}-src
+    ../mariadb-connector-c-${pkgver}
 
   ${MINGW_PREFIX}/bin/cmake.exe --build ./
 }
@@ -110,5 +109,5 @@ package() {
     sed -s "s|${_PRE_WIN}|${MINGW_PREFIX}|g" -i "${pcfile}"
   done
 
-  install -Dm644 "${srcdir}/mariadb-connector-c-${pkgver}-src/COPYING.LIB" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.LIB"
+  install -Dm644 "${srcdir}/mariadb-connector-c-${pkgver}/COPYING.LIB" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.LIB"
 }


### PR DESCRIPTION
This also changes the source from a mirror to the GitHub repository.