### PR TITLE
libebml: update to 1.4.7

### DIFF
--- a/mingw-w64-libebml/003-enable-shared-library.patch
+++ b/mingw-w64-libebml/003-enable-shared-library.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -14,7 +14,7 @@ function(feature_info_on_off)
+   endif()
+ endfunction(feature_info_on_off)
+ 
+-cmake_dependent_option(BUILD_SHARED_LIBS "Build libebml as a shared library (except Windows)" OFF "NOT WIN32" OFF)
++option(BUILD_SHARED_LIBS "Build libebml as a shared library" OFF)
+ feature_info_on_off(BUILD_SHARED_LIBS "will build as a dynamic library" "will build as a static library")
+ 
+ option(DISABLE_PKGCONFIG "Disable PkgConfig module generation" OFF)

--- a/mingw-w64-libebml/PKGBUILD
+++ b/mingw-w64-libebml/PKGBUILD
@@ -3,14 +3,14 @@
 _realname=libebml
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.4.5
+pkgver=1.4.7
 pkgrel=1
 pkgdesc="Extensible Binary Meta Language library (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
-license=('LGPL')
+license=('spdx:LGPL-2.1-or-later')
 msys2_repository_url="https://github.com/Matroska-Org/libebml"
-url="https://matroska.org"
+url="https://matroska.org/"
 msys2_references=(
   "cpe: cpe:/a:matroska:libebml"
 )
@@ -20,13 +20,16 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-cc")
 source=("https://dl.matroska.org/downloads/${_realname}/${_realname}-${pkgver}.tar.xz"
-        002-mingw-versioned-dll.patch)
-sha256sums=('4971640b0592da29c2d426f303e137a9b0b3d07e1b81d069c1e56a2f49ab221b'
-            'b9697c3c8cba108cc76df6d943c51c4b2bc30092bd5fd6c60e8beff641361a71')
+        002-mingw-versioned-dll.patch
+        003-enable-shared-library.patch)
+sha256sums=('5b08214f929ee54c6187c370f84235fc9d0f2a2258c4d320d68eae6e2bdfd3f7'
+            'b9697c3c8cba108cc76df6d943c51c4b2bc30092bd5fd6c60e8beff641361a71'
+            '58dc431c8eeb7fbbc50afb56b36fba3fda3afd698b120c50d26f543e4c2c8fec')
 
 prepare() {
-  cd "${srcdir}"/${_realname}-${pkgver}
+  cd "${_realname}-${pkgver}"
   patch -p1 -i "${srcdir}"/002-mingw-versioned-dll.patch
+  patch -p1 -i "${srcdir}"/003-enable-shared-library.patch
 }
 
 build() {
@@ -46,7 +49,7 @@ build() {
     -DBUILD_SHARED_LIBS=OFF \
     ../${_realname}-${pkgver}
 
-  ${MINGW_PREFIX}/bin/cmake.exe --build ./
+  cmake --build ./
 
   mkdir -p "${srcdir}"/build-${MSYSTEM}-shared && cd "${srcdir}"/build-${MSYSTEM}-shared
 
@@ -58,7 +61,7 @@ build() {
     -DBUILD_SHARED_LIBS=ON \
     ../${_realname}-${pkgver}
 
-  ${MINGW_PREFIX}/bin/cmake.exe --build ./
+  cmake --build ./
 }
 
 package() {


### PR DESCRIPTION
Upstream disabled building of shared library on Windows after version 1.4.5, so an extra patch is needed to reverse that and keep the shared library.