### PR TITLE
qt6-doc: update to 6.11.2 (3/4)

### DIFF
--- a/mingw-w64-qt6-doc/PKGBUILD
+++ b/mingw-w64-qt6-doc/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=qt6-doc
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-_qtver=6.11.1
+_qtver=6.11.2
 pkgver=${_qtver/-/}
 pkgrel=1
 arch=(any)
@@ -37,7 +37,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
 groups=(${MINGW_PACKAGE_PREFIX}-qt6)
 _pkgfn="qt-everywhere-src-${_qtver}"
 source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/$_qtver/single/$_pkgfn.tar.xz")
-sha256sums=('252acef8c5ae68074d91cadba2ee4a83465051bbb970dd26e8f0daa0f3904e03')
+sha256sums=('6dcfbca271d76a6502741a2c0dc6fc98ef7dd0b7b4cfd0abcebb285a86a26f33')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {


### PR DESCRIPTION
Split out of #31105 to prevent the CI pipelines from timing out. Depends on #31106