### PR TITLE
osgearth: Update to 3.8.1

### DIFF
--- a/mingw-w64-osgearth/PKGBUILD
+++ b/mingw-w64-osgearth/PKGBUILD
@@ -4,9 +4,8 @@
 _realname=osgearth
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=3.8
-pkgrel=2
-_lerc_commit=19542a00b9a8b5c1089f74239e5859e02e403212
+pkgver=3.8.1
+pkgrel=1
 arch=('any')
 pkgdesc="A terrain rendering toolkit for OpenSceneGraph (mingw-w64)"
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -23,7 +22,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
          "${MINGW_PACKAGE_PREFIX}-gdal"
          "${MINGW_PACKAGE_PREFIX}-geos"
          "${MINGW_PACKAGE_PREFIX}-glew"
-         #"${MINGW_PACKAGE_PREFIX}-lerc"
+         "${MINGW_PACKAGE_PREFIX}-lerc"
          #"${MINGW_PACKAGE_PREFIX}-leveldb"
          #"${MINGW_PACKAGE_PREFIX}-libzip"
          "${MINGW_PACKAGE_PREFIX}-OpenSceneGraph"
@@ -39,10 +38,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 #optdepends=("${MINGW_PACKAGE_PREFIX}-libwebp")
             #"${MINGW_PACKAGE_PREFIX}-rocksdb")
 source=("https://github.com/gwaldron/osgearth/archive/${_realname}-${pkgver}.tar.gz"
-        "https://github.com/Esri/lerc/archive/${_lerc_commit}/lerc-${_lerc_commit}.tar.gz"
         "0005-rocksdb-update.patch")
-sha256sums=('206c3a64dc6a907679e6f250262ff3403478c9f0f9db2896dc2d33219c0458ca'
-            '11988ad44f4b63df7dde62bccde9b194cff468bf389912e3f3f7ebf06246c370'
+sha256sums=('2d195ed9ec16b38373a8d2700baec2208cc18fa9a1b2ad46cd453ae8ef5cf5ed'
             'dfe3746ab93f45c168f300f3072d741abebdbb6a4385c1c41b8f4ee204f8df35')
 
 apply_patch_with_msg() {
@@ -57,7 +54,6 @@ prepare() {
   cd "${srcdir}"/${_realname}-${_realname}-${pkgver}
   apply_patch_with_msg \
     0005-rocksdb-update.patch
-  mv "${srcdir}"/lerc-${_lerc_commit}/* src/third_party/lerc/
 }
 
 build() {


### PR DESCRIPTION
it no longer bundles lerc, so drop the hack

Fixes #30779