### PR TITLE
arpack: Fix CMake module if parpack is not installed

### DIFF
--- a/mingw-w64-arpack/0002-parpack-optional-installation.patch
+++ b/mingw-w64-arpack/0002-parpack-optional-installation.patch
@@ -1,0 +1,57 @@
+From f76b9267392f77716d205394108e1d9fe156c416 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Markus=20M=C3=BCtzel?= <markus.muetzel@gmx.de>
+Date: Sat, 5 Sep 2026 18:42:19 +0200
+Subject: [PATCH] parpack: optional installation
+
+In MSYS2, the parpack library is split into a separate package.
+
+Support using the CMake config files in the case where the parpack package is
+not installed.
+---
+ CMakeLists.txt                 | 7 ++++++-
+ cmake/arpackng-config.cmake.in | 4 ++++
+ 2 files changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d15ff0e..c46b63f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -860,7 +860,7 @@ install(FILES "${PROJECT_BINARY_DIR}/SRC/arpack${LIBSUFFIX}${ITF64SUFFIX}.pc"
+ 
+ if (MPI)
+   install(TARGETS parpack
+-      EXPORT arpackngTargets
++      EXPORT parpackngTargets
+       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+       LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+@@ -905,6 +905,11 @@ endif()
+ install(EXPORT arpackngTargets
+   DESTINATION "${ARPACK_INSTALL_CMAKEDIR}"
+ )
++if (MPI)
++  install(EXPORT parpackngTargets
++    DESTINATION "${ARPACK_INSTALL_CMAKEDIR}"
++)
++endif()
+ # Provide find_package for arpack-ng to users.
+ configure_file(cmake/arpackng-config.cmake.in "${PROJECT_BINARY_DIR}/arpackng-config.cmake" @ONLY)
+ configure_file(cmake/arpackng-config-version.cmake.in "${PROJECT_BINARY_DIR}/arpackng-config-version.cmake" @ONLY)
+diff --git a/cmake/arpackng-config.cmake.in b/cmake/arpackng-config.cmake.in
+index bafa3fe..72e5458 100644
+--- a/cmake/arpackng-config.cmake.in
++++ b/cmake/arpackng-config.cmake.in
+@@ -34,6 +34,10 @@ endif()
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/arpackngTargets.cmake")
+ 
++if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/parpackngTargets.cmake")
++  include("${CMAKE_CURRENT_LIST_DIR}/parpackngTargets.cmake")
++endif()
++
+ add_library(ARPACK::ARPACK ALIAS arpack)
+ if (TARGET parpack)
+ 	add_library(PARPACK::PARPACK ALIAS parpack)
+-- 
+2.51.0.windows.2
+

--- a/mingw-w64-arpack/PKGBUILD
+++ b/mingw-w64-arpack/PKGBUILD
@@ -10,7 +10,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}64"
          $([[ "${CARCH}" != "x86_64" ]] || echo "${MINGW_PACKAGE_PREFIX}-p${_realname}"))
 pkgver=3.9.1
-pkgrel=6
+pkgrel=7
 pkgdesc="Fortran77 subroutines designed to solve large scale eigenvalue problems (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -27,9 +27,11 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-fc"
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}-ng")
 options=('!buildflags')
 source=(https://github.com/opencollab/arpack-ng/archive/${pkgver}/${_realname}-${pkgver}.tar.gz
-        0001-parallel-tests.patch)
+        0001-parallel-tests.patch
+        0002-parpack-optional-installation.patch)
 sha256sums=('f6641deb07fa69165b7815de9008af3ea47eb39b2bb97521fbf74c97aba6e844'
-            '8bf923fb87d51bb313fc154d070941b932e74d6b7094e699fa84da6a913e3817')
+            '8bf923fb87d51bb313fc154d070941b932e74d6b7094e699fa84da6a913e3817'
+            '4247a559c9cf6c158107648534c56af756013dc4ba9bbdbd6741f0618084a849')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -44,7 +46,8 @@ prepare() {
   cd "${_realname}-ng-${pkgver}"
 
   apply_patch_with_msg \
-    0001-parallel-tests.patch
+    0001-parallel-tests.patch \
+    0002-parpack-optional-installation.patch
 }
 
 _build_arpack() {
@@ -163,10 +166,12 @@ package_arpack() {
     # separate files for PARPACK
     mkdir -p "${srcdir}"/${MSYSTEM}-PARPACK/bin
     mkdir -p "${srcdir}"/${MSYSTEM}-PARPACK/include/arpack
+    mkdir -p "${srcdir}"/${MSYSTEM}-PARPACK/lib/cmake/arpackng
     mkdir -p "${srcdir}"/${MSYSTEM}-PARPACK/lib/pkgconfig
     mv "${pkgdir}"${MINGW_PREFIX}/bin/libparpack* "${srcdir}"/${MSYSTEM}-PARPACK/bin/
     mv "${pkgdir}"${MINGW_PREFIX}/include/arpack/parpack* "${srcdir}"/${MSYSTEM}-PARPACK/include/arpack/
     mv "${pkgdir}"${MINGW_PREFIX}/lib/libparpack* "${srcdir}"/${MSYSTEM}-PARPACK/lib/
+    mv "${pkgdir}"${MINGW_PREFIX}/lib/cmake/arpackng/parpack* "${srcdir}"/${MSYSTEM}-PARPACK/lib/cmake/arpackng/
     mv "${pkgdir}"${MINGW_PREFIX}/lib/pkgconfig/parpack* "${srcdir}"/${MSYSTEM}-PARPACK/lib/pkgconfig/
   fi
 }


### PR DESCRIPTION
The parallel ARPACK libraries are split into a separate package in MSYS2. However, attempting to import the `arpack` CMake target while the `parpack` package is not installed results in an error.

Adapt the CMake module such that it gracefully creates the `arpack` import target (but not the `parpack` import target) if the `parpack` package is not installed.
