### PR TITLE
rust: update to 1.98.0

### DIFF
--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -69,7 +69,7 @@ source=("${rust_dist_server}/${_realname}c-${pkgver}-src.tar.xz"{,.asc}
         #"0015-lesser-llvm-build.patch"
 )
 noextract=(${_realname}c-${pkgver}-src.tar.xz)
-sha256sums=('SKIP'
+sha256sums=('271fa73d8174f53d713c46a8310da7bf7cfdcfb8b7cfd1c2b74b84a83ae9fb1e'
             'SKIP'
             '61e30b72cb7526766d155dedb1d751f6fbb3c845234478cf09afbfc0f03b2e98'
             '3dcac012fea5051cc080c0e841492d848056ea8bd19e80d6527fb7acec88784d'

--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -10,8 +10,8 @@ if [[ ${MSYSTEM} != MINGW64 ]]; then
   _wasm=1
 fi
 
-rust_dist_server=https://static.rust-lang.org/dist
-#rust_dist_server=https://dev-static.rust-lang.org/dist/2026-05-26
+#rust_dist_server=https://static.rust-lang.org/dist
+rust_dist_server=https://dev-static.rust-lang.org/dist/2026-08-18
 
 _realname=rust
 pkgbase=mingw-w64-${_realname}
@@ -20,7 +20,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          $((( _wasm )) && echo \
            "${MINGW_PACKAGE_PREFIX}-rust-wasm" \
            "${MINGW_PACKAGE_PREFIX}-rust-emscripten"))
-pkgver=1.97.0
+pkgver=1.98.0
 pkgrel=1
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
@@ -69,9 +69,9 @@ source=("${rust_dist_server}/${_realname}c-${pkgver}-src.tar.xz"{,.asc}
         #"0015-lesser-llvm-build.patch"
 )
 noextract=(${_realname}c-${pkgver}-src.tar.xz)
-sha256sums=('de002ee301c1b7422b0a7b09d7c4cb4924cd3224e6cfb24f065dad786dd3ed12'
+sha256sums=('SKIP'
             'SKIP'
-            '142fbd0821a3c04a0350a037496173dfba5e109cc42032719c1fde541258ddad'
+            '61e30b72cb7526766d155dedb1d751f6fbb3c845234478cf09afbfc0f03b2e98'
             '3dcac012fea5051cc080c0e841492d848056ea8bd19e80d6527fb7acec88784d'
             'db5d0dbeaaab5bd22c71ef35d1978960dd7e79cc153e5eeb72a5f635255991de'
             '56882f1a0f1404c10c7726d6cc37444f2b343e72b969badfcb43760f80db0f32'

--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -10,8 +10,8 @@ if [[ ${MSYSTEM} != MINGW64 ]]; then
   _wasm=1
 fi
 
-#rust_dist_server=https://static.rust-lang.org/dist
-rust_dist_server=https://dev-static.rust-lang.org/dist/2026-08-18
+rust_dist_server=https://static.rust-lang.org/dist
+#rust_dist_server=https://dev-static.rust-lang.org/dist/2026-08-18
 
 _realname=rust
 pkgbase=mingw-w64-${_realname}

--- a/mingw-w64-rust/bootstrap.toml
+++ b/mingw-w64-rust/bootstrap.toml
@@ -2,7 +2,7 @@
 profile = "dist"
 
 # see src/bootstrap/src/utils/change_tracker.rs
-change-id = 154587
+change-id = 160100
 
 [llvm]
 link-shared = true


### PR DESCRIPTION
~~currently no pre-release tarball exist, but pushing this because~~ I won't have an access to laptop for the next 4 days...