### PR TITLE
msmpi: Use correct type of strlen arguments in replaced functions

### DIFF
--- a/mingw-w64-msmpi/PKGBUILD
+++ b/mingw-w64-msmpi/PKGBUILD
@@ -9,7 +9,7 @@ _realname=msmpi
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=10.1.1
-pkgrel=22
+pkgrel=23
 pkgdesc="Microsoft MPI SDK (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -50,7 +50,7 @@ sha256sums=('ed828846d5086c7fd503a8a0e52bf6245132c187bbbf0f5ec8fe006032f62cef'
             '7e8be35bd1286d671dd3d47ffa1c3eaca09bf0cb6286f2474dc0eb71ea976d75'
             '90c90a29ed4084dccf227920f1600ebde7d33c02f308551c764bd19d36b0d7fc'
             '05caa0fa05b1a6afeae62590758e2543c5f59fe998d4b55cf5b4db771e65f515'
-            '07c8e199fc4d4725f4b93a5a9f4c6ac68aa0390ef9208b7b3dcc49347bda38b4'
+            '1df31d57f8e8d423cd1d8fd9f4598f5d8467d56fbb5b43317d796ac0efecb71d'
             'c4e4d85d01d1ef052596589d100920bd53523eb7006f66c39ddc1d36acaa242c'
             'ea8203492942fa900c4946741ad88af8957c4d058e06eb618ffae0e5e967b71b'
             '9483053c0f3ce15d850f69565f2b4e53630cee75073c27432cd08ecc596a57d9'

