### PR TITLE
libmpeg2: fix alignment detection on Win64

### DIFF
--- a/mingw-w64-libmpeg2/0005-fix-win64-alignment-detection.patch
+++ b/mingw-w64-libmpeg2/0005-fix-win64-alignment-detection.patch
@@ -1,0 +1,23 @@
+--- a/m4/keywords.m4
++++ b/m4/keywords.m4
+@@ -72,17 +72,17 @@ AC_DEFUN([AC_C_ATTRIBUTE_ALIGNED],
+         [ac_cv_c_attribute_aligned],
+         [ac_cv_c_attribute_aligned=0
+         for ac_cv_c_attr_align_try in 2 4 8 16 32 64; do
+-            AC_TRY_COMPILE([],
++            AC_TRY_COMPILE([#include <stdint.h>],
+                 [static struct s {
+                     char a;
+                     char b __attribute__ ((aligned($ac_cv_c_attr_align_try)));
+                 } S = {0, 0};
+                 switch (1) {
+                     case 0:
+-                    case (long)(&((struct s *)0)->b) == $ac_cv_c_attr_align_try:
++                    case (uintptr_t)(&((struct s *)0)->b) == $ac_cv_c_attr_align_try:
+                         return 0;
+                 }
+-                return (long)&S;],
++                return (uintptr_t)&S;],
+                 [ac_cv_c_attribute_aligned=$ac_cv_c_attr_align_try])
+         done])
+     if test x"$ac_cv_c_attribute_aligned" != x"0"; then

--- a/mingw-w64-libmpeg2/PKGBUILD
+++ b/mingw-w64-libmpeg2/PKGBUILD
@@ -5,7 +5,7 @@ _realname=libmpeg2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.5.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Library for decoding MPEG-1 and MPEG-2 video streams (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -22,12 +22,14 @@ source=("https://download.videolan.org/contrib/libmpeg2/${_realname}-${pkgver}.t
         0001-use-system-getopt.patch
         0002-libmpeg2-fix-deprecated.patch
         0003-do-not-AC_C_ALWAYS_INLINE-it-redefines-inline-breaking-mingw-w64-GCC-5.1.0-C99.patch
-        0004-stringop-overflow.patch)
+        0004-stringop-overflow.patch
+        0005-fix-win64-alignment-detection.patch)
 sha256sums=('dee22e893cb5fc2b2b6ebd60b88478ab8556cb3b93f9a0d7ce8f3b61851871d4'
             '8df95ae46b9224e9888513137ee8f99423de88973c2c865e30c19f213e6660d8'
             '0b9fddc5161ee11d7d0dba559ace98425c2d709b6ab99e130b6ff816444f014a'
             '8beb78faac22b9a6c37b4ff23663cd83ce894443c02337e427729acd8bd6cce0'
-            'b21d712c563fad8a68d7d7851858fdb041de682929b2e80993a1febdd9ea5f44')
+            'b21d712c563fad8a68d7d7851858fdb041de682929b2e80993a1febdd9ea5f44'
+            '4c8c3c7a6276e80317b631336b98458ecd1b8c60557ce645dcd5de2d3eaea145')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -44,7 +46,8 @@ prepare() {
     0001-use-system-getopt.patch \
     0002-libmpeg2-fix-deprecated.patch \
     0003-do-not-AC_C_ALWAYS_INLINE-it-redefines-inline-breaking-mingw-w64-GCC-5.1.0-C99.patch \
-    0004-stringop-overflow.patch
+    0004-stringop-overflow.patch \
+    0005-fix-win64-alignment-detection.patch
 
   # Use system getopt.h instead
   rm -f src/getopt.h


### PR DESCRIPTION
On Win64, libmpeg2's alignment probe casts pointers to 32-bit `long`. Warnings from those casts become errors under the probe's `-Werror`, so configure rejects supported alignments. This removes the alignment declaration from the decoder's DCT block and can cause faults in its SSE2 IDCT path.

This PR backports the `m4/keywords.m4` hunk from [MXE's existing fix](https://github.com/mxe/mxe/blob/221403b640229649ae397718ff2757347fe1385e/src/libmpeg2-1-fixes.patch), using `<stdint.h>` and `uintptr_t` for both casts. MXE in turn adapted it from ScummVM. Coincidentally, this backport is needed to support a future ScummVM PR not adversely affecting the existing MSYS2 ScummVM package `mingw-w64-scummvm` through the dependency chain...