### PR TITLE
passagemath: update to 10.8.11

### DIFF
--- a/mingw-w64-passagemath-benzene/PKGBUILD
+++ b/mingw-w64-passagemath-benzene/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-benzene
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Generate fusene and benzenoid graphs with benzene (mingw-w64)"
 arch=('any')
@@ -34,7 +34,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('5e35f25acb7ca272de0c79ed50ebd6824e9ac87449860b5f082e3d1a735c1574')
+sha256sums=('cfd8de28c58260cc21cb891fa2daad12dee28299f472639076087007222b6b03')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-bliss/PKGBUILD
+++ b/mingw-w64-passagemath-bliss/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-bliss
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Graph (iso/auto)morphisms with bliss (mingw-w64)"
 arch=('any')
@@ -30,7 +30,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('f71dc92698bf3714849830948cb7eaff399950dedd198e123f4d577a615eb507')
+sha256sums=('9954120b0f0a3dcb14f6d7188da40df3138cc8991ea8fb93072f62348704a3d3')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-bootstrap/PKGBUILD
+++ b/mingw-w64-passagemath-bootstrap/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-bootstrap
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Package database (mingw-w64)"
 arch=('any')
@@ -23,7 +23,7 @@ makedepends=(
 )
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('349075c7d52615375b3ef07069a8428c11a421b4224e103e228e2aa72ede5726')
+sha256sums=('d3332c51cb2187f158251511ceac8f7f10da82120ff58fdf9c0fa615d4a65465')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-buckygen/PKGBUILD
+++ b/mingw-w64-passagemath-buckygen/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-buckygen
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Generation of nonisomorphic fullerenes with buckygen (mingw-w64)"
 arch=('any')
@@ -36,7 +36,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('6e92caa3649b6303edda00986156d55b48ee200c5cd477d861bfb9f645474c7b')
+sha256sums=('ab7466386eab8f13e713fdb61e8081930712794ca78b68df12f4ef3a28be4f0c')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-categories/PKGBUILD
+++ b/mingw-w64-passagemath-categories/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-categories
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Sage categories and basic rings (mingw-w64)"
 arch=('any')
@@ -32,7 +32,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('5ded89300b485ae5c46601c16e665cc5543141a9b10db5b6ba1d0df77c9af73d')
+sha256sums=('979b0a5792eeee611697d760e6723929b1de8b8716576abbe688a4d16003013c')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-cddlib/PKGBUILD
+++ b/mingw-w64-passagemath-cddlib/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-cddlib
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Polynomial system solving through algebraic methods with cddlib (mingw-w64)"
 arch=('any')
@@ -29,7 +29,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('8a98e7adde5067a930710b7b0740098e746a671b2ec1c2c1c98d889a0a2c728d')
+sha256sums=('663346dbe8ff22cae42245d7c80876c672e2b1debe3559f28bab8ef5183564cf')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-cliquer/PKGBUILD
+++ b/mingw-w64-passagemath-cliquer/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-cliquer
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Finding cliques in graphs with cliquer (mingw-w64)"
 arch=('any')
@@ -31,7 +31,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('c366927c74aecbb5ef196f12799dc8e3370986e84d41840e1398f0c269831ed6')
+sha256sums=('cdbe15e3b0e17792ea6d9d4be35a1956eddb49c206eed08fa2a01a6b1cdad94d')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-cmr/PKGBUILD
+++ b/mingw-w64-passagemath-cmr/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-cmr
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Combinatorial matrix recognition (mingw-w64)"
 arch=('any')
@@ -31,7 +31,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('83a2a0c68fe663b7a9dc45eaecabaf77ed054e0ac8d57007e25515734bf4a471')
+sha256sums=('2d06984ced74c79e961c800ba745152c3db39e3f799037b2b1e8b892b00bfdad')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-combinat/PKGBUILD
+++ b/mingw-w64-passagemath-combinat/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-combinat
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Algebraic combinatorics, combinatorial representation theory (mingw-w64)"
 arch=('any')
@@ -42,7 +42,7 @@ optdepends=(
 )
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('f1a8d7c971e6599e3a39d5ea3b9f350614bd6f919f2df3403871790e61760c42')
+sha256sums=('830fb94bba98739220bcc0595c3ab154e76613c8884228af6293aeea53bdde62')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-database-cunningham/PKGBUILD
+++ b/mingw-w64-passagemath-database-cunningham/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-database-cunningham
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: List of the prime numbers occuring in the Cunningham table (mingw-w64)"
 arch=('any')
