### PR TITLE
[new package] binwalk (3.1.0)

### DIFF
--- a/mingw-w64-binwalk/PKGBUILD
+++ b/mingw-w64-binwalk/PKGBUILD
@@ -1,0 +1,47 @@
+_realname='binwalk'
+pkgbase="mingw-w64-${_realname}"
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=3.1.0
+pkgrel=1
+pkgdesc='Tool for searching a given binary image for embedded files (mingw-w64)'
+arch=('any')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
+url='https://github.com/ReFirmLabs/binwalk'
+msys2_repository_url='https://github.com/ReFirmLabs/binwalk'
+msys2_references=(
+  'anitya: 5593'
+  'archlinux: binwalk'
+  'gentoo: app-misc/binwalk'
+)
+license=('spdx:MIT')
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-bzip2"
+  "${MINGW_PACKAGE_PREFIX}-fontconfig"
+  "${MINGW_PACKAGE_PREFIX}-freetype"
+  "${MINGW_PACKAGE_PREFIX}-xz"
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-rust"
+)
+options=('!strip')
+source=("https://github.com/ReFirmLabs/binwalk/archive/v${pkgver}/${_realname}-v${pkgver}.tar.gz")
+sha256sums=('06f595719417b70a592580258ed980237892eadc198e02363201abe6ca59e49a')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+
+  cargo fetch --locked --target "${RUST_CHOST}"
+}
+
+build() {
+  cd "${_realname}-${pkgver}"
+
+  cargo build --release --locked
+}
+
+package() {
+  cd "${_realname}-${pkgver}"
+
+  install -Dm755 "target/release/${_realname}.exe" "${pkgdir}${MINGW_PREFIX}/bin/${_realname}.exe"
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
`python-binwalk` is EOL since true `binwalk` has been rewritten