### PR TITLE
chore: add .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,18 @@
+Alexey Pavlov <alexpux@gmail.com>
+Alexey Pavlov <alexpux@gmail.com> <alexey.pawlow@gmail.com>
+Andrea Zagli <azagli@libero.it> <andrea.zagli.free@gmail.com>
+Andrea Zagli <azagli@libero.it> <a.zagli@comune.scandicci.fi.it>
+Andy Tao <taozuhong@users.noreply.github.com>
+Biswapriyo Nath <nathbappai@gmail.com>
+LIU Hao <lh_mouse@126.com>
+Jeremy Drake <github@jdrake.com>
+Konstantin Podsvirov <konstantin@podsvirov.pro> <konstantin@podsvirov.su>
+Maksim Bondarenkov <maksapple2306@gmail.com>
+Maksim Bondarenkov <maksapple2306@gmail.com> <119937608+ognevny@users.noreply.github.com>
+Mehdi Chinoune <mehdi.chinoune@hotmail.com>
+Mehdi Chinoune <mehdi.chinoune@hotmail.com> <79349457+MehdiChinoune@users.noreply.github.com>
+Miloš Komarčević <miloskomarcevic@aim.com> <4973094+kmilos@users.noreply.github.com>
+Naveen <naveen@syrusdark.website>
+Naveen <naveen@syrusdark.website> <naveen521kk@gmail.com>
+Raed Rizqie <raedrizqie@gmail.com> <raed.rizqie@gmail.com>
+Zhongteng Gui <dragon-archer@outlook.com>


### PR DESCRIPTION
This helps git to group commits with different uids (name + email) to a canonical one.

The canonical name and email is selected from the one used most (by `git shortlog -sne`)

The list is made by hand, and I only checked uids with 20+ commits, so there may be missing ones.