### PR TITLE
fzf: update to 0.74.2

### DIFF
--- a/mingw-w64-fzf/PKGBUILD
+++ b/mingw-w64-fzf/PKGBUILD
@@ -3,11 +3,11 @@
 _realname=fzf
 pkgbase="mingw-w64-${_realname}"
 pkgname="$MINGW_PACKAGE_PREFIX-${_realname}"
-pkgver=0.74.1
+pkgver=0.74.2
 pkgrel=1
 pkgdesc='Command-line fuzzy finder (mingw-w64)'
 arch=('any')
-mingw_arch=(mingw64 ucrt64 clang64 clangarm64)
+mingw_arch=(ucrt64 clang64 clangarm64)
 msys2_references=(
   'anitya: 15856'
   'archlinux: fzf'
@@ -24,7 +24,7 @@ makedepends=(
 options=('!strip')
 source=("https://github.com/junegunn/fzf/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
         "001-detect-arch.patch")
-sha256sums=('ba37120bbe45966c6eba6a00c8ea64b86c3c57e349cb55b1c3e0f522976fd978'
+sha256sums=('3ce36bd4fb0cde458a7f93c11ef534408d92c3bf19e6acc90e112f3e9e2acc60'
             '91c5a10e23125bdfb8ccf03daabf65f984b7d203d1da40f9e749ee83ea6e7aca')
 
 apply_patch_with_msg() {


### PR DESCRIPTION
This commit also drops the mingw64 package of fzf, because the enviroment has been deprecated.