### PR TITLE
libmariadbclient: fix missing zstd and curl in --libs_sys output

### DIFF
--- a/mingw-w64-libmariadbclient/PKGBUILD
+++ b/mingw-w64-libmariadbclient/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libmariadbclient
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.4.9
-pkgrel=1
+pkgrel=2
 pkgdesc="MariaDB client libraries (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -80,6 +80,12 @@ build() {
     -DCLIENT_PLUGIN_MYSQL_OLD_PASSWORD=STATIC \
     -DCLIENT_PLUGIN_ZSTD=STATIC \
     ../mariadb-connector-c-${pkgver}
+
+  # Fix: zstd and curl are missing from --libs_sys (mariadb_config CMake scoping
+  # bug: SYSTEM_LIBS updated inside libmariadb/ without PARENT_SCOPE). Inject them
+  # into the generated mariadb_config.c before it is compiled.
+  sed -i 's/\(#define LIBS_SYS ".*\)"/\1 -lzstd -lcurl.dll"/' \
+    "${srcdir}/build-${MSYSTEM}/mariadb_config/mariadb_config.c"
 
   ${MINGW_PREFIX}/bin/cmake.exe --build ./
 }


### PR DESCRIPTION
## Problem

\`CLIENT_PLUGIN_ZSTD=STATIC\` and \`CLIENT_PLUGIN_REMOTE_IO=STATIC\` embed zstd
and curl code into \`libmysqlclient_r.a\`, but \`mariadb_config --libs_sys\` does
not report \`-lzstd\` or \`-lcurl.dll\`. This breaks static linking on Windows:
applications get undefined references to zstd symbols and \`__imp_curl_*\` import
stubs at link time.

Repro (MINGW64/UCRT64, any project linking the static client lib):

\`\`\`
libmysqlclient_r.a(compress_zstd.c.obj): undefined reference to \`ZSTD_compress'
libmysqlclient_r.a(remote_io.c.obj): undefined reference to \`__imp_curl_multi_init'
... (~25 more)
\`\`\`

## Root Cause

Both \`ZSTD_LIBRARY\` and \`CURL_LIBRARIES\` are appended to \`SYSTEM_LIBS\` inside
\`libmariadb/CMakeLists.txt\` **without \`PARENT_SCOPE\`**. The sibling
\`mariadb_config/\` subdirectory (processed after \`libmariadb/\`) reads the
top-level \`SYSTEM_LIBS\` to build the \`@extra_dynamic_LDFLAGS@\` substitution
that becomes \`#define LIBS_SYS\` in \`mariadb_config.c\`. It never sees those
additions, so \`--libs_sys\` only outputs the Win32 baseline
(\`-lws2_32 -ladvapi32 ...\`) and omits \`-lzstd\` and \`-lcurl.dll\`.

## Fix

After \`cmake\` configure (which generates \`mariadb_config.c\`), patch that file
to append \`-lzstd -lcurl.dll\` to the \`LIBS_SYS\` string literal before it is
compiled into \`mariadb_config.exe\`.

\`-lcurl.dll\` (not \`-lcurl\`) is used deliberately: on MinGW the linker resolves
\`-lcurl.dll\` to \`libcurl.dll.a\` (the import library that provides the
\`__imp_curl_*\` stubs needed by the statically-embedded \`remote_io\` plugin),
whereas \`-lcurl\` may resolve to \`libcurl.a\` (the static archive, which does
not define \`__imp_curl_*\`).