### PR TITLE
xxhash: enable auto-dispatch on x86_64

### DIFF
--- a/mingw-w64-xxhash/PKGBUILD
+++ b/mingw-w64-xxhash/PKGBUILD
@@ -4,7 +4,7 @@ _realname=xxhash
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.8.3
-pkgrel=1
+pkgrel=2
 pkgdesc="Extremely fast non-cryptographic hash algorithm (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -23,6 +23,10 @@ build() {
     _extra_config+=("-DCMAKE_BUILD_TYPE=Release")
   else
     _extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  if [[ ${CARCH} == x86_64 ]]; then
+    _extra_config+=("-DDISPATCH=ON")
   fi
 
   mkdir -p "${srcdir}/build-static-${MSYSTEM}" && cd "${srcdir}/build-static-${MSYSTEM}"


### PR DESCRIPTION
This can significantly improve performance of XXH3_64b and XXH128 on CPUs supporting AVX2 and/or AVX512

Benchmark gathered on my i7-14650HX:
```
# Before
$ xxhsum -b
xxhsum.exe 0.8.3 by Yann Collet
compiled as 64-bit x86_64 + SSE2 little endian with GCC 14.2.0
Sample of 100 KB...
 1#XXH32                         :     102400 ->    60340 it/s ( 5892.6 MB/s)
 3#XXH64                         :     102400 ->   121286 it/s (11844.3 MB/s)
 5#XXH3_64b                      :     102400 ->   215721 it/s (21066.5 MB/s)
11#XXH128                        :     102400 ->   218110 it/s (21299.8 MB/s)
# After
$ xxhsum -b
xxhsum.exe 0.8.3 by Yann Collet
compiled as 64-bit x86 autoVec (AVX2 detected) little endian with GCC 16.1.0
Sample of 100 KB...
 1#XXH32                         :     102400 ->    60844 it/s ( 5941.8 MB/s)
 3#XXH64                         :     102400 ->   121407 it/s (11856.2 MB/s)
 5#XXH3_64b                      :     102400 ->   411071 it/s (40143.7 MB/s)
11#XXH128                        :     102400 ->   414375 it/s (40466.3 MB/s)
```