### PR TITLE
msmpi: fix usage of MPI_IN_PLACE and other common block symbols with gfortran

### DIFF
--- a/mingw-w64-msmpi/PKGBUILD
+++ b/mingw-w64-msmpi/PKGBUILD
@@ -9,7 +9,7 @@ _realname=msmpi
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=10.1.1
-pkgrel=19
+pkgrel=20
 pkgdesc="Microsoft MPI SDK (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -40,7 +40,7 @@ source=(
 sha256sums=('17086fb1cf949251e4ae1549a06d292c58e468c822cca3ac1851e57e79d8ab20'
             'baee3f18f38650e7182956baa0d3d8f8e5c26d8603ccee4871a4dbd160c13660'
             '681be9e946eea309e419254e4032b8df3d53621e1d93b850cb0a75f8900cca57'
-            'defa8f2da4c79d0be4020d23f228462f589d3a0d4b792ea8bda26878a3c8e529'
+            '016c7cf061f2d1d9a766de5be7b5439de040e3e99ff0356c37f37b09de7310ae'
             'edd76b5096bd31052be13e2d3306d931277d9c983b147ecf8aef0761d4ae8fb3'
             '126bb8230844ad1de5f7e368c12008d2eea9831cb149b4a6952c775c08b294a2'
             'fd18184993872fc4eaea825e85f974dca4b020598d838c424c6c112c2328cf2a'
@@ -84,6 +84,13 @@ build() {
 
   # FORTRAN90 MPI modules
   bin/mpifort -c -Jinclude "${srcdir}"/mpi.F90
+
+  if [[ ${MSYSTEM} != CLANG64 ]]; then
+    # append object file with symbols to import library
+    ar rcs lib/libmsmpi.dll.a mpi.o
+  fi
+
+  # remove object file
   rm mpi.o
 }
 

--- a/mingw-w64-msmpi/mpi.F90
+++ b/mingw-w64-msmpi/mpi.F90
@@ -46,17 +46,73 @@
 !
 !
        MODULE MPI_CONSTANTS
+
+#ifdef __GNUC__
+       USE, INTRINSIC :: ISO_C_BINDING, ONLY: C_INT, C_CHAR
+#endif
+
        IMPLICIT NONE
 
        INTEGER MPI_SOURCE, MPI_TAG, MPI_ERROR
        PARAMETER (MPI_SOURCE=3,MPI_TAG=4,MPI_ERROR=5)
        INTEGER MPI_STATUS_SIZE
        PARAMETER (MPI_STATUS_SIZE=5)
+
+#ifdef __GNUC__
+       ! define structure layout of common blocks exported from DLL
+       TYPE, BIND(C) :: mpipriv1_layout
+       ! COMMON /MPIPRIV1/ MPI_BOTTOM, MPI_IN_PLACE, MPI_STATUS_IGNORE
+           INTEGER(C_INT) :: bottom
+           INTEGER(C_INT) :: in_place
+           INTEGER(C_INT) :: status_ignore(MPI_STATUS_SIZE)
+       END TYPE mpipriv1_layout
+
+       TYPE, BIND(C) :: mpipriv2_layout
+       ! COMMON /MPIPRIV2/ MPI_STATUSES_IGNORE, MPI_ERRCODES_IGNORE
+           INTEGER(C_INT) :: statuses_ignore(MPI_STATUS_SIZE,1)
+           INTEGER(C_INT) :: errcodes_ignore(1)
+       END TYPE mpipriv2_layout
+
+       TYPE, BIND(C) :: mpifcmb5_layout
+       ! COMMON /MPIFCMB5/ MPI_UNWEIGHTED
+           INTEGER(C_INT) :: unweighted
+       END TYPE mpifcmb5_layout
+
+       TYPE, BIND(C) :: mpifcmb9_layout
+       ! COMMON /MPIFCMB9/ MPI_WEIGHTS_EMPTY
+           INTEGER(C_INT) :: weights_empty
+       END TYPE mpifcmb9_layout
+
+       TYPE, BIND(C) :: mpiprivc_layout
+       ! COMMON /MPIPRIVC/ MPI_ARGVS_NULL, MPI_ARGV_NULL
+           CHARACTER(KIND=C_CHAR) :: argvs_null(1,1)
+           CHARACTER(KIND=C_CHAR) :: argv_null(1)
+       END TYPE mpiprivc_layout
+
+       ! bind global structure instance directly to members of common block exported from DLL
+       TYPE(mpipriv1_layout), BIND(C, NAME="mpipriv1"), TARGET :: mpipriv1_data
+       !GCC$ ATTRIBUTES DLLIMPORT :: mpipriv1_data
+       TYPE(mpipriv2_layout), BIND(C, NAME="mpipriv2"), TARGET :: mpipriv2_data
+       !GCC$ ATTRIBUTES DLLIMPORT :: mpipriv2_data
+       TYPE(mpifcmb5_layout), BIND(C, NAME="mpifcmb5"), TARGET :: mpifcmb5_data
+       !GCC$ ATTRIBUTES DLLIMPORT :: mpifcmb5_data
+       TYPE(mpifcmb9_layout), BIND(C, NAME="mpifcmb9"), TARGET :: mpifcmb9_data
+       !GCC$ ATTRIBUTES DLLIMPORT :: mpifcmb9_data
+       TYPE(mpiprivc_layout), BIND(C, NAME="mpiprivc"), TARGET :: mpiprivc_data
+       !GCC$ ATTRIBUTES DLLIMPORT :: mpiprivc_data
+
+       INTEGER, POINTER :: MPI_STATUS_IGNORE(:) => mpipriv1_data%status_ignore
+       INTEGER, POINTER :: MPI_STATUSES_IGNORE(:,:) => mpipriv2_data%statuses_ignore
+       INTEGER, POINTER :: MPI_ERRCODES_IGNORE(:) => mpipriv2_data%errcodes_ignore
+       CHARACTER*1, POINTER :: MPI_ARGVS_NULL(:,:) => mpiprivc_data%argvs_null
+       CHARACTER*1, POINTER :: MPI_ARGV_NULL(:) => mpiprivc_data%argv_null
+#else
        INTEGER MPI_STATUS_IGNORE(MPI_STATUS_SIZE)
        INTEGER MPI_STATUSES_IGNORE(MPI_STATUS_SIZE,1)
        INTEGER MPI_ERRCODES_IGNORE(1)
        CHARACTER*1 MPI_ARGVS_NULL(1,1)
        CHARACTER*1 MPI_ARGV_NULL(1)
+#endif
        INTEGER MPI_SUCCESS
        PARAMETER (MPI_SUCCESS=0)
        INTEGER MPI_ERR_OTHER
@@ -510,6 +566,12 @@
        PARAMETER (MPI_DISTRIBUTE_DFLT_DARG=-49767)
        INTEGER (KIND=8) MPI_DISPLACEMENT_CURRENT
        PARAMETER (MPI_DISPLACEMENT_CURRENT=-54278278)
+#ifdef __GNUC__
+       INTEGER, POINTER :: MPI_BOTTOM   => mpipriv1_data%bottom
+       INTEGER, POINTER :: MPI_IN_PLACE => mpipriv1_data%in_place
+       INTEGER, POINTER :: MPI_UNWEIGHTED   => mpifcmb5_data%unweighted
+       INTEGER, POINTER :: MPI_WEIGHTS_EMPTY => mpifcmb9_data%weights_empty
+#else
        INTEGER MPI_BOTTOM, MPI_IN_PLACE
        INTEGER MPI_UNWEIGHTED, MPI_WEIGHTS_EMPTY
 
@@ -524,6 +586,7 @@
 
        COMMON /MPIPRIVC/ MPI_ARGVS_NULL, MPI_ARGV_NULL
 !DEC$ ATTRIBUTES DLLIMPORT :: /MPIPRIVC/
+#endif
 
        END MODULE MPI_CONSTANTS
 


### PR DESCRIPTION
`gfortran` on Windows does not support the `DLLIMPORT` attribute on `COMMON` blocks, which prevents correct resolution of individual variables packed inside them. This causes sentinel buffer variables like `MPI_IN_PLACE`, `MPI_BOTTOM`, and `MPI_STATUS_IGNORE` to evaluate to 0 or garbage addresses at runtime.

Furthermore, `msmpi.dll` does not export these variables as separate data symbols (precluding standard variable-level `DLLIMPORT`), but instead exports the raw common blocks themselves (e.g., `mpipriv1`, `mpipriv2`).

Fix this for `gfortran` by
1. Re-mapping the exported MS-MPI common block symbols as statically bound `BIND(C)` target structures using `DLLIMPORT`.
2. Exposing the standard public MPI constants as Fortran POINTER arrays statically initialized to target the exact fields inside those structures. These symbols are exported from the import library to which all projects need to link anyway.

This should allow that downstream users of the Fortran 90 module (`use mpi`) use MPI_IN_PLACE and other common block symbols without needing to write platform-specific code.

It does not fix the issue for users of the Fortran 77 `mpif.h` header.

I haven't looked at how `flang` deals with this at all. To be on the save side, I made these changes only for `gfortran`.
