### PR TITLE
python-tox: update to 4.55.1

### DIFF
--- a/mingw-w64-python-tox/PKGBUILD
+++ b/mingw-w64-python-tox/PKGBUILD
@@ -3,11 +3,11 @@
 _realname=tox
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=4.35.0
+pkgver=4.55.1
 pkgrel=1
 pkgdesc="Python virtualenv management and testing tool (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 msys2_references=(
   'archlinux: python-tox'
   'gentoo: dev-python/tox'
@@ -17,45 +17,41 @@ msys2_repository_url='https://github.com/tox-dev/tox/'
 url='https://tox.wiki/'
 msys2_changelog_url='https://tox.wiki/en/stable/changelog.html'
 license=('spdx:MIT')
-makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
-             "${MINGW_PACKAGE_PREFIX}-python-installer"
-             "${MINGW_PACKAGE_PREFIX}-python-hatchling"
-             "${MINGW_PACKAGE_PREFIX}-python-hatch-vcs")
-depends=("${MINGW_PACKAGE_PREFIX}-python"
-         "${MINGW_PACKAGE_PREFIX}-python-cachetools"
-         "${MINGW_PACKAGE_PREFIX}-python-chardet"
-         "${MINGW_PACKAGE_PREFIX}-python-colorama"
-         "${MINGW_PACKAGE_PREFIX}-python-filelock"
-         "${MINGW_PACKAGE_PREFIX}-python-packaging"
-         "${MINGW_PACKAGE_PREFIX}-python-platformdirs"
-         "${MINGW_PACKAGE_PREFIX}-python-pluggy"
-         "${MINGW_PACKAGE_PREFIX}-python-pyproject-api"
-         "${MINGW_PACKAGE_PREFIX}-python-virtualenv")
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-python"
+  "${MINGW_PACKAGE_PREFIX}-python-cachetools"
+  "${MINGW_PACKAGE_PREFIX}-python-colorama"
+  "${MINGW_PACKAGE_PREFIX}-python-filelock"
+  "${MINGW_PACKAGE_PREFIX}-python-packaging"
+  "${MINGW_PACKAGE_PREFIX}-python-platformdirs"
+  "${MINGW_PACKAGE_PREFIX}-python-pluggy"
+  "${MINGW_PACKAGE_PREFIX}-python-pyproject-api"
+  "${MINGW_PACKAGE_PREFIX}-python-python-discovery"
+  "${MINGW_PACKAGE_PREFIX}-python-tomli-w"
+  "${MINGW_PACKAGE_PREFIX}-python-virtualenv"
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-python-build"
+  "${MINGW_PACKAGE_PREFIX}-python-installer"
+  "${MINGW_PACKAGE_PREFIX}-python-docutils"
+  "${MINGW_PACKAGE_PREFIX}-python-hatchling"
+  "${MINGW_PACKAGE_PREFIX}-python-hatch-vcs"
+)
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('74d2fe33eb37233d506f854196bd7bd7e2fbb79e8d9b4bed214ab3da98740876')
+sha256sums=('0678fbf26dd5b559b1ef128fa4388325920219322ebc8cc5f3497627c00f4472')
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
-  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
-}
 
-#This hangs when I try this.
-#check() {
-#  cd "${srcdir}/python-build-${MSYSTEM}"
-#  msg "Python build for ${MSYSTEM}"
-#  ${MINGW_PREFIX}/bin/virtualenv "$srcdir/pyvenv" --system-site-packages
-#  . "$srcdir/pyvenv/bin/activate"
-#  ${MINGW_PREFIX}/bin/python setup.py install
-#  ${MINGW_PREFIX}/bin/python setup.py pytest
-#
-#}
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
 
 package() {
   cd "${srcdir}/python-build-${MSYSTEM}"
+
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
-    --destdir="${pkgdir}" dist/*.whl
+    python -m installer --prefix=${MINGW_PREFIX} --destdir="${pkgdir}" dist/*.whl
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
 }


### PR DESCRIPTION
* drop mingw32, as there's no rdeps, and its new dep tomli-w isn't available for mingw32