### PR TITLE
git: use mingw-w64-perl

### DIFF
--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -3,66 +3,65 @@
 _realname=git
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
-	 "${MINGW_PACKAGE_PREFIX}-${_realname}-doc-html"
-	 "${MINGW_PACKAGE_PREFIX}-${_realname}-doc-man"
-	 "${MINGW_PACKAGE_PREFIX}-${_realname}-subtree"
-	 "${MINGW_PACKAGE_PREFIX}-${_realname}-credential-wincred"
-	 "${MINGW_PACKAGE_PREFIX}-${_realname}-perl"
-	 "${MINGW_PACKAGE_PREFIX}-${_realname}-send-email"
-	 "${MINGW_PACKAGE_PREFIX}-gitweb"
-	 "${MINGW_PACKAGE_PREFIX}-${_realname}-svn"
-	 "${MINGW_PACKAGE_PREFIX}-${_realname}-archimport"
-	 "${MINGW_PACKAGE_PREFIX}-${_realname}-cvs"
-	 "${MINGW_PACKAGE_PREFIX}-${_realname}-p4"
-	 "${MINGW_PACKAGE_PREFIX}-gitk"
-	 "${MINGW_PACKAGE_PREFIX}-${_realname}-gui"
-	 "${MINGW_PACKAGE_PREFIX}-${_realname}-for-windows-addons")
+   "${MINGW_PACKAGE_PREFIX}-${_realname}-doc-html"
+   "${MINGW_PACKAGE_PREFIX}-${_realname}-doc-man"
+   "${MINGW_PACKAGE_PREFIX}-${_realname}-subtree"
+   "${MINGW_PACKAGE_PREFIX}-${_realname}-credential-wincred"
+   "${MINGW_PACKAGE_PREFIX}-${_realname}-perl"
+   "${MINGW_PACKAGE_PREFIX}-${_realname}-send-email"
+   "${MINGW_PACKAGE_PREFIX}-gitweb"
+   "${MINGW_PACKAGE_PREFIX}-${_realname}-svn"
+   "${MINGW_PACKAGE_PREFIX}-${_realname}-archimport"
+   "${MINGW_PACKAGE_PREFIX}-${_realname}-cvs"
+   "${MINGW_PACKAGE_PREFIX}-${_realname}-p4"
+   "${MINGW_PACKAGE_PREFIX}-gitk"
+   "${MINGW_PACKAGE_PREFIX}-${_realname}-gui"
+   "${MINGW_PACKAGE_PREFIX}-${_realname}-for-windows-addons")
 tag=2.55.0.windows.3
-pkgver=${tag/.windows./.}
-pkgrel=1
+pkgver=${tag/.windows/}
+pkgrel=2
 pkgdesc="The fast distributed version control system (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
 url="https://gitforwindows.org/"
+msys2_repository_url="https://github.com/git-for-windows/git"
 msys2_references=(
   "cpe: cpe:/a:git-scm:git"
   "cpe: cpe:/a:git:git"
   "cpe: cpe:/a:git_project:git"
 )
