### PR TITLE
libpcap: update to 1.10.7

### DIFF
--- a/mingw-w64-libpcap/PKGBUILD
+++ b/mingw-w64-libpcap/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=libpcap
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.10.6
-pkgrel=3
+pkgver=1.10.7
+pkgrel=1
 pkgdesc="A system-independent interface for user-level packet capture (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -25,7 +25,7 @@ source=("https://www.tcpdump.org/release/${_realname}-${pkgver}.tar.gz"{,.sig}
         "0001-cmake-install-rpcapd-bindir.patch"
         "0002-cmake-keep-lib-prefixed-dll.patch"
         "0003-charconv-include-errno.patch")
-sha256sums=('872dd11337fe1ab02ad9d4fee047c9da244d695c6ddf34e2ebb733efd4ed8aa9'
+sha256sums=('0b394ac90dbc0a9838ff97468e05c9c9a3e873dec2514cd58db65d859d296e31'
             'SKIP'
             'c3b177c92d76fd0300b1d2d1cb7975f9dc393d5c0286d83a3e22bfdafdf265f4'
             '09dfe0f962a99df7d1d8fdb9bb9b320b6d33e0a7c2efec136065a7b359de188d'
@@ -33,7 +33,7 @@ sha256sums=('872dd11337fe1ab02ad9d4fee047c9da244d695c6ddf34e2ebb733efd4ed8aa9'
 validpgpkeys=('1F166A5742ABB9E0249A8D30E089DEF1D9C15D0D') # The Tcpdump Group
 
 prepare() {
-  cd "${srcdir}/${_realname}-${pkgver}"
+  cd "${_realname}-${pkgver}"
   patch -Np1 -i "${srcdir}/0001-cmake-install-rpcapd-bindir.patch"
   patch -Np1 -i "${srcdir}/0002-cmake-keep-lib-prefixed-dll.patch"
   patch -Np1 -i "${srcdir}/0003-charconv-include-errno.patch"
@@ -63,12 +63,12 @@ build() {
 }
 
 check() {
-  cd "${srcdir}/build-${MSYSTEM}"
-  ${MINGW_PREFIX}/bin/ctest.exe ./ || true
+  cd "build-${MSYSTEM}"
+  ctest ./ || true
 }
 
 package() {
-  cd "${srcdir}/build-${MSYSTEM}"
+  cd "build-${MSYSTEM}"
   DESTDIR="${pkgdir}" ${MINGW_PREFIX}/bin/cmake.exe --install .
 
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})


### PR DESCRIPTION
**Edit:** Looks like `rpcapd.exe`, the remote capture daemon, was removed. That's because the remote capture support has been disabled by default for Windows in the 1.10.7 release (see commit <https://github.com/the-tcpdump-group/libpcap/commit/6bdb960a31b490257c2b8b36b2799c750991f861>). To re-enable it, we would have to add `-DENABLE_REMOTE=YES` to the CMake build options. Since the CMake file mentions that remote capture support is experimental and not ready for production use, ...
```
if(ENABLE_REMOTE)
  message(WARNING "
  ***  REMOTE PACKET CAPTURE IS ENABLED  ***
  The ENABLE_REMOTE feature is experimental and is not ready for
  production use. Remote packet capture may expose libpcap-based
  applications to attacks by malicious remote capture servers!"
  )
endif()
```
... I'll leave it disabled. If someone needs that feature, we can re-enable it in our build.