### PR TITLE
qt6-pdf: update to 6.11.2 (2/4)

### DIFF
--- a/mingw-w64-qt6-pdf/PKGBUILD
+++ b/mingw-w64-qt6-pdf/PKGBUILD
@@ -4,7 +4,7 @@ _realname=qt6-pdf
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
-_qtver=6.11.1
+_qtver=6.11.2
 pkgver=${_qtver/-/}
 pkgrel=1
 pkgdesc='Qt6 PDF module (mingw-w64)'
@@ -27,7 +27,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 _pkgfn="qtwebengine-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/submodules/${_pkgfn}.tar.xz"
         "0001-missing-include.patch")
-sha256sums=('679c66ccc6c158fc215e9c58ef160331ecd29974232e345c05161889f8667083'
+sha256sums=('6101c1aa00ff933d1b65ee5d167f76e8d71b9ac5b378b0111277723ebda7c163'
             '6eb8984843aaeb0f97b55c609d78231a82cb0bb2b04ac6f466edd7a53a76b5ac')
 
 apply_patch_with_msg() {


### PR DESCRIPTION
Split out of #31105 to prevent the CI pipelines from timing out. Depends on #31106