### PR TITLE
dbus: split documention into dbus-doc

### DIFF
--- a/mingw-w64-dbus/PKGBUILD
+++ b/mingw-w64-dbus/PKGBUILD
@@ -2,9 +2,12 @@
 
 _realname=dbus
 pkgbase=mingw-w64-${_realname}
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgname=(
+  "${MINGW_PACKAGE_PREFIX}-${_realname}"
+  "${MINGW_PACKAGE_PREFIX}-${_realname}-doc"
+)
 pkgver=1.16.2
-pkgrel=3
+pkgrel=4
 pkgdesc="Freedesktop.org message bus system (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -15,13 +18,16 @@ msys2_references=(
   "cpe: cpe:/a:freedesktop:dbus"
 )
 license=('spdx:AFL-2.1 OR GPL-2.0-or-later')
-makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-ninja"
-             "${MINGW_PACKAGE_PREFIX}-pkgconf"
-             "${MINGW_PACKAGE_PREFIX}-expat"
-             "${MINGW_PACKAGE_PREFIX}-glib2"
-             "${MINGW_PACKAGE_PREFIX}-doxygen")
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+  "${MINGW_PACKAGE_PREFIX}-ninja"
+  "${MINGW_PACKAGE_PREFIX}-pkgconf"
+  "${MINGW_PACKAGE_PREFIX}-expat"
+  "${MINGW_PACKAGE_PREFIX}-glib2"
+  "${MINGW_PACKAGE_PREFIX}-doxygen"
+)
+options=('!emptydirs')
 source=("https://dbus.freedesktop.org/releases/dbus/${_realname}-${pkgver}.tar.xz"{,.asc}
         "0001-add-aarch64-backtrace-support.patch"
         "0002-enable-static-lib.patch")
@@ -74,14 +80,33 @@ build() {
 }
 
 check() {
-  cd "${srcdir}/build-${MSYSTEM}"
-  ctest
+  ctest --test-dir "build-${MSYSTEM}-shared" --output-on-failure
 }
 
-package() {
+package_dbus() {
+  optdepends=("${MINGW_PACKAGE_PREFIX}-dbus-doc: html documentation")
   DESTDIR="${pkgdir}" cmake --install build-${MSYSTEM}-static
   DESTDIR="${pkgdir}" cmake --install build-${MSYSTEM}-shared
+
+  # HACK: move doc out for dbus-doc package
+  mv "${pkgdir}${MINGW_PREFIX}/share/doc" "${pkgdir}/../"
 
   install -Dt "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname} -m644 "${srcdir}"/${_realname}-${pkgver}/COPYING
   install -Dt "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname} -m644 "${srcdir}"/${_realname}-${pkgver}/LICENSES/{AFL-2.1,GPL-2.0-or-later}.txt
 }
+
+package_dbus-doc() {
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/share"
+  mv "${pkgdir}/../doc" "${pkgdir}${MINGW_PREFIX}/share/"
+}
+
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
+
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;


### PR DESCRIPTION
This significantly reduce installed size from ~24MB to ~3MB