### PR TITLE
[RFC] Clean up templates

### DIFF
--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-git.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-git.sh
@@ -9,11 +9,17 @@ pkgdesc="Some package (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
 url="https://github.com/someproject/somepackage"
-license=('LICENSE')
-makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-ninja"
-             "${MINGW_PACKAGE_PREFIX}-cc"
-             'git')
+msys2_repository_url='https://www.somepackage.org/'
+msys2_references=(
+  'archlinux: somepackage'
+)
+license=('spdx:LICENSE')
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+  "${MINGW_PACKAGE_PREFIX}-ninja"
+  'git'
+)
 _commit='ff9ee68d7e31784c6fea3c864a235ad1f32ff026'
 source=("${_realname}"::"git+https://github.com/someproject/somepackage.git#commit=${_commit}"
         0001-An-important-fix.patch

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-git.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-git.sh
@@ -55,6 +55,7 @@ build() {
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       "${extra_config[@]}" \
       -DBUILD_{SHARED,STATIC}_LIBS=ON \
+      -DBUILD_TESTING=OFF \
       -S ${_realname} \
       -B build-${MSYSTEM}
 
@@ -62,7 +63,9 @@ build() {
 }
 
 check() {
-  cmake --build build-${MSYSTEM} --target test
+  cmake -DBUILD_TESTING=ON -S ${_realname} -B build-${MSYSTEM}
+  cmake --build build-${MSYSTEM}
+  ctest --test-dir build-${MSYSTEM} --output-on-failure
 }
 
 package() {

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-git.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-git.sh
@@ -29,13 +29,13 @@ sha256sums=('SKIP'
             'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
 
 pkgver() {
-  cd "${_realname}"
+  cd ${_realname}
 
   git describe --long "${_commit}" | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//g'
 }
 
 prepare() {
-  cd "${_realname}"
+  cd ${_realname}
 
   patch -Nbp1 -i "${srcdir}"/0001-A-really-important-fix.patch
   patch -Nbp1 -i "${srcdir}"/0002-A-less-important-fix.patch
@@ -55,18 +55,19 @@ build() {
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       "${extra_config[@]}" \
       -DBUILD_{SHARED,STATIC}_LIBS=ON \
-      -S "${_realname}" \
-      -B "build-${MSYSTEM}"
+      -S ${_realname} \
+      -B build-${MSYSTEM}
 
-  cmake --build "build-${MSYSTEM}"
+  cmake --build build-${MSYSTEM}
 }
 
 check() {
-  cmake --build "build-${MSYSTEM}" --target test
+  cmake --build build-${MSYSTEM} --target test
 }
 
 package() {
   DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}"
 
-  install -Dm644 "${srcdir}/${_realname}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  install -Dm644 "${srcdir}"/${_realname}/LICENSE \
+    "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
 }

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-git.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-git.sh
@@ -22,8 +22,8 @@ makedepends=(
 )
 _commit='ff9ee68d7e31784c6fea3c864a235ad1f32ff026'
 source=("${_realname}"::"git+https://github.com/someproject/somepackage.git#commit=${_commit}"
-        0001-An-important-fix.patch
-        0002-A-less-important-fix.patch)
+        '0001-An-important-fix.patch'
+        '0002-A-less-important-fix.patch')
 sha256sums=('SKIP'
             'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
             'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
@@ -37,8 +37,8 @@ pkgver() {
 prepare() {
   cd "${_realname}"
 
-  patch -Np1 -i "${srcdir}/0001-A-really-important-fix.patch"
-  patch -Np1 -i "${srcdir}/0002-A-less-important-fix.patch"
+  patch -Nbp1 -i "${srcdir}"/0001-A-really-important-fix.patch
+  patch -Nbp1 -i "${srcdir}"/0002-A-less-important-fix.patch
 }
 
 build() {

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-tarball.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-tarball.sh
@@ -27,7 +27,7 @@ sha256sums=('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
             'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc')
 
 prepare() {
-  cd "${_realname}-${pkgver}"
+  cd ${_realname}-${pkgver}
 
   patch -Nbp1 -i "${srcdir}"/0001-A-really-important-fix.patch
   patch -Nbp1 -i "${srcdir}"/0002-A-less-important-fix.patch
@@ -47,18 +47,19 @@ build() {
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       "${extra_config[@]}" \
       -DBUILD_{SHARED,STATIC}_LIBS=ON \
-      -S "${_realname}-${pkgver}" \
-      -B "build-${MSYSTEM}"
+      -S ${_realname}-${pkgver} \
+      -B build-${MSYSTEM}
 
-  cmake --build "build-${MSYSTEM}"
+  cmake --build build-${MSYSTEM}
 }
 
 check() {
-  cmake --build "build-${MSYSTEM}" --target test
+  cmake --build build-${MSYSTEM} --target test
 }
 
 package() {
-  DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}"
+  DESTDIR="${pkgdir}" cmake --install build-${MSYSTEM}
 
-  install -Dm644 "${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  install -Dm644 "${srcdir}"/${_realname}-${pkgver}/LICENSE \
+    "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
 }

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-tarball.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-tarball.sh
@@ -9,10 +9,16 @@ pkgdesc="Some package (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
 url='https://www.somepackage.org/'
-license=('LICENSE')
-makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-ninja"
-             "${MINGW_PACKAGE_PREFIX}-cc")
+msys2_repository_url='https://www.somepackage.org/'
+msys2_references=(
+  'archlinux: somepackage'
+)
+license=('spdx:LICENSE')
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+  "${MINGW_PACKAGE_PREFIX}-ninja"
+)
 source=("https://www.somepackage.org/${_realname}/${_realname}-${pkgver}.tar.gz"
         "0001-An-important-fix.patch"
         "0002-A-less-important-fix.patch")

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-tarball.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-tarball.sh
@@ -47,6 +47,7 @@ build() {
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
       "${extra_config[@]}" \
       -DBUILD_{SHARED,STATIC}_LIBS=ON \
+      -DBUILD_TESTING=OFF \
       -S ${_realname}-${pkgver} \
       -B build-${MSYSTEM}
 
@@ -54,7 +55,9 @@ build() {
 }
 
 check() {
-  cmake --build build-${MSYSTEM} --target test
+  cmake -DBUILD_TESTING=ON -S ${_realname}-${pkgver} -B build-${MSYSTEM}
+  cmake --build build-${MSYSTEM}
+  ctest --test-dir build-${MSYSTEM} --output-on-failure
 }
 
 package() {

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-tarball.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-tarball.sh
@@ -20,8 +20,8 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-ninja"
 )
 source=("https://www.somepackage.org/${_realname}/${_realname}-${pkgver}.tar.gz"
-        "0001-An-important-fix.patch"
-        "0002-A-less-important-fix.patch")
+        '0001-An-important-fix.patch'
+        '0002-A-less-important-fix.patch')
 sha256sums=('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
             'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
             'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc')
@@ -29,8 +29,8 @@ sha256sums=('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  patch -Np1 -i ../0001-A-really-important-fix.patch
-  patch -Np1 -i ../0002-A-less-important-fix.patch
+  patch -Nbp1 -i "${srcdir}"/0001-A-really-important-fix.patch
+  patch -Nbp1 -i "${srcdir}"/0002-A-less-important-fix.patch
 }
 
 build() {

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.autotools-tarball.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.autotools-tarball.sh
@@ -24,15 +24,15 @@ sha256sums=('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
             'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
 
 prepare() {
-  cd "${_realname}-${pkgver}"
+  cd ${_realname}-${pkgver}
 
   patch -Nbp1 -i "${srcdir}"/0001-A-fix.patch
 }
 
 build() {
-  mkdir -p "build-${MSYSTEM}" && cd "build-${MSYSTEM}"
+  mkdir -p build-${MSYSTEM} && cd build-${MSYSTEM}
 
-  ../"${_realname}-${pkgver}"/configure \
+  ../${_realname}-${pkgver}/configure \
     --prefix="${MINGW_PREFIX}" \
     --build="${MINGW_CHOST}" \
     --host="${MINGW_CHOST}" \
@@ -44,15 +44,16 @@ build() {
 }
 
 check() {
-  cd "build-${MSYSTEM}"
+  cd build-${MSYSTEM}
 
   make check
 }
 
 package() {
-  cd "build-${MSYSTEM}"
+  cd build-${MSYSTEM}
 
   make install DESTDIR="${pkgdir}"
 
-  install -Dm644 "../${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  install -Dm644 "${srcdir}"/${_realname}-${pkgver}/LICENSE \
+    "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
 }

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.autotools-tarball.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.autotools-tarball.sh
@@ -9,9 +9,15 @@ pkgdesc="Some package (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
 url='https://www.somepackage.org/'
-license=('LICENSE')
-makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
-             "${MINGW_PACKAGE_PREFIX}-cc")
+msys2_repository_url='https://www.somepackage.org/'
+msys2_references=(
+  'archlinux: somepackage'
+)
+license=('spdx:LICENSE')
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-autotools"
+  "${MINGW_PACKAGE_PREFIX}-cc"
+)
 source=("https://www.somepackage.org/${_realname}/${_realname}-${pkgver}.tar.gz"
         "0001-A-fix.patch")
 sha256sums=('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.autotools-tarball.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.autotools-tarball.sh
@@ -19,14 +19,14 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cc"
 )
 source=("https://www.somepackage.org/${_realname}/${_realname}-${pkgver}.tar.gz"
-        "0001-A-fix.patch")
+        '0001-A-fix.patch')
 sha256sums=('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
             'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
 
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  patch -p1 -i ../0001-A-fix.patch
+  patch -Nbp1 -i "${srcdir}"/0001-A-fix.patch
 }
 
 build() {

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.cargo-c-tarball.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.cargo-c-tarball.sh
@@ -9,9 +9,15 @@ pkgdesc="Some package (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
 url='https://www.somepackage.org/'
-license=('LICENSE')
-makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
-             "${MINGW_PACKAGE_PREFIX}-cargo-c")
+msys2_repository_url='https://www.somepackage.org/'
+msys2_references=(
+  'archlinux: somepackage'
+)
+license=('spdx:LICENSE')
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-rust"
+  "${MINGW_PACKAGE_PREFIX}-cargo-c"
+)
 source=("https://www.somepackage.org/${_realname}/${_realname}-${pkgver}.tar.gz"
         "0001-An-important-fix.patch"
         "0002-A-less-important-fix.patch")

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.cargo-c-tarball.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.cargo-c-tarball.sh
@@ -26,16 +26,16 @@ sha256sums=('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
             'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc')
 
 prepare() {
-  cd "${_realname}-${pkgver}"
+  cd ${_realname}-${pkgver}
 
   patch -Nbp1 -i "${srcdir}"/0001-A-really-important-fix.patch
   patch -Nbp1 -i "${srcdir}"/0002-A-less-important-fix.patch
 
-  cargo fetch --locked --target "${RUST_CHOST}"
+  cargo fetch --locked --target ${RUST_CHOST}
 }
 
 build() {
-  cd "${_realname}-${pkgver}"
+  cd ${_realname}-${pkgver}
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
     cargo cbuild \
@@ -47,13 +47,13 @@ build() {
 }
 
 check() {
-  cd "${_realname}-${pkgver}"
+  cd ${_realname}-${pkgver}
 
   cargo test --release --frozen
 }
 
 package() {
-  cd "${_realname}-${pkgver}"
+  cd ${_realname}-${pkgver}
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
     cargo cinstall \
@@ -61,11 +61,12 @@ package() {
       --release \
       --frozen \
       --all-features \
-      --prefix="${MINGW_PREFIX}" \
+      --prefix=${MINGW_PREFIX} \
       --destdir="${pkgdir}"
 
   # Remove def file
   rm -f "${pkgdir}"${MINGW_PREFIX}/lib/*.def
 
-  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  install -Dm644 "${srcdir}"/${_realname}-${pkgver}/LICENSE \
+    "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
 }

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.cargo-c-tarball.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.cargo-c-tarball.sh
@@ -19,8 +19,8 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cargo-c"
 )
 source=("https://www.somepackage.org/${_realname}/${_realname}-${pkgver}.tar.gz"
-        "0001-An-important-fix.patch"
-        "0002-A-less-important-fix.patch")
+        '0001-An-important-fix.patch'
+        '0002-A-less-important-fix.patch')
 sha256sums=('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
             'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
             'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc')
@@ -28,8 +28,8 @@ sha256sums=('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  patch -Np1 -i ../0001-A-really-important-fix.patch
-  patch -Np1 -i ../0002-A-less-important-fix.patch
+  patch -Nbp1 -i "${srcdir}"/0001-A-really-important-fix.patch
+  patch -Nbp1 -i "${srcdir}"/0002-A-less-important-fix.patch
 
   cargo fetch --locked --target "${RUST_CHOST}"
 }

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.cargo-tarball.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.cargo-tarball.sh
@@ -23,36 +23,37 @@ sha256sums=('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
             'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc')
 
 prepare() {
-  cd "${_realname}-${pkgver}"
+  cd ${_realname}-${pkgver}
 
   patch -Nbp1 -i "${srcdir}"/0001-A-really-important-fix.patch
   patch -Nbp1 -i "${srcdir}"/0002-A-less-important-fix.patch
 
   # if cargo wants to make an http request at build stage, use `cargo fetch --locked` instead
-  cargo fetch --locked --target "${RUST_CHOST}"
+  cargo fetch --locked --target ${RUST_CHOST}
 }
 
 build() {
-  cd "${_realname}-${pkgver}"
+  cd ${_realname}-${pkgver}
 
   cargo build --release --frozen
 }
 
 check() {
-  cd "${_realname}-${pkgver}"
+  cd ${_realname}-${pkgver}
 
   cargo test --release --frozen
 }
 
 package() {
-  cd "${_realname}-${pkgver}"
+  cd ${_realname}-${pkgver}
 
   cargo install \
     --offline \
     --no-track \
     --frozen \
     --path . \
-    --root "${pkgdir}${MINGW_PREFIX}"
+    --root "${pkgdir}"${MINGW_PREFIX}
 
-  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  install -Dm644 "${srcdir}"/${_realname}-${pkgver}/LICENSE \
+    "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
 }

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.cargo-tarball.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.cargo-tarball.sh
@@ -9,7 +9,11 @@ pkgdesc="Some package (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
 url='https://www.somepackage.org/'
-license=('LICENSE')
+msys2_repository_url='https://www.somepackage.org/'
+msys2_references=(
+  'archlinux: somepackage'
+)
+license=('spdx:LICENSE')
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
 source=("https://www.somepackage.org/${_realname}/${_realname}-${pkgver}.tar.gz"
         "0001-An-important-fix.patch"

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.cargo-tarball.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.cargo-tarball.sh
@@ -16,8 +16,8 @@ msys2_references=(
 license=('spdx:LICENSE')
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
 source=("https://www.somepackage.org/${_realname}/${_realname}-${pkgver}.tar.gz"
-        "0001-An-important-fix.patch"
-        "0002-A-less-important-fix.patch")
+        '0001-An-important-fix.patch'
+        '0002-A-less-important-fix.patch')
 sha256sums=('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
             'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
             'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc')
@@ -25,8 +25,8 @@ sha256sums=('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  patch -Np1 -i ../0001-A-really-important-fix.patch
-  patch -Np1 -i ../0002-A-less-important-fix.patch
+  patch -Nbp1 -i "${srcdir}"/0001-A-really-important-fix.patch
+  patch -Nbp1 -i "${srcdir}"/0002-A-less-important-fix.patch
 
   # if cargo wants to make an http request at build stage, use `cargo fetch --locked` instead
   cargo fetch --locked --target "${RUST_CHOST}"

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.meson-tarball.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.meson-tarball.sh
@@ -28,7 +28,7 @@ sha256sums=('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
             'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc')
 
 prepare() {
-  cd "${_realname}-${pkgver}"
+  cd ${_realname}-${pkgver}
 
   patch -Nbp1 -i "${srcdir}"/0001-A-really-important-fix.patch
   patch -Nbp1 -i "${srcdir}"/0002-A-less-important-fix.patch
@@ -41,18 +41,19 @@ build() {
       --wrap-mode=nodownload \
       --auto-features=enabled \
       --buildtype=plain \
-      "build-${MSYSTEM}" \
-      "${_realname}-${pkgver}"
+      build-${MSYSTEM} \
+      ${_realname}-${pkgver}
 
-  meson compile -C "build-${MSYSTEM}"
+  meson compile -C build-${MSYSTEM}
 }
 
 check() {
-  meson test -C "build-${MSYSTEM}"
+  meson test -C build-${MSYSTEM}
 }
 
 package() {
-  meson install -C "build-${MSYSTEM}" --destdir "${pkgdir}"
+  meson install -C build-${MSYSTEM} --destdir "${pkgdir}"
 
-  install -Dm644 "${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+  install -Dm644 "${srcdir}"/${_realname}-${pkgver}/LICENSE \
+    "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
 }

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.meson-tarball.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.meson-tarball.sh
@@ -21,8 +21,8 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-pkgconf"
 )
 source=("https://www.somepackage.org/${_realname}/${_realname}-${pkgver}.tar.gz"
-        "0001-An-important-fix.patch"
-        "0002-A-less-important-fix.patch")
+        '0001-An-important-fix.patch'
+        '0002-A-less-important-fix.patch')
 sha256sums=('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
             'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
             'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc')
@@ -30,8 +30,8 @@ sha256sums=('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  patch -Np1 -i ../0001-A-really-important-fix.patch
-  patch -Np1 -i ../0002-A-less-important-fix.patch
+  patch -Nbp1 -i "${srcdir}"/0001-A-really-important-fix.patch
+  patch -Nbp1 -i "${srcdir}"/0002-A-less-important-fix.patch
 }
 
 build() {

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.meson-tarball.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.meson-tarball.sh
@@ -9,11 +9,17 @@ pkgdesc="Some package (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
 url='https://www.somepackage.org/'
-license=('LICENSE')
-makedepends=("${MINGW_PACKAGE_PREFIX}-meson"
-             "${MINGW_PACKAGE_PREFIX}-ninja"
-             "${MINGW_PACKAGE_PREFIX}-pkg-config"
-             "${MINGW_PACKAGE_PREFIX}-cc")
+msys2_repository_url='https://www.somepackage.org/'
+msys2_references=(
+  'archlinux: somepackage'
+)
+license=('spdx:LICENSE')
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-meson"
+  "${MINGW_PACKAGE_PREFIX}-ninja"
+  "${MINGW_PACKAGE_PREFIX}-pkgconf"
+)
 source=("https://www.somepackage.org/${_realname}/${_realname}-${pkgver}.tar.gz"
         "0001-An-important-fix.patch"
         "0002-A-less-important-fix.patch")

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.python.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.python.sh
@@ -31,7 +31,7 @@ sha256sums=('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
             'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc')
 
 prepare() {
-  cd "${_realname}-${pkgver}"
+  cd ${_realname}-${pkgver}
 
   patch -Nbp1 -i "${srcdir}"/0001-A-really-important-fix.patch
   patch -Nbp1 -i "${srcdir}"/0002-A-less-important-fix.patch
@@ -42,13 +42,13 @@ prepare() {
 }
 
 build() {
-  cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+  cp -r ${_realname}-${pkgver} python-build-${MSYSTEM} && cd python-build-${MSYSTEM}
 
   python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 check() {
-  cd "python-build-${MSYSTEM}"
+  cd python-build-${MSYSTEM}
 
 # The test command will usually depend upon what is contained in the tox.ini file
 # or in the [testenv:py] section of the pyproject.toml file.
@@ -56,11 +56,12 @@ check() {
 }
 
 package() {
-  cd "python-build-${MSYSTEM}"
+  cd python-build-${MSYSTEM}
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
     python -m installer --prefix=${MINGW_PREFIX} \
     --destdir="${pkgdir}" dist/*.whl
 
-  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+  install -Dm644 "${srcdir}"/${_realname}-${pkgver}/LICENSE \
+    "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
 }

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.python.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.python.sh
@@ -9,9 +9,18 @@ pkgdesc="Some package (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
 url='https://www.somepackage.org/'
-license=('LICENSE')
+msys2_repository_url='https://www.somepackage.org/'
+msys2_references=(
+  'archlinux: python-somepackage'
+  'gentoo: dev-python/somepackage'
+  'purl: pkg:pypi/somepackage'
+)
+license=('spdx:LICENSE')
 depends=("${MINGW_PACKAGE_PREFIX}-python")
-makedepends=("${MINGW_PACKAGE_PREFIX}-python-build" "${MINGW_PACKAGE_PREFIX}-python-installer")
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-python-build"
+  "${MINGW_PACKAGE_PREFIX}-python-installer"
+)
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.python.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.python.sh
@@ -50,17 +50,16 @@ build() {
 check() {
   cd python-build-${MSYSTEM}
 
-# The test command will usually depend upon what is contained in the tox.ini file
-# or in the [testenv:py] section of the pyproject.toml file.
-  python -m pytest
+  # The test command will usually depend upon what is contained in the tox.ini file
+  # or in the [testenv:py] section of the pyproject.toml file.
+  PYTHONPATH="$(pwd)/src" python -m pytest
 }
 
 package() {
   cd python-build-${MSYSTEM}
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-    python -m installer --prefix=${MINGW_PREFIX} \
-    --destdir="${pkgdir}" dist/*.whl
+    python -m installer --prefix=${MINGW_PREFIX} --destdir="${pkgdir}" dist/*.whl
 
   install -Dm644 "${srcdir}"/${_realname}-${pkgver}/LICENSE \
     "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.python.sh
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.python.sh
@@ -24,8 +24,8 @@ makedepends=(
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
-        "0001-An-important-fix.patch"
-        "0002-A-less-important-fix.patch")
+        '0001-An-important-fix.patch'
+        '0002-A-less-important-fix.patch')
 sha256sums=('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
             'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
             'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc')
@@ -33,8 +33,8 @@ sha256sums=('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  patch -Np1 -i ../0001-A-really-important-fix.patch
-  patch -Np1 -i ../0002-A-less-important-fix.patch
+  patch -Nbp1 -i "${srcdir}"/0001-A-really-important-fix.patch
+  patch -Nbp1 -i "${srcdir}"/0002-A-less-important-fix.patch
 
   ## (OPTIONAL) Only if setuptools-scm is used
   # Set version for setuptools_scm


### PR DESCRIPTION
The current PKGBUILD templates have inconsistent styling. To address this, I've performed several cleanups to unify the style, primarily based on the conventions commonly used in this repository.

I've split these changes into 4 distinct commits, each representing a logical subset of the overall cleanup.

Suggestions or feedback on alternative style preferences are welcome.