### PR TITLE
croc: update to 11.0.3

### DIFF
--- a/mingw-w64-croc/PKGBUILD
+++ b/mingw-w64-croc/PKGBUILD
@@ -3,11 +3,11 @@
 _realname=croc
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=11.0.2
+pkgver=11.0.3
 pkgrel=1
 pkgdesc='Easily and securely send things from one computer to another.'
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
 url='https://github.com/schollz/croc'
 msys2_repository_url='https://github.com/schollz/croc'
 msys2_references=(
@@ -19,7 +19,7 @@ msys2_references=(
 license=('spdx:MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-go" "${MINGW_PACKAGE_PREFIX}-cc")
 source=("$pkgname-v$pkgver.tar.gz::$url/releases/download/v$pkgver/${_realname}_v${pkgver}_src.tar.gz")
-sha256sums=('842471b59b6b22240f06ade917189a36ff5be775c886be6673b2eb29693aea0e')
+sha256sums=('3e93554a597c79bd2ffb867314e037f88f0cfbbfa0c98b48447f1aae9f5938b0')
 
 build() {
   cd "${_realname}-v${pkgver}"


### PR DESCRIPTION
This commit also drops the mingw64 package of croc, because the environment has been deprecated.