### PR TITLE
autotools: depend on autoconf/automake instead of wrapper

### DIFF
--- a/mingw-w64-autotools/PKGBUILD
+++ b/mingw-w64-autotools/PKGBUILD
@@ -3,23 +3,22 @@
 _realname=autotools
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2023.09.28
-pkgrel=2
+pkgver=2026.08.04
+pkgrel=1
 pkgdesc="A meta package for the GNU autotools build system (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 msys2_references=(
   'internal'
 )
-license=('GPL')
 url="https://www.gnu.org/software/automake/manual/html_node/Autotools-Introduction.html"
 depends=(
-  'autoconf-wrapper'
-  'automake-wrapper'
+  'autoconf'
+  'automake'
   'make'
   "${MINGW_PACKAGE_PREFIX}-libtool"
   "${MINGW_PACKAGE_PREFIX}-gettext-tools"
   "${MINGW_PACKAGE_PREFIX}-pkgconf"
 )
-source=(README.md)
+source=('README.md')
 sha256sums=('de6ec37dee4875be8e2759dea340f6c1bbdc04457333dc666dcb81b00962a145')

--- a/mingw-w64-libtool/PKGBUILD
+++ b/mingw-w64-libtool/PKGBUILD
@@ -17,8 +17,8 @@ msys2_references=(
 license=('spdx:LGPL-2.0-or-later WITH Libtool-exception')
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cc"
-  "autoconf-wrapper"
-  "automake-wrapper"
+  "autoconf"
+  "automake"
   "help2man"
   "m4"
 )


### PR DESCRIPTION
See msys2/MSYS2-packages#6494 for more details