### PR TITLE
autohotkey: update to v2.0.27

### DIFF
--- a/mingw-w64-autohotkey/PKGBUILD
+++ b/mingw-w64-autohotkey/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=autohotkey
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.0.26
-pkgrel=2
+pkgver=2.0.27
+pkgrel=1
 pkgdesc="Automation scripting language for Windows (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -48,7 +48,7 @@ source=("https://github.com/AutoHotkey/AutoHotkey/archive/refs/tags/v${pkgver}.t
         0019-fix-const-string-literal-to-LPTSTR-assignments-for-c.patch
         0020-replace-_countof-with-sizeof-for-arrays-with-incompl.patch
         0021-add-explicit-template-instantiations-for-ScriptItemL.patch)
-sha256sums=('bd11ee00ba75657dcedf3c6c671621bc6ee27cc90802395840a449cce77c5228'
+sha256sums=('976376e699695bf6435c2b6abf23f9e37e08fc1d1c6f51ac2f0d5eea721ebbf3'
             'de4e313ea798fe5c8f76df1f76c6470ce6492358240615783327fd1502415740'
             '3eccb84dba6a6994053482b5c00f4683e581ebdd565c1fa62812eaf990004746'
             'a7c5d0ebe16295623882f734a62814e23aeee2f2ae9f2004e46c036a91bde67a'


### PR DESCRIPTION
From https://github.com/AutoHotkey/AutoHotkey/releases/tag/v2.0.27:

* Fixed breakpoint on line containing `=>` where direct parent is a block.

* Fixed `Send "{Click X Y Count}"` to move only once, not _Count_ times.

* Fixed IServiceProvider interface pointer leak in ComObjQuery.

* Fixed setter definition to be permitted after a separate getter.

* Fixed Item parameter of ContextMenu event raised by a ListView's Header.

* Fixed class declarations to not permit a class to subclass itself.