### PR TITLE
mingw-w64-git: upgrade to Git for Windows 2.55.0.2

### DIFF
--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -83,6 +83,12 @@ STRIP=
 STRIP_OPTS=
 LDFLAGS=
 
+if test i686 = "$CARCH"
+then
+  # There is no i686 Rust we can use
+  export NO_RUST=ThatsRight
+fi
+
 if test -z "$NO_RUST"
 then
   makedepends+=("${MINGW_PACKAGE_PREFIX}-rust")

--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -17,7 +17,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
 	 "${MINGW_PACKAGE_PREFIX}-gitk"
 	 "${MINGW_PACKAGE_PREFIX}-${_realname}-gui"
 	 "${MINGW_PACKAGE_PREFIX}-${_realname}-for-windows-addons")
-tag=2.55.0.windows.1
+tag=2.55.0.windows.2
 pkgver=${tag/.windows./.}
 pkgrel=1
 pkgdesc="The fast distributed version control system (mingw-w64)"
@@ -62,7 +62,7 @@ source=("${_realname}"::"git+https://github.com/git-for-windows/git.git#tag=v$ta
 # resulting in different sha256sums.
 export GIT_CONFIG_PARAMETERS="${GIT_CONFIG_PARAMETERS:+$GIT_CONFIG_PARAMETERS }'core.autocrlf=false' 'core.eol=lf'"
 
-sha256sums=('c4881a6f310159335227c5a908625df6fbfd0e7949597fb662d03dd68eb2f641'
+sha256sums=('34f0847fa706b811fbc37363548bc6d247e9d39a515b99e620004de9af9b8000'
             'a9dcba5aebc93ae7aacdee03275780fc6c0f15e88fda30c93041e75851e75090'
             '7e6c5f3dc6a4209dca0e1f38880b2978500a5c745c04bc60dbeda5fc48e8d3cb'
             '80b0b11efe5a2f9b4cd92f28c260d0b3aad8b809c34ed95237c59b73e08ade0b'
@@ -82,12 +82,6 @@ COMPAT_CFLAGS=
 STRIP=
 STRIP_OPTS=
 LDFLAGS=
-
-if test i686 = "$CARCH"
-then
-  # There is no i686 Rust we can use
-  export NO_RUST=ThatsRight
-fi
 
 if test -z "$NO_RUST"
 then


### PR DESCRIPTION
This PR synchronizes the `mingw-w64-git` package definition from [Git for Windows](https://github.com/git-for-windows/MINGW-packages/tree/main/mingw-w64-git).

See https://github.com/git-for-windows/git/releases/tag/v2.55.0.windows.2 for the release notes.

> [!IMPORTANT]
Git for Windows v2.55.0(2) was released very quickly after v2.55.0 for one reason, and one reason only: to re-enable (opt-in) NTLM support. This was done by re-building `mingw-w64-curl` with `--enable-ntlm`, as cURL v8.21.0 builds _without_ NTLM support altogether by default. That re-build only lives in Git for Windows' Pacman repository, though, and MSYS2's variant of `mingw-w64-curl` _no longer supports NTLM_, period. Therefore, even with this here PR, regular MSYS2's `git.exe` will no longer allow NTLM authentication, with or without the `http.allowNTLMAuth` flag set.

This branch was pushed by https://github.com/git-for-windows/git-for-windows-automation/actions/runs/28594311252 (with a fixup cherry-picked from https://github.com/git-for-windows/MINGW-packages/pull/207 because I had forgotten to merge it before kicking off the workflow run that generated that branch).