### PR TITLE
passagemath-bootstrap: add version 10.8.5 (new package)

### DIFF
--- a/mingw-w64-passagemath-bootstrap/PKGBUILD
+++ b/mingw-w64-passagemath-bootstrap/PKGBUILD
@@ -1,0 +1,40 @@
+# Maintainer: Dirk Stolle
+
+_realname=passagemath-bootstrap
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=10.8.5
+pkgrel=1
+pkgdesc="passagemath: Package database (mingw-w64)"
+arch=('any')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/passagemath/passagemath'
+msys2_repository_url='https://github.com/passagemath/passagemath'
+msys2_references=(
+  'purl: pkg:pypi/passagemath-bootstrap'
+)
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-python")
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-python-build"
+  "${MINGW_PACKAGE_PREFIX}-python-installer"
+  "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+)
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
+sha256sums=('ed25cbc13a670e03afe990b6abdfc593053a68e31648a665f81e02bc2ad0ac74')
+
+build() {
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+}


### PR DESCRIPTION
This PR adds python-passagemath-bootstrap, a package to provide some functionality from passagemath (https://github.com/msys2/MINGW-packages/issues/24738). 