### PR TITLE
mdcat: update to 2.12.0

### DIFF
--- a/mingw-w64-mdcat/PKGBUILD
+++ b/mingw-w64-mdcat/PKGBUILD
@@ -3,13 +3,13 @@
 _realname=mdcat
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.7.1
+pkgver=2.12.0
 pkgrel=1
 pkgdesc="Fancy cat for Markdown (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64' 'mingw64')
-url='https://github.com/swsnr/mdcat'
-msys2_repository_url='https://github.com/swsnr/mdcat'
+url='https://github.com/BIRSAx2/mdcat'
+msys2_repository_url='https://github.com/BIRSAx2/mdcat'
 msys2_references=(
   'purl: pkg:cargo/mdcat'
 )
@@ -18,7 +18,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-curl")
 makedepends=("${MINGW_PACKAGE_PREFIX}-rust")
 options=('!strip')
 source=("${url}/archive/${_realname}-${pkgver}.tar.gz")
-sha256sums=('460024d9795eb578be09ec2284af243627721151aa001aae6ffb5589380b2ba1')
+sha256sums=('2d3af226b43ffba0b29f26150bb95e970f324b9ea5ab048a4200fb9b8d5e5915')
 prepare() {
   cd "${_realname}-${_realname}-${pkgver}"
 


### PR DESCRIPTION
Upstream [swsnr/mdcat](https://github.com/swsnr/mdcat) is archived; its README points to [BIRSAx2/mdcat](https://github.com/BIRSAx2/mdcat) as the maintained fork.