### PR TITLE
handbrake: enable libdovi

### DIFF
--- a/mingw-w64-handbrake/0006-fix-build-with-external-libdovi.patch
+++ b/mingw-w64-handbrake/0006-fix-build-with-external-libdovi.patch
@@ -1,0 +1,14 @@
+diff --git a/test/module.defs b/test/module.defs
+--- a/test/module.defs
++++ b/test/module.defs
+@@ -21,6 +21,10 @@ TEST.pkgconfig_libs = libass libavformat libavfilter libavcodec libavutil libswres
+ 	dvdread libswscale theoraenc theoradec vorbis vorbisenc ogg x264 libbluray \
+ 	jansson libturbojpeg SvtAv1Enc
+ 
++ifeq (1,$(FEATURE.libdovi))
++TEST.pkgconfig_libs += dovi
++endif
++
+ TEST.pkgconfig_libs += $(foreach m,$(MODULES.NAMES),$($m.OSL.libs))
+ 
+ ifeq (1,$(FEATURE.flatpak))

--- a/mingw-w64-handbrake/PKGBUILD
+++ b/mingw-w64-handbrake/PKGBUILD
@@ -4,7 +4,7 @@ _realname=handbrake
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.10.2
-pkgrel=5
+pkgrel=6
 pkgdesc="The open source video transcoder (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -13,6 +13,7 @@ msys2_repository_url='https://github.com/HandBrake/HandBrake/'
 license=('GPL-2.0-or-later')
 depends=(
   "${MINGW_PACKAGE_PREFIX}-ffmpeg"
+  "${MINGW_PACKAGE_PREFIX}-libdovi"
   "${MINGW_PACKAGE_PREFIX}-jansson"
   "${MINGW_PACKAGE_PREFIX}-libass"
   "${MINGW_PACKAGE_PREFIX}-libbluray"
@@ -40,14 +41,16 @@ source=(
   "0003-Remove-ambient-viewing-support.patch"
   "0004-fix-build-with-ffmpeg-8.patch"
   "0005-arch-detection.patch"
+  "0006-fix-build-with-external-libdovi.patch"
 )
 sha256sums=('c65e1cc4f8cfc36c24107b92c28d60e71ef185ec983e9a5841facffafea5f8db'
             'SKIP'
             '3a240bc164143706c025dd8809f969352e0dbd0226611ee9a97c05eb772a9d75'
             'f0ed0f8f42c74e098db8c8f361411bc712dc594e2464fa0476d554d3153dfa3b'
             '5245ef3310df3326a28f0da40e78d8bfd6cd83f790600e3557acc99b1de6ac32'
-            '4a12334c0cf6e4655fd264e2ae0e9607b7deaf65c8b757766ab15c248738b83b'
-            '3f3331d5d4ef822ae4cefa00c528691a46207a3df1365da9f1441c12bde524d8')
+             '4a12334c0cf6e4655fd264e2ae0e9607b7deaf65c8b757766ab15c248738b83b'
+             '3f3331d5d4ef822ae4cefa00c528691a46207a3df1365da9f1441c12bde524d8'
+             '39caaa4a84e357c1904d395e354ef9e9a45a2771c83ff1f8ded8a4c0501d7ce5')
 validpgpkeys=('1629C061B3DDE7EB4AE34B81021DB8B44E4A8645') # HandBrake Team <developers@handbrake.fr>
 
 _apply_patch_with_msg() {
@@ -79,6 +82,8 @@ prepare() {
   _apply_patch_with_msg 0004-fix-build-with-ffmpeg-8.patch
 
   _apply_patch_with_msg 0005-arch-detection.patch
+
+  _apply_patch_with_msg 0006-fix-build-with-external-libdovi.patch
 }
 
 build() {


### PR DESCRIPTION
ít gets picked up when it's installed, so why not