### PR TITLE
Split portaudio with asio support to portaudio-asio.

### DIFF
--- a/mingw-w64-portaudio/PKGBUILD
+++ b/mingw-w64-portaudio/PKGBUILD
@@ -2,11 +2,12 @@
 
 _realname=portaudio
 pkgbase=mingw-w64-${_realname}
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-asio")
 epoch=1
 pkgver=19.7.0
 _tarver=190700_20210406
-pkgrel=5
+pkgrel=6
 pkgdesc="A free, cross-platform, open source, audio I/O library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -53,14 +54,25 @@ prepare() {
 }
 
 build() {
-  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
-
   declare -a extra_config
   if check_option "debug" "n"; then
     extra_config+=("-DCMAKE_BUILD_TYPE=Release")
   else
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
+
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake \
+      -GNinja \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      "${extra_config[@]}" \
+      ../${_realname}
+
+  ${MINGW_PREFIX}/bin/cmake --build .
+
+  mkdir -p "${srcdir}/build-${MSYSTEM}-asio" && cd "${srcdir}/build-${MSYSTEM}-asio"
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake \
@@ -73,8 +85,30 @@ build() {
   ${MINGW_PREFIX}/bin/cmake --build .
 }
 
-package() {
+package_portaudio() {
   cd "${srcdir}/build-${MSYSTEM}"
 
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --build . --target install
 }
+
+package_portaudio-asio() {
+  pkgdesc="A free, cross-platform, open source, audio I/O library with ASIO support (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-cc-libs")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+  provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+
+  cd "${srcdir}/build-${MSYSTEM}-asio"
+
+  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --build . --target install
+}
+
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
+
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;


### PR DESCRIPTION
Fixes #30506 . Copies patterns from bullet's PKGBUILD.