### PR TITLE
glew: fixed missing export of glew_s target

### DIFF
--- a/mingw-w64-glew/0001-cmake-fixes.patch
+++ b/mingw-w64-glew/0001-cmake-fixes.patch
@@ -1,5 +1,19 @@
 --- glew-2.3.1/build/cmake/CMakeLists.txt.orig	2026-06-28 12:40:09.750353800 +0200
 +++ glew-2.3.1/build/cmake/CMakeLists.txt	2026-06-28 12:41:41.151575100 +0200
+@@ -163,10 +163,7 @@
+ endforeach()
+ 
+ set(targets_to_install "")
+-if(BUILD_SHARED_LIBS)
+-  list(APPEND targets_to_install glew)
++list(APPEND targets_to_install glew)
+-else ()
+-  list(APPEND targets_to_install glew_s)
++list(APPEND targets_to_install glew_s)
+-endif()
+ 
+ install ( TARGETS ${targets_to_install}
+
 @@ -221,7 +221,7 @@
  set (requireslib glu)
  

--- a/mingw-w64-glew/0001-cmake-fixes.patch
+++ b/mingw-w64-glew/0001-cmake-fixes.patch
@@ -13,7 +13,6 @@
 -endif()
  
  install ( TARGETS ${targets_to_install}
-
 @@ -221,7 +221,7 @@
  set (requireslib glu)
  

--- a/mingw-w64-glew/PKGBUILD
+++ b/mingw-w64-glew/PKGBUILD
@@ -17,7 +17,7 @@ msys2_repository_url='https://github.com/nigels-com/glew'
 source=("https://sourceforge.net/projects/glew/files/glew/${pkgver}/${_realname}-${pkgver}.tgz"
         "0001-cmake-fixes.patch")
 sha256sums=('b64790f94b926acd7e8f84c5d6000a86cb43967bd1e688b03089079799c9e889'
-            '14531954ac3e8e191e288e6ca4a625da62cebb4f18afce15999d15f446cc5b70')
+            '6fea0691c35ff1222d088ed653fc0fee24663854120b2e10dd9b508134c41650')
 
 prepare() {
   cd "${_realname}-${pkgver}"

--- a/mingw-w64-glew/PKGBUILD
+++ b/mingw-w64-glew/PKGBUILD
@@ -17,7 +17,7 @@ msys2_repository_url='https://github.com/nigels-com/glew'
 source=("https://sourceforge.net/projects/glew/files/glew/${pkgver}/${_realname}-${pkgver}.tgz"
         "0001-cmake-fixes.patch")
 sha256sums=('b64790f94b926acd7e8f84c5d6000a86cb43967bd1e688b03089079799c9e889'
-            '355a496497a0c3ef592c4e61967f96b2fca7309e823cc710007be41b14307e3c')
+            '14531954ac3e8e191e288e6ca4a625da62cebb4f18afce15999d15f446cc5b70')
 
 prepare() {
   cd "${_realname}-${pkgver}"

--- a/mingw-w64-glew/PKGBUILD
+++ b/mingw-w64-glew/PKGBUILD
@@ -47,7 +47,6 @@ package () {
   echo "Cflags.private: -DGLEW_STATIC" \
     >> "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/glew.pc
 
-  cp -a "${srcdir}/build-${MSYSTEM}/lib/libglew32.a" "${pkgdir}"${MINGW_PREFIX}/lib/
   mkdir -p "${pkgdir}"${MINGW_PREFIX}/share/doc/${_realname}
   cp -a "${srcdir}"/${_realname}-${pkgver}/doc "${pkgdir}"${MINGW_PREFIX}/share/doc/${_realname}/html
 

--- a/mingw-w64-glew/PKGBUILD
+++ b/mingw-w64-glew/PKGBUILD
@@ -4,7 +4,7 @@ _realname=glew
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.3.1
-pkgrel=3
+pkgrel=4
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 pkgdesc="GLEW, The OpenGL Extension Wrangler Library (mingw-w64)"
@@ -15,14 +15,14 @@ license=('Modified BSD/MIT/GPL')
 url="https://glew.sourceforge.io/"
 msys2_repository_url='https://github.com/nigels-com/glew'
 source=("https://sourceforge.net/projects/glew/files/glew/${pkgver}/${_realname}-${pkgver}.tgz"
-        "0001-pc-no-glu.patch")
+        "0001-cmake-fixes.patch")
 sha256sums=('b64790f94b926acd7e8f84c5d6000a86cb43967bd1e688b03089079799c9e889'
-            '8d73338690de4e6dcee4268ca3f911516a4d1357aa89c3b7b88a5673cc226a5a')
+            '355a496497a0c3ef592c4e61967f96b2fca7309e823cc710007be41b14307e3c')
 
 prepare() {
   cd "${_realname}-${pkgver}"
 
-  patch -p1 -i "${srcdir}/0001-pc-no-glu.patch"
+  patch -p1 -i "${srcdir}/0001-cmake-fixes.patch"
 }
 
 build() {


### PR DESCRIPTION
due to a change upstream not both targets (static and shared) are exported upstream but we need both of them. 