### PR TITLE
kde-apps: update to 26.08.1, part 2/3

### DIFF
--- a/mingw-w64-kcachegrind/PKGBUILD
+++ b/mingw-w64-kcachegrind/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=kcachegrind
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 pkgdesc="Visualization of Performance Profiling Data (mingw-w64)"
 arch=('any')
@@ -51,7 +51,7 @@ source=(
   "https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig}
   0001-zap-bad-constexpr.patch
 )
-sha256sums=('760296956f12ced6bb51a6db2be813be425ee60bc204bd36a9c42a273e5ca0df'
+sha256sums=('179753cb1884fbad0ad43517ef660dda4ceeb161be741fcd54553485d7fbd852'
             'SKIP'
             '0ba354fdb797a498c457767f98e1babbd4e83114808b7108754c417ffd9716ea')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>

--- a/mingw-w64-kdeconnect/PKGBUILD
+++ b/mingw-w64-kdeconnect/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=kdeconnect
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 pkgdesc="Adds communication between KDE and your smartphone (mingw-w64)"
 arch=('any')
@@ -66,7 +66,7 @@ source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realna
         "0003-kdeconnect-remove-in-sal.patch"
         "0004-kdeconnect-cmake-disable-checking-winsdk.patch"
         "0005-kdeconnect-add-return-value.patch")
-sha256sums=('9acf2e9bed4537eda6cd009eccfc9cce80dafbe2f9bfdb8054c2f0ebf92d0bfc'
+sha256sums=('2aed54ecd6b88a91d047714b384d7bd20d0a8d8bf399923c73cf3509372b36e0'
             'SKIP'
             'cb50dad306a9e265869db895eb5e31ba0f5b2e019f511b817caaf0c657a319c3'
             'e8a0a39da7da94893b100a384cb8738f13470291c14dfae9ccf68835ac4cec55'

--- a/mingw-w64-kdegraphics-mobipocket/PKGBUILD
+++ b/mingw-w64-kdegraphics-mobipocket/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=kdegraphics-mobipocket
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 pkgdesc='A library to handle mobipocket files (mingw-w64)'
 arch=('any')
@@ -26,7 +26,7 @@ makedepends=(
   "${MINGW_PACKAGE_PREFIX}-ninja"
 )
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('4223d58c7f137b3958879de96ef1870bff7348e2be671c7caab1aad1757f87d3'
+sha256sums=('69ec5076b02332f23d96cfd7b560ae716726bfab2984ce0285e0a67c1270522a'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>

--- a/mingw-w64-kdenlive/PKGBUILD
+++ b/mingw-w64-kdenlive/PKGBUILD
@@ -2,7 +2,7 @@
 _realname=kdenlive
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 pkgdesc="A non-linear video editor for Linux using the MLT video framework (mingw-w64)"
 arch=('any')
@@ -62,7 +62,7 @@ optdepends=(
   "${MINGW_PACKAGE_PREFIX}-opencv: For motion tracking"
 )
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-$pkgver.tar.xz"{,.sig})
-sha256sums=('754e1b3e288f8529b2739cfe8ce702d3880f3f3239b0d73f2aef2c88aca49b12'
+sha256sums=('8a0e2cc6451de6901fec778a8b6d00165399879233a264ca5bb1b1b283266513'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>

--- a/mingw-w64-konversation/PKGBUILD
+++ b/mingw-w64-konversation/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=konversation
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 pkgdesc="User-friendly and fully-featured IRC client (mingw-w64)"
 arch=('any')
@@ -66,7 +66,7 @@ groups=(
   "${MINGW_PACKAGE_PREFIX}-kde-network"
 )
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('11e9f6bd368cf8eb59fb5ab6b83ae50903ab5792b935a0fc5ae37bdd15591bbf'
+sha256sums=('0ee0926868f312379f5a51e9f81897f1a8b122d01207733393b3804a8f9ef886'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>


### PR DESCRIPTION
- mingw-w64-kcachegrind: update to 26.08.1
- mingw-w64-kdeconnect: update to 26.08.1
- mingw-w64-kdegraphics-mobipocket: update to 26.08.1
- mingw-w64-kdenlive: update to 26.08.1
- mingw-w64-konversation: update to 26.08.1