### PR TITLE
nodejs: don't link to delayimp

### DIFF
--- a/mingw-w64-nodejs/0103-node-gyp-support-mingw-toolchain.patch
+++ b/mingw-w64-nodejs/0103-node-gyp-support-mingw-toolchain.patch
@@ -41,7 +41,7 @@ index b4ac369a..4f866859 100644
 +          '-loleaut32',
 +          '-luuid',
 +          '-lodbc32',
-+          '-ldelayimp',
++          # '-ldelayimp', # delayimp is not required for MinGW-w64.
 +          '-lnode'
          ],
          'msvs_disabled_warnings': [

--- a/mingw-w64-nodejs/PKGBUILD
+++ b/mingw-w64-nodejs/PKGBUILD
@@ -9,7 +9,7 @@ _realname=nodejs
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=24.20.0
-pkgrel=1
+pkgrel=2
 pkgdesc="An open-source, cross-platform JavaScript runtime environment (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -88,7 +88,7 @@ sha256sums=('2732fc3f588dd335cd6779c06864f7cd424bb1b5ff9a1743059a66c54f9ca4a1'
             'f3f3b2e8a8aecac06e959bd4d107b5e1955f48f6065c1757748f10c15d763130'
             '87e1904252f333c5bd1d059055a4a8b332404c3f739ed79ed8e60dc3b4728fe8'
             '18ca0c99da6761aeba3b2e8b6fa23787d7d3114e1798fecd9037e9a7a8bc93c1'
-            'ff8fb38df5f6b49598397a93e1e2c53271ea3f4fdc10d2b5aa75b05f283652c9'
+            'ad6d506ee0844812a54c16017108b895fb537bc62c14558e40c5f25d76637026'
             'd4ee69098fc1d00b960ceef3a9affaa4c5a1f9d75d004ba8389889f6b2d89c3d'
             '492758c11d287d88ea035d84f5ab3eb0dc76da0b8552f6ad13c4cd89597f4183'
             '03662d63d260aca7c97b5671d6905f7c236c91eb7a0585109c6c9ad63f1e94cc'


### PR DESCRIPTION
It's empty on MinGW-w64