### PR TITLE
CI: mask pkgver in file-diff

### DIFF
--- a/.ci/ci-build.sh
+++ b/.ci/ci-build.sh
@@ -61,6 +61,13 @@ install_packages() {
     pacman --noprogressbar --upgrade --noconfirm *.pkg.tar.*
 }
 
+pkgver_from_metadata() {
+    local version
+    version="$(sed -n 's/^Version[[:space:]]*:[[:space:]]*//p')"
+    version="${version%-*}"
+    printf '%s\n' "${version#*~}" | sed 's/\./\\./g'
+}
+
 # List DLL dependencies
 list_dll_deps(){
     local target="${1}"
@@ -157,7 +164,11 @@ for package in "${packages[@]}"; do
 
         echo "::group::[file-diff] ${pkgname}"
         message "File listing diff for ${pkgname}"
-        diff -Nur <(pacman -Fl ${MSYSTEM,,}/"$pkgname" | sed -e 's|^[^ ]* |/|' | sort) <(pacman -Ql "$pkgname" | sed -e 's|^[^/]*||' | sort) || true
+        old_pkgver="$(pacman -Si ${MSYSTEM,,}/"${pkgname}" | pkgver_from_metadata)"
+        new_pkgver="$(pacman -Qip "${pkg}" | pkgver_from_metadata)"
+        diff -Nur \
+            <(pacman -Fl ${MSYSTEM,,}/"${pkgname}" | sed -e 's|^[^ ]* |/|' -e "s|${old_pkgver}|PKGVER|g" | sort) \
+            <(pacman -Ql "${pkgname}" | sed -e 's|^[^/]*||' -e "s|${new_pkgver}|PKGVER|g" | sort) || true
         echo "::endgroup::"
 
         echo "::group::[runtime-dependencies] ${pkgname}"


### PR DESCRIPTION
This helps comparing the true file-diff during updates of those pkgs that use pkgver as part of file path.