### PR TITLE
libyuv: depends on libjpeg-turbo instead of libjpeg

### DIFF
--- a/mingw-w64-libyuv/PKGBUILD
+++ b/mingw-w64-libyuv/PKGBUILD
@@ -5,7 +5,7 @@ _realname=libyuv
 pkgbase=mingw-w64-${_realname}
 pkgname=(${MINGW_PACKAGE_PREFIX}-${_realname})
 pkgver=1924.r2921.644251f25
-pkgrel=1
+pkgrel=2
 pkgdesc="YUV conversion and scaling library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -15,8 +15,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cc"
              'git')
-depends=("${MINGW_PACKAGE_PREFIX}-cc-libs"
-         "${MINGW_PACKAGE_PREFIX}-libjpeg")
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-cc-libs"
+  "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
+)
 _commit="644251f252a84bf8ce91ff0aca86a9b16b069ab8"
 source=("${_realname}::git+https://chromium.googlesource.com/${_realname}/${_realname}#commit=${_commit}"
         "libyuv.pc.in"


### PR DESCRIPTION
libjpeg has been replaced by libjpeg-turbo since long ago.