### PR TITLE
crt: disable -Wp,-D_FORTIFY_SOURCE=2

### DIFF
--- a/mingw-w64-crt/PKGBUILD
+++ b/mingw-w64-crt/PKGBUILD
@@ -4,7 +4,7 @@ _realname=crt
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=14.0.0.r353.g6df76fa52
-pkgrel=2
+pkgrel=3
 _commit='6df76fa527c36e770217ddd763adaaf37bd2887f'
 pkgdesc='MinGW-w64 CRT for Windows (mingw-w64)'
 arch=('any')
@@ -47,10 +47,21 @@ build() {
     ;;
   esac
 
+  # mingw-w64 will define __USE_MINGW_ANSI_STDIO itself on demand.
   CFLAGS="${CFLAGS//-Wp,-D__USE_MINGW_ANSI_STDIO=1/}"
   CXXFLAGS="${CXXFLAGS//-Wp,-D__USE_MINGW_ANSI_STDIO=1/}"
+
+  # This will require another `-lmsvcrt` after the last `-lmingwex`, which breaks Rust packages
+  # See also: https://github.com/msys2/MINGW-packages/pull/31309#issuecomment-5489549886
+  # Might can be removed after Rust is patched.
   CFLAGS="${CFLAGS//-fstack-protector-strong/}"
   CXXFLAGS="${CXXFLAGS//-fstack-protector-strong/}"
+
+  # This currently causes Clang to compile `__memcpy_chk` as infinite loop.
+  # See also: https://github.com/msys2/MINGW-packages/pull/31309#issuecomment-5505514064
+  # Might can be removed after mingw-w64 fixes this.
+  CFLAGS="${CFLAGS//-Wp,-D_FORTIFY_SOURCE=2/}"
+  CXXFLAGS="${CXXFLAGS//-Wp,-D_FORTIFY_SOURCE=2/}"
 
   # only clang+lld support this at the moment
   if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then


### PR DESCRIPTION
This is a hotfix for the miscompilation of Clang for __memcpy_chk. Likely should be fixed in mingw-w64 itself later.