### PR TITLE
mingw-w64-vlc: backport vlc_poll.h separation from master

### DIFF
--- a/mingw-w64-vlc/0029-vlc_threads-move-poll-definitions-in-a-separate-header.patch
+++ b/mingw-w64-vlc/0029-vlc_threads-move-poll-definitions-in-a-separate-header.patch
@@ -1,0 +1,292 @@
+From 3f613a85f58edc1e37d56a1fe7769c9e14981258 Mon Sep 17 00:00:00 2001
+From: Steve Lhomme <robux4@videolan.org>
+Date: Thu, 11 Jul 2024 10:00:00 +0200
+Subject: [PATCH] vlc_threads: move poll() definitions in a separate header
+
+It's using a compat version on Windows/Android/OS2 which is not available
+to external modules.
+
+This new header can't be used directly from external modules on Windows.
+This makes vlc_threads.h usable from external modules on Windows.
+
+Backported from VLC master branch commit 3f613a85f58edc1e37d56a1fe7769c9e14981258
+Adapted for VLC 3.0.23.
+
+--- /dev/null	2026-08-24 20:18:02.000000000 +0800
++++ vlc-new/include/vlc_poll.h	2026-08-24 20:17:39.639327900 +0800
+@@ -0,0 +1,100 @@
++/*****************************************************************************
++ * vlc_poll.h : poll implementation for the VideoLAN client
++ *****************************************************************************
++ * Copyright (C) 1999, 2002 VLC authors and VideoLAN
++ * Copyright © 2007-2016 Rémi Denis-Courmont
++ *
++ * Authors: Jean-Marc Dressler <polux@via.ecp.fr>
++ *          Samuel Hocevar <sam@via.ecp.fr>
++ *          Gildas Bazin <gbazin@netcourrier.com>
++ *          Christophe Massiot <massiot@via.ecp.fr>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_POLL_H_
++#define VLC_POLL_H_
++
++#include <vlc_threads.h>
++
++/**
++ * \ingroup os
++ * \defgroup thread_poll Poll implementations
++ * @{
++ * \file
++ * Poll implementations
++ */
++
++#if defined (_WIN32)
++static inline int vlc_poll(struct pollfd *fds, unsigned nfds, int timeout)
++{
++    int val;
++
++    vlc_testcancel();
++    val = poll(fds, nfds, timeout);
++    if (val < 0)
++        vlc_testcancel();
++    return val;
++}
++# define poll(u,n,t) vlc_poll(u, n, t)
++
++#elif defined (__OS2__)
++static inline int vlc_poll (struct pollfd *fds, unsigned nfds, int timeout)
++{
++    static int (*vlc_poll_os2)(struct pollfd *, unsigned, int) = NULL;
++
++    if (!vlc_poll_os2)
++    {
++        HMODULE hmod;
++        CHAR szFailed[CCHMAXPATH];
++
++        if (DosLoadModule(szFailed, sizeof(szFailed), "vlccore", &hmod))
++            return -1;
++
++        if (DosQueryProcAddr(hmod, 0, "_vlc_poll_os2", (PFN *)&vlc_poll_os2))
++            return -1;
++    }
++
++    return (*vlc_poll_os2)(fds, nfds, timeout);
++}
++# define poll(u,n,t) vlc_poll(u, n, t)
++
++#elif defined (__ANDROID__)
++static inline int vlc_poll (struct pollfd *fds, unsigned nfds, int timeout)
++{
++    int val;
++
++    do
++    {
++        int ugly_timeout = ((unsigned)timeout >= 50) ? 50 : timeout;
++        if (timeout >= 0)
++            timeout -= ugly_timeout;
++
++        vlc_testcancel ();
++        val = poll (fds, nfds, ugly_timeout);
++    }
++    while (val == 0 && timeout != 0);
++
++    return val;
++}
++# define poll(u,n,t) vlc_poll(u, n, t)
++
++#else /* POSIX threads */
++
++#endif
++
++/** @} */
++
++#endif /* !VLC_POLL_H_ */
+--- a/include/vlc_threads.h	2025-12-23 18:49:20.000000000 +0800
++++ b/include/vlc_threads.h	2026-08-24 20:16:17.729888200 +0800
+@@ -82,18 +82,6 @@
+ # define VLC_THREAD_PRIORITY_OUTPUT   THREAD_PRIORITY_ABOVE_NORMAL
+ # define VLC_THREAD_PRIORITY_HIGHEST  THREAD_PRIORITY_TIME_CRITICAL
+ 
+-static inline int vlc_poll(struct pollfd *fds, unsigned nfds, int timeout)
+-{
+-    int val;
+-
+-    vlc_testcancel();
+-    val = poll(fds, nfds, timeout);
+-    if (val < 0)
+-        vlc_testcancel();
+-    return val;
+-}
+-# define poll(u,n,t) vlc_poll(u, n, t)
+-
+ #elif defined (__OS2__)
+ # include <errno.h>
+ 
+@@ -137,26 +125,6 @@
+ 
+ # define pthread_sigmask  sigprocmask
+ 
+-static inline int vlc_poll (struct pollfd *fds, unsigned nfds, int timeout)
+-{
+-    static int (*vlc_poll_os2)(struct pollfd *, unsigned, int) = NULL;
+-
+-    if (!vlc_poll_os2)
+-    {
+-        HMODULE hmod;
+-        CHAR szFailed[CCHMAXPATH];
+-
+-        if (DosLoadModule(szFailed, sizeof(szFailed), "vlccore", &hmod))
+-            return -1;
+-
+-        if (DosQueryProcAddr(hmod, 0, "_vlc_poll_os2", (PFN *)&vlc_poll_os2))
+-            return -1;
+-    }
+-
+-    return (*vlc_poll_os2)(fds, nfds, timeout);
+-}
+-# define poll(u,n,t) vlc_poll(u, n, t)
+-
+ #elif defined (__ANDROID__)      /* pthreads subset without pthread_cancel() */
+ # include <unistd.h>
+ # include <pthread.h>
+@@ -182,26 +150,6 @@
+ # define VLC_THREAD_PRIORITY_OUTPUT   0
+ # define VLC_THREAD_PRIORITY_HIGHEST  0
+ 
+-static inline int vlc_poll (struct pollfd *fds, unsigned nfds, int timeout)
+-{
+-    int val;
+-
+-    do
+-    {
+-        int ugly_timeout = ((unsigned)timeout >= 50) ? 50 : timeout;
+-        if (timeout >= 0)
+-            timeout -= ugly_timeout;
+-
+-        vlc_testcancel ();
+-        val = poll (fds, nfds, ugly_timeout);
+-    }
+-    while (val == 0 && timeout != 0);
+-
+-    return val;
+-}
+-
+-# define poll(u,n,t) vlc_poll(u, n, t)
+-
+ #elif defined (__APPLE__)
+ # define _APPLE_C_SOURCE    1 /* Proper pthread semantics on OSX */
+ # include <unistd.h>
+--- a/modules/access/dtv/en50221.c	2025-12-23 18:49:20.000000000 +0800
++++ b/modules/access/dtv/en50221.c	2026-08-24 20:16:27.122833200 +0800
+@@ -27,6 +27,7 @@
+ #endif
+ 
+ #include <vlc_common.h>
++#include <vlc_poll.h>
+ #include <vlc_charset.h>
+ #include <vlc_fs.h>
+ 
+--- a/modules/access/dv.c	2025-12-23 18:49:20.000000000 +0800
++++ b/modules/access/dv.c	2026-08-24 20:16:27.172223500 +0800
+@@ -31,6 +31,7 @@
+ #include <assert.h>
+ 
+ #include <vlc_common.h>
++#include <vlc_poll.h>
+ #include <vlc_plugin.h>
+ #include <vlc_access.h>
+ 
+--- a/modules/access/http/h2conn.c	2025-12-23 18:49:20.000000000 +0800
++++ b/modules/access/http/h2conn.c	2026-08-24 20:16:27.215519700 +0800
+@@ -33,6 +33,7 @@
+ # include <sys/uio.h>
+ #endif
+ #include <vlc_common.h>
++#include <vlc_poll.h>
+ #include <vlc_block.h>
+ #include <vlc_interrupt.h>
+ #include <vlc_tls.h>
+--- a/modules/access/http/h2output.c	2025-12-23 18:49:20.000000000 +0800
++++ b/modules/access/http/h2output.c	2026-08-24 20:16:27.265620800 +0800
+@@ -32,6 +32,7 @@
+ # include <sys/uio.h>
+ #endif
+ #include <vlc_common.h>
++#include <vlc_poll.h>
+ #include <vlc_tls.h>
+ #include "h2frame.h"
+ #include "h2output.h"
+--- a/modules/access/linsys/linsys_hdsdi.c	2025-12-23 18:49:20.000000000 +0800
++++ b/modules/access/linsys/linsys_hdsdi.c	2026-08-24 20:16:27.401782900 +0800
+@@ -42,6 +42,7 @@
+ #include <vlc_input.h>
+ #include <vlc_access.h>
+ #include <vlc_demux.h>
++#include <vlc_poll.h>
+ 
+ #include <vlc_fs.h>
+ 
+--- a/modules/access/linsys/linsys_sdi.c	2025-12-23 18:49:20.000000000 +0800
++++ b/modules/access/linsys/linsys_sdi.c	2026-08-24 20:16:27.470160200 +0800
+@@ -41,6 +41,7 @@
+ #include <vlc_input.h>
+ #include <vlc_access.h>
+ #include <vlc_demux.h>
++#include <vlc_poll.h>
+ 
+ #include <vlc_fs.h>
+ 
+--- a/modules/access/oss.c	2025-12-23 18:49:20.000000000 +0800
++++ b/modules/access/oss.c	2026-08-24 20:16:27.511978700 +0800
+@@ -37,6 +37,7 @@
+ #include <vlc_access.h>
+ #include <vlc_demux.h>
+ #include <vlc_fs.h>
++#include <vlc_poll.h>
+ 
+ #include <errno.h>
+ #include <fcntl.h>
+--- a/modules/access/rdp.c	2025-12-23 18:49:20.000000000 +0800
++++ b/modules/access/rdp.c	2026-08-24 20:16:27.351580700 +0800
+@@ -27,6 +27,7 @@
+ #endif
+ 
+ #include <vlc_common.h>
++#include <vlc_poll.h>
+ #include <vlc_plugin.h>
+ #include <vlc_demux.h>
+ #include <vlc_url.h>
+--- a/src/Makefile.am	2025-12-23 18:49:21.000000000 +0800
++++ b/src/Makefile.am	2026-08-24 20:16:41.531300500 +0800
+@@ -92,6 +92,7 @@
+ 	../include/vlc_subpicture.h \
+ 	../include/vlc_text_style.h \
+ 	../include/vlc_threads.h \
++	../include/vlc_poll.h \
+ 	../include/vlc_timestamp_helper.h \
+ 	../include/vlc_tls.h \
+ 	../include/vlc_url.h \
+--- a/src/misc/interrupt.c	2025-12-23 18:49:21.000000000 +0800
++++ b/src/misc/interrupt.c	2026-08-24 20:16:27.567777500 +0800
+@@ -37,6 +37,7 @@
+ #endif
+ 
+ #include <vlc_common.h>
++#include <vlc_poll.h>
+ #include <vlc_fs.h> /* vlc_pipe */
+ #include <vlc_network.h> /* vlc_accept */
+ 