-license=('GPL2')
-
-options=()
-makedepends=('git' 'openssh' 'ca-certificates' 'xmlto' 'docbook-xsl' 'docbook-xsl-ns'
-	"${MINGW_PACKAGE_PREFIX}-cc"
-	"${MINGW_PACKAGE_PREFIX}-curl"
-	"${MINGW_PACKAGE_PREFIX}-expat>=2.0"
-	"${MINGW_PACKAGE_PREFIX}-openssl"
-	"${MINGW_PACKAGE_PREFIX}-pcre2"
-	"${MINGW_PACKAGE_PREFIX}-asciidoctor")
-
-source=("${_realname}"::"git+https://github.com/git-for-windows/git.git#tag=v$tag"
-	'git-for-windows.ico'
-	'start-ssh-agent.cmd'
-	'start-ssh-pageant.cmd'
-	'git-wrapper.c'
-	'git-bash.rc'
-	'git-bash.adoc'
-	'git-cmd.rc'
-	'git-wrapper.rc'
-	'gitk.rc'
-	'compat-bash.rc'
-	'tig.rc'
-	'mingw-w64-git.mak'
-	'cv2pdb-strip'
-	'edit-git-bash.c')
-
-# Need to disable autoCRLF to ensure a stable checksum; `git archive` (which
-# is used by `calc_checksum_git()` in `/usr/share/makepkg/source/git.sh`) would
-# otherwise produce different line endings depending on the autoCRLF setting,
-# resulting in different sha256sums.
-export GIT_CONFIG_PARAMETERS="${GIT_CONFIG_PARAMETERS:+$GIT_CONFIG_PARAMETERS }'core.autocrlf=false' 'core.eol=lf'"
-
-sha256sums=('f29bb132f02371d28bd473ee872c42adcc6d8e3f58a61a810c400fc78d67dcfd'
+license=('spdx:GPL-2.0-or-later') # and LGPL-2.1-or-later')
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-asciidoctor"
+  "${MINGW_PACKAGE_PREFIX}-ca-certificates"
+  "${MINGW_PACKAGE_PREFIX}-curl"
+  "${MINGW_PACKAGE_PREFIX}-docbook-xsl"
+  "${MINGW_PACKAGE_PREFIX}-expat"
+  "${MINGW_PACKAGE_PREFIX}-gettext-tools"
+  "${MINGW_PACKAGE_PREFIX}-openssl"
+  "${MINGW_PACKAGE_PREFIX}-pcre2"
+  "${MINGW_PACKAGE_PREFIX}-rust"
+  #"${MINGW_PACKAGE_PREFIX}-xmlto"
+  'docbook-xsl'
+  'docbook-xsl-ns'
+  'xmlto')
+source=("https://github.com/git-for-windows/git/archive/v$tag/${_realname}-${tag}.tar.gz"
+  'git-for-windows.ico'
+  'start-ssh-agent.cmd'
+  'start-ssh-pageant.cmd'
+  'git-wrapper.c'
+  'git-bash.rc'
+  'git-bash.adoc'
+  'git-cmd.rc'
+  'git-wrapper.rc'
+  'gitk.rc'
+  'compat-bash.rc'
+  'tig.rc'
+  'mingw-w64-git.mak'
+  'cv2pdb-strip'
+  'edit-git-bash.c')
+sha256sums=('412a3ea02d49ef902c712588194eea63af686bcb128187699bed5c6c68b22e74'
             'a9dcba5aebc93ae7aacdee03275780fc6c0f15e88fda30c93041e75851e75090'
             '7e6c5f3dc6a4209dca0e1f38880b2978500a5c745c04bc60dbeda5fc48e8d3cb'
             '80b0b11efe5a2f9b4cd92f28c260d0b3aad8b809c34ed95237c59b73e08ade0b'
@@ -83,40 +82,28 @@ STRIP=
 STRIP_OPTS=
 LDFLAGS=
 
-if test i686 = "$CARCH"
-then
-  # There is no i686 Rust we can use
-  export NO_RUST=ThatsRight
-fi
-
-if test -z "$NO_RUST"
-then
-  makedepends+=("${MINGW_PACKAGE_PREFIX}-rust")
-fi
-
-if test -z "$WITH_PDBS"
-then
+if test -z "$WITH_PDBS"; then
   options+=('strip')
-elif [[ "$MSYSTEM" == CLANG* ]]
-then
-  pkgname+=("${MINGW_PACKAGE_PREFIX}-${_realname}-pdb")
-  options+=('!strip')
-  STRIP=llvm-strip
-  STRIP_OPTS=--strip-debug
-  LDFLAGS="-Wl,-pdb=" # Ensures that Clang generates PDB files
 else
   pkgname+=("${MINGW_PACKAGE_PREFIX}-${_realname}-pdb")
-  makedepends+=("${MINGW_PACKAGE_PREFIX}-cv2pdb")
   options+=('!strip')
-  COMPAT_CFLAGS="-gdwarf-4 -gstrict-dwarf" # cv2pdb cannot really handle DWARF5 yet
-  STRIP="${BASH_SOURCE%/*}/src/cv2pdb-strip"
+  if [[ "$MSYSTEM" == CLANG* ]]; then
+    STRIP=llvm-strip
+    STRIP_OPTS=--strip-debug
+    LDFLAGS="-Wl,-pdb=" # Ensures that Clang generates PDB files
+  else
+    makedepends+=("${MINGW_PACKAGE_PREFIX}-cv2pdb")
+    options+=('!strip')
+    COMPAT_CFLAGS="-gdwarf-4 -gstrict-dwarf" # cv2pdb cannot really handle DWARF5 yet
+    STRIP="${BASH_SOURCE%/*}/src/cv2pdb-strip"
+  fi
 fi
 
 SHAREDIR=$MINGW_PREFIX/share/git
 _DEFAULT_EDITOR="${_DEFAULT_EDITOR:-nano}"
 
 prepare () {
-  cd "$srcdir/git" &&
+  cd "$srcdir/${_realname}-${tag}" &&
 
   cat >config.mak <<-EOF
 	CC = $CC
@@ -130,11 +117,11 @@ prepare () {
 }
 
 build() {
-  cd "$srcdir/git"
+  cd "$srcdir/${_realname}-${tag}"
 
   # Git wants to decide itself whether to use ANSI stdio emulation or not
   CPPFLAGS="$(echo "$CPPFLAGS" |
-	sed 's/-D__USE_MINGW_ANSI_STDIO\(=[0-9]*\)\?//')"
+  sed 's/-D__USE_MINGW_ANSI_STDIO\(=[0-9]*\)\?//')"
 
   # Guarantee that `GIT-VERSION-GEN` determines the version
   unset GIT_VERSION
@@ -142,10 +129,10 @@ build() {
   # Make git-bash.exe first, to avoid triggering `* new link flags`
   rm -f *.res &&
   make -f ../mingw-w64-git.mak git-wrapper.exe \
-	git-bash.exe git-cmd.exe compat-bash.exe \
-	cmd/git.exe cmd/gitk.exe cmd/git-gui.exe \
-	cmd/git-receive-pack.exe cmd/git-upload-pack.exe \
-	cmd/tig.exe edit-git-bash.exe &&
+  git-bash.exe git-cmd.exe compat-bash.exe \
+  cmd/git.exe cmd/gitk.exe cmd/git-gui.exe \
+  cmd/git-receive-pack.exe cmd/git-upload-pack.exe \
+  cmd/tig.exe edit-git-bash.exe &&
   rm -f *.res &&
 
   # Also build git-credential-wincred.exe before the rest, so that those
@@ -185,12 +172,12 @@ build() {
 package_git () {
   depends=("${MINGW_PACKAGE_PREFIX}-curl"
            "${MINGW_PACKAGE_PREFIX}-ca-certificates"
-           "${MINGW_PACKAGE_PREFIX}-expat>=2.0"
+           "${MINGW_PACKAGE_PREFIX}-expat"
            "${MINGW_PACKAGE_PREFIX}-openssl"
            "${MINGW_PACKAGE_PREFIX}-pcre2"
            "$_DEFAULT_EDITOR")
 
-  cd "$srcdir"/git
+  cd "$srcdir"/${_realname}-${tag}
 
   make -j1 DESTDIR="$pkgdir" install
 
@@ -236,7 +223,7 @@ package_git () {
 }
 
 package_git-doc-html () {
-  cd "$srcdir"/git
+  cd "$srcdir"/${_realname}-${tag}
 
   make DESTDIR="$pkgdir" install-html
 
@@ -284,7 +271,7 @@ package_git-doc-html () {
 }
 
 package_git-doc-man () {
-  cd "$srcdir"/git
+  cd "$srcdir"/${_realname}-${tag}
 
   make DESTDIR="$pkgdir" install-man
 
@@ -322,7 +309,7 @@ package_git-subtree () {
   depends=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}")
   pkgdesc="Subtree support for Git (mingw-w64)"
 
-  cd "$srcdir"/git
+  cd "$srcdir"/${_realname}-${tag}
 
   make -C contrib/subtree prefix="$pkgdir/$MINGW_PREFIX" install
   make -C contrib/subtree prefix="$pkgdir/$MINGW_PREFIX" install-man
@@ -333,7 +320,7 @@ package_git-credential-wincred () {
   depends=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}")
   pkgdesc="Git credential helper for Windows Credential Manager (mingw-w64)"
 
-  cd "$srcdir"/git
+  cd "$srcdir"/${_realname}-${tag}
 
   install -d -m755 "$pkgdir/$MINGW_PREFIX/libexec/git-core"
   make -C contrib/credential/wincred prefix="$pkgdir/$MINGW_PREFIX" install
@@ -341,13 +328,13 @@ package_git-credential-wincred () {
 
 package_git-perl () {
   depends=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}"
-           "perl>=5.14.0"
-           "perl-Error"
-           "perl-libwww"
-           "perl-TermReadKey")
+           "${MINGW_PACKAGE_PREFIX}-perl"
+           "${MINGW_PACKAGE_PREFIX}-perl-error"
+           "${MINGW_PACKAGE_PREFIX}-perl-libwww"
+           "${MINGW_PACKAGE_PREFIX}-perl-termreadkey")
   pkgdesc="Perl module for Git (mingw-w64)"
 
-  cd "$srcdir"/git
+  cd "$srcdir"/${_realname}-${tag}
 
   # Install Git.pm and related Perl modules (excluding Git::SVN)
   make -j1 -f ../mingw-w64-git.mak DESTDIR="$pkgdir" install-perl-module
@@ -356,12 +343,12 @@ package_git-perl () {
 package_git-send-email () {
   depends=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}"
            "${MINGW_PACKAGE_PREFIX}-${_realname}-perl=${pkgver}"
-           "perl-Authen-SASL"
-           "perl-MIME-tools"
-           "perl-Net-SMTP-SSL")
+           "${MINGW_PACKAGE_PREFIX}-perl-authen-sasl"
+           "${MINGW_PACKAGE_PREFIX}-perl-mime-tools"
+           "${MINGW_PACKAGE_PREFIX}-perl-net-smtp-ssl")
   pkgdesc="Send patch emails with git (mingw-w64)"
 
-  cd "$srcdir"/git
+  cd "$srcdir"/${_realname}-${tag}
 
   install -d -m755 "$pkgdir/$MINGW_PREFIX/libexec/git-core"
   install -m755 git-send-email "$pkgdir/$MINGW_PREFIX/libexec/git-core/"
@@ -376,10 +363,10 @@ package_git-send-email () {
 
 package_gitweb () {
   depends=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}"
-           "perl")
+           "${MINGW_PACKAGE_PREFIX}-perl")
   pkgdesc="Git web interface (mingw-w64)"
 
-  cd "$srcdir"/git
+  cd "$srcdir"/${_realname}-${tag}
 
   make DESTDIR="$pkgdir" install-gitweb
 
@@ -401,7 +388,7 @@ package_git-svn () {
            "subversion")
   pkgdesc="Subversion support for Git (mingw-w64)"
 
-  cd "$srcdir"/git
+  cd "$srcdir"/${_realname}-${tag}
 
   install -d -m755 "$pkgdir/$MINGW_PREFIX/libexec/git-core"
   install -m755 git-svn "$pkgdir/$MINGW_PREFIX/libexec/git-core/"
@@ -422,7 +409,7 @@ package_git-archimport () {
            "${MINGW_PACKAGE_PREFIX}-${_realname}-perl=${pkgver}")
   pkgdesc="Import an Arch repository into Git (mingw-w64)"
 
-  cd "$srcdir"/git
+  cd "$srcdir"/${_realname}-${tag}
 
   install -d -m755 "$pkgdir/$MINGW_PREFIX/libexec/git-core"
   install -m755 git-archimport "$pkgdir/$MINGW_PREFIX/libexec/git-core/"
@@ -438,10 +425,10 @@ package_git-archimport () {
 package_git-cvs () {
   depends=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}"
            "${MINGW_PACKAGE_PREFIX}-${_realname}-perl=${pkgver}"
-           "perl-DBI")
+           "${MINGW_PACKAGE_PREFIX}-perl-dbi")
   pkgdesc="CVS support for Git (mingw-w64)"
 
-  cd "$srcdir"/git
+  cd "$srcdir"/${_realname}-${tag}
 
   install -d -m755 "$pkgdir/$MINGW_PREFIX/bin"
   install -m755 git-cvsserver "$pkgdir/$MINGW_PREFIX/bin/"
@@ -475,7 +462,7 @@ package_gitk () {
            "${MINGW_PACKAGE_PREFIX}-tk")
   pkgdesc="Git repository browser (mingw-w64)"
 
-  cd "$srcdir"/git
+  cd "$srcdir"/${_realname}-${tag}
 
   make -C gitk-git prefix="$pkgdir/$MINGW_PREFIX" install
 
@@ -493,7 +480,7 @@ package_git-gui () {
            "${MINGW_PACKAGE_PREFIX}-tk")
   pkgdesc="Git GUI tool (mingw-w64)"
 
-  cd "$srcdir"/git
+  cd "$srcdir"/${_realname}-${tag}
 
   make -C git-gui DESTDIR="$pkgdir$MINGW_PREFIX" gitexecdir=/libexec/git-core install
 
@@ -510,7 +497,7 @@ package_git-p4 () {
            "${MINGW_PACKAGE_PREFIX}-python")
   pkgdesc="Perforce support for Git (mingw-w64)"
 
-  cd "$srcdir"/git
+  cd "$srcdir"/${_realname}-${tag}
 
   install -d -m755 "$pkgdir/$MINGW_PREFIX/libexec/git-core"
   install -m755 git-p4 "$pkgdir/$MINGW_PREFIX/libexec/git-core/"
@@ -524,34 +511,34 @@ package_git-p4 () {
 }
 
 echo 'bin_path () {
-	echo "$(cygpath -am / | sed "s/^\\([A-Z]\\):/\\/proc\\/cygdrive\\/\\1/")/bin"
+  echo "$(cygpath -am / | sed "s/^\\([A-Z]\\):/\\/proc\\/cygdrive\\/\\1/")/bin"
 }
 
 copy_files () {
-	mkdir -p "$2" &&
-	cp "$1"/share/git/compat-bash.exe "$2"/bash.exe &&
-	cp "$1"/share/git/compat-bash.exe "$2"/sh.exe &&
-	cp /cmd/git.exe "$2"/
+  mkdir -p "$2" &&
+  cp "$1"/share/git/compat-bash.exe "$2"/bash.exe &&
+  cp "$1"/share/git/compat-bash.exe "$2"/sh.exe &&
+  cp /cmd/git.exe "$2"/
 }
 
 post_install () {
-	# Install git, bash and sh redirectors into the bin/ directory
-	# This needs to use the absolute path because /bin/ is overlayed by
-	# /usr/bin/.
-	copy_files '"$MINGW_PREFIX"' "$(bin_path)"
+  # Install git, bash and sh redirectors into the bin/ directory
+  # This needs to use the absolute path because /bin/ is overlayed by
+  # /usr/bin/.
+  copy_files '"$MINGW_PREFIX"' "$(bin_path)"
 }
 
 post_upgrade () {
-	post_install
+  post_install
 }
 
 remove_files () {
-	rm "$1"/git.exe "$1"/bash.exe "$1"/sh.exe &&
-	{ test -n "$(ls -A "$1")" || rm -r "$1"; }
+  rm "$1"/git.exe "$1"/bash.exe "$1"/sh.exe &&
+  { test -n "$(ls -A "$1")" || rm -r "$1"; }
 }
 
 post_remove () {
-	remove_files "$(bin_path)"
+  remove_files "$(bin_path)"
 }
 ' >"${MINGW_PACKAGE_PREFIX}-git-for-windows-addons.install"
 
@@ -565,7 +552,7 @@ package_git-for-windows-addons () {
   pkgdesc="Git for Windows extra executables and wrappers (mingw-w64)"
   install=${MINGW_PACKAGE_PREFIX}-git-for-windows-addons.install
 
-  cd "$srcdir"/git
+  cd "$srcdir"/${_realname}-${tag}
 
   # Git Bash, Git CMD
   install -d -m755 $pkgdir$SHAREDIR
@@ -579,9 +566,9 @@ package_git-for-windows-addons () {
   # Install Git wrapper into /cmd/
   install -d -m755 $pkgdir/cmd
   install -m755 cmd/git.exe cmd/gitk.exe cmd/git-gui.exe \
-	cmd/git-receive-pack.exe cmd/git-upload-pack.exe \
-	cmd/tig.exe ../start-ssh-agent.cmd ../start-ssh-pageant.cmd \
-	$pkgdir/cmd
+  cmd/git-receive-pack.exe cmd/git-upload-pack.exe \
+  cmd/tig.exe ../start-ssh-agent.cmd ../start-ssh-pageant.cmd \
+  $pkgdir/cmd
 
   # Scalar
   test ! -x ./scalar.exe ||
@@ -599,7 +586,7 @@ package_git-for-windows-addons () {
 }
 
 package_git-pdb () {
-  cd "$srcdir"/git
+  cd "$srcdir"/${_realname}-${tag}
 
   make -f ../mingw-w64-git.mak DESTDIR="$pkgdir" install-pdbs
 }


### PR DESCRIPTION
perl packages are not available for mingw64.

I'll mark it as a draft until git-for-windows move to UCRT64 git-for-windows/git-sdk-64#117