### PR TITLE
v8: don't link to delayimp

### DIFF
--- a/mingw-w64-v8/001-add-mingw-toolchain.patch
+++ b/mingw-w64-v8/001-add-mingw-toolchain.patch
@@ -53,7 +53,7 @@ diff -ruN --ex build-repo/config/BUILD.gn build-repo-check/config/BUILD.gn
 -        "delayimp.lib",
 -        "kernel32.lib",
 -        "ole32.lib",
-+        "delayimp",
++        # "delayimp", # delayimp is not required for MinGW-w64.
 +        "kernel32",
 +        "ole32",
        ]

--- a/mingw-w64-v8/PKGBUILD
+++ b/mingw-w64-v8/PKGBUILD
@@ -5,7 +5,7 @@ _realname=v8
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=14.6.202.26
-pkgrel=3
+pkgrel=4
 pkgdesc="Fast and modern Javascript engine (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -71,7 +71,7 @@ sha256sums=('9967736b8381fdf34de72c3f84eebbdb30a867cb94d9a8ff6993504549cc65b5'
             '81daaa3fe38b4b5569a18bff4daf06dea57e46fb1fd3b4930f9f9c423243c7b5'
             '9c40290088cf1e8845fc7f86ed7c25930e74d0454affb892dbc7b236d276331c'
             'be0417df9753bf1dea6b5bb0ee81ffc1352d94a03dffcc3a9b0012d663ae11c2'
-            '04ccd7b9ff3064bd74d4e521facadf71cdc09c8304fe58cdcf52901a345500da'
+            '41712de403dc412e4c2d75736d078f2907e811d8d455d9c47dfa6c3aa04cce61'
             'ebd7b8e2b91e02879cb6c83154cb276be2a820f939b6d166e98b39c175b0eb51'
             '274d4cfc5a8a4f99699e67fed36565f315dd3bc0d1335bbf5070ba7052d99541'
             'aa7255002773aa3944027e0aab19627eee089c2ec3893713c8c7ff082e214553'


### PR DESCRIPTION
It's empty on MinGW-w64