### PR TITLE
qt5-pdf: don't link to delayimp

### DIFF
--- a/mingw-w64-qt5-pdf/0002-chromium-add-mingw-toolchain.patch
+++ b/mingw-w64-qt5-pdf/0002-chromium-add-mingw-toolchain.patch
@@ -106,7 +106,7 @@ index f88c691..03c1fba 100644
      # TODO(brettw) this list of defaults should probably be smaller, and
      # instead the targets that use the less common ones (e.g. wininet or
      # winspool) should include those explicitly.
-@@ -215,6 +215,31 @@ config("default_libs") {
+@@ -215,6 +215,30 @@ config("default_libs") {
          "ole32.lib",
        ]
      }
@@ -131,7 +131,6 @@ index f88c691..03c1fba 100644
 +      "winmm",
 +      "winspool",
 +      "ws2_32",
-+      "delayimp",
 +      "kernel32",
 +      "ole32",
 +    ]

--- a/mingw-w64-qt5-pdf/PKGBUILD
+++ b/mingw-w64-qt5-pdf/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
 pkgver=5.15.19
-pkgrel=1
+pkgrel=2
 pkgdesc='Qt5 PDF module'
 arch=(any)
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -42,7 +42,7 @@ source=("https://download.qt.io/archive/qt/${pkgver%.*}/${pkgver}/submodules/${_
         0201-gn-mingw-fixes.patch)
 sha256sums=('06627d8c6f10e06c25b42a7e88a6c61b4afc255914ca1a55bc72909899d36c2b'
             '3ecb09b542dde54d517983e520c16489b83b8a1ece056f2ad98e038106573dd2'
-            '2cfc166befe02e810549bc142f5bd8763979fc3d319d9bd46606fe2541d78507'
+            '1d6771597a02870ca40bc3c638a9781b48cd375de2d000027af670277edc526a'
             '8513924be7b0efc69a3d125839921d4011cb81ddb7e839d5232032c0915dcf1a'
             'ea89b376d412d8923cbab02aa38ffcf8e35dc94bb13a1cfdcd13bc4b469fc714')
 


### PR DESCRIPTION
It's empty on MinGW-w64.