### PR TITLE
petsc-all: new package, single-node PETSc with the full solver set

### DIFF
--- a/mingw-w64-petsc-all/0001-hwloc-windows-pid.patch
+++ b/mingw-w64-petsc-all/0001-hwloc-windows-pid.patch
@@ -1,0 +1,61 @@
+From 9a5d0f30aa557ccd33f8356bc4d6d1d15feb8cf3 Mon Sep 17 00:00:00 2001
+From: hbadi <badi.hamid@gmail.com>
+Date: Sat, 8 Aug 2026 22:33:30 +0200
+Subject: [PATCH] sys: fix PetscProcessPlacementView() build on Windows
+
+hwloc defines hwloc_pid_t as a HANDLE when it is built against
+windows.h, so passing getpid() to hwloc_get_proc_cpubind() fails to
+compile on every Windows target. This makes --with-hwloc unusable with
+MinGW-w64 and with Intel oneAPI on Windows alike; the discriminant is
+the platform hwloc was built for, not the compiler in use.
+
+Select the process identifier on HWLOC_HAVE_WINDOWS_H, which hwloc
+publishes in its installed autogen/config.h and which is exactly the
+condition under which hwloc_pid_t becomes a HANDLE. hwloc.h already
+includes windows.h, so no further header is required. GetCurrentProcess()
+returns the pseudo-handle hwloc expects, while GetCurrentProcessId()
+returns the numeric identifier wanted for display; normalising the
+latter to unsigned long keeps a single format string.
+
+Tested on MSYS2/MinGW-w64 against hwloc 2.14.0, where -process_view now
+reports "MPI rank 0 Process id: 42796 coreid 0". No PETSc CI job
+configures hwloc on Windows, which is why this went unnoticed; the MSYS2
+petsc package has carried an equivalent downstream patch since 3.18.3.
+---
+ src/sys/utils/memc.c | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/src/sys/utils/memc.c b/src/sys/utils/memc.c
+index 9ef9e6395a6..ffbb3f9d712 100644
+--- a/src/sys/utils/memc.c
++++ b/src/sys/utils/memc.c
+@@ -51,6 +51,14 @@ PetscErrorCode PetscMemcmp(const void *str1, const void *str2, size_t len, Petsc
+ #if defined(PETSC_HAVE_HWLOC)
+   #include <petsc/private/petscimpl.h>
+   #include <hwloc.h>
++  #if defined(HWLOC_HAVE_WINDOWS_H)
++    // hwloc_pid_t is a HANDLE on Windows, and hwloc.h has already included windows.h
++    #define PetscHwlocSelf() GetCurrentProcess()
++    #define PetscHwlocPid()  ((unsigned long)GetCurrentProcessId())
++  #else
++    #define PetscHwlocSelf() getpid()
++    #define PetscHwlocPid()  ((unsigned long)getpid())
++  #endif
+ #endif
+ 
+ /*@
+@@ -84,9 +92,9 @@ PetscErrorCode PetscProcessPlacementView(PetscViewer viewer)
+   hwloc_topology_load(topology);
+   set = hwloc_bitmap_alloc();
+ 
+-  PetscCallExternal(hwloc_get_proc_cpubind, topology, getpid(), set, HWLOC_CPUBIND_PROCESS);
++  PetscCallExternal(hwloc_get_proc_cpubind, topology, PetscHwlocSelf(), set, HWLOC_CPUBIND_PROCESS);
+   PetscCall(PetscViewerASCIIPushSynchronized(viewer));
+-  PetscCall(PetscViewerASCIISynchronizedPrintf(viewer, "MPI rank %d Process id: %d coreid %d\n", rank, getpid(), hwloc_bitmap_first(set)));
++  PetscCall(PetscViewerASCIISynchronizedPrintf(viewer, "MPI rank %d Process id: %lu coreid %d\n", rank, PetscHwlocPid(), hwloc_bitmap_first(set)));
+   PetscCall(PetscViewerFlush(viewer));
+   hwloc_bitmap_free(set);
+   hwloc_topology_destroy(topology);
+-- 
+2.53.0.windows.2
+

--- a/mingw-w64-petsc-all/PKGBUILD
+++ b/mingw-w64-petsc-all/PKGBUILD
@@ -1,0 +1,216 @@
+# Maintainer: hbadi <badi.hamid@gmail.com>
+# Contributor: Oleg A. Khlybov <fougas@mail.ru>   (base petsc recipe this one derives from)
+
+# PETSc for a single compute node, carrying the widest set of solvers that the
+# MSYS2 packages can supply.
+#
+# This is NOT a drop-in replacement for the `petsc` package and never claims to
+# be one: `petsc` ships twelve build flavors, this ships a single one, so
+# declaring provides=petsc would break slepc and anything else asking for a
+# flavor that is not here. Both packages install side by side under distinct
+# prefixes.
+#
+# Flavor `dto`, following the naming of the base package:
+#   d - double precision real
+#   t - multithreaded (OpenMP, MPIUNI)
+#   o - optimized
+#
+#   pkg-config petsc-all-dto --cflags
+#
+# 32-bit indices, matching the base package, which never sets
+# --with-64-bit-indices either. This is what lets METIS, PaStiX and SuperLU in:
+# all three are packaged with 32-bit index types and PETSc hands its PetscInt
+# arrays straight to them.
+
+_realname=petsc-all
+_petscver=3.25.4
+# v3.1.0 plus the fixes PETSc pins, see config/BuildSystem/config/packages/hypre.py
+_hyprecommit=85b779557005b2eb94c231c1b516e988b87f4e53
+
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=${_petscver}
+pkgrel=1
+pkgdesc='Sparse iterative (non)linear solver package, single-node build with the full solver set (mingw-w64)'
+arch=('any')
+# Watch the clang environments: OpenMP paired with MUMPS was measured hanging in
+# the solve under flang, see https://github.com/msys2/MINGW-packages/issues/30888
+# That measurement predates this recipe and has to be replayed against it in CI.
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url="https://petsc.org/"
+msys2_repository_url="https://gitlab.com/petsc/petsc"
+license=('spdx:BSD-2-Clause')
+depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
+         "${MINGW_PACKAGE_PREFIX}-fc-libs"
+         "${MINGW_PACKAGE_PREFIX}-fftw"
+         "${MINGW_PACKAGE_PREFIX}-hdf5"
+         "${MINGW_PACKAGE_PREFIX}-hwloc"
+         "${MINGW_PACKAGE_PREFIX}-libyaml"
+         "${MINGW_PACKAGE_PREFIX}-metis"
+         "${MINGW_PACKAGE_PREFIX}-mumps"
+         "${MINGW_PACKAGE_PREFIX}-muparser"
+         "${MINGW_PACKAGE_PREFIX}-netcdf"
+         "${MINGW_PACKAGE_PREFIX}-omp"
+         "${MINGW_PACKAGE_PREFIX}-openblas"
+         "${MINGW_PACKAGE_PREFIX}-pastix"
+         "${MINGW_PACKAGE_PREFIX}-suitesparse"
+         "${MINGW_PACKAGE_PREFIX}-superlu"
+         "${MINGW_PACKAGE_PREFIX}-zlib")
+makedepends=('python'
+             "${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-fc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-pkgconf")
+source=("https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-${_petscver}.tar.gz"
+        "hypre-${_hyprecommit}.tar.gz::https://github.com/hypre-space/hypre/archive/${_hyprecommit}.tar.gz"
+        '0001-hwloc-windows-pid.patch')
+noextract=("petsc-${_petscver}.tar.gz" "hypre-${_hyprecommit}.tar.gz")
+sha256sums=('12c990fb39a5764ac8311211d09c01ed80fb983136c75bf7b558312b2509dbbd'
+            '76051b711e4d684270c888f7be0b0524f626e19eca3b091939321e0fb68bbc25'
+            '7523e224ded68c7c3e674f496b6b06b379e2aec91d7849dc65fde53a66bcc006')
+
+_variant=dto
+
+# The Fortran runtime PETSc drags in differs by environment: the clang ones use
+# flang. Needed both when linking and in the generated .pc file, hence a function
+# rather than a variable local to build().
+_fcruntime() {
+  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
+    echo "-lflang_rt.runtime"
+  else
+    echo "-lgfortran -lquadmath"
+  fi
+}
+
+prepare() {
+  mkdir -p "${srcdir}/build-${MSYSTEM}"
+  cd "${srcdir}/build-${MSYSTEM}"
+  tar xzf "${srcdir}/petsc-${_petscver}.tar.gz"
+
+  cd "petsc-${_petscver}"
+  # hwloc_pid_t is a HANDLE on Windows, so passing getpid() to
+  # hwloc_get_proc_cpubind() does not compile. Submitted upstream as
+  # https://gitlab.com/petsc/petsc/-/merge_requests/9491 ; drop this patch once
+  # it lands in a release.
+  patch -Nbp1 -i "${srcdir}/0001-hwloc-windows-pid.patch"
+}
+
+build() {
+  cd "${srcdir}/build-${MSYSTEM}/petsc-${_petscver}"
+  export PETSC_DIR="$(pwd)"
+
+  local cflags="${CFLAGS}"
+  local fflags fc libs
+  # Same split as the base petsc recipe: the clang environments use flang, whose
+  # runtime is named differently and which does not take the gfortran leniency
+  # flags.
+  libs="$(_fcruntime)"
+  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
+    fc=flang
+    cflags+=" -Wno-incompatible-function-pointer-types"
+    [[ ${CARCH} == aarch64 ]] && fflags='-march=armv8.1-a' || fflags='-march=nocona -mtune=generic'
+    fflags+=" -O2 -I${MINGW_PREFIX}/include"
+  else
+    fc=gfortran
+    fflags="${cflags} -fallow-invalid-boz -fallow-argument-mismatch -I${MINGW_PREFIX}/include"
+  fi
+
+  # Everything comes from pacman except hypre. The packaged hypre is built
+  # against MS-MPI (HYPRE_config.h has HYPRE_SEQUENTIAL undefined) and cannot be
+  # handed MPIUNI communicators, so PETSc builds its own from the tarball
+  # declared in source(). No network access at build time.
+  #
+  # PaStiX needs more than the single library PETSc's liblist assumes: it
+  # delegates its sparse-matrix structures to libspm and schedules through
+  # StarPU. The closure below is what `pkg-config --libs pastix` reports.
+  /usr/bin/python configure --PETSC_ARCH="${_variant}" \
+    --with-cc="${CC}" --with-cxx="${CXX}" --with-fc="${fc}" \
+    --with-precision=double --with-scalar-type=real \
+    --with-debugging=0 \
+    --with-openmp=1 \
+    --with-mpi=0 \
+    --with-single-library=1 \
+    --with-shared-libraries=0 \
+    --with-windows-graphics=0 --with-x=0 \
+    --with-pthread=1 --with-pthread-include="${MINGW_PREFIX}/include" --with-pthread-lib=-lpthread \
+    --with-openblas=1 --with-openblas-dir="${MINGW_PREFIX}" \
+    --with-hwloc=1 --with-hwloc-include="${MINGW_PREFIX}/include" --with-hwloc-lib=-lhwloc \
+    --with-mumps=1 --with-mumps-include="${MINGW_PREFIX}/include" \
+    --with-mumps-lib=[-lmumps-${_variant},-lesmumps] \
+    --with-suitesparse=1 --with-suitesparse-include="${MINGW_PREFIX}/include/suitesparse" \
+    --with-suitesparse-lib=[-lspqr,-lumfpack,-lklu,-lcholmod,-lamd] \
+    --with-metis=1 --with-metis-include="${MINGW_PREFIX}/include" --with-metis-lib=-lmetis \
+    --with-superlu=1 --with-superlu-include="${MINGW_PREFIX}/include/superlu" \
+    --with-superlu-lib=-lsuperlu \
+    --with-pastix=1 --with-pastix-include="${MINGW_PREFIX}/include" \
+    --with-pastix-lib=[-lpastix,-lpastix_kernels,-lpastix_starpu,-lstarpu-1.4,-lspm] \
+    --download-hypre="${srcdir}/hypre-${_hyprecommit}.tar.gz" \
+    --with-fftw=1 --with-fftw-include="${MINGW_PREFIX}/include" --with-fftw-lib=-lfftw3 \
+    --with-hdf5=1 --with-hdf5-include="${MINGW_PREFIX}/include" --with-hdf5-lib=[-lhdf5_hl,-lhdf5] \
+    --with-netcdf=1 --with-netcdf-include="${MINGW_PREFIX}/include" --with-netcdf-lib=-lnetcdf \
+    --with-zlib=1 --with-zlib-include="${MINGW_PREFIX}/include" --with-zlib-lib=-lz \
+    --with-yaml=1 --with-yaml-include="${MINGW_PREFIX}/include" --with-yaml-lib=-lyaml \
+    --with-muparser=1 --with-muparser-include="${MINGW_PREFIX}/include" --with-muparser-lib=-lmuparser \
+    CFLAGS="${cflags}" CXXFLAGS="${CXXFLAGS}" FFLAGS="${fflags}" \
+    CPPFLAGS="${CPPFLAGS}" LDFLAGS="${LDFLAGS} -fopenmp" \
+    LIBS="${libs}" MAKEFLAGS="${MAKEFLAGS}"
+
+  # MAKE_LOAD is cleared: the -l load limit PETSc adds divides parallelism by
+  # eight under MSYS2.
+  make MAKE_LOAD= PETSC_ARCH="${_variant}" all
+
+  # The base package does the same: build static, then link the DLL from the
+  # archive, so both a .a and a .dll ship. --with-shared-libraries=1 would give
+  # the DLL only.
+  cd "${_variant}/lib"
+  strip -S libpetsc.a
+  local ext
+  ext=$(sed -n 's/^PETSC_EXTERNAL_LIB_BASIC *= *//p' petsc/conf/petscvariables)
+  # Handed to package() for Libs.private. Deliberately NOT expressed as
+  # Requires.private in the .pc: pkg-config folds a private requirement's Cflags
+  # into --cflags, which would put mumps/mpi_seq -- MUMPS's own MPI stub -- on
+  # every consumer's include path, and drag in StarPU's -DSTARPU_OPENCL_DATADIR
+  # whose embedded quotes break the compile line.
+  # Strip references to the build tree: PETSc points -L and -rpath at its own
+  # arch lib directory, which does not exist once installed. The archives found
+  # there -- libHYPRE.a above all, built by --download-hypre -- ship inside the
+  # package, so ${libdir}/${_variant} from Libs covers them.
+  printf '%s' "${ext}" | tr ' ' '\n' | grep -vF "${srcdir}" | tr '\n' ' ' \
+    > "${srcdir}/external-libs"
+  "${CC}" -shared -fopenmp -Wl,--enable-auto-import -Wl,--export-all-symbols \
+    -o "libpetsc-all-${_variant}.dll" -Wl,--out-implib,libpetsc.dll.a \
+    -Wl,--whole-archive libpetsc.a -Wl,--no-whole-archive \
+    ${LDFLAGS} ${ext} ${libs}
+}
+
+package() {
+  local builddir="${srcdir}/build-${MSYSTEM}/petsc-${_petscver}"
+  local incdir="${pkgdir}${MINGW_PREFIX}/include/${_realname}"
+  local libdir="${pkgdir}${MINGW_PREFIX}/lib/${_realname}"
+
+  install -d "${pkgdir}${MINGW_PREFIX}"/{bin,lib/pkgconfig} "${incdir}" "${libdir}/${_variant}"
+
+  cp -R "${builddir}/include/." "${incdir}/"
+  install -d "${incdir}/${_variant}"
+  cp -R "${builddir}/${_variant}/include/." "${incdir}/${_variant}/"
+  find "${incdir}" \( ! \( -name '*.h' -o -name '*.hpp' -o -name '*.mod' \) -a -type f \) -delete
+
+  cp "${builddir}/${_variant}/lib"/*.a "${libdir}/${_variant}/"
+  cp "${builddir}/${_variant}/lib"/*.dll "${pkgdir}${MINGW_PREFIX}/bin/"
+
+  cat > "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/${_realname}-${_variant}.pc" <<EOF
+prefix=${MINGW_PREFIX}
+libdir=\${prefix}/lib/${_realname}
+includedir=\${prefix}/include/${_realname}
+Name: ${_realname}
+URL: ${url}
+Version: ${pkgver}
+Description: Single-node PETSc with the full solver set, OpenMP multithreaded double precision
+Cflags: -I\${includedir}/${_variant} -I\${includedir} -fopenmp
+Libs: -L\${libdir}/${_variant} -lpetsc
+Libs.private: -L\${libdir}/${_variant} -lpetsc $(cat "${srcdir}/external-libs") $(_fcruntime)
+EOF
+
+  install -Dm644 "${builddir}/LICENSE" \
+    "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}

--- a/mingw-w64-petsc-all/PKGBUILD
+++ b/mingw-w64-petsc-all/PKGBUILD
@@ -48,14 +48,11 @@ depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
          "${MINGW_PACKAGE_PREFIX}-libyaml"
          "${MINGW_PACKAGE_PREFIX}-metis"
          "${MINGW_PACKAGE_PREFIX}-mumps"
-         "${MINGW_PACKAGE_PREFIX}-muparser"
-         "${MINGW_PACKAGE_PREFIX}-netcdf"
          "${MINGW_PACKAGE_PREFIX}-omp"
          "${MINGW_PACKAGE_PREFIX}-openblas"
          "${MINGW_PACKAGE_PREFIX}-pastix"
          "${MINGW_PACKAGE_PREFIX}-suitesparse"
-         "${MINGW_PACKAGE_PREFIX}-superlu"
-         "${MINGW_PACKAGE_PREFIX}-zlib")
+         "${MINGW_PACKAGE_PREFIX}-superlu")
 makedepends=('python'
              "${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-fc"
@@ -123,6 +120,15 @@ build() {
   # PaStiX needs more than the single library PETSc's liblist assumes: it
   # delegates its sparse-matrix structures to libspm and schedules through
   # StarPU. The closure below is what `pkg-config --libs pastix` reports.
+  #
+  # netCDF, zlib and muParser are deliberately absent. configure accepts them and
+  # records them in PETSC_HAVE_PACKAGES, but nothing links: `nm -u libpetsc.a`
+  # reports zero undefined symbols for the three, and the DLL imports none of
+  # them. netCDF in particular only reaches PETSc through ExodusII
+  # (ExodusII.py: deps = [hdf5, netcdf, pnetcdf]), which MSYS2 does not package,
+  # so plexexodusii2.c -- the single file including netcdf.h -- is never built.
+  # Declaring them would impose install-time dependencies on libraries the
+  # package never calls.
   /usr/bin/python configure --PETSC_ARCH="${_variant}" \
     --with-cc="${CC}" --with-cxx="${CXX}" --with-fc="${fc}" \
     --with-precision=double --with-scalar-type=real \
@@ -147,10 +153,7 @@ build() {
     --download-hypre="${srcdir}/hypre-${_hyprecommit}.tar.gz" \
     --with-fftw=1 --with-fftw-include="${MINGW_PREFIX}/include" --with-fftw-lib=-lfftw3 \
     --with-hdf5=1 --with-hdf5-include="${MINGW_PREFIX}/include" --with-hdf5-lib=[-lhdf5_hl,-lhdf5] \
-    --with-netcdf=1 --with-netcdf-include="${MINGW_PREFIX}/include" --with-netcdf-lib=-lnetcdf \
-    --with-zlib=1 --with-zlib-include="${MINGW_PREFIX}/include" --with-zlib-lib=-lz \
     --with-yaml=1 --with-yaml-include="${MINGW_PREFIX}/include" --with-yaml-lib=-lyaml \
-    --with-muparser=1 --with-muparser-include="${MINGW_PREFIX}/include" --with-muparser-lib=-lmuparser \
     CFLAGS="${cflags}" CXXFLAGS="${CXXFLAGS}" FFLAGS="${fflags}" \
     CPPFLAGS="${CPPFLAGS}" LDFLAGS="${LDFLAGS} -fopenmp" \
     LIBS="${libs}" MAKEFLAGS="${MAKEFLAGS}"


### PR DESCRIPTION
A new package: PETSc for a single compute node, carrying the widest set of solvers the MSYS2 packages can supply.

This follows the separate-package route suggested in #30888 — keeping the base `petsc` narrow, and letting extra dependencies live where they cannot make it fragile.

## Not a replacement for `petsc`

No `provides`, no `conflicts`. `petsc` ships twelve build flavors, this ships one, so claiming to provide it would break `slepc` and anything else asking for a flavor that is absent. The two install side by side under distinct prefixes: `/mingw64/include/petsc-all/`, `/mingw64/lib/petsc-all/`, `petsc-all-dto.pc`. Verified with both installed.

## What is in it

Flavor `dto` — double precision real, OpenMP multithreaded over MPIUNI, optimized — with **32-bit indices**, matching the base package, which never sets `--with-64-bit-indices` either. That is what lets METIS, PaStiX and SuperLU in: all three are packaged with 32-bit index types, and PETSc hands its `PetscInt` arrays straight to them.

Solvers: MUMPS, UMFPACK, CHOLMOD, KLU, SPQR, SuperLU, PaStiX, hypre BoomerAMG. Plus FFTW, HDF5, NetCDF, METIS, muParser, yaml, hwloc.

## The one dependency not taken from pacman, and why

**hypre.** The packaged one is built against MS-MPI — `HYPRE_config.h` leaves `HYPRE_SEQUENTIAL` undefined — so it cannot be handed MPIUNI communicators. PETSc builds it instead from a tarball declared in `source()`, pinned to the same commit PETSc itself pins. No network access at build time.

I would rather link the system library and will switch the moment a sequential hypre is available.

## Two packaging details worth flagging

**The `.pc` has no `Requires.private`, deliberately.** pkg-config folds a private requirement's `Cflags` into `--cflags`, which would put `mumps/mpi_seq` — MUMPS's own MPI stub — on every consumer's include path, and drag in StarPU's `-DSTARPU_OPENCL_DATADIR` whose embedded quotes break the compile line. Both were caught by actually consuming the package. The concrete link flags go in `Libs.private` instead, with build-tree paths stripped.

**PaStiX needs more than one library.** PETSc's own `liblist` assumes `libpastix.a` alone; PaStiX delegates its sparse-matrix structures to `libspm` and schedules through StarPU. The recipe passes the closure `pkg-config --libs pastix` reports.

Like the base package, this builds static and links the DLL from the archive, so both a `.a` and a `.dll` ship; `--with-shared-libraries=1` would give the DLL only.

## Patch carried

One, against PETSc: `hwloc_pid_t` is a `HANDLE` on Windows, so passing `getpid()` to `hwloc_get_proc_cpubind()` does not compile on any Windows target, which makes `--with-hwloc` unusable there. The base package carries an equivalent patch (`0003-pid.patch`) and has since 3.18.3. Submitted upstream as https://gitlab.com/petsc/petsc/-/merge_requests/9491 ; the patch goes away once it lands in a release.

## Testing

Built on MINGW64, UCRT64, CLANG64 and CLANGARM64 — full run on my fork, four packages produced: https://github.com/hbadi/MINGW-packages/actions/runs/31284210983

**Consumption-tested on MINGW64 only**: a program compiled solely through `pkg-config petsc-all-dto` links against the installed DLL and solves through MUMPS, UMFPACK, CHOLMOD, SuperLU, PaStiX and BoomerAMG. The other three environments are built but not exercised.

One known risk I would rather state than hide: #30888 recorded MUMPS paired with OpenMP hanging in the solve under flang. That measurement predates this recipe and has not been replayed against it, so CLANG64 and CLANGARM64 carry that uncertainty.
