### PR TITLE
python-jupyter-builder: add version 1.2.2 (new package)

### DIFF
--- a/mingw-w64-python-jupyter-builder/PKGBUILD
+++ b/mingw-w64-python-jupyter-builder/PKGBUILD
@@ -1,0 +1,46 @@
+# Contributor: Dirk Stolle
+
+_realname=jupyter-builder
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
+pkgver=1.2.2
+pkgrel=1
+pkgdesc="Build tools for JupyterLab (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://jupyter.org/'
+msys2_repository_url='https://github.com/jupyterlab/jupyter-builder'
+msys2_references=(
+  'archlinux: python-jupyter-builder'
+  'purl: pkg:pypi/jupyter-builder'
+)
+license=('spdx:BSD-3-Clause')
+depends=(
+    "${MINGW_PACKAGE_PREFIX}-python"
+    "${MINGW_PACKAGE_PREFIX}-python-jupyter_core"
+    "${MINGW_PACKAGE_PREFIX}-python-traitlets"
+)
+makedepends=(
+    "${MINGW_PACKAGE_PREFIX}-python-build"
+    "${MINGW_PACKAGE_PREFIX}-python-hatchling"
+    "${MINGW_PACKAGE_PREFIX}-python-installer"
+)
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
+sha256sums=('b6cea88f58e44b2c5eba96f28d2e0d16fd453d3ca6dc9c4492ff8a1f2e97f601')
+
+build() {
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd "python-build-${MSYSTEM}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    python -m installer --prefix=${MINGW_PREFIX} \
+    --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+}


### PR DESCRIPTION
Will be required to build newer versions of some jupyterlab packages.