### PR TITLE
ccache: update to 4.14

### DIFF
--- a/mingw-w64-ccache/0002-use-sed-instead-of-perl.patch
+++ b/mingw-w64-ccache/0002-use-sed-instead-of-perl.patch
@@ -1,0 +1,8 @@
+--- ccache-4.14/doc/scripts/generate-manpage.orig	2026-08-23 16:35:18.000000000 +0800
++++ ccache-4.14/doc/scripts/generate-manpage	2026-08-25 12:38:29.667212600 +0800
+@@ -24,4 +24,4 @@
+ 
+ # Convert monospace to bold since that's typically rendered better when viewing
+ # the man page.
+-perl -pe "'s!\\\\f\\(CR(.*?)\\\\fP!\\\\fB\\1\\\\fP!g'" "${tmpfile}" >"${output}"
++sed 's/\\f(CR/\\fB/g' "${tmpfile}" >"${output}"

--- a/mingw-w64-ccache/PKGBUILD
+++ b/mingw-w64-ccache/PKGBUILD
@@ -34,16 +34,18 @@ makedepends=(
   $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-asciidoctor")
 )
 source=("https://github.com/ccache/ccache/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.xz"{,.minisig}
-        "0001-generate-docs-bash.patch")
+        "0001-generate-docs-bash.patch"
+        "0002-use-sed-instead-of-perl.patch")
 sha256sums=('b093ac5d38204cb4d9f29b0bbd570675aa5a592a78e6675b2c506dbe045234e7'
             '9f870c123b8f4a52b34b28b68f9dda333d3bcf096150554ca235763a566955f4'
-            '55e60c7413774387f0b2b36f654fa5ad736e828c95372d85a65d15c8a784fb12')
+            '55e60c7413774387f0b2b36f654fa5ad736e828c95372d85a65d15c8a784fb12'
+            '037731448ddbe50b6d128a0a1f999b1f9f23c5e506b5d27013cf2675935c7424')
 validpgpkeys=('5A939A71A46792CF57866A51996DDA075594ADB8') # Joel Rosdahl <joel@rosdahl.net>
 
 prepare() {
   cd "${_realname}-${pkgver}"
   patch -p1 -i "${srcdir}/0001-generate-docs-bash.patch"
-
+  patch -p1 -i "${srcdir}/0002-use-sed-instead-of-perl.patch"
 }
 build() {
   declare -a extra_config

--- a/mingw-w64-ccache/PKGBUILD
+++ b/mingw-w64-ccache/PKGBUILD
@@ -4,8 +4,8 @@
 _realname=ccache
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.13.6
-pkgrel=2
+pkgver=4.14
+pkgrel=1
 pkgdesc="Compiler cache that speeds up recompilation by caching previous compilations (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'mingw32' 'ucrt64' 'clang64' 'clangarm64')
@@ -18,23 +18,25 @@ msys2_references=(
   'gentoo: dev-util/ccache'
 )
 license=("spdx:GPL-3.0-or-later")
-replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
-makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-ninja"
-             $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-asciidoctor")
-             "${MINGW_PACKAGE_PREFIX}-pkgconf")
-depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
-         "${MINGW_PACKAGE_PREFIX}-fmt"
-         "${MINGW_PACKAGE_PREFIX}-xxhash"
-         "${MINGW_PACKAGE_PREFIX}-zstd"
-         $([[ ${CARCH} == i686 ]] || echo \
-           "${MINGW_PACKAGE_PREFIX}-hiredis" \
-           "${MINGW_PACKAGE_PREFIX}-libblake3"))
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-cc-libs"
+  "${MINGW_PACKAGE_PREFIX}-fmt"
+  "${MINGW_PACKAGE_PREFIX}-xxhash"
+  "${MINGW_PACKAGE_PREFIX}-zstd"
+  $([[ ${CARCH} == i686 ]] || echo \
+    "${MINGW_PACKAGE_PREFIX}-hiredis" \
+    "${MINGW_PACKAGE_PREFIX}-libblake3")
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+  "${MINGW_PACKAGE_PREFIX}-ninja"
+  $([[ ${CARCH} == i686 ]] || echo "${MINGW_PACKAGE_PREFIX}-asciidoctor")
+)
 source=("https://github.com/ccache/ccache/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.xz"{,.minisig}
         "0001-generate-docs-bash.patch")
