### PR TITLE
mingw-w64-git: upgrade to Git for Windows 2.55.0.5

### DIFF
--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -17,7 +17,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
 	 "${MINGW_PACKAGE_PREFIX}-gitk"
 	 "${MINGW_PACKAGE_PREFIX}-${_realname}-gui"
 	 "${MINGW_PACKAGE_PREFIX}-${_realname}-for-windows-addons")
-tag=2.55.0.windows.4
+tag=2.55.0.windows.5
 pkgver=${tag/.windows./.}
 pkgrel=1
 pkgdesc="The fast distributed version control system (mingw-w64)"
@@ -62,7 +62,7 @@ source=("${_realname}"::"git+https://github.com/git-for-windows/git.git#tag=v$ta
 # resulting in different sha256sums.
 export GIT_CONFIG_PARAMETERS="${GIT_CONFIG_PARAMETERS:+$GIT_CONFIG_PARAMETERS }'core.autocrlf=false' 'core.eol=lf'"
 
-sha256sums=('4b46af6c404cdb8aedf0ee0e9b365c2e1e31cc1a4f08ae68f55527b7228dc6a8'
+sha256sums=('6925371671a574826d17cfb9a085b2cb7a4b7b099341498624c710edee1193f9'
             'a9dcba5aebc93ae7aacdee03275780fc6c0f15e88fda30c93041e75851e75090'
             '7e6c5f3dc6a4209dca0e1f38880b2978500a5c745c04bc60dbeda5fc48e8d3cb'
             '80b0b11efe5a2f9b4cd92f28c260d0b3aad8b809c34ed95237c59b73e08ade0b'


### PR DESCRIPTION
This PR synchronizes the `mingw-w64-git` package definition from [Git for Windows](https://github.com/git-for-windows/MINGW-packages/tree/main/mingw-w64-git).

See https://github.com/git-for-windows/git/releases/tag/v2.55.0.windows.5 for the release notes.

This branch was pushed by https://github.com/git-for-windows/git-for-windows-automation/actions/runs/32391386997