--- a/mingw-w64-msmpi/msmpifec.c
+++ b/mingw-w64-msmpi/msmpifec.c
@@ -423,7 +423,7 @@ MSMPIF_API void
 mpi_comm_spawn_(const char *command, const char *argv_block, const int *maxprocs,
     const int *info, const int *root, const int *comm, int *intercomm,
     int array_of_errcodes[], int *ierr,
-    int d1, int d2)
+    size_t command_len, size_t argv_block_len)
 {
   char *cmd = NULL;
   char **argv = NULL;
@@ -434,7 +434,7 @@ mpi_comm_spawn_(const char *command, const char *argv_block, const int *maxprocs
      Trim and copy COMMAND
      --------------------------- */
   {
-    const char *p = command + d1 - 1;
+    const char *p = command + command_len - 1;
     while (p > command && *p == ' ')
       p--;
     int len = (int)(p - command + 1);
@@ -453,7 +453,7 @@ mpi_comm_spawn_(const char *command, const char *argv_block, const int *maxprocs
      Build ARGV array for C interface
      Fortran passes a flat block:
        argv_block = [entry0][entry1][entry2]...
-     Each entry is CHARACTER(d2)
+     Each entry is CHARACTER(argv_block_len)
      MS-MPI terminates when an entry is all blanks.
      --------------------------- */
   {
@@ -462,12 +462,12 @@ mpi_comm_spawn_(const char *command, const char *argv_block, const int *maxprocs
     /* Count entries until all-blank */
     for (argc = 0;; argc++)
     {
-      const char *end = p + d2 - 1;
+      const char *end = p + argv_block_len - 1;
       while (end > p && *end == ' ')
         end--;
       if (*end == ' ')  /* all blank */
         break;
-      p += d2;
+      p += argv_block_len;
     }
 
     argv = (char **)malloc((argc + 1) * sizeof(char *));
@@ -477,7 +477,7 @@ mpi_comm_spawn_(const char *command, const char *argv_block, const int *maxprocs
       goto cleanup;
     }
 
-    argv_storage = (char *)malloc(argc * (d2 + 1));
+    argv_storage = (char *)malloc(argc * (argv_block_len + 1));
     if (!argv_storage)
     {
       *ierr = MPI_ERR_NO_MEM;
@@ -486,13 +486,13 @@ mpi_comm_spawn_(const char *command, const char *argv_block, const int *maxprocs
 
     for (int i = 0; i < argc; i++)
     {
-      const char *src = argv_block + i * d2;
-      const char *end = src + d2 - 1;
+      const char *src = argv_block + i * argv_block_len;
+      const char *end = src + argv_block_len - 1;
       while (end > src && *end == ' ')
         end--;
       int len = (int)(end - src + 1);
 
-      char *dest = argv_storage + i * (d2 + 1);
+      char *dest = argv_storage + i * (argv_block_len + 1);
       memcpy(dest, src, len);
       dest[len] = '\0';
       argv[i] = dest;
@@ -522,7 +522,7 @@ mpi_comm_spawn_multiple_(const int *count,
     const char *commands_block, const char *argv_block, const int maxprocs[],
     const int infos[], const int *root, const int *comm, int *intercomm,
     int array_of_errcodes[], int *ierr,
-    int d2, int d3)
+    size_t commands_block_len, size_t argv_block_len)
 {
   char **commands = NULL;
   char *commands_storage = NULL;
@@ -534,7 +534,7 @@ mpi_comm_spawn_multiple_(const int *count,
      Build COMMANDS array
      Fortran passes flat block:
        commands_block = [cmd0][cmd1]...[cmdN-1]
-     Each entry is CHARACTER(d2)
+     Each entry is CHARACTER(commands_block_len)
      --------------------------- */
   {
     int asize = ncmd + 1; /* extra NULL terminator */
@@ -546,7 +546,7 @@ mpi_comm_spawn_multiple_(const int *count,
       goto cleanup;
     }
 
-    commands_storage = (char *)malloc(asize * (d2 + 1));
+    commands_storage = (char *)malloc(asize * (commands_block_len + 1));
     if (!commands_storage)
     {
       *ierr = MPI_ERR_NO_MEM;
@@ -555,13 +555,13 @@ mpi_comm_spawn_multiple_(const int *count,
 
     for (int i = 0; i < ncmd; i++)
     {
-      const char *src = commands_block + i * d2;
-      const char *end = src + d2 - 1;
+      const char *src = commands_block + i * commands_block_len;
+      const char *end = src + commands_block_len - 1;
       while (end > src && *end == ' ')
         end--;
       int len = (int)(end - src + 1);
 
-      char *dest = commands_storage + i * (d2 + 1);
+      char *dest = commands_storage + i * (commands_block_len + 1);
       memcpy(dest, src, len);
       dest[len] = '\0';
       commands[i] = dest;
@@ -574,10 +574,10 @@ mpi_comm_spawn_multiple_(const int *count,
   /* ---------------------------
      Build ARGV array-of-arrays
      Fortran passes a 2D block:
-       argv_block(k, i) with CHARACTER(d3)
+       argv_block(k, i) with CHARACTER(argv_block_len)
      laid out column-major:
-       row k starts at argv_block + k*d3
-       next arg for same command is + (*count)*d3
+       row k starts at argv_block + k*argv_block_len
+       next arg for same command is + (*count)*argv_block_len
      Each row is terminated by an all-blank entry.
      --------------------------- */
   {
@@ -597,20 +597,20 @@ mpi_comm_spawn_multiple_(const int *count,
 
     for (int k = 0; k < ncmd; k++)
     {
-      const char *p = argv_block + k * d3;
+      const char *p = argv_block + k * argv_block_len;
       int argc = 0;
 
       /* Count arguments until all-blank entry */
       for (;;)
       {
-        const char *end = p + d3 - 1;
+        const char *end = p + argv_block_len - 1;
         while (end > p && *end == ' ')
           end--;
         if (*end == ' ' && end == p)
           break; /* all blank => terminator */
 
         argc++;
-        p += ncmd * d3;
+        p += ncmd * argv_block_len;
       }
 
       /* Allocate pointers and storage for this command's args */
@@ -621,7 +621,7 @@ mpi_comm_spawn_multiple_(const int *count,
         goto cleanup;
       }
 
-      char *pdata = (char *)malloc(argc * (d3 + 1));
+      char *pdata = (char *)malloc(argc * (argv_block_len + 1));
       if (!pdata)
       {
         free(pargs);
@@ -633,21 +633,21 @@ mpi_comm_spawn_multiple_(const int *count,
       argv_storage[k] = pdata;
 
       /* Copy each argument, trimming and null-terminating */
-      p = argv_block + k * d3;
+      p = argv_block + k * argv_block_len;
       for (int i = 0; i < argc; i++)
       {
         const char *src = p;
-        const char *end = src + d3 - 1;
+        const char *end = src + argv_block_len - 1;
         while (end > src && *end == ' ')
           end--;
         int len = (int)(end - src + 1);
 
-        char *dest = pdata + i * (d3 + 1);
+        char *dest = pdata + i * (argv_block_len + 1);
         memcpy(dest, src, len);
         dest[len] = '\0';
 
         pargs[i] = dest;
-        p += ncmd * d3;
+        p += ncmd * argv_block_len;
       }
 
       pargs[argc] = NULL; /* terminate argv[k] */


### PR DESCRIPTION
Of course, I was going to find a new issue the day after merging #31265. 😖
Fortunately, it is entirely contained in the shim library and we don't need to rebuild all MPI packages again.

In GCC 8 or newer, the type of the trailing strlen arguments in the Fortran C ABI is `size_t` (not `int` like in previous versions).

That might be an issue with more functions in the Fortran interface of `msmpi.dll` that we do not replace in the shim library. Looking at `mpif.cpp` in the Microsoft-MPI repository, the following functions might be affected:
`mpi_get_processor_name_`, `mpi_get_library_version_`, `mpi_error_string_`, `mpi_close_port_`, `mpi_comm_accept_`, `mpi_comm_connect_`, `mpi_comm_spawn_`, `mpi_comm_spawn_multiple_`, `mpi_lookup_name_`, `mpi_open_port_`, `mpi_publish_name_`, `mpi_unpublish_name_`, `mpi_add_error_string_`, `mpi_comm_get_name_`, `mpi_comm_set_name_`, `mpi_type_get_name_`, `mpi_type_set_name_`, `mpi_win_get_name_`, `mpi_win_set_name_`, `mpi_info_delete_`, `mpi_info_get_`, `mpi_info_get_nthkey_`, `mpi_info_get_valuelen_`, `mpi_info_set_`, `mpi_pack_external_`, `mpi_pack_external_size_`, `mpi_unpack_external_`, `mpi_file_open_`, `mpi_file_delete_`, `mpi_file_set_view_`, `mpi_file_get_view_`, `mpi_register_datarep_`.

I haven't checked if any of these functions are actually used in any of the packages that are distributed by MSYS2. And I don't know how often those functions are used "in the wild".

In principle, it is possible to replace all (or some) of them like we do with the functions that use sentinel variables.
I don't know if it is worth the effort at this point though.

Additionally, the last commit to the Microsoft-MPI repository predates the latest binary release of `msmpi.dll` by Microsoft. So, maybe that issue has already been fixed in their internal sources that they used to build the latest version of `msmpi.dll`.

We could add replacements if we hear about actual issues from users.

Anyway, do that correctly at least for the functions that we replace.
