### PR TITLE
source-highlight: fix building with latest boost

### DIFF
--- a/mingw-w64-source-highlight/3.1.4-no-undefined.patch
+++ b/mingw-w64-source-highlight/3.1.4-no-undefined.patch
@@ -1,5 +1,5 @@
---- origsrc/source-highlight-3.1.4/lib/srchilite/Makefile.am	2010-06-14 09:41:58.000000000 -0500
-+++ src/source-highlight-3.1.4/lib/srchilite/Makefile.am	2010-09-07 00:33:53.901330300 -0500
+--- a/lib/srchilite/Makefile.am
++++ b/lib/srchilite/Makefile.am
 @@ -98,7 +98,7 @@ libsource_highlight_la_SOURCES = \
  libsource_highlight_la_LIBADD = $(top_builddir)/gl/libgnu.la \
  	@LTLIBOBJS@ $(BOOST_REGEX_LIB)

--- a/mingw-w64-source-highlight/PKGBUILD
+++ b/mingw-w64-source-highlight/PKGBUILD
@@ -4,39 +4,36 @@ _realname=source-highlight
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=3.1.9
-pkgrel=5
+pkgrel=6
 pkgdesc="Convert source code to syntax highlighted document (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://www.gnu.org/software/src-highlite/"
 msys2_repository_url='https://git.savannah.gnu.org/cgit/src-highlite'
-license=('GPL')
-depends=("bash" "${MINGW_PACKAGE_PREFIX}-boost")
-makedepends=("${MINGW_PACKAGE_PREFIX}-ctags"
-             "${MINGW_PACKAGE_PREFIX}-doxygen"
+license=('spdx:GPL-3.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-cc-libs")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools"
-             "${MINGW_PACKAGE_PREFIX}-graphviz"
-             "${MINGW_PACKAGE_PREFIX}-cc")
+             "${MINGW_PACKAGE_PREFIX}-boost"
+             "${MINGW_PACKAGE_PREFIX}-ctags"
+             "${MINGW_PACKAGE_PREFIX}-doxygen"
+             "${MINGW_PACKAGE_PREFIX}-graphviz")
 source=("https://ftp.gnu.org/gnu/src-highlite/${_realname}-${pkgver}.tar.gz"
         "source-highlight-gcc11.patch"
-        "3.1.4-no-undefined.patch")
+        "3.1.4-no-undefined.patch"
+        "boost-regex-header-only.patch"
+        "source-highlight-pc.patch")
 sha256sums=('3a7fd28378cb5416f8de2c9e77196ec915145d44e30ff4e0ee8beb3fe6211c91'
             '7dbbdb7a1363d650aee75337f1204761754d9ad82a7c873c3f8b3f0ba07e814d'
-            '971063177b338e9a037b755c9ade11f8a2d6ec44be576da24e0a73d33fe63fc7')
+            '512ca23a9b6113c78bda4efd2d1c28b58bf8362556cdc9b637bf846898f3f3fa'
+            'd9eb2c84e5acd7e72428c0b70df12c09dbdbeb732634ab427f145cde0500ec46'
+            '1c881ab92bc1665e915989e5c517ec7c4d5395900025e988b2ec9b37c4dbe737')
 
 apply_patch_with_msg() {
   for _patch in "$@"
   do
     msg2 "Applying $_patch"
     patch -Nbp1 -i "${srcdir}/$_patch"
-  done
-}
-
-apply_patch_p2_with_msg() {
-  for _patch in "$@"
-  do
-    msg2 "Applying $_patch"
-    patch -Nbp2 -i "${srcdir}/$_patch"
   done
 }
 
@@ -51,8 +48,10 @@ del_file_exists() {
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
-  apply_patch_with_msg source-highlight-gcc11.patch
-  apply_patch_p2_with_msg 3.1.4-no-undefined.patch
+  apply_patch_with_msg source-highlight-gcc11.patch \
+                       boost-regex-header-only.patch \
+					   source-highlight-pc.patch \
+                       3.1.4-no-undefined.patch
   autoreconf -fiv
 }
 
@@ -64,12 +63,9 @@ build() {
 
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
-    --build=${MINGW_CHOST} \
-    --host=${MINGW_CHOST} \
-    --target=${MINGW_CHOST} \
     --with-boost-libdir=${MINGW_PREFIX}/lib \
     --with-bash-completion=no \
-    --with-doxygen=on
+    --with-doxygen=yes
 # Fix source documentation so your packaging dirs don't appear
   sed "s|STRIP_FROM_PATH =*|STRIP_FROM_PATH = $(cygpath -m "${srcdir}")|g" \
      -i lib/srchilite/srchilite.doxyfile
@@ -79,6 +75,8 @@ build() {
 package() {
   cd "${srcdir}/build-${MSYSTEM}"
   make install DESTDIR="${pkgdir}"
+  install -Dm644 "${srcdir}"/${_realname}-${pkgver}/COPYING \
+    "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
   #Fix documentation to give a sensible path for source.
 #  local _src="$(cygpath -m "${srcdir}"/src)"
 }

--- a/mingw-w64-source-highlight/boost-regex-header-only.patch
+++ b/mingw-w64-source-highlight/boost-regex-header-only.patch
@@ -1,0 +1,37 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -104,7 +104,8 @@
+ 
+ dnl check for Boost regular expression library
+ AX_BOOST_BASE([1.33.1])
+-AX_BOOST_REGEX
++dnl Boost.Regex is header-only; just check header
++AC_CHECK_HEADER([boost/regex.hpp], [], [AC_MSG_ERROR([boost/regex.hpp not found])])
+ dnl AC_CHECK_HEADERS([boost/shared_ptr.hpp])
+ dnl it's no use searching for shared_ptr.hpp: it's already included in boost base
+ 
+@@ -289,24 +290,6 @@
+ 
+ AC_OUTPUT
+ 
+-if test "$ax_cv_boost_regex" = "yes"; then
+-  if test -z "$BOOST_REGEX_LIB"; then
+-    AC_MSG_ERROR([
+-
+-ERROR! Boost::regex library is installed, but you
+-must specify the suffix with --with-boost-regex at configure
+-for instance, --with-boost-regex=boost_regex-gcc-1_31])
+-  else
+-    echo ""
+-    echo "Good - your configure finished. Start make now"
+-    echo ""
+-  fi
+-else
+-  AC_MSG_ERROR([
+-
+-ERROR! Boost::regex library not installed.
+-Please install it (download at http://www.boost.org/)])
+-fi
+ 
+ echo "
+   These programs are NOT required, and

--- a/mingw-w64-source-highlight/source-highlight-pc.patch
+++ b/mingw-w64-source-highlight/source-highlight-pc.patch
@@ -1,0 +1,11 @@
+--- a/source-highlight.pc.in
++++ b/source-highlight.pc.in
+@@ -7,6 +7,6 @@
+ Description: GNU Source-highlight library.
+ URL: http://www.gnu.org/software/src-highlite/
+ Version: @VERSION@
+-Libs: -L${libdir} -lsource-highlight @BOOST_LDFLAGS@ @BOOST_REGEX_LIB@
+-Cflags: -I${includedir} @BOOST_CPPFLAGS@
++Libs: -L${libdir} -lsource-highlight 
++Cflags: -I${includedir} 
+ 


### PR DESCRIPTION
It didn't work and it didn't even build. So I fixed it. There is still the problem that the wrong path to the `datadir` is hardcoded, but someone else can fix it. It simply means that you have to run `source-highlight-settings` once and set it to something like `C:/msys64/ucrt64/share/source-highlight`.