### PR TITLE
allow gcc plugins again, by disabling only plugins for ada

### DIFF
--- a/mingw-w64-gcc/0023-Ada-Don-t-export-gnat1-s-symbols-on-PE-hosts.patch
+++ b/mingw-w64-gcc/0023-Ada-Don-t-export-gnat1-s-symbols-on-PE-hosts.patch
@@ -1,0 +1,49 @@
+From: Kreijstal <rainb@tfwno.gf>
+Subject: [PATCH] Ada: Don't export gnat1's symbols on PE hosts
+
+--enable-plugin links every compiler proper with -Wl,--export-all-symbols
+-Wl,--out-implib=$@.a on mingw hosts, so that a plugin can resolve back into
+the compiler it is loaded by.  gnat1 is the one front end that cannot be
+linked that way: a PE/COFF export directory addresses its entries by a
+16-bit ordinal, so an image can export at most 65535 symbols, and gnat1 is
+past that ceiling.  With GCC 16.1.0 the link dies outright:
+
+  ld: error: export ordinal too large: 66466
+  make[3]: *** [gcc/ada/gcc-interface/Make-lang.in:796: gnat1.exe] Error 1
+
+There is no way to fit them all -- the limit is in the file format, not in
+the linker -- so drop just the plugin export flags for gnat1.  Ada is built,
+installed and used exactly as before; the only thing it loses is -fplugin,
+which needs the import library that cannot exist here anyway.  Every other
+front end keeps full plugin support.
+
+Hosts that do not link the compiler against an import library are left
+alone, so this changes nothing outside PE.
+
+--- a/gcc/ada/gcc-interface/Make-lang.in
++++ b/gcc/ada/gcc-interface/Make-lang.in
+@@ -787,6 +787,15 @@ ada/libgnat/s-excmac.adb: $(srcdir)/ada/libgnat/s-excmac__$(EH_MECHANISM).adb
+ 	mkdir -p ada/libgnat
+ 	$(CP) $< $@
+
++# A PE/COFF image addresses its exports by a 16-bit ordinal and so cannot
++# export more than 65535 symbols, which gnat1 -- unlike every other front
++# end -- exceeds.  Linking it with the --enable-plugin export flags fails
++# with "export ordinal too large", and no amount of pruning brings a front
++# end that large back under a limit set by the file format.  Link gnat1
++# without them instead: it just does not accept -fplugin then.
++ADA_BACKENDLIBS = $(if $(findstring --out-implib,$(PLUGINLIBS)),\
++		    $(filter-out $(PLUGINLIBS),$(BACKENDLIBS)),$(BACKENDLIBS))
++
+ # Needs to be built with CC=gcc
+ # Since the RTL should be built with the latest compiler, remove the
+ #  stamp target in the parent directory whenever gnat1 is rebuilt
+@@ -794,7 +803,7 @@ gnat1$(exeext): $(TARGET_ADA_SRCS) $(GNAT1_OBJS) $(ADA_BACKEND) $(EXTRA_HOST_OBJ
+ 		$(EXTRA_HOST_OBJS) $(LIBDEPS) $(ada.prev)
+ 	@$(call LINK_PROGRESS,$(INDEX.ada),start)
+ 	+$(GCC_LLINK) -o $@ $(GNAT1_OBJS) $(ADA_BACKEND) $(EXTRA_HOST_OBJS) $(CFLAGS) \
+-	  libcommon-target.a $(LIBS) $(SYSLIBS) $(BACKENDLIBS) $(GNATLIB)
++	  libcommon-target.a $(LIBS) $(SYSLIBS) $(ADA_BACKENDLIBS) $(GNATLIB)
+ 	$(RM) stamp-gnatlib2-rts stamp-tools
+ 	@$(call LINK_PROGRESS,$(INDEX.ada),end)
+

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -53,7 +53,7 @@ else
   _url=https://gcc.gnu.org/pub/gcc/snapshots/${_version}-${_snapshot}
 fi
 _libdir=lib/gcc/${CHOST}/${pkgver}
-pkgrel=5
+pkgrel=6
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64')
@@ -93,6 +93,7 @@ source=(${_url}/${_sourcedir}.tar.xz{,.sig}
         0014-gcc-9-branch-clone_function_name_1-Retain-any-stdcall-suffix.patch
         0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
         0022-unset-native-system-header-dir.patch
+        0023-Ada-Don-t-export-gnat1-s-symbols-on-PE-hosts.patch
         0140-gcc-diagnostic-color.patch
         0200-add-m-no-align-vector-insn-option-for-i386.patch
         2001-fix-building-rust-on-mingw-w64.patch
@@ -109,6 +110,7 @@ sha256sums=('50efb4d94c3397aff3b0d61a5abd748b4dd31d9d3f2ab7be05b171d36a510f79'
             'fd9bdecb2bbc4796bbc9f00b708dac42ef9e3464a06d6d27e5475cee117de5be'
             'ad1f7b5e7afaaec008b7cbd14feea13a10989fa91bda7003af72d457619bb199'
             'd8b9b979dc1742f63d23dfca92bc05944612bd196a31fb882b8a616baba84383'
+            '395dd4df29c295f917aa4a136a0aa72af34eee6320ecc2d92ee717397578398d'
             'c94004dab1685a6fa9124de86aae742df4136a2e9ff5d5e1ad87ecdc35fbcef4'
             '1484911163634f30324827619c873a6267b377abba0df8bbedfd128163c53ea4'
             'a411f59953553a3d01dd64c79b1acbb91eca092c4cb01bfd26b1c51c3eb798e8'
@@ -149,7 +151,8 @@ prepare() {
     0012-Handle-spaces-in-path-for-default-manifest.patch \
     0014-gcc-9-branch-clone_function_name_1-Retain-any-stdcall-suffix.patch \
     0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch \
-    0022-unset-native-system-header-dir.patch
+    0022-unset-native-system-header-dir.patch \
+    0023-Ada-Don-t-export-gnat1-s-symbols-on-PE-hosts.patch
 
   # Enable diagnostic color under mintty
   # based on https://github.com/BurntSushi/ripgrep/issues/94#issuecomment-261761687
@@ -202,7 +205,7 @@ build() {
     LDFLAGS+=" -Wl,--large-address-aware"
     local _arch=pentium4
   else
-    #_extra_config+=("--enable-plugin")
+    _extra_config+=("--enable-plugin")
     local _arch=nocona
   fi
 


### PR DESCRIPTION
Last pr https://github.com/msys2/MINGW-packages/pull/29194 silently disabled plugins which I was using for SEH on windows, I would like to have that functionality back, so I restored it, at the cost of disabling it for ada.

Caveat: ada currently segfaults if you attempt to use ada with plugins. But it was broken anyway — no gcc in the repo has plugins at all right now.

`gnat1` is the only front end past the 65535 PE export-ordinal limit (`export ordinal too large: 66466`), so this drops the plugin export flags for `gnat1` only. Ada never had usable plugins regardless: `gcc-ada-15.1.0-3`, built with `--enable-plugin` on, ships `gnat1.exe` and no `gnat1.exe.a`.