### PR TITLE
fastfetch: update to 2.68.1

### DIFF
--- a/mingw-w64-fastfetch/PKGBUILD
+++ b/mingw-w64-fastfetch/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=fastfetch
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.67.1
+pkgver=2.68.1
 pkgrel=1
 pkgdesc="An actively maintained, feature-rich and performance oriented, neofetch like system information tool (mingw-w64)"
 arch=('any')
@@ -46,7 +46,7 @@ optdepends=(
 )
 source=("${url}/archive/${pkgver}/${_realname}-${pkgver}.tar.gz")
 noextract=("${_realname}-${pkgver}.tar.gz")
-sha256sums=('52489550d1fdeac8bde8b3442064e3bc78d28fda752a171dc46a6cd97454f237')
+sha256sums=('c268cfcd230cc7ed5447fb34ed21bf4977315c7104356a39388b6ba784ad11b0')
 
 prepare() {
   # Workaround for symlinks in archive, see <https://www.msys2.org/docs/symlinks/>.


### PR DESCRIPTION
Update fastfetch to 2.68.1.

Includes various new features, improvements, and bug fixes from upstream.
