### PR TITLE
nss: update to 3.125

### DIFF
--- a/mingw-w64-nss/PKGBUILD
+++ b/mingw-w64-nss/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=nss
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.121
+pkgver=3.125
 pkgrel=1
 pkgdesc="Mozilla Network Security Services (mingw-w64)"
 arch=('any')
@@ -20,12 +20,18 @@ msys2_repository_url='https://hg.mozilla.org/projects/nss/'
 msys2_changelog_url='https://firefox-source-docs.mozilla.org/security/nss/releases/index.html'
 url='https://firefox-source-docs.mozilla.org/security/nss/index.html'
 license=('spdx:MPL-2.0')
-depends=("${MINGW_PACKAGE_PREFIX}-nspr"
-         "${MINGW_PACKAGE_PREFIX}-sqlite3"
-         "${MINGW_PACKAGE_PREFIX}-zlib")
-makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-pkgconf"
-             "zip" "perl" "nsinstall")
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-nspr"
+  "${MINGW_PACKAGE_PREFIX}-sqlite3"
+  "${MINGW_PACKAGE_PREFIX}-zlib"
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-pkgconf"
+  "${MINGW_PACKAGE_PREFIX}-perl"
+  'nsinstall'
+  'zip'
+)
 source=(https://ftp.mozilla.org/pub/security/nss/releases/NSS_${pkgver//./_}_RTM/src/${_realname}-${pkgver}.tar.gz
         nss-build.patch
         blank-cert8.db
@@ -33,7 +39,7 @@ source=(https://ftp.mozilla.org/pub/security/nss/releases/NSS_${pkgver//./_}_RTM
         blank-secmod.db
         nss-3.20.1-headers.patch
         nss-3.81-aarch64.patch)
-sha256sums=('cb3a8f8781bea78b7b8edd3afb7a2cb58e4881bb0160d189a39b98216ba7632e'
+sha256sums=('1ad541f10da7c58dec01f540ecc44d28cbbc033f741a57473de5a0893d91606d'
             '39e45367f5bf114ea007b2e8364950e1f77a13b5d0556af61cddf1928f2d34bc'
             'e45105a21696a26c834cfaa3f664c42426c99546094e22fbe3a5e1dd3fbc1f33'
             '6115cab6d646a05dd6b63e21c488da6bc36975f6e5ad8d6371c30a166c41cddc'
@@ -74,18 +80,14 @@ build() {
   export EXTRA_SHARED_LIBS="-lplc4 -lplds4 -lnspr4 -lz -lcrypt32 -lws2_32"
   [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] && {
     export CC_IS_CLANG=1
-  } 
-  local conf64=
-  [[ "$CARCH" = "x86_64" ]] && {
-    conf64="USE_64=1"
+  }
+  declare -a _extra_config
+  [[ "${CARCH}" == "aarch64" ]] && {
+    _extra_config+=("USE_ARM64=1")
   }
 
-  [[ "$CARCH" = "aarch64" ]] && {
-    conf64="USE_64=1 USE_ARM64=1"
-  }
-
-  make -j1 -C nss OS_TARGET=WINNT OS_RELEASE=5.0 XP_WIN=1 \
-    NS_USE_GCC=1 ${conf64} \
+  make -C nss OS_TARGET=WINNT OS_RELEASE=5.0 XP_WIN=1 \
+    NS_USE_GCC=1 USE_64=1 ${_extra_config[@]} \
     NSS_USE_SYSTEM_SQLITE=1 USE_SYSTEM_ZLIB=1 ZLIB_LIBS=${MINGW_PREFIX}/lib/libz.dll.a
 }
 
@@ -137,7 +139,7 @@ package() {
   install -m 644 "${srcdir}"/blank-secmod.db "${pkgdir}"${MINGW_PREFIX}/etc/pki/nssdb/secmod.db
 
   # Copy the development libraries we want
-  for file in libcrmf.dll.a libnssb.dll.a libnssckfw.dll.a libfreebl.dll.a libcryptohi.dll.a libcerthi.dll.a libcertdb.dll.a libsoftokn.dll.a libpkixutil.dll.a
+  for file in libnssb.dll.a libnssckfw.dll.a libfreebl.dll.a libcryptohi.dll.a libcerthi.dll.a libcertdb.dll.a libsoftokn.dll.a libpkixutil.dll.a
   do
     install -m 644 dist/*.OBJ/lib/${file} "${pkgdir}"${MINGW_PREFIX}/lib/
   done


### PR DESCRIPTION
* crmf has been removed by default since 3.124