### PR TITLE
imagemagick: update to 7.1.2.26

### DIFF
--- a/mingw-w64-imagemagick/PKGBUILD
+++ b/mingw-w64-imagemagick/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
 _basever=7.1.2
-_rc=-25
+_rc=-26
 pkgver=${_basever}${_rc//-/.} # pkgver doesn't have "," "/", "-" and space.
 pkgrel=1
 pkgdesc="An image viewing/manipulation program (mingw-w64)"
@@ -79,17 +79,14 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-ghostscript: for Ghostscript support"
             )
 # libtool files are required in imagemagick to relocate modules path
 options=('libtool')
-source=(https://imagemagick.org/archive/releases/ImageMagick-${_basever}${_rc}.tar.xz{,.asc}
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/ImageMagick/ImageMagick/archive/refs/tags/${_basever}${_rc}.tar.gz"
         pathtools.c
         pathtools.h
         001-7.1.1.39-relocate.patch)
-sha256sums=('2b2070802de374871737ff1a516b3d9d1e66643779b7ed9c52e2534db7772006'
-            'SKIP'
+sha256sums=('d63594e334e1c410f600fb9370d78d49e4dc6f315722ca4ba083e864e5c354cb'
             'ebf471173f5ee9c4416c10a78760cea8afaf1a4a6e653977321e8547ce7bf3c0'
             '1585ef1b61cf53a2ca27049c11d49e0834683dfda798f03547761375df482a90'
             'f3454a7938069f91fbe220dc03e444e7454a4a8a286b2408bbfe6f15a9c8a6dc')
-#Lexie Parsimoniae (ImageMagick code signing key) <lexie.parsimoniae@imagemagick.org>
-validpgpkeys=('D8272EF51DA223E4D05B466989AB63D48277377A')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {


### PR DESCRIPTION
* Upstream recommends migrating to the tarball generated by GitHub. https://github.com/ImageMagick/ImageMagick/issues/8817

/cc @kmilos