-sha256sums=('a7de667ca08cf67c3c8af9f213f6aa701a1188a2b3163fb74483858ce5e79fbb'
-            'a45a1b58566df6c648dc0b4473ed12d8fc077137e46e4ccea96c64f784b091fc'
+sha256sums=('b093ac5d38204cb4d9f29b0bbd570675aa5a592a78e6675b2c506dbe045234e7'
+            '9f870c123b8f4a52b34b28b68f9dda333d3bcf096150554ca235763a566955f4'
             '55e60c7413774387f0b2b36f654fa5ad736e828c95372d85a65d15c8a784fb12')
 validpgpkeys=('5A939A71A46792CF57866A51996DDA075594ADB8') # Joel Rosdahl <joel@rosdahl.net>
 
@@ -44,8 +46,6 @@ prepare() {
 
 }
 build() {
-  mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
-
   declare -a extra_config
   if check_option "debug" "n"; then
     extra_config+=("-DCMAKE_BUILD_TYPE=Release")
@@ -53,20 +53,20 @@ build() {
     extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
   fi
 
-  if [[ ${CARCH} == x86_64 ]]; then
-    extra_config+=("-DENABLE_DOCUMENTATION=ON")
-  else
-    extra_config+=("-DENABLE_DOCUMENTATION=OFF")
-  fi
-
   if [[ ${CARCH} == i686 ]]; then
-    extra_config+=("-DREDIS_STORAGE_BACKEND=OFF")
+    extra_config+=(
+      "-DENABLE_DOCUMENTATION=OFF"
+      "-DREDIS_STORAGE_BACKEND=OFF"
+    )
   else
-    extra_config+=("-DREDIS_STORAGE_BACKEND=ON")
+    extra_config+=(
+      "-DENABLE_DOCUMENTATION=ON"
+      "-DREDIS_STORAGE_BACKEND=ON"
+    )
   fi
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-    ${MINGW_PREFIX}/bin/cmake \
+    cmake \
       -GNinja \
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
       "${extra_config[@]}" \
@@ -75,23 +75,21 @@ build() {
       -DENABLE_TESTING=OFF \
       -DCCACHE_DEV_MODE=OFF \
       -DWARNINGS_AS_ERRORS=OFF \
-      ../${_realname}-${pkgver}
+      -S ${_realname}-${pkgver} \
+      -B build-${MSYSTEM}
 
-  ${MINGW_PREFIX}/bin/cmake --build .
+  cmake --build build-${MSYSTEM}
 }
 
 check() {
   # run unittest to verify that the program is not broken
-  cd "${srcdir}"/build-${MSYSTEM}
-  ${MINGW_PREFIX}/bin/cmake -DENABLE_TESTING=ON ../${_realname}-${pkgver}
-  ${MINGW_PREFIX}/bin/cmake --build .
-  ${MINGW_PREFIX}/bin/ctest -R unittest
+  cmake -DENABLE_TESTING=ON -S ${_realname}-${pkgver} -B build-${MSYSTEM}
+  cmake --build build-${MSYSTEM}
+  ctest -R unittest --test-dir build-${MSYSTEM} --output-on-failure
 }
 
 package() {
-  cd "${srcdir}/build-${MSYSTEM}"
-
-  DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake --install .
+  DESTDIR="${pkgdir}" cmake --install build-${MSYSTEM}
 
   # hack: use bash scripts as shortcuts since we cannot use symlinks
   install -d "${pkgdir}"${MINGW_PREFIX}/lib/ccache/bin


### PR DESCRIPTION
drop `replaces`, since 11 years have passed.