### PR TITLE
umbrello: update to 26.08.0

### DIFF
--- a/mingw-w64-umbrello/PKGBUILD
+++ b/mingw-w64-umbrello/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=umbrello
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.04.3
+pkgver=26.08.0
 pkgrel=1
 pkgdesc="UML modeller (mingw-w64)"
 arch=('any')
@@ -35,13 +35,11 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-clang-tools-extra"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
-             "${MINGW_PACKAGE_PREFIX}-doxygen"
-             "${MINGW_PACKAGE_PREFIX}-graphviz"
              "${MINGW_PACKAGE_PREFIX}-extra-cmake-modules"
              "${MINGW_PACKAGE_PREFIX}-kdoctools"
              "${MINGW_PACKAGE_PREFIX}-icoutils")
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('48fc62edb58bf3c65cc5d89e8fd4927f441902a163e47a55ff1b6d4b7ed40d56'
+sha256sums=('fa9e4f235f39c6977a3e034d95be2d8b6af3665e6397474aebcd1b244d9f0bfa'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>
@@ -64,7 +62,6 @@ build() {
     -DBUILD_WITH_QT6=ON \
     -DBUILD_QCH=OFF \
     -DBUILD_TESTING=OFF \
-    -DBUILD_PHP_IMPORT=OFF \
     -DECM_DIR=${MINGW_PREFIX}/share/ECM \
     "${_extra_config[@]}" \
     -S ${_realname}-${pkgver} \


### PR DESCRIPTION
Remove API docs which is not used for general use cases.