### PR TITLE
python-passagemath-modules: update optional dependencies

### DIFF
--- a/mingw-w64-passagemath-modules/PKGBUILD
+++ b/mingw-w64-passagemath-modules/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=10.8.11
-pkgrel=1
+pkgrel=2
 pkgdesc="passagemath: Vectors, matrices, tensors, vector spaces, affine spaces, modules and algebras, additive groups, quadratic forms, homology, coding theory, matroids (mingw-w64)"
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -37,14 +37,11 @@ optdepends=(
   # Optional dependencies which are not packaged yet are commented out.
   # "${MINGW_PACKAGE_PREFIX}-python-fpyll"
   "${MINGW_PACKAGE_PREFIX}-python-numpy"
-  # passagemath-flint is currently only available on non-clang builds.
-  $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-python-passagemath-flint")
-  # "${MINGW_PACKAGE_PREFIX}-python-passagemath-flint"
+  "${MINGW_PACKAGE_PREFIX}-python-passagemath-flint"
   # "${MINGW_PACKAGE_PREFIX}-python-passagemath-linbox"
-  # "${MINGW_PACKAGE_PREFIX}-python-passagemath-m4ri-m4rie"
+  "${MINGW_PACKAGE_PREFIX}-python-passagemath-m4ri-m4rie"
   # "${MINGW_PACKAGE_PREFIX}-python-passagemath-meataxe"
-  # passagemath-ntl is currently only available on non-clang builds.
-  $([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-python-passagemath-ntl")
+  "${MINGW_PACKAGE_PREFIX}-python-passagemath-ntl"
   # "${MINGW_PACKAGE_PREFIX}-python-passagemath-pari"
 )
 options=('!strip')


### PR DESCRIPTION
passagemath-flint and passagemath-ntl are no longer unavailable in Clang-based environments, and passagemath-m4ri-m4rie has been added, too.