### PR TITLE
Add `mingw-w64-sdl2-compat`.

### DIFF
--- a/mingw-w64-sdl2-compat/0001-just-build-normal.patch
+++ b/mingw-w64-sdl2-compat/0001-just-build-normal.patch
@@ -1,0 +1,24 @@
+diff -ura sdl2-compat-2.32.70/CMakeLists.txt sdl2-compat-2.32.70.new/CMakeLists.txt
+--- sdl2-compat-2.32.70/CMakeLists.txt	2026-06-08 16:01:06 +0100
++++ sdl2-compat-2.32.70.new/CMakeLists.txt	2026-08-23 10:21:26 +0100
+@@ -381,7 +381,7 @@
+   )
+ endif()
+ 
+-if(MINGW)
++if(0)
+   set_property(TARGET SDL2 APPEND_STRING PROPERTY LINK_FLAGS " -nostdlib")
+   if(USE_CLANG)
+     if(SDL_CPU_X86)
+diff -ura sdl2-compat-2.32.70/src/sdl2_compat.c sdl2-compat-2.32.70.new/src/sdl2_compat.c
+--- sdl2-compat-2.32.70/src/sdl2_compat.c	2026-06-08 16:01:06 +0100
++++ sdl2-compat-2.32.70.new/src/sdl2_compat.c	2026-08-23 10:31:54 +0100
+@@ -1197,7 +1197,7 @@
+ __declspec(selectany) int _fltused = 1;
+ #endif
+ #if defined(__MINGW32__)
+-#define _DllMainCRTStartup DllMainCRTStartup
++#define _DllMainCRTStartup DllMain
+ #endif
+ #if defined(__WATCOMC__)
+ #define _DllMainCRTStartup LibMain

--- a/mingw-w64-sdl2-compat/0002-sdl-config-win-paths.patch
+++ b/mingw-w64-sdl2-compat/0002-sdl-config-win-paths.patch
@@ -1,0 +1,11 @@
+--- sdl2-compat-2.32.70/sdl2-config.in.orig	2023-06-20 22:16:09.769575500 +0200
++++ sdl2-compat-2.32.70/sdl2-config.in	2023-06-20 22:16:23.995182600 +0200
+@@ -7,7 +7,7 @@
+ 
+ # Copied and modified from SDL2's sdl2-compat.
+ 
+-prefix=@CMAKE_INSTALL_PREFIX@
++prefix="$(cygpath -m "@CMAKE_INSTALL_PREFIX@")"
+ exec_prefix=${prefix}
+ exec_prefix_set=no
+ libdir=@CMAKE_INSTALL_FULL_LIBDIR@

--- a/mingw-w64-sdl2-compat/PKGBUILD
+++ b/mingw-w64-sdl2-compat/PKGBUILD
@@ -1,0 +1,74 @@
+# Maintainer: Fred Arnold <clownacy@yahoo.com>
+
+_realname=sdl2-compat
+pkgbase="mingw-w64-${_realname}"
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=2.32.70
+pkgrel=1
+pkgdesc="An SDL2 compatibility layer that uses SDL3 behind the scenes (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url="https://github.com/libsdl-org/sdl2-compat"
+msys2_repository_url='https://github.com/libsdl-org/sdl2-compat'
+msys2_references=(
+  "gentoo: media-libs/libsdl"
+)
+license=('spdx:Zlib')
+conflicts=("${MINGW_PACKAGE_PREFIX}-SDL2")
+provides=("${MINGW_PACKAGE_PREFIX}-SDL2")
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-sdl3"
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+  "${MINGW_PACKAGE_PREFIX}-ninja"
+  "${MINGW_PACKAGE_PREFIX}-cc")
+source=("https://github.com/libsdl-org/${_realname}/releases/download/release-${pkgver}/${_realname}-${pkgver}.tar.gz"
+        "0001-just-build-normal.patch"
+        "0002-sdl-config-win-paths.patch")
+sha256sums=('998fa62557eb46ffe7e5c3e2c123bc332f7df9d9f593b3ceed88ed1158428a44'
+            '484cc733b3f1b8ecec23d4a60eebd20c4e645a4e085e6e26ec8142b47b68fc12'
+            '0b761282e9f96a1a967b735374ec60c875aa7aefb5b99d100430c323e0b06d5c')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+
+  patch -Np1 -i "${srcdir}/0001-just-build-normal.patch"
+  patch -Np1 -i "${srcdir}/0002-sdl-config-win-paths.patch"
+}
+
+build() {
+  cd "${_realname}-${pkgver}"
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
+
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    "${MINGW_PREFIX}"/bin/cmake.exe \
+      -GNinja \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+      "${extra_config[@]}" \
+      -DBUILD_SHARED_LIBS=ON \
+      "../${_realname}-${pkgver}"
+
+  "${MINGW_PREFIX}"/bin/cmake.exe --build .
+}
+
+check() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  "${MINGW_PREFIX}"/bin/ctest.exe . || warning "Tests failed"
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+
+  DESTDIR="${pkgdir}" "${MINGW_PREFIX}"/bin/cmake.exe --install .
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.txt"
+}


### PR DESCRIPTION
Modelled after the `mingw-w64-sdl12-compat` package, for consistency.

Closes #26595.