### PR TITLE
rustfs{,-launcher}: update to 1.0.0-rc.6

### DIFF
--- a/mingw-w64-rustfs-launcher/0001-launcher-0.0.4-system-candidate.patch
+++ b/mingw-w64-rustfs-launcher/0001-launcher-0.0.4-system-candidate.patch
@@ -1,6 +1,6 @@
---- launcher-0.0.4.orig/src-tauri/src/process.rs	2025-12-20 06:39:43.000000000 +0300
-+++ launcher-0.0.4/src-tauri/src/process.rs	2025-12-23 22:48:29.897657200 +0300
-@@ -36,6 +36,9 @@
+--- launcher-1.0.0-rc.6.orig/src-tauri/src/process.rs	2026-08-31 07:30:34.000000000 +0300
++++ launcher-1.0.0-rc.6/src-tauri/src/process.rs	2026-09-11 21:57:54.879271800 +0300
+@@ -80,6 +80,9 @@
          }
      };
  
@@ -8,13 +8,14 @@
 +
 +    /*
      push_candidate(exe_dir.join("binaries").join(binary_name));
- 
-     #[cfg(target_os = "macos")]
-@@ -51,6 +54,7 @@
+     push_candidate(exe_dir.join("resources").join("binaries").join(binary_name));
+     push_candidate(exe_dir.join("../Resources/binaries").join(binary_name));
+@@ -100,6 +103,8 @@
      }
  
      push_candidate(PathBuf::from("src-tauri/binaries").join(binary_name));
 +    */
++
+     candidates
+ }
  
