### PR TITLE
qemu: Update to 11.1.1

### DIFF
--- a/mingw-w64-qemu/PKGBUILD
+++ b/mingw-w64-qemu/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=(
   "${MINGW_PACKAGE_PREFIX}-qemu-guest-agent"
   "${MINGW_PACKAGE_PREFIX}-qemu-image-util"
 )
-_base_ver="11.1.0"
+_base_ver="11.1.1"
 # QEMU Versioning of RC-SourcePackage and RC-Version differs
 # e.g. qemu-6.1.0-rc0.tar.xz contains 6.0.90, qemu-6.1.0-rc1.tar.xz contains 6.0.91
 # Unset _rc_no to create Release-Build
@@ -119,7 +119,7 @@ source=(
   msys2.examples.tests.sh
 )
 sha256sums=(
-  '6ee1d1a61f68212476b27108c26da5f449dc09b626d42f8279ba0dc2e08fa858'
+  '079ffbff8a7111bbc89022107cbabf3bbfd614d5fc9d7cc675991196aca12482'
   'SKIP'
   '07370d914562bb8dab16ce3e76b5a4d32d471c792ea95b9c12afd5c29dc619bf'
   'f2f9eeb31023d002f54637a9941ea0d8fae3c6f0a66c05c033857b305bd1470d'


### PR DESCRIPTION
The QEMU v11.1.1 stable release is now available.

v11.1.1 is now tagged in the official qemu.git repository, and the
stable-11.1 branch has been updated accordingly:

  https://gitlab.com/qemu-project/qemu/-/commits/stable-11.1

There are 91 changes since the previous v11.1.0 release.