### PR TITLE
crt: also install startfiles under ${MINGW_CHOST}

### DIFF
--- a/mingw-w64-crt/PKGBUILD
+++ b/mingw-w64-crt/PKGBUILD
@@ -4,7 +4,7 @@ _realname=crt
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=14.0.0.r248.g7735a1a63
-pkgrel=1
+pkgrel=2
 _commit='7735a1a6356d2699f6b04538ca8870c0b3dfc441'
 pkgdesc='MinGW-w64 CRT for Windows (mingw-w64)'
 arch=('any')
@@ -76,6 +76,10 @@ package() {
   # adds -lssp -lssh_nonshared when linking.
   ar rcs "${pkgdir}"${MINGW_PREFIX}/lib/libssp.a
   ar rcs "${pkgdir}"${MINGW_PREFIX}/lib/libssp_nonshared.a
+
+  for f in {,dll,g}crt{1,2}.o crt{begin,end}.o gcrt0.o; do
+    install -Dm644 "${pkgdir}${MINGW_PREFIX}/lib/$f" "${pkgdir}${MINGW_PREFIX}/${MINGW_CHOST}/lib/$f"
+  done
 
   install -Dm644 "${srcdir}"/mingw-w64/COPYING "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/COPYING
   install -Dm644 "${srcdir}"/mingw-w64/COPYING.MinGW-w64/COPYING.MinGW-w64.txt "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.MinGW-w64.txt


### PR DESCRIPTION
GCC treat these files as target-specific and expects to find them under target triplet. It only search `<prefix>/lib` as a fallback, and GCC not alwyas correctly searched the fallback, e.g. in bootstrap where xgcc.exe is misplaced.