### PR TITLE
dtc: update to 1.8.1

### DIFF
--- a/mingw-w64-dtc/001-remove-setup-py-install.patch
+++ b/mingw-w64-dtc/001-remove-setup-py-install.patch
@@ -1,8 +1,8 @@
 --- dtc-1.7.1/meson.build.orig	2024-08-17 10:22:16.000000000 +0200
 +++ dtc-1.7.1/meson.build	2024-11-05 08:39:01.183531100 +0100
-@@ -127,10 +127,6 @@
-   )
- endif
+@@ -123,10 +123,6 @@
+   meson.override_find_program(e.name(), e)
+ endforeach
  
 -if pylibfdt_enabled
 -  subdir('pylibfdt')

--- a/mingw-w64-dtc/002-legacy-swig.patch
+++ b/mingw-w64-dtc/002-legacy-swig.patch
@@ -1,0 +1,27 @@
+--- dtc-1.8.1/pylibfdt/libfdt.i	2026-09-04 00:48:36.595840800 +0000
++++ dtc-1.8.1/pylibfdt/libfdt.i	2026-09-04 00:48:39.045840800 +0000
+@@ -1136,7 +1136,7 @@
+ 	PyObject *buff;
+ 
+ 	if ($1) {
+-		resultobj = PyString_FromString(
++		resultobj = PyUnicode_FromString(
+ 			fdt_string(fdt1, fdt32_to_cpu($1->nameoff)));
+ 		buff = PyByteArray_FromStringAndSize(
+ 			(const char *)($1 + 1), fdt32_to_cpu($1->len));
+@@ -1169,13 +1169,13 @@
+         }
+         $1 = PyBytes_AsString($input);
+     %#else
+-        $1 = PyString_AsString($input);   /* char *str */
++        $1 = PyBytes_AsString($input);   /* char *str */
+     %#endif
+ }
+ 
+ /* typemaps used for fdt_next_node() */
+ %typemap(in, numinputs=1) int *depth (int depth) {
+-   depth = (int) PyInt_AsLong($input);
++   depth = (int) PyLong_AsLong($input);
+    $1 = &depth;
+ }
+ 

--- a/mingw-w64-dtc/PKGBUILD
+++ b/mingw-w64-dtc/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=dtc
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.7.2
-pkgrel=3
+pkgver=1.8.1
+pkgrel=1
 pkgdesc="Device Tree Compiler"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -15,25 +15,31 @@ msys2_references=(
 )
 license=('spdx:GPL-2.0-or-later')
 depends=("${MINGW_PACKAGE_PREFIX}-libyaml")
-makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
-             "${MINGW_PACKAGE_PREFIX}-meson"
-             "${MINGW_PACKAGE_PREFIX}-ninja"
-             "${MINGW_PACKAGE_PREFIX}-python"
-             "${MINGW_PACKAGE_PREFIX}-python-build"
-             "${MINGW_PACKAGE_PREFIX}-python-installer"
-             "${MINGW_PACKAGE_PREFIX}-python-setuptools"
-             "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm"
-             "${MINGW_PACKAGE_PREFIX}-swig")
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-meson"
+  "${MINGW_PACKAGE_PREFIX}-meson-python"
+  "${MINGW_PACKAGE_PREFIX}-ninja"
+  "${MINGW_PACKAGE_PREFIX}-python"
+  "${MINGW_PACKAGE_PREFIX}-python-build"
+  "${MINGW_PACKAGE_PREFIX}-python-installer"
+  "${MINGW_PACKAGE_PREFIX}-python-setuptools"
+  "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm"
+  "${MINGW_PACKAGE_PREFIX}-swig"
+)
 source=("https://git.kernel.org/pub/scm/utils/dtc/dtc.git/snapshot/${_realname}-${pkgver}.tar.gz"
-        "0001-remove-setup-py-install.patch")
-sha256sums=('8f1486962f093f28a2f79f01c1fd82f144ef640ceabe555536d43362212ceb7c'
-            '72ada7074ec472f8d06a05a1d09300a490436f8665d7a4a600d6bd56fb0d7d30')
+        "001-remove-setup-py-install.patch"
+        "002-legacy-swig.patch")
+sha256sums=('74b50bb19134f6562490afea53e59953dd6c4afb17e5ccb60be32221262d3390'
+            '0246aaace4ed0450c2f136515161bed62a7dc32e436a06fb99120497fae6b491'
+            '96c1d1383927d841529babb06ef19588dfee995739df18c56d08f4ebc9eed4d3')
 
 prepare() {
   cd "${_realname}-${pkgver}"
 
   # conflicts with the wheel build and uses deprecated setuptools install
-  patch -Np1 -i "${srcdir}/0001-remove-setup-py-install.patch"
+  patch -Nbp1 -i "${srcdir}/001-remove-setup-py-install.patch"
+  patch -Nbp1 -i "${srcdir}/002-legacy-swig.patch"
 }
 
 build() {
@@ -49,9 +55,11 @@ build() {
 
   ${MINGW_PREFIX}/bin/meson compile -C "build-${MSYSTEM}"
 
+  # tell meson-python backend to also skip tests during the wheel build
   LDFLAGS+=" -L$(cygpath -wm "${srcdir}/build-${MSYSTEM}/libfdt")" \
   python -m build --wheel --skip-dependency-check --no-isolation \
-  "${_realname}-${pkgver}"
+    -C setup-args="-Dtests=false" \
+    "${_realname}-${pkgver}"
 }
 
 package() {

--- a/mingw-w64-dtc/PKGBUILD
+++ b/mingw-w64-dtc/PKGBUILD
@@ -28,6 +28,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm"
   "${MINGW_PACKAGE_PREFIX}-swig"
 )
+options=('!strip')
 source=(
   "https://git.kernel.org/pub/scm/utils/dtc/dtc.git/snapshot/${_realname}-${pkgver}.tar.gz"
   '001-remove-setup-py-install.patch'

--- a/mingw-w64-dtc/PKGBUILD
+++ b/mingw-w64-dtc/PKGBUILD
@@ -1,17 +1,18 @@
 # Maintainer: Marc-André Lureau <marcandre.lureau@redhat.com>
 
 _realname=dtc
-pkgbase=mingw-w64-${_realname}
+pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.8.1
 pkgrel=1
-pkgdesc="Device Tree Compiler"
+pkgdesc='Device Tree Compiler'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
-url="https://git.kernel.org/pub/scm/utils/dtc/dtc.git/"
+url='https://git.kernel.org/pub/scm/utils/dtc/dtc.git/'
 msys2_repository_url='https://git.kernel.org/pub/scm/utils/dtc/dtc.git'
 msys2_references=(
-  "cpe: cpe:2.3:a:dtc_project:dtc"
+  'anitya: 16911'
+  'cpe: cpe:2.3:a:dtc_project:dtc'
 )
 license=('spdx:GPL-2.0-or-later')
 depends=("${MINGW_PACKAGE_PREFIX}-libyaml")
@@ -27,9 +28,11 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-setuptools-scm"
   "${MINGW_PACKAGE_PREFIX}-swig"
 )
-source=("https://git.kernel.org/pub/scm/utils/dtc/dtc.git/snapshot/${_realname}-${pkgver}.tar.gz"
-        "001-remove-setup-py-install.patch"
-        "002-legacy-swig.patch")
+source=(
+  "https://git.kernel.org/pub/scm/utils/dtc/dtc.git/snapshot/${_realname}-${pkgver}.tar.gz"
+  '001-remove-setup-py-install.patch'
+  '002-legacy-swig.patch'
+)
 sha256sums=('74b50bb19134f6562490afea53e59953dd6c4afb17e5ccb60be32221262d3390'
             '0246aaace4ed0450c2f136515161bed62a7dc32e436a06fb99120497fae6b491'
             '96c1d1383927d841529babb06ef19588dfee995739df18c56d08f4ebc9eed4d3')
@@ -43,17 +46,17 @@ prepare() {
 }
 
 build() {
-  export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}
+  export SETUPTOOLS_SCM_PRETEND_VERSION="${pkgver}"
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-  ${MINGW_PREFIX}/bin/meson setup \
+  "${MINGW_PREFIX}/bin/meson" setup \
     --prefix="${MINGW_PREFIX}" \
     -Dtests=false \
     -Dtools=true \
     "build-${MSYSTEM}" \
     "${_realname}-${pkgver}"
 
-  ${MINGW_PREFIX}/bin/meson compile -C "build-${MSYSTEM}"
+  "${MINGW_PREFIX}/bin/meson" compile -C "build-${MSYSTEM}"
 
   # tell meson-python backend to also skip tests during the wheel build
   LDFLAGS+=" -L$(cygpath -wm "${srcdir}/build-${MSYSTEM}/libfdt")" \
@@ -63,12 +66,14 @@ build() {
 }
 
 package() {
-  ${MINGW_PREFIX}/bin/meson install -C "build-${MSYSTEM}" --destdir "${pkgdir}"
+  "${MINGW_PREFIX}/bin/meson" install -C "build-${MSYSTEM}" --destdir "${pkgdir}"
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-    python -m installer --prefix=${MINGW_PREFIX} \
+    python -m installer --prefix="${MINGW_PREFIX}" \
     --destdir="${pkgdir}" \
-    "${_realname}-${pkgver}"/dist/*.whl
+    "${_realname}-${pkgver}/dist/"*.whl
 
-  install -Dm644 "${srcdir}/${_realname}-${pkgver}"/GPL "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname}/GPL
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  install -Dm644 GPL "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/GPL"
 }


### PR DESCRIPTION
Latest SWIG dropped Python 2 support but `dtc` needs to catch up on this.

Currently it needs `meson-python` to build. MSYS package is simpler, so it just works, but here I needed to add `-Dtests=false` not only to `meson setup` but `python -m build` as well.