### PR TITLE
rnote: add package

### DIFF
--- a/mingw-w64-rnote/001-force-dcomp-on-windows.patch
+++ b/mingw-w64-rnote/001-force-dcomp-on-windows.patch
@@ -1,0 +1,31 @@
+Force DirectComposition on, so that GSK picks a GPU renderer.
+
+Our gtk4 keeps DirectComposition off by default on Windows unless
+GDK_WIN32_FORCE_DCOMP is set (see mingw-w64-gtk4/003-default-dcomp-off.patch,
+added in msys2/MINGW-packages#25319 because dcomp + GL rendering was broken in
+gtk4 4.20). Without it GSK falls back to the cairo software renderer, under
+which rnote draws every stroke and image as a flat coloured box:
+
+  https://github.com/flxzt/rnote/issues/1693
+  https://github.com/flxzt/rnote/issues/1654
+
+Upstream works around this by pinning gtk4 to 4.18 (flxzt/rnote#1615), which is
+not an option here. Setting the variable restores correct rendering; users can
+still override with GDK_DISABLE=dcomp or GSK_RENDERER=<name>.
+
+--- a/crates/rnote-ui/src/env.rs
++++ b/crates/rnote-ui/src/env.rs
+@@ -75,6 +75,13 @@
+                 lib_dir.join("gdk-pixbuf-2.0\\2.10.0\\loaders"),
+             );
+ 
++            // Without DirectComposition GSK falls back to the cairo software
++            // renderer, where strokes and images render as flat coloured boxes.
++            // Override with GDK_DISABLE=dcomp or GSK_RENDERER=<name>.
++            if std::env::var_os("GDK_WIN32_FORCE_DCOMP").is_none() {
++                std::env::set_var("GDK_WIN32_FORCE_DCOMP", "1");
++            }
++
+             //std::env::set_var("RUST_LOG", "rnote=debug,rnote-cli=debug,rnote-engine=debug,rnote-compose=debug");
+         }
+     } else if cfg!(target_os = "macos") {

--- a/mingw-w64-rnote/PKGBUILD
+++ b/mingw-w64-rnote/PKGBUILD
@@ -14,20 +14,18 @@ msys2_references=(
   'archlinux: rnote'
 )
 license=('spdx:GPL-3.0-or-later')
-depends=("${MINGW_PACKAGE_PREFIX}-appstream"
-         "${MINGW_PACKAGE_PREFIX}-gtk4"
-         "${MINGW_PACKAGE_PREFIX}-libadwaita")
-makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-desktop-file-utils"
-             "${MINGW_PACKAGE_PREFIX}-meson"
-             "${MINGW_PACKAGE_PREFIX}-ninja"
-             "${MINGW_PACKAGE_PREFIX}-pkgconf"
-             "${MINGW_PACKAGE_PREFIX}-python"
-             "${MINGW_PACKAGE_PREFIX}-rust"
-             "gettext"
-             "patch")
-options=('!lto')
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-appstream"
+  "${MINGW_PACKAGE_PREFIX}-gtk4"
+  "${MINGW_PACKAGE_PREFIX}-libadwaita"
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-desktop-file-utils"
+  "${MINGW_PACKAGE_PREFIX}-meson"
+  "${MINGW_PACKAGE_PREFIX}-python"
+  "${MINGW_PACKAGE_PREFIX}-rust"
+)
 source=("https://github.com/flxzt/rnote/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
         "001-force-dcomp-on-windows.patch")
 sha256sums=('10dd7849b593034b7fbd55f5b5baa51fb082ef48d96e1a6200d361e6ed49363e'

--- a/mingw-w64-rnote/PKGBUILD
+++ b/mingw-w64-rnote/PKGBUILD
@@ -1,0 +1,79 @@
+# Contributor: Kreijstal <elektrischrainbow@gmail.com>
+
+_realname=rnote
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.14.2
+pkgrel=1
+pkgdesc="Sketch and take handwritten notes (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url="https://rnote.flxzt.net"
+msys2_repository_url='https://github.com/flxzt/rnote'
+msys2_references=(
+  'archlinux: rnote'
+)
+license=('spdx:GPL-3.0-or-later')
+depends=("${MINGW_PACKAGE_PREFIX}-appstream"
+         "${MINGW_PACKAGE_PREFIX}-gtk4"
+         "${MINGW_PACKAGE_PREFIX}-libadwaita")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-desktop-file-utils"
+             "${MINGW_PACKAGE_PREFIX}-meson"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-pkgconf"
+             "${MINGW_PACKAGE_PREFIX}-python"
+             "${MINGW_PACKAGE_PREFIX}-rust"
+             "gettext"
+             "patch")
+options=('!lto')
+source=("https://github.com/flxzt/rnote/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
+        "001-force-dcomp-on-windows.patch")
+sha256sums=('10dd7849b593034b7fbd55f5b5baa51fb082ef48d96e1a6200d361e6ed49363e'
+            '6ac357f37cffa106819d01c5ba569618d6e663e69058e36320a0c0fef26d9da3')
+noextract=("${_realname}-${pkgver}.tar.gz")
+
+prepare() {
+  # The Chinese locales are symlinks to zh_Hans.po/zh_Hant.po. Windows cannot
+  # create a symlink whose target does not exist yet, so extract them as plain
+  # copies instead of relying on the order they appear in the archive.
+  local _po="${_realname}-${pkgver}/crates/rnote-ui/po"
+  bsdtar -xf "${srcdir}/${_realname}-${pkgver}.tar.gz" -C "${srcdir}" \
+    --exclude="${_po}/zh_CN.po" \
+    --exclude="${_po}/zh_HK.po" \
+    --exclude="${_po}/zh_SG.po" \
+    --exclude="${_po}/zh_TW.po"
+
+  cd "${srcdir}/${_po}"
+  cp -f zh_Hans.po zh_CN.po
+  cp -f zh_Hans.po zh_SG.po
+  cp -f zh_Hant.po zh_HK.po
+  cp -f zh_Hant.po zh_TW.po
+
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -Np1 -i "${srcdir}/001-force-dcomp-on-windows.patch"
+}
+
+build() {
+  # meson places CARGO_HOME inside the build directory, so crate paths end up
+  # embedded in panic messages. Remap them to keep $srcdir out of the binaries.
+  export RUSTFLAGS="${RUSTFLAGS} --remap-path-prefix=$(cygpath -m "${srcdir}")=/${_realname}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    meson setup \
+      --prefix="${MINGW_PREFIX}" \
+      --wrap-mode=nodownload \
+      --buildtype=plain \
+      -Dprofile=default \
+      -Dui=true \
+      -Dcli=true \
+      "build-${MSYSTEM}" \
+      "${_realname}-${pkgver}"
+
+  meson compile -C "build-${MSYSTEM}"
+}
+
+package() {
+  meson install -C "build-${MSYSTEM}" --destdir "${pkgdir}"
+}

--- a/mingw-w64-rnote/PKGBUILD
+++ b/mingw-w64-rnote/PKGBUILD
@@ -21,6 +21,7 @@ depends=(
 )
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-cmake"
   "${MINGW_PACKAGE_PREFIX}-desktop-file-utils"
   "${MINGW_PACKAGE_PREFIX}-meson"
   "${MINGW_PACKAGE_PREFIX}-python"


### PR DESCRIPTION
New package: rnote 0.14.2, a GTK4 handwritten-notes app.

`zh_CN.po`/`zh_HK.po` are symlinks that appear before their targets in the tarball, which bsdtar cannot create on Windows, so they are extracted as copies in `prepare()`.

`GDK_WIN32_FORCE_DCOMP=1` is set at startup, because our gtk4 keeps DirectComposition off (#25319) and GSK then falls back to the cairo renderer, under which rnote draws every stroke and image as a flat coloured box (flxzt/rnote#1693).

Built and installed on UCRT64.
