### PR TITLE
qemu: Update to 11.0.2

### DIFF
--- a/mingw-w64-qemu/PKGBUILD
+++ b/mingw-w64-qemu/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=(
   "${MINGW_PACKAGE_PREFIX}-qemu-guest-agent"
   "${MINGW_PACKAGE_PREFIX}-qemu-image-util"
 )
-_base_ver="11.0.1"
+_base_ver="11.0.2"
 # QEMU Versioning of RC-SourcePackage and RC-Version differs
 # e.g. qemu-6.1.0-rc0.tar.xz contains 6.0.90, qemu-6.1.0-rc1.tar.xz contains 6.0.91
 # Unset _rc_no to create Release-Build
@@ -119,7 +119,7 @@ source=(
   msys2.examples.tests.sh
 )
 sha256sums=(
-  '0d235f5820278d914a3155ec27af8e4258d697ea892895570807d69c0cb8cd64'
+  '3745f6ea88e2e87fe0dc838b2b1d4e0a770bf48e01a1d5a186842a1fff76ccf5'
   'SKIP'
   '07370d914562bb8dab16ce3e76b5a4d32d471c792ea95b9c12afd5c29dc619bf'
   'f2f9eeb31023d002f54637a9941ea0d8fae3c6f0a66c05c033857b305bd1470d'


### PR DESCRIPTION
The QEMU v11.0.2 stable release is now available.

  https://download.qemu.org/qemu-11.0.2.tar.xz
  https://download.qemu.org/qemu-11.0.2.tar.xz.sig (signature)

v11.0.2 is now tagged in the official qemu.git repository, and the
stable-11.0 branch has been updated accordingly:

  https://gitlab.com/qemu-project/qemu/-/commits/stable-11.0

There are 107 changes since the previous v11.0.1 release.
