### PR TITLE
libvips: ignore incorrectly assigned CVE

### DIFF
--- a/mingw-w64-libvips/PKGBUILD
+++ b/mingw-w64-libvips/PKGBUILD
@@ -15,6 +15,9 @@ msys2_references=(
   'gentoo: media-libs/vips'
   "cpe: cpe:2.3:a:libvips:libvips"
 )
+msys2_ignore_vulnerabilities=(
+  "CVE-2026-2913" # fixed since 8.18.1
+)
 license=('spdx:LGPL-2.1-or-later')
 depends=("${MINGW_PACKAGE_PREFIX}-cairo"
          "${MINGW_PACKAGE_PREFIX}-cfitsio"


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2026-2913

The linked patch is in the 8.18.1 tag.

Should've been assigned to <= 8.18.0, not (non-existant) 8.19.0...