### PR TITLE
mumps: Avoid MPI_IN_PLACE

### DIFF
--- a/mingw-w64-mumps/PKGBUILD
+++ b/mingw-w64-mumps/PKGBUILD
@@ -33,7 +33,7 @@ _realname=mumps
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.9.0
-pkgrel=4
+pkgrel=5
 pkgdesc="MUltifrontal Massively Parallel sparse direct solver (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -97,6 +97,14 @@ build() {
     export FC=flang
     export FFLAGS="-O2"
   fi
+  # MPI_IN_PLACE is unusable with MS-MPI and gfortran: mpif.h keeps the sentinel
+  # in COMMON /MPIPRIV1/ and imports the block with a !DEC$ directive, Intel
+  # syntax that gfortran treats as a comment. So gfortran uses its own
+  # zero-filled copy, the address matches nothing the C layer compares against,
+  # and MPI reads that memory as a real send buffer.
+  # Define AVOID_MPI_IN_PLACE to select alternative code paths that do not
+  # require a working implementation of MPI_IN_PLACE.
+  FFLAGS="$FFLAGS -DAVOID_MPI_IN_PLACE"
   declare -a _mods=(SEQ SHM)
   [[ ${CARCH} == aarch64 ]] || _mods+=(PAR)
   for mod in ${_mods[@]}; do


### PR DESCRIPTION
`MPI_IN_PLACE` is unusable with MS-MPI and `gfortran`: `mpif.h` keeps the sentinel in `COMMON /MPIPRIV1/` and imports the block with a `!DEC$` directive, Intel syntax that `gfortran` treats as a comment. So `gfortran` uses its own zero-filled copy, the address matches nothing the C layer compares against, and MPI reads that memory as a real send buffer.

Define `AVOID_MPI_IN_PLACE` to select alternative code paths that do not require a working implementation of `MPI_IN_PLACE`.

See also the explanation in this commit in downstream ElmerFEM: https://github.com/ElmerCSC/elmerfem/commit/0775538508584d43dc029787046d823f6c11ace1