### PR TITLE
ollama: Update to 0.32.15 + fixes

### DIFF
--- a/mingw-w64-ollama/PKGBUILD
+++ b/mingw-w64-ollama/PKGBUILD
@@ -4,9 +4,9 @@ _realname=ollama
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgdesc='Create, run and share large language models (LLMs) (mingw-w64)'
-pkgver=0.32.14
+pkgver=0.32.15
 pkgrel=1
-_llama_ver=b10434 # from LLAMA_CPP_VERSION file
+_llama_ver=b10488 # from LLAMA_CPP_VERSION file
 arch=(any)
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://ollama.com'
@@ -36,8 +36,8 @@ source=(https://github.com/ollama/ollama/archive/v${pkgver}/${_realname}-${pkgve
         https://github.com/ggml-org/llama.cpp/archive/${_llama_ver}/llama.cpp-${_llama_ver}.tar.gz
         0001-do-not-install-runtime-dlls.patch
         0002-do-not-skip-llama-compat-patch.patch)
-sha256sums=('0d84e94d6cfe050084e8c0249983f163f68cbf43e504a47fb5ee51c922934300'
-            'c4fbc1eb7ddff021ccc84554fccd47d4c4034fba6e71d6e066e02e0c1b3f3d40'
+sha256sums=('5370f62c5dd875b58e37b312524af6af311119b5443e2907e20c2aa239fca52e'
+            'a006ca1a0268a3748686040d1ae021939d92ec0f58f341a30e52056298da4a0b'
             '8cff7aba9b45dfbef669c6e5c6c778cc9d40ff6b94a8cde060150f618f41feaf'
             '3dcdee56985715b611c3bb4c02012ead5f5a4806e461489fa00e4378eae4377e')
 
@@ -51,6 +51,13 @@ apply_patch_with_msg() {
 
 prepare() {
   cd ${_realname}-${pkgver}
+
+  local _llama_ver_file
+  _llama_ver_file=$(<LLAMA_CPP_VERSION)
+  if [[ ${_llama_ver_file} != "${_llama_ver}" ]]; then
+    error "llama.cpp version mismatch: LLAMA_CPP_VERSION specifies ${_llama_ver_file}, but PKGBUILD specifies ${_llama_ver}"
+    return 1
+  fi
 
   apply_patch_with_msg \
     0001-do-not-install-runtime-dlls.patch \
@@ -80,7 +87,6 @@ build() {
     CXXFLAGS+=" ${_flags}"
   fi
 
-  export OLLAMA_LLAMA_CPP_SOURCE="${srcdir}"/llama.cpp-${_llama_ver}
   export CGO_CFLAGS="$CFLAGS" CGO_CPPFLAGS="$CPPFLAGS" CGO_CXXFLAGS="$CXXFLAGS" CGO_LDFLAGS="$LDFLAGS"
   export GOPROXY=direct
   export GOROOT=${MINGW_PREFIX}/lib/go
@@ -93,7 +99,7 @@ build() {
     -DBUILD_SHARED_LIBS=ON \
     -DOLLAMA_VERSION=${pkgver} \
     -DOLLAMA_LLAMA_BACKENDS="vulkan" \
-    -DOLLAMA_LLAMA_CPP_SKIP_COMPAT_PATCH=OFF \
+    -DFETCHCONTENT_SOURCE_DIR_LLAMA_CPP="${srcdir}"/llama.cpp-${_llama_ver} \
     -DGGML_OPENMP=ON \
     -DGGML_BLAS=ON \
     -DGGML_BLAS_VENDOR=OpenBLAS \
@@ -106,9 +112,9 @@ build() {
 }
 
 check() {
-  $srcdir/build-$MSYSTEM/ollama --version >/dev/null
+  "${srcdir}/${_realname}-${pkgver}/ollama.exe" --version >/dev/null
 
-  cd "build-${MSYSTEM}"
+  cd "${srcdir}/${_realname}-${pkgver}"
   go test .
 }
 


### PR DESCRIPTION
fix ollama not using the llama.cpp compat shims in case CPP_SOURCES is set. Instead prepare llama.cpp for fetchcontent.

remove unused toplevel OLLAMA_LLAMA_CPP_SKIP_COMPAT_PATCH=OFF

add a check that the llama.cpp version matches the expected one

Fixes #31150