### PR TITLE
swig: Update to 4.5.0

### DIFF
--- a/mingw-w64-swig/001-relocate.patch
+++ b/mingw-w64-swig/001-relocate.patch
@@ -39,19 +39,23 @@ diff -Naur swig-4.0.0.orig/Source/Modules/main.cxx swig-4.0.0/Source/Modules/mai
        SwigLib = NewStringf("");	// Unexpected error
      }
      if (Len(SWIG_LIB_WIN_UNIX) > 0)
--      SwigLibWinUnix = NewString(SWIG_LIB_WIN_UNIX); // Unix installation path using a drive letter (for msys/mingw)
+-      SwigLibWinUnix = NewString(SWIG_LIB_WIN_UNIX);  // Unix installation path using a drive letter (for msys/mingw)
 +      SwigLibWinUnix = NewString(single_path_relocation(SWIG_BINDIR, SWIG_LIB)); // Unix installation path using a drive letter (for msys/mingw)
  #else
      SwigLib = NewString(SWIG_LIB);
  #endif
---- swig-4.4.1/Tools/convertpath.orig	2026-01-27 20:17:58.954121200 +0100
-+++ swig-4.4.1/Tools/convertpath	2026-01-27 20:18:06.206576600 +0100
-@@ -22,7 +22,7 @@
-   -m) shift
-       case $MACHTYPE in
-         # This echo converts unix to mixed paths. Then zap unexpected trailing space on old versions of MinGW.
--        *-msys) echo `cmd //c echo "$@" | sed -e "s/[ ]*$//"`;;
-+        *-msys|*-cygwin) echo `cmd //c echo "$@" | sed -e "s/[ ]*$//"`;;
-         *) echo "The -m option is only supported on MinGW MSYS" 1>&2; exit 1 ;;
-       esac ;;
-   -u) shift; echo $@ | sed -e 's,\\,/,g' ;;
+diff --git a/configure.ac b/configure.ac
+index 7fb425767..3612e6f91 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2710,8 +2710,7 @@ AC_DEFINE_DIR(SWIG_LIB, swig_lib, [Directory for SWIG system-independent librari
+ 
+ case $build in
+   # Windows does not understand unix directories. Convert into a windows directory with drive letter.
+-  *-*-mingw*) SWIG_LIB_WIN_UNIX=`${srcdir}/Tools/convertpath -m $SWIG_LIB`;;
+-  *-*-cygwin*) SWIG_LIB_WIN_UNIX=`cygpath --mixed "$SWIG_LIB"`;;
++  *-*-cygwin* | *-*-mingw*) SWIG_LIB_WIN_UNIX=`$CYGPATH -m $SWIG_LIB`;;
+   *) SWIG_LIB_WIN_UNIX="";;
+ esac
+ AC_DEFINE_UNQUOTED(SWIG_LIB_WIN_UNIX, ["$SWIG_LIB_WIN_UNIX"], [Directory for SWIG system-independent libraries (Unix install on native Windows)])
+ 

--- a/mingw-w64-swig/PKGBUILD
+++ b/mingw-w64-swig/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=swig
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.4.1
+pkgver=4.5.0
 pkgrel=1
 pkgdesc="Generate scripting interfaces to C/C++ code (mingw-w64)"
 arch=('any')
@@ -23,10 +23,10 @@ source=(https://downloads.sourceforge.net/${_realname}/${_realname}-${pkgver}.ta
         pathtools.c
         pathtools.h
         001-relocate.patch)
-sha256sums=('40162a706c56f7592d08fd52ef5511cb7ac191f3593cf07306a0a554c6281fcf'
+sha256sums=('22ae0e887f8cca8031a325c67d005207653200b40e71edb3f88780e28e47d0ff'
             'ebf471173f5ee9c4416c10a78760cea8afaf1a4a6e653977321e8547ce7bf3c0'
             '1585ef1b61cf53a2ca27049c11d49e0834683dfda798f03547761375df482a90'
-            '87d905560e432661fbf44b6b65b9957abb91f2067796b5195c991a33cf6d73fa')
+            '095ed6a0cb239e16978c4384af0c1e59fe602024859e99c5a829d079074f2bd3')
 
 prepare() {
   test ! -d "${startdir}/../mingw-w64-pathtools" || {


### PR DESCRIPTION
swig-4.5 removes `convertpath` in favour of `cygpath`, but still requires a patch. The upstreamed patch is here: https://github.com/swig/swig/pull/3534

Release notes of swig-4.5.0 are here: https://www.swig.org/Release/RELEASENOTES It fixes compatibility with ruby-4.1 (current ruby master branch).