### PR TITLE
gcc: split packages like Arch did while preserving upgrades

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -28,24 +28,32 @@ _threads="posix"
 
 _realname=gcc
 pkgbase=mingw-w64-${_realname}
-pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
-         $([[ "$_enable_ada" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-ada")
-         $([[ "$_enable_fortran" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-fortran")
-         "${MINGW_PACKAGE_PREFIX}-${_realname}-libs"
-         $([[ "$_enable_objc" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-objc")
-         $([[ "$_enable_plugin" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-plugin")
-         $([[ "$_enable_rust" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-rust")
-         $([[ "$_enable_jit" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-libgccjit")
-         $([[ "$_enable_fortran" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-libgfortran")
-         $([[ "$_enable_lto" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-lto-dump")
-        )
+pkgname=(
+  "${MINGW_PACKAGE_PREFIX}-cc-libs"
+  "${MINGW_PACKAGE_PREFIX}-gcc"
+  $([[ "$_enable_ada" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-gcc-ada")
+  $([[ "$_enable_fortran" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-gcc-fortran")
+  "${MINGW_PACKAGE_PREFIX}-gcc-libs"
+  $([[ "$_enable_objc" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-gcc-objc")
+  $([[ "$_enable_plugin" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-gcc-plugin")
+  $([[ "$_enable_rust" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-gcc-rust")
+  "${MINGW_PACKAGE_PREFIX}-libatomic"
+  "${MINGW_PACKAGE_PREFIX}-libgcc"
+  $([[ "$_enable_jit" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-libgccjit")
+  $([[ "$_enable_fortran" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-libgfortran")
+  "${MINGW_PACKAGE_PREFIX}-libgomp"
+  $([[ "$_enable_objc" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-libobjc")
+  "${MINGW_PACKAGE_PREFIX}-libquadmath"
+  "${MINGW_PACKAGE_PREFIX}-libstdc++"
+  $([[ "$_enable_lto" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-lto-dump")
+)
 _pkgver=16.2.0
 _rc=""
 _snapshot=
 if [[ -z ${_rc} && -z ${_snapshot} ]]; then
   pkgver=${_pkgver}
-  _sourcedir=${_realname}-${pkgver}
-  _url=https://ftp.gnu.org/gnu/gcc/${_realname}-${pkgver}
+  _sourcedir=gcc-${pkgver}
+  _url=https://ftp.gnu.org/gnu/gcc/gcc-${pkgver}
 else
   pkgver=${_pkgver%%.*}.0.1
   if [[ -z ${_rc} ]]; then
@@ -53,11 +61,11 @@ else
   else
     _version=${_pkgver}-${_rc}
   fi
-  _sourcedir=${_realname}-${_version}-${_snapshot}
+  _sourcedir=gcc-${_version}-${_snapshot}
   _url=https://gcc.gnu.org/pub/gcc/snapshots/${_version}-${_snapshot}
 fi
 _libdir=lib/gcc/${CHOST}/${pkgver}
-pkgrel=3
+pkgrel=4
 pkgdesc="The GNU Compiler Collection (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -66,27 +74,28 @@ msys2_repository_url='https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git'
 msys2_references=(
   "cpe: cpe:/a:gnu:gcc"
 )
-license=('spdx:GPL-3.0-or-later')
-makedepends=("${MINGW_PACKAGE_PREFIX}-${_realname}"
-             $([[ "$_enable_ada" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-${_realname}-ada")
-             $([[ "$_enable_rust" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-rust")
-             "${MINGW_PACKAGE_PREFIX}-autotools"
-             "${MINGW_PACKAGE_PREFIX}-binutils"
-             "${MINGW_PACKAGE_PREFIX}-crt"
-             "${MINGW_PACKAGE_PREFIX}-headers"
-             "${MINGW_PACKAGE_PREFIX}-gmp"
-             "${MINGW_PACKAGE_PREFIX}-gperf"
-             "${MINGW_PACKAGE_PREFIX}-isl"
-             "${MINGW_PACKAGE_PREFIX}-libiconv"
-             "${MINGW_PACKAGE_PREFIX}-mpc"
-             "${MINGW_PACKAGE_PREFIX}-mpfr"
-             "${MINGW_PACKAGE_PREFIX}-python"
-             "${MINGW_PACKAGE_PREFIX}-texinfo"
-             "${MINGW_PACKAGE_PREFIX}-windows-default-manifest"
-             "${MINGW_PACKAGE_PREFIX}-winpthreads"
-             "${MINGW_PACKAGE_PREFIX}-zlib"
-             "${MINGW_PACKAGE_PREFIX}-zstd")
-options=('!emptydirs') # '!strip' 'debug')
+license=('spdx:GPL-3.0-or-later WITH GCC-exception-3.1 AND GFDL-1.3-or-later')
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-gcc"
+  $([[ "$_enable_ada" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-gcc-ada")
+  $([[ "$_enable_rust" == "yes" ]] && echo "${MINGW_PACKAGE_PREFIX}-gcc-rust")
+  "${MINGW_PACKAGE_PREFIX}-autotools"
+  "${MINGW_PACKAGE_PREFIX}-binutils"
+  "${MINGW_PACKAGE_PREFIX}-crt"
+  "${MINGW_PACKAGE_PREFIX}-headers"
+  "${MINGW_PACKAGE_PREFIX}-gmp"
+  "${MINGW_PACKAGE_PREFIX}-isl"
+  "${MINGW_PACKAGE_PREFIX}-libiconv"
+  "${MINGW_PACKAGE_PREFIX}-mpc"
+  "${MINGW_PACKAGE_PREFIX}-mpfr"
+  "${MINGW_PACKAGE_PREFIX}-python"
+  "${MINGW_PACKAGE_PREFIX}-texinfo"
+  "${MINGW_PACKAGE_PREFIX}-windows-default-manifest"
+  "${MINGW_PACKAGE_PREFIX}-winpthreads"
+  "${MINGW_PACKAGE_PREFIX}-zlib"
+  "${MINGW_PACKAGE_PREFIX}-zstd"
+)
+options=('!emptydirs')
 source=(${_url}/${_sourcedir}.tar.xz{,.sig}
         "gdbinit"
         0002-i386-Keep-SEH-enabled-for-Win64-sysv_abi-functions.patch
@@ -137,15 +146,6 @@ apply_patch_with_msg() {
   do
     msg2 "Applying ${_patch}"
     patch -Nbp1 -i "${srcdir}/${_patch}"
-  done
-}
-
-del_file_exists() {
-  for _fname in "$@"
-  do
-    if [ -f ${_fname} ]; then
-      rm -rf ${_fname}
-    fi
   done
 }
 # =========================================== #
@@ -331,288 +331,408 @@ build() {
             profiledbootstrap
 }
 
-package_gcc-libs() {
-  pkgdesc="GNU Compiler Collection (libraries) for MinGW-w64"
-  depends=("${MINGW_PACKAGE_PREFIX}-libwinpthread" "${MINGW_PACKAGE_PREFIX}-tzdata")
-  provides=("${MINGW_PACKAGE_PREFIX}-omp" "${MINGW_PACKAGE_PREFIX}-cc-libs")
-
-  # Licensing information
-
-  # Part of the package is GCCRLE, part is LGPL-2.1-or-later, see README generation below.
-  # Since the packaged GCCRLE libraries are also spdx:GPL-3.0-or-later,
-  # and LGPL-2.1-or-later is compatible with GPL-3.0-or-later, the whole package can
-  # be redistributed under GPL-3.0-or-later.
-  license=('spdx:GPL-3.0-or-later WITH GCC-exception-3.1 AND LGPL-2.1-or-later')
-
-  cd "${srcdir}"/build-${MSYSTEM}
-
-  make -C $CHOST/libgcc DESTDIR="${pkgdir}" install-shared
-  install -dm755 "${pkgdir}"${MINGW_PREFIX}/bin
-  mv "${pkgdir}"/libgcc_*.dll "${pkgdir}"${MINGW_PREFIX}/bin/
-
-  # libitm* and libvtv* are disbled until fixed
-  for lib in libatomic libgomp libquadmath libstdc++-v3/src; do
-    make -C $CHOST/$lib DESTDIR="${pkgdir}" install-toolexeclibLTLIBRARIES
+_pick() {
+  local p="$1" f d; shift
+  for f; do
+    d="$srcdir/$p/${f#${pkgdir}/}"
+    mkdir -vp "$(dirname "$d")"
+    mv -v "$f" "$d"
+    rmdir -vp --ignore-fail-on-non-empty "$(dirname "$f")"
   done
+}
 
-  rm -r "${pkgdir}"${MINGW_PREFIX}/lib
+_install() {
+  mkdir -p "${pkgdir}${MINGW_PREFIX}"
+  mv -v "${pkgname#${MINGW_PACKAGE_PREFIX}-}"/* "${pkgdir}${MINGW_PREFIX}"
+}
 
-  make -C $CHOST/libstdc++-v3/po DESTDIR="${pkgdir}" install
+_install_GPL3() {
+  install -Dm644 "$srcdir/${_sourcedir}/COPYING3" \
+    "${pkgdir}${MINGW_PREFIX}/share/licenses/${pkgname#${MINGW_PACKAGE_PREFIX}-}/COPYING3"
+}
 
-  # We explain the licensing in this generated README file
-  mkdir -p "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}-libs
-  cat << ENDFILE > "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}-libs/README
-The libgcc, libstdc++, libgomp and libatomic libraries are covered by
-GPL-3.0-or-later with GCC-exception-3.1. The libquadmath library is covered
-by LGPL-2.1-or-later. The package as a whole can be redistributed under GPL-3.0-or-later.
-ENDFILE
+_install_RLE() {
+  _install_GPL3 # RLE must come with GPL3
+  install -Dm644 "$srcdir/${_sourcedir}/COPYING.RUNTIME" \
+    "${pkgdir}${MINGW_PREFIX}/share/licenses/${pkgname#${MINGW_PACKAGE_PREFIX}-}/COPYING.RUNTIME"
+}
 
-  # License files
-  install -Dm644 "${srcdir}"/${_sourcedir}/COPYING3        "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}-libs/COPYING3
-  install -Dm644 "${srcdir}"/${_sourcedir}/COPYING.LIB     "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}-libs/COPYING.LIB
-  install -Dm644 "${srcdir}"/${_sourcedir}/COPYING.RUNTIME "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}-libs/COPYING.RUNTIME
+# TODO: move libatomic and libquadmath to gcc-libs
+package_cc-libs() {
+  pkgdesc="C++ Standard Library (mingw-w64)"
+  depends=(
+    "${MINGW_PACKAGE_PREFIX}-libatomic=${pkgver}-${pkgrel}"
+    "${MINGW_PACKAGE_PREFIX}-libgcc=${pkgver}-${pkgrel}"
+    "${MINGW_PACKAGE_PREFIX}-libstdc++=${pkgver}-${pkgrel}"
+    "${MINGW_PACKAGE_PREFIX}-libquadmath=${pkgver}-${pkgrel}"
+  )
 }
 
 package_gcc() {
-  pkgdesc="GNU Compiler Collection (C,C++,OpenMP) for MinGW-w64"
-  depends=("${MINGW_PACKAGE_PREFIX}-binutils"
-           "${MINGW_PACKAGE_PREFIX}-crt"
-           "${MINGW_PACKAGE_PREFIX}-headers"
-           "${MINGW_PACKAGE_PREFIX}-isl"
-           "${MINGW_PACKAGE_PREFIX}-gmp"
-           "${MINGW_PACKAGE_PREFIX}-mpfr"
-           "${MINGW_PACKAGE_PREFIX}-mpc"
-           "${MINGW_PACKAGE_PREFIX}-${_realname}-libs=${pkgver}-${pkgrel}"
-           "${MINGW_PACKAGE_PREFIX}-windows-default-manifest"
-           "${MINGW_PACKAGE_PREFIX}-winpthreads"
-           "${MINGW_PACKAGE_PREFIX}-zlib"
-           "${MINGW_PACKAGE_PREFIX}-zstd")
-  provides=("${MINGW_PACKAGE_PREFIX}-${_realname}-base"
-            "${MINGW_PACKAGE_PREFIX}-cc")
-  conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-base"
-             $([[ "$_enable_objc" == "yes" ]] || echo "${MINGW_PACKAGE_PREFIX}-${_realname}-objc")
-             $([[ "$_enable_ada" == "yes" ]] || echo "${MINGW_PACKAGE_PREFIX}-${_realname}-ada")
-             $([[ "$_enable_rust" == "yes" ]] || echo "${MINGW_PACKAGE_PREFIX}-${_realname}-rust")
-             $([[ "$_enable_plugin" == "yes" ]] || echo "${MINGW_PACKAGE_PREFIX}-${_realname}-plugin")
-             $([[ "$_enable_jit" == "yes" ]] || echo "${MINGW_PACKAGE_PREFIX}-libgccjit")
-             $([[ "$_enable_fortran" == "yes" ]] || echo \
-               "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran" \
-               "${MINGW_PACKAGE_PREFIX}-gcc-fortran")
+  pkgdesc="The GNU Compiler Collection - C and C++ frontends (mingw-w64)"
+  depends=(
+    "${MINGW_PACKAGE_PREFIX}-binutils"
+    "${MINGW_PACKAGE_PREFIX}-crt"
+    "${MINGW_PACKAGE_PREFIX}-headers"
+    "${MINGW_PACKAGE_PREFIX}-isl"
+    "${MINGW_PACKAGE_PREFIX}-gmp"
+    "${MINGW_PACKAGE_PREFIX}-mpfr"
+    "${MINGW_PACKAGE_PREFIX}-mpc"
+    "${MINGW_PACKAGE_PREFIX}-libgcc=${pkgver}-${pkgrel}"
+    "${MINGW_PACKAGE_PREFIX}-libstdc++=${pkgver}-${pkgrel}"
+    "${MINGW_PACKAGE_PREFIX}-windows-default-manifest"
+    "${MINGW_PACKAGE_PREFIX}-winpthreads"
+    "${MINGW_PACKAGE_PREFIX}-zlib"
+    "${MINGW_PACKAGE_PREFIX}-zstd"
+  )
+  optdepends=(
+    "${MINGW_PACKAGE_PREFIX}-libatomic"
+    "${MINGW_PACKAGE_PREFIX}-libgomp: OpenMP"
+    "${MINGW_PACKAGE_PREFIX}-libquadmath: Quad Math"
+  )
+  provides=("${MINGW_PACKAGE_PREFIX}-cc")
+  conflicts=(
+    $([[ "$_enable_ada" == "yes" ]] || echo "${MINGW_PACKAGE_PREFIX}-gcc-ada")
+    $([[ "$_enable_fortran" == "yes" ]] || echo \
+      "${MINGW_PACKAGE_PREFIX}-gcc-fortran" \
+      "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran" \
+      "${MINGW_PACKAGE_PREFIX}-libgfortran")
+    $([[ "$_enable_jit" == "yes" ]] || echo "${MINGW_PACKAGE_PREFIX}-libgccjit")
+    $([[ "$_enable_lto" == "yes" ]] || echo \
+      "${MINGW_PACKAGE_PREFIX}-gcc-lto-dump" \
+      "${MINGW_PACKAGE_PREFIX}-lto-dump")
+    $([[ "$_enable_objc" == "yes" ]] || echo "${MINGW_PACKAGE_PREFIX}-gcc-objc")
+    $([[ "$_enable_plugin" == "yes" ]] || echo "${MINGW_PACKAGE_PREFIX}-gcc-plugin")
+    $([[ "$_enable_rust" == "yes" ]] || echo "${MINGW_PACKAGE_PREFIX}-gcc-rust")
   )
   groups=("${MINGW_PACKAGE_PREFIX}-toolchain")
 
-  cd "${srcdir}"/build-${MSYSTEM}
+  cd build-${MSYSTEM}
 
-  make -C gcc DESTDIR="${pkgdir}" install-driver install-cpp install-gcc-ar \
-    c++.install-common install-headers install-lto-wrapper
+  make DESTDIR="${pkgdir}" install
 
-  make -C c++tools DESTDIR="${pkgdir}" install
+  (
+    cd "${pkgdir}${MINGW_PREFIX}"
 
-  install -m755 -t "${pkgdir}"${MINGW_PREFIX}/bin/ gcc/gcov{,-tool}.exe
-  install -m755 -t "${pkgdir}"${MINGW_PREFIX}/${_libdir}/ \
-    gcc/{cc1,cc1plus,collect2}.exe
+    if [[ "$_enable_ada" == "yes" ]]; then
+      _pick gcc-ada bin/gnat{,bind,chop,clean,dll,kr,link,ls,make,name,prep}.exe
+      _pick gcc-ada ${_libdir}/ada_target_properties
+      _pick gcc-ada ${_libdir}/ada{include,lib}/
+      _pick gcc-ada ${_libdir}/gnat1.exe
+      _pick gcc-ada share/info/gnat{-style,_rm,_ugn}.info
+    fi
 
-  make -C $CHOST/libgcc DESTDIR="${pkgdir}" install
-  rm "${pkgdir}"/libgcc_*.dll
+    if [[ "$_enable_fortran" == "yes" ]]; then
+      _pick gcc-fortran bin/{$CHOST-,}gfortran.exe
+      _pick gcc-fortran ${_libdir}/finclude/
+      _pick gcc-fortran ${_libdir}/libcaf_{shmem,single}.a
+      _pick gcc-fortran ${_libdir}/f951.exe
+      _pick gcc-fortran ${_libdir}/include/ISO_Fortran_binding.h
+      _pick gcc-fortran lib/libgfortran.spec
+      _pick gcc-fortran share/info/gfortran.info
+      _pick gcc-fortran share/man/man1/gfortran.1
+    fi
 
-  make -C $CHOST/libstdc++-v3/src DESTDIR="${pkgdir}" install
-  make -C $CHOST/libstdc++-v3/include DESTDIR="${pkgdir}" install
-  make -C $CHOST/libstdc++-v3/libsupc++ DESTDIR="${pkgdir}" install
-  make -C $CHOST/libstdc++-v3/python DESTDIR="${pkgdir}" install
-  make DESTDIR="${pkgdir}" install-libcc1
-  rm "${pkgdir}"${MINGW_PREFIX}/bin/libstdc++*.dll
+    if [[ "$_enable_objc" == "yes" ]]; then
+      _pick gcc-objc ${_libdir}/include/objc/
+      _pick gcc-objc ${_libdir}/cc1obj*
+    fi
 
-  for lib in libatomic libgomp libquadmath; do
-    make -C $CHOST/$lib DESTDIR="${pkgdir}" install
-    rm "${pkgdir}"${MINGW_PREFIX}/bin/${lib}*.dll
-  done
+    if [[ "$_enable_plugin" == "yes" ]]; then
+      _pick gcc-plugin ${_libdir}/plugin/
+    fi
 
-  # install -d "${pkgdir}"${MINGW_PREFIX}/share/gdb/auto-load/usr/lib
-  # mv "${pkgdir}"${MINGW_PREFIX}/lib/libstdc++.dll.a-gdb.py \
-  #   "${pkgdir}"${MINGW_PREFIX}/share/gdb/auto-load/usr/lib/
+    if [[ "$_enable_rust" == "yes" ]]; then
+      _pick gcc-rust bin/{$CHOST-,}gccrs.exe
+      _pick gcc-rust ${_libdir}/crab1.exe
+    fi
 
-  make DESTDIR="${pkgdir}" install-fixincludes
-  make -C gcc DESTDIR="${pkgdir}" install-mkheaders
+    # Note: static libraries and import libraries of core runtime libraries (lib{atomic,gcc,quadmath,stdc++})
+    # are currently packed into gcc to keep them as small as possible.
+    _pick libatomic bin/libatomic*
 
-  make -C $CHOST/libgomp DESTDIR="${pkgdir}" install-nodist_{libsubinclude,toolexeclib}HEADERS
-  make -C $CHOST/libquadmath DESTDIR="${pkgdir}" install-nodist_libsubincludeHEADERS
+    _pick libgcc bin/libgcc_s*
 
-  make -C gcc DESTDIR="${pkgdir}" install-man install-info
-  if [ "$_enable_ada" == "yes" ]; then
-    rm "${pkgdir}"${MINGW_PREFIX}/share/info/{gnat-style,gnat_rm,gnat_ugn}.info
-  fi
-  if [[ "$_enable_fortran" == yes ]]; then
-    rm -r "${pkgdir}"${MINGW_PREFIX}/${_libdir}/finclude
-    rm "${pkgdir}"${MINGW_PREFIX}/share/man/man1/gfortran.1
-    rm "${pkgdir}"${MINGW_PREFIX}/share/info/gfortran.info
-  fi
-  if [ "$_enable_jit" == "yes" ]; then
-    rm "${pkgdir}"${MINGW_PREFIX}/share/info/libgccjit.info
-  fi
-  if [[ "$_enable_lto" == yes ]]; then
-    make -C gcc DESTDIR="${pkgdir}" install-lto-wrapper
-    install -m755 -t "${pkgdir}"${MINGW_PREFIX}/${_libdir}/ gcc/lto1.exe
-    make -C lto-plugin DESTDIR="${pkgdir}" install
+    if [[ "$_enable_jit" == "yes" ]]; then
+      _pick libgccjit bin/libgccjit*
+      _pick libgccjit include/libgccjit*
+      _pick libgccjit lib/libgccjit.dll.a
+      _pick libgccjit share/info/libgccjit.info
+    fi
+
+    if [[ "$_enable_fortran" == "yes" ]]; then
+      _pick libgfortran bin/libgfortran*
+      _pick libgfortran lib/libgfortran{.dll,}.a
+    fi
+
+    _pick libgomp bin/libgomp*
+    _pick libgomp lib/libgomp{.dll,}.a
+    _pick libgomp share/info/libgomp.info
+
+    if [[ "$_enable_objc" == "yes" ]]; then
+      _pick libobjc bin/libobjc*
+      _pick libobjc lib/libobjc{.dll,}.a
+    fi
+
+    _pick libquadmath bin/libquadmath*
+
+    _pick libstdc++ bin/libstdc++*
+
+    if [[ "$_enable_lto" == "yes" ]]; then
+      _pick lto-dump bin/lto-dump.exe
+      _pick lto-dump share/man/man1/lto-dump.1
+    fi
+  )
+
+  if [[ "$_enable_lto" == "yes" ]]; then
     install -dm755 "${pkgdir}"${MINGW_PREFIX}/lib/bfd-plugins/
-    cp "${pkgdir}"${MINGW_PREFIX}/${_libdir}/liblto_plugin.dll "${pkgdir}"${MINGW_PREFIX}/lib/bfd-plugins/
-    rm "${pkgdir}"${MINGW_PREFIX}/share/man/man1/lto-dump.1
+    ln -v "${pkgdir}"${MINGW_PREFIX}/${_libdir}/liblto_plugin.dll "${pkgdir}"${MINGW_PREFIX}/lib/bfd-plugins/
   fi
 
-  make -C libcpp DESTDIR="${pkgdir}" install
-  make -C gcc DESTDIR="${pkgdir}" install-po
+  # Note: GDB doesn't treat ${MINGW_PREFIX}/bin as a safe path by default, may need patching later.
+  # Have to install besides the real dll instead of in share/gdb/auto-load as gdb uses the whole Windows path
+  # to search for auto-load scripts.
+  mv -v "${pkgdir}"${MINGW_PREFIX}/lib/libstdc++.dll.a-gdb.py \
+    "${pkgdir}"${MINGW_PREFIX}/bin/libstdc++-6.dll-gdb.py
 
+  # install the libstdc++ man pages, requires doxygen
   # make -C $CHOST/libstdc++-v3/doc DESTDIR="${pkgdir}" doc-install-man
 
-  cp "${pkgdir}"${MINGW_PREFIX}/bin/gcc.exe "${pkgdir}"${MINGW_PREFIX}/bin/cc.exe
-  cp "${pkgdir}"${MINGW_PREFIX}/bin/gcc.exe "${pkgdir}"${MINGW_PREFIX}/bin/${CHOST}-cc.exe
+  # Hardlink
+  ln -v "${pkgdir}"${MINGW_PREFIX}/bin/gcc.exe "${pkgdir}"${MINGW_PREFIX}/bin/cc.exe
+  ln -v "${pkgdir}"${MINGW_PREFIX}/bin/gcc.exe "${pkgdir}"${MINGW_PREFIX}/bin/${CHOST}-cc.exe
 
   # install "custom" system gdbinit
-  install -D -m644 "${srcdir}"/gdbinit "${pkgdir}"${MINGW_PREFIX}/etc/gdbinit
+  install -Dm644 "${srcdir}"/gdbinit "${pkgdir}"${MINGW_PREFIX}/etc/gdbinit
   sed -i 's|%GCC_NAME%|gcc-'${pkgver}'|g' "${pkgdir}"${MINGW_PREFIX}/etc/gdbinit
 
   # byte-compile python libraries
-  ${MINGW_PREFIX}/bin/python -m compileall -o 0 -o 1 "${pkgdir}"${MINGW_PREFIX}/share/gcc-${pkgver}/
-}
+  python -m compileall -o 0 -o 1 "${pkgdir}"${MINGW_PREFIX}/share/gcc-${pkgver}/
 
-package_gcc-libgfortran() {
-  pkgdesc="GNU Compiler Collection (libgfortran) for MinGW-w64"
-  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}-libs=${pkgver}-${pkgrel}"
-           "${MINGW_PACKAGE_PREFIX}-libwinpthread")
-  provides=("${MINGW_PACKAGE_PREFIX}-fc-libs")
-
-  cd "${srcdir}"/build-${MSYSTEM}
-  make -C $CHOST/libgfortran DESTDIR="${pkgdir}" install-toolexeclibLTLIBRARIES
-  rm -r "${pkgdir}"${MINGW_PREFIX}/lib
-
-  install -Dm644 "${srcdir}"/${_sourcedir}/COPYING.RUNTIME \
-    "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}-libgfortran/COPYING.RUNTIME
-}
-
-package_gcc-fortran() {
-  pkgdesc="GNU Compiler Collection (Fortran) for MinGW-w64"
-  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}-${pkgrel}"
-           "${MINGW_PACKAGE_PREFIX}-${_realname}-libgfortran=${pkgver}-${pkgrel}"
-           "${MINGW_PACKAGE_PREFIX}-${_realname}-libs=${pkgver}-${pkgrel}"
-           "${MINGW_PACKAGE_PREFIX}-gmp"
-           "${MINGW_PACKAGE_PREFIX}-isl"
-           "${MINGW_PACKAGE_PREFIX}-libwinpthread"
-           "${MINGW_PACKAGE_PREFIX}-mpc"
-           "${MINGW_PACKAGE_PREFIX}-mpfr"
-           "${MINGW_PACKAGE_PREFIX}-zlib"
-           "${MINGW_PACKAGE_PREFIX}-zstd")
-  provides=("${MINGW_PACKAGE_PREFIX}-fc")
-
-  cd "${srcdir}"/build-${MSYSTEM}
-
-  make -C $CHOST/libgfortran DESTDIR="${pkgdir}" install
-  rm "${pkgdir}"${MINGW_PREFIX}/bin/libgfortran*.dll
-  make -C $CHOST/libgomp DESTDIR="${pkgdir}" install-nodist_fincludeHEADERS
-  make -C gcc DESTDIR="${pkgdir}" fortran.install-{common,man,info}
-  install -Dm755 gcc/f951.exe "${pkgdir}"${MINGW_PREFIX}/${_libdir}/f951.exe
+  _install_RLE
 }
 
 package_gcc-ada() {
-  pkgdesc="GNU Compiler Collection (Ada) for MinGW-w64"
-  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}-${pkgrel}"
-           "${MINGW_PACKAGE_PREFIX}-${_realname}-libs=${pkgver}-${pkgrel}"
-           "${MINGW_PACKAGE_PREFIX}-gmp"
-           "${MINGW_PACKAGE_PREFIX}-isl"
-           "${MINGW_PACKAGE_PREFIX}-libwinpthread"
-           "${MINGW_PACKAGE_PREFIX}-mpc"
-           "${MINGW_PACKAGE_PREFIX}-mpfr"
-           "${MINGW_PACKAGE_PREFIX}-zlib"
-           "${MINGW_PACKAGE_PREFIX}-zstd")
+  pkgdesc="Ada frontend for GCC (GNAT) (mingw-w64)"
+  depends=(
+    "${MINGW_PACKAGE_PREFIX}-gcc=${pkgver}-${pkgrel}"
+    "${MINGW_PACKAGE_PREFIX}-gmp"
+    "${MINGW_PACKAGE_PREFIX}-isl"
+    "${MINGW_PACKAGE_PREFIX}-libgcc=${pkgver}-${pkgrel}"
+    "${MINGW_PACKAGE_PREFIX}-libwinpthread"
+    "${MINGW_PACKAGE_PREFIX}-mpc"
+    "${MINGW_PACKAGE_PREFIX}-mpfr"
+    "${MINGW_PACKAGE_PREFIX}-zlib"
+    "${MINGW_PACKAGE_PREFIX}-zstd"
+  )
 
-  cd "${srcdir}"/build-${MSYSTEM}
+  _install
+  mv -v "${pkgdir}"${MINGW_PREFIX}/${_libdir}/adalib/*.dll "${pkgdir}"${MINGW_PREFIX}/bin/
+  _install_RLE
+}
 
-  make -C gcc DESTDIR="${pkgdir}" ada.install-{common,info} install-gnatlib
-  mv "${pkgdir}"${MINGW_PREFIX}/${_libdir}/adalib/*.dll "${pkgdir}"${MINGW_PREFIX}/bin/
-  install -m755 gcc/gnat1.exe "${pkgdir}"${MINGW_PREFIX}/${_libdir}
+package_gcc-fortran() {
+  pkgdesc="Fortran frontend for GCC (mingw-w64)"
+  depends=(
+    "${MINGW_PACKAGE_PREFIX}-gcc=${pkgver}-${pkgrel}"
+    "${MINGW_PACKAGE_PREFIX}-gmp"
+    "${MINGW_PACKAGE_PREFIX}-isl"
+    "${MINGW_PACKAGE_PREFIX}-libgfortran=${pkgver}-${pkgrel}"
+    "${MINGW_PACKAGE_PREFIX}-libwinpthread"
+    "${MINGW_PACKAGE_PREFIX}-mpc"
+    "${MINGW_PACKAGE_PREFIX}-mpfr"
+    "${MINGW_PACKAGE_PREFIX}-zlib"
+    "${MINGW_PACKAGE_PREFIX}-zstd"
+  )
+  optdepends=("${MINGW_PACKAGE_PREFIX}-libgomp: OpenMP")
+  provides=("${MINGW_PACKAGE_PREFIX}-fc")
+  license=('spdx:GPL-3.0-or-later')
+
+  _install
+  mv -v "${pkgdir}"${MINGW_PREFIX}/lib/libgfortran.spec "${pkgdir}"${MINGW_PREFIX}/${_libdir}/
+  _install_RLE
+}
+
+# TODO: depends on all gcc libraries like Arch
+package_gcc-libs() {
+  pkgdesc="Runtime libraries shipped by GCC (mingw-w64)"
+  depends=(
+    "${MINGW_PACKAGE_PREFIX}-cc-libs=${pkgver}-${pkgrel}"
+    "${MINGW_PACKAGE_PREFIX}-libgomp=${pkgver}-${pkgrel}"
+    # "${MINGW_PACKAGE_PREFIX}-libgfortran=${pkgver}-${pkgrel}"
+    # "${MINGW_PACKAGE_PREFIX}-libobjc=${pkgver}-${pkgrel}"
+  )
 }
 
 package_gcc-objc() {
-  pkgdesc="GNU Compiler Collection (ObjC,Obj-C++) for MinGW-w64"
-  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}-${pkgrel}"
-           "${MINGW_PACKAGE_PREFIX}-${_realname}-libs=${pkgver}-${pkgrel}"
-           "${MINGW_PACKAGE_PREFIX}-gmp"
-           "${MINGW_PACKAGE_PREFIX}-isl"
-           "${MINGW_PACKAGE_PREFIX}-libwinpthread"
-           "${MINGW_PACKAGE_PREFIX}-mpc"
-           "${MINGW_PACKAGE_PREFIX}-mpfr"
-           "${MINGW_PACKAGE_PREFIX}-zlib"
-           "${MINGW_PACKAGE_PREFIX}-zstd")
+  pkgdesc="Objective-C frontend for GCC (mingw-w64)"
+  depends=(
+    "${MINGW_PACKAGE_PREFIX}-gcc=${pkgver}-${pkgrel}"
+    "${MINGW_PACKAGE_PREFIX}-gmp"
+    "${MINGW_PACKAGE_PREFIX}-isl"
+    "${MINGW_PACKAGE_PREFIX}-libobjc=${pkgver}-${pkgrel}"
+    "${MINGW_PACKAGE_PREFIX}-libwinpthread"
+    "${MINGW_PACKAGE_PREFIX}-mpc"
+    "${MINGW_PACKAGE_PREFIX}-mpfr"
+    "${MINGW_PACKAGE_PREFIX}-zlib"
+    "${MINGW_PACKAGE_PREFIX}-zstd"
+  )
+  license=('spdx:GPL-3.0-or-later')
 
-  cd "${srcdir}"/build-${MSYSTEM}
-
-  make -C $CHOST/libobjc DESTDIR="${pkgdir}" install-libs
-  make -C $CHOST/libobjc DESTDIR="${pkgdir}" install-headers
-  install -dm755 "${pkgdir}"${MINGW_PREFIX}/${_libdir}
-  install -m755 gcc/cc1obj{,plus}.exe "${pkgdir}"${MINGW_PREFIX}/${_libdir}/
-
-  install -Dm644 "${srcdir}/${_sourcedir}/COPYING.RUNTIME" \
-    "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}-objc/COPYING.RUNTIME
+  _install
+  _install_RLE
 }
 
 package_gcc-plugin() {
-  pkgdesc="GNU Compiler Collection (plugin) for MinGW-w64"
-  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}-${pkgrel}")
-  conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}<16.1.0-7")
+  pkgdesc="Plugin support for GCC (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-gcc=${pkgver}-${pkgrel}")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-gcc<16.1.0-7")
 
-  cd "${srcdir}"/build-${MSYSTEM}
-
-  make -C gcc DESTDIR="${pkgdir}" install-plugin
+  _install
+  _install_RLE
 }
 
 package_gcc-rust() {
-  pkgdesc="GNU Compiler Collection (Rust) for MinGW-w64"
-  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}-${pkgrel}"
-           "${MINGW_PACKAGE_PREFIX}-${_realname}-libs=${pkgver}-${pkgrel}"
-           "${MINGW_PACKAGE_PREFIX}-gmp"
-           "${MINGW_PACKAGE_PREFIX}-isl"
-           "${MINGW_PACKAGE_PREFIX}-libwinpthread"
-           "${MINGW_PACKAGE_PREFIX}-mpc"
-           "${MINGW_PACKAGE_PREFIX}-mpfr"
-           "${MINGW_PACKAGE_PREFIX}-zlib"
-           "${MINGW_PACKAGE_PREFIX}-zstd")
+  pkgdesc="Rust frontend for GCC (mingw-w64)"
+  depends=(
+    "${MINGW_PACKAGE_PREFIX}-gcc=${pkgver}-${pkgrel}"
+    "${MINGW_PACKAGE_PREFIX}-gmp"
+    "${MINGW_PACKAGE_PREFIX}-isl"
+    "${MINGW_PACKAGE_PREFIX}-libwinpthread"
+    "${MINGW_PACKAGE_PREFIX}-mpc"
+    "${MINGW_PACKAGE_PREFIX}-mpfr"
+    "${MINGW_PACKAGE_PREFIX}-zlib"
+    "${MINGW_PACKAGE_PREFIX}-zstd"
+  )
+  license=('spdx:GPL-3.0-or-later')
 
-  cd "${srcdir}"/build-${MSYSTEM}
-
-  make -C gcc DESTDIR="${pkgdir}" rust.install-{common,man,info}
-  install -Dm755 gcc/crab1.exe "${pkgdir}"${MINGW_PREFIX}/${_libdir}/crab1.exe
+  _install
+  _install_GPL3
 }
 
-package_gcc-lto-dump() {
-  pkgdesc="Dump link time optimization object files (mingw-w64)"
-  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}=$pkgver-$pkgrel"
-           "${MINGW_PACKAGE_PREFIX}-${_realname}-libs=${pkgver}-${pkgrel}"
-           "${MINGW_PACKAGE_PREFIX}-gmp"
-           "${MINGW_PACKAGE_PREFIX}-isl"
-           "${MINGW_PACKAGE_PREFIX}-libwinpthread"
-           "${MINGW_PACKAGE_PREFIX}-mpc"
-           "${MINGW_PACKAGE_PREFIX}-mpfr"
-           "${MINGW_PACKAGE_PREFIX}-zlib"
-           "${MINGW_PACKAGE_PREFIX}-zstd")
+package_libatomic() {
+  pkgdesc="GNU Atomic library shipped by GCC (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-libwinpthread")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-gcc-libs<16.2.0-4")
 
-  cd "${srcdir}"/build-${MSYSTEM}
+  _install
+  _install_RLE
+}
 
-  make -C gcc DESTDIR="${pkgdir}" lto.install-{common,man,info}
+package_libgcc() {
+  pkgdesc="Low-level runtime library shipped by GCC (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-libwinpthread")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-gcc-libs<16.2.0-4")
+
+  _install
+  _install_RLE
 }
 
 package_libgccjit() {
-  pkgdesc="GNU Compiler Collection (libgccjit) for MinGW-w64"
-  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}-${pkgrel}"
-           "${MINGW_PACKAGE_PREFIX}-${_realname}-libs=${pkgver}-${pkgrel}"
-           "${MINGW_PACKAGE_PREFIX}-gmp"
-           "${MINGW_PACKAGE_PREFIX}-isl"
-           "${MINGW_PACKAGE_PREFIX}-libwinpthread"
-           "${MINGW_PACKAGE_PREFIX}-mpc"
-           "${MINGW_PACKAGE_PREFIX}-mpfr"
-           "${MINGW_PACKAGE_PREFIX}-zlib"
-           "${MINGW_PACKAGE_PREFIX}-zstd")
+  pkgdesc="Just-In-Time Compilation with GCC backend (mingw-w64)"
+  depends=(
+    "${MINGW_PACKAGE_PREFIX}-gcc=${pkgver}-${pkgrel}"
+    "${MINGW_PACKAGE_PREFIX}-gmp"
+    "${MINGW_PACKAGE_PREFIX}-isl"
+    "${MINGW_PACKAGE_PREFIX}-libwinpthread"
+    "${MINGW_PACKAGE_PREFIX}-mpc"
+    "${MINGW_PACKAGE_PREFIX}-mpfr"
+    "${MINGW_PACKAGE_PREFIX}-zlib"
+    "${MINGW_PACKAGE_PREFIX}-zstd"
+  )
+  license=('spdx:GPL-3.0-or-later')
 
-  cd "${srcdir}"/build-${MSYSTEM}
+  _install
+  _install_GPL3
+}
 
-  make -C gcc DESTDIR="${pkgdir}" jit.install-common jit.install-info
+package_libgfortran() {
+  pkgdesc="GNU Fortran runtime library shipped by GCC (mingw-w64)"
+  depends=(
+    "${MINGW_PACKAGE_PREFIX}-libgcc=${pkgver}-${pkgrel}"
+    "${MINGW_PACKAGE_PREFIX}-libquadmath=${pkgver}-${pkgrel}"
+    "${MINGW_PACKAGE_PREFIX}-libwinpthread"
+  )
+  provides=(
+    "${MINGW_PACKAGE_PREFIX}-fc-libs"
+    "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran"
+  )
+  replaces=("${MINGW_PACKAGE_PREFIX}-gcc-libgfortran")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-gcc-libgfortran")
+
+  _install
+  _install_RLE
+}
+
+package_libgomp() {
+  pkgdesc="OpenMP library shipped by GCC (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-libwinpthread")
+  provides=("${MINGW_PACKAGE_PREFIX}-omp")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-gcc-libs<16.2.0-4")
+  groups=("${MINGW_PACKAGE_PREFIX}-toolchain")
+
+  _install
+  _install_RLE
+}
+
+package_libobjc() {
+  pkgdesc="Objective-C runtime libraries shipped by GCC (mingw-w64)"
+  depends=(
+    "${MINGW_PACKAGE_PREFIX}-libgcc=${pkgver}-${pkgrel}"
+    "${MINGW_PACKAGE_PREFIX}-libwinpthread"
+  )
+  conflicts=("${MINGW_PACKAGE_PREFIX}-gcc-objc<16.2.0-4")
+
+  _install
+  _install_RLE
+}
+
+package_libquadmath() {
+  pkgdesc="GCC Quad-Precision Math Runtime Library (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-libgcc=${pkgver}-${pkgrel}")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-gcc-libs<16.2.0-4")
+  license=('spdx:LGPL-2.1-or-later AND GFDL-1.2-or-later')
+
+  _install
+
+  install -Dm644 "$srcdir/${_sourcedir}/libquadmath/COPYING.LIB" \
+    "${pkgdir}${MINGW_PREFIX}/share/licenses/${pkgname#${MINGW_PACKAGE_PREFIX}-}/COPYING.LIB"
+}
+
+package_libstdc++() {
+  pkgdesc="C++ runtime libraries shipped by GCC (mingw-w64)"
+  depends=(
+    "${MINGW_PACKAGE_PREFIX}-libgcc=${pkgver}-${pkgrel}"
+    "${MINGW_PACKAGE_PREFIX}-libwinpthread"
+    "${MINGW_PACKAGE_PREFIX}-tzdata"
+  )
+  conflicts=("${MINGW_PACKAGE_PREFIX}-gcc-libs<16.2.0-4")
+  groups=("${MINGW_PACKAGE_PREFIX}-toolchain")
+
+  _install
+  _install_RLE
+}
+
+package_lto-dump() {
+  pkgdesc="Dump link time optimization object files (mingw-w64)"
+  depends=(
+    "${MINGW_PACKAGE_PREFIX}-gcc=$pkgver-$pkgrel"
+    "${MINGW_PACKAGE_PREFIX}-gmp"
+    "${MINGW_PACKAGE_PREFIX}-isl"
+    "${MINGW_PACKAGE_PREFIX}-libgcc=${pkgver}-${pkgrel}"
+    "${MINGW_PACKAGE_PREFIX}-libwinpthread"
+    "${MINGW_PACKAGE_PREFIX}-mpc"
+    "${MINGW_PACKAGE_PREFIX}-mpfr"
+    "${MINGW_PACKAGE_PREFIX}-zlib"
+    "${MINGW_PACKAGE_PREFIX}-zstd"
+  )
+  provides=("${MINGW_PACKAGE_PREFIX}-gcc-lto-dump")
+  replaces=("${MINGW_PACKAGE_PREFIX}-gcc-lto-dump")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-gcc-lto-dump")
+  license=('spdx:GPL-3.0-or-later')
+
+  _install
+  _install_GPL3
 }
 
 # template start; name=mingw-w64-splitpkg-wrappers; version=1.0;


### PR DESCRIPTION
Keep gcc-libs as a compatibility package that depends on the new cc-libs metapackage and libgomp.

The previous split (#28751) moved the omp provision from gcc-libs to libgomp without retaining a dependency edge between them. During a system upgrade, the old gcc-libs package had to be removed because the split runtime packages took ownership of its files. This also removed the only installed omp provider.

Although libgomp provides omp, pacman only searches for providers while resolving forward dependencies of packages already selected for the transaction. The missing omp dependency was detected later, during the final reverse-dependency validation. That validation reports broken dependencies but does not add new provider packages to the transaction, so libgomp was never selected automatically.

Add a concrete cc-libs package for the common GCC runtime libraries and turn gcc-libs into a compatibility package depending on matching versions of cc-libs and libgomp. Upgrading the installed gcc-libs package now pulls libgomp into the transaction before reverse-dependency validation, preserving all existing omp dependencies.

Keeping libgomp outside cc-libs also allows new common-runtime consumers to avoid installing the OpenMP runtime when it is not required.

Move the tzdata dependency to libstdc++, which is the component using the C++ time-zone database.