### PR TITLE
sonivox: update to 4.0.2

### DIFF
--- a/mingw-w64-sonivox/PKGBUILD
+++ b/mingw-w64-sonivox/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=sonivox
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=4.0.1
+pkgver=4.0.2
 pkgrel=1
 pkgdesc="Fork of the AOSP 'platform_external_sonivox' to use outside of Android (mingw-w64)"
 arch=('any')
@@ -22,9 +22,10 @@ makedepends=(
 )
 source=(
   "${_realname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz"
-  "https://www.ronimusic.com/sf2/Airfont_340.dls"  # soundfont required for testing...
+  "https://ftp.chasnah.com/soundfonts/Airfont_340.dls"  # soundfont required for testing...
+  # ronimusic.com not reliable anymore: https://github.com/EmbeddedSynth/sonivox/issues/25
 )
-sha256sums=('dabdbd54bd6ba8d5be995bd9ef504c2a34bdf654f41a389510c99043cfc237ca'
+sha256sums=('5c513d7a6fa0ebf61afd3b96da881e3014edf53acfb8d08a63dd853fca37c1fa'
             'beb3e39e3c9fc51ef4dff36fdd8db0361471a91d244c3ee78af90f6d3c783b04')
 
 prepare() {
@@ -48,8 +49,10 @@ build() {
     cmake \
       -GNinja \
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
-	  "${extra_config[@]}" \
-	  -DBUILD_SHARED_LIBS=OFF \
+      "${extra_config[@]}" \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DBUILD_TESTING=ON \
+      -DSOUNDFONT_TEST=ON \
       -S "${_realname}-${pkgver}" \
       -B build-${MSYSTEM}-static \
       -W no-dev
@@ -60,11 +63,11 @@ build() {
     cmake \
       -GNinja \
       -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
-	  "${extra_config[@]}" \
-	  -DBUILD_SHARED_LIBS=ON \
+      "${extra_config[@]}" \
+      -DBUILD_SHARED_LIBS=ON \
       -DCMAKE_DLL_NAME_WITH_SOVERSION=ON \
-	  -DBUILD_APPLICATION=OFF \
-	  -DBUILD_TESTING=OFF \
+      -DBUILD_APPLICATION=OFF \
+      -DBUILD_TESTING=OFF \
       -S "${_realname}-${pkgver}" \
       -B build-${MSYSTEM}-shared \
       -W no-dev


### PR DESCRIPTION
update sonivox to 4.0.2: https://github.com/EmbeddedSynth/sonivox/releases/tag/v4.0.2
update testing soundfont URI: https://github.com/EmbeddedSynth/sonivox/issues/25