### PR TITLE
uutils-coreutils: handle OPENSSL_DIR by pkgconf

### DIFF
--- a/mingw-w64-uutils-coreutils/PKGBUILD
+++ b/mingw-w64-uutils-coreutils/PKGBUILD
@@ -41,7 +41,6 @@ package() {
 
   export OPENSSL_NO_VENDOR=1
   export OPENSSL_STATIC=0
-  export OPENSSL_DIR="${MINGW_PREFIX}"
   export RUSTONIG_DYNAMIC_LIBONIG=1
   export RUSTFLAGS="${RUSTFLAGS/+crt-static/-crt-static}"
   export CARGOFLAGS="--features openssl"


### PR DESCRIPTION
```
  /ucrt64/bin/uu-cksum.exe:
  	libcrypto-3-x64.dll => D:\M\msys64\ucrt64\bin\libcrypto-3-x64.dll (0x0000020753c60000)
  	libonig-5.dll => D:\M\msys64\ucrt64\bin\libonig-5.dll (0x0000020753330000)
  	libssl-3-x64.dll => D:\M\msys64\ucrt64\bin\libssl-3-x64.dll (0x0000020753330000)
```