### PR TITLE
android-tools: drop upstreamed hunk

### DIFF
--- a/mingw-w64-android-tools/0005-missing-includes.patch
+++ b/mingw-w64-android-tools/0005-missing-includes.patch
@@ -18,13 +18,3 @@
  
  #include "socket.h"
  #include "transport.h"
---- android-tools-35.0.2/vendor/core/fastboot/usb.h.orig	2026-05-03 13:12:37.703259500 +0200
-+++ android-tools-35.0.2/vendor/core/fastboot/usb.h	2026-05-03 13:12:40.217044800 +0200
-@@ -30,6 +30,7 @@
- 
- #include <functional>
- #include <memory>
-+#include <cstdint>
- 
- #include "transport.h"
- 

--- a/mingw-w64-android-tools/PKGBUILD
+++ b/mingw-w64-android-tools/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=37.0.0
 _tag=${pkgver}
-pkgrel=1
+pkgrel=2
 pkgdesc='Android platform tools (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -41,7 +41,7 @@ sha256sums=('2725d09f892a3a38e534429f47a321f58ecf6a3169caa42c915fb2cb7d46be0e'
             'e02e8a54ff265f75b48e00c444bb6486276fb6051b93ce4d055cb531287f8055'
             '528e7a2dbf366832d6ae339e013de7c311efb7fa9139ce3478bc18fe29b0542d'
             '4c670ab8a96da18f26741bad300a8c218ac50cfa96efb713d36a6883d774c300'
-            'a71a5370446e3e033c6632e48fc0a29f40fadc7b43ede6a46c61f478df22d49d')
+            'e0b89815ef8cc40943f79721344937cc037d25cb4ee24a8d4bad5c1d031b0354')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {


### PR DESCRIPTION
I'm currently working on getting [my fork](https://github.com/meator/android-tools-static) of nmeum/android-tools up to date with nmeum/android-tools (Biswa96, if you're reading this, sorry for not responding to https://github.com/msys2/MINGW-packages/discussions/30410 sooner, I'll look into it more once I finish porting the changes). I use MSYS2 patches for guidance. I've noticed that one of the hunks should no longer be needed, because an identical hunk is part of [`patches/core/0011-core-include-missing-headers.patch`](https://github.com/nmeum/android-tools/blob/0c15591afc76852efea2f46f29f94b60aac44750/patches/core/0011-core-include-missing-headers.patch):

https://github.com/nmeum/android-tools/blob/0c15591afc76852efea2f46f29f94b60aac44750/patches/core/0011-core-include-missing-headers.patch#L39-L50