### PR TITLE
llvm: use llvm-tools instead of lld to provide binutils & use hardlink instead of copy

### DIFF
--- a/mingw-w64-llvm/PKGBUILD
+++ b/mingw-w64-llvm/PKGBUILD
@@ -17,16 +17,18 @@ fi
 
 _realname=llvm
 pkgbase=mingw-w64-${_realname}
-pkgname=("${MINGW_PACKAGE_PREFIX}-llvm"
-         "${MINGW_PACKAGE_PREFIX}-llvm-tools"
-         "${MINGW_PACKAGE_PREFIX}-llvm-libs"
-         "${MINGW_PACKAGE_PREFIX}-clang"
-         "${MINGW_PACKAGE_PREFIX}-clang-libs"
-         "${MINGW_PACKAGE_PREFIX}-clang-analyzer"
-         "${MINGW_PACKAGE_PREFIX}-clang-tools-extra"
-         "${MINGW_PACKAGE_PREFIX}-compiler-rt"
-         $( (( _clangprefix )) && echo "${MINGW_PACKAGE_PREFIX}-gcc-compat" )
-         "${MINGW_PACKAGE_PREFIX}-lld")
+pkgname=(
+  "${MINGW_PACKAGE_PREFIX}-llvm"
+  "${MINGW_PACKAGE_PREFIX}-llvm-tools"
+  "${MINGW_PACKAGE_PREFIX}-llvm-libs"
+  "${MINGW_PACKAGE_PREFIX}-clang"
+  "${MINGW_PACKAGE_PREFIX}-clang-libs"
+  "${MINGW_PACKAGE_PREFIX}-clang-analyzer"
+  "${MINGW_PACKAGE_PREFIX}-clang-tools-extra"
+  "${MINGW_PACKAGE_PREFIX}-compiler-rt"
+  $( (( _clangprefix )) && echo "${MINGW_PACKAGE_PREFIX}-gcc-compat" )
+  "${MINGW_PACKAGE_PREFIX}-lld"
+)
 _pkgver=22.1.8
 pkgver=${_pkgver/-/}
 pkgrel=3
@@ -40,20 +42,21 @@ msys2_references=(
 )
 license=("spdx:Apache-2.0 WITH LLVM-exception")
 groups=($( (( _clangprefix )) && echo "${MINGW_PACKAGE_PREFIX}-toolchain"))
