### PR TITLE
python-poetry-core: update to 2.4.1

### DIFF
--- a/mingw-w64-python-poetry-core/PKGBUILD
+++ b/mingw-w64-python-poetry-core/PKGBUILD
@@ -1,21 +1,24 @@
 # Maintainer: @naveen521kk on Github Naveen M K <naveen521kk@gmail.com>
 
-_realname=poetry-core
-pkgbase=mingw-w64-python-${_realname}
+_realname='poetry-core'
+_pyname="${_realname/-/_}"
+pkgbase="mingw-w64-python-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=2.4.1
 pkgrel=1
-pkgdesc="Poetry PEP 517 Build Backend (mingw-w64)"
+pkgdesc='Poetry PEP 517 Build Backend (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
-url="https://github.com/python-poetry/poetry-core"
-msys2_repository_url="https://github.com/python-poetry/poetry-core"
+url='https://github.com/python-poetry/poetry-core'
+msys2_repository_url='https://github.com/python-poetry/poetry-core'
 msys2_references=(
   'archlinux: python-poetry-core'
   'purl: pkg:pypi/poetry-core'
 )
 license=('spdx:MIT')
-depends=("${MINGW_PACKAGE_PREFIX}-python")
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-python"
+)
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-python-build"
   "${MINGW_PACKAGE_PREFIX}-python-installer"
@@ -26,14 +29,14 @@ checkdepends=(
   "${MINGW_PACKAGE_PREFIX}-python-pytest-mock"
   "${MINGW_PACKAGE_PREFIX}-python-setuptools"
   "${MINGW_PACKAGE_PREFIX}-python-tomli-w"
-  "${MINGW_PACKAGE_PREFIX}-python-virtualenv"
   "${MINGW_PACKAGE_PREFIX}-python-trove-classifiers"
+  "${MINGW_PACKAGE_PREFIX}-python-virtualenv"
 )
-source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
+source=("https://pypi.org/packages/source/${_pyname::1}/${_pyname}/_pyname-${pkgver}.tar.gz")
 sha256sums=('89dceb6c10e9c6d8650a16183400e3c9ff9ddee13b0a81023b5575334a2b3744')
 
 build() {
-  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+  cp -r "_pyname-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
 
   python -m build --wheel --skip-dependency-check --no-isolation
 }
@@ -49,7 +52,7 @@ package() {
   cd "python-build-${MSYSTEM}"
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-    python -m installer --prefix=${MINGW_PREFIX} --destdir="${pkgdir}" dist/*.whl
+    python -m installer --prefix="${MINGW_PREFIX}" --destdir="${pkgdir}" dist/*.whl
 
-  install -D -m644 LICENSE "${pkgdir}${MINGW_PREFIX}"/share/licenses/python-${_realname}/LICENSE
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python-${_realname}/LICENSE"
 }

--- a/mingw-w64-python-poetry-core/PKGBUILD
+++ b/mingw-w64-python-poetry-core/PKGBUILD
@@ -11,8 +11,11 @@ arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://github.com/python-poetry/poetry-core'
 msys2_repository_url='https://github.com/python-poetry/poetry-core'
+msys2_changelog_url='https://github.com/python-poetry/poetry-core/blob/main/CHANGELOG.md'
 msys2_references=(
+  'anitya: 71155'
   'archlinux: python-poetry-core'
+  'gentoo: dev-python/poetry-core'
   'purl: pkg:pypi/poetry-core'
 )
 license=('spdx:MIT')

--- a/mingw-w64-python-poetry-core/PKGBUILD
+++ b/mingw-w64-python-poetry-core/PKGBUILD
@@ -39,7 +39,7 @@ source=("https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${
 sha256sums=('89dceb6c10e9c6d8650a16183400e3c9ff9ddee13b0a81023b5575334a2b3744')
 
 build() {
-  cp -r "_pyname-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+  cp -r "${_pyname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
 
   python -m build --wheel --skip-dependency-check --no-isolation
 }

--- a/mingw-w64-python-poetry-core/PKGBUILD
+++ b/mingw-w64-python-poetry-core/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=poetry-core
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
-pkgver=2.4.0
+pkgver=2.4.1
 pkgrel=1
 pkgdesc="Poetry PEP 517 Build Backend (mingw-w64)"
 arch=('any')
@@ -30,7 +30,7 @@ checkdepends=(
   "${MINGW_PACKAGE_PREFIX}-python-trove-classifiers"
 )
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('4e8c7496cf797998ffc493f2e23eba4b038c894c08eadacdcdf688945de6b43a')
+sha256sums=('89dceb6c10e9c6d8650a16183400e3c9ff9ddee13b0a81023b5575334a2b3744')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/mingw-w64-python-poetry-core/PKGBUILD
+++ b/mingw-w64-python-poetry-core/PKGBUILD
@@ -35,7 +35,7 @@ checkdepends=(
   "${MINGW_PACKAGE_PREFIX}-python-trove-classifiers"
   "${MINGW_PACKAGE_PREFIX}-python-virtualenv"
 )
-source=("https://pypi.org/packages/source/${_pyname::1}/${_pyname}/_pyname-${pkgver}.tar.gz")
+source=("https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${pkgver}.tar.gz")
 sha256sums=('89dceb6c10e9c6d8650a16183400e3c9ff9ddee13b0a81023b5575334a2b3744')
 
 build() {


### PR DESCRIPTION
CI logs:

```text
poetry 2.4.1 has requirement poetry-core==2.4.0, but you have poetry-core 2.4.1.
```

It's waiting time since `poetry` locked on older version even on `2.3.4` version:

https://github.com/python-poetry/poetry/blob/2.4.3/pyproject.toml#L7