### PR TITLE
python-docutils: update to 0.23

### DIFF
--- a/mingw-w64-python-docutils/PKGBUILD
+++ b/mingw-w64-python-docutils/PKGBUILD
@@ -1,60 +1,65 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 # Contributor: Ray Donnelly <mingw.android@gmail.com>
 
-_realname=docutils
-pkgbase=mingw-w64-python-${_realname}
+_realname='docutils'
+pkgbase="mingw-w64-python-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=0.23
 pkgrel=1
-pkgdesc="Set of tools for processing plaintext docs into formats such as HTML, XML, or LaTeX (mingw-w64)"
+pkgdesc='Set of tools for processing plaintext docs into formats such as HTML, XML, or LaTeX (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
-url="https://docutils.sourceforge.io/"
+url='https://pypi.org/project/docutils/'
+msys2_repository_url='https://sourceforge.net/p/docutils/code'
+msys2_documentation_url='https://docutils.sourceforge.io/docs/index.html'
 msys2_changelog_url='https://docutils.sourceforge.io/HISTORY.html'
 msys2_references=(
+  'anitya: 3849'
   'archlinux: python-docutils'
   'gentoo: dev-python/docutils'
   'purl: pkg:pypi/docutils'
 )
-license=('Public Domain' AND 'spdx:BSD-2-Clause AND ZPL-2.1 AND GPL-3.0-or-later')
-depends=("${MINGW_PACKAGE_PREFIX}-python")
+license=('Public Domain AND spdx:BSD-2-Clause AND ZPL-2.1 AND GPL-3.0-or-later')
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-python"
+)
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-build"
-  "${MINGW_PACKAGE_PREFIX}-python-installer"
   "${MINGW_PACKAGE_PREFIX}-python-flit-core"
+  "${MINGW_PACKAGE_PREFIX}-python-installer"
 )
-options=(!strip)
-source=(https://pypi.io/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz)
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+noextract=("${_realname}-${pkgver}.tar.gz")
 sha256sums=('746f5060322511280a1e50eb76846ed6bf2342984b2ac04dc42caa1a8d78799e')
-noextract=(${_realname}-${pkgver}.tar.gz)
 
 prepare() {
-  tar -xzf "${srcdir}"/${_realname}-${pkgver}.tar.gz -C "${srcdir}" || true
+  tar -xzf "${_realname}-${pkgver}.tar.gz" || true
 
   rm -rf "python-build-${MSYSTEM}"
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}"
 }
 
 build() {
-  cd "${srcdir}/python-build-${MSYSTEM}"
+  cd "python-build-${MSYSTEM}"
 
-  ${MINGW_PREFIX}/bin/python -m build --wheel --skip-dependency-check --no-isolation
+  "${MINGW_PREFIX}/bin/python" -m build --wheel --skip-dependency-check --no-isolation
 }
 
 check() {
-  cd "${srcdir}/python-build-${MSYSTEM}"
+  cd "python-build-${MSYSTEM}"
 
-  PYTHONUTF8=1 PYTHONPATH="$PWD/build/python/" ${MINGW_PREFIX}/bin/python test/alltests.py
+  PYTHONUTF8=1 PYTHONPATH="${PWD}/build/python/" "${MINGW_PREFIX}/bin/python" test/alltests.py
 }
 
 package() {
-  cd "${srcdir}/python-build-${MSYSTEM}"
+  cd "python-build-${MSYSTEM}"
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-    ${MINGW_PREFIX}/bin/python -m installer --prefix=${MINGW_PREFIX} \
+    "${MINGW_PREFIX}/bin/python" -m installer --prefix="${MINGW_PREFIX}" \
     --destdir="${pkgdir}" dist/*.whl
 
   # setup license
-  install -D -m644 COPYING.rst "${pkgdir}"${MINGW_PREFIX}/share/licenses/python-${_realname}/COPYING.txt
-  install -D -m644 licenses/*.{rst,txt} "${pkgdir}"${MINGW_PREFIX}/share/licenses/python-${_realname}/
+  install -Dm644 COPYING.rst "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/COPYING.txt"
+  install -Dm644 licenses/*.{rst,txt} -t "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/"
 }

--- a/mingw-w64-python-docutils/PKGBUILD
+++ b/mingw-w64-python-docutils/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=docutils
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=0.22.4
+pkgver=0.23
 pkgrel=1
 pkgdesc="Set of tools for processing plaintext docs into formats such as HTML, XML, or LaTeX (mingw-w64)"
 arch=('any')
@@ -25,7 +25,7 @@ makedepends=(
 )
 options=(!strip)
 source=(https://pypi.io/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz)
-sha256sums=('4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968')
+sha256sums=('746f5060322511280a1e50eb76846ed6bf2342984b2ac04dc42caa1a8d78799e')
 noextract=(${_realname}-${pkgver}.tar.gz)
 
 prepare() {


### PR DESCRIPTION
CI logs:

```text
  Here is what it failed.
  myst-parser 5.1.0 has requirement docutils<0.23,>=0.20, but you have docutils 0.23.
  sphinx 9.1.0 has requirement docutils<0.23,>=0.21, but you have docutils 0.23.
  sphinx-rtd-theme 3.1.0 has requirement docutils<0.23,>0.18, but you have docutils 0.23.
```