### PR TITLE
python-aiohttp: update to 3.14.3

### DIFF
--- a/mingw-w64-python-aiohttp/PKGBUILD
+++ b/mingw-w64-python-aiohttp/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=aiohttp
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=3.14.1
+pkgver=3.14.3
 pkgrel=1
 pkgdesc='HTTP client/server for asyncio (mingw-w64)'
 arch=('any')
@@ -41,7 +41,7 @@ checkdepends=(
 )
 optdepends=("${MINGW_PACKAGE_PREFIX}-python-brotli: for Brotli transfer-encodings support")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035')
+sha256sums=('9491196535a88924a60afd5b5f434b5b203b6cc616250878dbdb223a8f7844bc')
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"


### PR DESCRIPTION
Edit: Looks like eventlet has some requirements which are not met:
```
   Pip Check Failed for mingw-w64-ucrt-x86_64-python-eventlet
  Running `pip check` didn't suceed. Maybe missing dependencies?
  Here is what it failed.
  eventlet 0.41.1 has requirement greenlet<3.4, but you have greenlet 3.5.4.
```
Therefore, let's just remove the eventlet update from this PR.