### PR TITLE
darktable: update to 5.6.1

### DIFF
--- a/mingw-w64-darktable/PKGBUILD
+++ b/mingw-w64-darktable/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=darktable
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=5.6.0
+pkgver=5.6.1
 pkgrel=1
 pkgdesc="darktable is an open source photography workflow application and raw developer (mingw-w64)"
 arch=('any')
@@ -58,7 +58,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 # Disable strip option to write backtraces with drmingw
 options=('!strip')
 source=("https://github.com/darktable-org/${_realname}/releases/download/release-${pkgver}/${_realname}-${pkgver}.tar.xz"{,.asc})
-sha256sums=('157d6d3847af8afcabe78944454786f73a886e08a504b4bd6114c2065fe006e4'
+sha256sums=('e8b84ac98b0b689a244e4036c4b56394c1d58ce2d9abc05e0a060ef9f756dc36'
             'SKIP')
 validpgpkeys=('F10F9686652B0E949FCD94C318DCA123F949BD3B') # Pascal Obry <pascal@obry.net>
 


### PR DESCRIPTION
Edit: the source tarball is up now, please re-run.

Edit 2: Ah, looks like MSYS2 packaged onnxruntime doesn't support DirectML, so will revert to basic build.