-makedepends=($([[ "$_compiler" == "clang" ]] && echo \
-               "${MINGW_PACKAGE_PREFIX}-clang" || echo \
-               "${MINGW_PACKAGE_PREFIX}-gcc")
-             "${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-ninja"
-             "${MINGW_PACKAGE_PREFIX}-pkgconf"
-             "${MINGW_PACKAGE_PREFIX}-libffi"
-             "${MINGW_PACKAGE_PREFIX}-z3"
-             "${MINGW_PACKAGE_PREFIX}-python"
-             $((( _clangprefix )) && echo \
-               "${MINGW_PACKAGE_PREFIX}-compiler-rt" \
-               "${MINGW_PACKAGE_PREFIX}-libc++")
-             "${MINGW_PACKAGE_PREFIX}-git"
-             )
+makedepends=(
+  $([[ "$_compiler" == "clang" ]] && echo \
+    "${MINGW_PACKAGE_PREFIX}-clang" || echo \
+    "${MINGW_PACKAGE_PREFIX}-gcc")
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+  "${MINGW_PACKAGE_PREFIX}-ninja"
+  "${MINGW_PACKAGE_PREFIX}-pkgconf"
+  "${MINGW_PACKAGE_PREFIX}-libffi"
+  "${MINGW_PACKAGE_PREFIX}-z3"
+  "${MINGW_PACKAGE_PREFIX}-python"
+  $( (( _clangprefix )) && echo \
+    "${MINGW_PACKAGE_PREFIX}-compiler-rt" \
+    "${MINGW_PACKAGE_PREFIX}-libc++")
+  "${MINGW_PACKAGE_PREFIX}-git"
+)
 _url=https://github.com/llvm/llvm-project/releases/download/llvmorg-${_pkgver}
 _pkgfn=llvm-project-${_pkgver}.src
 source=("${_url}/${_pkgfn}.tar.xz"{,.sig}
@@ -93,17 +96,9 @@ apply_patch_with_msg() {
   done
 }
 
-revert_patch_with_msg() {
-  for _patch in "$@"
-  do
-    msg2 "Reverting ${_patch}"
-    patch -Rbp1 -i "${srcdir}/${_patch}"
-  done
-}
-
 prepare() {
   plain "Extracting ${_pkgfn}.tar.xz due to symlink(s) without pre-existing target(s)"
-  ${MINGW_PREFIX}/bin/bsdtar -xJf "${srcdir}"/${_pkgfn}.tar.xz -C "${srcdir}" || true
+  bsdtar -xJf "${srcdir}"/${_pkgfn}.tar.xz -C "${srcdir}" || true
 
   # Patch llvm
   # 0004 patch from https://github.com/llvm/llvm-project/pull/208683
@@ -185,7 +180,7 @@ build() {
 
   if (( _pgo )); then
     # Build Clang with instrumentation.
-    ${MINGW_PREFIX}/bin/cmake.exe \
+    cmake \
       -GNinja \
       -DDEFAULT_SYSROOT=${MINGW_PREFIX} \
       -DLLVM_ENABLE_PROJECTS="clang" \
@@ -200,9 +195,9 @@ build() {
       "${common_cmake_args[@]}" \
       -S ${_pkgfn}/${_realname} \
       -B build-${MSYSTEM}-instrument
-    ${MINGW_PREFIX}/bin/cmake --build build-${MSYSTEM}-instrument --target compiler-rt --target clang
+    cmake --build build-${MSYSTEM}-instrument --target compiler-rt --target clang
     # Use that to build part of llvm to generate a profile.
-    ${MINGW_PREFIX}/bin/cmake.exe \
+    cmake \
       -GNinja \
       -DCMAKE_C_COMPILER="${srcdir}"/build-${MSYSTEM}-instrument/bin/clang.exe \
       -DCMAKE_CXX_COMPILER="${srcdir}"/build-${MSYSTEM}-instrument/bin/clang++.exe \
@@ -213,9 +208,9 @@ build() {
       -B build-${MSYSTEM}-train
     # Drop profiles generated from running cmake; those are not representative.
     rm "${srcdir}"/build-${MSYSTEM}-instrument/profiles/*.profraw
-    ${MINGW_PREFIX}/bin/cmake --build build-${MSYSTEM}-train --target clangSema
+    cmake --build build-${MSYSTEM}-train --target clangSema
     # Save Profile data
-    ${MINGW_PREFIX}/bin/llvm-profdata merge -output="${srcdir}"/profdata "${srcdir}"/build-${MSYSTEM}-instrument/profiles/*.profraw
+    llvm-profdata merge -output="${srcdir}"/profdata "${srcdir}"/build-${MSYSTEM}-instrument/profiles/*.profraw
     common_cmake_args+=("-DLLVM_PROFDATA_FILE="${srcdir}"/profdata")
   fi
 
@@ -264,7 +259,7 @@ build() {
   fi
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-  ${MINGW_PREFIX}/bin/cmake.exe \
+  cmake \
     -GNinja \
     -DLLVM_ENABLE_PROJECTS="${_projects}" \
     -DLLVM_ENABLE_RTTI=ON \
@@ -276,7 +271,7 @@ build() {
     -S ${_pkgfn}/${_realname} \
     -B build-${MSYSTEM}
 
-  ${MINGW_PREFIX}/bin/cmake.exe --build build-${MSYSTEM}
+  cmake --build build-${MSYSTEM}
 }
 
 check() {
@@ -284,33 +279,39 @@ check() {
   # Remove || true once testcase doesn't cause failures.
   # make check || true
   # make check-clang || true
-  ${MINGW_PREFIX}/bin/cmake.exe -DLLVM_INCLUDE_TESTS=ON ../llvm
-  ${MINGW_PREFIX}/bin/cmake.exe --build .
-  ${MINGW_PREFIX}/bin/cmake.exe --build . -- check-lld || true
+  cmake -DLLVM_INCLUDE_TESTS=ON ../llvm
+  cmake --build .
+  cmake --build . -- check-lld || true
 }
 
 package_clang() {
   pkgdesc="C language family frontend for LLVM (mingw-w64)"
   url="https://clang.llvm.org/"
-  depends=("${MINGW_PACKAGE_PREFIX}-clang-libs=${pkgver}"
-           $( ((_clangprefix)) && echo \
-             "${MINGW_PACKAGE_PREFIX}-compiler-rt=${pkgver}" \
-             "${MINGW_PACKAGE_PREFIX}-llvm-tools=${pkgver}" \
-             "${MINGW_PACKAGE_PREFIX}-crt" \
-             "${MINGW_PACKAGE_PREFIX}-headers" \
-             "${MINGW_PACKAGE_PREFIX}-lld=${pkgver}" \
-             "${MINGW_PACKAGE_PREFIX}-winpthreads" || echo \
-             "${MINGW_PACKAGE_PREFIX}-llvm-libs=${pkgver}" \
-             "${MINGW_PACKAGE_PREFIX}-gcc"))
+  depends=("${MINGW_PACKAGE_PREFIX}-clang-libs=${pkgver}")
   optdepends=("${MINGW_PACKAGE_PREFIX}-llvm=${pkgver}")
-  provides=($( (( _clangprefix )) && echo \
-             "${MINGW_PACKAGE_PREFIX}-cc" \
-             || true ))
+  provides=()
+  if (( _clangprefix )); then
+    depends+=(
+      "${MINGW_PACKAGE_PREFIX}-compiler-rt=${pkgver}"
+      "${MINGW_PACKAGE_PREFIX}-lld=${pkgver}"
+      "${MINGW_PACKAGE_PREFIX}-llvm-tools=${pkgver}"
+      "${MINGW_PACKAGE_PREFIX}-crt"
+      "${MINGW_PACKAGE_PREFIX}-headers"
+      "${MINGW_PACKAGE_PREFIX}-winpthreads"
+    )
+    provides+=("${MINGW_PACKAGE_PREFIX}-cc")
+  else
+    depends+=(
+      "${MINGW_PACKAGE_PREFIX}-llvm-libs=${pkgver}"
+      "${MINGW_PACKAGE_PREFIX}-gcc"
+    )
+  fi
 
   # Disable automatic installation of components that go into subpackages
   # -i.orig to check what has been removed in-case it starts dropping more than it should
-  sed -i.orig '/\(extra\|scan-build\|scan-build-py\|scan-view\)\/cmake_install.cmake/d' build-${MSYSTEM}/tools/clang/tools/cmake_install.cmake
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install "${srcdir}"/build-${MSYSTEM}/tools/clang
+  sed -i.orig '/\(extra\|scan-build\|scan-build-py\|scan-view\)\/cmake_install.cmake/d' \
+    build-${MSYSTEM}/tools/clang/tools/cmake_install.cmake
+  DESTDIR="${pkgdir}" cmake --install "${srcdir}"/build-${MSYSTEM}/tools/clang
 
   install -Dm644 "${srcdir}"/${_pkgfn}/clang/LICENSE.TXT \
     "${pkgdir}"${MINGW_PREFIX}/share/licenses/clang/LICENSE
@@ -320,7 +321,7 @@ package_clang() {
   site_packages=$(cygpath ${_site_packages})
   install -d "${pkgdir}"/${site_packages}
   cp -a "${srcdir}"/${_pkgfn}/clang/bindings/python/clang "${pkgdir}"/${site_packages}
-  ${MINGW_PREFIX}/bin/python -m compileall -o 0 -o 1 "${pkgdir}"/${site_packages}
+  python -m compileall -o 0 -o 1 "${pkgdir}"/${site_packages}
 
   # Runtime libraries
   rm -rf "${srcdir}"/clang-libs
@@ -331,8 +332,10 @@ package_clang() {
 package_clang-libs() {
   pkgdesc="Clang runtime libraries (mingw-w64)"
   url="https://clang.llvm.org/"
-  depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
-           "${MINGW_PACKAGE_PREFIX}-llvm-libs=${pkgver}")
+  depends=(
+    "${MINGW_PACKAGE_PREFIX}-cc-libs"
+    "${MINGW_PACKAGE_PREFIX}-llvm-libs=${pkgver}"
+  )
   conflicts=("${MINGW_PACKAGE_PREFIX}-clang<17.0.6")
 
   cp -r "${srcdir}"/clang-libs/${MINGW_PREFIX} "${pkgdir}"${MINGW_PREFIX}
@@ -344,16 +347,18 @@ package_clang-libs() {
 package_clang-analyzer() {
   pkgdesc="A source code analysis framework (mingw-w64)"
   url="https://clang-analyzer.llvm.org/"
-  depends=("${MINGW_PACKAGE_PREFIX}-clang=${pkgver}"
-           "${MINGW_PACKAGE_PREFIX}-python")
+  depends=(
+    "${MINGW_PACKAGE_PREFIX}-clang=${pkgver}"
+    "${MINGW_PACKAGE_PREFIX}-python"
+  )
 
   local _analyzer
   for _analyzer in scan-build scan-build-py scan-view; do
-    DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install "${srcdir}"/build-${MSYSTEM}/tools/clang/tools/${_analyzer}
+    DESTDIR="${pkgdir}" cmake --install "${srcdir}"/build-${MSYSTEM}/tools/clang/tools/${_analyzer}
   done
 
   # Compile Python scripts
-  ${MINGW_PREFIX}/bin/python -m compileall -o 0 -o 1 "${pkgdir}"${MINGW_PREFIX}/lib/libscanbuild
+  python -m compileall -o 0 -o 1 "${pkgdir}"${MINGW_PREFIX}/lib/libscanbuild
 
   install -Dm644 "${srcdir}"/${_pkgfn}/clang/LICENSE.TXT \
     "${pkgdir}"${MINGW_PREFIX}/share/licenses/clang-analyzer/LICENSE
@@ -364,7 +369,7 @@ package_clang-tools-extra() {
   url="https://clang.llvm.org/"
   depends=("${MINGW_PACKAGE_PREFIX}-clang=${pkgver}")
 
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install "${srcdir}"/build-${MSYSTEM}/tools/clang/tools/extra
+  DESTDIR="${pkgdir}" cmake --install "${srcdir}"/build-${MSYSTEM}/tools/clang/tools/extra
 
   install -Dm644 "${srcdir}"/${_pkgfn}/clang-tools-extra/LICENSE.TXT \
     "${pkgdir}"${MINGW_PREFIX}/share/licenses/clang-tools-extra/LICENSE
@@ -375,7 +380,7 @@ package_compiler-rt() {
   url="https://compiler-rt.llvm.org/"
   depends=($( (( _clangprefix )) || echo "${MINGW_PACKAGE_PREFIX}-cc-libs"))
 
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install "${srcdir}"/build-${MSYSTEM}//projects/compiler-rt
+  DESTDIR="${pkgdir}" cmake --install "${srcdir}"/build-${MSYSTEM}//projects/compiler-rt
   mkdir -p "${pkgdir}"${MINGW_PREFIX}/bin/
   find "${pkgdir}"${MINGW_PREFIX}/lib/clang/${pkgver%.[0-9].*}/lib/windows/ \
     -name '*.dll' -exec mv '{}' "${pkgdir}"${MINGW_PREFIX}/bin/ \;
@@ -404,12 +409,14 @@ package_gcc-compat() {
 package_lld() {
   pkgdesc="Linker tools for LLVM (mingw-w64)"
   url="https://lld.llvm.org/"
-  depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
-           "${MINGW_PACKAGE_PREFIX}-llvm-libs=${pkgver}"
-           "${MINGW_PACKAGE_PREFIX}-zlib"
-           "${MINGW_PACKAGE_PREFIX}-zstd")
+  depends=(
+    "${MINGW_PACKAGE_PREFIX}-cc-libs"
+    "${MINGW_PACKAGE_PREFIX}-llvm-libs=${pkgver}"
+    "${MINGW_PACKAGE_PREFIX}-zlib"
+    "${MINGW_PACKAGE_PREFIX}-zstd"
+  )
 
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install "${srcdir}"/build-${MSYSTEM}/tools/lld
+  DESTDIR="${pkgdir}" cmake --install "${srcdir}"/build-${MSYSTEM}/tools/lld
   if (( _clangprefix )); then
     install -Dm755 "${pkgdir}"${MINGW_PREFIX}/bin/lld.exe "${pkgdir}"${MINGW_PREFIX}/bin/ld.exe
   fi
@@ -420,15 +427,17 @@ package_lld() {
 
 package_llvm() {
   pkgdesc="Low Level Virtual Machine (mingw-w64)"
-  depends=("${MINGW_PACKAGE_PREFIX}-llvm-libs=${pkgver}"
-           "${MINGW_PACKAGE_PREFIX}-llvm-tools=${pkgver}")
+  depends=(
+    "${MINGW_PACKAGE_PREFIX}-llvm-libs=${pkgver}"
+    "${MINGW_PACKAGE_PREFIX}-llvm-tools=${pkgver}"
+  )
 
   # Disable automatic installation of components that go into subpackages
   # -i.orig to check what has been removed in-case it starts dropping more than it should
   sed -i.orig '/tools\/cmake_install.cmake/d' build-${MSYSTEM}/cmake_install.cmake
   sed -i.orig '/compiler-rt\/cmake_install.cmake/d' build-${MSYSTEM}/projects/cmake_install.cmake
 
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install build-${MSYSTEM}
+  DESTDIR="${pkgdir}" cmake --install build-${MSYSTEM}
 
   install -Dm644 "${srcdir}"/${_pkgfn}/llvm/LICENSE.TXT \
     "${pkgdir}"${MINGW_PREFIX}/share/licenses/llvm/LICENSE
@@ -452,12 +461,15 @@ package_llvm-tools() {
     "${MINGW_PACKAGE_PREFIX}-lld=${pkgver}" # for ld
   )
   conflicts=("${MINGW_PACKAGE_PREFIX}-llvm<20.1.5-2")
-  provides=($( (( _clangprefix )) && echo "${MINGW_PACKAGE_PREFIX}-binutils"))
+  provides=()
+  if (( _clangprefix )); then
+    provides+=("${MINGW_PACKAGE_PREFIX}-binutils")
+  fi
 
   # Disable automatic installation of components that go into subpackages
   # -i.orig to check what has been removed in-case it starts dropping more than it should
   sed -i.orig '/\(clang\|lld\)\/cmake_install.cmake/d' build-${MSYSTEM}/tools/cmake_install.cmake
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install build-${MSYSTEM}/tools
+  DESTDIR="${pkgdir}" cmake --install build-${MSYSTEM}/tools
 
   # Runtime libraries
   rm -rf "${srcdir}"/llvm-libs
@@ -470,18 +482,20 @@ package_llvm-tools() {
     "${pkgdir}"${MINGW_PREFIX}/share/licenses/llvm-tools/LICENSE
 
   # Provide gcov on CLANG*
-  if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
+  if (( _clangprefix )) ; then
     cp "${pkgdir}"${MINGW_PREFIX}/bin/llvm-cov.exe "${pkgdir}"${MINGW_PREFIX}/bin/gcov.exe
   fi
 }
 
 package_llvm-libs() {
   pkgdesc="Low Level Virtual Machine Runtime Libraries (mingw-w64)"
-  depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
-           "${MINGW_PACKAGE_PREFIX}-libffi"
-           "${MINGW_PACKAGE_PREFIX}-libxml2"
-           "${MINGW_PACKAGE_PREFIX}-zlib"
-           "${MINGW_PACKAGE_PREFIX}-zstd")
+  depends=(
+    "${MINGW_PACKAGE_PREFIX}-cc-libs"
+    "${MINGW_PACKAGE_PREFIX}-libffi"
+    "${MINGW_PACKAGE_PREFIX}-libxml2"
+    "${MINGW_PACKAGE_PREFIX}-zlib"
+    "${MINGW_PACKAGE_PREFIX}-zstd"
+  )
   conflicts=("${MINGW_PACKAGE_PREFIX}-llvm<16.0.2-2")
 
   cp -r "${srcdir}"/llvm-libs/${MINGW_PREFIX} "${pkgdir}"${MINGW_PREFIX}

--- a/mingw-w64-llvm/PKGBUILD
+++ b/mingw-w64-llvm/PKGBUILD
@@ -327,6 +327,15 @@ package_clang() {
   rm -rf "${srcdir}"/clang-libs
   mkdir -p "${srcdir}"/clang-libs/${MINGW_PREFIX}/bin
   mv -f "${pkgdir}"${MINGW_PREFIX}/bin/libclang{,-cpp}.dll "${srcdir}"/clang-libs/${MINGW_PREFIX}/bin
+
+  # Try use hardlinks
+  local _alias
+  for _alias in clang++ clang-cpp ${MINGW_CHOST}-clang ${MINGW_CHOST}-clang++; do
+    if cmp "${pkgdir}${MINGW_PREFIX}/bin/clang.exe" "${pkgdir}${MINGW_PREFIX}/bin/${_alias}.exe"; then
+      rm -vf "${pkgdir}${MINGW_PREFIX}/bin/${_alias}.exe"
+      ln -v "${pkgdir}${MINGW_PREFIX}/bin/clang.exe" "${pkgdir}${MINGW_PREFIX}/bin/${_alias}.exe"
+    fi
+  done
 }
 
 package_clang-libs() {
@@ -400,9 +409,11 @@ package_gcc-compat() {
   groups=()
 
   mkdir -p "${pkgdir}"${MINGW_PREFIX}/bin
+
+  # Use hardlinks
   local _alias
   for _alias in gcc g++ ${MINGW_CHOST}-gcc ${MINGW_CHOST}-g++; do
-    cp -f "${srcdir}"/build-${MSYSTEM}/bin/clang.exe "${pkgdir}"${MINGW_PREFIX}/bin/${_alias}.exe
+    ln -vf "${srcdir}"/build-${MSYSTEM}/bin/clang.exe "${pkgdir}"${MINGW_PREFIX}/bin/${_alias}.exe
   done
 }
 
@@ -418,7 +429,7 @@ package_lld() {
 
   DESTDIR="${pkgdir}" cmake --install "${srcdir}"/build-${MSYSTEM}/tools/lld
   if (( _clangprefix )); then
-    install -Dm755 "${pkgdir}"${MINGW_PREFIX}/bin/lld.exe "${pkgdir}"${MINGW_PREFIX}/bin/ld.exe
+    ln -vf "${pkgdir}"${MINGW_PREFIX}/bin/lld.exe "${pkgdir}"${MINGW_PREFIX}/bin/ld.exe
   fi
 
   install -Dm644 "${srcdir}"/${_pkgfn}/lld/LICENSE.TXT \
@@ -483,7 +494,7 @@ package_llvm-tools() {
 
   # Provide gcov on CLANG*
   if (( _clangprefix )) ; then
-    cp "${pkgdir}"${MINGW_PREFIX}/bin/llvm-cov.exe "${pkgdir}"${MINGW_PREFIX}/bin/gcov.exe
+    ln -vf "${pkgdir}"${MINGW_PREFIX}/bin/llvm-cov.exe "${pkgdir}"${MINGW_PREFIX}/bin/gcov.exe
   fi
 }
 

--- a/mingw-w64-llvm/PKGBUILD
+++ b/mingw-w64-llvm/PKGBUILD
@@ -29,7 +29,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-llvm"
          "${MINGW_PACKAGE_PREFIX}-lld")
 _pkgver=22.1.8
 pkgver=${_pkgver/-/}
-pkgrel=2
+pkgrel=3
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -408,9 +408,6 @@ package_lld() {
            "${MINGW_PACKAGE_PREFIX}-llvm-libs=${pkgver}"
            "${MINGW_PACKAGE_PREFIX}-zlib"
            "${MINGW_PACKAGE_PREFIX}-zstd")
-  provides=($( (( _clangprefix )) && echo \
-             "${MINGW_PACKAGE_PREFIX}-binutils" \
-             || true))
 
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install "${srcdir}"/build-${MSYSTEM}/tools/lld
   if (( _clangprefix )); then
@@ -450,8 +447,12 @@ package_llvm() {
 
 package_llvm-tools() {
   pkgdesc="Low Level Virtual Machine - Tools (mingw-w64)"
-  depends=("${MINGW_PACKAGE_PREFIX}-llvm-libs=${pkgver}")
+  depends=(
+    "${MINGW_PACKAGE_PREFIX}-llvm-libs=${pkgver}"
+    "${MINGW_PACKAGE_PREFIX}-lld=${pkgver}" # for ld
+  )
   conflicts=("${MINGW_PACKAGE_PREFIX}-llvm<20.1.5-2")
+  provides=($( (( _clangprefix )) && echo "${MINGW_PACKAGE_PREFIX}-binutils"))
 
   # Disable automatic installation of components that go into subpackages
   # -i.orig to check what has been removed in-case it starts dropping more than it should


### PR DESCRIPTION
lld only contain ld, while llvm-tools contain most other stuff (ar, nm, objdump, ranlib, windres, etc.), so it's more like an replacement of binutils. Add lld to llvm-tools' depends, so that it also provides ld