### PR TITLE
llvm: backport fix for rustc miscompilations

### DIFF
--- a/mingw-w64-llvm/0004-freeze-cond-in-select-of-load-fold.patch
+++ b/mingw-w64-llvm/0004-freeze-cond-in-select-of-load-fold.patch
@@ -1,0 +1,33 @@
+--- a/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
++++ b/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+@@ -30506,10 +30506,12 @@ bool DAGCombiner::SimplifySelectOps(SDNode *TheSelect, SDValue LHS,
+            SDNode::hasPredecessorHelper(RLD, Visited, Worklist)))
+         return false;
+ 
+-      Addr = DAG.getSelect(SDLoc(TheSelect),
+-                           LLD->getBasePtr().getValueType(),
+-                           TheSelect->getOperand(0), LLD->getBasePtr(),
+-                           RLD->getBasePtr());
++      // If the condition is poison, originally this would result in a poison
++      // result. After the transform, this would result in a load of poison,
++      // which is UB. Freeze the condition to prevent this.
++      Addr = DAG.getSelect(SDLoc(TheSelect), LLD->getBasePtr().getValueType(),
++                           DAG.getFreeze(TheSelect->getOperand(0)),
++                           LLD->getBasePtr(), RLD->getBasePtr());
+     } else {  // Otherwise SELECT_CC
+       // We cannot do this optimization if any pair of {RLD, LLD} is a
+       // predecessor to {RLD, LLD, CondLHS, CondRHS}. As we've already compared
+@@ -30528,10 +30530,10 @@ bool DAGCombiner::SimplifySelectOps(SDNode *TheSelect, SDValue LHS,
+            SDNode::hasPredecessorHelper(RLD, Visited, Worklist)))
+         return false;
+ 
++      SDValue FrozenOp0 = DAG.getFreeze(TheSelect->getOperand(0));
++      SDValue FrozenOp1 = DAG.getFreeze(TheSelect->getOperand(1));
+       Addr = DAG.getNode(ISD::SELECT_CC, SDLoc(TheSelect),
+-                         LLD->getBasePtr().getValueType(),
+-                         TheSelect->getOperand(0),
+-                         TheSelect->getOperand(1),
++                         LLD->getBasePtr().getValueType(), FrozenOp0, FrozenOp1,
+                          LLD->getBasePtr(), RLD->getBasePtr(),
+                          TheSelect->getOperand(4));
+     }

--- a/mingw-w64-llvm/PKGBUILD
+++ b/mingw-w64-llvm/PKGBUILD
@@ -29,7 +29,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-llvm"
          "${MINGW_PACKAGE_PREFIX}-lld")
 _pkgver=22.1.8
 pkgver=${_pkgver/-/}
-pkgrel=1
+pkgrel=2
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -61,6 +61,7 @@ source=("${_url}/${_pkgfn}.tar.xz"{,.sig}
         "0001-Fix-GetHostTriple-for-mingw-w64-in-msys.patch"
         "0002-Fix-Findzstd-on-MINGW.patch"
         "0003-add-pthread-as-system-lib-for-mingw.patch"
+        "0004-freeze-cond-in-select-of-load-fold.patch"
         # 0101-0199 -> clang
         "0101-link-pthread-with-mingw.patch"
         # 0201-0299 -> rt
@@ -74,6 +75,7 @@ sha256sums=('922f1817a0df7b1489272d18134ee0087a8b068828f87ac63b9861b1a9965888'
             'eb03df53671df6627768141b3aaa76abe176a14e5e47911c97bec544387c4aff'
             'd77d47e37e4948f5c01ae8bc05fb4e879b6516132c5a60c7bc820c9cbbb39668'
             '790eb0fccb4ef29c3795bceb8a62c8f4ecd0bdd6c49b2812352b04cfbc552342'
+            'cb62805ad8aa3dfbfd743dc139272ec0c985fefc8f3a1b91706554f26fb2b978'
             '715cb8862753854b2d9256e0b70003e2d1f57083d83eaeaf5a095fc72b8a4e26'
             'fd0253879cc5e31857f57307e6105e56493358e35d7c4540e0b476be607ab94e')
 validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Google.
@@ -104,10 +106,12 @@ prepare() {
   ${MINGW_PREFIX}/bin/bsdtar -xJf "${srcdir}"/${_pkgfn}.tar.xz -C "${srcdir}" || true
 
   # Patch llvm
+  # 0004 patch from https://github.com/llvm/llvm-project/pull/208683
   cd "${srcdir}"/${_pkgfn}/llvm
   apply_patch_with_msg \
     "0001-Fix-GetHostTriple-for-mingw-w64-in-msys.patch" \
-    "0002-Fix-Findzstd-on-MINGW.patch"
+    "0002-Fix-Findzstd-on-MINGW.patch" \
+    "0004-freeze-cond-in-select-of-load-fold.patch"
 
   if (( ! _clangprefix )); then
     apply_patch_with_msg \

--- a/mingw-w64-llvm/README-patches.md
+++ b/mingw-w64-llvm/README-patches.md
@@ -12,6 +12,7 @@ Legend:
 
 - `"0001-Fix-GetHostTriple-for-mingw-w64-in-msys.patch"` :x:
 - `"0003-add-pthread-as-system-lib-for-mingw.patch"` :grey_exclamation:
+- `"0004-freeze-cond-in-select-of-load-fold.patch"` :arrow_down_small:
 - `"0101-link-pthread-with-mingw.patch"` :grey_exclamation:
 - `"0102-Rename-flang-new-flang-experimental-exec-to-flang.patch"` :grey_question: https://reviews.llvm.org/D143592
 - `"0303-ignore-new-bfd-options.patch"` :x:


### PR DESCRIPTION
rust 1.97.1 was relased which added that fix in their downstream fork of LLVM, so backporting it here