@@ -24,7 +24,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname//-/_}-${pkgver}.tar.gz")
-sha256sums=('140d44122f36757d629dfc118dfeb6e7b7662b23dc6f80c034c13018bb24bcec')
+sha256sums=('b261c1634e6d042fa2ed2e62567853a4da3658e2af5ad8e1c55b5e8cb59ee314')
 
 build() {
   cp -r "${_realname//-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-environment/PKGBUILD
+++ b/mingw-w64-passagemath-environment/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=passagemath-environment
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgdesc="Subset of the Sage library providing the connection to the system and software environment (mingw-w64)"
@@ -23,7 +23,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('284bf517fbe5bfdc9d029cead6728de3d589345045903c43384056a1b22772eb')
+sha256sums=('c62b1c9a37eb4abbd62ae53b0b4c268aff3bfabc6e40c5eed3628aa644dcf1aa')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-flint/PKGBUILD
+++ b/mingw-w64-passagemath-flint/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-flint
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Fast computations with MPFI and FLINT (mingw-w64)"
 arch=('any')
@@ -43,7 +43,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('5b6fc50555bbea00e6fb45e9ec33ba92285284ec1f37b6e3673ffc5ee2788a68')
+sha256sums=('ee88f3fd7438782014bcca18e69ede314cd432bde0fe29b70f4688def777b9da')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-glpk/PKGBUILD
+++ b/mingw-w64-passagemath-glpk/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-glpk
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Linear and mixed integer linear optimization backend using GLPK (mingw-w64)"
 arch=('any')
@@ -35,7 +35,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('f894beec52c2e91394f08f1e88015fc689ee26c292d90b32ffa8568af8482a5d')
+sha256sums=('954d2fe4a3855f1091a10f99b6246003f9c845cc36ae3d239c148ccefd7b8659')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-graphs/PKGBUILD
+++ b/mingw-w64-passagemath-graphs/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-graphs
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Graphs, posets, hypergraphs, designs, abstract complexes, combinatorial polyhedra, abelian sandpiles, quivers (mingw-w64)"
 arch=('any')
@@ -47,7 +47,7 @@ optdepends=(
 )
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('b5b620ff6e738c82b88e862df624272a538b0c1a887daa68f15a90346860f478')
+sha256sums=('54f0f822eea01c4e0855c0439a330a3e6162155caf7cbaa7f52feb5b88bfc25f')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-gsl/PKGBUILD
+++ b/mingw-w64-passagemath-gsl/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-gsl
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Numerics with the GNU Scientific Library (mingw-w64)"
 arch=('any')
@@ -38,7 +38,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('69ce6fd90a3b1510061be64c41ec25aa9956ce7cb2ed58ed0cc63d222e323855')
+sha256sums=('af52377892c620deb4960c56938f9e43cdce0cbc3d84232624c2fbf4b059af5e')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-highs/PKGBUILD
+++ b/mingw-w64-passagemath-highs/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-highs
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Linear and mixed integer linear optimization backend using HiGHS (mingw-w64)"
 arch=('any')
@@ -37,7 +37,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('d90a721368d52a1257d802526445b37c0885feb20ce4ab742efbb814778627c9')
+sha256sums=('1b8b46473d54c0169df9c71fa4305364e6df9cb151def1e25148dd5b9f75406f')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-homfly/PKGBUILD
+++ b/mingw-w64-passagemath-homfly/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-homfly
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Homfly polynomials of knots/links with libhomfly (mingw-w64)"
 arch=('any')
@@ -30,7 +30,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('ef2eea53fe4268bf46a5356826acbfa2d2103d4b6f9ebe7233df25a27dfb034b')
+sha256sums=('3c234dc7f9c1548979beaa12d9bcbf08a20b02dd8724f2ce88dcd1208d72201f')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-iml/PKGBUILD
+++ b/mingw-w64-passagemath-iml/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-iml
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Linear Algebra with IML (mingw-w64)"
 arch=('any')
@@ -34,7 +34,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('e93c4d3cf6b5b5c39f2704c914ca1d111b54fa94e70b219e4076fa7de0a9999e')
+sha256sums=('50d6b9216fd65787b9605b084dadd7e6cfcea79d468d9d0ec263ab5b3396ae2b')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-libbraiding/PKGBUILD
+++ b/mingw-w64-passagemath-libbraiding/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-libbraiding
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Braid computations with libbraiding (mingw-w64)"
 arch=('any')
@@ -30,7 +30,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('fe8fc9045d45488794458355ce641afdbb64458a517706d4710e2513ca87a538')
+sha256sums=('28fd537551bae56d54d9cce2c12b575c63e0180ed6d7193fa3529e31234d1de6')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-m4ri-m4rie/PKGBUILD
+++ b/mingw-w64-passagemath-m4ri-m4rie/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-m4ri-m4rie
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Linear Algebra with m4ri and m4rie (mingw-w64)"
 arch=('any')
@@ -37,7 +37,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname//-/_}-${pkgver}.tar.gz")
-sha256sums=('bdbb440062b370f971aae8f2260aaf0a9343dae6aecc3d82e7568f449d8630da')
+sha256sums=('f96e530ccd8d2aaff5659b159f15f4fd698b27134b0ff5038d5269ce0da8e08a')
 
 build() {
   cp -r "${_realname//-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-mcqd/PKGBUILD
+++ b/mingw-w64-passagemath-mcqd/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-mcqd
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Finding maximum cliques with mcqd (mingw-w64)"
 arch=('any')
@@ -31,7 +31,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('87579ccb22b3601b56ea195095e97423a7f15fc359bf22d2ed95b20ab377a50b')
+sha256sums=('c150aeec3bea375373f05b25e25c0662a73bbd80fcf611e5ca7b42f452df26c4')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-modules/PKGBUILD
+++ b/mingw-w64-passagemath-modules/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-modules
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Vectors, matrices, tensors, vector spaces, affine spaces, modules and algebras, additive groups, quadratic forms, homology, coding theory, matroids (mingw-w64)"
 arch=('any')
@@ -49,7 +49,7 @@ optdepends=(
 )
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('b85407da611f5fd9d51d20a5088526136dda38b8e0c691d320ee8010f7ecd26c')
+sha256sums=('99c79a0e6ae784fda51c6ade300a68f020954be5b4b93d236b78f09e10ef49b1')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-msolve/PKGBUILD
+++ b/mingw-w64-passagemath-msolve/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-msolve
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Polynomial system solving through algebraic methods with msolve (mingw-w64)"
 arch=('any')
@@ -38,7 +38,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('09c5c3c6d42742ff12c03e17800f790a943be9da8bd317a1fc16ce91054afadf')
+sha256sums=('02cd2e88db083bbdde12082d5bf884ffd616f2ee0e05c2a686ff45003992bad1')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-nauty/PKGBUILD
+++ b/mingw-w64-passagemath-nauty/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-nauty
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Find automorphism groups of graphs, generate non-isomorphic graphs with nauty (mingw-w64)"
 arch=('any')
@@ -30,7 +30,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('bc5dfbcd30558756e9345ace6d0c0da0d5b2800de92bf1500edaaf67ea2a3be8')
+sha256sums=('ffaaf6f0a49ea8f3ce8f2653e20736461ae46ed6c5f85d18f3fc168fd1f8bbf0')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-ntl/PKGBUILD
+++ b/mingw-w64-passagemath-ntl/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-ntl
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Computational Number Theory with NTL (mingw-w64)"
 arch=('any')
@@ -34,7 +34,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('136065eb4200f6dcffbb4ddc5a1c60f368581cb1c0dc13124b6497b632d3069e')
+sha256sums=('8b970e54a58a1836923bf7ee3ef29a285b3de5e9db14377cd7ed25d796876e48')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-objects/PKGBUILD
+++ b/mingw-w64-passagemath-objects/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=passagemath-objects
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgdesc="Part of the Sage library making object, element/parent framework, categories and the coercion system available (mingw-w64)"
@@ -30,7 +30,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('8d4469ef13885e100e67bf6637979d8c3bda2232bd8f92b561d25d60b75dd1cd')
+sha256sums=('6de3d5acd6f02f55d9f465b27d4341a5d5cb01b4f8339dbba33ee9a4f647da2f')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-planarity/PKGBUILD
+++ b/mingw-w64-passagemath-planarity/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-planarity
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Graph planarity with the edge addition planarity suite (mingw-w64)"
 arch=('any')
@@ -30,7 +30,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-boost"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('dd4a37c88625fabee2cd8e5242e845b92b7acf0344b33c54b177831579d6e3c0')
+sha256sums=('53037e10c42b2dfca1a2ffa4887353da908b051d30505abd3248ebbd94f8c833')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-plantri/PKGBUILD
+++ b/mingw-w64-passagemath-plantri/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-plantri
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Generating planar graphs with plantri and fullgen (mingw-w64)"
 arch=('any')
@@ -33,7 +33,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('456f40e040aece6192f67fcc121131a833e7dc9444c60973bb494585736d1082')
+sha256sums=('eddb97a2b47a095180ad3a430d74c6a7e438e05684b761e862e6052b4e0cad2b')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-plot/PKGBUILD
+++ b/mingw-w64-passagemath-plot/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-plot
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Plotting and graphics with Matplotlib, Three.JS, etc. (mingw-w64)"
 arch=('any')
@@ -45,7 +45,7 @@ optdepends=(
 )
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('5613dbd2e78d4806cfc64ed158db68c8c236e1daa287c8f5c2509341aa29e3fd')
+sha256sums=('8f0e6b9391be0b08828e87a1c923533b872970003ec89725faca2eed7ad0506a')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-polyhedra/PKGBUILD
+++ b/mingw-w64-passagemath-polyhedra/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-polyhedra
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Convex polyhedra in arbitrary dimension, mixed integer linear optimization (mingw-w64)"
 arch=('any')
@@ -55,7 +55,7 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-python-cvxopt"
 )
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('323d05439be276f65c85e94eb8560b47dd3591d210893f2aa6a1b1a07e13cbbe')
+sha256sums=('15dfd09f02fce2ecc5f288b40f796837734a8f905a53e864b5296a81c07979e8')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-rankwidth/PKGBUILD
+++ b/mingw-w64-passagemath-rankwidth/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-rankwidth
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Rankwidth and rank decompositions of graphs (mingw-w64)"
 arch=('any')
@@ -30,7 +30,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('1c59304a7a4253af8d4a869312bc4f05d733ae9538d0030aa7986e8813fd2511')
+sha256sums=('30cc8233841983b7128ce329e1288d7b8c951514df2963e6f0864119141084af')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-repl/PKGBUILD
+++ b/mingw-w64-passagemath-repl/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-repl
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: IPython kernel, Sage preparser, doctester (mingw-w64)"
 arch=('any')
@@ -28,7 +28,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('e21fd90f294e8ad7068728b435b390bb92ab79bf824ad16f4ef425d664a21c74')
+sha256sums=('b37d4b7b0cc6a7efa6ed56bf78be9dd8e4044c1f4cbc8f6110fc38b536047dc7')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-setup/PKGBUILD
+++ b/mingw-w64-passagemath-setup/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-setup
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: build system of the Sage library (mingw-w64)"
 arch=('any')
@@ -22,7 +22,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-build"
 optdepends=("${MINGW_PACKAGE_PREFIX}-python-jinja: for autogen feature")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('5badee266ebab229786cf223462e3c4d74d63a22805e84899f6d80f7fcb9eaec')
+sha256sums=('604d53d05fa514f285f1eca15baccb0dc0f5b87c64084ccd5184170cd377d0c2')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-sirocco/PKGBUILD
+++ b/mingw-w64-passagemath-sirocco/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-sirocco
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Certified root continuation with sirocco (mingw-w64)"
 arch=('any')
@@ -31,7 +31,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-python-setuptools")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('d19408990c8a49ae988e4863e863ff2303ad79fbc1187c2df66b3624548e82e3')
+sha256sums=('6ee041afe24c35005f1f5764dfcd620432d22b1579b4bd65c94a245e365c0466')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-passagemath-tdlib/PKGBUILD
+++ b/mingw-w64-passagemath-tdlib/PKGBUILD
@@ -4,7 +4,7 @@ _realname=passagemath-tdlib
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=10.8.9
+pkgver=10.8.11
 pkgrel=1
 pkgdesc="passagemath: Tree decompositions with tdlib (mingw-w64)"
 arch=('any')
@@ -31,7 +31,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-treedec")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('73f9f657d336e52ab039cee043c37c11dd3dc82485f5111f4490467c739a30e0')
+sha256sums=('18327663d3c5df03c417efebb9957b6f1c4001ec04f5d3104bad7490c646fcc1')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"


### PR DESCRIPTION
https://github.com/passagemath/passagemath/releases/tag/passagemath-10.8.11
~~https://github.com/passagemath/passagemath/releases/tag/passagemath-10.8.10~~

**Edit:** Skipping 10.8.10 and trying 10.8.11 instead, because there were build issues with 10.8.10 due to Cython 3.3.0.