### PR TITLE
docker-compose: update to 5.4.0

### DIFF
--- a/mingw-w64-docker-compose/PKGBUILD
+++ b/mingw-w64-docker-compose/PKGBUILD
@@ -3,11 +3,11 @@
 _realname=docker-compose
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=5.3.1
+pkgver=5.4.0
 pkgrel=1
 pkgdesc="Define and run multi-container applications with Docker (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
 url="https://www.docker.com/"
 msys2_repository_url="https://github.com/docker/compose"
 msys2_references=(
@@ -20,7 +20,7 @@ msys2_references=(
 license=("spdx:Apache-2.0")
 makedepends=("${MINGW_PACKAGE_PREFIX}-go")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/docker/compose/archive/v${pkgver}.tar.gz")
-sha256sums=('1823e1b09c4082779fdf5cc9f3d8453b95dba3d939105b39366175ce12fdb6c7')
+sha256sums=('142f895ba74715ea0018a20b7f93fa96e36fb6c91ea66f856a61c6e3716c4ef8')
 
 build() {
   cd "compose-${pkgver}"


### PR DESCRIPTION
This PR also drops the mingw64 package of docker-compose, because the environment has been deprecated.