### PR TITLE
python-asttokens: update to 3.0.2

### DIFF
--- a/mingw-w64-python-asttokens/PKGBUILD
+++ b/mingw-w64-python-asttokens/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=asttokens
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=3.0.1
-pkgrel=3
+pkgver=3.0.2
+pkgrel=1
 pkgdesc="Annotate AST trees with source code positions (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -15,15 +15,22 @@ msys2_references=(
 url='https://github.com/gristlabs/asttokens'
 msys2_repository_url='https://github.com/gristlabs/asttokens'
 license=('spdx:Apache-2.0')
-depends=("${MINGW_PACKAGE_PREFIX}-python"
-         "${MINGW_PACKAGE_PREFIX}-python-six")
-makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
-             "${MINGW_PACKAGE_PREFIX}-python-installer"
-             "${MINGW_PACKAGE_PREFIX}-python-setuptools"
-             "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm")
-checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-python"
+  "${MINGW_PACKAGE_PREFIX}-python-six"
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-python-build"
+  "${MINGW_PACKAGE_PREFIX}-python-installer"
+  "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+  "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm"
+)
+checkdepends=(
+  "${MINGW_PACKAGE_PREFIX}-python-astroid"
+  "${MINGW_PACKAGE_PREFIX}-python-pytest"
+)
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7')
+sha256sums=('3ecdbd8f2cc195f53ccada3a613538bb5f9ef6f6869129f13e03c30a677b8fe2')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -35,17 +42,17 @@ prepare() {
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
 
-  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
+  python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 check() {
-  cd "${srcdir}/python-build-${MSYSTEM}"
+  cd "python-build-${MSYSTEM}"
 
-  ${MINGW_PREFIX}/bin/python -m pytest || warning "Tests failed"
+  python -m pytest
 }
 
 package() {
-  cd "${srcdir}/python-build-${MSYSTEM}"
+  cd "python-build-${MSYSTEM}"
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
     ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \


### PR DESCRIPTION
This also fixes the `check()` step by adding `python-astroid` to makedepends.