### PR TITLE
python-passagemath-graphs: add new optional dependency (benzene)

### DIFF
--- a/mingw-w64-passagemath-graphs/PKGBUILD
+++ b/mingw-w64-passagemath-graphs/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=10.8.7
-pkgrel=1
+pkgrel=2
 pkgdesc="passagemath: Graphs, posets, hypergraphs, designs, abstract complexes, combinatorial polyhedra, abelian sandpiles, quivers (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -31,6 +31,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-boost"
              "${MINGW_PACKAGE_PREFIX}-python-passagemath-setup"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 optdepends=(
+  "${MINGW_PACKAGE_PREFIX}-python-passagemath-benzene: generate fusene and benzenoid graphs with benzene"
   "${MINGW_PACKAGE_PREFIX}-python-passagemath-bliss: graph (iso/auto)morphisms with bliss"
   "${MINGW_PACKAGE_PREFIX}-python-passagemath-cliquer: find cliques in graphs with cliquer"
   "${MINGW_PACKAGE_PREFIX}-python-passagemath-cmr: combinatorial matrix recognition"


### PR DESCRIPTION
After passagemath-benzene has been made available in <https://github.com/msys2/MINGW-packages/pull/30821>, this new optional dependency can be added to the passagemath-graphs package.