### PR TITLE
innoextract: support InnoSetup versions up to v7.0.2

### DIFF
--- a/mingw-w64-innoextract/0001-loader-support-setup-loader-offset-table-revision-2.patch
+++ b/mingw-w64-innoextract/0001-loader-support-setup-loader-offset-table-revision-2.patch
@@ -1,7 +1,7 @@
 From 67d95c40e742ca68340d44e34b1a56e8e8795828 Mon Sep 17 00:00:00 2001
 From: Johannes Schindelin <johannes.schindelin@gmx.de>
 Date: Tue, 5 May 2026 01:13:19 +0200
-Subject: [PATCH 01/11] loader: support setup loader offset table revision 2
+Subject: [PATCH 01/N] loader: support setup loader offset table revision 2
 
 Inno Setup 6.5.0 bumped SetupLdrOffsetTableVersion from 1 to 2 and
 widened the on-disk TSetupLdrOffsetTable struct: TotalSize, OffsetEXE,
@@ -92,6 +92,3 @@ index 0c0d6a4..80bcdc4 100644
  		} else if(revision != 1) {
  			log_warning << "Unexpected setup loader revision: " << revision;
  		}
--- 
-2.54.0.windows.1
-

--- a/mingw-w64-innoextract/0002-Add-support-for-Inno-Setup-6.4.2-and-6.4.3.patch
+++ b/mingw-w64-innoextract/0002-Add-support-for-Inno-Setup-6.4.2-and-6.4.3.patch
@@ -1,7 +1,7 @@
 From 9f3cee2dd8e1c105d0bd280a3bac331ea3a0417d Mon Sep 17 00:00:00 2001
 From: Johannes Schindelin <johannes.schindelin@gmx.de>
 Date: Tue, 5 May 2026 01:24:06 +0200
-Subject: [PATCH 02/11] Add support for Inno Setup 6.4.2 and 6.4.3
+Subject: [PATCH 02/N] Add support for Inno Setup 6.4.2 and 6.4.3
 
 Inno Setup 6.4.2 added the new [Setup] section directive
 CloseApplicationsFilterExcludes (see
@@ -80,6 +80,3 @@ index 7f68af2..be6682b 100644
  };
  
  } // anonymous namespace
--- 
-2.54.0.windows.1
-

--- a/mingw-w64-innoextract/0003-Add-support-for-Inno-Setup-6.5.0-6.5.1-6.5.2-6.5.3-a.patch
+++ b/mingw-w64-innoextract/0003-Add-support-for-Inno-Setup-6.5.0-6.5.1-6.5.2-6.5.3-a.patch
@@ -1,7 +1,7 @@
 From 6c584226b9adc9decd64f621d36d267b7bc5026d Mon Sep 17 00:00:00 2001
 From: Johannes Schindelin <johannes.schindelin@gmx.de>
 Date: Tue, 5 May 2026 01:44:12 +0200
-Subject: [PATCH 03/11] Add support for Inno Setup 6.5.0, 6.5.1, 6.5.2, 6.5.3
+Subject: [PATCH 03/N] Add support for Inno Setup 6.5.0, 6.5.1, 6.5.2, 6.5.3
  and 6.5.4
 
 Inno Setup 6.5.0 made two on-disk changes to TSetupHeader:
@@ -107,6 +107,3 @@ index be6682b..2911396 100644
  };
  
  } // anonymous namespace
--- 
-2.54.0.windows.1
-

--- a/mingw-w64-innoextract/0004-Add-support-for-Inno-Setup-6.6.0-and-6.6.1.patch
+++ b/mingw-w64-innoextract/0004-Add-support-for-Inno-Setup-6.6.0-and-6.6.1.patch
@@ -1,7 +1,7 @@
 From 65c61e140738ffebf45083a10b6a2cb835f130b2 Mon Sep 17 00:00:00 2001
 From: Johannes Schindelin <johannes.schindelin@gmx.de>
 Date: Tue, 5 May 2026 01:49:32 +0200
-Subject: [PATCH 04/11] Add support for Inno Setup 6.6.0 and 6.6.1
+Subject: [PATCH 04/N] Add support for Inno Setup 6.6.0 and 6.6.1
 
 Inno Setup 6.6.0 made several rearrangements in TSetupHeader's wizard
 section (Projects/Src/Shared.Struct.pas at tag is-6_6_0 in
@@ -241,6 +241,3 @@ index 2911396..4aadc56 100644
  };
  
  } // anonymous namespace
