### PR TITLE
calceph: update to 5.0.0

### DIFF
--- a/mingw-w64-calceph/PKGBUILD
+++ b/mingw-w64-calceph/PKGBUILD
@@ -1,12 +1,12 @@
 _realname=calceph
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=4.0.5
-pkgrel=2
+pkgver=5.0.0
+pkgrel=1
 pkgdesc='The CALCEPH Library is designed to access the binary planetary ephemeris files, such INPOPxx and JPL DExxx ephemeris files (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
-url='https://www.imcce.fr/inpop/calceph'
+url='https://calceph.imcce.fr/'
 msys2_repository_url='https://gitlab.obspm.fr/imcce_calceph/calceph'
 license=('spdx:CECILL-C OR CECILL-B OR CECILL-2.1')
 depends=("${MINGW_PACKAGE_PREFIX}-libwinpthread"
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-fc"
 )
 source=("https://www.imcce.fr/content/medias/recherche/equipes/asd/calceph/${_realname}-${pkgver}.tar.gz")
-sha256sums=('3460d8a3e10a86e7fe0228d5d9abcda589713b8ed3ee007ce061ae01f8c2e1ea')
+sha256sums=('aea5120af73f0a492cea2fdc9c63078ee5b625a181cc4f0622ffa68160a2d20b')
 
 build() {
   declare -a extra_config


### PR DESCRIPTION
update the major stable release 5.0.0.
update the new location of the website of calceph