### PR TITLE
tree-sitter-grammars: install library under bin/

### DIFF
--- a/mingw-w64-tree-sitter-c/PKGBUILD
+++ b/mingw-w64-tree-sitter-c/PKGBUILD
@@ -4,7 +4,7 @@ _realname=tree-sitter-c
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.24.2
-pkgrel=1
+pkgrel=2
 pkgdesc='C grammar for tree-sitter (mingw-w64)'
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -35,8 +35,6 @@ build() {
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       -Wno-dev \
       -DCMAKE_BUILD_TYPE=None \
-      -DCMAKE_SHARED_LIBRARY_SUFFIX_C=.so \
-      -DCMAKE_INSTALL_BINDIR=lib \
       -S "${_realname}-${pkgver}" \
       -B "build-${MSYSTEM}"
 
@@ -48,7 +46,7 @@ package() {
 
   # To add library to neovim runtime path
   mkdir -p "${pkgdir}${MINGW_PREFIX}/lib/nvim/parser"
-  cp "${pkgdir}${MINGW_PREFIX}/lib/lib${_realname}.so" "${pkgdir}${MINGW_PREFIX}/lib/nvim/parser/${_realname#tree-sitter-}.so"
+  ln "${pkgdir}${MINGW_PREFIX}/bin/lib${_realname}.dll" "${pkgdir}${MINGW_PREFIX}/lib/nvim/parser/${_realname#tree-sitter-}.so"
 
   install -Dm644 "${_realname}-${pkgver}"/LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-tree-sitter-lua/PKGBUILD
+++ b/mingw-w64-tree-sitter-lua/PKGBUILD
@@ -4,7 +4,7 @@ _realname=tree-sitter-lua
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.5.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Lua grammar for tree-sitter (mingw-w64)'
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -35,8 +35,6 @@ build() {
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       -Wno-dev \
       -DCMAKE_BUILD_TYPE=None \
-      -DCMAKE_SHARED_LIBRARY_SUFFIX_C=.so \
-      -DCMAKE_INSTALL_BINDIR=lib \
       -S "${_realname}-${pkgver}" \
       -B "build-${MSYSTEM}"
 
@@ -48,7 +46,7 @@ package() {
 
   # To add library to neovim runtime path
   mkdir -p "${pkgdir}${MINGW_PREFIX}/lib/nvim/parser"
-  cp "${pkgdir}${MINGW_PREFIX}/lib/lib${_realname}.so" "${pkgdir}${MINGW_PREFIX}/lib/nvim/parser/${_realname#tree-sitter-}.so"
+  ln "${pkgdir}${MINGW_PREFIX}/bin/lib${_realname}.dll" "${pkgdir}${MINGW_PREFIX}/lib/nvim/parser/${_realname#tree-sitter-}.so"
 
   install -Dm644 "${_realname}-${pkgver}"/LICENSE.md "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.md"
 }

--- a/mingw-w64-tree-sitter-markdown/PKGBUILD
+++ b/mingw-w64-tree-sitter-markdown/PKGBUILD
@@ -4,7 +4,7 @@ _realname=tree-sitter-markdown
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.5.3
-pkgrel=1
+pkgrel=2
 pkgdesc='Markdown grammar for tree-sitter (mingw-w64)'
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -35,8 +35,6 @@ build() {
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       -Wno-dev \
       -DCMAKE_BUILD_TYPE=None \
-      -DCMAKE_SHARED_LIBRARY_SUFFIX_C=.so \
-      -DCMAKE_INSTALL_BINDIR=lib \
       -S "${_realname}-${pkgver}" \
       -B "build-${MSYSTEM}"
 
@@ -48,8 +46,8 @@ package() {
 
   # To add library to neovim runtime path
   mkdir -p "${pkgdir}${MINGW_PREFIX}/lib/nvim/parser"
-  cp "${pkgdir}${MINGW_PREFIX}/lib/lib${_realname}.so" "${pkgdir}${MINGW_PREFIX}/lib/nvim/parser/${_realname#tree-sitter-}.so"
-  cp "${pkgdir}${MINGW_PREFIX}/lib/lib${_realname}-inline.so" "${pkgdir}${MINGW_PREFIX}/lib/nvim/parser/${_realname#tree-sitter-}_inline.so"
+  ln "${pkgdir}${MINGW_PREFIX}/bin/lib${_realname}.dll" "${pkgdir}${MINGW_PREFIX}/lib/nvim/parser/${_realname#tree-sitter-}.so"
+  ln "${pkgdir}${MINGW_PREFIX}/bin/lib${_realname}-inline.dll" "${pkgdir}${MINGW_PREFIX}/lib/nvim/parser/${_realname#tree-sitter-}_inline.so"
 
   install -Dm644 "${_realname}-${pkgver}"/LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-tree-sitter-query/PKGBUILD
+++ b/mingw-w64-tree-sitter-query/PKGBUILD
@@ -4,7 +4,7 @@ _realname=tree-sitter-query
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.8.0
-pkgrel=1
+pkgrel=2
 pkgdesc='TS query grammar for tree-sitter (mingw-w64)'
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -34,8 +34,6 @@ build() {
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       -Wno-dev \
       -DCMAKE_BUILD_TYPE=None \
-      -DCMAKE_SHARED_LIBRARY_SUFFIX_C=.so \
-      -DCMAKE_INSTALL_BINDIR=lib \
       -S "${_realname}-${pkgver}" \
       -B "build-${MSYSTEM}"
 
@@ -47,7 +45,7 @@ package() {
 
   # To add library to neovim runtime path
   mkdir -p "${pkgdir}${MINGW_PREFIX}/lib/nvim/parser"
-  cp "${pkgdir}${MINGW_PREFIX}/lib/lib${_realname}.so" "${pkgdir}${MINGW_PREFIX}/lib/nvim/parser/${_realname#tree-sitter-}.so"
+  ln "${pkgdir}${MINGW_PREFIX}/bin/lib${_realname}.dll" "${pkgdir}${MINGW_PREFIX}/lib/nvim/parser/${_realname#tree-sitter-}.so"
 
   install -Dm644 "${_realname}-${pkgver}"/LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-tree-sitter-vim/PKGBUILD
+++ b/mingw-w64-tree-sitter-vim/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=tree-sitter-vim
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.7.0
-pkgrel=2
+pkgver=0.8.1
+pkgrel=1
 pkgdesc='Vimscript grammar for tree-sitter (mingw-w64)'
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -19,7 +19,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-tree-sitter"
 )
 source=("https://github.com/tree-sitter-grammars/${_realname}/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('44eabc31127c4feacda19f2a05a5788272128ff561ce01093a8b7a53aadcc7b2')
+sha256sums=('93cafb9a0269420362454ace725a118ff1c3e08dcdfdc228aa86334b54d53c2a')
 
 prepare() {
   cd "${_realname}-${pkgver}"
@@ -28,17 +28,14 @@ prepare() {
 
 build() {
   cd "${_realname}-${pkgver}"
-  # To get around Windows not being supported
-  OS='unknown' make CC='cc' LINKSHARED='-shared' PREFIX="${MINGW_PREFIX}" PARSER_URL=$url
+  tree-sitter build --output lib${_realname}.dll
 }
 
 package() {
-  install -d "${pkgdir}${MINGW_PREFIX}/lib/tree_sitter"
+  install -d "${pkgdir}${MINGW_PREFIX}/bin/tree_sitter"
   cd "${_realname}-${pkgver}"
-  OS='unknown' make DESTDIR="${pkgdir}" PREFIX="${MINGW_PREFIX}" install
-
-  mkdir -p "${pkgdir}${MINGW_PREFIX}/bin"
-  mv "${pkgdir}${MINGW_PREFIX}/lib/lib${_realname}.so" "${pkgdir}${MINGW_PREFIX}/bin/lib${_realname}.dll"
+  install -Dm755 -t "${pkgdir}${MINGW_PREFIX}"/bin/ lib${_realname}.dll
+  install -Dm644 -t "${pkgdir}${MINGW_PREFIX}"/share/tree-sitter/queries/vim queries/vim/*.scm
 
   # To add library to neovim runtime path
   mkdir -p "${pkgdir}${MINGW_PREFIX}/lib/nvim/parser"

--- a/mingw-w64-tree-sitter-vim/PKGBUILD
+++ b/mingw-w64-tree-sitter-vim/PKGBUILD
@@ -4,7 +4,7 @@ _realname=tree-sitter-vim
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.7.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Vimscript grammar for tree-sitter (mingw-w64)'
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -37,9 +37,12 @@ package() {
   cd "${_realname}-${pkgver}"
   OS='unknown' make DESTDIR="${pkgdir}" PREFIX="${MINGW_PREFIX}" install
 
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/bin"
+  mv "${pkgdir}${MINGW_PREFIX}/lib/lib${_realname}.so" "${pkgdir}${MINGW_PREFIX}/bin/lib${_realname}.dll"
+
   # To add library to neovim runtime path
   mkdir -p "${pkgdir}${MINGW_PREFIX}/lib/nvim/parser"
-  cp "${pkgdir}${MINGW_PREFIX}/lib/lib${_realname}.so" "${pkgdir}${MINGW_PREFIX}/lib/nvim/parser/${_realname#tree-sitter-}.so"
+  ln "${pkgdir}${MINGW_PREFIX}/bin/lib${_realname}.dll" "${pkgdir}${MINGW_PREFIX}/lib/nvim/parser/${_realname#tree-sitter-}.so"
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-tree-sitter-vimdoc/PKGBUILD
+++ b/mingw-w64-tree-sitter-vimdoc/PKGBUILD
@@ -4,7 +4,7 @@ _realname=tree-sitter-vimdoc
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=4.0.2
-pkgrel=1
+pkgrel=2
 pkgdesc='Vim help file grammar for tree-sitter (mingw-w64)'
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -38,9 +38,13 @@ package() {
   cd "${_realname}-${pkgver}"
   OS='unknown' make DESTDIR="${pkgdir}" PREFIX="${MINGW_PREFIX}" install
 
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/bin"
+  mv "${pkgdir}${MINGW_PREFIX}/lib/lib${_realname}.so" "${pkgdir}${MINGW_PREFIX}/bin/lib${_realname}.dll"
+  rm "${pkgdir}${MINGW_PREFIX}"/lib/*.so.*
+
   # To add library to neovim runtime path
   mkdir -p "${pkgdir}${MINGW_PREFIX}/lib/nvim/parser"
-  cp "${pkgdir}${MINGW_PREFIX}/lib/lib${_realname}.so" "${pkgdir}${MINGW_PREFIX}/lib/nvim/parser/${_realname#tree-sitter-}.so"
+  ln "${pkgdir}${MINGW_PREFIX}/bin/lib${_realname}.dll" "${pkgdir}${MINGW_PREFIX}/lib/nvim/parser/${_realname#tree-sitter-}.so"
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
in case of nvim everything works, but for other users of grammars it's a bit problematic to locate them in PATH. so install grammars with .dll extension under bin/ and hardlink the library to nvim parsers location

fixes #30097 