### PR TITLE
prettier: update to 3.9.4

### DIFF
--- a/mingw-w64-prettier/PKGBUILD
+++ b/mingw-w64-prettier/PKGBUILD
@@ -6,7 +6,7 @@
 _realname=prettier
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.8.4
+pkgver=3.9.4
 pkgrel=1
 pkgdesc='An opinionated code formatter (mingw-w64)'
 arch=('any')
@@ -22,7 +22,7 @@ license=('spdx:MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-nodejs")
 source=("https://registry.npmjs.org/${_realname}/-/${_realname}-${pkgver}.tgz"
         "prettier.sh")
-sha256sums=('f63025e225974ad864e063d76d015903b01f3a7dea4d3bf153e6faa2f6087077'
+sha256sums=('236949d3528822d117b33a26109bd5d70a3d7828dccd5a0805f9684398888c8b'
             'b3a516743b4e7dc4a9a7923c4d66b53fc750619f2c5fa7ec8cca974f95f74d06')
 
 package() {


### PR DESCRIPTION
[Changelog](https://github.com/prettier/prettier/blob/3.9.4/CHANGELOG.md#394)