### PR TITLE
konsole: update to 26.08.1

### DIFF
--- a/mingw-w64-konsole/PKGBUILD
+++ b/mingw-w64-konsole/PKGBUILD
@@ -4,8 +4,8 @@ source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-framework
 _realname=konsole
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=25.12.3
-pkgrel=2
+pkgver=26.08.1
+pkgrel=1
 pkgdesc='KDE terminal emulator (mingw-w64)'
 arch=('any')
 mingw_arch=('ucrt64' 'clang64' 'clangarm64')
@@ -61,7 +61,7 @@ groups=(
   "${MINGW_PACKAGE_PREFIX}-kde-utilities"
 )
 source=("https://download.kde.org/stable/release-service/${pkgver}/src/${_realname}-${pkgver}.tar.xz"{,.sig})
-sha256sums=('c3e13be55cbe553ebd6ba5f04f9194c79a4ba15d1ed8f3d151ac7afae016f232'
+sha256sums=('64d8aaba741f4412ede26ffbbbe3824523e941b725d3046ec27f510fd42d82e6'
             'SKIP')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87  # Christoph Feck <cfeck@kde.org>


### PR DESCRIPTION
konsole is probably broken, so here's a separate PR

EDIT: yeah, linker errors