### PR TITLE
cppwinrt: update to 3.0.260818.1

### DIFF
--- a/mingw-w64-cppwinrt/PKGBUILD
+++ b/mingw-w64-cppwinrt/PKGBUILD
@@ -3,9 +3,9 @@
 _realname=cppwinrt
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.0.250303.1
-_windows_rs_ver=70
-pkgrel=2
+pkgver=3.0.260818.1
+_windows_rs_ver=74
+pkgrel=1
 pkgdesc="C++ language projection for Windows Runtime (WinRT) APIs (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -18,8 +18,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-ninja")
 source=("https://github.com/microsoft/cppwinrt/archive/${pkgver}/${_realname}-${pkgver}.tar.gz"
         "https://github.com/microsoft/windows-rs/archive/${_windows_rs_ver}/windows-rs-${_windows_rs_ver}.tar.gz")
-sha256sums=('da75b7047f4615a3db582ed8c75ee327f228b05bb47750621593594d2d0459e1'
-            'c637c399d3dbd5d01235dc3fea9055237e4bf6ea7a3cc7b5f8cdda4cd58f68f7')
+sha256sums=('082d4b4b0db1d258a449fe3eda1b394921420cfe21b1e03917b486972bfc2e6f'
+            '32045bbff59a1eef0ca51c74443b417acea7081a4306df9602449f0597017a7a')
 
 build() {
   mkdir -p "${srcdir}/build-${MSYSTEM}" && cd "${srcdir}/build-${MSYSTEM}"
@@ -64,7 +64,7 @@ Generated using .winmd files from https://github.com/microsoft/windows-rs
 " > license.txt
 
   ./cppwinrt.exe -license license.txt \
-    -input "${srcdir}/windows-rs-${_windows_rs_ver}/crates/libs/bindgen/default" \
+    -input "${srcdir}/windows-rs-${_windows_rs_ver}/crates/libs/default" \
     -output "${pkgdir}${MINGW_PREFIX}/include"
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"


### PR DESCRIPTION
- Update windows-rs from 70 to 74, and the dir stores winmd files has also changed. See also: [this pull](https://github.com/microsoft/windows-rs/pull/4779)

On my Win11 PC, `build()` and `package()` always succeed, but `check()` always fails because undefine symbol. So I try this PR to see whether Github CI/CD passes these tests.