### PR TITLE
crt: disable -fstack-protector-strong to avoid link failures

### DIFF
--- a/mingw-w64-crt/PKGBUILD
+++ b/mingw-w64-crt/PKGBUILD
@@ -4,7 +4,7 @@ _realname=crt
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=14.0.0.r353.g6df76fa52
-pkgrel=1
+pkgrel=2
 _commit='6df76fa527c36e770217ddd763adaaf37bd2887f'
 pkgdesc='MinGW-w64 CRT for Windows (mingw-w64)'
 arch=('any')
@@ -49,6 +49,8 @@ build() {
 
   CFLAGS="${CFLAGS//-Wp,-D__USE_MINGW_ANSI_STDIO=1/}"
   CXXFLAGS="${CXXFLAGS//-Wp,-D__USE_MINGW_ANSI_STDIO=1/}"
+  CFLAGS="${CFLAGS//-fstack-protector-strong/}"
+  CXXFLAGS="${CXXFLAGS//-fstack-protector-strong/}"
 
   # only clang+lld support this at the moment
   if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then


### PR DESCRIPTION
See also: https://github.com/msys2/MINGW-packages/pull/31309#issuecomment-5489474532