--- 
-2.54.0.windows.1
-

--- a/mingw-w64-innoextract/0005-refactor-widen-seekable-offset-and-size-types-to-64-.patch
+++ b/mingw-w64-innoextract/0005-refactor-widen-seekable-offset-and-size-types-to-64-.patch
@@ -1,7 +1,7 @@
 From 37c2d6eed1fe0041fdd270f005022d4a10cd2437 Mon Sep 17 00:00:00 2001
 From: Johannes Schindelin <johannes.schindelin@gmx.de>
 Date: Tue, 5 May 2026 12:42:56 +0200
-Subject: [PATCH 05/11] refactor: widen seekable offset and size types to
+Subject: [PATCH 05/N] refactor: widen seekable offset and size types to
  64-bit
 
 Inno Setup 6.7.0 widens several on-disk size and offset fields from
@@ -315,6 +315,3 @@ index b2ec52c..d0b3bc0 100644
  	
  	/*!
  	 * Read a number of bytes starting at the current slice and offset within that slice.
--- 
-2.54.0.windows.1
-

--- a/mingw-w64-innoextract/0006-loader-block-consume-native-64-bit-offsets-and-sizes.patch
+++ b/mingw-w64-innoextract/0006-loader-block-consume-native-64-bit-offsets-and-sizes.patch
@@ -1,7 +1,7 @@
 From b7388dfd161f8de29085e68fafbc32d0250c8924 Mon Sep 17 00:00:00 2001
 From: Johannes Schindelin <johannes.schindelin@gmx.de>
 Date: Tue, 5 May 2026 13:07:43 +0200
-Subject: [PATCH 06/11] loader, block: consume native 64-bit offsets and sizes
+Subject: [PATCH 06/N] loader, block: consume native 64-bit offsets and sizes
 
 Now that loader::offsets, stream::chunk, stream::slice_reader and the
 block-reader local size hold their values in uint64_t, drop the
@@ -116,6 +116,3 @@ index 2a90c20..9a7d958 100644
  	
  	fis->exceptions(std::ios_base::badbit | std::ios_base::failbit);
  	
--- 
-2.54.0.windows.1
-

--- a/mingw-w64-innoextract/0007-util-storedenum-let-stored_flag_reader-pad-to-a-fixe.patch
+++ b/mingw-w64-innoextract/0007-util-storedenum-let-stored_flag_reader-pad-to-a-fixe.patch
@@ -1,7 +1,7 @@
 From 0e92dbc4b09405bd7f4d506fc4b21fc0ae767bbb Mon Sep 17 00:00:00 2001
 From: Johannes Schindelin <johannes.schindelin@gmx.de>
 Date: Wed, 6 May 2026 15:56:44 +0200
-Subject: [PATCH 07/11] util/storedenum: let stored_flag_reader pad to a fixed
+Subject: [PATCH 07/N] util/storedenum: let stored_flag_reader pad to a fixed
  byte count
 
 Inno Setup 6.7.0 padded both TSetupHeaderOption and TSetupFileEntryOption
@@ -56,6 +56,3 @@ index 0ccf333..00aec39 100644
  };
  
  template <class Enum>
--- 
-2.54.0.windows.1
-

--- a/mingw-w64-innoextract/0008-Add-support-for-the-Inno-Setup-6.5.0-entry-stream-re.patch
+++ b/mingw-w64-innoextract/0008-Add-support-for-the-Inno-Setup-6.5.0-entry-stream-re.patch
@@ -1,7 +1,7 @@
 From cc1444754d1ac68c59acb91f60bfb22ac2b34acf Mon Sep 17 00:00:00 2001
 From: Johannes Schindelin <johannes.schindelin@gmx.de>
 Date: Wed, 6 May 2026 20:33:46 +0200
-Subject: [PATCH 08/11] Add support for the Inno Setup 6.5.0 entry stream
+Subject: [PATCH 08/N] Add support for the Inno Setup 6.5.0 entry stream
  rework
 
 Inno Setup 6.5.0 made several invasive changes to the on-disk
@@ -620,6 +620,3 @@ index 0000000..e027d43
 +} // namespace setup
 +
 +#endif // INNOEXTRACT_SETUP_ISSIGKEY_HPP
--- 
-2.54.0.windows.1
-

--- a/mingw-w64-innoextract/0009-data-widen-the-per-file-location-start-offset-to-64-.patch
+++ b/mingw-w64-innoextract/0009-data-widen-the-per-file-location-start-offset-to-64-.patch
@@ -1,7 +1,7 @@
 From 5cb290709b281e8de5a752ae07b7c3eeddc5cd0f Mon Sep 17 00:00:00 2001
 From: Johannes Schindelin <johannes.schindelin@gmx.de>
 Date: Wed, 6 May 2026 21:20:26 +0200
-Subject: [PATCH 09/11] data: widen the per-file location start offset to 64
+Subject: [PATCH 09/N] data: widen the per-file location start offset to 64
  bits for Inno Setup 6.5.2
 
 Inno Setup 6.5.2 widened TSetupFileLocationEntry.StartOffset from
@@ -45,6 +45,3 @@ index a269c3c..9e48939 100644
  	
  	if(i.version >= INNO_VERSION(4, 0, 1)) {
  		file.offset = util::load<boost::uint64_t>(is);
--- 
-2.54.0.windows.1
-

--- a/mingw-w64-innoextract/0010-Add-support-for-the-Inno-Setup-6.6.0-entry-stream-re.patch
+++ b/mingw-w64-innoextract/0010-Add-support-for-the-Inno-Setup-6.6.0-entry-stream-re.patch
@@ -1,7 +1,7 @@
 From 1f1c5ce97d4b44deca39c8fd11130936ac9522e4 Mon Sep 17 00:00:00 2001
 From: Johannes Schindelin <johannes.schindelin@gmx.de>
 Date: Wed, 6 May 2026 22:33:50 +0200
-Subject: [PATCH 10/11] Add support for the Inno Setup 6.6.0 entry stream
+Subject: [PATCH 10/N] Add support for the Inno Setup 6.6.0 entry stream
  rework
 
 Inno Setup 6.6.0 reorganised TSetupLanguageEntry beyond what is
@@ -146,6 +146,3 @@ index 8801c64..99b65d0 100644
  	size_t title_font_size;
  	size_t welcome_font_size;
  	size_t copyright_font_size;
--- 
-2.54.0.windows.1
-

--- a/mingw-w64-innoextract/0011-Add-support-for-Inno-Setup-6.7.0-and-6.7.1.patch
+++ b/mingw-w64-innoextract/0011-Add-support-for-Inno-Setup-6.7.0-and-6.7.1.patch
@@ -1,7 +1,7 @@
 From 0254c3f11e34701000ad763be7753623f81152bf Mon Sep 17 00:00:00 2001
 From: Johannes Schindelin <johannes.schindelin@gmx.de>
 Date: Thu, 7 May 2026 01:08:13 +0200
-Subject: [PATCH 11/11] Add support for Inno Setup 6.7.0 and 6.7.1
+Subject: [PATCH 11/N] Add support for Inno Setup 6.7.0 and 6.7.1
 
 Inno Setup 6.7.0 made another sweep of changes to the on-disk
 serialisation. The 6.7.x point releases share a single SetupID magic,
@@ -461,6 +461,3 @@ index 4aadc56..01582aa 100644
  };
  
  } // anonymous namespace
--- 
-2.54.0.windows.1
-

--- a/mingw-w64-innoextract/0012-Add-support-for-Inno-Setup-7.0.0-preview-builds.patch
+++ b/mingw-w64-innoextract/0012-Add-support-for-Inno-Setup-7.0.0-preview-builds.patch
@@ -1,0 +1,79 @@
+From b152f283dee5f112d9129eefb40bdbd3f7ef09dd Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 28 Jul 2026 18:26:42 +0200
+Subject: [PATCH 12/N] Add support for Inno Setup 7.0.0 preview builds
+
+The Inno Setup 7.0.0-preview-2 and -preview-3 builds (issrc tags
+is-7_0_0_1 and is-7_0_0_2) identify their on-disk format with the
+SetupID magic "Inno Setup Setup Data (7.0.0.1)". The earlier
+7.0.0-preview-0 and -preview-1 builds, like the 6.7.x releases before
+them, still used the already-supported "(6.7.0)" magic; the released
+7.0.0, 7.0.1 and 7.0.2 switched to a later "(7.0.0.3)" magic handled in
+a follow-up commit.
+
+The sole format change carried by this magic is in TSetupRunEntry, the
+record behind [Run] and [UninstallRun] entries: an OnLog expression
+string was appended after BeforeInstall, bumping SetupRunEntryStrings
+from 13 to 14. See Projects/Src/Shared.Struct.pas at tag is-7_0_0_1 in
+https://github.com/jrsoftware/issrc. Read it as an encoded expression
+string right after the condition data and before the version data,
+gated to versions >= 7.0.0.1.
+
+Since these are preview builds, register the new SetupID as a
+prerelease Unicode variant, mirroring the existing 6.4.0 prerelease
+entry.
+
+Assisted-by: Claude Opus 4.8
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ src/setup/run.cpp     | 11 +++++++++++
+ src/setup/run.hpp     |  1 +
+ src/setup/version.cpp |  1 +
+ 3 files changed, 13 insertions(+)
+
+diff --git a/src/setup/run.cpp b/src/setup/run.cpp
+index 9fe1bdf..d428156 100644
+--- a/src/setup/run.cpp
++++ b/src/setup/run.cpp
+@@ -69,6 +69,17 @@ void run_entry::load(std::istream & is, const info & i) {
+ 	
+ 	load_condition_data(is, i);
+ 	
++	if(i.version >= INNO_VERSION_EXT(7, 0, 0, 1)) {
++		// Inno Setup 7.0.0 (SetupID "7.0.0.1", first used by the
++		// 7.0.0-preview-2 build) appended an OnLog expression string to
++		// TSetupRunEntry after BeforeInstall, bumping SetupRunEntryStrings
++		// from 13 to 14. See Projects/Src/Shared.Struct.pas at tag
++		// is-7_0_0_1 in https://github.com/jrsoftware/issrc.
++		is >> util::encoded_string(on_log, i.codepage);
++	} else {
++		on_log.clear();
++	}
++	
+ 	load_version_data(is, i.version);
+ 	
+ 	if(i.version >= INNO_VERSION(1, 3, 24)) {
+diff --git a/src/setup/run.hpp b/src/setup/run.hpp
+index cead27b..8691a67 100644
+--- a/src/setup/run.hpp
++++ b/src/setup/run.hpp
+@@ -67,6 +67,7 @@ struct run_entry : public item {
+ 	std::string status_message;
+ 	std::string verb;
+ 	std::string description;
++	std::string on_log;         //!< Inno Setup 7.0.0.1+ (OnLog)
+ 	
+ 	int show_command;
+ 	
+diff --git a/src/setup/version.cpp b/src/setup/version.cpp
+index 01582aa..bdde909 100644
+--- a/src/setup/version.cpp
++++ b/src/setup/version.cpp
+@@ -193,6 +193,7 @@ const known_version versions[] = {
+ 	{ "Inno Setup Setup Data (6.6.0)",                      INNO_VERSION_EXT(6, 6,  0, 0), version::Unicode },
+ 	{ "Inno Setup Setup Data (6.6.1)",                      INNO_VERSION_EXT(6, 6,  1, 0), version::Unicode },
+ 	{ "Inno Setup Setup Data (6.7.0)",                      INNO_VERSION_EXT(6, 7,  0, 0), version::Unicode },
++	{ "Inno Setup Setup Data (7.0.0.1)",   /* prerelease */ INNO_VERSION_EXT(7, 0,  0, 1), version::Unicode },
+ };
+ 
+ } // anonymous namespace

