### PR TITLE
mcfgthread: Upgrade to 2.4.2

### DIFF
--- a/mingw-w64-mcfgthread/PKGBUILD
+++ b/mingw-w64-mcfgthread/PKGBUILD
@@ -4,7 +4,7 @@ _realname=mcfgthread
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}"-libs)
-pkgver=2.4.1
+pkgver=2.4.2
 pkgrel=1
 pkgdesc="An efficient gthread implementation, providing C++11 threading support (mingw-w64)"
 arch=('any')
@@ -21,7 +21,7 @@ makedepends=(
   "git"
 )
 source=("git+https://github.com/lhmouse/mcfgthread.git#tag=v${pkgver%.*}-ga.${pkgver##*.}")
-sha256sums=('127254a357b3e64e58baf26e275644b1a0567d568eda18e85875d93c1f662218')
+sha256sums=('434bc3f0ca98970eed2cc1606ad1c791a505c3e6cdfeff2c8239e3cd907e1570')
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"


### PR DESCRIPTION
https://github.com/lhmouse/mcfgthread/releases/tag/v2.4-ga.2