### PR TITLE
binutils: Fix `--gc-sections` for recent mingw-w64 changes

### DIFF
--- a/mingw-w64-binutils/2004-ld-Prevent-_tls_used-and-_load_config_used-from-bein.patch
+++ b/mingw-w64-binutils/2004-ld-Prevent-_tls_used-and-_load_config_used-from-bein.patch
@@ -1,0 +1,75 @@
+From ee7506d8ffbec39df2262f08a348346914d71efd Mon Sep 17 00:00:00 2001
+From: LIU Hao <lh_mouse@126.com>
+Date: Fri, 31 Jul 2026 13:52:14 +0200
+Subject: [PATCH] ld: Prevent `_tls_used` and `_load_config_used` from being
+ garbage-collected
+
+In mingw-w64 there's an ongoing effort to make the TLS directory of an image
+optional and only linked on demand. The approach is to have the entrypoint
+function reference TLS initialization callbacks through function pointers as
+tentative definitions, and the object files where TLS initialization callbacks
+are defined should ensure `_tls_used` is linked, by referencing its address in
+file-scope static pointers.
+
+The issue here is that data sections of those object files are not referenced
+otherwise. During linking, if LD is passed `--gc-sections`, it garbage-collects
+such sections along with `_tls_used`, leaving a symbol of value zero, which
+results in a broken executable:
+
+   $ objdump -p bin/test_thread_id_cpp.exe | grep -F .tls
+   Entry 9 ffffffffc0000000 00000028 Thread Storage Directory [.tls]
+
+This patch prevents `_tls_used` from being garbage-collected, and likewise for
+`_load_config_used`.
+
+Signed-off-by: LIU Hao <lh_mouse@126.com>
+---
+ ld/emultempl/pe.em  | 10 ++++++++++
+ ld/emultempl/pep.em | 10 ++++++++++
+ 2 files changed, 20 insertions(+)
+
+diff --git a/ld/emultempl/pe.em b/ld/emultempl/pe.em
+index 07ef2ca5953..1d02a86be96 100644
+--- a/ld/emultempl/pe.em
++++ b/ld/emultempl/pe.em
+@@ -1573,6 +1573,16 @@ gld${EMULATION_NAME}_after_open (void)
+ 
+   pe_output_file_set_long_section_names (link_info.output_bfd);
+ 
++  /* The RVAs of these symbols will be written into the PE header, so they
++     must not be collected.  */
++  char *sym = xstrdup ("__tls_used");
++  sym[0] = bfd_get_symbol_leading_char (link_info.output_bfd);
++  lang_add_gc_name (sym + !sym[0]);
++
++  sym = xstrdup ("__load_config_used");
++  sym[0] = bfd_get_symbol_leading_char (link_info.output_bfd);
++  lang_add_gc_name (sym + !sym[0]);
++
+ #ifdef DLL_SUPPORT
+   pe_process_import_defs (link_info.output_bfd, &link_info);
+ 
+diff --git a/ld/emultempl/pep.em b/ld/emultempl/pep.em
+index 25ce3963b36..3ba29401821 100644
+--- a/ld/emultempl/pep.em
++++ b/ld/emultempl/pep.em
+@@ -1582,6 +1582,16 @@ gld${EMULATION_NAME}_after_open (void)
+ 
+   pep_output_file_set_long_section_names (link_info.output_bfd);
+ 
++  /* The RVAs of these symbols will be written into the PE header, so they
++     must not be collected.  */
++  char *sym = xstrdup ("__tls_used");
++  sym[0] = bfd_get_symbol_leading_char (link_info.output_bfd);
++  lang_add_gc_name (sym + !sym[0]);
++
++  sym = xstrdup ("__load_config_used");
++  sym[0] = bfd_get_symbol_leading_char (link_info.output_bfd);
++  lang_add_gc_name (sym + !sym[0]);
++
+ #ifdef DLL_SUPPORT
+   pep_process_import_defs (link_info.output_bfd, &link_info);
+ 
+-- 
+2.55.0
+

--- a/mingw-w64-binutils/PKGBUILD
+++ b/mingw-w64-binutils/PKGBUILD
@@ -6,7 +6,7 @@ _realname=binutils
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.47
-pkgrel=1
+pkgrel=2
 pkgdesc="A set of programs to assemble and manipulate binary and object files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -28,6 +28,7 @@ source=(https://ftp.gnu.org/gnu/binutils/binutils-${pkgver}.tar.bz2{,.sig}
         0002-check-for-unusual-file-harder.patch
         2001-ld-option-to-move-default-bases-under-4GB.patch
         2003-Revert-Restore-old-behaviour-of-windres-so-that-opti.patch
+        2004-ld-Prevent-_tls_used-and-_load_config_used-from-bein.patch
         reproducible-import-libraries.patch
         libiberty-unlink-handle-windows-nul.patch
         4000-fix-DEBUG_S_INLINEELINES.patch
@@ -37,6 +38,7 @@ sha256sums=('3068128c75cda9f898ccb4211d360246e8e195ffcc9dfb655b23ae23a54800e8'
             '2c99345fc575c3a060d6677537f636c6c4154fac0fde508070f3b6296c1060d4'
             '9945635f4a67712616202f09cbb66cf70df01be168c2c8054c455bb58bf334dd'
             '3e3c53b0751a6389cd50dcbd7f78b52aaa55113414da01d3415592af18809702'
+            '5fddd0c6e380955c2d219f173d286bae07ff23ba79afcd15aba6f29ae6dea47d'
             'a094660ec95996c00b598429843b7869037732146442af567ada9f539bd40480'
             '7ccbd418695733c50966068fa9755a6abb156f53af23701d2bc097c63e9e0030'
             '5ed35a728b956ad49a5e196ae59f681666f2754f0a4903b9280a430d7a312ea8')
@@ -65,6 +67,9 @@ prepare() {
 
   # https://github.com/msys2/MINGW-packages/pull/9233#issuecomment-889439433
   apply_patch_with_msg 2003-Revert-Restore-old-behaviour-of-windres-so-that-opti.patch
+
+  # This is required for `gcc -Wl,--gc-sections` to work with recent mingw-w64.
+  apply_patch_with_msg 2004-ld-Prevent-_tls_used-and-_load_config_used-from-bein.patch
 
   # patches for reproducibility from Debian:
   # https://salsa.debian.org/mingw-w64-team/binutils-mingw-w64/-/tree/master/debian/patches


### PR DESCRIPTION
Earlier today I pushed some patches to mingw-w64 to make `_tls_used` only
linked on demand, by referencing it indirectly through tentative definitions.
However, since the startup code no longer has strong references to `_tls_used`,
if LD is passed `--gc-sections`, it garbage-collects `_tls_used`, resulting in
a broken executable:

   $ objdump -p bin/test_thread_id_cpp.exe | grep -F .tls
   Entry 9 ffffffffc0000000 00000028 Thread Storage Directory [.tls]

This patch prevents `_tls_used` from being garbage-collected, and likewise for
`_load_config_used`.
