### PR TITLE
elmerfem: disable Zoltan

### DIFF
--- a/mingw-w64-elmerfem/PKGBUILD
+++ b/mingw-w64-elmerfem/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          $([[ "${CARCH}" == "aarch64" ]] || echo "${MINGW_PACKAGE_PREFIX}-${_realname}-mpi"))
 pkgver=26.2.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Finite element software for multiphysical problems (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64')
@@ -26,7 +26,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-arpack"
          "${MINGW_PACKAGE_PREFIX}-qt6-declarative"
          "${MINGW_PACKAGE_PREFIX}-qwt-qt6"
          "${MINGW_PACKAGE_PREFIX}-suitesparse"
-         "${MINGW_PACKAGE_PREFIX}-trilinos"
          "${MINGW_PACKAGE_PREFIX}-unixodbc"
          "${MINGW_PACKAGE_PREFIX}-vtk")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
@@ -94,8 +93,7 @@ build() {
                   "-DWITH_PARAVIEW=ON"
                   "-DWITH_QT6=ON"
                   "-DWITH_VTK=ON"
-                  "-DWITH_Zoltan=ON"
-                  "-DUSE_SYSTEM_ZOLTAN=ON"
+                  "-DWITH_Zoltan=OFF"
                   "-DCREATE_PKGCONFIG_FILE=ON")
 
   if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then


### PR DESCRIPTION
So only depend on the `trilinos` package for the MPI variant.

Beside that point: I tried to run ElmerFEM's test suite using the Zoltan library that is included with the Trilinos package since recently. And that version of Zoltan doesn't seem to play nice with ElmerFEM:
https://github.com/mmuetzel/elmerfem/actions/runs/29006230679/job/86080147930#step:11:3376
```
The following tests FAILED:
	105 - ContactPatch3DZoltan_np4 (Failed)                 n-t parallel partition zoltan
	154 - DirichletNeumannZoltan_np3 (Failed)               parallel partition zoltan
	448 - PartitioningZoltanQuads_np4 (Failed)              mumps parallel zoltan
	599 - Shell_with_Solid_Beam_Par_np3 (Failed)            block mumps parallel shell
	604 - Shell_with_Solid_EigenanalysisPar_np3 (Failed)    block eigen mumps parallel shell
	659 - TEAM30a_3ph_transient_par_np3 (Failed)            harmonic mumps parallel restart
Errors while running CTest
```

@MehdiChinoune: Should we disable Zoltan in ElmerFEM again? Should 731495c7c19ed637ec53609cb37fa27751815eda be reverted?

See also https://github.com/ElmerCSC/elmerfem/issues/780 about the missing Zoltan in the release tarballs of ElmerFEM.
