### PR TITLE
lrdf: Fix .pc file's cflags

### DIFF
--- a/mingw-w64-lrdf/0003-fix-pc-cflags.patch
+++ b/mingw-w64-lrdf/0003-fix-pc-cflags.patch
@@ -1,7 +1,0 @@
---- a/lrdf.pc.in
-+++ b/lrdf.pc.in
-@@ -8,4 +8,4 @@
- Libs: -L${libdir} -llrdf
- Libs.private: @RAPTOR_LIBS@
--Cflags: @RAPTOR_CFLAGS@ -I${includedir}
-+Cflags: -I${includedir}/raptor2 -I${includedir}

--- a/mingw-w64-lrdf/0003-fix-pc-cflags.patch
+++ b/mingw-w64-lrdf/0003-fix-pc-cflags.patch
@@ -1,0 +1,7 @@
+--- a/lrdf.pc.in
++++ b/lrdf.pc.in
+@@ -8,4 +8,4 @@
+ Libs: -L${libdir} -llrdf
+ Libs.private: @RAPTOR_LIBS@
+-Cflags: @RAPTOR_CFLAGS@ -I${includedir}
++Cflags: -I${includedir}/raptor2 -I${includedir}

--- a/mingw-w64-lrdf/PKGBUILD
+++ b/mingw-w64-lrdf/PKGBUILD
@@ -22,18 +22,15 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-cc")
 source=("https://github.com/swh/LRDF/archive/refs/tags/v${pkgver}.tar.gz"
         "0001-add-stdint-h.patch"
-		"0002-add-no-undefined.patch"
-		"0003-fix-pc-cflags.patch")
+		"0002-add-no-undefined.patch")
 sha256sums=('d579417c477ac3635844cd1b94f273ee2529a8c3b6b21f9b09d15f462b89b1ef'
             '2e94d9a6192052bd8181c7817c5a3c8c9df453d4e64ab35654dd8ab6dfffe5af'
-			'd922f92c54d5a8bc6f8805ad4e9a24ac2bea6bd584c42d6e764bbce47835b9e1'
-			'7eb7d9c433b15b430a01b127a63034493029a3a618187943d6ea10aebe737c48')
+			'd922f92c54d5a8bc6f8805ad4e9a24ac2bea6bd584c42d6e764bbce47835b9e1')
 
 prepare() {
   cd "${_dirname}"
   patch -p1 -i ../0001-add-stdint-h.patch
   patch -p1 -i ../0002-add-no-undefined.patch
-  patch -p1 -i ../0003-fix-pc-cflags.patch
   autoreconf -fi
 }
 
@@ -54,6 +51,9 @@ package() {
   cd "build-${MSYSTEM}"
 
   make install DESTDIR="${pkgdir}"
+
+  local _PREFIX_WIN="$(cygpath -wm ${MINGW_PREFIX})"
+  sed -s "s|${_PREFIX_WIN}|${MINGW_PREFIX}|g" -i "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/lrdf.pc
 
   install -Dm644 "../${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-lrdf/PKGBUILD
+++ b/mingw-w64-lrdf/PKGBUILD
@@ -4,7 +4,7 @@ _realname=lrdf
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.6.1
-pkgrel=1
+pkgrel=2
 _dirname=LRDF-${pkgver}
 pkgdesc="A lightweight RDF library for accessing plugin metadata in the LADSPA plugin system (mingw-w64)"
 arch=('any')
@@ -22,15 +22,18 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-cc")
 source=("https://github.com/swh/LRDF/archive/refs/tags/v${pkgver}.tar.gz"
         "0001-add-stdint-h.patch"
-		"0002-add-no-undefined.patch")
+		"0002-add-no-undefined.patch"
+		"0003-fix-pc-cflags.patch")
 sha256sums=('d579417c477ac3635844cd1b94f273ee2529a8c3b6b21f9b09d15f462b89b1ef'
             '2e94d9a6192052bd8181c7817c5a3c8c9df453d4e64ab35654dd8ab6dfffe5af'
-			'd922f92c54d5a8bc6f8805ad4e9a24ac2bea6bd584c42d6e764bbce47835b9e1')
+			'd922f92c54d5a8bc6f8805ad4e9a24ac2bea6bd584c42d6e764bbce47835b9e1'
+			'7eb7d9c433b15b430a01b127a63034493029a3a618187943d6ea10aebe737c48')
 
 prepare() {
   cd "${_dirname}"
   patch -p1 -i ../0001-add-stdint-h.patch
   patch -p1 -i ../0002-add-no-undefined.patch
+  patch -p1 -i ../0003-fix-pc-cflags.patch
   autoreconf -fi
 }
 


### PR DESCRIPTION
Closes #30250 , an issue discovered when attempting to compile a project that depended on lrdf.