### PR TITLE
dxvk: update to 3.0.2

### DIFF
--- a/mingw-w64-dxvk/001-use-msys2-spirv-headers.patch
+++ b/mingw-w64-dxvk/001-use-msys2-spirv-headers.patch
@@ -1,0 +1,12 @@
+diff --git a/subprojects/dxbc-spirv/spirv/spirv_types.h b/subprojects/dxbc-spirv/spirv/spirv_types.h
+index 9b6a254..34d694a 100644
+--- a/subprojects/dxbc-spirv/spirv/spirv_types.h
++++ b/subprojects/dxbc-spirv/spirv/spirv_types.h
+@@ -1,5 +1,5 @@
+-#include "../submodules/spirv_headers/include/spirv/unified1/spirv.hpp"
+-#include "../submodules/spirv_headers/include/spirv/unified1/GLSL.std.450.h"
++#include <spirv/unified1/spirv.hpp>
++#include <spirv/unified1/GLSL.std.450.h>
+ 
+ #include "../ir/ir.h"
+ #include "../ir/ir_builder.h"

--- a/mingw-w64-dxvk/PKGBUILD
+++ b/mingw-w64-dxvk/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=dxvk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.7.1
+pkgver=3.0.2
 pkgrel=1
 pkgdesc="Vulkan-based implementation of D3D8, 9, 10 and 11 for Linux / Wine and Windows (mingw-w64)"
 arch=('any')
@@ -24,14 +24,34 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-vulkan-loader: use MSYS2 Vulkan loader when
 
 _libdisplay_info_name=libdisplay-info
 _libdisplay_info_commit=275e6459c7ab1ddd4b125f28d0440716e4888078
+_dxbc_spirv_name=dxbc-spirv
+_dxbc_spirv_commit=c5c1a5b9b61773d59592f628faa39be9add26282
 source=("https://github.com/doitsujin/dxvk/archive/refs/tags/v$pkgver.tar.gz"
         "${_libdisplay_info_name}"::"git+https://github.com/doitsujin/${_libdisplay_info_name}.git#commit=${_libdisplay_info_commit}"
+        "${_dxbc_spirv_name}"::"git+https://github.com/doitsujin/${_dxbc_spirv_name}.git#commit=${_dxbc_spirv_commit}"
+        "001-use-msys2-spirv-headers.patch"
 )
-sha256sums=('4966be884da4a1ded7e38ee018caef5626bd06bbd0853715084b1a1644aaaf02'
-            'e341e1f897220f586c95e1843059031633d780ea08800eea023ce3282730dfe7')
+sha256sums=('03ad9dc888238f325af0ca5a74e2f6d2ade4492ad14017152758c614e2073e22'
+            'e341e1f897220f586c95e1843059031633d780ea08800eea023ce3282730dfe7'
+            '588ffaa85c3370281ce1f0a59ddf22bca90e51fc03f9728a8591d65fb6915abd'
+            'a1a4f0b21c15b578c3a6f44139e6af90da0127da1fd0b05b51d9051be31f88a8')
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying ${_patch}"
+    patch -Nbp1 --binary -i "${srcdir}/${_patch}"
+  done
+}
 
 prepare() {
-    mv ${_libdisplay_info_name} "${_realname}-${pkgver}"/subprojects
+  mv ${_libdisplay_info_name} "${_realname}-${pkgver}"/subprojects
+  mv ${_dxbc_spirv_name} "${_realname}-${pkgver}"/subprojects
+
+  cd ${_realname}-${pkgver}
+
+  apply_patch_with_msg \
+    001-use-msys2-spirv-headers.patch
 }
 
 build() {


### PR DESCRIPTION
dxvk now depends on dxbc-spirv additionally. Just like libdisplay-info, it was by the same author, requires a sepcific commit, and not really used by anyone else. Therefore, it will not form an additional package.