### PR TITLE
crt: enable buildflags

### DIFF
--- a/mingw-w64-crt/PKGBUILD
+++ b/mingw-w64-crt/PKGBUILD
@@ -4,7 +4,7 @@ _realname=crt
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=14.0.0.r302.gd7f3c5201
-pkgrel=1
+pkgrel=2
 _commit='d7f3c52012c4af4fb526330117d9c86b266018dc'
 pkgdesc='MinGW-w64 CRT for Windows (mingw-w64)'
 arch=('any')
@@ -20,7 +20,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}-git=${pkgver}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
-options=('!strip' '!buildflags' '!emptydirs')
+options=('!strip' '!emptydirs')
 source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64#commit=$_commit")
 sha256sums=('3f831df1c0aaad43ca0d37c751f55b87948d1fd802598010fb94a127217af6f0')
 
@@ -47,6 +47,9 @@ build() {
     ;;
   esac
 
+  CFLAGS="${CFLAGS//-Wp,-D__USE_MINGW_ANSI_STDIO=1/}"
+  CXXFLAGS="${CXXFLAGS//-Wp,-D__USE_MINGW_ANSI_STDIO=1/}"
+
   # only clang+lld support this at the moment
   if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then
     _extra_config+=("--enable-cfguard")
@@ -72,12 +75,9 @@ package() {
   cd "${srcdir}"/build-${MSYSTEM}
   make DESTDIR="${pkgdir}" install-strip
 
-  # Create empty dummy archives, to avoid failing when the compiler driver
-  # adds -lssp -lssh_nonshared when linking.
-  ar rcs "${pkgdir}"${MINGW_PREFIX}/lib/libssp.a
-  ar rcs "${pkgdir}"${MINGW_PREFIX}/lib/libssp_nonshared.a
-
   install -Dm644 "${srcdir}"/mingw-w64/COPYING "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/COPYING
-  install -Dm644 "${srcdir}"/mingw-w64/COPYING.MinGW-w64/COPYING.MinGW-w64.txt "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.MinGW-w64.txt
-  install -Dm644 "${srcdir}"/mingw-w64/COPYING.MinGW-w64-runtime/COPYING.MinGW-w64-runtime.txt "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.MinGW-w64-runtime.txt
+  install -Dm644 "${srcdir}"/mingw-w64/COPYING.MinGW-w64/COPYING.MinGW-w64.txt \
+    "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.MinGW-w64.txt
+  install -Dm644 "${srcdir}"/mingw-w64/COPYING.MinGW-w64-runtime/COPYING.MinGW-w64-runtime.txt \
+    "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.MinGW-w64-runtime.txt
 }

--- a/mingw-w64-crt/PKGBUILD
+++ b/mingw-w64-crt/PKGBUILD
@@ -75,6 +75,11 @@ package() {
   cd "${srcdir}"/build-${MSYSTEM}
   make DESTDIR="${pkgdir}" install-strip
 
+  # Create empty dummy archives, to avoid failing when the compiler driver
+  # adds -lssp -lssp_nonshared when linking.
+  ar rcs "${pkgdir}"${MINGW_PREFIX}/lib/libssp.a
+  ar rcs "${pkgdir}"${MINGW_PREFIX}/lib/libssp_nonshared.a
+
   install -Dm644 "${srcdir}"/mingw-w64/COPYING "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/COPYING
   install -Dm644 "${srcdir}"/mingw-w64/COPYING.MinGW-w64/COPYING.MinGW-w64.txt \
     "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.MinGW-w64.txt


### PR DESCRIPTION
buildflags was first disabled at 4b21c49bfcb4167a28aa85b3de48a7e7ea955547 at 2014, and I didn't find any reason/blocker for it.
libssp.a and libssp_nonshared.d are no longer used since we add --disable-ssp to gcc at dfa6dd8c269cb4899e57f7ae033ab54e5a7b414f