### PR TITLE
python-uharfbuzz: update to 0.56.0

### DIFF
--- a/mingw-w64-python-uharfbuzz/PKGBUILD
+++ b/mingw-w64-python-uharfbuzz/PKGBUILD
@@ -3,11 +3,11 @@
 _realname=uharfbuzz
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=0.55.0
+pkgver=0.56.0
 pkgrel=1
 pkgdesc="HarfBuzz Python binding (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
 url='https://uharfbuzz.readthedocs.io/'
 msys2_repository_url='https://github.com/harfbuzz/uharfbuzz'
 msys2_references=(
@@ -27,7 +27,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('a29bda4c147c35240a71051315423b1933b46eac558a72f55d9ffdc1f2bbb69f')
+sha256sums=('77f4ad1c9f32f44cc6f0c0c4f98fab54587719c96c810a043d01669f704d3e0c')
 
 prepare() {
   # Set version for setuptools_scm


### PR DESCRIPTION
This commit also drops the mingw64 package, because that environment has been deprecated.