### PR TITLE
Update kde apps to 26.08.1

### DIFF
--- a/mingw-w64-ark/PKGBUILD
+++ b/mingw-w64-ark/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=ark
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 pkgdesc="Archiving Tool (mingw-w64)"
 arch=('any')
@@ -63,7 +63,7 @@ source=(
   "0001-ark-define-QT_STAT_LNK-macro.patch"
   "0002-ark-disable-zip-plugin.patch"
 )
-sha256sums=('d4627791d17d17f0c4472f8bc464778d7b5526adeca9bba27565e77ff8b44db7'
+sha256sums=('0b277a28263074359ce1a1b994c83e974187c0901e320dcbac6042e104b4d8ce'
             'SKIP'
             'ad2dd0f258b1258df779a69ee629fdd3c34d95dc34539b0c70020a27ea995036'
             '06df815353f73edbde4edbdc945118f52cd849041f61bae142dccdae9a091442')

--- a/mingw-w64-elisa/PKGBUILD
+++ b/mingw-w64-elisa/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=elisa
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 pkgdesc="A simple music player aiming to provide a nice experience for its users (mingw-w64)"
 arch=('any')
@@ -50,7 +50,7 @@ groups=(
   "${MINGW_PACKAGE_PREFIX}-kde-multimedia"
 )
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('0808766fda2d11274cca943bfed2347d89e7a85225e0606bb724eb6d50f0a434'
+sha256sums=('e6a36f4c6cd8b775cc8f60f41dc950db86c45107ef74672616c8c683611aecc1'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>

--- a/mingw-w64-kate/PKGBUILD
+++ b/mingw-w64-kate/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=kate
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 pkgdesc="Advanced text editor (mingw-w64)"
 arch=('any')
@@ -63,7 +63,7 @@ groups=(
   "${MINGW_PACKAGE_PREFIX}-kde-utilities"
 )
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('abe6ceb81155eaa4c046fbff21deaed2a1cd3b031f732acfb95aa283e68d0f52'
+sha256sums=('b7d690761e37c29b425375ee42b959b59a9de693789de86e0fb826bace5b3d7f'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>

--- a/mingw-w64-kcachegrind/PKGBUILD
+++ b/mingw-w64-kcachegrind/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=kcachegrind
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 pkgdesc="Visualization of Performance Profiling Data (mingw-w64)"
 arch=('any')
@@ -51,7 +51,7 @@ source=(
   "https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig}
   0001-zap-bad-constexpr.patch
 )
-sha256sums=('760296956f12ced6bb51a6db2be813be425ee60bc204bd36a9c42a273e5ca0df'
+sha256sums=('179753cb1884fbad0ad43517ef660dda4ceeb161be741fcd54553485d7fbd852'
             'SKIP'
             '0ba354fdb797a498c457767f98e1babbd4e83114808b7108754c417ffd9716ea')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>

--- a/mingw-w64-kdeconnect/PKGBUILD
+++ b/mingw-w64-kdeconnect/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=kdeconnect
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 pkgdesc="Adds communication between KDE and your smartphone (mingw-w64)"
 arch=('any')
@@ -66,7 +66,7 @@ source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realna
         "0003-kdeconnect-remove-in-sal.patch"
         "0004-kdeconnect-cmake-disable-checking-winsdk.patch"
         "0005-kdeconnect-add-return-value.patch")
-sha256sums=('9acf2e9bed4537eda6cd009eccfc9cce80dafbe2f9bfdb8054c2f0ebf92d0bfc'
+sha256sums=('2aed54ecd6b88a91d047714b384d7bd20d0a8d8bf399923c73cf3509372b36e0'
             'SKIP'
             'cb50dad306a9e265869db895eb5e31ba0f5b2e019f511b817caaf0c657a319c3'
             'e8a0a39da7da94893b100a384cb8738f13470291c14dfae9ccf68835ac4cec55'

--- a/mingw-w64-kdegraphics-mobipocket/PKGBUILD
+++ b/mingw-w64-kdegraphics-mobipocket/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=kdegraphics-mobipocket
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 pkgdesc='A library to handle mobipocket files (mingw-w64)'
 arch=('any')
@@ -26,7 +26,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-ninja"
 )
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('4223d58c7f137b3958879de96ef1870bff7348e2be671c7caab1aad1757f87d3'
+sha256sums=('69ec5076b02332f23d96cfd7b560ae716726bfab2984ce0285e0a67c1270522a'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>

--- a/mingw-w64-kdenlive/PKGBUILD
+++ b/mingw-w64-kdenlive/PKGBUILD
@@ -2,7 +2,7 @@
 _realname=kdenlive
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 pkgdesc="A non-linear video editor for Linux using the MLT video framework (mingw-w64)"
 arch=('any')
@@ -62,7 +62,7 @@ optdepends=(
   "${MINGW_PACKAGE_PREFIX}-opencv: For motion tracking"
 )
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-$pkgver.tar.xz"{,.sig})
-sha256sums=('754e1b3e288f8529b2739cfe8ce702d3880f3f3239b0d73f2aef2c88aca49b12'
+sha256sums=('8a0e2cc6451de6901fec778a8b6d00165399879233a264ca5bb1b1b283266513'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>

--- a/mingw-w64-konsole/PKGBUILD
+++ b/mingw-w64-konsole/PKGBUILD
@@ -4,8 +4,8 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=konsole
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=25.12.3
-pkgrel=2
+pkgver=26.08.1
+pkgrel=1
 pkgdesc='KDE terminal emulator (mingw-w64)'
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -61,7 +61,7 @@ groups=(
   "${MINGW_PACKAGE_PREFIX}-kde-utilities"
 )
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('c3e13be55cbe553ebd6ba5f04f9194c79a4ba15d1ed8f3d151ac7afae016f232'
+sha256sums=('64d8aaba741f4412ede26ffbbbe3824523e941b725d3046ec27f510fd42d82e6'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>

--- a/mingw-w64-konversation/PKGBUILD
+++ b/mingw-w64-konversation/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=konversation
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 pkgdesc="User-friendly and fully-featured IRC client (mingw-w64)"
 arch=('any')
@@ -66,7 +66,7 @@ groups=(
   "${MINGW_PACKAGE_PREFIX}-kde-network"
 )
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('11e9f6bd368cf8eb59fb5ab6b83ae50903ab5792b935a0fc5ae37bdd15591bbf'
+sha256sums=('0ee0926868f312379f5a51e9f81897f1a8b122d01207733393b3804a8f9ef886'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>

--- a/mingw-w64-kqtquickcharts/PKGBUILD
+++ b/mingw-w64-kqtquickcharts/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=kqtquickcharts
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 pkgdesc="A QtQuick plugin to render beautiful and interactive charts (mingw-w64)"
 arch=('any')
@@ -22,7 +22,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-qt6-base"
          "${MINGW_PACKAGE_PREFIX}-qt6-declarative")
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig}
         '0001-kqtquickcharts-22.08.1-fix-prefix.patch')
-sha256sums=('28ef23f4a4819ef3906148a9258b9dc6e17db44b6705d19697011dcb64c3c283'
+sha256sums=('c768f41e62d71d7ffe8400cfd48986be3a6ebdf6aec64364655abd122210a39a'
             'SKIP'
             'c239447ab092b19a2fe22d0c34e193c4af89cceebf321061f4221c1abdeda2dd')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>

--- a/mingw-w64-ktouch/PKGBUILD
+++ b/mingw-w64-ktouch/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=ktouch
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -47,7 +47,7 @@ makedepends=(
 )
 optdepends=("${MINGW_PACKAGE_PREFIX}-breeze-icons: application icon theme")
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('8a3223ee1daaf1519575d1fa5ab5771a08988fbd100a5fae147ef0c723a35bcc'
+sha256sums=('262d9374dbf2a4407db7af780f734e8d91fc2005424a24af6db1a2dd8b8a05f7'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>

--- a/mingw-w64-libkexiv2/PKGBUILD
+++ b/mingw-w64-libkexiv2/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=libkexiv2
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 pkgdesc='A library to manipulate pictures metadata (mingw-w64)'
 arch=('any')
@@ -26,7 +26,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-ninja"
 )
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('98e8cf468d44388263b4dd3b3d29e8ed8b9e204dbcd3040b4a73b087c3d287b9'
+sha256sums=('d50cc3e641d1d9dd6a0f2ea5cd8e0e210e7386f11ba2729b0ade2785400b0e31'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>

--- a/mingw-w64-lokalize/PKGBUILD
+++ b/mingw-w64-lokalize/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=lokalize
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 pkgdesc="Computer-Aided Translation System (mingw-w64)"
 arch=('any')
@@ -52,7 +52,7 @@ groups=(
 )
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig}
         '0002-lokalize-22.04.3-fix-cast.patch')
-sha256sums=('9b973874b6544c0172086636a10558873d2e45571c69d86e1843297f21bfcbf2'
+sha256sums=('085526120fbcd7335a48373ef6305612a5e8a41c063710f282abe3f90da7417e'
             'SKIP'
             'd11a8f48dfc0dcd8d85f0b364a917f40d5d7b01bcd74726336c557e6e18339fe')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>

--- a/mingw-w64-okular/PKGBUILD
+++ b/mingw-w64-okular/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=okular
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 pkgdesc='Document Viewer (mingw-w64)'
 arch=('any')
@@ -73,7 +73,7 @@ groups=(
   "${MINGW_PACKAGE_PREFIX}-kde-utilities"
 )
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('235e8e761f949b81953582e3ff6e45b8832d0d551b71bd1b5098c1ad663511e4'
+sha256sums=('7eb26c37ee42b6657526aeddd1bce71c5556e3865772a677f49b68deb46885d6'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>

--- a/mingw-w64-umbrello/PKGBUILD
+++ b/mingw-w64-umbrello/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=umbrello
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 pkgdesc="UML modeller (mingw-w64)"
 arch=('any')
@@ -39,7 +39,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-kdoctools"
              "${MINGW_PACKAGE_PREFIX}-icoutils")
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('fa9e4f235f39c6977a3e034d95be2d8b6af3665e6397474aebcd1b244d9f0bfa'
+sha256sums=('25cc282f9cba45f4b83d6c7b1e87ef9974c04cd269c8643a032db0f6d486838b'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>


### PR DESCRIPTION
Used script from #31512

```bash
PACKAGES=(
  mingw-w64-konsole
  mingw-w64-kate
  mingw-w64-ark
  mingw-w64-umbrello
  mingw-w64-lokalize
  mingw-w64-kcachegrind
  mingw-w64-konversation
  mingw-w64-kdeconnect
  mingw-w64-kdenlive
  mingw-w64-elisa
  mingw-w64-ktouch
  mingw-w64-okular
  mingw-w64-kqtquickcharts
  mingw-w64-libkexiv2
  mingw-w64-kdegraphics-mobipocket
)
```

CLANGARM64: internet failed

UCRT64: konsole build failed
May be related to the fact that konsole is the only software updating from 25.12.3 to 26.x