### PR TITLE
libarchive: backport fix for octave compat issue

### DIFF
--- a/mingw-w64-libarchive/PKGBUILD
+++ b/mingw-w64-libarchive/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libarchive
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.8.9
-pkgrel=3
+pkgrel=4
 pkgdesc="Multi-format archive and compression library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -38,15 +38,19 @@ makedepends=(
 provides=("${MINGW_PACKAGE_PREFIX}-unzip")
 source=("${msys2_repository_url}releases/download/v${pkgver}/${_realname}-${pkgver}.tar.xz"
         "001-fix-static-library-output-name-on-mingw.patch"
-        "https://patch-diff.githubusercontent.com/raw/libarchive/libarchive/pull/3401.patch")
+        "o-binary.patch::https://github.com/libarchive/libarchive/commit/9aa710d571dc30d7345683b2c705f33b675263a6.patch"
+        "z1-for-octave.patch::https://github.com/libarchive/libarchive/commit/9c9cb937ed6c5963d4ddd94dbc567d291ab71ab6.patch")
 sha256sums=('888c934f9d95648ecb9163dc8e23ab80a476ecb81a8f1154704a227b5b676dde'
             '4331c43882b4dad45f6036ee5e81671e0b54bdacbea48a64597282fd3d1bfb85'
-            'dbce3ee73a6b2231e134bebcf4ccdb0f582257da318a4c22f0204484e6a11c80')
+            'dbce3ee73a6b2231e134bebcf4ccdb0f582257da318a4c22f0204484e6a11c80'
+            '94d4ab4d6e7dad0b44e9074c3db0cc45bfc33a29862eee43a5f20b172f4040c0')
 
 prepare() {
   cd ${_realname}-${pkgver}
   patch -p1 -i "${srcdir}"/001-fix-static-library-output-name-on-mingw.patch
-  patch -p1 -i "${srcdir}"/3401.patch
+  # backport for unzip compat
+  patch -p1 -i "${srcdir}"/o-binary.patch
+  patch -p1 -i "${srcdir}"/z1-for-octave.patch
 }
 
 build() {


### PR DESCRIPTION
Needed for https://github.com/msys2/MINGW-packages/pull/31063