### PR TITLE
autohotkey: update to v2.0.28

### DIFF
--- a/mingw-w64-autohotkey/PKGBUILD
+++ b/mingw-w64-autohotkey/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=autohotkey
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.0.27
+pkgver=2.0.28
 pkgrel=1
 pkgdesc="Automation scripting language for Windows (mingw-w64)"
 arch=('any')
@@ -48,7 +48,7 @@ source=("https://github.com/AutoHotkey/AutoHotkey/archive/refs/tags/v${pkgver}.t
         0019-fix-const-string-literal-to-LPTSTR-assignments-for-c.patch
         0020-replace-_countof-with-sizeof-for-arrays-with-incompl.patch
         0021-add-explicit-template-instantiations-for-ScriptItemL.patch)
-sha256sums=('976376e699695bf6435c2b6abf23f9e37e08fc1d1c6f51ac2f0d5eea721ebbf3'
+sha256sums=('4520c28768080941342fd75f0ca1f294a6b80840fb9a04243d289ba080696d63'
             'de4e313ea798fe5c8f76df1f76c6470ce6492358240615783327fd1502415740'
             '3eccb84dba6a6994053482b5c00f4683e581ebdd565c1fa62812eaf990004746'
             'a7c5d0ebe16295623882f734a62814e23aeee2f2ae9f2004e46c036a91bde67a'


### PR DESCRIPTION
From https://github.com/AutoHotkey/AutoHotkey/releases/tag/v2.0.28:

- Fixed Gui.Move to not DPI-scale X or Y.