### PR TITLE
elmerfem: enable Zoltan with new release tarball 

### DIFF
--- a/mingw-w64-elmerfem/PKGBUILD
+++ b/mingw-w64-elmerfem/PKGBUILD
@@ -45,6 +45,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-libmariadbclient"
              $([[ "${CARCH}" == "aarch64" ]] || echo "${MINGW_PACKAGE_PREFIX}-msmpi")
              "${MINGW_PACKAGE_PREFIX}-netcdf"
+             "${MINGW_PACKAGE_PREFIX}-nlohmann-json"
              "${MINGW_PACKAGE_PREFIX}-openslide"
              "${MINGW_PACKAGE_PREFIX}-openvdb"
              "${MINGW_PACKAGE_PREFIX}-pdal"

--- a/mingw-w64-elmerfem/PKGBUILD
+++ b/mingw-w64-elmerfem/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          $([[ "${CARCH}" == "aarch64" ]] || echo "${MINGW_PACKAGE_PREFIX}-${_realname}-mpi"))
 pkgver=26.2.1
-pkgrel=3
+pkgrel=4
 pkgdesc="Finite element software for multiphysical problems (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64')
@@ -50,9 +50,9 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-pdal"
              "${MINGW_PACKAGE_PREFIX}-seacas"
              "${MINGW_PACKAGE_PREFIX}-utf8cpp")
-source=("https://github.com/ElmerCSC/elmerfem/archive/release-${pkgver}/${_realname}-${pkgver}.tar.gz"
+source=("https://github.com/ElmerCSC/elmerfem/releases/download/release-${pkgver}/${_realname}-release-${pkgver}.tar.gz"
         "001-use-system-metis.patch")
-sha256sums=('2271444cabdc9ae6185df961d939359062d43b1940ac9a7463a2b8adf7e0009b'
+sha256sums=('729809851d07b0ee8d7aff636bc21745d65b35c94d90027f39958fb759ec1d31'
             '4dbcdf142f368b2d45d9caa11ab2d899dc9625e876cb95ab47b7100ba734fabe')
 
 _apply_patch_with_msg() {
@@ -120,6 +120,7 @@ build() {
       "${_mumps_omp_config[@]}" \
       -DWITH_ElmerIce=OFF \
       -DWITH_MPI=OFF \
+      -DWITH_Zoltan=OFF \
       ../${_realname}-release-${pkgver}
 
   "${MINGW_PREFIX}"/bin/cmake.exe --build .
@@ -145,6 +146,7 @@ build() {
         "${_mumps_mpi_config[@]}" \
         -DWITH_ElmerIce=ON \
         -DWITH_MPI=ON \
+        -DWITH_Zoltan=ON \
         ../${_realname}-release-${pkgver}
 
     "${MINGW_PREFIX}"/bin/cmake.exe --build .


### PR DESCRIPTION
New tarballs have been uploaded for ElmerFEM that contain the Zoltan submodule.
The new tarballs are still for the released version of ElmerFEM. They just contain the files for the Zoltan submodule now.

Re-build ElmerFEM enabling Zoltan in the variant with MPI. (Zoltan requires MPI to be enabled.)

No conflict with the `trilinos` package (which installs an incompatible version of Zoltan as a shared library) is necessary because ElmerFEM links to its own version statically.

Also add the build dependency `nlohmann-json` that is required for importing the VTK CMake target now.
