### PR TITLE
python-passagemath-benzene: add version 10.8.7 + benzene: add version 20130630 (new packages)

### DIFF
--- a/mingw-w64-benzene/.gitignore
+++ b/mingw-w64-benzene/.gitignore
@@ -1,0 +1,1 @@
+LICENSE.txt

--- a/mingw-w64-benzene/001-fix-forward-declaration.patch
+++ b/mingw-w64-benzene/001-fix-forward-declaration.patch
@@ -1,0 +1,14 @@
+--- a/benzene-20130630/benzene.c
++++ b/benzene-20130630/benzene.mod.c
+@@ -238,8 +238,9 @@ int jump[MAXNV]; /* How many edges are BETWEEN the first edge with boundary on t
+ int jumpname[MAXNV]; /* What is the name of the vertex at the end of that edge ? */
+ 
+ 
+-static int canon();
+-
++static int
++canon(int colour_prev[], EDGE *can_numberings[][MAXE],
++      int *num_can_numberings, int *num_can_numberings_or_pres);
+ 
+ static int markvalue_v = 30000;
+ static int marks__v[MAXNV+1];

--- a/mingw-w64-benzene/PKGBUILD
+++ b/mingw-w64-benzene/PKGBUILD
@@ -1,0 +1,61 @@
+# Maintainer: Dirk Stolle
+
+_realname=benzene
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=20130630
+pkgrel=1
+pkgdesc="Generator for nonisomorphic fusenes and benzenoids (mingw-w64)"
+arch=('any')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/sagemath/sage/tree/develop/build/pkgs/benzene'
+msys2_references=(
+  'archlinux: benzene'
+)
+license=('spdx:GPL-2.0-or-later')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-make")
+source=("https://mirrors.mit.edu/sage/spkg/upstream/benzene/${_realname}-${pkgver}.tar.bz2"
+        "LICENSE.txt::https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt"
+        "001-fix-forward-declaration.patch")
+sha256sums=('63e8662672a007f5b2a727df0ab0e38825c65229fd1060fbf5b5d87b3301e9c6'
+            'edaef632cbb643e4e7a221717a6c441a4c1a7c918e6e4d56debc3d8739b233f6'
+            '93125b7ab02006f4e9d39e0091a90363eec1cd8bdd7358eb505e4c92a0eb41a1')
+
+prepare() {
+  mv src "${_realname}-${pkgver}" && cd "${_realname}-${pkgver}"
+
+  # Honor system's CFLAGS.
+  sed -e '/^CFLAGS/d' -i makefile
+  # Use system's CC.
+  sed -e '/^CC/d' -i makefile
+
+  patch -Np2 -i ../001-fix-forward-declaration.patch
+}
+
+build() {
+  cd "${_realname}-${pkgver}"
+
+  # Avoid <sys/times.h> which is not available on Windows.
+  CFLAGS+=" -DNOLOG"
+
+  make
+}
+
+check() {
+  cd "${_realname}-${pkgver}"
+
+  # There's no "make check" or even any tests at all for benzene, so let's just invoke the basic
+  # executable with some parameters to generate some output and confirm it built properly.
+  NUMBER_OF_LINES=$(./benzene 9 B b | wc -l)
+  # It should generate 6505 lines for those parameters.
+  test $NUMBER_OF_LINES -eq 6505
+}
+
+package() {
+  cd "${_realname}-${pkgver}"
+
+  install -Dm755 "${_realname}.exe" -t "${pkgdir}${MINGW_PREFIX}/bin/"
+
+  install -Dm644 "../LICENSE.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.txt"
+}

--- a/mingw-w64-passagemath-benzene/PKGBUILD
+++ b/mingw-w64-passagemath-benzene/PKGBUILD
@@ -1,0 +1,51 @@
+# Maintainer: Dirk Stolle
+
+_realname=passagemath-benzene
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=10.8.7
+pkgrel=1
+pkgdesc="passagemath: Generate fusene and benzenoid graphs with benzene (mingw-w64)"
+arch=('any')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/passagemath/passagemath'
+msys2_repository_url='https://github.com/passagemath/passagemath'
+msys2_references=(
+  'purl: pkg:pypi/passagemath-benzene'
+)
+license=('spdx:GPL-2.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-benzene"
+         "${MINGW_PACKAGE_PREFIX}-gmp"
+         "${MINGW_PACKAGE_PREFIX}-mpc"
+         "${MINGW_PACKAGE_PREFIX}-mpfr"
+         "${MINGW_PACKAGE_PREFIX}-python")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cython"
+             "${MINGW_PACKAGE_PREFIX}-python-build"
+             "${MINGW_PACKAGE_PREFIX}-python-cysignals"
+             "${MINGW_PACKAGE_PREFIX}-python-installer"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-categories"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-environment"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-objects"
+             "${MINGW_PACKAGE_PREFIX}-python-passagemath-setup"
+             "${MINGW_PACKAGE_PREFIX}-python-pkgconfig"
+             "${MINGW_PACKAGE_PREFIX}-python-setuptools")
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
+sha256sums=('401bddf2d75fb91ce492913f74202fd0573fccfb70d632003b000fe608ea7be6')
+
+build() {
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+}


### PR DESCRIPTION
This adds **python-passagemath-benzene**, a package to provide some functionality from passagemath (<https://github.com/msys2/MINGW-packages/issues/24738>).

It also adds **benzene**, a package for generating for nonisomorphic fusenes and benzenoids .

benzene is also available in several other distributions, for example:
* Arch Linux: https://archlinux.org/packages/extra/x86_64/benzene/
* openSUSE: https://build.opensuse.org/package/show/openSUSE:Factory/benzene