### PR TITLE
msmpi: fix gfortran handling of MPI_IN_PLACE and other sentinel constants

### DIFF
--- a/mingw-w64-msmpi/PKGBUILD
+++ b/mingw-w64-msmpi/PKGBUILD
@@ -9,7 +9,7 @@ _realname=msmpi
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=10.1.1
-pkgrel=20
+pkgrel=21
 pkgdesc="Microsoft MPI SDK (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -40,7 +40,7 @@ source=(
 sha256sums=('17086fb1cf949251e4ae1549a06d292c58e468c822cca3ac1851e57e79d8ab20'
             'baee3f18f38650e7182956baa0d3d8f8e5c26d8603ccee4871a4dbd160c13660'
             '681be9e946eea309e419254e4032b8df3d53621e1d93b850cb0a75f8900cca57'
-            '016c7cf061f2d1d9a766de5be7b5439de040e3e99ff0356c37f37b09de7310ae'
+            '83042b1d8ae24da8f0efe3a446a627202da9a741cd8f8c273dbacc463fab7fd0'
             'edd76b5096bd31052be13e2d3306d931277d9c983b147ecf8aef0761d4ae8fb3'
             '126bb8230844ad1de5f7e368c12008d2eea9831cb149b4a6952c775c08b294a2'
             'fd18184993872fc4eaea825e85f974dca4b020598d838c424c6c112c2328cf2a'

--- a/mingw-w64-msmpi/mpi.F90
+++ b/mingw-w64-msmpi/mpi.F90
@@ -48,7 +48,7 @@
        MODULE MPI_CONSTANTS
 
 #ifdef __GNUC__
-       USE, INTRINSIC :: ISO_C_BINDING, ONLY: C_INT, C_CHAR
+       USE, INTRINSIC :: ISO_C_BINDING, ONLY: C_INT
 #endif
 
        IMPLICIT NONE
@@ -67,12 +67,6 @@
            INTEGER(C_INT) :: status_ignore(MPI_STATUS_SIZE)
        END TYPE mpipriv1_layout
 
-       TYPE, BIND(C) :: mpipriv2_layout
-       ! COMMON /MPIPRIV2/ MPI_STATUSES_IGNORE, MPI_ERRCODES_IGNORE
-           INTEGER(C_INT) :: statuses_ignore(MPI_STATUS_SIZE,1)
-           INTEGER(C_INT) :: errcodes_ignore(1)
-       END TYPE mpipriv2_layout
-
        TYPE, BIND(C) :: mpifcmb5_layout
        ! COMMON /MPIFCMB5/ MPI_UNWEIGHTED
            INTEGER(C_INT) :: unweighted
@@ -83,36 +77,21 @@
            INTEGER(C_INT) :: weights_empty
        END TYPE mpifcmb9_layout
 
-       TYPE, BIND(C) :: mpiprivc_layout
-       ! COMMON /MPIPRIVC/ MPI_ARGVS_NULL, MPI_ARGV_NULL
-           CHARACTER(KIND=C_CHAR) :: argvs_null(1,1)
-           CHARACTER(KIND=C_CHAR) :: argv_null(1)
-       END TYPE mpiprivc_layout
-
        ! bind global structure instance directly to members of common block exported from DLL
        TYPE(mpipriv1_layout), BIND(C, NAME="mpipriv1"), TARGET :: mpipriv1_data
        !GCC$ ATTRIBUTES DLLIMPORT :: mpipriv1_data
-       TYPE(mpipriv2_layout), BIND(C, NAME="mpipriv2"), TARGET :: mpipriv2_data
-       !GCC$ ATTRIBUTES DLLIMPORT :: mpipriv2_data
        TYPE(mpifcmb5_layout), BIND(C, NAME="mpifcmb5"), TARGET :: mpifcmb5_data
        !GCC$ ATTRIBUTES DLLIMPORT :: mpifcmb5_data
        TYPE(mpifcmb9_layout), BIND(C, NAME="mpifcmb9"), TARGET :: mpifcmb9_data
        !GCC$ ATTRIBUTES DLLIMPORT :: mpifcmb9_data
-       TYPE(mpiprivc_layout), BIND(C, NAME="mpiprivc"), TARGET :: mpiprivc_data
-       !GCC$ ATTRIBUTES DLLIMPORT :: mpiprivc_data
+#endif
 
-       INTEGER, POINTER :: MPI_STATUS_IGNORE(:) => mpipriv1_data%status_ignore
-       INTEGER, POINTER :: MPI_STATUSES_IGNORE(:,:) => mpipriv2_data%statuses_ignore
-       INTEGER, POINTER :: MPI_ERRCODES_IGNORE(:) => mpipriv2_data%errcodes_ignore
-       CHARACTER*1, POINTER :: MPI_ARGVS_NULL(:,:) => mpiprivc_data%argvs_null
-       CHARACTER*1, POINTER :: MPI_ARGV_NULL(:) => mpiprivc_data%argv_null
-#else
        INTEGER MPI_STATUS_IGNORE(MPI_STATUS_SIZE)
        INTEGER MPI_STATUSES_IGNORE(MPI_STATUS_SIZE,1)
        INTEGER MPI_ERRCODES_IGNORE(1)
        CHARACTER*1 MPI_ARGVS_NULL(1,1)
        CHARACTER*1 MPI_ARGV_NULL(1)
-#endif
+
        INTEGER MPI_SUCCESS
        PARAMETER (MPI_SUCCESS=0)
        INTEGER MPI_ERR_OTHER


### PR DESCRIPTION
#31136 broke using `MPI_STATUSES_IGNORE` (and other array constants) with errors like the following:
```
Fatal error in MPI_Waitall: Invalid argument, error stack:
MPI_Waitall(count=1, req_array=0x0000020AA5697E40, status_array=0x0000000000000000) failed
Null pointer in parameter array_of_statuses
```

MS-MPI exports several Fortran COMMON blocks (MPIPRIV1, MPIFCMB5, MPIFCMB9, ...) from msmpi.dll. But these symbols are Intel-Fortran linker stubs rather than real storage. I originally assumed they contained usable data structures and bound gfortran POINTERs to their members. This worked accidentally for scalar sentinels (MPI_BOTTOM, MPI_IN_PLACE, MPI_UNWEIGHTED, MPI_WEIGHTS_EMPTY), but all array-valued members resolved to NULL pointers at runtime, causing failures such as "Null pointer in parameter array_of_statuses" in `MPI_Waitall`.

This change removes all array-valued POINTER bindings and restores local Fortran storage for MPI_STATUS_IGNORE, MPI_STATUSES_IGNORE, MPI_ERRCODES_IGNORE, MPI_ARGV_NULL, and MPI_ARGVS_NULL. These constants act as sentinel arguments and do not require DLL-backed storage.

Scalar sentinels remain bound to the COMMON block symbols, since MS-MPI's Fortran wrapper relies on their specific addresses to implement special semantics (e.g., MPI_IN_PLACE). This preserves correct behavior for gfortran while avoiding the NULL-pointer issues caused by the array members.

(I took some help from an LLM for the commit message.)