--- a/mingw-w64-vlc/PKGBUILD
+++ b/mingw-w64-vlc/PKGBUILD
@@ -6,7 +6,7 @@ _realname=vlc
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.0.23
-pkgrel=12
+pkgrel=13
 pkgdesc="A multi-platform MPEG, VCD/DVD, and DivX player (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -114,6 +114,7 @@ source=(https://get.videolan.org/${_realname}/${pkgver}/${_realname}-${pkgver}.t
         0026-fix-libsynchronization-check.patch
         0027-lua5.5-support.patch
         0028-link-network-plugins-with-socket-libs.patch
+        0029-vlc_threads-move-poll-definitions-in-a-separate-header.patch
         )
 sha256sums=('e891cae6aa3ccda69bf94173d5105cbc55c7a7d9b1d21b9b21666e69eff3e7e0'
             '130cdf7655deca92fd28dd177cd99aab24113bd1052700896046b66acbcb1f2d'
@@ -128,7 +129,8 @@ sha256sums=('e891cae6aa3ccda69bf94173d5105cbc55c7a7d9b1d21b9b21666e69eff3e7e0'
             '2b0f45a93c804e8e6e59a56d0ed82d2bc703a3b7ef166aa98ad311d9b15d4f08'
             '54ddd07473da265ebaff7d928a23bcc639354513d5e0677afe21b6496f934625'
             '75a2cc1a458aa27fe21e880ccd3844b66f90e52b2227fb99a401f8010525cc17'
-            '637ab633e5af502f71698d0833e568e739040d63264a15a423a1784a9fb4d36c')
+            '637ab633e5af502f71698d0833e568e739040d63264a15a423a1784a9fb4d36c'
+            '204678aa6e361dc56442be9e19623e8c2450990d9a8dd5d4dea5ce6b82357834')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -154,7 +156,8 @@ prepare() {
     0025-iovec-redefined.patch \
     0026-fix-libsynchronization-check.patch \
     0027-lua5.5-support.patch \
-    0028-link-network-plugins-with-socket-libs.patch
+    0028-link-network-plugins-with-socket-libs.patch \
+    0029-vlc_threads-move-poll-definitions-in-a-separate-header.patch
 
   ./bootstrap
 }


### PR DESCRIPTION
Backport VLC master commit 3f613a85f58edc1e37d56a1fe7769c9e14981258 'vlc_threads: move poll() definitions in a separate header'  https://code.videolan.org/videolan/vlc/-/commit/3f613a85f58edc1e37d56a1fe7769c9e14981258

This moves the vlc_poll() compat implementations (Windows, OS/2, Android) from vlc_threads.h into a new vlc_poll.h header. The original commit message explains:

  It's using a compat version on Windows/Android/OS2 which is not
  available to external modules. This new header can't be used directly
  from external modules on Windows. This makes vlc_threads.h usable
  from external modules on Windows.

Adapted for VLC 3.0.23.


fix #31198 