### PR TITLE
python-passagemath-graphs: add new optional dependency (buckygen)

### DIFF
--- a/mingw-w64-passagemath-graphs/PKGBUILD
+++ b/mingw-w64-passagemath-graphs/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=10.8.8
-pkgrel=1
+pkgrel=2
 pkgdesc="passagemath: Graphs, posets, hypergraphs, designs, abstract complexes, combinatorial polyhedra, abelian sandpiles, quivers (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -33,6 +33,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-boost"
 optdepends=(
   "${MINGW_PACKAGE_PREFIX}-python-passagemath-benzene: generate fusene and benzenoid graphs with benzene"
   "${MINGW_PACKAGE_PREFIX}-python-passagemath-bliss: graph (iso/auto)morphisms with bliss"
+  "${MINGW_PACKAGE_PREFIX}-python-passagemath-buckygen: generate nonisomorphic fullerenes with buckygen"
   "${MINGW_PACKAGE_PREFIX}-python-passagemath-cliquer: find cliques in graphs with cliquer"
   "${MINGW_PACKAGE_PREFIX}-python-passagemath-cmr: combinatorial matrix recognition"
   "${MINGW_PACKAGE_PREFIX}-python-passagemath-homfly: Homfly polynomials of knots/links with libhomfly"


### PR DESCRIPTION
After passagemath-buckygen has been made available in <https://github.com/msys2/MINGW-packages/pull/30878>, this new optional dependency can be added to the passagemath-graphs package.