### PR TITLE
graphicsmagick: remove txt2html

### DIFF
--- a/mingw-w64-graphicsmagick/PKGBUILD
+++ b/mingw-w64-graphicsmagick/PKGBUILD
@@ -26,8 +26,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-ghostscript"
              "${MINGW_PACKAGE_PREFIX}-libjxl"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-autotools"
-             "${MINGW_PACKAGE_PREFIX}-cc"
-             "txt2html")
+             "${MINGW_PACKAGE_PREFIX}-cc")
 depends=("${MINGW_PACKAGE_PREFIX}-bzip2"
          "${MINGW_PACKAGE_PREFIX}-fontconfig"
          "${MINGW_PACKAGE_PREFIX}-freetype"

--- a/mingw-w64-graphicsmagick/PKGBUILD
+++ b/mingw-w64-graphicsmagick/PKGBUILD
@@ -11,9 +11,12 @@ mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://www.graphicsmagick.org/'
 msys2_repository_url='https://sourceforge.net/p/graphicsmagick/code'
 msys2_references=(
+  'anitya: 1248'
+  'archlinux: graphicsmagick'
   'cpe: cpe:/a:graphicsmagick:graphicsmagick'
   'cpe: cpe:/a:imagemagick:graphicsmagick'
   'cygwin: GraphicsMagick'
+  'gentoo: media-gfx/graphicsmagick'
 )
 msys2_ignore_vulnerabilities=(
   'CVE-2007-0770'  # fixed since 1.1.8

--- a/mingw-w64-graphicsmagick/PKGBUILD
+++ b/mingw-w64-graphicsmagick/PKGBUILD
@@ -61,9 +61,9 @@ optdepends=(
 options=('libtool')
 source=(
   "https://sourceforge.net/projects/graphicsmagick/files/${_realname}/${pkgver}/GraphicsMagick-${pkgver}.tar.xz"
-  '001-relocate.patch'
   'pathtools.c'
   'pathtools.h'
+  '001-relocate.patch'
 )
 sha256sums=('9218eb78179110f91371066ab75cb3b4dd034b9bb464b29ce9bab7a11979232b'
             'ebf471173f5ee9c4416c10a78760cea8afaf1a4a6e653977321e8547ce7bf3c0'

--- a/mingw-w64-graphicsmagick/PKGBUILD
+++ b/mingw-w64-graphicsmagick/PKGBUILD
@@ -1,75 +1,79 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
-_realname=graphicsmagick
-pkgbase=mingw-w64-${_realname}
+_realname='graphicsmagick'
+pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.3.48
 pkgrel=1
-pkgdesc="An image viewing/manipulation program (mingw-w64)"
+pkgdesc='An image viewing/manipulation program (mingw-w64)'
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
-url="http://www.graphicsmagick.org/"
-msys2_repository_url='http://sourceforge.net/p/graphicsmagick/code'
+url='https://www.graphicsmagick.org/'
+msys2_repository_url='https://sourceforge.net/p/graphicsmagick/code'
 msys2_references=(
+  'cpe: cpe:/a:graphicsmagick:graphicsmagick'
+  'cpe: cpe:/a:imagemagick:graphicsmagick'
   'cygwin: GraphicsMagick'
-  "cpe: cpe:/a:graphicsmagick:graphicsmagick"
-  "cpe: cpe:/a:imagemagick:graphicsmagick"
 )
 msys2_ignore_vulnerabilities=(
-  "CVE-2007-0770"  # fixed since 1.1.8
-  "CVE-2014-9826"  # was https://sources.debian.org/src/imagemagick/8%3A6.8.9.9-5/debian/patches/0025-Fix-handling-of-corrupted-of-psd-sun-and-xpm-file.patch which was fixed upstream long ago
-  "CVE-2025-32460" # fixed since 1.3.46
+  'CVE-2007-0770'  # fixed since 1.1.8
+  'CVE-2014-9826'  # was https://sources.debian.org/src/imagemagick/8%3A6.8.9.9-5/debian/patches/0025-Fix-handling-of-corrupted-of-psd-sun-and-xpm-file.patch which was fixed upstream long ago
+  'CVE-2025-32460' # fixed since 1.3.46
 )
-license=("spdx:MIT")
-makedepends=("${MINGW_PACKAGE_PREFIX}-ghostscript"
-             "${MINGW_PACKAGE_PREFIX}-libheif"
-             "${MINGW_PACKAGE_PREFIX}-libjxl"
-             "${MINGW_PACKAGE_PREFIX}-pkgconf"
-             "${MINGW_PACKAGE_PREFIX}-autotools"
-             "${MINGW_PACKAGE_PREFIX}-cc")
-depends=("${MINGW_PACKAGE_PREFIX}-bzip2"
-         "${MINGW_PACKAGE_PREFIX}-fontconfig"
-         "${MINGW_PACKAGE_PREFIX}-freetype"
-         "${MINGW_PACKAGE_PREFIX}-cc-libs"
-         "${MINGW_PACKAGE_PREFIX}-glib2"
-         "${MINGW_PACKAGE_PREFIX}-jasper"
-         "${MINGW_PACKAGE_PREFIX}-jbigkit"
-         "${MINGW_PACKAGE_PREFIX}-lcms2"
-         "${MINGW_PACKAGE_PREFIX}-libxml2"
-         "${MINGW_PACKAGE_PREFIX}-libpng"
-         "${MINGW_PACKAGE_PREFIX}-libtiff"
-         "${MINGW_PACKAGE_PREFIX}-libwebp"
-         "${MINGW_PACKAGE_PREFIX}-libwmf"
-         "${MINGW_PACKAGE_PREFIX}-libltdl"
-         "${MINGW_PACKAGE_PREFIX}-libwinpthread"
-         "${MINGW_PACKAGE_PREFIX}-omp"
-         "${MINGW_PACKAGE_PREFIX}-xz"
-         "${MINGW_PACKAGE_PREFIX}-zlib"
-         "${MINGW_PACKAGE_PREFIX}-zstd")
-         #"${MINGW_PACKAGE_PREFIX}-perl"
-optdepends=("${MINGW_PACKAGE_PREFIX}-ghostscript: for Ghostscript support"
-            "${MINGW_PACKAGE_PREFIX}-libheif: for HEIF support"
-            "${MINGW_PACKAGE_PREFIX}-libjxl: for JPEG XL support")
+license=('spdx:MIT')
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-bzip2"
+  "${MINGW_PACKAGE_PREFIX}-cc-libs"
+  "${MINGW_PACKAGE_PREFIX}-fontconfig"
+  "${MINGW_PACKAGE_PREFIX}-freetype"
+  "${MINGW_PACKAGE_PREFIX}-glib2"
+  "${MINGW_PACKAGE_PREFIX}-jasper"
+  "${MINGW_PACKAGE_PREFIX}-jbigkit"
+  "${MINGW_PACKAGE_PREFIX}-lcms2"
+  "${MINGW_PACKAGE_PREFIX}-libltdl"
+  "${MINGW_PACKAGE_PREFIX}-libpng"
+  "${MINGW_PACKAGE_PREFIX}-libtiff"
+  "${MINGW_PACKAGE_PREFIX}-libwebp"
+  "${MINGW_PACKAGE_PREFIX}-libwinpthread"
+  "${MINGW_PACKAGE_PREFIX}-libwmf"
+  "${MINGW_PACKAGE_PREFIX}-libxml2"
+  "${MINGW_PACKAGE_PREFIX}-omp"
+  "${MINGW_PACKAGE_PREFIX}-xz"
+  "${MINGW_PACKAGE_PREFIX}-zlib"
+  "${MINGW_PACKAGE_PREFIX}-zstd"
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-autotools"
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-ghostscript"
+  "${MINGW_PACKAGE_PREFIX}-libheif"
+  "${MINGW_PACKAGE_PREFIX}-libjxl"
+  "${MINGW_PACKAGE_PREFIX}-pkgconf"
+)
+optdepends=(
+  "${MINGW_PACKAGE_PREFIX}-ghostscript: for Ghostscript support"
+  "${MINGW_PACKAGE_PREFIX}-libheif: for HEIF support"
+  "${MINGW_PACKAGE_PREFIX}-libjxl: for JPEG XL support"
+)
 options=('libtool')
-source=(https://sourceforge.net/projects/graphicsmagick/files/${_realname}/${pkgver}/GraphicsMagick-${pkgver}.tar.xz
-        pathtools.c
-        pathtools.h
-        001-relocate.patch)
+source=(
+  "https://sourceforge.net/projects/graphicsmagick/files/${_realname}/${pkgver}/GraphicsMagick-${pkgver}.tar.xz"
+  '001-relocate.patch'
+  'pathtools.c'
+  'pathtools.h'
+)
 sha256sums=('9218eb78179110f91371066ab75cb3b4dd034b9bb464b29ce9bab7a11979232b'
             'ebf471173f5ee9c4416c10a78760cea8afaf1a4a6e653977321e8547ce7bf3c0'
             '1585ef1b61cf53a2ca27049c11d49e0834683dfda798f03547761375df482a90'
             '39e6bd91660fb30ea375553cc90eaeec5e11a6dc6dd32d77c56fed4316402e08')
 
 # Helper macros to help make tasks easier #
-apply_patch_with_msg() {
-  for _patch in "$@"
-  do
-    msg2 "Applying $_patch"
-    patch -Nbp1 -i "${srcdir}/$_patch"
+_apply_patch_with_msg() {
+  for _patch in "$@"; do
+    msg2 "Applying ${_patch}"
+    patch -Np1 -i "${srcdir}/${_patch}"
   done
 }
-
-# =========================================== #
 
 prepare() {
   test ! -d "${startdir}/../mingw-w64-pathtools" || {
@@ -77,24 +81,25 @@ prepare() {
     cmp "${startdir}/../mingw-w64-pathtools/pathtools.h" "${srcdir}/pathtools.h"
   } || exit 1
 
-  cd GraphicsMagick-${pkgver}
+  cd "GraphicsMagick-${pkgver}"
+
   cp -fHv "${srcdir}"/pathtools.[ch] magick/
 
-  apply_patch_with_msg \
-    001-relocate.patch
+  _apply_patch_with_msg \
+    '001-relocate.patch'
 
   autoreconf -fiv
 }
 
 build() {
-  mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
+  mkdir -p "build-${MSYSTEM}" && cd "build-${MSYSTEM}"
 
   export lt_cv_deplibs_check_method='pass_all'
 
-  ../GraphicsMagick-${pkgver}/configure \
-    --prefix=${MINGW_PREFIX} \
-    --build=${MINGW_CHOST} \
-    --host=${MINGW_CHOST} \
+  "../GraphicsMagick-${pkgver}/configure" \
+    --prefix="${MINGW_PREFIX}" \
+    --build="${MINGW_CHOST}" \
+    --host="${MINGW_CHOST}" \
     --enable-shared \
     --disable-static \
     --with-quantum-depth=16 \
@@ -116,12 +121,16 @@ build() {
 }
 
 package() {
-  cd "${srcdir}"/build-${MSYSTEM}
+  cd "build-${MSYSTEM}"
+
   make -j1 DESTDIR="${pkgdir}" install
-  local PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
-  # fix path references in some files.
-  find "${pkgdir}"${MINGW_PREFIX}/bin -name "*-config" -exec \
-    sed "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i {} \;
-  find "${pkgdir}"${MINGW_PREFIX}/ -name "*.la" -exec \
-    sed "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i {} \;
+
+  local _prefix_win
+  _prefix_win="$(cygpath -m "${MINGW_PREFIX}")"
+
+  # fix path references in installed configuration and libtool files
+  find "${pkgdir}${MINGW_PREFIX}/bin" -name "*-config" -exec \
+    sed "s|${_prefix_win}|${MINGW_PREFIX}|g" -i {} +
+  find "${pkgdir}${MINGW_PREFIX}/" -name "*.la" -exec \
+    sed "s|${_prefix_win}|${MINGW_PREFIX}|g" -i {} +
 }


### PR DESCRIPTION
I removed the last msys package from PKGBUILD. This has not been used for a very long time and is confirmed by Arch repository.