### PR TITLE
python-passagemath-msolve: add version 10.8.4 + msolve: add version 0.10.0 (new packages)

### DIFF
--- a/mingw-w64-msolve/PKGBUILD
+++ b/mingw-w64-msolve/PKGBUILD
@@ -1,0 +1,69 @@
+# Maintainer: Dirk Stolle
+
+_realname=msolve
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=0.10.0
+pkgrel=1
+pkgdesc="Library for polynomial system solving through algebraic methods (mingw-w64)"
+arch=('any')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
+url='https://msolve.lip6.fr/'
+msys2_repository_url='https://github.com/algebraic-solving/msolve'
+msys2_references=(
+  'anitya: 368664'
+  'archlinux: msolve'
+)
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
+         "${MINGW_PACKAGE_PREFIX}-flint"
+         "${MINGW_PACKAGE_PREFIX}-gmp"
+         "${MINGW_PACKAGE_PREFIX}-omp")
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+source=("https://msolve.lip6.fr/downloads/v${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('a8faf29307b57bfbd74929fcdf47a34f7d33f4b6dd82e29a160b0f0a1a2a2816')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+
+  # Disable CPU autodetection.
+  sed -e '/AX_EXT/d' -i configure.ac
+
+  autoreconf -fiv
+}
+
+build() {
+  mkdir -p "build-${MSYSTEM}" && cd "build-${MSYSTEM}"
+
+  ../"${_realname}-${pkgver}"/configure \
+    --prefix="${MINGW_PREFIX}" \
+    --build="${MINGW_CHOST}" \
+    --host="${MINGW_CHOST}" \
+    --target="${MINGW_CHOST}" \
+    --enable-static \
+    --enable-shared
+
+  # Fix overlinking (copied from Arch Linux)
+  sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool
+
+  # This is required to build shared libraries with libtool, too.
+  # Otherwise just the static libraries are generated.
+  sed -i 's/allow_undefined=yes/allow_undefined=no/g' libtool
+
+  make
+}
+
+check() {
+  cd "build-${MSYSTEM}"
+
+  make check
+}
+
+package() {
+  cd "build-${MSYSTEM}"
+
+  make install DESTDIR="${pkgdir}"
+
+  install -Dm644 "../${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}

--- a/mingw-w64-passagemath-msolve/PKGBUILD
+++ b/mingw-w64-passagemath-msolve/PKGBUILD
@@ -1,0 +1,55 @@
+# Maintainer: Dirk Stolle
+
+_realname=passagemath-msolve
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=10.8.4
+pkgrel=1
+pkgdesc="passagemath: Polynomial system solving through algebraic methods with msolve (mingw-w64)"
+arch=('any')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/passagemath/passagemath'
+msys2_repository_url='https://github.com/passagemath/passagemath'
+msys2_references=(
+  'purl: pkg:pypi/passagemath-msolve'
+)
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-gmp"
+         "${MINGW_PACKAGE_PREFIX}-mpc"
+         "${MINGW_PACKAGE_PREFIX}-mpfr"
+         "${MINGW_PACKAGE_PREFIX}-msolve"
+         "${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python-cysignals"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-categories"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-flint"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-modules"
+         "${MINGW_PACKAGE_PREFIX}-python-passagemath-repl"
+)
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cython"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-environment"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-objects"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-setup"
+             "${MINGW_PACKAGE_PREFIX}-python-pkgconfig"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
+sha256sums=('3b472946cc9455c5dcddbf44fee3fd73892c4212dd0f1c137fb22773cb750eb7')
+
+build() {
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+}


### PR DESCRIPTION
This adds **python-passagemath-msolve**, a package to provide some functionality from passagemath (<https://github.com/msys2/MINGW-packages/issues/24738>).

It also adds **msolve**, a package for polynomial system solving.

msolve is also available in several other distributions, for example:
* Arch Linux: https://archlinux.org/packages/extra/x86_64/msolve/
* Debian: https://packages.debian.org/trixie/source/msolve
* Fedora: https://packages.fedoraproject.org/pkgs/msolve/