### PR TITLE
librist: update to 0.2.20

### DIFF
--- a/mingw-w64-librist/PKGBUILD
+++ b/mingw-w64-librist/PKGBUILD
@@ -3,31 +3,31 @@
 _realname=librist
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.2.11
-pkgrel=3
+pkgver=0.2.20
+pkgrel=1
 pkgdesc='A library that can be used to add the RIST protocol to applications (mingw-w64)'
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
 url='https://code.videolan.org/rist/librist/'
 msys2_repository_url='https://code.videolan.org/rist/librist'
 license=('spdx:BSD-2-Clause')
 depends=(
   "${MINGW_PACKAGE_PREFIX}-cjson"
   "${MINGW_PACKAGE_PREFIX}-libwinpthread"
+  "${MINGW_PACKAGE_PREFIX}-lz4"
   "${MINGW_PACKAGE_PREFIX}-mbedtls"
 )
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cc"
   "${MINGW_PACKAGE_PREFIX}-cmake"
   "${MINGW_PACKAGE_PREFIX}-cmocka"
-  "${MINGW_PACKAGE_PREFIX}-lz4"
   "${MINGW_PACKAGE_PREFIX}-meson"
   "${MINGW_PACKAGE_PREFIX}-ninja"
   "${MINGW_PACKAGE_PREFIX}-pkgconf"
   "${MINGW_PACKAGE_PREFIX}-winpthreads"
 )
 source=("https://code.videolan.org/rist/librist/-/archive/v${pkgver}/${_realname}-v${pkgver}.tar.bz2")
-sha256sums=('f254842900a9dd20fb477b05ea0cce3ec1a8004d85177eef2408eefddca68b86')
+sha256sums=('20a5cdce88ccaeab11cd8860c82c565472f21572705d9a476265c5148bf4aeb1')
 
 build() {
   MSYS2_ARG_CONV_EXCL="--prefix=" \


### PR DESCRIPTION
This PR also drops mingw64 from the arch list, because the environment has been deprecated.