### PR TITLE
vtk: add nlohmann-json to makedepends

### DIFF
--- a/mingw-w64-vtk/PKGBUILD
+++ b/mingw-w64-vtk/PKGBUILD
@@ -5,7 +5,7 @@ _realname=vtk
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=9.6.2
-pkgrel=6
+pkgrel=7
 pkgdesc="A software system for 3D computer graphics, image processing and visualization (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -66,6 +66,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-libtheora"
              "${MINGW_PACKAGE_PREFIX}-libxml2"
              "${MINGW_PACKAGE_PREFIX}-netcdf"
+             "${MINGW_PACKAGE_PREFIX}-nlohmann-json"
              "${MINGW_PACKAGE_PREFIX}-openslide"
              "${MINGW_PACKAGE_PREFIX}-opencascade"
              "${MINGW_PACKAGE_PREFIX}-openturns"


### PR DESCRIPTION
Looks like this is now required to build vtk: https://github.com/msys2/msys2-autobuild/actions/runs/31336765611/job/93303801865?check_suite_focus=true#step:10:49813

```
  CMake Warning at CMake/vtkModule.cmake:5394 (find_package):
    By not providing "Findnlohmann_json.cmake" in CMAKE_MODULE_PATH this
    project has asked CMake to find a package configuration file provided by
    "nlohmann_json", but CMake did not find one.
  
    Could not find a package configuration file provided by "nlohmann_json"
    with any of the following names:
  
      nlohmann_json.cps
      nlohmann_jsonConfig.cmake
      nlohmann_json-config.cmake
  
    Add the installation prefix of "nlohmann_json" to CMAKE_PREFIX_PATH or set
    "nlohmann_json_DIR" to a directory containing one of the above files.  If
    "nlohmann_json" provides a separate development package or SDK, be sure it
    has been installed.
  Call Stack (most recent call first):
    CMake/vtkModule.cmake:6037 (vtk_module_find_package)
    CMake/vtkModule.cmake:5904 (vtk_module_third_party_external)
    ThirdParty/nlohmannjson/CMakeLists.txt:1 (vtk_module_third_party)
  
  
  CMake Error at CMake/vtkModule.cmake:5400 (message):
    Could not find the nlohmann_json external dependency.
  Call Stack (most recent call first):
    CMake/vtkModule.cmake:6037 (vtk_module_find_package)
    CMake/vtkModule.cmake:5904 (vtk_module_third_party_external)
    ThirdParty/nlohmannjson/CMakeLists.txt:1 (vtk_module_third_party)
  
  
  -- Configuring incomplete, errors occurred!
  ==> ERROR: A failure occurred in build().

```