### PR TITLE
python-cx-freeze: update to 8.7.0

### DIFF
--- a/mingw-w64-python-cx-freeze/PKGBUILD
+++ b/mingw-w64-python-cx-freeze/PKGBUILD
@@ -2,11 +2,12 @@
 # Maintainer: Frode Solheim <frode@fs-uae.net>
 # Contributor: Duong Pham <dthpham@gmail.com>
 # Contributor: Lara Maia <dev@lara.click>
+# makepkg-mingw -sCLfi --noconfirm
 
 _realname=cx-freeze
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=8.6.4
+pkgver=8.7.0
 pkgrel=1
 pkgdesc="Creates standalone executables from Python scripts with the same performance as the original script (mingw-w64)"
 arch=('any')
@@ -45,33 +46,42 @@ source=(
   "https://pypi.org/packages/source/${_realname::1}/${_realname/-/_}/${_realname/-/_}-${pkgver}.tar.gz"
 )
 sha256sums=(
-  "16227706ad06b4b96f77c48980e2b363f0302c971f66c6b05567fd63a27596a4"
+  "3d6aed189f96fb6d13182bbc6f33f73d14526fc6fec934286d0456e31faf1543"
 )
 
 prepare() {
-  cd cx_freeze-${pkgver}
+  cd "cx_freeze-${pkgver}"
   # ignore version check for setuptools
   sed -i 's/"setuptools>=.*"/"setuptools"/' pyproject.toml
 
-  rm -Rf "${srcdir}"/python-${_realname}-${MSYSTEM}
-  cp -a "${srcdir}"/cx_freeze-${pkgver} "${srcdir}"/python-${_realname}-${MSYSTEM}
+  rm -Rf "${srcdir}/python-${_realname}-${MSYSTEM}"
+  cp -a "${srcdir}/cx_freeze-${pkgver}" "${srcdir}/python-${_realname}-${MSYSTEM}"
 }
 
 build() {
-  cd python-${_realname}-${MSYSTEM}
+  cd "python-${_realname}-${MSYSTEM}"
   python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 check() {
-  cd python-${_realname}-${MSYSTEM}
-  pip install cx_Freeze -f dist --no-deps --no-index
+  pacman -R "${MINGW_PACKAGE_PREFIX}-python-${_realname}" --noconfirm
+  cd "python-${_realname}-${MSYSTEM}"
+  pip install ${_realname} -f dist --no-deps --no-index --break-system-packages
+
+  mkdir -p "${srcdir}/${_realname}-test"
+  cp pyproject.toml "${srcdir}/${_realname}-test"
+  cp -a tests "${srcdir}/${_realname}-test"
+
+  cd "${srcdir}/${_realname}-test"
   coverage run
+  coverage combine
+  coverage report
+  pip uninstall ${_realname} -y --break-system-packages
 }
 
 package() {
-  cd python-${_realname}-${MSYSTEM}
+  cd "python-${_realname}-${MSYSTEM}"
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-    python -m installer --prefix=${MINGW_PREFIX} \
-    --destdir="${pkgdir}" dist/*.whl
+    python -m installer --prefix="${MINGW_PREFIX}" --destdir="${pkgdir}" dist/*.whl
   install -Dm644 LICENSE.md "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE.md"
 }

--- a/mingw-w64-python-freeze-core/PKGBUILD
+++ b/mingw-w64-python-freeze-core/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=freeze-core
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=0.7.1
+pkgver=0.7.2
 pkgrel=1
 pkgdesc="Core dependency for cx_Freeze (mingw-w64)"
 arch=('any')
@@ -42,11 +42,11 @@ options=(!strip)
 source=(
   "https://pypi.org/packages/source/${_realname::1}/${_realname/-/_}/${_realname/-/_}-${pkgver}.tar.gz"
 )
-sha256sums=('5b7a7aceb94b946d613d0ec4f348aa3c692b5834c458c83da517756da43fd74e')
+sha256sums=("b1dfa43f88e472ff153dc5bb88bb343d1fb875f5ddfb390fe13aca657e0e894a")
 
 prepare() {
   rm -Rf "${srcdir}/python-${_realname}-${MSYSTEM}"
-  cp -a "${srcdir}"/${_realname/-/_}-${pkgver} "${srcdir}/python-${_realname}-${MSYSTEM}"
+  cp -a "${srcdir}/${_realname/-/_}-${pkgver}" "${srcdir}/python-${_realname}-${MSYSTEM}"
 }
 
 build() {
@@ -65,7 +65,6 @@ check() {
 
   cd "${srcdir}/${_realname}-test"
   coverage run
-  coverage combine
   coverage report
   pip uninstall ${_realname} -y --break-system-packages
 }
@@ -73,6 +72,6 @@ check() {
 package() {
   cd "python-${_realname}-${MSYSTEM}"
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-    python -m installer --prefix=${MINGW_PREFIX} --destdir="${pkgdir}" dist/*.whl
+    python -m installer --prefix="${MINGW_PREFIX}" --destdir="${pkgdir}" dist/*.whl
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
 }

--- a/mingw-w64-python-msilib/PKGBUILD
+++ b/mingw-w64-python-msilib/PKGBUILD
@@ -5,7 +5,7 @@ _realname=python-msilib
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=0.7.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Read and write Microsoft Installer files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -35,25 +35,25 @@ build() {
 }
 
 check() {
-  cd "python-build-${MSYSTEM}"
-  pip install ${_realname} -f dist --no-deps --no-index
+  pacman -R "${MINGW_PACKAGE_PREFIX}-python-${_realname}" --noconfirm
+  cd "python-${_realname}-${MSYSTEM}"
+  pip install ${_realname} -f dist --no-deps --no-index --break-system-packages
 
   mkdir -p "${srcdir}/${_realname}-test"
-  cp pyproject.toml "${srcdir}/${_realname}-test/"
-  cp -a tests "${srcdir}/${_realname}-test/tests/"
+  cp pyproject.toml "${srcdir}/${_realname}-test"
+  cp -a tests "${srcdir}/${_realname}-test"
 
   cd "${srcdir}/${_realname}-test"
   coverage run
-  coverage combine
   coverage report
-  pip uninstall ${_realname} -y
+  pip uninstall ${_realname} -y --break-system-packages
 }
 
 package() {
   cd "python-build-${MSYSTEM}"
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-    python -m installer --prefix=${MINGW_PREFIX} --destdir="${pkgdir}" dist/*.whl
+    python -m installer --prefix="${MINGW_PREFIX}" --destdir="${pkgdir}" dist/*.whl
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
Also:
- update freeze-core dependency to 0.7.2
- fixes shell paths
- update check function to facilitate local testing (including attempting to address https://github.com/msys2/MINGW-packages/pull/30868#issuecomment-5200051589)
