### PR TITLE
rustfs/-launcher: update to 1.0.0-beta.12

### DIFF
--- a/mingw-w64-rustfs-launcher/PKGBUILD
+++ b/mingw-w64-rustfs-launcher/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=rustfs-launcher
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_pkgver=1.0.0-beta.11
+_pkgver=1.0.0-beta.12
 pkgver=${_pkgver//-/_}
 pkgrel=1
 pkgdesc="A simple launcher for RustFS (mingw-w64)"
@@ -26,7 +26,7 @@ makedepends=(
 )
 source=("${msys2_repository_url}/archive/${_pkgver}/launcher-${_pkgver}.tar.gz"
         '0001-launcher-0.0.4-system-candidate.patch')
-sha256sums=('c79cebe31066fa47c366bec63b3f65ffb8e205c2e294d3e009f6c8d1c3f03aee'
+sha256sums=('4d01e3c64148e5898b540f119f5200d7fb4e0129246137cf294b971e712e4aa2'
             'e66b9267bde7dc875c6bdca48563a5c2dc2c9764e1a9207c6c6b929b733d760a')
 
 prepare() {

--- a/mingw-w64-rustfs/PKGBUILD
+++ b/mingw-w64-rustfs/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=rustfs
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_pkgver=1.0.0-beta.11
+_pkgver=1.0.0-beta.12
 pkgver=${_pkgver//-/_}
 _consolever=0.1.17
 pkgrel=1
@@ -28,6 +28,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-flatbuffers"
   "${MINGW_PACKAGE_PREFIX}-protobuf"
   "${MINGW_PACKAGE_PREFIX}-git"
+  "${MINGW_PACKAGE_PREFIX}-sed"
 )
 source=(
   "${msys2_repository_url}/archive/${_pkgver}/rustfs-${_pkgver}.tar.gz"
@@ -35,7 +36,7 @@ source=(
 )
 noextract=("rustfs-${_pkgver}.tar.gz"
            "rustfs-console-v${_consolever}.zip")
-sha256sums=('00091f98304593594a5456709abfd936fdd8b0d4422760dfaa88a458276bd40e'
+sha256sums=('a80b8eff2d9234ac6a0a507f41ec3fc4572422d43b38498ef06a95b389391fad'
             '2f897a9ac76968e1b09d1f055f4aa49025b894d16a08fda5c264cda4d84dc290')
 
 prepare() {
@@ -49,6 +50,9 @@ prepare() {
     -d rustfs/static
 
   export RUSTUP_TOOLCHAIN=stable-${RUST_CHOST}
+
+  # for more info see https://github.com/msys2/MINGW-packages/pull/30731
+  sed -e 's|rust-version = "1.97.1"|rust-version = "1.97.0"|g' -i Cargo.toml
 
   rm rust-toolchain.toml
 


### PR DESCRIPTION
The `rustc 1.97.1` ~~is needed~~:
```
  error: rustc 1.97.0 is not supported by the following packages:
    rustfs-common@1.0.0-beta.12 requires rustc 1.97.1
    rustfs-config@1.0.0-beta.12 requires rustc 1.97.1
    rustfs-io-metrics@1.0.0-beta.12 requires rustc 1.97.1
    rustfs-protos@1.0.0-beta.12 requires rustc 1.97.1
    rustfs-protos@1.0.0-beta.12 requires rustc 1.97.1
    rustfs-s3-ops@1.0.0-beta.12 requires rustc 1.97.1
    rustfs-s3-types@1.0.0-beta.12 requires rustc 1.97.1
    rustfs-tls-runtime@1.0.0-beta.12 requires rustc 1.97.1
    rustfs-utils@1.0.0-beta.12 requires rustc 1.97.1
```