### PR TITLE
perl: speedup profile

### DIFF
--- a/mingw-w64-perl/PKGBUILD
+++ b/mingw-w64-perl/PKGBUILD
@@ -14,7 +14,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
 # provides array, then repackage.
 pkgver="5.44.0"
 #       v    ^
-pkgrel=1
+pkgrel=2
 pkgdesc="A highly capable, feature-rich programming language (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -49,7 +49,7 @@ source=("https://www.cpan.org/src/5.0/${_realname}-${pkgver}.tar.xz"
         "018-copy-clang-runtime.patch"
         "019-fixes.patch")
 sha256sums=('505cf43912e9480495c344c70260452e32aa2a73c546a026b3f100053b23ce91'
-            'a98fc21fb079a9b31194292191ea8be1590b97be16b57cc25c3cf73a5d2bd25e'
+            'e7dac67b047c711da2dbf14503bbef8e4512395b411ad39b778f7dc8eb7877d0'
             'ec41f5054fcc61cd3f0942dc42fe24fcca50a9ff13cb42003b119e221a207d40'
             'e99bb18b75d9550d45c18d76edea0136642a5b3a0f93adefc472929f180487d0'
             '9f77b5674eda8553422d2e1f547b176d5a97ed292e0a13271a6a9936c519d897'

--- a/mingw-w64-perl/perlprofile.in
+++ b/mingw-w64-perl/perlprofile.in
@@ -4,7 +4,7 @@
 
 [ "${MSYSTEM_PREFIX}" != "@PREFIX@" ] && return 0
 
-if [ "$(echo -n "$PATH" | wc -l)" -gt 0 ]; then
+if [[ "${PATH}" == *$'\n'* ]]; then
     echo "@FILENAME@: ERROR: PATH contains line break, skipping PATH setup" >&2
     return 1
 fi
@@ -12,16 +12,25 @@ fi
 modify_path() {
     # @REM@ mypath is determined in package() based on the built configuration
     local mypath=""
+    local remaining="${PATH}"
+    local path_entry newpath="" separator=""
 
     # Remove MSYS perl modules from PATH to avoid conflicts
-    local newpath="$(echo -n "${PATH}" \
-        | gawk -v mypath="${mypath}" '
-            BEGIN { RS = ":" }
-            /^\/usr\/bin\/.*_perl$/ { next }
-            { printf "%s", (++i > 1 ? ":" : "") $0 }
-            mypath && /^\@PREFIX@\/bin$/ { printf "%s", ":" mypath }
-        '
-    )"
+    while [[ "${remaining}" == *:* || -n "${remaining}" ]]; do
+        if [[ "${remaining}" == *:* ]]; then
+            path_entry="${remaining%%:*}"
+            remaining="${remaining#*:}"
+        else
+            path_entry="${remaining}"
+            remaining=""
+        fi
+
+        [[ "${path_entry}" == /usr/bin/*_perl ]] && continue
+
+        newpath+="${separator}${path_entry}"
+        separator=:
+        [[ "${path_entry}" == "@PREFIX@/bin" ]] && newpath+=":${mypath}"
+    done
     [ -z "${newpath}" ] && return 1
 
     PATH="${newpath}"


### PR DESCRIPTION
External commands are expensive on MSYS2, so replacing them with shell builtins.
Reduce time cost from ~200ms to negligible.
Tested on Bash and Zsh.

Fixes #29391