### PR TITLE
python-filelock: update to 3.29.7 + python-typing-inspection: update to 0.4.4

### DIFF
--- a/mingw-w64-python-filelock/PKGBUILD
+++ b/mingw-w64-python-filelock/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=filelock
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=3.29.4
+pkgver=3.29.7
 pkgrel=1
 pkgdesc="A platform independent file lock (mingw-w64)"
 arch=('any')
@@ -28,22 +28,22 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest"
               "${MINGW_PACKAGE_PREFIX}-python-pytest-timeout"
               "${MINGW_PACKAGE_PREFIX}-python-virtualenv")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a')
+sha256sums=('5b481979797ae69e72f0b389d89a80bdd585c260c5b3f1fb9c0a5ba9bb3f195d')
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
-  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
+  python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 check() {
-  cd "${srcdir}/python-build-${MSYSTEM}"
+  cd "python-build-${MSYSTEM}"
   PYTHONPATH=src ${MINGW_PREFIX}/bin/pytest tests
 }
 
 package() {
-  cd "${srcdir}/python-build-${MSYSTEM}"
+  cd "python-build-${MSYSTEM}"
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    python -m installer --prefix=${MINGW_PREFIX} \
     --destdir="${pkgdir}" dist/*.whl
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"

--- a/mingw-w64-python-typing-inspection/PKGBUILD
+++ b/mingw-w64-python-typing-inspection/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=typing-inspection
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=0.4.2
-pkgrel=3
+pkgver=0.4.4
+pkgrel=1
 pkgdesc="Runtime typing introspection tools (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -23,7 +23,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-installer"
              "${MINGW_PACKAGE_PREFIX}-python-hatchling")
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname/-/_}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464')
+sha256sums=('547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"


### PR DESCRIPTION
**Edit:** The [check job fails](https://github.com/msys2/MINGW-packages/actions/runs/31854410762/job/94938077561?pr=31041#step:8:209) with the following error:
```
  Pip Check Failed for mingw-w64-ucrt-x86_64-python-filelock
  Running `pip check` didn't suceed. Maybe missing dependencies?
  Here is what it failed.
  torch 2.12.0 has requirement setuptools<82, but you have setuptools 83.0.0.
```
However, that problem with pytorch's dependencies already existed before this pull request, so it's not a regression or problem caused by the changes here.