### PR TITLE
kde-apps: update to 26.08.1, part 1/3

### DIFF
--- a/mingw-w64-ark/PKGBUILD
+++ b/mingw-w64-ark/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=ark
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 pkgdesc="Archiving Tool (mingw-w64)"
 arch=('any')
@@ -63,7 +63,7 @@ source=(
   "0001-ark-define-QT_STAT_LNK-macro.patch"
   "0002-ark-disable-zip-plugin.patch"
 )
-sha256sums=('d4627791d17d17f0c4472f8bc464778d7b5526adeca9bba27565e77ff8b44db7'
+sha256sums=('0b277a28263074359ce1a1b994c83e974187c0901e320dcbac6042e104b4d8ce'
             'SKIP'
             'ad2dd0f258b1258df779a69ee629fdd3c34d95dc34539b0c70020a27ea995036'
             '06df815353f73edbde4edbdc945118f52cd849041f61bae142dccdae9a091442')

--- a/mingw-w64-elisa/PKGBUILD
+++ b/mingw-w64-elisa/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=elisa
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 pkgdesc="A simple music player aiming to provide a nice experience for its users (mingw-w64)"
 arch=('any')
@@ -50,7 +50,7 @@ groups=(
   "${MINGW_PACKAGE_PREFIX}-kde-multimedia"
 )
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('0808766fda2d11274cca943bfed2347d89e7a85225e0606bb724eb6d50f0a434'
+sha256sums=('e6a36f4c6cd8b775cc8f60f41dc950db86c45107ef74672616c8c683611aecc1'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>

--- a/mingw-w64-kate/PKGBUILD
+++ b/mingw-w64-kate/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=kate
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 pkgdesc="Advanced text editor (mingw-w64)"
 arch=('any')
@@ -63,7 +63,7 @@ groups=(
   "${MINGW_PACKAGE_PREFIX}-kde-utilities"
 )
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('abe6ceb81155eaa4c046fbff21deaed2a1cd3b031f732acfb95aa283e68d0f52'
+sha256sums=('b7d690761e37c29b425375ee42b959b59a9de693789de86e0fb826bace5b3d7f'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>

--- a/mingw-w64-libkexiv2/PKGBUILD
+++ b/mingw-w64-libkexiv2/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=libkexiv2
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 pkgdesc='A library to manipulate pictures metadata (mingw-w64)'
 arch=('any')
@@ -26,7 +26,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-ninja"
 )
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('98e8cf468d44388263b4dd3b3d29e8ed8b9e204dbcd3040b4a73b087c3d287b9'
+sha256sums=('d50cc3e641d1d9dd6a0f2ea5cd8e0e210e7386f11ba2729b0ade2785400b0e31'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>

--- a/mingw-w64-okular/PKGBUILD
+++ b/mingw-w64-okular/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=okular
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 pkgdesc='Document Viewer (mingw-w64)'
 arch=('any')
@@ -73,7 +73,7 @@ groups=(
   "${MINGW_PACKAGE_PREFIX}-kde-utilities"
 )
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('235e8e761f949b81953582e3ff6e45b8832d0d551b71bd1b5098c1ad663511e4'
+sha256sums=('7eb26c37ee42b6657526aeddd1bce71c5556e3865772a677f49b68deb46885d6'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>


### PR DESCRIPTION
- mingw-w64-libkexiv2: update to 26.08.1
- mingw-w64-okular: update to 26.08.1
- mingw-w64-ark: update to 26.08.1
- mingw-w64-elisa: update to 26.08.1
- mingw-w64-kate: update to 26.08.1

Used script: https://gist.github.com/Omikorin/734bb64809104f10d69264c576fa936b

I believe KDE framework update should come first to merge, so there is no need to rebuild all those apps.