### PR TITLE
python-flit: update to 4.0.2

### DIFF
--- a/mingw-w64-python-flit/PKGBUILD
+++ b/mingw-w64-python-flit/PKGBUILD
@@ -11,7 +11,11 @@ arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://flit.pypa.io/'
 msys2_repository_url='https://github.com/pypa/flit/'
+msys2_changelog_url='https://flit.pypa.io/en/stable/history.html'
 msys2_references=(
+  'anitya: 44865'
+  'archlinux: python-flit'
+  'gentoo: dev-python/flit'
   'purl: pkg:pypi/flit'
 )
 license=('spdx:BSD-3-Clause')

--- a/mingw-w64-python-flit/PKGBUILD
+++ b/mingw-w64-python-flit/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=flit
 pkgbase=mingw-w64-python-${_realname}
 pkgname=(${MINGW_PACKAGE_PREFIX}-python-$_realname)
-pkgver=3.12.0
-pkgrel=3
+pkgver=4.0.2
+pkgrel=1
 pkgdesc='Simplified packaging of Python modules (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -33,7 +33,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-pygments-github-lexers"
              "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-github-alt")
 options=('!strip')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('1c80f34dd96992e7758b40423d2809f48f640ca285d0b7821825e50745ec3740')
+sha256sums=('232bc4317279e8952eca9fb3f5e000d8395d693b39c105b99f619ce461e1da85')
 
 prepare() {
   cd "${_realname}-${pkgver}"

--- a/mingw-w64-python-flit/PKGBUILD
+++ b/mingw-w64-python-flit/PKGBUILD
@@ -1,44 +1,51 @@
 # Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
 
-_realname=flit
-pkgbase=mingw-w64-python-${_realname}
-pkgname=(${MINGW_PACKAGE_PREFIX}-python-$_realname)
+_realname='flit'
+_pyname="${_realname/-/_}"
+pkgbase="mingw-w64-python-${_realname}"
+pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 pkgver=4.0.2
 pkgrel=1
 pkgdesc='Simplified packaging of Python modules (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url='https://flit.pypa.io/'
 msys2_repository_url='https://github.com/pypa/flit/'
 msys2_references=(
   'purl: pkg:pypi/flit'
 )
-url='https://flit.pypa.io/'
 license=('spdx:BSD-3-Clause')
 depends=(
   "${MINGW_PACKAGE_PREFIX}-python"
+  "${MINGW_PACKAGE_PREFIX}-python-docutils"
   "${MINGW_PACKAGE_PREFIX}-python-flit-core"
   "${MINGW_PACKAGE_PREFIX}-python-requests"
   "${MINGW_PACKAGE_PREFIX}-python-tomli-w"
-  "${MINGW_PACKAGE_PREFIX}-python-docutils"
 )
-checkdepends=("${MINGW_PACKAGE_PREFIX}-python-coverage"
-              "${MINGW_PACKAGE_PREFIX}-python-responses"
-              "${MINGW_PACKAGE_PREFIX}-python-testpath"
-              "${MINGW_PACKAGE_PREFIX}-python-pytest"
-              "${MINGW_PACKAGE_PREFIX}-python-pytest-cov")
-makedepends=("${MINGW_PACKAGE_PREFIX}-python-pygments-github-lexers"
-             "${MINGW_PACKAGE_PREFIX}-python-sphinx"
-             "${MINGW_PACKAGE_PREFIX}-python-sphinx_rtd_theme"
-             "${MINGW_PACKAGE_PREFIX}-python-installer"
-             "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-github-alt")
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-python-installer"
+  "${MINGW_PACKAGE_PREFIX}-python-pygments-github-lexers"
+  "${MINGW_PACKAGE_PREFIX}-python-sphinx"
+  "${MINGW_PACKAGE_PREFIX}-python-sphinx_rtd_theme"
+  "${MINGW_PACKAGE_PREFIX}-python-sphinxcontrib-github-alt"
+)
+checkdepends=(
+  "${MINGW_PACKAGE_PREFIX}-python-coverage"
+  "${MINGW_PACKAGE_PREFIX}-python-pytest"
+  "${MINGW_PACKAGE_PREFIX}-python-pytest-cov"
+  "${MINGW_PACKAGE_PREFIX}-python-responses"
+  "${MINGW_PACKAGE_PREFIX}-python-testpath"
+)
 options=('!strip')
-source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+source=("https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${pkgver}.tar.gz")
 sha256sums=('232bc4317279e8952eca9fb3f5e000d8395d693b39c105b99f619ce461e1da85')
 
 prepare() {
   cd "${_realname}-${pkgver}"
+
   rm -f tests/test_sdist.py
-  cd "flit_core"
+
+  cd 'flit_core'
 
   python build_dists.py
 }
@@ -46,7 +53,7 @@ prepare() {
 build() {
   cd "${_realname}-${pkgver}"
 
-  PYTHONPATH=flit_core python -m flit build --format wheel
+  PYTHONPATH='flit_core' python -m flit build --format wheel
 
   cd doc
   make dirhtml man
@@ -55,21 +62,22 @@ build() {
 check() {
   cd "${_realname}-${pkgver}"
 
-  # 9 failed, 172 passed, 5 skipped, 1 warning in 13.73s
-  PYTHONPATH=flit_core ${MINGW_PREFIX}/bin/python -m pytest  --cov=flit --cov=flit_core/flit_core || true
+  # 4.0.2: 13 failed, 301 passed, 8 skipped in 20.65s
+  # earlier: 9 failed, 172 passed, 5 skipped, 1 warning in 13.73s
+  PYTHONPATH='flit_core' "${MINGW_PREFIX}/bin/python" -m pytest --cov=flit --cov=flit_core/flit_core || true
 }
 
 package() {
   cd "${_realname}-${pkgver}"
 
   MSYS2_ARG_CONV_EXCL="--prefix=" \
-    python -m installer --prefix=${MINGW_PREFIX} --destdir="${pkgdir}" dist/*.whl
+    python -m installer --prefix="${MINGW_PREFIX}" --destdir="${pkgdir}" dist/*.whl
 
-  install -Dm 644 LICENSE "$pkgdir${MINGW_PREFIX}"/share/licenses/${_realname}/LICENSE
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 
-  mkdir -p "$pkgdir${MINGW_PREFIX}"/share/doc/${_realname}
-  cp -r doc/_build/dirhtml/* "$pkgdir${MINGW_PREFIX}"/share/doc/${_realname}
-  
-  mkdir -p "$pkgdir${MINGW_PREFIX}"/share/man/man1
-  cp -r doc/_build/man/*.1 "$pkgdir${MINGW_PREFIX}"/share/man/man1
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"
+  cp -r doc/_build/dirhtml/* "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"
+
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/share/man/man1"
+  cp -r doc/_build/man/*.1 "${pkgdir}${MINGW_PREFIX}/share/man/man1"
 }


### PR DESCRIPTION
I guess it should be updated after the `python-flit-core` looking at last timing.