--- a/mingw-w64-innoextract/0013-Add-support-for-Inno-Setup-7.0.0-7.0.1-and-7.0.2.patch
+++ b/mingw-w64-innoextract/0013-Add-support-for-Inno-Setup-7.0.0-7.0.1-and-7.0.2.patch
@@ -1,0 +1,212 @@
+From e48636159522550acb2ac32950e43fb3c0d54281 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 29 Jul 2026 18:03:13 +0200
+Subject: [PATCH 13/N] Add support for Inno Setup 7.0.0, 7.0.1 and 7.0.2
+
+The released Inno Setup 7.0.0, 7.0.1 and 7.0.2 identify their setup
+data with the SetupID magic "Inno Setup Setup Data (7.0.0.3)";
+register it as a known Unicode version. Two on-disk format changes
+come with it, both described in Projects/Src/Shared.Struct.pas at
+tag is-7_0_0 in https://github.com/jrsoftware/issrc.
+
+TSetupHeader gained a CompiledCodeVersion field (Cardinal), inserted
+after the entry-count block and before MinVersion, recording the
+version of the compiled Pascal [Code] script. innoextract does not
+run that script and merely reads and stores the value.
+
+That magic also replaced the per-architecture option flags with a
+single-byte enum, TSetupEntryBitness = (ebInstallDefault, eb32Bit,
+eb64Bit, ebNativeBit, ebCurrentProcessBit). It drops fo32Bit/fo64Bit
+from TSetupFileEntry.Options, ro32Bit/ro64Bit from
+TSetupRegistryEntry.Options and roRun32Bit/roRun64Bit from
+TSetupRunEntry.Options; each of those three records now stores a
+Bitness byte immediately before Options.
+
+For 7.0.0.3 and newer, innoextract reads that Bitness byte in place of
+the removed flag pair and maps its two fixed-architecture values,
+eb32Bit and eb64Bit, back onto the Bits32/Bits64 flags so that
+architecture-based file-collision handling keeps working. The
+remaining values (ebInstallDefault, ebNativeBit and
+ebCurrentProcessBit) are architecture-neutral and set no flag.
+
+Assisted-by: Claude Opus 4.8
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ src/setup/file.cpp     | 21 ++++++++++++++++++++-
+ src/setup/header.cpp   | 11 +++++++++++
+ src/setup/header.hpp   |  2 ++
+ src/setup/registry.cpp | 18 +++++++++++++++++-
+ src/setup/run.cpp      | 18 +++++++++++++++++-
+ src/setup/version.cpp  |  1 +
+ 6 files changed, 68 insertions(+), 3 deletions(-)
+
+diff --git a/src/setup/file.cpp b/src/setup/file.cpp
+index 484b027..afb5c56 100644
+--- a/src/setup/file.cpp
++++ b/src/setup/file.cpp
+@@ -157,6 +157,25 @@ void file_entry::load(std::istream & is, const info & i) {
+ 		permission = boost::int16_t(-1);
+ 	}
+ 	
++	if(i.version >= INNO_VERSION_EXT(7, 0, 0, 3)) {
++		// Inno Setup 7.0.0 (SetupID "7.0.0.3") removed the fo32Bit/fo64Bit
++		// flags from TSetupFileEntryOption and moved the target
++		// architecture into a dedicated TSetupEntryBitness byte enum
++		// (ebInstallDefault, eb32Bit, eb64Bit, ebNativeBit,
++		// ebCurrentProcessBit) stored before Options. See
++		// Projects/Src/Shared.Struct.pas at tag is-7_0_0 in
++		// https://github.com/jrsoftware/issrc. Translate the two
++		// fixed-architecture values back into the existing Bits32/Bits64
++		// flags so architecture-specific collision handling keeps working;
++		// the runtime-resolved values are treated as architecture-neutral.
++		boost::uint8_t bitness = util::load<boost::uint8_t>(is);
++		if(bitness == 1) {
++			options |= Bits32;
++		} else if(bitness == 2) {
++			options |= Bits64;
++		}
++	}
++	
+ 	stored_flag_reader<flags> flagreader(is, i.version.bits());
+ 	
+ 	flagreader.add(ConfirmOverwrite);
+@@ -219,7 +238,7 @@ void file_entry::load(std::istream & is, const info & i) {
+ 	if(i.version >= INNO_VERSION(5, 1, 0)) {
+ 		flagreader.add(CreateAllSubDirs);
+ 	}
+-	if(i.version >= INNO_VERSION(5, 1, 2)) {
++	if(i.version >= INNO_VERSION(5, 1, 2) && i.version < INNO_VERSION_EXT(7, 0, 0, 3)) {
+ 		flagreader.add(Bits32);
+ 		flagreader.add(Bits64);
+ 	}
+diff --git a/src/setup/header.cpp b/src/setup/header.cpp
+index 7fbac6f..c4ad88f 100644
+--- a/src/setup/header.cpp
++++ b/src/setup/header.cpp
+@@ -390,6 +390,17 @@ void header::load(std::istream & is, const version & version) {
+ 		info_after_size = util::load<boost::int32_t>(is, version.bits());
+ 	}
+ 	
++	if(version >= INNO_VERSION_EXT(7, 0, 0, 3)) {
++		// Inno Setup 7.0.0 (SetupID "7.0.0.3") added a CompiledCodeVersion
++		// (Cardinal) field to TSetupHeader between the entry counts and
++		// MinVersion. See Projects/Src/Shared.Struct.pas at tag is-7_0_0 in
++		// https://github.com/jrsoftware/issrc. innoextract does not run the
++		// compiled [Code] script, so the value is only stored.
++		compiled_code_version = util::load<boost::uint32_t>(is);
++	} else {
++		compiled_code_version = 0;
++	}
++	
+ 	winver.load(is, version);
+ 	
+ 	if(version < INNO_VERSION_EXT(6, 4, 0, 1)) {
+diff --git a/src/setup/header.hpp b/src/setup/header.hpp
+index 2138c22..f2e03f2 100644
+--- a/src/setup/header.hpp
++++ b/src/setup/header.hpp
+@@ -206,6 +206,8 @@ struct header {
+ 	size_t run_entry_count;
+ 	size_t uninstall_run_entry_count;
+ 	
++	boost::uint32_t compiled_code_version; //!< Inno Setup 7.0.0.3+ (CompiledCodeVersion)
++	
+ 	windows_version_range winver;
+ 	
+ 	typedef boost::uint32_t Color;
+diff --git a/src/setup/registry.cpp b/src/setup/registry.cpp
+index f5a1ef4..19fc2ab 100644
+--- a/src/setup/registry.cpp
++++ b/src/setup/registry.cpp
+@@ -103,6 +103,17 @@ void registry_entry::load(std::istream & is, const info & i) {
+ 		type = stored_enum<stored_registry_entry_type_0>(is).get();
+ 	}
+ 	
++	boost::uint8_t bitness = 0;
++	if(i.version >= INNO_VERSION_EXT(7, 0, 0, 3)) {
++		// Inno Setup 7.0.0 (SetupID "7.0.0.3") removed the ro32Bit/ro64Bit
++		// flags from TSetupRegistryEntry.Options and moved the target
++		// registry view into a TSetupEntryBitness byte enum stored after
++		// Typ, before Options. See Projects/Src/Shared.Struct.pas at tag
++		// is-7_0_0 in https://github.com/jrsoftware/issrc. Translated to
++		// the existing Bits32/Bits64 flags after the flag set is read.
++		bitness = util::load<boost::uint8_t>(is);
++	}
++	
+ 	stored_flag_reader<flags> flagreader(is, i.version.bits());
+ 	
+ 	if(i.version.bits() != 16) {
+@@ -125,12 +136,17 @@ void registry_entry::load(std::istream & is, const info & i) {
+ 	if(i.version >= INNO_VERSION(1, 3, 16)) {
+ 		flagreader.add(DontCreateKey);
+ 	}
+-	if(i.version >= INNO_VERSION(5, 1, 0)) {
++	if(i.version >= INNO_VERSION(5, 1, 0) && i.version < INNO_VERSION_EXT(7, 0, 0, 3)) {
+ 		flagreader.add(Bits32);
+ 		flagreader.add(Bits64);
+ 	}
+ 	
+ 	options = flagreader.finalize();
++	if(bitness == 1) {
++		options |= Bits32;
++	} else if(bitness == 2) {
++		options |= Bits64;
++	}
+ }
+ 
+ } // namespace setup
+diff --git a/src/setup/run.cpp b/src/setup/run.cpp
+index d428156..e77c71e 100644
+--- a/src/setup/run.cpp
++++ b/src/setup/run.cpp
+@@ -90,6 +90,17 @@ void run_entry::load(std::istream & is, const info & i) {
+ 	
+ 	wait = stored_enum<stored_run_wait_condition>(is).get();
+ 	
++	boost::uint8_t bitness = 0;
++	if(i.version >= INNO_VERSION_EXT(7, 0, 0, 3)) {
++		// Inno Setup 7.0.0 (SetupID "7.0.0.3") removed the roRun32Bit/
++		// roRun64Bit flags from TSetupRunEntry.Options and moved the target
++		// architecture into a TSetupEntryBitness byte enum stored after
++		// Wait, before Options. See Projects/Src/Shared.Struct.pas at tag
++		// is-7_0_0 in https://github.com/jrsoftware/issrc. Translated to
++		// the existing Bits32/Bits64 flags after the flag set is read.
++		bitness = util::load<boost::uint8_t>(is);
++	}
++	
+ 	stored_flag_reader<flags> flagreader(is, i.version.bits());
+ 	
+ 	if(i.version >= INNO_VERSION(1, 2, 3)) {
+@@ -107,7 +118,7 @@ void run_entry::load(std::istream & is, const info & i) {
+ 	if(i.version >= INNO_VERSION(2, 0, 8)) {
+ 		flagreader.add(HideWizard);
+ 	}
+-	if(i.version >= INNO_VERSION(5, 1, 10)) {
++	if(i.version >= INNO_VERSION(5, 1, 10) && i.version < INNO_VERSION_EXT(7, 0, 0, 3)) {
+ 		flagreader.add(Bits32);
+ 		flagreader.add(Bits64);
+ 	}
+@@ -122,6 +133,11 @@ void run_entry::load(std::istream & is, const info & i) {
+ 	}
+ 	
+ 	options = flagreader.finalize();
++	if(bitness == 1) {
++		options |= Bits32;
++	} else if(bitness == 2) {
++		options |= Bits64;
++	}
+ }
+ 
+ } // namespace setup
+diff --git a/src/setup/version.cpp b/src/setup/version.cpp
+index bdde909..19e2c3c 100644
+--- a/src/setup/version.cpp
++++ b/src/setup/version.cpp
+@@ -194,6 +194,7 @@ const known_version versions[] = {
+ 	{ "Inno Setup Setup Data (6.6.1)",                      INNO_VERSION_EXT(6, 6,  1, 0), version::Unicode },
+ 	{ "Inno Setup Setup Data (6.7.0)",                      INNO_VERSION_EXT(6, 7,  0, 0), version::Unicode },
+ 	{ "Inno Setup Setup Data (7.0.0.1)",   /* prerelease */ INNO_VERSION_EXT(7, 0,  0, 1), version::Unicode },
++	{ "Inno Setup Setup Data (7.0.0.3)",                    INNO_VERSION_EXT(7, 0,  0, 3), version::Unicode },
+ };
+ 
+ } // anonymous namespace

--- a/mingw-w64-innoextract/0014-README-VERSION-advertise-that-InnoSetup-v7.0.2-is-su.patch
+++ b/mingw-w64-innoextract/0014-README-VERSION-advertise-that-InnoSetup-v7.0.2-is-su.patch
@@ -1,0 +1,41 @@
+From 376a13e7c41cc5528b6088d0dd16ec1b323a8d37 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 29 Jul 2026 18:12:11 +0200
+Subject: [PATCH 14/N] README/VERSION: advertise that InnoSetup v7.0.2 is
+ supported, too
+
+I forgot to bump this in the previous commits.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ README.md | 4 ++--
+ VERSION   | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/README.md b/README.md
+index 3a5e826..cdfc2bf 100644
+--- a/README.md
++++ b/README.md
+@@ -1,7 +1,7 @@
+ 
+-# innoextract - A tool to unpack installers created by Inno Setup
+ 
+-[Inno Setup](https://jrsoftware.org/isinfo.php) is a tool to create installers for Microsoft Windows applications. innoextract allows to extract such installers under non-Windows systems without running the actual installer using wine. innoextract currently supports installers created by Inno Setup 1.2.10 to 6.3.3.
++
++[Inno Setup](https://jrsoftware.org/isinfo.php) is a tool to create installers for Microsoft Windows applications. innoextract allows to extract such installers under non-Windows systems without running the actual installer using wine. innoextract currently supports installers created by Inno Setup 1.2.10 to 7.0.2.
+ 
+ In addition to standard Inno Setup installers, innoextract also supports some modified Inno Setup variants including Martijn Laan's My Inno Setup Extensions 1.3.10 to 3.0.6.1 as well as GOG.com's Inno Setup-based game installers. innoextract is able to unpack Wadjet Eye Games installers (to play with AGS), Arx Fatalis patches (for use with Arx Libertatis) as well as various other Inno Setup executables.
+ 
+diff --git a/VERSION b/VERSION
+index e2b4fe9..e42b64b 100644
+--- a/VERSION
++++ b/VERSION
+@@ -1,7 +1,7 @@
+ innoextract 1.10-dev
+ 
+ Known working Inno Setup versions:
+-Inno Setup 1.2.10 to 6.3.3
++Inno Setup 1.2.10 to 7.0.2
+ 
+ Bug tracker:
+ https://innoextract.constexpr.org/issues

--- a/mingw-w64-innoextract/PKGBUILD
+++ b/mingw-w64-innoextract/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _pkgver=1.9
 pkgver=1.9.r82.6e9e34e
-pkgrel=2
+pkgrel=3
 _commit=6e9e34ed0876014fdb46e684103ef8c3605e382e
 pkgdesc="A tool to extract installers created by Inno Setup (mingw-w64)"
 arch=('any')
@@ -38,19 +38,25 @@ source=("git+https://github.com/dscharrer/innoextract#commit=${_commit}"
         "0008-Add-support-for-the-Inno-Setup-6.5.0-entry-stream-re.patch"
         "0009-data-widen-the-per-file-location-start-offset-to-64-.patch"
         "0010-Add-support-for-the-Inno-Setup-6.6.0-entry-stream-re.patch"
-        "0011-Add-support-for-Inno-Setup-6.7.0-and-6.7.1.patch")
+        "0011-Add-support-for-Inno-Setup-6.7.0-and-6.7.1.patch"
+        "0012-Add-support-for-Inno-Setup-7.0.0-preview-builds.patch"
+        "0013-Add-support-for-Inno-Setup-7.0.0-7.0.1-and-7.0.2.patch"
+        "0014-README-VERSION-advertise-that-InnoSetup-v7.0.2-is-su.patch")
 sha256sums=('9e12fe63358bfa1b9ed4810f850d2e628ef7b87acc1ad44fc4d35e1b3a8e2a8e'
-            '8df6248cc85f7bad135acb20ca8acfad9c1af53f947729a858d7f470e70cb59c'
-            '3276cb3cbc2c9b4128047aae33385098c46dcaf138d7248a4b3e3541f256ea7f'
-            'cd45a25d31f083c31eafc906e1cfc192e63f43c61d946dce5f177a266b185a2b'
-            'c971ae68d5e289f351ff94b5a2c0a548f34b87e9d6e136e47c2c4c911d80500b'
-            '89fdeb932c6c86d304548e59a6a5bee56e13b55e7e0dea06259942d33fe6c322'
-            '7a757ad7f4221312954d55a67a84ca4453378fc30e0cefb80bf30f208f11c568'
-            '6ad83e255639e7ca733ee4e2d19c2d933064275be0219c56a0472a9ba734d99b'
-            '6e79f0d1f0cec40b9ceeb1f56bc7a1ab4e5597617e97627fa34ad8abe9e511c0'
-            'a0d6329d286c16d9419935daf2056b0fd01b72b6d04ced23d7610ebb8af6b88f'
-            '0d1985a70c533a67221bf5b182ffb1105d393758f649acd10f6953d6e5dc612a'
-            '311eafccac8e1c980d29c629102517ea3da08971b237380c82590fda6cdf3da3')
+            '14f7bb4332b8f5139541d76ee78ea8f6093809e875c7aadab56455bfe928d30c'
+            '3f96ac24c2aee0de29e4005b3445066cd72caf5a4c42b067fc386c80b69da352'
+            '8b9f293bde3cc22a15183029e4b50f56b6b7f26b2a28e58ea3a999b17ecb6596'
+            'c7b7768dd0ea815ecb3eba1f6e27adec3ba124ec630c7341802ac1b0885a7de1'
+            'ac90fd4dcf2bc1037ae5e74c350fdc758e2d1f6ce25b23f17879fadde2b70979'
+            '21d9d6f37f767f398f05cecde0fcc63b0916c955c09d21c44deb7625626d6466'
+            'ba88db2dfd1c23d7b5fd9689e32e5167ac61a529e4c5820424e9f858315ed774'
+            '0785b5e120ef77f62eaeae189b4e16deecb28850f4c6078dad7cdf12cec97998'
+            '9f07a75347ff2bd0df453c6958ba28a51b5d956127953802e9ddb57d24c3bbf4'
+            'c64526b35c8e451fbf441328661854839752d7350884c8907e5a6abad1f2baf5'
+            '4f21c9646199995224fa2130ac8ec118767bd8b19689fd16e2a3198411022aa5'
+            'f1bfe4ed13138b3975b33793fe57e596e1febf31e50167263efde825d0483e71'
+            '036460db84dd059fbe64245431c272871bc98245e46a58fe4aa2e8212e15bf63'
+            '521b4b0ffa1e0ca0dec7b82e4f93af244dec234ad9564ca06ef5d2e68ce30a85')
 validpgpkeys=("ADE9653703D4ADE0E997758128555A66D7E1DEC9") # Daniel Scharrer <daniel@constexpr.org>
 
 pkgver() {


### PR DESCRIPTION
With InnoSetup v7.0.2, that release train has left the beta stage and is now used e.g. to bundle Git for Windows' installer.

Since the upstream `innoextract` project seems to have lost interest in updating support for newer versions, there is now a long-running PR at https://github.com/dscharrer/innoextract/pull/210 to fill the widening gap.

In https://github.com/msys2/MINGW-packages/pull/29441, the MSYS2 project already accepted the then-current backfill to support versions up to InnoSetup v6.7.1, and with this here commit, that support is extended to the now-current InnoSetup version.