### PR TITLE
octave: replace unzip of checkdepends by native unzip

### DIFF
--- a/mingw-w64-octave/PKGBUILD
+++ b/mingw-w64-octave/PKGBUILD
@@ -4,7 +4,7 @@ _realname=octave
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=11.3.0
-pkgrel=2
+pkgrel=3
 pkgdesc="GNU Octave: Interactive programming environment for numerical computations (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -50,12 +50,12 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-fltk"
              "${MINGW_PACKAGE_PREFIX}-portaudio"
              "${MINGW_PACKAGE_PREFIX}-rapidjson")
-checkdepends=("unzip"
+checkdepends=("${MINGW_PACKAGE_PREFIX}-unzip"
               "zip")
-optdepends=("unzip: for decompressing .zip archives"
-            "zip: for compressing .zip archives"
+optdepends=("zip: for compressing .zip archives"
             "${MINGW_PACKAGE_PREFIX}-epstool: eps output with tight bounding box"
             "${MINGW_PACKAGE_PREFIX}-fltk: alternative plotting and dialogs"
+            "${MINGW_PACKAGE_PREFIX}-unzip: for decompressing .zip archives"
             "${MINGW_PACKAGE_PREFIX}-gnuplot: alternative plotting"
             "${MINGW_PACKAGE_PREFIX}-portaudio: audio support")
 source=(https://github.com/gnu-octave/octave/releases/download/release-${pkgver//./-}/octave-$pkgver.tar.xz{,.sig}


### PR DESCRIPTION
Needed to backport https://github.com/libarchive/libarchive/pull/3422