### PR TITLE
turbo: update to 2.10.9

### DIFF
--- a/mingw-w64-turbo/PKGBUILD
+++ b/mingw-w64-turbo/PKGBUILD
@@ -3,17 +3,18 @@
 _realname=turbo
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.10.0
+pkgver=2.10.3
 pkgrel=1
 pkgdesc="Incremental bundler and build system optimized for JavaScript and TypeScript (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+mingw_arch=('clang64' 'clangarm64')
 url='https://turbo.build'
 msys2_repository_url='https://github.com/vercel/turborepo'
 license=('spdx:MPL-2.0')
 depends=("${MINGW_PACKAGE_PREFIX}-zstd")
 makedepends=("${MINGW_PACKAGE_PREFIX}-rustup"
              "${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-zig"
              "${MINGW_PACKAGE_PREFIX}-capnproto"
              "${MINGW_PACKAGE_PREFIX}-protobuf"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
@@ -25,7 +26,7 @@ options=('!strip')
 source=("git+${msys2_repository_url}.git#tag=v${pkgver}"
         "zstd-sys.tar.gz::https://static.crates.io/crates/zstd-sys/2.0.16+zstd.1.5.7/download"
         "zstd-sys-remove-statik.patch")
-sha256sums=('0c5489094f95f461b85650146c5321abdca3720b547ce79eb945bdf754688825'
+sha256sums=('eefac175105e19cd7aa242b4cdcabe4b2fab1eeafc734a325483985916d2590d'
             '91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748'
             '48f4900ceb02d3aaf9a1020f33d56629156e96759f456c0e7ca18bfcf910767b')
 
@@ -33,13 +34,9 @@ prepare() {
   cd turborepo
 
   patch -d ../zstd-sys-2.0.16+zstd.1.5.7 -i ../zstd-sys-remove-statik.patch
-  cat >> Cargo.toml <<END
+  sed -i '/\[patch\.crates-io\]/a zstd-sys.path = "../zstd-sys-2.0.16+zstd.1.5.7"' Cargo.toml
 
-[patch.crates-io]
-zstd-sys.path = "../zstd-sys-2.0.16+zstd.1.5.7"
-END
-
-  export RUSTUP_TOOLCHAIN=nightly-2026-02-27-${RUST_CHOST}
+  export RUSTUP_TOOLCHAIN=nightly-2026-04-10-${RUST_CHOST}
   cargo update -p zstd-sys --config='net.git-fetch-with-cli=true'
   cargo fetch --locked --target "${RUST_CHOST}"
 }
@@ -53,7 +50,7 @@ build() {
   # this disables telemetry only at runtime, the relevant code is compiled anyway
   export TURBO_TELEMETRY_DISABLED=1
   export RUSTFLAGS="${RUSTFLAGS/+crt-static/-crt-static}"
-  export RUSTUP_TOOLCHAIN=nightly-2026-02-27-${RUST_CHOST}
+  export RUSTUP_TOOLCHAIN=nightly-2026-04-10-${RUST_CHOST}
   cargo build --frozen --profile release-turborepo -p turbo
 }
 

--- a/mingw-w64-turbo/PKGBUILD
+++ b/mingw-w64-turbo/PKGBUILD
@@ -3,17 +3,18 @@
 _realname=turbo
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.10.0
+pkgver=2.10.9
 pkgrel=1
 pkgdesc="Incremental bundler and build system optimized for JavaScript and TypeScript (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+mingw_arch=('clang64' 'clangarm64')
 url='https://turbo.build'
 msys2_repository_url='https://github.com/vercel/turborepo'
 license=('spdx:MPL-2.0')
 depends=("${MINGW_PACKAGE_PREFIX}-zstd")
 makedepends=("${MINGW_PACKAGE_PREFIX}-rustup"
              "${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-zig"
              "${MINGW_PACKAGE_PREFIX}-capnproto"
              "${MINGW_PACKAGE_PREFIX}-protobuf"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
@@ -25,7 +26,7 @@ options=('!strip')
 source=("git+${msys2_repository_url}.git#tag=v${pkgver}"
         "zstd-sys.tar.gz::https://static.crates.io/crates/zstd-sys/2.0.16+zstd.1.5.7/download"
         "zstd-sys-remove-statik.patch")
-sha256sums=('0c5489094f95f461b85650146c5321abdca3720b547ce79eb945bdf754688825'
+sha256sums=('885fd3df6039800900c290eae3c848ded0edbeb1e771a18e5558cfb78318ae53'
             '91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748'
             '48f4900ceb02d3aaf9a1020f33d56629156e96759f456c0e7ca18bfcf910767b')
 
@@ -33,13 +34,9 @@ prepare() {
   cd turborepo
 
   patch -d ../zstd-sys-2.0.16+zstd.1.5.7 -i ../zstd-sys-remove-statik.patch
-  cat >> Cargo.toml <<END
+  sed -i '/\[patch\.crates-io\]/a zstd-sys.path = "../zstd-sys-2.0.16+zstd.1.5.7"' Cargo.toml
 
-[patch.crates-io]
-zstd-sys.path = "../zstd-sys-2.0.16+zstd.1.5.7"
-END
-
-  export RUSTUP_TOOLCHAIN=nightly-2026-02-27-${RUST_CHOST}
+  export RUSTUP_TOOLCHAIN=nightly-2026-04-10-${RUST_CHOST}
   cargo update -p zstd-sys --config='net.git-fetch-with-cli=true'
   cargo fetch --locked --target "${RUST_CHOST}"
 }
@@ -53,7 +50,7 @@ build() {
   # this disables telemetry only at runtime, the relevant code is compiled anyway
   export TURBO_TELEMETRY_DISABLED=1
   export RUSTFLAGS="${RUSTFLAGS/+crt-static/-crt-static}"
-  export RUSTUP_TOOLCHAIN=nightly-2026-02-27-${RUST_CHOST}
+  export RUSTUP_TOOLCHAIN=nightly-2026-04-10-${RUST_CHOST}
   cargo build --frozen --profile release-turborepo -p turbo
 }
 


### PR DESCRIPTION
requires zig to compile one of crates, so no GCC environments now