### PR TITLE
new package: agar

### DIFF
--- a/mingw-w64-agar/01_mk_gen_includes.patch
+++ b/mingw-w64-agar/01_mk_gen_includes.patch
@@ -1,0 +1,11 @@
+--- a/mk/gen-includes.pl
++++ b/mk/gen-includes.pl
+@@ -33,7 +33,7 @@ ($$)
+ 			next;
+ 		}
+ 		if ($ent =~ /\.h$/) {
+-			my @o = readpipe("perl mk/gen-declspecs.pl '$file'");
++			my @o = readpipe("perl mk/gen-declspecs.pl \"$file\"");
+ 			if ($? != 0) {
+ 				print STDERR "gen-declspecs.pl failed\n";
+ 				exit(1);

--- a/mingw-w64-agar/PKGBUILD
+++ b/mingw-w64-agar/PKGBUILD
@@ -1,0 +1,77 @@
+# Maintainer: <open>
+# Contributor: Brian Allen <blallen@users.sourceforge.net>
+# Contributor: Simon Sobisch <simonsobisch@gnu.org>
+
+_realname=agar
+pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
+pkgver=1.7.1
+pkgrel=1
+pkgdesc="LibAgar cross-plattform GUI system"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url="https://libagar.org/"
+license=('spdx:BSD-2-Clause')
+
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-SDL2"
+  "${MINGW_PACKAGE_PREFIX}-freetype"
+  "${MINGW_PACKAGE_PREFIX}-fontconfig"
+  "${MINGW_PACKAGE_PREFIX}-libpng"
+  "${MINGW_PACKAGE_PREFIX}-zlib"
+  "${MINGW_PACKAGE_PREFIX}-bzip2"
+)
+
+makedepends=(
+  # "${MINGW_PACKAGE_PREFIX}-gcc"
+  # "${MINGW_PACKAGE_PREFIX}-binutils"
+  "${MINGW_PACKAGE_PREFIX}-pkgconf"
+  'make'
+)
+
+source=("https://stable.hypertriton.com/${_realname}/${_realname}-${pkgver}.tar.gz"{,.asc}
+        "01_mk_gen_includes.patch")
+sha256sums=('d1eb994c8262cd70df1d4d9462c5453089db5dc815d01b5767508c2923a5965c'
+            'SKIP'
+            '9b143138fc2c3987e763364be8cf04242bfcd9f2e13b0c63437c8714b4b58c6a')
+validpgpkeys=('3402651BD9445550FC76094010BCF281E7EEBFDF')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -p1 -i "${srcdir}/01_mk_gen_includes.patch"
+}
+
+build() {
+  mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
+
+  # note: this build system uses perl which raises locale warnings,
+  #       we drop those by explicit LANG settings;
+  #       bindir with trailing / needs to be set as this build system defaults
+  #       to prefix/bin - and does a direct "install" of files as "bin"
+  LANG=C \
+  ${srcdir}/${_realname}-${pkgver}/configure \
+    --srcdir=${srcdir}/${_realname}-${pkgver} \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --bindir=${MINGW_PREFIX}/bin/ \
+    --mandir=${MINGW_PREFIX}/share/man/ \
+    --with-freetype \
+    --with-fontconfig \
+    --with-png \
+    --with-sdl2
+
+  make depend all
+}
+
+package() {
+  cd "${srcdir}/build-${MSYSTEM}"
+  # for some reason parallel install always fail...
+  make --jobs=1 DESTDIR="${pkgdir}" install
+  
+  # copy license files and docs from source to expected places
+  cd "${srcdir}/${_realname}-${pkgver}"
+  install -d "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
+  install -p -m644 LICENSE OFL.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
+
+  install -d "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"
+  install -p -m644 README.md "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"
+}

--- a/mingw-w64-agar/PKGBUILD
+++ b/mingw-w64-agar/PKGBUILD
@@ -27,8 +27,10 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-pkgconf"
   'make'
 )
-
-source=("https://stable.hypertriton.com/${_realname}/${_realname}-${pkgver}.tar.gz"{,.asc}
+# main URL broken at time of PKGBUID - use slow mirror instead
+# download_url="https://stable.hypertriton.com/${_realname}/${_realname}-${pkgver}.tar.gz"
+download_url="https://master.dl.sourceforge.net/project/${_realname}/${_realname}/${pkgver}/${_realname}-${pkgver}.tar.gz"
+source=("${download_url}"{,.asc}
         "01_mk_gen_includes.patch")
 sha256sums=('d1eb994c8262cd70df1d4d9462c5453089db5dc815d01b5767508c2923a5965c'
             'SKIP'

--- a/mingw-w64-agar/PKGBUILD
+++ b/mingw-w64-agar/PKGBUILD
@@ -22,6 +22,7 @@ depends=(
 )
 
 makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
   "${MINGW_PACKAGE_PREFIX}-pkgconf"
   "${MINGW_PACKAGE_PREFIX}-perl"
   'make'

--- a/mingw-w64-agar/PKGBUILD
+++ b/mingw-w64-agar/PKGBUILD
@@ -22,9 +22,8 @@ depends=(
 )
 
 makedepends=(
-  # "${MINGW_PACKAGE_PREFIX}-gcc"
-  # "${MINGW_PACKAGE_PREFIX}-binutils"
   "${MINGW_PACKAGE_PREFIX}-pkgconf"
+  "${MINGW_PACKAGE_PREFIX}-perl"
   'make'
 )
 # main URL broken at time of PKGBUID - use slow mirror instead


### PR DESCRIPTION
side note: does not build on mingw32 any more because of missing dependencies SDL2 and fontconfig,
tested with an application that uses agar, sdl2, fontconfig under ucrt64