### PR TITLE
glfw: update to 3.5.1

### DIFF
--- a/mingw-w64-glfw/PKGBUILD
+++ b/mingw-w64-glfw/PKGBUILD
@@ -4,7 +4,7 @@ _realname=glfw
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-docs")
-pkgver=3.4
+pkgver=3.5.1
 pkgrel=1
 pkgdesc="A free, open source, portable framework for OpenGL application development (mingw-w64)"
 arch=('any')
@@ -22,7 +22,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-doxygen")
 source=("https://github.com/glfw/glfw/archive/${pkgver}/${_realname}-${pkgver}.tar.gz"
         001-3.2-cmake-suffix.patch)
-sha256sums=('c038d34200234d071fae9345bc455e4a8f2f544ab60150765d7704e08f3dac01'
+sha256sums=('5234f4f29473e9a06bc7847d8371858dd135d38466eeeaa652fdc9f8f9ff0c20'
             'ed4444d58e8b4cf40780bc2f22cff00f12efd50ec3cffa338d402430eea5a910')
 
 prepare() {


### PR DESCRIPTION
It seems that this minor release is ABI-compatible (goxel runs without any problems). Should we recompile all the dependent packages?