### PR TITLE
python-polars: update to 1.43.0

### DIFF
--- a/mingw-w64-python-polars/PKGBUILD
+++ b/mingw-w64-python-polars/PKGBUILD
@@ -3,8 +3,10 @@
 _realname=polars
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}"
-         "${MINGW_PACKAGE_PREFIX}-python-${_realname}-runtime-64")
-pkgver=1.42.1
+         "${MINGW_PACKAGE_PREFIX}-python-${_realname}-runtime-32"
+         "${MINGW_PACKAGE_PREFIX}-python-${_realname}-runtime-64"
+         "${MINGW_PACKAGE_PREFIX}-python-${_realname}-runtime-compat")
+pkgver=1.43.0
 pkgrel=1
 pkgdesc="Extremely fast Query Engine for DataFrames, written in Rust (mingw-w64)"
 arch=('any')
@@ -19,26 +21,40 @@ msys2_references=(
 )
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-rust"
+  "${MINGW_PACKAGE_PREFIX}-cc"
   "${MINGW_PACKAGE_PREFIX}-maturin"
   "${MINGW_PACKAGE_PREFIX}-python-installer"
   "${MINGW_PACKAGE_PREFIX}-python-build"
   "${MINGW_PACKAGE_PREFIX}-python-setuptools"
-  "${MINGW_PACKAGE_PREFIX}-git"
+  "${MINGW_PACKAGE_PREFIX}-pkgconf"
+  "git"
 )
 options=('!strip' '!lto')
-source=("${msys2_repository_url}/archive/py-${pkgver}/${_realname}-py-${pkgver}.tar.gz")
+source=("${msys2_repository_url}/archive/py-${pkgver}/${_realname}-py-${pkgver}.tar.gz"
+        "git+https://github.com/PyO3/pyo3#tag=v0.29.0"
+        "pyo3-fix-python-abi-linking.patch"
+        "polars-use-patched-pyo3.patch")
 noextract=("${_realname}-py-${pkgver}.tar.gz")
