### PR TITLE
windows-default-manifest: minimize & embed source

### DIFF
--- a/mingw-w64-windows-default-manifest/PKGBUILD
+++ b/mingw-w64-windows-default-manifest/PKGBUILD
@@ -1,34 +1,27 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Maintainer: dragon-archer <dragon-archer@outlook.com>
 
 _realname=windows-default-manifest
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=6.4
-pkgrel=4
+pkgver=20260815
+pkgrel=1
 pkgdesc='Default Windows application manifest (mingw-w64)'
-url='https://cygwin.com/'
-msys2_repository_url='https://sourceware.org/git/cygwin-apps/windows-default-manifest'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
-license=('BSD')
-makedepends=('git' "${MINGW_PACKAGE_PREFIX}-cc" "${MINGW_PACKAGE_PREFIX}-autotools")
-_GIT_TAG="release-6_4"
-source=("git+https://sourceware.org/git/cygwin-apps/${_realname}.git#tag=${_GIT_TAG}")
-sha256sums=('SKIP')
+license=('custom:Public Domain')
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc" # windres requires cc to preprocess, cc implies binutils.
+  "${MINGW_PACKAGE_PREFIX}-python"
+)
+source=('genrc.py') # https://gist.github.com/lazka/e485d49354b39b81dae45d3848004b7d
+sha256sums=('f2bfbcd92ab28d8671dda5a1485aae150ce5d5faf4395a6a4462cacd2a6fb60a')
 
 build() {
-  [[ -d "${srcdir}"/build-${MSYSTEM} ]] && rm -rf "${srcdir}"/build-${MSYSTEM}
-  cp -rf "${srcdir}"/${_realname} "${srcdir}"/build-${MSYSTEM}
-  cd "${srcdir}"/build-${MSYSTEM}
-  ./configure \
-    --prefix=${MINGW_PREFIX} \
-    --build=${MINGW_CHOST} \
-    --host=${MINGW_CHOST} \
-    --target=${MINGW_CHOST}
-  make
+  python genrc.py -o "default-manifest.rc"
+  windres --target ${MINGW_CHOST} -i "default-manifest.rc" -o "default-manifest.o"
 }
 
 package() {
-  cd "${srcdir}"/build-${MSYSTEM}
-  make DESTDIR="${pkgdir}" install
+  install -Dm644 "default-manifest.o" "${pkgdir}${MINGW_PREFIX}/lib/default-manifest.o"
 }

--- a/mingw-w64-windows-default-manifest/genrc.py
+++ b/mingw-w64-windows-default-manifest/genrc.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Generate a Windows RT_MANIFEST resource (.rc) with minified XML."""
+
+import re
+
+XML_TEMPLATE = """\
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!--The ID below indicates application support for Windows Vista -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+      <!--The ID below indicates application support for Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <!--The ID below indicates application support for Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!--The ID below indicates application support for Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!--The ID below indicates application support for Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+</assembly>
+"""
+
+def minify_xml(xml: str) -> str:
+    """Strip comments and collapse whitespace between tags."""
+    # Remove XML comments
+    xml = re.sub(r"<!--.*?-->", "", xml, flags=re.DOTALL)
+    # Collapse whitespace between tags
+    xml = re.sub(r">\s+<", "><", xml)
+    # Trim leading/trailing whitespace
+    return xml.strip()
+
+
+def escape_rc_string(s: str) -> str:
+    """Escape a string for use inside an RC BEGIN/END block."""
+    return s.replace('"', '""')
+
+
+def generate_rc(xml: str, resource_id: int = 1, resource_type: int = 24) -> str:
+    data = escape_rc_string(minify_xml(xml))
+    return f"""\
+LANGUAGE 0, 0
+
+/* CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST MOVEABLE PURE DISCARDABLE */
+{resource_id} {resource_type} MOVEABLE PURE DISCARDABLE
+BEGIN
+  "{data}"
+END
+"""
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Generate a minified RT_MANIFEST .rc resource."
+    )
+    parser.add_argument(
+        "-o", "--output", help="Output .rc file (defaults to stdout)."
+    )
+    args = parser.parse_args()
+
+    rc = generate_rc(XML_TEMPLATE)
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(rc)
+    else:
+        print(rc, end="")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
default-manifest.o is embedded into every execuatables, so it worth minimizing it.

Also, the upstream cygwin repo is seldom updated, and the autotools stuff are redudant. It's easier to embed the source here instead of patching.