### PR TITLE
zed: update to 1.17.2

### DIFF
--- a/mingw-w64-zed/PKGBUILD
+++ b/mingw-w64-zed/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          #"${MINGW_PACKAGE_PREFIX}-${_realname}-docs"
 )
-pkgver=1.16.3
+pkgver=1.17.2
 pkgrel=1
 pkgdesc="A high-performance, multiplayer code editor (mingw-w64)"
 arch=('any')
@@ -48,7 +48,7 @@ source=("git+${msys2_repository_url}.git#tag=v${pkgver}"
         "zstd-sys-remove-statik.patch"
         "zed-fix-docs-build.patch"
         "zed-wsl-set-proper-cli-name.patch")
-sha256sums=('252ba543a1e41dfe805ff056c47f6d2d8a59169aff5894b0ffe9815846efa5df'
+sha256sums=('dbaadbf48182e0e71f1d086ab67b7ef9e5b2bf119505140ff7dab3e4b719067e'
             '91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748'
             '48f4900ceb02d3aaf9a1020f33d56629156e96759f456c0e7ca18bfcf910767b'
             'acaf155e37120a1af8918854a457939cad71e59bca2ced866f89795ed6b0a7b2'
@@ -65,12 +65,6 @@ prepare() {
   patch -Np1 -i ../zed-wsl-set-proper-cli-name.patch
   # use patched *-sys crates
   sed -i '/\[patch\.crates-io\]/a zstd-sys.path = "../zstd-sys-2.0.16+zstd.1.5.7"' Cargo.toml
-
-  # change git config so `pet*` crates would be fetched without error; requires Windows registry
-  # changes, see https://zed.dev/docs/development/windows#build-fails-path-too-long for details
-  if test true != "$(git config core.longpaths)"; then
-    git config --global core.longpaths true
-  fi
 
   cargo update -p zstd-sys
   cargo fetch --locked --target "${RUST_CHOST}"


### PR DESCRIPTION
longpath workaround seems to be not needed anymore (finally)