### PR TITLE
qt6-base: search for qmlimportscanner in LibraryExecutablesPath

### DIFF
--- a/mingw-w64-qt6-base/013-qt6-windeployqt-qmlimportscanner-path.patch
+++ b/mingw-w64-qt6-base/013-qt6-windeployqt-qmlimportscanner-path.patch
@@ -1,0 +1,20 @@
+--- a/src/tools/windeployqt/qmlutils.cpp
++++ b/src/tools/windeployqt/qmlutils.cpp
+@@ -7,6 +7,7 @@
+ #include <QtCore/QDir>
+ #include <QtCore/QFileInfo>
+ #include <QtCore/QCoreApplication>
++#include <QtCore/QLibraryInfo>
+ #include <QtCore/QJsonDocument>
+ #include <QtCore/QJsonObject>
+ #include <QtCore/QJsonArray>
+@@ -86,7 +87,8 @@ QmlImportScanResult runQmlImportScanner(const QString &directory, const QStringL
+     unsigned long exitCode;
+     QByteArray stdOut;
+     QByteArray stdErr;
+-    const QString binary = QStringLiteral("qmlimportscanner");
++    const QString binary = QDir(QLibraryInfo::path(QLibraryInfo::LibraryExecutablesPath))
++            .filePath(QStringLiteral("qmlimportscanner"));
+     if (!runProcess(binary, arguments, QDir::currentPath(), &exitCode, &stdOut, &stdErr,
+                     errorMessage, timeout))
+         return result;

--- a/mingw-w64-qt6-base/PKGBUILD
+++ b/mingw-w64-qt6-base/PKGBUILD
@@ -11,7 +11,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
 _qtver=6.11.2
 pkgver=${_qtver/-/}
-pkgrel=1
+pkgrel=2
 pkgdesc="A cross-platform application and UI framework (mingw-w64)"
 arch=(any)
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -59,7 +59,8 @@ source=("https://download.qt.io/official_releases/qt/${pkgver%.*}/${_qtver}/subm
         009-qfileinfo-undefine-mingw-stat.patch
         010-export-some-constexpr-variables.patch
         011-qt6-windeployqt-fixes.patch
-        012-qt6-windeployqt-ignore-debug.patch)
+        012-qt6-windeployqt-ignore-debug.patch
+        013-qt6-windeployqt-qmlimportscanner-path.patch)
 sha256sums=('5b2e00eccaf5a4d8c14134ffa0ea8dfd0a35ae1ffc7f8d87fa4305a1ed23cf22'
             '68156b8b7717a0ce19c4b991942469171bfa048cd5c90765115a546e65669a1d'
             'ed5b61bcb367bbda459bec903d796ea45604278f577a988d602ade07ec6bf363'
@@ -69,7 +70,8 @@ sha256sums=('5b2e00eccaf5a4d8c14134ffa0ea8dfd0a35ae1ffc7f8d87fa4305a1ed23cf22'
             'f4261d43a142a24e5fa3b23e25813754839db84078cc8c6dc611139bf531e64a'
             '2cd0b791209d53ce5a0ff2afc76cb1aedbdc1a92fe406c27bc6e5cd2f4ed0ad4'
             '9d9131f412f0505c38449718fcf2fcd4ae548563eb94b71d55c8238efffbbe5a'
-            'ce3449f8202766f1ceab9b44a0e94efdbb6b6a1c833381c93136a3786de1bea7')
+            'ce3449f8202766f1ceab9b44a0e94efdbb6b6a1c833381c93136a3786de1bea7'
+            'c4783da805c1189c747dc899fb4275a593b2e08522d3af88e74b3dec42d9b4fe')
 
 # Use the right mkspecs file
 if [[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]]; then
@@ -98,6 +100,10 @@ prepare() {
     008-freetype-fonts-fallback-dir.patch \
     009-qfileinfo-undefine-mingw-stat.patch \
     011-qt6-windeployqt-fixes.patch
+
+  # https://qt-project.atlassian.net//browse/QTBUG-141545
+  apply_patch_with_msg \
+    013-qt6-windeployqt-qmlimportscanner-path.patch
 
   # Debug DLL detection is unreliable for the binaries our toolchains produce
   # resulting in windeployqt refusing to deploy necessary DLLs. Just ignore

--- a/mingw-w64-qt6-base/PKGBUILD
+++ b/mingw-w64-qt6-base/PKGBUILD
@@ -155,6 +155,7 @@ build() {
     -DFEATURE_openssl=ON \
     -DFEATURE_opengl=ON \
     -DFEATURE_opengl_desktop=ON \
+    -DFEATURE_egl=OFF \
     -DFEATURE_dbus=ON \
     -DFEATURE_glib=ON \
     -DFEATURE_icu=ON \


### PR DESCRIPTION
That's where qt6-declarative installs it to -> INSTALL_LIBEXECDIR

macdeployqt/shared/shared.cpp does the same lookup already.

See https://github.com/msys2/MINGW-packages/pull/26127

https://github.com/qt/qtbase/blob/517da3e648fe1f5f6d456433d75a008cf5063aed/src/tools/macdeployqt/shared/shared.cpp#L1320-L1333