### PR TITLE
ansifilter: update to 2.23

### DIFF
--- a/mingw-w64-ansifilter/PKGBUILD
+++ b/mingw-w64-ansifilter/PKGBUILD
@@ -3,18 +3,18 @@
 _realname=ansifilter
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.22
+pkgver=2.23
 pkgrel=1
 pkgdesc="remove or convert ANSI codes to another format (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
 url="https://gitlab.com/saalen/ansifilter"
 msys2_repository_url='https://gitlab.com/saalen/ansifilter'
 license=('spdx:GPL-3.0-or-later')
 depends=("${MINGW_PACKAGE_PREFIX}-cc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc")
 source=("https://gitlab.com/saalen/ansifilter/-/archive/${pkgver}/${_realname}-${pkgver}.tar.bz2")
-sha256sums=('ccff41ca740b813bf9103868b5000f4243d32a75304ea929a214c49b943ecc93')
+sha256sums=('ff9efcfe8623593a54cd7bec2499711ec2a49a425ab50c61f2148c6d7450d525')
 
 build() {
   cd "${srcdir}/${_realname}-${pkgver}"


### PR DESCRIPTION
This commit also drops the mingw64 package, because that environment has been deprecated.