-sha256sums=('ebb017bd32dfd075d5489d42e95cd8074762cf99744fb27b25154e4cfac88342')
+sha256sums=('22d4d7c6db9fe8b7aa29bc8727af1a40b4f9a98beb862c2be20fe9ccf254edd0'
+            '03411beda834ac76b28742d97fc3136bbbcbb4738598fd21633e78301f916e17'
+            '0b815dcb69127b60bd8250df5f5f4f57e94458240bd634cd2c5c6a4823d7b75b'
+            '7d4ff2db0d5c72d600273b41ae073de563446f60b95ae525642f1b7acf797cfe')
 
 prepare() {
   tar -xf "${_realname}-py-${pkgver}.tar.gz" || true
 
-  cd "${_realname}-py-${pkgver}/py-polars"
+  cd "${srcdir}/${_realname}-py-${pkgver}"
+
+  patch -d ../pyo3 -p1 -i ../pyo3-fix-python-abi-linking.patch
+  patch -p1 -i ../polars-use-patched-pyo3.patch
+
+  cargo update -p pyo3 \
+    --config='net.git-fetch-with-cli=true'
+
+  cd "${srcdir}/${_realname}-py-${pkgver}/py-polars"
 
   cp ../LICENSE .
   cp ../rust-toolchain.toml .
-
-  sed -i 's/polars-runtime-32/polars-runtime-64/g' pyproject.toml
 
   cargo fetch \
     --locked \
@@ -51,11 +67,16 @@ build() {
 
   export _PYTHON_HOST_PLATFORM=$(python -c "import sysconfig, sys; sys.stdout.write(sysconfig.get_platform())")
   export WINAPI_NO_BUNDLED_LIBRARIES=1
+  export OPENSSL_NO_VENDOR=1
+  export PYO3_USE_RAW_DYLIB=0
   python -m build --wheel --no-isolation --skip-dependency-check
-  maturin build -o dist --release --locked --strip \
-   --no-default-features --features full \
-   --compatibility linux \
-   --manifest-path runtime/polars-runtime-64/Cargo.toml
+
+  for _runtime in 32 64 compat; do
+    maturin build -o dist --release --locked --strip \
+     --no-default-features --features full \
+     --compatibility linux \
+     --manifest-path runtime/polars-runtime-${_runtime}/Cargo.toml
+  done
 }
 
 package_python-polars() {
@@ -64,14 +85,16 @@ package_python-polars() {
   depends=(
     "${MINGW_PACKAGE_PREFIX}-python"
     "${MINGW_PACKAGE_PREFIX}-python-numpy"
-    "${MINGW_PACKAGE_PREFIX}-python-polars-runtime-64"
+    "${MINGW_PACKAGE_PREFIX}-python-polars-runtime-32"
   )
   optdepends=(
+    "${MINGW_PACKAGE_PREFIX}-python-polars-runtime-64: for large dataset support"
+    "${MINGW_PACKAGE_PREFIX}-python-polars-runtime-compat: for older CPU compatibility"
     "${MINGW_PACKAGE_PREFIX}-python-pandas: for interoperability with pandas frames"
     "${MINGW_PACKAGE_PREFIX}-python-pyarrow: for interoperability with arrow types"
     "${MINGW_PACKAGE_PREFIX}-python-pytz: to enable conversion to python datetimes with timezones"
     "${MINGW_PACKAGE_PREFIX}-python-fastexcel: for reading excel workbooks"
-    #"${MINGW_PACKAGE_PREFIX}-python-fsspec: to transparently open files locally or remotely"
+    "${MINGW_PACKAGE_PREFIX}-python-fsspec: to transparently open files locally or remotely"
   )
 
   python -m installer -d "$pkgdir" ./dist/polars-*.whl
@@ -87,17 +110,31 @@ package_python-polars() {
   for _df in $(ls | grep -v ${MINGW_PREFIX/\//}); do rm -rf $_df; done
 }
 
-package_python-polars-runtime-64() {
+_package_runtime() {
+  local _runtime=$1
   cd "${_realname}-py-${pkgver}/py-polars"
 
-  pkgdesc+=" (native runtime libraries)"
+  pkgdesc+=" (runtime libraries$2)"
+  provides=("${MINGW_PACKAGE_PREFIX}-python-polars-runtime")
   depends=("${MINGW_PACKAGE_PREFIX}-python")
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
     python -m installer --prefix=${MINGW_PREFIX} \
-    --destdir="${pkgdir}" ./dist/polars_runtime*.whl
+    --destdir="${pkgdir}" ./dist/polars_runtime_${_runtime}*.whl
 
-  install -Dm0644 LICENSE -t "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}-runtime-64/"
+  install -Dm0644 LICENSE -t "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}-runtime-${_runtime}/"
+}
+
+package_python-polars-runtime-32() {
+  _package_runtime 32 ""
+}
+
+package_python-polars-runtime-64() {
+  _package_runtime 64 ", large dataset support"
+}
+
+package_python-polars-runtime-compat() {
+  _package_runtime compat ", older CPU compatibility"
 }
 
 # template start; name=mingw-w64-splitpkg-wrappers; version=1.0;

--- a/mingw-w64-python-polars/PKGBUILD
+++ b/mingw-w64-python-polars/PKGBUILD
@@ -27,7 +27,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-build"
   "${MINGW_PACKAGE_PREFIX}-python-setuptools"
   "${MINGW_PACKAGE_PREFIX}-pkgconf"
-  "git"
+  "${MINGW_PACKAGE_PREFIX}-git"
 )
 options=('!strip' '!lto')
 source=("${msys2_repository_url}/archive/py-${pkgver}/${_realname}-py-${pkgver}.tar.gz"

--- a/mingw-w64-python-polars/PKGBUILD
+++ b/mingw-w64-python-polars/PKGBUILD
@@ -27,7 +27,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-build"
   "${MINGW_PACKAGE_PREFIX}-python-setuptools"
   "${MINGW_PACKAGE_PREFIX}-pkgconf"
-  "${MINGW_PACKAGE_PREFIX}-git"
+  "git"
 )
 options=('!strip' '!lto')
 source=("${msys2_repository_url}/archive/py-${pkgver}/${_realname}-py-${pkgver}.tar.gz"

--- a/mingw-w64-python-polars/polars-use-patched-pyo3.patch
+++ b/mingw-w64-python-polars/polars-use-patched-pyo3.patch
@@ -1,0 +1,10 @@
+--- polars-py-1.43.0.orig/Cargo.toml	2026-07-20 18:54:27.000000000 +0300
++++ polars-py-1.43.0/Cargo.toml	2026-07-21 20:42:16.985303400 +0300
+@@ -163,6 +163,7 @@
+ question_mark = "allow" # https://github.com/rust-lang/rust-clippy/issues/17384
+ 
+ [patch.crates-io]
++pyo3.path = "../pyo3"
+ # packed_simd_2 = { git = "https://github.com/rust-lang/packed_simd", rev = "e57c7ba11386147e6d2cbad7c88f376aab4bdc86" }
+ # simd-json = { git = "https://github.com/ritchie46/simd-json", branch = "alignment" }
+ # custom DNS resolver - ref https://github.com/apache/arrow-rs-object-store/pull/728

--- a/mingw-w64-python-polars/pyo3-fix-python-abi-linking.patch
+++ b/mingw-w64-python-polars/pyo3-fix-python-abi-linking.patch
@@ -1,0 +1,327 @@
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -236,7 +236,17 @@ unsafe_op_in_unsafe_fn = "warn"
+ level = "warn"
+ check-cfg = [
+     'cfg(pyo3_disable_reference_pool)',
+-    'cfg(pyo3_leak_on_drop_without_reference_pool)'
++    'cfg(pyo3_leak_on_drop_without_reference_pool)',
++    'cfg(pyo3_use_raw_dylib)',
++    # this horrible hard-coded list should be kept in sync with the list of possible
++    # cfgs in pyo3-ffi/src/impl_/macros.rs
++    #
++    # for library names outside of this set we don't support raw-dylib and require a
++    # proper import library
++    #
++    # maybe in the future this list will not be necessary, see
++    # internals.rust-lang.org/t/support-renames-with-link-name-kind-raw-dylib/24415
++    'cfg(pyo3_dll, values("python3", "python3_d", "python3t", "python3t_d", "python38", "python38_d", "python39", "python39_d", "python310", "python310_d", "python311", "python311_d", "python312", "python312_d", "python313", "python313_d", "python313t", "python313t_d", "python314", "python314_d", "python314t", "python314t_d", "python315", "python315_d", "python315t", "python315t_d", "python316", "python316_d", "python316t", "python316t_d", "libpypy3.11-c"))',
+ ]
+ 
+ 
+--- a/pyo3-build-config/src/impl_.rs
++++ b/pyo3-build-config/src/impl_.rs
+@@ -25,15 +25,6 @@ use crate::{
+ /// Minimum Python version PyO3 supports.
+ pub(crate) const MINIMUM_SUPPORTED_VERSION: PythonVersion = PythonVersion { major: 3, minor: 9 };
+ 
+-pub(crate) const MINIMUM_SUPPORTED_VERSION_PYPY: PythonVersion = PythonVersion {
+-    major: 3,
+-    minor: 11,
+-};
+-pub(crate) const MAXIMUM_SUPPORTED_VERSION_PYPY: PythonVersion = PythonVersion {
+-    major: 3,
+-    minor: 11,
+-};
+-
+ pub(crate) const MINIMUM_SUPPORTED_VERSION_ABI3T: PythonVersion = PythonVersion {
+     major: 3,
+     minor: 15,
+@@ -2314,6 +2305,15 @@ fn default_lib_name_for_target(abi: PythonAbi, target: &Triple) -> String {
+ }
+ 
+ fn default_lib_name_windows(abi: PythonAbi, mingw: bool, debug: bool) -> Result<String> {
++    // mingw formats lib names like unix, and uses a "lib" prefix. We could let the linker
++    // handle "lib" prefix, but that means the `raw-dylib` name is incorrect (where the
++    // "lib" prefix is not automatically added).)
++    if mingw {
++        let mut lib_name = default_lib_name_unix(abi, true, None)?;
++        lib_name.insert_str(0, "lib");
++        return Ok(lib_name);
++    }
++
+     if abi.implementation.is_pypy() {
+         // PyPy on Windows ships `libpypy3.X-c.dll` (e.g. `libpypy3.11-c.dll`),
+         // not CPython's `pythonXY.dll`. With raw-dylib linking we need the real
+@@ -2341,13 +2341,6 @@ fn default_lib_name_windows(abi: PythonAbi, mingw: bool, debug: bool) -> Result<
+             lib_name = lib_name.replace("python3", "python3t");
+         }
+         Ok(lib_name)
+-    } else if mingw {
+-        ensure!(
+-            !abi.kind.is_free_threaded(),
+-            "MinGW free-threaded builds are not currently tested or supported"
+-        );
+-        // https://packages.msys2.org/base/mingw-w64-python
+-        Ok(format!("python{}.{}", abi.version.major, abi.version.minor))
+     } else if abi.kind().is_free_threaded() {
+         #[expect(deprecated, reason = "using constant internally")]
+         {
+@@ -2371,28 +2364,36 @@ fn default_lib_name_windows(abi: PythonAbi, mingw: bool, debug: bool) -> Result<
+     }
+ }
+ 
+-fn default_lib_name_unix(abi: PythonAbi, cygwin: bool, ld_version: Option<&str>) -> Result<String> {
++fn default_lib_name_unix(
++    abi: PythonAbi,
++    use_stable_abi_lib: bool,
++    ld_version: Option<&str>,
++) -> Result<String> {
+     match abi.implementation {
+         PythonImplementation::CPython => match ld_version {
+             Some(ld_version) => Ok(format!("python{ld_version}")),
+-            None => {
+-                if cygwin && matches!(abi.kind, PythonAbiKind::Stable(StableAbi::Abi3)) {
++            None => match abi.kind {
++                PythonAbiKind::Stable(StableAbi::Abi3) if use_stable_abi_lib => {
+                     Ok("python3".to_string())
+-                } else if cygwin && matches!(abi.kind, PythonAbiKind::Stable(StableAbi::Abi3t)) {
++                }
++                PythonAbiKind::Stable(StableAbi::Abi3t) if use_stable_abi_lib => {
+                     Ok("python3t".to_string())
+-                } else if abi.kind.is_free_threaded() {
+-                    #[expect(deprecated, reason = "using constant internally")]
+-                    {
+-                        ensure!(abi.version >= PythonVersion::PY313, "Cannot compile extensions for the free-threaded build on Python versions earlier than 3.13, found {}.{}", abi.version.major, abi.version.minor);
++                }
++                _ => {
++                    if abi.kind.is_free_threaded() {
++                        #[expect(deprecated, reason = "using constant internally")]
++                        {
++                            ensure!(abi.version >= PythonVersion::PY313, "Cannot compile extensions for the free-threaded build on Python versions earlier than 3.13, found {}.{}", abi.version.major, abi.version.minor);
++                        }
++                        Ok(format!(
++                            "python{}.{}t",
++                            abi.version.major, abi.version.minor
++                        ))
++                    } else {
++                        Ok(format!("python{}.{}", abi.version.major, abi.version.minor))
+                     }
+-                    Ok(format!(
+-                        "python{}.{}t",
+-                        abi.version.major, abi.version.minor
+-                    ))
+-                } else {
+-                    Ok(format!("python{}.{}", abi.version.major, abi.version.minor))
+                 }
+-            }
++            },
+         },
+         PythonImplementation::PyPy => match ld_version {
+             Some(ld_version) => Ok(format!("pypy{ld_version}-c")),
+--- a/pyo3-build-config/src/lib.rs
++++ b/pyo3-build-config/src/lib.rs
+@@ -164,34 +164,6 @@ pub fn print_expected_cfgs() {
+     for i in impl_::MINIMUM_SUPPORTED_VERSION.minor..=impl_::STABLE_ABI_MAX_MINOR + 1 {
+         println!("cargo:rustc-check-cfg=cfg(Py_3_{i})");
+     }
+-
+-    // pyo3_dll cfg for raw-dylib linking on Windows
+-    let mut dll_names = vec![
+-        "python3".to_string(),
+-        "python3_d".to_string(),
+-        "python3t".to_string(),
+-        "python3t_d".to_string(),
+-    ];
+-    for i in impl_::MINIMUM_SUPPORTED_VERSION.minor..=impl_::STABLE_ABI_MAX_MINOR + 1 {
+-        dll_names.push(format!("python3{i}"));
+-        dll_names.push(format!("python3{i}_d"));
+-        if i >= 13 {
+-            dll_names.push(format!("python3{i}t"));
+-            dll_names.push(format!("python3{i}t_d"));
+-        }
+-    }
+-    // PyPy DLL names (libpypy3.X-c.dll)
+-    for i in
+-        impl_::MINIMUM_SUPPORTED_VERSION_PYPY.minor..=impl_::MAXIMUM_SUPPORTED_VERSION_PYPY.minor
+-    {
+-        dll_names.push(format!("libpypy3.{i}-c"));
+-    }
+-    let values = dll_names
+-        .iter()
+-        .map(|n| format!("\"{n}\""))
+-        .collect::<Vec<_>>()
+-        .join(", ");
+-    println!("cargo:rustc-check-cfg=cfg(pyo3_dll, values({values}))");
+ }
+ 
+ /// Private exports used in PyO3's build.rs
+--- a/pyo3-ffi/build.rs
++++ b/pyo3-ffi/build.rs
+@@ -191,15 +191,79 @@ fn ensure_target_pointer_width(interpreter_config: &InterpreterConfig) -> Result
+     Ok(())
+ }
+ 
++/// `raw-dylib` currently does not support arbitrary names
++/// (see https://internals.rust-lang.org/t/support-renames-with-link-name-kind-raw-dylib/24415)
++/// so if the lib name is not one of the known subset, we must fall back to full linking.
++fn lib_name_is_known_for_raw_dylib(lib_name: &str) -> bool {
++    // pyo3_dll cfg for raw-dylib linking on Windows
++    if matches!(
++        lib_name,
++        "python3" | "python3_d" | "python3t" | "python3t_d"
++    ) {
++        return true;
++    }
++
++    // support raw-dylib linking for all CPython versions supported, plus the next prerelease
++    for i in SUPPORTED_VERSIONS_CPYTHON.min.minor..=SUPPORTED_VERSIONS_CPYTHON.max.minor + 1 {
++        if lib_name == format!("python3{i}") || lib_name == format!("python3{i}_d") {
++            return true;
++        }
++        if i >= 13 && (lib_name == format!("python3{i}t") || lib_name == format!("python3{i}t_d")) {
++            return true;
++        }
++    }
++    // PyPy DLL names (libpypy3.X-c.dll)
++    for i in SUPPORTED_VERSIONS_PYPY.min.minor..=SUPPORTED_VERSIONS_PYPY.max.minor {
++        if lib_name == format!("libpypy3.{i}-c") {
++            return true;
++        }
++    }
++
++    false
++}
++
++/// Whether to use raw-dylib linking.
++///
++/// Currently, this only applies if all of the following are true:
++/// - The target OS is Windows.
++/// - The Python library name is one of the [known subset][lib_name_is_known_for_raw_dylib].
++/// - The `PYO3_USE_RAW_DYLIB` environment variable is not set, or is set to `1`.
++///
++/// NB in some cases (e.g. mixed C / Rust builds) it might be necessary to link the full Python
++/// library rather than rely on the symbols which PyO3 defines as raw-dylib, which is why
++/// we have the opt-out env var.
++fn should_use_raw_dylib_linking(lib_name: &str) -> bool {
++    let target_os = cargo_env_var("CARGO_CFG_TARGET_OS").unwrap();
++    if target_os != "windows" {
++        return false;
++    }
++
++    match (
++        lib_name_is_known_for_raw_dylib(lib_name),
++        env_var("PYO3_USE_RAW_DYLIB"),
++    ) {
++        (true, None) => true,
++        (true, Some(os_str)) if os_str == "1" => true,
++        (false, Some(os_str)) if os_str == "1" => {
++            warn!(
++                "PYO3_USE_RAW_DYLIB is set to 1 but the Python library name is not recognized. \
++                Falling back to full linking."
++            );
++            false
++        }
++        _ => false,
++    }
++}
++
+ fn emit_link_config(build_config: &BuildConfig) -> Result<()> {
+-    let interpreter_config = &build_config.interpreter_config;
+     let target_os = cargo_env_var("CARGO_CFG_TARGET_OS").unwrap();
++    let interpreter_config = &build_config.interpreter_config;
+ 
+     let lib_name = interpreter_config
+         .lib_name()
+         .ok_or("attempted to link to Python shared library but config does not contain lib_name")?;
+ 
+-    if target_os == "windows" {
++    if should_use_raw_dylib_linking(lib_name) {
+         // Use raw-dylib linking: emit a cfg so that `extern_libpython!` picks the
+         // right `#[link(name = "...", kind = "raw-dylib")]` attribute at compile time.
+         // This eliminates the need for import libraries (.lib files) entirely.
+@@ -207,27 +271,36 @@ fn emit_link_config(build_config: &BuildConfig) -> Result<()> {
+         // Note: raw-dylib is inherently dynamic linking. Static embedding of the
+         // Python interpreter on Windows is not supported by this path (and is not
+         // officially supported by CPython on Windows).
++        println!("cargo:rustc-cfg=pyo3_use_raw_dylib");
+         println!("cargo:rustc-cfg=pyo3_dll=\"{lib_name}\"");
+-    } else {
+-        println!(
+-            "cargo:rustc-link-lib={link_model}{lib_name}",
+-            link_model = if interpreter_config.shared() {
+-                ""
+-            } else {
+-                "static="
+-            },
+-        );
++        return Ok(());
++    }
+ 
+-        if let Some(lib_dir) = interpreter_config.lib_dir() {
+-            println!("cargo:rustc-link-search=native={lib_dir}");
+-        } else if matches!(build_config.source, BuildConfigSource::CrossCompile) {
+-            warn!(
+-                "The output binary will link to libpython, \
+-                but PYO3_CROSS_LIB_DIR environment variable is not set. \
+-                Ensure that the target Python library directory is \
+-                in the rustc native library search path."
+-            );
++    println!(
++        "cargo:rustc-link-lib={link_model}{alias}{lib_name}",
++        link_model = if interpreter_config.shared() {
++            ""
++        } else {
++            "static="
++        },
++        // on windows we emit `#[link(name = "pythonXY")]` attributes
++        // and need this alias here to get the right name for the final link
++        alias = if target_os == "windows" {
++            "pythonXY:"
++        } else {
++            ""
+         }
++    );
++
++    if let Some(lib_dir) = interpreter_config.lib_dir() {
++        println!("cargo:rustc-link-search=native={lib_dir}");
++    } else if matches!(build_config.source, BuildConfigSource::CrossCompile) {
++        warn!(
++            "The output binary will link to libpython, \
++            but PYO3_CROSS_LIB_DIR environment variable is not set. \
++            Ensure that the target Python library directory is \
++            in the rustc native library search path."
++        );
+     }
+ 
+     Ok(())
+--- a/pyo3-ffi/src/impl_/macros.rs
++++ b/pyo3-ffi/src/impl_/macros.rs
+@@ -268,10 +268,12 @@ macro_rules! extern_libpython {
+             "python313", "python313_d",
+             "python314", "python314_d",
+             "python315", "python315_d",
++            "python316", "python316_d",
+             // free-threaded builds (3.13+)
+             "python313t", "python313t_d",
+             "python314t", "python314t_d",
+             "python315t", "python315t_d",
++            "python316t", "python316t_d",
+             // PyPy (DLL is libpypy3.X-c.dll, not pythonXY.dll)
+             "libpypy3.11-c",
+         );
+@@ -286,11 +288,12 @@ macro_rules! extern_libpython {
+     // separate cfg_attr arms per architecture.
+     (@impl $abi:literal { $($body:tt)* } $($dll:literal),* $(,)?) => {
+         $(
+-            #[cfg_attr(all(windows, target_arch = "x86", pyo3_dll = $dll),
++            #[cfg_attr(all(windows, pyo3_use_raw_dylib, target_arch = "x86", pyo3_dll = $dll),
+                 link(name = $dll, kind = "raw-dylib", import_name_type = "undecorated"))]
+-            #[cfg_attr(all(windows, not(target_arch = "x86"), pyo3_dll = $dll),
++            #[cfg_attr(all(windows, pyo3_use_raw_dylib, not(target_arch = "x86"), pyo3_dll = $dll),
+                 link(name = $dll, kind = "raw-dylib"))]
+         )*
++        #[cfg_attr(all(windows, not(pyo3_use_raw_dylib)), link(name = "pythonXY"))]
+         extern $abi {
+             extern_libpython_items! { $($body)* }
+         }


### PR DESCRIPTION
Closes #30442

The [pyo3-fix-python-abi-linking.patch](https://github.com/msys2/MINGW-packages/pull/29942/changes#diff-2472d1678d8e64017baffa49e288c400fc15f83af74ad6fc0c1b8ef8f50edaa7) just copied from #29942.