### PR TITLE
primesieve: add version 12.14 + primecount: add version 8.5 (new packages)

### DIFF
--- a/mingw-w64-primecount/PKGBUILD
+++ b/mingw-w64-primecount/PKGBUILD
@@ -1,0 +1,62 @@
+# Maintainer: Dirk Stolle
+
+_realname=primecount
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=8.5
+pkgrel=1
+pkgdesc="Fast C++ prime counting function implementation (mingw-w64)"
+arch=('any')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/kimwalisch/primecount'
+msys2_repository_url='https://github.com/kimwalisch/primecount'
+license=('spdx:BSD-2-Clause')
+msys2_references=(
+  'archlinux: primecount'
+  'gentoo: sci-mathematics/primecount'
+)
+depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
+         "${MINGW_PACKAGE_PREFIX}-omp"
+         "${MINGW_PACKAGE_PREFIX}-primesieve")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+source=("https://github.com/kimwalisch/primecount/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('a2dd9714e723388987183776d068d6845b82b2cf8ea44ecb6cea3fd9dde938ea')
+
+build() {
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  if [[ ${MSYSTEM} == CLANG* ]]
+  then
+    # GCC's libquadmath is required for the 128-bit float feature, but this is
+    # a Clang/LLVM environment, so turn it off.
+    extra_config+=("-DWITH_FLOAT128=OFF")
+  else
+    # GCC-based environments have libquadmath, so they can use 128-bit floats.
+    extra_config+=("-DWITH_FLOAT128=ON")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    cmake \
+      -GNinja \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      "${extra_config[@]}" \
+      -DBUILD_LIBPRIMESIEVE=OFF \
+      -DBUILD_{SHARED,STATIC}_LIBS=ON \
+      -S "${_realname}-${pkgver}" \
+      -B "build-${MSYSTEM}"
+
+  cmake --build "build-${MSYSTEM}"
+}
+
+package() {
+  DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}"
+
+  install -Dm644 "${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}

--- a/mingw-w64-primesieve/PKGBUILD
+++ b/mingw-w64-primesieve/PKGBUILD
@@ -1,0 +1,50 @@
+# Maintainer: Dirk Stolle
+
+_realname=primesieve
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=12.14
+pkgrel=1
+pkgdesc="Fast prime number generator (mingw-w64)"
+arch=('any')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/kimwalisch/primesieve'
+msys2_repository_url='https://github.com/kimwalisch/primesieve'
+license=('spdx:BSD-2-Clause')
+msys2_references=(
+  'archlinux: primesieve'
+  'gentoo: sci-mathematics/primesieve'
+)
+depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
+         "${MINGW_PACKAGE_PREFIX}-libwinpthread")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-cc")
+source=("https://github.com/kimwalisch/primesieve/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('65cf173e11bc9aff1b189f2cd19c6b6c502c30e966876b5c5ef71e138f49c8c9')
+
+build() {
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    cmake \
+      -GNinja \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      "${extra_config[@]}" \
+      -DBUILD_{SHARED,STATIC}_LIBS=ON \
+      -S "${_realname}-${pkgver}" \
+      -B "build-${MSYSTEM}"
+
+  cmake --build "build-${MSYSTEM}"
+}
+
+package() {
+  DESTDIR="${pkgdir}" cmake --install "build-${MSYSTEM}"
+
+  install -Dm644 "${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}


### PR DESCRIPTION
Both primesieve and primecount are programs to count and/or calculate prime numbers fast.

primesieve is already packaged for various other distributions:
* Arch Linux: https://archlinux.org/packages/extra/x86_64/primesieve/
* Debian: https://packages.debian.org/trixie/source/primesieve
* Fedora: https://packages.fedoraproject.org/pkgs/primesieve/
* Gentoo: https://packages.gentoo.org/packages/sci-mathematics/primesieve

And so is primecount:
* Arch Linux: https://archlinux.org/packages/extra/x86_64/primecount/
* Debian: https://packages.debian.org/trixie/source/primecount
* Fedora: https://packages.fedoraproject.org/pkgs/primecount/
* Gentoo: https://packages.gentoo.org/packages/sci-mathematics/primecount

Potentially, it could also be used by passagemath, but that's stuff for a future pull request.