### PR TITLE
kde-apps: update to 26.08.1, part 3/3

### DIFF
--- a/mingw-w64-kqtquickcharts/PKGBUILD
+++ b/mingw-w64-kqtquickcharts/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=kqtquickcharts
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 pkgdesc="A QtQuick plugin to render beautiful and interactive charts (mingw-w64)"
 arch=('any')
@@ -22,7 +22,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-qt6-base"
          "${MINGW_PACKAGE_PREFIX}-qt6-declarative")
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig}
         '0001-kqtquickcharts-22.08.1-fix-prefix.patch')
-sha256sums=('28ef23f4a4819ef3906148a9258b9dc6e17db44b6705d19697011dcb64c3c283'
+sha256sums=('c768f41e62d71d7ffe8400cfd48986be3a6ebdf6aec64364655abd122210a39a'
             'SKIP'
             'c239447ab092b19a2fe22d0c34e193c4af89cceebf321061f4221c1abdeda2dd')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>

--- a/mingw-w64-ktouch/PKGBUILD
+++ b/mingw-w64-ktouch/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=ktouch
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -47,7 +47,7 @@ makedepends=(
 )
 optdepends=("${MINGW_PACKAGE_PREFIX}-breeze-icons: application icon theme")
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('8a3223ee1daaf1519575d1fa5ab5771a08988fbd100a5fae147ef0c723a35bcc'
+sha256sums=('262d9374dbf2a4407db7af780f734e8d91fc2005424a24af6db1a2dd8b8a05f7'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>

--- a/mingw-w64-lokalize/PKGBUILD
+++ b/mingw-w64-lokalize/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=lokalize
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 pkgdesc="Computer-Aided Translation System (mingw-w64)"
 arch=('any')
@@ -52,7 +52,7 @@ groups=(
 )
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig}
         '0002-lokalize-22.04.3-fix-cast.patch')
-sha256sums=('9b973874b6544c0172086636a10558873d2e45571c69d86e1843297f21bfcbf2'
+sha256sums=('085526120fbcd7335a48373ef6305612a5e8a41c063710f282abe3f90da7417e'
             'SKIP'
             'd11a8f48dfc0dcd8d85f0b364a917f40d5d7b01bcd74726336c557e6e18339fe')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>

--- a/mingw-w64-umbrello/PKGBUILD
+++ b/mingw-w64-umbrello/PKGBUILD
@@ -4,7 +4,7 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=umbrello
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=26.08.0
+pkgver=26.08.1
 pkgrel=1
 pkgdesc="UML modeller (mingw-w64)"
 arch=('any')
@@ -39,7 +39,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-kdoctools"
              "${MINGW_PACKAGE_PREFIX}-icoutils")
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('fa9e4f235f39c6977a3e034d95be2d8b6af3665e6397474aebcd1b244d9f0bfa'
+sha256sums=('25cc282f9cba45f4b83d6c7b1e87ef9974c04cd269c8643a032db0f6d486838b'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>


### PR DESCRIPTION
- mingw-w64-kqtquickcharts: update to 26.08.1
- mingw-w64-ktouch: update to 26.08.1
- mingw-w64-lokalize: update to 26.08.1
- mingw-w64-umbrello: update to 26.08.1