-     for candidate in &candidates {
-         add_app_log(format!(

--- a/mingw-w64-rustfs-launcher/0002-launcher-1.0.0-rc.6-fix-csp.patch
+++ b/mingw-w64-rustfs-launcher/0002-launcher-1.0.0-rc.6-fix-csp.patch
@@ -1,0 +1,11 @@
+--- launcher-1.0.0-rc.6.orig/src-tauri/tauri.conf.json	2026-08-31 07:30:34.000000000 +0300
++++ launcher-1.0.0-rc.6/src-tauri/tauri.conf.json	2026-09-12 14:51:00.670168200 +0300
+@@ -29,7 +29,7 @@
+       }
+     ],
+     "security": {
+-      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src ipc: http://ipc.localhost"
++      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src ipc: http://ipc.localhost http://tauri.localhost"
+     }
+   },
+   "bundle": {

--- a/mingw-w64-rustfs-launcher/0003-launcher-1.0.0-rc.6-disable-updates.patch
+++ b/mingw-w64-rustfs-launcher/0003-launcher-1.0.0-rc.6-disable-updates.patch
@@ -1,0 +1,141 @@
+--- launcher-1.0.0-rc.6.orig/src/app.rs	2026-08-31 07:30:34.000000000 +0300
++++ launcher-1.0.0-rc.6/src/app.rs	2026-09-12 15:01:37.585298600 +0300
+@@ -742,6 +742,7 @@
+         run_update_checks(false);
+     });
+ 
++    /*
+     let check_update = move |_| {
+         run_update_checks(true);
+     };
+@@ -863,6 +864,7 @@
+             set_rustfs_update_progress.set(None);
+         });
+     };
++    */
+ 
+     let open_service_url = move |url: String| {
+         if !is_tauri() {
+@@ -968,122 +970,6 @@
+                     </div>
+                 </div>
+ 
+-                <section class="update-card">
+-                    <div class="update-heading">
+-                        <div>
+-                            <span class="summary-label">"Software Update"</span>
+-                            <strong>"Version & Updates"</strong>
+-                        </div>
+-                        <button
+-                            type="button"
+-                            class="update-check-btn"
+-                            disabled=updates_busy
+-                            on:click=check_update
+-                        >
+-                            {move || if is_checking_update.get() { "Checking…" } else { "Check for Updates" }}
+-                        </button>
+-                    </div>
+-
+-                    <p class="update-platform">
+-                        {move || version_info
+-                            .get()
+-                            .map(|info| info.platform)
+-                            .unwrap_or_else(|| "Windows / macOS".to_string())}
+-                    </p>
+-
+-                    <div class="version-row">
+-                        <span>{move || format!(
+-                            "Launcher {}",
+-                            version_info.get().map(|info| info.launcher_version).unwrap_or_else(|| "—".to_string())
+-                        )}</span>
+-                        <span>{move || {
+-                            let info = version_info.get();
+-                            let version = info
+-                                .as_ref()
+-                                .map(|info| info.rustfs_version.as_str())
+-                                .unwrap_or("—");
+-                            let source = info
+-                                .as_ref()
+-                                .map(|info| rustfs_source_label(info.rustfs_managed))
+-                                .unwrap_or("bundled");
+-                            format!("RustFS {version} ({source})")
+-                        }}</span>
+-                    </div>
+-
+-                    {move || update_info.get().map(|info| {
+-                        if info.available {
+-                            let version = info.version.unwrap_or_else(|| "unknown".to_string());
+-                            let notes = info.notes.unwrap_or_else(|| "No release notes for this version.".to_string());
+-                            view! {
+-                                <div class="update-available">
+-                                    <div>
+-                                        <strong>{format!("Launcher {}", version)}</strong>
+-                                        <p>{notes}</p>
+-                                    </div>
+-                                    <button
+-                                        type="button"
+-                                        class="update-install-btn"
+-                                        disabled=updates_busy
+-                                        on:click=install_update
+-                                    >
+-                                        {move || if is_installing_update.get() { "Installing…" } else { "Update Launcher" }}
+-                                    </button>
+-                                </div>
+-                            }.into_any()
+-                        } else {
+-                            view! { <p class="update-current">"Launcher is up to date."</p> }.into_any()
+-                        }
+-                    })}
+-
+-                    {move || rustfs_update_info.get().map(|info| {
+-                        if info.available {
+-                            let version = info.latest_version.unwrap_or_else(|| "unknown".to_string());
+-                            let detail = match (info.release_type, info.asset_name) {
+-                                (Some(kind), Some(asset)) => format!("{kind} · {asset}"),
+-                                (Some(kind), None) => kind,
+-                                (None, Some(asset)) => asset,
+-                                (None, None) => "Verified download from the RustFS release feed.".to_string(),
+-                            };
+-                            view! {
+-                                <div class="update-available">
+-                                    <div>
+-                                        <strong>{format!("RustFS {}", version)}</strong>
+-                                        <p>{detail}</p>
+-                                    </div>
+-                                    <button
+-                                        type="button"
+-                                        class="update-install-btn"
+-                                        disabled=updates_busy
+-                                        on:click=install_rustfs_update
+-                                    >
+-                                        {move || if is_installing_rustfs.get() { "Installing…" } else { "Update RustFS" }}
+-                                    </button>
+-                                </div>
+-                            }.into_any()
+-                        } else {
+-                            view! { <p class="update-current">{rustfs_idle_message(info.notes.as_deref())}</p> }.into_any()
+-                        }
+-                    })}
+-
+-                    {move || is_installing_update.get().then(|| view! {
+-                        <div class="update-progress" aria-label="Launcher update progress">
+-                            <div
+-                                class="update-progress-bar"
+-                                style:width=move || format!("{}%", update_progress.get().unwrap_or(8))
+-                            ></div>
+-                        </div>
+-                    })}
+-
+-                    {move || is_installing_rustfs.get().then(|| view! {
+-                        <div class="update-progress" aria-label="RustFS update progress">
+-                            <div
+-                                class="update-progress-bar"
+-                                style:width=move || format!("{}%", rustfs_update_progress.get().unwrap_or(8))
+-                            ></div>
+-                        </div>
+-                    })}
+-                </section>
+-
+                 <ConfigForm
+                     config=config
+                     set_config=set_config

--- a/mingw-w64-rustfs-launcher/PKGBUILD
+++ b/mingw-w64-rustfs-launcher/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=rustfs-launcher
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_pkgver=1.0.0-rc.3
+_pkgver=1.0.0-rc.6
 pkgver=${_pkgver//-/_}
 pkgrel=1
 pkgdesc="A simple launcher for RustFS (mingw-w64)"
@@ -25,20 +25,29 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-wasm-bindgen"
 )
 source=("${msys2_repository_url}/archive/${_pkgver}/launcher-${_pkgver}.tar.gz"
-        '0001-launcher-0.0.4-system-candidate.patch')
-sha256sums=('6ac0308eaa5a3cba136b163c460de88c732793651d5017b4f1b287d200e4d027'
-            'e66b9267bde7dc875c6bdca48563a5c2dc2c9764e1a9207c6c6b929b733d760a')
+        '0001-launcher-0.0.4-system-candidate.patch'
+        '0002-launcher-1.0.0-rc.6-fix-csp.patch'
+        '0003-launcher-1.0.0-rc.6-disable-updates.patch')
+sha256sums=('059a5b524cdbe1f7610578adaac691d3b77f9d7a5841e7ce4a0a46e6ed08ac0f'
+            '4cdc7f58af29881c975843db501b8af306cade885cd79f547c66cb2a3e889155'
+            '618bbf9dd72881a8f489cf8d205c467d1d339e54509fa3dbd8fc3ba34d33bb42'
+            '223904b1c3e157ad1490fe5d2f35de92511e2d2ddca9d3ead70fba5ae1873698')
 
 prepare() {
   cd "${srcdir}/launcher-${_pkgver}"
 
   patch -p1 -i "${srcdir}"/0001-launcher-0.0.4-system-candidate.patch
+  patch -p1 -i "${srcdir}"/0002-launcher-1.0.0-rc.6-fix-csp.patch
+  patch -p1 -i "${srcdir}"/0003-launcher-1.0.0-rc.6-disable-updates.patch
 
   local _conf=src-tauri/tauri.conf.json
   if [[ ${MSYSTEM} != UCRT64 ]]; then
     echo $(jq '.build.beforeBuildCommand |= "trunk build --release"' $_conf) > $_conf
   fi
   echo $(jq 'del(.bundle.resources)' $_conf) > $_conf
+
+  # To avoid errors on CLANGARM64
+  cargo add wasm-bindgen@0.2.128
 
   cargo fetch --target "${RUST_CHOST}"
 }

--- a/mingw-w64-rustfs/PKGBUILD
+++ b/mingw-w64-rustfs/PKGBUILD
@@ -3,9 +3,9 @@
 _realname=rustfs
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_pkgver=1.0.0-rc.3
+_pkgver=1.0.0-rc.6
 pkgver=${_pkgver//-/_}
-_consolever=0.1.22
+_consolever=0.1.26
 pkgrel=1
 pkgdesc="High-performance, memory-safe distributed object storage (mingw-w64)"
 arch=('any')
@@ -36,8 +36,8 @@ source=(
 )
 noextract=("rustfs-${_pkgver}.tar.gz"
            "rustfs-console-v${_consolever}.zip")
-sha256sums=('327b39ed38418d0ea424fb67e3ce4aaf9d92245a06eaaf228717ed0008538f8f'
-            '4699a2ca43d3a0bdf19e172825540b87b29da61ee7d80e03d6a5ad9cffa31806')
+sha256sums=('c2b3f79221966f87ebefd53207b61bdba8a45997c7dc6814ade20ca4a2fe6d9a'
+            '76a5e4ccccc7af80e702174aa9d17c21c20884822c59b6430b0e7523cd27f01a')
 
 prepare() {
   echo "Extracting ${_realname}-${_pkgver}.tar.gz ..."


### PR DESCRIPTION
Error in `rustfs-mimalloc-sys`:
```
  warning: rustfs-mimalloc-sys@0.5.1: clang: error: no such file or directory: '/MD'
  warning: rustfs-mimalloc-sys@0.5.1: clang: error: no such file or directory: '/wd4100'
  warning: rustfs-mimalloc-sys@0.5.1: clang: error: no such file or directory: '/wd4127'
  warning: rustfs-mimalloc-sys@0.5.1: clang: error: no such file or directory: '/wd4201'
  error: failed to run custom build command for `rustfs-mimalloc-sys v0.5.1`
  
  Caused by:
    process didn't exit successfully: `D:\_\B\src\rustfs-1.0.0-rc.4\target\release\build\rustfs-mimalloc-sys-50239f66ca8284db\build-script-build` (exit code: 1)
    --- stdout
    cargo:rerun-if-changed=build.rs
    cargo:rerun-if-env-changed=CARGO_FEATURE_SECURE
    cargo:rerun-if-env-changed=CARGO_FEATURE_DEBUG
    cargo:rerun-if-env-changed=CARGO_FEATURE_DEBUG_IN_DEBUG
    cargo:rerun-if-env-changed=CARGO_FEATURE_OVERRIDE
    cargo:rerun-if-env-changed=CARGO_FEATURE_LOCAL_DYNAMIC_TLS
    cargo:rerun-if-env-changed=CARGO_FEATURE_WIN_DIRECT_TLS
    cargo:rerun-if-env-changed=CARGO_FEATURE_NO_THP
    cargo:rerun-if-env-changed=CC_FORCE_DISABLE
    CC_FORCE_DISABLE = None
    cargo:rerun-if-env-changed=CC_x86_64-pc-windows-gnullvm
    CC_x86_64-pc-windows-gnullvm = None
    cargo:rerun-if-env-changed=CC_x86_64_pc_windows_gnullvm
    CC_x86_64_pc_windows_gnullvm = None
    cargo:rerun-if-env-changed=HOST_CC
    HOST_CC = None
    cargo:rerun-if-env-changed=CC
    CC = Some(clang)
    cargo:rerun-if-env-changed=CC_KNOWN_WRAPPER_CUSTOM
    CC_KNOWN_WRAPPER_CUSTOM = None
    cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
    cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
    CRATE_CC_NO_DEFAULTS = None
    cargo:rerun-if-env-changed=CFLAGS
    CFLAGS = Some(-march=nocona -msahf -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wp,-D__USE_MINGW_ANSI_STDIO=1)
    cargo:rerun-if-env-changed=CC_SHELL_ESCAPED_FLAGS
    CC_SHELL_ESCAPED_FLAGS = None
    cargo:rerun-if-env-changed=HOST_CFLAGS
    HOST_CFLAGS = None
    cargo:rerun-if-env-changed=CFLAGS_x86_64_pc_windows_gnullvm
    CFLAGS_x86_64_pc_windows_gnullvm = None
    cargo:rerun-if-env-changed=CFLAGS_x86_64-pc-windows-gnullvm
    CFLAGS_x86_64-pc-windows-gnullvm = None
    cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
    CRATE_CC_NO_DEFAULTS = None
    cargo:rerun-if-env-changed=CFLAGS
    CFLAGS = Some(-march=nocona -msahf -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wp,-D__USE_MINGW_ANSI_STDIO=1)
    cargo:rerun-if-env-changed=CC_SHELL_ESCAPED_FLAGS
    CC_SHELL_ESCAPED_FLAGS = None
    cargo:rerun-if-env-changed=HOST_CFLAGS
    HOST_CFLAGS = None
    cargo:rerun-if-env-changed=CFLAGS_x86_64_pc_windows_gnullvm
    CFLAGS_x86_64_pc_windows_gnullvm = None
    cargo:rerun-if-env-changed=CFLAGS_x86_64-pc-windows-gnullvm
    CFLAGS_x86_64-pc-windows-gnullvm = None
    cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
    CRATE_CC_NO_DEFAULTS = None
    cargo:rerun-if-env-changed=CFLAGS
    CFLAGS = Some(-march=nocona -msahf -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wp,-D__USE_MINGW_ANSI_STDIO=1)
    cargo:rerun-if-env-changed=CC_SHELL_ESCAPED_FLAGS
    CC_SHELL_ESCAPED_FLAGS = None
    cargo:rerun-if-env-changed=HOST_CFLAGS
    HOST_CFLAGS = None
    cargo:rerun-if-env-changed=CFLAGS_x86_64_pc_windows_gnullvm
    CFLAGS_x86_64_pc_windows_gnullvm = None
    cargo:rerun-if-env-changed=CFLAGS_x86_64-pc-windows-gnullvm
    CFLAGS_x86_64-pc-windows-gnullvm = None
    cargo:warning=clang: error: no such file or directory: '/MD'
    cargo:warning=clang: error: no such file or directory: '/wd4100'
    cargo:warning=clang: error: no such file or directory: '/wd4127'
    cargo:warning=clang: error: no such file or directory: '/wd4201'
  
    --- stderr
  
  
    error occurred in cc-rs: command did not execute successfully (status code exit code: 1): "clang" "-O3" "-ffunction-sections" "-fdata-sections" "-m64" "--target=x86_64-pc-windows-gnu" "-I" "c_src/mimalloc/include" "-I" "c_src/mimalloc/src" "-fno-omit-frame-pointer" "-mno-omit-leaf-frame-pointer" "/MD" "/wd4100" "/wd4127" "/wd4201" "-DNDEBUG" "-DMI_BUILD_RELEASE" "-DMI_DEBUG=0" "-march=nocona" "-msahf" "-mtune=generic" "-O2" "-pipe" "-Wp,-D_FORTIFY_SOURCE=2" "-fstack-protector-strong" "-Wp,-D__USE_MINGW_ANSI_STDIO=1" "-o" "D:\\_\\B\\src\\rustfs-1.0.0-rc.4\\target\\release\\build\\rustfs-mimalloc-sys-5aff27e394d0a0a3\\out\\5a07bf3761bb5df8-static.o" "-c" "c_src/mimalloc/src/static.c"
```

Cc: @loverustfs @reatang