### PR TITLE
gtest: don't install .in files under src

### DIFF
--- a/mingw-w64-gtest/PKGBUILD
+++ b/mingw-w64-gtest/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gtest
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.17.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Google Testing and Mocking Framework (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -12,9 +12,11 @@ url="https://github.com/google/googletest"
 msys2_repository_url='https://github.com/google/googletest'
 license=('spdx:BSD-3-Clause')
 depends=("${MINGW_PACKAGE_PREFIX}-cc-libs")
-makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-ninja")
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+  "${MINGW_PACKAGE_PREFIX}-ninja"
+)
 source=("https://github.com/google/googletest/releases/download/v${pkgver}/googletest-${pkgver}.tar.gz"
         01-fix-pkgconfig-files.patch)
 sha256sums=('65fab701d9829d38cb77c14acdc431d2108bfdbf8979e40eb8ae567edf10b27c'
@@ -33,42 +35,35 @@ build() {
     _extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
-  mkdir -p "${srcdir}/build-${MSYSTEM}-static" && cd "${srcdir}/build-${MSYSTEM}-static"
-
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX" \
-    ${MINGW_PREFIX}/bin/cmake.exe \
+    cmake \
       -GNinja \
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
       "${_extra_config[@]}" \
       -DGOOGLETEST_VERSION="${pkgver}" \
       -DBUILD_SHARED_LIBS=OFF \
-      ../googletest-${pkgver}
+      -S googletest-${pkgver} \
+      -B build-${MSYSTEM}-static
 
-  ${MINGW_PREFIX}/bin/cmake.exe --build ./
-
-  mkdir -p "${srcdir}/build-${MSYSTEM}-shared" && cd "${srcdir}/build-${MSYSTEM}-shared"
+  cmake --build build-${MSYSTEM}-static
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX" \
-    ${MINGW_PREFIX}/bin/cmake.exe \
+    cmake \
       -GNinja \
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
       "${_extra_config[@]}" \
       -DGOOGLETEST_VERSION="${pkgver}" \
       -DBUILD_SHARED_LIBS=ON \
-      ../googletest-${pkgver}
+      -S googletest-${pkgver} \
+      -B build-${MSYSTEM}-shared
 
-  ${MINGW_PREFIX}/bin/cmake.exe --build ./
+  cmake --build build-${MSYSTEM}-shared
 }
 
 package() {
-  cd "${srcdir}/build-${MSYSTEM}-static"
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install ./
+  DESTDIR="${pkgdir}" cmake --install build-${MSYSTEM}-static
 
-  cd "${srcdir}/build-${MSYSTEM}-shared"
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install ./
-
-  mkdir -p "${pkgdir}"/${MINGW_PREFIX}/src/gtest/cmake
-  install -m 0644 "${srcdir}"/googletest-${pkgver}/googletest/cmake/* "${pkgdir}"${MINGW_PREFIX}/src/gtest/cmake/
+  DESTDIR="${pkgdir}" cmake --install build-${MSYSTEM}-shared
 
   install -Dm 0644 "${srcdir}"/googletest-${pkgver}/LICENSE \
     "${pkgdir}"${MINGW_PREFIX}/share/licenses/gtest/LICENSE


### PR DESCRIPTION
They are completely useless and redundant.