### PR TITLE
python-chardet: update to 7.6.0

### DIFF
--- a/mingw-w64-python-chardet/PKGBUILD
+++ b/mingw-w64-python-chardet/PKGBUILD
@@ -4,7 +4,7 @@ _realname=chardet
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgdesc="Python module for character encoding auto-detection (mingw-w64)"
-pkgver=7.4.3
+pkgver=7.6.0
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -24,7 +24,7 @@ makedepends=(
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python-pytest")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('cc1d4eb92a4ec1c2df3b490836ffa46922e599d34ce0bb75cf41fd2bf6303d56')
+sha256sums=('93d9df6089ded42ed1fe9f57e272c0b74bd0464d45c0c7d50f09f26f31105c3c')
 
 build() {
   cp -r "${_realname}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"


### PR DESCRIPTION
Update chardet from 7.4.3 to 7.6.0.

This includes upstream fixes from 7.5.0, 7.5.1, and 7.6.0. In particular, 7.6.0 fixes false UTF-7 detection of ASCII data.

The previously encountered UTF-7 misdetection with chardet 7.4.3 was reproduced and no longer occurs with 7.6.0.

Testing:

* Built and installed successfully with `makepkg-mingw --cleanbuild --syncdeps --force --install --noconfirm`
* Verified chardet 7.6.0
* Re-tested the previously failing input
